### PR TITLE
Re-Allow absolute paths, make them behave correctly

### DIFF
--- a/core/globals.cpp
+++ b/core/globals.cpp
@@ -54,7 +54,7 @@ String Globals::localize_path(const String& p_path) const {
 	if (resource_path=="")
 		return p_path; //not initialied yet
 
-	if (p_path.begins_with("res://") || p_path.begins_with("user://"))
+	if (p_path.begins_with("res://") || p_path.begins_with("user://") || p_path.is_abs_path())
 		return p_path.simplify_path();
 
 

--- a/modules/gdscript/gd_functions.cpp
+++ b/modules/gdscript/gd_functions.cpp
@@ -840,10 +840,6 @@ void GDFunctions::call(Function p_func,const Variant **p_args,int p_arg_count,Va
 				r_error.error=Variant::CallError::CALL_ERROR_INVALID_ARGUMENT;
 				r_error.argument=0;
 				r_ret=Variant();
-			} else if(((String)(*p_args[0])).begins_with("/")) {
-				r_error.error=Variant::CallError::CALL_ERROR_INVALID_ARGUMENT;
-				r_error.argument=0;
-				r_ret=RTR("Paths cannot start with '/', absolute paths must start with 'res://', 'user://', or 'local://'");
 			} else {
 				r_ret=ResourceLoader::load(*p_args[0]);
 			}

--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -309,10 +309,6 @@ GDParser::Node* GDParser::_parse_expression(Node *p_parent,bool p_static,bool p_
 				_set_error("expected string constant as 'preload' argument.");
 				return NULL;
 			}
-			if (path.begins_with("/")) {
-				_set_error("Paths cannot start with '/', absolute paths must start with \'res://\', \'user://\', or \'local://\'");
-				return NULL;
-			}
 			if (!path.is_abs_path() && base_path!="")
 				path=base_path+"/"+path;
 			path = path.replace("///","//").simplify_path();
@@ -2120,10 +2116,6 @@ void GDParser::_parse_extends(ClassNode *p_class) {
 		if (constant.get_type()!=Variant::STRING) {
 
 			_set_error("'extends' constant must be a string.");
-			return;
-		}
-		if (((String)(constant)).begins_with("/")) {
-			_set_error("Paths cannot start with '/', absolute paths must start with \'res://\', \'user://\', or \'local://\'");
 			return;
 		}
 


### PR DESCRIPTION
This PR reverts #6702 and closes #6801 .

It also provide a fix that will prevent an absolute path to be misinterpreted as a resource path (which keeps #3106 and #4280 closed since it should not be misleading anymore).
I tested this with absolute paths on Windows and Linux, all is working on my side.

Regarding the `local://` path, apparently is used inside XML representation for resources saved inside the scene file (eg. CollisionShape2D). So I left it untouched.

Example content of XML scene

```
        <resource type="CircleShape2D" path="local://2">
                <real name="custom_solver_bias"> 0 </real>
                <real name="radius"> 11.5 </real>

        </resource>
```
