### PR TITLE
fixes #6464 lost icons in dock and file dialog, also #6443 , #6302

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -480,10 +480,10 @@ void Control::_notification(int p_notification) {
 			if (is_set_as_toplevel()) {
 				data.SI=get_viewport()->_gui_add_subwindow_control(this);
 
-				/*if (data.theme.is_null() && data.parent && data.parent->data.theme_owner) {
+				if (data.theme.is_null() && data.parent && data.parent->data.theme_owner) {
 					data.theme_owner=data.parent->data.theme_owner;
 					notification(NOTIFICATION_THEME_CHANGED);
-				}*/
+				}
 
 			} else {
 
@@ -519,10 +519,10 @@ void Control::_notification(int p_notification) {
 
 				if (parent_control) {
 					//do nothing, has a parent control
-					/*if (data.theme.is_null() && parent_control->data.theme_owner) {
+					if (data.theme.is_null() && parent_control->data.theme_owner) {
 						data.theme_owner=parent_control->data.theme_owner;
 						notification(NOTIFICATION_THEME_CHANGED);
-					}*/
+					}
 				} else if (subwindow) {
 					//is a subwindow (process input before other controls for that canvas)
 					data.SI=get_viewport()->_gui_add_subwindow_control(this);


### PR DESCRIPTION
Fixes lost icons in docks, file manager, sample library, settings and various other places.

image shows testing of changing layout while no icons vanish anywhere.

![icons_mov1](https://cloud.githubusercontent.com/assets/3224132/20421036/c69bb172-ad61-11e6-9611-d6e9ab0292f9.gif)


(_bugsquad edit_) Fixes #6464
