### PR TITLE
Added CanvasItem::set_visible method

### DIFF
--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -273,6 +273,17 @@ void CanvasItem::_propagate_visibility_changed(bool p_visible) {
 
 }
 
+void CanvasItem::set_visible(bool p_visible)
+{
+	if (p_visible == !hidden)
+		return;
+
+	if (p_visible)
+		show();
+	else
+		hide();
+}
+
 void CanvasItem::show() {
 
 	if (!hidden)
@@ -1041,6 +1052,7 @@ void CanvasItem::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("is_visible"),&CanvasItem::is_visible);
 	ObjectTypeDB::bind_method(_MD("is_hidden"),&CanvasItem::is_hidden);
+	ObjectTypeDB::bind_method(_MD("set_visible","visible"),&CanvasItem::set_visible);
 	ObjectTypeDB::bind_method(_MD("show"),&CanvasItem::show);
 	ObjectTypeDB::bind_method(_MD("hide"),&CanvasItem::hide);
 

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -187,6 +187,7 @@ public:
 
 	bool is_visible() const;
 	bool is_hidden() const;
+	void set_visible(bool p_visible);
 	void show();
 	void hide();
 


### PR DESCRIPTION
Can toggle CanvasItem through a boolean rather than separate calls to show and hide. Functionally just a wrapper for the two methods.
