### PR TITLE
Fix documentation for randf

### DIFF
--- a/doc/html/@GDScript.html
+++ b/doc/html/@GDScript.html
@@ -55,7 +55,7 @@
 			</div></div><div class="method_doc"><div class="method"><a class="datatype_existing" href="int.html">int </a><span class="funcdecl"><a name="@GDScript_rand">@GDScript::rand</a></span><span class="symbol"> (</span><span class="symbol">)</span></div><div class="description">
 			Random value (integer).
 			</div></div><div class="method_doc"><div class="method"><a class="datatype_existing" href="real.html">real </a><span class="funcdecl"><a name="@GDScript_randf">@GDScript::randf</a></span><span class="symbol"> (</span><span class="symbol">)</span></div><div class="description">
-			Random value (0 to 1 float).
+			Random float value between 0 and 1 exclusive.
 			</div></div><div class="method_doc"><div class="method"><a class="datatype_existing" href="real.html">real </a><span class="funcdecl"><a name="@GDScript_rand_range">@GDScript::rand_range</a></span><span class="symbol"> (</span><span> </span><a class="datatype_existing" href="real.html">real </a><span>from</span><span>, </span><a class="datatype_existing" href="real.html">real </a><span>to</span><span class="symbol"> )</span></div><div class="description">
 			Random range.
 			</div></div><div class="method_doc"><div class="method"><a class="datatype_existing" href="Array.html">Array </a><span class="funcdecl"><a name="@GDScript_rand_seed">@GDScript::rand_seed</a></span><span class="symbol"> (</span><span> </span><a class="datatype_existing" href="real.html">real </a><span>seed</span><span class="symbol"> )</span></div><div class="description">


### PR DESCRIPTION
Verified that 0 and 1 are exclusive (given the algorithm in math_funcs.cpp); reflected that in the docs.
