### PR TITLE
thumbnail preview for AtlasTextures

### DIFF
--- a/tools/editor/plugins/editor_preview_plugins.cpp
+++ b/tools/editor/plugins/editor_preview_plugins.cpp
@@ -10,13 +10,26 @@
 
 bool EditorTexturePreviewPlugin::handles(const String& p_type) const {
 
-	return ObjectTypeDB::is_type(p_type,"ImageTexture");
+	return (ObjectTypeDB::is_type(p_type,"ImageTexture") || ObjectTypeDB::is_type(p_type, "AtlasTexture"));
 }
 
 Ref<Texture> EditorTexturePreviewPlugin::generate(const RES& p_from) {
 
-	Ref<ImageTexture> tex =p_from;
-	Image img = tex->get_data();
+	Image img;
+	Ref<AtlasTexture> atex = p_from;
+	if (atex.is_valid()) {
+		Ref<ImageTexture> tex = atex->get_atlas();
+		if (!tex.is_valid()) {
+			return Ref<Texture>();
+		}
+		Image atlas = tex->get_data();
+		img = atlas.get_rect(atex->get_region());
+	}
+	else {
+		Ref<ImageTexture> tex = p_from;
+		img = tex->get_data();
+	}
+
 	if (img.empty())
 		return Ref<Texture>();
 


### PR DESCRIPTION
Fixes #3372 
AtlasTextures that reference a `LargeTexture` will still show the default icon, but I think regular Textures are the most common case.
