### PR TITLE
Fix #240 TouchScreenButton release signal is not valid

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -26402,7 +26402,7 @@
 			<description>
 			</description>
 		</signal>
-		<signal name="release">
+		<signal name="released">
 			<description>
 			</description>
 		</signal>

--- a/scene/2d/screen_button.cpp
+++ b/scene/2d/screen_button.cpp
@@ -357,7 +357,7 @@ void TouchScreenButton::_bind_methods() {
 	ADD_PROPERTY( PropertyInfo(Variant::INT,"visibility_mode",PROPERTY_HINT_ENUM,"Always,TouchScreen Only"),_SCS("set_visibility_mode"),_SCS("get_visibility_mode"));
 
 	ADD_SIGNAL( MethodInfo("pressed" ) );
-	ADD_SIGNAL( MethodInfo("release" ) );
+	ADD_SIGNAL( MethodInfo("released" ) );
 
 
 


### PR DESCRIPTION
The signal was misspelled as "release" (should be "released")
