### PR TITLE
Ask confirmation if closing scene was modified (using close [x] tab)

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -2008,6 +2008,11 @@ void EditorNode::_menu_option_confirm(int p_option,bool p_confirmed) {
 
 
 		} break;
+		case SCENE_TAB_CLOSE: {
+		 	_remove_scene(tab_closing);
+			_update_scene_tabs();
+			current_option = -1;
+		} break;
 		case FILE_SAVE_SCENE: {
 
 
@@ -2019,7 +2024,7 @@ void EditorNode::_menu_option_confirm(int p_option,bool p_confirmed) {
 				return;
 			};
 			// fallthrough to save_as
-		};
+		} break;
 		case FILE_SAVE_AS_SCENE: {
 			
 			Node *scene = editor_data.get_edited_scene_root();
@@ -2960,14 +2965,14 @@ void EditorNode::_remove_edited_scene() {
 
 void EditorNode::_remove_scene(int index) {
 //	printf("Attempting to remove scene %d (current is %d)\n", index, editor_data.get_edited_scene());
+
 	if (editor_data.get_edited_scene() == index) {
 		//Scene to remove is current scene
 		_remove_edited_scene();
 	}
 	else {
-		// Scene to remove is not active scene.");
+		// Scene to remove is not active scene
 		editor_data.remove_scene(index);
-		editor_data.get_undo_redo().clear_history();
 	}
 }
 
@@ -4463,8 +4468,19 @@ void EditorNode::_scene_tab_script_edited(int p_tab) {
 }
 
 void EditorNode::_scene_tab_closed(int p_tab) {
- 	_remove_scene(p_tab);
-	_update_scene_tabs();
+	current_option = SCENE_TAB_CLOSE;
+	tab_closing = p_tab;
+	if (unsaved_cache) {
+		confirmation->get_ok()->set_text("Yes");
+		//confirmation->get_cancel()->show();
+		confirmation->set_text("Close scene? (Unsaved changes will be lost)");
+		confirmation->popup_centered_minsize();
+	}
+	else {
+		_remove_scene(p_tab);
+		//_update_scene_tabs();
+	}
+
 }
 
 

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -2956,11 +2956,11 @@ void EditorNode::_remove_edited_scene() {
 	_update_title();
 	_update_scene_tabs();
 
-	if (editor_data.get_edited_scene_count()==1) {
-		//make new scene appear saved
-		set_current_version(editor_data.get_undo_redo().get_version());
-		unsaved_cache=false;
-	}
+//	if (editor_data.get_edited_scene_count()==1) {
+//		//make new scene appear saved
+//		set_current_version(editor_data.get_undo_redo().get_version());
+//		unsaved_cache=false;
+//	}
 }
 
 void EditorNode::_remove_scene(int index) {

--- a/tools/editor/editor_node.h
+++ b/tools/editor/editor_node.h
@@ -173,6 +173,7 @@ class EditorNode : public Node {
 		SOURCES_REIMPORT,
 		DEPENDENCY_LOAD_CHANGED_IMAGES,
 		DEPENDENCY_UPDATE_IMPORTED,
+		SCENE_TAB_CLOSE,
 
 		IMPORT_PLUGIN_BASE=100,
 
@@ -217,6 +218,7 @@ class EditorNode : public Node {
 	//main tabs
 
 	Tabs *scene_tabs;
+	int tab_closing;
 
 
 	int old_split_ofs;


### PR DESCRIPTION
- SWITCHED THE SCENE TAB CLOSE BUTTON DISPLAY POLICY TO "SHOW_ACTIVE_ONLY" !
- Also added a missing break;  statement
