### PR TITLE
Make .app bundle high resolution aware

### DIFF
--- a/tools/Godot.app/Contents/Info.plist
+++ b/tools/Godot.app/Contents/Info.plist
@@ -34,7 +34,7 @@
 		<string>10.6.0</string>
 	</dict>
 	<key>NSHighResolutionCapable</key>
-	<false/>
+	<true/>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
This commit changes the .app bundle in `tools` to allow running in high resolution (retina) mode.  Tested with the latest Master on 10.11.6.

First pull request, so I hoping I didn't mess it up :)
