### PR TITLE
Could not use pre multiply alpha for material in editor

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -68,7 +68,7 @@ void Material::set_flag(Flag p_flag,bool p_enabled) {
 
 void Material::set_blend_mode(BlendMode p_blend_mode) {
 
-	ERR_FAIL_INDEX(p_blend_mode,3);
+	ERR_FAIL_INDEX(p_blend_mode,4);
 	blend_mode=p_blend_mode;
 	VisualServer::get_singleton()->material_set_blend_mode(material,(VS::MaterialBlendMode)p_blend_mode);
 	_change_notify();


### PR DESCRIPTION
- 3 was hard coded, I just changed to 4. Unfortunately this will break every time
  a blend mode is added
