### PR TITLE
Fixed crash bug in the shaderlang test

### DIFF
--- a/bin/tests/test_shader_lang.cpp
+++ b/bin/tests/test_shader_lang.cpp
@@ -288,8 +288,7 @@ MainLoop* test() {
 
 	FileAccess *fa = FileAccess::open(test,FileAccess::READ);
 
-	if (!fa) {
-		memdelete(fa);
+	if (!fa) {        
 		ERR_FAIL_V(NULL);
 	}
 


### PR DESCRIPTION
The shaderlang test crashed every time for me when I executed it. It tried to delete/deconstruct a zero pointer.
