### PR TITLE
Renames vsnc to vsync

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -480,9 +480,9 @@ void _OS::set_use_vsync(bool p_enable) {
 	OS::get_singleton()->set_use_vsync(p_enable);
 }
 
-bool _OS::is_vsnc_enabled() const {
+bool _OS::is_vsync_enabled() const {
 
-	return OS::get_singleton()->is_vsnc_enabled();
+	return OS::get_singleton()->is_vsync_enabled();
 }
 
 
@@ -1172,7 +1172,7 @@ void _OS::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_thread_name","name"),&_OS::set_thread_name);
 
 	ObjectTypeDB::bind_method(_MD("set_use_vsync","enable"),&_OS::set_use_vsync);
-	ObjectTypeDB::bind_method(_MD("is_vsnc_enabled"),&_OS::is_vsnc_enabled);
+	ObjectTypeDB::bind_method(_MD("is_vsync_enabled"),&_OS::is_vsync_enabled);
 
 	ObjectTypeDB::bind_method(_MD("get_engine_version"),&_OS::get_engine_version);
 

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -318,7 +318,7 @@ public:
 	Error set_thread_name(const String& p_name);
 
 	void set_use_vsync(bool p_enable);
-	bool is_vsnc_enabled() const;
+	bool is_vsync_enabled() const;
 
 	Dictionary get_engine_version() const;
 

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -542,7 +542,7 @@ void OS::set_use_vsync(bool p_enable) {
 
 }
 
-bool OS::is_vsnc_enabled() const{
+bool OS::is_vsync_enabled() const{
 
 	return true;
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -431,7 +431,7 @@ public:
 	virtual void set_context(int p_context);
 
 	virtual void set_use_vsync(bool p_enable);
-	virtual bool is_vsnc_enabled() const;
+	virtual bool is_vsync_enabled() const;
 
 	Dictionary get_engine_version() const;
 

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -24152,7 +24152,7 @@
 				Return true if the window is resizable.
 			</description>
 		</method>
-		<method name="is_vsnc_enabled" qualifiers="const">
+		<method name="is_vsync_enabled" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2388,7 +2388,7 @@ void OS_Windows::set_use_vsync(bool p_enable) {
 		gl_context->set_use_vsync(p_enable);
 }
 
-bool OS_Windows::is_vsnc_enabled() const{
+bool OS_Windows::is_vsync_enabled() const{
 
 	if (gl_context)
 		return gl_context->is_using_vsync();

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -295,7 +295,7 @@ public:
 	virtual String get_joy_guid(int p_device) const;
 
 	virtual void set_use_vsync(bool p_enable);
-	virtual bool is_vsnc_enabled() const;
+	virtual bool is_vsync_enabled() const;
 
 	OS_Windows(HINSTANCE _hInstance);
 	~OS_Windows();

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -1951,7 +1951,7 @@ void OS_X11::set_use_vsync(bool p_enable) {
 		return context_gl->set_use_vsync(p_enable);
 }
 
-bool OS_X11::is_vsnc_enabled() const {
+bool OS_X11::is_vsync_enabled() const {
 
 	if (context_gl)
 		return context_gl->is_using_vsync();

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -264,7 +264,7 @@ public:
 	virtual void set_context(int p_context);
 
 	virtual void set_use_vsync(bool p_enable);
-	virtual bool is_vsnc_enabled() const;
+	virtual bool is_vsync_enabled() const;
 
 	void run();
 


### PR DESCRIPTION
I'm pretty sure, vsnc was meant to be vsync.