### PR TITLE
BoneAttachment fix.

### DIFF
--- a/scene/3d/skeleton.cpp
+++ b/scene/3d/skeleton.cpp
@@ -250,7 +250,7 @@ void Skeleton::_notification(int p_what) {
 					ERR_CONTINUE(!obj);
 					Spatial *sp = obj->cast_to<Spatial>();
 					ERR_CONTINUE(!sp);
-					sp->set_transform(b.pose_global * b.rest_global_inverse);
+					sp->set_transform(b.pose_global);
 				}
 			}
 


### PR DESCRIPTION
This just makes bone attachments work as I imagine they're expected to, it simply removes the inverse rest matrix from the equation so the attachment's spatial position follows the attached bone exactly.
