### PR TITLE
Editor layout dialog: name field grabs focus on popup

### DIFF
--- a/tools/editor/editor_layout_dialog.cpp
+++ b/tools/editor/editor_layout_dialog.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  editor_node.cpp                                                      */
+/*  editor_layout_dialog.cpp                                             */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -33,6 +33,12 @@
 void EditorLayoutDialog::clear_layout_name() {
 
 	layout_name->clear();
+}
+
+void EditorLayoutDialog::_post_popup() {
+
+	ConfirmationDialog::_post_popup();
+	layout_name->grab_focus();
 }
 
 void EditorLayoutDialog::ok_pressed() {

--- a/tools/editor/editor_layout_dialog.h
+++ b/tools/editor/editor_layout_dialog.h
@@ -43,6 +43,7 @@ protected:
 
 	static void _bind_methods();
 	virtual void ok_pressed();
+	virtual void _post_popup();
 
 public:
 	void clear_layout_name();


### PR DESCRIPTION
Solves little usability issue I noticed with the save/delete editor layout dialog.
Also renamed wrong file name comment on the header (sorry about that :P).
