### PR TITLE
magic _str method

### DIFF
--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -1673,6 +1673,7 @@ Variant::operator String() const {
 						};
 					};
 				#endif
+				if (_get_obj().obj->has_method("_str")) return _get_obj().obj->call("_str");
 				return "["+_get_obj().obj->get_type()+":"+itos(_get_obj().obj->get_instance_ID())+"]";
 			} else
 				return "[Object:null]";


### PR DESCRIPTION
Python has many magic methods, one of them [**str**](https://docs.python.org/2/reference/datamodel.html#object.__str__) 

I propose to add same magic to GDScript. This PR is just proof of concept. I tested some expressions and all works ok, but probably I forgot something

Example:

```
func _str(): return "Test.gd script"
```

Was:

```
print(self) # [Node:588]
print("Init %s" % self) # Init [Node:552]
```

Now:

```
print(self) # Test.gd script
print("Init %s" % self) # init Test.gd script
```
