### PR TITLE
Fix X11 Editor Boot Splash (Maximized Boot Splash)

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -892,7 +892,13 @@ void OS_X11::set_window_maximized(bool p_enabled) {
 
 	XSendEvent(x11_display, DefaultRootWindow(x11_display), False, SubstructureRedirectMask | SubstructureNotifyMask, &xev);
 
+	XWindowAttributes xwa;
+	XGetWindowAttributes(x11_display,DefaultRootWindow(x11_display),&xwa);
+	current_videomode.width = xwa.width;
+	current_videomode.height = xwa.height;
+
 	maximized = p_enabled;
+	visual_server->init();
 }
 
 bool OS_X11::is_window_maximized() const {


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/9015847/9922331/3e82923a-5cfc-11e5-8c0a-6cc2727231b8.png)
After:
![after](https://cloud.githubusercontent.com/assets/9015847/9922334/4a6774a8-5cfc-11e5-8a9c-90d7196b2745.png)
