### PR TITLE
Fix weird deselection behaviour with text field

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -294,6 +294,9 @@ void LineEdit::_input_event(InputEvent p_event) {
 					}
 					case KEY_LEFT: {
 
+#ifndef APPLE_STYLE_KEYS
+						if (!k.mod.alt)
+#endif
 						shift_selection_check_pre(k.mod.shift);
 
 #ifdef APPLE_STYLE_KEYS

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2065,6 +2065,12 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 
 					if (k.mod.shift)
 						_pre_shift_selection();
+#ifdef APPLE_STYLE_KEYS
+					else
+#else
+					else if (!k.mod.alt)
+#endif
+						deselect();
 
 #ifdef APPLE_STYLE_KEYS
 					if (k.mod.command) {
@@ -2118,6 +2124,12 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 
 					if (k.mod.shift)
 						_pre_shift_selection();
+#ifdef APPLE_STYLE_KEYS
+					else
+#else
+					else if (!k.mod.alt)
+#endif
+						deselect();
 
 #ifdef APPLE_STYLE_KEYS
 					if (k.mod.command) {


### PR DESCRIPTION
- TextEdit will now deselect if Ctrl+Left/Right is pressed.
- TextEdit and LineEdit no longer deselect text when Alt is pressed (except with Apple style keys).

Fixes #5375
