### PR TITLE
Fix #5263: Useless preprocessor condition

### DIFF
--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -44,18 +44,6 @@ struct Vector3 {
 	};
 
 	union {
-
-#ifdef USE_QUAD_VECTORS
-
-		struct {
-			real_t x;
-			real_t y;
-			real_t z;
-			real_t _unused;
-		};
-		real_t coord[4];
-#else
-
 		struct {
 			real_t x;
 			real_t y;
@@ -63,7 +51,6 @@ struct Vector3 {
 		};
 
 		real_t coord[3];
-#endif
 	};
 
 	_FORCE_INLINE_ const real_t& operator[](int p_axis) const {

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -46,11 +46,9 @@ public:
 	operator const char*() {return get_data();};
 };
 
-#ifndef CHARTYPE_16BITS
+
 typedef wchar_t CharType;
-#else
-typedef wchar_t uint16_t;
-#endif
+
 
 struct StrRange {
 

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -1445,12 +1445,12 @@ Variant::operator unsigned char() const {
 
 	return 0;
 }
-#ifndef CHARTYPE_16BITS
+
 Variant::operator CharType() const {
 
 	return operator unsigned int();
 }
-#endif
+
 
 Variant::operator float() const {
 

--- a/core/variant.h
+++ b/core/variant.h
@@ -151,11 +151,7 @@ private:
 		InputEvent *_input_event;
 		Image *_image;
 		void *_ptr; //generic pointer
-#ifdef USE_QUAD_VECTORS
-		uint8_t _mem[sizeof(ObjData) > (sizeof(real_t)*5) ? sizeof(ObjData) : (sizeof(real_t)*5)]; // plane uses an extra real
-#else
 		uint8_t _mem[sizeof(ObjData) > (sizeof(real_t)*4) ? sizeof(ObjData) : (sizeof(real_t)*4)];
-#endif
 	} _data;
 
 

--- a/core/variant.h
+++ b/core/variant.h
@@ -202,9 +202,8 @@ public:
 	operator unsigned long() const;
 #endif
 
-#ifndef	CHARTYPE_16BITS
+
 	operator CharType() const;
-#endif
 	operator float() const;
 	operator double() const;
 	operator String() const;


### PR DESCRIPTION
Removes the useless preprocessor conditions `CHARTYPE_16BITS` and  disables`USE_QUAD_VECTORS` since it seems there was some work/some implementation may be done in the future there.
