### PR TITLE
fixed crash when creating new object with wrong number of arguments (rebased)

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -970,7 +970,10 @@ void Object::set_script_instance(ScriptInstance *p_instance) {
 
 	script_instance=p_instance;
 
-	script=p_instance->get_script().get_ref_ptr();
+	if (p_instance)
+		script=p_instance->get_script().get_ref_ptr();
+	else
+		script=RefPtr();
 }
 
 RefPtr Object::get_script() const {


### PR DESCRIPTION
If .new() call fails engine crashes while accessing null pointer.

Repro is here:
https://github.com/koalefant/godot-bug-new-arguments

Fixes #2280 

(Previous pull request: https://github.com/godotengine/godot/pull/2935)
