### PR TITLE
[UI-FIX] - Close all parent PopupMenus

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -738,10 +738,18 @@ int PopupMenu::find_item_by_accelerator(uint32_t p_accel) const {
 
 void PopupMenu::activate_item(int p_item) {
 
-
 	ERR_FAIL_INDEX(p_item,items.size());
 	ERR_FAIL_COND(items[p_item].separator);
 	emit_signal("item_pressed",items[p_item].ID);
+
+	//hide all parent PopupMenue's
+	Node *next = get_parent();
+	PopupMenu *pop = next->cast_to<PopupMenu>();
+	while (pop) {
+		pop->hide();
+		next = next->get_parent();
+		pop = next->cast_to<PopupMenu>();
+	}
 	hide();
 
 }


### PR DESCRIPTION
close PopupMenu fix: Sub-PopupMenus did not hide parent PopupMenus.
