### PR TITLE
Added possibility to strip left and right to strip_edges

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -2894,12 +2894,42 @@ String String::strip_edges() const {
 	return substr(beg,end-beg);
 }
 
-String String::strip_edges_left() const {
+String String::strip_edge_left() const {
 
+	int len = length();
+	int beg = 0, end = len;
+
+	for (int i = 0; i<len; i++) {
+
+		if (operator[](i) <= 32)
+			beg++;
+		else
+			break;
+	}
+
+	if (beg == 0)
+		return *this;
+
+	return substr(beg, len - beg);
 }
 
-String String::strip_edges_left() const {
+String String::strip_edge_right() const {
 
+	int len = length();
+	int end = len;
+
+	for (int i = (int)(len - 1); i >= 0; i--) {
+
+		if (operator[](i) <= 32)
+			end--;
+		else
+			break;
+	}
+
+	if (end == len)
+		return *this;
+
+	return substr(0, end);
 }
 
 String String::strip_escapes() const {

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -2872,7 +2872,7 @@ String String::strip_edges() const {
 	int len=length();
 	int beg=0,end=len;
 
-	for (int i=0;i<length();i++) {
+	for (int i=0;i<len;i++) {
 
 		if (operator[](i)<=32)
 			beg++;
@@ -2880,7 +2880,7 @@ String String::strip_edges() const {
 			break;
 	}
 
-	for (int i=(int)(length()-1);i>=0;i--) {
+	for (int i=(int)(len-1);i>=0;i--) {
 
 		if (operator[](i)<=32)
 			end--;
@@ -2892,6 +2892,14 @@ String String::strip_edges() const {
 		return *this;
 
 	return substr(beg,end-beg);
+}
+
+String String::strip_edges_left() const {
+
+}
+
+String String::strip_edges_left() const {
+
 }
 
 String String::strip_escapes() const {

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -2867,69 +2867,35 @@ CharType String::ord_at(int p_idx) const {
 	return operator[](p_idx);
 }
 
-String String::strip_edges() const {
+String String::strip_edges(bool left, bool right) const {
 
 	int len=length();
 	int beg=0,end=len;
 
-	for (int i=0;i<len;i++) {
+	if(left) {
+		for (int i=0;i<len;i++) {
 
-		if (operator[](i)<=32)
-			beg++;
-		else
-			break;
+			if (operator[](i)<=32)
+				beg++;
+			else
+				break;
+		}
 	}
 
-	for (int i=(int)(len-1);i>=0;i--) {
+	if(right) {
+		for (int i=(int)(len-1);i>=0;i--) {
 
-		if (operator[](i)<=32)
-			end--;
-		else
-			break;
+			if (operator[](i)<=32)
+				end--;
+			else
+				break;
+		}
 	}
 
 	if (beg==0 && end==len)
 		return *this;
 
 	return substr(beg,end-beg);
-}
-
-String String::strip_edge_left() const {
-
-	int len = length();
-	int beg = 0, end = len;
-
-	for (int i = 0; i<len; i++) {
-
-		if (operator[](i) <= 32)
-			beg++;
-		else
-			break;
-	}
-
-	if (beg == 0)
-		return *this;
-
-	return substr(beg, len - beg);
-}
-
-String String::strip_edge_right() const {
-
-	int len = length();
-	int end = len;
-
-	for (int i = (int)(len - 1); i >= 0; i--) {
-
-		if (operator[](i) <= 32)
-			end--;
-		else
-			break;
-	}
-
-	if (end == len)
-		return *this;
-
-	return substr(0, end);
 }
 
 String String::strip_escapes() const {

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -170,8 +170,8 @@ public:
 	String left(int p_pos) const;
 	String right(int p_pos) const;
 	String strip_edges() const;
-	String strip_edges_left() const;
-	String strip_edges_right() const;
+	String strip_edge_left() const;
+	String strip_edge_right() const;
 	String strip_escapes() const;
 	String extension() const;
 	String basename() const;

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -169,9 +169,7 @@ public:
 
 	String left(int p_pos) const;
 	String right(int p_pos) const;
-	String strip_edges() const;
-	String strip_edge_left() const;
-	String strip_edge_right() const;
+	String strip_edges(bool left = true, bool right = true) const;
 	String strip_escapes() const;
 	String extension() const;
 	String basename() const;

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -170,6 +170,8 @@ public:
 	String left(int p_pos) const;
 	String right(int p_pos) const;
 	String strip_edges() const;
+	String strip_edges_left() const;
+	String strip_edges_right() const;
 	String strip_escapes() const;
 	String extension() const;
 	String basename() const;

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -258,6 +258,8 @@ static void _call_##m_type##_##m_method(Variant& r_ret,Variant& p_self,const Var
 	VCALL_LOCALMEM1R(String,left);
 	VCALL_LOCALMEM1R(String,right);
 	VCALL_LOCALMEM0R(String,strip_edges);
+	VCALL_LOCALMEM0R(String,strip_edge_left);
+	VCALL_LOCALMEM0R(String,strip_edge_right);
 	VCALL_LOCALMEM0R(String,extension);
 	VCALL_LOCALMEM0R(String,basename);
 	VCALL_LOCALMEM1R(String,plus_file);
@@ -1278,6 +1280,8 @@ _VariantCall::addfunc(Variant::m_vtype,Variant::m_ret,_SCS(#m_method),VCALL(m_cl
 	ADDFUNC1(STRING,STRING,String,left,INT,"pos",varray());
 	ADDFUNC1(STRING,STRING,String,right,INT,"pos",varray());
 	ADDFUNC0(STRING,STRING,String,strip_edges,varray());
+	ADDFUNC0(STRING,STRING,String,strip_edge_left,varray());
+	ADDFUNC0(STRING,STRING,String,strip_edge_right,varray());
 	ADDFUNC0(STRING,STRING,String,extension,varray());
 	ADDFUNC0(STRING,STRING,String,basename,varray());
 	ADDFUNC1(STRING,STRING,String,plus_file,STRING,"file",varray());

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -257,9 +257,7 @@ static void _call_##m_type##_##m_method(Variant& r_ret,Variant& p_self,const Var
 	VCALL_LOCALMEM0R(String,to_lower);
 	VCALL_LOCALMEM1R(String,left);
 	VCALL_LOCALMEM1R(String,right);
-	VCALL_LOCALMEM0R(String,strip_edges);
-	VCALL_LOCALMEM0R(String,strip_edge_left);
-	VCALL_LOCALMEM0R(String,strip_edge_right);
+	VCALL_LOCALMEM2R(String,strip_edges);
 	VCALL_LOCALMEM0R(String,extension);
 	VCALL_LOCALMEM0R(String,basename);
 	VCALL_LOCALMEM1R(String,plus_file);
@@ -1279,9 +1277,7 @@ _VariantCall::addfunc(Variant::m_vtype,Variant::m_ret,_SCS(#m_method),VCALL(m_cl
 
 	ADDFUNC1(STRING,STRING,String,left,INT,"pos",varray());
 	ADDFUNC1(STRING,STRING,String,right,INT,"pos",varray());
-	ADDFUNC0(STRING,STRING,String,strip_edges,varray());
-	ADDFUNC0(STRING,STRING,String,strip_edge_left,varray());
-	ADDFUNC0(STRING,STRING,String,strip_edge_right,varray());
+	ADDFUNC2(STRING,STRING,String,strip_edges,BOOL,"left",BOOL,"right",varray(true,true));
 	ADDFUNC0(STRING,STRING,String,extension,varray());
 	ADDFUNC0(STRING,STRING,String,basename,varray());
 	ADDFUNC1(STRING,STRING,String,plus_file,STRING,"file",varray());


### PR DESCRIPTION
Added two optional parameters to `strip_edges` in order to strip only left and only right part of the string. This are defaulted to true to ensure compatibility with current stripping mechanic.

Also optimizes the call by replacing calls to `length()` with a local variable

Fixes #968 

If needed I can squish commits.
