### PR TITLE
Allow use double as real_t

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -132,7 +132,7 @@ opts.Add("LINKFLAGS", "Custom flags for the linker");
 opts.Add('disable_3d', 'Disable 3D nodes for smaller executable (yes/no)', "no")
 opts.Add('disable_advanced_gui', 'Disable advance 3D gui nodes and behaviors (yes/no)', "no")
 opts.Add('old_scenes', 'Compatibility with old-style scenes', "yes")
-opts.Add('use_double', 'Use Real type as Double, default is float', "yes")
+opts.Add('use_double', 'Use Real type as Double, default is float', "no")
 
 # add platform specific options
 

--- a/SConstruct
+++ b/SConstruct
@@ -132,6 +132,7 @@ opts.Add("LINKFLAGS", "Custom flags for the linker");
 opts.Add('disable_3d', 'Disable 3D nodes for smaller executable (yes/no)', "no")
 opts.Add('disable_advanced_gui', 'Disable advance 3D gui nodes and behaviors (yes/no)', "no")
 opts.Add('old_scenes', 'Compatibility with old-style scenes', "yes")
+opts.Add('use_double', 'Use Real type as Double, default is float', "yes")
 
 # add platform specific options
 
@@ -261,6 +262,8 @@ for p in platform_list:
 		env.Append(CPPFLAGS=['-DTOOLS_ENABLED'])
 	if (env['disable_3d']=='yes'):
 		env.Append(CPPFLAGS=['-D_3D_DISABLED'])
+	if (env['use_double']=='yes'):
+		env.Append(CPPFLAGS=['-DREAL_T_IS_DOUBLE'])
 	if (env['gdscript']=='yes'):
 		env.Append(CPPFLAGS=['-DGDSCRIPT_ENABLED'])
 	if (env['disable_advanced_gui']=='yes'):

