### PR TITLE
A rotating Camera2D

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -131,7 +131,7 @@ Matrix32 Camera2D::get_camera_transform()  {
 	}
 
 
-    Point2 screen_offset = (centered ? (screen_size * 0.5 * zoom) : Point2());;
+	Point2 screen_offset = (centered ? (screen_size * 0.5 * zoom) : Point2());;
 	screen_offset+=offset;
 
 	float angle = get_global_transform().get_rotation();

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -131,8 +131,13 @@ Matrix32 Camera2D::get_camera_transform()  {
 	}
 
 
-	Point2 screen_offset = (centered ? (screen_size * 0.5 * zoom) : Point2());;
+    Point2 screen_offset = (centered ? (screen_size * 0.5 * zoom) : Point2());;
 	screen_offset+=offset;
+
+	float angle = get_global_transform().get_rotation();
+	if(rotating){
+		screen_offset = screen_offset.rotated(angle);
+	}
 
 	Rect2 screen_rect(-screen_offset+ret_camera_pos,screen_size);
 	if (screen_rect.pos.x + screen_rect.size.x > limit[MARGIN_RIGHT])
@@ -151,6 +156,9 @@ Matrix32 Camera2D::get_camera_transform()  {
 	camera_screen_center=screen_rect.pos+screen_rect.size*0.5;
 
 	Matrix32 xform;
+	if(rotating){
+		xform.set_rotation(angle);
+	}
 	xform.scale_basis(zoom);
 	xform.set_origin(screen_rect.pos/*.floor()*/);
 
@@ -249,6 +257,17 @@ void Camera2D::set_centered(bool p_centered){
 bool Camera2D::is_centered() const {
 
 	return centered;
+}
+
+void Camera2D::set_rotating(bool p_rotating){
+
+	rotating=p_rotating;
+	_update_scroll();
+}
+
+bool Camera2D::is_rotating() const {
+
+	return rotating;
 }
 
 
@@ -394,6 +413,9 @@ void Camera2D::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_centered","centered"),&Camera2D::set_centered);
 	ObjectTypeDB::bind_method(_MD("is_centered"),&Camera2D::is_centered);
 
+	ObjectTypeDB::bind_method(_MD("set_rotating","rotating"),&Camera2D::set_rotating);
+	ObjectTypeDB::bind_method(_MD("is_rotating"),&Camera2D::is_rotating);
+
 	ObjectTypeDB::bind_method(_MD("make_current"),&Camera2D::make_current);
 	ObjectTypeDB::bind_method(_MD("_make_current"),&Camera2D::_make_current);
 
@@ -436,6 +458,7 @@ void Camera2D::_bind_methods() {
 
 	ADD_PROPERTYNZ( PropertyInfo(Variant::VECTOR2,"offset"),_SCS("set_offset"),_SCS("get_offset"));
 	ADD_PROPERTY( PropertyInfo(Variant::BOOL,"centered"),_SCS("set_centered"),_SCS("is_centered"));
+	ADD_PROPERTY( PropertyInfo(Variant::BOOL,"rotating"),_SCS("set_rotating"),_SCS("is_rotating"));
 	ADD_PROPERTY( PropertyInfo(Variant::BOOL,"current"),_SCS("_set_current"),_SCS("is_current"));
 	ADD_PROPERTY( PropertyInfo(Variant::REAL,"smoothing"),_SCS("set_follow_smoothing"),_SCS("get_follow_smoothing") );
 	ADD_PROPERTY( PropertyInfo(Variant::VECTOR2,"zoom"),_SCS("set_zoom"),_SCS("get_zoom") );
@@ -462,6 +485,7 @@ Camera2D::Camera2D() {
 
 
 	centered=true;
+	rotating=false;
 	current=false;
 	limit[MARGIN_LEFT]=-10000000;
 	limit[MARGIN_TOP]=-10000000;

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -50,6 +50,7 @@ protected:
 	Vector2 offset;
 	Vector2 zoom;
 	bool centered;
+	bool rotating;
 	bool current;
 	float smoothing;
 	int limit[4];
@@ -78,6 +79,9 @@ public:
 
 	void set_centered(bool p_centered);
 	bool is_centered() const;
+
+	void set_rotating(bool p_rotating);
+	bool is_rotating() const;
 
 	void set_limit(Margin p_margin,int p_limit);
 	int get_limit(Margin p_margin) const;


### PR DESCRIPTION
These changes add a new Camera2D.Rotating property. By default this setting is off, and such default behaviour is exactly the same as before these changes.

When on, the camera will follow it's global rotation, so that one can change its orientation if desired.
In some cases rotating the camera makes not much sense, for example when it is a child of a movable character in a side-scrolling platform game - it should follow that character, but never rotate, so that game's top is always camera's top.

However, there is a number of cases when we would like to rotate the view.
- Any kind of 2D top-down games, where the player sees the surroundings from above, like a flat map - in such case the camera should follow character's orientation, so that screen's top is the character's front. For example, top-down driving/racing game's controls are much less confusing when if the camera rotates [to enable view from vehicle's perspective one might simply reparent the camera to the vehicle node, and enable Centered and Rotating properties.].
- Some animations/effect may include a wiggling camera.
- Games with perspective changes, (where e.g. one can change gravity orientation) may want to rotate the camera instead of rotating the whole world, as this approach is simpler and probably more efficient.

The way I have implemented this feature makes it fully compatible with other camera properties, including Camera2D.Centered, Camera2D.Zoom, Camera2D.Offset, drag margin, etc.

It does not break existing scenes, as it is an optional feature that is turned off by default.

I have tested it in a number of different use cases [following cam, dragged cam, static camera, multiple cameras and animated camera movement], with desired results, but if you notice anything wrong, I will be happy to fix it.
