### PR TITLE
Expose android/shutdown_adb_on_exit parameter

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1771,6 +1771,7 @@ void register_android_exporter() {
 	//EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING,"android/release_keystore",PROPERTY_HINT_GLOBAL_FILE,"*.keystore"));
 	EDITOR_DEF("android/timestamping_authority_url","");
 	EDITOR_DEF("android/use_remote_debug_over_adb",false);
+	EDITOR_DEF("android/shutdown_adb_on_exit",true);
 
 	Ref<EditorExportPlatformAndroid> exporter = Ref<EditorExportPlatformAndroid>( memnew(EditorExportPlatformAndroid) );
 	EditorImportExport::get_singleton()->add_export_platform(exporter);


### PR DESCRIPTION
It was added in 30d0ca9 for the Steam build but only enabled
when parsing a ._sc_ file that would define it.
It is now available for all users to toggle, in and outside of Steam.

Fixes #4073.
