### PR TITLE
Added metadata to TileSet tiles and MeshLibrary items

### DIFF
--- a/scene/resources/mesh_library.cpp
+++ b/scene/resources/mesh_library.cpp
@@ -138,12 +138,25 @@ void MeshLibrary::set_item_preview(int p_item,const Ref<Texture>& p_preview) {
 	_change_notify();
 
 }
+
+void MeshLibrary::set_item_meta(int p_item, const String& p_name, const Variant& p_value ) {
+
+	ERR_FAIL_COND(!item_map.has(p_item));
+	if (p_value.get_type() == Variant::NIL) {
+		item_map[p_item].metadata.erase(p_name);
+		return;
+	};
+
+	item_map[p_item].metadata[p_name]=p_value;
+}
+
 String MeshLibrary::get_item_name(int p_item) const {
 
 	ERR_FAIL_COND_V(!item_map.has(p_item),"");
 	return item_map[p_item].name;
 
 }
+
 Ref<Mesh> MeshLibrary::get_item_mesh(int p_item) const {
 
 	ERR_FAIL_COND_V(!item_map.has(p_item),Ref<Mesh>());
@@ -163,10 +176,38 @@ Ref<Texture> MeshLibrary::get_item_preview(int p_item) const {
 	return item_map[p_item].preview;
 }
 
+Variant MeshLibrary::get_item_meta(int p_item, const String& p_name) const {
+
+	ERR_FAIL_COND_V(!item_map.has(p_item) || !item_map[p_item].metadata.has(p_name),Variant());
+	return item_map[p_item].metadata[p_name];
+}
+
+bool MeshLibrary::item_has_meta(int p_item, const String& p_name) const {
+
+	ERR_FAIL_COND_V(!item_map.has(p_item),false);
+	return item_map[p_item].metadata.has(p_name);
+}
+
+DVector<String> MeshLibrary::get_item_meta_list(int p_item) const {
+
+	ERR_FAIL_COND_V(!item_map.has(p_item), DVector<String>());
+	DVector<String> _metaret;
+
+	List<Variant> keys;
+	item_map[p_item].metadata.get_key_list(&keys);
+	for(List<Variant>::Element *E=keys.front();E;E=E->next()) {
+
+		_metaret.push_back(E->get());
+	}
+
+	return _metaret;
+}
+
 bool MeshLibrary::has_item(int p_item) const {
 
 	return item_map.has(p_item)	;
 }
+
 void MeshLibrary::remove_item(int p_item) {
 
 	ERR_FAIL_COND(!item_map.has(p_item));
@@ -224,9 +265,13 @@ void MeshLibrary::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_item_name","id","name"),&MeshLibrary::set_item_name);
 	ObjectTypeDB::bind_method(_MD("set_item_mesh","id","mesh:Mesh"),&MeshLibrary::set_item_mesh);
 	ObjectTypeDB::bind_method(_MD("set_item_shape","id","shape:Shape"),&MeshLibrary::set_item_shape);
+	ObjectTypeDB::bind_method(_MD("set_item_meta","id","name","value"),&MeshLibrary::set_item_meta);
 	ObjectTypeDB::bind_method(_MD("get_item_name","id"),&MeshLibrary::get_item_name);
 	ObjectTypeDB::bind_method(_MD("get_item_mesh:Mesh","id"),&MeshLibrary::get_item_mesh);
 	ObjectTypeDB::bind_method(_MD("get_item_shape:Shape","id"),&MeshLibrary::get_item_shape);
+	ObjectTypeDB::bind_method(_MD("get_item_meta","id","name"),&MeshLibrary::get_item_meta);
+	ObjectTypeDB::bind_method(_MD("item_has_meta","id","name"),&MeshLibrary::item_has_meta);
+	ObjectTypeDB::bind_method(_MD("get_item_meta_list","id"),&MeshLibrary::get_item_meta_list);
 	ObjectTypeDB::bind_method(_MD("remove_item","id"),&MeshLibrary::remove_item);
 	ObjectTypeDB::bind_method(_MD("clear"),&MeshLibrary::clear);
 	ObjectTypeDB::bind_method(_MD("get_item_list"),&MeshLibrary::get_item_list);

--- a/scene/resources/mesh_library.h
+++ b/scene/resources/mesh_library.h
@@ -45,6 +45,7 @@ class MeshLibrary : public Resource {
 		Ref<Mesh> mesh;
 		Ref<Shape> shape;
 		Ref<Texture> preview;
+		Dictionary metadata;
 	};
 
 	Map<int,Item> item_map;
@@ -64,10 +65,15 @@ public:
 	void set_item_mesh(int p_item,const Ref<Mesh>& p_mesh);
 	void set_item_shape(int p_item,const Ref<Shape>& p_shape);
 	void set_item_preview(int p_item,const Ref<Texture>& p_preview);
+	void set_item_meta(int p_item, const String& p_name, const Variant& p_value );
 	String get_item_name(int p_item) const;
 	Ref<Mesh> get_item_mesh(int p_item) const;
 	Ref<Shape> get_item_shape(int p_item) const;
 	Ref<Texture> get_item_preview(int p_item) const;
+	Variant get_item_meta(int p_item, const String& p_name) const;
+
+	bool item_has_meta(int p_item, const String& p_name) const;
+	DVector<String> get_item_meta_list(int p_item) const;
 
 	void remove_item(int p_item);
 	bool has_item(int p_item) const;

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -317,6 +317,44 @@ Vector<Ref<Shape2D> > TileSet::tile_get_shapes(int p_id) const {
 	return tile_map[p_id].shapes;
 }
 
+void TileSet::tile_set_meta(int p_id, const String& p_name, const Variant& p_value ) {
+
+	ERR_FAIL_COND(!tile_map.has(p_id));
+	if (p_value.get_type() == Variant::NIL) {
+		tile_map[p_id].metadata.erase(p_name);
+		return;
+	};
+
+	tile_map[p_id].metadata[p_name]=p_value;
+}
+
+Variant TileSet::tile_get_meta(int p_id, const String& p_name) const {
+
+	ERR_FAIL_COND_V(!tile_map.has(p_id) || !tile_map[p_id].metadata.has(p_name),Variant());
+	return tile_map[p_id].metadata[p_name];
+}
+
+bool TileSet::tile_has_meta(int p_id, const String& p_name) const {
+
+	ERR_FAIL_COND_V(!tile_map.has(p_id),false);
+	return tile_map[p_id].metadata.has(p_name);
+}
+
+DVector<String> TileSet::tile_get_meta_list(int p_id) const {
+
+	ERR_FAIL_COND_V(!tile_map.has(p_id), DVector<String>());
+	DVector<String> _metaret;
+
+	List<Variant> keys;
+	tile_map[p_id].metadata.get_key_list(&keys);
+	for(List<Variant>::Element *E=keys.front();E;E=E->next()) {
+
+		_metaret.push_back(E->get());
+	}
+
+	return _metaret;
+}
+
 void TileSet::_tile_set_shapes(int p_id,const Array& p_shapes) {
 
 	ERR_FAIL_COND(!tile_map.has(p_id));
@@ -432,6 +470,10 @@ void TileSet::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("tile_get_light_occluder:OccluderPolygon2D","id"),&TileSet::tile_get_light_occluder);
 	ObjectTypeDB::bind_method(_MD("tile_set_occluder_offset","id","occluder_offset"),&TileSet::tile_set_occluder_offset);
 	ObjectTypeDB::bind_method(_MD("tile_get_occluder_offset","id"),&TileSet::tile_get_occluder_offset);
+	ObjectTypeDB::bind_method(_MD("tile_set_meta","id","name","value"),&TileSet::tile_set_meta);
+	ObjectTypeDB::bind_method(_MD("tile_get_meta","id","name"),&TileSet::tile_get_meta);
+	ObjectTypeDB::bind_method(_MD("tile_has_meta","id","name"),&TileSet::tile_has_meta);
+	ObjectTypeDB::bind_method(_MD("tile_get_meta_list","id"),&TileSet::tile_get_meta_list);
 
 	ObjectTypeDB::bind_method(_MD("remove_tile","id"),&TileSet::remove_tile);
 	ObjectTypeDB::bind_method(_MD("clear"),&TileSet::clear);

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -52,6 +52,7 @@ class TileSet : public Resource {
 		Vector2 navigation_polygon_offset;
 		Ref<NavigationPolygon> navigation_polygon;
 		Ref<CanvasItemMaterial> material;
+		Dictionary metadata;
 	};
 
 	Map<int,Data> tile_map;
@@ -108,6 +109,11 @@ public:
 
 	void tile_set_shapes(int p_id,const Vector<Ref<Shape2D> > &p_shapes);
 	Vector<Ref<Shape2D> > tile_get_shapes(int p_id) const;
+
+	void tile_set_meta(int p_id, const String& p_name, const Variant& p_value );
+	Variant tile_get_meta(int p_id, const String& p_name) const;
+	bool tile_has_meta(int p_id, const String& p_name) const;
+	DVector<String> tile_get_meta_list(int p_id) const;
 
 	void remove_tile(int p_id);
 


### PR DESCRIPTION
Requested by #2753.

Notice I didn't add the close/fixed prefix because it's currently only possible to add meta via code.

There is no Dictionary property hint, so in my tests I tried displaying a json string (with multiline property hint) of the meta for editing it in the inspector. It worked fine, but it didn't seem like the right way to do it.

Hopefully the new TileSet importer will allow editing meta visually (perhaps we could help with this).

NOTE: This PR does not include descriptions in _classes.xml_ for the new methods.
