### PR TITLE
Fix delay on audio stream pause

### DIFF
--- a/scene/3d/spatial_stream_player.cpp
+++ b/scene/3d/spatial_stream_player.cpp
@@ -60,7 +60,7 @@ void SpatialStreamPlayer::sp_set_mix_rate(int p_rate){
 
 bool SpatialStreamPlayer::sp_mix(int32_t *p_buffer,int p_frames) {
 
-	if (resampler.is_ready()) {
+	if (resampler.is_ready() && !paused) {
 		return resampler.mix(p_buffer,p_frames);
 	}
 

--- a/scene/audio/stream_player.cpp
+++ b/scene/audio/stream_player.cpp
@@ -58,7 +58,7 @@ void StreamPlayer::sp_set_mix_rate(int p_rate){
 
 bool StreamPlayer::sp_mix(int32_t *p_buffer,int p_frames) {
 
-	if (resampler.is_ready()) {
+	if (resampler.is_ready() && !paused) {
 		return resampler.mix(p_buffer,p_frames);
 	}
 


### PR DESCRIPTION
Self-explanatory: when pausing before, there would be a delay until the stream actually paused properly.
