### PR TITLE
Fixed issue #429: in scene tab, clicking on some instance folder, change all the others views

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -2730,10 +2730,10 @@ Error EditorNode::load_scene(const String& p_scene) {
 	}
 */
 	set_edited_scene(new_scene);
-	scene_tree_dock->set_selected(new_scene);
+	_get_scene_metadata();
+	scene_tree_dock->set_selected(new_scene, true);
 	property_editor->edit(new_scene);
 	scene_import_metadata = sdata->get_import_metadata();
-	_get_scene_metadata();
 
 	editor_data.get_undo_redo().clear_history();
 	saved_version=editor_data.get_undo_redo().get_version();


### PR DESCRIPTION
- Fix issue #429
- Script editor plugin try to restore state after sub-scene loaded, if there were scripts opened, will trigger loading resource and will make script tab visible. Solved it by select scene node after restoring plugins' state
