### PR TITLE
x11: Add support for filesystem drag & drop using xdnd

### DIFF
--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -70,6 +70,17 @@ typedef struct {
 class OS_X11 : public OS_Unix {
 
 	Atom wm_delete;
+	Atom xdnd_enter;
+	Atom xdnd_position;
+	Atom xdnd_status;
+	Atom xdnd_action_copy;
+	Atom xdnd_drop;
+	Atom xdnd_finished;
+	Atom xdnd_selection;
+	Atom requested;
+
+	int  xdnd_version;
+
 #if defined(OPENGL_ENABLED) || defined(LEGACYGL_ENABLED)
 	ContextGL_X11 *context_gl;
 #endif
@@ -78,6 +89,7 @@ class OS_X11 : public OS_Unix {
 	VideoMode current_videomode;
 	List<String> args;
 	Window x11_window;
+	Window xdnd_source_window;
 	MainLoop *main_loop;
 	::Display* x11_display;
 	char *xmbstring;


### PR DESCRIPTION
Accepting only the `text/uri-list` type for now, as it seemed the most common to me.

Tested with the following File managers:
- Dolphin
- Thunar
- Whatever the e20 one is called

and these DEs:
- KDE Plasma 5.6
- Cinnamon
- Enlightenment

All on Arch Linux, kernel 4.5, Xorg 18.3

~~The only one that didn't work was Nemo (on all WMs)... it seems not to send XdndEnter events to our window. I have no idea what's happening there yet.~~ **Edit:** Nemo works now, as does PCManFM
