### PR TITLE
Change winrt build to be less dependent on ANGLE

### DIFF
--- a/platform/winrt/SCsub
+++ b/platform/winrt/SCsub
@@ -13,7 +13,10 @@ files = [
 	'os_winrt.cpp',
 ]
 
-cmd = env.AlwaysBuild(env.ANGLE('libANGLE.lib', None))
+if "build_angle" in env and env["build_angle"]:
+	cmd = env.AlwaysBuild(env.ANGLE('libANGLE.lib', None))
 
 prog = env.Program('#bin/godot', files)
-env.Depends(prog, [cmd])
+
+if "build_angle" in env and env["build_angle"]:
+	env.Depends(prog, [cmd])

--- a/platform/winrt/detect.py
+++ b/platform/winrt/detect.py
@@ -17,11 +17,6 @@ def can_build():
 		if (os.getenv("VSINSTALLDIR")):
 
 			if (os.getenv("ANGLE_SRC_PATH") == None):
-				print("You need to define ANGLE_SRC_PATH to the path of ANGLE source root.")
-				return False
-
-			if not os.path.isfile(str(os.getenv("ANGLE_SRC_PATH")) + "/winrt/10/src/angle.sln"):
-				print ("Couldn't find the ANGLE solution. Is ANGLE_SRC_PATH configured to the right path?")
 				return False
 
 			return True
@@ -55,6 +50,9 @@ def configure(env):
 	env.Append(CPPPATH=[angle_root + '/include'])
 	jobs = str(env.GetOption("num_jobs"))
 	angle_build_cmd = "msbuild.exe " + angle_root + "/winrt/10/src/angle.sln /nologo /v:m /m:" + jobs + " /p:Configuration=Release /p:Platform="
+
+	if os.path.isfile(str(os.getenv("ANGLE_SRC_PATH")) + "/winrt/10/src/angle.sln"):
+		env["build_angle"] = True
 
 	if os.getenv('Platform') == "ARM":
 


### PR DESCRIPTION
Now it does not try to build if the solution is not found. This way it's
possible to provide a minimal package with includes and libs and make it
build correctly.

Also remove messages from detect.py since it is ran for every platform
target.
