### PR TITLE
remove column titles in property inspector

### DIFF
--- a/tools/editor/property_editor.cpp
+++ b/tools/editor/property_editor.cpp
@@ -3090,9 +3090,7 @@ PropertyEditor::PropertyEditor() {
 	
 	capitalize_paths=true;
 	autoclear=false;
-	tree->set_column_title(0,"Property");
-	tree->set_column_title(1,"Value");
-	tree->set_column_titles_visible(true);
+	tree->set_column_titles_visible(false);
 
 	keying=false;
 	read_only=false;


### PR DESCRIPTION
These are just wasting space. It's obvious that the value is on the right and the name is on the left.
