### PR TITLE
fix string iterator

### DIFF
--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -3046,7 +3046,7 @@ bool Variant::iter_next(Variant& r_iter,bool &valid) const {
 			const String *str=reinterpret_cast<const String*>(_data._mem);
 			int idx = r_iter;
 			idx++;
-			if (idx >= str->size())
+			if (idx >= str->length())
 				return false;
 			r_iter = idx;
 			return true;


### PR DESCRIPTION
Since strings are null-terminated, size() returns incorrect length,
so use length() instead.

fixes #6287
