### PR TITLE
Removed invalid DEFVAL for HTTPClient::request_raw

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -639,7 +639,7 @@ void HTTPClient::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("connect:Error","host","port","use_ssl","verify_host"),&HTTPClient::connect,DEFVAL(false),DEFVAL(true));
 	ObjectTypeDB::bind_method(_MD("set_connection","connection:StreamPeer"),&HTTPClient::set_connection);
 	ObjectTypeDB::bind_method(_MD("get_connection:StreamPeer"),&HTTPClient::get_connection);
-	ObjectTypeDB::bind_method(_MD("request_raw","method","url","headers","body"),&HTTPClient::request_raw,DEFVAL(String()));
+	ObjectTypeDB::bind_method(_MD("request_raw","method","url","headers","body"),&HTTPClient::request_raw);
 	ObjectTypeDB::bind_method(_MD("request","method","url","headers","body"),&HTTPClient::request,DEFVAL(String()));
 	ObjectTypeDB::bind_method(_MD("send_body_text","body"),&HTTPClient::send_body_text);
 	ObjectTypeDB::bind_method(_MD("send_body_data","body"),&HTTPClient::send_body_data);


### PR DESCRIPTION
That method has no default value.
