### PR TITLE
Fixes in Theora SCsub

### DIFF
--- a/drivers/theora/SCsub
+++ b/drivers/theora/SCsub
@@ -1,11 +1,11 @@
 Import('env')
 
 sources = [
-	"theora/analyze.c",
-	"theora/apiwrapper.c",
+	#"theora/analyze.c",
+	#"theora/apiwrapper.c",
 	"theora/bitpack.c",
 	"theora/cpu.c",
-	"theora/decapiwrapper.c",
+	#"theora/decapiwrapper.c",
 	"theora/decinfo.c",
 	"theora/decode.c",
 	"theora/dequant.c",
@@ -13,55 +13,53 @@ sources = [
 	#"theora/encfrag.c",
 	#"theora/encinfo.c",
 	#"theora/encode.c",
-	"theora/encoder_disabled.c",
-	"theora/enquant.c",
-	"theora/fdct.c",
+	#"theora/encoder_disabled.c",
+	#"theora/enquant.c",
+	#"theora/fdct.c",
 	"theora/fragment.c",
 	"theora/huffdec.c",
-	"theora/huffenc.c",
+	#"theora/huffenc.c",
 	"theora/idct.c",
 	"theora/info.c",
 	"theora/internal.c",
-	"theora/mathops.c",
-	"theora/mcenc.c",
+	#"theora/mathops.c",
+	#"theora/mcenc.c",
 	"theora/quant.c",
-	"theora/rate.c",
+	#"theora/rate.c",
 	"theora/state.c",
-	"theora/tokenize.c",
+	#"theora/tokenize.c",
 	"theora/video_stream_theora.cpp",
 ]
 
 sources_x86 = [
-	"theora/x86/mmxencfrag.c",
-	"theora/x86/mmxfdct.c",
+	#"theora/x86/mmxencfrag.c",
+	#"theora/x86/mmxfdct.c",
 	"theora/x86/mmxfrag.c",
 	"theora/x86/mmxidct.c",
 	"theora/x86/mmxstate.c",
-	"theora/x86/sse2fdct.c",
-	"theora/x86/x86enc.c",
+	#"theora/x86/sse2fdct.c",
+	#"theora/x86/x86enc.c",
 	"theora/x86/x86state.c",
 ]
 
 sources_x86_vc = [
-	"theora/x86_vc/mmxencfrag.c",
-	"theora/x86_vc/mmxfdct.c",
+	#"theora/x86_vc/mmxencfrag.c",
+	#"theora/x86_vc/mmxfdct.c",
 	"theora/x86_vc/mmxfrag.c",
 	"theora/x86_vc/mmxidct.c",
 	"theora/x86_vc/mmxstate.c",
-	"theora/x86_vc/x86enc.c",
+	#"theora/x86_vc/x86enc.c",
 	"theora/x86_vc/x86state.c",
 ]
 
 env.drivers_sources += sources
 
 if (env["x86_opt_gcc"]):
-	env.Append(CCFLAGS=["-DOC_X86_ASM"])
 	env.drivers_sources += sources_x86
 
 if (env["x86_opt_vc"]):
-	env.Append(CCFLAGS=["-DOC_X86_ASM"])
 	env.drivers_sources += sources_x86_vc
 
-	
-
-
+if (env["x86_opt_gcc"] or env["x86_opt_vc"]):
+	Import('env_drivers')
+	env_drivers.Append(CCFLAGS=["-DOC_X86_ASM"])


### PR DESCRIPTION
- properly pass x86 assembly define to the compiler,
- don't compile unnecessary/encoder files.
