### PR TITLE
fix String error

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -3744,6 +3744,7 @@ String String::sprintf(const Array& values, bool* error) const {
 					break;
 				}
 				case 'd': // Integer (signed)
+				case 'i': // Integer (signed)
 				case 'o': // Octal
 				case 'x': // Hexadecimal (lowercase)
 				case 'X': { // Hexadecimal (uppercase)
@@ -3760,6 +3761,7 @@ String String::sprintf(const Array& values, bool* error) const {
 					bool capitalize = false;
 					switch (c) {
 						case 'd': base = 10; break;
+						case 'i': base = 10; break;
 						case 'o': base = 8; break;
 						case 'x': base = 16; break;
 						case 'X': base = 16; capitalize = true; break;


### PR DESCRIPTION
#4733 uses `vformat` with `%i`.

this causes error when open project with editor.

```
ERROR: vformat: Condition ' error ' is true. returned: String()
   At: core\variant.cpp:3090
```

because vformat doesn't have %i format.
