### PR TITLE
Scene Tree can now display full instanced scenes hierarchy

### DIFF
--- a/tools/editor/plugins/spatial_editor_plugin.cpp
+++ b/tools/editor/plugins/spatial_editor_plugin.cpp
@@ -1371,12 +1371,31 @@ void SpatialEditorViewport::_sinput(const InputEvent &p_event) {
 				}
 
 			} else if (m.button_mask&2) {
+			
+				if (nav_scheme == NAVIGATION_GODOT) {
 
-				if (nav_scheme == NAVIGATION_MAYA && m.mod.alt) {
-					nav_mode = NAVIGATION_ZOOM;
+					int mod = 0;
+					if (m.mod.shift)
+						mod=KEY_SHIFT;
+					if (m.mod.alt)
+						mod=KEY_ALT;
+					if (m.mod.control)
+						mod=KEY_CONTROL;
+					if (m.mod.meta)
+						mod=KEY_META;
+
+					if (mod == _get_key_modifier("3d_editor/pan_modifier"))
+						nav_mode = NAVIGATION_PAN;
+					else if (mod == _get_key_modifier("3d_editor/zoom_modifier"))
+						nav_mode = NAVIGATION_ZOOM;
+					else if (mod == _get_key_modifier("3d_editor/orbit_modifier"))
+						nav_mode = NAVIGATION_ORBIT;
+
+				} else if( nav_scheme == NAVIGATION_MAYA && m.mod.alt ) {
+						nav_mode = NAVIGATION_ZOOM;
 				}
 
-			} else if (m.button_mask&4) {
+			} else if( m.button_mask&4 ) {
 
 				if (nav_scheme == NAVIGATION_GODOT) {
 
@@ -1397,8 +1416,7 @@ void SpatialEditorViewport::_sinput(const InputEvent &p_event) {
 					else if (mod == _get_key_modifier("3d_editor/orbit_modifier"))
 						nav_mode = NAVIGATION_ORBIT;
 
-				} else if (nav_scheme == NAVIGATION_MAYA) {
-					if (m.mod.alt)
+				} else if (nav_scheme == NAVIGATION_MAYA && m.mod.alt ) {
 						nav_mode = NAVIGATION_PAN;
 				}
 			}

--- a/tools/editor/scene_tree_editor.cpp
+++ b/tools/editor/scene_tree_editor.cpp
@@ -170,7 +170,8 @@ void SceneTreeEditor::_add_nodes(Node *p_node,TreeItem *p_parent) {
 
 	if (!display_foreign && p_node->get_owner()!=get_scene_node() && p_node!=get_scene_node()) {
 
-		if ((show_enabled_subscene || can_open_instance) && p_node->get_owner() && p_node->get_owner()->get_owner()==get_scene_node() && p_node->get_owner()->has_meta("__editor_show_subtree")) {
+		//if ((show_enabled_subscene || can_open_instance) && p_node->get_owner() && p_node->get_owner()->get_owner()==get_scene_node() && p_node->get_owner()->has_meta("__editor_show_subtree")) {
+		if ((show_enabled_subscene || can_open_instance) && p_node->get_owner()->has_meta("__editor_show_subtree")) {
 
 			part_of_subscene=true;
 			//allow
@@ -208,6 +209,7 @@ void SceneTreeEditor::_add_nodes(Node *p_node,TreeItem *p_parent) {
 				
 		item->set_selectable(0,marked_selectable);
 		item->set_custom_color(0,Color(0.8,0.1,0.10));
+		  //item->set_custom_color(0,Color(0.0,1.0,0.0));
 	} else if (!marked_selectable && !marked_children_selectable) {
 
 		Node *node=p_node;
@@ -215,6 +217,7 @@ void SceneTreeEditor::_add_nodes(Node *p_node,TreeItem *p_parent) {
 			if (marked.has(node)) {
 				item->set_selectable(0,false);
 				item->set_custom_color(0,Color(0.8,0.1,0.10));
+				  //item->set_custom_color(0,Color(0.0,0.0,1.0));
 				break;
 			}
 			node=node->get_parent();
@@ -222,7 +225,9 @@ void SceneTreeEditor::_add_nodes(Node *p_node,TreeItem *p_parent) {
 	}
 
 	if (p_node!=get_scene_node() && p_node->get_filename()!="" && can_open_instance) {
-
+      // ### ADDED ###
+      item->set_custom_color(0,Color(0.8,0.4,0.20));
+      // #############
 		item->add_button(0,get_icon("InstanceOptions","EditorIcons"),BUTTON_SUBSCENE);
 		item->set_tooltip(0,"Instance: "+p_node->get_filename()+"\nType: "+p_node->get_type());
 	} else {


### PR DESCRIPTION
- Scene Tree can now display full instanced scenes hierarchy, useful to keyframe any parameter from any instanced scene children, no matter how deep they are in he hierarchy.
- The root of an instanced scene get the same color as its children. There is no reason to treat it differently, they are all part of the instanced scene. This way you get an instant overview of which nodes are part of an instanced scene and which are not.

![image](https://cloud.githubusercontent.com/assets/1168072/4670046/7dbc3cb2-5573-11e4-9170-ae3e611bc1e6.png)
