### PR TITLE
Add Node2d global rot/rotd/scale methods

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -22242,6 +22242,27 @@
 				Return the global position of the 2D node.
 			</description>
 		</method>
+		<method name="get_global_rot" qualifiers="const">
+				<return type="float">
+				</return>
+				<description>
+					Return the global rotation in radians of the 2D node.
+				</description>
+		</method>
+		<method name="get_global_rotd" qualifiers="const">
+				<return type="float">
+				</return>
+				<description>
+					Return the global rotation in degrees of the 2D node.
+				</description>
+		</method>
+		<method name="get_global_scale" qualifiers="const">
+				<return type="Vector2">
+				</return>
+				<description>
+					Return the global scale of the 2D node.
+				</description>
+		</method>
 		<method name="get_pos" qualifiers="const">
 			<return type="Vector2">
 			</return>
@@ -22344,6 +22365,27 @@
 			<description>
 				Set the global position of the 2D node to 'pos'.
 			</description>
+		</method>
+		<method name="set_global_rot">
+				<argument index="0" name="radians" type="float">
+				</argument>
+				<description>
+					Set the global rotation in radians of the 2D node.
+				</description>
+		</method>
+		<method name="set_global_rotd">
+				<argument index="0" name="degrees" type="float">
+				</argument>
+				<description>
+					Set the global rotation in degrees of the 2D node.
+				</description>
+		</method>
+		<method name="set_global_scale">
+				<argument index="0" name="scale" type="Vector2">
+				</argument>
+				<description>
+					Set the global scale of the 2D node.
+				</description>
 		</method>
 		<method name="set_global_transform">
 			<argument index="0" name="xform" type="Matrix32">

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -295,6 +295,53 @@ void Node2D::set_global_pos(const Point2& p_pos) {
 	}
 }
 
+
+float Node2D::get_global_rot() const {
+
+	return get_global_transform().get_rotation();
+}
+
+void Node2D::set_global_rot(float p_radians) {
+
+	CanvasItem *pi = get_parent_item();
+	if (pi) {
+		const float parent_global_rot = pi->get_global_transform().get_rotation();
+		set_rot(p_radians - parent_global_rot);
+	} else {
+		set_rot(p_radians);
+	}
+}
+
+
+float Node2D::get_global_rotd() const {
+
+	return Math::rad2deg(get_global_rot());
+}
+
+void Node2D::set_global_rotd(float p_degrees) {
+
+	set_global_rot(Math::deg2rad(p_degrees));
+}
+
+
+Size2 Node2D::get_global_scale() const {
+
+	return get_global_transform().get_scale();
+}
+
+void Node2D::set_global_scale(const Size2& p_scale) {
+
+	CanvasItem *pi = get_parent_item();
+	if (pi) {
+		const Size2 parent_global_scale = pi->get_global_transform().get_scale();
+		set_scale(p_scale - parent_global_scale);
+	} else {
+		set_scale(p_scale);
+	}
+
+}
+
+
 void Node2D::set_transform(const Matrix32& p_transform) {
 
 	_mat=p_transform;
@@ -398,6 +445,12 @@ void Node2D::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("set_global_pos","pos"),&Node2D::set_global_pos);
 	ObjectTypeDB::bind_method(_MD("get_global_pos"),&Node2D::get_global_pos);
+	ObjectTypeDB::bind_method(_MD("set_global_rot","radians"),&Node2D::set_global_rot);
+	ObjectTypeDB::bind_method(_MD("get_global_rot"),&Node2D::get_global_rot);
+	ObjectTypeDB::bind_method(_MD("set_global_rotd","degrees"),&Node2D::set_global_rotd);
+	ObjectTypeDB::bind_method(_MD("get_global_rotd"),&Node2D::get_global_rotd);
+	ObjectTypeDB::bind_method(_MD("set_global_scale","scale"),&Node2D::set_global_scale);
+	ObjectTypeDB::bind_method(_MD("get_global_scale"),&Node2D::get_global_scale);
 
 	ObjectTypeDB::bind_method(_MD("set_transform","xform"),&Node2D::set_transform);
 	ObjectTypeDB::bind_method(_MD("set_global_transform","xform"),&Node2D::set_global_transform);

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -87,11 +87,17 @@ public:
 	Size2 get_scale() const;
 
 	Point2 get_global_pos() const;
+	float get_global_rot() const;
+	float get_global_rotd() const;
+	Size2 get_global_scale() const;
 	virtual Rect2 get_item_rect() const;
 
 	void set_transform(const Matrix32& p_transform);
 	void set_global_transform(const Matrix32& p_transform);
 	void set_global_pos(const Point2& p_pos);
+	void set_global_rot(float p_radians);
+	void set_global_rotd(float p_degrees);
+	void set_global_scale(const Size2& p_scale);
 
 	void set_z(int p_z);
 	int get_z() const;


### PR DESCRIPTION
This PR is related to issue #6148.
It implement in Node2D the following methods:
- set_global_rot
- get_global_rot
- set_global_rotd
- get_global_rotd
- set_global_scale
- get_global_scale

I didn't see any clear place where to add tests, is there a policy on this ?
