### PR TITLE
Add missing iostream include to editor_import.collada.cpp

### DIFF
--- a/tools/editor/io_plugins/editor_import_collada.cpp
+++ b/tools/editor/io_plugins/editor_import_collada.cpp
@@ -26,6 +26,8 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
+#include <iostream>
+
 #include "editor_import_collada.h"
 #include "collada/collada.h"
 #include "scene/3d/spatial.h"


### PR DESCRIPTION
I was trying to build in Ubuntu 14.10 with gcc 4.9.1, and this file was giving me a multitude of errors along the lines of "cout is not a member of std". Seems to me that if the file is referencing cout and endl, it should include iostream, and in any case this patch allowed my build to proceed to completion.
