### PR TITLE
Fixed autocomplete strings not appearing for function arguments

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3903,7 +3903,7 @@ void TextEdit::_update_completion_candidates() {
 		}
 	}
 
-	if (l[cursor.column - 1] == '(' && !pre_keyword) {
+	if (l[cursor.column - 1] == '(' && !pre_keyword && !completion_strings[0].begins_with("\"")) {
 		cancel = true;
 	}
 


### PR DESCRIPTION
As a result of #4573 string arguments for function such as `get_node()` would no longer appear until you typed the first opening quotation, this fixes that. Though I don't know if this is the desired behavior as it covers the tooltip again for those functions.
