### PR TITLE
Adds EditorPlugin::remove_control_from_bottom_panel()

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -10252,21 +10252,18 @@ Returns an empty String "" at the end of the list.
 			remove your custom controls too.
 			</description>
 		</method>
-		<method name="add_control_to_bottom_dock">
+		<method name="add_control_to_bottom_panel">
 			<argument index="0" name="control" type="Control">
 			</argument>
 			<argument index="1" name="title" type="String">
 			</argument>
 			<description>
-			Add a control to the bottom dock (together with
+			Add a control to the bottom panel (together with
 			Output, Debug, Animation, etc).
 			
-			Please remember that you have to manage the
-			visibility of your custom controls yourself (and likely
-			hide it after adding it).
-			
 			If your plugin is being removed, also make sure to
-			remove your custom controls too.
+			remove your control by calling [method
+			remove_control_from_bottom_panel].
 			</description>
 		</method>
 		<method name="add_control_to_dock">
@@ -10295,6 +10292,15 @@ Returns an empty String "" at the end of the list.
 			Remove the control from the dock. Don't forget to
 			call this if you added one, so the editor can save
 			the layout and remove it cleanly.
+			</description>
+		</method>
+		<method name="remove_control_from_bottom_panel">
+			<argument index="0" name="control" type="Control">
+			</argument>
+			<description>
+			Remove the control from the bottom panel. Don't forget
+			to call this if you added one, so the editor can
+			remove it cleanly.
 			</description>
 		</method>
 		<method name="add_custom_type">

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -4810,6 +4810,28 @@ void EditorNode::raise_bottom_panel_item(Control *p_item) {
 
 }
 
+void EditorNode::remove_bottom_panel_item(Control *p_item) {
+
+	for(int i=0;i<bottom_panel_items.size();i++) {
+
+		if (bottom_panel_items[i].control==p_item) {
+			if (p_item->is_visible()) {
+				_bottom_panel_switch(false,0);
+			}
+			bottom_panel_vb->remove_child(bottom_panel_items[i].control);
+			bottom_panel_hb->remove_child(bottom_panel_items[i].button);
+			memdelete( bottom_panel_items[i].button );
+			bottom_panel_items.remove(i);
+			break;
+		}
+	}
+
+	for(int i=0;i<bottom_panel_items.size();i++) {
+		bottom_panel_items[i].button->disconnect("toggled",this,"_bottom_panel_switch");
+		bottom_panel_items[i].button->connect("toggled",this,"_bottom_panel_switch",varray(i));
+	}
+}
+
 void EditorNode::_bottom_panel_switch(bool p_enable,int p_idx) {
 
 	ERR_FAIL_INDEX(p_idx,bottom_panel_items.size());

--- a/tools/editor/editor_node.h
+++ b/tools/editor/editor_node.h
@@ -691,6 +691,7 @@ public:
 	void make_bottom_panel_item_visible(Control *p_item);
 	void raise_bottom_panel_item(Control *p_item);
 	void hide_bottom_panel();
+	void remove_bottom_panel_item(Control *p_item);
 
 	EditorNode();	
 	~EditorNode();

--- a/tools/editor/editor_plugin.cpp
+++ b/tools/editor/editor_plugin.cpp
@@ -43,7 +43,7 @@ void EditorPlugin::remove_custom_type(const String& p_type){
 }
 
 
-void EditorPlugin::add_control_to_bottom_dock(Control *p_control, const String &p_title) {
+void EditorPlugin::add_control_to_bottom_panel(Control *p_control, const String &p_title) {
 
 	EditorNode::get_singleton()->add_bottom_panel_item(p_title,p_control);
 }
@@ -59,6 +59,13 @@ void EditorPlugin::remove_control_from_docks(Control *p_control) {
 
 	ERR_FAIL_NULL(p_control);
 	EditorNode::get_singleton()->remove_control_from_dock(p_control);
+
+}
+
+void EditorPlugin::remove_control_from_bottom_panel(Control *p_control) {
+
+	ERR_FAIL_NULL(p_control);
+	EditorNode::get_singleton()->remove_bottom_panel_item(p_control);
 
 }
 
@@ -270,9 +277,10 @@ Control *EditorPlugin::get_base_control() {
 void EditorPlugin::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("add_control_to_container","container","control:Control"),&EditorPlugin::add_control_to_container);
-	ObjectTypeDB::bind_method(_MD("add_control_to_bottom_dock","control:Control","title"),&EditorPlugin::add_control_to_bottom_dock);
+	ObjectTypeDB::bind_method(_MD("add_control_to_bottom_panel","control:Control","title"),&EditorPlugin::add_control_to_bottom_panel);
 	ObjectTypeDB::bind_method(_MD("add_control_to_dock","slot","control:Control"),&EditorPlugin::add_control_to_dock);
 	ObjectTypeDB::bind_method(_MD("remove_control_from_docks","control:Control"),&EditorPlugin::remove_control_from_docks);
+	ObjectTypeDB::bind_method(_MD("remove_control_from_bottom_panel","control:Control"),&EditorPlugin::remove_control_from_bottom_panel);
 	ObjectTypeDB::bind_method(_MD("add_custom_type","type","base","script:Script","icon:Texture"),&EditorPlugin::add_custom_type);
 	ObjectTypeDB::bind_method(_MD("remove_custom_type","type"),&EditorPlugin::remove_custom_type);
 

--- a/tools/editor/editor_plugin.h
+++ b/tools/editor/editor_plugin.h
@@ -91,9 +91,10 @@ public:
 	//TODO: send a resoucre for editing to the editor node?
 
 	void add_control_to_container(CustomControlContainer p_location, Control *p_control);
-	void add_control_to_bottom_dock(Control *p_control, const String &p_title);
+	void add_control_to_bottom_panel(Control *p_control, const String &p_title);
 	void add_control_to_dock(DockSlot p_slot,Control *p_control);
 	void remove_control_from_docks(Control *p_control);
+	void remove_control_from_bottom_panel(Control *p_control);
 
 	virtual Ref<SpatialEditorGizmo> create_spatial_gizmo(Spatial* p_spatial);
 	virtual bool forward_input_event(const InputEvent& p_event);


### PR DESCRIPTION
Also renames `add_control_to_bottom_dock` to `add_control_to_bottom_panel` so that it would be clear that the removal functions are different too.

This was done as adding and then removing plugins using the bottom panel/dock would not clean up properly.
