### PR TITLE
Improve quick open sorting

### DIFF
--- a/tools/editor/quick_open.h
+++ b/tools/editor/quick_open.h
@@ -49,6 +49,7 @@ class EditorQuickOpen : public ConfirmationDialog {
 
 	void _sbox_input(const InputEvent& p_ie);
 	void _parse_fs(EditorFileSystemDirectory *efsd, Vector< Pair< String,Ref <Texture> > > &list);
+	float _path_cmp(String search, String path) const;
 
 
 	void _confirmed();


### PR DESCRIPTION
Perfect matches and substrings will be shown first. Similar matches will
be at the bottom. When they score is the same they're shown in the natural
file system order.

The natural file system order shows upper-case names before lower-case.
