### PR TITLE
Fix headless exporting bugs

### DIFF
--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -264,6 +264,7 @@ void EditorSettings::create() {
 
 	singleton = Ref<EditorSettings>( memnew( EditorSettings ) );
 	singleton->config_file_path=config_file_path;
+	singleton->settings_path=config_path+"/"+config_dir;
 	singleton->_load_defaults();
 	singleton->scan_plugins();
 

--- a/tools/editor/project_export.cpp
+++ b/tools/editor/project_export.cpp
@@ -479,6 +479,11 @@ Error ProjectExportDialog::export_platform(const String& p_platform, const Strin
 	if (err!=OK) {
 		error->set_text("Error exporting project!");
 		error->popup_centered_minsize();
+		ERR_PRINT("Exporting failed!");
+		if (p_quit_after) {
+			OS::get_singleton()->set_exit_code(255);
+			get_tree()->quit();
+		}
 		return ERR_CANT_CREATE;
 	} else {
 		if (p_quit_after) {


### PR DESCRIPTION
fixes two bugs. Firs one: on first run (when the config directory can't be found and one with the defaults is created), we don't set the settings variable. This leads headless exporting for android search for the template apk under `/` and not inside the  `~/.godot/` directory.

The second bug was that if configuration fails, e.g. because that said apk can't be found, the application neither prints an error nor exits. Instead, it hangs.
