### PR TITLE
Fixed typo in undefined main_scene alert

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -1459,7 +1459,7 @@ void EditorNode::_run(bool p_current,const String& p_custom) {
 			current_option=-1;
 			//accept->get_cancel()->hide();
 			accept->get_ok()->set_text("I see..");
-			accept->set_text("No main scene has ever been defined.\nSelect one from \"Project Settings\" under the 'run' category.");
+			accept->set_text("No main scene has ever been defined.\nSelect one from \"Project Settings\" under the 'application' category.");
 			accept->popup_centered(Size2(300,100));;
 			return;
 		}


### PR DESCRIPTION
This is just a tiny fix to correct a typo when `application/main_scene` is undefined. Alert incorrectly stated that `main_scene` was in the `run` category of the Project Settings.
