### PR TITLE
reworked Label class

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -13219,26 +13219,28 @@
 			<argument index="0" name="align" type="int">
 			</argument>
 			<description>
-			Set the alignmend mode to any of the ALIGN_* enumeration values.
+			Sets the alignment mode to any of the ALIGN_* enumeration values.
 			</description>
 		</method>
 		<method name="get_align" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-			Return the alignmend mode (any of the ALIGN_* enumeration values).
+			Return the alignment mode (any of the ALIGN_* enumeration values).
 			</description>
 		</method>
 		<method name="set_valign">
 			<argument index="0" name="valign" type="int">
 			</argument>
 			<description>
+			Sets the vertical alignment mode to any of the VALIGN_* enumeration values.
 			</description>
 		</method>
 		<method name="get_valign" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
+			Return the vertical alignment mode (any of the VALIGN_* enumeration values).
 			</description>
 		</method>
 		<method name="set_text">
@@ -13269,16 +13271,32 @@
 			Return the state of the [i]autowrap[/i] mode (see [method set_autowrap]).
 			</description>
 		</method>
+		<method name="set_clip_text">
+			<argument index="0" name="enable" type="bool">
+			</argument>
+			<description>
+			Cuts off the rest of the text if it is too wide.
+			</description>
+		</method>
+		<method name="is_clipping_text" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+			Return true if text would be cut off if it is too wide.
+			</description>
+		</method>
 		<method name="set_uppercase">
 			<argument index="0" name="enable" type="bool">
 			</argument>
 			<description>
+			Display text in all capitals.
 			</description>
 		</method>
 		<method name="is_uppercase" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
+			Return true if text is displayed in all capitals.
 			</description>
 		</method>
 		<method name="get_line_height" qualifiers="const">
@@ -13299,24 +13317,63 @@
 			<return type="int">
 			</return>
 			<description>
+			Return the total length of the text.
 			</description>
 		</method>
 		<method name="set_visible_characters">
-			<argument index="0" name="arg0" type="int">
+			<argument index="0" name="amount" type="int">
 			</argument>
 			<description>
+			Restricts the number of characters to display. Set to -1 to disable.
+			</description>
+		</method>
+		<method name="get_visible_characters" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+			Return the restricted number of characters to display. Returns -1 if unrestricted.
 			</description>
 		</method>
 		<method name="set_percent_visible">
 			<argument index="0" name="percent_visible" type="float">
 			</argument>
 			<description>
+			Restricts the number of characters to display (as a percentage of the total text).
 			</description>
 		</method>
 		<method name="get_percent_visible" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
+			Return the restricted number of characters to display (as a percentage of the total text).
+			</description>
+		</method>
+		<method name="set_max_lines_visible">
+			<argument index="0" name="lines_visible" type="int">
+			</argument>
+			<description>
+			Restricts the number of lines to display. Set to -1 to disable.
+			</description>
+		</method>
+		<method name="get_max_lines_visible" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+			Return the restricted number of lines to display. Returns -1 if unrestricted.
+			</description>
+		</method>
+		<method name="set_lines_skipped">
+			<argument index="0" name="lines_skipped" type="int">
+			</argument>
+			<description>
+			Sets the number of lines to skip before displaying. Useful for scrolling text.
+			</description>
+		</method>
+		<method name="get_lines_skipped" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+			Return the the number of lines to skipped before displaying.
 			</description>
 		</method>
 	</methods>

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -564,6 +564,11 @@ void Label::set_visible_characters(int p_amount) {
 	update();
 }
 
