### PR TITLE
baked light baker : improves randomness

### DIFF
--- a/tools/editor/plugins/baked_light_baker.cpp
+++ b/tools/editor/plugins/baked_light_baker.cpp
@@ -137,6 +137,18 @@
 			return rng();
 		}
 	#endif
+	#ifdef BAKER_RNG_USE_XORSHIFT32
+		void BLB_RNG::seed(uint32_t value) {
+			x = value;
+			if ( x == 0 ) x = 0xFFFFffff;
+		}
+		uint32_t BLB_RNG::rand() {
+			x ^= x << 13;
+			x ^= x >> 17;
+			x ^= x << 5;
+			return x;
+		}
+	#endif
 	#define RAND_DOUBLE() (double(thread_stack.rng.rand())/BAKER_RNG_RAND_MAX)
 #endif
 

--- a/tools/editor/plugins/baked_light_baker.h
+++ b/tools/editor/plugins/baked_light_baker.h
@@ -34,6 +34,98 @@
 #include "scene/3d/mesh_instance.h"
 #include "os/thread.h"
 
+#if !defined(BAKER_RNG_USE_C_RAND) \
+ && !defined(BAKER_RNG_USE_XONOROSHI128PLUS) \
+ && !defined(BAKER_RNG_USE_XORSHIFT128) \
+ && !defined(BAKER_RNG_USE_XORSHIFTSTAR) \
+ && !defined(BAKER_RNG_USE_XORSHIFTPLUS) \
+ && !defined(BAKER_RNG_USE_MT19937) \
+ && !defined(BAKER_RNG_USE_CXX11_MT19937)
+	//#define BAKER_RNG_USE_C_RAND
+	//#define BAKER_RNG_USE_XONOROSHI128PLUS
+	//#define BAKER_RNG_USE_XORSHIFT128
+	//#define BAKER_RNG_USE_XORSHIFTSTAR
+	//#define BAKER_RNG_USE_XORSHIFTPLUS
+	#define BAKER_RNG_USE_MT19937
+	//#define BAKER_RNG_USE_CXX11_MT19937 
+#endif
+
+#ifdef BAKER_RNG_USE_XONOROSHI128PLUS
+	// from public domain : http://xoroshiro.di.unimi.it/xoroshiro128plus.c
+	#define BAKER_RNG_RAND_MAX 0xFFFFffffFFFFffffu 
+	#define RNG_rotl(x,k) ((uint64_t)( x << k ) | ( x >> ( 64 - k ))) 
+	class BLB_RNG {
+	private:
+		uint64_t s[2];
+	public:
+		uint64_t rand();
+		void seed(uint64_t value);
+	};
+#endif
+#ifdef BAKER_RNG_USE_XORSHIFT128
+	// from https://en.wikipedia.org/wiki/Xorshift
+	#define BAKER_RNG_RAND_MAX 0xffffFFFFu
+	class BLB_RNG {
+	private:
+		uint32_t x;
+		uint32_t y;
+		uint32_t z;
+		uint32_t w;
+		uint32_t t;
+	public:
+		uint32_t rand();
+		void seed(uint32_t value);
+	};
+#endif
+#ifdef BAKER_RNG_USE_XORSHIFTSTAR
+	// from https://en.wikipedia.org/wiki/Xorshift
+	#define BAKER_RNG_RAND_MAX 0xFFFFffffFFFFffffu
+	class BLB_RNG {
+	private:
+		uint64_t x;
+	public:
+		uint64_t rand();
+		void seed(uint64_t value);
+	};
+#endif
+#ifdef BAKER_RNG_USE_XORSHIFTPLUS
+	// from https://en.wikipedia.org/wiki/Xorshift
+	#define BAKER_RNG_RAND_MAX 0xFFFFffffFFFFffffu
+	class BLB_RNG {
+	private:
+		uint64_t s0;
+		uint64_t s1;
+	public:
+		uint64_t rand();
+		void seed(uint64_t value);
+	};
+#endif
+#ifdef BAKER_RNG_USE_MT19937
+	// from https://en.wikipedia.org/wiki/Mersenne_Twister
+	#define BAKER_RNG_RAND_MAX 0xFFFFffffu
+	class BLB_RNG {
+	private:
+		uint32_t x[624];
+		int index;
+	private:
+		void twist();
+	public:
+		uint32_t rand();
+		void seed(uint32_t value);
+	};
+#endif
+#ifdef BAKER_RNG_USE_CXX11_MT19937
+	#include <random>
+	#define BAKER_RNG_RAND_MAX 0xFFFFffffu
+	class BLB_RNG {
+	private:
+		std::mt19937 rng;
+	public:
+		uint32_t rand();
+		void seed(uint32_t value);
+	};
+#endif
+
 class BakedLightBaker {
 public:
 
@@ -249,6 +341,11 @@ public:
 
 	};
 
