### PR TITLE
Build system related fixes

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -122,6 +122,7 @@ opts.Add("LINKFLAGS", "Custom flags for the linker");
 opts.Add('disable_3d', 'Disable 3D nodes for smaller executable (yes/no)', "no")
 opts.Add('disable_advanced_gui', 'Disable advance 3D gui nodes and behaviors (yes/no)', "no")
 opts.Add('old_scenes', 'Compatibility with old-style scenes', "yes")
+opts.Add('dynlink', 'Use dynamic linked libraries where appropriate', "no")
 
 # add platform specific options
 
@@ -138,7 +139,7 @@ Help(opts.GenerateHelpText(env_base)) # generate help
 
 # add default include paths
 
-env_base.Append(CPPPATH=['#core','#core/math','#tools','#drivers','#'])
+env_base.Append(CPPPATH=['#core','#core/math','#tools','#'])
 	
 # configure ENV for platform	
 env_base.detect_python=True
@@ -196,6 +197,8 @@ for p in platform_list:
 		sys.modules.pop('config')
 
 
+	if (env['dynlink']=='yes'):
+		env.Append(CPPFLAGS=['-DGODOT_DYNLINK']);
 	if (env['musepack']=='yes'):
 		env.Append(CPPFLAGS=['-DMUSEPACK_ENABLED']);
 

--- a/SConstruct
+++ b/SConstruct
@@ -1,5 +1,6 @@
 EnsureSConsVersion(0,14);
 
+import string
 import os
 import os.path
 import glob
@@ -165,6 +166,11 @@ for p in platform_list:
 		env = detect.create(env_base)
 	else:
 		env = env_base.Clone()
+
+	CCFLAGS = env.get('CCFLAGS', '')
+	env['CCFLAGS'] = ''
+
+	env.Append(CCFLAGS=string.split(str(CCFLAGS)))
 	detect.configure(env)
 	env['platform'] = p
 	sys.path.remove("./platform/"+p)

--- a/drivers/gles1/rasterizer_gles1.cpp
+++ b/drivers/gles1/rasterizer_gles1.cpp
@@ -35,7 +35,6 @@
 #include "drivers/gl_context/context_gl.h"
 #include "servers/visual/shader_language.h"
 #include "servers/visual/particle_system_sw.h"
