### PR TITLE
(editor)filedialog open file and dir MODE_OPEN_ANY

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -181,12 +181,10 @@ void FileDialog::_action_pressed() {
 
 	String f=dir_access->get_current_dir().plus_file(file->get_text());
 
-	if (mode==MODE_OPEN_FILE && dir_access->file_exists(f)) {
+	if ((mode==MODE_OPEN_ANY || mode==MODE_OPEN_FILE) && dir_access->file_exists(f)) {
 		emit_signal("file_selected",f);
 		hide();
-	}
-
-	if (mode==MODE_OPEN_DIR) {
+	}else if (mode==MODE_OPEN_ANY || mode==MODE_OPEN_DIR) {
 
 
 		String path=dir_access->get_current_dir();
@@ -304,7 +302,7 @@ void FileDialog::_tree_dc_selected() {
 	if (d["dir"]) {
 
 		dir_access->change_dir(d["name"]);
-		if (mode==MODE_OPEN_FILE || mode==MODE_OPEN_FILES || mode==MODE_OPEN_DIR)
+		if (mode==MODE_OPEN_FILE || mode==MODE_OPEN_FILES || mode==MODE_OPEN_DIR || mode==MODE_OPEN_ANY)
 			file->set_text("");
 		call_deferred("_update_file_list");
 		call_deferred("_update_dir");
@@ -552,8 +550,9 @@ void FileDialog::set_mode(Mode p_mode) {
 
 		case MODE_OPEN_FILE: get_ok()->set_text("Open"); set_title("Open a File"); makedir->hide(); break;
 		case MODE_OPEN_FILES: get_ok()->set_text("Open"); set_title("Open File(s)"); makedir->hide(); break;
-		case MODE_SAVE_FILE: get_ok()->set_text("Save"); set_title("Save a File"); makedir->show(); break;
 		case MODE_OPEN_DIR: get_ok()->set_text("Open"); set_title("Open a Directory"); makedir->show(); break;
+		case MODE_OPEN_ANY: get_ok()->set_text("Open"); set_title("Open a File or Directory"); makedir->show(); break;
+		case MODE_SAVE_FILE: get_ok()->set_text("Save"); set_title("Save a File"); makedir->show(); break;
 	}
 
 	if (mode==MODE_OPEN_FILES) {
@@ -710,6 +709,8 @@ void FileDialog::_bind_methods() {
 	BIND_CONSTANT( MODE_OPEN_FILE );
 	BIND_CONSTANT( MODE_OPEN_FILES );
 	BIND_CONSTANT( MODE_OPEN_DIR );
+	BIND_CONSTANT( MODE_OPEN_ANY );
+
 	BIND_CONSTANT( MODE_SAVE_FILE );
 
 	BIND_CONSTANT( ACCESS_RESOURCES );
@@ -877,3 +878,4 @@ LineEditFileChooser::LineEditFileChooser() {
 	dialog->connect("files_selected",this,"_chosen");
 
 }
+

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -57,7 +57,8 @@ public:
 		MODE_OPEN_FILE,
 		MODE_OPEN_FILES,
 		MODE_OPEN_DIR,
-		MODE_SAVE_FILE,
+		MODE_OPEN_ANY,
+		MODE_SAVE_FILE
 	};
 
 	typedef Ref<Texture> (*GetIconFunc)(const String&);

--- a/tools/editor/editor_file_dialog.cpp
+++ b/tools/editor/editor_file_dialog.cpp
@@ -273,13 +273,11 @@ void EditorFileDialog::_action_pressed() {
 
 	String f=dir_access->get_current_dir().plus_file(file->get_text());
 
-	if (mode==MODE_OPEN_FILE && dir_access->file_exists(f)) {
+	if ((mode==MODE_OPEN_ANY || mode==MODE_OPEN_FILE) && dir_access->file_exists(f)) {
 		_save_to_recent();
 		emit_signal("file_selected",f);
 		hide();
-	}
-
-	if (mode==MODE_OPEN_DIR) {
+	}else if (mode==MODE_OPEN_ANY || mode==MODE_OPEN_DIR) {
 
 
 		String path=dir_access->get_current_dir();
@@ -413,7 +411,7 @@ void EditorFileDialog::_item_dc_selected(int p_item) {
 
 		//print_line("change dir: "+String(d["name"]));
 		dir_access->change_dir(d["name"]);
-		if (mode==MODE_OPEN_FILE || mode==MODE_OPEN_FILES || mode==MODE_OPEN_DIR)
+		if (mode==MODE_OPEN_FILE || mode==MODE_OPEN_FILES || mode==MODE_OPEN_DIR || MODE_OPEN_ANY)
 			file->set_text("");
 		call_deferred("_update_file_list");
 		call_deferred("_update_dir");
@@ -771,8 +769,9 @@ void EditorFileDialog::set_mode(Mode p_mode) {
 
 		case MODE_OPEN_FILE: get_ok()->set_text("Open"); set_title("Open a File"); makedir->hide(); break;
 		case MODE_OPEN_FILES: get_ok()->set_text("Open"); set_title("Open File(s)"); makedir->hide(); break;
-		case MODE_SAVE_FILE: get_ok()->set_text("Save"); set_title("Save a File"); makedir->show(); break;
 		case MODE_OPEN_DIR: get_ok()->set_text("Open"); set_title("Open a Directory"); makedir->show(); break;
+		case MODE_OPEN_ANY: get_ok()->set_text("Open"); set_title("Open a File or Directory"); makedir->show(); break;
+		case MODE_SAVE_FILE: get_ok()->set_text("Save"); set_title("Save a File"); makedir->show(); break;
 	}
 
 	if (mode==MODE_OPEN_FILES) {
@@ -1149,6 +1148,7 @@ void EditorFileDialog::_bind_methods() {
 	BIND_CONSTANT( MODE_OPEN_FILE );
 	BIND_CONSTANT( MODE_OPEN_FILES );
 	BIND_CONSTANT( MODE_OPEN_DIR );
+	BIND_CONSTANT( MODE_OPEN_ANY );
 	BIND_CONSTANT( MODE_SAVE_FILE );
 
 	BIND_CONSTANT( ACCESS_RESOURCES );

--- a/tools/editor/editor_file_dialog.h
+++ b/tools/editor/editor_file_dialog.h
@@ -66,7 +66,8 @@ public:
 		MODE_OPEN_FILE,
 		MODE_OPEN_FILES,
 		MODE_OPEN_DIR,
-		MODE_SAVE_FILE,
+		MODE_OPEN_ANY,
+		MODE_SAVE_FILE
 	};
 
 	typedef Ref<Texture> (*GetIconFunc)(const String&);


### PR DESCRIPTION
closes #4019
old PR #4023

How to use/test?

Select a file and you will see a file selected print
Select a dir and you will see a dir selected print
Try to create and save a new scene.

```
extends Node2D

onready var filedialog = get_node( "FileDialog" )

func _ready():
    filedialog.connect("dir_selected", self,"_on_FileDialog_dir_selected")
    filedialog.connect("file_selected", self,"_on_FileDialog_file_selected")
    filedialog.connect("files_selected", self,"_on_FileDialog_files_selected")

    filedialog.set_mode( filedialog.MODE_OPEN_ANY )
    #filedialog.set_mode( filedialog.MODE_SAVE_FILE )
    #filedialog.set_mode( filedialog.MODE_OPEN_FILES )
    #filedialog.set_mode( filedialog.MODE_OPEN_FILE )
    filedialog.popup()

func _on_FileDialog_dir_selected( dir ):
    print("dir selected: " + dir )


func _on_FileDialog_file_selected( path ):
    print("file selected: " + path )

func _on_FileDialog_files_selected( paths ):
    print("files selected: " + str(paths) )
```
