### PR TITLE
UI navigation via JOYSTICK_MOTION.

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2095,6 +2095,7 @@ void Viewport::_gui_input_event(InputEvent p_event) {
 		} break;
 		case InputEvent::ACTION:
 		case InputEvent::JOYSTICK_BUTTON:
+		case InputEvent::JOYSTICK_MOTION:
 		case InputEvent::KEY: {
 
 


### PR DESCRIPTION
Previously, you could assign joystick axis events to "ui_*" actions but they had no effect.
See https://godotengine.org/qa/6232
