### PR TITLE
Script Editor: automatic indentation after a colon

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1610,6 +1610,13 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 						else
 							break;
 					}
+					if(auto_indent){
+						// indent once again if previous line will end with ':'
+						// (i.e. colon precedes current cursor position)
+						if(cursor.column>0 && text[cursor.line][cursor.column-1]==':') {
+							ins+="\t";
+						}
+					}
 					
 					_insert_text_at_cursor(ins);
 					_push_current_op();
@@ -2869,6 +2876,10 @@ bool TextEdit::is_syntax_coloring_enabled() const {
 	return syntax_coloring;
 }
 
+void TextEdit::set_auto_indent(bool p_auto_indent) {
+	auto_indent = p_auto_indent;
+}
+
 void TextEdit::cut() {
 	
 	if (!selection.active)
@@ -3836,7 +3847,7 @@ TextEdit::TextEdit()  {
 	next_operation_is_complex=false;
 	auto_brace_completion_enabled=false;
 	brace_matching_enabled=false;
-	
+	auto_indent=false;
 }
 
 TextEdit::~TextEdit()

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -213,6 +213,7 @@ class TextEdit : public Control  {
 	
 	bool auto_brace_completion_enabled;
 	bool brace_matching_enabled;
+	bool auto_indent;
 	bool cut_copy_line;
 
 	uint64_t last_dblclk;
@@ -323,6 +324,7 @@ public:
 		brace_matching_enabled=p_enabled;
 		update();
 	}
+	void set_auto_indent(bool p_auto_indent);
 
 	void cursor_set_column(int p_col, bool p_adjust_viewport=true);
 	void cursor_set_line(int p_row, bool p_adjust_viewport=true);

--- a/tools/editor/code_editor.cpp
+++ b/tools/editor/code_editor.cpp
@@ -614,6 +614,7 @@ CodeTextEditor::CodeTextEditor() {
 		text_editor->add_font_override("font",get_font("source","Fonts"));
 	text_editor->set_show_line_numbers(true);
 	text_editor->set_brace_matching(true);
+	text_editor->set_auto_indent(true);
 
 	line_col = memnew( Label );
 	add_child(line_col);


### PR DESCRIPTION
This is a little code editor improvement, whenever you hit Enter after a colon the next line will be automatically indented:

if condition:⏎
-> ꕯ

Saves one tab-press for each control statement or function declaration.
