### PR TITLE
Added 'fat' option for bits param on scons for osx, this will produce…

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -117,7 +117,7 @@ if profile:
 
 opts=Variables(customs, ARGUMENTS)
 opts.Add('target', 'Compile Target (debug/release_debug/release).', "debug")
-opts.Add('bits', 'Compile Target Bits (default/32/64).', "default")
+opts.Add('bits', 'Compile Target Bits (default/32/64/fat).', "default")
 opts.Add('platform','Platform: '+str(platform_list)+'.',"")
 opts.Add('p','Platform (same as platform=).',"")
 opts.Add('tools','Build Tools (Including Editor): (yes/no)','yes')
@@ -276,6 +276,8 @@ if selected_platform in platform_list:
 		suffix+=".32"
 	elif (env["bits"]=="64"):
 		suffix+=".64"
+	elif (env["bits"]=="fat"):
+		suffix+=".fat"
 
 	suffix+=env.extra_suffix
 

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -68,9 +68,12 @@ def configure(env):
 		if (env["bits"]=="64"):
 		    env.Append(CCFLAGS=['-arch', 'x86_64'])
 		    env.Append(LINKFLAGS=['-arch', 'x86_64'])
-		else:
+		elif (env["bits"]=="32"):
 		    env.Append(CCFLAGS=['-arch', 'i386'])
 		    env.Append(LINKFLAGS=['-arch', 'i386'])
+		else:
+		    env.Append(CCFLAGS=['-arch', 'i386', '-arch', 'x86_64'])
+		    env.Append(LINKFLAGS=['-arch', 'i386', '-arch', 'x86_64'])
 	else:
 		#osxcross build
 		root=os.environ.get("OSXCROSS_ROOT",0)


### PR DESCRIPTION
… a fat binary that contains both 32 bits and 64 bits binaries.

With this godot can be distributed for OSX with only one binary.
