### PR TITLE
Windows: Hide the mouse cursor when MOUSE_MODE_CAPTURED is activated.

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1364,7 +1364,9 @@ void OS_Windows::set_mouse_mode(MouseMode p_mode) {
 		POINT pos = { (int) center.x, (int) center.y };
 		ClientToScreen(hWnd, &pos);
 		SetCursorPos(pos.x, pos.y);
+		ShowCursor(false);
 	} else {
+		ShowCursor(true);
 		ReleaseCapture();
 		ClipCursor(NULL);
 	}


### PR DESCRIPTION
The reference of the [Input class](http://docs.godotengine.org/en/latest/classes/class_input.html#numeric-constants) constants states:

> **MOUSE_MODE_CAPTURED**: Captures the mouse. The mouse will be hidden and unable to leave the game window. But it will still register movement and mouse button presses.

This pull request will hide the mouse cursor on `Input.set_mouse_mode(MOUSE_MODE_CAPTURED)` and shows it on `Input.set_mouse_mode(MOUSE_MODE_VISIBLE)`.
