### PR TITLE
Camel casing being capitalized only happens in the inspector now.

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -498,6 +498,27 @@ String String::capitalize() const {
 	
 	return cap;
 }
+
+String String::camelcase_to_underscore() const {
+	const CharType * cstr = c_str();
+	String newString;
+	const char A = 'A', Z = 'Z';
+	int startIndex = 0;
+
+	for ( int i = 1; i < this->size()-1; i++ ) {
+		bool isCapital = cstr[i] >= A && cstr[i] <= Z;
+
+		if ( isCapital ) {
+			newString += "_" + this->substr(startIndex, i-startIndex);
+			startIndex = i;
+		}
+	}
+
+	newString += "_" + this->substr(startIndex, this->size()-startIndex);
+
+	return newString;
+}
+
 int String::get_slice_count(String p_splitter) const{
 
 	if (empty())

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -149,6 +149,7 @@ public:
 	static double to_double(const CharType* p_str, const CharType **r_end=NULL);
 	static int64_t to_int(const CharType* p_str,int p_len=-1);
 	String capitalize() const;
+	String camelcase_to_underscore() const;
 
 	int get_slice_count(String p_splitter) const;
 	String get_slice(String p_splitter,int p_slice) const;

--- a/tools/editor/property_editor.cpp
+++ b/tools/editor/property_editor.cpp
@@ -2258,7 +2258,7 @@ void PropertyEditor::update_tree() {
 		}
 
 		if (capitalize_paths)
-			item->set_text( 0, name.capitalize() );
+			item->set_text( 0, name.camelcase_to_underscore().capitalize() );
 		else
 			item->set_text( 0, name );
 


### PR DESCRIPTION
Fixed camel casing being in the capitalize function. It now only occurs when setting the text for the inspector.
