### PR TITLE
Updating demo engine.cfgs where name is missing

### DIFF
--- a/demos/2d/isometric_light/engine.cfg
+++ b/demos/2d/isometric_light/engine.cfg
@@ -1,5 +1,6 @@
 [application]
 
+name="Isometric 2D + Lighting"
 main_scene="res://map.scn"
 
 [input]

--- a/demos/3d/truck_town/engine.cfg
+++ b/demos/3d/truck_town/engine.cfg
@@ -1,5 +1,6 @@
 [application]
 
+name="Truck Town"
 main_scene="res://car_select.scn"
 
 [display]

--- a/demos/gui/rich_text_bbcode/engine.cfg
+++ b/demos/gui/rich_text_bbcode/engine.cfg
@@ -1,3 +1,4 @@
 [application]
 
+name="Rich Text Label (BBCode)"
 main_scene="res://rich_text_bbcode.scn"

--- a/demos/misc/window_management/engine.cfg
+++ b/demos/misc/window_management/engine.cfg
@@ -1,6 +1,6 @@
 [application]
 
-name="window_management"
+name="Window Management"
 main_scene="res://window_management.scn"
 icon="icon.png"
 

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -3504,6 +3504,7 @@ EditorNode::EditorNode() {
 	p=file_menu->get_popup();
 	p->add_item("New Scene",FILE_NEW_SCENE);
 	p->add_item("Open Scene..",FILE_OPEN_SCENE,KEY_MASK_CMD+KEY_O);
+	p->add_separator();
 	p->add_item("Save Scene",FILE_SAVE_SCENE,KEY_MASK_CMD+KEY_S);
 	p->add_item("Save Scene As..",FILE_SAVE_AS_SCENE,KEY_MASK_SHIFT+KEY_MASK_CMD+KEY_S);
 	p->add_separator();


### PR DESCRIPTION
Tiny fix - adds logical names to a few demos that lacked them, to cut down on "Unnamed Project" listings in the project manager. (Also changing window_management to Window Management, for legibility.)
