### PR TITLE
Expose more 2D/3D physics options in project settings (#5029)

### DIFF
--- a/scene/resources/world.cpp
+++ b/scene/resources/world.cpp
@@ -332,6 +332,10 @@ World::World() {
 	sound_space = SpatialSoundServer::get_singleton()->space_create();
 
 	PhysicsServer::get_singleton()->space_set_active(space,true);
+	PhysicsServer::get_singleton()->area_set_param(space,PhysicsServer::AREA_PARAM_GRAVITY,GLOBAL_DEF("physics/default_gravity",9.8));
+	PhysicsServer::get_singleton()->area_set_param(space,PhysicsServer::AREA_PARAM_GRAVITY_VECTOR,GLOBAL_DEF("physics/default_gravity_vector",Vector3(0,-1,0)));
+	PhysicsServer::get_singleton()->area_set_param(space,PhysicsServer::AREA_PARAM_LINEAR_DAMP,GLOBAL_DEF("physics/default_linear_damp",0.1));
+	PhysicsServer::get_singleton()->area_set_param(space,PhysicsServer::AREA_PARAM_ANGULAR_DAMP,GLOBAL_DEF("physics/default_angular_damp",0.1));
 
 #ifdef _3D_DISABLED
 	indexer = NULL;

--- a/scene/resources/world_2d.cpp
+++ b/scene/resources/world_2d.cpp
@@ -416,12 +416,6 @@ World2D::World2D() {
 	}
 	Physics2DServer::get_singleton()->area_set_param(space,Physics2DServer::AREA_PARAM_LINEAR_DAMP,GLOBAL_DEF("physics_2d/default_linear_damp",0.1));
 	Physics2DServer::get_singleton()->area_set_param(space,Physics2DServer::AREA_PARAM_ANGULAR_DAMP,GLOBAL_DEF("physics_2d/default_angular_damp",1));
-	Physics2DServer::get_singleton()->space_set_param(space,Physics2DServer::SPACE_PARAM_CONTACT_RECYCLE_RADIUS,1.0);
-	Physics2DServer::get_singleton()->space_set_param(space,Physics2DServer::SPACE_PARAM_CONTACT_MAX_SEPARATION,1.5);
-	Physics2DServer::get_singleton()->space_set_param(space,Physics2DServer::SPACE_PARAM_BODY_MAX_ALLOWED_PENETRATION,0.3);
-	Physics2DServer::get_singleton()->space_set_param(space,Physics2DServer::SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_TRESHOLD,2);
-	Physics2DServer::get_singleton()->space_set_param(space,Physics2DServer::SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS,0.2);
-
 	indexer = memnew( SpatialIndexer2D );
 
 }

--- a/scene/resources/world_2d.h
+++ b/scene/resources/world_2d.h
@@ -31,6 +31,7 @@
 
 #include "resource.h"
 #include "servers/physics_2d_server.h"
+#include "globals.h"
 
 class SpatialIndexer2D;
 class VisibilityNotifier2D;

--- a/servers/physics/space_sw.cpp
+++ b/servers/physics/space_sw.cpp
@@ -721,7 +721,7 @@ SpaceSW::SpaceSW() {
 	constraint_bias = 0.01;
 	body_linear_velocity_sleep_threshold=GLOBAL_DEF("physics/sleep_threshold_linear",0.1);
 	body_angular_velocity_sleep_threshold=GLOBAL_DEF("physics/sleep_threshold_angular", (8.0 / 180.0 * Math_PI) );
-	body_time_to_sleep=0.5;
+	body_time_to_sleep=GLOBAL_DEF("physics/time_before_sleep",0.5);
 	body_angular_velocity_damp_ratio=10;
 
 

--- a/servers/physics/space_sw.h
+++ b/servers/physics/space_sw.h
@@ -37,6 +37,7 @@
 #include "area_pair_sw.h"
 #include "broad_phase_sw.h"
 #include "collision_object_sw.h"
+#include "globals.h"
 
 
 class PhysicsDirectSpaceStateSW : public PhysicsDirectSpaceState {

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -1321,14 +1321,14 @@ Space2DSW::Space2DSW() {
 	contact_debug_count=0;
 
 	locked=false;
-	contact_recycle_radius=0.01;
-	contact_max_separation=0.05;
-	contact_max_allowed_penetration= 0.01;
+	contact_recycle_radius=1.0;
+	contact_max_separation=1.5;
+	contact_max_allowed_penetration= 0.3;
 
-	constraint_bias = 0.01;
-	body_linear_velocity_sleep_treshold=0.01;
-	body_angular_velocity_sleep_treshold=(8.0 / 180.0 * Math_PI);
-	body_time_to_sleep=0.5;
+	constraint_bias = 0.2;
+	body_linear_velocity_sleep_treshold=GLOBAL_DEF("physics_2d/sleep_threashold_linear",2.0);
+	body_angular_velocity_sleep_treshold=GLOBAL_DEF("physics_2d/sleep_threshold_angular",(8.0 / 180.0 * Math_PI));
+	body_time_to_sleep=GLOBAL_DEF("physics_2d/time_before_sleep",0.5);
 
 
 	broadphase = BroadPhase2DSW::create_func();

--- a/servers/physics_2d/space_2d_sw.h
+++ b/servers/physics_2d/space_2d_sw.h
@@ -37,6 +37,7 @@
 #include "area_pair_2d_sw.h"
 #include "broad_phase_2d_sw.h"
 #include "collision_object_2d_sw.h"
+#include "globals.h"
 
 
 class Physics2DDirectSpaceStateSW : public Physics2DDirectSpaceState {


### PR DESCRIPTION
This PR fix #5029 :
- Expose default gravity, gravity vector, linear damp, and angular damp for 3D
- Expose sleep parameters for 2D and 3D
- Remove all calls to `space_set_param` from World2D constructor, now those parameters are set in Space2DSW constructor (`space_2d_sw.cpp`). The 3D counterpart already did this.

NOTE:
There was a difference between default values defined in `space_2d_sw.cpp` and those defined in `world_2d.cpp`. I used those in `world_2d.cpp` because they were actually being applied.
