### PR TITLE
Add missing signal token name

### DIFF
--- a/modules/gdscript/gd_tokenizer.cpp
+++ b/modules/gdscript/gd_tokenizer.cpp
@@ -97,6 +97,7 @@ const char* GDTokenizer::token_names[TK_MAX]={
 "preload",
 "assert",
 "yield",
+"signal",
 "'['",
 "']'",
 "'{'",


### PR DESCRIPTION
TK_PR_SIGNAL name was missing in token_names since 48f1d02 which caused TK_CURSOR to exceed the size of the array.

closes #2201
