### PR TITLE
Changed all instances of Meta to Command

### DIFF
--- a/core/os/keyboard.cpp
+++ b/core/os/keyboard.cpp
@@ -58,7 +58,7 @@ static const _KeyCodeText _keycodes[]={
 		{KEY_PAGEDOWN                      ,"PageDown"},
 		{KEY_SHIFT                         ,"Shift"},
 		{KEY_CONTROL                       ,"Control"},
-		{KEY_META                          ,"Meta"},
+		{KEY_META                          ,"Command"},
 		{KEY_ALT                           ,"Alt"},
 		{KEY_CAPSLOCK                      ,"CapsLock"},
 		{KEY_NUMLOCK                       ,"NumLock"},
@@ -315,7 +315,7 @@ String keycode_get_string(uint32_t p_code) {
 	if (p_code&KEY_MASK_CTRL)
 		codestr+="Ctrl+";
 	if (p_code&KEY_MASK_META)
-		codestr+="Meta+";
+		codestr+="Command+";
 
 	p_code&=KEY_CODE_MASK;
 

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -17386,7 +17386,7 @@
 			Echo state of the key, i.e. whether it's a repeat event or not.
 		</member>
 		<member name="meta" type="bool">
-			State of the Meta modifier.
+			State of the Command modifier.
 		</member>
 		<member name="pressed" type="bool">
 			Pressed state of the key.
@@ -17525,7 +17525,7 @@
 			Global Y coordinate of the mouse click.
 		</member>
 		<member name="meta" type="bool">
-			State of the Meta modifier.
+			State of the Command modifier.
 		</member>
 		<member name="pos" type="Vector2">
 			Local position of the mouse click.
@@ -17661,7 +17661,7 @@
 			Global Y coordinate of the mouse pointer.
 		</member>
 		<member name="meta" type="bool">
-			State of the Meta modifier.
+			State of the Command modifier.
 		</member>
 		<member name="pos" type="Vector2">
 			Local position of the mouse pointer.

--- a/drivers/theora/theora.h
+++ b/drivers/theora/theora.h
@@ -259,7 +259,7 @@ typedef struct{
  * This structure holds the in-stream metadata corresponding to
  * the 'comment' header packet.
  *
- * Meta data is stored as a series of (tag, value) pairs, in
+ * Command data is stored as a series of (tag, value) pairs, in
  * length-encoded string vectors. The first occurence of the 
  * '=' character delimits the tag and value. A particular tag
  * may occur more than once. The character set encoding for

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -1574,7 +1574,7 @@ bool VisualScriptEditor::can_drop_data_fw(const Point2& p_point,const Variant& p
 				if (String(d["type"])=="obj_property") {
 
 #ifdef OSX_ENABLED
-					const_cast<VisualScriptEditor*>(this)->_show_hint(TTR("Hold Meta to drop a Getter. Hold Shift to drop a generic signature."));
+					const_cast<VisualScriptEditor*>(this)->_show_hint(TTR("Hold Command to drop a Getter. Hold Shift to drop a generic signature."));
 #else
 					const_cast<VisualScriptEditor*>(this)->_show_hint(TTR("Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."));
 #endif
@@ -1583,7 +1583,7 @@ bool VisualScriptEditor::can_drop_data_fw(const Point2& p_point,const Variant& p
 				if (String(d["type"])=="nodes") {
 
 #ifdef OSX_ENABLED
-					const_cast<VisualScriptEditor*>(this)->_show_hint(TTR("Hold Meta to drop a simple reference to the node."));
+					const_cast<VisualScriptEditor*>(this)->_show_hint(TTR("Hold Command to drop a simple reference to the node."));
 #else
 					const_cast<VisualScriptEditor*>(this)->_show_hint(TTR("Hold Ctrl to drop a simple reference to the node."));
 #endif
@@ -1592,7 +1592,7 @@ bool VisualScriptEditor::can_drop_data_fw(const Point2& p_point,const Variant& p
 				if (String(d["type"])=="visual_script_variable_drag") {
 
 #ifdef OSX_ENABLED
-					const_cast<VisualScriptEditor*>(this)->_show_hint(TTR("Hold Meta to drop a Variable Setter."));
+					const_cast<VisualScriptEditor*>(this)->_show_hint(TTR("Hold Command to drop a Variable Setter."));
 #else
 					const_cast<VisualScriptEditor*>(this)->_show_hint(TTR("Hold Ctrl to drop a Variable Setter."));
 #endif

--- a/modules/visual_script/visual_script_flow_control.cpp
+++ b/modules/visual_script/visual_script_flow_control.cpp
@@ -821,7 +821,7 @@ String VisualScriptInputFilter::get_output_sequence_port_text(int p_port) const 
 				if (k.mod.control)
 					text="Ctrl+"+text;
 				if (k.mod.meta)
-					text="Meta+"+text;
+					text="Command+"+text;
 			}
 
 		} break;
@@ -843,7 +843,7 @@ String VisualScriptInputFilter::get_output_sequence_port_text(int p_port) const 
 			if (mm.mod.control)
 				text="Ctrl+"+text;
 			if (mm.mod.meta)
-				text="Meta+"+text;
+				text="Command+"+text;
 		} break;
 		case InputEvent::MOUSE_BUTTON: {
 
@@ -867,7 +867,7 @@ String VisualScriptInputFilter::get_output_sequence_port_text(int p_port) const 
 			if (mb.mod.control)
 				text="Ctrl+"+text;
 			if (mb.mod.meta)
-				text="Meta+"+text;
+				text="Command+"+text;
 
 
 		} break;

--- a/scene/gui/input_action.cpp
+++ b/scene/gui/input_action.cpp
@@ -63,7 +63,7 @@ String ShortCut::get_as_text() const {
 			if (shortcut.key.mod.control)
 				str+=RTR("Ctrl+");
 			if (shortcut.key.mod.meta)
-				str+=RTR("Meta+");
+				str+=RTR("Command+");
 
 			str+=keycode_get_string(shortcut.key.scancode).capitalize();
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -51,7 +51,7 @@ String PopupMenu::_get_accel_text(int p_item) const {
 	if (p_accel&KEY_MASK_CTRL)
 		atxt+="Ctrl+";
 	if (p_accel&KEY_MASK_META)
-		atxt+="Meta+";
+		atxt+="Command+";
 
 	p_accel&=KEY_CODE_MASK;
 

--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -586,11 +586,11 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("3d_editor/zoom_style",0);
 	hints["3d_editor/zoom_style"]=PropertyInfo(Variant::INT,"3d_editor/zoom_style",PROPERTY_HINT_ENUM,"Vertical, Horizontal");
 	set("3d_editor/orbit_modifier",0);
-	hints["3d_editor/orbit_modifier"]=PropertyInfo(Variant::INT,"3d_editor/orbit_modifier",PROPERTY_HINT_ENUM,"None,Shift,Alt,Meta,Ctrl");
+	hints["3d_editor/orbit_modifier"]=PropertyInfo(Variant::INT,"3d_editor/orbit_modifier",PROPERTY_HINT_ENUM,"None,Shift,Alt,Command,Ctrl");
 	set("3d_editor/pan_modifier",1);
-	hints["3d_editor/pan_modifier"]=PropertyInfo(Variant::INT,"3d_editor/pan_modifier",PROPERTY_HINT_ENUM,"None,Shift,Alt,Meta,Ctrl");
+	hints["3d_editor/pan_modifier"]=PropertyInfo(Variant::INT,"3d_editor/pan_modifier",PROPERTY_HINT_ENUM,"None,Shift,Alt,Command,Ctrl");
 	set("3d_editor/zoom_modifier",4);
-	hints["3d_editor/zoom_modifier"]=PropertyInfo(Variant::INT,"3d_editor/zoom_modifier",PROPERTY_HINT_ENUM,"None,Shift,Alt,Meta,Ctrl");
+	hints["3d_editor/zoom_modifier"]=PropertyInfo(Variant::INT,"3d_editor/zoom_modifier",PROPERTY_HINT_ENUM,"None,Shift,Alt,Command,Ctrl");
 	set("3d_editor/emulate_numpad",false);
 	set("3d_editor/emulate_3_button_mouse", false);
 

--- a/tools/editor/project_settings.cpp
+++ b/tools/editor/project_settings.cpp
@@ -321,7 +321,7 @@ void ProjectSettings::_wait_for_key(const InputEvent& p_event) {
 		last_wait_for_key=p_event;
 		String str=keycode_get_string(p_event.key.scancode).capitalize();
 		if (p_event.key.mod.meta)
-			str=TTR("Meta+")+str;
+			str=TTR("Command+")+str;
 		if (p_event.key.mod.shift)
 			str=TTR("Shift+")+str;
 		if (p_event.key.mod.alt)
@@ -520,7 +520,7 @@ void ProjectSettings::_update_actions() {
 
 					String str=keycode_get_string(ie.key.scancode).capitalize();
 					if (ie.key.mod.meta)
-						str=TTR("Meta+")+str;
+						str=TTR("Command+")+str;
 					if (ie.key.mod.shift)
 						str=TTR("Shift+")+str;
 					if (ie.key.mod.alt)

--- a/tools/editor/settings_config_dialog.cpp
+++ b/tools/editor/settings_config_dialog.cpp
@@ -242,7 +242,7 @@ void EditorSettingsDialog::_wait_for_key(const InputEvent& p_event) {
 		last_wait_for_key=p_event;
 		String str=keycode_get_string(p_event.key.scancode).capitalize();
 		if (p_event.key.mod.meta)
-			str=TTR("Meta+")+str;
+			str=TTR("Command+")+str;
 		if (p_event.key.mod.shift)
 			str=TTR("Shift+")+str;
 		if (p_event.key.mod.alt)

--- a/tools/translations/ar.po
+++ b/tools/translations/ar.po
@@ -160,7 +160,7 @@ msgid "Add Node"
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -168,7 +168,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -176,7 +176,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -610,7 +610,7 @@ msgstr ""
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
+msgid "Command+"
 msgstr ""
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp

--- a/tools/translations/bg.po
+++ b/tools/translations/bg.po
@@ -169,7 +169,7 @@ msgid "Add Node"
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -177,7 +177,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -185,7 +185,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -647,7 +647,7 @@ msgstr ""
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
+msgid "Command+"
 msgstr ""
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp

--- a/tools/translations/bn.po
+++ b/tools/translations/bn.po
@@ -165,7 +165,7 @@ msgid "Add Node"
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -173,7 +173,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -181,7 +181,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -657,8 +657,8 @@ msgstr "Ctrl+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
-msgstr "Meta+"
+msgid "Command+"
+msgstr "Command+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 msgid "Device"

--- a/tools/translations/ca.po
+++ b/tools/translations/ca.po
@@ -170,7 +170,7 @@ msgid "Add Node"
 msgstr "Afegeix Node"
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -178,7 +178,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -186,7 +186,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -676,8 +676,8 @@ msgstr "Ctrl +"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
-msgstr "Meta +"
+msgid "Command+"
+msgstr "Command +"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 msgid "Device"

--- a/tools/translations/cs.po
+++ b/tools/translations/cs.po
@@ -166,7 +166,7 @@ msgid "Add Node"
 msgstr "Přidat uzel"
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -174,7 +174,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -182,7 +182,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -656,7 +656,7 @@ msgstr "Ctrl+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
+msgid "Command+"
 msgstr ""
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp

--- a/tools/translations/da.po
+++ b/tools/translations/da.po
@@ -164,7 +164,7 @@ msgid "Add Node"
 msgstr "Tilføj Node"
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -172,7 +172,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -180,7 +180,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -664,8 +664,8 @@ msgstr "CTRL +"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
-msgstr "Meta +"
+msgid "Command+"
+msgstr "Command +"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 msgid "Device"

--- a/tools/translations/de.po
+++ b/tools/translations/de.po
@@ -185,7 +185,7 @@ msgid "Add Node"
 msgstr "Node hinzufügen"
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -193,7 +193,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -201,7 +201,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -699,8 +699,8 @@ msgstr "Strg+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
-msgstr "Meta+"
+msgid "Command+"
+msgstr "Command+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 msgid "Device"

--- a/tools/translations/de_CH.po
+++ b/tools/translations/de_CH.po
@@ -162,7 +162,7 @@ msgid "Add Node"
 msgstr "Node"
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -170,7 +170,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -178,7 +178,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -641,7 +641,7 @@ msgstr ""
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
+msgid "Command+"
 msgstr ""
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp

--- a/tools/translations/es.po
+++ b/tools/translations/es.po
@@ -181,7 +181,7 @@ msgid "Add Node"
 msgstr "Añadir nodo"
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -189,7 +189,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -197,7 +197,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -686,8 +686,8 @@ msgstr "Ctrl+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
-msgstr "Meta+"
+msgid "Command+"
+msgstr "Command+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 msgid "Device"

--- a/tools/translations/es_AR.po
+++ b/tools/translations/es_AR.po
@@ -172,7 +172,7 @@ msgid "Add Node"
 msgstr "Agregar Nodo"
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -180,7 +180,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -188,7 +188,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -676,8 +676,8 @@ msgstr "Ctrl+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
-msgstr "Meta+"
+msgid "Command+"
+msgstr "Command+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 msgid "Device"

--- a/tools/translations/fa.po
+++ b/tools/translations/fa.po
@@ -175,7 +175,7 @@ msgid "Add Node"
 msgstr "افزودن گره"
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -183,7 +183,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -191,7 +191,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -680,8 +680,8 @@ msgstr "+Ctrl"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
-msgstr "+Meta"
+msgid "Command+"
+msgstr "+Command"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 msgid "Device"

--- a/tools/translations/fr.po
+++ b/tools/translations/fr.po
@@ -176,7 +176,7 @@ msgid "Add Node"
 msgstr "Ajouter un nœud"
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -184,7 +184,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -192,7 +192,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -684,7 +684,7 @@ msgstr "Contrôle+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
+msgid "Command+"
 msgstr "Méta+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp

--- a/tools/translations/id.po
+++ b/tools/translations/id.po
@@ -171,7 +171,7 @@ msgid "Add Node"
 msgstr "Tambahkan Node"
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -179,7 +179,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -187,7 +187,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -683,8 +683,8 @@ msgstr "Ctrl+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
-msgstr "Meta+"
+msgid "Command+"
+msgstr "Command+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 msgid "Device"

--- a/tools/translations/it.po
+++ b/tools/translations/it.po
@@ -169,7 +169,7 @@ msgid "Add Node"
 msgstr "Aggiungi Nodo"
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -177,7 +177,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -185,7 +185,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -684,8 +684,8 @@ msgstr "Ctrl+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
-msgstr "Meta+"
+msgid "Command+"
+msgstr "Command+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 msgid "Device"

--- a/tools/translations/ja.po
+++ b/tools/translations/ja.po
@@ -171,7 +171,7 @@ msgid "Add Node"
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -179,7 +179,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -187,7 +187,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -676,8 +676,8 @@ msgstr "Ctrl+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
-msgstr "Meta+"
+msgid "Command+"
+msgstr "Command+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 msgid "Device"

--- a/tools/translations/ko.po
+++ b/tools/translations/ko.po
@@ -163,7 +163,7 @@ msgid "Add Node"
 msgstr "노드 추가"
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -171,7 +171,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -179,7 +179,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -656,7 +656,7 @@ msgstr "컨트롤+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
+msgid "Command+"
 msgstr "메타+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp

--- a/tools/translations/nb.po
+++ b/tools/translations/nb.po
@@ -158,7 +158,7 @@ msgid "Add Node"
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -166,7 +166,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -174,7 +174,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -604,7 +604,7 @@ msgstr ""
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
+msgid "Command+"
 msgstr ""
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp

--- a/tools/translations/pl.po
+++ b/tools/translations/pl.po
@@ -168,7 +168,7 @@ msgid "Add Node"
 msgstr "Dodaj węzeł"
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -176,7 +176,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -184,7 +184,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -671,8 +671,8 @@ msgstr "Ctrl+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
-msgstr "Meta+"
+msgid "Command+"
+msgstr "Command+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 msgid "Device"

--- a/tools/translations/pt_BR.po
+++ b/tools/translations/pt_BR.po
@@ -165,7 +165,7 @@ msgid "Add Node"
 msgstr "Adicionar Nó"
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -173,7 +173,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -181,7 +181,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -673,8 +673,8 @@ msgstr "Ctrl+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
-msgstr "Meta+"
+msgid "Command+"
+msgstr "Command+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 msgid "Device"

--- a/tools/translations/pt_PT.po
+++ b/tools/translations/pt_PT.po
@@ -168,7 +168,7 @@ msgid "Add Node"
 msgstr "Adicionar Nó"
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -176,7 +176,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -184,7 +184,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -616,7 +616,7 @@ msgstr ""
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
+msgid "Command+"
 msgstr ""
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp

--- a/tools/translations/ro.po
+++ b/tools/translations/ro.po
@@ -152,7 +152,7 @@ msgid "Add Node"
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -160,7 +160,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -168,7 +168,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -598,7 +598,7 @@ msgstr ""
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
+msgid "Command+"
 msgstr ""
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp

--- a/tools/translations/ru.po
+++ b/tools/translations/ru.po
@@ -170,7 +170,7 @@ msgid "Add Node"
 msgstr "Добавить узел"
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -178,7 +178,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -186,7 +186,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -679,8 +679,8 @@ msgstr "Ctrl+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
-msgstr "Meta+"
+msgid "Command+"
+msgstr "Command+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 msgid "Device"

--- a/tools/translations/sk.po
+++ b/tools/translations/sk.po
@@ -163,7 +163,7 @@ msgid "Add Node"
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -171,7 +171,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -179,7 +179,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -617,8 +617,8 @@ msgstr "Ctrl+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
-msgstr "Meta+"
+msgid "Command+"
+msgstr "Command+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 msgid "Device"

--- a/tools/translations/sl.po
+++ b/tools/translations/sl.po
@@ -166,7 +166,7 @@ msgid "Add Node"
 msgstr "Dodaj Node"
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -174,7 +174,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -182,7 +182,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -628,7 +628,7 @@ msgstr ""
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
+msgid "Command+"
 msgstr ""
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp

--- a/tools/translations/tools.pot
+++ b/tools/translations/tools.pot
@@ -152,7 +152,7 @@ msgid "Add Node"
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -160,7 +160,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -168,7 +168,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -598,7 +598,7 @@ msgstr ""
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
+msgid "Command+"
 msgstr ""
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp

--- a/tools/translations/tr.po
+++ b/tools/translations/tr.po
@@ -159,7 +159,7 @@ msgid "Add Node"
 msgstr "Düğüm Ekle"
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -167,7 +167,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -175,7 +175,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -611,8 +611,8 @@ msgstr "Ctrl+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
-msgstr "Meta+"
+msgid "Command+"
+msgstr "Command+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 msgid "Device"

--- a/tools/translations/ur_PK.po
+++ b/tools/translations/ur_PK.po
@@ -162,7 +162,7 @@ msgid "Add Node"
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -170,7 +170,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -178,7 +178,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -608,7 +608,7 @@ msgstr ""
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
+msgid "Command+"
 msgstr ""
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp

--- a/tools/translations/zh_CN.po
+++ b/tools/translations/zh_CN.po
@@ -178,7 +178,7 @@ msgid "Add Node"
 msgstr "添加子节点"
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -186,7 +186,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -194,7 +194,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -665,8 +665,8 @@ msgstr "Ctrl+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
-msgstr "Meta+"
+msgid "Command+"
+msgstr "Command+"
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 msgid "Device"

--- a/tools/translations/zh_HK.po
+++ b/tools/translations/zh_HK.po
@@ -165,7 +165,7 @@ msgid "Add Node"
 msgstr "新增節點"
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -173,7 +173,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -181,7 +181,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -614,7 +614,7 @@ msgstr ""
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
+msgid "Command+"
 msgstr ""
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp

--- a/tools/translations/zh_TW.po
+++ b/tools/translations/zh_TW.po
@@ -158,7 +158,7 @@ msgid "Add Node"
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Getter. Hold Shift to drop a generic signature."
+msgid "Hold Command to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -166,7 +166,7 @@ msgid "Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a simple reference to the node."
+msgid "Hold Command to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -174,7 +174,7 @@ msgid "Hold Ctrl to drop a simple reference to the node."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
-msgid "Hold Meta to drop a Variable Setter."
+msgid "Hold Command to drop a Variable Setter."
 msgstr ""
 
 #: modules/visual_script/visual_script_editor.cpp
@@ -610,7 +610,7 @@ msgstr ""
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp
 #: tools/editor/settings_config_dialog.cpp
-msgid "Meta+"
+msgid "Command+"
 msgstr ""
 
 #: scene/gui/input_action.cpp tools/editor/project_settings.cpp


### PR DESCRIPTION
Fixes issue #1619 - Use 'command' name instead of 'Meta' for shortcuts on Mac

Replaces all instances of Meta (just when used for naming shortcuts) with Command.
