### PR TITLE
send axis events only once per frame on linux

### DIFF
--- a/platform/x11/joystick_linux.h
+++ b/platform/x11/joystick_linux.h
@@ -54,6 +54,7 @@ private:
 	};
 
 	struct Joystick {
+		InputDefault::JoyAxis curr_axis[MAX_ABS];
 		int key_map[MAX_KEY - BT_MISC];
 		int abs_map[MAX_ABS];
 		int dpad;


### PR DESCRIPTION
fixes a massive performance hit for gamepads with high sensitivity sticks (before, a ds4 could cause 100% core load on my laptop)
