### PR TITLE
Fix bug help history overwrote by tree item selected call back

### DIFF
--- a/tools/editor/editor_help.cpp
+++ b/tools/editor/editor_help.cpp
@@ -406,7 +406,6 @@ void EditorHelp::_class_list_select(const String& p_select) {
 void EditorHelp::_class_desc_select(const String& p_select) {
 
 	if (p_select.begins_with("#")) {
-
 		_goto_desc(p_select.substr(1,p_select.length()));
 		return;
 	} else if (p_select.begins_with("@")) {
@@ -469,9 +468,11 @@ Error EditorHelp::_goto_desc(const String& p_class,bool p_update_history,int p_v
 
 
 	if (tree_item_map.has(p_class)) {
+		select_locked = true;
 		tree_item_map[p_class]->select(0);
 		class_list->ensure_cursor_is_visible();
 	}
+
 	class_desc->show();
 	//tabs->set_current_tab(PAGE_CLASS_DESC);
 	edited_class->set_pressed(true);
@@ -497,7 +498,6 @@ Error EditorHelp::_goto_desc(const String& p_class,bool p_update_history,int p_v
 
 	class_desc->clear();
 	method_line.clear();
-
 	edited_class->set_text(p_class);
 	//edited_class->show();
 
@@ -870,7 +870,7 @@ Error EditorHelp::_goto_desc(const String& p_class,bool p_update_history,int p_v
 	return OK;
 }
 
-void EditorHelp::_request_help(const String& p_string) {	
+void EditorHelp::_request_help(const String& p_string) {
 	Error err = _goto_desc(p_string);
 	if (err==OK) {
 		editor->call("_editor_select",3);
@@ -1231,8 +1231,10 @@ void EditorHelp::_notification(int p_what) {
 
 void EditorHelp::_tree_item_selected() {
 
-	if (select_locked)
+	if (select_locked) {
+		select_locked = false;
 		return;
+	}
 	TreeItem *s=class_list->get_selected();
 	if (!s)
 		return;
@@ -1280,7 +1282,6 @@ EditorHelp::EditorHelp(EditorNode *p_editor) {
 	edited_class->hide();
 	b->set_toggle_mode(true);
 	b->connect("pressed",this,"_button_pressed",make_binds(PAGE_CLASS_DESC));
-	edited_class->hide();
 
 	b = memnew( Button );
 	b->set_text("Search in Classes");


### PR DESCRIPTION
- Fixed the bug by making sure "_tree_item_selected" not get invoked when selecting class by code
- The bug will crash the editor which is not supposed to. ( It should only mesh up help history ) It might worth further investigation in case deeper bug is hidden.
- Crash happened at line: 

```
if (p_class==edited_class->get_text())
```
