### PR TITLE
AnimationPlayer: Prevent resetting timeline when pinned

### DIFF
--- a/tools/editor/plugins/animation_player_editor_plugin.cpp
+++ b/tools/editor/plugins/animation_player_editor_plugin.cpp
@@ -616,6 +616,9 @@ void AnimationPlayerEditor::_blend_edited() {
 
 void AnimationPlayerEditor::ensure_visibility() {
 
+	if (player && pin->is_pressed())
+		return; // another player is pinned, don't reset
+
 	_animation_edit();
 }
 


### PR DESCRIPTION
I don't know if it's the proper place for it, maybe the check should be done earlier in the call stack (e.g. in `AnimationPlayerEditorPlugin::make_visible`), I'm not sure how much impact these thing have.

Fixes #1019
