### PR TITLE
VideoPlayer: Added started,paused,stopped,finished signals

### DIFF
--- a/drivers/theora/video_stream_theora.h
+++ b/drivers/theora/video_stream_theora.h
@@ -124,7 +124,7 @@ class VideoStreamPlaybackTheora : public VideoStreamPlayback {
 protected:
 
 	void clear();
-	
+
 public:
 
 	virtual void play();

--- a/scene/resources/video_stream.h
+++ b/scene/resources/video_stream.h
@@ -90,4 +90,3 @@ public:
 
 
 #endif
-


### PR DESCRIPTION
- fixes #5377
- started is emitted on play()
- paused is emitted when going from not paused state to paused state
- stopped is emitted when the stream was playing on a call to stop
- finished is emitted when the stream naturally stops(runs out)
- also cleaned up the files a bit, removed some unnecessary prints, changed some `fprintf(stderr` prints into `ERR_PRINT`
