### PR TITLE
Add "bool" to GDScript reserverd keywords

### DIFF
--- a/modules/gdscript/gd_script.cpp
+++ b/modules/gdscript/gd_script.cpp
@@ -1709,6 +1709,7 @@ void GDScriptLanguage::get_reserved_words(List<String> *p_words) const  {
 		"false",
 		"float",
 		"int",
+		"bool",
 		"null",
 		"PI",
 		"self",


### PR DESCRIPTION
Noticed that "bool" wasn't highlighted when used like `export(bool) var is_xy = false`
