### PR TITLE
Fix a bug with doctool

### DIFF
--- a/tools/doc/doc_data.cpp
+++ b/tools/doc/doc_data.cpp
@@ -917,9 +917,9 @@ Error DocData::save(const String& p_path) {
 
 			String qualifiers;
 			if (m.qualifiers!="")
-				qualifiers+="qualifiers=\""+m.qualifiers.xml_escape()+"\"";
+				qualifiers+=" qualifiers=\""+m.qualifiers.xml_escape()+"\"";
 
-			_write_string(f,2,"<method name=\""+m.name+"\" "+qualifiers+" >");
+			_write_string(f,2,"<method name=\""+m.name+"\""+qualifiers+">");
 
 			if (m.return_type!="") {
 


### PR DESCRIPTION
Doctool was inserting `"  >"` after every method open tag. e.g. it generated methods like:

``` xml
<method name="name"  >
  <!--
    Notice the two spaces after the second quote of "name"
  -->
</method>
```

Please test, this was made from GitHub GUI, so couldn't test it myself.
