### PR TITLE
Fix BaseButtons remaining pressed when hiding while pressed down

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -5018,7 +5018,7 @@
 			<return type="bool">
 			</return>
 			<description>
-			Return when the button is pressed (only if toggle_mode is active).
+			If toggle_mode is active, return whether the button is toggled. If toggle_mode is not active, return whether the button is pressed down.
 			</description>
 		</method>
 		<method name="is_hovered" qualifiers="const">

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -255,6 +255,16 @@ void BaseButton::_notification(int p_what) {
 			group->_remove_button(this);
 	}
 
+	if (p_what==NOTIFICATION_VISIBILITY_CHANGED && !is_visible()) {
+
+		if (!toggle_mode) {
+			status.pressed = false;
+		}
+		status.hovering = false;
+		status.press_attempt = false;
+		status.pressing_inside = false;
+		status.pressing_button = 0;
+	}
 }
 
 void BaseButton::pressed() {


### PR DESCRIPTION
When a BaseButton is pressed down while being hidden (itself or one of its parents), it will remain pressed down. This easily leads to unexpected behavior when doing something like:

``` python
func _process( delta ):
    if is_pressed():
        get_parent().hide()
        print( "Pressed & hidden!" ) # will be called every frame after pressing
```

For more info see https://github.com/okamstudio/godot/issues/2496#issuecomment-142167856 and [this forum post](http://www.godotengine.org/topics/12083?r=12112#message-12112).
This change "unpresses" the button when hidden. Closes #2496. Depends on pull request #2533.
