### PR TITLE
Somewhat fixed Directory::get_space_left() return values.

### DIFF
--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -69,7 +69,7 @@ bool DirAccessWindows::list_dir_begin() {
 
 	_cisdir=false;
 	_cishidden=false;
-	
+
 	list_dir_end();
 	p->h = FindFirstFileExW((current_dir+"\\*").c_str(), FindExInfoStandard, &p->fu, FindExSearchNameMatch, NULL, 0);
 
@@ -83,7 +83,7 @@ String DirAccessWindows::get_next() {
 	if (p->h==INVALID_HANDLE_VALUE)
 		return "";
 
-	
+
 	_cisdir=(p->fu.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY);
 	_cishidden=(p->fu.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN);
 
@@ -192,7 +192,7 @@ Error DirAccessWindows::make_dir(String p_dir) {
 #else
 
 	p_dir=fix_path(p_dir);
-	
+
 	//p_dir.replace("/","\\");
 
 	bool success;
@@ -249,7 +249,7 @@ bool DirAccessWindows::file_exists(String p_file) {
 		p_file=get_current_dir().plus_file(p_file);
 
 	p_file=fix_path(p_file);
-	
+
 	//p_file.replace("/","\\");
 
 	//WIN32_FILE_ATTRIBUTE_DATA    fileInfo;
@@ -359,8 +359,12 @@ FileType DirAccessWindows::get_file_type(const String& p_file) const {
 */
 size_t  DirAccessWindows::get_space_left() {
 
-	return -1;
-};
+	uint64_t bytes = 0;
+	GetDiskFreeSpaceEx(NULL,(PULARGE_INTEGER)&bytes,NULL,NULL);
+
+	//this is either 0 or a value in bytes.
+	return (size_t)bytes;
+}
 
 DirAccessWindows::DirAccessWindows() {
 

--- a/platform/osx/dir_access_osx.mm
+++ b/platform/osx/dir_access_osx.mm
@@ -319,10 +319,10 @@ size_t DirAccessOSX::get_space_left() {
 	struct statvfs vfs;
 	if (statvfs(current_dir.utf8().get_data(), &vfs) != 0) {
 
-		return -1;
+		return 0;
 	};
 
-	return vfs.f_bfree * vfs.f_bsize;
+	return (size_t) (vfs.f_bavail * vfs.f_bsize);
 #else
 #warning THIS IS BROKEN
 	return 0;


### PR DESCRIPTION
Implemented it on windows using `GetDiskFreeSpaceEx()`.
Works on linux/osx(if STAT_VFS is enabled) and windows. On other platforms currently returns 0.

Partly fixes #4617 , only Android implementation remaining. I'm not sure what proper behavior for `DirAccessPack` is.
