### PR TITLE
Change default extension to .tscn when import 3d scene

### DIFF
--- a/tools/editor/io_plugins/editor_scene_import_plugin.cpp
+++ b/tools/editor/io_plugins/editor_scene_import_plugin.cpp
@@ -756,7 +756,7 @@ void EditorSceneImportDialog::_import(bool p_and_open) {
 	}
 
 
-	String save_file = save_path->get_text().plus_file(import_path->get_text().get_file().basename()+".scn");
+	String save_file = save_path->get_text().plus_file(import_path->get_text().get_file().basename()+".tscn");
 	print_line("Saving to: "+save_file);
 
 


### PR DESCRIPTION
I'm not sure it's intended to let extension as `.scn`
But in recent, `.tscn` is set to default for scene, so I guess this one should be changed too.
If it's intended, just close it. :)
