### PR TITLE
Rotation APIs: Better exposure for degrees methods

### DIFF
--- a/demos/misc/tween/main.gd
+++ b/demos/misc/tween/main.gd
@@ -108,7 +108,7 @@ func reset_tween():
 		sprite.set_scale(Vector2(1,1))
 	
 	if get_node("modes/rotate").is_pressed():
-		tween.interpolate_method(sprite, "_set_rotd", 0, 360, 2, state.trans, state.eases)
+		tween.interpolate_method(sprite, "set_rotd", 0, 360, 2, state.trans, state.eases)
 		tween.interpolate_property(sprite, "transform/rot", 360, 0, 2, state.trans, state.eases, 2)
 	
 	if get_node("modes/callback").is_pressed():

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -148,13 +148,26 @@ void Node2D::set_pos(const Point2& p_pos) {
 
 }
 
-void Node2D::set_rot(float p_angle) {
+void Node2D::set_rot(float p_radians) {
 
 	if (_xform_dirty)
 		((Node2D*)this)->_update_xform_values();
-	angle=p_angle;
+	angle=p_radians;
 	_update_transform();
 	_change_notify("transform/rot");
+}
+
+void Node2D::set_rotd(float p_degrees) {
+
+	set_rot(Math::deg2rad(p_degrees));
+}
+
+// Kept for compatibility after rename to set_rotd.
+// Could be removed after a couple releases.
+void Node2D::_set_rotd(float p_degrees) {
+
+	WARN_PRINT("Deprecated method Node2D._set_rotd(): This method was renamed to set_rotd. Please adapt your code accordingly, as the old method will be obsoleted.");
+	set_rotd(p_degrees);
 }
 
 void Node2D::set_scale(const Size2& p_scale) {
@@ -183,21 +196,22 @@ float Node2D::get_rot() const {
 
 	return angle;
 }
+float Node2D::get_rotd() const {
+
+	return Math::rad2deg(get_rot());
+}
+// Kept for compatibility after rename to get_rotd.
+// Could be removed after a couple releases.
+float Node2D::_get_rotd() const {
+
+	WARN_PRINT("Deprecated method Node2D._get_rotd(): This method was renamed to get_rotd. Please adapt your code accordingly, as the old method will be obsoleted.");
+	return get_rotd();
+}
 Size2 Node2D::get_scale() const {
 	if (_xform_dirty)
 		((Node2D*)this)->_update_xform_values();
 
 	return _scale;
-}
-
-void Node2D::_set_rotd(float p_angle) {
-
-	set_rot(Math::deg2rad(p_angle));
-}
-
-float Node2D::_get_rotd() const {
-
-	return Math::rad2deg(get_rot());
 }
 
 
@@ -361,16 +375,18 @@ float Node2D::get_angle_to(const Vector2& p_pos) const {
 void Node2D::_bind_methods() {
 
 
-
+	// TODO: Obsolete those two methods (old name) properly (GH-4397)
 	ObjectTypeDB::bind_method(_MD("_get_rotd"),&Node2D::_get_rotd);
-	ObjectTypeDB::bind_method(_MD("_set_rotd"),&Node2D::_set_rotd);
+	ObjectTypeDB::bind_method(_MD("_set_rotd","degrees"),&Node2D::_set_rotd);
 
 	ObjectTypeDB::bind_method(_MD("set_pos","pos"),&Node2D::set_pos);
-	ObjectTypeDB::bind_method(_MD("set_rot","rot"),&Node2D::set_rot);
+	ObjectTypeDB::bind_method(_MD("set_rot","radians"),&Node2D::set_rot);
+	ObjectTypeDB::bind_method(_MD("set_rotd","degrees"),&Node2D::set_rotd);
 	ObjectTypeDB::bind_method(_MD("set_scale","scale"),&Node2D::set_scale);
 
 	ObjectTypeDB::bind_method(_MD("get_pos"),&Node2D::get_pos);
 	ObjectTypeDB::bind_method(_MD("get_rot"),&Node2D::get_rot);
+	ObjectTypeDB::bind_method(_MD("get_rotd"),&Node2D::get_rotd);
 	ObjectTypeDB::bind_method(_MD("get_scale"),&Node2D::get_scale);
 
 	ObjectTypeDB::bind_method(_MD("rotate","radians"),&Node2D::rotate);
@@ -400,7 +416,7 @@ void Node2D::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_relative_transform_to_parent","parent"),&Node2D::get_relative_transform_to_parent);
 
 	ADD_PROPERTYNZ(PropertyInfo(Variant::VECTOR2,"transform/pos"),_SCS("set_pos"),_SCS("get_pos"));
-	ADD_PROPERTYNZ(PropertyInfo(Variant::REAL,"transform/rot",PROPERTY_HINT_RANGE,"-1440,1440,0.1"),_SCS("_set_rotd"),_SCS("_get_rotd"));
+	ADD_PROPERTYNZ(PropertyInfo(Variant::REAL,"transform/rot",PROPERTY_HINT_RANGE,"-1440,1440,0.1"),_SCS("set_rotd"),_SCS("get_rotd"));
 	ADD_PROPERTYNO(PropertyInfo(Variant::VECTOR2,"transform/scale"),_SCS("set_scale"),_SCS("get_scale"));
 	ADD_PROPERTYNZ(PropertyInfo(Variant::INT,"z/z",PROPERTY_HINT_RANGE,itos(VS::CANVAS_ITEM_Z_MIN)+","+itos(VS::CANVAS_ITEM_Z_MAX)+",1"),_SCS("set_z"),_SCS("get_z"));
 	ADD_PROPERTYNO(PropertyInfo(Variant::BOOL,"z/relative"),_SCS("set_z_as_relative"),_SCS("is_z_relative"));

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -47,6 +47,7 @@ class Node2D : public CanvasItem {
 
 	void _update_transform();
 
+	// Deprecated, should be removed in a future version.
 	void _set_rotd(float p_angle);
 	float _get_rotd() const;
 
@@ -69,7 +70,8 @@ public:
 	virtual bool edit_has_pivot() const;
 
 	void set_pos(const Point2& p_pos);
-	void set_rot(float p_angle);
+	void set_rot(float p_radians);
+	void set_rotd(float p_degrees);
 	void set_scale(const Size2& p_scale);
 
 	void rotate(float p_radians);
@@ -81,6 +83,7 @@ public:
 
 	Point2 get_pos() const;
 	float get_rot() const;
+	float get_rotd() const;
 	Size2 get_scale() const;
 
 	Point2 get_global_pos() const;

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -346,14 +346,14 @@ void Spatial::set_translation(const Vector3& p_translation) {
 
 }
 
-void Spatial::set_rotation(const Vector3& p_euler){
+void Spatial::set_rotation(const Vector3& p_euler_rad){
 
 	if (data.dirty&DIRTY_VECTORS) {
 		data.scale=data.local_transform.basis.get_scale();
 		data.dirty&=~DIRTY_VECTORS;
 	}
 
-	data.rotation=p_euler;
+	data.rotation=p_euler_rad;
 	data.dirty|=DIRTY_LOCAL;
 	_propagate_transform_changed(this);
 	if (data.notify_local_transform) {
@@ -361,6 +361,18 @@ void Spatial::set_rotation(const Vector3& p_euler){
 	}
 
 }
+
+void Spatial::set_rotation_deg(const Vector3& p_euler_deg) {
+
+	set_rotation(p_euler_deg * Math_PI / 180.0);
+}
+
+void Spatial::_set_rotation_deg(const Vector3& p_euler_deg) {
+
+	WARN_PRINT("Deprecated method Spatial._set_rotation_deg(): This method was renamed to set_rotation_deg. Please adapt your code accordingly, as the old method will be obsoleted.");
+	set_rotation_deg(p_euler_deg);
+}
+
 void Spatial::set_scale(const Vector3& p_scale){
 
 	if (data.dirty&DIRTY_VECTORS) {
@@ -381,6 +393,7 @@ Vector3 Spatial::get_translation() const{
 
 	return data.local_transform.origin;
 }
+
 Vector3 Spatial::get_rotation() const{
 
 	if (data.dirty&DIRTY_VECTORS) {
@@ -391,6 +404,20 @@ Vector3 Spatial::get_rotation() const{
 
 	return data.rotation;
 }
+
+Vector3 Spatial::get_rotation_deg() const {
+
+	return get_rotation() * 180.0 / Math_PI;
+}
+
+// Kept for compatibility after rename to set_rotd.
+// Could be removed after a couple releases.
+Vector3 Spatial::_get_rotation_deg() const {
+
+	WARN_PRINT("Deprecated method Spatial._get_rotation_deg(): This method was renamed to get_rotation_deg. Please adapt your code accordingly, as the old method will be obsoleted.");
+	return get_rotation_deg();
+}
+
 Vector3 Spatial::get_scale() const{
 
 	if (data.dirty&DIRTY_VECTORS) {
@@ -493,16 +520,6 @@ void Spatial::set_as_toplevel(bool p_enabled) {
 bool Spatial::is_set_as_toplevel() const{
 
 	return data.toplevel;
-}
-
-void Spatial::_set_rotation_deg(const Vector3& p_deg) {
-
-	set_rotation(p_deg * Math_PI / 180.0);
-}
-
-Vector3 Spatial::_get_rotation_deg() const {
-
-	return get_rotation() * 180.0 / Math_PI;
 }
 
 Ref<World> Spatial::get_world() const {
@@ -722,8 +739,10 @@ void Spatial::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_transform"), &Spatial::get_transform);
 	ObjectTypeDB::bind_method(_MD("set_translation","translation"), &Spatial::set_translation);
 	ObjectTypeDB::bind_method(_MD("get_translation"), &Spatial::get_translation);
-	ObjectTypeDB::bind_method(_MD("set_rotation","rotation"), &Spatial::set_rotation);
+	ObjectTypeDB::bind_method(_MD("set_rotation","rotation_rad"), &Spatial::set_rotation);
 	ObjectTypeDB::bind_method(_MD("get_rotation"), &Spatial::get_rotation);
+	ObjectTypeDB::bind_method(_MD("set_rotation_deg","rotation_deg"), &Spatial::set_rotation_deg);
+	ObjectTypeDB::bind_method(_MD("get_rotation_deg"), &Spatial::get_rotation_deg);
 	ObjectTypeDB::bind_method(_MD("set_scale","scale"), &Spatial::set_scale);
 	ObjectTypeDB::bind_method(_MD("get_scale"), &Spatial::get_scale);
 	ObjectTypeDB::bind_method(_MD("set_global_transform","global"), &Spatial::set_global_transform);
@@ -732,9 +751,11 @@ void Spatial::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_ignore_transform_notification","enabled"), &Spatial::set_ignore_transform_notification);
 	ObjectTypeDB::bind_method(_MD("set_as_toplevel","enable"), &Spatial::set_as_toplevel);
 	ObjectTypeDB::bind_method(_MD("is_set_as_toplevel"), &Spatial::is_set_as_toplevel);
+	ObjectTypeDB::bind_method(_MD("get_world:World"), &Spatial::get_world);
+
+	// TODO: Obsolete those two methods (old name) properly (GH-4397)
 	ObjectTypeDB::bind_method(_MD("_set_rotation_deg","rotation_deg"), &Spatial::_set_rotation_deg);
 	ObjectTypeDB::bind_method(_MD("_get_rotation_deg"), &Spatial::_get_rotation_deg);
-	ObjectTypeDB::bind_method(_MD("get_world:World"), &Spatial::get_world);
 
 #ifdef TOOLS_ENABLED
 	ObjectTypeDB::bind_method(_MD("_update_gizmo"), &Spatial::_update_gizmo);
@@ -789,7 +810,7 @@ void Spatial::_bind_methods() {
 	//ADD_PROPERTY( PropertyInfo(Variant::TRANSFORM,"transform/global",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR ), _SCS("set_global_transform"), _SCS("get_global_transform") );
 	ADD_PROPERTYNZ( PropertyInfo(Variant::TRANSFORM,"transform/local",PROPERTY_HINT_NONE,""), _SCS("set_transform"), _SCS("get_transform") );
 	ADD_PROPERTY( PropertyInfo(Variant::VECTOR3,"transform/translation",PROPERTY_HINT_NONE,"",PROPERTY_USAGE_EDITOR), _SCS("set_translation"), _SCS("get_translation") );
-	ADD_PROPERTY( PropertyInfo(Variant::VECTOR3,"transform/rotation",PROPERTY_HINT_NONE,"",PROPERTY_USAGE_EDITOR), _SCS("_set_rotation_deg"), _SCS("_get_rotation_deg") );
+	ADD_PROPERTY( PropertyInfo(Variant::VECTOR3,"transform/rotation",PROPERTY_HINT_NONE,"",PROPERTY_USAGE_EDITOR), _SCS("set_rotation_deg"), _SCS("get_rotation_deg") );
 	ADD_PROPERTY( PropertyInfo(Variant::VECTOR3,"transform/rotation_rad",PROPERTY_HINT_NONE,"",0), _SCS("set_rotation"), _SCS("get_rotation") );
 	ADD_PROPERTY( PropertyInfo(Variant::VECTOR3,"transform/scale",PROPERTY_HINT_NONE,"",PROPERTY_USAGE_EDITOR), _SCS("set_scale"), _SCS("get_scale") );
 	ADD_PROPERTYNO( PropertyInfo(Variant::BOOL,"visibility/visible"), _SCS("_set_visible_"), _SCS("_is_visible_") );

--- a/scene/3d/spatial.h
+++ b/scene/3d/spatial.h
@@ -110,7 +110,8 @@ class Spatial : public Node {
 	void _notify_dirty();
 	void _propagate_transform_changed(Spatial *p_origin);
 
-	void _set_rotation_deg(const Vector3& p_deg);
+	// Deprecated, should be removed in a future version.
+	void _set_rotation_deg(const Vector3& p_euler_deg);
 	Vector3 _get_rotation_deg() const;
 
 	void _propagate_visibility_changed();
@@ -144,11 +145,13 @@ public:
 	Ref<World> get_world() const;
 
 	void set_translation(const Vector3& p_translation);
-	void set_rotation(const Vector3& p_euler);
+	void set_rotation(const Vector3& p_euler_rad);
+	void set_rotation_deg(const Vector3& p_euler_deg);
 	void set_scale(const Vector3& p_scale);
 
 	Vector3 get_translation() const;
 	Vector3 get_rotation() const;
+	Vector3 get_rotation_deg() const;
 	Vector3 get_scale() const;
 
 	void set_transform(const Transform& p_transform);

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2157,17 +2157,9 @@ bool Control::is_text_field() const {
 }
 
 
-void Control::_set_rotation_deg(float p_rot) {
-	set_rotation(Math::deg2rad(p_rot));
-}
+void Control::set_rotation(float p_radians) {
 
-float Control::_get_rotation_deg() const {
-	return Math::rad2deg(get_rotation());
-}
-
-void Control::set_rotation(float p_rotation) {
-
-	data.rotation=p_rotation;
+	data.rotation=p_radians;
 	update();
 	_notify_transform();
 }
@@ -2175,6 +2167,25 @@ void Control::set_rotation(float p_rotation) {
 float Control::get_rotation() const{
 
 	return data.rotation;
+}
+
+void Control::set_rotation_deg(float p_degrees) {
+	set_rotation(Math::deg2rad(p_degrees));
+}
+
+float Control::get_rotation_deg() const {
+	return Math::rad2deg(get_rotation());
+}
+
+// Kept for compatibility after rename to {s,g}et_rotation_deg.
+// Could be removed after a couple releases.
+void Control::_set_rotation_deg(float p_degrees) {
+	WARN_PRINT("Deprecated method Control._set_rotation_deg(): This method was renamed to set_rotation_deg. Please adapt your code accordingly, as the old method will be obsoleted.");
+	set_rotation_deg(p_degrees);
+}
+float Control::_get_rotation_deg() const {
+	WARN_PRINT("Deprecated method Control._get_rotation_deg(): This method was renamed to get_rotation_deg. Please adapt your code accordingly, as the old method will be obsoleted.");
+	return get_rotation_deg();
 }
 
 void Control::set_scale(const Vector2& p_scale){
@@ -2232,8 +2243,10 @@ void Control::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_size","size"),&Control::set_size);
 	ObjectTypeDB::bind_method(_MD("set_custom_minimum_size","size"),&Control::set_custom_minimum_size);
 	ObjectTypeDB::bind_method(_MD("set_global_pos","pos"),&Control::set_global_pos);
-	ObjectTypeDB::bind_method(_MD("set_rotation","rotation"),&Control::set_rotation);
-	ObjectTypeDB::bind_method(_MD("_set_rotation_deg","rotation"),&Control::_set_rotation_deg);
+	ObjectTypeDB::bind_method(_MD("set_rotation","radians"),&Control::set_rotation);
+	ObjectTypeDB::bind_method(_MD("set_rotation_deg","degrees"),&Control::set_rotation_deg);
+	// TODO: Obsolete this method (old name) properly (GH-4397)
+	ObjectTypeDB::bind_method(_MD("_set_rotation_deg","degrees"),&Control::_set_rotation_deg);
 	ObjectTypeDB::bind_method(_MD("set_scale","scale"),&Control::set_scale);
 	ObjectTypeDB::bind_method(_MD("get_margin","margin"),&Control::get_margin);
 	ObjectTypeDB::bind_method(_MD("get_begin"),&Control::get_begin);
@@ -2241,12 +2254,14 @@ void Control::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_pos"),&Control::get_pos);
 	ObjectTypeDB::bind_method(_MD("get_size"),&Control::get_size);
 	ObjectTypeDB::bind_method(_MD("get_rotation"),&Control::get_rotation);
+	ObjectTypeDB::bind_method(_MD("get_rotation_deg"),&Control::get_rotation_deg);
+	// TODO: Obsolete this method (old name) properly (GH-4397)
+	ObjectTypeDB::bind_method(_MD("_get_rotation_deg"),&Control::_get_rotation_deg);
 	ObjectTypeDB::bind_method(_MD("get_scale"),&Control::get_scale);
 	ObjectTypeDB::bind_method(_MD("get_custom_minimum_size"),&Control::get_custom_minimum_size);
 	ObjectTypeDB::bind_method(_MD("get_parent_area_size"),&Control::get_size);
 	ObjectTypeDB::bind_method(_MD("get_global_pos"),&Control::get_global_pos);
 	ObjectTypeDB::bind_method(_MD("get_rect"),&Control::get_rect);
-	ObjectTypeDB::bind_method(_MD("_get_rotation_deg"),&Control::_get_rotation_deg);
 	ObjectTypeDB::bind_method(_MD("get_global_rect"),&Control::get_global_rect);
 	ObjectTypeDB::bind_method(_MD("set_area_as_parent_rect","margin"),&Control::set_area_as_parent_rect,DEFVAL(0));
 	ObjectTypeDB::bind_method(_MD("show_modal","exclusive"),&Control::show_modal,DEFVAL(false));
@@ -2325,7 +2340,7 @@ void Control::_bind_methods() {
 	ADD_PROPERTYNZ( PropertyInfo(Variant::VECTOR2,"rect/pos", PROPERTY_HINT_NONE, "",PROPERTY_USAGE_EDITOR), _SCS("set_pos"),_SCS("get_pos") );
 	ADD_PROPERTYNZ( PropertyInfo(Variant::VECTOR2,"rect/size", PROPERTY_HINT_NONE, "",PROPERTY_USAGE_EDITOR), _SCS("set_size"),_SCS("get_size") );
 	ADD_PROPERTYNZ( PropertyInfo(Variant::VECTOR2,"rect/min_size"), _SCS("set_custom_minimum_size"),_SCS("get_custom_minimum_size") );
-	ADD_PROPERTYNZ( PropertyInfo(Variant::REAL,"rect/rotation",PROPERTY_HINT_RANGE,"-1080,1080,0.01"), _SCS("_set_rotation_deg"),_SCS("_get_rotation_deg") );
+	ADD_PROPERTYNZ( PropertyInfo(Variant::REAL,"rect/rotation",PROPERTY_HINT_RANGE,"-1080,1080,0.01"), _SCS("set_rotation_deg"),_SCS("get_rotation_deg") );
 	ADD_PROPERTYNO( PropertyInfo(Variant::VECTOR2,"rect/scale"), _SCS("set_scale"),_SCS("get_scale") );
 	ADD_PROPERTYNZ( PropertyInfo(Variant::STRING,"hint/tooltip", PROPERTY_HINT_MULTILINE_TEXT), _SCS("set_tooltip"),_SCS("_get_tooltip") );
 	ADD_PROPERTYINZ( PropertyInfo(Variant::NODE_PATH,"focus_neighbour/left" ), _SCS("set_focus_neighbour"),_SCS("get_focus_neighbour"),MARGIN_LEFT );

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -180,7 +180,8 @@ private:
 	void _size_changed();
 	String _get_tooltip() const;
 
-	void _set_rotation_deg(float p_rot);
+	// Deprecated, should be removed in a future version.
+	void _set_rotation_deg(float p_degrees);
 	float _get_rotation_deg() const;
 
 friend class Viewport;
@@ -275,8 +276,10 @@ public:
 	Rect2 get_global_rect() const;
 	Rect2 get_window_rect() const; ///< use with care, as it blocks waiting for the visual server
 
-	void set_rotation(float p_rotation);
+	void set_rotation(float p_radians);
+	void set_rotation_deg(float p_degrees);
 	float get_rotation() const;
+	float get_rotation_deg() const;
 
 	void set_scale(const Vector2& p_scale);
 	Vector2 get_scale() const;

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -94,13 +94,13 @@ Vector2 CanvasLayer::get_offset() const {
 }
 
 
-void CanvasLayer::set_rotation(real_t p_rotation) {
+void CanvasLayer::set_rotation(real_t p_radians) {
 
 	if (locrotscale_dirty)
 		_update_locrotscale();
 
 
-	rot=p_rotation;
+	rot=p_radians;
 	_update_xform();
 
 }
@@ -113,6 +113,29 @@ real_t CanvasLayer::get_rotation() const {
 	return rot;
 }
 
+void CanvasLayer::set_rotationd(real_t p_degrees) {
+
+	set_rotation(Math::deg2rad(p_degrees));
+}
+
+real_t CanvasLayer::get_rotationd() const {
+
+	return Math::rad2deg(get_rotation());
+}
+
+// Kept for compatibility after rename to {s,g}et_rotationd.
+// Could be removed after a couple releases.
+void CanvasLayer::_set_rotationd(real_t p_degrees) {
+
+	WARN_PRINT("Deprecated method CanvasLayer._set_rotationd(): This method was renamed to set_rotationd. Please adapt your code accordingly, as the old method will be obsoleted.");
+	set_rotationd(p_degrees);
+}
+
+real_t CanvasLayer::_get_rotationd() const {
+
+	WARN_PRINT("Deprecated method CanvasLayer._get_rotationd(): This method was renamed to get_rotationd. Please adapt your code accordingly, as the old method will be obsoleted.");
+	return get_rotationd();
+}
 
 void CanvasLayer::set_scale(const Vector2& p_scale) {
 
@@ -121,7 +144,6 @@ void CanvasLayer::set_scale(const Vector2& p_scale) {
 
 	scale=p_scale;
 	_update_xform();
-
 
 }
 
@@ -193,16 +215,6 @@ RID CanvasLayer::get_viewport() const {
 	return viewport;
 }
 
-void CanvasLayer::_set_rotationd(real_t p_rotation) {
-
-	set_rotation(Math::deg2rad(p_rotation));
-}
-
-real_t CanvasLayer::_get_rotationd() const {
-
-	return Math::rad2deg(get_rotation());
-}
-
 
 void CanvasLayer::_bind_methods() {
 
@@ -216,10 +228,14 @@ void CanvasLayer::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_offset","offset"),&CanvasLayer::set_offset);
 	ObjectTypeDB::bind_method(_MD("get_offset"),&CanvasLayer::get_offset);
 
-	ObjectTypeDB::bind_method(_MD("set_rotation","rotation"),&CanvasLayer::set_rotation);
+	ObjectTypeDB::bind_method(_MD("set_rotation","radians"),&CanvasLayer::set_rotation);
 	ObjectTypeDB::bind_method(_MD("get_rotation"),&CanvasLayer::get_rotation);
 
-	ObjectTypeDB::bind_method(_MD("_set_rotationd","rotationd"),&CanvasLayer::_set_rotationd);
+	ObjectTypeDB::bind_method(_MD("set_rotationd","degrees"),&CanvasLayer::set_rotationd);
+	ObjectTypeDB::bind_method(_MD("get_rotationd"),&CanvasLayer::get_rotationd);
+
+	// TODO: Obsolete those two methods (old name) properly (GH-4397)
+	ObjectTypeDB::bind_method(_MD("_set_rotationd","degrees"),&CanvasLayer::_set_rotationd);
 	ObjectTypeDB::bind_method(_MD("_get_rotationd"),&CanvasLayer::_get_rotationd);
 
 	ObjectTypeDB::bind_method(_MD("set_scale","scale"),&CanvasLayer::set_scale);
@@ -231,7 +247,7 @@ void CanvasLayer::_bind_methods() {
 	ADD_PROPERTY( PropertyInfo(Variant::INT,"layer",PROPERTY_HINT_RANGE,"-128,128,1"),_SCS("set_layer"),_SCS("get_layer") );
 	//ADD_PROPERTY( PropertyInfo(Variant::MATRIX32,"transform",PROPERTY_HINT_RANGE),_SCS("set_transform"),_SCS("get_transform") );
 	ADD_PROPERTY( PropertyInfo(Variant::VECTOR2,"offset"),_SCS("set_offset"),_SCS("get_offset") );
-	ADD_PROPERTY( PropertyInfo(Variant::REAL,"rotation"),_SCS("_set_rotationd"),_SCS("_get_rotationd") );
+	ADD_PROPERTY( PropertyInfo(Variant::REAL,"rotation"),_SCS("set_rotationd"),_SCS("get_rotationd") );
 	ADD_PROPERTY( PropertyInfo(Variant::VECTOR2,"scale"),_SCS("set_scale"),_SCS("get_scale") );
 
 }

--- a/scene/main/canvas_layer.h
+++ b/scene/main/canvas_layer.h
@@ -48,7 +48,7 @@ class CanvasLayer : public Node {
 	RID viewport;
 	Viewport *vp;
 
-
+	// Deprecated, should be removed in a future version.
 	void _set_rotationd(real_t p_rotation);
 	real_t _get_rotationd() const;
 
@@ -70,8 +70,11 @@ public:
 	void set_offset(const Vector2& p_offset);
 	Vector2 get_offset() const;
 
-	void set_rotation(real_t p_rotation);
+	void set_rotation(real_t p_radians);
 	real_t get_rotation() const;
+
+	void set_rotationd(real_t p_degrees);
+	real_t get_rotationd() const;
 
 	void set_scale(const Vector2& p_scale);
 	Vector2 get_scale() const;


### PR DESCRIPTION
Made public the various set/getters for rotations in degrees.
For consistency, renamed the exposed method names to remove the leading
underscore, and kept the old names with a deprecation warning.

Fixes #4511.
