### PR TITLE
Fix snap mode selector sticking in texture region module

### DIFF
--- a/tools/editor/plugins/texture_region_editor_plugin.cpp
+++ b/tools/editor/plugins/texture_region_editor_plugin.cpp
@@ -507,8 +507,8 @@ void TextureRegionEditor::_scroll_changed(float)
 
 void TextureRegionEditor::_set_snap_mode(int p_mode)
 {
-	snap_mode = p_mode;
 	snap_mode_button->get_popup()->set_item_checked(snap_mode,false);
+	snap_mode = p_mode;
 	snap_mode_button->set_text(snap_mode_button->get_popup()->get_item_text(p_mode));
 	snap_mode_button->get_popup()->set_item_checked(snap_mode,true);
 


### PR DESCRIPTION
When changing snap mode in texture region plugin ticks was not updating. Issue was fixed by changing order of setting checked status and setting snap mode.

![screenshot](https://cloud.githubusercontent.com/assets/8849693/20644835/f9fcb654-b44d-11e6-9500-90dc54e84c46.png)

