### PR TITLE
fixes #makes_editorhelp_uses_editor_settings_bg_color

### DIFF
--- a/tools/editor/editor_help.cpp
+++ b/tools/editor/editor_help.cpp
@@ -1390,7 +1390,9 @@ EditorHelp::EditorHelp(EditorNode *p_editor) {
 
 	{
 		PanelContainer *pc = memnew( PanelContainer );
-		pc->add_style_override("panel",get_stylebox("normal","TextEdit"));
+		Ref<StyleBoxFlat> style( memnew( StyleBoxFlat ) );
+		style->set_bg_color( EditorSettings::get_singleton()->get("text_editor/background_color") );	
+		pc->add_style_override("panel", style); //get_stylebox("normal","TextEdit"));
 		h_split->add_child(pc);
 		class_desc = memnew( RichTextLabel );
 		pc->add_child(class_desc);


### PR DESCRIPTION
This fixes issue #332 by using the "text_editor/background_color" editor
setting as background color for the EditorHelp.
