### PR TITLE
More space to avoid the buttons are covered with other components.

### DIFF
--- a/tools/editor/project_manager.cpp
+++ b/tools/editor/project_manager.cpp
@@ -262,7 +262,7 @@ public:
 			pn->show();
 			project_name->show();
 
-			popup_centered(Size2(500,145));
+			popup_centered(Size2(500,175));
 
 		}
 


### PR DESCRIPTION
Dialogs have no enough space to contain thier children components when the font of editor is larger than default.
The default font kill my eyes on my 13.3-inch retina laptop screen with arch linux.
I have no ideal with other dialogs.
So I just fix the dialog for create new project.
