### PR TITLE
Methods for supporting advanced and deterministic screen capture

### DIFF
--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -7986,7 +7986,8 @@ void RasterizerGLES2::end_frame() {
 	//print_line("VTX: "+itos(_rinfo.vertex_count)+" OBJ: "+itos(_rinfo.object_count)+" MAT: "+itos(_rinfo.mat_change_count)+" SHD: "+itos(_rinfo.shader_change_count)+" CI: "+itos(_rinfo.ci_draw_commands));
 
 	//print_line("TOTAL VTX: "+itos(_rinfo.vertex_count));
-	OS::get_singleton()->swap_buffers();
+	if(swap_buffers_active)
+		OS::get_singleton()->swap_buffers();
 }
 
 void RasterizerGLES2::flush_frame() {
@@ -10980,7 +10981,7 @@ void RasterizerGLES2::init() {
 	//etc_supported=false;
 
 #endif
-
+	swap_buffers_active = true;
 	//use_rgba_shadowmaps=true;
 
 
@@ -11146,6 +11147,9 @@ bool RasterizerGLES2::has_feature(VS::Features p_feature) const {
 	}
 }
 
+void RasterizerGLES2::set_swap_buffers_active(const bool p_active) {
+	swap_buffers_active = p_active;
+}
 
 void RasterizerGLES2::reload_vram() {
 

--- a/drivers/gles2/rasterizer_gles2.h
+++ b/drivers/gles2/rasterizer_gles2.h
@@ -110,6 +110,8 @@ class RasterizerGLES2 : public Rasterizer {
 
 	bool shrink_textures_x2;
 
+	bool swap_buffers_active;
+
 	Vector<float> skel_default;
 
 	Image _get_gl_image_and_format(const Image& p_image, Image::Format p_format, uint32_t p_flags,GLenum& r_gl_format,GLenum& r_gl_internal_format,int &r_gl_components,bool &r_has_alpha_cache,bool &r_compressed);
@@ -1712,6 +1714,8 @@ public:
 	virtual bool has_feature(VS::Features p_feature) const;
 	
 	virtual void restore_framebuffer();
+
+	virtual void set_swap_buffers_active(const bool p_active);
 
 	static RasterizerGLES2* get_singleton();
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1185,6 +1185,10 @@ Image Viewport::get_screen_capture() const {
 
 	return VS::get_singleton()->viewport_get_screen_capture(viewport);
 }
+bool Viewport::is_screen_capture_queued() const {
+
+	return VS::get_singleton()->viewport_is_screen_capture_queued(viewport);
+}
 
 Ref<RenderTargetTexture> Viewport::get_render_target_texture() const {
 
@@ -2450,6 +2454,7 @@ void Viewport::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("is_size_override_stretch_enabled"), &Viewport::is_size_override_stretch_enabled);
 	ObjectTypeDB::bind_method(_MD("queue_screen_capture"), &Viewport::queue_screen_capture);
 	ObjectTypeDB::bind_method(_MD("get_screen_capture"), &Viewport::get_screen_capture);
+	ObjectTypeDB::bind_method(_MD("is_screen_capture_queued"), &Viewport::is_screen_capture_queued);
 
 	ObjectTypeDB::bind_method(_MD("set_as_render_target","enable"), &Viewport::set_as_render_target);
 	ObjectTypeDB::bind_method(_MD("is_set_as_render_target"), &Viewport::is_set_as_render_target);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -341,6 +341,7 @@ public:
 
 	void queue_screen_capture();
 	Image get_screen_capture() const;
+	bool is_screen_capture_queued() const;
 
 	void set_use_own_world(bool p_world);
 	bool is_using_own_world() const;

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -1038,6 +1038,7 @@ public:
 	virtual bool has_feature(VS::Features p_feature) const=0;
 
 	virtual void restore_framebuffer()=0;
+	virtual void set_swap_buffers_active(const bool p_active)=0;
 
 	virtual int get_render_info(VS::RenderInfo p_info)=0;
 

--- a/servers/visual/rasterizer_dummy.cpp
+++ b/servers/visual/rasterizer_dummy.cpp
@@ -1952,6 +1952,10 @@ void RasterizerDummy::restore_framebuffer() {
 
 }
 
+void RasterizerDummy::set_swap_buffers_active(const bool p_active) {
+
+}
+
 RasterizerDummy::RasterizerDummy() {
 
 };

--- a/servers/visual/rasterizer_dummy.h
+++ b/servers/visual/rasterizer_dummy.h
@@ -780,6 +780,7 @@ public:
 	virtual bool needs_to_draw_next_frame() const;
 
 	virtual bool has_feature(VS::Features p_feature) const;
+	virtual void set_swap_buffers_active(const bool p_active);
 
 	virtual void restore_framebuffer();
 

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -7607,6 +7607,11 @@ bool VisualServerRaster::has_feature(Features p_feature) const {
 	return rasterizer->has_feature(p_feature); // lies for now
 }
 
+void VisualServerRaster::set_swap_buffers_active(const bool p_active) {
+
+	rasterizer->set_swap_buffers_active(p_active);
+}
+
 void VisualServerRaster::set_default_clear_color(const Color& p_color) {
 
 	clear_color=p_color;

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -1731,6 +1731,13 @@ Image VisualServerRaster::viewport_get_screen_capture(RID p_viewport) const {
 	return ret;
 }
 
+bool VisualServerRaster::viewport_is_screen_capture_queued(RID p_viewport) const {
+
+	Viewport *viewport = (Viewport*)viewport_owner.get(p_viewport);
+	ERR_FAIL_COND_V(!viewport, false);
+	return viewport->queue_capture;
+}
+
 void VisualServerRaster::viewport_set_rect(RID p_viewport,const ViewportRect& p_rect) {
 	VS_CHANGED;
 	Viewport *viewport=NULL;

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -1277,6 +1277,8 @@ public:
 	virtual int get_render_info(RenderInfo p_info);
 	virtual bool has_feature(Features p_feature) const;
 
+	virtual void set_swap_buffers_active(const bool p_active);
+
 	RID get_test_cube();
 
 	virtual void set_boot_image(const Image& p_image, const Color& p_color, bool p_scale);

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -1010,6 +1010,7 @@ public:
 
 	virtual void viewport_queue_screen_capture(RID p_viewport);
 	virtual Image viewport_get_screen_capture(RID p_viewport) const;
+	virtual bool viewport_is_screen_capture_queued(RID p_viewport) const;
 
 	virtual void viewport_set_rect(RID p_viewport,const ViewportRect& p_rect);
 	virtual ViewportRect viewport_get_rect(RID p_viewport) const;

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -715,6 +715,7 @@ public:
 
 	FUNC1R(int,get_render_info,RenderInfo );
 	virtual bool has_feature(Features p_feature) const { return visual_server->has_feature(p_feature); }
+	FUNC1(set_swap_buffers_active, bool);
 
 	FUNC3(set_boot_image,const Image& , const Color&,bool );
 	FUNC1(set_default_clear_color,const Color& );

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -450,6 +450,7 @@ public:
 
 	FUNC1(viewport_queue_screen_capture,RID);
 	FUNC1RC(Image,viewport_get_screen_capture,RID);
+	FUNC1RC(bool, viewport_is_screen_capture_queued, RID);
 
 	FUNC2(viewport_set_rect,RID,const ViewportRect&);
 	FUNC1RC(ViewportRect,viewport_get_rect,RID);

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -562,6 +562,8 @@ void VisualServer::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("sync"),&VisualServer::sync);
 	ObjectTypeDB::bind_method(_MD("free"),&VisualServer::free);
 
+	ObjectTypeDB::bind_method(_MD("set_swap_buffers_active"),&VisualServer::set_swap_buffers_active);
+
 	ObjectTypeDB::bind_method(_MD("set_default_clear_color"),&VisualServer::set_default_clear_color);
 
 	ObjectTypeDB::bind_method(_MD("get_render_info"),&VisualServer::get_render_info);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -718,6 +718,7 @@ public:
 
 	virtual void viewport_queue_screen_capture(RID p_viewport)=0;
 	virtual Image viewport_get_screen_capture(RID p_viewport) const=0;
+	virtual bool viewport_is_screen_capture_queued(RID p_viewport) const = 0;
 
 
 

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -1189,6 +1189,7 @@ public:
 	};
 
 	virtual bool has_feature(Features p_feature) const=0;
+	virtual void set_swap_buffers_active(const bool p_active)=0;
 
 	VisualServer();
 	virtual ~VisualServer();


### PR DESCRIPTION
This PR simply adds a couple of methods to aid in doing in some things with screen capturing which wasn't previously possible which are fairly self-contained. The first is a renderer method for disabling buffer swapping. By turning this off, the game can retain what it last rendered while still rendering something else internally. With this, you could make it so the properties of the screenshot change without it being visible to the player. In my specific case, I use it for an ingame camera phone which has an overlay which gets removed during the screenshot phase. Once the screenshot has been successfully processed, you can then turn swap buffering back on.

The other method relates to the feeling that in the demo project, where the script simply waits two frames before getting the screen capture. Since capturing screenshots is multi-threaded, this method is not 'truly' deterministic, since although it's unlikely, it's theoretically possible that a screenshot could take longer to process. As such, I've added a simple method to check whether any screenshots are still pending, and the idea is you would continually loop and check if the screenshot has finished processing, at which point you can do something with it. You may also prefer to pause the tree, which would allow a more controlled way of handling screenshots while still being able to take advantage of multi-threading to avoid the problem of the application stalling.
