### PR TITLE
Fix issues with tilemap covering child nodes and old quadrants

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -504,6 +504,7 @@ void TileMap::_update_dirty_quadrants() {
 		}
 
 		dirty_quadrant_list.remove( dirty_quadrant_list.first() );
+		quadrant_order_dirty=true;
 	}
 
 
@@ -522,6 +523,14 @@ void TileMap::_update_dirty_quadrants() {
 		}
 
 		quadrant_order_dirty=false;
+	}
+
+	for(int i=0;i<get_child_count();i++) {
+
+		CanvasItem *c=get_child(i)->cast_to<CanvasItem>();
+
+		if (c)
+			VS::get_singleton()->canvas_item_raise(c->get_canvas_item());
 	}
 
 	_recompute_rect_cache();


### PR DESCRIPTION
Closes #4070 

The fix is as following:
1. Even when redrawing a quadrant, we would still reorder all quadrants.
2. All child CanvasItems are raised above the tiles after repaint. (Hope this doesn't add a regression or two xD)
