### PR TITLE
Print error if no export destination has been passed

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1086,6 +1086,17 @@ bool Main::start() {
 
 #endif
 
+	if (_export_platform!="") {
+		if (game_path=="") {
+			String err="Command line param ";
+			err+=export_debug?"-export_debug":"-export";
+			err+=" passed but no destination path given.\n";
+			err+="Please specify the binary's file path to export to. Aborting export.";
+			ERR_PRINT(err.utf8().get_data());
+			return false;
+		}
+	}
+
 	if(script=="" && game_path=="" && String(GLOBAL_DEF("application/main_scene",""))!="") {
 		game_path=GLOBAL_DEF("application/main_scene","");
 	}


### PR DESCRIPTION
Closes #2843.

Its not perfect, as it should probably also check whether one wants to export into the project folder, but that check can be added later on as well.
Such a change can then also improve the check in project_export.cpp method `ProjectExportDialog::_export_action`.
