### PR TITLE
Fix maven repositories bug

### DIFF
--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -45,8 +45,11 @@ gradle_text = gradle_basein.read()
 
 gradle_maven_repos_text=""
 
-for x in env.android_maven_repos:
-	gradle_maven_repos_text+=x+"\n"
+if len(env.android_maven_repos) > 0:
+	gradle_maven_repos_text+="maven {\n"
+	for x in env.android_maven_repos:
+		gradle_maven_repos_text+="\t\t"+x+"\n"
+	gradle_maven_repos_text+="\t}\n"
 
 gradle_maven_dependencies_text=""
 

--- a/platform/android/build.gradle.template
+++ b/platform/android/build.gradle.template
@@ -12,9 +12,7 @@ apply plugin: 'com.android.application'
 allprojects {
     repositories {
 	mavenCentral()
-	maven {
-		$$GRADLE_REPOSITORY_URLS$$
-	}
+	$$GRADLE_REPOSITORY_URLS$$
     }
 }
 


### PR DESCRIPTION
If a dependency added to gradle dependencies, previous gradle template cause build to be failed. This fixes second bug reported by @volzhs at #3285.
