### PR TITLE
Corrected two return types in Area2D

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -4026,7 +4026,7 @@
 			</description>
 		</method>
 		<method name="overlaps_body" qualifiers="const">
-			<return type="PhysicsBody2D">
+			<return type="bool">
 			</return>
 			<argument index="0" name="body" type="Object">
 			</argument>
@@ -4035,7 +4035,7 @@
 			</description>
 		</method>
 		<method name="overlaps_area" qualifiers="const">
-			<return type="Area2D">
+			<return type="bool">
 			</return>
 			<argument index="0" name="area" type="Object">
 			</argument>

--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -638,8 +638,8 @@ void Area2D::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_overlapping_bodies"),&Area2D::get_overlapping_bodies);
 	ObjectTypeDB::bind_method(_MD("get_overlapping_areas"),&Area2D::get_overlapping_areas);
 
-	ObjectTypeDB::bind_method(_MD("overlaps_body:PhysicsBody2D","body"),&Area2D::overlaps_body);
-	ObjectTypeDB::bind_method(_MD("overlaps_area:Area2D","area"),&Area2D::overlaps_area);
+	ObjectTypeDB::bind_method(_MD("overlaps_body","body"),&Area2D::overlaps_body);
+	ObjectTypeDB::bind_method(_MD("overlaps_area","area"),&Area2D::overlaps_area);
 
 	ObjectTypeDB::bind_method(_MD("_body_inout"),&Area2D::_body_inout);
 	ObjectTypeDB::bind_method(_MD("_area_inout"),&Area2D::_area_inout);

--- a/scene/3d/area.cpp
+++ b/scene/3d/area.cpp
@@ -628,8 +628,8 @@ void Area::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_overlapping_bodies"),&Area::get_overlapping_bodies);
 	ObjectTypeDB::bind_method(_MD("get_overlapping_areas"),&Area::get_overlapping_areas);
 
-	ObjectTypeDB::bind_method(_MD("overlaps_body:PhysicsBody","body"),&Area::overlaps_body);
-	ObjectTypeDB::bind_method(_MD("overlaps_area:Area","area"),&Area::overlaps_area);
+	ObjectTypeDB::bind_method(_MD("overlaps_body","body"),&Area::overlaps_body);
+	ObjectTypeDB::bind_method(_MD("overlaps_area","area"),&Area::overlaps_area);
 
 	ObjectTypeDB::bind_method(_MD("_body_inout"),&Area::_body_inout);
 	ObjectTypeDB::bind_method(_MD("_area_inout"),&Area::_area_inout);


### PR DESCRIPTION
Corrected the return type of overlaps_body() and overlaps_area() in the Area2D class documentation: they are now booleans.

This is my first attempt with github, I hope I did it correctly. (I can't access the collaborative pad, due to 504 error...)
