### PR TITLE
Fix if statement with empty body.

### DIFF
--- a/modules/multiscript/register_types.cpp
+++ b/modules/multiscript/register_types.cpp
@@ -27,6 +27,7 @@ void register_multiscript_types() {
 }
 void unregister_multiscript_types() {
 
-	if (script_multi_script);
+	if (script_multi_script) {
 		memdelete(script_multi_script);
+	}
 }


### PR DESCRIPTION
I get the following warning message :scream: :  

```
modules/multiscript/register_types.cpp:30:26: warning: if statement has empty body [-Wempty-body]
```

in line 30 of `modules/multiscript/register_types.cpp`:

``` 1
if (script_multi_script); // WARNING
        memdelete(script_multi_script);
```
