### PR TITLE
Edit the region of AtlasTexture by TextureRegionEditorPlugin

### DIFF
--- a/tools/editor/plugins/texture_region_editor_plugin.h
+++ b/tools/editor/plugins/texture_region_editor_plugin.h
@@ -38,6 +38,7 @@
 #include "scene/2d/sprite.h"
 #include "scene/gui/patch_9_frame.h"
 #include "scene/resources/style_box.h"
+#include "scene/resources/texture.h"
 
 class TextureRegionEditor : public HBoxContainer {
 
@@ -82,6 +83,7 @@ class TextureRegionEditor : public HBoxContainer {
 	Patch9Frame *node_patch9;
 	Sprite *node_sprite;
 	StyleBoxTexture *obj_styleBox;
+	AtlasTexture *atlas_tex;
 
 	int editing_region;
 	Rect2 rect;


### PR DESCRIPTION
The texture region can be set by the TextureRegionEditorPlugin and applied to the AtlasTexture resources.

**But the editor won't update the preview and region property before re-open the project**.

Maybe related to #4769 
