### PR TITLE
Fix wrong return bool, string, string array data through jni

### DIFF
--- a/platform/android/java_glue.cpp
+++ b/platform/android/java_glue.cpp
@@ -259,8 +259,7 @@ Variant _jobject_to_variant(JNIEnv * env, jobject obj) {
 
 		for (int i=0; i<stringCount; i++) {
 			jstring string = (jstring) env->GetObjectArrayElement(arr, i);
-			const char *rawString = env->GetStringUTFChars(string, 0);
-			sarr.push_back(String(rawString));
+			sarr.push_back(String::utf8(env->GetStringUTFChars(string, NULL)));
 			env->DeleteLocalRef(string);
 
 		}
@@ -506,7 +505,7 @@ public:
 			} break;
 			case Variant::BOOL: {
 
-				ret = env->CallBooleanMethodA(instance,E->get().method,v);
+				ret = env->CallBooleanMethodA(instance,E->get().method,v)==JNI_TRUE;
 				//print_line("call bool");
 			} break;
 			case Variant::INT: {
@@ -521,8 +520,7 @@ public:
 			case Variant::STRING: {
 
 				jobject o = env->CallObjectMethodA(instance,E->get().method,v);
-				String str = env->GetStringUTFChars((jstring)o, NULL );
-				ret=str;
+				ret = String::utf8(env->GetStringUTFChars((jstring)o, NULL));
 				env->DeleteLocalRef(o);
 			} break;
 			case Variant::STRING_ARRAY: {


### PR DESCRIPTION
test java code

``` java
public boolean getBool(){
    return true;
}
public String getString(){
    return "test string 한글";
}
public String[] getStringArray(){
    String[] data = new String[2];
    data[0] = "test string";
    data[1] = "한글";
    return data;
}
```

return value with current head

``` gdscript
print(java_instance.getBool())        # 1
print(java_instance.getString())      # test string íê¸
print(java_instance.getStringArray()) # data_string_array = test string, íê¸
```

return value with this PR

``` gdscript
print(java_instance.getBool())        # True
print(java_instance.getString())      # test string 한글
print(java_instance.getStringArray()) # test string, 한글
```
