### PR TITLE
Detect multiple monitors using Xinerama extension for fullscreen

### DIFF
--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -39,6 +39,10 @@ def can_build():
 		print("xcursor not found.. x11 disabled.")
 		return False
 
+	x11_error=os.system("pkg-config xinerama --modversion > /dev/null")
+	if (x11_error):
+		print("xinerama not found.. x11 disabled.")
+		return False
 	
 	return True # X11 enabled
   
@@ -108,6 +112,7 @@ def configure(env):
 
 	env.ParseConfig('pkg-config x11 --cflags --libs')
 	env.ParseConfig('pkg-config xcursor --cflags --libs')
+	env.ParseConfig('pkg-config xinerama --cflags --libs')
 	env.ParseConfig('pkg-config openssl --cflags --libs')
 
 

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -36,6 +36,8 @@
 #include "servers/physics/physics_server_sw.h"
 
 #include "X11/Xutil.h"
+#include "X11/extensions/Xinerama.h"
+
 #include "main/main.h"
 
 
@@ -191,6 +193,25 @@ void OS_X11::initialize(const VideoMode& p_desired,int p_video_driver,int p_audi
 		XMapRaised(x11_display, x11_window);
 		XWindowAttributes xwa;
 		XGetWindowAttributes(x11_display, DefaultRootWindow(x11_display), &xwa);
+
+		// Check for multiple monitors and go full screen on screen 0
+		int event_base;
+		int error_base;
+		bool xineramaActive = XineramaQueryExtension(x11_display, &event_base, &error_base);
+		if (xineramaActive) {
+			int screen_count;
+			XineramaScreenInfo* screen = XineramaQueryScreens(x11_display, &screen_count);
+			if (screen_count > 0) {
+				// for(int i = 0; i < screen_count; i++) {
+				// 	printf("Screen %d: %d,%d %dx%d\n", i, screen[i].x_org, screen[i].y_org, screen[i].width, screen[i].height);
+				// }
+				xwa.width = screen[0].width;
+				xwa.height = screen[0].height;
+				
+				XFree(screen);			
+			}
+		}
+
 		XMoveResizeWindow(x11_display, x11_window, 0, 0, xwa.width, xwa.height);
 
 		// code for netwm-compliants


### PR DESCRIPTION
This change includes the Xinerama extension and queries it when going
fullscreen. Xinerama has information about the actual monitors
connected in a multi-monitor configuration. X normally treats both
monitors as a single large screen. Xinerama allows us to get the
actual dimensions of attached screens. Nvidia TwinView and other
drivers use the Xinerama protocol so this should be compatible with
most multi-screen setups.

This forces fullscreen to always go to screen 0. This fixes #1408.
This also fixes the issue in some window managers (e.g. LXDE and
OpenBox) where Godot would stretch across both monitors.
