### PR TITLE
Fix for broken Visual Studio Project generation which happened in:

### DIFF
--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -16,8 +16,11 @@ restarget="godot_res"+env["OBJSUFFIX"]
 
 obj = env.RES(restarget,'godot_res.rc')
 
-common_win.append(obj)
-
+if env["is_mingw"]:
+	common_win.append(obj)
+else:
+	common_win.append("godot_res.res")
+	
 env.Program('#bin/godot',['godot_win.cpp']+common_win,PROGSUFFIX=env["PROGSUFFIX"])
 
 # Microsoft Visual Studio Project Generation


### PR DESCRIPTION
Author:     Juan Linietsky reduzio@gmail.com
Date:       1 month ago (11/24/2015 6:42:05 AM)
Commit hash:    ccd40f76e8975b679619eb3591eb56376e82a6b3
Parent(s):  85eedffbc7

-work in progress resourceparser and .tscn parser. Still non-functional
-fixed theora so it can compile theoralib but not theora
-fixed generation of windows icon in .rc, which didn't previously work in 32 bits
