### PR TITLE
Ability to hide  panel with scripts

### DIFF
--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -2331,7 +2331,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 
 	script_list = memnew( ItemList );
 	script_split->add_child(script_list);
-	script_list->set_custom_minimum_size(Size2(70,0));
+	script_list->set_custom_minimum_size(Size2(0,0));
 	script_split->set_split_offset(70);
 
 	tab_container = memnew( TabContainer );


### PR DESCRIPTION
Minimal horizontal size for  panel with scripts was = 70, changed it to 0.
It's especially helpful if someone is working on a laptop, or just don't like to have anything on the left side of the screen.
Video  that shows how it's working after the change: https://www.youtube.com/watch?v=Y_o4pOpjyhY&feature=youtu.be
