### PR TITLE
Import Sub-Scene as root's child if no node is selected

### DIFF
--- a/tools/editor/scene_tree_dock.cpp
+++ b/tools/editor/scene_tree_dock.cpp
@@ -1264,7 +1264,10 @@ void SceneTreeDock::import_subscene() {
 void SceneTreeDock::_import_subscene() {
 
 	Node* parent = scene_tree->get_selected();
-	ERR_FAIL_COND(!parent);
+	if (!parent) {
+		parent = editor_data->get_edited_scene_root();
+		ERR_FAIL_COND(!parent);
+	}
 
 	import_subscene_dialog->move(parent,edited_scene);
 	editor_data->get_undo_redo().clear_history(); //no undo for now..


### PR DESCRIPTION
Related to #2386

I preferred to import the sub-scene automatically as root's child rather than showing an error. Is it fine?
