### PR TITLE
Add auto code completion (without press Ctrl+Space manually)

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1106,7 +1106,7 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 						return;
 					}
 
-					if (k.scancode==KEY_RETURN) {
+					if (k.scancode==KEY_RETURN || k.scancode==KEY_TAB) {
 
 						_confirm_completion();
 						accept_event();
@@ -2896,6 +2896,7 @@ void TextEdit::_update_completion_candidates() {
 
 	completion_current=completion_options[completion_index];
 
+#if 0	// even there's only one option, user still get the chance to choose using it or not
 	if (completion_options.size()==1) {
 		//one option to complete, just complete it automagically
 		_confirm_completion();
@@ -2904,6 +2905,9 @@ void TextEdit::_update_completion_candidates() {
 		return;
 
 	}
+#endif
+	if (completion_options.size()==1 && s==completion_options[0])
+		_cancel_completion();
 
 	completion_enabled=true;
 

--- a/tools/editor/code_editor.cpp
+++ b/tools/editor/code_editor.cpp
@@ -479,8 +479,13 @@ void CodeTextEditor::_line_col_changed() {
 
 void CodeTextEditor::_text_changed() {
 
-
+	code_complete_timer->start();
 	idle->start();
+}
+
+void CodeTextEditor::_code_complete_timer_timeout() {
+
+	text_editor->query_code_comple();
 }
 
 void CodeTextEditor::_complete_request(const String& p_request, int p_line) {
@@ -551,6 +556,7 @@ void CodeTextEditor::_bind_methods() {
 	ObjectTypeDB::bind_method("_text_changed",&CodeTextEditor::_text_changed);
 	ObjectTypeDB::bind_method("_on_settings_change",&CodeTextEditor::_on_settings_change);
 	ObjectTypeDB::bind_method("_text_changed_idle_timeout",&CodeTextEditor::_text_changed_idle_timeout);
+	ObjectTypeDB::bind_method("_code_complete_timer_timeout",&CodeTextEditor::_code_complete_timer_timeout);
 	ObjectTypeDB::bind_method("_complete_request",&CodeTextEditor::_complete_request);
 }
 
@@ -575,6 +581,11 @@ CodeTextEditor::CodeTextEditor() {
 	idle->set_one_shot(true);
 	idle->set_wait_time(EDITOR_DEF("text_editor/idle_parse_delay",2));
 
+	code_complete_timer = memnew(Timer);
+	add_child(code_complete_timer);
+	code_complete_timer->set_one_shot(true);
+	code_complete_timer->set_wait_time(EDITOR_DEF("text_editor/code_complete_delay",.3f));
+
 	error = memnew( Label );
 	add_child(error);
 	error->set_anchor_and_margin(MARGIN_LEFT,ANCHOR_BEGIN,5);
@@ -593,6 +604,7 @@ CodeTextEditor::CodeTextEditor() {
 	cs.push_back(".");
 	text_editor->set_completion(true,cs);
 	idle->connect("timeout", this,"_text_changed_idle_timeout");
+	code_complete_timer->connect("timeout", this,"_code_complete_timer_timeout");
 
 	EditorSettings::get_singleton()->connect("settings_changed",this,"_on_settings_change");
 }

--- a/tools/editor/code_editor.h
+++ b/tools/editor/code_editor.h
@@ -128,6 +128,7 @@ class CodeTextEditor : public Control {
 	Label *line_col;
 	Label *info;
 	Timer *idle;
+	Timer *code_complete_timer;
 
 	Label *error;
 
@@ -145,6 +146,7 @@ protected:
 
 
 	void _text_changed_idle_timeout();
+	void _code_complete_timer_timeout();
 	void _text_changed();
 	void _line_col_changed();
 	void _notification(int);


### PR DESCRIPTION
- Add auto code completion (without press Ctrl+Space manually)
- Support use tab key to accept code completion option
- Add Code Complete Delay in Editor Setting
  ![](http://oi62.tinypic.com/izuiw9.jpg)

check http://www.godotengine.org/forum/viewtopic.php?f=8&t=546#p2289 for more info
