### PR TITLE
Fix min size bug of Label

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -488,9 +488,9 @@ void Label::regenerate_word_cache() {
 	if (!autowrap) {
 		minsize.width=width;
 		if (max_lines_visible > 0 && line_count > max_lines_visible) {
-			minsize.height=(font->get_height() * max_lines_visible) + (line_spacing * (max_lines_visible - 1));
+			minsize.height=(font->get_height()+line_spacing)*max_lines_visible;
 		} else {
-			minsize.height=(font->get_height() * line_count)+(line_spacing * (line_count - 1));
+			minsize.height=(font->get_height()+line_spacing)*line_count;
 		}
 	}
 


### PR DESCRIPTION
caused by #5030 and fix #5046

with #5030
![label_bug](https://cloud.githubusercontent.com/assets/8281454/15806287/1c273828-2b7b-11e6-80c0-aad752af278c.gif)

with old code (this commit)
![label_fix](https://cloud.githubusercontent.com/assets/8281454/15806291/2d08db60-2b7b-11e6-9a10-5c4467553f6e.gif)
