### PR TITLE
Create script Dialog changes extension automatically.

### DIFF
--- a/tools/editor/script_create_dialog.cpp
+++ b/tools/editor/script_create_dialog.cpp
@@ -164,10 +164,12 @@ void ScriptCreateDialog::_lang_changed(int l) {
 	} else {
 		class_name->set_editable(false);
 	}
-	if (file_path->get_text().basename()==initial_bp) {
-		file_path->set_text(initial_bp+"."+ScriptServer::get_language( l )->get_extension());
-		_path_changed(file_path->get_text());
+
+	if (file_path->get_text().rfind(".") > file_path->get_text().rfind(file_path->get_text().basename())) { // if there is an extention after basename
+		file_path->set_text(String(file_path->get_text().substr(0, file_path->get_text().rfind(".")+1) + ScriptServer::get_language( l )->get_extension()));
 	}
+	
+	_path_changed(file_path->get_text());
 	_class_name_changed(class_name->get_text());
 
 }


### PR DESCRIPTION
Fix on Issue #6878.

I'm assuming that a file or a folder named with a "." is invalid in any system when you change the language of your script. If that is untrue, the fix is literally just taking the "_path_changed(file_path->get_text());" from the original if statement.

EDIT: corrected this case, now it changes the extension regardless of folders names.
