### PR TITLE
Show object string cast instead of object id in debugger

### DIFF
--- a/core/script_debugger_remote.cpp
+++ b/core/script_debugger_remote.cpp
@@ -219,7 +219,8 @@ void ScriptDebuggerRemote::debug(ScriptLanguage *p_script,bool p_can_continue) {
 
 						if (F->get().get_type()==Variant::OBJECT) {
 							packet_peer_stream->put_var("*"+E->get());
-							packet_peer_stream->put_var(safe_get_instance_id(F->get()));
+							String pretty_print = F->get().operator String();
+							packet_peer_stream->put_var(pretty_print.ascii().get_data());
 						} else {
 							packet_peer_stream->put_var(E->get());
 							packet_peer_stream->put_var(F->get());
@@ -242,7 +243,8 @@ void ScriptDebuggerRemote::debug(ScriptLanguage *p_script,bool p_can_continue) {
 
 						if (F->get().get_type()==Variant::OBJECT) {
 							packet_peer_stream->put_var("*"+E->get());
-							packet_peer_stream->put_var(safe_get_instance_id(F->get()));
+							String pretty_print = F->get().operator String();
+							packet_peer_stream->put_var(pretty_print.ascii().get_data());
 						} else {
 							packet_peer_stream->put_var(E->get());
 							packet_peer_stream->put_var(F->get());


### PR DESCRIPTION
Fixes #6374 

![bildschirmfoto von 2016-09-06 00-43-55](https://cloud.githubusercontent.com/assets/1311798/18257858/08795930-73cb-11e6-8c91-bd492cba39c0.png)
