### PR TITLE
Changed GUI text to better match action

### DIFF
--- a/tools/editor/create_dialog.cpp
+++ b/tools/editor/create_dialog.cpp
@@ -289,7 +289,7 @@ CreateDialog::CreateDialog() {
 	search_box->connect("input_event",this,"_sbox_input");
 	search_options = memnew( Tree );
 	vbc->add_margin_child("Matches:",search_options,true);
-	get_ok()->set_text("Open");
+	get_ok()->set_text("Create");
 	get_ok()->set_disabled(true);
 	register_text_enter(search_box);
 	set_hide_on_ok(false);


### PR DESCRIPTION
Seems how you are creating a node not opening one it would make more sense to have the GUI say create rather than open.

I have built and tested this change and it works ;)
