### PR TITLE
Added small modification on gdscript parser to allow users insert '+' before variables

### DIFF
--- a/core/variant.h
+++ b/core/variant.h
@@ -336,6 +336,7 @@ public:
 		OP_MULTIPLY,
 		OP_DIVIDE,
 		OP_NEGATE,
+		OP_POSITIVE,
 		OP_MODULE,
 		OP_STRING_CONCAT,
 		//bitwise

--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -97,6 +97,12 @@ case m_name: {\
 	_RETURN( -p_a._data.m_type);\
 };
 
+#define DEFAULT_OP_NUM_POS(m_name,m_type)\
+case m_name: {\
+\
+	_RETURN( p_a._data.m_type);\
+};
+
 #define DEFAULT_OP_NUM_VEC(m_op,m_name,m_type)\
 case m_name: {\
 	switch(p_b.type) {\
@@ -136,6 +142,10 @@ case m_name: {\
 	_RETURN( -*reinterpret_cast<const m_type*>(p_a._data._mem));\
 }
 
+#define DEFAULT_OP_LOCALMEM_POS(m_name,m_type)\
+case m_name: {\
+	_RETURN( *reinterpret_cast<const m_type*>(p_a._data._mem));\
+}
 
 #define DEFAULT_OP_LOCALMEM_NUM(m_op,m_name,m_type)\
 case m_name: {switch(p_b.type) {\
@@ -740,6 +750,48 @@ void Variant::evaluate(const Operator& p_op, const Variant& p_a, const Variant& 
 			}
 
 		} break;
+		case OP_POSITIVE: {
+				// Simple case when user defines variable as +value.
+				switch(p_a.type) {
+
+					DEFAULT_OP_FAIL(NIL);
+					DEFAULT_OP_FAIL(STRING);
+					DEFAULT_OP_FAIL(RECT2);
+					DEFAULT_OP_FAIL(MATRIX32);
+					DEFAULT_OP_FAIL(_AABB);
+					DEFAULT_OP_FAIL(MATRIX3);
+					DEFAULT_OP_FAIL(TRANSFORM);
+					DEFAULT_OP_NUM_POS(BOOL,_bool);
+					DEFAULT_OP_NUM_POS(INT,_int);
+					DEFAULT_OP_NUM_POS(REAL,_real);
+					DEFAULT_OP_LOCALMEM_POS(VECTOR3,Vector3);
+					DEFAULT_OP_LOCALMEM_POS(PLANE,Plane);
+					DEFAULT_OP_LOCALMEM_POS(QUAT,Quat);
+					DEFAULT_OP_LOCALMEM_POS(VECTOR2,Vector2);
+
+					DEFAULT_OP_FAIL(COLOR);
+					DEFAULT_OP_FAIL(IMAGE);
+					DEFAULT_OP_FAIL(NODE_PATH);
+					DEFAULT_OP_FAIL(_RID);
+					DEFAULT_OP_FAIL(OBJECT);
+					DEFAULT_OP_FAIL(INPUT_EVENT);
+					DEFAULT_OP_FAIL(DICTIONARY);
+					DEFAULT_OP_FAIL(ARRAY);
+					DEFAULT_OP_FAIL(RAW_ARRAY);
+					DEFAULT_OP_FAIL(INT_ARRAY);
+					DEFAULT_OP_FAIL(REAL_ARRAY);
+					DEFAULT_OP_FAIL(STRING_ARRAY);
+					DEFAULT_OP_FAIL(VECTOR2_ARRAY);
+					DEFAULT_OP_FAIL(VECTOR3_ARRAY);
+					DEFAULT_OP_FAIL(COLOR_ARRAY);
+					case VARIANT_MAX: {
+						r_valid=false;
+						return;
+
+					} break;
+					
+				}
+		} break;
 		case OP_NEGATE: {
 				switch(p_a.type) {
 
@@ -778,9 +830,7 @@ void Variant::evaluate(const Operator& p_op, const Variant& p_a, const Variant& 
 						return;
 
 					} break;
-
 				}
-
 		} break;
 		case OP_MODULE: {
 			if (p_a.type==INT && p_b.type==INT) {

--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -544,14 +544,15 @@ GDParser::Node* GDParser::_parse_expression(Node *p_parent,bool p_static,bool p_
 				expr = id;
 			}
 
-		} else if (/*tokenizer->get_token()==GDTokenizer::TK_OP_ADD ||*/ tokenizer->get_token()==GDTokenizer::TK_OP_SUB || tokenizer->get_token()==GDTokenizer::TK_OP_NOT || tokenizer->get_token()==GDTokenizer::TK_OP_BIT_INVERT) {
+		} else if (tokenizer->get_token()==GDTokenizer::TK_OP_ADD || tokenizer->get_token()==GDTokenizer::TK_OP_SUB || tokenizer->get_token()==GDTokenizer::TK_OP_NOT || tokenizer->get_token()==GDTokenizer::TK_OP_BIT_INVERT) {
 
-			//single prefix operators like !expr -expr ++expr --expr
+			//single prefix operators like !expr +expr -expr ++expr --expr
 			alloc_node<OperatorNode>();
 			Expression e;
 			e.is_op=true;
 
 			switch(tokenizer->get_token()) {
+				case GDTokenizer::TK_OP_ADD: e.op=OperatorNode::OP_POS; break;
 				case GDTokenizer::TK_OP_SUB: e.op=OperatorNode::OP_NEG; break;
 				case GDTokenizer::TK_OP_NOT: e.op=OperatorNode::OP_NOT; break;
 				case GDTokenizer::TK_OP_BIT_INVERT: e.op=OperatorNode::OP_BIT_INVERT;; break;
@@ -999,6 +1000,7 @@ GDParser::Node* GDParser::_parse_expression(Node *p_parent,bool p_static,bool p_
 
 				case OperatorNode::OP_BIT_INVERT: priority=0; unary=true; break;
 				case OperatorNode::OP_NEG: priority=1; unary=true; break;
+				case OperatorNode::OP_POS: priority=1; unary=true; break;
 
 				case OperatorNode::OP_MUL: priority=2; break;
 				case OperatorNode::OP_DIV: priority=2; break;
@@ -1516,6 +1518,7 @@ GDParser::Node* GDParser::_reduce_expression(Node *p_node,bool p_to_const) {
 
 				//unary operators
 				case OperatorNode::OP_NEG: { _REDUCE_UNARY(Variant::OP_NEGATE); } break;
+				case OperatorNode::OP_POS: { _REDUCE_UNARY(Variant::OP_POSITIVE); } break;
 				case OperatorNode::OP_NOT: { _REDUCE_UNARY(Variant::OP_NOT); } break;
 				case OperatorNode::OP_BIT_INVERT: { _REDUCE_UNARY(Variant::OP_BIT_NEGATE); } break;
 				//binary operators (in precedence order)

--- a/modules/gdscript/gd_parser.h
+++ b/modules/gdscript/gd_parser.h
@@ -209,6 +209,7 @@ public:
 			OP_INDEX_NAMED,
 			//unary operators
 			OP_NEG,
+			OP_POS,
 			OP_NOT,
 			OP_BIT_INVERT,
 			OP_PREINC,


### PR DESCRIPTION
Just modified the gdscript parser to allow users to insert a '+' before a variable value; it is mathematically redundant, but is not wrong, and sometimes it is visually useful, like when a variable is relative-to-something ("move(+5)").
