### PR TITLE
Improve Android build (Clang + tidyness)

### DIFF
--- a/modules/regex/regex.cpp
+++ b/modules/regex/regex.cpp
@@ -97,6 +97,9 @@ struct RegExNode {
 			memdelete(next);
 	}
 
+	// For avoiding RTTI
+	virtual bool is_look_behind() { return false; }
+
 	virtual int test(RegExSearch& s, int pos) const {
 
 		return next ? next->test(s, pos) : -1;
@@ -750,6 +753,8 @@ struct RegExNodeLookBehind : public RegExNodeGroup {
 		reset_pos = true;
 	}
 
+	virtual bool is_look_behind() { return true; }
+
 	virtual int test(RegExSearch& s, int pos) const {
 
 		if (pos < length)
@@ -1089,7 +1094,7 @@ Error RegEx::compile(const String& p_pattern) {
 						REGEX_COMPILE_FAIL("backreference not found");
 
 					for (int i = 0; i < stack.size(); ++i)
-						if (dynamic_cast<RegExNodeLookBehind*>(stack[i]))
+						if (stack[i]->is_look_behind())
 							REGEX_COMPILE_FAIL("backreferences inside lookbehind not supported");
 
 					for (int i = 0; i < group_names.size(); ++i) {
@@ -1112,7 +1117,7 @@ Error RegEx::compile(const String& p_pattern) {
 					c = d;
 
 					for (int i = 0; i < stack.size(); ++i)
-						if (dynamic_cast<RegExNodeLookBehind*>(stack[i]))
+						if (stack[i]->is_look_behind())
 							REGEX_COMPILE_FAIL("backreferences inside lookbehind not supported");
 
 					int ref = -1;
@@ -1238,7 +1243,7 @@ Error RegEx::compile(const String& p_pattern) {
 				break;
 			case '|':
 				for (int i = 0; i < stack.size(); ++i)
-					if (dynamic_cast<RegExNodeLookBehind*>(stack[i]))
+					if (stack[i]->is_look_behind())
 						REGEX_COMPILE_FAIL("alternations inside lookbehind not supported");
 				stack[0]->add_childset();
 				break;
@@ -1312,7 +1317,7 @@ Error RegEx::compile(const String& p_pattern) {
 
 						if (min_val != max_val)
 							for (int i = 0; i < stack.size(); ++i)
-								if (dynamic_cast<RegExNodeLookBehind*>(stack[i]))
+								if (stack[i]->is_look_behind())
 									REGEX_COMPILE_FAIL("variable length quantifiers inside lookbehind not supported");
 
 						RegExNodeQuantifier* quant = memnew(RegExNodeQuantifier(min_val, max_val));

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -24,9 +24,8 @@ def can_build():
 def get_opts():
 
     return [
-        ('ANDROID_NDK_ROOT', 'the path to Android NDK', os.environ.get("ANDROID_NDK_ROOT", 0)),
-        ('NDK_TARGET', 'toolchain to use for the NDK', os.environ.get("NDK_TARGET", "arm-linux-androideabi-4.9")),
-        ('NDK_TARGET_X86', 'toolchain to use for the NDK x86', os.environ.get("NDK_TARGET_X86", "x86-4.9")),
+        ('ANDROID_NDK_ROOT', 'the path to Android NDK',
+         os.environ.get("ANDROID_NDK_ROOT", 0)),
         ('ndk_platform', 'compile for platform: (android-<api> , example: android-14)', "android-14"),
         ('android_arch', 'select compiler architecture: (armv7/armv6/x86)', "armv7"),
         ('android_neon', 'enable neon (armv7 only)', "yes"),
@@ -100,7 +99,6 @@ def configure(env):
         env['android_arch'] = 'armv7'
 
     if env['android_arch'] == 'x86':
-        env['NDK_TARGET'] = env['NDK_TARGET_X86']
         env["x86_libtheora_opt_gcc"] = True
 
     if env['PLATFORM'] == 'win32':
@@ -116,96 +114,129 @@ def configure(env):
 
     if env['android_arch'] == 'x86':
         env.extra_suffix = ".x86" + env.extra_suffix
+        target_subpath = "x86-4.9"
+        abi_subpath = "i686-linux-android"
+        arch_subpath = "x86"
     elif env['android_arch'] == 'armv6':
         env.extra_suffix = ".armv6" + env.extra_suffix
+        target_subpath = "arm-linux-androideabi-4.9"
+        abi_subpath = "arm-linux-androideabi"
+        arch_subpath = "armeabi"
     elif env["android_arch"] == "armv7":
+        target_subpath = "arm-linux-androideabi-4.9"
+        abi_subpath = "arm-linux-androideabi"
+        arch_subpath = "armeabi-v7a"
         if env['android_neon'] == 'yes':
             env.extra_suffix = ".armv7.neon" + env.extra_suffix
         else:
             env.extra_suffix = ".armv7" + env.extra_suffix
 
-    gcc_path = env["ANDROID_NDK_ROOT"] + "/toolchains/" + env["NDK_TARGET"] + "/prebuilt/"
-
     if (sys.platform.startswith("linux")):
         if (platform.machine().endswith('64')):
-            gcc_path = gcc_path + "/linux-x86_64/bin"
+            host_subpath = "linux-x86_64"
         else:
-            gcc_path = gcc_path + "/linux-x86/bin"
+            host_subpath = "linux-x86"
     elif (sys.platform.startswith("darwin")):
-        gcc_path = gcc_path + "/darwin-x86_64/bin"
-        env['SHLINKFLAGS'][1] = '-shared'
-        env['SHLIBSUFFIX'] = '.so'
+        host_subpath = "darwin-x86_64"
     elif (sys.platform.startswith('win')):
         if (platform.machine().endswith('64')):
-            gcc_path = gcc_path + "/windows-x86_64/bin"
+            host_subpath = "windows-x86_64"
         else:
-            gcc_path = gcc_path + "/windows-x86/bin"
+            host_subpath = "windows-x86"
 
-    env['ENV']['PATH'] = gcc_path + ":" + env['ENV']['PATH']
-    if env['android_arch'] == 'x86':
-        env['CC'] = gcc_path + '/i686-linux-android-gcc'
-        env['CXX'] = gcc_path + '/i686-linux-android-g++'
-        env['AR'] = gcc_path + "/i686-linux-android-ar"
-        env['RANLIB'] = gcc_path + "/i686-linux-android-ranlib"
-        env['AS'] = gcc_path + "/i686-linux-android-as"
-    else:
-        env['CC'] = gcc_path + '/arm-linux-androideabi-gcc'
-        env['CXX'] = gcc_path + '/arm-linux-androideabi-g++'
-        env['AR'] = gcc_path + "/arm-linux-androideabi-ar"
-        env['RANLIB'] = gcc_path + "/arm-linux-androideabi-ranlib"
-        env['AS'] = gcc_path + "/arm-linux-androideabi-as"
+    compiler_path = env["ANDROID_NDK_ROOT"] + \
+        "/toolchains/llvm/prebuilt/" + host_subpath + "/bin"
+    gcc_toolchain_path = env["ANDROID_NDK_ROOT"] + \
+        "/toolchains/" + target_subpath + "/prebuilt/" + host_subpath
+    tools_path = gcc_toolchain_path + "/" + abi_subpath + "/bin"
+
+    # For Clang to find NDK tools in preference of those system-wide
+    env.PrependENVPath('PATH', tools_path)
+
+    env['CC'] = compiler_path + '/clang'
+    env['CXX'] = compiler_path + '/clang++'
+    env['AR'] = tools_path + "/ar"
+    env['RANLIB'] = tools_path + "/ranlib"
+    env['AS'] = tools_path + "/as"
 
     if env['android_arch'] == 'x86':
         env['ARCH'] = 'arch-x86'
     else:
         env['ARCH'] = 'arch-arm'
 
-    import string
-    # include path
-    gcc_include = env["ANDROID_NDK_ROOT"] + "/platforms/" + ndk_platform + "/" + env['ARCH'] + "/usr/include"
-    ld_sysroot = env["ANDROID_NDK_ROOT"] + "/platforms/" + ndk_platform + "/" + env['ARCH']
-    # glue_include=env["ANDROID_NDK_ROOT"]+"/sources/android/native_app_glue"
-    ld_path = env["ANDROID_NDK_ROOT"] + "/platforms/" + ndk_platform + "/" + env['ARCH'] + "/usr/lib"
-    env.Append(CPPPATH=[gcc_include])
-#	env['CCFLAGS'] = string.split('-DNO_THREADS -MMD -MP -MF -fpic -ffunction-sections -funwind-tables -fstack-protector -D__ARM_ARCH_5__ -D__ARM_ARCH_5T__ -D__ARM_ARCH_5E__ -D__ARM_ARCH_5TE__  -Wno-psabi -march=armv5te -mtune=xscale -msoft-float  -fno-exceptions -mthumb -fno-strict-aliasing -DANDROID -Wa,--noexecstack -DGLES2_ENABLED ')
+    sysroot = env["ANDROID_NDK_ROOT"] + \
+        "/platforms/" + ndk_platform + "/" + env['ARCH']
+    common_opts = ['-fno-integrated-as', '-gcc-toolchain', gcc_toolchain_path]
+
+    env.Append(CPPFLAGS=["-isystem", sysroot + "/usr/include"])
+    env.Append(CPPFLAGS=string.split(
+        '-Wno-invalid-command-line-argument -Wno-unused-command-line-argument'))
+    env.Append(CPPFLAGS=string.split(
+        '-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -fvisibility=hidden -fno-strict-aliasing -Wa,--noexecstack'))
+    env.Append(CPPFLAGS=string.split('-DANDROID -DNO_STATVFS -DGLES2_ENABLED'))
 
     env['neon_enabled'] = False
     if env['android_arch'] == 'x86':
-        env.Append(CCFLAGS=string.split('-DNO_STATVFS -fpic -ffunction-sections -funwind-tables -fstack-protector -fvisibility=hidden -D__GLIBC__  -Wno-psabi -ftree-vectorize -funsafe-math-optimizations -fno-strict-aliasing -DANDROID -Wa,--noexecstack -DGLES2_ENABLED'))
+        can_vectorize = True
+        target_opts = ['-target', 'i686-none-linux-android']
     elif env["android_arch"] == "armv6":
-        env.Append(CCFLAGS=string.split('-DNO_STATVFS -fpic -ffunction-sections -funwind-tables -fstack-protector -fvisibility=hidden -D__ARM_ARCH_6__ -D__GLIBC__  -Wno-psabi -march=armv6 -mfpu=vfp -mfloat-abi=softfp -funsafe-math-optimizations -fno-strict-aliasing -DANDROID -Wa,--noexecstack -DGLES2_ENABLED'))
+        can_vectorize = False
+        target_opts = ['-target', 'armv6-none-linux-androideabi']
+        env.Append(CPPFLAGS=string.split(
+            '-D__ARM_ARCH_6__ -march=armv6 -mfpu=vfp -mfloat-abi=softfp'))
     elif env["android_arch"] == "armv7":
-        env.Append(CCFLAGS=string.split('-DNO_STATVFS -fpic -ffunction-sections -funwind-tables -fstack-protector -fvisibility=hidden -D__ARM_ARCH_7__ -D__ARM_ARCH_7A__ -D__GLIBC__  -Wno-psabi -march=armv7-a -mfloat-abi=softfp -ftree-vectorize -funsafe-math-optimizations -fno-strict-aliasing -DANDROID -Wa,--noexecstack -DGLES2_ENABLED'))
+        can_vectorize = True
+        target_opts = ['-target', 'armv7-none-linux-androideabi']
+        env.Append(CPPFLAGS=string.split(
+            '-D__ARM_ARCH_7__ -D__ARM_ARCH_7A__ -march=armv7-a -mfloat-abi=softfp'))
         if env['android_neon'] == 'yes':
             env['neon_enabled'] = True
-            env.Append(CCFLAGS=['-mfpu=neon', '-D__ARM_NEON__'])
+            env.Append(CPPFLAGS=['-mfpu=neon', '-D__ARM_NEON__'])
         else:
-            env.Append(CCFLAGS=['-mfpu=vfpv3-d16'])
+            env.Append(CPPFLAGS=['-mfpu=vfpv3-d16'])
 
-    env.Append(LDPATH=[ld_path])
+    env.Append(CPPFLAGS=target_opts)
+    env.Append(CPPFLAGS=common_opts)
+
     env.Append(LIBS=['OpenSLES'])
-#	env.Append(LIBS=['c','m','stdc++','log','EGL','GLESv1_CM','GLESv2','OpenSLES','supc++','android'])
     env.Append(LIBS=['EGL', 'OpenSLES', 'android'])
-    env.Append(LIBS=['c', 'm', 'stdc++', 'log', 'GLESv1_CM', 'GLESv2', 'z'])
+    env.Append(LIBS=['log', 'GLESv1_CM', 'GLESv2', 'z'])
 
-    env["LINKFLAGS"] = string.split(" -g --sysroot=" + ld_sysroot + " -Wl,--no-undefined -Wl,-z,noexecstack ")
-    env.Append(LINKFLAGS=["-Wl,-soname,libgodot_android.so"])
+    if (sys.platform.startswith("darwin")):
+        env['SHLIBSUFFIX'] = '.so'
 
-    if (env["target"] == "release"):
+    env['LINKFLAGS'] = ['-shared', '--sysroot=' +
+                        sysroot, '-Wl,--warn-shared-textrel',
+                        '-Wl,--threads']
+    env.Append(LINKFLAGS=string.split(
+        '-Wl,--fix-cortex-a8'))
+    env.Append(LINKFLAGS=string.split(
+        '-Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now'))
+    env.Append(LINKFLAGS=string.split(
+        '-Wl,-soname,libgodot_android.so -Wl,--gc-sections'))
+    env.Append(LINKFLAGS=target_opts)
+    env.Append(LINKFLAGS=common_opts)
 
-        env.Append(CCFLAGS=['-O2', '-ffast-math', '-fomit-frame-pointer'])
+    env.Append(LIBPATH=[env["ANDROID_NDK_ROOT"] + '/toolchains/arm-linux-androideabi-4.9/prebuilt/' +
+                        host_subpath + '/lib/gcc/' + abi_subpath + '/4.9.x'])
+    env.Append(LIBPATH=[env["ANDROID_NDK_ROOT"] +
+                        '/toolchains/arm-linux-androideabi-4.9/prebuilt/' + host_subpath + '/' + abi_subpath + '/lib'])
 
-    elif (env["target"] == "release_debug"):
-
-        env.Append(CCFLAGS=['-O2', '-ffast-math', '-DDEBUG_ENABLED'])
-
+    if (env["target"].startswith("release")):
+        env.Append(LINKFLAGS=['-O2'])
+        env.Append(CPPFLAGS=['-O2', '-DNDEBUG', '-ffast-math',
+                             '-funsafe-math-optimizations', '-fomit-frame-pointer'])
+        if (can_vectorize):
+            env.Append(CPPFLAGS=['-ftree-vectorize'])
+        if (env["target"] == "release_debug"):
+            env.Append(CPPFLAGS=['-DDEBUG_ENABLED'])
     elif (env["target"] == "debug"):
+        env.Append(LINKFLAGS=['-O0'])
+        env.Append(CPPFLAGS=['-O0', '-D_DEBUG', '-UNDEBUG', '-DDEBUG_ENABLED',
+                             '-DDEBUG_MEMORY_ALLOC', '-g', '-fno-limit-debug-info'])
 
-        env.Append(CCFLAGS=['-D_DEBUG', '-g1', '-Wall', '-O0', '-DDEBUG_ENABLED'])
-        env.Append(CPPFLAGS=['-DDEBUG_MEMORY_ALLOC'])
-
-    env.Append(CPPFLAGS=['-DANDROID_ENABLED', '-DUNIX_ENABLED', '-DNO_FCNTL', '-DMPC_FIXED_POINT'])
-#	env.Append(CPPFLAGS=['-DANDROID_ENABLED', '-DUNIX_ENABLED','-DMPC_FIXED_POINT'])
+    env.Append(CPPFLAGS=['-DANDROID_ENABLED',
+                         '-DUNIX_ENABLED', '-DNO_FCNTL', '-DMPC_FIXED_POINT'])
 
     # TODO: Move that to opus module's config
     if("module_opus_enabled" in env and env["module_opus_enabled"] != "no"):
@@ -214,40 +245,22 @@ def configure(env):
         env.opus_fixed_point = "yes"
 
     if (env['android_stl'] == 'yes'):
-        # env.Append(CCFLAGS=[env["ANDROID_NDK_ROOT"]+"/sources/cxx-stl/system/include"])
-        env.Append(CPPPATH=[env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/gnu-libstdc++/4.9/include"])
-        if env['android_arch'] == 'x86':
-            env.Append(CPPPATH=[env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/gnu-libstdc++/4.9/libs/x86/include"])
-            env.Append(LIBPATH=[env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/gnu-libstdc++/4.9/libs/x86"])
-        elif env['android_arch'] == 'armv6':
-            env.Append(CPPPATH=[env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi/include"])
-            env.Append(LIBPATH=[env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi"])
-        elif env["android_arch"] == "armv7":
-            env.Append(CPPPATH=[env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi-v7a/include"])
-            env.Append(LIBPATH=[env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi-v7a"])
-
-        env.Append(LIBS=["gnustl_static", "supc++"])
-        env.Append(CPPPATH=[env["ANDROID_NDK_ROOT"] + "/sources/cpufeatures"])
-
-        # env.Append(CCFLAGS=["-I"+env["ANDROID_NDK_ROOT"]+"/sources/cxx-stl/stlport/stlport"])
-        # env.Append(CCFLAGS=["-I"+env["ANDROID_NDK_ROOT"]+"/sources/cxx-stl/gnu-libstdc++/libs/armeabi/include"])
-        # env.Append(LINKFLAGS=[env["ANDROID_NDK_ROOT"]+"/sources/cxx-stl/gnu-libstdc++/libs/armeabi/libstdc++.a"])
+        env.Append(CPPPATH=[env["ANDROID_NDK_ROOT"] +
+                            "/sources/cxx-stl/gnu-libstdc++/4.9/include"])
+        env.Append(CPPPATH=[env["ANDROID_NDK_ROOT"] +
+                            "/sources/cxx-stl/gnu-libstdc++/4.9/libs/" + arch_subpath + "/include"])
+        env.Append(LIBPATH=[env["ANDROID_NDK_ROOT"] +
+                            "/sources/cxx-stl/gnu-libstdc++/4.9/libs/" + arch_subpath])
+        env.Append(LIBS=["gnustl_static"])
     else:
-
-        env.Append(CPPPATH=[env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/gnu-libstdc++/4.9/include"])
-        env.Append(CPPPATH=[env["ANDROID_NDK_ROOT"] + "/sources/cpufeatures"])
-        if env['android_arch'] == 'x86':
-            env.Append(LIBPATH=[env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/gnu-libstdc++/4.9/libs/x86"])
-        elif env["android_arch"] == "armv6":
-            env.Append(LIBPATH=[env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi"])
-        elif env["android_arch"] == "armv7":
-            env.Append(LIBPATH=[env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi-v7a"])
-        env.Append(LIBS=['gnustl_static'])
-        env.Append(CCFLAGS=["-fno-exceptions", '-DNO_SAFE_CAST'])
+        env.Append(CXXFLAGS=['-fno-rtti', '-fno-exceptions', '-DNO_SAFE_CAST'])
 
     import methods
-    env.Append(BUILDERS={'GLSL120': env.Builder(action=methods.build_legacygl_headers, suffix='glsl.h', src_suffix='.glsl')})
-    env.Append(BUILDERS={'GLSL': env.Builder(action=methods.build_glsl_headers, suffix='glsl.h', src_suffix='.glsl')})
-    env.Append(BUILDERS={'GLSL120GLES': env.Builder(action=methods.build_gles2_headers, suffix='glsl.h', src_suffix='.glsl')})
+    env.Append(BUILDERS={'GLSL120': env.Builder(
+        action=methods.build_legacygl_headers, suffix='glsl.h', src_suffix='.glsl')})
+    env.Append(BUILDERS={'GLSL': env.Builder(
+        action=methods.build_glsl_headers, suffix='glsl.h', src_suffix='.glsl')})
+    env.Append(BUILDERS={'GLSL120GLES': env.Builder(
+        action=methods.build_gles2_headers, suffix='glsl.h', src_suffix='.glsl')})
 
     env.use_windows_spawn_fix()


### PR DESCRIPTION
This is something I wanted to do for a long time.

**_This must be heavily tested (different combinations of target architectures and build variants, etc.)._**   ~~Not possible on Windows until #6844 is solved. For testing on Windows, merge #6959 first.~~

~~### **_WARNING: This is not ready to be tested/merged until I fix the Mac build since I will be pushing test commits until I get it to work. I'll remove this notice as soon as that's done._**~~
- Compile source files with Clang (Google dropped support for GCC in the NDK so Clang is the only recommended compiler). Anyway, like the NDK does, the _binutils_ are those from GNU.
- Dropped `NDK_TARGET/NDK_TARGET_X86` since only one Clang version is included, thus no choice possible. Regarding _binutils_ and **gnu-libstdc++** the NDK also includes only one version (4.9), so no choice there either.
- Remove a lot of almost duplicate code and replace with more readable constructs and variables.
- Remove dead code (old commented code).
- Remove unneeded flags for `android_stl=yes`.
- Remove explicit specification of libraries that the linker will be adding anyway (**c, m, gcc**).
- Disable RTTI for non-STL-enabled builds (the general case).
- Restrict math optimizations to _release/release_debug_.
- Try to set the compile/link flags as close as possible to what the NDK does (based on r13), which includes new stuff like strong stack protection and other security measures.
- Instruct the linker to drop unused functions (hopefully this will reduce the resulting binary size and won't break things).
- Enable multithreaded linking where available.
- Enabled linker optimization (not true LTO by now; mainly string optimization).
- ~~Fix cases of bad indentation.~~ (Superseeded by the new PEP8 effort).
