### PR TITLE
fix compiling android templates on windows

### DIFF
--- a/drivers/png/SCsub
+++ b/drivers/png/SCsub
@@ -22,17 +22,16 @@ png_sources = [
 	"png/image_loader_png.cpp"
 ]
 
-if ("neon_enabled" in env and env["neon_enabled"]):
+# Currently .ASM filter_neon.S does not compile on NT.
+import os
+if ("neon_enabled" in env and env["neon_enabled"]) and os.name!="nt":
 	env.Append(CPPFLAGS=["-DPNG_ARM_NEON_OPT=2"])
 	env_neon = env.Clone();
 	if "S_compiler" in env:
 		env_neon['CC'] = env['S_compiler']
 	#env_neon.Append(CPPFLAGS=["-DPNG_ARM_NEON"])
-	import os
-	# Currently .ASM filter_neon.S does not compile on NT.
-	if (os.name!="nt"):
-		png_sources.append(env_neon.Object("#drivers/png/arm/arm_init.c"))
-		png_sources.append(env_neon.Object("#drivers/png/arm/filter_neon.S"))
+	png_sources.append(env_neon.Object("#drivers/png/arm/arm_init.c"))
+	png_sources.append(env_neon.Object("#drivers/png/arm/filter_neon.S"))
 else:
 	env.Append(CPPFLAGS=["-DPNG_ARM_NEON_OPT=0"])
 


### PR DESCRIPTION
This will disable png arm neon optimizing for android template if compile on windows, but make compiling successful.

And arm neon opt is enabled if not on windows.
