### PR TITLE
Fixes LineEdit text selection with mouse selecting more than intended

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -806,16 +806,6 @@ void LineEdit::set_cursor_at_pixel_pos(int p_x) {
 		pixel_ofs+=char_w;
 
 		if (pixel_ofs > p_x) { //found what we look for
-
-
-			if ( (pixel_ofs-p_x) < (char_w >> 1 ) ) {
-
-				ofs+=1;
-			} else if ( (pixel_ofs-p_x) > (char_w >> 1 ) ) {
-
-				ofs-=1;
-			}
-
 			break;
 		}
 


### PR DESCRIPTION
LineEdit control was selecting +1/-1 character when text was selected with mouse. Not anymore.

Check this out:
![godot_line_edit](https://cloud.githubusercontent.com/assets/160668/18208970/14264786-7108-11e6-9fff-986b6f935142.gif)

Fix #6174 
