### PR TITLE
Missing return statement inside tween logic

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -830,6 +830,7 @@ bool Tween::remove(Object *p_object, String p_key) {
 			continue;
 		if(object == p_object && (data.key == p_key || p_key == "")) {
 			for_removal.push_back(E);
+			return true;
 		}
 	}
 	for(List<List<InterpolateData>::Element *>::Element *E=for_removal.front();E;E=E->next()) {


### PR DESCRIPTION
https://github.com/godotengine/godot/pull/6613/  commit broke backward compatibility for my project, 
It turned out that missing 'return' statement from line 833 affects the logic of tween
