### PR TITLE
Adds the ".vscode" folder from Visual Studio Code to ".gitignore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -299,3 +299,7 @@ godot.creator.*
 
 projects/
 platform/windows/godot_res.res
+
+# Visual Studio Code folder (and files) that are created
+# when the C/C++ extension (https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) is used
+/.vscode


### PR DESCRIPTION
Adds to ".gitignore" the ".vscode" folder which is created when using
Visual Studio Code together with the "C/C++" extension.
