### PR TITLE
change shortcut for toggle-comment to Ctrl+K

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1911,27 +1911,6 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 
                 } break;
 
-                case KEY_K:{
-                    if (!k.mod.command || k.mod.shift || k.mod.alt) {
-                        scancode_handled=false;
-                        break;
-                    }
-                    else {
-                        if (selection.active) {
-                            int ini = selection.from_line;
-                            int end = selection.to_line;
-                            for (int i=ini; i<= end; i++)
-                            {
-                                _insert_text(i,0,"#");
-                            }
-                        }
-                        else{
-                            _insert_text(cursor.line,0,"#");
-                        }
-                        update();
-                    }
-                    break;}
-
             case KEY_U:{
                 if (!k.mod.command || k.mod.shift || k.mod.alt) {
                     scancode_handled=false;

--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -1599,7 +1599,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	edit_menu->get_popup()->add_item("Move Down",EDIT_MOVE_LINE_DOWN,KEY_MASK_ALT|KEY_DOWN);
 	edit_menu->get_popup()->add_item("Indent Left",EDIT_INDENT_LEFT,KEY_MASK_ALT|KEY_LEFT);
 	edit_menu->get_popup()->add_item("Indent Right",EDIT_INDENT_RIGHT,KEY_MASK_ALT|KEY_RIGHT);
-	edit_menu->get_popup()->add_item("Toggle Comment",EDIT_TOGGLE_COMMENT,KEY_MASK_CMD|KEY_SLASH);
+	edit_menu->get_popup()->add_item("Toggle Comment",EDIT_TOGGLE_COMMENT,KEY_MASK_CMD|KEY_K);
 	edit_menu->get_popup()->add_item("Clone Down",EDIT_CLONE_DOWN,KEY_MASK_CMD|KEY_B);
 	edit_menu->get_popup()->add_separator();
 	edit_menu->get_popup()->add_item("Complete Symbol",EDIT_COMPLETE,KEY_MASK_CMD|KEY_SPACE);


### PR DESCRIPTION
change shortcut for toggle-comment to Ctrl+K
Ctrl+/ is not standard, doesn't work on eg: German keyboards.
Ctrl+K was already used for commenting lines, so I just replaced it with the newer, better, toggle function.
