### PR TITLE
Replace export pack mode "Copy" with "Exec+Zip"

### DIFF
--- a/tools/editor/editor_import_export.h
+++ b/tools/editor/editor_import_export.h
@@ -175,8 +175,7 @@ public:
 	enum ExportMode {
 		EXPORT_EXE,
 		EXPORT_PACK,
-		EXPORT_COPY,
-		EXPORT_BUNDLES
+		EXPORT_ZIP
 	};
 
 
@@ -198,6 +197,7 @@ private:
 	Ref<Texture> logo;
 
 	ExportMode export_mode;
+	bool bundle;
 protected:
 
 	bool _set(const StringName& p_name, const Variant& p_value);


### PR DESCRIPTION
Comment on this from #godotengine-devel:

```
16:04:38 <eska> what's "Pack mode: Copy" supposed to do? sounds like it's supposed to just recreate the file structure (instead of a pck), but it doesn't seem to work
16:11:06 <eska> reduzio, punto, seems like it's that way since 1.1, so probably no one knows other than you? ^
16:16:44 <reduzio> eska, that needs to be removed, it's pretty dangerous :|
16:17:14 <reduzio> godot support exporting all the files to a folder instead of packing them and use them unpacked
16:17:42 <reduzio> but updating a directory tree is kinda dangerous, so it's either changed to work exporting a zip with all stuff, or removed
```

This change removes pack mode "Copy" and adds "Exec+Zip". I also renamed the options to hopefully be more expressive.
Additionally, `bundle` is now a separate toggle.

Related: #2788, #2879
