### PR TITLE
fix - HTTPClient connection keep-alive duplicate Headers #4208

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -303,6 +303,7 @@ Error HTTPClient::poll(){
 					chunked=false;
 					body_left=0;
 					chunk_left=0;
+					response_str.clear();
 					response_headers.clear();
 					response_num = RESPONSE_OK;
 


### PR DESCRIPTION
Strange that no one else had this issue.

It solves #4208.
