### PR TITLE
Add ability to set "keep screen on" for android & iOS. fixes #2428

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -708,6 +708,15 @@ _OS::ScreenOrientation _OS::get_screen_orientation() const {
 	return ScreenOrientation(OS::get_singleton()->get_screen_orientation());
 }
 
+void _OS::set_keep_screen_on(bool p_enabled) {
+
+	OS::get_singleton()->set_keep_screen_on(p_enabled);
+}
+
+bool _OS::is_keep_screen_on() const {
+
+	return OS::get_singleton()->is_keep_screen_on();
+}
 
 String _OS::get_system_dir(SystemDir p_dir) const {
 
@@ -775,6 +784,8 @@ void _OS::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_screen_orientation","orientation"),&_OS::set_screen_orientation);
 	ObjectTypeDB::bind_method(_MD("get_screen_orientation"),&_OS::get_screen_orientation);
 
+	ObjectTypeDB::bind_method(_MD("set_keep_screen_on","enabled"),&_OS::set_keep_screen_on);
+	ObjectTypeDB::bind_method(_MD("is_keep_screen_on"),&_OS::is_keep_screen_on);
 
 	ObjectTypeDB::bind_method(_MD("set_iterations_per_second","iterations_per_second"),&_OS::set_iterations_per_second);
 	ObjectTypeDB::bind_method(_MD("get_iterations_per_second"),&_OS::get_iterations_per_second);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -262,6 +262,9 @@ public:
 	void set_screen_orientation(ScreenOrientation p_orientation);
 	ScreenOrientation get_screen_orientation() const;
 
+	void set_keep_screen_on(bool p_enabled);
+	bool is_keep_screen_on() const;
+
 	void set_time_scale(float p_scale);
 	float get_time_scale();
 

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -112,6 +112,14 @@ float OS::get_target_fps() const {
 	return _target_fps;
 }
 
+void OS::set_keep_screen_on(bool p_enabled) {
+	_keep_screen_on=p_enabled;
+}
+
+bool OS::is_keep_screen_on() const {
+	return _keep_screen_on;
+}
+
 void OS::set_low_processor_usage_mode(bool p_enabled) {
 
 	low_processor_usage_mode=p_enabled;
@@ -513,6 +521,7 @@ OS::OS() {
 	frames_drawn=0;
 	singleton=this;
 	ips=60;
+	_keep_screen_on=true; // set default value to true, because this had been true before godot 2.0.
 	low_processor_usage_mode=false;
 	_verbose_stdout=false;
 	_frame_delay=0;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -46,6 +46,7 @@ class OS {
 	String _custom_level;
 	List<String> _cmdline;
 	int ips;
+	bool _keep_screen_on;
 	bool low_processor_usage_mode;
 	bool _verbose_stdout;
 	String _local_clipboard;
@@ -180,7 +181,8 @@ public:
 
 	virtual float get_frames_per_second() const { return _fps; };
 
-
+	virtual void set_keep_screen_on(bool p_enabled);
+	virtual bool is_keep_screen_on() const;
 	virtual void set_low_processor_usage_mode(bool p_enabled);
 	virtual bool is_in_low_processor_usage_mode() const;
 

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -19151,6 +19151,19 @@ returns:= "username=user&amp;password=pass"
 			<description>
 			</description>
 		</method>
+		<method name="set_keep_screen_on">
+			<argument index="0" name="enabled" type="bool">
+			</argument>
+			<description>
+			Set keep screen on if true, or goes to sleep by device setting if false. (for Android/iOS)
+			</description>
+		</method>
+		<method name="is_keep_screen_on" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="set_iterations_per_second">
 			<argument index="0" name="iterations_per_second" type="int">
 			</argument>

--- a/drivers/gles2/rasterizer_gles2.h
+++ b/drivers/gles2/rasterizer_gles2.h
@@ -91,6 +91,7 @@ class RasterizerGLES2 : public Rasterizer {
 	bool srgb_supported;
 	bool float_supported;
 	bool float_linear_supported;
+	bool use_16bits_fbo;
 
 	ShadowFilterTechnique shadow_filter;
 
@@ -1704,6 +1705,8 @@ public:
 	virtual void restore_framebuffer();
 
 	static RasterizerGLES2* get_singleton();
+
+	virtual void set_force_16_bits_fbo(bool p_force);
 
 	RasterizerGLES2(bool p_compress_arrays=false,bool p_keep_ram_copy=true,bool p_default_fragment_lighting=true,bool p_use_reload_hooks=false);
 	virtual ~RasterizerGLES2();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -702,6 +702,7 @@ Error Main::setup(const char *execpath,int argc, char *argv[],bool p_second_phas
 	GLOBAL_DEF("display/test_width",0);
 	GLOBAL_DEF("display/test_height",0);
 	OS::get_singleton()->_pixel_snap=GLOBAL_DEF("display/use_2d_pixel_snap",false);
+	OS::get_singleton()->_keep_screen_on=GLOBAL_DEF("display/set_keep_screen_on",true);
 	if (rtm==-1) {
 		rtm=GLOBAL_DEF("render/thread_model",OS::RENDER_THREAD_SAFE);
 		if (rtm>=1) //hack for now

--- a/platform/android/java/src/com/android/godot/Godot.java
+++ b/platform/android/java/src/com/android/godot/Godot.java
@@ -113,6 +113,7 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
     private boolean use_immersive=false;
     private boolean mStatePaused;
     private int mState;
+	private boolean keep_screen_on=true;
 
     private void setState(int newState) {
         if (mState != newState) {
@@ -259,7 +260,7 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 		
 		mView = new GodotView(getApplication(),io,use_gl2,use_32_bits, this);
 		layout.addView(mView,new LayoutParams(LayoutParams.FILL_PARENT,LayoutParams.FILL_PARENT));
-		mView.setKeepScreenOn(true);
+		setKeepScreenOn(GodotLib.getGlobal("display/set_keep_screen_on").equals("True"));
 		
         edittext.setView(mView);
         io.setEdit(edittext);
@@ -270,7 +271,19 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 		layout.addView(adLayout);
 		
 	}
-
+	
+	public void setKeepScreenOn(final boolean p_enabled) {
+		keep_screen_on = p_enabled;
+		if (mView != null){
+			runOnUiThread(new Runnable() {
+				@Override
+				public void run() {
+					mView.setKeepScreenOn(p_enabled);
+				}
+			});
+		}
+	}
+	
 	private static Godot _self;
 	
 	public static Godot getInstance(){
@@ -385,8 +398,8 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 		super.onCreate(icicle);
 		_self = this;
 		Window window = getWindow();
-		window.addFlags(WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
-			| WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+		//window.addFlags(WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON | WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+		window.addFlags(WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
 
 
 		//check for apk expansion API

--- a/platform/android/java/src/com/android/godot/GodotLib.java
+++ b/platform/android/java/src/com/android/godot/GodotLib.java
@@ -46,7 +46,7 @@ public class GodotLib {
 
      public static native void initialize(Godot p_instance,boolean need_reload_hook,String[] p_cmdline,Object p_asset_manager);
      public static native void resize(int width, int height,boolean reload);
-     public static native void newcontext();
+     public static native void newcontext(boolean p_32_bits);
      public static native void quit();
      public static native void step();
      public static native void touch(int what,int pointer,int howmany, int[] arr);

--- a/platform/android/java/src/com/android/godot/GodotView.java
+++ b/platform/android/java/src/com/android/godot/GodotView.java
@@ -425,6 +425,7 @@ public class GodotView extends GLSurfaceView {
 			if (ec == null) {
 	  			Log.w(TAG, "Trying ConfigChooser fallback");
 	  			ec = fallback.chooseConfig(egl, display, configs);
+				use_32=false;
 			}
 			return ec;
       		}
@@ -654,7 +655,7 @@ public class GodotView extends GLSurfaceView {
 		}
 
 		public void onSurfaceCreated(GL10 gl, EGLConfig config) {
-			GodotLib.newcontext();
+			GodotLib.newcontext(use_32);
 		}
 	}
 }

--- a/platform/android/java_glue.cpp
+++ b/platform/android/java_glue.cpp
@@ -920,13 +920,19 @@ JNIEXPORT void JNICALL Java_com_android_godot_GodotLib_resize(JNIEnv * env, jobj
 
 }
 
-JNIEXPORT void JNICALL Java_com_android_godot_GodotLib_newcontext(JNIEnv * env, jobject obj) {
+JNIEXPORT void JNICALL Java_com_android_godot_GodotLib_newcontext(JNIEnv * env, jobject obj,bool p_32_bits) {
 
 	__android_log_print(ANDROID_LOG_INFO,"godot","^_^_^_^_^ newcontext %lld\n",Thread::get_caller_ID());
+
+	if (os_android) {
+		os_android->set_context_is_16_bits(!p_32_bits);
+	}
+
 	if (os_android && step > 0) {
 
 		os_android->reload_gfx();
 	}
+
 
 }
 

--- a/platform/android/java_glue.cpp
+++ b/platform/android/java_glue.cpp
@@ -671,7 +671,7 @@ static jmethodID _playVideo=0;
 static jmethodID _isVideoPlaying=0;
 static jmethodID _pauseVideo=0;
 static jmethodID _stopVideo=0;
-
+static jmethodID _setKeepScreenOn=0;
 
 static void _gfx_init_func(void* ud, bool gl2) {
 
@@ -765,6 +765,11 @@ static void _stop_video() {
 	env->CallVoidMethod(godot_io, _stopVideo);
 }
 
+static void _set_keep_screen_on(bool p_enabled) {
+	JNIEnv* env = ThreadAndroid::get_env();
+	env->CallVoidMethod(_godot_instance, _setKeepScreenOn, p_enabled);
+}
+
 JNIEXPORT void JNICALL Java_com_android_godot_GodotLib_initialize(JNIEnv * env, jobject obj, jobject activity,jboolean p_need_reload_hook, jobjectArray p_cmdline,jobject p_asset_manager) {
 
 	__android_log_print(ANDROID_LOG_INFO,"godot","**INIT EVENT! - %p\n",env);
@@ -801,6 +806,7 @@ JNIEXPORT void JNICALL Java_com_android_godot_GodotLib_initialize(JNIEnv * env, 
 		godot_io=gob;
 
 		_on_video_init = env->GetMethodID(cls, "onVideoInit", "(Z)V");
+		_setKeepScreenOn = env->GetMethodID(cls,"setKeepScreenOn","(Z)V");
 
 		jclass clsio = env->FindClass("com/android/godot/Godot");
 		if (cls) {
@@ -863,7 +869,7 @@ JNIEXPORT void JNICALL Java_com_android_godot_GodotLib_initialize(JNIEnv * env, 
 
 	__android_log_print(ANDROID_LOG_INFO,"godot","CMDLINE LEN %i - APK EXPANSION %I\n",cmdlen,int(use_apk_expansion));
 
-	os_android = new OS_Android(_gfx_init_func,env,_open_uri,_get_data_dir,_get_locale, _get_model,_show_vk, _hide_vk,_set_screen_orient,_get_unique_id, _get_system_dir, _play_video,_is_video_playing, _pause_video, _stop_video,use_apk_expansion);
+	os_android = new OS_Android(_gfx_init_func,env,_open_uri,_get_data_dir,_get_locale, _get_model,_show_vk, _hide_vk,_set_screen_orient,_get_unique_id, _get_system_dir, _play_video,_is_video_playing, _pause_video, _stop_video, _set_keep_screen_on, use_apk_expansion);
 	os_android->set_need_reload_hooks(p_need_reload_hook);
 
 	char wd[500];

--- a/platform/android/java_glue.h
+++ b/platform/android/java_glue.h
@@ -38,7 +38,7 @@
 extern "C" {
     JNIEXPORT void JNICALL Java_com_android_godot_GodotLib_initialize(JNIEnv * env, jobject obj, jobject activity,jboolean p_need_reload_hook, jobjectArray p_cmdline,jobject p_asset_manager);
     JNIEXPORT void JNICALL Java_com_android_godot_GodotLib_resize(JNIEnv * env, jobject obj,  jint width, jint height, jboolean reload);
-    JNIEXPORT void JNICALL Java_com_android_godot_GodotLib_newcontext(JNIEnv * env, jobject obj);
+    JNIEXPORT void JNICALL Java_com_android_godot_GodotLib_newcontext(JNIEnv * env, jobject obj, bool p_32_bits);
     JNIEXPORT void JNICALL Java_com_android_godot_GodotLib_step(JNIEnv * env, jobject obj);
     JNIEXPORT void JNICALL Java_com_android_godot_GodotLib_quit(JNIEnv * env, jobject obj);
     JNIEXPORT void JNICALL Java_com_android_godot_GodotLib_touch(JNIEnv * env, jobject obj, jint ev,jint pointer, jint count, jintArray positions);

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -302,6 +302,14 @@ void OS_Android::get_fullscreen_mode_list(List<VideoMode> *p_list,int p_screen) 
 	p_list->push_back(default_videomode);
 }
 
+void OS_Android::set_keep_screen_on(bool p_enabled) {
+	OS::set_keep_screen_on(p_enabled);
+	
+	if (set_keep_screen_on_func) {
+		set_keep_screen_on_func(p_enabled);
+	}
+}
+
 Size2 OS_Android::get_window_size() const {
 
 	return Vector2(default_videomode.width,default_videomode.height);
@@ -734,7 +742,7 @@ void OS_Android::set_context_is_16_bits(bool p_is_16) {
 		rasterizer->set_force_16_bits_fbo(p_is_16);
 }
 
-OS_Android::OS_Android(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetDataDirFunc p_get_data_dir_func,GetLocaleFunc p_get_locale_func,GetModelFunc p_get_model_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk,  SetScreenOrientationFunc p_screen_orient,GetUniqueIDFunc p_get_unique_id,GetSystemDirFunc p_get_sdir_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func,bool p_use_apk_expansion) {
+OS_Android::OS_Android(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetDataDirFunc p_get_data_dir_func,GetLocaleFunc p_get_locale_func,GetModelFunc p_get_model_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk,  SetScreenOrientationFunc p_screen_orient,GetUniqueIDFunc p_get_unique_id,GetSystemDirFunc p_get_sdir_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func, SetKeepScreenOnFunc p_set_keep_screen_on_func, bool p_use_apk_expansion) {
 
 
 	use_apk_expansion=p_use_apk_expansion;
@@ -767,6 +775,7 @@ OS_Android::OS_Android(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, OpenURIFu
 	hide_virtual_keyboard_func = p_hide_vk;
 
 	set_screen_orientation_func=p_screen_orient;
+	set_keep_screen_on_func = p_set_keep_screen_on_func;
 	use_reload_hooks=false;
 
 }

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -141,6 +141,8 @@ void OS_Android::initialize(const VideoMode& p_desired,int p_video_driver,int p_
 
 	}
 
+	rasterizer->set_force_16_bits_fbo(use_16bits_fbo);
+
 	visual_server = memnew( VisualServerRaster(rasterizer) );
 	if (get_render_thread_mode() != RENDER_THREAD_UNSAFE) {
 
@@ -723,6 +725,13 @@ String OS_Android::get_system_dir(SystemDir p_dir) const {
 void OS_Android::native_video_stop() {
 	if (video_stop_func)
 		video_stop_func();
+}
+
+void OS_Android::set_context_is_16_bits(bool p_is_16) {
+
+	use_16bits_fbo=p_is_16;
+	if (rasterizer)
+		rasterizer->set_force_16_bits_fbo(p_is_16);
 }
 
 OS_Android::OS_Android(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetDataDirFunc p_get_data_dir_func,GetLocaleFunc p_get_locale_func,GetModelFunc p_get_model_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk,  SetScreenOrientationFunc p_screen_orient,GetUniqueIDFunc p_get_unique_id,GetSystemDirFunc p_get_sdir_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func,bool p_use_apk_expansion) {

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -300,6 +300,14 @@ void OS_Android::get_fullscreen_mode_list(List<VideoMode> *p_list,int p_screen) 
 	p_list->push_back(default_videomode);
 }
 
+void OS_Android::set_keep_screen_on(bool p_enabled) {
+	OS::set_keep_screen_on(p_enabled);
+	
+	if (set_keep_screen_on_func) {
+		set_keep_screen_on_func(p_enabled);
+	}
+}
+
 Size2 OS_Android::get_window_size() const {
 
 	return Vector2(default_videomode.width,default_videomode.height);
@@ -725,7 +733,7 @@ void OS_Android::native_video_stop() {
 		video_stop_func();
 }
 
-OS_Android::OS_Android(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetDataDirFunc p_get_data_dir_func,GetLocaleFunc p_get_locale_func,GetModelFunc p_get_model_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk,  SetScreenOrientationFunc p_screen_orient,GetUniqueIDFunc p_get_unique_id,GetSystemDirFunc p_get_sdir_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func,bool p_use_apk_expansion) {
+OS_Android::OS_Android(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetDataDirFunc p_get_data_dir_func,GetLocaleFunc p_get_locale_func,GetModelFunc p_get_model_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk,  SetScreenOrientationFunc p_screen_orient,GetUniqueIDFunc p_get_unique_id,GetSystemDirFunc p_get_sdir_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func, SetKeepScreenOnFunc p_set_keep_screen_on_func, bool p_use_apk_expansion) {
 
 
 	use_apk_expansion=p_use_apk_expansion;
@@ -758,6 +766,7 @@ OS_Android::OS_Android(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, OpenURIFu
 	hide_virtual_keyboard_func = p_hide_vk;
 
 	set_screen_orientation_func=p_screen_orient;
+	set_keep_screen_on_func = p_set_keep_screen_on_func;
 	use_reload_hooks=false;
 
 }

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -95,6 +95,8 @@ private:
 	bool use_reload_hooks;
 	bool use_apk_expansion;
 
+	bool use_16bits_fbo;
+
 	Rasterizer *rasterizer;
 	VisualServer *visual_server;
 	AudioServerSW *audio_server;
@@ -200,6 +202,7 @@ public:
 	void set_display_size(Size2 p_size);
 
 	void reload_gfx();
+	void set_context_is_16_bits(bool p_is_16);
 
 	void set_need_reload_hooks(bool p_needs_them);
 	virtual void set_screen_orientation(ScreenOrientation p_orientation);

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -73,6 +73,7 @@ typedef void (*VideoPlayFunc)(const String&);
 typedef bool (*VideoIsPlayingFunc)();
 typedef void (*VideoPauseFunc)();
 typedef void (*VideoStopFunc)();
+typedef void (*SetKeepScreenOnFunc)(bool p_enabled);
 
 class OS_Android : public OS_Unix {
 public:
@@ -132,6 +133,7 @@ private:
 	VideoIsPlayingFunc video_is_playing_func;
 	VideoPauseFunc video_pause_func;
 	VideoStopFunc video_stop_func;
+	SetKeepScreenOnFunc set_keep_screen_on_func;
 
 public:
 
@@ -175,7 +177,9 @@ public:
 	virtual void set_video_mode(const VideoMode& p_video_mode,int p_screen=0);
 	virtual VideoMode get_video_mode(int p_screen=0) const;
 	virtual void get_fullscreen_mode_list(List<VideoMode> *p_list,int p_screen=0) const;
-
+	
+	virtual void set_keep_screen_on(bool p_enabled);
+	
 	virtual Size2 get_window_size() const;
 
 	virtual String get_name();
@@ -228,7 +232,7 @@ public:
 	virtual void native_video_pause();
 	virtual void native_video_stop();
 
-	OS_Android(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetDataDirFunc p_get_data_dir_func,GetLocaleFunc p_get_locale_func,GetModelFunc p_get_model_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk,  SetScreenOrientationFunc p_screen_orient,GetUniqueIDFunc p_get_unique_id,GetSystemDirFunc p_get_sdir_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func,bool p_use_apk_expansion);
+	OS_Android(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetDataDirFunc p_get_data_dir_func,GetLocaleFunc p_get_locale_func,GetModelFunc p_get_model_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk,  SetScreenOrientationFunc p_screen_orient,GetUniqueIDFunc p_get_unique_id,GetSystemDirFunc p_get_sdir_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func, SetKeepScreenOnFunc p_set_keep_screen_on_func, bool p_use_apk_expansion);
 	~OS_Android();
 
 };

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -73,6 +73,7 @@ typedef void (*VideoPlayFunc)(const String&);
 typedef bool (*VideoIsPlayingFunc)();
 typedef void (*VideoPauseFunc)();
 typedef void (*VideoStopFunc)();
+typedef void (*SetKeepScreenOnFunc)(bool p_enabled);
 
 class OS_Android : public OS_Unix {
 public:
@@ -130,6 +131,7 @@ private:
 	VideoIsPlayingFunc video_is_playing_func;
 	VideoPauseFunc video_pause_func;
 	VideoStopFunc video_stop_func;
+	SetKeepScreenOnFunc set_keep_screen_on_func;
 
 public:
 
@@ -173,7 +175,9 @@ public:
 	virtual void set_video_mode(const VideoMode& p_video_mode,int p_screen=0);
 	virtual VideoMode get_video_mode(int p_screen=0) const;
 	virtual void get_fullscreen_mode_list(List<VideoMode> *p_list,int p_screen=0) const;
-
+	
+	virtual void set_keep_screen_on(bool p_enabled);
+	
 	virtual Size2 get_window_size() const;
 
 	virtual String get_name();
@@ -225,7 +229,7 @@ public:
 	virtual void native_video_pause();
 	virtual void native_video_stop();
 
-	OS_Android(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetDataDirFunc p_get_data_dir_func,GetLocaleFunc p_get_locale_func,GetModelFunc p_get_model_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk,  SetScreenOrientationFunc p_screen_orient,GetUniqueIDFunc p_get_unique_id,GetSystemDirFunc p_get_sdir_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func,bool p_use_apk_expansion);
+	OS_Android(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetDataDirFunc p_get_data_dir_func,GetLocaleFunc p_get_locale_func,GetModelFunc p_get_model_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk,  SetScreenOrientationFunc p_screen_orient,GetUniqueIDFunc p_get_unique_id,GetSystemDirFunc p_get_sdir_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func, SetKeepScreenOnFunc p_set_keep_screen_on_func, bool p_use_apk_expansion);
 	~OS_Android();
 
 };

--- a/platform/iphone/app_delegate.mm
+++ b/platform/iphone/app_delegate.mm
@@ -57,6 +57,7 @@
 #endif
 
 Error _shell_open(String);
+void _set_keep_screen_on(bool p_enabled);
 
 Error _shell_open(String p_uri) {
 	NSString* url = [[NSString alloc] initWithUTF8String:p_uri.utf8().get_data()];
@@ -68,6 +69,10 @@ Error _shell_open(String p_uri) {
 	[[UIApplication sharedApplication] openURL:[NSURL URLWithString:url]];
 	[url release];
 	return OK;
+};
+
+void _set_keep_screen_on(bool p_enabled) {
+    [[UIApplication sharedApplication] setIdleTimerDisabled:(BOOL)p_enabled];
 };
 
 @implementation AppDelegate
@@ -212,8 +217,8 @@ static int frame_count = 0;
 
 	[application setStatusBarHidden:YES withAnimation:UIStatusBarAnimationNone];
 	// disable idle timer
-	application.idleTimerDisabled = YES;
-
+	//application.idleTimerDisabled = YES;
+    
 	//Create a full-screen window
 	window = [[UIWindow alloc] initWithFrame:rect];
 	//window.autoresizesSubviews = YES;
@@ -238,6 +243,7 @@ static int frame_count = 0;
 	view_controller.view = glView;
 	window.rootViewController = view_controller;
 
+    _set_keep_screen_on(bool(GLOBAL_DEF("display/set_keep_screen_on",true)) ? YES : NO);
 	glView.useCADisplayLink = bool(GLOBAL_DEF("display.iOS/use_cadisplaylink",true)) ? YES : NO;
 	printf("cadisaplylink: %d", glView.useCADisplayLink);
 	glView.animationInterval = 1.0 / kRenderingFrequency;

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -452,6 +452,7 @@ bool OSIPhone::has_virtual_keyboard() const {
 extern void _show_keyboard(String p_existing);
 extern void _hide_keyboard();
 extern Error _shell_open(String p_uri);
+extern void _set_keep_screen_on(bool p_enabled);
 
 void OSIPhone::show_virtual_keyboard(const String& p_existing_text,const Rect2& p_screen_rect) {
 	_show_keyboard(p_existing_text);
@@ -465,6 +466,10 @@ Error OSIPhone::shell_open(String p_uri) {
 	return _shell_open(p_uri);
 };
 
+void OSIPhone::set_keep_screen_on(bool p_enabled) {
+    OS::set_keep_screen_on(p_enabled);
+    _set_keep_screen_on(p_enabled);
+};
 
 void OSIPhone::set_cursor_shape(CursorShape p_shape) {
 

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -166,6 +166,8 @@ public:
 	virtual void set_video_mode(const VideoMode& p_video_mode,int p_screen=0);
 	virtual VideoMode get_video_mode(int p_screen=0) const;
 	virtual void get_fullscreen_mode_list(List<VideoMode> *p_list,int p_screen=0) const;
+    
+    virtual void set_keep_screen_on(bool p_enabled);
 
 	virtual bool can_draw() const;
 

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -329,6 +329,16 @@ void ImageTexture::normal_to_xy() {
 	create_from_image(img,flags);
 }
 
+void ImageTexture::shrink_x2_and_keep_size() {
+
+	Size2 sizeov=get_size();
+	Image img = get_data();
+	img.resize(img.get_width()/2,img.get_height()/2,Image::INTERPOLATE_BILINEAR);
+	create_from_image(img,flags);
+	set_size_override(sizeov);
+
+}
+
 bool ImageTexture::has_alpha() const {
 
 	return ( format==Image::FORMAT_GRAYSCALE_ALPHA || format==Image::FORMAT_INDEXED_ALPHA || format==Image::FORMAT_RGBA );
@@ -424,10 +434,13 @@ void ImageTexture::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("fix_alpha_edges"),&ImageTexture::fix_alpha_edges);
 	ObjectTypeDB::bind_method(_MD("premultiply_alpha"),&ImageTexture::premultiply_alpha);
 	ObjectTypeDB::bind_method(_MD("normal_to_xy"),&ImageTexture::normal_to_xy);
+	ObjectTypeDB::bind_method(_MD("shrink_x2_and_keep_size"),&ImageTexture::shrink_x2_and_keep_size);
+
 	ObjectTypeDB::bind_method(_MD("set_size_override","size"),&ImageTexture::set_size_override);
 	ObjectTypeDB::set_method_flags(get_type_static(),_SCS("fix_alpha_edges"),METHOD_FLAGS_DEFAULT|METHOD_FLAG_EDITOR);
 	ObjectTypeDB::set_method_flags(get_type_static(),_SCS("premultiply_alpha"),METHOD_FLAGS_DEFAULT|METHOD_FLAG_EDITOR);
 	ObjectTypeDB::set_method_flags(get_type_static(),_SCS("normal_to_xy"),METHOD_FLAGS_DEFAULT|METHOD_FLAG_EDITOR);
+	ObjectTypeDB::set_method_flags(get_type_static(),_SCS("shrink_x2_and_keep_size"),METHOD_FLAGS_DEFAULT|METHOD_FLAG_EDITOR);
 	ObjectTypeDB::bind_method(_MD("_reload_hook","rid"),&ImageTexture::_reload_hook);
 
 

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -148,6 +148,7 @@ public:
 	void fix_alpha_edges();
 	void premultiply_alpha();
 	void normal_to_xy();
+	void shrink_x2_and_keep_size();
 
 
 	void set_size_override(const Size2& p_size);

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -1029,6 +1029,8 @@ public:
 
 	virtual int get_render_info(VS::RenderInfo p_info)=0;
 
+	virtual void set_force_16_bits_fbo(bool p_force) {}
+
 	Rasterizer();
 	virtual ~Rasterizer() {}
 };


### PR DESCRIPTION
Can change "Set Keep Screen On" at Project settings.

2 methods are added to `OS`.

```
OS::set_keep_screen_on(bool)
bool OS::is_keep_screen_on()
```

I made another PR instead of #2943 
