### PR TITLE
Change windows build to use CFlag /Od so that you get the full debug …

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -204,7 +204,7 @@ def configure(env):
 
 		elif (env["target"]=="debug"):
 
-			env.Append(CCFLAGS=['/Zi','/DDEBUG_ENABLED','/DDEBUG_MEMORY_ENABLED','/DD3D_DEBUG_INFO','/O1'])
+			env.Append(CCFLAGS=['/Zi','/DDEBUG_ENABLED','/DDEBUG_MEMORY_ENABLED','/DD3D_DEBUG_INFO','/Od'])
 			env.Append(LINKFLAGS=['/SUBSYSTEM:CONSOLE'])
 			env.Append(LINKFLAGS=['/DEBUG'])
 


### PR DESCRIPTION
…experience. Without this flag set,  Visual Studio lets you use breakpoints, but the watch and locals is pretty much useless.
