### PR TITLE
Use full width of TreeItem::Cell to change value in CELL_MODE_CHECK

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1701,16 +1701,11 @@ int Tree::propagate_mouse_event(const Point2i &p_pos,int x_ofs,int y_ofs,bool p_
 			} break;
 			case TreeItem::CELL_MODE_CHECK: {
 
-				Ref<Texture> checked = cache.checked;
 				bring_up_editor=false; //checkboxes are not edited with editor
-				if (x>=0 && x<= checked->get_width()+cache.hseparation ) {
-
-
-					p_item->set_checked(col,!c.checked);
-					item_edited(col,p_item);
-					click_handled=true;
-					//p_item->edited_signal.call(col);
-				}
+				p_item->set_checked(col, !c.checked);
+				item_edited(col, p_item);
+				click_handled = true;
+				//p_item->edited_signal.call(col);
 
 			} break;
 			case TreeItem::CELL_MODE_RANGE:


### PR DESCRIPTION
I think TreeItem::Cell in CELL_MODE_CHECK should use all its width to set/unset it's value.
It's user friendly and it is consistent with CheckBox control (which uses it's label for changing value) or cell in CELL_MODE_STRING which uses all it's width to gather clicks to start editing (user does not need to hit entered text, which would be even impossible when text is empty).
Maybe there was purpose to narrow clicks to cell texture before, but I see no reason to force user to aim this small rectangle.
