### PR TITLE
Improve drag and drop on 2D viewport

### DIFF
--- a/tools/editor/plugins/canvas_item_editor_plugin.h
+++ b/tools/editor/plugins/canvas_item_editor_plugin.h
@@ -31,17 +31,18 @@
 
 #include "tools/editor/editor_plugin.h"
 #include "tools/editor/editor_node.h"
+#include "scene/gui/button_group.h"
+#include "scene/gui/check_box.h"
+#include "scene/gui/label.h"
 #include "scene/gui/spin_box.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/box_container.h"
 #include "scene/2d/canvas_item.h"
-
 /**
 	@author Juan Linietsky <reduzio@gmail.com>
 */
 
-
-
+class CanvasItemEditorViewport;
 
 class CanvasItemEditorSelectedItem : public Object {
 
@@ -451,6 +452,51 @@ public:
 	CanvasItemEditorPlugin(EditorNode *p_node);
 	~CanvasItemEditorPlugin();
 
+};
+
+class CanvasItemEditorViewport : public VBoxContainer {
+	OBJ_TYPE( CanvasItemEditorViewport, VBoxContainer );
+
+	String default_type;
+	Vector<String> types;
+
+	Vector<String> selected_files;
+	Node* target_node;
+	Point2 drop_pos;
+
+	EditorNode* editor;
+	EditorData* editor_data;
+	CanvasItemEditor* canvas;
+	Node2D* preview;
+	AcceptDialog* accept;
+	WindowDialog* selector;
+	Label* selector_label;
+	Label* label;
+	Label* label_desc;
+	ButtonGroup* btn_group;
+
+	void _on_mouse_exit();
+	void _on_select_type(Object* selected);
+	void _on_change_type();
+
+	void _create_preview(const Vector<String>& files) const;
+	void _remove_preview();
+
+	bool _cyclical_dependency_exists(const String& p_target_scene_path, Node* p_desired_node);
+	void _create_nodes(Node* parent, Node* child, String& path, const Point2& p_point);
+	bool _create_instance(Node* parent, String& path, const Point2& p_point);
+	void _perform_drop_data();
+
+	static void _bind_methods();
+
+protected:
+	void _notification(int p_what);
+
+public:
+	virtual bool can_drop_data(const Point2& p_point,const Variant& p_data) const;
+	virtual void drop_data(const Point2& p_point,const Variant& p_data);
+
+	CanvasItemEditorViewport(EditorNode *p_node, CanvasItemEditor* p_canvas);
 };
 
 #endif

--- a/tools/editor/scene_tree_dock.h
+++ b/tools/editor/scene_tree_dock.h
@@ -174,7 +174,7 @@ public:
 	void fill_path_renames(Node* p_node, Node *p_new_parent, List<Pair<NodePath,NodePath> > *p_renames);
 	void perform_node_renames(Node* p_base,List<Pair<NodePath,NodePath> > *p_renames, Map<Ref<Animation>, Set<int> > *r_rem_anims=NULL);
 	SceneTreeEditor *get_tree_editor() { return scene_tree; }
-
+	EditorData *get_editor_data() { return editor_data; }
 
 	void open_script_dialog(Node* p_for_node);
 	SceneTreeDock(EditorNode *p_editor,Node *p_scene_root,EditorSelection *p_editor_selection,EditorData &p_editor_data);


### PR DESCRIPTION
Can make faster by dragging texture or Scene file onto 2D viewport.
And also working with live edit scene (Sync scene changes)

Drag & drop : Add node under selected node
Drag & drop + Shift : Add node as sibling with selected node
Drag & drop + Alt : Change default node type

[Preview on YouTube](https://www.youtube.com/watch?v=JEBr2zGnUcM)
