### PR TITLE
add timestamping authority server option for Android

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1231,6 +1231,11 @@ Error EditorExportPlatformAndroid::export_project(const String& p_path, bool p_d
 		args.push_back("SHA1");
 		args.push_back("-sigalg");
 		args.push_back("MD5withRSA");
+		String tsa_url=EditorSettings::get_singleton()->get("android/timestamping_authority_url");
+		if (tsa_url != "") {
+			args.push_back("-tsa");
+			args.push_back(tsa_url);
+		}
 		args.push_back("-verbose");
 		args.push_back("-keystore");
 		args.push_back(keystore);
@@ -1613,6 +1618,7 @@ void register_android_exporter() {
 	//EDITOR_DEF("android/release_keystore","");
 	//EDITOR_DEF("android/release_username","");
 	//EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING,"android/release_keystore",PROPERTY_HINT_GLOBAL_FILE,"*.keystore"));
+	EDITOR_DEF("android/timestamping_authority_url","");
 
 	Ref<EditorExportPlatformAndroid> exporter = Ref<EditorExportPlatformAndroid>( memnew(EditorExportPlatformAndroid) );
 	EditorImportExport::get_singleton()->add_export_platform(exporter);


### PR DESCRIPTION
This adds an option for specifying a TSA URL which will timestamp Android APK exports when signing with jarsigner. Tested with http://tsa.safecreative.org/ as an example on OpenJDK7 jarsigner on Debian Jessie.