--- a/bin/tests/test_math.cpp
+++ b/bin/tests/test_math.cpp
@@ -90,14 +90,14 @@ MainLoop* test() {
 	{
 		Vector3 v(1,2,3);
 		v.normalize();
-		float a=0.3;
+		real_t a=0.3;
 
 		//Quat q(v,a);
 		Matrix3 m(v,a);
 
 		Vector3 v2(7,3,1);
 		v2.normalize();
-		float a2=0.8;
+		real_t a2=0.8;
 
 		//Quat q(v,a);
 		Matrix3 m2(v2,a2);

--- a/core/globals.cpp
+++ b/core/globals.cpp
@@ -700,7 +700,7 @@ static Variant _decode_variant(const String& p_string) {
 	}
 
 	if (str.find(",")!=-1) { //vector2 or vector3
-		Vector<float> farr = str.split_floats(",",true);
+		Vector<real_t> farr = str.split_floats(",",true);
 		if (farr.size()==2) {
 			return Point2(farr[0],farr[1]);
 		}

--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -620,7 +620,7 @@ static Variant _decode_variant(const String& p_string) {
 	}
 
 	if (str.find(",")!=-1) { //vector2 or vector3
-		Vector<float> farr = str.split_floats(",",true);
+		Vector<real_t> farr = str.split_floats(",",true);
 		if (farr.size()==2) {
 			return Point2(farr[0],farr[1]);
 		}

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -608,7 +608,21 @@ Error decode_variant(Variant& r_variant,const uint8_t *p_buffer, int p_len,int *
 
 				w = DVector<float>::Write();
 			}
+#ifdef REAL_T_IS_DOUBLE
+			// Convert float_array to double_array
+			DVector<real_t> output;
+			output.resize(count);
+
+			DVector<float>::Read r = data.read();
+			DVector<real_t>::Write ow=output.write();
+			for(int i=0;i<len;i++) {
+				ow[i]=r[i];
+			}
+			ow=DVector<real_t>::Write();
+			r_variant=output;
+#else
 			r_variant=data;
+#endif
 
 			if (r_len) {
 				(*r_len)+=4+count*sizeof(float);
@@ -1274,7 +1288,7 @@ Error encode_variant(const Variant& p_variant, uint8_t *r_buffer, int &r_len) {
 
 			DVector<real_t> data = p_variant;
 			int datalen=data.size();
-			int datasize=sizeof(real_t);
+			int datasize=sizeof(float);
 
 			if (buf) {
 				encode_uint32(datalen,buf);

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -137,8 +137,10 @@ Error ResourceInteractiveLoaderBinary::parse_variant(Variant& r_v)  {
 			r_v=int(f->get_32());
 		} break;
 		case VARIANT_REAL: {
-
-			r_v=f->get_real();
+			if(use_real64)
+				r_v=f->get_double();
+			else
+				r_v=f->get_real();
 		} break;
 		case VARIANT_STRING: {
 
@@ -481,23 +483,71 @@ Error ResourceInteractiveLoaderBinary::parse_variant(Variant& r_v)  {
 
 			uint32_t len = f->get_32();
 
+			if(!use_real64) {
+				DVector<float> array;
+				array.resize(len);
+				DVector<float>::Write w = array.write();
+				f->get_buffer((uint8_t*)w.ptr(),len*sizeof(float));
+#ifdef BIG_ENDIAN_ENABLED
+				{
+					uint32_t *ptr=(uint32_t*)w.ptr();
+					for(int i=0;i<len;i++) {
+
+						ptr[i]=BSWAP32(ptr[i]);
+					}
+				}
+#endif
+				w=DVector<float>::Write();
+
+#if REAL_T_IS_DOUBLE
+				DVector<real_t> output;
+				output.resize(len);
+				{
+					DVector<float>::Read r = array.read();
+					DVector<real_t>::Write ow=output.write();
+					for(int i=0;i<len;i++) {
+						ow[i]=r[i];
+					}
+					ow=DVector<real_t>::Write();
+				}
+				r_v=output;
+#else
+				r_v=array;
+#endif
+				break;
+			} 
+
 			DVector<real_t> array;
 			array.resize(len);
 			DVector<real_t>::Write w = array.write();
 			f->get_buffer((uint8_t*)w.ptr(),len*sizeof(real_t));
 #ifdef BIG_ENDIAN_ENABLED
 			{
-				uint32_t *ptr=(uint32_t*)w.ptr();
+				uint64_t *ptr=(uint64_t*)w.ptr();
 				for(int i=0;i<len;i++) {
 
-					ptr[i]=BSWAP32(ptr[i]);
+					ptr[i]=BSWAP64(ptr[i]);
 				}
 			}
 
 #endif
 
 			w=DVector<real_t>::Write();
+#if REAL_T_IS_DOUBLE
 			r_v=array;
+#else
+			DVector<real_t> output;
+			output.resize(len);
+			{
+				DVector<double>::Read r = array.read();
+				DVector<real_t>::Write ow=output.write();
+				for(int i=0;i<len;i++) {
+					ow[i]=r[i];
+				}
+				ow=DVector<real_t>::Write();
+			}
+			r_v=output;
+#endif
 		} break;
 		case VARIANT_STRING_ARRAY: {
 
@@ -846,7 +896,9 @@ void ResourceInteractiveLoaderBinary::open(FileAccess *p_f) {
 	bool endian_swap = big_endian;
 #endif
 
-	bool use_real64 = f->get_32();
+	use_real64 = f->get_32();
+
+	f->real_is_double = use_real64;
 
 	f->set_endian_swap(big_endian!=0); //read big endian if saved as big endian
 
@@ -960,7 +1012,9 @@ String ResourceInteractiveLoaderBinary::recognize(FileAccess *p_f) {
 	bool endian_swap = big_endian;
 #endif
 
-	bool use_real64 = f->get_32();
+	use_real64 = f->get_32();
+
+	f->real_is_double = use_real64;
 
 	f->set_endian_swap(big_endian!=0); //read big endian if saved as big endian
 
@@ -1769,8 +1823,11 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path,const RES& p_
 		f->set_endian_swap(true);
 	} else
 		f->store_32(0);
-
+#ifdef REAL_T_IS_DOUBLE
+	f->store_32(1); //64 bits file, false for now
+#else
 	f->store_32(0); //64 bits file, false for now
+#endif // REAL_T_IS_DOUBLE
 	f->store_32(VERSION_MAJOR);
 	f->store_32(VERSION_MINOR);
 	f->store_32(FORMAT_VERSION);

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -569,6 +569,15 @@ Error ResourceInteractiveLoaderBinary::parse_variant(Variant& r_v)  {
 			DVector<Vector2> array;
 			array.resize(len);
 			DVector<Vector2>::Write w = array.write();
+			if(use_real64)
+			{
+				for(uint32_t idx=0;idx<len;idx++) {
+					w[idx].x=f->get_double();
+					w[idx].y=f->get_double();
+				}
+				r_v=array;
+				break;
+			}
 			if (sizeof(Vector2)==8) {
 				f->get_buffer((uint8_t*)w.ptr(),len*sizeof(real_t)*2);
 #ifdef BIG_ENDIAN_ENABLED
@@ -597,6 +606,16 @@ Error ResourceInteractiveLoaderBinary::parse_variant(Variant& r_v)  {
 			DVector<Vector3> array;
 			array.resize(len);
 			DVector<Vector3>::Write w = array.write();
+			if(use_real64)
+			{
+				for(uint32_t idx=0;idx<len;idx++) {
+					w[idx].x=f->get_double();
+					w[idx].y=f->get_double();
+					w[idx].z=f->get_double();
+				}
+				r_v=array;
+				break;
+			}
 			if (sizeof(Vector3)==12) {
 				f->get_buffer((uint8_t*)w.ptr(),len*sizeof(real_t)*3);
 #ifdef BIG_ENDIAN_ENABLED
@@ -625,6 +644,17 @@ Error ResourceInteractiveLoaderBinary::parse_variant(Variant& r_v)  {
 			DVector<Color> array;
 			array.resize(len);
 			DVector<Color>::Write w = array.write();
+			if(use_real64)
+			{
+				for(uint32_t idx=0;idx<len;idx++) {
+					w[idx].r=f->get_double();
+					w[idx].g=f->get_double();
+					w[idx].b=f->get_double();
+					w[idx].a=f->get_double();
+				}
+				r_v=array;
+				break;
+			}
 			if (sizeof(Color)==16) {
 				f->get_buffer((uint8_t*)w.ptr(),len*sizeof(real_t)*4);
 #ifdef BIG_ENDIAN_ENABLED
@@ -637,7 +667,6 @@ Error ResourceInteractiveLoaderBinary::parse_variant(Variant& r_v)  {
 			}
 
 #endif
-
 			} else {
 				ERR_EXPLAIN("Color size is NOT 16!");
 				ERR_FAIL_V(ERR_UNAVAILABLE);

--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -95,7 +95,7 @@ public:
 	_FORCE_INLINE_ Vector3 get_endpoint(int p_point) const;
 
 	AABB expand(const Vector3& p_vector) const;
-	_FORCE_INLINE_ void project_range_in_plane(const Plane& p_plane,float &r_min,float& r_max) const;
+	_FORCE_INLINE_ void project_range_in_plane(const Plane& p_plane,real_t &r_min,real_t& r_max) const;
 	_FORCE_INLINE_ void expand_to(const Vector3& p_vector); /** expand to contain a point if necesary */
 
 	operator String() const;
@@ -273,7 +273,7 @@ inline void AABB::expand_to(const Vector3& p_vector) {
 	size=end-begin;
 }
 
-void AABB::project_range_in_plane(const Plane& p_plane,float &r_min,float& r_max) const {
+void AABB::project_range_in_plane(const Plane& p_plane,real_t &r_min,real_t& r_max) const {
 
 	Vector3 half_extents( size.x * 0.5, size.y * 0.5, size.z * 0.5 );
 	Vector3 center( pos.x + half_extents.x, pos.y + half_extents.y, pos.z + half_extents.z );

--- a/core/math/bsp_tree.cpp
+++ b/core/math/bsp_tree.cpp
@@ -471,7 +471,7 @@ BSP_Tree::operator Variant() const {
 	Dictionary d;
 	d["error_radius"]=error_radius;
 
-	Vector<float> plane_values;
+	Vector<real_t> plane_values;
 	plane_values.resize(planes.size()*4);
 
 	for(int i=0;i<planes.size();i++) {
@@ -520,13 +520,13 @@ BSP_Tree::BSP_Tree(const Variant& p_variant) {
 
 	if (d["planes"].get_type()==Variant::REAL_ARRAY) {
 
-		DVector<float> src_planes=d["planes"];
+		DVector<real_t> src_planes=d["planes"];
 		int plane_count=src_planes.size();
 		ERR_FAIL_COND(plane_count%4);
 		planes.resize(plane_count/4);
 
 		if (plane_count) {
-			DVector<float>::Read r = src_planes.read();
+			DVector<real_t>::Read r = src_planes.read();
 			for(int i=0;i<plane_count/4;i++) {
 
 				planes[i].normal.x=r[i*4+0];

--- a/core/math/face3.cpp
+++ b/core/math/face3.cpp
@@ -255,7 +255,7 @@ bool Face3::intersects_aabb(const AABB& p_aabb) const {
 				continue; // coplanar
 			axis.normalize();
 
-			float minA,maxA,minB,maxB;
+			real_t minA,maxA,minB,maxB;
 			p_aabb.project_range_in_plane(Plane(axis,0),minA,maxA);
 			project_range(axis,Transform(),minB,maxB);
 
@@ -272,7 +272,7 @@ Face3::operator String() const {
 	return String()+vertex[0]+", "+vertex[1]+", "+vertex[2];
 }
 
-void Face3::project_range(const Vector3& p_normal,const Transform& p_transform,float& r_min, float& r_max) const {
+void Face3::project_range(const Vector3& p_normal,const Transform& p_transform,real_t& r_min, real_t& r_max) const {
 
 	for (int i=0;i<3;i++) {
 

--- a/core/math/face3.h
+++ b/core/math/face3.h
@@ -75,7 +75,7 @@ public:
         ClockDirection get_clock_dir() const; ///< todo, test if this is returning the proper clockwisity
 
         void get_support(const Vector3& p_normal,const Transform& p_transform,Vector3 *p_vertices,int* p_count,int p_max) const;
-        void project_range(const Vector3& p_normal,const Transform& p_transform,float& r_min, float& r_max) const;
+        void project_range(const Vector3& p_normal,const Transform& p_transform,real_t& r_min, real_t& r_max) const;
         
         AABB get_aabb() const {
 

--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -514,6 +514,10 @@ String FileAccess::get_md5(const String& p_file) {
 FileAccess::FileAccess() {
 
 	endian_swap=false;
+#ifdef REAL_T_IS_DOUBLE
+	real_is_double=true;
+#else
 	real_is_double=false;
+#endif
 	_access_type=ACCESS_FILESYSTEM;
 };

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -202,6 +202,12 @@ static inline uint32_t BSWAP32(uint32_t x) {
 	return((x<<24)|((x<<8)&0x00FF0000)|((x>>8)&0x0000FF00)|(x>>24));
 }
 
+/** Swap 64 bits value for endianness */
+static inline uint64_t BSWAP64(uint64_t x) {
+	return((x<<56)&0xff00000000000000UL)|((x<<40)&0x00ff000000000000UL)|((x<<24)&0x0000ff0000000000UL)|((x<<8)&0x000000ff00000000UL)|
+		  ((x>>8)&0x00000000ff000000UL)|((x>>24)&0x0000000000ff0000UL)|((x>>40)&0x000000000000ff00UL)|((x>>56)&0x00000000000000ffUL);
+}
+
 /** When compiling with RTTI, we can add an "extra"
  * layer of safeness in many operations, so dynamic_cast
  * is used besides casting by enum.

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -578,9 +578,9 @@ Vector<String> String::split(const String &p_splitter,bool p_allow_empty) const 
 	return ret;
 }
 
-Vector<float> String::split_floats(const String &p_splitter,bool p_allow_empty) const {
+Vector<real_t> String::split_floats(const String &p_splitter,bool p_allow_empty) const {
 
-	Vector<float> ret;
+	Vector<real_t> ret;
 	int from=0;
 	int len = length();
 
@@ -601,9 +601,9 @@ Vector<float> String::split_floats(const String &p_splitter,bool p_allow_empty) 
 	return ret;
 }
 
-Vector<float> String::split_floats_mk(const Vector<String> &p_splitters,bool p_allow_empty) const {
+Vector<real_t> String::split_floats_mk(const Vector<String> &p_splitters,bool p_allow_empty) const {
 
-	Vector<float> ret;
+	Vector<real_t> ret;
 	int from=0;
 	int len = length();
 

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -31,6 +31,7 @@
 
 #include "typedefs.h"
 #include "vector.h"
+#include "math/math_defs.h"
 
 /**
 	@author red <red@killy>
@@ -150,8 +151,8 @@ public:
 	String get_slice(String p_splitter,int p_slice) const;
 
 	Vector<String> split(const String &p_splitter,bool p_allow_empty=true) const;
-	Vector<float> split_floats(const String &p_splitter,bool p_allow_empty=true) const;
-	Vector<float> split_floats_mk(const Vector<String> &p_splitters,bool p_allow_empty=true) const;
+	Vector<real_t> split_floats(const String &p_splitter,bool p_allow_empty=true) const;
+	Vector<real_t> split_floats_mk(const Vector<String> &p_splitters,bool p_allow_empty=true) const;
 	Vector<int> split_ints(const String &p_splitter,bool p_allow_empty=true) const;
 	Vector<int> split_ints_mk(const Vector<String> &p_splitters,bool p_allow_empty=true) const;
 

--- a/drivers/convex_decomp/b2Polygon.cpp
+++ b/drivers/convex_decomp/b2Polygon.cpp
@@ -206,8 +206,8 @@ b2Vec2* b2Polygon::GetVertexVecs() {
 	
 b2Polygon::b2Polygon(b2Triangle& t) {
 	nVertices = 3;
-	x = new float[nVertices];
-	y = new float[nVertices];
+	x = new real_t[nVertices];
+	y = new real_t[nVertices];
 	for (int32 i = 0; i < nVertices; ++i) {
 		x[i] = t.x[i];
 		y[i] = t.y[i];
@@ -494,8 +494,8 @@ b2Polygon* b2Polygon::Add(b2Triangle& t) {
         if (tipT == firstT || tipT == secondT)
             tipT = 2;
 		
-        float32* newx = new float[nVertices + 1];
-        float32* newy = new float[nVertices + 1];
+        float32* newx = new real_t[nVertices + 1];
+        float32* newy = new real_t[nVertices + 1];
         int32 currOut = 0;
         for (int32 i = 0; i < nVertices; i++) {
             newx[currOut] = x[i];
@@ -923,7 +923,7 @@ void ReversePolygon(b2Polygon& p){
 	ReversePolygon(p.x,p.y,p.nVertices);
 }
 	
-void ReversePolygon(float* x, float* y, int n) {
+void ReversePolygon(real_t* x, real_t* y, int n) {
         if (n == 1)
             return;
         int32 low = 0;

--- a/drivers/convex_decomp/b2Triangle.h
+++ b/drivers/convex_decomp/b2Triangle.h
@@ -27,8 +27,8 @@ namespace b2ConvexDecomp {
 
 class b2Triangle{
 public:
-	float* x;
-    float* y;
+	real_t* x;
+    real_t* y;
 	b2Triangle();
 	b2Triangle(float32 x1, float32 y1, float32 x2, float32 y2, float32 x3, float32 y3);
 	~b2Triangle();

--- a/drivers/gles1/rasterizer_gles1.cpp
+++ b/drivers/gles1/rasterizer_gles1.cpp
@@ -3546,7 +3546,7 @@ static const int gl_texcoord_index[VS::ARRAY_MAX-1] = {
 };
 
 
-Error RasterizerGLES1::_setup_geometry(const Geometry *p_geometry, const Material* p_material, const Skeleton *p_skeleton,const float *p_morphs) {
+Error RasterizerGLES1::_setup_geometry(const Geometry *p_geometry, const Material* p_material, const Skeleton *p_skeleton,const real_t *p_morphs) {
 
 
 	switch(p_geometry->type) {

--- a/drivers/gles1/rasterizer_gles1.h
+++ b/drivers/gles1/rasterizer_gles1.h
@@ -735,7 +735,7 @@ class RasterizerGLES1 : public Rasterizer {
 	void _setup_fixed_material(const Geometry *p_geometry,const Material *p_material);
 	void _setup_material(const Geometry *p_geometry,const Material *p_material);
 
-	Error _setup_geometry(const Geometry *p_geometry, const Material* p_material,const Skeleton *p_skeleton, const float *p_morphs);
+	Error _setup_geometry(const Geometry *p_geometry, const Material* p_material,const Skeleton *p_skeleton, const real_t *p_morphs);
 	void _render(const Geometry *p_geometry,const Material *p_material, const Skeleton* p_skeleton, const GeometryOwner *p_owner);
 
 

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -4496,7 +4496,7 @@ void RasterizerGLES2::_skeleton_xform(const uint8_t * p_src_array, int p_src_str
 }
 
 
-Error RasterizerGLES2::_setup_geometry(const Geometry *p_geometry, const Material* p_material, const Skeleton *p_skeleton,const float *p_morphs) {
+Error RasterizerGLES2::_setup_geometry(const Geometry *p_geometry, const Material* p_material, const Skeleton *p_skeleton,const real_t *p_morphs) {
 
 
 	switch(p_geometry->type) {
@@ -7999,7 +7999,7 @@ RasterizerGLES2::RasterizerGLES2(bool p_compress_arrays,bool p_keep_ram_copy,boo
 	skel_default.resize(1024*4);
 	for(int i=0;i<1024/3;i++) {
 
-		float * ptr = skel_default.ptr();
+		real_t * ptr = skel_default.ptr();
 		ptr+=i*4*4;
 		ptr[0]=1.0;
 		ptr[1]=0.0;

--- a/drivers/gles2/rasterizer_gles2.h
+++ b/drivers/gles2/rasterizer_gles2.h
@@ -90,7 +90,7 @@ class RasterizerGLES2 : public Rasterizer {
 	bool use_half_float;
 
 
-	Vector<float> skel_default;
+	Vector<real_t> skel_default;
 
 	Image _get_gl_image_and_format(const Image& p_image, Image::Format p_format, uint32_t p_flags,GLenum& r_gl_format,int &r_gl_components,bool &r_has_alpha_cache,bool &r_compressed);
 
@@ -938,7 +938,7 @@ class RasterizerGLES2 : public Rasterizer {
 	void _setup_skeleton(const Skeleton *p_skeleton);
 
 
-	Error _setup_geometry(const Geometry *p_geometry, const Material* p_material,const Skeleton *p_skeleton, const float *p_morphs);
+	Error _setup_geometry(const Geometry *p_geometry, const Material* p_material,const Skeleton *p_skeleton, const real_t *p_morphs);
 	void _render(const Geometry *p_geometry,const Material *p_material, const Skeleton* p_skeleton, const GeometryOwner *p_owner,const Transform& p_xform);
 
 

--- a/modules/gdscript/gd_tokenizer.cpp
+++ b/modules/gdscript/gd_tokenizer.cpp
@@ -689,9 +689,13 @@ void GDTokenizerText::_advance() {
 						//print_line("*%*%*%*% to convert: "+str+" result: "+rtos(val));
 						_make_constant(val);
                     } else {
-						int val = str.to_int();
-						_make_constant(val);
-
+						// Use real_t if real(value) ~= int(value)
+						real_t val = str.to_double();
+						int int_val = str.to_int();
+						if(int_val != val)
+							_make_constant(int_val);
+						else
+							_make_constant(val);
 					}
 
 					return;

--- a/platform/android/godot_android.cpp
+++ b/platform/android/godot_android.cpp
@@ -174,10 +174,18 @@ public:
 				} break;
 				case Variant::REAL_ARRAY: {
 
-					DVector<float> array = *p_args[i];
+					DVector<real_t> array = *p_args[i];
+#ifdef REAL_T_IS_DOUBLE
+					jdoubleArray arr = env->NewDoubleArray(array.size());
+#else
 					jfloatArray arr = env->NewFloatArray(array.size());
-					DVector<float>::Read r = array.read();
+#endif
+					DVector<real_t>::Read r = array.read();
+#ifdef REAL_T_IS_DOUBLE
+					env->SetDoubleArrayRegion(arr,0,array.size(),r.ptr());
+#else
 					env->SetFloatArrayRegion(arr,0,array.size(),r.ptr());
+#endif
 					v[i].l=arr;
 
 				} break;
@@ -250,16 +258,23 @@ public:
 				ret=sarr;
 			} break;
 			case Variant::REAL_ARRAY: {
-
+#ifdef REAL_T_IS_DOUBLE
+				jdoubleArray arr = (jdoubleArray)env->CallObjectMethodA(instance,E->get().method,v);
+#else
 				jfloatArray arr = (jfloatArray)env->CallObjectMethodA(instance,E->get().method,v);
+#endif
 
 				int fCount = env->GetArrayLength(arr);
-				DVector<float> sarr;
+				DVector<real_t> sarr;
 				sarr.resize(fCount);
 
-				DVector<float>::Write w = sarr.write();
+				DVector<real_t>::Write w = sarr.write();
+#ifdef REAL_T_IS_DOUBLE
+				env->GetDoubleArrayRegion(arr,0,fCount,w.ptr());
+#else
 				env->GetFloatArrayRegion(arr,0,fCount,w.ptr());
-				w = DVector<float>::Write();
+#endif
+				w = DVector<real_t>::Write();
 				ret=sarr;
 			} break;
 			default: {
@@ -885,10 +900,18 @@ static Variant::Type get_jni_type(const String& p_type) {
 		{"void",Variant::NIL},
 		{"boolean",Variant::BOOL},
 		{"int",Variant::INT},
+#ifdef REAL_T_IS_DOUBLE
+		{"double",Variant::REAL},
+#else
 		{"float",Variant::REAL},
+#endif
 		{"java.lang.String",Variant::STRING},
 		{"[I",Variant::INT_ARRAY},
+#ifdef REAL_T_IS_DOUBLE
+		{"[D",Variant::REAL_ARRAY},
+#else
 		{"[F",Variant::REAL_ARRAY},
+#endif
 		{"[java.lang.String",Variant::STRING_ARRAY},
 		{NULL,Variant::NIL}
 	};

--- a/platform/android/java_glue.cpp
+++ b/platform/android/java_glue.cpp
@@ -155,10 +155,18 @@ jvalue _variant_to_jvalue(JNIEnv *env, Variant::Type p_type, const Variant* p_ar
 		} break;
 		case Variant::REAL_ARRAY: {
 
-			DVector<float> array = *p_arg;
+			DVector<real_t> array = *p_arg;
+#ifdef REAL_T_IS_DOUBLE
+			jdoubleArray arr = env->NewDoubleArray(array.size());
+#else
 			jfloatArray arr = env->NewFloatArray(array.size());
-			DVector<float>::Read r = array.read();
+#endif
+			DVector<real_t>::Read r = array.read();
+#ifdef REAL_T_IS_DOUBLE
+			env->SetDoubleArrayRegion(arr,0,array.size(),r.ptr());
+#else
 			env->SetFloatArrayRegion(arr,0,array.size(),r.ptr());
+#endif
 			v.l=arr;
 
 		} break;
@@ -464,16 +472,22 @@ public:
 				ret=sarr;
 			} break;
 			case Variant::REAL_ARRAY: {
-
+#ifdef REAL_T_IS_DOUBLE
+				jdoubleArray arr = (jdoubleArray)env->CallObjectMethodA(instance,E->get().method,v);
+#else
 				jfloatArray arr = (jfloatArray)env->CallObjectMethodA(instance,E->get().method,v);
-
+#endif
 				int fCount = env->GetArrayLength(arr);
-				DVector<float> sarr;
+				DVector<real_t> sarr;
 				sarr.resize(fCount);
 
-				DVector<float>::Write w = sarr.write();
+				DVector<real_t>::Write w = sarr.write();
+#ifdef REAL_T_IS_DOUBLE
+				env->GetDoubleArrayRegion(arr,0,fCount,w.ptr());
+#else
 				env->GetFloatArrayRegion(arr,0,fCount,w.ptr());
-				w = DVector<float>::Write();
+#endif
+				w = DVector<real_t>::Write();
 				ret=sarr;
 			} break;
 
@@ -1333,6 +1347,7 @@ static Variant::Type get_jni_type(const String& p_type) {
 		{"java.lang.String",Variant::STRING},
 		{"[I",Variant::INT_ARRAY},
 		{"[F",Variant::REAL_ARRAY},
+		{"[D",Variant::REAL_ARRAY},
 		{"[java.lang.String",Variant::STRING_ARRAY},
 		{"com.android.godot.Dictionary", Variant::DICTIONARY},
 		{NULL,Variant::NIL}

--- a/scene/3d/portal.cpp
+++ b/scene/3d/portal.cpp
@@ -34,7 +34,7 @@
 bool Portal::_set(const StringName& p_name, const Variant& p_value) {
 
 	if (p_name=="shape") {
-		DVector<float> src_coords=p_value;
+		DVector<real_t> src_coords=p_value;
 		Vector<Point2> points;
 		int src_coords_size = src_coords.size();
 		ERR_FAIL_COND_V(src_coords_size%2,false);
@@ -63,7 +63,7 @@ bool Portal::_get(const StringName& p_name,Variant &r_ret) const {
 
 	if (p_name=="shape") {
 		Vector<Point2> points=get_shape();
-		DVector<float> dst_coords;
+		DVector<real_t> dst_coords;
 		dst_coords.resize(points.size()*2);
 		
 		for (int i=0;i<points.size();i++) {

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -77,14 +77,14 @@ bool Animation::_set(const StringName& p_name, const Variant& p_value) {
 			if (track_get_type(track)==TYPE_TRANSFORM) {
 
 				TransformTrack *tt = static_cast<TransformTrack*>(tracks[track]);
-				DVector<float> values=p_value;
+				DVector<real_t> values=p_value;
 				int vcount=values.size();
 
 #if 0 // old compatibility hack
 				if ((vcount%11) == 0) {
 
 
-					DVector<float>::Read r = values.read();
+					DVector<real_t>::Read r = values.read();
 
 					tt->transforms.resize(vcount/11);
 
@@ -119,7 +119,7 @@ bool Animation::_set(const StringName& p_name, const Variant& p_value) {
 #endif
 				ERR_FAIL_COND_V(vcount%12,false); // shuld be multiple of 11
 
-				DVector<float>::Read r = values.read();
+				DVector<real_t>::Read r = values.read();
 
 				tt->transforms.resize(vcount/12);
 
@@ -128,7 +128,7 @@ bool Animation::_set(const StringName& p_name, const Variant& p_value) {
 
 
 					TKey<TransformKey> &tk=tt->transforms[i];
-					const float *ofs=&r[i*12];
+					const real_t *ofs=&r[i*12];
 					tk.time=ofs[0];
 					tk.transition=ofs[1];
 
@@ -157,7 +157,7 @@ bool Animation::_set(const StringName& p_name, const Variant& p_value) {
 				if (d.has("cont"))
 					vt->continuous=d["cont"];
 
-				DVector<float> times=d["times"];
+				DVector<real_t> times=d["times"];
 				Array values=d["values"];
 
 				ERR_FAIL_COND_V(times.size()!=values.size(),false);
@@ -166,7 +166,7 @@ bool Animation::_set(const StringName& p_name, const Variant& p_value) {
 
 					int valcount=times.size();
 
-					DVector<float>::Read rt = times.read();
+					DVector<real_t>::Read rt = times.read();
 
 					vt->values.resize(valcount);
 
@@ -178,10 +178,10 @@ bool Animation::_set(const StringName& p_name, const Variant& p_value) {
 
 					if (d.has("transitions")) {
 
-						DVector<float> transitions = d["transitions"];
+						DVector<real_t> transitions = d["transitions"];
 						ERR_FAIL_COND_V(transitions.size()!=valcount,false);
 
-						DVector<float>::Read rtr = transitions.read();
+						DVector<real_t>::Read rtr = transitions.read();
 
 
 						for(int i=0;i<valcount;i++) {
@@ -203,7 +203,7 @@ bool Animation::_set(const StringName& p_name, const Variant& p_value) {
 				ERR_FAIL_COND_V(!d.has("times"),false);
 				ERR_FAIL_COND_V(!d.has("values"),false);
 
-				DVector<float> times=d["times"];
+				DVector<real_t> times=d["times"];
 				Array values=d["values"];
 
 				ERR_FAIL_COND_V(times.size()!=values.size(),false);
@@ -212,7 +212,7 @@ bool Animation::_set(const StringName& p_name, const Variant& p_value) {
 
 					int valcount=times.size();
 
-					DVector<float>::Read rt = times.read();
+					DVector<real_t>::Read rt = times.read();
 
 					for(int i=0;i<valcount;i++) {
 
@@ -221,10 +221,10 @@ bool Animation::_set(const StringName& p_name, const Variant& p_value) {
 
 					if (d.has("transitions")) {
 
-						DVector<float> transitions = d["transitions"];
+						DVector<real_t> transitions = d["transitions"];
 						ERR_FAIL_COND_V(transitions.size()!=valcount,false);
 
-						DVector<float>::Read rtr = transitions.read();
+						DVector<real_t>::Read rtr = transitions.read();
 
 						for(int i=0;i<valcount;i++) {
 
@@ -321,8 +321,8 @@ bool Animation::_get(const StringName& p_name,Variant &r_ret) const {
 
 				Dictionary d;
 
-				DVector<float> key_times;
-				DVector<float> key_transitions;
+				DVector<real_t> key_times;
+				DVector<real_t> key_transitions;
 				Array key_values;
 
 				int kk=vt->values.size();
@@ -331,8 +331,8 @@ bool Animation::_get(const StringName& p_name,Variant &r_ret) const {
 				key_transitions.resize(kk);
 				key_values.resize(kk);
 
-				DVector<float>::Write wti=key_times.write();
-				DVector<float>::Write wtr=key_transitions.write();
+				DVector<real_t>::Write wti=key_times.write();
+				DVector<real_t>::Write wtr=key_transitions.write();
 
 				int idx=0;
 
@@ -346,8 +346,8 @@ bool Animation::_get(const StringName& p_name,Variant &r_ret) const {
 					idx++;
 				}
 
-				wti=DVector<float>::Write();
-				wtr=DVector<float>::Write();
+				wti=DVector<real_t>::Write();
+				wtr=DVector<real_t>::Write();
 
 				d["times"]=key_times;
 				d["transitions"]=key_transitions;
@@ -365,8 +365,8 @@ bool Animation::_get(const StringName& p_name,Variant &r_ret) const {
 
 				Dictionary d;
 
-				DVector<float> key_times;
-				DVector<float> key_transitions;
+				DVector<real_t> key_times;
+				DVector<real_t> key_transitions;
 				Array key_values;
 
 				int kk=track_get_key_count(track);
@@ -375,8 +375,8 @@ bool Animation::_get(const StringName& p_name,Variant &r_ret) const {
 				key_transitions.resize(kk);
 				key_values.resize(kk);
 
-				DVector<float>::Write wti=key_times.write();
-				DVector<float>::Write wtr=key_transitions.write();
+				DVector<real_t>::Write wti=key_times.write();
+				DVector<real_t>::Write wtr=key_transitions.write();
 
 				int idx=0;
 				for(int i=0;i<track_get_key_count(track);i++) {
@@ -387,8 +387,8 @@ bool Animation::_get(const StringName& p_name,Variant &r_ret) const {
 					idx++;
 				}
 
-				wti=DVector<float>::Write();
-				wtr=DVector<float>::Write();
+				wti=DVector<real_t>::Write();
+				wtr=DVector<real_t>::Write();
 
 				d["times"]=key_times;
 				d["transitions"]=key_transitions;

--- a/scene/resources/mesh_data_tool.cpp
+++ b/scene/resources/mesh_data_tool.cpp
@@ -449,13 +449,13 @@ void MeshDataTool::set_vertex_bones(int p_idx,const Vector<int>& p_bones){
 
 }
 
-Vector<float> MeshDataTool::get_vertex_weights(int p_idx) const{
+Vector<real_t> MeshDataTool::get_vertex_weights(int p_idx) const{
 
-	ERR_FAIL_INDEX_V(p_idx,vertices.size(),Vector<float>());
+	ERR_FAIL_INDEX_V(p_idx,vertices.size(),Vector<real_t>());
 	return vertices[p_idx].weights;
 
 }
-void MeshDataTool::set_vertex_weights(int p_idx,const Vector<float>& p_weights){
+void MeshDataTool::set_vertex_weights(int p_idx,const Vector<real_t>& p_weights){
 	ERR_FAIL_INDEX(p_idx,vertices.size());
 	vertices[p_idx].weights=p_weights;
 	format|=Mesh::ARRAY_FORMAT_WEIGHTS;

--- a/scene/resources/mesh_data_tool.h
+++ b/scene/resources/mesh_data_tool.h
@@ -45,7 +45,7 @@ class MeshDataTool : public Reference  {
 		Vector2 uv;
 		Vector2 uv2;
 		Vector<int> bones;
-		Vector<float> weights;
+		Vector<real_t> weights;
 		Vector<int> edges;
 		Vector<int> faces;
 		Variant meta;
@@ -109,8 +109,8 @@ public:
 	Vector<int> get_vertex_bones(int p_idx) const;
 	void set_vertex_bones(int p_idx,const Vector<int>& p_bones);
 
-	Vector<float> get_vertex_weights(int p_idx) const;
-	void set_vertex_weights(int p_idx,const Vector<float>& p_weights);
+	Vector<real_t> get_vertex_weights(int p_idx) const;
+	void set_vertex_weights(int p_idx,const Vector<real_t>& p_weights);
 
 	Variant get_vertex_meta(int p_idx) const;
 	void set_vertex_meta(int p_idx,const Variant& p_meta);

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -174,7 +174,7 @@ void SurfaceTool::add_bones( const Vector<int>& p_bones) {
 	last_bones=p_bones;
 }
 
-void SurfaceTool::add_weights( const Vector<float>& p_weights) {
+void SurfaceTool::add_weights( const Vector<real_t>& p_weights) {
 
 	ERR_FAIL_COND(!begun);
 
@@ -277,9 +277,9 @@ Ref<Mesh> SurfaceTool::commit(const Ref<Mesh>& p_existing) {
 			case Mesh::ARRAY_FORMAT_TANGENT: {
 
 
-				DVector<float> array;
+				DVector<real_t> array;
 				array.resize(varr_len*4);
-				DVector<float>::Write w = array.write();
+				DVector<real_t>::Write w = array.write();
 
 				int idx=0;
 				for(List< Vertex >::Element *E=vertex_array.front();E;E=E->next(),idx+=4) {
@@ -289,11 +289,11 @@ Ref<Mesh> SurfaceTool::commit(const Ref<Mesh>& p_existing) {
 					w[idx+0]=v.tangent.x;
 					w[idx+1]=v.tangent.y;
 					w[idx+2]=v.tangent.z;
-					float d = v.binormal.dot(v.normal.cross(v.tangent));
+					real_t d = v.binormal.dot(v.normal.cross(v.tangent));
 					w[idx+3]=d<0 ? -1 : 1;
 				}
 
-				w=DVector<float>::Write();
+				w=DVector<real_t>::Write();
 				a[i]=array;
 
 			} break;
@@ -317,9 +317,9 @@ Ref<Mesh> SurfaceTool::commit(const Ref<Mesh>& p_existing) {
 			case Mesh::ARRAY_FORMAT_WEIGHTS: {
 
 
-				DVector<float> array;
+				DVector<real_t> array;
 				array.resize(varr_len*4);
-				DVector<float>::Write w = array.write();
+				DVector<real_t>::Write w = array.write();
 
 				int idx=0;
 				for(List< Vertex >::Element *E=vertex_array.front();E;E=E->next(),idx+=4) {
@@ -341,7 +341,7 @@ Ref<Mesh> SurfaceTool::commit(const Ref<Mesh>& p_existing) {
 
 				}
 
-				w=DVector<float>::Write();
+				w=DVector<real_t>::Write();
 				a[i]=array;
 
 			} break;
@@ -460,12 +460,12 @@ void SurfaceTool::_create_list(const Ref<Mesh>& p_existing, int p_surface, List<
 
 	DVector<Vector3> varr = arr[VS::ARRAY_VERTEX];
 	DVector<Vector3> narr = arr[VS::ARRAY_NORMAL];
-	DVector<float> tarr = arr[VS::ARRAY_TANGENT];
+	DVector<real_t> tarr = arr[VS::ARRAY_TANGENT];
 	DVector<Color> carr = arr[VS::ARRAY_COLOR];
 	DVector<Vector2> uvarr = arr[VS::ARRAY_TEX_UV];
 	DVector<Vector2> uv2arr = arr[VS::ARRAY_TEX_UV2];
 	DVector<int> barr = arr[VS::ARRAY_BONES];
-	DVector<float> warr = arr[VS::ARRAY_WEIGHTS];
+	DVector<real_t> warr = arr[VS::ARRAY_WEIGHTS];
 
 	int vc = varr.size();
 
@@ -483,7 +483,7 @@ void SurfaceTool::_create_list(const Ref<Mesh>& p_existing, int p_surface, List<
 		lformat|=VS::ARRAY_FORMAT_NORMAL;
 		rn=narr.read();
 	}
-	DVector<float>::Read rt;
+	DVector<real_t>::Read rt;
 	if (tarr.size()) {
 		lformat|=VS::ARRAY_FORMAT_TANGENT;
 		rt=tarr.read();
@@ -512,7 +512,7 @@ void SurfaceTool::_create_list(const Ref<Mesh>& p_existing, int p_surface, List<
 		rb=barr.read();
 	}
 
-	DVector<float>::Read rw;
+	DVector<real_t>::Read rw;
 	if (warr.size()) {
 		lformat|=VS::ARRAY_FORMAT_WEIGHTS;
 		rw=warr.read();
@@ -546,7 +546,7 @@ void SurfaceTool::_create_list(const Ref<Mesh>& p_existing, int p_surface, List<
 			v.bones=b;
 		}
 		if (lformat&VS::ARRAY_FORMAT_WEIGHTS) {
-			Vector<float> w;
+			Vector<real_t> w;
 			w.resize(4);
 			w[0]=warr[i*4+0];
 			w[1]=warr[i*4+1];

--- a/scene/resources/surface_tool.h
+++ b/scene/resources/surface_tool.h
@@ -47,7 +47,7 @@ public:
 			Vector2 uv;
 			Vector2 uv2;
 			Vector<int> bones;
-			Vector<float> weights;
+			Vector<real_t> weights;
 
 			Vertex() {  }
 	};
@@ -71,7 +71,7 @@ private:
 	Vector2 last_uv;
 	Vector2 last_uv2;
 	Vector<int> last_bones;
-	Vector<float> last_weights;
+	Vector<real_t> last_weights;
 	Plane last_tangent;
 
 	void _create_list(const Ref<Mesh>& p_existing, int p_surface, List<Vertex> *r_vertex, List<int> *r_index,int &lformat);
@@ -91,7 +91,7 @@ public:
 	void add_uv( const Vector2& p_uv);
 	void add_uv2( const Vector2& p_uv);
 	void add_bones( const Vector<int>& p_indices);
-	void add_weights( const Vector<float>& p_weights);
+	void add_weights( const Vector<real_t>& p_weights);
 
 	void add_index( int p_index);
 

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -46,7 +46,7 @@ AudioServer *AudioServer::get_singleton() {
 	return singleton;
 }
 
-void AudioServer::sample_set_signed_data(RID p_sample, const DVector<float>& p_buffer) {
+void AudioServer::sample_set_signed_data(RID p_sample, const DVector<real_t>& p_buffer) {
 
 	int len = p_buffer.size();
 	ERR_FAIL_COND( len == 0 );
@@ -57,7 +57,7 @@ void AudioServer::sample_set_signed_data(RID p_sample, const DVector<float>& p_b
 
 	int16_t *samples = (int16_t*)w.ptr();
 
-	DVector<float>::Read r = p_buffer.read();
+	DVector<real_t>::Read r = p_buffer.read();
 
 	for(int i=0;i<len;i++) {
 

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -167,7 +167,7 @@ public:
 	virtual int sample_get_length(RID p_sample) const=0;
 	virtual const void* sample_get_data_ptr(RID p_sample) const=0;
 
-	virtual void sample_set_signed_data(RID p_sample, const DVector<float>& p_buffer);
+	virtual void sample_set_signed_data(RID p_sample, const DVector<real_t>& p_buffer);
 	virtual void sample_set_data(RID p_sample, const DVector<uint8_t>& p_buffer)=0;
 	virtual const DVector<uint8_t> sample_get_data(RID p_sample) const=0;
 

--- a/servers/physics/body_sw.cpp
+++ b/servers/physics/body_sw.cpp
@@ -475,7 +475,7 @@ void BodySW::simulate_motion(const Transform& p_xform,real_t p_step) {
 	//compute a FAKE angular velocity, not so easy
 	Matrix3 rot=get_transform().basis.orthonormalized().transposed() * p_xform.basis.orthonormalized();
 	Vector3 axis;
-	float angle;
+	real_t angle;
 
 	rot.get_axis_and_angle(axis,angle);
 	axis.normalize();

--- a/servers/physics/collision_solver_sat.cpp
+++ b/servers/physics/collision_solver_sat.cpp
@@ -118,9 +118,9 @@ static void _generate_contacts_edge_edge(const Vector3 * p_points_A,int p_point_
 		Vector3 base_B = p_points_B[0] - axis * axis.dot(p_points_B[0]);
 
 		//sort all 4 points in axis
-		float dvec[4]={ axis.dot(p_points_A[0]), axis.dot(p_points_A[1]), axis.dot(p_points_B[0]), axis.dot(p_points_B[1]) };
+		real_t dvec[4]={ axis.dot(p_points_A[0]), axis.dot(p_points_A[1]), axis.dot(p_points_B[0]), axis.dot(p_points_B[1]) };
 
-		SortArray<float> sa;
+		SortArray<real_t> sa;
 		sa.sort(dvec,4);
 
 		//use the middle ones as contacts

--- a/servers/physics/collision_solver_sw.cpp
+++ b/servers/physics/collision_solver_sw.cpp
@@ -158,10 +158,10 @@ bool CollisionSolverSW::solve_concave(const ShapeSW *p_shape_A,const Transform& 
 	for(int i=0;i<3;i++) {
 
 	     Vector3 axis( p_transform_B.basis.get_axis(i) );
-	     float axis_scale = 1.0/axis.length();
+	     real_t axis_scale = 1.0/axis.length();
 	     axis*=axis_scale;
 
-	     float smin,smax;
+	     real_t smin,smax;
 	     p_shape_A->project_range(axis,rel_transform,smin,smax);
 	     smin*=axis_scale;
 	     smax*=axis_scale;

--- a/servers/physics/shape_sw.cpp
+++ b/servers/physics/shape_sw.cpp
@@ -1534,7 +1534,7 @@ ConcavePolygonShapeSW::ConcavePolygonShapeSW() {
 
 /* HEIGHT MAP SHAPE */
 
-DVector<float> HeightMapShapeSW::get_heights() const {
+DVector<real_t> HeightMapShapeSW::get_heights() const {
 
 	return heights;
 }
@@ -1610,7 +1610,7 @@ void HeightMapShapeSW::_setup(DVector<real_t> p_heights,int p_width,int p_depth,
 
 		for(int j=0;j<width;j++) {
 
-			float h = r[i*width+j];
+			real_t h = r[i*width+j];
 
 			Vector3 pos( j*cell_size, h, i*cell_size );
 			if (i==0 || j==0)
@@ -1636,8 +1636,8 @@ void HeightMapShapeSW::set_data(const Variant& p_data) {
 
 	int width=d["width"];
 	int depth=d["depth"];
-	float cell_size=d["cell_size"];
-	DVector<float> heights=d["heights"];
+	real_t cell_size=d["cell_size"];
+	DVector<real_t> heights=d["heights"];
 
 	ERR_FAIL_COND( width<= 0);
 	ERR_FAIL_COND( depth<= 0);

--- a/servers/physics/shape_sw.h
+++ b/servers/physics/shape_sw.h
@@ -354,12 +354,12 @@ struct HeightMapShapeSW : public ConcaveShapeSW {
 	DVector<real_t> heights;
 	int width;
 	int depth;
-	float cell_size;
+	real_t cell_size;
 
 //	void _cull_segment(int p_idx,_SegmentCullParams *p_params) const;
 //	void _cull(int p_idx,_CullParams *p_params) const;
 
-	void _setup(DVector<float> p_heights,int p_width,int p_depth,float p_cell_size);
+	void _setup(DVector<real_t> p_heights,int p_width,int p_depth,real_t p_cell_size);
 public:
 
 	DVector<real_t> get_heights() const;

--- a/servers/physics_2d/collision_solver_2d_sat.cpp
+++ b/servers/physics_2d/collision_solver_2d_sat.cpp
@@ -249,7 +249,7 @@ _FORCE_INLINE_ static void _generate_contacts_edge_edge(const Vector2 * p_points
 	float dvec[4]={ axis.dot(p_points_A[0]), axis.dot(p_points_A[1]), axis.dot(p_points_B[0]), axis.dot(p_points_B[1]) };
 
 	//todo , find max/min and then use 2 central points
-	SortArray<float> sa;
+	SortArray<real_t> sa;
 	sa.sort(dvec,4);
 
 	//use the middle ones as contacts

--- a/servers/physics_2d/collision_solver_2d_sw.cpp
+++ b/servers/physics_2d/collision_solver_2d_sw.cpp
@@ -211,10 +211,10 @@ bool CollisionSolver2DSW::solve_concave(const Shape2DSW *p_shape_A,const Matrix3
 	for(int i=0;i<2;i++) {
 
 	     Vector2 axis( p_transform_B.elements[i] );
-	     float axis_scale = 1.0/axis.length();
+	     real_t axis_scale = 1.0/axis.length();
 	     axis*=axis_scale;
 
-	     float smin,smax;
+	     real_t smin,smax;
 	     p_shape_A->project_rangev(axis,rel_transform,smin,smax);
 	     smin*=axis_scale;
 	     smax*=axis_scale;

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -464,7 +464,7 @@ public:
 		RID skeleton;
 		RID material_override;
 		Vector<RID> light_instances;
-		Vector<float> morph_values;
+		Vector<real_t> morph_values;
 		bool mirror :8;
 		bool depth_scale :8;
 		bool billboard :8;

--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -1137,7 +1137,7 @@ ShaderLanguage::Node* ShaderLanguage::validate_function_call(Parser&parser, Oper
 		if (p_func->op==OP_CONSTRUCT && all_const) {
 
 			bool all_const=false;
-			Vector<float> cdata;
+			Vector<real_t> cdata;
 			for(int i=0;i<argcount;i++) {
 
 				Variant v = static_cast<ConstantNode*>(p_func->arguments[i+1])->value;

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -3473,7 +3473,7 @@ void VisualServerRaster::_instance_draw(Instance *p_instance) {
 	switch(p_instance->base_type) {
 	
 		case INSTANCE_MESH: {
-			const float *morphs = NULL;
+			const real_t *morphs = NULL;
 			if (!p_instance->data.morph_values.empty()) {
 				morphs=&p_instance->data.morph_values[0];
 			}
@@ -3762,7 +3762,7 @@ void VisualServerRaster::_light_instance_update_pssm_shadow(Instance *p_light,Sc
 		// a pre pass will need to be needed to determine the actual z-near to be used
 		for(int j=0;j<caster_cull_count;j++) {
 		
-			float min,max;
+			real_t min,max;
 			Instance *ins=instance_shadow_cull_result[j];
 			if (!ins->visible || !ins->cast_shadows)
 				continue;
@@ -4968,7 +4968,7 @@ void VisualServerRaster::_render_camera(Viewport *p_viewport,Camera *p_camera, S
 
 			if (keep) {
 				// update cull range
-				float min,max;
+				real_t min,max;
 				ins->transformed_aabb.project_range_in_plane(cull_range.nearp,min,max);
 
 				if (min<cull_range.min)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -133,7 +133,7 @@ RID VisualServer::_make_test_cube() {
 
 	DVector<Vector3> vertices;
 	DVector<Vector3> normals;
-	DVector<float> tangents;	
+	DVector<real_t> tangents;	
 	DVector<Vector3> uvs;
 							
 	int vtx_idx=0;
@@ -630,7 +630,7 @@ void VisualServer::_bind_methods() {
 
 }
 
-void VisualServer::_canvas_item_add_style_box(RID p_item, const Rect2& p_rect, RID p_texture,const Vector<float>& p_margins, const Color& p_modulate) {
+void VisualServer::_canvas_item_add_style_box(RID p_item, const Rect2& p_rect, RID p_texture,const Vector<real_t>& p_margins, const Color& p_modulate) {
 
 	ERR_FAIL_COND(p_margins.size()!=4);
 	canvas_item_add_style_box(p_item, p_rect, p_texture,Vector2(p_margins[0],p_margins[1]),Vector2(p_margins[2],p_margins[3]),true,p_modulate);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -52,7 +52,7 @@ class VisualServer : public Object {
 	void _camera_set_orthogonal(RID p_camera,float p_size,float p_z_near,float p_z_far);
 	void _viewport_set_rect(RID p_viewport,const Rect2& p_rect);
 	Rect2 _viewport_get_rect(RID p_viewport) const;
-	void _canvas_item_add_style_box(RID p_item, const Rect2& p_rect, RID p_texture,const Vector<float>& p_margins, const Color& p_modulate=Color(1,1,1));
+	void _canvas_item_add_style_box(RID p_item, const Rect2& p_rect, RID p_texture,const Vector<real_t>& p_margins, const Color& p_modulate=Color(1,1,1));
 protected:	
 	RID _make_test_cube();
 	RID test_texture;

--- a/tools/collada/collada.cpp
+++ b/tools/collada/collada.cpp
@@ -109,7 +109,7 @@ Transform Collada::fix_transform(const Transform& p_transform) {
 }
 
 
-static Transform _read_transform_from_array(const Vector<float>& array, int ofs=0) {
+static Transform _read_transform_from_array(const Vector<real_t>& array, int ofs=0) {
 
 	Transform tr;
 	// i wonder why collada matrices are transposed, given that's opposed to opengl..
@@ -197,9 +197,9 @@ Transform Collada::Node::get_global_transform() const {
 
 }
 
-Vector<float> Collada::AnimationTrack::get_value_at_time(float p_time) {
+Vector<real_t> Collada::AnimationTrack::get_value_at_time(float p_time) {
 
-	ERR_FAIL_COND_V(keys.size()==0,Vector<float>());
+	ERR_FAIL_COND_V(keys.size()==0,Vector<real_t>());
 	int i=0;
 
 	for(i=0;i<keys.size();i++) {
@@ -228,7 +228,7 @@ Vector<float> Collada::AnimationTrack::get_value_at_time(float p_time) {
 
 				Transform interp = c<0.001 ? src : src.interpolate_with(dst,c);
 
-				Vector<float> ret;
+				Vector<real_t> ret;
 				ret.resize(16);
 				Transform tr;
 				// i wonder why collada matrices are transposed, given that's opposed to opengl..
@@ -252,7 +252,7 @@ Vector<float> Collada::AnimationTrack::get_value_at_time(float p_time) {
 				return ret;
 			} else {
 
-				Vector<float> dest;
+				Vector<real_t> dest;
 				dest.resize(keys[i].data.size());
 				for(int j=0;j<dest.size();j++) {
 
@@ -264,7 +264,7 @@ Vector<float> Collada::AnimationTrack::get_value_at_time(float p_time) {
 		} break;
 	}
 
-	ERR_FAIL_V(Vector<float>());
+	ERR_FAIL_V(Vector<real_t>());
 }
 
 
@@ -398,10 +398,10 @@ void Collada::_parse_material(XMLParser& parser) {
 }
 
 //! reads floats from inside of xml element until end of xml element
-Vector<float> Collada::_read_float_array(XMLParser& parser) {
+Vector<real_t> Collada::_read_float_array(XMLParser& parser) {
 
 	if (parser.is_empty())
-		return Vector<float>();
+		return Vector<real_t>();
 
 	Vector<String> splitters;
 	splitters.push_back(" ");
@@ -409,7 +409,7 @@ Vector<float> Collada::_read_float_array(XMLParser& parser) {
 	splitters.push_back("\r");
 	splitters.push_back("\t");
 
-	Vector<float> array;
+	Vector<real_t> array;
 	while(parser.read()==OK) {
 		// TODO: check for comments inside the element
 		// and ignore them.
@@ -458,7 +458,7 @@ Transform Collada::_read_transform(XMLParser& parser) {
 	if (parser.is_empty())
 		return Transform();
 
-	Vector<float> array;
+	Vector<real_t> array;
 	while(parser.read()==OK) {
 		// TODO: check for comments inside the element
 		// and ignore them.
@@ -497,7 +497,7 @@ Variant Collada::_parse_param(XMLParser& parser) {
 				}
 			} else if (parser.get_node_name() == "float2") {
 
-				Vector<float> v2 = _read_float_array(parser);
+				Vector<real_t> v2 = _read_float_array(parser);
 
 				if (v2.size()>=2) {
 
@@ -505,7 +505,7 @@ Variant Collada::_parse_param(XMLParser& parser) {
 				}
 			} else if (parser.get_node_name() == "float3") {
 
-				Vector<float> v3 = _read_float_array(parser);
+				Vector<real_t> v3 = _read_float_array(parser);
 
 				if (v3.size()>=3) {
 
@@ -513,7 +513,7 @@ Variant Collada::_parse_param(XMLParser& parser) {
 				}
 			} else if (parser.get_node_name() == "float4") {
 
-				Vector<float> v4 = _read_float_array(parser);
+				Vector<real_t> v4 = _read_float_array(parser);
 
 				if (v4.size()>=4) {
 
@@ -627,7 +627,7 @@ void Collada::_parse_effect_material(XMLParser& parser,Effect &effect,String &id
 
 									if (parser.get_node_name()=="color") {
 
-										Vector<float> colorarr = _read_float_array(parser);
+										Vector<real_t> colorarr = _read_float_array(parser);
 										COLLADA_PRINT("colorarr size: "+rtos(colorarr.size()));
 
 										if (colorarr.size()>=3) {
@@ -891,7 +891,7 @@ void Collada::_parse_light(XMLParser& parser) {
 			} else if (name=="color") {
 
 				parser.read();
-				Vector<float> colorarr = _read_float_array(parser);
+				Vector<real_t> colorarr = _read_float_array(parser);
 				COLLADA_PRINT("colorarr size: "+rtos(colorarr.size()));
 
 				if (colorarr.size()>=4) {
@@ -1154,7 +1154,7 @@ void Collada::_parse_mesh_geometry(XMLParser& parser,String p_id,String p_name) 
 
 						} else if (parser.get_node_name()=="p") { //indices
 
-							Vector<float> values = _read_float_array(parser);
+							Vector<real_t> values = _read_float_array(parser);
 							if (polygons) {
 
 								prim.polygons.push_back(values.size()/prim.vertex_size);
@@ -1171,7 +1171,7 @@ void Collada::_parse_mesh_geometry(XMLParser& parser,String p_id,String p_name) 
 
 						} else if (parser.get_node_name()=="vcount") { // primitive
 
-							Vector<float> values = _read_float_array(parser);
+							Vector<real_t> values = _read_float_array(parser);
 							prim.polygons=values;
 							COLLADA_PRINT("read "+itos(values.size())+" polygon values");
 						}
@@ -1321,13 +1321,13 @@ void Collada::_parse_skin_controller(XMLParser& parser,String p_id) {
 
 						} else if (parser.get_node_name()=="v") { //indices
 
-							Vector<float> values = _read_float_array(parser);
+							Vector<real_t> values = _read_float_array(parser);
 							weights.indices=values;
 							COLLADA_PRINT("read "+itos(values.size())+" index values");
 
 						} else if (parser.get_node_name()=="vcount") { // weightsitive
 
-							Vector<float> values = _read_float_array(parser);
+							Vector<real_t> values = _read_float_array(parser);
 							weights.sets=values;
 							COLLADA_PRINT("read "+itos(values.size())+" polygon values");
 						}
@@ -1693,7 +1693,7 @@ Collada::Node* Collada::_parse_visual_scene_node(XMLParser& parser) {
 				}
 				xf.op=Node::XForm::OP_TRANSLATE;
 
-				Vector<float> xlt = _read_float_array(parser);
+				Vector<real_t> xlt = _read_float_array(parser);
 				xf.data=xlt;
 				xform_list.push_back(xf);
 
@@ -1704,7 +1704,7 @@ Collada::Node* Collada::_parse_visual_scene_node(XMLParser& parser) {
 				}
 				xf.op=Node::XForm::OP_ROTATE;
 
-				Vector<float> rot = _read_float_array(parser);
+				Vector<real_t> rot = _read_float_array(parser);
 				xf.data=rot;
 
 				xform_list.push_back(xf);
@@ -1717,7 +1717,7 @@ Collada::Node* Collada::_parse_visual_scene_node(XMLParser& parser) {
 
 				xf.op=Node::XForm::OP_SCALE;
 
-				Vector<float> scale = _read_float_array(parser);
+				Vector<real_t> scale = _read_float_array(parser);
 
 				xf.data=scale;
 
@@ -1730,7 +1730,7 @@ Collada::Node* Collada::_parse_visual_scene_node(XMLParser& parser) {
 				}
 				xf.op=Node::XForm::OP_MATRIX;
 
-				Vector<float> matrix = _read_float_array(parser);
+				Vector<real_t> matrix = _read_float_array(parser);
 
 				xf.data=matrix;
 				String mtx;
@@ -1746,7 +1746,7 @@ Collada::Node* Collada::_parse_visual_scene_node(XMLParser& parser) {
 				   }
 				   xf.op=Node::XForm::OP_VISIBILITY;
 
-				   Vector<float> visible = _read_float_array(parser);
+				   Vector<real_t> visible = _read_float_array(parser);
 
 				   xf.data=visible;
 
@@ -1859,7 +1859,7 @@ void Collada::_parse_animation(XMLParser& parser) {
 		return;
 	}
 
-	Map<String,Vector<float> > float_sources;
+	Map<String,Vector<real_t> > float_sources;
 	Map<String,Vector<String> > string_sources;
 	Map<String,int > source_strides;
 	Map<String, Map<String,String> > samplers;
@@ -1966,7 +1966,7 @@ void Collada::_parse_animation(XMLParser& parser) {
 
 			String name = names[l];
 
-			Vector<float> &time_keys=float_sources[input_id];
+			Vector<real_t> &time_keys=float_sources[input_id];
 			int key_count = time_keys.size();
 
 			AnimationTrack track; //begin crating track
@@ -1990,7 +1990,7 @@ void Collada::_parse_animation(XMLParser& parser) {
 			ERR_CONTINUE(output_len==0);
 			ERR_CONTINUE(!float_sources.has(output_id));
 
-			Vector<float> &output = float_sources[output_id];
+			Vector<real_t> &output = float_sources[output_id];
 
 			ERR_EXPLAIN("Wrong number of keys in output");
 			ERR_CONTINUE( (output.size()/stride) != key_count );
@@ -2020,7 +2020,7 @@ void Collada::_parse_animation(XMLParser& parser) {
 				//bezier control points..
 				String intangent_id=_uri_to_id(sampler["IN_TANGENT"]);
 				ERR_CONTINUE(!float_sources.has(intangent_id));
-				Vector<float> &intangents=float_sources[intangent_id];
+				Vector<real_t> &intangents=float_sources[intangent_id];
 
 
 
@@ -2029,7 +2029,7 @@ void Collada::_parse_animation(XMLParser& parser) {
 
 				String outangent_id=_uri_to_id(sampler["OUT_TANGENT"]);
 				ERR_CONTINUE(!float_sources.has(outangent_id));
-				Vector<float> &outangents=float_sources[outangent_id];
+				Vector<real_t> &outangents=float_sources[outangent_id];
 				ERR_CONTINUE(outangents.size()!=key_count*2*names.size());
 
 				for(int j=0;j<key_count;j++) {

--- a/tools/collada/collada.h
+++ b/tools/collada/collada.h
@@ -160,7 +160,7 @@ public:
 		String name;
 		struct Source {
 
-			Vector<float> array;
+			Vector<real_t> array;
 			int stride;
 
 		};
@@ -186,8 +186,8 @@ public:
 
 			String material;
 			Map<String,SourceRef> sources;
-			Vector<float> polygons;
-			Vector<float> indices;
+			Vector<real_t> polygons;
+			Vector<real_t> indices;
 			int count;
 			int vertex_size;
 		};
@@ -209,7 +209,7 @@ public:
 		struct Source {
 
 			Vector<String> sarray;
-			Vector<float> array;
+			Vector<real_t> array;
 			int stride;
 		};
 
@@ -234,7 +234,7 @@ public:
 		struct Source {
 
 			Vector<String> sarray; //maybe for names
-			Vector<float> array;
+			Vector<real_t> array;
 			int stride;
 			Source() {
 				stride=1;
@@ -260,8 +260,8 @@ public:
 
 			String material;
 			Map<String,SourceRef> sources;
-			Vector<float> sets;
-			Vector<float> indices;
+			Vector<real_t> sets;
+			Vector<real_t> indices;
 			int count;
 		} weights;
 
@@ -280,7 +280,7 @@ public:
 
 			int stride;
 			Vector<String> sarray; //maybe for names
-			Vector<float> array;
+			Vector<real_t> array;
 			Source() { stride=1; }
 		};
 
@@ -370,7 +370,7 @@ public:
 
 			String id;
 			Op op;
-			Vector<float> data;
+			Vector<real_t> data;
 		};
 
 		Type type;
@@ -481,7 +481,7 @@ public:
 			};
 
 			float time;
-			Vector<float> data;
+			Vector<real_t> data;
 			Point2 in_tangent;
 			Point2 out_tangent;
 			InterpolationType interp_type;
@@ -490,7 +490,7 @@ public:
 		};
 
 
-		Vector<float> get_value_at_time(float p_time);
+		Vector<real_t> get_value_at_time(float p_time);
 
 		Vector<Key> keys;
 
@@ -605,7 +605,7 @@ private: // private stuff
 
 
 	Variant _parse_param(XMLParser& parser);
-	Vector<float> _read_float_array(XMLParser& parser);
+	Vector<real_t> _read_float_array(XMLParser& parser);
 	Vector<String> _read_string_array(XMLParser& parser);
 	Transform _read_transform(XMLParser& parser);
 

--- a/tools/editor/io_plugins/editor_import_collada.cpp
+++ b/tools/editor/io_plugins/editor_import_collada.cpp
@@ -1004,12 +1004,12 @@ Error ColladaImport::_create_mesh_surfaces(Ref<Mesh>& p_mesh,const Map<String,Co
 
 			DVector<Vector3> final_vertex_array;
 			DVector<Vector3> final_normal_array;
-			DVector<float> final_tangent_array;
+			DVector<real_t> final_tangent_array;
 			DVector<Color> final_color_array;
 			DVector<Vector3> final_uv_array;
 			DVector<Vector3> final_uv2_array;
-			DVector<float> final_bone_array;
-			DVector<float> final_weight_array;
+			DVector<real_t> final_bone_array;
+			DVector<real_t> final_weight_array;
 
 			uint32_t final_format=0;
 
@@ -1158,13 +1158,13 @@ Error ColladaImport::_create_mesh_surfaces(Ref<Mesh>& p_mesh,const Map<String,Co
 			}
 
 			if (has_weights) {
-				DVector<float> weightarray;
-				DVector<float> bonearray;
+				DVector<real_t> weightarray;
+				DVector<real_t> bonearray;
 
 				weightarray.resize(vertex_array.size()*4);
-				DVector<float>::Write weightarrayw = weightarray.write();
+				DVector<real_t>::Write weightarrayw = weightarray.write();
 				bonearray.resize(vertex_array.size()*4);
-				DVector<float>::Write bonearrayw = bonearray.write();
+				DVector<real_t>::Write bonearrayw = bonearray.write();
 
 				for(int k=0;k<vlen;k++) {
 					float sum=0;
@@ -1189,8 +1189,8 @@ Error ColladaImport::_create_mesh_surfaces(Ref<Mesh>& p_mesh,const Map<String,Co
 
 				}
 
-				weightarrayw = DVector<float>::Write();
-				bonearrayw = DVector<float>::Write();
+				weightarrayw = DVector<real_t>::Write();
+				bonearrayw = DVector<real_t>::Write();
 
 				final_weight_array = weightarray;
 				final_bone_array = bonearray;
@@ -1310,7 +1310,7 @@ Error ColladaImport::_create_mesh_surfaces(Ref<Mesh>& p_mesh,const Map<String,Co
 					//vertices are in place, now generate everything else
 					vertw = DVector<Vector3>::Write();
 					DVector<Vector3> normals;
-					DVector<float> tangents;
+					DVector<real_t> tangents;
 
 					_generate_normals(index_array,vertices,normals);
 					if (final_tangent_array.size() && final_uv_array.size()) {
@@ -1799,7 +1799,7 @@ void ColladaImport::create_animation(int p_clip) {
 	//animation->set_loop(true);
 	//create animation tracks
 
-	Vector<float> base_snapshots;
+	Vector<real_t> base_snapshots;
 
 	float f=0;
 	float snapshot_interval = 1.0/20.0; //should be customizable somewhere...
@@ -1850,7 +1850,7 @@ void ColladaImport::create_animation(int p_clip) {
 		int track = animation->get_track_count() -1;		
 		animation->track_set_path( track , path );
 
-		Vector<float> snapshots = base_snapshots;
+		Vector<real_t> snapshots = base_snapshots;
 
 		if (nm.anim_tracks.size()==1) {
 			//use snapshot keys from anim track instead, because this was most likely exported baked
@@ -1900,7 +1900,7 @@ void ColladaImport::create_animation(int p_clip) {
 
 				ERR_CONTINUE(xform_idx==-1);
 
-				Vector<float> data = at.get_value_at_time(snapshots[i]);
+				Vector<real_t> data = at.get_value_at_time(snapshots[i]);
 				ERR_CONTINUE(data.empty());
 
 
@@ -2056,7 +2056,7 @@ void ColladaImport::create_animation(int p_clip) {
 
 			float time = at.keys[i].time;
 			Variant value;
-			Vector<float> data = at.keys[i].data;
+			Vector<real_t> data = at.keys[i].data;
 			if (data.size()==1) {
 				//push a float
 				value=data[0];

--- a/tools/editor/io_plugins/editor_sample_import_plugin.cpp
+++ b/tools/editor/io_plugins/editor_sample_import_plugin.cpp
@@ -414,7 +414,7 @@ Error EditorSampleImportPlugin::import(const String& p_path, const Ref<ResourceI
 	print_line("\tloop: "+itos(loop));
 	print_line("\tloop begin: "+itos(loop_beg));
 	print_line("\tloop end: "+itos(loop_end));
-	Vector<float> data;
+	Vector<real_t> data;
 	data.resize(len*chans);
 
 	{
@@ -445,7 +445,7 @@ Error EditorSampleImportPlugin::import(const String& p_path, const Ref<ResourceI
 	if (limit_rate && rate > limit_rate_hz) {
 		//resampleeee!!!
 		int new_data_len = len * limit_rate_hz / rate;
-		Vector<float> new_data;
+		Vector<real_t> new_data;
 		new_data.resize( new_data_len * chans );
 		for(int c=0;c<chans;c++) {
 
@@ -533,7 +533,7 @@ Error EditorSampleImportPlugin::import(const String& p_path, const Ref<ResourceI
 
 		if (first<last) {
 
-			Vector<float> new_data;
+			Vector<real_t> new_data;
 			new_data.resize((last-first+1)*chans);
 			for(int i=first*chans;i<=last*chans;i++) {
 				new_data[i-first*chans]=data[i];
@@ -557,7 +557,7 @@ Error EditorSampleImportPlugin::import(const String& p_path, const Ref<ResourceI
 	bool force_mono = from->get_option("force/mono");
 	if (force_mono && chans==2) {
 
-		Vector<float> new_data;
+		Vector<real_t> new_data;
 		new_data.resize(data.size()/2);
 		for(int i=0;i<len;i++) {
 			new_data[i]=(data[i*2+0]+data[i*2+1])/2.0;

--- a/tools/editor/script_editor_debugger.cpp
+++ b/tools/editor/script_editor_debugger.cpp
@@ -328,7 +328,7 @@ void ScriptEditorDebugger::_parse_message(const String& p_msg,const Array& p_dat
 
 	} else if (p_msg=="performance") {
 		Array arr = p_data[0];
-		Vector<float> p;
+		Vector<real_t> p;
 		p.resize(arr.size());
 		for(int i=0;i<arr.size();i++) {
 			p[i]=arr[i];
@@ -405,7 +405,7 @@ void ScriptEditorDebugger::_performance_draw() {
 		float spacing=point_sep/float(cols);
 		float from = r.size.width;
 
-		List<Vector<float> >::Element *E=perf_history.front();
+		List<Vector<real_t> >::Element *E=perf_history.front();
 		float prev=-1;
 		while(from>=0 && E) {
 

--- a/tools/editor/script_editor_debugger.h
+++ b/tools/editor/script_editor_debugger.h
@@ -76,8 +76,8 @@ class ScriptEditorDebugger : public Control {
 	Button *dobreak;
 	Button *docontinue;
 
-	List<Vector<float> > perf_history;
-	Vector<float> perf_max;
+	List<Vector<real_t> > perf_history;
+	Vector<real_t> perf_max;
 	Vector<TreeItem*> perf_items;
 
 	Tree *perf_monitors;

--- a/tools/editor/spatial_editor_gizmos.cpp
+++ b/tools/editor/spatial_editor_gizmos.cpp
@@ -1147,7 +1147,7 @@ void SkeletonSpatialGizmo::redraw() {
 	grests.resize(skel->get_bone_count());
 
 	Vector<int> bones;
-	Vector<float> weights;
+	Vector<real_t> weights;
 	bones.resize(4);
 	weights.resize(4);
 


### PR DESCRIPTION
Allow use double as real_t(fix compile errors)
Marshal always store/load float in file
ResourceFormatBinary compatible float/double format
GDScript parser automate detect int or real_t(if expression value out of int range)

This feature default is disabled
