### PR TITLE
More vs scons changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -281,3 +281,5 @@ cscope.out
 cscope.in.out
 cscope.po.out
 godot.creator.*
+
+projects/

--- a/SConstruct
+++ b/SConstruct
@@ -360,6 +360,11 @@ if selected_platform in platform_list:
 		AddToVSProject(env.scene_sources)
 		AddToVSProject(env.servers_sources)
 		AddToVSProject(env.tool_sources)
+		
+		#env['MSVS_VERSION']='9.0'
+		env['MSVSBUILDCOM'] = "scons platform=" + selected_platform + " target=" + env["target"] + " bits=" + env["bits"] + " tools=yes"
+		env['MSVSREBUILDCOM'] = "scons platform=" + selected_platform + " target=" + env["target"] + " bits=" + env["bits"] + " tools=yes"
+		env['MSVSCLEANCOM'] = "scons platform=" + selected_platform + " target=" + env["target"] + " bits=" + env["bits"] + " tools=yes"
 			
 		debug_variants = ['Debug|Win32']+['Debug|x64']
 		release_variants = ['Release|Win32']+['Release|x64']


### PR DESCRIPTION
This sets the NMAKE build command stuff in the visual studio project properties. Unfortunately it uses the target=? passed into SCONS to set all of the Visual Studio configurations with that target.
