### PR TITLE
Add documentation for RayCast2D about is_colliding and get_collider quirks

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -23032,12 +23032,14 @@
 			<return type="bool">
 			</return>
 			<description>
+			Return whether the closest object the ray is pointing to is colliding with the vector, with the vector length considered.
 			</description>
 		</method>
 		<method name="get_collider" qualifiers="const" >
 			<return type="Object">
 			</return>
 			<description>
+			Return the closest object the ray is pointing to. Note that this does not consider the length of the vector, so you must also use [is_colliding] to check if the object returned is actually colliding with the ray.
 			</description>
 		</method>
 		<method name="get_collider_shape" qualifiers="const" >


### PR DESCRIPTION
At first, I thought get_collider() wouldn't return anything if the object it was pointing to wasn't in contact with it, but it turns out this isn't the case (though I suppose this would be useful for cases like wind tunnels). So I added some documentation for get_collider() and is_collidiing() to help clarify this.

If it's a bug, I'll go open a ticket for that too.
