### PR TITLE
EditorAssetLibrary: Don't call add_child() on uninitialized pointer

### DIFF
--- a/tools/editor/asset_library_editor_plugin.cpp
+++ b/tools/editor/asset_library_editor_plugin.cpp
@@ -1282,8 +1282,6 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	}
 
 
-	library_vb->add_child(search_hb);
-
 	HBoxContainer *search_hb2 = memnew( HBoxContainer );
 	library_main->add_child(search_hb2);
 


### PR DESCRIPTION
Fixes possible crash and fixes crash when using undefined sanitizer.
The "search_hb" is already added into "library_main" container.
