### PR TITLE
Fix for crash when finding intersection on colliders that overlap

### DIFF
--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -81,6 +81,9 @@ int Physics2DDirectSpaceStateSW::intersect_point(const Vector2& p_point,ShapeRes
 		if (!shape->contains_point(local_point))
 			continue;
 
+		if (cc>=p_result_max)
+			continue;
+
 		r_results[cc].collider_id=col_obj->get_instance_id();
 		if (r_results[cc].collider_id!=0)
 			r_results[cc].collider=ObjectDB::get_instance(r_results[cc].collider_id);


### PR DESCRIPTION
This is a fix for #6610. It seems the crash happens when there are more collision shapes than max_results specified to intersect_point. I made it so it ignores remaining results. Maybe it would be better to return the ones on top, but at least it doesn't crash anymore. 
