### PR TITLE
Port collision and layer masks to 3D

### DIFF
--- a/scene/3d/area.cpp
+++ b/scene/3d/area.cpp
@@ -519,6 +519,60 @@ bool Area::overlaps_body(Node* p_body) const{
 	return E->get().in_tree;
 
 }
+void Area::set_collision_mask(uint32_t p_mask) {
+
+	collision_mask=p_mask;
+	PhysicsServer::get_singleton()->area_set_collision_mask(get_rid(),p_mask);
+}
+
+uint32_t Area::get_collision_mask() const {
+
+	return collision_mask;
+}
+void Area::set_layer_mask(uint32_t p_mask) {
+
+	layer_mask=p_mask;
+	PhysicsServer::get_singleton()->area_set_layer_mask(get_rid(),p_mask);
+}
+
+uint32_t Area::get_layer_mask() const {
+
+	return layer_mask;
+}
+
+void Area::set_collision_mask_bit(int p_bit, bool p_value) {
+
+	uint32_t mask = get_collision_mask();
+	if (p_value)
+		mask|=1<<p_bit;
+	else
+		mask&=~(1<<p_bit);
+	set_collision_mask(mask);
+
+}
+
+bool Area::get_collision_mask_bit(int p_bit) const{
+
+	return get_collision_mask()&(1<<p_bit);
+}
+
+
+void Area::set_layer_mask_bit(int p_bit, bool p_value) {
+
+	uint32_t mask = get_layer_mask();
+	if (p_value)
+		mask|=1<<p_bit;
+	else
+		mask&=~(1<<p_bit);
+	set_layer_mask(mask);
+
+}
+
+bool Area::get_layer_mask_bit(int p_bit) const{
+
+	return get_layer_mask()&(1<<p_bit);
+}
+
 
 void Area::_bind_methods() {
 
@@ -551,6 +605,18 @@ void Area::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("set_priority","priority"),&Area::set_priority);
 	ObjectTypeDB::bind_method(_MD("get_priority"),&Area::get_priority);
+
+	ObjectTypeDB::bind_method(_MD("set_collision_mask","collision_mask"),&Area::set_collision_mask);
+	ObjectTypeDB::bind_method(_MD("get_collision_mask"),&Area::get_collision_mask);
+
+	ObjectTypeDB::bind_method(_MD("set_layer_mask","layer_mask"),&Area::set_layer_mask);
+	ObjectTypeDB::bind_method(_MD("get_layer_mask"),&Area::get_layer_mask);
+
+	ObjectTypeDB::bind_method(_MD("set_collision_mask_bit","bit","value"),&Area::set_collision_mask_bit);
+	ObjectTypeDB::bind_method(_MD("get_collision_mask_bit","bit"),&Area::get_collision_mask_bit);
+
+	ObjectTypeDB::bind_method(_MD("set_layer_mask_bit","bit","value"),&Area::set_layer_mask_bit);
+	ObjectTypeDB::bind_method(_MD("get_layer_mask_bit","bit"),&Area::get_layer_mask_bit);
 
 	ObjectTypeDB::bind_method(_MD("set_monitorable","enable"),&Area::set_monitorable);
 	ObjectTypeDB::bind_method(_MD("is_monitorable"),&Area::is_monitorable);
@@ -589,6 +655,8 @@ void Area::_bind_methods() {
 	ADD_PROPERTY( PropertyInfo(Variant::INT,"priority",PROPERTY_HINT_RANGE,"0,128,1"),_SCS("set_priority"),_SCS("get_priority"));
 	ADD_PROPERTY( PropertyInfo(Variant::BOOL,"monitoring"),_SCS("set_enable_monitoring"),_SCS("is_monitoring_enabled"));
 	ADD_PROPERTY( PropertyInfo(Variant::BOOL,"monitorable"),_SCS("set_monitorable"),_SCS("is_monitorable"));
+	ADD_PROPERTY( PropertyInfo(Variant::INT,"collision/layers",PROPERTY_HINT_ALL_FLAGS),_SCS("set_layer_mask"),_SCS("get_layer_mask"));
+	ADD_PROPERTY( PropertyInfo(Variant::INT,"collision/mask",PROPERTY_HINT_ALL_FLAGS),_SCS("set_collision_mask"),_SCS("get_collision_mask"));
 
 }
 
