### PR TITLE
Add new Camera2D alignment functions

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -6678,6 +6678,17 @@
 			Force the camera to update scroll immediately.
 			</description>
 		</method>
+		<method name="reset_smoothing">
+			<description>
+			Set the camera's position immediately to its current smoothing destination.
+			This has no effect if smoothing is disabled.
+			</description>
+		</method>
+		<method name="align">
+			<description>
+			Align the camera to the tracked node
+			</description>
+		</method>
 		<method name="get_anchor_mode" qualifiers="const">
 			<return type="int">
 			</return>

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -415,6 +415,29 @@ void Camera2D::reset_smoothing() {
 	_update_scroll();
 }
 
+void Camera2D::align() {
+
+	Size2 screen_size = get_viewport_rect().size;
+	screen_size=get_viewport_rect().size;
+	Point2 current_camera_pos = get_global_transform().get_origin();
+	if (anchor_mode==ANCHOR_MODE_DRAG_CENTER) {
+		if (h_ofs<0) {
+			camera_pos.x = current_camera_pos.x + screen_size.x * 0.5 * drag_margin[MARGIN_RIGHT] * h_ofs;
+		} else {
+			camera_pos.x = current_camera_pos.x + screen_size.x * 0.5 * drag_margin[MARGIN_LEFT] * h_ofs;
+		}
+		if (v_ofs<0) {
+			camera_pos.y = current_camera_pos.y + screen_size.y * 0.5 * drag_margin[MARGIN_TOP] * v_ofs;
+		} else {
+			camera_pos.y = current_camera_pos.y + screen_size.y * 0.5 * drag_margin[MARGIN_BOTTOM] * v_ofs;
+		}
+	} else if (anchor_mode==ANCHOR_MODE_FIXED_TOP_LEFT){
+
+		camera_pos=current_camera_pos;
+	}
+
+	_update_scroll();
+}
 
 void Camera2D::set_follow_smoothing(float p_speed) {
 
@@ -551,6 +574,7 @@ void Camera2D::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("force_update_scroll"),&Camera2D::force_update_scroll);
 	ObjectTypeDB::bind_method(_MD("reset_smoothing"),&Camera2D::reset_smoothing);
+	ObjectTypeDB::bind_method(_MD("align"),&Camera2D::align);
 
 	ObjectTypeDB::bind_method(_MD("_set_old_smoothing","follow_smoothing"),&Camera2D::_set_old_smoothing);
 

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -409,6 +409,12 @@ void Camera2D::force_update_scroll() {
 	_update_scroll();
 }
 
+void Camera2D::reset_smoothing() {
+
+	smoothed_camera_pos = camera_pos;
+	_update_scroll();
+}
+
 
 void Camera2D::set_follow_smoothing(float p_speed) {
 
@@ -544,6 +550,7 @@ void Camera2D::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("is_follow_smoothing_enabled"),&Camera2D::is_follow_smoothing_enabled);
 
 	ObjectTypeDB::bind_method(_MD("force_update_scroll"),&Camera2D::force_update_scroll);
+	ObjectTypeDB::bind_method(_MD("reset_smoothing"),&Camera2D::reset_smoothing);
 
 	ObjectTypeDB::bind_method(_MD("_set_old_smoothing","follow_smoothing"),&Camera2D::_set_old_smoothing);
 

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -129,6 +129,7 @@ public:
 	Vector2 get_camera_pos() const;
 	void force_update_scroll();
 	void reset_smoothing();
+	void center();
 
 	Camera2D();
 };

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -129,7 +129,7 @@ public:
 	Vector2 get_camera_pos() const;
 	void force_update_scroll();
 	void reset_smoothing();
-	void center();
+	void align();
 
 	Camera2D();
 };

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -128,6 +128,7 @@ public:
 
 	Vector2 get_camera_pos() const;
 	void force_update_scroll();
+	void reset_smoothing();
 
 	Camera2D();
 };


### PR DESCRIPTION
**`reset_smoothing()`** to immediately set the Camera2D's position to the destination point where it is smoothing to. This has only an effect if smoothing is enabled.

**`align()`** to align the camera's position to the tracked Node. (e.g. if anchor mode is set to DRAG_CENTER, it will center the Node). This function does **not** reset smoothing, so if you want to realign the camera immediately, you have to call `align()` and `reset_smoothing()` afterwards.
