### PR TITLE
Some WebAssembly stuff

### DIFF
--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -86,7 +86,6 @@ def configure(env):
 
     if env['wasm'] == 'yes':
         env.Append(LINKFLAGS=['-s', 'BINARYEN=1'])
-        env.Append(LINKFLAGS=['-s', '\'BINARYEN_METHOD="native-wasm"\''])
         # Maximum memory size is baked into the WebAssembly binary during
         # compilation, so we need to enable memory growth to allow setting
         # TOTAL_MEMORY at runtime. The value set at runtime must be higher than

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -76,6 +76,7 @@ def configure(env):
     if("module_opus_enabled" in env and env["module_opus_enabled"] != "no"):
         env.opus_fixed_point = "yes"
 
+    # These flags help keep the file size down
     env.Append(CPPFLAGS=["-fno-exceptions", '-DNO_SAFE_CAST', '-fno-rtti'])
     env.Append(CPPFLAGS=['-DJAVASCRIPT_ENABLED', '-DUNIX_ENABLED', '-DPTHREAD_NO_RENAME', '-DNO_FCNTL', '-DMPC_FIXED_POINT', '-DTYPED_METHOD_BIND', '-DNO_THREADS'])
     env.Append(CPPFLAGS=['-DGLES2_ENABLED'])
@@ -86,6 +87,12 @@ def configure(env):
     if env['wasm'] == 'yes':
         env.Append(LINKFLAGS=['-s', 'BINARYEN=1'])
         env.Append(LINKFLAGS=['-s', '\'BINARYEN_METHOD="native-wasm"\''])
+        # Maximum memory size is baked into the WebAssembly binary during
+        # compilation, so we need to enable memory growth to allow setting
+        # TOTAL_MEMORY at runtime. The value set at runtime must be higher than
+        # what is set during compilation, check TOTAL_MEMORY in Emscripten's
+        # src/settings.js for the default.
+        env.Append(LINKFLAGS=['-s', 'ALLOW_MEMORY_GROWTH=1'])
         env["PROGSUFFIX"] += ".webassembly"
     else:
         env.Append(CPPFLAGS=['-s', 'ASM_JS=1'])

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1331,7 +1331,7 @@ int Tree::draw_item(const Point2i& p_pos,const Point2& p_draw_ofs, const Size2& 
 				int root_ofs = children_pos.x + (hide_folding?cache.hseparation:cache.item_margin);
 				int parent_ofs = p_pos.x + (hide_folding?cache.hseparation:cache.item_margin);
 				Point2i root_pos = Point2i(root_ofs, children_pos.y + label_h/2)-cache.offset+p_draw_ofs;
-				if (c->get_children() > 0)
+				if (c->get_children() != NULL)
 					root_pos -= Point2i(cache.arrow->get_width(),0);
 
 				Point2i parent_pos = Point2i(parent_ofs - cache.arrow->get_width()/2, p_pos.y + label_h/2 + cache.arrow->get_height()/2)-cache.offset+p_draw_ofs;


### PR DESCRIPTION
Running on Firefox Nightly should now work due to enabling memory growth.
Enabling the flag `javascript.options.wasm_baselinejit` to use Firefox's experimental compiler starts up faster.

Compiling per LLVM backend doesn't work yet, this is just another step.