### PR TITLE
TextureRegionEditor: Fix mouse wheel scroll speed.

### DIFF
--- a/tools/editor/plugins/texture_region_editor_plugin.cpp
+++ b/tools/editor/plugins/texture_region_editor_plugin.cpp
@@ -388,9 +388,9 @@ void TextureRegionEditor::_region_input(const InputEvent& p_input)
 					drag_index = -1;
 				}
 			}
-		} else if (mb.button_index == BUTTON_WHEEL_UP) {
+		} else if (mb.button_index == BUTTON_WHEEL_UP && mb.pressed) {
 			_zoom_in();
-		} else if (mb.button_index == BUTTON_WHEEL_DOWN) {
+		} else if (mb.button_index == BUTTON_WHEEL_DOWN && mb.pressed) {
 			_zoom_out();
 		}
 	} else if (p_input.type==InputEvent::MOUSE_MOTION) {


### PR DESCRIPTION
Any given mouse wheel input will generate two InputEvents in godot.
The zoom methods here acted on both ones, effectively giving a step value of 4 instead of 2.
Fixes #7236