### PR TITLE
Fix Remove Item option in TileSet plugin

### DIFF
--- a/tools/editor/plugins/tile_set_editor_plugin.h
+++ b/tools/editor/plugins/tile_set_editor_plugin.h
@@ -33,6 +33,7 @@
 
 #include "scene/resources/tile_set.h"
 #include "tools/editor/editor_node.h"
+#include "tools/editor/editor_name_dialog.h"
 
 
 class TileSetEditor : public Control {
@@ -44,7 +45,8 @@ class TileSetEditor : public Control {
 	EditorNode *editor;
 	MenuButton *menu;
 	ConfirmationDialog *cd;
-	int to_erase;
+	EditorNameDialog *nd;
+	AcceptDialog *err_dialog;
 
 	enum {
 
@@ -56,7 +58,8 @@ class TileSetEditor : public Control {
 
 	int option;
 	void _menu_cbk(int p_option);
-	void _menu_confirm();	
+	void _menu_confirm();
+	void _name_dialog_confirm(const String& name);
 
 	static void _import_scene(Node *p_scene, Ref<TileSet> p_library, bool p_merge);
 


### PR DESCRIPTION
Fixes #3088

This seems like the best way to handle tiles deletion for now. Perhaps the TileSet editor plugin may be improved in the future, allowing to select tiles (among other features).

It will display a dialog asking for a tile name or id (the name has priority when checking).
