### PR TITLE
Added relative paths for DirAccess::remove()

### DIFF
--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -292,8 +292,11 @@ Error DirAccessUnix::rename(String p_path,String p_new_path) {
 }
 Error DirAccessUnix::remove(String p_path)  {
 
-	p_path=fix_path(p_path);
-	
+	if (p_path.is_rel_path())
+		p_path=get_current_dir().plus_file(p_path);
+	else
+		p_path=fix_path(p_path);
+
 	struct stat flags;
 	if ((stat(p_path.utf8().get_data(),&flags)!=0))
 		return FAILED;

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -310,8 +310,11 @@ Error DirAccessWindows::rename(String p_path,String p_new_path) {
 
 Error DirAccessWindows::remove(String p_path)  {
 
-	p_path=fix_path(p_path);
-	
+	if (p_path.is_rel_path())
+		p_path=get_current_dir().plus_file(p_path);
+	else
+		p_path=fix_path(p_path);
+
 	printf("erasing %s\n",p_path.utf8().get_data());
 	//WIN32_FILE_ATTRIBUTE_DATA    fileInfo;
 	//DWORD fileAttr = GetFileAttributesExW(p_path.c_str(), GetFileExInfoStandard, &fileInfo);

--- a/platform/flash/dir_access_flash.cpp
+++ b/platform/flash/dir_access_flash.cpp
@@ -183,12 +183,12 @@ size_t DirAccessFlash::get_space_left() {
 
 Error DirAccessFlash::rename(String p_from, String p_to) {
 
-	return FAILED;
+	ERR_FAIL_V(ERR_UNAVAILABLE);
 };
 
 Error DirAccessFlash::remove(String p_name) {
 
-	return FAILED;
+	ERR_FAIL_V(ERR_UNAVAILABLE);
 };
 
 extern char* psp_drive;

--- a/platform/osx/dir_access_osx.mm
+++ b/platform/osx/dir_access_osx.mm
@@ -297,8 +297,11 @@ Error DirAccessOSX::rename(String p_path,String p_new_path) {
 }
 Error DirAccessOSX::remove(String p_path)  {
 
-	p_path=fix_path(p_path);
-	
+	if (p_path.is_rel_path())
+		p_path=get_current_dir().plus_file(p_path);
+	else
+		p_path=fix_path(p_path);
+
 	struct stat flags;
 	if ((stat(p_path.utf8().get_data(),&flags)!=0))
 		return FAILED;


### PR DESCRIPTION
Follows similar behaviour to DirAccess::rename().

Previously, appending the path was necessary:

```
var dir = Directory.new()
dir.open(path)
dir.remove(path + "file.txt")
```

Should not break backwards compatibility.
