### PR TITLE
Clang on Windows Compilation via clang-cl

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -49,7 +49,7 @@ for x in glob.glob("platform/*"):
 module_list=methods.detect_modules()
 
 
-#print "Detected Platforms: "+str(platform_list)
+print "Detected Platforms: "+str(platform_list)
 
 methods.save_active_platforms(active_platforms,active_platform_ids)
 
@@ -451,3 +451,6 @@ else:
 	for x in platform_list:
 		print("\t"+x)
 	print("\nPlease run scons again with argument: platform=<string>")
+
+env.Replace(CC = "clang-cl")
+env.Append(CPPFLAGS=['/EHsc']);

--- a/tools/editor/plugins/baked_light_baker_cmpxchg.cpp
+++ b/tools/editor/plugins/baked_light_baker_cmpxchg.cpp
@@ -59,6 +59,7 @@ void baked_light_baker_add_64i(int64_t *dst,int64_t value) {
 #elif defined(WINDOWS_ENABLED)
 
 #include "windows.h"
+#include <intrin.h>
 
 void baked_light_baker_add_64f(double *dst,double value) {
 


### PR DESCRIPTION
Hello, I am not sure on how to work with this as what I have here is a merely Proof of Concept.

After fiddling a bit with LLVM and the `clang-cl` wrapper I managed to provide a compilation of Godot (master) using LLVM on Windows.

I am open to discussion on how to implement this if there is interest. Meanwhile I can provide a build for testing (64bit only) [here](https://1drv.ms/u/s!AtCKgU6ij1Tyi_AGvzJlecrHmaoaQg)
