### PR TITLE
added nvidia optimus enablement Issue #1120

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -56,6 +56,9 @@
 #include "shlobj.h"
 static const WORD MAX_CONSOLE_LINES = 1500;
 
+extern "C" {
+	_declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+}
 
 //#define STDOUT_FILE
 


### PR DESCRIPTION
enables the dedicated gpu with nvidia optimus.
(windows only)

this only works for the exported game, not for the editor!

edit: even works for editor :D
