### PR TITLE
Make export GUI debug toggle more obvious

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -251,7 +251,7 @@ public:
 	virtual String get_device_info(int p_device) const;
 	virtual Error run(int p_device,int p_flags=0);
 
-	virtual bool requieres_password(bool p_debug) const { return !p_debug; }
+	virtual bool requires_password(bool p_debug) const { return !p_debug; }
 	virtual String get_binary_extension() const { return "apk"; }
 	virtual Error export_project(const String& p_path, bool p_debug, int p_flags=0);
 

--- a/platform/bb10/export/export.cpp
+++ b/platform/bb10/export/export.cpp
@@ -69,7 +69,7 @@ public:
 	virtual String get_device_info(int p_device) const;
 	virtual Error run(int p_device,int p_flags=0);
 
-	virtual bool requieres_password(bool p_debug) const { return !p_debug; }
+	virtual bool requires_password(bool p_debug) const { return !p_debug; }
 	virtual String get_binary_extension() const { return "bar"; }
 	virtual Error export_project(const String& p_path,bool p_debug,int p_flags=0);
 

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -86,7 +86,7 @@ public:
 	virtual String get_device_info(int p_device) const { return "Run exported HTML in the system's default browser."; }
 	virtual Error run(int p_device,int p_flags=0);
 
-	virtual bool requieres_password(bool p_debug) const { return false; }
+	virtual bool requires_password(bool p_debug) const { return false; }
 	virtual String get_binary_extension() const { return "html"; }
 	virtual Error export_project(const String& p_path,bool p_debug,int p_flags=0);
 

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -59,7 +59,7 @@ public:
 	virtual String get_device_info(int p_device) const { return String(); }
 	virtual Error run(int p_device,int p_flags=0);
 
-	virtual bool requieres_password(bool p_debug) const { return false; }
+	virtual bool requires_password(bool p_debug) const { return false; }
 	virtual String get_binary_extension() const { return "zip"; }
 	virtual Error export_project(const String& p_path,bool p_debug,int p_flags=0);
 

--- a/tools/editor/editor_import_export.cpp
+++ b/tools/editor/editor_import_export.cpp
@@ -294,6 +294,39 @@ static void _remove_filter_from_list(Set<StringName>& r_list,const String& p_fil
 	_edit_filter_list(r_list,p_filter,true);
 }
 
