### PR TITLE
Correct Directory.list_dir_begin() Documentation

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -10871,7 +10871,7 @@
 			</return>
 			<description>
 				Initialise the stream used to list all files and directories using the [method get_next] function, closing the current opened stream if needed. Once the stream has been processed, it should typically be closed with [method list_dir_end].
-				Return false if the stream could not be initialised.
+				Return true if the stream could not be initialised.
 			</description>
 		</method>
 		<method name="list_dir_end">


### PR DESCRIPTION
Change the documentation to reflect that Directory.list_dir_begin() returns true (not false) when a stream could not be initialized. (See, for
example,
https://github.com/godotengine/godot/blob/master/drivers/windows/dir_access_windows.cpp#L76
)
