### PR TITLE
Fixed overloaded virtual functions with const vs none warning

### DIFF
--- a/scene/3d/vehicle_body.cpp
+++ b/scene/3d/vehicle_body.cpp
@@ -990,7 +990,7 @@ float VehicleBody::get_steering() const{
 	return m_steeringValue;
 }
 
-Vector3 VehicleBody::get_linear_velocity()
+Vector3 VehicleBody::get_linear_velocity() const
 {
 	return linear_velocity;
 }

--- a/scene/3d/vehicle_body.h
+++ b/scene/3d/vehicle_body.h
@@ -178,7 +178,7 @@ public:
 	void set_steering(float p_steering);
 	float get_steering() const;
 
-	Vector3 get_linear_velocity();
+	Vector3 get_linear_velocity() const;
 
 	VehicleBody();
 };

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -351,7 +351,7 @@ void SplitContainer::_input_event(const InputEvent& p_event) {
 
 }
 
-Control::CursorShape SplitContainer::get_cursor_shape(const Point2& p_pos) {
+Control::CursorShape SplitContainer::get_cursor_shape(const Point2& p_pos) const {
 
 	if (collapsed)
 		return Control::get_cursor_shape(p_pos);

--- a/scene/gui/split_container.h
+++ b/scene/gui/split_container.h
@@ -75,7 +75,7 @@ public:
 	void set_dragger_visibility(DraggerVisibility p_visibility);
 	DraggerVisibility get_dragger_visibility() const;
 
-	virtual CursorShape get_cursor_shape(const Point2& p_pos=Point2i());
+	virtual CursorShape get_cursor_shape(const Point2& p_pos=Point2i()) const;
 
 	virtual Size2 get_minimum_size() const;
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2892,7 +2892,7 @@ int TextEdit::get_char_count() {
 	return totalsize; // omit last \n
 }
 
-Size2 TextEdit::get_minimum_size() {
+Size2 TextEdit::get_minimum_size() const {
 
 	return cache.style_normal->get_minimum_size();
 }

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -278,7 +278,7 @@ class TextEdit : public Control  {
 	void _scroll_lines_down();
 
 //	void mouse_motion(const Point& p_pos, const Point& p_rel, int p_button_mask);
-	Size2 get_minimum_size();
+	Size2 get_minimum_size() const;
 
 	int get_row_height() const;
 

--- a/scene/resources/room.cpp
+++ b/scene/resources/room.cpp
@@ -31,7 +31,7 @@
 #include "servers/visual_server.h"
 
 
-RID RoomBounds::get_rid() {
+RID RoomBounds::get_rid() const {
 
 	return area;
 }

--- a/scene/resources/room.h
+++ b/scene/resources/room.h
@@ -50,7 +50,7 @@ protected:
 
 public:
 
-	virtual RID get_rid();
+	virtual RID get_rid() const;
 
 	void set_bounds( const BSP_Tree& p_bounds );
 	BSP_Tree get_bounds() const;


### PR DESCRIPTION
This is a simple PR, it just fixes functions that miss the const declaration.
