### PR TITLE
Middle mouse button now searches the help for the text over the mouse

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -33,6 +33,7 @@
 
 #include "globals.h"
 #include "message_queue.h"
+#include "tools/editor/editor_node.h"
 
 #define TAB_PIXELS
 
@@ -1284,6 +1285,32 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 					
 					update();
 				}
+				
+#ifdef TOOLS_ENABLED
+				if (mb.button_index == BUTTON_MIDDLE) {
+
+					// Hacky solution
+					int row, col;
+					if (!_get_mouse_pos(Point2i(mb.x, mb.y), row, col))
+						return;
+
+					int prev_col = cursor.column;
+					int prev_line = cursor.line;
+
+					cursor_set_line(row);
+					cursor_set_column(col);
+
+					String text = get_word_under_cursor();
+					if (text != "") {
+						EditorNode *singleton = EditorNode::get_singleton();
+						if (singleton)
+								singleton->emit_signal("request_help", text);
+					}
+
+					cursor_set_line(prev_line);
+					cursor_set_column(prev_col);
+				}
+#endif
 			} else {
 				
 				selection.selecting_mode=Selection::MODE_NONE;


### PR DESCRIPTION
Kinda hacked this feature into TextEdit, but it executes only when tools are enabled. It's a really helpful feature when scripting and you need to check something really quick. Recommend implementing with #2111.
