### PR TITLE
Remove found dead code

### DIFF
--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -149,12 +149,6 @@ bool Mesh::_set(const StringName& p_name, const Variant& p_value) {
 		return true;
 	}
 
-	if (what=="custom_aabb") {
-
-		surface_set_custom_aabb(idx,p_value);
-		return true;
-	}
-
 	return false;
 }
 


### PR DESCRIPTION
1) That property is called 'custom_aabb/custom_aabb'.
2) Anyway, the execution will never get to that block because at that point that function is only dealing with `surfaces*` properties.
