### PR TITLE
prevent to change tool mode when control key is pressed

### DIFF
--- a/tools/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/tools/editor/plugins/canvas_item_editor_plugin.cpp
@@ -144,6 +144,9 @@ void CanvasItemEditor::_unhandled_key_input(const InputEvent& p_ev) {
 
 	if (!is_visible())
 		return;
+	if (p_ev.key.mod.control || p_ev.key.mod.shift)
+		// prevent to change tool mode when control or shift key is pressed
+		return;
 	if (p_ev.key.pressed && !p_ev.key.echo && p_ev.key.scancode==KEY_Q)
 		_tool_select(TOOL_SELECT);
 	if (p_ev.key.pressed && !p_ev.key.echo && p_ev.key.scancode==KEY_W)

--- a/tools/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/tools/editor/plugins/canvas_item_editor_plugin.cpp
@@ -144,8 +144,8 @@ void CanvasItemEditor::_unhandled_key_input(const InputEvent& p_ev) {
 
 	if (!is_visible())
 		return;
-	if (p_ev.key.mod.control || p_ev.key.mod.shift)
-		// prevent to change tool mode when control or shift key is pressed
+	if (p_ev.key.mod.control)
+		// prevent to change tool mode when control key is pressed
 		return;
 	if (p_ev.key.pressed && !p_ev.key.echo && p_ev.key.scancode==KEY_Q)
 		_tool_select(TOOL_SELECT);


### PR DESCRIPTION
Select/Move/Rotate mode is changed unexpectedly when closing editor or scene.
1. Move mode is changed to Select mode when trying to close editor with Ctrl + Q
2. Select mode is changed to Move mode when trying to close scene with Ctrl + Shift + W
