### PR TITLE
Make editor compatible with Windows high contrast themes

### DIFF
--- a/platform/windows/godot.manifest
+++ b/platform/windows/godot.manifest
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <!-- Windows 10 -->
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+            <!-- Windows 8.1 -->
+            <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+            <!-- Windows 8 -->
+            <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+            <!-- Windows 7 -->
+            <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+            <!-- Windows Vista -->
+            <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+        </application>
+    </compatibility>
+</assembly>

--- a/platform/windows/godot_res.rc
+++ b/platform/windows/godot_res.rc
@@ -1,3 +1,4 @@
+#include <winuser.h>
 #include "core/version.h"
 #ifndef _STR
 #define _STR(m_x) #m_x
@@ -5,6 +6,8 @@
 #endif
 
 GODOT_ICON ICON platform/windows/godot.ico
+
+CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST platform/windows/godot.manifest
 
 1 VERSIONINFO
 FILEVERSION    	VERSION_MAJOR,VERSION_MINOR,0,0


### PR DESCRIPTION
By providing a manifest specifying the targeted Windows versions (as per [this document](https://msdn.microsoft.com/en-us/library/windows/desktop/hh404233%28v=vs.85%29.aspx#_______supporting_high_contrast_themes_in_windows_8_and_later)) **now the Godot editor renders normally under a high contrast theme on Windows**, instead of staying white/black.
