### PR TITLE
Encode axis_value in Variant for InputEvent::JOYSTICK_MOTION.

### DIFF
--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -438,8 +438,9 @@ Error decode_variant(Variant& r_variant,const uint8_t *p_buffer, int p_len,int *
 				case InputEvent::JOYSTICK_MOTION: {
 
 					ie.joy_motion.axis=decode_uint32(&buf[12]);
+					ie.joy_motion.axis_value=decode_float(&buf[16]);
 					if (r_len)
-						(*r_len)+=4;
+						(*r_len)+=8;
 				} break;
 			}
 
@@ -1154,8 +1155,9 @@ Error encode_variant(const Variant& p_variant, uint8_t *r_buffer, int &r_len) {
 
 						int axis = ie.joy_motion.axis;
 						encode_uint32(axis,&buf[llen]);
+						encode_float(ie.joy_motion.axis_value, &buf[llen+4]);
 					}
-					llen+=4;
+					llen+=8;
 				} break;
 			}
 


### PR DESCRIPTION
Fixes a bug that caused InputMap actions which have been set to joystick axes
not to work correctly on exported builds as the `axis_value` property wouldn't be serialized into engine.cfb.
See recent discussion in #49 (Post 121+)
