### PR TITLE
Load main scene if defined when running editor from the command line

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -432,7 +432,6 @@ Error Main::setup(const char *execpath,int argc, char *argv[],bool p_second_phas
 		} else if (I->get()=="-e" || I->get()=="-editor") { // fonud editor
 
 			editor=true;
-			init_maximized=true;
 		} else if (I->get()=="-nowindow") { // fullscreen
 
 			OS::get_singleton()->set_no_window_mode(true);
@@ -649,6 +648,7 @@ Error Main::setup(const char *execpath,int argc, char *argv[],bool p_second_phas
 
 	if (editor) {
 		main_args.push_back("-editor");
+		init_maximized=true;
 		use_custom_res=false;
 	}
 
@@ -1093,7 +1093,7 @@ bool Main::start() {
 
 #endif
 
-	if(script=="" && game_path=="" && !editor && String(GLOBAL_DEF("application/main_scene",""))!="") {
+	if(script=="" && game_path=="" && String(GLOBAL_DEF("application/main_scene",""))!="") {
 		game_path=GLOBAL_DEF("application/main_scene","");
 	}
 

--- a/tools/editor/project_manager.cpp
+++ b/tools/editor/project_manager.cpp
@@ -624,11 +624,6 @@ void ProjectManager::_open_project_confirm() {
 
 		args.push_back("-editor");
 
-		const String &selected_main = E->get();
-		if (selected_main!="") {
-			args.push_back(selected_main);
-		}
-
 		String exec = OS::get_singleton()->get_executable_path();
 
 		OS::ProcessID pid=0;


### PR DESCRIPTION
If no main scene is defined, or if it's an empty string, the previous behaviour will still be used, i.e. launch the project manager.
A small fix was also added not to maximize the window when opening the project manager via -editor (i.e. "godot" and "godot -e" will behave the same when no project is in the path).

Fixes #2869.
