### PR TITLE
Fixed caret not drawing on focus regain

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1209,6 +1209,9 @@ void TextEdit::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_FOCUS_ENTER: {
 
+			if (!caret_blink_enabled) {
+				draw_caret = true;
+			}
 			if (OS::get_singleton()->has_virtual_keyboard())
 				OS::get_singleton()->show_virtual_keyboard(get_text(),get_global_rect());
 


### PR DESCRIPTION
Fixed caret not drawing on focus regain, when caret blink is disabled.

closes #5320 
