### PR TITLE
Added selection menu to spatial and canvas editors

### DIFF
--- a/tools/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/tools/editor/plugins/canvas_item_editor_plugin.cpp
@@ -435,6 +435,47 @@ CanvasItem* CanvasItemEditor::_select_canvas_item_at_pos(const Point2& p_pos,Nod
 	return NULL;
 }
 
+void CanvasItemEditor::_find_canvas_items_at_pos(const Point2 &p_pos,Node* p_node,const Matrix32& p_parent_xform,const Matrix32& p_canvas_xform, Vector<_SelectResult> &r_items) {
+	if (!p_node)
+		return;
+	if (p_node->cast_to<Viewport>())
+		return;
+
+	CanvasItem *c=p_node->cast_to<CanvasItem>();
+
+	for (int i=p_node->get_child_count()-1;i>=0;i--) {
+
+		if (c && !c->is_set_as_toplevel())
+			_find_canvas_items_at_pos(p_pos,p_node->get_child(i),p_parent_xform * c->get_transform(),p_canvas_xform, r_items);
+		else {
+			CanvasLayer *cl = p_node->cast_to<CanvasLayer>();
+			if (cl)
+				return;
+			_find_canvas_items_at_pos(p_pos,p_node->get_child(i),transform ,cl ? cl->get_transform() : p_canvas_xform, r_items); //use base transform
+		}
+	}
+
+
+	if (c && c->is_visible() && !c->has_meta("_edit_lock_")) {
+
+		Rect2 rect = c->get_item_rect();
+		Point2 local_pos = (p_parent_xform * p_canvas_xform * c->get_transform()).affine_inverse().xform(p_pos);
+
+
+		if (rect.has_point(local_pos)) {
+			Node2D *node=c->cast_to<Node2D>();
+
+			_SelectResult res;
+			res.item=c;
+			res.z=node?node->get_z():0;
+			res.has_z=node;
+			r_items.push_back(res);
+		}
+
+	}
+
+	return;
+}
 
 void CanvasItemEditor::_find_canvas_items_at_rect(const Rect2& p_rect,Node* p_node,const Matrix32& p_parent_xform,const Matrix32& p_canvas_xform,List<CanvasItem*> *r_items) {
 
@@ -475,6 +516,96 @@ void CanvasItemEditor::_find_canvas_items_at_rect(const Rect2& p_rect,Node* p_no
 	}
 
 
+}
+
+bool CanvasItemEditor::_select(CanvasItem *item, Point2 p_click_pos, bool p_append, bool p_drag) {
+
+	if (p_append) {
+		//additive selection
+
+		if (!item) {
+
+			if (p_drag) {
+				drag_from=transform.affine_inverse().xform(p_click_pos);
+
+				box_selecting=true;
+				box_selecting_to=drag_from;
+			}
+
+			return false; //nothing to add
+		}
+
+		if (editor_selection->is_selected(item)) {
+			//already in here, erase it
+			editor_selection->remove_node(item);
+			//_remove_canvas_item(c);
+
+			viewport->update();
+			return false;
+
+		}
+		_append_canvas_item(item);
+		viewport->update();
+
+	} else {
+		//regular selection
+
+		if (!item) {
+			//clear because nothing clicked
+			editor_selection->clear();;
+
+			if (p_drag) {
+				drag_from=transform.affine_inverse().xform(p_click_pos);
+
+				box_selecting=true;
+				box_selecting_to=drag_from;
+			}
+
+			viewport->update();
+			return false;
+		}
+
+		if (!editor_selection->is_selected(item)) {
+			//select a new one and clear previous selection
+			editor_selection->clear();
+			editor_selection->add_node(item);
+			//reselect
+			if (get_tree()->is_editor_hint()) {
+				editor->call("edit_node",item);
+			}
+
+		}
+
+		if (p_drag) {
+			//prepare to move!
+
+			List<Node*> &selection = editor_selection->get_selected_node_list();
+
+			for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
+
+				CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+				if (!canvas_item || !canvas_item->is_visible())
+					continue;
+				CanvasItemEditorSelectedItem *se=editor_selection->get_node_editor_data<CanvasItemEditorSelectedItem>(canvas_item);
+				if (!se)
+					continue;
+
+				se->undo_state=canvas_item->edit_get_state();
+				if (canvas_item->cast_to<Node2D>())
+					se->undo_pivot=canvas_item->cast_to<Node2D>()->edit_get_pivot();
+
+			}
+
+			drag=DRAG_ALL;
+			drag_from=transform.affine_inverse().xform(p_click_pos);
+			drag_point_from=_find_topleftmost_point();
+		}
+
+		viewport->update();
+
+		return true;
+
+	}
 }
 
 void CanvasItemEditor::_key_move(const Vector2& p_dir, bool p_snap, KeyMoveMODE p_move_mode) {
@@ -776,6 +907,24 @@ void CanvasItemEditor::_dialog_value_changed(double) {
 	}
 }
 
