### PR TITLE
Fix String::is_valid_integer() for single symbols + and -

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -3491,7 +3491,7 @@ bool String::is_valid_integer() const {
 		return false;
 
 	int from=0;
-	if (operator[](0)=='+' || operator[](0)=='-')
+	if (len!=1 && (operator[](0)=='+' || operator[](0)=='-'))
 		from++;
 
 	for(int i=from;i<len;i++) {


### PR DESCRIPTION
Before: print("+".is_valid_integer()) return True, after: False. Please review it's my first little commit.
