### PR TITLE
Expose virtual keyboard functions to GDScript

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -894,6 +894,17 @@ void _OS::print_resources_by_type(const Vector<String>& p_types) {
 
 };
 
+bool _OS::has_virtual_keyboard() const {
+	return OS::get_singleton()->has_virtual_keyboard();
+}
+
+void _OS::show_virtual_keyboard(const String& p_existing_text) {
+	OS::get_singleton()->show_virtual_keyboard(p_existing_text, Rect2());
+}
+
+void _OS::hide_virtual_keyboard() {
+	OS::get_singleton()->hide_virtual_keyboard();
+}
 
 void _OS::print_all_resources(const String& p_to_file ) {
 
@@ -1117,6 +1128,9 @@ void _OS::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("dump_memory_to_file","file"),&_OS::dump_memory_to_file);
 	ObjectTypeDB::bind_method(_MD("dump_resources_to_file","file"),&_OS::dump_resources_to_file);
+	ObjectTypeDB::bind_method(_MD("has_virtual_keyboard"),&_OS::has_virtual_keyboard);
+	ObjectTypeDB::bind_method(_MD("show_virtual_keyboard", "existing_text"),&_OS::show_virtual_keyboard,DEFVAL(""));
+	ObjectTypeDB::bind_method(_MD("hide_virtual_keyboard"),&_OS::hide_virtual_keyboard);
 	ObjectTypeDB::bind_method(_MD("print_resources_in_use","short"),&_OS::print_resources_in_use,DEFVAL(false));
 	ObjectTypeDB::bind_method(_MD("print_all_resources","tofile"),&_OS::print_all_resources,DEFVAL(""));
 

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -204,6 +204,10 @@ public:
 	void dump_memory_to_file(const String& p_file);
 	void dump_resources_to_file(const String& p_file);
 
+	bool has_virtual_keyboard() const;
+	void show_virtual_keyboard(const String& p_existing_text="");
+	void hide_virtual_keyboard();
+
 	void print_resources_in_use(bool p_short=false);
 	void print_all_resources(const String& p_to_file);
 	void print_all_textures_by_size();

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -209,17 +209,14 @@ bool OS::has_virtual_keyboard() const {
 
 	return false;
 }
+
 void OS::show_virtual_keyboard(const String& p_existing_text,const Rect2& p_screen_rect) {
-
-
 
 }
 
 void OS::hide_virtual_keyboard(){
 
-
 }
-
 
 void OS::print_all_resources(String p_to_file) {
 

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -22721,6 +22721,18 @@
 			<description>
 			</description>
 		</method>
+		<method name="has_virtual_keyboard" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+				Returns true if the platform has a virtual keyboard, false otherwise.
+			</description>
+		</method>
+		<method name="hide_virtual_keyboard">
+			<description>
+				Hides the virtual keyboard if it is shown, does nothing otherwise.
+			</description>
+		</method>
 		<method name="is_debug_build" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -23031,6 +23043,13 @@
 			<argument index="0" name="uri" type="String">
 			</argument>
 			<description>
+			</description>
+		</method>
+		<method name="show_virtual_keyboard">
+			<argument index="0" name="existing_text" type="String">
+			</argument>
+			<description>
+				Shows the virtual keyboard if the platform has one. The [i]existing_text[/i] parameter is useful for implementing your own LineEdit, as it tells the virtual keyboard what text has already been typed (the virtual keyboard uses it for auto-correct and predictions).
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Fixes #2126.
I'm not 100% sure of the example use of the existing_text parameter of the show_virtual_keyboard function I gave in the description, as it was really the only thing I could think of to justify this parameter. It works though, so I thought it should be exposed to GDScript too.
