### PR TITLE
Improved Blender/Collada extra section handling, can break double sid…

### DIFF
--- a/core/array.cpp
+++ b/core/array.cpp
@@ -200,6 +200,10 @@ int Array::count(const Variant& p_value) const {
 	return amount;
 }
 
+bool Array::has(const Variant& p_value) const {
+	return _p->array.find(p_value, 0) != -1;
+}
+
 void Array::remove(int p_pos) {
 
 	_p->array.remove(p_pos);

--- a/core/array.h
+++ b/core/array.h
@@ -75,6 +75,7 @@ public:
 	int rfind(const Variant& p_value, int p_from=-1) const;
 	int find_last(const Variant& p_value) const;
 	int count(const Variant& p_value) const;
+	bool has(const Variant& p_value) const;
 
 	void erase(const Variant& p_value);
 

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -474,6 +474,7 @@ static void _call_##m_type##_##m_method(Variant& r_ret,Variant& p_self,const Var
 	VCALL_LOCALMEM2R(Array,rfind);
 	VCALL_LOCALMEM1R(Array,find_last);
 	VCALL_LOCALMEM1R(Array,count);
+	VCALL_LOCALMEM1R(Array,has);
 	VCALL_LOCALMEM1(Array,erase);
 	VCALL_LOCALMEM0(Array,sort);
 	VCALL_LOCALMEM2(Array,sort_custom);
@@ -1498,6 +1499,7 @@ _VariantCall::addfunc(Variant::m_vtype,Variant::m_ret,_SCS(#m_method),VCALL(m_cl
 	ADDFUNC2(ARRAY,INT,Array,rfind,NIL,"what",INT,"from",varray(-1));
 	ADDFUNC1(ARRAY,INT,Array,find_last,NIL,"value",varray());
 	ADDFUNC1(ARRAY,INT,Array,count,NIL,"value",varray());
+	ADDFUNC1(ARRAY,BOOL,Array,has,NIL,"value",varray());
 	ADDFUNC0(ARRAY,NIL,Array,pop_back,varray());
 	ADDFUNC0(ARRAY,NIL,Array,pop_front,varray());
 	ADDFUNC0(ARRAY,NIL,Array,sort,varray());


### PR DESCRIPTION
…ed backwards compability

I think that the <extra> element handling in Blender/Collada effect export can be created only when needed. This is when material has normal map, is unshaded or is double sided (or any combination of these).
Before <extra> element was created always. Typically it had empty FCOLLADA element and GOOGLEEARTH double_sided set to 0.
As I changed the default value for double sidedness to FALSE it can collide with other exporters which maybe assume that this feature is normally set to TRUE.
Still I think it's better assumption in game engine that material is one sided and it should be extra stated that it is double sided.
