### PR TITLE
Fixed tiny error in detect.py causing compilation for Android to fail.

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -133,7 +133,7 @@ def configure(env):
 		gcc_path=gcc_path+"/darwin-x86_64/bin"
 		env['SHLINKFLAGS'][1] = '-shared'
 		env['SHLIBSUFFIX'] = '.so'
-	elif (os.platform.startswith('win')):
+	elif (sys.platform.startswith('win')):
                 if (platform.machine().endswith('64')):
 			gcc_path=gcc_path+"/windows-x86_64/bin"
                 else:


### PR DESCRIPTION
```
scons: Reading SConscript files ...
Godot Android!!!!! (armv7) (with neon)
AttributeError: 'module' object has no attribute 'platform':
  File "Z:\git_repos_godot\godot\SConstruct", line 256:
    detect.configure(env)
  File "./platform/android\detect.py", line 136:
    elif (os.platform.startswith('win')):
```
