### PR TITLE
Contextual help for Script Editor

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2485,6 +2485,27 @@ String TextEdit::get_selection_text() const {
 
 }
 
+String TextEdit::get_word_under_cursor() const {
+
+	int prev_cc = cursor.column;
+	while(prev_cc >0) {
+		bool is_char = _is_text_char(text[cursor.line][prev_cc-1]);
+		if (!is_char)
+			break;
+		--prev_cc;
+	}
+
+	int next_cc = cursor.column;
+	while(next_cc<text[cursor.line].length()) {
+		bool is_char = _is_text_char(text[cursor.line][next_cc]);
+		if(!is_char)
+			break;
+		++ next_cc;
+	}
+	if (prev_cc == cursor.column || next_cc == cursor.column)
+		return "";
+	return text[cursor.line].substr(prev_cc, next_cc-prev_cc);
+}
 
 DVector<int> TextEdit::_search_bind(const String &p_key,uint32_t p_search_flags, int p_from_line,int p_from_column) const {
 
@@ -3037,6 +3058,7 @@ void TextEdit::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_selection_to_line"),&TextEdit::get_selection_to_line);
 	ObjectTypeDB::bind_method(_MD("get_selection_to_column"),&TextEdit::get_selection_to_column);
 	ObjectTypeDB::bind_method(_MD("get_selection_text"),&TextEdit::get_selection_text);
+	ObjectTypeDB::bind_method(_MD("get_word_under_cursor"),&TextEdit::get_word_under_cursor);
 	ObjectTypeDB::bind_method(_MD("search","flags","from_line","from_column","to_line","to_column"),&TextEdit::_search_bind);
 
 	ObjectTypeDB::bind_method(_MD("undo"),&TextEdit::undo);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -341,6 +341,8 @@ public:
 	int get_selection_to_column() const;
 	String get_selection_text() const;
 
+	String get_word_under_cursor() const;
+
 	bool search(const String &p_key,uint32_t p_search_flags, int p_from_line, int p_from_column,int &r_line,int &r_column) const;
 
 	void undo();

--- a/tools/editor/editor_help.cpp
+++ b/tools/editor/editor_help.cpp
@@ -43,9 +43,16 @@ void EditorHelpSearch::popup(const String& p_term) {
 	if (p_term!="") {
 		search_box->set_text(p_term);
 		search_box->select_all();
-	} else
+		_update_search();
+		//TreeItem *ti = search_options->select_single_item();
+		//if (!ti)
+		//	return;
+		search_options->grab_focus();
+
+	} else {
 		search_box->clear();
-	search_box->grab_focus();
+		search_box->grab_focus();
+	}
 }
 
 
@@ -863,6 +870,8 @@ void EditorHelp::_goto_desc(const String& p_class,bool p_update_history,int p_vs
 void EditorHelp::_request_help(const String& p_string) {
 
 	_goto_desc(p_string);
+	class_search->popup(p_string);
+
 
 
 	//100 palabras

--- a/tools/editor/editor_help.cpp
+++ b/tools/editor/editor_help.cpp
@@ -44,15 +44,9 @@ void EditorHelpSearch::popup(const String& p_term) {
 		search_box->set_text(p_term);
 		search_box->select_all();
 		_update_search();
-		//TreeItem *ti = search_options->select_single_item();
-		//if (!ti)
-		//	return;
-		search_options->grab_focus();
-
-	} else {
+	} else
 		search_box->clear();
-		search_box->grab_focus();
-	}
+	search_box->grab_focus();
 }
 
 
