### PR TITLE
Expose softness parameter of pin joint to the editor.

### DIFF
--- a/scene/2d/joints_2d.cpp
+++ b/scene/2d/joints_2d.cpp
@@ -126,7 +126,7 @@ void Joint2D::_bind_methods() {
 
 	ADD_PROPERTY( PropertyInfo( Variant::NODE_PATH, "node_a"), _SCS("set_node_a"),_SCS("get_node_a") );
 	ADD_PROPERTY( PropertyInfo( Variant::NODE_PATH, "node_b"), _SCS("set_node_b"),_SCS("get_node_b") );
-	ADD_PROPERTY( PropertyInfo( Variant::REAL, "bias/bias",PROPERTY_HINT_RANGE,"0,0.9,0.01"), _SCS("set_bias"),_SCS("get_bias") );
+	ADD_PROPERTY( PropertyInfo( Variant::REAL, "bias/bias",PROPERTY_HINT_RANGE,"0,0.9,0.001"), _SCS("set_bias"),_SCS("get_bias") );
 
 }
 
@@ -175,15 +175,37 @@ RID PinJoint2D::_configure_joint() {
 		//add a collision exception between both
 		Physics2DServer::get_singleton()->body_add_collision_exception(body_a->get_rid(),body_b->get_rid());
 	}
-
-	return Physics2DServer::get_singleton()->pin_joint_create(get_global_transform().get_origin(),body_a->get_rid(),body_b?body_b->get_rid():RID());
+	RID pj = Physics2DServer::get_singleton()->pin_joint_create(get_global_transform().get_origin(),body_a->get_rid(),body_b?body_b->get_rid():RID());
+	Physics2DServer::get_singleton()->pin_joint_set_param(pj, Physics2DServer::PIN_JOINT_SOFTNESS, softness);
+	return pj;
 
 }
 
+void PinJoint2D::set_softness(real_t p_softness) {
+
+	softness=p_softness;
+	update();
+	if (get_joint().is_valid())
+		Physics2DServer::get_singleton()->pin_joint_set_param(get_joint(), Physics2DServer::PIN_JOINT_SOFTNESS, p_softness);
+
+}
+
+real_t PinJoint2D::get_softness() const {
+
+	return softness;
+}
+
+void PinJoint2D::_bind_methods() {
+
+	ObjectTypeDB::bind_method(_MD("set_softness","softness"), &PinJoint2D::set_softness);
+	ObjectTypeDB::bind_method(_MD("get_softness"), &PinJoint2D::get_softness);
+
+	ADD_PROPERTY( PropertyInfo( Variant::REAL, "softness", PROPERTY_HINT_EXP_RANGE,"0.00,16,0.01"), _SCS("set_softness"), _SCS("get_softness"));
+}
 
 PinJoint2D::PinJoint2D() {
 
-
+	softness = 0;
 }
 
 

--- a/scene/2d/joints_2d.h
+++ b/scene/2d/joints_2d.h
@@ -72,13 +72,17 @@ class PinJoint2D : public Joint2D {
 
 	OBJ_TYPE(PinJoint2D,Joint2D);
 
+	real_t softness;
+
 protected:
 
 	void _notification(int p_what);
 	virtual RID _configure_joint();
+	static void _bind_methods();
 public:
 
-
+	void set_softness(real_t p_stiffness);
+	real_t get_softness() const;
 
 	PinJoint2D();
 };

--- a/servers/physics_2d/joints_2d_sw.cpp
+++ b/servers/physics_2d/joints_2d_sw.cpp
@@ -279,6 +279,18 @@ void PinJoint2DSW::solve(float p_step){
 	P += impulse;
 }
 
