### PR TITLE
Add missing `return` so Visual Studio compiles again

### DIFF
--- a/scene/resources/rectangle_shape_2d.cpp
+++ b/scene/resources/rectangle_shape_2d.cpp
@@ -57,7 +57,7 @@ void RectangleShape2D::draw(const RID& p_to_rid,const Color& p_color) {
 
 Rect2 RectangleShape2D::get_rect() const {
 
-	Rect2(-extents,extents*2.0);
+	return Rect2(-extents,extents*2.0);
 
 }
 


### PR DESCRIPTION
Even without this `return`, many (most?) compilers will still compile. However, Visual Studio is not one of them. Fixes #2500.
