### PR TITLE
Improve parallax mirroring algorithm

### DIFF
--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -92,23 +92,13 @@ void ParallaxLayer::set_base_offset_and_scale(const Point2& p_offset,float p_sca
 	Point2 new_ofs = ((orig_offset+p_offset)*motion_scale)*p_scale;
 
 	if (mirroring.x) {
-
-		while( new_ofs.x>=0) {
-			new_ofs.x -= mirroring.x*p_scale;
-		}
-		while(new_ofs.x < -mirroring.x*p_scale) {
-			new_ofs.x += mirroring.x*p_scale;
-		}
+		double den = mirroring.x*p_scale;
+		new_ofs.x = fmod(new_ofs.x,den) - (mirroring.x > 0 ? den : 0);
 	}
 
 	if (mirroring.y) {
-
-		while( new_ofs.y>=0) {
-			new_ofs.y -= mirroring.y*p_scale;
-		}
-		while(new_ofs.y < -mirroring.y*p_scale) {
-			new_ofs.y += mirroring.y*p_scale;
-		}
+		double den = mirroring.y*p_scale;
+		new_ofs.y = fmod(new_ofs.y,den) - (mirroring.y > 0 ? den : 0);
 	}
 
 


### PR DESCRIPTION
Replaces the iterative approach currently used by the standard fmod() function.
Also fixes infinite looping that happens when the mirroring value is negative. *

*: Negative mirroring can make things look better in the editor when your 2D game scrolls "backwards". For instance, if your level scrolls from bottom to top and you have placed a parallax layer so its bottom edge matches the bottom edge of the initial viewport, by setting a negative Y mirroring, the mirror piece will be placed above, on level space instead of outside. Not very important and achievable perhaps by transforms but at least we get rid of the infinite loop in case someone tries.
