### PR TITLE
Add way to look for templates at system wide level too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,10 +15,10 @@ core/method_bind.inc
 core/method_bind_ext.inc
 core/script_encryption_key.cpp
 core/global_defaults.cpp
+drivers/unix/os_unix_global_settings_path.cpp
 tools/editor/register_exporters.cpp
 tools/editor/doc_data_compressed.h
 tools/editor/editor_icons.cpp
-tools/editor/editor_global_settings.cpp
 -fpic
 .fscache
 make.bat

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ core/global_defaults.cpp
 tools/editor/register_exporters.cpp
 tools/editor/doc_data_compressed.h
 tools/editor/editor_icons.cpp
+tools/editor/editor_global_settings.cpp
 -fpic
 .fscache
 make.bat

--- a/SConstruct
+++ b/SConstruct
@@ -126,7 +126,7 @@ opts.Add("CXX", "Compiler");
 opts.Add("CCFLAGS", "Custom flags for the C++ compiler");
 opts.Add("CFLAGS", "Custom flags for the C compiler");
 opts.Add("LINKFLAGS", "Custom flags for the linker");
-opts.Add('global_settings_path', 'Path to system-wide settings. Currently only used by templates.','')
+opts.Add('unix_global_settings_path', 'unix-specific path to system-wide settings. Currently only used by templates.','')
 opts.Add('disable_3d', 'Disable 3D nodes for smaller executable (yes/no)', "no")
 opts.Add('disable_advanced_gui', 'Disable advance 3D gui nodes and behaviors (yes/no)', "no")
 opts.Add('colored', 'Enable colored output for the compilation (yes/no)', 'no')

--- a/SConstruct
+++ b/SConstruct
@@ -126,6 +126,7 @@ opts.Add("CXX", "Compiler");
 opts.Add("CCFLAGS", "Custom flags for the C++ compiler");
 opts.Add("CFLAGS", "Custom flags for the C compiler");
 opts.Add("LINKFLAGS", "Custom flags for the linker");
+opts.Add('global_settings_path', 'Path to system-wide settings. Currently only used by templates.','')
 opts.Add('disable_3d', 'Disable 3D nodes for smaller executable (yes/no)', "no")
 opts.Add('disable_advanced_gui', 'Disable advance 3D gui nodes and behaviors (yes/no)', "no")
 opts.Add('colored', 'Enable colored output for the compilation (yes/no)', 'no')

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -184,6 +184,7 @@ public:
 	virtual void set_low_processor_usage_mode(bool p_enabled);
 	virtual bool is_in_low_processor_usage_mode() const;
 
+	virtual String get_installed_templates_path() const { return ""; };
 	virtual String get_executable_path() const;
 	virtual Error execute(const String& p_path, const List<String>& p_arguments,bool p_blocking,ProcessID *r_child_id=NULL,String* r_pipe=NULL,int *r_exitcode=NULL)=0;
 	virtual Error kill(const ProcessID& p_pid)=0;

--- a/drivers/unix/SCsub
+++ b/drivers/unix/SCsub
@@ -1,5 +1,13 @@
 Import('env')
 
+ed_gl_set='#include "os_unix.h"\n'
+ed_gl_set+='String OS_Unix::get_global_settings_path() const {\n'
+ed_gl_set+='\treturn "' + env["unix_global_settings_path"]+'";\n'
+ed_gl_set+='}\n'
+f = open("os_unix_global_settings_path.cpp","wb")
+f.write(ed_gl_set)
+f.close()
+
 env.add_source_files(env.drivers_sources,"*.cpp")
 
 Export('env')

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -477,6 +477,14 @@ String OS_Unix::get_data_dir() const {
 
 }
 
