### PR TITLE
Fix "missing dependency resolver" in Windows

### DIFF
--- a/core/io/resource_format_xml.cpp
+++ b/core/io/resource_format_xml.cpp
@@ -1796,6 +1796,7 @@ Error ResourceInteractiveLoaderXML::rename_dependencies(FileAccess *p_f, const S
 		fw->store_8(c);
 		c=f->get_8();
 	}
+	f->close();
 
 	bool all_ok = fw->get_error()==OK;
 

--- a/scene/resources/scene_format_text.cpp
+++ b/scene/resources/scene_format_text.cpp
@@ -736,6 +736,7 @@ Error ResourceInteractiveLoaderText::rename_dependencies(FileAccess *p_f, const 
 		fw->store_8(c);
 		c=f->get_8();
 	}
+	f->close();
 
 	bool all_ok = fw->get_error()==OK;
 


### PR DESCRIPTION
Fixes #3794