+void PinJoint2DSW::set_param(Physics2DServer::PinJointParam p_param, real_t p_value) {
+
+	if(p_param == Physics2DServer::PIN_JOINT_SOFTNESS)
+		softness = p_value;
+}
+
+real_t PinJoint2DSW::get_param(Physics2DServer::PinJointParam p_param) const {
+
+	if(p_param == Physics2DServer::PIN_JOINT_SOFTNESS)
+		return softness;
+	ERR_FAIL_V(0);
+}
 
 PinJoint2DSW::PinJoint2DSW(const Vector2& p_pos,Body2DSW* p_body_a,Body2DSW* p_body_b) : Joint2DSW(_arr,p_body_b?2:1) {
 

--- a/servers/physics_2d/joints_2d_sw.h
+++ b/servers/physics_2d/joints_2d_sw.h
@@ -121,6 +121,8 @@ public:
 	virtual bool setup(float p_step);
 	virtual void solve(float p_step);
 
+	void set_param(Physics2DServer::PinJointParam p_param, real_t p_value);
+	real_t get_param(Physics2DServer::PinJointParam p_param) const;
 
 	PinJoint2DSW(const Vector2& p_pos,Body2DSW* p_body_a,Body2DSW* p_body_b=NULL);
 	~PinJoint2DSW();

--- a/servers/physics_2d/physics_2d_server_sw.cpp
+++ b/servers/physics_2d/physics_2d_server_sw.cpp
@@ -1096,6 +1096,25 @@ RID Physics2DServerSW::damped_spring_joint_create(const Vector2& p_anchor_a,cons
 
 }
 
+void Physics2DServerSW::pin_joint_set_param(RID p_joint, PinJointParam p_param, real_t p_value) {
+
+	Joint2DSW *j = joint_owner.get(p_joint);
+	ERR_FAIL_COND(!j);
+	ERR_FAIL_COND(j->get_type()!=JOINT_PIN);
+
+	PinJoint2DSW *pin_joint = static_cast<PinJoint2DSW*>(j);
+	pin_joint->set_param(p_param, p_value);
+}
+
+real_t Physics2DServerSW::pin_joint_get_param(RID p_joint, PinJointParam p_param) const {
+	Joint2DSW *j = joint_owner.get(p_joint);
+	ERR_FAIL_COND_V(!j,0);
+	ERR_FAIL_COND_V(j->get_type()!=JOINT_PIN,0);
+
+	PinJoint2DSW *pin_joint = static_cast<PinJoint2DSW*>(j);
+	return pin_joint->get_param(p_param);
+}
+
 void Physics2DServerSW::damped_string_joint_set_param(RID p_joint, DampedStringParam p_param, real_t p_value) {
 
 

--- a/servers/physics_2d/physics_2d_server_sw.h
+++ b/servers/physics_2d/physics_2d_server_sw.h
@@ -243,6 +243,8 @@ public:
 	virtual RID pin_joint_create(const Vector2& p_pos,RID p_body_a,RID p_body_b=RID());
 	virtual RID groove_joint_create(const Vector2& p_a_groove1,const Vector2& p_a_groove2, const Vector2& p_b_anchor, RID p_body_a,RID p_body_b);
 	virtual RID damped_spring_joint_create(const Vector2& p_anchor_a,const Vector2& p_anchor_b,RID p_body_a,RID p_body_b=RID());
+	virtual void pin_joint_set_param(RID p_joint, PinJointParam p_param, real_t p_value);
+	virtual real_t pin_joint_get_param(RID p_joint, PinJointParam p_param) const;
 	virtual void damped_string_joint_set_param(RID p_joint, DampedStringParam p_param, real_t p_value);
 	virtual real_t damped_string_joint_get_param(RID p_joint, DampedStringParam p_param) const;
 

--- a/servers/physics_2d/physics_2d_server_wrap_mt.h
+++ b/servers/physics_2d/physics_2d_server_wrap_mt.h
@@ -258,6 +258,9 @@ public:
 	FUNC5R(RID,groove_joint_create,const Vector2&,const Vector2&,const Vector2&,RID,RID);
 	FUNC4R(RID,damped_spring_joint_create,const Vector2&,const Vector2&,RID,RID);
 
+	FUNC3(pin_joint_set_param,RID,PinJointParam,real_t);
+	FUNC2RC(real_t,pin_joint_get_param,RID,PinJointParam);
+
 	FUNC3(damped_string_joint_set_param,RID,DampedStringParam,real_t);
 	FUNC2RC(real_t,damped_string_joint_get_param,RID,DampedStringParam);
 

--- a/servers/physics_2d_server.h
+++ b/servers/physics_2d_server.h
@@ -516,6 +516,13 @@ public:
 	virtual RID groove_joint_create(const Vector2& p_a_groove1,const Vector2& p_a_groove2, const Vector2& p_b_anchor, RID p_body_a,RID p_body_b)=0;
 	virtual RID damped_spring_joint_create(const Vector2& p_anchor_a,const Vector2& p_anchor_b,RID p_body_a,RID p_body_b=RID())=0;
 
+	enum PinJointParam {
+		PIN_JOINT_SOFTNESS
+	};
+
+	virtual void pin_joint_set_param(RID p_joint, PinJointParam p_param, real_t p_value)=0;
+	virtual real_t pin_joint_get_param(RID p_joint, PinJointParam p_param) const=0;
+
 	enum DampedStringParam {
 		DAMPED_STRING_REST_LENGTH,
 		DAMPED_STRING_STIFFNESS,


### PR DESCRIPTION
This parameter was already presented inside PinJoint and it was always set to 0. So I played with it and decided to expose it to the editor. It allows some fine tuning of joint and decreases impulses inside. The actual behaviour depends on "bias" value. If bias is trying to correct position errors by introducing some energy into the system, softness in the opposite decreases the final impulse. So together they act a bit like spring. If bias introduce too much energy and make simulation unstable some softness may make it stable again.
