### PR TITLE
Add editor setting: Manipulator Gizmo Opacity

### DIFF
--- a/tools/editor/plugins/spatial_editor_plugin.cpp
+++ b/tools/editor/plugins/spatial_editor_plugin.cpp
@@ -2800,11 +2800,13 @@ void SpatialEditor::_init_indicators() {
 		//move gizmo
 
 
+		float gizmo_alph = EditorSettings::get_singleton()->get("3d_editor/manipulator_gizmo_opacity");
+
 		gizmo_hl = Ref<FixedMaterial>( memnew( FixedMaterial ) );
 		gizmo_hl->set_flag(Material::FLAG_UNSHADED, true);
 		gizmo_hl->set_flag(Material::FLAG_ONTOP, true);
 		gizmo_hl->set_fixed_flag(FixedMaterial::FLAG_USE_ALPHA, true);
-		gizmo_hl->set_parameter(FixedMaterial::PARAM_DIFFUSE,Color(1,1,1,0.4));
+		gizmo_hl->set_parameter(FixedMaterial::PARAM_DIFFUSE,Color(1,1,1,gizmo_alph+0.2f));
 
 		for(int i=0;i<3;i++) {
 
@@ -2818,7 +2820,7 @@ void SpatialEditor::_init_indicators() {
 			mat->set_fixed_flag(FixedMaterial::FLAG_USE_ALPHA, true);
 			Color col;
 			col[i]=1.0;
-			col.a=0.2;
+			col.a= gizmo_alph;
 			mat->set_parameter(FixedMaterial::PARAM_DIFFUSE,col);
 			gizmo_color[i]=mat;
 
@@ -3507,6 +3509,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 
 	EDITOR_DEF("3d_editor/manipulator_gizmo_size",80);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT,"3d_editor/manipulator_gizmo_size",PROPERTY_HINT_RANGE,"16,1024,1"));
+	EDITOR_DEF("3d_editor/manipulator_gizmo_opacity",0.2);
 
 	over_gizmo_handle=-1;
 }


### PR DESCRIPTION
Sometimes it might be difficult to tell where's exactly the gizmo
![](http://i60.tinypic.com/nfl0kg.jpg)

New Manipulator Gizmo Opacity setting:
![](http://i62.tinypic.com/15wm7tz.jpg)

Set Manipulator Gizmo Opacity  to 0.8:
![](http://i58.tinypic.com/24euck8.jpg)
