### PR TITLE
Fix implicit GDScript Reference inheritance

### DIFF
--- a/modules/gdscript/gd_compiler.cpp
+++ b/modules/gdscript/gd_compiler.cpp
@@ -1588,6 +1588,12 @@ Error GDCompiler::_parse_class(GDScript *p_script, GDScript *p_owner, const GDPa
 		}
 
 
+	} else {
+		// without extends, implicitly extend Reference
+		int native_idx = GDScriptLanguage::get_singleton()->get_global_map()["Reference"];
+		native = GDScriptLanguage::get_singleton()->get_global_array()[native_idx];
+		ERR_FAIL_COND_V(native.is_null(), ERR_BUG);
+		p_script->native=native;
 	}
 
 

--- a/modules/gdscript/gd_script.cpp
+++ b/modules/gdscript/gd_script.cpp
@@ -145,11 +145,8 @@ Variant GDScript::_new(const Variant** p_args,int p_argcount,Variant::CallError&
 		_baseptr=_baseptr->_base;
 	}
 
-	if (_baseptr->native.ptr()) {
-		owner=_baseptr->native->instance();
-	} else {
-		owner=memnew( Reference ); //by default, no base means use reference
-	}
+	ERR_FAIL_COND_V(_baseptr->native.is_null(), Variant());
+	owner=_baseptr->native->instance();
 
 	Reference *r=owner->cast_to<Reference>();
 	if (r) {


### PR DESCRIPTION
Currently, applying a GDScript without `extends` to a non-Reference type (e.g. a Node) will not yield an error but result in a somewhat ambiguous state. Lack of explicit `extends` should result in an implicit `extends Reference`. This change fixes the behavior accordingly.
