### PR TITLE
Added specific get_locale to OSX platform

### DIFF
--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -157,6 +157,8 @@ public:
 	Error shell_open(String p_uri);
 	void push_input(const InputEvent& p_event);
 
+	String get_locale() const;
+
 	virtual void set_video_mode(const VideoMode& p_video_mode,int p_screen=0);
 	virtual VideoMode get_video_mode(int p_screen=0) const;
 	virtual void get_fullscreen_mode_list(List<VideoMode> *p_list,int p_screen=0) const;

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1254,6 +1254,11 @@ Error OS_OSX::shell_open(String p_uri) {
 	return OK;
 }
 
+String OS_OSX::get_locale() const {
+  NSString* preferredLang = [[NSLocale preferredLanguages] objectAtIndex:0];
+	return [preferredLang UTF8String];
+}
+
 void OS_OSX::swap_buffers() {
 
 	[context flushBuffer];


### PR DESCRIPTION
The default unix get_locale didn’t work. OS X requires a specific one.
