### PR TITLE
Emit "*_changed" signal in set_*

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -660,6 +660,7 @@ void ColorPickerButton::set_color(const Color& p_color){
 
 	picker->set_color(p_color);
 	update();
+	emit_signal("color_changed",p_color);
 }
 Color ColorPickerButton::get_color() const{
 

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -918,6 +918,7 @@ void LineEdit::set_text(String p_text) {
 	update();
 	cursor_pos=0;
 	window_pos=0;
+	_text_changed();
 }
 
 void LineEdit::clear() {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3327,7 +3327,7 @@ void TextEdit::set_text(String p_text){
 	cursor_set_column(0);
 	update();
 	setting_text=false;
-
+	_text_changed_emit();
 	//get_range()->set(0);
 };
 


### PR DESCRIPTION
Add `emit_signal` in `set_*` function.
It's useful when make `reset` function in game with showing or hiding reset button.