### PR TITLE
Export shape keys to .dae as geometry

### DIFF
--- a/tools/export/blender25/io_scene_dae/__init__.py
+++ b/tools/export/blender25/io_scene_dae/__init__.py
@@ -126,6 +126,10 @@ class ExportDAE(bpy.types.Operator, ExportHelper):
             default=True,
             options={'HIDDEN'},
             )
+    export_shapekeys = BoolProperty(
+            name="Export Shape Keys",
+            default=False,
+            )
    
     @property
     def check_extension(self):

--- a/tools/export/blender25/io_scene_dae/export_dae.py
+++ b/tools/export/blender25/io_scene_dae/export_dae.py
@@ -934,7 +934,7 @@ class DaeExporter:
 		if shapename==None:
 			for x in node.children:
 				self.export_node(x,il)
-			if node.type=="MESH":
+			if node.type=="MESH" and self.config["export_shapekeys"]:
 				for k in range(0,len(node.data.shape_keys.key_blocks)):
 					shape = node.data.shape_keys.key_blocks[k]
 					shape.value = 1.0

--- a/tools/export/blender25/io_scene_dae/export_dae.py
+++ b/tools/export/blender25/io_scene_dae/export_dae.py
@@ -937,6 +937,7 @@ class DaeExporter:
 			if node.type=="MESH" and self.config["export_shapekeys"]:
 				for k in range(0,len(node.data.shape_keys.key_blocks)):
 					shape = node.data.shape_keys.key_blocks[k]
+					oldval = shape.value
 					shape.value = 1.0
 					node.active_shape_key_index = k
 					p = node.data
@@ -945,6 +946,7 @@ class DaeExporter:
 					self.export_node(node,il,shape.name)
 					node.data = p
 					node.data.update()
+					shape.value = oldval
 		il-=1
 		self.writel(S_NODES,il,'</node>')
 


### PR DESCRIPTION
This adds basic support for shape keys geometry objects.
It is added as hyerarchy, with shapes as childs of main object.

Some bugs can live here, but at least it works on my test objects.

This is first step to support exporting Blender shape keys as morph targets.
It was only tested on Blender 2.71.
