### PR TITLE
Adds invert() method DVector

### DIFF
--- a/core/dvector.h
+++ b/core/dvector.h
@@ -285,6 +285,7 @@ public:
 
 	Error resize(int p_size);
 
+	void invert();
 
 	void operator=(const DVector& p_dvector) { reference(p_dvector); }
 	DVector() {}
@@ -424,6 +425,18 @@ Error DVector<T>::resize(int p_size) {
 	return OK;
 }
 
+template<class T>
+void DVector<T>::invert() {
+	T temp;
+	Write w = write();
+	int s = size();
+	int half_s = s/2;
 
+	for(int i=0;i<half_s;i++) {
+		temp = w[i];
+		w[i] = w[s-i-1];
+		w[s-i-1] = temp;
+	}
+}
 
 #endif


### PR DESCRIPTION
Satisfies issue #4601 
Cleaned up this PR.

This effectively allows invert() to be used on the following types:
ByteArray, IntArray, RealArray, StringArray, Vector2Array, Vector3Array, ColorArray

The last issues to be brought up were:
-Assigning the size values to variables (see s and half_s)
-Operating on a Write() pointer instead of using get() and set()
These have been satisfied.
