### PR TITLE
Fix for js compilation erro.

### DIFF
--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -77,7 +77,7 @@ def configure(env):
 		#env.Append(CCFLAGS=['-D_DEBUG', '-Wall', '-g4', '-DDEBUG_ENABLED'])
 		env.Append(CPPFLAGS=['-DDEBUG_MEMORY_ALLOC'])
 
-	env.Append(CPPFLAGS=["-fno-exceptions",'-DNO_SAFE_CAST','-fno-rtti'])
+	env.Append(CPPFLAGS=["-fno-exceptions",'-DNO_SAFE_CAST'])
 	env.Append(CPPFLAGS=['-DJAVASCRIPT_ENABLED', '-DUNIX_ENABLED', '-DNO_FCNTL','-DMPC_FIXED_POINT','-DTYPED_METHOD_BIND','-DNO_THREADS'])
 	env.Append(CPPFLAGS=['-DGLES2_ENABLED'])
 	env.Append(CPPFLAGS=['-DGLES_NO_CLIENT_ARRAYS'])


### PR DESCRIPTION
1) removed the flag that was causing js builds to fail due to use
of dynamic_cast<> in scene/gui/check_box.cpp:62:13

Fix for bug #1829
