### PR TITLE
Flat button support in ButtonArray. Fixes #7153

### DIFF
--- a/scene/gui/button_array.cpp
+++ b/scene/gui/button_array.cpp
@@ -267,9 +267,9 @@ void ButtonArray::_notification(int p_what) {
 				} else {
 					if (hover==i)
 						draw_style_box(style_hover,r);
-					else
+					else if (!flat)
 						draw_style_box(style_normal,r);
-					sbsize=style_selected->get_minimum_size();
+					sbsize=style_normal->get_minimum_size();
 					sbofs=style_normal->get_offset();
 					f=font_normal;
 					c=color_normal;
@@ -386,6 +386,17 @@ void ButtonArray::set_align(Align p_align) {
 ButtonArray::Align ButtonArray::get_align() const {
 
 	return align;
+}
+
+void ButtonArray::set_flat(bool p_flat) {
+
+	flat=p_flat;
+	update();
+}
+
+bool ButtonArray::is_flat() const {
+
+	return flat;
 }
 
 
@@ -525,6 +536,8 @@ void ButtonArray::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_button_tooltip","button_idx"),&ButtonArray::get_button_tooltip);
 	ObjectTypeDB::bind_method(_MD("get_button_icon:Texture","button_idx"),&ButtonArray::get_button_icon);
 	ObjectTypeDB::bind_method(_MD("get_button_count"),&ButtonArray::get_button_count);
+	ObjectTypeDB::bind_method(_MD("set_flat","enabled"),&ButtonArray::set_flat);
+	ObjectTypeDB::bind_method(_MD("is_flat"),&ButtonArray::is_flat);
 	ObjectTypeDB::bind_method(_MD("get_selected"),&ButtonArray::get_selected);
 	ObjectTypeDB::bind_method(_MD("get_hovered"),&ButtonArray::get_hovered);
 	ObjectTypeDB::bind_method(_MD("set_selected","button_idx"),&ButtonArray::set_selected);
@@ -539,6 +552,8 @@ void ButtonArray::_bind_methods() {
 	BIND_CONSTANT( ALIGN_FILL );
 	BIND_CONSTANT( ALIGN_EXPAND_FILL );
 
+	ADD_PROPERTY( PropertyInfo( Variant::BOOL, "flat" ), _SCS("set_flat"),_SCS("is_flat") );
+
 	ADD_SIGNAL( MethodInfo("button_selected",PropertyInfo(Variant::INT,"button_idx")));
 
 }
@@ -549,5 +564,6 @@ ButtonArray::ButtonArray(Orientation p_orientation) {
 	selected=-1;
 	set_focus_mode(FOCUS_ALL);
 	hover=-1;
+	flat=false;
 	min_button_size = -1;
 }

--- a/scene/gui/button_array.h
+++ b/scene/gui/button_array.h
@@ -59,6 +59,7 @@ private:
 
 	int selected;
 	int hover;
+	bool flat;
 	double min_button_size;
 
 	Vector<Button> buttons;
@@ -78,6 +79,9 @@ public:
 
 	void set_align(Align p_align);
 	Align get_align() const;
+
+	void set_flat(bool p_flat);
+	bool is_flat() const;
 
 	void add_button(const String& p_button,const String& p_tooltip="");
 	void add_icon_button(const Ref<Texture>& p_icon,const String& p_button="",const String& p_tooltip="");

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -899,10 +899,9 @@ void fill_default_theme(Ref<Theme>& t, const Ref<Font> & default_font, const Ref
 
 
 	// HButtonArray
-
-	t->set_stylebox("normal","HButtonArray", make_stylebox( button_normal_png,4,4,4,4,0,4,22,4) );
-	t->set_stylebox("selected","HButtonArray", make_stylebox( button_pressed_png,4,4,4,4,0,4,22,4) );
-	t->set_stylebox("hover","HButtonArray", make_stylebox( button_hover_png,4,4,4,4) );
+	t->set_stylebox("normal","HButtonArray", sb_button_normal);
+	t->set_stylebox("selected","HButtonArray", sb_button_pressed);
+	t->set_stylebox("hover","HButtonArray", sb_button_hover);
 
 	t->set_font("font","HButtonArray", default_font);
 	t->set_font("font_selected","HButtonArray", default_font);
@@ -910,17 +909,17 @@ void fill_default_theme(Ref<Theme>& t, const Ref<Font> & default_font, const Ref
 	t->set_color("font_color","HButtonArray", control_font_color_low );
 	t->set_color("font_color_selected","HButtonArray", control_font_color_hover );
 
-	t->set_constant("icon_separator","HButtonArray", 4 *scale );
-	t->set_constant("button_separator","HButtonArray", 8 *scale );
+	t->set_constant("icon_separator","HButtonArray", 2 *scale );
+	t->set_constant("button_separator","HButtonArray", 4 *scale );
 
 	t->set_stylebox("focus","HButtonArray", focus );
 
 
 	// VButtonArray
 
-	t->set_stylebox("normal","VButtonArray", make_stylebox( button_normal_png,4,4,4,4,0,4,22,4) );
-	t->set_stylebox("selected","VButtonArray", make_stylebox( button_pressed_png,4,4,4,4,0,4,22,4) );
-	t->set_stylebox("hover","VButtonArray", make_stylebox( button_hover_png,4,4,4,4) );
+	t->set_stylebox("normal","VButtonArray", sb_button_normal);
+	t->set_stylebox("selected","VButtonArray", sb_button_pressed);
+	t->set_stylebox("hover","VButtonArray", sb_button_hover);
 
 	t->set_font("font","VButtonArray", default_font);
 	t->set_font("font_selected","VButtonArray", default_font);
@@ -928,8 +927,8 @@ void fill_default_theme(Ref<Theme>& t, const Ref<Font> & default_font, const Ref
 	t->set_color("font_color","VButtonArray", control_font_color_low );
 	t->set_color("font_color_selected","VButtonArray", control_font_color_hover );
 
-	t->set_constant("icon_separator","VButtonArray", 4 *scale);
-	t->set_constant("button_separator","VButtonArray", 8 *scale);
+	t->set_constant("icon_separator","VButtonArray", 2 *scale);
+	t->set_constant("button_separator","VButtonArray", 4 *scale);
 
 	t->set_stylebox("focus","VButtonArray", focus );
 


### PR DESCRIPTION
Since I was working on ButtonArray recently I decided to dive in and do more tweaks. Flat rendering is now supported, fixing #7153

I've also modified the size and spacing of the default theme slightly so it should look almost the same as a list of individual buttons. I think the only visual difference now is the font colour. That said, I'm not entirely sure how people feel about this change.

Before:
![before](https://cloud.githubusercontent.com/assets/185322/20456033/dee9c292-aea5-11e6-87f6-5064d2c2bfa9.png)

After:
![after](https://cloud.githubusercontent.com/assets/185322/20456035/eb03c44c-aea5-11e6-8b40-4a9b7df0a80b.png)
