### PR TITLE
Keep the default environment variables as set by SCons

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -63,14 +63,9 @@ elif (os.name=="nt"):
 	if (os.getenv("VSINSTALLDIR")==None or platform_arg=="android"):
 		custom_tools=['mingw']
 
-env_base=Environment(
-	tools=custom_tools,
-	ENV={
-		'PATH' : os.getenv('PATH'),
-		'PKG_CONFIG_PATH' : os.getenv('PKG_CONFIG_PATH')
-});
-
-#env_base=Environment(tools=custom_tools);
+env_base=Environment(tools=custom_tools);
+env_base.AppendENVPath('PATH', os.getenv('PATH'))
+env_base.AppendENVPath('PKG_CONFIG_PATH', os.getenv('PKG_CONFIG_PATH'))
 env_base.global_defaults=global_defaults
 env_base.android_maven_repos=[]
 env_base.android_dependencies=[]


### PR DESCRIPTION
Fixes a regression introduced by  #4179 by which cross-building on Windows would fail because of the SystemRoot env var not being present.
That makes the toolchains to fail to find certain system DLLs.
I noticed this while trying to build for Android with GCC 4.9 on Windows. g++ crashed and that was the reason.
