### PR TITLE
Do not show black margins when stretch_aspect=keep

### DIFF
--- a/scene/main/scene_main_loop.cpp
+++ b/scene/main/scene_main_loop.cpp
@@ -1072,7 +1072,7 @@ void SceneTree::_update_root_rect() {
 	} else if (viewport_aspect < video_mode_aspect) {
 		// screen ratio is smaller vertically
 
-		if (stretch_aspect==STRETCH_ASPECT_KEEP_HEIGHT) {
+		if (stretch_aspect==STRETCH_ASPECT_KEEP_HEIGHT || stretch_aspect==STRETCH_ASPECT_KEEP) {
 
 			//will stretch horizontally
 			viewport_size.x=desired_res.y*video_mode_aspect;
@@ -1087,7 +1087,7 @@ void SceneTree::_update_root_rect() {
 		}
 	} else {
 		//screen ratio is smaller horizontally
-		if (stretch_aspect==STRETCH_ASPECT_KEEP_WIDTH) {
+		if (stretch_aspect==STRETCH_ASPECT_KEEP_WIDTH || stretch_aspect==STRETCH_ASPECT_KEEP) {
 
 			//will stretch horizontally
 			viewport_size.x=desired_res.x;


### PR DESCRIPTION
_Bugsquad edit: removed mention to #1136 being fixed based on later comment_

If user set stretch_aspect=keep, then godot will keep both width and height of viewport and will not clip it. 
