### PR TITLE
add : bool Object.is_queued_for_deletion()

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1503,6 +1503,8 @@ void Object::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("XL_MESSAGE","message"),&Object::XL_MESSAGE);
 	ObjectTypeDB::bind_method(_MD("tr","message"),&Object::tr);
 
+	ObjectTypeDB::bind_method(_MD("is_queued_for_deletion"),&Object::is_queued_for_deletion);
+
 	ADD_SIGNAL( MethodInfo("script_changed"));
 
 	BIND_VMETHOD( MethodInfo("_notification",PropertyInfo(Variant::INT,"what")) );
@@ -1566,6 +1568,10 @@ void Object::get_translatable_strings(List<String> *p_strings) const {
 
 }
 
+bool Object::is_queued_for_deletion() const {
+	return _is_queued_for_deletion;
+}
+
 #ifdef TOOLS_ENABLED
 void Object::set_edited(bool p_edited) {
 
@@ -1587,6 +1593,7 @@ Object::Object() {
 	_instance_ID=0;
 	_instance_ID = ObjectDB::add_instance(this);
 	_can_translate=true;
+	_is_queued_for_deletion=false;
 	script_instance=NULL;
 #ifdef TOOLS_ENABLED
 

--- a/core/object.h
+++ b/core/object.h
@@ -588,7 +588,7 @@ public:
 	StringName XL_MESSAGE(const StringName& p_message) const; //translate message (internationalization)
 	StringName tr(const StringName& p_message) const; //translate message (alternative)
 
-	bool _is_queued_for_deletion; // set to true by SceneTree::queue_delete(), and returned by 
+	bool _is_queued_for_deletion; // set to true by SceneTree::queue_delete()
 	bool is_queued_for_deletion() const; 
 
 	_FORCE_INLINE_ void set_message_translation(bool p_enable) { _can_translate=p_enable; }

--- a/core/object.h
+++ b/core/object.h
@@ -397,7 +397,6 @@ friend void postinitialize_handler(Object*);
 
 protected:	
 
-
 	virtual bool _use_builtin_script() const { return false; }
 	virtual void _initialize_typev() { initialize_type(); }
 	virtual bool _setv(const StringName& p_name,const Variant &p_property) { return false; };
@@ -588,6 +587,9 @@ public:
 
 	StringName XL_MESSAGE(const StringName& p_message) const; //translate message (internationalization)
 	StringName tr(const StringName& p_message) const; //translate message (alternative)
+
+	bool _is_queued_for_deletion; // set to true by SceneTree::queue_delete(), and returned by 
+	bool is_queued_for_deletion() const; 
 
 	_FORCE_INLINE_ void set_message_translation(bool p_enable) { _can_translate=p_enable; }
 	_FORCE_INLINE_ bool can_translate_messages() const { return _can_translate; }

--- a/scene/main/scene_main_loop.cpp
+++ b/scene/main/scene_main_loop.cpp
@@ -850,6 +850,7 @@ void SceneTree::queue_delete(Object *p_object) {
 
 	_THREAD_SAFE_METHOD_
 	ERR_FAIL_NULL(p_object);
+	p_object->_is_queued_for_deletion = true;
 	delete_queue.push_back(p_object->get_instance_ID());
 }
 


### PR DESCRIPTION
This adds an `Object.is_queued_for_deletion()` method which returns true if the object has just been
`object.queue_free()` or `SceneTree.queue_delete(object)`.

( note : of course, the object must have not been deleted already. )
