### PR TITLE
Additional Fix for Multi-touch release problem

### DIFF
--- a/platform/android/java/src/com/android/godot/Godot.java
+++ b/platform/android/java/src/com/android/godot/Godot.java
@@ -747,7 +747,7 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 				//}
 			} break;
 			case MotionEvent.ACTION_POINTER_UP: {
-				final int indexPointUp = event.getAction() >> MotionEvent.ACTION_POINTER_INDEX_SHIFT;
+				final int indexPointUp = event.getActionIndex();
 				final int pointer_idx = event.getPointerId(indexPointUp); 
 				GodotLib.touch(4,pointer_idx,evcount,arr);
 				//System.out.printf("%d - s.up at: %f,%f\n",pointer_idx, event.getX(pointer_idx),event.getY(pointer_idx));


### PR DESCRIPTION
- Was duplicating the functionality of event.getActionIndex() but was missing the bitmask.
- Switched back to getActionIndex() but kept the corrected getPointerId() from
  change https://github.com/okamstudio/godot/pull/1908

https://github.com/okamstudio/godot/pull/1908
