### PR TITLE
fixes default project dir option 

### DIFF
--- a/tools/editor/project_manager.cpp
+++ b/tools/editor/project_manager.cpp
@@ -321,6 +321,7 @@ public:
 		fdialog = memnew( FileDialog );
 		add_child(fdialog);
 		fdialog->set_access(FileDialog::ACCESS_FILESYSTEM);
+		fdialog->set_current_dir( EditorSettings::get_singleton()->get("global/default_project_path") );
 		project_name->connect("text_changed", this,"_text_changed");
 		project_path->connect("text_changed", this,"_path_text_changed");
 		fdialog->connect("dir_selected", this,"_path_selected");


### PR DESCRIPTION
Currently, if you set a default project directory in the editor prefs, it works fine when you launch Godot.

But if you open a project, then quit back to the Project Manager, it no longer respects the default directory preference for the Create or Import options (Scan option was working correctly, however).

This one-liner patch fixes it for Create and Import dialogs, as I had originally intended.
