### PR TITLE
Add option 'wasm' to compile to WebAssembly in web export

### DIFF
--- a/platform/javascript/SCsub
+++ b/platform/javascript/SCsub
@@ -10,8 +10,6 @@ javascript_files = [
 	"javascript_eval.cpp"
 ]
 
-#obj = env.SharedObject('godot_javascript.cpp')
-
 env_javascript = env.Clone()
 if env['target'] == "profile":
 	env_javascript.Append(CPPFLAGS=['-DPROFILER_ENABLED'])
@@ -21,9 +19,19 @@ for x in javascript_files:
 	javascript_objects.append( env_javascript.Object( x ) )
 
 env.Append(LINKFLAGS=["-s","EXPORTED_FUNCTIONS=\"['_main','_audio_server_mix_function','_main_after_fs_sync']\""])
+env.Append(LINKFLAGS=["--shell-file",'"platform/javascript/godot_shell.html"'])
 
-prog = None
+build = env.Program('#bin/godot',javascript_objects,PROGSUFFIX=env["PROGSUFFIX"]+".html")
 
-#env_javascript.SharedLibrary("#platform/javascript/libgodot_javascript.so",[javascript_objects])
+def make_html_shell(target, source, env):
+	html_path = target[0].rstr()
+	assert html_path[:4] == 'bin/'
+	assert html_path[-5:] == '.html'
+	basename = html_path[4:-5]
+	with open(html_path, 'r+') as html_file:
+		fixed_html = html_file.read().replace('.html.mem', '.mem').replace(basename, '$GODOT_BASE')
+		html_file.seek(0)
+		html_file.truncate()
+		html_file.write(fixed_html)
 
-env.Program('#bin/godot',javascript_objects,PROGSUFFIX=env["PROGSUFFIX"]+".html")
+env.AddPostAction(build, Action(make_html_shell, "Creating HTML shell file"))

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -18,6 +18,7 @@ def can_build():
 def get_opts():
 
 	return [
+		['wasm','Compile to WebAssembly','no'],
 		['javascript_eval','Enable JavaScript eval interface','yes'],
 	]
 
@@ -42,7 +43,6 @@ def configure(env):
 	em_path=os.environ["EMSCRIPTEN_ROOT"]
 
 	env['ENV']['PATH'] = em_path+":"+env['ENV']['PATH']
-
 	env['CC'] = em_path+'/emcc'
 	env['CXX'] = em_path+'/emcc'
 	#env['AR'] = em_path+"/emar"
@@ -77,14 +77,20 @@ def configure(env):
 	env.Append(CPPFLAGS=['-DJAVASCRIPT_ENABLED', '-DUNIX_ENABLED', '-DPTHREAD_NO_RENAME', '-DNO_FCNTL','-DMPC_FIXED_POINT','-DTYPED_METHOD_BIND','-DNO_THREADS'])
 	env.Append(CPPFLAGS=['-DGLES2_ENABLED'])
 	env.Append(CPPFLAGS=['-DGLES_NO_CLIENT_ARRAYS'])
-	env.Append(CPPFLAGS=['-s','ASM_JS=1'])
 	env.Append(CPPFLAGS=['-s','FULL_ES2=1'])
 #	env.Append(CPPFLAGS=['-DANDROID_ENABLED', '-DUNIX_ENABLED','-DMPC_FIXED_POINT'])
+
+	if env['wasm'] == 'yes':
+		env.Append(LINKFLAGS=['-s','BINARYEN=1'])
+		env.Append(LINKFLAGS=['-s','\'BINARYEN_METHOD="native-wasm"\''])
+		env["PROGSUFFIX"]+=".webassembly"
+	else:
+		env.Append(CPPFLAGS=['-s','ASM_JS=1'])
+		env.Append(LINKFLAGS=['-s','ASM_JS=1'])
 
 	if env['javascript_eval'] == 'yes':
 		env.Append(CPPFLAGS=['-DJAVASCRIPT_EVAL_ENABLED'])
 
