### PR TITLE
Fix #5891 by not expecting the script instance to be a GDInstance

### DIFF
--- a/modules/gdscript/gd_function.cpp
+++ b/modules/gdscript/gd_function.cpp
@@ -372,8 +372,7 @@ Variant GDFunction::call(GDInstance *p_instance, const Variant **p_args, int p_a
 
 					if (obj_A->get_script_instance() && obj_A->get_script_instance()->get_language()==GDScriptLanguage::get_singleton()) {
 
-						GDInstance *ins = static_cast<GDInstance*>(obj_A->get_script_instance());
-						GDScript *cmp = ins->script.ptr();
+						GDScript *cmp = static_cast<GDScript*>(obj_A->get_script_instance()->get_script().ptr());
 						//bool found=false;
 						while(cmp) {
 


### PR DESCRIPTION
It could be a placeholder instance as well. This fix makes use of C++ OOP and polymorphism, ~~might need a check if some console compilers don't like it.~~ Edit: It is already used a few lines above, so no need to check it there.
