### PR TITLE
fix gradle build on windows

### DIFF
--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -59,7 +59,7 @@ for x in env.android_dependencies:
 gradle_java_dirs_text=""
 
 for x in env.android_java_dirs:
-	gradle_java_dirs_text+=",'"+x+"'"
+	gradle_java_dirs_text+=",'"+x.replace("\\","/")+"'"
 
 
 gradle_res_dirs_text=""


### PR DESCRIPTION
`unexpected char: '\'` error occurred when gradle build on windows with custom android modules.
the directory text has both `\` and `/` like `D:\godot\platform/android...`.
after replace `\` with `/`, can build successfully.
