### PR TITLE
Fix Android build (#5645)

### DIFF
--- a/platform/android/build.gradle.template
+++ b/platform/android/build.gradle.template
@@ -67,7 +67,6 @@ android {
 				$$GRADLE_ASSET_DIRS$$
 			]
 			jniLibs.srcDirs = [
-				'libs'
 				$$GRADLE_JNI_DIRS$$
 			]
 		}


### PR DESCRIPTION
Well, I've come across the issue some people are getting, too.
As I've found Gradle intermediate library directories gets messy, I've removed the unused specification of a libraries directory for all build types so it now appears to work better.
