### PR TITLE
(Array) .pop_front, .pop_back & .remove return values instead of void

### DIFF
--- a/core/array.cpp
+++ b/core/array.cpp
@@ -276,16 +276,26 @@ void Array::push_front(const Variant& p_value) {
 	_p->array.insert(0,p_value);
 }
 
-void Array::pop_back(){
+Variant Array::pop_back(){
 
-	if (!_p->array.empty())
-		_p->array.resize( _p->array.size() -1 );
+	if (!_p->array.empty()) {
+		int n = _p->array.size() - 1;
+		Variant ret = _p->array.get(n);
+		_p->array.resize(n);
+		return ret;
+	}
+	return Variant();
 
 }
-void Array::pop_front(){
 
-	if (!_p->array.empty())
+Variant Array::pop_front(){
+
+	if (!_p->array.empty()) {
+		Variant ret = _p->array.get(0);
 		_p->array.remove(0);
+		return ret;
+	}
+	return Variant();
 
 }
 

--- a/core/array.h
+++ b/core/array.h
@@ -80,8 +80,8 @@ public:
 	void erase(const Variant& p_value);
 
 	void push_front(const Variant& p_value);
-	void pop_back();
-	void pop_front();
+	Variant pop_back();
+	Variant pop_front();
 
 	Array(const Array& p_from);
 	Array(bool p_shared=false);

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -464,8 +464,8 @@ static void _call_##m_type##_##m_method(Variant& r_ret,Variant& p_self,const Var
 	VCALL_LOCALMEM0R(Array,hash);
 	VCALL_LOCALMEM1(Array,push_back);
 	VCALL_LOCALMEM1(Array,push_front);
-	VCALL_LOCALMEM0(Array,pop_back);
-	VCALL_LOCALMEM0(Array,pop_front);
+	VCALL_LOCALMEM0R(Array,pop_back);
+	VCALL_LOCALMEM0R(Array,pop_front);
 	VCALL_LOCALMEM1(Array,append);
 	VCALL_LOCALMEM1(Array,resize);
 	VCALL_LOCALMEM2(Array,insert);


### PR DESCRIPTION
`.pop_front`, `.pop_back` & `.remove` now return values instead of `void`. Things
that don't work or I didn't know how to properly handle:
1. `.pop_front` & `.pop_back` shows in the help menu `Object` as return value.
   I know this is incorrect but if not `Object` than what? Cause it
   can't be `void`. It needs to be a generic type that includes all the
   `Array` types
2. `.remove` works OK as long as it has something to return, if the index
   is out of bounds it just terminates the application and gives this
   error:
   
   ```
   ERROR: operator[]: Condition ' p_index<0 || p_index>=size() ' is true. returned: aux
   At: core/vector.h:144
   ```
   
   That's because I used `ERR_FAIL_INDEX_V` inside of `DVector::remove()`,
   but I don't know how else to implement this.
