### PR TITLE
F5 hotkey to refresh FileDialog/EditorFileDialog

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -85,6 +85,10 @@ void FileDialog::_unhandled_input(const InputEvent& p_event) {
 					}
 
 				} break;
+				case KEY_F5: {
+
+					invalidate();
+				} break;
 				default: { handled=false; }
 			}
 

--- a/tools/editor/editor_file_dialog.cpp
+++ b/tools/editor/editor_file_dialog.cpp
@@ -90,6 +90,10 @@ void EditorFileDialog::_unhandled_input(const InputEvent& p_event) {
 					}
 
 				} break;
+				case KEY_F5: {
+
+					invalidate();
+				} break;
 				default: { handled=false; }
 			}
 


### PR DESCRIPTION
Related to #1123, but it may not entirely fix the issue (continue reading).

The unhandled input is captured before the EditorNode captures it, so it won't fire run. At least it does so for the file dialogs that are child of EditorNode.
Are the input events spread in a tree way, children before parent? If so, perhaps we should check if a dialog is visible before handling that input in editor node, which I am not sure how to do since:

> _EditorNode_ inherits from _Node_ so it cannot call `Control::window_has_modal_stack()`, and this method is private so it cannot be called on _EditorNode_'s `gui_base`
