### PR TITLE
Added script tree list, and function fast access

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -557,6 +557,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["text_editor/theme/font"] = PropertyInfo(Variant::STRING, "text_editor/theme/font", PROPERTY_HINT_GLOBAL_FILE, "*.fnt");
 	set("text_editor/completion/auto_brace_complete", false);
 	set("text_editor/files/restore_scripts_on_load", true);
+	set("text_editor/open_scripts/use_list_mode", false);
 	set("text_editor/completion/complete_file_paths", true);
 
 	//set("docks/scene_tree/display_old_action_buttons",false);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -43,6 +43,7 @@
 #include "scene/gui/tree.h"
 #include "scene/main/timer.h"
 #include "script_language.h"
+#include "script_tree_list.h"
 
 class ScriptEditorQuickOpen : public ConfirmationDialog {
 
@@ -174,7 +175,7 @@ class ScriptEditor : public VBoxContainer {
 	Button *class_search;
 	EditorHelpSearch *help_search_dialog;
 
-	ItemList *script_list;
+	ScriptTreeList *script_list;
 	HSplitContainer *script_split;
 	TabContainer *tab_container;
 	EditorFileDialog *file_dialog;
@@ -271,6 +272,7 @@ class ScriptEditor : public VBoxContainer {
 
 	void _update_script_names();
 
+	void _function_selected(int p_idx, String function);
 	void _script_selected(int p_idx);
 
 	void _find_scripts(Node *p_base, Node *p_current, Set<Ref<Script> > &used);

--- a/editor/plugins/script_tree_list.cpp
+++ b/editor/plugins/script_tree_list.cpp
@@ -1,0 +1,248 @@
+/*************************************************************************/
+/*  script_tree_list.cpp                                                 */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "script_tree_list.h"
+#include "editor/editor_settings.h"
+
+void ScriptTreeList::clear() {
+	root->clear_children();
+	item_count = 0;
+	current = -1;
+}
+
+void ScriptTreeList::add_item(const String &p_item, const Ref<Texture> &p_texture) {
+	TreeItem *item = tree->create_item(root);
+	item->set_text(0, p_item);
+	item->set_icon(0, p_texture);
+	item->set_selectable(0, true);
+	item->set_collapsed(true);
+	item_count++;
+}
+
+void ScriptTreeList::remove_item(const int p_idx) {
+	TreeItem *item = _get_item(p_idx);
+	if (item) {
+		root->remove_child(item);
+		item_count--;
+	}
+}
+
+int ScriptTreeList::get_item_count() const {
+	return item_count;
+}
+
+void ScriptTreeList::set_item_metadata(const int p_idx, const Variant &p_metadata) {
+	TreeItem *item = _get_item(p_idx);
+	if (item) {
+		item->set_metadata(0, p_metadata);
+	}
+}
+
+int ScriptTreeList::get_item_metadata(const int p_idx) {
+	TreeItem *item = _get_item(p_idx);
+	if (item) {
+		return item->get_metadata(0);
+	}
+	return -1;
+}
+
+int ScriptTreeList::find_metadata(const Variant &p_idx) const {
+	TreeItem *item = root->get_children();
+	int i = 0;
+
+	while (item) {
+
+		if (item->get_metadata(0) == p_idx) {
+			return i;
+		}
+		item = item->get_next();
+		i++;
+	}
+	return -1;
+}
+
+void ScriptTreeList::set_item_tooltip(const int p_idx, const String &p_tooltip) {
+	TreeItem *item = _get_item(p_idx);
+	if (item) {
+		item->set_tooltip(0, p_tooltip);
+	}
+}
+
+String ScriptTreeList::get_item_tooltip(const int p_idx) {
+	TreeItem *item = _get_item(p_idx);
+	if (item) {
+		return item->get_tooltip(0);
+	}
+	return "";
+}
+
+void ScriptTreeList::set_item_custom_font_color(const int p_idx, const Color &p_font_color) {
+	TreeItem *item = _get_item(p_idx);
+	if (item) {
+		item->set_custom_color(0, p_font_color);
+	}
+}
+
+Color ScriptTreeList::get_item_custom_font_color(const int p_idx) {
+	TreeItem *item = _get_item(p_idx);
+	if (item) {
+		return item->get_custom_color(0);
+	}
+}
+
+void ScriptTreeList::set_item_custom_bg_color(const int p_idx, const Color &p_custom_bg_color) {
+	TreeItem *item = _get_item(p_idx);
+	if (item) {
+		item->set_custom_bg_color(0, p_custom_bg_color);
+	}
+}
+
+Color ScriptTreeList::get_item_custom_bg_color(const int p_idx) {
+	TreeItem *item = _get_item(p_idx);
+	if (item) {
+		item->get_custom_bg_color(0);
+	}
+	return Color(0, 0, 0, 0);
+}
+
+void ScriptTreeList::set_item_collapsed(const int p_idx, const bool p_collapsed) {
+	TreeItem *item = _get_item(p_idx);
+	if (item) {
+		item->set_collapsed(p_collapsed);
+	}
+}
+
+bool ScriptTreeList::is_item_collapsed(const int p_idx) {
+	TreeItem *item = _get_item(p_idx);
+	if (item) {
+		return item->is_collapsed();
+	}
+	return false;
+}
+
+void ScriptTreeList::add_functions(const int p_idx, const Vector<String> p_functions) {
+	TreeItem *item = _get_item(p_idx);
+	if (item) {
+		for (int i = 0; i < p_functions.size(); i++) {
+			TreeItem *function = tree->create_item(item);
+			function->set_text(0, p_functions[i].get_slice(":", 0));
+			function->set_selectable(0, true);
+		}
+	}
+}
+
+void ScriptTreeList::clear_functions(const int p_idx) {
+	TreeItem *item = _get_item(p_idx);
+	if (item) {
+		item->clear_children();
+	}
+}
+
+void ScriptTreeList::select(const int p_idx) {
+	TreeItem *item = _get_item(p_idx);
+	if (item) {
+		item->select(0);
+		current = p_idx;
+	}
+}
+
+int ScriptTreeList::get_current() const {
+	return current;
+}
+
+TreeItem *ScriptTreeList::_get_item(const int p_idx) {
+	if (p_idx < item_count && p_idx >= 0) {
+		TreeItem *item = root->get_children();
+
+		for (int i = 0; i < p_idx; i++) {
+
+			if (!item) {
+				break;
+			}
+			item = item->get_next();
+		}
+		return item;
+	}
+	return NULL;
+}
+
+void ScriptTreeList::_item_selected() {
+	TreeItem *item = tree->get_selected();
+	if (item) {
+		if (item->get_parent() == root) {
+			emit_signal("script_selected", find_metadata(item->get_metadata(0)));
+		} else {
+			emit_signal("function_selected", find_metadata(item->get_parent()->get_metadata(0)), item->get_text(0));
+		}
+	}
+}
+
+void ScriptTreeList::_notification(int p_what) {
+	if (p_what == NOTIFICATION_ENTER_TREE) {
+		tree->connect("cell_selected", this, "_item_selected");
+		update_settings();
+	}
+}
+
+void ScriptTreeList::_bind_methods() {
+	ClassDB::bind_method("_item_selected", &ScriptTreeList::_item_selected);
+
+	ADD_SIGNAL(MethodInfo("script_selected", PropertyInfo(Variant::INT, "index")));
+	ADD_SIGNAL(MethodInfo("function_selected", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::STRING, "function")));
+}
+
+void ScriptTreeList::update_settings() {
+	tree->set_hide_folding(EditorSettings::get_singleton()->get("text_editor/open_scripts/use_list_mode"));
+	if (EditorSettings::get_singleton()->get("text_editor/open_scripts/use_list_mode")) {
+		TreeItem *item = root->get_children();
+		while (item) {
+			item->set_collapsed(true);
+			item = item->get_next();
+		}
+	}
+}
+
+ScriptTreeList::ScriptTreeList() {
+	VBoxContainer *vbc = this;
+
+	item_count = 0;
+	current = -1;
+
+	tree = memnew(Tree);
+	tree->set_hide_root(true);
+	tree->set_select_mode(Tree::SELECT_SINGLE);
+	vbc->add_child(tree);
+	tree->set_v_size_flags(SIZE_EXPAND | SIZE_FILL);
+
+	root = tree->create_item();
+}
+
+ScriptTreeList::~ScriptTreeList() {
+}

--- a/editor/plugins/script_tree_list.h
+++ b/editor/plugins/script_tree_list.h
@@ -1,0 +1,88 @@
+/*************************************************************************/
+/*  script_tree_list.h                                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#ifndef SCRIPT_TREE_LIST_H
+#define SCRIPT_TREE_LIST_H
+
+#include "scene/gui/box_container.h"
+#include "scene/gui/control.h"
+#include "scene/gui/tree.h"
+
+class ScriptTreeList : public VBoxContainer {
+
+	GDCLASS(ScriptTreeList, VBoxContainer);
+
+	Tree *tree;
+	TreeItem *root;
+
+	int item_count;
+	int current;
+
+	TreeItem *_get_item(const int p_idx);
+	void _item_selected();
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	void clear();
+	void add_item(const String &p_item, const Ref<Texture> &p_texture = Ref<Texture>());
+	void remove_item(const int p_idx);
+	int get_item_count() const;
+
+	void set_item_metadata(const int p_idx, const Variant &p_metadata);
+	int get_item_metadata(const int p_idx);
+	int find_metadata(const Variant &p_idx) const;
+
+	void set_item_tooltip(const int p_idx, const String &p_tooltip);
+	String get_item_tooltip(const int p_idx);
+
+	void set_item_custom_font_color(const int p_idx, const Color &p_font_color);
+	Color get_item_custom_font_color(const int p_idx);
+
+	void set_item_custom_bg_color(const int p_idx, const Color &p_custom_bg_color);
+	Color get_item_custom_bg_color(const int p_idx);
+
+	void set_item_collapsed(const int p_idx, const bool p_collapsed);
+	bool is_item_collapsed(const int p_idx);
+
+	void add_functions(const int p_idx, const Vector<String> p_functions);
+	void clear_functions(const int p_idx);
+
+	void select(const int p_idx);
+	int get_current() const;
+
+	void update_settings();
+
+	ScriptTreeList();
+	~ScriptTreeList();
+};
+
+#endif


### PR DESCRIPTION
This PR adds a new class `ScriptTreeList` to replace the `ItemList` in the `script_editor_plugin`, and adds quick function access, based on @puppetmaster- mockup in #2732.

The `ScriptTreeList` follows the same API as the `ItemList` class. It comes with a setting to enable list mode that will make it behave as before. If not running in list mode the `ScriptTreeList` will create a drop down containing all function in that file. By clicking on the function it will open the file and go to the function.

![code_tree](https://cloud.githubusercontent.com/assets/6584330/17463972/6a9d1398-5ccb-11e6-94f2-d422e14bf8bb.png)

closes #3238
