### PR TITLE
Fix for Issue #108

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -2518,7 +2518,7 @@ bool String::begins_with(const char* p_string) const {
 		
 	}
 	
-	return true;
+	return *p_string == 0;
 	
 }
 


### PR DESCRIPTION
Entering a somethign in the 'Path field' triggers the
`_path_changed` signal being triggered.
This in turn calls Globals::localize_path(const String& p_path) with the
currently entered string.
localize_path then is replacing backslashes with slashes and calls
afterwards `String::simplify_path`

String::simplify_path is checking wheter a string starts with:
- res://
- local://
- user://

If any of those is true it removes this section.

However, if any of the first letters of those are matching begins_with
returns true, which is wrong. It should only return true if the whole
string is matched at the beginning.

This caused the whole desaster and lead localize_path into an endless loop
because out of `u` suddenly became user:// which it then tried again to
localize and so on.

This fix, fixes the root of the problem which is begins_with which should
not return true if not the whole search string was matched.

Signed-off-by: Vinzenz Feenstra evilissimo@gmail.com
