### PR TITLE
Add scons custom extra suffix

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -175,7 +175,7 @@ if selected_platform in platform_list:
 	else:
 		env = env_base.Clone()
 
-	env.extra_suffix=""
+	env.extra_suffix=env["extra_suffix"]
 
 	CCFLAGS = env.get('CCFLAGS', '')
 	env['CCFLAGS'] = ''
@@ -226,7 +226,7 @@ if selected_platform in platform_list:
 	elif (env["bits"]=="64"):
 		suffix+=".64"
 
-	suffix+=env.extra_suffix
+	suffix+="."+env.extra_suffix
 
 	env["PROGSUFFIX"]=suffix+env["PROGSUFFIX"]
 	env["OBJSUFFIX"]=suffix+env["OBJSUFFIX"]

--- a/SConstruct
+++ b/SConstruct
@@ -121,6 +121,7 @@ opts.Add("LINKFLAGS", "Custom flags for the linker");
 opts.Add('disable_3d', 'Disable 3D nodes for smaller executable (yes/no)', "no")
 opts.Add('disable_advanced_gui', 'Disable advance 3D gui nodes and behaviors (yes/no)', "no")
 opts.Add('colored', 'Enable colored output for the compilation (yes/no)', 'no')
+opts.Add('extra_suffix', 'Custom extra suffix added to the base filename of all generated binary files.', '')
 
 # add platform specific options
 


### PR DESCRIPTION
makes it possible to add a custom extra suffix to the base filename of all generated binary files.

example :
`scons p=windows extra_suffix=yourBranchName`
or
`scons p=windows bits=32 extra_suffix=v20150401_1642`
or
`scons p=windows extra_suffix=msvc2010_git20150401`
