### PR TITLE
changed PolygonPathFinder::get_closest_point to return the closest posit...

### DIFF
--- a/scene/resources/polygon_path_finder.cpp
+++ b/scene/resources/polygon_path_finder.cpp
@@ -525,23 +525,31 @@ bool PolygonPathFinder::is_point_inside(const Vector2& p_point) const {
 
 Vector2 PolygonPathFinder::get_closest_point(const Vector2& p_point) const {
 
-	int closest_idx=-1;
 	float closest_dist=1e20;
-	for(int i=0;i<points.size()-2;i++) {
+	Vector2 closest_point;
 
-		float d = p_point.distance_squared_to(points[i].pos);
+	for (Set<Edge>::Element *E=edges.front();E;E=E->next()) {
+
+		const Edge& e=E->get();
+		Vector2 seg[2]={
+			points[e.points[0]].pos,
+			points[e.points[1]].pos
+		};
+
+
+		Vector2 closest = Geometry::get_closest_point_to_segment_2d(p_point,seg);
+		float d = p_point.distance_squared_to(closest);
+
 		if (d<closest_dist) {
 			closest_dist=d;
-			closest_idx=i;
+			closest_point=closest;
 		}
-
 	}
+	
+	ERR_FAIL_COND_V(closest_dist==1e20,Vector2());
 
-	ERR_FAIL_COND_V(closest_idx==-1,Vector2());
-
-	return points[closest_idx].pos;
+	return closest_point;
 }
-
 
 Vector<Vector2> PolygonPathFinder::get_intersections(const Vector2& p_from, const Vector2& p_to) const {
 


### PR DESCRIPTION
...ion inside, rather then the closest vertex.

This seems to be of much more practical use than returning the closest vertex.  Perhaps two different functions would be appropriate, one for each interpretation of "closest point".
