### PR TITLE
Fix PopupMenu returning wrong item index

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -363,9 +363,8 @@ void PopupMenu::_input_event(const InputEvent &p_event) {
 			}
 
 			int over=_get_mouse_over(Point2(m.x,m.y));
-			int id = (over<0 || items[over].separator || items[over].disabled)?-1:items[over].ID;
 
-			if (id<0) {
+			if (over<0 || items[over].separator || items[over].disabled) {
 				mouse_over=-1;
 				update();
 				break;
@@ -517,7 +516,7 @@ void PopupMenu::add_icon_item(const Ref<Texture>& p_icon,const String& p_label,i
 	item.icon=p_icon;
 	item.text=p_label;
 	item.accel=p_accel;
-	item.ID=(p_ID<0)?idcount++:p_ID;
+	item.ID=p_ID;
 	items.push_back(item);
 	update();
 }
@@ -526,7 +525,7 @@ void PopupMenu::add_item(const String& p_label,int p_ID,uint32_t p_accel) {
 	Item item;
 	item.text=XL_MESSAGE(p_label);
 	item.accel=p_accel;
-	item.ID=(p_ID<0)?idcount++:p_ID;
+	item.ID=p_ID;
 	items.push_back(item);
 	update();
 }
@@ -535,7 +534,7 @@ void PopupMenu::add_submenu_item(const String& p_label, const String& p_submenu,
 
 	Item item;
 	item.text=XL_MESSAGE(p_label);
-	item.ID=(p_ID<0)?idcount++:p_ID;
+	item.ID=p_ID;
 	item.submenu=p_submenu;
 	items.push_back(item);
 	update();
@@ -547,7 +546,7 @@ void PopupMenu::add_icon_check_item(const Ref<Texture>& p_icon,const String& p_l
 	item.icon=p_icon;
 	item.text=XL_MESSAGE(p_label);
 	item.accel=p_accel;
-	item.ID=(p_ID<0)?idcount++:p_ID;
+	item.ID=p_ID;
 	item.checkable=true;
 	items.push_back(item);
 	update();
@@ -557,7 +556,7 @@ void PopupMenu::add_check_item(const String& p_label,int p_ID,uint32_t p_accel) 
 	Item item;
 	item.text=XL_MESSAGE(p_label);
 	item.accel=p_accel;
-	item.ID=(p_ID<0)?idcount++:p_ID;
+	item.ID=p_ID;
 	item.checkable=true;
 	items.push_back(item);
 	update();
@@ -748,7 +747,7 @@ void PopupMenu::activate_item(int p_item) {
 
 	ERR_FAIL_INDEX(p_item,items.size());
 	ERR_FAIL_COND(items[p_item].separator);
-	emit_signal("item_pressed",items[p_item].ID);
+	emit_signal("item_pressed",items[p_item].ID<0?p_item:items[p_item].ID);
 
 	//hide all parent PopupMenue's
 	Node *next = get_parent();

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -59,7 +59,6 @@ class PopupMenu : public Popup {
 	Timer *submenu_timer;
 	List<Rect2> autohide_areas;
 	Vector<Item> items;
-	int idcount;
 	int mouse_over;
 	int submenu_over;
 	Rect2 parent_rect;


### PR DESCRIPTION
It's quite hard to explain the bug, but this is a sample code to recreate it:

``` GDScript
extends Button

var menu = PopupMenu.new()

func _ready():
    add_child(menu)
    connect("pressed", menu, "popup_centered")
    menu.add_item("First", 101) # index 0
    menu.add_item("Second", 102) # index 1
    menu.add_item("Third") # index 2
    menu.connect("item_pressed", self, "_menu_item_pressed")

func _menu_item_pressed(id): # or index if the item has no id
    if id > 100:
        print(menu.get_item_index(id))
    else:
        prints(id)
```

Output:

```
0 # First
1 # Second
0 # Third! Should be 2! How can two items have the same index!?
```

This PR fixes it. I still find it confusing to use (specially when procedurally adding items to the menu), since you don't know if the parameter passed is the id or the index... IMO the best would be to pass both with the _item_pressed_ signal.
