### PR TITLE
Fixes Visual Studio compile error due to pe_bliss

### DIFF
--- a/tools/pe_bliss/pe_section.cpp
+++ b/tools/pe_bliss/pe_section.cpp
@@ -19,6 +19,7 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
+#include <algorithm>
 #include <string.h>
 #include "utils.h"
 #include "pe_section.h"


### PR DESCRIPTION
Compile error: C2039: 'min': is not a member of 'std'
Reason: #2518 introduced pe_bliss

Fix: Need to include algorithm header before string, otherwise std:min cannot be used while compiling with Visual Studio 2015 / 2013. Should not have any effect on other platforms, because algorithm is a standard header.
See: http://stackoverflow.com/questions/17409956

By the way: #2822 fixes another Visual Studio compile error. After merging both, builds succeed.
