### PR TITLE
Camelcased script variables will now capitalize in the inspector.

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -482,7 +482,7 @@ void String::erase(int p_pos, int p_chars) {
 
 String String::capitalize() const {
 
-	String aux=this->replace("_"," ").to_lower();
+	String aux=this->camelcase_to_underscore().replace("_"," ").to_lower();
 	String cap;
 	for (int i=0;i<aux.get_slice_count(" ");i++) {
 		
@@ -498,6 +498,29 @@ String String::capitalize() const {
 	
 	return cap;
 }
+
+
+String String::camelcase_to_underscore() const {
+	const CharType * cstr = c_str();
+	String newString;
+	const char A = 'A', Z = 'Z';
+	int startIndex = 0;
+
+	for ( int i = 1; i < this->size()-1; i++ ) {
+		bool isCapital = cstr[i] >= A && cstr[i] <= Z;
+
+		if ( isCapital ) {
+			newString += "_" + this->substr(startIndex, i-startIndex);
+			startIndex = i;
+		}
+	}
+
+	newString += "_" + this->substr(startIndex, this->size()-startIndex);
+
+	return newString;
+}
+
+
 int String::get_slice_count(String p_splitter) const{
 
 	if (empty())

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -149,6 +149,7 @@ public:
 	static double to_double(const CharType* p_str, const CharType **r_end=NULL);
 	static int64_t to_int(const CharType* p_str,int p_len=-1);
 	String capitalize() const;
+	String camelcase_to_underscore() const;
 
 	int get_slice_count(String p_splitter) const;
 	String get_slice(String p_splitter,int p_slice) const;
@@ -225,8 +226,6 @@ public:
 	String(const char *p_str);
 	String(const CharType *p_str,int p_clip_to_len=-1);
 	String(const StrRange& p_range);
-
-
 };
 
 


### PR DESCRIPTION
Variables like this in GDScript:

export var aNewVariable
export var ANewVariable
export var aNew_variable
export var a_new_variable
etc...

Now, all show up as "A New Variable" in the inspector
