### PR TITLE
Fix a XML error with the documentation

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -1103,7 +1103,7 @@
 			% key
 		</constant>
 		<constant name="KEY_AMPERSAND" value="38">
-			& key
+			&amp; key
 		</constant>
 		<constant name="KEY_APOSTROPHE" value="39">
 			' key


### PR DESCRIPTION
An ampersand was left by #4563 without it being a valid XML token.

@akien-mga ~ Can we have travis check if doc_status.py crashes?
