### PR TITLE
Adds support for aligned memory needed for SIMD code.

### DIFF
--- a/bin/tests/test_math.cpp
+++ b/bin/tests/test_math.cpp
@@ -43,7 +43,7 @@
 namespace TestMath {
 
 
-void test_vec(Plane p_vec) {
+void test_vec(const Plane& p_vec) {
 
 
 	CameraMatrix cm;

--- a/bin/tests/test_misc.cpp
+++ b/bin/tests/test_misc.cpp
@@ -167,7 +167,7 @@ struct TConvex {
 	float CylinderHalfHeight() const { return half_height; }
 };
 
-float GetDistanceFromLine2(Vector3 v, Vector3 & project, const Vector3 & pointA, const Vector3 & pointB)
+float GetDistanceFromLine2(const Vector3 & v, Vector3 & project, const Vector3 & pointA, const Vector3 & pointB)
 {
 	Vector3 ba = pointB - pointA;
 

--- a/bin/tests/test_physics.cpp
+++ b/bin/tests/test_physics.cpp
@@ -84,7 +84,7 @@ protected:
 		ObjectTypeDB::bind_method("body_changed_transform",&TestPhysicsMainLoop::body_changed_transform);
 	}
 
-	RID create_body(PhysicsServer::ShapeType p_shape, PhysicsServer::BodyMode p_body,const Transform p_location,bool p_active_default=true,const Transform&p_shape_xform=Transform()) {
+	RID create_body(PhysicsServer::ShapeType p_shape, PhysicsServer::BodyMode p_body,const Transform& p_location,bool p_active_default=true,const Transform&p_shape_xform=Transform()) {
 
 		VisualServer *vs=VisualServer::get_singleton();
 		PhysicsServer * ps = PhysicsServer::get_singleton();

--- a/core/command_queue_mt.cpp
+++ b/core/command_queue_mt.cpp
@@ -75,6 +75,8 @@ CommandQueueMT::SyncSemaphore* CommandQueueMT::_alloc_sync_sem() {
 
 CommandQueueMT::CommandQueueMT(bool p_sync){
 
+	command_mem = (uint8_t *)memalloc(COMMAND_MEM_SIZE);
+
 	read_ptr=0;
 	write_ptr=0;
 	mutex = Mutex::create();
@@ -102,6 +104,8 @@ CommandQueueMT::~CommandQueueMT() {
 
 		memdelete(sync_sems[i].sem);
 	}
+
+	memdelete(command_mem);
 }
 
 

--- a/core/command_queue_mt.h
+++ b/core/command_queue_mt.h
@@ -66,9 +66,19 @@ class CommandQueueMT {
 
 		T*instance;
 		M method;
-		typename GetSimpleTypeT<P1>::type_t p1;
-
+		typename GetSimpleTypeT<P1>::type_t &p1;
+	
 		virtual void call() { (instance->*method)(p1); }
+		_FORCE_INLINE_ Command1() :
+			p1(*((P1 *)memalloc(sizeof(P1))))
+		{
+			memnew_placement(&p1, P1);
+		}
+
+		_FORCE_INLINE_ ~Command1()
+		{
+			memdelete<P1>(&p1);
+		}
 	};
 
 	template<class T,class M,class P1,class P2>
@@ -76,10 +86,23 @@ class CommandQueueMT {
 
 		T*instance;
 		M method;
-		typename GetSimpleTypeT<P1>::type_t p1;
-		typename GetSimpleTypeT<P2>::type_t p2;
-
+		typename GetSimpleTypeT<P1>::type_t &p1;
+		typename GetSimpleTypeT<P2>::type_t &p2;
+	
 		virtual void call() { (instance->*method)(p1,p2); }
+		_FORCE_INLINE_ Command2() :
+			p1(*((P1 *)memalloc(sizeof(P1)))),
+			p2(*((P2 *)memalloc(sizeof(P2))))
+		{
+			memnew_placement(&p1, P1);
+			memnew_placement(&p2, P2);
+		}
+
+		_FORCE_INLINE_ ~Command2()
+		{
+			memdelete<P1>(&p1);
+			memdelete<P2>(&p2);
+		}
 	};
 
 	template<class T,class M,class P1,class P2,class P3>
@@ -87,11 +110,27 @@ class CommandQueueMT {
 
 		T*instance;
 		M method;
-		typename GetSimpleTypeT<P1>::type_t p1;
-		typename GetSimpleTypeT<P2>::type_t p2;
-		typename GetSimpleTypeT<P3>::type_t p3;
-
+		typename GetSimpleTypeT<P1>::type_t &p1;
+		typename GetSimpleTypeT<P2>::type_t &p2;
+		typename GetSimpleTypeT<P3>::type_t &p3;
+	
 		virtual void call() { (instance->*method)(p1,p2,p3); }
+		_FORCE_INLINE_ Command3() :
+			p1(*((P1 *)memalloc(sizeof(P1)))),
+			p2(*((P2 *)memalloc(sizeof(P2)))),
+			p3(*((P3 *)memalloc(sizeof(P3))))
+		{
+			memnew_placement(&p1, P1);
+			memnew_placement(&p2, P2);
+			memnew_placement(&p3, P3);
+		}
+
+		_FORCE_INLINE_ ~Command3()
+		{
+			memdelete<P1>(&p1);
+			memdelete<P2>(&p2);
+			memdelete<P3>(&p3);
+		}
 	};
 
 	template<class T,class M,class P1,class P2,class P3,class P4>
@@ -99,12 +138,31 @@ class CommandQueueMT {
 
 		T*instance;
 		M method;
-		typename GetSimpleTypeT<P1>::type_t p1;
-		typename GetSimpleTypeT<P2>::type_t p2;
-		typename GetSimpleTypeT<P3>::type_t p3;
-		typename GetSimpleTypeT<P4>::type_t p4;
-
+		typename GetSimpleTypeT<P1>::type_t &p1;
+		typename GetSimpleTypeT<P2>::type_t &p2;
+		typename GetSimpleTypeT<P3>::type_t &p3;
+		typename GetSimpleTypeT<P4>::type_t &p4;
+	
 		virtual void call() { (instance->*method)(p1,p2,p3,p4); }
+		_FORCE_INLINE_ Command4() :
+			p1(*((P1 *)memalloc(sizeof(P1)))),
+			p2(*((P2 *)memalloc(sizeof(P2)))),
+			p3(*((P3 *)memalloc(sizeof(P3)))),
+			p4(*((P4 *)memalloc(sizeof(P4))))
+		{
+			memnew_placement(&p1, P1);
+			memnew_placement(&p2, P2);
+			memnew_placement(&p3, P3);
+			memnew_placement(&p4, P4);
+		}
+
+		_FORCE_INLINE_ ~Command4()
+		{
+			memdelete<P1>(&p1);
+			memdelete<P2>(&p2);
+			memdelete<P3>(&p3);
+			memdelete<P4>(&p4);
+		}
 	};
 
 	template<class T,class M,class P1,class P2,class P3,class P4,class P5>
@@ -112,13 +170,35 @@ class CommandQueueMT {
 
 		T*instance;
 		M method;
-		typename GetSimpleTypeT<P1>::type_t p1;
-		typename GetSimpleTypeT<P2>::type_t p2;
-		typename GetSimpleTypeT<P3>::type_t p3;
-		typename GetSimpleTypeT<P4>::type_t p4;
-		typename GetSimpleTypeT<P5>::type_t p5;
-
+		typename GetSimpleTypeT<P1>::type_t &p1;
+		typename GetSimpleTypeT<P2>::type_t &p2;
+		typename GetSimpleTypeT<P3>::type_t &p3;
+		typename GetSimpleTypeT<P4>::type_t &p4;
+		typename GetSimpleTypeT<P5>::type_t &p5;
+	
 		virtual void call() { (instance->*method)(p1,p2,p3,p4,p5); }
+		_FORCE_INLINE_ Command5() :
+			p1(*((P1 *)memalloc(sizeof(P1)))),
+			p2(*((P2 *)memalloc(sizeof(P2)))),
+			p3(*((P3 *)memalloc(sizeof(P3)))),
+			p4(*((P4 *)memalloc(sizeof(P4)))),
+			p5(*((P5 *)memalloc(sizeof(P5))))
+		{
+			memnew_placement(&p1, P1);
+			memnew_placement(&p2, P2);
+			memnew_placement(&p3, P3);
+			memnew_placement(&p4, P4);
+			memnew_placement(&p5, P5);
+		}
+
+		_FORCE_INLINE_ ~Command5()
+		{
+			memdelete<P1>(&p1);
+			memdelete<P2>(&p2);
+			memdelete<P3>(&p3);
+			memdelete<P4>(&p4);
+			memdelete<P5>(&p5);
+		}
 	};
 
 	template<class T,class M,class P1,class P2,class P3,class P4,class P5,class P6>
@@ -126,14 +206,39 @@ class CommandQueueMT {
 
 		T*instance;
 		M method;
-		typename GetSimpleTypeT<P1>::type_t p1;
-		typename GetSimpleTypeT<P2>::type_t p2;
-		typename GetSimpleTypeT<P3>::type_t p3;
-		typename GetSimpleTypeT<P4>::type_t p4;
-		typename GetSimpleTypeT<P5>::type_t p5;
-		typename GetSimpleTypeT<P6>::type_t p6;
-
+		typename GetSimpleTypeT<P1>::type_t &p1;
+		typename GetSimpleTypeT<P2>::type_t &p2;
+		typename GetSimpleTypeT<P3>::type_t &p3;
+		typename GetSimpleTypeT<P4>::type_t &p4;
+		typename GetSimpleTypeT<P5>::type_t &p5;
+		typename GetSimpleTypeT<P6>::type_t &p6;
+	
 		virtual void call() { (instance->*method)(p1,p2,p3,p4,p5,p6); }
+		_FORCE_INLINE_ Command6() :
+			p1(*((P1 *)memalloc(sizeof(P1)))),
+			p2(*((P2 *)memalloc(sizeof(P2)))),
+			p3(*((P3 *)memalloc(sizeof(P3)))),
+			p4(*((P4 *)memalloc(sizeof(P4)))),
+			p5(*((P5 *)memalloc(sizeof(P5)))),
+			p6(*((P6 *)memalloc(sizeof(P6))))
+		{
+			memnew_placement(&p1, P1);
+			memnew_placement(&p2, P2);
+			memnew_placement(&p3, P3);
+			memnew_placement(&p4, P4);
+			memnew_placement(&p5, P5);
+			memnew_placement(&p6, P6);
+		}
+
+		_FORCE_INLINE_ ~Command6()
+		{
+			memdelete<P1>(&p1);
+			memdelete<P2>(&p2);
+			memdelete<P3>(&p3);
+			memdelete<P4>(&p4);
+			memdelete<P5>(&p5);
+			memdelete<P6>(&p6);
+		}
 	};
 
 	template<class T,class M,class P1,class P2,class P3,class P4,class P5,class P6,class P7>
@@ -141,15 +246,43 @@ class CommandQueueMT {
 
 		T*instance;
 		M method;
-		typename GetSimpleTypeT<P1>::type_t p1;
-		typename GetSimpleTypeT<P2>::type_t p2;
-		typename GetSimpleTypeT<P3>::type_t p3;
-		typename GetSimpleTypeT<P4>::type_t p4;
-		typename GetSimpleTypeT<P5>::type_t p5;
-		typename GetSimpleTypeT<P6>::type_t p6;
-		typename GetSimpleTypeT<P7>::type_t p7;
-
+		typename GetSimpleTypeT<P1>::type_t &p1;
+		typename GetSimpleTypeT<P2>::type_t &p2;
+		typename GetSimpleTypeT<P3>::type_t &p3;
+		typename GetSimpleTypeT<P4>::type_t &p4;
+		typename GetSimpleTypeT<P5>::type_t &p5;
+		typename GetSimpleTypeT<P6>::type_t &p6;
+		typename GetSimpleTypeT<P7>::type_t &p7;
+	
 		virtual void call() { (instance->*method)(p1,p2,p3,p4,p5,p6,p7); }
+		_FORCE_INLINE_ Command7() :
+			p1(*((P1 *)memalloc(sizeof(P1)))),
+			p2(*((P2 *)memalloc(sizeof(P2)))),
+			p3(*((P3 *)memalloc(sizeof(P3)))),
+			p4(*((P4 *)memalloc(sizeof(P4)))),
+			p5(*((P5 *)memalloc(sizeof(P5)))),
+			p6(*((P6 *)memalloc(sizeof(P6)))),
+			p7(*((P7 *)memalloc(sizeof(P7))))
+		{
+			memnew_placement(&p1, P1);
+			memnew_placement(&p2, P2);
+			memnew_placement(&p3, P3);
+			memnew_placement(&p4, P4);
+			memnew_placement(&p5, P5);
+			memnew_placement(&p6, P6);
+			memnew_placement(&p7, P7);
+		}
+
+		_FORCE_INLINE_ ~Command7()
+		{
+			memdelete<P1>(&p1);
+			memdelete<P2>(&p2);
+			memdelete<P3>(&p3);
+			memdelete<P4>(&p4);
+			memdelete<P5>(&p5);
+			memdelete<P6>(&p6);
+			memdelete<P7>(&p7);
+		}
 	};
 
 	/* comands that return */
@@ -399,7 +532,7 @@ class CommandQueueMT {
 	};
 
 
-	uint8_t command_mem[COMMAND_MEM_SIZE];
+	uint8_t *command_mem;
 	uint32_t read_ptr;
 	uint32_t write_ptr;
 	SyncSemaphore sync_sems[SYNC_SEMAPHORES];
@@ -509,7 +642,7 @@ public:
 	/* NORMAL PUSH COMMANDS */
 
 	template<class T, class M>
-	void push( T * p_instance, M p_method ) {
+	void push( T * p_instance, const M& p_method ) {
 
 		Command0<T,M> * cmd = allocate_and_lock< Command0<T,M> >();
 
@@ -522,7 +655,7 @@ public:
 	}
 
 	template<class T, class M, class P1>
-	void push( T * p_instance, M p_method, P1 p1 ) {
+	void push( T * p_instance, const M& p_method, const P1& p1 ) {
 
 		Command1<T,M,P1> * cmd = allocate_and_lock< Command1<T,M,P1> >();
 
@@ -536,7 +669,7 @@ public:
 	}
 
 	template<class T, class M, class P1, class P2>
-	void push( T * p_instance, M p_method, P1 p1, P2 p2 ) {
+	void push( T * p_instance, const M& p_method, const P1& p1, const P2& p2 ) {
 
 		Command2<T,M,P1,P2> * cmd = allocate_and_lock< Command2<T,M,P1,P2> >();
 
@@ -551,7 +684,7 @@ public:
 	}
 
 	template<class T, class M, class P1, class P2, class P3>
-	void push( T * p_instance, M p_method, P1 p1, P2 p2, P3 p3 ) {
+	void push( T * p_instance, const M& p_method, const P1& p1, const P2& p2, const P3& p3 ) {
 
 		Command3<T,M,P1,P2,P3> * cmd = allocate_and_lock< Command3<T,M,P1,P2,P3> >();
 
@@ -567,7 +700,7 @@ public:
 	}
 
 	template<class T, class M, class P1, class P2, class P3, class P4>
-	void push( T * p_instance, M p_method, P1 p1, P2 p2, P3 p3, P4 p4 ) {
+	void push( T * p_instance, const M& p_method, const P1& p1, const P2& p2, const P3& p3, const P4& p4 ) {
 
 		Command4<T,M,P1,P2,P3,P4> * cmd = allocate_and_lock< Command4<T,M,P1,P2,P3,P4> >();
 
@@ -584,7 +717,7 @@ public:
 	}
 
 	template<class T, class M, class P1, class P2, class P3, class P4, class P5>
-	void push( T * p_instance, M p_method, P1 p1, P2 p2, P3 p3, P4 p4, P5 p5 ) {
+	void push( T * p_instance, const M& p_method, const P1& p1, const P2& p2, const P3& p3, const P4& p4, const P5& p5 ) {
 
 		Command5<T,M,P1,P2,P3,P4,P5> * cmd = allocate_and_lock< Command5<T,M,P1,P2,P3,P4,P5> >();
 
@@ -602,7 +735,7 @@ public:
 	}
 
 	template<class T, class M, class P1, class P2, class P3, class P4, class P5, class P6>
-	void push( T * p_instance, M p_method, P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6 ) {
+	void push( T * p_instance, const M& p_method, const P1& p1, const P2& p2, const P3& p3, const P4& p4, const P5& p5, const P6& p6 ) {
 
 		Command6<T,M,P1,P2,P3,P4,P5,P6> * cmd = allocate_and_lock< Command6<T,M,P1,P2,P3,P4,P5,P6> >();
 
@@ -621,7 +754,7 @@ public:
 	}
 
 	template<class T, class M, class P1, class P2, class P3, class P4, class P5, class P6, class P7>
-	void push( T * p_instance, M p_method, P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7 ) {
+	void push( T * p_instance, const M& p_method, const P1& p1, const P2& p2, const P3& p3, const P4& p4, const P5& p5, const P6& p6, const P7& p7 ) {
 
 		Command7<T,M,P1,P2,P3,P4,P5,P6,P7> * cmd = allocate_and_lock< Command7<T,M,P1,P2,P3,P4,P5,P6,P7> >();
 
@@ -643,7 +776,7 @@ public:
 
 
 	template<class T, class M,class R>
-	void push_and_ret( T * p_instance, M p_method, R* r_ret) {
+	void push_and_ret( T * p_instance, const M& p_method, R* r_ret) {
 
 		CommandRet0<T,M,R> * cmd = allocate_and_lock< CommandRet0<T,M,R> >();
 
@@ -660,7 +793,7 @@ public:
 	}
 
 	template<class T, class M, class P1,class R>
-	void push_and_ret( T * p_instance, M p_method, P1 p1, R* r_ret) {
+	void push_and_ret( T * p_instance, const M& p_method, const P1& p1, R* r_ret) {
 
 		CommandRet1<T,M,P1,R> * cmd = allocate_and_lock< CommandRet1<T,M,P1,R> >();
 
@@ -678,7 +811,7 @@ public:
 	}
 
 	template<class T, class M, class P1, class P2,class R>
-	void push_and_ret( T * p_instance, M p_method, P1 p1, P2 p2, R* r_ret) {
+	void push_and_ret( T * p_instance, const M& p_method, const P1& p1, const P2& p2, R* r_ret) {
 
 		CommandRet2<T,M,P1,P2,R> * cmd = allocate_and_lock< CommandRet2<T,M,P1,P2,R> >();
 
@@ -697,7 +830,7 @@ public:
 	}
 
 	template<class T, class M, class P1, class P2, class P3,class R>
-	void push_and_ret( T * p_instance, M p_method, P1 p1, P2 p2, P3 p3, R* r_ret ) {
+	void push_and_ret( T * p_instance, const M& p_method, const P1& p1, const P2& p2, const P3& p3, R* r_ret ) {
 
 		CommandRet3<T,M,P1,P2,P3,R> * cmd = allocate_and_lock< CommandRet3<T,M,P1,P2,P3,R> >();
 
@@ -717,7 +850,7 @@ public:
 	}
 
 	template<class T, class M, class P1, class P2, class P3, class P4,class R>
-	void push_and_ret( T * p_instance, M p_method, P1 p1, P2 p2, P3 p3, P4 p4, R* r_ret ) {
+	void push_and_ret( T * p_instance, const M& p_method, const P1& p1, const P2& p2, const P3& p3, const P4& p4, R* r_ret ) {
 
 		CommandRet4<T,M,P1,P2,P3,P4,R> * cmd = allocate_and_lock< CommandRet4<T,M,P1,P2,P3,P4,R> >();
 
@@ -738,7 +871,7 @@ public:
 	}
 
 	template<class T, class M, class P1, class P2, class P3, class P4, class P5,class R>
-	void push_and_ret( T * p_instance, M p_method, P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, R* r_ret ) {
+	void push_and_ret( T * p_instance, const M& p_method, const P1& p1, const P2& p2, const P3& p3, const P4& p4, const P5& p5, R* r_ret ) {
 
 		CommandRet5<T,M,P1,P2,P3,P4,P5,R> * cmd = allocate_and_lock< CommandRet5<T,M,P1,P2,P3,P4,P5,R> >();
 
@@ -760,7 +893,7 @@ public:
 	}
 
 	template<class T, class M, class P1, class P2, class P3, class P4, class P5, class P6,class R>
-	void push_and_ret( T * p_instance, M p_method, P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, R* r_ret ) {
+	void push_and_ret( T * p_instance, const M& p_method, const P1& p1, const P2& p2, const P3& p3, const P4& p4, const P5& p5, const P6& p6, R* r_ret ) {
 
 		CommandRet6<T,M,P1,P2,P3,P4,P5,P6,R> * cmd = allocate_and_lock< CommandRet6<T,M,P1,P2,P3,P4,P5,P6,R> >();
 
@@ -783,7 +916,7 @@ public:
 	}
 
 	template<class T, class M, class P1, class P2, class P3, class P4, class P5, class P6,class P7,class R>
-	void push_and_ret( T * p_instance, M p_method, P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6,P7 p7, R* r_ret ) {
+	void push_and_ret( T * p_instance, const M& p_method, const P1& p1, const P2& p2, const P3& p3, const P4& p4, const P5& p5, const P6& p6,const P7& p7, R* r_ret ) {
 
 		CommandRet7<T,M,P1,P2,P3,P4,P5,P6,P7,R> * cmd = allocate_and_lock< CommandRet7<T,M,P1,P2,P3,P4,P5,P6,P7,R> >();
 
@@ -808,7 +941,7 @@ public:
 
 
 	template<class T, class M>
-	void push_and_sync( T * p_instance, M p_method) {
+	void push_and_sync( T * p_instance, const M& p_method) {
 
 		CommandSync0<T,M> * cmd = allocate_and_lock< CommandSync0<T,M> >();
 
@@ -825,7 +958,7 @@ public:
 	}
 
 	template<class T, class M, class P1>
-	void push_and_sync( T * p_instance, M p_method, P1 p1) {
+	void push_and_sync( T * p_instance, const M& p_method, const P1& p1) {
 
 		CommandSync1<T,M,P1> * cmd = allocate_and_lock< CommandSync1<T,M,P1> >();
 
@@ -843,7 +976,7 @@ public:
 	}
 
 	template<class T, class M, class P1, class P2>
-	void push_and_sync( T * p_instance, M p_method, P1 p1, P2 p2) {
+	void push_and_sync( T * p_instance, const M& p_method, const P1& p1, const P2& p2) {
 
 		CommandSync2<T,M,P1,P2> * cmd = allocate_and_lock< CommandSync2<T,M,P1,P2> >();
 
@@ -862,7 +995,7 @@ public:
 	}
 
 	template<class T, class M, class P1, class P2, class P3>
-	void push_and_sync( T * p_instance, M p_method, P1 p1, P2 p2, P3 p3 ) {
+	void push_and_sync( T * p_instance, const M& p_method, const P1& p1, const P2& p2, const P3& p3 ) {
 
 		CommandSync3<T,M,P1,P2,P3> * cmd = allocate_and_lock< CommandSync3<T,M,P1,P2,P3> >();
 
@@ -882,7 +1015,7 @@ public:
 	}
 
 	template<class T, class M, class P1, class P2, class P3, class P4>
-	void push_and_sync( T * p_instance, M p_method, P1 p1, P2 p2, P3 p3, P4 p4 ) {
+	void push_and_sync( T * p_instance, const M& p_method, const P1& p1, const P2& p2, const P3& p3, const P4& p4 ) {
 
 		CommandSync4<T,M,P1,P2,P3,P4> * cmd = allocate_and_lock< CommandSync4<T,M,P1,P2,P3,P4> >();
 
@@ -903,7 +1036,7 @@ public:
 	}
 
 	template<class T, class M, class P1, class P2, class P3, class P4, class P5>
-	void push_and_sync( T * p_instance, M p_method, P1 p1, P2 p2, P3 p3, P4 p4, P5 p5 ) {
+	void push_and_sync( T * p_instance, const M& p_method, const P1& p1, const P2& p2, const P3& p3, const P4& p4, const P5& p5 ) {
 
 		CommandSync5<T,M,P1,P2,P3,P4,P5> * cmd = allocate_and_lock< CommandSync5<T,M,P1,P2,P3,P4,P5> >();
 
@@ -925,7 +1058,7 @@ public:
 	}
 
 	template<class T, class M, class P1, class P2, class P3, class P4, class P5, class P6>
-	void push_and_sync( T * p_instance, M p_method, P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6 ) {
+	void push_and_sync( T * p_instance, const M& p_method, const P1& p1, const P2& p2, const P3& p3, const P4& p4, const P5& p5, const P6& p6 ) {
 
 		CommandSync6<T,M,P1,P2,P3,P4,P5,P6> * cmd = allocate_and_lock< CommandSync6<T,M,P1,P2,P3,P4,P5,P6> >();
 
@@ -948,7 +1081,7 @@ public:
 	}
 
 	template<class T, class M, class P1, class P2, class P3, class P4, class P5, class P6,class P7>
-	void push_and_sync( T * p_instance, M p_method, P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6,P7 p7 ) {
+	void push_and_sync( T * p_instance, const M& p_method, const P1& p1, const P2& p2, const P3& p3, const P4& p4, const P5& p5, const P6& p6,const P7& p7 ) {
 
 		CommandSync7<T,M,P1,P2,P3,P4,P5,P6,P7> * cmd = allocate_and_lock< CommandSync7<T,M,P1,P2,P3,P4,P5,P6,P7> >();
 

--- a/core/sort.h
+++ b/core/sort.h
@@ -82,29 +82,35 @@ public:
 
 	/* Heap / Heapsort functions */
 
-	inline void push_heap(int p_first,int p_hole_idx,int p_top_index,T p_value,T* p_array) const {
+	inline void push_heap(int p_first,int p_hole_idx,int p_top_index, const T& p_value,T* p_array) const {
+  
+		T value_copy = p_value;
 
 		int parent = (p_hole_idx - 1) / 2;
-		while (p_hole_idx > p_top_index && compare(p_array[p_first + parent], p_value)) {
+		while (p_hole_idx > p_top_index && compare(p_array[p_first + parent], value_copy)) {
 
 			p_array[p_first + p_hole_idx] = p_array[p_first + parent];
 			p_hole_idx = parent;
 			parent = (p_hole_idx - 1) / 2;
 		}
-		p_array[p_first + p_hole_idx] = p_value;
+		p_array[p_first + p_hole_idx] = value_copy;
 	}
 
-	inline void pop_heap(int p_first, int p_last, int p_result, T p_value, T* p_array) const {
+	inline void pop_heap(int p_first, int p_last, int p_result, const T& p_value, T* p_array) const {
+	
+		T value_copy = p_value;
 
 		p_array[p_result]=p_array[p_first];
-		adjust_heap(p_first,0,p_last-p_first,p_value,p_array);
+		adjust_heap(p_first,0,p_last-p_first,value_copy,p_array);
 	}
 	inline void pop_heap(int p_first,int p_last,T* p_array) const {
 
 	 	pop_heap(p_first,p_last-1,p_last-1,p_array[p_last-1],p_array);
 	}
 
-	inline void adjust_heap(int p_first,int p_hole_idx,int p_len,T p_value,T* p_array) const {
+	inline void adjust_heap(int p_first,int p_hole_idx,int p_len, const T& p_value,T* p_array) const {
+	
+		T value_copy = p_value;
 
 
 		int top_index = p_hole_idx;
@@ -124,7 +130,7 @@ public:
 			p_array[p_first + p_hole_idx] = p_array[p_first + (second_child - 1)];
 			p_hole_idx = second_child - 1;
 		}
-		push_heap(p_first, p_hole_idx, top_index, p_value,p_array);
+		push_heap(p_first, p_hole_idx, top_index, value_copy,p_array);
 	}
 
 	inline void sort_heap(int p_first,int p_last,T* p_array) const {
@@ -166,13 +172,15 @@ public:
 				pop_heap(p_first,p_middle,i,p_array[i],p_array);
 	}
 
-	inline int partitioner(int p_first, int p_last, T p_pivot, T* p_array) const {
+	inline int partitioner(int p_first, int p_last, const T& p_pivot, T* p_array) const {
+	
+		T value_copy = p_pivot;
 
 		while (true) {
-			while (compare(p_array[p_first],p_pivot))
+			while (compare(p_array[p_first], value_copy))
 				p_first++;
 			p_last--;
-			while (compare(p_pivot,p_array[p_last]))
+			while (compare(value_copy, p_array[p_last]))
 				p_last--;
 
 			if (!(p_first < p_last))
@@ -244,15 +252,17 @@ public:
 		insertion_sort(p_first,p_last,p_array);
 	}
 
-	inline void unguarded_linear_insert(int p_last,T p_value,T* p_array) const {
+	inline void unguarded_linear_insert(int p_last, const T& p_value,T* p_array) const {
+	
+		T value_copy = p_value;
 
 		int next = p_last-1;
-		while (compare(p_value,p_array[next])) {
+		while (compare(value_copy, p_array[next])) {
 			p_array[p_last]=p_array[next];
 			p_last = next;
 			next--;
 		}
-		p_array[p_last] = p_value;
+		p_array[p_last] = value_copy;
 	}
 
 	inline void linear_insert(int p_first,int p_last,T*p_array) const {

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -2150,7 +2150,7 @@ Variant::operator IP_Address() const {
 	return IP_Address( operator String() );
 }
 
-Variant::Variant(bool p_bool) {
+Variant::Variant(bool p_bool) : VARIANT_ALLOCATE_DATA() {
 
 	type=BOOL;
 	_data._bool=p_bool;
@@ -2164,13 +2164,13 @@ Variant::Variant(long unsigned int p_long) {
 };
 */
 
-Variant::Variant(signed int p_int) {
+Variant::Variant(signed int p_int) : VARIANT_ALLOCATE_DATA() {
 
 	type=INT;
 	_data._int=p_int;
 
 }
-Variant::Variant(unsigned int p_int) {
+Variant::Variant(unsigned int p_int) : VARIANT_ALLOCATE_DATA() {
 
 	type=INT;
 	_data._int=p_int;
@@ -2193,167 +2193,167 @@ Variant::Variant(unsigned long p_int) {
 }
 #endif
 
-Variant::Variant(int64_t p_int) {
+Variant::Variant(int64_t p_int) : VARIANT_ALLOCATE_DATA() {
 
 	type=INT;
 	_data._int=p_int;
 
 }
 
-Variant::Variant(uint64_t p_int) {
+Variant::Variant(uint64_t p_int) : VARIANT_ALLOCATE_DATA() {
 
 	type=INT;
 	_data._int=p_int;
 
 }
 
-Variant::Variant(signed short p_short) {
+Variant::Variant(signed short p_short) : VARIANT_ALLOCATE_DATA() {
 
 	type=INT;
 	_data._int=p_short;
 
 }
-Variant::Variant(unsigned short p_short) {
+Variant::Variant(unsigned short p_short) : VARIANT_ALLOCATE_DATA() {
 
 	type=INT;
 	_data._int=p_short;
 
 }
-Variant::Variant(signed char p_char) {
+Variant::Variant(signed char p_char) : VARIANT_ALLOCATE_DATA() {
 
 	type=INT;
 	_data._int=p_char;
 
 }
-Variant::Variant(unsigned char p_char) {
+Variant::Variant(unsigned char p_char) : VARIANT_ALLOCATE_DATA() {
 
 	type=INT;
 	_data._int=p_char;
 
 }
-Variant::Variant(float p_float) {
+Variant::Variant(float p_float) : VARIANT_ALLOCATE_DATA() {
 
 	type=REAL;
 	_data._real=p_float;
 
 }
-Variant::Variant(double p_double) {
+Variant::Variant(double p_double) : VARIANT_ALLOCATE_DATA() {
 
 	type=REAL;
 	_data._real=p_double;
 }
 
-Variant::Variant(const StringName& p_string) {
+Variant::Variant(const StringName& p_string) : VARIANT_ALLOCATE_DATA() {
 
 	type=STRING;
 	memnew_placement( _data._mem, String( p_string.operator String() ) );
 
 }
-Variant::Variant(const String& p_string) {
+Variant::Variant(const String& p_string) : VARIANT_ALLOCATE_DATA() {
 
 	type=STRING;
 	memnew_placement( _data._mem, String( p_string ) );
 
 }
 
-Variant::Variant(const char * const p_cstring) {
+Variant::Variant(const char * const p_cstring) : VARIANT_ALLOCATE_DATA() {
 
 	type=STRING;
 	memnew_placement( _data._mem, String( (const char*)p_cstring ) );
 
 }
 
-Variant::Variant(const CharType * p_wstring) {
+Variant::Variant(const CharType * p_wstring) : VARIANT_ALLOCATE_DATA() {
 
 	type=STRING;
 	memnew_placement( _data._mem, String( p_wstring ) );
 
 }
-Variant::Variant(const Vector3& p_vector3) {
+Variant::Variant(const Vector3& p_vector3) : VARIANT_ALLOCATE_DATA() {
 
 	type=VECTOR3;
 	memnew_placement( _data._mem, Vector3( p_vector3 ) );
 
 }
-Variant::Variant(const Vector2& p_vector2) {
+Variant::Variant(const Vector2& p_vector2) : VARIANT_ALLOCATE_DATA() {
 
 	type=VECTOR2;
 	memnew_placement( _data._mem, Vector2( p_vector2 ) );
 
 }
-Variant::Variant(const Rect2& p_rect2) {
+Variant::Variant(const Rect2& p_rect2) : VARIANT_ALLOCATE_DATA() {
 
 	type=RECT2;
 	memnew_placement( _data._mem, Rect2( p_rect2 ) );
 
 }
 
-Variant::Variant(const Plane& p_plane) {
+Variant::Variant(const Plane& p_plane) : VARIANT_ALLOCATE_DATA() {
 
 	type=PLANE;
 	memnew_placement( _data._mem, Plane( p_plane ) );
 
 }
-Variant::Variant(const AABB& p_aabb) {
+Variant::Variant(const AABB& p_aabb) : VARIANT_ALLOCATE_DATA() {
 
 	type=_AABB;
 	_data._aabb = memnew( AABB( p_aabb ) );
 }
 
-Variant::Variant(const Matrix3& p_matrix) {
+Variant::Variant(const Matrix3& p_matrix) : VARIANT_ALLOCATE_DATA() {
 
 	type=MATRIX3;
 	_data._matrix3= memnew( Matrix3( p_matrix ) );
 
 }
 
-Variant::Variant(const Quat& p_quat) {
+Variant::Variant(const Quat& p_quat) : VARIANT_ALLOCATE_DATA() {
 
 	type=QUAT;
 	memnew_placement( _data._mem, Quat( p_quat ) );
 
 }
-Variant::Variant(const Transform& p_transform) {
+Variant::Variant(const Transform& p_transform) : VARIANT_ALLOCATE_DATA() {
 
 	type=TRANSFORM;
 	_data._transform = memnew( Transform( p_transform ) );
 
 }
 
-Variant::Variant(const Matrix32& p_transform) {
+Variant::Variant(const Matrix32& p_transform) : VARIANT_ALLOCATE_DATA() {
 
 	type=MATRIX32;
 	_data._matrix32 = memnew( Matrix32( p_transform ) );
 
 }
-Variant::Variant(const Color& p_color) {
+Variant::Variant(const Color& p_color) : VARIANT_ALLOCATE_DATA() {
 
 	type=COLOR;
 	memnew_placement( _data._mem, Color(p_color) );
 
 }
-Variant::Variant(const Image& p_image) {
+Variant::Variant(const Image& p_image) : VARIANT_ALLOCATE_DATA() {
 
 	type=IMAGE;
 	_data._image=memnew( Image(p_image) );
 
 }
 
-Variant::Variant(const NodePath& p_node_path) {
+Variant::Variant(const NodePath& p_node_path) : VARIANT_ALLOCATE_DATA() {
 
 	type=NODE_PATH;
 	memnew_placement( _data._mem, NodePath(p_node_path) );
 
 }
 
-Variant::Variant(const InputEvent& p_input_event) {
+Variant::Variant(const InputEvent& p_input_event) : VARIANT_ALLOCATE_DATA() {
 
 	type=INPUT_EVENT;
 	_data._input_event = memnew( InputEvent(p_input_event) );
 
 }
 
-Variant::Variant(const RefPtr& p_resource) {
+Variant::Variant(const RefPtr& p_resource) : VARIANT_ALLOCATE_DATA() {
 
 	type=OBJECT;
 	memnew_placement( _data._mem, ObjData );
@@ -2363,14 +2363,14 @@ Variant::Variant(const RefPtr& p_resource) {
 
 }
 
-Variant::Variant(const RID& p_rid) {
+Variant::Variant(const RID& p_rid) : VARIANT_ALLOCATE_DATA() {
 
 	type=_RID;
 	memnew_placement( _data._mem, RID(p_rid) );
 
 }
 
-Variant::Variant(const Object* p_object) {
+Variant::Variant(const Object* p_object) : VARIANT_ALLOCATE_DATA() {
 
 	type=OBJECT;
 
@@ -2378,21 +2378,21 @@ Variant::Variant(const Object* p_object) {
 	_get_obj().obj=const_cast<Object*>(p_object);
 }
 
-Variant::Variant(const Dictionary& p_dictionary) {
+Variant::Variant(const Dictionary& p_dictionary) : VARIANT_ALLOCATE_DATA() {
 
 	type=DICTIONARY;
 	memnew_placement( _data._mem, (Dictionary)( p_dictionary) );
 
 }
 
-Variant::Variant(const Array& p_array) {
+Variant::Variant(const Array& p_array) : VARIANT_ALLOCATE_DATA() {
 
 	type=ARRAY;
 	memnew_placement( _data._mem, Array(p_array) );
 
 }
 
-Variant::Variant(const DVector<Plane>& p_array) {
+Variant::Variant(const DVector<Plane>& p_array) : VARIANT_ALLOCATE_DATA() {
 
 
 	type=ARRAY;
@@ -2407,7 +2407,7 @@ Variant::Variant(const DVector<Plane>& p_array) {
 	}
 }
 
-Variant::Variant(const Vector<Plane>& p_array) {
+Variant::Variant(const Vector<Plane>& p_array) : VARIANT_ALLOCATE_DATA() {
 
 
 	type=ARRAY;
@@ -2422,7 +2422,7 @@ Variant::Variant(const Vector<Plane>& p_array) {
 	}
 }
 
-Variant::Variant(const Vector<RID>& p_array) {
+Variant::Variant(const Vector<RID>& p_array) : VARIANT_ALLOCATE_DATA() {
 
 
 	type=ARRAY;
@@ -2437,7 +2437,7 @@ Variant::Variant(const Vector<RID>& p_array) {
 	}
 }
 
-Variant::Variant(const Vector<Vector2>& p_array) {
+Variant::Variant(const Vector<Vector2>& p_array) : VARIANT_ALLOCATE_DATA() {
 
 
 	type=NIL;
@@ -2455,50 +2455,50 @@ Variant::Variant(const Vector<Vector2>& p_array) {
 }
 
 
-Variant::Variant(const DVector<uint8_t>& p_raw_array) {
+Variant::Variant(const DVector<uint8_t>& p_raw_array) : VARIANT_ALLOCATE_DATA() {
 
 	type=RAW_ARRAY;
 	memnew_placement( _data._mem, DVector<uint8_t>(p_raw_array) );
 
 }
-Variant::Variant(const DVector<int>& p_int_array) {
+Variant::Variant(const DVector<int>& p_int_array) : VARIANT_ALLOCATE_DATA() {
 
 	type=INT_ARRAY;
 	memnew_placement( _data._mem, DVector<int>(p_int_array) );
 
 }
-Variant::Variant(const DVector<real_t>& p_real_array) {
+Variant::Variant(const DVector<real_t>& p_real_array) : VARIANT_ALLOCATE_DATA() {
 
 	type=REAL_ARRAY;
 	memnew_placement( _data._mem, DVector<real_t>(p_real_array) );
 
 }
-Variant::Variant(const DVector<String>& p_string_array) {
+Variant::Variant(const DVector<String>& p_string_array) : VARIANT_ALLOCATE_DATA() {
 
 	type=STRING_ARRAY;
 	memnew_placement( _data._mem, DVector<String>(p_string_array) );
 
 }
-Variant::Variant(const DVector<Vector3>& p_vector3_array) {
+Variant::Variant(const DVector<Vector3>& p_vector3_array) : VARIANT_ALLOCATE_DATA() {
 
 	type=VECTOR3_ARRAY;
 	memnew_placement( _data._mem, DVector<Vector3>(p_vector3_array) );
 
 }
 
-Variant::Variant(const DVector<Vector2>& p_vector2_array) {
+Variant::Variant(const DVector<Vector2>& p_vector2_array) : VARIANT_ALLOCATE_DATA() {
 
 	type=VECTOR2_ARRAY;
 	memnew_placement( _data._mem, DVector<Vector2>(p_vector2_array) );
 
 }
-Variant::Variant(const DVector<Color>& p_color_array) {
+Variant::Variant(const DVector<Color>& p_color_array) : VARIANT_ALLOCATE_DATA() {
 
 	type=COLOR_ARRAY;
 	memnew_placement( _data._mem, DVector<Color>(p_color_array) );
 }
 
-Variant::Variant(const DVector<Face3>& p_face_array) {
+Variant::Variant(const DVector<Face3>& p_face_array) : VARIANT_ALLOCATE_DATA() {
 
 
 	DVector<Vector3> vertices;
@@ -2527,7 +2527,7 @@ Variant::Variant(const DVector<Face3>& p_face_array) {
 
 /* helpers */
 
-Variant::Variant(const Vector<Variant>& p_array) {
+Variant::Variant(const Vector<Variant>& p_array) : VARIANT_ALLOCATE_DATA() {
 
 	type=NIL;
 	Array v;
@@ -2538,7 +2538,7 @@ Variant::Variant(const Vector<Variant>& p_array) {
 	*this=v;
 }
 
-Variant::Variant(const Vector<uint8_t>& p_array) {
+Variant::Variant(const Vector<uint8_t>& p_array) : VARIANT_ALLOCATE_DATA() {
 
 	type=NIL;
 	DVector<uint8_t> v;
@@ -2549,7 +2549,7 @@ Variant::Variant(const Vector<uint8_t>& p_array) {
 	*this=v;
 }
 
-Variant::Variant(const Vector<int>& p_array) {
+Variant::Variant(const Vector<int>& p_array) : VARIANT_ALLOCATE_DATA() {
 
 	type=NIL;
 	DVector<int> v;
@@ -2560,7 +2560,7 @@ Variant::Variant(const Vector<int>& p_array) {
 	*this=v;
 }
 
-Variant::Variant(const Vector<real_t>& p_array) {
+Variant::Variant(const Vector<real_t>& p_array) : VARIANT_ALLOCATE_DATA() {
 
 	type=NIL;
 	DVector<real_t> v;
@@ -2571,7 +2571,7 @@ Variant::Variant(const Vector<real_t>& p_array) {
 	*this=v;
 }
 
-Variant::Variant(const Vector<String>& p_array) {
+Variant::Variant(const Vector<String>& p_array) : VARIANT_ALLOCATE_DATA() {
 
 	type=NIL;
 	DVector<String> v;
@@ -2582,7 +2582,7 @@ Variant::Variant(const Vector<String>& p_array) {
 	*this=v;
 }
 
-Variant::Variant(const Vector<Vector3>& p_array) {
+Variant::Variant(const Vector<Vector3>& p_array) : VARIANT_ALLOCATE_DATA() {
 
 	type=NIL;
 	DVector<Vector3> v;
@@ -2598,7 +2598,7 @@ Variant::Variant(const Vector<Vector3>& p_array) {
 	*this=v;
 }
 
-Variant::Variant(const Vector<Color>& p_array) {
+Variant::Variant(const Vector<Color>& p_array) : VARIANT_ALLOCATE_DATA() {
 
 	type=NIL;
 	DVector<Color> v;
@@ -2614,13 +2614,13 @@ void Variant::operator=(const Variant& p_variant) {
 	reference(p_variant);
 }
 
-Variant::Variant(const IP_Address& p_address) {
+Variant::Variant(const IP_Address& p_address) : VARIANT_ALLOCATE_DATA() {
 
 	type=STRING;
 	memnew_placement( _data._mem, String( p_address ) );
 }
 
-Variant::Variant(const Variant& p_variant) {
+Variant::Variant(const Variant& p_variant) : VARIANT_ALLOCATE_DATA() {
 
 	type=NIL;
 	reference(p_variant);

--- a/core/variant.h
+++ b/core/variant.h
@@ -71,21 +71,24 @@ typedef DVector<Vector2> Vector2Array;
 typedef DVector<Vector3> Vector3Array;
 typedef DVector<Color> ColorArray;
 
+#define VARIANT_ALLOCATE_DATA()		_data( *((DataUnion *)memalloc(sizeof(ObjData) > (sizeof(real_t)*5) ? sizeof(ObjData) : (sizeof(real_t)*5))) )
+#define VARIANT_FREE_DATA()			memfree(&_data)
+
 class Variant {
 public:
 
 	enum Type {
-
-		NIL,
-
-		// atomic types
+	
+		NIL,		
+		
+		// atomic types 		
 		BOOL,
 		INT,
 		REAL,
 		STRING,
-
+		
 		// math types
-
+		
 		VECTOR2,		// 5
 		RECT2,
 		VECTOR3,
@@ -95,17 +98,17 @@ public:
 		_AABB, //sorry naming convention fail :( not like it's used often
 		MATRIX3,
 		TRANSFORM,
-
-		// misc types
+		
+		// misc types		
 		COLOR,
 		IMAGE,			// 15
 		NODE_PATH,
 		_RID,
-		OBJECT,
+		OBJECT,		
 		INPUT_EVENT,
 		DICTIONARY,		// 20
 		ARRAY,
-
+			
 		// arrays
 		RAW_ARRAY,
 		INT_ARRAY,
@@ -114,10 +117,10 @@ public:
 		VECTOR2_ARRAY,
 		VECTOR3_ARRAY,
 		COLOR_ARRAY,
-
+			
 		VARIANT_MAX
-
-	};
+		
+	};	
 
 private:
 
@@ -125,7 +128,7 @@ private:
 	friend class _VariantCall;
 	// Variant takes 20 bytes when real_t is float, and 36 if double
 	// it only allocates extra memory for aabb/matrix.
-
+	
 	Type type;
 
 	struct ObjData {
@@ -133,12 +136,12 @@ private:
 		Object *obj;
 		RefPtr ref;
 	};
-
+	
 
 	_FORCE_INLINE_ ObjData& _get_obj();
 	_FORCE_INLINE_ const ObjData& _get_obj() const;
 
-	union {
+	union DataUnion {
 
 		bool _bool;
 		int _int;
@@ -151,12 +154,14 @@ private:
 		InputEvent *_input_event;
 		Image *_image;
 		void *_ptr; //generic pointer
-#ifdef USE_QUAD_VECTORS
-		uint8_t _mem[sizeof(ObjData) > (sizeof(real_t)*5) ? sizeof(ObjData) : (sizeof(real_t)*5)]; // plane uses an extra real
+#ifdef USE_QUAD_VECTORS		
+		uint8_t _mem[sizeof(ObjData) > (sizeof(real_t)* 5) ? sizeof(ObjData) : (sizeof(real_t)* 5)]; // plane uses an extra real
 #else
-		uint8_t _mem[sizeof(ObjData) > (sizeof(real_t)*4) ? sizeof(ObjData) : (sizeof(real_t)*4)];
+		uint8_t _mem[sizeof(ObjData) > (sizeof(real_t)* 4) ? sizeof(ObjData) : (sizeof(real_t)* 4)];
 #endif
-	} _data;
+	};
+
+	DataUnion &_data;
 
 
 	void reference(const Variant& p_variant);
@@ -172,7 +177,7 @@ public:
 
 	template<class T>
 	static Type get_type_for() {
-
+		
 		GetSimpleType<T> t;
 		Variant v(t.type);
 		Type r = v.get_type();
@@ -231,7 +236,7 @@ public:
 
 	operator Dictionary() const;
 	operator Array() const;
-
+	
 	operator DVector<uint8_t>() const;
 	operator DVector<int>() const;
 	operator DVector<real_t>() const;
@@ -260,7 +265,7 @@ public:
 
 	operator IP_Address() const;
 
-
+	
 	Variant(bool p_bool);
 	Variant(signed int p_int); // real one
 	Variant(unsigned int p_int);
@@ -286,8 +291,8 @@ public:
 	Variant(const Vector3& p_vector3);
 	Variant(const Plane& p_plane);
 	Variant(const AABB& p_aabb);
-	Variant(const Quat& p_quat);
-	Variant(const Matrix3& p_transform);
+	Variant(const Quat& p_quat);	
+	Variant(const Matrix3& p_transform);	
 	Variant(const Matrix32& p_transform);
 	Variant(const Transform& p_transform);
 	Variant(const Color& p_color);
@@ -295,10 +300,10 @@ public:
 	Variant(const NodePath& p_path);
 	Variant(const RefPtr& p_resource);
 	Variant(const RID& p_rid);
-	Variant(const Object* p_object);
+	Variant(const Object* p_object);	
 	Variant(const InputEvent& p_input_event);
 	Variant(const Dictionary& p_dictionary);
-
+	
 	Variant(const Array& p_array);
 	Variant(const DVector<Plane>& p_array); // helper
 	Variant(const DVector<uint8_t>& p_raw_array);
@@ -309,7 +314,7 @@ public:
 	Variant(const DVector<Color>& p_color_array);
 	Variant(const DVector<Face3>& p_face_array);
 
-
+	
 	Variant(const Vector<Variant>& p_array);
 	Variant(const Vector<uint8_t>& p_raw_array);
 	Variant(const Vector<int>& p_int_array);
@@ -436,8 +441,10 @@ public:
 
 	void operator=(const Variant& p_variant); // only this is enough for all the other types
 	Variant(const Variant& p_variant);
-	_FORCE_INLINE_ Variant() { type=NIL; }
-	_FORCE_INLINE_ ~Variant() { if (type!=Variant::NIL) clear(); }
+
+	_FORCE_INLINE_ Variant() : VARIANT_ALLOCATE_DATA() { type = NIL; }
+
+	_FORCE_INLINE_ ~Variant() { if (type != Variant::NIL) clear(); VARIANT_FREE_DATA(); }
 
 };
 

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -349,6 +349,7 @@ static void _call_##m_type##_##m_method(Variant& r_ret,Variant& p_self,const Var
 	VCALL_LOCALMEM1R(Rect2,has_point);
 	VCALL_LOCALMEM1R(Rect2,grow);
 	VCALL_LOCALMEM1R(Rect2,expand);
+	VCALL_LOCALMEM1R(Rect2,distance_to);
 
 	VCALL_LOCALMEM0R(Vector3, min_axis);
 	VCALL_LOCALMEM0R(Vector3, max_axis);
@@ -1343,6 +1344,7 @@ _VariantCall::addfunc(Variant::m_vtype,Variant::m_ret,_SCS(#m_method),VCALL(m_cl
 	ADDFUNC1(RECT2,BOOL,Rect2,has_point,VECTOR2,"point",varray());
 	ADDFUNC1(RECT2,RECT2,Rect2,grow,REAL,"by",varray());
 	ADDFUNC1(RECT2,RECT2,Rect2,expand,VECTOR2,"to",varray());
+	ADDFUNC1(RECT2,REAL,Rect2,distance_to,VECTOR2,"b",varray());
 
 	ADDFUNC0(VECTOR3,INT,Vector3,min_axis,varray());
 	ADDFUNC0(VECTOR3,INT,Vector3,max_axis,varray());

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -620,7 +620,7 @@ Error Animation::transform_track_get_key(int p_track, int p_key, Vector3* r_loc,
 	return OK;
 }
 
-int Animation::transform_track_insert_key(int p_track, float p_time, const Vector3 p_loc, const Quat& p_rot, const Vector3& p_scale) {
+int Animation::transform_track_insert_key(int p_track, float p_time, const Vector3& p_loc, const Quat& p_rot, const Vector3& p_scale) {
 
 	ERR_FAIL_INDEX_V(p_track, tracks.size(),-1);
 	Track *t=tracks[p_track];

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -232,7 +232,7 @@ public:
 	void track_move_up(int p_track);
 	void track_move_down(int p_track);
 
-	int transform_track_insert_key(int p_track, float p_time, const Vector3 p_loc, const Quat& p_rot=Quat(), const Vector3& p_scale=Vector3());
+	int transform_track_insert_key(int p_track, float p_time, const Vector3& p_loc=Vector3(), const Quat& p_rot=Quat(), const Vector3& p_scale=Vector3());
 	void track_insert_key(int p_track, float p_time, const Variant& p_key, float p_transition=1);
 	void track_set_key_transition(int p_track, int p_key_idx,float p_transition);
 	void track_set_key_value(int p_track, int p_key_idx,const Variant& p_value);

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -30,7 +30,7 @@
 #include "core_string_names.h"
 
 template<class T>
-static _FORCE_INLINE_ T _bezier_interp(real_t t, T start, T control_1, T control_2, T end) {
+static _FORCE_INLINE_ T _bezier_interp(real_t t, const T& start, const T& control_1, const T& control_2, const T& end) {
     /* Formula from Wikipedia article on Bezier curves. */
 	real_t omt = (1.0 - t);
 	real_t omt2 = omt*omt;

--- a/scene/resources/plane_shape.cpp
+++ b/scene/resources/plane_shape.cpp
@@ -64,7 +64,7 @@ void PlaneShape::_update_shape() {
 	PhysicsServer::get_singleton()->shape_set_data(get_shape(),plane);
 }
 
-void PlaneShape::set_plane(Plane p_plane) {
+void PlaneShape::set_plane(const Plane& p_plane=Plane()) {
 
 	plane=p_plane;
 	_update_shape();

--- a/scene/resources/plane_shape.h
+++ b/scene/resources/plane_shape.h
@@ -44,7 +44,7 @@ protected:
 	virtual Vector<Vector3> _gen_debug_mesh_lines();
 public:
 
-	void set_plane(Plane p_plane);
+	void set_plane(const Plane& p_plane);
 	Plane get_plane() const;
 
 	PlaneShape();

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -5152,7 +5152,7 @@ void VisualServerRaster::_light_instance_update_pssm_shadow(Instance *p_light,Sc
 }
 
 
-CameraMatrix _lispm_look( const Vector3 pos, const Vector3 dir, const Vector3 up) {
+CameraMatrix _lispm_look( const Vector3& pos, const Vector3& dir, const Vector3& up) {
 
 	Vector3 dirN;
 	Vector3 upN;


### PR DESCRIPTION
Okay, this PR is actually adapted and updated from a stale fork by @rraallvv to be compatible with the latest revisions. This fork successfully implemented some working SIMD code for vectors and matricies. In order to make it work, and I can confirm this, these changes are required for Neon or SSE code work as SIMD code requires data to be 16-bit aligned. Without it, you will get random crashes. By default though, the actual alignment is disabled with macros, but what is intended to happen is that these macros should be activated when attempting to compile a build of the engine with SIMD support enabled.

I do actually have some experimental SIMD code ready, but it has yet to be given a fair performance comparsion and it could definetly use some cleaning up first, so that will likely be submitted as a seperate PR, but it will depend on merging this PR first.
