### PR TITLE
GDScript export hints: Add float w/ ease, remove duplicate, adapt multiline to established format

### DIFF
--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -2607,23 +2607,16 @@ void GDParser::_parse_class(ClassNode *p_class) {
 					} else if (tokenizer->get_token()==GDTokenizer::TK_IDENTIFIER) {
 
 						String identifier = tokenizer->get_token_identifier();
-						if (identifier == "flag") {
-							current_export.type=Variant::INT;
-							current_export.hint=PROPERTY_HINT_ALL_FLAGS;
-						}else if (identifier == "multiline"){
-							current_export.type=Variant::STRING;
-							current_export.hint=PROPERTY_HINT_MULTILINE_TEXT;
-						} else {
-							if (!ObjectTypeDB::is_type(identifier,"Resource")) {
-	
-								current_export=PropertyInfo();
-								_set_error("Export hint not a type or resource.");
-							}
-	
-							current_export.type=Variant::OBJECT;
-							current_export.hint=PROPERTY_HINT_RESOURCE_TYPE;
-							current_export.hint_string=identifier;
+						if (!ObjectTypeDB::is_type(identifier,"Resource")) {
+
+							current_export=PropertyInfo();
+							_set_error("Export hint not a type or resource.");
 						}
+
+						current_export.type=Variant::OBJECT;
+						current_export.hint=PROPERTY_HINT_RESOURCE_TYPE;
+						current_export.hint_string=identifier;
+
 						tokenizer->advance();
 					}
 

--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -2571,6 +2571,17 @@ void GDParser::_parse_class(ClassNode *p_class) {
 										}
 										break;
 									}
+
+									if (tokenizer->get_token()==GDTokenizer::TK_IDENTIFIER && tokenizer->get_token_identifier()=="MULTILINE") {
+
+										current_export.hint=PROPERTY_HINT_MULTILINE_TEXT;
+										tokenizer->advance();
+										if (tokenizer->get_token()!=GDTokenizer::TK_PARENTHESIS_CLOSE) {
+											_set_error("Expected ')' in hint.");
+											return;
+										}
+										break;
+									}
 								} break;
 								case Variant::COLOR: {
 

--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -2421,6 +2421,16 @@ void GDParser::_parse_class(ClassNode *p_class) {
 								}; //fallthrough to use the same
 								case Variant::REAL: {
 
+									if (tokenizer->get_token()==GDTokenizer::TK_IDENTIFIER && tokenizer->get_token_identifier()=="EASE") {
+										current_export.hint=PROPERTY_HINT_EXP_EASING;
+										tokenizer->advance();
+										if (tokenizer->get_token()!=GDTokenizer::TK_PARENTHESIS_CLOSE) {
+											_set_error("Expected ')' in hint.");
+											return;
+										}
+										break;
+									}
+
 									float sign=1.0;
 
 									if (tokenizer->get_token()==GDTokenizer::TK_OP_SUB) {


### PR DESCRIPTION
A pull request from not too long ago added `flags` and `multiline` export hints, both of which are very useful. However:
-  Bitmasks were already available using `export(int, FLAGS) var bitmask`. As far as I can see, there is no difference between the two, and having duplicate functionality seems like a bad idea to me. This change deletes the duplicate.
  When this pull request is dealt with, I'm also going to update the `export var` section of the GDScript doc page to avoid this kind of confusion in the future.
-  The `multline` hint doesn't use the default syntax which has the actual type followed by the all-caps hint: `export(String, MULTILINE)` versus `export(multiline)`.
  This change adapts the the multi-line export hint to the established format.

I'm hoping to get these changed while they're not yet part of a stable release and people using the release builds start using them.
-  In addition, this change also adds exporting real numbers with easing hint: `export(float, EASE) var takeiteasy`. Requested in and closes #2403.
