### PR TITLE
[OSX Clang] Fix parentheses-equality warnings

### DIFF
--- a/core/io/unzip.c
+++ b/core/io/unzip.c
@@ -1788,7 +1788,7 @@ extern int ZEXPORT unzReadCurrentFile  (unzFile file, voidp buf, unsigned len)
         return UNZ_PARAMERROR;
 
 
-    if ((pfile_in_zip_read_info->read_buffer == NULL))
+    if (pfile_in_zip_read_info->read_buffer==NULL)
         return UNZ_END_OF_LIST_OF_FILE;
     if (len==0)
         return 0;

--- a/core/io/zip.c
+++ b/core/io/zip.c
@@ -1114,9 +1114,9 @@ extern int ZEXPORT zipOpenNewFileInZip4_64 (zipFile file, const char* filename, 
     zi->ci.flag = flagBase;
     if ((level==8) || (level==9))
       zi->ci.flag |= 2;
-    if ((level==2))
+    if (level==2)
       zi->ci.flag |= 4;
-    if ((level==1))
+    if (level==1)
       zi->ci.flag |= 6;
     if (password != NULL)
       zi->ci.flag |= 1;


### PR DESCRIPTION
Fixed this warning
`warning: equality comparison with extraneous parentheses [-Wparentheses-equality]`

Tested on LLVM Clang 7.0.0
