### PR TITLE
Expose AudioServer::free(RID rid) as AudioServer.free_rid(RID rid)

### DIFF
--- a/doc/engine_classes.xml
+++ b/doc/engine_classes.xml
@@ -1502,7 +1502,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="free">
+		<method name="free_rid">
 			<argument index="0" name="rid" type="RID">
 			</argument>
 			<description>

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -132,7 +132,7 @@ void AudioServer::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("voice_stop","voice"), &AudioServer::voice_stop );
 
-	ObjectTypeDB::bind_method(_MD("free","rid"), &AudioServer::free );
+	ObjectTypeDB::bind_method(_MD("free_rid","rid"), &AudioServer::free );
 
 	ObjectTypeDB::bind_method(_MD("set_stream_global_volume_scale","scale"), &AudioServer::set_stream_global_volume_scale );
 	ObjectTypeDB::bind_method(_MD("get_stream_global_volume_scale"), &AudioServer::get_stream_global_volume_scale );


### PR DESCRIPTION
To avoid script error due to collision with Object method free.

Calling AudioServer.free(rid) (eg. to delete a sample) currently cause the following error:
"Invalid call to function 'free' in base 'AudioServerSW'. Expected 0 arguments".

This patch creates expose the method to free a specific resource as AudioServer.free_rid(rid) as done for example in Physics2DServer and PhysicsServer
