### PR TITLE
Fix the joystick vibration on Linux

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -365,7 +365,7 @@ void InputDefault::stop_joy_vibration(int p_device) {
 	vibration.weak_magnitude = 0;
 	vibration.strong_magnitude = 0;
 	vibration.duration = 0;
-	vibration.timestamp = OS::get_singleton()->get_unix_time();
+	vibration.timestamp = OS::get_singleton()->get_ticks_usec();
 	joy_vibration[p_device] = vibration;
 }
 

--- a/platform/x11/joystick_linux.cpp
+++ b/platform/x11/joystick_linux.cpp
@@ -439,11 +439,9 @@ void joystick_linux::joystick_vibration_stop(int p_id, uint64_t p_timestamp)
 		return;
 	}
 
-	struct input_event stop;
-	stop.type = EV_FF;
-	stop.code = joy.ff_effect_id;
-	stop.value = 0;
-	write(joy.fd, (const void*)&stop, sizeof(stop));
+	if (ioctl(joy.fd, EVIOCRMFF, joy.ff_effect_id) < 0) {
+		return;
+	}
 
 	joy.ff_effect_id = -1;
 	joy.ff_effect_timestamp = p_timestamp;


### PR DESCRIPTION
My previous pull request ( #5043 ) had two major bugs:
- The timestamp for the _start_ and _stop_ commands were generated using different functions
-  The effects were not removed from the joystick after being uploaded, so the vibration stopped working when the joystick's list of effects was full

Which made the joystick pretty much unusable, except for very basic tests (which is why I discovered these bugs only when I tried to _actually_ use the feature). Sorry about that, I should definitely have tested my code more thoroughly.
