### PR TITLE
scons: enabled debug symbols for x11 when using platform=release_debug and debug_release=yes together

### DIFF
--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -118,6 +118,8 @@ def configure(env):
 	elif (env["target"]=="release_debug"):
 
 		env.Append(CCFLAGS=['-O2','-ffast-math','-DDEBUG_ENABLED'])
+		if (env["debug_release"]=="yes"):
+			env.Append(CCFLAGS=['-g2'])
 
 	elif (env["target"]=="debug"):
 


### PR DESCRIPTION
Currently debug_release=yes affects target=release, but not target=release_debug.
This combination is handy, as one can use it run projects with decent performance and still being able to use debugger.
