### PR TITLE
x11: Flush the X output buffer after changing mouse mode

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -541,6 +541,8 @@ void OS_X11::set_mouse_mode(MouseMode p_mode) {
 	} else {
 		do_mouse_warp=false;
 	}
+
+	XFlush(x11_display);
 }
 
 void OS_X11::warp_mouse_pos(const Point2& p_to) {


### PR DESCRIPTION
Ensures the event is received before a break happens.

Fixes #2232
