### PR TITLE
Correct #6530 Issue on unintended editor input after game crashes.

### DIFF
--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -1620,6 +1620,7 @@ void ScriptEditor::apply_scripts() const {
 void ScriptEditor::_editor_play() {
 
 	debugger->start();
+	debug_menu->get_popup()->grab_focus();
 	debug_menu->get_popup()->set_item_disabled( debug_menu->get_popup()->get_item_index(DEBUG_NEXT), true );
 	debug_menu->get_popup()->set_item_disabled( debug_menu->get_popup()->get_item_index(DEBUG_STEP), true );
 	debug_menu->get_popup()->set_item_disabled( debug_menu->get_popup()->get_item_index(DEBUG_BREAK), false );


### PR DESCRIPTION
Grabbed focus from the editor in popup() when user press play, so no unintended inputs will affect the editor after a game crashes.
