### PR TITLE
Hide right UR and BR dock slots by default

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -4275,6 +4275,9 @@ EditorNode::EditorNode() {
 	right_l_vsplit->add_child(dock_slot[DOCK_SLOT_RIGHT_UL]);
 	dock_slot[DOCK_SLOT_RIGHT_BL]=memnew( TabContainer );
 	right_l_vsplit->add_child(dock_slot[DOCK_SLOT_RIGHT_BL]);
+	//right_l_vsplit->hide();
+	//dock_slot[DOCK_SLOT_RIGHT_UL]->hide();
+	//dock_slot[DOCK_SLOT_RIGHT_BL]->hide();
 
 	right_r_vsplit = memnew( VSplitContainer );
 	right_hsplit->add_child(right_r_vsplit);
@@ -4283,8 +4286,8 @@ EditorNode::EditorNode() {
 	dock_slot[DOCK_SLOT_RIGHT_BR]=memnew( TabContainer );
 	right_r_vsplit->add_child(dock_slot[DOCK_SLOT_RIGHT_BR]);
 	right_r_vsplit->hide();
-	//dock_slot[DOCK_SLOT_RIGHT_UL]->hide();
-	//dock_slot[DOCK_SLOT_RIGHT_BL]->hide();
+	dock_slot[DOCK_SLOT_RIGHT_UR]->hide();
+	dock_slot[DOCK_SLOT_RIGHT_BR]->hide();
 
 	left_l_vsplit->connect("dragged",this,"_dock_split_dragged");
 	left_r_vsplit->connect("dragged",this,"_dock_split_dragged");


### PR DESCRIPTION
Unlike _left_ UpLeft and BottomLeft dock slots, _right_ UpRight and BottomRight slots was not hidden by default, causing one not to fill vertically if the other one is empty.

Since there was no issue about this problem, here is an screenshot:
![image](https://cloud.githubusercontent.com/assets/7718100/9156757/63c9419a-3ee5-11e5-9367-6394ba6d9c3b.png)
