### PR TITLE
Add modulate (color) to TileSet tiles

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -457,10 +457,11 @@ void TileMap::_update_dirty_quadrants() {
 			}
 
 
+			Color modulate = tile_set->tile_get_modulate(c.id);
 			if (r==Rect2()) {
-				tex->draw_rect(canvas_item,rect,false,Color(1,1,1),c.transpose);
+				tex->draw_rect(canvas_item,rect,false,modulate,c.transpose);
 			} else {
-				tex->draw_rect_region(canvas_item,rect,r,Color(1,1,1),c.transpose);
+				tex->draw_rect_region(canvas_item,rect,r,modulate,c.transpose);
 			}
 
 			Vector< Ref<Shape2D> > shapes = tile_set->tile_get_shapes(c.id);

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -48,6 +48,8 @@ bool TileSet::_set(const StringName& p_name, const Variant& p_value) {
 		tile_set_texture_offset(id,p_value);
 	else if (what=="material")
 		tile_set_material(id,p_value);
+	else if (what=="modulate")
+		tile_set_modulate(id,p_value);
 	else if (what=="shape_offset")
 		tile_set_shape_offset(id,p_value);
 	else if (what=="region")
@@ -91,6 +93,8 @@ bool TileSet::_get(const StringName& p_name,Variant &r_ret) const{
 		r_ret=tile_get_texture_offset(id);
 	else if (what=="material")
 		r_ret=tile_get_material(id);
+	else if (what=="modulate")
+		r_ret=tile_get_modulate(id);
 	else if (what=="shape_offset")
 		r_ret=tile_get_shape_offset(id);
 	else if (what=="region")
@@ -124,6 +128,7 @@ void TileSet::_get_property_list( List<PropertyInfo> *p_list) const{
 		p_list->push_back(PropertyInfo(Variant::OBJECT,pre+"texture",PROPERTY_HINT_RESOURCE_TYPE,"Texture"));
 		p_list->push_back(PropertyInfo(Variant::VECTOR2,pre+"tex_offset"));
 		p_list->push_back(PropertyInfo(Variant::OBJECT,pre+"material",PROPERTY_HINT_RESOURCE_TYPE,"CanvasItemMaterial"));
+		p_list->push_back(PropertyInfo(Variant::COLOR,pre+"modulate"));
 		p_list->push_back(PropertyInfo(Variant::RECT2,pre+"region"));
 		p_list->push_back(PropertyInfo(Variant::VECTOR2,pre+"occluder_offset"));
 		p_list->push_back(PropertyInfo(Variant::OBJECT,pre+"occluder",PROPERTY_HINT_RESOURCE_TYPE,"OccluderPolygon2D"));
@@ -174,6 +179,20 @@ Ref<CanvasItemMaterial> TileSet::tile_get_material(int p_id) const{
 	return tile_map[p_id].material;
 }
 
+
+void TileSet::tile_set_modulate(int p_id,const Color &p_modulate) {
+
+	ERR_FAIL_COND(!tile_map.has(p_id));
+	tile_map[p_id].modulate=p_modulate;
+	emit_changed();
+
+}
+
+Color TileSet::tile_get_modulate(int p_id) const{
+
+	ERR_FAIL_COND_V(!tile_map.has(p_id),Color(1,1,1));
+	return tile_map[p_id].modulate;
+}
 
 void TileSet::tile_set_texture_offset(int p_id,const Vector2 &p_offset) {
 

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -52,6 +52,10 @@ class TileSet : public Resource {
 		Vector2 navigation_polygon_offset;
 		Ref<NavigationPolygon> navigation_polygon;
 		Ref<CanvasItemMaterial> material;
+		Color modulate;
+
+		// Default modulate for back-compat
+		explicit Data() : modulate(1,1,1) {}
 	};
 
 	Map<int,Data> tile_map;
@@ -93,6 +97,9 @@ public:
 
 	void tile_set_material(int p_id,const Ref<CanvasItemMaterial> &p_material);
 	Ref<CanvasItemMaterial> tile_get_material(int p_id) const;
+
+	void tile_set_modulate(int p_id,const Color &p_color);
+	Color tile_get_modulate(int p_id) const;
 
 	void tile_set_occluder_offset(int p_id,const Vector2& p_offset);
 	Vector2 tile_get_occluder_offset(int p_id) const;

--- a/tools/editor/plugins/tile_set_editor_plugin.cpp
+++ b/tools/editor/plugins/tile_set_editor_plugin.cpp
@@ -76,6 +76,8 @@ void TileSetEditor::_import_scene(Node *scene, Ref<TileSet> p_library, bool p_me
 		p_library->tile_set_texture(id,texture);
 		p_library->tile_set_material(id,material);
 
+		p_library->tile_set_modulate(id,mi->get_modulate());
+
 		Vector2 phys_offset;
 		Size2 s;
 


### PR DESCRIPTION
Tiles now get the modulate color of their source `Sprite`.

Non-breaking change: for tile sets generated before this, the modulate color defaults to white (as if this PR had never existed).
