### PR TITLE
Fixed #199 duplicate control will failed 

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -42,22 +42,6 @@
 #include <stdio.h>
 
 
-class TooltipPanel : public Panel {
-
-	OBJ_TYPE(TooltipPanel,Panel)
-public:
-	TooltipPanel() {};
-
-};
-
-class TooltipLabel : public Label {
-
-	OBJ_TYPE(TooltipLabel,Label)
-public:
-	TooltipLabel() {};
-
-};
-
 Control::Window::Window() {
 
 

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -133,4 +133,13 @@ public:
 VARIANT_ENUM_CAST( Label::Align );
 VARIANT_ENUM_CAST( Label::VAlign );
 
+
+class TooltipLabel : public Label {
+
+	OBJ_TYPE(TooltipLabel,Label)
+public:
+	TooltipLabel() {};
+
+};
+
 #endif

--- a/scene/gui/panel.h
+++ b/scene/gui/panel.h
@@ -45,4 +45,12 @@ public:
 
 };
 
+class TooltipPanel : public Panel {
+
+	OBJ_TYPE(TooltipPanel,Panel)
+public:
+	TooltipPanel() {};
+
+};
+
 #endif

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -297,6 +297,8 @@ void register_scene_types() {
 	ObjectTypeDB::register_type<MenuButton>();
 	ObjectTypeDB::register_type<CheckButton>();
 	ObjectTypeDB::register_type<Panel>();
+	ObjectTypeDB::register_type<TooltipPanel>();
+	ObjectTypeDB::register_type<TooltipLabel>();
 	ObjectTypeDB::register_type<Range>();
 
 	OS::get_singleton()->yield(); //may take time to init


### PR DESCRIPTION
Bug: Duplicate node will failed if there's control in node hierarchy

Fixed it by registering TooltipPanel and TooltipLabel of Control in TypeDB.
