### PR TITLE
Select newly created folder on Directory dialog

### DIFF
--- a/tools/editor/editor_dir_dialog.cpp
+++ b/tools/editor/editor_dir_dialog.cpp
@@ -143,7 +143,7 @@ void EditorDirDialog::set_current_path(const String& p_path) {
 	reload();
 	String p = p_path;
 	if (p.begins_with("res://"))
-		p.replace_first("res://","");
+		p = p.replace_first("res://","");
 
 	Vector<String> dirs = p.split("/");
 
@@ -162,13 +162,13 @@ void EditorDirDialog::set_current_path(const String& p_path) {
 		ERR_FAIL_COND(!p);
 		String pp = p->get_metadata(0);
 		if (pp=="") {
+			p->set_metadata(0,String(r->get_metadata(0)).plus_file(d));
 			_update_dir(p);
-			updating=true;
-			p->set_collapsed(false);
-			updating=false;
-			_item_collapsed(p);
-
 		}
+		updating=true;
+		p->set_collapsed(false);
+		updating=false;
+		_item_collapsed(p);
 		r=p;
 	}
 
@@ -216,7 +216,7 @@ void EditorDirDialog::_make_dir_confirm() {
 	if (err!=OK) {
 		mkdirerr->popup_centered_minsize(Size2(250,80));
 	} else {
-		reload();
+		set_current_path(dir.plus_file(makedirname->get_text()));
 	}
 	makedirname->set_text(""); // reset label
 }


### PR DESCRIPTION
File tree resets when create folder now.
![current](https://cloud.githubusercontent.com/assets/8281454/18257731/90aceed8-7403-11e6-9430-aad54cf09a0c.gif)

Make it to select new folder with this PR
![after](https://cloud.githubusercontent.com/assets/8281454/18257735/a3bc74b2-7403-11e6-8af2-6cbfaec11c3e.gif)
