### PR TITLE
SCsub: Add python shebang as a hint for syntax highlighting

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 EnsureSConsVersion(0,14);
 
 

--- a/bin/SCsub
+++ b/bin/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 Import('env')
 Export('env')
 

--- a/bin/tests/SCsub
+++ b/bin/tests/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 Import('env')
 
 env.tests_sources=[]

--- a/core/SCsub
+++ b/core/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.core_sources=[]

--- a/core/bind/SCsub
+++ b/core/bind/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.core_sources,"*.cpp")

--- a/core/io/SCsub
+++ b/core/io/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.core_sources,"*.cpp")

--- a/core/math/SCsub
+++ b/core/math/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.core_sources,"*.cpp")

--- a/core/os/SCsub
+++ b/core/os/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.core_sources,"*.cpp")

--- a/doc/tools/doc_merge.py
+++ b/doc/tools/doc_merge.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import sys

--- a/doc/tools/doc_status.py
+++ b/doc/tools/doc_status.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import re

--- a/doc/tools/makedocs.py
+++ b/doc/tools/makedocs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 #

--- a/doc/tools/makedoku.py
+++ b/doc/tools/makedoku.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import sys

--- a/doc/tools/makehtml.py
+++ b/doc/tools/makehtml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import sys

--- a/doc/tools/makemd.py
+++ b/doc/tools/makemd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import sys

--- a/doc/tools/makerst.py
+++ b/doc/tools/makerst.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import codecs

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.drivers_sources=[]

--- a/drivers/alsa/SCsub
+++ b/drivers/alsa/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.drivers_sources, "*.cpp")

--- a/drivers/convex_decomp/SCsub
+++ b/drivers/convex_decomp/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.drivers_sources, "*.cpp")

--- a/drivers/gl_context/SCsub
+++ b/drivers/gl_context/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 if (env["platform"] in ["haiku","osx","windows","x11"]):

--- a/drivers/gles2/SCsub
+++ b/drivers/gles2/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.drivers_sources, "*.cpp")

--- a/drivers/gles2/shaders/SCsub
+++ b/drivers/gles2/shaders/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 if env['BUILDERS'].has_key('GLSL120GLES'):

--- a/drivers/nrex/SCsub
+++ b/drivers/nrex/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.drivers_sources, "*.cpp")

--- a/drivers/png/SCsub
+++ b/drivers/png/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env_png = env.Clone()

--- a/drivers/pulseaudio/SCsub
+++ b/drivers/pulseaudio/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.drivers_sources, "*.cpp")

--- a/drivers/rtaudio/SCsub
+++ b/drivers/rtaudio/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 # Not cloning the env, the includes need to be accessible for platform/

--- a/drivers/unix/SCsub
+++ b/drivers/unix/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 g_set_p='#ifdef UNIX_ENABLED\n'

--- a/drivers/windows/SCsub
+++ b/drivers/windows/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.drivers_sources, "*.cpp")

--- a/drivers/zlib/SCsub
+++ b/drivers/zlib/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 # Not cloning the env, the includes need to be accessible for core/

--- a/main/SCsub
+++ b/main/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.main_sources=[]

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env_modules = env.Clone()

--- a/modules/chibi/SCsub
+++ b/modules/chibi/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 Import('env_modules')
 

--- a/modules/cscript/SCsub
+++ b/modules/cscript/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/dds/SCsub
+++ b/modules/dds/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 Import('env_modules')
 

--- a/modules/enet/SCsub
+++ b/modules/enet/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 Import('env_modules')
 

--- a/modules/etc1/SCsub
+++ b/modules/etc1/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 Import('env_modules')
 

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 # Not building in a separate env as core needs it

--- a/modules/gdscript/SCsub
+++ b/modules/gdscript/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/gridmap/SCsub
+++ b/modules/gridmap/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/ik/SCsub
+++ b/modules/ik/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/jpg/SCsub
+++ b/modules/jpg/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 Import('env_modules')
 

--- a/modules/mpc/SCsub
+++ b/modules/mpc/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 Import('env_modules')
 

--- a/modules/ogg/SCsub
+++ b/modules/ogg/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 Import('env_modules')
 

--- a/modules/openssl/SCsub
+++ b/modules/openssl/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 Import('env_modules')
 

--- a/modules/opus/SCsub
+++ b/modules/opus/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 Import('env_modules')
 

--- a/modules/pbm/SCsub
+++ b/modules/pbm/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 Import('env_modules')
 

--- a/modules/pvr/SCsub
+++ b/modules/pvr/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 Import('env_modules')
 

