### PR TITLE
OS: Add get_engine_version method

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -1016,6 +1016,11 @@ void _OS::alert(const String& p_alert,const String& p_title) {
 	OS::get_singleton()->alert(p_alert,p_title);
 }
 
+Dictionary _OS::get_engine_version() const {
+
+	return OS::get_singleton()->get_engine_version();
+}
+
 _OS *_OS::singleton=NULL;
 
 void _OS::_bind_methods() {
@@ -1162,6 +1167,8 @@ void _OS::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("set_use_vsync","enable"),&_OS::set_use_vsync);
 	ObjectTypeDB::bind_method(_MD("is_vsnc_enabled"),&_OS::is_vsnc_enabled);
+
+	ObjectTypeDB::bind_method(_MD("get_engine_version"),&_OS::get_engine_version);
 
 	BIND_CONSTANT( DAY_SUNDAY );
 	BIND_CONSTANT( DAY_MONDAY );

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -315,6 +315,8 @@ public:
 	void set_use_vsync(bool p_enable);
 	bool is_vsnc_enabled() const;
 
+	Dictionary get_engine_version() const;
+
 	static _OS *get_singleton() { return singleton; }
 
 	_OS();

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -32,6 +32,8 @@
 #include "dir_access.h"
 #include "globals.h"
 #include "input.h"
+// For get_engine_version, could be removed if it's moved to a new Engine singleton
+#include "version.h"
 
 OS* OS::singleton=NULL;
 
@@ -546,6 +548,28 @@ void OS::set_use_vsync(bool p_enable) {
 bool OS::is_vsnc_enabled() const{
 
 	return true;
+}
+
+Dictionary OS::get_engine_version() const {
+
+	Dictionary dict;
+	dict["major"] = _MKSTR(VERSION_MAJOR);
+	dict["minor"] = _MKSTR(VERSION_MINOR);
+#ifdef VERSION_PATCH
+	dict["patch"] = _MKSTR(VERSION_PATCH);
+#else
+	dict["patch"] = "";
+#endif
+	dict["status"] = _MKSTR(VERSION_STATUS);
+	dict["revision"] = _MKSTR(VERSION_REVISION);
+
+	String stringver = String(dict["major"]) + "." + String(dict["minor"]);
+	if (dict["patch"] != "")
+		stringver += "." + String(dict["patch"]);
+	stringver += "-" + String(dict["status"]) + " (" + String(dict["revision"]) + ")";
+	dict["string"] = stringver;
+
+	return dict;
 }
 
 OS::OS() {

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -186,14 +186,14 @@ public:
 	virtual void set_target_fps(int p_fps);
 	virtual float get_target_fps() const;
 
-	virtual float get_frames_per_second() const { return _fps; };
+	virtual float get_frames_per_second() const { return _fps; }
 
 	virtual void set_keep_screen_on(bool p_enabled);
 	virtual bool is_keep_screen_on() const;
 	virtual void set_low_processor_usage_mode(bool p_enabled);
 	virtual bool is_in_low_processor_usage_mode() const;
 
-	virtual String get_installed_templates_path() const { return ""; };
+	virtual String get_installed_templates_path() const { return ""; }
 	virtual String get_executable_path() const;
 	virtual Error execute(const String& p_path, const List<String>& p_arguments,bool p_blocking,ProcessID *r_child_id=NULL,String* r_pipe=NULL,int *r_exitcode=NULL)=0;
 	virtual Error kill(const ProcessID& p_pid)=0;
@@ -363,7 +363,7 @@ public:
 	virtual void set_screen_orientation(ScreenOrientation p_orientation);
 	ScreenOrientation get_screen_orientation() const;
 
-	virtual void move_window_to_foreground() {};
+	virtual void move_window_to_foreground() {}
 
 	virtual void debug_break();
 
@@ -422,6 +422,8 @@ public:
 
 	virtual void set_use_vsync(bool p_enable);
 	virtual bool is_vsnc_enabled() const;
+
+	Dictionary get_engine_version() const;
 
 	bool is_hidpi_allowed() const { return _allow_hidpi; }
 	OS();


### PR DESCRIPTION
Comments welcome on the proposed dictionary, if you want the parameter to be named differently/expose different things, it could likely be done.

Example output:

```
print(OS.get_engine_version());
# (major:2), (minor:1), (patch:), (revision:custom_build), (status:beta), (version:2.1-beta (custom_build))
print(OS.get_engine_version().version);
#2.1-beta (custom_build)
```

Fixes #5693.
