### PR TITLE
editor_node.cpp now takes care of removing plugin after deactivating it

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -2944,6 +2944,9 @@ void EditorNode::remove_editor_plugin(EditorPlugin *p_editor) {
 		//singleton->main_editor_tabs->add_tab(p_editor->get_name());
 		singleton->editor_table.erase(p_editor);
 	}
+	p_editor->make_visible(false);
+	p_editor->clear();
+	singleton->editor_plugins_over->get_plugins_list().erase(p_editor);
 	singleton->remove_child(p_editor);
 	singleton->editor_data.remove_editor_plugin( p_editor );
 
@@ -2996,7 +2999,7 @@ void EditorNode::set_addon_plugin_enabled(const String& p_addon,bool p_enabled) 
 	if (!p_enabled) {
 
 		EditorPlugin *addon = plugin_addons[p_addon];
-		editor_data.remove_editor_plugin( addon );
+		remove_editor_plugin(addon);
 		memdelete(addon); //bye
 		plugin_addons.erase(p_addon);
 		_update_addon_config();


### PR DESCRIPTION
Time ago I have created a PR(#4174) that later was merged. A week ago I was looking into the code to find what crashes after disabling a plugin. So I have mede this little change to try fixing crash when disabling plugin. 

With that, the plugin gets removed by using the remove_editor_plugin() existent method instead of just removing from editor_data. 

Also removes from the active plugins list if it is on that list... 

As a bonus, this change seems to solve #5273.
