### PR TITLE
fix crash and error with texture atlas

### DIFF
--- a/tools/editor/editor_import_export.cpp
+++ b/tools/editor/editor_import_export.cpp
@@ -889,7 +889,7 @@ Error EditorExportPlatform::export_project_files(EditorExportSaveFunction p_func
 
 
 
-			Ref<EditorTextureImportPlugin> plugin = EditorImportExport::get_singleton()->get_import_plugin_by_name("texture_atlas");
+			Ref<EditorTextureImportPlugin> plugin = EditorImportExport::get_singleton()->get_import_plugin_by_name("texture");
 			Error err = plugin->import2(dst_file,imd,get_image_compression(),true);
 			if (err) {
 

--- a/tools/editor/io_plugins/editor_texture_import_plugin.cpp
+++ b/tools/editor/io_plugins/editor_texture_import_plugin.cpp
@@ -1834,7 +1834,7 @@ EditorTextureImportPlugin::EditorTextureImportPlugin(EditorNode *p_editor) {
 	} else if (EditorImportExport::get_singleton()->image_get_export_group(p_path)) {
 
 
-		Ref<EditorImportPlugin> pl = EditorImportExport::get_singleton()->get_import_plugin_by_name("texture_2d");
+		Ref<EditorImportPlugin> pl = EditorImportExport::get_singleton()->get_import_plugin_by_name("texture");
 		if (pl.is_valid()) {
 			Vector<uint8_t> ce = pl->custom_export(p_path,p_platform);
 			if (ce.size()) {
@@ -1848,7 +1848,7 @@ EditorTextureImportPlugin::EditorTextureImportPlugin(EditorNode *p_editor) {
 		String xt = p_path.extension().to_lower();
 		if (EditorImportExport::get_singleton()->get_image_formats().has(xt)) { //should check for more I guess?
 
-			Ref<EditorImportPlugin> pl = EditorImportExport::get_singleton()->get_import_plugin_by_name("texture_2d");
+			Ref<EditorImportPlugin> pl = EditorImportExport::get_singleton()->get_import_plugin_by_name("texture");
 			if (pl.is_valid()) {
 				Vector<uint8_t> ce = pl->custom_export(p_path,p_platform);
 				if (ce.size()) {

--- a/tools/editor/project_export.cpp
+++ b/tools/editor/project_export.cpp
@@ -1057,7 +1057,7 @@ void ProjectExportDialog::_group_atlas_preview() {
 	imd->set_option("atlas",true);
 	imd->set_option("crop",true);
 
-	Ref<EditorTextureImportPlugin> plugin = EditorImportExport::get_singleton()->get_import_plugin_by_name("texture_atlas");
+	Ref<EditorTextureImportPlugin> plugin = EditorImportExport::get_singleton()->get_import_plugin_by_name("texture");
 	Error err = plugin->import2(dst_file,imd,EditorExportPlatform::IMAGE_COMPRESSION_NONE,true);
 	if (err) {
 


### PR DESCRIPTION
- crashes at Project Export Settings > Preview Atlas
- error message when export project

```
ERROR: EditorImportExport::get_import_plugin_by_name: Condition ' !by_idx.has(p_string) ' is true. returned: Ref<EditorImportPlugin>()
   At: tools\editor\editor_import_export.cpp:1548
```

it is caused by https://github.com/godotengine/godot/commit/8be2fabbe5cd846bac5e5a38e55f3fb70e73f2da#diff-67a74bd708380c6b3baa717bb178dd47R802
