### PR TITLE
Windows StreamPeerWinsock::set_nodelay implementation

### DIFF
--- a/platform/windows/stream_peer_winsock.cpp
+++ b/platform/windows/stream_peer_winsock.cpp
@@ -337,8 +337,9 @@ Error StreamPeerWinsock::connect(const IP_Address& p_host, uint16_t p_port) {
 };
 
 void StreamPeerWinsock::set_nodelay(bool p_enabled) {
-
-
+    ERR_FAIL_COND(!is_connected());
+    int flag=p_enabled?1:0;
+    setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, (char*)&flag, sizeof(int));
 }
 
 


### PR DESCRIPTION
The Windows implementation of StreamPeer left set_nodelay() as a no-op.  The code from the POSIX implementation is also correct on Windows so this patch just copies that code.
