### PR TITLE
Fix help view not scrolling to the top

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1504,7 +1504,6 @@ Error RichTextLabel::append_bbcode(const String& p_bbcode) {
 
 void RichTextLabel::scroll_to_line(int p_line) {
 
-	p_line -= 1;
 	ERR_FAIL_INDEX(p_line,lines.size());
 	_validate_line_caches();
 	vscroll->set_val(lines[p_line].height_accum_cache-lines[p_line].height_cache);
@@ -1572,11 +1571,8 @@ bool RichTextLabel::search(const String& p_string,bool p_from_selection) {
 
 				}
 
-				if (line > 1) {
-					line-=1;
-				}
-
-				scroll_to_line(line);
+				line-=2;
+				scroll_to_line(line<0?0:line);
 
 				return true;
 			}


### PR DESCRIPTION
Fixes the following issue:

Search "Node" and open "Node (Class)" result in _Search Help_ dialog. You will get the following error:

```
ERROR: scroll_to_line: Index p_line out of size (lines.size()).
   At: scene/gui/rich_text_label.cpp:1508.
```

If the help view for this class was already open, it won't scroll to the top.
