### PR TITLE
expose md5 for file(s) to gdscript

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -1319,6 +1319,15 @@ String _File::get_as_text() const {
 
 
 }
+
+
+String _File::get_md5(const String& p_path) const {
+
+	return FileAccess::get_md5(p_path);
+
+}
+
+
 String _File::get_line() const{
 
 	ERR_FAIL_COND_V(!f,String());
@@ -1507,6 +1516,7 @@ void _File::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_buffer","len"),&_File::get_buffer);
 	ObjectTypeDB::bind_method(_MD("get_line"),&_File::get_line);
 	ObjectTypeDB::bind_method(_MD("get_as_text"),&_File::get_as_text);
+	ObjectTypeDB::bind_method(_MD("get_md5","path"),&_File::get_md5);
 	ObjectTypeDB::bind_method(_MD("get_endian_swap"),&_File::get_endian_swap);
 	ObjectTypeDB::bind_method(_MD("set_endian_swap","enable"),&_File::set_endian_swap);
 	ObjectTypeDB::bind_method(_MD("get_error:Error"),&_File::get_error);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -367,6 +367,7 @@ public:
 	DVector<uint8_t> get_buffer(int p_length) const; ///< get an array of bytes
 	String get_line() const;
 	String get_as_text() const;
+	String get_md5(const String& p_path) const;
 
 	/**< use this for files WRITTEN in _big_ endian machines (ie, amiga/mac)
 	 * It's not about the current CPU type but file formats.

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<doc version="2.0.rc1.custom_build" name="Engine Types">
+<doc version="2.0.stable.custom_build" name="Engine Types">
 <class name="@GDScript" category="Core">
 	<brief_description>
 	Built-in GDScript functions.
@@ -10689,6 +10689,16 @@ Returns an empty String "" at the end of the list.
 			<return type="String">
 			</return>
 			<description>
+			</description>
+		</method>
+		<method name="get_md5" qualifiers="const">
+			<return type="String">
+			</return>
+			<argument index="0" name="path" type="String">
+			</argument>
+			<description>
+			Returns on success, a md5 String representing the file of the given path.
+				else, empty String "".
 			</description>
 		</method>
 		<method name="get_endian_swap">
@@ -29903,6 +29913,22 @@ This method controls whether the position between two cached points is interpola
 		</method>
 		<method name="get_node_owner_path" qualifiers="const">
 			<return type="NodePath">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="is_node_instance_placeholder" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_node_instance_placeholder" qualifiers="const">
+			<return type="String">
 			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>


### PR DESCRIPTION
Looks a little bit dirty.
When the file is open you still have to pass the path. I can't find any variable that is saving the path of the currently open file.

Current version.

```
var f = File.new()
var md5 = f.get_md5("/path/to/file")
```

Alternatives:
1.Bad because you always have to open the file first.

```
var f = File.new()
f.open("/path/to/file")
var md5 = f.get_md5()
```

2.Maybe the static way is the best?

```
var md5 = File.get_md5("/path/to/file")
```

Closes #3820
