### PR TITLE
added missing onready allocation for subclasses

### DIFF
--- a/modules/gdscript/gd_compiler.cpp
+++ b/modules/gdscript/gd_compiler.cpp
@@ -1218,7 +1218,7 @@ Error GDCompiler::_parse_function(GDScript *p_script,const GDParser::ClassNode *
 
 	bool is_initializer=!p_for_ready && !p_func;
 
-	if (is_initializer || String(p_func->name)=="_init") {
+	if (is_initializer || (p_func && String(p_func->name)=="_init")) {
 		//parse initializer for class members
 		if (!p_func && p_class->extends_used && p_script->native.is_null()){
 

--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -2081,6 +2081,8 @@ void GDParser::_parse_class(ClassNode *p_class) {
 				ClassNode *newclass = alloc_node<ClassNode>();
 				newclass->initializer = alloc_node<BlockNode>();
 				newclass->initializer->parent_class=newclass;
+				newclass->ready = alloc_node<BlockNode>();
+				newclass->ready->parent_class=newclass;
 				newclass->name=name;
 				newclass->owner=p_class;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/3158

The problem was with https://github.com/godotengine/godot/commit/30c12297dc6df7d35df140475c0cec7308aea77a. While gd_parser allocated the container for p_class->ready in the main classes, it didn't do so for subclasses.
