### PR TITLE
Issue #6296: When searching for control, checking if matrix is inversible

### DIFF
--- a/core/math/math_2d.cpp
+++ b/core/math/math_2d.cpp
@@ -424,7 +424,7 @@ Matrix32 Matrix32::inverse() const {
 
 void Matrix32::affine_invert() {
 
-	float det = elements[0][0]*elements[1][1] - elements[1][0]*elements[0][1];
+	float det = basis_determinant();
 	ERR_FAIL_COND(det==0);
 	float idet = 1.0 / det;
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1715,6 +1715,9 @@ Control* Viewport::_gui_find_control_at_pos(CanvasItem* p_node,const Point2& p_g
 	}
 
 	Matrix32 matrix = p_xform * p_node->get_transform();
+	// matrix.basis_determinant() == 0.0f implies that node does not exist on scene
+	if(matrix.basis_determinant() == 0.0f)
+		return NULL;
 
 	if (!c || !c->clips_input() || c->has_point(matrix.affine_inverse().xform(p_global))) {
 


### PR DESCRIPTION
I have added check to viewport testing, if matrix is inversible. In general, if basis_determinant()== 0.0, one cannot inverse matrix and error is left. But when searching for control, basis_determinant()==0.0 implies, that control is not in scene. See https://github.com/godotengine/godot/issues/6296.
