### PR TITLE
Fix typo in error

### DIFF
--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -1790,7 +1790,7 @@ void GDParser::_parse_block(BlockNode *p_block,bool p_static) {
 				p_block->sub_blocks.push_back(cf_for->body);
 
 				if (!_enter_indent_block(cf_for->body)) {
-					_set_error("Expected indented block after 'while'");
+					_set_error("Expected indented block after 'for'");
 					p_block->end_line=tokenizer->get_token_line();
 					return;
 				}


### PR DESCRIPTION
Try the following code:

```
for i in range(0, 10):
print(str("iteration ", i))
```

It will print you a wrong error. Error printing for while loops is not affected, see line 1741 of that file.
