### PR TITLE
Properly encode InputEvent of type NONE. Fix #5987

### DIFF
--- a/core/variant_parser.cpp
+++ b/core/variant_parser.cpp
@@ -986,7 +986,18 @@ Error VariantParser::parse_value(Token& token,Variant &value,Stream *p_stream,in
 
 			InputEvent ie;
 
-			if (id=="KEY") {
+			if (id=="NONE") {
+
+				ie.type=InputEvent::NONE;
+
+				get_token(p_stream,token,line,r_err_str);
+
+				if (token.type!=TK_PARENTHESIS_CLOSE) {
+					r_err_str="Expected ')'";
+					return ERR_PARSE_ERROR;
+				}
+
+			} else if (id=="KEY") {
 
 				get_token(p_stream,token,line,r_err_str);
 				if (token.type!=TK_COMMA) {
@@ -2092,6 +2103,9 @@ Error VariantWriter::write(const Variant& p_variant, StoreStringFunc p_store_str
 				} break;
 				case InputEvent::JOYSTICK_MOTION: {
 					str+="JAXIS,"+itos(ev.joy_motion.axis)+","+itos(ev.joy_motion.axis_value);
+				} break;
+				case InputEvent::NONE: {
+					str+="NONE";
 				} break;
 				default: {}
 			}


### PR DESCRIPTION
In the editor settings you can disable default editor shortcuts.
When a default shortcut is disabled an InputEvent of type NONE must
be stored in the config file to allow the editor to remember that setting.
variant_parser.cpp was not properly encoding InputEvent of type NONE causing
the "corruption" of the editor settings file. (Fix #5987 )

P.S.: Hacktoberfest has started :beers: 
