### PR TITLE
GLES2: Check for GPU capabilities to display an error

### DIFF
--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -10788,8 +10788,17 @@ void RasterizerGLES2::init() {
 	if (OS::get_singleton()->is_stdout_verbose()) {
 		print_line(String("GLES2: Using GLEW ") + (const char*) glewGetString(GLEW_VERSION));
 	}
-#endif
 
+	// Check for GL 2.1 compatibility, if not bail out
+	if (!glewIsSupported("GL_VERSION_2_1")) {
+		ERR_PRINT("Your system's graphic drivers seem not to support OpenGL 2.1 / GLES 2.0, sorry :(\n"
+			  "Try a drivers update, buy a new GPU or try software rendering on Linux; Godot will now crash with a segmentation fault.");
+		OS::get_singleton()->alert("Your system's graphic drivers seem not to support OpenGL 2.1 / GLES 2.0, sorry :(\n"
+					   "Godot Engine will self-destruct as soon as you acknowledge this error message.",
+					   "Fatal error: Insufficient OpenGL / GLES drivers");
+		// TODO: If it's even possible, we should stop the execution without segfault and memory leaks :)
+	}
+#endif
 
 
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1343,7 +1343,7 @@ void OS_Windows::vprint(const char* p_format, va_list p_list, bool p_stderr) {
 void OS_Windows::alert(const String& p_alert,const String& p_title) {
 
 	if (!is_no_window_mode_enabled())
-		MessageBoxW(NULL,p_alert.c_str(),p_title.c_str(),MB_OK|MB_ICONEXCLAMATION);
+		MessageBoxW(NULL, p_alert.c_str(), p_title.c_str(), MB_OK | MB_ICONEXCLAMATION | MB_TASKMODAL);
 	else
 		print_line("ALERT: "+p_alert);
 }


### PR DESCRIPTION
The engine will still segfault, but the error message should be displayed by the
OS in a blocking manner, so that it will only crash once users have acknowledged
the error dialog.

**Please test**, especially if you have hardware that does not support GL 2.1 / GLES 2.0. I only tested on Linux X11, and by tweaking the `if` to make it fail when GL 2.1 was actually supported. @SuperUserNameMan's test in https://github.com/godotengine/godot/issues/1162#issuecomment-235047879 seems to indicate that it would be working on Windows for his hardware.

Closes #1162.
