### PR TITLE
Draw gray block into atlas image preview

### DIFF
--- a/tools/editor/io_plugins/editor_texture_import_plugin.cpp
+++ b/tools/editor/io_plugins/editor_texture_import_plugin.cpp
@@ -708,7 +708,7 @@ Error EditorTextureImportPlugin::import(const String& p_path, const Ref<Resource
 	return import2(p_path,p_from,EditorExportPlatform::IMAGE_COMPRESSION_BC,false);
 }
 
-Error EditorTextureImportPlugin::import2(const String& p_path, const Ref<ResourceImportMetadata>& p_from,EditorExportPlatform::ImageCompression p_compr, bool p_external){
+Error EditorTextureImportPlugin::import2(const String& p_path, const Ref<ResourceImportMetadata>& p_from,EditorExportPlatform::ImageCompression p_compr, bool p_external, bool p_preview){
 
 
 
@@ -810,7 +810,6 @@ Error EditorTextureImportPlugin::import2(const String& p_path, const Ref<Resourc
 
 		Image atlas;
 		atlas.create(nearest_power_of_2(dst_size.width),nearest_power_of_2(dst_size.height),0,alpha?Image::FORMAT_RGBA:Image::FORMAT_RGB);
-
 		for(int i=0;i<sources.size();i++) {
 
 			int x=dst_positions[i].x;
@@ -833,6 +832,15 @@ Error EditorTextureImportPlugin::import2(const String& p_path, const Ref<Resourc
 			at->set_path(apath);
 			atlases.push_back(at);
 
+		}
+		if (p_preview) {
+			for(int x=0;x<atlas.get_width();x++) {
+				for(int y=0;y<atlas.get_height();y++) {
+					bool gray=(x / 32 + y / 32) & 1;
+					Color c=Color(gray?0.25:0.75,gray?0.25:0.75,gray?0.25:0.75,0.5);
+					atlas.put_pixel(x,y,c.blend(atlas.get_pixel(x,y)));
+				}
+			}
 		}
 		if (ResourceCache::has(p_path)) {
 			texture = Ref<ImageTexture> ( ResourceCache::get(p_path)->cast_to<ImageTexture>() );

--- a/tools/editor/io_plugins/editor_texture_import_plugin.h
+++ b/tools/editor/io_plugins/editor_texture_import_plugin.h
@@ -98,7 +98,7 @@ public:
 	virtual String get_visible_name() const;
 	virtual void import_dialog(const String& p_from="");
 	virtual Error import(const String& p_path, const Ref<ResourceImportMetadata>& p_from);
-	virtual Error import2(const String& p_path, const Ref<ResourceImportMetadata>& p_from,EditorExportPlatform::ImageCompression p_compr, bool p_external=false);
+	virtual Error import2(const String& p_path, const Ref<ResourceImportMetadata>& p_from,EditorExportPlatform::ImageCompression p_compr, bool p_external=false, bool p_preview=false);
 	virtual Vector<uint8_t> custom_export(const String& p_path,const Ref<EditorExportPlatform> &p_platform);
 
 

--- a/tools/editor/project_export.cpp
+++ b/tools/editor/project_export.cpp
@@ -942,7 +942,7 @@ void ProjectExportDialog::_group_atlas_preview() {
 	imd->set_option("crop",true);
 
 	Ref<EditorTextureImportPlugin> plugin = EditorImportExport::get_singleton()->get_import_plugin_by_name("texture_atlas");
-	Error err = plugin->import2(dst_file,imd,EditorExportPlatform::IMAGE_COMPRESSION_NONE,true);
+	Error err = plugin->import2(dst_file,imd,EditorExportPlatform::IMAGE_COMPRESSION_NONE,true,true);
 	if (err) {
 
 		EditorNode::add_io_error("Error saving atlas! "+dst_file.get_file());


### PR DESCRIPTION
Draw some gray blocks on preview atlas texture, look's like this:
![image](https://cloud.githubusercontent.com/assets/6880378/2719133/78ad2810-c55b-11e3-8c78-7c74da07c8d7.png)
