### PR TITLE
windows' fix for issues #1357 and #1636 : delayed MouseWheel button release events

### DIFF
--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -55,6 +55,11 @@
 
 #include <fcntl.h>
 #include <stdio.h>
+
+#define WM_USER_FAKE_MOUSEWHEEL_UP_RELEASE WM_USER+123
+#define WM_USER_FAKE_MOUSEWHEEL_DOWN_RELEASE WM_USER+124
+#define FAKE_MOUSEWHEEL_RELEASE_DELAY_IN_TICKS 100000
+
 /**
 	@author Juan Linietsky <reduzio@gmail.com>
 */
@@ -151,6 +156,15 @@ class OS_Windows : public OS {
 	bool force_quit;
 	uint32_t last_button_state;
 
+	// --- Simulate MouseWheel button release events :
+	int last_mouse_wheel_up_ticks; // date-time in ticks when the event occured
+	int fake_mouse_wheel_up_release_after; // tristate : -1 = early release, 0 = disabled, >0 = date-time in ticks after which the release should occur
+	int last_mouse_wheel_down_ticks;
+	int fake_mouse_wheel_down_release_after;
+	WPARAM last_mouse_wparam;
+	LPARAM last_mouse_lparam;
+	// ---
+	
 	CursorShape cursor_shape;
 
 	InputDefault *input;


### PR DESCRIPTION
This makes BUTTON_WHEEL_UP/DOWN readable like any other mouse button
using `Input.is_mouse_button_pressed()` or `Input.is_action_pressed()`.

It simulates a delay between the "mousewheel press" event and the fake
"mousewheel release" event.

**I describe the intended behavior here, so it could be easily
reimplemented for other platforms :**

The fake release event is scheduled to occurs 100ms after the press
event, which makes it catchable into any gdscript process function (as
long as the delta is smaller than 100ms indeed).

WheelUp and WheelDown cancel each others by immediately triggering an
early release event if one was scheduled. Overlapping WheelUp and
WheelDown is thus impossible.

If several "WheelUp press" (or several "WheelDown press") events occurs
in less than 100ms, the matching release event is simply postponed to
occur 100ms after the last "wheel press" event.

The states of the BUTTON_WHEEL_UP/DOWN are also accessible through
Input.get_mouse_button_mask() respectively as bits 4 and 5.

**What behavior does it change into the Editor ?**

The only change I have noticed is that when you mouse-wheel over the 2D
or 3D viewports, it zooms in and out into two half steps instead of just
one. But this behavior was already happening before this patch. It's
just that it was not noticeable because there was no delay between the
press event and the fake release event.

**TODO (by someone else) :**
- reimplement it on Linux and MacOS
- then, add `BUTTON_MASK_WHEEL_UP = 4` and `BUTTON_MASK_WHEEL_DOWN = 5`
  into `input_event.h` and bind them into `globals_constants.cpp`.
- replace the FAKE_MOUSEWHEEL_RELEASE_DELAY_IN_TICKS constant by a
  project setting to allow to choose the fake release delay

it fixes #1357 and #1636 for windows platform only.
