### PR TITLE
Add multi-select to project manager

### DIFF
--- a/tools/editor/project_manager.h
+++ b/tools/editor/project_manager.h
@@ -49,7 +49,8 @@ class ProjectManager : public Control {
 	NewProjectDialog *npdialog;
 	ScrollContainer *scroll;
 	VBoxContainer *scroll_childs;
-	String selected;
+	Set<String> selected_list;
+	String last_clicked;
 	String selected_main;
 	bool importing;
 


### PR DESCRIPTION
- Support multi-select in project manager, useful for erasing multiple projects
- Hold Shift to select items in range
- Hold Control to multi-select items one at a time
