### PR TITLE
Fixed help search showing after displaying result

### DIFF
--- a/tools/editor/editor_help.cpp
+++ b/tools/editor/editor_help.cpp
@@ -339,7 +339,7 @@ void EditorHelp::_unhandled_key_input(const InputEvent& p_ev) {
 
 		search->grab_focus();
 		search->select_all();
-	} else if (p_ev.key.mod.shift && p_ev.key.scancode==KEY_F1) {
+	} else if (p_ev.key.mod.shift && p_ev.key.scancode==KEY_F1 && p_ev.is_pressed() && !p_ev.is_echo()) {
 		class_search->popup();
 	}
 }


### PR DESCRIPTION
The default behavior for Shift+F1 from the code editor to the editor help is to open the corresponding page or open the search if it can't find. In the former case, not releasing Shift+F1 fast enough will open the search in the editor help, getting in the way of what you were searching for. This fix makes it so editor help only responds to the key press.
