### PR TITLE
fix custom export packages for PC

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -378,8 +378,8 @@ bool EditorExportPlatformAndroid::_get(const StringName& p_name,Variant &r_ret) 
 
 void EditorExportPlatformAndroid::_get_property_list( List<PropertyInfo> *p_list) const{
 
-	p_list->push_back( PropertyInfo( Variant::STRING, "custom_package/debug", PROPERTY_HINT_FILE,"apk"));
-	p_list->push_back( PropertyInfo( Variant::STRING, "custom_package/release", PROPERTY_HINT_FILE,"apk"));
+	p_list->push_back( PropertyInfo( Variant::STRING, "custom_package/debug", PROPERTY_HINT_GLOBAL_FILE,"apk"));
+	p_list->push_back( PropertyInfo( Variant::STRING, "custom_package/release", PROPERTY_HINT_GLOBAL_FILE,"apk"));
 	p_list->push_back( PropertyInfo( Variant::STRING, "command_line/extra_args"));
 	p_list->push_back( PropertyInfo( Variant::INT, "version/code", PROPERTY_HINT_RANGE,"1,65535,1"));
 	p_list->push_back( PropertyInfo( Variant::STRING, "version/name") );

--- a/platform/bb10/export/export.cpp
+++ b/platform/bb10/export/export.cpp
@@ -147,7 +147,7 @@ void EditorExportPlatformBB10::_get_property_list( List<PropertyInfo> *p_list) c
 	p_list->push_back( PropertyInfo( Variant::STRING, "package/name") );
 	p_list->push_back( PropertyInfo( Variant::STRING, "package/description",PROPERTY_HINT_MULTILINE_TEXT) );
 	p_list->push_back( PropertyInfo( Variant::STRING, "package/icon",PROPERTY_HINT_FILE,"png") );
-	p_list->push_back( PropertyInfo( Variant::STRING, "package/custom_template", PROPERTY_HINT_FILE,"zip"));
+	p_list->push_back( PropertyInfo( Variant::STRING, "package/custom_template", PROPERTY_HINT_GLOBAL_FILE,"zip"));
 	p_list->push_back( PropertyInfo( Variant::STRING, "release/author") );
 	p_list->push_back( PropertyInfo( Variant::STRING, "release/author_id") );
 

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -126,8 +126,8 @@ bool EditorExportPlatformJavaScript::_get(const StringName& p_name,Variant &r_re
 }
 void EditorExportPlatformJavaScript::_get_property_list( List<PropertyInfo> *p_list) const{
 
-	p_list->push_back( PropertyInfo( Variant::STRING, "custom_package/debug", PROPERTY_HINT_FILE,"zip"));
-	p_list->push_back( PropertyInfo( Variant::STRING, "custom_package/release", PROPERTY_HINT_FILE,"zip"));
+	p_list->push_back( PropertyInfo( Variant::STRING, "custom_package/debug", PROPERTY_HINT_GLOBAL_FILE,"zip"));
+	p_list->push_back( PropertyInfo( Variant::STRING, "custom_package/release", PROPERTY_HINT_GLOBAL_FILE,"zip"));
 	p_list->push_back( PropertyInfo( Variant::INT, "options/memory_size",PROPERTY_HINT_ENUM,"32mb,64mb,128mb,256mb,512mb,1024mb"));
 	p_list->push_back( PropertyInfo( Variant::BOOL, "browser/enable_run"));
 

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -138,8 +138,8 @@ bool EditorExportPlatformOSX::_get(const StringName& p_name,Variant &r_ret) cons
 }
 void EditorExportPlatformOSX::_get_property_list( List<PropertyInfo> *p_list) const{
 
-	p_list->push_back( PropertyInfo( Variant::STRING, "custom_package/debug", PROPERTY_HINT_FILE,"zip"));
-	p_list->push_back( PropertyInfo( Variant::STRING, "custom_package/release", PROPERTY_HINT_FILE,"zip"));
+	p_list->push_back( PropertyInfo( Variant::STRING, "custom_package/debug", PROPERTY_HINT_GLOBAL_FILE,"zip"));
+	p_list->push_back( PropertyInfo( Variant::STRING, "custom_package/release", PROPERTY_HINT_GLOBAL_FILE,"zip"));
 
 	p_list->push_back( PropertyInfo( Variant::STRING, "application/name") );
 	p_list->push_back( PropertyInfo( Variant::STRING, "application/info") );

--- a/tools/editor/editor_import_export.cpp
+++ b/tools/editor/editor_import_export.cpp
@@ -439,8 +439,8 @@ bool EditorExportPlatformPC::_get(const StringName& p_name,Variant &r_ret) const
 
 void EditorExportPlatformPC::_get_property_list( List<PropertyInfo> *p_list) const {
 
-	p_list->push_back( PropertyInfo( Variant::STRING, "custom_binary/debug", PROPERTY_HINT_FILE,binary_extension));
-	p_list->push_back( PropertyInfo( Variant::STRING, "custom_binary/release", PROPERTY_HINT_FILE,binary_extension));
+	p_list->push_back( PropertyInfo( Variant::STRING, "custom_binary/debug", PROPERTY_HINT_GLOBAL_FILE,binary_extension));
+	p_list->push_back( PropertyInfo( Variant::STRING, "custom_binary/release", PROPERTY_HINT_GLOBAL_FILE,binary_extension));
 	p_list->push_back( PropertyInfo( Variant::INT, "resources/pack_mode", PROPERTY_HINT_ENUM,"Single Exec.,Exec+Pack (.pck),Copy,Bundles (Optical)"));
 	p_list->push_back( PropertyInfo( Variant::BOOL, "binary/64_bits"));
 }
@@ -1009,15 +1009,15 @@ Error EditorExportPlatformPC::export_project(const String& p_path, bool p_debug,
 	String exe_path = EditorSettings::get_singleton()->get_settings_path()+"/templates/";
 	if (use64) {
 		if (p_debug)
-			exe_path+=custom_debug_binary!=""?custom_debug_binary:debug_binary64;
+			exe_path=custom_debug_binary!=""?custom_debug_binary:exe_path+debug_binary64;
 		else
-			exe_path+=custom_release_binary!=""?custom_release_binary:release_binary64;
+			exe_path=custom_release_binary!=""?custom_release_binary:exe_path+release_binary64;
 	} else {
 
 		if (p_debug)
-			exe_path+=custom_debug_binary!=""?custom_debug_binary:debug_binary32;
+			exe_path=custom_debug_binary!=""?custom_debug_binary:exe_path+debug_binary32;
 		else
-			exe_path+=custom_release_binary!=""?custom_release_binary:release_binary32;
+			exe_path=custom_release_binary!=""?custom_release_binary:exe_path+release_binary32;
 
 	}
 


### PR DESCRIPTION
this fixes the interface bug with adding "res://" into a path for Linux and Windows custom binary option fields.

it also allow custom templates to reside outside of res:// for all platforms. now there's no need to have separate copies of custom binaries for every project.
