### PR TITLE
Expose physics 2d sleep threshold to project setting

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -375,7 +375,10 @@ void RigidBody2D::_direct_state_changed(Object *p_state) {
 		set_global_transform(state->get_transform());
 	linear_velocity=state->get_linear_velocity();
 	angular_velocity=state->get_angular_velocity();
-	active=!state->is_sleeping();
+	bool is_active = !state->is_sleeping();
+	if (active != is_active)
+		emit_signal("active_state_changed", is_active);
+	active=is_active;
 	if (get_script_instance())
 		get_script_instance()->call("_integrate_forces",state);
 	set_block_transform_notify(false); // want it back
@@ -527,9 +530,10 @@ bool RigidBody2D::is_using_custom_integrator(){
 
 void RigidBody2D::set_active(bool p_active) {
 
+	if (active != p_active)
+		emit_signal("active_state_changed", p_active);
 	active=p_active;
 	Physics2DServer::get_singleton()->body_set_state(get_rid(),Physics2DServer::BODY_STATE_SLEEPING,!active);
-
 }
 
 void RigidBody2D::set_can_sleep(bool p_active) {
@@ -687,6 +691,7 @@ void RigidBody2D::_bind_methods() {
 	ADD_SIGNAL( MethodInfo("body_exit_shape",PropertyInfo(Variant::INT,"body_id"),PropertyInfo(Variant::OBJECT,"body"),PropertyInfo(Variant::INT,"body_shape"),PropertyInfo(Variant::INT,"local_shape")));
 	ADD_SIGNAL( MethodInfo("body_enter",PropertyInfo(Variant::OBJECT,"body")));
 	ADD_SIGNAL( MethodInfo("body_exit",PropertyInfo(Variant::OBJECT,"body")));
+	ADD_SIGNAL( MethodInfo("active_state_changed",PropertyInfo(Variant::BOOL,"active")));
 
 	BIND_CONSTANT( MODE_STATIC );
 	BIND_CONSTANT( MODE_KINEMATIC );

--- a/scene/resources/world_2d.cpp
+++ b/scene/resources/world_2d.cpp
@@ -368,7 +368,9 @@ World2D::World2D() {
 	Physics2DServer::get_singleton()->space_set_param(space,Physics2DServer::SPACE_PARAM_CONTACT_RECYCLE_RADIUS,1.0);
 	Physics2DServer::get_singleton()->space_set_param(space,Physics2DServer::SPACE_PARAM_CONTACT_MAX_SEPARATION,1.5);
 	Physics2DServer::get_singleton()->space_set_param(space,Physics2DServer::SPACE_PARAM_BODY_MAX_ALLOWED_PENETRATION,0.3);
-	Physics2DServer::get_singleton()->space_set_param(space,Physics2DServer::SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_TRESHOLD,2);
+	Physics2DServer::get_singleton()->space_set_param(space,Physics2DServer::SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_TRESHOLD,GLOBAL_DEF("physics_2d/sleep_threshold_linear",2));
+	Physics2DServer::get_singleton()->space_set_param(space,Physics2DServer::SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_TRESHOLD,GLOBAL_DEF("physics_2d/sleep_threshold_angular",(8.0 / 180.0 * Math_PI)));
+	Physics2DServer::get_singleton()->space_set_param(space,Physics2DServer::SPACE_PARAM_BODY_TIME_TO_SLEEP,GLOBAL_DEF("physics_2d/time_to_sleep",0.5));
 	Physics2DServer::get_singleton()->space_set_param(space,Physics2DServer::SPACE_PARAM_BODY_ANGULAR_VELOCITY_DAMP_RATIO,20);
 	Physics2DServer::get_singleton()->space_set_param(space,Physics2DServer::SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS,0.2);
 

--- a/servers/physics/space_sw.cpp
+++ b/servers/physics/space_sw.cpp
@@ -405,9 +405,9 @@ SpaceSW::SpaceSW() {
 	contact_max_allowed_penetration= 0.01;
 
 	constraint_bias = 0.01;
-	body_linear_velocity_sleep_threshold=GLOBAL_DEF("physics/sleep_threshold_linear",0.1);
-	body_angular_velocity_sleep_threshold=GLOBAL_DEF("physics/sleep_threshold_angular", (8.0 / 180.0 * Math_PI) );
-	body_time_to_sleep=0.5;
+	body_linear_velocity_sleep_threshold=GLOBAL_DEF("physics_3d/sleep_threshold_linear",0.1);
+	body_angular_velocity_sleep_threshold=GLOBAL_DEF("physics_3d/sleep_threshold_angular", (8.0 / 180.0 * Math_PI) );
+	body_time_to_sleep=GLOBAL_DEF("physics_3d/time_to_sleep", 0.5);
 	body_angular_velocity_damp_ratio=10;
 
 


### PR DESCRIPTION
- Expose physics 2d sleep threshold to project setting
- Add active_state_changed signal to RigiBody2D for easy sleep state monitoring; 
- Move physics 3d sleep threshold to physics_3d group in project setting
