### PR TITLE
Manage middle click in Tabs / Close scene if middle click on scene tab

### DIFF
--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -151,7 +151,7 @@ void Tabs::_input_event(const InputEvent& p_event) {
 
 				if (found!=-1) {
 					set_current_tab(found);
-					emit_signal("middle_button_pressed", found);
+					emit_signal("tab_close", found);
 				}
 				break;
 			}
@@ -442,7 +442,7 @@ void Tabs::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("tab_changed",PropertyInfo(Variant::INT,"tab")));
 	ADD_SIGNAL(MethodInfo("right_button_pressed",PropertyInfo(Variant::INT,"tab")));
-	ADD_SIGNAL(MethodInfo("middle_button_pressed",PropertyInfo(Variant::INT,"tab")));
+	ADD_SIGNAL(MethodInfo("tab_close",PropertyInfo(Variant::INT,"tab")));
 
 	ADD_PROPERTY( PropertyInfo(Variant::INT, "current_tab", PROPERTY_HINT_RANGE,"-1,4096,1",PROPERTY_USAGE_EDITOR), _SCS("set_current_tab"), _SCS("get_current_tab") );
 

--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -107,35 +107,54 @@ void Tabs::_input_event(const InputEvent& p_event) {
 	}
 
 	if (p_event.type==InputEvent::MOUSE_BUTTON &&
-	    p_event.mouse_button.pressed &&
-	    p_event.mouse_button.button_index==BUTTON_LEFT) {
+	    p_event.mouse_button.pressed) {
 
 		// clicks
 		Point2 pos( p_event.mouse_button.x, p_event.mouse_button.y );
 
-		int found=-1;
-		for(int i=0;i<tabs.size();i++) {
+		switch (p_event.mouse_button.button_index) {
+			case BUTTON_LEFT:
+			{
 
-			if (tabs[i].rb_rect.has_point(pos)) {
-				rb_pressing=true;
-				update();
-				return;
-			}
 
-			int ofs=tabs[i].ofs_cache;
-			int size = tabs[i].ofs_cache;
-			if (pos.x >=tabs[i].ofs_cache && pos.x<tabs[i].ofs_cache+tabs[i].size_cache) {
+				int found=-1;
+				for(int i=0;i<tabs.size();i++) {
 
-				found=i;
+					if (tabs[i].rb_rect.has_point(pos)) {
+						rb_pressing=true;
+						update();
+						return;
+					}
+
+					if (pos.x >=tabs[i].ofs_cache && pos.x<tabs[i].ofs_cache+tabs[i].size_cache) {
+						found=i;
+						break;
+					}
+				}
+
+				if (found!=-1) {
+					set_current_tab(found);
+					emit_signal("tab_changed",found);
+				}
 				break;
 			}
-		}
+			case BUTTON_MIDDLE:
+			{
+				int found=-1;
+				for(int i=0;i<tabs.size();i++) {
 
+					if (pos.x >=tabs[i].ofs_cache && pos.x<tabs[i].ofs_cache+tabs[i].size_cache) {
+						found=i;
+						break;
+					}
+				}
 
-		if (found!=-1) {
-
-			set_current_tab(found);
-			emit_signal("tab_changed",found);
+				if (found!=-1) {
+					set_current_tab(found);
+					emit_signal("middle_button_pressed", found);
+				}
+				break;
+			}
 		}
 	}
 
@@ -423,6 +442,7 @@ void Tabs::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("tab_changed",PropertyInfo(Variant::INT,"tab")));
 	ADD_SIGNAL(MethodInfo("right_button_pressed",PropertyInfo(Variant::INT,"tab")));
+	ADD_SIGNAL(MethodInfo("middle_button_pressed",PropertyInfo(Variant::INT,"tab")));
 
 	ADD_PROPERTY( PropertyInfo(Variant::INT, "current_tab", PROPERTY_HINT_RANGE,"-1,4096,1",PROPERTY_USAGE_EDITOR), _SCS("set_current_tab"), _SCS("get_current_tab") );
 

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -4074,8 +4074,11 @@ void EditorNode::_scene_tab_script_edited(int p_tab) {
 }
 
 void EditorNode::_scene_tab_closed(int p_tab) {
-	set_current_scene(p_tab);
-	_remove_edited_scene();
+	bool p_confirmed = true;
+	if (unsaved_cache)
+		p_confirmed = false;
+
+	_menu_option_confirm(FILE_CLOSE, p_confirmed);
 }
 
 void EditorNode::_scene_tab_changed(int p_tab) {

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -4074,11 +4074,13 @@ void EditorNode::_scene_tab_script_edited(int p_tab) {
 }
 
 void EditorNode::_scene_tab_closed(int p_tab) {
+	set_current_scene(p_tab);
 	bool p_confirmed = true;
 	if (unsaved_cache)
 		p_confirmed = false;
 
 	_menu_option_confirm(FILE_CLOSE, p_confirmed);
+	_update_scene_tabs();
 }
 
 void EditorNode::_scene_tab_changed(int p_tab) {

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -3621,6 +3621,7 @@ void EditorNode::_bind_methods() {
 	ObjectTypeDB::bind_method("set_current_version",&EditorNode::set_current_version);
 	ObjectTypeDB::bind_method("_scene_tab_changed",&EditorNode::_scene_tab_changed);
 	ObjectTypeDB::bind_method("_scene_tab_script_edited",&EditorNode::_scene_tab_script_edited);
+	ObjectTypeDB::bind_method("_scene_tab_closed",&EditorNode::_scene_tab_closed);
 	ObjectTypeDB::bind_method("_set_main_scene_state",&EditorNode::_set_main_scene_state);
 	ObjectTypeDB::bind_method("_update_scene_tabs",&EditorNode::_update_scene_tabs);
 
@@ -4072,6 +4073,11 @@ void EditorNode::_scene_tab_script_edited(int p_tab) {
 		edit_resource(script);
 }
 
+void EditorNode::_scene_tab_closed(int p_tab) {
+	set_current_scene(p_tab);
+	_remove_edited_scene();
+}
+
 void EditorNode::_scene_tab_changed(int p_tab) {
 
 
@@ -4227,6 +4233,7 @@ EditorNode::EditorNode() {
 	scene_tabs->set_tab_align(Tabs::ALIGN_CENTER);
 	scene_tabs->connect("tab_changed",this,"_scene_tab_changed");
 	scene_tabs->connect("right_button_pressed",this,"_scene_tab_script_edited");
+	scene_tabs->connect("middle_button_pressed", this, "_scene_tab_closed");
 	top_dark_vb->add_child(scene_tabs);
 	//left
 	left_l_hsplit = memnew( HSplitContainer );

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -918,6 +918,7 @@ void EditorNode::_save_scene(String p_file) {
 		//EditorFileSystem::get_singleton()->update_file(p_file,sdata->get_type());
 		set_current_version(editor_data.get_undo_redo().get_version());
 		_update_title();
+		_update_scene_tabs();
 	} else {
 
 		_dialog_display_file_error(p_file,err);
@@ -1323,7 +1324,6 @@ void EditorNode::_dialog_action(String p_file) {
 
 		default: { //save scene?
 		
-			
 			if (file->get_mode()==FileDialog::MODE_SAVE_FILE) {
 
 				//_save_scene(p_file);
@@ -4240,7 +4240,7 @@ EditorNode::EditorNode() {
 	scene_tabs->set_tab_align(Tabs::ALIGN_CENTER);
 	scene_tabs->connect("tab_changed",this,"_scene_tab_changed");
 	scene_tabs->connect("right_button_pressed",this,"_scene_tab_script_edited");
-	scene_tabs->connect("middle_button_pressed", this, "_scene_tab_closed");
+	scene_tabs->connect("tab_close", this, "_scene_tab_closed");
 	top_dark_vb->add_child(scene_tabs);
 	//left
 	left_l_hsplit = memnew( HSplitContainer );

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -2688,8 +2688,10 @@ void EditorNode::_remove_edited_scene() {
 
 	if (editor_data.get_edited_scene_count()==1) {
 		//make new scene appear saved
-		set_current_version(editor_data.get_undo_redo().get_version());
-		unsaved_cache=false;
+		if (editor_data.get_scene_title(0) == "[empty]") {
+			set_current_version(editor_data.get_undo_redo().get_version());
+			unsaved_cache=false;
+		}
 	}
 }
 void EditorNode::set_edited_scene(Node *p_scene) {

--- a/tools/editor/editor_node.h
+++ b/tools/editor/editor_node.h
@@ -473,6 +473,7 @@ class EditorNode : public Node {
 	void _dock_split_dragged(int ofs);
 	void _dock_popup_exit();
 	void _scene_tab_changed(int p_tab);
+	void _scene_tab_closed(int p_tab);
 	void _scene_tab_script_edited(int p_tab);
 
 	Dictionary _get_main_scene_state();


### PR DESCRIPTION
- Added new signal in Tabs : middle_button_pressed. 
- Added corresponding behaviour in editors Scene tabs to close scene on middle click.
- Managed confirmation question on closing a non-saved scene.

Note : tabs.cpp _input_event() is now opened for different calls depending on the mouse button pressed.
