### PR TITLE
Fix a crash when running a game with Controls with a tools build

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1175,7 +1175,12 @@ void Control::set_anchor(Margin p_margin,AnchorType p_anchor, bool p_keep_margin
 
 void Control::_set_anchor(Margin p_margin,AnchorType p_anchor) {
 	#ifdef TOOLS_ENABLED
-	set_anchor(p_margin, p_anchor, EDITOR_DEF("2d_editor/keep_margins_when_changing_anchors", false));
+	SceneTree *st=OS::get_singleton()->get_main_loop()->cast_to<SceneTree>();
+	if (st && st->is_editor_hint()) {
+		set_anchor(p_margin, p_anchor, EDITOR_DEF("2d_editor/keep_margins_when_changing_anchors", false));
+	} else {
+		set_anchor(p_margin, p_anchor);
+	}
 	#else
 	set_anchor(p_margin, p_anchor);
 	#endif


### PR DESCRIPTION
Regression from #3997

`TOOLS_ENABLED` is defined, when running from an editor binary, but `EDITOR_DEF` crashes if `SceneTree::editor_hint` is false.

Sorry about that one...
