### PR TITLE
Added alert() functionality for OS X

### DIFF
--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -142,6 +142,8 @@ public:
 
 	virtual String get_name();
 
+	virtual void alert(const String& p_alert, const String& p_title="ALERT!");
+
 	virtual void set_cursor_shape(CursorShape p_shape);
 
 	virtual void set_mouse_show(bool p_show);

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1209,6 +1209,22 @@ String OS_OSX::get_name() {
 	return "OSX";
 }
 
+void OS_OSX::alert(const String& p_alert, const String& p_title) {
+	// Set OS X-compliant variables
+	NSAlert *window = [[NSAlert alloc] init];
+	NSString *ns_title = [NSString stringWithUTF8String:p_title.utf8().get_data()];
+	NSString *ns_alert = [NSString stringWithUTF8String:p_alert.utf8().get_data()];
+
+	[window addButtonWithTitle:@"OK"];
+	[window setMessageText:ns_title];
+	[window setInformativeText:ns_alert];
+	[window setAlertStyle:NSWarningAlertStyle];
+
+	// Display it, then release
+	[window runModal];
+	[window release];
+}
+
 void OS_OSX::set_cursor_shape(CursorShape p_shape) {
 
 	if (cursor_shape==p_shape)


### PR DESCRIPTION
Fills in the blank for OS X, since the `alert()` seemingly didn’t do anything (it actually printed something to `stderr`, which could go undetected).
