### PR TITLE
Add an option to smooth camera limits when camera smoothing is enabled.

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -6839,6 +6839,14 @@
 				Set the scrolling limit in pixels.
 			</description>
 		</method>
+		<method name="set_limit_smoothing_enabled">
+			<argument index="0" name="enable" type="bool">
+			</argument>
+			<description>
+				Smooth camera when reaching camera limits.
+				This requires camera smoothing being enabled to have a noticeable effect.
+			</description>
+		</method>
 		<method name="set_offset">
 			<argument index="0" name="offset" type="Vector2">
 			</argument>

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -61,13 +61,13 @@ protected:
 	float smoothing;
 	bool smoothing_enabled;
 	int limit[4];
+	bool limit_smoothing_enabled;
 	float drag_margin[4];
 
 	bool h_drag_enabled;
 	bool v_drag_enabled;
 	float h_ofs;
 	float v_ofs;
-
 
 	Point2 camera_screen_center;
 	void _update_scroll();
@@ -95,6 +95,8 @@ public:
 	void set_limit(Margin p_margin,int p_limit);
 	int get_limit(Margin p_margin) const;
 
+	void set_limit_smoothing_enabled(bool enable);
+	bool is_limit_smoothing_enabled() const;
 
 	void set_h_drag_enabled(bool p_enabled);
 	bool is_h_drag_enabled() const;


### PR DESCRIPTION
I'm currently making a game which uses camera smoothing. When my Camera2D hits a world boundary, it stops immediately, which looks somehow disturbing.

So this option allows you to have the limits smoothed, too. It works by limiting the camera's position (instead of the transform), so it's smoothed. And yes, it's a bit hacky, so if you have improvements for that, I'll try to do my best ;-)
