### PR TITLE
Node duplication positions under duplicated node, issue #964

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -749,6 +749,16 @@ void Node::add_child(Node *p_child, bool p_legible_unique_name) {
 
 }
 
+void Node::add_child_below_node(Node *p_node, Node *p_child, bool p_legible_unique_name) {
+	add_child(p_child, p_legible_unique_name);
+
+	if (is_a_parent_of(p_node)) {
+		move_child(p_child, p_node->get_position_in_parent() + 1);
+	} else {
+		WARN_PRINTS("Cannot move under node " + p_node->get_name() + " as " + p_child->get_name() + " does not share a parent")
+	}
+}
+
 
 void Node::_propagate_validate_owner() {
 
@@ -2011,6 +2021,8 @@ void Node::clear_internal_tree_resource_paths() {
 }
 
 void Node::_bind_methods() {
+
+	ObjectTypeDB::bind_method(_MD("_add_child_below_node","node:Node","child_node:Node","legible_unique_name"),&Node::add_child_below_node,DEFVAL(false));
 
 	ObjectTypeDB::bind_method(_MD("set_name","name"),&Node::set_name);
 	ObjectTypeDB::bind_method(_MD("get_name"),&Node::get_name);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -190,6 +190,7 @@ public:
 	void set_name(const String& p_name);
 
 	void add_child(Node *p_child,bool p_legible_unique_name=false);
+	void add_child_below_node(Node *p_node, Node *p_child, bool p_legible_unique_name=false);
 	void remove_child(Node *p_child);
 
 	int get_child_count() const;

--- a/tools/editor/scene_tree_dock.cpp
+++ b/tools/editor/scene_tree_dock.cpp
@@ -438,7 +438,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 				dup->set_name(attempt);
 
-				editor_data->get_undo_redo().add_do_method(parent,"add_child",dup);
+				editor_data->get_undo_redo().add_do_method(parent,"_add_child_below_node",node, dup);
 				for (List<Node*>::Element *F=owned.front();F;F=F->next()) {
 
 					if (!duplimap.has(F->get())) {


### PR DESCRIPTION
When duplicating a node it is now positioned under the node that was duplicated.

closes #964
