### PR TITLE
Adopt simpler strategy for big libs on Windows

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -100,6 +100,7 @@ env_base.__class__.disable_module = methods.disable_module
 
 env_base.__class__.add_source_files = methods.add_source_files
 env_base.__class__.use_windows_spawn_fix = methods.use_windows_spawn_fix
+env_base.__class__.split_lib = methods.split_lib
 
 env_base["x86_libtheora_opt_gcc"]=False
 env_base["x86_libtheora_opt_vc"]=False

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -35,6 +35,9 @@ if (env["tools"]=="yes"):
 if env['vsproj']=="yes":
 	env.AddToVSProject(env.drivers_sources)
 
-env.add_source_files(env.drivers_sources,"*.cpp")
-lib = env.Library("drivers",env.drivers_sources)
-env.Prepend(LIBS=[lib])
+if env.split_drivers:
+	env.split_lib("drivers")
+else:
+	env.add_source_files(env.drivers_sources,"*.cpp")
+	lib = env.Library("drivers",env.drivers_sources)
+	env.Prepend(LIBS=[lib])

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -35,52 +35,6 @@ if (env["tools"]=="yes"):
 if env['vsproj']=="yes":
 	env.AddToVSProject(env.drivers_sources)
 
-
-# Split drivers, this used to be needed for windows until separate builders for windows were created
-# FIXME: Check if still needed now that the drivers were made more lightweight
-if (env.split_drivers):
-	import string
-
-	num = 0
-	cur_base = ""
-	max_src = 64
-	list = []
-	lib_list = []
-
-	for f in env.drivers_sources:
-		fname = ""
-		if type(f) == type(""):
-			fname = env.File(f).path
-		else:
-			fname = env.File(f)[0].path
-		fname = fname.replace("\\", "/")
-		base = string.join(fname.split("/")[:2], "/")
-		if base != cur_base and len(list) > max_src:
-			if num > 0:
-				lib = env.Library("drivers"+str(num), list)
-				lib_list.append(lib)
-				list = []
-			num = num+1
-		cur_base = base
-		list.append(f)
-
-	lib = env.Library("drivers"+str(num), list)
-	lib_list.append(lib)
-
-	if len(lib_list) > 0:
-		import os, sys
-		if os.name=='posix' and sys.platform=='msys':
-			env.Replace(ARFLAGS=['rcsT'])
-
-			lib = env.Library("drivers_collated", lib_list)
-			lib_list = [lib]
-
-	drivers_base=[]
-	env.add_source_files(drivers_base,"*.cpp")
-	lib_list.insert(0, env.Library("drivers", drivers_base))
-
-	env.Prepend(LIBS=lib_list)
-else:
-	env.add_source_files(env.drivers_sources,"*.cpp")
-	lib = env.Library("drivers",env.drivers_sources)
-	env.Prepend(LIBS=[lib])
+env.add_source_files(env.drivers_sources,"*.cpp")
+lib = env.Library("drivers",env.drivers_sources)
+env.Prepend(LIBS=[lib])

--- a/methods.py
+++ b/methods.py
@@ -1352,7 +1352,15 @@ def use_windows_spawn_fix(self, platform=None):
     if (os.name!="nt"):
 	return #not needed, only for windows
 
-    self.split_drivers=True
+    # On Windows, due to the limited command line length, when creating a static library
+    # from a very high number of objects SCons will invoke "ar" once per object file;
+    # that makes object files with same names to be overwritten so the last wins and
+    # the library looses symbols defined by overwritten objects.
+    # By enabling quick append instead of the default mode (replacing), libraries will
+    # got built correctly regardless the invokation strategy.
+    # Furthermore, since SCons will rebuild the library from scratch when an object file
+    # changes, no multiple versions of the same object file will be present.
+    self.Replace(ARFLAGS='q')
 
     import subprocess
 


### PR DESCRIPTION
Also fixes #6844.

As explained in **methods.py** (also explains why it fixes #6844 ):

> On Windows, due to the limited command line length, when creating a static library
> from a very high number of objects SCons will invoke "ar" once per object file;
> that makes object files with same names to be overwritten so the last wins and
> the library looses symbols defined by overwritten objects.
> By enabling quick append instead of the default mode (replacing), libraries will
> got built correctly regardless the invokation strategy.
> Furthermore, since SCons will rebuild the library from scratch when an object file
> changes, no multiple versions of the same object file will be present.
