### PR TITLE
Added texture filtering and char spacing for DynamicFont

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -334,7 +334,7 @@ int Label::get_longest_line_width() const {
 			}
 		} else {
 
-			int char_width=font->get_char_size(current).width;
+			int char_width=font->get_char_size(current,text[i+1]).width;
 			line_width+=char_width;
 		}
 
@@ -454,7 +454,7 @@ void Label::regenerate_word_cache() {
 				word_pos=i;
 			}
 
-			char_width=font->get_char_size(current).width;
+			char_width=font->get_char_size(current,text[i+1]).width;
 			current_word_size+=char_width;
 			line_width+=char_width;
 			total_char_cache++;

--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -159,6 +159,17 @@ class DynamicFont : public Font {
 
 	OBJ_TYPE( DynamicFont, Font );
 
+public:
+
+	enum SpacingType{
+		SPACING_TOP,
+		SPACING_BOTTOM,
+		SPACING_CHAR,
+		SPACING_SPACE
+	};
+
+private:
+
 	Ref<DynamicFontData> data;
 	Ref<DynamicFontAtSize> data_at_size;
 
@@ -168,6 +179,10 @@ class DynamicFont : public Font {
 
 	int size;
 	bool valid;
+	int spacing_top;
+	int spacing_bottom;
+	int spacing_char;
+	int spacing_space;
 	bool use_mipmaps;
 	bool use_filter;
 	uint32_t texture_flags;
@@ -195,6 +210,9 @@ public:
 
 	bool get_use_filter() const;
 	void set_use_filter(bool p_enable);
+
+	int get_spacing(int p_type) const;
+	void set_spacing(int p_type, int p_value);
 
 	void add_fallback(const Ref<DynamicFontData>& p_data);
 	void set_fallback(int p_idx,const Ref<DynamicFontData>& p_data);

--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -45,21 +45,32 @@ class DynamicFontData : public Resource {
 
 	OBJ_TYPE(DynamicFontData,Resource);
 
+public:
 
+	struct CacheID{
+
+		int size;
+		bool mipmaps;
+		bool filter;
+
+		bool operator< (CacheID right) const;
+		CacheID() { size=16; mipmaps=false; filter=false; }
+	};
+
+private:
 
 	const uint8_t *font_mem;
 	int font_mem_size;
 	bool force_autohinter;
 
 	String font_path;
-	Map<int,DynamicFontAtSize*> size_cache;
+	Map<CacheID,DynamicFontAtSize*> size_cache;
 
 	friend class DynamicFontAtSize;
 
 friend class DynamicFont;
 
-
-	Ref<DynamicFontAtSize> _get_dynamic_font_at_size(int p_size, uint32_t p_texture_flags=0);
+	Ref<DynamicFontAtSize> _get_dynamic_font_at_size(CacheID p_cache);
 protected:
 
 	static void _bind_methods();
@@ -126,7 +137,7 @@ class DynamicFontAtSize : public Reference {
 
 friend class DynamicFontData;
 	Ref<DynamicFontData> font;
-	int size;
+	DynamicFontData::CacheID id;
 
 
 
@@ -177,19 +188,16 @@ private:
 	Vector< Ref<DynamicFontAtSize> > fallback_data_at_size;
 
 
-	int size;
+	DynamicFontData::CacheID cache_id;
 	bool valid;
 	int spacing_top;
 	int spacing_bottom;
 	int spacing_char;
 	int spacing_space;
-	bool use_mipmaps;
-	bool use_filter;
-	uint32_t texture_flags;
 
 protected:
 
-	void _update_texture_flags();
+	void _reload_cache();
 
 	bool _set(const StringName& p_name, const Variant& p_value);
 	bool _get(const StringName& p_name,Variant &r_ret) const;

--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -59,7 +59,7 @@ class DynamicFontData : public Resource {
 friend class DynamicFont;
 
 
-	Ref<DynamicFontAtSize> _get_dynamic_font_at_size(int p_size);
+	Ref<DynamicFontAtSize> _get_dynamic_font_at_size(int p_size, uint32_t p_texture_flags=0);
 protected:
 
 	static void _bind_methods();
@@ -89,6 +89,8 @@ class DynamicFontAtSize : public Reference {
 	int descent;
 	int linegap;
 	int rect_margin;
+
+	uint32_t texture_flags;
 
 	bool valid;
 
@@ -145,7 +147,7 @@ public:
 
 	float draw_char(RID p_canvas_item, const Point2& p_pos, CharType p_char,CharType p_next,const Color& p_modulate,const Vector<Ref<DynamicFontAtSize> >& p_fallbacks) const;
 
-
+	void set_texture_flags(uint32_t p_flags);
 
 	DynamicFontAtSize();
 	~DynamicFontAtSize();
@@ -157,7 +159,7 @@ class DynamicFont : public Font {
 
 	OBJ_TYPE( DynamicFont, Font );
 
-	Ref<DynamicFontData> data;	
+	Ref<DynamicFontData> data;
 	Ref<DynamicFontAtSize> data_at_size;
 
 	Vector< Ref<DynamicFontData> > fallbacks;
@@ -166,8 +168,13 @@ class DynamicFont : public Font {
 
 	int size;
 	bool valid;
+	bool use_mipmaps;
+	bool use_filter;
+	uint32_t texture_flags;
 
 protected:
+
+	void _update_texture_flags();
 
 	bool _set(const StringName& p_name, const Variant& p_value);
 	bool _get(const StringName& p_name,Variant &r_ret) const;
@@ -183,6 +190,11 @@ public:
 	void set_size(int p_size);
 	int get_size() const;
 
+	bool get_use_mipmaps() const;
+	void set_use_mipmaps(bool p_enable);
+
+	bool get_use_filter() const;
+	void set_use_filter(bool p_enable);
 
 	void add_fallback(const Ref<DynamicFontData>& p_data);
 	void set_fallback(int p_idx,const Ref<DynamicFontData>& p_data);


### PR DESCRIPTION
Adds properties for texture filtering and mipmaps in DynamicFont. This should allow better control when scaling. By default it is off to follow the old behaviour.

Example (4.5x scale):
Old / No Filtering
![before](https://cloud.githubusercontent.com/assets/185322/17325337/e7bcb00e-58a2-11e6-91e3-078505a1892e.png)

With Filtering
![after](https://cloud.githubusercontent.com/assets/185322/17325336/e7b41ca0-58a2-11e6-8ca9-f8fd5693def7.png)

Adds properties for adding extra spacing between characters, ascent, descent, and space width, similar to how BitmapFont worked.

![screen](https://cloud.githubusercontent.com/assets/185322/17325536/0846e0c8-58a4-11e6-8e02-364961931602.png)

Also, to make this change work with labels, I modified the Label class to check for kerning when calculating string sizes.
