### PR TITLE
BoxContainer: Add helper method add_margin(int)

### DIFF
--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -313,6 +313,7 @@ void BoxContainer::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("get_alignment"),&BoxContainer::get_alignment);
 	ObjectTypeDB::bind_method(_MD("set_alignment","alignment"),&BoxContainer::set_alignment);
+	ObjectTypeDB::bind_method(_MD("add_spacer","begin"),&BoxContainer::add_spacer);
 	ObjectTypeDB::bind_method(_MD("add_margin","margin"),&BoxContainer::add_margin);
 
 	BIND_CONSTANT( ALIGN_BEGIN );

--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -290,6 +290,17 @@ void BoxContainer::add_spacer(bool p_begin) {
 		move_child(c,0);
 }
 
+void BoxContainer::add_margin(int margin) {
+
+	Control *c = memnew( Control );
+	if (vertical)
+		c->set_custom_minimum_size(Size2(0, margin));
+	else
+		c->set_custom_minimum_size(Size2(margin, 0));
+
+	add_child(c);
+}
+
 BoxContainer::BoxContainer(bool p_vertical) {
 
 	vertical=p_vertical;
@@ -302,6 +313,7 @@ void BoxContainer::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("get_alignment"),&BoxContainer::get_alignment);
 	ObjectTypeDB::bind_method(_MD("set_alignment","alignment"),&BoxContainer::set_alignment);
+	ObjectTypeDB::bind_method(_MD("add_margin","margin"),&BoxContainer::add_margin);
 
 	BIND_CONSTANT( ALIGN_BEGIN );
 	BIND_CONSTANT( ALIGN_CENTER );

--- a/scene/gui/box_container.h
+++ b/scene/gui/box_container.h
@@ -56,6 +56,7 @@ protected:
 public:
 
 	void add_spacer(bool p_begin=false);
+	void add_margin(int margin);
 
 	void set_alignment(AlignMode p_align);
 	AlignMode get_alignment() const;


### PR DESCRIPTION
I couldn't find a way to make margins work inside BoxContainer. The only possible solution seems to be adding a control with a minimum size:

``` C++
Control *margin = memnew( Control );
margin->set_custom_minimum_size(Size2(0, 10)); // vertical margin of 10
vbc->add_child(margin);
```

However this is too verbose so I added this helper method.

**Just to be sure...** Is there a better way to add a margin to (or to make margins work inside of) _BoxContainer_?
