### PR TITLE
Fixed wrong get_global_mouse_pos() caused by canvas_layer being null

### DIFF
--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -487,6 +487,19 @@ void CanvasItem::_enter_canvas() {
 
 	} else {
 
+		if (!canvas_layer) {
+			// Find CanvasLayer in parent nodes
+			Node *n = get_parent();
+			while (n) {
+				CanvasLayer * l_canvas_layer = n->cast_to<CanvasLayer>();
+				if (l_canvas_layer) {
+					canvas_layer = l_canvas_layer;
+					break;
+				}
+				n = n->get_parent();
+			}
+		}
+
 		CanvasItem *parent = get_parent_item();
 		VisualServer::get_singleton()->canvas_item_set_parent(canvas_item,parent->get_canvas_item());
 		parent->_queue_sort_children();


### PR DESCRIPTION
Fix proposal for issue #4368.
Check this sample for context: http://zylannprods.fr/dl/godot/GlobalMousePosLayer.zip
I noticed canvas_layer was null in node B, so I made it so it finds it in _enter_canvas.
Tell me if it's a correct fix or if I missed something, maybe it was null for a reason but after testing a few projects I don't see any trouble :)