+	struct ThreadFuncArgs {
+		BakedLightBaker *back_light_baker;
+		uint32_t random_seed;
+	};
+
 
 	Vector<LightData> lights;
 
@@ -276,6 +373,9 @@ public:
 		uint32_t *octantptr_stack;
 		uint32_t *ray_stack;
 		BVH **bvh_stack;
+#ifndef BAKER_RNG_USE_C_RAND
+		BLB_RNG rng;
+#endif
 	};
 
 	Map<Vector3,Vector3> endpoint_normal;
@@ -341,6 +441,7 @@ public:
 	float total_light_area;
 
 	Vector<Thread*> threads;
+	Vector<ThreadFuncArgs> threads_func_args;
 
 	bool bake_thread_exit;
 	static void _bake_thread_func(void *arg);

--- a/tools/editor/plugins/baked_light_baker.h
+++ b/tools/editor/plugins/baked_light_baker.h
@@ -40,14 +40,16 @@
  && !defined(BAKER_RNG_USE_XORSHIFTSTAR) \
  && !defined(BAKER_RNG_USE_XORSHIFTPLUS) \
  && !defined(BAKER_RNG_USE_MT19937) \
- && !defined(BAKER_RNG_USE_CXX11_MT19937)
+ && !defined(BAKER_RNG_USE_CXX11_MT19937) \
+ && !defined(BAKER_RNG_USE_XORSHIFT32)
 	//#define BAKER_RNG_USE_C_RAND
 	//#define BAKER_RNG_USE_XONOROSHI128PLUS
 	//#define BAKER_RNG_USE_XORSHIFT128
 	//#define BAKER_RNG_USE_XORSHIFTSTAR
 	//#define BAKER_RNG_USE_XORSHIFTPLUS
 	#define BAKER_RNG_USE_MT19937
-	//#define BAKER_RNG_USE_CXX11_MT19937 
+	//#define BAKER_RNG_USE_CXX11_MT19937
+	//#define BAKER_RNG_USE_XORSHIFT32
 #endif
 
 #ifdef BAKER_RNG_USE_XONOROSHI128PLUS
@@ -120,6 +122,16 @@
 	class BLB_RNG {
 	private:
 		std::mt19937 rng;
+	public:
+		uint32_t rand();
+		void seed(uint32_t value);
+	};
+#endif
+#ifdef BAKER_RNG_USE_XORSHIFT32
+	#define BAKER_RNG_RAND_MAX 0xFFFFffffu
+	class BLB_RNG {
+	private:
+		uint32_t x;
 	public:
 		uint32_t rand();
 		void seed(uint32_t value);


### PR DESCRIPTION
**edit :** as mentioned into #6682, Reduz said on IRC that he will rewrite the baker for 3.x.
- For the time being, this PR can be merged as is into custom 2.x version to fixes the multi-threaded baking bug and to standardize the baking quality and accuracy among platforms (`rand()` implementation is not standardized and not multi-thread safe).
- Other than that, this PR can also be used to evaluate the actual influence of different PRNG over the quality and the speed of the baking process. If you find that a PRNG gives better or worst results than others, please, share your findings with us.

---

see #6682

replace `rand()` by a thread-safe and thread-seeded RNG.

------ edit ----------

So I've put different algorithms that can be easily changed at compile time by defining one of these preprocessor variable :

```
BAKER_RNG_USE_C_RAND
BAKER_RNG_USE_XONOROSHI128PLUS
BAKER_RNG_USE_XORSHIFT128
BAKER_RNG_USE_XORSHIFTSTAR
BAKER_RNG_USE_XORSHIFTPLUS
BAKER_RNG_USE_MT19937
BAKER_RNG_USE_CXX11_MT19937
BAKER_RNG_USE_XORSHIFT32
```

Some are more optimized for 64bits, some others for 32bits.
Some are more optimized for MSVC, some others for GCC.
Some have relatively low periodicity, some others relatively higher one.

Default is set to BAKER_RNG_USE_MT19937.

note : 
- BAKER_RNG_USE_C_RAND is the default `rand()`.
  It is guaranteed to be multithread-safe only with MSVC.
  It is slightly faster than others RNG, but it has a RAND_MAX of only 0x7FFF, is based on an unknown underlying algorithm with an unknown periodicity.
- BAKER_RNG_USE_CXX11_MT19937 is the standard C++11 std::mt19937.
  It is still experimental on GCC 4.6.3, and is fully supported by MSVC.
