### PR TITLE
Fixed toggle breakpoint gutter not updating when the game is running, issue 5712

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -39459,6 +39459,11 @@
 		</method>
 	</methods>
 	<signals>
+		<signal name="breakpoint_toggled">
+			<description>
+				Emitted when a breakpoint is placed via the breakpoint gutter.
+			</description>
+		</signal>
 		<signal name="cursor_changed">
 			<description>
 				Emitted when the cursor changes.

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1502,6 +1502,7 @@ void TextEdit::_input_event(const InputEvent& p_input_event) {
 						int gutter=cache.style_normal->get_margin(MARGIN_LEFT);
 						if (mb.x > gutter && mb.x <= gutter + cache.breakpoint_gutter_width + 3) {
 							set_line_as_breakpoint(row, !is_line_set_as_breakpoint(row));
+							emit_signal("breakpoint_toggled", row);
 							return;
 						}
 					}
@@ -4468,6 +4469,7 @@ void TextEdit::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("cursor_changed"));
 	ADD_SIGNAL(MethodInfo("text_changed"));
 	ADD_SIGNAL(MethodInfo("request_completion"));
+	ADD_SIGNAL(MethodInfo("breakpoint_toggled", PropertyInfo( Variant::INT, "row")));
 
 	BIND_CONSTANT( MENU_CUT );
 	BIND_CONSTANT( MENU_COPY );

--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -1012,6 +1012,18 @@ void ScriptEditor::swap_lines(TextEdit *tx, int line1, int line2)
     tx->cursor_set_line(line2);
 }
 
+void ScriptEditor::_breakpoint_toggled(const int p_row) {
+	int selected = tab_container->get_current_tab();
+	if (selected<0 || selected>=tab_container->get_child_count()) {
+		return;
+	}
+
+	ScriptTextEditor *current = tab_container->get_child(selected)->cast_to<ScriptTextEditor>();
+	if (current) {
+		get_debugger()->set_breakpoint(current->get_edited_script()->get_path(),p_row+1,current->get_text_edit()->is_line_set_as_breakpoint(p_row));
+	}
+}
+
 void ScriptEditor::_file_dialog_action(String p_file) {
 
 	switch (file_dialog_option) {
@@ -2198,6 +2210,7 @@ void ScriptEditor::edit(const Ref<Script>& p_script) {
 	ste->get_text_edit()->set_callhint_settings(
 		EditorSettings::get_singleton()->get("text_editor/put_callhint_tooltip_below_current_line"),
 		EditorSettings::get_singleton()->get("text_editor/callhint_tooltip_offset"));
+	ste->get_text_edit()->connect("breakpoint_toggled", this, "_breakpoint_toggled");
 	tab_container->add_child(ste);
 	_go_to_tab(tab_container->get_tab_count()-1);
 
@@ -2671,6 +2684,7 @@ void ScriptEditor::_bind_methods() {
 	ObjectTypeDB::bind_method("_res_saved_callback",&ScriptEditor::_res_saved_callback);
 	ObjectTypeDB::bind_method("_goto_script_line",&ScriptEditor::_goto_script_line);
 	ObjectTypeDB::bind_method("_goto_script_line2",&ScriptEditor::_goto_script_line2);
+	ObjectTypeDB::bind_method("_breakpoint_toggled", &ScriptEditor::_breakpoint_toggled);
 	ObjectTypeDB::bind_method("_breaked",&ScriptEditor::_breaked);
 	ObjectTypeDB::bind_method("_show_debugger",&ScriptEditor::_show_debugger);
 	ObjectTypeDB::bind_method("_get_debug_tooltip",&ScriptEditor::_get_debug_tooltip);

--- a/tools/editor/plugins/script_editor_plugin.h
+++ b/tools/editor/plugins/script_editor_plugin.h
@@ -321,6 +321,7 @@ public:
 	void get_breakpoints(List<String> *p_breakpoints);
 
 	void swap_lines(TextEdit *tx, int line1, int line2);
+	void _breakpoint_toggled(const int p_row);
 
 	void save_all_scripts();
 


### PR DESCRIPTION
Fixed breakpoints toggled by clicking the breakpoint gutter not updating when the game is running.

closes #5712 
