### PR TITLE
Fixes compile bug for Android template on Windows.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -54,13 +54,16 @@ methods.save_active_platforms(active_platforms,active_platform_ids)
 
 custom_tools=['default']
 
+platform_arg = ARGUMENTS.get("platform", False)
+
 if (os.name=="posix"):
 	pass
 elif (os.name=="nt"):
-    if (os.getenv("VSINSTALLDIR")==None):
-	custom_tools=['mingw']
+    if (os.getenv("VSINSTALLDIR")==None or platform_arg=="android"):
+		custom_tools=['mingw']
 
 env_base=Environment(tools=custom_tools,ENV = {'PATH' : os.environ['PATH']});
+
 #env_base=Environment(tools=custom_tools);
 env_base.global_defaults=global_defaults
 env_base.android_source_modules=[]
@@ -363,8 +366,8 @@ if selected_platform in platform_list:
 		
 		#env['MSVS_VERSION']='9.0'
 		env['MSVSBUILDCOM'] = "scons platform=" + selected_platform + " target=" + env["target"] + " bits=" + env["bits"] + " tools=yes"
-		env['MSVSREBUILDCOM'] = "scons platform=" + selected_platform + " target=" + env["target"] + " bits=" + env["bits"] + " tools=yes"
-		env['MSVSCLEANCOM'] = "scons platform=" + selected_platform + " target=" + env["target"] + " bits=" + env["bits"] + " tools=yes"
+		env['MSVSREBUILDCOM'] = "scons platform=" + selected_platform + " target=" + env["target"] + " bits=" + env["bits"] + " tools=yes vsproj=true"
+		env['MSVSCLEANCOM'] = "scons --clean platform=" + selected_platform + " target=" + env["target"] + " bits=" + env["bits"] + " tools=yes"
 			
 		debug_variants = ['Debug|Win32']+['Debug|x64']
 		release_variants = ['Release|Win32']+['Release|x64']

--- a/drivers/png/SCsub
+++ b/drivers/png/SCsub
@@ -27,7 +27,10 @@ if ("neon_enabled" in env and env["neon_enabled"]):
 	if "S_compiler" in env:
 		env_neon['CC'] = env['S_compiler']
 	env_neon.Append(CPPFLAGS=["-DPNG_ARM_NEON"])
-	png_sources.append(env_neon.Object("#drivers/png/filter_neon.S"))
+	import os
+	# Currently .ASM filter_neon.S does not compile on NT.
+	if (os.name!="nt"):
+		png_sources.append(env_neon.Object("#drivers/png/filter_neon.S"))
 
 
 env.drivers_sources+=png_sources

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -54,13 +54,53 @@ def create(env):
 
 def configure(env):
 
+	# Workaround for MinGW. See:
+	# http://www.scons.org/wiki/LongCmdLinesOnWin32
+	import os
+	if (os.name=="nt"):
+	
+		import subprocess
+			
+		def mySubProcess(cmdline,env):
+			#print "SPAWNED : " + cmdline
+			startupinfo = subprocess.STARTUPINFO()
+			startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+			proc = subprocess.Popen(cmdline, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+				stderr=subprocess.PIPE, startupinfo=startupinfo, shell = False, env = env)
+			data, err = proc.communicate()
+			rv = proc.wait()
+			if rv:
+				print "====="
+				print err
+				print "====="
+			return rv
+				
+		def mySpawn(sh, escape, cmd, args, env):
+								
+			newargs = ' '.join(args[1:])
+			cmdline = cmd + " " + newargs
+				
+			rv=0
+			if len(cmdline) > 32000 and cmd.endswith("ar") :
+				cmdline = cmd + " " + args[1] + " " + args[2] + " "
+				for i in range(3,len(args)) :
+					rv = mySubProcess( cmdline + args[i], env )
+					if rv :
+						break	
+			else:				
+				rv = mySubProcess( cmdline, env )
+					
+			return rv
+				
+		env['SPAWN'] = mySpawn
+	
 	if env['x86']=='yes':
 		env['NDK_TARGET']='x86-4.8'
 
 	if env['PLATFORM'] == 'win32':
 		import methods
 		env.Tool('gcc')
-		env['SPAWN'] = methods.win32_spawn
+		#env['SPAWN'] = methods.win32_spawn
 		env['SHLIBSUFFIX'] = '.so'
 
 #	env.android_source_modules.append("../libs/apk_expansion")	


### PR DESCRIPTION
Update to compiling Android on Windows.

After much testing these version numbers and file links seemed to work for me.
1. Install Java SDK 6. Can be found at.
   http://download.oracle.com/otn-pub/java/java_ee_sdk/6u4/java_ee_sdk-6u4-jdk-windows-x64.exe?AuthParam=1437511929_e3d8ec6a4c6908ab727d2323a640cf67
2. Install latest Android-SDK.
   https://dl.google.com/android/installer_r24.3.3-windows.exe
   
   Using the SDK Manager.
   Install Android 4.4.2 API & Android 4.0.3 API
   Install Android SDK Build-Tools 19.1
   You may need to prune stuff so all you have is the above.
3. Install Android-NDK 9b.
   https://dl.google.com/android/ndk/android-ndk-r9b-windows-x86_64.zip
4. Install Apache Ant version 1.9.2
   http://archive.apache.org/dist/ant/binaries/

Previous documentation seemed to be accurate for the most part.

Make sure that the CommandPrompt window is Run As Administrator. Or things will crash.

"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" needs to be run so that platforms other than Android can be detected.

Pull request is required for this process to work.
