### PR TITLE
Add joystick vibration support on Linux

### DIFF
--- a/core/os/input.cpp
+++ b/core/os/input.cpp
@@ -59,6 +59,10 @@ void Input::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_joy_axis","device","axis"),&Input::get_joy_axis);
 	ObjectTypeDB::bind_method(_MD("get_joy_name","device"),&Input::get_joy_name);
 	ObjectTypeDB::bind_method(_MD("get_joy_guid","device"),&Input::get_joy_guid);
+	ObjectTypeDB::bind_method(_MD("get_joy_vibration_strength", "device"), &Input::get_joy_vibration_strength);
+	ObjectTypeDB::bind_method(_MD("get_joy_vibration_duration", "device"), &Input::get_joy_vibration_duration);
+	ObjectTypeDB::bind_method(_MD("start_joy_vibration", "device", "strong_magnitude", "weak_magnitude", "duration"), &Input::start_joy_vibration);
+	ObjectTypeDB::bind_method(_MD("stop_joy_vibration", "device"), &Input::stop_joy_vibration);
 	ObjectTypeDB::bind_method(_MD("get_accelerometer"),&Input::get_accelerometer);
 	ObjectTypeDB::bind_method(_MD("get_magnetometer"),&Input::get_magnetometer);
 	//ObjectTypeDB::bind_method(_MD("get_mouse_pos"),&Input::get_mouse_pos); - this is not the function you want

--- a/core/os/input.cpp
+++ b/core/os/input.cpp
@@ -61,7 +61,7 @@ void Input::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_joy_guid","device"),&Input::get_joy_guid);
 	ObjectTypeDB::bind_method(_MD("get_joy_vibration_strength", "device"), &Input::get_joy_vibration_strength);
 	ObjectTypeDB::bind_method(_MD("get_joy_vibration_duration", "device"), &Input::get_joy_vibration_duration);
-	ObjectTypeDB::bind_method(_MD("start_joy_vibration", "device", "strong_magnitude", "weak_magnitude", "duration"), &Input::start_joy_vibration);
+	ObjectTypeDB::bind_method(_MD("start_joy_vibration", "device", "weak_magnitude", "strong_magnitude", "duration"), &Input::start_joy_vibration);
 	ObjectTypeDB::bind_method(_MD("stop_joy_vibration", "device"), &Input::stop_joy_vibration);
 	ObjectTypeDB::bind_method(_MD("get_accelerometer"),&Input::get_accelerometer);
 	ObjectTypeDB::bind_method(_MD("get_magnetometer"),&Input::get_magnetometer);

--- a/core/os/input.h
+++ b/core/os/input.h
@@ -67,6 +67,11 @@ public:
 	virtual void remove_joy_mapping(String p_guid)=0;
 	virtual bool is_joy_known(int p_device)=0;
 	virtual String get_joy_guid(int p_device) const=0;
+	virtual Vector2 get_joy_vibration_strength(int p_device)=0;
+	virtual float get_joy_vibration_duration(int p_device)=0;
+	virtual uint64_t get_joy_vibration_timestamp(int p_device)=0;
+	virtual void start_joy_vibration(int p_device, float p_weak_magnitude, float p_strong_magnitude, float p_duration)=0;
+	virtual void stop_joy_vibration(int p_device)=0;
 
 	virtual Point2 get_mouse_pos() const=0;
 	virtual Point2 get_mouse_speed() const=0;

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -15627,7 +15627,7 @@ Example: (content-length:12), (Content-Type:application/json; charset=UTF-8)
 			<argument index="3" name="duration" type="float">
 			</argument>
 			<description>
