### PR TITLE
Fixed closing a scene tab when it was not the CURRENT tab. Fixes #3810

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -4539,7 +4539,7 @@ void EditorNode::_scene_tab_closed(int p_tab) {
 	}
 	else {
 		_remove_scene(p_tab);
-		//_update_scene_tabs();
+		_update_scene_tabs();
 	}
 
 }


### PR DESCRIPTION
Yes, it was that simple.
