### PR TITLE
Send a text without godot serialization.

### DIFF
--- a/core/io/stream_peer.cpp
+++ b/core/io/stream_peer.cpp
@@ -29,6 +29,21 @@
 #include "stream_peer.h"
 
 
+Error StreamPeer::put_text(const Variant& p_packet) {
+
+	CharString utf8 = p_packet.operator String().utf8();
+
+	int len = utf8.length();
+
+	if (len==0)
+		return OK;
+	
+	uint8_t  *buf = (uint8_t*)alloca(len);
+	copymem(buf,utf8.get_data(),len);
+
+	return put_data(&buf[0],len);
+}
+
 Error StreamPeer::_put_data(const DVector<uint8_t>& p_data) {
 
 	int len = p_data.size();
@@ -118,6 +133,7 @@ Array StreamPeer::_get_partial_data(int p_bytes) {
 
 void StreamPeer::_bind_methods() {
 
+	ObjectTypeDB::bind_method(_MD("put_text", "var:var"),&StreamPeer::put_text);
 	ObjectTypeDB::bind_method(_MD("put_data","data"),&StreamPeer::_put_data);
 	ObjectTypeDB::bind_method(_MD("put_partial_data","data"),&StreamPeer::_put_partial_data);
 

--- a/core/io/stream_peer.h
+++ b/core/io/stream_peer.h
@@ -46,6 +46,7 @@ protected:
 
 public:
 
+	Error put_text(const Variant& p_packet);//send pure utf8 string, no godot serialization.synchronized
 	virtual Error put_data(const uint8_t* p_data,int p_bytes)=0; ///< put a whole chunk of data, blocking until it sent
 	virtual Error put_partial_data(const uint8_t* p_data,int p_bytes, int &r_sent)=0; ///< put as much data as possible, without blocking.
 


### PR DESCRIPTION
#2863

Test file .gd

```

extends Node

var server

func _ready():
    set_process(true)
    var port = 5555
    server = TCP_Server.new()

    if server.listen( port ) == 0:
        print("Server started on port " + str(port) )
        set_process( true )
    else:
        print( "Failed to start server on port " + str(port) )

func _process( delta ):
    if server.is_connection_available(): # check if someone's trying to connect
        var client = server.take_connection() # accept connection
        var rs = ""
        var cache = ""
        var end = false
        while(!end):
            cache += client.get_data(1)[1].get_string_from_utf8()
            #check end of line
            if(cache.substr(cache.length()-2,cache.length()) == "\r\n"):
                #check begin with \r\n -> end of stream
                if(cache.length()==2):
                    end = true
                else:#next line
                    rs += cache
                    cache = ""
        print(rs)
        print( "Client has connected!" )
        client.put_text( "HTTP/1.1 200 Ok\n" + "Content-Type: application/json; charset=UTF-8\n" + "Content-Length: 0\n" + "Connection: close\n" + "\r\n" )
        client.disconnect()
```
