### PR TITLE
Add scrolling to Tree control in Drag and Drop mode

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -32,6 +32,7 @@
 #include "os/keyboard.h"
 #include "globals.h"
 #include "os/input.h"
+#include "scene/main/viewport.h"
 
 
 
@@ -829,6 +830,8 @@ void Tree::update_cache() {
 	cache.guide_width=get_constant("guide_width");
 	cache.draw_relationship_lines=get_constant("draw_relationship_lines");
 	cache.relationship_line_color=get_color("relationship_line_color");
+	cache.scroll_border=get_constant("scroll_border");
+	cache.scroll_speed=get_constant("scroll_speed");
 
 	cache.title_button = get_stylebox("title_button_normal");
 	cache.title_button_pressed = get_stylebox("title_button_pressed");
@@ -2681,11 +2684,17 @@ void Tree::_notification(int p_what) {
 	if (p_what==NOTIFICATION_DRAG_END) {
 
 		drop_mode_flags=0;
+		scrolling = false;
+		set_fixed_process(false);
 		update();
 	}
 	if (p_what==NOTIFICATION_DRAG_BEGIN) {
 
 		single_select_defer=NULL;
+		if (cache.scroll_speed > 0 && get_rect().has_point(get_viewport()->get_mouse_pos() - get_global_pos())) {
+			scrolling = true;
+			set_fixed_process(true);
+		}
 	}
 	if (p_what==NOTIFICATION_FIXED_PROCESS) {
 
@@ -2730,6 +2739,28 @@ void Tree::_notification(int p_what) {
 			} else {
 
 			}
+		}
+		
+		if (scrolling) {
+			Point2 point = get_viewport()->get_mouse_pos() - get_global_pos();
+			if (point.x < cache.scroll_border) {
+				point.x -= cache.scroll_border;
+			} else if (point.x > get_size().width - cache.scroll_border) {
+				point.x -= get_size().width - cache.scroll_border;
+			} else {
+				point.x = 0;
+			}
+			if (point.y < cache.scroll_border) {
+				point.y -= cache.scroll_border;
+			} else if (point.y > get_size().height - cache.scroll_border) {
+				point.y -= get_size().height - cache.scroll_border;
+			} else {
+				point.y = 0;
+			}
+			point *= cache.scroll_speed * get_fixed_process_delta_time();
+			point += get_scroll();
+			h_scroll->set_val(point.x);
+			v_scroll->set_val(point.y);
 		}
 	}
 

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -390,6 +390,8 @@ friend class TreeItem;
 		int button_margin;
 		Point2 offset;
 		int draw_relationship_lines;
+		int scroll_border;
+		int scroll_speed;
 
 		enum ClickType {
 			CLICK_NONE,
@@ -448,6 +450,7 @@ friend class TreeItem;
 	bool drag_touching_deaccel;
 	bool click_handled;
 	bool allow_rmb_select;
+	bool scrolling;
 
 	bool force_select_on_already_selected;
 

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -714,6 +714,8 @@ void fill_default_theme(Ref<Theme>& t, const Ref<Font> & default_font, const Ref
 	t->set_constant("item_margin","Tree",12 *scale);
 	t->set_constant("button_margin","Tree",4 *scale);
 	t->set_constant("draw_relationship_lines", "Tree", 0);
+	t->set_constant("scroll_border", "Tree", 4);
+	t->set_constant("scroll_speed", "Tree", 12);
 
 
 	// ItemList


### PR DESCRIPTION
When you want to drag one of nodes in scene tree to position which is out of view you can use mouse wheel. But for me it's hard to use wheel when left mouse button is already down and should stay this way.

I've implemented simple border scrolling - grab a node and move it close to the border or even out of tree control. The further you move the mouse the quicker it will scroll.

Scroll speed and active border size can be set up in theme.
Setting speed to 0 makes the Tree to behave in old way - without border scrolling.

It will not only affect the editor but can be used in the apps you create.
