### PR TITLE
Fix updating value of SpinBox with prefix

### DIFF
--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -51,7 +51,10 @@ void SpinBox::_text_entered(const String& p_string) {
 
 	//if (!p_string.is_numeric())
 	//	return;
-	set_val( p_string.to_double() );
+	String value = p_string;
+	if (prefix!="" && p_string.begins_with(prefix))
+		value = p_string.substr(prefix.length(), p_string.length()-prefix.length());
+	set_val( value.to_double() );
 	_value_changed(0);
 }
 


### PR DESCRIPTION
updating value without removing prefix will lose value currently.
![spinbox_a](https://cloud.githubusercontent.com/assets/8281454/20015888/92c6d324-a300-11e6-80da-541f00f59bb7.gif)

demo after fix it
![spinbox_b](https://cloud.githubusercontent.com/assets/8281454/20015890/9474bb78-a300-11e6-988b-81e91469c3c8.gif)
