### PR TITLE
Fix Directory.dir_exist/get_current_dir for 'res://' on Android

### DIFF
--- a/platform/android/dir_access_jandroid.cpp
+++ b/platform/android/dir_access_jandroid.cpp
@@ -154,7 +154,7 @@ Error DirAccessJAndroid::change_dir(String p_dir){
 
 String DirAccessJAndroid::get_current_dir(){
 
-	return "/"+current_dir;
+	return "res://"+current_dir;
 }
 
 bool DirAccessJAndroid::file_exists(String p_file){
@@ -268,6 +268,6 @@ DirAccessJAndroid::DirAccessJAndroid() {
 
 DirAccessJAndroid::~DirAccessJAndroid() {
 
-	list_dir_end();;
+	list_dir_end();
 }
 #endif

--- a/platform/android/java/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/src/org/godotengine/godot/GodotIO.java
@@ -288,6 +288,11 @@ public class GodotIO {
 
 		try {
 			ad.files = am.list(path);
+			// no way to find path is directory or file exactly.
+			// but if ad.files.length==0, then it's an empty directory or file.
+			if (ad.files.length==0) {
+				return -1;
+			}
 		} catch (IOException e) {
 
 			System.out.printf("Exception on dir_open: %s\n",e);


### PR DESCRIPTION
Fix #7014

a little more detail info.
```gdscript
var dir = Directory.new()
if dir.open("res://")==OK:
    print("current dir path = ", dir.get_current_dir())        # prints "/"
    var path = dir.get_current_dir().plus_file("sub_dir_name") # path is now "/sub_dir_name"
    var sub_dir = Directory.new()
        # it tries to search on filesystem not under "res://"
        if sub_dir.open(path)==OK:
            # so can't be reached here
            pass
```