@@ -604,6 +672,8 @@ Area::Area() : CollisionObject(PhysicsServer::get_singleton()->area_create(),tru
 	angular_damp=1;
 	priority=0;
 	monitoring=false;
+	collision_mask=1;
+	layer_mask=1;
 	set_ray_pickable(false);
 	set_enable_monitoring(true);
 	set_monitorable(true);

--- a/scene/3d/area.h
+++ b/scene/3d/area.h
@@ -54,6 +54,8 @@ private:
 	real_t gravity_distance_scale;
 	real_t angular_damp;
 	real_t linear_damp;
+	uint32_t collision_mask;
+	uint32_t layer_mask;
 	int priority;
 	bool monitoring;
 	bool monitorable;
@@ -156,6 +158,18 @@ public:
 
 	void set_monitorable(bool p_enable);
 	bool is_monitorable() const;
+
+	void set_collision_mask(uint32_t p_mask);
+	uint32_t get_collision_mask() const;
+
+	void set_layer_mask(uint32_t p_mask);
+	uint32_t get_layer_mask() const;
+
+	void set_collision_mask_bit(int p_bit, bool p_value);
+	bool get_collision_mask_bit(int p_bit) const;
+
+	void set_layer_mask_bit(int p_bit, bool p_value);
+	bool get_layer_mask_bit(int p_bit) const;
 
 	Array get_overlapping_bodies() const;
 	Array get_overlapping_areas() const; //function for script

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -69,6 +69,50 @@ uint32_t PhysicsBody::get_layer_mask() const {
 	return layer_mask;
 }
 
+void PhysicsBody::set_collision_mask(uint32_t p_mask) {
+
+	collision_mask=p_mask;
+	PhysicsServer::get_singleton()->body_set_collision_mask(get_rid(),p_mask);
+}
+
+uint32_t PhysicsBody::get_collision_mask() const {
+
+	return collision_mask;
+}
+
+void PhysicsBody::set_collision_mask_bit(int p_bit, bool p_value) {
+
+	uint32_t mask = get_collision_mask();
+	if (p_value)
+		mask|=1<<p_bit;
+	else
+		mask&=~(1<<p_bit);
+	set_collision_mask(mask);
+
+}
+
+bool PhysicsBody::get_collision_mask_bit(int p_bit) const{
+
+	return get_collision_mask()&(1<<p_bit);
+}
+
+
+void PhysicsBody::set_layer_mask_bit(int p_bit, bool p_value) {
+
+	uint32_t mask = get_layer_mask();
+	if (p_value)
+		mask|=1<<p_bit;
+	else
+		mask&=~(1<<p_bit);
+	set_layer_mask(mask);
+
+}
+
+bool PhysicsBody::get_layer_mask_bit(int p_bit) const{
+
+	return get_layer_mask()&(1<<p_bit);
+}
+
 void PhysicsBody::add_collision_exception_with(Node* p_node) {
 
 	ERR_FAIL_NULL(p_node);
@@ -92,17 +136,42 @@ void PhysicsBody::remove_collision_exception_with(Node* p_node) {
 	PhysicsServer::get_singleton()->body_remove_collision_exception(get_rid(),physics_body->get_rid());
 }
 
+void PhysicsBody::_set_layers(uint32_t p_mask) {
+	set_layer_mask(p_mask);
+	set_collision_mask(p_mask);
+}
+
+uint32_t PhysicsBody::_get_layers() const{
+
+	return get_layer_mask();
+}
 
 void PhysicsBody::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_layer_mask","mask"),&PhysicsBody::set_layer_mask);
 	ObjectTypeDB::bind_method(_MD("get_layer_mask"),&PhysicsBody::get_layer_mask);
-	ADD_PROPERTY(PropertyInfo(Variant::INT,"layers",PROPERTY_HINT_ALL_FLAGS),_SCS("set_layer_mask"),_SCS("get_layer_mask"));
+
+	ObjectTypeDB::bind_method(_MD("set_collision_mask","mask"),&PhysicsBody::set_collision_mask);
+	ObjectTypeDB::bind_method(_MD("get_collision_mask"),&PhysicsBody::get_collision_mask);
+
+	ObjectTypeDB::bind_method(_MD("set_collision_mask_bit","bit","value"),&PhysicsBody::set_collision_mask_bit);
+	ObjectTypeDB::bind_method(_MD("get_collision_mask_bit","bit"),&PhysicsBody::get_collision_mask_bit);
+
+	ObjectTypeDB::bind_method(_MD("set_layer_mask_bit","bit","value"),&PhysicsBody::set_layer_mask_bit);
+	ObjectTypeDB::bind_method(_MD("get_layer_mask_bit","bit"),&PhysicsBody::get_layer_mask_bit);
+
+	ObjectTypeDB::bind_method(_MD("_set_layers","mask"),&PhysicsBody::_set_layers);
+	ObjectTypeDB::bind_method(_MD("_get_layers"),&PhysicsBody::_get_layers);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT,"layers",PROPERTY_HINT_ALL_FLAGS,"",0),_SCS("_set_layers"),_SCS("_get_layers")); //for backwards compat
+	ADD_PROPERTY(PropertyInfo(Variant::INT,"collision/layers",PROPERTY_HINT_ALL_FLAGS),_SCS("set_layer_mask"),_SCS("get_layer_mask"));
+	ADD_PROPERTY(PropertyInfo(Variant::INT,"collision/mask",PROPERTY_HINT_ALL_FLAGS),_SCS("set_collision_mask"),_SCS("get_collision_mask"));
 }
 
 
 PhysicsBody::PhysicsBody(PhysicsServer::BodyMode p_mode) : CollisionObject( PhysicsServer::get_singleton()->body_create(p_mode), false) {
 
 	layer_mask=1;
+	collision_mask=1;
 
 }
 