+int Label::get_visible_characters() const {
+
+	return visible_chars;
+}
+
 void Label::set_percent_visible(float p_percent) {
 
 	if (p_percent<0 || p_percent>=1) {
@@ -631,7 +636,8 @@ void Label::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_line_height"),&Label::get_line_height);
 	ObjectTypeDB::bind_method(_MD("get_line_count"),&Label::get_line_count);
 	ObjectTypeDB::bind_method(_MD("get_total_character_count"),&Label::get_total_character_count);
-	ObjectTypeDB::bind_method(_MD("set_visible_characters"),&Label::set_visible_characters);
+	ObjectTypeDB::bind_method(_MD("set_visible_characters","amount"),&Label::set_visible_characters);
+	ObjectTypeDB::bind_method(_MD("get_visible_characters"),&Label::get_visible_characters);
 	ObjectTypeDB::bind_method(_MD("set_percent_visible","percent_visible"),&Label::set_percent_visible);
 	ObjectTypeDB::bind_method(_MD("get_percent_visible"),&Label::get_percent_visible);
 	ObjectTypeDB::bind_method(_MD("set_lines_skipped","lines_skipped"),&Label::set_lines_skipped);

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -70,9 +70,8 @@ void Label::_notification(int p_what) {
 
 	if (p_what==NOTIFICATION_DRAW) {
 
-		if (clip && !autowrap)
+		if (clip || autowrap)
 			VisualServer::get_singleton()->canvas_item_set_clip(get_canvas_item(),true);
-
 
 		if (word_cache_dirty)
 			regenerate_word_cache();
@@ -317,9 +316,9 @@ int Label::get_longest_line_width() const {
 	int max_line_width=0;
 	int line_width=0;
 
-	for (int i=0;i<text.size()+1;i++) {
+	for (int i=0;i<text.size();i++) {
 
-		CharType current=i<text.length()?text[i]:' '; //always a space at the end, so the algo works
+		CharType current=text[i];
 		if (uppercase)
 			current=String::char_uppercase(current);
 
@@ -486,10 +485,11 @@ void Label::regenerate_word_cache() {
 
 	if (!autowrap) {
 		minsize.width=width;
-		minsize.height=font->get_height()*line_count;
-	} else {
-	        minsize.width=0;
-	        minsize.height=0;
+		if (max_lines_visible > 0 && line_count > max_lines_visible) {
+			minsize.height=font->get_height()*max_lines_visible;
+		} else {
+			minsize.height=font->get_height()*line_count;
+		}
 	}
 
 	word_cache_dirty=false;
@@ -538,8 +538,6 @@ void Label::set_text(const String& p_string) {
 
 void Label::set_clip_text(bool p_clip) {
 
-	if (clip==p_clip)
-		return;
 	clip=p_clip;
 	update();
 	minimum_size_changed();
@@ -631,6 +629,8 @@ void Label::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_text"),&Label::get_text);
 	ObjectTypeDB::bind_method(_MD("set_autowrap","enable"),&Label::set_autowrap);
 	ObjectTypeDB::bind_method(_MD("has_autowrap"),&Label::has_autowrap);
+	ObjectTypeDB::bind_method(_MD("set_clip_text","enable"),&Label::set_clip_text);
+	ObjectTypeDB::bind_method(_MD("is_clipping_text"),&Label::is_clipping_text);
 	ObjectTypeDB::bind_method(_MD("set_uppercase","enable"),&Label::set_uppercase);
 	ObjectTypeDB::bind_method(_MD("is_uppercase"),&Label::is_uppercase);
 	ObjectTypeDB::bind_method(_MD("get_line_height"),&Label::get_line_height);
@@ -659,6 +659,7 @@ void Label::_bind_methods() {
 	ADD_PROPERTYNZ( PropertyInfo( Variant::INT, "align", PROPERTY_HINT_ENUM,"Left,Center,Right,Fill" ),_SCS("set_align"),_SCS("get_align") );
 	ADD_PROPERTYNZ( PropertyInfo( Variant::INT, "valign", PROPERTY_HINT_ENUM,"Top,Center,Bottom,Fill" ),_SCS("set_valign"),_SCS("get_valign") );
 	ADD_PROPERTYNZ( PropertyInfo( Variant::BOOL, "autowrap"),_SCS("set_autowrap"),_SCS("has_autowrap") );
+	ADD_PROPERTYNZ( PropertyInfo( Variant::BOOL, "clip_text"),_SCS("set_clip_text"),_SCS("is_clipping_text") );
 	ADD_PROPERTYNZ( PropertyInfo( Variant::BOOL, "uppercase"),_SCS("set_uppercase"),_SCS("is_uppercase") );
 	ADD_PROPERTY( PropertyInfo( Variant::REAL, "percent_visible", PROPERTY_HINT_RANGE,"0,1,0.001"),_SCS("set_percent_visible"),_SCS("get_percent_visible") );
 	ADD_PROPERTY( PropertyInfo( Variant::INT, "lines_skipped", PROPERTY_HINT_RANGE,"0,999,1"),_SCS("set_lines_skipped"),_SCS("get_lines_skipped") );

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -29,17 +29,17 @@
 #ifndef LABEL_H
 #define LABEL_H
 
-#include "scene/gui/range.h"
+#include "scene/gui/control.h"
 /**
 	@author Juan Linietsky <reduzio@gmail.com>
 */
-class Label : public Range {
-	
-	OBJ_TYPE( Label, Range );	
-public:	
-	
+class Label : public Control {
+
+	OBJ_TYPE( Label, Control );
+public:
+
 	enum Align {
-		
+
 		ALIGN_LEFT,
 		ALIGN_CENTER,
 		ALIGN_RIGHT,
@@ -63,11 +63,11 @@ private:
 	Size2 minsize;
 	int line_count;
 	bool uppercase;
-	
+
 	int get_longest_line_width() const;
-	
+
 	struct WordCache {
-		
+
 		enum {
 			CHAR_NEWLINE=-1,
 			CHAR_WRAPLINE=-2
@@ -78,23 +78,25 @@ private:
 		int space_count;
 		WordCache *next;
 		WordCache() { char_pos=0; word_len=0; pixel_width=0; next=0; space_count=0;}
-	};	
-	
+	};
+
 	bool word_cache_dirty;
 	void regenerate_word_cache();
 
 	float percent_visible;
-	
+
 	WordCache *word_cache;
 	int total_char_cache;
 	int visible_chars;
-protected:		
+	int lines_skipped;
+	int max_lines_visible;
+protected:
 	void _notification(int p_what);
 
 	static void _bind_methods();
 	// bind helpers
 public:
-	
+
 	virtual Size2 get_minimum_size() const;
 
 	void set_align(Align p_align);
@@ -105,7 +107,7 @@ public:
 
 	void set_text(const String& p_string);
 	String get_text() const;
-	
+
 	void set_autowrap(bool p_autowrap);
 	bool has_autowrap() const;
 
@@ -121,6 +123,11 @@ public:
 	void set_percent_visible(float p_percent);
 	float get_percent_visible() const;
 
+	void set_lines_skipped(int p_lines);
+	int get_lines_skipped() const;
+
+	void set_max_lines_visible(int p_lines);
+	int get_max_lines_visible() const;
 
 	int get_line_height() const;
 	int get_line_count() const;

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -115,6 +115,7 @@ public:
 	bool is_uppercase() const;
 
 	void set_visible_characters(int p_amount);
+	int get_visible_characters() const;
 	int get_total_character_count() const;
 
 	void set_clip_text(bool p_clip);


### PR DESCRIPTION
- no longer inherits Range - instead, more sensible
  function names controlling lines visible
- more accurate vertical alignment
- percent_visible preserved even after setting new text

Largely motivated by the frustratingly inaccurate vertical alignment, particularly with large fonts.
Before: https://gfycat.com/WaterySimpleHornedtoad
After: https://gfycat.com/NeighboringMetallicKilldeer

The code for controlling the lines visible was already there, but I changed it so that instead of using `set_val()` and `set_max()` you now use `set_lines_skipped()` and `set_max_lines_visible()`.

Also, `percent_visible` and `visible_chars` are now recalculated properly each time you use `set_text()` because that could change the total length, and when you use `set_visible_characters()`.
