### PR TITLE
allow Alt+arrow keys to pass through editor

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1360,6 +1360,7 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 
 #else
                     if (k.mod.alt) {
+                        scancode_handled=false;
                         break;
                     } else if (k.mod.command) {
 #endif
@@ -1404,6 +1405,7 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
                     } else if (k.mod.alt) {
 #else
                     if (k.mod.alt) {
+                        scancode_handled=false;
                         break;
                     } else if (k.mod.command) {
 #endif
@@ -1439,8 +1441,10 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 
                     if (k.mod.shift)
                         _pre_shift_selection();
-                    if (k.mod.alt)
+                    if (k.mod.alt) {
+                        scancode_handled=false;
                         break;
+                    }
 #ifdef APPLE_STYLE_KEYS
                     if (k.mod.command)
                         cursor_set_line(0);
@@ -1456,8 +1460,10 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 
                     if (k.mod.shift)
                         _pre_shift_selection();
-                    if (k.mod.alt)
+                    if (k.mod.alt) {
+                        scancode_handled=false;
                         break;
+                    }
 #ifdef APPLE_STYLE_KEYS
                     if (k.mod.command)
                         cursor_set_line(text.size()-1);


### PR DESCRIPTION
This fixes DCubix's merged PR features for indenting and moving lines in the editor via Alt+arrow keys.
