### PR TITLE
Fixed crash in viewport object picking.

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -406,7 +406,7 @@ void Viewport::_notification(int p_what) {
 						int rc = ss2d->intersect_point(point,res,64,Set<RID>(),0xFFFFFFFF,0xFFFFFFFF);
 						for(int i=0;i<rc;i++) {
 
-							if (res[i].collider) {
+							if (res[i].collider_id && res[i].collider) {
 								CollisionObject2D *co=res[i].collider->cast_to<CollisionObject2D>();
 								if (co) {
 


### PR DESCRIPTION
Bullet shower demo crashed because of dynamic casting in the code for object picking. Making sure the object has an ID greater than 0 before typecasting solves it. Fixes #1592
