### PR TITLE
fixed iOS splash screen

### DIFF
--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -11188,6 +11188,12 @@ RasterizerGLES2::RasterizerGLES2(bool p_compress_arrays,bool p_keep_ram_copy,boo
 	tc0_idx=0;
 };
 
+void RasterizerGLES2::restore_framebuffer() {
+
+	glBindFramebuffer(GL_FRAMEBUFFER, base_framebuffer);
+	
+}
+
 RasterizerGLES2::~RasterizerGLES2() {
 
 	memdelete_arr(skinned_buffer);

--- a/drivers/gles2/rasterizer_gles2.h
+++ b/drivers/gles2/rasterizer_gles2.h
@@ -1695,6 +1695,8 @@ public:
 	void reload_vram();
 
 	virtual bool has_feature(VS::Features p_feature) const;
+	
+	virtual void restore_framebuffer();
 
 	static RasterizerGLES2* get_singleton();
 

--- a/platform/iphone/gl_view.mm
+++ b/platform/iphone/gl_view.mm
@@ -345,6 +345,8 @@ static void clear_touches() {
 	[self destroyFramebuffer];
 	[self createFramebuffer];
 	[self drawView];
+	[self drawView];
+
 }
 
 - (BOOL)createFramebuffer

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -1022,6 +1022,7 @@ public:
 
 	virtual bool has_feature(VS::Features p_feature) const=0;
 
+	virtual void restore_framebuffer()=0;
 
 	virtual int get_render_info(VS::RenderInfo p_info)=0;
 

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -7427,6 +7427,8 @@ void VisualServerRaster::set_boot_image(const Image& p_image, const Color& p_col
 	if (p_image.empty())
 		return;
 
+	rasterizer->restore_framebuffer();
+
 	rasterizer->begin_frame();
 
 	int window_w = OS::get_singleton()->get_video_mode(0).width;


### PR DESCRIPTION
ios now displays splash screen between launch image and main scene, instead of a black screen.  Note that the duplicated "[self drawView];" line in gl_view.mm is deliberate.  This prevents first frame from being drawn black, and causing a brief black screen between launch image and splash screen.
