### PR TITLE
Set AnimationEditor UndoRedo reference on creation, Fix #2418

### DIFF
--- a/tools/editor/plugins/animation_player_editor_plugin.cpp
+++ b/tools/editor/plugins/animation_player_editor_plugin.cpp
@@ -1393,6 +1393,7 @@ AnimationPlayerEditorPlugin::AnimationPlayerEditorPlugin(EditorNode *p_node) {
 
 	editor=p_node;
 	anim_editor = memnew( AnimationPlayerEditor(editor) );
+	anim_editor->set_undo_redo(editor->get_undo_redo());
 	editor->get_animation_panel()->add_child(anim_editor);
 	/*
 	editor->get_viewport()->add_child(anim_editor);


### PR DESCRIPTION
Resolve the problem where the animation editor crash the editor when trying to rename, duplicate or delete an animation (#2418).
