### PR TITLE
Fix build for Windows 64-bits with GCC

### DIFF
--- a/drivers/gl_context/glew.h
+++ b/drivers/gl_context/glew.h
@@ -153,7 +153,11 @@ typedef unsigned short wchar_t;
 #endif
 #if !defined(_PTRDIFF_T_DEFINED) && !defined(_PTRDIFF_T_)
 #  ifdef _WIN64
+#    ifdef _MSC_VER // Using MSVC
 typedef __int64 ptrdiff_t;
+#    else // Using GCC
+typedef long int ptrdiff_t;
+#    endif
 #  else
 typedef _W64 int ptrdiff_t;
 #  endif


### PR DESCRIPTION
I believe now it's working for all compilers.
