### PR TITLE
 Fix typos and missing newlines in --help

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -159,7 +159,7 @@ void Main::print_help(const char* p_binary) {
 		OS::get_singleton()->print("%s",OS::get_singleton()->get_video_driver_name(i));
 	}
 	OS::get_singleton()->print(")\n");
-	OS::get_singleton()->print("\t-ldpi\t : Force low-dpi mode (OSX Only)");
+	OS::get_singleton()->print("\t-ldpi\t : Force low-dpi mode (OSX Only)\n");
 
 	OS::get_singleton()->print("\t-ad DRIVER\t : Audio Driver (");
 	for (int i=0;i<OS::get_singleton()->get_audio_driver_count();i++) {
@@ -169,8 +169,7 @@ void Main::print_help(const char* p_binary) {
 		OS::get_singleton()->print("%s",OS::get_singleton()->get_audio_driver_name(i));
 	}
     OS::get_singleton()->print(")\n");
-	OS::get_singleton()->print("\t-rthread <mode>\t : Render Thread Mode ('unsafe', 'safe', 'separate).");
-	OS::get_singleton()->print(")\n");
+	OS::get_singleton()->print("\t-rthread <mode>\t : Render Thread Mode ('unsafe', 'safe', 'separate').\n");
 	OS::get_singleton()->print("\t-s,-script [script] : Run a script.\n");
 	OS::get_singleton()->print("\t-d,-debug : Debug (local stdout debugger).\n");
 	OS::get_singleton()->print("\t-rdebug ADDRESS : Remote debug (<ip>:<port> host address).\n");


### PR DESCRIPTION
Adds missing newlines, and quotes and remove parentheses in --help output:

![screenshot-20161103-162456](https://cloud.githubusercontent.com/assets/877229/19972519/9cd9234a-a1e2-11e6-8b1c-b92938a1b1da.png)
