### PR TITLE
Add editor option to hide material/texture preview in inspector

### DIFF
--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -653,6 +653,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	set("import/automatic_reimport_on_sources_changed",true);
 
+	set("inspector/show_texture_preview",true);
+	set("inspector/show_material_preview",true);
+
 	if (p_extra_config.is_valid()) {
 
 		if (p_extra_config->has_section("init_projects") && p_extra_config->has_section_key("init_projects", "list")) {

--- a/tools/editor/plugins/material_editor_plugin.cpp
+++ b/tools/editor/plugins/material_editor_plugin.cpp
@@ -352,8 +352,10 @@ bool MaterialEditorPlugin::handles(Object *p_object) const {
 void MaterialEditorPlugin::make_visible(bool p_visible) {
 
 	if (p_visible) {
-		material_editor->show();
-//		material_editor->set_process(true);
+		if( (bool)EditorSettings::get_singleton()->get("inspector/show_material_preview") ) {
+			material_editor->show();
+//			material_editor->set_process(true);
+		}
 	} else {
 
 		material_editor->hide();

--- a/tools/editor/plugins/texture_editor_plugin.cpp
+++ b/tools/editor/plugins/texture_editor_plugin.cpp
@@ -112,8 +112,10 @@ bool TextureEditorPlugin::handles(Object *p_object) const {
 void TextureEditorPlugin::make_visible(bool p_visible) {
 
 	if (p_visible) {
-		texture_editor->show();
-//		texture_editor->set_process(true);
+		if( (bool)EditorSettings::get_singleton()->get("inspector/show_texture_preview") ) {
+			texture_editor->show();
+//			texture_editor->set_process(true);
+		}
 	} else {
 
 		texture_editor->hide();


### PR DESCRIPTION
Hello, this is my first try to contribute to a open source project, any advices are welcome.
I have added two options for toggling material and texture preview located at editor settings, inspector section. The purpose is to save space in the inspector tag. 

Closes #6542
