### PR TITLE
Refresh TextureRegionEditor when region has been changed externally.

### DIFF
--- a/tools/editor/plugins/texture_region_editor_plugin.cpp
+++ b/tools/editor/plugins/texture_region_editor_plugin.cpp
@@ -653,6 +653,7 @@ void TextureRegionEditor::edit(Object *p_obj)
 		} else {
 			p_obj->connect("texture_changed",this,"_edit_region");
 		}
+		p_obj->add_change_receptor(this);
 		p_obj->connect("exit_tree",this,"_node_removed",varray(p_obj),CONNECT_ONESHOT);
 		_edit_region();
 	} else {
@@ -671,6 +672,12 @@ void TextureRegionEditor::edit(Object *p_obj)
 		atlas_tex = Ref<AtlasTexture>(NULL);
 	}
 	edit_draw->update();
+}
+
+void TextureRegionEditor::_changed_callback(Object *p_changed, const char *p_prop) {
+	if ((String)p_prop == "region_rect") {
+		_edit_region();
+	}
 }
 
 void TextureRegionEditor::_edit_region()

--- a/tools/editor/plugins/texture_region_editor_plugin.h
+++ b/tools/editor/plugins/texture_region_editor_plugin.h
@@ -116,6 +116,8 @@ protected:
 
 	Vector2 snap_point(Vector2 p_target) const;
 
+	virtual void _changed_callback(Object *p_changed, const char *p_prop);
+
 public:
 
 	void _edit_region();


### PR DESCRIPTION
Now the TextureRegionEditor updates when you change the region_rect either via the inspector or via
undo/redo.

Fixes #6772
