### PR TITLE
Itemlist tooltip disable issue 6240

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -17920,6 +17920,15 @@
 				Return tooltip hint for specified item index.
 			</description>
 		</method>
+		<method name="is_item_tooltip_enabled" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<description>
+				Returns whether the tooptip is enabled for specified item index.
+			</description>
+		</method>
 		<method name="get_max_columns" qualifiers="const">
 			<return type="int">
 			</return>
@@ -18099,6 +18108,15 @@
 			</argument>
 			<description>
 				Sets tooltip hint for item at specified index.
+			</description>
+		</method>
+		<method name="set_item_tooltip_enabled">
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<argument index="1" name="enable" type="bool">
+			</argument>
+			<description>
+				Sets whether the tooltip is enabled for specified item index.
 			</description>
 		</method>
 		<method name="set_max_columns">

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -40,6 +40,7 @@ void ItemList::add_item(const String& p_item,const Ref<Texture>& p_texture,bool 
 	item.selectable=p_selectable;
 	item.selected=false;
 	item.disabled=false;
+	item.tooltip_enabled=true;
 	item.custom_bg=Color(0,0,0,0);
 	items.push_back(item);
 
@@ -57,6 +58,7 @@ void ItemList::add_icon_item(const Ref<Texture>& p_item,bool p_selectable){
 	item.selectable=p_selectable;
 	item.selected=false;
 	item.disabled=false;
+	item.tooltip_enabled=true;
 	item.custom_bg=Color(0,0,0,0);
 	items.push_back(item);
 
@@ -80,6 +82,16 @@ String ItemList::get_item_text(int p_idx) const{
 	ERR_FAIL_INDEX_V(p_idx,items.size(),String());
 	return items[p_idx].text;
 
+}
+
+void ItemList::set_item_tooltip_enabled(int p_idx, const bool p_enabled) {
+	ERR_FAIL_INDEX(p_idx,items.size());
+	items[p_idx].tooltip_enabled = p_enabled;
+}
+
+bool ItemList::is_item_tooltip_enabled(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx,items.size(), false);
+	return items[p_idx].tooltip_enabled;
 }
 
 void ItemList::set_item_tooltip(int p_idx,const String& p_tooltip){
@@ -1198,6 +1210,9 @@ String ItemList::get_tooltip(const Point2& p_pos) const {
 	int closest = get_item_at_pos(p_pos);
 
 	if (closest!=-1) {
+		if (!items[closest].tooltip_enabled) {
+			return "";
+		}
 		if (items[closest].tooltip!="") {
 			return items[closest].tooltip;
 		}
@@ -1293,6 +1308,9 @@ void ItemList::_bind_methods(){
 
 	ObjectTypeDB::bind_method(_MD("set_item_custom_bg_color","idx","custom_bg_color"),&ItemList::set_item_custom_bg_color);
 	ObjectTypeDB::bind_method(_MD("get_item_custom_bg_color","idx"),&ItemList::get_item_custom_bg_color);
+
+	ObjectTypeDB::bind_method(_MD("set_item_tooltip_enabled","idx","enable"),&ItemList::set_item_tooltip_enabled);
+	ObjectTypeDB::bind_method(_MD("is_item_tooltip_enabled","idx"),&ItemList::is_item_tooltip_enabled);
 
 	ObjectTypeDB::bind_method(_MD("set_item_tooltip","idx","tooltip"),&ItemList::set_item_tooltip);
 	ObjectTypeDB::bind_method(_MD("get_item_tooltip","idx"),&ItemList::get_item_tooltip);

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -56,6 +56,7 @@ private:
 		bool selectable;
 		bool selected;
 		bool disabled;
+		bool tooltip_enabled;
 		Variant metadata;
 		String tooltip;
 		Color custom_bg;
@@ -134,6 +135,9 @@ public:
 
 	void set_item_tag_icon(int p_idx,const Ref<Texture>& p_tag_icon);
 	Ref<Texture> get_item_tag_icon(int p_idx) const;
+
+	void set_item_tooltip_enabled(int p_idx, const bool p_enabled);
+	bool is_item_tooltip_enabled(int p_idx) const;
 
 	void set_item_tooltip(int p_idx,const String& p_tooltip);
 	String get_item_tooltip(int p_idx) const;


### PR DESCRIPTION
Added methods to enabled and disable ItemList's Item's Tooltip.

closes #6240 
