### PR TITLE
Make GDScript parser ignore floating strings in class definition

### DIFF
--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -3375,7 +3375,16 @@ void GDParser::_parse_class(ClassNode *p_class) {
 				
 
 			} break;
-
+			
+			case GDTokenizer::TK_CONSTANT: {
+				if(tokenizer->get_token_constant().get_type() == Variant::STRING) {
+					tokenizer->advance();
+					// Ignore
+				} else {
+					_set_error(String()+"Unexpected constant of type: "+Variant::get_type_name(tokenizer->get_token_constant().get_type()));
+					return;
+				}
+			} break;
 
 			default: {
 


### PR DESCRIPTION
Fixes #1320.

I'm not sure if I should outright ignore it, or if I have to assign a ConstantNode to it, WDYT?
Also, I'm not sure if I have to disallow only strings (as I do now), or other types are useful as well.