### PR TITLE
Progress bar minsize now checks percent_visible

### DIFF
--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -35,7 +35,9 @@ Size2 ProgressBar::get_minimum_size() const {
 	Ref<Font> font = get_font("font");
 
 	Size2 ms=bg->get_minimum_size()+bg->get_center_size();
-	ms.height=MAX(ms.height,bg->get_minimum_size().height+font->get_height());
+	if (percent_visible) {
+		ms.height=MAX(ms.height,bg->get_minimum_size().height+font->get_height());
+	}
 	return ms;
 }
 


### PR DESCRIPTION
Allows for really thin progress bars such as for pixel-art styles (e.g. 2 pixels high).
