### PR TITLE
remove old unused pref, added new confirm insert track

### DIFF
--- a/tools/editor/animation_editor.cpp
+++ b/tools/editor/animation_editor.cpp
@@ -2530,16 +2530,20 @@ void AnimationKeyEditor::_query_insert(const InsertData& p_id) {
 	insert_data.push_back(p_id);
 
 	if (p_id.track_idx==-1) {
-		//potential new key, does not exist		
-		if (insert_data.size()==1)
-			insert_confirm->set_text("Create NEW track for "+p_id.query+" and insert key?");
-		else
-			insert_confirm->set_text("Create "+itos(insert_data.size())+" NEW tracks and insert keys?");
+		if (bool(EDITOR_DEF("animation/confirm_insert_track",true))) {
+			//potential new key, does not exist		
+			if (insert_data.size()==1)
+				insert_confirm->set_text("Create NEW track for "+p_id.query+" and insert key?");
+			else
+				insert_confirm->set_text("Create "+itos(insert_data.size())+" NEW tracks and insert keys?");
 
-		insert_confirm->get_ok()->set_text("Create");
-		insert_confirm->popup_centered(Size2(300,100));
-		insert_query=true;
-
+			insert_confirm->get_ok()->set_text("Create");
+			insert_confirm->popup_centered(Size2(300,100));
+			insert_query=true;
+		} else {
+			call_deferred("_insert_delay");
+			insert_queue=true;
+		}
 
 	} else {
 		if (!insert_query && !insert_queue) {
@@ -3150,7 +3154,7 @@ AnimationKeyEditor::AnimationKeyEditor(UndoRedo *p_undo_redo, EditorHistory *p_h
 	//add_child(menu);
 
 	menu_track = memnew( MenuButton );
-	menu_track->set_text("Tracks..");
+	menu_track->set_text("Tracks");
 	hb->add_child(menu_track);
 	menu_track->get_popup()->connect("item_pressed",this,"_menu_track");
 
@@ -3347,8 +3351,6 @@ AnimationKeyEditor::AnimationKeyEditor(UndoRedo *p_undo_redo, EditorHistory *p_h
 	insert_confirm = memnew( ConfirmationDialog );
 	add_child(insert_confirm);
 	insert_confirm->connect("confirmed",this,"_confirm_insert_list");
-
-	EDITOR_DEF("animation_editor/confirm_insert_key",true);
 
 	click.click=ClickOver::CLICK_NONE;
 

--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -440,6 +440,7 @@ void EditorSettings::_load_defaults() {
 
 
 	set("animation/autorename_animation_tracks",true);
+	set("animation/confirm_insert_track",true);
 
 	set("property_editor/texture_preview_width",48);
 	set("help/doc_path","");


### PR DESCRIPTION
The editor setting animation_editor/confirm_insert_key was not used at all. I added the functionality and also moved the preference name to animation/confirm_insert_track instead.
