### PR TITLE
Tween: fix non-repeat interpolate_callback

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -619,6 +619,8 @@ void Tween::_tween_process(float p_delta) {
 					};
 					object->call(data.key, (const Variant **) arg, data.args, error);
 				}
+				if (!repeat)
+					call_deferred("remove", object, data.key);
 			}
 			continue;
 		}


### PR DESCRIPTION
Tween: fix non-repeat interpolate_callback does not delete after call triggered
