### PR TITLE
Add missing return for typeof() MethodInfo

### DIFF
--- a/modules/gdscript/gd_functions.cpp
+++ b/modules/gdscript/gd_functions.cpp
@@ -1254,9 +1254,12 @@ MethodInfo GDFunctions::get_info(Function p_func) {
 			return mi;
 		} break;
 		case TYPE_OF: {
+
 			MethodInfo mi("typeof",PropertyInfo(Variant::NIL,"what"));
 			mi.return_val.type=Variant::INT;
-		};
+			return mi;
+
+		} break;
 		case TEXT_STR: {
 
 			MethodInfo mi("str",PropertyInfo(Variant::NIL,"what"),PropertyInfo(Variant::NIL,"..."));


### PR DESCRIPTION
This would add the missing typeof() entry in the @Global Scope documentation once doctool is run (I think).
