### PR TITLE
Update file_access_windows.cpp for mingw cross-compile

### DIFF
--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -28,8 +28,10 @@
 /*************************************************************************/
 #ifdef WINDOWS_ENABLED
 
-#include <Windows.h>
-#include "Shlwapi.h"
+#define WINVER 0x0500
+
+#include <windows.h>
+#include "shlwapi.h"
 #include "file_access_windows.h"
 
 


### PR DESCRIPTION
Cross compiling on linux failed on this file. Changing case of the windows.h and shlwapi.h allows mingw to find these headers but setting WINVER 0x0500 is needed for the compiler to find ReplaceFileW
