### PR TITLE
Remove focus from restart button, fixes #1850

### DIFF
--- a/demos/2d/tetris/grid.gd
+++ b/demos/2d/tetris/grid.gd
@@ -143,6 +143,7 @@ func restart_pressed():
 		cells.clear()
 		get_node("gameover").set_text("")		
 		piece_active=true
+		get_node("../restart").release_focus()
 		update()
 		
 		


### PR DESCRIPTION
Fixes a problem where the restart button would keep focus after being pressed, making the tetris' pieces impossible to rotate without activating the button again.
