### PR TITLE
TileSet Export: Avoid invalid error when merge is enabled but file doesn't exist

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -1267,23 +1267,20 @@ void EditorNode::_dialog_action(String p_file) {
 			if (FileAccess::exists(p_file)) {
 				ml=ResourceLoader::load(p_file,"TileSet");
 
-				if (!file_export_lib_merge->is_pressed()) {
+				if (ml.is_null()) {
+					if (file_export_lib_merge->is_pressed()) {
+						current_option=-1;
+						//accept->get_cancel()->hide();
+						accept->get_ok()->set_text("I see..");
+						accept->set_text("Can't load TileSet for merging!.");
+						accept->popup_centered_minsize();
+						return;
+					}
+				} else if (!file_export_lib_merge->is_pressed()) {
 					ml->clear();
 				}
 
-			}
-
-			if (ml.is_null()) {
-
-				if (file_export_lib_merge->is_pressed()) {
-					current_option=-1;
-					//accept->get_cancel()->hide();
-					accept->get_ok()->set_text("I see..");
-					accept->set_text("Can't load TileSet for merging!.");
-					accept->popup_centered_minsize();
-					return;
-				}
-
+			} else {
 				ml = Ref<TileSet>( memnew( TileSet ));
 			}
 


### PR DESCRIPTION
Regression from #3280

This error (`Can't load TileSet for merging!`) should only appear if the resource could not be loaded, not if it (the file) doesn't exist.
