### PR TITLE
Core motion implementation for iPhone (Accelerometer/Gyro/Magnetometer support)

### DIFF
--- a/core/os/input.cpp
+++ b/core/os/input.cpp
@@ -70,6 +70,7 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(_MD("get_joy_axis_index_from_string", "axis"), &Input::get_joy_axis_index_from_string);
 	ClassDB::bind_method(_MD("start_joy_vibration", "device", "weak_magnitude", "strong_magnitude", "duration"), &Input::start_joy_vibration, DEFVAL(0));
 	ClassDB::bind_method(_MD("stop_joy_vibration", "device"), &Input::stop_joy_vibration);
+	ClassDB::bind_method(_MD("get_gravity"),&Input::get_gravity);
 	ClassDB::bind_method(_MD("get_accelerometer"),&Input::get_accelerometer);
 	ClassDB::bind_method(_MD("get_magnetometer"),&Input::get_magnetometer);
 	ClassDB::bind_method(_MD("get_gyroscope"),&Input::get_gyroscope);

--- a/core/os/input.h
+++ b/core/os/input.h
@@ -82,6 +82,7 @@ public:
 
 	virtual void warp_mouse_pos(const Vector2& p_to)=0;
 
+	virtual Vector3 get_gravity() const=0;
 	virtual Vector3 get_accelerometer() const=0;
 	virtual Vector3 get_magnetometer() const=0;
 	virtual Vector3 get_gyroscope() const=0;

--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -277,6 +277,12 @@ void InputDefault::joy_connection_changed(int p_idx, bool p_connected, String p_
 	emit_signal("joy_connection_changed", p_idx, p_connected);
 };
 
