### PR TITLE
Added helper methods to InputEvent

### DIFF
--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -173,6 +173,16 @@ bool InputEvent::is_action(const String& p_action) const {
 	return InputMap::get_singleton()->event_is_action(*this,p_action);
 }
 
+bool InputEvent::is_action_pressed(const String& p_action) const {
+
+	return is_action(p_action) && is_pressed() && !is_echo();
+}
+
+bool InputEvent::is_action_released(const String& p_action) const {
+
+	return is_action(p_action) && !is_pressed();
+}
+
 uint32_t InputEventKey::get_scancode_with_modifiers() const {
 
 	uint32_t sc=scancode;

--- a/core/os/input_event.h
+++ b/core/os/input_event.h
@@ -287,6 +287,8 @@ struct InputEvent {
 
 	bool is_pressed() const;
 	bool is_action(const String& p_action) const;
+	bool is_action_pressed(const String& p_action) const;
+	bool is_action_released(const String& p_action) const;
 	bool is_echo() const;
 	void set_as_action(const String& p_action, bool p_pressed);
 

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -715,6 +715,8 @@ static void _call_##m_type##_##m_method(Variant& r_ret,Variant& p_self,const Var
 
 	VCALL_PTR0R( InputEvent, is_pressed );
 	VCALL_PTR1R( InputEvent, is_action );
+	VCALL_PTR1R( InputEvent, is_action_pressed );
+	VCALL_PTR1R( InputEvent, is_action_released );
 	VCALL_PTR0R( InputEvent, is_echo );
     VCALL_PTR2( InputEvent, set_as_action );
 
@@ -1540,6 +1542,8 @@ _VariantCall::addfunc(Variant::m_vtype,Variant::m_ret,_SCS(#m_method),VCALL(m_cl
 
 	ADDFUNC0(INPUT_EVENT,BOOL,InputEvent,is_pressed,varray());
 	ADDFUNC1(INPUT_EVENT,BOOL,InputEvent,is_action,STRING,"action",varray());
+	ADDFUNC1(INPUT_EVENT,BOOL,InputEvent,is_action_pressed,STRING,"is_action_pressed",varray());
+	ADDFUNC1(INPUT_EVENT,BOOL,InputEvent,is_action_released,STRING,"is_action_released",varray());
 	ADDFUNC0(INPUT_EVENT,BOOL,InputEvent,is_echo,varray());
     ADDFUNC2(INPUT_EVENT,NIL,InputEvent,set_as_action,STRING,"action",BOOL,"pressed",varray());
 


### PR DESCRIPTION
Added helper methods for InputEvent to detect first press and release actions. Could be done before, but this makes it nicer and more clear to write. Would like to amend the in-editor documentation to explain the new methods.
