### PR TITLE
fix get_joy_name() on windows

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -54,6 +54,8 @@
 #include "io/marshalls.h"
 
 #include "shlobj.h"
+#include <regstr.h>
+
 static const WORD MAX_CONSOLE_LINES = 1500;
 
 extern "C" {
@@ -685,6 +687,48 @@ LRESULT CALLBACK WndProc(HWND	hWnd,UINT uMsg,	WPARAM	wParam,	LPARAM	lParam)	{
 
 }
 
+
+String OS_Windows::get_joystick_name(int id, JOYCAPS jcaps)
+{
+	char buffer [256];
+	char OEM [256];
+	HKEY hKey;
+	DWORD sz;
+	int res;
+
+	_snprintf(buffer, sizeof(buffer), "%s\\%s\\%s",
+				REGSTR_PATH_JOYCONFIG, jcaps.szRegKey,
+				REGSTR_KEY_JOYCURR );
+	res = RegOpenKeyEx(HKEY_LOCAL_MACHINE, buffer, 0, KEY_QUERY_VALUE, &hKey);
+	if (res != ERROR_SUCCESS)
+	{
+		res = RegOpenKeyEx(HKEY_CURRENT_USER, buffer, 0, KEY_QUERY_VALUE, &hKey);
+		if (res != ERROR_SUCCESS) 
+			return "";
+	}
+
+	sz = sizeof(OEM);
+	_snprintf( buffer, sizeof(buffer), "Joystick%d%s", id + 1, REGSTR_VAL_JOYOEMNAME);
+	res = RegQueryValueEx ( hKey, buffer, 0, 0, (LPBYTE) OEM, &sz);
+	RegCloseKey ( hKey );
+	if (res != ERROR_SUCCESS) 
+		return "";
+
+	_snprintf( buffer, sizeof(buffer), "%s\\%s", REGSTR_PATH_JOYOEM, OEM);
+	res = RegOpenKeyEx ( HKEY_LOCAL_MACHINE, buffer, 0, KEY_QUERY_VALUE, &hKey);
+	if (res != ERROR_SUCCESS) 
+		return "";
+
+	sz = sizeof(buffer);
+	res = RegQueryValueEx(hKey, REGSTR_VAL_JOYOEMNAME, 0, 0, (LPBYTE) buffer,
+						  &sz);
+	RegCloseKey(hKey);
+	if (res != ERROR_SUCCESS) 
+		return "";
+
+	return String(buffer);
+}
+
 void OS_Windows::probe_joysticks() {
 
 	static uint32_t last_attached = 0;
@@ -726,7 +770,13 @@ void OS_Windows::probe_joysticks() {
 			JOYCAPS jcaps;
 			MMRESULT res = joyGetDevCaps(JOYSTICKID1 + i, &jcaps, sizeof(jcaps));
 			if (res == JOYERR_NOERROR) {
-				joy.name = jcaps.szPname;
+				String name = get_joystick_name(JOYSTICKID1 + i, jcaps);
+				if ( name == "")
+					joy.name = jcaps.szPname;
+				else
+					joy.name = name;
+				
+					
 			};
 		};
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -187,6 +187,7 @@ protected:
 	void probe_joysticks();
 	void process_joysticks();
 	void process_key_events();
+	String get_joystick_name( int id, JOYCAPS jcaps);
 	
 	struct ProcessInfo {
 


### PR DESCRIPTION
The szPname field in joycaps contains "Microsoft PC-joystick driver" for
almost all devices. working around this by retrieving joystick name from
registry
