### PR TITLE
remove child variable that is duplicated from parent class

### DIFF
--- a/modules/gdscript/gd_parser.h
+++ b/modules/gdscript/gd_parser.h
@@ -276,7 +276,6 @@ public:
 	};
 
 	struct NewLineNode : public Node {
-		int line;
 		NewLineNode() { type=TYPE_NEWLINE; }
 	};
 

--- a/servers/visual/rasterizer_dummy.h
+++ b/servers/visual/rasterizer_dummy.h
@@ -162,10 +162,6 @@ class RasterizerDummy : public Rasterizer {
 		uint32_t format;
 		uint32_t morph_format;
 
-		RID material;
-		bool material_owned;
-
-
 		Surface() {
 
 			packed=false;


### PR DESCRIPTION
Please double check but I think this is correct. :)
- The struct `NewLineNode` defines member variable with name `line` also defined in its parent struct `Node`.
- The struct `Surface` defines member variable with name `material` also defined in its parent struct `Geometry`.
- The struct `Surface` defines member variable with name `material_owned` also defined in its parent struct `Geometry`.
