### PR TITLE
Live Script Reloading

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -950,7 +950,7 @@ void Object::set_script(const RefPtr& p_script) {
 	script=p_script;
 	Ref<Script> s(script);
 
-	if (!s.is_null() && s->can_instance() ) {
+	if (!s.is_null()) {
 		OBJ_DEBUG_LOCK
 		script_instance = s->instance_create(this);
 
@@ -959,6 +959,22 @@ void Object::set_script(const RefPtr& p_script) {
 	_change_notify("script/script");
 	emit_signal(CoreStringNames::get_singleton()->script_changed);
 
+}
+
+void Object::refresh_script_instance() {
+
+	if (script_instance) {
+		memdelete(script_instance);
+		script_instance = NULL;
+	}
+
+	Ref<Script> s(script);
+
+	if (!script.is_null()) {
+		OBJ_DEBUG_LOCK
+			script_instance = s->instance_create(this);
+
+	}
 }
 
 void Object::set_script_instance(ScriptInstance *p_instance) {

--- a/core/object.h
+++ b/core/object.h
@@ -579,6 +579,8 @@ public:
 	void set_script(const RefPtr& p_script);
 	RefPtr get_script() const;
 
+	void refresh_script_instance();
+
 	/* SCRIPT */
 
 	bool has_meta(const String& p_name) const;

--- a/core/script_debugger_remote.cpp
+++ b/core/script_debugger_remote.cpp
@@ -996,8 +996,17 @@ void ScriptDebuggerRemote::live_script_reload(const Array &p_script_name_array, 
 		String source_code = script_source_code_array[0];
 		Ref<Script> script = ResourceLoader::load(path);
 		if (script.is_valid()) {
-			script->set_source_code(source_code);
-			script->reload();
+
+			if (path.find("local://") == -1 && path.find("::")) {
+				if (script->is_used()) {
+					script->set_source_code(source_code);
+					script->reload();
+				}
+			}
+			else {
+				script->set_source_code(source_code);
+				script->reload();
+			}
 		}
 		script_name_array.pop_back();
 		script_source_code_array.pop_back();

--- a/core/script_debugger_remote.cpp
+++ b/core/script_debugger_remote.cpp
@@ -31,6 +31,8 @@
 #include "io/ip.h"
 #include "globals.h"
 #include "os/input.h"
+#include "io/resource_loader.h"
+
 void ScriptDebuggerRemote::_send_video_memory() {
 
 	List<ResourceUsage> usage;
@@ -539,8 +541,11 @@ bool ScriptDebuggerRemote::_parse_live_edit(const Array& cmd) {
 
 		live_edit_funcs->tree_reparent_node_func(live_edit_funcs->udata,cmd[1],cmd[2],cmd[3],cmd[4]);
 
-	} else {
-
+	}
+	else if (cmdstr == "live_script_reload") {
+		live_script_reload(cmd[1], cmd[2]);
+	}
+	else {
 		return false;
 	}
 
@@ -979,6 +984,25 @@ void ScriptDebuggerRemote::profiling_set_frame_times(float p_frame_time, float p
 }
 
 
+void ScriptDebuggerRemote::live_script_reload(const Array &p_script_name_array, const Array &p_script_source_code_array) {
+	// Messy, could use better reload hooks
+	Array script_name_array = p_script_name_array;
+	Array script_source_code_array = p_script_source_code_array;
+
+	ERR_FAIL_COND(script_name_array.size()!=script_source_code_array.size());
+
+	while (script_name_array.size() > 0) {
+		String path = script_name_array[0];
+		String source_code = script_source_code_array[0];
+		Ref<Script> script = ResourceLoader::load(path);
+		if (script.is_valid()) {
+			script->set_source_code(source_code);
+			script->reload();
+		}
+		script_name_array.pop_back();
+		script_source_code_array.pop_back();
+	}
+}
 ScriptDebuggerRemote::ResourceUsageFunc ScriptDebuggerRemote::resource_usage_func=NULL;
 
 ScriptDebuggerRemote::ScriptDebuggerRemote() {

--- a/core/script_debugger_remote.h
+++ b/core/script_debugger_remote.h
@@ -168,6 +168,7 @@ public:
 	virtual void profiling_end();
 	virtual void profiling_set_frame_times(float p_frame_time,float p_idle_time,float p_fixed_time,float p_fixed_frame_time);
 
+	virtual void live_script_reload(const Array &p_script_name_array, const Array &p_script_source_code_array);
 	ScriptDebuggerRemote();
 	~ScriptDebuggerRemote();
 };

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -106,6 +106,7 @@ public:
 
 	virtual Ref<Script> get_base() const=0;
 	virtual const Set<Ref<Script> > get_inherited_scripts() const=0;
+	virtual const bool is_used() const=0;
 
 	Script() {}
 };

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -100,8 +100,12 @@ public:
 
 	virtual bool get_property_default_value(const StringName& p_property,Variant& r_value) const=0;
 
+	virtual Error load_source_code(const String& p_path)=0;
+
 	virtual void update_exports() {} //editor tool
 
+	virtual Ref<Script> get_base() const=0;
+	virtual const Set<Ref<Script> > get_inherited_scripts() const=0;
 
 	Script() {}
 };

--- a/modules/gdscript/gd_editor.cpp
+++ b/modules/gdscript/gd_editor.cpp
@@ -1565,7 +1565,7 @@ static void _find_type_arguments(const GDParser::Node*p_node,int p_line,const St
 							}
 
 							if (scr->get_base().is_valid())
-								scr=scr->get_base().ptr();
+								scr=static_cast<GDScript *>(scr->get_base().ptr());
 							else
 								scr=NULL;
 						}
@@ -1715,7 +1715,7 @@ static void _find_type_arguments(const GDParser::Node*p_node,int p_line,const St
 						}
 
 						if (scr->get_base().is_valid())
-							scr=scr->get_base().ptr();
+							scr=static_cast<GDScript *>(scr->get_base().ptr());
 						else
 							scr=NULL;
 					}
@@ -2184,7 +2184,7 @@ Error GDScriptLanguage::complete_code(const String& p_code, const String& p_base
 									}
 
 									if (scr->get_base().is_valid())
-										scr=scr->get_base().ptr();
+										scr=static_cast<GDScript *>(scr->get_base().ptr());
 									else
 										scr=NULL;
 								}
@@ -2280,7 +2280,7 @@ Error GDScriptLanguage::complete_code(const String& p_code, const String& p_base
 								}
 
 								if (scr->get_base().is_valid())
-									scr=scr->get_base().ptr();
+									scr=static_cast<GDScript *>(scr->get_base().ptr());
 								else
 									scr=NULL;
 							}

