### PR TITLE
Make dialogs translatable

### DIFF
--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -349,7 +349,7 @@ Button* AcceptDialog::add_cancel(const String &p_cancel) {
 
 	String c = p_cancel;
 	if (p_cancel=="")
-		c="Cancel";
+		c=RTR("Cancel");
 	Button *b = swap_ok_cancel ? add_button(c,true) : add_button(c);
 	b->connect("pressed",this,"_closed");
 	return b;
@@ -406,7 +406,7 @@ AcceptDialog::AcceptDialog() {
 
 	hbc->add_spacer();
 	ok = memnew( Button );
-	ok->set_text("OK");
+	ok->set_text(RTR("OK"));
 	hbc->add_child(ok);
 	hbc->add_spacer();
 	//add_child(ok);
@@ -416,7 +416,7 @@ AcceptDialog::AcceptDialog() {
 	set_as_toplevel(true);
 
 	hide_on_ok=true;
-	set_title("Alert!");
+	set_title(RTR("Alert!"));
 
 	child=NULL;
 }
@@ -439,6 +439,6 @@ Button *ConfirmationDialog::get_cancel() {
 
 ConfirmationDialog::ConfirmationDialog() {
 
-	set_title("Please Confirm...");
+	set_title(RTR("Please Confirm..."));
 	cancel = add_cancel();
 }


### PR DESCRIPTION
I am not sure dialogs should be translated as it is not located under tools/editor folder. So feel free to drop this PR if it is not necessary.
