### PR TITLE
Remove unnecessary null pointer checks

### DIFF
--- a/drivers/convex_decomp/b2Polygon.cpp
+++ b/drivers/convex_decomp/b2Polygon.cpp
@@ -217,8 +217,8 @@ b2Polygon::b2Polygon(b2Triangle& t) {
 void b2Polygon::Set(const b2Polygon& p) {
         if (nVertices != p.nVertices){
 			nVertices = p.nVertices;
-			if (x) delete[] x;
-			if (y) delete[] y;
+			delete[] x;
+			delete[] y;
 			x = new float32[nVertices];
 			y = new float32[nVertices];
         }

--- a/drivers/rtaudio/RtAudio.cpp
+++ b/drivers/rtaudio/RtAudio.cpp
@@ -139,8 +139,7 @@ void RtAudio :: getCompiledApi( std::vector<RtAudio::Api> &apis ) throw()
 
 void RtAudio :: openRtApi( RtAudio::Api api )
 {
-  if ( rtapi_ )
-    delete rtapi_;
+  delete rtapi_;
   rtapi_ = 0;
 
 #if defined(__UNIX_JACK__)
@@ -216,8 +215,7 @@ RtAudio :: RtAudio( RtAudio::Api api )
 
 RtAudio :: ~RtAudio() throw()
 {
-  if ( rtapi_ )
-    delete rtapi_;
+  delete rtapi_;
 }
 
 void RtAudio :: openStream( RtAudio::StreamParameters *outputParameters,

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -149,8 +149,7 @@ void OS_Unix::finalize_core() {
 
 	if (mempool_dynamic)
 		memdelete( mempool_dynamic );
-	if (mempool_static)
-		delete mempool_static;
+	delete mempool_static;
 
 }
 

--- a/platform/haiku/audio_driver_media_kit.cpp
+++ b/platform/haiku/audio_driver_media_kit.cpp
@@ -118,8 +118,7 @@ void AudioDriverMediaKit::unlock() {
 }
 
 void AudioDriverMediaKit::finish() {
-	if (player)
-		delete player;
+	delete player;
 
 	if (samples_in) {
 		memdelete_arr(samples_in);

--- a/platform/haiku/haiku_direct_window.cpp
+++ b/platform/haiku/haiku_direct_window.cpp
@@ -16,9 +16,7 @@ HaikuDirectWindow::HaikuDirectWindow(BRect p_frame)
 
 
 HaikuDirectWindow::~HaikuDirectWindow() {
-	if (update_runner) {
-		delete update_runner;
-	}
+	delete update_runner;
 }
 
 void HaikuDirectWindow::SetHaikuGLView(HaikuGLView* p_view) {

--- a/platform/nacl/os_nacl.cpp
+++ b/platform/nacl/os_nacl.cpp
@@ -144,8 +144,7 @@ void OSNacl::finalize_core() {
 
 	if (mempool_dynamic)
 		memdelete( mempool_dynamic );
-	if (mempool_static)
-		delete mempool_static;
+	delete mempool_static;
 
 };
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1144,8 +1144,7 @@ void OS_Windows::finalize_core() {
 
 	if (mempool_dynamic)
 		memdelete( mempool_dynamic );
-	if (mempool_static)
-		delete mempool_static;
+	delete mempool_static;
 
 
 	TCPServerWinsock::cleanup();

--- a/platform/winrt/os_winrt.cpp
+++ b/platform/winrt/os_winrt.cpp
@@ -345,8 +345,7 @@ void OSWinrt::finalize_core() {
 
 	if (mempool_dynamic)
 		memdelete( mempool_dynamic );
-	if (mempool_static)
-		delete mempool_static;
+	delete mempool_static;
 
 }
 


### PR DESCRIPTION
Removing useless non-null pointer checks before using `delete` and `delete[]` (see issue #55)
