### PR TITLE
fix unexpected char: '\' error on windows for android module

### DIFF
--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -65,17 +65,17 @@ for x in env.android_java_dirs:
 gradle_res_dirs_text=""
 
 for x in env.android_res_dirs:
-	gradle_res_dirs_text+=",'"+x+"'"
+	gradle_res_dirs_text+=",'"+x.replace("\\","/")+"'"
 
 gradle_aidl_dirs_text=""
 
 for x in env.android_aidl_dirs:
-	gradle_aidl_dirs_text+=",'"+x+"'"
+	gradle_aidl_dirs_text+=",'"+x.replace("\\","/")+"'"
 
 gradle_jni_dirs_text=""
 
 for x in env.android_jni_dirs:
-	gradle_jni_dirs_text+=",'"+x+"'"
+	gradle_jni_dirs_text+=",'"+x.replace("\\","/")+"'"
 
 gradle_asset_dirs_text=""
 


### PR DESCRIPTION
error occurred when register additional directory for android module on windows.
### config.py

``` python
def can_build(plat):
    return plat=="android"

def configure(env):
    if (env['platform'] == 'android'):
        env.android_add_res_dir("android/res")
```
