### PR TITLE
Fix resetting to default value in EditorSettings

### DIFF
--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -1098,7 +1098,6 @@ EditorSettings::EditorSettings() {
 	}
 
 	_load_defaults();
-	save_changed_setting=false;
 
 
 }


### PR DESCRIPTION
I tested several ways to fix this problem.
And I found there is nowhere this `save_changed_setting` is setting back to `false` except the line with this PR.

in EditorSettings constructor, `save_changed_setting=true;`
https://github.com/godotengine/godot/blob/master/tools/editor/editor_settings.cpp#L1076
so, `_load_defaults();` can keep setting for the defaults things.
but after `save_changed_setting=false;` in the end of constructor,
https://github.com/godotengine/godot/blob/master/tools/editor/editor_settings.cpp#L1101
EditorSettings::create() will not save custom settings.
https://github.com/godotengine/godot/blob/master/tools/editor/editor_node.cpp#L5405

After several tests, I can keep my editor settings now.

Fix #6056