### PR TITLE
Added epoc to dictionary converter (for human readable display when only given an epoc time)

### DIFF
--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -208,6 +208,7 @@ public:
 	void set_icon(const Image& p_icon);
 	Dictionary get_date(bool utc) const;
 	Dictionary get_time(bool utc) const;
+	Dictionary get_time_from_unix_time(uint64_t unix_time_val) const;
 	Dictionary get_time_zone_info() const;
 	uint64_t get_unix_time() const;
 	uint64_t get_system_time_secs() const;


### PR DESCRIPTION
Useful for when user is storing time as epoc and wants to do operations on this
time and then display in human readable form

https://www.facebook.com/groups/godotengine/permalink/737469773056286/?comment_id=738011009668829&reply_comment_id=738192799650650&notif_t=group_comment_reply
