### PR TITLE
Fix icons (default location and in demos)

### DIFF
--- a/demos/2d/fog_of_war/engine.cfg
+++ b/demos/2d/fog_of_war/engine.cfg
@@ -2,7 +2,7 @@
 
 name="Fog of War"
 main_scene="res://fog.scn"
-icon="icon.png"
+icon="res://icon.png"
 
 [input]
 

--- a/demos/2d/polygon_path_finder_demo/engine.cfg
+++ b/demos/2d/polygon_path_finder_demo/engine.cfg
@@ -2,4 +2,4 @@
 
 name="polygon_path_finder_demo"
 main_scene="res://new_scene_poly_with_holes.scn"
-icon="icon.png"
+icon="res://icon.png"

--- a/demos/gui/input_mapping/engine.cfg
+++ b/demos/gui/input_mapping/engine.cfg
@@ -2,7 +2,6 @@
 
 name="Input Mapping GUI"
 main_scene="res://controls.scn"
-icon="icon.png"
 
 [display]
 

--- a/demos/misc/tween/engine.cfg
+++ b/demos/misc/tween/engine.cfg
@@ -2,7 +2,7 @@
 
 name="Tween Demo"
 main_scene="res://main.xml"
-icon="icon.png"
+icon="res://icon.png"
 target_fps=60
 
 [display]

--- a/demos/misc/window_management/engine.cfg
+++ b/demos/misc/window_management/engine.cfg
@@ -2,7 +2,7 @@
 
 name="Window Management"
 main_scene="res://window_management.scn"
-icon="icon.png"
+icon="res://icon.png"
 
 [display]
 

--- a/tools/editor/project_manager.cpp
+++ b/tools/editor/project_manager.cpp
@@ -193,7 +193,7 @@ class NewProjectDialog : public ConfirmationDialog {
 				f->store_line("\n");
 				f->store_line("[application]");
 				f->store_line("name=\""+project_name->get_text()+"\"");
-				f->store_line("icon=\"icon.png\"");
+				f->store_line("icon=\"res://icon.png\"");
 
 				memdelete(f);
 


### PR DESCRIPTION
I was getting the following error in the project manager:

```
ERROR OPENING FILE: icon.png
```

By default, when creating a new project, the code was using `icon.png` instead of `res://icon.png` for the icon in the `engine.cfg` file.  This fixes that as well as adjusts the demos to either use that location if the demo has an icon or removes the icon if it doesn't have one.
