### PR TITLE
Fixed #553: Disable 3D nodes for smaller executable

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -276,7 +276,7 @@ void Viewport::_notification(int p_what) {
 
 		} break;
 		case NOTIFICATION_READY: {
-
+#ifndef _3D_DISABLED
 			if (cameras.size() && !camera) {
 				//there are cameras but no current camera, pick first in tree and make it current
 				Camera *first=NULL;
@@ -290,6 +290,7 @@ void Viewport::_notification(int p_what) {
 				if (first)
 					first->make_current();
 			}
+#endif
 		} break;
 		case NOTIFICATION_EXIT_SCENE: {
 

--- a/scene/resources/world.cpp
+++ b/scene/resources/world.cpp
@@ -225,17 +225,22 @@ struct SpatialIndexer {
 
 void World::_register_camera(Camera* p_camera) {
 
+#ifndef _3D_DISABLED
 	indexer->_add_camera(p_camera);
+#endif
 }
 
 void World::_update_camera(Camera* p_camera){
 
+#ifndef _3D_DISABLED
 	indexer->_update_camera(p_camera);
-
+#endif
 }
 void World::_remove_camera(Camera* p_camera){
 
+#ifndef _3D_DISABLED
 	indexer->_remove_camera(p_camera);
+#endif
 }
 
 
@@ -243,26 +248,31 @@ void World::_remove_camera(Camera* p_camera){
 
 void World::_register_notifier(VisibilityNotifier* p_notifier,const AABB& p_rect){
 
-
+#ifndef _3D_DISABLED
 	indexer->_notifier_add(p_notifier,p_rect);
+#endif
 }
 
 void World::_update_notifier(VisibilityNotifier* p_notifier,const AABB& p_rect){
 
-
+#ifndef _3D_DISABLED
 	indexer->_notifier_update(p_notifier,p_rect);
+#endif
 }
 
 void World::_remove_notifier(VisibilityNotifier* p_notifier){
 
-
+#ifndef _3D_DISABLED
 	indexer->_notifier_remove(p_notifier);
+#endif
 }
 
 
 void World::_update(uint64_t p_frame) {
 
+#ifndef _3D_DISABLED
 	indexer->_update(p_frame);
+#endif
 }
 
 


### PR DESCRIPTION
- Fix issue #553
- Please make sure following flags are added for successful build

disable_3d=yes module_gridmap_enabled=no tools=no
