### PR TITLE
Fix SConstruct output file name

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -285,7 +285,7 @@ if selected_platform in platform_list:
 
 	if env["arch"] != "":
 		suffix += "."+env["arch"]
-	elif (env["bits"]=="32"):
+	if (env["bits"]=="32"):
 		suffix+=".32"
 	elif (env["bits"]=="64"):
 		suffix+=".64"


### PR DESCRIPTION
When I wanted to build Godot for iOS, output file names for 32 and 64 bits were the same
