### PR TITLE
RFC: Fix reference check in debug marshaller

### DIFF
--- a/core/script_debugger_remote.cpp
+++ b/core/script_debugger_remote.cpp
@@ -80,20 +80,7 @@ static ObjectID safe_get_instance_id(const Variant& p_v) {
 	if (o==NULL)
 		return 0;
 	else {
-
-		REF r = p_v;
-		if (r.is_valid()) {
-
-			return r->get_instance_ID();
-		} else {
-
-
-			_ScriptDebuggerRemote_found_id=0;
-			_ScriptDebuggerRemote_find=NULL;
-			ObjectDB::debug_objects(_ScriptDebuggerRemote_debug_func);
-			return _ScriptDebuggerRemote_found_id;
-
-		}
+		return o->get_instance_ID();
 	}
 }
 


### PR DESCRIPTION
In the GDScript debugger, the value of a variable is often printed as zero when it is actually a valid reference to an object.  This appears to be a problem in the remote script debugger.  When a variant is created from an object, the object pointer in the ObjData is initialized, but not the RefPtr.  When the variant is passed across the debugging connection, the remote debugger checks to see if it has a valid reference.  Since there is no reference, it does not retrieve the ObjectID from the object pointer to pass to the GDScript debugger, instead passing "0".

When I simply remove the RefPtr check in this patch, the ObjectID appears in the GDScript debugger as expected.  The safe_get_instance_id function is only used for the purpose of marshalling objects across the debugging connection, so there doesn't seem to be any harm in removing this check.  Is there a reason for this check that I am missing?  Is it OK to just remove this?

This "fix" corrects the seeming null reference issue reported in #2275.  In this case, find_node returns a Node pointer.  The binding code creates a variant from the Object pointer, which the remote debugger then reports as 0 instead of the Node's ObjectID.
