### PR TITLE
Someone fixed compiling issue on Win

### DIFF
--- a/drivers/builtin_openssl2/crypto/o_str.c
+++ b/drivers/builtin_openssl2/crypto/o_str.c
@@ -63,7 +63,11 @@
 #if !defined(OPENSSL_IMPLEMENTS_strncasecmp) && \
     !defined(OPENSSL_SYSNAME_WIN32) && \
     !defined(NETWARE_CLIB)
-# include <strings.h>
+#ifdef _WIN32
+#include <string.h>
+#else
+#include <strings.h>
+#endif
 #endif
 
 int OPENSSL_strncasecmp(const char *str1, const char *str2, size_t n)

--- a/drivers/builtin_openssl2/openssl/rand.h
+++ b/drivers/builtin_openssl2/openssl/rand.h
@@ -64,6 +64,7 @@
 #include <openssl/e_os2.h>
 
 #if defined(OPENSSL_SYS_WINDOWS)
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #ifdef OCSP_RESPONSE
 #undef OCSP_RESPONSE


### PR DESCRIPTION
I'm not taking any credits, so I'm just going to paste Juans email.

"Subject: Bug fixes for godot windows compile

Comments:
 Hi, I found and fixed a couple of errors in the compilation of godot for
windows,
I'm using windows 8.1 and Visual Studio 2013 Update 3,

I changed rand.h in C:\godot-master\drivers\builtin_openssl2\openssl\rand.h
...
to avoid redefinition errors, and I changed C:\godot-master\drivers\builtin_openssl2\crypto\o_str.c
...
to use proper string for win32"
