### PR TITLE
Add error when (pre)loading paths with leading / (#4280 - #3106)

### DIFF
--- a/modules/gdscript/gd_functions.cpp
+++ b/modules/gdscript/gd_functions.cpp
@@ -840,8 +840,13 @@ void GDFunctions::call(Function p_func,const Variant **p_args,int p_arg_count,Va
 				r_error.error=Variant::CallError::CALL_ERROR_INVALID_ARGUMENT;
 				r_error.argument=0;
 				r_ret=Variant();
+			} else if(((String)(*p_args[0])).begins_with("/")) {
+				r_error.error=Variant::CallError::CALL_ERROR_INVALID_ARGUMENT;
+				r_error.argument=0;
+				r_ret=RTR("Paths cannot start with '/', absolute paths must start with \'res://\', \'user://\', or \'local://\'");
+			} else {
+				r_ret=ResourceLoader::load(*p_args[0]);
 			}
-			r_ret=ResourceLoader::load(*p_args[0]);
 
 		} break;
 		case INST2DICT: {

--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -307,6 +307,10 @@ GDParser::Node* GDParser::_parse_expression(Node *p_parent,bool p_static,bool p_
 				_set_error("expected string constant as 'preload' argument.");
 				return NULL;
 			}
+			if (path.begins_with("/")) {
+				_set_error("Paths cannot start with '/', absolute paths must start with \'res://\', \'user://\', or \'local://\'");
+				return NULL;
+			}
 			if (!path.is_abs_path() && base_path!="")
 				path=base_path+"/"+path;
 			path = path.replace("///","//").simplify_path();
@@ -2107,6 +2111,10 @@ void GDParser::_parse_extends(ClassNode *p_class) {
 		if (constant.get_type()!=Variant::STRING) {
 
 			_set_error("'extends' constant must be a string.");
+			return;
+		}
+		if (((String)(constant)).begins_with("/")) {
+			_set_error("Paths cannot start with '/', absolute paths must start with \'res://\', \'user://\', or \'local://\'");
 			return;
 		}
 


### PR DESCRIPTION
Calling "load", "extends" and "preload" with absolute paths not including the drive (e.g. `/script/myscript.gd`) causes a series of unexpected behavior (see #3106 and #4280).

With this PR those commands will throw an error if you try to use a path with a leading slash.
As the error message states the path must either specify the drive or be local, e.g. `res://path/to/file.gd` `path/to/file.gd`
