### PR TITLE
Fix #19 Can't open project (with non-ASCII path)

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -202,7 +202,7 @@ Error Main::setup(const char *execpath,int argc, char *argv[],bool p_second_phas
 	
 	for(int i=0;i<argc;i++) {
 
-		args.push_back(argv[i]);	
+		args.push_back(String::utf8(argv[i]));
 	}
 
 	List<String>::Element *I=args.front();


### PR DESCRIPTION
In `class OS_Unix` the arguments in the `execute` method are converted
to UTF-8, but in the `main` program's method they're inserted into a
wide-char `Vector` before translating them from UTF-8 and thus the
non-ASCII characters are lost.

This fix converts the `argv` elements to UTF-8 using `String::utf8`
before inserting them in the `Vector`.

Tested in Archlinux x86_64.

Please test this change in Windows with a non-UTF-8 encoding (e.g. ISO-8859-15), it may break Windows-only behavior because the `execute` method in `class OS_Windows` doesn't convert the arguments to UTF-8.
