### PR TITLE
Keep editable instances data when replacing tree root node

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1374,6 +1374,16 @@ bool Node::is_editable_instance(Node *p_node) const {
 	return data.editable_instances.has(p);
 }
 
+void Node::set_editable_instances(const HashMap<NodePath,int>& p_editable_instances) {
+
+	data.editable_instances=p_editable_instances;
+}
+
+HashMap<NodePath,int> Node::get_editable_instances() const {
+
+	return data.editable_instances;
+}
+
 
 #if 0
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -239,6 +239,8 @@ public:
 
 	void set_editable_instance(Node* p_node,bool p_editable);
 	bool is_editable_instance(Node* p_node) const;
+	void set_editable_instances(const HashMap<NodePath,int>& p_editable_instances);
+	HashMap<NodePath,int> get_editable_instances() const;
 
 
 	/* NOTIFICATIONS */

--- a/tools/editor/scene_tree_dock.cpp
+++ b/tools/editor/scene_tree_dock.cpp
@@ -1317,6 +1317,7 @@ void SceneTreeDock::_create() {
 		if (n==edited_scene) {
 			edited_scene=newnode;
 			editor->set_edited_scene(newnode);
+			newnode->set_editable_instances(n->get_editable_instances());
 		}
 
 		//small hack to make collisionshapes and other kind of nodes to work


### PR DESCRIPTION
Fixes #4297

Ping @reduz since I am not sure if we want to expose `data.editable_instances` to outsiders :)
