### PR TITLE
TileMap now honors blending mode.

### DIFF
--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -193,7 +193,7 @@ public:
 
 	void update();
 
-	void set_blend_mode(BlendMode p_blend_mode);
+	virtual void set_blend_mode(BlendMode p_blend_mode);
 	BlendMode get_blend_mode() const;
 
 	virtual void set_light_mask(int p_light_mask);

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -352,6 +352,7 @@ void TileMap::_update_dirty_quadrants() {
 				xform.set_origin( q.pos );
 				vs->canvas_item_set_transform( canvas_item, xform );
 				vs->canvas_item_set_light_mask(canvas_item,get_light_mask());
+				vs->canvas_item_set_blend_mode(canvas_item,VS::MaterialBlendMode(get_blend_mode()));
 
 				q.canvas_items.push_back(canvas_item);
 
@@ -1189,6 +1190,14 @@ void TileMap::set_light_mask(int p_light_mask) {
 		}
 	}
 }
+
+void TileMap::set_blend_mode(BlendMode p_blend_mode) {
+
+	CanvasItem::set_blend_mode(p_blend_mode);
+	_recreate_quadrants();
+	
+}
+
 
 void TileMap::_bind_methods() {
 

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -255,6 +255,8 @@ public:
 	void set_occluder_light_mask(int p_mask);
 	int get_occluder_light_mask() const;
 
+	void set_blend_mode(BlendMode p_blend_mode);
+
 	virtual void set_light_mask(int p_light_mask);
 
 	void clear();


### PR DESCRIPTION
Previously, blending mode was ignored.
I had to make CanvasItem::set_blending_mode virtual, to allow the TileMap refresh.