### PR TITLE
The create node dialog now starts collapsed. 

### DIFF
--- a/tools/editor/create_dialog.cpp
+++ b/tools/editor/create_dialog.cpp
@@ -36,6 +36,7 @@
 #if 1
 
 #include "os/keyboard.h"
+#include "editor_settings.h"
 #include "editor_help.h"
 
 
@@ -106,6 +107,18 @@ void CreateDialog::add_type(const String& p_type,HashMap<String,TreeItem*>& p_ty
 			*to_select=item;
 		}
 
+	}
+
+	if (bool(EditorSettings::get_singleton()->get("scenetree_editor/start_create_dialog_fully_expanded"))) {
+		item->set_collapsed(false);
+	} else {
+		// don't collapse search results
+		bool collapse = (search_box->get_text() == "");
+		// don't collapse the root node
+		collapse &= (item != p_root);
+		// don't collapse abstract nodes on the first tree level
+		collapse &= ((parent != p_root) || (ObjectTypeDB::can_instance(p_type)));
+		item->set_collapsed(collapse);
 	}
 
 	const String& description = EditorHelp::get_doc_data()->class_list[p_type].brief_description;

--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -493,6 +493,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("scenetree_editor/duplicate_node_name_num_separator",0);
 	hints["scenetree_editor/duplicate_node_name_num_separator"]=PropertyInfo(Variant::INT,"scenetree_editor/duplicate_node_name_num_separator",PROPERTY_HINT_ENUM, "None,Space,Underscore,Dash");
 	//set("scenetree_editor/display_old_action_buttons",false);
+	set("scenetree_editor/start_create_dialog_fully_expanded",false);
 
 	set("gridmap_editor/pick_distance", 5000.0);
 


### PR DESCRIPTION
This was a suggestion by one of my students to make the editor more beginner friendly.
Every node except for the root node starts collapsed now, so you aren't presented with a wall of text right away.
Once you start typing in the search box the tree unfolds automatically.

If you prefer the tree to start expanded you can uncheck the "start collapsed"-option in the Editor settings' "create dialog" tab.
