### PR TITLE
dictionary has_all

### DIFF
--- a/core/dictionary.cpp
+++ b/core/dictionary.cpp
@@ -110,6 +110,16 @@ bool Dictionary::has(const Variant& p_key) const {
 
 	return _p->variant_map.has(p_key);
 }
+
+bool Dictionary::has_all(const Array& p_keys) const {
+	for (int i=0;i<p_keys.size();i++) {
+		if( !has(p_keys[i]) ) {
+			return false;
+		}
+	}
+	return true;
+}
+
 void Dictionary::erase(const Variant& p_key) {
 	_copy_on_write();
 	_p->variant_map.erase(p_key);

--- a/core/dictionary.h
+++ b/core/dictionary.h
@@ -69,6 +69,8 @@ public:
 	bool is_shared() const;
 
 	bool has(const Variant& p_key) const;
+	bool has_all(const Array& p_keys) const;
+
 	void erase(const Variant& p_key);
 
 	bool operator==(const Dictionary& p_dictionary) const;

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -440,6 +440,7 @@ static void _call_##m_type##_##m_method(Variant& r_ret,Variant& p_self,const Var
 	VCALL_LOCALMEM0R(Dictionary,empty);
 	VCALL_LOCALMEM0(Dictionary,clear);
 	VCALL_LOCALMEM1R(Dictionary,has);
+	VCALL_LOCALMEM1R(Dictionary,has_all);
 	VCALL_LOCALMEM1(Dictionary,erase);
 	VCALL_LOCALMEM0R(Dictionary,hash);
 	VCALL_LOCALMEM0R(Dictionary,keys);
@@ -1423,6 +1424,7 @@ _VariantCall::addfunc(Variant::m_vtype,Variant::m_ret,_SCS(#m_method),VCALL(m_cl
 	ADDFUNC0(DICTIONARY,BOOL,Dictionary,empty,varray());
 	ADDFUNC0(DICTIONARY,NIL,Dictionary,clear,varray());
 	ADDFUNC1(DICTIONARY,BOOL,Dictionary,has,NIL,"value",varray());
+	ADDFUNC1(DICTIONARY,BOOL,Dictionary,has_all,ARRAY,"values",varray());
 	ADDFUNC1(DICTIONARY,NIL,Dictionary,erase,NIL,"value",varray());
 	ADDFUNC0(DICTIONARY,INT,Dictionary,hash,varray());
 	ADDFUNC0(DICTIONARY,ARRAY,Dictionary,keys,varray());


### PR DESCRIPTION
closes #3629 

Tested with

```
var dict = {}
var a = [1,2,3]
dict[a] = "some"
dict["test"] = "text"
print(dict.has_all( ["test",[1,2]] ) ) # false

print(dict.has_all( ["test",[1,2,3]] ) ) # true
```
