### PR TITLE
Fix bugs caused by merged Script and Help tabs

### DIFF
--- a/tools/editor/editor_help.cpp
+++ b/tools/editor/editor_help.cpp
@@ -263,7 +263,7 @@ void EditorHelpSearch::_confirmed() {
 
 	String mdata=ti->get_metadata(0);
 	emit_signal("go_to_help",mdata);
-	editor->call("_editor_select",3); // in case EditorHelpSearch beeen invoked on top of other editor window
+	editor->call("_editor_select",2); // in case EditorHelpSearch beeen invoked on top of other editor window
 	// go to that
 	hide();
 }
@@ -1049,7 +1049,7 @@ Error EditorHelp::_goto_desc(const String& p_class,int p_vscr) {
 void EditorHelp::_request_help(const String& p_string) {
 	Error err = _goto_desc(p_string);
 	if (err==OK) {
-		editor->call("_editor_select",3);
+		editor->call("_editor_select",2);
 	}
 	//100 palabras
 }

--- a/tools/editor/editor_help.cpp
+++ b/tools/editor/editor_help.cpp
@@ -1350,7 +1350,6 @@ void EditorHelp::_notification(int p_what) {
 //			forward->set_icon(get_icon("Forward","EditorIcons"));
 //			back->set_icon(get_icon("Back","EditorIcons"));
 			_update_doc();
-			editor->connect("request_help",this,"_request_help");
 
 		} break;
 	}

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -169,9 +169,18 @@ void EditorNode::_unhandled_input(const InputEvent& p_event) {
 				if (!p_event.key.mod.shift && !p_event.key.mod.command)
 					_editor_select(3);
 			break;*/
-			case KEY_F1: _editor_select(0); break;
-			case KEY_F2: _editor_select(1); break;
-			case KEY_F3: _editor_select(2); break;
+			case KEY_F1:
+				if (!p_event.key.mod.shift && !p_event.key.mod.command)
+					_editor_select(0);
+			break;
+			case KEY_F2:
+				if (!p_event.key.mod.shift && !p_event.key.mod.command)
+					_editor_select(1);
+			break;
+			case KEY_F3:
+				if (!p_event.key.mod.shift && !p_event.key.mod.command)
+					_editor_select(2);
+			break;
 			case KEY_F5: _menu_option_confirm((p_event.key.mod.control&&p_event.key.mod.shift)?RUN_PLAY_CUSTOM_SCENE:RUN_PLAY,true); break;
 			case KEY_F6: _menu_option_confirm(RUN_PLAY_SCENE,true); break;
 			case KEY_F7: _menu_option_confirm(RUN_PAUSE,true); break;
@@ -2519,7 +2528,7 @@ void EditorNode::_menu_option_confirm(int p_option,bool p_confirmed) {
 		case OBJECT_REQUEST_HELP: {
 
 			if (current) {
-				_editor_select(3);
+				_editor_select(2);
 				emit_signal("request_help",current->get_type());
 			}
 

--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -1388,6 +1388,7 @@ void ScriptEditor::_notification(int p_what) {
 	if (p_what==NOTIFICATION_READY) {
 
 		get_tree()->connect("tree_changed",this,"_tree_changed");
+		editor->connect("request_help",this,"_request_help");
 	}
 
 	if (p_what==NOTIFICATION_EXIT_TREE) {
@@ -2205,6 +2206,7 @@ void ScriptEditor::_bind_methods() {
 	ObjectTypeDB::bind_method("_script_split_dragged",&ScriptEditor::_script_split_dragged);
 	ObjectTypeDB::bind_method("_help_class_open",&ScriptEditor::_help_class_open);
 	ObjectTypeDB::bind_method("_help_class_goto",&ScriptEditor::_help_class_goto);
+	ObjectTypeDB::bind_method("_request_help",&ScriptEditor::_help_class_open);
 	ObjectTypeDB::bind_method("_history_forward",&ScriptEditor::_history_forward);
 	ObjectTypeDB::bind_method("_history_back",&ScriptEditor::_history_back);
 }


### PR DESCRIPTION
Fixed the following bugs (regressions from 081a236):
- Fixes #2807
- Fixes #2844 (applied the same change to F2 and F3).
- Fixes the Class Reference in the Inspector (_Object properties_ -> _Class Reference_), which also stopped working after that commit.
