### PR TITLE
fixed interactive_loader() not returning a cached scene

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -319,7 +319,11 @@ Ref<ResourceInteractiveLoader> ResourceLoader::load_interactive(const String &p_
 		if (OS::get_singleton()->is_stdout_verbose())
 			print_line("load resource: "+local_path+" (cached)");
 
-		return RES( ResourceCache::get(local_path ) );
+		Ref<Resource> res_cached = ResourceCache::get(local_path);
+		Ref<ResourceInteractiveLoaderDefault> ril = Ref<ResourceInteractiveLoaderDefault>(memnew(ResourceInteractiveLoaderDefault));
+
+		ril->resource = res_cached;
+		return ril;
 	}
 
 	if (OS::get_singleton()->is_stdout_verbose())


### PR DESCRIPTION
As title suggests, interactive_loader() did not return cached resource and returned null object in gdscript. Can be reproduced by loading same scene twice, and this patch seems to work just fine.

P.S. created new fork because couldn't rebase it properly, old conversation here #4867 
