### PR TITLE
Add editor_only param to Light2D

### DIFF
--- a/scene/2d/light_2d.h
+++ b/scene/2d/light_2d.h
@@ -45,6 +45,7 @@ public:
 private:
 	RID canvas_light;
 	bool enabled;
+	bool editor_only;
 	bool shadow;
 	Color color;
 	Color shadow_color;
@@ -77,6 +78,9 @@ public:
 
 	void set_enabled( bool p_enabled);
 	bool is_enabled() const;
+
+	void set_editor_only(bool p_editor_only);
+	bool is_editor_only() const;
 
 	void set_texture( const Ref<Texture>& p_texture);
 	Ref<Texture> get_texture() const;


### PR DESCRIPTION
Since it's useful for 2D as well.

Already protected against #6665 with the same logic as #6693.
