### PR TITLE
MarginContainer improvements

### DIFF
--- a/scene/gui/margin_container.cpp
+++ b/scene/gui/margin_container.cpp
@@ -31,7 +31,10 @@
 
 Size2 MarginContainer::get_minimum_size() const {
 
-	int margin = get_constant("margin");
+	int margin_left = get_constant("margin_left");
+	int margin_top = get_constant("margin_top");
+	int margin_right = get_constant("margin_right");
+	int margin_bottom = get_constant("margin_bottom");
 
 	Size2 max;
 
@@ -52,9 +55,10 @@ Size2 MarginContainer::get_minimum_size() const {
 			max.height = s.height;
 	}
 
-	max.width += margin;
-	return max;
+	max.width += (margin_left + margin_right);
+	max.height += (margin_top + margin_bottom);
 
+	return max;
 
 }
 
@@ -62,7 +66,10 @@ void MarginContainer::_notification(int p_what) {
 
 	if (p_what==NOTIFICATION_SORT_CHILDREN) {
 
-		int margin = get_constant("margin");
+		int margin_left = get_constant("margin_left");
+		int margin_top = get_constant("margin_top");
+		int margin_right = get_constant("margin_right");
+		int margin_bottom = get_constant("margin_bottom");
 
 		Size2 s = get_size();
 
@@ -73,13 +80,10 @@ void MarginContainer::_notification(int p_what) {
 				continue;
 			if (c->is_set_as_toplevel())
 				continue;
-			int w;
-			if (c->get_h_size_flags() & Control::SIZE_EXPAND)
-				w=s.width-margin;
-			else
-				w=c->get_combined_minimum_size().width;
 
-			fit_child_in_rect(c,Rect2(margin,0,s.width-margin,s.height));
+			int w=s.width-margin_left-margin_right;
+			int h=s.height-margin_top-margin_bottom;
+			fit_child_in_rect(c,Rect2(margin_left,margin_top,w,h));
 		}
 
 	}

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -836,7 +836,10 @@ void make_default_theme() {
 
 	t->set_constant("separation","HBoxContainer",4);
 	t->set_constant("separation","VBoxContainer",4);
-	t->set_constant("margin","MarginContainer",8);
+	t->set_constant("margin_left","MarginContainer",8);
+	t->set_constant("margin_top","MarginContainer",0);
+	t->set_constant("margin_right","MarginContainer",0);
+	t->set_constant("margin_bottom","MarginContainer",0);
 	t->set_constant("hseparation","GridContainer",4);
 	t->set_constant("vseparation","GridContainer",4);
 	t->set_constant("separation","HSplitContainer",12);


### PR DESCRIPTION
What is introduced by this PR:
- Extra margins: top, right and bottom. The custom constant _margin_ has been replaced by _margin_left_, _margin_top_, _margin_right_ and _margin_bottom_ (only for _MarginContainer_). All margins except _margin_left_ are set to _0_ by default, to avoid breaking compatibility with the editor.

I am adding the _discussion_ label, since I am not sure if this may be against the original purpose of _MarginContainer_.
