### PR TITLE
Fix Theora video playback without a Vorbis stream

### DIFF
--- a/drivers/theora/video_stream_theora.cpp
+++ b/drivers/theora/video_stream_theora.cpp
@@ -513,7 +513,7 @@ void VideoStreamPlaybackTheora::update(float p_delta) {
 	}
 
 	bool frame_done=false;
-	bool audio_done=false;
+	bool audio_done=!vorbis_p;
 
 	bool theora_done=false;
 

--- a/scene/gui/video_player.cpp
+++ b/scene/gui/video_player.cpp
@@ -208,10 +208,17 @@ void VideoPlayer::set_stream(const Ref<VideoStream> &p_stream) {
 		playback->set_paused(paused);
 		texture=playback->get_texture();
 
+		const int channels = playback->get_channels();
+
 		AudioServer::get_singleton()->lock();
-		resampler.setup(playback->get_channels(),playback->get_mix_rate(),server_mix_rate,buffering_ms,0);
+		if (channels > 0)
+			resampler.setup(channels,playback->get_mix_rate(),server_mix_rate,buffering_ms,0);
+		else
+			resampler.clear();
 		AudioServer::get_singleton()->unlock();
-		playback->set_mix_callback(_audio_mix_callback,this);
+
+		if (channels > 0)
+			playback->set_mix_callback(_audio_mix_callback,this);
 
 	} else {
 		texture.unref();


### PR DESCRIPTION
- prevent audio resampler errors when number of channels is 0,
- don't check for `audio_done` when there is no audio data.

Fixes #5133 and #4878
Please test :)
