### PR TITLE
Fix main(2D, 3D, Script) panel not updated when start up and select f…

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -3431,7 +3431,7 @@ Dictionary EditorNode::_get_main_scene_state() {
 
 void EditorNode::_set_main_scene_state(Dictionary p_state,Node* p_for_scene) {
 
-	if (get_edited_scene()!=p_for_scene)
+	if (get_edited_scene()!=p_for_scene && p_for_scene!=NULL)
 		return; //not for this scene
 
 	//print_line("set current 7 ");


### PR DESCRIPTION
…rom tool button

The main panel (2D, 3D viewport and Script editor) is not updated when editor start or select from tool buttons.
It happens after fbdb7a947bd9d75ed6e2a86e58337ca4d47d085e
