### PR TITLE
x11: make dependancy on libudev optional

### DIFF
--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -56,7 +56,7 @@ def get_opts():
 	('use_sanitizer','Use llvm compiler sanitize address','no'),
 	('use_leak_sanitizer','Use llvm compiler sanitize memory leaks','no'),
 	('pulseaudio','Detect & Use pulseaudio','yes'),
-	('gamepad','Gamepad support, requires libudev and libevdev','yes'),
+	('udev','Use udev for gamepad connection callbacks','no'),
 	('new_wm_api', 'Use experimental window management API','no'),
 	('debug_release', 'Add debug symbols to release version','no'),
 	]
@@ -156,20 +156,18 @@ def configure(env):
 	else:
 		print("ALSA libraries not found, disabling driver")
 
-	if (env["gamepad"]=="yes" and platform.system() == "Linux"):
+	if (platform.system() == "Linux"):
+		env.Append(CPPFLAGS=["-DJOYDEV_ENABLED"])
+	if (env["udev"]=="yes"):
 		# pkg-config returns 0 when the lib exists...
 		found_udev = not os.system("pkg-config --exists libudev")
-		
+
 		if (found_udev):
-			print("Enabling gamepad support with udev")
-			env.Append(CPPFLAGS=["-DJOYDEV_ENABLED"])
+			print("Enabling udev support")
+			env.Append(CPPFLAGS=["-DUDEV_ENABLED"])
 			env.ParseConfig('pkg-config libudev --cflags --libs')
 		else:
-			print("libudev development libraries not found")
-
-			print("Some libraries are missing for the required gamepad support, aborting!")
-			print("Install the mentioned libraries or build with 'gamepad=no' to disable gamepad support.")
-			sys.exit(255)
+			print("libudev development libraries not found, disabling udev support")
 
 	if (env["pulseaudio"]=="yes"):
 		if not os.system("pkg-config --exists libpulse-simple"):

--- a/platform/x11/joystick_linux.h
+++ b/platform/x11/joystick_linux.h
@@ -73,6 +73,7 @@ private:
 	Thread *joy_thread;
 	InputDefault *input;
 	Joystick joysticks[JOYSTICKS_MAX];
+	Vector<String> attached_devices;
 
 	static void joy_thread_func(void *p_user);
 
@@ -81,8 +82,11 @@ private:
 
 	void setup_joystick_properties(int p_id);
 	void close_joystick(int p_id = -1);
+#ifdef UDEV_ENABLED
 	void enumerate_joysticks(struct udev *_udev);
 	void monitor_joysticks(struct udev *_udev);
+#endif
+	void monitor_joysticks();
 	void run_joystick_thread();
 	void open_joystick(const char* path);
 


### PR DESCRIPTION
fixes #3702
Udev monitoring can be optionally enabled by compiling with `udev=yes`, removes the `gamepad` flag.
Else, we loop through `/dev/input/event0` to `event31` once per second to discover new devices.
Disconnection should be instant.

ping @punto- 
