### PR TITLE
Keep subclass alive when inheriting, fix #5170

### DIFF
--- a/modules/gdscript/gd_compiler.cpp
+++ b/modules/gdscript/gd_compiler.cpp
@@ -1497,7 +1497,8 @@ Error GDCompiler::_parse_class(GDScript *p_script, GDScript *p_owner, const GDPa
 					String sub = p_class->extends_class[i];
 					if (script->subclasses.has(sub)) {
 
-						script=script->subclasses[sub];
+						Ref<Script> subclass=script->subclasses[sub];
+						script=subclass;
 					} else {
 
 						_set_error("Could not find subclass: "+sub,p_class);


### PR DESCRIPTION
assigning to `script` unreferences itself before the subclass is assigned, so a null pointer is assigned

@reduz should `Ref` be changed to unreference after assignment, or do we fix it like this?
