### PR TITLE
inherit PKG_CONFIG_PATH from environment

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -63,7 +63,12 @@ elif (os.name=="nt"):
 	if (os.getenv("VSINSTALLDIR")==None or platform_arg=="android"):
 		custom_tools=['mingw']
 
-env_base=Environment(tools=custom_tools,ENV = {'PATH' : os.environ['PATH']});
+env_base=Environment(
+	tools=custom_tools,
+	ENV={
+		'PATH' : os.getenv('PATH'),
+		'PKG_CONFIG_PATH' : os.getenv('PKG_CONFIG_PATH')
+});
 
 #env_base=Environment(tools=custom_tools);
 env_base.global_defaults=global_defaults


### PR DESCRIPTION
Allows pkg-config to read files from custom install directories during build.

This addresses issue #4161
