### PR TITLE
Ability to rename autoloads

### DIFF
--- a/tools/editor/project_settings.h
+++ b/tools/editor/project_settings.h
@@ -91,6 +91,7 @@ class ProjectSettings : public AcceptDialog {
 
 
 	Tree *autoload_list;
+	String selected_autoload;
 	EditorFileDialog *autoload_file_open;
 	LineEdit *autoload_add_name;
 	LineEdit *autoload_add_path;
@@ -104,6 +105,7 @@ class ProjectSettings : public AcceptDialog {
 	void _autoload_edited();
 	void _autoload_file_open();
 	void _autoload_delete(Object *p_item,int p_column, int p_button);
+	void _autoload_selected();
 	bool updating_autoload;
 
 


### PR DESCRIPTION
This PR makes the 'Name' field of autoloads editable, with support
for undo/redo. Name clashes/invalid characters are handled. Fixes #3481.

I used the _action_edited function (which renames input actions) as a base for some of the logic, and I think I've tested the functionnality pretty thoroughly, no errors, undo/redo works, the autoloads' order is preserved... should be good!
