### PR TITLE
Fixed resource name not updated when saved in resurce dock

### DIFF
--- a/tools/editor/resources_dock.cpp
+++ b/tools/editor/resources_dock.cpp
@@ -224,6 +224,7 @@ void ResourcesDock::_file_action(const String& p_path) {
 
 			save_resource(p_path,res);
 
+			_update_name(ti);
 
 		} break;
 


### PR DESCRIPTION
- by enforcing resource name been updated in "save" or "save as" action
