### PR TITLE
Allow documenting unexposed return types in bind_native_method

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1651,7 +1651,7 @@ void Object::_bind_methods() {
 		}
 
 
-		ObjectTypeDB::bind_native_method(METHOD_FLAGS_DEFAULT,"call",&Object::_call_bind,mi,defargs);
+		ObjectTypeDB::bind_native_method(METHOD_FLAGS_DEFAULT,"call:Variant",&Object::_call_bind,mi,defargs);
 	}
 
 	{

--- a/core/object_type_db.h
+++ b/core/object_type_db.h
@@ -415,7 +415,7 @@ public:
 
 #endif
 	template<class M>
-	static MethodBind* bind_native_method(uint32_t p_flags, const StringName& p_name, M p_method,const MethodInfo& p_info=MethodInfo(),const Vector<Variant>& p_default_args=Vector<Variant>()) {
+	static MethodBind* bind_native_method(uint32_t p_flags, StringName p_name, M p_method,const MethodInfo& p_info=MethodInfo(),const Vector<Variant>& p_default_args=Vector<Variant>()) {
 
 		GLOBAL_LOCK_FUNCTION;
 
@@ -423,6 +423,13 @@ public:
 
 		MethodBind *bind = create_native_method_bind(p_method,p_info);
 		ERR_FAIL_COND_V(!bind,NULL);
+
+		String rettype;
+		if (p_name.operator String().find(":")!=-1) {
+			rettype = p_name.operator String().get_slice(":",1);
+			p_name = p_name.operator String().get_slice(":",0);
+		}
+
 		bind->set_name(p_name);
 		bind->set_default_arguments(p_default_args);
 
@@ -442,6 +449,8 @@ public:
 		}
 		type->method_map[p_name]=bind;
 #ifdef DEBUG_METHODS_ENABLED
+		if (!rettype.empty())
+			bind->set_return_type(rettype);
 		type->method_order.push_back(p_name);
 #endif
 

--- a/modules/gdscript/gd_script.cpp
+++ b/modules/gdscript/gd_script.cpp
@@ -663,7 +663,7 @@ void GDScript::_get_property_list(List<PropertyInfo> *p_properties) const {
 
 void GDScript::_bind_methods() {
 
-	ObjectTypeDB::bind_native_method(METHOD_FLAGS_DEFAULT,"new",&GDScript::_new,MethodInfo("new"));
+	ObjectTypeDB::bind_native_method(METHOD_FLAGS_DEFAULT,"new",&GDScript::_new,MethodInfo(Variant::OBJECT,"new"));
 
 	ObjectTypeDB::bind_method(_MD("get_as_byte_code"),&GDScript::get_as_byte_code);
 


### PR DESCRIPTION
Fixes_ #6035
But frankly I'd prefer to just revert the faulty line (https://github.com/godotengine/godot/commit/b80c42ef4e99ee155a98c7a2f17201280612257f#diff-1bd5d382d9201d75ddcd89131b5333c4R68) for 2.1 and merge this for 2.2, method binding is scary

Also document return type of `Object.call` and `GDScript.new`
