### PR TITLE
Physics2D: Rename default_density to default_linear_damp

### DIFF
--- a/scene/resources/world_2d.cpp
+++ b/scene/resources/world_2d.cpp
@@ -373,7 +373,15 @@ World2D::World2D() {
 	Physics2DServer::get_singleton()->space_set_active(space,true);
 	Physics2DServer::get_singleton()->area_set_param(space,Physics2DServer::AREA_PARAM_GRAVITY,GLOBAL_DEF("physics_2d/default_gravity",98));
 	Physics2DServer::get_singleton()->area_set_param(space,Physics2DServer::AREA_PARAM_GRAVITY_VECTOR,GLOBAL_DEF("physics_2d/default_gravity_vector",Vector2(0,1)));
-	Physics2DServer::get_singleton()->area_set_param(space,Physics2DServer::AREA_PARAM_LINEAR_DAMP,GLOBAL_DEF("physics_2d/default_density",0.1));
+	// TODO: Remove this deprecation warning and compatibility code for 2.2 or 3.0
+	if (Globals::get_singleton()->get("physics_2d/default_density") && !Globals::get_singleton()->get("physics_2d/default_linear_damp)")) {
+		WARN_PRINT("Deprecated parameter 'physics_2d/default_density'. It was renamed to 'physics_2d/default_linear_damp', adjusting your project settings accordingly (make sure to adjust scripts that potentially rely on 'physics_2d/default_density'.");
+		Globals::get_singleton()->set("physics_2d/default_linear_damp", Globals::get_singleton()->get("physics_2d/default_density"));
+		Globals::get_singleton()->set_persisting("physics_2d/default_linear_damp", true);
+		Globals::get_singleton()->set_persisting("physics_2d/default_density", false);
+		Globals::get_singleton()->save();
+	}
+	Physics2DServer::get_singleton()->area_set_param(space,Physics2DServer::AREA_PARAM_LINEAR_DAMP,GLOBAL_DEF("physics_2d/default_linear_damp",0.1));
 	Physics2DServer::get_singleton()->area_set_param(space,Physics2DServer::AREA_PARAM_ANGULAR_DAMP,GLOBAL_DEF("physics_2d/default_angular_damp",1));
 	Physics2DServer::get_singleton()->space_set_param(space,Physics2DServer::SPACE_PARAM_CONTACT_RECYCLE_RADIUS,1.0);
 	Physics2DServer::get_singleton()->space_set_param(space,Physics2DServer::SPACE_PARAM_CONTACT_MAX_SEPARATION,1.5);


### PR DESCRIPTION
Also adds a proper deprecating warning and tries to do some porting automatically.
Supersedes #4109.

@reduz @neikeq What do you think of the way I added the deprecation warning? Should I make this a method of Globals, e.g. `set_and_deprecate("physics_2d/default_linear_damp","physics_2d/default_density")`? Related to #4397.
