### PR TITLE
Add stop and delete buttons to sample library (supersedes #3339)

### DIFF
--- a/tools/editor/plugins/sample_library_editor_plugin.cpp
+++ b/tools/editor/plugins/sample_library_editor_plugin.cpp
@@ -52,14 +52,8 @@ void SampleLibraryEditor::_notification(int p_what) {
 	}
 
 	if (p_what==NOTIFICATION_ENTER_TREE) {
-		play->set_icon( get_icon("Play","EditorIcons") );
-		play->set_tooltip("Play Sample");
-		stop->set_icon( get_icon("Stop","EditorIcons") );
-		stop->set_tooltip("Stop Sample");
 		load->set_icon( get_icon("Folder","EditorIcons") );
 		load->set_tooltip("Open Sample File(s)");
-		_delete->set_icon( get_icon("Del","EditorIcons") );
-		_delete->set_tooltip("Remove Sample");
 	}
 
 	if (p_what==NOTIFICATION_READY) {
@@ -70,23 +64,6 @@ void SampleLibraryEditor::_notification(int p_what) {
 	if (p_what==NOTIFICATION_DRAW) {
 
 	}
-}
-
-void SampleLibraryEditor::_play_pressed() {
-
-	if (!tree->get_selected())
-		return;
-
-	String to_play = tree->get_selected()->get_text(0);
-
-	player->play(to_play,true);
-	play->set_pressed(false);
-	stop->set_pressed(false);
-}
-void SampleLibraryEditor::_stop_pressed() {
-
-	player->stop_all();
-	play->set_pressed(false);
 }
 
 void SampleLibraryEditor::_file_load_request(const DVector<String>& p_path) {
@@ -142,7 +119,7 @@ void SampleLibraryEditor::_button_pressed(Object *p_item,int p_column, int p_id)
 			last_sample_playing = p_item;
 			set_process(true);
 		} else {
-			_stop_pressed();
+			player->stop_all();
 			if(last_sample_playing != p_item){
 				TreeItem *tl=last_sample_playing->cast_to<TreeItem>();
 				tl->set_button(p_column,0,get_icon("Play","EditorIcons"));
@@ -216,7 +193,7 @@ void SampleLibraryEditor::_item_edited() {
 
 }
 
-void SampleLibraryEditor::_delete_confirm_pressed() {
+void SampleLibraryEditor::_delete_pressed() {
 
 	if (!tree->get_selected())
 		return;
@@ -228,24 +205,6 @@ void SampleLibraryEditor::_delete_confirm_pressed() {
 	undo_redo->add_do_method(this,"_update_library");
 	undo_redo->add_undo_method(this,"_update_library");
 	undo_redo->commit_action();
-}
-
-
-void SampleLibraryEditor::_delete_pressed() {
-
-
-	if (!tree->get_selected())
-		return;
-
-	_delete_confirm_pressed(); //it has undo.. why bother with a dialog..
-	/*
-	dialog->set_title("Confirm...");
-	dialog->set_text("Remove Sample '"+tree->get_selected()->get_text(0)+"' ?");
-	//dialog->get_cancel()->set_text("Cancel");
-	//dialog->get_ok()->show();
-	dialog->get_ok()->set_text("Remove");
-	dialog->popup_centered(Size2(300,60));*/
-
 }
 
 
@@ -336,12 +295,9 @@ void SampleLibraryEditor::edit(Ref<SampleLibrary> p_sample_library) {
 void SampleLibraryEditor::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("_input_event"),&SampleLibraryEditor::_input_event);
-	ObjectTypeDB::bind_method(_MD("_play_pressed"),&SampleLibraryEditor::_play_pressed);
-	ObjectTypeDB::bind_method(_MD("_stop_pressed"),&SampleLibraryEditor::_stop_pressed);
 	ObjectTypeDB::bind_method(_MD("_load_pressed"),&SampleLibraryEditor::_load_pressed);
 	ObjectTypeDB::bind_method(_MD("_item_edited"),&SampleLibraryEditor::_item_edited);
 	ObjectTypeDB::bind_method(_MD("_delete_pressed"),&SampleLibraryEditor::_delete_pressed);
-	ObjectTypeDB::bind_method(_MD("_delete_confirm_pressed"),&SampleLibraryEditor::_delete_confirm_pressed);
 	ObjectTypeDB::bind_method(_MD("_file_load_request"),&SampleLibraryEditor::_file_load_request);
 	ObjectTypeDB::bind_method(_MD("_update_library"),&SampleLibraryEditor::_update_library);
 	ObjectTypeDB::bind_method(_MD("_button_pressed"),&SampleLibraryEditor::_button_pressed);
@@ -354,28 +310,10 @@ SampleLibraryEditor::SampleLibraryEditor() {
 	add_style_override("panel", get_stylebox("panel","Panel"));
 
 
-	play = memnew( Button );
-
-	play->set_pos(Point2( 5, 5 ));
-	play->set_size( Size2(1,1 ) );
-	play->set_toggle_mode(true);
-	add_child(play);
-	play->hide();
-
-	stop = memnew( Button );
-
-	stop->set_pos(Point2( 5, 5 ));
-	stop->set_size( Size2(1,1 ) );
-	//stop->set_toggle_mode(true);
-	add_child(stop);
-
 	load = memnew( Button );
-
-	load->set_pos(Point2( 35, 5 ));
+	load->set_pos(Point2( 5, 5 ));
 	load->set_size( Size2(1,1 ) );
 	add_child(load);
-
-	_delete = memnew( Button );
 
 	file = memnew( EditorFileDialog );
 	add_child(file);
@@ -384,10 +322,6 @@ SampleLibraryEditor::SampleLibraryEditor() {
 	for(int i=0;i<extensions.size();i++)
 		file->add_filter("*."+extensions[i]);
 	file->set_mode(EditorFileDialog::MODE_OPEN_FILES);
-
-	_delete->set_pos(Point2( 65, 5 ));
-	_delete->set_size( Size2(1,1 ) );
-	add_child(_delete);
 
 	tree = memnew( Tree );
 	tree->set_columns(6);
@@ -419,12 +353,8 @@ SampleLibraryEditor::SampleLibraryEditor() {
 	add_child( dialog );
 
 	tree->connect("button_pressed",this,"_button_pressed");
-	play->connect("pressed", this,"_play_pressed");
-	stop->connect("pressed", this,"_stop_pressed");
 	load->connect("pressed", this,"_load_pressed");
-	_delete->connect("pressed", this,"_delete_pressed");
 	file->connect("files_selected", this,"_file_load_request");
-	//dialog->connect("confirmed", this,"_delete_confirm_pressed");
 	tree->connect("item_edited", this,"_item_edited");
 
 

--- a/tools/editor/plugins/sample_library_editor_plugin.cpp
+++ b/tools/editor/plugins/sample_library_editor_plugin.cpp
@@ -35,7 +35,6 @@
 #include "sample_editor_plugin.h"
 
 
-
 void SampleLibraryEditor::_input_event(InputEvent p_event) {
 
 
@@ -43,8 +42,13 @@ void SampleLibraryEditor::_input_event(InputEvent p_event) {
 
 void SampleLibraryEditor::_notification(int p_what) {
 
-	if (p_what==NOTIFICATION_FIXED_PROCESS) {
-
+	if (p_what==NOTIFICATION_PROCESS) {
+		if (is_playing && !player->is_active()) {
+			TreeItem *tl=last_sample_playing->cast_to<TreeItem>();
+			tl->set_button(0,0,get_icon("Play","EditorIcons"));
+			is_playing = false;
+			set_process(false);
+		}
 	}
 
 	if (p_what==NOTIFICATION_ENTER_TREE) {
@@ -128,13 +132,36 @@ void SampleLibraryEditor::_button_pressed(Object *p_item,int p_column, int p_id)
 	TreeItem *ti=p_item->cast_to<TreeItem>();
 	String name = ti->get_text(0);
 
-	if (p_column==0) {
+	if (p_column==0) { // Play/Stop
 
-		player->play(name,true);
-	} else if (p_column==1) {
+		String btn_type;
+		if(!is_playing) {
+			is_playing = true;
+			btn_type = "Stop";
+			player->play(name,true);
+			last_sample_playing = p_item;
+			set_process(true);
+		} else {
+			_stop_pressed();
+			if(last_sample_playing != p_item){
+				TreeItem *tl=last_sample_playing->cast_to<TreeItem>();
+				tl->set_button(p_column,0,get_icon("Play","EditorIcons"));
+				btn_type = "Stop";
+				player->play(name,true);
+				last_sample_playing = p_item;
+			} else {
+				btn_type = "Play";
+				is_playing = false;
+			}
+		}
+		ti->set_button(p_column,0,get_icon(btn_type,"EditorIcons"));
+	} else if (p_column==1) { // Edit
 
 		get_tree()->get_root()->get_child(0)->call("_resource_selected",sample_library->get_sample(name));
+	} else if (p_column==5) { // Delete
 
+		ti->select(0);
+		_delete_pressed();
 	}
 
 
@@ -151,7 +178,7 @@ void SampleLibraryEditor::_item_edited() {
 
 	TreeItem *s = tree->get_selected();
 
-	if (tree->get_selected_column()==0) {
+	if (tree->get_selected_column()==0) { // Name
 		// renamed
 		String old_name=s->get_metadata(0);
 		String new_name=s->get_text(0);
@@ -174,23 +201,16 @@ void SampleLibraryEditor::_item_edited() {
 		undo_redo->add_undo_method(this,"_update_library");
 		undo_redo->commit_action();
 
-	} else if (tree->get_selected_column()==3) {
+	} else if (tree->get_selected_column()==3) { // Volume dB
 
 		StringName n = s->get_text(0);
 		sample_library->sample_set_volume_db(n,s->get_range(3));
 
-	} else if (tree->get_selected_column()==4) {
+	} else if (tree->get_selected_column()==4) { // Pitch scale
 
 		StringName n = s->get_text(0);
 		sample_library->sample_set_pitch_scale(n,s->get_range(4));
 
-	} else if (tree->get_selected_column()==5) {
-
-		//edit
-
-		Ref<Sample> samp = sample_library->get_sample(tree->get_selected()->get_metadata(0));
-
-		get_tree()->get_root()->get_child(0)->call("_resource_selected",samp);
 	}
 
 
@@ -244,16 +264,18 @@ void SampleLibraryEditor::_update_library() {
 	for(List<StringName>::Element *E=names.front();E;E=E->next()) {
 
 		TreeItem *ti = tree->create_item(root);
+
+		// Name + Play/Stop
 		ti->set_cell_mode(0,TreeItem::CELL_MODE_STRING);
 		ti->set_editable(0,true);
 		ti->set_selectable(0,true);
 		ti->set_text(0,E->get());
 		ti->set_metadata(0,E->get());
-		ti->add_button(0,get_icon("Play","EditorIcons"),0);
-		ti->add_button(1,get_icon("Edit","EditorIcons"),1);
+		ti->add_button(0,get_icon("Play","EditorIcons"));
 
 		Ref<Sample> smp = sample_library->get_sample(E->get());
 
+		// Preview/edit
 		Ref<ImageTexture> preview( memnew( ImageTexture ));
 		preview->create(128,16,Image::FORMAT_RGB);
 		SampleEditor::generate_preview_texture(smp,preview);
@@ -261,30 +283,32 @@ void SampleLibraryEditor::_update_library() {
 		ti->set_selectable(1,false);
 		ti->set_editable(1,false);
 		ti->set_icon(1,preview);
+		ti->add_button(1,get_icon("Edit","EditorIcons"));
 
-
+		// Format
 		ti->set_cell_mode(2,TreeItem::CELL_MODE_STRING);
 		ti->set_editable(2,false);
 		ti->set_selectable(2,false);
-		Ref<Sample> s = sample_library->get_sample(E->get());
-		ti->set_text(2,String()+/*itos(s->get_length())+" frames ("+String::num(s->get_length()/(float)s->get_mix_rate(),2)+" s), "+*/(s->get_format()==Sample::FORMAT_PCM16?"16 Bits, ":(s->get_format()==Sample::FORMAT_PCM8?"8 bits, ":"IMA-ADPCM,"))+(s->is_stereo()?"Stereo":"Mono"));
+		ti->set_text(2,String()+/*itos(smp->get_length())+" frames ("+String::num(smp->get_length()/(float)smp->get_mix_rate(),2)+" smp), "+*/(smp->get_format()==Sample::FORMAT_PCM16?"16 Bits, ":(smp->get_format()==Sample::FORMAT_PCM8?"8 bits, ":"IMA-ADPCM,"))+(smp->is_stereo()?"Stereo":"Mono"));
 
+		// Volume dB
 		ti->set_cell_mode(3,TreeItem::CELL_MODE_RANGE);
 		ti->set_range_config(3,-60,24,0.01);
 		ti->set_selectable(3,true);
 		ti->set_editable(3,true);
 		ti->set_range(3,sample_library->sample_get_volume_db(E->get()));
 
+		// Pitch scale
 		ti->set_cell_mode(4,TreeItem::CELL_MODE_RANGE);
 		ti->set_range_config(4,0.01,100,0.01);
 		ti->set_selectable(4,true);
 		ti->set_editable(4,true);
 		ti->set_range(4,sample_library->sample_get_pitch_scale(E->get()));
 
-		//ti->set_cell_mode(5,TreeItem::CELL_MODE_CUSTOM);
-		//ti->set_text(5,"Edit..");
-		//ti->set_selectable(5,true);
-		//ti->set_editable(5,true);
+		// Delete
+		ti->set_cell_mode(5,TreeItem::CELL_MODE_STRING);
+		ti->add_button(5,get_icon("Remove","EditorIcons"));
+
 	}
 
 	//player->add_sample("default",sample);
@@ -303,7 +327,6 @@ void SampleLibraryEditor::edit(Ref<SampleLibrary> p_sample_library) {
 	} else {
 
 		hide();
-		set_fixed_process(false);
 	}
 
 }
@@ -367,7 +390,7 @@ SampleLibraryEditor::SampleLibraryEditor() {
 	add_child(_delete);
 
 	tree = memnew( Tree );
-	tree->set_columns(5);
+	tree->set_columns(6);
 	add_child(tree);
 	tree->set_anchor_and_margin(MARGIN_LEFT,ANCHOR_BEGIN,5);
 	tree->set_anchor_and_margin(MARGIN_RIGHT,ANCHOR_END,5);
@@ -375,19 +398,22 @@ SampleLibraryEditor::SampleLibraryEditor() {
 	tree->set_anchor_and_margin(MARGIN_BOTTOM,ANCHOR_END,5);
 	tree->set_column_titles_visible(true);
 	tree->set_column_title(0,"Name");
-
 	tree->set_column_title(1,"Preview");
 	tree->set_column_title(2,"Format");
 	tree->set_column_title(3,"dB");
-	tree->set_column_title(4,"PScale");
+	tree->set_column_title(4,"Pitch");
+	tree->set_column_title(5,"");
+
 	tree->set_column_min_width(1,150);
 	tree->set_column_min_width(2,100);
 	tree->set_column_min_width(3,50);
 	tree->set_column_min_width(4,50);
+	tree->set_column_min_width(5,32);
 	tree->set_column_expand(1,false);
 	tree->set_column_expand(2,false);
 	tree->set_column_expand(3,false);
 	tree->set_column_expand(4,false);
+	tree->set_column_expand(5,false);
 
 	dialog = memnew( ConfirmationDialog );
 	add_child( dialog );
@@ -461,5 +487,3 @@ SampleLibraryEditorPlugin::SampleLibraryEditorPlugin(EditorNode *p_node) {
 SampleLibraryEditorPlugin::~SampleLibraryEditorPlugin()
 {
 }
-
-

--- a/tools/editor/plugins/sample_library_editor_plugin.h
+++ b/tools/editor/plugins/sample_library_editor_plugin.h
@@ -48,10 +48,7 @@ class SampleLibraryEditor : public Panel {
 
 	SamplePlayer *player;
 	Ref<SampleLibrary> sample_library;
-	Button *stop;
-	Button *play;
 	Button *load;
-	Button *_delete;
 	Tree *tree;
 	bool is_playing;
 	Object *last_sample_playing;
@@ -61,12 +58,9 @@ class SampleLibraryEditor : public Panel {
 	ConfirmationDialog *dialog;
 
 
-	void _play_pressed();
-	void _stop_pressed();
 	void _load_pressed();
 	void _file_load_request(const DVector<String>& p_path);
 	void _delete_pressed();
-	void _delete_confirm_pressed();
 	void _update_library();
 	void _item_edited();
 

--- a/tools/editor/plugins/sample_library_editor_plugin.h
+++ b/tools/editor/plugins/sample_library_editor_plugin.h
@@ -53,6 +53,8 @@ class SampleLibraryEditor : public Panel {
 	Button *load;
 	Button *_delete;
 	Tree *tree;
+	bool is_playing;
+	Object *last_sample_playing;
 
 	EditorFileDialog *file;
 
@@ -79,7 +81,6 @@ protected:
 public:
 
 	void set_undo_redo(UndoRedo *p_undo_redo) {undo_redo=p_undo_redo; }
-
 	void edit(Ref<SampleLibrary> p_sample);
 	SampleLibraryEditor();
 };


### PR DESCRIPTION
Based on the work by @rdcklinux in #3339.
The play button becomes a stop button while playing (and goes back to "play" after the sample has finished playing), a delete button is added in the last column.

I removed the global buttons that thus became irrelevant, so in the end it looks like that:
![spectacle z13273](https://cloud.githubusercontent.com/assets/4701338/13729223/6b710c7a-e930-11e5-98e9-31de8483991e.png)

Before the PR, the SampleLibrary looks like that:
![spectacle a10895](https://cloud.githubusercontent.com/assets/4701338/13729109/3e789858-e92d-11e5-9d37-24f68788b2e3.png)

A further improvement would be to find a better place for the "Load Sample" icon, which is now alone on its line.
