### PR TITLE
Viewport: Replace obsolete "windows" group calls

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1782,7 +1782,6 @@ void Viewport::_gui_input_event(InputEvent p_event) {
 							if (top->data.modal_exclusive || top->data.modal_frame==OS::get_singleton()->get_frames_drawn()) {
 								//cancel event, sorry, modal exclusive EATS UP ALL
 								//alternative, you can't pop out a window the same frame it was made modal (fixes many issues)
-								//get_tree()->call_group(SceneTree::GROUP_CALL_REALTIME,"windows","_cancel_input_ID",p_event.ID);
 								get_tree()->set_input_as_handled();
 								return; // no one gets the event if exclusive NO ONE
 							}
@@ -2062,7 +2061,6 @@ void Viewport::_gui_input_event(InputEvent p_event) {
 
 
 
-			//get_tree()->call_group(SceneTree::GROUP_CALL_REALTIME,"windows","_cancel_input_ID",p_event.ID);
 			get_tree()->set_input_as_handled();
 
 
@@ -2102,7 +2100,7 @@ void Viewport::_gui_input_event(InputEvent p_event) {
 
 				if (gui.key_event_accepted) {
 
-					get_tree()->call_group(SceneTree::GROUP_CALL_REALTIME,"windows","_cancel_input_ID",p_event.ID);
+					get_tree()->set_input_as_handled();
 					break;
 				}
 			}
@@ -2162,7 +2160,7 @@ void Viewport::_gui_input_event(InputEvent p_event) {
 
 				if (next) {
 					next->grab_focus();
-					get_tree()->call_group(SceneTree::GROUP_CALL_REALTIME,"windows","_cancel_input_ID",p_event.ID);
+					get_tree()->set_input_as_handled();
 				}
 			}
 
@@ -2355,8 +2353,7 @@ void Viewport::_gui_control_grab_focus(Control* p_control) {
 	if (gui.key_focus && gui.key_focus==p_control)
 		return;
 
-	_gui_remove_focus();
-	get_tree()->call_group(SceneTree::GROUP_CALL_REALTIME,"windows","_gui_remove_focus");
+	get_tree()->call_group(SceneTree::GROUP_CALL_REALTIME,"_viewports","_gui_remove_focus");
 	gui.key_focus=p_control;
 	p_control->notification(Control::NOTIFICATION_FOCUS_ENTER);
 	p_control->update();
@@ -2664,6 +2661,7 @@ void Viewport::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("is_input_disabled"), &Viewport::is_input_disabled);
 
 	ObjectTypeDB::bind_method(_MD("_gui_show_tooltip"), &Viewport::_gui_show_tooltip);
+	ObjectTypeDB::bind_method(_MD("_gui_remove_focus"), &Viewport::_gui_remove_focus);
 
 	ADD_PROPERTY( PropertyInfo(Variant::RECT2,"rect"), _SCS("set_rect"), _SCS("get_rect") );
 	ADD_PROPERTY( PropertyInfo(Variant::BOOL,"own_world"), _SCS("set_use_own_world"), _SCS("is_using_own_world") );


### PR DESCRIPTION
I am not familiar with this code, so I am not sure if this line should replace the previous one.

I found it's being used as an addition in two other places:
- [scene/main/viewport.cpp#L1856-L1857](https://github.com/godotengine/godot/blob/f93e333e85191a467f87143cf1edec0829595767/scene/main/viewport.cpp#L1856-L1857)
- [scene/main/viewport.cpp#L1933-L1934](https://github.com/godotengine/godot/blob/f93e333e85191a467f87143cf1edec0829595767/scene/main/viewport.cpp#L1933-L1934)

It replaces the previous group call in two other places:
- [scene/main/viewport.cpp#L1785-L1786](https://github.com/godotengine/godot/blob/f93e333e85191a467f87143cf1edec0829595767/scene/main/viewport.cpp#L1785-L1786)
- [scene/main/viewport.cpp#L2065-L2066](https://github.com/godotengine/godot/blob/f93e333e85191a467f87143cf1edec0829595767/scene/main/viewport.cpp#L2065-L2066)

And it's missing in favour of the group call in one place:
- [scene/main/viewport.cpp#L2105](https://github.com/godotengine/godot/blob/f93e333e85191a467f87143cf1edec0829595767/scene/main/viewport.cpp#L2105)

This is another place where the _"windows"_ group is being used for a different purpose:
- [scene/main/viewport.cpp#L2359](https://github.com/godotengine/godot/blob/f93e333e85191a467f87143cf1edec0829595767/scene/main/viewport.cpp#L2359)
