### PR TITLE
Fix typo in http_client.h

### DIFF
--- a/core/io/http_client.h
+++ b/core/io/http_client.h
@@ -40,7 +40,7 @@ class HTTPClient : public Reference {
 	OBJ_TYPE(HTTPClient,Reference);
 public:
 
-	enum RespondeCode {
+	enum ResponseCode {
 
 		// 1xx informational
 		RESPONSE_CONTINUE = 100,


### PR DESCRIPTION
Fix small typo, this enum is otherwise unused.
