### PR TITLE
Make return value explicit

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2082,7 +2082,7 @@ void Node::update_configuration_warning() {
 }
 
 bool Node::is_owned_by_parent() const {
-	data.parent_owned;
+	return data.parent_owned;
 }
 
 void Node::_bind_methods() {


### PR DESCRIPTION
Makes this method explictly return a value. Fixes compiler error in Visual Studio.
