### PR TITLE
Disable asserts in release mode

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -261,6 +261,8 @@ if selected_platform in platform_list:
 			sys.exit(255)
 		suffix+=".opt"
 
+		env.Append(CCFLAGS=['-DNDEBUG']);
+
 	elif (env["target"]=="release_debug"):
 		if (env["tools"]=="yes"):
 			suffix+=".opt.tools"


### PR DESCRIPTION
Generated code should be smaller and faster.

This patch is extracted from old WebM PR.

Btw. in Godot `CFLAGS` works for C compiler, but `CCFLAGS` works for both C and C++ compilers on my computer. Description in `SConstruct` file tells that `CCFLAGS` is only for C++ compiler.
