### PR TITLE
Improve debug focus behavior

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -372,6 +372,7 @@ public:
 	virtual void set_screen_orientation(ScreenOrientation p_orientation);
 	ScreenOrientation get_screen_orientation() const;
 
+	virtual void enable_for_stealing_focus(ProcessID pid) {}
 	virtual void move_window_to_foreground() {}
 
 	virtual void debug_break();

--- a/core/script_debugger_remote.cpp
+++ b/core/script_debugger_remote.cpp
@@ -134,6 +134,8 @@ void ScriptDebuggerRemote::debug(ScriptLanguage *p_script,bool p_can_continue) {
 		ERR_FAIL();
 	}
 
+	OS::get_singleton()->enable_for_stealing_focus(Globals::get_singleton()->get("editor_pid"));
+
 	packet_peer_stream->put_var("debug_enter");
 	packet_peer_stream->put_var(2);
 	packet_peer_stream->put_var(p_can_continue);
@@ -271,6 +273,7 @@ void ScriptDebuggerRemote::debug(ScriptLanguage *p_script,bool p_can_continue) {
 
 				set_depth(-1);
 				set_lines_left(-1);
+				OS::get_singleton()->move_window_to_foreground();
 				break;
 			} else if (command=="break") {
 				ERR_PRINT("Got break when already broke!");

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -560,6 +560,16 @@ Error Main::setup(const char *execpath,int argc, char *argv[],bool p_second_phas
 				goto error;
 
 			}
+		} else if (I->get()=="-epid") {
+			if (I->next()) {
+
+				int editor_pid=I->next()->get().to_int();
+				Globals::get_singleton()->set("editor_pid",editor_pid);
+				N=I->next()->next();
+			} else {
+				goto error;
+
+			}
 		} else {
 
 			//test for game path

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2154,10 +2154,15 @@ String OS_Windows::get_stdin_string(bool p_block) {
 }
 
 
+void OS_Windows::enable_for_stealing_focus(ProcessID pid) {
+
+	AllowSetForegroundWindow(pid);
+
+}
+
 void OS_Windows::move_window_to_foreground() {
 
 	SetForegroundWindow(hWnd);
-	BringWindowToTop(hWnd);
 
 }
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -269,6 +269,7 @@ public:
 	virtual String get_locale() const;
 	virtual LatinKeyboardVariant get_latin_keyboard_variant() const; 
 
+	virtual void enable_for_stealing_focus(ProcessID pid);
 	virtual void move_window_to_foreground();
 	virtual String get_data_dir() const;
 	virtual String get_system_dir(SystemDir p_dir) const;

--- a/tools/editor/editor_node.h
+++ b/tools/editor/editor_node.h
@@ -690,6 +690,7 @@ public:
 
 	void notify_child_process_exited();
 
+	OS::ProcessID get_child_process_id() const { return editor_run.get_pid(); }
 	void stop_child_process();
 
 	Ref<Theme> get_editor_theme() const { return theme; }

--- a/tools/editor/editor_run.cpp
+++ b/tools/editor/editor_run.cpp
@@ -52,6 +52,9 @@ Error EditorRun::run(const String& p_scene,const String p_custom_args,const List
 		args.push_back("localhost:"+String::num(GLOBAL_DEF("debug/debug_port", 6007)));
 	}
 
+	args.push_back("-epid");
+	args.push_back(String::num(OS::get_singleton()->get_process_ID()));
+
 	if (p_custom_args!="") {
 
 		Vector<String> cargs=p_custom_args.split(" ",false);
@@ -130,6 +133,7 @@ Error EditorRun::run(const String& p_scene,const String p_custom_args,const List
 			args.push_back("-f");
 		} break;
 	}
+
 
 
 	if (p_breakpoints.size()) {

--- a/tools/editor/editor_run.h
+++ b/tools/editor/editor_run.h
@@ -53,6 +53,8 @@ public:
 	void run_native_notify() { status=STATUS_PLAY; }
 	void stop();
 
+	OS::ProcessID get_pid() const { return pid; }
+
 	void set_debug_collisions(bool p_debug);
 	bool get_debug_collisions() const;
 

--- a/tools/editor/script_editor_debugger.cpp
+++ b/tools/editor/script_editor_debugger.cpp
@@ -216,6 +216,8 @@ void ScriptEditorDebugger::debug_continue() {
 	ERR_FAIL_COND(connection.is_null());
 	ERR_FAIL_COND(!connection->is_connected());
 
+	OS::get_singleton()->enable_for_stealing_focus(EditorNode::get_singleton()->get_child_process_id());
+
 	Array msg;
 	msg.push_back("continue");
 	ppeer->put_var(msg);


### PR DESCRIPTION
Fix focusing debugged game on Windows
Add re-focusing editor on continue

In Windows it's a bit convoluted letting one process moving another one's window to the foreground. It requires explicit authorization and it must be renewed.

So I've made both the parent and child process authorize each other so it's possible both focusing the editor on breakpoint and re-focusing the game on continue. The game being debugged must know the editor PID to authorize it so I've created a new parameter `-epid`.

(Fixes #6478.)
