### PR TITLE
FileDialog: reset mkdir label after use

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -613,7 +613,6 @@ FileDialog::Access FileDialog::get_access() const{
 
 void FileDialog::_make_dir_confirm() {
 
-
 	Error err = dir_access->make_dir( makedirname->get_text() );
 	if (err==OK) {
 		dir_access->change_dir(makedirname->get_text());
@@ -623,6 +622,7 @@ void FileDialog::_make_dir_confirm() {
 	} else {
 		mkdirerr->popup_centered_minsize(Size2(250,50));
 	}
+	makedirname->set_text(""); // reset label
 }
 
 

--- a/tools/editor/editor_dir_dialog.cpp
+++ b/tools/editor/editor_dir_dialog.cpp
@@ -189,6 +189,7 @@ void EditorDirDialog::_make_dir_confirm() {
 	} else {
 		reload();
 	}
+	makedirname->set_text(""); // reset label
 }
 
 

--- a/tools/editor/editor_file_dialog.cpp
+++ b/tools/editor/editor_file_dialog.cpp
@@ -831,7 +831,6 @@ EditorFileDialog::Access EditorFileDialog::get_access() const{
 
 void EditorFileDialog::_make_dir_confirm() {
 
-
 	Error err = dir_access->make_dir( makedirname->get_text() );
 	if (err==OK) {
 		dir_access->change_dir(makedirname->get_text());
@@ -843,6 +842,7 @@ void EditorFileDialog::_make_dir_confirm() {
 	} else {
 		mkdirerr->popup_centered_minsize(Size2(250,50));
 	}
+	makedirname->set_text(""); // reset label
 }
 
 


### PR DESCRIPTION
Closes #1686.
