### PR TITLE
improve android payments

### DIFF
--- a/platform/android/java/src/com/android/godot/payments/PurchaseTask.java
+++ b/platform/android/java/src/com/android/godot/payments/PurchaseTask.java
@@ -62,7 +62,11 @@ abstract public class PurchaseTask {
 //		Log.d("XXX", "Buy intent response code: " + responseCode);
 		if(responseCode == 1 || responseCode == 3 || responseCode == 4){
 			canceled();
-			return ;
+			return;
+		}
+		if(responseCode == 7){
+			alreadyOwned();
+			return;
 		}
 			
 		
@@ -92,6 +96,6 @@ abstract public class PurchaseTask {
 
 	abstract protected void error(String message);
 	abstract protected void canceled();
-
+	abstract protected void alreadyOwned();
 	
 }


### PR DESCRIPTION
GodotPaymentV3 currently consumes purchased item right after purchasing.
But, some in-app item should not be consumed like "remove ads permanently"
So, I added "setAutoConsume(boolean)", "requestPurchased()",
"consume(sku_string)".
AutoConsume is true by default as before.

usage:

``` python
func _ready():
    var payment = Globals.get_singleton("GodotPayments")
    payment.setPurchaseCallbackId(get_instance_ID())
    payment.setAutoConsume(false) # default : true
    payment.requestPurchased() # callback : has_purchased
    payment.purchase("item_name") # callback : purchase_success, purchase_fail, purchase_cancel, purchase_owned
    payment.consume("item_name") # callback : consume_success

func purchase_success(receipt, signature, sku):
    print("purchase_success : ", sku)

func purchase_fail():
    print("purchase_fail")

func purchase_cancel():
    print("purchase_cancel")

func purchase_owned(sku):
    print("purchase_owned : ", sku)

func consume_success(receipt, signature, sku):
    print("consume_success : ", sku)

func has_purchased(receipt, signature, sku):
    if sku == "":
        print("has_purchased : nothing")
    else:
        print("has_purchased : ", sku)
```
