### PR TITLE
Remember last search help term

### DIFF
--- a/tools/editor/editor_help.cpp
+++ b/tools/editor/editor_help.cpp
@@ -36,6 +36,14 @@
 
 #include "os/keyboard.h"
 
+void EditorHelpSearch::popup() {
+	popup_centered_ratio(0.6);
+	if (search_box->get_text()!="") {
+		search_box->select_all();
+		_update_search();
+	}
+	search_box->grab_focus();
+}
 
 void EditorHelpSearch::popup(const String& p_term) {
 

--- a/tools/editor/editor_help.h
+++ b/tools/editor/editor_help.h
@@ -68,7 +68,8 @@ protected:
 	static void _bind_methods();
 public:
 
-	void popup(const String& p_term="");
+	void popup();
+	void popup(const String& p_term);
 
 	EditorHelpSearch();
 };

--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -881,7 +881,7 @@ void ScriptEditor::_menu_option(int p_option) {
 		} break;
 		case SEARCH_HELP: {
 
-			help_search_dialog->popup("current");
+			help_search_dialog->popup();
 		} break;
 		case SEARCH_CLASSES: {
 


### PR DESCRIPTION
After 081a236, the search term was always set to "current" when opening the search help dialog.
