### PR TITLE
Add F key to center 3d viewport to selected node

### DIFF
--- a/tools/editor/plugins/spatial_editor_plugin.cpp
+++ b/tools/editor/plugins/spatial_editor_plugin.cpp
@@ -1407,6 +1407,9 @@ void SpatialEditorViewport::_sinput(const InputEvent &p_event) {
 
 				} break;
 
+				case KEY_F: {
+					_menu_option(VIEW_CENTER_TO_SELECTION);
+				} break;
 			}
 
 


### PR DESCRIPTION
Godot has already support center viewport to selected node in 3d view port, but there's no hot-key This commit add F key binding to the view port menu ( View->Selection )
