### PR TITLE
WebM: Fix crash when there is no audio stream

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -98,6 +98,7 @@ Files extracted from upstream source:
 ## libsimplewebm
 
 - Upstream: https://github.com/zaps166/libsimplewebm
+- Version: 05cfdc2 (git)
 - License: MIT, BSD-3-Clause
 
 

--- a/thirdparty/libsimplewebm/OpusVorbisDecoder.cpp
+++ b/thirdparty/libsimplewebm/OpusVorbisDecoder.cpp
@@ -43,16 +43,17 @@ struct VorbisDecoder
 
 OpusVorbisDecoder::OpusVorbisDecoder(const WebMDemuxer &demuxer) :
 	m_vorbis(NULL), m_opus(NULL),
-	m_numSamples(0),
-	m_channels(demuxer.getChannels())
+	m_numSamples(0)
 {
 	switch (demuxer.getAudioCodec())
 	{
 		case WebMDemuxer::AUDIO_VORBIS:
+			m_channels = demuxer.getChannels();
 			if (openVorbis(demuxer))
 				return;
 			break;
 		case WebMDemuxer::AUDIO_OPUS:
+			m_channels = demuxer.getChannels();
 			if (openOpus(demuxer))
 				return;
 			break;


### PR DESCRIPTION
Sync with libsimplewebm-git: ~~https://github.com/zaps166/libsimplewebm/commit/75a0a6c7549adeb7400856af904a962dcbbc974c~~ https://github.com/zaps166/libsimplewebm/commit/05cfdc2cc6208b313964354c76603ec6f0551a5b