### PR TITLE
TextEdit/LineEdit: Handle numpad when NumLock is disabled

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -245,12 +245,26 @@ void LineEdit::_input_event(InputEvent p_event) {
 								delete_char();
 						}
 					} break;
+					case KEY_KP_4: {
+						if (k.unicode != 0) {
+							handled = false;
+							break;
+						}
+						// numlock disabled. fallthrough to key_left
+					}
 					case KEY_LEFT: {
 						shift_selection_check_pre(k.mod.shift);
 						set_cursor_pos(get_cursor_pos()-1);
 						shift_selection_check_post(k.mod.shift);
 
 					} break;
+					case KEY_KP_6: {
+						if (k.unicode != 0) {
+							handled = false;
+							break;
+						}
+						// numlock disabled. fallthrough to key_right
+					}
 					case KEY_RIGHT: {
 
 						shift_selection_check_pre(k.mod.shift);
@@ -287,26 +301,27 @@ void LineEdit::_input_event(InputEvent p_event) {
 
 					default: {
 
-						if (k.unicode>=32 && k.scancode!=KEY_DELETE) {
-
-							if (editable) {
-								selection_delete();
-								CharType ucodestr[2]={(CharType)k.unicode,0};
-								append_at_cursor(ucodestr);
-								emit_signal("text_changed",text);
-								_change_notify("text");
-							}
-
-						} else {
-							handled=false;
-						}
+						handled=false;
 					} break;
 				}
 
-				if (handled)
+				if (handled) {
 					accept_event();
-				else
-					return;
+				} else {
+					if (k.unicode>=32 && k.scancode!=KEY_DELETE) {
+
+						if (editable) {
+							selection_delete();
+							CharType ucodestr[2]={(CharType)k.unicode,0};
+							append_at_cursor(ucodestr);
+							emit_signal("text_changed",text);
+							_change_notify("text");
+						}
+
+					} else {
+						return;
+					}
+				}
 
 
 				selection.old_shift=k.mod.shift;

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -285,12 +285,26 @@ void LineEdit::_input_event(InputEvent p_event) {
 						}
 
 					} break;
+					case KEY_KP_7: {
+						if (k.unicode != 0) {
+							handled = false;
+							break;
+						}
+						// numlock disabled. fallthrough to key_home
+					}
 					case KEY_HOME: {
 
 						shift_selection_check_pre(k.mod.shift);
 						set_cursor_pos(0);
 						shift_selection_check_post(k.mod.shift);
 					} break;
+					case KEY_KP_1: {
+						if (k.unicode != 0) {
+							handled = false;
+							break;
+						}
+						// numlock disabled. fallthrough to key_end
+					}
 					case KEY_END: {
 
 						shift_selection_check_pre(k.mod.shift);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1740,6 +1740,13 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 					}
 
 				} break;
+				case KEY_KP_4: {
+					if (k.unicode != 0) {
+						scancode_handled = false;
+						break;
+					}
+					// numlock disabled. fallthrough to key_left
+				}
 				case KEY_LEFT: {
 					
 					if (k.mod.shift)
@@ -1786,6 +1793,13 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 						_post_shift_selection();
 					
 				} break;
+				case KEY_KP_6: {
+					if (k.unicode != 0) {
+						scancode_handled = false;
+						break;
+					}
+					// numlock disabled. fallthrough to key_right
+				}
 				case KEY_RIGHT: {
 					
 					if (k.mod.shift)
@@ -1829,6 +1843,13 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 						_post_shift_selection();
 					
 				} break;
+				case KEY_KP_8: {
+					if (k.unicode != 0) {
+						scancode_handled = false;
+						break;
+					}
+					// numlock disabled. fallthrough to key_up
+				}
 				case KEY_UP: {
 					
 					if (k.mod.shift)
@@ -1849,6 +1870,13 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 					_cancel_code_hint();
 					
 				} break;
+				case KEY_KP_2: {
+					if (k.unicode != 0) {
+						scancode_handled = false;
+						break;
+					}
+					// numlock disabled. fallthrough to key_down
+				}
 				case KEY_DOWN: {
 					
 					if (k.mod.shift)

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1965,6 +1965,13 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 					update();
 
 				} break;
+				case KEY_KP_7: {
+					if (k.unicode != 0) {
+						scancode_handled = false;
+						break;
+					}
+					// numlock disabled. fallthrough to key_home
+				}
 #ifdef APPLE_STYLE_KEYS
 				case KEY_HOME: {
 					
@@ -1978,18 +1985,6 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 						_post_shift_selection();
 					
 				} break;
-				case KEY_END: {
-					
-					if (k.mod.shift)
-						_pre_shift_selection();
-					
-					cursor_set_line(text.size()-1);
-					
-					if (k.mod.shift)
-						_post_shift_selection();
-					
-				} break;
-					
 #else
 				case KEY_HOME: {
 					
@@ -2020,6 +2015,27 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 					completion_hint="";
 					
 				} break;
+#endif
+				case KEY_KP_1: {
+					if (k.unicode != 0) {
+						scancode_handled = false;
+						break;
+					}
+					// numlock disabled. fallthrough to key_end
+				}
+#ifdef APPLE_STYLE_KEYS
+				case KEY_END: {
+
+					if (k.mod.shift)
+						_pre_shift_selection();
+
+					cursor_set_line(text.size()-1);
+
+					if (k.mod.shift)
+						_post_shift_selection();
+
+				} break;
+#else
 				case KEY_END: {
 					
 					if (k.mod.shift)
@@ -2037,6 +2053,13 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 					
 				} break;
 #endif
+				case KEY_KP_9: {
+					if (k.unicode != 0) {
+						scancode_handled = false;
+						break;
+					}
+					// numlock disabled. fallthrough to key_pageup
+				}
 				case KEY_PAGEUP: {
 					
 					if (k.mod.shift)
@@ -2052,6 +2075,13 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 
 					
 				} break;
+				case KEY_KP_3: {
+					if (k.unicode != 0) {
+						scancode_handled = false;
+						break;
+					}
+					// numlock disabled. fallthrough to key_pageup
+				}
 				case KEY_PAGEDOWN: {
 					
 					if (k.mod.shift)


### PR DESCRIPTION
A small request from the list on #2982:

> numpad arrow/home/end/pgup/pgdn should work as usual when numlock is off
> -- grigi