-			Starts to vibrate the joystick. Joysticks usually come with two rumble motors, a strong and a weak one. weak_magnitude is the strength of the weak motor (between 0 and 1) and strong_magnitude is the strength of the strong motor (between 0 and 1). duration is the duration of the effect in seconds.
+			Starts to vibrate the joystick. Joysticks usually come with two rumble motors, a strong and a weak one. weak_magnitude is the strength of the weak motor (between 0 and 1) and strong_magnitude is the strength of the strong motor (between 0 and 1). duration is the duration of the effect in seconds (a duration of 0 will play the vibration indefinitely).
 			</description>
 		</method>
 		<method name="stop_joy_vibration">

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -15558,6 +15558,23 @@ Example: (content-length:12), (Content-Type:application/json; charset=UTF-8)
 			Returns a SDL2 compatible device guid on platforms that use gamepad remapping. Returns "Default Gamepad" otherwise.
 			</description>
 		</method>
+		<method name="get_joy_vibration_strength">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="device" type="int">
+			</argument>
+			<description>
+			Returns the strength of the joystick vibration: x is the strength of the weak motor, and y is the strength of the strong motor.
+			</description>
+		</method>
+		<method name="get_joy_vibration_duration">
+			<return type="float">
+			</return>
+			<argument index="0" name="device" type="int">
+			</argument>
+			<description>
+			Returns the duration of the current vibration effect in seconds.
+			</description>
 		<method name="get_accelerometer">
 			<return type="Vector3">
 			</return>
@@ -15598,6 +15615,26 @@ Example: (content-length:12), (Content-Type:application/json; charset=UTF-8)
 			</return>
 			<description>
 			Return the mouse mode. See the constants for more information.
+			</description>
+		</method>
+		<method name="start_joy_vibration">
+			<argument index="0" name="device" type="int">
+			</argument>
+			<argument index="1" name="weak_magnitude" type="float">
+			</argument>
+			<argument index="2" name="strong_magnitude" type="float">
+			</argument>
+			<argument index="3" name="duration" type="float">
+			</argument>
+			<description>
+			Starts to vibrate the joystick. Joysticks usually come with two rumble motors, a strong and a weak one. weak_magnitude is the strength of the weak motor (between 0 and 1) and strong_magnitude is the strength of the strong motor (between 0 and 1). duration is the duration of the effect in seconds.
+			</description>
+		</method>
+		<method name="stop_joy_vibration">
+			<argument index="0" name="device" type="int">
+			</argument>
+			<description>
+			Stops the vibration of the joystick.
 			</description>
 		</method>
 		<method name="warp_mouse_pos">

--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -137,6 +137,30 @@ String InputDefault::get_joy_name(int p_idx) {
 	return joy_names[p_idx].name;
 };
 
