### PR TITLE
Fix access to local file system with "local://" prefix

### DIFF
--- a/core/os/dir_access.cpp
+++ b/core/os/dir_access.cpp
@@ -234,6 +234,10 @@ String DirAccess::fix_path(String p_path) const {
 		} break;
 		case ACCESS_FILESYSTEM: {
 
+			if (p_path.begins_with("local://")) {
+
+				return p_path.replace_first("local:/","");
+			}
 			return p_path;
 		} break;
 	}

--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -169,6 +169,10 @@ String FileAccess::fix_path(const String& p_path) const {
 		} break;
 		case ACCESS_FILESYSTEM: {
 
+			if (r_path.begins_with("local://")) {
+
+				return r_path.replace_first("local:/","");
+			}
 			return r_path;
 		} break;
 	}


### PR DESCRIPTION
Apparently the `"local://"` prefix was not handled properly by `DirAccess` and `FileAccess` classes.
This prevented the user from accessing the file system from script since #6702 

dir_access and file_access classes now properly remove "local:/"
prefix when accessing the file system.

Closes #6801 .
