### PR TITLE
Fix windows 64-bits build.

### DIFF
--- a/drivers/gl_context/glew.h
+++ b/drivers/gl_context/glew.h
@@ -153,8 +153,7 @@ typedef unsigned short wchar_t;
 #endif
 #if !defined(_PTRDIFF_T_DEFINED) && !defined(_PTRDIFF_T_)
 #  ifdef _WIN64
-//typedef __int64 ptrdiff_t;
-typedef long int ptrdiff_t;
+typedef __int64 ptrdiff_t;
 #  else
 typedef _W64 int ptrdiff_t;
 #  endif

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -289,6 +289,8 @@ def configure(env):
                         print "Compiled program architecture will be a 32 bit executable. (forcing bits=32)."
                 else:
                         print "Failed to detect MSVC compiler architecture version... Defaulting to 32bit executable settings (forcing bits=32). Compilation attempt will continue, but SCons can not detect for what architecture this build is compiled for. You should check your settings/compilation setup."                        
+		if env["bits"]=="64":
+			env.Append(CCFLAGS=['/D_WIN64'])
 	else:
 
 		# Workaround for MinGW. See:

--- a/tools/doc/doc_data.cpp
+++ b/tools/doc/doc_data.cpp
@@ -64,7 +64,7 @@ void DocData::merge_from(const DocData& p_data) {
 				// since polymorphic functions are allowed we need to check the type of
 				// the arguments so we make sure they are different.
 				int arg_count = cf.methods[j].arguments.size();
-				bool arg_used[arg_count];
+				bool* arg_used = new bool[arg_count];
 				for (int l = 0; l < arg_count; ++l) arg_used[l] = false;
 				// also there is no guarantee that argument ordering will match, so we
 				// have to check one by one so we make sure we have an exact match


### PR DESCRIPTION
The change in `tools/doc/doc_data.cpp` is needed because the MSVC compiler does not support variable length arrays.

Tested with MSVC x86 and x64 compilers with `scons p=windows target=release_debug`.

@Marqin may want to have a look at this.

Fix #4113
