### PR TITLE
Reverted change to classHint

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -299,9 +299,8 @@ void OS_X11::initialize(const VideoMode& p_desired,int p_video_driver,int p_audi
 	/* set the name and class hints for the window manager to use */
 	classHint = XAllocClassHint();
 	if (classHint) {
-		char wmclass[] = "Godot";
-		classHint->res_name = wmclass;
-		classHint->res_class = wmclass;
+		classHint->res_name = "Godot";
+		classHint->res_class = "Godot";
 	}
 	XSetClassHint(x11_display, x11_window, classHint);
 	XFree(classHint);


### PR DESCRIPTION
This reverts the change made in 15bee515e63f8d9d93fc9aacd00f2b99e37cd58b

Using `char wmclass[] = "Godot"` causes `xprop` to
report the following for WM_CLASS:

`WM_CLASS(STRING) = "\200\326\322\365\377\177", "\200\326\322\365\377\177"`

This makes the Unity window manager in Ubuntu fail to connect the running app
with the icon on the launcher. This change fixes WM_CLASS so it reports "Godot" again.