--- a/scene/3d/physics_body.h
+++ b/scene/3d/physics_body.h
@@ -39,6 +39,11 @@ class PhysicsBody : public CollisionObject {
 	OBJ_TYPE(PhysicsBody,CollisionObject);
 
 	uint32_t layer_mask;
+	uint32_t collision_mask;
+
+	void _set_layers(uint32_t p_mask);
+	uint32_t _get_layers() const;
+
 protected:
 
 	static void _bind_methods();
@@ -52,6 +57,15 @@ public:
 
 	void set_layer_mask(uint32_t p_mask);
 	uint32_t get_layer_mask() const;
+
+	void set_collision_mask(uint32_t p_mask);
+	uint32_t get_collision_mask() const;
+
+	void set_layer_mask_bit(int p_bit, bool p_value);
+	bool get_layer_mask_bit(int p_bit) const;
+
+	void set_collision_mask_bit(int p_bit, bool p_value);
+	bool get_collision_mask_bit(int p_bit) const;
 
 	void add_collision_exception_with(Node* p_node); //must be physicsbody
 	void remove_collision_exception_with(Node* p_node);

--- a/scene/3d/ray_cast.cpp
+++ b/scene/3d/ray_cast.cpp
@@ -43,6 +43,26 @@ Vector3 RayCast::get_cast_to() const{
 	return cast_to;
 }
 
+void RayCast::set_layer_mask(uint32_t p_mask) {
+
+	layer_mask=p_mask;
+}
+
+uint32_t RayCast::get_layer_mask() const {
+
+	return layer_mask;
+}
+
+void RayCast::set_type_mask(uint32_t p_mask) {
+
+	type_mask=p_mask;
+}
+
+uint32_t RayCast::get_type_mask() const {
+
+	return type_mask;
+}
+
 bool RayCast::is_colliding() const{
 
 	return collided;
@@ -130,7 +150,7 @@ void RayCast::_notification(int p_what) {
 
 			PhysicsDirectSpaceState::RayResult rr;
 
-			if (dss->intersect_ray(gt.get_origin(),gt.xform(to),rr,exclude)) {
+			if (dss->intersect_ray(gt.get_origin(),gt.xform(to),rr,exclude, layer_mask, type_mask)) {
 
 				collided=true;
 				against=rr.collider_id;
@@ -206,8 +226,16 @@ void RayCast::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("clear_exceptions"),&RayCast::clear_exceptions);
 
+	ObjectTypeDB::bind_method(_MD("set_layer_mask","mask"),&RayCast::set_layer_mask);
+	ObjectTypeDB::bind_method(_MD("get_layer_mask"),&RayCast::get_layer_mask);
+
+	ObjectTypeDB::bind_method(_MD("set_type_mask","mask"),&RayCast::set_type_mask);
+	ObjectTypeDB::bind_method(_MD("get_type_mask"),&RayCast::get_type_mask);
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL,"enabled"),_SCS("set_enabled"),_SCS("is_enabled"));
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3,"cast_to"),_SCS("set_cast_to"),_SCS("get_cast_to"));
+	ADD_PROPERTY(PropertyInfo(Variant::INT,"layer_mask",PROPERTY_HINT_ALL_FLAGS),_SCS("set_layer_mask"),_SCS("get_layer_mask"));
+	ADD_PROPERTY(PropertyInfo(Variant::INT,"type_mask",PROPERTY_HINT_FLAGS,"Static,Kinematic,Rigid,Character,Area"),_SCS("set_type_mask"),_SCS("get_type_mask"));
 }
 
 RayCast::RayCast() {
@@ -216,5 +244,7 @@ RayCast::RayCast() {
 	against=0;
 	collided=false;
 	against_shape=0;
+	layer_mask=1;
+	type_mask=PhysicsDirectSpaceState::TYPE_MASK_COLLISION;
 	cast_to=Vector3(0,-1,0);
 }

--- a/scene/3d/ray_cast.h
+++ b/scene/3d/ray_cast.h
@@ -47,6 +47,9 @@ class RayCast : public Spatial {
 
 	Set<RID> exclude;
 
+	uint32_t layer_mask;
+	uint32_t type_mask;
+
 protected:
 
 	void _notification(int p_what);
@@ -58,6 +61,12 @@ public:
 
 	void set_cast_to(const Vector3& p_point);
 	Vector3 get_cast_to() const;
+
+	void set_layer_mask(uint32_t p_mask);
+	uint32_t get_layer_mask() const;
+
+	void set_type_mask(uint32_t p_mask);
+	uint32_t get_type_mask() const;
 
 	bool is_colliding() const;
 	Object *get_collider() const;

--- a/servers/physics/area_pair_sw.cpp
+++ b/servers/physics/area_pair_sw.cpp
@@ -32,6 +32,11 @@
 
 bool AreaPairSW::setup(float p_step) {
 
+	if (!area->test_collision_mask(body)) {
+		colliding = false;
+		return false;
+	}
+
 	bool result = CollisionSolverSW::solve_static(body->get_shape(body_shape),body->get_transform() * body->get_shape_transform(body_shape),area->get_shape(area_shape),area->get_transform() * area->get_shape_transform(area_shape),NULL,this);
 
 	if (result!=colliding) {
@@ -99,6 +104,11 @@ AreaPairSW::~AreaPairSW() {
 
 
 bool Area2PairSW::setup(float p_step) {
+
+	if (!area_a->test_collision_mask(area_b)) {
+		colliding = false;
+		return false;
+	}
 
 //	bool result = area_a->test_collision_mask(area_b) && CollisionSolverSW::solve(area_a->get_shape(shape_a),area_a->get_transform() * area_a->get_shape_transform(shape_a),Vector2(),area_b->get_shape(shape_b),area_b->get_transform() * area_b->get_shape_transform(shape_b),Vector2(),NULL,this);
 	bool result = CollisionSolverSW::solve_static(area_a->get_shape(shape_a),area_a->get_transform() * area_a->get_shape_transform(shape_a),area_b->get_shape(shape_b),area_b->get_transform() * area_b->get_shape_transform(shape_b),NULL,this);

--- a/servers/physics/body_pair_sw.cpp
+++ b/servers/physics/body_pair_sw.cpp
@@ -221,7 +221,7 @@ bool BodyPairSW::_test_ccd(float p_step,BodySW *p_A, int p_shape_A,const Transfo
 bool BodyPairSW::setup(float p_step) {
 
 	//cannot collide
-	if ((A->get_layer_mask()&B->get_layer_mask())==0 || A->has_exception(B->get_self()) || B->has_exception(A->get_self()) || (A->get_mode()<=PhysicsServer::BODY_MODE_KINEMATIC && B->get_mode()<=PhysicsServer::BODY_MODE_KINEMATIC && A->get_max_contacts_reported()==0 && B->get_max_contacts_reported()==0)) {
+	if (!A->test_collision_mask(B) || A->has_exception(B->get_self()) || B->has_exception(A->get_self()) || (A->get_mode()<=PhysicsServer::BODY_MODE_KINEMATIC && B->get_mode()<=PhysicsServer::BODY_MODE_KINEMATIC && A->get_max_contacts_reported()==0 && B->get_max_contacts_reported()==0)) {
 		collided=false;
 		return false;
 	}

--- a/servers/physics/collision_object_sw.cpp
+++ b/servers/physics/collision_object_sw.cpp
@@ -217,5 +217,6 @@ CollisionObjectSW::CollisionObjectSW(Type p_type) {
 	space=NULL;
 	instance_id=0;
 	layer_mask=1;
+	collision_mask=1;
 	ray_pickable=true;
 }

--- a/servers/physics/collision_object_sw.h
+++ b/servers/physics/collision_object_sw.h
@@ -53,6 +53,7 @@ private:
 	RID self;
 	ObjectID instance_id;
 	uint32_t layer_mask;
+	uint32_t collision_mask;
 
 	struct Shape {
 
@@ -135,6 +136,13 @@ public:
 
 	_FORCE_INLINE_ void set_layer_mask(uint32_t p_mask) { layer_mask=p_mask; }
 	_FORCE_INLINE_ uint32_t get_layer_mask() const { return layer_mask; }
+
+	_FORCE_INLINE_ void set_collision_mask(uint32_t p_mask) { collision_mask=p_mask; }
+	_FORCE_INLINE_ uint32_t get_collision_mask() const { return collision_mask; }
+
+	_FORCE_INLINE_ bool test_collision_mask(CollisionObjectSW* p_other) const {
+		return layer_mask&p_other->collision_mask || p_other->layer_mask&collision_mask;
+	}
 
 	void remove_shape(ShapeSW *p_shape);
 	void remove_shape(int p_index);

--- a/servers/physics/physics_server_sw.cpp
+++ b/servers/physics/physics_server_sw.cpp
@@ -418,6 +418,22 @@ Transform PhysicsServerSW::area_get_transform(RID p_area) const {
 	return area->get_transform();
 };
 
+void PhysicsServerSW::area_set_layer_mask(RID p_area,uint32_t p_mask) {
+
+	AreaSW *area = area_owner.get(p_area);
+	ERR_FAIL_COND(!area);
+
+	area->set_layer_mask(p_mask);
+}
+
+void PhysicsServerSW::area_set_collision_mask(RID p_area,uint32_t p_mask) {
+
+	AreaSW *area = area_owner.get(p_area);
+	ERR_FAIL_COND(!area);
+
+	area->set_collision_mask(p_mask);
+}
+
 void PhysicsServerSW::area_set_monitorable(RID p_area,bool p_monitorable) {
 
 	AreaSW *area = area_owner.get(p_area);
@@ -654,6 +670,25 @@ uint32_t PhysicsServerSW::body_get_layer_mask(RID p_body, uint32_t p_mask) const
 	ERR_FAIL_COND_V(!body,0);
 
 	return body->get_layer_mask();
+
+}
+
+void PhysicsServerSW::body_set_collision_mask(RID p_body, uint32_t p_mask) {
+
+	BodySW *body = body_owner.get(p_body);
+	ERR_FAIL_COND(!body);
+
+	body->set_collision_mask(p_mask);
+	body->wakeup();
+
+}
+
+uint32_t PhysicsServerSW::body_get_collision_mask(RID p_body, uint32_t p_mask) const{
+
+	const BodySW *body = body_owner.get(p_body);
+	ERR_FAIL_COND_V(!body,0);
+
+	return body->get_collision_mask();
 
 }
 

--- a/servers/physics/physics_server_sw.h
+++ b/servers/physics/physics_server_sw.h
@@ -131,6 +131,9 @@ public:
 	virtual void area_set_ray_pickable(RID p_area,bool p_enable);
 	virtual bool area_is_ray_pickable(RID p_area) const;
 
+	virtual void area_set_collision_mask(RID p_area,uint32_t p_mask);
+	virtual void area_set_layer_mask(RID p_area,uint32_t p_mask);
+
 	virtual void area_set_monitorable(RID p_area,bool p_monitorable);
 
 	virtual void area_set_monitor_callback(RID p_area,Object *p_receiver,const StringName& p_method);
@@ -170,6 +173,9 @@ public:
 
 	virtual void body_set_layer_mask(RID p_body, uint32_t p_mask);
 	virtual uint32_t body_get_layer_mask(RID p_body, uint32_t p_mask) const;
+
+	virtual void body_set_collision_mask(RID p_body, uint32_t p_mask);
+	virtual uint32_t body_get_collision_mask(RID p_body, uint32_t p_mask) const;
 
 	virtual void body_set_user_flags(RID p_body, uint32_t p_flags);
 	virtual uint32_t body_get_user_flags(RID p_body, uint32_t p_flags) const;

--- a/servers/physics_server.cpp
+++ b/servers/physics_server.cpp
@@ -457,6 +457,8 @@ void PhysicsServer::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("area_remove_shape","area","shape_idx"),&PhysicsServer::area_remove_shape);
 	ObjectTypeDB::bind_method(_MD("area_clear_shapes","area"),&PhysicsServer::area_clear_shapes);
 
+	ObjectTypeDB::bind_method(_MD("area_set_layer_mask","area","mask"),&PhysicsServer::area_set_layer_mask);
+	ObjectTypeDB::bind_method(_MD("area_set_collision_mask","area","mask"),&PhysicsServer::area_set_collision_mask);
 
 	ObjectTypeDB::bind_method(_MD("area_set_param","area","param","value"),&PhysicsServer::area_set_param);
 	ObjectTypeDB::bind_method(_MD("area_set_transform","area","transform"),&PhysicsServer::area_set_transform);
@@ -479,6 +481,12 @@ void PhysicsServer::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("body_set_mode","body","mode"),&PhysicsServer::body_set_mode);
 	ObjectTypeDB::bind_method(_MD("body_get_mode","body"),&PhysicsServer::body_get_mode);
+
+	ObjectTypeDB::bind_method(_MD("body_set_layer_mask","body","mask"),&PhysicsServer::body_set_layer_mask);
+	ObjectTypeDB::bind_method(_MD("body_get_layer_mask","body"),&PhysicsServer::body_get_layer_mask);
+
+	ObjectTypeDB::bind_method(_MD("body_set_collision_mask","body","mask"),&PhysicsServer::body_set_collision_mask);
+	ObjectTypeDB::bind_method(_MD("body_get_collision_mask","body"),&PhysicsServer::body_get_collision_mask);
 
 	ObjectTypeDB::bind_method(_MD("body_add_shape","body","shape","transform"),&PhysicsServer::body_add_shape,DEFVAL(Transform()));
 	ObjectTypeDB::bind_method(_MD("body_set_shape","body","shape_idx","shape"),&PhysicsServer::body_set_shape);

--- a/servers/physics_server.h
+++ b/servers/physics_server.h
@@ -346,6 +346,9 @@ public:
 	virtual Variant area_get_param(RID p_parea,AreaParameter p_param) const=0;
 	virtual Transform area_get_transform(RID p_area) const=0;
 
+	virtual void area_set_collision_mask(RID p_area,uint32_t p_mask)=0;
+	virtual void area_set_layer_mask(RID p_area,uint32_t p_mask)=0;
+
 	virtual void area_set_monitorable(RID p_area,bool p_monitorable)=0;
 
 	virtual void area_set_monitor_callback(RID p_area,Object *p_receiver,const StringName& p_method)=0;
@@ -396,6 +399,9 @@ public:
 
 	virtual void body_set_layer_mask(RID p_body, uint32_t p_mask)=0;
 	virtual uint32_t body_get_layer_mask(RID p_body, uint32_t p_mask) const=0;
+
+	virtual void body_set_collision_mask(RID p_body, uint32_t p_mask)=0;
+	virtual uint32_t body_get_collision_mask(RID p_body, uint32_t p_mask) const=0;
 
 	virtual void body_set_user_flags(RID p_body, uint32_t p_flags)=0;
 	virtual uint32_t body_get_user_flags(RID p_body, uint32_t p_flags) const=0;


### PR DESCRIPTION
Fixes #1759.
I added `type_mask` and `layer_mask` to Raycast nodes,  `collision_mask` and `layer_mask` to Area nodes, and `collision_mask` to PhysicsBody nodes.

I have tested the code, but I'm not sure if I've copied everything from 2D correctly, so it would be nice if you test it too :smile: (though I can just make another PR with missing content).
