### PR TITLE
Add http method and request data parameters to HTTPRequest::request

### DIFF
--- a/scene/main/http_request.h
+++ b/scene/main/http_request.h
@@ -66,6 +66,8 @@ private:
 	Vector<String> headers;
 	bool validate_ssl;
 	bool use_ssl;
+	HTTPClient::Method method;
+	String request_data;
 
 	bool request_sent;
 	Ref<HTTPClient> client;
@@ -114,7 +116,7 @@ protected:
 	static void _bind_methods();
 public:
 
-	Error request(const String& p_url,const Vector<String>& p_custom_headers=Vector<String>(),bool p_ssl_validate_domain=true); //connects to a full url and perform request
+	Error request(const String& p_url, const Vector<String>& p_custom_headers=Vector<String>(), bool p_ssl_validate_domain=true, HTTPClient::Method p_method=HTTPClient::METHOD_GET, const String& p_request_data=""); //connects to a full url and perform request
 	void cancel_request();
 	HTTPClient::Status get_http_client_status() const;
 


### PR DESCRIPTION
Implements feature proposed in #4028.
- scene/main/http_request.{h,cpp}: add `method` and `request_data` parameters to `HTTPRequest::request`

This is my first PR in Godot. Hope it helps.