-	env.Append(LINKFLAGS=['-s','ASM_JS=1'])
 	env.Append(LINKFLAGS=['-O2'])
 	#env.Append(LINKFLAGS=['-g4'])
 

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -180,9 +180,7 @@ void EditorExportPlatformJavaScript::_fix_html(Vector<uint8_t>& p_html, const St
 
 		String current_line = lines[i];
 		current_line = current_line.replace("$GODOT_TMEM",itos((1<<(max_memory+5))*1024*1024));
-		current_line = current_line.replace("$GODOT_FS",p_name+"fs.js");
-		current_line = current_line.replace("$GODOT_MEM",p_name+".mem");
-		current_line = current_line.replace("$GODOT_JS",p_name+".js");
+		current_line = current_line.replace("$GODOT_BASE",p_name);
 		current_line = current_line.replace("$GODOT_CANVAS_WIDTH",Globals::get_singleton()->get("display/width"));
 		current_line = current_line.replace("$GODOT_CANVAS_HEIGHT",Globals::get_singleton()->get("display/height"));
 		current_line = current_line.replace("$GODOT_HEAD_TITLE",!html_title.empty()?html_title:(String) Globals::get_singleton()->get("application/name"));
@@ -319,14 +317,17 @@ Error EditorExportPlatformJavaScript::export_project(const String& p_path, bool 
 		}
 		if (file=="godot.js") {
 
-			//_fix_godot(data);
 			file=p_path.get_file().basename()+".js";
 		}
 
 		if (file=="godot.mem") {
 
-			//_fix_godot(data);
 			file=p_path.get_file().basename()+".mem";
+		}
+
+		if (file=="godot.wasm") {
+
+			file=p_path.get_file().basename()+".wasm";
 		}
 
 		String dst = p_path.get_base_dir().plus_file(file);

--- a/platform/javascript/godot_shell.html
+++ b/platform/javascript/godot_shell.html
@@ -351,24 +351,7 @@
 			};
 		};
 	//]]></script>
-	<script type="text/javascript" src="$GODOT_FS"></script>
-	<script>
-		(function() {
-			var memoryInitializer = "$GODOT_MEM";
-			if (typeof Module.locateFile === "function") {
-				memoryInitializer = Module.locateFile(memoryInitializer);
-			} else if (Module.memoryInitializerPrefixURL) {
-				memoryInitializer = Module.memoryInitializerPrefixURL + memoryInitializer;
-			}
-			var xhr = Module.memoryInitializerRequest = new XMLHttpRequest();
-			xhr.open("GET", memoryInitializer, true);
-			xhr.responseType = "arraybuffer";
-			xhr.send(null);
-		})();
-
-		var script = document.createElement("script");
-		script.src = "$GODOT_JS";
-		document.body.appendChild(script);
-	</script>
+	<script type="text/javascript" src="$GODOT_BASEfs.js"></script>
+	{{{ SCRIPT }}}
 </body>
 </html>


### PR DESCRIPTION
e.g. `scons p=javascript wasm=yes`

WebAssembly is experimental, so disabled by default.
The standard is still in flux, so the compile toolchain is occasionally broken.
Compiling for WebAssembly requires the `incoming`-branch of Emscripten.
Running WebAssembly requires nightly browser builds with WebAssembly flag enabled.

If `LLVM_ROOT` in `~/.emscripten` is set to Emscripten's "fastcomp" fork of clang, Godot will be compiled per `asm2wasm` (i.e. first compile to asm.js as usual, then translate that to wasm). This method of compilation currently has better chances of finishing successfully.
If `LLVM_ROOT` points to clang built with experimental WebAssembly backend (`-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly`), the output will be translated per `s2wasm` to WebAssembly. This method should eventually offer better performance.

The HTML shell file now uses `$GODOT_BASE`, a placeholder for the base filename, instead of `$GODOT_JS`, `$GODOT_MEM` and `$GODOT_FS`.