### PR TITLE
Disable the slider for numeric values on the tree view.

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1575,7 +1575,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos,int x_ofs,int y_ofs,bool p_
 					}  else {
 
 						editor_text=String::num( p_item->cells[col].val, Math::decimals( p_item->cells[col].step ) );
-						bring_up_value_editor=true;
+						bring_up_value_editor=false;
 						if (select_mode==SELECT_MULTI && get_scene()->get_last_event_id() == focus_in_id)
 							bring_up_editor=false;
 


### PR DESCRIPTION
I've talked to Juan about this, and he seems to be in relative agreement that the slider on the treeview's numeric values isn't exactly an optimal solution. There are multiple things wrong with it, namely that there is no intelligent handling of limits that are essentially limitless (that is, -65536 to 65535), and it doesn't go away when you're done editing a field, which leads to accidental clicks that cause chaos. Example: I change the screen width of my project, and then for some reason try to use the mouse to go to the field below. Oops, the width of my project is now -12445.

I'm not a C++ programmer, I'm more comfortable in C#. And I don't know the codebase well enough to create proper fixes, but I don't feel the slider contributes anything of value to this particular gui element, so for now, I've just gotten rid of it.
