### PR TITLE
Fix to focus or rename node by double click

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2363,19 +2363,11 @@ void Tree::_input_event(InputEvent p_event) {
 							Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
 							warp_mouse(range_drag_capture_pos);
 						} else {
-
-							if (delayed_text_editor) {
-								uint64_t diff = OS::get_singleton()->get_ticks_msec() - first_selection_time;
-								if (diff >= 400 && diff <= 800)
-									edit_selected();
-								// fast double click
-								else if (diff < 400) {
-									emit_signal("item_double_clicked");
-								}
-
-								first_selection_time = OS::get_singleton()->get_ticks_msec();
-							} else {
+							Rect2 rect = get_selected()->get_meta("__focus_rect");
+							if (rect.has_point(Point2(p_event.mouse_button.x,p_event.mouse_button.y))) {
 								edit_selected();
+							} else {
+								emit_signal("item_double_clicked");
 							}
 						}
 						pressing_for_editor=false;
@@ -2921,8 +2913,6 @@ void Tree::item_selected(int p_column,TreeItem *p_item) {
 
 		p_item->cells[p_column].selected=true;
 		//emit_signal("multi_selected",p_item,p_column,true); - NO this is for TreeItem::select
-		if (delayed_text_editor)
-			first_selection_time = OS::get_singleton()->get_ticks_msec();
 
 	} else {
 
@@ -3572,15 +3562,6 @@ bool Tree::get_allow_rmb_select() const{
 }
 
 
-void Tree::set_delayed_text_editor(bool enabled) {
-	delayed_text_editor = enabled;
-}
-
-bool Tree::is_delayed_text_editor_enabled() const {
-	return delayed_text_editor;
-}
-
-
 void Tree::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("_range_click_timeout"),&Tree::_range_click_timeout);
@@ -3633,10 +3614,6 @@ void Tree::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("set_allow_rmb_select","allow"),&Tree::set_allow_rmb_select);
 	ObjectTypeDB::bind_method(_MD("get_allow_rmb_select"),&Tree::get_allow_rmb_select);
-
-	ObjectTypeDB::bind_method(_MD("set_delayed_text_editor","enable"),&Tree::set_delayed_text_editor);
-	ObjectTypeDB::bind_method(_MD("is_delayed_text_editor_enabled"),&Tree::is_delayed_text_editor_enabled);
-
 
 	ObjectTypeDB::bind_method(_MD("set_single_select_cell_editing_only_when_already_selected","enable"),&Tree::set_single_select_cell_editing_only_when_already_selected);
 	ObjectTypeDB::bind_method(_MD("get_single_select_cell_editing_only_when_already_selected"),&Tree::get_single_select_cell_editing_only_when_already_selected);
@@ -3751,9 +3728,6 @@ Tree::Tree() {
 	force_select_on_already_selected=false;
 
 	allow_rmb_select=false;
-
-	first_selection_time = 0;
-	delayed_text_editor = false;
 }
 
 

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -439,9 +439,6 @@ friend class TreeItem;
 	float last_drag_time;
 	float time_since_motion;*/
 
-	bool delayed_text_editor;
-	uint64_t first_selection_time;
-
 	float drag_speed;
 	float drag_from;
 	float drag_accum;
@@ -536,9 +533,6 @@ public:
 	bool get_allow_rmb_select() const;
 
 	void set_value_evaluator(ValueEvaluator *p_evaluator);
-
-	void set_delayed_text_editor(bool enabled);
-	bool is_delayed_text_editor_enabled() const;
 
 	Tree();
 	~Tree();

--- a/tools/editor/scene_tree_dock.cpp
+++ b/tools/editor/scene_tree_dock.cpp
@@ -2004,7 +2004,6 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor,Node *p_scene_root,EditorSelec
 	scene_tree->connect("nodes_dragged",this,"_nodes_drag_begin");
 
 	scene_tree->get_scene_tree()->connect("item_double_clicked", this, "_focus_node");
-	scene_tree->get_scene_tree()->set_delayed_text_editor(true);
 
 	scene_tree->set_undo_redo(&editor_data->get_undo_redo());
 	scene_tree->set_editor_selection(editor_selection);


### PR DESCRIPTION
Fix #6452

in no matter double click speed,
double clicking at label will show rename field, and at icon will focus on viewport.
And clicking selected node label will also show rename field.

![peek 2016-11-01 22-22](https://cloud.githubusercontent.com/assets/8281454/19891305/d9b250fe-a082-11e6-8cc8-e762550f9a98.gif)

