### PR TITLE
Added Completion box colors. Exposed show line numbers, highlight all occurrences, and updated theme.

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -39408,6 +39408,34 @@
 				Set the color for symbols.
 			</description>
 		</method>
+		<method name="set_show_line_numbers">
+			<argument index="0" name="enable" type="bool">
+			</argument>
+			<description>
+				Set to enable showing line numbers.
+			</description>
+		</method>
+		<method name="is_show_line_numbers_enabled" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+				Returns true if line numbers are enabled.
+			</description>
+		</method>
+		<method name="set_highlight_all_occurrences">
+			<argument index="0" name="enable" type="bool">
+			</argument>
+			<description>
+				Set to enable highlighting all occurrences of the current selection.
+			</description>
+		</method>
+		<method name="is_highlight_all_occurrences_enabled" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+				Returns true if highlight all occurrences is enabled.
+			</description>
+		</method>
 		<method name="set_syntax_coloring">
 			<argument index="0" name="enable" type="bool">
 			</argument>
@@ -39489,6 +39517,8 @@
 		</theme_item>
 		<theme_item name="completion_existing_color" type="Color">
 		</theme_item>
+		<theme_item name="completion_font_color" type="Color">
+		</theme_item>
 		<theme_item name="completion_lines" type="int">
 		</theme_item>
 		<theme_item name="completion_max_width" type="int">
@@ -39509,17 +39539,27 @@
 		</theme_item>
 		<theme_item name="font_color_selected" type="Color">
 		</theme_item>
+		<theme_item name="function_color" type="Color">
+		</theme_item>
+		<theme_item name="line_number_color" type="Color">
+		</theme_item>
 		<theme_item name="line_spacing" type="int">
 		</theme_item>
 		<theme_item name="mark_color" type="Color">
 		</theme_item>
+		<theme_item name="member_variable_color" type="Color">
+		</theme_item>
 		<theme_item name="normal" type="StyleBox">
+		</theme_item>
+		<theme_item name="number_color" type="Color">
 		</theme_item>
 		<theme_item name="selection_color" type="Color">
 		</theme_item>
 		<theme_item name="symbol_color" type="Color">
 		</theme_item>
 		<theme_item name="tab" type="Texture">
+		</theme_item>
+		<theme_item name="word_highlighted_color" type="Color">
 		</theme_item>
 	</theme_items>
 </class>

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3610,6 +3610,10 @@ void TextEdit::set_highlight_all_occurrences(const bool p_enabled) {
 	update();
 }
 
