### PR TITLE
Rename input actions by editing its item in the list

### DIFF
--- a/tools/editor/project_settings.cpp
+++ b/tools/editor/project_settings.cpp
@@ -97,32 +97,71 @@ void ProjectSettings::_notification(int p_what) {
 	}
 }
 
-void ProjectSettings::_action_persist_toggle() {
+void ProjectSettings::_action_selected() {
 
+	TreeItem *ti=input_editor->get_selected();
+	if (!ti || !ti->is_editable(0))
+		return;
+
+	add_at="input/"+ti->get_text(0);
+}
+
+void ProjectSettings::_action_edited() {
 
 	TreeItem *ti=input_editor->get_selected();
 	if (!ti)
 		return;
 
-	String name="input/"+ti->get_text(0);
+	String new_name=ti->get_text(0);
+	String old_name=add_at.substr(add_at.find("/")+1,add_at.length());
 
-	bool prev = Globals::get_singleton()->is_persisting(name);
-	print_line("prev persist: "+itos(prev));
-	print_line("new persist: "+itos(ti->is_checked(0)));
-	if (prev==ti->is_checked(0))
+	if (new_name==old_name)
 		return;
 
+	if (new_name.find("/")!=-1 || new_name.find(":")!=-1 || new_name=="") {
+
+		ti->set_text(0,old_name);
+		add_at="input/"+old_name;
+
+		message->set_text("Invalid Action (Anything goes but / or :).");
+		message->popup_centered(Size2(300,100));
+		return;
+	}
+
+	String action_prop="input/"+new_name;
+
+	if (Globals::get_singleton()->has(action_prop)) {
+
+		ti->set_text(0,old_name);
+		add_at="input/"+old_name;
+
+		message->set_text("Action '"+new_name+"' already exists!.");
+		message->popup_centered(Size2(300,100));
+		return;
+	}
+
+	int order = Globals::get_singleton()->get_order(add_at);
+	Array va = Globals::get_singleton()->get(add_at);
+	bool persisting = Globals::get_singleton()->is_persisting(add_at);
 
 	setting=true;
-	undo_redo->create_action("Change Input Action Persistence");
-	undo_redo->add_do_method(Globals::get_singleton(),"set_persisting",name,ti->is_checked(0));
-	undo_redo->add_undo_method(Globals::get_singleton(),"set_persisting",name,prev);
+	undo_redo->create_action("Rename Input Action Event");
+	undo_redo->add_do_method(Globals::get_singleton(),"clear",add_at);
+	undo_redo->add_do_method(Globals::get_singleton(),"set",action_prop,va);
+	undo_redo->add_do_method(Globals::get_singleton(),"set_persisting",action_prop,persisting);
+	undo_redo->add_do_method(Globals::get_singleton(),"set_order",action_prop,order);
+	undo_redo->add_undo_method(Globals::get_singleton(),"clear",action_prop);
+	undo_redo->add_undo_method(Globals::get_singleton(),"set",add_at,va);
+	undo_redo->add_undo_method(Globals::get_singleton(),"set_persisting",add_at,persisting);
+	undo_redo->add_undo_method(Globals::get_singleton(),"set_order",add_at,order);
 	undo_redo->add_do_method(this,"_update_actions");
 	undo_redo->add_undo_method(this,"_update_actions");
 	undo_redo->add_do_method(this,"_settings_changed");
 	undo_redo->add_undo_method(this,"_settings_changed");
 	undo_redo->commit_action();
 	setting=false;
+
+	add_at=action_prop;
 
 }
 
@@ -356,15 +395,6 @@ void ProjectSettings::_action_button_pressed(Object* p_obj, int p_column,int p_i
 		add_at="input/"+ti->get_text(0);
 
 	} else if (p_id==2) {
-		//rename
-
-		add_at="input/"+ti->get_text(0);
-		rename_action->popup_centered();
-		rename_action->get_line_edit()->set_text(ti->get_text(0));
-		rename_action->get_line_edit()->set_cursor_pos(ti->get_text(0).length());
-		rename_action->get_line_edit()->select_all();
-
-	} else if (p_id==3) {
 		//remove
 
 		if (ti->get_parent()==input_editor->get_root()) {
@@ -446,13 +476,11 @@ void ProjectSettings::_update_actions() {
 		item->set_text(0,name);
 		item->add_button(0,get_icon("Add","EditorIcons"),1);
 		if (!Globals::get_singleton()->get_input_presets().find(pi.name)) {
-			item->add_button(0,get_icon("Rename","EditorIcons"),2);
-			item->add_button(0,get_icon("Remove","EditorIcons"),3);
+			item->add_button(0,get_icon("Remove","EditorIcons"),2);
+			item->set_editable(0,true);
 		}
 		item->set_custom_bg_color(0,get_color("prop_subsection","Editor"));
-		item->set_editable(0,true);
 		//item->set_checked(0,pi.usage&PROPERTY_USAGE_CHECKED);
-
 
 
 		Array actions=Globals::get_singleton()->get(pi.name);
@@ -527,7 +555,7 @@ void ProjectSettings::_update_actions() {
 					action->set_icon(0,get_icon("JoyAxis","EditorIcons"));
 				} break;
 			}
-			action->add_button(0,get_icon("Remove","EditorIcons"),3);
+			action->add_button(0,get_icon("Remove","EditorIcons"),2);
 			action->set_metadata(0,i);
 		}
 	}
@@ -656,45 +684,6 @@ void ProjectSettings::_action_add() {
 	r->select(0);
 	input_editor->ensure_cursor_is_visible();
 
-}
-
-void ProjectSettings::_action_rename(const String &p_name) {
-
-
-	if (p_name.find("/")!=-1 || p_name.find(":")!=-1 || p_name=="") {
-		message->set_text("Invalid Action (Anything goes but / or :).");
-		message->popup_centered(Size2(300,100));
-		return;
-	}
-
-	String new_name = "input/"+p_name;
-
-	if (Globals::get_singleton()->has(new_name)) {
-		message->set_text("Action '"+p_name+"' already exists!.");
-		message->popup_centered(Size2(300,100));
-		return;
-	}
-
-	int order = Globals::get_singleton()->get_order(add_at);
-	Array va = Globals::get_singleton()->get(add_at);
-	bool persisting = Globals::get_singleton()->is_persisting(add_at);
-
-	undo_redo->create_action("Rename Input Action Event");
-	undo_redo->add_do_method(Globals::get_singleton(),"clear",add_at);
-	undo_redo->add_do_method(Globals::get_singleton(),"set",new_name,va);
-	undo_redo->add_do_method(Globals::get_singleton(),"set_persisting",new_name,persisting);
-	undo_redo->add_do_method(Globals::get_singleton(),"set_order",new_name,order);
-	undo_redo->add_undo_method(Globals::get_singleton(),"clear",new_name);
-	undo_redo->add_undo_method(Globals::get_singleton(),"set",add_at,va);
-	undo_redo->add_undo_method(Globals::get_singleton(),"set_persisting",add_at,persisting);
-	undo_redo->add_undo_method(Globals::get_singleton(),"set_order",add_at,order);
-	undo_redo->add_do_method(this,"_update_actions");
-	undo_redo->add_undo_method(this,"_update_actions");
-	undo_redo->add_do_method(this,"_settings_changed");
-	undo_redo->add_undo_method(this,"_settings_changed");
-	undo_redo->commit_action();
-
-	rename_action->hide();
 }
 
 
@@ -1403,9 +1392,9 @@ void ProjectSettings::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("_save"),&ProjectSettings::_save);
 	ObjectTypeDB::bind_method(_MD("_action_add"),&ProjectSettings::_action_add);
 	ObjectTypeDB::bind_method(_MD("_action_adds"),&ProjectSettings::_action_adds);
