### PR TITLE
Revert documentation of return type for FuncRef::call_func from b80c42e

### DIFF
--- a/core/func_ref.cpp
+++ b/core/func_ref.cpp
@@ -65,7 +65,7 @@ void FuncRef::_bind_methods() {
 			mi.arguments.push_back( PropertyInfo( Variant::NIL, "arg"+itos(i)));
 			defargs.push_back(Variant());
 		}
-		ObjectTypeDB::bind_native_method(METHOD_FLAGS_DEFAULT,"call_func:Variant",&FuncRef::call_func,mi,defargs);
+		ObjectTypeDB::bind_native_method(METHOD_FLAGS_DEFAULT,"call_func",&FuncRef::call_func,mi,defargs);
 
 	}
 


### PR DESCRIPTION
Fixes #6035 with minimal changes for 2.1.

See #6055 for the proper fix
