### PR TITLE
Enable touch event emulation on desktop

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -334,6 +334,16 @@ static int button_mask=0;
 	ev.mouse_button.mod = translateFlags([event modifierFlags]);
 	OS_OSX::singleton->push_input(ev);
 
+	if (OS_OSX::singleton->has_touchscreen_ui_hint()) {
+		InputEvent touch_event;
+		touch_event.type = InputEvent::SCREEN_TOUCH;
+		touch_event.screen_touch.index=0;
+		touch_event.screen_touch.pressed = true;
+		touch_event.screen_touch.x = mouse_x;
+		touch_event.screen_touch.y = mouse_y;
+		OS_OSX::singleton->push_input(touch_event);
+	}
+
 
   /*  _glfwInputMouseClick(window,
 			 GLFW_MOUSE_BUTTON_LEFT,
@@ -361,6 +371,16 @@ static int button_mask=0;
 	ev.mouse_button.button_mask=button_mask;
 	ev.mouse_button.mod = translateFlags([event modifierFlags]);
 	OS_OSX::singleton->push_input(ev);
+
+	if (OS_OSX::singleton->has_touchscreen_ui_hint()) {
+		InputEvent touch_event;
+		touch_event.type = InputEvent::SCREEN_TOUCH;
+		touch_event.screen_touch.index = 0;
+		touch_event.screen_touch.pressed = false;
+		touch_event.screen_touch.x = mouse_x;
+		touch_event.screen_touch.y = mouse_y;
+		OS_OSX::singleton->push_input(touch_event);
+	}
 
    /* _glfwInputMouseClick(window,
 			 GLFW_MOUSE_BUTTON_LEFT,
@@ -396,6 +416,16 @@ static int button_mask=0;
 	OS_OSX::singleton->input->set_mouse_pos(Point2(mouse_x,mouse_y));
 	OS_OSX::singleton->push_input(ev);
 
+	if (OS_OSX::singleton->input->is_mouse_button_pressed(1) && OS_OSX::singleton->has_touchscreen_ui_hint()) {
+		InputEvent drag_event;
+		drag_event.type=InputEvent::SCREEN_DRAG;
+		drag_event.screen_drag.index=0;
+		drag_event.screen_drag.x = mouse_x;
+		drag_event.screen_drag.y = mouse_y;
+		drag_event.screen_drag.relative_x = mouse_x - prev_mouse_x;
+		drag_event.screen_drag.relative_y = mouse_y - prev_mouse_y;
+		OS_OSX::singleton->push_input(drag_event);
+	}
 
   /*  if (window->cursorMode == GLFW_CURSOR_DISABLED)
 	_glfwInputCursorMotion(window, [event deltaX], [event deltaY]);

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -270,28 +270,29 @@ LRESULT OS_Windows::WndProc(HWND hWnd,UINT uMsg, WPARAM	wParam,	LPARAM	lParam) {
 		}
 		case WM_MOUSELEAVE: {
 
-                    old_invalid=true;
-                    outside=true;
+			old_invalid=true;
+			outside=true;
 
 		} break;
 		case WM_MOUSEMOVE: {
 
-                    if (outside) {
+			if (outside) {
 
-                        CursorShape c=cursor_shape;
-                        cursor_shape=CURSOR_MAX;
-                        set_cursor_shape(c);
-                        outside=false;
+				CursorShape c=cursor_shape;
+				cursor_shape=CURSOR_MAX;
+				set_cursor_shape(c);
+				outside=false;
 
-			//Once-Off notification, must call again....
-			TRACKMOUSEEVENT tme;
-			tme.cbSize=sizeof(TRACKMOUSEEVENT);
-			tme.dwFlags=TME_LEAVE;
-			tme.hwndTrack=hWnd;
-			tme.dwHoverTime=HOVER_DEFAULT;
-			TrackMouseEvent(&tme);
+				//Once-Off notification, must call again....
+				TRACKMOUSEEVENT tme;
+				tme.cbSize=sizeof(TRACKMOUSEEVENT);
+				tme.dwFlags=TME_LEAVE;
+				tme.hwndTrack=hWnd;
+				tme.dwHoverTime=HOVER_DEFAULT;
+				TrackMouseEvent(&tme);
 
-                    }
+			}
+
 			InputEvent event;
 			event.type=InputEvent::MOUSE_MOTION;
 			event.ID=++last_id;
@@ -343,9 +344,21 @@ LRESULT OS_Windows::WndProc(HWND hWnd,UINT uMsg, WPARAM	wParam,	LPARAM	lParam) {
 			mm.relative_y=mm.y-old_y;
 			old_x=mm.x;
 			old_y=mm.y;
-			if (main_loop)
+			if (main_loop) {
 				input->parse_input_event(event);
 
+				if (input->is_mouse_button_pressed(1) && has_touchscreen_ui_hint()) {
+					InputEvent drag_event;
+					drag_event.type=InputEvent::SCREEN_DRAG;
+					drag_event.ID = ++last_id;
+					drag_event.screen_drag.index=0;
+					drag_event.screen_drag.x=mm.x;
+					drag_event.screen_drag.y=mm.y;
+					drag_event.screen_drag.relative_x = mm.relative_x;
+					drag_event.screen_drag.relative_y = mm.relative_y;
+					input->parse_input_event(drag_event);
+				}
+			}
 			
 
 		} break;
@@ -481,6 +494,17 @@ LRESULT OS_Windows::WndProc(HWND hWnd,UINT uMsg, WPARAM	wParam,	LPARAM	lParam) {
 					event.ID=++last_id;
 					input->parse_input_event(event);
 
+				}
+
+				if (mb.button_index==1 && has_touchscreen_ui_hint()) {
+					InputEvent touch_event;
+					touch_event.type = InputEvent::SCREEN_TOUCH;
+					touch_event.ID = ++last_id;
+					touch_event.screen_touch.index=0;
+					touch_event.screen_touch.pressed=mb.pressed;
+					touch_event.screen_touch.x=mb.x;
+					touch_event.screen_touch.y=mb.y;
+					input->parse_input_event(touch_event);
 				}
 			}
 

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -759,6 +759,16 @@ void OS_X11::process_xevents() {
 
 			input->parse_input_event( mouse_event);
 
+			if (mouse_event.mouse_button.button_index==1 && has_touchscreen_ui_hint()) {
+				InputEvent touch_event;
+				touch_event.type = InputEvent::SCREEN_TOUCH;
+				touch_event.ID = ++event_id;
+				touch_event.screen_touch.index=0;
+				touch_event.screen_touch.pressed = mouse_event.mouse_button.pressed;
+				touch_event.screen_touch.x = mouse_event.mouse_button.x;
+				touch_event.screen_touch.y = mouse_event.mouse_button.y;
+				input->parse_input_event(touch_event);
+			}
 			
 		} break;	
 		case MotionNotify: {
@@ -831,6 +841,18 @@ void OS_X11::process_xevents() {
 			last_mouse_pos=pos;
 			
 			input->parse_input_event( motion_event);
+
+			if (input->is_mouse_button_pressed(1) && has_touchscreen_ui_hint()) {
+				InputEvent drag_event;
+				drag_event.type = InputEvent::SCREEN_DRAG;
+				drag_event.ID = ++event_id;
+				drag_event.screen_drag.index = 0;
+				drag_event.screen_drag.x = pos.x;
+				drag_event.screen_drag.y = pos.y;
+				drag_event.screen_drag.relative_x = rel.x;
+				drag_event.screen_drag.relative_y = rel.y;
+				input->parse_input_event(drag_event);
+			}
 			
 		} break;			
 		case KeyPress: 


### PR DESCRIPTION
- Emulate SCREEN_TOUCH and SCREEN_DRAG event on desktop (win/mac/linux) when emulate_touchscreen options is on
- Resolve issue #249, now touch only control's behavior (eg. TouchScreenButton) could be emulated on desktop
