### PR TITLE
Fix propagation of `NOTIFICATION_VISIBILITY_CHANGED`

### DIFF
--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -265,7 +265,7 @@ void CanvasItem::_propagate_visibility_changed(bool p_visible) {
 
 		CanvasItem *c=get_child(i)->cast_to<CanvasItem>();
 
-		if (c && c->hidden!=p_visible) //should the toplevels stop propagation? i think so but..
+		if (c && !c->hidden) //should the toplevels stop propagation? i think so but..
 			c->_propagate_visibility_changed(p_visible);
 	}
 


### PR DESCRIPTION
For `CanvasItem`s, hiding a previously visible node's parent (direct or indirect) currently does not propagate a `NOTIFICATION_VISIBILITY_CHANGED` notification to the child. This change propagates the notification whenever the child's actual visibility changes as a result of it's parent's change in visibility.
