### PR TITLE
Make text column numbers one-based

### DIFF
--- a/modules/gdscript/gd_tokenizer.cpp
+++ b/modules/gdscript/gd_tokenizer.cpp
@@ -943,7 +943,7 @@ void GDTokenizerText::set_code(const String& p_code) {
 	}
 	code_pos=0;
 	line=1; //it is stand-ar-ized that lines begin in 1 in code..
-	column=0;
+	column=1; //the same holds for columns
 	tk_rb_pos=0;
 	error_flag=false;
 	last_error="";

--- a/tools/editor/code_editor.cpp
+++ b/tools/editor/code_editor.cpp
@@ -1051,7 +1051,7 @@ void CodeTextEditor::_reset_zoom() {
 void CodeTextEditor::_line_col_changed() {
 
 	line_nb->set_text(itos(text_editor->cursor_get_line() + 1));
-	col_nb->set_text(itos(text_editor->cursor_get_column()));
+	col_nb->set_text(itos(text_editor->cursor_get_column() + 1));
 }
 
 void CodeTextEditor::_text_changed() {

--- a/tools/editor/plugins/shader_editor_plugin.cpp
+++ b/tools/editor/plugins/shader_editor_plugin.cpp
@@ -155,7 +155,7 @@ void ShaderTextEditor::_validate_script() {
 	Error err = ShaderLanguage::compile(code,type,NULL,NULL,&errortxt,&line,&col);
 
 	if (err!=OK) {
-		String error_text="error("+itos(line+1)+","+itos(col)+"): "+errortxt;
+		String error_text="error("+itos(line+1)+","+itos(col+1)+"): "+errortxt;
 		set_error(error_text);
 		get_text_edit()->set_line_as_marked(line,true);
 


### PR DESCRIPTION
It has always seem strange to me that Godot reports text locations with a one-based line number and zero-based column number.

I think that by also making the column numbers one-based makes for a **more consistent** experience, yet **friendlier** (Godot strives to be a friendly environment) and more **universal** (text editors universally count lines from one).

This PR covers cursor location and error locations for both GDScript and shader editors. Not completely sure if these are all the cases.
