### PR TITLE
Fix absolute paths used in doxygen, ignore generated documentation in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ tools/editor/editor_icons.cpp
 make.bat
 log.txt
 
+# Doxygen generated documentation
+doc/doxygen/*
+
 # Javascript specific
 *.bc
 

--- a/Doxyfile
+++ b/Doxyfile
@@ -51,14 +51,14 @@ PROJECT_BRIEF          = "Game Engine MIT"
 # pixels and the maximum width should not exceed 200 pixels. Doxygen will copy
 # the logo to the output directory.
 
-PROJECT_LOGO           = E:/development/godot/logo_small.png
+PROJECT_LOGO           = ./logo_small.png
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
 # into which the generated documentation will be written. If a relative path is
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = E:/development/godot/doxygen
+OUTPUT_DIRECTORY       = ./doc/doxygen/
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -768,7 +768,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = E:/development/godot
+INPUT                  = ./core/ ./main/ ./scene/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
Relative paths are better for cross-platform usage.  Puts the documentation in the appropriate `doc` folder.
