### PR TITLE
Code completion for is_action_just_{pressed, released}

### DIFF
--- a/core/os/input.cpp
+++ b/core/os/input.cpp
@@ -94,7 +94,7 @@ void Input::get_argument_options(const StringName& p_function,int p_idx,List<Str
 #ifdef TOOLS_ENABLED
 
 	String pf=p_function;
-	if (p_idx==0 && (pf=="is_action_pressed" || pf=="action_press" || pf=="action_release")) {
+	if (p_idx==0 && (pf=="is_action_pressed" || pf=="action_press" || pf=="action_release" || pf=="is_action_just_pressed" || pf=="is_action_just_released")) {
 
 		List<PropertyInfo> pinfo;
 		Globals::get_singleton()->get_property_list(&pinfo);


### PR DESCRIPTION
Now these methods show the list of available actions during a completion request.
Fixes #6621
