### PR TITLE
Made trackpad behaviour optional in 3D mode (issue #4265)

### DIFF
--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -451,6 +451,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("3d_editor/zoom_modifier",4);
 	hints["3d_editor/zoom_modifier"]=PropertyInfo(Variant::INT,"3d_editor/zoom_modifier",PROPERTY_HINT_ENUM,"None,Shift,Alt,Meta,Ctrl");
 	set("3d_editor/emulate_numpad",false);
+	set("3d_editor/trackpad_hint", false);
 
 	set("2d_editor/bone_width",5);
 	set("2d_editor/bone_color1",Color(1.0,1.0,1.0,0.9));

--- a/tools/editor/plugins/spatial_editor_plugin.cpp
+++ b/tools/editor/plugins/spatial_editor_plugin.cpp
@@ -1579,7 +1579,8 @@ void SpatialEditorViewport::_sinput(const InputEvent &p_event) {
 					if (m.mod.alt)
 						nav_mode = NAVIGATION_PAN;
 				}
-			}else{
+
+			} else if (EditorSettings::get_singleton()->get("3d_editor/trackpad_hint")) {
 				// Handle trackpad (no external mouse) use case
 				int mod = 0;
 				if (m.mod.shift)


### PR DESCRIPTION
Added an option in editor settings as a boolean "3d_editor/trackpad_hint". It is disabled by default.
