### PR TITLE
Make fullscreen go to the primary monitor under X11

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -190,7 +190,7 @@ void OS_X11::initialize(const VideoMode& p_desired,int p_video_driver,int p_audi
 		XChangeProperty(x11_display, x11_window, property, property, 32, PropModeReplace, (unsigned char *)&hints, 5);
 		XMapRaised(x11_display, x11_window);
 		XWindowAttributes xwa;
-		XGetWindowAttributes(x11_display, DefaultRootWindow(x11_display), &xwa);
+		XGetWindowAttributes(x11_display, x11_window, &xwa);
 		XMoveResizeWindow(x11_display, x11_window, 0, 0, xwa.width, xwa.height);
 
 		// code for netwm-compliants


### PR DESCRIPTION
This fixes #1408.

Prior to this change, fullscreen would always open on my second monitor (Ubuntu 14.10, dual head, nvidia driver). It _looks_ like `DefaultRootWindow(x11_display)` is returning bad information and the `XGetWindowAttributes()` call should be using the `x11_window` variable like all of the other calls. But I've never done any X11 programming so I don't fully understand what's going on here.
