### PR TITLE
Change set_locale to fallback to the global language

### DIFF
--- a/core/translation.cpp
+++ b/core/translation.cpp
@@ -779,6 +779,11 @@ Vector<String> TranslationServer::get_all_locale_names(){
 }
 
 
+static String get_trimmed_locale(const String& p_locale) {
+
+	return p_locale.substr(0,2);
+}
+
 static bool is_valid_locale(const String& p_locale) {
 
 	const char **ptr=locale_list;

--- a/core/translation.cpp
+++ b/core/translation.cpp
@@ -844,9 +844,17 @@ void Translation::_set_messages(const DVector<String>& p_messages){
 
 void Translation::set_locale(const String& p_locale) {
 
-	ERR_EXPLAIN("Invalid Locale: "+p_locale);
-	ERR_FAIL_COND(!is_valid_locale(p_locale));
-	locale=p_locale;
+	if(!is_valid_locale(p_locale)) {
+		String trimmed_locale = get_trimmed_locale(p_locale);
+		
+		ERR_EXPLAIN("Invalid Locale: "+trimmed_locale);
+		ERR_FAIL_COND(!is_valid_locale(trimmed_locale));
+		
+		locale=trimmed_locale;
+	}
+	else {
+		locale=p_locale;
+	}
 }
 
 void Translation::add_message( const StringName& p_src_text, const StringName& p_xlated_text ) {

--- a/core/translation.cpp
+++ b/core/translation.cpp
@@ -919,9 +919,17 @@ Translation::Translation() {
 
 void TranslationServer::set_locale(const String& p_locale) {
 
-	ERR_EXPLAIN("Invalid Locale: "+p_locale);
-	ERR_FAIL_COND(!is_valid_locale(p_locale));
-	locale=p_locale;
+	if(!is_valid_locale(p_locale)) {
+		String trimmed_locale = get_trimmed_locale(p_locale);
+		
+		ERR_EXPLAIN("Invalid Locale: "+trimmed_locale);
+		ERR_FAIL_COND(!is_valid_locale(trimmed_locale));
+		
+		locale=trimmed_locale;
+	}
+	else {
+		locale=p_locale;
+	}
 }
 
 String TranslationServer::get_locale() const {


### PR DESCRIPTION
Addresses #6787 by adding a function to get the locale's language and attempt to use it as the locale before failing.

There is no test coverage for this new function or for the new functionality in set_locale. If needed, please let me know where to add it. Thanks!
