### PR TITLE
Fix #6913, theme editor regression in 2.1.1 rc

### DIFF
--- a/tools/editor/plugins/theme_editor_plugin.cpp
+++ b/tools/editor/plugins/theme_editor_plugin.cpp
@@ -532,12 +532,10 @@ void ThemeEditor::_theme_menu_cbk(int p_option) {
 	name_edit->show();
 	name_menu->show();
 
-
 	if (p_option==POPUP_ADD) {//add
 
 		add_del_dialog->set_title(TTR("Add Item"));
 		add_del_dialog->get_ok()->set_text(TTR("Add"));
-		add_del_dialog->popup_centered(Size2(490,85)*EDSCALE);
 
 		base_theme=Theme::get_default();
 
@@ -545,7 +543,6 @@ void ThemeEditor::_theme_menu_cbk(int p_option) {
 
 		add_del_dialog->set_title(TTR("Add All Items"));
 		add_del_dialog->get_ok()->set_text(TTR("Add All"));
-		add_del_dialog->popup_centered(Size2(240,85)*EDSCALE);
 
 		base_theme=Theme::get_default();
 
@@ -559,7 +556,6 @@ void ThemeEditor::_theme_menu_cbk(int p_option) {
 
 		add_del_dialog->set_title(TTR("Remove Item"));
 		add_del_dialog->get_ok()->set_text(TTR("Remove"));
-		add_del_dialog->popup_centered(Size2(490,85)*EDSCALE);
 
 		base_theme=theme;
 
@@ -567,7 +563,6 @@ void ThemeEditor::_theme_menu_cbk(int p_option) {
 
 		add_del_dialog->set_title("Remove All Items");
 		add_del_dialog->get_ok()->set_text("Remove All");
-		add_del_dialog->popup_centered(Size2(240,85)*EDSCALE);
 
 		base_theme=Theme::get_default();
 
@@ -578,13 +573,17 @@ void ThemeEditor::_theme_menu_cbk(int p_option) {
 		name_menu->hide();
 	}
 	popup_mode=p_option;
+	add_del_dialog->show();
+	add_del_dialog->set_size(Size2());
+	add_del_dialog->popup_centered();
+	
 
 	ERR_FAIL_COND( theme.is_null() );
 
 	List<StringName> types;
 	base_theme->get_type_list(&types);
 
-	type_menu->get_popup()->clear();;
+	type_menu->get_popup()->clear();
 
 	if (p_option==0 || p_option==1) {//add
 
@@ -880,50 +879,34 @@ ThemeEditor::ThemeEditor() {
 	add_del_dialog->hide();
 	add_child(add_del_dialog);
 
+	grid = memnew(GridContainer);
+	grid->set_columns(5);
+	add_del_dialog->add_child(grid);
+	add_del_dialog->set_child_rect(grid);
 
-	Label *l = memnew( Label );
-	l->set_pos( Point2(5,5)*EDSCALE );
-	l->set_text(TTR("Type:"));
-	add_del_dialog->add_child(l);
-	dtype_select_label=l;
-
+	dtype_select_label = memnew( Label );
+	dtype_select_label->set_text(TTR("Type:"));
 
 	type_edit = memnew( LineEdit );
-	type_edit->set_pos(Point2(5,25)*EDSCALE);
-	type_edit->set_size(Point2(150,5)*EDSCALE);
-	add_del_dialog->add_child(type_edit);
+
 	type_menu = memnew( MenuButton );
-	type_menu->set_pos(Point2(160,25)*EDSCALE);
-	type_menu->set_size(Point2(30,5)*EDSCALE);
 	type_menu->set_text("..");
-	add_del_dialog->add_child(type_menu);
 
 	type_menu->get_popup()->connect("item_pressed", this,"_type_menu_cbk");
 
-	l = memnew( Label );
-	l->set_pos( Point2(200,5)*EDSCALE );
-	l->set_text(TTR("Name:"));
-	add_del_dialog->add_child(l);
-	name_select_label=l;
+	name_select_label = memnew( Label );
+	name_select_label->set_text(TTR("Name:"));
 
 	name_edit = memnew( LineEdit );
-	name_edit->set_pos(Point2(200,25)*EDSCALE);
-	name_edit->set_size(Point2(150,5)*EDSCALE);
-	add_del_dialog->add_child(name_edit);
-	name_menu = memnew( MenuButton );
-	name_menu->set_pos(Point2(360,25)*EDSCALE);
-	name_menu->set_size(Point2(30,5)*EDSCALE);
-	name_menu->set_text("..");
 
-	add_del_dialog->add_child(name_menu);
+	name_menu = memnew( MenuButton );
+	name_menu->set_text("..");
 
 	name_menu->get_popup()->connect("about_to_show", this,"_name_menu_about_to_show");
 	name_menu->get_popup()->connect("item_pressed", this,"_name_menu_cbk");
 
 	type_select_label= memnew( Label );
-	type_select_label->set_pos( Point2(400,5)*EDSCALE );
 	type_select_label->set_text(TTR("Data Type:"));
-	add_del_dialog->add_child(type_select_label);
 
 	type_select = memnew( OptionButton );
 	type_select->add_item(TTR("Icon"));
@@ -931,11 +914,24 @@ ThemeEditor::ThemeEditor() {
 	type_select->add_item(TTR("Font"));
 	type_select->add_item(TTR("Color"));
 	type_select->add_item(TTR("Constant"));
-	type_select->set_pos( Point2( 400,25 )*EDSCALE );
-	type_select->set_size( Point2( 80,5 )*EDSCALE );
 
+	Size2 min = type_edit->get_minimum_size();
+	min.x = type_edit->get_font("font")->get_char_size('x').x * 22 * EDSCALE;
+	type_edit->set_custom_minimum_size(min);
+	name_edit->set_custom_minimum_size(min);
+	min.x *= 0.7;
+	type_select->set_custom_minimum_size(min);
 
-	add_del_dialog->add_child(type_select);
+	grid->add_child(dtype_select_label);
+	grid->add_child(memnew( Control ));
+	grid->add_child(name_select_label);
+	grid->add_child(memnew( Control ));
+	grid->add_child(type_select_label);
+	grid->add_child(type_edit);
+	grid->add_child(type_menu);
+	grid->add_child(name_edit);
+	grid->add_child(name_menu);
+	grid->add_child(type_select);
 
 	add_del_dialog->get_ok()->connect("pressed", this,"_dialog_cbk");
 

--- a/tools/editor/plugins/theme_editor_plugin.h
+++ b/tools/editor/plugins/theme_editor_plugin.h
@@ -36,6 +36,7 @@
 #include "scene/gui/check_box.h"
 #include "scene/gui/button_group.h"
 #include "scene/gui/scroll_container.h"
+#include "scene/gui/grid_container.h"
 
 #include "tools/editor/editor_node.h"
 
@@ -57,6 +58,7 @@ class ThemeEditor : public Control {
 
 	MenuButton *theme_menu;
 	ConfirmationDialog *add_del_dialog;
+	GridContainer *grid;
 	MenuButton *type_menu;
 	LineEdit *type_edit;
 	MenuButton *name_menu;


### PR DESCRIPTION
After #6423 which fixed #6143 absolute layout of theme editor popups stopped working.
It should work now. I had a little problem with centering (maybe it's another thing to fix) so any help appreciated with this `show()` before `popup_centered()`.
