### PR TITLE
Added constant to retrieve Windows' Documents path

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2075,7 +2075,7 @@ String OS_Windows::get_system_dir(SystemDir p_dir) const {
 			id=CSIDL_MYPICTURES;
 		} break;
 		case SYSTEM_DIR_DOCUMENTS: {
-			id=0x000C;
+			id=CSIDL_PERSONAL;
 		} break;
 		case SYSTEM_DIR_DOWNLOADS: {
 			id=0x000C ;


### PR DESCRIPTION
Currently, the function `OS.get_system_dir(OS.SYSTEM_DIR_DOCUMENTS)` returns an empty string in Windows.

From the commit message:

According to MSDN's documentation ([(https://msdn.microsoft.com/en-us/library/windows/desktop/bb762181(v=vs.85).aspx)]),
`CSIDL_PERSONAL` represents the default path to Windows Document's folder:

"Previous to Version 6.0. The file system directory used to physically store a user's common repository of documents. A typical path is `C:\Documents and Settings\username\My Documents`. This should be distinguished from the virtual My Documents folder in the namespace. To access that virtual folder, use `SHGetFolderLocation`, which returns the `ITEMIDLIST` for the virtual location, or refer to the technique described in Managing the File System."

`SHGetFolderPath()` may fail in some conditions for the Documents folder, though. I believe failures may occur when the user moves the documents folder elsewhere, or uses a symbolic link.

Thanks. Best regards.
