### PR TITLE
Expose missing Quaternion operators.

### DIFF
--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -477,7 +477,7 @@ void Variant::evaluate(const Operator& p_op, const Variant& p_a, const Variant& 
 					DEFAULT_OP_FAIL(MATRIX32);
 					DEFAULT_OP_LOCALMEM(+,VECTOR3,Vector3);
 					DEFAULT_OP_FAIL(PLANE);
-					DEFAULT_OP_FAIL(QUAT);
+					DEFAULT_OP_LOCALMEM(+, QUAT, Quat);
 					DEFAULT_OP_FAIL(_AABB);
 					DEFAULT_OP_FAIL(MATRIX3);
 					DEFAULT_OP_FAIL(TRANSFORM);
@@ -535,7 +535,7 @@ void Variant::evaluate(const Operator& p_op, const Variant& p_a, const Variant& 
 				DEFAULT_OP_FAIL(MATRIX32);
 				DEFAULT_OP_LOCALMEM(-,VECTOR3,Vector3);
 				DEFAULT_OP_FAIL(PLANE);
-				DEFAULT_OP_FAIL(QUAT);
+				DEFAULT_OP_LOCALMEM(-, QUAT, Quat);
 				DEFAULT_OP_FAIL(_AABB);
 				DEFAULT_OP_FAIL(MATRIX3);
 				DEFAULT_OP_FAIL(TRANSFORM);
@@ -596,6 +596,9 @@ void Variant::evaluate(const Operator& p_op, const Variant& p_a, const Variant& 
 						case QUAT: {
 
 							_RETURN( *reinterpret_cast<const Quat*>(p_a._data._mem) * *reinterpret_cast<const Quat*>(p_b._data._mem) );
+						} break;
+						case REAL: {
+							_RETURN( *reinterpret_cast<const Quat*>(p_a._data._mem) * p_b._data._real);
 						} break;
 					};
 					r_valid=false;
@@ -699,7 +702,13 @@ void Variant::evaluate(const Operator& p_op, const Variant& p_a, const Variant& 
 				DEFAULT_OP_FAIL(MATRIX32);
 				DEFAULT_OP_LOCALMEM_NUM(/,VECTOR3,Vector3);
 				DEFAULT_OP_FAIL(PLANE);
-				DEFAULT_OP_FAIL(QUAT);
+				case QUAT: {
+					if (p_b.type != REAL) {
+						r_valid = false;
+						return;
+					}
+					_RETURN( *reinterpret_cast<const Quat*>(p_a._data._mem) / p_b._data._real);
+				} break;
 				DEFAULT_OP_FAIL(_AABB);
 				DEFAULT_OP_FAIL(MATRIX3);
 				DEFAULT_OP_FAIL(TRANSFORM);


### PR DESCRIPTION
Scripts can now evaluate the following cases:
- (quat \* real) and (quat / real)
- (quat + quat) and (quat - quat)
