### PR TITLE
enable autoload for command-line scripts

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1294,9 +1294,10 @@ bool Main::start() {
 		}
 
 
+		String local_game_path;
 		if (game_path!="" && !project_manager_request) {
 
-			String local_game_path=game_path.replace("\\","/");
+			local_game_path=game_path.replace("\\","/");
 
 			if (!local_game_path.begins_with("res://")) {
 				bool absolute=(local_game_path.size()>1) && (local_game_path[0]=='/' || local_game_path[1]==':');
@@ -1363,98 +1364,99 @@ bool Main::start() {
 				OS::get_singleton()->set_context(OS::CONTEXT_EDITOR);
 
 				//editor_node->set_edited_scene(game);
-			} else {
+			}
 #endif
+		}
 
-				{
-					//autoload
-					List<PropertyInfo> props;
-					Globals::get_singleton()->get_property_list(&props);
+		if (!project_manager_request && !editor) {
+			if (game_path!="" || script!="") {
+				//autoload
+				List<PropertyInfo> props;
+				Globals::get_singleton()->get_property_list(&props);
 
-					//first pass, add the constants so they exist before any script is loaded
-					for(List<PropertyInfo>::Element *E=props.front();E;E=E->next()) {
+				//first pass, add the constants so they exist before any script is loaded
+				for(List<PropertyInfo>::Element *E=props.front();E;E=E->next()) {
 
-						String s = E->get().name;
-						if (!s.begins_with("autoload/"))
-							continue;
-						String name = s.get_slicec('/',1);
-						String path = Globals::get_singleton()->get(s);
-						bool global_var=false;
-						if (path.begins_with("*")) {
-							global_var=true;
-						}
-
-						if (global_var) {
-							for(int i=0;i<ScriptServer::get_language_count();i++) {
-								ScriptServer::get_language(i)->add_global_constant(name,Variant());
-							}
-						}
-
+					String s = E->get().name;
+					if (!s.begins_with("autoload/"))
+						continue;
+					String name = s.get_slicec('/',1);
+					String path = Globals::get_singleton()->get(s);
+					bool global_var=false;
+					if (path.begins_with("*")) {
+						global_var=true;
 					}
 
-					//second pass, load into global constants
-					List<Node*> to_add;
-					for(List<PropertyInfo>::Element *E=props.front();E;E=E->next()) {
-
-						String s = E->get().name;
-						if (!s.begins_with("autoload/"))
-							continue;
-						String name = s.get_slicec('/',1);
-						String path = Globals::get_singleton()->get(s);
-						bool global_var=false;
-						if (path.begins_with("*")) {
-							global_var=true;
-							path=path.substr(1,path.length()-1);
+					if (global_var) {
+						for(int i=0;i<ScriptServer::get_language_count();i++) {
+							ScriptServer::get_language(i)->add_global_constant(name,Variant());
 						}
-
-						RES res = ResourceLoader::load(path);
-						ERR_EXPLAIN("Can't autoload: "+path);
-						ERR_CONTINUE(res.is_null());
-						Node *n=NULL;
-						if (res->is_type("PackedScene")) {
-							Ref<PackedScene> ps = res;
-							n=ps->instance();
-						} else if (res->is_type("Script")) {
-							Ref<Script> s = res;
-							StringName ibt = s->get_instance_base_type();
-							bool valid_type = ObjectTypeDB::is_type(ibt,"Node");
-							ERR_EXPLAIN("Script does not inherit a Node: "+path);
-							ERR_CONTINUE( !valid_type );
-
-							Object *obj = ObjectTypeDB::instance(ibt);
-
-							ERR_EXPLAIN("Cannot instance script for autoload, expected 'Node' inheritance, got: "+String(ibt));
-							ERR_CONTINUE( obj==NULL );
-
-							n = obj->cast_to<Node>();
-							n->set_script(s.get_ref_ptr());
-						}
-
-						ERR_EXPLAIN("Path in autoload not a node or script: "+path);
-						ERR_CONTINUE(!n);
-						n->set_name(name);
-
-						//defer so references are all valid on _ready()
-						//sml->get_root()->add_child(n);
-						to_add.push_back(n);
-
-						if (global_var) {
-							for(int i=0;i<ScriptServer::get_language_count();i++) {
-								ScriptServer::get_language(i)->add_global_constant(name,n);
-							}
-						}
-
 					}
-
-					for(List<Node*>::Element *E=to_add.front();E;E=E->next()) {
-
-						sml->get_root()->add_child(E->get());
-					}
-
-
 
 				}
 
+				//second pass, load into global constants
+				List<Node*> to_add;
+				for(List<PropertyInfo>::Element *E=props.front();E;E=E->next()) {
+
+					String s = E->get().name;
+					if (!s.begins_with("autoload/"))
+						continue;
+					String name = s.get_slicec('/',1);
+					String path = Globals::get_singleton()->get(s);
+					bool global_var=false;
+					if (path.begins_with("*")) {
+						global_var=true;
+						path=path.substr(1,path.length()-1);
+					}
+
+					RES res = ResourceLoader::load(path);
+					ERR_EXPLAIN("Can't autoload: "+path);
+					ERR_CONTINUE(res.is_null());
+					Node *n=NULL;
+					if (res->is_type("PackedScene")) {
+						Ref<PackedScene> ps = res;
+						n=ps->instance();
+					} else if (res->is_type("Script")) {
+						Ref<Script> s = res;
+						StringName ibt = s->get_instance_base_type();
+						bool valid_type = ObjectTypeDB::is_type(ibt,"Node");
+						ERR_EXPLAIN("Script does not inherit a Node: "+path);
+						ERR_CONTINUE( !valid_type );
+
+						Object *obj = ObjectTypeDB::instance(ibt);
+
+						ERR_EXPLAIN("Cannot instance script for autoload, expected 'Node' inheritance, got: "+String(ibt));
+						ERR_CONTINUE( obj==NULL );
+
+						n = obj->cast_to<Node>();
+						n->set_script(s.get_ref_ptr());
+					}
+
+					ERR_EXPLAIN("Path in autoload not a node or script: "+path);
+					ERR_CONTINUE(!n);
+					n->set_name(name);
+
+					//defer so references are all valid on _ready()
+					//sml->get_root()->add_child(n);
+					to_add.push_back(n);
+
+					if (global_var) {
+						for(int i=0;i<ScriptServer::get_language_count();i++) {
+							ScriptServer::get_language(i)->add_global_constant(name,n);
+						}
+					}
+
+				}
+
+				for(List<Node*>::Element *E=to_add.front();E;E=E->next()) {
+
+					sml->get_root()->add_child(E->get());
+				}
+				//singletons
+			}
+
+			if (game_path!="") {
 				Node *scene=NULL;
 				Ref<PackedScene> scenedata = ResourceLoader::load(local_game_path);
 				if (scenedata.is_valid())
@@ -1471,12 +1473,7 @@ bool Main::start() {
 					if (icon.load(iconpath)==OK)
 						OS::get_singleton()->set_icon(icon);
 				}
-
-
-				//singletons
-#ifdef TOOLS_ENABLED
 			}
-#endif
 		}
 
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
fixes #6360

Note that while this might look like a lot of changes, it's only because of indentation (diff without it: https://github.com/godotengine/godot/pull/6413/commits/8ddc0b697b26797d2d5682a9112dff59c950b22a?w=1). Only real difference is in conditions: autoload code is executed if either `game_path` **or** `script` is non-empty.
