### PR TITLE
Fix #6803 - Particle2D params

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -26265,7 +26265,7 @@
 	</methods>
 	<constants>
 		<constant name="PARAM_DIRECTION" value="0">
-			Direction in radians at which the particles will be launched, Notice that when the direction is set to 0 the particles will be launched to the negative
+			Direction in degrees at which the particles will be launched, Notice that when the direction is set to 0 the particles will be launched to the negative
 		</constant>
 		<constant name="PARAM_SPREAD" value="1">
 		</constant>
@@ -26279,7 +26279,7 @@
 			Velocity at which the particles will orbit around the emitter center
 		</constant>
 		<constant name="PARAM_GRAVITY_DIRECTION" value="5">
-			Direction in radians at which the particles will be attracted
+			Direction in degrees at which the particles will be attracted
 		</constant>
 		<constant name="PARAM_GRAVITY_STRENGTH" value="6">
 			Strength of the gravitation attraction for each particle


### PR DESCRIPTION
Fixes #6803 - description of PARAM_DIRECTION and PARAM_GRAVITY_DIRECTION to use degrees instead of radians.
