### PR TITLE
Fix Area when is_gravity_point is set

### DIFF
--- a/servers/physics/body_sw.cpp
+++ b/servers/physics/body_sw.cpp
@@ -358,7 +358,7 @@ void BodySW::_compute_area_gravity(const AreaSW *p_area) {
 
 	if (p_area->is_gravity_point()) {
 
-		gravity = (p_area->get_gravity_vector() - get_transform().get_origin()).normalized() * p_area->get_gravity();
+		gravity = (p_area->get_transform().get_origin()+p_area->get_gravity_vector() - get_transform().get_origin()).normalized() * p_area->get_gravity();
 
 	} else {
 		gravity = p_area->get_gravity_vector() * p_area->get_gravity();


### PR DESCRIPTION
Fix the gravity point feature for Area.
BodySW::_compute_area_gravity was not adding Area's vector from the origin.
