### PR TITLE
Update Autoload demo

### DIFF
--- a/demos/misc/autoload/global.gd
+++ b/demos/misc/autoload/global.gd
@@ -1,7 +1,9 @@
 extends Node
 
-# Member variables
-var current_scene = null
+
+# Changing scenes is most easily done using the functions `change_scene`
+# and `change_scene_to` of the SceneTree. This script demonstrates how to
+# change scenes without those helpers.
 
 
 func goto_scene(path):
@@ -18,20 +20,17 @@ func goto_scene(path):
 
 
 func _deferred_goto_scene(path):
-	# Immediately free the current scene,
-	# there is no risk here.
-	current_scene.free()
+	# Immediately free the current scene, there is no risk here.
+	get_tree().get_current_scene().free()
 	
 	# Load new scene
-	var s = ResourceLoader.load(path)
+	var packed_scene = ResourceLoader.load(path)
 	
 	# Instance the new scene
-	current_scene = s.instance()
+	var instanced_scene = packed_scene.instance()
 	
-	# Add it to the active scene, as child of root
-	get_tree().get_root().add_child(current_scene)
-
-
-func _ready():
-	# Get the current scene at the time of initialization
-	current_scene = get_tree().get_current_scene()
+	# Add it to the scene tree, as direct child of root
+	get_tree().get_root().add_child(instanced_scene)
+	
+	# Set it as the current scene, only after it has been added to the tree
+	get_tree().set_current_scene(instanced_scene)

--- a/demos/misc/autoload/scene_a.gd
+++ b/demos/misc/autoload/scene_a.gd
@@ -1,16 +1,5 @@
-
 extends Panel
-
-# Member variables here, example:
-# var a=2
-# var b="textvar"
-
-
-func _ready():
-	# Initalization here
-	pass
 
 
 func _on_goto_scene_pressed():
 	get_node("/root/global").goto_scene("res://scene_b.scn")
-	pass # Replace with function body

--- a/demos/misc/autoload/scene_b.gd
+++ b/demos/misc/autoload/scene_b.gd
@@ -1,16 +1,5 @@
-
 extends Panel
-
-# Member variables here, example:
-# var a=2
-# var b="textvar"
-
-
-func _ready():
-	# Initalization here
-	pass
 
 
 func _on_goto_scene_pressed():
 	get_node("/root/global").goto_scene("res://scene_a.scn")
-	pass # Replace with function body


### PR DESCRIPTION
The Autoload demo uses scene loading and changing as a usage example of autoload nodes. However, the new `current_scene` functionality simplifies this without the need for autoloads.

The demo now clarifies this and shows how to manually implement scene changing. Hopefully this will help users implementing more advanced techniques (e.g. interactive or threaded loading).