+Vector3 InputDefault::get_gravity() const{
+
+	_THREAD_SAFE_METHOD_
+	return gravity;
+}
+
 Vector3 InputDefault::get_accelerometer() const{
 
 	_THREAD_SAFE_METHOD_
@@ -421,6 +427,14 @@ void InputDefault::stop_joy_vibration(int p_device) {
 	vibration.duration = 0;
 	vibration.timestamp = OS::get_singleton()->get_ticks_usec();
 	joy_vibration[p_device] = vibration;
+}
+
+void InputDefault::set_gravity(const Vector3& p_gravity) {
+
+	_THREAD_SAFE_METHOD_
+
+	gravity=p_gravity;
+
 }
 
 void InputDefault::set_accelerometer(const Vector3& p_accel) {

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -44,6 +44,7 @@ class InputDefault : public Input {
 	Set<int> joy_buttons_pressed;
 	Map<int,float> _joy_axis;
 	//Map<StringName,int> custom_action_press;
+	Vector3 gravity;
 	Vector3 accelerometer;
 	Vector3 magnetometer;
 	Vector3 gyroscope;
@@ -191,6 +192,7 @@ public:
 	void joy_connection_changed(int p_idx, bool p_connected, String p_name, String p_guid = "");
 	void parse_joypad_mapping(String p_mapping, bool p_update_existing);
 
+	virtual Vector3 get_gravity() const;
 	virtual Vector3 get_accelerometer() const;
 	virtual Vector3 get_magnetometer() const;
 	virtual Vector3 get_gyroscope() const;
@@ -203,6 +205,7 @@ public:
 
 
 	void parse_input_event(const InputEvent& p_event);
+	void set_gravity(const Vector3& p_gravity);
 	void set_accelerometer(const Vector3& p_accel);
 	void set_magnetometer(const Vector3& p_magnetometer);
 	void set_gyroscope(const Vector3& p_gyroscope);

--- a/platform/iphone/app_delegate.h
+++ b/platform/iphone/app_delegate.h
@@ -30,11 +30,16 @@
 #import "gl_view.h"
 #import "view_controller.h"
 
-@interface AppDelegate : NSObject <UIApplicationDelegate, UIAccelerometerDelegate, GLViewDelegate> {
+// Old accelerometer approach deprecated since IOS 7.0
+// Include coremotion for accelerometer, gyroscope and magnetometer access, available since IOS 4.0 but some functionality won't work for anything before IOS 5.0
+#import <CoreMotion/CoreMotion.h>
+
+//@interface AppDelegate : NSObject <UIApplicationDelegate, UIAccelerometerDelegate, GLViewDelegate> {
+@interface AppDelegate : NSObject <UIApplicationDelegate, GLViewDelegate> {
 	//@property (strong, nonatomic) UIWindow *window;
 	ViewController* view_controller;
-	UIAccelerationValue accel[3];
-	UIAccelerationValue last_accel[3];
+//	UIAccelerationValue accel[3];
+//	UIAccelerationValue last_accel[3];
 };
 
 @property (strong, nonatomic) UIWindow *window;

--- a/platform/iphone/app_delegate.h
+++ b/platform/iphone/app_delegate.h
@@ -34,12 +34,9 @@
 // Include coremotion for accelerometer, gyroscope and magnetometer access, available since IOS 4.0 but some functionality won't work for anything before IOS 5.0
 #import <CoreMotion/CoreMotion.h>
 
-//@interface AppDelegate : NSObject <UIApplicationDelegate, UIAccelerometerDelegate, GLViewDelegate> {
 @interface AppDelegate : NSObject <UIApplicationDelegate, GLViewDelegate> {
 	//@property (strong, nonatomic) UIWindow *window;
 	ViewController* view_controller;
-//	UIAccelerationValue accel[3];
-//	UIAccelerationValue last_accel[3];
 };
 
 @property (strong, nonatomic) UIWindow *window;

--- a/platform/iphone/app_delegate.mm
+++ b/platform/iphone/app_delegate.mm
@@ -84,6 +84,9 @@ extern char** gargv;
 extern int iphone_main(int, int, int, char**);
 extern void iphone_finish();
 
+CMMotionManager *motionManager;
+bool motionInitialised; 
+
 static ViewController* mainViewController = nil;
 + (ViewController*) getViewController
 {
@@ -195,7 +198,22 @@ static int frame_count = 0;
 	default: {
 
 		if (OSIPhone::get_singleton()) {
-			OSIPhone::get_singleton()->update_accelerometer(accel[0], accel[1], accel[2]);
+//			OSIPhone::get_singleton()->update_accelerometer(accel[0], accel[1], accel[2]);
+			if (motionInitialised) {
+				// Just using polling approach for now, we can set this up so it sends data to us in intervals, might be better.
+				// See Apple reference pages for more details:
+				// https://developer.apple.com/reference/coremotion/cmmotionmanager?language=objc
+				CMAcceleration acceleration = motionManager.deviceMotion.userAcceleration;
+				OSIPhone::get_singleton()->update_accelerometer(acceleration.x, acceleration.y, acceleration.z);
+
+				CMMagneticField magnetic = motionManager.deviceMotion.magneticField.field;
+				OSIPhone::get_singleton()->update_magnetometer(magnetic.x, magnetic.y, magnetic.z);
+
+				///@TODO we can access rotationRate as a CMRotationRate variable (processed date) or CMGyroData (raw data), have to see what works best
+				CMRotationRate rotation = motionManager.deviceMotion.rotationRate;
+				OSIPhone::get_singleton()->update_gyroscope(rotation.x, rotation.y, rotation.z);
+			}
+
 			bool quit_request = OSIPhone::get_singleton()->iterate();
 		};
 
@@ -253,11 +271,24 @@ static int frame_count = 0;
 	[window makeKeyAndVisible];
 
 	//Configure and start accelerometer
+/*
+  Old accelerometer approach deprecated since IOS 7.0
+
 	last_accel[0] = 0;
 	last_accel[1] = 0;
 	last_accel[2] = 0;
 	[[UIAccelerometer sharedAccelerometer] setUpdateInterval:(1.0 / kAccelerometerFrequency)];
 	[[UIAccelerometer sharedAccelerometer] setDelegate:self];
+*/
+
+	if (!motionInitialised) {
+		motionManager = [[CMMotionManager alloc] init];
+		if (motionManager.deviceMotionAvailable) {
+      motionManager.deviceMotionUpdateInterval = 1.0/70.0;
+      [motionManager startDeviceMotionUpdates];			
+			motionInitialised = YES;
+		};
+	};
 
 	//OSIPhone::screen_width = rect.size.width - rect.origin.x;
 	//OSIPhone::screen_height = rect.size.height - rect.origin.y;
@@ -297,12 +328,23 @@ static int frame_count = 0;
 - (void)applicationWillTerminate:(UIApplication*)application {
 
 	printf("********************* will terminate\n");
+
+	if (motionInitialised) {
+		///@TODO is this the right place to clean this up?
+    [motionManager stopDeviceMotionUpdates];
+    // no free ?
+    motionManager = nil;
+    motionInitialised = NO;	
+	};
+
 	iphone_finish();
 };
 
 - (void)applicationDidEnterBackground:(UIApplication *)application
 {
 	printf("********************* did enter background\n");
+	///@TODO maybe add pause motionManager? and where would we unpause it?
+
 	if (OS::get_singleton()->get_main_loop())
 		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_WM_FOCUS_OUT);
 	[view_controller.view stopAnimation];
@@ -340,12 +382,15 @@ static int frame_count = 0;
 	};
 }
 
+/*
+  Depricated since IOS 7.0
 - (void)accelerometer:(UIAccelerometer*)accelerometer didAccelerate:(UIAcceleration*)acceleration {
 	//Use a basic low-pass filter to only keep the gravity in the accelerometer values
 	accel[0] = acceleration.x; // * kFilteringFactor + accel[0] * (1.0 - kFilteringFactor);
 	accel[1] = acceleration.y; // * kFilteringFactor + accel[1] * (1.0 - kFilteringFactor);
 	accel[2] = acceleration.z; // * kFilteringFactor + accel[2] * (1.0 - kFilteringFactor);
 }
+*/
 
 - (BOOL)application:(UIApplication *)application handleOpenURL:(NSURL *)url {
 #ifdef MODULE_FACEBOOKSCORER_IOS_ENABLED

--- a/platform/iphone/app_delegate.mm
+++ b/platform/iphone/app_delegate.mm
@@ -203,8 +203,11 @@ static int frame_count = 0;
 				// Just using polling approach for now, we can set this up so it sends data to us in intervals, might be better.
 				// See Apple reference pages for more details:
 				// https://developer.apple.com/reference/coremotion/cmmotionmanager?language=objc
+
+				// Apple splits our accelerometer date into a gravity and user movement component. We add them back together
+				CMAcceleration gravity = motionManager.deviceMotion.gravity;
 				CMAcceleration acceleration = motionManager.deviceMotion.userAcceleration;
-				OSIPhone::get_singleton()->update_accelerometer(acceleration.x, acceleration.y, acceleration.z);
+				OSIPhone::get_singleton()->update_accelerometer(acceleration.x + gravity.x, acceleration.y + gravity.y, acceleration.z + gravity.z);
 
 				CMMagneticField magnetic = motionManager.deviceMotion.magneticField.field;
 				OSIPhone::get_singleton()->update_magnetometer(magnetic.x, magnetic.y, magnetic.z);

--- a/platform/iphone/app_delegate.mm
+++ b/platform/iphone/app_delegate.mm
@@ -332,7 +332,7 @@ static int frame_count = 0;
 	if (motionInitialised) {
 		///@TODO is this the right place to clean this up?
     [motionManager stopDeviceMotionUpdates];
-    // no free ?
+    [motionManager release];
     motionManager = nil;
     motionInitialised = NO;	
 	};

--- a/platform/iphone/app_delegate.mm
+++ b/platform/iphone/app_delegate.mm
@@ -218,25 +218,29 @@ static int frame_count = 0;
 				// a good thing when you're trying to get your user to move the screen in all directions and want consistent output
 
 				///@TODO Using [[UIApplication sharedApplication] statusBarOrientation] is a bit of a hack. Godot obviously knows the orientation so maybe we 
-				// can use that instead?
+				// can use that instead? (note that left and right seem swapped)
 
 				switch ([[UIApplication sharedApplication] statusBarOrientation]) {
 				case UIDeviceOrientationLandscapeLeft: {
-					OSIPhone::get_singleton()->update_accelerometer(-(acceleration.y + gravity.y), acceleration.x + gravity.x, acceleration.z + gravity.z);
+					OSIPhone::get_singleton()->update_gravity(-gravity.y, gravity.x, gravity.z);
+					OSIPhone::get_singleton()->update_accelerometer(-(acceleration.y + gravity.y), (acceleration.x + gravity.x), acceleration.z + gravity.z);
 					OSIPhone::get_singleton()->update_magnetometer(-magnetic.y, magnetic.x, magnetic.z);
 					OSIPhone::get_singleton()->update_gyroscope(-rotation.y, rotation.x, rotation.z);
 				}; break;
 				case UIDeviceOrientationLandscapeRight: {
-					OSIPhone::get_singleton()->update_accelerometer(acceleration.y + gravity.y, acceleration.x + gravity.x, acceleration.z + gravity.z);
-					OSIPhone::get_singleton()->update_magnetometer(magnetic.y, magnetic.x, magnetic.z);
-					OSIPhone::get_singleton()->update_gyroscope(rotation.y, rotation.x, rotation.z);
+					OSIPhone::get_singleton()->update_gravity(gravity.y, -gravity.x, gravity.z);
+					OSIPhone::get_singleton()->update_accelerometer((acceleration.y + gravity.y), -(acceleration.x + gravity.x), acceleration.z + gravity.z);
+					OSIPhone::get_singleton()->update_magnetometer(magnetic.y, -magnetic.x, magnetic.z);
+					OSIPhone::get_singleton()->update_gyroscope(rotation.y, -rotation.x, rotation.z);
 				}; break;
 				case UIDeviceOrientationPortraitUpsideDown: {
-					OSIPhone::get_singleton()->update_accelerometer(-(acceleration.x + gravity.x), acceleration.y + gravity.y, acceleration.z + gravity.z);
+					OSIPhone::get_singleton()->update_gravity(-gravity.x, gravity.y, gravity.z);
+					OSIPhone::get_singleton()->update_accelerometer(-(acceleration.x + gravity.x), (acceleration.y + gravity.y), acceleration.z + gravity.z);
 					OSIPhone::get_singleton()->update_magnetometer(-magnetic.x, magnetic.y, magnetic.z);
 					OSIPhone::get_singleton()->update_gyroscope(-rotation.x, rotation.y, rotation.z);
 				}; break;
 				default: { // assume portrait
+					OSIPhone::get_singleton()->update_gravity(gravity.x, gravity.y, gravity.z);
 					OSIPhone::get_singleton()->update_accelerometer(acceleration.x + gravity.x, acceleration.y + gravity.y, acceleration.z + gravity.z);
 					OSIPhone::get_singleton()->update_magnetometer(magnetic.x, magnetic.y, magnetic.z);
 					OSIPhone::get_singleton()->update_gyroscope(rotation.x, rotation.y, rotation.z);

--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -83,6 +83,7 @@ def configure(env):
                               '-framework', 'CoreAudio',
                               '-framework', 'CoreGraphics',
                               '-framework', 'CoreMedia',
+                              '-framework', 'CoreMotion',
                               '-framework', 'Foundation',
                               '-framework', 'Security',
                               '-framework', 'UIKit',
@@ -109,6 +110,7 @@ def configure(env):
                                                 '-framework', 'MediaPlayer',
                                                 '-framework', 'AVFoundation',
                                                 '-framework', 'CoreMedia',
+                                                '-framework', 'CoreMotion',
                               ])
     else:
         env.Append(LINKFLAGS=['-arch', 'armv7', '-Wl,-dead_strip', '-miphoneos-version-min=5.1.1',
@@ -126,6 +128,7 @@ def configure(env):
                                                 '-framework', 'MediaPlayer',
                                                 '-framework', 'AVFoundation',
                                                 '-framework', 'CoreMedia',
+                                                '-framework', 'CoreMotion',
                               ])
 
     if env['game_center'] == 'yes':

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -325,6 +325,7 @@ static const float ACCEL_RANGE = 1;
 
 void OSIPhone::update_accelerometer(float p_x, float p_y, float p_z) {
 
+	///@TODO I've made the Z negative like the original accelerometer code, this probably needs more work
 	input->set_accelerometer(Vector3(p_x / (float)ACCEL_RANGE, p_y / (float)ACCEL_RANGE, -p_z / (float)ACCEL_RANGE));
 
 	/*
@@ -365,11 +366,13 @@ void OSIPhone::update_accelerometer(float p_x, float p_y, float p_z) {
 };
 
 void OSIPhone::update_magnetometer(float p_x, float p_y, float p_z) {
-	input->set_magnetometer(Vector3(p_x, p_y, p_z));
+	///@TODO I've made the Z negative like the original accelerometer code, this probably needs more work
+	input->set_magnetometer(Vector3(p_x, p_y, -p_z));
 };
 
 void OSIPhone::update_gyroscope(float p_x, float p_y, float p_z) {
-	input->set_gyroscope(Vector3(p_x, p_y, p_z));
+	///@TODO I've made the Z negative like the original accelerometer code, this probably needs more work
+	input->set_gyroscope(Vector3(p_x, p_y, -p_z));
 };
 
 void OSIPhone::delete_main_loop() {

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -364,7 +364,13 @@ void OSIPhone::update_accelerometer(float p_x, float p_y, float p_z) {
 	*/
 };
 
+void OSIPhone::update_magnetometer(float p_x, float p_y, float p_z) {
+	input->set_magnetometer(Vector3(p_x, p_y, p_z));
+};
 
+void OSIPhone::update_gyroscope(float p_x, float p_y, float p_z) {
+	input->set_gyroscope(Vector3(p_x, p_y, p_z));
+};
 
 void OSIPhone::delete_main_loop() {
 

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -323,6 +323,10 @@ void OSIPhone::touches_cancelled() {
 
 static const float ACCEL_RANGE = 1;
 
+void OSIPhone::update_gravity(float p_x, float p_y, float p_z) {
+	input->set_gravity(Vector3(p_x, p_y, p_z));
+};
+
 void OSIPhone::update_accelerometer(float p_x, float p_y, float p_z) {
 
 	// Found out the Z should not be negated! Pass as is!

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -325,8 +325,8 @@ static const float ACCEL_RANGE = 1;
 
 void OSIPhone::update_accelerometer(float p_x, float p_y, float p_z) {
 
-	///@TODO I've made the Z negative like the original accelerometer code, this probably needs more work
-	input->set_accelerometer(Vector3(p_x / (float)ACCEL_RANGE, p_y / (float)ACCEL_RANGE, -p_z / (float)ACCEL_RANGE));
+	// Found out the Z should not be negated! Pass as is!
+	input->set_accelerometer(Vector3(p_x / (float)ACCEL_RANGE, p_y / (float)ACCEL_RANGE, p_z / (float)ACCEL_RANGE));
 
 	/*
 	if (p_x != last_accel.x) {
@@ -366,8 +366,7 @@ void OSIPhone::update_accelerometer(float p_x, float p_y, float p_z) {
 };
 
 void OSIPhone::update_magnetometer(float p_x, float p_y, float p_z) {
-	///@TODO I've made the Z negative like the original accelerometer code, this probably needs more work
-	input->set_magnetometer(Vector3(p_x, p_y, -p_z));
+	input->set_magnetometer(Vector3(p_x, p_y, p_z));
 };
 
 void OSIPhone::update_gyroscope(float p_x, float p_y, float p_z) {

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -371,8 +371,7 @@ void OSIPhone::update_magnetometer(float p_x, float p_y, float p_z) {
 };
 
 void OSIPhone::update_gyroscope(float p_x, float p_y, float p_z) {
-	///@TODO I've made the Z negative like the original accelerometer code, this probably needs more work
-	input->set_gyroscope(Vector3(p_x, p_y, -p_z));
+	input->set_gyroscope(Vector3(p_x, p_y, p_z));
 };
 
 void OSIPhone::delete_main_loop() {

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -152,6 +152,7 @@ public:
 
 	int set_base_framebuffer(int p_fb);
 
+	void update_gravity(float p_x, float p_y, float p_z);
 	void update_accelerometer(float p_x, float p_y, float p_z);
 	void update_magnetometer(float p_x, float p_y, float p_z);
 	void update_gyroscope(float p_x, float p_y, float p_z);

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -153,6 +153,8 @@ public:
 	int set_base_framebuffer(int p_fb);
 
 	void update_accelerometer(float p_x, float p_y, float p_z);
+	void update_magnetometer(float p_x, float p_y, float p_z);
+	void update_gyroscope(float p_x, float p_y, float p_z);
 
 	static OSIPhone* get_singleton();
 


### PR DESCRIPTION
These changes replace the now deprecated UIAccelerometer implementation with one using the newer CoreMotion, specifically implementing CMDeviceMotion. This adds gyro and magnetometer data to the iPhone platform. 

I've gone for a simple polling approach, CMDeviceMotion does have an option for pushing data but I'm not sure if there is any added benefit.

The accelerometer data is split into a user vector and gravity vector by iOS but I add them together again so it behaves as before.

The gyro seems to work but testing an app that was build for the Android platform the axis seem flipped. Without an Android device to compare output with I'm not entirely sure how to best deal with this. 

I have not been able to test the magnetometer output, my iPhone 5 doesn't seem to be giving any output though that may be a fault on my side in testing.