### PR TITLE
Resize autoload buttons and singleton columns

### DIFF
--- a/tools/editor/editor_autoload_settings.cpp
+++ b/tools/editor/editor_autoload_settings.cpp
@@ -602,10 +602,10 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 
 	tree->set_column_title(2,TTR("Singleton"));
 	tree->set_column_expand(2,false);
-	tree->set_column_min_width(2,80);
+	tree->set_column_min_width(2,150);
 
 	tree->set_column_expand(3,false);
-	tree->set_column_min_width(3,80);
+	tree->set_column_min_width(3,160);
 
 	tree->connect("cell_selected", this, "_autoload_selected");
 	tree->connect("item_edited", this, "_autoload_edited");


### PR DESCRIPTION
Problem on retina displays in hidpi mode.

Currently:
https://i.gyazo.com/b033e51857f8187dfd0916f5ebb701aa.png

After my fix:
https://i.gyazo.com/2ac3232f2a56049bf9dc5cb7ea9e6741.png

Can't test on non retina display
