### PR TITLE
Add type mask customization to RayCast2D

### DIFF
--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -53,6 +53,16 @@ uint32_t RayCast2D::get_layer_mask() const {
 	return layer_mask;
 }
 
+void RayCast2D::set_type_mask(uint32_t p_mask) {
+
+	type_mask=p_mask;
+}
+
+uint32_t RayCast2D::get_type_mask() const {
+
+	return type_mask;
+}
+
 bool RayCast2D::is_colliding() const{
 
 	return collided;
@@ -162,7 +172,7 @@ void RayCast2D::_notification(int p_what) {
 
 			Physics2DDirectSpaceState::RayResult rr;
 
-			if (dss->intersect_ray(gt.get_origin(),gt.xform(to),rr,exclude,layer_mask)) {
+			if (dss->intersect_ray(gt.get_origin(),gt.xform(to),rr,exclude,layer_mask,type_mask)) {
 
 				collided=true;
 				against=rr.collider_id;
@@ -241,9 +251,13 @@ void RayCast2D::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_layer_mask","mask"),&RayCast2D::set_layer_mask);
 	ObjectTypeDB::bind_method(_MD("get_layer_mask"),&RayCast2D::get_layer_mask);
 
+	ObjectTypeDB::bind_method(_MD("set_type_mask","mask"),&RayCast2D::set_type_mask);
+	ObjectTypeDB::bind_method(_MD("get_type_mask"),&RayCast2D::get_type_mask);
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL,"enabled"),_SCS("set_enabled"),_SCS("is_enabled"));
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2,"cast_to"),_SCS("set_cast_to"),_SCS("get_cast_to"));
 	ADD_PROPERTY(PropertyInfo(Variant::INT,"layer_mask",PROPERTY_HINT_ALL_FLAGS),_SCS("set_layer_mask"),_SCS("get_layer_mask"));
+	ADD_PROPERTY(PropertyInfo(Variant::INT,"type_mask",PROPERTY_HINT_FLAGS,"Static,Kinematic,Rigid,Character,Area"),_SCS("set_type_mask"),_SCS("get_type_mask"));
 }
 
 RayCast2D::RayCast2D() {
@@ -253,5 +267,6 @@ RayCast2D::RayCast2D() {
 	collided=false;
 	against_shape=0;
 	layer_mask=1;
+	type_mask=Physics2DDirectSpaceState::TYPE_MASK_COLLISION;
 	cast_to=Vector2(0,50);
 }

--- a/scene/2d/ray_cast_2d.h
+++ b/scene/2d/ray_cast_2d.h
@@ -44,6 +44,7 @@ class RayCast2D : public Node2D {
 	Vector2 collision_normal;
 	Set<RID> exclude;
 	uint32_t layer_mask;
+	uint32_t type_mask;
 
 
 	Vector2 cast_to;
@@ -61,6 +62,9 @@ public:
 
 	void set_layer_mask(uint32_t p_mask);
 	uint32_t get_layer_mask() const;
+
+	void set_type_mask(uint32_t p_mask);
+	uint32_t get_type_mask() const;
 
 	bool is_colliding() const;
 	Object *get_collider() const;


### PR DESCRIPTION
`RayCast2D` currently uses the default ray cast type mask `TYPE_MASK_COLLISION`, which does not include `TYPE_MASK_AREA`. This makes it impossible to use the node to check for collision with `Area2D` nodes.

This change adds full customization of the object type mask used for the raycast.

Depends on #2587 for `Area2D` collision to work properly.
