### PR TITLE
Lift Godot GLView update frequency from 30 to 60

### DIFF
--- a/platform/iphone/app_delegate.mm
+++ b/platform/iphone/app_delegate.mm
@@ -38,7 +38,7 @@
 #endif
 
 #define kFilteringFactor                        0.1
-#define kRenderingFrequency						30
+#define kRenderingFrequency						60
 #define kAccelerometerFrequency         100.0 // Hz
 
 #ifdef APPIRATER_ENABLED


### PR DESCRIPTION
30 fps is not smooth enough for some games, lift the default fps to 60;
With pull request #212, user can customize max fps per project by setting target_fps.
