### PR TITLE
add option to auto-scan a directory for projects

### DIFF
--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -386,6 +386,8 @@ void EditorSettings::_load_defaults() {
 
 	set("global/font","");
 	hints["global/font"]=PropertyInfo(Variant::STRING,"global/font",PROPERTY_HINT_GLOBAL_FILE,"*.fnt");
+	set("global/autoscan_project_path","");
+	hints["global/autoscan_project_path"]=PropertyInfo(Variant::STRING,"global/autoscan_project_path",PROPERTY_HINT_GLOBAL_DIR);
 	set("global/default_project_path","");
 	hints["global/default_project_path"]=PropertyInfo(Variant::STRING,"global/default_project_path",PROPERTY_HINT_GLOBAL_DIR);
 	set("global/default_project_export_path","");

--- a/tools/editor/project_manager.cpp
+++ b/tools/editor/project_manager.cpp
@@ -973,6 +973,11 @@ ProjectManager::ProjectManager() {
 
 	npdialog->connect("project_created", this,"_load_recent_projects");
 	_load_recent_projects();
+
+	if ( EditorSettings::get_singleton()->get("global/autoscan_project_path") ) {
+		_scan_begin( EditorSettings::get_singleton()->get("global/autoscan_project_path") );
+	}
+
 	//get_ok()->set_text("Open");
 	//get_ok()->set_text("Exit");
 


### PR DESCRIPTION
This adds an option to allow the Project Manager to auto-scan a certain directory once at startup.

Saves having to scan every time new Godot demos are added, for example.
