### PR TITLE
Option to rename input actions

### DIFF
--- a/core/globals.cpp
+++ b/core/globals.cpp
@@ -1414,6 +1414,7 @@ Globals::Globals() {
 	joyb.joy_button.button_index=JOY_BUTTON_0;
 	va.push_back(joyb);
 	set("input/ui_accept",va);
+	input_presets.push_back("input/ui_accept");
 
 	va=Array();
 	key.key.scancode=KEY_SPACE;
@@ -1421,6 +1422,7 @@ Globals::Globals() {
 	joyb.joy_button.button_index=JOY_BUTTON_3;
 	va.push_back(joyb);
 	set("input/ui_select",va);
+	input_presets.push_back("input/ui_select");
 
 	va=Array();
 	key.key.scancode=KEY_ESCAPE;
@@ -1428,17 +1430,20 @@ Globals::Globals() {
 	joyb.joy_button.button_index=JOY_BUTTON_1;
 	va.push_back(joyb);
 	set("input/ui_cancel",va);
+	input_presets.push_back("input/ui_cancel");
 
 	va=Array();
 	key.key.scancode=KEY_TAB;
 	va.push_back(key);
 	set("input/ui_focus_next",va);
+	input_presets.push_back("input/ui_focus_next");
 
 	va=Array();
 	key.key.scancode=KEY_TAB;
 	key.key.mod.shift=true;
 	va.push_back(key);
 	set("input/ui_focus_prev",va);
+	input_presets.push_back("input/ui_focus_prev");
 	key.key.mod.shift=false;
 
 	va=Array();
@@ -1447,6 +1452,7 @@ Globals::Globals() {
 	joyb.joy_button.button_index=JOY_DPAD_LEFT;
 	va.push_back(joyb);
 	set("input/ui_left",va);
+	input_presets.push_back("input/ui_left");
 
 	va=Array();
 	key.key.scancode=KEY_RIGHT;
@@ -1454,6 +1460,7 @@ Globals::Globals() {
 	joyb.joy_button.button_index=JOY_DPAD_RIGHT;
 	va.push_back(joyb);
 	set("input/ui_right",va);
+	input_presets.push_back("input/ui_right");
 
 	va=Array();
 	key.key.scancode=KEY_UP;
@@ -1461,6 +1468,7 @@ Globals::Globals() {
 	joyb.joy_button.button_index=JOY_DPAD_UP;
 	va.push_back(joyb);
 	set("input/ui_up",va);
+	input_presets.push_back("input/ui_up");
 
 	va=Array();
 	key.key.scancode=KEY_DOWN;
@@ -1468,17 +1476,20 @@ Globals::Globals() {
 	joyb.joy_button.button_index=JOY_DPAD_DOWN;
 	va.push_back(joyb);
 	set("input/ui_down",va);
+	input_presets.push_back("input/ui_down");
 
 
 	va=Array();
 	key.key.scancode=KEY_PAGEUP;
 	va.push_back(key);
 	set("input/ui_page_up",va);
+	input_presets.push_back("input/ui_page_up");
 
 	va=Array();
 	key.key.scancode=KEY_PAGEDOWN;
 	va.push_back(key);
 	set("input/ui_page_down",va);
+	input_presets.push_back("input/ui_page_down");
 
 //	set("display/orientation", "landscape");
 

--- a/core/globals.h
+++ b/core/globals.h
@@ -70,6 +70,7 @@ protected:
 	Map<StringName,PropertyInfo> custom_prop_info;
 	bool disable_platform_override;
 	bool using_datapack;
+	List<String> input_presets;
 
 	
 	bool _set(const StringName& p_name, const Variant& p_value);
@@ -123,6 +124,8 @@ public:
 	bool has_singleton(const String& p_name) const;
 
 	Vector<String> get_optimizer_presets() const;
+
+	List<String> get_input_presets() const { return input_presets; }
 
 	void set_disable_platform_override(bool p_disable);
 	Object* get_singleton_object(const String& p_name) const;

--- a/tools/editor/editor_name_dialog.cpp
+++ b/tools/editor/editor_name_dialog.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  editor_layout_dialog.h                                                        */
+/*  editor_name_dialog.cpp                                               */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -27,28 +27,63 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef EDITOR_LAYOUT_DIALOG_H
-#define EDITOR_LAYOUT_DIALOG_H
+#include "editor_name_dialog.h"
+#include "object_type_db.h"
+#include "os/keyboard.h"
 
-#include "scene/gui/dialogs.h"
-#include "scene/gui/line_edit.h"
+void EditorNameDialog::_line_input_event(const InputEvent& p_event) {
 
-class EditorLayoutDialog : public ConfirmationDialog {
+	if (p_event.type == InputEvent::KEY) {
 
-	OBJ_TYPE( EditorLayoutDialog, ConfirmationDialog );
+		if (!p_event.key.pressed)
+			return;
 
-	LineEdit *layout_name;
+		switch (p_event.key.scancode) {
+			case KEY_ENTER:
+			case KEY_RETURN: {
 
-protected:
+				if (get_hide_on_ok())
+					hide();
+				ok_pressed();
+				accept_event();
+			} break;
+			case KEY_ESCAPE: {
 
-	static void _bind_methods();
-	virtual void ok_pressed();
-	virtual void _post_popup();
+				hide();
+				accept_event();
+			} break;
+		}
+	}
+}
 
-public:
-	void clear_layout_name();
+void EditorNameDialog::_post_popup() {
 
-	EditorLayoutDialog();
-};
+	ConfirmationDialog::_post_popup();
+	name->clear();
+	name->grab_focus();
+}
 
-#endif // EDITOR_LAYOUT_DIALOG_H
+void EditorNameDialog::ok_pressed() {
+
+	if (name->get_text()!="") {
+		emit_signal("name_confirmed", name->get_text());
+	}
+}
+
+void EditorNameDialog::_bind_methods() {
+
+	ObjectTypeDB::bind_method("_line_input_event",&EditorNameDialog::_line_input_event);
+
+	ADD_SIGNAL(MethodInfo("name_confirmed",PropertyInfo( Variant::STRING,"name")));
+}
+
+EditorNameDialog::EditorNameDialog()
+{
+	name = memnew( LineEdit );
+	add_child(name);
+	move_child(name, get_label()->get_index()+1);
+	name->set_margin(MARGIN_TOP,5);
+	name->set_anchor_and_margin(MARGIN_LEFT,ANCHOR_BEGIN,5);
+	name->set_anchor_and_margin(MARGIN_RIGHT,ANCHOR_END,5);
+	name->connect("input_event", this, "_line_input_event");
+}

--- a/tools/editor/editor_name_dialog.h
+++ b/tools/editor/editor_name_dialog.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  editor_layout_dialog.cpp                                             */
+/*  editor_name_dialog.h                                                 */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -27,39 +27,31 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "editor_layout_dialog.h"
-#include "object_type_db.h"
+#ifndef EDITOR_NAME_DIALOG_H
+#define EDITOR_NAME_DIALOG_H
 
-void EditorLayoutDialog::clear_layout_name() {
+#include "scene/gui/dialogs.h"
+#include "scene/gui/line_edit.h"
 
-	layout_name->clear();
-}
+class EditorNameDialog : public ConfirmationDialog {
 
-void EditorLayoutDialog::_post_popup() {
+	OBJ_TYPE( EditorNameDialog, ConfirmationDialog );
 
-	ConfirmationDialog::_post_popup();
-	layout_name->grab_focus();
-}
+	LineEdit *name;
 
-void EditorLayoutDialog::ok_pressed() {
+	void _line_input_event(const InputEvent& p_event);
 
-	if (layout_name->get_text()!="") {
-		emit_signal("layout_selected", layout_name->get_text());
-	}
-}
+protected:
 
-void EditorLayoutDialog::_bind_methods() {
+	static void _bind_methods();
+	virtual void ok_pressed();
+	virtual void _post_popup();
 
-	ADD_SIGNAL(MethodInfo("layout_selected",PropertyInfo( Variant::STRING,"layout_name")));
-}
+public:
 
-EditorLayoutDialog::EditorLayoutDialog()
-{
+	LineEdit* get_line_edit() { return name; }
 
-	layout_name = memnew( LineEdit );
-	layout_name->set_margin(MARGIN_TOP,5);
-	layout_name->set_anchor_and_margin(MARGIN_LEFT,ANCHOR_BEGIN,5);
-	layout_name->set_anchor_and_margin(MARGIN_RIGHT,ANCHOR_END,5);
-	add_child(layout_name);
-	move_child(layout_name, get_label()->get_index()+1);
-}
+	EditorNameDialog();
+};
+
+#endif // EDITOR_NAME_DIALOG_H

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -4124,7 +4124,6 @@ void EditorNode::_bind_methods() {
 	ObjectTypeDB::bind_method("_dock_move_right",&EditorNode::_dock_move_right);
 
 	ObjectTypeDB::bind_method("_layout_menu_option",&EditorNode::_layout_menu_option);
-	ObjectTypeDB::bind_method("_layout_dialog_action",&EditorNode::_dialog_action);
 
 	ObjectTypeDB::bind_method("set_current_scene",&EditorNode::set_current_scene);
 	ObjectTypeDB::bind_method("set_current_version",&EditorNode::set_current_version);
@@ -4624,7 +4623,6 @@ void EditorNode::_layout_menu_option(int p_id) {
 		case SETTINGS_LAYOUT_SAVE: {
 
 			current_option=p_id;
-			layout_dialog->clear_layout_name();
 			layout_dialog->set_title("Save Layout");
 			layout_dialog->get_ok()->set_text("Save");
 			layout_dialog->popup_centered();
@@ -4632,7 +4630,6 @@ void EditorNode::_layout_menu_option(int p_id) {
 		case SETTINGS_LAYOUT_DELETE: {
 
 			current_option=p_id;
-			layout_dialog->clear_layout_name();
 			layout_dialog->set_title("Delete Layout");
 			layout_dialog->get_ok()->set_text("Delete");
 			layout_dialog->popup_centered();
@@ -5427,13 +5424,13 @@ EditorNode::EditorNode() {
 	p->add_separator();
 	p->add_item("About",SETTINGS_ABOUT);
 
-	layout_dialog = memnew( EditorLayoutDialog );
+	layout_dialog = memnew( EditorNameDialog );
 	gui_base->add_child(layout_dialog);
 	layout_dialog->set_hide_on_ok(false);
 	layout_dialog->set_size(Size2(175, 70));
 	confirm_error = memnew( AcceptDialog  );
 	layout_dialog->add_child(confirm_error);
-	layout_dialog->connect("layout_selected", this,"_layout_dialog_action");
+	layout_dialog->connect("name_confirmed", this,"_dialog_action");
 
 	sources_button = memnew( ToolButton );
 	right_menu_hb->add_child(sources_button);

--- a/tools/editor/editor_node.h
+++ b/tools/editor/editor_node.h
@@ -76,7 +76,7 @@
 #include "editor_reimport_dialog.h"
 #include "import_settings.h"
 #include "tools/editor/editor_plugin.h"
-#include "tools/editor/editor_layout_dialog.h"
+#include "tools/editor/editor_name_dialog.h"
 
 #include "fileserver/editor_file_server.h"
 #include "editor_resource_preview.h"
@@ -290,7 +290,7 @@ class EditorNode : public Node {
 
 	Ref<ConfigFile> default_theme;
 	PopupMenu *editor_layouts;
-	EditorLayoutDialog *layout_dialog;
+	EditorNameDialog *layout_dialog;
 	AcceptDialog *confirm_error;
 
 	//OptimizedPresetsDialog *optimized_presets;

--- a/tools/editor/project_settings.cpp
+++ b/tools/editor/project_settings.cpp
@@ -427,7 +427,8 @@ void ProjectSettings::_update_actions() {
 		item->set_cell_mode(0,TreeItem::CELL_MODE_CHECK);
 		item->set_text(0,name);
 		item->add_button(0,get_icon("Add","EditorIcons"),1);
-		item->add_button(0,get_icon("Rename","EditorIcons"),2);
+		if (!Globals::get_singleton()->get_input_presets().find(pi.name))
+			item->add_button(0,get_icon("Rename","EditorIcons"),2);
 		item->add_button(0,get_icon("Remove","EditorIcons"),3);
 		item->set_custom_bg_color(0,get_color("prop_subsection","Editor"));
 		item->set_editable(0,true);

--- a/tools/editor/project_settings.cpp
+++ b/tools/editor/project_settings.cpp
@@ -338,6 +338,15 @@ void ProjectSettings::_action_button_pressed(Object* p_obj, int p_column,int p_i
 		add_at="input/"+ti->get_text(0);
 
 	} else if (p_id==2) {
+		//rename
+
+		add_at="input/"+ti->get_text(0);
+		rename_action->popup_centered();
+		rename_action->get_line_edit()->set_text(ti->get_text(0));
+		rename_action->get_line_edit()->set_cursor_pos(ti->get_text(0).length());
+		rename_action->get_line_edit()->select_all();
+
+	} else if (p_id==3) {
 		//remove
 
 		if (ti->get_parent()==input_editor->get_root()) {
@@ -418,7 +427,8 @@ void ProjectSettings::_update_actions() {
 		item->set_cell_mode(0,TreeItem::CELL_MODE_CHECK);
 		item->set_text(0,name);
 		item->add_button(0,get_icon("Add","EditorIcons"),1);
-		item->add_button(0,get_icon("Remove","EditorIcons"),2);
+		item->add_button(0,get_icon("Rename","EditorIcons"),2);
+		item->add_button(0,get_icon("Remove","EditorIcons"),3);
 		item->set_custom_bg_color(0,get_color("prop_subsection","Editor"));
 		item->set_editable(0,true);
 		item->set_checked(0,pi.usage&PROPERTY_USAGE_CHECKED);
@@ -486,7 +496,7 @@ void ProjectSettings::_update_actions() {
 					action->set_icon(0,get_icon("JoyAxis","EditorIcons"));
 				} break;
 			}
-			action->add_button(0,get_icon("Remove","EditorIcons"),2);
+			action->add_button(0,get_icon("Remove","EditorIcons"),3);
 			action->set_metadata(0,i);
 		}
 	}
@@ -614,6 +624,45 @@ void ProjectSettings::_action_add() {
 	r->select(0);
 	input_editor->ensure_cursor_is_visible();
 
+}
+
+void ProjectSettings::_action_rename(const String &p_name) {
+
+
+	if (p_name.find("/")!=-1 || p_name.find(":")!=-1 || p_name=="") {
+		message->set_text("Invalid Action (Anything goes but / or :).");
+		message->popup_centered(Size2(300,100));
+		return;
+	}
+
+	String new_name = "input/"+p_name;
+
+	if (Globals::get_singleton()->has(new_name)) {
+		message->set_text("Action '"+p_name+"' already exists!.");
+		message->popup_centered(Size2(300,100));
+		return;
+	}
+
+	int order = Globals::get_singleton()->get_order(add_at);
+	Array va = Globals::get_singleton()->get(add_at);
+	bool persisting = Globals::get_singleton()->is_persisting(add_at);
+
+	undo_redo->create_action("Rename Input Action Event");
+	undo_redo->add_do_method(Globals::get_singleton(),"clear",add_at);
+	undo_redo->add_do_method(Globals::get_singleton(),"set",new_name,va);
+	undo_redo->add_do_method(Globals::get_singleton(),"set_persisting",new_name,persisting);
+	undo_redo->add_do_method(Globals::get_singleton(),"set_order",new_name,order);
+	undo_redo->add_undo_method(Globals::get_singleton(),"clear",new_name);
+	undo_redo->add_undo_method(Globals::get_singleton(),"set",add_at,va);
+	undo_redo->add_undo_method(Globals::get_singleton(),"set_persisting",add_at,persisting);
+	undo_redo->add_undo_method(Globals::get_singleton(),"set_order",add_at,order);
+	undo_redo->add_do_method(this,"_update_actions");
+	undo_redo->add_undo_method(this,"_update_actions");
+	undo_redo->add_do_method(this,"_settings_changed");
+	undo_redo->add_undo_method(this,"_settings_changed");
+	undo_redo->commit_action();
+
+	rename_action->hide();
 }
 
 
@@ -1219,6 +1268,7 @@ void ProjectSettings::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("_action_adds"),&ProjectSettings::_action_adds);
 	ObjectTypeDB::bind_method(_MD("_action_persist_toggle"),&ProjectSettings::_action_persist_toggle);
 	ObjectTypeDB::bind_method(_MD("_action_button_pressed"),&ProjectSettings::_action_button_pressed);
+	ObjectTypeDB::bind_method(_MD("_action_rename"),&ProjectSettings::_action_rename);
 	ObjectTypeDB::bind_method(_MD("_update_actions"),&ProjectSettings::_update_actions);
 	ObjectTypeDB::bind_method(_MD("_wait_for_key"),&ProjectSettings::_wait_for_key);
 	ObjectTypeDB::bind_method(_MD("_add_item"),&ProjectSettings::_add_item);
@@ -1438,11 +1488,16 @@ ProjectSettings::ProjectSettings(EditorData *p_data) {
 	add_child(popup_add);
 	popup_add->connect("item_pressed",this,"_add_item");
 
+	rename_action = memnew( EditorNameDialog );
+	add_child(rename_action);
+	rename_action->set_hide_on_ok(false);
+	rename_action->set_size(Size2(200, 70));
+	rename_action->set_title("Rename Input Action");
+	rename_action->connect("name_confirmed", this,"_action_rename");
+
 	press_a_key = memnew( ConfirmationDialog );
 	press_a_key->set_focus_mode(FOCUS_ALL);
 	add_child(press_a_key);
-
-
 
 	l = memnew( Label );
 	l->set_text("Press a Key..");

--- a/tools/editor/project_settings.h
+++ b/tools/editor/project_settings.h
@@ -34,6 +34,7 @@
 #include "optimized_save_dialog.h"
 #include "undo_redo.h"
 #include "editor_data.h"
+#include "editor_name_dialog.h"
 //#include "project_export_settings.h"
 
 class ProjectSettings : public AcceptDialog {
@@ -65,6 +66,8 @@ class ProjectSettings : public AcceptDialog {
 	OptionButton *device_index;
 	Label *device_index_label;
 	MenuButton *popup_platform;
+
+	EditorNameDialog *rename_action;
 
 	LineEdit *action_name;
 	Tree *input_editor;
@@ -106,6 +109,7 @@ class ProjectSettings : public AcceptDialog {
 
 	void _action_adds(String);
 	void _action_add();
+	void _action_rename(const String& p_name);
 	void _device_input_add();
 
 	void _item_checked(const String& p_item, bool p_check);


### PR DESCRIPTION
Closes #517

Since it used the same dialog as editor layouts, I renamed it to EditorNameDialog to make it more generic.

![Screenshot](https://cloud.githubusercontent.com/assets/7718100/11785694/44a0c480-a283-11e5-92cc-464b7ef3ee9f.png)
