### PR TITLE
correct current Intent for android

### DIFF
--- a/platform/android/java/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/src/org/godotengine/godot/Godot.java
@@ -115,7 +115,17 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
     private int mState;
 	private boolean keep_screen_on=true;
 
-    private void setState(int newState) {
+	static private Intent mCurrentIntent;
+
+	@Override public void onNewIntent(Intent intent) {
+		mCurrentIntent = intent;
+	}
+
+	static public Intent getCurrentIntent() {
+		return mCurrentIntent;
+	}
+
+	private void setState(int newState) {
         if (mState != newState) {
             mState = newState;
             mStatusText.setText(Helpers.getDownloaderStringResourceIDFromState(newState));
@@ -544,6 +554,8 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 
 			}
 		}
+
+		mCurrentIntent = getIntent();
 
 		initializeGodot();
 


### PR DESCRIPTION
Push notification can have extra data in Intent.
You can get extra data with `activity.getIntent().getExtras()`.

Problem is `getIntent()` return first `Intent` that launched activity.

You can get app to foreground with push notification when app is in background.
In this case, the `Intent` that brings to foreground with push notification is not the same as first `Intent`.
You can not get `getExtras()` properly with this new `Intent` by doing `activity.getIntent().getExtras()`.
So, current intent should be updated.
