### PR TITLE
Rename 'default_density' to 'default_linear_damp' in project settings

### DIFF
--- a/scene/resources/world_2d.cpp
+++ b/scene/resources/world_2d.cpp
@@ -373,7 +373,7 @@ World2D::World2D() {
 	Physics2DServer::get_singleton()->space_set_active(space,true);
 	Physics2DServer::get_singleton()->area_set_param(space,Physics2DServer::AREA_PARAM_GRAVITY,GLOBAL_DEF("physics_2d/default_gravity",98));
 	Physics2DServer::get_singleton()->area_set_param(space,Physics2DServer::AREA_PARAM_GRAVITY_VECTOR,GLOBAL_DEF("physics_2d/default_gravity_vector",Vector2(0,1)));
-	Physics2DServer::get_singleton()->area_set_param(space,Physics2DServer::AREA_PARAM_LINEAR_DAMP,GLOBAL_DEF("physics_2d/default_density",0.1));
+	Physics2DServer::get_singleton()->area_set_param(space,Physics2DServer::AREA_PARAM_LINEAR_DAMP,GLOBAL_DEF("physics_2d/default_linear_damp",0.1));
 	Physics2DServer::get_singleton()->area_set_param(space,Physics2DServer::AREA_PARAM_ANGULAR_DAMP,GLOBAL_DEF("physics_2d/default_angular_damp",1));
 	Physics2DServer::get_singleton()->space_set_param(space,Physics2DServer::SPACE_PARAM_CONTACT_RECYCLE_RADIUS,1.0);
 	Physics2DServer::get_singleton()->space_set_param(space,Physics2DServer::SPACE_PARAM_CONTACT_MAX_SEPARATION,1.5);


### PR DESCRIPTION
What 'default_density' in project settings actually sets is AREA_PARAM_LINEAR_DAMP. There's already a 'default_angular_damp' setting and this property seems to be mostly referred to as linear damp in the editor and docs, so to avoid confusion I suggest being consistent with the naming.

This change will affect older projects that use 'default_density', but the switch should be very simple.

[Test project](https://github.com/godotengine/godot/files/181423/godot-test-default-linear-damp.zip)
