### PR TITLE
Add a function to plugin get the main screen parent

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -11697,6 +11697,13 @@
 				Get the general settings for the editor (the same window that appears in the Settings menu).
 			</description>
 		</method>
+		<method name="get_editor_viewport">
+			<return type="Control">
+			</return>
+			<description>
+				Get the main editor control. Use this as a parent for main screens.
+			</description>
+		</method>
 		<method name="get_name" qualifiers="virtual">
 			<return type="String">
 			</return>

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -3016,7 +3016,7 @@ void EditorNode::remove_editor_plugin(EditorPlugin *p_editor) {
 
 		for(int i=0;i<singleton->main_editor_buttons.size();i++) {
 
-			if (p_editor->get_name()==singleton->main_editor_buttons[i]->get_name()) {
+			if (p_editor->get_name()==singleton->main_editor_buttons[i]->get_text()) {
 
 				memdelete( singleton->main_editor_buttons[i] );
 				singleton->main_editor_buttons.remove(i);

--- a/tools/editor/editor_plugin.cpp
+++ b/tools/editor/editor_plugin.cpp
@@ -71,6 +71,11 @@ void EditorPlugin::remove_control_from_bottom_panel(Control *p_control) {
 
 }
 
+Control * EditorPlugin::get_editor_viewport() {
+
+	return EditorNode::get_singleton()->get_viewport();
+}
+
 void EditorPlugin::add_control_to_container(CustomControlContainer p_location,Control *p_control) {
 
 	switch(p_location) {
@@ -333,6 +338,7 @@ void EditorPlugin::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("remove_control_from_bottom_panel","control:Control"),&EditorPlugin::remove_control_from_bottom_panel);
 	ObjectTypeDB::bind_method(_MD("add_custom_type","type","base","script:Script","icon:Texture"),&EditorPlugin::add_custom_type);
 	ObjectTypeDB::bind_method(_MD("remove_custom_type","type"),&EditorPlugin::remove_custom_type);
+	ObjectTypeDB::bind_method(_MD("get_editor_viewport:Control"), &EditorPlugin::get_editor_viewport);
 
 	ObjectTypeDB::bind_method(_MD("add_import_plugin","plugin:EditorImportPlugin"),&EditorPlugin::add_import_plugin);
 	ObjectTypeDB::bind_method(_MD("remove_import_plugin","plugin:EditorImportPlugin"),&EditorPlugin::remove_import_plugin);

--- a/tools/editor/editor_plugin.h
+++ b/tools/editor/editor_plugin.h
@@ -100,6 +100,7 @@ public:
 	void add_control_to_dock(DockSlot p_slot,Control *p_control);
 	void remove_control_from_docks(Control *p_control);
 	void remove_control_from_bottom_panel(Control *p_control);
+	Control* get_editor_viewport();
 
 	virtual Ref<SpatialEditorGizmo> create_spatial_gizmo(Spatial* p_spatial);
 	virtual bool forward_canvas_input_event(const Matrix32& p_canvas_xform, const InputEvent& p_event);


### PR DESCRIPTION
- Fix a bug where the main screen button did not disappear when the plugin
  was deactivated.

Fix #5754.
Fix #5786.
