### PR TITLE
Add ignore error flag to OpenSSL driver

### DIFF
--- a/drivers/builtin_openssl2/SCsub
+++ b/drivers/builtin_openssl2/SCsub
@@ -650,6 +650,7 @@ env_ssl.Append(CPPPATH=["#drivers/builtin_openssl2/crypto/asn1"])
 env_ssl.Append(CPPPATH=["#drivers/builtin_openssl2/crypto/modes"])
 #env_ssl.Append(CPPPATH=["#drivers/builtin_openssl2/crypto/store"])
 env_ssl.Append(CPPFLAGS=["-DOPENSSL_NO_ASM","-DOPENSSL_THREADS","-DL_ENDIAN"])
+env_ssl.Append(CFLAGS=["-Wno-error=implicit-function-declaration"]);
 
 env_ssl.add_source_files(env.drivers_sources,openssl_sources)
 


### PR DESCRIPTION
This fixes #4517. However, it still doesn't build for Javascript with `openssl=builtin` because of another error:

```
ERROR: Linking globals named 'OPENSSL_cpuid_setup': symbol multiply defined!
```
