### PR TITLE
Show selected node in Scene dock when parent node is folded

### DIFF
--- a/tools/editor/scene_tree_editor.cpp
+++ b/tools/editor/scene_tree_editor.cpp
@@ -725,6 +725,12 @@ void SceneTreeEditor::set_selected(Node *p_node,bool p_emit_selected) {
 	TreeItem* item=p_node?_find(tree->get_root(),p_node->get_path()):NULL;
 
 	if (item) {
+		// make visible when it's collapsed
+		TreeItem* node=item->get_parent();
+		while (node && node!=tree->get_root()) {
+			node->set_collapsed(false);
+			node=node->get_parent();
+		}
 		item->select(0);
 		item->set_as_cursor(0);
 		selected=p_node;


### PR DESCRIPTION
Fix #7228

current behavior
![select_current](https://cloud.githubusercontent.com/assets/8281454/20820998/9fe82732-b882-11e6-8903-b9390b0d78c4.gif)

fixed behavior
![select_now](https://cloud.githubusercontent.com/assets/8281454/20821012/aceed0de-b882-11e6-91be-6038a52e972a.gif)
