### PR TITLE
add missing physics unit test to --help listing in main.cpp

### DIFF
--- a/bin/tests/test_main.cpp
+++ b/bin/tests/test_main.cpp
@@ -61,6 +61,7 @@ const char ** tests_get_names()  {
 		"gui",
 		"io",
 		"shaderlang",
+		"physics",
 		NULL
 	};
 	


### PR DESCRIPTION
"physics" is missing from the unit test list when running --help
