### PR TITLE
Fix release build. (II)

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -54,10 +54,10 @@ struct _VariantCall {
 		int arg_count;
 		Vector<Variant> default_args;
 		Vector<Variant::Type> arg_types;
-
-#ifdef DEBUG_ENABLED
 		Vector<StringName> arg_names;
 		Variant::Type return_type;
+
+#ifdef DEBUG_ENABLED
 		bool returns;
 #endif
 		VariantFunc func;


### PR DESCRIPTION
Same topic like in #6309.
- **variant_call.cpp**: make the members `arg_names` + `return_type` also available for the release build.

@reduz same story: please check if this is okay for you.
@akien-mga: Sorry for the mess.
- This should fix #6134.
- #6291 should be closed now. It will have the same compilation errors than #6134 right now.
