### PR TITLE
AnimationTreePlayer: blend value tracks (intended to close #2299)

### DIFF
--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -1116,6 +1116,21 @@ void Variant::reference(const Variant& p_variant) {
 
 
 }
+void Variant::zero() {
+	switch(type) {
+		case NIL: break;
+		case BOOL: this->_data._bool = false; break;
+		case INT: this->_data._int = 0; break;
+		case REAL: this->_data._real = 0; break;
+		case VECTOR2: *reinterpret_cast<Vector2*>(this->_data._mem) = Vector2(); break;
+		case RECT2: *reinterpret_cast<Rect2*>(this->_data._mem) = Rect2(); break;
+		case VECTOR3: *reinterpret_cast<Vector3*>(this->_data._mem) = Vector3(); break;
+		case PLANE: *reinterpret_cast<Plane*>(this->_data._mem) = Plane(); break;
+		case QUAT: *reinterpret_cast<Quat*>(this->_data._mem) = Quat(); break;
+		case COLOR: *reinterpret_cast<Color*>(this->_data._mem) = Color(); break;
+		default: this->clear(); break;
+	}
+}
 void Variant::clear() {
 
 	switch(type) {

--- a/core/variant.h
+++ b/core/variant.h
@@ -372,6 +372,8 @@ public:
 		return res;
 	}
 
+	void zero();
+	static void blend(const Variant& a, const Variant& b, float c,Variant &r_dst);
 	static void interpolate(const Variant& a, const Variant& b, float c,Variant &r_dst);
 
 	struct CallError {

--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -3431,6 +3431,59 @@ Variant Variant::iter_get(const Variant& r_iter,bool &r_valid) const {
 
 }
 
+void Variant::blend(const Variant& a, const Variant& b, float c, Variant &r_dst) {
+	if (a.type!=b.type) {
+		if(a.is_num() && b.is_num()) {
+			real_t va=a;
+			real_t vb=b;
+			r_dst=va + vb * c;
+		} else {
+			r_dst=a;
+		}
+		return;
+	}
+
+	switch(a.type) {
+		case NIL: { r_dst=Variant(); } return;
+		case INT:{
+			int va=a._data._int;
+			int vb=b._data._int;
+			r_dst=int(va + vb * c + 0.5);
+		} return;
+		case REAL:{
+			double ra=a._data._real;
+			double rb=b._data._real;
+			r_dst=ra + rb * c;
+		} return;
+		case VECTOR2:{ r_dst=*reinterpret_cast<const Vector2*>(a._data._mem)+*reinterpret_cast<const Vector2*>(b._data._mem)*c; } return;
+		case RECT2:{
+					   const Rect2 *ra = reinterpret_cast<const Rect2*>(a._data._mem);
+					   const Rect2 *rb = reinterpret_cast<const Rect2*>(b._data._mem);
+					   r_dst=Rect2(ra->pos + rb->pos * c, ra->size + rb->size * c);
+				   } return;
+		case VECTOR3:{ r_dst=*reinterpret_cast<const Vector2*>(a._data._mem)+*reinterpret_cast<const Vector2*>(b._data._mem)*c; } return;
+		case _AABB:{
+					   const AABB *ra = reinterpret_cast<const AABB*>(a._data._mem);
+					   const AABB *rb = reinterpret_cast<const AABB*>(b._data._mem);
+					   r_dst=AABB(ra->pos + rb->pos * c, ra->size + rb->size * c);
+				   } return;
+		case COLOR:{
+					   const Color *ca = reinterpret_cast<const Color*>(a._data._mem);
+					   const Color *cb = reinterpret_cast<const Color*>(b._data._mem);
+					   float r = ca->r + cb->r * c;
+					   float g = ca->g + cb->g * c;
+					   float b = ca->b + cb->b * c;
+					   float a = ca->a + cb->a * c;
+					   r = r > 1.0 ? 1.0 : r;
+					   g = g > 1.0 ? 1.0 : g;
+					   b = b > 1.0 ? 1.0 : b;
+					   a = a > 1.0 ? 1.0 : a;
+					   r_dst=Color(r, g, b, a);
+				   } return;
+		default:{ r_dst = c<0.5 ? a : b; } return;
+	}
+}
+
 void Variant::interpolate(const Variant& a, const Variant& b, float c,Variant &r_dst) {
 
 	if (a.type!=b.type) {

--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -768,6 +768,10 @@ void AnimationTreePlayer::_process_animation(float p_delta) {
 		t.scale.x=0;
 		t.scale.y=0;
 		t.scale.z=0;
+
+		Variant value = t.node->get(t.property);
+		value.zero();
+		t.node->set(t.property, value);
 	}
 
 
@@ -777,11 +781,9 @@ void AnimationTreePlayer::_process_animation(float p_delta) {
 	Quat empty_rot;
 
 
-	int total = 0;
 	while(anim_list) {
 
 		if (!anim_list->animation.is_null() && !anim_list->skip) {
-			++total;
 			//check if animation is meaningful
 			Animation *a = anim_list->animation.operator->();
 
@@ -816,8 +818,9 @@ void AnimationTreePlayer::_process_animation(float p_delta) {
 					case Animation::TYPE_VALUE: { ///< Set a value in a property, can be interpolated.
 
 						if (a->value_track_is_continuous(tr.local_track)) {
-							Variant value = a->value_track_interpolate(tr.local_track,anim_list->time);
-							tr.track->node->set(tr.track->property,value);
+							Variant blended, value = a->value_track_interpolate(tr.local_track,anim_list->time);
+							Variant::blend(tr.track->node->get(tr.track->property),value,blend,blended);
+							tr.track->node->set(tr.track->property,blended);
 						} else {
 
 							List<int> indices;


### PR DESCRIPTION
Someone should check this to make sure I'm not doing something stupid...I added the following methods to Variant:
- zero() sets a Variant to the appropriate type of zero value
- blend() blends part of one Variant on top of another (a + k*b)

Then I used them to clear/blend values for value tracks in AnimationTreePlayer::_process_animation. I have two questions:

blend() doesn't handle arrays and strings the way interpolate does. Is it possible to create string or int array (real array etc) keys on an animation?

Does every element of an AnimationTreePlayer's track_map have a valid property name, or should I be checking for empty/invalid names?
