### PR TITLE
Set the window title as UTF-8 on X11

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -576,7 +576,8 @@ Point2 OS_X11::get_mouse_pos() const {
 }
 
 void OS_X11::set_window_title(const String& p_title) {
-	XStoreName(x11_display,x11_window,p_title.utf8().get_data());
+	//XStoreName(x11_display,x11_window,p_title.utf8().get_data());
+	Xutf8SetWMProperties(x11_display, x11_window, p_title.utf8().get_data(), NULL, NULL, 0, NULL, NULL, NULL);
 }
 
 void OS_X11::set_video_mode(const VideoMode& p_video_mode,int p_screen) {


### PR DESCRIPTION
Fixes #2952.
This might not be the best implementation, so feel free to propose something better.
It was also only tested on a system with UTF-8 locale.
