### PR TITLE
OS.get_screen_size now returns the correct value on OSX

### DIFF
--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -184,7 +184,7 @@ public:
 	virtual bool is_window_minimized() const;
 	virtual void set_window_maximized(bool p_enabled);
 	virtual bool is_window_maximized() const;
-	Size2 get_screen_size(int p_screen);
+	Size2 get_screen_size(int p_screen=0) const;
 
 
 	void run();

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1354,7 +1354,7 @@ Point2 OS_OSX::get_screen_position(int p_screen) const {
 	return screens[p_screen].pos;
 };
 
-Size2 OS_OSX::get_screen_size(int p_screen) {
+Size2 OS_OSX::get_screen_size(int p_screen) const {
 
 	ERR_FAIL_INDEX_V(p_screen, screens.size(), Point2());
 	return screens[p_screen].size;


### PR DESCRIPTION
Hi, on OSX OS.get_screen_size was not returning the correct size, I tested the patch on Yosemite and now it's working properly.
