### PR TITLE
Fixes flipped condition in scene tree dock disable checks

### DIFF
--- a/tools/editor/scene_tree_dock.cpp
+++ b/tools/editor/scene_tree_dock.cpp
@@ -1088,7 +1088,7 @@ void SceneTreeDock::_delete_confirm() {
 void SceneTreeDock::_update_tool_buttons() {
 
 	Node *sel = scene_tree->get_selected();
-	bool disable = !sel || (sel!=edited_scene && sel->get_owner()!=edited_scene) || (edited_scene->get_scene_instance_state().is_valid() && edited_scene->get_scene_instance_state()->find_node_by_path(edited_scene->get_path_to(sel))>=0);
+	bool disable = !sel || (sel!=edited_scene && sel->get_owner()!=edited_scene) || !(edited_scene->get_scene_instance_state().is_valid() && edited_scene->get_scene_instance_state()->find_node_by_path(edited_scene->get_path_to(sel))>=0);
 	bool disable_root = disable || sel->get_parent()==scene_root;
 	bool disable_edit = !sel;
 


### PR DESCRIPTION
Without this the scenes are uneditable, at least for me.
Might have misunderstood something. That whole line should be split off and made
clearer but I didn't want to poke the bear just yet.
Signed-off-by: Saggi Mizrahi ficoos@gmail.com
