### PR TITLE
remove the warning of instances in use at Project manager exit

### DIFF
--- a/tools/editor/project_manager.cpp
+++ b/tools/editor/project_manager.cpp
@@ -871,9 +871,6 @@ ProjectManager::ProjectManager() {
 
 	HBoxContainer *top_hb = memnew( HBoxContainer);
 	vb->add_child(top_hb);
-	TextureFrame *logo = memnew( TextureFrame );
-	logo->set_texture(theme->get_icon("LogoSmall","EditorIcons"));
-	//top_hb->add_child( logo );
 	CenterContainer *ccl = memnew( CenterContainer );
 	Label *l = memnew( Label );
 	l->set_text(_MKSTR(VERSION_NAME)+String(" - ")+TTR("Project Manager"));


### PR DESCRIPTION
fix warning message on exit project manager

```
WARNING: ObjectDB::cleanup: ObjectDB Instances still exist!
     At: core\object.cpp:1944
```
