### PR TITLE
Return an error code when address/port already in use

### DIFF
--- a/drivers/unix/tcp_server_posix.cpp
+++ b/drivers/unix/tcp_server_posix.cpp
@@ -93,6 +93,9 @@ Error TCPServerPosix::listen(uint16_t p_port,const List<String> *p_accepted_host
 			close(sockfd);
 			ERR_FAIL_V(FAILED);
 		};
+	}
+	else {
+		return ERR_ALREADY_IN_USE;
 	};
 
 	if (listen_sockfd != -1) {

--- a/platform/windows/tcp_server_winsock.cpp
+++ b/platform/windows/tcp_server_winsock.cpp
@@ -86,6 +86,9 @@ Error TCPServerWinsock::listen(uint16_t p_port,const List<String> *p_accepted_ho
 			closesocket(sockfd);
 			ERR_FAIL_V(FAILED);
 		};
+	}
+	else {
+		return ERR_ALREADY_IN_USE;
 	};
 
 	if (listen_sockfd != INVALID_SOCKET) {


### PR DESCRIPTION
This should fix okamstudio/godot#474
