### PR TITLE
MeshInstance morph ID technique with AnimationPlayer caching.

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -20596,6 +20596,33 @@
 				Return the current [Mesh] resource for the instance.
 			</description>
 		</method>
+		<method name="get_morph_track_index" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="name" type="String">
+			</argument>
+			<description>
+				Return the id for the morph track with this name. Returns -1 if no morph track is found.
+			</description>
+		</method>
+		<method name="get_morph_track_name" qualifiers="const">
+			<return type="String">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<description>
+				Return the name for this morph track id.
+			</description>
+		</method>
+		<method name="get_morph_track_value" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<description>
+				Return the value for the morph track with this id.
+			</description>
+		</method>
 		<method name="get_skeleton_path">
 			<return type="NodePath">
 			</return>
@@ -20609,6 +20636,15 @@
 				Set the [Mesh] resource for the instance.
 			</description>
 		</method>
+		<method name="set_morph_track_value">
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<argument index="1" name="value" type="float">
+			</argument>
+			<description>
+				Set the value for the morph track with this id.
+			</description>
+		</method>
 		<method name="set_skeleton_path">
 			<argument index="0" name="skeleton_path" type="NodePath">
 			</argument>
@@ -20616,6 +20652,13 @@
 			</description>
 		</method>
 	</methods>
+	<signals>
+		<signal name="mesh_changed">
+			<description>
+				Emitted whenever the a new mesh is assigned or the currently assigned mesh changes.
+			</description>
+		</signal>
+	</signals>
 	<constants>
 	</constants>
 </class>

--- a/scene/3d/mesh_instance.h
+++ b/scene/3d/mesh_instance.h
@@ -44,12 +44,12 @@ class MeshInstance : public GeometryInstance {
 
 	struct MorphTrack {
 
-		int idx;
+		String name;
 		float value;
-		MorphTrack() { idx=0; value=0; }
+		MorphTrack() { value=0; }
 	};
 
-	Map<StringName,MorphTrack> morph_tracks;
+	Vector<MorphTrack> morph_tracks;
 	Vector<Ref<Material> > materials;
 
 	void _mesh_changed();
@@ -67,6 +67,11 @@ public:
 
 	void set_mesh(const Ref<Mesh>& p_mesh);
 	Ref<Mesh> get_mesh() const;
+
+	void set_morph_track_value(const int p_idx, float p_value);
+	float get_morph_track_value(const int p_idx) const;
+	StringName get_morph_track_name(const int p_idx) const;
+	int get_morph_track_index(const StringName &p_name) const;
 
 	void set_skeleton_path(const NodePath& p_skeleton);
 	NodePath get_skeleton_path();

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -33,6 +33,7 @@
 #include "scene/resources/animation.h"
 #include "scene/3d/spatial.h"
 #include "scene/3d/skeleton.h"
+#include "scene/3d/mesh_instance.h"
 #include "scene/2d/node_2d.h"
 /**
 	@author Juan Linietsky <reduzio@gmail.com>
@@ -63,6 +64,7 @@ private:
 		SP_NODE2D_POS,
 		SP_NODE2D_ROT,
 		SP_NODE2D_SCALE,
+		SP_MORPH_TRACK
 	};
 
 	struct TrackNodeCache {
@@ -74,7 +76,8 @@ private:
 		Spatial* spatial;
 		Node2D* node_2d;
 		Skeleton *skeleton;
-		int bone_idx;
+		MeshInstance *mesh_instance;
+		int idx;
 		// accumulated transforms
 
 		Vector3 loc_accum;
@@ -95,15 +98,14 @@ private:
 
 		Map<StringName,PropertyAnim> property_anim;
 
-
-		TrackNodeCache() { skeleton=NULL; spatial=NULL; node=NULL; accum_pass=0; bone_idx=-1; node_2d=NULL; }
+		TrackNodeCache() { skeleton=NULL; spatial=NULL; node=NULL; accum_pass=0; idx=-1; node_2d=NULL; mesh_instance=NULL; }
 
 	};
 
 	struct TrackNodeCacheKey {
 
 		uint32_t id;
-		int bone_idx;
+		int idx;
 
 		inline bool operator<(const TrackNodeCacheKey& p_right) const {
 
@@ -112,7 +114,7 @@ private:
 			else if (id>p_right.id)
 				return false;
 			else
-				return bone_idx<p_right.bone_idx;
+				return idx<p_right.idx;
 		}
 	};
 
@@ -206,6 +208,7 @@ private:
 	void _animation_process(float p_delta);
 
 	void _node_removed(Node *p_node);
+	void _mesh_changed(Node *p_node);
 
 // bind helpers
 	DVector<String> _get_animation_list() const {


### PR DESCRIPTION
In the first of what I hope to be a series of optimizations and improvements to the otherwise fairly limiteded pre-existing mesh morph system, this changes the technique for reading and modifying morph values from string comparsion to a more conventional ID-based system similar to bones in a Skeleton. The AnimationPlayer is made aware of this change and handles it at the caching stage, caching the IDs in the same way as bones are cached.

This should make it a future-proofed technique for animations making frequent changes to the morph tracks (facial animation, ect.). A new signal has been added to the MeshInstance which is emitted whenever the mesh is reassigned, which is needed to signal to the AnimationPlayer that the cache needs to be rebuilt. Some new methods have also been added for handling morph track IDs. Morph tracks can still be handled through the set and get methods (which is needed to retaining access to the them through the property window), so all pre-existing functionality concerning morph tracks should be unaffected, but using the newly added methods is the preferred way of dealing with morph tracks through code.

It's a small internal change, but I think it's a key part of bringing signficant improvements to morph system, and one which I feel I can put forward with confidence right away.
