### PR TITLE
Implement OS.request_attention() for OSX

### DIFF
--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -200,7 +200,7 @@ public:
 	virtual bool is_window_minimized() const;
 	virtual void set_window_maximized(bool p_enabled);
 	virtual bool is_window_maximized() const;
-
+	virtual void request_attention();
 
 	void run();
 

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1563,7 +1563,7 @@ void OS_OSX::move_window_to_foreground() {
 
 void OS_OSX::request_attention() {
 
-	[NSApp requestUserAttention:NSInformationalRequest];
+	[NSApp requestUserAttention:NSCriticalRequest];
 }
 
 String OS_OSX::get_executable_path() const {

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1561,6 +1561,11 @@ void OS_OSX::move_window_to_foreground() {
 	[window_object orderFrontRegardless];
 }
 
+void OS_OSX::request_attention() {
+
+	[NSApp requestUserAttention:NSInformationalRequest];
+}
+
 String OS_OSX::get_executable_path() const {
 
 	int ret;


### PR DESCRIPTION
Makes the dock icon bounce for 1 second.  This is only an OS X implementation for #5560, so that should be merged first.  Tested on OS X 10.11.6.
