### PR TITLE
Fixed and improved search bar

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3554,6 +3554,7 @@ void TextEdit::set_search_flags(uint32_t p_flags) {
 void TextEdit::set_current_search_result(int line, int col) {
 	search_result_line = line;
 	search_result_col = col;
+	update();
 }
 
 void TextEdit::set_highlight_all_occurrences(const bool p_enabled) {

--- a/tools/editor/code_editor.h
+++ b/tools/editor/code_editor.h
@@ -83,13 +83,18 @@ class FindReplaceBar : public HBoxContainer {
 
 	TextEdit *text_edit;
 
-	int current_result_line;
-	int current_result_col;
+	int result_line;
+	int result_col;
 
 	bool replace_all_mode;
+	bool preserve_cursor;
+
+	void _get_search_from(int& r_line, int& r_col);
 
 	void _show_search();
 	void _hide_bar();
+
+	void _editor_text_changed();
 	void _search_options_changed(bool p_pressed);
 	void _search_text_changed(const String& p_text);
 	void _search_text_entered(const String& p_text);
@@ -98,7 +103,7 @@ protected:
 	void _notification(int p_what);
 	void _unhandled_input(const InputEvent &p_event);
 
-	bool _search(bool p_include_current=false, bool p_backwards=false);
+	bool _search(uint32_t p_flags, int p_from_line, int p_from_col);
 
 	void _replace();
 	void _replace_all();
@@ -119,9 +124,9 @@ public:
 	void popup_search();
 	void popup_replace();
 
-	void search_current();
-	void search_prev();
-	void search_next();
+	bool search_current();
+	bool search_prev();
+	bool search_next();
 
 	FindReplaceBar();
 };


### PR DESCRIPTION
Important changes:
- Search no longer selects the results.
- Return focus to the text editor when hiding the bar.
- Fix connecting to invalid signal `_text_changed`. Fixing this made me notice another bug where the caret cursor was being moved to the search result after searching due to text editor writing.
- Update/redraw the text editor after searching.

After this PR, replace won't longer replace the current selected word (inherited behaviour from `FindReplaceDialog`) but the current search result. This is because just comparing the selection and the search text ignores the search flags like _Match Case_ and _Words Only_.
