### PR TITLE
Place child dialog contents under label in AcceptDialog

### DIFF
--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -232,6 +232,8 @@ String AcceptDialog::get_text() const {
 void AcceptDialog::set_text(String p_text) {
 
 	label->set_text(p_text);
+	minimum_size_changed();
+	_update_child_rect();
 }
 
 void AcceptDialog::set_hide_on_ok(bool p_hide) {
@@ -253,38 +255,51 @@ void AcceptDialog::register_text_enter(Node *p_line_edit) {
 
 void AcceptDialog::_update_child_rect() {
 
-	int margin = get_constant("margin","Dialogs");
-	Size2 size = get_size();
+	const int margin = get_constant("margin","Dialogs");
+	const Size2 size = get_size();
 	Size2 hminsize = hbc->get_combined_minimum_size();
 
-	Vector2 cpos(margin,margin);
-	Vector2 csize(size.x-margin*2,size.y-margin*3-hminsize.y);
+	const Size2 max_csize(
+		size.width - margin * 2,
+		size.height - margin * 3 - hminsize.height);
+	hminsize.width = max_csize.width;
+
+	Point2 cpos(margin, margin);
+	Size2 csize = label->get_combined_minimum_size();
+	if(label->get_text().empty())
+		csize.y = 0;
+	csize.x = MIN(csize.width, max_csize.width);
+	csize.y = MIN(csize.height, max_csize.height);
 	label->set_pos(cpos);
 	label->set_size(csize);
 
-	if (child) {
+	if(child) {
+		const float child_y_offset = csize.height + (csize.height > 0 ? margin : 0);
+		cpos.y += child_y_offset;
+		csize = max_csize;
+		csize.height -= child_y_offset;
 
 		child->set_pos(cpos);
 		child->set_size(csize);
 	}
 
-	cpos.y+=csize.y+margin;
-	csize.y=hminsize.y;
+	cpos.y += csize.height + margin;
 
 	hbc->set_pos(cpos);
-	hbc->set_size(csize);
-
+	hbc->set_size(hminsize);
 }
 
 Size2 AcceptDialog::get_minimum_size() const {
 
 	int margin = get_constant("margin","Dialogs");
 	Size2 minsize = label->get_combined_minimum_size();
+	if(label->get_text().empty())
+		minsize.y = 0;
 	if (child) {
 
 		Size2 cminsize = child->get_combined_minimum_size();
 		minsize.x=MAX(cminsize.x,minsize.x);
-		minsize.y=MAX(cminsize.y,minsize.y);
+		minsize.y += cminsize.y + (minsize.y > 0 ? margin : 0);
 	}
 
 	Size2 hminsize = hbc->get_combined_minimum_size();


### PR DESCRIPTION
Placing child dialog contents under label in AcceptDialog ensures, that custom text and FileDialog Path label do not overlap.

Fixes #6199.
