### PR TITLE
Open line below and above

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1677,9 +1677,30 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 							ins+="\t";
 						}
 					}
+
+					bool first_line = false;
+					if (k.mod.command) {
+						if (k.mod.shift) {
+							if (cursor.line > 0) {
+								cursor_set_line(cursor.line - 1);
+								cursor_set_column(text[cursor.line].length());
+							}
+							else {
+								cursor_set_column(0);
+								first_line = true;
+							}
+						}
+						else {
+							cursor_set_column(text[cursor.line].length());
+						}
+					}
 					
 					_insert_text_at_cursor(ins);
 					_push_current_op();
+
+					if (first_line) {
+						cursor_set_line(0);
+					}
 					
 				} break;
 				case KEY_ESCAPE: {


### PR DESCRIPTION
This adds the functionality to the text editor to open lines below and above the current line:

![snl1](https://cloud.githubusercontent.com/assets/4700122/13537570/e0c5ec6c-e245-11e5-9317-cb83d2582f4a.png)
CTRL+ENTER
![snl2](https://cloud.githubusercontent.com/assets/4700122/13537569/e0c60404-e245-11e5-9047-4f7aaa70d94f.png)

![snl3](https://cloud.githubusercontent.com/assets/4700122/13537568/e0c49038-e245-11e5-8b58-ee463e56fb49.png)
CTRL+SHIFT+ENTER
![snl4](https://cloud.githubusercontent.com/assets/4700122/13537571/e0c79f4e-e245-11e5-9352-23c63217cb14.png)
