### PR TITLE
New shader nodes are now created under (more or less) the cursor.

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -42,7 +42,6 @@ bool GraphEdit::is_node_connected(const StringName& p_from, int p_from_port,cons
 
 void GraphEdit::disconnect_node(const StringName& p_from, int p_from_port,const StringName& p_to,int p_to_port){
 
-
 	for(List<Connection>::Element *E=connections.front();E;E=E->next()) {
 
 		if (E->get().from==p_from && E->get().from_port==p_from_port && E->get().to==p_to && E->get().to_port==p_to_port) {
@@ -59,9 +58,12 @@ void GraphEdit::get_connection_list(List<Connection> *r_connections) const {
 	*r_connections=connections;
 }
 
+Vector2 GraphEdit::get_scroll_ofs() const{
+
+	return Vector2(h_scroll->get_val(),v_scroll->get_val());
+}
 
 void GraphEdit::_scroll_moved(double) {
-
 
 	_update_scroll_offset();
 	top_layer->update();
@@ -718,6 +720,7 @@ void GraphEdit::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("is_node_connected","from","from_port","to","to_port"),&GraphEdit::is_node_connected);
 	ObjectTypeDB::bind_method(_MD("disconnect_node","from","from_port","to","to_port"),&GraphEdit::disconnect_node);
 	ObjectTypeDB::bind_method(_MD("get_connection_list"),&GraphEdit::_get_connection_list);
+	ObjectTypeDB::bind_method(_MD("get_scroll_ofs"),&GraphEdit::get_scroll_ofs);
 
 	ObjectTypeDB::bind_method(_MD("set_right_disconnects","enable"),&GraphEdit::set_right_disconnects);
 	ObjectTypeDB::bind_method(_MD("is_right_disconnects_enabled"),&GraphEdit::is_right_disconnects_enabled);

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -101,6 +101,8 @@ public:
 
 	void set_right_disconnects(bool p_enable);
 	bool is_right_disconnects_enabled() const;
+	
+	Vector2 get_scroll_ofs() const;
 
 
 	GraphEdit();

--- a/tools/editor/plugins/shader_graph_editor_plugin.cpp
+++ b/tools/editor/plugins/shader_graph_editor_plugin.cpp
@@ -2658,13 +2658,13 @@ void ShaderGraphEditor::edit(Ref<ShaderGraph> p_shader) {
 void ShaderGraphEditor::_add_node(int p_type) {
 
 	ShaderGraph::ShaderType shader_type=ShaderGraph::ShaderType(tabs->get_current_tab());
-
 	graph_edits[shader_type]->add_node(p_type, next_location);
 }
 
 void ShaderGraphEditor::_popup_requested(const Vector2 &p_position)
 {
-	next_location = get_local_mouse_pos();
+	Vector2 scroll_ofs=graph_edits[tabs->get_current_tab()]->get_graph_edit()->get_scroll_ofs();
+	next_location = get_local_mouse_pos() + scroll_ofs;
 	popup->set_global_pos(p_position);
 	popup->set_size( Size2( 200, 0) );
 	popup->popup();

--- a/tools/editor/plugins/shader_graph_editor_plugin.h
+++ b/tools/editor/plugins/shader_graph_editor_plugin.h
@@ -149,7 +149,7 @@ class ShaderGraphView : public Node {
 	void _end_node_move();
 	void _move_node(int p_id,const Vector2& p_to);
 	void _duplicate_nodes_request();
-    void _duplicate_nodes(const Array &p_nodes);
+	void _duplicate_nodes(const Array &p_nodes);
 	void _delete_nodes_request();
 
 


### PR DESCRIPTION
Shader nodes were created at seemingly random locations. It happened because get_local_mouse_pos doesn't take into account scroll offset.

A new public method has been created in graph_edit.cpp to allow reading the scroll offset.
