### PR TITLE
Set project name as directory name instead of '.'

### DIFF
--- a/tools/editor/project_manager.cpp
+++ b/tools/editor/project_manager.cpp
@@ -141,7 +141,7 @@ private:
 		}
 		String sp = p.simplify_path();
 		project_path->set_text(sp);
-		_path_text_changed(p);
+		_path_text_changed(sp);
 		get_ok()->call_deferred("grab_focus");
 	}
 
@@ -150,7 +150,7 @@ private:
 		String p = p_path;
 		String sp = p.simplify_path();
 		project_path->set_text(sp);
-		_path_text_changed(p);
+		_path_text_changed(sp);
 		get_ok()->call_deferred("grab_focus");
 	}
 


### PR DESCRIPTION
IIRC, project name is set as directory name when creating new project.
But, I don't know since when, but now it's set `.` now. (tested it on Windows & Linux)

![pm](https://cloud.githubusercontent.com/assets/8281454/20099510/2d221570-a5fc-11e6-8f6d-f17bb0ce3c3c.gif)

This `gif` is made for another PR, but it shows the bug when creating new project.