### PR TITLE
fix bug introduced by #6501

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -61,7 +61,7 @@ platform_arg = ARGUMENTS.get("platform", ARGUMENTS.get("p", False))
 if (os.name=="posix"):
 	pass
 elif (os.name=="nt"):
-	if (not methods.msvc_is_detected() or platform_arg=="android"):
+	if ( os.getenv("VCINSTALLDIR")==None or platform_arg=="android"):
 		custom_tools=['mingw']
 
 env_base=Environment(tools=custom_tools);

--- a/methods.py
+++ b/methods.py
@@ -1516,11 +1516,6 @@ def detect_visual_c_compiler_version(tools_env):
 
         return vc_chosen_compiler_str
 
-def msvc_is_detected() :
-	# looks for VisualStudio env variable 
-	# or for Visual C++ Build Tools (which is a standalone MSVC)
-	return os.getenv("VSINSTALLDIR") or os.getenv("VS100COMNTOOLS") or os.getenv("VS110COMNTOOLS") or os.getenv("VS120COMNTOOLS") or os.getenv("VS140COMNTOOLS");
-
 
 def precious_program(env, program, sources, **args):
 	program = env.ProgramOriginal(program, sources, **args)

--- a/modules/openssl/SCsub
+++ b/modules/openssl/SCsub
@@ -671,7 +671,7 @@ if (env["openssl"] != "system"): # builtin
 	# Workaround for compilation error with GCC/Clang when -Werror is too greedy (GH-4517)
 	import os
 	import methods
-	if not (os.name=="nt" and methods.msvc_is_detected()): # not Windows and not MSVC
+	if not (os.name=="nt" and os.getenv("VCINSTALLDIR")): # not Windows and not MSVC
 		env_openssl.Append(CFLAGS = ["-Wno-error=implicit-function-declaration"])
 
 

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -1,22 +1,22 @@
 #
-# 	tested on                   | Windows native    | Linux cross-compilation
-#	----------------------------+-------------------+---------------------------
-#	MSVS C++ 2010 Express       | WORKS             | n/a
+#   tested on                   | Windows native    | Linux cross-compilation
+#   ----------------------------+-------------------+---------------------------
 #   Visual C++ Build Tools 2015 | WORKS             | n/a
-#	Mingw-w64                   | WORKS             | WORKS
-#	Mingw-w32                   | WORKS             | WORKS
-#	MinGW                       | WORKS             | untested
-#
-#####
-# Notes about MSVS C++ :
-#
-# 	- MSVC2010-Express compiles to 32bits only.
+#   MSVS C++ 2010 Express       | WORKS             | n/a
+#   Mingw-w64                   | WORKS             | WORKS
+#   Mingw-w32                   | WORKS             | WORKS
+#   MinGW                       | WORKS             | untested
 #
 #####
 # Note about Visual C++ Build Tools :
 #
 #	- Visual C++ Build Tools is the standalone MSVC compiler :
 #		http://landinghub.visualstudio.com/visual-cpp-build-tools
+#
+#####
+# Notes about MSVS C++ :
+#
+# 	- MSVC2010-Express compiles to 32bits only.
 #
 #####
 # Notes about Mingw-w64 and Mingw-w32 under Windows :
@@ -109,7 +109,7 @@ def can_build():
 
 	if (os.name=="nt"):
 		#building natively on windows!
-		if ( methods.msvc_is_detected() ):
+		if ( os.getenv("VCINSTALLDIR") ):
 			return True
 		else:
 			print("\nMSVC not detected, attempting Mingw.")
@@ -204,7 +204,7 @@ def configure(env):
 
 	env.Append(CPPPATH=['#platform/windows'])
 	env['is_mingw']=False
-	if (os.name=="nt" and methods.msvc_is_detected() ):
+	if (os.name=="nt" and os.getenv("VCINSTALLDIR") ):
 		#build using visual studio
 		env['ENV']['TMP'] = os.environ['TMP']
 		env.Append(CPPPATH=['#platform/windows/include'])


### PR DESCRIPTION
( @Akien : this PR is for current HEAD only, not to be cherry-picked for 2.1.1 )

this is manual revertion of #6501 which introduced a bug that prevented
scons from detecting Mingw under Windows when MSVC was installed.
(thanks to @vnen for finding this)

AND
it fixes the actual bug that prevented scons from detecting MSVC standalone
compiler ( a confusions between `VSINSTALLDIR` and `VCINSTALLDIR` )

The freeware Standalone MSVC C++ Build Tools are available here :
http://landinghub.visualstudio.com/visual-cpp-build-tools
