### PR TITLE
Properly localize absolute path that starts with the resource folder.

### DIFF
--- a/core/globals.cpp
+++ b/core/globals.cpp
@@ -54,7 +54,8 @@ String Globals::localize_path(const String& p_path) const {
 	if (resource_path=="")
 		return p_path; //not initialied yet
 
-	if (p_path.begins_with("res://") || p_path.begins_with("user://") || p_path.is_abs_path())
+	if (p_path.begins_with("res://") || p_path.begins_with("user://") ||
+		(p_path.is_abs_path() && !p_path.begins_with(resource_path)))
 		return p_path.simplify_path();
 
 


### PR DESCRIPTION
Calling localize_path will return a localized path in `res://` if the path starts with the resource file-system/folder, and will return the unchanged absolute path otherwise.

Closes #6979 .
Closes #7161.