### PR TITLE
X11: include libudev only on udev builds

### DIFF
--- a/platform/x11/joystick_linux.cpp
+++ b/platform/x11/joystick_linux.cpp
@@ -33,10 +33,13 @@
 #include "joystick_linux.h"
 
 #include <linux/input.h>
-#include <libudev.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
+
+#ifdef UDEV_ENABLED
+#include <libudev.h>
+#endif
 
 #define LONG_BITS  (sizeof(long) * 8)
 #define test_bit(nr, addr)  (((1UL << ((nr) % LONG_BITS)) & ((addr)[(nr) / LONG_BITS])) != 0)


### PR DESCRIPTION
fixes #3714