+Vector2 InputDefault::get_joy_vibration_strength(int p_device) {
+	if (joy_vibration.has(p_device)) {
+		return Vector2(joy_vibration[p_device].weak_magnitude, joy_vibration[p_device].strong_magnitude);
+	} else {
+		return Vector2(0, 0);
+	}
+}
+
+uint64_t InputDefault::get_joy_vibration_timestamp(int p_device) {
+	if (joy_vibration.has(p_device)) {
+		return joy_vibration[p_device].timestamp;
+	} else {
+		return 0;
+	}
+}
+
+float InputDefault::get_joy_vibration_duration(int p_device) {
+	if (joy_vibration.has(p_device)) {
+		return joy_vibration[p_device].duration;
+	} else {
+		return 0.f;
+	}
+}
+
 static String _hex_str(uint8_t p_byte) {
 
 	static const char* dict = "0123456789abcdef";
@@ -292,6 +316,29 @@ void InputDefault::set_joy_axis(int p_device,int p_axis,float p_value) {
 	_THREAD_SAFE_METHOD_
 	int c = _combine_device(p_axis,p_device);
 	_joy_axis[c]=p_value;
+}
+
+void InputDefault::start_joy_vibration(int p_device, float p_weak_magnitude, float p_strong_magnitude, float p_duration) {
+	_THREAD_SAFE_METHOD_
+	if (p_weak_magnitude < 0.f || p_weak_magnitude > 1.f || p_strong_magnitude < 0.f || p_strong_magnitude > 1.f) {
+		return;
+	}
+	VibrationInfo vibration;
+	vibration.weak_magnitude = p_weak_magnitude;
+	vibration.strong_magnitude = p_strong_magnitude;
+	vibration.duration = p_duration;
+	vibration.timestamp = OS::get_singleton()->get_unix_time();
+	joy_vibration[p_device] = vibration;
+}
+
+void InputDefault::stop_joy_vibration(int p_device) {
+	_THREAD_SAFE_METHOD_
+	VibrationInfo vibration;
+	vibration.weak_magnitude = 0;
+	vibration.strong_magnitude = 0;
+	vibration.duration = 0;
+	vibration.timestamp = OS::get_singleton()->get_unix_time();
+	joy_vibration[p_device] = vibration;
 }
 
 void InputDefault::set_accelerometer(const Vector3& p_accel) {

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -3,6 +3,7 @@
 
 #include "os/input.h"
 
+
 class InputDefault : public Input {
 
 	OBJ_TYPE( InputDefault, Input );
@@ -19,6 +20,16 @@ class InputDefault : public Input {
 	MainLoop *main_loop;
 
 	bool emulate_touch;
+
+	struct VibrationInfo {
+		float weak_magnitude;
+		float strong_magnitude;
+		float duration; // Duration in seconds
+		uint64_t timestamp;
+	};
+
+	Map<int, VibrationInfo> joy_vibration;
+
 	struct SpeedTrack {
 
 		uint64_t last_tick;
@@ -129,6 +140,9 @@ public:
 
 	virtual float get_joy_axis(int p_device,int p_axis);
 	String get_joy_name(int p_idx);
+	virtual Vector2 get_joy_vibration_strength(int p_device);
+	virtual float get_joy_vibration_duration(int p_device);
+	virtual uint64_t get_joy_vibration_timestamp(int p_device);
 	void joy_connection_changed(int p_idx, bool p_connected, String p_name, String p_guid = "");
 	void parse_joystick_mapping(String p_mapping, bool p_update_existing);
 
@@ -146,6 +160,9 @@ public:
 	void set_accelerometer(const Vector3& p_accel);
 	void set_magnetometer(const Vector3& p_magnetometer);
 	void set_joy_axis(int p_device,int p_axis,float p_value);
+
+	virtual void start_joy_vibration(int p_device, float p_weak_magnitude, float p_strong_magnitude, float p_duration);
+	virtual void stop_joy_vibration(int p_device);
 
 	void set_main_loop(MainLoop *main_loop);
 	void set_mouse_pos(const Point2& p_posf);

--- a/platform/x11/joystick_linux.h
+++ b/platform/x11/joystick_linux.h
@@ -61,6 +61,10 @@ private:
 		String devpath;
 		input_absinfo *abs_info[MAX_ABS];
 
+		bool force_feedback;
+		int ff_effect_id;
+		uint64_t ff_effect_timestamp;
+
 		Joystick();
 		~Joystick();
 		void reset();
@@ -87,6 +91,9 @@ private:
 	void monitor_joysticks();
 	void run_joystick_thread();
 	void open_joystick(const char* path);
+
+	void joystick_vibration_start(int p_id, float p_weak_magnitude, float p_strong_magnitude, float p_duration, uint64_t p_timestamp);
+	void joystick_vibration_stop(int p_id, uint64_t p_timestamp);
 
 	InputDefault::JoyAxis axis_correct(const input_absinfo *abs, int value) const;
 };


### PR DESCRIPTION
Related to #5013 
This pull request adds joystick vibration support on Linux.
Here is the cross platform API:
- `Input.start_joy_vibration(device, weak_magnitude, strong_magnitude)` to start the joystick vibration
- `Input.stop_joy_vibration(device)` to stop the vibration
- `Input.get_joy_vibration(device)` to get the current strength of the vibration

**TODO**:
- Add support for Windows and OS X (unfortunately I don't know the API for these platforms, hopefully someone could add support after this PR is merged)
- Update the joystick demo (I will do that myself when this PR is merged)

I don't know much about Godot's codebase, so don't hesitate to tell me if I did something wrong :)
