### PR TITLE
Fix CppCheck 'duplicateExpression' warning

### DIFF
--- a/core/globals.cpp
+++ b/core/globals.cpp
@@ -674,7 +674,7 @@ static Variant _decode_variant(const String& p_string) {
 		int w=params[2].to_int();
 		int h=params[3].to_int();
 
-		if (w == 0 && w == 0) {
+		if (w == 0 && h == 0) {
 			//r_v = Image(w, h, imgformat);
 			return Image();
 		};

--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -580,7 +580,7 @@ static Variant _decode_variant(const String& p_string) {
 		int w=params[2].to_int();
 		int h=params[3].to_int();
 
-		if (w == 0 && w == 0) {
+		if (w == 0 && h == 0) {
 			//r_v = Image(w, h, imgformat);
 			return Image();
 		};

--- a/core/io/resource_format_xml.cpp
+++ b/core/io/resource_format_xml.cpp
@@ -571,7 +571,7 @@ Error ResourceInteractiveLoaderXML::parse_property(Variant& r_v, String &r_name)
 			int w=width.to_int();
 			int h=height.to_int();
 
-			if (w == 0 && w == 0) {
+			if (w == 0 && h == 0) {
 				//r_v = Image(w, h, imgformat);
 				r_v=Image();
 				String sdfsdfg;


### PR DESCRIPTION
BTW, all three cases looks similar. It would be nice to refactor it
to avoid repeating code.
