### PR TITLE
Add missing \n to world_wrap.

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -3066,7 +3066,7 @@ String String::world_wrap(int p_chars_per_line) const {
 		} else if (operator[](i)==' ' || operator[](i)=='\t') {
 			last_space=i;
 		} else if (operator[](i)=='\n') {
-			ret+=substr(from,i-from);
+			ret+=substr(from,i-from)+"\n";
 			from=i+1;
 			last_space=-1;
 		}


### PR DESCRIPTION
The issue was that world_wrap would skip over newlines, without adding them to the output.

Closes #2516.
