### PR TITLE
Fix script editor scrollbar disappear issue

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -336,7 +336,7 @@ void TextEdit::_update_scrollbars() {
 		v_scroll->set_val(cursor.line_ofs);
 
 	}  else {
-
+		cursor.line_ofs = 0;
 		v_scroll->hide();
 	}
 


### PR DESCRIPTION
- Fix issue #423
- Fix issue #427
- When v_scroll is hiding in text editor, make sure line offset is always 0
