### PR TITLE
(Fix crash) in visual shader for curve remap node

### DIFF
--- a/modules/gdscript/gd_script.cpp
+++ b/modules/gdscript/gd_script.cpp
@@ -1689,7 +1689,7 @@ bool GDScript::_update_exports() {
 			}
 
 
-			if (c->extends_used && String(c->extends_file)!="") {
+			if (c->extends_used && String(c->extends_file)!="" && String(c->extends_file) != get_path()) {
 
 				String path = c->extends_file;
 				if (path.is_rel_path()) {

--- a/tools/editor/plugins/shader_graph_editor_plugin.cpp
+++ b/tools/editor/plugins/shader_graph_editor_plugin.cpp
@@ -376,7 +376,7 @@ void GraphCurveMapEdit::_input_event(const InputEvent& p_event) {
 		update();
 	}
 
-	if (p_event.type==InputEvent::MOUSE_MOTION && grabbing) {
+	if (p_event.type==InputEvent::MOUSE_MOTION && grabbing  && grabbed != -1) {
 
 		Point2 p = Vector2(p_event.mouse_button.x,p_event.mouse_button.y)/get_size();
 		p.y=1.0-p.y;


### PR DESCRIPTION
Should not crash godot anymore when adding a keypoint and deleting it while still holding mouse button down.
