### PR TITLE
Don't crash in "_process_hdr()" if "framebuffer.luminance" is empty

### DIFF
--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -7018,6 +7018,10 @@ void RasterizerGLES2::_process_glow_bloom() {
 
 void RasterizerGLES2::_process_hdr() {
 
+	if (framebuffer.luminance.empty()) {
+		return;
+	}
+
 	glBindFramebuffer(GL_FRAMEBUFFER, framebuffer.luminance[0].fbo);
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(GL_TEXTURE_2D, framebuffer.color );


### PR DESCRIPTION
If "glFramebufferTexture2D()" fails on old drivers the Vector is empty.
Don't allow to read from empty Vector (NULL pointer).
