### PR TITLE
Add all collision shapes to a tile when converting scenes to TileSets

### DIFF
--- a/tools/editor/plugins/tile_set_editor_plugin.cpp
+++ b/tools/editor/plugins/tile_set_editor_plugin.cpp
@@ -110,11 +110,15 @@ void TileSetEditor::_import_scene(Node *scene, Ref<TileSet> p_library, bool p_me
 			if (!child2->cast_to<StaticBody2D>())
 				continue;
 			StaticBody2D *sb = child2->cast_to<StaticBody2D>();
-			if (sb->get_shape_count()==0)
+			int shape_count = sb->get_shape_count();
+			if (shape_count==0)
 				continue;
-			Ref<Shape2D> collision=sb->get_shape(0);
-			if (collision.is_valid()) {
-				collisions.push_back(collision);
+			for (int shape_index=0; shape_index<shape_count; ++shape_index)
+			{
+				Ref<Shape2D> collision=sb->get_shape(shape_index);
+				if (collision.is_valid()) {
+					collisions.push_back(collision);
+				}
 			}
 		}
 


### PR DESCRIPTION
Currently when converting a scene to a `TileSet`, only the first shape of each `StaticBody2D` is added to the tile.
For multiple shapes, one has to add multiple `StaticBody2D` nodes and give one shape to each.
For concave `CollisionPolygon2D` nodes in `BUILD_SOLIDS` mode, which split the concave polygon shape into multiple convex polygon shapes, only the first shape is added to the tile, making it impossible to use `CollisionPolygon2D` for concave polygons.

This change has all shapes added to the tile when converting.

Fixes #2331
