### PR TITLE
UDP fixes

### DIFF
--- a/drivers/unix/packet_peer_udp_posix.cpp
+++ b/drivers/unix/packet_peer_udp_posix.cpp
@@ -120,8 +120,10 @@ Error PacketPeerUDPPosix::_poll(bool p_wait) {
 
 	struct sockaddr_in from = {0};
 	socklen_t len = sizeof(struct sockaddr_in);
+	int rb_size = MAX(rb.space_left()-12, 0);
+	int buffer_size = MIN((int)sizeof(recv_buffer),rb_size);
 	int ret;
-	while ( (ret = recvfrom(sockfd, recv_buffer, MIN(sizeof(recv_buffer),rb.space_left()-12), p_wait?0:MSG_DONTWAIT, (struct sockaddr*)&from, &len)) > 0) {
+	while ( (ret = recvfrom(sockfd, recv_buffer, buffer_size, p_wait?0:MSG_DONTWAIT, (struct sockaddr*)&from, &len)) > 0) {
 		rb.write((uint8_t*)&from.sin_addr, 4);
 		uint32_t port = ntohs(from.sin_port);
 		rb.write((uint8_t*)&port, 4);
@@ -131,6 +133,8 @@ Error PacketPeerUDPPosix::_poll(bool p_wait) {
 		++queue_count;
 	};
 
+
+	// TODO: Should ECONNRESET be handled here?
 	if (ret == 0 || (ret == -1 && errno != EAGAIN) ) {
 		close();
 		return FAILED;

--- a/drivers/unix/packet_peer_udp_posix.cpp
+++ b/drivers/unix/packet_peer_udp_posix.cpp
@@ -121,7 +121,7 @@ Error PacketPeerUDPPosix::_poll(bool p_wait) {
 	struct sockaddr_in from = {0};
 	socklen_t len = sizeof(struct sockaddr_in);
 	int ret;
-	while ( (ret = recvfrom(sockfd, recv_buffer, MIN(sizeof(recv_buffer),rb.data_left()-12), p_wait?0:MSG_DONTWAIT, (struct sockaddr*)&from, &len)) > 0) {
+	while ( (ret = recvfrom(sockfd, recv_buffer, MIN(sizeof(recv_buffer),rb.space_left()-12), p_wait?0:MSG_DONTWAIT, (struct sockaddr*)&from, &len)) > 0) {
 		rb.write((uint8_t*)&from.sin_addr, 4);
 		uint32_t port = ntohs(from.sin_port);
 		rb.write((uint8_t*)&port, 4);

--- a/drivers/unix/packet_peer_udp_posix.cpp
+++ b/drivers/unix/packet_peer_udp_posix.cpp
@@ -120,10 +120,8 @@ Error PacketPeerUDPPosix::_poll(bool p_wait) {
 
 	struct sockaddr_in from = {0};
 	socklen_t len = sizeof(struct sockaddr_in);
-	int rb_size = MAX(rb.space_left()-12, 0);
-	int buffer_size = MIN((int)sizeof(recv_buffer),rb_size);
 	int ret;
-	while ( (ret = recvfrom(sockfd, recv_buffer, buffer_size, p_wait?0:MSG_DONTWAIT, (struct sockaddr*)&from, &len)) > 0) {
+	while ( (ret = recvfrom(sockfd, recv_buffer, MIN((int)sizeof(recv_buffer),MAX(rb.space_left()-12, 0)), p_wait?0:MSG_DONTWAIT, (struct sockaddr*)&from, &len)) > 0) {
 		rb.write((uint8_t*)&from.sin_addr, 4);
 		uint32_t port = ntohs(from.sin_port);
 		rb.write((uint8_t*)&port, 4);

--- a/platform/windows/packet_peer_udp_winsock.cpp
+++ b/platform/windows/packet_peer_udp_winsock.cpp
@@ -120,8 +120,10 @@ Error PacketPeerUDPWinsock::_poll(bool p_wait) {
 
 	struct sockaddr_in from = {0};
 	int len = sizeof(struct sockaddr_in);
+	int rb_size = MAX(rb.space_left()-12, 0);
+	int buffer_size = MIN((int)sizeof(recv_buffer),rb_size);
 	int ret;
-	while ( (ret = recvfrom(sockfd, (char*)recv_buffer, MIN(sizeof(recv_buffer),rb.space_left()-12), 0, (struct sockaddr*)&from, &len)) > 0) {
+	while ( (ret = recvfrom(sockfd, (char*)recv_buffer, buffer_size, 0, (struct sockaddr*)&from, &len)) > 0) {
 		rb.write((uint8_t*)&from.sin_addr, 4);
 		uint32_t port = ntohs(from.sin_port);
 		rb.write((uint8_t*)&port, 4);
@@ -132,8 +134,25 @@ Error PacketPeerUDPWinsock::_poll(bool p_wait) {
 		++queue_count;
 	};
 
+	if (ret == SOCKET_ERROR){
+		int error = WSAGetLastError();
 
-	if (ret == 0 || (ret == SOCKET_ERROR && WSAGetLastError() != WSAEWOULDBLOCK) ) {
+		if (error == WSAEWOULDBLOCK){
+			// Expected when doing non-blocking sockets, retry later.
+		}
+		else if (error == WSAECONNRESET){
+			// If the remote target does not accept messages, this error may occur, but is harmless.
+			// Once the remote target gets available, this message will disappear for new messages.
+		}
+		else
+		{
+			close();
+			return FAILED;
+		}
+	}
+
+
+	if (ret == 0) {
 		close();
 		return FAILED;
 	};

--- a/platform/windows/packet_peer_udp_winsock.cpp
+++ b/platform/windows/packet_peer_udp_winsock.cpp
@@ -120,10 +120,8 @@ Error PacketPeerUDPWinsock::_poll(bool p_wait) {
 
 	struct sockaddr_in from = {0};
 	int len = sizeof(struct sockaddr_in);
-	int rb_size = MAX(rb.space_left()-12, 0);
-	int buffer_size = MIN((int)sizeof(recv_buffer),rb_size);
 	int ret;
-	while ( (ret = recvfrom(sockfd, (char*)recv_buffer, buffer_size, 0, (struct sockaddr*)&from, &len)) > 0) {
+	while ( (ret = recvfrom(sockfd, (char*)recv_buffer, MIN((int)sizeof(recv_buffer),MAX(rb.space_left()-12, 0)), 0, (struct sockaddr*)&from, &len)) > 0) {
 		rb.write((uint8_t*)&from.sin_addr, 4);
 		uint32_t port = ntohs(from.sin_port);
 		rb.write((uint8_t*)&port, 4);

--- a/platform/windows/packet_peer_udp_winsock.cpp
+++ b/platform/windows/packet_peer_udp_winsock.cpp
@@ -121,7 +121,7 @@ Error PacketPeerUDPWinsock::_poll(bool p_wait) {
 	struct sockaddr_in from = {0};
 	int len = sizeof(struct sockaddr_in);
 	int ret;
-	while ( (ret = recvfrom(sockfd, (char*)recv_buffer, MIN(sizeof(recv_buffer),rb.data_left()-12), 0, (struct sockaddr*)&from, &len)) > 0) {
+	while ( (ret = recvfrom(sockfd, (char*)recv_buffer, MIN(sizeof(recv_buffer),rb.space_left()-12), 0, (struct sockaddr*)&from, &len)) > 0) {
 		rb.write((uint8_t*)&from.sin_addr, 4);
 		uint32_t port = ntohs(from.sin_port);
 		rb.write((uint8_t*)&port, 4);


### PR DESCRIPTION
Fixed a couple of issues with PacketPeerUDP:
- recvfrom was getting wrong buffer sizes causing disconnects.
- recvfrom could get wrong buffer sizes due to signed<->unsigned conversion.
- disconnects were caused by WSAECONNRESET-error, which normally should be ignored (the udp chat example is difficult to try on Windows due to this). I did not do anything in the posix implementation with this, as I'm not sure if it's an issue there - not able to test right now.
