### PR TITLE
Improved Blender/Collada -colonly import creating collision shapes fo…

### DIFF
--- a/tools/collada/collada.cpp
+++ b/tools/collada/collada.cpp
@@ -482,6 +482,24 @@ Transform Collada::_read_transform(XMLParser& parser) {
 	return _read_transform_from_array(array);
 }
 
+String Collada::_read_empty_draw_type(XMLParser& parser) {
+
+	String empty_draw_type = "";
+	
+	if (parser.is_empty())
+		return empty_draw_type;
+	
+	while (parser.read()==OK) {
+		if (parser.get_node_type() == XMLParser::NODE_TEXT) {
+			empty_draw_type = parser.get_node_data();
+		}
+		else
+		if (parser.get_node_type() == XMLParser::NODE_ELEMENT_END)
+			break; // end parsing text
+	}
+	return empty_draw_type;
+}
+
 Variant Collada::_parse_param(XMLParser& parser) {
 
 	if (parser.is_empty())
@@ -1664,6 +1682,8 @@ Collada::Node* Collada::_parse_visual_scene_node(XMLParser& parser) {
 
 	Vector<Node::XForm> xform_list;
 	Vector<Node*> children;
+	
+	String empty_draw_type="";
 
 	Node *node=NULL;
 
@@ -1771,7 +1791,9 @@ Collada::Node* Collada::_parse_visual_scene_node(XMLParser& parser) {
 
 				   xform_list.push_back(xf);
 
-			} else if (section=="technique" || section=="extra") {
+			} else if (section=="empty_draw_type") {
+				empty_draw_type = _read_empty_draw_type(parser);
+			} else if (section == "technique" || section=="extra") {
 
 			} else if (section!="node") {
 				//usually what defines the type of node
@@ -1817,6 +1839,7 @@ Collada::Node* Collada::_parse_visual_scene_node(XMLParser& parser) {
 
 	node->name=name;
 	node->id=id;
+	node->empty_draw_type=empty_draw_type;
 
 	if (node->children.size()==1) {
 		if (node->children[0]->noname && !node->noname) {

--- a/tools/collada/collada.h
+++ b/tools/collada/collada.h
@@ -403,6 +403,7 @@ public:
 
 		String name;
 		String id;
+		String empty_draw_type;
 		bool noname;
 		Vector<XForm> xform_list;
 		Transform default_transform;
@@ -635,6 +636,7 @@ private: // private stuff
 	Vector<float> _read_float_array(XMLParser& parser);
 	Vector<String> _read_string_array(XMLParser& parser);
 	Transform _read_transform(XMLParser& parser);
+	String _read_empty_draw_type(XMLParser& parser);
 
 	void _joint_set_owner(Collada::Node *p_node, NodeSkeleton *p_owner);
 	void _create_skeletons(Collada::Node **p_node, NodeSkeleton *p_skeleton=NULL);

--- a/tools/editor/io_plugins/editor_import_collada.cpp
+++ b/tools/editor/io_plugins/editor_import_collada.cpp
@@ -355,6 +355,10 @@ Error ColladaImport::_create_scene(Collada::Node *p_node, Spatial *p_parent) {
 	p_parent->add_child(node);
 	node->set_owner(scene);
 
+	if (p_node->empty_draw_type!="") {
+		node->set_meta("empty_draw_type", Variant(p_node->empty_draw_type));
+	}
+	
 	for(int i=0;i<p_node->children.size();i++) {
 
 		Error err = _create_scene(p_node->children[i],node);

--- a/tools/export/blender25/io_scene_dae/export_dae.py
+++ b/tools/export/blender25/io_scene_dae/export_dae.py
@@ -1104,6 +1104,14 @@ class DaeExporter:
 
 		self.writel(S_NODES,il,'<instance_light url="#'+lightid+'"/>')
 
+	def export_empty_node(self,node,il):
+
+		self.writel(S_NODES,4,'<extra>')
+		self.writel(S_NODES,5,'<technique profile="GODOT">')
+		self.writel(S_NODES,6,'<empty_draw_type>'+node.empty_draw_type+'</empty_draw_type>')
+		self.writel(S_NODES,5,'</technique>')
+		self.writel(S_NODES,4,'</extra>')
+
 
 	def export_curve(self,curve):
 
@@ -1264,6 +1272,8 @@ class DaeExporter:
 			self.export_camera_node(node,il)
 		elif (node.type=="LAMP"):
 			self.export_lamp_node(node,il)
+		elif (node.type=="EMPTY"):
+			self.export_empty_node(node,il)
 
 		for x in node.children:
 			self.export_node(x,il)


### PR DESCRIPTION
…r empties

It would be nice to create StaticBodies / ColisionShapes for Empties imported from blender.
Blender has plenty of Empty types and some of them can be mapped to Godot collision shapes.

My proposal is to map:
CUBE -> BoxShape
IMAGE -> PlaneShape
SINGLE_ARROW -> RayShape
SPHERE -> SphereShape
anything else -> SphereShape

![blender](https://cloud.githubusercontent.com/assets/19764492/15807641/72445320-2b63-11e6-9439-83fceb7eafe2.png)

![godot](https://cloud.githubusercontent.com/assets/19764492/15807643/79cae8b6-2b63-11e6-9d45-6965342ded9c.png)
