### PR TITLE
TextEdit: Scroll while selecting with mouse idle

### DIFF
--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -219,6 +219,7 @@ class TextEdit : public Control  {
 	uint64_t last_dblclk;
 
 	Timer *idle_detect;
+	Timer *click_select_held;
 	HScrollBar *h_scroll;
 	VScrollBar *v_scroll;
 	bool updating_scrolls;
@@ -240,6 +241,7 @@ class TextEdit : public Control  {
 	void adjust_viewport_to_cursor();
 	void _scroll_moved(double);
 	void _update_scrollbars();
+	void _click_selection_held();
 
 	void _pre_shift_selection();
 	void _post_shift_selection();


### PR DESCRIPTION
The last enhancement missing on #2364
Selecting and scrolling with the cursor outside the TextEdit rect will now work when mouse is idle too.
