### PR TITLE
Explicitly initialize 'pending_auto_reload' to false.

### DIFF
--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -2749,6 +2749,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	completion_cache = memnew( EditorScriptCodeCompletionCache );
 	restoring_layout=false;
 	waiting_update_names=false;
+	pending_auto_reload=false;
 	auto_reload_running_scripts=false;
 	editor=p_editor;
 


### PR DESCRIPTION
Makes sure the 'pending_auto_reload' variable is initalized to false. Fixes a bug where the script sync between editor and game runtime wouldn't signal a script reload if the variable auto-initalized to true.
