### PR TITLE
Project manager: unescape project names

### DIFF
--- a/tools/editor/project_manager.cpp
+++ b/tools/editor/project_manager.cpp
@@ -539,7 +539,7 @@ void ProjectManager::_load_recent_projects() {
 		String project_name="Unnamed Project";
 
 		if (cf->has_section_key("application","name")) {
-			project_name = cf->get_value("application","name");
+			project_name = static_cast<String>(cf->get_value("application","name")).xml_unescape();
 		}
 
 		if (filter_option==ProjectListFilter::FILTER_NAME && search_term!="" && project_name.findn(search_term)==-1)


### PR DESCRIPTION
Fixes #3609

As mentioned there by @reduz, the better fix would likely be done when moving Globals to use VariantParser, but for the time being this should do the trick.
