### PR TITLE
Add preview of the Camera2D's screen boundaries

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -37,8 +37,7 @@ void Camera2D::_update_scroll() {
 		return;
 
 	if (get_tree()->is_editor_hint()) {
-	//	update(); //will just be drawn
-		//??
+		update(); //will just be drawn
 		return;
 	}
 
@@ -85,7 +84,7 @@ Matrix32 Camera2D::get_camera_transform()  {
 
 		if (anchor_mode==ANCHOR_MODE_DRAG_CENTER) {
 
-			if (h_drag_enabled) {
+			if (h_drag_enabled && !get_tree()->is_editor_hint()) {
 				camera_pos.x = MIN( camera_pos.x, (new_camera_pos.x + screen_size.x * 0.5 * drag_margin[MARGIN_RIGHT]));
 				camera_pos.x = MAX( camera_pos.x, (new_camera_pos.x - screen_size.x * 0.5 * drag_margin[MARGIN_LEFT]));
 			} else {
@@ -97,7 +96,7 @@ Matrix32 Camera2D::get_camera_transform()  {
 				}
 			}
 
-			if (v_drag_enabled) {
+			if (v_drag_enabled && !get_tree()->is_editor_hint()) {
 
 				camera_pos.y = MIN( camera_pos.y, (new_camera_pos.y + screen_size.y * 0.5 * drag_margin[MARGIN_BOTTOM]));
 				camera_pos.y = MAX( camera_pos.y, (new_camera_pos.y - screen_size.y * 0.5 * drag_margin[MARGIN_TOP]));
@@ -118,7 +117,7 @@ Matrix32 Camera2D::get_camera_transform()  {
 
 
 
-		if (smoothing_enabled) {
+		if (smoothing_enabled && !get_tree()->is_editor_hint()) {
 
 			float c = smoothing*get_fixed_process_delta_time();
 			smoothed_camera_pos = ((camera_pos-smoothed_camera_pos)*c)+smoothed_camera_pos;
@@ -258,6 +257,34 @@ void Camera2D::_notification(int p_what) {
 			viewport=NULL;
 
 		} break;
+		case NOTIFICATION_DRAW: {
+
+			if (!is_inside_tree() || !get_tree()->is_editor_hint())
+				break;
+
+			Color area_axis_color(0.5, 0.42, 0.87, 0.63);
+			float area_axis_width = 1;
+			if(current)
+				area_axis_width = 3;
+
+			Matrix32 inv_camera_transform = get_camera_transform().affine_inverse();
+			Size2 screen_size = get_viewport_rect().size;
+
+			Vector2 screen_endpoints[4]= {
+				inv_camera_transform.xform(Vector2(0, 0)),
+				inv_camera_transform.xform(Vector2(screen_size.width,0)),
+				inv_camera_transform.xform(Vector2(screen_size.width, screen_size.height)),
+				inv_camera_transform.xform(Vector2(0, screen_size.height))
+			};
+
+			Matrix32 inv_transform = get_transform().affine_inverse(); // undo global space
+			draw_set_transform(inv_transform.get_origin(), inv_transform.get_rotation(), inv_transform.get_scale());
+
+			for(int i=0;i<4;i++) {
+				draw_line(screen_endpoints[i], screen_endpoints[(i+1)%4], area_axis_color, area_axis_width);
+			}
+
+		} break;
 	}
 }
 
@@ -383,7 +410,7 @@ void Camera2D::force_update_scroll() {
 void Camera2D::set_follow_smoothing(float p_speed) {
 
 	smoothing=p_speed;
-	if (smoothing>0)
+	if (smoothing>0 && !(is_inside_tree() && get_tree()->is_editor_hint()))
 		set_fixed_process(true);
 	else
 		set_fixed_process(false);


### PR DESCRIPTION
Closes #3365

This implementation does not apply smoothing _nor drag margins_ to the preview, which might be misleading in some cases (e.g. you still have to make sure the player can see what is displayed). This is not much of an issue though, since most of the time you would either position the camera at a starting location, or you would animate a non-interpolating camera around.
