### PR TITLE
Added Tile Origin = Bottom Left option to the TileMap

### DIFF
--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -54,7 +54,8 @@ public:
 
 	enum TileOrigin {
 		TILE_ORIGIN_TOP_LEFT,
-		TILE_ORIGIN_CENTER
+		TILE_ORIGIN_CENTER,
+		TILE_ORIGIN_BOTTOM_LEFT
 	};
 
 

--- a/tools/editor/plugins/tile_map_editor_plugin.cpp
+++ b/tools/editor/plugins/tile_map_editor_plugin.cpp
@@ -412,6 +412,24 @@ void TileMapEditor::_draw_cell(int p_cell, const Point2i& p_point, bool p_flip_h
 	if (node->get_tile_origin()==TileMap::TILE_ORIGIN_TOP_LEFT) {
 
 		rect.pos+=tile_ofs;
+	} else if (node->get_tile_origin()==TileMap::TILE_ORIGIN_BOTTOM_LEFT) {
+		Size2 cell_size = node->get_cell_size();
+		
+		rect.pos+=tile_ofs;
+		
+		if(p_transpose)
+		{
+			if(p_flip_h)
+				rect.pos.x-=cell_size.x;
+			else
+				rect.pos.x+=cell_size.x;
+		} else {
+			if(p_flip_v)
+				rect.pos.y-=cell_size.y;
+			else
+				rect.pos.y+=cell_size.y;
+		}
+
 	} else if (node->get_tile_origin()==TileMap::TILE_ORIGIN_CENTER) {
 		rect.pos+=node->get_cell_size()/2;
 		Vector2 s = r.size;


### PR DESCRIPTION
I find it useful to have the tile origins in my tileset at the bottom left corner. In a game in 3/4 view, the point which decides if an object is in front of another is often the one at the bottom of the sprite (if the shapes are simple enough). Since y-sort sorts by the origin of the tiles and other objects, it would be nice to have the possibility to use tiles with the origin at the bottom. This is already doable by using the offset when creating a tileset, but in the TileMap the tiles will then appear above the cursor (if you choose Tile Origin = Top Left). See also the issue https://github.com/godotengine/godot/issues/3892. 

I added an option for tiles with the origin at the bottom left and want to contribute this small addition to the project.
