### PR TITLE
Fixed ui_accept problem

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -148,6 +148,7 @@ void BaseButton::_input_event(InputEvent p_event) {
 					update();
 			}
 		} break;
+		case InputEvent::ACTION:
 		case InputEvent::JOYSTICK_BUTTON:
 		case InputEvent::KEY: {
 		


### PR DESCRIPTION
It's possible now to make a custom ui_accept action event and pull it.
