### PR TITLE
Improve parallax mirroring algorithm

### DIFF
--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -123,25 +123,14 @@ void ParallaxLayer::set_base_offset_and_scale(const Point2& p_offset,float p_sca
 	Point2 new_ofs = ((orig_offset+p_offset)*motion_scale)*p_scale+motion_offset;
 
 	if (mirroring.x) {
-
-		while( new_ofs.x>=0) {
-			new_ofs.x -= mirroring.x*p_scale;
-		}
-		while(new_ofs.x < -mirroring.x*p_scale) {
-			new_ofs.x += mirroring.x*p_scale;
-		}
+		double den = mirroring.x*p_scale;
+		new_ofs.x -= den*ceil(new_ofs.x/den);
 	}
 
 	if (mirroring.y) {
-
-		while( new_ofs.y>=0) {
-			new_ofs.y -= mirroring.y*p_scale;
-		}
-		while(new_ofs.y < -mirroring.y*p_scale) {
-			new_ofs.y += mirroring.y*p_scale;
-		}
+		double den = mirroring.y*p_scale;
+		new_ofs.y -= den*ceil(new_ofs.y/den);
 	}
-
 
 	set_pos(new_ofs);
 	set_scale(Vector2(1,1)*p_scale);


### PR DESCRIPTION
Replaces the iterative approach currently used by an equivalent direct computation.
Also fixes infinite looping that happens when the mirroring value is negative.

It's a corrected version of #5391. Tested with the 2D platformer example, Jetpaca and my own project.
