### PR TITLE
Made background and symbol color follow the color API

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -492,10 +492,10 @@ void TextEdit::_notification(int p_what) {
 
 			if (syntax_coloring) {
 
-				if (custom_bg_color.a>0.01) {
+				if (cache.background_color.a>0.01) {
 
 					Point2i ofs = Point2i(cache.style_normal->get_offset())/2.0;
-					VisualServer::get_singleton()->canvas_item_add_rect(ci,Rect2(ofs, get_size()-cache.style_normal->get_minimum_size()+ofs),custom_bg_color);
+					VisualServer::get_singleton()->canvas_item_add_rect(ci,Rect2(ofs, get_size()-cache.style_normal->get_minimum_size()+ofs),cache.background_color);
 				}
 				//compute actual region to start (may be inside say, a comment).
 				//slow in very large documments :( but ok for source!
@@ -907,7 +907,7 @@ void TextEdit::_notification(int p_what) {
 						else if (in_function_name)
 							color=cache.function_color;
 						else if (is_symbol)
-							color=symbol_color;
+							color=cache.symbol_color;
 						else if (is_number)
 							color=cache.number_color;
 
@@ -3489,6 +3489,8 @@ void TextEdit::_update_caches() {
 	cache.word_highlighted_color=get_color("word_highlighted_color");
 	cache.search_result_color=get_color("search_result_color");
 	cache.search_result_border_color=get_color("search_result_border_color");
+	cache.symbol_color=get_color("symbol_color");
+	cache.background_color=get_color("background_color");
 	cache.line_spacing=get_constant("line_spacing");
 	cache.row_height = cache.font->get_height() + cache.line_spacing;
 	cache.tab_icon=get_icon("tab");
@@ -3500,15 +3502,8 @@ void TextEdit::_update_caches() {
 void TextEdit::clear_colors() {
 
 	keywords.clear();
-	color_regions.clear();;
+	color_regions.clear();
 	text.clear_caches();
-	custom_bg_color=Color(0,0,0,0);
-}
-
-void TextEdit::set_custom_bg_color(const Color& p_color) {
-
-	custom_bg_color=p_color;
-	update();
 }
 
 void TextEdit::add_keyword_color(const String& p_keyword,const Color& p_color) {
@@ -3524,12 +3519,6 @@ void TextEdit::add_color_region(const String& p_begin_key,const String& p_end_ke
 	text.clear_caches();
 	update();
 
-}
-
-void TextEdit::set_symbol_color(const Color& p_color) {
-
-	symbol_color=p_color;
-	update();
 }
 
 void TextEdit::set_syntax_coloring(bool p_enabled) {
@@ -4689,8 +4678,6 @@ void TextEdit::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("add_keyword_color","keyword","color"),&TextEdit::add_keyword_color);
 	ObjectTypeDB::bind_method(_MD("add_color_region","begin_key","end_key","color","line_only"),&TextEdit::add_color_region,DEFVAL(false));
-	ObjectTypeDB::bind_method(_MD("set_symbol_color","color"),&TextEdit::set_symbol_color);
-	ObjectTypeDB::bind_method(_MD("set_custom_bg_color","color"),&TextEdit::set_custom_bg_color);
 	ObjectTypeDB::bind_method(_MD("clear_colors"),&TextEdit::clear_colors);
 	ObjectTypeDB::bind_method(_MD("menu_option"),&TextEdit::menu_option);
 	ObjectTypeDB::bind_method(_MD("get_menu:PopupMenu"),&TextEdit::get_menu);
@@ -4775,7 +4762,6 @@ TextEdit::TextEdit()  {
 	caret_blink_timer->connect("timeout", this,"_toggle_draw_caret");
 	cursor_set_blink_enabled(false);
 
-	custom_bg_color=Color(0,0,0,0);
 	idle_detect = memnew( Timer );
 	add_child(idle_detect);
 	idle_detect->set_one_shot(true);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -95,6 +95,8 @@ class TextEdit : public Control  {
 		Color word_highlighted_color;
 		Color search_result_color;
 		Color search_result_border_color;
+		Color symbol_color;
+		Color background_color;
 
 		int row_height;
 		int line_spacing;
@@ -187,9 +189,7 @@ class TextEdit : public Control  {
 
 
 	//syntax coloring
-	Color symbol_color;
 	HashMap<String,Color> keywords;
-	Color custom_bg_color;
 
 	Vector<ColorRegion> color_regions;
 
@@ -471,8 +471,6 @@ public:
 
 	void add_keyword_color(const String& p_keyword,const Color& p_color);
 	void add_color_region(const String& p_begin_key=String(),const String& p_end_key=String(),const Color &p_color=Color(),bool p_line_only=false);
-	void set_symbol_color(const Color& p_color);
-	void set_custom_bg_color(const Color& p_color);
 	void clear_colors();
 
 	int get_v_scroll() const;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -490,6 +490,7 @@ void fill_default_theme(Ref<Theme>& t, const Ref<Font> & default_font, const Ref
 
 	t->set_font("font","TextEdit", default_font );
 
+	t->set_color("background_color", "TextEdit", Color(0,0,0,0));
 	t->set_color("completion_background_color", "TextEdit",Color::html("2C2A32"));
 	t->set_color("completion_selected_color", "TextEdit",Color::html("434244"));
 	t->set_color("completion_existing_color", "TextEdit",Color::html("21dfdfdf"));

--- a/tools/editor/plugins/script_text_editor.cpp
+++ b/tools/editor/plugins/script_text_editor.cpp
@@ -100,7 +100,7 @@ void ScriptTextEditor::_load_theme_settings() {
 	/* keyword color */
 
 
-	text_edit->set_custom_bg_color(EDITOR_DEF("text_editor/background_color",Color(0,0,0,0)));
+	text_edit->add_color_override("background_color", EDITOR_DEF("text_editor/background_color",Color(0,0,0,0)));
 	text_edit->add_color_override("completion_background_color", EDITOR_DEF("text_editor/completion_background_color", Color(0,0,0,0)));
 	text_edit->add_color_override("completion_selected_color", EDITOR_DEF("text_editor/completion_selected_color", Color::html("434244")));
 	text_edit->add_color_override("completion_existing_color", EDITOR_DEF("text_editor/completion_existing_color", Color::html("21dfdfdf")));
@@ -122,6 +122,7 @@ void ScriptTextEditor::_load_theme_settings() {
 	text_edit->add_color_override("breakpoint_color", EDITOR_DEF("text_editor/breakpoint_color", Color(0.8,0.8,0.4,0.2)));
 	text_edit->add_color_override("search_result_color",EDITOR_DEF("text_editor/search_result_color",Color(0.05,0.25,0.05,1)));
 	text_edit->add_color_override("search_result_border_color",EDITOR_DEF("text_editor/search_result_border_color",Color(0.1,0.45,0.1,1)));
+	text_edit->add_color_override("symbol_color",EDITOR_DEF("text_editor/symbol_color",Color::hex(0x005291ff)));
 	text_edit->add_constant_override("line_spacing", EDITOR_DEF("text_editor/line_spacing",4));
 
 	Color keyword_color= EDITOR_DEF("text_editor/keyword_color",Color(0.5,0.0,0.2));
@@ -190,11 +191,6 @@ void ScriptTextEditor::_load_theme_settings() {
 		String end = string.get_slice_count(" ")>1?string.get_slice(" ",1):String();
 		text_edit->add_color_region(beg,end,string_color,end=="");
 	}
-
-	//colorize symbols
-	Color symbol_color= EDITOR_DEF("text_editor/symbol_color",Color::hex(0x005291ff));
-	text_edit->set_symbol_color(symbol_color);
-
 }
 
 

--- a/tools/editor/plugins/shader_editor_plugin.cpp
+++ b/tools/editor/plugins/shader_editor_plugin.cpp
@@ -77,7 +77,7 @@ void ShaderTextEditor::_load_theme_settings() {
 
 	/* keyword color */
 
-	get_text_edit()->set_custom_bg_color(EDITOR_DEF("text_editor/background_color",Color(0,0,0,0)));
+	get_text_edit()->add_color_override("background_color", EDITOR_DEF("text_editor/background_color",Color(0,0,0,0)));
 	get_text_edit()->add_color_override("completion_background_color", EDITOR_DEF("text_editor/completion_background_color", Color(0,0,0,0)));
 	get_text_edit()->add_color_override("completion_selected_color", EDITOR_DEF("text_editor/completion_selected_color", Color::html("434244")));
 	get_text_edit()->add_color_override("completion_existing_color", EDITOR_DEF("text_editor/completion_existing_color", Color::html("21dfdfdf")));
@@ -99,6 +99,7 @@ void ShaderTextEditor::_load_theme_settings() {
 	get_text_edit()->add_color_override("breakpoint_color", EDITOR_DEF("text_editor/breakpoint_color", Color(0.8,0.8,0.4,0.2)));
 	get_text_edit()->add_color_override("search_result_color",EDITOR_DEF("text_editor/search_result_color",Color(0.05,0.25,0.05,1)));
 	get_text_edit()->add_color_override("search_result_border_color",EDITOR_DEF("text_editor/search_result_border_color",Color(0.1,0.45,0.1,1)));
+	get_text_edit()->add_color_override("symbol_color",EDITOR_DEF("text_editor/symbol_color",Color::hex(0x005291ff)));
 
 	Color keyword_color= EDITOR_DEF("text_editor/keyword_color",Color(0.5,0.0,0.2));
 
@@ -135,11 +136,6 @@ void ShaderTextEditor::_load_theme_settings() {
 		String end = string.get_slice_count(" ")>1?string.get_slice(" ",1):String();
 		get_text_edit()->add_color_region(beg,end,string_color,end=="");
 	}*/
-
-	//colorize symbols
-	Color symbol_color= EDITOR_DEF("text_editor/symbol_color",Color::hex(0x005291ff));
-	get_text_edit()->set_symbol_color(symbol_color);
-
 }
 
 


### PR DESCRIPTION
Made background and symbol color follow the color API. Since this would break backwards compatibility, had to wait for 3.0 as mentioned in #5648