### PR TITLE
Alt+arrows editor undo/redo fix

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3150,12 +3150,18 @@ void TextEdit::set_line(int line, String new_text)
 {
     if (line < 0 || line > text.size())
         return;
-    text.set(line, new_text);
+    text.remove(line); // TODO: Make this Undo/Redoable....
+    insert_at(new_text, line);
+    //text.set(line, new_text);
 }
 
 void TextEdit::insert_at(const String &p_text, int at)
 {
-    text.insert(at, p_text);
+    cursor_set_column(0);
+    cursor_set_line(at);
+    _insert_text(at, 0, p_text+"\n");
+    //_insert_text_at_cursor(p_text);
+    //old: text.insert(at, p_text);
 }
 
 void TextEdit::set_show_line_numbers(bool p_show) {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3150,18 +3150,15 @@ void TextEdit::set_line(int line, String new_text)
 {
     if (line < 0 || line > text.size())
         return;
-    text.remove(line); // TODO: Make this Undo/Redoable....
-    insert_at(new_text, line);
-    //text.set(line, new_text);
+    _remove_text(line, 0, line, text[line].length());
+    _insert_text(line, 0, new_text);
 }
 
 void TextEdit::insert_at(const String &p_text, int at)
 {
-    cursor_set_column(0);
-    cursor_set_line(at);
-    _insert_text(at, 0, p_text+"\n");
-    //_insert_text_at_cursor(p_text);
-    //old: text.insert(at, p_text);
+	cursor_set_column(0);
+	cursor_set_line(at);
+	_insert_text(at, 0, p_text+"\n");
 }
 
 void TextEdit::set_show_line_numbers(bool p_show) {

--- a/tools/editor/plugins/script_editor_plugin.h
+++ b/tools/editor/plugins/script_editor_plugin.h
@@ -218,7 +218,7 @@ public:
 
 	void get_breakpoints(List<String> *p_breakpoints);
 
-
+    void swap_lines(TextEdit *tx, int line1, int line2);
 
 	void save_external_data();
 


### PR DESCRIPTION
This is the same as PR #882 by DCubix, but I fixed it so undo/redo is supported. (I wasn't sure how to just add the fix to his PR.)

It doesn't move everything to functions, just adds the undo/redo support. Hoping it can be in 1.0 since the alt+arrows in rc1 don't work properly and don't support undo/redo at all.
