### PR TITLE
Setting build vs properties in scons.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -360,6 +360,11 @@ if selected_platform in platform_list:
 		AddToVSProject(env.scene_sources)
 		AddToVSProject(env.servers_sources)
 		AddToVSProject(env.tool_sources)
+		
+		#env['MSVS_VERSION']='9.0'
+		env['MSVSBUILDCOM'] = "scons platform=" + selected_platform + " target=" + env["target"] + " bits=" + env["bits"] + " tools=yes"
+		env['MSVSREBUILDCOM'] = "scons platform=" + selected_platform + " target=" + env["target"] + " bits=" + env["bits"] + " tools=yes"
+		env['MSVSCLEANCOM'] = "scons platform=" + selected_platform + " target=" + env["target"] + " bits=" + env["bits"] + " tools=yes"
 			
 		debug_variants = ['Debug|Win32']+['Debug|x64']
 		release_variants = ['Release|Win32']+['Release|x64']


### PR DESCRIPTION
This sets up the nmake build properties in visual studio. The build properties are limited to the build settings you used when making the vsproj. so if you built the vs project files with debug all of the vs configurations will use target debug.
