### PR TITLE
Fix Area/Area2D mask matching

### DIFF
--- a/servers/physics/space_sw.cpp
+++ b/servers/physics/space_sw.cpp
@@ -34,10 +34,10 @@
 
 _FORCE_INLINE_ static bool _match_object_type_query(CollisionObjectSW *p_object, uint32_t p_layer_mask, uint32_t p_type_mask) {
 
-	if ((p_object->get_layer_mask()&p_layer_mask)==0)
-		return false;
+	if (p_object->get_type()==CollisionObjectSW::TYPE_AREA)
+		return p_type_mask&PhysicsDirectSpaceState::TYPE_MASK_AREA;
 
-	if (p_object->get_type()==CollisionObjectSW::TYPE_AREA && !(p_type_mask&PhysicsDirectSpaceState::TYPE_MASK_AREA))
+	if ((p_object->get_layer_mask()&p_layer_mask)==0)
 		return false;
 
 	BodySW *body = static_cast<BodySW*>(p_object);

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -36,8 +36,8 @@ _FORCE_INLINE_ static bool _match_object_type_query(CollisionObject2DSW *p_objec
 	if ((p_object->get_layer_mask()&p_layer_mask)==0)
 		return false;
 
-	if (p_object->get_type()==CollisionObject2DSW::TYPE_AREA && !(p_type_mask&Physics2DDirectSpaceState::TYPE_MASK_AREA))
-		return false;
+	if (p_object->get_type()==CollisionObject2DSW::TYPE_AREA)
+		return p_type_mask&Physics2DDirectSpaceState::TYPE_MASK_AREA;
 
 	Body2DSW *body = static_cast<Body2DSW*>(p_object);
 


### PR DESCRIPTION
Currently, `Area2DSW` has its non-existent `BodyMode` checked like a `Body2DSW`. This prevents, for example, performing raycasts only for `Area2D`s.

This change has the relevant function return as soon as all checks needed for `Area2DSW` are done.

Fixes #1906.

(Curiously, setting the object type mask to `TYPE_MASK_AREA | TYPE_MASK_STATIC_BODY` works as a workaround to this bug — apparently calling `get_mode()` on a `Area2DSW` casted to a `Body2DSW` returns `TYPE_MASK_STATIC_BODY`? No idea what happens here…)
