### PR TITLE
Added tooltip for a few buttons in sample library editor

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,2 @@
+set vc_path=%1
+call %vc_path% & scons platform=windows

--- a/build.bat
+++ b/build.bat
@@ -1,2 +1,0 @@
-set vc_path=%1
-call %vc_path% & scons platform=windows

--- a/tools/editor/plugins/sample_library_editor_plugin.cpp
+++ b/tools/editor/plugins/sample_library_editor_plugin.cpp
@@ -49,9 +49,13 @@ void SampleLibraryEditor::_notification(int p_what) {
 
 	if (p_what==NOTIFICATION_ENTER_TREE) {
 		play->set_icon( get_icon("Play","EditorIcons") );
+		play->set_tooltip("Play Audio");
 		stop->set_icon( get_icon("Stop","EditorIcons") );
+		stop->set_tooltip("Stop Audio");
 		load->set_icon( get_icon("Folder","EditorIcons") );
+		load->set_tooltip("Open Audio File(s)");
 		_delete->set_icon( get_icon("Del","EditorIcons") );
+		_delete->set_tooltip("Remove Audio");
 	}
 
 	if (p_what==NOTIFICATION_READY) {

--- a/tools/editor/plugins/sample_library_editor_plugin.cpp
+++ b/tools/editor/plugins/sample_library_editor_plugin.cpp
@@ -49,13 +49,13 @@ void SampleLibraryEditor::_notification(int p_what) {
 
 	if (p_what==NOTIFICATION_ENTER_TREE) {
 		play->set_icon( get_icon("Play","EditorIcons") );
-		play->set_tooltip("Play Audio");
+		play->set_tooltip("Play Sample");
 		stop->set_icon( get_icon("Stop","EditorIcons") );
-		stop->set_tooltip("Stop Audio");
+		stop->set_tooltip("Stop Sample");
 		load->set_icon( get_icon("Folder","EditorIcons") );
-		load->set_tooltip("Open Audio File(s)");
+		load->set_tooltip("Open Sample File(s)");
 		_delete->set_icon( get_icon("Del","EditorIcons") );
-		_delete->set_tooltip("Remove Audio");
+		_delete->set_tooltip("Remove Sample");
 	}
 
 	if (p_what==NOTIFICATION_READY) {


### PR DESCRIPTION
I have added appropriate tool-tips on a few buttons that did not have any tool tips or descriptive text associated with them.
