### PR TITLE
Fix the Windows environment in SCons spawn function

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -1379,6 +1379,7 @@ def use_windows_spawn_fix(self, platform=None):
 	    cmdline = cmd + " " + newargs
 
 	    rv=0
+	    env = {str(key): str(value) for key, value in env.iteritems()}
 	    if len(cmdline) > 32000 and cmd.endswith("ar") :
 		    cmdline = cmd + " " + args[1] + " " + args[2] + " "
 		    for i in range(3,len(args)) :


### PR DESCRIPTION
Properly fix #2974 as discussed there. See https://github.com/godotengine/godot/issues/2974#issuecomment-231850125.
