### PR TITLE
Added windows specific .gitignore for icon related change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -296,3 +296,4 @@ cscope.po.out
 godot.creator.*
 
 projects/
+platform/windows/godot_res.res


### PR DESCRIPTION
godot_res.res is showing up as a changed file when compiling for
windows.  Need to ignore it.
