### PR TITLE
Fixed minor typo

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -46238,7 +46238,7 @@ do_property].
 			<argument index="0" name="to_pos" type="Vector2">
 			</argument>
 			<description>
-				Wrap the mouse to a position, relative to the viewport.
+				Warp the mouse to a position, relative to the viewport.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Fixed a minor typo in the warp_mouse method in the Viewport class reference