### PR TITLE
xml_parser: check array length index before accessing the array.

### DIFF
--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -34,7 +34,7 @@ VARIANT_ENUM_CAST(XMLParser::NodeType);
 
 static bool _equalsn(const CharType* str1, const CharType* str2, int len) {
 	int i;
-	for(i=0; str1[i] && str2[i] && i < len; ++i)
+	for(i=0; i < len && str1[i] && str2[i] ; ++i)
 	     if (str1[i] != str2[i])
 		     return false;
 


### PR DESCRIPTION
Defensive programming: The variable `i` is used as an array index before it is checked that is within limits. This can mean that the array might be accessed out of bounds. Reorder conditions such as `(a[i] && i < 10)` to `(i < 10 && a[i])`. That way the array will not be accessed if the index is out of limits.
