### PR TITLE
Fix scene tree drag & drop places node as child (#6912)

### DIFF
--- a/tools/editor/scene_tree_dock.cpp
+++ b/tools/editor/scene_tree_dock.cpp
@@ -1564,7 +1564,7 @@ static bool _is_node_visible(Node* p_node) {
 
 static bool _has_visible_children(Node* p_node) {
 
-	bool collapsed = p_node->has_meta("_editor_collapsed") ? (bool)p_node->get_meta("_editor_collapsed") : false;
+	bool collapsed = p_node->is_displayed_folded();
 	if (collapsed)
 		return false;
 
@@ -1587,7 +1587,7 @@ static Node* _find_last_visible(Node* p_node) {
 
 	Node* last=NULL;
 
-	bool collapsed = p_node->has_meta("_editor_collapsed") ? (bool)p_node->get_meta("_editor_collapsed") : false;
+	bool collapsed = p_node->is_displayed_folded();
 
 	if (!collapsed)	{
 		for(int i=0;i<p_node->get_child_count();i++) {
@@ -1622,36 +1622,9 @@ void SceneTreeDock::_normalize_drop(Node*& to_node, int &to_pos, int p_type) {
 			ERR_EXPLAIN("Cannot perform drop above the root node!");
 			ERR_FAIL();
 		}
-		Node* upper_sibling=NULL;
 
-		for(int i=0;i<to_node->get_index();i++) {
-			Node *c =to_node->get_parent()->get_child(i);
-			if (_is_node_visible(c)) {
-				upper_sibling=c;
-			}
-		}
-
-
-		if (upper_sibling) {
-			//quite complicated, look for next visible in tree
-			upper_sibling=_find_last_visible(upper_sibling);
-
-			if (upper_sibling->get_parent()==to_node->get_parent()) {
-				//just insert over this node because nothing is above at an upper level
-				to_pos=to_node->get_index();
-				to_node=to_node->get_parent();
-			} else {
-				to_pos=-1; //insert last in whathever is up
-				to_node=upper_sibling->get_parent(); //insert at a parent of whathever is up
-			}
-
-
-		} else {
-			//just insert over this node because nothing is above at the same level
-			to_pos=to_node->get_index();
-			to_node=to_node->get_parent();
-
-		}
+		to_pos=to_node->get_index();
+		to_node=to_node->get_parent();
 
 	} else if (p_type==1) {
 			//drop at below selected node


### PR DESCRIPTION
The meta "_editor_collapsed" is no longer a part of a node, so i have updated the code to use "is_displayed_folded()" instead.

If a node was dropped above a certain node, instead of just being placed above it, it would end up as a child to the node above the place you dropped it if that node is unfolded and has children. I have fixed this so it now just gets placed above the node even if the above node is unfolded.

See #6912 for bug reference.