### PR TITLE
Correct spot light size conversion in Blender exporter.

### DIFF
--- a/tools/export/blender25/io_scene_dae/export_dae.py
+++ b/tools/export/blender25/io_scene_dae/export_dae.py
@@ -1087,7 +1087,7 @@ class DaeExporter:
 			self.writel(S_LAMPS,5,'<color>'+strarr(light.color)+'</color>')
 			att_by_distance = 2.0 / light.distance # convert to linear attenuation
 			self.writel(S_LAMPS,5,'<linear_attenuation>'+str(att_by_distance)+'</linear_attenuation>')
-			self.writel(S_LAMPS,5,'<falloff_angle>'+str(math.degrees(light.spot_size))+'</falloff_angle>')
+			self.writel(S_LAMPS,5,'<falloff_angle>'+str(math.degrees(light.spot_size/2))+'</falloff_angle>')
 			self.writel(S_LAMPS,4,'</spot>')
 
 


### PR DESCRIPTION
Tiny fix.

The collada falloff angle is the angle from the center of the spot
light projection, whereas Blender's point light size is the angle from
one side to the opposite, meaning it's twice as much.

Before:
![](http://i.imgur.com/UQbi4I6.png)

After:
![](http://i.imgur.com/RHIVqSu.png)
