### PR TITLE
Reload scene if it was modified on disk.

### DIFF
--- a/tools/editor/editor_data.cpp
+++ b/tools/editor/editor_data.cpp
@@ -765,7 +765,15 @@ Dictionary EditorData::restore_edited_scene_state(EditorSelection *p_selection, 
 	return es.custom_state;
 }
 
+void EditorData::set_edited_scene_md5(const String& p_md5){
+	ERR_FAIL_INDEX(current_edited_scene,edited_scene.size());
+	edited_scene[current_edited_scene].md5 = p_md5;
+}
 
+String EditorData::get_edited_scene_md5() const{
+	ERR_FAIL_INDEX_V(current_edited_scene,edited_scene.size(), "");
+	return edited_scene[current_edited_scene].md5;
+}
 void EditorData::set_edited_scene_import_metadata(Ref<ResourceImportMetadata> p_mdata) {
 
 	ERR_FAIL_INDEX(current_edited_scene,edited_scene.size());

--- a/tools/editor/editor_data.h
+++ b/tools/editor/editor_data.h
@@ -135,6 +135,7 @@ private:
 		int history_current;
 		Dictionary custom_state;
 		uint64_t version;
+		String md5;
 		NodePath live_edit_root;
 
 
@@ -184,10 +185,12 @@ public:
 	void remove_scene(int p_idx);
 	void set_edited_scene(int p_idx);
 	void set_edited_scene_root(Node* p_root);
+	void set_edited_scene_md5(const String& p_md5);
 	void set_edited_scene_import_metadata(Ref<ResourceImportMetadata> p_mdata);
 	Ref<ResourceImportMetadata> get_edited_scene_import_metadata(int p_idx = -1) const;
 	int get_edited_scene() const;
 	Node* get_edited_scene_root(int p_idx = -1);
+	String get_edited_scene_md5() const;
 	int get_edited_scene_count() const;
 	String get_scene_title(int p_idx) const;
 	String get_scene_path(int p_idx) const;

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -398,6 +398,7 @@ void EditorNode::_notification(int p_what) {
 
 		waiting_for_sources_changed=true;
 		EditorFileSystem::get_singleton()->scan_sources();
+		call_deferred("_reload_edited_scene_if_changed");
 
 	}
 
@@ -2101,6 +2102,10 @@ void EditorNode::_menu_option_confirm(int p_option,bool p_confirmed) {
 			_update_scene_tabs();
 			current_option = -1;
 		} break;
+		case SCENE_RELOAD: {
+			_reload_edited_scene();
+			current_option = -1;
+		} break;
 		case FILE_SAVE_SCENE: {
 
 
@@ -3468,8 +3473,55 @@ Dictionary EditorNode::_get_main_scene_state() {
 	return state;
 }
 
-void EditorNode::_set_main_scene_state(Dictionary p_state,Node* p_for_scene) {
+void EditorNode::_reload_edited_scene_if_changed() {
+	Node* current_scene = get_edited_scene();
+	if (!current_scene)
+		return;
 
+	String path = current_scene->get_filename();
+	if (path == String())
+		return;
+	
+	if (!FileAccess::exists(path)){
+		show_warning(TTR("The scene file has been deleted from disk") + " (" + path + ")");
+		set_current_version(0);
+		_update_scene_tabs();
+		return;
+	}
+
+	String md5 = FileAccess::get_md5(path);
+	if (editor_data.get_edited_scene_md5() == md5)
+		return;
+
+	if (saved_version==editor_data.get_undo_redo().get_version()) {
+		_reload_edited_scene();
+	} else {
+		current_option = SCENE_RELOAD;
+		confirmation->get_ok()->set_text(TTR("Reload from disk"));
+		confirmation->set_text(TTR("The scene file has been modified on the disk."));
+		confirmation->popup_centered_minsize();
+		editor_data.set_edited_scene_md5(md5); // ask only once
+	}
+}
+
+void EditorNode::_reload_edited_scene(){
+	Node* current_scene = get_edited_scene();
+	if (!current_scene)
+		return;
+
+	String path = current_scene->get_filename();
+	if (path == String())
+		return;
+
+	int idx = editor_data.get_edited_scene();
+	editor_data.remove_scene(idx);
+	editor_data.get_undo_redo().clear_history();
+	Error err = load_scene(path);
+	if (err == OK)
+		editor_data.move_edited_scene_to_index(idx);
+}
+
+void EditorNode::_set_main_scene_state(Dictionary p_state,Node* p_for_scene) {
 	if (get_edited_scene()!=p_for_scene && p_for_scene!=NULL)
 		return; //not for this scene
 
@@ -3616,6 +3668,7 @@ void EditorNode::set_current_scene(int p_idx) {
 	//_set_main_scene_state(state);
 
 	call_deferred("_set_main_scene_state",state,get_edited_scene()); //do after everything else is done setting up
+	call_deferred("_reload_edited_scene_if_changed");
 	//print_line("set current 6 ");
 
 
@@ -3801,6 +3854,7 @@ Error EditorNode::load_scene(const String& p_scene, bool p_ignore_broken_deps,bo
 	editor_data.set_edited_scene_root(new_scene);
 */
 	editor_data.set_edited_scene_import_metadata( sdata->get_import_metadata() );
+	editor_data.set_edited_scene_md5(FileAccess::get_md5(lpath));
 
 //	editor_data.get_undo_redo().clear_history();
 	saved_version=editor_data.get_undo_redo().get_version();
@@ -5337,6 +5391,8 @@ void EditorNode::_bind_methods() {
 	ObjectTypeDB::bind_method("_scene_tab_script_edited",&EditorNode::_scene_tab_script_edited);
 	ObjectTypeDB::bind_method("_set_main_scene_state",&EditorNode::_set_main_scene_state);
 	ObjectTypeDB::bind_method("_update_scene_tabs",&EditorNode::_update_scene_tabs);
+	ObjectTypeDB::bind_method("_reload_edited_scene",&EditorNode::_reload_edited_scene);
+	ObjectTypeDB::bind_method("_reload_edited_scene_if_changed",&EditorNode::_reload_edited_scene_if_changed);
 
 	ObjectTypeDB::bind_method("_prepare_history",&EditorNode::_prepare_history);
 	ObjectTypeDB::bind_method("_select_history",&EditorNode::_select_history);

--- a/tools/editor/editor_node.h
+++ b/tools/editor/editor_node.h
@@ -195,6 +195,7 @@ private:
 		DEPENDENCY_LOAD_CHANGED_IMAGES,
 		DEPENDENCY_UPDATE_IMPORTED,
 		SCENE_TAB_CLOSE,
+		SCENE_RELOAD,
 
 		IMPORT_PLUGIN_BASE=100,
 
@@ -513,6 +514,8 @@ private:
 	void _cleanup_scene();
 	void _remove_edited_scene();
 	void _remove_scene(int index);
+	void _reload_edited_scene();
+	void _reload_edited_scene_if_changed();
 	bool _find_and_save_resource(RES p_res,Map<RES,bool>& processed,int32_t flags);
 	bool _find_and_save_edited_subresources(Object *obj,Map<RES,bool>& processed,int32_t flags);
 	void _save_edited_subresources(Node* scene,Map<RES,bool>& processed,int32_t flags);


### PR DESCRIPTION
This PR fixes #4769.
- Reload silently if the scene has no local modifications
- Ask user if the scene has local modifications
