### PR TITLE
Revert "Fix implicit GDScript Reference inheritance"

### DIFF
--- a/modules/gdscript/gd_compiler.cpp
+++ b/modules/gdscript/gd_compiler.cpp
@@ -1588,12 +1588,6 @@ Error GDCompiler::_parse_class(GDScript *p_script, GDScript *p_owner, const GDPa
 		}
 
 
-	} else {
-		// without extends, implicitly extend Reference
-		int native_idx = GDScriptLanguage::get_singleton()->get_global_map()["Reference"];
-		native = GDScriptLanguage::get_singleton()->get_global_array()[native_idx];
-		ERR_FAIL_COND_V(native.is_null(), ERR_BUG);
-		p_script->native=native;
 	}
 
 

--- a/modules/gdscript/gd_script.cpp
+++ b/modules/gdscript/gd_script.cpp
@@ -145,8 +145,11 @@ Variant GDScript::_new(const Variant** p_args,int p_argcount,Variant::CallError&
 		_baseptr=_baseptr->_base;
 	}
 
-	ERR_FAIL_COND_V(_baseptr->native.is_null(), Variant());
-	owner=_baseptr->native->instance();
+	if (_baseptr->native.ptr()) {
+		owner=_baseptr->native->instance();
+	} else {
+		owner=memnew( Reference ); //by default, no base means use reference
+	}
 
 	Reference *r=owner->cast_to<Reference>();
 	if (r) {


### PR DESCRIPTION
Reverts godotengine/godot#5054
This breaks Dog Mendonca, and any other game where the scripts don't extend anything (so it's assumed they'll extend whatever node they're assigned to it). Does it cause any actual bugs?
