### PR TITLE
use node name as filename when save scene

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -2151,7 +2151,8 @@ void EditorNode::_menu_option_confirm(int p_option,bool p_confirmed) {
 
 				String existing;
 				if (extensions.size()) {
-					existing="new_scene."+extensions.front()->get().to_lower();
+					String root_name(get_edited_scene()->get_name());
+					existing=root_name+"."+extensions.front()->get().to_lower();
 				}
 				file->set_current_path(existing);
 

--- a/tools/editor/scene_tree_dock.cpp
+++ b/tools/editor/scene_tree_dock.cpp
@@ -583,7 +583,8 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 			String existing;
 			if (extensions.size()) {
-				existing="new_scene."+extensions.front()->get().to_lower();
+				String root_name(tocopy->get_name());
+				existing=root_name+"."+extensions.front()->get().to_lower();
 			}
 			new_scene_from_dialog->set_current_path(existing);
 


### PR DESCRIPTION
fix #4723
