### PR TITLE
Usability: don't switch to resource tab when switching to script tab

### DIFF
--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -1102,7 +1102,6 @@ void ScriptEditor::ensure_select_current() {
 		if (!ste)
 			return;
 		Ref<Script> script = ste->get_edited_script();
-		editor->call("_resource_selected",script);
 	}
 }
 


### PR DESCRIPTION
This simply disables switching to the Resource tab automatically when switching to the Script tab.

Yes, you will now have to click if you ever want to look at the Resource tab. But you no longer have to click every time you want to go back to look at your Scene tree, which is significantly more often, in my experience.

Thanks to Theo for this fix because I was too stupid to find it myself.
