### PR TITLE
Stereo camera

### DIFF
--- a/core/math/camera_matrix.cpp
+++ b/core/math/camera_matrix.cpp
@@ -91,6 +91,44 @@ void CameraMatrix::set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_
 	matrix[3][3] = 0;
 }
 
+void CameraMatrix::set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_t p_z_near, real_t p_z_far, bool p_flip_fov, int p_eye, real_t p_intraocular_dist, real_t p_convergence_dist) {
+	if (p_flip_fov) {
+		p_fovy_degrees = get_fovy(p_fovy_degrees, 1.0 / p_aspect);
+	}
+
+	real_t left, right, modeltranslation, ymax, xmax, frustumshift;
+
+	ymax = p_z_near * tan(p_fovy_degrees * Math_PI / 360.0f);
+	xmax = ymax * p_aspect;
+	frustumshift = (p_intraocular_dist / 2.0) * p_z_near / p_convergence_dist;
+
+	switch (p_eye) {
+		case 1: { // left eye
+			left = -xmax + frustumshift;
+			right = xmax + frustumshift;
+			modeltranslation = p_intraocular_dist / 2.0;
+		}; break;
+		case 2: { // right eye
+			left = -xmax - frustumshift;
+			right = xmax - frustumshift;
+			modeltranslation = -p_intraocular_dist / 2.0;
+		}; break;
+		default: { // mono, should give the same result as set_perspective(p_fovy_degrees,p_aspect,p_z_near,p_z_far,p_flip_fov)
+			left = -xmax;
+			right = xmax;
+			modeltranslation = 0.0;
+		}; break;
+	};
+
+	set_frustum(left, right, -ymax, ymax, p_z_near, p_z_far);
+
+	// translate matrix by (modeltranslation, 0.0, 0.0)
+	CameraMatrix cm;
+	cm.set_identity();
+	cm.matrix[3][0] = modeltranslation;
+	*this = *this * cm;
+}
+
 void CameraMatrix::set_orthogonal(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_znear, real_t p_zfar) {
 
 	set_identity();
@@ -116,6 +154,7 @@ void CameraMatrix::set_orthogonal(real_t p_size, real_t p_aspect, real_t p_znear
 void CameraMatrix::set_frustum(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_near, real_t p_far) {
 #if 0
 	///@TODO, give a check to this. I'm not sure if it's working.
+	// I think columns and rows are swapped...
 	set_identity();
 
 	matrix[0][0]=(2*p_near) / (p_right-p_left);
@@ -126,6 +165,7 @@ void CameraMatrix::set_frustum(real_t p_left, real_t p_right, real_t p_bottom, r
 	matrix[2][3]=-(2*p_far*p_near) / (p_far-p_near);
 	matrix[3][2]=-1;
 	matrix[3][3]=0;
+
 #else
 	real_t *te = &matrix[0][0];
 	real_t x = 2 * p_near / (p_right - p_left);
@@ -243,23 +283,44 @@ bool CameraMatrix::get_endpoints(const Transform &p_transform, Vector3 *p_8point
 			-matrix[15] + matrix[13]);
 	top_plane.normalize();
 
-	Vector3 near_endpoint;
-	Vector3 far_endpoint;
+	Vector3 near_endpoint_left, near_endpoint_right;
+	Vector3 far_endpoint_left, far_endpoint_right;
 
-	bool res = near_plane.intersect_3(right_plane, top_plane, &near_endpoint);
+	bool res = near_plane.intersect_3(right_plane, top_plane, &near_endpoint_right);
 	ERR_FAIL_COND_V(!res, false);
 
-	res = far_plane.intersect_3(right_plane, top_plane, &far_endpoint);
+	res = far_plane.intersect_3(right_plane, top_plane, &far_endpoint_right);
 	ERR_FAIL_COND_V(!res, false);
 
-	p_8points[0] = p_transform.xform(Vector3(near_endpoint.x, near_endpoint.y, near_endpoint.z));
-	p_8points[1] = p_transform.xform(Vector3(near_endpoint.x, -near_endpoint.y, near_endpoint.z));
-	p_8points[2] = p_transform.xform(Vector3(-near_endpoint.x, near_endpoint.y, near_endpoint.z));
-	p_8points[3] = p_transform.xform(Vector3(-near_endpoint.x, -near_endpoint.y, near_endpoint.z));
-	p_8points[4] = p_transform.xform(Vector3(far_endpoint.x, far_endpoint.y, far_endpoint.z));
-	p_8points[5] = p_transform.xform(Vector3(far_endpoint.x, -far_endpoint.y, far_endpoint.z));
-	p_8points[6] = p_transform.xform(Vector3(-far_endpoint.x, far_endpoint.y, far_endpoint.z));
-	p_8points[7] = p_transform.xform(Vector3(-far_endpoint.x, -far_endpoint.y, far_endpoint.z));
+	if ((matrix[8] == 0) && (matrix[9] == 0)) {
+		near_endpoint_left = near_endpoint_right;
+		near_endpoint_left.x = -near_endpoint_left.x;
+
+		far_endpoint_left = far_endpoint_right;
+		far_endpoint_left.x = -far_endpoint_left.x;
+	} else {
+		///////--- Left Plane ---///////
+		Plane left_plane = Plane(matrix[0] + matrix[3],
+				matrix[4] + matrix[7],
+				matrix[8] + matrix[11],
+				-matrix[15] - matrix[12]);
+		left_plane.normalize();
+
+		res = near_plane.intersect_3(left_plane, top_plane, &near_endpoint_left);
+		ERR_FAIL_COND_V(!res, false);
+
+		res = far_plane.intersect_3(left_plane, top_plane, &far_endpoint_left);
+		ERR_FAIL_COND_V(!res, false);
+	}
+
+	p_8points[0] = p_transform.xform(Vector3(near_endpoint_right.x, near_endpoint_right.y, near_endpoint_right.z));
+	p_8points[1] = p_transform.xform(Vector3(near_endpoint_right.x, -near_endpoint_right.y, near_endpoint_right.z));
+	p_8points[2] = p_transform.xform(Vector3(near_endpoint_left.x, near_endpoint_left.y, near_endpoint_left.z));
+	p_8points[3] = p_transform.xform(Vector3(near_endpoint_left.x, -near_endpoint_left.y, near_endpoint_left.z));
+	p_8points[4] = p_transform.xform(Vector3(far_endpoint_right.x, far_endpoint_right.y, far_endpoint_right.z));
+	p_8points[5] = p_transform.xform(Vector3(far_endpoint_right.x, -far_endpoint_right.y, far_endpoint_right.z));
+	p_8points[6] = p_transform.xform(Vector3(far_endpoint_left.x, far_endpoint_left.y, far_endpoint_left.z));
+	p_8points[7] = p_transform.xform(Vector3(far_endpoint_left.x, -far_endpoint_left.y, far_endpoint_left.z));
 
 	return true;
 }
@@ -270,6 +331,9 @@ Vector<Plane> CameraMatrix::get_projection_planes(const Transform &p_transform) 
 	 * References:
 	 * http://www.markmorley.com/opengl/frustumculling.html
 	 * http://www2.ravensoft.com/users/ggribb/plane%20extraction.pdf
+	 *
+	 * !BAS! The above to links seem broken, heres another that explains this:
+	 * http://gamedevs.org/uploads/fast-extraction-viewing-frustum-planes-from-world-view-projection-matrix.pdf
 	 */
 
 	Vector<Plane> planes;
@@ -546,7 +610,18 @@ real_t CameraMatrix::get_fov() const {
 			-matrix[15] + matrix[12]);
 	right_plane.normalize();
 
-	return Math::rad2deg(Math::acos(Math::abs(right_plane.normal.x))) * 2.0;
+	if ((matrix[8] == 0) && (matrix[9] == 0)) {
+		return Math::rad2deg(Math::acos(Math::abs(right_plane.normal.x))) * 2.0;
+	} else {
+		// our frustum is asymetrical need to calculate the left planes angle seperately..
+		Plane left_plane = Plane(matrix[3] + matrix[0],
+				matrix[7] + matrix[4],
+				matrix[11] + matrix[8],
+				matrix[15] + matrix[12]);
+		left_plane.normalize();
+
+		return Math::rad2deg(Math::acos(Math::abs(left_plane.normal.x))) + Math::rad2deg(Math::acos(Math::abs(right_plane.normal.x)));
+	}
 }
 
 void CameraMatrix::make_scale(const Vector3 &p_scale) {

--- a/core/math/camera_matrix.h
+++ b/core/math/camera_matrix.h
@@ -54,6 +54,7 @@ struct CameraMatrix {
 	void set_light_bias();
 	void set_light_atlas_rect(const Rect2 &p_rect);
 	void set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_t p_z_near, real_t p_z_far, bool p_flip_fov = false);
+	void set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_t p_z_near, real_t p_z_far, bool p_flip_fov, int p_eye, real_t p_intraocular_dist, real_t p_convergence_dist);
 	void set_orthogonal(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_znear, real_t p_zfar);
 	void set_orthogonal(real_t p_size, real_t p_aspect, real_t p_znear, real_t p_zfar, bool p_flip_fov = false);
 	void set_frustum(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_near, real_t p_far);

--- a/core/math/frustum.cpp
+++ b/core/math/frustum.cpp
@@ -1,0 +1,149 @@
+/*************************************************************************/
+/*  frustum.cpp                                                          */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2016 Juan Linietsky, Ariel Manzur.                 */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#include "frustum.h"
+#include "math_funcs.h"
+
+void Frustum::set_frustum(real_t p_left, real_t p_right, real_t p_top, real_t p_bottom) {
+	left = p_left;
+	right = p_right;
+	top = p_top;
+	bottom = p_bottom;
+};
+
+void Frustum::set_frustum(real_t p_fov_degrees) {
+	right = tan(p_fov_degrees * Math_PI / 360.0);
+	left = -right;
+	top = right;
+	bottom = left;
+};
+
+void Frustum::set_frustum(real_t p_fov_degrees, int p_eye, real_t p_intraocular_dist, real_t p_convergency_dist) {
+	right = tan(p_fov_degrees * Math_PI / 360.0);
+	left = -right;
+	top = right;
+	bottom = left;
+
+	real_t shift = p_intraocular_dist / (2.0 * p_convergency_dist);
+	if (p_eye == Frustum::EYE_LEFT) {
+		left += shift;
+		right += shift;
+	} else {
+		left -= shift;
+		right -= shift;
+	};
+};
+
+void Frustum::set_frustum_for_hmd(int p_eye, real_t p_intraocular_dist, real_t p_display_width, real_t p_display_to_lens, real_t p_oversample) {
+	/*
+		We calculate our frustum initialy based initialy without taking the magnifying properties of the lens into account limiting our initial FOV
+		to the physical size of our device.
+
+		The magnification of our lens is determined by the k1..kn constants that will be used to distort our rendered image but we can't use those
+		directly to figure out by how much we need to increase our FOV. The calculation that does this assumes that a distance of 1.0 is equivilent
+		to our unmagnified FOV. If we oversample our render target by a factor of two, we'll be adjusting our coordinates accordingly by multiplying
+		our distance by the oversample, applying our magnification, and then divided the result. 
+
+		By how much we oversample is always a tradeoff between performance and how much of the screen we want to use, especially with lenses like
+		we find in headsets such as the Vive and Rift which often oversize by 2.0 while mobile VR often uses much lower magnification due to
+		performance limitations of the phones.
+	*/
+
+	// create our factors based on our physical screen dimentions
+	real_t f1 = (p_intraocular_dist / 2.0) / (2.0 * p_display_to_lens);
+	real_t f2 = ((p_display_width - p_intraocular_dist) / 2.0) / (2.0 * p_display_to_lens);
+	real_t f3 = (p_display_width / 4.0) / (2.0 * p_display_to_lens);
+
+	// apply our oversample to increase the FOV
+	f3 *= p_oversample;
+	real_t add_width = ((f1 + f2) * (p_oversample - 1.0)) / 2.0;
+	f1 += add_width;
+	f2 += add_width;
+
+	// and set our frustum for the correct eye
+	left = p_eye == Frustum::EYE_LEFT ? -f2 : -f1;
+	right = p_eye == Frustum::EYE_LEFT ? f1 : f2;
+	top = f3;
+	bottom = -f3;
+};
+
+CameraMatrix Frustum::make_camera_matrix(real_t p_aspect, bool p_vaspect, real_t p_znear, real_t p_zfar) const {
+	// Slightly modified version of ComposeProjection found in: https://github.com/ValveSoftware/openvr/wiki/IVRSystem::GetProjectionRaw
+	// We are expecting a left/right/top/bottom frustum not adjusted to the near place but unified.
+
+	CameraMatrix M;
+	real_t *m = &M.matrix[0][0];
+	real_t l = left;
+	real_t r = right;
+	real_t t = top;
+	real_t b = bottom;
+
+	// apply aspect ratio of our viewport
+	if (p_vaspect) {
+		t /= p_aspect;
+		b /= p_aspect;
+	} else {
+		l *= p_aspect;
+		r *= p_aspect;
+	}
+
+	real_t idx = 1.0f / (r - l);
+	real_t idy = 1.0f / (t - b);
+	real_t idz = 1.0f / (p_zfar - p_znear);
+	real_t sx = r + l;
+	real_t sy = t + b;
+
+	m[0] = 2.0f * idx;
+	m[4] = 0.0f;
+	m[8] = sx * idx;
+	m[12] = 0.0f;
+	m[1] = 0.0f;
+	m[5] = 2.0f * idy;
+	m[9] = sy * idy;
+	m[13] = 0.0f;
+	m[2] = 0.0f;
+	m[6] = 0.0f;
+	m[10] = -p_zfar * idz;
+	m[14] = -p_zfar * p_znear * idz;
+	m[3] = 0.0f;
+	m[7] = 0.0f;
+	m[11] = -1.0f;
+	m[15] = 0.0f;
+
+	return M;
+};
+
+Frustum::Frustum() {
+	set_frustum(-0.5f, 0.5f, 0.5f, -0.5f);
+};
+
+Frustum::Frustum(real_t p_left, real_t p_right, real_t p_top, real_t p_bottom) {
+	set_frustum(p_left, p_right, p_top, p_bottom);
+};
+
+Frustum::~Frustum(){};

--- a/core/math/frustum.h
+++ b/core/math/frustum.h
@@ -1,0 +1,57 @@
+/*************************************************************************/
+/*  frustum.h                                                            */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2016 Juan Linietsky, Ariel Manzur.                 */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#ifndef FRUSTUM_H
+#define FRUSTUM_H
+
+#include "camera_matrix.h"
+/**
+	@author Bastiaan Olij <mux213@gmail.com>
+*/
+
+struct Frustum {
+	enum Eyes {
+		EYE_LEFT,
+		EYE_RIGHT
+	};
+
+	real_t left, right, top, bottom;
+
+	void set_frustum(real_t p_left, real_t p_right, real_t p_top, real_t p_bottom);
+	void set_frustum(real_t p_fov_degrees);
+	void set_frustum(real_t p_fov_degrees, int p_eye, real_t p_intraocular_dist, real_t p_convergency_dist);
+	void set_frustum_for_hmd(int p_eye, real_t p_intraocular_dist, real_t p_display_width, real_t p_display_to_lens, real_t p_oversample = 1.0);
+
+	CameraMatrix make_camera_matrix(real_t p_aspect, bool p_vaspect, real_t p_znear, real_t p_zfar) const;
+
+	Frustum();
+	Frustum(real_t p_left, real_t p_right, real_t p_top, real_t p_bottom);
+	~Frustum();
+};
+
+#endif

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -7675,6 +7675,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_bottom" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+				In frustum mode, returns the bottom size of the frustum.
+			</description>
+		</method>
 		<method name="get_camera_transform" qualifiers="const">
 			<return type="Transform">
 			</return>
@@ -7698,48 +7705,77 @@
 			<return type="float">
 			</return>
 			<description>
+				In perspective mode, returns the Field Of View value set for the camera.
 			</description>
 		</method>
 		<method name="get_h_offset" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
+				Gets the horizontal offset added to the camera position
 			</description>
 		</method>
 		<method name="get_keep_aspect_mode" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
+				Gets the aspect ratio mode
+			</description>
+		</method>
+		<method name="get_left" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+				In frustum mode, returns the left size of the frustum.
 			</description>
 		</method>
 		<method name="get_projection" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
+				Gets the projection mode
+			</description>
+		</method>
+		<method name="get_right" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+				In frustum mode, returns the right size of the frustum.
 			</description>
 		</method>
 		<method name="get_size" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
+				In orthographic mode, returns the size
+			</description>
+		</method>
+		<method name="get_top" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+				In frustum mode, returns the top size of the frustum.
 			</description>
 		</method>
 		<method name="get_v_offset" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
+				Gets the vertical offset added to the camera position
 			</description>
 		</method>
 		<method name="get_zfar" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
+				Get the far distance for the camera, anything further away will not render
 			</description>
 		</method>
 		<method name="get_znear" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
+				Get the near distance for the camera, anything before this will not render
 			</description>
 		</method>
 		<method name="is_current" qualifiers="const">
@@ -7808,16 +7844,37 @@
 			<description>
 			</description>
 		</method>
+		<method name="set_frustum">
+			<argument index="0" name="left" type="float">
+			</argument>
+			<argument index="1" name="right" type="float">
+			</argument>
+			<argument index="2" name="top" type="float">
+			</argument>
+			<argument index="3" name="bottom" type="float">
+			</argument>
+			<argument index="4" name="z_near" type="float">
+			</argument>
+			<argument index="5" name="z_far" type="float">
+			</argument>
+			<description>
+				Set the projection mode to frustum mode, by specifying a [i]left[/i], [i]right[/i], [i]top[/i] and [i]bottom[/i] value in unit distance along with the [i]near[/i] and [i]far[/i] clip planes in worldspace units.
+				The [i]left[/i], [i]right[/i], [i]top[/i] and [i]bottom[/i] values will be adjusted by Godot based on the aspect ratio of the viewport.
+				This mode allows for assymmetric projections, required for stereoscopic rendering.
+			</description>
+		</method>
 		<method name="set_h_offset">
 			<argument index="0" name="ofs" type="float">
 			</argument>
 			<description>
+				Sets the horizontal offset added to the camera position
 			</description>
 		</method>
 		<method name="set_keep_aspect_mode">
 			<argument index="0" name="mode" type="int">
 			</argument>
 			<description>
+				Sets the aspect ratio mode
 			</description>
 		</method>
 		<method name="set_orthogonal">
@@ -7842,10 +7899,29 @@
 				Set the camera projection to perspective mode, by specifying a [i]FOV[/i] Y angle in degrees (FOV means Field of View), and the [i]near[/i] and [i]far[/i] clip planes in worldspace units.
 			</description>
 		</method>
-		<method name="set_v_offset">
+		<method name="set_perspective_for_eye">
+			<argument index="0" name="fov" type="float">
+			</argument>
+			<argument index="1" name="z_near" type="float">
+			</argument>
+			<argument index="2" name="z_far" type="float">
+			</argument>
+			<argument index="3" name="eye" type="int">
+			</argument>
+			<argument index="4" name="intraocular_dist" type="float">
+			</argument>
+			<argument index="5" name="convergence_dist" type="float">
+			</argument>
+			<description>
+				Set the camera projection to frustum mode, by specifying a [i]FOV[/i] Y angle in degrees (FOV means Field of View), and the [i]near[/i] and [i]far[/i] clip planes in worldspace units and by specifying the [i]eye[/i], [i]intracular_dist[/i] and [i]convergence_dist[/i] values.
+				The intra oculur distance is the distance between the two eyes and the convergence distance determines how far the focus plane lies. This function should be used for stereoscopic rendering to a 3D monitor or similar device. With the convergence distance think of the distance before which things will "pop" out of the screen and after which things seem to be inside of the screen.
+			</description>
+		</method>
+ 		<method name="set_v_offset">
 			<argument index="0" name="ofs" type="float">
 			</argument>
 			<description>
+				Sets the vertical offset added to the camera position
 			</description>
 		</method>
 		<method name="unproject_position" qualifiers="const">
@@ -7865,9 +7941,20 @@
 		<constant name="PROJECTION_ORTHOGONAL" value="1">
 			Orthogonal Projection (objects remain the same size on the screen no matter how far away they are).
 		</constant>
-		<constant name="KEEP_WIDTH" value="0">
+		<constant name="PROJECTION_FRUSTUM" value="2">
+			Frustum projection, similar to perspective projection but with more control.
+		</constant>
+		<constant name="EYE_LEFT" value="0">
+			Left eye
+		</constant>
+		<constant name="EYE_RIGHT" value="1">
+			Right eye
+		</constant>
+ 		<constant name="KEEP_WIDTH" value="0">
+ 			As the user resizes the render area, keep the width of 3D objects constant by adjusting the height
 		</constant>
 		<constant name="KEEP_HEIGHT" value="1">
+			As the user resizes the render area, keep the height of 3D objects constant by adjusting the width
 		</constant>
 	</constants>
 </class>

--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -1012,6 +1012,53 @@ void CameraSpatialGizmo::redraw() {
 			ADD_TRIANGLE(tup, right + up + back, -right + up + back);
 
 		} break;
+		case Camera::PROJECTION_FRUSTUM: {
+
+			float hoff = camera->get_h_offset();
+			float voff = camera->get_v_offset();
+			float left = camera->get_left();
+			float right = camera->get_right();
+			float top = camera->get_top();
+			float bottom = camera->get_bottom();
+			float near = camera->get_znear();
+			float far = camera->get_zfar();
+
+			// use our default screensize to show impact of aspect ratio on our frustum
+			float screen_width = GlobalConfig::get_singleton()->get("display/window/width");
+			float screen_height = GlobalConfig::get_singleton()->get("display/window/height");
+			float aspect = screen_width / screen_height;
+
+			if (camera->get_keep_aspect_mode() == Camera::KEEP_WIDTH) {
+				top /= aspect;
+				bottom /= aspect;
+			} else {
+				left *= aspect;
+				right *= aspect;
+			}
+
+			Vector3 left_top_near = Vector3(left * near + hoff, top * near + voff, -near);
+			Vector3 right_top_near = Vector3(right * near + hoff, top * near + voff, -near);
+			Vector3 right_bottom_near = Vector3(right * near + hoff, bottom * near + voff, -near);
+			Vector3 left_bottom_near = Vector3(left * near + hoff, bottom * near + voff, -near);
+
+			Vector3 left_top_far = Vector3(left * far + hoff, top * far + voff, -far);
+			Vector3 right_top_far = Vector3(right * far + hoff, top * far + voff, -far);
+			Vector3 right_bottom_far = Vector3(right * far + hoff, bottom * far + voff, -far);
+			Vector3 left_bottom_far = Vector3(left * far + hoff, bottom * far + voff, -far);
+
+			ADD_QUAD(left_top_near, right_top_near, right_bottom_near, left_bottom_near);
+			ADD_QUAD(left_top_far, right_top_far, right_bottom_far, left_bottom_far);
+
+			lines.push_back(left_top_near);
+			lines.push_back(left_top_far);
+			lines.push_back(right_top_near);
+			lines.push_back(right_top_far);
+			lines.push_back(right_bottom_near);
+			lines.push_back(right_bottom_far);
+			lines.push_back(left_bottom_near);
+			lines.push_back(left_bottom_far);
+
+		} break;
 	}
 
 	add_lines(lines, SpatialEditorGizmos::singleton->camera_material);

--- a/scene/3d/camera.h
+++ b/scene/3d/camera.h
@@ -30,9 +30,11 @@
 #ifndef CAMERA_H
 #define CAMERA_H
 
+#include "core/math/frustum.h"
 #include "scene/3d/spatial.h"
 #include "scene/main/viewport.h"
 #include "scene/resources/environment.h"
+
 /**
 	@author Juan Linietsky <reduzio@gmail.com>
 */
@@ -44,7 +46,13 @@ public:
 	enum Projection {
 
 		PROJECTION_PERSPECTIVE,
-		PROJECTION_ORTHOGONAL
+		PROJECTION_ORTHOGONAL,
+		PROJECTION_FRUSTUM
+	};
+
+	enum Eye {
+		EYE_LEFT,
+		EYE_RIGHT
 	};
 
 	enum KeepAspect {
@@ -64,6 +72,8 @@ private:
 	float v_offset;
 	float h_offset;
 	KeepAspect keep_aspect;
+
+	Frustum frustum;
 
 	RID camera;
 	RID scenario_id;
@@ -101,6 +111,9 @@ public:
 
 	void set_perspective(float p_fovy_degrees, float p_z_near, float p_z_far);
 	void set_orthogonal(float p_size, float p_z_near, float p_z_far);
+	void set_perspective_for_eye(float p_fovy_degrees, float p_z_near, float p_z_far, int p_eye, float p_intraocular_dist, float p_convergence_dist);
+	void set_for_hmd(int p_eye, float p_intraocular_dist, float p_display_width, float p_display_to_lens, float p_oversample, float p_z_near, float p_z_far);
+	void set_frustum(float p_left, float p_right, float p_top, float p_bottom, float p_z_near, float p_z_far);
 
 	void make_current();
 	void clear_current();
@@ -112,6 +125,10 @@ public:
 	float get_size() const;
 	float get_zfar() const;
 	float get_znear() const;
+	float get_left() const;
+	float get_right() const;
+	float get_top() const;
+	float get_bottom() const;
 	Projection get_projection() const;
 
 	virtual Transform get_camera_transform() const;
@@ -145,6 +162,7 @@ public:
 };
 
 VARIANT_ENUM_CAST(Camera::Projection);
+VARIANT_ENUM_CAST(Camera::Eye);
 VARIANT_ENUM_CAST(Camera::KeepAspect);
 
 #endif

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -1622,7 +1622,6 @@ void VisualServerRaster::camera_set_perspective(RID p_camera,float p_fovy_degree
 	camera->fov=p_fovy_degrees;
 	camera->znear=p_z_near;
 	camera->zfar=p_z_far;
-
 }
 
 void VisualServerRaster::camera_set_orthogonal(RID p_camera,float p_size, float p_z_near, float p_z_far) {
@@ -1631,6 +1630,16 @@ void VisualServerRaster::camera_set_orthogonal(RID p_camera,float p_size, float 
 	ERR_FAIL_COND(!camera);
 	camera->type=Camera::ORTHOGONAL;
 	camera->size=p_size;
+	camera->znear=p_z_near;
+	camera->zfar=p_z_far;
+}
+
+void VisualServerRaster::camera_set_frustum(RID p_camera, const Frustum& p_frustum, float p_z_near, float p_z_far) {
+	VS_CHANGED;
+	Camera *camera = camera_owner.get( p_camera );
+	ERR_FAIL_COND(!camera);
+	camera->type=Camera::FRUSTUM;
+	camera->frustum=p_frustum;
 	camera->znear=p_z_near;
 	camera->zfar=p_z_far;
 }
@@ -1692,7 +1701,6 @@ bool VisualServerRaster::camera_is_using_vertical_aspect(RID p_camera,bool p_ena
 	return camera->vaspect;
 
 }
-
 
 /* VIEWPORT API */
 
@@ -5019,6 +5027,15 @@ Vector<Vector3> VisualServerRaster::_camera_generate_endpoints(Instance *p_light
 			);
 
 		} break;
+		case Camera::FRUSTUM: {
+			camera_matrix = p_camera->frustum.make_camera_matrix(
+				viewport_rect.width / (float)viewport_rect.height,
+				p_camera->vaspect,
+				p_range_min,
+				p_range_max
+			);
+
+		} break;
 	}
 
 	//obtain the frustum endpoints
