### PR TITLE
Pr - Fixed a bug where a user could add a cyclical dependency, causing a crash.

### DIFF
--- a/tools/editor/scene_tree_dock.cpp
+++ b/tools/editor/scene_tree_dock.cpp
@@ -79,7 +79,15 @@ Node* SceneTreeDock::instance(const String& p_file) {
 		//accept->get_cancel()->hide();
 		accept->get_ok()->set_text("Ugh");
 		accept->set_text(String("Error loading scene from ")+p_file);
-		accept->popup_centered(Size2(300,70));;
+		accept->popup_centered(Size2(300,70));
+		return NULL;
+	}
+
+	if (_cyclical_dependency_exists(edited_scene->get_filename(), instanced_scene)) {
+
+		accept->get_ok()->set_text("Ok");
+		accept->set_text(String("Cannot instance the scene '")+p_file+String("' because the current scene exists within one of its' nodes."));
+		accept->popup_centered(Size2(300,90));
 		return NULL;
 	}
 
@@ -99,6 +107,25 @@ Node* SceneTreeDock::instance(const String& p_file) {
 	return instanced_scene;
 
 }
+
+bool SceneTreeDock::_cyclical_dependency_exists(const String& p_target_scene_path, Node* p_desired_node) {
+	int childCount = p_desired_node->get_child_count();
+
+	if (p_desired_node->get_filename()==p_target_scene_path) {
+		return true;
+	}
+
+	for (int i=0;i<childCount;i++) {
+		Node* child=p_desired_node->get_child(i);
+
+		if(_cyclical_dependency_exists(p_target_scene_path,child)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 
 static String _get_name_num_separator() {
 	switch(EditorSettings::get_singleton()->get("scenetree_editor/duplicate_node_name_num_separator").operator int()) {

--- a/tools/editor/scene_tree_dock.cpp
+++ b/tools/editor/scene_tree_dock.cpp
@@ -83,12 +83,16 @@ Node* SceneTreeDock::instance(const String& p_file) {
 		return NULL;
 	}
 
-	if (_cyclical_dependency_exists(edited_scene->get_filename(), instanced_scene)) {
+	// If the scene hasn't been saved yet a cyclical dependency cannot exist.
+	if (edited_scene->get_filename()!="") {
 
-		accept->get_ok()->set_text("Ok");
-		accept->set_text(String("Cannot instance the scene '")+p_file+String("' because the current scene exists within one of its' nodes."));
-		accept->popup_centered(Size2(300,90));
-		return NULL;
+		if (_cyclical_dependency_exists(edited_scene->get_filename(), instanced_scene)) {
+
+			accept->get_ok()->set_text("Ok");
+			accept->set_text(String("Cannot instance the scene '")+p_file+String("' because the current scene exists within one of its' nodes."));
+			accept->popup_centered(Size2(300,90));
+			return NULL;
+		}
 	}
 
 	instanced_scene->generate_instance_state();

--- a/tools/editor/scene_tree_dock.h
+++ b/tools/editor/scene_tree_dock.h
@@ -102,6 +102,7 @@ class SceneTreeDock : public VBoxContainer {
 	void _load_request(const String& p_path);
 	void _script_open_request(const Ref<Script>& p_script);
 
+	bool _cyclical_dependency_exists(const String& p_target_scene_path, Node* p_desired_node);
 
 	void _node_selected();
 	void _node_renamed();


### PR DESCRIPTION
This fix prevents a user from adding a scene instance when the current scene exists somewhere inside of that potential instance. Thus, it also prevents a scene from having an instance of itself. Either of these scenarios would cause a crash.