+bool TextEdit::is_highlight_all_occurrences_enabled() const {
+	return highlight_all_occurrences;
+}
+
 int TextEdit::_get_column_pos_of_word(const String &p_key, const String &p_search, uint32_t p_search_flags, int p_from_column) {
 	int col = -1;
 
@@ -4440,6 +4444,9 @@ void TextEdit::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_show_line_numbers", "enable"), &TextEdit::set_show_line_numbers);
 	ObjectTypeDB::bind_method(_MD("is_show_line_numbers_enabled"), &TextEdit::is_show_line_numbers_enabled);
 
+	ObjectTypeDB::bind_method(_MD("set_highlight_all_occurrences", "enable"), &TextEdit::set_highlight_all_occurrences);
+	ObjectTypeDB::bind_method(_MD("is_highlight_all_occurrences_enabled"), &TextEdit::is_highlight_all_occurrences_enabled);
+
 	ObjectTypeDB::bind_method(_MD("set_syntax_coloring","enable"),&TextEdit::set_syntax_coloring);
 	ObjectTypeDB::bind_method(_MD("is_syntax_coloring_enabled"),&TextEdit::is_syntax_coloring_enabled);
 
@@ -4453,6 +4460,7 @@ void TextEdit::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_menu:PopupMenu"),&TextEdit::get_menu);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_line_numbers"), _SCS("set_show_line_numbers"), _SCS("is_show_line_numbers_enabled"));
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "highlight_all_occurrences"), _SCS("set_highlight_all_occurrences"), _SCS("is_highlight_all_occurrences_enabled"));
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret/caret_blink"), _SCS("cursor_set_blink_enabled"), _SCS("cursor_get_blink_enabled"));
 	ADD_PROPERTYNZ(PropertyInfo(Variant::REAL, "caret/caret_blink_speed",PROPERTY_HINT_RANGE,"0.1,10,0.1"), _SCS("cursor_set_blink_speed"),_SCS("cursor_get_blink_speed") );

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1111,7 +1111,7 @@ void TextEdit::_notification(int p_what) {
 
 					int l = line_from + i;
 					ERR_CONTINUE( l < 0 || l>= completion_options.size());
-					Color text_color = cache.font_color;
+					Color text_color = cache.completion_font_color;
 					for(int j=0;j<color_regions.size();j++) {
 						if (completion_options[l].begins_with(color_regions[j].begin_key)) {
 							text_color=color_regions[j].color;
@@ -3312,6 +3312,7 @@ void TextEdit::_update_caches() {
 	cache.completion_background_color=get_color("completion_background_color");
 	cache.completion_selected_color=get_color("completion_selected_color");
 	cache.completion_existing_color=get_color("completion_existing_color");
+	cache.completion_font_color=get_color("completion_font_color");
 	cache.font=get_font("font");
 	cache.caret_color=get_color("caret_color");
 	cache.line_number_color=get_color("line_number_color");

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4319,6 +4319,10 @@ void TextEdit::set_show_line_numbers(bool p_show) {
 	update();
 }
 
+bool TextEdit::is_show_line_numbers_enabled() const {
+	return line_numbers;
+}
+
 void TextEdit::set_draw_breakpoint_gutter(bool p_draw) {
 	draw_breakpoint_gutter = p_draw;
 	update();
@@ -4433,6 +4437,9 @@ void TextEdit::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("redo"),&TextEdit::redo);
 	ObjectTypeDB::bind_method(_MD("clear_undo_history"),&TextEdit::clear_undo_history);
 
+	ObjectTypeDB::bind_method(_MD("set_show_line_numbers", "enable"), &TextEdit::set_show_line_numbers);
+	ObjectTypeDB::bind_method(_MD("is_show_line_numbers_enabled"), &TextEdit::is_show_line_numbers_enabled);
+
 	ObjectTypeDB::bind_method(_MD("set_syntax_coloring","enable"),&TextEdit::set_syntax_coloring);
 	ObjectTypeDB::bind_method(_MD("is_syntax_coloring_enabled"),&TextEdit::is_syntax_coloring_enabled);
 
@@ -4445,7 +4452,9 @@ void TextEdit::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("menu_option"),&TextEdit::menu_option);
 	ObjectTypeDB::bind_method(_MD("get_menu:PopupMenu"),&TextEdit::get_menu);
 
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret/caret_blink"), _SCS("cursor_set_blink_enabled"), _SCS("cursor_get_blink_enabled"));;
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_line_numbers"), _SCS("set_show_line_numbers"), _SCS("is_show_line_numbers_enabled"));
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret/caret_blink"), _SCS("cursor_set_blink_enabled"), _SCS("cursor_get_blink_enabled"));
 	ADD_PROPERTYNZ(PropertyInfo(Variant::REAL, "caret/caret_blink_speed",PROPERTY_HINT_RANGE,"0.1,10,0.1"), _SCS("cursor_set_blink_speed"),_SCS("cursor_get_blink_speed") );
 
 	ADD_SIGNAL(MethodInfo("cursor_changed"));

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -469,6 +469,7 @@ public:
 	void menu_option(int p_option);
 
 	void set_show_line_numbers(bool p_show);
+	bool is_show_line_numbers_enabled() const;
 
 	void set_draw_breakpoint_gutter(bool p_draw);
 	bool is_drawing_breakpoint_gutter() const;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -77,6 +77,7 @@ class TextEdit : public Control  {
 		Color completion_background_color;
 		Color completion_selected_color;
 		Color completion_existing_color;
+		Color completion_font_color;
 		Color caret_color;
 		Color line_number_color;
 		Color font_color;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -428,6 +428,7 @@ public:
 	void set_current_search_result(int line, int col);
 
 	void set_highlight_all_occurrences(const bool p_enabled);
+	bool is_highlight_all_occurrences_enabled() const;
 	bool is_selection_active() const;
 	int get_selection_from_line() const;
     int get_selection_from_column() const;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -473,7 +473,6 @@ void fill_default_theme(Ref<Theme>& t,const Ref<Font> & default_font,const Ref<F
 	t->set_color("completion_selected_color", "TextEdit",Color::html("434244"));
 	t->set_color("completion_existing_color", "TextEdit",Color::html("21dfdfdf"));
 	t->set_color("completion_scroll_color","TextEdit", control_font_color_pressed );
-	t->set_color("completion_scroll_color","TextEdit", Color::html("ffffff"));
 	t->set_color("completion_font_color","TextEdit", Color::html("aaaaaa"));
 	t->set_color("font_color","TextEdit", control_font_color );
 	t->set_color("font_color_selected","TextEdit", Color(0,0,0) );

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -473,6 +473,8 @@ void fill_default_theme(Ref<Theme>& t,const Ref<Font> & default_font,const Ref<F
 	t->set_color("completion_selected_color", "TextEdit",Color::html("434244"));
 	t->set_color("completion_existing_color", "TextEdit",Color::html("21dfdfdf"));
 	t->set_color("completion_scroll_color","TextEdit", control_font_color_pressed );
+	t->set_color("completion_scroll_color","TextEdit", Color::html("ffffff"));
+	t->set_color("completion_font_color","TextEdit", Color::html("aaaaaa"));
 	t->set_color("font_color","TextEdit", control_font_color );
 	t->set_color("font_color_selected","TextEdit", Color(0,0,0) );
 	t->set_color("selection_color","TextEdit", font_color_selection );
@@ -482,6 +484,11 @@ void fill_default_theme(Ref<Theme>& t,const Ref<Font> & default_font,const Ref<F
 	t->set_color("caret_color","TextEdit", control_font_color );
 	t->set_color("symbol_color","TextEdit", control_font_color_hover );
 	t->set_color("brace_mismatch_color","TextEdit", Color(1,0.2,0.2) );
+	t->set_color("line_number_color","TextEdit",Color::html("66aaaaaa"));
+	t->set_color("function_color","TextEdit",Color::html("66a2ce"));
+	t->set_color("member_variable_color","TextEdit",Color::html("e64e59"));
+	t->set_color("number_color","TextEdit",Color::html("EB9532"));
+	t->set_color("word_highlighted_color","TextEdit",Color(0.8,0.9,0.9,0.15));
 
 	t->set_constant("completion_lines","TextEdit", 7 );
 	t->set_constant("completion_max_width","TextEdit", 50 );

--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -683,6 +683,7 @@ void EditorSettings::_load_default_text_editor_theme() {
 	set("text_editor/completion_background_color", Color::html("2C2A32"));
 	set("text_editor/completion_selected_color", Color::html("434244"));
 	set("text_editor/completion_existing_color", Color::html("21dfdfdf"));
+	set("text_editor/completion_scroll_color", Color::html("ffffff"));
 	set("text_editor/caret_color",Color::html("aaaaaa"));
 	set("text_editor/line_number_color",Color::html("66aaaaaa"));
 	set("text_editor/text_color",Color::html("aaaaaa"));
@@ -918,6 +919,7 @@ bool EditorSettings::_save_text_editor_theme(String p_file) {
 	cf->set_value(theme_section, "completion_background_color", ((Color)get("text_editor/completion_background_color")).to_html());
 	cf->set_value(theme_section, "completion_selected_color", ((Color)get("text_editor/completion_selected_color")).to_html());
 	cf->set_value(theme_section, "completion_existing_color", ((Color)get("text_editor/completion_existing_color")).to_html());
+	cf->set_value(theme_section, "completion_scroll_color", ((Color)get("text_editor/completion_scroll_color")).to_html());
 	cf->set_value(theme_section, "caret_color", ((Color)get("text_editor/caret_color")).to_html());
 	cf->set_value(theme_section, "line_number_color", ((Color)get("text_editor/line_number_color")).to_html());
 	cf->set_value(theme_section, "text_color", ((Color)get("text_editor/text_color")).to_html());

--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -684,6 +684,7 @@ void EditorSettings::_load_default_text_editor_theme() {
 	set("text_editor/completion_selected_color", Color::html("434244"));
 	set("text_editor/completion_existing_color", Color::html("21dfdfdf"));
 	set("text_editor/completion_scroll_color", Color::html("ffffff"));
+	set("text_editor/completion_font_color", Color::html("aaaaaa"));
 	set("text_editor/caret_color",Color::html("aaaaaa"));
 	set("text_editor/line_number_color",Color::html("66aaaaaa"));
 	set("text_editor/text_color",Color::html("aaaaaa"));
@@ -920,6 +921,7 @@ bool EditorSettings::_save_text_editor_theme(String p_file) {
 	cf->set_value(theme_section, "completion_selected_color", ((Color)get("text_editor/completion_selected_color")).to_html());
 	cf->set_value(theme_section, "completion_existing_color", ((Color)get("text_editor/completion_existing_color")).to_html());
 	cf->set_value(theme_section, "completion_scroll_color", ((Color)get("text_editor/completion_scroll_color")).to_html());
+	cf->set_value(theme_section, "completion_font_color", ((Color)get("text_editor/completion_font_color")).to_html());
 	cf->set_value(theme_section, "caret_color", ((Color)get("text_editor/caret_color")).to_html());
 	cf->set_value(theme_section, "line_number_color", ((Color)get("text_editor/line_number_color")).to_html());
 	cf->set_value(theme_section, "text_color", ((Color)get("text_editor/text_color")).to_html());

--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -313,6 +313,7 @@ void ScriptTextEditor::_load_theme_settings() {
 	get_text_edit()->add_color_override("completion_selected_color", EDITOR_DEF("text_editor/completion_selected_color", Color::html("434244")));
 	get_text_edit()->add_color_override("completion_existing_color", EDITOR_DEF("text_editor/completion_existing_color", Color::html("21dfdfdf")));
 	get_text_edit()->add_color_override("completion_scroll_color", EDITOR_DEF("text_editor/completion_scroll_color", Color::html("ffffff")));
+	get_text_edit()->add_color_override("completion_font_color", EDITOR_DEF("text_editor/completion_font_color", Color::html("aaaaaa")));
 	get_text_edit()->add_color_override("font_color",EDITOR_DEF("text_editor/text_color",Color(0,0,0)));
 	get_text_edit()->add_color_override("line_number_color",EDITOR_DEF("text_editor/line_number_color",Color(0,0,0)));
 	get_text_edit()->add_color_override("caret_color",EDITOR_DEF("text_editor/caret_color",Color(0,0,0)));

--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -312,6 +312,7 @@ void ScriptTextEditor::_load_theme_settings() {
 	get_text_edit()->add_color_override("completion_background_color", EDITOR_DEF("text_editor/completion_background_color", Color(0,0,0,0)));
 	get_text_edit()->add_color_override("completion_selected_color", EDITOR_DEF("text_editor/completion_selected_color", Color::html("434244")));
 	get_text_edit()->add_color_override("completion_existing_color", EDITOR_DEF("text_editor/completion_existing_color", Color::html("21dfdfdf")));
+	get_text_edit()->add_color_override("completion_scroll_color", EDITOR_DEF("text_editor/completion_scroll_color", Color::html("ffffff")));
 	get_text_edit()->add_color_override("font_color",EDITOR_DEF("text_editor/text_color",Color(0,0,0)));
 	get_text_edit()->add_color_override("line_number_color",EDITOR_DEF("text_editor/line_number_color",Color(0,0,0)));
 	get_text_edit()->add_color_override("caret_color",EDITOR_DEF("text_editor/caret_color",Color(0,0,0)));

--- a/tools/editor/plugins/shader_editor_plugin.cpp
+++ b/tools/editor/plugins/shader_editor_plugin.cpp
@@ -82,6 +82,7 @@ void ShaderTextEditor::_load_theme_settings() {
 	get_text_edit()->add_color_override("completion_selected_color", EDITOR_DEF("text_editor/completion_selected_color", Color::html("434244")));
 	get_text_edit()->add_color_override("completion_existing_color", EDITOR_DEF("text_editor/completion_existing_color", Color::html("21dfdfdf")));
 	get_text_edit()->add_color_override("completion_scroll_color", EDITOR_DEF("text_editor/completion_scroll_color", Color::html("ffffff")));
+	get_text_edit()->add_color_override("completion_font_color", EDITOR_DEF("text_editor/completion_font_color", Color::html("aaaaaa")));
 	get_text_edit()->add_color_override("font_color",EDITOR_DEF("text_editor/text_color",Color(0,0,0)));
 	get_text_edit()->add_color_override("line_number_color",EDITOR_DEF("text_editor/line_number_color",Color(0,0,0)));
 	get_text_edit()->add_color_override("caret_color",EDITOR_DEF("text_editor/caret_color",Color(0,0,0)));

--- a/tools/editor/plugins/shader_editor_plugin.cpp
+++ b/tools/editor/plugins/shader_editor_plugin.cpp
@@ -81,6 +81,7 @@ void ShaderTextEditor::_load_theme_settings() {
 	get_text_edit()->add_color_override("completion_background_color", EDITOR_DEF("text_editor/completion_background_color", Color(0,0,0,0)));
 	get_text_edit()->add_color_override("completion_selected_color", EDITOR_DEF("text_editor/completion_selected_color", Color::html("434244")));
 	get_text_edit()->add_color_override("completion_existing_color", EDITOR_DEF("text_editor/completion_existing_color", Color::html("21dfdfdf")));
+	get_text_edit()->add_color_override("completion_scroll_color", EDITOR_DEF("text_editor/completion_scroll_color", Color::html("ffffff")));
 	get_text_edit()->add_color_override("font_color",EDITOR_DEF("text_editor/text_color",Color(0,0,0)));
 	get_text_edit()->add_color_override("line_number_color",EDITOR_DEF("text_editor/line_number_color",Color(0,0,0)));
 	get_text_edit()->add_color_override("caret_color",EDITOR_DEF("text_editor/caret_color",Color(0,0,0)));


### PR DESCRIPTION
Added the last completion box colors  font and scroll bar).

Exposed show line numbers, highlight all occurrences to the user, through gdscript and properties.

Updated the TextEdit theme to contain the newly added colors. I didn't add `custom_bg_color` and `symbol_color` because I would have to break api compatibility to keep the styling consistent and didn't want to throw in a work around.

Lastly, updated the docs to reflect these changes.
