### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Godot has been developed by Juan Linietsky and Ariel Manzur for several years, a
 
 ### Documentation
 
-Documentation has been moved to the [GitHub Wiki](https://github.com/okamstudio/godot/wiki).
+Documentation has been moved to the [GitHub Wiki](https://github.com/godotengine/godot/wiki).
 
 ### Binary Downloads, Community, etc.
 
@@ -22,4 +22,4 @@ http://www.godotengine.org
 ### Compiling from Source
 
 Compilation instructions for every platform can be found in the Wiki:
-https://github.com/okamstudio/godot/wiki/advanced
+https://github.com/godotengine/godot/wiki/advanced


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein
### GitHub Corrected URLs

| Was | Now |
| --- | --- |
| https://github.com/okamstudio/godot/wiki | https://github.com/godotengine/godot/wiki |
| https://github.com/okamstudio/godot/wiki/advanced | https://github.com/godotengine/godot/wiki/advanced |
