### PR TITLE
Display error type (error, warning, script error) in OS::print_error + cleanup error ANSI coloring

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -61,9 +61,16 @@ void OS::debug_break() {
 
 void OS::print_error(const char* p_function,const char* p_file,int p_line,const char *p_code,const char*p_rationale,ErrorType p_type) {
 
+	const char* err_type;
+	switch(p_type) {
+		case ERR_ERROR: err_type="**ERROR**"; break;
+		case ERR_WARNING: err_type="**WARNING**"; break;
+		case ERR_SCRIPT: err_type="**SCRIPT ERROR**"; break;
+	}
+
 	if (p_rationale && *p_rationale)
-		print("**ERROR**: %s\n ",p_rationale);
-	print("**ERROR**: At: %s:%i:%s() - %s\n",p_file,p_line,p_function,p_code);
+		print("%s: %s\n ",err_type,p_rationale);
+	print("%s: At: %s:%i:%s() - %s\n",err_type,p_file,p_line,p_function,p_code);
 }
 
 void OS::print(const char* p_format, ...) {

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -73,16 +73,16 @@ void OS_Unix::print_error(const char* p_function,const char* p_file,int p_line,c
 
 	switch(p_type) {
 		case ERR_ERROR:
-			print("\E[1;31;40mERROR: %s: \E[1;37;40m%s\n",p_function,err_details);
-			print("\E[0;31;40m   At: %s:%i.\E[0;0;37m\n",p_file,p_line);
+			print("\E[1;31mERROR: %s: \E[0m\E[1m%s\n",p_function,err_details);
+			print("\E[0;31m   At: %s:%i.\E[0m\n",p_file,p_line);
 			break;
 		case ERR_WARNING:
-			print("\E[1;33;40mWARNING: %s: \E[1;37;40m%s\n",p_function,err_details);
-			print("\E[0;33;40m     At: %s:%i.\E[0;0;37m\n",p_file,p_line);
+			print("\E[1;33mWARNING: %s: \E[0m\E[1m%s\n",p_function,err_details);
+			print("\E[0;33m     At: %s:%i.\E[0m\n",p_file,p_line);
 			break;
 		case ERR_SCRIPT:
-			print("\E[1;35;40mSCRIPT ERROR: %s: \E[1;37;40m%s\n",p_function,err_details);
-			print("\E[0;35;40m          At: %s:%i.\E[0;0;37m\n",p_file,p_line);
+			print("\E[1;35mSCRIPT ERROR: %s: \E[0m\E[1m%s\n",p_function,err_details);
+			print("\E[0;35m          At: %s:%i.\E[0m\n",p_file,p_line);
 			break;
 	}
 }

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -65,15 +65,25 @@ void OS_Unix::print_error(const char* p_function,const char* p_file,int p_line,c
 	if (!_print_error_enabled)
 		return;
 
-	if (p_rationale && p_rationale[0]) {
+	const char* err_details;
+	if (p_rationale && p_rationale[0])
+		err_details=p_rationale;
+	else
+		err_details=p_code;
 
-		print("\E[1;31;40mERROR: %s: \E[1;37;40m%s\n",p_function,p_rationale);
-		print("\E[0;31;40m   At: %s:%i.\E[0;0;37m\n",p_file,p_line);
-
-	} else {
-		print("\E[1;31;40mERROR: %s: \E[1;37;40m%s\n",p_function,p_code);
-		print("\E[0;31;40m   At: %s:%i.\E[0;0;37m\n",p_file,p_line);
-
+	switch(p_type) {
+		case ERR_ERROR:
+			print("\E[1;31;40mERROR: %s: \E[1;37;40m%s\n",p_function,err_details);
+			print("\E[0;31;40m   At: %s:%i.\E[0;0;37m\n",p_file,p_line);
+			break;
+		case ERR_WARNING:
+			print("\E[1;33;40mWARNING: %s: \E[1;37;40m%s\n",p_function,err_details);
+			print("\E[0;33;40m     At: %s:%i.\E[0;0;37m\n",p_file,p_line);
+			break;
+		case ERR_SCRIPT:
+			print("\E[1;35;40mSCRIPT ERROR: %s: \E[1;37;40m%s\n",p_function,err_details);
+			print("\E[0;35;40m          At: %s:%i.\E[0;0;37m\n",p_file,p_line);
+			break;
 	}
 }
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1768,15 +1768,26 @@ void OS_Windows::print_error(const char* p_function,const char* p_file,int p_lin
 
 	HANDLE hCon=GetStdHandle(STD_OUTPUT_HANDLE);
 	if (!hCon || hCon==INVALID_HANDLE_VALUE) {
-		if (p_rationale && p_rationale[0]) {
 
-			print("\E[1;31;40mERROR: %s: \E[1;37;40m%s\n",p_function,p_rationale);
-			print("\E[0;31;40m   At: %s:%i.\E[0;0;37m\n",p_file,p_line);
+		const char* err_details;
+		if (p_rationale && p_rationale[0])
+			err_details=p_rationale;
+		else
+			err_details=p_code;
 
-		} else {
-			print("\E[1;31;40mERROR: %s: \E[1;37;40m%s\n",p_function,p_code);
-			print("\E[0;31;40m   At: %s:%i.\E[0;0;37m\n",p_file,p_line);
-
+		switch(p_type) {
+			case ERR_ERROR:
+				print("\E[1;31;40mERROR: %s: \E[1;37;40m%s\n",p_function,err_details);
+				print("\E[0;31;40m   At: %s:%i.\E[0;0;37m\n",p_file,p_line);
+				break;
+			case ERR_WARNING:
+				print("\E[1;33;40mWARNING: %s: \E[1;37;40m%s\n",p_function,err_details);
+				print("\E[0;33;40m     At: %s:%i.\E[0;0;37m\n",p_file,p_line);
+				break;
+			case ERR_SCRIPT:
+				print("\E[1;35;40mSCRIPT ERROR: %s: \E[1;37;40m%s\n",p_function,err_details);
+				print("\E[0;35;40m          At: %s:%i.\E[0;0;37m\n",p_file,p_line);
+				break;
 		}
 	} else {
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1777,16 +1777,16 @@ void OS_Windows::print_error(const char* p_function,const char* p_file,int p_lin
 
 		switch(p_type) {
 			case ERR_ERROR:
-				print("\E[1;31;40mERROR: %s: \E[1;37;40m%s\n",p_function,err_details);
-				print("\E[0;31;40m   At: %s:%i.\E[0;0;37m\n",p_file,p_line);
+				print("\E[1;31mERROR: %s: \E[0m\E[1m%s\n",p_function,err_details);
+				print("\E[0;31m   At: %s:%i.\E[0m\n",p_file,p_line);
 				break;
 			case ERR_WARNING:
-				print("\E[1;33;40mWARNING: %s: \E[1;37;40m%s\n",p_function,err_details);
-				print("\E[0;33;40m     At: %s:%i.\E[0;0;37m\n",p_file,p_line);
+				print("\E[1;33mWARNING: %s: \E[0m\E[1m%s\n",p_function,err_details);
+				print("\E[0;33m     At: %s:%i.\E[0m\n",p_file,p_line);
 				break;
 			case ERR_SCRIPT:
-				print("\E[1;35;40mSCRIPT ERROR: %s: \E[1;37;40m%s\n",p_function,err_details);
-				print("\E[0;35;40m          At: %s:%i.\E[0;0;37m\n",p_file,p_line);
+				print("\E[1;35mSCRIPT ERROR: %s: \E[0m\E[1m",p_function,err_details);
+				print("\E[0;35m          At: %s:%i.\E[0m\n",p_file,p_line);
 				break;
 		}
 	} else {

--- a/platform/winrt/os_winrt.cpp
+++ b/platform/winrt/os_winrt.cpp
@@ -424,15 +424,25 @@ void OSWinrt::get_fullscreen_mode_list(List<VideoMode> *p_list,int p_screen) con
 
 void OSWinrt::print_error(const char* p_function,const char* p_file,int p_line,const char *p_code,const char*p_rationale,ErrorType p_type) {
 
-	if (p_rationale && p_rationale[0]) {
+	const char* err_details;
+	if (p_rationale && p_rationale[0])
+		err_details=p_rationale;
+	else
+		err_details=p_code;
 
-		print("\E[1;31;40mERROR: %s: \E[1;37;40m%s\n",p_function,p_rationale);
-		print("\E[0;31;40m   At: %s:%i.\E[0;0;37m\n",p_file,p_line);
-
-	} else {
-		print("\E[1;31;40mERROR: %s: \E[1;37;40m%s\n",p_function,p_code);
-		print("\E[0;31;40m   At: %s:%i.\E[0;0;37m\n",p_file,p_line);
-
+	switch(p_type) {
+		case ERR_ERROR:
+			print("\E[1;31;40mERROR: %s: \E[1;37;40m%s\n",p_function,err_details);
+			print("\E[0;31;40m   At: %s:%i.\E[0;0;37m\n",p_file,p_line);
+			break;
+		case ERR_WARNING:
+			print("\E[1;33;40mWARNING: %s: \E[1;37;40m%s\n",p_function,err_details);
+			print("\E[0;33;40m     At: %s:%i.\E[0;0;37m\n",p_file,p_line);
+			break;
+		case ERR_SCRIPT:
+			print("\E[1;35;40mSCRIPT ERROR: %s: \E[1;37;40m%s\n",p_function,err_details);
+			print("\E[0;35;40m          At: %s:%i.\E[0;0;37m\n",p_file,p_line);
+			break;
 	}
 }
 

--- a/platform/winrt/os_winrt.cpp
+++ b/platform/winrt/os_winrt.cpp
@@ -432,16 +432,16 @@ void OSWinrt::print_error(const char* p_function,const char* p_file,int p_line,c
 
 	switch(p_type) {
 		case ERR_ERROR:
-			print("\E[1;31;40mERROR: %s: \E[1;37;40m%s\n",p_function,err_details);
-			print("\E[0;31;40m   At: %s:%i.\E[0;0;37m\n",p_file,p_line);
+			print("\E[1;31mERROR: %s: \E[0m\E[1m%s\n",p_function,err_details);
+			print("\E[0;31m   At: %s:%i.\E[0m\n",p_file,p_line);
 			break;
 		case ERR_WARNING:
-			print("\E[1;33;40mWARNING: %s: \E[1;37;40m%s\n",p_function,err_details);
-			print("\E[0;33;40m     At: %s:%i.\E[0;0;37m\n",p_file,p_line);
+			print("\E[1;33mWARNING: %s: \E[0m\E[1m%s\n",p_function,err_details);
+			print("\E[0;33m     At: %s:%i.\E[0m\n",p_file,p_line);
 			break;
 		case ERR_SCRIPT:
-			print("\E[1;35;40mSCRIPT ERROR: %s: \E[1;37;40m%s\n",p_function,err_details);
-			print("\E[0;35;40m          At: %s:%i.\E[0;0;37m\n",p_file,p_line);
+			print("\E[1;35mSCRIPT ERROR: %s: \E[0m\E[1m",p_function,err_details);
+			print("\E[0;35m          At: %s:%i.\E[0m\n",p_file,p_line);
 			break;
 	}
 }


### PR DESCRIPTION
**tl;dr:** In the end, it looks like this:
- _Dark background colour:_
  ![gt-colour1](https://cloud.githubusercontent.com/assets/4701338/11056936/1560544a-8787-11e5-80b8-b4aa6f7c56ff.jpg)
- _Light background colour:_
  ![gt-colour2](https://cloud.githubusercontent.com/assets/4701338/11056937/17db05da-8787-11e5-8d4c-5ded24b2b4c9.jpg)

---

Previously all types of errors would be shown as ERROR, thus making for example warnings (WARN_PRINT) somewhat aggressive.

Fixes #1127.

Note that I'm a beginner C++ developer, so the coding logic I adopted might not be the best one. I also only tested the changes on Unix/X11, so the changes for Windows and WinRT need to be thoroughly reviewed (though they're more or less copy-pastes of the Unix code).
