### PR TITLE
Added update_render_texture function to viewport

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1264,7 +1264,11 @@ Viewport::RenderTargetUpdateMode Viewport::get_render_target_update_mode() const
 
 	return render_target_update_mode;
 }
-//RID get_render_target_texture() const;
+//RID get_render_target_texture() const; // clean this up ?
+void Viewport::update_render_target(){
+
+	VS::get_singleton()->viewport_update_render_target(viewport);
+}
 
 void Viewport::queue_screen_capture(){
 
@@ -2643,6 +2647,7 @@ void Viewport::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_render_target_clear_on_new_frame"), &Viewport::get_render_target_clear_on_new_frame);
 
 	ObjectTypeDB::bind_method(_MD("render_target_clear"), &Viewport::render_target_clear);
+	ObjectTypeDB::bind_method(_MD("update_render_target"), &Viewport::update_render_target);
 
 	ObjectTypeDB::bind_method(_MD("set_render_target_filter","enable"), &Viewport::set_render_target_filter);
 	ObjectTypeDB::bind_method(_MD("get_render_target_filter"), &Viewport::get_render_target_filter);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -351,6 +351,8 @@ public:
 	RenderTargetUpdateMode get_render_target_update_mode() const;
 	Ref<RenderTargetTexture> get_render_target_texture() const;
 
+	void update_render_target();
+
 
 	Vector2 get_camera_coords(const Vector2& p_viewport_coords) const;
 	Vector2 get_camera_rect_size() const;

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -1657,6 +1657,17 @@ RID VisualServerRaster::viewport_get_render_target_texture(RID p_viewport) const
 	return viewport->render_target_texture;
 
 }
+void VisualServerRaster::viewport_update_render_target(RID p_viewport){
+
+        VS_CHANGED;
+        Viewport *viewport = viewport_owner.get( p_viewport );
+        ERR_FAIL_COND(!viewport);
+
+	if(viewport->render_target.is_valid() && viewport->render_target_update_mode==RENDER_TARGET_UPDATE_DISABLED){
+		viewport->render_target_update_mode = RENDER_TARGET_UPDATE_ONCE;
+                viewport_update_list.add(&viewport->update_list);
+	}
+}
 
 void VisualServerRaster::viewport_set_render_target_vflip(RID p_viewport,bool p_enable) {
 

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -1002,6 +1002,7 @@ public:
 	virtual void viewport_set_render_target_update_mode(RID p_viewport,RenderTargetUpdateMode p_mode);
 	virtual RenderTargetUpdateMode viewport_get_render_target_update_mode(RID p_viewport) const;
 	virtual RID viewport_get_render_target_texture(RID p_viewport) const;
+	virtual void viewport_update_render_target(RID p_viewport);
 	virtual void viewport_set_render_target_vflip(RID p_viewport,bool p_enable);
 	virtual bool viewport_get_render_target_vflip(RID p_viewport) const;
 	virtual void viewport_set_render_target_clear_on_new_frame(RID p_viewport,bool p_enable);

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -439,6 +439,7 @@ public:
 	FUNC2(viewport_set_render_target_update_mode,RID,RenderTargetUpdateMode);
 	FUNC1RC(RenderTargetUpdateMode,viewport_get_render_target_update_mode,RID);
 	FUNC1RC(RID,viewport_get_render_target_texture,RID);
+	FUNC1(viewport_update_render_target,RID);
 
 	FUNC2(viewport_set_render_target_vflip,RID,bool);
 	FUNC1RC(bool,viewport_get_render_target_vflip,RID);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -709,6 +709,7 @@ public:
 	virtual void viewport_set_as_render_target(RID p_viewport,bool p_enable)=0;
 	virtual void viewport_set_render_target_update_mode(RID p_viewport,RenderTargetUpdateMode p_mode)=0;
 	virtual RenderTargetUpdateMode viewport_get_render_target_update_mode(RID p_viewport) const=0;
+	virtual void viewport_update_render_target(RID p_viewport)=0;
 	virtual RID viewport_get_render_target_texture(RID p_viewport) const=0;
 	virtual void viewport_set_render_target_vflip(RID p_viewport,bool p_enable)=0;
 	virtual bool viewport_get_render_target_vflip(RID p_viewport) const=0;


### PR DESCRIPTION
This patch adds a `update_render_texture` function to the `Viewport` object.

This makes it possible to update a `Viewport`, used to render to a texture, only if it is required.
The Viewports `Update Mode` need to be set to `Never` (only draw after update_render_texture call) or `Once` (draw initially and after that update calls are required.)

In its behavior it is similar to the `queue_screen_capture`function but doesn't generate a image.
