### PR TITLE
Bug #2241 : atan2() function and Vector2 method inconsistent x,y / y,x parameters fix

### DIFF
--- a/core/math/math_2d.cpp
+++ b/core/math/math_2d.cpp
@@ -74,12 +74,12 @@ float Vector2::distance_squared_to(const Vector2& p_vector2) const {
 
 float Vector2::angle_to(const Vector2& p_vector2) const  {
 	
-	return Math::atan2( tangent().dot(p_vector2), dot(p_vector2) );
+	return Math::atan2( dot(p_vector2), tangent().dot(p_vector2) );
 }
 
 float Vector2::angle_to_point(const Vector2& p_vector2) const  {
 
-	return Math::atan2( x-p_vector2.x, y - p_vector2.y );
+	return Math::atan2( y - p_vector2.y, x-p_vector2.x );
 }
 
 float Vector2::dot(const Vector2& p_other) const {

--- a/core/math/math_2d.cpp
+++ b/core/math/math_2d.cpp
@@ -74,7 +74,7 @@ float Vector2::distance_squared_to(const Vector2& p_vector2) const {
 
 float Vector2::angle_to(const Vector2& p_vector2) const  {
 	
-	return Math::atan2( dot(p_vector2), tangent().dot(p_vector2) );
+	return Math::atan2( tangent().dot(p_vector2), dot(p_vector2) );
 }
 
 float Vector2::angle_to_point(const Vector2& p_vector2) const  {

--- a/core/math/math_2d.cpp
+++ b/core/math/math_2d.cpp
@@ -31,7 +31,7 @@
 
 real_t Vector2::atan2() const {
 
-	return Math::atan2(x,y);
+	return Math::atan2(y,x);
 }
 
 float Vector2::length() const {

--- a/demos/2d/isometric_light/cubio.gd
+++ b/demos/2d/isometric_light/cubio.gd
@@ -62,7 +62,7 @@ func _fixed_process(delta):
 		next_anim="idle"
 		next_mirror=false
 	elif (speed.length()>IDLE_SPEED*0.1):
-		var angle = atan2(abs(speed.x),speed.y)	
+		var angle = atan2(speed.y, abs(speed.x))	
 		
 		next_mirror = speed.x>0
 		if (angle<PI/8):

--- a/demos/3d/platformer/player.gd
+++ b/demos/3d/platformer/player.gd
@@ -42,8 +42,8 @@ func adjust_facing(p_facing, p_target,p_step, p_adjust_rate,current_gn):
 	var n = p_target # normal
 	var t = n.cross(current_gn).normalized()
 	
-	var x = n.dot(p_facing)
-	var y = t.dot(p_facing)
+	var x = t.dot(p_facing)
+	var y = n.dot(p_facing)
 	
 	var ang = atan2(y,x)
 	

--- a/modules/gdscript/gd_functions.cpp
+++ b/modules/gdscript/gd_functions.cpp
@@ -190,7 +190,7 @@ void GDFunctions::call(Function p_func,const Variant **p_args,int p_arg_count,Va
 			VALIDATE_ARG_COUNT(2);
 			VALIDATE_ARG_NUM(0);
 			VALIDATE_ARG_NUM(1);
-			r_ret=Math::atan2(*p_args[0],*p_args[1]);
+			r_ret=Math::atan2(*p_args[1], *p_args[0]);
 		} break;
 		case MATH_SQRT: {
 			VALIDATE_ARG_COUNT(1);

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -353,8 +353,8 @@ void Node2D::look_at(const Vector2& p_pos) {
 }
 
 float Node2D::get_angle_to(const Vector2& p_pos) const {
-
-	return (get_global_transform().affine_inverse().xform(p_pos)).atan2();
+	Vector2 v = (get_global_transform().affine_inverse().xform(p_pos));
+	return Vector2(v.y,v.x).atan2();
 }
 
 void Node2D::_bind_methods() {

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -442,7 +442,8 @@ void Body2DSW::integrate_forces(real_t p_step) {
 		//compute motion, angular and etc. velocities from prev transform
 		linear_velocity = (new_transform.elements[2] - get_transform().elements[2])/p_step;
 
-		real_t rot = new_transform.affine_inverse().basis_xform(get_transform().elements[1]).atan2();
+		Vector2 v =  new_transform.affine_inverse().basis_xform(get_transform().elements[1]);
+		real_t rot = (Vector2(v.y,v.x)).atan2();
 		angular_velocity = rot / p_step;
 
 		motion = new_transform.elements[2] - get_transform().elements[2];


### PR DESCRIPTION
- fixed Vector2.atan2()
- fixed atan2(x,y) -> atan2(y,x)
  WARNING : this fix may provoke many atan2(x,y) uses elsewhere to work badly
