### PR TITLE
Reject any native video player calls on iOS that point to files withi…

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -689,6 +689,10 @@ void _OS::native_video_pause() {
 	OS::get_singleton()->native_video_pause();
 };
 
+void _OS::native_video_unpause() {
+	OS::get_singleton()->native_video_unpause();
+};
+
 void _OS::native_video_stop() {
 
 	OS::get_singleton()->native_video_stop();
@@ -874,6 +878,7 @@ void _OS::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("native_video_is_playing"),&_OS::native_video_is_playing);
 	ObjectTypeDB::bind_method(_MD("native_video_stop"),&_OS::native_video_stop);
 	ObjectTypeDB::bind_method(_MD("native_video_pause"),&_OS::native_video_pause);
+	ObjectTypeDB::bind_method(_MD("native_video_unpause"),&_OS::native_video_unpause);
 
 	ObjectTypeDB::bind_method(_MD("get_scancode_string","code"),&_OS::get_scancode_string);
 	ObjectTypeDB::bind_method(_MD("is_scancode_unicode","code"),&_OS::is_scancode_unicode);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -131,6 +131,7 @@ public:
 	Error native_video_play(String p_path, float p_volume, String p_audio_track, String p_subtitle_track);
 	bool native_video_is_playing();
 	void native_video_pause();
+	void native_video_unpause();
 	void native_video_stop();
 
 	void set_iterations_per_second(int p_ips);

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -478,6 +478,10 @@ void OS::native_video_pause() {
 
 };
 
+void OS::native_video_unpause() {
+
+};
+
 void OS::native_video_stop() {
 
 };

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -376,6 +376,7 @@ public:
 	virtual Error native_video_play(String p_path, float p_volume, String p_audio_track, String p_subtitle_track);
 	virtual bool native_video_is_playing() const;
 	virtual void native_video_pause();
+	virtual void native_video_unpause();
 	virtual void native_video_stop();
 
 	virtual bool can_use_threads() const;

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -195,12 +195,12 @@ public:
 	void set_unique_ID(String p_ID);
 	String get_unique_ID() const;
 
-    virtual Error native_video_play(String p_path, float p_volume, String p_audio_track, String p_subtitle_track);
-    virtual bool native_video_is_playing() const;
-    virtual void native_video_pause();
+	virtual Error native_video_play(String p_path, float p_volume, String p_audio_track, String p_subtitle_track);
+	virtual bool native_video_is_playing() const;
+	virtual void native_video_pause();
 	virtual void native_video_unpause();
 	virtual void native_video_focus_out();
-    virtual void native_video_stop();
+	virtual void native_video_stop();
 
 	OSIPhone(int width, int height);
 	~OSIPhone();


### PR DESCRIPTION
…n .pck archives.

Fix the paths for both res:// and user:// specified video files.

This is a rewrite of https://github.com/godotengine/godot/pull/3769
Instead of copying the files out of the .pck files, we just reject instead with a notification that explains why.
