### PR TITLE
Add CC parameter to allow use of custom C compiler

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -138,7 +138,8 @@ opts.Add('etc1','etc1 Texture compression support (yes/no)','yes')
 opts.Add('builtin_zlib','Use built-in zlib (yes/no)','yes')
 opts.Add('openssl','Use OpenSSL (yes/no/builtin)','no')
 opts.Add('musepack','Musepack Audio (yes/no)','yes')
-opts.Add("CXX", "Compiler");
+opts.Add("CXX", "C++ Compiler")
+opts.Add("CC", "C Compiler")
 opts.Add("CCFLAGS", "Custom flags for the C++ compiler");
 opts.Add("CFLAGS", "Custom flags for the C compiler");
 opts.Add("LINKFLAGS", "Custom flags for the linker");


### PR DESCRIPTION
Hi,

Currently we can only customize the C++ compiler with the `CXX` option and the C compiler sticks to `gcc` no matter what.
This small patch provide the `CC` option in the SConscruct to fix this ;-)
