### PR TITLE
Fix crash on TextEdit complex operations redo.

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3675,7 +3675,6 @@ void TextEdit::_push_current_op() {
 		return; // do nothing
 
 	if(next_operation_is_complex) {
-		current_op.chain_forward=true;
 		next_operation_is_complex=false;
 	}
 


### PR DESCRIPTION
A null pointer crash would occur before if you tried to redo past a complex operation in the text editor. This should resolve it.
