### PR TITLE
Break into GDScript debugger when new() fails

### DIFF
--- a/modules/gdscript/gd_script.h
+++ b/modules/gdscript/gd_script.h
@@ -286,7 +286,7 @@ friend class GDScriptLanguage;
 	String name;
 
 
-	GDInstance* _create_instance(const Variant** p_args,int p_argcount,Object *p_owner,bool p_isref);
+	GDInstance* _create_instance(const Variant** p_args,int p_argcount,Object *p_owner,bool p_isref,Variant::CallError &r_error);
 
 	void _set_subclass_path(Ref<GDScript>& p_sc,const String& p_path);
 


### PR DESCRIPTION
This works with this repro: https://github.com/koalefant/godot-bug-new-arguments
I am testing during regular usage now...

This should conclude my previous change: https://github.com/godotengine/godot/pull/2937
