### PR TITLE
Activate PopupMenu items with middle and right click

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -315,6 +315,8 @@ void PopupMenu::_input_event(const InputEvent &p_event) {
 
 					}
 				} break;
+				case BUTTON_MIDDLE:
+				case BUTTON_RIGHT:
 				case BUTTON_LEFT: {
 
 					int over=_get_mouse_over(Point2(b.x,b.y));


### PR DESCRIPTION
This is the default behaviour in most applications. Right/middle clicking on a popup menu item gives the same result as left clicking it.
