### PR TITLE
Update documentation on joystick vibration.

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -16640,7 +16640,8 @@
 			<argument index="3" name="duration" type="float" default="0">
 			</argument>
 			<description>
-				Starts to vibrate the joystick. Joysticks usually come with two rumble motors, a strong and a weak one. weak_magnitude is the strength of the weak motor (between 0 and 1) and strong_magnitude is the strength of the strong motor (between 0 and 1). duration is the duration of the effect in seconds (a duration of 0 will play the vibration indefinitely).
+				Starts to vibrate the joystick. Joysticks usually come with two rumble motors, a strong and a weak one. weak_magnitude is the strength of the weak motor (between 0 and 1) and strong_magnitude is the strength of the strong motor (between 0 and 1). duration is the duration of the effect in seconds (a duration of 0 will try to play the vibration indefinitely).
+				Note that not every hardware is compatible with long effect durations, it is recommended to restart an effect if in need to play it for more than a few seconds.
 			</description>
 		</method>
 		<method name="stop_joy_vibration">


### PR DESCRIPTION
Added a note that long vibration durations are not recommended because of hardware limitations.

For example, my ps4 controller can only vibrate for ~3s on linux.