@@ -5145,6 +5162,19 @@ void VisualServerRaster::_light_instance_update_pssm_shadow(Instance *p_light,Sc
 
 				camera_matrix.set_perspective(
 					p_camera->fov,
+					viewport_rect.width / (float)viewport_rect.height,
+					distances[(i==0 || !overlap )?i:i-1],
+					distances[i+1],
+					p_camera->vaspect
+
+				);
+
+			} break;
+			case Camera::FRUSTUM: {
+				// FIXME well this actually changes alot in Godot 3 so maybe we don't care
+
+				camera_matrix.set_perspective(
+					60.0,
 					viewport_rect.width / (float)viewport_rect.height,
 					distances[(i==0 || !overlap )?i:i-1],
 					distances[i+1],
@@ -6627,6 +6657,15 @@ void VisualServerRaster::_render_camera(Viewport *p_viewport,Camera *p_camera, S
 			);
 			ortho=false;
 
+		} break;
+		case Camera::FRUSTUM: {
+			camera_matrix = p_camera->frustum.make_camera_matrix(
+				viewport_rect.width / (float) viewport_rect.height, 
+				p_camera->vaspect, 
+				p_camera->znear, 
+				p_camera->zfar
+			);
+			ortho=false;
 		} break;
 	}
 

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -124,16 +124,18 @@ class VisualServerRaster : public VisualServer {
 
 		enum Type {
 			PERSPECTIVE,
-			ORTHOGONAL
+			ORTHOGONAL,
+			FRUSTUM
 		};
 		Type type;
 		float fov;
-		float znear,zfar;
+		float znear, zfar;
 		float size;
 		uint32_t visible_layers;
 		bool vaspect;
 		RID env;
 
+		Frustum frustum;
 		Transform transform;
 
 		Camera() {
@@ -875,6 +877,7 @@ public:
 	BIND0R(RID, camera_create)
 	BIND4(camera_set_perspective, RID, float, float, float)
 	BIND4(camera_set_orthogonal, RID, float, float, float)
+	BIND4(camera_set_frustum, RID, const Frustum &, float, float)
 	BIND2(camera_set_transform, RID, const Transform &)
 	BIND2(camera_set_cull_mask, RID, uint32_t)
 	BIND2(camera_set_environment, RID, RID)

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -59,6 +59,16 @@ void VisualServerScene::camera_set_orthogonal(RID p_camera, float p_size, float 
 	camera->zfar = p_z_far;
 }
 
+void VisualServerScene::camera_set_frustum(RID p_camera, const Frustum &p_frustum, float p_z_near, float p_z_far) {
+
+	Camera *camera = camera_owner.get(p_camera);
+	ERR_FAIL_COND(!camera);
+	camera->type = Camera::FRUSTUM;
+	camera->frustum = p_frustum;
+	camera->znear = p_z_near;
+	camera->zfar = p_z_far;
+}
+
 void VisualServerScene::camera_set_transform(RID p_camera, const Transform &p_transform) {
 
 	Camera *camera = camera_owner.get(p_camera);
@@ -1653,6 +1663,18 @@ void VisualServerScene::render_camera(RID p_camera, RID p_scenario, Size2 p_view
 					camera->znear,
 					camera->zfar,
 					camera->vaspect
+
+					);
+			ortho = false;
+
+		} break;
+
+		case Camera::FRUSTUM: {
+			camera_matrix = camera->frustum.make_camera_matrix(
+					p_viewport_size.width / (float)p_viewport_size.height,
+					camera->vaspect,
+					camera->znear,
+					camera->zfar
 
 					);
 			ortho = false;

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -103,7 +103,8 @@ public:
 
 		enum Type {
 			PERSPECTIVE,
-			ORTHOGONAL
+			ORTHOGONAL,
+			FRUSTUM
 		};
 		Type type;
 		float fov;
@@ -113,6 +114,7 @@ public:
 		bool vaspect;
 		RID env;
 
+		Frustum frustum;
 		Transform transform;
 
 		Camera() {
@@ -132,6 +134,7 @@ public:
 	virtual RID camera_create();
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far);
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far);
+	virtual void camera_set_frustum(RID p_camera, const Frustum &p_frustum, float p_z_near, float p_z_far);
 	virtual void camera_set_transform(RID p_camera, const Transform &p_transform);
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers);
 	virtual void camera_set_environment(RID p_camera, RID p_env);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -31,6 +31,7 @@
 #define VISUAL_SERVER_H
 
 #include "bsp_tree.h"
+#include "frustum.h"
 #include "geometry.h"
 #include "image.h"
 #include "math_2d.h"
@@ -506,6 +507,7 @@ public:
 	virtual RID camera_create() = 0;
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
+	virtual void camera_set_frustum(RID p_camera, const Frustum &p_frustum, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_transform(RID p_camera, const Transform &p_transform) = 0;
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers) = 0;
 	virtual void camera_set_environment(RID p_camera, RID p_env) = 0;


### PR DESCRIPTION
These changes introduce a new camera mode to the camera object in Godot so it can be set as a uniform left/right/top/bottom frustum. The main reason for this is to allow asymmetrical frustums which is not possible with the normal camera settings but this is needed for left eye / right eye stereoscopic rendering. 

Note that the frustum is defined at unit distance NOT at the near plane. This allows the near and far plane to be adjusted without needing to change the frustum values themselves.
Also keep in mind that Godot will apply the aspect ratio of the viewport you are rendering to, you should not apply the aspect ratio to the frustum yourself (many textbook FOV -> frustum calculations will do this).

To help with this the PR also introduces a few functions on the camera that allow you to set the frustum based on the intraoculur distance (distance between the two eyes) and convergence distance (distance at which they eyes converge, basically anything in front of this will seem to pop out towards you, anything behind this distance will be seen as in depth).

I've got a little test project here:
https://github.com/BastiaanOlij/StereoCameraTest
This shows the stereoscopic rendering of two eyes to a split screen. I'll be adding on to this sample project in due time to highlight some of the differences between rendering for an HMD (if you want to use this for cardboard like mobile solutions) and stereo rendering on a 3D TV. 