### PR TITLE
change invalid characters when get user data dir on Windows & Unix

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -306,6 +306,15 @@ String OS::get_system_dir(SystemDir p_dir) const {
 	return ".";
 }
 
+String OS::get_safe_application_name() const {
+	String an = Globals::get_singleton()->get("application/name");
+	Vector<String> invalid_char = String("\\ / : * ? \" < > |").split(" ");
+	for (int i=0;i<invalid_char.size();i++) {
+		an = an.replace(invalid_char[i],"-");
+	}
+	return an;
+}
+
 String OS::get_data_dir() const {
 
 	return ".";

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -326,6 +326,7 @@ public:
 
 	virtual String get_locale() const;
 
+	String get_safe_application_name() const;
 	virtual String get_data_dir() const;
 	virtual String get_resource_dir() const;
 

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -464,7 +464,7 @@ int OS_Unix::get_processor_count() const {
 
 String OS_Unix::get_data_dir() const {
 
-	String an = Globals::get_singleton()->get("application/name");
+	String an = get_safe_application_name();
 	if (an!="") {
 
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2243,7 +2243,7 @@ String OS_Windows::get_system_dir(SystemDir p_dir) const {
 }
 String OS_Windows::get_data_dir() const {
 
-	String an = Globals::get_singleton()->get("application/name");
+	String an = get_safe_application_name();
 	if (an!="") {
 
 		if (has_environment("APPDATA")) {


### PR DESCRIPTION
Can't create user data folder when project name has `\ / : * ? " < > |` characters on OS_Windows & OS_Unix.
So, change it to `-` to be able to make folder.

fixes #4928.
It's altanative to #4986, but this one has no restriction to make project name.

It's up to @akien-mga to merge which one and close. :)
