### PR TITLE
Exposed Control::focus_mode to the scene editor

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -5655,6 +5655,20 @@
 			Return the visual state used to draw the button. This is useful mainly when implementing your own draw code by either overriding _draw() or connecting to "draw" signal. The visual state of the button is defined by the DRAW_* enum.
 			</description>
 		</method>
+		<method name="set_enabled_focus_mode">
+			<argument index="0" name="mode" type="int">
+			</argument>
+			<description>
+			Sets the focus access mode to use when switching between enabled/disabled (see [method Control.set_focus_mode] and [method set_disabled]).
+			</description>
+		</method>
+		<method name="get_enabled_focus_mode" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+			Returns focus access mode used when switching between enabled/disabled (see [method Control.set_focus_mode] and [method set_disabled]).
+			</description>
+		</method>
 	</methods>
 	<signals>
 		<signal name="released">
@@ -9086,6 +9100,13 @@
 			</argument>
 			<description>
 			Set the focus access mode for the control (FOCUS_NONE, FOCUS_CLICK, FOCUS_ALL). Only one Control can be focused at the same time, and it will receive keyboard signals.
+			</description>
+		</method>
+		<method name="get_focus_mode" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+			Returns the focus access mode for the control (FOCUS_NONE, FOCUS_CLICK, FOCUS_ALL) (see [method set_focus_mode]).
 			</description>
 		</method>
 		<method name="has_focus" qualifiers="const">

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -289,7 +289,7 @@ void BaseButton::set_disabled(bool p_disabled) {
 	if (p_disabled)
 		set_focus_mode(FOCUS_NONE);
 	else
-		set_focus_mode(FOCUS_ALL);
+		set_focus_mode(enabled_focus_mode);
 }
 
 bool BaseButton::is_disabled() const {
@@ -377,7 +377,18 @@ bool BaseButton::get_click_on_press() const {
 	return status.click_on_press;
 }
 
+void BaseButton::set_enabled_focus_mode(FocusMode p_mode) {
 
+	enabled_focus_mode = p_mode;
+	if (!status.disabled) {
+		set_focus_mode( p_mode );
+	}
+}
+
+Control::FocusMode BaseButton::get_enabled_focus_mode() const {
+
+	return enabled_focus_mode;
+}
 
 
 void BaseButton::_bind_methods() {
@@ -393,6 +404,8 @@ void BaseButton::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_click_on_press","enable"),&BaseButton::set_click_on_press);
 	ObjectTypeDB::bind_method(_MD("get_click_on_press"),&BaseButton::get_click_on_press);
 	ObjectTypeDB::bind_method(_MD("get_draw_mode"),&BaseButton::get_draw_mode);
+	ObjectTypeDB::bind_method(_MD("set_enabled_focus_mode","mode"),&BaseButton::set_enabled_focus_mode);
+	ObjectTypeDB::bind_method(_MD("get_enabled_focus_mode"),&BaseButton::get_enabled_focus_mode);
 
 	BIND_VMETHOD(MethodInfo("_pressed"));
 	BIND_VMETHOD(MethodInfo("_toggled",PropertyInfo(Variant::BOOL,"pressed")));
@@ -404,6 +417,7 @@ void BaseButton::_bind_methods() {
 	ADD_PROPERTY( PropertyInfo( Variant::BOOL, "toggle_mode"), _SCS("set_toggle_mode"), _SCS("is_toggle_mode"));
 	ADD_PROPERTYNZ( PropertyInfo( Variant::BOOL, "is_pressed"), _SCS("set_pressed"), _SCS("is_pressed"));
 	ADD_PROPERTYNZ( PropertyInfo( Variant::BOOL, "click_on_press"), _SCS("set_click_on_press"), _SCS("get_click_on_press"));
+	ADD_PROPERTY( PropertyInfo( Variant::INT,"enabled_focus_mode", PROPERTY_HINT_ENUM, "None,Click,All" ), _SCS("set_enabled_focus_mode"), _SCS("get_enabled_focus_mode") );
 
 
 	BIND_CONSTANT( DRAW_NORMAL );
@@ -424,6 +438,7 @@ BaseButton::BaseButton() {
 	status.click_on_press=false;
 	status.pressing_button=0;
 	set_focus_mode( FOCUS_ALL );
+	enabled_focus_mode = FOCUS_ALL;
 	group=NULL;
 
 

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -42,6 +42,7 @@ class BaseButton : public Control {
 	OBJ_TYPE( BaseButton, Control );
 
 	bool toggle_mode;
+	FocusMode enabled_focus_mode;
 
 	struct Status {
 
@@ -96,6 +97,9 @@ public:
 
 	void set_click_on_press(bool p_click_on_press);
 	bool get_click_on_press() const;
+
+	void set_enabled_focus_mode(FocusMode p_mode);
+	FocusMode get_enabled_focus_mode() const;
 
 
 	BaseButton();

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2265,6 +2265,7 @@ void Control::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_area_as_parent_rect","margin"),&Control::set_area_as_parent_rect,DEFVAL(0));
 	ObjectTypeDB::bind_method(_MD("show_modal","exclusive"),&Control::show_modal,DEFVAL(false));
 	ObjectTypeDB::bind_method(_MD("set_focus_mode","mode"),&Control::set_focus_mode);
+	ObjectTypeDB::bind_method(_MD("get_focus_mode"),&Control::get_focus_mode);
 	ObjectTypeDB::bind_method(_MD("has_focus"),&Control::has_focus);
 	ObjectTypeDB::bind_method(_MD("grab_focus"),&Control::grab_focus);
 	ObjectTypeDB::bind_method(_MD("release_focus"),&Control::release_focus);

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1027,7 +1027,7 @@ void LineEdit::_bind_methods() {
 	ADD_PROPERTYNZ( PropertyInfo( Variant::INT, "max_length" ), _SCS("set_max_length"),_SCS("get_max_length") );
 	ADD_PROPERTYNO( PropertyInfo( Variant::BOOL, "editable" ), _SCS("set_editable"),_SCS("is_editable") );
 	ADD_PROPERTYNZ( PropertyInfo( Variant::BOOL, "secret" ), _SCS("set_secret"),_SCS("is_secret") );
-
+	ADD_PROPERTY( PropertyInfo( Variant::INT,"focus_mode", PROPERTY_HINT_ENUM, "None,Click,All" ), _SCS("set_focus_mode"), _SCS("get_focus_mode") );
 
 }
 

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -119,6 +119,6 @@ void LinkButton::_bind_methods() {
 
 LinkButton::LinkButton() {
 	underline_mode=UNDERLINE_MODE_ALWAYS;
-	set_focus_mode(FOCUS_NONE);
+	set_enabled_focus_mode(FOCUS_NONE);
 	set_default_cursor_shape(CURSOR_POINTING_HAND);
 }

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -123,7 +123,7 @@ MenuButton::MenuButton() {
 
 
 	set_flat(true);
-	set_focus_mode(FOCUS_NONE);
+	set_enabled_focus_mode(FOCUS_NONE);
 	popup = memnew( PopupMenu );
 	popup->hide();
 	add_child(popup);

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -237,6 +237,7 @@ void Slider::_bind_methods() {
 
 	ADD_PROPERTY( PropertyInfo( Variant::INT, "tick_count", PROPERTY_HINT_RANGE,"0,4096,1"), _SCS("set_ticks"), _SCS("get_ticks") );
         ADD_PROPERTY( PropertyInfo( Variant::BOOL, "ticks_on_borders" ), _SCS("set_ticks_on_borders"), _SCS("get_ticks_on_borders") );
+	ADD_PROPERTY( PropertyInfo( Variant::INT,"focus_mode", PROPERTY_HINT_ENUM, "None,Click,All" ), _SCS("set_focus_mode"), _SCS("get_focus_mode") );
 
 }
 


### PR DESCRIPTION
Allows fine-tuning of tab focusing without using scripts.

Exposed `get_focus_mode()` to the script
Added `focus_mode` to the property panels for line-edit and sliders
Added `enabled_focus_mode` to the property panels for buttons

enabled_focus_mode is used when button is enabled/disabled
