### PR TITLE
Respect texture .flags files on export

### DIFF
--- a/scene/io/resource_format_image.cpp
+++ b/scene/io/resource_format_image.cpp
@@ -136,61 +136,7 @@ RES ResourceFormatLoaderImage::load(const String &p_path, const String& p_origin
 #endif
 
 
-		uint32_t flags=0;
-
-		FileAccess *f2 = FileAccess::open(p_path+".flags",FileAccess::READ);
-		Map<String,bool> flags_found;
-		if (f2) {
-
-			while(!f2->eof_reached()) {
-				String l2 = f2->get_line();
-				int eqpos = l2.find("=");
-				if (eqpos!=-1) {
-					String flag=l2.substr(0,eqpos).strip_edges();
-					String val=l2.substr(eqpos+1,l2.length()).strip_edges().to_lower();
-					flags_found[flag]=(val=="true" || val=="1")?true:false;
-				}
-			}
-			memdelete(f2);
-		}
-
-
-		if (flags_found.has("filter")) {
-			if (flags_found["filter"])
-				flags|=Texture::FLAG_FILTER;
-		} else if (bool(GLOBAL_DEF("image_loader/filter",true))) {
-			flags|=Texture::FLAG_FILTER;
-		}
-
-
-		if (flags_found.has("gen_mipmaps")) {
-			if (flags_found["gen_mipmaps"])
-				flags|=Texture::FLAG_MIPMAPS;
-		} else if (bool(GLOBAL_DEF("image_loader/gen_mipmaps",true))) {
-			flags|=Texture::FLAG_MIPMAPS;
-		}
-
-		if (flags_found.has("repeat")) {
-			if (flags_found["repeat"])
-				flags|=Texture::FLAG_REPEAT;
-		} else if (bool(GLOBAL_DEF("image_loader/repeat",true))) {
-			flags|=Texture::FLAG_REPEAT;
-		}
-
-		if (flags_found.has("anisotropic")) {
-			if (flags_found["anisotropic"])
-				flags|=Texture::FLAG_ANISOTROPIC_FILTER;
-		}
-
-		if (flags_found.has("tolinear")) {
-			if (flags_found["tolinear"])
-				flags|=Texture::FLAG_CONVERT_TO_LINEAR;
-		}
-
-		if (flags_found.has("mirroredrepeat")) {
-			if (flags_found["mirroredrepeat"])
-				flags|=Texture::FLAG_MIRRORED_REPEAT;
-		}
+		uint32_t flags=load_image_flags(p_path);
 
 		if (debug_load_times)
 			begtime=OS::get_singleton()->get_ticks_usec();
@@ -212,6 +158,68 @@ RES ResourceFormatLoaderImage::load(const String &p_path, const String& p_origin
 	}
 
 
+}
+
+uint32_t ResourceFormatLoaderImage::load_image_flags(const String &p_path) {
+
+
+	FileAccess *f2 = FileAccess::open(p_path+".flags",FileAccess::READ);
+	Map<String,bool> flags_found;
+	if (f2) {
+
+		while(!f2->eof_reached()) {
+			String l2 = f2->get_line();
+			int eqpos = l2.find("=");
+			if (eqpos!=-1) {
+				String flag=l2.substr(0,eqpos).strip_edges();
+				String val=l2.substr(eqpos+1,l2.length()).strip_edges().to_lower();
+				flags_found[flag]=(val=="true" || val=="1")?true:false;
+			}
+		}
+		memdelete(f2);
+	}
+
+
+	uint32_t flags=0;
+
+	if (flags_found.has("filter")) {
+		if (flags_found["filter"])
+			flags|=Texture::FLAG_FILTER;
+	} else if (bool(GLOBAL_DEF("image_loader/filter",true))) {
+		flags|=Texture::FLAG_FILTER;
+	}
+
+
+	if (flags_found.has("gen_mipmaps")) {
+		if (flags_found["gen_mipmaps"])
+			flags|=Texture::FLAG_MIPMAPS;
+	} else if (bool(GLOBAL_DEF("image_loader/gen_mipmaps",true))) {
+		flags|=Texture::FLAG_MIPMAPS;
+	}
+
+	if (flags_found.has("repeat")) {
+		if (flags_found["repeat"])
+			flags|=Texture::FLAG_REPEAT;
+	} else if (bool(GLOBAL_DEF("image_loader/repeat",true))) {
+		flags|=Texture::FLAG_REPEAT;
+	}
+
+	if (flags_found.has("anisotropic")) {
+		if (flags_found["anisotropic"])
+			flags|=Texture::FLAG_ANISOTROPIC_FILTER;
+	}
+
+	if (flags_found.has("tolinear")) {
+		if (flags_found["tolinear"])
+			flags|=Texture::FLAG_CONVERT_TO_LINEAR;
+	}
+
+	if (flags_found.has("mirroredrepeat")) {
+		if (flags_found["mirroredrepeat"])
+			flags|=Texture::FLAG_MIRRORED_REPEAT;
+	}
+
+	return flags;
 }
 
 bool ResourceFormatLoaderImage::handles_type(const String& p_type) const {

--- a/scene/io/resource_format_image.h
+++ b/scene/io/resource_format_image.h
@@ -39,8 +39,8 @@ class ResourceFormatLoaderImage : public ResourceFormatLoader {
 	bool debug_load_times;
 	int max_texture_size;
 public:
-
 	virtual RES load(const String &p_path,const String& p_original_path="",Error *r_error=NULL);
+	static uint32_t load_image_flags(const String &p_path);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String& p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/tools/editor/io_plugins/editor_texture_import_plugin.h
+++ b/tools/editor/io_plugins/editor_texture_import_plugin.h
@@ -72,6 +72,8 @@ private:
 
 	Error _process_texture_data(Ref<ImageTexture> &texture, int format, float quality, int flags,EditorExportPlatform::ImageCompression p_compr,int tex_flags,float shrink);
 	void compress_image(EditorExportPlatform::ImageCompression p_mode,Image& image,bool p_smaller);
+
+	uint32_t texture_flags_to_export_flags(uint32_t p_tex_flags) const;
 public:
 
 


### PR DESCRIPTION
**_The problem_**

Textures kept as **.png** in the project can have several flags set, stored in an associated `.png.flags` file. Any texture of this kind which is set to be converted on export will get saved onto a `.tex` file. The `.png.flags` file, although bundled, is ignored because it cannot be matched any longer with the image file name. *

**_What this PR does_**

With this PR merged, the export process reads the flags from the `.png.flags` files and sets the corresponding ones in the `.tex` file.

Moreover, the flags file is read on every export and considered for the computation of the hash of the converted file. That way should those flags change from export to export, Godot is aware and knows it has to reconvert them

(*) It would be nice also to prevent these no longer needed flag files from getting into the exported game (work for another PR). Another option would have been to rename or remap these (`.png.flags` -> `.tex.flags`) but as long as the `.tex` format is capable of storing flags I believed that should be the way to go.
