### PR TITLE
Hide cursor only inside window

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -705,6 +705,23 @@ LRESULT OS_Windows::WndProc(HWND hWnd,UINT uMsg, WPARAM	wParam,	LPARAM	lParam) {
 
 			joystick->probe_joysticks();
 		} break;
+		case WM_SETCURSOR: {
+
+			if(LOWORD(lParam) == HTCLIENT) {
+				if(mouse_mode == MOUSE_MODE_HIDDEN) {
+					//Hide the cursor
+					if(hCursor == NULL)
+						hCursor = SetCursor(NULL);
+				}
+				else {
+					if(hCursor != NULL) {
+						SetCursor(hCursor);
+						hCursor = NULL;
+					}
+				}
+			}
+
+		} break;
 
 		default: {
 
@@ -1211,7 +1228,6 @@ void OS_Windows::set_mouse_mode(MouseMode p_mode) {
 
 	if (mouse_mode==p_mode)
 		return;
-	ShowCursor(p_mode==MOUSE_MODE_VISIBLE);
 	mouse_mode=p_mode;
 	if (p_mode==MOUSE_MODE_CAPTURED) {
 		RECT clipRect;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -712,6 +712,8 @@ LRESULT OS_Windows::WndProc(HWND hWnd,UINT uMsg, WPARAM	wParam,	LPARAM	lParam) {
 					//Hide the cursor
 					if(hCursor == NULL)
 						hCursor = SetCursor(NULL);
+					else
+						SetCursor(NULL);
 				}
 				else {
 					if(hCursor != NULL) {

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -103,6 +103,8 @@ class OS_Windows : public OS {
 	HDC		hDC;	// Private GDI Device Context
 	HINSTANCE	hInstance;		// Holds The Instance Of The Application
 	HWND hWnd;
+	
+	HCURSOR hCursor;
 
 	Size2 window_rect;
 	VideoMode video_mode;


### PR DESCRIPTION
With this PR the function `Input.set_mouse_mode(Input.MOUSE_MODE_HIDDEN)`  actually hides the cursor only inside the window (Winodws only, seems OK on other platforms)

Fixes: #4564

I am not sure on how it will behave when changing the cursor before showing it.
