### PR TITLE
Set minimum version to 10.9 building OSX

### DIFF
--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -80,10 +80,12 @@ def configure(env):
 
     env.Append(CPPFLAGS=["-DAPPLE_STYLE_KEYS"])
     env.Append(CPPFLAGS=['-DUNIX_ENABLED', '-DGLES2_ENABLED', '-DOSX_ENABLED'])
+    env.Append(CPPFLAGS=["-mmacosx-version-min=10.9"])
     env.Append(LIBS=['pthread'])
     #env.Append(CPPFLAGS=['-F/Developer/SDKs/MacOSX10.4u.sdk/System/Library/Frameworks', '-isysroot', '/Developer/SDKs/MacOSX10.4u.sdk', '-mmacosx-version-min=10.4'])
     #env.Append(LINKFLAGS=['-mmacosx-version-min=10.4', '-isysroot', '/Developer/SDKs/MacOSX10.4u.sdk', '-Wl,-syslibroot,/Developer/SDKs/MacOSX10.4u.sdk'])
     env.Append(LINKFLAGS=['-framework', 'Cocoa', '-framework', 'Carbon', '-framework', 'OpenGL', '-framework', 'AGL', '-framework', 'AudioUnit', '-lz', '-framework', 'IOKit', '-framework', 'ForceFeedback'])
+    env.Append(LINKFLAGS=["-mmacosx-version-min=10.9"])
 
     if (env["CXX"] == "clang++"):
         env.Append(CPPFLAGS=['-DTYPED_METHOD_BIND'])

--- a/tools/dist/osx_template.app/Contents/Info.plist
+++ b/tools/dist/osx_template.app/Contents/Info.plist
@@ -27,11 +27,11 @@
 	<key>NSHumanReadableCopyright</key>
 	<string>$copyright</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.6.0</string>
+	<string>10.9.0</string>
 	<key>LSMinimumSystemVersionByArchitecture</key>
 	<dict>
 		<key>x86_64</key>
-		<string>10.6.0</string>
+		<string>10.9.0</string>
 	</dict>
 	<key>NSHighResolutionCapable</key>
 	$highres

--- a/tools/dist/osx_tools.app/Contents/Info.plist
+++ b/tools/dist/osx_tools.app/Contents/Info.plist
@@ -27,11 +27,11 @@
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2007-2016 Juan Linietsky, Ariel Manzur</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.6.0</string>
+	<string>10.9.0</string>
 	<key>LSMinimumSystemVersionByArchitecture</key>
 	<dict>
 		<key>x86_64</key>
-		<string>10.6.0</string>
+		<string>10.9.0</string>
 	</dict>
 	<key>NSHighResolutionCapable</key>
 	<true/>


### PR DESCRIPTION
Since XCode 6 Apple has only supplied the latest SDK with a macro switch to support earlier versions of the OS. Without the switch the minimum supported OS seems to match the latest SDK supplied with XCode.

Ergo, compiling using XCode 6 sets the minimum to 10.9, XCode 7 to 10.11 and XCode 8 to 10.12
2.1.1 having been compiled using XCode 7 won't run on anything older then 10.11 and for those of us who had to go to XCode 8 to deploy on the latest iOS.....

This pull request sets this minimum to 10.9 resulting in the binary produced being able to run on 10.9 upwards even when compiled with XCode 8

We'll need to monitor what the earliest SDK should be, Apple isn't shy in deprecating and then removing APIs nor introducing new APIs that replace old ones so going too far back may result in breaking the build on newer platforms.