### PR TITLE
Isolate XAudio2 driver

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -132,6 +132,7 @@ opts.Add('openssl','OpenSSL library for openssl module (system/builtin)','builti
 opts.Add('libmpcdec','libmpcdec library for mpc module (system/builtin)','builtin')
 opts.Add('enet','ENet library (system/builtin)','builtin')
 opts.Add('glew','GLEW library for the gl_context (system/builtin)','builtin')
+opts.Add('xaudio2','XAudio2 audio driver (yes/no)','no')
 opts.Add("CXX", "C++ Compiler")
 opts.Add("CC", "C Compiler")
 opts.Add("CCFLAGS", "Custom flags for the C++ compiler");

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -14,6 +14,8 @@ SConscript('alsa/SCsub');
 SConscript('pulseaudio/SCsub');
 if (env["platform"] == "windows"):
 	SConscript("rtaudio/SCsub");
+if (env["xaudio2"] == "yes"):
+	SConscript("xaudio2/SCsub");
 
 # Graphics drivers
 SConscript('gles2/SCsub');

--- a/drivers/xaudio2/SCsub
+++ b/drivers/xaudio2/SCsub
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+Import('env')
+
+env.add_source_files(env.drivers_sources, "*.cpp")
+env.Append(CXXFLAGS=['-DXAUDIO2_ENABLED'])
+env.Append(LINKFLAGS=['xaudio2_8.lib'])
+
+Export('env')

--- a/drivers/xaudio2/audio_driver_xaudio2.cpp
+++ b/drivers/xaudio2/audio_driver_xaudio2.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  audio_driver_winrt.cpp                                               */
+/*  audio_driver_xaudio2.cpp                                             */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -26,23 +26,17 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#include "audio_driver_winrt.h"
+#include "audio_driver_xaudio2.h"
 
 #include "globals.h"
 #include "os/os.h"
 
-using namespace Windows::Media;
-using namespace Windows::Media::Core;
-using namespace Windows::Media::MediaProperties;
-using namespace Windows::Media::Editing;
-using namespace Windows::Foundation;
-
-const char * AudioDriverWinRT::get_name() const
+const char * AudioDriverXAudio2::get_name() const
 {
-	return "WinRT";
+	return "XAudio2";
 }
 
-Error AudioDriverWinRT::init() {
+Error AudioDriverXAudio2::init() {
 
 	active = false;
 	thread_exited = false;
@@ -95,14 +89,14 @@ Error AudioDriverWinRT::init() {
 	}
 
 	mutex = Mutex::create();
-	thread = Thread::create(AudioDriverWinRT::thread_func, this);
+	thread = Thread::create(AudioDriverXAudio2::thread_func, this);
 
 	return OK;
 };
 
-void AudioDriverWinRT::thread_func(void* p_udata) {
+void AudioDriverXAudio2::thread_func(void* p_udata) {
 
-	AudioDriverWinRT* ad = (AudioDriverWinRT*)p_udata;
+	AudioDriverXAudio2* ad = (AudioDriverXAudio2*)p_udata;
 
 	uint64_t usdelay = (ad->buffer_size / float(ad->mix_rate)) * 1000000;
 
@@ -149,7 +143,7 @@ void AudioDriverWinRT::thread_func(void* p_udata) {
 
 };
 
-void AudioDriverWinRT::start() {
+void AudioDriverXAudio2::start() {
 
 	active = true;
 	HRESULT hr = source_voice->Start(0);
@@ -159,17 +153,17 @@ void AudioDriverWinRT::start() {
 	}
 };
 
-int AudioDriverWinRT::get_mix_rate() const {
+int AudioDriverXAudio2::get_mix_rate() const {
 
 	return mix_rate;
 };
 
-AudioDriverSW::OutputFormat AudioDriverWinRT::get_output_format() const {
+AudioDriverSW::OutputFormat AudioDriverXAudio2::get_output_format() const {
 
 	return output_format;
 };
 
-float AudioDriverWinRT::get_latency() {
+float AudioDriverXAudio2::get_latency() {
 
 	XAUDIO2_PERFORMANCE_DATA perf_data;
 	xaudio->GetPerformanceData(&perf_data);
@@ -180,20 +174,20 @@ float AudioDriverWinRT::get_latency() {
 	}
 }
 
-void AudioDriverWinRT::lock() {
+void AudioDriverXAudio2::lock() {
 
 	if (!thread || !mutex)
 		return;
 	mutex->lock();
 };
-void AudioDriverWinRT::unlock() {
+void AudioDriverXAudio2::unlock() {
 
 	if (!thread || !mutex)
 		return;
 	mutex->unlock();
 };
 
-void AudioDriverWinRT::finish() {
+void AudioDriverXAudio2::finish() {
 
 	if (!thread)
 		return;
@@ -224,7 +218,7 @@ void AudioDriverWinRT::finish() {
 	thread = NULL;
 };
 
-AudioDriverWinRT::AudioDriverWinRT() {
+AudioDriverXAudio2::AudioDriverXAudio2() {
 
 	mutex = NULL;
 	thread = NULL;
@@ -236,7 +230,7 @@ AudioDriverWinRT::AudioDriverWinRT() {
 	current_buffer = 0;
 };
 
-AudioDriverWinRT::~AudioDriverWinRT() {
+AudioDriverXAudio2::~AudioDriverXAudio2() {
 
 
 };

--- a/drivers/xaudio2/audio_driver_xaudio2.h
+++ b/drivers/xaudio2/audio_driver_xaudio2.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  audio_driver_winrt.h                                                 */
+/*  audio_driver_xaudio2.h                                               */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -26,8 +26,8 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#ifndef AUDIO_DRIVER_WINRT_H
-#define AUDIO_DRIVER_WINRT_H
+#ifndef AUDIO_DRIVER_XAUDIO2_H
+#define AUDIO_DRIVER_XAUDIO2_H
 
 #include "servers/audio/audio_server_sw.h"
 
@@ -40,7 +40,7 @@
 #include <xaudio2.h>
 #include <wrl/client.h>
 
-class AudioDriverWinRT : public AudioDriverSW {
+class AudioDriverXAudio2 : public AudioDriverSW {
 
 	enum {
 		AUDIO_BUFFERS = 2
@@ -53,12 +53,12 @@ class AudioDriverWinRT : public AudioDriverSW {
 		void STDMETHODCALLTYPE OnBufferEnd(void* pBufferContext) { /*print_line("buffer ended");*/ SetEvent(buffer_end_event); }
 
 		//Unused methods are stubs
-		void STDMETHODCALLTYPE OnStreamEnd() { }
-		void STDMETHODCALLTYPE OnVoiceProcessingPassEnd() { }
-		void STDMETHODCALLTYPE OnVoiceProcessingPassStart(UINT32 SamplesRequired) {    }
-		void STDMETHODCALLTYPE OnBufferStart(void * pBufferContext) {    }
-		void STDMETHODCALLTYPE OnLoopEnd(void * pBufferContext) {    }
-		void STDMETHODCALLTYPE OnVoiceError(void * pBufferContext, HRESULT Error) { }
+		void STDMETHODCALLTYPE OnStreamEnd() {}
+		void STDMETHODCALLTYPE OnVoiceProcessingPassEnd() {}
+		void STDMETHODCALLTYPE OnVoiceProcessingPassStart(UINT32 SamplesRequired) {}
+		void STDMETHODCALLTYPE OnBufferStart(void * pBufferContext) {}
+		void STDMETHODCALLTYPE OnLoopEnd(void * pBufferContext) {}
+		void STDMETHODCALLTYPE OnVoiceError(void * pBufferContext, HRESULT Error) {}
 
 	};
 
@@ -102,8 +102,8 @@ public:
 	virtual void unlock();
 	virtual void finish();
 
-	AudioDriverWinRT();
-	~AudioDriverWinRT();
+	AudioDriverXAudio2();
+	~AudioDriverXAudio2();
 };
 
 #endif

--- a/drivers/xaudio2/audio_driver_xaudio2.h
+++ b/drivers/xaudio2/audio_driver_xaudio2.h
@@ -87,7 +87,7 @@ class AudioDriverXAudio2 : public AudioDriverSW {
 	IXAudio2MasteringVoice* mastering_voice;
 	XAUDIO2_BUFFER xaudio_buffer[AUDIO_BUFFERS];
 	IXAudio2SourceVoice* source_voice;
-	XAudio2DriverVoiceCallback* voice_callback;
+	XAudio2DriverVoiceCallback voice_callback;
 
 public:
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2418,6 +2418,9 @@ OS_Windows::OS_Windows(HINSTANCE _hInstance) {
 #ifdef RTAUDIO_ENABLED
 	AudioDriverManagerSW::add_driver(&driver_rtaudio);
 #endif
+#ifdef XAUDIO2_ENABLED
+	AudioDriverManagerSW::add_driver(&driver_xaudio2);
+#endif
 
 }
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -41,6 +41,9 @@
 #include "servers/audio/audio_server_sw.h"
 #include "servers/audio/sample_manager_sw.h"
 #include "drivers/rtaudio/audio_driver_rtaudio.h"
+#ifdef XAUDIO2_ENABLED
+#include "drivers/xaudio2/audio_driver_xaudio2.h"
+#endif
 #include "servers/spatial_sound/spatial_sound_server_sw.h"
 #include "servers/spatial_sound_2d/spatial_sound_2d_server_sw.h"
 #include "drivers/unix/ip_unix.h"
@@ -136,6 +139,9 @@ class OS_Windows : public OS {
 
 #ifdef RTAUDIO_ENABLED
 	AudioDriverRtAudio driver_rtaudio;
+#endif
+#ifdef XAUDIO2_ENABLED
+	AudioDriverXAudio2 driver_xaudio2;
 #endif
 
 	void _drag_event(int p_x, int p_y, int idx);

--- a/platform/winrt/SCsub
+++ b/platform/winrt/SCsub
@@ -8,7 +8,6 @@ files = [
 	'#platform/windows/key_mapping_win.cpp',
 	'joystick_winrt.cpp',
 	'gl_context_egl.cpp',
-	'audio_driver_winrt.cpp',
 	'app.cpp',
 	'os_winrt.cpp',
 ]

--- a/platform/winrt/detect.py
+++ b/platform/winrt/detect.py
@@ -31,6 +31,7 @@ def get_flags():
 	('tools', 'no'),
 	('builtin_zlib', 'yes'),
 	('openssl', 'builtin'),
+	('xaudio2', 'yes'),
 	]
 
 
@@ -145,7 +146,6 @@ def configure(env):
 	env.Append(CCFLAGS=['/DGLES2_ENABLED','/DGL_GLEXT_PROTOTYPES','/DEGL_EGLEXT_PROTOTYPES','/DANGLE_ENABLED'])
 
 	LIBS = [
-		'xaudio2',
 		'WindowsApp',
 		'mincore',
 		'libANGLE',

--- a/platform/winrt/os_winrt.h
+++ b/platform/winrt/os_winrt.h
@@ -40,7 +40,7 @@
 #include "servers/spatial_sound/spatial_sound_server_sw.h"
 #include "servers/spatial_sound_2d/spatial_sound_2d_server_sw.h"
 #include "servers/physics_2d/physics_2d_server_sw.h"
-#include "audio_driver_winrt.h"
+#include "drivers/xaudio2/audio_driver_xaudio2.h"
 
 #include "gl_context_egl.h"
 
@@ -118,7 +118,7 @@ private:
 
 	MainLoop *main_loop;
 
-	AudioDriverWinRT audio_driver;
+	AudioDriverXAudio2 audio_driver;
 	AudioServerSW *audio_server;
 	SampleManagerMallocSW *sample_manager;
 	SpatialSoundServerSW *spatial_sound_server;


### PR DESCRIPTION
Now it's possible to compile for Windows platform if wanted. It's
supported only for Windows 8 or later, so it's not enabled by default.
