### PR TITLE
Fix Keyboard Input Hangs when using modifiers

### DIFF
--- a/core/input_map.cpp
+++ b/core/input_map.cpp
@@ -106,7 +106,7 @@ List<StringName> InputMap::get_actions() const {
 	return actions;
 }
 
-List<InputEvent>::Element *InputMap::_find_event(List<InputEvent> &p_list,const InputEvent& p_event) const {
+List<InputEvent>::Element *InputMap::_find_event(List<InputEvent> &p_list,const InputEvent& p_event, bool p_mod_ignore=false) const {
 
 	for (List<InputEvent>::Element *E=p_list.front();E;E=E->next()) {
 
@@ -122,7 +122,7 @@ List<InputEvent>::Element *InputMap::_find_event(List<InputEvent> &p_list,const 
 
 			case InputEvent::KEY: {
 
-				same=(e.key.scancode==p_event.key.scancode && e.key.mod == p_event.key.mod);
+				same=(e.key.scancode==p_event.key.scancode && (p_mod_ignore || e.key.mod == p_event.key.mod));
 
 			} break;
 			case InputEvent::JOYSTICK_BUTTON: {
@@ -229,7 +229,7 @@ bool InputMap::event_is_action(const InputEvent& p_event, const StringName& p_ac
 		return p_event.action.action==E->get().id;
 	}
 
-	return _find_event(E->get().inputs,p_event)!=NULL;
+	return _find_event(E->get().inputs,p_event,!p_event.is_pressed())!=NULL;
 }
 
 const Map<StringName, InputMap::Action>& InputMap::get_action_map() const {

--- a/core/input_map.h
+++ b/core/input_map.h
@@ -46,7 +46,7 @@ private:
 	mutable Map<StringName, Action> input_map;
 	mutable Map<int,StringName> input_id_map;
 
-	List<InputEvent>::Element *_find_event(List<InputEvent> &p_list,const InputEvent& p_event) const;
+	List<InputEvent>::Element *_find_event(List<InputEvent> &p_list,const InputEvent& p_event, bool p_mod_ignore) const;
 
 	Array _get_action_list(const StringName& p_action);
 	Array _get_actions();

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -18019,7 +18019,7 @@
 			<argument index="1" name="action" type="String">
 			</argument>
 			<description>
-				Return whether the given event is part of an existing action.
+				Return whether the given event is part of an existing action. This method ignores keyboard modifiers if the given [InputEvent] is not pressed (for proper release detection). See [method action_has_event] if you don't want this behavior.
 			</description>
 		</method>
 		<method name="get_action_from_id" qualifiers="const">

--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -377,13 +377,13 @@ void InputDefault::parse_input_event(const InputEvent& p_event) {
 
 			if (InputMap::get_singleton()->event_is_action(p_event,E->key())) {
 
-				Action action;
-				action.fixed_frame=OS::get_singleton()->get_fixed_frames();
-				action.idle_frame=OS::get_singleton()->get_idle_frames();
-				action.pressed=p_event.is_pressed();
-
-				action_state[E->key()]=action;
-
+				if(is_action_pressed(E->key()) != p_event.is_pressed()) {
+					Action action;
+					action.fixed_frame=OS::get_singleton()->get_fixed_frames();
+					action.idle_frame=OS::get_singleton()->get_idle_frames();
+					action.pressed=p_event.is_pressed();
+					action_state[E->key()]=action;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
`InputMap::event_is_action` now ignores keyboard modifiers if the event is not pressed.
Clarify difference between `InputMap::action_has_event` and `InputMap::event_is_action` in docs.

E.g.

```
# Action Map
print("Action Map")
InputMap.add_action("a")
InputMap.add_action("shift_a")
var action_ev = InputEvent()
action_ev.type = InputEvent.KEY
action_ev.scancode = KEY_A

InputMap.action_add_event("a", action_ev)
printt("a", var2str(action_ev))

action_ev.shift = true
InputMap.action_add_event("shift_a", action_ev)
printt("shift_a", var2str(action_ev))

# Key test
var ev = InputEvent()
ev.type = InputEvent.KEY
ev.scancode = KEY_A
ev.shift = true

print("\n")
printt("Event", var2str(ev))
printt("Released", "has_event", "is_action")
printt( "regular", InputMap.action_has_event("a", ev), InputMap.event_is_action(ev, "a") ) # False, True
printt( "shifted", InputMap.action_has_event("shift_a", ev), InputMap.event_is_action(ev, "shift_a") ) # True, True

print("\n")
printt("Pressed", "has_event", "is_action")
ev.pressed = true
printt( "regular", InputMap.action_has_event("a", ev), InputMap.event_is_action(ev, "a") ) # False, False
printt( "shifted", InputMap.action_has_event("shift_a", ev), InputMap.event_is_action(ev, "shift_a") ) # True, True
```

Closes #6388.
