### PR TITLE
Fix StreamPeerBuffer 'duplicate' method not returning a value.

### DIFF
--- a/core/io/stream_peer.cpp
+++ b/core/io/stream_peer.cpp
@@ -544,6 +544,8 @@ Ref<StreamPeerBuffer> StreamPeerBuffer::duplicate() const {
 	Ref<StreamPeerBuffer> spb;
 	spb.instance();
 	spb->data=data;
+
+	return spb;
 }
 
 


### PR DESCRIPTION
Fixes simple compile error.
