### PR TITLE
Fix continious update with Camera2D

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -240,6 +240,10 @@ void Camera2D::_notification(int p_what) {
 			add_to_group(group_name);
 			add_to_group(canvas_group_name);
 
+			if(get_tree()->is_editor_hint()) {
+				set_fixed_process(false);
+			}
+
 			_update_scroll();
 			first=true;
 


### PR DESCRIPTION
Closes #4406 

Seems like I forgot a simple way of getting into `fixed_process` callbacks still in the editor...

_Hint: `set_follow_smoothing` would trigger `set_fixed_process` while it is either out of the tree or not in the editor._
