### PR TITLE
Avoid stealing focus on mouse hover if focus owner is a text field

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2700,6 +2700,16 @@ bool Control::is_stopping_mouse() const {
 	return data.stop_mouse;
 }
 
+void Control::set_text_field(bool p_enable) {
+
+	data.text_field=p_enable;
+}
+
+bool Control::is_text_field() const {
+
+	return data.text_field;
+}
+
 Control *Control::get_focus_owner() const {
 
 	ERR_FAIL_COND_V(!is_inside_tree(),NULL);
@@ -2901,6 +2911,7 @@ Control::Control() {
 	data.viewport=NULL;
 	data.ignore_mouse=false;
 	data.stop_mouse=true;
+	data.text_field=false;
 	window=NULL;
 
 	data.SI=NULL;

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -119,6 +119,7 @@ private:
 
 		bool ignore_mouse;
 		bool stop_mouse;
+		bool text_field;
 
 		Control *parent;
 		Control *window;
@@ -339,6 +340,9 @@ public:
 
 	void set_stop_mouse(bool p_stop);
 	bool is_stopping_mouse() const;
+
+	void set_text_field(bool p_enable);
+	bool is_text_field() const;
 
 	/* SKINNING */
 	

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -824,7 +824,7 @@ LineEdit::LineEdit() {
 	editable=true;
 	set_default_cursor_shape(CURSOR_IBEAM);
 	set_stop_mouse(true);
-		
+	set_text_field(true);
 	
 }
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3655,6 +3655,7 @@ TextEdit::TextEdit()  {
 	cache.row_height=1;
 	cache.line_spacing=1;
 	cache.line_number_w=1;
+	set_text_field(true);
 
 	tab_size=4;
 	text.set_tab_size(tab_size);

--- a/tools/editor/animation_editor.cpp
+++ b/tools/editor/animation_editor.cpp
@@ -2369,7 +2369,7 @@ void AnimationKeyEditor::_track_editor_input_event(const InputEvent& p_input) {
 			te->update();
 			track_editor->set_tooltip("");
 
-			if (!track_editor->has_focus() && (!get_focus_owner() || !get_focus_owner()->cast_to<LineEdit>()))
+			if (!track_editor->has_focus() && (!get_focus_owner() || !get_focus_owner()->is_text_field()))
 				track_editor->call_deferred("grab_focus");
 
 

--- a/tools/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/tools/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1281,7 +1281,7 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 
 	if (p_event.type==InputEvent::MOUSE_MOTION) {
 
-		if (!viewport->has_focus())
+		if (!viewport->has_focus() && (!get_focus_owner() || !get_focus_owner()->is_text_field()))
 			viewport->call_deferred("grab_focus");
 
 		const InputEventMouseMotion &m=p_event.mouse_motion;

--- a/tools/editor/plugins/spatial_editor_plugin.cpp
+++ b/tools/editor/plugins/spatial_editor_plugin.cpp
@@ -677,7 +677,8 @@ bool SpatialEditorViewport::_gizmo_select(const Vector2& p_screenpos,bool p_hili
 
 void SpatialEditorViewport::_smouseenter() {
 
-	surface->grab_focus();
+	if (!surface->has_focus() && (!get_focus_owner() || !get_focus_owner()->is_text_field()))
+		surface->grab_focus();
 }
 
 void SpatialEditorViewport::_sinput(const InputEvent &p_event) {


### PR DESCRIPTION
Using many _cast_to_ for both _LineEdit_ and _TextEdit_ looked ugly so I added a **text_field** (could be named retain_focus instead?) member flag to _Control_. It should make it simpler if adding new text field like controls later. Closes #2473

There may be a better way to do this, if you don't want that new variable in Control.
