### PR TITLE
Make builtin openssl optional on windows, save 1M runtime size

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -225,10 +225,11 @@ for p in platform_list:
 
 	if (env['musepack']=='yes'):
 		env.Append(CPPFLAGS=['-DMUSEPACK_ENABLED']);
-        if (env['openssl']!='no'):
-            env.Append(CPPFLAGS=['-DOPENSSL_ENABLED']);
-            if (env['openssl']=="builtin"):
-                env.Append(CPPPATH=['#drivers/builtin_openssl'])
+
+	if (env['openssl']!='no'):
+		env.Append(CPPFLAGS=['-DOPENSSL_ENABLED']);
+		if (env['openssl']=="builtin"):
+			env.Append(CPPPATH=['#drivers/builtin_openssl'])
 
 
 	if (env["old_scenes"]=='yes'):

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -11,7 +11,8 @@ SConscript('windows/SCsub');
 SConscript('gles2/SCsub');
 SConscript('gles1/SCsub');
 SConscript('gl_context/SCsub');
-SConscript('openssl/SCsub');
+if (env["openssl"]!="no"):
+	SConscript('openssl/SCsub');
 
 if (env["png"]=="yes"):
 	SConscript("png/SCsub");

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -51,7 +51,6 @@ def get_flags():
 
 	return [
 		('freetype','builtin'), #use builtin freetype
-                ('openssl','builtin'), #use builtin openssl
         ]
 			
 


### PR DESCRIPTION
- And user can enable built-in openssl anytime by passing "openssl=builtin" to scons
- Save 1.2M runtime size on windows for games don't require ssl capability
