### PR TITLE
Make FileDialog directory selection less misleading

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -186,15 +186,17 @@ void FileDialog::_action_pressed() {
 		hide();
 	}else if (mode==MODE_OPEN_ANY || mode==MODE_OPEN_DIR) {
 
-
 		String path=dir_access->get_current_dir();
-		/*if (tree->get_selected()) {
-			Dictionary d = tree->get_selected()->get_metadata(0);
-			if (d["dir"]) {
-				path=path+"/"+String(d["name"]);
-			}
-		}*/
+
 		path=path.replace("\\","/");
+
+		if (TreeItem* item = tree->get_selected()) {
+			Dictionary d = item->get_metadata(0);
+			if (d["dir"]) {
+				path=path.plus_file(d["name"]);
+			}
+		}
+
 		emit_signal("dir_selected",path);
 		hide();
 	}
@@ -348,18 +350,18 @@ void FileDialog::update_file_list() {
 	files.sort_custom<NoCaseComparator>();
 
 	while(!dirs.empty()) {
+		String& dir_name = dirs.front()->get();
+		TreeItem *ti=tree->create_item(root);
+		ti->set_text(0,dir_name+"/");
+		ti->set_icon(0,folder);
 
-		if (dirs.front()->get()!=".") {
-			TreeItem *ti=tree->create_item(root);
-			ti->set_text(0,dirs.front()->get()+"/");
-			ti->set_icon(0,folder);
-			Dictionary d;
-			d["name"]=dirs.front()->get();
-			d["dir"]=true;
-			ti->set_metadata(0,d);
-		}
+		Dictionary d;
+		d["name"]=dir_name;
+		d["dir"]=true;
+
+		ti->set_metadata(0,d);
+
 		dirs.pop_front();
-
 	}
 
 	dirs.clear();

--- a/tools/editor/editor_file_dialog.cpp
+++ b/tools/editor/editor_file_dialog.cpp
@@ -571,25 +571,26 @@ void EditorFileDialog::update_file_list() {
 	files.sort_custom<NoCaseComparator>();
 
 	while(!dirs.empty()) {
+		const String& dir_name=dirs.front()->get();
 
-		if (dirs.front()->get()!=".") {
-			item_list->add_item(dirs.front()->get()+"/");
-			if (display_mode==DISPLAY_THUMBNAILS) {
+		item_list->add_item(dir_name+"/");
 
-				item_list->set_item_icon(item_list->get_item_count()-1,folder_thumbnail);
-			} else {
+		if (display_mode==DISPLAY_THUMBNAILS) {
 
-				item_list->set_item_icon(item_list->get_item_count()-1,folder);
-			}
+			item_list->set_item_icon(item_list->get_item_count()-1,folder_thumbnail);
+		} else {
 
-			Dictionary d;
-			d["name"]=dirs.front()->get();
-			d["path"]=String();
-			d["dir"]=true;
-			item_list->set_item_metadata( item_list->get_item_count() -1, d);
+			item_list->set_item_icon(item_list->get_item_count()-1,folder);
 		}
-		dirs.pop_front();
 
+		Dictionary d;
+		d["name"]=dir_name;
+		d["path"]=String();
+		d["dir"]=true;
+
+		item_list->set_item_metadata( item_list->get_item_count() -1, d);
+
+		dirs.pop_front();
 	}
 
 	dirs.clear();

--- a/tools/editor/editor_file_dialog.cpp
+++ b/tools/editor/editor_file_dialog.cpp
@@ -336,15 +336,21 @@ void EditorFileDialog::_action_pressed() {
 		hide();
 	}else if (mode==MODE_OPEN_ANY || mode==MODE_OPEN_DIR) {
 
-
 		String path=dir_access->get_current_dir();
-		/*if (tree->get_selected()) {
-			Dictionary d = tree->get_selected()->get_metadata(0);
-			if (d["dir"]) {
-				path=path+"/"+String(d["name"]);
-			}
-		}*/
+
 		path=path.replace("\\","/");
+
+		for(int i=0;i<item_list->get_item_count();i++) {
+			if (item_list->is_selected(i)) {
+				Dictionary d=item_list->get_item_metadata(i);
+				if (d["dir"]) {
+					path=path.plus_file(d["name"]);
+
+					break;
+				}
+			}
+		}
+
 		_save_to_recent();
 		emit_signal("dir_selected",path);
 		hide();


### PR DESCRIPTION
This should fix #5989.

Changes which applied to FileDialog and EditorFileDialog are basically the same:
- show `.(current working directory)` in Tree/ItemList
- append name of selected item with current directory when under MODE_OPEN_DIR

Here's some screenshots:
![_003](https://cloud.githubusercontent.com/assets/5238484/18827288/a5c54d22-8404-11e6-8d8b-576dbd94ac39.png)

![_004](https://cloud.githubusercontent.com/assets/5238484/18827298/ae3b61a8-8404-11e6-8b69-c720fee12859.png)

Please let me know if there's anything could be improved and make thing works better!