--- a/modules/gdscript/gd_script.cpp
+++ b/modules/gdscript/gd_script.cpp
@@ -2367,6 +2367,18 @@ void GDScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
 
 }
 
+const bool GDScript::is_used() const {
+#ifdef TOOLS_ENABLED
+	if (placeholders.size() > 0 || instances.size() > 0 || inheriters_cache.size() > 0) {
+#else
+	if (instances.size() > 0) {
+#endif
+		return true;
+	}
+	else {
+		return false;
+	}
+}
 
 GDScript::GDScript() {
 

--- a/modules/gdscript/gd_script.h
+++ b/modules/gdscript/gd_script.h
@@ -350,6 +350,7 @@ public:
 	virtual bool has_script_signal(const StringName& p_signal) const;
 	virtual void get_script_signal_list(List<MethodInfo> *r_signals) const;
 
+	virtual const bool is_used() const;
 
 	bool is_tool() const { return tool; }
 	virtual Ref<Script> get_base() const;

--- a/modules/gdscript/gd_script.h
+++ b/modules/gdscript/gd_script.h
@@ -310,6 +310,9 @@ friend class GDScriptLanguage;
 
 
 	GDInstance* _create_instance(const Variant** p_args,int p_argcount,Object *p_owner,bool p_isref,Variant::CallError &r_error);
+	virtual void _update_instances(Map<StringName, MemberInfo> &p_original_member_indices);
+	virtual void _convert_placeholders_to_instances();
+	virtual void _convert_instances_to_placeholders();
 
 	void _set_subclass_path(Ref<GDScript>& p_sc,const String& p_path);
 
@@ -342,12 +345,14 @@ public:
 	const Map<StringName,GDFunction*>& get_member_functions() const { return member_functions; }
 	const Ref<GDNativeClass>& get_native() const { return native; }
 
+	virtual const Set<Ref<Script> > get_inherited_scripts() const;
+
 	virtual bool has_script_signal(const StringName& p_signal) const;
 	virtual void get_script_signal_list(List<MethodInfo> *r_signals) const;
 
 
 	bool is_tool() const { return tool; }
-	Ref<GDScript> get_base() const;
+	virtual Ref<Script> get_base() const;
 
 	const Map<StringName,MemberInfo>& debug_get_member_indices() const { return member_indices; }
 	const Map<StringName,GDFunction*>& debug_get_member_functions() const; //this is debug only
@@ -369,8 +374,8 @@ public:
 
 	virtual String get_node_type() const;
 	void set_script_path(const String& p_path) { path=p_path; } //because subclasses need a path too...
-	Error load_source_code(const String& p_path);
-	Error load_byte_code(const String& p_path);
+	virtual Error load_source_code(const String& p_path);
+	virtual Error load_byte_code(const String& p_path);
 
 	Vector<uint8_t> get_as_byte_code() const;
 

--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -513,6 +513,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("resources/save_compressed_resources",true);
 	set("resources/auto_reload_modified_images",true);
 
+	// Since this feature is still somewhat experimental, recommend keeping it off by default until it's been more intensively tested.
+	set("text_editor/dynamic_script_reloading_enabled", false);
+
 	if (p_extra_config.is_valid()) {
 
 		if (p_extra_config->has_section("init_projects") && p_extra_config->has_section_key("init_projects", "list")) {

--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -817,6 +817,7 @@ void ScriptEditor::_resave_scripts(const String& p_str) {
 
 }
 
+// Very messy, needs better reload hooks
 void ScriptEditor::_reload_scripts(){
 
 
@@ -837,16 +838,34 @@ void ScriptEditor::_reload_scripts(){
 			continue; //internal script, who cares
 		}
 
+		String script_path;
+		script_path = script->get_path();
+		script->set_path("");
 
-		Ref<Script> rel_script = ResourceLoader::load(script->get_path(),script->get_type(),true);
-		ERR_CONTINUE(!rel_script.is_valid());
-		script->set_source_code( rel_script->get_source_code() );
-		script->set_last_modified_time( rel_script->get_last_modified_time() );
-		script->reload();
-		ste->reload_text();
+		Ref<Script> rel_script = ResourceLoader::load(script_path,script->get_type(),true);
 
+		if (!rel_script.is_valid()) {
+			if(!rel_script.is_null()) {
+				rel_script->set_path("");
+			}
+			script->set_path(script_path);
+			ERR_CONTINUE(!rel_script.is_valid());
+		}
+
+		// Valid, reload this
+		if (script->get_last_modified_time() != rel_script->get_last_modified_time()) {
+			script->set_source_code(rel_script->get_source_code());
+			script->set_last_modified_time(rel_script->get_last_modified_time());
+			add_script_to_dirty_list(script);
+			ste->reload_text();
+		}
+
+		rel_script->set_path("");
+		script->set_path(script_path);
 
 	}
+
+	reload_script_dirty_list();
 
 	disk_changed->hide();
 	_update_script_names();
@@ -857,9 +876,10 @@ void ScriptEditor::_reload_scripts(){
 
 void ScriptEditor::_res_saved_callback(const Ref<Resource>& p_res) {
 
+	const Ref<Script>& script_res = p_res;
+	ERR_FAIL_COND(script_res.is_null());
 
-
-	for(int i=0;i<tab_container->get_child_count();i++) {
+	for (int i = 0; i < tab_container->get_child_count(); i++) {
 
 		ScriptTextEditor *ste = tab_container->get_child(i)->cast_to<ScriptTextEditor>();
 		if (!ste) {
@@ -870,19 +890,20 @@ void ScriptEditor::_res_saved_callback(const Ref<Resource>& p_res) {
 
 		Ref<Script> script = ste->get_edited_script();
 
-		if (script->get_path()=="" || script->get_path().find("local://")!=-1 || script->get_path().find("::")!=-1) {
+		if (script->get_path() == "" || script->get_path().find("local://") != -1 || script->get_path().find("::") != -1) {
 			continue; //internal script, who cares
 		}
 
-		if (script==p_res) {
+		if (script == p_res) {
 
 			ste->get_text_edit()->tag_saved_version();
 		}
 
 	}
 
-	_update_script_names();
+	add_script_to_dirty_list(p_res);
 
+	_update_script_names();
 }
 
 bool ScriptEditor::_test_script_times_on_disk() {
@@ -966,7 +987,7 @@ void ScriptEditor::_menu_option(int p_option) {
 		} break;
 		case FILE_SAVE_ALL: {
 
-			if (!_test_script_times_on_disk())
+			if (_test_script_times_on_disk())
 				return;
 
 			save_all_scripts();
@@ -1063,6 +1084,7 @@ void ScriptEditor::_menu_option(int p_option) {
 					_trim_trailing_whitespace(current->get_text_edit());
 				}
 				editor->save_resource( current->get_edited_script() );
+				reload_script_dirty_list();
 
 			} break;
 			case FILE_SAVE_AS: {
@@ -1071,6 +1093,7 @@ void ScriptEditor::_menu_option(int p_option) {
 					_trim_trailing_whitespace(current->get_text_edit());
 				}
 				editor->save_resource_as( current->get_edited_script() );
+				reload_script_dirty_list();
 
 			} break;
 			case EDIT_UNDO: {
@@ -1479,6 +1502,66 @@ void ScriptEditor::_menu_option(int p_option) {
 	}
 
 
+}
+
+void ScriptEditor::add_script_to_dirty_list(Ref<Script> p_script) {	
+	Ref<Script> base_gdscript = p_script->get_base();
+	if (base_gdscript.is_valid()) {
+		add_script_base_to_dirty_list(base_gdscript);
+	}
+
+	if (script_dirty_list.find(p_script) == -1) {
+		script_dirty_list.push_back(p_script);
+	}
+
+	Set<Ref<Script> > inherited_scripts = p_script->get_inherited_scripts();
+	for (Set<Ref<Script> >::Element *E = inherited_scripts.front(); E; E = E->next()) {
+		add_script_inheritors_to_dirty_list(E->get());
+	}
+}
+
+void ScriptEditor::add_script_base_to_dirty_list(Ref<Script> p_script) {
+	Ref<Script> base_gdscript = p_script->get_base();
+	if (base_gdscript.is_valid()) {
+		add_script_base_to_dirty_list(base_gdscript);
+	}
+
+	if (script_dirty_list.find(p_script) == -1) {
+		script_dirty_list.push_back(p_script);
+	}
+}
+
+void ScriptEditor::add_script_inheritors_to_dirty_list(Ref<Script> p_script) {
+	if (script_dirty_list.find(p_script) == -1) {
+		script_dirty_list.push_back(p_script);
+	}
+
+	Set<Ref<Script> > inherited_scripts = p_script->get_inherited_scripts();
+	for (Set<Ref<Script> >::Element *E = inherited_scripts.front(); E; E = E->next()) {
+		add_script_inheritors_to_dirty_list(E->get());
+	}
+}
+
+void ScriptEditor::reload_script_dirty_list() {
+	if (EditorSettings::get_singleton()->get("text_editor/dynamic_script_reloading_enabled")) {
+		if (script_dirty_list.size() > 0) {
+			Array script_res_names;
+			Array script_new_source;
+
+			while (script_dirty_list.size() > 0)
+			{
+				script_dirty_list[0]->reload();
+
+				String path = script_dirty_list[0]->get_path();
+				script_res_names.push_back(path);
+				script_new_source.push_back(script_dirty_list[0]->get_source_code());
+
+				script_dirty_list.remove(0);
+			}
+
+			debugger->live_debug_script_reload(script_res_names, script_new_source);
+		}
+	}
 }
 
 void ScriptEditor::_tab_changed(int p_which) {
@@ -2028,7 +2111,7 @@ void ScriptEditor::save_all_scripts() {
 			//ResourceSaver::save(script->get_path(),script);
 		}
 	}
-
+	reload_script_dirty_list();
 }
 
 void ScriptEditor::apply_scripts() const {

--- a/tools/editor/plugins/script_editor_plugin.h
+++ b/tools/editor/plugins/script_editor_plugin.h
@@ -192,6 +192,7 @@ class ScriptEditor : public VBoxContainer {
 	ToolButton *script_back;
 	ToolButton *script_forward;
 
+	Ref<Script> pending_dirty_script;
 
 	struct ScriptHistory {
 
@@ -206,6 +207,14 @@ class ScriptEditor : public VBoxContainer {
 
 
 	EditorHelpIndex *help_index;
+
+	Vector<Ref<Script> > script_dirty_list;
+
+	void add_script_to_dirty_list(Ref<Script> p_script);
+	void add_script_base_to_dirty_list(Ref<Script> p_script);
+	void add_script_inheritors_to_dirty_list(Ref<Script> p_script);
+
+	void reload_script_dirty_list();
 
 	void _tab_changed(int p_which);
 	void _menu_option(int p_optin);

--- a/tools/editor/plugins/script_editor_plugin.h
+++ b/tools/editor/plugins/script_editor_plugin.h
@@ -206,11 +206,30 @@ class ScriptEditor : public VBoxContainer {
 	int history_pos;
 
 
+	//
+	enum {
+		RESOURCE_LOAD,
+		RESOURCE_SAVE
+	};
+
+	Ref<Resource> pending_save_script;
+	bool reload_dirty_list_after_save;
+
+	EditorFileDialog *file;
+	AcceptDialog *accept;
+	int current_option;
+
+	void _dialog_action(String p_file);
+
+	virtual void _script_save_in_path(const Ref<Resource>& p_resource, const String& p_path);
+	virtual void _script_save(const Ref<Resource>& p_resource);
+	virtual void _script_save_as(const Ref<Resource>& p_resource);
+
 	EditorHelpIndex *help_index;
 
 	Vector<Ref<Script> > script_dirty_list;
 
-	void add_script_to_dirty_list(Ref<Script> p_script);
+	void add_script_to_dirty_list(Ref<Script> p_script, const bool allow_duplicates);
 	void add_script_base_to_dirty_list(Ref<Script> p_script);
 	void add_script_inheritors_to_dirty_list(Ref<Script> p_script);
 

--- a/tools/editor/script_editor_debugger.cpp
+++ b/tools/editor/script_editor_debugger.cpp
@@ -1559,6 +1559,19 @@ void ScriptEditorDebugger::live_debug_reparent_node(const NodePath& p_at, const 
 
 }
 
+void ScriptEditorDebugger::live_debug_script_reload(const Array& p_script_reload_chain, const Array& p_script_new_code){
+
+	if (live_debug && connection.is_valid()) {
+		Array msg;
+		ERR_FAIL_COND(p_script_reload_chain.size() != p_script_new_code.size())
+		msg.push_back("live_script_reload");
+		msg.push_back(p_script_reload_chain);
+		msg.push_back(p_script_new_code);
+		ppeer->put_var(msg);
+	}
+
+}
+
 void ScriptEditorDebugger::set_breakpoint(const String& p_path,int p_line,bool p_enabled) {
 
 	if (connection.is_valid()) {
@@ -1659,6 +1672,8 @@ void ScriptEditorDebugger::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("live_debug_reparent_node"),&ScriptEditorDebugger::live_debug_reparent_node);
 	ObjectTypeDB::bind_method(_MD("_scene_tree_property_select_object"),&ScriptEditorDebugger::_scene_tree_property_select_object);
 	ObjectTypeDB::bind_method(_MD("_scene_tree_property_value_edited"),&ScriptEditorDebugger::_scene_tree_property_value_edited);
+
+	ObjectTypeDB::bind_method(_MD("live_debug_script_reload"), &ScriptEditorDebugger::live_debug_script_reload);
 
 	ADD_SIGNAL(MethodInfo("goto_script_line"));
 	ADD_SIGNAL(MethodInfo("breaked",PropertyInfo(Variant::BOOL,"reallydid"),PropertyInfo(Variant::BOOL,"can_debug")));

--- a/tools/editor/script_editor_debugger.h
+++ b/tools/editor/script_editor_debugger.h
@@ -208,6 +208,7 @@ public:
 	void live_debug_restore_node(ObjectID p_id,const NodePath& p_at,int p_at_pos);
 	void live_debug_duplicate_node(const NodePath& p_at,const String& p_new_name);
 	void live_debug_reparent_node(const NodePath& p_at,const NodePath& p_new_place,const String& p_new_name,int p_at_pos);
+	void live_debug_script_reload(const Array& p_script_reload_chain, const Array& p_script_new_code);
 
 	void set_breakpoint(const String& p_path,int p_line,bool p_enabled);
 


### PR DESCRIPTION
Okay, this is something I'm hoping will be exciting for some people. Scripts can now reload themselves automatically when saved, whether for in-editor tool scripts or ingame via the live edit protocol.

I should explain a little bit about how it works internally why I made certains decision on this experimental implementation. Firstly, regarding tool scripts, the way the editor currently handles non-tool scripts is that when they are instanced, if the script server is turned off which it is when in editor mode, the object using a particular script is simply given a null instance of that script, so that even if it is registered to run as a process prior, it won't do anything. Since in my implementation I want to allow non-tool scripts to change into tool scripts a vice-versa, script still need to keep an internal list of objects its attached to. In this case, I used the seemingly unused 'placeholder' list, giving objects a 'placeholder' reference when they attempt to instance a non-tool script with the scripting-engine disabled. When reloaded, instances and placeholders can convert between each other and vice-versa. The pre-existing 'placeholders' might not be the ideal way of storing this, since this implementation currently does not attempt to save members between placeholders and instances, but this can easily be changed depending on how this system should develop going forward. When reloading between instanced scripts, we simply copy the members array, resize the original if nessecary, and then attempt to copy the variables from the old one to the new one using simple string comparisons.

Next point is how scripts attempt to update themselves, particular in relation to script which inherit from other scripts. Internally, this implementation using a 'dirty script list' which attempts to keep a list of all saved scripts ordered based on inheritance hierarchy, meaning that if a script of which another script inherits from is modified, the inheritor will be added to list only after the initial script has updated. Internally, this is done by scanning the 'inheritors' list in a script object which is a tool-specific internal list of objects inheriting this script, not the scripts themselves. A reference-counted list of inherited scripts would be slightly more efficent here, but I didn't really want to change more than I felt I have to in this early implementation, but this can always be refined further. Ensuring the correct order of script reloads in relation to inheritance should work fairly reliably, but it may need to be tested more extensively just in case there's some rare edge-cases I haven't anticipated. This part of the code is mostly confined to the script editor, and there are also some fixes in regards to the various methods of saving scripts, as well as handling scripts being modified from outside of the editor. It should be worth noting that there isn't a really good interface for 'reloading' preexisting resources, so there's some vaguely hacky workarounds going on which have been noted in comments. There's also a fix in another pull request I just sent concerning fixes to the text editor regarding undo/redo, but I decided to send them seperately since while they do affect this feature, it's still kind of a self-contained fix.

Finally, there's reloading scripts in the game itself. Internally, it uses the same ordered dirty list on the editor side as on the game side. It creates a 'live edit' packet consisting of two arrays, one containing the names of the scripts requiring reload, and the other containing the modified source code for each file. The rest is fairly self-explanatory. It might be slightly inefficient to send the entire source code for each file over the protocol, but it shouldn't be a problem for now considering it only does it for files detected as modified, and at most would only ever be done over an internal wi-fi connection. The reason for doing it like this is of course the afformentioned lack of a good interface for reloading resources, but this method should also ensure that script reloading works when debugging a game on an alternative device like a tablet.

One final thing, this feature currently depends on a setting in the text editor 'dynamic_script_reloading_enabled' which is set to be off by default since this is still a somewhat experimental feature, and of course, 'live edit' has to enabled to use this feature with ingame scripts.

That should cover everything, but please ask if there's anything about this implementation which is unclear. This came out of some experiments to see if the editor could be made more 'WYSIWYG-like', so hopefully this should help with speeding up iteration time in game development.
