### PR TITLE
Subarray patch

### DIFF
--- a/core/dvector.h
+++ b/core/dvector.h
@@ -262,6 +262,34 @@ public:
 			w[bs+i]=r[i];
 	}
 
+	DVector<T> subarray(int p_from, int p_to) {
+
+		if (p_from<0) {
+			p_from=size()+p_from;
+		}
+		if (p_to<0) {
+			p_to=size()+p_to;
+		}
+		if (p_from<0 || p_from>=size()) {
+			DVector<T>& aux=*((DVector<T>*)0); // nullreturn
+			ERR_FAIL_COND_V(p_from<0 || p_from>=size(),aux)
+		}
+		if (p_to<0 || p_to>=size()) {
+			DVector<T>& aux=*((DVector<T>*)0); // nullreturn
+			ERR_FAIL_COND_V(p_to<0 || p_to>=size(),aux)
+		}
+
+		DVector<T> slice;
+		int span=1 + p_to - p_from;
+		slice.resize(span);
+		Read r = read();
+		Write w = slice.write();
+		for (int i=0; i<span; ++i) {
+			w[i] = r[p_from+i];
+		}
+
+		return slice;
+	}
 
 	Error insert(int p_pos,const T& p_val) {
 

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -517,6 +517,7 @@ static void _call_##m_type##_##m_method(Variant& r_ret,Variant& p_self,const Var
 	VCALL_LOCALMEM1(ByteArray,append);
 	VCALL_LOCALMEM1(ByteArray,append_array);
 	VCALL_LOCALMEM0(ByteArray,invert);
+	VCALL_LOCALMEM2R(ByteArray,subarray);
 
 	VCALL_LOCALMEM0R(IntArray,size);
 	VCALL_LOCALMEM2(IntArray,set);
@@ -1532,6 +1533,7 @@ _VariantCall::addfunc(Variant::m_vtype,Variant::m_ret,_SCS(#m_method),VCALL(m_cl
 	ADDFUNC2(RAW_ARRAY,INT,ByteArray,insert,INT,"idx",INT,"byte",varray());
 	ADDFUNC1(RAW_ARRAY,NIL,ByteArray,resize,INT,"idx",varray());
 	ADDFUNC0(RAW_ARRAY,NIL,ByteArray,invert,varray());
+	ADDFUNC2(RAW_ARRAY,RAW_ARRAY,ByteArray,subarray,INT,"from",INT,"to",varray());
 
 	ADDFUNC0(RAW_ARRAY,STRING,ByteArray,get_string_from_ascii,varray());
 	ADDFUNC0(RAW_ARRAY,STRING,ByteArray,get_string_from_utf8,varray());

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -30544,6 +30544,17 @@
 				Return the size of the array.
 			</description>
 		</method>
+		<method name="subarray">
+			<return type="RawArray">
+			</return>
+			<argument index="0" name="from" type="int">
+			</argument>
+			<argument index="1" name="to" type="int">
+			</argument>
+			<description>
+				Returns the slice of the [RawArray] between indices (inclusive) as a new [RawArray].  Any negative index is considered to be from the end of the array.
+			</description>
+		</method>
 	</methods>
 	<constants>
 	</constants>


### PR DESCRIPTION
This is a fresh version of the subarray patch for `DVector` properly put into its own branch.  Please see #5765
