### PR TITLE
revert incorrect logo path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![GODOT](../../logo.png)
+![GODOT](logo.png)
 
 ### The Engine
 


### PR DESCRIPTION
the logo isn't displaying in the README anymore, this should fix it.
