### PR TITLE
ConnectionsDock: Double click to create and go to signal connection

### DIFF
--- a/tools/editor/connections_dialog.cpp
+++ b/tools/editor/connections_dialog.cpp
@@ -35,6 +35,7 @@
 #include "print_string.h"
 #include "editor_settings.h"
 #include "editor_node.h"
+#include "plugins/script_editor_plugin.h"
 
 class ConnectDialogBinds : public Object {
 
@@ -808,11 +809,58 @@ void ConnectionsDock::_something_selected() {
 
 }
 
+void ConnectionsDock::_something_activated() {
+
+	TreeItem *item = tree->get_selected();
+
+	if (!item)
+		return;
+
+	if (item->get_parent()==tree->get_root() || item->get_parent()->get_parent()==tree->get_root()) {
+		// a signal - connect
+		String signal=item->get_metadata(0).operator Dictionary()["name"];
+		String midname=node->get_name();
+		for(int i=0;i<midname.length();i++) {
+			CharType c = midname[i];
+			if  ((c>='a' && c<='z') || (c>='A' && c<='Z') || (c>='0' && c<='9') || c=='_') {
+				//all good
+			} else if (c==' ') {
+				c='_';
+			} else {
+				midname.remove(i);
+				i--;
+				continue;
+			}
+
+			midname[i]=c;
+		}
+
+		connect_dialog->edit(node);
+		connect_dialog->popup_centered_ratio();
+		connect_dialog->set_dst_method("_on_"+midname+"_"+signal);
+		connect_dialog->set_dst_node(node->get_owner()?node->get_owner():node);
+	} else {
+		// a slot - go to target method
+		Connection c=item->get_metadata(0);
+		ERR_FAIL_COND(c.source!=node); //shouldn't happen but...bugcheck
+
+		if (!c.target)
+			return;
+
+		Ref<Script> script = c.target->get_script();
+
+		if (script.is_valid() && ScriptEditor::get_singleton()->script_go_to_method(script,c.method)) {
+			editor->call("_editor_select",EditorNode::EDITOR_SCRIPT);
+		}
+	}
+}
+
 void ConnectionsDock::_bind_methods() {
 
 
 	ObjectTypeDB::bind_method("_connect",&ConnectionsDock::_connect);
 	ObjectTypeDB::bind_method("_something_selected",&ConnectionsDock::_something_selected);
+	ObjectTypeDB::bind_method("_something_activated",&ConnectionsDock::_something_activated);
 	ObjectTypeDB::bind_method("_close",&ConnectionsDock::_close);
 	ObjectTypeDB::bind_method("_connect_pressed",&ConnectionsDock::_connect_pressed);
 	ObjectTypeDB::bind_method("update_tree",&ConnectionsDock::update_tree);
@@ -865,6 +913,7 @@ ConnectionsDock::ConnectionsDock(EditorNode *p_editor) {
 	remove_confirm->connect("confirmed", this,"_remove_confirm");
 	connect_dialog->connect("connected", this,"_connect");
 	tree->connect("item_selected", this,"_something_selected");
+	tree->connect("item_activated", this,"_something_activated");
 
 	add_constant_override("separation",3*EDSCALE);
 }

--- a/tools/editor/connections_dialog.h
+++ b/tools/editor/connections_dialog.h
@@ -111,6 +111,7 @@ class ConnectionsDock : public VBoxContainer {
 	void _close();
 	void _connect();
 	void _something_selected();
+	void _something_activated();
 	UndoRedo *undo_redo;
 
 protected:

--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -2495,6 +2495,51 @@ void ScriptEditor::set_scene_root_script( Ref<Script> p_script ) {
 	}
 }
 
+bool ScriptEditor::script_go_to_method(Ref<Script> p_script, const String& p_method) {
+
+	Vector<String> functions;
+	bool found=false;
+
+	for (int i=0;i<tab_container->get_child_count();i++) {
+		ScriptTextEditor *current = tab_container->get_child(i)->cast_to<ScriptTextEditor>();
+
+		if (current && current->get_edited_script()==p_script) {
+			functions=current->get_functions();
+			found=true;
+			break;
+		}
+	}
+
+	if (!found) {
+		String errortxt;
+		int line=-1,col;
+		String text=p_script->get_source_code();
+		List<String> fnc;
+
+		if (p_script->get_language()->validate(text,line,col,errortxt,p_script->get_path(),&fnc)) {
+
+			for (List<String>::Element *E=fnc.front();E;E=E->next())
+				functions.push_back(E->get());
+		}
+	}
+
+	String method_search = p_method + ":";
+
+	for (int i=0;i<functions.size();i++) {
+		String function=functions[i];
+
+		if (function.begins_with(method_search)) {
+
+			edit(p_script);
+			int line=function.get_slice(":",1).to_int();
+			_goto_script_line2(line-1);
+			return true;
+		}
+	}
+
+	return false;
+}
+
 void ScriptEditor::set_live_auto_reload_running_scripts(bool p_enabled) {
 
 	auto_reload_running_scripts=p_enabled;

--- a/tools/editor/plugins/script_editor_plugin.h
+++ b/tools/editor/plugins/script_editor_plugin.h
@@ -325,6 +325,8 @@ public:
 
 	void set_scene_root_script( Ref<Script> p_script );
 
+	bool script_go_to_method(Ref<Script> p_script, const String& p_method);
+
 	virtual void edited_scene_changed();
 
 	ScriptEditorDebugger *get_debugger() { return debugger; }


### PR DESCRIPTION
Partially deals with #5116 (this PR does not add connection edit on double click)

I didn't find a better way to go to the method, I hope it's not too much of a hack :/
