### PR TITLE
ConnectionDialog: Don't allow connecting to a Node without a script if target method is invalid.

### DIFF
--- a/tools/editor/connections_dialog.cpp
+++ b/tools/editor/connections_dialog.cpp
@@ -181,6 +181,14 @@ void ConnectDialog::ok_pressed() {
 		error->popup_centered_minsize();
 		return;
 	}
+	Node* target = tree->get_selected();
+	if (target->get_script().is_null()) {
+		if (!target->has_method(dst_method->get_text())) {
+			error->set_text(TTR("Target method not found! Specify a valid method or attach a script to target Node."));
+			error->popup_centered_minsize();
+			return;
+		}
+	}
 	emit_signal("connected");
 	hide();
 


### PR DESCRIPTION
Shows an error now.
Fixes #6656
