### PR TITLE
Select exactly matched file automatically in FileDialog

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -403,11 +403,12 @@ void FileDialog::update_file_list() {
 	while(!files.empty()) {
 
 		bool match=patterns.empty();
+		String match_str;
 
 		for(List<String>::Element *E=patterns.front();E;E=E->next()) {
 
 			if (files.front()->get().matchn(E->get())) {
-
+				match_str=E->get();
 				match=true;
 				break;
 			}
@@ -432,14 +433,14 @@ void FileDialog::update_file_list() {
 			d["dir"]=false;
 			ti->set_metadata(0,d);
 
-			if (file->get_text()==files.front()->get())
+			if (file->get_text()==files.front()->get() || match_str==files.front()->get())
 				ti->select(0);
 		}
 
 		files.pop_front();
 	}
 
-	if (tree->get_root() && tree->get_root()->get_children())
+	if (tree->get_root() && tree->get_root()->get_children() && tree->get_selected()==NULL)
 		tree->get_root()->get_children()->select(0);
 
 	files.clear();


### PR DESCRIPTION
So, it will improve usability like when importing project.

![peek 2016-11-15 22-47](https://cloud.githubusercontent.com/assets/8281454/20308114/dd232eb2-ab85-11e6-944f-aa3de285384b.gif)
