### PR TITLE
Sprite: Fix inspector not showing changes on "frame" property.

### DIFF
--- a/scene/2d/sprite.cpp
+++ b/scene/2d/sprite.cpp
@@ -214,6 +214,7 @@ void Sprite::set_frame(int p_frame) {
 
 	frame=p_frame;
 
+	_change_notify("frame");
 	emit_signal(SceneStringNames::get_singleton()->frame_changed);
 }
 


### PR DESCRIPTION
Fixes #6562
