### PR TITLE
Added color themes to the text editor

### DIFF
--- a/tools/editor/editor_settings.h
+++ b/tools/editor/editor_settings.h
@@ -84,6 +84,9 @@ private:
 
 
 	void _load_defaults(Ref<ConfigFile> p_extra_config = NULL);
+	void _load_default_text_editor_theme();
+
+	bool _save_text_editor_theme(String p_file);
 
 	String project_config_path;
 
@@ -129,6 +132,12 @@ public:
 	Vector<String> get_recent_dirs() const;
 
 	void load_favorites();
+
+	void list_text_editor_themes();
+	void load_text_editor_theme();
+	bool import_text_editor_theme(String p_file);
+	bool save_text_editor_theme();
+	bool save_text_editor_theme_as(String p_file);
 
 	EditorSettings();
 	~EditorSettings();

--- a/tools/editor/plugins/script_editor_plugin.h
+++ b/tools/editor/plugins/script_editor_plugin.h
@@ -122,6 +122,10 @@ class ScriptEditor : public VBoxContainer {
 		FILE_SAVE,
 		FILE_SAVE_AS,
 		FILE_SAVE_ALL,
+		FILE_IMPORT_THEME,
+		FILE_RELOAD_THEME,
+		FILE_SAVE_THEME,
+		FILE_SAVE_THEME_AS,
 		FILE_CLOSE,
 		EDIT_UNDO,
 		EDIT_REDO,
@@ -179,12 +183,15 @@ class ScriptEditor : public VBoxContainer {
 	ItemList *script_list;
 	HSplitContainer *script_split;
 	TabContainer *tab_container;
+	EditorFileDialog *file_dialog;
 	FindReplaceDialog *find_replace_dialog;
 	GotoLineDialog *goto_line_dialog;
 	ConfirmationDialog *erase_tab_confirm;
 	ScriptCreateDialog *script_create_dialog;
 	ScriptEditorDebugger* debugger;
 	ToolButton *scripts_visible;
+
+	String current_theme;
 
 	TextureFrame *script_icon;
 	Label *script_name_label;
@@ -277,6 +284,8 @@ class ScriptEditor : public VBoxContainer {
 	void _update_script_colors();
 	void _update_modified_scripts_for_external_editor();
 
+	int file_dialog_option;
+	void _file_dialog_action(String p_file);
 
 	static ScriptEditor *script_editor;
 protected:

--- a/tools/editor/settings_config_dialog.cpp
+++ b/tools/editor/settings_config_dialog.cpp
@@ -45,6 +45,7 @@ void EditorSettingsDialog::_settings_changed() {
 
 
 	timer->start();
+	property_editor->get_property_editor()->update_tree(); // else color's won't update when theme is selected.
 }
 
 void EditorSettingsDialog::_settings_save() {
@@ -69,6 +70,8 @@ void EditorSettingsDialog::popup_edit_settings() {
 
 	if (!EditorSettings::get_singleton())
 		return;
+
+	EditorSettings::get_singleton()->list_text_editor_themes(); // make sure we have an up to date list of themes
 
 	property_editor->edit(EditorSettings::get_singleton());
 	property_editor->get_property_editor()->update_tree();


### PR DESCRIPTION
Adds themes for the code / text editor.

Firstly, i'm unsure if this is the best / godot way of going about this, so feel free to not merge.

With that said It creates a new folder called `text_editor_themes` under the .godot setting directory, that themes can be dropped in too. Theme files end in `.tet` for text editor theme. The layout of a `.tet` file follows the following format:

`color_name : html color code`

Themes are then selected via the editor setting with a drop down, the name of the theme is the same name as the file. The theme files are only read when changing themes via the drop down in the editor settings, or reloading themes via `file -> reload theme` inside the text editor.

The only real enforcement is a theme cannot be called `default` and themes must be placed inside of the  `text_editor_themes` directory.

closes #1656 
