### PR TITLE
Scripts now have default code when created from the inspector.

### DIFF
--- a/core/object.h
+++ b/core/object.h
@@ -550,6 +550,7 @@ public:
 	
 	void set_script(const RefPtr& p_script);
 	RefPtr get_script() const;
+	virtual String get_default_gdscript_code() const { return ""; }
 
 	/* SCRIPT */
 

--- a/core/resource.h
+++ b/core/resource.h
@@ -119,7 +119,9 @@ protected:
 	void _set_path(const String& p_path);
 	void _take_over_path(const String& p_path);
 public:
-	
+
+	virtual void setup_new_resource(Object *p_owner) {}
+
 	virtual bool can_reload_from_file();
 	virtual void reload_from_file();
 

--- a/modules/gdscript/gd_editor.cpp
+++ b/modules/gdscript/gd_editor.cpp
@@ -45,8 +45,14 @@ void GDScriptLanguage::get_string_delimiters(List<String> *p_delimiters) const {
 }
 String GDScriptLanguage::get_template(const String& p_class_name, const String& p_base_class_name) const {
 
-	String _template = String()+
-	"\nextends %BASE%\n\n"+
+	String _template = String()+"\nextends %BASE%\n\n"+get_template_body();
+
+	return _template.replace("%BASE%",p_base_class_name);
+}
+
+
+String GDScriptLanguage::get_template_body() const {
+	return String()+
 	"# member variables here, example:\n"+
 	"# var a=2\n"+
 	"# var b=\"textvar\"\n\n"+
@@ -55,8 +61,6 @@ String GDScriptLanguage::get_template(const String& p_class_name, const String& 
 	"\tpass\n"+
 	"\n"+
 	"\n";
-
-	return _template.replace("%BASE%",p_base_class_name);
 }
 
 

--- a/modules/gdscript/gd_script.h
+++ b/modules/gdscript/gd_script.h
@@ -328,6 +328,10 @@ public:
 
 	Variant _new(const Variant** p_args,int p_argcount,Variant::CallError& r_error);
 	virtual bool can_instance() const;
+	virtual void setup_new_resource(Object* p_owner) {
+		String code = p_owner->get_default_gdscript_code();
+		set_source_code("extends " + p_owner->get_type_name() + code);
+	}
 
 	virtual StringName get_instance_base_type() const; // this may not work in all scripts, will return empty if so
 	virtual ScriptInstance* instance_create(Object *p_this);

--- a/modules/gdscript/gd_script.h
+++ b/modules/gdscript/gd_script.h
@@ -330,7 +330,7 @@ public:
 	virtual bool can_instance() const;
 	virtual void setup_new_resource(Object* p_owner) {
 		String code = p_owner->get_default_gdscript_code();
-		set_source_code("extends " + p_owner->get_type_name() + code);
+		set_source_code("\nextends " + p_owner->get_type_name() + code);
 	}
 
 	virtual StringName get_instance_base_type() const; // this may not work in all scripts, will return empty if so
@@ -505,6 +505,7 @@ public:
 	virtual void get_comment_delimiters(List<String> *p_delimiters) const;
 	virtual void get_string_delimiters(List<String> *p_delimiters) const;
 	virtual String get_template(const String& p_class_name, const String& p_base_class_name) const;
+	String get_template_body() const;
 	virtual bool validate(const String& p_script,int &r_line_error,int &r_col_error,String& r_test_error, const String& p_path="",List<String> *r_functions=NULL) const;
 	virtual Script *create_script() const;
 	virtual bool has_named_classes() const;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1234,7 +1234,18 @@ String Node::get_filename() const {
 	return data.filename;
 }
 
+String Node::get_default_gdscript_code() const {
+	String code;
 
+	code += "\n\n# Initialization code here...";
+	code += "\nfunc _ready():";
+	code += "\n\tset_process(true)";
+	code += "\n\n# _process() executes each frame";
+	code += "\nfunc _process(delta):";
+	code += "\n\t# Code here...";
+
+	return code;
+}
 
 void Node::generate_instance_state() {
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -31,6 +31,7 @@
 #include "message_queue.h"
 #include "scene/scene_string_names.h"
 #include "scene/resources/packed_scene.h"
+#include "modules/gdscript/gd_script.h"
 #include "io/resource_loader.h"
 #include "viewport.h"
 
@@ -1235,14 +1236,9 @@ String Node::get_filename() const {
 }
 
 String Node::get_default_gdscript_code() const {
-	String code;
+	String code = String() + "\n\n";
 
-	code += "\n\n# Initialization code here...";
-	code += "\nfunc _ready():";
-	code += "\n\tset_process(true)";
-	code += "\n\n# _process() executes each frame";
-	code += "\nfunc _process(delta):";
-	code += "\n\t# Code here...";
+	code += GDScriptLanguage::get_singleton()->get_template_body();
 
 	return code;
 }

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -225,7 +225,9 @@ public:
 	
 	void set_filename(const String& p_filename);
 	String get_filename() const;
-	
+
+	virtual String get_default_gdscript_code() const;
+
 	/* NOTIFICATIONS */
 	
 	void propagate_notification(int p_notification);

--- a/tools/editor/property_editor.cpp
+++ b/tools/editor/property_editor.cpp
@@ -195,6 +195,7 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 					Resource *res=obj->cast_to<Resource>();
 					ERR_BREAK( !res );
 
+					res->setup_new_resource(owner);
 					v=Ref<Resource>(res).get_ref_ptr();
 					emit_signal("variant_changed");
 


### PR DESCRIPTION
When creating a new script in the inspector for anything deriving from Object it will automatically fill in the "extends" at the top of the script.

IE. A script on a fixed material will automatically have...

``` python
extends FixedMaterial
```

Nodes have more filled out on them so new users can get up and going quicker and understand the very basics immediately...

``` python
extends Spatial

# Initialization code here...
func _ready():
    set_process(true)

# _process() executes each frame
func _process(delta):
    # Code here...
```

Any node type or other Object derivative can have its' own specific code by overriding the virtual method in the Object class:

``` c++
virtual String get_default_gdscript_code() const;
```
