### PR TITLE
Fixed #173 #157 Update parent when deleting CollisionShape2D

### DIFF
--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -39,6 +39,9 @@
 
 void CollisionShape2D::_add_to_collision_object(Object *p_obj) {
 
+	if (unparenting)
+		return;
+
 	CollisionObject2D *co = p_obj->cast_to<CollisionObject2D>();
 	ERR_FAIL_COND(!co);
 	co->add_shape(shape,get_transform());
@@ -189,7 +192,10 @@ void CollisionShape2D::_notification(int p_what) {
 			rect=rect.grow(3);
 
 		} break;
-
+		case NOTIFICATION_UNPARENTED: {
+			unparenting = true;
+			_update_parent();
+		} break;
 	}
 
 }
@@ -245,4 +251,5 @@ CollisionShape2D::CollisionShape2D() {
 	rect=Rect2(-Point2(10,10),Point2(20,20));
 
 	trigger=false;
+	unparenting = false;
 }

--- a/scene/2d/collision_shape_2d.h
+++ b/scene/2d/collision_shape_2d.h
@@ -38,7 +38,7 @@ class CollisionShape2D : public Node2D {
 	Ref<Shape2D> shape;
 	Rect2 rect;
 	bool trigger;
-
+	bool unparenting;
 	void _shape_changed();
 protected:
 


### PR DESCRIPTION
- Force update parent when unpareting a CollsionShape2D
  - Tag self as unparenting so not contribute to parent's collision shape data
