### PR TITLE
Fixes platform/windows/detect.py

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -45,7 +45,7 @@
 #
 #			set PATH=C:\mingw-w64\bin;%PATH%
 #			set PATH=C:\mingw-w64\bin;%PATH%
-#			set MINGW32_PREFIX=C:\mingw-w64\bin\
+#			set MINGW32_PREFIX=C:\mingw-w32\bin\
 #			set MINGW64_PREFIX=C:\mingw-w64\bin\
 #
 #####

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -43,7 +43,7 @@
 #	For instance, you could store that set of commands into a .bat script
 #	that you would run just before scons :
 #
-#			set PATH=C:\mingw-w64\bin;%PATH%
+#			set PATH=C:\mingw-w32\bin;%PATH%
 #			set PATH=C:\mingw-w64\bin;%PATH%
 #			set MINGW32_PREFIX=C:\mingw-w32\bin\
 #			set MINGW64_PREFIX=C:\mingw-w64\bin\


### PR DESCRIPTION
- fixes issue #1298 and #1344 : under windows, too long `ar` command lines are now split into several smaller command lines.
- fixes issue #1285 : under linux, cross compiling with Mingw-w64 now generates actual 64bits EXE.
- `MINGW32_PREFIX` and `MINGW64_PREFIX` environment variables are also available for Windows.
- started to clean-up the remains of previous hacks and workarounds.
- added some documentation into the script.
