### PR TITLE
SampleLibraryEditor: Initialize "is_playing" variable

### DIFF
--- a/tools/editor/plugins/sample_library_editor_plugin.cpp
+++ b/tools/editor/plugins/sample_library_editor_plugin.cpp
@@ -357,7 +357,7 @@ SampleLibraryEditor::SampleLibraryEditor() {
 	file->connect("files_selected", this,"_file_load_request");
 	tree->connect("item_edited", this,"_item_edited");
 
-
+	is_playing = false;
 }
 
 


### PR DESCRIPTION
Fixes crash caused by jumping to wrong place due to uninitialized variable (#4703).
