### PR TITLE
Added breakpoint markers, issue 4750

### DIFF
--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -92,6 +92,7 @@ class TextEdit : public Control  {
 		int row_height;
 		int line_spacing;
 		int line_number_w;
+		int breakpoint_gutter_width;
 		Size2 size;
 	} cache;
 
@@ -222,6 +223,8 @@ class TextEdit : public Control  {
 	bool text_changed_dirty;
 	bool undo_enabled;
 	bool line_numbers;
+	bool draw_breakpoint_gutter;
+	int breakpoint_gutter_width;
 
 	bool highlight_all_occurrences;
 	bool scroll_past_end_of_file_enabled;
@@ -450,6 +453,12 @@ public:
 	void menu_option(int p_option);
 
 	void set_show_line_numbers(bool p_show);
+
+	void set_draw_breakpoint_gutter(bool p_draw);
+	bool is_drawing_breakpoint_gutter() const;
+
+	void set_breakpoint_gutter_width(int p_gutter_width);
+	int get_breakpoint_gutter_width() const;
 
 	void set_tooltip_request_func(Object *p_obj, const StringName& p_function, const Variant& p_udata);
 

--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -414,6 +414,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("text_editor/draw_tabs", true);
 
 	set("text_editor/show_line_numbers", true);
+	set("text_editor/show_breakpoint_gutter", true);
 
 	set("text_editor/trim_trailing_whitespace_on_save", false);
 	set("text_editor/idle_parse_delay",2);

--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -586,7 +586,7 @@ void ScriptTextEditor::_bind_methods() {
 }
 
 ScriptTextEditor::ScriptTextEditor() {
-
+	get_text_edit()->set_breakpoint_gutter_width(12);
 }
 
 /*** SCRIPT EDITOR ******/
@@ -2034,6 +2034,7 @@ void ScriptEditor::edit(const Ref<Script>& p_script) {
 	ste->get_text_edit()->set_highlight_all_occurrences(EditorSettings::get_singleton()->get("text_editor/highlight_all_occurrences"));
 	ste->get_text_edit()->cursor_set_blink_enabled(EditorSettings::get_singleton()->get("text_editor/caret_blink"));
 	ste->get_text_edit()->cursor_set_blink_speed(EditorSettings::get_singleton()->get("text_editor/caret_blink_speed"));
+	ste->get_text_edit()->set_draw_breakpoint_gutter(EditorSettings::get_singleton()->get("text_editor/show_breakpoint_gutter"));
 	ste->get_text_edit()->set_callhint_settings(
 		EditorSettings::get_singleton()->get("text_editor/put_callhint_tooltip_below_current_line"),
 		EditorSettings::get_singleton()->get("text_editor/callhint_tooltip_offset"));
@@ -2190,6 +2191,7 @@ void ScriptEditor::_editor_settings_changed() {
 		ste->get_text_edit()->set_highlight_all_occurrences(EditorSettings::get_singleton()->get("text_editor/highlight_all_occurrences"));
 		ste->get_text_edit()->cursor_set_blink_enabled(EditorSettings::get_singleton()->get("text_editor/caret_blink"));
 		ste->get_text_edit()->cursor_set_blink_speed(EditorSettings::get_singleton()->get("text_editor/caret_blink_speed"));
+		ste->get_text_edit()->set_draw_breakpoint_gutter(EditorSettings::get_singleton()->get("text_editor/show_breakpoint_gutter"));
 	}
 
 }


### PR DESCRIPTION
Added an optional gutter for drawing breakpoint markers. You can click the gutter to toggle the breakpoint on that line. Lastly, It changes the cursor to `CURSOR_ARROW` when hovering over the gutter and line numbers. 

It looks like the following image: 

![breakpoint_gutter_final](https://cloud.githubusercontent.com/assets/6584330/15575907/264d14ac-234d-11e6-82a5-1e2ded68bb18.png)

closes #4750 
