### PR TITLE
removed redundant assign operation in mesh_add_surface

### DIFF
--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -1998,7 +1998,6 @@ void RasterizerGLES2::mesh_add_surface(RID p_mesh,VS::PrimitiveType p_primitive,
 				if (use_VBO) {
 
 					elem_size=VS::ARRAY_WEIGHTS_SIZE*sizeof(GLushort);
-					elem_count=VS::ARRAY_WEIGHTS_SIZE;
 					valid_local=false;
 					bind=true;
 					normalize=true;
@@ -2007,7 +2006,6 @@ void RasterizerGLES2::mesh_add_surface(RID p_mesh,VS::PrimitiveType p_primitive,
 
 				} else {
 					elem_size=VS::ARRAY_WEIGHTS_SIZE*sizeof(GLfloat);
-					elem_count=VS::ARRAY_WEIGHTS_SIZE;
 					valid_local=false;
 					bind=false;
 					datatype=GL_FLOAT;
@@ -2019,7 +2017,6 @@ void RasterizerGLES2::mesh_add_surface(RID p_mesh,VS::PrimitiveType p_primitive,
 
 				if (use_VBO) {
 					elem_size=VS::ARRAY_WEIGHTS_SIZE*sizeof(GLubyte);
-					elem_count=VS::ARRAY_WEIGHTS_SIZE;
 					valid_local=false;
 					bind=true;
 					datatype=GL_UNSIGNED_BYTE;
@@ -2027,7 +2024,6 @@ void RasterizerGLES2::mesh_add_surface(RID p_mesh,VS::PrimitiveType p_primitive,
 				} else {
 
 					elem_size=VS::ARRAY_WEIGHTS_SIZE*sizeof(GLushort);
-					elem_count=VS::ARRAY_WEIGHTS_SIZE;
 					valid_local=false;
 					bind=false;
 					datatype=GL_UNSIGNED_SHORT;


### PR DESCRIPTION
'elem_count' was assigned twice.

cppcheck messages:

[rasterizer_gles2.cpp:2001] -> [rasterizer_gles2.cpp:2006]: (performance) Variable 'elem_count' is reassigned a value before the old one has been used.
[rasterizer_gles2.cpp:2010] -> [rasterizer_gles2.cpp:2014]: (performance) Variable 'elem_count' is reassigned a value before the old one has been used.
[rasterizer_gles2.cpp:2022] -> [rasterizer_gles2.cpp:2026]: (performance) Variable 'elem_count' is reassigned a value before the old one has been used.
[rasterizer_gles2.cpp:2030] -> [rasterizer_gles2.cpp:2034]: (performance) Variable 'elem_count' is reassigned a value before the old one has been used.
