### PR TITLE
Caret blink no longer updates when hidden, issue 5100

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3261,7 +3261,9 @@ void TextEdit::_reset_caret_blink_timer() {
 
 void TextEdit::_toggle_draw_caret() {
 	draw_caret = !draw_caret;
-	update();
+	if (is_visible()) {
+		update();
+	}
 }
 
 void TextEdit::_update_caches() {


### PR DESCRIPTION
Caret blink no longer updates when hidden. 

closes #5100 
