### PR TITLE
Improved error log colours in the Windows terminal

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1765,84 +1765,85 @@ bool OS_Windows::is_window_maximized() const{
 }
 
 
-void OS_Windows::print_error(const char* p_function,const char* p_file,int p_line,const char *p_code,const char*p_rationale,ErrorType p_type) {
+void OS_Windows::print_error(const char* p_function, const char* p_file, int p_line, const char* p_code, const char* p_rationale, ErrorType p_type) {
 
-	HANDLE hCon=GetStdHandle(STD_OUTPUT_HANDLE);
-	if (!hCon || hCon==INVALID_HANDLE_VALUE) {
+	HANDLE hCon = GetStdHandle(STD_OUTPUT_HANDLE);
+	if (!hCon || hCon == INVALID_HANDLE_VALUE) {
 
 		const char* err_details;
 		if (p_rationale && p_rationale[0])
-			err_details=p_rationale;
+			err_details = p_rationale;
 		else
-			err_details=p_code;
+			err_details = p_code;
 
 		switch(p_type) {
 			case ERR_ERROR:
-				print("\E[1;31mERROR: %s: \E[0m\E[1m%s\n",p_function,err_details);
-				print("\E[0;31m   At: %s:%i.\E[0m\n",p_file,p_line);
+				print("\E[1;31mERROR: %s: \E[0m\E[1m%s\n", p_function, err_details);
+				print("\E[0;31m   At: %s:%i.\E[0m\n", p_file, p_line);
 				break;
 			case ERR_WARNING:
-				print("\E[1;33mWARNING: %s: \E[0m\E[1m%s\n",p_function,err_details);
-				print("\E[0;33m     At: %s:%i.\E[0m\n",p_file,p_line);
+				print("\E[1;33mWARNING: %s: \E[0m\E[1m%s\n", p_function, err_details);
+				print("\E[0;33m     At: %s:%i.\E[0m\n", p_file, p_line);
 				break;
 			case ERR_SCRIPT:
-				print("\E[1;35mSCRIPT ERROR: %s: \E[0m\E[1m",p_function,err_details);
-				print("\E[0;35m          At: %s:%i.\E[0m\n",p_file,p_line);
+				print("\E[1;35mSCRIPT ERROR: %s: \E[0m\E[1m", p_function, err_details);
+				print("\E[0;35m          At: %s:%i.\E[0m\n", p_file, p_line);
 				break;
 		}
+
 	} else {
 
 		CONSOLE_SCREEN_BUFFER_INFO sbi; //original
-		GetConsoleScreenBufferInfo(hCon,&sbi);
+		GetConsoleScreenBufferInfo(hCon, &sbi);
 
-		SetConsoleTextAttribute(hCon,sbi.wAttributes);
+		SetConsoleTextAttribute(hCon, sbi.wAttributes);
 
-
-
-		uint32_t basecol=0;
+		uint32_t basecol = 0;
 		switch(p_type) {
 			case ERR_ERROR: basecol = FOREGROUND_RED; break;
-			case ERR_WARNING: basecol = FOREGROUND_RED|FOREGROUND_GREEN; break;
+			case ERR_WARNING: basecol = FOREGROUND_RED | FOREGROUND_GREEN; break;
 			case ERR_SCRIPT: basecol = FOREGROUND_GREEN; break;
 		}
 
 		if (p_rationale && p_rationale[0]) {
 
-			SetConsoleTextAttribute(hCon,basecol|FOREGROUND_INTENSITY);
-
-
+			SetConsoleTextAttribute(hCon, basecol | FOREGROUND_INTENSITY);
 			switch(p_type) {
 				case ERR_ERROR: print("ERROR: "); break;
 				case ERR_WARNING: print("WARNING: "); break;
 				case ERR_SCRIPT: print("SCRIPT ERROR: "); break;
 			}
 
-			SetConsoleTextAttribute(hCon,FOREGROUND_RED|FOREGROUND_BLUE|FOREGROUND_GREEN|FOREGROUND_INTENSITY);
-			print(" %s\n",p_rationale);
-			SetConsoleTextAttribute(hCon,basecol);
-			print("At: ");
-			SetConsoleTextAttribute(hCon,FOREGROUND_RED|FOREGROUND_BLUE|FOREGROUND_GREEN);
-			print(" %s:%i\n",p_file,p_line);
+			SetConsoleTextAttribute(hCon, FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_INTENSITY);
+			print(" %s\n", p_rationale);
 
+			SetConsoleTextAttribute(hCon, basecol);
+			print("At: ");
+
+			SetConsoleTextAttribute(hCon, FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_GREEN);
+			print(" %s:%i\n", p_file, p_line);
 
 		} else {
-			SetConsoleTextAttribute(hCon,basecol|FOREGROUND_INTENSITY);
+
+			SetConsoleTextAttribute(hCon, basecol | FOREGROUND_INTENSITY);
 			switch(p_type) {
-				case ERR_ERROR: print("ERROR: %s: ",p_function); break;
-				case ERR_WARNING: print("WARNING: %s: ",p_function); break;
-				case ERR_SCRIPT: print("SCRIPT ERROR: %s: ",p_function); break;
+				case ERR_ERROR: print("ERROR: %s: ", p_function); break;
+				case ERR_WARNING: print("WARNING: %s: ", p_function); break;
+				case ERR_SCRIPT: print("SCRIPT ERROR: %s: ", p_function); break;
 			}
-			SetConsoleTextAttribute(hCon,FOREGROUND_RED|FOREGROUND_BLUE|FOREGROUND_GREEN|FOREGROUND_INTENSITY);
-			print(" %s\n",p_code);
-			SetConsoleTextAttribute(hCon,basecol);
+
+			SetConsoleTextAttribute(hCon, FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_INTENSITY);
+			print(" %s\n", p_code);
+
+			SetConsoleTextAttribute(hCon, basecol);
 			print("At: ");
-			SetConsoleTextAttribute(hCon,FOREGROUND_RED|FOREGROUND_BLUE|FOREGROUND_GREEN);
-			print(" %s:%i\n",p_file,p_line);
+
+			SetConsoleTextAttribute(hCon, FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_GREEN);
+			print(" %s:%i\n", p_file, p_line);
 		}
 
-		SetConsoleTextAttribute(hCon,sbi.wAttributes);
+		SetConsoleTextAttribute(hCon, sbi.wAttributes);
 	}
-
 }
 
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1796,7 +1796,8 @@ void OS_Windows::print_error(const char* p_function, const char* p_file, int p_l
 		CONSOLE_SCREEN_BUFFER_INFO sbi; //original
 		GetConsoleScreenBufferInfo(hCon, &sbi);
 
-		SetConsoleTextAttribute(hCon, sbi.wAttributes);
+		WORD current_fg = sbi.wAttributes & (FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY);
+		WORD current_bg = sbi.wAttributes & (BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE | BACKGROUND_INTENSITY);
 
 		uint32_t basecol = 0;
 		switch(p_type) {
@@ -1804,6 +1805,8 @@ void OS_Windows::print_error(const char* p_function, const char* p_file, int p_l
 			case ERR_WARNING: basecol = FOREGROUND_RED | FOREGROUND_GREEN; break;
 			case ERR_SCRIPT: basecol = FOREGROUND_RED | FOREGROUND_BLUE; break;
 		}
+
+		basecol |= current_bg;
 
 		if (p_rationale && p_rationale[0]) {
 
@@ -1814,13 +1817,13 @@ void OS_Windows::print_error(const char* p_function, const char* p_file, int p_l
 				case ERR_SCRIPT: print("SCRIPT ERROR: "); break;
 			}
 
-			SetConsoleTextAttribute(hCon, FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_INTENSITY);
+			SetConsoleTextAttribute(hCon, current_fg | current_bg | FOREGROUND_INTENSITY);
 			print(" %s\n", p_rationale);
 
 			SetConsoleTextAttribute(hCon, basecol);
 			print("At: ");
 
-			SetConsoleTextAttribute(hCon, FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_GREEN);
+			SetConsoleTextAttribute(hCon, current_fg | current_bg);
 			print(" %s:%i\n", p_file, p_line);
 
 		} else {
@@ -1832,13 +1835,13 @@ void OS_Windows::print_error(const char* p_function, const char* p_file, int p_l
 				case ERR_SCRIPT: print("SCRIPT ERROR: %s: ", p_function); break;
 			}
 
-			SetConsoleTextAttribute(hCon, FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_INTENSITY);
+			SetConsoleTextAttribute(hCon, current_fg | current_bg | FOREGROUND_INTENSITY);
 			print(" %s\n", p_code);
 
 			SetConsoleTextAttribute(hCon, basecol);
 			print("At: ");
 
-			SetConsoleTextAttribute(hCon, FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_GREEN);
+			SetConsoleTextAttribute(hCon, current_fg | current_bg);
 			print(" %s:%i\n", p_file, p_line);
 		}
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1802,7 +1802,7 @@ void OS_Windows::print_error(const char* p_function, const char* p_file, int p_l
 		switch(p_type) {
 			case ERR_ERROR: basecol = FOREGROUND_RED; break;
 			case ERR_WARNING: basecol = FOREGROUND_RED | FOREGROUND_GREEN; break;
-			case ERR_SCRIPT: basecol = FOREGROUND_GREEN; break;
+			case ERR_SCRIPT: basecol = FOREGROUND_RED | FOREGROUND_BLUE; break;
 		}
 
 		if (p_rationale && p_rationale[0]) {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1786,7 +1786,7 @@ void OS_Windows::print_error(const char* p_function, const char* p_file, int p_l
 				print("     At: %s:%i\n", p_file, p_line);
 				break;
 			case ERR_SCRIPT:
-				print("SCRIPT ERROR: %s: %s", p_function, err_details);
+				print("SCRIPT ERROR: %s: %s\n", p_function, err_details);
 				print("          At: %s:%i\n", p_file, p_line);
 				break;
 		}

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1779,15 +1779,15 @@ void OS_Windows::print_error(const char* p_function, const char* p_file, int p_l
 		switch(p_type) {
 			case ERR_ERROR:
 				print("ERROR: %s: %s\n", p_function, err_details);
-				print("   At: %s:%i.\n", p_file, p_line);
+				print("   At: %s:%i\n", p_file, p_line);
 				break;
 			case ERR_WARNING:
 				print("WARNING: %s: %s\n", p_function, err_details);
-				print("     At: %s:%i.\n", p_file, p_line);
+				print("     At: %s:%i\n", p_file, p_line);
 				break;
 			case ERR_SCRIPT:
 				print("SCRIPT ERROR: %s: %s", p_function, err_details);
-				print("          At: %s:%i.\n", p_file, p_line);
+				print("          At: %s:%i\n", p_file, p_line);
 				break;
 		}
 
@@ -1818,13 +1818,17 @@ void OS_Windows::print_error(const char* p_function, const char* p_file, int p_l
 			}
 
 			SetConsoleTextAttribute(hCon, current_fg | current_bg | FOREGROUND_INTENSITY);
-			print(" %s\n", p_rationale);
+			print("%s\n", p_rationale);
 
 			SetConsoleTextAttribute(hCon, basecol);
-			print("At: ");
+			switch (p_type) {
+				case ERR_ERROR: print("   At: "); break;
+				case ERR_WARNING: print("     At: "); break;
+				case ERR_SCRIPT: print("          At: "); break;
+			}
 
 			SetConsoleTextAttribute(hCon, current_fg | current_bg);
-			print(" %s:%i\n", p_file, p_line);
+			print("%s:%i\n", p_file, p_line);
 
 		} else {
 
@@ -1836,13 +1840,17 @@ void OS_Windows::print_error(const char* p_function, const char* p_file, int p_l
 			}
 
 			SetConsoleTextAttribute(hCon, current_fg | current_bg | FOREGROUND_INTENSITY);
-			print(" %s\n", p_code);
+			print("%s\n", p_code);
 
 			SetConsoleTextAttribute(hCon, basecol);
-			print("At: ");
+			switch (p_type) {
+				case ERR_ERROR: print("   At: "); break;
+				case ERR_WARNING: print("     At: "); break;
+				case ERR_SCRIPT: print("          At: "); break;
+			}
 
 			SetConsoleTextAttribute(hCon, current_fg | current_bg);
-			print(" %s:%i\n", p_file, p_line);
+			print("%s:%i\n", p_file, p_line);
 		}
 
 		SetConsoleTextAttribute(hCon, sbi.wAttributes);

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1778,16 +1778,16 @@ void OS_Windows::print_error(const char* p_function, const char* p_file, int p_l
 
 		switch(p_type) {
 			case ERR_ERROR:
-				print("\E[1;31mERROR: %s: \E[0m\E[1m%s\n", p_function, err_details);
-				print("\E[0;31m   At: %s:%i.\E[0m\n", p_file, p_line);
+				print("ERROR: %s: %s\n", p_function, err_details);
+				print("   At: %s:%i.\n", p_file, p_line);
 				break;
 			case ERR_WARNING:
-				print("\E[1;33mWARNING: %s: \E[0m\E[1m%s\n", p_function, err_details);
-				print("\E[0;33m     At: %s:%i.\E[0m\n", p_file, p_line);
+				print("WARNING: %s: %s\n", p_function, err_details);
+				print("     At: %s:%i.\n", p_file, p_line);
 				break;
 			case ERR_SCRIPT:
-				print("\E[1;35mSCRIPT ERROR: %s: \E[0m\E[1m", p_function, err_details);
-				print("\E[0;35m          At: %s:%i.\E[0m\n", p_file, p_line);
+				print("SCRIPT ERROR: %s: %s", p_function, err_details);
+				print("          At: %s:%i.\n", p_file, p_line);
 				break;
 		}
 

--- a/platform/winrt/os_winrt.cpp
+++ b/platform/winrt/os_winrt.cpp
@@ -433,16 +433,16 @@ void OSWinrt::print_error(const char* p_function, const char* p_file, int p_line
 
 	switch(p_type) {
 		case ERR_ERROR:
-			print("\E[1;31mERROR: %s: \E[0m\E[1m%s\n", p_function, err_details);
-			print("\E[0;31m   At: %s:%i.\E[0m\n", p_file, p_line);
+			print("ERROR: %s: %s\n", p_function, err_details);
+			print("   At: %s:%i.\n", p_file, p_line);
 			break;
 		case ERR_WARNING:
-			print("\E[1;33mWARNING: %s: \E[0m\E[1m%s\n", p_function, err_details);
-			print("\E[0;33m     At: %s:%i.\E[0m\n", p_file, p_line);
+			print("WARNING: %s: %s\n", p_function, err_details);
+			print("     At: %s:%i.\n", p_file, p_line);
 			break;
 		case ERR_SCRIPT:
-			print("\E[1;35mSCRIPT ERROR: %s: \E[0m\E[1m", p_function, err_details);
-			print("\E[0;35m          At: %s:%i.\E[0m\n", p_file, p_line);
+			print("SCRIPT ERROR: %s: %s", p_function, err_details);
+			print("          At: %s:%i.\n", p_file, p_line);
 			break;
 	}
 }

--- a/platform/winrt/os_winrt.cpp
+++ b/platform/winrt/os_winrt.cpp
@@ -441,7 +441,7 @@ void OSWinrt::print_error(const char* p_function, const char* p_file, int p_line
 			print("     At: %s:%i\n", p_file, p_line);
 			break;
 		case ERR_SCRIPT:
-			print("SCRIPT ERROR: %s: %s", p_function, err_details);
+			print("SCRIPT ERROR: %s: %s\n", p_function, err_details);
 			print("          At: %s:%i\n", p_file, p_line);
 			break;
 	}

--- a/platform/winrt/os_winrt.cpp
+++ b/platform/winrt/os_winrt.cpp
@@ -423,26 +423,26 @@ void OSWinrt::get_fullscreen_mode_list(List<VideoMode> *p_list,int p_screen) con
 	
 }
 
-void OSWinrt::print_error(const char* p_function,const char* p_file,int p_line,const char *p_code,const char*p_rationale,ErrorType p_type) {
+void OSWinrt::print_error(const char* p_function, const char* p_file, int p_line, const char* p_code, const char* p_rationale, ErrorType p_type) {
 
 	const char* err_details;
 	if (p_rationale && p_rationale[0])
-		err_details=p_rationale;
+		err_details = p_rationale;
 	else
-		err_details=p_code;
+		err_details = p_code;
 
 	switch(p_type) {
 		case ERR_ERROR:
-			print("\E[1;31mERROR: %s: \E[0m\E[1m%s\n",p_function,err_details);
-			print("\E[0;31m   At: %s:%i.\E[0m\n",p_file,p_line);
+			print("\E[1;31mERROR: %s: \E[0m\E[1m%s\n", p_function, err_details);
+			print("\E[0;31m   At: %s:%i.\E[0m\n", p_file, p_line);
 			break;
 		case ERR_WARNING:
-			print("\E[1;33mWARNING: %s: \E[0m\E[1m%s\n",p_function,err_details);
-			print("\E[0;33m     At: %s:%i.\E[0m\n",p_file,p_line);
+			print("\E[1;33mWARNING: %s: \E[0m\E[1m%s\n", p_function, err_details);
+			print("\E[0;33m     At: %s:%i.\E[0m\n", p_file, p_line);
 			break;
 		case ERR_SCRIPT:
-			print("\E[1;35mSCRIPT ERROR: %s: \E[0m\E[1m",p_function,err_details);
-			print("\E[0;35m          At: %s:%i.\E[0m\n",p_file,p_line);
+			print("\E[1;35mSCRIPT ERROR: %s: \E[0m\E[1m", p_function, err_details);
+			print("\E[0;35m          At: %s:%i.\E[0m\n", p_file, p_line);
 			break;
 	}
 }

--- a/platform/winrt/os_winrt.cpp
+++ b/platform/winrt/os_winrt.cpp
@@ -434,15 +434,15 @@ void OSWinrt::print_error(const char* p_function, const char* p_file, int p_line
 	switch(p_type) {
 		case ERR_ERROR:
 			print("ERROR: %s: %s\n", p_function, err_details);
-			print("   At: %s:%i.\n", p_file, p_line);
+			print("   At: %s:%i\n", p_file, p_line);
 			break;
 		case ERR_WARNING:
 			print("WARNING: %s: %s\n", p_function, err_details);
-			print("     At: %s:%i.\n", p_file, p_line);
+			print("     At: %s:%i\n", p_file, p_line);
 			break;
 		case ERR_SCRIPT:
 			print("SCRIPT ERROR: %s: %s", p_function, err_details);
-			print("          At: %s:%i.\n", p_file, p_line);
+			print("          At: %s:%i\n", p_file, p_line);
 			break;
 	}
 }


### PR DESCRIPTION
Fixes #2811 

All wishes from @vnen and @akien-mga should be in the commits. Thanks for your guidance!

Here's how it looks like:
![godotwindowsterminalblackbackground](https://cloud.githubusercontent.com/assets/4233942/11273268/95d7884e-8ed2-11e5-9a58-3798312ae7b7.png)

And with a blue terminal:
![godotwindowsterminalbluebackground](https://cloud.githubusercontent.com/assets/4233942/11273257/83dad74a-8ed2-11e5-92d1-19f7e01070d4.png)
