### PR TITLE
Fix typo in font import plugin.

### DIFF
--- a/tools/editor/io_plugins/editor_font_import_plugin.cpp
+++ b/tools/editor/io_plugins/editor_font_import_plugin.cpp
@@ -439,7 +439,7 @@ class EditorFontImportDialog : public ConfirmationDialog {
 		}
 
 		if (dest->get_line_edit()->get_text()=="") {
-			error_dialog->set_text("No tatget font resource!");
+			error_dialog->set_text("No target font resource!");
 			error_dialog->popup_centered(Size2(200,100));
 			return;
 		}


### PR DESCRIPTION
The font import plugin has a small typo when importing a font without selecting a resource.

![screenshot - 02102014 - 09 15 35 am](https://f.cloud.github.com/assets/8477/2123364/a7a61f54-922b-11e3-9487-7e7b289b4d03.png)
