### PR TITLE
Removed double incluson of scene/gui/dialogs.h

### DIFF
--- a/tools/editor/editor_file_dialog.h
+++ b/tools/editor/editor_file_dialog.h
@@ -35,7 +35,6 @@
 #include "scene/gui/item_list.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/option_button.h"
-#include "scene/gui/dialogs.h"
 #include "os/dir_access.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/texture_frame.h"


### PR DESCRIPTION
Removed a double inclusion of `scene/gui/dialogs.h` in file `editor_file_dialog.h`
