### PR TITLE
[Issue #1173] HTTPClient: make read_response_body_chunk() return proper length for small files

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -503,7 +503,7 @@ ByteArray HTTPClient::read_response_body_chunk() {
 
 	} else {
 		ByteArray ret;
-		ret.resize(MAX(body_left,tmp_read.size()));
+		ret.resize(body_left);
 		ByteArray::Write w = ret.write();
 		int _offset = 0;
 		while (body_left > 0) {


### PR DESCRIPTION
For your consideration,

I think I found a bug and have a fix for issue #1173.
