### PR TITLE
Add "Never" underline mode to LinkButton

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -20298,6 +20298,9 @@
 		<constant name="UNDERLINE_MODE_ON_HOVER" value="1">
 			The LinkButton will show an underline at the bottom of its text when the mouse cursor is over it.
 		</constant>
+		<constant name="UNDERLINE_MODE_NEVER" value="2">
+			The LinkButton will never show an underline at the bottom of its text.
+		</constant>
 	</constants>
 	<theme_items>
 		<theme_item name="font" type="Font">

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -87,13 +87,13 @@ void LinkButton::_notification(int p_what) {
 					else
 						color=get_color("font_color");
 
-					do_underline=true;
+					do_underline=underline_mode!=UNDERLINE_MODE_NEVER;
 
 				} break;
 				case DRAW_HOVER: {
 
 					color=get_color("font_color_hover");
-					do_underline=true;
+					do_underline=underline_mode!=UNDERLINE_MODE_NEVER;
 
 				} break;
 				case DRAW_DISABLED: {
@@ -139,9 +139,10 @@ void LinkButton::_bind_methods() {
 
 	BIND_CONSTANT( 	UNDERLINE_MODE_ALWAYS );
 	BIND_CONSTANT( 	UNDERLINE_MODE_ON_HOVER );
+	BIND_CONSTANT( 	UNDERLINE_MODE_NEVER );
 
 	ADD_PROPERTYNZ(PropertyInfo(Variant::STRING,"text"), _SCS("set_text"), _SCS("get_text"));
-	ADD_PROPERTYNZ(PropertyInfo(Variant::INT,"underline",PROPERTY_HINT_ENUM,"Always,On Hover"), _SCS("set_underline_mode"), _SCS("get_underline_mode"));
+	ADD_PROPERTYNZ(PropertyInfo(Variant::INT,"underline",PROPERTY_HINT_ENUM,"Always,On Hover,Never"), _SCS("set_underline_mode"), _SCS("get_underline_mode"));
 
 }
 

--- a/scene/gui/link_button.h
+++ b/scene/gui/link_button.h
@@ -40,7 +40,8 @@ public:
 
 	enum UnderlineMode {
 		UNDERLINE_MODE_ALWAYS,
-		UNDERLINE_MODE_ON_HOVER
+		UNDERLINE_MODE_ON_HOVER,
+		UNDERLINE_MODE_NEVER
 	};
 private:
 	String text;


### PR DESCRIPTION
This trivial patch makes it possible to use LinkButton without any underline at all by adding a third "Never" underline mode.
