### PR TITLE
Fix AnimationTreePlayer.node_get_input_source typo

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -2747,7 +2747,7 @@
 			types of nodes have different amount of inputs.
 			</description>
 		</method>
-		<method name="node_get_input_sourcre" qualifiers="const" >
+		<method name="node_get_input_source" qualifiers="const" >
 			<return type="String">
 			</return>
 			<argument index="0" name="id" type="String">

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -2392,7 +2392,7 @@
 			<argument index="1" name="animation" type="Animation">
 			</argument>
 			<description>
-			Add an animation resource to the player, which will be later referenced by the "name" arguemnt.
+			Add an animation resource to the player, which will be later referenced by the "name" argument.
 			</description>
 		</method>
 		<method name="remove_animation"  >

--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -1662,7 +1662,7 @@ void AnimationTreePlayer::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("node_get_type","id"),&AnimationTreePlayer::node_get_type);
 	ObjectTypeDB::bind_method(_MD("node_get_input_count","id"),&AnimationTreePlayer::node_get_input_count);
-	ObjectTypeDB::bind_method(_MD("node_get_input_sourcre","id","idx"),&AnimationTreePlayer::node_get_input_source);
+	ObjectTypeDB::bind_method(_MD("node_get_input_source","id","idx"),&AnimationTreePlayer::node_get_input_source);
 
 	ObjectTypeDB::bind_method(_MD("animation_node_set_animation","id","animation:Animation"),&AnimationTreePlayer::animation_node_set_animation);
 	ObjectTypeDB::bind_method(_MD("animation_node_get_animation:Animation","id"),&AnimationTreePlayer::animation_node_get_animation);

--- a/tools/docdump/class_list.xml
+++ b/tools/docdump/class_list.xml
@@ -319,7 +319,7 @@
 			<argument index="1" name="animation" type="Object">
 			</argument>
 			<description>
-			Add an animation resource to the player, which will be later referenced by the &quot;name&quot; arguemnt.
+			Add an animation resource to the player, which will be later referenced by the &quot;name&quot; argument.
 			</description>
 		</method>
 		<method name="remove_animation"  >


### PR DESCRIPTION
- Changed node_get_input_sourcre to node_get_input_source
