### PR TITLE
fixed wrong placement of AcceptDialog Buttons issue-6143

### DIFF
--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -399,8 +399,6 @@ AcceptDialog::AcceptDialog() {
 	add_child(label);
 
 	hbc = memnew( HBoxContainer );
-	hbc->set_area_as_parent_rect(margin);
-	hbc->set_anchor_and_margin(MARGIN_TOP,ANCHOR_END,button_margin);
 	add_child(hbc);
 
 	hbc->add_spacer();


### PR DESCRIPTION
The Buttons of AcceptDialog, ConfirmationDialog and FileDialog were wrong placed after creation.
