### PR TITLE
Properly detect .h as a C++ header file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+# Properly detect languages on Github
+*.h linguist-language=cpp
+
 *.cpp eol=lf
 *.h eol=lf
 *.py eol=lf


### PR DESCRIPTION
Github shows Godot as a C project, which it isn't. This will fix it.
