### PR TITLE
Fixed a couple of tooltips on the editor

### DIFF
--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -2486,13 +2486,13 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	script_back->connect("pressed",this,"_history_back");
 	menu_hb->add_child(script_back);
 	script_back->set_disabled(true);
-	help_search->set_tooltip("Go to previous edited document.");
+	script_back->set_tooltip("Go to previous edited document.");
 
 	script_forward = memnew( ToolButton );
 	script_forward->connect("pressed",this,"_history_forward");
 	menu_hb->add_child(script_forward);
 	script_forward->set_disabled(true);
-	help_search->set_tooltip("Go to next edited document.");
+	script_forward->set_tooltip("Go to next edited document.");
 
 
 


### PR DESCRIPTION
There was just a simple copy-paste mistake which gave some buttons a wrong tooltip or no tooltip at all.
