### PR TITLE
Fix setting minimum size for autowrap labels in VBoxContainer and HBoxContainer

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -298,19 +298,15 @@ void Label::_notification(int p_what) {
 
 Size2 Label::get_minimum_size() const {
 
-	if (autowrap)
-		return Size2(1,1);
-	else {
+	// don't want to mutable everything
+	if(word_cache_dirty)
+		const_cast<Label*>(this)->regenerate_word_cache();
 
-		// don't want to mutable everything
-		if(word_cache_dirty)
-			const_cast<Label*>(this)->regenerate_word_cache();
+	Size2 ms=minsize;
+	if (clip || autowrap)
+		ms.width=1;
+	return ms;
 
-		Size2 ms=minsize;
-		if (clip)
-			ms.width=1;
-		return ms;
-	}
 }
 
 int Label::get_longest_line_width() const {
@@ -489,13 +485,13 @@ void Label::regenerate_word_cache() {
 
 	if (!autowrap) {
 		minsize.width=width;
-		if (max_lines_visible > 0 && line_count > max_lines_visible) {
-			minsize.height=(font->get_height() * max_lines_visible) + (line_spacing * (max_lines_visible - 1));
-		} else {
-			minsize.height=(font->get_height() * line_count)+(line_spacing * (line_count - 1));
-		}
 	}
 
+	if (max_lines_visible > 0 && line_count > max_lines_visible) {
+		minsize.height=(font->get_height() * max_lines_visible) + (line_spacing * (max_lines_visible - 1));
+	} else {
+		minsize.height=(font->get_height() * line_count)+(line_spacing * (line_count - 1));
+	}
 	word_cache_dirty=false;
 
 }


### PR DESCRIPTION
When you set autowrap to label in VBoxContainer it disappear. This little patch fix it for my projects.
For HboxContainer you must set min width or/and set horizontal size flags to expand if you want it grow with HboxContainer.
