### PR TITLE
BaseButton: Add identifier for shortcut in tooltip

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -418,8 +418,13 @@ void BaseButton::_unhandled_input(InputEvent p_event) {
 String BaseButton::get_tooltip(const Point2& p_pos) const {
 
 	String tooltip=Control::get_tooltip(p_pos);
-	if (shortcut.is_valid() && shortcut->is_valid())
-		tooltip+=" ("+shortcut->get_as_text()+")";
+	if (shortcut.is_valid() && shortcut->is_valid()) {
+		if (tooltip.find("$sc")!=-1) {
+			tooltip=tooltip.replace_first("$sc","("+shortcut->get_as_text()+")");
+		} else {
+			tooltip+=" ("+shortcut->get_as_text()+")";
+		}
+	}
 	return tooltip;
 }
 


### PR DESCRIPTION
This allows to specify a custom place where the shortcut text will be placed in the tooltip. Usage example:

``` C++

select_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/tool_select",TTR("Select Mode (Q)"),KEY_Q));
select_button->set_tooltip(TTR("Select Mode $sc")+"\n... some other text ...");
```

Results in:

```
Select Mode (Q)
... some other text ...
```

If the tooltip does not contain the text `$sc`, then the shortcut text will be added at the end of the tooltip like normal.
