### PR TITLE
Fix is_node_being_edited() when not building tools

### DIFF
--- a/scene/main/scene_main_loop.cpp
+++ b/scene/main/scene_main_loop.cpp
@@ -621,7 +621,11 @@ void SceneTree::set_editor_hint(bool p_enabled) {
 }
 
 bool SceneTree::is_node_being_edited(const Node* p_node) const {
+#ifdef TOOLS_ENABLED
 	return editor_hint && edited_scene_root && edited_scene_root->is_a_parent_of(p_node);
+#else
+	return false;
+#endif
 }
 
 bool SceneTree::is_editor_hint() const {


### PR DESCRIPTION
Fixes #3213.
Superseded #3242.
