### PR TITLE
(Crash fix) script will not be able to extend itself

### DIFF
--- a/modules/gdscript/gd_script.cpp
+++ b/modules/gdscript/gd_script.cpp
@@ -1689,7 +1689,7 @@ bool GDScript::_update_exports() {
 			}
 
 
-			if (c->extends_used && String(c->extends_file)!="") {
+			if (c->extends_used && String(c->extends_file)!="" && String(c->extends_file) != get_path()) {
 
 				String path = c->extends_file;
 				if (path.is_rel_path()) {


### PR DESCRIPTION
Crash fix - edtior will no longer crash when a script is trying to extend itself. This fixes #1572
