### PR TITLE
[WIP/RFC] Fix calling XMapWindow before XSetClassHint

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -413,6 +413,7 @@ public:
 	enum EngineContext {
 		CONTEXT_EDITOR,
 		CONTEXT_PROJECTMAN,
+		CONTEXT_PLAYER,
 	};
 
 	virtual void set_context(int p_context);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1344,6 +1344,7 @@ bool Main::start() {
 			} else {
 #endif
 
+				OS::get_singleton()->set_context(OS::CONTEXT_PLAYER);
 				{
 					//autoload
 					List<PropertyInfo> props;

--- a/platform/x11/context_gl_x11.cpp
+++ b/platform/x11/context_gl_x11.cpp
@@ -120,14 +120,6 @@ Error ContextGL_X11::initialize() {
 	*/
 		x11_window = XCreateWindow(x11_display, RootWindow(x11_display, vi->screen), 0, 0, OS::get_singleton()->get_video_mode().width, OS::get_singleton()->get_video_mode().height, 0, vi->depth, InputOutput, vi->visual, CWBorderPixel|CWColormap|CWEventMask, &swa);
 		ERR_FAIL_COND_V(!x11_window,ERR_UNCONFIGURED);
-		XMapWindow(x11_display, x11_window);
-		while(true) {
-			// wait for mapnotify (window created)
-			XEvent e;
-			XNextEvent(x11_display, &e);
-			if (e.type == MapNotify)
-				break;
-		}
 		//};
 
 

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -1797,9 +1797,20 @@ void OS_X11::set_context(int p_context) {
 			classHint->res_name = (char *)"Godot_Editor";
 		if (p_context == CONTEXT_PROJECTMAN)
 			classHint->res_name = (char *)"Godot_ProjectList";
+		if (p_context == CONTEXT_PLAYER)
+			classHint->res_name = (char *)"Godot_Player";
 		classHint->res_class = (char *)"Godot";
 		XSetClassHint(x11_display, x11_window, classHint);
 		XFree(classHint);
+	}
+  
+	XMapWindow(x11_display, x11_window);
+	while(true) {
+		// wait for mapnotify (window created)
+		XEvent e;
+		XNextEvent(x11_display, &e);
+		if (e.type == MapNotify)
+			break;
 	}
 }
 


### PR DESCRIPTION
Add new context CONTEXT_PLAYER, move the XMapWindow call to the
set_context function in os_x11.cpp. Add another set_context call for
when you hit the play button.

Resolves #4827 

**NOTE:** This pull request really needs to be reviewed/tested as it might lead to other bugs. There might also be better ways of doing this than what I have done here.
