### PR TITLE
Various optimizations to compiler flags on X11

### DIFF
--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -136,6 +136,9 @@ def configure(env):
 
 		env.Prepend(CCFLAGS=['-g2', '-Wall','-DDEBUG_ENABLED','-DDEBUG_MEMORY_ENABLED'])
 
+	env.Prepend(CCFLAGS=['-pipe'])
+	env.Prepend(LINKFLAGS=['-pipe'])
+
 	env.ParseConfig('pkg-config x11 --cflags --libs')
 	env.ParseConfig('pkg-config xinerama --cflags --libs')
 	env.ParseConfig('pkg-config xcursor --cflags --libs')

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -118,11 +118,15 @@ def configure(env):
 	#	env['OBJSUFFIX'] = ".nt"+env['OBJSUFFIX']
 	#	env['LIBSUFFIX'] = ".nt"+env['LIBSUFFIX']
 
-
+	supports_Og = (
+		os.system('{} --help=optimizers 2>&1 | grep -- -Og'.format(env['CXX'])) == 0
+	)
 	if (env["target"]=="release"):
 
 		if (env["debug_release"]=="yes"):
 			env.Prepend(CCFLAGS=['-g2'])
+			if supports_Og:
+				env.Prepend(CCFLAGS=['-Og'])
 		else:
 			env.Prepend(CCFLAGS=['-O3','-ffast-math'])
 
@@ -131,10 +135,14 @@ def configure(env):
 		env.Prepend(CCFLAGS=['-O2','-ffast-math','-DDEBUG_ENABLED'])
 		if (env["debug_release"]=="yes"):
 			env.Prepend(CCFLAGS=['-g2'])
+			if supports_Og:
+				env.Prepend(CCFLAGS=['-Og'])
 
 	elif (env["target"]=="debug"):
 
 		env.Prepend(CCFLAGS=['-g2', '-Wall','-DDEBUG_ENABLED','-DDEBUG_MEMORY_ENABLED'])
+		if supports_Og:
+			env.Prepend(CCFLAGS=['-Og'])
 
 	env.Prepend(CCFLAGS=['-pipe'])
 	env.Prepend(LINKFLAGS=['-pipe'])

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -122,19 +122,19 @@ def configure(env):
 	if (env["target"]=="release"):
 
 		if (env["debug_release"]=="yes"):
-			env.Append(CCFLAGS=['-g2'])
+			env.Prepend(CCFLAGS=['-g2'])
 		else:
-			env.Append(CCFLAGS=['-O3','-ffast-math'])
+			env.Prepend(CCFLAGS=['-O3','-ffast-math'])
 
 	elif (env["target"]=="release_debug"):
 
-		env.Append(CCFLAGS=['-O2','-ffast-math','-DDEBUG_ENABLED'])
+		env.Prepend(CCFLAGS=['-O2','-ffast-math','-DDEBUG_ENABLED'])
 		if (env["debug_release"]=="yes"):
-			env.Append(CCFLAGS=['-g2'])
+			env.Prepend(CCFLAGS=['-g2'])
 
 	elif (env["target"]=="debug"):
 
-		env.Append(CCFLAGS=['-g2', '-Wall','-DDEBUG_ENABLED','-DDEBUG_MEMORY_ENABLED'])
+		env.Prepend(CCFLAGS=['-g2', '-Wall','-DDEBUG_ENABLED','-DDEBUG_MEMORY_ENABLED'])
 
 	env.ParseConfig('pkg-config x11 --cflags --libs')
 	env.ParseConfig('pkg-config xinerama --cflags --libs')


### PR DESCRIPTION
Various optimizations to the compiler flags on X11, ordered from least to most intrusive.
#### Prepend -O options instead of appending

This way, they can be overwritten by passing different CFLAGS/CCFLAGS to scons.
The last option takes effect, therefore we need to prepend them to the
user supplied flags.
#### pass "-pipe" to compiler and linker

GCC will use pipes instead of temporary files with this option,
which decreases compile time noticably.

clang's gcc compability layer also accepts the option, so we don't
have to check for it.
#### Use '-Og' for debugging if available.

Since 4.8 GCC supports the -Og optimization option. According to the
documentation:

> -Og enables optimizations that do not interfere with debugging.
> It should be the optimization level of choice for the standard
> edit-compile-debug cycle, offering a reasonable level of optimization
> while maintaining fast compilation and a good debugging experience.

clang doesn't support it, and people might use a pre 4.8 compiler, so
we check if the flag is supported and only use it if it is.
