### PR TITLE
Add 'mesh/skeleton' property to MeshInstance

### DIFF
--- a/scene/3d/mesh_instance.cpp
+++ b/scene/3d/mesh_instance.cpp
@@ -113,6 +113,27 @@ Ref<Mesh> MeshInstance::get_mesh() const {
 	return mesh;
 }
 
+void MeshInstance::_resolve_skeleton_path(){
+
+	if (skeleton_path.is_empty())
+		return;
+
+	Skeleton *skeleton=get_node(skeleton_path)?get_node(skeleton_path)->cast_to<Skeleton>():NULL;
+	if (skeleton)
+		VisualServer::get_singleton()->instance_attach_skeleton( get_instance(), skeleton->get_skeleton() );
+}
+
+void MeshInstance::set_skeleton_path(const NodePath &p_skeleton) {
+
+	skeleton_path = p_skeleton;
+	if (!is_inside_scene())
+		return;
+	_resolve_skeleton_path();
+}
+
+NodePath MeshInstance::get_skeleton_path() {
+	return skeleton_path;
+}
 
 AABB MeshInstance::get_aabb() const {
 
@@ -192,22 +213,32 @@ void MeshInstance::create_convex_collision() {
 
 }
 
+void MeshInstance::_notification(int p_what) {
+
+	if (p_what==NOTIFICATION_ENTER_SCENE) {
+		_resolve_skeleton_path();
+	}
+}
+
+
 void MeshInstance::_bind_methods() {
 	
 	ObjectTypeDB::bind_method(_MD("set_mesh","mesh:Mesh"),&MeshInstance::set_mesh);
 	ObjectTypeDB::bind_method(_MD("get_mesh:Mesh"),&MeshInstance::get_mesh);
+	ObjectTypeDB::bind_method(_MD("set_skeleton_path","skeleton_path:NodePath"),&MeshInstance::set_skeleton_path);
+	ObjectTypeDB::bind_method(_MD("get_skeleton_path:NodePath"),&MeshInstance::get_skeleton_path);
 	ObjectTypeDB::bind_method(_MD("get_aabb"),&MeshInstance::get_aabb);
 	ObjectTypeDB::bind_method(_MD("create_trimesh_collision"),&MeshInstance::create_trimesh_collision);
 	ObjectTypeDB::set_method_flags("MeshInstance","create_trimesh_collision",METHOD_FLAGS_DEFAULT|METHOD_FLAG_EDITOR);
 	ObjectTypeDB::bind_method(_MD("create_convex_collision"),&MeshInstance::create_convex_collision);
 	ObjectTypeDB::set_method_flags("MeshInstance","create_convex_collision",METHOD_FLAGS_DEFAULT|METHOD_FLAG_EDITOR);
 	ADD_PROPERTY( PropertyInfo( Variant::OBJECT, "mesh/mesh", PROPERTY_HINT_RESOURCE_TYPE, "Mesh" ), _SCS("set_mesh"), _SCS("get_mesh"));
-	
-	
+	ADD_PROPERTY( PropertyInfo (Variant::NODE_PATH, "mesh/skeleton"), _SCS("set_skeleton_path"), _SCS("get_skeleton_path"));
 }
 
 MeshInstance::MeshInstance()
 {
+	skeleton_path=NodePath("..");
 }
 
 

--- a/scene/3d/mesh_instance.h
+++ b/scene/3d/mesh_instance.h
@@ -40,6 +40,7 @@ class MeshInstance : public GeometryInstance {
 	OBJ_TYPE( MeshInstance, GeometryInstance );
 	
 	Ref<Mesh> mesh;
+	NodePath skeleton_path;
 
 	struct MorphTrack {
 
@@ -50,6 +51,7 @@ class MeshInstance : public GeometryInstance {
 
 	Map<StringName,MorphTrack> morph_tracks;
 
+	void _resolve_skeleton_path();
 
 protected:
 
@@ -57,12 +59,15 @@ protected:
 	bool _get(const StringName& p_name,Variant &r_ret) const;
 	void _get_property_list( List<PropertyInfo> *p_list) const;
 
-	
+	void _notification(int p_what);
 	static void _bind_methods();
 public:
 
 	void set_mesh(const Ref<Mesh>& p_mesh);
 	Ref<Mesh> get_mesh() const;
+
+	void set_skeleton_path(const NodePath& p_skeleton);
+	NodePath get_skeleton_path();
 	
 	Node* create_trimesh_collision_node();
 	void create_trimesh_collision();

--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -65,10 +65,12 @@ void VisualInstance::_notification(int p_what) {
 
 				VisualServer::get_singleton()->instance_set_room(instance,room->get_instance());
 			}
-			// CHECK SKELETON
+			// CHECK SKELETON => moving skeleton attaching logic to MeshInstance
+			/*
 			Skeleton *skeleton=get_parent()?get_parent()->cast_to<Skeleton>():NULL;
 			if (skeleton)
 				VisualServer::get_singleton()->instance_attach_skeleton( instance, skeleton->get_skeleton() );
+			*/
 
 			VisualServer::get_singleton()->instance_set_scenario( instance, get_world()->get_scenario() );
 


### PR DESCRIPTION
-  to decouple mesh->skeleton from child parent constraint
- default to ".." for compatibility
- make swapping skeleton in run-time easier
