### PR TITLE
Remove unused function in Project Manager.

### DIFF
--- a/tools/editor/project_manager.cpp
+++ b/tools/editor/project_manager.cpp
@@ -364,12 +364,6 @@ public:
 		mode=p_mode;
 	}
 
-	void import_from_file(const String& p_file) {
-		mode=MODE_IMPORT;
-		_file_selected(p_file);
-		ok_pressed();
-	}
-
 	void show_dialog() {
 
 


### PR DESCRIPTION
This has been deprecated by #5993
