### PR TITLE
Greater VCS friendliness

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -3286,8 +3286,17 @@ String String::c_escape() const {
 	escaped=escaped.replace("\t","\\t");
 	escaped=escaped.replace("\v","\\v");
 	escaped=escaped.replace("\'","\\'");
-	escaped=escaped.replace("\"","\\\"");
 	escaped=escaped.replace("\?","\\?");
+	escaped=escaped.replace("\"","\\\"");
+
+	return escaped;
+}
+
+String String::c_escape_multiline() const {
+
+	String escaped=*this;
+	escaped=escaped.replace("\\","\\\\");
+	escaped=escaped.replace("\"","\\\"");
 
 	return escaped;
 }

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -216,6 +216,7 @@ public:
     String http_escape() const;
     String http_unescape() const;
 	String c_escape() const;
+	String c_escape_multiline() const;
 	String c_unescape() const;
 	String json_escape() const;
 	String word_wrap(int p_chars_per_line) const;

--- a/core/variant_parser.cpp
+++ b/core/variant_parser.cpp
@@ -1878,7 +1878,7 @@ Error VariantWriter::write(const Variant& p_variant, StoreStringFunc p_store_str
 
 			String str=p_variant;
 
-			str="\""+str.c_escape()+"\"";
+			str="\""+str.c_escape_multiline()+"\"";
 			p_store_string_func(p_store_string_ud, str );
 		} break;
 		case Variant::VECTOR2: {
@@ -2123,20 +2123,20 @@ Error VariantWriter::write(const Variant& p_variant, StoreStringFunc p_store_str
 			dict.get_key_list(&keys);
 			keys.sort();
 
-			p_store_string_func(p_store_string_ud,"{ ");
+			p_store_string_func(p_store_string_ud,"{\n");
 			for(List<Variant>::Element *E=keys.front();E;E=E->next()) {
 
 				//if (!_check_type(dict[E->get()]))
 				//	continue;
 				write(E->get(),p_store_string_func,p_store_string_ud,p_encode_res_func,p_encode_res_ud);
-				p_store_string_func(p_store_string_ud,":");
+				p_store_string_func(p_store_string_ud,": ");
 				write(dict[E->get()],p_store_string_func,p_store_string_ud,p_encode_res_func,p_encode_res_ud);
 				if (E->next())
-					p_store_string_func(p_store_string_ud,", ");
+					p_store_string_func(p_store_string_ud,",\n");
 			}
 
 
-			p_store_string_func(p_store_string_ud," }");
+			p_store_string_func(p_store_string_ud,"\n}");
 
 
 		} break;

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -118,17 +118,20 @@ bool AnimationPlayer::_get(const StringName& p_name,Variant &r_ret) const {
 
 	} else if (name=="blend_times") {
 
-		Array array;
-
-		array.resize(blend_times.size()*3);
-		int idx=0;
+		Vector<BlendKey> keys;
 		for(Map<BlendKey, float >::Element *E=blend_times.front();E;E=E->next()) {
 
-			array.set(idx*3+0,E->key().from);
-			array.set(idx*3+1,E->key().to);
-			array.set(idx*3+2,E->get());
-			idx++;
+			keys.ordered_insert(E->key());
 		}
+
+		Array array;
+		for(int i=0;i<keys.size();i++) {
+
+			array.push_back(keys[i].from);
+			array.push_back(keys[i].to);
+			array.push_back(blend_times[keys[i]]);
+		}
+
 		r_ret=array;
 	} else if (name=="autoplay") {
 		r_ret=autoplay;

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -142,7 +142,7 @@ private:
 
 		StringName from;
 		StringName to;
-		bool operator<(const BlendKey& bk) const { return from==bk.from?to<bk.to:from<bk.from; }
+		bool operator<(const BlendKey& bk) const { return from==bk.from?String(to)<String(bk.to):String(from)<String(bk.from); }
 	};
 
 

--- a/scene/resources/scene_format_text.cpp
+++ b/scene/resources/scene_format_text.cpp
@@ -1158,7 +1158,7 @@ void ResourceFormatSaverTextInstance::_find_resources(const Variant& p_variant,b
 static String _valprop(const String& p_name) {
 
 	if (p_name.find("\"")!=-1 || p_name.find("=")!=-1 || p_name.find(" ")!=-1)
-		return "\""+p_name.c_escape()+"\"";
+		return "\""+p_name.c_escape_multiline()+"\"";
 	return p_name;
 }
 
@@ -1358,13 +1358,11 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path,const RES& p_re
 			}
 
 			if (groups.size()) {
-				String sgroups=" groups=[ ";
+				String sgroups=" groups=[\n";
 				for(int j=0;j<groups.size();j++) {
-					if (j>0)
-						sgroups+=", ";
-					sgroups+="\""+groups[j].operator String().c_escape()+"\"";
+					sgroups+="\""+String(groups[j]).c_escape()+"\",\n";
 				}
-				sgroups+=" ]";
+				sgroups+="]";
 				header+=sgroups;
 			}
 


### PR DESCRIPTION
Make `AnimationPlayer` serialize its blend times always sorted so their order is predictable in the **.tscn** file.
Serialize dictionaries adding newlines between key-value pairs.
Serialize group lists also with newlines in between.
Serialize string properties escaping only `"` and `\` (needed for a good diff experience with built-in scripts).

__This PR is back-compat; won't break loading of existing files.__