### PR TITLE
fix: TouchScreenButton should stop propagating action when button is …

### DIFF
--- a/scene/2d/screen_button.cpp
+++ b/scene/2d/screen_button.cpp
@@ -102,6 +102,10 @@ void TouchScreenButton::_notification(int p_what) {
 				action_id=-1;
 			}
 		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			if (is_pressed())
+				Input::get_singleton()->action_release(action);
+		} break;
 	}
 }
 


### PR DESCRIPTION
…removed from scene

Looks like an unreported issue, i didn0t find anything on issues
