### PR TITLE
Add resource type and editor plugin for text files

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -185,7 +185,7 @@ RES ResourceLoader::load(const String &p_path, const String& p_type_hint, bool p
 	String extension=remapped_path.extension();
 	bool found=false;
 
-	for (int i=0;i<loader_count;i++) {
+	for (int i=loader_count-1; i>=0; i--) {
 
 		if (!loader[i]->recognize(extension))
 			continue;

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -43,7 +43,7 @@ Error ResourceSaver::save(const String &p_path,const RES& p_resource,uint32_t p_
 	String extension=p_path.extension();
 	Error err=ERR_FILE_UNRECOGNIZED;
 
-	for (int i=0;i<saver_count;i++) {
+	for (int i=saver_count-1;i>=0;i--) {
 
 		if (!saver[i]->recognize(p_resource))
 			continue;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -180,6 +180,7 @@
 #include "scene/resources/color_ramp.h"
 #include "scene/scene_string_names.h"
 
+#include "scene/resources/raw_text.h"
 
 #include "scene/3d/spatial.h"
 #include "scene/3d/skeleton.h"
@@ -237,6 +238,9 @@ static ResourceFormatLoaderShader *resource_loader_shader=NULL;
 
 static ResourceFormatSaverText *resource_saver_text=NULL;
 static ResourceFormatLoaderText *resource_loader_text=NULL;
+
+static ResourceFormatSaverRawText *resource_saver_rawtext=NULL;
+static ResourceFormatLoaderRawText *resource_loader_rawtext=NULL;
 
 static ResourceFormatLoaderDynamicFont *resource_loader_dynamic_font=NULL;
 
@@ -597,6 +601,8 @@ void register_scene_types() {
 	ObjectTypeDB::register_type<BitMap>();
 	ObjectTypeDB::register_type<ColorRamp>();
 
+	ObjectTypeDB::register_type<RawText>();
+
 	OS::get_singleton()->yield(); //may take time to init
 
 	ObjectTypeDB::register_type<Sample>();
@@ -642,6 +648,12 @@ void register_scene_types() {
 	resource_loader_text = memnew( ResourceFormatLoaderText );
 	ResourceLoader::add_resource_format_loader(resource_loader_text);
 
+	resource_saver_rawtext = memnew( ResourceFormatSaverRawText );
+	ResourceSaver::add_resource_format_saver(resource_saver_rawtext);
+
+	resource_loader_rawtext = memnew( ResourceFormatLoaderRawText );
+	ResourceLoader::add_resource_format_loader(resource_loader_rawtext);
+
 }
 
 void unregister_scene_types() {
@@ -667,5 +679,12 @@ void unregister_scene_types() {
 	if (resource_loader_text) {
 		memdelete(resource_loader_text);
 	}
+	if (resource_saver_rawtext) {
+		memdelete(resource_saver_rawtext);
+	}
+	if (resource_loader_rawtext) {
+		memdelete(resource_loader_rawtext);
+	}
+
 	SceneStringNames::free();
 }

--- a/scene/resources/raw_text.cpp
+++ b/scene/resources/raw_text.cpp
@@ -1,0 +1,168 @@
+/*************************************************************************/
+/*  raw_text.cpp                                                         */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2016 Juan Linietsky, Ariel Manzur.                 */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "raw_text.h"
+#include "core/object_type_db.h"
+#include "core/os/file_access.h"
+
+void RawText::set_text(const String& text) {
+	if(text.length() != m_text.length() && text!=m_text) {
+		m_text = text;
+		emit_changed();
+	}
+}
+
+void RawText::_bind_methods() {
+
+	ObjectTypeDB::bind_method(_MD("set_text","text"),&RawText::set_text);
+	ObjectTypeDB::bind_method(_MD("get_text"),&RawText::get_text);
+	ADD_PROPERTY( PropertyInfo(Variant::STRING,"text"), _SCS("set_text"), _SCS("get_text"));
+
+}
+
+void RawText::get_recognized_extensions(List<String> *p_extensions) {
+	String extensions[] = {
+		"txt", "md", "json", "toml", "cfg", "ini", "inf", "c", "cpp", "cxx",
+		"c++", "h", "hpp",  "m", "mm", "css", "htm", "html", "py", "java", "js",
+		"sh", "cmd", "csv", "cs", "as", "bash", "hlsl", "glsl", "diff", "php",
+		"lua", "rb", "yml", "yaml", "go"
+#ifndef XML_ENABLED
+		,"xml"
+#endif
+	};
+	for(size_t i=0; i<sizeof(extensions)/sizeof (String); i++) {
+		p_extensions->push_back(extensions[i]);
+	}
+}
+
+Error RawText::load_text(const String& p_path) {
+
+	DVector<uint8_t> sourcef;
+	Error err;
+	FileAccess *f=FileAccess::open(p_path,FileAccess::READ,&err);
+	if (err) {
+
+		ERR_FAIL_COND_V(err,err);
+	}
+
+	int len = f->get_len();
+	sourcef.resize(len+1);
+	DVector<uint8_t>::Write w = sourcef.write();
+	int r = f->get_buffer(w.ptr(),len);
+	f->close();
+	memdelete(f);
+	ERR_FAIL_COND_V(r!=len,ERR_CANT_OPEN);
+	w[len]=0;
+
+	String s;
+	if (s.parse_utf8((const char*)w.ptr())) {
+
+		ERR_EXPLAIN("RawText '"+p_path+"' contains invalid unicode (utf-8), so it was not loaded. Please ensure that files are saved in valid utf-8 unicode.");
+		ERR_FAIL_V(ERR_INVALID_DATA);
+	}
+
+	set_text(s);
+
+	return OK;
+}
+
+/*************** RESOURCE ***************/
+
+RES ResourceFormatLoaderRawText::load(const String &p_path, const String& p_original_path, Error *r_error) {
+
+	if (r_error)
+		*r_error=ERR_FILE_CANT_OPEN;
+
+	RawText *rawtext = memnew( RawText );
+	Ref<RawText> text(rawtext);
+
+	Error err = text->load_text(p_path);
+	if (err!=OK) {
+		ERR_FAIL_COND_V(err!=OK, RES());
+	}
+	text->set_path(p_path);
+
+	return text;
+}
+
+void ResourceFormatLoaderRawText::get_recognized_extensions(List<String> *p_extensions) const {
+	RawText::get_recognized_extensions(p_extensions);
+}
+
+
+bool ResourceFormatLoaderRawText::handles_type(const String& p_type) const {
+	return "RawText";
+}
+
+String ResourceFormatLoaderRawText::get_resource_type(const String &p_path) const {
+	String el = p_path.extension().to_lower();
+	if (el=="txt" || el=="md" || el=="json")
+		return "RawText";
+	return "";
+}
+
+
+Error ResourceFormatSaverRawText::save(const String &p_path,const RES& p_resource,uint32_t p_flags) {
+
+	Ref<RawText> srtext = p_resource;
+	ERR_FAIL_COND_V(srtext.is_null(),ERR_INVALID_PARAMETER);
+
+	String text = srtext->get_text();
+
+	Error err;
+	FileAccess *file = FileAccess::open(p_path,FileAccess::WRITE,&err);
+
+	if (err) {
+		ERR_FAIL_COND_V(err,err);
+	}
+
+	file->store_string(text);
+	if (file->get_error()!=OK && file->get_error()!=ERR_FILE_EOF) {
+		memdelete(file);
+		return ERR_CANT_CREATE;
+	}
+	file->close();
+	memdelete(file);
+
+	return OK;
+}
+
+void ResourceFormatSaverRawText::get_recognized_extensions(const RES& p_resource,List<String> *p_extensions) const {
+
+	if (p_resource->cast_to<RawText>()) {
+		RawText::get_recognized_extensions(p_extensions);
+	}
+
+}
+
+bool ResourceFormatSaverRawText::recognize(const RES& p_resource) const {
+
+	return p_resource->cast_to<RawText>()!=NULL;
+}
+

--- a/scene/resources/raw_text.h
+++ b/scene/resources/raw_text.h
@@ -1,0 +1,70 @@
+/*************************************************************************/
+/*  raw_text.h                                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2016 Juan Linietsky, Ariel Manzur.                 */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#ifndef RAWTEXT_H
+#define RAWTEXT_H
+
+#include "core/resource.h"
+#include "core/io/resource_loader.h"
+#include "core/io/resource_saver.h"
+
+class RawText : public Resource
+{
+	OBJ_TYPE(RawText, Resource);
+	RES_BASE_EXTENSION("txt");
+protected:
+	String m_text;
+	static void _bind_methods();
+public:
+	void set_text(const String& text);
+	const String& get_text() const { return m_text; }
+	Error load_text(const String& p_path);
+	static void get_recognized_extensions(List<String> *p_extensions);
+	RawText() {}
+};
+
+class ResourceFormatLoaderRawText : public ResourceFormatLoader {
+public:
+
+	virtual RES load(const String &p_path,const String& p_original_path="",Error *r_error=NULL);
+	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual bool handles_type(const String& p_type) const;
+	virtual String get_resource_type(const String &p_path) const;
+
+};
+
+class ResourceFormatSaverRawText : public ResourceFormatSaver {
+public:
+
+	virtual Error save(const String &p_path,const RES& p_resource,uint32_t p_flags=0);
+	virtual void get_recognized_extensions(const RES& p_resource,List<String> *p_extensions) const;
+	virtual bool recognize(const RES& p_resource) const;
+
+};
+
+#endif // RAWTEXT_H

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -76,7 +76,7 @@
 #include "plugins/mesh_instance_editor_plugin.h"
 #include "plugins/mesh_editor_plugin.h"
 #include "plugins/theme_editor_plugin.h"
-
+#include "plugins/raw_text_editor_plugin.h"
 #include "plugins/tile_map_editor_plugin.h"
 #include "plugins/cube_grid_theme_editor_plugin.h"
 #include "plugins/shader_editor_plugin.h"
@@ -6292,6 +6292,8 @@ EditorNode::EditorNode() {
 	add_editor_plugin( memnew( ShaderGraphEditorPlugin(this,false) ) );
 	add_editor_plugin( memnew( ShaderEditorPlugin(this,true) ) );
 	add_editor_plugin( memnew( ShaderEditorPlugin(this,false) ) );
+	add_editor_plugin( memnew( RawTextEditorPlugin(this, true) ));
+	add_editor_plugin( memnew( RawTextEditorPlugin(this, false) ));
 	add_editor_plugin( memnew( CameraEditorPlugin(this) ) );
 	add_editor_plugin( memnew( SampleEditorPlugin(this) ) );
 	add_editor_plugin( memnew( SampleLibraryEditorPlugin(this) ) );

--- a/tools/editor/plugins/raw_text_editor_plugin.cpp
+++ b/tools/editor/plugins/raw_text_editor_plugin.cpp
@@ -1,0 +1,774 @@
+/*************************************************************************/
+/*  raw_text_editor_plugin.cpp                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2016 Juan Linietsky, Ariel Manzur.                 */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#include "raw_text_editor_plugin.h"
+#include "tools/editor/editor_settings.h"
+
+#include "spatial_editor_plugin.h"
+#include "io/resource_loader.h"
+#include "io/resource_saver.h"
+#include "os/keyboard.h"
+#include "tools/editor/editor_node.h"
+#include "tools/editor/property_editor.h"
+#include "os/os.h"
+
+Ref<RawText>& RawTextSourceEditor::get_edited_text() {
+	return text;
+}
+
+void RawTextSourceEditor::set_edited_text(const Ref<RawText>& p_text) {
+
+	text=p_text;
+	language = text->get_path().extension();
+
+	_load_theme_settings();
+
+	get_text_edit()->set_text(text->get_text());
+	get_text_edit()->call("cursor_set_blink_enabled", true);
+
+	_line_col_changed();
+}
+
+void RawTextSourceEditor::set_highlight_language(const String& lang) {
+
+	language = lang;
+	_load_theme_settings();
+
+}
+
+HighlightConfig RawTextSourceEditor::get_highlight(const String& extension) {
+	HighlightConfig hl;
+	hl.filled = false;
+
+	if (extension == "json") { // json
+		hl.filled = true;
+
+		hl.string_delimiters.push_back("\" \"");
+
+		hl.multi_line_comment_beg = "/*";
+		hl.multi_line_comment_beg = "*/";
+
+		String keywords [] = {
+			"null", "true", "false"
+		};
+		for (size_t i=0; i < sizeof (keywords) / sizeof (String); i++) {
+			hl.keywords.push_back(keywords[i]);
+		}
+	}
+	else if (extension == "xml" || extension == "html" || extension == "htm" || extension == "xhtml") { // xml
+		hl.filled = true;
+		hl.string_delimiters.push_back("\" \"");
+	}
+	else if (extension == "yml" || extension == "yaml") { // yaml
+		hl.filled = true;
+
+		hl.line_comment = "#";
+		hl.string_delimiters.push_back("\" \"");
+		hl.string_delimiters.push_back("\"\"\" \"\"\"");
+
+		hl.multi_line_comment_beg = "/*";
+		hl.multi_line_comment_beg = "*/";
+		String keywords [] = {
+			"null", "true", "false"
+		};
+		for (size_t i=0; i < sizeof (keywords) / sizeof (String); i++) {
+			hl.keywords.push_back(keywords[i]);
+		}
+	}
+	else if (extension == "cfg" || extension == "toml" || extension == "ini" ) { // toml
+		hl.filled = true;
+		hl.string_delimiters.push_back("\" \"");
+		hl.string_delimiters.push_back("\"\"\" \"\"\"");
+		hl.string_delimiters.push_back("' '");
+
+		hl.line_comment = "#";
+		hl.multi_line_comment_beg = ";";
+		hl.multi_line_comment_beg = "";
+		String keywords [] = {
+			"null", "true", "false"
+		};
+		for (size_t i=0; i < sizeof (keywords) / sizeof (String); i++) {
+			hl.keywords.push_back(keywords[i]);
+		}
+	}
+	else if (extension == "c++" || extension == "cxx" || extension == "cpp" || extension == "h" || extension == "hpp") { // C++
+		hl.filled = true;
+		hl.string_delimiters.push_back("R\"( )\"");
+		hl.string_delimiters.push_back("\" \"");
+		hl.string_delimiters.push_back("' '");
+
+		hl.line_comment = "//";
+		hl.multi_line_comment_beg = "/*";
+		hl.multi_line_comment_beg = "*/";
+
+		String keywords [] = {
+			"alignas", "alignof", "and", "and_eq", "asm", "auto", "bitand", "bitor",
+			"bool", "break", "case", "catch", "char", "char16_t", "char32_t",
+			"class", "compl", "concept", "const", "constexpr", "const_cast",
+			"continue", "decltype", "default", "delete", "do", "double", "else",
+			"dynamic_cast", "enum", "explicit", "export", "extern", "false", "for",
+			"float","friend", "goto", "if", "inline", "int", "long", "mutable",
+			"namespace", "new", "noexcept", "not", "not_eq", "nullptr", "operator",
+			"or", "or_eq", "private", "protected", "public", "register",
+			"reinterpret_cast", "requires", "return", "short", "signed", "sizeof",
+			"static", "static_assert", "static_cast", "struct", "switch", "xor_eq",
+			"template", "this", "thread_local", "throw", "true", "try", "typedef",
+			"typeid", "typename", "union", "unsigned", "using", "virtual", "void",
+			"volatile", "wchar_t", "while", "xor"
+		};
+		for (size_t i=0; i < sizeof (keywords) / sizeof (String); i++) {
+			hl.keywords.push_back(keywords[i]);
+		}
+	}
+	else if( extension == "cs") { // C#
+
+		hl.filled = true;
+
+		hl.string_delimiters.push_back("\" \"");
+		hl.string_delimiters.push_back("' '");
+
+		hl.line_comment = "//";
+		hl.multi_line_comment_beg = "/*";
+		hl.multi_line_comment_beg = "*/";
+
+		String keywords [] = {
+			"abstract", "as", "base", "bool", "break", "byte", "case", "catch",
+			"char", "checked", "class", "const", "continue", "decimal", "default",
+			"delegate", "do", "double", "else","enum", "event", "explicit", "extern",
+			"false", "finally", "fixed", "float", "for", "foreach", "goto", "if",
+			"implicit", "in", "int", "interface", "internal", "is", "lock", "long",
+			"namespace", "new", "null", "object", "operator", "out", "override",
+			"params", "private", "protected", "public", "readonly", "ref", "return",
+			"sbyte", "sealed", "short", "sizeof", "stackalloc", "static", "string",
+			"struct", "switch", "this", "throw", "true", "try", "typeof", "uint",
+			"ulong", "unchecked", "unsafe", "ushort", "using", "virtual", "void",
+			"volatile", "while", "add", "alias", "ascending", "async", "await",
+			"descending", "dynamic", "from", "get", "global", "group", "into",
+			"join", "let", "orderby", "remove", "select", "set", "value", "var",
+			"where", "yield"
+		};
+		for (size_t i=0; i < sizeof (keywords) / sizeof (String); i++) {
+			hl.keywords.push_back(keywords[i]);
+		}
+
+	}
+	else if( extension == "js") { // Javascript
+
+		hl.filled = true;
+
+		hl.string_delimiters.push_back("\" \"");
+		hl.string_delimiters.push_back("' '");
+		hl.string_delimiters.push_back("$` `");
+
+		hl.line_comment = "//";
+		hl.multi_line_comment_beg = "/*";
+		hl.multi_line_comment_beg = "*/";
+
+		String keywords [] = {
+			"do", "if", "in", "for", "let", "new", "try", "var", "case", "else",
+			"enum", "eval", "null", "this", "true", "void", "with", "await", "break",
+			"catch", "class", "const", "false", "super", "throw", "while", "yield",
+			"delete", "export", "import", "public", "return", "static", "switch",
+			"typeof", "default", "extends", "finally", "package", "private",
+			"continue", "debugger", "function", "arguments", "interface", "protected",
+			"implements", "instanceof"
+		};
+		for (size_t i=0; i < sizeof (keywords) / sizeof (String); i++) {
+			hl.keywords.push_back(keywords[i]);
+		}
+	}
+	else if( extension == "css") { // CSS
+
+		hl.filled = true;
+
+		hl.string_delimiters.push_back("\" \"");
+		hl.multi_line_comment_beg = "/*";
+		hl.multi_line_comment_beg = "*/";
+
+		String keywords [] = {
+			"accelerator", "azimuth", "background", "background-attachment",
+			"background-color", "background-image", "background-position",
+			"background-position-x", "background-position-y", "background-repeat",
+			"behavior", "border", "border-bottom", "border-bottom-color", "border-bottom-style",
+			"border-bottom-width", "border-collapse", "border-color", "border-left",
+			"border-left-color", "border-left-style", "border-left-width", "border-right",
+			"border-right-color", "border-right-style", "border-right-width",
+			"border-spacing", "border-style", "border-top", "border-top-color",
+			"border-top-style", "border-top-width", "border-width", "bottom",
+			"caption-side", "clear", "clip", "color", "content", "counter-increment",
+			"counter-reset", "cue", "cue-after", "cue-before", "cursor", "direction",
+			"display", "elevation", "empty-cells", "filter", "float", "font", "font-family",
+			"font-size", "font-size-adjust", "font-stretch", "font-style", "font-variant",
+			"font-weight", "height", "ime-mode", "include-source", "layer-background-color",
+			"layer-background-image", "layout-flow", "layout-grid", "layout-grid-char",
+			"layout-grid-char-spacing", "layout-grid-line", "layout-grid-mode",
+			"layout-grid-type", "left", "letter-spacing", "line-break", "line-height",
+			"list-style", "list-style-image", "list-style-position", "list-style-type",
+			"margin", "margin-bottom", "margin-left", "margin-right", "margin-top",
+			"marker-offset", "marks", "max-height", "max-width", "min-height",
+			"min-width", "-moz-binding", "-moz-border-radius",
+			"-moz-border-radius-topleft", "-moz-border-radius-topright",
+			"-moz-border-radius-bottomright", "-moz-border-radius-bottomleft",
+			"-moz-border-top-colors", "-moz-border-right-colors",
+			"-moz-border-bottom-colors", "-moz-border-left-colors",
+			"-moz-opacity", "-moz-outline", "-moz-outline-color",
+			"-moz-outline-style", "-moz-outline-width", "-moz-user-focus",
+			"-moz-user-input", "-moz-user-modify", "-moz-user-select", "orphans",
+			"outline", "outline-color", "outline-style", "outline-width", "overflow",
+			"overflow-X", "overflow-Y", "padding", "padding-bottom", "padding-left",
+			"padding-right", "padding-top", "page", "page-break-after", "page-break-before",
+			"page-break-inside", "pause", "pause-after", "pause-before", "pitch",
+			"pitch-range", "play-during", "position", "quotes", "-replace", "richness",
+			"right", "ruby-align", "ruby-overhang", "ruby-position", "-set-link-source",
+			"size", "speak", "speak-header", "speak-numeral", "speak-punctuation",
+			"speech-rate", "stress", "scrollbar-arrow-color", "scrollbar-base-color",
+			"scrollbar-dark-shadow-color", "scrollbar-face-color", "scrollbar-highlight-color",
+			"scrollbar-shadow-color", "scrollbar-3d-light-color", "scrollbar-track-color",
+			"table-layout", "text-align", "text-align-last", "text-decoration",
+			"text-indent", "text-justify", "text-overflow", "text-shadow",
+			"text-transform", "text-autospace", "text-kashida-space", "text-underline-position",
+			"top", "unicode-bidi", "-use-link-source", "vertical-align", "visibility",
+			"voice-family", "volume", "white-space", "widows", "width", "word-break",
+			"word-spacing", "word-wrap", "writing-mode", "z-index", "zoom",
+			"rgb", "rgba", "hsl", "hsla", "#", "~", "transparent"
+		};
+		for (size_t i=0; i < sizeof (keywords) / sizeof (String); i++) {
+			hl.keywords.push_back(keywords[i]);
+		}
+	}
+	else if (extension == "py") { // python
+		hl.filled = true;
+
+		hl.string_delimiters.push_back("\" \"");
+		hl.string_delimiters.push_back("' '");
+		hl.string_delimiters.push_back("\"\"\" \"\"\"");
+
+		hl.line_comment = "#";
+
+		String pykeywords [] = {
+			"and", "del", "from", "not", "while", "as", "elif", "global", "or",
+			"with", "assert", "else", "if", "pass", "yield", "break", "except",
+			"import", "print", "class", "exec", "in", "raise", "continue",
+			"finally", "is", "return", "def", "for", "lambda", "try"
+		};
+		for (size_t i=0; i < sizeof (pykeywords) / sizeof (String); i++) {
+			hl.keywords.push_back(pykeywords[i]);
+		}
+	}
+	else if (extension == "sh" || extension == "bash") { // Bash shell
+		hl.filled = true;
+
+		hl.string_delimiters.push_back("\" \"");
+		hl.string_delimiters.push_back("' '");
+
+		hl.line_comment = "#";
+
+		String pykeywords [] = {
+			".", ":", "[", "alias", "bg", "bind", "break", "builtin", "caller",
+			"cd", "ls", "mkdir", "command", "compgen", "complete", "compopt",
+			"dirs", "disown", "echo", "enable", "eval", "exec", "exit", "export",
+			"false", "fc", "fg", "getopts", "hash", "help", "history", "jobs",
+			"kill", "let", "local", "logout", "mapfile", "popd", "printf", "pushd",
+			"pwd", "read", "readarray", "readonly", "return", "set", "shift",
+			"shopt", "source", "suspend", "test", "times", "trap", "true", "type",
+			"typeset", "ulimit", "umask", "unalias", "unset", "wait", "if", "then",
+			"else", "elif", "fi", "case", "esac", "for", "select", "while", "until",
+			"do", "done", "in", "function", "time", "{", "}", "!", "[[", "]]",
+			"coproc", "continue", "declare"
+		};
+		for (size_t i=0; i < sizeof (pykeywords) / sizeof (String); i++) {
+			hl.keywords.push_back(pykeywords[i]);
+		}
+	}
+	return hl;
+}
+
+void RawTextSourceEditor::_load_theme_settings() {
+
+	get_text_edit()->clear_colors();
+
+	Color font_color = EDITOR_DEF("text_editor/text_color",Color(0,0,0));
+	Color keyword_color= EDITOR_DEF("text_editor/keyword_color",Color(0.5,0.0,0.2));
+	Color comment_color = EDITOR_DEF("text_editor/comment_color",Color::hex(0x797e7eff));
+	Color string_color = EDITOR_DEF("text_editor/string_color",Color::hex(0x6b6f00ff));
+
+	get_text_edit()->add_color_override("font_color", font_color);
+	get_text_edit()->set_custom_bg_color(EDITOR_DEF("text_editor/background_color",Color(0,0,0,0)));
+	get_text_edit()->add_color_override("line_number_color",EDITOR_DEF("text_editor/line_number_color",Color(0,0,0)));
+	get_text_edit()->add_color_override("caret_color",EDITOR_DEF("text_editor/caret_color",Color(0,0,0)));
+	get_text_edit()->add_color_override("font_selected_color",EDITOR_DEF("text_editor/text_selected_color",Color(1,1,1)));
+	get_text_edit()->add_color_override("selection_color",EDITOR_DEF("text_editor/selection_color",Color(0.2,0.2,1)));
+	get_text_edit()->add_color_override("current_line_color",EDITOR_DEF("text_editor/current_line_color",Color(0.3,0.5,0.8,0.15)));
+	get_text_edit()->add_color_override("search_result_color",EDITOR_DEF("text_editor/search_result_color",Color(0.05,0.25,0.05,1)));
+	get_text_edit()->add_color_override("search_result_border_color",EDITOR_DEF("text_editor/search_result_border_color",Color(0.1,0.45,0.1,1)));
+	get_text_edit()->add_color_override("mark_color", EDITOR_DEF("text_editor/mark_color", Color(1.0,0.4,0.4,0.4)));
+	get_text_edit()->add_color_override("word_highlighted_color",EDITOR_DEF("text_editor/word_highlighted_color",Color(0.8,0.9,0.9,0.15)));
+
+	HighlightConfig hl = get_highlight(language);
+	if (hl.filled) {
+
+		// colorize code
+		get_text_edit()->add_color_override("brace_mismatch_color",EDITOR_DEF("text_editor/brace_mismatch_color",Color(1,0.2,0.2)));
+		get_text_edit()->add_color_override("number_color",EDITOR_DEF("text_editor/number_color",Color(0.9,0.6,0.0,2)));
+		get_text_edit()->add_color_override("function_color",EDITOR_DEF("text_editor/function_color",Color(0.4,0.6,0.8)));
+		get_text_edit()->add_color_override("member_variable_color",EDITOR_DEF("text_editor/member_variable_color",Color(0.9,0.3,0.3)));
+		get_text_edit()->add_color_override("breakpoint_color", EDITOR_DEF("text_editor/breakpoint_color", Color(0.8,0.8,0.4,0.2)));
+
+		// colorize strings
+		for (List<String>::Element *E=hl.string_delimiters.front();E;E=E->next()) {
+			String string = E->get();
+			String beg = string.get_slice(" ",0);
+			String end = string.get_slice_count(" ")>1?string.get_slice(" ",1):String();
+			get_text_edit()->add_color_region(beg,end,string_color,end=="");
+		}
+
+		// colorize comments
+		if (hl.multi_line_comment_beg.length())
+			get_text_edit()->add_color_region(hl.multi_line_comment_beg, hl.multi_line_comment_end,comment_color,false);
+		if (hl.line_comment.length())
+			get_text_edit()->add_color_region(hl.line_comment,"",comment_color,false);
+
+		// colorize keywords
+		for(List<String>::Element *E=hl.keywords.front();E;E=E->next()) {
+			get_text_edit()->add_keyword_color(E->get(),keyword_color);
+		}
+
+		// colorize symbols
+		Color symbol_color= EDITOR_DEF("text_editor/symbol_color",Color::hex(0x005291ff));
+		get_text_edit()->set_symbol_color(symbol_color);
+	}
+	else {
+		get_text_edit()->add_color_override("brace_mismatch_color", font_color);
+		get_text_edit()->add_color_override("number_color", font_color);
+		get_text_edit()->add_color_override("function_color", font_color);
+		get_text_edit()->add_color_override("member_variable_color", font_color);
+		get_text_edit()->add_color_override("breakpoint_color",  font_color);
+		get_text_edit()->set_symbol_color(font_color);
+	}
+
+}
+
+void RawTextSourceEditor::_validate_script() {
+
+}
+
+
+void RawTextSourceEditor::_bind_methods() {
+
+}
+
+RawTextSourceEditor::RawTextSourceEditor() {
+}
+
+void RawTextEditor::_menu_option(int p_option) {
+
+	switch(p_option) {
+		case EDIT_UNDO: {
+			text_editor->get_text_edit()->undo();
+		} break;
+		case EDIT_REDO: {
+			text_editor->get_text_edit()->redo();
+
+		} break;
+		case EDIT_CUT: {
+
+			text_editor->get_text_edit()->cut();
+		} break;
+		case EDIT_COPY: {
+			text_editor->get_text_edit()->copy();
+
+		} break;
+		case EDIT_PASTE: {
+			text_editor->get_text_edit()->paste();
+
+		} break;
+		case EDIT_SELECT_ALL: {
+
+			text_editor->get_text_edit()->select_all();
+
+		} break;
+		case SEARCH_FIND: {
+
+			text_editor->get_find_replace_bar()->popup_search();
+		} break;
+		case SEARCH_FIND_NEXT: {
+
+			text_editor->get_find_replace_bar()->search_next();
+		} break;
+		case SEARCH_FIND_PREV: {
+
+			text_editor->get_find_replace_bar()->search_prev();
+		} break;
+		case SEARCH_REPLACE: {
+
+			text_editor->get_find_replace_bar()->popup_replace();
+		} break;
+		case SEARCH_GOTO_LINE: {
+			goto_line_dialog->popup_find_line(text_editor->get_text_edit());
+		} break;
+
+	}
+}
+
+void RawTextEditor::_notification(int p_what) {
+
+	if (p_what==NOTIFICATION_ENTER_TREE) {
+
+		close->set_normal_texture( get_icon("Close","EditorIcons"));
+		close->set_hover_texture( get_icon("CloseHover","EditorIcons"));
+		close->set_pressed_texture( get_icon("Close","EditorIcons"));
+		close->connect("pressed",this,"_close_callback");
+
+	}
+	if (p_what==NOTIFICATION_DRAW) {
+
+		RID ci = get_canvas_item();
+		Ref<StyleBox> style = get_stylebox("panel","Panel");
+		style->draw( ci, Rect2( Point2(), get_size() ) );
+
+	}
+
+}
+
+Dictionary RawTextEditor::get_state() const {
+	return Dictionary();
+}
+
+void RawTextEditor::set_state(const Dictionary& p_state) {
+
+}
+
+void RawTextEditor::clear() {
+	text_editor->get_text_edit()->set_text("");
+}
+
+void RawTextEditor::_text_changed() {
+	text_editor->_validate_script();
+	apply_text();
+}
+
+void RawTextEditor::_highlight_selected(int lang) {
+	String langs = "";
+
+	switch (lang) {
+		case HighlightConfig::LANG_CPP:
+			langs = "cpp";
+			break;
+		case HighlightConfig::LANG_CSHARP:
+			langs = "cs";
+			break;
+		case HighlightConfig::LANG_CSS:
+			langs = "css";
+			break;
+		case HighlightConfig::LANG_JAVASCRIPT:
+			langs = "js";
+			break;
+		case HighlightConfig::LANG_JSON:
+			langs = "json";
+			break;
+		case HighlightConfig::LANG_PYTHON:
+			langs = "py";
+			break;
+		case HighlightConfig::LANG_XML:
+			langs = "xml";
+			break;
+		case HighlightConfig::LANG_SHELL:
+			langs = "sh";
+			break;
+		case HighlightConfig::LANG_TOML:
+			langs = "toml";
+			break;
+		case HighlightConfig::LANG_YAML:
+			langs = "yaml";
+			break;
+		case HighlightConfig::LANG_NONE:
+		default:
+			langs = "txt";
+			break;
+	}
+
+	text_editor->set_highlight_language(langs);
+}
+
+void RawTextEditor::_editor_settings_changed() {
+
+	text_editor->get_text_edit()->set_auto_brace_completion(EditorSettings::get_singleton()->get("text_editor/auto_brace_complete"));
+	text_editor->get_text_edit()->set_scroll_pass_end_of_file(EditorSettings::get_singleton()->get("text_editor/scroll_past_end_of_file"));
+	text_editor->get_text_edit()->set_tab_size(EditorSettings::get_singleton()->get("text_editor/tab_size"));
+	text_editor->get_text_edit()->set_draw_tabs(EditorSettings::get_singleton()->get("text_editor/draw_tabs"));
+	text_editor->get_text_edit()->set_show_line_numbers(EditorSettings::get_singleton()->get("text_editor/show_line_numbers"));
+	text_editor->get_text_edit()->set_syntax_coloring(EditorSettings::get_singleton()->get("text_editor/syntax_highlighting"));
+	text_editor->get_text_edit()->set_highlight_all_occurrences(EditorSettings::get_singleton()->get("text_editor/highlight_all_occurrences"));
+	text_editor->get_text_edit()->cursor_set_blink_enabled(EditorSettings::get_singleton()->get("text_editor/caret_blink"));
+	text_editor->get_text_edit()->cursor_set_blink_speed(EditorSettings::get_singleton()->get("text_editor/caret_blink_speed"));
+	text_editor->get_text_edit()->add_constant_override("line_spacing", EditorSettings::get_singleton()->get("text_editor/line_spacing"));
+
+}
+
+void RawTextEditor::_update_lang_option() {
+	String extension = text->get_path().extension();
+
+	if (extension == "json")
+		lang_option->select(HighlightConfig::LANG_JSON);
+	else if (extension == "xml" || extension == "html" || extension == "htm" || extension == "xhtml")
+		lang_option->select(HighlightConfig::LANG_XML);
+	else if (extension == "yml" || extension == "yaml")
+		lang_option->select(HighlightConfig::LANG_YAML);
+	else if (extension == "sh" || extension == "bash")
+		lang_option->select(HighlightConfig::LANG_SHELL);
+	else if (extension == "cfg" || extension == "toml" || extension == "ini" )
+		lang_option->select(HighlightConfig::LANG_TOML);
+	else if (extension == "c++" || extension == "cxx" || extension == "cpp" || extension == "h" || extension == "hpp")
+		lang_option->select(HighlightConfig::LANG_CPP);
+	else if (extension == "py")
+		lang_option->select(HighlightConfig::LANG_PYTHON);
+	else if(extension == "js")
+		lang_option->select(HighlightConfig::LANG_JAVASCRIPT);
+	else if(extension == "cs")
+		lang_option->select(HighlightConfig::LANG_CSHARP);
+	else if(extension == "css")
+		lang_option->select(HighlightConfig::LANG_CSS);
+	else
+		lang_option->select(HighlightConfig::LANG_NONE);
+
+}
+
+void RawTextEditor::_update_title() {
+
+	String title = text->get_path();
+	if (title.length() == 0)
+		title = "Untitled";
+	title_label->set_text(title);
+}
+
+void RawTextEditor::_bind_methods() {
+
+	ObjectTypeDB::bind_method("_editor_settings_changed",&RawTextEditor::_editor_settings_changed);
+	ObjectTypeDB::bind_method("_menu_option",&RawTextEditor::_menu_option);
+	ObjectTypeDB::bind_method("_close_callback",&RawTextEditor::_close_callback);
+	ObjectTypeDB::bind_method("_text_changed",&RawTextEditor::_text_changed);
+	ObjectTypeDB::bind_method(_MD("_highlight_selected","lang"),&RawTextEditor::_highlight_selected);
+	ObjectTypeDB::bind_method("apply_text",&RawTextEditor::apply_text);
+}
+
+void RawTextEditor::ensure_select_current() {
+
+}
+
+void RawTextEditor::edit(const Ref<RawText>& p_text) {
+
+	if (p_text.is_null())
+		return;
+
+	text=p_text;
+	text_editor->set_edited_text(text);
+
+	_update_title();
+	_update_lang_option();
+}
+
+void RawTextEditor::save_external_data() {
+
+	if (text.is_null())
+		return;
+	apply_text();
+
+	if (text->get_path()!="" && text->get_path().find("local://")==-1 &&text->get_path().find("::")==-1) {
+		//external text, save it
+		ResourceSaver::save(text->get_path(),text);
+	}
+}
+
+void RawTextEditor::apply_text()  {
+
+	if (text.is_valid()) {
+		text->set_text(text_editor->get_text_edit()->get_text());
+		text->set_edited(true);
+	}
+}
+
+void RawTextEditor::_close_callback() {
+
+	hide();
+}
+
+
+RawTextEditor::RawTextEditor() {
+
+	VBoxContainer* container = memnew(VBoxContainer);
+	add_child(container);
+	container->set_area_as_parent_rect();
+	container->set_begin(Point2(0,0));
+
+	Control * menuspacer = memnew(Control);
+	menuspacer->set_custom_minimum_size(Size2(0,5));
+	container->add_child(menuspacer);
+
+	HBoxContainer * menubar = memnew(HBoxContainer);
+	container->add_child(menubar);
+	menubar->set_h_size_flags(SIZE_EXPAND_FILL);
+
+	edit_menu = memnew( MenuButton );
+	menubar->add_child(edit_menu);
+	edit_menu->set_pos(Point2(5,-1));
+	edit_menu->set_text(TTR("Edit"));
+	edit_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/undo", TTR("Undo"), KEY_MASK_CMD|KEY_Z), EDIT_UNDO);
+	edit_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/redo", TTR("Redo"), KEY_MASK_CMD|KEY_MASK_SHIFT|KEY_Z), EDIT_REDO);
+	edit_menu->get_popup()->add_separator();
+	edit_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/cut", TTR("Cut"), KEY_MASK_CMD|KEY_X), EDIT_CUT);
+	edit_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/copy", TTR("Copy"), KEY_MASK_CMD|KEY_C), EDIT_COPY);
+	edit_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/paste", TTR("Paste"), KEY_MASK_CMD|KEY_V), EDIT_PASTE);
+	edit_menu->get_popup()->add_separator();
+	edit_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/select_all", TTR("Select All"), KEY_MASK_CMD|KEY_A), EDIT_SELECT_ALL);
+	edit_menu->get_popup()->connect("item_pressed", this,"_menu_option");
+
+
+	search_menu = memnew( MenuButton );
+	menubar->add_child(search_menu);
+	search_menu->set_pos(Point2(38,-1));
+	search_menu->set_text(TTR("Search"));
+	search_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/find", TTR("Find.."), KEY_MASK_CMD|KEY_F), SEARCH_FIND);
+	search_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/find_next", TTR("Find Next"), KEY_F3), SEARCH_FIND_NEXT);
+	search_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/find_previous", TTR("Find Previous"), KEY_MASK_SHIFT|KEY_F3), SEARCH_FIND_PREV);
+	search_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/replace", TTR("Replace.."), KEY_MASK_CMD|KEY_R), SEARCH_REPLACE);
+	search_menu->get_popup()->add_separator();
+//	search_menu->get_popup()->add_item("Locate Symbol..",SEARCH_LOCATE_SYMBOL,KEY_MASK_CMD|KEY_K);
+	search_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/goto_line", TTR("Goto Line.."), KEY_MASK_CMD|KEY_G), SEARCH_GOTO_LINE);
+	search_menu->get_popup()->connect("item_pressed", this,"_menu_option");
+
+	title_label = memnew( Label );
+	title_label->set_h_size_flags(SIZE_EXPAND_FILL);
+	title_label->set_align(Label::ALIGN_CENTER);
+	menubar->add_child(title_label);
+
+	lang_option = memnew( OptionButton );
+	menubar->add_child(lang_option);
+	lang_option->set_pos(Point2(0,10));
+	lang_option->add_item(TTR("Plain Text"), HighlightConfig::LANG_NONE);
+	lang_option->add_item(TTR("C/C++"), HighlightConfig::LANG_CPP);
+	lang_option->add_item(TTR("C#"), HighlightConfig::LANG_CSHARP);
+	lang_option->add_item(TTR("CSS"), HighlightConfig::LANG_CSS);
+	lang_option->add_item(TTR("JavaScript"), HighlightConfig::LANG_JAVASCRIPT);
+	lang_option->add_item(TTR("Json"), HighlightConfig::LANG_JSON);
+	lang_option->add_item(TTR("Python"), HighlightConfig::LANG_PYTHON);
+	lang_option->add_item(TTR("Shell"),  HighlightConfig::LANG_SHELL);
+	lang_option->add_item(TTR("TOML, INI"),  HighlightConfig::LANG_TOML);
+	lang_option->add_item(TTR("XML"), HighlightConfig::LANG_XML);
+	lang_option->add_item(TTR("YAML"), HighlightConfig::LANG_YAML);
+	lang_option->select(HighlightConfig::LANG_NONE);
+	lang_option->connect("item_selected", this, "_highlight_selected");
+
+	close = memnew( TextureButton );
+	menubar->add_child(close);
+
+	erase_tab_confirm = memnew( ConfirmationDialog );
+	add_child(erase_tab_confirm);
+	erase_tab_confirm->connect("confirmed", this,"_close_current_tab");
+
+	goto_line_dialog = memnew(GotoLineDialog);
+	add_child(goto_line_dialog);
+
+	text_editor = memnew( RawTextSourceEditor );
+	container->add_child(text_editor);
+	text_editor->set_h_size_flags(SIZE_EXPAND_FILL);
+	text_editor->set_v_size_flags(SIZE_EXPAND_FILL);
+	text_editor->get_text_edit()->connect("text_changed", this,"_text_changed");
+
+	EditorSettings::get_singleton()->connect("settings_changed",this,"_editor_settings_changed");
+	_editor_settings_changed();
+}
+
+
+void RawTextEditorPlugin::edit(Object *p_object) {
+
+	if (!p_object->cast_to<RawText>())
+		return;
+
+	text_editor->edit(p_object->cast_to<RawText>());
+}
+
+bool RawTextEditorPlugin::handles(Object *p_object) const {
+
+	return p_object->cast_to<RawText>() != NULL;
+}
+
+void RawTextEditorPlugin::make_visible(bool p_visible) {
+
+	if (p_visible) {
+		text_editor->show();
+	} else {
+		text_editor->apply_text();
+	}
+}
+
+void RawTextEditorPlugin::selected_notify() {
+
+	text_editor->ensure_select_current();
+}
+
+Dictionary RawTextEditorPlugin::get_state() const {
+
+	return text_editor->get_state();
+}
+
+void RawTextEditorPlugin::set_state(const Dictionary& p_state) {
+
+	text_editor->set_state(p_state);
+}
+void RawTextEditorPlugin::clear() {
+
+	text_editor->clear();
+}
+
+void RawTextEditorPlugin::save_external_data() {
+
+	text_editor->save_external_data();
+}
+
+void RawTextEditorPlugin::apply_changes() {
+
+	text_editor->apply_text();
+
+}
+
+RawTextEditorPlugin::RawTextEditorPlugin(EditorNode *p_node, bool p_2d) {
+
+	editor=p_node;
+	text_editor = memnew( RawTextEditor );
+	if (p_2d)
+		add_control_to_container(CONTAINER_CANVAS_EDITOR_BOTTOM,text_editor);
+	else
+		add_control_to_container(CONTAINER_SPATIAL_EDITOR_BOTTOM,text_editor);
+	text_editor->hide();
+
+}
+
+
+RawTextEditorPlugin::~RawTextEditorPlugin() {
+
+}

--- a/tools/editor/plugins/raw_text_editor_plugin.h
+++ b/tools/editor/plugins/raw_text_editor_plugin.h
@@ -1,0 +1,176 @@
+/*************************************************************************/
+/*  raw_text_editor_plugin.h                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2016 Juan Linietsky, Ariel Manzur.                 */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#ifndef RAWTEXT_EDITOR_PLUGIN_H
+#define RAWTEXT_EDITOR_PLUGIN_H
+
+#include "tools/editor/code_editor.h"
+#include "tools/editor/editor_plugin.h"
+#include "scene/gui/tab_container.h"
+#include "scene/gui/text_edit.h"
+#include "scene/gui/label.h"
+#include "scene/gui/menu_button.h"
+#include "scene/gui/option_button.h"
+#include "scene/main/timer.h"
+#include "scene/resources/raw_text.h"
+
+struct HighlightConfig {
+	enum {
+		LANG_NONE,
+		LANG_CPP,
+		LANG_CSHARP,
+		LANG_CSS,
+		LANG_JAVASCRIPT,
+		LANG_JSON,
+		LANG_PYTHON,
+		LANG_SHELL,
+		LANG_TOML,
+		LANG_XML,
+		LANG_YAML,
+	};
+	String line_comment;
+	String multi_line_comment_beg;
+	String multi_line_comment_end;
+	List<String> string_delimiters;
+	List<String> keywords;
+	bool filled;
+};
+
+class RawTextSourceEditor : public CodeTextEditor {
+
+	OBJ_TYPE( RawTextSourceEditor, CodeTextEditor );
+
+	friend class RawTextEditor;
+
+	Ref<RawText> text;
+
+protected:
+	String language;
+	virtual void _validate_script();
+	static void _bind_methods();
+	virtual void _load_theme_settings();
+	HighlightConfig get_highlight(const String& extension);
+
+public:
+
+	Ref<RawText>& get_edited_text();
+	void set_edited_text(const Ref<RawText>& p_text);
+	void set_highlight_language(const String& lang);
+	RawTextSourceEditor();
+	virtual ~RawTextSourceEditor() {}
+};
+
+
+class RawTextEditor : public Control {
+
+	OBJ_TYPE(RawTextEditor, Control );
+
+	enum {
+
+		EDIT_UNDO,
+		EDIT_REDO,
+		EDIT_CUT,
+		EDIT_COPY,
+		EDIT_PASTE,
+		EDIT_SELECT_ALL,
+		SEARCH_FIND,
+		SEARCH_FIND_NEXT,
+		SEARCH_FIND_PREV,
+		SEARCH_REPLACE,
+		SEARCH_GOTO_LINE,
+	};
+	mutable Ref<RawText> text;
+	MenuButton *edit_menu;
+	MenuButton *search_menu;
+	MenuButton *settings_menu;
+	Label *title_label;
+	OptionButton *lang_option;
+	uint64_t idle;
+
+	GotoLineDialog *goto_line_dialog;
+	ConfirmationDialog *erase_tab_confirm;
+
+	TextureButton *close;
+
+	RawTextSourceEditor *text_editor;
+
+	void _menu_option(int p_optin);
+	void _close_callback();
+	void _editor_settings_changed();
+	void _update_lang_option();
+	void _update_title();
+
+protected:
+	void _text_changed();
+	void _highlight_selected(int);
+	void _notification(int p_what);
+	static void _bind_methods();
+public:
+
+	void apply_text();
+
+	void ensure_select_current();
+	void edit(const Ref<RawText>& p_text);
+
+	Dictionary get_state() const;
+	void set_state(const Dictionary& p_state);
+	void clear();
+
+	virtual Size2 get_minimum_size() const { return Size2(0,300); }
+	void save_external_data();
+
+	RawTextEditor();
+};
+
+class RawTextEditorPlugin : public EditorPlugin {
+
+	OBJ_TYPE( RawTextEditorPlugin, EditorPlugin );
+
+	RawTextEditor *text_editor;
+	EditorNode *editor;
+public:
+
+	virtual String get_name() const { return "RawText"; }
+	bool has_main_screen() const { return false; }
+	virtual void edit(Object *p_node);
+	virtual bool handles(Object *p_node) const;
+	virtual void make_visible(bool p_visible);
+	virtual void selected_notify();
+
+	Dictionary get_state() const;
+	virtual void set_state(const Dictionary& p_state);
+	virtual void clear();
+
+	virtual void save_external_data();
+	virtual void apply_changes();
+
+	RawTextEditorPlugin(EditorNode *p_node, bool p_2d);
+	~RawTextEditorPlugin();
+
+};
+#endif


### PR DESCRIPTION
Add `RawText` to handle text files as resources.
Add RawTextEditorPlugin to edit text files with code highlight.
![](https://cdn.rawgit.com/Geequlim/depot/master/images/godot/raw_texte_ditor.png)

Supported code highlight:
- Bash Shell
- C/C++
- C#
- CSS
- JSON
- Javascript/ECMAScript 6
- Python
- INI/TOML configuration files
- XML _When `XML_ENABLED` is not defined_
- YAML
