### PR TITLE
Fixed failed to connect to remote debugger with -rdebug will crash engine

### DIFF
--- a/core/script_language.h
+++ b/core/script_language.h
@@ -246,7 +246,7 @@ public:
 	virtual void set_request_scene_tree_message_func(RequestSceneTreeMessageFunc p_func, void *p_udata) {}
 
 	ScriptDebugger();
-	virtual ~ScriptDebugger() {}
+	virtual ~ScriptDebugger() {singleton=NULL;}
 
 };
 


### PR DESCRIPTION
ScriptDebuggerRemote instance is created and assigned to ScriptDebugger::singleton and will deleted when connection failed; Make sure it's set to NULL in destructor.
