### PR TITLE
html5 gamepad support

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -478,6 +478,13 @@ static const char *s_ControllerMappings [] =
 	#if defined(__ANDROID__)
 	"4e564944494120436f72706f72617469,NVIDIA Controller,a:b0,b:b1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,leftshoulder:b9,leftstick:b7,lefttrigger:a4,leftx:a0,lefty:a1,rightshoulder:b10,rightstick:b8,righttrigger:a5,rightx:a2,righty:a3,start:b6,x:b2,y:b3,",
 	#endif
+
+	#ifdef JAVASCRIPT_ENABLED
+	"Default HTML5 Gamepad, Default Mapping,leftx:a0,lefty:a1,dpdown:b13,rightstick:b11,rightshoulder:b5,rightx:a2,start:b9,righty:a3,dpleft:b14,lefttrigger:a6,x:b2,dpup:b12,back:b8,leftstick:b10,leftshoulder:b4,y:b3,a:b0,dpright:b15,righttrigger:a7,b:b1,",
+	"303534632d303236382d536f6e792050,PS3 Controller USB,leftx:a0,lefty:a1,dpdown:b6,rightstick:b2,rightshoulder:b11,rightx:a2,start:b3,righty:a3,dpleft:b7,lefttrigger:b8,x:b15,dpup:b4,back:b0,leftstick:b1,leftshoulder:b10,y:b12,a:b14,dpright:b5,righttrigger:b9,b:b13,",
+	"303534632d303563342d536f6e792043,PS4 Controller USB,leftx:a0,lefty:a1,dpdown:a7,rightstick:b11,rightshoulder:b5,rightx:a2,start:b9,righty:a5,dpleft:a6,lefttrigger:a3,x:b0,dpup:a7,back:b8,leftstick:b10,leftshoulder:b4,y:b3,a:b1,dpright:a6,righttrigger:a4,b:b2,",
+	"303435652d303238652d4d6963726f73,Nacon X360 Clone(XInput),leftx:a0,lefty:a1,dpdown:a7,rightstick:b10,rightshoulder:b5,rightx:a3,start:b7,righty:a4,dpleft:a6,lefttrigger:a2,x:b2,dpup:a7,back:b6,leftstick:b9,leftshoulder:b4,y:b3,a:b0,dpright:a6,righttrigger:a5,b:b1,",
+	#endif
 	NULL
 };
 
@@ -606,6 +613,41 @@ uint32_t InputDefault::joy_axis(uint32_t p_last_id, int p_device, int p_axis, co
 			float value = p_value.min == 0 ? p_value.value : 0.5f + p_value.value / 2.0f;
 			int axis = map.index == JOY_L2 ? JOY_ANALOG_L2 : JOY_ANALOG_R2;
 			p_last_id = _axis_event(p_last_id, p_device, axis, value);
+		}
+
+		if (map.index == JOY_DPAD_UP || map.index == JOY_DPAD_DOWN) {
+			bool pressed = p_value.value != 0.0f;
+			int button = p_value.value < 0 ? JOY_DPAD_UP : JOY_DPAD_DOWN;
+
+			if (!pressed) {
+				if (joy_buttons_pressed.has(_combine_device(JOY_DPAD_UP, p_device))) {
+					p_last_id = _button_event(p_last_id, p_device, JOY_DPAD_UP, false);
+				}
+				if (joy_buttons_pressed.has(_combine_device(JOY_DPAD_DOWN, p_device))) {
+					p_last_id = _button_event(p_last_id, p_device, JOY_DPAD_DOWN, false);
+				}
+			}
+			if ( pressed == joy_buttons_pressed.has(_combine_device(button, p_device))) {
+				return p_last_id;
+			}
+			return _button_event(p_last_id, p_device, button, true);
+		}
+		if (map.index == JOY_DPAD_LEFT || map.index == JOY_DPAD_RIGHT) {
+			bool pressed = p_value.value != 0.0f;
+			int button = p_value.value < 0 ? JOY_DPAD_LEFT : JOY_DPAD_RIGHT;
+
+			if (!pressed) {
+				if (joy_buttons_pressed.has(_combine_device(JOY_DPAD_LEFT, p_device))) {
+					p_last_id = _button_event(p_last_id, p_device, JOY_DPAD_LEFT, false);
+				}
+				if (joy_buttons_pressed.has(_combine_device(JOY_DPAD_RIGHT, p_device))) {
+					p_last_id = _button_event(p_last_id, p_device, JOY_DPAD_RIGHT, false);
+				}
+			}
+			if ( pressed == joy_buttons_pressed.has(_combine_device(button, p_device))) {
+				return p_last_id;
+			}
+			return _button_event(p_last_id, p_device, button, true);
 		}
 		float deadzone = p_value.min == 0 ? 0.5f : 0.0f;
 		bool pressed = p_value.value > deadzone ? true : false;

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -76,6 +76,14 @@ void OS_JavaScript::set_opengl_extensions(const char* p_gl_extensions) {
 	gl_extensions=p_gl_extensions;
 }
 
