### PR TITLE
Fix set_window_size not setting the correct size on OSX

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1494,9 +1494,19 @@ Size2 OS_OSX::get_window_size() const {
 
 };
 
+const int menuHeight = [[NSStatusBar systemStatusBar] thickness];
+
 void OS_OSX::set_window_size(const Size2 p_size) {
 
 	Size2 size=p_size;
+
+	// NSRect used by setFrame includes the title bar, so add it to our size.y
+	CGFloat menuBarHeight = [[[NSApplication sharedApplication] mainMenu] menuBarHeight];
+	if (menuBarHeight != 0.f) {
+		size.y+= menuBarHeight;
+	} else {
+		size.y+= menuHeight;
+	}
 	NSRect frame = [window_object frame];
 	[window_object setFrame:NSMakeRect(frame.origin.x, frame.origin.y, size.x, size.y) display:YES];
 };


### PR DESCRIPTION
On OSX set_window_size was missing always 22px for the height, since setFrame param uses the window size including the bar height, this PR adds the menu bar height into the rect.
