### PR TITLE
use joystick name from mapping-db if available

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -173,6 +173,7 @@ void InputDefault::joy_connection_changed(int p_idx, bool p_connected, String p_
 		for (int i=0; i < map_db.size(); i++) {
 			if (js.uid == map_db[i].uid) {
 				mapping = i;
+				js.name = map_db[i].name;
 				//printf("found mapping\n");
 			};
 		};
@@ -826,6 +827,7 @@ void InputDefault::parse_mapping(String p_mapping) {
 	uid.resize(17);
 
 	mapping.uid = entry[0];
+	mapping.name = entry[1];
 
 	int idx = 1;
 	while (++idx < entry.size()) {

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -102,6 +102,7 @@ private:
 	struct JoyDeviceMapping {
 
 		String uid;
+		String name;
 		Map<int,JoyEvent> buttons;
 		Map<int,JoyEvent> axis;
 		JoyEvent hat[HAT_MAX];


### PR DESCRIPTION
As they are often more precise/readable then what the hardware provides.
