### PR TITLE
Fixed animation player auto-queue duplication and undo/redo

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1299,6 +1299,9 @@ void AnimationPlayer::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_animation:Animation","name"),&AnimationPlayer::get_animation);
 	ObjectTypeDB::bind_method(_MD("get_animation_list"),&AnimationPlayer::_get_animation_list);
 
+	ObjectTypeDB::bind_method(_MD("animation_set_next", "anim_from", "anim_to"), &AnimationPlayer::animation_set_next);
+	ObjectTypeDB::bind_method(_MD("animation_get_next", "anim_from"), &AnimationPlayer::animation_get_next);
+
 	ObjectTypeDB::bind_method(_MD("set_blend_time","anim_from","anim_to","sec"),&AnimationPlayer::set_blend_time);
 	ObjectTypeDB::bind_method(_MD("get_blend_time","anim_from","anim_to"),&AnimationPlayer::get_blend_time);
 

--- a/tools/editor/plugins/animation_player_editor_plugin.h
+++ b/tools/editor/plugins/animation_player_editor_plugin.h
@@ -103,7 +103,7 @@ class AnimationPlayerEditor : public VBoxContainer {
 
 		AcceptDialog * dialog;
 		Tree *tree;
-		LineEdit *next;
+		OptionButton *next;
 
 	} blend_editor;
 
@@ -146,7 +146,7 @@ class AnimationPlayerEditor : public VBoxContainer {
 	void _dialog_action(String p_file);
 	void _seek_frame_changed(const String& p_frame);
 	void _seek_value_changed(float p_value);
-	void _blend_editor_next_changed(const String& p_string);
+	void _blend_editor_next_changed(const int p_idx);
 
 	void _list_changed();
 	void _update_animation();


### PR DESCRIPTION
Fixed animation player auto-queue duplication and undo/redo history, by doing this setting the scene as changed.

Also turned it into a dropdown instead of a text box.

closes #148 
closes #974 
