### PR TITLE
Add support to String type in gdscript iteration

### DIFF
--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -2911,6 +2911,14 @@ bool Variant::iter_init(Variant& r_iter,bool &valid) const {
 			return ret;
 		} break;
 
+		case STRING: {
+
+			const String *str=reinterpret_cast<const String*>(_data._mem);
+			if (str->empty())
+				return false;
+			r_iter = 0;
+			return true;
+		} break;
 		case DICTIONARY: {
 
 			const Dictionary *dic=reinterpret_cast<const Dictionary*>(_data._mem);
@@ -3027,6 +3035,17 @@ bool Variant::iter_next(Variant& r_iter,bool &valid) const {
 			r_iter=ref[0];
 
 			return ret;
+		} break;
+
+		case STRING: {
+
+			const String *str=reinterpret_cast<const String*>(_data._mem);
+			int idx = r_iter;
+			idx++;
+			if (idx >= str->size())
+				return false;
+			r_iter = idx;
+			return true;
 		} break;
 		case DICTIONARY: {
 
@@ -3158,6 +3177,11 @@ Variant Variant::iter_get(const Variant& r_iter,bool &r_valid) const {
 			return ret;
 		} break;
 
+		case STRING: {
+
+			const String *str=reinterpret_cast<const String*>(_data._mem);
+			return str->substr(r_iter,1);
+		} break;
 		case DICTIONARY: {
 
 			return r_iter; //iterator is the same as the key


### PR DESCRIPTION
Closes #5188.

My test script:

``` python
extends Node2D

# member variables here, example:
# var a=2
# var b="textvar"

func _ready():
    # Called every time the node is added to the scene.
    # Initialization here
    var x = "aábcç"
    var y = x[0]
    print("---")
    print(y)
    print("---")
    for c in x:
        print(c)
    print("---")
    for d in "":
        print("shouldn't enter here!")
    pass
```

Output:

```
** Debug Process Started **
[...]

---
a

---
a
á
b
c
ç

---
** Debug Process Stopped **
```
