### PR TITLE
Fix crash on variable export. Disallow Object Types as values for "export"(ed) vars.

### DIFF
--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -3099,6 +3099,10 @@ void GDParser::_parse_class(ClassNode *p_class) {
 								_set_error("Can't accept a null constant expression for infering export type.");
 								return;
 							}
+							if (cn->value.get_type()==Variant::OBJECT) {
+								_set_error("Can't accept an Object Type as expression for export value.");
+								return;
+							}
 							member._export.type=cn->value.get_type();
 							member._export.usage|=PROPERTY_USAGE_SCRIPT_VARIABLE;
 						}


### PR DESCRIPTION
Fix #6719 crash

Writing:

```
export var path = Path
```

would crash the engine.
Now it properly reports an error.
