### PR TITLE
ScrollContainer expand children bug fix

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -34139,7 +34139,7 @@
 		A helper node for displaying scrollable elements (e.g. lists).
 	</brief_description>
 	<description>
-		A ScrollContainer node with a [Control] child and scrollbar child ([HScrollbar], [VScrollBar], or both) will only draw the Control within the ScrollContainer area.  Scrollbars will automatically be drawn at the right (for vertical) or bottom (for horizontal) and will enable dragging to move the viewable Control (and its children) within the ScrollContainer.  Scrollbars will also automatically resize the grabber based on the minimum_size of the Control relative to the ScrollContainer.  Works great with a [Panel] control.
+		A ScrollContainer node with a [Control] child and scrollbar child ([HScrollbar], [VScrollBar], or both) will only draw the Control within the ScrollContainer area.  Scrollbars will automatically be drawn at the right (for vertical) or bottom (for horizontal) and will enable dragging to move the viewable Control (and its children) within the ScrollContainer.  Scrollbars will also automatically resize the grabber based on the minimum_size of the Control relative to the ScrollContainer.  Works great with a [Panel] control.  You can set EXPAND on children size flags, so they will upscale to ScrollContainer size if ScrollContainer size is bigger (scroll is invisible for chosen dimension).
 	</description>
 	<methods>
 		<method name="get_h_scroll" qualifiers="const">

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -228,14 +228,14 @@ void ScrollContainer::_notification(int p_what) {
 			child_max_size.y = MAX(child_max_size.y, minsize.y);
 
 			Rect2 r = Rect2(-scroll,minsize);
-			if (!scroll_h) {
+			if (!h_scroll->is_visible()) {
 				r.pos.x=0;
 				if (c->get_h_size_flags()&SIZE_EXPAND)
 					r.size.width=MAX(size.width,minsize.width);
 				else
 					r.size.width=minsize.width;
 			}
-			if (!scroll_v) {
+			if (!v_scroll->is_visible()) {
 				r.pos.y=0;
 				r.size.height=size.height;
 				if (c->get_v_size_flags()&SIZE_EXPAND)


### PR DESCRIPTION
In current implementation EXPAND flag is ignored when scrolls are enabled, even if they are invisible.
In fixed implementation EXPAND is taken into account when scrolls are invisible which simply means ScrollContainer is bigger than it's content so there is a place to expand.
Difference in implementations on screenshots.
![scroll](https://cloud.githubusercontent.com/assets/19764492/17187284/e4291c02-5438-11e6-9888-44be1cafc9e4.png)
Fixed implementation:
![scroll_fixed](https://cloud.githubusercontent.com/assets/19764492/17187283/e428d922-5438-11e6-8366-a2bde180cedc.png)
