### PR TITLE
Function syntax highlighting

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -671,6 +671,7 @@ void TextEdit::_notification(int p_what) {
 				bool prev_is_number = false;
 				bool in_keyword=false;
 				bool in_word = false;
+				bool in_function_name = false;
 				Color keyword_color;
 
 				// check if line contains highlighted word
@@ -790,11 +791,28 @@ void TextEdit::_notification(int p_what) {
 							}
 						}
 
+						if (!in_function_name && in_word && !in_keyword) {
+
+							int k = j;
+							while(k < str.length() && !_is_symbol(str[k]) && str[k] != '\t' && str[k] != ' ') {
+								k++;
+							}
+
+							if (str[k] == '(') {
+								in_function_name = true;
+							}
+						}
+
+						if (is_symbol) {
+							in_function_name = false;
+						}
 
 						if (in_region>=0)
 							color=color_regions[in_region].color;
 						else if (in_keyword)
 							color=keyword_color;
+						else if (in_function_name)
+							color=cache.function_color;
 						else if (is_symbol)
 							color=symbol_color;
 						else if (is_number)
@@ -2979,6 +2997,7 @@ void TextEdit::_update_caches() {
 	cache.font_color=get_color("font_color");
 	cache.font_selected_color=get_color("font_selected_color");
 	cache.keyword_color=get_color("keyword_color");
+	cache.function_color=get_color("function_color");
 	cache.number_color=get_color("number_color");
 	cache.selection_color=get_color("selection_color");
 	cache.mark_color=get_color("mark_color");

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -77,6 +77,7 @@ class TextEdit : public Control  {
 		Color font_selected_color;
 		Color keyword_color;
 		Color number_color;
+		Color function_color;
 		Color selection_color;
 		Color mark_color;
 		Color breakpoint_color;

--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -397,6 +397,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("text_editor/keyword_color",Color::html("ffffb3"));
 	set("text_editor/base_type_color",Color::html("a4ffd4"));
 	set("text_editor/engine_type_color",Color::html("83d3ff"));
+	set("text_editor/function_color",Color::html("66a2ce"));
 	set("text_editor/comment_color",Color::html("983d1b"));
 	set("text_editor/string_color",Color::html("ef6ebe"));
 	set("text_editor/number_color",Color::html("EB9532"));

--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -294,6 +294,7 @@ void ScriptTextEditor::_load_theme_settings() {
 	get_text_edit()->add_color_override("current_line_color",EDITOR_DEF("text_editor/current_line_color",Color(0.3,0.5,0.8,0.15)));
 	get_text_edit()->add_color_override("word_highlighted_color",EDITOR_DEF("text_editor/word_highlighted_color",Color(0.8,0.9,0.9,0.15)));
 	get_text_edit()->add_color_override("number_color",EDITOR_DEF("text_editor/number_color",Color(0.9,0.6,0.0,2)));
+	get_text_edit()->add_color_override("function_color",EDITOR_DEF("text_editor/function_color",Color(0.4,0.6,0.8)));
 
 	Color keyword_color= EDITOR_DEF("text_editor/keyword_color",Color(0.5,0.0,0.2));
 


### PR DESCRIPTION
Added syntax highlighting for functions and function calls. It does not change the highlighting of the built in functions such as yield, rand_range, ceil ect.
