### PR TITLE
Path2D editor bug fix and improvement

### DIFF
--- a/tools/editor/plugins/path_2d_editor_plugin.cpp
+++ b/tools/editor/plugins/path_2d_editor_plugin.cpp
@@ -516,7 +516,6 @@ void Path2DEditor::_node_visibility_changed() {
 		return;
 
 	canvas_item_editor->get_viewport_control()->update();
-
 }
 
 void Path2DEditor::edit(Node *p_path2d) {
@@ -533,15 +532,15 @@ void Path2DEditor::edit(Node *p_path2d) {
 		if (!node->is_connected("visibility_changed", this, "_node_visibility_changed"))
 			node->connect("visibility_changed", this, "_node_visibility_changed");
 
-
 	} else {
 
 		if (canvas_item_editor->get_viewport_control()->is_connected("draw",this,"_canvas_draw"))
 			canvas_item_editor->get_viewport_control()->disconnect("draw",this,"_canvas_draw");
-		if (node->is_connected("visibility_changed", this, "_node_visibility_changed"))
+
+		// node may have been deleted at this point
+		if (node && node->is_connected("visibility_changed", this, "_node_visibility_changed"))
 			node->disconnect("visibility_changed", this, "_node_visibility_changed");
 		node=NULL;
-
 	}
 
 }

