### PR TITLE
Fixes Visual Studio 2013 compile errors due to Opus

### DIFF
--- a/drivers/opus/audio_stream_opus.cpp
+++ b/drivers/opus/audio_stream_opus.cpp
@@ -30,6 +30,8 @@
 /*************************************************************************/
 #include "audio_stream_opus.h"
 
+const float AudioStreamPlaybackOpus::osrate=48000.0f;
+
 int AudioStreamPlaybackOpus::_op_read_func(void *_stream, unsigned char *_ptr, int _nbytes) {
 	FileAccess *fa=(FileAccess*)_stream;
 

--- a/drivers/opus/audio_stream_opus.h
+++ b/drivers/opus/audio_stream_opus.h
@@ -54,7 +54,7 @@ class AudioStreamPlaybackOpus : public AudioStreamPlayback {
 	static int _op_seek_func(void *_stream, opus_int64 _offset, int _whence);
 	static int _op_close_func(void *_stream);
 	static opus_int64 _op_tell_func(void *_stream);
-	static const float osrate=48000.0f;
+	static const float osrate;
 
 	String file;
 	int64_t frames_mixed;

--- a/drivers/opus/opus_config.h
+++ b/drivers/opus/opus_config.h
@@ -91,8 +91,13 @@
 /* This is a build of OPUS */
 #define OPUS_BUILD /**/
 
-/* Use C99 variable-size arrays */
-#define VAR_ARRAYS 1
+#ifndef WIN32
+	/* Use C99 variable-size arrays */
+	#define VAR_ARRAYS 1
+#else
+	/* Fixes VS 2013 compile error */
+	#define USE_ALLOCA 1
+#endif
 
 
 /* Define to `__inline__' or `__inline' if that's what the C compiler


### PR DESCRIPTION
"scons p=windows" failed to build on the Visual Studio 2013 command prompt on windows due to two small errors introduced by the recent opus addition.
