### PR TITLE
Fix for scroll_to_line and search functions, fix #1897

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1486,10 +1486,10 @@ Error RichTextLabel::append_bbcode(const String& p_bbcode) {
 
 void RichTextLabel::scroll_to_line(int p_line) {
 
+	p_line -= 1;
 	ERR_FAIL_INDEX(p_line,lines.size());
 	_validate_line_caches();
-	vscroll->set_val(lines[p_line].height_accum_cache);
-
+	vscroll->set_val(lines[p_line].height_accum_cache-lines[p_line].height_cache);
 
 }
 
@@ -1552,26 +1552,22 @@ bool RichTextLabel::search(const String& p_string,bool p_from_selection) {
 						it=_get_next_item(it);
 					}
 
-					if (!it)
-						line=lines.size()-1;
 				}
 
-				scroll_to_line(line-2);
+				if (line > 1) {
+					line-=1;
+				}
+
+				scroll_to_line(line);
 
 				return true;
 			}
-		} else if (it->type==ITEM_NEWLINE) {
-
-			line=static_cast<ItemNewline*>(it)->line;
 		}
-
 
 		it=_get_next_item(it);
 		charidx=0;
 
 	}
-
-
 
 	return false;
 


### PR DESCRIPTION
The function scroll_to_line(0) should return ERR_FAIL_INDEX because
the first line is 1.
