### PR TITLE
AboutDialog: Popup respecting its minimum size

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -2842,7 +2842,7 @@ void EditorNode::_menu_option_confirm(int p_option,bool p_confirmed) {
 		} break;
 		case SETTINGS_ABOUT: {
 
-			about->popup_centered(Size2(500,130)*EDSCALE);
+			about->popup_centered_minsize(Size2(500,130)*EDSCALE);
 		} break;
 		case SOURCES_REIMPORT: {
 


### PR DESCRIPTION
The text will no longer get partially out of the dialog. This bug is mentioned in #1893

There is still a problem with the _ok_ button though which can probably be fixed by using containers in AcceptDialog:

![ok buttom problem](https://cloud.githubusercontent.com/assets/7718100/17183085/4eb249ee-5426-11e6-8c59-926f5fb1a5c5.png)
