### PR TITLE
Set default destination filename of imported font

### DIFF
--- a/tools/editor/io_plugins/editor_font_import_plugin.cpp
+++ b/tools/editor/io_plugins/editor_font_import_plugin.cpp
@@ -520,6 +520,10 @@ class EditorFontImportDialog : public ConfirmationDialog {
 			return;
 		}
 
+		if (dest->get_line_edit()->get_text().get_file()==".fnt") {
+			dest->get_line_edit()->set_text(dest->get_line_edit()->get_text().get_base_dir() + "/" + source->get_line_edit()->get_text().get_file().basename() + ".fnt" );
+		}
+
 		Ref<ResourceImportMetadata> rimd = get_rimd();
 
 		if (rimd.is_null()) {


### PR DESCRIPTION
to be input font filename if destination filename was ".fnt" (ie. no filename set by user)
