### PR TITLE
Meaningful names for built-in scripts

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -947,10 +947,23 @@ void Object::set_script(const RefPtr& p_script) {
 		script_instance=NULL;
 	}
 
+#ifdef TOOLS_ENABLED
+	if (!script.is_null()) {
+		Ref<Script> s(script);
+		s->set_owner(nullptr);
+	}
+#endif
+
 	script=p_script;
 	Ref<Script> s(script);
 
 	if (!s.is_null() && s->can_instance() ) {
+#ifdef TOOLS_ENABLED
+		// If an internal script, record its owner
+		if (s->get_path()=="" || s->get_path().find("local://")!=-1 || s->get_path().find("::")!=-1) {
+			s->set_owner(this);
+		}
+#endif
 		OBJ_DEBUG_LOCK
 		script_instance = s->instance_create(this);
 
@@ -1828,6 +1841,13 @@ Object::~Object() {
 	if (script_instance)
 		memdelete(script_instance);
 	script_instance=NULL;
+
+#ifdef TOOLS_ENABLED
+	if (!script.is_null()) {
+		Ref<Script> s(script);
+		s->set_owner(nullptr);
+	}
+#endif
 
 
 	List<Connection> sconnections;

--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -27,6 +27,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include "script_language.h"
+#include "scene/main/node.h"
 
 ScriptLanguage *ScriptServer::_languages[MAX_LANGUAGES];
 int ScriptServer::_language_count=0;
@@ -54,6 +55,17 @@ void Script::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("reload","keep_state"),&Script::reload,DEFVAL(false));
 
 }
+
+void Script::set_owner(Object* p_owner) {
+
+	owner=p_owner;
+}
+
+Object* Script::get_owner() {
+	
+	return owner;
+}
+
 
 void ScriptServer::set_scripting_enabled(bool p_enabled) {
 

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -64,6 +64,7 @@ public:
 
 
 
+class Node;
 class ScriptInstance;
 class PlaceHolderScriptInstance;
 
@@ -71,6 +72,8 @@ class Script : public Resource {
 
 	OBJ_TYPE( Script, Resource );
 	OBJ_SAVE_TYPE( Script );
+
+	Object* owner;
 
 protected:
 
@@ -105,6 +108,9 @@ public:
 	virtual bool get_property_default_value(const StringName& p_property,Variant& r_value) const=0;
 
 	virtual void update_exports() {} //editor tool
+
+	void set_owner(Object* owner);
+	Object* get_owner();
 
 
 	Script() {}

--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -425,7 +425,13 @@ String ScriptTextEditor::get_name()  {
 		}
 	} else if (script->get_name()!="")
 		name=script->get_name();
-	else
+	else {
+		Node* owner_node = script->get_owner()->cast_to<Node>();
+		if (owner_node)
+			name=(String)owner_node->get_name()+" <"+TTR("Built-In")+">";
+	}
+
+	if (name.length()==0)
 		name=script->get_type()+"("+itos(script->get_instance_ID())+")";
 
 	return name;


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/11797174/16260267/ec95f43e-3866-11e6-9f62-4107e7739f86.png)

After:
![after](https://cloud.githubusercontent.com/assets/11797174/16260269/f1915fe6-3866-11e6-9bc1-833964dc2456.png)

Every object now will keep a pointer to the script attached to it in case it is internal (built-in). That way the script editor can show a meaningful name for it in the open scripts list. That is, instead of the cryptic and difficult to identify `GDScript(NNNNN)` now it will appear as `OwnerNodeName <Built-In>`.

User still has the option of giving an explicit name to the internal script resource and it will appear instead, but this change makes it a lot less needed.

The naming algorithm still will have to resort to the old notation in cases when the owner object is no longer present; e.g., when the scene has been closed but the script is still open in the editor.

Overall this makes easier to work with built-in scripts. I find them more convenient when a small amount of code is needed for a node in order to balance filesystem pollution against scene file complexity.
