### PR TITLE
Use int consistently instead of int32_t for Vectors

### DIFF
--- a/bin/tests/test_math.cpp
+++ b/bin/tests/test_math.cpp
@@ -516,7 +516,7 @@ MainLoop* test() {
 
 	{
 
-		Vector<int32_t> hashes;
+		Vector<int> hashes;
 		List<StringName> tl;
 		ObjectTypeDB::get_type_list(&tl);
 

--- a/core/variant_parser.cpp
+++ b/core/variant_parser.cpp
@@ -1177,16 +1177,16 @@ Error VariantParser::parse_value(Token& token,Variant &value,Stream *p_stream,in
 
 		} else if (id=="IntArray") {
 
-			Vector<int32_t> args;
-			Error err = _parse_construct<int32_t>(p_stream,args,line,r_err_str);
+			Vector<int> args;
+			Error err = _parse_construct<int>(p_stream,args,line,r_err_str);
 			if (err)
 				return err;
 
-			DVector<int32_t> arr;
+			DVector<int> arr;
 			{
 				int len=args.size();
 				arr.resize(len);
-				DVector<int32_t>::Write w = arr.write();
+				DVector<int>::Write w = arr.write();
 				for(int i=0;i<len;i++) {
 					w[i]=int(args[i]);
 				}


### PR DESCRIPTION
I'm using the devkitARM toolchain to use Godot in 3DS homebrew. This problem arose, but was easy to fix.

There is no defined `Vector<int32_t>` and therefore any compiler/arch that would distinguish between `int` and `int32_t` will have problems. Another possible solution is to change all defined Vector methods to all use `int32_t`, but this is easier and I wasn't sure what core devs would think about that.
