### PR TITLE
fix build on freebsd

### DIFF
--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -50,11 +50,16 @@
  #ifdef ANDROID_ENABLED
   #include "platform/android/ifaddrs_android.h"
  #else
+  #ifdef __FreeBSD__
+   #include <sys/types.h>
+  #endif
   #include <ifaddrs.h>
  #endif
  #include <arpa/inet.h>
  #include <sys/socket.h>
-
+ #ifdef __FreeBSD__
+  #include <netinet/in.h>
+ #endif
 #endif
 
 IP_Address IP_Unix::_resolve_hostname(const String& p_hostname) {

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -44,7 +44,9 @@
 #include "stream_peer_tcp_posix.h"
 #include "packet_peer_udp_posix.h"
 
-
+#ifdef __FreeBSD__
+#include <sys/param.h>
+#endif
 #include <stdarg.h>
 #include <sys/time.h>
 #include <sys/wait.h>
@@ -305,7 +307,17 @@ Error OS_Unix::execute(const String& p_path, const List<String>& p_arguments,boo
 			args.push_back((char*)cs[i].get_data());// shitty C cast
 		args.push_back(0);
 
+#ifdef __FreeBSD__
+		if(p_path.find("/")) {
+			// exec name contains path so use it
+			execv(p_path.utf8().get_data(),&args[0]);
+		}else{
+			// use program name and search through PATH to find it
+			execvp(getprogname(),&args[0]);
+		}
+#else
 		execv(p_path.utf8().get_data(),&args[0]);
+#endif
 		// still alive? something failed..
 		fprintf(stderr,"**ERROR** OS_Unix::execute - Could not create child process while executing: %s\n",p_path.utf8().get_data());
 		abort();
@@ -421,6 +433,12 @@ String OS_Unix::get_executable_path() const {
 		return OS::get_executable_path();
 	}
 	return b;
+#elif defined(__FreeBSD__)
+	char resolved_path[MAXPATHLEN];
+
+	realpath(OS::get_executable_path().utf8().get_data(), resolved_path);
+
+	return String(resolved_path);
 #else
 	ERR_PRINT("Warning, don't know how to obtain executable path on this OS! Please override this function properly.");
 	return OS::get_executable_path();


### PR DESCRIPTION
I have got godot to build and run on FreeBSD. I needed to make the following source changes, they are all #if'd so shouldn't interfere with anything else.

Add some needed includes
Provide freebsd variation of get_executable_path
Provide variation of execv so that either full path or appname to be found within $PATH can be used
