### PR TITLE
Small PopupMenu behaviour changes

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -323,10 +323,13 @@ void PopupMenu::_input_event(const InputEvent &p_event) {
 						invalidated_click=false;
 						break;
 					}
-					if (over<0 || items[over].separator || items[over].disabled) {
+					if (over<0) {
 						hide();
 						break; //non-activable
 					}
+
+					if (items[over].separator || items[over].disabled)
+						break;
 
 					if (items[over].submenu!="") {
 
@@ -362,8 +365,11 @@ void PopupMenu::_input_event(const InputEvent &p_event) {
 			int over=_get_mouse_over(Point2(m.x,m.y));
 			int id = (over<0 || items[over].separator || items[over].disabled)?-1:items[over].ID;
 
-			if (id<0)
+			if (id<0) {
+				mouse_over=-1;
+				update();
 				break;
+			}
 
 			if (items[over].submenu!="" && submenu_over!=over) {
 				submenu_over=over;


### PR DESCRIPTION
These are the three changes I propose:
- Do not hide the menu when clicking a separator or a disabled item. It is annoying if the user clicked it accidentally instead of the item above/below.
- Disable highlight when hovering a separator or a disabled item. Currently it keeps the last hovered item highlighted, which may make the user think he is still hovering it.
  ![screen](https://cloud.githubusercontent.com/assets/7718100/10970460/0fe93c40-83cf-11e5-8322-ebbff245a7cf.png)
- ~~Reset the current hover item to none when clearing the menu.~~
