### PR TITLE
Make String::right count from pos instead of pos+1

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -2640,7 +2640,7 @@ String String::right(int p_pos) const {
 	if (p_pos<0)
 		return "";
 
-	return substr(p_pos+1,(length()-p_pos)-1);
+	return substr(p_pos,(length()-p_pos));
 }
 
 CharType String::ord_at(int p_idx) const {

--- a/scene/audio/sample_player.cpp
+++ b/scene/audio/sample_player.cpp
@@ -52,7 +52,7 @@ bool SamplePlayer::_set(const StringName& p_name, const Variant& p_value) {
 		set_voice_count(p_value);
 	else if (name.begins_with("default/")) {
 
-		String what=name.right(7);
+		String what=name.right(8);
 
 		if (what=="volume_db")
 			set_default_volume_db(p_value);

--- a/tools/editor/property_editor.cpp
+++ b/tools/editor/property_editor.cpp
@@ -1941,7 +1941,7 @@ TreeItem *PropertyEditor::get_parent_node(String p_path,HashMap<String,TreeItem*
 		TreeItem *parent = get_parent_node( p_path.left( p_path.find_last("/") ),item_paths,root );
 		item = tree->create_item( parent );
 
-		String name = (p_path.find("/")!=-1)?p_path.right( p_path.find_last("/") ):p_path;
+		String name = (p_path.find("/")!=-1)?p_path.right( p_path.find_last("/")+1 ):p_path;
 		if (capitalize_paths)
 			item->set_text(0, name.capitalize() );
 		else
@@ -2099,7 +2099,7 @@ void PropertyEditor::update_tree() {
 
 		TreeItem * item = tree->create_item( parent );
 
-		String name = (p.name.find("/")!=-1)?p.name.right( p.name.find_last("/") ):p.name;
+		String name = (p.name.find("/")!=-1)?p.name.right( p.name.find_last("/")+1 ):p.name;
 
 		if (level>0) {
 			item->set_custom_bg_color(0,col);


### PR DESCRIPTION
- Change behavior of String:right to count from pos instead of pos+1

```
var s = "Godot"
print(s.right(2)) # return "dot" instead of "ot"
print(s.left(2), s.right(2)) # return "Godot" as usually expected, instead of "Goot"
```
- It might break existing script which reply on result from String::right