+void CanvasItemEditor::_selection_result_pressed(int p_result) {
+
+	if (selection_results.size() <= p_result)
+		return;
+
+	CanvasItem *item=selection_results[p_result].item;
+
+	if (item)
+		_select(item, Point2(), additive_selection, false);
+}
+
+void CanvasItemEditor::_selection_menu_hide() {
+
+	selection_results.clear();
+	selection_menu->clear();
+	selection_menu->set_size(Vector2(0, 0));
+}
+
 bool CanvasItemEditor::get_remove_list(List<Node*> *p_list) {
 
 
@@ -838,7 +987,60 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 
 		if (b.button_index==BUTTON_RIGHT) {
 
+			if (!b.pressed && tool==TOOL_SELECT && b.mod.alt) {
 
+				Point2 click=Point2(b.x,b.y);
+
+				Node* scene = editor->get_edited_scene();
+				if (!scene)
+					return;
+
+				_find_canvas_items_at_pos(click, scene,transform,Matrix32(), selection_results);
+
+				if (selection_results.size() == 1) {
+
+					CanvasItem *item = selection_results[0].item;
+					selection_results.clear();
+
+					additive_selection=b.mod.shift;
+					if (!_select(item, click, additive_selection, false))
+						return;
+
+				} else if (!selection_results.empty()) {
+
+					selection_results.sort();
+
+					NodePath root_path = get_tree()->get_edited_scene_root()->get_path();
+					StringName root_name = root_path.get_name(root_path.get_name_count()-1);
+
+					for (int i = 0; i < selection_results.size(); i++) {
+
+						CanvasItem *item=selection_results[i].item;
+
+						Ref<Texture> icon;
+						if (item->has_meta("_editor_icon"))
+							icon=item->get_meta("_editor_icon");
+						else
+							icon=get_icon( has_icon(item->get_type(),"EditorIcons")?item->get_type():String("Object"),"EditorIcons");
+
+						String node_path="/"+root_name+"/"+root_path.rel_path_to(item->get_path());
+
+						selection_menu->add_item(item->get_name());
+						selection_menu->set_item_icon(i, icon );
+						selection_menu->set_item_metadata(i, node_path);
+						selection_menu->set_item_tooltip(i,String(item->get_name())+
+								"\nType: "+item->get_type()+"\nPath: "+node_path);
+					}
+
+					additive_selection=b.mod.shift;
+
+					selection_menu->set_global_pos(Vector2( b.global_x, b.global_y ));
+					selection_menu->popup();
+					selection_menu->call_deferred("grab_click_focus");
+
+					return;
+				}
+			}
 
 			if (get_item_count() > 0 && drag!=DRAG_NONE) {
 				//cancel drag
@@ -1203,82 +1405,10 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 #if 0
 		if ( b.pressed ) box_selection_start( click );
 #endif
-		if (b.mod.shift) { //additive selection
 
-			if (!c) {
-
-				drag_from=transform.affine_inverse().xform(click);
-
-				box_selecting=true;
-				box_selecting_to=drag_from;
-
-				return; //nothing to add
-			}
-
-			if (editor_selection->is_selected(c)) {
-				//already in here, erase it
-				editor_selection->remove_node(c);
-				//_remove_canvas_item(c);
-
-				viewport->update();
-				return;
-
-			}
-			_append_canvas_item(c);
-			viewport->update();
-		} else {
-			//regular selection
-
-
-
-			if (!c) {
-				//clear because nothing clicked
-				editor_selection->clear();;
-
-				drag_from=transform.affine_inverse().xform(click);
-
-				box_selecting=true;
-				box_selecting_to=drag_from;
-				viewport->update();
-				return;
-			}
-
-			if (!editor_selection->is_selected(c)) {
-				//select a new one and clear previous selection
-				editor_selection->clear();
-				editor_selection->add_node(c);
-				//reselect
-				if (get_tree()->is_editor_hint()) {
-					editor->call("edit_node",c);
-				}
-
-			}
-
-			//prepare to move!
-
-			List<Node*> &selection = editor_selection->get_selected_node_list();
-
-			for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
-
-				CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
-				if (!canvas_item || !canvas_item->is_visible())
-					continue;
-				CanvasItemEditorSelectedItem *se=editor_selection->get_node_editor_data<CanvasItemEditorSelectedItem>(canvas_item);
-				if (!se)
-					continue;
-
-				se->undo_state=canvas_item->edit_get_state();
-				if (canvas_item->cast_to<Node2D>())
-					se->undo_pivot=canvas_item->cast_to<Node2D>()->edit_get_pivot();
-
-			}
-
-			drag=DRAG_ALL;
-			drag_from=transform.affine_inverse().xform(click);
-			drag_point_from=_find_topleftmost_point();
-			viewport->update();
-
-		}
+		additive_selection=b.mod.shift;
+		if (!_select(c, click, additive_selection))
+			return;
 
 	}
 
@@ -2867,6 +2997,8 @@ void CanvasItemEditor::_bind_methods() {
 	ObjectTypeDB::bind_method("_viewport_draw",&CanvasItemEditor::_viewport_draw);
 	ObjectTypeDB::bind_method("_viewport_input_event",&CanvasItemEditor::_viewport_input_event);
 	ObjectTypeDB::bind_method("_snap_changed",&CanvasItemEditor::_snap_changed);
+	ObjectTypeDB::bind_method(_MD("_selection_result_pressed"),&CanvasItemEditor::_selection_result_pressed);
+	ObjectTypeDB::bind_method(_MD("_selection_menu_hide"),&CanvasItemEditor::_selection_menu_hide);
 
 	ADD_SIGNAL( MethodInfo("item_lock_status_changed") );
 	ADD_SIGNAL( MethodInfo("item_group_status_changed") );
@@ -3196,6 +3328,12 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	dialog_val->connect("value_changed",this,"_dialog_value_changed");
 	select_sb = Ref<StyleBoxTexture>( memnew( StyleBoxTexture) );
 
+	selection_menu = memnew( PopupMenu );
+	add_child(selection_menu);
+	selection_menu->set_custom_minimum_size(Vector2(100, 0));
+	selection_menu->connect("item_pressed", this, "_selection_result_pressed");
+	selection_menu->connect("popup_hide", this, "_selection_menu_hide");
+
 	key_pos=true;
 	key_rot=true;
 	key_scale=false;
@@ -3218,6 +3356,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	can_move_pivot=false;
 	drag=DRAG_NONE;
 	bone_last_frame=0;
+	additive_selection=false;
 }
 
 CanvasItemEditor *CanvasItemEditor::singleton=NULL;

--- a/tools/editor/plugins/canvas_item_editor_plugin.h
+++ b/tools/editor/plugins/canvas_item_editor_plugin.h
@@ -150,6 +150,7 @@ class CanvasItemEditor : public VBoxContainer {
 	};
 
 	EditorSelection *editor_selection;
+	bool additive_selection;
 
 	Tool tool;
 	bool first_update;
@@ -182,6 +183,18 @@ class CanvasItemEditor : public VBoxContainer {
 
 
 	MenuOption last_option;
+
+	struct _SelectResult {
+
+		CanvasItem* item;
+		float z;
+		bool has_z;
+		_FORCE_INLINE_ bool operator<(const _SelectResult& p_rr) const {
+			return has_z && p_rr.has_z ? p_rr.z < z : p_rr.has_z;
+		}
+	};
+
+	Vector<_SelectResult> selection_results;
 
 	struct LockList {
 		Point2 pos;
@@ -249,6 +262,8 @@ class CanvasItemEditor : public VBoxContainer {
 	Button *key_scale_button;
 	Button *key_insert_button;
 
+	PopupMenu *selection_menu;
+
 	//PopupMenu *popup;
 	DragType drag;
 	Point2 drag_from;
@@ -276,7 +291,10 @@ class CanvasItemEditor : public VBoxContainer {
 
 	int handle_len;
 	CanvasItem* _select_canvas_item_at_pos(const Point2 &p_pos,Node* p_node,const Matrix32& p_parent_xform,const Matrix32& p_canvas_xform);
+	void _find_canvas_items_at_pos(const Point2 &p_pos,Node* p_node,const Matrix32& p_parent_xform,const Matrix32& p_canvas_xform, Vector<_SelectResult> &r_items);
 	void _find_canvas_items_at_rect(const Rect2& p_rect,Node* p_node,const Matrix32& p_parent_xform,const Matrix32& p_canvas_xform,List<CanvasItem*> *r_items);
+
+	bool _select(CanvasItem *item, Point2 p_click_pos, bool p_append, bool p_drag=true);
 
 	ConfirmationDialog *snap_dialog;
 	
@@ -304,6 +322,9 @@ class CanvasItemEditor : public VBoxContainer {
 	void _append_canvas_item(CanvasItem *p_item);
 	void _dialog_value_changed(double);
 	void _snap_changed();
+	void _selection_result_pressed(int);
+	void _selection_menu_hide();
+
 	UndoRedo *undo_redo;
 
 	Point2 _find_topleftmost_point();

--- a/tools/editor/plugins/spatial_editor_plugin.h
+++ b/tools/editor/plugins/spatial_editor_plugin.h
@@ -111,12 +111,21 @@ private:
 	bool orthogonal;
 	float gizmo_scale;
 
+	struct _RayResult {
+
+		Spatial* item;
+		float depth;
+		int handle;
+		_FORCE_INLINE_ bool operator<(const _RayResult& p_rr) const { return depth<p_rr.depth; }
+	};
+
 	void _update_name();
 	void _compute_edit(const Point2& p_point);
 	void _clear_selected();
 	void _select_clicked(bool p_append,bool p_single);
 	void _select(Spatial *p_node, bool p_append,bool p_single);
 	ObjectID _select_ray(const Point2& p_pos, bool p_append,bool &r_includes_current,int *r_gizmo_handle=NULL,bool p_alt_select=false);
+	void _find_items_at_pos(const Point2& p_pos,bool &r_includes_current,Vector<_RayResult> &results,bool p_alt_select=false);
 	Vector3 _get_ray_pos(const Vector2& p_pos) const;
 	Vector3 _get_ray(const Vector2& p_pos);
 	Point2 _point_to_screen(const Vector3& p_point);
@@ -136,8 +145,11 @@ private:
 	float get_fov() const;
 
 	ObjectID clicked;
+	Vector<_RayResult> selection_results;
 	bool clicked_includes_current;
 	bool clicked_wants_append;
+
+	PopupMenu *selection_menu;
 
 	enum NavigationScheme {
 		NAVIGATION_GODOT,
@@ -225,6 +237,8 @@ private:
 	void _toggle_camera_preview(bool);
 	void _init_gizmo_instance(int p_idx);
 	void _finish_gizmo_instances();
+	void _selection_result_pressed(int);
+	void _selection_menu_hide();
 
 
 protected:


### PR DESCRIPTION
Feature requested in #837
##### Still missing:
- [x] Sort selection results in canvas editor by Z.
- [ ] Maya navigation scheme support in spatial editor.

**Key combination:** _Alt_ + _Right Click_
##### Screenshots:

![Spatial editor Screenshot](https://cloud.githubusercontent.com/assets/7718100/11166015/b888e292-8b22-11e5-96af-e31f48abed1c.png)
![Canvas editor Screenshot](https://cloud.githubusercontent.com/assets/7718100/11166012/85573acc-8b22-11e5-845c-f214acb5c348.png)
