### PR TITLE
[BUILD] fix include paths in webp

### DIFF
--- a/drivers/webp/dec/alpha.c
+++ b/drivers/webp/dec/alpha.c
@@ -14,7 +14,7 @@
 #include "./vp8li.h"
 #include "../utils/filters.h"
 #include "../utils/quant_levels.h"
-#include "../webp/format_constants.h"
+#include "../format_constants.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {

--- a/drivers/webp/dec/vp8li.h
+++ b/drivers/webp/dec/vp8li.h
@@ -18,7 +18,7 @@
 #include "../utils/bit_reader.h"
 #include "../utils/color_cache.h"
 #include "../utils/huffman.h"
-#include "../webp/format_constants.h"
+#include "../format_constants.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {

--- a/drivers/webp/dsp/dsp.h
+++ b/drivers/webp/dsp/dsp.h
@@ -12,7 +12,7 @@
 #ifndef WEBP_DSP_DSP_H_
 #define WEBP_DSP_DSP_H_
 
-#include "../webp/types.h"
+#include "../types.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {

--- a/drivers/webp/dsp/lossless.h
+++ b/drivers/webp/dsp/lossless.h
@@ -13,8 +13,8 @@
 #ifndef WEBP_DSP_LOSSLESS_H_
 #define WEBP_DSP_LOSSLESS_H_
 
-#include "../webp/types.h"
-#include "../webp/decode.h"
+#include "../types.h"
+#include "../decode.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {

--- a/drivers/webp/enc/alpha.c
+++ b/drivers/webp/enc/alpha.c
@@ -15,7 +15,7 @@
 #include "./vp8enci.h"
 #include "../utils/filters.h"
 #include "../utils/quant_levels.h"
-#include "../webp/format_constants.h"
+#include "../format_constants.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {

--- a/drivers/webp/enc/backward_references.h
+++ b/drivers/webp/enc/backward_references.h
@@ -13,8 +13,8 @@
 
 #include <assert.h>
 #include <stdlib.h>
-#include "../webp/types.h"
-#include "../webp/format_constants.h"
+#include "../types.h"
+#include "../format_constants.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {

--- a/drivers/webp/enc/config.c
+++ b/drivers/webp/enc/config.c
@@ -9,7 +9,7 @@
 //
 // Author: Skal (pascal.massimino@gmail.com)
 
-#include "../webp/encode.h"
+#include "../encode.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {

--- a/drivers/webp/enc/histogram.h
+++ b/drivers/webp/enc/histogram.h
@@ -19,8 +19,8 @@
 #include <string.h>
 
 #include "./backward_references.h"
-#include "../webp/format_constants.h"
-#include "../webp/types.h"
+#include "../format_constants.h"
+#include "../types.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {

--- a/drivers/webp/enc/syntax.c
+++ b/drivers/webp/enc/syntax.c
@@ -11,7 +11,7 @@
 
 #include <assert.h>
 
-#include "../webp/format_constants.h"
+#include "../format_constants.h"
 #include "./vp8enci.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)

--- a/drivers/webp/enc/vp8enci.h
+++ b/drivers/webp/enc/vp8enci.h
@@ -13,7 +13,7 @@
 #define WEBP_ENC_VP8ENCI_H_
 
 #include <string.h>     // for memcpy()
-#include "../webp/encode.h"
+#include "../encode.h"
 #include "../dsp/dsp.h"
 #include "../utils/bit_writer.h"
 

--- a/drivers/webp/enc/vp8l.c
+++ b/drivers/webp/enc/vp8l.c
@@ -21,7 +21,7 @@
 #include "../utils/bit_writer.h"
 #include "../utils/huffman_encode.h"
 #include "../utils/utils.h"
-#include "../webp/format_constants.h"
+#include "../format_constants.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {

--- a/drivers/webp/enc/vp8li.h
+++ b/drivers/webp/enc/vp8li.h
@@ -14,8 +14,8 @@
 
 #include "./histogram.h"
 #include "../utils/bit_writer.h"
