### PR TITLE
[Fix] make_dir_recursive on Windows

### DIFF
--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -270,7 +270,7 @@ Error DirAccessWindows::make_dir(String p_dir) {
 		return OK;
 	};
 
-	if (err == ERROR_ALREADY_EXISTS) {
+	if (err == ERROR_ALREADY_EXISTS || err == ERROR_ACCESS_DENIED) {
 		return ERR_ALREADY_EXISTS;
 	};
 


### PR DESCRIPTION
function normally tries to create c: which isn't possible, because the access is denied, handling ERROR_ACCESS_DENIED as ERR_ALREADY_EXISTS lets the function skip the creation of c: .
