### PR TITLE
Fix/improve AnimationPlayer blending logic

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -583,35 +583,26 @@ void AnimationPlayer::_animation_process2(float p_delta) {
 
 	Playback &c=playback;
 
-	float prev_blend=1.0;
 	accum_pass++;
 
-	int pop_count=1;
-	int pop=0; // if >0, then amount of elements to pop from the back
+	_animation_process_data(c.current,p_delta,1.0f);
 
-
-	for (List<Blend>::Element *E=c.blend.back();E;E=E->prev(),pop_count++) {
+	List<Blend>::Element *prev = NULL;
+	for (List<Blend>::Element *E=c.blend.back();E;E=prev) {
 
 		Blend& b=E->get();
-		_animation_process_data(b.data,p_delta,prev_blend);
-
-		prev_blend=1.0-b.blend_left/b.blend_time;
+		float blend=b.blend_left/b.blend_time;
+		_animation_process_data(b.data,p_delta,blend);
 
 		b.blend_left-=Math::absf(speed_scale*p_delta);
 
+		prev = E->prev();
 		if (b.blend_left<0) {
 
-			pop=pop_count;
+			c.blend.erase(E);
 		}
 	}
-
-	while(pop--) {
-
-		c.blend.pop_back();
-	}
-
-
-	_animation_process_data(c.current,p_delta,prev_blend);
+	
 
 }
 


### PR DESCRIPTION
While _playing_ with the `AnimationPlayer` I found animation blending was misbehaving.

I found that it maintains a list of blended animations so it's able to blend on top of another blend, etc. But the current logic for removing finished animations is broken IMO as it can remove animations still not finished and keep finished animations pointlessly in the list. Also the interpolation weight is out-of-phase as I understand the code. (Maybe if I managed to understood how those two aspects work together I could see the rationale behind the current code, but still it works unnaturally for me,)

So my proposal changes both things: it applies the current animation as it is defined (weight of 1) and then applies each animation in the stack in reverse order to give the most predictable and natural results. It will remove the animations from the stack if and only if their blend time has finished.

For example, at one point the animation stack could contain something like this after some character has jumped:
Jump (0.2 s left)
Land (0.3 s left)
Stand (current)

The current implementation would remove both _Jump_ and _Land_ as soon as jump blend time is up, which I think is wrong. My proposal would just remove _Jump_ and keep `Land` with it's remaining blend time of 0.1 s.

_This change could break some projects. But if it's considered good, I could add a mode setting which would default to the current behavior so it could be merged safely._
