### PR TITLE
Small renaming and bug fixing in SamplePlayer

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -79,9 +79,9 @@ public:
 		return Math::log( p_linear ) * 8.6858896380650365530225783783321;
 	}
 
-	static inline double db2linear(double p_linear) {
+	static inline double db2linear(double p_db) {
 
-		return Math::exp( p_linear * 0.11512925464970228420089957273422 );
+		return Math::exp( p_db * 0.11512925464970228420089957273422 );
 	}
 
 	static bool is_nan(double p_val);

--- a/platform/javascript/audio_server_javascript.cpp
+++ b/platform/javascript/audio_server_javascript.cpp
@@ -259,12 +259,12 @@ void AudioServerJavascript::voice_play(RID p_voice, RID p_sample){
 	voice->active=true;
 }
 
-void AudioServerJavascript::voice_set_volume(RID p_voice, float p_gain){
+void AudioServerJavascript::voice_set_volume(RID p_voice, float p_volume){
 
 	Voice* voice=voice_owner.get(p_voice);
 	ERR_FAIL_COND(!voice);
 
-	voice->volume=p_gain;
+	voice->volume=p_volume;
 
 	if (voice->active) {
 		EM_ASM_( {

--- a/platform/javascript/audio_server_javascript.h
+++ b/platform/javascript/audio_server_javascript.h
@@ -125,7 +125,7 @@ public:
 
 	virtual void voice_play(RID p_voice, RID p_sample);
 
-	virtual void voice_set_volume(RID p_voice, float p_gain);
+	virtual void voice_set_volume(RID p_voice, float p_volume);
 	virtual void voice_set_pan(RID p_voice, float p_pan, float p_depth=0,float height=0); //pan and depth go from -1 to 1
 	virtual void voice_set_filter(RID p_voice, FilterType p_type, float p_cutoff, float p_resonance, float p_gain=0);
 	virtual void voice_set_chorus(RID p_voice, float p_chorus );

--- a/scene/2d/sample_player_2d.cpp
+++ b/scene/2d/sample_player_2d.cpp
@@ -214,7 +214,7 @@ void SamplePlayer2D::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_sample_library","library:SampleLibrary"),&SamplePlayer2D::set_sample_library);
 	ObjectTypeDB::bind_method(_MD("get_sample_library:SampleLibrary"),&SamplePlayer2D::get_sample_library);
 
-	ObjectTypeDB::bind_method(_MD("set_polyphony","voices"),&SamplePlayer2D::set_polyphony);
+	ObjectTypeDB::bind_method(_MD("set_polyphony","max_voices"),&SamplePlayer2D::set_polyphony);
 	ObjectTypeDB::bind_method(_MD("get_polyphony"),&SamplePlayer2D::get_polyphony);
 
 	ObjectTypeDB::bind_method(_MD("play","sample","voice"),&SamplePlayer2D::play,DEFVAL(NEXT_VOICE));

--- a/scene/audio/sample_player.cpp
+++ b/scene/audio/sample_player.cpp
@@ -102,7 +102,7 @@ bool SamplePlayer::_get(const StringName& p_name,Variant &r_ret) const {
 		r_ret= get_sample_library();
 	} else if (name.begins_with("default/")) {
 
-			String what=name.get_slicec('/',1);
+			String what=name.right(8);
 
 			if (what=="volume_db")
 				r_ret= get_default_volume_db();
@@ -164,7 +164,7 @@ void SamplePlayer::_get_property_list(List<PropertyInfo> *p_list) const {
 	p_list->push_back( PropertyInfo( Variant::REAL, "default/filter/cutoff", PROPERTY_HINT_RANGE, "20,16384.0,0.01"));
 	p_list->push_back( PropertyInfo( Variant::REAL, "default/filter/resonance", PROPERTY_HINT_RANGE, "0,4,0.01"));
 	p_list->push_back( PropertyInfo( Variant::REAL, "default/filter/gain", PROPERTY_HINT_RANGE, "0,2,0.01"));
-	p_list->push_back( PropertyInfo( Variant::INT, "default/reverb_room", PROPERTY_HINT_ENUM, "Small,Medimum,Large,Hall"));
+	p_list->push_back( PropertyInfo( Variant::INT, "default/reverb_room", PROPERTY_HINT_ENUM, "Small,Medium,Large,Hall"));
 	p_list->push_back( PropertyInfo( Variant::REAL, "default/reverb_send", PROPERTY_HINT_RANGE, "0,1,0.01"));
 	p_list->push_back( PropertyInfo( Variant::REAL, "default/chorus_send", PROPERTY_HINT_RANGE, "0,1,0.01"));
 

--- a/scene/audio/sample_player.cpp
+++ b/scene/audio/sample_player.cpp
@@ -48,8 +48,8 @@ bool SamplePlayer::_set(const StringName& p_name, const Variant& p_value) {
 		}
 	} else if (name=="config/samples")
 		set_sample_library(p_value);
-	else if (name=="config/voices")
-		set_voice_count(p_value);
+	else if (name=="config/polyphony")
+		set_polyphony(p_value);
 	else if (name.begins_with("default/")) {
 
 		String what=name.right(8);
@@ -95,8 +95,8 @@ bool SamplePlayer::_get(const StringName& p_name,Variant &r_ret) const {
 
 	if (name=="play/play") {
 		r_ret=played_back;
-	} else if (name=="config/voices") {
-		r_ret= get_voice_count();
+	} else if (name=="config/polyphony") {
+		r_ret= get_polyphony();
 	} else if (name=="config/samples") {
 
 		r_ret= get_sample_library();
@@ -153,7 +153,7 @@ void SamplePlayer::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 
 	p_list->push_back( PropertyInfo( Variant::STRING, "play/play", PROPERTY_HINT_ENUM, en,PROPERTY_USAGE_EDITOR));
-	p_list->push_back( PropertyInfo( Variant::INT, "config/voices", PROPERTY_HINT_RANGE, "1,256,1"));
+	p_list->push_back( PropertyInfo( Variant::INT, "config/polyphony", PROPERTY_HINT_RANGE, "1,256,1"));
 	p_list->push_back( PropertyInfo( Variant::OBJECT, "config/samples", PROPERTY_HINT_RESOURCE_TYPE, "SampleLibrary"));
 	p_list->push_back( PropertyInfo( Variant::REAL, "default/volume_db", PROPERTY_HINT_RANGE, "-80,24,0.01"));
 	p_list->push_back( PropertyInfo( Variant::REAL, "default/pitch_scale", PROPERTY_HINT_RANGE, "0.01,48,0.01"));
@@ -203,14 +203,14 @@ SamplePlayer::Voice::~Voice() {
 }
 
 
-void SamplePlayer::set_voice_count(int p_voice_count) {
+void SamplePlayer::set_polyphony(int p_voice_count) {
 
 	ERR_FAIL_COND( p_voice_count <1 || p_voice_count >0xFFFE );
 
 	voices.resize(p_voice_count);
 }
 
-int SamplePlayer::get_voice_count() const {
+int SamplePlayer::get_polyphony() const {
 
 	return voices.size();
 }
@@ -606,8 +606,8 @@ void SamplePlayer::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_sample_library","library:SampleLibrary"),&SamplePlayer::set_sample_library );
 	ObjectTypeDB::bind_method(_MD("get_sample_library:SampleLibrary"),&SamplePlayer::get_sample_library );
 
-	ObjectTypeDB::bind_method(_MD("set_voice_count","max_voices"),&SamplePlayer::set_voice_count );
-	ObjectTypeDB::bind_method(_MD("get_voice_count"),&SamplePlayer::get_voice_count );
+	ObjectTypeDB::bind_method(_MD("set_polyphony","max_voices"),&SamplePlayer::set_polyphony );
+	ObjectTypeDB::bind_method(_MD("get_polyphony"),&SamplePlayer::get_polyphony );
 
 	ObjectTypeDB::bind_method(_MD("play","name","unique"),&SamplePlayer::play, DEFVAL(false) );
 	ObjectTypeDB::bind_method(_MD("stop","voice"),&SamplePlayer::stop );
@@ -676,6 +676,8 @@ void SamplePlayer::_bind_methods() {
 	BIND_CONSTANT( REVERB_MEDIUM  );
 	BIND_CONSTANT( REVERB_LARGE  );
 	BIND_CONSTANT( REVERB_HALL );
+
+	BIND_CONSTANT( INVALID_VOICE_ID );
 
 }
 

--- a/scene/audio/sample_player.cpp
+++ b/scene/audio/sample_player.cpp
@@ -615,8 +615,8 @@ void SamplePlayer::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("set_mix_rate","voice","hz"),&SamplePlayer::set_mix_rate );
 	ObjectTypeDB::bind_method(_MD("set_pitch_scale","voice","ratio"),&SamplePlayer::set_pitch_scale );
-	ObjectTypeDB::bind_method(_MD("set_volume","voice","nrg"),&SamplePlayer::set_volume );
-	ObjectTypeDB::bind_method(_MD("set_volume_db","voice","nrg"),&SamplePlayer::set_volume_db );
+	ObjectTypeDB::bind_method(_MD("set_volume","voice","volume"),&SamplePlayer::set_volume );
+	ObjectTypeDB::bind_method(_MD("set_volume_db","voice","db"),&SamplePlayer::set_volume_db );
 	ObjectTypeDB::bind_method(_MD("set_pan","voice","pan","depth","height"),&SamplePlayer::set_pan,DEFVAL(0),DEFVAL(0) );
 	ObjectTypeDB::bind_method(_MD("set_filter","voice","type","cutoff_hz","resonance","gain"),&SamplePlayer::set_filter,DEFVAL(0) );
 	ObjectTypeDB::bind_method(_MD("set_chorus","voice","send"),&SamplePlayer::set_chorus );
@@ -638,8 +638,8 @@ void SamplePlayer::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_reverb","voice"),&SamplePlayer::get_reverb );
 
 	ObjectTypeDB::bind_method(_MD("set_default_pitch_scale","ratio"),&SamplePlayer::set_default_pitch_scale );
-	ObjectTypeDB::bind_method(_MD("set_default_volume","nrg"),&SamplePlayer::set_default_volume );
-	ObjectTypeDB::bind_method(_MD("set_default_volume_db","db"),&SamplePlayer::set_default_volume );
+	ObjectTypeDB::bind_method(_MD("set_default_volume","volume"),&SamplePlayer::set_default_volume );
+	ObjectTypeDB::bind_method(_MD("set_default_volume_db","db"),&SamplePlayer::set_default_volume_db );
 	ObjectTypeDB::bind_method(_MD("set_default_pan","pan","depth","height"),&SamplePlayer::set_default_pan,DEFVAL(0),DEFVAL(0) );
 	ObjectTypeDB::bind_method(_MD("set_default_filter","type","cutoff_hz","resonance","gain"),&SamplePlayer::set_default_filter,DEFVAL(0) );
 	ObjectTypeDB::bind_method(_MD("set_default_chorus","send"),&SamplePlayer::set_default_chorus );
@@ -647,7 +647,7 @@ void SamplePlayer::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("get_default_pitch_scale"),&SamplePlayer::get_default_pitch_scale );
 	ObjectTypeDB::bind_method(_MD("get_default_volume"),&SamplePlayer::get_default_volume );
-	ObjectTypeDB::bind_method(_MD("get_default_volume_db"),&SamplePlayer::get_default_volume );
+	ObjectTypeDB::bind_method(_MD("get_default_volume_db"),&SamplePlayer::get_default_volume_db );
 	ObjectTypeDB::bind_method(_MD("get_default_pan"),&SamplePlayer::get_default_pan );
 	ObjectTypeDB::bind_method(_MD("get_default_pan_depth"),&SamplePlayer::get_default_pan_depth );
 	ObjectTypeDB::bind_method(_MD("get_default_pan_height"),&SamplePlayer::get_default_pan_height );

--- a/scene/audio/sample_player.h
+++ b/scene/audio/sample_player.h
@@ -130,8 +130,8 @@ public:
 	void set_sample_library(const Ref<SampleLibrary>& p_library);
 	Ref<SampleLibrary> get_sample_library() const;
 
-	void set_voice_count(int p_voice_count);
-	int get_voice_count() const;	
+	void set_polyphony(int p_voice_count);
+	int get_polyphony() const;
 
 	VoiceID play(const String& p_name,bool unique=false);
 	void stop(VoiceID p_voice);

--- a/servers/audio/audio_server_sw.cpp
+++ b/servers/audio/audio_server_sw.cpp
@@ -455,12 +455,12 @@ void AudioServerSW::voice_play(RID p_voice, RID p_sample) {
 
 }
 
-void AudioServerSW::voice_set_volume(RID p_voice, float p_db) {
+void AudioServerSW::voice_set_volume(RID p_voice, float p_volume) {
 
 	VoiceRBSW::Command cmd;
 	cmd.type=VoiceRBSW::Command::CMD_SET_VOLUME;
 	cmd.voice=p_voice;
-	cmd.volume.volume=p_db;
+	cmd.volume.volume=p_volume;
 	voice_rb.push_command(cmd);
 
 }

--- a/servers/audio/audio_server_sw.h
+++ b/servers/audio/audio_server_sw.h
@@ -146,7 +146,7 @@ public:
 
 	virtual void voice_play(RID p_voice, RID p_sample);
 
-	virtual void voice_set_volume(RID p_voice, float p_db);
+	virtual void voice_set_volume(RID p_voice, float p_volume);
 	virtual void voice_set_pan(RID p_voice, float p_pan, float p_depth=0,float height=0); //pan and depth go from -1 to 1
 	virtual void voice_set_filter(RID p_voice, FilterType p_type, float p_cutoff, float p_resonance,float p_gain=0);
 	virtual void voice_set_chorus(RID p_voice, float p_chorus );

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -210,7 +210,7 @@ public:
 
 	virtual void voice_play(RID p_voice, RID p_sample)=0;
 
-	virtual void voice_set_volume(RID p_voice, float p_gain)=0;
+	virtual void voice_set_volume(RID p_voice, float p_volume)=0;
 	virtual void voice_set_pan(RID p_voice, float p_pan, float p_depth=0,float height=0)=0; //pan and depth go from -1 to 1
 	virtual void voice_set_filter(RID p_voice, FilterType p_type, float p_cutoff, float p_resonance, float p_gain=0)=0;
 	virtual void voice_set_chorus(RID p_voice, float p_chorus )=0;


### PR DESCRIPTION
As discussed on IRC, the first commit renames _voice_count to _polyphony in SamplePlayer to be consistent with SamplePlayer2D.
This also makes it consistent with SpatialSamplePlayer and SpatialSound_Server_. On the other hand it will break code that rely on GDScript's set_voice_count().

The second commit fixes some copy-paste mistakes where linear/db volume functions had wrong argument hint or even wrong bound function.
