### PR TITLE
Fix default ranges of the inspector, as well as Range.

### DIFF
--- a/tools/editor/property_editor.cpp
+++ b/tools/editor/property_editor.cpp
@@ -3039,10 +3039,10 @@ void PropertyEditor::update_tree() {
 				} else {
 					if (p.type == Variant::REAL) {
 
-						item->set_range_config(1, -65536, 65535, 0.001);
+						item->set_range_config(1, -16777216, 16777216, 0.001);
 					} else {
 
-						item->set_range_config(1, -65536, 65535, 1);
+						item->set_range_config(1, -2147483647, 2147483647, 1);
 					}
 				};
 


### PR DESCRIPTION
Probably closes #3091
(Should apply to Variant::REAL and Variant::INT)

Would be nice if this PR is tested, since I'm not sure if the casting to float and back that _might_ be done internally by the editor is working completely on all platforms for all values.
