### PR TITLE
Fix bug in String==StrRange comparison

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -257,13 +257,10 @@ bool String::operator==(const StrRange &p_range) const {
 		return true;
 
 	const CharType *c_str=p_range.c_str;
-
-	int l=length();
-
-	const CharType *dst = p_range.c_str;
+	const CharType *dst = &operator[](0);
 
 	/* Compare char by char */
-	for (int i=0;i<l;i++) {
+	for (int i=0;i<len;i++) {
 
 		if (c_str[i]!=dst[i])
 			return false;


### PR DESCRIPTION
It was comparing the StrRange with itself, always return true if both
were the same length.

Fix #3843.

My paranormal investigator skills are sharp, @reduz :laughing: 
