### PR TITLE
fix android support screen property for large screen

### DIFF
--- a/platform/android/AndroidManifest.xml.template
+++ b/platform/android/AndroidManifest.xml.template
@@ -7,7 +7,7 @@
       >
 <supports-screens android:smallScreens="true"
                       android:normalScreens="true"
-                      android:largeScreens="false"
+                      android:largeScreens="true"
                       android:xlargeScreens="true"/>
 
     <application android:label="@string/godot_project_name_string" android:icon="@drawable/icon" android:allowBackup="false" $$ADD_APPATTRIBUTE_CHUNKS$$ >


### PR DESCRIPTION
Only `largeScreens` is set to `false`.
I guess it's by mistake.
