### PR TITLE
Fix crash when using Directory.dir_exists(path) on Android

### DIFF
--- a/platform/android/dir_access_jandroid.cpp
+++ b/platform/android/dir_access_jandroid.cpp
@@ -203,7 +203,6 @@ bool DirAccessJAndroid::dir_exists(String p_dir) {
 		return false;
 
 	env->CallVoidMethod(io,_dir_close,res);
-	env->DeleteLocalRef(js);
 
 	return true;
 }


### PR DESCRIPTION
Fix #6837
