### PR TITLE
x11: more verbose checking for joystick capabilities

### DIFF
--- a/platform/x11/joystick_linux.cpp
+++ b/platform/x11/joystick_linux.cpp
@@ -312,8 +312,10 @@ void joystick_linux::open_joystick(const char *p_path) {
 		//check if the device supports basic gamepad events, prevents certain keyboards from
 		//being detected as joysticks
 		if (!(test_bit(EV_KEY, evbit) && test_bit(EV_ABS, evbit) &&
-		    ((test_bit(ABS_X, absbit) || test_bit(ABS_Y, absbit) || test_bit(ABS_HAT0X, absbit)) &&
-		     (test_bit(BTN_A, keybit) || test_bit(BTN_THUMBL, keybit))))) {
+		     (test_bit(ABS_X, absbit) || test_bit(ABS_Y, absbit) || test_bit(ABS_HAT0X, absbit) ||
+		      test_bit(ABS_GAS, absbit) || test_bit(ABS_RUDDER, absbit)) &&
+		     (test_bit(BTN_A, keybit) || test_bit(BTN_THUMBL, keybit) ||
+		      test_bit(BTN_TRIGGER, keybit) || test_bit(BTN_1, keybit)))) {
 			close(fd);
 			return;
 		}


### PR DESCRIPTION
ps3 pads (and racing wheels) are now properly detected as joysticks
