### PR TITLE
home button & whitespace

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1349,8 +1349,21 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 
 					if (k.mod.shift)
 						_pre_shift_selection();
-
-					cursor_set_column(0);
+					
+					// compute whitespace symbols seq length
+					int current_line_whitespace_len = 0;
+					while(current_line_whitespace_len < text[cursor.line].length()) {
+						CharType c = text[cursor.line][current_line_whitespace_len];
+						if(c != '\t' && c != ' ')
+							break;
+						current_line_whitespace_len++;
+					}
+					
+					if(cursor_get_column() == current_line_whitespace_len)
+						cursor_set_column(0);
+					else
+						cursor_set_column(current_line_whitespace_len);
+					
 					if (k.mod.command)
 						cursor_set_line(0);
 


### PR DESCRIPTION
There was a question:

<blockquote>
Home button in editor moves cursor not to first non-space symbol but to the real beginning. Is it possible to change?
</blockquote>

and this

<blockquote>
Home moves to the first non-space character, and if Home is pressed while already at the first non-space character, then it takes you to the very start of the line? best of both worlds that way.
</blockquote>

So this commit fix editor in this way.

P.S. I suppose that it will be useful to add new editor settings param . I can try to do it later.
