### PR TITLE
Prevend timer from processing inside the editor

### DIFF
--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -36,7 +36,7 @@ void Timer::_notification(int p_what) {
 
 		case NOTIFICATION_READY: {
 
-			if (autostart)
+			if (!get_scene()->is_editor_hint() && autostart)
 				start();
 		} break;
 		case NOTIFICATION_PROCESS: {


### PR DESCRIPTION
If timer was set to autostart - it would start processing inside the editor. This patch prevends it from doing that.
