### PR TITLE
Fixed numbers not highlighting after space

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -44,7 +44,7 @@ static bool _is_text_char(CharType c) {
 
 static bool _is_symbol(CharType c) {
 
-	return c!='_' && ((c>='!' && c<='/') || (c>=':' && c<='@') || (c>='[' && c<='`') || (c>='{' && c<='~') || c=='\t');
+	return c!='_' && ((c>='!' && c<='/') || (c>=':' && c<='@') || (c>='[' && c<='`') || (c>='{' && c<='~') || c=='\t' || c==' ');
 }
 
 static bool _is_char(CharType c) {


### PR DESCRIPTION
Fix for numbers not being highlighted after spaces, as mentioned [here.](https://github.com/godotengine/godot/pull/4115)
