### PR TITLE
Windows: prevent huge prints from crashing the engine

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1312,10 +1312,13 @@ void OS_Windows::finalize_core() {
 
 void OS_Windows::vprint(const char* p_format, va_list p_list, bool p_stderr) {
 
-	char buf[16384+1];
-	int len = vsnprintf(buf,16384,p_format,p_list);
+	const unsigned int BUFFER_SIZE = 16384;
+	char buf[BUFFER_SIZE+1]; // +1 for the terminating character
+	int len = vsnprintf(buf,BUFFER_SIZE,p_format,p_list);
 	if (len<=0)
 		return;
+	if(len >= BUFFER_SIZE)
+		len = BUFFER_SIZE; // Output is too big, will be truncated
 	buf[len]=0;
 
 


### PR DESCRIPTION
This snippet makes the engine crash on windows:

``` gdscript
func _ready():
    var dic = {}
    for y in range(0, 40):
        for x in range(0, 40):
            dic[Vector2(x,y)] = randi()%10
    print(dic)
```

It was caused by an out-of-bound access of a fixed-size buffer, which is later used for widechar conversion.
vsnprintf can actually return values greater than the provided length, as a count, even if it doesn't writes all the characters: http://www.cplusplus.com/reference/cstdio/vsnprintf/

Obviously the data is too big, but it should not make the engine crash.
This fix only prevents the crash to happen. It would also be nice to add a warning to the user.

On Unix there is nothing of this and vfprintf is used directly, I wonder why is there such a difference?
