### PR TITLE
Fix Accept/ConfirmationDialog UI broken

### DIFF
--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -232,6 +232,8 @@ String AcceptDialog::get_text() const {
 void AcceptDialog::set_text(String p_text) {
 
 	label->set_text(p_text);
+	minimum_size_changed();
+	_update_child_rect();
 }
 
 void AcceptDialog::set_hide_on_ok(bool p_hide) {
@@ -252,15 +254,16 @@ void AcceptDialog::register_text_enter(Node *p_line_edit) {
 }
 
 void AcceptDialog::_update_child_rect() {
-
+	Size2 label_size=label->get_minimum_size();
+	if (label->get_text().empty()) {
+		label_size.height = 0;
+	}
 	int margin = get_constant("margin","Dialogs");
 	Size2 size = get_size();
 	Size2 hminsize = hbc->get_combined_minimum_size();
 
-	Vector2 cpos(margin,margin);
-	Vector2 csize(size.x-margin*2,size.y-margin*3-hminsize.y);
-	label->set_pos(cpos);
-	label->set_size(csize);
+	Vector2 cpos(margin,margin+label_size.height);
+	Vector2 csize(size.x-margin*2,size.y-margin*3-hminsize.y-label_size.height);
 
 	if (child) {
 

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -232,8 +232,6 @@ String AcceptDialog::get_text() const {
 void AcceptDialog::set_text(String p_text) {
 
 	label->set_text(p_text);
-	minimum_size_changed();
-	_update_child_rect();
 }
 
 void AcceptDialog::set_hide_on_ok(bool p_hide) {
@@ -255,51 +253,38 @@ void AcceptDialog::register_text_enter(Node *p_line_edit) {
 
 void AcceptDialog::_update_child_rect() {
 
-	const int margin = get_constant("margin","Dialogs");
-	const Size2 size = get_size();
+	int margin = get_constant("margin","Dialogs");
+	Size2 size = get_size();
 	Size2 hminsize = hbc->get_combined_minimum_size();
 
-	const Size2 max_csize(
-		size.width - margin * 2,
-		size.height - margin * 3 - hminsize.height);
-	hminsize.width = max_csize.width;
-
-	Point2 cpos(margin, margin);
-	Size2 csize = label->get_combined_minimum_size();
-	if(label->get_text().empty())
-		csize.y = 0;
-	csize.x = MIN(csize.width, max_csize.width);
-	csize.y = MIN(csize.height, max_csize.height);
+	Vector2 cpos(margin,margin);
+	Vector2 csize(size.x-margin*2,size.y-margin*3-hminsize.y);
 	label->set_pos(cpos);
 	label->set_size(csize);
 
-	if(child) {
-		const float child_y_offset = csize.height + (csize.height > 0 ? margin : 0);
-		cpos.y += child_y_offset;
-		csize = max_csize;
-		csize.height -= child_y_offset;
+	if (child) {
 
 		child->set_pos(cpos);
 		child->set_size(csize);
 	}
 
-	cpos.y += csize.height + margin;
+	cpos.y+=csize.y+margin;
+	csize.y=hminsize.y;
 
 	hbc->set_pos(cpos);
-	hbc->set_size(hminsize);
+	hbc->set_size(csize);
+
 }
 
 Size2 AcceptDialog::get_minimum_size() const {
 
 	int margin = get_constant("margin","Dialogs");
 	Size2 minsize = label->get_combined_minimum_size();
-	if(label->get_text().empty())
-		minsize.y = 0;
 	if (child) {
 
 		Size2 cminsize = child->get_combined_minimum_size();
 		minsize.x=MAX(cminsize.x,minsize.x);
-		minsize.y += cminsize.y + (minsize.y > 0 ? margin : 0);
+		minsize.y=MAX(cminsize.y,minsize.y);
 	}
 
 	Size2 hminsize = hbc->get_combined_minimum_size();


### PR DESCRIPTION
Fix #6984

![image](https://cloud.githubusercontent.com/assets/8281454/19838783/c654527e-9f19-11e6-8572-52bab3aa39f9.png)

It's almost revert #6748
Below diff is with commit right before #6748

``` diff
$ git diff 1f9e16 HEAD scene/gui/dialogs.cpp

diff --git a/scene/gui/dialogs.cpp b/scene/gui/dialogs.cpp
index 15ff334..49782bc 100644
--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -232,6 +232,8 @@ String AcceptDialog::get_text() const {
 void AcceptDialog::set_text(String p_text) {

        label->set_text(p_text);
+       minimum_size_changed();
+       _update_child_rect();
 }

 void AcceptDialog::set_hide_on_ok(bool p_hide) {
@@ -252,15 +254,16 @@ void AcceptDialog::register_text_enter(Node *p_line_edit) {
 }

 void AcceptDialog::_update_child_rect() {
-
+       Size2 label_size=label->get_minimum_size();
+       if (label->get_text().empty()) {
+               label_size.height = 0;
+       }
        int margin = get_constant("margin","Dialogs");
        Size2 size = get_size();
        Size2 hminsize = hbc->get_combined_minimum_size();

-       Vector2 cpos(margin,margin);
-       Vector2 csize(size.x-margin*2,size.y-margin*3-hminsize.y);
-       label->set_pos(cpos);
-       label->set_size(csize);
+       Vector2 cpos(margin,margin+label_size.height);
+       Vector2 csize(size.x-margin*2,size.y-margin*3-hminsize.y-label_size.height);

        if (child) {
```
