### PR TITLE
Fixed editor help focus issues and input propagation

### DIFF
--- a/tools/editor/editor_help.cpp
+++ b/tools/editor/editor_help.cpp
@@ -649,6 +649,7 @@ void EditorHelp::_class_desc_input(const InputEvent& p_input) {
 		class_desc->set_selection_enabled(false);
 		class_desc->set_selection_enabled(true);
 	}
+	set_focused();
 }
 
 void EditorHelp::_add_type(const String& p_type) {


### PR DESCRIPTION
Fixes editor help not gaining focus / input not propagating through resulting in not being able to copy, or navigate with the arrow keys.

Should close #3826 although I cannot test as I don't own any apple products.
