### PR TITLE
Fix android build on windows

### DIFF
--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -66,6 +66,6 @@ for x in env.android_module_libraries:
 	shutil.copy(x,abspath+"/java/libs")	
 
 
-env_android.SharedLibrary("#bin/libgodot_android",[android_objects],SHLIBSUFFIX=env["SHLIBSUFFIX"])
+env_android.SharedLibrary("#bin/libgodot",[android_objects],SHLIBSUFFIX=env["SHLIBSUFFIX"])
 
 #env.Command('#bin/libgodot_android.so', '#platform/android/libgodot_android.so', Copy('bin/libgodot_android.so', 'platform/android/libgodot_android.so'))

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -61,6 +61,7 @@ def configure(env):
 		import methods
 		env.Tool('gcc')
 		env['SPAWN'] = methods.win32_spawn
+		env['SHLIBSUFFIX'] = '.so'
 
 #	env.android_source_modules.append("../libs/apk_expansion")	
 	env.android_source_modules.append("../libs/google_play_services")	


### PR DESCRIPTION
- use ".so" suffix for android windows build ( instead of ".dll" )
- use "libgodot.android.debug.so" output file format (instead of "libgodot_android.android.debug.so"), to be consistent with file name on other platforms.
