### PR TITLE
Add 2d unifrom scale

### DIFF
--- a/tools/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/tools/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1058,7 +1058,8 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 			Vector2 begin=local_rect.pos;
 			Vector2 end=local_rect.pos+local_rect.size;
 			Vector2 minsize = canvas_item->edit_get_minimum_size();
-			bool symmetric=m.mod.shift;
+			bool uniform = m.mod.shift;
+			bool symmetric=m.mod.alt;
 
 
 			switch(drag) {
@@ -1078,10 +1079,19 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 				} break;
 				case DRAG_BOTTOM_RIGHT: {
 
+					if (uniform) {
+						drag_vector.y=drag_vector.x;
+						minsize.y=minsize.x;
+					}
 					incend(begin.x,end.x,drag_vector.x,minsize.x,symmetric);
 					incend(begin.y,end.y,drag_vector.y,minsize.y,symmetric);
-				} break;
+				} break;				
 				case DRAG_TOP_LEFT: {
+
+					if (uniform) {
+						drag_vector.y=drag_vector.x;
+						minsize.y=minsize.x;
+					}
 					incbeg(begin.x,end.x,drag_vector.x,minsize.x,symmetric);
 					incbeg(begin.y,end.y,drag_vector.y,minsize.y,symmetric);
 				} break;
@@ -1097,12 +1107,20 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 				} break;
 				case DRAG_TOP_RIGHT: {
 
+					if (uniform) {
+						drag_vector.x=-drag_vector.y;
+						minsize.x=minsize.y;
+					}
 					incbeg(begin.y,end.y,drag_vector.y,minsize.y,symmetric);
 					incend(begin.x,end.x,drag_vector.x,minsize.x,symmetric);
 
 				} break;
 				case DRAG_BOTTOM_LEFT: {
 
+					if (uniform) {
+						drag_vector.x=-drag_vector.y;
+						minsize.x=minsize.y;
+					}
 					incbeg(begin.x,end.x,drag_vector.x,minsize.x,symmetric);
 					incend(begin.y,end.y,drag_vector.y,minsize.y,symmetric);
 				} break;


### PR DESCRIPTION
User usually expect "shift" key to be the modify key for unifrom scale:

![](http://i57.tinypic.com/2cwpok1.jpg)
A sprite to sclae

![](http://i61.tinypic.com/1zn6i3c.jpg)
Hold "Shift" and dragging corner to scale it uniformly

Godot's old "shift" symmetric scale behavior is keeped by using "Alt" key:

![](http://i58.tinypic.com/2is8mjo.jpg)
Hold "Shift" + "Alt" and dragging corner to scale it uniformly from center
