### PR TITLE
Fix some memory leaks on GLES2 and PackedData

### DIFF
--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -107,6 +107,14 @@ PackedData::PackedData() {
 	add_pack_source(memnew(PackedSourcePCK));
 }
 
+PackedData::~PackedData() {
+	for (int i=0; i<sources.size(); i++) {
+		memdelete(sources[i]);
+	}
+	sources.clear();
+	memdelete(root);
+	root = 0;
+}
 
 //////////////////////////////////////////////////////////////////
 

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -111,6 +111,7 @@ public:
 	_FORCE_INLINE_ bool has_path(const String& p_path);
 
 	PackedData();
+	virtual ~PackedData();
 };
 
 class PackSource {

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -9212,7 +9212,24 @@ bool RasterizerGLES2::ShadowBuffer::init(int p_size,bool p_use_depth) {
 
 }
 
+RasterizerGLES2::ShadowBuffer::~ShadowBuffer() {
+	if (fbo != 0)
+		glDeleteFramebuffers(1, &fbo);
+}
 
+void RasterizerGLES2::FrameBuffer::Luminance::free() {
+	if (color != 0)
+	{
+		glDeleteTextures(1, &color);
+		color = 0;
+	}
+	if (fbo != 0)
+	{
+		glDeleteFramebuffers(1, &fbo);
+		fbo = 0;
+	}
+	size = 0;
+}
 
 void RasterizerGLES2::_update_framebuffer() {
 
@@ -9243,11 +9260,9 @@ void RasterizerGLES2::_update_framebuffer() {
 		glDeleteTextures(1,&framebuffer.color);
 
 		for(int i=0;i<framebuffer.luminance.size();i++) {
-
-			glDeleteTextures(1,&framebuffer.luminance[i].color);
-			glDeleteFramebuffers(1,&framebuffer.luminance[i].fbo);
-
+			framebuffer.luminance[i].free();
 		}
+		framebuffer.luminance.clear();
 
 		for(int i=0;i<3;i++) {
 
@@ -9257,7 +9272,6 @@ void RasterizerGLES2::_update_framebuffer() {
 
 		glDeleteTextures(1,&framebuffer.sample_color);
 		glDeleteFramebuffers(1,&framebuffer.sample_fbo);
-		framebuffer.luminance.clear();
 		framebuffer.blur_size=0;
 		framebuffer.fbo=0;
 	}
@@ -9435,11 +9449,8 @@ void RasterizerGLES2::_update_framebuffer() {
 
 
 		for(int i=0;i<framebuffer.luminance.size();i++) {
-
-			glDeleteFramebuffers(1,&framebuffer.luminance[i].fbo);
-			glDeleteTextures(1,&framebuffer.luminance[i].color);
+			framebuffer.luminance[i].free();
 		}
-
 		framebuffer.luminance.clear();
 
 
@@ -9590,9 +9601,6 @@ void RasterizerGLES2::init() {
 	framebuffer.fbo=0;
 	framebuffer.width=0;
 	framebuffer.height=0;
-//	framebuffer.buff16=false;
-//	framebuffer.blur[0].fbo=false;
-//	framebuffer.blur[1].fbo=false;
 	framebuffer.active=false;
 
 
@@ -9774,8 +9782,12 @@ void RasterizerGLES2::init() {
 }
 
 void RasterizerGLES2::finish() {
-
-
+	free(default_material);
+	free(shadow_material);
+	free(overdraw_material);
+	for(int i=0;i<framebuffer.luminance.size();i++) {
+		framebuffer.luminance[i].free();
+	}
 }
 
 int RasterizerGLES2::get_render_info(VS::RenderInfo p_info) {
@@ -9999,6 +10011,9 @@ void RasterizerGLES2::reload_vram() {
 			framebuffer.blur[i].color=0;
 		}
 
+		for(int i=0;i<framebuffer.luminance.size();i++) {
+			framebuffer.luminance[i].free();
+		}
 		framebuffer.luminance.clear();
 
 	}

--- a/drivers/gles2/rasterizer_gles2.h
+++ b/drivers/gles2/rasterizer_gles2.h
@@ -1089,6 +1089,7 @@ class RasterizerGLES2 : public Rasterizer {
 		LightInstance *owner;
 		bool init(int p_size,bool p_use_depth);
 		ShadowBuffer() { size=0; depth=0; owner=NULL; }
+		~ShadowBuffer();
 	};
 
 	Vector<ShadowBuffer> near_shadow_buffers;
@@ -1132,7 +1133,7 @@ class RasterizerGLES2 : public Rasterizer {
 			GLuint fbo;
 			GLuint color;
 
-			Blur() { fbo=0; color=0; }
+			Blur() : fbo(0), color(0) {}
 		} blur[3];
 
 		struct Luminance {
@@ -1141,7 +1142,8 @@ class RasterizerGLES2 : public Rasterizer {
 			GLuint fbo;
 			GLuint color;
 
-			Luminance() { fbo=0; color=0; size=0;}
+			Luminance() : size(0), fbo(0), color(0) {}
+			void free();
 		};
 
 		Vector<Luminance> luminance;
@@ -1149,9 +1151,9 @@ class RasterizerGLES2 : public Rasterizer {
 		GLuint sample_fbo;
 		GLuint sample_color;
 
-		FrameBuffer() {
-			blur_size=0;
-		}
+		FrameBuffer() : fbo(0), color(0), depth(0), width(0), height(0),
+			scale(1), active(false), blur_size(0), sample_fbo(0), sample_color(0)
+		{}
 
 	} framebuffer;
 


### PR DESCRIPTION
Leaks found via valgrind when I just launch the project selection screen.

Signed-off-by: Rodolfo Ribeiro Gomes rodolforg@gmail.com
