### PR TITLE
Change Android float ABI to hard

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -166,13 +166,16 @@ def configure(env):
 	env.Append(CPPPATH=[gcc_include])
 #	env['CCFLAGS'] = string.split('-DNO_THREADS -MMD -MP -MF -fpic -ffunction-sections -funwind-tables -fstack-protector -D__ARM_ARCH_5__ -D__ARM_ARCH_5T__ -D__ARM_ARCH_5E__ -D__ARM_ARCH_5TE__  -Wno-psabi -march=armv5te -mtune=xscale -msoft-float  -fno-exceptions -mthumb -fno-strict-aliasing -DANDROID -Wa,--noexecstack -DGLES2_ENABLED ')
 
+	libm='m'
 	env['neon_enabled']=False
 	if env['android_arch']=='x86':
 		env['CCFLAGS'] = string.split('-DNO_STATVFS -fpic -ffunction-sections -funwind-tables -fstack-protector -fvisibility=hidden -D__GLIBC__  -Wno-psabi -ftree-vectorize -funsafe-math-optimizations -fno-strict-aliasing -DANDROID -Wa,--noexecstack -DGLES2_ENABLED')
 	elif env["android_arch"]=="armv6":
-		env['CCFLAGS'] = string.split('-DNO_STATVFS -fpic -ffunction-sections -funwind-tables -fstack-protector -fvisibility=hidden -D__ARM_ARCH_6__ -D__GLIBC__  -Wno-psabi -march=armv6 -mfpu=vfp -mfloat-abi=softfp -funsafe-math-optimizations -fno-strict-aliasing -DANDROID -Wa,--noexecstack -DGLES2_ENABLED')
+		env['CCFLAGS'] = string.split('-DNO_STATVFS -fpic -ffunction-sections -funwind-tables -fstack-protector -fvisibility=hidden -D__ARM_ARCH_6__ -D__GLIBC__  -Wno-psabi -march=armv6 -mfpu=vfp -mfloat-abi=hard -D_NDK_MATH_NO_SOFTFP=1 -funsafe-math-optimizations -fno-strict-aliasing -DANDROID -Wa,--noexecstack -DGLES2_ENABLED')
+		libm='m_hard'
 	elif env["android_arch"]=="armv7":
-		env['CCFLAGS'] = string.split('-DNO_STATVFS -fpic -ffunction-sections -funwind-tables -fstack-protector -fvisibility=hidden -D__ARM_ARCH_7__ -D__ARM_ARCH_7A__ -D__GLIBC__  -Wno-psabi -march=armv7-a -mfloat-abi=softfp -ftree-vectorize -funsafe-math-optimizations -fno-strict-aliasing -DANDROID -Wa,--noexecstack -DGLES2_ENABLED')
+		env['CCFLAGS'] = string.split('-DNO_STATVFS -fpic -ffunction-sections -funwind-tables -fstack-protector -fvisibility=hidden -D__ARM_ARCH_7__ -D__ARM_ARCH_7A__ -Wl,--fix-cortex-a8 -D__GLIBC__  -Wno-psabi -march=armv7-a -mfloat-abi=hard -D_NDK_MATH_NO_SOFTFP=1 -ftree-vectorize -funsafe-math-optimizations -fno-strict-aliasing -DANDROID -Wa,--noexecstack -DGLES2_ENABLED')
+		libm='m_hard'
 		if env['android_neon']=='yes':
 			env['neon_enabled']=True
 			env.Append(CCFLAGS=['-mfpu=neon','-D__ARM_NEON__'])
@@ -181,11 +184,11 @@ def configure(env):
 
 	env.Append(LDPATH=[ld_path])
 	env.Append(LIBS=['OpenSLES'])
-#	env.Append(LIBS=['c','m','stdc++','log','EGL','GLESv1_CM','GLESv2','OpenSLES','supc++','android'])
+#	env.Append(LIBS=['c',libm,'stdc++','log','EGL','GLESv1_CM','GLESv2','OpenSLES','supc++','android'])
 	env.Append(LIBS=['EGL','OpenSLES','android'])
-	env.Append(LIBS=['c','m','stdc++','log','GLESv1_CM','GLESv2', 'z'])
+	env.Append(LIBS=['c',libm,'stdc++','log','GLESv1_CM','GLESv2', 'z'])
 
-	env["LINKFLAGS"]= string.split(" -g --sysroot="+ld_sysroot+" -Wl,--no-undefined -Wl,-z,noexecstack ")
+	env["LINKFLAGS"]= string.split(" -g --sysroot="+ld_sysroot+" -Wl,--no-undefined -Wl,-z,noexecstack -Wl,--no-warn-mismatch")
 	env.Append(LINKFLAGS=["-Wl,-soname,libgodot_android.so"])
 
 	if (env["target"]=="release"):


### PR DESCRIPTION
I've done the experiment of compiling the Android export templates with the _hard_ float ABI instead of _soft-fp_. I've written a simple test script and measured:

Current _soft-fp_: 1781 +/- 48 ms
Experimental _hard_: 1796 +/- 53 ms

Pretty surprising for me. I didn't expect a big gain because GDScript is a large bottle neck compared with the floating point calling convention; but a pessimization?

Maybe my test program is not the best one for this task or maybe this has yielded gains in other aspects (render, sound, etc.) and only a real-word example is appropiate for testing.

Or maybe this change just does not improve things at all and should not be merged. However, as long as Godot is built as a whole and the relevant functions are qualified with `JNICALL` it should be safe.

At least I've pushed it for the records in case some day this is considered again so both these notes and the relevant compiler flags, etc. could be grabbed from here.

P. S.: The test program is an empty scene with this code:

```
extends Node2D

func _ready():
    set_process(true)

func _process(delta):
    var start = OS.get_ticks_msec()
    for i in range(0, 1000000):
        i = float(i)
        cos(i) * sqrt(i) + exp(i) / i
    var end = OS.get_ticks_msec()
    print(end - start)
```
