### PR TITLE
Save all edited scenes when Runing (and auto-save is enabled).

### DIFF
--- a/tools/editor/editor_data.cpp
+++ b/tools/editor/editor_data.cpp
@@ -613,11 +613,14 @@ void EditorData::set_edited_scene(int p_idx){
 	current_edited_scene=p_idx;
 	//swap
 }
-Node* EditorData::get_edited_scene_root(){
-
-	ERR_FAIL_INDEX_V(current_edited_scene,edited_scene.size(),NULL);
-
-	return edited_scene[current_edited_scene].root;
+Node* EditorData::get_edited_scene_root(int p_idx){
+	if (p_idx < 0) {
+		ERR_FAIL_INDEX_V(current_edited_scene,edited_scene.size(),NULL);
+		return edited_scene[current_edited_scene].root;
+	} else {
+		ERR_FAIL_INDEX_V(p_idx,edited_scene.size(),NULL);
+		return edited_scene[p_idx].root;
+	}
 }
 void EditorData::set_edited_scene_root(Node* p_root) {
 
@@ -630,9 +633,14 @@ int EditorData::get_edited_scene_count() const {
 	return edited_scene.size();
 }
 
-void EditorData::set_edited_scene_version(uint64_t version) {
+void EditorData::set_edited_scene_version(uint64_t version, int scene_idx) {
 	ERR_FAIL_INDEX(current_edited_scene,edited_scene.size());
-	edited_scene[current_edited_scene].version=version;
+	if (scene_idx < 0) {
+		edited_scene[current_edited_scene].version=version;
+	} else {
+		ERR_FAIL_INDEX(scene_idx,edited_scene.size());
+		edited_scene[scene_idx].version=version;
+	}
 
 }
 
@@ -758,10 +766,15 @@ void EditorData::set_edited_scene_import_metadata(Ref<ResourceImportMetadata> p_
 
 }
 
-Ref<ResourceImportMetadata> EditorData::get_edited_scene_import_metadata() const{
+Ref<ResourceImportMetadata> EditorData::get_edited_scene_import_metadata(int idx) const{
 
 	ERR_FAIL_INDEX_V(current_edited_scene,edited_scene.size(),Ref<ResourceImportMetadata>());
-	return edited_scene[current_edited_scene].medatata;
+	if(idx<0) {
+		return edited_scene[current_edited_scene].medatata;
+	} else {
+		ERR_FAIL_INDEX_V(idx,edited_scene.size(),Ref<ResourceImportMetadata>());
+		return edited_scene[idx].medatata;
+	}
 }
 
 

--- a/tools/editor/editor_data.cpp
+++ b/tools/editor/editor_data.cpp
@@ -326,6 +326,13 @@ Dictionary EditorData::get_editor_states() const {
 
 }
 
+Dictionary EditorData::get_scene_editor_states(int p_idx) const
+{
+	ERR_FAIL_INDEX_V(p_idx,edited_scene.size(),Dictionary());
+	EditedScene es = edited_scene[p_idx];
+	return es.editor_states;
+}
+
 void EditorData::set_editor_states(const Dictionary& p_states) {
 
 	List<Variant> keys;

--- a/tools/editor/editor_data.h
+++ b/tools/editor/editor_data.h
@@ -156,6 +156,7 @@ public:
 	void paste_object_params(Object *p_object);
 
 	Dictionary get_editor_states() const;
+	Dictionary get_scene_editor_states(int p_idx) const;
 	void set_editor_states(const Dictionary& p_states);
 	void get_editor_breakpoints(List<String> *p_breakpoints);
 	void clear_editor_states();

--- a/tools/editor/editor_data.h
+++ b/tools/editor/editor_data.h
@@ -184,15 +184,15 @@ public:
 	void set_edited_scene(int p_idx);
 	void set_edited_scene_root(Node* p_root);
 	void set_edited_scene_import_metadata(Ref<ResourceImportMetadata> p_mdata);
-	Ref<ResourceImportMetadata> get_edited_scene_import_metadata() const;
+	Ref<ResourceImportMetadata> get_edited_scene_import_metadata(int p_idx = -1) const;
 	int get_edited_scene() const;
-	Node* get_edited_scene_root();
+	Node* get_edited_scene_root(int p_idx = -1);
 	int get_edited_scene_count() const;
 	String get_scene_title(int p_idx) const;
 	String get_scene_path(int p_idx) const;
 	String get_scene_type(int p_idx) const;
 	Ref<Script> get_scene_root_script(int p_idx) const;
-	void set_edited_scene_version(uint64_t version);
+	void set_edited_scene_version(uint64_t version, int p_scene_idx = -1);
 	uint64_t get_edited_scene_version() const;
 	uint64_t get_scene_version(int p_idx) const;
 	void clear_edited_scenes();

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -740,7 +740,7 @@ void EditorNode::_set_scene_metadata(const String& p_file, int p_idx) {
 	Ref<ConfigFile> cf;
 	cf.instance();
 
-	Dictionary md = editor_data.get_editor_states();
+	Dictionary md = editor_data.get_edited_scene()==p_idx?editor_data.get_editor_states():editor_data.get_scene_editor_states(p_idx);
 	List<Variant> keys;
 	md.get_key_list(&keys);
 
@@ -970,7 +970,7 @@ void EditorNode::_save_scene(String p_file, int idx) {
 
 	editor_data.apply_changes_in_editors();
 
-	_set_scene_metadata(p_file);
+	_set_scene_metadata(p_file,idx);
 
 
 	Ref<PackedScene> sdata;

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -725,9 +725,9 @@ void EditorNode::_get_scene_metadata(const String& p_file) {
 
 }
 
-void EditorNode::_set_scene_metadata(const String& p_file) {
+void EditorNode::_set_scene_metadata(const String& p_file, int p_idx) {
 
-	Node *scene = editor_data.get_edited_scene_root();
+	Node *scene = editor_data.get_edited_scene_root(p_idx);
 
 	if (!scene)
 		return;
@@ -954,9 +954,9 @@ void EditorNode::_save_scene_with_preview(String p_file) {
 }
 
 
-void EditorNode::_save_scene(String p_file) {
+void EditorNode::_save_scene(String p_file, int idx) {
 
-	Node *scene = editor_data.get_edited_scene_root();
+	Node *scene = editor_data.get_edited_scene_root(idx);
 
 	if (!scene) {
 
@@ -1001,7 +1001,7 @@ void EditorNode::_save_scene(String p_file) {
 		return;
 	}
 
-	sdata->set_import_metadata(editor_data.get_edited_scene_import_metadata());
+	sdata->set_import_metadata(editor_data.get_edited_scene_import_metadata(idx));
 	int flg=0;
 	if (EditorSettings::get_singleton()->get("on_save/compress_binary_resources"))
 		flg|=ResourceSaver::FLAG_COMPRESS;
@@ -1017,7 +1017,10 @@ void EditorNode::_save_scene(String p_file) {
 	if (err==OK) {
 		scene->set_filename( Globals::get_singleton()->localize_path(p_file) );
 		//EditorFileSystem::get_singleton()->update_file(p_file,sdata->get_type());
-		set_current_version(editor_data.get_undo_redo().get_version());
+		if (idx < 0 || idx == editor_data.get_edited_scene())
+			set_current_version(editor_data.get_undo_redo().get_version());
+		else
+			editor_data.set_edited_scene_version(0,idx);
 		_update_title();
 		_update_scene_tabs();
 	} else {
@@ -1805,7 +1808,6 @@ void EditorNode::_run(bool p_current,const String& p_custom) {
 	String args;
 
 
-
 	if (p_current || (editor_data.get_edited_scene_root() && p_custom==editor_data.get_edited_scene_root()->get_filename())) {
 
 		Node *scene = editor_data.get_edited_scene_root();
@@ -1828,12 +1830,7 @@ void EditorNode::_run(bool p_current,const String& p_custom) {
 
 		}
 
-		bool autosave = EDITOR_DEF("run/auto_save_before_running",true);
 
-		if (autosave) {
-
-			_menu_option(FILE_SAVE_SCENE);
-		}
 
 		if (run_settings_dialog->get_run_mode()==RunSettingsDialog::RUN_LOCAL_SCENE) {
 
@@ -1906,7 +1903,7 @@ void EditorNode::_run(bool p_current,const String& p_custom) {
 				_save_scene_with_preview(scene->get_filename());
 			}
 		}
-
+		_menu_option(FILE_SAVE_ALL_SCENES);
 		editor_data.save_editor_external_data();
 	}
 
@@ -2162,6 +2159,19 @@ void EditorNode::_menu_option_confirm(int p_option,bool p_confirmed) {
 
 		} break;
 
+		case FILE_SAVE_ALL_SCENES: {
+			for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
+				Node *scene = editor_data.get_edited_scene_root(i);
+				if (scene && scene->get_filename()!="") {
+					// save in background if in the script editor
+					if (i != editor_data.get_edited_scene() || _get_current_main_editor() == EDITOR_SCRIPT) {
+						_save_scene(scene->get_filename(), i);
+					} else {
+						_save_scene_with_preview(scene->get_filename());
+					}
+				}// else: ignore new scenes
+			}
+		} break;
 		case FILE_SAVE_BEFORE_RUN: {
 			if (!p_confirmed) {
 				accept->get_ok()->set_text(TTR("Yes"));
@@ -5643,6 +5653,7 @@ EditorNode::EditorNode() {
 	p->add_separator();
 	p->add_shortcut(ED_SHORTCUT("editor/save_scene",TTR("Save Scene"),KEY_MASK_CMD+KEY_S),FILE_SAVE_SCENE);
 	p->add_shortcut(ED_SHORTCUT("editor/save_scene_as",TTR("Save Scene As.."),KEY_MASK_SHIFT+KEY_MASK_CMD+KEY_S),FILE_SAVE_AS_SCENE);
+	p->add_shortcut(ED_SHORTCUT("editor/save_all_scenes",TTR("Save all Scenes"),KEY_MASK_ALT+KEY_MASK_SHIFT+KEY_MASK_CMD+KEY_S),FILE_SAVE_ALL_SCENES);
 	p->add_separator();
 	p->add_shortcut(ED_SHORTCUT("editor/close_scene",TTR("Close Scene"),KEY_MASK_SHIFT+KEY_MASK_CTRL+KEY_W),FILE_CLOSE);
 	p->add_separator();

--- a/tools/editor/editor_node.h
+++ b/tools/editor/editor_node.h
@@ -124,6 +124,7 @@ private:
 		FILE_OPEN_SCENE,
 		FILE_SAVE_SCENE,
 		FILE_SAVE_AS_SCENE,
+		FILE_SAVE_ALL_SCENES,
 		FILE_SAVE_BEFORE_RUN,
 		FILE_SAVE_AND_RUN,
 		FILE_IMPORT_SUBSCENE,
@@ -438,7 +439,7 @@ private:
 
 	void _node_renamed();
 	void _editor_select(int p_which);
-	void _set_scene_metadata(const String &p_file);
+	void _set_scene_metadata(const String &p_file, int p_idx=-1);
 	void _get_scene_metadata(const String& p_file);
 	void _update_title();
 	void _update_scene_tabs();
@@ -448,7 +449,7 @@ private:
 
 	void _rebuild_import_menu();
 
-	void _save_scene(String p_file);
+	void _save_scene(String p_file, int idx = -1);
 
 
 	void _instance_request(const String& p_path);


### PR DESCRIPTION
Also add a new shortcut to save all modified scenes previously saved. (Ctrl+Alt+Shift+S)
