### PR TITLE
Fixed #93 Build error with latest commit

### DIFF
--- a/tools/editor/SCsub
+++ b/tools/editor/SCsub
@@ -42,6 +42,8 @@ if (env["tools"]=="yes"):
 	f = open("register_exporters.cpp","wb")
 	f.write(reg_exporters_inc)
 	f.write(reg_exporters)
+	f.close()
+	
 	env.Depends("#tools/editor/doc_data_compressed.h","#doc/base/classes.xml")
 	env.Command("#tools/editor/doc_data_compressed.h","#doc/base/classes.xml",make_doc_header)
 


### PR DESCRIPTION
Fixed #93 Build error with latest commit by explicitly close file "register_exporters.cpp" after generated.