+static EM_BOOL joy_callback_func(int p_type, const EmscriptenGamepadEvent *p_event, void *p_user) {
+	OS_JavaScript *os = (OS_JavaScript*) OS::get_singleton();
+	if (os) {
+		return os->joy_connection_changed(p_type, p_event);
+	}
+	return false;
+}
+
 void OS_JavaScript::initialize(const VideoMode& p_desired,int p_video_driver,int p_audio_driver) {
 
 	print_line("Init OS");
@@ -142,6 +150,8 @@ void OS_JavaScript::initialize(const VideoMode& p_desired,int p_video_driver,int
 
 	input = memnew( InputDefault );
 
+	emscripten_set_gamepadconnected_callback(NULL, true, &joy_callback_func);
+	emscripten_set_gamepaddisconnected_callback(NULL, true, &joy_callback_func);
 }
 
 void OS_JavaScript::set_main_loop( MainLoop * p_main_loop ) {
@@ -296,7 +306,7 @@ bool OS_JavaScript::main_loop_iterate() {
 
 
 	}
-
+	process_joysticks();
 	return Main::iteration();
 }
 
@@ -603,6 +613,62 @@ void OS_JavaScript::_close_notification_funcs(const String& p_file,int p_flags) 
 		static_cast<OS_JavaScript*>(get_singleton())->last_sync_time=OS::get_singleton()->get_ticks_msec();
 		static_cast<OS_JavaScript*>(get_singleton())->time_to_save_sync=5000; //five seconds since last save
 	}
+}
+
+void OS_JavaScript::process_joysticks() {
+
+	int joy_count = emscripten_get_num_gamepads();
+	for (int i = 0; i < joy_count; i++) {
+		EmscriptenGamepadEvent state;
+		emscripten_get_gamepad_status(i, &state);
+		if (state.connected) {
+
+			int num_buttons = MIN(state.numButtons, 16);
+			int num_axes = MIN(state.numAxes, 8);
+			for (int j = 0; j < num_buttons; j++) {
+
+				float value = state.analogButton[j];
+				if (String(state.mapping) == "standard" && (j == 6 || j == 7)) {
+					InputDefault::JoyAxis jx;
+					jx.min = 0;
+					jx.value = value;
+					last_id = input->joy_axis(last_id, i, j, jx);
+				}
+				else {
+					last_id = input->joy_button(last_id, i, j, value);
+				}
+			}
+			for (int j = 0; j < num_axes; j++) {
+
+				InputDefault::JoyAxis jx;
+				jx.min = -1;
+				jx.value = state.axis[j];
+				last_id = input->joy_axis(last_id, i, j, jx);
+			}
+		}
+	}
+}
+
+bool OS_JavaScript::joy_connection_changed(int p_type, const EmscriptenGamepadEvent *p_event) {
+	if (p_type == EMSCRIPTEN_EVENT_GAMEPADCONNECTED) {
+
+		String guid = "";
+		if (String(p_event->mapping) == "standard")
+			guid = "Default HTML5 Gamepad";
+		input->joy_connection_changed(p_event->index, true, String(p_event->id), guid);
+	}
+	else {
+		input->joy_connection_changed(p_event->index, false, "");
+	}
+	return true;
+}
+
+bool OS_JavaScript::is_joy_known(int p_device) {
+	return input->is_joy_mapped(p_device);
+}
+
+String OS_JavaScript::get_joy_guid(int p_device) const {
+	return input->get_joy_guid_remapped(p_device);
 }
 
 OS_JavaScript::OS_JavaScript(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetDataDirFunc p_get_data_dir_func,GetLocaleFunc p_get_locale_func) {

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -41,6 +41,7 @@
 #include "audio_server_javascript.h"
 #include "audio_driver_javascript.h"
 #include "main/input_default.h"
+#include "emscripten/html5.h"
 
 typedef void (*GFXInitFunc)(void *ud,bool gl2,int w, int h, bool fs);
 typedef int (*OpenURIFunc)(const String&);
@@ -89,6 +90,8 @@ private:
 	GetLocaleFunc get_locale_func;
 
 	static void _close_notification_funcs(const String& p_file,int p_flags);
+
+	void process_joysticks();
 
 public:
 
@@ -163,6 +166,11 @@ public:
 	void process_accelerometer(const Vector3& p_accelerometer);
 	void process_touch(int p_what,int p_pointer, const Vector<TouchPos>& p_points);
 	void push_input(const InputEvent& p_ev);
+
+	virtual bool is_joy_known(int p_device);
+	virtual String get_joy_guid(int p_device) const;
+	bool joy_connection_changed(int p_type, const EmscriptenGamepadEvent *p_event);
+
 	OS_JavaScript(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetDataDirFunc p_get_data_dir_func,GetLocaleFunc p_get_locale_func);
 	~OS_JavaScript();
 


### PR DESCRIPTION
Adds joystick support to the javascript platform.
Also, the remapping system can now map axis events to the dpad.

I don't have all my gamepads at hand, so there are only a few mappings for now.
I tried to host my mapping tool on googledrive but only had limited success :P 