+bool EditorExportPlatform::_set(const StringName& p_name, const Variant& p_value) {
+
+	String n = p_name;
+
+	if (n=="debug/debugging_enabled") {
+		set_debugging_enabled(p_value);
+	} else {
+		return false;
+	}
+
+	return true;
+
+}
+
+bool EditorExportPlatform::_get(const StringName& p_name,Variant &r_ret) const {
+
+	String n = p_name;
+
+	if (n=="debug/debugging_enabled") {
+		r_ret=is_debugging_enabled();
+	} else {
+		return false;
+	}
+
+	return true;
+
+}
+
+void EditorExportPlatform::_get_property_list( List<PropertyInfo> *p_list) const {
+
+	p_list->push_front( PropertyInfo( Variant::BOOL, "debug/debugging_enabled"));
+}
+
 Vector<uint8_t> EditorExportPlatform::get_exported_file_default(String& p_fname) const {
 
 	FileAccess *f = FileAccess::open(p_fname,FileAccess::READ);
@@ -481,8 +514,15 @@ bool EditorExportPlatform::exists_export_template(String template_file_name, Str
 
 
 
+bool EditorExportPlatform::is_debugging_enabled() const {
 
+	return debugging_enabled;
+}
 
+void EditorExportPlatform::set_debugging_enabled(bool p_enabled) {
+
+	debugging_enabled = p_enabled;
+}
 
 bool EditorExportPlatformPC::_set(const StringName& p_name, const Variant& p_value) {
 
@@ -1258,6 +1298,11 @@ Error EditorExportPlatform::save_pack(FileAccess *dst,bool p_make_bundles, int p
 	}
 
 	return OK;
+}
+
+EditorExportPlatform::EditorExportPlatform() {
+
+	debugging_enabled = true;
 }
 
 Error EditorExportPlatformPC::export_project(const String& p_path, bool p_debug, int p_flags) {

--- a/tools/editor/editor_import_export.h
+++ b/tools/editor/editor_import_export.h
@@ -86,7 +86,16 @@ class EditorExportPlatform : public Reference {
 public:
 
 	typedef Error (*EditorExportSaveFunction)(void *p_userdata,const String& p_path, const Vector<uint8_t>& p_data,int p_file,int p_total);
+
+private:
+
+	bool debugging_enabled;
+
 protected:
+
+	bool _set(const StringName& p_name, const Variant& p_value);
+	bool _get(const StringName& p_name,Variant &r_ret) const;
+	void _get_property_list( List<PropertyInfo> *p_list) const;
 
 	Vector<uint8_t> get_exported_file_default(String& p_fname) const;
 	virtual Vector<uint8_t> get_exported_file(String& p_fname) const;
@@ -145,6 +154,8 @@ public:
 		EXPORT_VIEW_NAVIGATION=16,
 	};
 
+	bool is_debugging_enabled() const;
+	void set_debugging_enabled( bool p_enabled );
 
 	Error export_project_files(EditorExportSaveFunction p_func, void* p_udata,bool p_make_bundles);
 
@@ -164,11 +175,11 @@ public:
 	virtual bool can_export(String *r_error=NULL) const=0;
 
 
-	virtual bool requieres_password(bool p_debug) const { return false; }
+	virtual bool requires_password(bool p_debug) const { return false; }
 	virtual String get_binary_extension() const=0;
 	virtual Error export_project(const String& p_path,bool p_debug,int p_flags=0)=0;
 
-	EditorExportPlatform() {};
+	EditorExportPlatform();
 };
 
 class EditorExportPlatformPC : public EditorExportPlatform {

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -6011,11 +6011,6 @@ EditorNode::EditorNode() {
 
 
 
-	file_export_check = memnew( CheckButton );
-	file_export_check->set_text("Enable Debugging");
-	file_export_check->set_pressed(true);
-	file_export_check->connect("pressed",this,"_export_debug_toggled");
-	file_export->get_vbox()->add_margin_child("Debug:",file_export_check);
 	file_export_password = memnew( LineEdit );
 	file_export_password->set_secret(true);
 	file_export_password->set_editable(false);

--- a/tools/editor/editor_node.h
+++ b/tools/editor/editor_node.h
@@ -299,7 +299,6 @@ private:
 	FileDialog *file_export;
 	FileDialog *file_export_lib;
 	FileDialog *file_script;
-	CheckButton *file_export_check;
 	CheckButton *file_export_lib_merge;
 	LineEdit *file_export_password;
 	String current_path;

--- a/tools/editor/project_export.cpp
+++ b/tools/editor/project_export.cpp
@@ -481,7 +481,8 @@ void ProjectExportDialog::_export_action(const String& p_file) {
 		return;
 
 	String platform = selected->get_metadata(0);
-	Error err = export_platform(platform,p_file,file_export_check->is_pressed(),file_export_password->get_text(),false);
+	bool debugging_enabled = EditorImportExport::get_singleton()->get_export_platform(platform)->is_debugging_enabled();
+	Error err = export_platform(platform,p_file,debugging_enabled,file_export_password->get_text(),false);
 	if (err!=OK) {
 		error->set_text("Error exporting project!");
 		error->popup_centered_minsize();
@@ -592,7 +593,7 @@ void ProjectExportDialog::custom_action(const String&) {
 
 	String extension = exporter->get_binary_extension();
 
-	file_export_password->set_editable( exporter->requieres_password(file_export_check->is_pressed()));
+	file_export_password->set_editable( exporter->requires_password(exporter->is_debugging_enabled()) );
 
 	file_export->clear_filters();
 	if (extension!="") {
@@ -1452,12 +1453,6 @@ ProjectExportDialog::ProjectExportDialog(EditorNode *p_editor) {
 
 	file_export->set_title("Export Project");
 	file_export->connect("file_selected", this,"_export_action");
-
-	file_export_check = memnew( CheckButton );
-	file_export_check->set_text("Enable Debugging");
-	file_export_check->set_pressed(true);
-	file_export_check->connect("pressed",this,"_export_debug_toggled");
-	file_export->get_vbox()->add_margin_child("Debug:",file_export_check);
 
 	file_export_password = memnew( LineEdit );
 	file_export_password->set_secret(true);

--- a/tools/editor/project_export.h
+++ b/tools/editor/project_export.h
@@ -86,7 +86,6 @@ private:
 
 	EditorFileDialog *pck_export;
 	EditorFileDialog *file_export;
-	CheckButton *file_export_check;
 	LineEdit *file_export_password;
 
 	Button *button_export;


### PR DESCRIPTION
This change moves the debug export toggle from the file browser to the Project Export Settings window

Also fixes a typo in a function name

Closes #4432
