### PR TITLE
Scons colored

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -116,6 +116,7 @@ opts.Add("CFLAGS", "Custom flags for the C compiler");
 opts.Add("LINKFLAGS", "Custom flags for the linker");
 opts.Add('disable_3d', 'Disable 3D nodes for smaller executable (yes/no)', "no")
 opts.Add('disable_advanced_gui', 'Disable advance 3D gui nodes and behaviors (yes/no)', "no")
+opts.Add('colored', 'Enable colored output for the compilation (yes/no)', 'no')
 
 # add platform specific options
 
@@ -299,6 +300,9 @@ if selected_platform in platform_list:
 	if (env['xml']=='yes'):
 		env.Append(CPPFLAGS=['-DXML_ENABLED'])
 
+	if (env['colored']=='yes'):
+		methods.colored(sys,env)
+		
 
 	Export('env')
 

--- a/methods.py
+++ b/methods.py
@@ -1316,3 +1316,39 @@ def save_active_platforms(apnames,ap):
 		logow = open(wf,"wb")
 		logow.write(str)
 
+
+def colored(sys,env):
+
+	#If the output is not a terminal, do nothing
+	if not sys.stdout.isatty():
+		return
+
+	colors = {}
+	colors['cyan']   = '\033[96m'
+	colors['purple'] = '\033[95m'
+	colors['blue']   = '\033[94m'
+	colors['green']  = '\033[92m'
+	colors['yellow'] = '\033[93m'
+	colors['red']    = '\033[91m'
+	colors['end']    = '\033[0m'
+
+	compile_source_message        = '%sCompiling %s==> %s$SOURCE%s' % (colors['blue'], colors['purple'], colors['yellow'], colors['end'])
+	java_compile_source_message   = '%sCompiling %s==> %s$SOURCE%s' % (colors['blue'], colors['purple'], colors['yellow'], colors['end'])
+	compile_shared_source_message = '%sCompiling shared %s==> %s$SOURCE%s' % (colors['blue'], colors['purple'], colors['yellow'], colors['end'])
+	link_program_message          = '%sLinking Program        %s==> %s$TARGET%s' % (colors['red'], colors['purple'], colors['yellow'], colors['end'])
+	link_library_message          = '%sLinking Static Library %s==> %s$TARGET%s' % (colors['red'], colors['purple'], colors['yellow'], colors['end'])
+	ranlib_library_message        = '%sRanlib Library         %s==> %s$TARGET%s' % (colors['red'], colors['purple'], colors['yellow'], colors['end'])
+	link_shared_library_message   = '%sLinking Shared Library %s==> %s$TARGET%s' % (colors['red'], colors['purple'], colors['yellow'], colors['end'])
+	java_library_message          = '%sCreating Java Archive  %s==> %s$TARGET%s' % (colors['red'], colors['purple'], colors['yellow'], colors['end'])
+
+	env.Append( CXXCOMSTR=[compile_source_message] )
+	env.Append( CCCOMSTR=[compile_source_message] )
+	env.Append( SHCCCOMSTR=[compile_shared_source_message] )
+	env.Append( SHCXXCOMSTR=[compile_shared_source_message] )
+	env.Append( ARCOMSTR=[link_library_message] )
+	env.Append( RANLIBCOMSTR=[ranlib_library_message] )
+	env.Append( SHLINKCOMSTR=[link_shared_library_message] )
+	env.Append( LINKCOMSTR=[link_program_message] )
+	env.Append( JARCOMSTR=[java_library_message] )
+	env.Append( JAVACCOMSTR=[java_compile_source_message] )
+

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -86,7 +86,7 @@ def configure(env):
 		env["LD"]="clang++"
 		if (env["colored"]=="yes"):
 			if sys.stdout.isatty():
-				env.Append(CXXFLAGS=["-fcolor-diagnostics"])
+				env.Append(CPPFLAGS=["-fcolor-diagnostics"])
 
 	import methods
 

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -84,6 +84,9 @@ def configure(env):
 		env.Append(CPPFLAGS=['-DTYPED_METHOD_BIND'])
 		env["CC"]="clang"
 		env["LD"]="clang++"
+		if (env["colored"]=="yes"):
+			if sys.stdout.isatty():
+				env.Append(CXXFLAGS=["-fcolor-diagnostics"])
 
 	import methods
 

--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -40,6 +40,9 @@ def configure(env):
 		env["CC"]="clang"
 		env["CXX"]="clang++"
 		env["LD"]="clang++"
+		if (env["colored"]=="yes"):
+			if sys.stdout.isatty():
+				env.Append(CXXFLAGS=["-fcolor-diagnostics"])
 
 	is64=sys.maxsize > 2**32
 

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -81,6 +81,9 @@ def configure(env):
 			env.extra_suffix=".llvms"
 		else:
 			env.extra_suffix=".llvm"
+		if (env["colored"]=="yes"):
+			if sys.stdout.isatty():
+				env.Append(CXXFLAGS=["-fcolor-diagnostics"])
 
 
 


### PR DESCRIPTION
adds optional colored terminal output for the SCons compilation process.
#### Compiling:

![pr1](https://cloud.githubusercontent.com/assets/1824607/5699305/3db812cc-9a5f-11e4-917b-7850764b1b4e.png)
#### Linking:

![pr3](https://cloud.githubusercontent.com/assets/1824607/5699303/3c881776-9a5f-11e4-9379-fb04ec68fb0a.png)
#### LLVM Warnings and Errors:

![pr2](https://cloud.githubusercontent.com/assets/1824607/5699311/75c64620-9a5f-11e4-908a-20af9c38d84f.png)
If LLVM is used, the warnings and errors are also colorized, when `... colored=yes ...` is set.
#### Examples:

```
scons p=windows colored=yes
scons p=x11 colored=yes
scons p=x11 use_llvm=yes colored=yes
scons p=osx colored=yes
```

Tested on Ubuntu 14.10.
Marynate tested it on Mac OS. No coloring for LLVM. But it works for the compiling messages.
