### PR TITLE
Implement get_screen_dpi() on Android

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -22534,6 +22534,15 @@
 			<argument index="0" name="screen" type="int" default="0">
 			</argument>
 			<description>
+				Returns the dots per inch density of the specified screen.
+
+				On Android Devices, the actual screen densities are grouped into six generalized densities:
+					ldpi    - 120 dpi
+					mdpi    - 160 dpi
+					hdpi    - 240 dpi
+					xhdpi   - 320 dpi
+					xxhdpi  - 480 dpi
+					xxxhdpi - 640 dpi
 			</description>
 		</method>
 		<method name="get_screen_orientation" qualifiers="const">

--- a/platform/android/java/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/src/org/godotengine/godot/GodotIO.java
@@ -40,6 +40,7 @@ import android.view.*;
 import android.view.inputmethod.InputMethodManager;
 import android.os.*;
 import android.util.Log;
+import android.util.DisplayMetrics;
 import android.graphics.*;
 import android.text.method.*;
 import android.text.*;
@@ -511,6 +512,11 @@ public class GodotIO {
 
 	public String getModel() {
 		return Build.MODEL;
+	}
+
+	public int getScreenDPI() {
+		DisplayMetrics metrics = applicationContext.getResources().getDisplayMetrics();
+		return (int)(metrics.density * 160f);
 	}
 
 	public boolean needsReloadHooks() {

--- a/platform/android/java_glue.cpp
+++ b/platform/android/java_glue.cpp
@@ -668,6 +668,7 @@ static jmethodID _openURI=0;
 static jmethodID _getDataDir=0;
 static jmethodID _getLocale=0;
 static jmethodID _getModel=0;
+static jmethodID _getScreenDPI=0;
 static jmethodID _showKeyboard=0;
 static jmethodID _hideKeyboard=0;
 static jmethodID _setScreenOrientation=0;
@@ -710,6 +711,12 @@ static String _get_model() {
     JNIEnv *env = ThreadAndroid::get_env();
     jstring s =(jstring)env->CallObjectMethod(godot_io,_getModel);
     return String(env->GetStringUTFChars( s, NULL ));
+}
+
+static int _get_screen_dpi() {
+
+	JNIEnv *env = ThreadAndroid::get_env();
+	return env->CallIntMethod(godot_io,_getScreenDPI);
 }
 
 static String _get_unique_id() {
@@ -821,6 +828,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_initialize(JNIEnv * e
 			_getDataDir = env->GetMethodID(c,"getDataDir","()Ljava/lang/String;");
 			_getLocale = env->GetMethodID(c,"getLocale","()Ljava/lang/String;");
 			_getModel = env->GetMethodID(c,"getModel","()Ljava/lang/String;");
+			_getScreenDPI = env->GetMethodID(c, "getScreenDPI","()I");
 			_getUniqueID = env->GetMethodID(c,"getUniqueID","()Ljava/lang/String;");
 			_showKeyboard = env->GetMethodID(c,"showKeyboard","(Ljava/lang/String;)V");
 			_hideKeyboard = env->GetMethodID(c,"hideKeyboard","()V");
@@ -875,7 +883,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_initialize(JNIEnv * e
 
 	__android_log_print(ANDROID_LOG_INFO,"godot","CMDLINE LEN %i - APK EXPANSION %I\n",cmdlen,int(use_apk_expansion));
 
-	os_android = new OS_Android(_gfx_init_func,env,_open_uri,_get_data_dir,_get_locale, _get_model,_show_vk, _hide_vk,_set_screen_orient,_get_unique_id, _get_system_dir, _play_video,_is_video_playing, _pause_video, _stop_video, _set_keep_screen_on, use_apk_expansion);
+	os_android = new OS_Android(_gfx_init_func,env,_open_uri,_get_data_dir,_get_locale, _get_model, _get_screen_dpi, _show_vk, _hide_vk,_set_screen_orient,_get_unique_id, _get_system_dir, _play_video,_is_video_playing, _pause_video, _stop_video, _set_keep_screen_on, use_apk_expansion);
 	os_android->set_need_reload_hooks(p_need_reload_hook);
 
 	char wd[500];

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -705,6 +705,13 @@ String OS_Android::get_model_name() const {
     return OS_Unix::get_model_name();
 }
 
+int OS_Android::get_screen_dpi(int p_screen) const {
+
+	if (get_screen_dpi_func) {
+		return get_screen_dpi_func();
+	}
+	return 160;
+}
 
 void OS_Android::set_need_reload_hooks(bool p_needs_them) {
 
@@ -808,7 +815,7 @@ String OS_Android::get_joy_guid(int p_device) const {
 	return input->get_joy_guid_remapped(p_device);
 }
 
-OS_Android::OS_Android(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetDataDirFunc p_get_data_dir_func,GetLocaleFunc p_get_locale_func,GetModelFunc p_get_model_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk,  SetScreenOrientationFunc p_screen_orient,GetUniqueIDFunc p_get_unique_id,GetSystemDirFunc p_get_sdir_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func, SetKeepScreenOnFunc p_set_keep_screen_on_func, bool p_use_apk_expansion) {
+OS_Android::OS_Android(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetDataDirFunc p_get_data_dir_func,GetLocaleFunc p_get_locale_func,GetModelFunc p_get_model_func, GetScreenDPIFunc p_get_screen_dpi_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk,  SetScreenOrientationFunc p_screen_orient,GetUniqueIDFunc p_get_unique_id,GetSystemDirFunc p_get_sdir_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func, SetKeepScreenOnFunc p_set_keep_screen_on_func, bool p_use_apk_expansion) {
 
 
 	use_apk_expansion=p_use_apk_expansion;
@@ -829,6 +836,7 @@ OS_Android::OS_Android(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, OpenURIFu
 	get_data_dir_func=p_get_data_dir_func;
 	get_locale_func=p_get_locale_func;
 	get_model_func=p_get_model_func;
+	get_screen_dpi_func = p_get_screen_dpi_func;
 	get_unique_id_func=p_get_unique_id;
 	get_system_dir_func=p_get_sdir_func;
 

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -63,6 +63,7 @@ typedef int (*OpenURIFunc)(const String&);
 typedef String (*GetDataDirFunc)();
 typedef String (*GetLocaleFunc)();
 typedef String (*GetModelFunc)();
+typedef int (*GetScreenDPIFunc)();
 typedef String (*GetUniqueIDFunc)();
 typedef void (*ShowVirtualKeyboardFunc)(const String&);
 typedef void (*HideVirtualKeyboardFunc)();
@@ -141,6 +142,7 @@ private:
 	GetDataDirFunc get_data_dir_func;
 	GetLocaleFunc get_locale_func;
 	GetModelFunc get_model_func;
+	GetScreenDPIFunc get_screen_dpi_func;
 	ShowVirtualKeyboardFunc show_virtual_keyboard_func;
 	HideVirtualKeyboardFunc hide_virtual_keyboard_func;
 	SetScreenOrientationFunc set_screen_orientation_func;
@@ -234,6 +236,7 @@ public:
 	virtual String get_resource_dir() const;
 	virtual String get_locale() const;
 	virtual String get_model_name() const;
+	virtual int get_screen_dpi(int p_screen=0) const;
 
 	virtual String get_unique_ID() const;
 
@@ -257,7 +260,7 @@ public:
 	virtual String get_joy_guid(int p_device) const;
 	void joy_connection_changed(int p_device, bool p_connected, String p_name);
 
-	OS_Android(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetDataDirFunc p_get_data_dir_func,GetLocaleFunc p_get_locale_func,GetModelFunc p_get_model_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk,  SetScreenOrientationFunc p_screen_orient,GetUniqueIDFunc p_get_unique_id,GetSystemDirFunc p_get_sdir_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func, SetKeepScreenOnFunc p_set_keep_screen_on_func, bool p_use_apk_expansion);
+	OS_Android(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetDataDirFunc p_get_data_dir_func,GetLocaleFunc p_get_locale_func,GetModelFunc p_get_model_func, GetScreenDPIFunc p_get_screen_dpi_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk,  SetScreenOrientationFunc p_screen_orient,GetUniqueIDFunc p_get_unique_id,GetSystemDirFunc p_get_sdir_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func, SetKeepScreenOnFunc p_set_keep_screen_on_func, bool p_use_apk_expansion);
 	~OS_Android();
 
 };


### PR DESCRIPTION
This will implement the OS::get_screen_dpi() method for Android.

On Android Devices, the actual screen densities are grouped into six generalized densities.
The possible return values are currently:

```
dpi     - 120 dpi
mdpi    - 160 dpi
hdpi    - 240 dpi
xhdpi   - 320 dpi
xxhdpi  - 480 dpi
xxxhdpi - 640 dpi
```

The info are taken from:
 [Stack Overflow -- getting the screen density programmatically in android](http://stackoverflow.com/questions/3166501/getting-the-screen-density-programmatically-in-android)
