### PR TITLE
2D shapes editor update

### DIFF
--- a/scene/resources/concave_polygon_shape_2d.cpp
+++ b/scene/resources/concave_polygon_shape_2d.cpp
@@ -34,6 +34,7 @@
 void ConcavePolygonShape2D::set_segments(const DVector<Vector2>& p_segments) {
 
 	Physics2DServer::get_singleton()->shape_set_data(get_rid(),p_segments);
+	emit_changed();
 }
 
 DVector<Vector2> ConcavePolygonShape2D::get_segments() const {

--- a/scene/resources/convex_polygon_shape_2d.cpp
+++ b/scene/resources/convex_polygon_shape_2d.cpp
@@ -33,6 +33,7 @@
 void ConvexPolygonShape2D::_update_shape() {
 
 	Physics2DServer::get_singleton()->shape_set_data(get_rid(),points);
+	emit_changed();
 
 }
 
@@ -62,7 +63,7 @@ void ConvexPolygonShape2D::_bind_methods() {
 
 
 
-	ADD_PROPERTY( PropertyInfo(Variant::VECTOR2,"points"),_SCS("set_points"),_SCS("get_points") );
+	ADD_PROPERTY( PropertyInfo(Variant::VECTOR2_ARRAY,"points"),_SCS("set_points"),_SCS("get_points") );
 
 }
 

--- a/scene/resources/shape_line_2d.cpp
+++ b/scene/resources/shape_line_2d.cpp
@@ -35,6 +35,7 @@ void LineShape2D::_update_shape() {
 	arr.push_back(normal);
 	arr.push_back(d);
 	Physics2DServer::get_singleton()->shape_set_data(get_rid(),arr);
+	emit_changed();
 
 }
 

--- a/tools/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/tools/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -115,6 +115,18 @@ void CollisionShape2DEditor::set_handle(int idx, Point2& p_point) {
 		} break;
 
 		case LINE_SHAPE: {
+			if (idx<2) {
+				Ref<LineShape2D> line = node->get_shape();
+
+				if (idx==0){
+					line->set_d(p_point.length());
+				}else{
+					line->set_normal(p_point/30.0);
+				}
+
+				canvas_item_editor->get_viewport_control()->update();
+			}
+
 
 		} break;
 
@@ -200,6 +212,19 @@ void CollisionShape2DEditor::commit_handle(int idx, Variant& p_org) {
 		} break;
 
 		case LINE_SHAPE: {
+			Ref<LineShape2D> line = node->get_shape();
+
+			if (idx==0) {
+				undo_redo->add_do_method(line.ptr(),"set_d",line->get_d());
+				undo_redo->add_do_method(c,"update");
+				undo_redo->add_undo_method(line.ptr(),"set_d",p_org);
+				undo_redo->add_undo_method(c,"update");
+			} else {
+				undo_redo->add_do_method(line.ptr(),"set_normal",line->get_normal());
+				undo_redo->add_do_method(c,"update");
+				undo_redo->add_undo_method(line.ptr(),"set_normal",p_org);
+				undo_redo->add_undo_method(c,"update");
+			}
 
 		} break;
 
@@ -418,6 +443,14 @@ void CollisionShape2DEditor::_canvas_draw() {
 		} break;
 
 		case LINE_SHAPE: {
+			Ref<LineShape2D> shape = node->get_shape();
+			
+			handles.resize(2);
+			handles[0] = shape->get_normal() * shape->get_d();
+			handles[1] = shape->get_normal() * (shape->get_d() + 30.0);
+			
+			c->draw_texture(h,gt.xform(handles[0])-size);
+			c->draw_texture(h,gt.xform(handles[1])-size);
 
 		} break;
 


### PR DESCRIPTION
ShapeLine2D is now graphically editable.
ConvexPolygon2D point array is now editable.
Con(vex|cave)Polygon2D now respond to any modifications to their point array on the editor.
