### PR TITLE
Enables parent-children relationship line drawing in scene tree editor

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -811,6 +811,8 @@ void Tree::update_cache() {
 	cache.item_margin=get_constant("item_margin");
 	cache.button_margin=get_constant("button_margin");
 	cache.guide_width=get_constant("guide_width");
+	cache.draw_relationship_lines=get_constant("draw_relationship_lines");
+	cache.relationship_line_color=get_color("relationship_line_color");
 
 	cache.title_button = get_stylebox("title_button_normal");
 	cache.title_button_pressed = get_stylebox("title_button_pressed");
@@ -1295,9 +1297,21 @@ int Tree::draw_item(const Point2i& p_pos,const Point2& p_draw_ofs, const Size2& 
 
 		while (c) {
 
+			if (cache.draw_relationship_lines == 1){
+				int root_ofs = children_pos.x + (hide_folding?cache.hseparation:cache.item_margin);
+				int parent_ofs = p_pos.x + (hide_folding?cache.hseparation:cache.item_margin);
+				Point2i root_pos = Point2i(root_ofs, children_pos.y + label_h/2)-cache.offset+p_draw_ofs;
+				if (c->get_children() > 0)
+					root_pos -= Point2i(cache.arrow->get_width(),0);
+
+				Point2i parent_pos = Point2i(parent_ofs - cache.arrow->get_width()/2, p_pos.y + label_h/2 + cache.arrow->get_height()/2)-cache.offset+p_draw_ofs;
+				VisualServer::get_singleton()->canvas_item_add_line(ci, root_pos, Point2i(parent_pos.x, root_pos.y), cache.relationship_line_color);
+				VisualServer::get_singleton()->canvas_item_add_line(ci, Point2i(parent_pos.x, root_pos.y), parent_pos, cache.relationship_line_color);
+			}
+
 			int child_h=draw_item(children_pos, p_draw_ofs, p_draw_size, c );
 
-			if (child_h<0)
+			if (child_h<0 && cache.draw_relationship_lines == 0)
 				return -1; // break, stop drawing, no need to anymore
 
 			htotal+=child_h;
@@ -3674,4 +3688,3 @@ Tree::~Tree() {
 	}
 
 }
-

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -377,6 +377,7 @@ friend class TreeItem;
 		Color font_color_selected;
 		Color guide_color;
 		Color drop_position_color;
+		Color relationship_line_color;
 
 		int hseparation;
 		int vseparation;
@@ -384,6 +385,7 @@ friend class TreeItem;
 		int guide_width;
 		int button_margin;
 		Point2 offset;
+		int draw_relationship_lines;
 
 		enum ClickType {
 			CLICK_NONE,
@@ -532,4 +534,3 @@ public:
 
 VARIANT_ENUM_CAST( Tree::SelectMode );
 #endif
-

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -661,12 +661,14 @@ void fill_default_theme(Ref<Theme>& t,const Ref<Font> & default_font,const Ref<F
 	t->set_color("cursor_color","Tree", Color(0,0,0) );
 	t->set_color("guide_color","Tree", Color(0,0,0,0.1) );
 	t->set_color("drop_position_color","Tree", Color(1,0.3,0.2) );
+	t->set_color("relationship_line_color", "Tree", Color::html("464646") );
 
 	t->set_constant("hseparation","Tree",4 *scale);
 	t->set_constant("vseparation","Tree",4 *scale);
 	t->set_constant("guide_width","Tree",2 *scale);
 	t->set_constant("item_margin","Tree",12 *scale);
 	t->set_constant("button_margin","Tree",4 *scale);
+	t->set_constant("draw_relationship_lines", "Tree", 0);
 
 
 	// ItemList
@@ -950,6 +952,3 @@ void clear_default_theme() {
 	Theme::set_default_font( Ref< Font >() );
 
 }
-
-
-

--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -381,7 +381,7 @@ void EditorSettings::create() {
 	singleton->save_changed_setting=true;
 	singleton->config_file_path=config_file_path;
 	singleton->settings_path=config_path+"/"+config_dir;
-	singleton->_load_defaults(extra_config);	
+	singleton->_load_defaults(extra_config);
 	singleton->setup_language();
 	singleton->setup_network();
 	singleton->list_text_editor_themes();
@@ -563,6 +563,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["scenetree_editor/duplicate_node_name_num_separator"]=PropertyInfo(Variant::INT,"scenetree_editor/duplicate_node_name_num_separator",PROPERTY_HINT_ENUM, "None,Space,Underscore,Dash");
 	//set("scenetree_editor/display_old_action_buttons",false);
 	set("scenetree_editor/start_create_dialog_fully_expanded",false);
+	set("scenetree_editor/draw_relationship_lines",false);
+	set("scenetree_editor/relationship_line_color",Color::html("464646"));
 
 	set("gridmap_editor/pick_distance", 5000.0);
 

--- a/tools/editor/scene_tree_editor.cpp
+++ b/tools/editor/scene_tree_editor.cpp
@@ -653,6 +653,8 @@ void SceneTreeEditor::_notification(int p_what) {
 		inheritance_menu->set_item_icon(2,get_icon("Load","EditorIcons"));
 		clear_inherit_confirm->connect("confirmed",this,"_subscene_option",varray(SCENE_MENU_CLEAR_INHERITANCE_CONFIRM));
 
+		EditorSettings::get_singleton()->connect("settings_changed",this,"_editor_settings_changed");
+
 
 //		get_scene()->connect("tree_changed",this,"_tree_changed",Vector<Variant>(),CONNECT_DEFERRED);
 //		get_scene()->connect("node_removed",this,"_node_removed",Vector<Variant>(),CONNECT_DEFERRED);
@@ -665,6 +667,7 @@ void SceneTreeEditor::_notification(int p_what) {
 		tree->disconnect("item_collapsed",this,"_cell_collapsed");
 		clear_inherit_confirm->disconnect("confirmed",this,"_subscene_option");
 		get_tree()->disconnect("node_configuration_warning_changed",this,"_warning_changed");
+		EditorSettings::get_singleton()->disconnect("settings_changed",this,"_editor_settings_changed");
 	}
 
 }
@@ -1048,6 +1051,21 @@ void SceneTreeEditor::_warning_changed(Node* p_for_node) {
 
 }
 
+
+void SceneTreeEditor::_editor_settings_changed() {
+	bool enable_rl = EditorSettings::get_singleton()->get("scenetree_editor/draw_relationship_lines");
+	Color rl_color = EditorSettings::get_singleton()->get("scenetree_editor/relationship_line_color");
+
+	if (enable_rl) {
+		tree->add_constant_override("draw_relationship_lines",1);
+		tree->add_color_override("relationship_line_color", rl_color);
+	}
+	else
+		tree->add_constant_override("draw_relationship_lines",0);
+
+}
+
+
 void SceneTreeEditor::_bind_methods() {
 
 	ObjectTypeDB::bind_method("_tree_changed",&SceneTreeEditor::_tree_changed);
@@ -1067,6 +1085,8 @@ void SceneTreeEditor::_bind_methods() {
 
 	ObjectTypeDB::bind_method("_node_script_changed",&SceneTreeEditor::_node_script_changed);
 	ObjectTypeDB::bind_method("_node_visibility_changed",&SceneTreeEditor::_node_visibility_changed);
+
+	ObjectTypeDB::bind_method("_editor_settings_changed", &SceneTreeEditor::_editor_settings_changed);
 
 	ObjectTypeDB::bind_method(_MD("get_drag_data_fw"), &SceneTreeEditor::get_drag_data_fw);
 	ObjectTypeDB::bind_method(_MD("can_drop_data_fw"), &SceneTreeEditor::can_drop_data_fw);
@@ -1252,4 +1272,3 @@ SceneTreeDialog::SceneTreeDialog() {
 SceneTreeDialog::~SceneTreeDialog()
 {
 }
-

--- a/tools/editor/scene_tree_editor.h
+++ b/tools/editor/scene_tree_editor.h
@@ -34,6 +34,7 @@
 #include "scene/gui/dialogs.h"
 #include "undo_redo.h"
 #include "editor_data.h"
+#include "editor_settings.h"
 /**
 	@author Juan Linietsky <reduzio@gmail.com>
 */
@@ -131,6 +132,8 @@ class SceneTreeEditor : public Control {
 	void _rmb_select(const Vector2& p_pos);
 
 	void _warning_changed(Node* p_for_node);
+
+	void _editor_settings_changed();
 
 	Timer* update_timer;
 


### PR DESCRIPTION
Helps to distinguish better which children nodes belong to which parent.
Can be turned on/off in editor settings + line color change available as
well
