### PR TITLE
Add missing keyword highlights for Rect2 and NodePath.

### DIFF
--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -316,6 +316,8 @@ void ScriptTextEditor::_load_theme_settings() {
 	get_text_edit()->add_keyword_color("Color",basetype_color);
 	get_text_edit()->add_keyword_color("Image",basetype_color);
 	get_text_edit()->add_keyword_color("InputEvent",basetype_color);
+	get_text_edit()->add_keyword_color("Rect2",basetype_color);
+	get_text_edit()->add_keyword_color("NodePath",basetype_color);
 
 	//colorize engine types
 	Color type_color= EDITOR_DEF("text_editor/engine_type_color",Color(0.0,0.2,0.4));


### PR DESCRIPTION
I always wondered why Rect2 was shown in the default color ^^ 
