### PR TITLE
Fix ios libpng link error

### DIFF
--- a/drivers/png/SCsub
+++ b/drivers/png/SCsub
@@ -23,7 +23,7 @@ png_sources = [
 ]
 
 if ("neon_enabled" in env and env["neon_enabled"]):
-	env.Append(CPPFLAGS=["-DPNG_ARM_NEON_OPT=2"])	
+	env.Append(CPPFLAGS=["-DPNG_ARM_NEON_OPT=2"])
 	env_neon = env.Clone();
 	if "S_compiler" in env:
 		env_neon['CC'] = env['S_compiler']

--- a/drivers/png/SCsub
+++ b/drivers/png/SCsub
@@ -22,18 +22,19 @@ png_sources = [
 	"png/image_loader_png.cpp"
 ]
 
-if ("neon_enabled" in env and env["neon_enabled"]):	
+if ("neon_enabled" in env and env["neon_enabled"]):
+	env.Append(CPPFLAGS=["-DPNG_ARM_NEON_OPT=2"])	
 	env_neon = env.Clone();
 	if "S_compiler" in env:
 		env_neon['CC'] = env['S_compiler']
-	env_neon.Append(CPPFLAGS=["-DPNG_ARM_NEON"])
+	#env_neon.Append(CPPFLAGS=["-DPNG_ARM_NEON"])
 	import os
 	# Currently .ASM filter_neon.S does not compile on NT.
 	if (os.name!="nt"):
-		env_neon.Append(CPPFLAGS=["-DPNG_ARM_NEON_OPT=2"])
 		png_sources.append(env_neon.Object("#drivers/png/arm/arm_init.c"))
 		png_sources.append(env_neon.Object("#drivers/png/arm/filter_neon.S"))
-
+else:
+	env.Append(CPPFLAGS=["-DPNG_ARM_NEON_OPT=0"])
 
 env.drivers_sources+=png_sources
 


### PR DESCRIPTION
Maybe this fix #3120
There is a commented line for neon_enabled in platform/iphone/detect.py, why? I suppose uncomment it and add -mfpu=neon and **ARM_NEON** needed to activate neon optimization on ios.
