### PR TITLE
AnimationTreePlayer (Blend3): process all inputs.

### DIFF
--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -607,19 +607,20 @@ float AnimationTreePlayer::_process_node(const StringName& p_node,AnimationNode 
 			Blend3Node *bn = static_cast<Blend3Node*>(nb);
 
 			float rem;
-
-			if (bn->value==0) {
-				rem = _process_node(bn->inputs[1].node,r_prev_anim,p_weight,p_time,switched,p_seek,p_filter,p_reverse_weight);
-			} else if (bn->value>0) {
-
-				rem = _process_node(bn->inputs[1].node,r_prev_anim,p_weight*(1.0-bn->value),p_time,switched,p_seek,p_filter,p_reverse_weight*(1.0-bn->value));
-				_process_node(bn->inputs[2].node,r_prev_anim,p_weight*bn->value,p_time,switched,p_seek,p_filter,p_reverse_weight*bn->value);
-
+			float blend, lower_blend, upper_blend;
+			if (bn->value < 0) {
+				lower_blend = -bn->value;
+				blend = 1.0 - lower_blend;
+				upper_blend = 0;
 			} else {
-
-				rem = _process_node(bn->inputs[1].node,r_prev_anim,p_weight*(1.0+bn->value),p_time,switched,p_seek,p_filter,p_reverse_weight*(1.0+bn->value));
-				_process_node(bn->inputs[0].node,r_prev_anim,p_weight*-bn->value,p_time,switched,p_seek,p_filter,p_reverse_weight*-bn->value);
+				lower_blend = 0;
+				blend = 1.0 - bn->value;
+				upper_blend = bn->value;
 			}
+
+			rem = _process_node(bn->inputs[1].node,r_prev_anim,p_weight*blend,p_time,switched,p_seek,p_filter,p_reverse_weight*blend);
+			_process_node(bn->inputs[2].node,r_prev_anim,p_weight*upper_blend,p_time,switched,p_seek,p_filter,p_reverse_weight*upper_blend);
+			_process_node(bn->inputs[0].node,r_prev_anim,p_weight*lower_blend,p_time,switched,p_seek,p_filter,p_reverse_weight*lower_blend);
 
 			return rem;
 		} break;


### PR DESCRIPTION
Always call _process_node on all three inputs so that looped animations
don't get out of sync.

We're using this to blend idle/walk/run cycles, and after blending back and forth the walk/run would no longer be lined up, so sometimes they would fight with each other and the legs would barely be moving.

Looks like all the other blend nodes are fine...
