### PR TITLE
Fix multichar character constant warning

### DIFF
--- a/drivers/dds/texture_loader_dds.cpp
+++ b/drivers/dds/texture_loader_dds.cpp
@@ -162,20 +162,20 @@ RES ResourceFormatDDS::load(const String &p_path, const String& p_original_path,
 
 	DDSFormat dds_format;
 
-	if (format_flags&DDPF_FOURCC && format_fourcc=='1TXD') {
+	if (format_flags&DDPF_FOURCC && format_fourcc==0x31545844) { //'1TXD'
 
 		dds_format=DDS_DXT1;
-	} else if (format_flags&DDPF_FOURCC && format_fourcc=='3TXD') {
+	} else if (format_flags&DDPF_FOURCC && format_fourcc==0x33545844) { //'3TXD'
 
 		dds_format=DDS_DXT3;
 
-	} else if (format_flags&DDPF_FOURCC && format_fourcc=='5TXD') {
+	} else if (format_flags&DDPF_FOURCC && format_fourcc==0x35545844) { //'5TXD'
 
 		dds_format=DDS_DXT5;
-	} else if (format_flags&DDPF_FOURCC && format_fourcc=='1ITA') {
+	} else if (format_flags&DDPF_FOURCC && format_fourcc==0x31495441) { //'1ITA'
 
 		dds_format=DDS_ATI1;
-	} else if (format_flags&DDPF_FOURCC && format_fourcc=='2ITA') {
+	} else if (format_flags&DDPF_FOURCC && format_fourcc==0x32495441) { //'2ITA'
 
 		dds_format=DDS_ATI2;
 


### PR DESCRIPTION
Multi-character character constants are implementation defined,
and therefore they are risky to use for use when trying to be compatible
with so many different platforms. Fixes #2540.

I made sure my conversions were correct with:

```
    print_line(itos(0x31545844)); print_line(itos('1TXD'));
    print_line(itos(0x33545844)); print_line(itos('3TXD'));
    print_line(itos(0x35545844)); print_line(itos('5TXD'));
    print_line(itos(0x31495441)); print_line(itos('1ITA'));
    print_line(itos(0x32495441)); print_line(itos('2ITA'));
```

Which prints on my system:

```
    827611204
    827611204
    861165636
    861165636
    894720068
    894720068
    826889281
    826889281
    843666497
    843666497
```
