### PR TITLE
Update Copyright for 2016

### DIFF
--- a/tools/editor/editor_log.cpp
+++ b/tools/editor/editor_log.cpp
@@ -243,7 +243,7 @@ EditorLog::EditorLog() {
 	log->set_selection_enabled(true);
 	log->set_focus_mode(FOCUS_CLICK);
 	pc->add_child(log);
-	add_message(VERSION_FULL_NAME" (c) 2008-2015 Juan Linietsky, Ariel Manzur.");
+	add_message(VERSION_FULL_NAME" (c) 2008-2016 Juan Linietsky, Ariel Manzur.");
 	//log->add_text("Initialization Complete.\n"); //because it looks cool.
 	add_style_override("panel",get_stylebox("panelf","Panel"));
 

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -3174,7 +3174,7 @@ Error EditorNode::save_translatable_strings(const String& p_to_file) {
 	OS::Time time = OS::get_singleton()->get_time();
 	f->store_line("# Translation Strings Dump.");
 	f->store_line("# Created By.");
-	f->store_line("# \t" VERSION_FULL_NAME " (c) 2008-2015 Juan Linietsky, Ariel Manzur.");
+	f->store_line("# \t" VERSION_FULL_NAME " (c) 2008-2016 Juan Linietsky, Ariel Manzur.");
 	f->store_line("# From Scene: ");
 	f->store_line("# \t"+get_edited_scene()->get_filename());
 	f->store_line("");
@@ -5808,7 +5808,7 @@ EditorNode::EditorNode() {
 	about->get_ok()->set_text("Thanks!");
 	about->set_hide_on_ok(true);
 	Label *about_text = memnew( Label );
-	about_text->set_text(VERSION_FULL_NAME"\n(c) 2008-2015 Juan Linietsky, Ariel Manzur.\n");
+	about_text->set_text(VERSION_FULL_NAME"\n(c) 2008-2016 Juan Linietsky, Ariel Manzur.\n");
 	about_text->set_pos(Point2(gui_base->get_icon("Logo","EditorIcons")->get_size().width+30,20));
 	gui_base->add_child(about);
 	about->add_child(about_text);

--- a/tools/editor/project_manager.cpp
+++ b/tools/editor/project_manager.cpp
@@ -964,7 +964,7 @@ ProjectManager::ProjectManager() {
 	String cp;
 	cp.push_back(0xA9);
 	cp.push_back(0);
-	l->set_text(cp+" 2008-2015 Juan Linietsky, Ariel Manzur.");
+	l->set_text(cp+" 2008-2016 Juan Linietsky, Ariel Manzur.");
 	l->set_align(Label::ALIGN_CENTER);
 	vb->add_child(l);
 


### PR DESCRIPTION
Update Copyright from 2015 to 2016 for Project Manager Window, About Godot, and Editor Log.

[ Before ]
![about godot - 2015](https://cloud.githubusercontent.com/assets/16637478/12241370/ffb04df0-b8bc-11e5-8711-a7214ac07f5b.png)

[ After ]
![about godot - 2016](https://cloud.githubusercontent.com/assets/16637478/12241381/19a71ef0-b8bd-11e5-85e1-9762296248e4.png)
![godot project manager - 2016](https://cloud.githubusercontent.com/assets/16637478/12241388/248bc348-b8bd-11e5-80fc-56c6bb5acd65.png)
