### PR TITLE
Proper alignment and fixed scaling for TileMapEditor tile icons.

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -720,7 +720,7 @@ void ItemList::ensure_current_is_visible() {
 	update();
 }
 
-static Size2 _adjust_to_max_size(Size2 p_size, Size2 p_max_size, bool p_stretch) {
+static Size2 _adjust_to_max_size(Size2 p_size, Size2 p_max_size) {
 
 	if (p_max_size.x<=0)
 		p_max_size.x=1e20;
@@ -729,10 +729,6 @@ static Size2 _adjust_to_max_size(Size2 p_size, Size2 p_max_size, bool p_stretch)
 
 
 	Size2 new_size;
-
-	if (p_stretch && (p_size.x * p_size.y < p_max_size.x * p_max_size.y)) {
-		return p_max_size;
-	}
 
 	if (p_size.x > p_max_size.x) {
 
@@ -835,7 +831,7 @@ void ItemList::_notification(int p_what) {
 				Size2 minsize;
 				if (items[i].icon.is_valid()) {
 
-					minsize=_adjust_to_max_size(items[i].get_icon_size(),max_icon_size, icon_stretch);
+					minsize=_adjust_to_max_size(items[i].get_icon_size(),max_icon_size) * icon_scale;
 
 					if (items[i].text!="") {
 						if (icon_mode==ICON_MODE_TOP) {
@@ -980,7 +976,7 @@ void ItemList::_notification(int p_what) {
 			Vector2 text_ofs;
 			if (items[i].icon.is_valid()) {
 
-				Size2 icon_size = _adjust_to_max_size(items[i].get_icon_size(),max_icon_size, icon_stretch);
+				Size2 icon_size = _adjust_to_max_size(items[i].get_icon_size(),max_icon_size) * icon_scale;
 
 				Vector2 icon_ofs;
 				if (min_icon_size!=Vector2()) {
@@ -1205,14 +1201,12 @@ bool ItemList::get_allow_rmb_select() const {
 	return allow_rmb_select;
 }
 
-void ItemList::set_icon_stretch_to_max_size(bool p_stretch) {
-
-	icon_stretch = p_stretch;
+void ItemList::set_icon_scale(real_t p_scale) {
+	icon_scale = p_scale;
 }
 
-bool ItemList::get_icon_stretch_to_max_size() const {
-
-	return icon_stretch;
+real_t ItemList::get_icon_scale() const {
+	return icon_scale;
 }
 
 void ItemList::_bind_methods(){
@@ -1275,8 +1269,8 @@ void ItemList::_bind_methods(){
 	ObjectTypeDB::bind_method(_MD("set_max_icon_size","size"),&ItemList::set_max_icon_size);
 	ObjectTypeDB::bind_method(_MD("get_max_icon_size"),&ItemList::get_max_icon_size);
 
-	ObjectTypeDB::bind_method(_MD("set_icon_stretch_to_max_size","stretch"),&ItemList::set_icon_stretch_to_max_size);
-	ObjectTypeDB::bind_method(_MD("get_icon_stretch_to_max_size"),&ItemList::get_icon_stretch_to_max_size);
+	ObjectTypeDB::bind_method(_MD("set_icon_scale","scale"),&ItemList::set_icon_scale);
+	ObjectTypeDB::bind_method(_MD("get_icon_scale"),&ItemList::get_icon_scale);
 
 	ObjectTypeDB::bind_method(_MD("set_allow_rmb_select","allow"),&ItemList::set_allow_rmb_select);
 	ObjectTypeDB::bind_method(_MD("get_allow_rmb_select"),&ItemList::get_allow_rmb_select);
@@ -1325,8 +1319,7 @@ ItemList::ItemList() {
 	defer_select_single=-1;
 	allow_rmb_select=false;
 
-	icon_stretch = false;
-
+	icon_scale = 1.0f;
 }
 
 ItemList::~ItemList() {

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -45,8 +45,6 @@ private:
 
 	bool ensure_selected_visible;
 
-	bool icon_stretch;
-
 	Vector<Item> items;
 	Vector<int> separators;
 
@@ -66,6 +64,8 @@ private:
 	int defer_select_single;
 
 	bool allow_rmb_select;
+
+	real_t icon_scale;
 
 	void _scroll_changed(double);
 	void _input_event(const InputEvent& p_event);
@@ -152,8 +152,8 @@ public:
 	virtual String get_tooltip(const Point2& p_pos) const;
 	int get_item_at_pos(const Point2& p_pos,bool p_exact=false) const;
 
-	void set_icon_stretch_to_max_size(bool p_stretch);
-	bool get_icon_stretch_to_max_size() const;
+	void set_icon_scale(real_t p_scale);
+	real_t get_icon_scale() const;
 
 	ItemList();
 	~ItemList();

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -33,6 +33,7 @@ private:
 		Color custom_bg;
 
 		Rect2 rect_cache;
+		Rect2 min_rect_cache;
 
 		Size2 get_icon_size() const;
 
@@ -44,6 +45,7 @@ private:
 	bool shape_changed;
 
 	bool ensure_selected_visible;
+	bool same_column_width;
 
 	Vector<Item> items;
 	Vector<int> separators;
@@ -59,8 +61,12 @@ private:
 	int fixed_column_width;
 	int max_text_lines;
 	int max_columns;
+
 	Size2 min_icon_size;
 	Size2 max_icon_size;
+
+	Size2 max_item_size_cache;
+
 	int defer_select_single;
 
 	bool allow_rmb_select;
@@ -122,6 +128,9 @@ public:
 
 	void set_fixed_column_width(int p_size);
 	int get_fixed_column_width() const;
+
+	void set_same_column_width(bool p_enable);
+	int is_same_column_width() const;
 
 	void set_max_text_lines(int p_amount);
 	int get_max_text_lines() const;

--- a/tools/editor/plugins/tile_map_editor_plugin.cpp
+++ b/tools/editor/plugins/tile_map_editor_plugin.cpp
@@ -1212,8 +1212,8 @@ void TileMapEditor::_icon_size_changed(float p_value) {
 	if (node) {
 		Size2 size = node->get_cell_size() * p_value;
 		palette->set_min_icon_size(size + Size2(4, 0)); //4px gap between tiles
-		palette->set_icon_stretch_to_max_size(true);
-		palette->set_max_icon_size(size);
+		//palette->set_max_icon_size(size);
+		palette->set_icon_scale(p_value);
 		_update_palette();
 	}
 }

--- a/tools/editor/plugins/tile_map_editor_plugin.cpp
+++ b/tools/editor/plugins/tile_map_editor_plugin.cpp
@@ -1214,8 +1214,6 @@ void TileMapEditor::_tileset_settings_changed() {
 
 void TileMapEditor::_icon_size_changed(float p_value) {
 	if (node) {
-		//Size2 size = node->get_cell_size() * p_value;
-		//palette->set_min_icon_size(size + Size2(4, 0)); //4px gap between tiles
 		palette->set_icon_scale(p_value);
 		_update_palette();
 	}

--- a/tools/editor/plugins/tile_map_editor_plugin.cpp
+++ b/tools/editor/plugins/tile_map_editor_plugin.cpp
@@ -205,7 +205,9 @@ void TileMapEditor::_update_palette() {
 	if (tiles.empty())
 		return;
 
+
 	palette->set_max_columns(0);
+	palette->add_constant_override("hseparation", 6);
 	palette->set_icon_mode(ItemList::ICON_MODE_TOP);
 	palette->set_max_text_lines(2);
 
@@ -239,6 +241,8 @@ void TileMapEditor::_update_palette() {
 
 		palette->set_item_metadata(palette->get_item_count()-1, E->get());
 	}
+	
+	palette->set_same_column_width(true);
 
 	if (selected != -1)
 		set_selected_tile(selected);
@@ -1210,9 +1214,8 @@ void TileMapEditor::_tileset_settings_changed() {
 
 void TileMapEditor::_icon_size_changed(float p_value) {
 	if (node) {
-		Size2 size = node->get_cell_size() * p_value;
-		palette->set_min_icon_size(size + Size2(4, 0)); //4px gap between tiles
-		//palette->set_max_icon_size(size);
+		//Size2 size = node->get_cell_size() * p_value;
+		//palette->set_min_icon_size(size + Size2(4, 0)); //4px gap between tiles
 		palette->set_icon_scale(p_value);
 		_update_palette();
 	}


### PR DESCRIPTION
Makes Tiles in the TileMapEditor nice & evenly distributed (thanks to @bojidar-bg).
Also, tiles with sizes different from the cell size are being properly scaled now.

Related to #4412 
