### PR TITLE
stops running process when quitting editor

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -1982,7 +1982,8 @@ void EditorNode::_menu_option_confirm(int p_option,bool p_confirmed) {
 				confirmation->popup_centered(Size2(300,70));
 				break;
 			}
-			
+
+			_menu_option_confirm(RUN_STOP,true);
 			get_scene()->quit();
 				
 		} break;


### PR DESCRIPTION
I noticed a bug where I could close Godot while I was running a project, and the project would continue to run.

If the program was left running and then ran into an error, or if an error was caught by the debugger and then I quit Godot, I could no longer close the running project without manually killing it.
This fixes that problem by essentially hitting the Stop button automatically just prior to quitting the editor.
