### PR TITLE
Quaternion uniform assignment.

### DIFF
--- a/drivers/gles2/shader_gles2.h
+++ b/drivers/gles2/shader_gles2.h
@@ -205,6 +205,11 @@ private:
 			Plane val=p_value;
 			glUniform4f( p_uniform, val.normal.x,val.normal.y,val.normal.z,val.d );
 		} break;
+		case Variant::QUAT: {
+
+			Quat val=p_value;
+			glUniform4f( p_uniform, val.x,val.y,val.z,val.w );
+		} break;
 
 		case Variant::MATRIX32: {
 


### PR DESCRIPTION
Fixes a bug which prevents shader vec4 uniforms from assigned to by quaternion types. They originally only worked with plane types. Fixing this should avoid some unnecessary confusion.
