### PR TITLE
Always show output panel when debugging

### DIFF
--- a/tools/editor/script_editor_debugger.cpp
+++ b/tools/editor/script_editor_debugger.cpp
@@ -1087,6 +1087,9 @@ void ScriptEditorDebugger::start() {
 
 	stop();
 
+	if (!EditorNode::get_log()->is_visible()) {
+		EditorNode::get_singleton()->make_bottom_panel_item_visible(EditorNode::get_log());
+	}
 
 	uint16_t port = GLOBAL_DEF("debug/remote_port",6007);
 	perf_history.clear();


### PR DESCRIPTION
Fixes #6029 

Now the Output panel is guaranteed to be visible when hitting F5.
