### PR TITLE
Changed *_scene() to *_tree() in the time-example

### DIFF
--- a/tools/script_plugins/time/time.gd
+++ b/tools/script_plugins/time/time.gd
@@ -21,12 +21,12 @@ func _init():
 	timer.set_one_shot(false)
 	timer.connect("timeout",self,"_timeout")
  
-func _enter_scene():
+func _enter_tree():
 	label = Label.new()
 	add_custom_control(CONTAINER_TOOLBAR,label)
 	timer.start()
 	
-func _exit_scene():
+func _exit_tree():
 	timer.stop()
 	label.free()
 	label=null


### PR DESCRIPTION
Changed _enter_scene and _exit_scene() to _enter_tree() and _exit_tree() in the time-example, because the *_scene no longer work.
