### PR TITLE
Implements hotkey for toggling grid snapping

### DIFF
--- a/tools/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/tools/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1571,7 +1571,13 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 
 
 			dfrom = drag_point_from;
+			if(p_event.key.mod.control){
+				snap_grid = !snap_grid;
+			}
 			dto = snap_point(dto - (drag == DRAG_ALL ? drag_from - drag_point_from : Vector2(0, 0)), drag_point_from);
+			if(p_event.key.mod.control){
+				snap_grid = !snap_grid;
+			}
 
 			Vector2 drag_vector =
 					canvas_item->get_global_transform_with_canvas().affine_inverse().xform(dto) -


### PR DESCRIPTION
Doing it this way is not optimal. The snap_point method handles checking
to snap rather than callers checking this before calling.

As a result I have to toggle the check before calling. I can't do the check
within the method because that means the method goes beyond its own
scope and would have visibility on input events. This would also break
anything calling which is again beyond the scope of this fix.

Fixes #3225
