### PR TITLE
Tween reset/stop/resume/remove for all object properties at once

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -43972,10 +43972,10 @@
 			</return>
 			<argument index="0" name="object" type="Object">
 			</argument>
-			<argument index="1" name="key" type="String">
+			<argument index="1" name="key" type="String" default="&quot;&quot;">
 			</argument>
 			<description>
-				Stop animating and completely remove a tween, given its object and property/method pair.
+				Stop animating and completely remove a tween, given its object and property/method pair. Passing empty String as key will remove all tweens for given object.
 			</description>
 		</method>
 		<method name="remove_all">
@@ -43990,10 +43990,10 @@
 			</return>
 			<argument index="0" name="object" type="Object">
 			</argument>
-			<argument index="1" name="key" type="String">
+			<argument index="1" name="key" type="String" default="&quot;&quot;">
 			</argument>
 			<description>
-				Resets a tween to the initial value (the one given, not the one before the tween), given its object and property/method pair.
+				Resets a tween to the initial value (the one given, not the one before the tween), given its object and property/method pair. Passing empty String as key will reset all tweens for given object.
 			</description>
 		</method>
 		<method name="reset_all">
@@ -44008,10 +44008,10 @@
 			</return>
 			<argument index="0" name="object" type="Object">
 			</argument>
-			<argument index="1" name="key" type="String">
+			<argument index="1" name="key" type="String" default="&quot;&quot;">
 			</argument>
 			<description>
-				Continue animating a stopped tween, given its object and property/method pair.
+				Continue animating a stopped tween, given its object and property/method pair. Passing empty String as key will resume all tweens for given object.
 			</description>
 		</method>
 		<method name="resume_all">
@@ -44070,10 +44070,10 @@
 			</return>
 			<argument index="0" name="object" type="Object">
 			</argument>
-			<argument index="1" name="key" type="String">
+			<argument index="1" name="key" type="String" default="&quot;&quot;">
 			</argument>
 			<description>
-				Stop animating a tween, given its object and property/method pair.
+				Stop animating a tween, given its object and property/method pair. Passing empty String as key will stop all tweens for given object.
 			</description>
 		</method>
 		<method name="stop_all">

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -199,13 +199,13 @@ void Tween::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_tween_process_mode"),&Tween::get_tween_process_mode);
 
 	ObjectTypeDB::bind_method(_MD("start"),&Tween::start );
-	ObjectTypeDB::bind_method(_MD("reset","object","key"),&Tween::reset );
+	ObjectTypeDB::bind_method(_MD("reset","object","key"),&Tween::reset, DEFVAL("") );
 	ObjectTypeDB::bind_method(_MD("reset_all"),&Tween::reset_all );
-	ObjectTypeDB::bind_method(_MD("stop","object","key"),&Tween::stop );
+	ObjectTypeDB::bind_method(_MD("stop","object","key"),&Tween::stop, DEFVAL("") );
 	ObjectTypeDB::bind_method(_MD("stop_all"),&Tween::stop_all );
-	ObjectTypeDB::bind_method(_MD("resume","object","key"),&Tween::resume );
+	ObjectTypeDB::bind_method(_MD("resume","object","key"),&Tween::resume, DEFVAL("") );
 	ObjectTypeDB::bind_method(_MD("resume_all"),&Tween::resume_all );
-	ObjectTypeDB::bind_method(_MD("remove","object","key"),&Tween::remove );
+	ObjectTypeDB::bind_method(_MD("remove","object","key"),&Tween::remove, DEFVAL("") );
 	ObjectTypeDB::bind_method(_MD("remove_all"),&Tween::remove_all );
 	ObjectTypeDB::bind_method(_MD("seek","time"),&Tween::seek );
 	ObjectTypeDB::bind_method(_MD("tell"),&Tween::tell );
@@ -723,7 +723,7 @@ bool Tween::reset(Object *p_object, String p_key) {
 		if(object == NULL)
 			continue;
 
-		if(object == p_object && data.key == p_key) {
+		if(object == p_object && (data.key == p_key || p_key == "")) {
 
 			data.elapsed = 0;
 			data.finish = false;
@@ -759,7 +759,7 @@ bool Tween::stop(Object *p_object, String p_key) {
 		Object *object = ObjectDB::get_instance(data.id);
 		if(object == NULL)
 			continue;
-		if(object == p_object && data.key == p_key)
+		if(object == p_object && (data.key == p_key || p_key == ""))
 			data.active = false;
 	}
 	pending_update --;
@@ -793,7 +793,7 @@ bool Tween::resume(Object *p_object, String p_key) {
 		Object *object = ObjectDB::get_instance(data.id);
 		if(object == NULL)
 			continue;
-		if(object == p_object && data.key == p_key)
+		if(object == p_object && (data.key == p_key || p_key == ""))
 			data.active = true;
 	}
 	pending_update --;
@@ -821,16 +821,19 @@ bool Tween::remove(Object *p_object, String p_key) {
 		call_deferred("remove", p_object, p_key);
 		return true;
 	}
+	List<List<InterpolateData>::Element *> for_removal;
 	for(List<InterpolateData>::Element *E=interpolates.front();E;E=E->next()) {
 
 		InterpolateData& data = E->get();
 		Object *object = ObjectDB::get_instance(data.id);
 		if(object == NULL)
 			continue;
-		if(object == p_object && data.key == p_key) {
-			interpolates.erase(E);
-			return true;
+		if(object == p_object && (data.key == p_key || p_key == "")) {
+			for_removal.push_back(E);
 		}
+	}
+	for(List<List<InterpolateData>::Element *>::Element *E=for_removal.front();E;E=E->next()) {
+		interpolates.erase(E->get());
 	}
 	return true;
 }


### PR DESCRIPTION
It would be easier to stop or resume tween for all object properties at once with one line of code.
Now it needs to be done one by one or with a loop.
My proposal is to pass an empty String to impact all tweens for a given object.
I've set the property param as default so syntax is more compact:
`get_node("Tween").reset(get_node("Node"))`
It will reset all tweens for Node.
