### PR TITLE
Prevents rand_from_seed from exceeding RANDOM_MAX

### DIFF
--- a/core/math/math_funcs.cpp
+++ b/core/math/math_funcs.cpp
@@ -45,14 +45,13 @@ uint32_t Math::rand_from_seed(uint32_t *seed) {
 #if 1
 	uint32_t k;
 	uint32_t s = (*seed);
-	if (s == 0)
+	if (s == 0){
 		s = 0x12345987;
+	}
 	k = s / 127773;
 	s = 16807 * (s - k * 127773) - 2836 * k;
-//	if (s < 0)
-//		s += 2147483647;
-	(*seed) = s;
-	return (s & Math::RANDOM_MAX);
+	(*seed) = (s & Math::RANDOM_MAX);
+	return (*seed);
 #else
 	*seed = *seed * 1103515245 + 12345;
 	return (*seed % ((unsigned int)RANDOM_MAX + 1));


### PR DESCRIPTION
Even though the seed being returned had the most significant bit killed by & masking with Math::RANDOM_MAX, the value was already set in memory. Thus, calls that don't use the return value of the function (which is completely sane behavior, given that the function sets the pointer) can get a number larger than RANDOM_MAX.
