### PR TITLE
Replace TileMapEditor floating tile palette with HSplitContainer.

### DIFF
--- a/tools/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/tools/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2683,6 +2683,11 @@ void CanvasItemEditor::add_control_to_menu_panel(Control *p_control) {
 	hb->add_child(p_control);
 }
 
+HSplitContainer *CanvasItemEditor::get_palette_split() {
+
+	return palette_split;
+}
+
 CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 
 	tool = TOOL_SELECT;
@@ -2697,14 +2702,19 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	add_child( hb );
 	hb->set_area_as_parent_rect();
 
+	palette_split = memnew( HSplitContainer);
+	palette_split->set_v_size_flags(SIZE_EXPAND_FILL);
+	add_child(palette_split);
+
 	Control *vp_base = memnew (Control);
-	add_child(vp_base);
 	vp_base->set_v_size_flags(SIZE_EXPAND_FILL);
+	palette_split->add_child(vp_base);
 
 	Control *vp = memnew (Control);
 	vp_base->add_child(vp);
 	vp->set_area_as_parent_rect();
 	vp->add_child(p_editor->get_scene_root());
+
 
 	viewport = memnew( Control );
 	vp_base->add_child(viewport);

--- a/tools/editor/plugins/canvas_item_editor_plugin.h
+++ b/tools/editor/plugins/canvas_item_editor_plugin.h
@@ -289,6 +289,10 @@ class CanvasItemEditor : public VBoxContainer {
 
 	void _viewport_input_event(const InputEvent& p_event);
 	void _viewport_draw();
+
+private:
+	HSplitContainer *palette_split;
+
 friend class CanvasItemEditorPlugin;
 protected:
 
@@ -340,6 +344,8 @@ public:
 	void set_state(const Dictionary& p_state);
 
 	void add_control_to_menu_panel(Control *p_control);
+
+	HSplitContainer *get_palette_split();
 
 	Control *get_viewport_control() { return viewport; }
 

--- a/tools/editor/plugins/tile_map_editor_plugin.h
+++ b/tools/editor/plugins/tile_map_editor_plugin.h
@@ -34,15 +34,14 @@
 #include "scene/2d/tile_map.h"
 #include "scene/gui/tool_button.h"
 #include "scene/gui/button_group.h"
-#include "tools/editor/pane_drag.h"
 /**
 	@author Juan Linietsky <reduzio@gmail.com>
 */
 class CanvasItemEditor;
 
-class TileMapEditor : public HBoxContainer {
+class TileMapEditor : public VBoxContainer {
 
-	OBJ_TYPE(TileMapEditor, BoxContainer );
+	OBJ_TYPE(TileMapEditor, VBoxContainer );
 
 	UndoRedo *undo_redo;
 
@@ -63,7 +62,6 @@ class TileMapEditor : public HBoxContainer {
 	Panel *panel;
 	TileMap *node;
 	MenuButton *options;
-	PaneDrag *pane_drag;
 
 	bool selection_active;
 	Point2i selection_begin;
@@ -88,7 +86,6 @@ class TileMapEditor : public HBoxContainer {
 	int get_selected_tile() const;
 
 	void _update_palette();
-	void _pane_drag(const Point2& p_to);
 	void _canvas_draw();
 	void _menu_option(int p_option);
 
@@ -99,8 +96,6 @@ class TileMapEditor : public HBoxContainer {
 	void _tileset_settings_changed();
 
 
-friend class TileMapEditorPlugin;
-	Panel *theme_panel;
 protected:
 	void _notification(int p_what);
 	void _node_removed(Node *p_node);


### PR DESCRIPTION
Replace TileMapEditor floating tile palette with HSplitContainer as used with GridMapEditor.
This fixes issue #1061.
