### PR TITLE
Spatial/Canvas Editor: Ignore unhandled input if there is a dialog

### DIFF
--- a/tools/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/tools/editor/plugins/canvas_item_editor_plugin.cpp
@@ -194,7 +194,7 @@ void CanvasItemEditor::_edit_set_pivot(const Vector2& mouse_pos) {
 
 void CanvasItemEditor::_unhandled_key_input(const InputEvent& p_ev) {
 
-	if (!is_visible())
+	if (!is_visible() || window_has_modal_stack())
 		return;
 	if (p_ev.key.mod.control)
 		// prevent to change tool mode when control key is pressed

--- a/tools/editor/plugins/spatial_editor_plugin.cpp
+++ b/tools/editor/plugins/spatial_editor_plugin.cpp
@@ -3529,10 +3529,10 @@ void SpatialEditor::_instance_scene() {
 
 void SpatialEditor::_unhandled_key_input(InputEvent p_event) {
 
-	if (!is_visible())
+	if (!is_visible() || window_has_modal_stack())
 		return;
 
-	 {
+	{
 
 		EditorNode *en = editor;
 		EditorPlugin *over_plugin = en->get_editor_plugin_over();


### PR DESCRIPTION
Ignore unhandled input if there is a dialog visible. However, I am not sure if there is any other situation where these editors catch this input when they shouldn't.
Fixed #3348
