### PR TITLE
Fix for KinematicBody2D::move

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -992,7 +992,7 @@ Vector2 KinematicBody2D::move(const Vector2& p_motion) {
 			continue;
 
 		float lsafe,lunsafe;
-		bool valid = dss->cast_motion(get_shape(i)->get_rid(), get_global_transform() * get_shape_transform(i), p_motion, 0,lsafe,lunsafe,exclude,get_layer_mask(),mask);
+		bool valid = dss->cast_motion(get_shape(i)->get_rid(), get_global_transform() * get_shape_transform(i), p_motion, margin,lsafe,lunsafe,exclude,get_layer_mask(),mask);
 		//print_line("shape: "+itos(i)+" travel:"+rtos(ltravel));
 		if (!valid) {
 


### PR DESCRIPTION
The current implementation of KinematicBody2D::move() has some problems. See an example here https://drive.google.com/open?id=0BwT-rSmeee4IT3Q3WmR4aTQ3Skk&authuser=0 . In the example, the square moves down vertically; however, when it reaches the slope it seems to slowly slide until it falls from it.

The cause of the issue seems to be the following. There are three points where collision detection is used in KinematicBody2D::move(): 1) recover for current collision, 2) the actual movement and 3) the calculation of the remaining move vector. For 1) and 3), the margin attribute of the body is used as a parameter of the collision detection; however, for 2) it is not, and zero is used instead. This causes the body to approach other objects beyond its margin, and therefore the collision recovery in the next call forces the object to move away from the colliding object, causing, in the example, the "sliding" effect.

If the margin attribute is passed as argument for the collision detection in the movement part, the given example works as expected (the square does not slide).

That said, I don't know the exact purpose of the margin attribute altogether, and I don't know either if there is a reason for using 0 as margin in the movement part. The comment at the beginning of the method body is rather discouraging with respect to doing changes lightly. Please share your thoughts on it and let me know if the fix is actually not valid.
