### PR TITLE
Update version in Info.plist

### DIFF
--- a/tools/Godot.app/Contents/Info.plist
+++ b/tools/Godot.app/Contents/Info.plist
@@ -19,11 +19,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>2.0.1</string>
 	<key>CFBundleSignature</key>
 	<string>godot</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.0</string>
+	<string>2.0.1</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2007-2016 Juan Linietsky, Ariel Manzur</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
Getting info on Godot.app still shows version 1.0.0.  Would be nice to have this reflect the real version number via the build system.  Any way to have this poked with the correct value during a build?  (Yeah, this is pretty far down the priority list, huh?  _smile_)
