### PR TITLE
Fix shader tokenizer-parser reporting wrong error location

### DIFF
--- a/servers/visual/shader_language.h
+++ b/servers/visual/shader_language.h
@@ -332,14 +332,14 @@ private:
 		void get_error(String *r_error, int *r_line, int *r_column) {
 
 			*r_error=error;
-			*r_line=get_token(pos).line;
-			*r_column=get_token(pos).col;
+			*r_line=get_next_token(0).line;
+			*r_column=get_next_token(0).col;
 		}
 
 
 
-		Token get_token(int ofs=0) const { int idx=pos+ofs; if (idx<0 || idx>=tokens.size()) return Token(TK_ERROR); return tokens[idx]; }
-		TokenType get_token_type(int ofs=0) const { int idx=pos+ofs;  if (idx<0 || idx>=tokens.size()) return TK_ERROR; return tokens[idx].type; }
+		Token get_next_token(int ofs=0) const { int idx=pos+ofs; if (idx<0 || idx>=tokens.size()) return Token(TK_ERROR); return tokens[idx]; }
+		TokenType get_next_token_type(int ofs=0) const { int idx=pos+ofs;  if (idx<0 || idx>=tokens.size()) return TK_ERROR; return tokens[idx].type; }
 		void advance(int p_amount=1) { pos+=p_amount; }
 		bool is_at_end() const { return pos>=tokens.size(); }
 


### PR DESCRIPTION
Keeping the commented line, adapted to the new flow, should it be needed sometime.
