### PR TITLE
Split up AnimationPlayer tracks editor `Tracks` button

### DIFF
--- a/tools/editor/animation_editor.h
+++ b/tools/editor/animation_editor.h
@@ -70,9 +70,9 @@ class AnimationKeyEditor : public VBoxContainer  {
 
 	enum {
 
-		TRACK_MENU_ADD_VALUE_TRACK,
-		TRACK_MENU_ADD_TRANSFORM_TRACK,
-		TRACK_MENU_ADD_CALL_TRACK,
+		ADD_TRACK_MENU_ADD_VALUE_TRACK,
+		ADD_TRACK_MENU_ADD_TRANSFORM_TRACK,
+		ADD_TRACK_MENU_ADD_CALL_TRACK,
 		TRACK_MENU_SCALE,
 		TRACK_MENU_SCALE_PIVOT,
 		TRACK_MENU_MOVE_UP,
@@ -192,6 +192,7 @@ class AnimationKeyEditor : public VBoxContainer  {
 
 	SpinBox *step;
 
+	MenuButton *menu_add_track;
 	MenuButton *menu_track;
 
 	HScrollBar *h_scroll;
@@ -286,6 +287,7 @@ class AnimationKeyEditor : public VBoxContainer  {
 
 	void _scroll_changed(double);
 
+	void _menu_add_track(int p_type);
 	void _menu_track(int p_type);
 
 	void _clear_selection_for_anim(const Ref<Animation>& p_anim);


### PR DESCRIPTION
Currently, many users overlook the "Tracks" button in the tracks editor of the AnimationPlayer, causing them to miss out on features like "Call Func Tracks". I assume most see it as a something like a "panel title", since ToolButtons are flat in normal state.

This change splits up this button into two buttons:
-  An `Add Tracks` button with a `+` icon, containing options to insert a new track of any of the three types
-  A `Track Tools` button with a gear icon, containing the other menu options previously contained in the `Tracks` button

The change also moves the new buttons to the opposite end of the editor, where the other buttons are positioned as well.

![tracks](https://cloud.githubusercontent.com/assets/6996191/11255758/41b942d2-8e48-11e5-8587-660e9deb911e.png)
Since these buttons now both use icons rather than text, it should be more obvious they're buttons.
