### PR TITLE
Don't uncamelcase str containing underscore

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -500,6 +500,8 @@ String String::capitalize() const {
 }
 
 String String::camelcase_to_underscore() const {
+	if ( this->find(String("_")) >=0 ) 
+		return *this; // a string containing underscore might already be uncamelcased. Ex : "test_AABB_collision"
 	const CharType * cstr = c_str();
 	String newString;
 	const char A = 'A', Z = 'Z';


### PR DESCRIPTION
Currently, `"test_AABB_collision"` is uncamelcased to `"test_A_A_B_B_collision"`.

So I propose that `String::camelcase_to_underscore()` ignores strings already containing an underscore.
