### PR TITLE
Fix manifest generation bug in Android export

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -913,14 +913,12 @@ void EditorExportPlatformAndroid::_fix_manifest(Vector<uint8_t>& p_manifest,bool
 	}
 
 
-	ret.resize(ret.size()+stable_extra.size());
+	for(int i=0;i<stable_extra.size();i++) {
+		ret.push_back(stable_extra[i]);
+	}
+
 	while(ret.size()%4)
 		ret.push_back(0);
-
-	for(int i=0;i<stable_extra.size();i++) {
-
-		chars[i]=stable_extra[i];
-	}
 
 
 	uint32_t new_stable_end=ret.size();


### PR DESCRIPTION
Related if not a total fix for #4777.

This was a memory bug. After resizing a vector and potentially resizing it again with `push_back`, pointers held to data become invalid. So depending on the circumstances (release vs. debug, allocation chunk size, current size of allocated block, etc.) `chars` may be pointing to old memory and writes through it don't end up where they should and, moreover, they could be smashing other data or cause SEGFAULTS.

(I'm detailing the bug report with a general explanation because this may serve for future reference for someone.)
