### PR TITLE
updated the RegEx library nrex to v0.1

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -26945,7 +26945,7 @@ This method controls whether the position between two cached points is interpola
 		Lazy (non-greedy) quantifiers [code]*?[/code]
 		Begining [code]^[/code] and end [code]$[/code] anchors
 		Alternation [code]|[/code]
-		Backreferences [code]\1[/code] to [code]\9[/code]
+		Backreferences [code]\1[/code] and [code]\g{1}[/code]
 		POSIX character classes [code][[:alnum:]][/code]
 		Lookahead [code](?=)[/code], [code](?!)[/code] and lookbehind [code](?&lt;=)[/code], [code](?&lt;!)[/code]
 		ASCII [code]\xFF[/code] and Unicode [code]\uFFFF[/code] code points (in a style similar to Python)
@@ -26957,9 +26957,10 @@ This method controls whether the position between two cached points is interpola
 			</return>
 			<argument index="0" name="pattern" type="String">
 			</argument>
-			<argument index="1" name="expanded" type="bool" default="true">
+			<argument index="1" name="capture" type="int" default="9">
 			</argument>
 			<description>
+            Compiles and assign the regular expression pattern to use. The limit on the number of capturing groups can be specified or made unlimited if negative.
 			</description>
 		</method>
 		<method name="find" qualifiers="const">

--- a/drivers/nrex/README.md
+++ b/drivers/nrex/README.md
@@ -1,5 +1,7 @@
 # NREX: Node RegEx
 
+Version 0.1
+
 Small node-based regular expression library. It only does text pattern
 matchhing, not replacement. To use add the files `nrex.hpp`, `nrex.cpp`
 and `nrex_config.h` to your project and follow the example:
@@ -32,7 +34,7 @@ Currently supported features:
  * Unicode `\uFFFF` code points
  * Positive `(?=)` and negative `(?!)` lookahead
  * Positive `(?<=)` and negative `(?<!)` lookbehind (fixed length and no alternations)
- * Backreferences `\1` to `\9` (with option to expand to `\99`)
+ * Backreferences `\1` and `\g{1}` (limited by default to 9 - can be unlimited)
 
 ## License
 

--- a/drivers/nrex/nrex.hpp
+++ b/drivers/nrex/nrex.hpp
@@ -1,4 +1,5 @@
 //  NREX: Node RegEx
+//  Version 0.1
 //
 //  Copyright (c) 2015, Zher Huei Lee
 //  All rights reserved.
@@ -59,7 +60,32 @@ class nrex
         int _capturing;
         nrex_node* _root;
     public:
+
+        /*!
+         * \brief Initialises an empty regex container
+         */
         nrex();
+
+        /*!
+         * \brief Initialises and compiles the regex pattern
+         *
+         * This calls nrex::compile() with the same arguments. To check whether
+         * the compilation was successfull, use nrex::valid().
+         *
+         * If the NREX_THROW_ERROR was defined it would automatically throw a
+         * runtime error nrex_compile_error if it encounters a problem when
+         * parsing the pattern.
+         *
+         * \param pattern   The regex pattern
+         * \param captures  The maximum number of capture groups to allow. Any
+         *                  extra would be converted to non-capturing groups.
+         *                  If negative, no limit would be imposed. Defaults
+         *                  to 9.
+         *
+         * \see nrex::compile()
+         */
+        nrex(const nrex_char* pattern, int captures = 9);
+
         ~nrex();
 
         /*!
@@ -78,9 +104,9 @@ class nrex
          *
          * This is used to provide the array size of the captures needed for
          * nrex::match() to work. The size is actually the number of capture
-         * groups + one for the matching of the entire pattern. The result is
-         * always capped at 10 or 100, depending on the extend option given in
-         * nrex::compile() (default 10).
+         * groups + one for the matching of the entire pattern. This can be
+         * capped using the extra argument given in nrex::compile()
+         * (default 10).
          *
          * \return The number of captures
          */
@@ -97,12 +123,13 @@ class nrex
          * parsing the pattern.
          *
          * \param pattern   The regex pattern
-         * \param extended  If true, raises the limit on number of capture
-         *                  groups and back-references to 99. Otherwise limited
-         *                  to 9. Defaults to false.
+         * \param captures  The maximum number of capture groups to allow. Any
+         *                  extra would be converted to non-capturing groups.
+         *                  If negative, no limit would be imposed. Defaults
+         *                  to 9.
          * \return True if the pattern was succesfully compiled
          */
-        bool compile(const nrex_char* pattern, bool extended = false);
+        bool compile(const nrex_char* pattern, int captures = 9);
 
         /*!
          * \brief Uses the pattern to search through the provided string

--- a/drivers/nrex/regex.cpp
+++ b/drivers/nrex/regex.cpp
@@ -15,7 +15,7 @@
 
 void RegEx::_bind_methods() {
 
-	ObjectTypeDB::bind_method(_MD("compile","pattern", "expanded"),&RegEx::compile, DEFVAL(true));
+	ObjectTypeDB::bind_method(_MD("compile","pattern", "capture"),&RegEx::compile, DEFVAL(9));
 	ObjectTypeDB::bind_method(_MD("find","text","start","end"),&RegEx::find, DEFVAL(0), DEFVAL(-1));
 	ObjectTypeDB::bind_method(_MD("clear"),&RegEx::clear);
 	ObjectTypeDB::bind_method(_MD("is_valid"),&RegEx::is_valid);
@@ -68,11 +68,11 @@ String RegEx::get_capture(int capture) const {
 
 }
 
-Error RegEx::compile(const String& p_pattern, bool expanded) {
+Error RegEx::compile(const String& p_pattern, int capture) {
 
 	clear();
 
-	exp.compile(p_pattern.c_str(), expanded);
+	exp.compile(p_pattern.c_str(), capture);
 
 	ERR_FAIL_COND_V( !exp.valid(), FAILED );
 

--- a/drivers/nrex/regex.h
+++ b/drivers/nrex/regex.h
@@ -36,7 +36,7 @@ public:
 	bool is_valid() const;
 	int get_capture_count() const;
 	String get_capture(int capture) const;
-	Error compile(const String& p_pattern, bool expanded = false);
+	Error compile(const String& p_pattern, int capture = 9);
 	int find(const String& p_text, int p_start = 0, int p_end = -1) const;
 
 	RegEx();


### PR DESCRIPTION
After implementing unit testing to nrex I caught and fixed some errors so it should behave more like Python's RegEx In addition, I've added version numbering so it should be easier to tell if the library needs updating. Here is a list of changes:
- Fixed zero count quantifiers failing.
- Fixed infinite recursion if quantifying zero length tokens.
- Fixed `$` (as a string pattern on its own) not matching.
- Fixed look behind rewinding beyond the start of the string.
- Added support for alternative back reference format `\g{1}` similar to
  Python. This allows digits to be used immediately after back references.
- Number of capture groups are still limited to 9 by default but can now
  be manually set, with option for no limit at all. (Python has no limit)
- Curly bracket quantifiers `{0}` no longer interpreted as a literal
  string if previous token is not quantifiable. (Python behaviour - Would now result in a compile error)
