### PR TITLE
Remove nocpuid.c from builtin OpenSSL 

### DIFF
--- a/drivers/builtin_openssl2/SCsub
+++ b/drivers/builtin_openssl2/SCsub
@@ -2,7 +2,6 @@ Import('env')
 Import('env_ssl')
 
 openssl_sources = [
-"nocpuid.c",
 "ssl/t1_lib.c",
 "ssl/t1_ext.c",
 "ssl/s3_srvr.c",

--- a/drivers/builtin_openssl2/nocpuid.c
+++ b/drivers/builtin_openssl2/nocpuid.c
@@ -1,7 +1,0 @@
-
-#include "openssl/crypto.h"
-
-
-void OPENSSL_cpuid_setup() {
-
-}


### PR DESCRIPTION
Fixes #4632

e97922f22038e9049ed4c2db5b3736dfaa0edde3 comments out `#define OPENSSL_CPUID_OBJ` in `opensslconf.h`, so OpenSSL defines `OPENSSL_cpuid_setup(void)` by itself, with the same empty definition: https://github.com/godotengine/godot/blob/e97922f22038e9049ed4c2db5b3736dfaa0edde3/drivers/builtin_openssl2/crypto/cryptlib.c#L738

I wonder why it's commented out though
