### PR TITLE
Added caret blink to line edit

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -18895,6 +18895,34 @@ Example: (content-length:12), (Content-Type:application/json; charset=UTF-8)
 			Set the cursor position inside the [LineEdit], causing it to scroll if needed.
 			</description>
 		</method>
+		<method name="cursor_set_blink_enabled">
+			<argument index="0" name="enable" type="bool">
+			</argument>
+			<description>
+			Set the line edit caret to blink.
+			</description>
+		</method>
+		<method name="cursor_get_blink_enabled" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+			Gets whether the line edit caret is blinking.
+			</description>
+		</method>
+		<method name="cursor_set_blink_speed">
+			<argument index="0" name="blink_speed" type="float">
+			</argument>
+			<description>
+			Set the line edit caret blink speed. Cannot be less then or equal to 0.
+			</description>
+		</method>
+		<method name="cursor_get_blink_speed" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+			Gets the line edit caret blink speed.
+			</description>
+		</method>
 		<method name="set_editable">
 			<argument index="0" name="enabled" type="bool">
 			</argument>

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -550,7 +550,21 @@ void LineEdit::_notification(int p_what) {
 			set_cursor_pos( get_cursor_pos() );
 
 		} break;
+		case MainLoop::NOTIFICATION_WM_FOCUS_IN: {
+			window_has_focus = true;
+			draw_caret = true;
+			update();
+		} break;
+		case MainLoop::NOTIFICATION_WM_FOCUS_OUT: {
+			window_has_focus = false;
+			draw_caret = false;
+			update();
+		} break;
 		case NOTIFICATION_DRAW: {
+
+			if ((!has_focus() && !menu->has_focus()) || !window_has_focus) {
+				draw_caret = false;
+			}
 
 			int width,height;
 
@@ -643,6 +657,10 @@ void LineEdit::_notification(int p_what) {
 			}
 		} break;
 		case NOTIFICATION_FOCUS_ENTER: {
+
+			if (!caret_blink_enabled) {
+				draw_caret = true;
+			}
 
 			if (OS::get_singleton()->has_virtual_keyboard())
 				OS::get_singleton()->show_virtual_keyboard(get_text(),get_global_rect());
@@ -1228,6 +1246,7 @@ LineEdit::LineEdit() {
 	cached_width = 0;
 	cursor_pos=0;
 	window_pos=0;
+	window_has_focus=true;
 	max_length = 0;
 	pass=false;
 

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -31,6 +31,9 @@
 #include "os/os.h"
 #include "print_string.h"
 #include "label.h"
+#ifdef TOOLS_ENABLED
+#include "tools/editor/editor_settings.h"
+#endif
 
 static bool _is_text_char(CharType c) {
 
@@ -544,7 +547,16 @@ void LineEdit::drop_data(const Point2& p_point,const Variant& p_data){
 void LineEdit::_notification(int p_what) {
 
 	switch(p_what) {
+#ifdef TOOLS_ENABLED
+		case NOTIFICATION_ENTER_TREE: {
+			if (get_tree()->is_editor_hint()) {
+				cursor_set_blink_enabled(EDITOR_DEF("text_editor/caret_blink", false));
+				cursor_set_blink_speed(EDITOR_DEF("text_editor/caret_blink_speed", 0.65));
 
+				EditorSettings::get_singleton()->connect("settings_changed",this,"_editor_settings_changed");
+			}
+		} break;
+#endif
 		case NOTIFICATION_RESIZED: {
 
 			set_cursor_pos( get_cursor_pos() );
@@ -1185,9 +1197,20 @@ PopupMenu *LineEdit::get_menu() const {
 	return menu;
 }
 
+#ifdef TOOLS_ENABLED
+	void LineEdit::_editor_settings_changed() {
+		cursor_set_blink_enabled(EDITOR_DEF("text_editor/caret_blink", false));
+		cursor_set_blink_speed(EDITOR_DEF("text_editor/caret_blink_speed", 0.65));
+	}
+#endif
+
 void LineEdit::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("_toggle_draw_caret"),&LineEdit::_toggle_draw_caret);
+
+#ifdef TOOLS_ENABLED
+	ObjectTypeDB::bind_method("_editor_settings_changed",&LineEdit::_editor_settings_changed);
+#endif
 
 	ObjectTypeDB::bind_method(_MD("set_align", "align"), &LineEdit::set_align);
 	ObjectTypeDB::bind_method(_MD("get_align"), &LineEdit::get_align);

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -108,7 +108,9 @@ private:
 	void clear_internal();
 	void changed_internal();
 
-
+#ifdef TOOLS_ENABLED
+	void _editor_settings_changed();
+#endif
 
 	void _input_event(InputEvent p_event);
 	void _notification(int p_what);

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -87,6 +87,10 @@ private:
 		bool drag_attempt;
 	} selection;
 
+	Timer *caret_blink_timer;
+	bool caret_blink_enabled;
+	bool draw_caret;
+
 	void shift_selection_check_pre(bool);
 	void shift_selection_check_post(bool);
 
@@ -96,6 +100,9 @@ private:
 	void set_window_pos(int p_pos);
 
 	void set_cursor_at_pixel_pos(int p_x);
+
+	void _reset_caret_blink_timer();
+	void _toggle_draw_caret();
 
 	void clear_internal();
 	void changed_internal();
@@ -131,6 +138,12 @@ public:
 	int get_max_length() const;
 	void append_at_cursor(String p_text);
 	void clear();
+
+	bool cursor_get_blink_enabled() const;
+	void cursor_set_blink_enabled(const bool p_enabled);
+
+	float cursor_get_blink_speed() const;
+	void cursor_set_blink_speed(const float p_speed);
 
 	void copy_text();
 	void cut_text();

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -90,6 +90,7 @@ private:
 	Timer *caret_blink_timer;
 	bool caret_blink_enabled;
 	bool draw_caret;
+	bool window_has_focus;
 
 	void shift_selection_check_pre(bool);
 	void shift_selection_check_post(bool);


### PR DESCRIPTION
Added caret blink to line edit, and exposed to gdscript. It's currently off by default.

It currently shares the setting with the text_editor. 

closes #3094
