### PR TITLE
Define TTR in non-tool builds

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -3963,17 +3963,17 @@ String String::sprintf(const Array& values, bool* error) const {
 
 #include "translation.h"
 
-#ifdef TOOLS_ENABLED
+
 String TTR(const String& p_text) {
 
+#ifdef TOOLS_ENABLED
 	if (TranslationServer::get_singleton()) {
 		return TranslationServer::get_singleton()->tool_translate(p_text);
 	}
-
+#endif
 	return p_text;
 }
 
-#endif
 
 String RTR(const String& p_text) {
 


### PR DESCRIPTION
May it be desired to make it inline if `TOOLS_ENABLED` is not defined?
