### PR TITLE
Add refresh button to file dialogs

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -46,6 +46,11 @@ VBoxContainer *FileDialog::get_vbox() {
 }
 
 void FileDialog::_notification(int p_what) {
+
+	if (p_what==NOTIFICATION_ENTER_TREE) {
+
+		refresh->set_icon(get_icon("Reload","EditorIcons"));
+	}
 	
 	if (p_what==NOTIFICATION_DRAW) {
 
@@ -699,6 +704,10 @@ FileDialog::FileDialog() {
 	HBoxContainer *pathhb = memnew( HBoxContainer );
 	pathhb->add_child(dir);
 	dir->set_h_size_flags(SIZE_EXPAND_FILL);
+
+	refresh = memnew( ToolButton );
+	refresh->connect("pressed",this,"_update_file_list");
+	pathhb->add_child(refresh);
 
 	drives = memnew( OptionButton );
 	pathhb->add_child(drives);

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -34,6 +34,7 @@
 #include "scene/gui/line_edit.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/dialogs.h"
+#include "scene/gui/tool_button.h"
 #include "os/dir_access.h"
 #include "box_container.h"
 /**
@@ -86,6 +87,8 @@ private:
 	OptionButton *filter;
 	DirAccess *dir_access;
 	ConfirmationDialog *confirm_save;
+
+	ToolButton *refresh;
 	
 	Vector<String> filters;
 

--- a/tools/editor/editor_file_dialog.cpp
+++ b/tools/editor/editor_file_dialog.cpp
@@ -27,6 +27,7 @@ void EditorFileDialog::_notification(int p_what) {
 		dir_prev->set_icon(get_icon("ArrowLeft","EditorIcons"));
 		dir_next->set_icon(get_icon("ArrowRight","EditorIcons"));
 		dir_up->set_icon(get_icon("ArrowUp","EditorIcons"));
+		refresh->set_icon(get_icon("Reload","EditorIcons"));
 		favorite->set_icon(get_icon("Favorites","EditorIcons"));
 
 		fav_up->set_icon(get_icon("MoveUp","EditorIcons"));
@@ -1169,6 +1170,10 @@ EditorFileDialog::EditorFileDialog() {
 	dir = memnew(LineEdit);
 	pathhb->add_child(dir);
 	dir->set_h_size_flags(SIZE_EXPAND_FILL);
+
+	refresh = memnew( ToolButton );
+	refresh->connect("pressed",this,"_update_file_list");
+	pathhb->add_child(refresh);
 
 	favorite = memnew( ToolButton );
 	favorite->set_toggle_mode(true);

--- a/tools/editor/editor_file_dialog.h
+++ b/tools/editor/editor_file_dialog.h
@@ -108,6 +108,7 @@ private:
 	ToolButton *mode_list;
 
 
+	ToolButton *refresh;
 	ToolButton *favorite;
 
 	ToolButton *fav_up;


### PR DESCRIPTION
Related to #2009, but not sure if it can be closed because the issue looks more like an auto-refresh request.

Editor File Dialog:
![Editor File Dialog Screenshot](https://cloud.githubusercontent.com/assets/7718100/11597851/af63e396-9abe-11e5-8f8c-4451117d5465.png)

File Dialog:
![File Dialog Screenshot - Open Mode](https://cloud.githubusercontent.com/assets/7718100/11597886/e774a4d2-9abe-11e5-9568-1db9e808f301.png)
![File Dialog Screenshot - Save Mode](https://cloud.githubusercontent.com/assets/7718100/11597887/e77d5a1e-9abe-11e5-950a-f4e997db5616.png)
