### PR TITLE
Fixed curve baking, now always start at origin point

### DIFF
--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -543,7 +543,8 @@ void Curve2D::_bake() const {
 	Vector2 pos=points[0].pos;
 	List<Vector2> pointlist;
 
-
+	pointlist.push_back(pos); //start always from origin
+	
 	for(int i=0;i<points.size()-1;i++) {
 
 		float step = 0.1; // at least 10 substeps ought to be enough?


### PR DESCRIPTION
Fix for https://github.com/godotengine/godot/issues/4318
Basically add always origin point to bake list on curve 2d
