### PR TITLE
Adjustment to x11/detect.py

### DIFF
--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -70,24 +70,23 @@ def configure(env):
 		else:
 			env["bits"]="32"
 
-
 	env.Append(CPPPATH=['#platform/x11'])
 	if (env["use_llvm"]=="yes"):
-		env["CC"]="clang"
-		env["CXX"]="clang++"
-		env["LD"]="clang++"
-		if (env["use_sanitizer"]=="yes"):
-			env.Append(CXXFLAGS=['-fsanitize=address','-fno-omit-frame-pointer'])
-			env.Append(LINKFLAGS=['-fsanitize=address'])
-			env.extra_suffix=".llvms"
-		else:
-			env.extra_suffix=".llvm"
+		if 'clang++' not in env['CXX']:
+			env["CC"]="clang"
+			env["CXX"]="clang++"
+			env["LD"]="clang++"
+		env.Append(CPPFLAGS=['-DTYPED_METHOD_BIND'])
+		env.extra_suffix=".llvm"
+
 		if (env["colored"]=="yes"):
 			if sys.stdout.isatty():
 				env.Append(CXXFLAGS=["-fcolor-diagnostics"])
 
-
-
+	if (env["use_sanitizer"]=="yes"):
+		env.Append(CXXFLAGS=['-fsanitize=address','-fno-omit-frame-pointer'])
+		env.Append(LINKFLAGS=['-fsanitize=address'])
+		env.extra_suffix+="s"
 
 	#if (env["tools"]=="no"):
 	#	#no tools suffix
@@ -140,11 +139,6 @@ def configure(env):
 		env.Append(CPPFLAGS=['-m64'])
 		env.Append(LINKFLAGS=['-m64','-L/usr/lib/i686-linux-gnu'])
 
-
-	if (env["CXX"]=="clang++"):
-		env.Append(CPPFLAGS=['-DTYPED_METHOD_BIND'])
-		env["CC"]="clang"
-		env["LD"]="clang++"
 
 	import methods
 


### PR DESCRIPTION
Test if clang is defined in CC/CXX/LD - this allows a specific version of clang to be defined, which may be a full path or have a version suffix.
Move appending -DTYPED_METHOD_BIND to keep clang options together

Move sanitize option out of use_llvm test, gcc48+ also supports sanitize=address
Not sure with env.extra_suffix after sanitize, would this way leave a trailing 's' not in a location desired?
