### PR TITLE
scons detects standalone MSVC on Windows

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -16,7 +16,6 @@ platform_list = [] # list of platforms
 platform_opts = {} # options for each platform
 platform_flags = {} # flags for each platform
 
-
 active_platforms=[]
 active_platform_ids=[]
 platform_exporters=[]
@@ -60,7 +59,7 @@ platform_arg = ARGUMENTS.get("platform", False)
 if (os.name=="posix"):
 	pass
 elif (os.name=="nt"):
-	if (os.getenv("VSINSTALLDIR")==None or platform_arg=="android"):
+	if (not methods.msvc_is_detected() or platform_arg=="android"):
 		custom_tools=['mingw']
 
 env_base=Environment(tools=custom_tools);

--- a/drivers/builtin_openssl2/SCsub
+++ b/drivers/builtin_openssl2/SCsub
@@ -656,7 +656,8 @@ if "platform" in env and env["platform"] == "winrt":
 
 # Workaround for compilation error with GCC/Clang when -Werror is too greedy (GH-4517)
 import os
-if not (os.name=="nt" and os.getenv("VSINSTALLDIR")!=None): # not Windows and not MSVC
+import methods
+if not (os.name=="nt" and methods.msvc_is_detected() ): # not Windows and not MSVC
 	env_drivers.Append(CFLAGS=["-Wno-error=implicit-function-declaration"])
 
 env_drivers.add_source_files(env.drivers_sources,openssl_sources)

--- a/methods.py
+++ b/methods.py
@@ -1516,6 +1516,12 @@ def detect_visual_c_compiler_version(tools_env):
 
         return vc_chosen_compiler_str
 
+def msvc_is_detected() :
+	# looks for VisualStudio env variable 
+	# or for Visual C++ Build Tools (which is a standalone MSVC)
+	return os.getenv("VSINSTALLDIR") or os.getenv("VS100COMNTOOLS") or os.getenv("VS110COMNTOOLS") or os.getenv("VS120COMNTOOLS") or os.getenv("VS140COMNTOOLS");
+
+
 def precious_program(env, program, sources, **args):
 	program = env.ProgramOriginal(program, sources, **args)
 	env.Precious(program)

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -1,15 +1,22 @@
 #
-# 	tested on               | Windows native    | Linux cross-compilation
-#	------------------------+-------------------+---------------------------
-#	MSVS C++ 2010 Express   | WORKS             | n/a
-#	Mingw-w64               | WORKS             | WORKS
-#	Mingw-w32               | WORKS             | WORKS
-#	MinGW                   | WORKS             | untested
+# 	tested on                   | Windows native    | Linux cross-compilation
+#	----------------------------+-------------------+---------------------------
+#	MSVS C++ 2010 Express       | WORKS             | n/a
+#   Visual C++ Build Tools 2015 | WORKS             | n/a
+#	Mingw-w64                   | WORKS             | WORKS
+#	Mingw-w32                   | WORKS             | WORKS
+#	MinGW                       | WORKS             | untested
 #
 #####
 # Notes about MSVS C++ :
 #
 # 	- MSVC2010-Express compiles to 32bits only.
+#
+#####
+# Note about Visual C++ Build Tools :
+#
+#	- Visual C++ Build Tools is the standalone MSVC compiler :
+#		http://landinghub.visualstudio.com/visual-cpp-build-tools
 #
 #####
 # Notes about Mingw-w64 and Mingw-w32 under Windows :
@@ -78,7 +85,7 @@
 
 #####
 # TODO :
-#
+# 
 #	- finish to cleanup this script to remove all the remains of previous hacks and workarounds
 #	- make it work with the Windows7 SDK that is supposed to enable 64bits compilation for MSVC2010-Express
 #	- confirm it works well with other Visual Studio versions.
@@ -102,7 +109,7 @@ def can_build():
 
 	if (os.name=="nt"):
 		#building natively on windows!
-		if (os.getenv("VSINSTALLDIR")):
+		if ( methods.msvc_is_detected() ):
 			return True
 		else:
 			print("\nMSVC not detected, attempting Mingw.")
@@ -197,7 +204,7 @@ def configure(env):
 
 	env.Append(CPPPATH=['#platform/windows'])
 	env['is_mingw']=False
-	if (os.name=="nt" and os.getenv("VSINSTALLDIR")!=None):
+	if (os.name=="nt" and methods.msvc_is_detected() ):
 		#build using visual studio
 		env['ENV']['TMP'] = os.environ['TMP']
 		env.Append(CPPPATH=['#platform/windows/include'])


### PR DESCRIPTION
Under Windows, Scons is now capable of detecting and compiling with
standalone MSVC compilers (aka "Visual C++ Build Tools").
http://landinghub.visualstudio.com/visual-cpp-build-tools

Tried with version 2015, and native x86 and x64 compilers under
Windows 10 pro 64 and Windows 8.1 64, with the default Win8 SDK
provided by the "Visual C++ Build Tools" web-installer.

Follow the same compiling instructions than for compiling with Visual
Studio, except that Visual Studio is no more required.

KNOWN ISSUES :
- `methods.detect_visual_c_compiler_version()` will emit a warning message
  on computers where the `VSINSTALLDIR` environement variable is not present.
  But it should compile just fine and still automatically detects the 32 or
  64 bits according to the compiler you picked.

TODO :
~~\- try to make the `msvc_is_detected()` function available in all
script from global or import, so that it is not required to update it
several time in each scripts where it is used.~~
- eventually, update `platform/winrt/dectet.py` with function
  `methods.msvc_is_detected()` and try to compile winrt/UWP with
  these standalone compilers (if you did not select Win10 SDK when
  installing the standalone tools, you can run it again).
- update doc to make people aware about the standalone MSVC aka "Visual C++ Build Tools".
- eventually, update `methods.detect_visual_c_compiler_version()`
