### PR TITLE
Fix StreamPeerBuffer::duplicate() does not return value

### DIFF
--- a/core/io/stream_peer.cpp
+++ b/core/io/stream_peer.cpp
@@ -544,6 +544,7 @@ Ref<StreamPeerBuffer> StreamPeerBuffer::duplicate() const {
 	Ref<StreamPeerBuffer> spb;
 	spb.instance();
 	spb->data=data;
+	return spb;
 }
 
 


### PR DESCRIPTION
And this causes compiling failure on Windows.
