### PR TITLE
Add CollapsibleVSeparator for easy hide/show groups of menu toolbuttons

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -186,11 +186,13 @@ void BaseButton::_notification(int p_what) {
 	if (p_what==NOTIFICATION_MOUSE_ENTER) {
 	
 		status.hovering=true;
+		emit_signal("hovered",true);
 		update();
 	}
 	
 	if (p_what==NOTIFICATION_MOUSE_EXIT) {
 		status.hovering=false;
+		emit_signal("hovered",false);
 		update();
 	}	
 	if (p_what==NOTIFICATION_FOCUS_EXIT) {
@@ -351,6 +353,7 @@ void BaseButton::_bind_methods() {
 
 	ADD_SIGNAL( MethodInfo("pressed" ) );
 	ADD_SIGNAL( MethodInfo("toggled", PropertyInfo( Variant::BOOL,"pressed") ) );
+	ADD_SIGNAL( MethodInfo("hovered", PropertyInfo( Variant::BOOL,"hovering") ) );
 	ADD_PROPERTY( PropertyInfo( Variant::BOOL, "disabled"), _SCS("set_disabled"), _SCS("is_disabled"));
 	ADD_PROPERTY( PropertyInfo( Variant::BOOL, "toggle_mode"), _SCS("set_toggle_mode"), _SCS("is_toggle_mode"));
 	ADD_PROPERTY( PropertyInfo( Variant::BOOL, "click_on_press"), _SCS("set_click_on_press"), _SCS("get_click_on_press"));

--- a/scene/gui/separator.cpp
+++ b/scene/gui/separator.cpp
@@ -123,16 +123,9 @@ void CollapsibleVSeparator::_notification(int p_what) {
 
 		RID ci = get_canvas_item();
 
-		Color color(1,1,1);
-
-		if (collapsed) {
-			color.a = 0.7f;
-		} else {
-			color.a = 0.4f;
-		}
-
-		if (hovering)
-			color = Color(.9,.9,0,0.7f);
+		Color color = hovering ?
+			get_color("color_hover"):
+			(collapsed ? get_color("color_collapsed") : get_color("color_expanded"));
 
 		Size2 handle(MIN(3,size.width), size.height*0.33f);
 		Point2 ofs((size.width-handle.width)/2, (size.height-handle.height)/2);

--- a/scene/gui/separator.cpp
+++ b/scene/gui/separator.cpp
@@ -79,3 +79,86 @@ VSeparator::VSeparator() {
 
 	orientation=VERTICAL;
 }
+
+Size2 CollapsibleVSeparator::get_minimum_size() const {
+
+	return Size2(5,get_constant("separation"));
+}
+
+void CollapsibleVSeparator::add_control(Control *p_control) {
+	controls.push_back(p_control);
+}
+
+void CollapsibleVSeparator::remove_control(Control *p_control) {
+	controls.erase(p_control);
+}
+
+void CollapsibleVSeparator::set_collapsed(bool p_collapsed) {
+
+	toggle_button->set_pressed(p_collapsed);
+
+	collapsed = p_collapsed;
+	for (List<Control *>::Element *E = controls.front(); E; E=E->next()) {
+		if (collapsed)
+			E->get()->hide();
+		else
+			E->get()->show();
+	}
+	update();
+}
+
+void CollapsibleVSeparator::_on_hovered(bool p_hovered) {
+
+	hovering = p_hovered;
+	update();
+}
+
+void CollapsibleVSeparator::_notification(int p_what) {
+
+	if (p_what==NOTIFICATION_DRAW) {
+
+		Size2i size = get_size();
+		if (size.width==0 || size.height==0)
+			return;
+
+		RID ci = get_canvas_item();
+
+		Color color(1,1,1);
+
+		if (collapsed) {
+			color.a = 0.7f;
+		} else {
+			color.a = 0.4f;
+		}
+
+		if (hovering)
+			color = Color(.9,.9,0,0.7f);
+
+		Size2 handle(MIN(3,size.width), size.height*0.33f);
+		Point2 ofs((size.width-handle.width)/2, (size.height-handle.height)/2);
+
+		draw_rect(Rect2(ofs,handle),color);
+	}
+}
+
+void CollapsibleVSeparator::_bind_methods() {
+
+	ObjectTypeDB::bind_method(_MD("add_control","control"), &CollapsibleVSeparator::add_control);
+	ObjectTypeDB::bind_method(_MD("remove_control","control"), &CollapsibleVSeparator::remove_control);
+	ObjectTypeDB::bind_method(_MD("set_collapsed"), &CollapsibleVSeparator::set_collapsed);
+	ObjectTypeDB::bind_method(_MD("_on_hovered"), &CollapsibleVSeparator::_on_hovered);
+}
+
+CollapsibleVSeparator::CollapsibleVSeparator() {
+
+	collapsed = false;
+	hovering=false;
+
+	toggle_button = memnew(BaseButton);
+	toggle_button->set_toggle_mode(true);
+	toggle_button->set_area_as_parent_rect();
+	toggle_button->connect("toggled", this, "set_collapsed");
+	toggle_button->connect("hovered", this, "_on_hovered");
+	add_child(toggle_button);
+
+}

--- a/scene/gui/separator.h
+++ b/scene/gui/separator.h
@@ -34,6 +34,8 @@
 */
 
 #include "scene/gui/control.h"
+#include "scene/gui/base_button.h"
+
 class Separator : public Control {
 
 	OBJ_TYPE( Separator, Control );
@@ -45,7 +47,7 @@ protected:
 	void _notification(int p_what);
 public:
 
-	virtual Size2 get_minimum_size() const;;
+	virtual Size2 get_minimum_size() const;
 
 	Separator();
 	~Separator();
@@ -69,6 +71,35 @@ class HSeparator : public Separator {
 public:
 
 	HSeparator();
+
+};
+
+class CollapsibleVSeparator : public VSeparator {
+
+	OBJ_TYPE( CollapsibleVSeparator, VSeparator );
+
+	List<Control *> controls;
+	BaseButton *toggle_button;
+
+	bool collapsed;
+	bool hovering;
+
+	void _on_hovered(bool p_hovered);
+
+protected:
+
+	static void _bind_methods();
+	void _notification(int p_what);
+
+public:
+
+	virtual Size2 get_minimum_size() const;
+
+	void set_collapsed(bool p_toggled);
+	void add_control(Control *p_control);
+	void remove_control(Control *p_control);
+
+	CollapsibleVSeparator();
 
 };
 

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -312,6 +312,7 @@ void register_scene_types() {
 	ObjectTypeDB::register_virtual_type<Separator>();
 	ObjectTypeDB::register_type<HSeparator>();
 	ObjectTypeDB::register_type<VSeparator>();
+	ObjectTypeDB::register_type<CollapsibleVSeparator>();
 	ObjectTypeDB::register_type<TextureButton>();
 	ObjectTypeDB::register_type<Container>();
 	ObjectTypeDB::register_virtual_type<BoxContainer>();

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -500,6 +500,10 @@ void make_default_theme() {
 	t->set_constant("separation","VSeparator", 7);
 	t->set_stylebox("separator","CollapsibleVSeparator", make_stylebox( hseparator_png,3,3,3,3) );
 	t->set_constant("separation","CollapsibleVSeparator", 7);
+	t->set_color("color_expanded","CollapsibleVSeparator", Color(1.0,1.0,1.0,0.3));
+	t->set_color("color_collapsed","CollapsibleVSeparator", Color(1.0,1.0,1.0,0.7));
+	t->set_color("color_hover","CollapsibleVSeparator", control_font_color_hover);
+
 
 	t->set_icon("close","Icons", make_icon(icon_close_png));
 	t->set_font("source","Fonts", source_font);

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -498,6 +498,8 @@ void make_default_theme() {
 	t->set_constant("separation","HSeparator", 7);
 	t->set_stylebox("separator","VSeparator", make_stylebox( hseparator_png,3,3,3,3) );
 	t->set_constant("separation","VSeparator", 7);
+	t->set_stylebox("separator","CollapsibleVSeparator", make_stylebox( hseparator_png,3,3,3,3) );
+	t->set_constant("separation","CollapsibleVSeparator", 7);
 
 	t->set_icon("close","Icons", make_icon(icon_close_png));
 	t->set_font("source","Fonts", source_font);


### PR DESCRIPTION
Normal:
![](http://i62.tinypic.com/2rc23y1.jpg)

Hovered:
![](http://i61.tinypic.com/250mhb8.jpg)

Pressed:
![](http://i57.tinypic.com/2dhzbdx.jpg)
