### PR TITLE
Clean up editor theme creation

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -29,8 +29,7 @@
 #include "version.h"
 #include "editor_node.h"
 #include "print_string.h"
-#include "editor_icons.h"
-#include "editor_fonts.h"
+#include "editor_themes.h"
 
 #include "editor_help.h"
 #include "core/io/resource_saver.h"
@@ -5328,44 +5327,9 @@ EditorNode::EditorNode() {
 	theme_base->add_child(gui_base);
 	gui_base->set_area_as_parent_rect();
 
-
-	theme = Ref<Theme>( memnew( Theme ) );
-	theme_base->set_theme( theme );
-	editor_register_icons(theme);
-	editor_register_fonts(theme);
-
-	//theme->set_icon("folder","EditorFileDialog",Theme::get_default()->get_icon("folder","EditorFileDialog"));
-	//theme->set_color("files_disabled","EditorFileDialog",Color(0,0,0,0.7));
-
-	String global_font = EditorSettings::get_singleton()->get("global/custom_font");
-	if (global_font!="") {
-		Ref<Font> fnt = ResourceLoader::load(global_font);
-		if (fnt.is_valid()) {
-			theme->set_default_theme_font(fnt);
-		}
-	}
-
-
-
-	Ref<StyleBoxTexture> focus_sbt=memnew( StyleBoxTexture );
-	focus_sbt->set_texture(theme->get_icon("EditorFocus","EditorIcons"));
-	for(int i=0;i<4;i++) {
-		focus_sbt->set_margin_size(Margin(i),16);
-		focus_sbt->set_default_margin(Margin(i),16);
-	}
-	focus_sbt->set_draw_center(false);
-	theme->set_stylebox("EditorFocus","EditorStyles",focus_sbt);
-
-
-	String custom_theme = EditorSettings::get_singleton()->get("global/custom_theme");
-	if (custom_theme!="") {
-		Ref<Theme> theme = ResourceLoader::load(custom_theme);
-		if (theme.is_valid()) {
-			gui_base->set_theme(theme);
-		}
-	}
-
-
+	theme_base->set_theme( create_default_theme() );
+	theme = create_editor_theme();
+	gui_base->set_theme(theme);
 
 	resource_preview = memnew( EditorResourcePreview );
 	add_child(resource_preview);

--- a/tools/editor/editor_themes.cpp
+++ b/tools/editor/editor_themes.cpp
@@ -1,0 +1,77 @@
+/*************************************************************************/
+/*  editor_themes.cpp                                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2016 Juan Linietsky, Ariel Manzur.                 */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "editor_themes.h"
+#include "editor_icons.h"
+#include "editor_fonts.h"
+#include "editor_settings.h"
+#include "core/io/resource_loader.h"
+
+Ref<Theme> create_default_theme()
+{
+	Ref<Theme> theme = Ref<Theme>( memnew( Theme ) );
+
+	editor_register_fonts(theme);
+	editor_register_icons(theme);
+
+	Ref<StyleBoxTexture> focus_sbt=memnew( StyleBoxTexture );
+	focus_sbt->set_texture(theme->get_icon("EditorFocus","EditorIcons"));
+	for(int i=0;i<4;i++) {
+		focus_sbt->set_margin_size(Margin(i),16);
+		focus_sbt->set_default_margin(Margin(i),16);
+	}
+	focus_sbt->set_draw_center(false);
+	theme->set_stylebox("EditorFocus","EditorStyles",focus_sbt);
+
+	return theme;
+}
+
+Ref<Theme> create_editor_theme()
+{
+	Ref<Theme> theme = NULL;
+
+	String custom_theme = EditorSettings::get_singleton()->get("global/custom_theme");
+	if (custom_theme!="") {
+		theme = ResourceLoader::load(custom_theme);
+	}
+
+	if (theme.is_null() || !theme.is_valid()) {
+		theme = create_default_theme();
+	}
+
+	String global_font = EditorSettings::get_singleton()->get("global/custom_font");
+	if (global_font!="") {
+		Ref<Font> fnt = ResourceLoader::load(global_font);
+		if (fnt.is_valid()) {
+			theme->set_default_theme_font(fnt);
+		}
+	}
+
+	return theme;
+}

--- a/tools/editor/editor_themes.h
+++ b/tools/editor/editor_themes.h
@@ -1,0 +1,38 @@
+/*************************************************************************/
+/*  editor_themes.h                                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2016 Juan Linietsky, Ariel Manzur.                 */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#ifndef EDITOR_THEMES_H
+#define EDITOR_THEMES_H
+
+#include "scene/resources/theme.h"
+
+Ref<Theme> create_default_theme();
+
+Ref<Theme> create_editor_theme();
+
+#endif

--- a/tools/editor/project_manager.cpp
+++ b/tools/editor/project_manager.cpp
@@ -45,8 +45,7 @@
 #include "scene/gui/margin_container.h"
 #include "io/resource_saver.h"
 
-#include "editor_icons.h"
-#include "editor_fonts.h"
+#include "editor_themes.h"
 
 #include "editor_scale.h"
 
@@ -846,21 +845,16 @@ ProjectManager::ProjectManager() {
 
 	set_area_as_parent_rect();
 
-	Ref<Theme> theme = Ref<Theme>( memnew( Theme ) );
-	set_theme(theme);
-	editor_register_icons(theme);
-	editor_register_fonts(theme);
+	gui_base = memnew( Control );
+	add_child(gui_base);
+	gui_base->set_area_as_parent_rect();
 
-	String global_font = EditorSettings::get_singleton()->get("global/font");
-	if (global_font!="") {
-		Ref<Font> fnt = ResourceLoader::load(global_font);
-		if (fnt.is_valid()) {
-			theme->set_default_theme_font(fnt);
-		}
-	}
+	set_theme(create_default_theme());
+	Ref<Theme> theme = create_editor_theme();
+	gui_base->set_theme(theme);
 
 	Panel *panel = memnew( Panel );
-	add_child(panel);
+	gui_base->add_child(panel);
 	panel->set_area_as_parent_rect();
 
 	VBoxContainer *vb = memnew( VBoxContainer );
@@ -961,7 +955,7 @@ ProjectManager::ProjectManager() {
 	scan_dir->set_access(FileDialog::ACCESS_FILESYSTEM);
 	scan_dir->set_mode(FileDialog::MODE_OPEN_DIR);
 	scan_dir->set_current_dir( EditorSettings::get_singleton()->get("global/default_project_path") );
-	add_child(scan_dir);
+	gui_base->add_child(scan_dir);
 	scan_dir->connect("dir_selected",this,"_scan_begin");
 
 
@@ -1010,26 +1004,26 @@ ProjectManager::ProjectManager() {
 	erase_ask->get_ok()->set_text(TTR("Remove"));
 	erase_ask->get_ok()->connect("pressed", this,"_erase_project_confirm");
 
-	add_child(erase_ask);
+	gui_base->add_child(erase_ask);
 
 	multi_open_ask = memnew( ConfirmationDialog );
 	multi_open_ask->get_ok()->set_text(TTR("Edit"));
 	multi_open_ask->get_ok()->connect("pressed", this, "_open_project_confirm");
 
-	add_child(multi_open_ask);
+	gui_base->add_child(multi_open_ask);
 
 	multi_run_ask = memnew( ConfirmationDialog );
 	multi_run_ask->get_ok()->set_text(TTR("Run"));
 	multi_run_ask->get_ok()->connect("pressed", this, "_run_project_confirm");
 
-	add_child(multi_run_ask);
+	gui_base->add_child(multi_run_ask);
 
 
 
 	OS::get_singleton()->set_low_processor_usage_mode(true);
 
 	npdialog = memnew( NewProjectDialog );
-	add_child(npdialog);
+	gui_base->add_child(npdialog);
 
 	npdialog->connect("project_created", this,"_load_recent_projects");
 	_load_recent_projects();

--- a/tools/editor/project_manager.h
+++ b/tools/editor/project_manager.h
@@ -67,6 +67,8 @@ class ProjectManager : public Control {
 
 	TabContainer *tabs;
 
+	Control *gui_base;
+
 	void _item_doubleclicked();
 
 


### PR DESCRIPTION
Allow editor to load custom themes generated with itself.

Fix #5184.

![](https://cdn.rawgit.com/Geequlim/depot/master/images/godot/costum_theme.png)
