### PR TITLE
Member variable syntax highlighting

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -672,6 +672,7 @@ void TextEdit::_notification(int p_what) {
 				bool in_keyword=false;
 				bool in_word = false;
 				bool in_function_name = false;
+				bool in_member_variable = false;
 				Color keyword_color;
 
 				// check if line contains highlighted word
@@ -803,14 +804,28 @@ void TextEdit::_notification(int p_what) {
 							}
 						}
 
+						if (!in_function_name && !in_member_variable && !in_keyword && !is_number && in_word) {
+							int k = j;
+							while(k > 0 && !_is_symbol(str[k]) && str[k] != '\t' && str[k] != ' ') {
+								k--;
+							}
+
+							if (str[k] == '.') {
+								in_member_variable = true;
+							}
+						}
+
 						if (is_symbol) {
 							in_function_name = false;
+							in_member_variable = false;
 						}
 
 						if (in_region>=0)
 							color=color_regions[in_region].color;
 						else if (in_keyword)
 							color=keyword_color;
+						else if (in_member_variable)
+							color=cache.member_variable_color;
 						else if (in_function_name)
 							color=cache.function_color;
 						else if (is_symbol)
@@ -3044,6 +3059,7 @@ void TextEdit::_update_caches() {
 	cache.font_selected_color=get_color("font_selected_color");
 	cache.keyword_color=get_color("keyword_color");
 	cache.function_color=get_color("function_color");
+	cache.member_variable_color=get_color("member_variable_color");
 	cache.number_color=get_color("number_color");
 	cache.selection_color=get_color("selection_color");
 	cache.mark_color=get_color("mark_color");

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -78,6 +78,7 @@ class TextEdit : public Control  {
 		Color keyword_color;
 		Color number_color;
 		Color function_color;
+		Color member_variable_color;
 		Color selection_color;
 		Color mark_color;
 		Color breakpoint_color;

--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -398,6 +398,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("text_editor/base_type_color",Color::html("a4ffd4"));
 	set("text_editor/engine_type_color",Color::html("83d3ff"));
 	set("text_editor/function_color",Color::html("66a2ce"));
+	set("text_editor/member_variable_color",Color::html("e64e59"));
 	set("text_editor/comment_color",Color::html("983d1b"));
 	set("text_editor/string_color",Color::html("ef6ebe"));
 	set("text_editor/number_color",Color::html("EB9532"));

--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -295,6 +295,7 @@ void ScriptTextEditor::_load_theme_settings() {
 	get_text_edit()->add_color_override("word_highlighted_color",EDITOR_DEF("text_editor/word_highlighted_color",Color(0.8,0.9,0.9,0.15)));
 	get_text_edit()->add_color_override("number_color",EDITOR_DEF("text_editor/number_color",Color(0.9,0.6,0.0,2)));
 	get_text_edit()->add_color_override("function_color",EDITOR_DEF("text_editor/function_color",Color(0.4,0.6,0.8)));
+	get_text_edit()->add_color_override("member_variable_color",EDITOR_DEF("text_editor/member_variable_color",Color(0.9,0.3,0.3)));
 
 	Color keyword_color= EDITOR_DEF("text_editor/keyword_color",Color(0.5,0.0,0.2));
 


### PR DESCRIPTION
Added syntax highlighting for member variables, basically any word after a `.` providing it is not a function, keyword or number.
