### PR TITLE
Fix 32 bit windows export crash

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -339,7 +339,13 @@ def configure(env):
 
 		if (env["target"]=="release"):
 			
-			env.Append(CCFLAGS=['-O3','-ffast-math','-fomit-frame-pointer','-msse2'])
+			env.Append(CCFLAGS=['-ffast-math','-fomit-frame-pointer','-msse2'])
+
+			if (env["bits"]=="64"):
+				env.Append(CCFLAGS=['-O3'])
+			else:
+				env.Append(CCFLAGS=['-O2'])
+
 			env.Append(LINKFLAGS=['-Wl,--subsystem,windows'])
 
 		elif (env["target"]=="release_debug"):
@@ -382,7 +388,7 @@ def configure(env):
 
 		#'d3dx9d'
 		env.Append(CPPFLAGS=['-DMINGW_ENABLED'])
-		env.Append(LINKFLAGS=['-g'])
+		#env.Append(LINKFLAGS=['-g'])
 
 		# resrc
 		env['is_mingw']=True


### PR DESCRIPTION
Fixes #2189 and #1868.
I don't know these build warnings were related to this issue or not but after change -O3 compiler option to -O2 they gone:
`scene/libscene.windows.opt.32.a(shader_graph.windows.opt.32.o): duplicate section .data$_ZZN4Math9fast_ftoiEfE1b[__ZZN4Math9fast_ftoiEfE1b]' has different size
servers/libservers.windows.opt.32.a(audio_mixer_sw.windows.opt.32.o): duplicate section .data$_ZZN4Math9fast_ftoiEfE1b[__ZZN4Math9fast_ftoiEfE1b]' has different size`
and 32 bit release Windows export doesn't crash anymore.
Built on ubuntu 14.04 64 bit and tested on windows 7 64 bit.
