### PR TITLE
Add keyboard shortcut to toggle "show hidden files" in FileDialog

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -862,6 +862,13 @@ bool Control::window_has_modal_stack() const {
 	return data.window->window->modal_stack.size();
 }
 
+bool Control::is_window_modal_on_top() const {
+
+	if (window_has_modal_stack())
+		return data.window->window->modal_stack.back()->get()==this;
+	return false;
+}
+
 void Control::_window_cancel_tooltip() {
 
 	window->tooltip=NULL;

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -270,6 +270,8 @@ public:
 	void set_custom_minimum_size(const Size2& p_custom);
 	Size2 get_custom_minimum_size() const;
 
+	bool is_window_modal_on_top() const;
+
 	bool is_window() const;
 	Control *get_window() const;
 	Control *get_parent_control() const;

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -56,7 +56,42 @@ void FileDialog::_notification(int p_what) {
 
 		//RID ci = get_canvas_item();
 		//get_stylebox("panel","PopupMenu")->draw(ci,Rect2(Point2(),get_size()));
-	}	
+	}
+
+	if (p_what==NOTIFICATION_POPUP_HIDE) {
+
+		set_process_unhandled_input(false);
+	}
+}
+
+void FileDialog::_unhandled_input(const InputEvent& p_event) {
+
+	if (p_event.type==InputEvent::KEY && is_window_modal_on_top()) {
+
+		const InputEventKey &k=p_event.key;
+
+		if (k.pressed) {
+
+			bool handled=true;
+
+			switch (k.scancode) {
+
+				case KEY_H: {
+
+					if (k.mod.command) {
+						set_show_hidden_files(!show_hidden_files);
+					} else {
+						handled=false;
+					}
+
+				} break;
+				default: { handled=false; }
+			}
+
+			if (handled)
+				accept_event();
+		}
+	}
 }
 
 void FileDialog::set_enable_multiple_selection(bool p_enable) {
@@ -113,6 +148,8 @@ void FileDialog::_post_popup() {
 		file->grab_focus();
 	else
 		tree->grab_focus();
+
+	set_process_unhandled_input(true);
 
 }
 
@@ -628,6 +665,8 @@ bool FileDialog::default_show_hidden_files=false;
 
 void FileDialog::_bind_methods() {
 	
+	ObjectTypeDB::bind_method(_MD("_unhandled_input"),&FileDialog::_unhandled_input);
+
 	ObjectTypeDB::bind_method(_MD("_tree_selected"),&FileDialog::_tree_selected);
 	ObjectTypeDB::bind_method(_MD("_tree_db_selected"),&FileDialog::_tree_dc_selected);
 	ObjectTypeDB::bind_method(_MD("_dir_entered"),&FileDialog::_dir_entered);

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -117,6 +117,8 @@ private:
 
 	void _update_drives();
 
+	void _unhandled_input(const InputEvent& p_event);
+
 	virtual void _post_popup();
 
 protected:

--- a/tools/editor/editor_file_dialog.cpp
+++ b/tools/editor/editor_file_dialog.cpp
@@ -53,10 +53,49 @@ void EditorFileDialog::_notification(int p_what) {
 
 		//RID ci = get_canvas_item();
 		//get_stylebox("panel","PopupMenu")->draw(ci,Rect2(Point2(),get_size()));
+	} else if (p_what==NOTIFICATION_POPUP_HIDE) {
+
+		set_process_unhandled_input(false);
+
 	} else if (p_what==EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
 
-		set_show_hidden_files(EditorSettings::get_singleton()->get("file_dialog/show_hidden_files"));
+		bool show_hidden=EditorSettings::get_singleton()->get("file_dialog/show_hidden_files");
+		if (show_hidden_files!=show_hidden)
+			set_show_hidden_files(show_hidden);
 		set_display_mode((DisplayMode)EditorSettings::get_singleton()->get("file_dialog/display_mode").operator int());
+	}
+}
+
+void EditorFileDialog::_unhandled_input(const InputEvent& p_event) {
+
+	if (p_event.type==InputEvent::KEY && is_window_modal_on_top()) {
+
+		const InputEventKey &k=p_event.key;
+
+		if (k.pressed) {
+
+			bool handled=true;
+
+			switch (k.scancode) {
+
+				case KEY_H: {
+
+					if (k.mod.command) {
+
+						bool show=!show_hidden_files;
+						set_show_hidden_files(show);
+						EditorSettings::get_singleton()->set("file_dialog/show_hidden_files",show);
+					} else {
+						handled=false;
+					}
+
+				} break;
+				default: { handled=false; }
+			}
+
+			if (handled)
+				accept_event();
+		}
 	}
 }
 
@@ -150,6 +189,8 @@ void EditorFileDialog::_post_popup() {
 
 		_update_favorites();
 	}
+
+	set_process_unhandled_input(true);
 
 }
 
@@ -1048,6 +1089,8 @@ EditorFileDialog::DisplayMode EditorFileDialog::get_display_mode() const{
 
 
 void EditorFileDialog::_bind_methods() {
+
+	ObjectTypeDB::bind_method(_MD("_unhandled_input"),&EditorFileDialog::_unhandled_input);
 
 	ObjectTypeDB::bind_method(_MD("_item_selected"),&EditorFileDialog::_item_selected);
 	ObjectTypeDB::bind_method(_MD("_item_db_selected"),&EditorFileDialog::_item_dc_selected);

--- a/tools/editor/editor_file_dialog.h
+++ b/tools/editor/editor_file_dialog.h
@@ -176,6 +176,8 @@ private:
 	void _thumbnail_done(const String& p_path,const Ref<Texture>& p_preview, const Variant& p_udata);
 	void _request_single_thumbnail(const String& p_path);
 
+	void _unhandled_input(const InputEvent& p_event);
+
 protected:
 
 	void _notification(int p_what);


### PR DESCRIPTION
Keyboard shortcut to toggle "show hidden files" in file dialog: _Ctrl + H_

Added `bool Control::window_is_modal_on_top(Control* p_modal)` method to avoid handling the input in dialogs that are behind the one on top.

More shortcuts could be added later, like refresh or zoom thumbnails.

Note: Using this shortcut in _EditorFileDialog_ modifies _"file_dialog/show_hidden_files"_ property in the editor settings. However, doing so on _FileDialog_ does not (I didn't find a clean way to do it... Would `#ifdef TOOLS_ENABLED` do the job?).
