### PR TITLE
Get godot to build on FreeBSD

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -45,7 +45,10 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
+
+#ifdef __linux__
 #include <linux/joystick.h>
+#endif
 
 //stupid linux.h
 #ifdef KEY_TAB
@@ -1031,7 +1034,6 @@ void OS_X11::close_joystick(int p_id) {
 };
 
 void OS_X11::probe_joystick(int p_id) {
-
 	if (p_id == -1) {
 
 		for (int i=0; i<JOYSTICKS_MAX; i++) {
@@ -1073,7 +1075,6 @@ void OS_X11::move_window_to_foreground() {
 }
 
 void OS_X11::process_joysticks() {
-
 	int bytes;
 	js_event events[32];
 	InputEvent ievent;

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -1034,6 +1034,7 @@ void OS_X11::close_joystick(int p_id) {
 };
 
 void OS_X11::probe_joystick(int p_id) {
+	#ifndef __FreeBSD__
 	if (p_id == -1) {
 
 		for (int i=0; i<JOYSTICKS_MAX; i++) {
@@ -1067,6 +1068,7 @@ void OS_X11::probe_joystick(int p_id) {
 
 		++i;
 	};
+	#endif
 };
 
 void OS_X11::move_window_to_foreground() {
@@ -1075,6 +1077,7 @@ void OS_X11::move_window_to_foreground() {
 }
 
 void OS_X11::process_joysticks() {
+	#ifndef __FreeBSD__
 	int bytes;
 	js_event events[32];
 	InputEvent ievent;
@@ -1173,6 +1176,7 @@ void OS_X11::process_joysticks() {
 			};
 		};
 	};
+	#endif
 };
 
 void OS_X11::set_cursor_shape(CursorShape p_shape) {

--- a/platform/x11/platform_config.h
+++ b/platform/x11/platform_config.h
@@ -26,7 +26,13 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
+#ifdef __linux__
 #include <alloca.h>
+#endif
+#ifdef __FreeBSD__
+#include <stdlib.h>
+#endif
+
 #define GLES2_INCLUDE_H "gl_context/glew.h"
 #define GLES1_INCLUDE_H "gl_context/glew.h"
 

--- a/script/gdscript/gd_script.cpp
+++ b/script/gdscript/gd_script.cpp
@@ -1416,7 +1416,7 @@ Error GDScript::reload() {
 	String basedir=path;
 
 	if (basedir=="")
-		basedir==get_path();
+		basedir=get_path();
 
 	if (basedir!="")
 		basedir=basedir.get_base_dir();


### PR DESCRIPTION
There were a few linuxisms that were preventing godot from compiling on FreeBSD.  These changes allow it to build.  I've tested building on Linux and FreeBSD and bin/godot does start up and seem usable.

The joystick code is not working as I'm not familiar with the FreeBSD joystick API.  I ifdefed out the body of the functions. I realize this is probably frowned upon (I don't do much C/C++ stuff) so I'd appreciate a suggestion for a cleaner way to do that.  SDL looks like it might be a good model for cross-platform joystick support.
