### PR TITLE
Export immediately if only one device present

### DIFF
--- a/tools/editor/editor_run_native.cpp
+++ b/tools/editor/editor_run_native.cpp
@@ -55,6 +55,7 @@ void EditorRunNative::_notification(int p_what) {
 					small_icon->create_from_image(im);
 					MenuButton *mb = memnew( MenuButton );
 					mb->get_popup()->connect("item_pressed",this,"_run_native",varray(E->get()));
+					mb->connect("pressed",this,"_run_native",varray(-1, E->get()));
 					mb->set_icon(small_icon);
 					add_child(mb);
 					menus[E->get()]=mb;
@@ -79,13 +80,16 @@ void EditorRunNative::_notification(int p_what) {
 				if (dc==0) {
 					mb->hide();
 				} else {
-
 					mb->get_popup()->clear();
 					mb->show();
-					for(int i=0;i<dc;i++) {
-
-						mb->get_popup()->add_icon_item(get_icon("Play","EditorIcons"),eep->get_device_name(i));
-						mb->get_popup()->set_item_tooltip(mb->get_popup()->get_item_count() -1,eep->get_device_info(i));
+					if (dc == 1) {
+						mb->set_tooltip(eep->get_device_name(0) + "\n\n" + eep->get_device_info(0).strip_edges());
+					} else {
+						mb->set_tooltip("Select device from the list");
+						for(int i=0;i<dc;i++) {
+							mb->get_popup()->add_icon_item(get_icon("Play","EditorIcons"),eep->get_device_name(i));
+							mb->get_popup()->set_item_tooltip(mb->get_popup()->get_item_count() -1,eep->get_device_info(i).strip_edges());
+						}
 					}
 				}
 			}
@@ -96,11 +100,18 @@ void EditorRunNative::_notification(int p_what) {
 
 }
 
-
 void EditorRunNative::_run_native(int p_idx,const String& p_platform) {
 
 	Ref<EditorExportPlatform> eep = EditorImportExport::get_singleton()->get_export_platform(p_platform);
 	ERR_FAIL_COND(eep.is_null());
+	if (p_idx == -1) {
+		if (eep->get_device_count() == 1) {
+			menus[p_platform]->get_popup()->hide();
+			p_idx = 0;
+		} else {
+			return;
+		}
+	}
 	emit_signal("native_run");
 
 	int flags=0;


### PR DESCRIPTION
I assume most developers exporting to Android (or other platforms) use only one device at once.
Now Godot always shows menu with device(s) which is ineffective as developer needs to click twice to run even if there's only one device connected:
![export_old](https://cloud.githubusercontent.com/assets/19764492/20113652/923c99a4-a5f1-11e6-8afc-5c4c2d48f124.png)
I think it's better to run export immediately on menu button press if there's only one device connected and show the menu if there are more choices:
![export_new](https://cloud.githubusercontent.com/assets/19764492/20113707/d22124fe-a5f1-11e6-8f44-acb2a89eefc2.png)
Device name / description (if there is only one) is shown in the button's tooltip.
I've also removed last empty description line as it looked bad in tooltips.

I was not able to test it on other platform than Android.
