### PR TITLE
Editor: Fix base dir when going back to project manager

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -2732,8 +2732,8 @@ void EditorNode::_menu_option_confirm(int p_option,bool p_confirmed) {
 			String exec = OS::get_singleton()->get_executable_path();
 
 			List<String> args;
-			//args.push_back ( "-path" );
-			//args.push_back (exec.get_base_dir() );
+			args.push_back("-path");
+			args.push_back(exec.get_base_dir());
 			args.push_back("-pm");
 
 			OS::ProcessID pid=0;


### PR DESCRIPTION
This caused the PM to load with the parameters of the previously loaded project.
Was a regression from ea751724a21e3513ff2291aa24491e9d91c8c0f0 (@punto- ;)).

Closes #4045.
