### PR TITLE
Added classes' short descriptions as tooltips in the create dialog.

### DIFF
--- a/tools/editor/create_dialog.cpp
+++ b/tools/editor/create_dialog.cpp
@@ -36,6 +36,7 @@
 #if 1
 
 #include "os/keyboard.h"
+#include "editor_help.h"
 
 
 void CreateDialog::popup(bool p_dontclear) {
@@ -106,6 +107,9 @@ void CreateDialog::add_type(const String& p_type,HashMap<String,TreeItem*>& p_ty
 		}
 
 	}
+
+	const String& description = EditorHelp::get_doc_data()->class_list[p_type].brief_description;
+	item->set_tooltip(0,description);
 
 
 	if (has_icon(p_type,"EditorIcons")) {


### PR DESCRIPTION
Each entry in the create dialog now has the corresponding class's short description as a tooltip, so beginners can get a first help without having to switch back and forth between the create dialog and the help files.
