### PR TITLE
SConstruct imports multiprocessing, which is then never used

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -6,7 +6,6 @@ import os.path
 import glob
 import sys
 import methods
-import multiprocessing
 
 methods.update_version()
 


### PR DESCRIPTION
Godot also failed to start building on my setup. Multiprocessing imported without failure on same system in both python2, python3 and ipython running python2.

Removed import statement and godot built without problems.
