### PR TITLE
tools/editor/project_export: tree_vb already has a parent

### DIFF
--- a/tools/editor/project_export.cpp
+++ b/tools/editor/project_export.cpp
@@ -1057,7 +1057,7 @@ ProjectExportDialog::ProjectExportDialog(EditorNode *p_editor) {
 
 	tree = memnew( Tree );
 	tree_vb->add_margin_child("Resources to Export:",tree,true);
-	sections->add_child(tree);
+
 	tree->set_v_size_flags(SIZE_EXPAND_FILL);
 	tree->connect("item_edited",this,"_tree_changed");
 	tree->set_columns(2);


### PR DESCRIPTION
This error was printed on the console on every start of the editor.
