### PR TITLE
Fixed HTTPClient's possible 411 errors

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -97,6 +97,8 @@ Error HTTPClient::request( Method p_method, const String& p_url, const Vector<St
 
 	String request=String(_methods[p_method])+" "+p_url+" HTTP/1.1\r\n";
 	request+="Host: "+conn_host+":"+itos(conn_port)+"\r\n";
+	request = request + "Content-Length: " + itos(p_body.length()) + "\r\n";
+	
 	for(int i=0;i<p_headers.size();i++) {
 		request+=p_headers[i]+"\r\n";
 	}


### PR DESCRIPTION
HTTPClient is receiving HTTP 411 error message from servers as response when tried to send POST request because of unspecified Content-Length header.

And I fixed this issue by adding new Content-Length header to the request string with body length.
