### PR TITLE
Fix visual server error when minimizing the window

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -604,8 +604,12 @@ LRESULT OS_Windows::WndProc(HWND hWnd,UINT uMsg, WPARAM	wParam,	LPARAM	lParam) {
 		} break;
 
 		case WM_SIZE: {
-			video_mode.width=LOWORD(lParam);
-			video_mode.height=HIWORD(lParam);
+			int window_w = LOWORD(lParam);
+			int window_h = HIWORD(lParam);
+			if (window_w > 0 && window_h > 0) {
+				video_mode.width = window_w;
+				video_mode.height = window_h;
+			}
 			//return 0;								// Jump Back
 		} break;
 		case WM_SYSKEYDOWN:


### PR DESCRIPTION
Fix #4821.
Fix #1930.

~~I'm not sure if this is the right way to fix~~, but it seems that `OS` reports the width and height as zero when minimized and this stops the framebuffer of being properly updated. With this check the errors about the `VisualServer` and `RasterizerGLES2` are gone.

EDIT: I changed my original commit, so now it has the proper way to fix.
