### PR TITLE
Fix http response and user directory

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -514,6 +514,8 @@ ByteArray HTTPClient::read_response_body_chunk() {
 				_offset += rec;
 			}
 		}
+		w = ByteArray::Write();
+		ret.resize(_offset);
 		if (body_left==0) {
 			status=STATUS_CONNECTED;
 		}

--- a/core/os/dir_access.cpp
+++ b/core/os/dir_access.cpp
@@ -170,10 +170,10 @@ Error DirAccess::make_dir_recursive(String p_dir) {
 			String to_create = full_dir.substr(0, pos -1);
 			//print_line("MKDIR: "+to_create);
 			Error err = make_dir(to_create);
-			//if (err != OK && err != ERR_ALREADY_EXISTS) {
+			if (err != OK && err != ERR_ALREADY_EXISTS) {
 
-			//	ERR_FAIL_V(err);
-			//};
+				ERR_FAIL_V(err);
+			};
 		};
 	};
 

--- a/core/os/dir_access.cpp
+++ b/core/os/dir_access.cpp
@@ -170,10 +170,10 @@ Error DirAccess::make_dir_recursive(String p_dir) {
 			String to_create = full_dir.substr(0, pos -1);
 			//print_line("MKDIR: "+to_create);
 			Error err = make_dir(to_create);
-			if (err != OK && err != ERR_ALREADY_EXISTS) {
+			//if (err != OK && err != ERR_ALREADY_EXISTS) {
 
-				ERR_FAIL_V(err);
-			};
+			//	ERR_FAIL_V(err);
+			//};
 		};
 	};
 

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -268,7 +268,7 @@ Error DirAccessWindows::make_dir(String p_dir) {
 		return OK;
 	};
 
-	if (err == ERROR_ALREADY_EXISTS) {
+	if (err == ERROR_ALREADY_EXISTS || err == ERROR_ACCESS_DENIED) {
 		return ERR_ALREADY_EXISTS;
 	};
 


### PR DESCRIPTION
Fix http read response body size mismatch
Fix user directory does not correct created under windows platform.

HTTPClient::read_response_body_chunk -> set result size to received size
DirAccess::make_dir_recursive -> ignore E_CANT_CREATE error
