### PR TITLE
Remove of use_exclude_ctrl_bones option

### DIFF
--- a/tools/export/blender25/io_scene_dae/__init__.py
+++ b/tools/export/blender25/io_scene_dae/__init__.py
@@ -104,11 +104,6 @@ class ExportDAE(bpy.types.Operator, ExportHelper):
             description="Export only objects on the active layers.",
             default=True,
             )
-    use_exclude_ctrl_bones = BoolProperty(
-            name="Exclude Control Bones",
-            description="Exclude skeleton bones with names that begin with 'ctrl'.",
-            default=True,
-            )
     use_anim = BoolProperty(
             name="Export Animation",
             description="Export keyframe animation",


### PR DESCRIPTION
use_exclude_ctrl_bones option is not implemented.
This option is supposed to filter-out unneeded skeleton bones.
This option was never implemented (in repository) and confuses
users that feature exists.
This commit removes this option as this option implementation
is not happenning any time soon and claim it exists
confuses users into thinking the feature is supported.

Closes #2476
