### PR TITLE
Updated nrex to v0.2

### DIFF
--- a/drivers/nrex/README.md
+++ b/drivers/nrex/README.md
@@ -1,6 +1,8 @@
 # NREX: Node RegEx
 
-Version 0.1
+[![Build Status](https://travis-ci.org/leezh/nrex.svg?branch=master)](https://travis-ci.org/leezh/nrex)
+
+** Version 0.2 **
 
 Small node-based regular expression library. It only does text pattern
 matchhing, not replacement. To use add the files `nrex.hpp`, `nrex.cpp`
@@ -38,7 +40,7 @@ Currently supported features:
 
 ## License
 
-Copyright (c) 2015, Zher Huei Lee
+Copyright (c) 2015-2016, Zher Huei Lee
 All rights reserved.
 
 This software is provided 'as-is', without any express or implied
@@ -59,3 +61,15 @@ freely, subject to the following restrictions:
     
  3. This notice may not be removed or altered from any source
     distribution.
+
+
+# Changes
+
+## Version 0.2 (2016-08-04)
+ * Fixed capturing groups matching to invalid results
+ * Fixed parents of recursive quantifiers not expanding properly
+ * Fixed LookAhead sometimes adding to result
+ * More verbose unit testing
+
+## Version 0.1 (2015-12-04)
+ * Initial release

--- a/drivers/nrex/nrex.hpp
+++ b/drivers/nrex/nrex.hpp
@@ -1,7 +1,7 @@
 //  NREX: Node RegEx
-//  Version 0.1
+//  Version 0.2
 //
-//  Copyright (c) 2015, Zher Huei Lee
+//  Copyright (c) 2015-2016, Zher Huei Lee
 //  All rights reserved.
 //
 //  This software is provided 'as-is', without any express or implied
@@ -57,7 +57,8 @@ class nrex_node;
 class nrex
 {
     private:
-        int _capturing;
+        unsigned int _capturing;
+        unsigned int _lookahead_depth;
         nrex_node* _root;
     public:
 


### PR DESCRIPTION
More updates I've made to https://github.com/leezh/nrex
- Fixed capturing groups matching to invalid results
- Fixed parents of recursive quantifiers not expanding properly
- Fixed LookAhead sometimes adding to result

Unit tests should ensure no breakages, but it's a bit limited at the moment. If anything breaks or isn't working do let me know and I'll add it to the test cases.
