### PR TITLE
Fix Script Editor drawing over Dialogs.

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1245,15 +1245,19 @@ void TextEdit::_notification(int p_what) {
 			}
 			if (OS::get_singleton()->has_virtual_keyboard())
 				OS::get_singleton()->show_virtual_keyboard(get_text(),get_global_rect());
+			if (raised_from_completion) {
+				VisualServer::get_singleton()->canvas_item_set_z(get_canvas_item(), 1);
+			}
 
 		} break;
 		case NOTIFICATION_FOCUS_EXIT: {
 
 			if (OS::get_singleton()->has_virtual_keyboard())
 				OS::get_singleton()->hide_virtual_keyboard();
-
+			if (raised_from_completion) {
+				VisualServer::get_singleton()->canvas_item_set_z(get_canvas_item(), 0);
+			}
 		} break;
-
 	}
 }
 
@@ -4199,6 +4203,7 @@ void TextEdit::_confirm_completion() {
 void TextEdit::_cancel_code_hint() {
 
 	VisualServer::get_singleton()->canvas_item_set_z(get_canvas_item(), 0);
+	raised_from_completion = false;
 	completion_hint="";
 	update();
 }
@@ -4206,6 +4211,7 @@ void TextEdit::_cancel_code_hint() {
 void TextEdit::_cancel_completion() {
 
 	VisualServer::get_singleton()->canvas_item_set_z(get_canvas_item(), 0);
+	raised_from_completion = false;
 	if (!completion_active)
 		return;
 
@@ -4386,6 +4392,7 @@ void TextEdit::query_code_comple() {
 void TextEdit::set_code_hint(const String& p_hint) {
 
 	VisualServer::get_singleton()->canvas_item_set_z(get_canvas_item(), 1);
+	raised_from_completion = true;
 	completion_hint=p_hint;
 	completion_hint_offset=-0xFFFF;
 	update();
@@ -4394,6 +4401,7 @@ void TextEdit::set_code_hint(const String& p_hint) {
 void TextEdit::code_complete(const Vector<String> &p_strings) {
 
 	VisualServer::get_singleton()->canvas_item_set_z(get_canvas_item(), 1);
+	raised_from_completion = true;
 	completion_strings=p_strings;
 	completion_active=true;
 	completion_current="";
@@ -4795,6 +4803,8 @@ TextEdit::TextEdit()  {
 	insert_mode = false;
 	window_has_focus=true;
 	select_identifiers_enabled=false;
+
+	raised_from_completion = false;
 
 	context_menu_enabled=true;
 	menu = memnew( PopupMenu );

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -244,6 +244,8 @@ class TextEdit : public Control  {
 	bool insert_mode;
 	bool select_identifiers_enabled;
 
+	bool raised_from_completion;
+
 	String hilighted_word;
 
 	uint64_t last_dblclk;


### PR DESCRIPTION
Resets the z-index when focus is lost and the completion is shown.

Fixes #6769 

Also relevant for the 2.1 branch ( @akien-mga )
