### PR TITLE
Fix for memory leak: rasterizer_gles2.cpp

### DIFF
--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -11050,6 +11050,7 @@ void RasterizerGLES2::finish() {
 
 	free(default_material);
 	free(shadow_material);
+	free(shadow_material_double_sided);
 	free(canvas_shadow_blur);
 	free( overdraw_material );
 }


### PR DESCRIPTION
Valgrind found a memory leak in **godot/drivers/gles2/rasterizer_gles2.cpp**:

```
2,008 (120 direct, 1,888 indirect) bytes in 1 blocks are definitely lost in loss record 760 of 786
  in MemoryPoolStaticMalloc::_alloc(unsigned long, char const*) in godot/drivers/unix/memory_pool_static_malloc.cpp:79
  1: malloc in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so
  2: MemoryPoolStaticMalloc::_alloc(unsigned long, char const*) in godot/drivers/unix/memory_pool_static_malloc.cpp:79
  3: MemoryPoolStaticMalloc::alloc(unsigned long, char const*) in godot/drivers/unix/memory_pool_static_malloc.cpp:47
  4: Memory::alloc_static(unsigned long, char const*) in godot/core/os/memory.cpp:48
  5: operator new(unsigned long, char const*) in godot/core/os/memory.cpp:35
  6: RasterizerGLES2::material_create() in godot/drivers/gles2/rasterizer_gles2.cpp:1670
  7: RasterizerGLES2::init() in godot/drivers/gles2/rasterizer_gles2.cpp:11006
  8: VisualServerRaster::init() in godot/servers/visual/visual_server_raster.cpp:7639
  9: VisualServerWrapMT::init() in godot/servers/visual/visual_server_wrap_mt.cpp:156
  10: OS_X11::initialize(OS::VideoMode const&, int, int) in godot/platform/x11/os_x11.cpp:419
  11: Main::setup2() in godot/main/main.cpp:857
  12: Main::setup(char const*, int, char**, bool) in godot/main/main.cpp:801
  13: main in godot/platform/x11/godot_x11.cpp:36
```

The Material `shadow_material_double_sided` is created here:
- [godot/drivers/gles2/rasterizer_gles2.cpp:11006](https://github.com/godotengine/godot/blob/master/drivers/gles2/rasterizer_gles2.cpp#L11006)

This fix only frees the Material `shadow_material_double_sided` on ::finish()
