### PR TITLE
Add OS.request_attention() for Windows

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -946,6 +946,11 @@ void _OS::native_video_stop() {
 	OS::get_singleton()->native_video_stop();
 };
 
+void _OS::request_attention() {
+
+	OS::get_singleton()->request_attention();
+}
+
 bool _OS::is_debug_build() const {
 
 #ifdef DEBUG_ENABLED
@@ -1039,6 +1044,7 @@ void _OS::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("is_window_minimized"),&_OS::is_window_minimized);
 	ObjectTypeDB::bind_method(_MD("set_window_maximized", "enabled"),&_OS::set_window_maximized);
 	ObjectTypeDB::bind_method(_MD("is_window_maximized"),&_OS::is_window_maximized);
+	ObjectTypeDB::bind_method(_MD("request_attention"), &_OS::request_attention);
 
 	ObjectTypeDB::bind_method(_MD("set_borderless_window", "borderless"), &_OS::set_borderless_window);
 	ObjectTypeDB::bind_method(_MD("get_borderless_window"), &_OS::get_borderless_window);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -158,6 +158,7 @@ public:
 	virtual bool is_window_minimized() const;
 	virtual void set_window_maximized(bool p_enabled);
 	virtual bool is_window_maximized() const;
+	virtual void request_attention();
 
 	virtual void set_borderless_window(bool p_borderless);
 	virtual bool get_borderless_window() const;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -174,6 +174,7 @@ public:
 	virtual bool is_window_minimized() const { return false; }
 	virtual void set_window_maximized(bool p_enabled) {}
 	virtual bool is_window_maximized() const { return true; }
+	virtual void request_attention() { }
 
 	virtual void set_borderless_window(int p_borderless) {}
 	virtual bool get_borderless_window() { return 0; }

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -22729,6 +22729,11 @@ Example: (content-length:12), (Content-Type:application/json; charset=UTF-8)
 			<description>
 			</description>
 		</method>
+		<method name="request_attention">
+			<description>
+			Request the user attention to the window. It'll flash the taskbar button on Windows or bounce the dock icon on OSX.
+			</description>
+		</method>
 		<method name="set_borderless_window">
 			<argument index="0" name="borderless" type="bool">
 			</argument>

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1683,6 +1683,17 @@ bool OS_Windows::get_borderless_window() {
 	return video_mode.borderless_window;
 }
 
+void OS_Windows::request_attention() {
+
+	FLASHWINFO info;
+	info.cbSize = sizeof(FLASHWINFO);
+	info.hwnd = hWnd;
+	info.dwFlags = FLASHW_TRAY;
+	info.dwTimeout = 0;
+	info.uCount = 2;
+	FlashWindowEx(&info);
+}
+
 void OS_Windows::print_error(const char* p_function, const char* p_file, int p_line, const char* p_code, const char* p_rationale, ErrorType p_type) {
 
 	HANDLE hCon = GetStdHandle(STD_OUTPUT_HANDLE);

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -230,6 +230,7 @@ public:
 	virtual bool is_window_minimized() const;
 	virtual void set_window_maximized(bool p_enabled);
 	virtual bool is_window_maximized() const;
+	virtual void request_attention();
 
 	virtual void set_borderless_window(int p_borderless);
 	virtual bool get_borderless_window();


### PR DESCRIPTION
This makes the taskbar icon flash to request user attention.

On OSX there's the [`NSApplication.requestUserAttention()`](https://developer.apple.com/reference/appkit/nsapplication/1428358-requestuserattention?language=objc) function that does a similar job (makes the dock icon bounce), but I don't know Objective-C nor do I have a Mac to test it.

I found nothing about this for Linux though...

Related to #3292.
