### PR TITLE
Spinbox update range on mouse held

### DIFF
--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -31,6 +31,7 @@
 
 #include "scene/gui/line_edit.h"
 #include "scene/gui/range.h"
+#include "scene/main/timer.h"
 
 class SpinBox : public Range {
 
@@ -38,6 +39,9 @@ class SpinBox : public Range {
 
 	LineEdit *line_edit;
 	int last_w;
+
+	Timer *range_click_timer;
+	void _range_click_timeout();
 
 	void _text_entered(const String& p_string);
 	virtual void _value_changed(double);

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -127,7 +127,7 @@ friend class Tree;
 
 
 	
-	TreeItem(Tree *p_tree);		
+	TreeItem(Tree *p_tree);
 		
 
 	void _changed_notify(int p_cell);
@@ -300,6 +300,11 @@ friend class TreeItem;
 	PopupMenu *popup_menu;
 
 	Vector<ColumnInfo> columns;
+
+	Timer *range_click_timer;
+	TreeItem *range_item_last;
+	bool range_up_last;
+	void _range_click_timeout();
 
 	int compute_item_height(TreeItem *p_item) const;
 	int get_item_height(TreeItem *p_item) const;


### PR DESCRIPTION
Initial delay is 600 ms. After first tick, it's set to 75 ms for Spinbox and 50 ms for Tree ranges.

Closes #868
