### PR TITLE
should fixes #1284 (KinematicBody .move() crash)

### DIFF
--- a/servers/physics/shape_sw.h
+++ b/servers/physics/shape_sw.h
@@ -438,7 +438,7 @@ struct MotionShapeSW : public ShapeSW {
 		}
 		return support;
 	}
-	virtual void get_supports(const Vector3& p_normal,int p_max,Vector3 *r_supports,int & r_amount) const {}
+	virtual void get_supports(const Vector3& p_normal,int p_max,Vector3 *r_supports,int & r_amount) const { r_amount=0; }
 	bool intersect_segment(const Vector3& p_begin,const Vector3& p_end,Vector3 &r_result, Vector3 &r_normal) const { return false; }
 
 	Vector3 get_moment_of_inertia(float p_mass) const { return Vector3(); }


### PR DESCRIPTION
I could reproduce the crash described in #1284 only with 32bits versions of godot.

The test scene contains a Plane collision shape, and a kinematicsbody with a Sphere collision shape.

The crash occurs into `CollisionSolverSW::solve_distance_plane()` on line 299 when `p_shape_A` is a `PlaneShapeSW` object and when `p_shape_B` is a `MotionShapeSW` object, because `int support_count;` is not initialized by default, and because `MotionShapeSW::get_supports()` does not change `support_count` once passed as referenced parameter, and if the default value of `support_count` is greater than the length of `supports[16]`.

I don't know if it is the good way to fix it because i'm not skilled ennough with the physics server inner working, but this fix prevents the crash and the test-scene seems to work correctly.
