### PR TITLE
Add a "copy path" item to the filesystem dock context menu.

### DIFF
--- a/tools/editor/scenes_dock.cpp
+++ b/tools/editor/scenes_dock.cpp
@@ -1101,7 +1101,13 @@ void ScenesDock::_file_option(int p_option) {
 			}
 
 		} break;
+		case FILE_COPY_PATH:
 
+			int idx = files->get_current();
+			if (idx<0 || idx>=files->get_item_count())
+				break;
+			String path = files->get_item_metadata(idx);
+			OS::get_singleton()->set_clipboard(path);
 	}
 }
 
@@ -1545,6 +1551,7 @@ void ScenesDock::_files_list_rmb_select(int p_item,const Vector2& p_pos) {
 	}
 
 	if (filenames.size()==1) {
+		file_options->add_item(TTR("Copy Path"), FILE_COPY_PATH);
 		file_options->add_item(TTR("Rename or Move.."),FILE_MOVE);
 	} else {
 		file_options->add_item(TTR("Move To.."),FILE_MOVE);

--- a/tools/editor/scenes_dock.h
+++ b/tools/editor/scenes_dock.h
@@ -63,7 +63,8 @@ class ScenesDock : public VBoxContainer {
 		FILE_REMOVE,
 		FILE_REIMPORT,
 		FILE_INFO,
-		FILE_SHOW_IN_EXPLORER
+		FILE_SHOW_IN_EXPLORER,
+		FILE_COPY_PATH
 	};
 
 


### PR DESCRIPTION
Copies the path (in "res://" format) of the selected resource to the clipboard.
Useful for script preloads/extends etc.
