### PR TITLE
Allow typing hints for Array class (in GDScript and Inspector)

### DIFF
--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -2554,10 +2554,34 @@ void GDParser::_parse_class(ClassNode *p_class) {
 						current_export.type=type;
 						current_export.usage|=PROPERTY_USAGE_SCRIPT_VARIABLE;
 						tokenizer->advance();
+						
+						String hint_prefix ="";
+						
+						if(type == Variant::ARRAY && tokenizer->get_token()==GDTokenizer::TK_COMMA) {
+							tokenizer->advance();
+
+							while(tokenizer->get_token()==GDTokenizer::TK_BUILT_IN_TYPE) {
+								type = tokenizer->get_token_type();
+								
+								tokenizer->advance();
+
+								if(type == Variant::ARRAY) {
+									hint_prefix += itos(Variant::ARRAY)+":";
+									if (tokenizer->get_token()==GDTokenizer::TK_COMMA) {
+										tokenizer->advance();
+									}
+								} else {
+									hint_prefix += itos(type);
+									break;
+								}
+							}
+						}
+						
 						if (tokenizer->get_token()==GDTokenizer::TK_COMMA) {
 							// hint expected next!
 							tokenizer->advance();
-							switch(current_export.type) {
+
+							switch(type) {
 
 
 								case Variant::INT: {
@@ -2913,7 +2937,14 @@ void GDParser::_parse_class(ClassNode *p_class) {
 									return;
 								} break;
 							}
-
+							
+						}
+						if(current_export.type == Variant::ARRAY && !hint_prefix.empty()) {
+							if(current_export.hint) {
+								hint_prefix += "/"+itos(current_export.hint);
+							}
+							current_export.hint_string=hint_prefix+":"+current_export.hint_string;
+							current_export.hint=PROPERTY_HINT_NONE;
 						}
 
 					} else if (tokenizer->get_token()==GDTokenizer::TK_IDENTIFIER) {

--- a/tools/editor/array_property_edit.h
+++ b/tools/editor/array_property_edit.h
@@ -39,6 +39,9 @@ class ArrayPropertyEdit : public Reference {
 	ObjectID obj;
 	StringName property;
 	String vtypes;
+	String subtype_hint_string;
+	PropertyHint subtype_hint;
+	Variant::Type subtype;
 	Variant get_array() const;
 	Variant::Type default_type;
 
@@ -56,7 +59,7 @@ protected:
 
 public:
 
-	void edit(Object* p_obj, const StringName& p_prop, Variant::Type p_deftype);
+	void edit(Object* p_obj, const StringName& p_prop, const String& p_hint_string, Variant::Type p_deftype);
 
 	Node *get_node();
 

--- a/tools/editor/property_editor.cpp
+++ b/tools/editor/property_editor.cpp
@@ -3258,7 +3258,7 @@ void PropertyEditor::update_tree() {
 						max=p.hint_string.get_slice(",",1).to_double();
 					}
 
-					if (p.type!=PROPERTY_HINT_SPRITE_FRAME && c>=3) {
+					if (p.hint!=PROPERTY_HINT_SPRITE_FRAME && c>=3) {
 
 						step= p.hint_string.get_slice(",",2).to_double();
 					}
@@ -3403,10 +3403,30 @@ void PropertyEditor::update_tree() {
 
 
 				Variant v = obj->get(p.name);
+				String type_name = "Array";
+				String type_name_suffix = "";
+				
+				String hint = p.hint_string;
+				while(hint.begins_with(itos(Variant::ARRAY)+":")) {
+					type_name += "<Array";
+					type_name_suffix += ">";
+					hint = hint.substr(2, hint.size()-2);
+				}
+				if(hint.find(":") >= 0) {
+					hint = hint.substr(0,hint.find(":"));
+					if(hint.find("/") >= 0) {
+						hint = hint.substr(0,hint.find("/"));
+					}
+					type_name += "<" + Variant::get_type_name(Variant::Type(hint.to_int()));
+					type_name_suffix += ">";
+				}
+				type_name += type_name_suffix;
+				
 				if (v.is_array())
-					item->set_text(1,"Array["+itos(v.call("size"))+"]");
+					item->set_text(1,type_name+"["+itos(v.call("size"))+"]");
 				else
-					item->set_text(1,"Array[]");
+					item->set_text(1,type_name+"[]");
+				
 				if (show_type_icons)
 					item->set_icon( 0, get_icon("ArrayData","EditorIcons") );
 
@@ -4118,7 +4138,7 @@ void PropertyEditor::_edit_button(Object *p_item, int p_column, int p_button) {
 			}
 
 			Ref<ArrayPropertyEdit> ape = memnew( ArrayPropertyEdit );
-			ape->edit(obj,n,Variant::Type(t));
+			ape->edit(obj,n,ht,Variant::Type(t));
 
 			EditorNode::get_singleton()->push_item(ape.ptr());
 		}


### PR DESCRIPTION
Closes #3586, by implementing the `1b` variation mentioned there.

Use as:

``` gdscript
export(Array, IntArray) var map
export(Array, Array, int, FLAGS, "Walkable", "Mineable") var map
```
