### PR TITLE
Completion tooltip

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -967,7 +967,7 @@ void TextEdit::_notification(int p_what) {
 				}
 				
 				
-				Point2 hint_ofs = Vector2(completion_hint_offset,cursor_pos.y-minsize.y);
+				Point2 hint_ofs = Vector2(completion_hint_offset,cursor_pos.y+minsize.y);
 				draw_style_box(sb,Rect2(hint_ofs,minsize));
 				
 				spacing=0;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -931,7 +931,7 @@ void TextEdit::_notification(int p_what) {
 				
 			}
 			
-			if (completion_hint!="") {
+			if (completion_hint!="" && !completion_active) {
 				
 				Ref<StyleBox> sb = get_stylebox("panel","TooltipPanel");
 				Ref<Font> font = cache.font;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -847,7 +847,7 @@ void TextEdit::_notification(int p_what) {
 				}
 			}
 			
-			
+			bool completion_below = false;
 			if (completion_active) {
 				// code completion box
 				Ref<StyleBox> csb = get_stylebox("completion");
@@ -878,11 +878,12 @@ void TextEdit::_notification(int p_what) {
 				}
 				
 				int th = h + csb->get_minimum_size().y;
+				
 				if (cursor_pos.y+get_row_height()+th > get_size().height) {
 					completion_rect.pos.y=cursor_pos.y-th;
 				} else {
 					completion_rect.pos.y=cursor_pos.y+get_row_height()+csb->get_offset().y;
-					
+					completion_below = true;
 				}
 				
 				if (cursor_pos.x-nofs+w+scrollw  > get_size().width) {
@@ -930,8 +931,24 @@ void TextEdit::_notification(int p_what) {
 				completion_line_ofs=line_from;
 				
 			}
+
+			// check to see if the hint should be drawn
+			bool show_hint = false;
+			if (completion_hint!="") {
+				if (completion_active) {
+					if (completion_below && !callhint_below) {
+						show_hint = true;
+					}
+					else if (!completion_below && callhint_below) {
+						show_hint = true;
+					}
+				}
+				else {
+					show_hint = true;
+				}
+			}
 			
-			if (completion_hint!="" && !completion_active) {
+			if (show_hint) {
 				
 				Ref<StyleBox> sb = get_stylebox("panel","TooltipPanel");
 				Ref<Font> font = cache.font;
@@ -967,7 +984,15 @@ void TextEdit::_notification(int p_what) {
 				}
 				
 				
-				Point2 hint_ofs = Vector2(completion_hint_offset,cursor_pos.y+minsize.y);
+				Point2 hint_ofs = Vector2(completion_hint_offset,cursor_pos.y) + callhint_offset;
+
+				if (callhint_below) {
+					hint_ofs.y += get_row_height() + sb->get_offset().y;
+				}
+				else {
+					hint_ofs.y -= minsize.y + sb->get_offset().y;
+				}
+
 				draw_style_box(sb,Rect2(hint_ofs,minsize));
 				
 				spacing=0;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -231,6 +231,9 @@ class TextEdit : public Control  {
 	
 	bool next_operation_is_complex;
 
+	bool callhint_below;
+	Vector2 callhint_offset;
+
 	int get_visible_rows() const;
 
 	int get_char_count();
@@ -325,6 +328,10 @@ public:
 	inline void set_brace_matching(bool p_enabled) {
 		brace_matching_enabled=p_enabled;
 		update();
+	}
+	inline void set_callhint_settings(bool below, Vector2 offset) {
+		callhint_below = below;
+		callhint_offset = offset;
 	}
 	void set_auto_indent(bool p_auto_indent);
 

--- a/tools/editor/code_editor.cpp
+++ b/tools/editor/code_editor.cpp
@@ -568,6 +568,12 @@ void CodeTextEditor::_on_settings_change() {
 	);
 
 	enable_complete_timer = EDITOR_DEF("text_editor/enable_code_completion_delay",true);
+
+	// call hint settings
+	text_editor->set_callhint_settings(
+		EDITOR_DEF("text_editor/put_callhint_tooltip_below_current_line", true),
+		EDITOR_DEF("text_editor/callhint_tooltip_offset", Vector2())
+	);
 }
 
 void CodeTextEditor::_text_changed_idle_timeout() {

--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -1928,6 +1928,9 @@ void ScriptEditor::edit(const Ref<Script>& p_script) {
 	ste->set_edited_script(p_script);
 	ste->get_text_edit()->set_tooltip_request_func(this,"_get_debug_tooltip",ste);
 	ste->get_text_edit()->set_auto_brace_completion(EditorSettings::get_singleton()->get("text_editor/auto_brace_complete"));
+	ste->get_text_edit()->set_callhint_settings(
+		EditorSettings::get_singleton()->get("text_editor/put_callhint_tooltip_below_current_line"),
+		EditorSettings::get_singleton()->get("text_editor/callhint_tooltip_offset"));
 	tab_container->add_child(ste);
 	_go_to_tab(tab_container->get_tab_count()-1);
 


### PR DESCRIPTION
I moved the hint under the current line, so it looks like this:

![it1](https://cloud.githubusercontent.com/assets/4700122/13506668/7efa3e3c-e17f-11e5-872f-b71fa52ca3d3.png)

It gets disabled when the code completion appears.

![hint1](https://cloud.githubusercontent.com/assets/4700122/13507330/6ba95a90-e182-11e5-9adc-7a5fe6660c41.png)
![hint2](https://cloud.githubusercontent.com/assets/4700122/13507328/6ba31aa4-e182-11e5-9876-24fa6bd8acfe.png)
![hint3](https://cloud.githubusercontent.com/assets/4700122/13507329/6ba40aae-e182-11e5-904c-e6931b9d7d6b.png)

Closes #1261.
#### UPDATE:

I have added editor settings:

![hint4](https://cloud.githubusercontent.com/assets/4700122/13524137/c4f6b6ac-e1f9-11e5-8769-808ff8026487.png)

And it all works as expected:

![hint5](https://cloud.githubusercontent.com/assets/4700122/13524150/d587056c-e1f9-11e5-9b6d-5e79898311aa.png)
![hint6](https://cloud.githubusercontent.com/assets/4700122/13524151/d587ccd6-e1f9-11e5-8574-0fb03d23dff6.png)

The call hint tooltip gets hidden only when it has to (when to completion is shown on the same side).
