### PR TITLE
Fix checking unsaved changes only in current scene

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -4668,7 +4668,11 @@ void EditorNode::_scene_tab_script_edited(int p_tab) {
 void EditorNode::_scene_tab_closed(int p_tab) {
 	current_option = SCENE_TAB_CLOSE;
 	tab_closing = p_tab;
-	if (unsaved_cache) {
+
+	bool unsaved = (p_tab==editor_data.get_edited_scene()) ?
+			saved_version!=editor_data.get_undo_redo().get_version() :
+			editor_data.get_scene_version(p_tab)!=0;
+	if (unsaved) {
 		confirmation->get_ok()->set_text("Yes");
 		//confirmation->get_cancel()->show();
 		confirmation->set_text("Close scene? (Unsaved changes will be lost)");


### PR DESCRIPTION
Fixes #4504

AFAIK, the only way to close a scene without making it the currently edited one is with the _"Always Show Close Button In Scene Tabs"_ option activated, right?
