### PR TITLE
Added extra controls to GeometryInstances for controlling how shadows are cast.

### DIFF
--- a/drivers/gles2/rasterizer_gles2.h
+++ b/drivers/gles2/rasterizer_gles2.h
@@ -829,7 +829,9 @@ class RasterizerGLES2 : public Rasterizer {
 
 	bool fragment_lighting;
 	RID shadow_material;
+	RID shadow_material_double_sided;
 	Material *shadow_mat_ptr;
+	Material *shadow_mat_double_sided_ptr;
 
 	int max_texture_units;
 	GLuint base_framebuffer;

--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -267,6 +267,15 @@ void GeometryInstance::_update_visibility() {
 void GeometryInstance::set_flag(Flags p_flag,bool p_value) {
 
 	ERR_FAIL_INDEX(p_flag,FLAG_MAX);
+	if (p_flag==FLAG_CAST_SHADOW) {
+		if (p_value == true) {
+			set_cast_shadows_setting(SHADOW_CASTING_SETTING_ON);
+		}
+		else {
+			set_cast_shadows_setting(SHADOW_CASTING_SETTING_OFF);
+		}
+	}
+
 	if (flags[p_flag]==p_value)
 		return;
 
@@ -294,8 +303,30 @@ void GeometryInstance::set_flag(Flags p_flag,bool p_value) {
 bool GeometryInstance::get_flag(Flags p_flag) const{
 
 	ERR_FAIL_INDEX_V(p_flag,FLAG_MAX,false);
+
+	if (p_flag == FLAG_CAST_SHADOW) {
+		if (shadow_casting_setting == SHADOW_CASTING_SETTING_OFF) {
+			return false;
+		}
+		else {
+			return true;
+		}
+	}
+
 	return flags[p_flag];
 
+}
+
+void GeometryInstance::set_cast_shadows_setting(ShadowCastingSetting p_shadow_casting_setting) {
+
+	shadow_casting_setting = p_shadow_casting_setting;
+
+	VS::get_singleton()->instance_geometry_set_cast_shadows_setting(get_instance(), (VS::ShadowCastingSetting)p_shadow_casting_setting);
+}
+
+GeometryInstance::ShadowCastingSetting GeometryInstance::get_cast_shadows_setting() const {
+
+	return shadow_casting_setting;
 }
 
 void GeometryInstance::set_baked_light_texture_id(int p_id) {
@@ -330,6 +361,9 @@ void GeometryInstance::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_flag","flag","value"), &GeometryInstance::set_flag);
 	ObjectTypeDB::bind_method(_MD("get_flag","flag"), &GeometryInstance::get_flag);
 
+	ObjectTypeDB::bind_method(_MD("set_cast_shadows_setting", "shadow_casting_setting"), &GeometryInstance::set_cast_shadows_setting);
+	ObjectTypeDB::bind_method(_MD("get_cast_shadows_setting"), &GeometryInstance::get_cast_shadows_setting);
+
 	ObjectTypeDB::bind_method(_MD("set_draw_range_begin","mode"), &GeometryInstance::set_draw_range_begin);
 	ObjectTypeDB::bind_method(_MD("get_draw_range_begin"), &GeometryInstance::get_draw_range_begin);
 
@@ -346,7 +380,7 @@ void GeometryInstance::_bind_methods() {
 
 	ADD_PROPERTYI( PropertyInfo( Variant::BOOL, "geometry/visible"), _SCS("set_flag"), _SCS("get_flag"),FLAG_VISIBLE);
 	ADD_PROPERTY( PropertyInfo( Variant::OBJECT, "geometry/material_override",PROPERTY_HINT_RESOURCE_TYPE,"Material"), _SCS("set_material_override"), _SCS("get_material_override"));
-	ADD_PROPERTYI( PropertyInfo( Variant::BOOL, "geometry/cast_shadow"), _SCS("set_flag"), _SCS("get_flag"),FLAG_CAST_SHADOW);
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "geometry/cast_shadow", PROPERTY_HINT_ENUM, "Off,On,Double-Sided,Shadows Only"), _SCS("set_cast_shadows_setting"), _SCS("get_cast_shadows_setting"));
 	ADD_PROPERTYI( PropertyInfo( Variant::BOOL, "geometry/receive_shadows"), _SCS("set_flag"), _SCS("get_flag"),FLAG_RECEIVE_SHADOWS);
 	ADD_PROPERTY( PropertyInfo( Variant::INT, "geometry/range_begin",PROPERTY_HINT_RANGE,"0,32768,0.01"), _SCS("set_draw_range_begin"), _SCS("get_draw_range_begin"));
 	ADD_PROPERTY( PropertyInfo( Variant::INT, "geometry/range_end",PROPERTY_HINT_RANGE,"0,32768,0.01"), _SCS("set_draw_range_end"), _SCS("get_draw_range_end"));
@@ -369,6 +403,11 @@ void GeometryInstance::_bind_methods() {
 	BIND_CONSTANT(FLAG_VISIBLE_IN_ALL_ROOMS );
 	BIND_CONSTANT(FLAG_MAX );
 
+	BIND_CONSTANT(SHADOW_CASTING_SETTING_OFF);
+	BIND_CONSTANT(SHADOW_CASTING_SETTING_ON);
+	BIND_CONSTANT(SHADOW_CASTING_SETTING_DOUBLE_SIDED);
+	BIND_CONSTANT(SHADOW_CASTING_SETTING_SHADOWS_ONLY);
+
 }
 
 GeometryInstance::GeometryInstance() {
@@ -381,6 +420,7 @@ GeometryInstance::GeometryInstance() {
 	flags[FLAG_VISIBLE]=true;
 	flags[FLAG_CAST_SHADOW]=true;
 	flags[FLAG_RECEIVE_SHADOWS]=true;
+	shadow_casting_setting=SHADOW_CASTING_SETTING_ON;
 	baked_light_instance=NULL;
 	baked_light_texture_id=0;
 	extra_cull_margin=0;

--- a/scene/3d/visual_instance.h
+++ b/scene/3d/visual_instance.h
@@ -98,10 +98,17 @@ public:
 		FLAG_MAX=VS::INSTANCE_FLAG_MAX,
 	};
 
+	enum ShadowCastingSetting {
+		SHADOW_CASTING_SETTING_OFF=VS::SHADOW_CASTING_SETTING_OFF,
+		SHADOW_CASTING_SETTING_ON = VS::SHADOW_CASTING_SETTING_ON,
+		SHADOW_CASTING_SETTING_DOUBLE_SIDED=VS::SHADOW_CASTING_SETTING_DOUBLE_SIDED,
+		SHADOW_CASTING_SETTING_SHADOWS_ONLY=VS::SHADOW_CASTING_SETTING_SHADOWS_ONLY
+	};
 
 private:
 
 	bool flags[FLAG_MAX];
+	ShadowCastingSetting shadow_casting_setting;
 	Ref<Material> material_override;
 	float draw_begin;
 	float draw_end;
@@ -120,6 +127,9 @@ public:
 
 	void set_flag(Flags p_flag,bool p_value);
 	bool get_flag(Flags p_flag) const;
+
+	void set_cast_shadows_setting(ShadowCastingSetting p_shadow_casting_setting);
+	ShadowCastingSetting get_cast_shadows_setting() const;
 
 	void set_draw_range_begin(float p_dist);
 	float get_draw_range_begin() const;
@@ -140,5 +150,7 @@ public:
 };
 
 VARIANT_ENUM_CAST( GeometryInstance::Flags );
+VARIANT_ENUM_CAST( GeometryInstance::ShadowCastingSetting );
+
 
 #endif

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -539,6 +539,7 @@ public:
 		Vector<RID> light_instances;
 		Vector<float> morph_values;
 		BakedLightData *baked_light;
+		VS::ShadowCastingSetting cast_shadows;
 		Transform *baked_light_octree_xform;
 		int baked_lightmap_id;
 		bool mirror :8;

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -2724,7 +2724,12 @@ void VisualServerRaster::instance_geometry_set_flag(RID p_instance,InstanceFlags
 
 		} break;
 		case INSTANCE_FLAG_CAST_SHADOW: {
-			instance->cast_shadows=p_enabled;
+			if (p_enabled == true) {
+				instance->data.cast_shadows = SHADOW_CASTING_SETTING_ON;
+			}
+			else {
+				instance->data.cast_shadows = SHADOW_CASTING_SETTING_OFF;
+			}
 
 		} break;
 		case INSTANCE_FLAG_RECEIVE_SHADOWS: {
@@ -2771,7 +2776,12 @@ bool VisualServerRaster::instance_geometry_get_flag(RID p_instance,InstanceFlags
 
 		} break;
 		case INSTANCE_FLAG_CAST_SHADOW: {
-			return instance->cast_shadows;
+			if(instance->data.cast_shadows == SHADOW_CASTING_SETTING_OFF) {
+				return false;
+			}
+			else {
+				return true;
+			}
 
 		} break;
 		case INSTANCE_FLAG_RECEIVE_SHADOWS: {
@@ -2793,6 +2803,22 @@ bool VisualServerRaster::instance_geometry_get_flag(RID p_instance,InstanceFlags
 	}
 
 	return false;
+}
+
+void VisualServerRaster::instance_geometry_set_cast_shadows_setting(RID p_instance, VS::ShadowCastingSetting p_shadow_casting_setting) {
+
+	Instance *instance = instance_owner.get( p_instance );
+	ERR_FAIL_COND( !instance );
+
+	instance->data.cast_shadows = p_shadow_casting_setting;
+}
+
+VS::ShadowCastingSetting VisualServerRaster::instance_geometry_get_cast_shadows_setting(RID p_instance) const{
+
+	const Instance *instance = instance_owner.get( p_instance );
+	ERR_FAIL_COND_V( !instance, SHADOW_CASTING_SETTING_OFF );
+
+	return instance->data.cast_shadows;
 }
 
 
@@ -5019,7 +5045,7 @@ void VisualServerRaster::_light_instance_update_pssm_shadow(Instance *p_light,Sc
 		
 			float min,max;
 			Instance *ins=instance_shadow_cull_result[j];
-			if (!ins->visible || !ins->cast_shadows)
+			if (!ins->visible || ins->data.cast_shadows == VS::SHADOW_CASTING_SETTING_OFF)
 				continue;
 			ins->transformed_aabb.project_range_in_plane(Plane(z_vec,0),min,max);
 
@@ -5047,7 +5073,7 @@ void VisualServerRaster::_light_instance_update_pssm_shadow(Instance *p_light,Sc
 		for (int j=0;j<caster_cull_count;j++) {
 		
 			Instance *instance = instance_shadow_cull_result[j];
-			if (!instance->visible || !instance->cast_shadows)
+			if (!instance->visible || instance->data.cast_shadows==VS::SHADOW_CASTING_SETTING_OFF)
 				continue;
 			_instance_draw(instance);
 		}
@@ -5130,7 +5156,7 @@ void VisualServerRaster::_light_instance_update_lispsm_shadow(Instance *p_light,
 		for(int i=0;i<caster_count;i++) {
 
 			Instance *ins = instance_shadow_cull_result[i];
-			if (!ins->visible || !ins->cast_shadows)
+			if (!ins->visible || ins->data.cast_shadows == VS::SHADOW_CASTING_SETTING_OFF)
 				continue;
 
 			for(int j=0;j<8;j++) {
@@ -5281,7 +5307,7 @@ void VisualServerRaster::_light_instance_update_lispsm_shadow(Instance *p_light,
 
 		Instance *instance = instance_shadow_cull_result[i];
 
-		if (!instance->visible || !instance->cast_shadows)
+		if (!instance->visible || instance->data.cast_shadows == VS::SHADOW_CASTING_SETTING_OFF)
 			continue;
 		_instance_draw(instance);
 	}
@@ -5378,7 +5404,7 @@ void VisualServerRaster::_light_instance_update_lispsm_shadow(Instance *p_light,
 	for(int i=0;i<caster_count;i++) {
 
 		Instance *ins=instance_shadow_cull_result[i];
-		if (!ins->visible || !ins->cast_shadows)
+		if (!ins->visible || ins->cast_shadows==VS::SHADOW_CASTING_SETTING_OFF)
 			continue;
 
 		//@TODO optimize using support mapping
@@ -5468,7 +5494,7 @@ void VisualServerRaster::_light_instance_update_lispsm_shadow(Instance *p_light,
 
 		Instance *instance = instance_shadow_cull_result[i];
 
-		if (!instance->visible || !instance->cast_shadows)
+		if (!instance->visible || instance->cast_shadows==VS::SHADOW_CASTING_SETTING_OFF)
 			continue;
 		_instance_draw(instance);
 	}
@@ -5516,7 +5542,7 @@ void VisualServerRaster::_light_instance_update_shadow(Instance *p_light,Scenari
 			for (int i=0;i<cull_count;i++) {
 
 				Instance *instance = instance_shadow_cull_result[i];
-				if (!instance->visible || !instance->cast_shadows)
+				if (!instance->visible || instance->data.cast_shadows == VS::SHADOW_CASTING_SETTING_OFF)
 					continue;
 				_instance_draw(instance);
 			}
@@ -5557,7 +5583,7 @@ void VisualServerRaster::_light_instance_update_shadow(Instance *p_light,Scenari
 					for (int j=0;j<cull_count;j++) {
 
 						Instance *instance = instance_shadow_cull_result[j];
-						if (!instance->visible || !instance->cast_shadows)
+						if (!instance->visible || instance->data.cast_shadows == VS::SHADOW_CASTING_SETTING_OFF)
 							continue;
 
 						_instance_draw(instance);
@@ -6511,7 +6537,7 @@ void VisualServerRaster::_render_camera(Viewport *p_viewport,Camera *p_camera, S
 				}
 			}
 
-		} else if ((1<<ins->base_type)&INSTANCE_GEOMETRY_MASK && ins->visible) {
+		} else if ((1<<ins->base_type)&INSTANCE_GEOMETRY_MASK && ins->visible && ins->data.cast_shadows!=VS::SHADOW_CASTING_SETTING_SHADOWS_ONLY) {
 
 
 			bool discarded=false;

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -169,7 +169,6 @@ class VisualServerRaster : public VisualServer {
 		AABB transformed_aabb;
 		uint32_t object_ID;
 		bool visible;
-		bool cast_shadows;
 		bool receive_shadows;
 		bool visible_in_all_rooms;
 		uint32_t layer_mask;
@@ -300,7 +299,7 @@ class VisualServerRaster : public VisualServer {
 			update_next=NULL;
 			update=false;
 			visible=true;
-			cast_shadows=true;
+			data.cast_shadows=SHADOW_CASTING_SETTING_ON;
 			receive_shadows=true;
 			data.depth_scale=false;
 			data.billboard=false;
@@ -1092,6 +1091,9 @@ public:
 
 	virtual void instance_geometry_set_flag(RID p_instance,InstanceFlags p_flags,bool p_enabled);
 	virtual bool instance_geometry_get_flag(RID p_instance,InstanceFlags p_flags) const;
+
+	virtual void instance_geometry_set_cast_shadows_setting(RID p_instance, VS::ShadowCastingSetting p_shadow_casting_setting);
+	virtual VS::ShadowCastingSetting instance_geometry_get_cast_shadows_setting(RID p_instance) const;
 
 	virtual void instance_geometry_set_material_override(RID p_instance, RID p_material);
 	virtual RID instance_geometry_get_material_override(RID p_instance) const;

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -534,6 +534,9 @@ public:
 	FUNC3(instance_geometry_set_flag,RID,InstanceFlags ,bool );
 	FUNC2RC(bool,instance_geometry_get_flag,RID,InstanceFlags );
 
+	FUNC2(instance_geometry_set_cast_shadows_setting, RID, ShadowCastingSetting);
+	FUNC1RC(ShadowCastingSetting, instance_geometry_get_cast_shadows_setting, RID);
+
 	FUNC2(instance_geometry_set_material_override,RID, RID );
 	FUNC1RC(RID,instance_geometry_get_material_override,RID);
 

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -937,8 +937,18 @@ public:
 		INSTANCE_FLAG_MAX
 	};
 
+	enum ShadowCastingSetting {
+		SHADOW_CASTING_SETTING_OFF,
+		SHADOW_CASTING_SETTING_ON,
+		SHADOW_CASTING_SETTING_DOUBLE_SIDED,
+		SHADOW_CASTING_SETTING_SHADOWS_ONLY,
+	};
+
 	virtual void instance_geometry_set_flag(RID p_instance,InstanceFlags p_flags,bool p_enabled)=0;
 	virtual bool instance_geometry_get_flag(RID p_instance,InstanceFlags p_flags) const=0;
+
+	virtual void instance_geometry_set_cast_shadows_setting(RID p_instance, ShadowCastingSetting p_shadow_casting_setting) = 0;
+	virtual ShadowCastingSetting instance_geometry_get_cast_shadows_setting(RID p_instance) const = 0;
 
 	virtual void instance_geometry_set_material_override(RID p_instance, RID p_material)=0;
 	virtual RID instance_geometry_get_material_override(RID p_instance) const=0;

--- a/tools/editor/plugins/spatial_editor_plugin.cpp
+++ b/tools/editor/plugins/spatial_editor_plugin.cpp
@@ -2196,7 +2196,7 @@ void SpatialEditorViewport::_init_gizmo_instance(int p_idx) {
 		VS::get_singleton()->instance_set_scenario(move_gizmo_instance[i],get_tree()->get_root()->get_world()->get_scenario());
 		VS::get_singleton()->instance_geometry_set_flag(move_gizmo_instance[i],VS::INSTANCE_FLAG_VISIBLE,false);
 		//VS::get_singleton()->instance_geometry_set_flag(move_gizmo_instance[i],VS::INSTANCE_FLAG_DEPH_SCALE,true);
-		VS::get_singleton()->instance_geometry_set_flag(move_gizmo_instance[i],VS::INSTANCE_FLAG_CAST_SHADOW,false);
+		VS::get_singleton()->instance_geometry_set_cast_shadows_setting(move_gizmo_instance[i], VS::SHADOW_CASTING_SETTING_OFF);
 		VS::get_singleton()->instance_set_layer_mask(move_gizmo_instance[i],layer);
 
 		rotate_gizmo_instance[i]=VS::get_singleton()->instance_create();
@@ -2204,7 +2204,7 @@ void SpatialEditorViewport::_init_gizmo_instance(int p_idx) {
 		VS::get_singleton()->instance_set_scenario(rotate_gizmo_instance[i],get_tree()->get_root()->get_world()->get_scenario());
 		VS::get_singleton()->instance_geometry_set_flag(rotate_gizmo_instance[i],VS::INSTANCE_FLAG_VISIBLE,false);
 		//VS::get_singleton()->instance_geometry_set_flag(rotate_gizmo_instance[i],VS::INSTANCE_FLAG_DEPH_SCALE,true);
-		VS::get_singleton()->instance_geometry_set_flag(rotate_gizmo_instance[i],VS::INSTANCE_FLAG_CAST_SHADOW,false);
+		VS::get_singleton()->instance_geometry_set_cast_shadows_setting(rotate_gizmo_instance[i], VS::SHADOW_CASTING_SETTING_OFF);
 		VS::get_singleton()->instance_set_layer_mask(rotate_gizmo_instance[i],layer);
 	}
 
@@ -2585,7 +2585,7 @@ Object *SpatialEditor::_get_editor_data(Object *p_what) {
 
 	si->sp=sp;
 	si->sbox_instance=VisualServer::get_singleton()->instance_create2(selection_box->get_rid(),sp->get_world()->get_scenario());
-	VS::get_singleton()->instance_geometry_set_flag(si->sbox_instance,VS::INSTANCE_FLAG_CAST_SHADOW,false);
+	VS::get_singleton()->instance_geometry_set_cast_shadows_setting(si->sbox_instance, VS::SHADOW_CASTING_SETTING_OFF);
 
 	RID inst = sp->call("_get_visual_instance_rid");
 
@@ -3272,8 +3272,8 @@ void SpatialEditor::_init_indicators() {
 			grid_visible[i]=false;
 			grid_enable[i]=false;
 			VisualServer::get_singleton()->instance_geometry_set_flag(grid_instance[i],VS::INSTANCE_FLAG_VISIBLE,false);
-			VisualServer::get_singleton()->instance_geometry_set_flag(grid_instance[i],VS::INSTANCE_FLAG_CAST_SHADOW,false);
-			VS::get_singleton()->instance_set_layer_mask(grid_instance[i],1<<SpatialEditorViewport::GIZMO_GRID_LAYER);
+			VisualServer::get_singleton()->instance_geometry_set_cast_shadows_setting(grid_instance[i], VS::SHADOW_CASTING_SETTING_OFF);
+			VS::get_singleton()->instance_set_layer_mask(grid_instance[i], 1 << SpatialEditorViewport::GIZMO_GRID_LAYER);
 
 
 		}
@@ -3294,7 +3294,7 @@ void SpatialEditor::_init_indicators() {
 		origin_instance = VisualServer::get_singleton()->instance_create2(origin,get_tree()->get_root()->get_world()->get_scenario());
 		VS::get_singleton()->instance_set_layer_mask(origin_instance,1<<SpatialEditorViewport::GIZMO_GRID_LAYER);
 
-		VisualServer::get_singleton()->instance_geometry_set_flag(origin_instance,VS::INSTANCE_FLAG_CAST_SHADOW,false);
+		VisualServer::get_singleton()->instance_geometry_set_cast_shadows_setting(origin_instance, VS::SHADOW_CASTING_SETTING_OFF);
 
 
 
@@ -3331,7 +3331,7 @@ void SpatialEditor::_init_indicators() {
 		cursor_instance = VisualServer::get_singleton()->instance_create2(cursor_mesh,get_tree()->get_root()->get_world()->get_scenario());
 		VS::get_singleton()->instance_set_layer_mask(cursor_instance,1<<SpatialEditorViewport::GIZMO_GRID_LAYER);
 
-		VisualServer::get_singleton()->instance_geometry_set_flag(cursor_instance,VS::INSTANCE_FLAG_CAST_SHADOW,false);
+		VisualServer::get_singleton()->instance_geometry_set_cast_shadows_setting(cursor_instance, VS::SHADOW_CASTING_SETTING_OFF);
 
 
 	}

--- a/tools/editor/spatial_editor_gizmos.cpp
+++ b/tools/editor/spatial_editor_gizmos.cpp
@@ -81,7 +81,7 @@ void EditorSpatialGizmo::Instance::create_instance(Spatial *p_base) {
 		VS::get_singleton()->instance_attach_skeleton(instance,skeleton);
 	if (extra_margin)
 		VS::get_singleton()->instance_set_extra_visibility_margin(instance,1);
-	VS::get_singleton()->instance_geometry_set_flag(instance,VS::INSTANCE_FLAG_CAST_SHADOW,false);
+	VS::get_singleton()->instance_geometry_set_cast_shadows_setting(instance,VS::SHADOW_CASTING_SETTING_OFF);
 	VS::get_singleton()->instance_geometry_set_flag(instance,VS::INSTANCE_FLAG_RECEIVE_SHADOWS,false);
 	VS::get_singleton()->instance_set_layer_mask(instance,1<<SpatialEditorViewport::GIZMO_EDIT_LAYER); //gizmos are 26
 }


### PR DESCRIPTION
This pull request adds support for two new setttings for GeometryInstances casting shadows: they can now be double-sided or cast only the shadow. These settings can be very useful to have, especially since there's currently no way to have double-sided shadows which doesn't involve creating double-sided polygons manually and it also gives this aspect feature-parity with the Unity engine.

If you merge though, while I've left the pre-existing functionality intact so as not to break any backwards compatibility, it might be worth marking the CAST_SHADOW flag for deprecation since it is now obsolete due to the new features introduced.
