### PR TITLE
Fix enemy.gd to actually remove dead enemies.

### DIFF
--- a/demos/3d/platformer/enemy.gd
+++ b/demos/3d/platformer/enemy.gd
@@ -91,4 +91,5 @@ func _ready():
 	# Initalization here
 	pass
 
-
+func _on_AnimationPlayer_finished():
+	queue_free()


### PR DESCRIPTION
Previously, enemies sat around as invisible physics objects.  You could sometimes trip over it if it was in your way, or you could use it as a stepping stone.  I won't say the stepping stone part couldn't be interesting, but I'm fairly certain it was unintended.
