### PR TITLE
DocData: Fix null reference not detected correctly

### DIFF
--- a/tools/doc/doc_data.cpp
+++ b/tools/doc/doc_data.cpp
@@ -294,6 +294,10 @@ void DocData::generate(bool p_basic_types) {
 								default_arg_text=Variant::get_type_name(default_arg.get_type())+"("+default_arg_text+")";
 								break;
 							case Variant::OBJECT:
+								if (default_arg.is_zero()) {
+									default_arg_text="NULL";
+									break;
+								}
 							case Variant::INPUT_EVENT:
 							case Variant::DICTIONARY:		// 20
 							case Variant::ARRAY:


### PR DESCRIPTION
Now `DEFVAL(Ref<Type>())` will be translated as `NULL` in the docs instead of `Object()`, so using `DEFVAL(Variant())` instead won't be needed any more.
