### PR TITLE
Windows: prevent freeze while moving or resizing the game window.

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -612,6 +612,20 @@ LRESULT OS_Windows::WndProc(HWND hWnd,UINT uMsg, WPARAM	wParam,	LPARAM	lParam) {
 			}
 			//return 0;								// Jump Back
 		} break;
+
+		case WM_ENTERSIZEMOVE: {
+			move_timer_id = SetTimer(hWnd, 1, USER_TIMER_MINIMUM,(TIMERPROC) NULL);
+		} break;
+		case WM_EXITSIZEMOVE: {
+			KillTimer(hWnd, move_timer_id);
+		} break;
+		case WM_TIMER: {
+			if (wParam == move_timer_id) {
+				process_key_events();
+				Main::iteration();
+			}
+		} break;
+
 		case WM_SYSKEYDOWN:
 		case WM_SYSKEYUP:
 		case WM_KEYUP:
@@ -1140,7 +1154,7 @@ void OS_Windows::initialize(const VideoMode& p_desired,int p_video_driver,int p_
 
 	DragAcceptFiles(hWnd,true);
 
-
+	move_timer_id = 1;
 }
 
 void OS_Windows::set_clipboard(const String& p_text) {

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -104,6 +104,8 @@ class OS_Windows : public OS {
 	HINSTANCE	hInstance;		// Holds The Instance Of The Application
 	HWND hWnd;
 
+	uint32_t move_timer_id;
+
 	HCURSOR hCursor;
 
 	Size2 window_rect;


### PR DESCRIPTION
When moving or resizing the window, Windows spins up a seperate event-loop, effectively blocking the normal one.
To work around this, we're starting a timer that will continue sending WM_TIMER messages which we can use to keep the mainloop running.

fixes #4695
