### PR TITLE
Fix config file parser bug that cause showing project name as "Unnamed Project"

### DIFF
--- a/core/variant_parser.cpp
+++ b/core/variant_parser.cpp
@@ -1634,6 +1634,7 @@ Error VariantParser::parse_tag_assign_eof(Stream *p_stream, int &line, String &r
 
 
 	//assign..
+	r_assign="";
 	String what;
 
 	while(true) {


### PR DESCRIPTION
Fixes #3178 
