### PR TITLE
fix Globals::localize_path

### DIFF
--- a/core/globals.cpp
+++ b/core/globals.cpp
@@ -90,6 +90,8 @@ String Globals::localize_path(const String& p_path) const {
 		if (plocal == "") {
 			return "";
 		};
+		if (plocal.find("res:/") != -1 && (plocal.find("res://") == -1))
+			plocal = plocal.replace("res:/", "res://");
 		return plocal + path.substr(sep, path.size() - sep);
 	};
 


### PR DESCRIPTION
fix Globals::localize_path, on windows platform, path of editor_settings.tres is:
res:/Users/USERNAME/AppData/Roaming/Godot/editor_settings.tres
this path can't open correct, fix it to
res://Users/USERNAME/AppData/Roaming/Godot/editor_settings.tres
