### PR TITLE
fix zippack bugs

### DIFF
--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -29,7 +29,7 @@
 #ifdef MINIZIP_ENABLED
 
 #include "file_access_zip.h"
-
+#include "core/os/os.h"
 #include "core/os/file_access.h"
 #include "core/os/copymem.h"
 
@@ -44,7 +44,8 @@ static void* godot_open(void* data, const char* p_fname, int mode) {
 	};
 
 	FileAccess* f = (FileAccess*)data;
-	f->open(p_fname, FileAccess::READ);
+	if(!f->is_open())
+		f->open(p_fname, FileAccess::READ);
 
 	return f->is_open()?data:NULL;
 
@@ -196,6 +197,9 @@ bool ZipArchive::try_open_pack(const String& p_name) {
 	packages.push_back(pkg);
 	int pkg_num = packages.size()-1;
 
+	if (OS::get_singleton()->is_stdout_verbose())
+		print_line("Total files in pack: " + gi.number_entry);
+
 	for (unsigned int i=0;i<gi.number_entry;i++) {
 
 		char filename_inzip[256];
@@ -212,8 +216,10 @@ bool ZipArchive::try_open_pack(const String& p_name) {
 		files[fname] = f;
 
 		uint8_t md5[16]={0,0,0,0,0,0,0,0 , 0,0,0,0,0,0,0,0};
-		PackedData::get_singleton()->add_path(p_name, fname, 1, 0, md5, this);
-		//printf("packed data add path %ls, %ls\n", p_name.c_str(), fname.c_str());
+		PackedData::get_singleton()->add_path(p_name, fname, file_info.crc, file_info.uncompressed_size, md5, this);
+
+		if (OS::get_singleton()->is_stdout_verbose())
+			print_line(" >> " + p_name + " : " + fname);
 
 		if ((i+1)<gi.number_entry) {
 			unzGoToNextFile(zfile);
@@ -267,23 +273,29 @@ Error FileAccessZip::_open(const String& p_path, int p_mode_flags) {
 	close();
 
 	ERR_FAIL_COND_V(p_mode_flags & FileAccess::WRITE, FAILED);
-	ZipArchive* arch = ZipArchive::get_singleton();
+	const ZipArchive* arch = archive; //ZipArchive::get_singleton();
 	ERR_FAIL_COND_V(!arch, FAILED);
 	zfile = arch->get_file_handle(p_path);
 	ERR_FAIL_COND_V(!zfile, FAILED);
 
 	int err = unzGetCurrentFileInfo64(zfile,&file_info,NULL,0,NULL,0,NULL,0);
 	ERR_FAIL_COND_V(err != UNZ_OK, FAILED);
+	at_eof = false;
 
 	return OK;
 };
 
 void FileAccessZip::close() {
 
+	if(mem != NULL) {
+		memdelete(mem);
+		mem = NULL;
+	}
+
 	if (!zfile)
 		return;
 
-	ZipArchive* arch = ZipArchive::get_singleton();
+	const ZipArchive* arch = archive;//ZipArchive::get_singleton();
 	ERR_FAIL_COND(!arch);
 	arch->close_handle(zfile);
 	zfile = NULL;
@@ -296,37 +308,54 @@ bool FileAccessZip::is_open() const {
 
 void FileAccessZip::seek(size_t p_position) {
 
+	if(mem != NULL) return mem->seek(p_position);
+
+	// load zipped file into file_access_memory
 	ERR_FAIL_COND(!zfile);
-	unzSeekCurrentFile(zfile, p_position);
+	FileAccessMemory *f = memnew(FileAccessMemory);
+	unzSeekCurrentFile(zfile, 0);
+	data.resize(file_info.uncompressed_size);
+	size_t len = get_buffer(&data[0], data.size());
+	// close zipped file
+	close();
+	if(len != data.size()) {
+		WARN_PRINT("get_buffer less data than requested");
+	}
+	f->open_custom(&data[0], len);
+	f->seek(p_position);
+	this->mem = f;
 };
 
 void FileAccessZip::seek_end(int64_t p_position) {
 
-	ERR_FAIL_COND(!zfile);
-	unzSeekCurrentFile(zfile, get_len() + p_position);
+	if(mem) mem->seek_end(p_position);
+	seek(get_len() + p_position);
 };
 
 size_t FileAccessZip::get_pos() const {
 
+	if(mem) return mem->get_pos();
 	ERR_FAIL_COND_V(!zfile, 0);
 	return unztell(zfile);
 };
 
 size_t FileAccessZip::get_len() const {
 
+	if(mem) return mem->get_len();
 	ERR_FAIL_COND_V(!zfile, 0);
 	return file_info.uncompressed_size;
 };
 
 bool FileAccessZip::eof_reached() const {
 
+	if(mem) return mem->eof_reached();
 	ERR_FAIL_COND_V(!zfile, true);
-
 	return at_eof;
 };
 
 uint8_t FileAccessZip::get_8() const {
 
+	if(mem) return mem->get_8();
 	uint8_t ret = 0;
 	get_buffer(&ret, 1);
 	return ret;
@@ -334,6 +363,7 @@ uint8_t FileAccessZip::get_8() const {
 
 int FileAccessZip::get_buffer(uint8_t *p_dst,int p_length) const {
 
+	if(mem) return mem->get_buffer(p_dst, p_length);
 	ERR_FAIL_COND_V(!zfile, -1);
 	at_eof = unzeof(zfile);
 	if (at_eof)
@@ -347,6 +377,7 @@ int FileAccessZip::get_buffer(uint8_t *p_dst,int p_length) const {
 
 Error FileAccessZip::get_error() const {
 
+	if(mem) return mem->get_error();
 	if (!zfile) {
 
 		return ERR_UNCONFIGURED;
@@ -372,6 +403,10 @@ bool FileAccessZip::file_exists(const String& p_name) {
 FileAccessZip::FileAccessZip(const String& p_path, const PackedData::PackedFile& p_file) {
 
 	zfile = NULL;
+	at_eof = false;
+	mem = NULL;
+	archive=dynamic_cast<ZipArchive *>(p_file.src);
+	ERR_FAIL_COND(archive==NULL);
 	_open(p_path, FileAccess::READ);
 };
 

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -33,6 +33,7 @@
 
 #include <stdlib.h>
 #include "core/io/file_access_pack.h"
+#include "core/io/file_access_memory.h"
 #include "unzip.h"
 #include "map.h"
 
@@ -91,7 +92,9 @@ class FileAccessZip : public FileAccess {
 
 	mutable bool at_eof;
 
-	ZipArchive* archive;
+	const ZipArchive* archive;
+	FileAccessMemory *mem;
+	Vector<uint8_t> data;
 
 public:
 


### PR DESCRIPTION
1.fix godot_open reopen an opened zip pack file.
2.use archive parameter instead of ZipArchive::get_singleton()
3.load zipped file into memory file if seek called(better performance for zip access file seek)
