### PR TITLE
Don't crash when video is stopped and played again

### DIFF
--- a/scene/gui/video_player.cpp
+++ b/scene/gui/video_player.cpp
@@ -248,7 +248,7 @@ void VideoPlayer::stop() {
 
 	playback->stop();
 	AudioServer::get_singleton()->stream_set_active(stream_rid,false);
-	resampler.clear();
+	resampler.flush();
 	set_process(false);
 	last_audio_time=0;
 };
@@ -426,5 +426,6 @@ VideoPlayer::~VideoPlayer() {
 
 	if (stream_rid.is_valid())
 		AudioServer::get_singleton()->free(stream_rid);
+	resampler.clear(); //Not necessary here, but make in consistent with other "stream_player" classes
 };
 


### PR DESCRIPTION
in GDscript stopping the video with sound and playing it again, e.g.:

```
stop()
play()
```

causes a crash in resampler. This patch fixes it - don't free arrays in resampler as in other `stream_player` classes.
