### PR TITLE
Fix typo for word_wrap

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -3173,7 +3173,7 @@ bool String::is_valid_identifier() const {
 
 //kind of poor should be rewritten properly
 
-String String::world_wrap(int p_chars_per_line) const {
+String String::word_wrap(int p_chars_per_line) const {
 
 	int from=0;
 	int last_space=0;

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -218,7 +218,7 @@ public:
 	String c_escape() const;
 	String c_unescape() const;
 	String json_escape() const;
-	String world_wrap(int p_chars_per_line) const;
+	String word_wrap(int p_chars_per_line) const;
 
 	String percent_encode() const;
 	String percent_decode() const;

--- a/tools/editor/property_editor.cpp
+++ b/tools/editor/property_editor.cpp
@@ -3049,7 +3049,7 @@ void PropertyEditor::update_tree() {
 					if (E) {
 						descr=E->get().brief_description;
 					}
-					class_descr_cache[type]=descr.world_wrap(80);
+					class_descr_cache[type]=descr.word_wrap(80);
 
 				}
 
@@ -3142,7 +3142,7 @@ void PropertyEditor::update_tree() {
 					if (E) {
 						for(int i=0;i<E->get().methods.size();i++) {
 							if (E->get().methods[i].name==setter.operator String()) {
-								descr=E->get().methods[i].description.strip_edges().world_wrap(80);
+								descr=E->get().methods[i].description.strip_edges().word_wrap(80);
 							}
 						}
 					}

--- a/tools/editor/scene_tree_editor.cpp
+++ b/tools/editor/scene_tree_editor.cpp
@@ -254,7 +254,7 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item,int p_column,int p_id)
 		String config_err = n->get_configuration_warning();
 		if (config_err==String())
 			return;
-		config_err=config_err.world_wrap(80);
+		config_err=config_err.word_wrap(80);
 		warning->set_text(config_err);
 		warning->popup_centered_minsize();
 


### PR DESCRIPTION
I think `word_wrap` is correct if not intent to wrap the world. :)
