### PR TITLE
Fix for dialog label text going out of popup.

### DIFF
--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -329,7 +329,7 @@ AcceptDialog::AcceptDialog() {
 	label->set_anchor(MARGIN_BOTTOM,ANCHOR_END);
 	label->set_begin( Point2( margin, margin) );
 	label->set_end( Point2( margin, button_margin+10) );
-	//label->set_autowrap(true);
+	label->set_autowrap(true);
 	add_child(label);
 
 	hbc = memnew( HBoxContainer );


### PR DESCRIPTION
In the latest code, the dialog box text shows up outside the box when it's too long. 
