### PR TITLE
Popup Always on Top option

### DIFF
--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -124,8 +124,9 @@ private:
 		Control *window;
 		bool modal;
 		bool modal_exclusive;
+		bool always_on_top;
 		Ref<Theme> theme;
-		Control *theme_owner;		
+		Control *theme_owner;
 		String tooltip;
 		CursorShape default_cursor;
 
@@ -303,6 +304,9 @@ public:
 	void set_area_as_parent_rect(int p_margin=0);
 	
 	void show_modal(bool p_exclusive=false);
+
+	void set_always_on_top(bool p_enable);
+	bool is_always_on_top() const;
 
 	void set_theme(const Ref<Theme>& p_theme);
 	Ref<Theme> get_theme() const;

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -261,9 +261,12 @@ void Popup::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("popup"),&Popup::popup);
 	ObjectTypeDB::bind_method(_MD("set_exclusive","enable"),&Popup::set_exclusive);
 	ObjectTypeDB::bind_method(_MD("is_exclusive"),&Popup::is_exclusive);
+	ObjectTypeDB::bind_method(_MD("set_always_on_top","enable"),&Popup::set_always_on_top);
+	ObjectTypeDB::bind_method(_MD("is_always_on_top"),&Popup::is_always_on_top);
 	ADD_SIGNAL( MethodInfo("about_to_show") );
 	ADD_SIGNAL( MethodInfo("popup_hide") );
 	ADD_PROPERTY( PropertyInfo( Variant::BOOL, "popup/exclusive"), _SCS("set_exclusive"),_SCS("is_exclusive") );
+	ADD_PROPERTY( PropertyInfo( Variant::BOOL, "popup/always_on_top"), _SCS("set_always_on_top"),_SCS("is_always_on_top") );
 	BIND_CONSTANT(NOTIFICATION_POST_POPUP);
 	BIND_CONSTANT(NOTIFICATION_POPUP_HIDE);
 


### PR DESCRIPTION
The option ("TopMost" for windows users) let's you work outside the dialog while keeping it visible. If another always on top dialog is clicked, this one will be raised to the front.

A quick usage example is with plugin dialogs that need to be visible while working with the editor.

I find this very useful, but I am not sure if modals were made to behave this way~
