### PR TITLE
Fix ItemList.clear() not removing separators

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -336,6 +336,7 @@ void ItemList::clear(){
 	current=-1;
 	ensure_selected_visible=false;
 	update();
+	shape_changed=true;
 	defer_select_single=-1;
 
 }


### PR DESCRIPTION
Fixes #5817.
