### PR TITLE
Fixed Android crash by adding safety to the hideKeyboard() -function.

### DIFF
--- a/platform/android/java/src/com/android/godot/GodotIO.java
+++ b/platform/android/java/src/com/android/godot/GodotIO.java
@@ -472,8 +472,13 @@ public class GodotIO {
 
 	public void hideKeyboard() {
 
-		InputMethodManager inputMgr = (InputMethodManager)activity.getSystemService(Context.INPUT_METHOD_SERVICE);
-		inputMgr.hideSoftInputFromWindow(activity.getCurrentFocus().getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
+        InputMethodManager inputMgr = (InputMethodManager)activity.getSystemService(Context.INPUT_METHOD_SERVICE);
+        View v = activity.getCurrentFocus();
+        if (v != null) {
+            inputMgr.hideSoftInputFromWindow(v.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
+        } else {
+            inputMgr.hideSoftInputFromWindow(new View(activity).getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
+        }
 	};
 
 	public void setScreenOrientation(int p_orientation) {


### PR DESCRIPTION
I tested this on Xperia Mini Pro with Android 4.0.4, which crashed always nicely. In the original code, the activity.getCurrentFocus() always returned null on my project (PopupDialog with LineEdit and/or TextEdit)
