### PR TITLE
Changed the "Start the scene (F5)." tooltip to say "Play the project (F5)."

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -3552,7 +3552,7 @@ EditorNode::EditorNode() {
 	play_button->set_icon(gui_base->get_icon("MainPlay","EditorIcons"));
 	play_button->set_focus_mode(Control::FOCUS_NONE);
 	play_button->connect("pressed", this,"_menu_option",make_binds(RUN_PLAY));
-	play_button->set_tooltip("Start the scene (F5).");
+	play_button->set_tooltip("Play the project (F5).");
 
 
 


### PR DESCRIPTION
"Start the scene" seems to be deceiving because if you're in a scene other than the main scene it will not run, but the main scene will be run instead, or rather the starting point of your project.

I changed the word "Start" to "Play" since it's consistent with the other two play options: "Play the edited scene. (F6)" and "Play custom scene. (Shift+Ctrl+F5)"
