### PR TITLE
EditorData: Add plugins in front to allow overriding plugins

### DIFF
--- a/tools/editor/editor_data.cpp
+++ b/tools/editor/editor_data.cpp
@@ -419,7 +419,7 @@ void EditorData::remove_editor_plugin(EditorPlugin *p_plugin) {
 void EditorData::add_editor_plugin(EditorPlugin *p_plugin) {
 
 	p_plugin->undo_redo=&undo_redo;
-	editor_plugins.push_back(p_plugin);
+	editor_plugins.insert(0, p_plugin);
 }
 
 int EditorData::get_editor_plugin_count() const {


### PR DESCRIPTION
Currently, new plugins are being added to the back so it is not possible to create a plugin to handle a object that already has a built-in plugin. Example:

``` GDScript
tool
extends EditorPlugin

func handles(object):
    # Suppossing my_custom_sprite_node.gd extends Sprite
    # This is never called since SpriteRegionEditorPlugin already edits Sprite
    return object extends preload("my_custom_sprite_node.gd")
```

Adding the plugins in front fixes that, though I am not sure what's the addition order for GDScript plugins. Maybe a _get_priority()_ method that could be overridden to sort _editor_plugins_ would be a better idea.
