### PR TITLE
Fix GraphEdit connection wire when resizing GraphNode

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -254,6 +254,7 @@ void GraphEdit::add_child_notify(Node *p_child) {
 		gn->set_scale(Vector2(zoom,zoom));
 		gn->connect("offset_changed",this,"_graph_node_moved",varray(gn));
 		gn->connect("raise_request",this,"_graph_node_raised",varray(gn));
+		gn->connect("item_rect_changed",connections_layer,"update");
 		_graph_node_moved(gn);
 		gn->set_stop_mouse(false);
 	}


### PR DESCRIPTION
Current behavior
![graphedit1 gif](https://cloud.githubusercontent.com/assets/8281454/19397959/2c984f00-9285-11e6-8df5-c2f1b04750a3.gif)

Fixed behavior
![graphedit2 gif](https://cloud.githubusercontent.com/assets/8281454/19397968/37786b1c-9285-11e6-9c69-1ff312899c56.gif)
