### PR TITLE
Fixes #3942 - Throws an error when exporting for X11 with no filename

### DIFF
--- a/tools/editor/project_export.cpp
+++ b/tools/editor/project_export.cpp
@@ -467,6 +467,14 @@ void ProjectExportDialog::_export_action(const String& p_file) {
 		location=nl;
 	}
 
+	/* Checked if the export location is outside the project directory,
+	 * now will check if a file name has been entered */
+	if (p_file.ends_with("/")) {
+		
+		error->set_text("Please enter a file name!");
+		error->popup_centered_minsize();
+		return;
+	}
 
 	TreeItem *selected = platforms->get_selected();
 	if (!selected)
@@ -1908,4 +1916,3 @@ ProjectExport::ProjectExport(EditorData* p_data) {
 
 
 }
-


### PR DESCRIPTION
Error was only when exporting for Linux/X11, other platforms were managed by the filter, while checking for the file extension.
