### PR TITLE
Fix Ctrl+LaunchMedia showing up as a shortcut for "Make Bones"

### DIFF
--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -53,23 +53,7 @@ void MenuButton::_unhandled_key_input(InputEvent p_event) {
 			code|=KEY_MASK_SHIFT;
 
 
-		int item = popup->find_item_by_accelerator(code);
-
-
-		if (item>=0 && ! popup->is_item_disabled(item))
-			popup->activate_item(item);
-		/*
-		for(int i=0;i<items.size();i++) {
-
-
-			if (items[i].accel==0)
-				continue;
-
-			if (items[i].accel==code) {
-
-				emit_signal("item_pressed",items[i].ID);
-			}
-		}*/
+		int item = popup->activate_item_by_accelerator(code);
 	}
 
 }

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -740,15 +740,33 @@ int PopupMenu::get_item_count() const {
 	return items.size();
 }
 
-int PopupMenu::find_item_by_accelerator(uint32_t p_accel) const {
+bool PopupMenu::activate_item_by_accelerator(uint32_t p_accel) {
 
 	int il=items.size();
 	for(int i=0;i<il;i++) {
+		if (is_item_disabled(i))
+			continue;
 
-		if (items[i].accel==p_accel)
-			return i;
+		if (items[i].accel==p_accel) {
+			activate_item(i);
+			return true;
+		}
+
+		if (items[i].submenu!="") {
+			Node* n = get_node(items[i].submenu);
+			if(!n)
+				continue;
+
+			PopupMenu* pm = n->cast_to<PopupMenu>();
+			if(!pm)
+				continue;
+
+			if(pm->activate_item_by_accelerator(p_accel)) {
+				return true;
+			}
+		}
 	}
-	return -1;
+	return false;
 }
 
 void PopupMenu::activate_item(int p_item) {

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -117,7 +117,7 @@ public:
 
 	int get_item_count() const;
 
-	int find_item_by_accelerator(uint32_t p_accel) const;
+	bool activate_item_by_accelerator(uint32_t p_accel);
 	void activate_item(int p_item);
 
 	void remove_item(int p_idx);

--- a/tools/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/tools/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3345,7 +3345,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	PopupMenu *p2 = memnew(PopupMenu);
 	p->add_child(p2);
 	p2->set_name("skeleton");
-	p2->add_item("Make Bones",SKELETON_MAKE_BONES,KEY_MASK_CMD|KEY_SHIFT|KEY_B);
+	p2->add_item("Make Bones",SKELETON_MAKE_BONES,KEY_MASK_CMD|KEY_MASK_SHIFT|KEY_B);
 	p2->add_item("Clear Bones",SKELETON_CLEAR_BONES);
 	p2->add_separator();
 	p2->add_item("Make IK Chain",SKELETON_SET_IK_CHAIN);


### PR DESCRIPTION
Close #4044

This PR also fixes a bug with accelerator keys in submenus of PopupMenu.
