### PR TITLE
Fix building release target with debug symbols

### DIFF
--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -109,8 +109,8 @@ def configure(env):
 
 
 	if (env["target"]=="release"):
-		
-		if (env["debug_release"]):
+
+		if (env["debug_release"]=="yes"):
 			env.Append(CCFLAGS=['-g2','-fomit-frame-pointer'])
 		else:
 			env.Append(CCFLAGS=['-O2','-ffast-math','-fomit-frame-pointer'])


### PR DESCRIPTION
This forced the -g2 CCFLAG in release builds, making them relatively heavy.
Fixes #1781.
