### PR TITLE
Fixed text edit undo and redo operation interaction

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1132,7 +1132,7 @@ void TextEdit::_consume_pair_symbol(CharType ch) {
 
 		int new_column,new_line;
 
-		_begin_complex_operation();
+		begin_complex_operation();
 		_insert_text(get_selection_from_line(), get_selection_from_column(),
 			     ch_single,
 			     &new_line, &new_column);
@@ -1145,7 +1145,7 @@ void TextEdit::_consume_pair_symbol(CharType ch) {
 			     get_selection_to_column() + to_col_offset,
 			     ch_single_pair,
 			     &new_line,&new_column);
-		_end_complex_operation();
+		end_complex_operation();
 
 		cursor_set_line(get_selection_to_line());
 		cursor_set_column(get_selection_to_column() + to_col_offset);
@@ -1599,7 +1599,7 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 
 								// remove the old character if in insert mode
 								if (insert_mode) {
-									_begin_complex_operation();
+									begin_complex_operation();
 
 									// make sure we don't try and remove empty space
 									if (cursor.column < get_line(cursor.line).length()) {
@@ -1610,7 +1610,7 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 								_insert_text_at_cursor(chr);
 
 								if (insert_mode) {
-									_end_complex_operation();
+									end_complex_operation();
 								}
 							}
 						}
@@ -1686,10 +1686,10 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 
 							cursor_set_line(selection.from_line);
 							cursor_set_column(selection.from_column);
-							_begin_complex_operation();
+							begin_complex_operation();
 							_remove_text(selection.from_line,selection.from_column,selection.to_line,selection.to_column);
 							_insert_text_at_cursor(txt);
-							_end_complex_operation();
+							end_complex_operation();
 							selection.active=true;
 							selection.from_column=sel_column;
 							selection.from_line=sel_line;
@@ -1747,7 +1747,7 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 				}
 				if (clear) {
 
-					_begin_complex_operation();
+					begin_complex_operation();
 					selection.active=false;
 					update();
 					_remove_text(selection.from_line,selection.from_column,selection.to_line,selection.to_column);
@@ -2396,7 +2396,7 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 
 					// remove the old character if in insert mode and no selection
 					if (insert_mode && !had_selection) {
-						_begin_complex_operation();
+						begin_complex_operation();
 
 						// make sure we don't try and remove empty space
 						if (cursor.column < get_line(cursor.line).length()) {
@@ -2416,11 +2416,11 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 					}
 
 					if (insert_mode && !had_selection) {
-						_end_complex_operation();
+						end_complex_operation();
 					}
 
 					if (selection.active != had_selection) {
-						_end_complex_operation();
+						end_complex_operation();
 					}
 					accept_event();
 				} else {
@@ -3613,12 +3613,12 @@ void TextEdit::clear_undo_history() {
 
 }
 
-void TextEdit::_begin_complex_operation() {
+void TextEdit::begin_complex_operation() {
 	_push_current_op();
 	next_operation_is_complex=true;
 }
 
-void TextEdit::_end_complex_operation() {
+void TextEdit::end_complex_operation() {
 
 	_push_current_op();
 	ERR_FAIL_COND(undo_stack.size() == 0);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -265,8 +265,6 @@ class TextEdit : public Control  {
 	void _cursor_changed_emit();
 	void _text_changed_emit();
 
-	void _begin_complex_operation();
-	void _end_complex_operation();
 	void _push_current_op();
 
 	/* super internal api, undo/redo builds on it */
@@ -317,6 +315,9 @@ public:
 
 	//void delete_char();
 	//void delete_line();
+
+	void begin_complex_operation();
+	void end_complex_operation();
 
 	void set_text(String p_text);
 	void insert_text_at_cursor(const String& p_text);

--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -1071,6 +1071,7 @@ void ScriptEditor::_menu_option(int p_option) {
 				if (scr.is_null())
 					return;
 
+				tx->begin_complex_operation();
 				if (tx->is_selection_active())
 				{
 					int from_line = tx->get_selection_from_line();
@@ -1102,6 +1103,7 @@ void ScriptEditor::_menu_option(int p_option) {
 
 					swap_lines(tx, line_id, next_id);
 				}
+				tx->end_complex_operation();
 				tx->update();
 
 			} break;
@@ -1112,6 +1114,7 @@ void ScriptEditor::_menu_option(int p_option) {
 				if (scr.is_null())
 					return;
 
+				tx->begin_complex_operation();
 				if (tx->is_selection_active())
 				{
 					int from_line = tx->get_selection_from_line();
@@ -1143,6 +1146,7 @@ void ScriptEditor::_menu_option(int p_option) {
 
 					swap_lines(tx, line_id, next_id);
 				}
+				tx->end_complex_operation();
 				tx->update();
 
 			} break;
@@ -1153,7 +1157,7 @@ void ScriptEditor::_menu_option(int p_option) {
 				if (scr.is_null())
 					return;
 
-
+				tx->begin_complex_operation();
 				if (tx->is_selection_active())
 				{
 					int begin = tx->get_selection_from_line();
@@ -1192,6 +1196,7 @@ void ScriptEditor::_menu_option(int p_option) {
 						tx->set_line(begin, line_text);
 					}
 				}
+				tx->end_complex_operation();
 				tx->update();
 				//tx->deselect();
 
@@ -1203,6 +1208,7 @@ void ScriptEditor::_menu_option(int p_option) {
 				if (scr.is_null())
 					return;
 
+				tx->begin_complex_operation();
 				if (tx->is_selection_active())
 				{
 					int begin = tx->get_selection_from_line();
@@ -1221,6 +1227,7 @@ void ScriptEditor::_menu_option(int p_option) {
 					line_text = '\t' + line_text;
 					tx->set_line(begin, line_text);
 				}
+				tx->end_complex_operation();
 				tx->update();
 				//tx->deselect();
 
@@ -1252,7 +1259,7 @@ void ScriptEditor::_menu_option(int p_option) {
 					return;
 
 
-
+				tx->begin_complex_operation();
 				if (tx->is_selection_active())
 				{
 					int begin = tx->get_selection_from_line();
@@ -1284,6 +1291,7 @@ void ScriptEditor::_menu_option(int p_option) {
 						line_text = "#" + line_text;
 					tx->set_line(begin, line_text);
 				}
+				tx->end_complex_operation();
 				tx->update();
 				//tx->deselect();
 


### PR DESCRIPTION
Fixes the undo and redo interaction with the text editor operations such as toggle comments, indent right, indent left e.t.c as mentioned [here](https://github.com/godotengine/godot/issues/4198#issuecomment-205062696) and [here.](https://github.com/godotengine/godot/issues/3803#issuecomment-189211158)
