### PR TITLE
Ragdoll Support: override centre of mass on 3D rigid bodies and set as toplevel during integration phase

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -8069,6 +8069,11 @@
 			<description>
 			</description>
 		</method>
+		<method name="calculate_center_of_mass">
+			<description>
+				Automatically determine this rigid body's center of mass by calculating the median of all [CollisionShape] node children.
+			</description>
+		</method>
 		<method name="clear_shapes">
 			<description>
 			</description>
@@ -8077,6 +8082,20 @@
 			<return type="bool">
 			</return>
 			<description>
+			</description>
+		</method>
+		<method name="get_center_of_mass" qualifiers="const">
+			<return type="Vector3">
+			</return>
+			<description>
+				Return the center of mass of this rigid body in local space.
+			</description>
+		</method>
+		<method name="get_global_center_of_mass" qualifiers="const">
+			<return type="Vector3">
+			</return>
+			<description>
+				Return the center of mass of this rigid body in world space.
 			</description>
 		</method>
 		<method name="get_rid" qualifiers="const">
@@ -8131,6 +8150,13 @@
 			<argument index="0" name="enable" type="bool">
 			</argument>
 			<description>
+			</description>
+		</method>
+		<method name="set_center_of_mass">
+			<argument index="0" name="center_of_mass" type="Vector3">
+			</argument>
+			<description>
+				Manually assign a value which will be used as this rigid body's local center of mass.
 			</description>
 		</method>
 		<method name="set_ray_pickable">

