### PR TITLE
compilation fails on some systems

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -6,13 +6,13 @@ import os.path
 import glob
 import sys
 import methods
-import multiprocessing
 
 # Enable aggresive compile mode if building on a multi core box
 # only is we have not set the number of jobs already or we do
 # not want it
 if ARGUMENTS.get('spawn_jobs', 'no') == 'yes' and \
 	int(GetOption('num_jobs')) <= 1:
+	import multiprocessing
 	NUM_JOBS = multiprocessing.cpu_count()
 	if NUM_JOBS > 1:
 		SetOption('num_jobs', NUM_JOBS+1)


### PR DESCRIPTION
Compilations fails on Gentoo. Anyway, multiprocessing module is only needed if the spawn_jobs are indicated on the command line.
