### PR TITLE
Added InputMap.get_actions()

### DIFF
--- a/core/input_map.cpp
+++ b/core/input_map.cpp
@@ -36,6 +36,7 @@ void InputMap::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("has_action","action"),&InputMap::has_action);
 	ObjectTypeDB::bind_method(_MD("get_action_id","action"),&InputMap::get_action_id);
 	ObjectTypeDB::bind_method(_MD("get_action_from_id","id"),&InputMap::get_action_from_id);
+	ObjectTypeDB::bind_method(_MD("get_actions"),&InputMap::_get_actions);
 	ObjectTypeDB::bind_method(_MD("add_action","action"),&InputMap::add_action);
 	ObjectTypeDB::bind_method(_MD("erase_action","action"),&InputMap::erase_action);
 
@@ -73,6 +74,35 @@ StringName InputMap::get_action_from_id(int p_id) const {
 
 	ERR_FAIL_COND_V(!input_id_map.has(p_id),StringName());
 	return input_id_map[p_id];
+}
+
+Array InputMap::_get_actions() {
+
+	Array ret;
+	List<StringName> actions = get_actions();
+	if(actions.empty())
+		return ret;
+
+	for(const List<StringName>::Element *E=actions.front();E;E=E->next()) {
+
+		ret.push_back(E->get());
+	}
+
+	return ret;
+}
+
+List<StringName> InputMap::get_actions() const {
+
+	List<StringName> actions = List<StringName>();
+	if(input_map.empty()){
+		return actions;
+	}
+
+	for (Map<StringName, Action>::Element *E=input_map.front();E;E=E->next()) {
+		actions.push_back(E->key());
+	}
+
+	return actions;
 }
 
 List<InputEvent>::Element *InputMap::_find_event(List<InputEvent> &p_list,const InputEvent& p_event) const {

--- a/core/input_map.h
+++ b/core/input_map.h
@@ -47,6 +47,7 @@ class InputMap : public Object {
 	List<InputEvent>::Element *_find_event(List<InputEvent> &p_list,const InputEvent& p_event) const;
 
 	Array _get_action_list(const StringName& p_action);
+	Array _get_actions();
 
 protected:
 
@@ -59,6 +60,7 @@ public:
 	bool has_action(const StringName& p_action) const;
 	int get_action_id(const StringName& p_action) const;
 	StringName get_action_from_id(int p_id) const;
+	List<StringName> get_actions() const;
 	void add_action(const StringName& p_action);
 	void erase_action(const StringName& p_action);
 

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -16566,6 +16566,7 @@ Example: (content-length:12), (Content-Type:application/json; charset=UTF-8)
 			<argument index="0" name="action" type="String">
 			</argument>
 			<description>
+			Whether this InputMap has an action with name "action".
 			</description>
 		</method>
 		<method name="get_action_id" qualifiers="const">
@@ -16574,6 +16575,7 @@ Example: (content-length:12), (Content-Type:application/json; charset=UTF-8)
 			<argument index="0" name="action" type="String">
 			</argument>
 			<description>
+			Return the id of an action.
 			</description>
 		</method>
 		<method name="get_action_from_id" qualifiers="const">
@@ -16582,18 +16584,28 @@ Example: (content-length:12), (Content-Type:application/json; charset=UTF-8)
 			<argument index="0" name="id" type="int">
 			</argument>
 			<description>
+			Return the action from an id.
+			</description>
+		</method>
+		<method name="get_actions">
+			<return type="Array">
+			</return>
+			<description>
+			Return an [Array] of all actions in the [InputMap].
 			</description>
 		</method>
 		<method name="add_action">
 			<argument index="0" name="action" type="String">
 			</argument>
 			<description>
+			Add an action to the [InputMap].
 			</description>
 		</method>
 		<method name="erase_action">
 			<argument index="0" name="action" type="String">
 			</argument>
 			<description>
+			Remove an action from the [InputMap].
 			</description>
 		</method>
 		<method name="action_add_event">
@@ -16602,6 +16614,7 @@ Example: (content-length:12), (Content-Type:application/json; charset=UTF-8)
 			<argument index="1" name="event" type="InputEvent">
 			</argument>
 			<description>
+			Add an [InputEvent] to action. This [InputEvent] will trigger the action.
 			</description>
 		</method>
 		<method name="action_has_event">
@@ -16612,6 +16625,7 @@ Example: (content-length:12), (Content-Type:application/json; charset=UTF-8)
 			<argument index="1" name="event" type="InputEvent">
 			</argument>
 			<description>
+			Whether an action has an [InputEvent] associated with it.
 			</description>
 		</method>
 		<method name="action_erase_event">
@@ -16620,6 +16634,7 @@ Example: (content-length:12), (Content-Type:application/json; charset=UTF-8)
 			<argument index="1" name="event" type="InputEvent">
 			</argument>
 			<description>
+			Remove an [InputEvent] from an action.
 			</description>
 		</method>
 		<method name="get_action_list">
@@ -16628,6 +16643,7 @@ Example: (content-length:12), (Content-Type:application/json; charset=UTF-8)
 			<argument index="0" name="action" type="String">
 			</argument>
 			<description>
+			Return an [Array] of [InputEvent]s associated with an action.
 			</description>
 		</method>
 		<method name="event_is_action" qualifiers="const">
@@ -16642,6 +16658,7 @@ Example: (content-length:12), (Content-Type:application/json; charset=UTF-8)
 		</method>
 		<method name="load_from_globals">
 			<description>
+			Clears the [InputMap] and loads it from [Globals].
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Adds `InputMap.get_actions()` which lists all actions in the InputMap. Resolves #5033 

However I think the `InputMap.get_action_list(var action)` is misleading and should be renamed to something like `InputMap.action_get_events(var action)`, however thats maybe for another PR.
