### PR TITLE
UI - close PopupMenu fix - update scene tab fix - load tileset directly from .scn

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -30,6 +30,8 @@
 #include "io/marshalls.h"
 #include "servers/physics_2d_server.h"
 #include "method_bind_ext.inc"
+#include "scene/resources/packed_scene.h"
+#include "tools/editor/plugins/tile_set_editor_plugin.h"
 
 int TileMap::_get_quadrant_size() const {
 
@@ -159,6 +161,24 @@ void TileMap::set_tileset(const Ref<TileSet>& p_tileset) {
 Ref<TileSet> TileMap::get_tileset() const {
 
 	return tile_set;
+}
+
+void TileMap::set_tilesetscene(const Ref<PackedScene>& p_tilesetscene) {
+
+	tile_set_scene = p_tilesetscene;
+	Ref<TileSet> t;
+	if (tile_set_scene.is_valid()){
+		Node *n = tile_set_scene->instance();
+		TileSet *ts = memnew(TileSet);
+		t = Ref<TileSet>(ts);
+		TileSetEditor::update_library_file(n, t, true);	
+	}
+	set_tileset(t);
+}
+
+Ref<PackedScene> TileMap::get_tilesetscene() const {
+
+	return tile_set_scene;
 }
 
 void TileMap::set_cell_size(Size2 p_size) {
@@ -1064,6 +1084,9 @@ void TileMap::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_tileset","tileset:TileSet"),&TileMap::set_tileset);
 	ObjectTypeDB::bind_method(_MD("get_tileset:TileSet"),&TileMap::get_tileset);
 
+	ObjectTypeDB::bind_method(_MD("set_tilesetscene", "tilesetscene:PackedScene"), &TileMap::set_tilesetscene);
+	ObjectTypeDB::bind_method(_MD("get_tilesetscene:PackedScene"), &TileMap::get_tilesetscene);
+
 	ObjectTypeDB::bind_method(_MD("set_mode","mode"),&TileMap::set_mode);
 	ObjectTypeDB::bind_method(_MD("get_mode"),&TileMap::get_mode);
 
@@ -1131,6 +1154,7 @@ void TileMap::_bind_methods() {
 
 	ADD_PROPERTY( PropertyInfo(Variant::INT,"mode",PROPERTY_HINT_ENUM,"Square,Isometric,Custom"),_SCS("set_mode"),_SCS("get_mode"));
 	ADD_PROPERTY( PropertyInfo(Variant::OBJECT,"tile_set",PROPERTY_HINT_RESOURCE_TYPE,"TileSet"),_SCS("set_tileset"),_SCS("get_tileset"));
+	ADD_PROPERTY( PropertyInfo(Variant::OBJECT, "tile_set_scene", PROPERTY_HINT_RESOURCE_TYPE, "PackedScene"), _SCS("set_tilesetscene"), _SCS("get_tilesetscene"));
 	ADD_PROPERTY( PropertyInfo(Variant::INT,"cell_size",PROPERTY_HINT_RANGE,"1,8192,1",0),_SCS("_set_old_cell_size"),_SCS("_get_old_cell_size"));
 	ADD_PROPERTY( PropertyInfo(Variant::VECTOR2,"cell/size",PROPERTY_HINT_RANGE,"1,8192,1"),_SCS("set_cell_size"),_SCS("get_cell_size"));
 	ADD_PROPERTY( PropertyInfo(Variant::INT,"cell/quadrant_size",PROPERTY_HINT_RANGE,"1,128,1"),_SCS("set_quadrant_size"),_SCS("get_quadrant_size"));

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -32,6 +32,7 @@
 #include "scene/2d/node_2d.h"
 #include "scene/2d/navigation2d.h"
 #include "scene/resources/tile_set.h"
+#include "scene/resources/packed_scene.h"
 #include "self_list.h"
 #include "vset.h"
 
@@ -61,6 +62,7 @@ public:
 private:
 
 	Ref<TileSet> tile_set;
+	Ref<PackedScene> tile_set_scene;
 	Size2i cell_size;
 	int quadrant_size;
 	bool center_x,center_y;
@@ -189,6 +191,9 @@ public:
 
 	void set_tileset(const Ref<TileSet>& p_tileset);
 	Ref<TileSet> get_tileset() const;
+
+	void set_tilesetscene(const Ref<PackedScene>& p_tilesetscene);
+	Ref<PackedScene> get_tilesetscene() const;
 
 	void set_cell_size(Size2 p_size);
 	Size2 get_cell_size() const;

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -738,10 +738,18 @@ int PopupMenu::find_item_by_accelerator(uint32_t p_accel) const {
 
 void PopupMenu::activate_item(int p_item) {
 
-
 	ERR_FAIL_INDEX(p_item,items.size());
 	ERR_FAIL_COND(items[p_item].separator);
 	emit_signal("item_pressed",items[p_item].ID);
+
+	//hide all parent PopupMenue's
+	Node *next = get_parent();
+	PopupMenu *pop = next->cast_to<PopupMenu>();
+	while (pop) {
+		pop->hide();
+		next = next->get_parent();
+		pop = next->cast_to<PopupMenu>();
+	}
 	hide();
 
 }

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -918,6 +918,7 @@ void EditorNode::_save_scene(String p_file) {
 		//EditorFileSystem::get_singleton()->update_file(p_file,sdata->get_type());
 		set_current_version(editor_data.get_undo_redo().get_version());
 		_update_title();
+		_update_scene_tabs();
 	} else {
 
 		_dialog_display_file_error(p_file,err);
@@ -1323,7 +1324,6 @@ void EditorNode::_dialog_action(String p_file) {
 
 		default: { //save scene?
 		
-			
 			if (file->get_mode()==FileDialog::MODE_SAVE_FILE) {
 
 				//_save_scene(p_file);


### PR DESCRIPTION
I'm new to c++ and this is my first pull request so be nice ;D.

close PopupMenu fix: Sub-PopupMenus did not hide parent PopupMenus.

update scene tab fix: After "save" the scene tab name was still with (*).

load tileset directly from .scn: Creating a TileSet on each update of the scene is annoying, so i made a new Property to load the scene dircetly in a TileMap.