-#include "gl_context/context_gl.h"
 #include <string.h>
 
 _FORCE_INLINE_ static void _gl_load_transform(const Transform& tr) {

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -34,7 +34,7 @@
 #include <stdio.h>
 #include "servers/visual/shader_language.h"
 #include "servers/visual/particle_system_sw.h"
-#include "gl_context/context_gl.h"
+#include "drivers/gl_context/context_gl.h"
 #include <string.h>
 
 #ifdef GLEW_ENABLED

--- a/drivers/mpc/SCsub
+++ b/drivers/mpc/SCsub
@@ -1,6 +1,5 @@
 Import('env')
 
-
 mpc_sources = [
 	"mpc/huffman.c",
 	"mpc/mpc_bits_reader.c",
@@ -12,11 +11,10 @@ mpc_sources = [
 	"mpc/synth_filter.c",
 ]
 
+#if env.get('dynlink', 'no') == 'no':
 env.drivers_sources+=mpc_sources
 
 env.add_source_files(env.drivers_sources,"*.cpp")
-
-#env.add_source_files(env.drivers_sources, mpc_sources)
 
 Export('env')
 

--- a/drivers/mpc/audio_stream_mpc.h
+++ b/drivers/mpc/audio_stream_mpc.h
@@ -3,7 +3,7 @@
 
 #include "scene/resources/audio_stream_resampled.h"
 #include "os/file_access.h"
-#include "mpc/mpcdec.h"
+#include "drivers/mpc/mpcdec.h"
 #include "os/thread_safe.h"
 #include "io/resource_loader.h"
 //#include "../libmpcdec/decoder.h"

--- a/drivers/mpc/decoder.h
+++ b/drivers/mpc/decoder.h
@@ -38,7 +38,7 @@
 #pragma once
 #endif
 
-#include <mpc/reader.h>
+#include "reader.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/mpc/huffman.h
+++ b/drivers/mpc/huffman.h
@@ -40,7 +40,7 @@
 #pragma once
 #endif
 
-#include <mpc/mpc_types.h>
+#include "mpc_types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/mpc/internal.h
+++ b/drivers/mpc/internal.h
@@ -42,7 +42,7 @@
 extern "C" {
 #endif
 
-#include <mpc/mpcdec.h>
+#include "mpcdec.h"
 
 /// Big/little endian 32 bit byte swapping routine.
 static mpc_inline

--- a/drivers/mpc/mpc_bits_reader.c
+++ b/drivers/mpc/mpc_bits_reader.c
@@ -32,7 +32,7 @@
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <mpc/mpcdec.h>
+#include "mpcdec.h"
 #include "internal.h"
 #include "huffman.h"
 #include "mpc_bits_reader.h"

--- a/drivers/mpc/mpc_decoder.c
+++ b/drivers/mpc/mpc_decoder.c
@@ -35,8 +35,8 @@
 /// Core decoding routines and logic.
 
 #include <string.h>
-#include <mpc/mpcdec.h>
-#include <mpc/minimax.h>
+#include "mpcdec.h"
+#include "minimax.h"
 #include "decoder.h"
 #include "huffman.h"
 #include "internal.h"

--- a/drivers/mpc/mpc_demux.c
+++ b/drivers/mpc/mpc_demux.c
@@ -34,8 +34,8 @@
 
 #include <math.h>
 #include <string.h>
-#include <mpc/streaminfo.h>
-#include <mpc/mpcdec.h>
+#include "streaminfo.h"
+#include "mpcdec.h"
 #include "internal.h"
 #include "decoder.h"
 #include "huffman.h"

--- a/drivers/mpc/mpc_reader.c
+++ b/drivers/mpc/mpc_reader.c
@@ -33,7 +33,7 @@
 */
 /// \file mpc_reader.c
 /// Contains implementations for simple file-based mpc_reader
-#include <mpc/reader.h>
+#include "reader.h"
 #include "internal.h"
 #include <stdio.h>
 

--- a/drivers/mpc/mpcdec_math.h
+++ b/drivers/mpc/mpcdec_math.h
@@ -39,7 +39,7 @@
 #pragma once
 #endif
 
-#include <mpc/mpc_types.h>
+#include "mpc_types.h"
 
 #include <assert.h>
 

--- a/drivers/mpc/mpcmath.h
+++ b/drivers/mpc/mpcmath.h
@@ -16,7 +16,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <mpc/mpc_types.h>
+#include "mpc_types.h"
 
 typedef union mpc_floatint
 {

--- a/drivers/mpc/reader.h
+++ b/drivers/mpc/reader.h
@@ -38,7 +38,7 @@
 #pragma once
 #endif
 
-#include <mpc/mpc_types.h>
+#include <drivers/mpc/mpc_types.h>
 #include <stdio.h>
 
 #ifdef __cplusplus

--- a/drivers/mpc/requant.c
+++ b/drivers/mpc/requant.c
@@ -34,7 +34,7 @@
 /// \file requant.c
 /// Requantization function implementations.
 /// \todo document me
-#include <mpc/mpcdec.h>
+#include "mpcdec.h"
 
 #include "requant.h"
 #include "mpcdec_math.h"

--- a/drivers/mpc/requant.h
+++ b/drivers/mpc/requant.h
@@ -39,7 +39,7 @@
 #pragma once
 #endif
 
-#include <mpc/mpc_types.h>
+#include "mpc_types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/mpc/streaminfo.c
+++ b/drivers/mpc/streaminfo.c
@@ -35,8 +35,8 @@
 /// Implementation of streaminfo reading functions.
 
 #include <math.h>
-#include <mpc/mpcdec.h>
-#include <mpc/streaminfo.h>
+#include "mpcdec.h"
+#include "streaminfo.h"
 #include <stdio.h>
 #include "internal.h"
 #include "huffman.h"

--- a/drivers/mpc/streaminfo.h
+++ b/drivers/mpc/streaminfo.h
@@ -38,7 +38,7 @@
 #pragma once
 #endif
 
-#include <mpc/mpc_types.h>
+#include "mpc_types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/mpc/synth_filter.c
+++ b/drivers/mpc/synth_filter.c
@@ -35,7 +35,7 @@
 /// Synthesis functions.
 /// \todo document me
 #include <string.h>
-#include <mpc/mpcdec.h>
+#include "mpcdec.h"
 #include "decoder.h"
 #include "mpcdec_math.h"
 

--- a/drivers/ogg/SCsub
+++ b/drivers/ogg/SCsub
@@ -1,10 +1,11 @@
 Import('env')
 
-ogg_sources = [
+if env.get('dynlink', 'no') == 'no':
+    ogg_sources = [
 
-	"ogg/bitwise.c",
-	"ogg/framing.c",
-]
+        "ogg/bitwise.c",
+        "ogg/framing.c",
+    ]
 
-env.drivers_sources+=ogg_sources
+    env.drivers_sources+=ogg_sources
 

--- a/drivers/png/SCsub
+++ b/drivers/png/SCsub
@@ -1,28 +1,33 @@
 Import('env')
 
+dynlink = env.get("dynlink", "no") == "yes"
 
-png_sources = [
-	"png/example.c",
-	"png/png.c",
-	"png/pngerror.c",
-	"png/pngget.c",
-	"png/pngmem.c",
-	"png/pngpread.c",
-	"png/pngread.c",
-	"png/pngrio.c",
-	"png/pngrtran.c",
-	"png/pngrutil.c",
-	"png/pngset.c",
-	"png/pngtrans.c",
-	"png/pngwio.c",
-	"png/pngwrite.c",
-	"png/pngwtran.c",
-	"png/pngwutil.c",
+png_sources = []
+if not dynlink:
+    png_sources.extend([
+        "png/example.c",
+        "png/png.c",
+        "png/pngerror.c",
+        "png/pngget.c",
+        "png/pngmem.c",
+        "png/pngpread.c",
+        "png/pngread.c",
+        "png/pngrio.c",
+        "png/pngrtran.c",
+        "png/pngrutil.c",
+        "png/pngset.c",
+        "png/pngtrans.c",
+        "png/pngwio.c",
+        "png/pngwrite.c",
+        "png/pngwtran.c",
+        "png/pngwutil.c",
+    ])
+png_sources.extend([
 	"png/resource_saver_png.cpp",
 	"png/image_loader_png.cpp"
-]
+])
 
-if ("neon_enabled" in env and env["neon_enabled"]):
+if not dynlink and ("neon_enabled" in env and env["neon_enabled"]):
 	env_neon = env.Clone();
 	if "S_compiler" in env:
 		env_neon['CC'] = env['S_compiler']

--- a/drivers/png/image_loader_png.cpp
+++ b/drivers/png/image_loader_png.cpp
@@ -27,7 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include "image_loader_png.h"
-
+#include <memory.h>
 #include "print_string.h"
 #include "os/os.h"
 

--- a/drivers/png/image_loader_png.h
+++ b/drivers/png/image_loader_png.h
@@ -30,7 +30,11 @@
 #define IMAGE_LOADER_PNG_H
 
 #include "io/image_loader.h"
-#include "drivers/png/png.h"
+#if defined(GODOT_DYNLINK)
+#   include <png.h>
+#else
+#   include "drivers/png/png.h"
+#endif
 
 /**
 	@author Juan Linietsky <reduzio@gmail.com>

--- a/drivers/png/resource_saver_png.cpp
+++ b/drivers/png/resource_saver_png.cpp
@@ -28,7 +28,11 @@
 /*************************************************************************/
 #include "resource_saver_png.h"
 #include "scene/resources/texture.h"
-#include "drivers/png/png.h"
+#if defined(GODOT_DYNLINK)
+#   include <png.h>
+#else
+#   include "drivers/png/png.h"
+#endif
 #include "os/file_access.h"
 
 static void _write_png_data(png_structp png_ptr,png_bytep data, png_size_t p_length) {

--- a/drivers/register_driver_types.cpp
+++ b/drivers/register_driver_types.cpp
@@ -11,44 +11,46 @@
 
 #include "register_driver_types.h"
 
-#include "png/image_loader_png.h"
-#include "webp/image_loader_webp.h"
-#include "png/resource_saver_png.h"
-#include "jpg/image_loader_jpg.h"
-#include "dds/texture_loader_dds.h"
-#include "pvr/texture_loader_pvr.h"
-#include "etc1/image_etc.h"
-#include "chibi/event_stream_chibi.h"
+#include "drivers/png/image_loader_png.h"
+#include "drivers/webp/image_loader_webp.h"
+#include "drivers/png/resource_saver_png.h"
+#include "drivers/jpg/image_loader_jpg.h"
+#include "drivers/dds/texture_loader_dds.h"
+#include "drivers/pvr/texture_loader_pvr.h"
+#include "drivers/etc1/image_etc.h"
+#include "drivers/chibi/event_stream_chibi.h"
 
 #ifdef TOOLS_ENABLED
-#include "squish/image_compress_squish.h"
+#ifdef SQUISH_ENABLED
+#include "drivers/squish/image_compress_squish.h"
+#endif
 #endif
 
 #ifdef TOOLS_ENABLED
-#include "convex_decomp/b2d_decompose.h"
+#include "drivers/convex_decomp/b2d_decompose.h"
 #endif
 
 #ifdef TREMOR_ENABLED
-#include "teora/audio_stream_ogg.h"
+#include "drivers/teora/audio_stream_ogg.h"
 #endif
 
 #ifdef VORBIS_ENABLED
-#include "vorbis/audio_stream_ogg_vorbis.h"
+#include "drivers/vorbis/audio_stream_ogg_vorbis.h"
 #endif
 
 
 #ifdef SPEEX_ENABLED
-#include "speex/audio_stream_speex.h"
+#include "drivers/speex/audio_stream_speex.h"
 #endif
 
 #ifdef THEORA_ENABLED
-#include "theora/video_stream_theora.h"
+#include "drivers/theora/video_stream_theora.h"
 #endif
 
 #include "drivers/trex/regex.h"
 
 #ifdef MUSEPACK_ENABLED
-#include "mpc/audio_stream_mpc.h"
+#include "drivers/mpc/audio_stream_mpc.h"
 #endif
 
 #ifdef PNG_ENABLED

--- a/drivers/speex/SCsub
+++ b/drivers/speex/SCsub
@@ -1,54 +1,54 @@
 Import('env')
 
 
+if env.get('dynlink', 'no') == 'no':
+    speex_sources = [
+        "speex/bits.c",
+        "speex/buffer.c",
+        "speex/cb_search.c",
+        "speex/exc_10_16_table.c",
+        "speex/exc_10_32_table.c",
+        "speex/exc_20_32_table.c",
+        "speex/exc_5_256_table.c",
+        "speex/exc_5_64_table.c",
+        "speex/exc_8_128_table.c",
+        "speex/fftwrap.c",
+        "speex/filterbank.c",
+        "speex/filters.c",
+        "speex/gain_table.c",
+        "speex/gain_table_lbr.c",
+        "speex/hexc_10_32_table.c",
+        "speex/hexc_table.c",
+        "speex/high_lsp_tables.c",
+        "speex/jitter.c",
+        "speex/kiss_fft.c",
+        "speex/kiss_fftr.c",
+        "speex/lpc.c",
+        "speex/lsp.c",
+        "speex/lsp_tables_nb.c",
+        "speex/ltp.c",
+        "speex/mdf.c",
+        "speex/modes.c",
+        "speex/modes_wb.c",
+        "speex/nb_celp.c",
+        "speex/preprocess.c",
+        "speex/quant_lsp.c",
+        "speex/resample.c",
+        "speex/sb_celp.c",
+        "speex/scal.c",
+        "speex/smallft.c",
+        "speex/speex.c",
+        "speex/speex_callbacks.c",
+        "speex/speex_header.c",
+        "speex/stereo.c",
+        "speex/vbr.c",
+        "speex/vq.c",
+        "speex/window.c",
+    ]
 
+    env.drivers_sources+=speex_sources
 
-speex_sources = [\
-"speex/bits.c",\
-"speex/buffer.c",\
-"speex/cb_search.c",\
-"speex/exc_10_16_table.c",\
-"speex/exc_10_32_table.c",\
-"speex/exc_20_32_table.c",\
-"speex/exc_5_256_table.c",\
-"speex/exc_5_64_table.c",\
-"speex/exc_8_128_table.c",\
-"speex/fftwrap.c",\
-"speex/filterbank.c",\
-"speex/filters.c",\
-"speex/gain_table.c",\
-"speex/gain_table_lbr.c",\
-"speex/hexc_10_32_table.c",\
-"speex/hexc_table.c",\
-"speex/high_lsp_tables.c",\
-"speex/jitter.c",\
-"speex/kiss_fft.c",\
-"speex/kiss_fftr.c",\
-"speex/lpc.c",\
-"speex/lsp.c",\
-"speex/lsp_tables_nb.c",\
-"speex/ltp.c",\
-"speex/mdf.c",\
-"speex/modes.c",\
-"speex/modes_wb.c",\
-"speex/nb_celp.c",\
-"speex/preprocess.c",\
-"speex/quant_lsp.c",\
-"speex/resample.c",\
-"speex/sb_celp.c",\
-"speex/scal.c",\
-"speex/smallft.c",\
-"speex/speex.c",\
-"speex/speex_callbacks.c",\
-"speex/speex_header.c",\
-"speex/stereo.c",\
-"speex/vbr.c",\
-"speex/vq.c",\
-"speex/window.c",\
-"speex/audio_stream_speex.cpp",
-]
-
-env.drivers_sources+=speex_sources
+env.drivers_sources.append("speex/audio_stream_speex.cpp")
 
 #env.add_source_files(env.drivers_sources, speex_sources)
 

--- a/drivers/speex/audio_stream_speex.cpp
+++ b/drivers/speex/audio_stream_speex.cpp
@@ -1,6 +1,4 @@
 #include "audio_stream_speex.h"
-
-#include "os_support.h"
 #include "os/os.h"
 #define READ_CHUNK 1024
 
@@ -270,7 +268,7 @@ void *AudioStreamSpeex::process_header(ogg_packet *op, int *frame_size, int *rat
 
 	*extra_headers = header->extra_headers;
 
-	speex_free(header);
+	speex_header_free(header);
 	return state;
 }
 

--- a/drivers/speex/audio_stream_speex.h
+++ b/drivers/speex/audio_stream_speex.h
@@ -2,17 +2,23 @@
 #define AUDIO_STREAM_SPEEX_H
 
 #include "scene/resources/audio_stream_resampled.h"
-#include "speex/speex.h"
 #include "os/file_access.h"
 #include "io/resource_loader.h"
 #include "os/thread_safe.h"
 
-#include <speex/speex.h>
-#include <speex/speex_header.h>
-#include <speex/speex_stereo.h>
-#include <speex/speex_callbacks.h>
-
-#include <ogg/ogg.h>
+#if defined(GODOT_DYNLINK)
+#   include <speex/speex.h>
+#   include <speex/speex_header.h>
+#   include <speex/speex_stereo.h>
+#   include <speex/speex_callbacks.h>
+#   include <ogg/ogg.h>
+#else
+#   include <drivers/speex/speex.h>
+#   include <drivers/speex/speex_header.h>
+#   include <drivers/speex/speex_stereo.h>
+#   include <dirvers/speex/speex_callbacks.h>
+#   include "drivers/ogg/ogg.h"
+#endif
 
 class AudioStreamSpeex : public AudioStreamResampled {
 

--- a/drivers/squish/alpha.h
+++ b/drivers/squish/alpha.h
@@ -26,7 +26,7 @@
 #ifndef SQUISH_ALPHA_H
 #define SQUISH_ALPHA_H
 
-#include "squish/squish.h"
+#include "squish.h"
 
 namespace squish {
 

--- a/drivers/squish/clusterfit.h
+++ b/drivers/squish/clusterfit.h
@@ -27,7 +27,7 @@
 #ifndef SQUISH_CLUSTERFIT_H
 #define SQUISH_CLUSTERFIT_H
 
-#include "squish/squish.h"
+#include "squish.h"
 #include "maths.h"
 #include "simd.h"
 #include "colourfit.h"

--- a/drivers/squish/colourblock.h
+++ b/drivers/squish/colourblock.h
@@ -26,7 +26,7 @@
 #ifndef SQUISH_COLOURBLOCK_H
 #define SQUISH_COLOURBLOCK_H
 
-#include "squish/squish.h"
+#include "squish.h"
 #include "maths.h"
 
 namespace squish {

--- a/drivers/squish/colourfit.h
+++ b/drivers/squish/colourfit.h
@@ -26,7 +26,7 @@
 #ifndef SQUISH_COLOURFIT_H
 #define SQUISH_COLOURFIT_H
 
-#include "squish/squish.h"
+#include "squish.h"
 #include "maths.h"
 
 namespace squish {

--- a/drivers/squish/colourset.h
+++ b/drivers/squish/colourset.h
@@ -26,7 +26,7 @@
 #ifndef SQUISH_COLOURSET_H
 #define SQUISH_COLOURSET_H
 
-#include "squish/squish.h"
+#include "squish.h"
 #include "maths.h"
 
 namespace squish {

--- a/drivers/squish/image_compress_squish.cpp
+++ b/drivers/squish/image_compress_squish.cpp
@@ -1,5 +1,5 @@
 #include "image_compress_squish.h"
-#include "squish/squish.h"
+#include "squish.h"
 #include "print_string.h"
 
 void image_compress_squish(Image *p_image) {

--- a/drivers/squish/rangefit.h
+++ b/drivers/squish/rangefit.h
@@ -26,7 +26,7 @@
 #ifndef SQUISH_RANGEFIT_H
 #define SQUISH_RANGEFIT_H
 
-#include "squish/squish.h"
+#include "squish.h"
 #include "colourfit.h"
 #include "maths.h"
 

--- a/drivers/squish/singlecolourfit.h
+++ b/drivers/squish/singlecolourfit.h
@@ -26,7 +26,7 @@
 #ifndef SQUISH_SINGLECOLOURFIT_H
 #define SQUISH_SINGLECOLOURFIT_H
 
-#include "squish/squish.h"
+#include "squish.h"
 #include "colourfit.h"
 
 namespace squish {

--- a/drivers/squish/squish.cpp
+++ b/drivers/squish/squish.cpp
@@ -23,7 +23,7 @@
 	
    -------------------------------------------------------------------------- */
    
-#include "squish/squish.h"
+#include "squish.h"
 #include "colourset.h"
 #include "maths.h"
 #include "rangefit.h"

--- a/drivers/theora/SCsub
+++ b/drivers/theora/SCsub
@@ -1,36 +1,40 @@
 
 Import('env')
 
-sources = [
-	"theora/analyze.c",
-	"theora/apiwrapper.c",
-	"theora/bitpack.c",
-	"theora/cpu.c",
-	"theora/decapiwrapper.c",
-	"theora/decinfo.c",
-	"theora/decode.c",
-	"theora/dequant.c",
-	#"theora/encapiwrapper.c",
-	#"theora/encfrag.c",
-	#"theora/encinfo.c",
-	#"theora/encode.c",
-	"theora/encoder_disabled.c",
-	"theora/enquant.c",
-	"theora/fdct.c",
-	"theora/fragment.c",
-	"theora/huffdec.c",
-	"theora/huffenc.c",
-	"theora/idct.c",
-	"theora/info.c",
-	"theora/internal.c",
-	"theora/mathops.c",
-	"theora/mcenc.c",
-	"theora/quant.c",
-	"theora/rate.c",
-	"theora/state.c",
-	"theora/tokenize.c",
-	"theora/video_stream_theora.cpp",
-]
+sources = []
+
+if env.get("dynlink", "no") == "no":
+    sources.extend([
+        "theora/analyze.c",
+        "theora/apiwrapper.c",
+        "theora/bitpack.c",
+        "theora/cpu.c",
+        "theora/decapiwrapper.c",
+        "theora/decinfo.c",
+        "theora/decode.c",
+        "theora/dequant.c",
+        #"theora/encapiwrapper.c",
+        #"theora/encfrag.c",
+        #"theora/encinfo.c",
+        #"theora/encode.c",
+        "theora/encoder_disabled.c",
+        "theora/enquant.c",
+        "theora/fdct.c",
+        "theora/fragment.c",
+        "theora/huffdec.c",
+        "theora/huffenc.c",
+        "theora/idct.c",
+        "theora/info.c",
+        "theora/internal.c",
+        "theora/mathops.c",
+        "theora/mcenc.c",
+        "theora/quant.c",
+        "theora/rate.c",
+        "theora/state.c",
+        "theora/tokenize.c",
+    ])
+
+sources.append("theora/video_stream_theora.cpp")
 
 env.drivers_sources += sources
 

--- a/drivers/theora/video_stream_theora.h
+++ b/drivers/theora/video_stream_theora.h
@@ -3,8 +3,13 @@
 
 #ifdef THEORA_ENABLED
 
-#include "theora/theoradec.h"
-#include "vorbis/codec.h"
+#if defined(GODOT_DYNLINK)
+#   include <theora/theoradec.h>
+#   include <vorbis/codec.h>
+#else
+#   include "driver/theora/theoradec.h"
+#   include "driver/vorbis/codec.h"
+#endif
 #include "os/file_access.h"
 
 #include "io/resource_loader.h"

--- a/drivers/vorbis/SCsub
+++ b/drivers/vorbis/SCsub
@@ -2,33 +2,37 @@
 Import('env')
 
 sources = [
-	"vorbis/audio_stream_ogg_vorbis.cpp",
-	"vorbis/analysis.c",
-	#"vorbis/barkmel.c",
-	"vorbis/bitrate.c",
-	"vorbis/block.c",
-	"vorbis/codebook.c",
-	"vorbis/envelope.c",
-	"vorbis/floor0.c",
-	"vorbis/floor1.c",
-	"vorbis/info.c",
-	"vorbis/lookup.c",
-	"vorbis/lpc.c",
-	"vorbis/lsp.c",
-	"vorbis/mapping0.c",
-	"vorbis/mdct.c",
-	"vorbis/psy.c",
-	#"vorbis/psytune.c",
-	"vorbis/registry.c",
-	"vorbis/res0.c",
-	"vorbis/sharedbook.c",
-	"vorbis/smallft.c",
-	"vorbis/synthesis.c",
-	#"vorbis/tone.c",
-	"vorbis/vorbisenc.c",
-	"vorbis/vorbisfile.c",
-	"vorbis/window.c",
+    "vorbis/audio_stream_ogg_vorbis.cpp"
 ]
+
+if env.get("dynlink", "no") == "no":
+    sources.extend([
+        "vorbis/analysis.c",
+        #"vorbis/barkmel.c",
+        "vorbis/bitrate.c",
+        "vorbis/block.c",
+        "vorbis/codebook.c",
+        "vorbis/envelope.c",
+        "vorbis/floor0.c",
+        "vorbis/floor1.c",
+        "vorbis/info.c",
+        "vorbis/lookup.c",
+        "vorbis/lpc.c",
+        "vorbis/lsp.c",
+        "vorbis/mapping0.c",
+        "vorbis/mdct.c",
+        "vorbis/psy.c",
+        #"vorbis/psytune.c",
+        "vorbis/registry.c",
+        "vorbis/res0.c",
+        "vorbis/sharedbook.c",
+        "vorbis/smallft.c",
+        "vorbis/synthesis.c",
+        #"vorbis/tone.c",
+        "vorbis/vorbisenc.c",
+        "vorbis/vorbisfile.c",
+        "vorbis/window.c",
+    ])
 
 env.drivers_sources += sources
 

--- a/drivers/vorbis/audio_stream_ogg_vorbis.h
+++ b/drivers/vorbis/audio_stream_ogg_vorbis.h
@@ -30,7 +30,11 @@
 #define AUDIO_STREAM_OGG_VORBIS_H
 
 #include "scene/resources/audio_stream_resampled.h"
-#include "vorbis/vorbisfile.h"
+#if defined(GODOT_DYNLINK)
+#include    <vorbis/vorbisfile.h>
+#else
+#   include "drivers/vorbis/vorbisfile.h"
+#endif
 #include "os/file_access.h"
 #include "io/resource_loader.h"
 #include "os/thread_safe.h"

--- a/drivers/webp/SCsub
+++ b/drivers/webp/SCsub
@@ -53,11 +53,12 @@ webp_sources = [
 	"webp/dec/io.c",
 	"webp/dec/layer.c",
 	"webp/dec/idec.c",
-	"webp/image_loader_webp.cpp"
 ]
 
-env.drivers_sources+=webp_sources
+if env.get('dynlink', 'no') == 'no':
+    env.drivers_sources+=webp_sources
 
+env.drivers_sources.append("webp/image_loader_webp.cpp")
 #env.add_source_files(env.drivers_sources, webp_sources)
 
 Export('env')

--- a/drivers/webp/image_loader_webp.cpp
+++ b/drivers/webp/image_loader_webp.cpp
@@ -13,8 +13,13 @@
 
 #include "print_string.h"
 #include "os/os.h"
+#if defined(GODOT_DYNLINK)
+#include <webp/decode.h>
+#include <webp/encode.h>
+#else
 #include "drivers/webp/decode.h"
 #include "drivers/webp/encode.h"
+#endif
 #include "io/marshalls.h"
 #include <stdlib.h>
 

--- a/platform/osx/platform_config.h
+++ b/platform/osx/platform_config.h
@@ -27,5 +27,5 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include <alloca.h>
-#define GLES2_INCLUDE_H "gl_context/glew.h"
-#define GLES1_INCLUDE_H "gl_context/glew.h"
+#define GLES2_INCLUDE_H "drivers/gl_context/glew.h"
+#define GLES1_INCLUDE_H "drivers/gl_context/glew.h"

--- a/platform/windows/platform_config.h
+++ b/platform/windows/platform_config.h
@@ -30,6 +30,6 @@
 //#else
 //#include <alloca.h>
 //#endif
-#define GLES2_INCLUDE_H "gl_context/glew.h"
-#define GLES1_INCLUDE_H "gl_context/glew.h"
+#define GLES2_INCLUDE_H "drivers/gl_context/glew.h"
+#define GLES1_INCLUDE_H "drivers/gl_context/glew.h"
 

--- a/platform/x11/platform_config.h
+++ b/platform/x11/platform_config.h
@@ -27,6 +27,6 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include <alloca.h>
-#define GLES2_INCLUDE_H "gl_context/glew.h"
-#define GLES1_INCLUDE_H "gl_context/glew.h"
+#define GLES2_INCLUDE_H "drivers/gl_context/glew.h"
+#define GLES1_INCLUDE_H "drivers/gl_context/glew.h"
 


### PR DESCRIPTION
While trying to package godot for fedora I encountered some issues and fixed them right away. 

The first patch addresses the CCFLAGS handling which was broken, CFLAGS, since not touched anywhere else works as expected though.

The second patch is a bit bigger, in order to support building godot without all the bundled libraries, which is necessary for packages which are introduced to the packaging system of any distribution I know, I had to make the bundled libraries optional. 
Now by specifying dynlink=yes you can leverage the libraries installed on the system. Of course this is not perfect, however now the bundled libraries are becoming optional :+1: 
