### PR TITLE
Fix node rename problem

### DIFF
--- a/tools/editor/scene_tree_editor.cpp
+++ b/tools/editor/scene_tree_editor.cpp
@@ -503,20 +503,28 @@ void SceneTreeEditor::_rename_node(ObjectID p_node,const String& p_name) {
 void SceneTreeEditor::_renamed() {
 
 	TreeItem *which=tree->get_edited();
-	
+
 	ERR_FAIL_COND(!which);
 	NodePath np = which->get_metadata(0);
 	Node *n=get_node(np);
 	ERR_FAIL_COND(!n);
 
+	String new_name=which->get_text(0);
+	if (new_name.find(".") != -1 || new_name.find("/") != -1) {
+
+		error->set_text(_TR("Invalid node name, contain illegal character(s):\n ('.', '/')"));
+		error->popup_centered_minsize(Size2(400,80));
+		new_name=n->get_name();
+	}
+
 	if (!undo_redo) {
-		n->set_name( which->get_text(0) );
+		n->set_name( new_name );
 		which->set_metadata(0,n->get_path());
 		emit_signal("node_renamed");
 	} else {
 		undo_redo->create_action("Rename Node");
-		emit_signal("node_prerename",n,which->get_text(0));
-		undo_redo->add_do_method(this,"_rename_node",n->get_instance_ID(),which->get_text(0));
+		emit_signal("node_prerename",n,new_name);
+		undo_redo->add_do_method(this,"_rename_node",n->get_instance_ID(),new_name);
 		undo_redo->add_undo_method(this,"_rename_node",n->get_instance_ID(),n->get_name());
 		undo_redo->commit_action();
 	}


### PR DESCRIPTION
If rename node to '.' or '..', will cause problems
1、rename node to '.'
2、rename this node again
3、node's parent name changed
4、remove this node
5、node's parent has removed...

And not recommended use '/' for node name
