### PR TITLE
Fix bug in Body(2D)SW::add_area

### DIFF
--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -32,14 +32,14 @@
 
 void CollisionObject2D::_update_shapes_from_children() {
 
-	shapes.resize(0);
+	shapes.clear();
 	for(int i=0;i<get_child_count();i++) {
 
 		Node* n = get_child(i);
 		n->call("_add_to_collision_object",this);
 	}
 
-//	_update_shapes();
+	_update_shapes();
 }
 
 void CollisionObject2D::_notification(int p_what) {

--- a/scene/3d/collision_object.cpp
+++ b/scene/3d/collision_object.cpp
@@ -31,14 +31,14 @@
 #include "scene/scene_string_names.h"
 void CollisionObject::_update_shapes_from_children() {
 
-	shapes.resize(0);
+	shapes.clear();
 	for(int i=0;i<get_child_count();i++) {
 
 		Node* n = get_child(i);
 		n->call("_add_to_collision_object",this);
 	}
 
-//	_update_shapes();
+	_update_shapes();
 }
 
 void CollisionObject::_notification(int p_what) {

--- a/servers/physics/body_sw.h
+++ b/servers/physics/body_sw.h
@@ -91,10 +91,11 @@ class BodySW : public CollisionObjectSW {
 	struct AreaCMP {
 
 		AreaSW *area;
+		int refCount;
 		_FORCE_INLINE_ bool operator==(const AreaCMP& p_cmp) const { return area->get_self() == p_cmp.area->get_self();}
 		_FORCE_INLINE_ bool operator<(const AreaCMP& p_cmp) const { return area->get_priority() < p_cmp.area->get_priority();}
 		_FORCE_INLINE_ AreaCMP() {}
-		_FORCE_INLINE_ AreaCMP(AreaSW *p_area) { area=p_area;}
+		_FORCE_INLINE_ AreaCMP(AreaSW *p_area) { area=p_area; refCount=1;}
 	};
 
 	Vector<AreaCMP> areas;
@@ -141,8 +142,23 @@ public:
 
 	void set_force_integration_callback(ObjectID p_id,const StringName& p_method,const Variant& p_udata=Variant());
 
-	_FORCE_INLINE_ void add_area(AreaSW *p_area) { areas.ordered_insert(AreaCMP(p_area)); }
-	_FORCE_INLINE_ void remove_area(AreaSW *p_area) { areas.erase(AreaCMP(p_area)); }
+	_FORCE_INLINE_ void add_area(AreaSW *p_area) {
+		int index = areas.find(AreaCMP(p_area));
+		if( index > -1 ) {
+			areas[index].refCount += 1;
+		} else {
+			areas.ordered_insert(AreaCMP(p_area));
+		}
+	}
+
+	_FORCE_INLINE_ void remove_area(AreaSW *p_area) {
+		int index = areas.find(AreaCMP(p_area));
+		if( index > -1 ) {
+			areas[index].refCount -= 1;
+			if( areas[index].refCount < 1 )
+				areas.remove(index);
+		}
+	}
 
 	_FORCE_INLINE_ void set_max_contacts_reported(int p_size) { contacts.resize(p_size); contact_count=0; if (mode==PhysicsServer::BODY_MODE_KINEMATIC && p_size) set_active(true);}
 	_FORCE_INLINE_ int get_max_contacts_reported() const { return contacts.size(); }

--- a/servers/physics_2d/body_2d_sw.h
+++ b/servers/physics_2d/body_2d_sw.h
@@ -92,10 +92,11 @@ class Body2DSW : public CollisionObject2DSW {
 	struct AreaCMP {
 
 		Area2DSW *area;
+		int refCount;
 		_FORCE_INLINE_ bool operator==(const AreaCMP& p_cmp) const { return area->get_self() == p_cmp.area->get_self();}
 		_FORCE_INLINE_ bool operator<(const AreaCMP& p_cmp) const { return area->get_priority() < p_cmp.area->get_priority();}
 		_FORCE_INLINE_ AreaCMP() {}
-		_FORCE_INLINE_ AreaCMP(Area2DSW *p_area) { area=p_area;}
+		_FORCE_INLINE_ AreaCMP(Area2DSW *p_area) { area=p_area; refCount=1;}
 	};
 
 
@@ -142,8 +143,23 @@ public:
 	void set_force_integration_callback(ObjectID p_id, const StringName& p_method, const Variant &p_udata=Variant());
 
 
-	_FORCE_INLINE_ void add_area(Area2DSW *p_area) { areas.ordered_insert(AreaCMP(p_area)); }
-	_FORCE_INLINE_ void remove_area(Area2DSW *p_area) { areas.erase(AreaCMP(p_area)); }
+	_FORCE_INLINE_ void add_area(Area2DSW *p_area) {
+		int index = areas.find(AreaCMP(p_area));
+		if( index > -1 ) {
+			areas[index].refCount += 1;
+		} else {
+			areas.ordered_insert(AreaCMP(p_area));
+		}
+	}
+
+	_FORCE_INLINE_ void remove_area(Area2DSW *p_area) {
+		int index = areas.find(AreaCMP(p_area));
+		if( index > -1 ) {
+			areas[index].refCount -= 1;
+			if( areas[index].refCount < 1 )
+				areas.remove(index);
+		}
+	}
 
 	_FORCE_INLINE_ void set_max_contacts_reported(int p_size) { contacts.resize(p_size); contact_count=0; if (mode==Physics2DServer::BODY_MODE_KINEMATIC && p_size) set_active(true);}
 


### PR DESCRIPTION
Since my patch ( #1691 ) to implement AREA_COMBINE mode a bug was introduced in BodySW and Body2DSW add_area function.

The data structure containing the areas the body was in used to be a SET but was converted to an ARRAY to implement priority.

The rest of the engine though did not check if the body was already inside an area when calling body->add_area. This basically causes the _update_shape signal to add the same area multiple times to the same body object. A very quick test for this is to change the shape of an area in combine mode after _ready (even setting it as the same value it used to be).

If you want a very simple demo project to test both the bug and the patch have a look at:
https://github.com/Faless/add_area_bug
