### PR TITLE
correctly parse floats in scientific notation (Fix #5267)

### DIFF
--- a/modules/gdscript/gd_tokenizer.cpp
+++ b/modules/gdscript/gd_tokenizer.cpp
@@ -725,7 +725,7 @@ void GDTokenizerText::_advance() {
 					if (hexa_found) {
 						int val = str.hex_to_int();
 						_make_constant(val);
-					} else if (period_found) {
+					} else if (period_found || exponent_found) {
 						real_t val = str.to_double();
 						//print_line("*%*%*%*% to convert: "+str+" result: "+rtos(val));
 						_make_constant(val);


### PR DESCRIPTION
well, that was easier than expected...

Fixes #5267 
