### PR TITLE
refix particles3d issue, bringing down the amount limit to 1024

### DIFF
--- a/scene/3d/particles.cpp
+++ b/scene/3d/particles.cpp
@@ -95,7 +95,7 @@ DVector<Face3> Particles::get_faces(uint32_t p_usage_flags) const {
 
 void Particles::set_amount(int p_amount) {
 
-	ERR_FAIL_INDEX(p_amount,4096);
+	ERR_FAIL_INDEX(p_amount,1024);
 	amount=p_amount;
 	VisualServer::get_singleton()->particles_set_amount(particles,p_amount);
 }
@@ -441,7 +441,7 @@ void Particles::_bind_methods() {
 
 	ADD_PROPERTY( PropertyInfo( Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "Material" ), _SCS("set_material"), _SCS("get_material") );
 
-	ADD_PROPERTY( PropertyInfo( Variant::INT, "amount", PROPERTY_HINT_RANGE, "1,4096,1" ), _SCS("set_amount"), _SCS("get_amount") );
+	ADD_PROPERTY( PropertyInfo( Variant::INT, "amount", PROPERTY_HINT_RANGE, "1,1024,1" ), _SCS("set_amount"), _SCS("get_amount") );
 	ADD_PROPERTY( PropertyInfo( Variant::BOOL, "emitting" ), _SCS("set_emitting"), _SCS("is_emitting") );
 	ADD_PROPERTY( PropertyInfo( Variant::_AABB, "visibility" ), _SCS("set_visibility_aabb"), _SCS("get_visibility_aabb") );
 	ADD_PROPERTY( PropertyInfo( Variant::VECTOR3, "emission_extents" ), _SCS("set_emission_half_extents"), _SCS("get_emission_half_extents") );

--- a/servers/visual/particle_system_sw.h
+++ b/servers/visual/particle_system_sw.h
@@ -38,7 +38,7 @@
 struct ParticleSystemSW {
 	enum {
 	
-		MAX_PARTICLES=4096
+		MAX_PARTICLES=1024
 	};
 
 	float particle_vars[VS::PARTICLE_VAR_MAX];


### PR DESCRIPTION
The previous fix raised the max amount to 4096, but that matches the default max value for the rasterizer's rendered objects. It sounds more sane to reduce the max allowed particles to 1024, also matching the 2d particle system.
