### PR TITLE
TextEdit: Fix Shift+Delete shortcut not calling cut()

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1630,6 +1630,13 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 						clear=(!k.mod.command || k.mod.shift || k.mod.alt );
 						break;
 					case KEY_DELETE:
+						if (!k.mod.shift) {
+							accept_event();
+							clear=true; dobreak=true;
+						} else if (k.mod.command || k.mod.alt) {
+							dobreak=true;
+						}
+						break;
 					case KEY_BACKSPACE:
 						accept_event();
 						clear=true; dobreak=true;


### PR DESCRIPTION
_Shift+Delete_ (introduced by #4062) was not working in _TextEdit_.

Closes #4060 again :P
