### PR TITLE
Fix build (pthread renaming) on Open/FreeBSD

### DIFF
--- a/drivers/unix/thread_posix.cpp
+++ b/drivers/unix/thread_posix.cpp
@@ -30,6 +30,10 @@
 
 #if defined(UNIX_ENABLED) || defined(PTHREAD_ENABLED)
 
+#ifdef PTHREAD_BSD_SET_NAME
+#include <pthread_np.h>
+#endif
+
 #include "os/memory.h"
 
 Thread::ID ThreadPosix::get_ID() const {
@@ -100,9 +104,14 @@ Error ThreadPosix::set_name(const String& p_name) {
 	
 	#else
 
+	#ifdef PTHREAD_BSD_SET_NAME
+	pthread_set_name_np(pthread, p_name.utf8().get_data());
+	int err = 0; // Open/FreeBSD ignore errors in this function
+	#else
 	int err = pthread_setname_np(pthread, p_name.utf8().get_data());
+	#endif // PTHREAD_BSD_SET_NAME
 
-	#endif
+	#endif // PTHREAD_RENAME_SELF
 
 	return err == 0 ? OK : ERR_INVALID_PARAMETER;
 

--- a/platform/x11/platform_config.h
+++ b/platform/x11/platform_config.h
@@ -31,6 +31,7 @@
 #endif
 #if defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <stdlib.h>
+#define PTHREAD_BSD_SET_NAME
 #endif
 
 #define GLES2_INCLUDE_H "gl_context/glew.h"


### PR DESCRIPTION
- declared in `pthread_np.h`
- written with underscore `pthread_set_name_np`
- does not return:
  
  > Because of the debugging nature of this function,
  > all errors that may appear inside are silently ignored.
  >   https://www.freebsd.org/cgi/man.cgi?query=pthread_set_name_np&sektion=3
