### PR TITLE
Fix help display

### DIFF
--- a/tools/editor/editor_help.cpp
+++ b/tools/editor/editor_help.cpp
@@ -1428,7 +1428,8 @@ EditorHelp::EditorHelp() {
 	{
 		Panel *pc = memnew( Panel );
 		Ref<StyleBoxFlat> style( memnew( StyleBoxFlat ) );
-		style->set_bg_color( EditorSettings::get_singleton()->get("text_editor/background_color") );	
+		style->set_bg_color( EditorSettings::get_singleton()->get("text_editor/background_color") );
+		pc->set_v_size_flags(SIZE_EXPAND_FILL);
 		pc->add_style_override("panel", style); //get_stylebox("normal","TextEdit"));
 		vbc->add_child(pc);
 		class_desc = memnew( RichTextLabel );


### PR DESCRIPTION
Currently when opening the in-editor help, nothing is displayed. This change adds the vertical expand flag to display the help again.

Fixes #2832
