### PR TITLE
new version does not overwrite editor_settings

### DIFF
--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -170,7 +170,7 @@ void EditorSettings::create() {
 
 	String config_path;
 	String config_dir;
-	String config_file="editor_settings.xml";
+	String config_file="editor_settings."VERSION_MKSTRING".xml";
 
 	if (OS::get_singleton()->has_environment("APPDATA")) {
 		// Most likely under windows, save here


### PR DESCRIPTION
Each new version of godot will have its own editor_settings.xml file.

Advantages :
- customized script editor colors won't be lost at each new version
- allow users to manage different projects with different versions of 
  godot (each version has its own project list)
- make comparing different version of godot to track bugs easier
