### PR TITLE
Enhanced Patch9Frame

### DIFF
--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -6497,7 +6497,7 @@ void RasterizerGLES2::_render_list_forward(RenderList *p_render_list,const Trans
 			if (!*e->additive_ptr) {
 
 				additive=false;
-				*e->additive_ptr=true;				
+				*e->additive_ptr=true;
 			} else {
 				additive=true;
 			}
@@ -6684,7 +6684,7 @@ void RasterizerGLES2::_render_list_forward(RenderList *p_render_list,const Trans
 			}
 			rebind=true;
 		}
-		
+
 		if  (use_hw_skeleton_xform && (skeleton!=prev_skeleton||morph_values!=prev_morph_values)) {
 			if (!prev_skeleton || !skeleton)
 				rebind=true; //went from skeleton <-> no skeleton, needs rebind
@@ -6718,7 +6718,7 @@ void RasterizerGLES2::_render_list_forward(RenderList *p_render_list,const Trans
 			DEBUG_TEST_ERROR("Setup geometry");
 		};
 
-		if (i==0 || light!=prev_light || rebind) {			
+		if (i==0 || light!=prev_light || rebind) {
 			if (e->light!=0xFFFF) {
 				_setup_light(e->light);
 
@@ -6958,7 +6958,7 @@ void RasterizerGLES2::_process_glow_bloom() {
 	_copy_screen_quad();
 
 	copy_shader.set_conditional(CopyShaderGLES2::USE_GLOW_COPY,false);
-	copy_shader.set_conditional(CopyShaderGLES2::USE_HDR,false);	
+	copy_shader.set_conditional(CopyShaderGLES2::USE_HDR,false);
 	int passes = current_env->fx_param[VS::ENV_FX_PARAM_GLOW_BLUR_PASSES];
 	Vector2 psize(1.0/framebuffer.blur_size,1.0/framebuffer.blur_size);
 	float pscale = current_env->fx_param[VS::ENV_FX_PARAM_GLOW_BLUR_SCALE];
@@ -7427,7 +7427,7 @@ void RasterizerGLES2::end_scene() {
 			_process_hdr();
 		}
 		if (current_env && current_env->fx_enabled[VS::ENV_FX_GLOW]) {
-			_process_glow_bloom();			
+			_process_glow_bloom();
 			int glow_transfer_mode=current_env->fx_param[VS::ENV_FX_PARAM_GLOW_BLUR_BLEND_MODE];
 			if (glow_transfer_mode==1)
 				copy_shader.set_conditional(CopyShaderGLES2::USE_GLOW_SCREEN,true);
@@ -8438,7 +8438,7 @@ void RasterizerGLES2::canvas_draw_rect(const Rect2& p_rect, int p_flags, const R
 
 }
 
-void RasterizerGLES2::canvas_draw_style_box(const Rect2& p_rect, RID p_texture,const float *p_margin, bool p_draw_center,const Color& p_modulate) {
+void RasterizerGLES2::canvas_draw_style_box(const Rect2& p_rect, const Rect2& p_src_region, RID p_texture,const float *p_margin, bool p_draw_center,const Color& p_modulate) {
 
 	Color m = p_modulate;
 	m.a*=canvas_opacity;
@@ -8446,52 +8446,57 @@ void RasterizerGLES2::canvas_draw_style_box(const Rect2& p_rect, RID p_texture,c
 
 	Texture* texture=_bind_canvas_texture(p_texture);
 	ERR_FAIL_COND(!texture);
-	/* CORNERS */
 
+	Rect2 region = p_src_region;
+	if (region.size.width <= 0 )
+	    region.size.width = texture->width;
+	if (region.size.height <= 0)
+	    region.size.height = texture->height;
+	/* CORNERS */
 	_draw_textured_quad( // top left
 		Rect2( p_rect.pos, Size2(p_margin[MARGIN_LEFT],p_margin[MARGIN_TOP])),
-		Rect2( Point2(), Size2(p_margin[MARGIN_LEFT],p_margin[MARGIN_TOP])),
+		Rect2( region.pos, Size2(p_margin[MARGIN_LEFT],p_margin[MARGIN_TOP])),
 		Size2( texture->width, texture->height ) );
 
 	_draw_textured_quad( // top right
 		Rect2( Point2( p_rect.pos.x + p_rect.size.width - p_margin[MARGIN_RIGHT], p_rect.pos.y), Size2(p_margin[MARGIN_RIGHT],p_margin[MARGIN_TOP])),
-		Rect2( Point2(texture->width-p_margin[MARGIN_RIGHT],0), Size2(p_margin[MARGIN_RIGHT],p_margin[MARGIN_TOP])),
+		Rect2( Point2(region.pos.x+region.size.width-p_margin[MARGIN_RIGHT], region.pos.y), Size2(p_margin[MARGIN_RIGHT],p_margin[MARGIN_TOP])),
 		Size2( texture->width, texture->height ) );
 
 
 	_draw_textured_quad( // bottom left
 		Rect2( Point2(p_rect.pos.x,p_rect.pos.y + p_rect.size.height - p_margin[MARGIN_BOTTOM]), Size2(p_margin[MARGIN_LEFT],p_margin[MARGIN_BOTTOM])),
-		Rect2( Point2(0,texture->height-p_margin[MARGIN_BOTTOM]), Size2(p_margin[MARGIN_LEFT],p_margin[MARGIN_BOTTOM])),
+		Rect2( Point2(region.pos.x, region.pos.y+region.size.height-p_margin[MARGIN_BOTTOM]), Size2(p_margin[MARGIN_LEFT],p_margin[MARGIN_BOTTOM])),
 		Size2( texture->width, texture->height ) );
 
 	_draw_textured_quad( // bottom right
 		Rect2( Point2( p_rect.pos.x + p_rect.size.width - p_margin[MARGIN_RIGHT], p_rect.pos.y + p_rect.size.height - p_margin[MARGIN_BOTTOM]), Size2(p_margin[MARGIN_RIGHT],p_margin[MARGIN_BOTTOM])),
-		Rect2( Point2(texture->width-p_margin[MARGIN_RIGHT],texture->height-p_margin[MARGIN_BOTTOM]), Size2(p_margin[MARGIN_RIGHT],p_margin[MARGIN_BOTTOM])),
+		Rect2( Point2(region.pos.x+region.size.width-p_margin[MARGIN_RIGHT], region.pos.y+region.size.height-p_margin[MARGIN_BOTTOM]), Size2(p_margin[MARGIN_RIGHT],p_margin[MARGIN_BOTTOM])),
 		Size2( texture->width, texture->height ) );
 
 	Rect2 rect_center( p_rect.pos+Point2( p_margin[MARGIN_LEFT], p_margin[MARGIN_TOP]), Size2( p_rect.size.width - p_margin[MARGIN_LEFT] - p_margin[MARGIN_RIGHT], p_rect.size.height - p_margin[MARGIN_TOP] - p_margin[MARGIN_BOTTOM] ));
 
-	Rect2 src_center( Point2( p_margin[MARGIN_LEFT], p_margin[MARGIN_TOP]), Size2( texture->width - p_margin[MARGIN_LEFT] - p_margin[MARGIN_RIGHT], texture->height - p_margin[MARGIN_TOP] - p_margin[MARGIN_BOTTOM] ));
+	Rect2 src_center( Point2(region.pos.x+p_margin[MARGIN_LEFT], region.pos.y+p_margin[MARGIN_TOP]), Size2(region.size.width - p_margin[MARGIN_LEFT] - p_margin[MARGIN_RIGHT], region.size.height - p_margin[MARGIN_TOP] - p_margin[MARGIN_BOTTOM] ));
 
 
 	_draw_textured_quad( // top
 		Rect2( Point2(rect_center.pos.x,p_rect.pos.y),Size2(rect_center.size.width,p_margin[MARGIN_TOP])),
-		Rect2( Point2(p_margin[MARGIN_LEFT],0), Size2(src_center.size.width,p_margin[MARGIN_TOP])),
+		Rect2( Point2(src_center.pos.x,region.pos.y), Size2(src_center.size.width,p_margin[MARGIN_TOP])),
 		Size2( texture->width, texture->height ) );
 
 	_draw_textured_quad( // bottom
 		Rect2( Point2(rect_center.pos.x,rect_center.pos.y+rect_center.size.height),Size2(rect_center.size.width,p_margin[MARGIN_BOTTOM])),
-		Rect2( Point2(p_margin[MARGIN_LEFT],src_center.pos.y+src_center.size.height), Size2(src_center.size.width,p_margin[MARGIN_BOTTOM])),
+		Rect2( Point2(src_center.pos.x,src_center.pos.y+src_center.size.height), Size2(src_center.size.width,p_margin[MARGIN_BOTTOM])),
 		Size2( texture->width, texture->height ) );
 
 	_draw_textured_quad( // left
 		Rect2( Point2(p_rect.pos.x,rect_center.pos.y),Size2(p_margin[MARGIN_LEFT],rect_center.size.height)),
-		Rect2( Point2(0,p_margin[MARGIN_TOP]), Size2(p_margin[MARGIN_LEFT],src_center.size.height)),
+		Rect2( Point2(region.pos.x,region.pos.y+p_margin[MARGIN_TOP]), Size2(p_margin[MARGIN_LEFT],src_center.size.height)),
 		Size2( texture->width, texture->height ) );
 
 	_draw_textured_quad( // right
 		Rect2( Point2(rect_center.pos.x+rect_center.size.width,rect_center.pos.y),Size2(p_margin[MARGIN_RIGHT],rect_center.size.height)),
-		Rect2( Point2(src_center.pos.x+src_center.size.width,p_margin[MARGIN_TOP]), Size2(p_margin[MARGIN_RIGHT],src_center.size.height)),
+		Rect2( Point2(src_center.pos.x+src_center.size.width,region.pos.y+p_margin[MARGIN_TOP]), Size2(p_margin[MARGIN_RIGHT],src_center.size.height)),
 		Size2( texture->width, texture->height ) );
 
 	if (p_draw_center) {
@@ -8569,7 +8574,7 @@ void RasterizerGLES2::canvas_draw_polygon(int p_vertex_count, const int* p_indic
 
 
 #else //WebGL specific impl.
-	glBindBuffer(GL_ARRAY_BUFFER, gui_quad_buffer);    
+	glBindBuffer(GL_ARRAY_BUFFER, gui_quad_buffer);
     float *b = GlobalVertexBuffer;
     int ofs = 0;
     if(p_vertex_count > MAX_POLYGON_VERTICES){
@@ -9184,7 +9189,7 @@ void RasterizerGLES2::_canvas_item_render_commands(CanvasItem *p_item,CanvasItem
 				CanvasItem::CommandStyle* style = static_cast<CanvasItem::CommandStyle*>(c);
 				if (use_normalmap)
 					_canvas_normal_set_flip(Vector2(1,1));
-				canvas_draw_style_box(style->rect,style->texture,style->margin,style->draw_center,style->color);
+				canvas_draw_style_box(style->rect,style->source,style->texture,style->margin,style->draw_center,style->color);
 
 			} break;
 			case CanvasItem::Command::TYPE_PRIMITIVE: {
@@ -9430,7 +9435,7 @@ void RasterizerGLES2::canvas_render_items(CanvasItem *p_item_list,int p_z,const 
 				draw_viewport_func(ci->vp_render->owner,ci->vp_render->udata,ci->vp_render->rect);
 			}
 			memdelete(ci->vp_render);
-			ci->vp_render=NULL;			
+			ci->vp_render=NULL;
 			canvas_last_material=NULL;
 			canvas_use_modulate=p_modulate!=Color(1,1,1,1);
 			canvas_modulate=p_modulate;
@@ -11424,7 +11429,7 @@ RasterizerGLES2::RasterizerGLES2(bool p_compress_arrays,bool p_keep_ram_copy,boo
 void RasterizerGLES2::restore_framebuffer() {
 
 	glBindFramebuffer(GL_FRAMEBUFFER, base_framebuffer);
-	
+
 }
 
 RasterizerGLES2::~RasterizerGLES2() {

--- a/drivers/gles2/rasterizer_gles2.h
+++ b/drivers/gles2/rasterizer_gles2.h
@@ -1635,7 +1635,7 @@ public:
 	virtual void canvas_end_rect();
 	virtual void canvas_draw_line(const Point2& p_from, const Point2& p_to,const Color& p_color,float p_width);
 	virtual void canvas_draw_rect(const Rect2& p_rect, int p_flags, const Rect2& p_source,RID p_texture,const Color& p_modulate);
-	virtual void canvas_draw_style_box(const Rect2& p_rect, RID p_texture,const float *p_margins, bool p_draw_center=true,const Color& p_modulate=Color(1,1,1));
+	virtual void canvas_draw_style_box(const Rect2& p_rect, const Rect2& p_src_region, RID p_texture,const float *p_margins, bool p_draw_center=true,const Color& p_modulate=Color(1,1,1));
 	virtual void canvas_draw_primitive(const Vector<Point2>& p_points, const Vector<Color>& p_colors,const Vector<Point2>& p_uvs, RID p_texture,float p_width);
 	virtual void canvas_draw_polygon(int p_vertex_count, const int* p_indices, const Vector2* p_vertices, const Vector2* p_uvs, const Color* p_colors,const RID& p_texture,bool p_singlecolor);
 	virtual void canvas_set_transform(const Matrix32& p_transform);

--- a/platform/iphone/rasterizer_iphone.cpp
+++ b/platform/iphone/rasterizer_iphone.cpp
@@ -2446,7 +2446,7 @@ void RasterizerIPhone::canvas_draw_rect(const Rect2& p_rect, bool p_region, cons
 
 
 }
-void RasterizerIPhone::canvas_draw_style_box(const Rect2& p_rect, RID p_texture,const float *p_margin, bool p_draw_center) {
+void RasterizerIPhone::canvas_draw_style_box(const Rect2& p_rect, const Rect2& p_src_region, RID p_texture,const float *p_margin, bool p_draw_center) {
 
 	glColor4f(1, 1, 1, 1);
 
@@ -2458,52 +2458,56 @@ void RasterizerIPhone::canvas_draw_style_box(const Rect2& p_rect, RID p_texture,
 	glBindTexture( GL_TEXTURE_2D,texture->tex_id );
 
 
+	Rect2 region = p_src_region;
+	if (region.size.width <= 0 )
+	    region.size.width = texture->width;
+	if (region.size.height <= 0)
+	    region.size.height = texture->height;
 	/* CORNERS */
-
 	_draw_textured_quad( // top left
 		Rect2( p_rect.pos, Size2(p_margin[MARGIN_LEFT],p_margin[MARGIN_TOP])),
-		Rect2( Point2(), Size2(p_margin[MARGIN_LEFT],p_margin[MARGIN_TOP])),
+		Rect2( region.pos, Size2(p_margin[MARGIN_LEFT],p_margin[MARGIN_TOP])),
 		Size2( texture->width, texture->height ) );
 
 	_draw_textured_quad( // top right
 		Rect2( Point2( p_rect.pos.x + p_rect.size.width - p_margin[MARGIN_RIGHT], p_rect.pos.y), Size2(p_margin[MARGIN_RIGHT],p_margin[MARGIN_TOP])),
-		Rect2( Point2(texture->width-p_margin[MARGIN_RIGHT],0), Size2(p_margin[MARGIN_RIGHT],p_margin[MARGIN_TOP])),
+		Rect2( Point2(region.pos.x+region.size.width-p_margin[MARGIN_RIGHT], region.pos.y), Size2(p_margin[MARGIN_RIGHT],p_margin[MARGIN_TOP])),
 		Size2( texture->width, texture->height ) );
 
 
 	_draw_textured_quad( // bottom left
 		Rect2( Point2(p_rect.pos.x,p_rect.pos.y + p_rect.size.height - p_margin[MARGIN_BOTTOM]), Size2(p_margin[MARGIN_LEFT],p_margin[MARGIN_BOTTOM])),
-		Rect2( Point2(0,texture->height-p_margin[MARGIN_BOTTOM]), Size2(p_margin[MARGIN_LEFT],p_margin[MARGIN_BOTTOM])),
+		Rect2( Point2(region.pos.x, region.pos.y+region.size.height-p_margin[MARGIN_BOTTOM]), Size2(p_margin[MARGIN_LEFT],p_margin[MARGIN_BOTTOM])),
 		Size2( texture->width, texture->height ) );
 
 	_draw_textured_quad( // bottom right
 		Rect2( Point2( p_rect.pos.x + p_rect.size.width - p_margin[MARGIN_RIGHT], p_rect.pos.y + p_rect.size.height - p_margin[MARGIN_BOTTOM]), Size2(p_margin[MARGIN_RIGHT],p_margin[MARGIN_BOTTOM])),
-		Rect2( Point2(texture->width-p_margin[MARGIN_RIGHT],texture->height-p_margin[MARGIN_BOTTOM]), Size2(p_margin[MARGIN_RIGHT],p_margin[MARGIN_BOTTOM])),
+		Rect2( Point2(region.pos.x+region.size.width-p_margin[MARGIN_RIGHT], region.pos.y+region.size.height-p_margin[MARGIN_BOTTOM]), Size2(p_margin[MARGIN_RIGHT],p_margin[MARGIN_BOTTOM])),
 		Size2( texture->width, texture->height ) );
 
 	Rect2 rect_center( p_rect.pos+Point2( p_margin[MARGIN_LEFT], p_margin[MARGIN_TOP]), Size2( p_rect.size.width - p_margin[MARGIN_LEFT] - p_margin[MARGIN_RIGHT], p_rect.size.height - p_margin[MARGIN_TOP] - p_margin[MARGIN_BOTTOM] ));
 
-	Rect2 src_center( Point2( p_margin[MARGIN_LEFT], p_margin[MARGIN_TOP]), Size2( texture->width - p_margin[MARGIN_LEFT] - p_margin[MARGIN_RIGHT], texture->height - p_margin[MARGIN_TOP] - p_margin[MARGIN_BOTTOM] ));
+	Rect2 src_center( Point2(region.pos.x+p_margin[MARGIN_LEFT], region.pos.y+p_margin[MARGIN_TOP]), Size2(region.size.width - p_margin[MARGIN_LEFT] - p_margin[MARGIN_RIGHT], region.size.height - p_margin[MARGIN_TOP] - p_margin[MARGIN_BOTTOM] ));
 
 
 	_draw_textured_quad( // top
 		Rect2( Point2(rect_center.pos.x,p_rect.pos.y),Size2(rect_center.size.width,p_margin[MARGIN_TOP])),
-		Rect2( Point2(p_margin[MARGIN_LEFT],0), Size2(src_center.size.width,p_margin[MARGIN_TOP])),
+		Rect2( Point2(src_center.pos.x,region.pos.y), Size2(src_center.size.width,p_margin[MARGIN_TOP])),
 		Size2( texture->width, texture->height ) );
 
 	_draw_textured_quad( // bottom
 		Rect2( Point2(rect_center.pos.x,rect_center.pos.y+rect_center.size.height),Size2(rect_center.size.width,p_margin[MARGIN_BOTTOM])),
-		Rect2( Point2(p_margin[MARGIN_LEFT],src_center.pos.y+src_center.size.height), Size2(src_center.size.width,p_margin[MARGIN_BOTTOM])),
+		Rect2( Point2(src_center.pos.x,src_center.pos.y+src_center.size.height), Size2(src_center.size.width,p_margin[MARGIN_BOTTOM])),
 		Size2( texture->width, texture->height ) );
 
 	_draw_textured_quad( // left
 		Rect2( Point2(p_rect.pos.x,rect_center.pos.y),Size2(p_margin[MARGIN_LEFT],rect_center.size.height)),
-		Rect2( Point2(0,p_margin[MARGIN_TOP]), Size2(p_margin[MARGIN_LEFT],src_center.size.height)),
+		Rect2( Point2(region.pos.x,region.pos.y+p_margin[MARGIN_TOP]), Size2(p_margin[MARGIN_LEFT],src_center.size.height)),
 		Size2( texture->width, texture->height ) );
 
 	_draw_textured_quad( // right
 		Rect2( Point2(rect_center.pos.x+rect_center.size.width,rect_center.pos.y),Size2(p_margin[MARGIN_RIGHT],rect_center.size.height)),
-		Rect2( Point2(src_center.pos.x+src_center.size.width,p_margin[MARGIN_TOP]), Size2(p_margin[MARGIN_RIGHT],src_center.size.height)),
+		Rect2( Point2(src_center.pos.x+src_center.size.width,region.pos.y+p_margin[MARGIN_TOP]), Size2(p_margin[MARGIN_RIGHT],src_center.size.height)),
 		Size2( texture->width, texture->height ) );
 
 	if (p_draw_center) {

--- a/scene/gui/patch_9_frame.cpp
+++ b/scene/gui/patch_9_frame.cpp
@@ -11,7 +11,7 @@ void Patch9Frame::_notification(int p_what) {
 
 		Size2 s=get_size();
 		RID ci = get_canvas_item();
-		VS::get_singleton()->canvas_item_add_style_box(ci,Rect2(Point2(),s),Rect2(),texture->get_rid(),Vector2(margin[MARGIN_LEFT],margin[MARGIN_TOP]),Vector2(margin[MARGIN_RIGHT],margin[MARGIN_BOTTOM]),draw_center,modulate);
+		VS::get_singleton()->canvas_item_add_style_box(ci,Rect2(Point2(),s),region_rect,texture->get_rid(),Vector2(margin[MARGIN_LEFT],margin[MARGIN_TOP]),Vector2(margin[MARGIN_RIGHT],margin[MARGIN_BOTTOM]),draw_center,modulate);
 //		draw_texture_rect(texture,Rect2(Point2(),s),false,modulate);
 
 /*
@@ -46,12 +46,15 @@ void Patch9Frame::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_modulate"), & Patch9Frame::get_modulate );
 	ObjectTypeDB::bind_method(_MD("set_patch_margin","margin","value"), & Patch9Frame::set_patch_margin );
 	ObjectTypeDB::bind_method(_MD("get_patch_margin","margin"), & Patch9Frame::get_patch_margin );
+	ObjectTypeDB::bind_method(_MD("set_region_rect","rect"),&Patch9Frame::set_region_rect);
+	ObjectTypeDB::bind_method(_MD("get_region_rect"),&Patch9Frame::get_region_rect);
 	ObjectTypeDB::bind_method(_MD("set_draw_center","draw_center"), & Patch9Frame::set_draw_center );
 	ObjectTypeDB::bind_method(_MD("get_draw_center"), & Patch9Frame::get_draw_center );
 
 	ADD_PROPERTYNZ( PropertyInfo( Variant::OBJECT, "texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), _SCS("set_texture"),_SCS("get_texture") );
 	ADD_PROPERTYNO( PropertyInfo( Variant::COLOR, "modulate"), _SCS("set_modulate"),_SCS("get_modulate") );
 	ADD_PROPERTYNO( PropertyInfo( Variant::BOOL, "draw_center"), _SCS("set_draw_center"),_SCS("get_draw_center") );
+	ADD_PROPERTYNZ( PropertyInfo( Variant::RECT2, "region_rect"), _SCS("set_region_rect"),_SCS("get_region_rect"));
 	ADD_PROPERTYINZ( PropertyInfo( Variant::INT, "patch_margin/left",PROPERTY_HINT_RANGE,"0,16384,1"), _SCS("set_patch_margin"),_SCS("get_patch_margin"),MARGIN_LEFT );
 	ADD_PROPERTYINZ( PropertyInfo( Variant::INT, "patch_margin/top",PROPERTY_HINT_RANGE,"0,16384,1"), _SCS("set_patch_margin"),_SCS("get_patch_margin"),MARGIN_TOP );
 	ADD_PROPERTYINZ( PropertyInfo( Variant::INT, "patch_margin/right",PROPERTY_HINT_RANGE,"0,16384,1"), _SCS("set_patch_margin"),_SCS("get_patch_margin"),MARGIN_RIGHT );
@@ -98,6 +101,22 @@ int Patch9Frame::get_patch_margin(Margin p_margin) const{
 
 	ERR_FAIL_INDEX_V(p_margin,4,0);
 	return margin[p_margin];
+}
+
+void Patch9Frame::set_region_rect(const Rect2& p_region_rect) {
+
+	if (region_rect==p_region_rect)
+		return;
+
+	region_rect=p_region_rect;
+
+	item_rect_changed();
+	_change_notify("region_rect");
+}
+
+Rect2 Patch9Frame::get_region_rect() const {
+
+	return region_rect;
 }
 
 void Patch9Frame::set_draw_center(bool p_draw) {

--- a/scene/gui/patch_9_frame.cpp
+++ b/scene/gui/patch_9_frame.cpp
@@ -9,10 +9,9 @@ void Patch9Frame::_notification(int p_what) {
 		if (texture.is_null())
 			return;
 
-
 		Size2 s=get_size();
 		RID ci = get_canvas_item();
-		VS::get_singleton()->canvas_item_add_style_box(ci,Rect2(Point2(),s),texture->get_rid(),Vector2(margin[MARGIN_LEFT],margin[MARGIN_TOP]),Vector2(margin[MARGIN_RIGHT],margin[MARGIN_BOTTOM]),draw_center,modulate);
+		VS::get_singleton()->canvas_item_add_style_box(ci,Rect2(Point2(),s),Rect2(),texture->get_rid(),Vector2(margin[MARGIN_LEFT],margin[MARGIN_TOP]),Vector2(margin[MARGIN_RIGHT],margin[MARGIN_BOTTOM]),draw_center,modulate);
 //		draw_texture_rect(texture,Rect2(Point2(),s),false,modulate);
 
 /*
@@ -128,5 +127,3 @@ Patch9Frame::Patch9Frame() {
 Patch9Frame::~Patch9Frame()
 {
 }
-
-

--- a/scene/gui/patch_9_frame.cpp
+++ b/scene/gui/patch_9_frame.cpp
@@ -95,6 +95,20 @@ void Patch9Frame::set_patch_margin(Margin p_margin,int p_size) {
 	margin[p_margin]=p_size;
 	update();
 	minimum_size_changed();
+	switch (p_margin) {
+		case MARGIN_LEFT:
+			_change_notify("patch_margin/left");
+			break;
+		case MARGIN_TOP:
+			_change_notify("patch_margin/top");
+			break;
+		case MARGIN_RIGHT:
+			_change_notify("patch_margin/right");
+			break;
+		case MARGIN_BOTTOM:
+			_change_notify("patch_margin/bottom");
+			break;
+	}
 }
 
 int Patch9Frame::get_patch_margin(Margin p_margin) const{

--- a/scene/gui/patch_9_frame.h
+++ b/scene/gui/patch_9_frame.h
@@ -11,6 +11,7 @@ class Patch9Frame : public Control {
 
 	bool draw_center;
 	int margin[4];
+	Rect2 region_rect;
 	Color modulate;
 	Ref<Texture> texture;
 protected:
@@ -29,6 +30,9 @@ public:
 
 	void set_patch_margin(Margin p_margin,int p_size);
 	int get_patch_margin(Margin p_margin) const;
+
+	void set_region_rect(const Rect2& p_region_rect);
+	Rect2 get_region_rect() const;
 
 	void set_draw_center(bool p_enable);
 	bool get_draw_center() const;

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -138,7 +138,7 @@ void StyleBoxTexture::draw(RID p_canvas_item,const Rect2& p_rect) const {
 	r.pos.y-=expand_margin[MARGIN_TOP];
 	r.size.x+=expand_margin[MARGIN_LEFT]+expand_margin[MARGIN_RIGHT];
 	r.size.y+=expand_margin[MARGIN_TOP]+expand_margin[MARGIN_BOTTOM];
-	VisualServer::get_singleton()->canvas_item_add_style_box( p_canvas_item,r,Rect2(),texture->get_rid(),Vector2(margin[MARGIN_LEFT],margin[MARGIN_TOP]),Vector2(margin[MARGIN_RIGHT],margin[MARGIN_BOTTOM]),draw_center);
+	VisualServer::get_singleton()->canvas_item_add_style_box( p_canvas_item,r,region_rect,texture->get_rid(),Vector2(margin[MARGIN_LEFT],margin[MARGIN_TOP]),Vector2(margin[MARGIN_RIGHT],margin[MARGIN_BOTTOM]),draw_center);
 }
 
 void StyleBoxTexture::set_draw_center(bool p_draw) {
@@ -175,6 +175,20 @@ float StyleBoxTexture::get_expand_margin_size(Margin p_expand_margin) const {
 	return expand_margin[p_expand_margin];
 }
 
+void StyleBoxTexture::set_region_rect(const Rect2& p_region_rect) {
+
+	if (region_rect==p_region_rect)
+		return;
+
+	region_rect=p_region_rect;
+	emit_changed();
+}
+
+Rect2 StyleBoxTexture::get_region_rect() const {
+
+	return region_rect;
+}
+
 
 void StyleBoxTexture::_bind_methods() {
 
@@ -187,10 +201,14 @@ void StyleBoxTexture::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_expand_margin_size","margin","size"),&StyleBoxTexture::set_expand_margin_size);
 	ObjectTypeDB::bind_method(_MD("get_expand_margin_size","margin"),&StyleBoxTexture::get_expand_margin_size);
 
+	ObjectTypeDB::bind_method(_MD("set_region_rect","region"),&StyleBoxTexture::set_region_rect);
+	ObjectTypeDB::bind_method(_MD("get_region_rect"),&StyleBoxTexture::get_region_rect);
+
 	ObjectTypeDB::bind_method(_MD("set_draw_center","enable"),&StyleBoxTexture::set_draw_center);
 	ObjectTypeDB::bind_method(_MD("get_draw_center"),&StyleBoxTexture::get_draw_center);
 
 	ADD_PROPERTY( PropertyInfo( Variant::OBJECT, "texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture" ), _SCS("set_texture"),_SCS("get_texture") );
+	ADD_PROPERTYNZ( PropertyInfo( Variant::RECT2, "region_rect"), _SCS("set_region_rect"),_SCS("get_region_rect"));
 	ADD_PROPERTYI( PropertyInfo( Variant::REAL, "margin/left", PROPERTY_HINT_RANGE,"0,2048,1" ), _SCS("set_margin_size"),_SCS("get_margin_size"), MARGIN_LEFT );
 	ADD_PROPERTYI( PropertyInfo( Variant::REAL, "margin/right", PROPERTY_HINT_RANGE,"0,2048,1" ), _SCS("set_margin_size"),_SCS("get_margin_size"), MARGIN_RIGHT );
 	ADD_PROPERTYI( PropertyInfo( Variant::REAL, "margin/top", PROPERTY_HINT_RANGE,"0,2048,1" ), _SCS("set_margin_size"),_SCS("get_margin_size"), MARGIN_TOP);

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -138,7 +138,7 @@ void StyleBoxTexture::draw(RID p_canvas_item,const Rect2& p_rect) const {
 	r.pos.y-=expand_margin[MARGIN_TOP];
 	r.size.x+=expand_margin[MARGIN_LEFT]+expand_margin[MARGIN_RIGHT];
 	r.size.y+=expand_margin[MARGIN_TOP]+expand_margin[MARGIN_BOTTOM];
-	VisualServer::get_singleton()->canvas_item_add_style_box( p_canvas_item,r,texture->get_rid(),Vector2(margin[MARGIN_LEFT],margin[MARGIN_TOP]),Vector2(margin[MARGIN_RIGHT],margin[MARGIN_BOTTOM]),draw_center);
+	VisualServer::get_singleton()->canvas_item_add_style_box( p_canvas_item,r,Rect2(),texture->get_rid(),Vector2(margin[MARGIN_LEFT],margin[MARGIN_TOP]),Vector2(margin[MARGIN_RIGHT],margin[MARGIN_BOTTOM]),draw_center);
 }
 
 void StyleBoxTexture::set_draw_center(bool p_draw) {
@@ -505,4 +505,3 @@ StyleBoxImageMask::StyleBoxImageMask() {
 	}
 	expand=true;
 }
-

--- a/scene/resources/style_box.h
+++ b/scene/resources/style_box.h
@@ -81,6 +81,7 @@ class StyleBoxTexture : public StyleBox {
 
 	float expand_margin[4];
 	float margin[4];
+	Rect2 region_rect;
 	Ref<Texture> texture;
 	bool draw_center;
 
@@ -97,6 +98,9 @@ public:
 
 	void set_margin_size(Margin p_margin,float p_size);
 	float get_margin_size(Margin p_margin) const;
+
+	void set_region_rect(const Rect2& p_region_rect);
+	Rect2 get_region_rect() const;
 
 	void set_texture(RES p_texture);
 	RES get_texture() const;

--- a/servers/server_wrap_mt_common.h
+++ b/servers/server_wrap_mt_common.h
@@ -698,3 +698,64 @@
 		}\
 	}
 
+#define FUNC8R(m_r,m_type,m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)\
+	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) { \
+		if (Thread::get_caller_ID()!=server_thread) {\
+			m_r ret;\
+			command_queue.push_and_ret( server_name, &ServerName::m_type,p1, p2, p3, p4, p5, p6, p7, p8, &ret);\
+			SYNC_DEBUG\
+			return ret;\
+		} else {\
+			return server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8);\
+		}\
+	}
+
+#define FUNC8RC(m_r,m_type,m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)\
+	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) const { \
+		if (Thread::get_caller_ID()!=server_thread) {\
+			m_r ret;\
+			command_queue.push_and_ret( server_name, &ServerName::m_type,p1, p2, p3, p4, p5, p6, p7, p8, &ret);\
+			SYNC_DEBUG\
+			return ret;\
+		} else {\
+			return server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8);\
+		}\
+	}
+
+
+#define FUNC8S(m_type,m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)\
+	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) { \
+		if (Thread::get_caller_ID()!=server_thread) {\
+			command_queue.push_and_sync( server_name, &ServerName::m_type,p1, p2, p3, p4, p5, p6, p7, p8);\
+		} else {\
+			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8);\
+		}\
+	}
+
+#define FUNC8SC(m_type,m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)\
+	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) const { \
+		if (Thread::get_caller_ID()!=server_thread) {\
+			command_queue.push_and_sync( server_name, &ServerName::m_type,p1, p2, p3, p4, p5, p6, p7, p8);\
+		} else {\
+			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8);\
+		}\
+	}
+
+
+#define FUNC8(m_type,m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)\
+	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) { \
+		if (Thread::get_caller_ID()!=server_thread) {\
+			command_queue.push( server_name, &ServerName::m_type,p1, p2, p3, p4, p5, p6, p7, p8);\
+		} else {\
+			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8);\
+		}\
+	}
+
+#define FUNC8C(m_type,m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)\
+	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) const { \
+		if (Thread::get_caller_ID()!=server_thread) {\
+			command_queue.push( server_name, &ServerName::m_type,p1, p2, p3, p4, p5, p6, p7, p8);\
+		} else {\
+			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8);\
+		}\
+	}

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -702,6 +702,7 @@ public:
 		struct CommandStyle : public Command {
 
 			Rect2 rect;
+			Rect2 source;
 			RID texture;
 			float margin[4];
 			bool draw_center;
@@ -944,12 +945,12 @@ public:
 	virtual void canvas_disable_blending()=0;
 	virtual void canvas_set_opacity(float p_opacity)=0;
 	virtual void canvas_set_blend_mode(VS::MaterialBlendMode p_mode)=0;
-	virtual void canvas_begin_rect(const Matrix32& p_transform)=0;;
+	virtual void canvas_begin_rect(const Matrix32& p_transform)=0;
 	virtual void canvas_set_clip(bool p_clip, const Rect2& p_rect)=0;
 	virtual void canvas_end_rect()=0;
 	virtual void canvas_draw_line(const Point2& p_from, const Point2& p_to,const Color& p_color,float p_width)=0;
 	virtual void canvas_draw_rect(const Rect2& p_rect, int p_flags, const Rect2& p_source,RID p_texture,const Color& p_modulate)=0;
-	virtual void canvas_draw_style_box(const Rect2& p_rect, RID p_texture,const float *p_margins, bool p_draw_center=true,const Color& p_modulate=Color(1,1,1))=0;
+	virtual void canvas_draw_style_box(const Rect2& p_rect, const Rect2& p_src_region, RID p_texture,const float *p_margins, bool p_draw_center=true,const Color& p_modulate=Color(1,1,1))=0;
 	virtual void canvas_draw_primitive(const Vector<Point2>& p_points, const Vector<Color>& p_colors,const Vector<Point2>& p_uvs, RID p_texture,float p_width)=0;
 	virtual void canvas_draw_polygon(int p_vertex_count, const int* p_indices, const Vector2* p_vertices, const Vector2* p_uvs, const Color* p_colors,const RID& p_texture,bool p_singlecolor)=0;
 	virtual void canvas_set_transform(const Matrix32& p_transform)=0;

--- a/servers/visual/rasterizer_dummy.cpp
+++ b/servers/visual/rasterizer_dummy.cpp
@@ -1627,7 +1627,7 @@ void RasterizerDummy::canvas_draw_rect(const Rect2& p_rect, int p_flags, const R
 
 
 }
-void RasterizerDummy::canvas_draw_style_box(const Rect2& p_rect, RID p_texture,const float *p_margin, bool p_draw_center,const Color& p_modulate) {
+void RasterizerDummy::canvas_draw_style_box(const Rect2& p_rect, const Rect2& p_src_region, RID p_texture,const float *p_margin, bool p_draw_center,const Color& p_modulate) {
 
 
 }
@@ -1959,4 +1959,3 @@ RasterizerDummy::RasterizerDummy() {
 RasterizerDummy::~RasterizerDummy() {
 
 };
-

--- a/servers/visual/rasterizer_dummy.h
+++ b/servers/visual/rasterizer_dummy.h
@@ -708,7 +708,7 @@ public:
 	virtual void canvas_end_rect();
 	virtual void canvas_draw_line(const Point2& p_from, const Point2& p_to,const Color& p_color,float p_width);
 	virtual void canvas_draw_rect(const Rect2& p_rect, int p_flags, const Rect2& p_source,RID p_texture,const Color& p_modulate);
-	virtual void canvas_draw_style_box(const Rect2& p_rect, RID p_texture,const float *p_margins, bool p_draw_center=true,const Color& p_modulate=Color(1,1,1));
+	virtual void canvas_draw_style_box(const Rect2& p_rect, const Rect2& p_src_region, RID p_texture,const float *p_margins, bool p_draw_center=true,const Color& p_modulate=Color(1,1,1));
 	virtual void canvas_draw_primitive(const Vector<Point2>& p_points, const Vector<Color>& p_colors,const Vector<Point2>& p_uvs, RID p_texture,float p_width);
 	virtual void canvas_draw_polygon(int p_vertex_count, const int* p_indices, const Vector2* p_vertices, const Vector2* p_uvs, const Color* p_colors,const RID& p_texture,bool p_singlecolor);
 	virtual void canvas_set_transform(const Matrix32& p_transform);

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -3745,7 +3745,7 @@ void VisualServerRaster::canvas_item_add_texture_rect_region(RID p_item, const R
 
 }
 
-void VisualServerRaster::canvas_item_add_style_box(RID p_item, const Rect2& p_rect, RID p_texture,const Vector2& p_topleft, const Vector2& p_bottomright, bool p_draw_center,const Color& p_modulate) {
+void VisualServerRaster::canvas_item_add_style_box(RID p_item, const Rect2& p_rect, const Rect2& p_source, RID p_texture, const Vector2& p_topleft, const Vector2& p_bottomright, bool p_draw_center,const Color& p_modulate) {
 
 	VS_CHANGED;
 	CanvasItem *canvas_item = canvas_item_owner.get( p_item );
@@ -3755,6 +3755,7 @@ void VisualServerRaster::canvas_item_add_style_box(RID p_item, const Rect2& p_re
 	ERR_FAIL_COND(!style);
 	style->texture=p_texture;
 	style->rect=p_rect;
+	style->source=p_source;
 	style->draw_center=p_draw_center;
 	style->color=p_modulate;
 	style->margin[MARGIN_LEFT]=p_topleft.x;

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -1171,7 +1171,7 @@ public:
 	virtual void canvas_item_add_circle(RID p_item, const Point2& p_pos, float p_radius,const Color& p_color);
 	virtual void canvas_item_add_texture_rect(RID p_item, const Rect2& p_rect, RID p_texture,bool p_tile=false,const Color& p_modulate=Color(1,1,1),bool p_transpose=false);
 	virtual void canvas_item_add_texture_rect_region(RID p_item, const Rect2& p_rect, RID p_texture,const Rect2& p_src_rect,const Color& p_modulate=Color(1,1,1),bool p_transpose=false);
-	virtual void canvas_item_add_style_box(RID p_item, const Rect2& p_rect, RID p_texture,const Vector2& p_topleft, const Vector2& p_bottomright, bool p_draw_center=true,const Color& p_modulate=Color(1,1,1));
+	virtual void canvas_item_add_style_box(RID p_item, const Rect2& p_rect, const Rect2& p_source, RID p_texture,const Vector2& p_topleft, const Vector2& p_bottomright, bool p_draw_center=true,const Color& p_modulate=Color(1,1,1));
 	virtual void canvas_item_add_primitive(RID p_item, const Vector<Point2>& p_points, const Vector<Color>& p_colors,const Vector<Point2>& p_uvs, RID p_texture,float p_width=1.0);
 	virtual void canvas_item_add_polygon(RID p_item, const Vector<Point2>& p_points, const Vector<Color>& p_colors,const Vector<Point2>& p_uvs=Vector<Point2>(), RID p_texture=RID());
 	virtual void canvas_item_add_triangle_array(RID p_item, const Vector<int>& p_indices, const Vector<Point2>& p_points, const Vector<Color>& p_colors,const Vector<Point2>& p_uvs=Vector<Point2>(), RID p_texture=RID(), int p_count=-1);

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -607,7 +607,7 @@ public:
 	FUNC4(canvas_item_add_circle,RID, const Point2& , float ,const Color& );
 	FUNC6(canvas_item_add_texture_rect,RID, const Rect2& , RID ,bool ,const Color&,bool );
 	FUNC6(canvas_item_add_texture_rect_region,RID, const Rect2& , RID ,const Rect2& ,const Color&,bool );
-	FUNC7(canvas_item_add_style_box,RID, const Rect2& , RID ,const Vector2& ,const Vector2&, bool ,const Color& );
+	FUNC8(canvas_item_add_style_box,RID, const Rect2& , const Rect2&, RID ,const Vector2& ,const Vector2&, bool ,const Color& );
 	FUNC6(canvas_item_add_primitive,RID, const Vector<Point2>& , const Vector<Color>& ,const Vector<Point2>& , RID ,float );
 	FUNC5(canvas_item_add_polygon,RID, const Vector<Point2>& , const Vector<Color>& ,const Vector<Point2>& , RID );
 	FUNC7(canvas_item_add_triangle_array,RID, const Vector<int>& , const Vector<Point2>& , const Vector<Color>& ,const Vector<Point2>& , RID , int );

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -705,10 +705,10 @@ void VisualServer::_bind_methods() {
 
 }
 
-void VisualServer::_canvas_item_add_style_box(RID p_item, const Rect2& p_rect, RID p_texture,const Vector<float>& p_margins, const Color& p_modulate) {
+void VisualServer::_canvas_item_add_style_box(RID p_item, const Rect2& p_rect, const Rect2& p_source, RID p_texture,const Vector<float>& p_margins, const Color& p_modulate) {
 
 	ERR_FAIL_COND(p_margins.size()!=4);
-	canvas_item_add_style_box(p_item, p_rect, p_texture,Vector2(p_margins[0],p_margins[1]),Vector2(p_margins[2],p_margins[3]),true,p_modulate);
+	canvas_item_add_style_box(p_item,p_rect,p_source,p_texture,Vector2(p_margins[0],p_margins[1]),Vector2(p_margins[2],p_margins[3]),true,p_modulate);
 }
 
 void VisualServer::_camera_set_orthogonal(RID p_camera,float p_size,float p_z_near,float p_z_far) {
@@ -822,5 +822,3 @@ VisualServer::~VisualServer() {
 
 	singleton=NULL;
 }
-
-

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -52,7 +52,7 @@ class VisualServer : public Object {
 	void _camera_set_orthogonal(RID p_camera,float p_size,float p_z_near,float p_z_far);
 	void _viewport_set_rect(RID p_viewport,const Rect2& p_rect);
 	Rect2 _viewport_get_rect(RID p_viewport) const;
-	void _canvas_item_add_style_box(RID p_item, const Rect2& p_rect, RID p_texture,const Vector<float>& p_margins, const Color& p_modulate=Color(1,1,1));
+	void _canvas_item_add_style_box(RID p_item, const Rect2& p_rect, const Rect2& p_source, RID p_texture,const Vector<float>& p_margins, const Color& p_modulate=Color(1,1,1));
 protected:
 	RID _make_test_cube();
 	void _free_internal_rids();
@@ -1025,7 +1025,7 @@ public:
 	virtual void canvas_item_add_circle(RID p_item, const Point2& p_pos, float p_radius,const Color& p_color)=0;
 	virtual void canvas_item_add_texture_rect(RID p_item, const Rect2& p_rect, RID p_texture,bool p_tile=false,const Color& p_modulate=Color(1,1,1),bool p_transpose=false)=0;
 	virtual void canvas_item_add_texture_rect_region(RID p_item, const Rect2& p_rect, RID p_texture,const Rect2& p_src_rect,const Color& p_modulate=Color(1,1,1),bool p_transpose=false)=0;
-	virtual void canvas_item_add_style_box(RID p_item, const Rect2& p_rect, RID p_texture,const Vector2& p_topleft, const Vector2& p_bottomright, bool p_draw_center=true,const Color& p_modulate=Color(1,1,1))=0;
+	virtual void canvas_item_add_style_box(RID p_item, const Rect2& p_rect, const Rect2& p_source, RID p_texture,const Vector2& p_topleft, const Vector2& p_bottomright, bool p_draw_center=true,const Color& p_modulate=Color(1,1,1))=0;
 	virtual void canvas_item_add_primitive(RID p_item, const Vector<Point2>& p_points, const Vector<Color>& p_colors,const Vector<Point2>& p_uvs, RID p_texture,float p_width=1.0)=0;
 	virtual void canvas_item_add_polygon(RID p_item, const Vector<Point2>& p_points, const Vector<Color>& p_colors,const Vector<Point2>& p_uvs=Vector<Point2>(), RID p_texture=RID())=0;
 	virtual void canvas_item_add_triangle_array(RID p_item, const Vector<int>& p_indices, const Vector<Point2>& p_points, const Vector<Color>& p_colors,const Vector<Point2>& p_uvs=Vector<Point2>(), RID p_texture=RID(), int p_count=-1)=0;

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -59,7 +59,7 @@
 
 // plugins
 #include "plugins/sprite_frames_editor_plugin.h"
-#include "plugins/sprite_region_editor_plugin.h"
+#include "plugins/texture_region_editor_plugin.h"
 #include "plugins/canvas_item_editor_plugin.h"
 #include "addon_editor_plugin.h"
 #include "plugins/spatial_editor_plugin.h"
@@ -5215,7 +5215,7 @@ void EditorNode::_bind_methods() {
 	ADD_SIGNAL( MethodInfo("play_pressed") );
 	ADD_SIGNAL( MethodInfo("pause_pressed") );
 	ADD_SIGNAL( MethodInfo("stop_pressed") );
-	ADD_SIGNAL( MethodInfo("request_help") );	
+	ADD_SIGNAL( MethodInfo("request_help") );
 	ADD_SIGNAL( MethodInfo("script_add_function_request",PropertyInfo(Variant::OBJECT,"obj"),PropertyInfo(Variant::STRING,"function"),PropertyInfo(Variant::STRING_ARRAY,"args")) );
 	ADD_SIGNAL( MethodInfo("resource_saved",PropertyInfo(Variant::OBJECT,"obj")) );
 
@@ -6387,7 +6387,7 @@ EditorNode::EditorNode() {
 	add_editor_plugin( memnew( TileSetEditorPlugin(this) ) );
 	add_editor_plugin( memnew( TileMapEditorPlugin(this) ) );
 	add_editor_plugin( memnew( SpriteFramesEditorPlugin(this) ) );
-	add_editor_plugin( memnew( SpriteRegionEditorPlugin(this) ) );
+	add_editor_plugin( memnew( TextureRegionEditorPlugin(this) ) );
 	add_editor_plugin( memnew( Particles2DEditorPlugin(this) ) );
 	add_editor_plugin( memnew( Path2DEditorPlugin(this) ) );
 	add_editor_plugin( memnew( PathEditorPlugin(this) ) );
@@ -6619,6 +6619,3 @@ EditorPluginList::EditorPluginList() {
 
 EditorPluginList::~EditorPluginList() {
 }
-
-
-

--- a/tools/editor/plugins/texture_region_editor_plugin.cpp
+++ b/tools/editor/plugins/texture_region_editor_plugin.cpp
@@ -41,6 +41,8 @@ void TextureRegionEditor::_region_draw()
 		base_tex = node_sprite->get_texture();
 	else if(node_type == "Patch9Frame" && node_patch9)
 		base_tex = node_patch9->get_texture();
+	else if(node_type == "StyleBoxTexture" && obj_styleBox)
+		base_tex = obj_styleBox->get_texture();
 	if (base_tex.is_null())
 		return;
 
@@ -164,6 +166,8 @@ void TextureRegionEditor::_region_input(const InputEvent& p_input)
 					rect_prev=node_sprite->get_region_rect();
 				else if(node_type == "Patch9Frame" && node_patch9)
 					rect_prev=node_patch9->get_region_rect();
+				else if(node_type == "StyleBoxTexture" && obj_styleBox)
+					rect_prev=obj_styleBox->get_region_rect();
 
 				drag_index=-1;
 				for(int i=0;i<8;i++) {
@@ -184,12 +188,12 @@ void TextureRegionEditor::_region_input(const InputEvent& p_input)
 				if(editing_region == REGION_TEXTURE_REGION) {
 					undo_redo->create_action("Set region_rect");
 					if(node_type == "Sprite" && node_sprite ){
-							undo_redo->add_do_method(node_sprite ,"set_region_rect",node_sprite->get_region_rect());
-							undo_redo->add_undo_method(node_sprite,"set_region_rect",rect_prev);
+						undo_redo->add_do_method(node_sprite ,"set_region_rect",node_sprite->get_region_rect());
+						undo_redo->add_undo_method(node_sprite,"set_region_rect",rect_prev);
 					}
 					else if(node_type == "Patch9Frame" && node_patch9){
-							undo_redo->add_do_method(node_patch9 ,"set_region_rect",node_patch9->get_region_rect());
-							undo_redo->add_undo_method(node_patch9,"set_region_rect",rect_prev);
+						undo_redo->add_do_method(node_patch9 ,"set_region_rect",node_patch9->get_region_rect());
+						undo_redo->add_undo_method(node_patch9,"set_region_rect",rect_prev);
 					}
 					undo_redo->add_do_method(edit_draw,"update");
 					undo_redo->add_undo_method(edit_draw,"update");
@@ -240,53 +244,53 @@ void TextureRegionEditor::_region_input(const InputEvent& p_input)
 
 			switch(drag_index) {
 			case 0: {
-				Vector2 p=rect_prev.pos+rect_prev.size;
-				rect = Rect2(p,Size2());
-				rect.expand_to(new_pos);
-				apply_rect(rect);
-			} break;
+					Vector2 p=rect_prev.pos+rect_prev.size;
+					rect = Rect2(p,Size2());
+					rect.expand_to(new_pos);
+					apply_rect(rect);
+				} break;
 			case 1: {
-				Vector2 p=rect_prev.pos+Vector2(0,rect_prev.size.y);
-				rect = Rect2(p,Size2(rect_prev.size.x,0));
-				rect.expand_to(new_pos);
-				apply_rect(rect);
-			} break;
+					Vector2 p=rect_prev.pos+Vector2(0,rect_prev.size.y);
+					rect = Rect2(p,Size2(rect_prev.size.x,0));
+					rect.expand_to(new_pos);
+					apply_rect(rect);
+				} break;
 			case 2: {
-				Vector2 p=rect_prev.pos+Vector2(0,rect_prev.size.y);
-				rect = Rect2(p,Size2());
-				rect.expand_to(new_pos);
-				apply_rect(rect);
-			} break;
+					Vector2 p=rect_prev.pos+Vector2(0,rect_prev.size.y);
+					rect = Rect2(p,Size2());
+					rect.expand_to(new_pos);
+					apply_rect(rect);
+				} break;
 			case 3: {
-				Vector2 p=rect_prev.pos;
-				rect = Rect2(p,Size2(0,rect_prev.size.y));
-				rect.expand_to(new_pos);
-				apply_rect(rect);
-			} break;
+					Vector2 p=rect_prev.pos;
+					rect = Rect2(p,Size2(0,rect_prev.size.y));
+					rect.expand_to(new_pos);
+					apply_rect(rect);
+				} break;
 			case 4: {
-				Vector2 p=rect_prev.pos;
-				rect = Rect2(p,Size2());
-				rect.expand_to(new_pos);
-				apply_rect(rect);
-			} break;
+					Vector2 p=rect_prev.pos;
+					rect = Rect2(p,Size2());
+					rect.expand_to(new_pos);
+					apply_rect(rect);
+				} break;
 			case 5: {
-				Vector2 p=rect_prev.pos;
-				rect = Rect2(p,Size2(rect_prev.size.x,0));
-				rect.expand_to(new_pos);
-				apply_rect(rect);
-			} break;
+					Vector2 p=rect_prev.pos;
+					rect = Rect2(p,Size2(rect_prev.size.x,0));
+					rect.expand_to(new_pos);
+					apply_rect(rect);
+				} break;
 			case 6: {
-				Vector2 p=rect_prev.pos+Vector2(rect_prev.size.x,0);
-				rect = Rect2(p,Size2());
-				rect.expand_to(new_pos);
-				apply_rect(rect);
-			} break;
+					Vector2 p=rect_prev.pos+Vector2(rect_prev.size.x,0);
+					rect = Rect2(p,Size2());
+					rect.expand_to(new_pos);
+					apply_rect(rect);
+				} break;
 			case 7: {
-				Vector2 p=rect_prev.pos+Vector2(rect_prev.size.x,0);
-				rect = Rect2(p,Size2(0,rect_prev.size.y));
-				rect.expand_to(new_pos);
-				apply_rect(rect);
-			} break;
+					Vector2 p=rect_prev.pos+Vector2(rect_prev.size.x,0);
+					rect = Rect2(p,Size2(0,rect_prev.size.y));
+					rect.expand_to(new_pos);
+					apply_rect(rect);
+				} break;
 
 			}
 			edit_draw->update();
@@ -349,19 +353,29 @@ void TextureRegionEditor::apply_rect(const Rect2& rect){
 			node_sprite->set_region_rect(rect);
 		else if(node_patch9)
 			node_patch9->set_region_rect(rect);
+		else if(obj_styleBox)
+			obj_styleBox->set_region_rect(rect);
 	}
-	else if(node_patch9 && this->editing_region == REGION_PATCH_MARGIN) {
-		node_patch9->set_patch_margin(MARGIN_LEFT, rect.pos.x - tex_region.pos.x);
-		node_patch9->set_patch_margin(MARGIN_RIGHT, tex_region.pos.x+tex_region.size.width-(rect.pos.x+rect.size.width));
-		node_patch9->set_patch_margin(MARGIN_TOP, rect.pos.y - tex_region.pos.y);
-		node_patch9->set_patch_margin(MARGIN_BOTTOM, tex_region.pos.y+tex_region.size.height-(rect.pos.y+rect.size.height));
+	else if(this->editing_region == REGION_PATCH_MARGIN) {
+		if(node_patch9) {
+			node_patch9->set_patch_margin(MARGIN_LEFT, rect.pos.x - tex_region.pos.x);
+			node_patch9->set_patch_margin(MARGIN_RIGHT, tex_region.pos.x+tex_region.size.width-(rect.pos.x+rect.size.width));
+			node_patch9->set_patch_margin(MARGIN_TOP, rect.pos.y - tex_region.pos.y);
+			node_patch9->set_patch_margin(MARGIN_BOTTOM, tex_region.pos.y+tex_region.size.height-(rect.pos.y+rect.size.height));
+		}
+		else if(obj_styleBox) {
+			obj_styleBox->set_margin_size(MARGIN_LEFT, rect.pos.x - tex_region.pos.x);
+			obj_styleBox->set_margin_size(MARGIN_RIGHT, tex_region.pos.x+tex_region.size.width-(rect.pos.x+rect.size.width));
+			obj_styleBox->set_margin_size(MARGIN_TOP, rect.pos.y - tex_region.pos.y);
+			obj_styleBox->set_margin_size(MARGIN_BOTTOM, tex_region.pos.y+tex_region.size.height-(rect.pos.y+rect.size.height));
+		}
 	}
 }
 
 void TextureRegionEditor::_notification(int p_what)
 {
 	switch(p_what) {
-		case NOTIFICATION_READY: {
+	case NOTIFICATION_READY: {
 			region_button->set_icon( get_icon("RegionEdit","EditorIcons"));
 			margin_button->set_icon( get_icon("Patch9Frame", "EditorIcons"));
 			b_snap_grid->set_icon( get_icon("Grid", "EditorIcons"));
@@ -371,11 +385,12 @@ void TextureRegionEditor::_notification(int p_what)
 	}
 }
 
-void TextureRegionEditor::_node_removed(Node *p_node)
+void TextureRegionEditor::_node_removed(Object *p_obj)
 {
-	if(p_node == node_sprite || p_node == node_patch9) {
+	if(p_obj == node_sprite || p_obj == node_patch9 || p_obj == obj_styleBox) {
 		node_patch9 = NULL;
 		node_sprite = NULL;
+		obj_styleBox = NULL;
 		hide();
 	}
 }
@@ -397,28 +412,39 @@ void TextureRegionEditor::_bind_methods()
 	ObjectTypeDB::bind_method(_MD("_set_snap_step_y"),&TextureRegionEditor::_set_snap_step_y);
 }
 
-void TextureRegionEditor::edit(Node *p_node)
+void TextureRegionEditor::edit(Object *p_obj)
 {
-	if (p_node) {
+	if (p_obj) {
 		margin_button->hide();
-		node_type = p_node->get_type();
+		node_type = p_obj->get_type();
 		if(node_type == "Sprite"){
-			node_sprite = p_node->cast_to<Sprite>();
+			node_sprite = p_obj->cast_to<Sprite>();
 			node_patch9 = NULL;
+			obj_styleBox = NULL;
 		}
 		else if(node_type == "Patch9Frame") {
-			node_patch9 = p_node->cast_to<Patch9Frame>();
+			node_patch9 = p_obj->cast_to<Patch9Frame>();
 			node_sprite = NULL;
+			obj_styleBox = NULL;
 			margin_button->show();
 		}
-		p_node->connect("exit_tree",this,"_node_removed",varray(p_node),CONNECT_ONESHOT);
+		else if(node_type == "StyleBoxTexture") {
+			obj_styleBox = p_obj->cast_to<StyleBoxTexture>();
+			node_sprite = NULL;
+			node_patch9 = NULL;
+			margin_button->show();
+		}
+		p_obj->connect("exit_tree",this,"_node_removed",varray(p_obj),CONNECT_ONESHOT);
 	} else {
 		if(node_sprite)
 			node_sprite->disconnect("exit_tree",this,"_node_removed");
 		else if(node_patch9)
 			node_patch9->disconnect("exit_tree",this,"_node_removed");
+		else if(obj_styleBox)
+			obj_styleBox->disconnect("exit_tree",this,"_node_removed");
 		node_sprite = NULL;
 		node_patch9 = NULL;
+		obj_styleBox = NULL;
 	}
 }
 
@@ -441,6 +467,8 @@ void TextureRegionEditor::_edit_node(int region)
 		texture = node_sprite->get_texture();
 	else if(node_type == "Patch9Frame" && node_patch9 )
 		texture = node_patch9->get_texture();
+	else if(node_type == "StyleBoxTexture" && obj_styleBox)
+		texture = obj_styleBox->get_texture();
 
 	if (texture.is_null()) {
 		error->set_text(TTR("No texture in this node.\nSet a texture to be able to edit region."));
@@ -452,12 +480,21 @@ void TextureRegionEditor::_edit_node(int region)
 		tex_region = node_sprite->get_region_rect();
 	else if(node_type == "Patch9Frame" && node_patch9 )
 		tex_region = node_patch9->get_region_rect();
+	else if(node_type == "StyleBoxTexture" && obj_styleBox)
+		tex_region = obj_styleBox->get_region_rect();
 	rect = tex_region;
 
-	if(region == REGION_PATCH_MARGIN && node_patch9) {
-		Patch9Frame *node = node_patch9->cast_to<Patch9Frame>();
-		rect.pos += Point2(node->get_patch_margin(MARGIN_LEFT),node->get_patch_margin(MARGIN_TOP));
-		rect.size -= Size2(node->get_patch_margin(MARGIN_RIGHT)+node->get_patch_margin(MARGIN_LEFT), node->get_patch_margin(MARGIN_BOTTOM)+node->get_patch_margin(MARGIN_TOP));
+	if(region == REGION_PATCH_MARGIN) {
+		if(node_patch9){
+			Patch9Frame *node = node_patch9;
+			rect.pos += Point2(node->get_patch_margin(MARGIN_LEFT),node->get_patch_margin(MARGIN_TOP));
+			rect.size -= Size2(node->get_patch_margin(MARGIN_RIGHT)+node->get_patch_margin(MARGIN_LEFT), node->get_patch_margin(MARGIN_BOTTOM)+node->get_patch_margin(MARGIN_TOP));
+		}
+		else if(obj_styleBox) {
+			StyleBoxTexture * node = obj_styleBox;
+			rect.pos += Point2(node->get_margin_size(MARGIN_LEFT),node->get_margin_size(MARGIN_TOP));
+			rect.size -= Size2(node->get_margin_size(MARGIN_RIGHT)+node->get_margin_size(MARGIN_LEFT), node->get_margin_size(MARGIN_BOTTOM)+node->get_margin_size(MARGIN_TOP));
+		}
 	}
 
 	dlg_editor->popup_centered_ratio(0.85);
@@ -619,12 +656,12 @@ TextureRegionEditor::TextureRegionEditor(EditorNode* p_editor)
 
 void TextureRegionEditorPlugin::edit(Object *p_node)
 {
-	region_editor->edit(p_node->cast_to<Node>());
+	region_editor->edit(p_node);
 }
 
-bool TextureRegionEditorPlugin::handles(Object *p_node) const
+bool TextureRegionEditorPlugin::handles(Object *p_obj) const
 {
-	return p_node->is_type("Sprite") || p_node->is_type("Patch9Frame");
+	return p_obj->is_type("Sprite") || p_obj->is_type("Patch9Frame") || p_obj->is_type("StyleBoxTexture");
 }
 
 void TextureRegionEditorPlugin::make_visible(bool p_visible)

--- a/tools/editor/plugins/texture_region_editor_plugin.h
+++ b/tools/editor/plugins/texture_region_editor_plugin.h
@@ -37,6 +37,7 @@
 #include "tools/editor/editor_node.h"
 #include "scene/2d/sprite.h"
 #include "scene/gui/patch_9_frame.h"
+#include "scene/resources/style_box.h"
 
 class TextureRegionEditor : public HBoxContainer {
 
@@ -80,6 +81,8 @@ class TextureRegionEditor : public HBoxContainer {
 	String node_type;
 	Patch9Frame *node_patch9;
 	Sprite *node_sprite;
+	StyleBoxTexture *obj_styleBox;
+
 	int editing_region;
 	Rect2 rect;
 	Rect2 rect_prev;
@@ -102,14 +105,13 @@ class TextureRegionEditor : public HBoxContainer {
 protected:
 
 	void _notification(int p_what);
-	void _node_removed(Node *p_node);
+	void _node_removed(Object *p_obj);
 	static void _bind_methods();
 
 	Vector2 snap_point(Vector2 p_target) const;
 
 public:
 
-	void edit();
 	void _edit_node(int tex_region);
 	void _edit_region();
 	void _edit_margin();
@@ -117,7 +119,7 @@ public:
 	void _region_input(const InputEvent &p_input);
 	void _scroll_changed(float);
 
-	void edit(Node *p_sprite);
+	void edit(Object *p_obj);
 	TextureRegionEditor(EditorNode* p_editor);
 
 };

--- a/tools/editor/plugins/texture_region_editor_plugin.h
+++ b/tools/editor/plugins/texture_region_editor_plugin.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  sprite_region_editor_plugin.h                                        */
+/*  texture_region_editor_plugin.h                                        */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -29,22 +29,26 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SPRITE_REGION_EDITOR_PLUGIN_H
-#define SPRITE_REGION_EDITOR_PLUGIN_H
+#ifndef TEXTURE_REGION_EDITOR_PLUGIN_H
+#define TEXTURE_REGION_EDITOR_PLUGIN_H
 
 #include "canvas_item_editor_plugin.h"
 #include "tools/editor/editor_plugin.h"
 #include "tools/editor/editor_node.h"
 #include "scene/2d/sprite.h"
+#include "scene/gui/patch_9_frame.h"
 
-class SpriteRegionEditor : public HBoxContainer {
+class TextureRegionEditor : public HBoxContainer {
 
-	OBJ_TYPE(SpriteRegionEditor, HBoxContainer );
+	OBJ_TYPE(TextureRegionEditor, HBoxContainer );
+	enum RegionType {
+		REGION_TEXTURE_REGION,
+		REGION_PATCH_MARGIN
+	};
 
-	friend class SpriteRegionEditorPlugin;
-
-	ToolButton *edit_node;
-//	Button *use_region;
+	friend class TextureRegionEditorPlugin;
+	ToolButton *region_button;
+	ToolButton *margin_button;
 	ToolButton *b_snap_enable;
 	ToolButton *b_snap_grid;
 	TextureFrame *icon_zoom;
@@ -59,7 +63,6 @@ class SpriteRegionEditor : public HBoxContainer {
 	VScrollBar *vscroll;
 	HScrollBar *hscroll;
 
-	Sprite *node;
 	EditorNode *editor;
 	AcceptDialog *dlg_editor;
 	UndoRedo* undo_redo;
@@ -73,8 +76,15 @@ class SpriteRegionEditor : public HBoxContainer {
 	Vector2 snap_offset;
 	Vector2 snap_step;
 
+
+	String node_type;
+	Patch9Frame *node_patch9;
+	Sprite *node_sprite;
+	int editing_region;
 	Rect2 rect;
 	Rect2 rect_prev;
+	Rect2 tex_region;
+
 	bool drag;
 	bool creating;
 	Vector2 drag_from;
@@ -88,7 +98,7 @@ class SpriteRegionEditor : public HBoxContainer {
 	void _set_snap_off_y(float p_val);
 	void _set_snap_step_x(float p_val);
 	void _set_snap_step_y(float p_val);
-
+	void apply_rect(const Rect2& rect);
 protected:
 
 	void _notification(int p_what);
@@ -100,22 +110,23 @@ protected:
 public:
 
 	void edit();
-	void _edit_node();
+	void _edit_node(int tex_region);
+	void _edit_region();
+	void _edit_margin();
 	void _region_draw();
 	void _region_input(const InputEvent &p_input);
 	void _scroll_changed(float);
 
 	void edit(Node *p_sprite);
-	SpriteRegionEditor(EditorNode* p_editor);
+	TextureRegionEditor(EditorNode* p_editor);
 
 };
 
-class SpriteRegionEditorPlugin : public EditorPlugin
+class TextureRegionEditorPlugin : public EditorPlugin
 {
+	OBJ_TYPE( TextureRegionEditorPlugin, EditorPlugin );
 
-	OBJ_TYPE( SpriteRegionEditorPlugin, EditorPlugin );
-
-	SpriteRegionEditor *region_editor;
+	TextureRegionEditor *region_editor;
 	EditorNode *editor;
 public:
 
@@ -127,7 +138,7 @@ public:
 	void set_state(const Dictionary &p_state);
 	Dictionary get_state() const;
 
-	SpriteRegionEditorPlugin(EditorNode *p_node);
+	TextureRegionEditorPlugin(EditorNode *p_node);
 };
 
-#endif // SPRITE_REGION_EDITOR_PLUGIN_H
+#endif // TEXTURE_REGION_EDITOR_PLUGIN_H


### PR DESCRIPTION
Here are a lot of changes:
- Add texture region support for Patch9Frame
- Add texture region support for stylebox rendering which can render the new Patch9Frame
- Add a plugin to quick select texture region and patch margins for Patch9Frame.

The GIF screen recorder:
![](https://cdn.rawgit.com/Geequlim/depot/master/images/godot/patch9plugin.gif)
