### PR TITLE
Multiple editor plugins for same obj type

### DIFF
--- a/tools/editor/editor_data.cpp
+++ b/tools/editor/editor_data.cpp
@@ -260,6 +260,16 @@ EditorPlugin* EditorData::get_subeditor(Object *p_object) {
 	return NULL;
 }
 
+Vector<EditorPlugin*> EditorData::get_subeditors(Object* p_object) {
+	Vector<EditorPlugin*> sub_plugins;
+	for (int i = 0; i < editor_plugins.size(); i++) {
+		if (!editor_plugins[i]->has_main_screen() && editor_plugins[i]->handles(p_object)) {
+			sub_plugins.push_back(editor_plugins[i]);
+		}
+	}
+	return sub_plugins;
+}
+
 EditorPlugin* EditorData::get_editor(String p_name) {
 
 	for(int i=0;i<editor_plugins.size();i++) {

--- a/tools/editor/editor_data.h
+++ b/tools/editor/editor_data.h
@@ -150,6 +150,7 @@ public:
 
 	EditorPlugin* get_editor(Object *p_object);
 	EditorPlugin* get_subeditor(Object *p_object);
+	Vector<EditorPlugin*> get_subeditors(Object *p_object);
 	EditorPlugin* get_editor(String p_name);
 
 	void copy_object_params(Object *p_object);

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -1571,14 +1571,26 @@ void EditorNode::_imported(Node *p_node) {
 }
 
 
-
-
 void EditorNode::_hide_top_editors() {
 
-	if (editor_plugin_over)
-		editor_plugin_over->make_visible(false);
-	editor_plugin_over=NULL;
+	_display_top_editors(false);
+
+	editor_plugins_over->clear();
 }
+
+void EditorNode::_display_top_editors(bool p_display) {
+	editor_plugins_over->make_visible(p_display);
+}
+
+void EditorNode::_set_top_editors(Vector<EditorPlugin*> p_editor_plugins_over) {
+	editor_plugins_over->set_plugins_list(p_editor_plugins_over);
+}
+
+void EditorNode::_set_editing_top_editors(Object* p_current_object) {
+	editor_plugins_over->edit(p_current_object);
+}
+
+
 
 void EditorNode::_edit_current() {
 
@@ -1598,8 +1610,7 @@ void EditorNode::_edit_current() {
 		property_editor->edit( NULL );
 		object_menu->set_disabled(true);
 
-		if (editor_plugin_over)
-			editor_plugin_over->make_visible(false);
+		_display_top_editors(false);
 
 		return;
 	}
@@ -1679,20 +1690,18 @@ void EditorNode::_edit_current() {
 
 	}
 
-	EditorPlugin *sub_plugin = editor_data.get_subeditor(current_obj);
+	Vector<EditorPlugin*> sub_plugins = editor_data.get_subeditors(current_obj);
 
-	if (sub_plugin) {
+	if (!sub_plugins.empty()) {
+		_display_top_editors(false);
 
+		_set_top_editors(sub_plugins);
+		_set_editing_top_editors(current_obj);
+		_display_top_editors(true);
+                
+	} else if (!editor_plugins_over->get_plugins_list().empty()) {
 
-		if (editor_plugin_over)
-			editor_plugin_over->make_visible(false);
-		editor_plugin_over=sub_plugin;
-		editor_plugin_over->edit(current_obj);
-		editor_plugin_over->make_visible(true);
-	} else if (editor_plugin_over) {
-
-		editor_plugin_over->make_visible(false);
-		editor_plugin_over=NULL;
+		_hide_top_editors();
 
 	}
 /*
@@ -2579,10 +2588,9 @@ void EditorNode::_menu_option_confirm(int p_option,bool p_confirmed) {
 			}
 
 			editor_data.get_undo_redo().clear_history();
-			if (editor_plugin_over) { //reload editor plugin
-				editor_plugin_over->edit(NULL);
-				editor_plugin_over->edit(current);
-			}
+
+			_set_editing_top_editors(NULL);
+			_set_editing_top_editors(current);
 
 		} break;
 		case OBJECT_CALL_METHOD: {
@@ -6134,7 +6142,7 @@ EditorNode::EditorNode() {
 	_rebuild_import_menu();
 
 	editor_plugin_screen=NULL;
-	editor_plugin_over=NULL;
+	editor_plugins_over = memnew(EditorPluginList);
 
 //	force_top_viewport(true);
 	_edit_current();
@@ -6266,12 +6274,72 @@ EditorNode::EditorNode() {
 
 
 EditorNode::~EditorNode() {
-
-
+        
 	memdelete( EditorHelp::get_doc_data() );
 	memdelete(editor_selection);
+	memdelete(editor_plugins_over);
 	memdelete(file_server);
 	EditorSettings::destroy();
 }
+
+/*
+ * EDITOR PLUGIN LIST
+ */
+
+
+void EditorPluginList::make_visible(bool p_visible) {
+	if (!plugins_list.empty()) {
+		for (int i = 0; i < plugins_list.size(); i++) {
+			plugins_list[i]->make_visible(p_visible);
+		}
+	}
+}
+
+void EditorPluginList::edit(Object* p_object) {
+	if (!plugins_list.empty()) {
+		for (int i = 0; i < plugins_list.size(); i++) {
+			plugins_list[i]->edit(p_object);
+		}
+	}
+}
+
+bool EditorPluginList::forward_input_event(const InputEvent& p_event) {
+	bool discard = false;
+	if (!plugins_list.empty()) {
+		for (int i = 0; i < plugins_list.size(); i++) {
+			if (plugins_list[i]->forward_input_event(p_event)) {
+				discard = true;
+			}
+		}
+	}
+	return discard;
+}
+
+bool EditorPluginList::forward_spatial_input_event(Camera* p_camera, const InputEvent& p_event) {
+	bool discard = false;
+	if (!plugins_list.empty()) {
+		for (int i = 0; i < plugins_list.size(); i++) {
+			if (plugins_list[i]->forward_spatial_input_event(p_camera, p_event)) {
+				discard = true;
+			}
+		}
+	}
+	return discard;
+}
+
+bool EditorPluginList::empty() {
+	return plugins_list.empty();
+}
+
+void EditorPluginList::clear() {
+	plugins_list.clear();
+}
+
+EditorPluginList::EditorPluginList() {
+}
+
+EditorPluginList::~EditorPluginList() {
+}
+        
 
 

--- a/tools/editor/editor_node.h
+++ b/tools/editor/editor_node.h
@@ -95,7 +95,7 @@
 
 typedef void (*EditorNodeInitCallback)();
 
-
+class EditorPluginList;
 
 class EditorNode : public Node {
 
@@ -372,7 +372,7 @@ private:
 
 	Vector<EditorPlugin*> editor_plugins;
 	EditorPlugin *editor_plugin_screen;
-	EditorPlugin *editor_plugin_over;
+	EditorPluginList *editor_plugins_over;
 
 	EditorHistory editor_history;
 	EditorData editor_data;
@@ -449,6 +449,10 @@ private:
 	void _transform_keyed(Object *sp,const String& p_sub,const Transform& p_key);
 
 	void _hide_top_editors();
+	void _display_top_editors(bool p_display);
+	void _set_top_editors(Vector<EditorPlugin*> p_editor_plugins_over);
+	void _set_editing_top_editors(Object * p_current_object);
+        
 	void _quick_opened();
 	void _quick_run();
 
@@ -575,7 +579,7 @@ public:
 
 
 	EditorPlugin *get_editor_plugin_screen() { return editor_plugin_screen; }
-	EditorPlugin *get_editor_plugin_over() { return editor_plugin_over; }
+	EditorPluginList *get_editor_plugins_over() { return editor_plugins_over; }
 	PropertyEditor *get_property_editor() { return property_editor; }
 
 	static void add_editor_plugin(EditorPlugin *p_editor);
@@ -709,6 +713,32 @@ struct EditorProgress {
 	EditorProgress(const String& p_task,const String& p_label,int p_amount) { EditorNode::progress_add_task(p_task,p_label,p_amount); task=p_task; }
 	~EditorProgress() { EditorNode::progress_end_task(task); }
 };
+
+class EditorPluginList : public Object {
+private:
+	Vector<EditorPlugin*> plugins_list;
+
+public:
+
+	void set_plugins_list(Vector<EditorPlugin*> p_plugins_list) {
+		plugins_list = p_plugins_list;
+	}
+
+	Vector<EditorPlugin*> get_plugins_list() {
+		return plugins_list;
+	}
+
+	void make_visible(bool p_visible);
+	void edit(Object *p_object);
+	bool forward_input_event(const InputEvent& p_event);
+	bool forward_spatial_input_event(Camera* p_camera, const InputEvent& p_event);
+	void clear();
+	bool empty();
+
+	EditorPluginList();
+	~EditorPluginList();
+
+} ; 
 
 struct EditorProgressBG {
 

--- a/tools/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/tools/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1037,10 +1037,10 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 	 {
 
 		EditorNode *en = editor;
-		EditorPlugin *over_plugin = en->get_editor_plugin_over();
+		EditorPluginList *over_plugin_list = en->get_editor_plugins_over();
 
-		if (over_plugin) {
-			bool discard = over_plugin->forward_input_event(p_event);
+		if (!over_plugin_list->empty()) {
+			bool discard = over_plugin_list->forward_input_event(p_event);
 			if (discard) {
 				accept_event();
 				return;

--- a/tools/editor/plugins/spatial_editor_plugin.cpp
+++ b/tools/editor/plugins/spatial_editor_plugin.cpp
@@ -810,10 +810,10 @@ void SpatialEditorViewport::_sinput(const InputEvent &p_event) {
 	{
 
 		EditorNode *en = editor;
-		EditorPlugin *over_plugin = en->get_editor_plugin_over();
+		EditorPluginList *over_plugin_list = en->get_editor_plugins_over();
 
-		if (over_plugin) {
-			bool discard = over_plugin->forward_spatial_input_event(camera,p_event);
+		if (!over_plugin_list->empty()) {
+			bool discard = over_plugin_list->forward_spatial_input_event(camera,p_event);
 			if (discard)
 				return;
 		}
@@ -3553,9 +3553,9 @@ void SpatialEditor::_unhandled_key_input(InputEvent p_event) {
 	{
 
 		EditorNode *en = editor;
-		EditorPlugin *over_plugin = en->get_editor_plugin_over();
+		EditorPluginList *over_plugin_list = en->get_editor_plugins_over();
 
-		if (over_plugin && over_plugin->forward_input_event(p_event)) {
+		if (!over_plugin_list->empty() && over_plugin_list->forward_input_event(p_event)) {
 
 			return; //ate the over input event
 		}

--- a/tools/editor/scene_tree_dock.cpp
+++ b/tools/editor/scene_tree_dock.cpp
@@ -1098,8 +1098,7 @@ void SceneTreeDock::_delete_confirm() {
 		return;
 
 
-	if (editor->get_editor_plugin_over())
-		editor->get_editor_plugin_over()->make_visible(false);
+	editor->get_editor_plugins_over()->make_visible(false);
 
 	editor_data->get_undo_redo().create_action("Remove Node(s)");
 


### PR DESCRIPTION
This is a small modification but may enable many possibilities. One of the possibilities is to create a plugin for a plugin and so on... e.g. Can create a plugin to handle an object of type Polygon2D.

One of main modification was the creation of the class `EditorPluginList`:

``` c++
class EditorPluginList : public Object{

    private:
        Vector<EditorPlugin*> plugins_list;

    public:
        void set_plugins_list(Vector<EditorPlugin*> p_plugins_list){ plugins_list = p_plugins_list; }
        Vector<EditorPlugin*> get_plugins_list(){ return plugins_list; }

        void make_visible(bool p_visible);
        void edit(Object *p_object);
        bool forward_input_event(const InputEvent& p_event);
        bool forward_spatial_input_event(Camera* p_camera,const InputEvent& p_event);
        void clear();
        bool empty();

        EditorPluginList();
        ~EditorPluginList();

}; 
```

This is nothing more than the information holder of current editors enabled. This is a wraper for actions to be executed simultaneously at all being edited plugins.

Now, instead of having one single top_editor_plugin, you can have multiple that will `handle()` the same Object type.

All the plugins that can handle the current selected editor object/resource is added to the list of editor plugins.

I already noticed that may be an inconsistency when were talking about event forwarding, because what I have implemented is: "When some plugin of the being edited list decide to discard the event, so ... DISCARD the event. ".

With this in mind, we can easily add a flag to define which plugins of the list have the priority to discard the events.

Well, it is my first contribution on third part github project, so I'm very excited whit that. I may be doing something wrong, but please correct me if I'm wrong. 

Hope it is cool for you, as it was for me. Thanks !
