### PR TITLE
Implement combine mode for area

### DIFF
--- a/core/vector.h
+++ b/core/vector.h
@@ -149,7 +149,16 @@ public:
 		sort_custom<_DefaultComparator<T> >();
 	}
 
+	void ordered_insert(const T& p_val) {
+			int i;
+			for (i=0; i<size(); i++) {
 
+				if (p_val < operator[](i)) {
+					break;
+				};
+			};
+			insert(i, p_val);
+	}
 
 	void operator=(const Vector& p_from);
 	Vector(const Vector& p_from);

--- a/servers/physics/body_sw.cpp
+++ b/servers/physics/body_sw.cpp
@@ -358,10 +358,10 @@ void BodySW::_compute_area_gravity(const AreaSW *p_area) {
 
 	if (p_area->is_gravity_point()) {
 
-		gravity = (p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin()).normalized() * p_area->get_gravity();
+		gravity += (p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin()).normalized() * p_area->get_gravity();
 
 	} else {
-		gravity = p_area->get_gravity_vector() * p_area->get_gravity();
+		gravity += p_area->get_gravity_vector() * p_area->get_gravity();
 	}
 }
 
@@ -371,23 +371,28 @@ void BodySW::integrate_forces(real_t p_step) {
 	if (mode==PhysicsServer::BODY_MODE_STATIC)
 		return;
 
-	AreaSW *current_area = get_space()->get_default_area();
-	ERR_FAIL_COND(!current_area);
+	AreaSW *def_area = get_space()->get_default_area();
+	ERR_FAIL_COND(!def_area);
 
-	int prio = current_area->get_priority();
 	int ac = areas.size();
+	bool replace = false;
+	gravity=Vector3(0,0,0);
 	if (ac) {
 		const AreaCMP *aa = &areas[0];
-		for(int i=0;i<ac;i++) {
-			if (aa[i].area->get_priority() > prio) {
-				current_area=aa[i].area;
-				prio=current_area->get_priority();
+		density = aa[ac-1].area->get_density();
+		for(int i=ac-1;i>=0;i--) {
+			_compute_area_gravity(aa[i].area);
+			if (aa[i].area->get_space_override_mode() == PhysicsServer::AREA_SPACE_OVERRIDE_REPLACE) {
+				replace = true;
+				break;
 			}
 		}
+	} else {
+		density=def_area->get_density();
 	}
-
-	_compute_area_gravity(current_area);
-	density=current_area->get_density();
+	if( !replace ) {
+		_compute_area_gravity(def_area);
+	}
 
 	Vector3 motion;
 	bool do_motion=false;
@@ -455,7 +460,7 @@ void BodySW::integrate_forces(real_t p_step) {
 	}
 
 
-	current_area=NULL; // clear the area, so it is set in the next frame
+	def_area=NULL; // clear the area, so it is set in the next frame
 	contact_count=0;
 
 }

--- a/servers/physics/body_sw.cpp
+++ b/servers/physics/body_sw.cpp
@@ -378,6 +378,7 @@ void BodySW::integrate_forces(real_t p_step) {
 	bool replace = false;
 	gravity=Vector3(0,0,0);
 	if (ac) {
+		areas.sort();
 		const AreaCMP *aa = &areas[0];
 		density = aa[ac-1].area->get_density();
 		for(int i=ac-1;i>=0;i--) {

--- a/servers/physics/body_sw.h
+++ b/servers/physics/body_sw.h
@@ -84,13 +84,13 @@ class BodySW : public CollisionObjectSW {
 	struct AreaCMP {
 
 		AreaSW *area;
-		_FORCE_INLINE_ bool operator<(const AreaCMP& p_cmp) const { return area->get_self() < p_cmp.area->get_self() ; }
+		_FORCE_INLINE_ bool operator==(const AreaCMP& p_cmp) const { return area->get_self() == p_cmp.area->get_self();}
+		_FORCE_INLINE_ bool operator<(const AreaCMP a) const { return area->get_priority() < a.area->get_priority();}
 		_FORCE_INLINE_ AreaCMP() {}
 		_FORCE_INLINE_ AreaCMP(AreaSW *p_area) { area=p_area;}
 	};
 
-
-	VSet<AreaCMP> areas;
+	Vector<AreaCMP> areas;
 
 	struct Contact {
 
@@ -134,8 +134,7 @@ public:
 
 	void set_force_integration_callback(ObjectID p_id,const StringName& p_method,const Variant& p_udata=Variant());
 
-
-	_FORCE_INLINE_ void add_area(AreaSW *p_area) { areas.insert(AreaCMP(p_area)); }
+	_FORCE_INLINE_ void add_area(AreaSW *p_area) { areas.ordered_insert(AreaCMP(p_area)); }
 	_FORCE_INLINE_ void remove_area(AreaSW *p_area) { areas.erase(AreaCMP(p_area)); }
 
 	_FORCE_INLINE_ void set_max_contacts_reported(int p_size) { contacts.resize(p_size); contact_count=0; if (mode==PhysicsServer::BODY_MODE_KINEMATIC && p_size) set_active(true);}


### PR DESCRIPTION
Slower implementation of #1559 that does not break when area priority is changed programmatically.
The area order calculation is done on every integration step.
