### PR TITLE
math: Fix rounding error for 0 in Math::round

### DIFF
--- a/core/math/math_funcs.cpp
+++ b/core/math/math_funcs.cpp
@@ -135,18 +135,20 @@ double Math::rad2deg(double p_y) {
 
 double Math::round(double p_val) {
 
-	if (p_val>0) {
+	if (p_val>=0) {
 		return ::floor(p_val+0.5);
 	} else {
 		p_val=-p_val;
 		return -::floor(p_val+0.5);
 	}
 }
+
 double Math::asin(double p_x) {
 
 	return ::asin(p_x);
 
 }
+
 double Math::acos(double p_x) {
 
 	return ::acos(p_x);

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -78,10 +78,6 @@ void Range::set_val(double p_val) {
 	if (p_val<shared->min)
 		p_val=shared->min;
 
-	//avoid to set -0
-	if (p_val == 0)
-		p_val = 0;
-
 	if (shared->val==p_val)
 		return;
 


### PR DESCRIPTION
Thus revert the previous workaround in commit b123bc4a2a9c07fcfd27a84109960bda158b3b9d.
Fixes #3221.
