### PR TITLE
Fix crash on asset lib install

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1504,6 +1504,8 @@ bool Main::start() {
 		if (project_manager_request || (script=="" && test=="" && game_path=="" && !editor)) {
 
 			ProjectManager *pmanager = memnew( ProjectManager );
+			ProgressDialog *progress_dialog = memnew( ProgressDialog );
+			pmanager->add_child(progress_dialog);
 			sml->get_root()->add_child(pmanager);
 			OS::get_singleton()->set_context(OS::CONTEXT_PROJECTMAN);
 		}

--- a/tools/editor/asset_library_editor_plugin.cpp
+++ b/tools/editor/asset_library_editor_plugin.cpp
@@ -600,7 +600,8 @@ void EditorAssetLibrary::_install_asset() {
 		EditorAssetLibraryItemDownload *d  = downloads_hb->get_child(i)->cast_to<EditorAssetLibraryItemDownload>();
 		if (d && d->get_asset_id() == description->get_asset_id()) {
 
-			EditorNode::get_singleton()->show_warning("Download for this asset is already in progress!");
+			if (EditorNode::get_singleton() != NULL)
+				EditorNode::get_singleton()->show_warning("Download for this asset is already in progress!");
 			return;
 		}
 	}

--- a/tools/editor/editor_asset_installer.cpp
+++ b/tools/editor/editor_asset_installer.cpp
@@ -317,9 +317,11 @@ void EditorAssetInstaller::ok_pressed() {
 			}
 			msg+=failed_files[i];
 		}
-		EditorNode::get_singleton()->show_warning(msg);
+		if (EditorNode::get_singleton() != NULL)
+			EditorNode::get_singleton()->show_warning(msg);
 	} else {
-		EditorNode::get_singleton()->show_warning("Package Installed Successfully!","Success!");
+		if (EditorNode::get_singleton() != NULL)
+			EditorNode::get_singleton()->show_warning("Package Installed Successfully!","Success!");
 	}
 
 


### PR DESCRIPTION
This is not the perfect solution, but fixes the crash and avoid a dependency on `EditorNode`. Without this dependency warning dialogs are not shown, so another solution for that is needed.

Fix #5607.
