### PR TITLE
Allow whitespace in Gamepad mappings.

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -1050,8 +1050,8 @@ void InputDefault::parse_mapping(String p_mapping) {
 		if (entry[idx] == "")
 			continue;
 
-		String from = entry[idx].get_slice(":", 1);
-		String to = entry[idx].get_slice(":", 0);
+		String from = entry[idx].get_slice(":", 1).replace(" ", "");
+		String to = entry[idx].get_slice(":", 0).replace(" ", "");
 
 		JoyEvent to_event = _find_to_event(to);
 		if (to_event.type == -1)


### PR DESCRIPTION
Previously, mappings that contained whitespace (most likely after a comma seperator) would not parse
correctly.
Consider the following mapping as an example:

"_test_guid_, test controller, a:b0, b:b1, leftx:a0 ,"
