### PR TITLE
Disable renaming SpriteFrames

### DIFF
--- a/tools/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/tools/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -338,7 +338,6 @@ void SpriteFramesEditor::_update_library() {
 
 		TreeItem *ti = tree->create_item(root);
 		ti->set_cell_mode(0,TreeItem::CELL_MODE_STRING);
-		ti->set_editable(0,true);
 		ti->set_selectable(0,true);
 
 		if (frames->get_frame(i).is_null()) {


### PR DESCRIPTION
Renaming SpriteFrames is just visual, since the name will always be _Frame #_. Allowing to rename them is confusing.
