### PR TITLE
AnimationTreePlayer (_process_node): remove `switched` argument.

### DIFF
--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -652,14 +652,14 @@ float AnimationTreePlayer::_process_node(const StringName& p_node,AnimationNode 
 		case NODE_TIMESEEK: {
 
 			TimeSeekNode *tsn = static_cast<TimeSeekNode*>(nb);
-			if (tsn->seek_pos>=0) {
+			if (tsn->seek_pos>=0 && !p_seek) {
 
-				float res = _process_node(tsn->inputs[0].node,r_prev_anim,p_weight,tsn->seek_pos,true,p_filter,p_reverse_weight);
-				tsn->seek_pos=-1;
-				return res;
+				p_time = tsn->seek_pos;
+				p_seek = true;
+			}
+			tsn->seek_pos=-1;
 
-			} else
-				return _process_node(tsn->inputs[0].node,r_prev_anim,p_weight,p_time,p_seek);
+			return _process_node(tsn->inputs[0].node,r_prev_anim,p_weight,p_time,p_seek);
 
 		}   break;
 		case NODE_TRANSITION: {

--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -1604,6 +1604,7 @@ void AnimationTreePlayer::set_active(bool p_active) {
 
 	active = p_active;
 	processing = active;
+	reset_request = p_active;
 	_set_process(processing, true);
 }
 
@@ -1621,7 +1622,7 @@ AnimationTreePlayer::ConnectError AnimationTreePlayer::get_last_error() const {
 void AnimationTreePlayer::reset() {
 
 
-	reset_request=false;
+	reset_request=true;
 }
 
 
@@ -1863,7 +1864,7 @@ AnimationTreePlayer::AnimationTreePlayer() {
 	processing = false;
 	active=false;
 	dirty_caches=true;
-	reset_request=false;
+	reset_request=true;
 	last_error=CONNECT_INCOMPLETE;
 	base_path=String("..");
 }

--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -571,8 +571,8 @@ float AnimationTreePlayer::_process_node(const StringName& p_node,AnimationNode 
 
 			if (!p_seek) {
 				osn->time+=p_time;
-				osn->remaining-=p_time;
-				if (osn->remaining<0)
+				osn->remaining=os_rem;
+				if (osn->remaining<=0)
 					osn->active=false;
 			}
 

--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -676,14 +676,7 @@ float AnimationTreePlayer::_process_node(const StringName& p_node,AnimationNode 
 
 				if (tn->input_data[tn->current].auto_advance && rem <= tn->xfade) {
 
-					tn->prev=tn->current;
-					tn->current++;
-					if (tn->current>=tn->inputs.size())
-						tn->current=0;
-					tn->prev_xfading=tn->xfade;
-					tn->prev_time=tn->time;
-					tn->time=0;
-					tn->switched=true;
+					tn->set_current((tn->current+1) % tn->inputs.size());
 				}
 
 
@@ -1156,21 +1149,24 @@ void AnimationTreePlayer::transition_node_set_xfade_time(const StringName& p_nod
 	n->xfade=p_time;
 }
 
+void AnimationTreePlayer::TransitionNode::set_current(int p_current) {
+	ERR_FAIL_INDEX(p_current,inputs.size());
+
+	if (current==p_current)
+		return;
+
+	prev=current;
+	prev_xfading=xfade;
+	prev_time=time;
+	time=0;
+	current=p_current;
+	switched=true;
+}
 
 void AnimationTreePlayer::transition_node_set_current(const StringName& p_node, int p_current) {
 
 	GET_NODE( NODE_TRANSITION, TransitionNode );
-	ERR_FAIL_INDEX(p_current,n->inputs.size());
-
-	if (n->current==p_current)
-		return;
-
-	n->prev=n->current;
-	n->prev_xfading=n->xfade;
-	n->prev_time=n->time;
-	n->time=0;
-	n->current=p_current;
-
+	n->set_current(p_current);
 }
 
 

--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -674,7 +674,7 @@ float AnimationTreePlayer::_process_node(const StringName& p_node,AnimationNode 
 				else
 					tn->time+=p_time;
 
-				if (tn->input_data[tn->current].auto_advance && rem < tn->xfade) {
+				if (tn->input_data[tn->current].auto_advance && rem <= tn->xfade) {
 
 					tn->prev=tn->current;
 					tn->current++;

--- a/scene/animation/animation_tree_player.h
+++ b/scene/animation/animation_tree_player.h
@@ -246,6 +246,7 @@ private:
 		float xfade;
 
 		TransitionNode() { type=NODE_TRANSITION;  xfade=0; inputs.resize(1); input_data.resize(1); current=0; prev=-1; prev_time=0; prev_xfading=0; switched=false; }
+		void set_current(int p_current);
 	};
 
 

--- a/scene/animation/animation_tree_player.h
+++ b/scene/animation/animation_tree_player.h
@@ -267,7 +267,7 @@ private:
 	Map<StringName,NodeBase*> node_map;
 
 	// return time left to finish animation
-	float _process_node(const StringName& p_node,AnimationNode **r_prev_anim, float p_weight,float p_step, bool switched, bool p_seek=false,const HashMap<NodePath,bool> *p_filter=NULL, float p_reverse_weight=0);
+	float _process_node(const StringName& p_node,AnimationNode **r_prev_anim, float p_weight,float p_step, bool p_seek=false,const HashMap<NodePath,bool> *p_filter=NULL, float p_reverse_weight=0);
 	void _process_animation(float p_delta);
 	bool reset_request;
 


### PR DESCRIPTION
The _process_node function (which recurses through the blend tree
generating blend values and the active animation list) had an argument
named `switched` which would loop an animation back to the beginning if
it had reached the end (regardless of whether or not it was supposed to
be a looping animation).

This argument was only used in four places: two of them were overridden
by a seek-to-zero, and I believe the other two are bugs.

In OneShot, it was used to reset the oneshot animation to the beginning
when fired. But this would fail if the oneshot node was fired before it
had completed its previous run. While this _could_ be a valid way for
oneshot to work (firing does nothing if it's already running), the code
currently resets the fade-in, so I believe that it is intended to reset.
I replaced this usage with seek-to-0.

In Transition, it was used on the previous (fading out) animation when
seeking the Transition node, which I believe is incorrect: why would you
want to loop a non-looping animation instead of simply fading out from
the end? Also it will never happen unless you seek the Transition node
twice during one cross-fade.

The other two uses are in Transition and _process_animation, where it is
used along with a seek-to-zero which overrides it.
