### PR TITLE
Text Edit no longer draws caret on focus loss

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -417,7 +417,21 @@ void TextEdit::_notification(int p_what) {
 
 			_update_caches();
 		} break;
+		case MainLoop::NOTIFICATION_WM_FOCUS_IN: {
+			window_has_focus = true;
+			draw_caret = true;
+			update();
+		} break;
+		case MainLoop::NOTIFICATION_WM_FOCUS_OUT: {
+			window_has_focus = false;
+			draw_caret = false;
+			update();
+		} break;
 		case NOTIFICATION_DRAW: {
+
+			if ((!has_focus() && !menu->has_focus()) || !window_has_focus) {
+				draw_caret = false;
+			}
 
 			if (draw_breakpoint_gutter) {
 				breakpoint_gutter_width = (get_row_height() * 55) / 100;
@@ -4518,6 +4532,7 @@ TextEdit::TextEdit()  {
 	brace_matching_enabled=false;
 	auto_indent=false;
 	insert_mode = false;
+	window_has_focus=true;
 
 	menu = memnew( PopupMenu );
 	add_child(menu);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -217,6 +217,7 @@ class TextEdit : public Control  {
 	Timer *caret_blink_timer;
 	bool caret_blink_enabled;
 	bool draw_caret;
+	bool window_has_focus;
 
 	bool setting_row;
 	bool wrap;


### PR DESCRIPTION
Text Edit will no longer draw the caret on focus loss including focusing another application
