### PR TITLE
Improved Blender/Collada shadeless->unshaded import

### DIFF
--- a/tools/collada/collada.cpp
+++ b/tools/collada/collada.cpp
@@ -736,6 +736,9 @@ void Collada::_parse_effect_material(XMLParser& parser,Effect &effect,String &id
 				effect.found_double_sided=true;
 				effect.double_sided=parser.get_node_data().to_int();
 				COLLADA_PRINT("double sided: "+itos(parser.get_node_data().to_int()));
+			} else if (parser.get_node_name()=="unshaded") {
+				parser.read();
+				effect.unshaded=parser.get_node_data().to_int();
 			} else if (parser.get_node_name()=="bump") {
 
 				// color or texture types

--- a/tools/collada/collada.h
+++ b/tools/collada/collada.h
@@ -75,6 +75,7 @@ public:
 		float shininess;
 		bool found_double_sided;
 		bool double_sided;
+		bool unshaded;
 
 		String get_texture_path(const String& p_source,Collada& state) const;
 
@@ -83,7 +84,7 @@ public:
 			double_sided=true;
 			found_double_sided=false;
 			shininess=40;
-
+			unshaded=false;
 		}
 	};
 

--- a/tools/editor/io_plugins/editor_import_collada.cpp
+++ b/tools/editor/io_plugins/editor_import_collada.cpp
@@ -467,6 +467,7 @@ Error ColladaImport::_create_material(const String& p_target) {
 
 	material->set_parameter(FixedMaterial::PARAM_SPECULAR_EXP,effect.shininess);
 	material->set_flag(Material::FLAG_DOUBLE_SIDED,effect.double_sided);
+	material->set_flag(Material::FLAG_UNSHADED,effect.unshaded);
 
 
 

--- a/tools/export/blender25/io_scene_dae/export_dae.py
+++ b/tools/export/blender25/io_scene_dae/export_dae.py
@@ -351,6 +351,12 @@ class DaeExporter:
 		self.writel(S_FX,5,'<technique profile="GOOGLEEARTH">')
 		self.writel(S_FX,6,'<double_sided>'+["0","1"][double_sided_hint]+"</double_sided>")
 		self.writel(S_FX,5,'</technique>')
+
+		if (material.use_shadeless):
+			self.writel(S_FX,5,'<technique profile="GODOT">')
+			self.writel(S_FX,6,'<unshaded>1</unshaded>')
+			self.writel(S_FX,5,'</technique>')
+
 		self.writel(S_FX,4,'</extra>')
 
 		self.writel(S_FX,3,'</technique>')


### PR DESCRIPTION
Little improvement for importing shadeless flag from Blender.
Simple test file: 
[shadeless.zip](https://github.com/godotengine/godot/files/303457/shadeless.zip)
