### PR TITLE
Undo and Redo Text Editor Fix

### DIFF
--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -156,6 +156,7 @@ class TextEdit : public Control  {
 		int from_line,from_column;
 		int to_line, to_column;
 		String text;
+		uint32_t prev_version;
 		uint32_t version;
 		bool chain_forward;
 		bool chain_backward;


### PR DESCRIPTION
The undo and redo commands on the text editor now affect the internal version appropriately, which is needed in the script editor when determining which files have been modified for saving.
