### PR TITLE
fix naming of duplicated nodes, closes #1161

### DIFF
--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -272,7 +272,7 @@ void register_scene_types() {
 
 	ObjectTypeDB::register_type<Control>();
 //	ObjectTypeDB::register_type<EmptyControl>();
-	ObjectTypeDB::add_compatibility_type("EmptyControl","control");
+	ObjectTypeDB::add_compatibility_type("EmptyControl","Control");
 	ObjectTypeDB::register_type<Button>();
 	ObjectTypeDB::register_type<Label>();
 	ObjectTypeDB::register_type<HScrollBar>();

--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -413,6 +413,10 @@ void EditorSettings::_load_defaults() {
 	set("text_editor/auto_brace_complete", false);
 
 
+	set("scenetree_editor/duplicate_node_name_num_separator",0);
+	hints["scenetree_editor/duplicate_node_name_num_separator"]=PropertyInfo(Variant::INT,"scenetree_editor/duplicate_node_name_num_separator",PROPERTY_HINT_ENUM, "None,Space,Underscore,Dash");
+
+
 	set("3d_editor/default_fov",45.0);
 	set("3d_editor/default_z_near",0.1);
 	set("3d_editor/default_z_far",500.0);

--- a/tools/editor/scene_tree_dock.cpp
+++ b/tools/editor/scene_tree_dock.cpp
@@ -100,6 +100,16 @@ Node* SceneTreeDock::instance(const String& p_file) {
 
 }
 
+static String _get_name_num_separator() {
+	switch(EditorSettings::get_singleton()->get("scenetree_editor/duplicate_node_name_num_separator").operator int()) {
+		case 0: return "";
+		case 1: return " ";
+		case 2: return "_";
+		case 3: return "-";
+	}
+	return " ";
+}
+
 void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 	current_option=p_tool;
@@ -318,17 +328,21 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				}
 
 				int num=nums.to_int();
-				if (num<2)
-					num=2;
+				if (num<1)
+					num=1;
 				else
 					num++;
 
-				name=name.substr(0,name.length()-nums.length()).strip_edges();
-				String attempt=name+" "+itos(num);
+				String nnsep = _get_name_num_separator();
+				name = name.substr(0,name.length()-nums.length()).strip_edges();
+				if ( name.substr(name.length()-nnsep.length(),nnsep.length()) == nnsep) {
+					name = name.substr(0,name.length()-nnsep.length());
+				}
+				String attempt = (name + nnsep + itos(num)).strip_edges();
 
 				while(parent->has_node(attempt)) {
 					num++;
-					attempt=name+" "+itos(num);
+					attempt = (name + nnsep + itos(num)).strip_edges();
 				}
 
 				dup->set_name(attempt);


### PR DESCRIPTION
adds separator character preference setting (so you can have duplicated nodes auto-named to stuff like: Name2, Name 2, Name_2, or Name-2, depending what naming convention you prefer)

closes #1161
