### PR TITLE
Fix default StyleBoxes of MenuButton

### DIFF
--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -311,6 +311,7 @@ void make_default_theme() {
 	t->set_stylebox("pressed","MenuButton", sb_button_pressed );
 	t->set_stylebox("hover","MenuButton", sb_button_pressed );
 	t->set_stylebox("disabled","MenuButton", make_empty_stylebox(0,0,0,0) );
+	t->set_stylebox("focus","MenuButton", sb_button_focus );
 
 	t->set_font("font","MenuButton", default_font );
 


### PR DESCRIPTION
The focus mode of MenuButton nodes is by default set to `FOCUS_NONE`. However, when the focus mode is changed, MenuButton falls back to the ERROR texture, since the `focus` StyleBox is not set in the default theme.
This happens in some MenuButton instances in the editor, such as the animation player "Tracks" button (see #729).

This change adds the `sb_button_focus` StyleBox for MenuButton. I think this looks alright, but a designer (@ndee85?) might want to take a look at it. In any case, this gets rid of the ugly ERROR texture.

Fixes #729.
