### PR TITLE
Support for fixed process on timer (Idle/Fixed mode) and a small change for more uniform ticks

### DIFF
--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -45,17 +45,32 @@ void Timer::_notification(int p_what) {
 			}
 		} break;
 		case NOTIFICATION_PROCESS: {
-
-			if (!is_processing())
+			if (timer_process_mode == TIMER_PROCESS_FIXED || !is_processing())
 				return;
 			time_left -= get_process_delta_time();
 
 			if (time_left<0) {
 				if (!one_shot)
-					time_left=wait_time+time_left;
+					//time_left=wait_time+time_left;
+					time_left = wait_time;
 				else
 					stop();
 
+				emit_signal("timeout");
+			}
+
+		} break;
+		case NOTIFICATION_FIXED_PROCESS: {
+			if (timer_process_mode == TIMER_PROCESS_IDLE || !is_fixed_processing())
+				return;
+			time_left -= get_fixed_process_delta_time();
+
+			if (time_left<0) {
+				if (!one_shot)
+					//time_left = wait_time + time_left;
+					time_left = wait_time;
+				else
+					stop();
 				emit_signal("timeout");
 			}
 
@@ -66,7 +81,6 @@ void Timer::_notification(int p_what) {
 
 
 void Timer::set_wait_time(float p_time) {
-
 	ERR_EXPLAIN("time should be greater than zero.");
 	ERR_FAIL_COND(p_time<=0);
 	wait_time=p_time;
@@ -96,14 +110,13 @@ bool Timer::has_autostart() const {
 }
 
 void Timer::start() {
-
 	time_left=wait_time;	
-	set_process(true);	
+	_set_process(true);
 }
 
 void Timer::stop() {
 	time_left=-1;
-	set_process(false);
+	_set_process(false);
 	autostart=false;
 }
 
@@ -112,6 +125,41 @@ float Timer::get_time_left() const {
 	return time_left >0 ? time_left : 0;
 }
 
+void Timer::set_timer_process_mode(TimerProcessMode p_mode) {
+
+	if (timer_process_mode == p_mode)
+		return;
+
+	switch (timer_process_mode) {
+		case TIMER_PROCESS_FIXED:
+			if (is_fixed_processing()) {
+				set_fixed_process(false);
+				set_process(true);
+			}
+		break;
+		case TIMER_PROCESS_IDLE:
+			if (is_processing()) {
+				set_process(false);
+				set_fixed_process(true);
+			}
+		break;
+	}
+	timer_process_mode = p_mode;
+}
+
+Timer::TimerProcessMode Timer::get_timer_process_mode() const{
+
+	return timer_process_mode;
+}
+
+
+void Timer::_set_process(bool p_process, bool p_force) 
+{
+	switch (timer_process_mode) {
+		case TIMER_PROCESS_FIXED: set_fixed_process(p_process); break;
+		case TIMER_PROCESS_IDLE: set_process(p_process); break;
+	}
+}
 
 void Timer::_bind_methods() {
 
@@ -129,8 +177,12 @@ void Timer::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("get_time_left"),&Timer::get_time_left);
 
+	ObjectTypeDB::bind_method(_MD("set_timer_process_mode", "mode"), &Timer::set_timer_process_mode);
+	ObjectTypeDB::bind_method(_MD("get_timer_process_mode"), &Timer::get_timer_process_mode);
+
 	ADD_SIGNAL( MethodInfo("timeout") );
 
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "process_mode", PROPERTY_HINT_ENUM, "Fixed,Idle"), _SCS("set_timer_process_mode"), _SCS("get_timer_process_mode"));
 	ADD_PROPERTY( PropertyInfo(Variant::REAL, "wait_time", PROPERTY_HINT_EXP_RANGE, "0.01,4096,0.01" ), _SCS("set_wait_time"), _SCS("get_wait_time") );
 	ADD_PROPERTY( PropertyInfo(Variant::BOOL, "one_shot" ), _SCS("set_one_shot"), _SCS("is_one_shot") );
 	ADD_PROPERTY( PropertyInfo(Variant::BOOL, "autostart" ), _SCS("set_autostart"), _SCS("has_autostart") );
@@ -138,8 +190,7 @@ void Timer::_bind_methods() {
 }
 
 Timer::Timer() {
-
-
+	timer_process_mode = TIMER_PROCESS_IDLE;
 	autostart=false;
 	wait_time=1;
 	one_shot=false;

--- a/scene/main/timer.h
+++ b/scene/main/timer.h
@@ -46,6 +46,11 @@ protected:
 	static void _bind_methods();
 public:
 
+	enum TimerProcessMode {
+		TIMER_PROCESS_FIXED,
+		TIMER_PROCESS_IDLE,
+	};
+
 	void set_wait_time(float p_time);
 	float get_wait_time() const;
 
@@ -60,7 +65,16 @@ public:
 
 	float get_time_left() const;
 
+	void set_timer_process_mode(TimerProcessMode p_mode);
+	TimerProcessMode get_timer_process_mode() const;
 	Timer();
+
+private:
+	TimerProcessMode timer_process_mode;
+	void _set_process(bool p_process, bool p_force = false);
+
 };
+
+VARIANT_ENUM_CAST(Timer::TimerProcessMode);
 
 #endif // TIMER_H


### PR DESCRIPTION
- **Implemented support for fixed process on timer** 
  This is useful for cooldowns without the influence from framerate.
  The implementation is similar to animation player (idle/fixed mode), where idle mode = old timer, fixed mode = fixed process implementation:
  Example of the new behaviour with a stream of bullets with timers for each shoot on different frame rates:
  https://gfycat.com/HeartyImpressiveIndiancow
- **A change for more uniform ticks on fixed/idle**
  without this fix:
  ![0tmq6cg 1](https://cloud.githubusercontent.com/assets/12376042/7554392/415ed4b8-f6f5-11e4-8acd-3af7582cc381.png)
  with this fix:
  ![3zyx16c 1](https://cloud.githubusercontent.com/assets/12376042/7554393/4ac3f7cc-f6f5-11e4-902d-6625b34e9355.png)

The change is:

> ```
>       time_left -= get_process_delta_time();
>         if (time_left<0) {
>             if (!one_shot)
>                 time_left=wait_time+time_left; //this line changed for: time_left = wait_time;
>             else
>                 stop();
>             emit_signal("timeout");
>         }
> ```

The reason for the change is:
With _time_left=wait_time+time_left;_ method: the algorithm takes on account the remaining ms from last tick for the next one, so not all ticks are the same
With _time_left = wait_time;_ method: the algorithm discards the remaining ms, so all the ticks are the same

Example of the old behaviour with a timer of 0.04 ms on a fixed framerate of 60 (~0,016 ms):

> 0,0
> 0,016
> 0,032
> 0,048
> ----- TICK on 4 frames
> 0,008
> 0,024
> 0,040
> ----- TICK on 3 frames
> 0,0
> 0,016
> 0,032
> 0,048
> ----- TICK on 4 frames

So every second tick is more fastest, resulting on non uniform behaviour between all ticks, On the fix, all the ticks start with the same value, so is always the same result (4 frames)
