### PR TITLE
String documentation: .ord_at() returns int not String

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1290,7 +1290,7 @@ _VariantCall::addfunc(Variant::m_vtype,Variant::m_ret,_SCS(#m_method),VCALL(m_cl
 	ADDFUNC0(STRING,STRING,String,extension,varray());
 	ADDFUNC0(STRING,STRING,String,basename,varray());
 	ADDFUNC1(STRING,STRING,String,plus_file,STRING,"file",varray());
-	ADDFUNC1(STRING,STRING,String,ord_at,INT,"at",varray());
+	ADDFUNC1(STRING,INT,String,ord_at,INT,"at",varray());
 	ADDFUNC2(STRING,NIL,String,erase,INT,"pos",INT,"chars", varray());
 	ADDFUNC0(STRING,INT,String,hash,varray());
 	ADDFUNC0(STRING,STRING,String,md5_text,varray());

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -37385,7 +37385,7 @@ This method controls whether the position between two cached points is interpola
 			</description>
 		</method>
 		<method name="ord_at">
-			<return type="String">
+			<return type="int">
 			</return>
 			<argument index="0" name="at" type="int">
 			</argument>


### PR DESCRIPTION
fixes #5189
