### PR TITLE
Print errors  to console when exporting

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -3857,7 +3857,8 @@ bool EditorNode::_find_editing_changed_scene(Node *p_from) {
 
 
 void EditorNode::add_io_error(const String& p_error) {
-
+	CharString err_ut = p_error.utf8();
+	ERR_PRINT(err_ut.get_data());
 	_load_error_notify(singleton,p_error);
 }
 

--- a/tools/editor/project_export.cpp
+++ b/tools/editor/project_export.cpp
@@ -491,6 +491,18 @@ Error ProjectExportDialog::export_platform(const String& p_platform, const Strin
 	Ref<EditorExportPlatform> exporter = EditorImportExport::get_singleton()->get_export_platform(p_platform);
 	if (exporter.is_null()) {
 		ERR_PRINT("Invalid platform for export");
+
+		List<StringName> platforms;
+		EditorImportExport::get_singleton()->get_export_platforms(&platforms);
+		print_line("Valid export plaftorms are:");
+		for (List<StringName>::Element *E=platforms.front();E;E=E->next())
+			print_line("    \""+E->get()+"\"");
+
+		if (p_quit_after) {
+			OS::get_singleton()->set_exit_code(255);
+			get_tree()->quit();
+		}
+
 		return ERR_INVALID_PARAMETER;
 	}
 	Error err = exporter->export_project(p_path,p_debug);


### PR DESCRIPTION
Fixes #1757 (at least I hope so).

Also exit and print a list of valid export platforms when
the supplied platform was not found.
