### PR TITLE
[UI fix] Hide opened menu when click on menu button

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -323,8 +323,10 @@ void PopupMenu::_input_event(const InputEvent &p_event) {
 						invalidated_click=false;
 						break;
 					}
-					if (over<0 || items[over].separator || items[over].disabled)
+					if (over<0 || items[over].separator || items[over].disabled) {
+						hide();
 						break; //non-activable
+					}
 
 					if (items[over].submenu!="") {
 


### PR DESCRIPTION
When you click a MenuButton, it opens a PopupMenu underneath it.  However, the only way to close the PopupMenu without selecting an item is to click outside the MenuButton and the PopupMenu.  Depending on the layout, this may be difficult.  In order to conform with other GUI systems, the PopupMenu will now close when the MenuButton is pressed.

Simple, but I think it's important. :)