--- a/modules/squish/SCsub
+++ b/modules/squish/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 Import('env_modules')
 

--- a/modules/theora/SCsub
+++ b/modules/theora/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 Import('env_modules')
 

--- a/modules/visual_script/SCsub
+++ b/modules/visual_script/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/vorbis/SCsub
+++ b/modules/vorbis/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 Import('env_modules')
 

--- a/modules/webp/SCsub
+++ b/modules/webp/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 Import('env_modules')
 

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import shutil
 
 Import('env')

--- a/platform/bb10/SCsub
+++ b/platform/bb10/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 bb10_lib = [

--- a/platform/haiku/SCsub
+++ b/platform/haiku/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 common_haiku = [

--- a/platform/iphone/SCsub
+++ b/platform/iphone/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 iphone_lib = [

--- a/platform/javascript/SCsub
+++ b/platform/javascript/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 javascript_files = [

--- a/platform/osx/SCsub
+++ b/platform/osx/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 files = [

--- a/platform/server/SCsub
+++ b/platform/server/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 

--- a/platform/winrt/SCsub
+++ b/platform/winrt/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 files = [

--- a/platform/x11/SCsub
+++ b/platform/x11/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 

--- a/scene/2d/SCsub
+++ b/scene/2d/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.scene_sources,"*.cpp")

--- a/scene/3d/SCsub
+++ b/scene/3d/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 

--- a/scene/SCsub
+++ b/scene/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.scene_sources=[]

--- a/scene/animation/SCsub
+++ b/scene/animation/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.scene_sources,"*.cpp")

--- a/scene/audio/SCsub
+++ b/scene/audio/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.scene_sources,"*.cpp")

--- a/scene/gui/SCsub
+++ b/scene/gui/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.scene_sources,"*.cpp")

--- a/scene/io/SCsub
+++ b/scene/io/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.scene_sources,"*.cpp")

--- a/scene/main/SCsub
+++ b/scene/main/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.scene_sources,"*.cpp")

--- a/scene/resources/SCsub
+++ b/scene/resources/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.scene_sources,"*.cpp")

--- a/scene/resources/default_theme/SCsub
+++ b/scene/resources/default_theme/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.scene_sources,"*.cpp")

--- a/servers/SCsub
+++ b/servers/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.servers_sources=[]

--- a/servers/audio/SCsub
+++ b/servers/audio/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.servers_sources,"*.cpp")

--- a/servers/physics/SCsub
+++ b/servers/physics/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.servers_sources,"*.cpp")

--- a/servers/physics/joints/SCsub
+++ b/servers/physics/joints/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.servers_sources,"*.cpp")

--- a/servers/physics_2d/SCsub
+++ b/servers/physics_2d/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.servers_sources,"*.cpp")

--- a/servers/spatial_sound/SCsub
+++ b/servers/spatial_sound/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.servers_sources,"*.cpp")

--- a/servers/spatial_sound_2d/SCsub
+++ b/servers/spatial_sound_2d/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.servers_sources,"*.cpp")

--- a/servers/visual/SCsub
+++ b/servers/visual/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.servers_sources,"*.cpp")

--- a/tools/SCsub
+++ b/tools/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.tool_sources=[]

--- a/tools/collada/SCsub
+++ b/tools/collada/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.tool_sources,"*.cpp")

--- a/tools/doc/SCsub
+++ b/tools/doc/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 env.add_source_files(env.tool_sources,"*.cpp")

--- a/tools/editor/SCsub
+++ b/tools/editor/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 

--- a/tools/editor/fileserver/SCsub
+++ b/tools/editor/fileserver/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 Export('env')
 env.add_source_files(env.tool_sources,"*.cpp")

--- a/tools/editor/icons/SCsub
+++ b/tools/editor/icons/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 
 def make_editor_icons_action(target, source, env):

--- a/tools/editor/io_plugins/SCsub
+++ b/tools/editor/io_plugins/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 Export('env')
 env.add_source_files(env.tool_sources,"*.cpp")

--- a/tools/editor/plugins/SCsub
+++ b/tools/editor/plugins/SCsub
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 Import('env')
 Export('env')
 env.add_source_files(env.tool_sources,"*.cpp")

--- a/tools/scripts/make_glwrapper.py
+++ b/tools/scripts/make_glwrapper.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python
 import sys
 
 if (len(sys.argv)<2):


### PR DESCRIPTION
It's a Unix shebang but I know at least from @vnen that it works as a hint for python syntax highlighting in Notepad++ on Windows.

Works fine for syntax highlighting in Kate and nano.
