### PR TITLE
Fix p_index out of size error when closing script

### DIFF
--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -945,7 +945,7 @@ void ScriptEditor::_menu_option(int p_option) {
 		}
 	}
 
-	EditorHelp *help = tab_container->get_child(selected)->cast_to<EditorHelp>();
+	EditorHelp *help = tab_container->get_current_tab_control()->cast_to<EditorHelp>();
 	if (help) {
 
 		switch(p_option) {


### PR DESCRIPTION
reproduce step : closing all opened script or help

```
ERROR: get_child: Index p_index out of size (data.children.size()).
   At: scene/main/node.cpp:1514.
```

It happens when closing last for sure, and sometimes even while some of scripts or helps are opened.
