### PR TITLE
Fix crash when redoing backspace to clear selection

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1820,7 +1820,9 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 				}
 				if (clear) {
 
-					begin_complex_operation();
+					if (!dobreak) {
+						begin_complex_operation();
+					}
 					selection.active=false;
 					update();
 					_remove_text(selection.from_line,selection.from_column,selection.to_line,selection.to_column);


### PR DESCRIPTION
Fixes a crash that would occur if you tried to redo a backspaced selection.

related to #4818 
