### PR TITLE
Revert "Fix issue when switching between FileSystem and other editor docks"

### DIFF
--- a/tools/editor/scenes_dock.cpp
+++ b/tools/editor/scenes_dock.cpp
@@ -1702,6 +1702,7 @@ ScenesDock::ScenesDock(EditorNode *p_editor) {
 
 	tree->set_hide_root(true);
 	split_box->add_child(tree);
+	tree->set_custom_minimum_size(Size2(0,200)*EDSCALE);
 	tree->set_drag_forwarding(this);
 
 


### PR DESCRIPTION
Reverts godotengine/godot#5416

This fix breaks the panel when used in full height, please don't remove lines that are useful for no reason
