### PR TITLE
Fix issue when switching between FileSystem and other editor docks

### DIFF
--- a/tools/editor/scenes_dock.cpp
+++ b/tools/editor/scenes_dock.cpp
@@ -164,12 +164,14 @@ void ScenesDock::_notification(int p_what) {
 				if (split_mode) {
 
 					file_list_vb->hide();
+					tree->set_custom_minimum_size(Size2(0,0));
 					tree->set_v_size_flags(SIZE_EXPAND_FILL);
 					button_back->show();
 				} else {
 
 					tree->show();
 					file_list_vb->show();
+					tree->set_custom_minimum_size(Size2(0,200)*EDSCALE);
 					tree->set_v_size_flags(SIZE_FILL);
 					button_back->hide();
 					if (!EditorFileSystem::get_singleton()->is_scanning()) {
@@ -1702,7 +1704,6 @@ ScenesDock::ScenesDock(EditorNode *p_editor) {
 
 	tree->set_hide_root(true);
 	split_box->add_child(tree);
-	tree->set_custom_minimum_size(Size2(0,200)*EDSCALE);
 	tree->set_drag_forwarding(this);
 
 


### PR DESCRIPTION
Fix #5384.

@akien-mga sorry about the other PR, I should've tested more thoroughly, but didn't know about this vertical split special case.

@reduz, now I tested with and without the vertical split, and it worked fine. Changing minimum size to `Size2(0,150)` also solved the problem, but I think this is a better way to address the issue, as if anyone should change the minimum size again in the future, it won't cause a regression.

Any other special cases you may find useful for me to test before merging?
