### PR TITLE
MenuButton: Avoid key event propagation if handled as hotkey

### DIFF
--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -39,7 +39,8 @@ void MenuButton::_unhandled_key_input(InputEvent p_event) {
 			return;
 
 
-		int item = popup->activate_item_by_event(p_event);
+		if (popup->activate_item_by_accelerator(code))
+			accept_event();
 	}
 }
 


### PR DESCRIPTION
Just avoid propagating it when already handled.

~~e.g: When the 2D editor and the shader editor are both visible, pressing <kbd>CTRL+F</kbd> with a node selected, both editors will handle the event, no matter which one is focused. The 2D editor will do _"Frame Selection"_ and the shader editor will popup the search dialog.~~

~~#### Do Not Merge!:
This PR is incomplete. It just avoids propagating the event if it was used. However, there is still other bug with `MenuButton` that need to be fixed. Until it's fixed, this PR may result in an even worse usability problem.
That bug is that there is no priority when propagating  unhandled key events to `MenuButton`s. Therefore, considering the previous example, if this PR is merged, the events will always be used by the shader editor's menu instead of the menu whose editor is focused, which is the expected behaviour.
A possible fix could be to create a relation between the `MenuButton` and that editor/Container, and handle the hotkey event only if that editor is a parent of the focused Control (`is_a_parent_of()`). I don't know what would be the performance penalty though.
Here is an issue about this last bug: #4856~~
