### PR TITLE
List::move_before updates front/back pointers, fixes #2255

### DIFF
--- a/core/list.h
+++ b/core/list.h
@@ -518,10 +518,16 @@ public:
 
 		if (value->prev_ptr) {
 			value->prev_ptr->next_ptr = value->next_ptr;
-		};
+		}
+		else {
+			_data->first = value->next_ptr;
+		}
 		if (value->next_ptr) {
 			value->next_ptr->prev_ptr = value->prev_ptr;
-		};
+		}
+		else {
+			_data->last = value->prev_ptr;
+		}
 
 		value->next_ptr = where;
 		if (!where) {


### PR DESCRIPTION
The move_before function wasn't updating the list's front/back pointers if the element to be moved was the front or the back of the list. Fixes issue #2255
