### PR TITLE
Fix: Should never call cast_to on a NULL object

### DIFF
--- a/core/object.h
+++ b/core/object.h
@@ -498,8 +498,6 @@ public:
 #ifndef NO_SAFE_CAST
 		return SAFE_CAST<T*>(this);
 #else
-		if (!this)
-			return NULL;
 		if (is_type_ptr(T::get_type_ptr_static()))
 			return static_cast<T*>(this);
 		else
@@ -513,8 +511,6 @@ public:
 #ifndef NO_SAFE_CAST
 		return SAFE_CAST<const T*>(this);
 #else
-		if (!this)
-			return NULL;
 		if (is_type_ptr(T::get_type_ptr_static()))
 			return static_cast<const T*>(this);
 		else

--- a/modules/gdscript/gd_script.cpp
+++ b/modules/gdscript/gd_script.cpp
@@ -394,6 +394,11 @@ Variant GDFunction::call(GDInstance *p_instance, const Variant **p_args, int p_a
 				Object *obj_A = *a;
 				Object *obj_B = *b;
 
+				// Make sure never NULL when caling #cast_to
+				if(obj_B == NULL) {
+					err_text="Right operand of 'extends' is NULL.";
+					break;
+				}
 
 				GDScript *scr_B = obj_B->cast_to<GDScript>();
 
@@ -3105,12 +3110,12 @@ Error ResourceFormatSaverGDScript::save(const String &p_path,const RES& p_resour
 
 void ResourceFormatSaverGDScript::get_recognized_extensions(const RES& p_resource,List<String> *p_extensions) const {
 
-	if (p_resource->cast_to<GDScript>()) {
+	if (p_resource != NULL && p_resource->cast_to<GDScript>()) {
 		p_extensions->push_back("gd");
 	}
 
 }
 bool ResourceFormatSaverGDScript::recognize(const RES& p_resource) const {
 
-	return p_resource->cast_to<GDScript>()!=NULL;
+	return p_resource != NULL && p_resource->cast_to<GDScript>()!=NULL;
 }

--- a/scene/gui/check_box.cpp
+++ b/scene/gui/check_box.cpp
@@ -56,14 +56,14 @@ void CheckBox::_notification(int p_what) {
 
 bool CheckBox::is_radio()
 {
-    Node* parent = this;
-    do {
-        parent = parent->get_parent();
-	if (parent->cast_to<ButtonGroup>())
-            break;
-    } while (parent);
+	Node* parent = this;
+	do {
+		parent = parent->get_parent();
+		if (parent && parent->cast_to<ButtonGroup>())
+				break;
+	} while (parent);
 
-    return (parent != 0);
+	return (parent != NULL);
 }
 
 CheckBox::CheckBox(const String &p_text):

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1449,9 +1449,9 @@ void Viewport::_gui_show_tooltip() {
 	}
 
 	Control *rp = gui.tooltip->get_root_parent_control();
-	if (!rp)
+	if (!rp) {
 		return;
-
+	}
 
 	gui.tooltip_popup = memnew( TooltipPanel );
 
@@ -2086,6 +2086,7 @@ void Viewport::_gui_force_drag(Control *p_base, const Variant& p_data, Control *
 
 void Viewport::_gui_set_drag_preview(Control *p_base, Control *p_control) {
 
+	ERR_FAIL_NULL(p_base);
 	ERR_FAIL_NULL(p_control);
 	ERR_FAIL_COND( !((Object*)p_control)->cast_to<Control>());
 	ERR_FAIL_COND(p_control->is_inside_tree());

--- a/tools/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/tools/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1492,6 +1492,10 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 		while ((n && n != scene && n->get_owner() != scene) || (n && !n->is_type("CanvasItem"))) {
 			n = n->get_parent();
 		};
+
+		if(n == NULL){
+			return;
+		}
 		c = n->cast_to<CanvasItem>();
 #if 0
 		if ( b.pressed ) box_selection_start( click );


### PR DESCRIPTION
- There may be other places I'm missing where cast should be checked. But the
  main spot for bug #4673 is taken care of at:  scene/main/viewport.cpp:2089

Ticket:
https://github.com/godotengine/godot/issues/4673
