### PR TITLE
Added delimiter to File.get_csv_line

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -1313,9 +1313,9 @@ String _File::get_line() const{
 
 }
 
-Vector<String> _File::get_csv_line() const {
+Vector<String> _File::get_csv_line(String delim) const {
 	ERR_FAIL_COND_V(!f,Vector<String>());
-	return f->get_csv_line();
+	return f->get_csv_line(delim);
 }
 
 /**< use this for files WRITTEN in _big_ endian machines (ie, amiga/mac)
@@ -1498,7 +1498,7 @@ void _File::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_endian_swap","enable"),&_File::set_endian_swap);
 	ObjectTypeDB::bind_method(_MD("get_error:Error"),&_File::get_error);
 	ObjectTypeDB::bind_method(_MD("get_var"),&_File::get_var);
-	ObjectTypeDB::bind_method(_MD("get_csv_line"),&_File::get_csv_line);
+	ObjectTypeDB::bind_method(_MD("get_csv_line","delim"),&_File::get_csv_line,DEFVAL(","));
 
 	ObjectTypeDB::bind_method(_MD("store_8","value"),&_File::store_8);
 	ObjectTypeDB::bind_method(_MD("store_16","value"),&_File::store_16);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -390,7 +390,7 @@ public:
 	virtual void store_pascal_string(const String& p_string);
 	virtual String get_pascal_string();
 
-	Vector<String> get_csv_line() const;
+	Vector<String> get_csv_line(String delim=",") const;
 
 
 	void store_buffer(const DVector<uint8_t>& p_buffer); ///< store an array of bytes

--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -277,7 +277,9 @@ String FileAccess::get_line() const {
 	return String::utf8(line.get_data());
 }
 
-Vector<String> FileAccess::get_csv_line() const {
+Vector<String> FileAccess::get_csv_line(String delim) const {
+
+	ERR_FAIL_COND_V(delim.length()!=1,Vector<String>());
 
 	String l;
 	int qc=0;
@@ -303,7 +305,7 @@ Vector<String> FileAccess::get_csv_line() const {
 		CharType s[2]={0,0};
 
 
-		if (!in_quote && c==',') {
+		if (!in_quote && c==delim[0]) {
 			strings.push_back(current);
 			current=String();
 		} else if (c=='"') {

--- a/core/os/file_access.h
+++ b/core/os/file_access.h
@@ -102,7 +102,7 @@ public:
 
 	virtual int get_buffer(uint8_t *p_dst,int p_length) const; ///< get an array of bytes
 	virtual String get_line() const;
-	virtual Vector<String> get_csv_line() const;
+	virtual Vector<String> get_csv_line(String delim=",") const;
 	
 	/**< use this for files WRITTEN in _big_ endian machines (ie, amiga/mac)
 	 * It's not about the current CPU type but file formats.


### PR DESCRIPTION
Allows you to choose which delimiter to use for splitting the line.
See #3495
