### PR TITLE
AnimationTreePlayer: constructor now sets processing mode.

### DIFF
--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -1860,7 +1860,6 @@ AnimationTreePlayer::AnimationTreePlayer() {
 	out_name="out";
 	out->pos=Point2(40,40);
 	node_map.insert( out_name , out);
-	AnimationProcessMode animation_process_mode;
 	animation_process_mode = ANIMATION_PROCESS_IDLE;
 	processing = false;
 	active=false;


### PR DESCRIPTION
This doesn't affect issue #4271, but it _has_ to be a bug: the constructor was creating and setting a local variable and neglecting to set the object property with the same name.
