### PR TITLE
Fixed compiler flags for 32-bit environments

### DIFF
--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -115,10 +115,10 @@ def configure(env):
 
 #host compiler is default..
 
-	if (is64 and env["bits"]=="32"):
+	if (env["bits"]=="32"):
 		env.Append(CPPFLAGS=['-m32'])
 		env.Append(LINKFLAGS=['-m32','-L/usr/lib/i386-linux-gnu'])
-	elif (not is64 and env["bits"]=="32"):
+	elif (env["bits"]=="64"):
 		env.Append(CPPFLAGS=['-m64'])
 		env.Append(LINKFLAGS=['-m64','-L/usr/lib/i686-linux-gnu'])
 


### PR DESCRIPTION
Fixes the "sorry, unimplemented: 64-bit mode not compiled in" message when trying to compile godot for x11 on 32-bit GNU/Linux.
