### PR TITLE
Fix browser lockups in web export startup

### DIFF
--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -96,6 +96,7 @@ def configure(env):
     else:
         env.Append(CPPFLAGS=['-s', 'ASM_JS=1'])
         env.Append(LINKFLAGS=['-s', 'ASM_JS=1'])
+        env.Append(LINKFLAGS=['--separate-asm'])
 
     if env['javascript_eval'] == 'yes':
         env.Append(CPPFLAGS=['-DJAVASCRIPT_EVAL_ENABLED'])

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -320,6 +320,11 @@ Error EditorExportPlatformJavaScript::export_project(const String& p_path, bool 
 			file=p_path.get_file().basename()+".js";
 		}
 
+		if (file=="godot.asm.js") {
+
+			file=p_path.get_file().basename()+".asm.js";
+		}
+
 		if (file=="godot.mem") {
 
 			file=p_path.get_file().basename()+".mem";


### PR DESCRIPTION
This change helps prevent browser lockups during start-up in web export (asm.js) at the cost of having to distribute an extra `.asm.js` file.

When I have multiple hundreds of tabs open for several hours in Firefox, this does help, but is this issue still relevant for 'normal' users in up-to-date browsers?

Hopefully fixes #3918

Here's a demo:

 - New, with changes:
   http://godot.eska.me/temp/os-sepasm/

 - Previously, without changes:
   http://godot.eska.me/temp/os-onejs/

You'll have to clear your cache to test/compare on Firefox, including the asm.js cache:

> to clear out the asm.js cache for a given origin, click the [Site Identity Button](https://support.mozilla.org/en-US/kb/how-do-i-tell-if-my-connection-is-secure) → More Information → Permissions → (scroll down) → Clear Storage.
> https://blog.mozilla.org/luke/2014/01/14/asm-js-aot-compilation-and-startup-performance/