### PR TITLE
Add a slider for zooming TileMap preview icons.

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -720,7 +720,7 @@ void ItemList::ensure_current_is_visible() {
 	update();
 }
 
-static Size2 _adjust_to_max_size(Size2 p_size, Size2 p_max_size) {
+static Size2 _adjust_to_max_size(Size2 p_size, Size2 p_max_size, bool p_stretch) {
 
 	if (p_max_size.x<=0)
 		p_max_size.x=1e20;
@@ -729,6 +729,10 @@ static Size2 _adjust_to_max_size(Size2 p_size, Size2 p_max_size) {
 
 
 	Size2 new_size;
+
+	if (p_stretch && (p_size.x * p_size.y < p_max_size.x * p_max_size.y)) {
+		return p_max_size;
+	}
 
 	if (p_size.x > p_max_size.x) {
 
@@ -831,7 +835,7 @@ void ItemList::_notification(int p_what) {
 				Size2 minsize;
 				if (items[i].icon.is_valid()) {
 
-					minsize=_adjust_to_max_size(items[i].get_icon_size(),max_icon_size);
+					minsize=_adjust_to_max_size(items[i].get_icon_size(),max_icon_size, icon_stretch);
 
 					if (items[i].text!="") {
 						if (icon_mode==ICON_MODE_TOP) {
@@ -976,7 +980,7 @@ void ItemList::_notification(int p_what) {
 			Vector2 text_ofs;
 			if (items[i].icon.is_valid()) {
 
-				Size2 icon_size = _adjust_to_max_size(items[i].get_icon_size(),max_icon_size);
+				Size2 icon_size = _adjust_to_max_size(items[i].get_icon_size(),max_icon_size, icon_stretch);
 
 				Vector2 icon_ofs;
 				if (min_icon_size!=Vector2()) {
@@ -1201,6 +1205,16 @@ bool ItemList::get_allow_rmb_select() const {
 	return allow_rmb_select;
 }
 
+void ItemList::set_icon_stretch_to_max_size(bool p_stretch) {
+
+	icon_stretch = p_stretch;
+}
+
+bool ItemList::get_icon_stretch_to_max_size() const {
+
+	return icon_stretch;
+}
+
 void ItemList::_bind_methods(){
 
 	ObjectTypeDB::bind_method(_MD("add_item","text","icon:Texture","selectable"),&ItemList::add_item,DEFVAL(Variant()),DEFVAL(true));
@@ -1261,6 +1275,9 @@ void ItemList::_bind_methods(){
 	ObjectTypeDB::bind_method(_MD("set_max_icon_size","size"),&ItemList::set_max_icon_size);
 	ObjectTypeDB::bind_method(_MD("get_max_icon_size"),&ItemList::get_max_icon_size);
 
+	ObjectTypeDB::bind_method(_MD("set_icon_stretch_to_max_size","stretch"),&ItemList::set_icon_stretch_to_max_size);
+	ObjectTypeDB::bind_method(_MD("get_icon_stretch_to_max_size"),&ItemList::get_icon_stretch_to_max_size);
+
 	ObjectTypeDB::bind_method(_MD("set_allow_rmb_select","allow"),&ItemList::set_allow_rmb_select);
 	ObjectTypeDB::bind_method(_MD("get_allow_rmb_select"),&ItemList::get_allow_rmb_select);
 
@@ -1307,6 +1324,8 @@ ItemList::ItemList() {
 	ensure_selected_visible=false;
 	defer_select_single=-1;
 	allow_rmb_select=false;
+
+	icon_stretch = false;
 
 }
 

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -45,6 +45,8 @@ private:
 
 	bool ensure_selected_visible;
 
+	bool icon_stretch;
+
 	Vector<Item> items;
 	Vector<int> separators;
 
@@ -149,6 +151,9 @@ public:
 
 	virtual String get_tooltip(const Point2& p_pos) const;
 	int get_item_at_pos(const Point2& p_pos,bool p_exact=false) const;
+
+	void set_icon_stretch_to_max_size(bool p_stretch);
+	bool get_icon_stretch_to_max_size() const;
 
 	ItemList();
 	~ItemList();

--- a/tools/editor/plugins/tile_map_editor_plugin.cpp
+++ b/tools/editor/plugins/tile_map_editor_plugin.cpp
@@ -1208,6 +1208,16 @@ void TileMapEditor::_tileset_settings_changed() {
 		canvas_item_editor->update();
 }
 
+void TileMapEditor::_icon_size_changed(float p_value) {
+	if (node) {
+		Size2 size = node->get_cell_size() * p_value;
+		palette->set_min_icon_size(size + Size2(4, 0)); //4px gap between tiles
+		palette->set_icon_stretch_to_max_size(true);
+		palette->set_max_icon_size(size);
+		_update_palette();
+	}
+}
+
 void TileMapEditor::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("_text_entered"),&TileMapEditor::_text_entered);
@@ -1222,6 +1232,8 @@ void TileMapEditor::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("_fill_points"),&TileMapEditor::_fill_points);
 	ObjectTypeDB::bind_method(_MD("_erase_points"),&TileMapEditor::_erase_points);
+
+	ObjectTypeDB::bind_method(_MD("_icon_size_changed"), &TileMapEditor::_icon_size_changed);
 }
 
 TileMapEditor::CellOp TileMapEditor::_get_op_from_cell(const Point2i& p_pos)
@@ -1296,6 +1308,15 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 	search_box->connect("text_changed", this, "_text_changed");
 	search_box->connect("input_event", this, "_sbox_input");
 	add_child(search_box);
+
+	size_slider = memnew( HSlider );
+	size_slider->set_h_size_flags(SIZE_EXPAND_FILL);
+	size_slider->set_min(0.1f);
+	size_slider->set_max(4.0f);
+	size_slider->set_step(0.1f);
+	size_slider->set_val(1.0f);
+	size_slider->connect("value_changed", this, "_icon_size_changed");
+	add_child(size_slider);
 
 	int mw = EDITOR_DEF("tile_map/palette_min_width", 80);
 

--- a/tools/editor/plugins/tile_map_editor_plugin.h
+++ b/tools/editor/plugins/tile_map_editor_plugin.h
@@ -76,6 +76,7 @@ class TileMapEditor : public VBoxContainer {
 	Control *canvas_item_editor;
 
 	LineEdit *search_box;
+	HSlider  *size_slider;
 	ItemList *palette;
 
 	HBoxContainer *toolbar;
@@ -151,6 +152,7 @@ class TileMapEditor : public VBoxContainer {
 	void _canvas_mouse_enter();
 	void _canvas_mouse_exit();
 	void _tileset_settings_changed();
+	void _icon_size_changed(float p_value);
 
 protected:
 


### PR DESCRIPTION
Fixes #2413
Can also be used for scaling down large tilesets.

16x16 tiles, default scale:
![16x16_default](https://cloud.githubusercontent.com/assets/8281916/15513432/eabbbf4c-21e4-11e6-8fc3-75482a96b84e.png)

16x16, scaled:
![16x16_scaled](https://cloud.githubusercontent.com/assets/8281916/15513455/f74c89da-21e4-11e6-9225-a56388a8d800.png)
