### PR TITLE
Instance button of SceneDock now working

### DIFF
--- a/tools/editor/scenes_dock.cpp
+++ b/tools/editor/scenes_dock.cpp
@@ -181,7 +181,7 @@ void ScenesDock::_instance_pressed() {
 	if (!sel)
 		return;
 	String path = sel->get_metadata(0);
-	emit_signal("instance","res://"+path);
+	emit_signal("instance",path);
 }
 
 void ScenesDock::_open_pressed(){


### PR DESCRIPTION
Fixed bug of Instance button of scene dock (file system) tab. It's now working properly.
