### PR TITLE
remove dependancy on libevdev

### DIFF
--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -158,18 +158,14 @@ def configure(env):
 	if (env["gamepad"]=="yes" and platform.system() == "Linux"):
 		# pkg-config returns 0 when the lib exists...
 		found_udev = not os.system("pkg-config --exists libudev")
-		found_evdev = not os.system("pkg-config --exists libevdev")
 		
-		if (found_udev and found_evdev):
-			print("Enabling gamepad support with udev/evdev")
+		if (found_udev):
+			print("Enabling gamepad support with udev")
 			env.Append(CPPFLAGS=["-DJOYDEV_ENABLED"])
 			env.ParseConfig('pkg-config libudev --cflags --libs')
-			env.ParseConfig('pkg-config libevdev --cflags --libs')
 		else:
-			if (not found_udev):
-				print("libudev development libraries not found")
-			if (not found_evdev):
-				print("libevdev development libraries not found")
+			print("libudev development libraries not found")
+
 			print("Some libraries are missing for the required gamepad support, aborting!")
 			print("Install the mentioned libraries or build with 'gamepad=no' to disable gamepad support.")
 			sys.exit(255)

--- a/platform/x11/joystick_linux.h
+++ b/platform/x11/joystick_linux.h
@@ -61,9 +61,10 @@ private:
 		int fd;
 
 		String devpath;
-		struct libevdev *dev;
+		input_absinfo *abs_info[MAX_ABS];
 
 		Joystick();
+		~Joystick();
 		void reset();
 	};
 


### PR DESCRIPTION
Fixes #3439. I couldn't find a clean way to link libevdev statically, so I just removed it.
Anyway, it's basically only a fancy wrapper around `read()` and `ioctl()` calls so we don't _really_ need it.

The diff looks heavier than it is, mostly because of added blocks and the resulting change in intendation :P
