### PR TITLE
Make custom_bg fit the whole "selected" area in ItemLists

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -826,22 +826,25 @@ void ItemList::_notification(int p_what) {
 			if (current_columns==1) {
 				rcache.size.width = width-rcache.pos.x;
 			}
-			if (items[i].custom_bg.a>0.001) {
-				Rect2 r=rcache;
-				r.pos+=base_ofs;
-				draw_rect(r,items[i].custom_bg);
-			}
+
+			Rect2 r=rcache;
+			r.pos+=base_ofs;
+
+			// Use stylebox to dimension potential bg color, even if not selected
+			r.pos.x-=sbsel->get_margin(MARGIN_LEFT);
+			r.size.x+=sbsel->get_margin(MARGIN_LEFT)+sbsel->get_margin(MARGIN_RIGHT);
+			r.pos.y-=sbsel->get_margin(MARGIN_TOP);
+			r.size.y+=sbsel->get_margin(MARGIN_TOP)+sbsel->get_margin(MARGIN_BOTTOM);
+
 			if (items[i].selected) {
-				Rect2 r=rcache;
-				r.pos+=base_ofs;
-
-				r.pos.x-=sbsel->get_margin(MARGIN_LEFT);
-				r.size.x+=sbsel->get_margin(MARGIN_LEFT)+sbsel->get_margin(MARGIN_RIGHT);
-				r.pos.y-=sbsel->get_margin(MARGIN_TOP);
-				r.size.y+=sbsel->get_margin(MARGIN_TOP)+sbsel->get_margin(MARGIN_BOTTOM);
-
 				draw_style_box(sbsel,r);
-
+			}
+			if (items[i].custom_bg.a>0.001) {
+				r.pos.x+=2;
+				r.size.x-=4;
+				r.pos.y+=2;
+				r.size.y-=4;
+				draw_rect(r,items[i].custom_bg);
 			}
 
 


### PR DESCRIPTION
Note that as this changes the ItemList node itself, we might want to check its other usages before merging. I expanded the area covered by the custom background colour to match that of the StyleBox selector, so that the StyleBox gets filled completely by the colour in the script editor tabs (+ the previously selected scripts have a size similar to the selector's).

One other graphical glitch that would be worth fixing here is that the items of the ItemList are too much to the left, so the left part of the StyleBox is not visible. I haven't found how to do it yet though.

Before:
![e02](https://cloud.githubusercontent.com/assets/4701338/12518296/2161d576-c138-11e5-8347-3c6f3c345b1b.png)

After:
![fd2](https://cloud.githubusercontent.com/assets/4701338/12518298/22e84844-c138-11e5-91ef-8afdd23e5cbc.png)

(The thing to notice is that the StyleBox is completely coloured, and the other tabs' background has a similar size)

Closes #3096 
