### PR TITLE
windows get_latin_keyboard_variant() implementation and gdscript binding, #5503

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -435,6 +435,18 @@ String _OS::get_locale() const {
 	return OS::get_singleton()->get_locale();
 }
 
+String _OS::get_latin_keyboard_variant() const {
+	switch( OS::get_singleton()->get_latin_keyboard_variant() ) {
+		case OS::LATIN_KEYBOARD_QWERTY: return "QWERTY";
+		case OS::LATIN_KEYBOARD_QWERTZ: return "QWERTZ";
+		case OS::LATIN_KEYBOARD_AZERTY: return "AZERTY";
+		case OS::LATIN_KEYBOARD_QZERTY: return "QZERTY";
+		case OS::LATIN_KEYBOARD_DVORAK: return "DVORAK";
+		case OS::LATIN_KEYBOARD_NEO   : return "NEO";
+		default: return "ERROR";
+	}
+}
+
 String _OS::get_model_name() const {
 
     return OS::get_singleton()->get_model_name();
@@ -1097,6 +1109,7 @@ void _OS::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_ticks_msec"),&_OS::get_ticks_msec);
 	ObjectTypeDB::bind_method(_MD("get_splash_tick_msec"),&_OS::get_splash_tick_msec);
 	ObjectTypeDB::bind_method(_MD("get_locale"),&_OS::get_locale);
+	ObjectTypeDB::bind_method(_MD("get_latin_keyboard_variant"),&_OS::get_latin_keyboard_variant);
 	ObjectTypeDB::bind_method(_MD("get_model_name"),&_OS::get_model_name);
 
 	ObjectTypeDB::bind_method(_MD("get_custom_level"),&_OS::get_custom_level);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -192,6 +192,8 @@ public:
 	Vector<String> get_cmdline_args();
 
 	String get_locale() const;
+	String get_latin_keyboard_variant() const;
+
 	String get_model_name() const;
 	MainLoop *get_main_loop() const;
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2164,6 +2164,68 @@ String OS_Windows::get_locale() const {
 	return "en";
 }
 
+
+OS::LatinKeyboardVariant OS_Windows::get_latin_keyboard_variant() const {
+	
+	unsigned long azerty[] = { 
+		0x00020401, // Arabic (102) AZERTY
+		0x0001080c, // Belgian (Comma)
+		0x0000080c, // Belgian French
+		0x0000040c, // French
+		0 // <--- STOP MARK
+	};
+	unsigned long qwertz[] = {
+		0x0000041a, // Croation
+		0x00000405, // Czech
+		0x00000407, // German
+		0x00010407, // German (IBM)
+		0x0000040e, // Hungarian
+		0x0000046e, // Luxembourgish
+		0x00010415, // Polish (214)
+		0x00000418, // Romanian (Legacy)
+		0x0000081a, // Serbian (Latin)
+		0x0000041b, // Slovak
+		0x00000424, // Slovenian
+		0x0001042e, // Sorbian Extended
+		0x0002042e, // Sorbian Standard
+		0x0000042e, // Sorbian Standard (Legacy)
+		0x0000100c, // Swiss French
+		0x00000807, // Swiss German
+		0 // <--- STOP MARK
+	};
+	unsigned long dvorak[] = {
+		0x00010409, // US-Dvorak
+		0x00030409, // US-Dvorak for left hand
+		0x00040409, // US-Dvorak for right hand
+		0 // <--- STOP MARK
+	};
+
+	char name[ KL_NAMELENGTH + 1 ]; name[0] = 0;
+	GetKeyboardLayoutNameA( name );
+
+	unsigned long hex = strtoul(name, NULL, 16);
+
+	int i=0;
+	while( azerty[i] != 0 ) {
+		if (azerty[i] == hex) return LATIN_KEYBOARD_AZERTY;
+		i++;
+	}
+
+	i = 0;
+	while( qwertz[i] != 0 ) {
+		if (qwertz[i] == hex) return LATIN_KEYBOARD_QWERTZ;
+		i++;
+	}
+	
+	i = 0;
+	while( dvorak[i] != 0 ) {
+		if (dvorak[i] == hex) return LATIN_KEYBOARD_DVORAK;
+		i++; 
+	}
+
+	return LATIN_KEYBOARD_QWERTY;
+}
+
 void OS_Windows::release_rendering_thread() {
 
 	gl_context->release_current();

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -264,6 +264,7 @@ public:
 	virtual String get_executable_path() const;
 
 	virtual String get_locale() const;
+	virtual LatinKeyboardVariant get_latin_keyboard_variant() const; 
 
 	virtual void move_window_to_foreground();
 	virtual String get_data_dir() const;


### PR DESCRIPTION
This is the `OS_Windows::get_latin_keyboard_variant()` implementation of `OS::get_latin_keyboard_variant()`, and its GDscript binding.

This method was already implemented for OSX.

It is still missing for LINUX, ANDROID and others platforms for which it will return QWERTY by default.

There is an open discussion about the purpose of this function, and the alternative workarounds here #5503. (edit : also, for reference, you'll also find there some resources and info to help you debug in case of problems)

edit : also, for reference, here are some python tool scripts and CSV datasheets that will be useful for adding missing keyboards and for debugging  :
https://github.com/SuperUserNameMan/os_windows_get_latin_keyboard_variant
