### PR TITLE
TextEdit: Change font size with Ctrl+Mouse Wheel Up/Down

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1452,10 +1452,10 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 			}
 
 			if (mb.pressed) {
-				if (mb.button_index==BUTTON_WHEEL_UP) {
+				if (mb.button_index==BUTTON_WHEEL_UP && !mb.mod.command) {
 					v_scroll->set_val( v_scroll->get_val() -3 );
 				}
-				if (mb.button_index==BUTTON_WHEEL_DOWN) {
+				if (mb.button_index==BUTTON_WHEEL_DOWN && !mb.mod.command) {
 					v_scroll->set_val( v_scroll->get_val() +3 );
 				}
 				if (mb.button_index==BUTTON_WHEEL_LEFT) {

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -516,7 +516,7 @@ void DynamicFontAtSize::_update_char(CharType p_char) {
 
 		if (tex.texture.is_null()) {
 			tex.texture.instance();
-			tex.texture->create_from_image(img,0/*Texture::FLAG_FILTER*/);
+			tex.texture->create_from_image(img,Texture::FLAG_VIDEO_SURFACE);
 		} else {
 			tex.texture->set_data(img); //update
 		}

--- a/tools/editor/code_editor.h
+++ b/tools/editor/code_editor.h
@@ -202,21 +202,26 @@ class CodeTextEditor : public VBoxContainer {
 	Timer *code_complete_timer;
 	bool enable_complete_timer;
 
+	Timer *font_resize_timer;
+	int font_resize_val;
+
 	Label *error;
 
 	void _on_settings_change();
 
 	void _update_font();
 	void _complete_request();
+	void _font_resize_timeout();
+
+	void _text_editor_input_event(const InputEvent& p_event);
+
 protected:
 
 	void set_error(const String& p_error);
 
-
 	virtual void _load_theme_settings() {}
 	virtual void _validate_script()=0;
 	virtual void _code_complete_script(const String& p_code, List<String>* r_options) {};
-
 
 	void _text_changed_idle_timeout();
 	void _code_complete_timer_timeout();
@@ -224,7 +229,6 @@ protected:
 	void _line_col_changed();
 	void _notification(int);
 	static void _bind_methods();
-
 
 public:
 

--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -515,7 +515,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("global/font_size",14);
 	hints["global/font_size"]=PropertyInfo(Variant::INT,"global/font_size",PROPERTY_HINT_RANGE,"10,40,1",PROPERTY_USAGE_DEFAULT|PROPERTY_USAGE_RESTART_IF_CHANGED);
 	set("global/source_font_size",14);
-	hints["global/source_font_size"]=PropertyInfo(Variant::INT,"global/source_font_size",PROPERTY_HINT_RANGE,"10,40,1",PROPERTY_USAGE_DEFAULT|PROPERTY_USAGE_RESTART_IF_CHANGED);
+	hints["global/source_font_size"]=PropertyInfo(Variant::INT,"global/source_font_size",PROPERTY_HINT_RANGE,"8,96,1",PROPERTY_USAGE_DEFAULT|PROPERTY_USAGE_RESTART_IF_CHANGED);
 	set("global/custom_font","");
 	hints["global/custom_font"]=PropertyInfo(Variant::STRING,"global/custom_font",PROPERTY_HINT_GLOBAL_FILE,"*.fnt",PROPERTY_USAGE_DEFAULT|PROPERTY_USAGE_RESTART_IF_CHANGED);
 	set("global/custom_theme","");


### PR DESCRIPTION
a.k.a. zoom

I used a timer to avoid slowing down because of many consecutive mouse wheel events.

~~I am not sure if adding #ifdefs for TOOL_ENABLED in scene/\* is ok.~~ Never mind, I moved it to CodeTextEditor.

Suggestions welcome.
