### PR TITLE
adds gles3 auto generated shader header files to ".gitignore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ platform/osx/logo.h
 platform/windows/logo.h
 platform/x11/logo.h
 drivers/gles2/shaders/*.h
+drivers/gles3/shaders/*.h
 modules/register_module_types.cpp
 core/version.h
 core/method_bind.inc


### PR DESCRIPTION
Just added the gles3 shader header files entry to ".gitignore" so we
avoid to accidentally commit also those generated files.