### PR TITLE
Fix regression #6864 caused by #6613

### DIFF
--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -143,6 +143,7 @@ private:
 
 	void _tween_process(float p_delta);
 	void _set_process(bool p_process,bool p_force=false);
+	void _remove(Object *p_node, String p_key, bool first_only);
 
 protected:
 


### PR DESCRIPTION
Should fix the issue. Calling remove should delete all matching tweens but internally it stops on first match so should work with delayed tweens as before.
