### PR TITLE
Fix Output panel annoying focus steal

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -4579,6 +4579,16 @@ ToolButton *EditorNode::add_bottom_panel_item(String p_text,Control *p_item) {
 
 }
 
+bool EditorNode::are_bottom_panels_hidden() const {
+
+	for(int i=0;i<bottom_panel_items.size();i++) {
+		if (bottom_panel_items[i].button->is_pressed())
+			return false;
+	}
+
+	return true;
+}
+
 void EditorNode::hide_bottom_panel() {
 
 	_bottom_panel_switch(false,0);

--- a/tools/editor/editor_node.h
+++ b/tools/editor/editor_node.h
@@ -670,6 +670,7 @@ public:
 
 
 	ToolButton* add_bottom_panel_item(String p_text,Control *p_item);
+	bool are_bottom_panels_hidden() const;
 	void make_bottom_panel_item_visible(Control *p_item);
 	void raise_bottom_panel_item(Control *p_item);
 	void hide_bottom_panel();

--- a/tools/editor/script_editor_debugger.cpp
+++ b/tools/editor/script_editor_debugger.cpp
@@ -360,7 +360,9 @@ void ScriptEditorDebugger::_parse_message(const String& p_msg,const Array& p_dat
 
 			if (EditorNode::get_log()->is_hidden()) {
 				log_forced_visible=true;
-				EditorNode::get_singleton()->make_bottom_panel_item_visible(EditorNode::get_log());
+				if (EditorNode::get_singleton()->are_bottom_panels_hidden()) {
+					EditorNode::get_singleton()->make_bottom_panel_item_visible(EditorNode::get_log());
+				}
 			}
 			EditorNode::get_log()->add_message(t);
 


### PR DESCRIPTION
Output panel was annoyingly stealing focus to the other bottom panels when a log was printed at game runtime.

Now it won't steal the focus if another bottom panel is already visible (in the above situation... it still steals focus once when run is pressed).
