### PR TITLE
Polygon2D now honors canvas opacity.

### DIFF
--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -8527,7 +8527,7 @@ void RasterizerGLES2::canvas_draw_polygon(int p_vertex_count, const int* p_indic
     Color m;
     if (p_singlecolor) {
         m = *p_colors;
-        m.a*=canvas_opacity;
+        m.a *= canvas_opacity;
         _set_color_attrib(m);
     } else if (!p_colors) {
         m = Color(1, 1, 1, canvas_opacity);

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -146,15 +146,17 @@ void Polygon2D::_notification(int p_what) {
 
 			Vector<Color> colors;
 			int color_len=vertex_colors.size();
-			colors.resize(len);
-			{
+			if (color_len>0){
 				DVector<Color>::Read color_r=vertex_colors.read();
+				colors.resize(len);
 				for(int i=0;i<color_len && i<len;i++){
 					colors[i]=color_r[i];
 				}
 				for(int i=color_len;i<len;i++){
 					colors[i]=color;
 				}
+			}else{
+				colors.push_back(color);
 			}
 
 			Vector<int> indices = Geometry::triangulate_polygon(points);


### PR DESCRIPTION
Previously, multi-colored polygons ignored canvas opacity, and the last patch made every polygon a multi-colored one.
