### PR TITLE
Fix string array parameter check with jni

### DIFF
--- a/platform/android/godot_android.cpp
+++ b/platform/android/godot_android.cpp
@@ -910,7 +910,7 @@ static Variant::Type get_jni_type(const String& p_type) {
 		{"java.lang.String",Variant::STRING},
 		{"[I",Variant::INT_ARRAY},
 		{"[F",Variant::REAL_ARRAY},
-		{"[java.lang.String",Variant::STRING_ARRAY},
+		{"[Ljava.lang.String;",Variant::STRING_ARRAY},
 		{NULL,Variant::NIL}
 	};
 
@@ -941,7 +941,7 @@ static const char* get_jni_sig(const String& p_type) {
 		{"java.lang.String","Ljava/lang/String;"},
 		{"[I","[I"},
 		{"[F","[F"},
-		{"[java.lang.String","[Ljava/lang/String;"},
+		{"[Ljava.lang.String;","[Ljava/lang/String;"},
 		{NULL,"V"}
 	};
 

--- a/platform/android/java_glue.cpp
+++ b/platform/android/java_glue.cpp
@@ -1563,7 +1563,7 @@ static Variant::Type get_jni_type(const String& p_type) {
 		{"[I",Variant::INT_ARRAY},
 		{"[B",Variant::RAW_ARRAY},
 		{"[F",Variant::REAL_ARRAY},
-		{"[java.lang.String",Variant::STRING_ARRAY},
+		{"[Ljava.lang.String;",Variant::STRING_ARRAY},
 		{"org.godotengine.godot.Dictionary", Variant::DICTIONARY},
 		{NULL,Variant::NIL}
 	};
@@ -1599,7 +1599,7 @@ static const char* get_jni_sig(const String& p_type) {
 		{"[I","[I"},
 		{"[B","[B"},
 		{"[F","[F"},
-		{"[java.lang.String","[Ljava/lang/String;"},
+		{"[Ljava.lang.String;","[Ljava/lang/String;"},
 		{NULL,"V"}
 	};
 


### PR DESCRIPTION
I checked String array parameter type in java_glue.cpp/Java_org_godotengine_godot_GodotLib_method

```
print_line("rawString = "+String(rawString));  // it prints "rawString = [Ljava.lang.String;"
```

so I changed type name `"[java.lang.String"` to `"[Ljava.lang.String;"` in `get_jni_type` and `get_jni_sig`.
And now it works String array parameter well.

It parses java `String[]` to `[Ljava.lang.Object;` before.