--- a/tools/editor/plugins/path_2d_editor_plugin.cpp
+++ b/tools/editor/plugins/path_2d_editor_plugin.cpp
@@ -78,6 +78,9 @@ bool Path2DEditor::forward_input_event(const InputEvent& p_event) {
 	if (!node)
 		return false;
 
+	if (!node->is_visible())
+		return false;
+
 	if (!node->get_curve().is_valid())
 		return false;
 
@@ -423,7 +426,6 @@ bool Path2DEditor::forward_input_event(const InputEvent& p_event) {
 
 				Ref<Curve2D> curve = node->get_curve();
 
-
 				Vector2 new_pos = moving_from + xform.basis_xform( gpoint - moving_screen_from );
 
 				switch(action) {
@@ -445,7 +447,7 @@ bool Path2DEditor::forward_input_event(const InputEvent& p_event) {
 				}
 
 
-				canvas_item_editor->update();
+				canvas_item_editor->get_viewport_control()->update();
 				return true;
 			}
 
@@ -471,58 +473,74 @@ void Path2DEditor::_canvas_draw() {
 	if (!node)
 		return ;
 
+	if (!node->is_visible())
+		return;
+
 	if (!node->get_curve().is_valid())
 		return ;
 
 	Matrix32 xform = canvas_item_editor->get_canvas_transform() * node->get_global_transform();
 	Ref<Texture> handle= get_icon("EditorHandle","EditorIcons");
+	Size2 handle_size = handle->get_size();
 
 	Ref<Curve2D> curve = node->get_curve();
 
 	int len = curve->get_point_count();
-	RID ci = canvas_item_editor->get_canvas_item();
+	Control *vpc = canvas_item_editor->get_viewport_control();
+
 
 	for(int i=0;i<len;i++) {
 
 
 		Vector2 point = xform.xform(curve->get_point_pos(i));
-		handle->draw(ci,point-handle->get_size()*0.5,Color(1,1,1,0.3));
+		vpc->draw_texture_rect(handle,Rect2(point-handle->get_size()*0.5,handle_size),false,Color(1,1,1,1));
 
 		if (i<len-1) {
 			Vector2 pointout = xform.xform(curve->get_point_pos(i)+curve->get_point_out(i));
-			canvas_item_editor->draw_line(point,pointout,Color(0.5,0.5,1.0,0.8),1.0);
-			handle->draw(ci,pointout-handle->get_size()*0.5,Color(1,0.5,1,0.3));
+			vpc->draw_line(point,pointout,Color(0.5,0.5,1.0,0.8),1.0);
+			vpc->draw_texture_rect(handle, Rect2(pointout-handle->get_size()*0.5,handle_size),false,Color(1,0.5,1,0.3));
 		}
 
 		if (i>0) {
 			Vector2 pointin = xform.xform(curve->get_point_pos(i)+curve->get_point_in(i));
-			canvas_item_editor->draw_line(point,pointin,Color(0.5,0.5,1.0,0.8),1.0);
-			handle->draw(ci,pointin-handle->get_size()*0.5,Color(1,0.5,1,0.3));
+			vpc->draw_line(point,pointin,Color(0.5,0.5,1.0,0.8),1.0);
+			vpc->draw_texture_rect(handle, Rect2(pointin-handle->get_size()*0.5,handle_size),false,Color(1,0.5,1,0.3));
 		}
 
 	}
 
 }
 
+void Path2DEditor::_node_visibility_changed() {
+	if (!node)
+		return;
 
+	canvas_item_editor->get_viewport_control()->update();
 
-void Path2DEditor::edit(Node *p_collision_polygon) {
+}
+
+void Path2DEditor::edit(Node *p_path2d) {
 
 	if (!canvas_item_editor) {
 		canvas_item_editor=CanvasItemEditor::get_singleton();
 	}
 
-	if (p_collision_polygon) {
+	if (p_path2d) {
 
-		node=p_collision_polygon->cast_to<Path2D>();
-		if (!canvas_item_editor->is_connected("draw",this,"_canvas_draw"))
-			canvas_item_editor->connect("draw",this,"_canvas_draw");
+		node=p_path2d->cast_to<Path2D>();
+		if (!canvas_item_editor->get_viewport_control()->is_connected("draw",this,"_canvas_draw"))
+			canvas_item_editor->get_viewport_control()->connect("draw",this,"_canvas_draw");
+		if (!node->is_connected("visibility_changed", this, "_node_visibility_changed"))
+			node->connect("visibility_changed", this, "_node_visibility_changed");
 
 
 	} else {
+
+		if (canvas_item_editor->get_viewport_control()->is_connected("draw",this,"_canvas_draw"))
+			canvas_item_editor->get_viewport_control()->disconnect("draw",this,"_canvas_draw");
+		if (node->is_connected("visibility_changed", this, "_node_visibility_changed"))
+			node->disconnect("visibility_changed", this, "_node_visibility_changed");
 		node=NULL;
-		if (canvas_item_editor->is_connected("draw",this,"_canvas_draw"))
-			canvas_item_editor->disconnect("draw",this,"_canvas_draw");
 
 	}
 
@@ -532,7 +550,7 @@ void Path2DEditor::_bind_methods() {
 
 	//ObjectTypeDB::bind_method(_MD("_menu_option"),&Path2DEditor::_menu_option);
 	ObjectTypeDB::bind_method(_MD("_canvas_draw"),&Path2DEditor::_canvas_draw);
-
+	ObjectTypeDB::bind_method(_MD("_node_visibility_changed"),&Path2DEditor::_node_visibility_changed);
 }
 
 Path2DEditor::Path2DEditor(EditorNode *p_editor) {
@@ -559,7 +577,7 @@ Path2DEditor::Path2DEditor(EditorNode *p_editor) {
 
 void Path2DEditorPlugin::edit(Object *p_object) {
 
-	collision_polygon_editor->edit(p_object->cast_to<Node>());
+	path2d_editor->edit(p_object->cast_to<Node>());
 }
 
 bool Path2DEditorPlugin::handles(Object *p_object) const {
@@ -570,11 +588,11 @@ bool Path2DEditorPlugin::handles(Object *p_object) const {
 void Path2DEditorPlugin::make_visible(bool p_visible) {
 
 	if (p_visible) {
-		collision_polygon_editor->show();
+		path2d_editor->show();
 	} else {
 
-		collision_polygon_editor->hide();
-		collision_polygon_editor->edit(NULL);
+		path2d_editor->hide();
+		path2d_editor->edit(NULL);
 	}
 
 }
@@ -582,16 +600,16 @@ void Path2DEditorPlugin::make_visible(bool p_visible) {
 Path2DEditorPlugin::Path2DEditorPlugin(EditorNode *p_node) {
 
 	editor=p_node;
-	collision_polygon_editor = memnew( Path2DEditor(p_node) );
-	editor->get_viewport()->add_child(collision_polygon_editor);
+	path2d_editor = memnew( Path2DEditor(p_node) );
+	editor->get_viewport()->add_child(path2d_editor);
 
-	collision_polygon_editor->set_margin(MARGIN_LEFT,200);
-	collision_polygon_editor->set_margin(MARGIN_RIGHT,230);
-	collision_polygon_editor->set_margin(MARGIN_TOP,0);
-	collision_polygon_editor->set_margin(MARGIN_BOTTOM,10);
+	path2d_editor->set_margin(MARGIN_LEFT,200);
+	path2d_editor->set_margin(MARGIN_RIGHT,230);
+	path2d_editor->set_margin(MARGIN_TOP,0);
+	path2d_editor->set_margin(MARGIN_BOTTOM,10);
 
 
-	collision_polygon_editor->hide();
+	path2d_editor->hide();
 
 
 

--- a/tools/editor/plugins/path_2d_editor_plugin.cpp
+++ b/tools/editor/plugins/path_2d_editor_plugin.cpp
@@ -115,7 +115,7 @@ bool Path2DEditor::forward_input_event(const InputEvent& p_event) {
 						Point2 p = xform.xform( curve->get_point_pos(i) );
 						if (gpoint.distance_to(p) < grab_treshold ) {
 
-							if (!mb.mod.control) {
+							if (!mb.mod.shift) {
 
 								action=ACTION_MOVING_POINT;
 								action_point=i;

--- a/tools/editor/plugins/path_2d_editor_plugin.h
+++ b/tools/editor/plugins/path_2d_editor_plugin.h
@@ -40,9 +40,9 @@
 */
 class CanvasItemEditor;
 
-class Path2DEditor : public ButtonGroup {
+class Path2DEditor : public HBoxContainer {
 
-	OBJ_TYPE(Path2DEditor, ButtonGroup);
+	OBJ_TYPE(Path2DEditor, HBoxContainer);
 
 	UndoRedo *undo_redo;
 

--- a/tools/editor/plugins/path_2d_editor_plugin.h
+++ b/tools/editor/plugins/path_2d_editor_plugin.h
@@ -42,7 +42,7 @@ class CanvasItemEditor;
 
 class Path2DEditor : public ButtonGroup {
 
-	OBJ_TYPE(Path2DEditor, ButtonGroup );
+	OBJ_TYPE(Path2DEditor, ButtonGroup);
 
 	UndoRedo *undo_redo;
 
@@ -67,6 +67,7 @@ class Path2DEditor : public ButtonGroup {
 
 
 	void _canvas_draw();
+	void _node_visibility_changed();
 
 protected:
 	void _notification(int p_what);
@@ -76,7 +77,7 @@ public:
 
 	Vector2 snap_point(const Vector2& p_point) const;
 	bool forward_input_event(const InputEvent& p_event);
-	void edit(Node *p_collision_polygon);
+	void edit(Node *p_path2d);
 	Path2DEditor(EditorNode *p_editor);
 };
 
@@ -84,12 +85,12 @@ class Path2DEditorPlugin : public EditorPlugin {
 
 	OBJ_TYPE( Path2DEditorPlugin, EditorPlugin );
 
-	Path2DEditor *collision_polygon_editor;
+	Path2DEditor *path2d_editor;
 	EditorNode *editor;
 
 public:
 
-	virtual bool forward_input_event(const InputEvent& p_event) { return collision_polygon_editor->forward_input_event(p_event); }
+	virtual bool forward_input_event(const InputEvent& p_event) { return path2d_editor->forward_input_event(p_event); }
 
 	virtual String get_name() const { return "Path2D"; }
 	bool has_main_screen() const { return false; }


### PR DESCRIPTION
- Fix #244 no path2d handles visible
- Update hotkey to be consistent with CollisionPolygon editor
- Add view-base point snap support (independent from node transform)

![](http://oi61.tinypic.com/2b713c.jpg)
Original curve

![](http://oi59.tinypic.com/xpzuia.jpg)
Use normal snapping, point is snapped to next step position

![](http://oi62.tinypic.com/28lz09w.jpg)
Activate view-base snapping, point is snapped to next grid point on view
