### PR TITLE
Sort xml files, so order is constant

### DIFF
--- a/core/io/resource_format_xml.cpp
+++ b/core/io/resource_format_xml.cpp
@@ -2243,12 +2243,12 @@ void ResourceFormatSaverXMLInstance::write_property(const String& p_name,const V
 
 			List<Variant> keys;
 			dict.get_key_list(&keys);
+			keys.sort();
 
 			for(List<Variant>::Element *E=keys.front();E;E=E->next()) {
 
 				//if (!_check_type(dict[E->get()]))
 				//	continue;
-
 				bool ok;
 				write_property("",E->get(),&ok);
 				ERR_CONTINUE(!ok);
@@ -2438,7 +2438,7 @@ void ResourceFormatSaverXMLInstance::_find_resources(const Variant& p_variant,bo
 				return;
 
 			if (!p_main && (!bundle_resources ) && res->get_path().length() && res->get_path().find("::") == -1 ) {
-				external_resources.insert(res);
+				external_resources.push_back(res);
 				return;
 			}
 
@@ -2448,6 +2448,7 @@ void ResourceFormatSaverXMLInstance::_find_resources(const Variant& p_variant,bo
 			List<PropertyInfo> property_list;
 
 			res->get_property_list( &property_list );
+			property_list.sort();
 
 			List<PropertyInfo>::Element *I=property_list.front();
 
@@ -2525,7 +2526,7 @@ Error ResourceFormatSaverXMLInstance::save(const String &p_path,const RES& p_res
 	enter_tag("resource_file","type=\""+p_resource->get_type()+"\" subresource_count=\""+itos(saved_resources.size()+external_resources.size())+"\" version=\""+itos(VERSION_MAJOR)+"."+itos(VERSION_MINOR)+"\" version_name=\""+VERSION_FULL_NAME+"\"");
 	write_string("\n",false);
 
-	for(Set<RES>::Element *E=external_resources.front();E;E=E->next()) {
+	for(List<RES>::Element *E=external_resources.front();E;E=E->next()) {
 
 		write_tabs();
 		String p = E->get()->get_path();
@@ -2562,6 +2563,7 @@ Error ResourceFormatSaverXMLInstance::save(const String &p_path,const RES& p_res
 
 		List<PropertyInfo> property_list;
 		res->get_property_list(&property_list);
+		property_list.sort();
 		for(List<PropertyInfo>::Element *PE = property_list.front();PE;PE=PE->next()) {
 
 

--- a/core/io/resource_format_xml.h
+++ b/core/io/resource_format_xml.h
@@ -125,7 +125,7 @@ class ResourceFormatSaverXMLInstance  {
 	int depth;
 	Map<RES,int> resource_map;
 	List<RES> saved_resources;
-	Set<RES> external_resources;
+	List<RES> external_resources;
 
 	void enter_tag(const char* p_tag,const String& p_args=String());
 	void exit_tag(const char* p_tag);

--- a/core/object.h
+++ b/core/object.h
@@ -111,6 +111,9 @@ struct PropertyInfo {
 	PropertyInfo( Variant::Type p_type, const String p_name, PropertyHint p_hint=PROPERTY_HINT_NONE, const String& p_hint_string="",uint32_t p_usage=PROPERTY_USAGE_DEFAULT) {
 		type=p_type; name=p_name; hint=p_hint; hint_string=p_hint_string; usage=p_usage;
 	}
+	bool operator<(const PropertyInfo& p_info) const {
+		return name<p_info.name;
+	}
 };
 
 

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -456,6 +456,15 @@ bool Variant::operator==(const Variant& p_variant) const {
 
 }
 
+bool Variant::operator<(const Variant& p_variant) const {
+	if (type!=p_variant.type) //if types differ, then order by type first
+		return type<p_variant.type;
+	bool v;
+	Variant r;
+	evaluate(OP_LESS,*this,p_variant,r,v);
+	return r;
+}
+
 bool Variant::is_zero() const {
 
 	switch( type ) {

--- a/core/variant.h
+++ b/core/variant.h
@@ -408,7 +408,8 @@ public:
 
 	//argsVariant call()
 
-	bool operator==(const Variant& p_variant) const;	
+	bool operator==(const Variant& p_variant) const;
+	bool operator<(const Variant& p_variant) const;
 	uint32_t hash() const;
 
 	bool booleanize(bool &valid) const;

--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -165,6 +165,12 @@ r_valid=false;\
 return;}
 
 #define DEFAULT_OP_ARRAY_EQ(m_name,m_type)\
+DEFAULT_OP_ARRAY_OP(m_name,m_type,!=,!=,true,false,false)
+
+#define DEFAULT_OP_ARRAY_LT(m_name,m_type)\
+DEFAULT_OP_ARRAY_OP(m_name,m_type,<,!=,false,a_len<array_b.size(),true)
+
+#define DEFAULT_OP_ARRAY_OP(m_name,m_type,m_opa,m_opb,m_ret_def,m_ret_s,m_ret_f)\
 case m_name: {	\
 	if (p_a.type!=p_b.type) {\
 		r_valid=false;\
@@ -174,19 +180,19 @@ case m_name: {	\
 	const DVector<m_type> &array_b=*reinterpret_cast<const DVector<m_type> *>(p_b._data._mem);\
 \
 	int a_len = array_a.size();\
-	if (a_len!=array_b.size()){\
-		_RETURN( false);\
+	if (a_len m_opa array_b.size()){\
+		_RETURN( m_ret_s);\
 	}else {\
 \
 		DVector<m_type>::Read ra = array_a.read();\
 		DVector<m_type>::Read rb = array_b.read();\
 \
 		for(int i=0;i<a_len;i++) {\
-			if (ra[i]!=rb[i])\
-				_RETURN( false);\
+			if (ra[i] m_opb rb[i])\
+				_RETURN( m_ret_f);\
 		}\
 \
-		_RETURN( true);\
+		_RETURN( m_ret_def);\
 	}\
 }
 
@@ -357,14 +363,33 @@ void Variant::evaluate(const Operator& p_op, const Variant& p_a, const Variant& 
 				} break;
 				DEFAULT_OP_FAIL(INPUT_EVENT);
 				DEFAULT_OP_FAIL(DICTIONARY);
-				DEFAULT_OP_FAIL(ARRAY);
-				DEFAULT_OP_FAIL(RAW_ARRAY);
-				DEFAULT_OP_FAIL(INT_ARRAY);
-				DEFAULT_OP_FAIL(REAL_ARRAY);
-				DEFAULT_OP_FAIL(STRING_ARRAY);
-				DEFAULT_OP_FAIL(VECTOR2_ARRAY);
-				DEFAULT_OP_FAIL(VECTOR3_ARRAY);
-				DEFAULT_OP_FAIL(COLOR_ARRAY);
+				case ARRAY: {
+
+					if (p_b.type!=ARRAY)
+						_RETURN( false );
+
+					const Array *arr_a=reinterpret_cast<const Array*>(p_a._data._mem);
+					const Array *arr_b=reinterpret_cast<const Array*>(p_b._data._mem);
+
+					int l = arr_a->size();
+					if (arr_b->size()<l)
+						_RETURN( false );
+					for(int i=0;i<l;i++) {
+						if (!((*arr_a)[i]<(*arr_b)[i])) {
+							_RETURN( true );
+						}
+					}
+
+					_RETURN( false );
+
+				} break;
+				DEFAULT_OP_ARRAY_LT(RAW_ARRAY,uint8_t);
+				DEFAULT_OP_ARRAY_LT(INT_ARRAY,int);
+				DEFAULT_OP_ARRAY_LT(REAL_ARRAY,real_t);
+				DEFAULT_OP_ARRAY_LT(STRING_ARRAY,String);
+				DEFAULT_OP_ARRAY_LT(VECTOR2_ARRAY,Vector3);
+				DEFAULT_OP_ARRAY_LT(VECTOR3_ARRAY,Vector3);
+				DEFAULT_OP_ARRAY_LT(COLOR_ARRAY,Color);
 				case VARIANT_MAX: {
 					r_valid=false;
 					return;


### PR DESCRIPTION
Makes xml format work better with version control systems. Mostly fixes #473. There are still some reorder problems left, e.g. with fonts, but mostly the xml is remaining the same. Of course, if this gets applied, there will be some changes due to sorting, but after that the order won't change.
