### PR TITLE
LineEdit: Fix event handled as text when a mod key is pressed

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -468,7 +468,7 @@ void LineEdit::_input_event(InputEvent p_event) {
 
 				if (handled) {
 					accept_event();
-				} else {
+				} else if (!k.mod.alt && !k.mod.command) {
 					if (k.unicode>=32 && k.scancode!=KEY_DELETE) {
 
 						if (editable) {


### PR DESCRIPTION
Regression from #5271
