### PR TITLE
Do not enter _ready twice

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -22621,7 +22621,7 @@
 		Nodes are the base bricks with which Godot games are developed. They can be set as children of other nodes, resulting in a tree arrangement. A given node can contain any number of nodes as children (but there is only one scene tree root node) with the requirement that all siblings (direct children of a node) should have unique names.
 		Any tree of nodes is called a [i]scene[/i]. Scenes can be saved to the disk and then instanced into other scenes. This allows for very high flexibility in the architecture and data model of the projects. Nodes can optionally be added to groups. This makes it easy to reach a number of nodes from the code (for example an "enemies" group) to perform grouped actions.
 		[b]Scene tree:[/b] The [SceneTree] contains the active tree of nodes. When a node is added to the scene tree, it receives the NOTIFICATION_ENTER_TREE notification and its [method _enter_tree] callback is triggered. Children nodes are always added [i]after[/i] their parent node, i.e. the [method _enter_tree] callback of a parent node will be triggered before its child's.
-		Once all nodes have been added in the scene tree, they receive the NOTIFICATION_READY notification and their respective [method _ready] callbacks are triggered. For groups of nodes, the [method _ready] callback is called in reverse order, from the children up to the parent nodes.
+		Once all nodes have been added in the scene tree for the first time, they receive the NOTIFICATION_READY notification and their respective [method _ready] callbacks are triggered. For groups of nodes, the [method _ready] callback is called in reverse order, from the children up to the parent nodes.
 		It means that when adding a scene to the scene tree, the following order will be used for the callbacks: [method _enter_tree] of the parent, [method _enter_tree] of the children, [method _ready] of the children and finally [method _ready] of the parent (and that recursively for the whole scene).
 		[b]Processing:[/b] Nodes can be set to the "process" state, so that they receive a callback on each frame requesting them to process (do something). Normal processing (callback [method _process], toggled with [method set_process]) happens as fast as possible and is dependent on the frame rate, so the processing time [i]delta[/i] is variable. Fixed processing (callback [method _fixed_process], toggled with [method set_fixed_process]) happens a fixed amount of times per second (by default 60) and is useful to link itself to the physics.
 		Nodes can also process input events. When set, the [method _input] function will be called for each input that the program receives. In many cases, this can be overkill (unless used for simple projects), and the [method _unhandled_input] function might be preferred; it is called when the input event was not handled by anyone else (typically, GUI [Control] nodes), ensuring that the node only receives the events that were meant for it.
@@ -23255,6 +23255,7 @@
 		<constant name="NOTIFICATION_MOVED_IN_PARENT" value="12">
 		</constant>
 		<constant name="NOTIFICATION_READY" value="13">
+			Notification received the first time the object is added into the scene tree, but after all it's children have received it.
 		</constant>
 		<constant name="NOTIFICATION_FIXED_PROCESS" value="16">
 		</constant>

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -166,6 +166,7 @@ void Node::_notification(int p_notification) {
 
 void Node::_propagate_ready() {
 
+	data.ready_notified=true;
 	data.blocked++;
 	for (int i=0;i<data.children.size();i++) {
 
@@ -2662,7 +2663,9 @@ void Node::_set_tree(SceneTree *p_tree) {
 
 
 		_propagate_enter_tree();
-		_propagate_ready(); //reverse_notification(NOTIFICATION_READY);
+		if (!data.parent || data.parent->data.ready_notified) { // No parent (root) or parent ready
+			_propagate_ready(); //reverse_notification(NOTIFICATION_READY);
+		}
 
 		tree_changed_b=data.tree;
 
@@ -2999,6 +3002,7 @@ Node::Node() {
 	data.fixed_process=false;
 	data.idle_process=false;
 	data.inside_tree=false;
+	data.ready_notified=false;
 
 	data.owner=NULL;
 	data.OW=NULL;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -166,14 +166,16 @@ void Node::_notification(int p_notification) {
 
 void Node::_propagate_ready() {
 
-	data.ready_notified=true;
 	data.blocked++;
 	for (int i=0;i<data.children.size();i++) {
 
 		data.children[i]->_propagate_ready();
 	}
 	data.blocked--;
-	notification(NOTIFICATION_READY);
+	if(!data.ready_notified) {
+		data.ready_notified=true;
+		notification(NOTIFICATION_READY);
+	}
 
 }
 
@@ -2663,9 +2665,7 @@ void Node::_set_tree(SceneTree *p_tree) {
 
 
 		_propagate_enter_tree();
-		if (!data.parent || data.parent->data.ready_notified) { // No parent (root) or parent ready
-			_propagate_ready(); //reverse_notification(NOTIFICATION_READY);
-		}
+		_propagate_ready(); //reverse_notification(NOTIFICATION_READY);
 
 		tree_changed_b=data.tree;
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -103,6 +103,7 @@ private:
 		StringName name;
 		SceneTree *tree;
 		bool inside_tree;
+		bool ready_notified;
 #ifdef TOOLS_ENABLED
 		NodePath import_path; //path used when imported, used by scene editors to keep tracking
 #endif


### PR DESCRIPTION
There are two commits in this PR -- the first guards only against a special case of `add_child` inside `_enter_tree`, while the second one guards against all cases.

Because of this, this PR is going to break some projects (and maybe AnimationPlayer/Tween/Joint2D as well, who knows..).
But, the first commit fixes a buggy behavior, so it can (and maybe should) be backported to 2.x.