### PR TITLE
Only show AnimationEditor automatically when an Animplayer is selected.

### DIFF
--- a/tools/editor/plugins/animation_player_editor_plugin.cpp
+++ b/tools/editor/plugins/animation_player_editor_plugin.cpp
@@ -666,7 +666,7 @@ void AnimationPlayerEditor::set_state(const Dictionary& p_state) {
 			return;
 
 		Node *n = EditorNode::get_singleton()->get_edited_scene()->get_node(p_state["player"]);
-		if (n && n->cast_to<AnimationPlayer>()) {
+		if (n && n->cast_to<AnimationPlayer>() && EditorNode::get_singleton()->get_editor_selection()->is_selected(n)) {
 			player=n->cast_to<AnimationPlayer>();
 			_update_player();
 			show();


### PR DESCRIPTION
Previous behaviour was to show it when an AnimationPlayer has been detected in the scene, now you actually have to select it.
Fixes #6213
