### PR TITLE
Throw an error when exporting a resource class

### DIFF
--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -3101,6 +3101,16 @@ void GDParser::_parse_class(ClassNode *p_class) {
 							}
 							member._export.type=cn->value.get_type();
 							member._export.usage|=PROPERTY_USAGE_SCRIPT_VARIABLE;
+							if (cn->value.get_type()==Variant::OBJECT) {
+								Object *obj = cn->value;
+								Resource *res = obj->cast_to<Resource>();
+								if(res==NULL) {
+									_set_error("Exported constant not a type or resource.");
+									return;
+								}
+								member._export.hint=PROPERTY_HINT_RESOURCE_TYPE;
+								member._export.hint_string=res->get_type();
+							}
 						}
 					}
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
As per requests in #6729 this is the patch that throws an error instead of allowing the behavior:
`export var tex = Texture`

The error will be:
"Exported constant not a type or resource"
I'm open to suggestion on better messages.

Fixes #6719 . Closes #6729
