### PR TITLE
fix dpad left/right not showing correctly in project settings

### DIFF
--- a/tools/editor/project_settings.cpp
+++ b/tools/editor/project_settings.cpp
@@ -474,7 +474,7 @@ void ProjectSettings::_update_actions() {
 				case InputEvent::JOYSTICK_BUTTON: {
 
 					String str = "Device "+itos(ie.device)+", Button "+itos(ie.joy_button.button_index);
-					if (ie.joy_button.button_index>=0 && ie.joy_button.button_index<14)
+					if (ie.joy_button.button_index>=0 && ie.joy_button.button_index<JOY_BUTTON_MAX)
 						str+=String()+" ("+_button_names[ie.joy_button.button_index]+").";
 					else
 						str+=".";


### PR DESCRIPTION
The condition relied on the magic number `14`  instead of `16/JOY_BUTTON_MAX`, causing the code not to run for the last two buttons.

![dpad-inputmap.png](http://oi67.tinypic.com/2a5abyg.jpg)