-	ObjectTypeDB::bind_method(_MD("_action_persist_toggle"),&ProjectSettings::_action_persist_toggle);
+	ObjectTypeDB::bind_method(_MD("_action_selected"),&ProjectSettings::_action_selected);
+	ObjectTypeDB::bind_method(_MD("_action_edited"),&ProjectSettings::_action_edited);
 	ObjectTypeDB::bind_method(_MD("_action_button_pressed"),&ProjectSettings::_action_button_pressed);
-	ObjectTypeDB::bind_method(_MD("_action_rename"),&ProjectSettings::_action_rename);
 	ObjectTypeDB::bind_method(_MD("_update_actions"),&ProjectSettings::_update_actions);
 	ObjectTypeDB::bind_method(_MD("_wait_for_key"),&ProjectSettings::_wait_for_key);
 	ObjectTypeDB::bind_method(_MD("_add_item"),&ProjectSettings::_add_item);
@@ -1620,18 +1609,12 @@ ProjectSettings::ProjectSettings(EditorData *p_data) {
 	input_editor->set_anchor_and_margin(MARGIN_BOTTOM,ANCHOR_END, 35 );
 	input_editor->set_anchor_and_margin(MARGIN_LEFT,ANCHOR_BEGIN, 5 );
 	input_editor->set_anchor_and_margin(MARGIN_RIGHT,ANCHOR_END, 5 );
-	input_editor->connect("item_edited",this,"_action_persist_toggle");
+	input_editor->connect("item_edited",this,"_action_edited");
+	input_editor->connect("cell_selected",this,"_action_selected");
 	input_editor->connect("button_pressed",this,"_action_button_pressed");
 	popup_add = memnew( PopupMenu );
 	add_child(popup_add);
 	popup_add->connect("item_pressed",this,"_add_item");
-
-	rename_action = memnew( EditorNameDialog );
-	add_child(rename_action);
-	rename_action->set_hide_on_ok(false);
-	rename_action->set_size(Size2(200, 70));
-	rename_action->set_title("Rename Input Action");
-	rename_action->connect("name_confirmed", this,"_action_rename");
 
 	press_a_key = memnew( ConfirmationDialog );
 	press_a_key->set_focus_mode(FOCUS_ALL);

--- a/tools/editor/project_settings.h
+++ b/tools/editor/project_settings.h
@@ -34,7 +34,6 @@
 #include "optimized_save_dialog.h"
 #include "undo_redo.h"
 #include "editor_data.h"
-#include "editor_name_dialog.h"
 //#include "project_export_settings.h"
 
 class ProjectSettings : public AcceptDialog {
@@ -66,8 +65,6 @@ class ProjectSettings : public AcceptDialog {
 	OptionButton *device_index;
 	Label *device_index_label;
 	MenuButton *popup_platform;
-
-	EditorNameDialog *rename_action;
 
 	LineEdit *action_name;
 	Tree *input_editor;
@@ -111,11 +108,11 @@ class ProjectSettings : public AcceptDialog {
 
 	void _action_adds(String);
 	void _action_add();
-	void _action_rename(const String& p_name);
 	void _device_input_add();
 
 	void _item_checked(const String& p_item, bool p_check);
-	void _action_persist_toggle();
+	void _action_selected();
+	void _action_edited();
 	void _action_button_pressed(Object* p_obj, int p_column,int p_id);
 	void _wait_for_key(const InputEvent& p_event);
 	void _press_a_key_confirm();


### PR DESCRIPTION
Closes #3682

Input action items became editable after 908f75c. This caused the confusion you see in the above issue.

To solve this, I removed the old rename dialog and the rename button. Now actions are renamed by editing the item in the tree.

Input preset items are not editable. This could be confusing for some users (as discussed with @akien-mga on irc). A solution could be to make them editable, but show an error message after confirming the edition (e.x.: "Input presets cannot be renamed").
