### PR TITLE
make GraphNode inherit VBoxContainer

### DIFF
--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -42,7 +42,8 @@ void BoxContainer::_resort() {
 	/** First pass, determine minimum size AND amount of stretchable elements */
 
 
-	Size2i new_size=get_size();;
+	Ref<StyleBox> sb=get_stylebox("frame");
+	Size2i new_size=get_size() - sb->get_minimum_size();
 
 	int sep=get_constant("separation");//,vertical?"VBoxContainer":"HBoxContainer");
 
@@ -181,10 +182,10 @@ void BoxContainer::_resort() {
 
 		if (vertical) {
 
-			rect=Rect2(0,from,new_size.width,size);
+			rect=Rect2(sb->get_margin(MARGIN_LEFT),sb->get_margin(MARGIN_TOP)+from,new_size.width,size);
 		} else {
 
-			rect=Rect2(from,0,size,new_size.height);
+			rect=Rect2(sb->get_margin(MARGIN_LEFT)+from,sb->get_margin(MARGIN_TOP),size,new_size.height);
 
 		}
 
@@ -203,6 +204,7 @@ Size2 BoxContainer::get_minimum_size() const {
 
 	Size2i minimum;
 	int sep=get_constant("separation");//,vertical?"VBoxContainer":"HBoxContainer");
+	Ref<StyleBox> sb=get_stylebox("frame");
 
 	bool first=true;
 
@@ -240,7 +242,7 @@ Size2 BoxContainer::get_minimum_size() const {
 		first=false;
 	}
 
-	return minimum;
+	return minimum + sb->get_minimum_size();
 }
 
 void BoxContainer::_notification(int p_what) {

--- a/scene/gui/box_container.h
+++ b/scene/gui/box_container.h
@@ -36,9 +36,9 @@ class BoxContainer : public Container {
 	OBJ_TYPE(BoxContainer,Container);
 
 	bool vertical;
+protected:
 
 	void _resort();
-protected:
 
 	void _notification(int p_what);
 public:

--- a/scene/gui/graph_node.h
+++ b/scene/gui/graph_node.h
@@ -1,11 +1,11 @@
 #ifndef GRAPH_NODE_H
 #define GRAPH_NODE_H
 
-#include "scene/gui/container.h"
+#include "scene/gui/box_container.h"
 
-class GraphNode : public Container {
+class GraphNode : public VBoxContainer {
 
-	OBJ_TYPE(GraphNode,Container);
+	OBJ_TYPE(GraphNode,VBoxContainer);
 
 
 
@@ -90,9 +90,6 @@ public:
 	Vector2 get_connection_output_pos(int p_idx);
 	int get_connection_output_type(int p_idx);
 	Color get_connection_output_color(int p_idx);
-
-
-	virtual Size2 get_minimum_size() const;
 
 	GraphNode();
 };


### PR DESCRIPTION
This allows children in GraphNode to use the EXPAND size flags, making its sizing behaviour more consistent.

Side effect is that BoxContainer now reads the frame stylebox for margins.