@@ -76,7 +70,6 @@ void EditorHelpSearch::_sbox_input(const InputEvent& p_ie) {
 }
 
 void EditorHelpSearch::_update_search() {
-
 
 	search_options->clear();
 	search_options->set_hide_root(true);
@@ -256,6 +249,7 @@ void EditorHelpSearch::_confirmed() {
 
 	String mdata=ti->get_metadata(0);
 	emit_signal("go_to_help",mdata);
+	editor->call("_editor_select",3); // in case EditorHelpSearch beeen invoked on top of other editor window
 	// go to that
 	hide();
 }
@@ -325,10 +319,14 @@ DocData *EditorHelp::doc=NULL;
 
 void EditorHelp::_unhandled_key_input(const InputEvent& p_ev) {
 
-	if (is_visible() && p_ev.key.mod.control && p_ev.key.scancode==KEY_F) {
+	if (!is_visible())
+		return;
+	if ( p_ev.key.mod.control && p_ev.key.scancode==KEY_F) {
 
 		search->grab_focus();
 		search->select_all();
+	} else if (p_ev.key.mod.shift && p_ev.key.scancode==KEY_F1) {
+		class_search->popup();
 	}
 }
 
@@ -461,9 +459,11 @@ void EditorHelp::_scroll_changed(double p_scroll) {
 	history[p].scroll=p_scroll;
 }
 
-void EditorHelp::_goto_desc(const String& p_class,bool p_update_history,int p_vscr) {
+Error EditorHelp::_goto_desc(const String& p_class,bool p_update_history,int p_vscr) {
 
-	ERR_FAIL_COND(!doc->class_list.has(p_class));
+	//ERR_FAIL_COND(!doc->class_list.has(p_class));
+	if (!doc->class_list.has(p_class))
+		return ERR_DOES_NOT_EXIST;
 
 
 	if (tree_item_map.has(p_class)) {
@@ -477,7 +477,7 @@ void EditorHelp::_goto_desc(const String& p_class,bool p_update_history,int p_vs
 	description_line=0;
 
 	if (p_class==edited_class->get_text())
-		return; //already there
+		return OK; //already there
 
 	scroll_locked=true;
 
@@ -865,15 +865,16 @@ void EditorHelp::_goto_desc(const String& p_class,bool p_update_history,int p_vs
 
 	scroll_locked=false;
 
+	return OK;
 }
 
-void EditorHelp::_request_help(const String& p_string) {
-
-	_goto_desc(p_string);
-	class_search->popup(p_string);
-
-
-
+void EditorHelp::_request_help(const String& p_string) {	
+	Error err = _goto_desc(p_string);
+	if (err==OK) {
+		editor->call("_editor_select",3);
+	} else {
+		class_search->popup(p_string);
+	}
 	//100 palabras
 }
 

--- a/tools/editor/editor_help.h
+++ b/tools/editor/editor_help.h
@@ -139,7 +139,7 @@ class EditorHelp : public VBoxContainer {
 	void _class_list_select(const String& p_select);
 	void _class_desc_select(const String& p_select);
 
-	void _goto_desc(const String& p_class,bool p_update_history=true,int p_vscr=-1);
+	Error _goto_desc(const String& p_class,bool p_update_history=true,int p_vscr=-1);
 	void _update_history_buttons();
 	void _update_doc();
 

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -115,7 +115,10 @@ void EditorNode::_unhandled_input(const InputEvent& p_event) {
 
 		switch(p_event.key.scancode) {
 
-			case KEY_F1: _editor_select(3); break;
+			case KEY_F1:
+				if (!p_event.key.mod.shift && !p_event.key.mod.command)
+					_editor_select(3);
+			break;
 			case KEY_F2: _editor_select(0); break;
 			case KEY_F3: _editor_select(1); break;
 			case KEY_F4: _editor_select(2); break;

--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -394,7 +394,6 @@ ScriptTextEditor::ScriptTextEditor() {
 
 /*** SCRIPT EDITOR ******/
 
-
 String ScriptEditor::_get_debug_tooltip(const String&p_text,Node *_ste) {
 
 	ScriptTextEditor *ste=_ste->cast_to<ScriptTextEditor>();
@@ -752,10 +751,12 @@ void ScriptEditor::_menu_option(int p_option) {
 					debugger->show();
 			}
 		} break;
-		case HELP_SELECTED: {
-			String selected = current->get_text_edit()->get_selection_text();
-			editor->call("_editor_select", 3);
-			editor->emit_signal("request_help", selected);
+		case HELP_CONTEXTUAL: {
+			String text = current->get_text_edit()->get_selection_text();
+			if (text == "")
+				text = current->get_text_edit()->get_word_under_cursor();
+			if (text != "")
+				editor->emit_signal("request_help", text);
 		} break;
 		case WINDOW_CLOSE: {
 
@@ -1055,9 +1056,6 @@ void ScriptEditor::_bind_methods() {
 	ObjectTypeDB::bind_method("_breaked",&ScriptEditor::_breaked);
 	ObjectTypeDB::bind_method("_show_debugger",&ScriptEditor::_show_debugger);
 	ObjectTypeDB::bind_method("_get_debug_tooltip",&ScriptEditor::_get_debug_tooltip);
-
-
-
 
 }
 
@@ -1370,7 +1368,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	help_menu = memnew( MenuButton );
 	menu_hb->add_child(help_menu);
 	help_menu->set_text("Help");
-	help_menu->get_popup()->add_item("Selected", HELP_SELECTED, KEY_MASK_CTRL|KEY_MASK_SHIFT|KEY_D);
+	help_menu->get_popup()->add_item("Contextual", HELP_CONTEXTUAL, KEY_MASK_SHIFT|KEY_F1);
 	help_menu->get_popup()->connect("item_pressed", this,"_menu_option");
 
 	tab_container->connect("tab_changed", this,"_tab_changed");
@@ -1425,6 +1423,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	v_split->add_child(debugger);
 	debugger->connect("breaked",this,"_breaked");
 //	debugger_gui->hide();
+
 }
 
 

--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -752,6 +752,11 @@ void ScriptEditor::_menu_option(int p_option) {
 					debugger->show();
 			}
 		} break;
+		case HELP_SELECTED: {
+			String selected = current->get_text_edit()->get_selection_text();
+			editor->call("_editor_select", 3);
+			editor->emit_signal("request_help", selected);
+		} break;
 		case WINDOW_CLOSE: {
 
 			erase_tab_confirm->set_text("Close Tab?:\n\""+current->get_name()+"\"");
@@ -1361,6 +1366,12 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	window_menu->get_popup()->add_item("Move Right",WINDOW_MOVE_RIGHT,KEY_MASK_CMD|KEY_RIGHT);
 	window_menu->get_popup()->add_separator();
 	window_menu->get_popup()->connect("item_pressed", this,"_menu_option");
+
+	help_menu = memnew( MenuButton );
+	menu_hb->add_child(help_menu);
+	help_menu->set_text("Help");
+	help_menu->get_popup()->add_item("Selected", HELP_SELECTED, KEY_MASK_CTRL|KEY_MASK_SHIFT|KEY_D);
+	help_menu->get_popup()->connect("item_pressed", this,"_menu_option");
 
 	tab_container->connect("tab_changed", this,"_tab_changed");
 

--- a/tools/editor/plugins/script_editor_plugin.h
+++ b/tools/editor/plugins/script_editor_plugin.h
@@ -133,7 +133,7 @@ class ScriptEditor : public VBoxContainer {
 		DEBUG_BREAK,
 		DEBUG_CONTINUE,
 		DEBUG_SHOW,
-		HELP_SELECTED,
+		HELP_CONTEXTUAL,
 		WINDOW_CLOSE,
 		WINDOW_MOVE_LEFT,
 		WINDOW_MOVE_RIGHT,
@@ -187,6 +187,7 @@ class ScriptEditor : public VBoxContainer {
 	void _breaked(bool p_breaked,bool p_can_debug);
 	void _show_debugger(bool p_show);
 	void _update_window_menu();
+
 	static ScriptEditor *script_editor;
 protected:
 	void _notification(int p_what);

--- a/tools/editor/plugins/script_editor_plugin.h
+++ b/tools/editor/plugins/script_editor_plugin.h
@@ -133,6 +133,7 @@ class ScriptEditor : public VBoxContainer {
 		DEBUG_BREAK,
 		DEBUG_CONTINUE,
 		DEBUG_SHOW,
+		HELP_SELECTED,
 		WINDOW_CLOSE,
 		WINDOW_MOVE_LEFT,
 		WINDOW_MOVE_RIGHT,
@@ -145,6 +146,7 @@ class ScriptEditor : public VBoxContainer {
 	MenuButton *search_menu;
 	MenuButton *window_menu;
 	MenuButton *debug_menu;
+	MenuButton *help_menu;
 	uint64_t idle;
 
 	TabContainer *tab_container;


### PR DESCRIPTION
- Press Shift + F1 to display help for selected text or word under cursor
- Add "get_word_under_cursor" to TextEdit api
- EditoNode only consume F1 key when no Shift or Command been pressed

Known issue:
When help tab been invoked first time, it scroll to wrong position. After the that, it works as expected.

See post http://www.godotengine.org/forum/viewtopic.php?f=8&t=546&start=10#p2317 for more info.
