### PR TITLE
Fix ui layout for EditorFontImportDialog

### DIFF
--- a/tools/editor/io_plugins/editor_font_import_plugin.cpp
+++ b/tools/editor/io_plugins/editor_font_import_plugin.cpp
@@ -622,6 +622,7 @@ public:
 		VBoxContainer *vbr = memnew( VBoxContainer );
 		hbc->add_child(vbr);
 		vbr->set_h_size_flags(SIZE_EXPAND_FILL);
+		vbr->set_custom_minimum_size(Size2(240,240));
 
 		source = memnew( EditorLineEditFileChooser );
 		source->get_file_dialog()->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
@@ -653,18 +654,18 @@ public:
 		test_string = memnew( LineEdit );
 		test_string->set_text(TTR("The quick brown fox jumps over the lazy dog."));
 		test_string->set_h_size_flags(SIZE_EXPAND_FILL);
-		test_string->set_stretch_ratio(5);
 
 		testhb->add_child(test_string);
 		test_color = memnew( ColorPickerButton );
 		test_color->set_color(get_color("font_color","Label"));
-		test_color->set_h_size_flags(SIZE_EXPAND_FILL);
-		test_color->set_stretch_ratio(1);
+		test_color->set_text("Color");
+		test_color->set_h_size_flags(SIZE_FILL);
 		test_color->connect("color_changed",this,"_update_text3");
 		testhb->add_child(test_color);
 
 		vbl->add_spacer();
-		vbl->add_margin_child(TTR("Test:")+" ",testhb);
+		vbl->add_margin_child(TTR("Test:"),testhb);
+		testhb->set_h_size_flags(SIZE_EXPAND_FILL);
 		/*
 		HBoxContainer *upd_hb = memnew( HBoxContainer );
 //		vbl->add_child(upd_hb);


### PR DESCRIPTION
Before:
![](https://cdn.rawgit.com/Geequlim/depot/master/images/godot/font_importer1.png)
After:
![](https://cdn.rawgit.com/Geequlim/depot/master/images/godot/font_importer2.png)

I have tried to limit the size of the `Test` LineEdit by `set_h_size_flags` and `set_anchor_and_margin` to it and it's parent `HBoxContainer` but didn't work. The size of the `Test` LineEdit ways changed by its content.

So I have to set the minium size of the `Options` Panel :(

The size of the dialog would be changed by the length of preview text.
