### PR TITLE
Keep ProjectManager.selected_list up to date

### DIFF
--- a/tools/editor/project_manager.h
+++ b/tools/editor/project_manager.h
@@ -82,6 +82,7 @@ class ProjectManager : public Control {
 	void _new_project();
 	void _erase_project();
 	void _erase_project_confirm();
+	void _update_project_buttons();
 	void _exit_dialog();
 	void _scan_begin(const String& p_base);
 


### PR DESCRIPTION
Currently selected_list ignore applied filter in Project Manager and user can run/delete invisible projects. This PR fix this issue.
