### PR TITLE
LineShape2D uses a narrower AABB to not fill up the cache with garbage.

### DIFF
--- a/servers/physics_2d/shape_2d_sw.cpp
+++ b/servers/physics_2d/shape_2d_sw.cpp
@@ -149,7 +149,7 @@ void LineShape2DSW::set_data(const Variant& p_data) {
 	ERR_FAIL_COND(arr.size()!=2);
 	normal=arr[0];
 	d=arr[1];
-	configure(Rect2(Vector2(-1e4,-1e4),Vector2(1e4*2,1e4*2)));
+	configure(Rect2(-1e4,0.0005,2e4,0.001));
 
 }
 


### PR DESCRIPTION
Fixes #4611 

Line2D, when changing, informs its parent that it has an AABB of 20000x20000 units. With the default cache size (128), that means ±30000 insertions in the cache!

Collision detection still doesn't work as it should, because the collision cache can't be infinite.
