### PR TITLE
Use 2 different ENet channels for reliable/unreliable packets

### DIFF
--- a/modules/enet/networked_multiplayer_enet.h
+++ b/modules/enet/networked_multiplayer_enet.h
@@ -23,6 +23,13 @@ private:
 		SYSMSG_REMOVE_PEER
 	};
 
+	enum {
+		SYSCH_CONFIG,
+		SYSCH_RELIABLE,
+		SYSCH_UNRELIABLE,
+		SYSCH_MAX
+	};
+
 	bool active;
 	bool server;
 


### PR DESCRIPTION
This avoids stalling other sequenced but unreliable packets
(i.e. UNRELIABLE_ORDERED) when sending RELIABLE packets.
## Important Notes:

With ENet, every packet can be:
Reliable/Unreliable (will be resent or not)
Sequenced/Unsequenced (order will be enforced, or not)

A **reliable** (RS) packet MUST be sequenced, will **stall other sequenced packet** on the same channel.
An **unreliable but sequenced** (US) packet will always be **delivered in order** (if delivered at all). **Will be stalled** by undelivered reliable packets on the same channel.
An **unreliable and unsequenced** (UU) packet **will not be stalled** by other packets.

With this patch reliable and unreliable packets will use two different channels yay!

Since all unreliable-but-sequenced (US) packets will always share the same channel (and thus sequencing) out-of-order packets will be dropped even if they reference different rpc calls.

```
eg:
RECV: 1-"set_pos", // GOOD
RECV: 3-"set_pos", // GOOD
RECV: 2-"set_vel" // DROPPED
```

This will force people that want to optimize latency to implement their own timing over unreliable-and-unsequenced (UU) packets.

**I still strongly reccomend allowing the developers to select the channel when sending RPCs.**
