### PR TITLE
Add option to NOT pause iOS game execution when resigning active

### DIFF
--- a/platform/iphone/app_delegate.mm
+++ b/platform/iphone/app_delegate.mm
@@ -269,7 +269,8 @@ static int frame_count = 0;
 - (void) applicationWillResignActive:(UIApplication *)application
 {
 	printf("********************* will resign active\n");
-	[view_controller.view stopAnimation]; // FIXME: pause seems to be recommended elsewhere
+	if (Globals::get_singleton() && GLOBAL_DEF("ios/pause_when_resign_active", true))
+		[view_controller.view stopAnimation]; // FIXME: pause seems to be recommended elsewhere
 }
 
 - (void) applicationDidBecomeActive:(UIApplication *)application


### PR DESCRIPTION
- If there's "ios/ios/pause_when_resign_active" project setting as false, then game execution will not be paused until it's actually entered background
- Player can still see game been updated when they're doing fast app switching
