### PR TITLE
Use cStringIO to write editor_icons.cpp

### DIFF
--- a/tools/editor/icons/SCsub
+++ b/tools/editor/icons/SCsub
@@ -3,13 +3,15 @@ Import('env')
 def make_editor_icons_action(target, source, env):
 
 	import os
+	import cStringIO
 
 	dst = target[0].srcnode().abspath
 	pixmaps = source
+
+	s = cStringIO.StringIO()
 	
-	f = open(dst,"wb")
-	f.write("#include \"editor_icons.h\"\n\n")
-	f.write("#include \"scene/resources/theme.h\"\n\n")
+	s.write("#include \"editor_icons.h\"\n\n")
+	s.write("#include \"scene/resources/theme.h\"\n\n")
 
 	for x in pixmaps:
 	
@@ -17,37 +19,41 @@ def make_editor_icons_action(target, source, env):
 		var_str=os.path.basename(x)[:-4]+"_png";
 		#print(var_str)
 		
-		f.write("static const unsigned char "+ var_str +"[]={\n");
+		s.write("static const unsigned char "+ var_str +"[]={\n");
 		
 		pngf=open(x,"rb");
 		
 		b=pngf.read(1);
 		while(len(b)==1):
-			f.write(hex(ord(b)))
+			s.write(hex(ord(b)))
 			b=pngf.read(1);
 			if (len(b)==1):
-				f.write(",")
+				s.write(",")
 				
-		f.write("\n};\n\n\n");
+		s.write("\n};\n\n\n");
 		pngf.close();
 	  
-	f.write("static Ref<ImageTexture> make_icon(const uint8_t* p_png) {\n")
-	f.write("\tRef<ImageTexture> texture( memnew( ImageTexture ) );\n")
-	f.write("\ttexture->create_from_image( Image(p_png),ImageTexture::FLAG_FILTER );\n")
-	f.write("\treturn texture;\n")
-	f.write("}\n\n")
+	s.write("static Ref<ImageTexture> make_icon(const uint8_t* p_png) {\n")
+	s.write("\tRef<ImageTexture> texture( memnew( ImageTexture ) );\n")
+	s.write("\ttexture->create_from_image( Image(p_png),ImageTexture::FLAG_FILTER );\n")
+	s.write("\treturn texture;\n")
+	s.write("}\n\n")
 
-	f.write("void editor_register_icons(Ref<Theme> p_theme) {\n\n")
+	s.write("void editor_register_icons(Ref<Theme> p_theme) {\n\n")
 
 	for x in pixmaps:
 	
 		x=os.path.basename(str(x))
 		type=x[5:-4].title().replace("_","");
 		var_str=x[:-4]+"_png";
-		f.write("\tp_theme->set_icon(\""+type+"\",\"EditorIcons\",make_icon("+var_str+"));\n");
+		s.write("\tp_theme->set_icon(\""+type+"\",\"EditorIcons\",make_icon("+var_str+"));\n");
 
-	f.write("\n\n}\n\n");
+	s.write("\n\n}\n\n");
+	
+	f = open(dst,"wb")
+	f.write(s.getvalue())
 	f.close()
+	s.close()
 
 make_editor_icons_builder = Builder(action=make_editor_icons_action,
 							suffix = '.cpp',


### PR DESCRIPTION
- Multiple jobs might try to access editor_icons.cpp when sCons is updating it. cStringIO helps to  minimize the blocking window, hence lower the chance getting file access conflict error when building with multiple jobs
