### PR TITLE
added XClassHint to windows in OS_X11::initialize

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -204,6 +204,20 @@ void OS_X11::initialize(const VideoMode& p_desired,int p_video_driver,int p_audi
 
 	XChangeWindowAttributes(x11_display, x11_window,CWEventMask,&new_attr);
 	
+    XClassHint* classHint;
+
+    /* set the titlebar name */
+    XStoreName(x11_display, x11_window, "Godot");
+
+    /* set the name and class hints for the window manager to use */
+    classHint = XAllocClassHint();
+    if (classHint) {
+        classHint->res_name = "Godot";
+        classHint->res_class = "Godot";
+    }
+    XSetClassHint(x11_display, x11_window, classHint);
+    XFree(classHint);
+
 	wm_delete = XInternAtom(x11_display, "WM_DELETE_WINDOW", true);	
 	XSetWMProtocols(x11_display, x11_window, &wm_delete, 1);
 		


### PR DESCRIPTION
added XClassHint to windows in OS_X11::initialize for improved window management in x11.

This actually makes godot show up in Cairo Dock where it wasn't properly before.
