### PR TITLE
Fixed shortcuts saving issues, fixes #5373

### DIFF
--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -106,9 +106,6 @@ bool EditorSettings::_get(const StringName& p_name,Variant &r_ret) const {
 			Ref<ShortCut> sc=E->get();
 
 			if (optimize_save) {
-				if (!sc->has_meta("original")) {
-					continue; //this came from settings but is not any longer used
-				}
 
 				InputEvent original = sc->get_meta("original");
 				if (sc->is_shortcut(original) || (original.type==InputEvent::NONE && sc->get_shortcut().type==InputEvent::NONE))


### PR DESCRIPTION
Pros:
- shortcuts assigned by the user are now persistent
- In case a shortcut is removed from code, user shortcuts remain the same (contrary to the current behavior were all the shortcuts will be removed)

Cons:
- legacy shortcuts could pile up in the editor settings (not a big deal since the file only grows some KB, and shortcut deprecation wont change that often)
