### PR TITLE
Make node serial naming per-project and universal

### DIFF
--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -29,6 +29,7 @@
 #ifndef NODE_H
 #define NODE_H
 
+#include "globals.h"
 #include "object.h"
 #include "path_db.h"
 #include "map.h"
@@ -150,7 +151,8 @@ private:
 
 	void _replace_connections_target(Node* p_new_target);
 
-	void _validate_child_name(Node *p_name, bool p_force_human_readable=false);
+	void _validate_child_name(Node *p_child, bool p_force_human_readable=false);
+	String _generate_serial_child_name(Node *p_child);
 
 	void _propagate_reverse_notification(int p_notification);
 	void _propagate_deferred_notification(int p_notification, bool p_reverse);
@@ -193,6 +195,7 @@ protected:
 	void _propagate_replace_owner(Node *p_owner,Node* p_by_owner);
 
 	static void _bind_methods();
+	static String _get_name_num_separator();
 
 friend class SceneState;
 
@@ -335,7 +338,9 @@ public:
 
 	static void print_stray_nodes();
 
-	String validate_child_name(const String& p_name) const;
+#ifdef TOOLS_ENABLED
+	String validate_child_name(Node* p_child);
+#endif
 
 	void queue_delete();
 

--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -565,8 +565,6 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("text_editor/restore_scripts_on_load",true);
 
 
-	set("scenetree_editor/duplicate_node_name_num_separator",0);
-	hints["scenetree_editor/duplicate_node_name_num_separator"]=PropertyInfo(Variant::INT,"scenetree_editor/duplicate_node_name_num_separator",PROPERTY_HINT_ENUM, "None,Space,Underscore,Dash");
 	//set("scenetree_editor/display_old_action_buttons",false);
 	set("scenetree_editor/start_create_dialog_fully_expanded",false);
 	set("scenetree_editor/draw_relationship_lines",false);

--- a/tools/editor/scene_tree_dock.cpp
+++ b/tools/editor/scene_tree_dock.cpp
@@ -1109,6 +1109,7 @@ void SceneTreeDock::_do_reparent(Node* p_new_parent,int p_position_in_parent,Vec
 	editor_data->get_undo_redo().create_action(TTR("Reparent Node"));
 
 	List<Pair<NodePath,NodePath> > path_renames;
+	Vector<StringName> former_names;
 
 	int inc=0;
 
@@ -1118,6 +1119,7 @@ void SceneTreeDock::_do_reparent(Node* p_new_parent,int p_position_in_parent,Vec
 		Node *node = p_nodes[ni];
 
 		fill_path_renames(node,new_parent,&path_renames);
+		former_names.push_back(node->get_name());
 
 		List<Node*> owned;
 		node->get_owned_by(node->get_owner(),&owned);
@@ -1159,6 +1161,7 @@ void SceneTreeDock::_do_reparent(Node* p_new_parent,int p_position_in_parent,Vec
 			editor_data->get_undo_redo().add_do_method(AnimationPlayerEditor::singleton->get_key_editor(),"set_root",node);
 
 		editor_data->get_undo_redo().add_undo_method(new_parent,"remove_child",node);
+		editor_data->get_undo_redo().add_undo_method(node,"set_name",former_names[ni]);
 
 		inc++;
 


### PR DESCRIPTION
The editor setting `duplicate_node_name_num_separator` was nice for duplicate operations, but on other situtations when node name collisions could arise (create, instance and reparent) the behavior was inconsistent.

While duplication was honoring the separator setting and looking for non-colliding numbers from the number of the operated node, the other operations were always putting a white space between and trying to find an available number from one.

This PR makes every operation follow the same rules (separator-aware, counting from the number of the operated node) and also renames and moves the setting to become now per-project because:
- it's the easiest way of making every operation aware of the separator setting without adding a lot of conditional code for editor/non-editor situations and to make live editing already aware without making it more complex;
- name-number seprator pertains to the naming style chosen for a specific project.

Furthermore, some duplicated code is removed and the APIs are clearer.

This PR also fixes a bug where a reparented node would not get its original name back on undo if it had been changed to avoid collision.
