### PR TITLE
This allows building when ALSA libs are in a non-standard location. PK…

### DIFF
--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -155,7 +155,6 @@ def configure(env):
 	if os.system("pkg-config --exists alsa")==0:
 		print("Enabling ALSA")
 		env.Append(CPPFLAGS=["-DALSA_ENABLED"])
-		env.Append(LIBS=['asound'])
 		env.ParseConfig('pkg-config alsa --cflags --libs')
 	else:
 		print("ALSA libraries not found, disabling driver")

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -156,6 +156,7 @@ def configure(env):
 		print("Enabling ALSA")
 		env.Append(CPPFLAGS=["-DALSA_ENABLED"])
 		env.Append(LIBS=['asound'])
+		env.ParseConfig('pkg-config alsa --cflags --libs')
 	else:
 		print("ALSA libraries not found, disabling driver")
 


### PR DESCRIPTION
…G_CONFIG_PATH alone is not enough as the final link fails. Adding this makes the final link succeed.

It seems like the correct way to handle this situation.  But I don't know SCons really at all so there may be some settings that are not getting propagated all the way through all the build steps. Just to reiterate the build progresses all the way to the end but fails at the final application link stage.

Here's my build command:

PKG_CONFIG_PATH=/path/to/alsalib/lib/pkgconfig:$PKG_CONFIG_PATH scons -j 4 platform=x11 tools=yes bits=64 2>&1 | tee make.log
