### PR TITLE
set initial flag 'show_hidden_files' for file dialogs in project manager initialization

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -692,7 +692,7 @@ void FileDialog::set_default_show_hidden_files(bool p_show) {
 
 FileDialog::FileDialog() {
 
-	show_hidden_files=true;
+	show_hidden_files=default_show_hidden_files;
 
 	VBoxContainer *vbc = memnew( VBoxContainer );
 	add_child(vbc);

--- a/tools/editor/project_manager.cpp
+++ b/tools/editor/project_manager.cpp
@@ -819,6 +819,7 @@ ProjectManager::ProjectManager() {
 	if (!EditorSettings::get_singleton())
 		EditorSettings::create();
 
+	FileDialog::set_default_show_hidden_files(EditorSettings::get_singleton()->get("file_dialog/show_hidden_files"));
 
 	set_area_as_parent_rect();
 	Panel *panel = memnew( Panel );


### PR DESCRIPTION
dialogs for directory browsing in project editor (e.g. new project -> browse) didn't use the flag 'show_hidden_files' from editor settings.
