### PR TITLE
Fix parameters of funcRef::call_func

### DIFF
--- a/core/func_ref.cpp
+++ b/core/func_ref.cpp
@@ -32,7 +32,6 @@ void FuncRef::_bind_methods() {
 	{
 		MethodInfo mi;
 		mi.name="call";
-		mi.arguments.push_back( PropertyInfo( Variant::STRING, "method"));
 		Vector<Variant> defargs;
 		for(int i=0;i<10;i++) {
 			mi.arguments.push_back( PropertyInfo( Variant::NIL, "arg"+itos(i)));

--- a/core/func_ref.cpp
+++ b/core/func_ref.cpp
@@ -31,7 +31,7 @@ void FuncRef::_bind_methods() {
 
 	{
 		MethodInfo mi;
-		mi.name="call";
+		mi.name="call_func";
 		Vector<Variant> defargs;
 		for(int i=0;i<10;i++) {
 			mi.arguments.push_back( PropertyInfo( Variant::NIL, "arg"+itos(i)));


### PR DESCRIPTION
BTW, should I change 

``` cpp
mi.name="call";
```

to `"call_func"` ?
