### PR TITLE
Polygon2D now exposes vertex colors.

### DIFF
--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -145,7 +145,18 @@ void Polygon2D::_notification(int p_what) {
 
 
 			Vector<Color> colors;
-			colors.push_back(color);
+			int color_len=vertex_colors.size();
+			colors.resize(len);
+			{
+				DVector<Color>::Read color_r=vertex_colors.read();
+				for(int i=0;i<color_len && i<len;i++){
+					colors[i]=color_r[i];
+				}
+				for(int i=color_len;i<len;i++){
+					colors[i]=color;
+				}
+			}
+
 			Vector<int> indices = Geometry::triangulate_polygon(points);
 
 			VS::get_singleton()->canvas_item_add_triangle_array(get_canvas_item(),indices,points,colors,uvs,texture.is_valid()?texture->get_rid():RID());
@@ -186,6 +197,16 @@ void Polygon2D::set_color(const Color& p_color){
 Color Polygon2D::get_color() const{
 
 	return color;
+}
+
+void Polygon2D::set_vertex_colors(const DVector<Color>& p_colors){
+
+	vertex_colors=p_colors;
+	update();
+}
+DVector<Color> Polygon2D::get_vertex_colors() const{
+
+	return vertex_colors;
 }
 
 void Polygon2D::set_texture(const Ref<Texture>& p_texture){
@@ -293,6 +314,9 @@ void Polygon2D::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_color","color"),&Polygon2D::set_color);
 	ObjectTypeDB::bind_method(_MD("get_color"),&Polygon2D::get_color);
 
+	ObjectTypeDB::bind_method(_MD("set_vertex_colors","vertex_colors"),&Polygon2D::set_vertex_colors);
+	ObjectTypeDB::bind_method(_MD("get_vertex_colors"),&Polygon2D::get_vertex_colors);
+
 	ObjectTypeDB::bind_method(_MD("set_texture","texture"),&Polygon2D::set_texture);
 	ObjectTypeDB::bind_method(_MD("get_texture"),&Polygon2D::get_texture);
 
@@ -323,6 +347,7 @@ void Polygon2D::_bind_methods() {
 	ADD_PROPERTY( PropertyInfo(Variant::VECTOR2_ARRAY,"polygon"),_SCS("set_polygon"),_SCS("get_polygon"));
 	ADD_PROPERTY( PropertyInfo(Variant::VECTOR2_ARRAY,"uv"),_SCS("set_uv"),_SCS("get_uv"));
 	ADD_PROPERTY( PropertyInfo(Variant::COLOR,"color"),_SCS("set_color"),_SCS("get_color"));
+	ADD_PROPERTY( PropertyInfo(Variant::COLOR_ARRAY,"vertex_colors"),_SCS("set_vertex_colors"),_SCS("get_vertex_colors"));
 	ADD_PROPERTY( PropertyInfo(Variant::VECTOR2,"offset"),_SCS("set_offset"),_SCS("get_offset"));
 	ADD_PROPERTY( PropertyInfo(Variant::OBJECT,"texture/texture",PROPERTY_HINT_RESOURCE_TYPE,"Texture"),_SCS("set_texture"),_SCS("get_texture"));
 	ADD_PROPERTY( PropertyInfo(Variant::VECTOR2,"texture/offset"),_SCS("set_texture_offset"),_SCS("get_texture_offset"));

--- a/scene/2d/polygon_2d.h
+++ b/scene/2d/polygon_2d.h
@@ -9,6 +9,7 @@ class Polygon2D : public Node2D {
 
 	DVector<Vector2> polygon;
 	DVector<Vector2> uv;
+	DVector<Color> vertex_colors;
 	Color color;
 	Ref<Texture> texture;
 	Vector2 tex_scale;
@@ -39,6 +40,9 @@ public:
 
 	void set_color(const Color& p_color);
 	Color get_color() const;
+
+	void set_vertex_colors(const DVector<Color>& p_colors);
+	DVector<Color> get_vertex_colors() const;
 
 	void set_texture(const Ref<Texture>& p_texture);
 	Ref<Texture> get_texture() const;


### PR DESCRIPTION
The original Color property is now the default color for unspecified vertices, to preserve compatibility with the old behavior.
