### PR TITLE
Conversion function for screen coords to local Canvas coords

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -7328,6 +7328,22 @@
 			</description>
 		</method>
 		<method name="update">
+		<method name="make_screen_coord_local" qualifiers="const">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="screen_point" type="Vector2">
+			</argument>
+			<description>
+				Take a 2d screen point and convert to 2D local coords relative to this Canvas
+				 item.  If this CanvasItem is the root of a Scene, its essentially the 
+				 world coords for that scene.
+			</description>
+		</method>
+		<method name="make_input_local" qualifiers="const">
+			<return type="InputEvent">
+			</return>
+			<argument index="0" name="event" type="InputEvent">
+			</argument>
 			<description>
 				Queue the CanvasItem for update. [code]NOTIFICATION_DRAW[/code] will be called on idle time to request redraw.
 			</description>

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -948,6 +948,15 @@ Ref<CanvasItemMaterial> CanvasItem::get_material() const{
 	return material;
 }
 
+Vector2 CanvasItem::make_canvas_pos_local(const Vector2& screen_point) const {
+
+	ERR_FAIL_COND_V(!is_inside_tree(),screen_point);
+
+	Matrix32 local_matrix = (get_canvas_transform() * 
+			get_global_transform()).affine_inverse();
+
+	return local_matrix.xform(screen_point);
+}
 
 InputEvent CanvasItem::make_input_local(const InputEvent& p_event) const {
 
@@ -1052,6 +1061,8 @@ void CanvasItem::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_use_parent_material","enable"),&CanvasItem::set_use_parent_material);
 	ObjectTypeDB::bind_method(_MD("get_use_parent_material"),&CanvasItem::get_use_parent_material);
 
+	ObjectTypeDB::bind_method(_MD("make_canvas_pos_local","screen_point"),
+			&CanvasItem::make_canvas_pos_local);
 	ObjectTypeDB::bind_method(_MD("make_input_local","event"),&CanvasItem::make_input_local);
 
 	BIND_VMETHOD(MethodInfo("_draw"));

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -263,6 +263,7 @@ public:
 	bool get_use_parent_material() const;
 
 	InputEvent make_input_local(const InputEvent& pevent) const;
+	Vector2 make_canvas_pos_local(const Vector2& screen_point) const;
 
 	Vector2 get_global_mouse_pos() const;
 	Vector2 get_local_mouse_pos() const;


### PR DESCRIPTION
- Useful if you need to Convert screen coords to the coordinate space of a CanvasItem, but don't have an
  associated InputEvent to use in #make_event_local.

For example, if you have a particular point on the screen you'd like to project into World Space, for various reasons, you would use this function on the root of the scene.  This is analogous to ray casting from screen space in 3D.
