### PR TITLE
Removed debugger X (hide) button

### DIFF
--- a/tools/editor/script_editor_debugger.cpp
+++ b/tools/editor/script_editor_debugger.cpp
@@ -536,9 +536,6 @@ void ScriptEditorDebugger::_notification(int p_what) {
 			forward->set_icon( get_icon("Forward","EditorIcons"));
 			dobreak->set_icon( get_icon("Pause","EditorIcons"));
 			docontinue->set_icon( get_icon("DebugContinue","EditorIcons"));
-			tb->set_normal_texture( get_icon("Close","EditorIcons"));
-			tb->set_hover_texture( get_icon("CloseHover","EditorIcons"));
-			tb->set_pressed_texture( get_icon("Close","EditorIcons"));
 			scene_tree_refresh->set_icon( get_icon("Reload","EditorIcons"));
 			le_set->connect("pressed",this,"_live_edit_set");
 			le_clear->connect("pressed",this,"_live_edit_clear");
@@ -777,13 +774,6 @@ void ScriptEditorDebugger::_stack_dump_frame_selected() {
 	msg.push_back(d["frame"]);
 	ppeer->put_var(msg);
 
-}
-
-void ScriptEditorDebugger::_hide_request() {
-
-	if (EditorNode::get_log()->is_visible())
-		EditorNode::get_singleton()->hide_bottom_panel();
-	emit_signal("show_debugger",false);
 }
 
 void ScriptEditorDebugger::_output_clear() {
@@ -1186,7 +1176,6 @@ void ScriptEditorDebugger::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("debug_break"),&ScriptEditorDebugger::debug_break);
 	ObjectTypeDB::bind_method(_MD("debug_continue"),&ScriptEditorDebugger::debug_continue);
 	ObjectTypeDB::bind_method(_MD("_output_clear"),&ScriptEditorDebugger::_output_clear);
-	ObjectTypeDB::bind_method(_MD("_hide_request"),&ScriptEditorDebugger::_hide_request);
 	ObjectTypeDB::bind_method(_MD("_performance_draw"),&ScriptEditorDebugger::_performance_draw);
 	ObjectTypeDB::bind_method(_MD("_performance_select"),&ScriptEditorDebugger::_performance_select);
 	ObjectTypeDB::bind_method(_MD("_scene_tree_request"),&ScriptEditorDebugger::_scene_tree_request);
@@ -1221,13 +1210,6 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor){
 	tabs->set_v_size_flags(SIZE_EXPAND_FILL);
 	tabs->set_area_as_parent_rect();
 	add_child(tabs);
-
-	tb = memnew( TextureButton );
-	tb->connect("pressed",this,"_hide_request");
-	tb->set_anchor_and_margin(MARGIN_LEFT,ANCHOR_END,20);
-	tb->set_margin(MARGIN_TOP,2);
-	add_child(tb);
-
 
 
 	VBoxContainer *vbc = memnew( VBoxContainer );

--- a/tools/editor/script_editor_debugger.h
+++ b/tools/editor/script_editor_debugger.h
@@ -76,9 +76,6 @@ class ScriptEditorDebugger : public Control {
 
 
 
-	TextureButton *tb;
-
-
 	TabContainer *tabs;
 
 	LineEdit *reason;
@@ -129,7 +126,6 @@ class ScriptEditorDebugger : public Control {
 	void _performance_select(Object *, int, bool);
 	void _stack_dump_frame_selected();
 	void _output_clear();
-	void _hide_request();
 
 	void _scene_tree_request();
 	void _parse_message(const String& p_msg,const Array& p_data);


### PR DESCRIPTION
The button stopped working after 74a48a0. I suppose the following change should fix it:

``` diff
@@ -783,7 +783,7 @@ void ScriptEditorDebugger::_stack_dump_frame_selected() {

 void ScriptEditorDebugger::_hide_request() {

-   if (EditorNode::get_log()->is_visible())
+   if (is_visible())
        EditorNode::get_singleton()->hide_bottom_panel();
    emit_signal("show_debugger",false);
 }
```

However, since now you can hide the debugger from the bottom bar, this button no longer makes sense, so I just removed it.

Closes #3418