+String OS_Unix::get_installed_templates_path() const {
+	String p=get_global_settings_path();
+	if (p!="")
+		return p+"/templates/";
+	else
+		return "";
+}
+
 String OS_Unix::get_executable_path() const {
 
 #ifdef __linux__

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -64,6 +64,8 @@ protected:
 	
 	String stdin_buf;
 
+	String get_global_settings_path() const;
+
 public:
 
 
@@ -111,6 +113,7 @@ public:
 
 	virtual void debug_break();
 
+	virtual String get_installed_templates_path() const;
 	virtual String get_executable_path() const;
 	virtual String get_data_dir() const;
 

--- a/platform/bb10/export/export.cpp
+++ b/platform/bb10/export/export.cpp
@@ -275,10 +275,16 @@ Error EditorExportPlatformBB10::export_project(const String& p_path, bool p_debu
 
 	EditorProgress ep("export","Exporting for BlackBerry 10",104);
 
-	String template_path = EditorSettings::get_singleton()->get_settings_path()+"/templates/";
+	String src_template=custom_package;
 
-	String src_template=custom_package!=""?custom_package:template_path.plus_file("bb10.zip");
-
+	if (src_template=="") {
+		String err;
+		src_template = find_export_template("bb10.zip", &err);
+		if (src_template=="") {
+			EditorNode::add_io_error(err);
+			return ERR_FILE_NOT_FOUND;
+		}
+	}
 
 	FileAccess *src_f=NULL;
 	zlib_filefunc_def io = zipio_create_io_from_file(&src_f);
@@ -733,9 +739,7 @@ bool EditorExportPlatformBB10::can_export(String *r_error) const {
 		err+="Blackberry host tools not configured in editor settings.\n";
 	}
 
-	String exe_path = EditorSettings::get_singleton()->get_settings_path()+"/templates/";
-
-	if (!FileAccess::exists(exe_path+"bb10.zip")) {
+	if (!exists_export_template("bb10.zip")) {
 		valid=false;
 		err+="No export template found.\nDownload and install export templates.\n";
 	}

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -205,17 +205,23 @@ Error EditorExportPlatformJavaScript::export_project(const String& p_path, bool 
 
 	EditorProgress ep("export","Exporting for javascript",104);
 
-	String template_path = EditorSettings::get_singleton()->get_settings_path()+"/templates/";
+	if (p_debug)
+		src_template=custom_debug_package;
+	else
+		src_template=custom_release_package;
 
-	if (p_debug) {
-
-		src_template=custom_debug_package!=""?custom_debug_package:template_path+"javascript_debug.zip";
-	} else {
-
-		src_template=custom_release_package!=""?custom_release_package:template_path+"javascript_release.zip";
-
+	if (src_template=="") {
+		String err;
+		if (p_debug) {
+			src_template=find_export_template("javascript_debug.zip", &err);
+		} else {
+			src_template=find_export_template("javascript_release.zip", &err);
+		}
+		if (src_template=="") {
+			EditorNode::add_io_error(err);
+			return ERR_FILE_NOT_FOUND;
+		}
 	}
-
 
 	FileAccess *src_f=NULL;
 	zlib_filefunc_def io = zipio_create_io_from_file(&src_f);
@@ -337,9 +343,8 @@ bool EditorExportPlatformJavaScript::can_export(String *r_error) const {
 
 	bool valid=true;
 	String err;
-	String exe_path = EditorSettings::get_singleton()->get_settings_path()+"/templates/";
 
-	if (!FileAccess::exists(exe_path+"javascript_debug.zip") || !FileAccess::exists(exe_path+"javascript_release.zip")) {
+	if (!exists_export_template("javascript_debug.zip") || !exists_export_template("javascript_release.zip")) {
 		valid=false;
 		err+="No export templates found.\nDownload and install export templates.\n";
 	}

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -251,15 +251,19 @@ Error EditorExportPlatformOSX::export_project(const String& p_path, bool p_debug
 
 	EditorProgress ep("export","Exporting for OSX",104);
 
-	String pkg_path = EditorSettings::get_singleton()->get_settings_path()+"/templates/osx.zip";
 
-	if (p_debug) {
+	if (p_debug)
+		src_pkg=custom_debug_package;
+	else
+		src_pkg=custom_release_package;
 
-		src_pkg=custom_debug_package!=""?custom_debug_package:pkg_path;
-	} else {
-
-		src_pkg=custom_release_package!=""?custom_release_package:pkg_path;
-
+	if (src_pkg=="") {
+		String err;
+		src_pkg=find_export_template("osx.zip", &err);
+		if (src_pkg=="") {
+			EditorNode::add_io_error(err);
+			return ERR_FILE_NOT_FOUND;
+		}
 	}
 
 
@@ -464,9 +468,8 @@ bool EditorExportPlatformOSX::can_export(String *r_error) const {
 
 	bool valid=true;
 	String err;
-	String exe_path = EditorSettings::get_singleton()->get_settings_path()+"/templates/";
 
-	if (!FileAccess::exists(exe_path+"osx.zip")) {
+	if (!exists_export_template("osx.zip")) {
 		valid=false;
 		err+="No export templates found.\nDownload and install export templates.\n";
 	}

--- a/tools/editor/SCsub
+++ b/tools/editor/SCsub
@@ -44,6 +44,15 @@ if (env["tools"]=="yes"):
 	f.write(reg_exporters)
 	f.close()
 
+	ed_gl_set='#include "editor_settings.h"\n'
+	ed_gl_set+='String EditorSettings::get_global_settings_path() const {\n'
+	ed_gl_set+='\treturn "' + env["global_settings_path"]+'";\n'
+	ed_gl_set+='}\n'
+	reg_exporters+='}\n'
+	f = open("editor_global_settings.cpp","wb")
+	f.write(ed_gl_set)
+	f.close()
+
 	env.Depends("#tools/editor/doc_data_compressed.h","#doc/base/classes.xml")
 	env.Command("#tools/editor/doc_data_compressed.h","#doc/base/classes.xml",make_doc_header)
 

--- a/tools/editor/SCsub
+++ b/tools/editor/SCsub
@@ -44,15 +44,6 @@ if (env["tools"]=="yes"):
 	f.write(reg_exporters)
 	f.close()
 
-	ed_gl_set='#include "editor_settings.h"\n'
-	ed_gl_set+='String EditorSettings::get_global_settings_path() const {\n'
-	ed_gl_set+='\treturn "' + env["global_settings_path"]+'";\n'
-	ed_gl_set+='}\n'
-	reg_exporters+='}\n'
-	f = open("editor_global_settings.cpp","wb")
-	f.write(ed_gl_set)
-	f.close()
-
 	env.Depends("#tools/editor/doc_data_compressed.h","#doc/base/classes.xml")
 	env.Command("#tools/editor/doc_data_compressed.h","#doc/base/classes.xml",make_doc_header)
 

--- a/tools/editor/editor_import_export.cpp
+++ b/tools/editor/editor_import_export.cpp
@@ -402,9 +402,9 @@ Vector<StringName> EditorExportPlatform::get_dependencies(bool p_bundles) const 
 String EditorExportPlatform::find_export_template(String template_file_name, String *err) const {
 	String user_file = EditorSettings::get_singleton()->get_settings_path()
 		+"/templates/"+template_file_name;
-	String system_file=EditorSettings::get_singleton()->get_global_settings_path();
+	String system_file=OS::get_singleton()->get_installed_templates_path();
 	bool has_system_path=(system_file!="");
-	system_file+="/templates/"+template_file_name;
+	system_file+=template_file_name;
 
 	// Prefer user file
 	if (FileAccess::exists(user_file)) {

--- a/tools/editor/editor_import_export.cpp
+++ b/tools/editor/editor_import_export.cpp
@@ -399,6 +399,40 @@ Vector<StringName> EditorExportPlatform::get_dependencies(bool p_bundles) const 
 
 }
 
+String EditorExportPlatform::find_export_template(String template_file_name, String *err) const {
+	String user_file = EditorSettings::get_singleton()->get_settings_path()
+		+"/templates/"+template_file_name;
+	String system_file=EditorSettings::get_singleton()->get_global_settings_path();
+	bool has_system_path=(system_file!="");
+	system_file+="/templates/"+template_file_name;
+
+	// Prefer user file
+	if (FileAccess::exists(user_file)) {
+		return user_file;
+	}
+
+	// Now check system file
+	if (has_system_path) {
+		if (FileAccess::exists(system_file)) {
+			return system_file;
+		}
+	}
+
+	// Not found
+	if (err) {
+		*err+="No export template found at \""+user_file+"\"";
+		if (has_system_path)
+			*err+="\n or \""+system_file+"\".";
+		else
+			*err+=".";
+	}
+	return "";
+}
+
+bool EditorExportPlatform::exists_export_template(String template_file_name, String *err) const {
+	return find_export_template(template_file_name,err)!="";
+}
+
 ///////////////////////////////////////
 
 
@@ -1131,19 +1165,32 @@ Error EditorExportPlatformPC::export_project(const String& p_path, bool p_debug,
 
 	ep.step("Setting Up..",0);
 
-	String exe_path = EditorSettings::get_singleton()->get_settings_path()+"/templates/";
-	if (use64) {
-		if (p_debug)
-			exe_path=custom_debug_binary!=""?custom_debug_binary:exe_path+debug_binary64;
-		else
-			exe_path=custom_release_binary!=""?custom_release_binary:exe_path+release_binary64;
-	} else {
+	String exe_path="";
 
-		if (p_debug)
-			exe_path=custom_debug_binary!=""?custom_debug_binary:exe_path+debug_binary32;
-		else
-			exe_path=custom_release_binary!=""?custom_release_binary:exe_path+release_binary32;
+	if (p_debug)
+		exe_path=custom_debug_binary;
+	else
+		exe_path=custom_release_binary;
 
+	if (exe_path=="") {
+		String fname;
+		if (use64) {
+			if (p_debug)
+				fname=debug_binary64;
+			else
+				fname=release_binary64;
+		} else {
+			if (p_debug)
+				fname=debug_binary32;
+			else
+				fname=release_binary32;
+		}
+		String err="";
+		exe_path=find_export_template(fname,&err);
+		if (exe_path=="") {
+			EditorNode::add_io_error(err);
+			return ERR_FILE_CANT_READ;
+		}
 	}
 
 	FileAccess *src_exe=FileAccess::open(exe_path,FileAccess::READ);
@@ -1207,14 +1254,12 @@ bool EditorExportPlatformPC::can_export(String *r_error) const {
 	String err;
 	bool valid=true;
 
-	String exe_path = EditorSettings::get_singleton()->get_settings_path()+"/templates/";
-
-	if (use64 && (!FileAccess::exists(exe_path+debug_binary64) || !FileAccess::exists(exe_path+release_binary64))) {
+	if (use64 && (!exists_export_template(debug_binary64)) || !exists_export_template(release_binary64)) {
 		valid=false;
 		err="No 64 bits export templates found.\nDownload and install export templates.\n";
 	}
 
-	if (!use64 && (!FileAccess::exists(exe_path+debug_binary32) || !FileAccess::exists(exe_path+release_binary32))) {
+	if (!use64 && (!exists_export_template(debug_binary32) || !exists_export_template(release_binary32))) {
 		valid=false;
 		err="No 32 bits export templates found.\nDownload and install export templates.\n";
 	}

--- a/tools/editor/editor_import_export.h
+++ b/tools/editor/editor_import_export.h
@@ -86,6 +86,8 @@ protected:
 	Vector<uint8_t> get_exported_file_default(String& p_fname) const;
 	virtual Vector<uint8_t> get_exported_file(String& p_fname) const;
 	virtual Vector<StringName> get_dependencies(bool p_bundles) const;
+	virtual String find_export_template(String template_file_name, String *err=NULL) const;
+	virtual bool exists_export_template(String template_file_name, String *err=NULL) const;
 
 	struct TempData {
 

--- a/tools/editor/editor_settings.h
+++ b/tools/editor/editor_settings.h
@@ -107,6 +107,7 @@ public:
 	static EditorSettings *get_singleton();
 	void erase(String p_var);
 	String get_settings_path() const;
+	String get_global_settings_path() const;
 	String get_project_settings_path() const;
 
 	const Map<String,Plugin>& get_plugins() const { return plugins; }


### PR DESCRIPTION
Useful for everybody wanting to package godot.
Fixes #1026.

-> Retain the old behaviour: path in error msg only when exporting.
-> User templates override system templates
