### PR TITLE
Add GDScript export hints for named bit flags, exponential ranges and global filesystem

### DIFF
--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -2381,10 +2381,48 @@ void GDParser::_parse_class(ClassNode *p_class) {
 
 										current_export.hint=PROPERTY_HINT_ALL_FLAGS;
 										tokenizer->advance();
-										if (tokenizer->get_token()!=GDTokenizer::TK_PARENTHESIS_CLOSE) {
-											_set_error("Expected ')' in hint.");
+
+										if (tokenizer->get_token()==GDTokenizer::TK_PARENTHESIS_CLOSE) {
+											break;
+										}
+										if (tokenizer->get_token()!=GDTokenizer::TK_COMMA)
+										{
+											_set_error("Expected ')' or ',' in bit flags hint.");
 											return;
 										}
+
+										current_export.hint=PROPERTY_HINT_FLAGS;
+										tokenizer->advance();
+
+										bool first = true;
+										while(true) {
+
+											if (tokenizer->get_token()!=GDTokenizer::TK_CONSTANT || tokenizer->get_token_constant().get_type()!=Variant::STRING) {
+												current_export=PropertyInfo();
+												_set_error("Expected a string constant in named bit flags hint.");
+												return;
+											}
+
+											String c = tokenizer->get_token_constant();
+											if (!first)
+												current_export.hint_string+=",";
+											else
+												first=false;
+
+											current_export.hint_string+=c.xml_escape();
+
+											tokenizer->advance();
+											if (tokenizer->get_token()==GDTokenizer::TK_PARENTHESIS_CLOSE)
+												break;
+
+											if (tokenizer->get_token()!=GDTokenizer::TK_COMMA) {
+												current_export=PropertyInfo();
+												_set_error("Expected ')' or ',' in named bit flags hint.");
+												return;
+											}
+											tokenizer->advance();
+										}
+
 										break;
 									}
 


### PR DESCRIPTION
See discussion in #2988
This change exposes remaining sensible export hints:
- Named bit flags (`PROPERTY_HINT_FLAGS`)
  
  `export( int, FLAGS, "Fire", "Water", "Earth", "Wind" )`
- Exponential ranges (`PROPERTY_HINT_EXP_RANGE`)
  
  `export( float, EXP, 100, 200, 2 )`
- Global filesystem directories (`PROPERTY_HINT_GLOBAL_DIR`) restricted to tool scripts
  
  `export( String, DIR, GLOBAL )`
- Global filesystem files (`PROPERTY_HINT_GLOBAL_FILE`) restricted to tool scripts
  
  `export( String, FILE, GLOBAL, ".txt" )`

Closes #2988
