### PR TITLE
Add lock and group icon to scene tree editor

### DIFF
--- a/tools/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/tools/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1673,7 +1673,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 					continue;
 
 				canvas_item->set_meta("_edit_lock_",true);
-
+				emit_signal("item_lock_status_changed");
 			}
 			viewport->update();
 		} break;
@@ -1691,7 +1691,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 
 				canvas_item->set_meta("_edit_lock_",Variant());
-
+				emit_signal("item_lock_status_changed");
 			}
 
 			viewport->update();
@@ -1710,7 +1710,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 					continue;
 
 				canvas_item->set_meta("_edit_group_",true);
-
+				emit_signal("item_group_status_changed");
 			}
 			viewport->update();
 		} break;
@@ -1726,9 +1726,8 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 				if (!canvas_item->is_visible())
 					continue;
 
-
 				canvas_item->set_meta("_edit_group_",Variant());
-
+				emit_signal("item_group_status_changed");
 			}
 
 			viewport->update();
@@ -2054,7 +2053,8 @@ void CanvasItemEditor::_bind_methods() {
 	ObjectTypeDB::bind_method("_viewport_draw",&CanvasItemEditor::_viewport_draw);
 	ObjectTypeDB::bind_method("_viewport_input_event",&CanvasItemEditor::_viewport_input_event);
 
-
+	ADD_SIGNAL( MethodInfo("item_lock_status_changed") );
+	ADD_SIGNAL( MethodInfo("item_group_status_changed") );
 
 }
 

--- a/tools/editor/scene_tree_dock.cpp
+++ b/tools/editor/scene_tree_dock.cpp
@@ -32,6 +32,7 @@
 #include "os/keyboard.h"
 #include "scene/resources/packed_scene.h"
 #include "editor_settings.h"
+#include "tools/editor/plugins/canvas_item_editor_plugin.h"
 
 
 void SceneTreeDock::_unhandled_key_input(InputEvent p_event) {
@@ -373,6 +374,15 @@ void SceneTreeDock::_notification(int p_what) {
 			for(int i=0;i<TOOL_BUTTON_MAX;i++)
 				tool_buttons[i]->set_icon(get_icon(button_names[i],"EditorIcons"));
 
+		} break;
+		case NOTIFICATION_READY: {
+
+			CanvasItemEditorPlugin *canvas_item_plugin =  editor_data->get_editor("2D")->cast_to<CanvasItemEditorPlugin>();
+			if (canvas_item_plugin) {
+				canvas_item_plugin->get_canvas_item_editor()->connect("item_lock_status_changed", scene_tree, "_update_tree");
+				canvas_item_plugin->get_canvas_item_editor()->connect("item_group_status_changed", scene_tree, "_update_tree");
+				scene_tree->connect("node_changed", canvas_item_plugin->get_canvas_item_editor()->get_viewport_control(), "update");
+			}
 		} break;
 	}
 }

--- a/tools/editor/scene_tree_editor.cpp
+++ b/tools/editor/scene_tree_editor.cpp
@@ -32,6 +32,7 @@
 #include "print_string.h"
 #include "message_queue.h"
 #include "scene/main/viewport.h"
+#include "tools/editor/plugins/canvas_item_editor_plugin.h"
 
 Node *SceneTreeEditor::get_scene_node() {
 
@@ -84,6 +85,21 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item,int p_column,int p_id)
 			undo_redo->add_do_method(n,v?"hide":"show");
 			undo_redo->add_undo_method(n,v?"show":"hide");
 			undo_redo->commit_action();
+		}
+
+	} else if (p_id==BUTTON_LOCK) {
+
+		if (n->is_type("CanvasItem")) {
+			n->set_meta("_edit_lock_", Variant());
+			_update_tree();
+			emit_signal("node_changed");
+		}
+
+	} else if (p_id==BUTTON_GROUP) {
+		if (n->is_type("CanvasItem")) {
+			n->set_meta("_edit_group_", Variant());
+			_update_tree();
+			emit_signal("node_changed");
 		}
 	}
 }
@@ -164,6 +180,16 @@ void SceneTreeEditor::_add_nodes(Node *p_node,TreeItem *p_parent) {
 
 			if (!p_node->is_connected("visibility_changed",this,"_node_visibility_changed"))
 				p_node->connect("visibility_changed",this,"_node_visibility_changed",varray(p_node));
+
+			bool is_locked = p_node->has_meta("_edit_lock_");//_edit_group_
+			if (is_locked)
+				item->add_button(0,get_icon("Lock", "EditorIcons"), BUTTON_LOCK);
+
+			bool is_grouped = p_node->has_meta("_edit_group_");
+			if (is_grouped)
+				item->add_button(0,get_icon("Group", "EditorIcons"), BUTTON_GROUP);
+
+
 
 		} else if (p_node->is_type("GeometryInstance")) {
 
@@ -627,9 +653,11 @@ void SceneTreeEditor::_bind_methods() {
 	ADD_SIGNAL( MethodInfo("node_selected") );
 	ADD_SIGNAL( MethodInfo("node_renamed") );
 	ADD_SIGNAL( MethodInfo("node_prerename") );
+	ADD_SIGNAL( MethodInfo("node_changed") );
 
 	ADD_SIGNAL( MethodInfo("open") );
 	ADD_SIGNAL( MethodInfo("open_script") );
+
 
 }
 
@@ -728,6 +756,7 @@ void SceneTreeDialog::_bind_methods() {
 	ObjectTypeDB::bind_method("_select",&SceneTreeDialog::_select);
 	ObjectTypeDB::bind_method("_cancel",&SceneTreeDialog::_cancel);
 	ADD_SIGNAL( MethodInfo("selected",PropertyInfo(Variant::NODE_PATH,"path")));
+
 
 }
 

--- a/tools/editor/scene_tree_editor.h
+++ b/tools/editor/scene_tree_editor.h
@@ -46,7 +46,9 @@ class SceneTreeEditor : public Control {
 	enum {
 		BUTTON_SUBSCENE=0,
 		BUTTON_VISIBILITY=1,
-		BUTTON_SCRIPT=2
+		BUTTON_SCRIPT=2,
+		BUTTON_LOCK=3,
+		BUTTON_GROUP=4,
 	};
 
 	Tree *tree;


### PR DESCRIPTION
![](http://oi57.tinypic.com/8xpk5s.jpg)

Sometimes it's hard to know if your node is locked or grouped when it's overlapped by other nodes. Some icons on scene tree might help. 

And they are buttons too, so you can also unlock or ungroup the node by click on the icon.
