### PR TITLE
Fix builtin OpenSSL configuration

### DIFF
--- a/drivers/builtin_openssl2/openssl/opensslconf.h
+++ b/drivers/builtin_openssl2/openssl/opensslconf.h
@@ -213,8 +213,13 @@ extern "C" {
 
 #ifdef OPENSSL_USE_64_BITS
 
-#define SIXTY_FOUR_BIT_LONG
-#undef SIXTY_FOUR_BIT
+# ifdef _WIN32
+#  undef SIXTY_FOUR_BIT_LONG
+#  define SIXTY_FOUR_BIT
+# else
+#  define SIXTY_FOUR_BIT_LONG
+#  undef SIXTY_FOUR_BIT
+# endif
 #undef THIRTY_TWO_BIT
 
 #else


### PR DESCRIPTION
Fixes a bug that happens on Windows 64-bits.

This should not make any difference for platforms other than Windows.

Fix #5596.
