### PR TITLE
1: File path in save dialog automatically appended with correct extension if not manually added by the user.  2: Removed .bin as default extension for Linux exports as it causes problems for common file managers.

### DIFF
--- a/platform/x11/export/export.cpp
+++ b/platform/x11/export/export.cpp
@@ -11,7 +11,7 @@ void register_x11_exporter() {
 
 	{
 		Ref<EditorExportPlatformPC> exporter = Ref<EditorExportPlatformPC>( memnew(EditorExportPlatformPC) );
-		exporter->set_binary_extension("bin");
+		exporter->set_binary_extension("");
 		exporter->set_release_binary32("linux_x11_32_release");
 		exporter->set_debug_binary32("linux_x11_32_debug");
 		exporter->set_release_binary64("linux_x11_64_release");

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -156,7 +156,6 @@ void FileDialog::_action_pressed() {
 
 	if (mode==MODE_SAVE_FILE) {
 		
-		String ext = f.extension();
 		bool valid=false;
 
 		if (filter->get_selected()==filter->get_item_count()-1) {
@@ -197,6 +196,7 @@ void FileDialog::_action_pressed() {
 				if (!valid && filterSliceCount>0) {
 					String str = (flt.get_slice(",",0).strip_edges());
 					f+=str.substr(1, str.length()-1);
+					file->set_text(f.get_file());
 					valid=true;
 				}
 			} else {

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -184,13 +184,20 @@ void FileDialog::_action_pressed() {
 			if (idx>=0 && idx<filters.size()) {
 
 				String flt=filters[idx].get_slice(";",0);
-				for (int j=0;j<flt.get_slice_count(",");j++) {
+				int filterSliceCount=flt.get_slice_count(",");
+				for (int j=0;j<filterSliceCount;j++) {
 
 					String str = (flt.get_slice(",",j).strip_edges());
 					if (f.match(str)) {
 						valid=true;
 						break;
 					}
+				}
+
+				if (!valid && filterSliceCount>0) {
+					String str = (flt.get_slice(",",0).strip_edges());
+					f+=str.substr(1, str.length()-1);
+					valid=true;
 				}
 			} else {
 				valid=true;


### PR DESCRIPTION
Both of these commits are based off of this thread in the Google mailing list:
https://groups.google.com/forum/#!topic/godot-engine/conGaOeeG8w

---

Commit 1:

Instead of showing the "Must use a valid extension." dialog, the item being saved will use the selected extension of the file types when the filter only contains one option extension.

For instance, when saving a scene file, selecting SCN will automatically add the extension if .scn is not in the file name already. If "All Recognized" is selected it will still show the "Must use a valid extension." dialog.

I think it might be good behavior to have this apply to something like the "All Recognized" as well and select the first option instead of the dialog. If you agree, let me know and I will add that functionality as well.

---

Commit 2:

Removed "bin" from the Linux export so that it will default to "All Files". This is due to myself and others experiencing an issue where several filemanagers such as Nautilus and LXDE will try and find a program to open the executable instead of just running it. If the build has no extension it works just fine. If the .bin extension is kept it will likely cause frustration and confusion to anyone not familiar with Linux who is trying to make a Linux port of their game. Also, while there are a few apps out there with it .bin is not a standard extension for executables in Linux. The typical thing done for almost every Linux app is to have no extension.

---

Thanks,
Nathan
