### PR TITLE
Shift+Del to delete nodes without confirmation

### DIFF
--- a/tools/editor/scene_tree_dock.cpp
+++ b/tools/editor/scene_tree_dock.cpp
@@ -47,6 +47,7 @@ void SceneTreeDock::_unhandled_key_input(InputEvent p_event) {
 		case KEY_MASK_CMD|KEY_D: { _tool_selected(TOOL_DUPLICATE); } break;
 		case KEY_MASK_CMD|KEY_UP: { _tool_selected(TOOL_MOVE_UP); } break;
 		case KEY_MASK_CMD|KEY_DOWN: { _tool_selected(TOOL_MOVE_DOWN); } break;
+		case KEY_MASK_SHIFT|KEY_DELETE: { _tool_selected(TOOL_ERASE, true); } break;
 		case KEY_DELETE: { _tool_selected(TOOL_ERASE); } break;
 	}
 }
@@ -99,7 +100,7 @@ Node* SceneTreeDock::instance(const String& p_file) {
 
 }
 
-void SceneTreeDock::_tool_selected(int p_tool) {
+void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 	current_option=p_tool;
 
@@ -340,8 +341,17 @@ void SceneTreeDock::_tool_selected(int p_tool) {
 			if (remove_list.empty())
 				return;
 
-			delete_dialog->set_text("Delete Node(s)?");
-			delete_dialog->popup_centered(Size2(200,80));
+			if (p_confirm_override) {
+				_delete_confirm();
+
+				// hack, force 2d editor viewport to refresh after deletion
+				if (CanvasItemEditor *editor = CanvasItemEditor::get_singleton())
+					editor->get_viewport_control()->update();
+
+			} else {
+				delete_dialog->set_text("Delete Node(s)?");
+				delete_dialog->popup_centered(Size2(200,80));
+			}
 
 
 
@@ -1096,19 +1106,19 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor,Node *p_scene_root,EditorSelec
 	ToolButton *tb;
 
 	tb = memnew( ToolButton );
-	tb->connect("pressed",this,"_tool_selected",make_binds(TOOL_NEW));
+	tb->connect("pressed",this,"_tool_selected",make_binds(TOOL_NEW, false));
 	tb->set_tooltip("Add/Create a New Node\n("+keycode_get_string(KEY_MASK_CMD|KEY_A)+")");
 	hbc_top->add_child(tb);
 	tool_buttons[TOOL_NEW]=tb;
 
 	tb = memnew( ToolButton );
-	tb->connect("pressed",this,"_tool_selected",make_binds(TOOL_INSTANCE));
+	tb->connect("pressed",this,"_tool_selected",make_binds(TOOL_INSTANCE, false));
 	tb->set_tooltip("Instance a Node from scene file.");
 	hbc_top->add_child(tb);
 	tool_buttons[TOOL_INSTANCE]=tb;
 
 	tb = memnew( ToolButton );
-	tb->connect("pressed",this,"_tool_selected",make_binds(TOOL_REPLACE));
+	tb->connect("pressed",this,"_tool_selected",make_binds(TOOL_REPLACE, false));
 	tb->set_tooltip("Replace a Node by Another Node Type");
 	hbc_top->add_child(tb);
 	tool_buttons[TOOL_REPLACE]=tb;
@@ -1116,19 +1126,19 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor,Node *p_scene_root,EditorSelec
 	hbc_top->add_spacer();
 
 	tb = memnew( ToolButton );
-	tb->connect("pressed",this,"_tool_selected",make_binds(TOOL_CONNECT));
+	tb->connect("pressed",this,"_tool_selected",make_binds(TOOL_CONNECT, false));
 	tb->set_tooltip("Edit the Node Connections");
 	hbc_top->add_child(tb);
 	tool_buttons[TOOL_CONNECT]=tb;
 
 	tb = memnew( ToolButton );
-	tb->connect("pressed",this,"_tool_selected",make_binds(TOOL_GROUP));
+	tb->connect("pressed",this,"_tool_selected",make_binds(TOOL_GROUP, false));
 	tb->set_tooltip("Edit the Node Groups");
 	hbc_top->add_child(tb);
 	tool_buttons[TOOL_GROUP]=tb;
 
 	tb = memnew( ToolButton );
-	tb->connect("pressed",this,"_tool_selected",make_binds(TOOL_SCRIPT));
+	tb->connect("pressed",this,"_tool_selected",make_binds(TOOL_SCRIPT, false));
 	tb->set_tooltip("Edit/Create the Node Script");
 	hbc_top->add_child(tb);
 	tool_buttons[TOOL_SCRIPT]=tb;
@@ -1151,25 +1161,25 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor,Node *p_scene_root,EditorSelec
 
 
 	tb = memnew( ToolButton );
-	tb->connect("pressed",this,"_tool_selected",make_binds(TOOL_MOVE_UP));
+	tb->connect("pressed",this,"_tool_selected",make_binds(TOOL_MOVE_UP, false));
 	tb->set_tooltip("Move Node Up\n("+keycode_get_string(KEY_MASK_CMD|KEY_UP)+")");
 	hbc_bottom->add_child(tb);
 	tool_buttons[TOOL_MOVE_UP]=tb;
 
 	tb = memnew( ToolButton );
-	tb->connect("pressed",this,"_tool_selected",make_binds(TOOL_MOVE_DOWN));
+	tb->connect("pressed",this,"_tool_selected",make_binds(TOOL_MOVE_DOWN, false));
 	tb->set_tooltip("Move Node Down\n("+keycode_get_string(KEY_MASK_CMD|KEY_DOWN)+")");
 	hbc_bottom->add_child(tb);
 	tool_buttons[TOOL_MOVE_DOWN]=tb;
 
 	tb = memnew( ToolButton );
-	tb->connect("pressed",this,"_tool_selected",make_binds(TOOL_DUPLICATE));
+	tb->connect("pressed",this,"_tool_selected",make_binds(TOOL_DUPLICATE, false));
 	tb->set_tooltip("Duplicate Selected Node(s)\n("+keycode_get_string(KEY_MASK_CMD|KEY_D)+")");
 	hbc_bottom->add_child(tb);
 	tool_buttons[TOOL_DUPLICATE]=tb;
 
 	tb = memnew( ToolButton );
-	tb->connect("pressed",this,"_tool_selected",make_binds(TOOL_REPARENT));
+	tb->connect("pressed",this,"_tool_selected",make_binds(TOOL_REPARENT, false));
 	tb->set_tooltip("Reparent Selected Node(s)");
 	hbc_bottom->add_child(tb);
 	tool_buttons[TOOL_REPARENT]=tb;
@@ -1177,7 +1187,7 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor,Node *p_scene_root,EditorSelec
 	hbc_bottom->add_spacer();
 
 	tb = memnew( ToolButton );
-	tb->connect("pressed",this,"_tool_selected",make_binds(TOOL_ERASE));
+	tb->connect("pressed",this,"_tool_selected",make_binds(TOOL_ERASE, false));
 	tb->set_tooltip("Erase Selected Node(s)");
 	hbc_bottom->add_child(tb);
 	tool_buttons[TOOL_ERASE]=tb;

--- a/tools/editor/scene_tree_dock.h
+++ b/tools/editor/scene_tree_dock.h
@@ -75,7 +75,7 @@ class SceneTreeDock : public VBoxContainer {
 	SceneTreeEditor *scene_tree;
 
 	HBoxContainer *tool_hbc;
-	void _tool_selected(int p_tool);
+	void _tool_selected(int p_tool, bool p_confirm_override = false);
 
 	EditorData *editor_data;
 	EditorSelection *editor_selection;


### PR DESCRIPTION
The delete confirmation dialog could become annoy when users do delete operation a lot, press Shift + Delete key to bypass confirmation dialog.