-#include "../webp/encode.h"
-#include "../webp/format_constants.h"
+#include "../encode.h"
+#include "../format_constants.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {

--- a/drivers/webp/utils/bit_reader.h
+++ b/drivers/webp/utils/bit_reader.h
@@ -18,7 +18,7 @@
 #include <stdlib.h>  // _byteswap_ulong
 #endif
 #include <string.h>  // For memcpy
-#include "../webp/types.h"
+#include "../types.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {

--- a/drivers/webp/utils/bit_writer.h
+++ b/drivers/webp/utils/bit_writer.h
@@ -12,7 +12,7 @@
 #ifndef WEBP_UTILS_BIT_WRITER_H_
 #define WEBP_UTILS_BIT_WRITER_H_
 
-#include "../webp/types.h"
+#include "../types.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {

--- a/drivers/webp/utils/color_cache.h
+++ b/drivers/webp/utils/color_cache.h
@@ -13,7 +13,7 @@
 #ifndef WEBP_UTILS_COLOR_CACHE_H_
 #define WEBP_UTILS_COLOR_CACHE_H_
 
-#include "../webp/types.h"
+#include "../types.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {

--- a/drivers/webp/utils/filters.h
+++ b/drivers/webp/utils/filters.h
@@ -12,7 +12,7 @@
 #ifndef WEBP_UTILS_FILTERS_H_
 #define WEBP_UTILS_FILTERS_H_
 
-#include "../webp/types.h"
+#include "../types.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {

--- a/drivers/webp/utils/huffman.c
+++ b/drivers/webp/utils/huffman.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include "./huffman.h"
 #include "../utils/utils.h"
-#include "../webp/format_constants.h"
+#include "../format_constants.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {

--- a/drivers/webp/utils/huffman.h
+++ b/drivers/webp/utils/huffman.h
@@ -13,7 +13,7 @@
 #define WEBP_UTILS_HUFFMAN_H_
 
 #include <assert.h>
-#include "../webp/types.h"
+#include "../types.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {

--- a/drivers/webp/utils/huffman_encode.c
+++ b/drivers/webp/utils/huffman_encode.c
@@ -14,7 +14,7 @@
 #include <string.h>
 #include "./huffman_encode.h"
 #include "../utils/utils.h"
-#include "../webp/format_constants.h"
+#include "../format_constants.h"
 
 // -----------------------------------------------------------------------------
 // Util function to optimize the symbol map for RLE coding

--- a/drivers/webp/utils/huffman_encode.h
+++ b/drivers/webp/utils/huffman_encode.h
@@ -12,7 +12,7 @@
 #ifndef WEBP_UTILS_HUFFMAN_ENCODE_H_
 #define WEBP_UTILS_HUFFMAN_ENCODE_H_
 
-#include "../webp/types.h"
+#include "../types.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {

--- a/drivers/webp/utils/quant_levels.h
+++ b/drivers/webp/utils/quant_levels.h
@@ -14,7 +14,7 @@
 
 #include <stdlib.h>
 
-#include "../webp/types.h"
+#include "../types.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {

--- a/drivers/webp/utils/rescaler.h
+++ b/drivers/webp/utils/rescaler.h
@@ -16,7 +16,7 @@
 extern "C" {
 #endif
 
-#include "../webp/types.h"
+#include "../types.h"
 
 // Structure used for on-the-fly rescaling
 typedef struct {

--- a/drivers/webp/utils/utils.h
+++ b/drivers/webp/utils/utils.h
@@ -12,7 +12,7 @@
 #ifndef WEBP_UTILS_UTILS_H_
 #define WEBP_UTILS_UTILS_H_
 
-#include "../webp/types.h"
+#include "../types.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {


### PR DESCRIPTION
This commit fixes include paths in provided webp. Without it build system is using webp provided by system which may lead to bugs as #687 
Tested on Archlinux and OS X.

Oh, I see it was fixed a long time ago in #74 , but someone have broken it…