--- a/scene/3d/collision_object.cpp
+++ b/scene/3d/collision_object.cpp
@@ -27,6 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include "collision_object.h"
+#include "body_shape.h"
 #include "servers/physics_server.h"
 #include "scene/scene_string_names.h"
 void CollisionObject::_update_shapes_from_children() {
@@ -50,7 +51,7 @@ void CollisionObject::_notification(int p_what) {
 			if (area)
 				PhysicsServer::get_singleton()->area_set_transform(rid,get_global_transform());
 			else
-				PhysicsServer::get_singleton()->body_set_state(rid,PhysicsServer::BODY_STATE_TRANSFORM,get_global_transform());
+				PhysicsServer::get_singleton()->body_set_state(rid,PhysicsServer::BODY_STATE_TRANSFORM,get_global_transform().translated(center_of_mass));
 
 			RID space = get_world()->get_space();
 			if (area) {
@@ -59,6 +60,7 @@ void CollisionObject::_notification(int p_what) {
 				PhysicsServer::get_singleton()->body_set_space(rid,space);
 
 			_update_pickable();
+			_update_shapes();
 		//get space
 		};
 
@@ -67,8 +69,9 @@ void CollisionObject::_notification(int p_what) {
 			if (area)
 				PhysicsServer::get_singleton()->area_set_transform(rid,get_global_transform());
 			else
-				PhysicsServer::get_singleton()->body_set_state(rid,PhysicsServer::BODY_STATE_TRANSFORM,get_global_transform());
+				PhysicsServer::get_singleton()->body_set_state(rid,PhysicsServer::BODY_STATE_TRANSFORM,get_global_transform().translated(center_of_mass));
 
+			_update_shapes();
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 
@@ -103,7 +106,18 @@ void CollisionObject::_update_shapes() {
 		if (area)
 			PhysicsServer::get_singleton()->area_add_shape(rid,shapes[i].shape->get_rid(),shapes[i].xform);
 		else {
-			PhysicsServer::get_singleton()->body_add_shape(rid,shapes[i].shape->get_rid(),shapes[i].xform);
+
+			Vector3 scale = Vector3(1.0, 1.0, 1.0);
+
+			if (is_inside_tree()) {
+				scale = get_global_transform().basis.get_scale();
+			}
+
+			Transform xform = shapes[i].xform;
+			xform.origin -= center_of_mass;
+			xform.scale(scale);
+
+			PhysicsServer::get_singleton()->body_add_shape(rid,shapes[i].shape->get_rid(),xform);
 			if (shapes[i].trigger)
 				PhysicsServer::get_singleton()->body_set_shape_as_trigger(rid,i,shapes[i].trigger);
 		}
@@ -232,7 +246,6 @@ void CollisionObject::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_shape_count"),&CollisionObject::get_shape_count);
 	ObjectTypeDB::bind_method(_MD("set_shape","shape_idx","shape:Shape"),&CollisionObject::set_shape);
 	ObjectTypeDB::bind_method(_MD("set_shape_transform","shape_idx","transform"),&CollisionObject::set_shape_transform);
-//    ObjectTypeDB::bind_method(_MD("set_shape_transform","shape_idx","transform"),&CollisionObject::set_shape_transform);
 	ObjectTypeDB::bind_method(_MD("set_shape_as_trigger","shape_idx","enable"),&CollisionObject::set_shape_as_trigger);
 	ObjectTypeDB::bind_method(_MD("is_shape_set_as_trigger","shape_idx"),&CollisionObject::is_shape_set_as_trigger);
 	ObjectTypeDB::bind_method(_MD("get_shape:Shape","shape_idx"),&CollisionObject::get_shape);
@@ -244,6 +257,12 @@ void CollisionObject::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_capture_input_on_drag","enable"),&CollisionObject::set_capture_input_on_drag);
 	ObjectTypeDB::bind_method(_MD("get_capture_input_on_drag"),&CollisionObject::get_capture_input_on_drag);
 	ObjectTypeDB::bind_method(_MD("get_rid"),&CollisionObject::get_rid);
+	
+	ObjectTypeDB::bind_method(_MD("set_center_of_mass", "center_of_mass"), &CollisionObject::set_center_of_mass);
+	ObjectTypeDB::bind_method(_MD("get_center_of_mass"), &CollisionObject::get_center_of_mass);
+	ObjectTypeDB::bind_method(_MD("get_global_center_of_mass"), &CollisionObject::get_global_center_of_mass);
+	ObjectTypeDB::bind_method(_MD("calculate_center_of_mass"), &CollisionObject::calculate_center_of_mass);
+
 	BIND_VMETHOD( MethodInfo("_input_event",PropertyInfo(Variant::OBJECT,"camera"),PropertyInfo(Variant::INPUT_EVENT,"event"),PropertyInfo(Variant::VECTOR3,"click_pos"),PropertyInfo(Variant::VECTOR3,"click_normal"),PropertyInfo(Variant::INT,"shape_idx")));
 
 	ADD_SIGNAL( MethodInfo("input_event",PropertyInfo(Variant::OBJECT,"camera"),PropertyInfo(Variant::INPUT_EVENT,"event"),PropertyInfo(Variant::VECTOR3,"click_pos"),PropertyInfo(Variant::VECTOR3,"click_normal"),PropertyInfo(Variant::INT,"shape_idx")));
@@ -334,6 +353,7 @@ CollisionObject::CollisionObject(RID p_rid, bool p_area) {
 	area=p_area;
 	capture_input_on_drag=false;
 	ray_pickable=true;
+	center_of_mass = Vector3();
 	if (p_area) {
 		PhysicsServer::get_singleton()->area_attach_object_instance_ID(rid,get_instance_ID());
 	} else {
@@ -352,6 +372,43 @@ void CollisionObject::set_capture_input_on_drag(bool p_capture) {
 bool CollisionObject::get_capture_input_on_drag() const {
 
 	return capture_input_on_drag;
+}
+
+void CollisionObject::set_center_of_mass(const Vector3& p_center_of_mass){
+
+	center_of_mass = p_center_of_mass;
+
+	_update_shapes();
+}
+Vector3 CollisionObject::get_center_of_mass() const{
+
+	return center_of_mass;
+}
+
+Vector3 CollisionObject::get_global_center_of_mass() const {
+	return get_global_transform().translated(center_of_mass).origin;
+}
+
+void CollisionObject::calculate_center_of_mass(){
+
+	AABB center;
+
+	for (int i = 0; i < get_child_count(); i++){
+
+		int valid_shape_count = 0;
+		CollisionShape *c = get_child(i)->cast_to<CollisionShape>();
+		if (c) {
+
+			if (valid_shape_count == 0)
+				center.pos = c->get_transform().origin;
+			else
+				center.expand_to(c->get_transform().origin);
+
+			valid_shape_count++;
+		}
+	}
+
+	center_of_mass = center.pos + center.size*0.5;
 }
 
 

--- a/scene/3d/collision_object.h
+++ b/scene/3d/collision_object.h
@@ -64,6 +64,8 @@ protected:
 
 	CollisionObject(RID p_rid, bool p_area);
 
+	Vector3 center_of_mass;
+
 	void _notification(int p_what);
 	bool _set(const StringName& p_name, const Variant& p_value);
 	bool _get(const StringName& p_name,Variant &r_ret) const;
@@ -94,6 +96,12 @@ public:
 	void set_capture_input_on_drag(bool p_capture);
 	bool get_capture_input_on_drag() const;
 
+	void set_center_of_mass(const Vector3& p_center_of_mass);
+	Vector3 get_center_of_mass() const;
+
+	Vector3 get_global_center_of_mass() const;
+
+	void calculate_center_of_mass();
 
 	_FORCE_INLINE_ RID get_rid() const { return rid; }
 

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -27,6 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include "physics_body.h"
+#include "collision_object.h"
 #include "scene/scene_string_names.h"
 
 void PhysicsBody::_notification(int p_what) {
@@ -398,7 +399,11 @@ void RigidBody::_direct_state_changed(Object *p_state) {
 #endif
 
 	set_ignore_transform_notification(true);
-	set_global_transform(state->get_transform());
+	Vector3 scale = get_global_transform().basis.get_scale();
+	Transform new_transform = state->get_transform();
+	new_transform.scale_basis(scale);
+	new_transform.translate(-center_of_mass);
+	set_global_transform(new_transform);
 	linear_velocity=state->get_linear_velocity();
 	angular_velocity=state->get_angular_velocity();
 	if(sleeping!=state->is_sleeping()) {
@@ -867,6 +872,7 @@ void RigidBody::_bind_methods() {
 	ADD_PROPERTY( PropertyInfo(Variant::REAL,"mass",PROPERTY_HINT_EXP_RANGE,"0.01,65535,0.01"),_SCS("set_mass"),_SCS("get_mass"));
 	ADD_PROPERTY( PropertyInfo(Variant::REAL,"weight",PROPERTY_HINT_EXP_RANGE,"0.01,65535,0.01",PROPERTY_USAGE_EDITOR),_SCS("set_weight"),_SCS("get_weight"));
 	ADD_PROPERTY( PropertyInfo(Variant::REAL,"friction",PROPERTY_HINT_RANGE,"0,1,0.01"),_SCS("set_friction"),_SCS("get_friction"));
+	ADD_PROPERTY( PropertyInfo(Variant::VECTOR3,"center_of_mass"), _SCS("set_center_of_mass"), _SCS("get_center_of_mass"));
 	ADD_PROPERTY( PropertyInfo(Variant::REAL,"bounce",PROPERTY_HINT_RANGE,"0,1,0.01"),_SCS("set_bounce"),_SCS("get_bounce"));
 	ADD_PROPERTY( PropertyInfo(Variant::REAL,"gravity_scale",PROPERTY_HINT_RANGE,"-128,128,0.01"),_SCS("set_gravity_scale"),_SCS("get_gravity_scale"));
 	ADD_PROPERTY( PropertyInfo(Variant::BOOL,"custom_integrator"),_SCS("set_use_custom_integrator"),_SCS("is_using_custom_integrator"));

--- a/scene/3d/physics_joint.cpp
+++ b/scene/3d/physics_joint.cpp
@@ -232,11 +232,24 @@ RID PinJoint::_configure_joint(PhysicsBody *body_a,PhysicsBody *body_b) {
 
 
 	Vector3 pinpos = get_global_transform().origin;
-	Vector3 local_a = body_a->get_global_transform().affine_inverse().xform(pinpos);
+
+	Transform ainv = body_a->get_global_transform().translated(body_a->get_center_of_mass());
+	ainv.basis.invert();
+	ainv.basis.scale(body_a->get_global_transform().basis.get_scale());
+	ainv.origin = ainv.basis.xform(-ainv.origin);
+
+	Vector3 local_a = ainv.xform(pinpos);
 	Vector3 local_b;
 
-	if (body_b)
-		local_b = body_b->get_global_transform().affine_inverse().xform(pinpos);
+	if (body_b) {
+
+		Transform binv = body_b->get_global_transform().translated(body_b->get_center_of_mass());
+		binv.basis.invert();
+		binv.basis.scale(body_b->get_global_transform().basis.get_scale());
+		binv.origin = binv.basis.xform(-binv.origin);
+
+		local_b = binv.xform(pinpos);
+	}
 	else
 		local_b=pinpos;
 
@@ -369,14 +382,21 @@ RID HingeJoint::_configure_joint(PhysicsBody *body_a,PhysicsBody *body_b) {
 
 
 	Transform gt = get_global_transform();
-	Transform ainv = body_a->get_global_transform().affine_inverse();
+	Transform ainv = body_a->get_global_transform().translated(body_a->get_center_of_mass());
+	ainv.basis.invert();
+	ainv.basis.scale(body_a->get_global_transform().basis.get_scale());
+	ainv.origin = ainv.basis.xform(-ainv.origin);
 
 	Transform local_a = ainv * gt;
 	local_a.orthonormalize();
 	Transform local_b = gt;
 
 	if (body_b) {
-		Transform binv = body_b->get_global_transform().affine_inverse();
+		Transform binv = body_b->get_global_transform().translated(body_b->get_center_of_mass());
+		binv.basis.invert();
+		binv.basis.scale(body_b->get_global_transform().basis.get_scale());
+		binv.origin = binv.basis.xform(-binv.origin);
+		
 		local_b = binv * gt;
 	}
 
@@ -529,14 +549,21 @@ RID SliderJoint::_configure_joint(PhysicsBody *body_a,PhysicsBody *body_b) {
 
 
 	Transform gt = get_global_transform();
-	Transform ainv = body_a->get_global_transform().affine_inverse();
+	Transform ainv = body_a->get_global_transform().translated(body_a->get_center_of_mass());
+	ainv.basis.invert();
+	ainv.basis.scale(body_a->get_global_transform().basis.get_scale());
+	ainv.origin = ainv.basis.xform(-ainv.origin);
 
 	Transform local_a = ainv * gt;
 	local_a.orthonormalize();
 	Transform local_b = gt;
 
 	if (body_b) {
-		Transform binv = body_b->get_global_transform().affine_inverse();
+		Transform binv = body_b->get_global_transform().translated(body_b->get_center_of_mass());
+		binv.basis.invert();
+		binv.basis.scale(body_b->get_global_transform().basis.get_scale());
+		binv.origin = binv.basis.xform(-binv.origin);
+		
 		local_b = binv * gt;
 	}
 
@@ -661,14 +688,21 @@ RID ConeTwistJoint::_configure_joint(PhysicsBody *body_a,PhysicsBody *body_b) {
 	//Vector3 cone_twistpos = gt.origin;
 	//Vector3 cone_twistdir = gt.basis.get_axis(2);
 
-	Transform ainv = body_a->get_global_transform().affine_inverse();
+	Transform ainv = body_a->get_global_transform().translated(body_a->get_center_of_mass());
+	ainv.basis.invert();
+	ainv.basis.scale(body_a->get_global_transform().basis.get_scale());
+	ainv.origin = ainv.basis.xform(-ainv.origin);
 
 	Transform local_a = ainv * gt;
 	local_a.orthonormalize();
 	Transform local_b = gt;
 
 	if (body_b) {
-		Transform binv = body_b->get_global_transform().affine_inverse();
+		Transform binv = body_b->get_global_transform().translated(body_b->get_center_of_mass());
+		binv.basis.invert();
+		binv.basis.scale(body_b->get_global_transform().basis.get_scale());
+		binv.origin = binv.basis.xform(-binv.origin);
+
 		local_b = binv * gt;
 	}
 
@@ -984,14 +1018,21 @@ RID Generic6DOFJoint::_configure_joint(PhysicsBody *body_a,PhysicsBody *body_b) 
 	//Vector3 cone_twistpos = gt.origin;
 	//Vector3 cone_twistdir = gt.basis.get_axis(2);
 
-	Transform ainv = body_a->get_global_transform().affine_inverse();
+	Transform ainv = body_a->get_global_transform().translated(body_a->get_center_of_mass());
+	ainv.basis.invert();
+	ainv.basis.scale(body_a->get_global_transform().basis.get_scale());
+	ainv.origin = ainv.basis.xform(-ainv.origin);
 
 	Transform local_a = ainv * gt;
 	local_a.orthonormalize();
 	Transform local_b = gt;
 
 	if (body_b) {
-		Transform binv = body_b->get_global_transform().affine_inverse();
+		Transform binv = body_b->get_global_transform().translated(body_b->get_center_of_mass());
+		binv.basis.invert();
+		binv.basis.scale(body_b->get_global_transform().basis.get_scale());
+		binv.origin = binv.basis.xform(-binv.origin);
+
 		local_b = binv * gt;
 	}
 

--- a/servers/physics/body_sw.cpp
+++ b/servers/physics/body_sw.cpp
@@ -662,6 +662,19 @@ void BodySW::wakeup_neighbours() {
 	}
 }
 
+void BodySW::set_as_toplevel(const bool p_true) {
+	if (fi_callback) {
+		Object *obj = ObjectDB::get_instance(fi_callback->id);
+		if (obj) {
+			Variant arg = Variant(p_true);
+			const Variant *vp[1] = { &arg };
+
+			Variant::CallError ce;
+			obj->call("set_as_toplevel",vp,1,ce);
+		}
+	}
+}
+
 void BodySW::call_queries() {
 
 

--- a/servers/physics/body_sw.h
+++ b/servers/physics/body_sw.h
@@ -289,6 +289,7 @@ public:
 	 }
 
 	//void simulate_motion(const Transform& p_xform,real_t p_step);
+	void set_as_toplevel(const bool p_true);
 	void call_queries();
 	void wakeup_neighbours();
 

--- a/servers/physics/space_sw.cpp
+++ b/servers/physics/space_sw.cpp
@@ -620,11 +620,28 @@ const SelfList<AreaSW>::List& SpaceSW::get_moved_area_list() const {
 
 void SpaceSW::call_queries() {
 
+	// Set all bodies to toplevel temporarily
+	active_list = get_active_body_list();
+	SelfList<BodySW> *curr = active_list.first();
+	while (curr) {
+		BodySW * b = curr->self();
+		b->set_as_toplevel(true);
+		curr = curr->next();
+	}
+
 	while(state_query_list.first()) {
 
 		BodySW * b = state_query_list.first()->self();
 		b->call_queries();
 		state_query_list.remove(state_query_list.first());
+	}
+
+	// Now set them back
+	curr = active_list.first();
+	while (curr) {
+		BodySW * b = curr->self();
+		b->set_as_toplevel(false);
+		curr = curr->next();
 	}
 
 	while(monitor_query_list.first()) {


### PR DESCRIPTION
This PR includes two enhancements to the physics system, specifically how the physics system integrates with the game's tree hierarchy. The first is that it allows you to override the centre of mass on rigid bodies. Originally, a rigid body's center of mass would always be its origin, regardless of where collision objects were positioned. The integration should account for this and work as expected, even with joints. The reason for wanting such a feature is primarily to support ragdoll physics. It's complicated to explain why I feel this feature is nessecary, but consider how an articulated ragdoll should work. Ideally, you would want to place the rigid body at the origin point of the corresponding bone, while repositioning the collision object to better represent the length to the next bone in the chain, and then simply feed the transform data from the rigid body back into corresponding. The problem with this method without this feature is that since the objects center of mass is not of the collision shape, the center of mass will simply fall through the ground and 'drag' the rest of the object indefinetly causing it to glitch out. By using this method, this implementation can work as expected, and I've even written a simple tool which can auto calculate the center of mass from several collision objects (not included yet since I want to rewrite it as a native C++ tool). I will likely release a simple example project soon to demonstrate exactly how to set up a ragdoll with this extension in practice.

Since this is a PR aimed at improving 3D ragdoll support, the second major feature of this PR is preventing buggy interactions with rigid bodies chained together in a tree. It simply does this currently by automatically setting all rigid bodies to toplevel during the integration phase. It might be worth considering feeding velocity vectors into chained rigid bodies and implementation might be worth being slightly cleaner, but in general, I consider this much safer and more reliable than the simple implementation of simply integrating with their global positions since the order in which they are integrated does not seem to be determined by their order in the tree, causing potentially unpredictable results. This aspect has also not been extensively profiled as of yet, but I don't imagine it would cause too significant of an impact and I cannot think of an alternative as of yet.

This PR should also allow ragdoll to function even when the ragdoll is programmatically scaled. This aspect of the PR would otherwise be perfectly reliable, but as pointed out in this issue #4491, there is currently a bug with internal implementation of the homegrown physics engine which causes wierd behaviour when scaling cube collision objects. Thankfully, a solution has already been identified which should solve these issues (feeding the scaling data directly into the shape construction), so hopefully @reduz or someone else can implement this fix soon, since this PR really mostly only affects the frontend of the physics system.
