### PR TITLE
Prevent calling 'Object::cast_to' method on NULL pointer

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -742,7 +742,7 @@ Error ResourceInteractiveLoaderBinary::poll(){
 	}
 	ERR_FAIL_COND_V(!obj,ERR_FILE_CORRUPT);
 
-	Resource *r = obj->cast_to<Resource>();
+	Resource *r = Object::cast_to<Resource>(obj);
 	if (!r) {
 		error=ERR_FILE_CORRUPT;
 		memdelete(obj); //bye

--- a/core/io/resource_format_xml.cpp
+++ b/core/io/resource_format_xml.cpp
@@ -1532,7 +1532,7 @@ Error ResourceInteractiveLoaderXML::poll() {
 	}
 	ERR_FAIL_COND_V(!obj,ERR_FILE_CORRUPT);
 
-	Resource *r = obj->cast_to<Resource>();
+	Resource *r = Object::cast_to<Resource>(obj);
 	if (!r) {
 		error=ERR_FILE_CORRUPT;
 		memdelete(obj); //bye

--- a/core/make_binders.py
+++ b/core/make_binders.py
@@ -23,7 +23,7 @@ public:
 
 	virtual Variant call(Object* p_object,const Variant** p_args,int p_arg_count, Variant::CallError& r_error) {
 
-		T *instance=p_object->cast_to<T>();
+		T *instance=Object::cast_to<T>(p_object);
 		r_error.error=Variant::CallError::CALL_OK;
 #ifdef DEBUG_METHODS_ENABLED
 

--- a/core/object.cpp
+++ b/core/object.cpp
@@ -585,7 +585,7 @@ void Object::call_multilevel(const StringName& p_method,const Variant** p_args,i
 
 	if (p_method==CoreStringNames::get_singleton()->_free) {
 #ifdef DEBUG_ENABLED
-		if (cast_to<Reference>()) {
+		if (Object::cast_to<Reference>(this)) {
 			ERR_EXPLAIN("Can't 'free' a reference.");
 			ERR_FAIL();
 			return;
@@ -710,7 +710,7 @@ Variant Object::call(const StringName& p_name, VARIANT_ARG_DECLARE) {
 #if 0
 	if (p_name==CoreStringNames::get_singleton()->_free) {
 #ifdef DEBUG_ENABLED
-		if (cast_to<Reference>()) {
+		if (Object::cast_to<Reference>(this)) {
 			ERR_EXPLAIN("Can't 'free' a reference.");
 			ERR_FAIL_V(Variant());
 		}
@@ -778,7 +778,7 @@ void Object::call_multilevel(const StringName& p_name, VARIANT_ARG_DECLARE) {
 #if 0
 	if (p_name==CoreStringNames::get_singleton()->_free) {
 #ifdef DEBUG_ENABLED
-		if (cast_to<Reference>()) {
+		if (Object::cast_to<Reference>(this)) {
 			ERR_EXPLAIN("Can't 'free' a reference.");
 			ERR_FAIL();
 			return;
@@ -847,7 +847,7 @@ Variant Object::call(const StringName& p_method,const Variant** p_args,int p_arg
 			r_error.error=Variant::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
 			return Variant();
 		}
-		if (cast_to<Reference>()) {
+		if (Object::cast_to<Reference>(this)) {
 			r_error.argument=0;
 			r_error.error=Variant::CallError::CALL_ERROR_INVALID_METHOD;
 			ERR_EXPLAIN("Can't 'free' a reference.");

--- a/core/object.h
+++ b/core/object.h
@@ -492,33 +492,27 @@ public:
 	void add_change_receptor( Object *p_receptor );
 	void remove_change_receptor( Object *p_receptor );
 
-	template<class T>
-	T *cast_to() {
+	template<class T, class OldT>
+	static T *cast_to(OldT *ptr) {
 
 #ifndef NO_SAFE_CAST
-		return SAFE_CAST<T*>(this);
+		return SAFE_CAST<T*>(ptr);
 #else
-		if (!this)
-			return NULL;
-		if (is_type_ptr(T::get_type_ptr_static()))
-			return static_cast<T*>(this);
-		else
-			return NULL;
+		if (ptr && ptr->is_type_ptr(T::get_type_ptr_static()))
+			return reinterpret_cast<T *>(ptr);
+		return NULL;
 #endif
 	}
 
-	template<class T>
-	const T *cast_to() const {
+	template<class T, class OldT>
+	static const T *cast_to(const OldT *ptr) {
 
 #ifndef NO_SAFE_CAST
-		return SAFE_CAST<const T*>(this);
+		return SAFE_CAST<const T*>(ptr);
 #else
-		if (!this)
-			return NULL;
-		if (is_type_ptr(T::get_type_ptr_static()))
-			return static_cast<const T*>(this);
-		else
-			return NULL;
+		if (ptr && ptr->is_type_ptr(T::get_type_ptr_static()))
+			return reinterpret_cast<const T *>(ptr);
+		return NULL;
 #endif
 	}
 

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -191,7 +191,7 @@ static FileAccess *_OSPRF=NULL;
 
 static void _OS_printres(Object *p_obj) {
 
-	Resource *res = p_obj->cast_to<Resource>();
+	Resource *res = Object::cast_to<Resource>(p_obj);
 	if (!res)
 		return;
 

--- a/core/ref_ptr.cpp
+++ b/core/ref_ptr.cpp
@@ -69,7 +69,7 @@ RID RefPtr::get_rid() const {
 	Ref<Reference> *ref = reinterpret_cast<Ref<Reference>*>( &data[0] );
 	if (ref->is_null())
 		return RID();
-	Resource *res = (*ref)->cast_to<Resource>();
+	Resource *res = Object::cast_to<Resource>(**ref);
 	if (res)
 		return res->get_rid();
 	return RID();

--- a/core/reference.cpp
+++ b/core/reference.cpp
@@ -92,7 +92,7 @@ Variant WeakRef::get_ref() const {
 	Object *obj = ObjectDB::get_instance(ref);
 	if (!obj)
 		return Variant();
-	Reference *r = obj->cast_to<Reference>();
+	Reference *r = Object::cast_to<Reference>(obj);
 	if (r) {
 
 		return REF(r);

--- a/core/reference.h
+++ b/core/reference.h
@@ -182,7 +182,7 @@ public:
 			return;
 		}
 		Ref r;
-		r.reference=refb->cast_to<T>();
+		r.reference=Object::cast_to<T>(refb);
 		ref(r);
 		r.reference=NULL;
 	}
@@ -196,7 +196,7 @@ public:
 			return;
 		}
 		Ref r;
-		r.reference=refb->cast_to<T>();
+		r.reference=Object::cast_to<T>(refb);
 		ref(r);
 		r.reference=NULL;
 	}
@@ -212,7 +212,7 @@ public:
 			return;
 		}
 		Ref r;
-		r.reference=refb->cast_to<T>();
+		r.reference=Object::cast_to<T>(refb);
 		ref(r);
 		r.reference=NULL;
 	}
@@ -233,7 +233,7 @@ public:
 			return;
 		}
 		Ref r;
-		r.reference=refb->cast_to<T>();
+		r.reference=Object::cast_to<T>(refb);
 		ref(r);
 		r.reference=NULL;
 	}
@@ -257,7 +257,7 @@ public:
 			return;
 		}
 		Ref r;
-		r.reference=refb->cast_to<T>();
+		r.reference=Object::cast_to<T>(refb);
 		ref(r);
 		r.reference=NULL;
 	}
@@ -274,7 +274,7 @@ public:
 			return;
 		}
 		Ref r;
-		r.reference=refb->cast_to<T>();
+		r.reference=Object::cast_to<T>(refb);
 		ref(r);
 		r.reference=NULL;
 	}

--- a/core/undo_redo.cpp
+++ b/core/undo_redo.cpp
@@ -85,8 +85,8 @@ void UndoRedo::add_do_method(Object *p_object,const String& p_method,VARIANT_ARG
 	ERR_FAIL_COND((current_action+1)>=actions.size());
 	Operation do_op;
 	do_op.object=p_object->get_instance_ID();
-	if (p_object->cast_to<Resource>())
-		do_op.resref=Ref<Resource>(p_object->cast_to<Resource>());
+	if (Object::cast_to<Resource>(p_object))
+		do_op.resref=Ref<Resource>(Object::cast_to<Resource>(p_object));
 
 	do_op.type=Operation::TYPE_METHOD;
 	do_op.name=p_method;
@@ -107,8 +107,8 @@ void UndoRedo::add_undo_method(Object *p_object,const String& p_method,VARIANT_A
 
 	Operation undo_op;
 	undo_op.object=p_object->get_instance_ID();
-	if (p_object->cast_to<Resource>())
-		undo_op.resref=Ref<Resource>(p_object->cast_to<Resource>());
+	if (Object::cast_to<Resource>(p_object))
+		undo_op.resref=Ref<Resource>(Object::cast_to<Resource>(p_object));
 
 	undo_op.type=Operation::TYPE_METHOD;
 	undo_op.name=p_method;
@@ -125,8 +125,8 @@ void UndoRedo::add_do_property(Object *p_object,const String& p_property,const V
 	ERR_FAIL_COND((current_action+1)>=actions.size());
 	Operation do_op;
 	do_op.object=p_object->get_instance_ID();
-	if (p_object->cast_to<Resource>())
-		do_op.resref=Ref<Resource>(p_object->cast_to<Resource>());
+	if (Object::cast_to<Resource>(p_object))
+		do_op.resref=Ref<Resource>(Object::cast_to<Resource>(p_object));
 
 	do_op.type=Operation::TYPE_PROPERTY;
 	do_op.name=p_property;
@@ -141,8 +141,8 @@ void UndoRedo::add_undo_property(Object *p_object,const String& p_property,const
 
 	Operation undo_op;
 	undo_op.object=p_object->get_instance_ID();
-	if (p_object->cast_to<Resource>())
-		undo_op.resref=Ref<Resource>(p_object->cast_to<Resource>());
+	if (Object::cast_to<Resource>(p_object))
+		undo_op.resref=Ref<Resource>(Object::cast_to<Resource>(p_object));
 
 	undo_op.type=Operation::TYPE_PROPERTY;
 	undo_op.name=p_property;
@@ -156,8 +156,8 @@ void UndoRedo::add_do_reference(Object *p_object) {
 	ERR_FAIL_COND((current_action+1)>=actions.size());
 	Operation do_op;
 	do_op.object=p_object->get_instance_ID();
-	if (p_object->cast_to<Resource>())
-		do_op.resref=Ref<Resource>(p_object->cast_to<Resource>());
+	if (Object::cast_to<Resource>(p_object))
+		do_op.resref=Ref<Resource>(Object::cast_to<Resource>(p_object));
 
 	do_op.type=Operation::TYPE_REFERENCE;
 	actions[current_action+1].do_ops.push_back(do_op);
@@ -169,8 +169,8 @@ void UndoRedo::add_undo_reference(Object *p_object) {
 	ERR_FAIL_COND((current_action+1)>=actions.size());
 	Operation undo_op;
 	undo_op.object=p_object->get_instance_ID();
-	if (p_object->cast_to<Resource>())
-		undo_op.resref=Ref<Resource>(p_object->cast_to<Resource>());
+	if (Object::cast_to<Resource>(p_object))
+		undo_op.resref=Ref<Resource>(Object::cast_to<Resource>(p_object));
 
 	undo_op.type=Operation::TYPE_REFERENCE;
 	actions[current_action+1].undo_ops.push_back(undo_op);
@@ -241,7 +241,7 @@ void UndoRedo::_process_operation_list(List<Operation>::Element *E) {
 
 				obj->call(op.name,VARIANT_ARGS_FROM_ARRAY(op.args));
 #ifdef TOOLS_ENABLED
-				Resource* res = obj->cast_to<Resource>();
+				Resource* res = Object::cast_to<Resource>(obj);
 				if (res)
 					res->set_edited(true);
 
@@ -255,7 +255,7 @@ void UndoRedo::_process_operation_list(List<Operation>::Element *E) {
 
 				obj->set(op.name,op.args[0]);
 #ifdef TOOLS_ENABLED
-				Resource* res = obj->cast_to<Resource>();
+				Resource* res = Object::cast_to<Resource>(obj);
 				if (res)
 					res->set_edited(true);
 #endif

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -1818,14 +1818,14 @@ Variant::operator Object*() const {
 Variant::operator Node*() const {
 
 	if (type==OBJECT)
-		return _get_obj().obj?_get_obj().obj->cast_to<Node>():NULL;
+		return Object::cast_to<Node>(_get_obj().obj);
 	else
 		return NULL;
 }
 Variant::operator Control*() const {
 
 	if (type==OBJECT)
-		return _get_obj().obj?_get_obj().obj->cast_to<Control>():NULL;
+		return Object::cast_to<Control>(_get_obj().obj);
 	else
 		return NULL;
 }

--- a/drivers/png/resource_saver_png.cpp
+++ b/drivers/png/resource_saver_png.cpp
@@ -225,7 +225,7 @@ bool ResourceSaverPNG::recognize(const RES& p_resource) const {
 }
 void ResourceSaverPNG::get_recognized_extensions(const RES& p_resource,List<String> *p_extensions) const{
 
-	if (p_resource->cast_to<Texture>()) {
+	if (Object::cast_to<Texture>(*p_resource)) {
 		p_extensions->push_back("png");
 	}
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -949,7 +949,7 @@ Error Main::setup2() {
 	if (bool(GLOBAL_DEF("display/emulate_touchscreen",false))) {
 		if (!OS::get_singleton()->has_touchscreen_ui_hint() && Input::get_singleton()) {
 			//only if no touchscreen ui hint, set emulation
-			InputDefault *id = Input::get_singleton()->cast_to<InputDefault>();
+			InputDefault *id = Object::cast_to<InputDefault>(Input::get_singleton());
 			if (id)
 				id->set_emulate_touch(true);
 		}
@@ -1166,7 +1166,7 @@ bool Main::start() {
 
 			StringName instance_type=script_res->get_instance_base_type();
 			Object *obj = ObjectTypeDB::instance(instance_type);
-			MainLoop *script_loop = obj?obj->cast_to<MainLoop>():NULL;
+			MainLoop *script_loop = Object::cast_to<MainLoop>(obj);
 			if (!script_loop) {
 				if (obj)
 					memdelete(obj);
@@ -1201,7 +1201,7 @@ bool Main::start() {
 				ERR_FAIL_V(false);
 			}
 
-			main_loop=ml->cast_to<MainLoop>();
+			main_loop=Object::cast_to<MainLoop>(ml);
 			if (!main_loop) {
 
 				memdelete(ml);
@@ -1214,7 +1214,7 @@ bool Main::start() {
 
 	if (main_loop->is_type("SceneTree")) {
 
-		SceneTree *sml = main_loop->cast_to<SceneTree>();
+		SceneTree *sml = Object::cast_to<SceneTree>(main_loop);
 
 		if (debug_collisions) {
 			sml->set_debug_collisions_hint(true);
@@ -1414,7 +1414,7 @@ bool Main::start() {
 							ERR_EXPLAIN("Cannot instance script for autoload, expected 'Node' inheritance, got: "+String(ibt));
 							ERR_CONTINUE( obj==NULL );
 
-							n = obj->cast_to<Node>();
+							n = Object::cast_to<Node>(obj);
 							n->set_script(s.get_ref_ptr());
 						}
 
@@ -1479,7 +1479,7 @@ bool Main::start() {
 
 			Console *console = memnew( Console );
 
-			sml->get_root_node()->cast_to<RootNode>()->set_console(console);
+			Object::cast_to<RootNode>(sml->get_root_node())->set_console(console);
 			if (GLOBAL_DEF("console/visible_default",false).operator bool()) {
 
 				console->show();

--- a/main/performance.cpp
+++ b/main/performance.cpp
@@ -133,7 +133,7 @@ float Performance::get_monitor(Monitor p_monitor) const {
 			MainLoop *ml = OS::get_singleton()->get_main_loop();
 			if (!ml)
 				return 0;
-			SceneTree *sml = ml->cast_to<SceneTree>();
+			SceneTree *sml = Object::cast_to<SceneTree>(ml);
 			if (!sml)
 				return 0;
 			return sml->get_node_count();

--- a/modules/gdscript/gd_editor.cpp
+++ b/modules/gdscript/gd_editor.cpp
@@ -358,8 +358,8 @@ static GDCompletionIdentifier _get_type_from_variant(const Variant& p_variant) {
 	if (p_variant.get_type()==Variant::OBJECT) {
 		Object *obj = p_variant;
 		if (obj) {
-			//if (obj->cast_to<GDNativeClass>()) {
-			//	t.obj_type=obj->cast_to<GDNativeClass>()->get_name();
+			//if (Object::cast_to<GDNativeClass>(obj)) {
+			//	t.obj_type=Object::cast_to<GDNativeClass>(obj)->get_name();
 			//	t.value=Variant();
 			//} else {
 				t.obj_type=obj->get_type();
@@ -640,8 +640,8 @@ static bool _guess_expression_type(GDCompletionContext& context,const GDParser::
 
 					if (id.operator String()=="new" && base.value.get_type()==Variant::OBJECT) {
 						Object *obj = base.value;
-						if (obj && obj->cast_to<GDNativeClass>()) {
-							GDNativeClass *gdnc = obj->cast_to<GDNativeClass>();
+						if (Object::cast_to<GDNativeClass>(obj)) {
+							GDNativeClass *gdnc = Object::cast_to<GDNativeClass>(obj);
 							r_type.type=Variant::OBJECT;
 							r_type.value=Variant();
 							r_type.obj_type=gdnc->get_name();
@@ -1532,7 +1532,7 @@ static void _find_type_arguments(const GDParser::Node*p_node,int p_line,const St
 				if (obj) {
 
 
-					GDScript *scr = obj->cast_to<GDScript>();
+					GDScript *scr = Object::cast_to<GDScript>(obj);
 					if (scr) {
 						while (scr) {
 
@@ -2169,7 +2169,7 @@ Error GDScriptLanguage::complete_code(const String& p_code, const String& p_base
 						if (obj) {
 
 
-							GDScript *scr = obj->cast_to<GDScript>();
+							GDScript *scr = Object::cast_to<GDScript>(obj);
 							if (scr) {
 								while (scr) {
 

--- a/modules/gdscript/gd_script.cpp
+++ b/modules/gdscript/gd_script.cpp
@@ -395,7 +395,7 @@ Variant GDFunction::call(GDInstance *p_instance, const Variant **p_args, int p_a
 				Object *obj_B = *b;
 
 
-				GDScript *scr_B = obj_B->cast_to<GDScript>();
+				GDScript *scr_B = Object::cast_to<GDScript>(obj_B);
 
 				bool extends_ok=false;
 
@@ -425,7 +425,7 @@ Variant GDFunction::call(GDInstance *p_instance, const Variant **p_args, int p_a
 
 				} else {
 
-					GDNativeClass *nc= obj_B->cast_to<GDNativeClass>();
+					GDNativeClass *nc= Object::cast_to<GDNativeClass>(obj_B);
 
 					if (!nc) {
 
@@ -1501,7 +1501,7 @@ Variant GDNativeClass::_new() {
 		ERR_FAIL_COND_V(!o,Variant());
 	}
 
-	Reference *ref = o->cast_to<Reference>();
+	Reference *ref = Object::cast_to<Reference>(o);
 	if (ref) {
 		return REF(ref);
 	} else {
@@ -1571,7 +1571,7 @@ Variant GDScript::_new(const Variant** p_args,int p_argcount,Variant::CallError&
 		owner=memnew( Reference ); //by default, no base means use reference
 	}
 
-	Reference *r=owner->cast_to<Reference>();
+	Reference *r=Object::cast_to<Reference>(owner);
 	if (r) {
 		ref=REF(r);
 	}
@@ -1732,7 +1732,7 @@ ScriptInstance* GDScript::instance_create(Object *p_this) {
 	}
 
 	Variant::CallError unchecked_error;
-	return _create_instance(NULL,0,p_this,p_this->cast_to<Reference>(),unchecked_error);
+	return _create_instance(NULL,0,p_this,Object::cast_to<Reference>(p_this),unchecked_error);
 
 }
 bool GDScript::instance_has(const Object *p_this) const {
@@ -1908,7 +1908,7 @@ void GDScript::update_exports() {
 		Object *id=ObjectDB::get_instance(E->get());
 		if (!id)
 			continue;
-		GDScript *s=id->cast_to<GDScript>();
+		GDScript *s=Object::cast_to<GDScript>(id);
 		if (!s)
 			continue;
 		s->update_exports();
@@ -3105,12 +3105,12 @@ Error ResourceFormatSaverGDScript::save(const String &p_path,const RES& p_resour
 
 void ResourceFormatSaverGDScript::get_recognized_extensions(const RES& p_resource,List<String> *p_extensions) const {
 
-	if (p_resource->cast_to<GDScript>()) {
+	if (Object::cast_to<GDScript>(*p_resource)) {
 		p_extensions->push_back("gd");
 	}
 
 }
 bool ResourceFormatSaverGDScript::recognize(const RES& p_resource) const {
 
-	return p_resource->cast_to<GDScript>()!=NULL;
+	return Object::cast_to<GDScript>(*p_resource)!=NULL;
 }

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -1056,12 +1056,12 @@ void GridMap::_notification(int p_what) {
 
 			Spatial *c=this;
 			while(c) {
-				navigation=c->cast_to<Navigation>();
+				navigation=Object::cast_to<Navigation>(c);
 				if (navigation) {
 					break;
 				}
 
-				c=c->get_parent()->cast_to<Spatial>();
+				c=Object::cast_to<Spatial>(c->get_parent());
 			}
 
 			if(navigation){
@@ -1677,8 +1677,8 @@ void GridMap::bake_geometry() {
 
 		for(int i=0;i<get_child_count();i++) {
 
-			if (get_child(i)->cast_to<Light>()) {
-				Light *l = get_child(i)->cast_to<Light>();
+			if (Object::cast_to<Light>(get_child(i))) {
+				Light *l = Object::cast_to<Light>(get_child(i));
 				BakeLight bl;
 				for(int i=0;i<Light::PARAM_MAX;i++) {
 					bl.param[i]=l->get_parameter(Light::Parameter(i));
@@ -1727,7 +1727,7 @@ void GridMap::_find_baked_light() {
 	Node *n=get_parent();
 	while(n) {
 
-		BakedLightInstance *bl=n->cast_to<BakedLightInstance>();
+		BakedLightInstance *bl=Object::cast_to<BakedLightInstance>(n);
 		if (bl) {
 
 			baked_light_instance=bl;

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -851,7 +851,7 @@ void GridMapEditor::edit(GridMap *p_gridmap) {
 	VS *vs = VS::get_singleton();
 
 	last_mouseover=Vector3(-1,-1,-1);
-	spatial_editor  = editor->get_editor_plugin_screen()->cast_to<SpatialEditorPlugin>();
+	spatial_editor  = Object::cast_to<SpatialEditorPlugin>(editor->get_editor_plugin_screen());
 
 	if (!node) {
 		set_process(false);
@@ -1045,14 +1045,14 @@ void GridMapEditor::_notification(int p_what) {
 
 		if (lock_view) {
 
-			EditorNode*editor = get_tree()->get_root()->get_child(0)->cast_to<EditorNode>();
+			EditorNode*editor = Object::cast_to<EditorNode>(get_tree()->get_root()->get_child(0));
 
 			Plane p;
 			p.normal[edit_axis]=1.0;
 			p.d=edit_floor[edit_axis]*node->get_cell_size();
 			p = node->get_transform().xform(p); // plane to snap
 
-			SpatialEditorPlugin *sep = editor->get_editor_plugin_screen()->cast_to<SpatialEditorPlugin>();
+			SpatialEditorPlugin *sep = Object::cast_to<SpatialEditorPlugin>(editor->get_editor_plugin_screen());
 			if (sep)
 				sep->snap_cursor_to_plane(p);
 				//editor->get_editor_plugin_screen()->call("snap_cursor_to_plane",p);
@@ -1478,7 +1478,7 @@ GridMapEditor::~GridMapEditor() {
 void GridMapEditorPlugin::edit(Object *p_object) {
 
 
-	gridmap_editor->edit(p_object?p_object->cast_to<GridMap>():NULL);
+	gridmap_editor->edit(Object::cast_to<GridMap>(p_object));
 }
 
 bool GridMapEditorPlugin::handles(Object *p_object) const {

--- a/modules/ik/ik.cpp
+++ b/modules/ik/ik.cpp
@@ -60,7 +60,7 @@ void InverseKinematics::_get_property_list( List<PropertyInfo>* p_list ) const
 
 	Skeleton *parent=NULL;
 	if(get_parent())
-		parent=get_parent()->cast_to<Skeleton>();
+		parent=Object::cast_to<Skeleton>(get_parent());
 
 	if (parent) {
 
@@ -83,8 +83,8 @@ void InverseKinematics::_get_property_list( List<PropertyInfo>* p_list ) const
 void InverseKinematics::_check_bind()
 {
 
-	if (get_parent() && get_parent()->cast_to<Skeleton>()) {
-		Skeleton *sk = get_parent()->cast_to<Skeleton>();
+	if (Object::cast_to<Skeleton>(get_parent())) {
+		Skeleton *sk = Object::cast_to<Skeleton>(get_parent());
 		int idx = sk->find_bone(ik_bone);
 		if (idx!=-1) {
 			ik_bone_no = idx;
@@ -99,8 +99,8 @@ void InverseKinematics::_check_unbind()
 
 	if (bound) {
 
-		if (get_parent() && get_parent()->cast_to<Skeleton>()) {
-			Skeleton *sk = get_parent()->cast_to<Skeleton>();
+		if (Object::cast_to<Skeleton>(get_parent())) {
+			Skeleton *sk = Object::cast_to<Skeleton>(get_parent());
 			int idx = sk->find_bone(ik_bone);
 			if (idx!=-1)
 				ik_bone_no = idx;
@@ -242,7 +242,7 @@ void InverseKinematics::_notification(int p_what)
 		} break;
 		case NOTIFICATION_PROCESS: {
 			float delta = get_process_delta_time();
-			Spatial *sksp = skel->cast_to<Spatial>();
+			Spatial *sksp = Object::cast_to<Spatial>(skel);
 			if (!bound)
 				break;
 			if (!sksp)

--- a/platform/android/java_class_wrapper.cpp
+++ b/platform/android/java_class_wrapper.cpp
@@ -84,7 +84,7 @@ bool JavaClass::_call_method(JavaObject* p_instance,const StringName& p_method,c
 
 						Ref<Reference> ref = *p_args[i];
 						if (!ref.is_null()) {
-							if (ref->cast_to<JavaObject>() ) {
+							if (Object::cast_to<JavaObject>(*ref) ) {
 
 								Ref<JavaObject> jo=ref;
 								//could be faster

--- a/platform/bb10/os_bb10.cpp
+++ b/platform/bb10/os_bb10.cpp
@@ -469,7 +469,7 @@ void OSBB10::process_events() {
 		if (!event) break;
 
 		#ifdef BB10_SCORELOOP_ENABLED
-		ScoreloopBB10* sc = Globals::get_singleton()->get_singleton_object("Scoreloop")->cast_to<ScoreloopBB10>();
+		ScoreloopBB10* sc = Object::cast_to<ScoreloopBB10>(Globals::get_singleton()->get_singleton_object("Scoreloop"));
 		if (sc->handle_event(event))
 			continue;
 		#endif

--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -119,7 +119,7 @@ real_t Area2D::get_priority() const{
 void Area2D::_body_enter_tree(ObjectID p_id) {
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 
 	Map<ObjectID,BodyState>::Element *E=body_map.find(p_id);
@@ -138,7 +138,7 @@ void Area2D::_body_enter_tree(ObjectID p_id) {
 void Area2D::_body_exit_tree(ObjectID p_id) {
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 	Map<ObjectID,BodyState>::Element *E=body_map.find(p_id);
 	ERR_FAIL_COND(!E);
@@ -158,7 +158,7 @@ void Area2D::_body_inout(int p_status,const RID& p_body, int p_instance, int p_b
 	ObjectID objid=p_instance;
 
 	Object *obj = ObjectDB::get_instance(objid);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 
 	Map<ObjectID,BodyState>::Element *E=body_map.find(objid);
 
@@ -231,7 +231,7 @@ void Area2D::_body_inout(int p_status,const RID& p_body, int p_instance, int p_b
 void Area2D::_area_enter_tree(ObjectID p_id) {
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 
 	Map<ObjectID,AreaState>::Element *E=area_map.find(p_id);
@@ -250,7 +250,7 @@ void Area2D::_area_enter_tree(ObjectID p_id) {
 void Area2D::_area_exit_tree(ObjectID p_id) {
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 	Map<ObjectID,AreaState>::Element *E=area_map.find(p_id);
 	ERR_FAIL_COND(!E);
@@ -270,7 +270,7 @@ void Area2D::_area_inout(int p_status,const RID& p_area, int p_instance, int p_a
 	ObjectID objid=p_instance;
 
 	Object *obj = ObjectDB::get_instance(objid);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 
 	Map<ObjectID,AreaState>::Element *E=area_map.find(objid);
 
@@ -355,7 +355,7 @@ void Area2D::_clear_monitoring() {
 		for (Map<ObjectID,BodyState>::Element *E=bmcopy.front();E;E=E->next()) {
 
 			Object *obj = ObjectDB::get_instance(E->key());
-			Node *node = obj ? obj->cast_to<Node>() : NULL;
+			Node *node = Object::cast_to<Node>(obj);
 			ERR_CONTINUE(!node);
 			if (!E->get().in_tree)
 				continue;
@@ -382,7 +382,7 @@ void Area2D::_clear_monitoring() {
 		for (Map<ObjectID,AreaState>::Element *E=bmcopy.front();E;E=E->next()) {
 
 			Object *obj = ObjectDB::get_instance(E->key());
-			Node *node = obj ? obj->cast_to<Node>() : NULL;
+			Node *node = Object::cast_to<Node>(obj);
 
 			if (!node) //node may have been deleted in previous frame, this should not be an error
 				continue;

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -225,7 +225,7 @@ void Camera2D::_notification(int p_what) {
 			Node *n=this;
 			while(n){
 
-				viewport = n->cast_to<Viewport>();
+				viewport = Object::cast_to<Viewport>(n);
 				if (viewport)
 					break;
 				n=n->get_parent();

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -263,7 +263,7 @@ void CanvasItem::_propagate_visibility_changed(bool p_visible) {
 
 	for(int i=0;i<get_child_count();i++) {
 
-		CanvasItem *c=get_child(i)->cast_to<CanvasItem>();
+		CanvasItem *c=Object::cast_to<CanvasItem>(get_child(i));
 
 		if (c && !c->hidden) //should the toplevels stop propagation? i think so but..
 			c->_propagate_visibility_changed(p_visible);
@@ -431,12 +431,12 @@ void CanvasItem::_sort_children() {
 	for(int i=0;i<get_child_count();i++) {
 
 		Node *n = get_child(i);
-		CanvasItem *ci=n->cast_to<CanvasItem>();
+		CanvasItem *ci=Object::cast_to<CanvasItem>(n);
 
 		if (ci) {
 			if (ci->toplevel || ci->group!="")
 				continue;
-			VisualServer::get_singleton()->canvas_item_raise(n->cast_to<CanvasItem>()->canvas_item);
+			VisualServer::get_singleton()->canvas_item_raise(Object::cast_to<CanvasItem>(n)->canvas_item);
 		}
 	}
 }
@@ -452,7 +452,7 @@ void CanvasItem::_raise_self() {
 
 void CanvasItem::_enter_canvas() {
 
-	if ((!get_parent() || !get_parent()->cast_to<CanvasItem>()) || toplevel) {
+	if ((!get_parent() || !Object::cast_to<CanvasItem>(get_parent())) || toplevel) {
 
 		Node *n = this;
 		Viewport *viewport=NULL;
@@ -460,14 +460,14 @@ void CanvasItem::_enter_canvas() {
 
 		while(n) {
 
-			if (n->cast_to<Viewport>()) {
+			if (Object::cast_to<Viewport>(n)) {
 
-				viewport = n->cast_to<Viewport>();
+				viewport = Object::cast_to<Viewport>(n);
 				break;
 			}
-			if (!canvas_layer && n->cast_to<CanvasLayer>()) {
+			if (!canvas_layer && Object::cast_to<CanvasLayer>(n)) {
 
-				canvas_layer = n->cast_to<CanvasLayer>();
+				canvas_layer = Object::cast_to<CanvasLayer>(n);
 			}
 			n=n->get_parent();
 		}
@@ -518,7 +518,7 @@ void CanvasItem::_notification(int p_what) {
 			first_draw=true;
 			pending_children_sort=false;
 			if (get_parent()) {
-				CanvasItem *ci = get_parent()->cast_to<CanvasItem>();
+				CanvasItem *ci = Object::cast_to<CanvasItem>(get_parent());
 				if (ci)
 					C=ci->children_items.push_back(this);
 			}
@@ -545,7 +545,7 @@ void CanvasItem::_notification(int p_what) {
 				get_tree()->xform_change_list.remove(&xform_change);
 			_exit_canvas();
 			if (C) {
-				get_parent()->cast_to<CanvasItem>()->children_items.erase(C);
+				Object::cast_to<CanvasItem>(get_parent())->children_items.erase(C);
 				C=NULL;
 			}
 			global_invalid=true;
@@ -631,7 +631,7 @@ CanvasItem *CanvasItem::get_parent_item() const {
 	if (!parent)
 		return NULL;
 
-	return parent->cast_to<CanvasItem>();
+	return Object::cast_to<CanvasItem>(parent);
 }
 
 
@@ -878,8 +878,8 @@ RID CanvasItem::get_canvas() const {
 CanvasItem *CanvasItem::get_toplevel() const {
 
 	CanvasItem *ci=const_cast<CanvasItem*>(this);
-	while(!ci->toplevel && ci->get_parent() && ci->get_parent()->cast_to<CanvasItem>()) {
-		ci=ci->get_parent()->cast_to<CanvasItem>();
+	while(!ci->toplevel && ci->get_parent() && Object::cast_to<CanvasItem>(ci->get_parent())) {
+		ci=Object::cast_to<CanvasItem>(ci->get_parent());
 	}
 
 	return ci;
@@ -1157,8 +1157,8 @@ Matrix32 CanvasItem::get_canvas_transform() const {
 
 	if (canvas_layer)
 		return canvas_layer->get_transform();
-	else if (get_parent()->cast_to<CanvasItem>())
-		return get_parent()->cast_to<CanvasItem>()->get_canvas_transform();
+	else if (Object::cast_to<CanvasItem>(get_parent()))
+		return Object::cast_to<CanvasItem>(get_parent())->get_canvas_transform();
 	else
 		return get_viewport()->get_canvas_transform();
 

--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -36,7 +36,7 @@ void CollisionPolygon2D::_add_to_collision_object(Object *p_obj) {
 	if (unparenting || !can_update_body)
 		return;
 
-	CollisionObject2D *co = p_obj->cast_to<CollisionObject2D>();
+	CollisionObject2D *co = Object::cast_to<CollisionObject2D>(p_obj);
 	ERR_FAIL_COND(!co);
 
 	if (polygon.size()==0)
@@ -100,7 +100,7 @@ void CollisionPolygon2D::_update_parent() {
 	Node *parent = get_parent();
 	if (!parent)
 		return;
-	CollisionObject2D *co = parent->cast_to<CollisionObject2D>();
+	CollisionObject2D *co = Object::cast_to<CollisionObject2D>(parent);
 	if (!co)
 		return;
 	co->_update_shapes_from_children();
@@ -175,7 +175,7 @@ void CollisionPolygon2D::_notification(int p_what) {
 			if (can_update_body) {
 				_update_parent();
 			} else if (shape_from>=0 && shape_to>=0) {
-				CollisionObject2D *co = get_parent()->cast_to<CollisionObject2D>();
+				CollisionObject2D *co = Object::cast_to<CollisionObject2D>(get_parent());
 				for(int i=shape_from;i<=shape_to;i++) {
 					co->set_shape_transform(i,get_transform());
 				}
@@ -272,7 +272,7 @@ void CollisionPolygon2D::set_trigger(bool p_trigger) {
 	trigger=p_trigger;
 	_update_parent();
 	if (!can_update_body && is_inside_tree() && shape_from>=0 && shape_to>=0) {
-		CollisionObject2D *co = get_parent()->cast_to<CollisionObject2D>();
+		CollisionObject2D *co = Object::cast_to<CollisionObject2D>(get_parent());
 		for(int i=shape_from;i<=shape_to;i++) {
 			co->set_shape_as_trigger(i,p_trigger);
 		}
@@ -299,7 +299,7 @@ Vector2 CollisionPolygon2D::_get_shape_range() const {
 
 String CollisionPolygon2D::get_configuration_warning() const {
 
-	if (!get_parent()->cast_to<CollisionObject2D>()) {
+	if (!Object::cast_to<CollisionObject2D>(get_parent())) {
 		return TTR("CollisionPolygon2D only serves to provide a collision shape to a CollisionObject2D derived node. Please only use it as a child of Area2D, StaticBody2D, RigidBody2D, KinematicBody2D, etc. to give them a shape.");
 	}
 

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -42,7 +42,7 @@ void CollisionShape2D::_add_to_collision_object(Object *p_obj) {
 	if (unparenting)
 		return;
 
-	CollisionObject2D *co = p_obj->cast_to<CollisionObject2D>();
+	CollisionObject2D *co = Object::cast_to<CollisionObject2D>(p_obj);
 	ERR_FAIL_COND(!co);
 	update_shape_index=co->get_shape_count();
 	co->add_shape(shape,get_transform());
@@ -64,7 +64,7 @@ void CollisionShape2D::_update_parent() {
 	Node *parent = get_parent();
 	if (!parent)
 		return;
-	CollisionObject2D *co = parent->cast_to<CollisionObject2D>();
+	CollisionObject2D *co = Object::cast_to<CollisionObject2D>(parent);
 	if (!co)
 		return;
 	co->_update_shapes_from_children();
@@ -92,7 +92,7 @@ void CollisionShape2D::_notification(int p_what) {
 				_update_parent();
 			} else if (update_shape_index>=0){
 
-				CollisionObject2D *co = get_parent()->cast_to<CollisionObject2D>();
+				CollisionObject2D *co = Object::cast_to<CollisionObject2D>(get_parent());
 				if (co) {
 					co->set_shape_transform(update_shape_index,get_transform());
 				}
@@ -151,7 +151,7 @@ void CollisionShape2D::set_shape(const Ref<Shape2D>& p_shape) {
 	if (is_inside_tree() && can_update_body)
 		_update_parent();
 	if (is_inside_tree() && !can_update_body && update_shape_index>=0) {
-		CollisionObject2D *co = get_parent()->cast_to<CollisionObject2D>();
+		CollisionObject2D *co = Object::cast_to<CollisionObject2D>(get_parent());
 		if (co) {
 			co->set_shape(update_shape_index,p_shape);
 		}
@@ -177,7 +177,7 @@ void CollisionShape2D::set_trigger(bool p_trigger) {
 	if (can_update_body) {
 		_update_parent();
 	} else if (is_inside_tree() && update_shape_index>=0){
-		CollisionObject2D *co = get_parent()->cast_to<CollisionObject2D>();
+		CollisionObject2D *co = Object::cast_to<CollisionObject2D>(get_parent());
 		if (co) {
 			co->set_shape_as_trigger(update_shape_index,p_trigger);
 		}
@@ -203,7 +203,7 @@ int CollisionShape2D::_get_update_shape_index() const{
 
 String CollisionShape2D::get_configuration_warning() const {
 
-	if (!get_parent()->cast_to<CollisionObject2D>()) {
+	if (!Object::cast_to<CollisionObject2D>(get_parent())) {
 		return TTR("CollisionShape2D only serves to provide a collision shape to a CollisionObject2D derived node. Please only use it as a child of Area2D, StaticBody2D, RigidBody2D, KinematicBody2D, etc. to give them a shape.");
 	}
 

--- a/scene/2d/joints_2d.cpp
+++ b/scene/2d/joints_2d.cpp
@@ -188,8 +188,8 @@ RID PinJoint2D::_configure_joint() {
 	if (!node_a && !node_b)
 		return RID();
 
-	PhysicsBody2D *body_a=node_a ? node_a->cast_to<PhysicsBody2D>() : (PhysicsBody2D*)NULL;
-	PhysicsBody2D *body_b=node_b ? node_b->cast_to<PhysicsBody2D>() : (PhysicsBody2D*)NULL;
+	PhysicsBody2D *body_a=Object::cast_to<PhysicsBody2D>(node_a);
+	PhysicsBody2D *body_b=Object::cast_to<PhysicsBody2D>(node_b);
 
 	if (!body_a && !body_b)
 		return RID();
@@ -271,8 +271,8 @@ RID GrooveJoint2D::_configure_joint(){
 	if (!node_a || !node_b)
 		return RID();
 
-	PhysicsBody2D *body_a=node_a->cast_to<PhysicsBody2D>();
-	PhysicsBody2D *body_b=node_b->cast_to<PhysicsBody2D>();
+	PhysicsBody2D *body_a=Object::cast_to<PhysicsBody2D>(node_a);
+	PhysicsBody2D *body_b=Object::cast_to<PhysicsBody2D>(node_b);
 
 	if (!body_a || !body_b)
 		return RID();
@@ -373,8 +373,8 @@ RID DampedSpringJoint2D::_configure_joint(){
 	if (!node_a || !node_b)
 		return RID();
 
-	PhysicsBody2D *body_a=node_a->cast_to<PhysicsBody2D>();
-	PhysicsBody2D *body_b=node_b->cast_to<PhysicsBody2D>();
+	PhysicsBody2D *body_a=Object::cast_to<PhysicsBody2D>(node_a);
+	PhysicsBody2D *body_b=Object::cast_to<PhysicsBody2D>(node_b);
 
 	if (!body_a || !body_b)
 		return RID();

--- a/scene/2d/navigation_polygon.cpp
+++ b/scene/2d/navigation_polygon.cpp
@@ -304,7 +304,7 @@ void NavigationPolygonInstance::_notification(int p_what) {
 			Node2D *c=this;
 			while(c) {
 
-				navigation=c->cast_to<Navigation2D>();
+				navigation=Object::cast_to<Navigation2D>(c);
 				if (navigation) {
 
 					if (enabled && navpoly.is_valid()) {
@@ -314,7 +314,7 @@ void NavigationPolygonInstance::_notification(int p_what) {
 					break;
 				}
 
-				c=c->get_parent()->cast_to<Node2D>();
+				c=Object::cast_to<Node2D>(c->get_parent());
 			}
 
 		} break;
@@ -440,11 +440,11 @@ String NavigationPolygonInstance::get_configuration_warning() const {
 	const Node2D *c=this;
 	while(c) {
 
-		if (c->cast_to<Navigation2D>()) {
+		if (Object::cast_to<Navigation2D>(c)) {
 			return String();
 		}
 
-		c=c->get_parent()->cast_to<Node2D>();
+		c=Object::cast_to<Node2D>(c->get_parent());
 	}
 
 	return TTR("NavigationPolygonInstance must be a child or grandchild to a Navigation2D node. It only provides navigation data.");

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -352,7 +352,7 @@ Matrix32 Node2D::get_relative_transform_to_parent(const Node *p_parent) const {
 	if (p_parent==this)
 		return Matrix32();
 
-	Node2D *parent_2d = get_parent()->cast_to<Node2D>();
+	Node2D *parent_2d = Object::cast_to<Node2D>(get_parent());
 
 	ERR_FAIL_COND_V(!parent_2d,Matrix32());
 	if (p_parent==parent_2d)

--- a/scene/2d/parallax_background.cpp
+++ b/scene/2d/parallax_background.cpp
@@ -106,7 +106,7 @@ void ParallaxBackground::_update_scroll() {
 
 	for(int i=0;i<get_child_count();i++) {
 
-		ParallaxLayer *l=get_child(i)->cast_to<ParallaxLayer>();
+		ParallaxLayer *l=Object::cast_to<ParallaxLayer>(get_child(i));
 		if (!l)
 			continue;
 

--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -46,7 +46,7 @@ void ParallaxLayer::_update_mirroring() {
 	if (!get_parent())
 		return;
 
-	ParallaxBackground *pb = get_parent()->cast_to<ParallaxBackground>();
+	ParallaxBackground *pb = Object::cast_to<ParallaxBackground>(get_parent());
 	if (pb) {
 
 		RID c = pb->get_world_2d()->get_canvas();
@@ -121,7 +121,7 @@ void ParallaxLayer::set_base_offset_and_scale(const Point2& p_offset,float p_sca
 
 String ParallaxLayer::get_configuration_warning() const {
 
-	if (!get_parent() || !get_parent()->cast_to<ParallaxBackground>()) {
+	if (!get_parent() || !Object::cast_to<ParallaxBackground>(get_parent())) {
 		return TTR("ParallaxLayer node only works when set as child of a ParallaxBackground node.");
 	}
 

--- a/scene/2d/particles_2d.cpp
+++ b/scene/2d/particles_2d.cpp
@@ -83,7 +83,7 @@ void ParticleAttractor2D::_update_owner() {
 
 	Node *n = get_node(path);
 	ERR_FAIL_COND(!n);
-	Particles2D *pn = n->cast_to<Particles2D>();
+	Particles2D *pn = Object::cast_to<Particles2D>(n);
 	if (!pn) {
 		_set_owner(NULL);
 		return;
@@ -207,7 +207,7 @@ NodePath ParticleAttractor2D::get_particles_path() const {
 
 String ParticleAttractor2D::get_configuration_warning() const {
 
-	if (!has_node(path) || !get_node(path) || !get_node(path)->cast_to<Particles2D>()) {
+	if (!has_node(path) || !get_node(path) || !Object::cast_to<Particles2D>(get_node(path))) {
 		return TTR("Path property must point to a valid Particles2D node to work.");
 	}
 

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -146,7 +146,7 @@ void PathFollow2D::_notification(int p_what) {
 			Node *parent=get_parent();
 			if (parent) {
 
-				path=parent->cast_to<Path2D>();
+				path=Object::cast_to<Path2D>(parent);
 				if (path) {
 					_update_transform();
 				}
@@ -242,7 +242,7 @@ String PathFollow2D::get_configuration_warning() const {
 	if (!is_visible() || !is_inside_tree())
 		return String();
 
-	if (!get_parent() || !get_parent()->cast_to<Path2D>()) {
+	if (!get_parent() || !Object::cast_to<Path2D>(get_parent())) {
 		return TTR("PathFollow2D only works when set as a child of a Path2D node.");
 	}
 

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -174,7 +174,7 @@ PhysicsBody2D::PhysicsBody2D(Physics2DServer::BodyMode p_mode) : CollisionObject
 void PhysicsBody2D::add_collision_exception_with(Node* p_node) {
 
 	ERR_FAIL_NULL(p_node);
-	PhysicsBody2D *physics_body = p_node->cast_to<PhysicsBody2D>();
+	PhysicsBody2D *physics_body = Object::cast_to<PhysicsBody2D>(p_node);
 	if (!physics_body) {
 		ERR_EXPLAIN("Collision exception only works between two objects of PhysicsBody type");
 	}
@@ -186,7 +186,7 @@ void PhysicsBody2D::add_collision_exception_with(Node* p_node) {
 void PhysicsBody2D::remove_collision_exception_with(Node* p_node) {
 
 	ERR_FAIL_NULL(p_node);
-	PhysicsBody2D *physics_body = p_node->cast_to<PhysicsBody2D>();
+	PhysicsBody2D *physics_body = Object::cast_to<PhysicsBody2D>(p_node);
 	if (!physics_body) {
 		ERR_EXPLAIN("Collision exception only works between two objects of PhysicsBody type");
 	}
@@ -303,7 +303,7 @@ StaticBody2D::~StaticBody2D() {
 void RigidBody2D::_body_enter_tree(ObjectID p_id) {
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 
 	Map<ObjectID,BodyState>::Element *E=contact_monitor->body_map.find(p_id);
@@ -329,7 +329,7 @@ void RigidBody2D::_body_enter_tree(ObjectID p_id) {
 void RigidBody2D::_body_exit_tree(ObjectID p_id) {
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 	Map<ObjectID,BodyState>::Element *E=contact_monitor->body_map.find(p_id);
 	ERR_FAIL_COND(!E);
@@ -355,7 +355,7 @@ void RigidBody2D::_body_inout(int p_status, ObjectID p_instance, int p_body_shap
 	ObjectID objid=p_instance;
 
 	Object *obj = ObjectDB::get_instance(objid);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 
 	Map<ObjectID,BodyState>::Element *E=contact_monitor->body_map.find(objid);
 
@@ -445,7 +445,7 @@ void RigidBody2D::_direct_state_changed(Object *p_state) {
 	//eh.. fuck
 #ifdef DEBUG_ENABLED
 
-	state=p_state->cast_to<Physics2DDirectBodyState>();
+	state=Object::cast_to<Physics2DDirectBodyState>(p_state);
 #else
 	state=(Physics2DDirectBodyState*)p_state; //trust it
 #endif
@@ -1030,7 +1030,7 @@ Variant KinematicBody2D::_get_collider() const {
 	if (!obj)
 		return Variant();
 
-	Reference *ref = obj->cast_to<Reference>();
+	Reference *ref = Object::cast_to<Reference>(obj);
 	if (ref) {
 		return Ref<Reference>(ref);
 	}

--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -197,7 +197,7 @@ void RayCast2D::add_exception_rid(const RID& p_rid) {
 void RayCast2D::add_exception(const Object* p_object){
 
 	ERR_FAIL_NULL(p_object);
-	CollisionObject2D *co=((Object*)p_object)->cast_to<CollisionObject2D>();
+	const CollisionObject2D *co=Object::cast_to<const CollisionObject2D>(p_object);
 	if (!co)
 		return;
 	add_exception_rid(co->get_rid());
@@ -211,7 +211,7 @@ void RayCast2D::remove_exception_rid(const RID& p_rid) {
 void RayCast2D::remove_exception(const Object* p_object){
 
 	ERR_FAIL_NULL(p_object);
-	CollisionObject2D *co=((Object*)p_object)->cast_to<CollisionObject2D>();
+	CollisionObject2D *co=Object::cast_to<CollisionObject2D>(((Object*)p_object));
 	if (!co)
 		return;
 	remove_exception_rid(co->get_rid());

--- a/scene/2d/remote_transform_2d.cpp
+++ b/scene/2d/remote_transform_2d.cpp
@@ -55,7 +55,7 @@ void RemoteTransform2D::_update_remote() {
 	if (!obj)
 		return;
 
-	Node2D *n = obj->cast_to<Node2D>();
+	Node2D *n = Object::cast_to<Node2D>(obj);
 	if (!n)
 		return;
 
@@ -109,7 +109,7 @@ NodePath RemoteTransform2D::get_remote_node() const{
 
 String RemoteTransform2D::get_configuration_warning() const {
 
-	if (!has_node(remote_node) || !get_node(remote_node) || !get_node(remote_node)->cast_to<Node2D>()) {
+	if (!has_node(remote_node) || !get_node(remote_node) || !Object::cast_to<Node2D>(get_node(remote_node))) {
 		return TTR("Path property must point to a valid Node2D node to work.");
 	}
 

--- a/scene/2d/sprite.cpp
+++ b/scene/2d/sprite.cpp
@@ -388,7 +388,7 @@ void ViewportSprite::_notification(int p_what) {
 
 				Node *n = get_node(viewport_path);
 				ERR_FAIL_COND(!n);
-				Viewport *vp=n->cast_to<Viewport>();
+				Viewport *vp=Object::cast_to<Viewport>(n);
 				ERR_FAIL_COND(!vp);
 
 				Ref<RenderTargetTexture> rtt = vp->get_render_target_texture();
@@ -456,7 +456,7 @@ void ViewportSprite::set_viewport_path(const NodePath& p_viewport) {
 
 	Node *n = get_node(viewport_path);
 	ERR_FAIL_COND(!n);
-	Viewport *vp=n->cast_to<Viewport>();
+	Viewport *vp=Object::cast_to<Viewport>(n);
 	ERR_FAIL_COND(!vp);
 
 	Ref<RenderTargetTexture> rtt = vp->get_render_target_texture();
@@ -531,13 +531,13 @@ Rect2 ViewportSprite::get_item_rect() const {
 
 String ViewportSprite::get_configuration_warning() const {
 
-	if (!has_node(viewport_path) || !get_node(viewport_path) || !get_node(viewport_path)->cast_to<Viewport>()) {
+	if (!has_node(viewport_path) || !get_node(viewport_path) || !Object::cast_to<Viewport>(get_node(viewport_path))) {
 		return TTR("Path property must point to a valid Viewport node to work. Such Viewport must be set to 'render target' mode.");
 	} else {
 
 		Node *n = get_node(viewport_path);
 		if (n) {
-			Viewport *vp = n->cast_to<Viewport>();
+			Viewport *vp = Object::cast_to<Viewport>(n);
 			if (!vp->is_set_as_render_target()) {
 
 				return TTR("The Viewport set in the path property must be set as 'render target' in order for this sprite to work.");

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -51,12 +51,12 @@ void TileMap::_notification(int p_what) {
 			Node2D *c=this;
 			while(c) {
 
-				navigation=c->cast_to<Navigation2D>();
+				navigation=Object::cast_to<Navigation2D>(c);
 				if (navigation) {
 					break;
 				}
 
-				c=c->get_parent()->cast_to<Node2D>();
+				c=Object::cast_to<Node2D>(c->get_parent());
 			}
 
 			pending_update=true;
@@ -527,7 +527,7 @@ void TileMap::_update_dirty_quadrants() {
 
 	for(int i=0;i<get_child_count();i++) {
 
-		CanvasItem *c=get_child(i)->cast_to<CanvasItem>();
+		CanvasItem *c=Object::cast_to<CanvasItem>(get_child(i));
 
 		if (c)
 			VS::get_singleton()->canvas_item_raise(c->get_canvas_item());

--- a/scene/2d/visibility_notifier_2d.cpp
+++ b/scene/2d/visibility_notifier_2d.cpp
@@ -187,7 +187,7 @@ void VisibilityEnabler2D::_find_nodes(Node* p_node) {
 
 	if (enabler[ENABLER_FREEZE_BODIES]) {
 
-		RigidBody2D *rb2d = p_node->cast_to<RigidBody2D>();
+		RigidBody2D *rb2d = Object::cast_to<RigidBody2D>(p_node);
 		if (rb2d && ((rb2d->get_mode()==RigidBody2D::MODE_CHARACTER || (rb2d->get_mode()==RigidBody2D::MODE_RIGID && !rb2d->is_able_to_sleep())))) {
 
 
@@ -198,7 +198,7 @@ void VisibilityEnabler2D::_find_nodes(Node* p_node) {
 
 	if (enabler[ENABLER_PAUSE_ANIMATIONS]) {
 
-		AnimationPlayer *ap = p_node->cast_to<AnimationPlayer>();
+		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node);
 		if (ap) {
 			add=true;
 		}
@@ -207,7 +207,7 @@ void VisibilityEnabler2D::_find_nodes(Node* p_node) {
 
 	if (enabler[ENABLER_PAUSE_ANIMATED_SPRITES]) {
 
-		AnimatedSprite *as = p_node->cast_to<AnimatedSprite>();
+		AnimatedSprite *as = Object::cast_to<AnimatedSprite>(p_node);
 		if (as) {
 			add=true;
 		}
@@ -217,7 +217,7 @@ void VisibilityEnabler2D::_find_nodes(Node* p_node) {
 
 	if (enabler[ENABLER_PAUSE_PARTICLES]) {
 
-		Particles2D *ps = p_node->cast_to<Particles2D>();
+		Particles2D *ps = Object::cast_to<Particles2D>(p_node);
 		if (ps) {
 			add=true;
 		}
@@ -290,7 +290,7 @@ void VisibilityEnabler2D::_change_node_state(Node* p_node,bool p_enabled) {
 	ERR_FAIL_COND(!nodes.has(p_node));
 
 	{
-		RigidBody2D *rb = p_node->cast_to<RigidBody2D>();
+		RigidBody2D *rb = Object::cast_to<RigidBody2D>(p_node);
 		if (rb) {
 
 			if (p_enabled) {
@@ -305,7 +305,7 @@ void VisibilityEnabler2D::_change_node_state(Node* p_node,bool p_enabled) {
 	}
 
 	{
-		AnimationPlayer *ap=p_node->cast_to<AnimationPlayer>();
+		AnimationPlayer *ap=Object::cast_to<AnimationPlayer>(p_node);
 
 		if (ap) {
 
@@ -313,7 +313,7 @@ void VisibilityEnabler2D::_change_node_state(Node* p_node,bool p_enabled) {
 		}
 	}
 	{
-		AnimatedSprite *as=p_node->cast_to<AnimatedSprite>();
+		AnimatedSprite *as=Object::cast_to<AnimatedSprite>(p_node);
 
 		if (as) {
 
@@ -325,7 +325,7 @@ void VisibilityEnabler2D::_change_node_state(Node* p_node,bool p_enabled) {
 	}
 
 	{
-		Particles2D *ps=p_node->cast_to<Particles2D>();
+		Particles2D *ps=Object::cast_to<Particles2D>(p_node);
 
 		if (ps) {
 

--- a/scene/3d/area.cpp
+++ b/scene/3d/area.cpp
@@ -118,7 +118,7 @@ real_t Area::get_priority() const{
 void Area::_body_enter_tree(ObjectID p_id) {
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 
 	Map<ObjectID,BodyState>::Element *E=body_map.find(p_id);
@@ -138,7 +138,7 @@ void Area::_body_exit_tree(ObjectID p_id) {
 
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 	Map<ObjectID,BodyState>::Element *E=body_map.find(p_id);
 	ERR_FAIL_COND(!E);
@@ -159,7 +159,7 @@ void Area::_body_inout(int p_status,const RID& p_body, int p_instance, int p_bod
 	ObjectID objid=p_instance;
 
 	Object *obj = ObjectDB::get_instance(objid);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 
 	Map<ObjectID,BodyState>::Element *E=body_map.find(objid);
 
@@ -243,7 +243,7 @@ void Area::_clear_monitoring() {
 		for (Map<ObjectID,BodyState>::Element *E=bmcopy.front();E;E=E->next()) {
 
 			Object *obj = ObjectDB::get_instance(E->key());
-			Node *node = obj ? obj->cast_to<Node>() : NULL;
+			Node *node = Object::cast_to<Node>(obj);
 			ERR_CONTINUE(!node);
 			if (!E->get().in_tree)
 				continue;
@@ -270,7 +270,7 @@ void Area::_clear_monitoring() {
 		for (Map<ObjectID,AreaState>::Element *E=bmcopy.front();E;E=E->next()) {
 
 			Object *obj = ObjectDB::get_instance(E->key());
-			Node *node = obj ? obj->cast_to<Node>() : NULL;
+			Node *node = Object::cast_to<Node>(obj);
 			ERR_CONTINUE(!node);
 			if (!E->get().in_tree)
 				continue;
@@ -323,7 +323,7 @@ void Area::set_enable_monitoring(bool p_enable) {
 void Area::_area_enter_tree(ObjectID p_id) {
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 
 	Map<ObjectID,AreaState>::Element *E=area_map.find(p_id);
@@ -342,7 +342,7 @@ void Area::_area_enter_tree(ObjectID p_id) {
 void Area::_area_exit_tree(ObjectID p_id) {
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 	Map<ObjectID,AreaState>::Element *E=area_map.find(p_id);
 	ERR_FAIL_COND(!E);
@@ -363,7 +363,7 @@ void Area::_area_inout(int p_status,const RID& p_area, int p_instance, int p_are
 	ObjectID objid=p_instance;
 
 	Object *obj = ObjectDB::get_instance(objid);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 
 	Map<ObjectID,AreaState>::Element *E=area_map.find(objid);
 

--- a/scene/3d/body_shape.cpp
+++ b/scene/3d/body_shape.cpp
@@ -47,8 +47,8 @@ void CollisionShape::_update_body() {
 		return;
 	if (!get_tree()->is_editor_hint())
 		return;
-	if (get_parent() && get_parent()->cast_to<CollisionObject>())
-		get_parent()->cast_to<CollisionObject>()->_update_shapes_from_children();
+	if (CollisionObject *co = Object::cast_to<CollisionObject>(get_parent()))
+		co->_update_shapes_from_children();
 
 }
 
@@ -61,9 +61,9 @@ void CollisionShape::make_convex_from_brothers() {
 	for(int i=0;i<p->get_child_count();i++) {
 
 		Node *n = p->get_child(i);
-		if (n->cast_to<MeshInstance>()) {
+		if (Object::cast_to<MeshInstance>(n)) {
 
-			MeshInstance *mi=n->cast_to<MeshInstance>();
+			MeshInstance *mi=Object::cast_to<MeshInstance>(n);
 			Ref<Mesh> m = mi->get_mesh();
 			if (m.is_valid()) {
 
@@ -89,16 +89,16 @@ void CollisionShape::_update_indicator() {
 
 	VS::PrimitiveType pt = VS::PRIMITIVE_TRIANGLES;
 
-	if (shape->cast_to<RayShape>()) {
+	if (Object::cast_to<RayShape>(shape)) {
 
-		RayShape *rs = shape->cast_to<RayShape>();
+		RayShape *rs = Object::cast_to<RayShape>(shape);
 		points.push_back(Vector3());
 		points.push_back(Vector3(0,0,rs->get_length()));
 		pt = VS::PRIMITIVE_LINES;
-	} else if (shape->cast_to<SphereShape>()) {
+	} else if (Object::cast_to<SphereShape>(shape)) {
 
 //		VisualServer *vs=VisualServer::get_singleton();
-		SphereShape *shapeptr=shape->cast_to<SphereShape>();
+		SphereShape *shapeptr=Object::cast_to<SphereShape>(shape);
 
 
 		Color col(0.4,1.0,1.0,0.5);
@@ -157,9 +157,9 @@ void CollisionShape::_update_indicator() {
 
 			}
 		}
-	} else if (shape->cast_to<BoxShape>()) {
+	} else if (Object::cast_to<BoxShape>(shape)) {
 
-		BoxShape *shapeptr=shape->cast_to<BoxShape>();
+		BoxShape *shapeptr=Object::cast_to<BoxShape>(shape);
 
 		for (int i=0;i<6;i++) {
 
@@ -201,9 +201,9 @@ void CollisionShape::_update_indicator() {
 
 		}
 
-	} else if (shape->cast_to<ConvexPolygonShape>()) {
+	} else if (Object::cast_to<ConvexPolygonShape>(shape)) {
 
-		ConvexPolygonShape *shapeptr=shape->cast_to<ConvexPolygonShape>();
+		ConvexPolygonShape *shapeptr=Object::cast_to<ConvexPolygonShape>(shape);
 
 		Geometry::MeshData md;
 		QuickHull::build(Variant(shapeptr->get_points()),md);
@@ -219,9 +219,9 @@ void CollisionShape::_update_indicator() {
 				normals.push_back(md.faces[i].plane.normal);
 			}
 		}
-	} else if (shape->cast_to<ConcavePolygonShape>()) {
+	} else if (Object::cast_to<ConcavePolygonShape>(shape)) {
 
-		ConcavePolygonShape *shapeptr=shape->cast_to<ConcavePolygonShape>();
+		ConcavePolygonShape *shapeptr=Object::cast_to<ConcavePolygonShape>(shape);
 
 		points = shapeptr->get_faces();
 		for(int i=0;i<points.size()/3;i++) {
@@ -232,9 +232,9 @@ void CollisionShape::_update_indicator() {
 			normals.push_back(n);
 		}
 
-	} else if (shape->cast_to<CapsuleShape>()) {
+	} else if (Object::cast_to<CapsuleShape>(shape)) {
 
-		CapsuleShape *shapeptr=shape->cast_to<CapsuleShape>();
+		CapsuleShape *shapeptr=Object::cast_to<CapsuleShape>(shape);
 
 		DVector<Plane> planes = Geometry::build_capsule_planes(shapeptr->get_radius(), shapeptr->get_height()/2.0, 12, Vector3::AXIS_Z);
 		Geometry::MeshData md = Geometry::build_convex_mesh(planes);
@@ -252,9 +252,9 @@ void CollisionShape::_update_indicator() {
 			}
 		}
 
-	} else if (shape->cast_to<PlaneShape>()) {
+	} else if (Object::cast_to<PlaneShape>(shape)) {
 
-		PlaneShape *shapeptr=shape->cast_to<PlaneShape>();
+		PlaneShape *shapeptr=Object::cast_to<PlaneShape>(shape);
 
 		Plane p = shapeptr->get_plane();
 		Vector3 n1 = p.get_any_perpendicular_normal();
@@ -308,7 +308,7 @@ void CollisionShape::_add_to_collision_object(Object* p_cshape) {
 	if (unparenting)
 		return;
 
-	CollisionObject *co=p_cshape->cast_to<CollisionObject>();
+	CollisionObject *co=Object::cast_to<CollisionObject>(p_cshape);
 	ERR_FAIL_COND(!co);
 
 	if (shape.is_valid()) {
@@ -368,7 +368,7 @@ void CollisionShape::_notification(int p_what) {
 
 			if (!can_update_body && update_shape_index>=0) {
 
-				CollisionObject *co = get_parent()->cast_to<CollisionObject>();
+				CollisionObject *co = Object::cast_to<CollisionObject>(get_parent());
 				if (co) {
 					co->set_shape_transform(update_shape_index,get_transform());
 				}
@@ -400,7 +400,7 @@ int CollisionShape::_get_update_shape_index() const{
 
 String CollisionShape::get_configuration_warning() const {
 
-	if (!get_parent()->cast_to<CollisionObject>()) {
+	if (!Object::cast_to<CollisionObject>(get_parent())) {
 		return TTR("CollisionShape only serves to provide a collision shape to a CollisionObject derived node. Please only use it as a child of Area, StaticBody, RigidBody, KinematicBody, etc. to give them a shape.");
 	}
 
@@ -445,7 +445,7 @@ void CollisionShape::set_shape(const Ref<Shape> &p_shape) {
 	if (updating_body) {
 		_update_body();
 	} else if (can_update_body && update_shape_index>=0 && is_inside_tree()){
-		CollisionObject *co = get_parent()->cast_to<CollisionObject>();
+		CollisionObject *co = Object::cast_to<CollisionObject>(get_parent());
 		if (co) {
 			co->set_shape(update_shape_index,p_shape);
 		}
@@ -474,7 +474,7 @@ void CollisionShape::set_trigger(bool p_trigger) {
     if (updating_body) {
         _update_body();
     } else if (can_update_body && update_shape_index>=0 && is_inside_tree()){
-	    CollisionObject *co = get_parent()->cast_to<CollisionObject>();
+	    CollisionObject *co = Object::cast_to<CollisionObject>(get_parent());
 	    if (co) {
 		    co->set_shape_as_trigger(update_shape_index,p_trigger);
 	    }
@@ -604,7 +604,7 @@ void CollisionShape::volume_changed() {
 	Object *parent=get_parent();
 	if (!parent)
 		return;
-	PhysicsBody *physics_body=parent->cast_to<PhysicsBody>();
+	PhysicsBody *physics_body=Object::cast_to<PhysicsBody>(parent);
 
 	ERR_EXPLAIN("CollisionShape parent is not of type PhysicsBody");
 	ERR_FAIL_COND(!physics_body);

--- a/scene/3d/bone_attachment.cpp
+++ b/scene/3d/bone_attachment.cpp
@@ -52,7 +52,7 @@ void BoneAttachment::_get_property_list( List<PropertyInfo>* p_list ) const{
 
 	Skeleton *parent=NULL;
 	if(get_parent())
-		parent=get_parent()->cast_to<Skeleton>();
+		parent=Object::cast_to<Skeleton>(get_parent());
 
 	if (parent) {
 
@@ -75,8 +75,8 @@ void BoneAttachment::_get_property_list( List<PropertyInfo>* p_list ) const{
 
 void BoneAttachment::_check_bind() {
 
-	if (get_parent() && get_parent()->cast_to<Skeleton>()) {
-		Skeleton *sk = get_parent()->cast_to<Skeleton>();
+	if (Object::cast_to<Skeleton>(get_parent())) {
+		Skeleton *sk = Object::cast_to<Skeleton>(get_parent());
 		int idx = sk->find_bone(bone_name);
 		if (idx!=-1) {
 			sk->bind_child_node_to_bone(idx,this);;
@@ -90,8 +90,8 @@ void BoneAttachment::_check_unbind() {
 
 	if (bound) {
 
-		if (get_parent() && get_parent()->cast_to<Skeleton>()) {
-			Skeleton *sk = get_parent()->cast_to<Skeleton>();
+		if (Object::cast_to<Skeleton>(get_parent())) {
+			Skeleton *sk = Object::cast_to<Skeleton>(get_parent());
 			int idx = sk->find_bone(bone_name);
 			if (idx!=-1) {
 				sk->unbind_child_node_from_bone(idx,this);;

--- a/scene/3d/character_camera.cpp
+++ b/scene/3d/character_camera.cpp
@@ -369,7 +369,7 @@ void CharacterCamera::_notification(int p_what) {
 
 			Node* parent = get_parent();
 			while (parent) {
-				PhysicsBody* p = parent->cast_to<PhysicsBody>();
+				PhysicsBody* p = Object::cast_to<PhysicsBody>(parent);
 				if (p) {
 					target_body = p->get_body();
 					break;

--- a/scene/3d/collision_polygon.cpp
+++ b/scene/3d/collision_polygon.cpp
@@ -9,7 +9,7 @@ void CollisionPolygon::_add_to_collision_object(Object *p_obj) {
 	if (!can_update_body)
 		return;
 
-	CollisionObject *co = p_obj->cast_to<CollisionObject>();
+	CollisionObject *co = Object::cast_to<CollisionObject>(p_obj);
 	ERR_FAIL_COND(!co);
 
 	if (polygon.size()==0)
@@ -85,7 +85,7 @@ void CollisionPolygon::_update_parent() {
 	Node *parent = get_parent();
 	if (!parent)
 		return;
-	CollisionObject *co = parent->cast_to<CollisionObject>();
+	CollisionObject *co = Object::cast_to<CollisionObject>(parent);
 	if (!co)
 		return;
 	co->_update_shapes_from_children();
@@ -128,7 +128,7 @@ void CollisionPolygon::_notification(int p_what) {
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
             if (!can_update_body && shape_from>=0 && shape_to>=0) {
 
-				CollisionObject *co = get_parent()->cast_to<CollisionObject>();
+				CollisionObject *co = Object::cast_to<CollisionObject>(get_parent());
 				if (co) {
 					for(int i=shape_from;i<=shape_to;i++) {
 						co->set_shape_transform(i,get_transform());
@@ -233,7 +233,7 @@ float CollisionPolygon::get_depth() const {
 
 String CollisionPolygon::get_configuration_warning() const {
 
-	if (!get_parent()->cast_to<CollisionObject>()) {
+	if (!Object::cast_to<CollisionObject>(get_parent())) {
 		return TTR("CollisionPolygon only serves to provide a collision shape to a CollisionObject derived node. Please only use it as a child of Area, StaticBody, RigidBody, KinematicBody, etc. to give them a shape.");
 	}
 

--- a/scene/3d/interpolated_camera.cpp
+++ b/scene/3d/interpolated_camera.cpp
@@ -44,7 +44,7 @@ void InterpolatedCamera::_notification(int p_what) {
 				break;
 			if (has_node(target)) {
 
-				Spatial *node = get_node(target)->cast_to<Spatial>();
+				Spatial *node = Object::cast_to<Spatial>(get_node(target));
 				if (!node)
 					break;
 
@@ -54,8 +54,7 @@ void InterpolatedCamera::_notification(int p_what) {
 				local_transform = local_transform.interpolate_with(target_xform,delta);
 				set_global_transform(local_transform);
 
-				if (node->cast_to<Camera>()) {
-					Camera *cam = node->cast_to<Camera>();
+				if (Camera *cam = Object::cast_to<Camera>(node)) {
 					if (cam->get_projection()==get_projection())  {
 
 						float new_near = Math::lerp(get_znear(),cam->get_znear(),delta);
@@ -83,7 +82,7 @@ void InterpolatedCamera::_notification(int p_what) {
 void InterpolatedCamera::_set_target(const Object *p_target) {
 
 	ERR_FAIL_NULL(p_target);
-	set_target(p_target->cast_to<Spatial>());
+	set_target(Object::cast_to<Spatial>(p_target));
 }
 
 void InterpolatedCamera::set_target(const Spatial *p_target) {

--- a/scene/3d/mesh_instance.cpp
+++ b/scene/3d/mesh_instance.cpp
@@ -152,7 +152,7 @@ void MeshInstance::_resolve_skeleton_path(){
 	if (skeleton_path.is_empty())
 		return;
 
-	Skeleton *skeleton=get_node(skeleton_path)?get_node(skeleton_path)->cast_to<Skeleton>():NULL;
+	Skeleton *skeleton=Object::cast_to<Skeleton>(get_node(skeleton_path));
 	if (skeleton)
 		VisualServer::get_singleton()->instance_attach_skeleton( get_instance(), skeleton->get_skeleton() );
 }
@@ -208,7 +208,7 @@ Node* MeshInstance::create_trimesh_collision_node() {
 void MeshInstance::create_trimesh_collision() {
 
 
-	StaticBody* static_body = create_trimesh_collision_node()->cast_to<StaticBody>();
+	StaticBody* static_body = Object::cast_to<StaticBody>(create_trimesh_collision_node());
 	ERR_FAIL_COND(!static_body);
 	static_body->set_name( String(get_name()) + "_col" );
 
@@ -242,7 +242,7 @@ Node* MeshInstance::create_convex_collision_node() {
 void MeshInstance::create_convex_collision() {
 
 
-	StaticBody* static_body = create_convex_collision_node()->cast_to<StaticBody>();
+	StaticBody* static_body = Object::cast_to<StaticBody>(create_convex_collision_node());
 	ERR_FAIL_COND(!static_body);
 	static_body->set_name( String(get_name()) + "_col" );
 

--- a/scene/3d/navigation.cpp
+++ b/scene/3d/navigation.cpp
@@ -590,7 +590,7 @@ Vector3 Navigation::get_closest_point_to_segment(const Vector3& p_from,const Vec
 	}
 
 	if (closest_navmesh && closest_navmesh->owner) {
-		//print_line("navmesh is: "+closest_navmesh->owner->cast_to<Node>()->get_name());
+		//print_line("navmesh is: "+Object::cast_to<Node>(closest_navmesh->owner)->get_name());
 	}
 
 	return closest_point;

--- a/scene/3d/navigation_mesh.cpp
+++ b/scene/3d/navigation_mesh.cpp
@@ -227,7 +227,7 @@ void NavigationMeshInstance::set_enabled(bool p_enabled) {
 	}
 
 	if (debug_view) {
-		MeshInstance *dm=debug_view->cast_to<MeshInstance>();
+		MeshInstance *dm=Object::cast_to<MeshInstance>(debug_view);
 		if (is_enabled()) {
 			dm->set_material_override( get_tree()->get_debug_navigation_material() );
 		} else {
@@ -258,7 +258,7 @@ void NavigationMeshInstance::_notification(int p_what) {
 			Spatial *c=this;
 			while(c) {
 
-				navigation=c->cast_to<Navigation>();
+				navigation=Object::cast_to<Navigation>(c);
 				if (navigation) {
 
 					if (enabled && navmesh.is_valid()) {
@@ -349,10 +349,10 @@ String NavigationMeshInstance::get_configuration_warning() const {
 	const Spatial *c=this;
 	while(c) {
 
-		if (c->cast_to<Navigation>())
+		if (Object::cast_to<Navigation>(c))
 			return String();
 
-		c=c->get_parent()->cast_to<Spatial>();
+		c=Object::cast_to<Spatial>(c->get_parent());
 	}
 
 	return TTR("NavigationMeshInstance must be a child or grandchild to a Navigation node. It only provides navigation data.");

--- a/scene/3d/path.cpp
+++ b/scene/3d/path.cpp
@@ -164,7 +164,7 @@ void PathFollow::_notification(int p_what) {
 			Node *parent=get_parent();
 			if (parent) {
 
-				path=parent->cast_to<Path>();
+				path=Object::cast_to<Path>(parent);
 				if (path) {
 					_update_transform();
 				}

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -116,7 +116,7 @@ bool PhysicsBody::get_layer_mask_bit(int p_bit) const{
 void PhysicsBody::add_collision_exception_with(Node* p_node) {
 
 	ERR_FAIL_NULL(p_node);
-	PhysicsBody *physics_body = p_node->cast_to<PhysicsBody>();
+	PhysicsBody *physics_body = Object::cast_to<PhysicsBody>(p_node);
 	if (!physics_body) {
 		ERR_EXPLAIN("Collision exception only works between two objects of PhysicsBody type");
 	}
@@ -128,7 +128,7 @@ void PhysicsBody::add_collision_exception_with(Node* p_node) {
 void PhysicsBody::remove_collision_exception_with(Node* p_node) {
 
 	ERR_FAIL_NULL(p_node);
-	PhysicsBody *physics_body = p_node->cast_to<PhysicsBody>();
+	PhysicsBody *physics_body = Object::cast_to<PhysicsBody>(p_node);
 	if (!physics_body) {
 		ERR_EXPLAIN("Collision exception only works between two objects of PhysicsBody type");
 	}
@@ -268,7 +268,7 @@ StaticBody::~StaticBody() {
 void RigidBody::_body_enter_tree(ObjectID p_id) {
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 
 	Map<ObjectID,BodyState>::Element *E=contact_monitor->body_map.find(p_id);
@@ -294,7 +294,7 @@ void RigidBody::_body_enter_tree(ObjectID p_id) {
 void RigidBody::_body_exit_tree(ObjectID p_id) {
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 	Map<ObjectID,BodyState>::Element *E=contact_monitor->body_map.find(p_id);
 	ERR_FAIL_COND(!E);
@@ -320,7 +320,7 @@ void RigidBody::_body_inout(int p_status, ObjectID p_instance, int p_body_shape,
 	ObjectID objid=p_instance;
 
 	Object *obj = ObjectDB::get_instance(objid);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 
 	Map<ObjectID,BodyState>::Element *E=contact_monitor->body_map.find(objid);
 
@@ -392,7 +392,7 @@ void RigidBody::_direct_state_changed(Object *p_state) {
 	//eh.. fuck
 #ifdef DEBUG_ENABLED
 
-	state=p_state->cast_to<PhysicsDirectBodyState>();
+	state=Object::cast_to<PhysicsDirectBodyState>(p_state);
 #else
 	state=(PhysicsDirectBodyState*)p_state; //trust it
 #endif
@@ -939,7 +939,7 @@ Variant KinematicBody::_get_collider() const {
 	if (!obj)
 		return Variant();
 
-	Reference *ref = obj->cast_to<Reference>();
+	Reference *ref = Object::cast_to<Reference>(obj);
 	if (ref) {
 		return Ref<Reference>(ref);
 	}

--- a/scene/3d/physics_joint.cpp
+++ b/scene/3d/physics_joint.cpp
@@ -58,8 +58,8 @@ void Joint::_update_joint(bool p_only_free) {
 	if (!node_a && !node_b)
 		return;
 
-	PhysicsBody *body_a=node_a ? node_a->cast_to<PhysicsBody>() : (PhysicsBody*)NULL;
-	PhysicsBody *body_b=node_b ? node_b->cast_to<PhysicsBody>() : (PhysicsBody*)NULL;
+	PhysicsBody *body_a=Object::cast_to<PhysicsBody>(node_a);
+	PhysicsBody *body_b=Object::cast_to<PhysicsBody>(node_b);
 
 	if (!body_a && !body_b)
 		return;
@@ -1263,8 +1263,8 @@ void PhysicsJoint::_disconnect() {
 	Node *nA = get_node(body_A);
 	Node *nB = get_node(body_B);
 
-	PhysicsBody *A = nA?nA->cast_to<PhysicsBody>():NULL;
-	PhysicsBody *B = nA?nB->cast_to<PhysicsBody>():NULL;
+	PhysicsBody *A = Object::cast_to<PhysicsBody>(nA);
+	PhysicsBody *B = Object::cast_to<PhysicsBody>(nB);
 
 	if (!A ||!B)
 		return;
@@ -1283,8 +1283,8 @@ void PhysicsJoint::_connect() {
 	Node *nA = get_node(body_A);
 	Node *nB = get_node(body_B);
 
-	PhysicsBody *A = nA?nA->cast_to<PhysicsBody>():NULL;
-	PhysicsBody *B = nA?nB->cast_to<PhysicsBody>():NULL;
+	PhysicsBody *A = Object::cast_to<PhysicsBody>(nA);
+	PhysicsBody *B = Object::cast_to<PhysicsBody>(nB);
 
 	if (!A && !B)
 		return;

--- a/scene/3d/ray_cast.cpp
+++ b/scene/3d/ray_cast.cpp
@@ -175,7 +175,7 @@ void RayCast::add_exception_rid(const RID& p_rid) {
 void RayCast::add_exception(const Object* p_object){
 
 	ERR_FAIL_NULL(p_object);
-	CollisionObject *co=((Object*)p_object)->cast_to<CollisionObject>();
+	const CollisionObject *co=Object::cast_to<const CollisionObject>(p_object);
 	if (!co)
 		return;
 	add_exception_rid(co->get_rid());
@@ -189,7 +189,7 @@ void RayCast::remove_exception_rid(const RID& p_rid) {
 void RayCast::remove_exception(const Object* p_object){
 
 	ERR_FAIL_NULL(p_object);
-	CollisionObject *co=((Object*)p_object)->cast_to<CollisionObject>();
+	const CollisionObject *co=Object::cast_to<const CollisionObject>(p_object);
 	if (!co)
 		return;
 	remove_exception_rid(co->get_rid());

--- a/scene/3d/room_instance.cpp
+++ b/scene/3d/room_instance.cpp
@@ -45,7 +45,7 @@ void Room::_notification(int p_what) {
 
 			while(parent_room) {
 
-				Room *r = parent_room->cast_to<Room>();
+				Room *r = Object::cast_to<Room>(parent_room);
 				if (r) {
 
 					level=r->level+1;
@@ -167,7 +167,7 @@ Ref<RoomBounds> Room::get_room() const {
 
 void Room::_parse_node_faces(DVector<Face3> &all_faces,const Node *p_node) const {
 
-	const VisualInstance *vi=p_node->cast_to<VisualInstance>();
+	const VisualInstance *vi=Object::cast_to<VisualInstance>(p_node);
 
 	if (vi) {
 		DVector<Face3> faces=vi->get_faces(FACES_ENCLOSING);

--- a/scene/3d/skeleton.cpp
+++ b/scene/3d/skeleton.cpp
@@ -110,7 +110,7 @@ bool Skeleton::_get(const StringName& p_name,Variant &r_ret) const {
 
 			Object *obj=ObjectDB::get_instance(E->get());
 			ERR_CONTINUE(!obj);
-			Node *node=obj->cast_to<Node>();
+			Node *node=Object::cast_to<Node>(obj);
 			ERR_CONTINUE(!node);
 			NodePath path=get_path_to(node);
 			children.push_back(path);
@@ -248,7 +248,7 @@ void Skeleton::_notification(int p_what) {
 
 					Object *obj=ObjectDB::get_instance(E->get());
 					ERR_CONTINUE(!obj);
-					Spatial *sp = obj->cast_to<Spatial>();
+					Spatial *sp = Object::cast_to<Spatial>(obj);
 					ERR_CONTINUE(!sp);
 					sp->set_transform(b.pose_global);
 				}
@@ -447,7 +447,7 @@ void Skeleton::get_bound_child_nodes_to_bone(int p_bone,List<Node*> *p_bound) co
 
 		Object *obj=ObjectDB::get_instance(E->get());
 		ERR_CONTINUE(!obj);
-		p_bound->push_back(obj->cast_to<Node>());
+		p_bound->push_back(Object::cast_to<Node>(obj));
 	}
 
 }

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -125,7 +125,7 @@ void Spatial::_notification(int p_what) {
 
 			Node *p = get_parent();
 			if (p)
-				data.parent=p->cast_to<Spatial>();
+				data.parent=Object::cast_to<Spatial>(p);
 
 			if (data.parent)
 				data.C=data.parent->data.children.push_back(this);
@@ -164,7 +164,7 @@ void Spatial::_notification(int p_what) {
 			data.viewport=NULL;
 			Node *parent = get_parent();
 			while(parent && !data.viewport) {
-				data.viewport=parent->cast_to<Viewport>();
+				data.viewport=Object::cast_to<Viewport>(parent);
 				parent=parent->get_parent();
 			}
 
@@ -287,7 +287,7 @@ Transform Spatial::get_global_transform() const {
 #if 0
 void Spatial::add_child_notify(Node *p_child) {
 /*
-	Spatial *s=p_child->cast_to<Spatial>();
+	Spatial *s=Object::cast_to<Spatial>(p_child);
 	if (!s)
 		return;
 
@@ -302,7 +302,7 @@ void Spatial::add_child_notify(Node *p_child) {
 
 void Spatial::remove_child_notify(Node *p_child) {
 /*
-	Spatial *s=p_child->cast_to<Spatial>();
+	Spatial *s=Object::cast_to<Spatial>(p_child);
 	if (!s)
 		return;
 

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -45,7 +45,7 @@ void SpriteBase3D::_notification(int p_what) {
 		Node *parent=get_parent();
 		if (parent) {
 
-			parent_sprite=parent->cast_to<SpriteBase3D>();
+			parent_sprite=Object::cast_to<SpriteBase3D>(parent);
 			if (parent_sprite) {
 				pI=parent_sprite->children.push_back(this);
 			}

--- a/scene/3d/vehicle_body.cpp
+++ b/scene/3d/vehicle_body.cpp
@@ -61,7 +61,7 @@ void VehicleWheel::_notification(int p_what) {
 
 		if (!get_parent())
 			return;
-		VehicleBody *cb = get_parent()->cast_to<VehicleBody>();
+		VehicleBody *cb = Object::cast_to<VehicleBody>(get_parent());
 		if (!cb)
 			return;
 		body=cb;
@@ -77,7 +77,7 @@ void VehicleWheel::_notification(int p_what) {
 
 		if (!get_parent())
 			return;
-		VehicleBody *cb = get_parent()->cast_to<VehicleBody>();
+		VehicleBody *cb = Object::cast_to<VehicleBody>(get_parent());
 		if (!cb)
 			return;
 		cb->wheels.erase(this);
@@ -398,7 +398,7 @@ real_t VehicleBody::_ray_cast(int p_idx,PhysicsDirectBodyState *s) {
 
 		wheel.m_raycastInfo.m_isInContact = true;
 		if (rr.collider)
-			wheel.m_raycastInfo.m_groundObject=rr.collider->cast_to<PhysicsBody>();
+			wheel.m_raycastInfo.m_groundObject=Object::cast_to<PhysicsBody>(rr.collider);
 
 
 		real_t hitDistance = param*raylen;
@@ -859,7 +859,7 @@ void VehicleBody::_update_friction(PhysicsDirectBodyState *s) {
 void VehicleBody::_direct_state_changed(Object *p_state) {
 
 
-	PhysicsDirectBodyState *s = p_state->cast_to<PhysicsDirectBodyState>();
+	PhysicsDirectBodyState *s = Object::cast_to<PhysicsDirectBodyState>(p_state);
 
 	set_ignore_transform_notification(true);
 	set_global_transform(s->get_transform());

--- a/scene/3d/visibility_notifier.cpp
+++ b/scene/3d/visibility_notifier.cpp
@@ -164,7 +164,7 @@ void VisibilityEnabler::_find_nodes(Node* p_node) {
 
 	if (enabler[ENABLER_FREEZE_BODIES]) {
 
-		RigidBody *rb = p_node->cast_to<RigidBody>();
+		RigidBody *rb = Object::cast_to<RigidBody>(p_node);
 		if (rb && ((rb->get_mode()==RigidBody::MODE_CHARACTER || (rb->get_mode()==RigidBody::MODE_RIGID && !rb->is_able_to_sleep())))) {
 
 
@@ -175,7 +175,7 @@ void VisibilityEnabler::_find_nodes(Node* p_node) {
 
 	if (enabler[ENABLER_PAUSE_ANIMATIONS]) {
 
-		AnimationPlayer *ap = p_node->cast_to<AnimationPlayer>();
+		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node);
 		if (ap) {
 			add=true;
 		}
@@ -241,7 +241,7 @@ void VisibilityEnabler::_change_node_state(Node* p_node,bool p_enabled) {
 	ERR_FAIL_COND(!nodes.has(p_node));
 
 	{
-		RigidBody *rb = p_node->cast_to<RigidBody>();
+		RigidBody *rb = Object::cast_to<RigidBody>(p_node);
 		if (rb) {
 
 			if (p_enabled) {
@@ -256,7 +256,7 @@ void VisibilityEnabler::_change_node_state(Node* p_node,bool p_enabled) {
 	}
 
 	{
-		AnimationPlayer *ap=p_node->cast_to<AnimationPlayer>();
+		AnimationPlayer *ap=Object::cast_to<AnimationPlayer>(p_node);
 
 		if (ap) {
 

--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -50,16 +50,16 @@ void VisualInstance::_notification(int p_what) {
 			// CHECK ROOM
 			Spatial * parent = get_parent_spatial();
 			Room *room=NULL;
-			bool is_geom = cast_to<GeometryInstance>();
+			bool is_geom = Object::cast_to<GeometryInstance>(this);
 
 			while(parent) {
 
-				room = parent->cast_to<Room>();
+				room = Object::cast_to<Room>(parent);
 				if (room)
 					break;
 
-				if (is_geom && parent->cast_to<BakedLightSampler>()) {
-					VS::get_singleton()->instance_geometry_set_baked_light_sampler(get_instance(),parent->cast_to<BakedLightSampler>()->get_instance());
+				if (is_geom && Object::cast_to<BakedLightSampler>(parent)) {
+					VS::get_singleton()->instance_geometry_set_baked_light_sampler(get_instance(),Object::cast_to<BakedLightSampler>(parent)->get_instance());
 					break;
 				}
 
@@ -74,7 +74,7 @@ void VisualInstance::_notification(int p_what) {
 			}
 			// CHECK SKELETON => moving skeleton attaching logic to MeshInstance
 			/*
-			Skeleton *skeleton=get_parent()?get_parent()->cast_to<Skeleton>():NULL;
+			Skeleton *skeleton=Object::cast_to<Skeleton>(get_parent());
 			if (skeleton)
 				VisualServer::get_singleton()->instance_attach_skeleton( instance, skeleton->get_skeleton() );
 			*/
@@ -239,7 +239,7 @@ void GeometryInstance::_find_baked_light() {
 	Node *n=get_parent();
 	while(n) {
 
-		BakedLightInstance *bl=n->cast_to<BakedLightInstance>();
+		BakedLightInstance *bl=Object::cast_to<BakedLightInstance>(n);
 		if (bl) {
 
 			baked_light_instance=bl;

--- a/scene/animation/animation_cache.cpp
+++ b/scene/animation/animation_cache.cpp
@@ -133,7 +133,7 @@ void AnimationCache::_update_cache() {
 				String ps = property;
 
 
-				Spatial *sp = node->cast_to<Spatial>();
+				Spatial *sp = Object::cast_to<Spatial>(node);
 
 				if (!sp) {
 
@@ -144,7 +144,7 @@ void AnimationCache::_update_cache() {
 
 				if (ps!="") {
 
-					Skeleton *sk = node->cast_to<Skeleton>();
+					Skeleton *sk = Object::cast_to<Skeleton>(node);
 					if (!sk) {
 
 						path_cache.push_back(Path());

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -259,9 +259,9 @@ void AnimationPlayer::_generate_node_caches(AnimationData* p_anim) {
 		uint32_t id=resource.is_valid()?resource->get_instance_ID():child->get_instance_ID();
 		int bone_idx=-1;
 
-		if (a->track_get_path(i).get_property() && child->cast_to<Skeleton>()) {
+		if (a->track_get_path(i).get_property() && Object::cast_to<Skeleton>(child)) {
 
-			bone_idx = child->cast_to<Skeleton>()->find_bone( a->track_get_path(i).get_property() );
+			bone_idx = Object::cast_to<Skeleton>(child)->find_bone( a->track_get_path(i).get_property() );
 			if (bone_idx==-1) {
 
 				continue;
@@ -290,14 +290,14 @@ void AnimationPlayer::_generate_node_caches(AnimationData* p_anim) {
 			p_anim->node_cache[i]->path=a->track_get_path(i);
 			p_anim->node_cache[i]->node=child;
 			p_anim->node_cache[i]->resource=resource;
-			p_anim->node_cache[i]->node_2d=child->cast_to<Node2D>();
+			p_anim->node_cache[i]->node_2d=Object::cast_to<Node2D>(child);
 			if (a->track_get_type(i)==Animation::TYPE_TRANSFORM) {
 				// special cases and caches for transform tracks
 
 				// cache spatial
-				p_anim->node_cache[i]->spatial=child->cast_to<Spatial>();
+				p_anim->node_cache[i]->spatial=Object::cast_to<Spatial>(child);
 				// cache skeleton
-				p_anim->node_cache[i]->skeleton=child->cast_to<Skeleton>();
+				p_anim->node_cache[i]->skeleton=Object::cast_to<Skeleton>(child);
 				if (p_anim->node_cache[i]->skeleton) {
 
 					StringName bone_name=a->track_get_path(i).get_property();

--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -1538,8 +1538,8 @@ AnimationTreePlayer::Track* AnimationTreePlayer::_find_track(const NodePath& p_p
 
 	if (p_path.get_property()) {
 
-		if (child->cast_to<Skeleton>())
-			bone_idx = child->cast_to<Skeleton>()->find_bone( p_path.get_property() );
+		if (Object::cast_to<Skeleton>(child))
+			bone_idx = Object::cast_to<Skeleton>(child)->find_bone( p_path.get_property() );
 		if (bone_idx==-1)
 			property=p_path.get_property();
 	}
@@ -1554,8 +1554,8 @@ AnimationTreePlayer::Track* AnimationTreePlayer::_find_track(const NodePath& p_p
 		Track tr;
 		tr.id=id;
 		tr.object=resource.is_valid()?(Object*)resource.ptr():(Object*)child;
-		tr.skeleton=child->cast_to<Skeleton>();
-		tr.spatial=child->cast_to<Spatial>();
+		tr.skeleton=Object::cast_to<Skeleton>(child);
+		tr.spatial=Object::cast_to<Spatial>(child);
 		tr.bone_idx=bone_idx;
 		tr.property=property;
 
@@ -1707,7 +1707,7 @@ void AnimationTreePlayer::_update_sources() {
 		ERR_FAIL_COND(!m);
 	}
 
-	AnimationPlayer *ap = m->cast_to<AnimationPlayer>();
+	AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(m);
 
 	if (!ap) {
 

--- a/scene/audio/sound_room_params.cpp
+++ b/scene/audio/sound_room_params.cpp
@@ -59,12 +59,12 @@ void SoundRoomParams::_notification(int p_what) {
 			Room *room_instance=NULL;
 			while(n) {
 
-				room_instance=n->cast_to<Room>();
+				room_instance=Object::cast_to<Room>(n);
 				if (room_instance) {
 
 					break;
 				}
-				if (n->cast_to<Viewport>())
+				if (Object::cast_to<Viewport>(n))
 					break;
 
 				n=n->get_parent();

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -238,7 +238,7 @@ void BaseButton::_notification(int p_what) {
 		CanvasItem *ci=this;
 		while(ci) {
 
-			ButtonGroup *bg = ci->cast_to<ButtonGroup>();
+			ButtonGroup *bg = Object::cast_to<ButtonGroup>(ci);
 			if (bg) {
 
 				group=bg;

--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -54,7 +54,7 @@ void BoxContainer::_resort() {
 	Map<Control*,_MinSizeCache> min_size_cache;
 
 	for(int i=0;i<get_child_count();i++) {
-		Control *c=get_child(i)->cast_to<Control>();
+		Control *c=Object::cast_to<Control>(get_child(i));
 		if (!c || !c->is_visible())
 			continue;
 		if (c->is_set_as_toplevel())
@@ -107,7 +107,7 @@ void BoxContainer::_resort() {
 
 		for(int i=0;i<get_child_count();i++) {
 
-			Control *c=get_child(i)->cast_to<Control>();
+			Control *c=Object::cast_to<Control>(get_child(i));
 			if (!c || !c->is_visible())
 				continue;
 			if (c->is_set_as_toplevel())
@@ -163,7 +163,7 @@ void BoxContainer::_resort() {
 
 	for(int i=0;i<get_child_count();i++) {
 
-		Control *c=get_child(i)->cast_to<Control>();
+		Control *c=Object::cast_to<Control>(get_child(i));
 		if (!c || !c->is_visible())
 			continue;
 		if (c->is_set_as_toplevel())
@@ -221,7 +221,7 @@ Size2 BoxContainer::get_minimum_size() const {
 	bool first=true;
 
 	for(int i=0;i<get_child_count();i++) {
-		Control *c=get_child(i)->cast_to<Control>();
+		Control *c=Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())

--- a/scene/gui/button_group.cpp
+++ b/scene/gui/button_group.cpp
@@ -53,7 +53,7 @@ void ButtonGroup::set_pressed_button(BaseButton *p_button) {
 void ButtonGroup::_pressed(Object *p_button) {
 
 	ERR_FAIL_NULL(p_button);
-	BaseButton *b=p_button->cast_to<BaseButton>();
+	BaseButton *b=Object::cast_to<BaseButton>(p_button);
 	ERR_FAIL_COND(!b);
 
 	for(Set<BaseButton*>::Element *E=buttons.front();E;E=E->next()) {

--- a/scene/gui/center_container.cpp
+++ b/scene/gui/center_container.cpp
@@ -37,7 +37,7 @@ Size2 CenterContainer::get_minimum_size() const {
 	Size2 ms;
 	for(int i=0;i<get_child_count();i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())
@@ -76,7 +76,7 @@ void CenterContainer::_notification(int p_what) {
 		Size2 size = get_size();
 		for(int i=0;i<get_child_count();i++) {
 
-			Control *c = get_child(i)->cast_to<Control>();
+			Control *c = Object::cast_to<Control>(get_child(i));
 			if (!c)
 				continue;
 			if (c->is_set_as_toplevel())

--- a/scene/gui/check_box.cpp
+++ b/scene/gui/check_box.cpp
@@ -59,7 +59,7 @@ bool CheckBox::is_radio()
     Node* parent = this;
     do {
         parent = parent->get_parent();
-	if (parent->cast_to<ButtonGroup>())
+	if (Object::cast_to<ButtonGroup>(parent))
             break;
     } while (parent);
 

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -67,8 +67,8 @@ void ColorPicker::_notification(int p_what) {
 			update_material(uv_material, color,h,s,v);
 			update_material(w_material, color,h,s,v);
 
-			uv_edit->get_child(0)->cast_to<Control>()->update();
-			w_edit->get_child(0)->cast_to<Control>()->update();
+			Object::cast_to<Control>(uv_edit->get_child(0))->update();
+			Object::cast_to<Control>(w_edit->get_child(0))->update();
 			_update_color();
 		}
 
@@ -109,8 +109,8 @@ void ColorPicker::set_color(const Color& p_color) {
 	update_material(uv_material, color,h,s,v);
 	update_material(w_material, color,h,s,v);
 
-	uv_edit->get_child(0)->cast_to<Control>()->update();
-	w_edit->get_child(0)->cast_to<Control>()->update();
+	Object::cast_to<Control>(uv_edit->get_child(0))->update();
+	Object::cast_to<Control>(w_edit->get_child(0))->update();
 	_update_color();
 
 }

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -41,7 +41,7 @@ void Container::_child_minsize_changed() {
 
 void Container::add_child_notify(Node *p_child) {
 
-	Control *control = p_child->cast_to<Control>();
+	Control *control = Object::cast_to<Control>(p_child);
 	if (!control)
 		return;
 
@@ -54,7 +54,7 @@ void Container::add_child_notify(Node *p_child) {
 
 void Container::move_child_notify(Node *p_child) {
 
-	if (!p_child->cast_to<Control>())
+	if (!Object::cast_to<Control>(p_child))
 		return;
 
 	queue_sort();
@@ -63,7 +63,7 @@ void Container::move_child_notify(Node *p_child) {
 void Container::remove_child_notify(Node *p_child) {
 
 
-	Control *control = p_child->cast_to<Control>();
+	Control *control = Object::cast_to<Control>(p_child);
 	if (!control)
 		return;
 

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -432,7 +432,7 @@ void Control::_notification(int p_notification) {
 
 		case NOTIFICATION_ENTER_CANVAS: {
 
-			data.parent=get_parent()->cast_to<Control>();
+			data.parent=Object::cast_to<Control>(get_parent());
 
 			if (is_set_as_toplevel()) {
 				data.SI=get_viewport()->_gui_add_subwindow_control(this);
@@ -450,14 +450,14 @@ void Control::_notification(int p_notification) {
 					if (!parent)
 						break;
 
-					CanvasItem *ci =parent->cast_to<CanvasItem>();
+					CanvasItem *ci =Object::cast_to<CanvasItem>(parent);
 					if (ci && ci->is_set_as_toplevel()) {
 						subwindow=true;
 						break;
 					}
 
-					if (parent->cast_to<Control>()) {
-						parent_control=parent->cast_to<Control>();
+					if (Object::cast_to<Control>(parent)) {
+						parent_control=Object::cast_to<Control>(parent);
 						break;
 					} else if (ci) {
 
@@ -526,7 +526,7 @@ void Control::_notification(int p_notification) {
 
 		case NOTIFICATION_PARENTED: {
 
-			Control * parent = get_parent()->cast_to<Control>();
+			Control * parent = Object::cast_to<Control>(get_parent());
 
 			//make children reference them theme
 
@@ -665,7 +665,7 @@ Variant Control::get_drag_data(const Point2& p_point) {
 	if (data.drag_owner) {
 		Object *obj = ObjectDB::get_instance(data.drag_owner);
 		if (obj) {
-			Control *c = obj->cast_to<Control>();
+			Control *c = Object::cast_to<Control>(obj);
 			return c->call("get_drag_data_fw",p_point,this);
 		}
 	}
@@ -688,7 +688,7 @@ bool Control::can_drop_data(const Point2& p_point,const Variant& p_data) const {
 	if (data.drag_owner) {
 		Object *obj = ObjectDB::get_instance(data.drag_owner);
 		if (obj) {
-			Control *c = obj->cast_to<Control>();
+			Control *c = Object::cast_to<Control>(obj);
 			return c->call("can_drop_data_fw",p_point,p_data,this);
 		}
 	}
@@ -710,7 +710,7 @@ void Control::drop_data(const Point2& p_point,const Variant& p_data){
 	if (data.drag_owner) {
 		Object *obj = ObjectDB::get_instance(data.drag_owner);
 		if (obj) {
-			Control *c = obj->cast_to<Control>();
+			Control *c = Object::cast_to<Control>(obj);
 			c->call("drop_data_fw",p_point,p_data,this);
 			return;
 		}
@@ -786,7 +786,7 @@ Ref<Texture> Control::get_icon(const StringName& p_name,const StringName& p_type
 
 		if (theme_owner->data.theme->has_icon(p_name, type ) )
 			return data.theme_owner->data.theme->get_icon(p_name, type );
-		Control *parent = theme_owner->get_parent()?theme_owner->get_parent()->cast_to<Control>():NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner=parent->data.theme_owner;
@@ -816,7 +816,7 @@ Ref<Shader> Control::get_shader(const StringName& p_name,const StringName& p_typ
 
 		if (theme_owner->data.theme->has_shader(p_name, type))
 			return data.theme_owner->data.theme->get_shader(p_name, type );
-		Control *parent = theme_owner->get_parent()?theme_owner->get_parent()->cast_to<Control>():NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner=parent->data.theme_owner;
@@ -845,7 +845,7 @@ Ref<StyleBox> Control::get_stylebox(const StringName& p_name,const StringName& p
 
 		if (theme_owner->data.theme->has_stylebox(p_name, type ) )
 			return data.theme_owner->data.theme->get_stylebox(p_name, type );
-		Control *parent = theme_owner->get_parent()?theme_owner->get_parent()->cast_to<Control>():NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner=parent->data.theme_owner;
@@ -875,7 +875,7 @@ Ref<Font> Control::get_font(const StringName& p_name,const StringName& p_type) c
 			return data.theme_owner->data.theme->get_font(p_name, type );
 		if (theme_owner->data.theme->get_default_theme_font().is_valid())
 			return theme_owner->data.theme->get_default_theme_font();
-		Control *parent = theme_owner->get_parent()?theme_owner->get_parent()->cast_to<Control>():NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner=parent->data.theme_owner;
@@ -903,7 +903,7 @@ Color Control::get_color(const StringName& p_name,const StringName& p_type) cons
 
 		if (theme_owner->data.theme->has_color(p_name, type ) )
 			return data.theme_owner->data.theme->get_color(p_name, type );
-		Control *parent = theme_owner->get_parent()?theme_owner->get_parent()->cast_to<Control>():NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner=parent->data.theme_owner;
@@ -932,7 +932,7 @@ int Control::get_constant(const StringName& p_name,const StringName& p_type) con
 
 		if (theme_owner->data.theme->has_constant(p_name, type ) )
 			return data.theme_owner->data.theme->get_constant(p_name, type );
-		Control *parent = theme_owner->get_parent()?theme_owner->get_parent()->cast_to<Control>():NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner=parent->data.theme_owner;
@@ -964,7 +964,7 @@ bool Control::has_icon(const StringName& p_name,const StringName& p_type) const 
 
 		if (theme_owner->data.theme->has_icon(p_name, type ) )
 			return true;
-		Control *parent = theme_owner->get_parent()?theme_owner->get_parent()->cast_to<Control>():NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner=parent->data.theme_owner;
@@ -994,7 +994,7 @@ bool Control::has_shader(const StringName &p_name, const StringName &p_type) con
 
 		if (theme_owner->data.theme->has_shader(p_name, type))
 			return true;
-		Control *parent = theme_owner->get_parent()?theme_owner->get_parent()->cast_to<Control>():NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner=parent->data.theme_owner;
@@ -1024,7 +1024,7 @@ bool Control::has_stylebox(const StringName& p_name,const StringName& p_type) co
 
 		if (theme_owner->data.theme->has_stylebox(p_name, type ) )
 			return true;
-		Control *parent = theme_owner->get_parent()?theme_owner->get_parent()->cast_to<Control>():NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner=parent->data.theme_owner;
@@ -1054,7 +1054,7 @@ bool Control::has_font(const StringName& p_name,const StringName& p_type) const 
 
 		if (theme_owner->data.theme->has_font(p_name, type ) )
 			return true;
-		Control *parent = theme_owner->get_parent()?theme_owner->get_parent()->cast_to<Control>():NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner=parent->data.theme_owner;
@@ -1083,7 +1083,7 @@ bool Control::has_color(const StringName& p_name,const StringName& p_type) const
 
 		if (theme_owner->data.theme->has_color(p_name, type ) )
 			return true;
-		Control *parent = theme_owner->get_parent()?theme_owner->get_parent()->cast_to<Control>():NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner=parent->data.theme_owner;
@@ -1115,7 +1115,7 @@ bool Control::has_constant(const StringName& p_name,const StringName& p_type) co
 
 		if (theme_owner->data.theme->has_constant(p_name, type ) )
 			return true;
-		Control *parent = theme_owner->get_parent()?theme_owner->get_parent()->cast_to<Control>():NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner=parent->data.theme_owner;
@@ -1536,7 +1536,7 @@ static Control *_next_control(Control *p_from) {
 	if (p_from->is_set_as_toplevel())
 		return NULL; // can't go above
 
-	Control *parent = p_from->get_parent()?p_from->get_parent()->cast_to<Control>():NULL;
+	Control *parent = Object::cast_to<Control>(p_from->get_parent());
 
 	if (!parent) {
 
@@ -1548,7 +1548,7 @@ static Control *_next_control(Control *p_from) {
 	ERR_FAIL_INDEX_V(next,parent->get_child_count(),NULL);
 	for(int i=(next+1);i<parent->get_child_count();i++) {
 
-		Control *c = parent->get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(parent->get_child(i));
 		if (!c || !c->is_visible() || c->is_set_as_toplevel())
 			continue;
 
@@ -1573,7 +1573,7 @@ Control *Control::find_next_valid_focus() const {
 
 		for(int i=0;i<from->get_child_count();i++) {
 
-			Control *c = from->get_child(i)->cast_to<Control>();
+			Control *c = Object::cast_to<Control>(from->get_child(i));
 			if (!c || !c->is_visible() || c->is_set_as_toplevel()) {
 				continue;
 			}
@@ -1592,7 +1592,7 @@ Control *Control::find_next_valid_focus() const {
 				next_child=const_cast<Control*>(this);
 				while(next_child && !next_child->is_set_as_toplevel()) {
 					if (next_child->get_parent()) {
-						next_child=next_child->get_parent()->cast_to<Control>();
+						next_child=Object::cast_to<Control>(next_child->get_parent());
 					} else
 						next_child=NULL;
 
@@ -1639,7 +1639,7 @@ static Control *_prev_control(Control *p_from) {
 	Control *child=NULL;
 	for(int i=p_from->get_child_count()-1;i>=0;i--) {
 
-		Control *c = p_from->get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(p_from->get_child(i));
 		if (!c || !c->is_visible() || c->is_set_as_toplevel())
 			continue;
 
@@ -1667,7 +1667,7 @@ Control *Control::find_prev_valid_focus() const {
 
 
 
-			if ( from->is_set_as_toplevel() || !from->get_parent() || !from->get_parent()->cast_to<Control>()) {
+			if ( from->is_set_as_toplevel() || !from->get_parent() || !Object::cast_to<Control>(from->get_parent())) {
 
 				//find last of the childs
 
@@ -1678,7 +1678,7 @@ Control *Control::find_prev_valid_focus() const {
 				for(int i=(from->get_position_in_parent()-1);i>=0;i--) {
 
 
-					Control *c = from->get_parent()->get_child(i)->cast_to<Control>();
+					Control *c = Object::cast_to<Control>(from->get_parent()->get_child(i));
 
 					if (!c || !c->is_visible() || c->is_set_as_toplevel()) {
 						continue;
@@ -1693,7 +1693,7 @@ Control *Control::find_prev_valid_focus() const {
 
 
 
-					prev_child = from->get_parent()->cast_to<Control>();
+					prev_child = Object::cast_to<Control>(from->get_parent());
 				} else {
 
 
@@ -1798,7 +1798,7 @@ void Control::_propagate_theme_changed(Control *p_owner) {
 
 	for(int i=0;i<get_child_count();i++) {
 
-		Control *child = get_child(i)->cast_to<Control>();
+		Control *child = Object::cast_to<Control>(get_child(i));
 		if (child && child->data.theme.is_null()) //has no theme, propagate
 			child->_propagate_theme_changed(p_owner);
 	}
@@ -1816,7 +1816,7 @@ void Control::set_theme(const Ref<Theme>& p_theme) {
 		_propagate_theme_changed(this);
 	} else {
 
-		Control *parent = get_parent()?get_parent()->cast_to<Control>():NULL;
+		Control *parent = Object::cast_to<Control>(get_parent());
 		if (parent && parent->data.theme_owner) {
 			_propagate_theme_changed(parent->data.theme_owner);
 		} else {
@@ -1900,7 +1900,7 @@ Control *Control::_get_focus_neighbour(Margin p_margin,int p_count) {
 		Control *c=NULL;
 		Node * n = get_node(data.focus_neighbour[p_margin]);
 		if (n) {
-			c=n->cast_to<Control>();
+			c=Object::cast_to<Control>(n);
 
 			if (!c) {
 
@@ -1958,7 +1958,7 @@ Control *Control::_get_focus_neighbour(Margin p_margin,int p_count) {
 
 	while (base) {
 
-		Control *c = base->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(base);
 		if (c) {
 			if (c->data.SI)
 				break;
@@ -1979,10 +1979,10 @@ Control *Control::_get_focus_neighbour(Margin p_margin,int p_count) {
 
 void Control::_window_find_focus_neighbour(const Vector2& p_dir, Node *p_at,const Point2* p_points,float p_min ,float &r_closest_dist,Control **r_closest) {
 
-	if (p_at->cast_to<Viewport>())
+	if (Object::cast_to<Viewport>(p_at))
 		return; //bye
 
-	Control *c = p_at->cast_to<Control>();
+	Control *c = Object::cast_to<Control>(p_at);
 
 	if (c && c !=this && c->get_focus_mode()==FOCUS_ALL && c->is_visible()) {
 
@@ -2035,7 +2035,7 @@ void Control::_window_find_focus_neighbour(const Vector2& p_dir, Node *p_at,cons
 	for(int i=0;i<p_at->get_child_count();i++) {
 
 		Node *child=p_at->get_child(i);
-		Control *childc = child->cast_to<Control>();
+		Control *childc = Object::cast_to<Control>(child);
 		if (childc && childc->data.SI)
 			continue; //subwindow, ignore
 		_window_find_focus_neighbour(p_dir,p_at->get_child(i),p_points,p_min,r_closest_dist,r_closest);
@@ -2205,7 +2205,7 @@ Control *Control::get_root_parent_control() const {
 
 	while(ci) {
 
-		const Control *c = ci->cast_to<Control>();
+		const Control *c = Object::cast_to<Control>(ci);
 		if (c) {
 			root=c;
 

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -87,7 +87,7 @@ void GraphEdit::_update_scroll_offset() {
 
 	for(int i=0;i<get_child_count();i++) {
 
-		GraphNode *gn=get_child(i)->cast_to<GraphNode>();
+		GraphNode *gn=Object::cast_to<GraphNode>(get_child(i));
 		if (!gn)
 			continue;
 
@@ -108,7 +108,7 @@ void GraphEdit::_update_scroll() {
 	Rect2 screen;
 	for(int i=0;i<get_child_count();i++) {
 
-		GraphNode *gn=get_child(i)->cast_to<GraphNode>();
+		GraphNode *gn=Object::cast_to<GraphNode>(get_child(i));
 		if (!gn)
 			continue;
 
@@ -146,7 +146,7 @@ void GraphEdit::_update_scroll() {
 
 void GraphEdit::_graph_node_raised(Node* p_gn) {
 
-	GraphNode *gn=p_gn->cast_to<GraphNode>();
+	GraphNode *gn=Object::cast_to<GraphNode>(p_gn);
 	ERR_FAIL_COND(!gn);
 	gn->raise();
 	top_layer->raise();
@@ -156,7 +156,7 @@ void GraphEdit::_graph_node_raised(Node* p_gn) {
 
 void GraphEdit::_graph_node_moved(Node *p_gn) {
 
-	GraphNode *gn=p_gn->cast_to<GraphNode>();
+	GraphNode *gn=Object::cast_to<GraphNode>(p_gn);
 	ERR_FAIL_COND(!gn);
 	top_layer->update();
 }
@@ -164,7 +164,7 @@ void GraphEdit::_graph_node_moved(Node *p_gn) {
 void GraphEdit::add_child_notify(Node *p_child) {
 
 	top_layer->call_deferred("raise"); //top layer always on top!
-	GraphNode *gn = p_child->cast_to<GraphNode>();
+	GraphNode *gn = Object::cast_to<GraphNode>(p_child);
 	if (gn) {
 		gn->set_scale(Vector2(zoom,zoom));
 		gn->connect("offset_changed",this,"_graph_node_moved",varray(gn));
@@ -177,7 +177,7 @@ void GraphEdit::add_child_notify(Node *p_child) {
 void GraphEdit::remove_child_notify(Node *p_child) {
 
 	top_layer->call_deferred("raise"); //top layer always on top!
-	GraphNode *gn = p_child->cast_to<GraphNode>();
+	GraphNode *gn = Object::cast_to<GraphNode>(p_child);
 	if (gn) {
 		gn->disconnect("offset_changed",this,"_graph_node_moved");
 		gn->disconnect("raise_request",this,"_graph_node_raised");
@@ -222,7 +222,7 @@ bool GraphEdit::_filter_input(const Point2& p_point) {
 	float grab_r=port->get_width()*0.5;
 	for(int i=get_child_count()-1;i>=0;i--) {
 
-		GraphNode *gn=get_child(i)->cast_to<GraphNode>();
+		GraphNode *gn=Object::cast_to<GraphNode>(get_child(i));
 		if (!gn)
 			continue;
 
@@ -258,7 +258,7 @@ void GraphEdit::_top_layer_input(const InputEvent& p_ev) {
 		float grab_r=port->get_width()*0.5;
 		for(int i=get_child_count()-1;i>=0;i--) {
 
-			GraphNode *gn=get_child(i)->cast_to<GraphNode>();
+			GraphNode *gn=Object::cast_to<GraphNode>(get_child(i));
 			if (!gn)
 				continue;
 
@@ -294,19 +294,19 @@ void GraphEdit::_top_layer_input(const InputEvent& p_ev) {
 							if (E->get().to==gn->get_name() && E->get().to_port==j) {
 
 								Node*fr = get_node(String(E->get().from));
-								if (fr && fr->cast_to<GraphNode>()) {
+								if (Object::cast_to<GraphNode>(fr)) {
 
 									connecting_from=E->get().from;
 									connecting_index=E->get().from_port;
 									connecting_out=true;
-									connecting_type=fr->cast_to<GraphNode>()->get_connection_output_type(E->get().from_port);
-									connecting_color=fr->cast_to<GraphNode>()->get_connection_output_color(E->get().from_port);
+									connecting_type=Object::cast_to<GraphNode>(fr)->get_connection_output_type(E->get().from_port);
+									connecting_color=Object::cast_to<GraphNode>(fr)->get_connection_output_color(E->get().from_port);
 									connecting_target=false;
 									connecting_to=pos;
 
 									emit_signal("disconnection_request",E->get().from,E->get().from_port,E->get().to,E->get().to_port);
 									fr = get_node(String(connecting_from)); //maybe it was erased
-									if (fr && fr->cast_to<GraphNode>()) {
+									if (Object::cast_to<GraphNode>(fr)) {
 										connecting=true;
 									}
 									return;
@@ -344,7 +344,7 @@ void GraphEdit::_top_layer_input(const InputEvent& p_ev) {
 		float grab_r=port->get_width()*0.5;
 		for(int i=get_child_count()-1;i>=0;i--) {
 
-			GraphNode *gn=get_child(i)->cast_to<GraphNode>();
+			GraphNode *gn=Object::cast_to<GraphNode>(get_child(i));
 			if (!gn)
 				continue;
 
@@ -441,7 +441,7 @@ void GraphEdit::_top_layer_draw() {
 
 		Node *fromn = get_node(connecting_from);
 		ERR_FAIL_COND(!fromn);
-		GraphNode *from = fromn->cast_to<GraphNode>();
+		GraphNode *from = Object::cast_to<GraphNode>(fromn);
 		ERR_FAIL_COND(!from);
 		Vector2 pos;
 		if (connecting_out)
@@ -474,7 +474,7 @@ void GraphEdit::_top_layer_draw() {
 			continue;
 		}
 
-		GraphNode *gfrom = from->cast_to<GraphNode>();
+		GraphNode *gfrom = Object::cast_to<GraphNode>(from);
 
 		if (!gfrom) {
 			to_erase.push_back(E);
@@ -488,7 +488,7 @@ void GraphEdit::_top_layer_draw() {
 			continue;
 		}
 
-		GraphNode *gto = to->cast_to<GraphNode>();
+		GraphNode *gto = Object::cast_to<GraphNode>(to);
 
 		if (!gto) {
 			to_erase.push_back(E);
@@ -522,7 +522,7 @@ void GraphEdit::_input_event(const InputEvent& p_ev) {
 		just_selected=true;
 		drag_accum+=Vector2(p_ev.mouse_motion.relative_x,p_ev.mouse_motion.relative_y);
 		for(int i=get_child_count()-1;i>=0;i--) {
-			GraphNode *gn=get_child(i)->cast_to<GraphNode>();
+			GraphNode *gn=Object::cast_to<GraphNode>(get_child(i));
 			if (gn && gn->is_selected())
 				gn->set_offset((gn->get_drag_from()*zoom+drag_accum)/zoom);
 		}
@@ -538,7 +538,7 @@ void GraphEdit::_input_event(const InputEvent& p_ev) {
 
 		for(int i=get_child_count()-1;i>=0;i--) {
 
-			GraphNode *gn=get_child(i)->cast_to<GraphNode>();
+			GraphNode *gn=Object::cast_to<GraphNode>(get_child(i));
 			if (!gn)
 				continue;
 
@@ -565,7 +565,7 @@ void GraphEdit::_input_event(const InputEvent& p_ev) {
 				box_selecting = false;
 				for(int i=get_child_count()-1;i>=0;i--) {
 
-					GraphNode *gn=get_child(i)->cast_to<GraphNode>();
+					GraphNode *gn=Object::cast_to<GraphNode>(get_child(i));
 					if (!gn)
 						continue;
 
@@ -586,7 +586,7 @@ void GraphEdit::_input_event(const InputEvent& p_ev) {
 			if (!just_selected && drag_accum==Vector2() && Input::get_singleton()->is_key_pressed(KEY_CONTROL)) {
 				//deselect current node
 				for(int i=get_child_count()-1;i>=0;i--) {
-					GraphNode *gn=get_child(i)->cast_to<GraphNode>();
+					GraphNode *gn=Object::cast_to<GraphNode>(get_child(i));
 
 					if (gn) {
 						Rect2 r = gn->get_rect();
@@ -602,7 +602,7 @@ void GraphEdit::_input_event(const InputEvent& p_ev) {
 				emit_signal("_begin_node_move");
 
 				for(int i=get_child_count()-1;i>=0;i--) {
-					GraphNode *gn=get_child(i)->cast_to<GraphNode>();
+					GraphNode *gn=Object::cast_to<GraphNode>(get_child(i));
 					if (gn && gn->is_selected())
 						gn->set_drag(false);
 				}
@@ -620,7 +620,7 @@ void GraphEdit::_input_event(const InputEvent& p_ev) {
 			GraphNode *gn = NULL;
 			for(int i=get_child_count()-1;i>=0;i--) {
 
-				gn=get_child(i)->cast_to<GraphNode>();
+				gn=Object::cast_to<GraphNode>(get_child(i));
 
 				if (gn) {
 					Rect2 r = gn->get_rect();
@@ -640,7 +640,7 @@ void GraphEdit::_input_event(const InputEvent& p_ev) {
 				just_selected = !gn->is_selected();
 				if(!gn->is_selected() && !Input::get_singleton()->is_key_pressed(KEY_CONTROL)) {
 					for (int i = 0; i < get_child_count(); i++) {
-						GraphNode *o_gn = get_child(i)->cast_to<GraphNode>();
+						GraphNode *o_gn = Object::cast_to<GraphNode>(get_child(i));
 						if (o_gn)
 							o_gn->set_selected(o_gn == gn);
 					}
@@ -648,7 +648,7 @@ void GraphEdit::_input_event(const InputEvent& p_ev) {
 
 				gn->set_selected(true);
 				for (int i = 0; i < get_child_count(); i++) {
-					GraphNode *o_gn = get_child(i)->cast_to<GraphNode>();
+					GraphNode *o_gn = Object::cast_to<GraphNode>(get_child(i));
 					if (!o_gn)
 						continue;
 					if (o_gn->is_selected())
@@ -668,7 +668,7 @@ void GraphEdit::_input_event(const InputEvent& p_ev) {
 					previus_selected.clear();
 					for(int i=get_child_count()-1;i>=0;i--) {
 
-						GraphNode *gn=get_child(i)->cast_to<GraphNode>();
+						GraphNode *gn=Object::cast_to<GraphNode>(get_child(i));
 						if (!gn || !gn->is_selected())
 							continue;
 
@@ -679,7 +679,7 @@ void GraphEdit::_input_event(const InputEvent& p_ev) {
 					previus_selected.clear();
 					for(int i=get_child_count()-1;i>=0;i--) {
 
-						GraphNode *gn=get_child(i)->cast_to<GraphNode>();
+						GraphNode *gn=Object::cast_to<GraphNode>(get_child(i));
 						if (!gn || !gn->is_selected())
 							continue;
 
@@ -690,7 +690,7 @@ void GraphEdit::_input_event(const InputEvent& p_ev) {
 					previus_selected.clear();
 					for(int i=get_child_count()-1;i>=0;i--) {
 
-						GraphNode *gn=get_child(i)->cast_to<GraphNode>();
+						GraphNode *gn=Object::cast_to<GraphNode>(get_child(i));
 						if (!gn)
 							continue;
 

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -74,7 +74,7 @@ void GraphNode::_get_property_list( List<PropertyInfo> *p_list) const{
 
 	int idx=0;
 	for(int i=0;i<get_child_count();i++) {
-		Control *c=get_child(i)->cast_to<Control>();
+		Control *c=Object::cast_to<Control>(get_child(i));
 		if (!c || c->is_set_as_toplevel() )
 			continue;
 
@@ -103,7 +103,7 @@ void GraphNode::_resort() {
 	Size2 minsize;
 
 	for(int i=0;i<get_child_count();i++) {
-		Control *c=get_child(i)->cast_to<Control>();
+		Control *c=Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())
@@ -128,7 +128,7 @@ void GraphNode::_resort() {
 
 	cache_y.clear();
 	for(int i=0;i<get_child_count();i++) {
-		Control *c=get_child(i)->cast_to<Control>();
+		Control *c=Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())
@@ -315,7 +315,7 @@ Size2 GraphNode::get_minimum_size() const {
 
 	for(int i=0;i<get_child_count();i++) {
 
-		Control *c=get_child(i)->cast_to<Control>();
+		Control *c=Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())
@@ -409,7 +409,7 @@ void GraphNode::_connpos_update() {
 	int idx=0;
 
 	for(int i=0;i<get_child_count();i++) {
-		Control *c=get_child(i)->cast_to<Control>();
+		Control *c=Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())

--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -52,7 +52,7 @@ void GridContainer::_notification(int p_what) {
 
 			for(int i=0;i<get_child_count();i++) {
 
-				Control *c = get_child(i)->cast_to<Control>();
+				Control *c = Object::cast_to<Control>(get_child(i));
 				if (!c || !c->is_visible())
 					continue;
 
@@ -111,7 +111,7 @@ void GridContainer::_notification(int p_what) {
 
 			for(int i=0;i<get_child_count();i++) {
 
-				Control *c = get_child(i)->cast_to<Control>();
+				Control *c = Object::cast_to<Control>(get_child(i));
 				if (!c || !c->is_visible())
 					continue;
 				int row = idx / columns;
@@ -188,7 +188,7 @@ Size2 GridContainer::get_minimum_size() const {
 
 	for(int i=0;i<get_child_count();i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c || !c->is_visible())
 			continue;
 		int row = idx / columns;

--- a/scene/gui/margin_container.cpp
+++ b/scene/gui/margin_container.cpp
@@ -40,7 +40,7 @@ Size2 MarginContainer::get_minimum_size() const {
 
 	for(int i=0;i<get_child_count();i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())
@@ -75,7 +75,7 @@ void MarginContainer::_notification(int p_what) {
 
 		for(int i=0;i<get_child_count();i++) {
 
-			Control *c = get_child(i)->cast_to<Control>();
+			Control *c = Object::cast_to<Control>(get_child(i));
 			if (!c)
 				continue;
 			if (c->is_set_as_toplevel())

--- a/scene/gui/panel_container.cpp
+++ b/scene/gui/panel_container.cpp
@@ -42,7 +42,7 @@ Size2 PanelContainer::get_minimum_size() const {
 	Size2 ms;
 	for(int i=0;i<get_child_count();i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c || !c->is_visible())
 			continue;
 		if (c->is_set_as_toplevel())
@@ -97,7 +97,7 @@ void PanelContainer::_notification(int p_what) {
 
 		for(int i=0;i<get_child_count();i++) {
 
-			Control *c = get_child(i)->cast_to<Control>();
+			Control *c = Object::cast_to<Control>(get_child(i));
 			if (!c || !c->is_visible())
 				continue;
 			if (c->is_set_as_toplevel())

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -100,7 +100,7 @@ void Popup::set_as_minsize() {
 
 	for(int i=0;i<get_child_count();i++) {
 
-		Control *c=get_child(i)->cast_to<Control>();
+		Control *c=Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_hidden())
@@ -143,7 +143,7 @@ void Popup::popup_centered_minsize(const Size2& p_minsize) {
 
 	for(int i=0;i<get_child_count();i++) {
 
-		Control *c=get_child(i)->cast_to<Control>();
+		Control *c=Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_hidden())

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -160,7 +160,7 @@ void PopupMenu::_activate_submenu(int over) {
 	Node* n = get_node(items[over].submenu);
 	ERR_EXPLAIN("item subnode does not exist: "+items[over].submenu);
 	ERR_FAIL_COND(!n);
-	Popup *pm = n->cast_to<Popup>();
+	Popup *pm = Object::cast_to<Popup>(n);
 	ERR_EXPLAIN("item subnode is not a Popup: "+items[over].submenu);
 	ERR_FAIL_COND(!pm);
 	if (pm->is_visible())
@@ -180,7 +180,7 @@ void PopupMenu::_activate_submenu(int over) {
 	pm->set_pos(pos);
 	pm->popup();
 
-	PopupMenu *pum = pm->cast_to<PopupMenu>();
+	PopupMenu *pum = Object::cast_to<PopupMenu>(pm);
 	if (pum) {
 
 		pr.pos-=pum->get_global_pos();
@@ -757,7 +757,7 @@ bool PopupMenu::activate_item_by_accelerator(uint32_t p_accel) {
 			if(!n)
 				continue;
 
-			PopupMenu* pm = n->cast_to<PopupMenu>();
+			PopupMenu* pm = Object::cast_to<PopupMenu>(n);
 			if(!pm)
 				continue;
 
@@ -779,11 +779,11 @@ void PopupMenu::activate_item(int p_item) {
 
 	//hide all parent PopupMenue's
 	Node *next = get_parent();
-	PopupMenu *pop = next->cast_to<PopupMenu>();
+	PopupMenu *pop = Object::cast_to<PopupMenu>(next);
 	while (pop) {
 		pop->hide();
 		next = next->get_parent();
-		pop = next->cast_to<PopupMenu>();
+		pop = Object::cast_to<PopupMenu>(next);
 	}
 	hide();
 

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -165,7 +165,7 @@ double Range::get_unit_value() const {
 
 void Range::_share(Node *p_range) {
 
-	Range * r = p_range->cast_to<Range>();
+	Range * r = Object::cast_to<Range>(p_range);
 	ERR_FAIL_COND(!r);
 	share(r);
 }

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -298,7 +298,7 @@ void ScrollBar::_notification(int p_what) {
 
 		if (has_node(drag_slave_path)) {
 			Node *n = get_node(drag_slave_path);
-			drag_slave=n->cast_to<Control>();
+			drag_slave=Object::cast_to<Control>(n);
 		}
 
 		if (drag_slave) {
@@ -650,7 +650,7 @@ void ScrollBar::set_drag_slave(const NodePath& p_path) {
 
 		if (has_node(p_path)) {
 			Node *n = get_node(p_path);
-			drag_slave=n->cast_to<Control>();
+			drag_slave=Object::cast_to<Control>(n);
 		}
 
 		if (drag_slave) {

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -40,7 +40,7 @@ Size2 ScrollContainer::get_minimum_size() const {
 
 	for(int i=0;i<get_child_count();i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())
@@ -217,7 +217,7 @@ void ScrollContainer::_notification(int p_what) {
 
 		for(int i=0;i<get_child_count();i++) {
 
-			Control *c = get_child(i)->cast_to<Control>();
+			Control *c = Object::cast_to<Control>(get_child(i));
 			if (!c)
 				continue;
 			if (c->is_set_as_toplevel())

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -46,7 +46,7 @@ Control *SplitContainer::_getch(int p_idx) const {
 	int idx=0;
 
 	for(int i=0;i<get_child_count();i++) {
-		Control *c=get_child(i)->cast_to<Control>();
+		Control *c=Object::cast_to<Control>(get_child(i));
 		if (!c || !c->is_visible())
 			continue;
 		if (c->is_set_as_toplevel())

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -45,7 +45,7 @@ int TabContainer::_get_top_margin() const {
 	int ch = font->get_height();;
 	for(int i=0;i<get_child_count();i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())
@@ -112,7 +112,7 @@ void TabContainer::_input_event(const InputEvent& p_event) {
 
 		for(int i=0;i<get_child_count();i++) {
 
-			Control *c = get_child(i)->cast_to<Control>();
+			Control *c = Object::cast_to<Control>(get_child(i));
 			if (!c)
 				continue;
 			if (c->is_set_as_toplevel())
@@ -243,7 +243,7 @@ void TabContainer::_notification(int p_what) {
 
 			for(int i=0;i<get_child_count();i++) {
 
-				Control *c = get_child(i)->cast_to<Control>();
+				Control *c = Object::cast_to<Control>(get_child(i));
 				if (!c)
 					continue;
 				if (c->is_set_as_toplevel())
@@ -427,7 +427,7 @@ void TabContainer::_child_renamed_callback() {
 void TabContainer::add_child_notify(Node *p_child) {
 
 
-	Control *c = p_child->cast_to<Control>();
+	Control *c = Object::cast_to<Control>(p_child);
 	if (!c)
 		return;
 	if (c->is_set_as_toplevel())
@@ -463,7 +463,7 @@ int TabContainer::get_tab_count() const {
 
 	for(int i=0;i<get_child_count();i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		count++;
@@ -485,7 +485,7 @@ void TabContainer::set_current_tab(int p_current) {
 	Ref<StyleBox> sb=get_stylebox("panel");
 	for(int i=0;i<get_child_count();i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())
@@ -521,7 +521,7 @@ Control* TabContainer::get_tab_control(int p_idx) const {
 
 	for(int i=0;i<get_child_count();i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())
@@ -542,7 +542,7 @@ Control* TabContainer::get_current_tab_control() const {
 
 	for(int i=0;i<get_child_count();i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())
@@ -597,7 +597,7 @@ void TabContainer::set_tabs_visible(bool p_visibe) {
 
 	for(int i=0;i<get_child_count();i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (p_visibe)
@@ -622,7 +622,7 @@ Control *TabContainer::_get_tab(int p_idx) const {
 
 	for(int i=0;i<get_child_count();i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())
@@ -676,7 +676,7 @@ void TabContainer::get_translatable_strings(List<String> *p_strings) const {
 
 	for(int i=0;i<get_child_count();i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())
@@ -699,7 +699,7 @@ Size2 TabContainer::get_minimum_size() const {
 
 	for(int i=0;i<get_child_count();i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())
@@ -728,7 +728,7 @@ Size2 TabContainer::get_minimum_size() const {
 
 void TabContainer::set_popup(Node *p_popup) {
 	ERR_FAIL_NULL(p_popup);
-	popup=p_popup->cast_to<Popup>();
+	popup=Object::cast_to<Popup>(p_popup);
 	update();
 }
 

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -154,7 +154,7 @@ protected:
 
 		return d;
 	}
-	void _remove_child(Object *p_child) { remove_child( p_child->cast_to<TreeItem>() ); }
+	void _remove_child(Object *p_child) { remove_child( Object::cast_to<TreeItem>(p_child) ); }
 public:
 
 	/* cell mode */
@@ -452,9 +452,9 @@ protected:
 	static void _bind_methods();
 
 	//bind helpers
-	Object* _create_item(Object *p_parent) { return create_item(p_parent->cast_to<TreeItem>() ); }
-	TreeItem *_get_next_selected(Object *p_item) { return get_next_selected(p_item->cast_to<TreeItem>() ); }
-	Rect2 _get_item_rect(Object *p_item,int p_column) const { return get_item_rect(p_item->cast_to<TreeItem>(),p_column ); }
+	Object* _create_item(Object *p_parent) { return create_item(Object::cast_to<TreeItem>(p_parent) ); }
+	TreeItem *_get_next_selected(Object *p_item) { return get_next_selected(Object::cast_to<TreeItem>(p_item) ); }
+	Rect2 _get_item_rect(Object *p_item,int p_column) const { return get_item_rect(Object::cast_to<TreeItem>(p_item),p_column ); }
 
 
 public:

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -173,9 +173,9 @@ void CanvasLayer::_notification(int p_what) {
 
 			while(n) {
 
-				if (n->cast_to<Viewport>()) {
+				if (Object::cast_to<Viewport>(n)) {
 
-					vp = n->cast_to<Viewport>();
+					vp = Object::cast_to<Viewport>(n);
 					break;
 				}
 				n=n->get_parent();

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -162,7 +162,7 @@ void Node::_propagate_enter_tree() {
 		data.depth=1;
 	}
 
-	data.viewport = cast_to<Viewport>();
+	data.viewport = Object::cast_to<Viewport>(this);
 	if (!data.viewport)
 		data.viewport = data.parent->data.viewport;
 
@@ -1492,9 +1492,9 @@ Node *Node::duplicate(bool p_use_instancing) const {
 
 	bool instanced=false;
 
-	if (cast_to<InstancePlaceholder>()) {
+	if (Object::cast_to<InstancePlaceholder>(this)) {
 
-		const InstancePlaceholder *ip = cast_to<const InstancePlaceholder>();
+		const InstancePlaceholder *ip = Object::cast_to<const InstancePlaceholder>(this);
 		InstancePlaceholder *nip = memnew( InstancePlaceholder );
 		nip->set_instance_path( ip->get_instance_path() );
 		node=nip;
@@ -1512,7 +1512,7 @@ Node *Node::duplicate(bool p_use_instancing) const {
 
 		Object *obj = ObjectTypeDB::instance(get_type());
 		ERR_FAIL_COND_V(!obj,NULL);
-		node = obj->cast_to<Node>();
+		node = Object::cast_to<Node>(obj);
 		if (!node)
 			memdelete(obj);
 		ERR_FAIL_COND_V(!node,NULL);
@@ -1588,7 +1588,7 @@ void Node::_duplicate_and_reown(Node* p_new_parent, const Map<Node*,Node*>& p_re
 			print_line("could not duplicate: "+String(get_type()));
 		}
 		ERR_FAIL_COND(!obj);
-		node = obj->cast_to<Node>();
+		node = Object::cast_to<Node>(obj);
 		if (!node)
 			memdelete(obj);
 	}
@@ -1649,7 +1649,7 @@ void Node::_duplicate_signals(const Node* p_original,Node* p_copy) const {
 			NodePath p = p_original->get_path_to(this);
 			Node *copy = p_copy->get_node(p);
 
-			Node *target = E->get().target->cast_to<Node>();
+			Node *target = Object::cast_to<Node>(E->get().target);
 			if (!target)
 				continue;
 			NodePath ptarget = p_original->get_path_to(target);
@@ -1680,7 +1680,7 @@ Node *Node::duplicate_and_reown(const Map<Node*,Node*>& p_reown_map) const {
 		print_line("could not duplicate: "+String(get_type()));
 	}
 	ERR_FAIL_COND_V(!obj,NULL);
-	node = obj->cast_to<Node>();
+	node = Object::cast_to<Node>(obj);
 	if (!node)
 		memdelete(obj);
 	ERR_FAIL_COND_V(!node,NULL);
@@ -1924,7 +1924,7 @@ void Node::_set_tree(SceneTree *p_tree) {
 
 static void _Node_debug_sn(Object *p_obj) {
 
-	Node *n = p_obj->cast_to<Node>();
+	Node *n = Object::cast_to<Node>(p_obj);
 	if (!n)
 		return;
 

--- a/scene/main/scene_main_loop.cpp
+++ b/scene/main/scene_main_loop.cpp
@@ -1378,7 +1378,7 @@ void SceneTree::_live_edit_create_node_func(const NodePath& p_parent,const Strin
 		Object *o = ObjectTypeDB::instance(p_type);
 		if (!o)
 			continue;
-		Node *no=o->cast_to<Node>();
+		Node *no=Object::cast_to<Node>(o);
 		no->set_name(p_name);
 
 		n2->add_child(no);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -291,7 +291,7 @@ void Viewport::_test_new_mouseover(ObjectID new_collider) {
 		if (physics_object_over) {
 			Object *obj = ObjectDB::get_instance(physics_object_over);
 			if (obj) {
-				CollisionObject *co = obj->cast_to<CollisionObject>();
+				CollisionObject *co = Object::cast_to<CollisionObject>(obj);
 				if (co) {
 					co->_mouse_exit();
 				}
@@ -301,7 +301,7 @@ void Viewport::_test_new_mouseover(ObjectID new_collider) {
 		if (new_collider) {
 			Object *obj = ObjectDB::get_instance(new_collider);
 			if (obj) {
-				CollisionObject *co = obj->cast_to<CollisionObject>();
+				CollisionObject *co = Object::cast_to<CollisionObject>(obj);
 				if (co) {
 					co->_mouse_enter();
 
@@ -327,7 +327,7 @@ void Viewport::_notification(int p_what) {
 			if (get_parent()) {
 				Node *parent=get_parent();
 				if (parent) {
-					parent_control=parent->cast_to<Control>();
+					parent_control=Object::cast_to<Control>(parent);
 				}
 			}
 
@@ -338,7 +338,7 @@ void Viewport::_notification(int p_what) {
 
 			while(parent_node) {
 
-				parent = parent_node->cast_to<Viewport>();
+				parent = Object::cast_to<Viewport>(parent_node);
 				if (parent)
 					break;
 
@@ -537,7 +537,7 @@ void Viewport::_notification(int p_what) {
 						for(int i=0;i<rc;i++) {
 
 							if (res[i].collider_id && res[i].collider) {
-								CollisionObject2D *co=res[i].collider->cast_to<CollisionObject2D>();
+								CollisionObject2D *co=Object::cast_to<CollisionObject2D>(res[i].collider);
 								if (co) {
 
 									Map<ObjectID,uint64_t>::Element *E=physics_2d_mouseover.find(res[i].collider_id);
@@ -560,7 +560,7 @@ void Viewport::_notification(int p_what) {
 								Object *o=ObjectDB::get_instance(E->key());
 								if (o) {
 
-									CollisionObject2D *co=o->cast_to<CollisionObject2D>();
+									CollisionObject2D *co=Object::cast_to<CollisionObject2D>(o);
 									if (co) {
 										co->_mouse_exit();
 									}
@@ -586,7 +586,7 @@ void Viewport::_notification(int p_what) {
 
 						Object *obj = ObjectDB::get_instance(physics_object_capture);
 						if (obj) {
-							CollisionObject *co = obj->cast_to<CollisionObject>();
+							CollisionObject *co = Object::cast_to<CollisionObject>(obj);
 							if (co) {
 								co->_input_event(camera,ev,Vector3(),Vector3(),0);
 								captured=true;
@@ -637,7 +637,7 @@ void Viewport::_notification(int p_what) {
 
 									if (result.collider) {
 
-										CollisionObject *co = result.collider->cast_to<CollisionObject>();
+										CollisionObject *co = Object::cast_to<CollisionObject>(result.collider);
 										if (co) {
 
 											co->_input_event(camera,ev,result.position,result.normal,result.shape);
@@ -675,7 +675,7 @@ void Viewport::_notification(int p_what) {
 						ObjectID new_collider=0;
 						if (col) {
 							if (result.collider) {
-								CollisionObject *co = result.collider->cast_to<CollisionObject>();
+								CollisionObject *co = Object::cast_to<CollisionObject>(result.collider);
 								if (co) {
 									new_collider=result.collider_id;
 
@@ -740,7 +740,7 @@ Rect2 Viewport::get_rect() const {
 
 void Viewport::_update_listener() {
 
-	if (is_inside_tree() && audio_listener && camera && (!get_parent() || (get_parent()->cast_to<Control>() && get_parent()->cast_to<Control>()->is_visible())))  {
+	if (is_inside_tree() && audio_listener && camera && (!get_parent() || (Object::cast_to<Control>(get_parent()) && cast_to<Control>(get_parent())->is_visible())))  {
 		SpatialSoundServer::get_singleton()->listener_set_space(listener,find_world()->get_sound_space());
 	} else {
 		SpatialSoundServer::get_singleton()->listener_set_space(listener,RID());
@@ -751,7 +751,7 @@ void Viewport::_update_listener() {
 
 void Viewport::_update_listener_2d() {
 
-	if (is_inside_tree() && audio_listener && (!get_parent() || (get_parent()->cast_to<Control>() && get_parent()->cast_to<Control>()->is_visible())))
+	if (is_inside_tree() && audio_listener && (!get_parent() || (Object::cast_to<Control>(get_parent()) && cast_to<Control>(get_parent())->is_visible())))
 		SpatialSound2DServer::get_singleton()->listener_set_space(listener_2d,find_world_2d()->get_sound_space());
 	else
 		SpatialSound2DServer::get_singleton()->listener_set_space(listener_2d,RID());
@@ -964,12 +964,12 @@ void Viewport::_propagate_enter_world(Node *p_node) {
 		if (!p_node->is_inside_tree()) //may not have entered scene yet
 			return;
 
-		Spatial *s = p_node->cast_to<Spatial>();
+		Spatial *s = Object::cast_to<Spatial>(p_node);
 		if (s) {
 
 			s->notification(Spatial::NOTIFICATION_ENTER_WORLD);
 		} else {
-			Viewport *v = p_node->cast_to<Viewport>();
+			Viewport *v = Object::cast_to<Viewport>(p_node);
 			if (v) {
 
 				if (v->world.is_valid())
@@ -990,7 +990,7 @@ void Viewport::_propagate_viewport_notification(Node* p_node,int p_what) {
 	p_node->notification(p_what);
 	for(int i=0;i<p_node->get_child_count();i++) {
 		Node *c = p_node->get_child(i);
-		if (c->cast_to<Viewport>())
+		if (Object::cast_to<Viewport>(c))
 			continue;
 		_propagate_viewport_notification(c,p_what);
 	}
@@ -1003,12 +1003,12 @@ void Viewport::_propagate_exit_world(Node *p_node) {
 		if (!p_node->is_inside_tree()) //may have exited scene already
 			return;
 
-		Spatial *s = p_node->cast_to<Spatial>();
+		Spatial *s = Object::cast_to<Spatial>(p_node);
 		if (s) {
 
 			s->notification(Spatial::NOTIFICATION_EXIT_WORLD,false);
 		} else {
-			Viewport *v = p_node->cast_to<Viewport>();
+			Viewport *v = Object::cast_to<Viewport>(p_node);
 			if (v) {
 
 				if (v->world.is_valid())
@@ -1565,10 +1565,10 @@ Control* Viewport::_gui_find_control(const Point2& p_global)  {
 
 Control* Viewport::_gui_find_control_at_pos(CanvasItem* p_node,const Point2& p_global,const Matrix32& p_xform,Matrix32& r_inv_xform)  {
 
-	if (p_node->cast_to<Viewport>())
+	if (Object::cast_to<Viewport>(p_node))
 		return NULL;
 
-	Control *c=p_node->cast_to<Control>();
+	Control *c=Object::cast_to<Control>(p_node);
 
 	if (c) {
 	//	print_line("at "+String(c->get_path())+" POS "+c->get_pos()+" bt "+p_xform);
@@ -1590,7 +1590,7 @@ Control* Viewport::_gui_find_control_at_pos(CanvasItem* p_node,const Point2& p_g
 			if (p_node==gui.tooltip_popup)
 				continue;
 
-			CanvasItem *ci = p_node->get_child(i)->cast_to<CanvasItem>();
+			CanvasItem *ci = Object::cast_to<CanvasItem>(p_node->get_child(i));
 			if (!ci || ci->is_set_as_toplevel())
 				continue;
 
@@ -2060,7 +2060,7 @@ void Viewport::_gui_remove_from_modal_stack(List<Control*>::Element *MI,ObjectID
 		if (!next) { //top of stack
 
 			Object *pfo = ObjectDB::get_instance(p_prev_focus_owner);
-			Control *pfoc = pfo->cast_to<Control>();
+			Control *pfoc = Object::cast_to<Control>(pfo);
 			if (!pfoc)
 				return;
 
@@ -2087,7 +2087,7 @@ void Viewport::_gui_force_drag(Control *p_base, const Variant& p_data, Control *
 void Viewport::_gui_set_drag_preview(Control *p_base, Control *p_control) {
 
 	ERR_FAIL_NULL(p_control);
-	ERR_FAIL_COND( !((Object*)p_control)->cast_to<Control>());
+	ERR_FAIL_COND( !Object::cast_to<Control>(((Object*)p_control)));
 	ERR_FAIL_COND(p_control->is_inside_tree());
 	ERR_FAIL_COND(p_control->get_parent()!=NULL);
 
@@ -2405,7 +2405,7 @@ Variant Viewport::gui_get_drag_data() const {
 
 String Viewport::get_configuration_warning() const {
 
-	if (get_parent() && !get_parent()->cast_to<Control>() && !render_target) {
+	if (get_parent() && !Object::cast_to<Control>(get_parent()) && !render_target) {
 
 		return TTR("This viewport is not set as render target. If you intend for it to display its contents directly to the screen, make it a child of a Control so it can obtain a size. Otherwise, make it a RenderTarget and assign its internal texture to some node for display.");
 	}

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -152,18 +152,18 @@ Node *SceneState::instance(bool p_gen_edit_state) const {
             //print_line("created");
 			//node belongs to this scene and must be created
 			Object * obj = ObjectTypeDB::instance(snames[ n.type ]);
-			if (!obj || !obj->cast_to<Node>()) {
+			if (!obj || !Object::cast_to<Node>(obj)) {
 				if (obj) {
 					memdelete(obj);
 					obj=NULL;
 				}
 				WARN_PRINT(String("Warning node of type "+snames[n.type].operator String()+" does not exist.").ascii().get_data());
 				if (n.parent>=0 && n.parent<nc && ret_nodes[n.parent]) {
-					if (ret_nodes[n.parent]->cast_to<Spatial>()) {
+					if (Object::cast_to<Spatial>(ret_nodes[n.parent])) {
 						obj = memnew( Spatial );
-					} else if (ret_nodes[n.parent]->cast_to<Control>()) {
+					} else if (Object::cast_to<Control>(ret_nodes[n.parent])) {
 						obj = memnew( Control );
-					} else if (ret_nodes[n.parent]->cast_to<Node2D>()) {
+					} else if (Object::cast_to<Node2D>(ret_nodes[n.parent])) {
 						obj = memnew( Node2D );
 					}
 
@@ -173,7 +173,7 @@ Node *SceneState::instance(bool p_gen_edit_state) const {
 				}
 			}
 
-			node = obj->cast_to<Node>();
+			node = Object::cast_to<Node>(obj);
 
 		}
 
@@ -738,7 +738,7 @@ Error SceneState::_parse_connections(Node *p_owner,Node *p_node, Map<StringName,
 			// only connections that originate or end into main saved scene are saved
 			// everything else is discarded
 
-			Node *n=c.target->cast_to<Node>();
+			Node *n=Object::cast_to<Node>(c.target);
 			if (!n) {
 				continue;
 			}

--- a/scene/resources/scene_format_text.cpp
+++ b/scene/resources/scene_format_text.cpp
@@ -213,7 +213,7 @@ Error ResourceInteractiveLoaderText::poll() {
 			}
 
 
-			Resource *r = obj->cast_to<Resource>();
+			Resource *r = Object::cast_to<Resource>(obj);
 			if (!r) {
 
 				error_text+="Can't create sub resource of type, because not a resource: "+type;
@@ -283,7 +283,7 @@ Error ResourceInteractiveLoaderText::poll() {
 		}
 
 
-		Resource *r = obj->cast_to<Resource>();
+		Resource *r = Object::cast_to<Resource>(obj);
 		if (!r) {
 
 			error_text+="Can't create sub resource of type, because not a resource: "+res_type;

--- a/scene/resources/scene_preloader.cpp
+++ b/scene/resources/scene_preloader.cpp
@@ -67,7 +67,7 @@ Node *ScenePreloader::instance() const {
 
 		Object * obj = ObjectTypeDB::instance(snames[ n.type ]);
 		ERR_FAIL_COND_V(!obj,NULL);
-		Node *node = obj->cast_to<Node>();
+		Node *node = Object::cast_to<Node>(obj);
 		ERR_FAIL_COND_V(!node,NULL);
 
 		int nprop_count=n.properties.size();
@@ -194,7 +194,7 @@ void ScenePreloader::_parse_connections(Node *p_node, Map<StringName,int> &name_
 			const Node::Connection &c = F->get();
 			if (!(c.flags&CONNECT_PERSIST))
 				continue;
-			Node *n=c.target->cast_to<Node>();
+			Node *n=Object::cast_to<Node>(c.target);
 			if (!n)
 				continue;
 

--- a/scene/resources/shape.cpp
+++ b/scene/resources/shape.cpp
@@ -75,7 +75,7 @@ Ref<Mesh> Shape::get_debug_mesh() {
 		arr.resize(Mesh::ARRAY_MAX);
 		arr[Mesh::ARRAY_VERTEX]=array;
 
-		SceneTree *st=OS::get_singleton()->get_main_loop()->cast_to<SceneTree>();
+		SceneTree *st=Object::cast_to<SceneTree>(OS::get_singleton()->get_main_loop());
 
 		debug_mesh_cache->add_surface(Mesh::PRIMITIVE_LINES,arr);
 

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -1022,14 +1022,14 @@ RES ResourceFormatLoaderTheme::load(const String &p_path, const String& p_origin
 					ERR_FAIL_V(RES());
 				}
 
-				if (res->cast_to<StyleBox>()) {
+				if (Object::cast_to<StyleBox>(*res)) {
 
 					theme->set_stylebox(item,control,res);
-				} else if (res->cast_to<Font>()) {
+				} else if (Object::cast_to<Font>(*res)) {
 					theme->set_font(item,control,res);
-				} else if (res->cast_to<Font>()) {
+				} else if (Object::cast_to<Font>(*res)) {
 					theme->set_font(item,control,res);
-				} else if (res->cast_to<Texture>()) {
+				} else if (Object::cast_to<Texture>(*res)) {
 					theme->set_icon(item,control,res);
 				} else {
 					memdelete(f);

--- a/tools/editor/addon_editor_plugin.cpp
+++ b/tools/editor/addon_editor_plugin.cpp
@@ -519,7 +519,7 @@ void EditorAddonLibrary::_install_asset() {
 
 	for(int i=0;i<downloads_hb->get_child_count();i++) {
 
-		EditorAddonLibraryItemDownload *d  = downloads_hb->get_child(i)->cast_to<EditorAddonLibraryItemDownload>();
+		EditorAddonLibraryItemDownload *d  = Object::cast_to<EditorAddonLibraryItemDownload>(downloads_hb->get_child(i));
 		if (d && d->get_asset_id() == description->get_asset_id()) {
 
 			EditorNode::get_singleton()->show_warning("Download for this asset is already in progress!");

--- a/tools/editor/animation_editor.cpp
+++ b/tools/editor/animation_editor.cpp
@@ -3238,9 +3238,9 @@ void AnimationKeyEditor::insert_value_key(const String& p_property,const Variant
 	//let's build a node path
 	ERR_FAIL_COND(history->get_path_size()==0);
 	Object *obj = ObjectDB::get_instance(history->get_path_object(0));
-	ERR_FAIL_COND(!obj || !obj->cast_to<Node>());
+	ERR_FAIL_COND(!obj || !Object::cast_to<Node>(obj));
 
-	Node *node = obj->cast_to<Node>();
+	Node *node = Object::cast_to<Node>(obj);
 
 	String path = root->get_path_to(node);
 

--- a/tools/editor/array_property_edit.cpp
+++ b/tools/editor/array_property_edit.cpp
@@ -225,7 +225,7 @@ Node *ArrayPropertyEdit::get_node() {
 	if (!o)
 		return NULL;
 
-	return o->cast_to<Node>();
+	return Object::cast_to<Node>(o);
 }
 
 void ArrayPropertyEdit::_bind_methods() {

--- a/tools/editor/connections_dialog.cpp
+++ b/tools/editor/connections_dialog.cpp
@@ -736,7 +736,7 @@ void ConnectionsDialog::update_tree() {
 				if (!(c.flags&CONNECT_PERSIST))
 					continue;
 
-				Node *target = c.target->cast_to<Node>();
+				Node *target = Object::cast_to<Node>(c.target);
 				if (!target)
 					continue;
 

--- a/tools/editor/dependency_editor.cpp
+++ b/tools/editor/dependency_editor.cpp
@@ -23,7 +23,7 @@ void DependencyEditor::_searched(const String& p_path) {
 
 void DependencyEditor::_load_pressed(Object* p_item,int p_cell,int p_button){
 
-	TreeItem *ti=p_item->cast_to<TreeItem>();
+	TreeItem *ti=Object::cast_to<TreeItem>(p_item);
 	String fname = ti->get_text(0);
 	replacing = ti->get_text(1);
 
@@ -650,7 +650,7 @@ void OrphanResourcesDialog::_delete_confirm() {
 
 void OrphanResourcesDialog::_button_pressed(Object *p_item,int p_column, int p_id) {
 
-	TreeItem *ti=p_item->cast_to<TreeItem>();
+	TreeItem *ti=Object::cast_to<TreeItem>(p_item);
 
 	String path = ti->get_metadata(0);
 	dep_edit->edit(path);

--- a/tools/editor/editor_data.cpp
+++ b/tools/editor/editor_data.cpp
@@ -73,7 +73,7 @@ void EditorHistory::_add_object(ObjectID p_object,const String& p_property,int p
 
 	Object *obj = ObjectDB::get_instance(p_object);
 	ERR_FAIL_COND(!obj);
-	Reference *r = obj->cast_to<Reference>();
+	Reference *r = Object::cast_to<Reference>(obj);
 	Obj o;
 	if (r)
 		o.ref=REF(r);

--- a/tools/editor/editor_data.h
+++ b/tools/editor/editor_data.h
@@ -249,7 +249,7 @@ public:
 		Object *obj = selection[p_node];
 		if (!obj)
 			return NULL;
-		return obj->cast_to<T>();
+		return Object::cast_to<T>(obj);
 	}
 
 	void add_editor_plugin(Object *p_object);

--- a/tools/editor/editor_dir_dialog.cpp
+++ b/tools/editor/editor_dir_dialog.cpp
@@ -96,7 +96,7 @@ void EditorDirDialog::_notification(int p_what) {
 
 void EditorDirDialog::_item_collapsed(Object* _p_item){
 
-	TreeItem *p_item=_p_item->cast_to<TreeItem>();
+	TreeItem *p_item=Object::cast_to<TreeItem>(_p_item);
 
 	if (updating || p_item->is_collapsed())
 		return;

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -1049,7 +1049,7 @@ void EditorNode::_save_scene(String p_file) {
 		// we must update it, but also let the previous scene state go, as
 		// old version still work for referencing changes in instanced or inherited scenes
 
-		sdata = Ref<PackedScene>( ResourceCache::get(p_file)->cast_to<PackedScene>() );
+		sdata = Ref<PackedScene>( Object::cast_to<PackedScene>(ResourceCache::get(p_file)) );
 		if (sdata.is_valid())
 			sdata->recreate_state();
 		else
@@ -1436,9 +1436,9 @@ void EditorNode::_dialog_action(String p_file) {
 			uint32_t current = editor_history.get_current();
 			Object *current_obj = current>0 ? ObjectDB::get_instance(current) : NULL;
 
-			ERR_FAIL_COND(!current_obj->cast_to<Resource>())
+			ERR_FAIL_COND(!Object::cast_to<Resource>(current_obj))
 
-			RES current_res = RES(current_obj->cast_to<Resource>());
+			RES current_res = RES(Object::cast_to<Resource>(current_obj));
 
 			save_resource_in_path(current_res,p_file);
 
@@ -1577,8 +1577,8 @@ void EditorNode::_prepare_history() {
 			icon=base_icon;
 
 		String text;
-		if (obj->cast_to<Resource>()) {
-			Resource *r=obj->cast_to<Resource>();
+		if (Object::cast_to<Resource>(obj)) {
+			Resource *r=Object::cast_to<Resource>(obj);
 			if (r->get_path().is_resource_file())
 				text=r->get_path().get_file();
 			else if (r->get_name()!=String()) {
@@ -1586,8 +1586,8 @@ void EditorNode::_prepare_history() {
 			} else {
 				text=r->get_type();
 			}
-		} else if (obj->cast_to<Node>()) {
-			text=obj->cast_to<Node>()->get_name();
+		} else if (Object::cast_to<Node>(obj)) {
+			text=Object::cast_to<Node>(obj)->get_name();
 		} else {
 			text=obj->get_type();
 		}
@@ -1681,7 +1681,7 @@ void EditorNode::_edit_current() {
 	if (is_resource) {
 
 
-		Resource *current_res = current_obj->cast_to<Resource>();
+		Resource *current_res = Object::cast_to<Resource>(current_obj);
 		ERR_FAIL_COND(!current_res);
 		scene_tree_dock->set_selected(NULL);
 		property_editor->edit( current_res );
@@ -1693,7 +1693,7 @@ void EditorNode::_edit_current() {
 		//top_pallete->set_current_tab(1);
 	} else if (current_obj->is_type("Node")) {
 
-		Node * current_node = current_obj->cast_to<Node>();
+		Node * current_node = Object::cast_to<Node>(current_obj);
 		ERR_FAIL_COND(!current_node);
 		ERR_FAIL_COND(!current_node->is_inside_tree());
 
@@ -1824,7 +1824,7 @@ void EditorNode::_resource_created() {
 	Object *c = create_dialog->instance_selected();
 
 	ERR_FAIL_COND(!c);
-	Resource *r = c->cast_to<Resource>();
+	Resource *r = Object::cast_to<Resource>(c);
 	ERR_FAIL_COND(!r);
 
 	REF res( r );
@@ -2546,9 +2546,9 @@ void EditorNode::_menu_option_confirm(int p_option,bool p_confirmed) {
 			uint32_t current = editor_history.get_current();
 			Object *current_obj = current>0 ? ObjectDB::get_instance(current) : NULL;
 
-			ERR_FAIL_COND(!current_obj->cast_to<Resource>())
+			ERR_FAIL_COND(!Object::cast_to<Resource>(current_obj))
 
-			RES current_res = RES(current_obj->cast_to<Resource>());
+			RES current_res = RES(Object::cast_to<Resource>(current_obj));
 
 			save_resource(current_res);
 
@@ -2558,9 +2558,9 @@ void EditorNode::_menu_option_confirm(int p_option,bool p_confirmed) {
 			uint32_t current = editor_history.get_current();
 			Object *current_obj = current>0 ? ObjectDB::get_instance(current) : NULL;
 
-			ERR_FAIL_COND(!current_obj->cast_to<Resource>())
+			ERR_FAIL_COND(!Object::cast_to<Resource>(current_obj))
 
-			RES current_res = RES(current_obj->cast_to<Resource>());
+			RES current_res = RES(Object::cast_to<Resource>(current_obj));
 
 			save_resource_as(current_res);
 
@@ -2570,9 +2570,9 @@ void EditorNode::_menu_option_confirm(int p_option,bool p_confirmed) {
 			uint32_t current = editor_history.get_current();
 			Object *current_obj = current>0 ? ObjectDB::get_instance(current) : NULL;
 
-			ERR_FAIL_COND(!current_obj->cast_to<Resource>())
+			ERR_FAIL_COND(!Object::cast_to<Resource>(current_obj))
 
-			RES current_res = RES(current_obj->cast_to<Resource>());
+			RES current_res = RES(Object::cast_to<Resource>(current_obj));
 			current_res->set_path("");
 			_edit_current();
 		} break;
@@ -2581,9 +2581,9 @@ void EditorNode::_menu_option_confirm(int p_option,bool p_confirmed) {
 			uint32_t current = editor_history.get_current();
 			Object *current_obj = current>0 ? ObjectDB::get_instance(current) : NULL;
 
-			ERR_FAIL_COND(!current_obj->cast_to<Resource>())
+			ERR_FAIL_COND(!Object::cast_to<Resource>(current_obj))
 
-			RES current_res = RES(current_obj->cast_to<Resource>());
+			RES current_res = RES(Object::cast_to<Resource>(current_obj));
 
 			EditorSettings::get_singleton()->set_resource_clipboard(current_res);
 
@@ -3166,8 +3166,8 @@ void EditorNode::set_edited_scene(Node *p_scene) {
 	}
 	get_editor_data().set_edited_scene_root(p_scene);
 
-	if (p_scene && p_scene->cast_to<Popup>())
-		p_scene->cast_to<Popup>()->show(); //show popups
+	if (Popup *p = Object::cast_to<Popup>(p_scene))
+		p->show(); //show popups
 	scene_tree_dock->set_edited_scene(p_scene);
 	if (get_tree())
 		get_tree()->set_edited_scene_root(p_scene);
@@ -3190,7 +3190,7 @@ void EditorNode::_fetch_translatable_strings(const Object *p_object,Set<StringNa
 
 
 
-	const Node * node = p_object->cast_to<Node>();
+	const Node * node = Object::cast_to<Node>(p_object);
 
 	if (!node)
 		return;
@@ -3540,8 +3540,8 @@ void EditorNode::set_current_scene(int p_idx) {
 
 	Node* new_scene = editor_data.get_edited_scene_root();
 
-	if (new_scene && new_scene->cast_to<Popup>())
-		new_scene->cast_to<Popup>()->show(); //show popups
+	if (Popup *p = Object::cast_to<Popup>(new_scene))
+		p->show(); //show popups
 
 	//print_line("set current 3 ");
 
@@ -3691,7 +3691,7 @@ Error EditorNode::load_scene(const String& p_scene, bool p_ignore_broken_deps,bo
 
 	if (ResourceCache::has(lpath)) {
 		//used from somewhere else? no problem! update state and replace sdata
-		Ref<PackedScene> ps = Ref<PackedScene>( ResourceCache::get(lpath)->cast_to<PackedScene>() );
+		Ref<PackedScene> ps = Ref<PackedScene>( Object::cast_to<PackedScene>(ResourceCache::get(lpath)) );
 		if (ps.is_valid()) {
 			ps->replace_state( sdata->get_state() );
 			ps->set_last_modified_time( sdata->get_last_modified_time() );
@@ -3809,7 +3809,7 @@ void EditorNode::_property_keyed(const String& p_keyed,const Variant& p_value,bo
 
 void EditorNode::_transform_keyed(Object *sp,const String& p_sub,const Transform& p_key) {
 
-	Spatial *s=sp->cast_to<Spatial>();
+	Spatial *s=Object::cast_to<Spatial>(sp);
 	if (!s)
 		return;
 	AnimationPlayerEditor::singleton->get_key_editor()->insert_transform_key(s,p_sub,p_key);
@@ -3826,7 +3826,7 @@ void EditorNode::update_keying() {
 		if (editor_history.get_path_size()>=1) {
 
 			Object *obj = ObjectDB::get_instance(editor_history.get_path_object(0));
-			if (obj && obj->cast_to<Node>()) {
+			if (Object::cast_to<Node>(obj)) {
 
 				valid=true;
 			}
@@ -4563,7 +4563,7 @@ void EditorNode::_load_docks_from_config(Ref<ConfigFile> p_layout, const String&
 			for(int k=0;k<DOCK_SLOT_MAX;k++) {
 				if (!dock_slot[k]->has_node(name))
 					continue;
-				node=dock_slot[k]->get_node(name)->cast_to<Control>();
+				node=Object::cast_to<Control>(dock_slot[k]->get_node(name));
 				if (!node)
 					continue;
 				atidx=k;
@@ -5147,7 +5147,7 @@ EditorNode::EditorNode() {
 	editor_initialize_certificates(); //for asset sharing
 
 
-	InputDefault *id = Input::get_singleton()->cast_to<InputDefault>();
+	InputDefault *id = Object::cast_to<InputDefault>(Input::get_singleton());
 
 	if (id) {
 

--- a/tools/editor/editor_path.cpp
+++ b/tools/editor/editor_path.cpp
@@ -70,9 +70,9 @@ void EditorPath::_notification(int p_what) {
 					if (left<0)
 						continue;
 					String name;
-					if (obj->cast_to<Resource>()) {
+					if (Object::cast_to<Resource>(obj)) {
 
-						Resource *r = obj->cast_to<Resource>();
+						Resource *r = Object::cast_to<Resource>(obj);
 						if (r->get_path().is_resource_file())
 							name=r->get_path().get_file();
 						else
@@ -80,11 +80,11 @@ void EditorPath::_notification(int p_what) {
 
 						if (name=="")
 							name=r->get_type();
-					} else if (obj->cast_to<Node>()) {
+					} else if (Object::cast_to<Node>(obj)) {
 
-						name=obj->cast_to<Node>()->get_name();
-					} else if (obj->cast_to<Resource>() && obj->cast_to<Resource>()->get_name()!="") {
-						name=obj->cast_to<Resource>()->get_name();
+						name=Object::cast_to<Node>(obj)->get_name();
+					} else if (Object::cast_to<Resource>(obj) && Object::cast_to<Resource>(obj)->get_name()!="") {
+						name=Object::cast_to<Resource>(obj)->get_name();
 					} else {
 						name=obj->get_type();
 					}

--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -632,7 +632,7 @@ void EditorSettings::notify_changes() {
 	SceneTree *sml=NULL;
 
 	if (OS::get_singleton()->get_main_loop())
-		sml = OS::get_singleton()->get_main_loop()->cast_to<SceneTree>();
+		sml = Object::cast_to<SceneTree>(OS::get_singleton()->get_main_loop());
 
 	if (!sml) {
 		print_line("not SML");

--- a/tools/editor/groups_editor.cpp
+++ b/tools/editor/groups_editor.cpp
@@ -60,7 +60,7 @@ void GroupsEditor::_remove_group(Object *p_item, int p_column, int p_id) {
 	if (!node)
 		return;
 
-	TreeItem *ti = p_item->cast_to<TreeItem>();
+	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 	if (!ti)
 		return;
 

--- a/tools/editor/import_settings.cpp
+++ b/tools/editor/import_settings.cpp
@@ -95,7 +95,7 @@ void ImportSettingsDialog::_item_edited() {
 
 void ImportSettingsDialog::_button_pressed(Object *p_button, int p_col, int p_id) {
 
-	TreeItem *ti=p_button->cast_to<TreeItem>();
+	TreeItem *ti=Object::cast_to<TreeItem>(p_button);
 	if (!ti)
 		return;
 	String path = ti->get_metadata(0);

--- a/tools/editor/io_plugins/editor_font_import_plugin.cpp
+++ b/tools/editor/io_plugins/editor_font_import_plugin.cpp
@@ -1557,7 +1557,7 @@ Ref<BitmapFont> EditorFontImportPlugin::generate_font(const Ref<ResourceImportMe
 
 	if (p_existing!=String() && ResourceCache::has(p_existing)) {
 
-		font = Ref<BitmapFont>( ResourceCache::get(p_existing)->cast_to<BitmapFont>());
+		font = Ref<BitmapFont>( Object::cast_to<BitmapFont>(ResourceCache::get(p_existing)));
 	}
 
 	if (font.is_null()) {

--- a/tools/editor/io_plugins/editor_import_collada.cpp
+++ b/tools/editor/io_plugins/editor_import_collada.cpp
@@ -330,7 +330,7 @@ Error ColladaImport::_create_scene(Collada::Node *p_node, Spatial *p_parent) {
 			} else {
 				//mesh since nothing else
 				node = memnew( MeshInstance );
-				node->cast_to<MeshInstance>()->set_flag(GeometryInstance::FLAG_USE_BAKED_LIGHT,true);
+				Object::cast_to<MeshInstance>(node)->set_flag(GeometryInstance::FLAG_USE_BAKED_LIGHT,true);
 			}
 		} break;
 		case Collada::Node::TYPE_SKELETON: {
@@ -1494,9 +1494,9 @@ Error ColladaImport::_create_resources(Collada::Node *p_node) {
 		Collada::NodeGeometry *ng = static_cast<Collada::NodeGeometry*>(p_node);
 
 
-		if (node->cast_to<Path>()) {
+		if (Object::cast_to<Path>(node)) {
 
-			Path *path = node->cast_to<Path>();
+			Path *path = Object::cast_to<Path>(node);
 
 			String curve = ng->source;
 
@@ -1576,12 +1576,12 @@ Error ColladaImport::_create_resources(Collada::Node *p_node) {
 		}
 
 
-		if (node->cast_to<MeshInstance>()) {
+		if (Object::cast_to<MeshInstance>(node)) {
 
 
 			Collada::NodeGeometry *ng = static_cast<Collada::NodeGeometry*>(p_node);
 
-			MeshInstance *mi = node->cast_to<MeshInstance>();
+			MeshInstance *mi = Object::cast_to<MeshInstance>(node);
 
 
 			ERR_FAIL_COND_V(!mi,ERR_BUG);
@@ -1618,7 +1618,7 @@ Error ColladaImport::_create_resources(Collada::Node *p_node) {
 					}
 					ERR_FAIL_COND_V( !node_map.has(skname), ERR_INVALID_DATA );
 					NodeMap nmsk = node_map[skname];
-					Skeleton *sk = nmsk.node->cast_to<Skeleton>();
+					Skeleton *sk = Object::cast_to<Skeleton>(nmsk.node);
 					ERR_FAIL_COND_V( !sk, ERR_INVALID_DATA );
 					ERR_FAIL_COND_V( !skeleton_bone_map.has(sk), ERR_INVALID_DATA );
 					Map<String, int> &bone_remap_map=skeleton_bone_map[sk];
@@ -2164,7 +2164,7 @@ void ColladaImport::create_animation(int p_clip, bool p_make_tracks_in_all_bones
 
 			if (nm.bone>=0) {
 				//make bone transform relative to rest (in case of skeleton)
-				Skeleton *sk = nm.node->cast_to<Skeleton>();
+				Skeleton *sk = Object::cast_to<Skeleton>(nm.node);
 				if (sk) {
 
 					xform = sk->get_bone_rest(nm.bone).affine_inverse() * xform;

--- a/tools/editor/io_plugins/editor_sample_import_plugin.cpp
+++ b/tools/editor/io_plugins/editor_sample_import_plugin.cpp
@@ -676,7 +676,7 @@ Error EditorSampleImportPlugin::import(const String& p_path, const Ref<ResourceI
 
 	if (ResourceCache::has(p_path)) {
 
-		target = Ref<Sample>( ResourceCache::get(p_path)->cast_to<Sample>() );
+		target = Ref<Sample>( Object::cast_to<Sample>(ResourceCache::get(p_path)) );
 	} else {
 
 		target = smp;

--- a/tools/editor/io_plugins/editor_scene_import_plugin.cpp
+++ b/tools/editor/io_plugins/editor_scene_import_plugin.cpp
@@ -1383,7 +1383,7 @@ void EditorSceneImportPlugin::_find_resources(const Variant& p_var, Map<Ref<Imag
 					for(List<PropertyInfo>::Element *E=pl.front();E;E=E->next()) {
 
 						if (E->get().type==Variant::OBJECT || E->get().type==Variant::ARRAY || E->get().type==Variant::DICTIONARY) {
-							if (E->get().type==Variant::OBJECT && res->cast_to<FixedMaterial>() && (E->get().name=="textures/diffuse" || E->get().name=="textures/detail" || E->get().name=="textures/emission")) {
+							if (E->get().type==Variant::OBJECT && Object::cast_to<FixedMaterial>(*res) && (E->get().name=="textures/diffuse" || E->get().name=="textures/detail" || E->get().name=="textures/emission")) {
 
 								Ref<ImageTexture> tex =res->get(E->get().name);
 								if (tex.is_valid()) {
@@ -1391,14 +1391,14 @@ void EditorSceneImportPlugin::_find_resources(const Variant& p_var, Map<Ref<Imag
 									image_map.insert(tex,TEXTURE_ROLE_DIFFUSE);
 								}
 
-							} else if (E->get().type==Variant::OBJECT && res->cast_to<FixedMaterial>() && (E->get().name=="textures/normal")) {
+							} else if (E->get().type==Variant::OBJECT && Object::cast_to<FixedMaterial>(*res) && (E->get().name=="textures/normal")) {
 
 								Ref<ImageTexture> tex =res->get(E->get().name);
 								if (tex.is_valid()) {
 
 									image_map.insert(tex,TEXTURE_ROLE_NORMALMAP);
 									if (p_flags&SCENE_FLAG_CONVERT_NORMALMAPS_TO_XY)
-										res->cast_to<FixedMaterial>()->set_fixed_flag(FixedMaterial::FLAG_USE_XY_NORMALMAP,true);
+										Object::cast_to<FixedMaterial>(*res)->set_fixed_flag(FixedMaterial::FLAG_USE_XY_NORMALMAP,true);
 								}
 
 
@@ -1484,9 +1484,9 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 
 
 
-	if (p_flags&SCENE_FLAG_CREATE_BILLBOARDS && p_node->cast_to<MeshInstance>()) {
+	if (p_flags&SCENE_FLAG_CREATE_BILLBOARDS && Object::cast_to<MeshInstance>(p_node)) {
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 		bool bb=false;
 
@@ -1517,9 +1517,9 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 	}
 
 
-	if (p_flags&(SCENE_FLAG_DETECT_ALPHA|SCENE_FLAG_DETECT_VCOLOR|SCENE_FLAG_SET_LIGHTMAP_TO_UV2_IF_EXISTS) && p_node->cast_to<MeshInstance>()) {
+	if (p_flags&(SCENE_FLAG_DETECT_ALPHA|SCENE_FLAG_DETECT_VCOLOR|SCENE_FLAG_SET_LIGHTMAP_TO_UV2_IF_EXISTS) && Object::cast_to<MeshInstance>(p_node)) {
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 		Ref<Mesh> m = mi->get_mesh();
 
@@ -1550,9 +1550,9 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 		}
 	}
 
-	if (p_flags&SCENE_FLAG_REMOVE_NOIMP && p_node->cast_to<AnimationPlayer>()) {
+	if (p_flags&SCENE_FLAG_REMOVE_NOIMP && Object::cast_to<AnimationPlayer>(p_node)) {
 		//remove animations referencing non-importable nodes
-		AnimationPlayer *ap = p_node->cast_to<AnimationPlayer>();
+		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node);
 
 		List<StringName> anims;
 		ap->get_animation_list(&anims);
@@ -1577,9 +1577,9 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 	}
 
 
-	if (p_flags&SCENE_FLAG_CREATE_IMPOSTORS && p_node->cast_to<MeshInstance>()) {
+	if (p_flags&SCENE_FLAG_CREATE_IMPOSTORS && Object::cast_to<MeshInstance>(p_node)) {
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 		String str;
 
@@ -1591,9 +1591,9 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 		}
 
 
-		if (p_node->get_parent() && p_node->get_parent()->cast_to<MeshInstance>()) {
-			MeshInstance *mi = p_node->cast_to<MeshInstance>();
-			MeshInstance *mip = p_node->get_parent()->cast_to<MeshInstance>();
+		if (p_node->get_parent() && Object::cast_to<MeshInstance>(p_node->get_parent())) {
+			MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
+			MeshInstance *mip = Object::cast_to<MeshInstance>(p_node->get_parent());
 			String d=str.substr(str.find("imp")+3,str.length());
 			if (d!="") {
 				if ((d[0]<'0' || d[0]>'9'))
@@ -1627,9 +1627,9 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 		}
 	}
 
-    if (p_flags&SCENE_FLAG_CREATE_LODS && p_node->cast_to<MeshInstance>()) {
+    if (p_flags&SCENE_FLAG_CREATE_LODS && Object::cast_to<MeshInstance>(p_node)) {
 
-	MeshInstance *mi = p_node->cast_to<MeshInstance>();
+	MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 	String str;
 
@@ -1641,9 +1641,9 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 	}
 
 
-	if (p_node->get_parent() && p_node->get_parent()->cast_to<MeshInstance>()) {
-	    MeshInstance *mi = p_node->cast_to<MeshInstance>();
-	    MeshInstance *mip = p_node->get_parent()->cast_to<MeshInstance>();
+	if (p_node->get_parent() && Object::cast_to<MeshInstance>(p_node->get_parent())) {
+	    MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
+	    MeshInstance *mip = Object::cast_to<MeshInstance>(p_node->get_parent());
 	    String d=str.substr(str.find("lod")+3,str.length());
 	    if (d!="") {
 		if ((d[0]<'0' || d[0]>'9'))
@@ -1676,31 +1676,31 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
     }
 
 
-	if (p_flags&SCENE_FLAG_DETECT_LIGHTMAP_LAYER && _teststr(name,"lm") && p_node->cast_to<MeshInstance>()) {
+	if (p_flags&SCENE_FLAG_DETECT_LIGHTMAP_LAYER && _teststr(name,"lm") && Object::cast_to<MeshInstance>(p_node)) {
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 		String str=name;
 		int layer = str.substr(str.find("lm")+3,str.length()).to_int();
 		mi->set_baked_light_texture_id(layer);
 	}
 
-	if (p_flags&SCENE_FLAG_CREATE_COLLISIONS && _teststr(name,"colonly") && p_node->cast_to<MeshInstance>()) {
+	if (p_flags&SCENE_FLAG_CREATE_COLLISIONS && _teststr(name,"colonly") && Object::cast_to<MeshInstance>(p_node)) {
 
 		if (isroot)
 			return p_node;
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 		Node * col = mi->create_trimesh_collision_node();
 		ERR_FAIL_COND_V(!col,NULL);
 
 		col->set_name(_fixstr(name,"colonly"));
-		col->cast_to<Spatial>()->set_transform(mi->get_transform());
+		Object::cast_to<Spatial>(col)->set_transform(mi->get_transform());
 		p_node->replace_by(col);
 		memdelete(p_node);
 		p_node=col;
 
-		StaticBody *sb = col->cast_to<StaticBody>();
+		StaticBody *sb = Object::cast_to<StaticBody>(col);
 		CollisionShape *colshape = memnew( CollisionShape);
 		colshape->set_shape(sb->get_shape(0));
 		colshape->set_name("shape");
@@ -1708,10 +1708,10 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 		colshape->set_owner(p_node->get_owner());
 
 
-	} else if (p_flags&SCENE_FLAG_CREATE_COLLISIONS &&_teststr(name,"col") && p_node->cast_to<MeshInstance>()) {
+	} else if (p_flags&SCENE_FLAG_CREATE_COLLISIONS &&_teststr(name,"col") && Object::cast_to<MeshInstance>(p_node)) {
 
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 		mi->set_name(_fixstr(name,"col"));
 		Node *col= mi->create_trimesh_collision_node();
@@ -1720,7 +1720,7 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 		col->set_name("col");
 		p_node->add_child(col);
 
-		StaticBody *sb=col->cast_to<StaticBody>();
+		StaticBody *sb=Object::cast_to<StaticBody>(col);
 		CollisionShape *colshape = memnew( CollisionShape);
 		colshape->set_shape(sb->get_shape(0));
 		colshape->set_name("shape");
@@ -1728,12 +1728,12 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 		colshape->set_owner(p_node->get_owner());
 		sb->set_owner(p_node->get_owner());
 
-	} else if (p_flags&SCENE_FLAG_CREATE_NAVMESH &&_teststr(name,"navmesh") && p_node->cast_to<MeshInstance>()) {
+	} else if (p_flags&SCENE_FLAG_CREATE_NAVMESH &&_teststr(name,"navmesh") && Object::cast_to<MeshInstance>(p_node)) {
 
 		if (isroot)
 			return p_node;
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 		Ref<Mesh> mesh=mi->get_mesh();
 		ERR_FAIL_COND_V(mesh.is_null(),NULL);
@@ -1744,7 +1744,7 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 		Ref<NavigationMesh> nmesh = memnew( NavigationMesh);
 		nmesh->create_from_mesh(mesh);
 		nmi->set_navigation_mesh(nmesh);
-		nmi->cast_to<Spatial>()->set_transform(mi->get_transform());
+		Object::cast_to<Spatial>(nmi)->set_transform(mi->get_transform());
 		p_node->replace_by(nmi);
 		memdelete(p_node);
 		p_node=nmi;
@@ -1754,7 +1754,7 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 			return p_node;
 
 		Node *owner = p_node->get_owner();
-		Spatial *s = p_node->cast_to<Spatial>();
+		Spatial *s = Object::cast_to<Spatial>(p_node);
 		VehicleBody *bv = memnew( VehicleBody );
 		String n = _fixstr(p_node->get_name(),"vehicle");
 		bv->set_name(n);
@@ -1775,7 +1775,7 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 			return p_node;
 
 		Node *owner = p_node->get_owner();
-		Spatial *s = p_node->cast_to<Spatial>();
+		Spatial *s = Object::cast_to<Spatial>(p_node);
 		VehicleWheel *bv = memnew( VehicleWheel );
 		String n = _fixstr(p_node->get_name(),"wheel");
 		bv->set_name(n);
@@ -1789,13 +1789,13 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 
 		p_node=bv;
 
-	} else if (p_flags&SCENE_FLAG_CREATE_ROOMS && _teststr(name,"room") && p_node->cast_to<MeshInstance>()) {
+	} else if (p_flags&SCENE_FLAG_CREATE_ROOMS && _teststr(name,"room") && Object::cast_to<MeshInstance>(p_node)) {
 
 
 		if (isroot)
 			return p_node;
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 		DVector<Face3> faces = mi->get_faces(VisualInstance::FACES_SOLID);
 
 
@@ -1820,7 +1820,7 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 		if (isroot)
 			return p_node;
 
-		Spatial *dummy = p_node->cast_to<Spatial>();
+		Spatial *dummy = Object::cast_to<Spatial>(p_node);
 		ERR_FAIL_COND_V(!dummy,NULL);
 
 		Room * room = memnew( Room );
@@ -1833,12 +1833,12 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 
 		room->compute_room_from_subtree();
 
-	} else if (p_flags&SCENE_FLAG_CREATE_PORTALS &&_teststr(name,"portal") && p_node->cast_to<MeshInstance>()) {
+	} else if (p_flags&SCENE_FLAG_CREATE_PORTALS &&_teststr(name,"portal") && Object::cast_to<MeshInstance>(p_node)) {
 
 		if (isroot)
 			return p_node;
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 		DVector<Face3> faces = mi->get_faces(VisualInstance::FACES_SOLID);
 
 		ERR_FAIL_COND_V(faces.size()==0,NULL);
@@ -1914,11 +1914,11 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 		memdelete(p_node);
 		p_node=portal;
 
-	} else if (p_node->cast_to<MeshInstance>()) {
+	} else if (Object::cast_to<MeshInstance>(p_node)) {
 
 		//last attempt, maybe collision insde the mesh data
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 		Ref<Mesh> mesh = mi->get_mesh();
 		if (!mesh.is_null()) {
@@ -2001,7 +2001,7 @@ void EditorSceneImportPlugin::_tag_import_paths(Node *p_scene,Node *p_node) {
 	NodePath path = p_scene->get_path_to(p_node);
 	p_node->set_import_path( path );
 
-	Spatial *snode=p_node->cast_to<Spatial>();
+	Spatial *snode=Object::cast_to<Spatial>(p_node);
 
 	if (snode) {
 
@@ -2089,7 +2089,7 @@ Error EditorSceneImportPlugin::import1(const Ref<ResourceImportMetadata>& p_from
 		Object *base = ObjectTypeDB::instance(type);
 		Node *base_node = NULL;
 		if (base)
-			base_node=base->cast_to<Node>();
+			base_node=Object::cast_to<Node>(base);
 
 		if (base_node) {
 
@@ -2113,7 +2113,7 @@ void EditorSceneImportPlugin::_create_clips(Node *scene, const Array& p_clips,bo
 
 	Node* n = scene->get_node(String("AnimationPlayer"));
 	ERR_FAIL_COND(!n);
-	AnimationPlayer *anim = n->cast_to<AnimationPlayer>();
+	AnimationPlayer *anim = Object::cast_to<AnimationPlayer>(n);
 	ERR_FAIL_COND(!anim);
 
 	if (!anim->has_animation("default"))
@@ -2242,7 +2242,7 @@ void EditorSceneImportPlugin::_filter_tracks(Node *scene, const String& p_text) 
 		return;
 		Node* n = scene->get_node(String("AnimationPlayer"));
 	ERR_FAIL_COND(!n);
-	AnimationPlayer *anim = n->cast_to<AnimationPlayer>();
+	AnimationPlayer *anim = Object::cast_to<AnimationPlayer>(n);
 	ERR_FAIL_COND(!anim);
 
 	Vector<String> strings = p_text.split("\n");
@@ -2360,7 +2360,7 @@ void EditorSceneImportPlugin::_optimize_animations(Node *scene, float p_max_lin_
 		return;
 		Node* n = scene->get_node(String("AnimationPlayer"));
 	ERR_FAIL_COND(!n);
-	AnimationPlayer *anim = n->cast_to<AnimationPlayer>();
+	AnimationPlayer *anim = Object::cast_to<AnimationPlayer>(n);
 	ERR_FAIL_COND(!anim);
 
 

--- a/tools/editor/io_plugins/editor_scene_importer_fbxconv.cpp
+++ b/tools/editor/io_plugins/editor_scene_importer_fbxconv.cpp
@@ -377,7 +377,7 @@ Error EditorSceneImporterFBXConv::_parse_nodes(State& state,const Array &p_nodes
 			print_line("IS SKELETON! ");
 		} else if (state.bones.has(id)) {
 			if (p_base)
-				node=p_base->cast_to<Spatial>();
+				node=Object::cast_to<Spatial>(p_base);
 			if (!state.bones[id].has_anim_chan) {
 				print_line("no has anim "+id);
 			}

--- a/tools/editor/io_plugins/editor_texture_import_plugin.cpp
+++ b/tools/editor/io_plugins/editor_texture_import_plugin.cpp
@@ -700,7 +700,7 @@ EditorTextureImportDialog::EditorTextureImportDialog(EditorTextureImportPlugin* 
 	VBoxContainer *source_vb=memnew(VBoxContainer);
 	MarginContainer *source_mc = vbc->add_margin_child(TTR("Source Texture(s):"),source_vb);
 
-	source_label = vbc->get_child(source_mc->get_index()-1)->cast_to<Label>();
+	source_label = Object::cast_to<Label>(vbc->get_child(source_mc->get_index()-1));
 
 	HBoxContainer *hbc = memnew( HBoxContainer );
 	source_vb->add_child(hbc);
@@ -730,7 +730,7 @@ EditorTextureImportDialog::EditorTextureImportDialog(EditorTextureImportPlugin* 
 
 	size->set_val(256);
 	size_mc=vbc->add_margin_child(TTR("Cell Size:"),size);
-	size_label=vbc->get_child(size_mc->get_index()-1)->cast_to<Label>();
+	size_label=Object::cast_to<Label>(vbc->get_child(size_mc->get_index()-1));
 
 
 	save_path = memnew( LineEdit );
@@ -1316,7 +1316,7 @@ Error EditorTextureImportPlugin::import2(const String& p_path, const Ref<Resourc
 				Ref<AtlasTexture> at;
 
 				if (ResourceCache::has(apath)) {
-					at = Ref<AtlasTexture>( ResourceCache::get(apath)->cast_to<AtlasTexture>() );
+					at = Ref<AtlasTexture>( Object::cast_to<AtlasTexture>(ResourceCache::get(apath)) );
 				} else {
 
 					at = Ref<AtlasTexture>( memnew( AtlasTexture ) );
@@ -1329,7 +1329,7 @@ Error EditorTextureImportPlugin::import2(const String& p_path, const Ref<Resourc
 			}
 		}
 		if (ResourceCache::has(p_path)) {
-			texture = Ref<ImageTexture> ( ResourceCache::get(p_path)->cast_to<ImageTexture>() );
+			texture = Ref<ImageTexture> ( Object::cast_to<ImageTexture>(ResourceCache::get(p_path)) );
 		} else {
 			texture = Ref<ImageTexture>( memnew( ImageTexture ) );
 		}
@@ -1343,7 +1343,7 @@ Error EditorTextureImportPlugin::import2(const String& p_path, const Ref<Resourc
 		if (ResourceCache::has(p_path)) {
 			Resource *r = ResourceCache::get(p_path);
 
-			texture = Ref<ImageTexture> ( r->cast_to<ImageTexture>() );
+			texture = Ref<ImageTexture> ( Object::cast_to<ImageTexture>(r) );
 
 			Image img;
 			Error err = img.load(src_path);

--- a/tools/editor/plugins/animation_player_editor_plugin.cpp
+++ b/tools/editor/plugins/animation_player_editor_plugin.cpp
@@ -666,8 +666,8 @@ void AnimationPlayerEditor::set_state(const Dictionary& p_state) {
 			return;
 
 		Node *n = EditorNode::get_singleton()->get_edited_scene()->get_node(p_state["player"]);
-		if (n && n->cast_to<AnimationPlayer>()) {
-			player=n->cast_to<AnimationPlayer>();
+		if (Object::cast_to<AnimationPlayer>(n)) {
+			player=Object::cast_to<AnimationPlayer>(n);
 			_update_player();
 			show();
 			set_process(true);
@@ -756,9 +756,9 @@ void AnimationPlayerEditor::_dialog_action(String p_file) {
 			if (current != "") {
 				Ref<Animation> anim = player->get_animation(current);
 
-				ERR_FAIL_COND(!anim->cast_to<Resource>())
+				ERR_FAIL_COND(!Object::cast_to<Resource>(*anim))
 
-					RES current_res = RES(anim->cast_to<Resource>());
+				RES current_res = RES(Object::cast_to<Resource>(*anim));
 
 				_animation_save_in_path(current_res, p_file);
 			}
@@ -1514,7 +1514,7 @@ void AnimationPlayerEditorPlugin::edit(Object *p_object) {
 	anim_editor->set_undo_redo(&get_undo_redo());
 	if (!p_object)
 		return;
-	anim_editor->edit(p_object->cast_to<AnimationPlayer>());
+	anim_editor->edit(Object::cast_to<AnimationPlayer>(p_object));
 }
 
 bool AnimationPlayerEditorPlugin::handles(Object *p_object) const {

--- a/tools/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/tools/editor/plugins/animation_tree_editor_plugin.cpp
@@ -291,9 +291,9 @@ void AnimationTreeEditor::_popup_edit_dialog() {
 
 			case AnimationTreePlayer::NODE_ANIMATION:
 
-				if (anim_tree->get_master_player()!=NodePath() && anim_tree->has_node(anim_tree->get_master_player())  && anim_tree->get_node(anim_tree->get_master_player())->cast_to<AnimationPlayer>()) {
+				if (anim_tree->get_master_player()!=NodePath() && anim_tree->has_node(anim_tree->get_master_player())  && Object::cast_to<AnimationPlayer>(anim_tree->get_node(anim_tree->get_master_player()))) {
 
-					AnimationPlayer *ap = anim_tree->get_node(anim_tree->get_master_player())->cast_to<AnimationPlayer>();
+					AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(anim_tree->get_node(anim_tree->get_master_player()));
 					master_anim_popup->clear();
 					master_anim_popup->add_item("Edit Filters");
 					master_anim_popup->add_separator();
@@ -1274,7 +1274,7 @@ void AnimationTreeEditor::_edit_filters() {
 
 			if (np.get_property()!=StringName()) {
 				Node *n = base->get_node(np);
-				Skeleton *s = n->cast_to<Skeleton>();
+				Skeleton *s = Object::cast_to<Skeleton>(n);
 				if (s) {
 
 					String skelbase = E->get().substr(0,E->get().find(":"));
@@ -1492,7 +1492,7 @@ AnimationTreeEditor::AnimationTreeEditor() {
 
 void AnimationTreeEditorPlugin::edit(Object *p_object) {
 
-	anim_tree_editor->edit(p_object->cast_to<AnimationTreePlayer>());
+	anim_tree_editor->edit(Object::cast_to<AnimationTreePlayer>(p_object));
 
 }
 

--- a/tools/editor/plugins/baked_light_baker.cpp
+++ b/tools/editor/plugins/baked_light_baker.cpp
@@ -272,16 +272,16 @@ void BakedLightBaker::_add_mesh(const Ref<Mesh>& p_mesh,const Ref<Material>& p_m
 
 void BakedLightBaker::_parse_geometry(Node* p_node) {
 
-	if (p_node->cast_to<MeshInstance>()) {
+	if (Object::cast_to<MeshInstance>(p_node)) {
 
-		MeshInstance *meshi=p_node->cast_to<MeshInstance>();
+		MeshInstance *meshi=Object::cast_to<MeshInstance>(p_node);
 		Ref<Mesh> mesh=meshi->get_mesh();
 		if (mesh.is_valid()) {
 			_add_mesh(mesh,meshi->get_material_override(),base_inv * meshi->get_global_transform(),meshi->get_baked_light_texture_id());
 		}
-	} else if (p_node->cast_to<Light>()) {
+	} else if (Object::cast_to<Light>(p_node)) {
 
-		Light *dl=p_node->cast_to<Light>();
+		Light *dl=Object::cast_to<Light>(p_node);
 
 		if (dl->get_bake_mode()!=Light::BAKE_MODE_DISABLED) {
 
@@ -311,9 +311,9 @@ void BakedLightBaker::_parse_geometry(Node* p_node) {
 			lights.push_back(dirl);
 		}
 
-	} else if (p_node->cast_to<Spatial>()){
+	} else if (Object::cast_to<Spatial>(p_node)){
 
-		Spatial *sp = p_node->cast_to<Spatial>();
+		Spatial *sp = Object::cast_to<Spatial>(p_node);
 
 		Array arr = p_node->call("_get_baked_light_meshes");
 		for(int i=0;i<arr.size();i+=2) {
@@ -1715,7 +1715,7 @@ void BakedLightBaker::bake(const Ref<BakedLight> &p_light, Node* p_node) {
 		return;
 	cell_count=0;
 
-	base_inv=p_node->cast_to<Spatial>()->get_global_transform().affine_inverse();
+	base_inv=Object::cast_to<Spatial>(p_node)->get_global_transform().affine_inverse();
 	EditorProgress ep("bake",TTR("Light Baker Setup:"),5);
 	baked_light=p_light;
 	lattice_size=baked_light->get_initial_lattice_subdiv();

--- a/tools/editor/plugins/baked_light_editor_plugin.cpp
+++ b/tools/editor/plugins/baked_light_editor_plugin.cpp
@@ -305,7 +305,7 @@ BakedLightEditor::~BakedLightEditor() {
 
 void BakedLightEditorPlugin::edit(Object *p_object) {
 
-	baked_light_editor->edit(p_object->cast_to<BakedLightInstance>());
+	baked_light_editor->edit(Object::cast_to<BakedLightInstance>(p_object));
 }
 
 bool BakedLightEditorPlugin::handles(Object *p_object) const {

--- a/tools/editor/plugins/camera_editor_plugin.cpp
+++ b/tools/editor/plugins/camera_editor_plugin.cpp
@@ -102,8 +102,8 @@ CameraEditor::CameraEditor() {
 
 void CameraEditorPlugin::edit(Object *p_object) {
 
-	SpatialEditor::get_singleton()->set_can_preview(p_object->cast_to<Camera>());
-	//camera_editor->edit(p_object->cast_to<Node>());
+	SpatialEditor::get_singleton()->set_can_preview(Object::cast_to<Camera>(p_object));
+	//camera_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool CameraEditorPlugin::handles(Object *p_object) const {
@@ -114,7 +114,7 @@ bool CameraEditorPlugin::handles(Object *p_object) const {
 void CameraEditorPlugin::make_visible(bool p_visible) {
 
 	if (p_visible) {
-//	SpatialEditor::get_singleton()->set_can_preview(p_object->cast_to<Camera>());
+//	SpatialEditor::get_singleton()->set_can_preview(Object::cast_to<Camera>(p_object));
 
 	} else {
 

--- a/tools/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/tools/editor/plugins/canvas_item_editor_plugin.cpp
@@ -162,7 +162,7 @@ void CanvasItemEditor::_edit_set_pivot(const Vector2& mouse_pos) {
 
 	for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-		Node2D *n2d = E->get()->cast_to<Node2D>();
+		Node2D *n2d = Object::cast_to<Node2D>(E->get());
 
 		if (n2d && n2d->edit_has_pivot()) {
 
@@ -178,7 +178,7 @@ void CanvasItemEditor::_edit_set_pivot(const Vector2& mouse_pos) {
 			undo_redo->add_undo_method(n2d,"set_global_pos",gpos);
 			undo_redo->add_undo_method(n2d,"edit_set_pivot",offset);
 			for(int i=0;i<n2d->get_child_count();i++) {
-				Node2D *n2dc = n2d->get_child(i)->cast_to<Node2D>();
+				Node2D *n2dc = Object::cast_to<Node2D>(n2d->get_child(i));
 				if (!n2dc)
 					continue;
 
@@ -247,7 +247,7 @@ void CanvasItemEditor::_tool_select(int p_index) {
 
 Object *CanvasItemEditor::_get_editor_data(Object *p_what) {
 
-	CanvasItem *ci = p_what->cast_to<CanvasItem>();
+	CanvasItem *ci = Object::cast_to<CanvasItem>(p_what);
 	if (!ci)
 		return NULL;
 
@@ -388,7 +388,7 @@ void CanvasItemEditor::_visibility_changed(ObjectID p_canvas_item) {
 	Object *c = ObjectDB::get_instance(p_canvas_item);
 	if (!c)
 		return;
-	CanvasItem *ct = c->cast_to<CanvasItem>();
+	CanvasItem *ct = Object::cast_to<CanvasItem>(c);
 	if (!ct)
 		return;
 	canvas_items.erase(ct);
@@ -429,10 +429,10 @@ CanvasItem* CanvasItemEditor::_select_canvas_item_at_pos(const Point2& p_pos,Nod
 
 	if (!p_node)
 		return NULL;
-	if (p_node->cast_to<Viewport>())
+	if (Object::cast_to<Viewport>(p_node))
 		return NULL;
 
-	CanvasItem *c=p_node->cast_to<CanvasItem>();
+	CanvasItem *c=Object::cast_to<CanvasItem>(p_node);
 
 
 	for (int i=p_node->get_child_count()-1;i>=0;i--) {
@@ -442,7 +442,7 @@ CanvasItem* CanvasItemEditor::_select_canvas_item_at_pos(const Point2& p_pos,Nod
 		if (c && !c->is_set_as_toplevel())
 			r=_select_canvas_item_at_pos(p_pos,p_node->get_child(i),p_parent_xform * c->get_transform(),p_canvas_xform);
 		else {
-			CanvasLayer *cl = p_node->cast_to<CanvasLayer>();
+			CanvasLayer *cl = Object::cast_to<CanvasLayer>(p_node);
 			r=_select_canvas_item_at_pos(p_pos,p_node->get_child(i),transform ,cl ? cl->get_transform() : p_canvas_xform); //use base transform
 		}
 
@@ -450,7 +450,7 @@ CanvasItem* CanvasItemEditor::_select_canvas_item_at_pos(const Point2& p_pos,Nod
 			return r;
 	}
 
-	if (c && c->is_visible() && !c->has_meta("_edit_lock_") && !_is_part_of_subscene(c) && !c->cast_to<CanvasLayer>()) {
+	if (c && c->is_visible() && !c->has_meta("_edit_lock_") && !_is_part_of_subscene(c) && !Object::cast_to<CanvasLayer>(c)) {
 
 		Rect2 rect = c->get_item_rect();
 		Point2 local_pos = (p_parent_xform * p_canvas_xform * c->get_transform()).affine_inverse().xform(p_pos);
@@ -467,30 +467,30 @@ CanvasItem* CanvasItemEditor::_select_canvas_item_at_pos(const Point2& p_pos,Nod
 void CanvasItemEditor::_find_canvas_items_at_pos(const Point2 &p_pos,Node* p_node,const Matrix32& p_parent_xform,const Matrix32& p_canvas_xform, Vector<_SelectResult> &r_items) {
 	if (!p_node)
 		return;
-	if (p_node->cast_to<Viewport>())
+	if (Object::cast_to<Viewport>(p_node))
 		return;
 
-	CanvasItem *c=p_node->cast_to<CanvasItem>();
+	CanvasItem *c=Object::cast_to<CanvasItem>(p_node);
 
 	for (int i=p_node->get_child_count()-1;i>=0;i--) {
 
 		if (c && !c->is_set_as_toplevel())
 			_find_canvas_items_at_pos(p_pos,p_node->get_child(i),p_parent_xform * c->get_transform(),p_canvas_xform, r_items);
 		else {
-			CanvasLayer *cl = p_node->cast_to<CanvasLayer>();
+			CanvasLayer *cl = Object::cast_to<CanvasLayer>(p_node);
 			_find_canvas_items_at_pos(p_pos,p_node->get_child(i),transform ,cl ? cl->get_transform() : p_canvas_xform, r_items); //use base transform
 		}
 	}
 
 
-	if (c && c->is_visible() && !c->has_meta("_edit_lock_") && !c->cast_to<CanvasLayer>()) {
+	if (c && c->is_visible() && !c->has_meta("_edit_lock_") && !Object::cast_to<CanvasLayer>(c)) {
 
 		Rect2 rect = c->get_item_rect();
 		Point2 local_pos = (p_parent_xform * p_canvas_xform * c->get_transform()).affine_inverse().xform(p_pos);
 
 
 		if (rect.has_point(local_pos)) {
-			Node2D *node=c->cast_to<Node2D>();
+			Node2D *node=Object::cast_to<Node2D>(c);
 
 			_SelectResult res;
 			res.item=c;
@@ -508,10 +508,10 @@ void CanvasItemEditor::_find_canvas_items_at_rect(const Rect2& p_rect,Node* p_no
 
 	if (!p_node)
 		return;
-	if (p_node->cast_to<Viewport>())
+	if (Object::cast_to<Viewport>(p_node))
 		return;
 
-	CanvasItem *c=p_node->cast_to<CanvasItem>();
+	CanvasItem *c=Object::cast_to<CanvasItem>(p_node);
 
 
 	for (int i=p_node->get_child_count()-1;i>=0;i--) {
@@ -519,13 +519,13 @@ void CanvasItemEditor::_find_canvas_items_at_rect(const Rect2& p_rect,Node* p_no
 		if (c && !c->is_set_as_toplevel())
 			_find_canvas_items_at_rect(p_rect,p_node->get_child(i),p_parent_xform * c->get_transform(),p_canvas_xform,r_items);
 		else {
-			CanvasLayer *cl = p_node->cast_to<CanvasLayer>();
+			CanvasLayer *cl = Object::cast_to<CanvasLayer>(p_node);
 			_find_canvas_items_at_rect(p_rect,p_node->get_child(i),transform,cl?cl->get_transform():p_canvas_xform,r_items);
 		}
 	}
 
 
-	if (c && c->is_visible() && !c->has_meta("_edit_lock_") && !c->cast_to<CanvasLayer>()) {
+	if (c && c->is_visible() && !c->has_meta("_edit_lock_") && !Object::cast_to<CanvasLayer>(c)) {
 
 		Rect2 rect = c->get_item_rect();
 		Matrix32 xform = p_parent_xform * p_canvas_xform * c->get_transform();
@@ -610,7 +610,7 @@ bool CanvasItemEditor::_select(CanvasItem *item, Point2 p_click_pos, bool p_appe
 
 			for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-				CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 				if (!canvas_item || !canvas_item->is_visible())
 					continue;
 				if (canvas_item->get_viewport()!=EditorNode::get_singleton()->get_scene_root())
@@ -621,8 +621,8 @@ bool CanvasItemEditor::_select(CanvasItem *item, Point2 p_click_pos, bool p_appe
 					continue;
 
 				se->undo_state=canvas_item->edit_get_state();
-				if (canvas_item->cast_to<Node2D>())
-					se->undo_pivot=canvas_item->cast_to<Node2D>()->edit_get_pivot();
+				if (Object::cast_to<Node2D>(canvas_item))
+					se->undo_pivot=Object::cast_to<Node2D>(canvas_item)->edit_get_pivot();
 
 			}
 
@@ -653,7 +653,7 @@ void CanvasItemEditor::_key_move(const Vector2& p_dir, bool p_snap, KeyMoveMODE 
 
 	for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-		CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+		CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 		if (!canvas_item || !canvas_item->is_visible())
 			continue;
 		if (canvas_item->get_viewport()!=EditorNode::get_singleton()->get_scene_root())
@@ -683,7 +683,7 @@ void CanvasItemEditor::_key_move(const Vector2& p_dir, bool p_snap, KeyMoveMODE 
 
 		} else { // p_move_mode==MOVE_LOCAL_BASE || p_move_mode==MOVE_LOCAL_WITH_ROT
 
-			if (Node2D *node_2d = canvas_item->cast_to<Node2D>()) {
+			if (Node2D *node_2d = Object::cast_to<Node2D>(canvas_item)) {
 
 				if (p_move_mode == MOVE_LOCAL_WITH_ROT) {
 					Matrix32 m;
@@ -692,7 +692,7 @@ void CanvasItemEditor::_key_move(const Vector2& p_dir, bool p_snap, KeyMoveMODE 
 				}
 				node_2d->set_pos(node_2d->get_pos() + drag);
 
-			} else if (Control *control = canvas_item->cast_to<Control>()) {
+			} else if (Control *control = Object::cast_to<Control>(canvas_item)) {
 
 				control->set_pos(control->get_pos()+drag);
 			}
@@ -715,7 +715,7 @@ Point2 CanvasItemEditor::_find_topleftmost_point() {
 
 	for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-		CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+		CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 		if (!canvas_item || !canvas_item->is_visible())
 			continue;
 		if (canvas_item->get_viewport()!=EditorNode::get_singleton()->get_scene_root())
@@ -746,7 +746,7 @@ int CanvasItemEditor::get_item_count() {
 	int ic=0;
 	for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-		CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+		CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 		if (!canvas_item || !canvas_item->is_visible())
 			continue;
 
@@ -768,7 +768,7 @@ CanvasItem *CanvasItemEditor::get_single_item() {
 
 	for(Map<Node*,Object*>::Element *E=selection.front();E;E=E->next()) {
 
-		CanvasItem *canvas_item = E->key()->cast_to<CanvasItem>();
+		CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->key());
 		if (!canvas_item || !canvas_item->is_visible())
 			continue;
 		if (canvas_item->get_viewport()!=EditorNode::get_singleton()->get_scene_root())
@@ -1123,7 +1123,7 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 
 					for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-						CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+						CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 						if (!canvas_item || !canvas_item->is_visible())
 							continue;
 						if (canvas_item->get_viewport()!=EditorNode::get_singleton()->get_scene_root())
@@ -1135,8 +1135,8 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 							continue;
 
 						canvas_item->edit_set_state(se->undo_state);
-						if (canvas_item->cast_to<Node2D>())
-							canvas_item->cast_to<Node2D>()->edit_set_pivot(se->undo_pivot);
+						if (Object::cast_to<Node2D>(canvas_item))
+							Object::cast_to<Node2D>(canvas_item)->edit_set_pivot(se->undo_pivot);
 
 					}
 				}
@@ -1151,7 +1151,7 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 			} else if (b.pressed) {
 #if 0
 				ref_item = NULL;
-				Node* scene = get_scene()->get_root_node()->cast_to<EditorNode>()->get_edited_scene();
+				Node* scene = Object::cast_to<EditorNode>(get_scene()->get_root_node())->get_edited_scene();
 				if ( scene ) ref_item =_select_canvas_item_at_pos( Point2( b.x, b.y ), scene, transform );
 #endif
 				//popup->set_pos(Point2(b.x,b.y));
@@ -1218,7 +1218,7 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 
 						for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-							CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+							CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 							if (!canvas_item || !canvas_item->is_visible())
 								continue;
 							if (canvas_item->get_viewport()!=EditorNode::get_singleton()->get_scene_root())
@@ -1231,8 +1231,7 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 							Variant state=canvas_item->edit_get_state();
 							undo_redo->add_do_method(canvas_item,"edit_set_state",state);
 							undo_redo->add_undo_method(canvas_item,"edit_set_state",se->undo_state);
-							if (canvas_item->cast_to<Node2D>()) {
-								Node2D *pvt = canvas_item->cast_to<Node2D>();
+							if (Node2D *pvt = Object::cast_to<Node2D>(canvas_item)) {
 								if (pvt->edit_has_pivot()) {
 									undo_redo->add_do_method(canvas_item,"edit_set_pivot",pvt->edit_get_pivot());
 									undo_redo->add_undo_method(canvas_item,"edit_set_pivot",se->undo_pivot);
@@ -1311,7 +1310,7 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 				Node2D *b=NULL;
 				Object* obj=ObjectDB::get_instance(Cbone->get().bone);
 				if (obj)
-					b=obj->cast_to<Node2D>();
+					b=Object::cast_to<Node2D>(obj);
 
 				if (b) {
 
@@ -1328,7 +1327,7 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 							break;
 
 						float len=pi->get_global_transform().get_origin().distance_to(b->get_global_pos());
-						b=pi->cast_to<Node2D>();
+						b=Object::cast_to<Node2D>(pi);
 						if (!b)
 							break;
 
@@ -1380,8 +1379,8 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 				drag=DRAG_ROTATE;
 				drag_from=transform.affine_inverse().xform(click);
 				se->undo_state=canvas_item->edit_get_state();
-				if (canvas_item->cast_to<Node2D>())
-					se->undo_pivot=canvas_item->cast_to<Node2D>()->edit_get_pivot();
+				if (Object::cast_to<Node2D>(canvas_item))
+					se->undo_pivot=Object::cast_to<Node2D>(canvas_item)->edit_get_pivot();
 				return;
 			}
 
@@ -1404,8 +1403,8 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 				if (drag!=DRAG_NONE && (!Cbone || drag!=DRAG_ALL)) {
 					drag_from=transform.affine_inverse().xform(click);
 					se->undo_state=canvas_item->edit_get_state();
-					if (canvas_item->cast_to<Node2D>())
-						se->undo_pivot=canvas_item->cast_to<Node2D>()->edit_get_pivot();
+					if (Object::cast_to<Node2D>(canvas_item))
+						se->undo_pivot=Object::cast_to<Node2D>(canvas_item)->edit_get_pivot();
 
 					return;
 				}
@@ -1427,7 +1426,7 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 
 			for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-				CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 				if (!canvas_item || !canvas_item->is_visible())
 					continue;
 				if (canvas_item->get_viewport()!=EditorNode::get_singleton()->get_scene_root())
@@ -1438,8 +1437,8 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 					continue;
 
 				se->undo_state=canvas_item->edit_get_state();
-				if (canvas_item->cast_to<Node2D>())
-					se->undo_pivot=canvas_item->cast_to<Node2D>()->edit_get_pivot();
+				if (Object::cast_to<Node2D>(canvas_item))
+					se->undo_pivot=Object::cast_to<Node2D>(canvas_item)->edit_get_pivot();
 
 			}
 
@@ -1467,7 +1466,7 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 
 			Object* obj=ObjectDB::get_instance(Cbone->get().bone);
 			if (obj)
-				c=obj->cast_to<CanvasItem>();
+				c=Object::cast_to<CanvasItem>(obj);
 			if (c)
 				c=c->get_parent_item();
 
@@ -1492,7 +1491,7 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 		while ((n && n != scene && n->get_owner() != scene) || (n && !n->is_type("CanvasItem"))) {
 			n = n->get_parent();
 		};
-		c = n->cast_to<CanvasItem>();
+		c = Object::cast_to<CanvasItem>(n);
 #if 0
 		if ( b.pressed ) box_selection_start( click );
 #endif
@@ -1537,7 +1536,7 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 
 		for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-			CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+			CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 			if (!canvas_item || !canvas_item->is_visible())
 				continue;
 			if (canvas_item->get_viewport()!=EditorNode::get_singleton()->get_scene_root())
@@ -1552,8 +1551,8 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 
 			if (!dragging_bone) {
 				canvas_item->edit_set_state(se->undo_state); //reset state and reapply
-				if (canvas_item->cast_to<Node2D>())
-					canvas_item->cast_to<Node2D>()->edit_set_pivot(se->undo_pivot);
+				if (Object::cast_to<Node2D>(canvas_item))
+					Object::cast_to<Node2D>(canvas_item)->edit_set_pivot(se->undo_pivot);
 			}
 
 
@@ -1566,7 +1565,7 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 			if (drag==DRAG_ROTATE) {
 
 				Vector2 center = canvas_item->get_global_transform_with_canvas().get_origin();
-				if (Node2D *node = canvas_item->cast_to<Node2D>()) {
+				if (Node2D *node = Object::cast_to<Node2D>(canvas_item)) {
 					Matrix32 rot;
 					rot.elements[1] = (dfrom - center).normalized();
 					rot.elements[0] = rot.elements[1].tangent();
@@ -1676,8 +1675,7 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 				} break;
 				case DRAG_PIVOT: {
 
-					if (canvas_item->cast_to<Node2D>()) {
-						Node2D *n2d =canvas_item->cast_to<Node2D>();
+					if (Node2D *n2d =Object::cast_to<Node2D>(canvas_item)) {
 						n2d->edit_set_pivot(se->undo_pivot+drag_vector);
 
 					}
@@ -1701,7 +1699,7 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent& p_event) {
 
 
 
-				Node2D *n2d = canvas_item->cast_to<Node2D>();
+				Node2D *n2d = Object::cast_to<Node2D>(canvas_item);
 				Matrix32 final_xform = bone_orig_xform;
 
 
@@ -1925,7 +1923,7 @@ void CanvasItemEditor::_viewport_draw() {
 	for(Map<Node*,Object*>::Element *E=selection.front();E;E=E->next()) {
 
 
-		CanvasItem *canvas_item = E->key()->cast_to<CanvasItem>();
+		CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->key());
 		if (!canvas_item || !canvas_item->is_visible())
 			continue;
 		if (canvas_item->get_viewport()!=EditorNode::get_singleton()->get_scene_root())
@@ -1967,10 +1965,10 @@ void CanvasItemEditor::_viewport_draw() {
 
 		if (single && (tool==TOOL_SELECT || tool == TOOL_MOVE || tool == TOOL_ROTATE || tool==TOOL_EDIT_PIVOT)) { //kind of sucks
 
-			if (canvas_item->cast_to<Node2D>()) {
+			if (Node2D *n2d = Object::cast_to<Node2D>(canvas_item)) {
 
 
-				if (canvas_item->cast_to<Node2D>()->edit_has_pivot()) {
+				if (n2d->edit_has_pivot()) {
 					viewport->draw_texture(pivot,xform.get_origin()+(-pivot->get_size()/2).floor());
 					can_move_pivot=true;
 					pivot_found=true;
@@ -2080,7 +2078,7 @@ void CanvasItemEditor::_viewport_draw() {
 		if (!obj)
 			continue;
 
-		Node2D* n2d = obj->cast_to<Node2D>();
+		Node2D* n2d = Object::cast_to<Node2D>(obj);
 		if (!n2d)
 			continue;
 
@@ -2090,7 +2088,7 @@ void CanvasItemEditor::_viewport_draw() {
 		CanvasItem *pi = n2d->get_parent_item();
 
 
-		Node2D* pn2d=n2d->get_parent()->cast_to<Node2D>();
+		Node2D* pn2d=Object::cast_to<Node2D>(n2d->get_parent());
 
 		if (!pn2d)
 			continue;
@@ -2149,14 +2147,14 @@ void CanvasItemEditor::_notification(int p_what) {
 
 		for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-			CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+			CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 			if (!canvas_item || !canvas_item->is_visible())
 				continue;
 
 			if (canvas_item->get_viewport()!=EditorNode::get_singleton()->get_scene_root())
 				continue;
 
-			if (canvas_item->cast_to<Control>())
+			if (Object::cast_to<Control>(canvas_item))
 				has_control=true;
 			else
 				all_control=false;
@@ -2194,7 +2192,7 @@ void CanvasItemEditor::_notification(int p_what) {
 				break;
 			}
 
-			Node2D *b2 = b->cast_to<Node2D>();
+			Node2D *b2 = Object::cast_to<Node2D>(b);
 			if (!b2) {
 				continue;
 			}
@@ -2289,7 +2287,7 @@ void CanvasItemEditor::_find_canvas_items_span(Node *p_node, Rect2& r_rect, cons
 	if (!p_node)
 		return;
 
-	CanvasItem *c=p_node->cast_to<CanvasItem>();
+	CanvasItem *c=Object::cast_to<CanvasItem>(p_node);
 
 
 	for (int i=p_node->get_child_count()-1;i>=0;i--) {
@@ -2467,7 +2465,7 @@ void CanvasItemEditor::_set_anchor(Control::AnchorType p_left,Control::AnchorTyp
 	undo_redo->create_action(TTR("Change Anchors"));
 	for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-		Control *c = E->get()->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(E->get());
 
 		undo_redo->add_do_method(c,"set_anchor",MARGIN_LEFT,p_left);
 		undo_redo->add_do_method(c,"set_anchor",MARGIN_TOP,p_top);
@@ -2559,7 +2557,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-				CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 				if (!canvas_item || !canvas_item->is_visible())
 					continue;
 
@@ -2577,7 +2575,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-				CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 				if (!canvas_item || !canvas_item->is_visible())
 					continue;
 
@@ -2598,7 +2596,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-				CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 				if (!canvas_item || !canvas_item->is_visible())
 					continue;
 
@@ -2616,7 +2614,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-				CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 				if (!canvas_item || !canvas_item->is_visible())
 					continue;
 
@@ -2637,7 +2635,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-				CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 				if (!canvas_item || !canvas_item->is_visible())
 					continue;
 
@@ -2645,7 +2643,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 					continue;
 
 
-				Control *c = canvas_item->cast_to<Control>();
+				Control *c = Object::cast_to<Control>(canvas_item);
 				if (!c)
 					continue;
 				c->set_area_as_parent_rect();
@@ -2758,15 +2756,14 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			for(Map<Node*,Object*>::Element *E=selection.front();E;E=E->next()) {
 
-				CanvasItem *canvas_item = E->key()->cast_to<CanvasItem>();
+				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->key());
 				if (!canvas_item || !canvas_item->is_visible())
 					continue;
 
 				if (canvas_item->get_viewport()!=EditorNode::get_singleton()->get_scene_root())
 					continue;
 
-				if (canvas_item->cast_to<Node2D>()) {
-					Node2D *n2d = canvas_item->cast_to<Node2D>();
+				if (Node2D *n2d = Object::cast_to<Node2D>(canvas_item)) {
 
 					if (key_pos)
 						AnimationPlayerEditor::singleton->get_key_editor()->insert_node_value_key(n2d,"transform/pos",n2d->get_pos(),existing);
@@ -2780,7 +2777,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 						//look for an IK chain
 						List<Node2D*> ik_chain;
 
-						Node2D *n = n2d->get_parent_item()->cast_to<Node2D>();
+						Node2D *n = Object::cast_to<Node2D>(n2d->get_parent_item());
 						bool has_chain=false;
 
 						while(n) {
@@ -2793,7 +2790,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 							if (!n->get_parent_item())
 								break;
-							n=n->get_parent_item()->cast_to<Node2D>();
+							n=Object::cast_to<Node2D>(n->get_parent_item());
 						}
 
 						if (has_chain && ik_chain.size()) {
@@ -2812,9 +2809,9 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 						}
 					}
 
-				} else if (canvas_item->cast_to<Control>()) {
+				} else if (Object::cast_to<Control>(canvas_item)) {
 
-					Control *ctrl = canvas_item->cast_to<Control>();
+					Control *ctrl = Object::cast_to<Control>(canvas_item);
 
 					if (key_pos)
 						AnimationPlayerEditor::singleton->get_key_editor()->insert_node_value_key(ctrl,"rect/pos",ctrl->get_pos(),existing);
@@ -2871,7 +2868,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			for(Map<Node*,Object*>::Element *E=selection.front();E;E=E->next()) {
 
-				CanvasItem *canvas_item = E->key()->cast_to<CanvasItem>();
+				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->key());
 				if (!canvas_item || !canvas_item->is_visible())
 					continue;
 
@@ -2879,9 +2876,8 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 					continue;
 
 
-				if (canvas_item->cast_to<Node2D>()) {
+				if (Node2D *n2d = Object::cast_to<Node2D>(canvas_item)) {
 
-					Node2D *n2d = canvas_item->cast_to<Node2D>();
 					PoseClipboard pc;
 					pc.pos=n2d->get_pos();
 					pc.rot=n2d->get_rot();
@@ -2904,7 +2900,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 				Object *o = ObjectDB::get_instance(E->get().id);
 				if (!o)
 					continue;
-				Node2D *n2d = o->cast_to<Node2D>();
+				Node2D *n2d = Object::cast_to<Node2D>(o);
 				if (!n2d)
 					continue;
 				undo_redo->add_do_method(n2d,"set_pos",E->get().pos);
@@ -2923,15 +2919,14 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			for(Map<Node*,Object*>::Element *E=selection.front();E;E=E->next()) {
 
-				CanvasItem *canvas_item = E->key()->cast_to<CanvasItem>();
+				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->key());
 				if (!canvas_item || !canvas_item->is_visible())
 					continue;
 
 				if (canvas_item->get_viewport()!=EditorNode::get_singleton()->get_scene_root())
 					continue;
 
-				if (canvas_item->cast_to<Node2D>()) {
-					Node2D *n2d = canvas_item->cast_to<Node2D>();
+				if (Node2D *n2d = Object::cast_to<Node2D>(canvas_item)) {
 
 					if (key_pos)
 						n2d->set_pos(Vector2());
@@ -2939,9 +2934,9 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 						n2d->set_rot(0);
 					if (key_scale)
 						n2d->set_scale(Vector2(1,1));
-				} else if (canvas_item->cast_to<Control>()) {
+				} else if (Object::cast_to<Control>(canvas_item)) {
 
-					Control *ctrl = canvas_item->cast_to<Control>();
+					Control *ctrl = Object::cast_to<Control>(canvas_item);
 
 					if (key_pos)
 						ctrl->set_pos(Point2());
@@ -2962,7 +2957,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			Map<Node*,Object*> &selection = editor_selection->get_selection();
 			for(Map<Node*,Object*>::Element *E=selection.front();E;E=E->next()) {
-				CanvasItem *canvas_item = E->key()->cast_to<CanvasItem>();
+				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->key());
 				if (!canvas_item) continue;
 				if (canvas_item->get_viewport()!=EditorNode::get_singleton()->get_scene_root())
 					continue;
@@ -3017,7 +3012,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			for(Map<Node*,Object*>::Element *E=selection.front();E;E=E->next()) {
 
-				Node2D *n2d = E->key()->cast_to<Node2D>();
+				Node2D *n2d = Object::cast_to<Node2D>(E->key());
 				if (!n2d)
 					continue;
 				if (!n2d->is_visible())
@@ -3037,7 +3032,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			for(Map<Node*,Object*>::Element *E=selection.front();E;E=E->next()) {
 
-				Node2D *n2d = E->key()->cast_to<Node2D>();
+				Node2D *n2d = Object::cast_to<Node2D>(E->key());
 				if (!n2d)
 					continue;
 				if (!n2d->is_visible())
@@ -3055,7 +3050,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-				CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 				if (!canvas_item || !canvas_item->is_visible())
 					continue;
 
@@ -3075,7 +3070,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			for(Map<Node*,Object*>::Element *E=selection.front();E;E=E->next()) {
 
-				CanvasItem *n2d = E->key()->cast_to<CanvasItem>();
+				CanvasItem *n2d = Object::cast_to<CanvasItem>(E->key());
 				if (!n2d)
 					continue;
 				if (!n2d->is_visible())
@@ -3174,7 +3169,7 @@ void CanvasItemEditor::box_selection_start( Point2 &click ) {
 bool CanvasItemEditor::box_selection_end() {
 	print_line( "box selection end" );
 
-	Node* scene = get_scene()->get_root_node()->cast_to<EditorNode>()->get_edited_scene();
+	Node* scene = Object::cast_to<EditorNode>(get_scene()->get_root_node())->get_edited_scene();
 	if (scene) {
 
 		List<CanvasItem*> selitems;
@@ -3513,7 +3508,7 @@ CanvasItemEditor *CanvasItemEditor::singleton=NULL;
 void CanvasItemEditorPlugin::edit(Object *p_object) {
 
 	canvas_item_editor->set_undo_redo(&get_undo_redo());
-	canvas_item_editor->edit(p_object->cast_to<CanvasItem>());
+	canvas_item_editor->edit(Object::cast_to<CanvasItem>(p_object));
 }
 
 bool CanvasItemEditorPlugin::handles(Object *p_object) const {

--- a/tools/editor/plugins/collision_polygon_2d_editor_plugin.cpp
+++ b/tools/editor/plugins/collision_polygon_2d_editor_plugin.cpp
@@ -352,7 +352,7 @@ void CollisionPolygon2DEditor::edit(Node *p_collision_polygon) {
 
 	if (p_collision_polygon) {
 
-		node=p_collision_polygon->cast_to<CollisionPolygon2D>();
+		node=Object::cast_to<CollisionPolygon2D>(p_collision_polygon);
 		if (!canvas_item_editor->get_viewport_control()->is_connected("draw",this,"_canvas_draw"))
 			canvas_item_editor->get_viewport_control()->connect("draw",this,"_canvas_draw");
 		wip.clear();
@@ -417,7 +417,7 @@ CollisionPolygon2DEditor::CollisionPolygon2DEditor(EditorNode *p_editor) {
 
 void CollisionPolygon2DEditorPlugin::edit(Object *p_object) {
 
-	collision_polygon_editor->edit(p_object->cast_to<Node>());
+	collision_polygon_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool CollisionPolygon2DEditorPlugin::handles(Object *p_object) const {

--- a/tools/editor/plugins/collision_polygon_editor_plugin.cpp
+++ b/tools/editor/plugins/collision_polygon_editor_plugin.cpp
@@ -507,7 +507,7 @@ void CollisionPolygonEditor::edit(Node *p_collision_polygon) {
 
 	if (p_collision_polygon) {
 
-		node=p_collision_polygon->cast_to<CollisionPolygon>();
+		node=Object::cast_to<CollisionPolygon>(p_collision_polygon);
 		wip.clear();
 		wip_active=false;
 		edited_point=-1;
@@ -607,7 +607,7 @@ CollisionPolygonEditor::~CollisionPolygonEditor() {
 
 void CollisionPolygonEditorPlugin::edit(Object *p_object) {
 
-	collision_polygon_editor->edit(p_object->cast_to<Node>());
+	collision_polygon_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool CollisionPolygonEditorPlugin::handles(Object *p_object) const {

--- a/tools/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/tools/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -368,21 +368,21 @@ void CollisionShape2DEditor::_get_current_shape_type() {
 		return;
 	}
 
-	if (s->cast_to<CapsuleShape2D>()) {
+	if (Object::cast_to<CapsuleShape2D>(*s)) {
 		shape_type = CAPSULE_SHAPE;
-	} else if (s->cast_to<CircleShape2D>()) {
+	} else if (Object::cast_to<CircleShape2D>(*s)) {
 		shape_type = CIRCLE_SHAPE;
-	} else if (s->cast_to<ConcavePolygonShape2D>()) {
+	} else if (Object::cast_to<ConcavePolygonShape2D>(*s)) {
 		shape_type = CONCAVE_POLYGON_SHAPE;
-	} else if (s->cast_to<ConvexPolygonShape2D>()) {
+	} else if (Object::cast_to<ConvexPolygonShape2D>(*s)) {
 		shape_type = CONVEX_POLYGON_SHAPE;
-	} else if (s->cast_to<LineShape2D>()) {
+	} else if (Object::cast_to<LineShape2D>(*s)) {
 		shape_type = LINE_SHAPE;
-	} else if (s->cast_to<RayShape2D>()) {
+	} else if (Object::cast_to<RayShape2D>(*s)) {
 		shape_type = RAY_SHAPE;
-	} else if (s->cast_to<RectangleShape2D>()) {
+	} else if (Object::cast_to<RectangleShape2D>(*s)) {
 		shape_type = RECTANGLE_SHAPE;
-	} else if (s->cast_to<SegmentShape2D>()) {
+	} else if (Object::cast_to<SegmentShape2D>(*s)) {
 		shape_type = SEGMENT_SHAPE;
 	} else {
 		shape_type = -1;
@@ -505,7 +505,7 @@ void CollisionShape2DEditor::edit(Node* p_node) {
 	}
 
 	if (p_node) {
-		node=p_node->cast_to<CollisionShape2D>();
+		node=Object::cast_to<CollisionShape2D>(p_node);
 
 		if (!canvas_item_editor->get_viewport_control()->is_connected("draw",this,"_canvas_draw"))
 			canvas_item_editor->get_viewport_control()->connect("draw",this,"_canvas_draw");
@@ -545,7 +545,7 @@ CollisionShape2DEditor::CollisionShape2DEditor(EditorNode* p_editor) {
 
 void CollisionShape2DEditorPlugin::edit(Object* p_obj) {
 
-	collision_shape_2d_editor->edit(p_obj->cast_to<Node>());
+	collision_shape_2d_editor->edit(Object::cast_to<Node>(p_obj));
 }
 
 bool CollisionShape2DEditorPlugin::handles(Object* p_obj) const {

--- a/tools/editor/plugins/color_ramp_editor_plugin.cpp
+++ b/tools/editor/plugins/color_ramp_editor_plugin.cpp
@@ -21,7 +21,7 @@ ColorRampEditorPlugin::ColorRampEditorPlugin(EditorNode *p_node) {
 
 void ColorRampEditorPlugin::edit(Object *p_object) {
 
-	ColorRamp* color_ramp = p_object->cast_to<ColorRamp>();
+	ColorRamp* color_ramp = Object::cast_to<ColorRamp>(p_object);
 	if (!color_ramp)
 		return;
 	color_ramp_ref = Ref<ColorRamp>(color_ramp);

--- a/tools/editor/plugins/control_editor_plugin.cpp
+++ b/tools/editor/plugins/control_editor_plugin.cpp
@@ -58,7 +58,7 @@ void ControlEditor::_visibility_changed(ObjectID p_control) {
 	Object *c = ObjectDB::get_instance(p_control);
 	if (!c)
 		return;
-	Control *ct = c->cast_to<Control>();
+	Control *ct = Object::cast_to<Control>(c);
 	if (!ct)
 		return;
 
@@ -88,7 +88,7 @@ Control* ControlEditor::_select_control_at_pos(const Point2& p_pos,Node* p_node)
 			return r;
 	}
 
-	Control *c=p_node->cast_to<Control>();
+	Control *c=Object::cast_to<Control>(p_node);
 
 	if (c) {
 		Rect2 rect = c->get_window_rect();
@@ -219,7 +219,7 @@ void ControlEditor::_input_event(InputEvent p_event) {
 		//multi control edit
 
 		Point2 click=Point2(b.x,b.y);
-		Node* scene = get_scene()->get_root_node()->cast_to<EditorNode>()->get_edited_scene();
+		Node* scene = Object::cast_to<EditorNode>(get_scene()->get_root_node())->get_edited_scene();
 		if (!scene)
 			return;
 		/*
@@ -233,7 +233,7 @@ void ControlEditor::_input_event(InputEvent p_event) {
 		while ((n && n != scene && n->get_owner() != scene) || (n && !n->is_type("Control"))) {
 			n = n->get_parent();
 		};
-		c = n->cast_to<Control>();
+		c = Object::cast_to<Control>(n);
 
 
 		if (b.mod.control) { //additive selection
@@ -255,26 +255,26 @@ void ControlEditor::_input_event(InputEvent p_event) {
 			}
 
 			//check parents!
-			Control *parent = c->get_parent()->cast_to<Control>();
+			Control *parent = Object::cast_to<Control>(c->get_parent());
 
 			while(parent) {
 
 				if (controls.has(parent))
 					return; //a parent is already selected, so this is pointless
-				parent=parent->get_parent()->cast_to<Control>();
+				parent=Object::cast_to<Control>(parent->get_parent());
 			}
 
 			//check childrens of everything!
 			List<Control*> to_erase;
 
 			for(ControlMap::Element *E=controls.front();E;E=E->next()) {
-				parent = E->key()->get_parent()->cast_to<Control>();
+				parent = Object::cast_to<Control>(E->key()->get_parent());
 				while(parent) {
 					if (parent==c) {
 						to_erase.push_back(E->key());
 						break;
 					}
-					parent=parent->get_parent()->cast_to<Control>();
+					parent=Object::cast_to<Control>(parent->get_parent());
 				}
 			}
 
@@ -595,8 +595,8 @@ void ControlEditor::_find_controls_span(Node *p_node, Rect2& r_rect) {
 	if (p_node!=editor->get_edited_scene() && p_node->get_owner()!=editor->get_edited_scene())
 		return;
 
-	if (p_node->cast_to<Control>()) {
-		Control *c = p_node->cast_to<Control>();
+	if (Object::cast_to<Control>(p_node)) {
+		Control *c = Object::cast_to<Control>(p_node);
 		if (c->get_viewport() != editor->get_viewport()->get_viewport())
 			return; //bye, it's in another viewport
 
@@ -783,7 +783,7 @@ ControlEditor::ControlEditor(EditorNode *p_editor) {
 void ControlEditorPlugin::edit(Object *p_object) {
 
 	control_editor->set_undo_redo(&get_undo_redo());
-	control_editor->edit(p_object->cast_to<Control>());
+	control_editor->edit(Object::cast_to<Control>(p_object));
 }
 
 bool ControlEditorPlugin::handles(Object *p_object) const {

--- a/tools/editor/plugins/cube_grid_theme_editor_plugin.cpp
+++ b/tools/editor/plugins/cube_grid_theme_editor_plugin.cpp
@@ -77,10 +77,10 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 
 		Node *child = p_scene->get_child(i);
 
-		if (!child->cast_to<MeshInstance>()) {
+		if (!Object::cast_to<MeshInstance>(child)) {
 			if (child->get_child_count()>0) {
 				child=child->get_child(0);
-				if (!child->cast_to<MeshInstance>()) {
+				if (!Object::cast_to<MeshInstance>(child)) {
 					continue;
 				}
 
@@ -90,7 +90,7 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 
 		}
 
-		MeshInstance *mi = child->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(child);
 		Ref<Mesh> mesh=mi->get_mesh();
 		if (mesh.is_null())
 			 continue;
@@ -112,9 +112,9 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 		for(int j=0;j<mi->get_child_count();j++) {
 #if 1
 			Node *child2 = mi->get_child(j);
-			if (!child2->cast_to<StaticBody>())
+			if (!Object::cast_to<StaticBody>(child2))
 				continue;
-			StaticBody *sb = child2->cast_to<StaticBody>();
+			StaticBody *sb = Object::cast_to<StaticBody>(child2);
 			if (sb->get_shape_count()==0)
 				continue;
 			collision=sb->get_shape(0);
@@ -130,9 +130,9 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 		Ref<NavigationMesh> navmesh;
 		for(int j=0;j<mi->get_child_count();j++) {
 				Node *child2 = mi->get_child(j);
-				if (!child2->cast_to<NavigationMeshInstance>())
+				if (!Object::cast_to<NavigationMeshInstance>(child2))
 					continue;
-				NavigationMeshInstance *sb = child2->cast_to<NavigationMeshInstance>();
+				NavigationMeshInstance *sb = Object::cast_to<NavigationMeshInstance>(child2);
 				navmesh=sb->get_navigation_mesh();
 				if (!navmesh.is_null())
 					break;
@@ -320,8 +320,8 @@ MeshLibraryEditor::MeshLibraryEditor(EditorNode *p_editor) {
 
 void MeshLibraryEditorPlugin::edit(Object *p_node) {
 
-	if (p_node && p_node->cast_to<MeshLibrary>()) {
-		theme_editor->edit( p_node->cast_to<MeshLibrary>() );
+	if (MeshLibrary *ml = Object::cast_to<MeshLibrary>(p_node)) {
+		theme_editor->edit(ml);
 		theme_editor->show();
 	} else
 		theme_editor->hide();

--- a/tools/editor/plugins/item_list_editor_plugin.cpp
+++ b/tools/editor/plugins/item_list_editor_plugin.cpp
@@ -114,7 +114,7 @@ void ItemListPlugin::_get_property_list( List<PropertyInfo> *p_list) const {
 
 void ItemListOptionButtonPlugin::set_object(Object *p_object) {
 
-	ob = p_object->cast_to<OptionButton>();
+	ob = Object::cast_to<OptionButton>(p_object);
 }
 
 bool ItemListOptionButtonPlugin::handles(Object *p_object) const {
@@ -154,9 +154,9 @@ ItemListOptionButtonPlugin::ItemListOptionButtonPlugin() {
 void ItemListPopupMenuPlugin::set_object(Object *p_object) {
 
 	if (p_object->is_type("MenuButton"))
-		pp = p_object->cast_to<MenuButton>()->get_popup();
+		pp = Object::cast_to<MenuButton>(p_object)->get_popup();
 	else
-		pp = p_object->cast_to<PopupMenu>();
+		pp = Object::cast_to<PopupMenu>(p_object);
 }
 
 bool ItemListPopupMenuPlugin::handles(Object *p_object) const {
@@ -344,7 +344,7 @@ ItemListEditor::~ItemListEditor() {
 
 void ItemListEditorPlugin::edit(Object *p_object) {
 
-	item_list_editor->edit(p_object->cast_to<Node>());
+	item_list_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool ItemListEditorPlugin::handles(Object *p_object) const {

--- a/tools/editor/plugins/light_occluder_2d_editor_plugin.cpp
+++ b/tools/editor/plugins/light_occluder_2d_editor_plugin.cpp
@@ -372,7 +372,7 @@ void LightOccluder2DEditor::edit(Node *p_collision_polygon) {
 
 	if (p_collision_polygon) {
 
-		node=p_collision_polygon->cast_to<LightOccluder2D>();
+		node=Object::cast_to<LightOccluder2D>(p_collision_polygon);
 		if (!canvas_item_editor->get_viewport_control()->is_connected("draw",this,"_canvas_draw"))
 			canvas_item_editor->get_viewport_control()->connect("draw",this,"_canvas_draw");
 		wip.clear();
@@ -453,7 +453,7 @@ LightOccluder2DEditor::LightOccluder2DEditor(EditorNode *p_editor) {
 
 void LightOccluder2DEditorPlugin::edit(Object *p_object) {
 
-	collision_polygon_editor->edit(p_object->cast_to<Node>());
+	collision_polygon_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool LightOccluder2DEditorPlugin::handles(Object *p_object) const {

--- a/tools/editor/plugins/material_editor_plugin.cpp
+++ b/tools/editor/plugins/material_editor_plugin.cpp
@@ -337,7 +337,7 @@ MaterialEditor::MaterialEditor() {
 
 void MaterialEditorPlugin::edit(Object *p_object) {
 
-	Material * s = p_object->cast_to<Material>();
+	Material * s = Object::cast_to<Material>(p_object);
 	if (!s)
 		return;
 

--- a/tools/editor/plugins/mesh_editor_plugin.cpp
+++ b/tools/editor/plugins/mesh_editor_plugin.cpp
@@ -173,7 +173,7 @@ MeshEditor::MeshEditor() {
 
 void MeshEditorPlugin::edit(Object *p_object) {
 
-	Mesh * s = p_object->cast_to<Mesh>();
+	Mesh * s = Object::cast_to<Mesh>(p_object);
 	if (!s)
 		return;
 

--- a/tools/editor/plugins/mesh_instance_editor_plugin.cpp
+++ b/tools/editor/plugins/mesh_instance_editor_plugin.cpp
@@ -76,7 +76,7 @@ void MeshInstanceEditor::_menu_option(int p_option) {
 
 			for (List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-				MeshInstance *instance = E->get()->cast_to<MeshInstance>();
+				MeshInstance *instance = Object::cast_to<MeshInstance>(E->get());
 				if (!instance)
 					continue;
 
@@ -263,7 +263,7 @@ MeshInstanceEditor::MeshInstanceEditor() {
 
 void MeshInstanceEditorPlugin::edit(Object *p_object) {
 
-	mesh_editor->edit(p_object->cast_to<MeshInstance>());
+	mesh_editor->edit(Object::cast_to<MeshInstance>(p_object));
 }
 
 bool MeshInstanceEditorPlugin::handles(Object *p_object) const {

--- a/tools/editor/plugins/multimesh_editor_plugin.cpp
+++ b/tools/editor/plugins/multimesh_editor_plugin.cpp
@@ -78,7 +78,7 @@ void MultiMeshEditor::_populate() {
 			return;
 		}
 
-		MeshInstance *ms_instance = ms_node->cast_to<MeshInstance>();
+		MeshInstance *ms_instance = Object::cast_to<MeshInstance>(ms_node);
 
 		if (!ms_instance) {
 
@@ -114,7 +114,7 @@ void MultiMeshEditor::_populate() {
 		return;
 	}
 
-	GeometryInstance *ss_instance = ss_node->cast_to<MeshInstance>();
+	GeometryInstance *ss_instance = Object::cast_to<MeshInstance>(ss_node);
 
 	if (!ss_instance) {
 
@@ -159,7 +159,7 @@ void MultiMeshEditor::_populate() {
 	ERR_EXPLAIN("Multimesh not present.");
 	ERR_FAIL_COND(multimesh.is_null());
 
-	VisualInstance *vi = get_parent()->cast_to<VisualInstance>();
+	VisualInstance *vi = Object::cast_to<VisualInstance>(get_parent());
 	ERR_EXPLAIN("Parent is not of type VisualInstance, can't be populated.");
 	ERR_FAIL_COND(!vi);
 
@@ -422,7 +422,7 @@ MultiMeshEditor::MultiMeshEditor() {
 
 void MultiMeshEditorPlugin::edit(Object *p_object) {
 
-	multimesh_editor->edit(p_object->cast_to<MultiMeshInstance>());
+	multimesh_editor->edit(Object::cast_to<MultiMeshInstance>(p_object));
 }
 
 bool MultiMeshEditorPlugin::handles(Object *p_object) const {

--- a/tools/editor/plugins/navigation_polygon_editor_plugin.cpp
+++ b/tools/editor/plugins/navigation_polygon_editor_plugin.cpp
@@ -431,7 +431,7 @@ void NavigationPolygonEditor::edit(Node *p_collision_polygon) {
 
 	if (p_collision_polygon) {
 
-		node=p_collision_polygon->cast_to<NavigationPolygonInstance>();
+		node=Object::cast_to<NavigationPolygonInstance>(p_collision_polygon);
 		if (!canvas_item_editor->get_viewport_control()->is_connected("draw",this,"_canvas_draw"))
 			canvas_item_editor->get_viewport_control()->connect("draw",this,"_canvas_draw");
 		wip.clear();
@@ -501,7 +501,7 @@ NavigationPolygonEditor::NavigationPolygonEditor(EditorNode *p_editor) {
 
 void NavigationPolygonEditorPlugin::edit(Object *p_object) {
 
-	collision_polygon_editor->edit(p_object->cast_to<Node>());
+	collision_polygon_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool NavigationPolygonEditorPlugin::handles(Object *p_object) const {

--- a/tools/editor/plugins/particles_2d_editor_plugin.cpp
+++ b/tools/editor/plugins/particles_2d_editor_plugin.cpp
@@ -35,7 +35,7 @@
 void Particles2DEditorPlugin::edit(Object *p_object) {
 
 	if (p_object) {
-		particles=p_object->cast_to<Particles2D>();
+		particles=Object::cast_to<Particles2D>(p_object);
 	} else {
 		particles=NULL;
 	}

--- a/tools/editor/plugins/particles_editor_plugin.cpp
+++ b/tools/editor/plugins/particles_editor_plugin.cpp
@@ -54,7 +54,7 @@ void ParticlesEditor::_node_selected(const NodePath& p_path){
 	if (!sel)
 		return;
 
-	VisualInstance *vi = sel->cast_to<VisualInstance>();
+	VisualInstance *vi = Object::cast_to<VisualInstance>(sel);
 	if (!vi) {
 
 		err_dialog->set_text(TTR("Node does not contain geometry."));
@@ -180,7 +180,7 @@ void ParticlesEditor::_menu_option(int p_option) {
 /*
 			Node *root = get_scene()->get_root_node();
 			ERR_FAIL_COND(!root);
-			EditorNode *en = root->cast_to<EditorNode>();
+			EditorNode *en = Object::cast_to<EditorNode>(root);
 			ERR_FAIL_COND(!en);
 			Node * node = en->get_edited_scene();
 */
@@ -421,7 +421,7 @@ ParticlesEditor::ParticlesEditor() {
 
 void ParticlesEditorPlugin::edit(Object *p_object) {
 
-	particles_editor->edit(p_object->cast_to<Particles>());
+	particles_editor->edit(Object::cast_to<Particles>(p_object));
 }
 
 bool ParticlesEditorPlugin::handles(Object *p_object) const {

--- a/tools/editor/plugins/path_2d_editor_plugin.cpp
+++ b/tools/editor/plugins/path_2d_editor_plugin.cpp
@@ -528,7 +528,7 @@ void Path2DEditor::edit(Node *p_path2d) {
 
 	if (p_path2d) {
 
-		node=p_path2d->cast_to<Path2D>();
+		node=Object::cast_to<Path2D>(p_path2d);
 		if (!canvas_item_editor->get_viewport_control()->is_connected("draw",this,"_canvas_draw"))
 			canvas_item_editor->get_viewport_control()->connect("draw",this,"_canvas_draw");
 		if (!node->is_connected("visibility_changed", this, "_node_visibility_changed"))
@@ -678,7 +678,7 @@ Path2DEditor::Path2DEditor(EditorNode *p_editor) {
 
 void Path2DEditorPlugin::edit(Object *p_object) {
 
-	path2d_editor->edit(p_object->cast_to<Node>());
+	path2d_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool Path2DEditorPlugin::handles(Object *p_object) const {

--- a/tools/editor/plugins/path_editor_plugin.cpp
+++ b/tools/editor/plugins/path_editor_plugin.cpp
@@ -270,9 +270,9 @@ PathSpatialGizmo::PathSpatialGizmo(Path* p_path){
 Ref<SpatialEditorGizmo> PathEditorPlugin::create_spatial_gizmo(Spatial* p_spatial) {
 
 
-	if (p_spatial->cast_to<Path>()) {
+	if (Object::cast_to<Path>(p_spatial)) {
 
-		return memnew( PathSpatialGizmo(p_spatial->cast_to<Path>()));
+		return memnew( PathSpatialGizmo(Object::cast_to<Path>(p_spatial)));
 	}
 
 	return Ref<SpatialEditorGizmo>();
@@ -428,7 +428,7 @@ bool PathEditorPlugin::forward_spatial_input_event(Camera* p_camera,const InputE
 void PathEditorPlugin::edit(Object *p_object) {
 
 	if (p_object) {
-		path=p_object->cast_to<Path>();
+		path=Object::cast_to<Path>(p_object);
 		if (path) {
 
 			if (path->get_curve().is_valid()) {
@@ -442,7 +442,7 @@ void PathEditorPlugin::edit(Object *p_object) {
 			pre->get_curve()->emit_signal("changed");
 		}
 	}
-//	collision_polygon_editor->edit(p_object->cast_to<Node>());
+//	collision_polygon_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool PathEditorPlugin::handles(Object *p_object) const {

--- a/tools/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/tools/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -757,7 +757,7 @@ void Polygon2DEditor::edit(Node *p_collision_polygon) {
 
 	if (p_collision_polygon) {
 
-		node=p_collision_polygon->cast_to<Polygon2D>();
+		node=Object::cast_to<Polygon2D>(p_collision_polygon);
 		if (!canvas_item_editor->get_viewport_control()->is_connected("draw",this,"_canvas_draw"))
 			canvas_item_editor->get_viewport_control()->connect("draw",this,"_canvas_draw");
 
@@ -992,7 +992,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) {
 void Polygon2DEditorPlugin::edit(Object *p_object) {
 
 
-	collision_polygon_editor->edit(p_object->cast_to<Node>());
+	collision_polygon_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool Polygon2DEditorPlugin::handles(Object *p_object) const {

--- a/tools/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/tools/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -453,7 +453,7 @@ ResourcePreloaderEditor::ResourcePreloaderEditor() {
 void ResourcePreloaderEditorPlugin::edit(Object *p_object) {
 
 	preloader_editor->set_undo_redo(&get_undo_redo());
-	ResourcePreloader * s = p_object->cast_to<ResourcePreloader>();
+	ResourcePreloader * s = Object::cast_to<ResourcePreloader>(p_object);
 	if (!s)
 		return;
 

--- a/tools/editor/plugins/rich_text_editor_plugin.cpp
+++ b/tools/editor/plugins/rich_text_editor_plugin.cpp
@@ -96,7 +96,7 @@ void RichTextEditor::_bind_methods() {
 
 void RichTextEditor::edit(Node *p_rich_text) {
 
-	node=p_rich_text->cast_to<RichTextLabel>();
+	node=Object::cast_to<RichTextLabel>(p_rich_text);
 
 }
 RichTextEditor::RichTextEditor() {
@@ -121,7 +121,7 @@ RichTextEditor::RichTextEditor() {
 
 void RichTextEditorPlugin::edit(Object *p_object) {
 
-	rich_text_editor->edit(p_object->cast_to<Node>());
+	rich_text_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool RichTextEditorPlugin::handles(Object *p_object) const {

--- a/tools/editor/plugins/sample_editor_plugin.cpp
+++ b/tools/editor/plugins/sample_editor_plugin.cpp
@@ -411,7 +411,7 @@ SampleEditor::SampleEditor() {
 
 void SampleEditorPlugin::edit(Object *p_object) {
 
-	Sample * s = p_object->cast_to<Sample>();
+	Sample * s = Object::cast_to<Sample>(p_object);
 	if (!s)
 		return;
 

--- a/tools/editor/plugins/sample_library_editor_plugin.cpp
+++ b/tools/editor/plugins/sample_library_editor_plugin.cpp
@@ -44,7 +44,7 @@ void SampleLibraryEditor::_notification(int p_what) {
 
 	if (p_what==NOTIFICATION_PROCESS) {
 		if (is_playing && !player->is_active()) {
-			TreeItem *tl=last_sample_playing->cast_to<TreeItem>();
+			TreeItem *tl=Object::cast_to<TreeItem>(last_sample_playing);
 			tl->set_button(0,0,get_icon("Play","EditorIcons"));
 			is_playing = false;
 			set_process(false);
@@ -106,7 +106,7 @@ void SampleLibraryEditor::_load_pressed() {
 
 void SampleLibraryEditor::_button_pressed(Object *p_item,int p_column, int p_id) {
 
-	TreeItem *ti=p_item->cast_to<TreeItem>();
+	TreeItem *ti=Object::cast_to<TreeItem>(p_item);
 	String name = ti->get_text(0);
 
 	if (p_column==0) { // Play/Stop
@@ -121,7 +121,7 @@ void SampleLibraryEditor::_button_pressed(Object *p_item,int p_column, int p_id)
 		} else {
 			player->stop_all();
 			if(last_sample_playing != p_item){
-				TreeItem *tl=last_sample_playing->cast_to<TreeItem>();
+				TreeItem *tl=Object::cast_to<TreeItem>(last_sample_playing);
 				tl->set_button(p_column,0,get_icon("Play","EditorIcons"));
 				btn_type = TTR("Stop");
 				player->play(name,true);
@@ -488,7 +488,7 @@ SampleLibraryEditor::SampleLibraryEditor() {
 void SampleLibraryEditorPlugin::edit(Object *p_object) {
 
 	sample_library_editor->set_undo_redo(&get_undo_redo());
-	SampleLibrary * s = p_object->cast_to<SampleLibrary>();
+	SampleLibrary * s = Object::cast_to<SampleLibrary>(p_object);
 	if (!s)
 		return;
 

--- a/tools/editor/plugins/sample_player_editor_plugin.cpp
+++ b/tools/editor/plugins/sample_player_editor_plugin.cpp
@@ -148,7 +148,7 @@ SamplePlayerEditor::SamplePlayerEditor() {
 
 void SamplePlayerEditorPlugin::edit(Object *p_object) {
 
-	sample_player_editor->edit(p_object->cast_to<Node>());
+	sample_player_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool SamplePlayerEditorPlugin::handles(Object *p_object) const {

--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -595,7 +595,7 @@ ScriptTextEditor::ScriptTextEditor() {
 
 String ScriptEditor::_get_debug_tooltip(const String&p_text,Node *_ste) {
 
-	ScriptTextEditor *ste=_ste->cast_to<ScriptTextEditor>();
+	ScriptTextEditor *ste=Object::cast_to<ScriptTextEditor>(_ste);
 
 	String val = debugger->get_var_value(p_text);
 	if (val!=String()) {
@@ -658,7 +658,7 @@ void ScriptEditor::_goto_script_line2(int p_line) {
 	if (selected<0 || selected>=tab_container->get_child_count())
 		return;
 
-	ScriptTextEditor *current = tab_container->get_child(selected)->cast_to<ScriptTextEditor>();
+	ScriptTextEditor *current = Object::cast_to<ScriptTextEditor>(tab_container->get_child(selected));
 	if (!current)
 		return;
 
@@ -687,7 +687,7 @@ void ScriptEditor::_go_to_tab(int p_idx) {
 	Node *cn = tab_container->get_child(p_idx);
 	if (!cn)
 		return;
-	Control *c = cn->cast_to<Control>();
+	Control *c = Object::cast_to<Control>(cn);
 	if (!c)
 		return;
 
@@ -695,15 +695,15 @@ void ScriptEditor::_go_to_tab(int p_idx) {
 
 		Node *n = tab_container->get_current_tab_control();
 
-		if (n->cast_to<ScriptTextEditor>()) {
+		if (Object::cast_to<ScriptTextEditor>(n)) {
 
-			history[history_pos].scroll_pos=n->cast_to<ScriptTextEditor>()->get_text_edit()->get_v_scroll();
-			history[history_pos].cursor_column=n->cast_to<ScriptTextEditor>()->get_text_edit()->cursor_get_column();
-			history[history_pos].cursor_row=n->cast_to<ScriptTextEditor>()->get_text_edit()->cursor_get_line();
+			history[history_pos].scroll_pos=Object::cast_to<ScriptTextEditor>(n)->get_text_edit()->get_v_scroll();
+			history[history_pos].cursor_column=Object::cast_to<ScriptTextEditor>(n)->get_text_edit()->cursor_get_column();
+			history[history_pos].cursor_row=Object::cast_to<ScriptTextEditor>(n)->get_text_edit()->cursor_get_line();
 		}
-		if (n->cast_to<EditorHelp>()) {
+		if (Object::cast_to<EditorHelp>(n)) {
 
-			history[history_pos].scroll_pos=n->cast_to<EditorHelp>()->get_scroll();
+			history[history_pos].scroll_pos=Object::cast_to<EditorHelp>(n)->get_scroll();
 		}
 	}
 
@@ -720,19 +720,19 @@ void ScriptEditor::_go_to_tab(int p_idx) {
 
 	c = tab_container->get_current_tab_control();
 
-	if (c->cast_to<ScriptTextEditor>()) {
+	if (Object::cast_to<ScriptTextEditor>(c)) {
 
-		script_name_label->set_text(c->cast_to<ScriptTextEditor>()->get_name());
-		script_icon->set_texture(c->cast_to<ScriptTextEditor>()->get_icon());
+		script_name_label->set_text(Object::cast_to<ScriptTextEditor>(c)->get_name());
+		script_icon->set_texture(Object::cast_to<ScriptTextEditor>(c)->get_icon());
 		if (is_visible())
-			c->cast_to<ScriptTextEditor>()->get_text_edit()->grab_focus();
+			Object::cast_to<ScriptTextEditor>(c)->get_text_edit()->grab_focus();
 	}
-	if (c->cast_to<EditorHelp>()) {
+	if (Object::cast_to<EditorHelp>(c)) {
 
-		script_name_label->set_text(c->cast_to<EditorHelp>()->get_class_name());
+		script_name_label->set_text(Object::cast_to<EditorHelp>(c)->get_class_name());
 		script_icon->set_texture(get_icon("Help","EditorIcons"));
 		if (is_visible())
-			c->cast_to<EditorHelp>()->set_focused();
+			Object::cast_to<EditorHelp>(c)->set_focused();
 	}
 
 
@@ -749,7 +749,7 @@ void ScriptEditor::_close_current_tab() {
 		return;
 
 	Node *tselected = tab_container->get_child(selected);
-	ScriptTextEditor *current = tab_container->get_child(selected)->cast_to<ScriptTextEditor>();
+	ScriptTextEditor *current = Object::cast_to<ScriptTextEditor>(tab_container->get_child(selected));
 	if (current) {
 		apply_scripts();
 	}
@@ -800,7 +800,7 @@ void ScriptEditor::_resave_scripts(const String& p_str) {
 
 	for(int i=0;i<tab_container->get_child_count();i++) {
 
-		ScriptTextEditor *ste = tab_container->get_child(i)->cast_to<ScriptTextEditor>();
+		ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(tab_container->get_child(i));
 		if (!ste)
 			continue;
 
@@ -827,7 +827,7 @@ void ScriptEditor::_reload_scripts(){
 
 	for(int i=0;i<tab_container->get_child_count();i++) {
 
-		ScriptTextEditor *ste = tab_container->get_child(i)->cast_to<ScriptTextEditor>();
+		ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(tab_container->get_child(i));
 		if (!ste) {
 
 			continue;
@@ -865,7 +865,7 @@ void ScriptEditor::_res_saved_callback(const Ref<Resource>& p_res) {
 
 	for(int i=0;i<tab_container->get_child_count();i++) {
 
-		ScriptTextEditor *ste = tab_container->get_child(i)->cast_to<ScriptTextEditor>();
+		ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(tab_container->get_child(i));
 		if (!ste) {
 
 			continue;
@@ -904,7 +904,7 @@ bool ScriptEditor::_test_script_times_on_disk() {
 
 	for(int i=0;i<tab_container->get_child_count();i++) {
 
-		ScriptTextEditor *ste = tab_container->get_child(i)->cast_to<ScriptTextEditor>();
+		ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(tab_container->get_child(i));
 		if (ste) {
 
 			Ref<Script> script = ste->get_edited_script();
@@ -995,7 +995,7 @@ void ScriptEditor::_menu_option(int p_option) {
 #if 0
 			for(int i=0;i<tab_container->get_child_count();i++) {
 
-				ScriptTextEditor *ste = tab_container->get_child(i)->cast_to<ScriptTextEditor>();
+				ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(tab_container->get_child(i));
 				if (!ste)
 					continue;
 
@@ -1047,7 +1047,7 @@ void ScriptEditor::_menu_option(int p_option) {
 			String current;
 
 			if (tab_container->get_tab_count()>0) {
-				EditorHelp *eh = tab_container->get_child( tab_container->get_current_tab() )->cast_to<EditorHelp>();
+				EditorHelp *eh = cast_to<EditorHelp>(tab_container->get_child( tab_container->get_current_tab() ));
 				if (eh) {
 					current=eh->get_class_name();
 				}
@@ -1094,7 +1094,7 @@ void ScriptEditor::_menu_option(int p_option) {
 	if (selected<0 || selected>=tab_container->get_child_count())
 		return;
 
-	ScriptTextEditor *current = tab_container->get_child(selected)->cast_to<ScriptTextEditor>();
+	ScriptTextEditor *current = Object::cast_to<ScriptTextEditor>(tab_container->get_child(selected));
 	if (current) {
 
 		switch(p_option) {
@@ -1563,7 +1563,7 @@ void ScriptEditor::_menu_option(int p_option) {
 		}
 	}
 
-	EditorHelp *help = tab_container->get_child(selected)->cast_to<EditorHelp>();
+	EditorHelp *help = Object::cast_to<EditorHelp>(tab_container->get_child(selected));
 	if (help) {
 
 		switch(p_option) {
@@ -1684,7 +1684,7 @@ Dictionary ScriptEditor::get_state() const {
 
 	for(int i=0;i<tab_container->get_child_count();i++) {
 
-		ScriptTextEditor *ste = tab_container->get_child(i)->cast_to<ScriptTextEditor>();
+		ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(tab_container->get_child(i));
 		if (!ste)
 			continue;
 
@@ -1761,7 +1761,7 @@ void ScriptEditor::clear() {
 	List<ScriptTextEditor*> stes;
 	for(int i=0;i<tab_container->get_child_count();i++) {
 
-		ScriptTextEditor *ste = tab_container->get_child(i)->cast_to<ScriptTextEditor>();
+		ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(tab_container->get_child(i));
 		if (!ste)
 			continue;
 		stes.push_back(ste);
@@ -1792,7 +1792,7 @@ void ScriptEditor::get_breakpoints(List<String> *p_breakpoints) {
 
 	for(int i=0;i<tab_container->get_child_count();i++) {
 
-		ScriptTextEditor *ste = tab_container->get_child(i)->cast_to<ScriptTextEditor>();
+		ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(tab_container->get_child(i));
 		if (!ste)
 			continue;
 
@@ -1822,10 +1822,10 @@ void ScriptEditor::ensure_focus_current() {
 
 	int cidx = tab_container->get_current_tab();
 	if (cidx<0 || cidx>=tab_container->get_tab_count());
-	Control *c = tab_container->get_child(cidx)->cast_to<Control>();
+	Control *c = Object::cast_to<Control>(tab_container->get_child(cidx));
 	if (!c)
 		return;
-	ScriptTextEditor *ste = c->cast_to<ScriptTextEditor>();
+	ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(c);
 	if (!ste)
 		return;
 	ste->get_text_edit()->grab_focus();
@@ -1847,7 +1847,7 @@ void ScriptEditor::ensure_select_current() {
 		Node *current = tab_container->get_child(tab_container->get_current_tab());
 
 
-		ScriptTextEditor *ste = current->cast_to<ScriptTextEditor>();
+		ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(current);
 		if (ste) {
 
 			Ref<Script> script = ste->get_edited_script();
@@ -1862,7 +1862,7 @@ void ScriptEditor::ensure_select_current() {
 
 		}
 
-		EditorHelp *eh = current->cast_to<EditorHelp>();
+		EditorHelp *eh = Object::cast_to<EditorHelp>(current);
 
 		if (eh) {
 			edit_menu->hide();
@@ -1964,7 +1964,7 @@ void ScriptEditor::_update_script_names() {
 	for(int i=0;i<tab_container->get_child_count();i++) {
 
 
-		ScriptTextEditor *ste = tab_container->get_child(i)->cast_to<ScriptTextEditor>();
+		ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(tab_container->get_child(i));
 		if (ste) {
 
 			String name = ste->get_name();
@@ -1982,7 +1982,7 @@ void ScriptEditor::_update_script_names() {
 			sedata.push_back(sd);
 		}
 
-		EditorHelp *eh = tab_container->get_child(i)->cast_to<EditorHelp>();
+		EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_child(i));
 		if (eh) {
 
 			String name = eh->get_class_name();
@@ -2060,7 +2060,7 @@ void ScriptEditor::edit(const Ref<Script>& p_script) {
 
 	for(int i=0;i<tab_container->get_child_count();i++) {
 
-		ScriptTextEditor *ste = tab_container->get_child(i)->cast_to<ScriptTextEditor>();
+		ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(tab_container->get_child(i));
 		if (!ste)
 			continue;
 
@@ -2114,7 +2114,7 @@ void ScriptEditor::save_all_scripts() {
 
 	for(int i=0;i<tab_container->get_child_count();i++) {
 
-		ScriptTextEditor *ste = tab_container->get_child(i)->cast_to<ScriptTextEditor>();
+		ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(tab_container->get_child(i));
 		if (!ste)
 			continue;
 
@@ -2140,7 +2140,7 @@ void ScriptEditor::apply_scripts() const {
 
 	for(int i=0;i<tab_container->get_child_count();i++) {
 
-		ScriptTextEditor *ste = tab_container->get_child(i)->cast_to<ScriptTextEditor>();
+		ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(tab_container->get_child(i));
 		if (!ste)
 			continue;
 		ste->apply_code();
@@ -2184,7 +2184,7 @@ void ScriptEditor::_add_callback(Object *p_obj, const String& p_function, const 
 
 	for(int i=0;i<tab_container->get_child_count();i++) {
 
-		ScriptTextEditor *ste = tab_container->get_child(i)->cast_to<ScriptTextEditor>();
+		ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(tab_container->get_child(i));
 		if (!ste)
 			continue;
 		if (ste->get_edited_script()!=script)
@@ -2236,7 +2236,7 @@ void ScriptEditor::_editor_settings_changed() {
 
 	for(int i=0;i<tab_container->get_child_count();i++) {
 
-		ScriptTextEditor *ste = tab_container->get_child(i)->cast_to<ScriptTextEditor>();
+		ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(tab_container->get_child(i));
 		if (!ste)
 			continue;
 
@@ -2327,7 +2327,7 @@ void ScriptEditor::get_window_layout(Ref<ConfigFile> p_layout) {
 
 	for(int i=0;i<tab_container->get_child_count();i++) {
 
-		ScriptTextEditor *ste = tab_container->get_child(i)->cast_to<ScriptTextEditor>();
+		ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(tab_container->get_child(i));
 		if (ste) {
 
 			String path = ste->get_edited_script()->get_path();
@@ -2337,7 +2337,7 @@ void ScriptEditor::get_window_layout(Ref<ConfigFile> p_layout) {
 			scripts.push_back(path);
 		}
 
-		EditorHelp *eh = tab_container->get_child(i)->cast_to<EditorHelp>();
+		EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_child(i));
 
 		if (eh) {
 
@@ -2358,7 +2358,7 @@ void ScriptEditor::_help_class_open(const String& p_class) {
 
 	for(int i=0;i<tab_container->get_child_count();i++) {
 
-		EditorHelp *eh = tab_container->get_child(i)->cast_to<EditorHelp>();
+		EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_child(i));
 
 		if (eh && eh->get_class_name()==p_class) {
 
@@ -2387,7 +2387,7 @@ void ScriptEditor::_help_class_goto(const String& p_desc) {
 
 	for(int i=0;i<tab_container->get_child_count();i++) {
 
-		EditorHelp *eh = tab_container->get_child(i)->cast_to<EditorHelp>();
+		EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_child(i));
 
 		if (eh && eh->get_class_name()==cname) {
 
@@ -2413,15 +2413,15 @@ void ScriptEditor::_update_history_pos(int p_new_pos) {
 
 	Node *n = tab_container->get_current_tab_control();
 
-	if (n->cast_to<ScriptTextEditor>()) {
+	if (Object::cast_to<ScriptTextEditor>(n)) {
 
-		history[history_pos].scroll_pos=n->cast_to<ScriptTextEditor>()->get_text_edit()->get_v_scroll();
-		history[history_pos].cursor_column=n->cast_to<ScriptTextEditor>()->get_text_edit()->cursor_get_column();
-		history[history_pos].cursor_row=n->cast_to<ScriptTextEditor>()->get_text_edit()->cursor_get_line();
+		history[history_pos].scroll_pos=Object::cast_to<ScriptTextEditor>(n)->get_text_edit()->get_v_scroll();
+		history[history_pos].cursor_column=Object::cast_to<ScriptTextEditor>(n)->get_text_edit()->cursor_get_column();
+		history[history_pos].cursor_row=Object::cast_to<ScriptTextEditor>(n)->get_text_edit()->cursor_get_line();
 	}
-	if (n->cast_to<EditorHelp>()) {
+	if (Object::cast_to<EditorHelp>(n)) {
 
-		history[history_pos].scroll_pos=n->cast_to<EditorHelp>()->get_scroll();
+		history[history_pos].scroll_pos=Object::cast_to<EditorHelp>(n)->get_scroll();
 	}
 
 	history_pos=p_new_pos;
@@ -2429,18 +2429,18 @@ void ScriptEditor::_update_history_pos(int p_new_pos) {
 
 	n = history[history_pos].control;
 
-	if (n->cast_to<ScriptTextEditor>()) {
+	if (Object::cast_to<ScriptTextEditor>(n)) {
 
-		n->cast_to<ScriptTextEditor>()->get_text_edit()->set_v_scroll(history[history_pos].scroll_pos);
-		n->cast_to<ScriptTextEditor>()->get_text_edit()->cursor_set_column( history[history_pos].cursor_column );
-		n->cast_to<ScriptTextEditor>()->get_text_edit()->cursor_set_line( history[history_pos].cursor_row );
-		n->cast_to<ScriptTextEditor>()->get_text_edit()->grab_focus();
+		Object::cast_to<ScriptTextEditor>(n)->get_text_edit()->set_v_scroll(history[history_pos].scroll_pos);
+		Object::cast_to<ScriptTextEditor>(n)->get_text_edit()->cursor_set_column( history[history_pos].cursor_column );
+		Object::cast_to<ScriptTextEditor>(n)->get_text_edit()->cursor_set_line( history[history_pos].cursor_row );
+		Object::cast_to<ScriptTextEditor>(n)->get_text_edit()->grab_focus();
 	}
 
-	if (n->cast_to<EditorHelp>()) {
+	if (Object::cast_to<EditorHelp>(n)) {
 
-		n->cast_to<EditorHelp>()->set_scroll(history[history_pos].scroll_pos);
-		n->cast_to<EditorHelp>()->set_focused();
+		Object::cast_to<EditorHelp>(n)->set_scroll(history[history_pos].scroll_pos);
+		Object::cast_to<EditorHelp>(n)->set_focused();
 	}
 
 	n->set_meta("__editor_pass",++edit_pass);
@@ -2789,10 +2789,10 @@ ScriptEditor::~ScriptEditor() {
 
 void ScriptEditorPlugin::edit(Object *p_object) {
 
-	if (!p_object->cast_to<Script>())
+	if (!Object::cast_to<Script>(p_object))
 		return;
 
-	script_editor->edit(p_object->cast_to<Script>());
+	script_editor->edit(Object::cast_to<Script>(p_object));
 
 }
 

--- a/tools/editor/plugins/shader_editor_plugin.cpp
+++ b/tools/editor/plugins/shader_editor_plugin.cpp
@@ -181,7 +181,7 @@ ShaderTextEditor::ShaderTextEditor() {
 void ShaderEditor::_menu_option(int p_option) {
 
 
-	ShaderTextEditor *current = tab_container->get_current_tab_control()->cast_to<ShaderTextEditor>();
+	ShaderTextEditor *current = Object::cast_to<ShaderTextEditor>(tab_container->get_current_tab_control());
 	if (!current)
 		return;
 
@@ -241,7 +241,7 @@ void ShaderEditor::_menu_option(int p_option) {
 
 void ShaderEditor::_tab_changed(int p_which) {
 
-	ShaderTextEditor *shader_editor = tab_container->get_tab_control(p_which)->cast_to<ShaderTextEditor>();
+	ShaderTextEditor *shader_editor = Object::cast_to<ShaderTextEditor>(tab_container->get_tab_control(p_which));
 
 	if (shader_editor && is_inside_tree())
 		shader_editor->get_text_edit()->grab_focus();
@@ -282,7 +282,7 @@ Dictionary ShaderEditor::get_state() const {
 
 	for(int i=0;i<tab_container->get_child_count();i++) {
 
-		ShaderTextEditor *ste = tab_container->get_child(i)->cast_to<ShaderTextEditor>();
+		ShaderTextEditor *ste = Object::cast_to<ShaderTextEditor>(tab_container->get_child(i));
 		if (!ste)
 			continue;
 
@@ -413,7 +413,7 @@ void ShaderEditor::ensure_select_current() {
 /*
 	if (tab_container->get_child_count() && tab_container->get_current_tab()>=0) {
 
-		ShaderTextEditor *ste = tab_container->get_child(tab_container->get_current_tab())->cast_to<ShaderTextEditor>();
+		ShaderTextEditor *ste = Object::cast_to<ShaderTextEditor>(tab_container->get_child(tab_container->get_current_tab()));
 		if (!ste)
 			return;
 		Ref<Shader> shader = ste->get_edited_shader();
@@ -554,16 +554,16 @@ ShaderEditor::ShaderEditor() {
 
 void ShaderEditorPlugin::edit(Object *p_object) {
 
-	if (!p_object->cast_to<Shader>())
+	if (!Object::cast_to<Shader>(p_object))
 		return;
 
-	shader_editor->edit(p_object->cast_to<Shader>());
+	shader_editor->edit(Object::cast_to<Shader>(p_object));
 
 }
 
 bool ShaderEditorPlugin::handles(Object *p_object) const {
 
-	Shader *shader=p_object->cast_to<Shader>();
+	Shader *shader=Object::cast_to<Shader>(p_object);
 	if (!shader)
 		return false;
 	if (_2d)

--- a/tools/editor/plugins/shader_graph_editor_plugin.cpp
+++ b/tools/editor/plugins/shader_graph_editor_plugin.cpp
@@ -837,7 +837,7 @@ void ShaderGraphView::_vec_input_changed(double p_value, int p_id,Array p_arr){
 void ShaderGraphView::_xform_input_changed(int p_id, Node *p_button){
 
 
-	ToolButton *tb = p_button->cast_to<ToolButton>();
+	ToolButton *tb = Object::cast_to<ToolButton>(p_button);
 	ped_popup->set_pos(tb->get_global_pos()+Vector2(0,tb->get_size().height));
 	ped_popup->set_size(tb->get_size());
 	edited_id=p_id;
@@ -848,7 +848,7 @@ void ShaderGraphView::_xform_input_changed(int p_id, Node *p_button){
 }
 void ShaderGraphView::_xform_const_changed(int p_id, Node *p_button){
 
-	ToolButton *tb = p_button->cast_to<ToolButton>();
+	ToolButton *tb = Object::cast_to<ToolButton>(p_button);
 	ped_popup->set_pos(tb->get_global_pos()+Vector2(0,tb->get_size().height));
 	ped_popup->set_size(tb->get_size());
 	edited_id=p_id;
@@ -961,7 +961,7 @@ void ShaderGraphView::_variant_edited() {
 void ShaderGraphView::_comment_edited(int p_id,Node* p_button) {
 
 	UndoRedo *ur=EditorNode::get_singleton()->get_undo_redo();
-	TextEdit *te=p_button->cast_to<TextEdit>();
+	TextEdit *te=Object::cast_to<TextEdit>(p_button);
 	ur->create_action(TTR("Change Comment"),true);
 	ur->add_do_method(graph.ptr(),"comment_node_set_text",type,p_id,te->get_text());
 	ur->add_undo_method(graph.ptr(),"comment_node_set_text",type,p_id,graph->comment_node_get_text(type,p_id));
@@ -975,7 +975,7 @@ void ShaderGraphView::_comment_edited(int p_id,Node* p_button) {
 
 void ShaderGraphView::_color_ramp_changed(int p_id,Node* p_ramp) {
 
-	GraphColorRampEdit *cr=p_ramp->cast_to<GraphColorRampEdit>();
+	GraphColorRampEdit *cr=Object::cast_to<GraphColorRampEdit>(p_ramp);
 
 	UndoRedo *ur=EditorNode::get_singleton()->get_undo_redo();
 
@@ -1017,7 +1017,7 @@ void ShaderGraphView::_color_ramp_changed(int p_id,Node* p_ramp) {
 
 void ShaderGraphView::_curve_changed(int p_id,Node* p_curve) {
 
-	GraphCurveMapEdit *cr=p_curve->cast_to<GraphCurveMapEdit>();
+	GraphCurveMapEdit *cr=Object::cast_to<GraphCurveMapEdit>(p_curve);
 
 	UndoRedo *ur=EditorNode::get_singleton()->get_undo_redo();
 
@@ -1054,7 +1054,7 @@ void ShaderGraphView::_curve_changed(int p_id,Node* p_curve) {
 
 void ShaderGraphView::_input_name_changed(const String& p_name, int p_id, Node *p_line_edit) {
 
-	LineEdit *le=p_line_edit->cast_to<LineEdit>();
+	LineEdit *le=Object::cast_to<LineEdit>(p_line_edit);
 	ERR_FAIL_COND(!le);
 
 	UndoRedo *ur=EditorNode::get_singleton()->get_undo_redo();
@@ -1071,7 +1071,7 @@ void ShaderGraphView::_input_name_changed(const String& p_name, int p_id, Node *
 
 void ShaderGraphView::_tex_edited(int p_id,Node* p_button) {
 
-	ToolButton *tb = p_button->cast_to<ToolButton>();
+	ToolButton *tb = Object::cast_to<ToolButton>(p_button);
 	ped_popup->set_pos(tb->get_global_pos()+Vector2(0,tb->get_size().height));
 	ped_popup->set_size(tb->get_size());
 	edited_id=p_id;
@@ -1081,7 +1081,7 @@ void ShaderGraphView::_tex_edited(int p_id,Node* p_button) {
 
 void ShaderGraphView::_cube_edited(int p_id,Node* p_button) {
 
-	ToolButton *tb = p_button->cast_to<ToolButton>();
+	ToolButton *tb = Object::cast_to<ToolButton>(p_button);
 	ped_popup->set_pos(tb->get_global_pos()+Vector2(0,tb->get_size().height));
 	ped_popup->set_size(tb->get_size());
 	edited_id=p_id;
@@ -1296,7 +1296,7 @@ void ShaderGraphView::_delete_nodes_request()
 
 void ShaderGraphView::_default_changed(int p_id, Node *p_button, int p_param, int v_type, String p_hint)
 {
-	ToolButton *tb = p_button->cast_to<ToolButton>();
+	ToolButton *tb = Object::cast_to<ToolButton>(p_button);
 	ped_popup->set_pos(tb->get_global_pos()+Vector2(0,tb->get_size().height));
 	ped_popup->set_size(tb->get_size());
 	edited_id=p_id;
@@ -2521,7 +2521,7 @@ void ShaderGraphView::_sg_updated() {
 
 Variant ShaderGraphView::get_drag_data_fw(const Point2 &p_point, Control *p_from)
 {
-	TextureFrame* frame = p_from->cast_to<TextureFrame>();
+	TextureFrame* frame = Object::cast_to<TextureFrame>(p_from);
 	if (!frame)
 		return Variant();
 
@@ -2547,7 +2547,7 @@ bool ShaderGraphView::can_drop_data_fw(const Point2 &p_point, const Variant &p_d
 
 			if (val.get_type()==Variant::OBJECT) {
 				RES res = val;
-				if (res.is_valid() && res->cast_to<Texture>())
+				if (res.is_valid() && Object::cast_to<Texture>(*res))
 					return true;
 			}
 		}
@@ -2567,7 +2567,7 @@ void ShaderGraphView::drop_data_fw(const Point2 &p_point, const Variant &p_data,
 	if (!can_drop_data_fw(p_point, p_data, p_from))
 		return;
 
-	TextureFrame *frame = p_from->cast_to<TextureFrame>();
+	TextureFrame *frame = Object::cast_to<TextureFrame>(p_from);
 	if (!frame)
 		return;
 
@@ -2581,20 +2581,20 @@ void ShaderGraphView::drop_data_fw(const Point2 &p_point, const Variant &p_data,
 			if (val.get_type()==Variant::OBJECT) {
 				RES res = val;
 				if (res.is_valid())
-					tex = Ref<Texture>(res->cast_to<Texture>());
+					tex = Ref<Texture>(Object::cast_to<Texture>(*res));
 			}
 		}
 		else if (d["type"] == "files" && d.has("files")) {
 			Vector<String> files = d["files"];
 			RES res = ResourceLoader::load(files[0]);
 			if (res.is_valid())
-				tex = Ref<Texture>(res->cast_to<Texture>());
+				tex = Ref<Texture>(Object::cast_to<Texture>(*res));
 		}
 	}
 
 	if (!tex.is_valid()) return;
 
-	GraphNode *gn = frame->get_parent()->cast_to<GraphNode>();
+	GraphNode *gn = Object::cast_to<GraphNode>(frame->get_parent());
 	if (!gn) return;
 
 	int id = -1;
@@ -2887,12 +2887,12 @@ ShaderGraphEditor::ShaderGraphEditor(bool p_2d) {
 
 void ShaderGraphEditorPlugin::edit(Object *p_object) {
 
-	shader_editor->edit(p_object->cast_to<ShaderGraph>());
+	shader_editor->edit(Object::cast_to<ShaderGraph>(p_object));
 }
 
 bool ShaderGraphEditorPlugin::handles(Object *p_object) const {
 
-	ShaderGraph *shader=p_object->cast_to<ShaderGraph>();
+	ShaderGraph *shader=Object::cast_to<ShaderGraph>(p_object);
 	if (!shader)
 		return false;
 	if (_2d)

--- a/tools/editor/plugins/spatial_editor_plugin.cpp
+++ b/tools/editor/plugins/spatial_editor_plugin.cpp
@@ -122,7 +122,7 @@ int SpatialEditorViewport::get_selected_count() const {
 
 	for(Map<Node*,Object*>::Element *E=selection.front();E;E=E->next()) {
 
-		Spatial *sp = E->key()->cast_to<Spatial>();
+		Spatial *sp = Object::cast_to<Spatial>(E->key());
 		if (!sp)
 			continue;
 
@@ -226,7 +226,7 @@ void SpatialEditorViewport::_select_clicked(bool p_append,bool p_single) {
 		return;
 
 
-	Spatial *sp = obj->cast_to<Spatial>();
+	Spatial *sp = Object::cast_to<Spatial>(obj);
 	if (!sp)
 		return;
 
@@ -288,7 +288,7 @@ ObjectID SpatialEditorViewport::_select_ray(const Point2& p_pos, bool p_append,b
 		if (!obj)
 			continue;
 
-		Spatial *spat=obj->cast_to<Spatial>();
+		Spatial *spat=Object::cast_to<Spatial>(obj);
 
 		if (!spat)
 			continue;
@@ -414,7 +414,7 @@ void SpatialEditorViewport::_find_items_at_pos(const Point2& p_pos,bool &r_inclu
 		if (!obj)
 			continue;
 
-		Spatial *spat=obj->cast_to<Spatial>();
+		Spatial *spat=Object::cast_to<Spatial>(obj);
 
 		if (!spat)
 			continue;
@@ -541,7 +541,7 @@ void SpatialEditorViewport::_select_region() {
 		Object *obj=ObjectDB::get_instance(id);
 		if (!obj)
 			continue;
-		Spatial *sp = obj->cast_to<Spatial>();
+		Spatial *sp = Object::cast_to<Spatial>(obj);
 		if (!sp)
 			continue;
 
@@ -584,7 +584,7 @@ void SpatialEditorViewport::_compute_edit(const Point2& p_point) {
 //	int nc=0;
 	for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-		Spatial *sp = E->get()->cast_to<Spatial>();
+		Spatial *sp = Object::cast_to<Spatial>(E->get());
 		if (!sp)
 			continue;
 
@@ -901,7 +901,7 @@ void SpatialEditorViewport::_sinput(const InputEvent &p_event) {
 								if (!obj)
 									continue;
 
-								VisualInstance *vi=obj->cast_to<VisualInstance>();
+								VisualInstance *vi=Object::cast_to<VisualInstance>(obj);
 								if (!vi)
 									continue;
 
@@ -971,7 +971,7 @@ void SpatialEditorViewport::_sinput(const InputEvent &p_event) {
 
 						for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-							Spatial *sp = E->get()->cast_to<Spatial>();
+							Spatial *sp = Object::cast_to<Spatial>(E->get());
 							if (!sp)
 								continue;
 
@@ -1146,7 +1146,7 @@ void SpatialEditorViewport::_sinput(const InputEvent &p_event) {
 							Object *obj=ObjectDB::get_instance(clicked);
 							if (obj) {
 
-								Spatial *spa = obj->cast_to<Spatial>();
+								Spatial *spa = Object::cast_to<Spatial>(obj);
 								if (spa) {
 
 									Ref<SpatialEditorGizmo> seg=spa->get_gizmo();
@@ -1203,7 +1203,7 @@ void SpatialEditorViewport::_sinput(const InputEvent &p_event) {
 
 							for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-								Spatial *sp = E->get()->cast_to<Spatial>();
+								Spatial *sp = Object::cast_to<Spatial>(E->get());
 								if (!sp)
 									continue;
 
@@ -1363,7 +1363,7 @@ void SpatialEditorViewport::_sinput(const InputEvent &p_event) {
 
 							for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-								Spatial *sp = E->get()->cast_to<Spatial>();
+								Spatial *sp = Object::cast_to<Spatial>(E->get());
 								if (!sp)
 									continue;
 
@@ -1437,7 +1437,7 @@ void SpatialEditorViewport::_sinput(const InputEvent &p_event) {
 
 							for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-								Spatial *sp = E->get()->cast_to<Spatial>();
+								Spatial *sp = Object::cast_to<Spatial>(E->get());
 								if (!sp) {
 									continue;
 								}
@@ -1512,7 +1512,7 @@ void SpatialEditorViewport::_sinput(const InputEvent &p_event) {
 
 							for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-								Spatial *sp = E->get()->cast_to<Spatial>();
+								Spatial *sp = Object::cast_to<Spatial>(E->get());
 								if (!sp)
 									continue;
 
@@ -1757,7 +1757,7 @@ void SpatialEditorViewport::_sinput(const InputEvent &p_event) {
 
 					for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-						Spatial *sp = E->get()->cast_to<Spatial>();
+						Spatial *sp = Object::cast_to<Spatial>(E->get());
 						if (!sp)
 							continue;
 
@@ -1846,7 +1846,7 @@ void SpatialEditorViewport::_notification(int p_what) {
 
 		for(Map<Node*,Object*>::Element *E=selection.front();E;E=E->next()) {
 
-			Spatial *sp = E->key()->cast_to<Spatial>();
+			Spatial *sp = Object::cast_to<Spatial>(E->key());
 			if (!sp)
 				continue;
 
@@ -1865,7 +1865,7 @@ void SpatialEditorViewport::_notification(int p_what) {
 				continue;
 			}
 			*/
-			VisualInstance *vi=sp->cast_to<VisualInstance>();
+			VisualInstance *vi=Object::cast_to<VisualInstance>(sp);
 
 
 			if (se->aabb.has_no_surface()) {
@@ -2096,7 +2096,7 @@ void SpatialEditorViewport::_menu_option(int p_option) {
 
 			for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-				Spatial *sp = E->get()->cast_to<Spatial>();
+				Spatial *sp = Object::cast_to<Spatial>(E->get());
 				if (!sp)
 					continue;
 
@@ -2126,7 +2126,7 @@ void SpatialEditorViewport::_menu_option(int p_option) {
 			undo_redo->create_action(TTR("Align with view"));
 			for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-				Spatial *sp = E->get()->cast_to<Spatial>();
+				Spatial *sp = Object::cast_to<Spatial>(E->get());
 				if (!sp)
 					continue;
 
@@ -2368,8 +2368,8 @@ void SpatialEditorViewport::set_state(const Dictionary& p_state) {
 
 	if (p_state.has("previewing")) {
 		Node *pv = EditorNode::get_singleton()->get_edited_scene()->get_node(p_state["previewing"]);
-		if (pv && pv->cast_to<Camera>()) {
-			previewing=pv->cast_to<Camera>();
+		if (Object::cast_to<Camera>(pv)) {
+			previewing=Object::cast_to<Camera>(pv);
 			previewing->connect("exit_tree",this,"_preview_exited_scene");
 			VS::get_singleton()->viewport_attach_camera( viewport->get_viewport(), previewing->get_camera() ); //replace
 			view_menu->hide();
@@ -2565,7 +2565,7 @@ void SpatialEditor::update_transform_gizmo() {
 
 	for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-		Spatial *sp = E->get()->cast_to<Spatial>();
+		Spatial *sp = Object::cast_to<Spatial>(E->get());
 		if (!sp)
 			continue;
 
@@ -2602,7 +2602,7 @@ void SpatialEditor::update_transform_gizmo() {
 
 Object *SpatialEditor::_get_editor_data(Object *p_what) {
 
-	Spatial *sp = p_what->cast_to<Spatial>();
+	Spatial *sp = Object::cast_to<Spatial>(p_what);
 	if (!sp)
 		return NULL;
 
@@ -2902,7 +2902,7 @@ void SpatialEditor::_xform_dialog_action() {
 
 	for(List<Node*>::Element *E=selection.front();E;E=E->next()) {
 
-		Spatial *sp = E->get()->cast_to<Spatial>();
+		Spatial *sp = Object::cast_to<Spatial>(E->get());
 		if (!sp)
 			continue;
 
@@ -3513,7 +3513,7 @@ void SpatialEditor::_init_indicators() {
 	_generate_selection_box();
 
 
-	//get_scene()->get_root_node()->cast_to<EditorNode>()->get_scene_root()->add_child(camera);
+	//Object::cast_to<EditorNode>(get_scene()->get_root_node())->get_scene_root()->add_child(camera);
 
 	//current_camera=camera;
 
@@ -3541,7 +3541,7 @@ void SpatialEditor::_finish_indicators() {
 
 void SpatialEditor::_instance_scene() {
 #if 0
-	EditorNode *en = get_scene()->get_root_node()->cast_to<EditorNode>();
+	EditorNode *en = Object::cast_to<EditorNode>(get_scene()->get_root_node());
 	ERR_FAIL_COND(!en);
 	String path = en->get_scenes_dock()->get_selected_path();
 	if (path=="") {
@@ -3559,7 +3559,7 @@ void SpatialEditor::_instance_scene() {
 		return;
 	}
 
-	Spatial *s = scene->cast_to<Spatial>();
+	Spatial *s = Object::cast_to<Spatial>(scene);
 	if (s) {
 
 		undo_redo->add_do_method(s,"set_global_transform",Transform(Matrix3(),cursor.cursor_pos));
@@ -3689,7 +3689,7 @@ HSplitContainer *SpatialEditor::get_palette_split() {
 
 void SpatialEditor::_request_gizmo(Object* p_obj) {
 
-	Spatial *sp=p_obj->cast_to<Spatial>();
+	Spatial *sp=Object::cast_to<Spatial>(p_obj);
 	if (!sp)
 		return;
 	if (editor->get_edited_scene() && (sp==editor->get_edited_scene() || sp->get_owner()==editor->get_edited_scene() || editor->get_edited_scene()->is_editable_instance(sp->get_owner()))) {
@@ -3722,7 +3722,7 @@ void SpatialEditor::_request_gizmo(Object* p_obj) {
 
 void SpatialEditor::_toggle_maximize_view(Object* p_viewport) {
 	if (!p_viewport) return;
-	SpatialEditorViewport *current_viewport = p_viewport->cast_to<SpatialEditorViewport>();
+	SpatialEditorViewport *current_viewport = Object::cast_to<SpatialEditorViewport>(p_viewport);
 	if (!current_viewport) return;
 
 	int index=-1;
@@ -4222,7 +4222,7 @@ void SpatialEditorPlugin::make_visible(bool p_visible) {
 }
 void SpatialEditorPlugin::edit(Object *p_object) {
 
-	spatial_editor->edit(p_object->cast_to<Spatial>());
+	spatial_editor->edit(Object::cast_to<Spatial>(p_object));
 }
 
 bool SpatialEditorPlugin::handles(Object *p_object) const {

--- a/tools/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/tools/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -859,7 +859,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 void SpriteFramesEditorPlugin::edit(Object *p_object) {
 
 	frames_editor->set_undo_redo(&get_undo_redo());
-	SpriteFrames * s = p_object->cast_to<SpriteFrames>();
+	SpriteFrames * s = Object::cast_to<SpriteFrames>(p_object);
 	if (!s)
 		return;
 

--- a/tools/editor/plugins/sprite_region_editor_plugin.cpp
+++ b/tools/editor/plugins/sprite_region_editor_plugin.cpp
@@ -366,7 +366,7 @@ void SpriteRegionEditor::_bind_methods()
 void SpriteRegionEditor::edit(Node *p_sprite)
 {
 	if (p_sprite) {
-		node=p_sprite->cast_to<Sprite>();
+		node=Object::cast_to<Sprite>(p_sprite);
 		node->connect("exit_tree",this,"_node_removed",varray(p_sprite),CONNECT_ONESHOT);
 	} else {
 		if (node)
@@ -537,7 +537,7 @@ SpriteRegionEditor::SpriteRegionEditor(EditorNode* p_editor)
 
 void SpriteRegionEditorPlugin::edit(Object *p_node)
 {
-	region_editor->edit(p_node->cast_to<Node>());
+	region_editor->edit(Object::cast_to<Node>(p_node));
 }
 
 bool SpriteRegionEditorPlugin::handles(Object *p_node) const

--- a/tools/editor/plugins/stream_editor_plugin.cpp
+++ b/tools/editor/plugins/stream_editor_plugin.cpp
@@ -99,7 +99,7 @@ StreamEditor::StreamEditor() {
 
 void StreamEditorPlugin::edit(Object *p_object) {
 
-	stream_editor->edit(p_object->cast_to<Node>());
+	stream_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool StreamEditorPlugin::handles(Object *p_object) const {

--- a/tools/editor/plugins/style_box_editor_plugin.cpp
+++ b/tools/editor/plugins/style_box_editor_plugin.cpp
@@ -76,8 +76,8 @@ StyleBoxEditor::StyleBoxEditor() {
 
 void StyleBoxEditorPlugin::edit(Object *p_node) {
 
-	if (p_node && p_node->cast_to<StyleBox>()) {
-		stylebox_editor->edit( p_node->cast_to<StyleBox>() );
+	if (StyleBox *sb = Object::cast_to<StyleBox>(p_node)) {
+		stylebox_editor->edit(sb);
 		stylebox_editor->show();
 	} else
 		stylebox_editor->hide();

--- a/tools/editor/plugins/texture_editor_plugin.cpp
+++ b/tools/editor/plugins/texture_editor_plugin.cpp
@@ -46,8 +46,8 @@ void TextureEditor::_notification(int p_what) {
 		Ref<Font> font = get_font("font","Label");
 
 		String format;
-		if (texture->cast_to<ImageTexture>()) {
-			format = Image::get_format_name(texture->cast_to<ImageTexture>()->get_format());
+		if (Object::cast_to<ImageTexture>(*texture)) {
+			format = Image::get_format_name(Object::cast_to<ImageTexture>(*texture)->get_format());
 		} else {
 			format=texture->get_type();
 		}
@@ -97,7 +97,7 @@ TextureEditor::TextureEditor() {
 
 void TextureEditorPlugin::edit(Object *p_object) {
 
-	Texture * s = p_object->cast_to<Texture>();
+	Texture * s = Object::cast_to<Texture>(p_object);
 	if (!s)
 		return;
 

--- a/tools/editor/plugins/theme_editor_plugin.cpp
+++ b/tools/editor/plugins/theme_editor_plugin.cpp
@@ -44,7 +44,7 @@ void ThemeEditor::_propagate_redraw(Control *p_at) {
 	p_at->minimum_size_changed();
 	p_at->update();
 	for(int i=0;i<p_at->get_child_count();i++) {
-		Control *a = p_at->get_child(i)->cast_to<Control>();
+		Control *a = Object::cast_to<Control>(p_at->get_child(i));
 		if (a)
 			_propagate_redraw(a);
 
@@ -876,9 +876,9 @@ ThemeEditor::ThemeEditor() {
 
 void ThemeEditorPlugin::edit(Object *p_node) {
 
-	if (p_node && p_node->cast_to<Theme>()) {
+	if (Theme *theme = Object::cast_to<Theme>(p_node)) {
 		theme_editor->show();
-		theme_editor->edit( p_node->cast_to<Theme>() );
+		theme_editor->edit(theme);
 	} else {
 		theme_editor->edit( Ref<Theme>() );
 		theme_editor->hide();

--- a/tools/editor/plugins/tile_map_editor_plugin.cpp
+++ b/tools/editor/plugins/tile_map_editor_plugin.cpp
@@ -1176,7 +1176,7 @@ void TileMapEditor::edit(Node *p_tile_map) {
 		node->disconnect("settings_changed",this,"_tileset_settings_changed");
 	if (p_tile_map) {
 
-		node=p_tile_map->cast_to<TileMap>();
+		node=Object::cast_to<TileMap>(p_tile_map);
 		if (!canvas_item_editor->is_connected("draw",this,"_canvas_draw"))
 			canvas_item_editor->connect("draw",this,"_canvas_draw");
 		if (!canvas_item_editor->is_connected("mouse_enter",this,"_canvas_mouse_enter"))
@@ -1254,7 +1254,7 @@ TileMapEditor::CellOp TileMapEditor::_get_op_from_cell(const Point2i& p_pos)
 
 void TileMapEditor::_update_transform_buttons(Object *p_button) {
 	//ERR_FAIL_NULL(p_button);
-	ToolButton *b=p_button->cast_to<ToolButton>();
+	ToolButton *b=Object::cast_to<ToolButton>(p_button);
 	//ERR_FAIL_COND(!b);
 
 	if (b == rotate_0) {
@@ -1410,7 +1410,7 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 
 void TileMapEditorPlugin::edit(Object *p_object) {
 
-	tile_map_editor->edit(p_object->cast_to<Node>());
+	tile_map_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool TileMapEditorPlugin::handles(Object *p_object) const {

--- a/tools/editor/plugins/tile_set_editor_plugin.cpp
+++ b/tools/editor/plugins/tile_set_editor_plugin.cpp
@@ -45,10 +45,10 @@ void TileSetEditor::_import_scene(Node *scene, Ref<TileSet> p_library, bool p_me
 		Node *child = scene->get_child(i);
 
 
-		if (!child->cast_to<Sprite>()) {
+		if (!Object::cast_to<Sprite>(child)) {
 			if (child->get_child_count()>0) {
 				child=child->get_child(0);
-				if (!child->cast_to<Sprite>()) {
+				if (!Object::cast_to<Sprite>(child)) {
 					continue;
 				}
 
@@ -58,7 +58,7 @@ void TileSetEditor::_import_scene(Node *scene, Ref<TileSet> p_library, bool p_me
 
 		}
 
-		Sprite *mi = child->cast_to<Sprite>();
+		Sprite *mi = Object::cast_to<Sprite>(child);
 		Ref<Texture> texture=mi->get_texture();
 		Ref<CanvasItemMaterial> material=mi->get_material();
 
@@ -101,15 +101,15 @@ void TileSetEditor::_import_scene(Node *scene, Ref<TileSet> p_library, bool p_me
 
 			Node *child2 = mi->get_child(j);
 
-			if (child2->cast_to<NavigationPolygonInstance>())
-				nav_poly=child2->cast_to<NavigationPolygonInstance>()->get_navigation_polygon();
+			if (Object::cast_to<NavigationPolygonInstance>(child2))
+				nav_poly=Object::cast_to<NavigationPolygonInstance>(child2)->get_navigation_polygon();
 
-			if (child2->cast_to<LightOccluder2D>())
-				occluder=child2->cast_to<LightOccluder2D>()->get_occluder_polygon();
+			if (Object::cast_to<LightOccluder2D>(child2))
+				occluder=Object::cast_to<LightOccluder2D>(child2)->get_occluder_polygon();
 
-			if (!child2->cast_to<StaticBody2D>())
+			if (!Object::cast_to<StaticBody2D>(child2))
 				continue;
-			StaticBody2D *sb = child2->cast_to<StaticBody2D>();
+			StaticBody2D *sb = Object::cast_to<StaticBody2D>(child2);
 			int shape_count = sb->get_shape_count();
 			if (shape_count==0)
 				continue;
@@ -259,8 +259,8 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 
 void TileSetEditorPlugin::edit(Object *p_node) {
 
-	if (p_node && p_node->cast_to<TileSet>()) {
-		tileset_editor->edit( p_node->cast_to<TileSet>() );
+	if (TileSet *ts = Object::cast_to<TileSet>(p_node)) {
+		tileset_editor->edit(ts);
 		tileset_editor->show();
 	} else
 		tileset_editor->hide();

--- a/tools/editor/project_export.cpp
+++ b/tools/editor/project_export.cpp
@@ -898,7 +898,7 @@ void ProjectExportDialog::_group_add() {
 
 void ProjectExportDialog::_group_del(Object *p_item, int p_column, int p_button){
 
-	TreeItem *item = p_item->cast_to<TreeItem>();
+	TreeItem *item = Object::cast_to<TreeItem>(p_item);
 	if (!item)
 		return;
 	String name = item->get_text(0);

--- a/tools/editor/project_manager.cpp
+++ b/tools/editor/project_manager.cpp
@@ -358,7 +358,7 @@ void ProjectManager::_notification(int p_what) {
 
 void ProjectManager::_panel_draw(Node *p_hb) {
 
-	HBoxContainer *hb = p_hb->cast_to<HBoxContainer>();
+	HBoxContainer *hb = Object::cast_to<HBoxContainer>(p_hb);
 
 	hb->draw_line(Point2(0,hb->get_size().y+1),Point2(hb->get_size().x-10,hb->get_size().y+1),get_color("guide_color","Tree"));
 
@@ -379,7 +379,7 @@ void ProjectManager::_panel_input(const InputEvent& p_ev,Node *p_hb) {
 			int clicked_id = -1;
 			int last_clicked_id = -1;
 			for(int i=0;i<scroll_childs->get_child_count();i++) {
-				HBoxContainer *hb = scroll_childs->get_child(i)->cast_to<HBoxContainer>();
+				HBoxContainer *hb = Object::cast_to<HBoxContainer>(scroll_childs->get_child(i));
 				if (!hb) continue;
 				if (hb->get_meta("name") == clicked) clicked_id = i;
 				if (hb->get_meta("name") == last_clicked) last_clicked_id = i;
@@ -389,7 +389,7 @@ void ProjectManager::_panel_input(const InputEvent& p_ev,Node *p_hb) {
 				int min = clicked_id < last_clicked_id? clicked_id : last_clicked_id;
 				int max = clicked_id > last_clicked_id? clicked_id : last_clicked_id;
 				for(int i=0; i<scroll_childs->get_child_count(); ++i) {
-					HBoxContainer *hb = scroll_childs->get_child(i)->cast_to<HBoxContainer>();
+					HBoxContainer *hb = Object::cast_to<HBoxContainer>(scroll_childs->get_child(i));
 					if (!hb) continue;
 					if (i!=clicked_id && (i<min || i>max) && !p_ev.key.mod.control) {
 						selected_list.erase(hb->get_meta("name"));
@@ -421,7 +421,7 @@ void ProjectManager::_panel_input(const InputEvent& p_ev,Node *p_hb) {
 
 		single_selected_main = "";
 		for(int i=0;i<scroll_childs->get_child_count();i++) {
-			CanvasItem *item = scroll_childs->get_child(i)->cast_to<CanvasItem>();
+			CanvasItem *item = Object::cast_to<CanvasItem>(scroll_childs->get_child(i));
 			item->update();
 
 			if (single_selected!="" && single_selected == item->get_meta("name"))

--- a/tools/editor/project_settings.cpp
+++ b/tools/editor/project_settings.cpp
@@ -384,7 +384,7 @@ void ProjectSettings::_add_item(int p_item){
 
 void ProjectSettings::_action_button_pressed(Object* p_obj, int p_column,int p_id) {
 
-	TreeItem *ti=p_obj->cast_to<TreeItem>();
+	TreeItem *ti=Object::cast_to<TreeItem>(p_obj);
 
 	ERR_FAIL_COND(!ti);
 
@@ -942,7 +942,7 @@ void ProjectSettings::_autoload_add() {
 void ProjectSettings::_autoload_delete(Object *p_item,int p_column, int p_button) {
 
 
-	TreeItem *ti=p_item->cast_to<TreeItem>();
+	TreeItem *ti=Object::cast_to<TreeItem>(p_item);
 	String name = "autoload/"+ti->get_text(0);
 
 	if (p_button==0) {
@@ -993,7 +993,7 @@ void ProjectSettings::_autoload_delete(Object *p_item,int p_column, int p_button
 
 void ProjectSettings::_translation_delete(Object *p_item,int p_column, int p_button) {
 
-	TreeItem *ti = p_item->cast_to<TreeItem>();
+	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 	ERR_FAIL_COND(!ti);
 
 	int idx=ti->get_metadata(0);
@@ -1151,7 +1151,7 @@ void ProjectSettings::_translation_res_delete(Object *p_item,int p_column, int p
 
 	Dictionary remaps = Globals::get_singleton()->get("locale/translation_remaps");
 
-	TreeItem *k = p_item->cast_to<TreeItem>();
+	TreeItem *k = Object::cast_to<TreeItem>(p_item);
 
 	String key = k->get_metadata(0);
 	ERR_FAIL_COND(!remaps.has(key));
@@ -1181,7 +1181,7 @@ void ProjectSettings::_translation_res_option_delete(Object *p_item,int p_column
 
 	TreeItem *k = translation_remap->get_selected();
 	ERR_FAIL_COND(!k);
-	TreeItem *ed = p_item->cast_to<TreeItem>();
+	TreeItem *ed = Object::cast_to<TreeItem>(p_item);
 	ERR_FAIL_COND(!ed);
 
 	String key = k->get_metadata(0);

--- a/tools/editor/property_editor.cpp
+++ b/tools/editor/property_editor.cpp
@@ -161,7 +161,7 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 
 					Object *inst = ObjectTypeDB::instance( orig_type );
 
-					Ref<Resource> res = Ref<Resource>( inst->cast_to<Resource>() );
+					Ref<Resource> res = Ref<Resource>( Object::cast_to<Resource>(inst) );
 
 					ERR_FAIL_COND(res.is_null());
 
@@ -208,7 +208,7 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 
 					Object *obj = ObjectTypeDB::instance(intype);
 					ERR_BREAK( !obj );
-					Resource *res=obj->cast_to<Resource>();
+					Resource *res=Object::cast_to<Resource>(obj);
 					ERR_BREAK( !res );
 
 					v=Ref<Resource>(res).get_ref_ptr();
@@ -910,7 +910,7 @@ void CustomPropertyEditor::_type_create_selected(int p_idx) {
 		ERR_FAIL_COND( !obj );
 
 
-		Resource *res=obj->cast_to<Resource>();
+		Resource *res=Object::cast_to<Resource>(obj);
 		ERR_FAIL_COND( !res );
 
 		v=Ref<Resource>(res).get_ref_ptr();
@@ -935,9 +935,9 @@ void CustomPropertyEditor::_node_path_selected(NodePath p_path) {
 		Node *node=NULL;
 
 		if (owner->is_type("Node"))
-			node = owner->cast_to<Node>();
+			node = Object::cast_to<Node>(owner);
 		else if (owner->is_type("ArrayPropertyEdit"))
-			node = owner->cast_to<ArrayPropertyEdit>()->get_node();
+			node = Object::cast_to<ArrayPropertyEdit>(owner)->get_node();
 
 		if (!node) {
 			v=p_path;
@@ -1074,7 +1074,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 
 					Object *obj = ObjectTypeDB::instance(intype);
 					ERR_BREAK( !obj );
-					Resource *res=obj->cast_to<Resource>();
+					Resource *res=Object::cast_to<Resource>(obj);
 					ERR_BREAK( !res );
 
 					v=Ref<Resource>(res).get_ref_ptr();
@@ -1823,7 +1823,7 @@ bool PropertyEditor::_might_be_in_instance() {
 	if (!obj)
 		return false;
 
-	Node *node = obj->cast_to<Node>();
+	Node *node = Object::cast_to<Node>(obj);
 
 	Node* edited_scene =EditorNode::get_singleton()->get_edited_scene();
 
@@ -1852,7 +1852,7 @@ bool PropertyEditor::_might_be_in_instance() {
 
 bool PropertyEditor::_get_instanced_node_original_property(const StringName& p_prop, Variant& value) {
 
-	Node *node = obj->cast_to<Node>();
+	Node *node = Object::cast_to<Node>(obj);
 
 	if (!node)
 		return false;
@@ -1910,7 +1910,7 @@ bool PropertyEditor::_is_property_different(const Variant& p_current, const Vari
 
 
 	{
-		Node *node = obj->cast_to<Node>();
+		Node *node = Object::cast_to<Node>(obj);
 		if (!node)
 			return false;
 
@@ -2675,7 +2675,7 @@ void PropertyEditor::update_tree() {
 */
 
 	/*
-	if (obj->cast_to<Node>() || obj->cast_to<Resource>()) {
+	if (Object::cast_to<Node>(obj) || Object::cast_to<Resource>(obj)) {
 		TreeItem *type = tree->create_item(root);
 
 		type->set_text(0,"Type"); // todo, fetch name if ID exists in database
@@ -2693,9 +2693,9 @@ void PropertyEditor::update_tree() {
 
 		name->set_text(0,"Name"); // todo, fetch name if ID exists in database
 		if (obj->is_type("Resource"))
-			name->set_text(1,obj->cast_to<Resource>()->get_name());
+			name->set_text(1,Object::cast_to<Resource>(obj)->get_name());
 		else if (obj->is_type("Node"))
-			name->set_text(1,obj->cast_to<Node>()->get_name());
+			name->set_text(1,Object::cast_to<Node>(obj)->get_name());
 		name->set_selectable(0,false);
 		name->set_selectable(1,false);
 	}
@@ -2706,7 +2706,7 @@ void PropertyEditor::update_tree() {
 	bool draw_red=false;
 
 	{
-		Node *nod = obj->cast_to<Node>();
+		Node *nod = Object::cast_to<Node>(obj);
 		Node *es = EditorNode::get_singleton()->get_edited_scene();
 		if (nod && es!=nod && nod->get_owner()!=es) {
 			draw_red=true;
@@ -3460,7 +3460,7 @@ void PropertyEditor::_edit_set(const String& p_name, const Variant& p_value) {
 		}
 	}
 
-	if (!undo_redo || obj->cast_to<MultiNodeEdit>() || obj->cast_to<ArrayPropertyEdit>()) { //kind of hacky
+	if (!undo_redo || Object::cast_to<MultiNodeEdit>(obj) || cast_to<ArrayPropertyEdit>(obj)) { //kind of hacky
 
 		obj->set(p_name,p_value);
 		_changed_callbacks(obj,p_name);
@@ -3476,7 +3476,7 @@ void PropertyEditor::_edit_set(const String& p_name, const Variant& p_value) {
 		undo_redo->add_do_method(this,"_changed_callback",obj,p_name);
 		undo_redo->add_undo_method(this,"_changed_callback",obj,p_name);
 		undo_redo->add_undo_method(this,"_changed_callback",obj,p_name);
-		Resource *r = obj->cast_to<Resource>();
+		Resource *r = Object::cast_to<Resource>(obj);
 		if (r) {
 			if (!r->is_edited() && String(p_name)!="resource/edited") {
 				undo_redo->add_do_method(r,"set_edited",true);
@@ -3702,7 +3702,7 @@ void PropertyEditor::edit(Object* p_object) {
 
 void PropertyEditor::_set_range_def(Object *p_item, String prop,float p_frame) {
 
-	TreeItem *ti = p_item->cast_to<TreeItem>();
+	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 	ERR_FAIL_COND(!ti);
 
 	ti->call_deferred("set_range",1, p_frame);
@@ -3711,7 +3711,7 @@ void PropertyEditor::_set_range_def(Object *p_item, String prop,float p_frame) {
 }
 
 void PropertyEditor::_edit_button(Object *p_item, int p_column, int p_button) {
-	TreeItem *ti = p_item->cast_to<TreeItem>();
+	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 	ERR_FAIL_COND(!ti);
 
 	Dictionary d = ti->get_metadata(0);
@@ -3838,7 +3838,7 @@ void PropertyEditor::set_keying(bool p_active) {
 
 void PropertyEditor::_draw_flags(Object *t,const Rect2& p_rect) {
 
-	TreeItem *ti = t->cast_to<TreeItem>();
+	TreeItem *ti = Object::cast_to<TreeItem>(t);
 	if (!ti)
 		return;
 
@@ -3894,7 +3894,7 @@ void PropertyEditor::_resource_preview_done(const String& p_path,const Ref<Textu
 	if (!obj)
 		return;
 
-	TreeItem *ti = obj->cast_to<TreeItem>();
+	TreeItem *ti = Object::cast_to<TreeItem>(obj);
 
 	ERR_FAIL_COND(!ti);
 
@@ -3990,7 +3990,7 @@ void PropertyEditor::set_use_filter(bool p_use) {
 void PropertyEditor::register_text_enter(Node* p_line_edit) {
 
 	ERR_FAIL_NULL(p_line_edit);
-	search_box=p_line_edit->cast_to<LineEdit>();
+	search_box=Object::cast_to<LineEdit>(p_line_edit);
 
 	if (search_box)
 		search_box->connect("text_changed",this,"_filter_changed");

--- a/tools/editor/resources_dock.cpp
+++ b/tools/editor/resources_dock.cpp
@@ -295,7 +295,7 @@ void ResourcesDock::_resource_selected() {
 
 void ResourcesDock::_delete(Object* p_item, int p_column, int p_id) {
 
-	TreeItem *ti = p_item->cast_to<TreeItem>();
+	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 	ERR_FAIL_COND(!ti);
 
 
@@ -308,7 +308,7 @@ void ResourcesDock::_create() {
 	Object *c = create_dialog->instance_selected();
 
 	ERR_FAIL_COND(!c);
-	Resource *r = c->cast_to<Resource>();
+	Resource *r = Object::cast_to<Resource>(c);
 	ERR_FAIL_COND(!r);
 
 	REF res( r );

--- a/tools/editor/scene_tree_dock.cpp
+++ b/tools/editor/scene_tree_dock.cpp
@@ -611,7 +611,7 @@ void SceneTreeDock::_notification(int p_what) {
 				break;
 			first_enter=false;
 
-			CanvasItemEditorPlugin *canvas_item_plugin =  editor_data->get_editor("2D")->cast_to<CanvasItemEditorPlugin>();
+			CanvasItemEditorPlugin *canvas_item_plugin =  Object::cast_to<CanvasItemEditorPlugin>(editor_data->get_editor("2D"));
 			if (canvas_item_plugin) {
 				canvas_item_plugin->get_canvas_item_editor()->connect("item_lock_status_changed", scene_tree, "_update_tree");
 				canvas_item_plugin->get_canvas_item_editor()->connect("item_group_status_changed", scene_tree, "_update_tree");
@@ -672,7 +672,7 @@ Node *SceneTreeDock::_duplicate(Node *p_node, Map<Node*,Node*> &duplimap) {
 	} else {
 		Object *obj = ObjectTypeDB::instance(p_node->get_type());
 		ERR_FAIL_COND_V(!obj,NULL);
-		node = obj->cast_to<Node>();
+		node = Object::cast_to<Node>(obj);
 		if (!node)
 			memdelete(obj);
 		ERR_FAIL_COND_V(!node,NULL);
@@ -733,7 +733,7 @@ void SceneTreeDock::_set_owners(Node *p_owner, const Array& p_nodes) {
 		if (!obj)
 			continue;
 
-		Node *n=obj->cast_to<Node>();
+		Node *n=Object::cast_to<Node>(obj);
 		if (!n)
 			continue;
 		n->set_owner(p_owner);
@@ -813,9 +813,9 @@ void SceneTreeDock::perform_node_renames(Node* p_base,List<Pair<NodePath,NodePat
 		return;
 
 
-	if (p_base->cast_to<AnimationPlayer>()) {
+	if (Object::cast_to<AnimationPlayer>(p_base)) {
 
-		AnimationPlayer *ap=p_base->cast_to<AnimationPlayer>();
+		AnimationPlayer *ap=Object::cast_to<AnimationPlayer>(p_base);
 		List<StringName> anims;
 		ap->get_animation_list(&anims);
 		Node *root = ap->get_node(ap->get_root());
@@ -1066,20 +1066,20 @@ void SceneTreeDock::_do_reparent(Node* p_new_parent,int p_position_in_parent,Vec
 		editor_data->get_undo_redo().add_undo_method(sed,"live_debug_reparent_node",NodePath(String(edited_scene->get_path_to(new_parent))+"/"+new_name),edited_scene->get_path_to(node->get_parent()),node->get_name(),node->get_index());
 
 		if (p_keep_global_xform) {
-			if (node->cast_to<Node2D>())
-				editor_data->get_undo_redo().add_do_method(node,"set_global_transform",node->cast_to<Node2D>()->get_global_transform());
-			if (node->cast_to<Spatial>())
-				editor_data->get_undo_redo().add_do_method(node,"set_global_transform",node->cast_to<Spatial>()->get_global_transform());
-			if (node->cast_to<Control>()) {
+			if (Object::cast_to<Node2D>(node))
+				editor_data->get_undo_redo().add_do_method(node,"set_global_transform",Object::cast_to<Node2D>(node)->get_global_transform());
+			if (Object::cast_to<Spatial>(node))
+				editor_data->get_undo_redo().add_do_method(node,"set_global_transform",Object::cast_to<Spatial>(node)->get_global_transform());
+			if (Object::cast_to<Control>(node)) {
 				bool can_do_it=false;
-				Control *c=node->cast_to<Control>();
-				if (c->get_parent()->cast_to<Container>())
+				Control *c=Object::cast_to<Control>(node);
+				if (Object::cast_to<Container>(c->get_parent()))
 					can_do_it=false;
 				for(int i=0;i<4;i++) {
 					if (c->get_anchor(Margin(i))!=ANCHOR_BEGIN)
 						can_do_it=false;
 				}
-				editor_data->get_undo_redo().add_do_method(node,"set_global_pos",node->cast_to<Control>()->get_global_pos());
+				editor_data->get_undo_redo().add_do_method(node,"set_global_pos",Object::cast_to<Control>(node)->get_global_pos());
 			}
 		}
 
@@ -1117,20 +1117,20 @@ void SceneTreeDock::_do_reparent(Node* p_new_parent,int p_position_in_parent,Vec
 			editor_data->get_undo_redo().add_undo_method(AnimationPlayerEditor::singleton->get_key_editor(),"set_root",node);
 
 		if (p_keep_global_xform) {
-			if (node->cast_to<Node2D>())
-				editor_data->get_undo_redo().add_undo_method(node,"set_transform",node->cast_to<Node2D>()->get_transform());
-			if (node->cast_to<Spatial>())
-				editor_data->get_undo_redo().add_undo_method(node,"set_transform",node->cast_to<Spatial>()->get_transform());
-			if (node->cast_to<Control>()) {
+			if (Object::cast_to<Node2D>(node))
+				editor_data->get_undo_redo().add_undo_method(node,"set_transform",Object::cast_to<Node2D>(node)->get_transform());
+			if (Object::cast_to<Spatial>(node))
+				editor_data->get_undo_redo().add_undo_method(node,"set_transform",Object::cast_to<Spatial>(node)->get_transform());
+			if (Object::cast_to<Control>(node)) {
 				bool can_do_it=false;
-				Control *c=node->cast_to<Control>();
-				if (c->get_parent()->cast_to<Container>())
+				Control *c=Object::cast_to<Control>(node);
+				if (Object::cast_to<Container>(c->get_parent()))
 					can_do_it=false;
 				for(int i=0;i<4;i++) {
 					if (c->get_anchor(Margin(i))!=ANCHOR_BEGIN)
 						can_do_it=false;
 				}
-				editor_data->get_undo_redo().add_undo_method(node,"set_pos",node->cast_to<Control>()->get_pos());
+				editor_data->get_undo_redo().add_undo_method(node,"set_pos",Object::cast_to<Control>(node)->get_pos());
 			}
 		}
 
@@ -1275,7 +1275,7 @@ void SceneTreeDock::_create() {
 		Object *c = create_dialog->instance_selected();
 
 		ERR_FAIL_COND(!c);
-		Node *child=c->cast_to<Node>();
+		Node *child=Object::cast_to<Node>(c);
 		ERR_FAIL_COND(!child);
 
 		editor_data->get_undo_redo().create_action(TTR("Create Node"));
@@ -1306,9 +1306,9 @@ void SceneTreeDock::_create() {
 		editor_data->get_undo_redo().commit_action();
 		editor->push_item(c);
 
-		if (c->cast_to<Control>()) {
+		if (Object::cast_to<Control>(c)) {
 			//make editor more comfortable, so some controls don't appear super shrunk
-			Control *ct = c->cast_to<Control>();
+			Control *ct = Object::cast_to<Control>(c);
 
 			Size2 ms = ct->get_minimum_size();
 			if (ms.width<4)
@@ -1326,7 +1326,7 @@ void SceneTreeDock::_create() {
 		Object *c = create_dialog->instance_selected();
 
 		ERR_FAIL_COND(!c);
-		Node *newnode=c->cast_to<Node>();
+		Node *newnode=Object::cast_to<Node>(c);
 		ERR_FAIL_COND(!newnode);
 
 		List<PropertyInfo> pinfo;

--- a/tools/editor/scene_tree_editor.cpp
+++ b/tools/editor/scene_tree_editor.cpp
@@ -49,7 +49,7 @@ void SceneTreeEditor::_subscene_option(int p_idx) {
 	Object *obj = ObjectDB::get_instance(instance_node);
 	if (!obj)
 		return;
-	Node *node = obj->cast_to<Node>();
+	Node *node = Object::cast_to<Node>(obj);
 	if (!node)
 		return;
 
@@ -115,7 +115,7 @@ void SceneTreeEditor::_subscene_option(int p_idx) {
 
 void SceneTreeEditor::_cell_button_pressed(Object *p_item,int p_column,int p_id) {
 
-	TreeItem *item=p_item->cast_to<TreeItem>();
+	TreeItem *item=Object::cast_to<TreeItem>(p_item);
 	ERR_FAIL_COND(!item);
 
 	NodePath np = item->get_metadata(0);
@@ -166,7 +166,7 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item,int p_column,int p_id)
 
 		if (n->is_type("Spatial")) {
 
-			Spatial *ci = n->cast_to<Spatial>();
+			Spatial *ci = Object::cast_to<Spatial>(n);
 			if (!ci->is_visible() && ci->get_parent_spatial() && !ci->get_parent_spatial()->is_visible()) {
 				error->set_text(TTR("This item cannot be made visible because the parent is hidden. Unhide the parent first."));
 				error->popup_centered_minsize();
@@ -180,7 +180,7 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item,int p_column,int p_id)
 			undo_redo->commit_action();
 		} else if (n->is_type("CanvasItem")) {
 
-			CanvasItem *ci = n->cast_to<CanvasItem>();
+			CanvasItem *ci = Object::cast_to<CanvasItem>(n);
 			if (!ci->is_visible() && ci->get_parent_item() && !ci->get_parent_item()->is_visible()) {
 				error->set_text(TTR("This item cannot be made visible because the parent is hidden. Unhide the parent first."));
 				error->popup_centered_minsize();
@@ -544,7 +544,7 @@ void SceneTreeEditor::_selected_changed() {
 
 void SceneTreeEditor::_cell_multi_selected(Object *p_object,int p_cell,bool p_selected) {
 
-	TreeItem *item = p_object->cast_to<TreeItem>();
+	TreeItem *item = Object::cast_to<TreeItem>(p_object);
 	ERR_FAIL_COND(!item);
 
 	NodePath np = item->get_metadata(0);
@@ -653,7 +653,7 @@ void SceneTreeEditor::_rename_node(ObjectID p_node,const String& p_name) {
 
 	Object *o = ObjectDB::get_instance(p_node);
 	ERR_FAIL_COND(!o);
-	Node *n = o->cast_to<Node>();
+	Node *n = Object::cast_to<Node>(o);
 	ERR_FAIL_COND(!n);
 	TreeItem* item=_find(tree->get_root(),n->get_path());
 	ERR_FAIL_COND(!item);
@@ -809,7 +809,7 @@ void SceneTreeEditor::_cell_collapsed(Object *p_obj) {
 	if (!can_rename)
 		return;
 
-	TreeItem *ti=p_obj->cast_to<TreeItem>();
+	TreeItem *ti=Object::cast_to<TreeItem>(p_obj);
 	if (!ti)
 		return;
 

--- a/tools/editor/script_editor_debugger.cpp
+++ b/tools/editor/script_editor_debugger.cpp
@@ -229,7 +229,7 @@ void ScriptEditorDebugger::_scene_tree_folded(Object* obj) {
 
 		return;
 	}
-	TreeItem *item=obj->cast_to<TreeItem>();
+	TreeItem *item=Object::cast_to<TreeItem>(obj);
 
 	if (!item)
 		return;
@@ -1275,7 +1275,7 @@ void ScriptEditorDebugger::_method_changed(Object*p_base,const StringName& p_nam
 	if (!p_base || !live_debug || !connection.is_valid() || !editor->get_edited_scene())
 		return;
 
-	Node *node = p_base->cast_to<Node>();
+	Node *node = Object::cast_to<Node>(p_base);
 
 	VARIANT_ARGPTRS
 
@@ -1306,7 +1306,7 @@ void ScriptEditorDebugger::_method_changed(Object*p_base,const StringName& p_nam
 
 	}
 
-	Resource *res = p_base->cast_to<Resource>();
+	Resource *res = Object::cast_to<Resource>(p_base);
 
 	if (res && res->get_path()!=String()) {
 
@@ -1334,7 +1334,7 @@ void ScriptEditorDebugger::_property_changed(Object*p_base,const StringName& p_p
 	if (!p_base || !live_debug || !connection.is_valid() || !editor->get_edited_scene())
 		return;
 
-	Node *node = p_base->cast_to<Node>();
+	Node *node = Object::cast_to<Node>(p_base);
 
 	if (node) {
 
@@ -1368,7 +1368,7 @@ void ScriptEditorDebugger::_property_changed(Object*p_base,const StringName& p_p
 
 	}
 
-	Resource *res = p_base->cast_to<Resource>();
+	Resource *res = Object::cast_to<Resource>(p_base);
 
 	if (res && res->get_path()!=String()) {
 

--- a/tools/editor/spatial_editor_gizmos.cpp
+++ b/tools/editor/spatial_editor_gizmos.cpp
@@ -792,7 +792,7 @@ void LightSpatialGizmo::set_handle(int p_idx,Camera *p_camera, const Point2& p_p
 	Vector3 s[2]={gi.xform(ray_from),gi.xform(ray_from+ray_dir*4096)};
 	if (p_idx==0) {
 
-		if (light->cast_to<SpotLight>()) {
+		if (Object::cast_to<SpotLight>(light)) {
 			Vector3 ra,rb;
 			Geometry::get_closest_points_between_segments(Vector3(),Vector3(0,0,-4096),s[0],s[1],ra,rb);
 
@@ -801,7 +801,7 @@ void LightSpatialGizmo::set_handle(int p_idx,Camera *p_camera, const Point2& p_p
 				d=0;
 
 			light->set_parameter(Light::PARAM_RADIUS,d);
-		} else if (light->cast_to<OmniLight>()) {
+		} else if (Object::cast_to<OmniLight>(light)) {
 
 			Plane cp=Plane( gt.origin, p_camera->get_transform().basis.get_axis(2));
 
@@ -850,7 +850,7 @@ void LightSpatialGizmo::commit_handle(int p_idx,const Variant& p_restore,bool p_
 void LightSpatialGizmo::redraw() {
 
 
-	if (light->cast_to<DirectionalLight>()) {
+	if (Object::cast_to<DirectionalLight>(light)) {
 
 
 
@@ -895,12 +895,12 @@ void LightSpatialGizmo::redraw() {
 
 	}
 
-	if (light->cast_to<OmniLight>()) {
+	if (Object::cast_to<OmniLight>(light)) {
 
 		clear();
 
 
-		OmniLight *on = light->cast_to<OmniLight>();
+		OmniLight *on = Object::cast_to<OmniLight>(light);
 
 		float r = on->get_parameter(Light::PARAM_RADIUS);
 
@@ -935,12 +935,12 @@ void LightSpatialGizmo::redraw() {
 	}
 
 
-	if (light->cast_to<SpotLight>()) {
+	if (Object::cast_to<SpotLight>(light)) {
 
 		clear();
 
 		Vector<Vector3> points;
-		SpotLight *on = light->cast_to<SpotLight>();
+		SpotLight *on = Object::cast_to<SpotLight>(light);
 
 		float r = on->get_parameter(Light::PARAM_RADIUS);
 		float w = r*Math::sin(Math::deg2rad(on->get_parameter(Light::PARAM_SPOT_ANGLE)));
@@ -1446,11 +1446,11 @@ SkeletonSpatialGizmo::SkeletonSpatialGizmo(Skeleton* p_skel) {
 void SpatialPlayerSpatialGizmo::redraw() {
 
 	clear();
-	if (splayer->cast_to<SpatialStreamPlayer>()) {
+	if (Object::cast_to<SpatialStreamPlayer>(splayer)) {
 
 		add_unscaled_billboard(SpatialEditorGizmos::singleton->stream_player_icon,0.05);
 
-	} else if (splayer->cast_to<SpatialSamplePlayer>()) {
+	} else if (Object::cast_to<SpatialSamplePlayer>(splayer)) {
 
 		add_unscaled_billboard(SpatialEditorGizmos::singleton->sample_player_icon,0.05);
 
@@ -1693,22 +1693,22 @@ String CollisionShapeSpatialGizmo::get_handle_name(int p_idx) const {
 	if (s.is_null())
 		return "";
 
-	if (s->cast_to<SphereShape>()) {
+	if (Object::cast_to<SphereShape>(*s)) {
 
 		return "Radius";
 	}
 
-	if (s->cast_to<BoxShape>()) {
+	if (Object::cast_to<BoxShape>(*s)) {
 
 		return "Extents";
 	}
 
-	if (s->cast_to<CapsuleShape>()) {
+	if (Object::cast_to<CapsuleShape>(*s)) {
 
 		return p_idx==0?"Radius":"Height";
 	}
 
-	if (s->cast_to<RayShape>()) {
+	if (Object::cast_to<RayShape>(*s)) {
 
 		return "Length";
 	}
@@ -1721,25 +1721,25 @@ Variant CollisionShapeSpatialGizmo::get_handle_value(int p_idx) const{
 	if (s.is_null())
 		return Variant();
 
-	if (s->cast_to<SphereShape>()) {
+	if (Object::cast_to<SphereShape>(*s)) {
 
 		Ref<SphereShape> ss = s;
 		return ss->get_radius();
 	}
 
-	if (s->cast_to<BoxShape>()) {
+	if (Object::cast_to<BoxShape>(*s)) {
 
 		Ref<BoxShape> bs = s;
 		return bs->get_extents();
 	}
 
-	if (s->cast_to<CapsuleShape>()) {
+	if (Object::cast_to<CapsuleShape>(*s)) {
 
 		Ref<CapsuleShape> cs = s;
 		return p_idx==0?cs->get_radius():cs->get_height();
 	}
 
-	if (s->cast_to<RayShape>()) {
+	if (Object::cast_to<RayShape>(*s)) {
 
 		Ref<RayShape> cs = s;
 		return cs->get_length();
@@ -1761,7 +1761,7 @@ void CollisionShapeSpatialGizmo::set_handle(int p_idx,Camera *p_camera, const Po
 
 	Vector3 sg[2]={gi.xform(ray_from),gi.xform(ray_from+ray_dir*4096)};
 
-	if (s->cast_to<SphereShape>()) {
+	if (Object::cast_to<SphereShape>(*s)) {
 
 		Ref<SphereShape> ss = s;
 		Vector3 ra,rb;
@@ -1773,7 +1773,7 @@ void CollisionShapeSpatialGizmo::set_handle(int p_idx,Camera *p_camera, const Po
 		ss->set_radius(d);
 	}
 
-	if (s->cast_to<RayShape>()) {
+	if (Object::cast_to<RayShape>(*s)) {
 
 		Ref<RayShape> rs = s;
 		Vector3 ra,rb;
@@ -1786,7 +1786,7 @@ void CollisionShapeSpatialGizmo::set_handle(int p_idx,Camera *p_camera, const Po
 	}
 
 
-	if (s->cast_to<BoxShape>()) {
+	if (Object::cast_to<BoxShape>(*s)) {
 
 		Vector3 axis;
 		axis[p_idx]=1.0;
@@ -1803,7 +1803,7 @@ void CollisionShapeSpatialGizmo::set_handle(int p_idx,Camera *p_camera, const Po
 
 	}
 
-	if (s->cast_to<CapsuleShape>()) {
+	if (Object::cast_to<CapsuleShape>(*s)) {
 
 		Vector3 axis;
 		axis[p_idx==0?0:2]=1.0;
@@ -1829,7 +1829,7 @@ void CollisionShapeSpatialGizmo::commit_handle(int p_idx,const Variant& p_restor
 	if (s.is_null())
 		return;
 
-	if (s->cast_to<SphereShape>()) {
+	if (Object::cast_to<SphereShape>(*s)) {
 
 		Ref<SphereShape> ss=s;
 		if (p_cancel) {
@@ -1845,7 +1845,7 @@ void CollisionShapeSpatialGizmo::commit_handle(int p_idx,const Variant& p_restor
 
 	}
 
-	if (s->cast_to<BoxShape>()) {
+	if (Object::cast_to<BoxShape>(*s)) {
 
 		Ref<BoxShape> ss=s;
 		if (p_cancel) {
@@ -1860,7 +1860,7 @@ void CollisionShapeSpatialGizmo::commit_handle(int p_idx,const Variant& p_restor
 		ur->commit_action();
 	}
 
-	if (s->cast_to<CapsuleShape>()) {
+	if (Object::cast_to<CapsuleShape>(*s)) {
 
 		Ref<CapsuleShape> ss=s;
 		if (p_cancel) {
@@ -1887,7 +1887,7 @@ void CollisionShapeSpatialGizmo::commit_handle(int p_idx,const Variant& p_restor
 
 	}
 
-	if (s->cast_to<RayShape>()) {
+	if (Object::cast_to<RayShape>(*s)) {
 
 		Ref<RayShape> ss=s;
 		if (p_cancel) {
@@ -1912,7 +1912,7 @@ void CollisionShapeSpatialGizmo::redraw(){
 	if (s.is_null())
 		return;
 
-	if (s->cast_to<SphereShape>()) {
+	if (Object::cast_to<SphereShape>(*s)) {
 
 		Ref<SphereShape> sp= s;
 		float r=sp->get_radius();
@@ -1960,7 +1960,7 @@ void CollisionShapeSpatialGizmo::redraw(){
 
 	}
 
-	if (s->cast_to<BoxShape>()) {
+	if (Object::cast_to<BoxShape>(*s)) {
 
 		Ref<BoxShape> bs=s;
 		Vector<Vector3> lines;
@@ -1990,7 +1990,7 @@ void CollisionShapeSpatialGizmo::redraw(){
 
 	}
 
-	if (s->cast_to<CapsuleShape>()) {
+	if (Object::cast_to<CapsuleShape>(*s)) {
 
 		Ref<CapsuleShape> cs=s;
 		float radius = cs->get_radius();
@@ -2070,7 +2070,7 @@ void CollisionShapeSpatialGizmo::redraw(){
 
 	}
 
-	if (s->cast_to<PlaneShape>()) {
+	if (Object::cast_to<PlaneShape>(*s)) {
 
 		Ref<PlaneShape> ps=s;
 		Plane p = ps->get_plane();
@@ -2103,9 +2103,9 @@ void CollisionShapeSpatialGizmo::redraw(){
 	}
 
 
-	if (s->cast_to<ConvexPolygonShape>()) {
+	if (Object::cast_to<ConvexPolygonShape>(*s)) {
 
-		DVector<Vector3> points = s->cast_to<ConvexPolygonShape>()->get_points();
+		DVector<Vector3> points = Object::cast_to<ConvexPolygonShape>(*s)->get_points();
 
 		if (points.size()>3) {
 
@@ -2131,7 +2131,7 @@ void CollisionShapeSpatialGizmo::redraw(){
 	}
 
 
-	if (s->cast_to<RayShape>()) {
+	if (Object::cast_to<RayShape>(*s)) {
 
 		Ref<RayShape> rs=s;
 
@@ -2901,124 +2901,124 @@ SpatialEditorGizmos *SpatialEditorGizmos::singleton=NULL;
 
 Ref<SpatialEditorGizmo> SpatialEditorGizmos::get_gizmo(Spatial *p_spatial) {
 
-	if (p_spatial->cast_to<Light>()) {
+	if (Object::cast_to<Light>(p_spatial)) {
 
-		Ref<LightSpatialGizmo> lsg = memnew( LightSpatialGizmo(p_spatial->cast_to<Light>()) );
+		Ref<LightSpatialGizmo> lsg = memnew( LightSpatialGizmo(Object::cast_to<Light>(p_spatial)) );
 		return lsg;
 	}
 
-	if (p_spatial->cast_to<Camera>()) {
+	if (Object::cast_to<Camera>(p_spatial)) {
 
-		Ref<CameraSpatialGizmo> lsg = memnew( CameraSpatialGizmo(p_spatial->cast_to<Camera>()) );
+		Ref<CameraSpatialGizmo> lsg = memnew( CameraSpatialGizmo(Object::cast_to<Camera>(p_spatial)) );
 		return lsg;
 	}
 
-	if (p_spatial->cast_to<Skeleton>()) {
+	if (Object::cast_to<Skeleton>(p_spatial)) {
 
-		Ref<SkeletonSpatialGizmo> lsg = memnew( SkeletonSpatialGizmo(p_spatial->cast_to<Skeleton>()) );
+		Ref<SkeletonSpatialGizmo> lsg = memnew( SkeletonSpatialGizmo(Object::cast_to<Skeleton>(p_spatial)) );
 		return lsg;
 	}
 
 
-	if (p_spatial->cast_to<Position3D>()) {
+	if (Object::cast_to<Position3D>(p_spatial)) {
 
-		Ref<Position3DSpatialGizmo> lsg = memnew( Position3DSpatialGizmo(p_spatial->cast_to<Position3D>()) );
+		Ref<Position3DSpatialGizmo> lsg = memnew( Position3DSpatialGizmo(Object::cast_to<Position3D>(p_spatial)) );
 		return lsg;
 	}
 
-	if (p_spatial->cast_to<MeshInstance>()) {
+	if (Object::cast_to<MeshInstance>(p_spatial)) {
 
-		Ref<MeshInstanceSpatialGizmo> misg = memnew( MeshInstanceSpatialGizmo(p_spatial->cast_to<MeshInstance>()) );
+		Ref<MeshInstanceSpatialGizmo> misg = memnew( MeshInstanceSpatialGizmo(Object::cast_to<MeshInstance>(p_spatial)) );
 		return misg;
 	}
 
-	if (p_spatial->cast_to<Room>()) {
+	if (Object::cast_to<Room>(p_spatial)) {
 
-		Ref<RoomSpatialGizmo> misg = memnew( RoomSpatialGizmo(p_spatial->cast_to<Room>()) );
+		Ref<RoomSpatialGizmo> misg = memnew( RoomSpatialGizmo(Object::cast_to<Room>(p_spatial)) );
 		return misg;
 	}
 
-	if (p_spatial->cast_to<NavigationMeshInstance>()) {
+	if (Object::cast_to<NavigationMeshInstance>(p_spatial)) {
 
-		Ref<NavigationMeshSpatialGizmo> misg = memnew( NavigationMeshSpatialGizmo(p_spatial->cast_to<NavigationMeshInstance>()) );
+		Ref<NavigationMeshSpatialGizmo> misg = memnew( NavigationMeshSpatialGizmo(Object::cast_to<NavigationMeshInstance>(p_spatial)) );
 		return misg;
 	}
 
-	if (p_spatial->cast_to<RayCast>()) {
+	if (Object::cast_to<RayCast>(p_spatial)) {
 
-		Ref<RayCastSpatialGizmo> misg = memnew( RayCastSpatialGizmo(p_spatial->cast_to<RayCast>()) );
+		Ref<RayCastSpatialGizmo> misg = memnew( RayCastSpatialGizmo(Object::cast_to<RayCast>(p_spatial)) );
 		return misg;
 	}
 
-	if (p_spatial->cast_to<Portal>()) {
+	if (Object::cast_to<Portal>(p_spatial)) {
 
-		Ref<PortalSpatialGizmo> misg = memnew( PortalSpatialGizmo(p_spatial->cast_to<Portal>()) );
+		Ref<PortalSpatialGizmo> misg = memnew( PortalSpatialGizmo(Object::cast_to<Portal>(p_spatial)) );
 		return misg;
 	}
 
 
-	if (p_spatial->cast_to<TestCube>()) {
+	if (Object::cast_to<TestCube>(p_spatial)) {
 
-		Ref<TestCubeSpatialGizmo> misg = memnew( TestCubeSpatialGizmo(p_spatial->cast_to<TestCube>()) );
+		Ref<TestCubeSpatialGizmo> misg = memnew( TestCubeSpatialGizmo(Object::cast_to<TestCube>(p_spatial)) );
 		return misg;
 	}
 
-	if (p_spatial->cast_to<SpatialPlayer>()) {
+	if (Object::cast_to<SpatialPlayer>(p_spatial)) {
 
-		Ref<SpatialPlayerSpatialGizmo> misg = memnew( SpatialPlayerSpatialGizmo(p_spatial->cast_to<SpatialPlayer>()) );
+		Ref<SpatialPlayerSpatialGizmo> misg = memnew( SpatialPlayerSpatialGizmo(Object::cast_to<SpatialPlayer>(p_spatial)) );
 		return misg;
 	}
 
-	if (p_spatial->cast_to<CollisionShape>()) {
+	if (Object::cast_to<CollisionShape>(p_spatial)) {
 
-		Ref<CollisionShapeSpatialGizmo> misg = memnew( CollisionShapeSpatialGizmo(p_spatial->cast_to<CollisionShape>()) );
+		Ref<CollisionShapeSpatialGizmo> misg = memnew( CollisionShapeSpatialGizmo(Object::cast_to<CollisionShape>(p_spatial)) );
 		return misg;
 	}
 
-	if (p_spatial->cast_to<VisibilityNotifier>()) {
+	if (Object::cast_to<VisibilityNotifier>(p_spatial)) {
 
-		Ref<VisibilityNotifierGizmo> misg = memnew( VisibilityNotifierGizmo(p_spatial->cast_to<VisibilityNotifier>()) );
+		Ref<VisibilityNotifierGizmo> misg = memnew( VisibilityNotifierGizmo(Object::cast_to<VisibilityNotifier>(p_spatial)) );
 		return misg;
 	}
 
-	if (p_spatial->cast_to<VehicleWheel>()) {
+	if (Object::cast_to<VehicleWheel>(p_spatial)) {
 
-		Ref<VehicleWheelSpatialGizmo> misg = memnew( VehicleWheelSpatialGizmo(p_spatial->cast_to<VehicleWheel>()) );
+		Ref<VehicleWheelSpatialGizmo> misg = memnew( VehicleWheelSpatialGizmo(Object::cast_to<VehicleWheel>(p_spatial)) );
 		return misg;
 	}
-	if (p_spatial->cast_to<PinJoint>()) {
+	if (Object::cast_to<PinJoint>(p_spatial)) {
 
-		Ref<PinJointSpatialGizmo> misg = memnew( PinJointSpatialGizmo(p_spatial->cast_to<PinJoint>()) );
-		return misg;
-	}
-
-	if (p_spatial->cast_to<HingeJoint>()) {
-
-		Ref<HingeJointSpatialGizmo> misg = memnew( HingeJointSpatialGizmo(p_spatial->cast_to<HingeJoint>()) );
+		Ref<PinJointSpatialGizmo> misg = memnew( PinJointSpatialGizmo(Object::cast_to<PinJoint>(p_spatial)) );
 		return misg;
 	}
 
-	if (p_spatial->cast_to<SliderJoint>()) {
+	if (Object::cast_to<HingeJoint>(p_spatial)) {
 
-		Ref<SliderJointSpatialGizmo> misg = memnew( SliderJointSpatialGizmo(p_spatial->cast_to<SliderJoint>()) );
+		Ref<HingeJointSpatialGizmo> misg = memnew( HingeJointSpatialGizmo(Object::cast_to<HingeJoint>(p_spatial)) );
 		return misg;
 	}
 
-	if (p_spatial->cast_to<ConeTwistJoint>()) {
+	if (Object::cast_to<SliderJoint>(p_spatial)) {
 
-		Ref<ConeTwistJointSpatialGizmo> misg = memnew( ConeTwistJointSpatialGizmo(p_spatial->cast_to<ConeTwistJoint>()) );
+		Ref<SliderJointSpatialGizmo> misg = memnew( SliderJointSpatialGizmo(Object::cast_to<SliderJoint>(p_spatial)) );
 		return misg;
 	}
 
-	if (p_spatial->cast_to<Generic6DOFJoint>()) {
+	if (Object::cast_to<ConeTwistJoint>(p_spatial)) {
 
-		Ref<Generic6DOFJointSpatialGizmo> misg = memnew( Generic6DOFJointSpatialGizmo(p_spatial->cast_to<Generic6DOFJoint>()) );
+		Ref<ConeTwistJointSpatialGizmo> misg = memnew( ConeTwistJointSpatialGizmo(Object::cast_to<ConeTwistJoint>(p_spatial)) );
 		return misg;
 	}
 
-	if (p_spatial->cast_to<CollisionPolygon>()) {
+	if (Object::cast_to<Generic6DOFJoint>(p_spatial)) {
 
-		Ref<CollisionPolygonSpatialGizmo> misg = memnew( CollisionPolygonSpatialGizmo(p_spatial->cast_to<CollisionPolygon>()) );
+		Ref<Generic6DOFJointSpatialGizmo> misg = memnew( Generic6DOFJointSpatialGizmo(Object::cast_to<Generic6DOFJoint>(p_spatial)) );
+		return misg;
+	}
+
+	if (Object::cast_to<CollisionPolygon>(p_spatial)) {
+
+		Ref<CollisionPolygonSpatialGizmo> misg = memnew( CollisionPolygonSpatialGizmo(Object::cast_to<CollisionPolygon>(p_spatial)) );
 		return misg;
 	}
 

--- a/tools/editor/spatial_editor_gizmos.h
+++ b/tools/editor/spatial_editor_gizmos.h
@@ -94,7 +94,7 @@ class EditorSpatialGizmo  : public SpatialEditorGizmo {
 	Vector<Instance> instances;
 	Spatial *spatial_node;
 
-	void _set_spatial_node(Node *p_node) { set_spatial_node(p_node->cast_to<Spatial>()); }
+	void _set_spatial_node(Node *p_node) { set_spatial_node(Object::cast_to<Spatial>(p_node)); }
 protected:
 	void add_lines(const Vector<Vector3> &p_lines,const Ref<Material>& p_material,bool p_billboard=false);
 	void add_mesh(const Ref<Mesh>& p_mesh,bool p_billboard=false,const RID& p_skeleton=RID());


### PR DESCRIPTION
Make 'Object::cast_to' static which can properly handle NULL pointers
as an argument.

This patch fixes crashes on GCC 6 and makes the sanitizer happy. It
also removes some redundant checks before calling 'Object::cast_to'.
