### PR TITLE
RichTextLabel: Fix adding raw text when bbcode is disabled

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -662,8 +662,7 @@ void RichTextLabel::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
 
-			if (use_bbcode)
-				parse_bbcode(bbcode);
+			set_bbcode(bbcode);
 			main->first_invalid_line=0; //invalidate ALL
 			update();
 
@@ -1440,7 +1439,6 @@ bool RichTextLabel::is_scroll_following() const {
 
 Error RichTextLabel::parse_bbcode(const String& p_bbcode) {
 
-
 	clear();
 	return append_bbcode(p_bbcode);
 }
@@ -1858,6 +1856,10 @@ void RichTextLabel::set_bbcode(const String& p_bbcode) {
 	bbcode=p_bbcode;
 	if (is_inside_tree() && use_bbcode)
 		parse_bbcode(p_bbcode);
+	else { // raw text
+		clear();
+		add_text(p_bbcode);
+	}
 }
 
 String RichTextLabel::get_bbcode() const {
@@ -1869,8 +1871,7 @@ void RichTextLabel::set_use_bbcode(bool p_enable) {
 	if (use_bbcode==p_enable)
 		return;
 	use_bbcode=p_enable;
-	if (is_inside_tree() && use_bbcode)
-		parse_bbcode(bbcode);
+	set_bbcode(bbcode);
 }
 
 bool RichTextLabel::is_using_bbcode() const {


### PR DESCRIPTION
An example with the RichTextLabel demo:
- `bbcode/enabled = true`:
  ![spectacle h13254](https://cloud.githubusercontent.com/assets/4701338/16707941/8d699f46-45e1-11e6-91fe-970d9663f94b.png)
- `bbcode/enabled = false`:
  ![spectacle w13254](https://cloud.githubusercontent.com/assets/4701338/16707933/611f9e2c-45e1-11e6-8753-81eff71f5a58.png)

Fixes #5605.
