### PR TITLE
Fix #113 editor_settings.xml corruption

### DIFF
--- a/core/io/resource_format_xml.cpp
+++ b/core/io/resource_format_xml.cpp
@@ -97,16 +97,17 @@ ResourceInteractiveLoaderXML::Tag* ResourceInteractiveLoaderXML::parse_tag(bool 
 
 	if (!complete) {
 		String name;
-		String value;
+		CharString r_value;
 		bool reading_value=false;
 
 		while(!f->eof_reached()) {
 
 			CharType c=get_char();
 			if (c=='>') {
-				if (value.length()) {
+				if (r_value.size()) {
 
-					tag.args[name]=value;
+					r_value.push_back(0);
+					tag.args[name].parse_utf8(r_value.get_data());
 				}
 				break;
 
@@ -115,17 +116,18 @@ ResourceInteractiveLoaderXML::Tag* ResourceInteractiveLoaderXML::parse_tag(bool 
 				if (!reading_value && name.length()) {
 
 					reading_value=true;
-				} else if (reading_value && value.length()) {
+				} else if (reading_value && r_value.size()) {
 
-					tag.args[name]=value;
+					r_value.push_back(0);
+					tag.args[name].parse_utf8(r_value.get_data());
 					name="";
-					value="";
+					r_value.clear();
 					reading_value=false;
 				}
 
 			} else if (reading_value) {
 
-				value+=c;
+				r_value.push_back(c);
 			} else {
 
 				name+=c;


### PR DESCRIPTION
In the `parse_tag` method of the `class ResourceInteractiveLoaderXML`,
the class responsible of loading the editor_settings.xml file, the
properties' values are loaded directly into an `String` object but the
file contents are always UTF-8, which leads to garbage in the XML file
when saved.

This patch reads the properties' values in a `CharString` and translate
them to UTF-8.

Tested on Archlinux x86_64.
To test, please try to reproduce the issue #113.
