### PR TITLE
Fixed error: set_current_tab print on project open

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -412,8 +412,9 @@ void TabContainer::_notification(int p_what) {
 
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
-
-			call_deferred("set_current_tab",get_current_tab()); //wait until all changed theme
+			if (get_tab_count() > 0) {
+				call_deferred("set_current_tab",get_current_tab()); //wait until all changed theme
+			}
 		} break;
 	}
 }


### PR DESCRIPTION
Fixes the console printing `set_current_tab: Index p_current out of size (get_tab_count())`

From #4997 which seems to have come back.
