### PR TITLE
FIX: forgotten bind to get_available_packet_count to be able to call get...

### DIFF
--- a/core/io/packet_peer.cpp
+++ b/core/io/packet_peer.cpp
@@ -112,6 +112,7 @@ void PacketPeer::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("get_var"),&PacketPeer::_bnd_get_var);
 	ObjectTypeDB::bind_method(_MD("put_var", "var:Variant"),&PacketPeer::put_var);
+	ObjectTypeDB::bind_method(_MD("get_available_packet_count"),&PacketPeer::get_available_packet_count);
 };
 
 /***************/


### PR DESCRIPTION
..._var only if needed and avoid editor errors (Closes: #480)
