### PR TITLE
Fixed 'osx' and 'iphone' compilation error on MacOSX 10.10 and HTML5 export

### DIFF
--- a/build_template_js.sh
+++ b/build_template_js.sh
@@ -1,0 +1,47 @@
+#This script is for testing EMScripten templates. Only tested on Mac OSX 10.10.
+#Based on https://github.com/okamstudio/godot/wiki/compiling_batch_templates
+
+#Need to set path to EMScripten
+export EMSCRIPTEN_ROOT=~/Dev/emsdk_portable/emscripten/1.34.1
+
+#Build OSX first so shaders are included.
+
+~/bin/scons -j 4 p=osx
+
+# EMScripten
+# Note: Changed a couple of 'cp' to 'sed' in order to change file references to 
+#       what platform/javascript/export/export.cpp expects.
+#       Also note that more recent Emscripten emits a *.html.mem file.
+
+~/bin/scons -j 4 p=javascript target=release
+sed -e 's/godot.*js/godot\.js/' bin/godot.javascript.opt.html > godot.html
+sed -e 's/godot.javascript.opt.html.mem/godot.html.mem/g' bin/godot.javascript.opt.js > godot.js
+cp bin/godot.javascript.opt.html.mem godot.html.mem
+cp tools/html_fs/filesystem.js .
+zip javascript_release.zip godot.html godot.js godot.html.mem filesystem.js
+cp javascript_release.zip ~/.godot/templates
+
+~/bin/scons -j 4 p=javascript target=debug
+#cp bin/godot.javascript.debug.html godot.html
+sed -e 's/godot.*js/godot\.js/' bin/godot.javascript.debug.html > godot.html
+#cp bin/godot.javascript.debug.js godot.js
+sed -e 's/godot.javascript.debug.html.mem/godot.html.mem/g' bin/godot.javascript.debug.js > godot.js
+cp bin/godot.javascript.debug.html.mem godot.html.mem
+cp tools/html_fs/filesystem.js .
+zip javascript_debug.zip godot.html godot.js godot.html.mem filesystem.js
+cp javascript_debug.zip ~/.godot/templates
+
+rm godot.html
+rm godot.js
+rm godot.html.mem
+rm filesystem.js
+
+# Just for quick testing, avoid having to manually re-export from editor every time, 
+# just one initial export as 'godot.html' is required.
+#cp bin/godot.javascript.debug.js ~/Downloads/godot_demos-1.1stable/builds/platformer3d/godot.js
+#cp bin/godot.javascript.debug.html.mem ~/Downloads/godot_demos-1.1stable/builds/platformer3d
+
+rm javascript_release.zip
+rm javascript_debug.zip
+
+

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -6656,7 +6656,7 @@ void RasterizerGLES2::_render_list_forward(RenderList *p_render_list,const Trans
 			material_shader.set_uniform(MaterialShaderGLES2::CAMERA_INVERSE_TRANSFORM, p_view_transform_inverse);
 			material_shader.set_uniform(MaterialShaderGLES2::PROJECTION_TRANSFORM, p_projection);
 			if (skeleton && use_hw_skeleton_xform) {
-				material_shader.set_uniform(MaterialShaderGLES2::SKELETON_MATRICES,GL_TEXTURE0+max_texture_units-2);
+				material_shader.set_uniform(MaterialShaderGLES2::SKELETON_MATRICES,/* GL_TEXTURE0+ */max_texture_units-2);
 				material_shader.set_uniform(MaterialShaderGLES2::SKELTEX_PIXEL_SIZE,skeleton->pixel_size);
 			}
 			if (!shadow) {
@@ -10762,6 +10762,10 @@ void RasterizerGLES2::init() {
 
 #endif
 
+	// NOTE: Uncomment the following line to test hardware skeleton transform.
+	//       Currently seems a bit glitchy, but somewhat works.
+	//use_hw_skeleton_xform = true;
+	
 	//use_rgba_shadowmaps=true;
 
 

--- a/drivers/gles2/shaders/copy.glsl
+++ b/drivers/gles2/shaders/copy.glsl
@@ -475,12 +475,7 @@ void main() {
 	highp float lum_accum = color.r;
 	highp float lum_max = color.g;
 
-#define LUM_REDUCE(m_uv) \
-	{\
-		vec2 val = texture2D( source,  uv_interp+m_uv ).rg;\
-		lum_accum+=val.x;\
-		lum_max=max(val.y,lum_max);\
-	}
+#define LUM_REDUCE(m_uv) { vec2 val = texture2D( source,  uv_interp+m_uv ).rg; lum_accum+=val.x; lum_max=max(val.y,lum_max); }
 
 	LUM_REDUCE( vec2(-pixel_size.x,-pixel_size.y) );
 	LUM_REDUCE( vec2(0.0,-pixel_size.y) );

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -226,7 +226,6 @@ uint64_t OS_Unix::get_unix_time() const {
 uint64_t OS_Unix::get_system_time_msec() const {
 	struct timeval tv_now;
 	gettimeofday(&tv_now, NULL);
-	localtime(&tv_now.tv_usec);
 	uint64_t msec = tv_now.tv_usec/1000;
 	return msec;
 }

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -80,7 +80,8 @@ def configure(env):
 	env.Append(CPPFLAGS=["-fno-exceptions",'-DNO_SAFE_CAST','-fno-rtti'])
 	env.Append(CPPFLAGS=['-DJAVASCRIPT_ENABLED', '-DUNIX_ENABLED', '-DNO_FCNTL','-DMPC_FIXED_POINT','-DTYPED_METHOD_BIND','-DNO_THREADS'])
 	env.Append(CPPFLAGS=['-DGLES2_ENABLED'])
-	env.Append(CPPFLAGS=['-DGLES_NO_CLIENT_ARRAYS'])
+# Disabled until the WebGL code correctly handles all cases where VBOs need to be implemented.
+#	env.Append(CPPFLAGS=['-DGLES_NO_CLIENT_ARRAYS'])
 	env.Append(CPPFLAGS=['-s','ASM_JS=1'])
 	env.Append(CPPFLAGS=['-s','FULL_ES2=1'])
 #	env.Append(CPPFLAGS=['-DANDROID_ENABLED', '-DUNIX_ENABLED','-DMPC_FIXED_POINT'])
@@ -91,6 +92,7 @@ def configure(env):
 		env.Append(LINKFLAGS=['--compression',lzma_binpath+","+lzma_decoder+","+lzma_dec])
 
 	env.Append(LINKFLAGS=['-s','ASM_JS=1'])
+	env.Append(LINKFLAGS=['-s','FULL_ES2=1'])
 	env.Append(LINKFLAGS=['-O2'])
 	#env.Append(LINKFLAGS=['-g4'])
 	

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -144,7 +144,7 @@ static void _fix_html(Vector<uint8_t>& html,const String& name,int max_memory) {
 	str.parse_utf8((const char*)html.ptr(),html.size());
 	Vector<String> lines=str.split("\n");
 	for(int i=0;i<lines.size();i++) {
-		if (lines[i].find("godot.js")!=-1) {
+		if (lines[i].find("src=\"godot.javascript")!=-1) {
 			strnew+="<script type=\"text/javascript\" src=\""+name+"_filesystem.js\"></script>\n";
 			strnew+="<script async type=\"text/javascript\" src=\""+name+".js\"></script>\n";
 		} else if (lines[i].find("var Module")!=-1) {

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -144,7 +144,7 @@ static void _fix_html(Vector<uint8_t>& html,const String& name,int max_memory) {
 	str.parse_utf8((const char*)html.ptr(),html.size());
 	Vector<String> lines=str.split("\n");
 	for(int i=0;i<lines.size();i++) {
-		if (lines[i].find("src=\"godot.javascript")!=-1) {
+		if (lines[i].find("godot.js")!=-1) {
 			strnew+="<script type=\"text/javascript\" src=\""+name+"_filesystem.js\"></script>\n";
 			strnew+="<script async type=\"text/javascript\" src=\""+name+".js\"></script>\n";
 		} else if (lines[i].find("var Module")!=-1) {
@@ -184,6 +184,30 @@ static void _fix_files(Vector<uint8_t>& html,uint64_t p_data_size) {
 	}
 
 }
+
+static void _fix_godot_js(Vector<uint8_t>& content, const String& name) {
+    
+    
+    String str;
+    String strnew;
+    str.parse_utf8((const char*)content.ptr(),content.size());
+    Vector<String> lines=str.split("\n");
+    for(int i=0;i<lines.size();i++) {
+        if (lines[i].find("godot.html.mem")!=-1) {
+            strnew+=lines[i].replace("godot.html.mem", name + ".html.mem") + "\n";
+        } else {
+            strnew+=lines[i]+"\n";
+        }
+    }
+    
+    CharString cs = strnew.utf8();
+    content.resize(cs.length());
+    for(int i=0;i<cs.length();i++) {
+        content[i]=cs[i];
+    }
+    
+}
+
 
 struct JSExportData {
 
@@ -274,9 +298,13 @@ Error EditorExportPlatformJavaScript::export_project(const String& p_path, bool 
 		}
 		if (file=="godot.js") {
 
-			//_fix_godot(data);
+			_fix_godot_js(data, p_path.get_file().basename());
 			file=p_path.get_file().basename()+".js";
 		}
+        if (file=="godot.html.mem") {
+            
+            file=p_path.get_file().basename()+".html.mem";
+        }
 
 		String dst = p_path.get_base_dir().plus_file(file);
 		FileAccess *f=FileAccess::open(dst,FileAccess::WRITE);


### PR DESCRIPTION
Removed call to 'localtime' in OS_Unix::get_system_time_msec, which caused the following compiler error when building:

```
sudo scons -j4 platform=osx
scons: Reading SConscript files ...
sh: i586-mingw32msvc-gcc: command not found
sh: x86_64-w64-mingw32-gcc: command not found
sh: i686-w64-mingw32-gcc: command not found
scons: done reading SConscript files.
scons: Building targets ...
g++ -o drivers/unix/os_unix.osx.tools.32.o -c -g3 -Wall -DDEBUG_ENABLED - DDEBUG_MEMORY_ENABLED -DFREETYPE_ENABLED -arch i386 -DDEBUG_MEMORY_ALLOC -DSCI_NAMESPACE -DAPPLE_STYLE_KEYS -DUNIX_ENABLED -DGLES2_ENABLED -DGLEW_ENABLED -DOSX_ENABLED -DMUSEPACK_ENABLED -DSQUISH_ENABLED -DVORBIS_ENABLED -DTHEORA_ENABLED -DPNG_ENABLED -DDDS_ENABLED -DPVR_ENABLED -DJPG_ENABLED -DWEBP_ENABLED -DSPEEX_ENABLED -DTOOLS_ENABLED -DGDSCRIPT_ENABLED -DMINIZIP_ENABLED -DXML_ENABLED -DETC1_ENABLED -Icore -Icore/math -Itools -Idrivers -I. -Iplatform/osx -Itools/freetype -Itools/freetype/freetype/include -Idrivers/unix/vorbis drivers/unix/os_unix.cpp
drivers/unix/os_unix.cpp:229:2: error: no matching function for call to 'localtime'
    localtime(&tv_now.tv_usec);
        ^~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/usr/include/time.h:112:12: note: 
  candidate function not viable: no known conversion from '__darwin_suseconds_t *' (aka 'int *') to 'const time_t *'
  (aka 'const long *') for 1st argument
struct tm *localtime(const time_t *);
           ^
1 error generated.
scons: *** [drivers/unix/os_unix.osx.tools.32.o] Error 1
scons: building terminated because of errors.
```
