### PR TITLE
BoneAttachments now position themselves instantly during bind.

### DIFF
--- a/scene/3d/bone_attachment.cpp
+++ b/scene/3d/bone_attachment.cpp
@@ -80,6 +80,7 @@ void BoneAttachment::_check_bind() {
 		int idx = sk->find_bone(bone_name);
 		if (idx!=-1) {
 			sk->bind_child_node_to_bone(idx,this);;
+			set_transform(sk->get_bone_global_pose(idx));
 			bound=true;
 		}
 	}


### PR DESCRIPTION
Simply makes it so that a BoneAttachment node will reposition itself to the bone it's attaching itself to instantly on a rebind. Makes working with this node in the editor a little bit easier to determine what's going to attach itself to where.
