### PR TITLE
Object: get_signal_connection_list fixed

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1320,14 +1320,16 @@ Array Object::_get_signal_connection_list(const String& p_signal) const{
 	for (List<Connection>::Element *E=conns.front();E;E=E->next()) {
 
 		Connection &c=E->get();
-		Dictionary rc;
-		rc["signal"]=c.signal;
-		rc["method"]=c.method;
-		rc["source"]=c.source;
-		rc["target"]=c.target;
-		rc["binds"]=c.binds;
-		rc["flags"]=c.flags;
-		ret.push_back(rc);
+		if (c.signal == p_signal){
+			Dictionary rc;
+			rc["signal"]=c.signal;
+			rc["method"]=c.method;
+			rc["source"]=c.source;
+			rc["target"]=c.target;
+			rc["binds"]=c.binds;
+			rc["flags"]=c.flags;
+			ret.push_back(rc);
+		}
 	}
 
 	return ret;


### PR DESCRIPTION
now returns only the connections for the signal argument, as specified
fixes #5329
