### PR TITLE
x11: use different strings for WM_CLASS depending on context

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -523,6 +523,10 @@ String OS::get_joy_guid(int p_device) const {
 	return "Default Joystick";
 }
 
+void OS::set_context(int p_context) {
+
+}
+
 OS::OS() {
 	last_error=NULL;
 	frames_drawn=0;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -402,6 +402,13 @@ public:
 	virtual bool is_joy_known(int p_device);
 	virtual String get_joy_guid(int p_device)const;
 
+	enum EngineContext {
+		CONTEXT_EDITOR,
+		CONTEXT_PROJECTMAN,
+	};
+
+	virtual void set_context(int p_context);
+
 	OS();	
 	virtual ~OS();
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1319,6 +1319,7 @@ bool Main::start() {
 						}
 					}
 				}
+				OS::get_singleton()->set_context(OS::CONTEXT_EDITOR);
 
 				//editor_node->set_edited_scene(game);
 			} else {
@@ -1463,6 +1464,7 @@ bool Main::start() {
 
 			ProjectManager *pmanager = memnew( ProjectManager );
 			sml->get_root()->add_child(pmanager);
+			OS::get_singleton()->set_context(OS::CONTEXT_PROJECTMAN);
 		}
 
 #endif

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -1782,6 +1782,22 @@ String OS_X11::get_joy_guid(int p_device) const {
 	return input->get_joy_guid_remapped(p_device);
 }
 
+void OS_X11::set_context(int p_context) {
+
+	XClassHint* classHint = NULL;
+	classHint = XAllocClassHint();
+	if (classHint) {
+
+		if (p_context == CONTEXT_EDITOR)
+			classHint->res_name = (char *)"Godot_Editor";
+		if (p_context == CONTEXT_PROJECTMAN)
+			classHint->res_name = (char *)"Godot_ProjectList";
+		classHint->res_class = (char *)"Godot";
+		XSetClassHint(x11_display, x11_window, classHint);
+		XFree(classHint);
+	}
+}
+
 OS_X11::OS_X11() {
 
 #ifdef RTAUDIO_ENABLED

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -226,6 +226,8 @@ public:
 	virtual bool is_joy_known(int p_device);
 	virtual String get_joy_guid(int p_device) const;
 
+	virtual void set_context(int p_context);
+
 	void run();
 
 	OS_X11();


### PR DESCRIPTION
Fixes #766, enables the use of custom window rules for tiling WMs. (eg. run editor maximized, and games floating/centered)

Sets the resource name in the WM_CLASS property to:
- "Godot" for game windows (same as before)
- "Godot_Editor" for the editor
- "Godot_ProjectList" for the project manager
