### PR TITLE
Clear output console (Button + clear on Play)

### DIFF
--- a/tools/editor/editor_log.cpp
+++ b/tools/editor/editor_log.cpp
@@ -107,7 +107,11 @@ void EditorLog::_close_request() {
 void EditorLog::_clear_request() {
 
 	log->clear();
-	
+
+}
+
+void EditorLog::clear() {
+	_clear_request();
 }
 
 
@@ -175,10 +179,11 @@ void EditorLog::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("_close_request"),&EditorLog::_close_request );
 	ObjectTypeDB::bind_method(_MD("_flip_request"),&EditorLog::_flip_request );
 	ObjectTypeDB::bind_method(_MD("_clear_request"),&EditorLog::_clear_request );
+
 	//ObjectTypeDB::bind_method(_MD("_dragged"),&EditorLog::_dragged );
 	ADD_SIGNAL( MethodInfo("close_request"));
 	ADD_SIGNAL( MethodInfo("show_request"));
-	ADD_SIGNAL( MethodInfo("clear_request"));	
+	ADD_SIGNAL( MethodInfo("clear_request"));
 }
 
 EditorLog::EditorLog() {
@@ -206,7 +211,7 @@ EditorLog::EditorLog() {
 	//hb->add_child(pd);
 	//pd->connect("dragged",this,"_dragged");
 	//pd->set_default_cursor_shape(Control::CURSOR_MOVE);
-	
+
 	clearbutton = memnew( Button );
 	hb->add_child(clearbutton);
 	clearbutton->set_text("Clear");
@@ -255,8 +260,8 @@ void EditorLog::deinit() {
 
 }
 
+
 EditorLog::~EditorLog() {
 
 
 }
-

--- a/tools/editor/editor_log.cpp
+++ b/tools/editor/editor_log.cpp
@@ -104,6 +104,13 @@ void EditorLog::_close_request() {
 }
 
 
+void EditorLog::_clear_request() {
+
+	log->clear();
+	
+}
+
+
 void EditorLog::add_message(const String& p_msg,bool p_error) {
 
 
@@ -167,9 +174,11 @@ void EditorLog::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("_close_request"),&EditorLog::_close_request );
 	ObjectTypeDB::bind_method(_MD("_flip_request"),&EditorLog::_flip_request );
+	ObjectTypeDB::bind_method(_MD("_clear_request"),&EditorLog::_clear_request );
 	//ObjectTypeDB::bind_method(_MD("_dragged"),&EditorLog::_dragged );
 	ADD_SIGNAL( MethodInfo("close_request"));
 	ADD_SIGNAL( MethodInfo("show_request"));
+	ADD_SIGNAL( MethodInfo("clear_request"));	
 }
 
 EditorLog::EditorLog() {
@@ -197,6 +206,11 @@ EditorLog::EditorLog() {
 	//hb->add_child(pd);
 	//pd->connect("dragged",this,"_dragged");
 	//pd->set_default_cursor_shape(Control::CURSOR_MOVE);
+	
+	clearbutton = memnew( Button );
+	hb->add_child(clearbutton);
+	clearbutton->set_text("Clear");
+	clearbutton->connect("pressed", this,"_clear_request");
 
 	tb = memnew( TextureButton );
 	hb->add_child(tb);

--- a/tools/editor/editor_log.h
+++ b/tools/editor/editor_log.h
@@ -33,7 +33,6 @@
 #include "scene/gui/label.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/texture_button.h"
-#include "scene/gui/check_button.h"
 //#include "scene/gui/empty_control.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/panel_container.h"

--- a/tools/editor/editor_log.h
+++ b/tools/editor/editor_log.h
@@ -33,6 +33,7 @@
 #include "scene/gui/label.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/texture_button.h"
+#include "scene/gui/check_button.h"
 //#include "scene/gui/empty_control.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/panel_container.h"
@@ -59,11 +60,11 @@ class EditorLog : public PanelContainer {
 
 	Thread::ID current;
 
-
 //	void _dragged(const Point2& p_ofs);
 	void _close_request();
 	void _flip_request();
 	void _clear_request();
+	void _clearonplay_request();
 	static void _undo_redo_cbk(void *p_self,const String& p_name);
 protected:
 
@@ -75,6 +76,7 @@ public:
 	void deinit();
 
 	ToolButton *get_button();
+	void clear();
 	EditorLog();
 	~EditorLog();
 };

--- a/tools/editor/editor_log.h
+++ b/tools/editor/editor_log.h
@@ -45,6 +45,7 @@ class EditorLog : public PanelContainer {
 	OBJ_TYPE( EditorLog, PanelContainer );
 
 	ToolButton *button;
+	Button *clearbutton;
 	Label *title;
 	RichTextLabel *log;
 	TextureButton *tb;
@@ -62,6 +63,7 @@ class EditorLog : public PanelContainer {
 //	void _dragged(const Point2& p_ofs);
 	void _close_request();
 	void _flip_request();
+	void _clear_request();
 	static void _undo_redo_cbk(void *p_self,const String& p_name);
 protected:
 

--- a/tools/editor/editor_log.h
+++ b/tools/editor/editor_log.h
@@ -63,7 +63,6 @@ class EditorLog : public PanelContainer {
 	void _close_request();
 	void _flip_request();
 	void _clear_request();
-	void _clearonplay_request();
 	static void _undo_redo_cbk(void *p_self,const String& p_name);
 protected:
 

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -1645,7 +1645,6 @@ void EditorNode::_run(bool p_current,const String& p_custom) {
 	}
 
 	if (bool(EDITOR_DEF("run/always_clear_output_on_play", true))) {
-		print_line("Setting option was set to ON -> clearing");
 		log->clear();
 	}
 

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -1564,7 +1564,6 @@ void EditorNode::_run(bool p_current,const String& p_custom) {
 		Node *scene = editor_data.get_edited_scene_root();
 
 		if (!scene) {
-
 			current_option=-1;
 			//accept->get_cancel()->hide();
 			accept->get_ok()->set_text("I see..");
@@ -1643,6 +1642,11 @@ void EditorNode::_run(bool p_current,const String& p_custom) {
 		}
 
 		editor_data.save_editor_external_data();
+	}
+
+	if (bool(EDITOR_DEF("run/always_clear_output_on_play", true))) {
+		print_line("Setting option was set to ON -> clearing");
+		log->clear();
 	}
 
 


### PR DESCRIPTION
This PR resolves Feature #1825 
- Added a "Clear" button above output console
- Added a Setting option to automatize clearing when Play is started
