### PR TITLE
Fix ERROR: FileAccessWindows::_get_modified_time:  Method/Function Failed on windows

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -2263,6 +2263,8 @@ void EditorNode::_menu_option_confirm(int p_option,bool p_confirmed) {
 
 				if (!E->get()->can_reload_from_file())
 					continue;
+				if (!FileAccess::exists(E->get()->get_path()))
+					continue;
 				uint64_t mt = FileAccess::get_modified_time(E->get()->get_path());
 				if (mt!=E->get()->get_last_modified_time()) {
 					E->get()->reload_from_file();


### PR DESCRIPTION
- Adding file exist check before trying to get resource modified time when editor gaining focus
