### PR TITLE
Fix setting Sliders in exponential mode

### DIFF
--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -50,9 +50,9 @@ void Slider::_input_event(InputEvent p_event) {
 				grab.pos=orientation==VERTICAL?mb.y:mb.x;
 				double max = orientation==VERTICAL ? get_size().height : get_size().width ;
 				if (orientation==VERTICAL)
-					set_val( ( ( -(double)grab.pos / max) * ( get_max() - get_min() ) ) + get_max() );
+					set_unit_value( 1 - ((double)grab.pos / max) );
 				else
-					set_val( ( ( (double)grab.pos / max) * ( get_max() - get_min() ) ) + get_min() );
+					set_unit_value((double)grab.pos / max);
 				grab.active=true;
 				grab.uvalue=get_unit_value();
 			} else {


### PR DESCRIPTION
Sliders in exponential mode are currently offset from the cursor.
This change should make `PROPERTY_HINT_EXP_RANGE` more useful (working on this for #2988).
