### PR TITLE
Change the default comment color to #676767

### DIFF
--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -401,7 +401,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("text_editor/engine_type_color",Color::html("83d3ff"));
 	set("text_editor/function_color",Color::html("66a2ce"));
 	set("text_editor/member_variable_color",Color::html("e64e59"));
-	set("text_editor/comment_color",Color::html("983d1b"));
+	set("text_editor/comment_color",Color::html("676767"));
 	set("text_editor/string_color",Color::html("ef6ebe"));
 	set("text_editor/number_color",Color::html("EB9532"));
 	set("text_editor/symbol_color",Color::html("badfff"));


### PR DESCRIPTION
A neutral gray color, more readable than the old brown one.

The current brown color is not very readable, especially on screens with a poor contrast ratio.

Example:

![Example screenshot](https://lut.im/BbCeCz0pkm/7dtkEYelQduE9lh4.png)
