### PR TITLE
Restore Viewport::set_world_2d() functionality (2D Split Screen)

### DIFF
--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -305,9 +305,11 @@ public:
 	RID get_viewport() const;
 
 	void set_world(const Ref<World>& p_world);
+	void set_world_2d(const Ref<World2D>& p_world_2d);
 	Ref<World> get_world() const;
 	Ref<World> find_world() const;
 
+	Ref<World2D> get_world_2d() const;
 	Ref<World2D> find_world_2d() const;
 
 


### PR DESCRIPTION
The official documentation (http://docs.godotengine.org/en/latest/tutorials/engine/viewports.html) says:

`For 2D, each Viewport always contains it’s own World2D. This suffices in most cases, but in case sharing them may be desired, it is possible to do so by calling the viewport API manually.`

Sadly, the code for it was disabled (and outdated).
This patch restore the functionality allowing viewports to share World2D and easily allowing 2D split screen games.

See the demo project here: https://github.com/Faless/viewport2d-test
Screenshot: 
![viewport2d_demo](https://cloud.githubusercontent.com/assets/1687918/18511719/b6c8a21e-7a85-11e6-8757-d90ba228e91b.png)
