### PR TITLE
Add a Close All files option to script editor

### DIFF
--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -480,6 +480,33 @@ void ScriptEditor::_close_docs_tab() {
 
 }
 
+void ScriptEditor::_close_all_tabs() {
+
+	int child_count = tab_container->get_child_count();
+	for (int i = child_count-1; i>=0; i--) {
+
+		tab_container->set_current_tab(i);
+		ScriptEditorBase *se = tab_container->get_child(i)->cast_to<ScriptEditorBase>();
+
+		if (se) {
+
+			// Maybe there are unsaved changes
+			if (se->is_unsaved()) {
+				_ask_close_current_unsaved_tab(se);
+				continue;
+			}
+
+		}
+
+		_close_current_tab();
+	}
+
+}
+
+void ScriptEditor::_ask_close_current_unsaved_tab(ScriptEditorBase *current) {
+	erase_tab_confirm->set_text("Close and save changes?\n\""+current->get_name()+"\"");
+	erase_tab_confirm->popup_centered_minsize();
+}
 
 
 void ScriptEditor::_resave_scripts(const String& p_str) {
@@ -831,14 +858,16 @@ void ScriptEditor::_menu_option(int p_option) {
 
 			case FILE_CLOSE: {
 				if (current->is_unsaved()) {
-					erase_tab_confirm->set_text("Close and save changes?\n\""+current->get_name()+"\"");
-					erase_tab_confirm->popup_centered_minsize();
+					_ask_close_current_unsaved_tab(current);
 				} else {
 					_close_current_tab();
 				}
 			} break;
 			case CLOSE_DOCS: {
 				_close_docs_tab();
+			} break;
+			case CLOSE_ALL: {
+				_close_all_tabs();
 			} break;
 			case DEBUG_NEXT: {
 
@@ -912,6 +941,9 @@ void ScriptEditor::_menu_option(int p_option) {
 			} break;
 			case CLOSE_DOCS: {
 				_close_docs_tab();
+			} break;
+			case CLOSE_ALL: {
+				_close_all_tabs();
 			} break;
 
 
@@ -1949,6 +1981,7 @@ void ScriptEditor::_bind_methods() {
 	ObjectTypeDB::bind_method("_menu_option",&ScriptEditor::_menu_option);
 	ObjectTypeDB::bind_method("_close_current_tab",&ScriptEditor::_close_current_tab);
 	ObjectTypeDB::bind_method("_close_docs_tab", &ScriptEditor::_close_docs_tab);
+	ObjectTypeDB::bind_method("_close_all_tabs", &ScriptEditor::_close_all_tabs);
 	ObjectTypeDB::bind_method("_editor_play",&ScriptEditor::_editor_play);
 	ObjectTypeDB::bind_method("_editor_pause",&ScriptEditor::_editor_pause);
 	ObjectTypeDB::bind_method("_editor_stop",&ScriptEditor::_editor_stop);
@@ -2039,6 +2072,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	file_menu->get_popup()->add_separator();
 	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/close_docs", TTR("Close Docs")), CLOSE_DOCS);
 	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/close_file", TTR("Close"), KEY_MASK_CMD | KEY_W), FILE_CLOSE);
+	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/close_all", TTR("Close All")), CLOSE_ALL);
 	file_menu->get_popup()->connect("item_pressed", this,"_menu_option");
 
 

--- a/tools/editor/plugins/script_editor_plugin.h
+++ b/tools/editor/plugins/script_editor_plugin.h
@@ -132,6 +132,7 @@ class ScriptEditor : public VBoxContainer {
 		FILE_SAVE_THEME_AS,
 		FILE_CLOSE,
 		CLOSE_DOCS,
+		CLOSE_ALL,
 		FILE_TOOL_RELOAD,
 		FILE_TOOL_RELOAD_SOFT,
 		DEBUG_NEXT,
@@ -220,6 +221,9 @@ class ScriptEditor : public VBoxContainer {
 
 	void _close_current_tab();
 	void _close_docs_tab();
+	void _close_all_tabs();
+
+	void _ask_close_current_unsaved_tab(ScriptEditorBase *current);
 
 	bool grab_focus_block;
 


### PR DESCRIPTION
I got annoyed to have to close all opened scripts manually and added an option that closes all scripts and docs.

![bildschirmfoto von 2016-08-13 03-09-01](https://cloud.githubusercontent.com/assets/1311798/17640590/54fe35e4-6103-11e6-9079-7c099d471e3d.png)

It's not perfect though. When there are mulitple unsaved files, only the first triggers a dialog while the others remain open.

I also don't know why I get 
`ERROR: set_current_tab: Index p_current out of size (get_tab_count()).
   At: scene/gui/tab_container.cpp:453`

when closing more than 1 file, but it happens with Close Docs as well, so I don't think I'm at fault.

It's not compatible with 2.1, because ScriptTextEditor is now a ScriptEditorBase, but it's easily backported if needed.
