### PR TITLE
Improve Android build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,17 +37,10 @@ platform/android/java/.gradle
 platform/android/java/.gradletasknamecache
 platform/android/java/local.properties
 platform/android/java/project.properties
+platform/android/java/build.gradle
 platform/android/java/AndroidManifest.xml
-platform/android/java/bin/*
 platform/android/java/libs/*
-platform/android/java/gen/*
 platform/android/java/assets
-platform/android/libs/apk_expansion/bin/*
-platform/android/libs/apk_expansion/gen/*
-platform/android/libs/google_play_services/bin/*
-platform/android/libs/google_play_services/gen/*
-platform/android/libs/play_licensing/bin/*
-platform/android/libs/play_licensing/gen/*
 
 # General c++ generated files
 *.lib

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -103,4 +103,22 @@ pp_baseout.write( manifest )
 
 env_android.SharedLibrary("#bin/libgodot",[android_objects],SHLIBSUFFIX=env["SHLIBSUFFIX"])
 
-#env.Command('#bin/libgodot_android.so', '#platform/android/libgodot_android.so', Copy('bin/libgodot_android.so', 'platform/android/libgodot_android.so'))
+
+lib_arch_dir = ''
+if env['android_arch'] == 'armv6':
+	lib_arch_dir = 'armeabi'
+elif env['android_arch'] == 'armv7':
+	lib_arch_dir = 'armeabi-v7a'
+elif env['android_arch'] == 'x86':
+	lib_arch_dir = 'x86'
+else:
+	print 'WARN: Architecture not suitable for embedding into APK; keeping .so at \\bin'
+
+if lib_arch_dir != '':
+	if env['target'] == 'release':
+		lib_type_dir = 'release'
+	else: # release_debug, debug
+		lib_type_dir = 'debug'
+		
+	out_dir = '#platform/android/java/libs/'+lib_type_dir+'/'+lib_arch_dir
+	env_android.Command(out_dir+'/libgodot_android.so', '#bin/libgodot'+env['SHLIBSUFFIX'], Move("$TARGET", "$SOURCE"))

--- a/platform/android/build.gradle.template
+++ b/platform/android/build.gradle.template
@@ -3,7 +3,7 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:1.3.1'
+		classpath 'com.android.tools.build:gradle:2.1.0'
 	}
 }
 
@@ -40,6 +40,11 @@ android {
 		minSdkVersion 14
 		targetSdkVersion 23
 	}
+	// Both signing and zip-aligning will be done at export time
+	buildTypes.all { buildType ->
+		buildType.zipAlignEnabled false
+		buildType.signingConfig null
+	}
 	sourceSets {
 		main {
 			manifest.srcFile 'AndroidManifest.xml'
@@ -65,8 +70,17 @@ android {
 				$$GRADLE_JNI_DIRS$$
 			]
 		}
-
+		debug.jniLibs.srcDirs = [
+			'libs/debug'
+			$$GRADLE_JNI_DIRS$$
+		]
+		release.jniLibs.srcDirs = [
+			'libs/release'
+			$$GRADLE_JNI_DIRS$$
+		]
 	}
-
-
+	applicationVariants.all { variant ->
+		// ApplicationVariant is undocumented, but this method is widely used; may break with another version of the Android Gradle plugin
+		variant.outputs.get(0).setOutputFile(new File("${projectDir}/../../../bin", "android_${variant.name}.apk"))
+	}
 }

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -23,7 +23,7 @@ def get_opts():
 			('ANDROID_NDK_ROOT', 'the path to Android NDK', os.environ.get("ANDROID_NDK_ROOT", 0)),
 			('NDK_TARGET', 'toolchain to use for the NDK',os.environ.get("NDK_TARGET", "arm-linux-androideabi-4.9")),
 			('NDK_TARGET_X86', 'toolchain to use for the NDK x86',os.environ.get("NDK_TARGET_X86", "x86-4.9")),
-			('ndk_platform', 'compile for platform: (android-<api> , example: android-15)',"android-15"),
+			('ndk_platform', 'compile for platform: (android-<api> , example: android-14)',"android-14"),
 			('android_arch', 'select compiler architecture: (armv7/armv6/x86)',"armv7"),
 			('android_neon','enable neon (armv7 only)',"yes"),
 			('android_stl','enable STL support in android port (for modules)',"no")

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1166,7 +1166,7 @@ Error EditorExportPlatformAndroid::export_project(const String& p_path, bool p_d
 			skip=true;
 		}
 
-		if (file=="lib/armeabi/libgodot_android.so" && !export_arm) {
+		if (file.match("lib/armeabi*/libgodot_android.so") && !export_arm) {
 			skip=true;
 		}
 

--- a/platform/android/java/gradle/wrapper/gradle-wrapper.properties
+++ b/platform/android/java/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip


### PR DESCRIPTION
**Edit:** Keeping just the updated, consolidated text. If this PR gets merged, I can update the docs.

**Overall note: All this proposal is based on the assumption that the Android build is only used for generating the export templates as reliably as possible. Moreover, I believe that makes the Android build handier. If in some future tools-enabled Android builds were needed because of a widespread desire of using Godot under Android netbooks or so, some things would need to be changed.**
## Android/build component versions
- Upgrade Android plugin for Gradle to 2.1.0
- Downgrade NDK platform to 14 to match minSdkVersion.
## Smarter build and packaging of the Godot export template
### SCons phase

When the SCons phase of the Android build is done the generated .so file is moved to the directory relevant for the Gradle phase to pick it for the combination of arch and build type (release or debug). For instance, `platform/android/java/libs/debug/armeabi-v7a`.

Moving is performed instead of copying or symlinking to avoid polluting the `bin` directory with intermediate files, because the final binaries for Android are the APKs. The only scenario (and is a theoretical one) in which the .`so` would be kept at `bin` is that of building for an arch unknown to Android. And in that case, the SCons script would print a warning message.

Notes:
- ARMv7 both with or without NEON will be copied to the same `armeabi-v7a` dir (the newest wins).
- Both _debug_ and _debug_release_ targets will get copied to the same `debug` dir (the newest wins). Release is unambiguous.
### Gradle phase

Because of all that is done at the SCons level, Gradle will be able to generate both debug and release APKs containing libraries for x86, ARMv6 and/or ARMv7. In the case of the debug APK it can contain the handy release_debug or a full debug build if needed.

Furthermore, Gradle will generate the export template APKs with their correct naming (`android_debug.apk` and `android_release.apk`) and at the correct location at the top-level `bin` directory.

Also the Gradle script disables explicitly singing and zip-aligning of the APKs to save time since those operations must be done at export time then the final game APK is generated.
