### PR TITLE
Fixed some items caught in cppcheck

### DIFF
--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -292,7 +292,7 @@ SpriteBase3D::SpriteBase3D() {
 	parent_sprite=NULL;
 	pI=NULL;
 
-	for(int i=0;i<4;i++)
+	for(int i=0;i<FLAG_MAX;i++)
 		flags[i]=i==FLAG_TRANSPARENT;
 
 	axis=Vector3::AXIS_Z;

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -1216,8 +1216,8 @@ T Animation::_interpolate( const Vector< TKey<T> >& p_keys, float p_time,  Inter
 	
 	if (p_ok)
 		*p_ok=true;
-	
-	int next;
+
+	int next=0;
 	float c=0;	
 	// prepare for all cases of interpolation
 	


### PR DESCRIPTION
In sprite_3d.cpp the array "flags" is initialized to "FLAG_MAX" which has a value of 2 which would give two indexes 0 and 1, however a loop was accessing it up to index 3 via "i < 4".

Also, simply initialized the next variable to 0 in animation.cpp
