### PR TITLE
Add <Select All>(Ctrl+A) shortcut to LineEdit. Fixes #1094

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -192,6 +192,9 @@ void LineEdit::_input_event(InputEvent p_event) {
 						}
 
 					} break;
+					case (KEY_A): { //Select All
+						select();
+					} break;
 					default: { handled=false;}
 				}
 


### PR DESCRIPTION
Fixes #1094
