### PR TITLE
raised the max amount of particles to match the max number allowed …

### DIFF
--- a/servers/visual/particle_system_sw.h
+++ b/servers/visual/particle_system_sw.h
@@ -38,7 +38,7 @@
 struct ParticleSystemSW {
 	enum {
 	
-		MAX_PARTICLES=1024
+		MAX_PARTICLES=4096
 	};
 
 	float particle_vars[VS::PARTICLE_VAR_MAX];


### PR DESCRIPTION
…in the inspector (prevents crash)

this fixes #3659
