### PR TITLE
Fix crash when select target path on import 3d scene window

### DIFF
--- a/tools/editor/editor_dir_dialog.cpp
+++ b/tools/editor/editor_dir_dialog.cpp
@@ -145,7 +145,7 @@ void EditorDirDialog::set_current_path(const String& p_path) {
 	if (p.begins_with("res://"))
 		p = p.replace_first("res://","");
 
-	Vector<String> dirs = p.split("/");
+	Vector<String> dirs = p.split("/",false);
 
 	TreeItem *r=tree->get_root();
 	for(int i=0;i<dirs.size();i++) {

--- a/tools/editor/io_plugins/editor_scene_import_plugin.cpp
+++ b/tools/editor/io_plugins/editor_scene_import_plugin.cpp
@@ -894,9 +894,9 @@ void EditorSceneImportDialog::_browse() {
 
 void EditorSceneImportDialog::_browse_target() {
 
+	save_select->popup_centered_ratio();
 	if (save_path->get_text()!="")
 		save_select->set_current_path(save_path->get_text());
-	save_select->popup_centered_ratio();
 
 }
 


### PR DESCRIPTION
Reproduce step (on Ubuntu 16.04)

1. Import > Scene
2. Select target path with [..] button
3. Select target path with [..] button again
4. crash

it happens only **Import 3D Scene** window.