### PR TITLE
Stop baking process if there is no geometry in the BakedLightInstance.

### DIFF
--- a/scene/3d/baked_light_instance.cpp
+++ b/scene/3d/baked_light_instance.cpp
@@ -60,6 +60,8 @@ void BakedLightInstance::set_baked_light(const Ref<BakedLight>& p_baked_light) {
 //			VS::get_singleton()->instance_geometry_set_baked_light(E->get()->get_instance(),baked_light.is_valid()?get_instance():RID());
 //		}
 	}
+
+	update_configuration_warning();
 }
 
 Ref<BakedLight> BakedLightInstance::get_baked_light() const{
@@ -74,6 +76,14 @@ AABB BakedLightInstance::get_aabb() const {
 DVector<Face3> BakedLightInstance::get_faces(uint32_t p_usage_flags) const {
 
 	return DVector<Face3>();
+}
+
+
+String BakedLightInstance::get_configuration_warning() const {
+	if (get_baked_light().is_null()) {
+		return TTR("BakedLightInstance does not contain a BakedLight resource.");
+	}
+	return String();
 }
 
 

--- a/scene/3d/baked_light_instance.h
+++ b/scene/3d/baked_light_instance.h
@@ -55,6 +55,8 @@ public:
 	virtual AABB get_aabb() const;
 	virtual DVector<Face3> get_faces(uint32_t p_usage_flags) const;
 
+	String get_configuration_warning() const;
+
 	BakedLightInstance();
 };
 

--- a/tools/editor/plugins/baked_light_baker.cpp
+++ b/tools/editor/plugins/baked_light_baker.cpp
@@ -1772,6 +1772,10 @@ void BakedLightBaker::bake(const Ref<BakedLight> &p_light, Node* p_node) {
 	mat_map.clear();
 	tex_map.clear();
 	print_line("\ttotal triangles: "+itos(triangles.size()));
+	// no geometry
+	if (triangles.size() == 0) {
+		return;
+	}
 	ep.step(TTR("Fixing Lights"),1);
 	_fix_lights();
 	ep.step(TTR("Making BVH"),2);

--- a/tools/editor/plugins/baked_light_editor_plugin.cpp
+++ b/tools/editor/plugins/baked_light_editor_plugin.cpp
@@ -206,8 +206,9 @@ void BakedLightEditor::_menu_option(int p_option) {
 void BakedLightEditor::_bake_pressed() {
 
 	ERR_FAIL_COND(!node);
-	if (node->get_baked_light().is_null()) {
-		err_dialog->set_text(TTR("BakedLightInstance does not contain a BakedLight resource."));
+	const String conf_warning = node->get_configuration_warning();
+	if (!conf_warning.empty()) {
+		err_dialog->set_text(conf_warning);
 		err_dialog->popup_centered_minsize();
 		button_bake->set_pressed(false);
 		return;
@@ -236,6 +237,7 @@ void BakedLightEditor::_bake_pressed() {
 		update_timeout=0;
 
 		last_rays_time=0;
+		button_bake->set_pressed(false);
 
 		set_process(true);
 	}


### PR DESCRIPTION
moved missing baked light warning to BakedLightInstance configuration warning
closes #1990
