### PR TITLE
Wider initial size of the panel with scripts

### DIFF
--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -2329,7 +2329,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	script_list = memnew( ItemList );
 	script_split->add_child(script_list);
 	script_list->set_custom_minimum_size(Size2(0,0));
-	script_split->set_split_offset(70);
+	script_split->set_split_offset(140);
 
 	tab_container = memnew( TabContainer );
 	tab_container->set_tabs_visible(false);


### PR DESCRIPTION
I believe it's size is now exactly the same how it was before commit that allowed to hide script panel entirely (https://github.com/godotengine/godot/commit/d4a2409334764f2b29503a93c505603ec122c8db). 
I assume previously it was 140 wide because of 70px of minimal size + 70px of offset, so now when minimal size is 0 the offset need to be 140.
