### PR TITLE
Revert "make msvc 64bits build again, fixes #3098"

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -262,7 +262,7 @@ def configure(env):
 		env.Append(CCFLAGS=["/I"+DIRECTX_PATH+"/Include"])
 		env.Append(LIBPATH=[DIRECTX_PATH+"/Lib/x86"])
 		env['ENV'] = os.environ;
-		env["x86_opt_vc"]=env["bits"]!="64"
+		env["x86_opt_vc"]=True
 	else:
 
 		# Workaround for MinGW. See:


### PR DESCRIPTION
This reverts commit b21ce6cecbd75ae3281177c4890902586ca710f7.

As discussed in #3098, this fix is not needed and might be removing optimizations from the Theora library.
