### PR TITLE
Fix JavaScript build

### DIFF
--- a/drivers/opus/SCsub
+++ b/drivers/opus/SCsub
@@ -116,7 +116,6 @@ opus_sources_lib = [
 	"opus/info.c",
 	"opus/stream.c",
 	"opus/opus_decoder.c",
-	"opus/opus_compare.c",
 	"opus/internal.c",
 	"opus/wincerts.c",
 	"opus/opus.c",


### PR DESCRIPTION
`opus_compare.c` isn't needed, and Emscripten doesn't like multiple `main` functions
