### PR TITLE
Make Variant REAL name double if REAL_T_IS_DOUBLE is defined

### DIFF
--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -55,8 +55,11 @@ String Variant::get_type_name(Variant::Type p_type) {
 
 		} break;
 		case REAL: {
-
+#ifdef REAL_T_IS_DOUBLE
+			return "double";
+#else
 			return "float";
+#endif
 
 		} break;
 		case STRING: {


### PR DESCRIPTION
@reduz IINW, you plan to use `double` instead of `float` in 3.0. I guess you will use `real_t` and the `REAL_T_IS_DOUBLE` macro for this. If that's the case, this change would help me when generating the C# bindings.
