### PR TITLE
Make joydev build using libudev and libevdev opt-out

### DIFF
--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -55,6 +55,7 @@ def get_opts():
 	('use_sanitizer','Use llvm compiler sanitize address','no'),
 	('use_leak_sanitizer','Use llvm compiler sanitize memory leaks','no'),
 	('pulseaudio','Detect & Use pulseaudio','yes'),
+	('gamepad','Gamepad support, requires libudev and libevdev','yes'),
 	('new_wm_api', 'Use experimental window management API','no'),
 	('debug_release', 'Add debug symbols to release version','no'),
 	]
@@ -145,23 +146,29 @@ def configure(env):
 			env.Append(CPPPATH=['#tools/freetype/freetype/include'])
 
 
-
-	
 	env.Append(CPPFLAGS=['-DOPENGL_ENABLED','-DGLEW_ENABLED'])
 	if platform.system() == 'Linux':
 		env.Append(CPPFLAGS=["-DALSA_ENABLED"])
 		env.Append(LIBS=['asound'])
 
-		if not os.system("pkg-config --exists libudev"):
-			if not os.system("pkg-config --exists libevdev"):
-				print("Enabling udev/evdev")
-				env.Append(CPPFLAGS=["-DJOYDEV_ENABLED"])
-				env.ParseConfig('pkg-config libudev --cflags --libs')
-				env.ParseConfig('pkg-config libevdev --cflags --libs')
-			else:
-				print("libevdev development libraries not found, disabling gamepad support")
+	if (env["gamepad"]=="yes" and platform.system() == "Linux"):
+		# pkg-config returns 0 when the lib exists...
+		found_udev = not os.system("pkg-config --exists libudev")
+		found_evdev = not os.system("pkg-config --exists libevdev")
+		
+		if (found_udev and found_evdev):
+			print("Enabling gamepad support with udev/evdev")
+			env.Append(CPPFLAGS=["-DJOYDEV_ENABLED"])
+			env.ParseConfig('pkg-config libudev --cflags --libs')
+			env.ParseConfig('pkg-config libevdev --cflags --libs')
 		else:
-			print("libudev development libraries not found, disabling gamepad support")
+			if (not found_udev):
+				print("libudev development libraries not found")
+			if (not found_evdev):
+				print("libevdev development libraries not found")
+			print("Some libraries are missing for the required gamepad support, aborting!")
+			print("Install the mentioned libraries or build with 'gamepad=no' to disable gamepad support.")
+			sys.exit(255)
 
 	if (env["pulseaudio"]=="yes"):
 		if not os.system("pkg-config --exists libpulse-simple"):


### PR DESCRIPTION
(i.e. it's enabled by default, users have to specifically ask for it if they don't want gamepad support)
Follow-up on #49.

Note that right now the "gamepad" option is X11-specific, as the checks for libudev and libevdev are only done there. I also removed the "Linux" condition though, as @reduz hinted that udev and evdev should work fine on FreeBSD too.
