### PR TITLE
Fix for world_to_map() with negative coords.  Fixes issue #2665

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1031,13 +1031,12 @@ Vector2 TileMap::world_to_map(const Vector2& p_pos) const{
 	switch(half_offset) {
 
 		case HALF_OFFSET_X: {
-			if (int(ret.y)&1) {
-
+			if ( ret.y > 0 ? int(ret.y)&1 : (int(ret.y)-1)&1 ) {
 				ret.x-=0.5;
 			}
 		} break;
 		case HALF_OFFSET_Y: {
-			if (int(ret.x)&1) {
+			if ( ret.x > 0 ? int(ret.x)&1 : (int(ret.x)-1)&1) {
 				ret.y-=0.5;
 			}
 		} break;


### PR DESCRIPTION
int() of negative numbers rounds up. Needed to add a condition to account for negative values. Thanks to Romulox_x for providing this solution.
