### PR TITLE
"path not found" when assign the ViewportSprite's target.

### DIFF
--- a/tools/editor/property_editor.cpp
+++ b/tools/editor/property_editor.cpp
@@ -38,6 +38,7 @@
 #include "scene/scene_string_names.h"
 #include "editor_settings.h"
 #include "editor_import_export.h"
+#include "editor_node.h"
 
 void CustomPropertyEditor::_notification(int p_what) {
 	
@@ -849,11 +850,12 @@ void CustomPropertyEditor::_color_changed(const Color& p_color) {
 void CustomPropertyEditor::_node_path_selected(NodePath p_path) {
 
 	if (owner && owner->is_type("Node")) {
-
-		Node *node = owner->cast_to<Node>();
-		Node *tonode=node->get_node(p_path);
+        Node *scene = EditorNode::get_singleton()->get_edited_scene();
+        p_path = NodePath( "/"+scene->get_name() ).rel_path_to( p_path );
+		Node *node      = owner->cast_to<Node>();
+		Node *tonode    = scene->get_node( p_path );
+        //
 		if (tonode) {
-
 			p_path=node->get_path_to(tonode);
 		}
 

--- a/tools/editor/scene_tree_editor.cpp
+++ b/tools/editor/scene_tree_editor.cpp
@@ -716,7 +716,7 @@ void SceneTreeDialog::_select() {
 
 	if (tree->get_selected()) {
         Node *scene = EditorNode::get_singleton()->get_edited_scene();
-        emit_signal("selected","/root/" + scene->get_parent()->get_path_to(tree->get_selected()));
+        emit_signal("selected","/" + scene->get_parent()->get_path_to(tree->get_selected()));
 		hide();
 	}
 }


### PR DESCRIPTION
Fixed:
"path not found" when assign the ViewportSprite's target.

Now: make a relative path for the ViewportSprite's target.
