### PR TITLE
AnimationPlayer frame SpinBox snaps to steps.

### DIFF
--- a/tools/editor/plugins/animation_player_editor_plugin.cpp
+++ b/tools/editor/plugins/animation_player_editor_plugin.cpp
@@ -942,6 +942,14 @@ void AnimationPlayerEditor::_seek_value_changed(float p_value) {
 	anim=player->get_animation(current);
 
 	float pos = anim->get_length() * (p_value / frame->get_max());
+	float step = anim->get_step();
+	if (step) {
+		pos=Math::stepify(pos, step);
+		if (pos<0)
+			pos=0;
+		if (pos>=anim->get_length())
+			pos=anim->get_length();
+	}
 
 	if (player->is_valid()) {
 		float cpos = player->get_current_animation_pos();


### PR DESCRIPTION
This makes it so that using the frame # SpinBox aligns the cursor with a step if it was in-between steps from you playing/stopping. This makes it consistent whether 2D sprite image frames change when you step.
