### PR TITLE
Add singleton instance to _Marshalls

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2043,6 +2043,13 @@ _Directory::~_Directory() {
 		memdelete(d);
 }
 
+_Marshalls* _Marshalls::singleton=NULL;
+
+_Marshalls *_Marshalls::get_singleton()
+{
+	return singleton;
+}
+
 String _Marshalls::variant_to_base64(const Variant& p_var) {
 
 	int len;

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -503,12 +503,16 @@ class _Marshalls : public Reference {
 
 	OBJ_TYPE(_Marshalls,Reference);
 
+	static _Marshalls* singleton;
+
 protected:
 
 	static void _bind_methods();
 
 
 public:
+
+	static _Marshalls* get_singleton();
 
 	String variant_to_base64(const Variant& p_var);
 	Variant base64_to_variant(const String& p_str);
@@ -519,7 +523,8 @@ public:
 	String utf8_to_base64(const String& p_str);
 	String base64_to_utf8(const String& p_str);
 
-	_Marshalls() {};
+	_Marshalls() { singleton = this; }
+	~_Marshalls() { singleton = NULL; }
 };
 
 

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -177,7 +177,7 @@ void register_core_singletons() {
 	Globals::get_singleton()->add_singleton( Globals::Singleton("ResourceSaver",_ResourceSaver::get_singleton()) );
 	Globals::get_singleton()->add_singleton( Globals::Singleton("PathRemap",PathRemap::get_singleton() ) );
 	Globals::get_singleton()->add_singleton( Globals::Singleton("OS",_OS::get_singleton() ) );
-	Globals::get_singleton()->add_singleton( Globals::Singleton("Marshalls",_marshalls ) );
+	Globals::get_singleton()->add_singleton( Globals::Singleton("Marshalls",_Marshalls::get_singleton() ) );
 	Globals::get_singleton()->add_singleton( Globals::Singleton("TranslationServer",TranslationServer::get_singleton() ) );
 	Globals::get_singleton()->add_singleton( Globals::Singleton("TS",TranslationServer::get_singleton() ) );
 	Globals::get_singleton()->add_singleton( Globals::Singleton("Input",Input::get_singleton() ) );


### PR DESCRIPTION
I need this because my bindings generator expects a static `get_singleton` method to be available for singleton types.

Other options would be to not expose this type at all to my bindings (if the type is irrelevant, which I don't know) or to use the script API to retrieve the instance.
