### PR TITLE
fix errors while exporting android

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -794,40 +794,6 @@ void EditorExportPlatformAndroid::_fix_manifest(Vector<uint8_t>& p_manifest,bool
 						}*/
 					}
 
-					if (tname=="application" && /*nspace=="android" &&*/ attrname=="label") {
-
-						print_line("FOUND application");
-						if (attr_value==0xFFFFFFFF) {
-							WARN_PRINT("Application name in a resource, should be plaintext (but you can ignore this).")
-						} else {
-
-							String aname = get_project_name();
-							string_table[attr_value]=aname;
-						}
-					}
-					if (tname=="activity" && /*nspace=="android" &&*/ attrname=="label") {
-
-						print_line("FOUND activity name");
-						if (attr_value==0xFFFFFFFF) {
-							WARN_PRINT("Activity name in a resource, should be plaintext (but you can ignore this)")
-						} else {
-							String aname;
-							if (this->name!="") {
-								aname=this->name;
-							} else {
-								aname = Globals::get_singleton()->get("application/name");
-
-							}
-
-							if (aname=="") {
-								aname=_MKSTR(VERSION_NAME);
-							}
-
-							print_line("APP NAME IS..."+aname);
-							string_table[attr_value]=aname;
-						}
-					}
-
 					if (tname=="uses-permission" && /*nspace=="android" &&*/ attrname=="name") {
 
 						if (value.begins_with("godot.custom")) {
@@ -852,13 +818,11 @@ void EditorExportPlatformAndroid::_fix_manifest(Vector<uint8_t>& p_manifest,bool
 
 					if (tname=="supports-screens" ) {
 
-						if (attr_value==0xFFFFFFFF) {
-							WARN_PRINT("Screen res name in a resource, should be plaintext")
-						} else if (attrname=="smallScreens") {
+						if (attrname=="smallScreens") {
 
 							encode_uint32(screen_support[SCREEN_SMALL]?0xFFFFFFFF:0,&p_manifest[iofs+16]);
 
-						} else if (attrname=="mediumScreens") {
+						} else if (attrname=="normalScreens") {
 
 							encode_uint32(screen_support[SCREEN_NORMAL]?0xFFFFFFFF:0,&p_manifest[iofs+16]);
 


### PR DESCRIPTION
application label and activity label comes from values/string.xml and resources.arsc in exported APK.
it's resource not a string.

```
<resources>
    <string name="godot_project_name_string">godot-project-name</string>
    ....
</resources>
```

so below error occurrs when export to android.

```
Application name in a resource, should be plaintext (but you can ignore this).
Activity name in a resource, should be plaintext (but you can ignore this)
```

it actually does nothing with current code.

and regarding this information with `aapt`

```
Android manifest:
N: android=http://schemas.android.com/apk/res/android
  E: manifest (line=2)
    A: android:versionCode(0x0101021b)=(type 0x10)0x1
    A: android:versionName(0x0101021c)="1.0" (Raw: "1.0")
    A: android:installLocation(0x010102b7)=(type 0x10)0x0
    A: package="com.godot.game" (Raw: "com.godot.game")
    A: platformBuildVersionCode=(type 0x10)0x17 (Raw: "23")
    A: platformBuildVersionName="6.0-2704002" (Raw: "6.0-2704002")
    E: uses-sdk (line=8)
      A: android:minSdkVersion(0x0101020c)=(type 0x10)0xe
      A: android:targetSdkVersion(0x01010270)=(type 0x10)0x17
    E: supports-screens (line=12)
      A: android:smallScreens(0x01010284)=(type 0x12)0xffffffff
      A: android:normalScreens(0x01010285)=(type 0x12)0xffffffff
      A: android:largeScreens(0x01010286)=(type 0x12)0xffffffff
      A: android:xlargeScreens(0x010102bf)=(type 0x12)0xffffffff
    E: uses-feature (line=18)
      A: android:glEsVersion(0x01010281)=(type 0x11)0x20000
```

support-screens attribute values are also not string.
so removed checking if it's string.
now exports to android without error and works properly for screen attributes.

tested with each screen option on / off.
and tested about application name with nexus 9, nexus 6p, note 2 devices.

fixes #4144.

this PR supersedes #5135, but #5135 can be merged for clean code. (only largeScreens is false).
it's up to dev team. :)
