### PR TITLE
Color Ramp Editor Plugin Fix

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -5963,7 +5963,8 @@ EditorNode::EditorNode() {
 	add_editor_plugin( memnew( Polygon2DEditorPlugin(this) ) );
 	add_editor_plugin( memnew( LightOccluder2DEditorPlugin(this) ) );
 	add_editor_plugin( memnew( NavigationPolygonEditorPlugin(this) ) );
-	add_editor_plugin( memnew( ColorRampEditorPlugin(this) ) );
+	add_editor_plugin( memnew( ColorRampEditorPlugin(this,true) ) );
+	add_editor_plugin( memnew( ColorRampEditorPlugin(this,false) ) );
 	add_editor_plugin( memnew( CollisionShape2DEditorPlugin(this) ) );
 
 	for(int i=0;i<EditorPlugins::get_plugin_count();i++)

--- a/tools/editor/plugins/color_ramp_editor_plugin.cpp
+++ b/tools/editor/plugins/color_ramp_editor_plugin.cpp
@@ -3,14 +3,20 @@
  */
 
 #include "color_ramp_editor_plugin.h"
+#include "spatial_editor_plugin.h"
+#include "canvas_item_editor_plugin.h"
 
-ColorRampEditorPlugin::ColorRampEditorPlugin(EditorNode *p_node) {
+ColorRampEditorPlugin::ColorRampEditorPlugin(EditorNode *p_node, bool p_2d) {
 
 	editor=p_node;
 	ramp_editor = memnew( ColorRampEdit );
 
-	add_custom_control(CONTAINER_CANVAS_EDITOR_BOTTOM,ramp_editor);
-	//add_custom_control(CONTAINER_SPATIAL_EDITOR_BOTTOM,ramp_editor);
+	_2d=p_2d;
+	if (p_2d)
+		add_custom_control(CONTAINER_CANVAS_EDITOR_BOTTOM,ramp_editor);
+	else
+		add_custom_control(CONTAINER_SPATIAL_EDITOR_BOTTOM,ramp_editor);
+
 	ramp_editor->set_custom_minimum_size(Size2(100, 48));
 	ramp_editor->hide();
 	ramp_editor->connect("ramp_changed", this, "ramp_changed");
@@ -27,7 +33,10 @@ void ColorRampEditorPlugin::edit(Object *p_object) {
 
 bool ColorRampEditorPlugin::handles(Object *p_object) const {
 
-	return p_object->is_type("ColorRamp");
+	if (_2d)
+		return p_object->is_type("ColorRamp") && CanvasItemEditor::get_singleton()->is_visible() == true;
+	else
+		return p_object->is_type("ColorRamp") && SpatialEditor::get_singleton()->is_visible() == true;
 }
 
 void ColorRampEditorPlugin::make_visible(bool p_visible) {

--- a/tools/editor/plugins/color_ramp_editor_plugin.h
+++ b/tools/editor/plugins/color_ramp_editor_plugin.h
@@ -13,6 +13,7 @@ class ColorRampEditorPlugin : public EditorPlugin {
 
 	OBJ_TYPE( ColorRampEditorPlugin, EditorPlugin );
 
+	bool _2d;
 	Ref<ColorRamp> color_ramp_ref;
 	ColorRampEdit *ramp_editor;
 	EditorNode *editor;
@@ -29,7 +30,7 @@ public:
 	virtual bool handles(Object *p_node) const;
 	virtual void make_visible(bool p_visible);
 
-	ColorRampEditorPlugin(EditorNode *p_node);
+	ColorRampEditorPlugin(EditorNode *p_node, bool p_2d);
 	~ColorRampEditorPlugin();
 
 };


### PR DESCRIPTION
The Color Ramp Editor originally only assigned itself to the canvas editor thereby only making it appear when editing canvas item-derived nodes and not spatial-derived. I've modified it now to work on both, similar to the shader editor.
