### PR TITLE
Added a shortcut for faster _iter* calls supplied by modules.

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1019,6 +1019,19 @@ void Object::cancel_delete() {
 	_predelete_ok=true;
 }
 
+bool Object::_iter_init(Variant& arg, bool& valid){
+	valid = false;
+	return false;
+}
+bool Object::_iter_next(Variant& arg, bool& valid){
+	valid = false;
+	return false;
+}
+Variant Object::_iter_get(const Variant& arg, bool& valid){
+	valid = false;
+	return Variant();
+}
+
 void Object::set_script(const RefPtr& p_script) {
 
 	if (script==p_script)
@@ -1864,6 +1877,7 @@ Object::Object() {
 	_instance_ID = ObjectDB::add_instance(this);
 	_can_translate=true;
 	_is_queued_for_deletion=false;
+	_script_use_iter=true;
 	script_instance=NULL;
 #ifdef TOOLS_ENABLED
 

--- a/core/object.h
+++ b/core/object.h
@@ -417,6 +417,7 @@ friend void postinitialize_handler(Object*);
 	Dictionary metadata;
 	mutable StringName _type_name;
 	mutable const StringName* _type_ptr;
+	bool _script_use_iter;
 
 	void _add_user_signal(const String& p_name, const Array& p_pargs=Array());
 	bool _has_user_signal(const StringName& p_name) const;
@@ -596,6 +597,17 @@ public:
 	//used mainly by script, get and set all INCLUDING string
 	virtual Variant getvar(const Variant& p_key, bool *r_valid=NULL) const;
 	virtual void setvar(const Variant& p_key, const Variant& p_value,bool *r_valid=NULL);
+
+
+	_FORCE_INLINE_ bool has_script_iter(){
+		return _script_use_iter;
+	}
+	_FORCE_INLINE_ void use_script_iter(bool use_script_iter){
+		_script_use_iter=use_script_iter;
+	}
+	virtual bool _iter_init(Variant& arg, bool& valid);
+	virtual bool _iter_next(Variant& arg, bool& valid);
+	virtual Variant _iter_get(const Variant& arg, bool& valid);
 
 	/* SCRIPT */
 

--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -2947,13 +2947,22 @@ bool Variant::iter_init(Variant& r_iter,bool &valid) const {
 				return false;
 			}
 #endif
+			Object *obj = _get_obj().obj;
+			if(	!(obj->has_method(CoreStringNames::get_singleton()->_iter_init)
+				&& obj->has_method(CoreStringNames::get_singleton()->_iter_next)
+				&& obj->has_method(CoreStringNames::get_singleton()->_iter_get))
+			){
+				obj->use_script_iter(false);
+				return obj->_iter_init(r_iter, valid);
+			}
+			obj->use_script_iter(true);
 			Variant::CallError ce;
 			ce.error=Variant::CallError::CALL_OK;
 			Array ref(true);
 			ref.push_back(r_iter);
 			Variant vref=ref;
 			const Variant *refp[]={&vref};
-			Variant ret = _get_obj().obj->call(CoreStringNames::get_singleton()->_iter_init,refp,1,ce);
+			Variant ret = obj->call(CoreStringNames::get_singleton()->_iter_init,refp,1,ce);
 
 			if (ref.size()!=1 || ce.error!=Variant::CallError::CALL_OK) {
 				valid=false;
@@ -3073,13 +3082,17 @@ bool Variant::iter_next(Variant& r_iter,bool &valid) const {
 				return false;
 			}
 #endif
+			Object *obj = _get_obj().obj;
+			if(!obj->has_script_iter()){
+				return obj->_iter_next(r_iter, valid);
+			}
 			Variant::CallError ce;
 			ce.error=Variant::CallError::CALL_OK;
 			Array ref(true);
 			ref.push_back(r_iter);
 			Variant vref=ref;
 			const Variant *refp[]={&vref};
-			Variant ret = _get_obj().obj->call(CoreStringNames::get_singleton()->_iter_next,refp,1,ce);
+			Variant ret = obj->call(CoreStringNames::get_singleton()->_iter_next,refp,1,ce);
 
 			if (ref.size()!=1 || ce.error!=Variant::CallError::CALL_OK) {
 				valid=false;
@@ -3217,10 +3230,14 @@ Variant Variant::iter_get(const Variant& r_iter,bool &r_valid) const {
 				return Variant();
 			}
 #endif
+			Object *obj = _get_obj().obj;
+			if(!obj->has_script_iter()){
+				return obj->_iter_get(r_iter, r_valid);
+			}
 			Variant::CallError ce;
 			ce.error=Variant::CallError::CALL_OK;
 			const Variant *refp[]={&r_iter};
-			Variant ret = _get_obj().obj->call(CoreStringNames::get_singleton()->_iter_get,refp,1,ce);
+			Variant ret = obj->call(CoreStringNames::get_singleton()->_iter_get,refp,1,ce);
 
 			if (ce.error!=Variant::CallError::CALL_OK) {
 				r_valid=false;


### PR DESCRIPTION
Referenced in Issue #7218 

This commit adds the possibility to implement faster iterators over Objects in C++.
This will be handy for custom data structures (hint* linked list #7194) and modules providing anything iterable (AI, Simulation related stuff, ...) .