### PR TITLE
Backport web export changes for 2.1

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -522,9 +522,6 @@ String OS_Unix::get_executable_path() const {
 	delete[] resolved_path;
 
 	return path;
-#elif defined(EMSCRIPTEN)
-	// We return nothing
-	return String();
 #else
 	ERR_PRINT("Warning, don't know how to obtain executable path on this OS! Please override this function properly.");
 	return OS::get_executable_path();

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -91,6 +91,7 @@ def configure(env):
         env.Append(LINKFLAGS=['--compression', lzma_binpath + "," + lzma_decoder + "," + lzma_dec])
 
     env.Append(LINKFLAGS=['-s', 'ASM_JS=1'])
+    env.Append(LINKFLAGS=['--separate-asm'])
     env.Append(LINKFLAGS=['-O2'])
     # env.Append(LINKFLAGS=['-g4'])
 

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -183,6 +183,7 @@ void EditorExportPlatformJavaScript::_fix_html(Vector<uint8_t>& p_html, const St
 		current_line = current_line.replace("$GODOT_FS",p_name+"fs.js");
 		current_line = current_line.replace("$GODOT_MEM",p_name+".mem");
 		current_line = current_line.replace("$GODOT_JS",p_name+".js");
+		current_line = current_line.replace("$GODOT_ASM",p_name+".asm.js");
 		current_line = current_line.replace("$GODOT_CANVAS_WIDTH",Globals::get_singleton()->get("display/width"));
 		current_line = current_line.replace("$GODOT_CANVAS_HEIGHT",Globals::get_singleton()->get("display/height"));
 		current_line = current_line.replace("$GODOT_HEAD_TITLE",!html_title.empty()?html_title:(String) Globals::get_singleton()->get("application/name"));
@@ -321,6 +322,11 @@ Error EditorExportPlatformJavaScript::export_project(const String& p_path, bool 
 
 			//_fix_godot(data);
 			file=p_path.get_file().basename()+".js";
+		}
+
+		if (file=="godot.asm.js") {
+
+			file=p_path.get_file().basename()+".asm.js";
 		}
 
 		if (file=="godot.mem") {

--- a/platform/javascript/javascript_main.cpp
+++ b/platform/javascript/javascript_main.cpp
@@ -66,11 +66,12 @@ static void _glut_mouse_button(int button, int state, int x, int y) {
 
 	if (ev.mouse_button.button_index<4) {
 		if (ev.mouse_button.pressed) {
-			_mouse_button_mask|=1<<ev.mouse_button.button_index;
+			_mouse_button_mask |= 1 << (ev.mouse_button.button_index-1);
 		} else {
-			_mouse_button_mask&=~(1<<ev.mouse_button.button_index);
+			_mouse_button_mask &= ~(1 << (ev.mouse_button.button_index-1));
 		}
 	}
+	ev.mouse_button.button_mask=_mouse_button_mask;
 
 	uint32_t m = glutGetModifiers();
 	ev.mouse_button.mod.alt=(m&GLUT_ACTIVE_ALT)!=0;
@@ -79,6 +80,11 @@ static void _glut_mouse_button(int button, int state, int x, int y) {
 
 	os->push_input(ev);
 
+	if (ev.mouse_button.button_index==BUTTON_WHEEL_UP || ev.mouse_button.button_index==BUTTON_WHEEL_DOWN) {
+		// GLUT doesn't send release events for mouse wheel, so send manually
+		ev.mouse_button.pressed=false;
+		os->push_input(ev);
+	}
 }
 
 
@@ -161,7 +167,6 @@ int main(int argc, char *argv[]) {
 	ResourceLoader::set_abort_on_missing_resources(false); //ease up compatibility
 
 	glutMouseFunc(_glut_mouse_button);
-	glutMotionFunc(_glut_mouse_motion);
 	glutMotionFunc(_glut_mouse_motion);
 	glutPassiveMotionFunc(_glut_mouse_motion);
 

--- a/platform/javascript/javascript_main.cpp
+++ b/platform/javascript/javascript_main.cpp
@@ -148,7 +148,7 @@ int main(int argc, char *argv[]) {
 	/* Initialize the window */
 	printf("let it go!\n");
 	glutInit(&argc, argv);
-	os = new OS_JavaScript(_gfx_init,NULL,NULL,NULL,NULL);
+	os = new OS_JavaScript(_gfx_init,NULL,NULL);
 #if 0
 	char *args[]={"-test","gui","-v",NULL};
 	Error err  = Main::setup("apk",3,args);

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -37,6 +37,7 @@
 #include "main/main.h"
 
 #include "core/globals.h"
+#include "stdlib.h"
 #include "emscripten.h"
 #include "dom_keys.h"
 
@@ -89,7 +90,9 @@ static InputEvent _setup_key_event(const EmscriptenKeyboardEvent *emscripten_eve
 	ev.key.scancode = dom2godot_scancode(emscripten_event->keyCode);
 
 	String unicode = String::utf8(emscripten_event->key);
+	// check if empty or multi-character (e.g. `CapsLock`)
 	if (unicode.length()!=1) {
+		// might be empty as well, but better than nonsense
 		unicode = String::utf8(emscripten_event->charValue);
 	}
 	if (unicode.length()==1) {
@@ -152,6 +155,25 @@ void OS_JavaScript::initialize(const VideoMode& p_desired,int p_video_driver,int
 		gfx_init_func(gfx_init_ud,use_gl2,p_desired.width,p_desired.height,p_desired.fullscreen);
 
 	default_videomode=p_desired;
+
+	// find locale, emscripten only sets "C"
+	char locale_ptr[16];
+	EM_ASM_({
+		var locale = "";
+		if (Module.locale) {
+			// best case: server-side script reads Accept-Language early and
+			// defines the locale to be read here
+			locale = Module.locale;
+		} else {
+			// no luck, use what the JS engine can tell us
+			// if this turns out not compatible enough, add tests for
+			// browserLanguage, systemLanguage and userLanguage
+			locale = navigator.languages ? navigator.languages[0] : navigator.language;
+		}
+		locale = locale.split('.')[0];
+		stringToUTF8(locale, $0, 16);
+	}, locale_ptr);
+	setenv("LANG", locale_ptr, true);
 
 	print_line("Init Audio");
 
@@ -249,32 +271,11 @@ void OS_JavaScript::finalize() {
 	memdelete(input);
 }
 
+void OS_JavaScript::alert(const String& p_alert,const String& p_title) {
 
-void OS_JavaScript::vprint(const char* p_format, va_list p_list, bool p_stderr) {
-
-	if (p_stderr) {
-
-		vfprintf(stderr,p_format,p_list);
-		fflush(stderr);
-	} else {
-
-		vprintf(p_format,p_list);
-		fflush(stdout);
-	}
-}
-
-void OS_JavaScript::print(const char *p_format, ... ) {
-
-	va_list argp;
-	va_start(argp, p_format);
-	vprintf(p_format, argp );
-	va_end(argp);
-
-}
-
-void OS_JavaScript::alert(const String& p_alert) {
-
-	print("ALERT: %s\n",p_alert.utf8().get_data());
+	EM_ASM_({
+		window.alert(UTF8ToString($0));
+	}, p_alert.utf8().get_data());
 }
 
 
@@ -301,9 +302,12 @@ int OS_JavaScript::get_mouse_button_state() const {
 
 	return 0;
 }
+
 void OS_JavaScript::set_window_title(const String& p_title) {
 
-
+	EM_ASM_({
+		document.title = UTF8ToString($0);
+	}, p_title.utf8().get_data());
 }
 
 //interesting byt not yet
@@ -659,24 +663,16 @@ void OS_JavaScript::reload_gfx() {
 }
 
 Error OS_JavaScript::shell_open(String p_uri) {
-
-	if (open_uri_func)
-		return open_uri_func(p_uri)?ERR_CANT_OPEN:OK;
-	return ERR_UNAVAILABLE;
-};
+	EM_ASM_({
+		window.open(UTF8ToString($0), '_blank');
+	}, p_uri.utf8().get_data());
+	return OK;
+}
 
 String OS_JavaScript::get_resource_dir() const {
 
 	return "/"; //javascript has it's own filesystem for resources inside the APK
 }
-
-String OS_JavaScript::get_locale() const {
-
-	if (get_locale_func)
-		return get_locale_func();
-	return OS_Unix::get_locale();
-}
-
 
 String OS_JavaScript::get_data_dir() const {
 
@@ -686,6 +682,10 @@ String OS_JavaScript::get_data_dir() const {
 	//return Globals::get_singleton()->get_singleton_object("GodotOS")->call("get_data_dir");
 };
 
+String OS_JavaScript::get_executable_path() const {
+
+	return String();
+}
 
 void OS_JavaScript::_close_notification_funcs(const String& p_file,int p_flags) {
 
@@ -752,9 +752,7 @@ String OS_JavaScript::get_joy_guid(int p_device) const {
 	return input->get_joy_guid_remapped(p_device);
 }
 
-OS_JavaScript::OS_JavaScript(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetDataDirFunc p_get_data_dir_func,GetLocaleFunc p_get_locale_func) {
-
-
+OS_JavaScript::OS_JavaScript(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, GetDataDirFunc p_get_data_dir_func) {
 	default_videomode.width=800;
 	default_videomode.height=600;
 	default_videomode.fullscreen=true;
@@ -767,9 +765,7 @@ OS_JavaScript::OS_JavaScript(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, Ope
 	gl_extensions=NULL;
 	rasterizer=NULL;
 
-	open_uri_func=p_open_uri_func;
 	get_data_dir_func=p_get_data_dir_func;
-	get_locale_func=p_get_locale_func;
 	FileAccessUnix::close_notification_func=_close_notification_funcs;
 
 	time_to_save_sync=-1;

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -78,6 +78,37 @@ void OS_JavaScript::set_opengl_extensions(const char* p_gl_extensions) {
 	gl_extensions=p_gl_extensions;
 }
 
+static Size2 _windowed_size;
+
+static EM_BOOL _fullscreen_change_callback(int event_type, const EmscriptenFullscreenChangeEvent *event, void *user_data) {
+
+	ERR_FAIL_COND_V(event_type!=EMSCRIPTEN_EVENT_FULLSCREENCHANGE, false);
+
+	OS_JavaScript* os = static_cast<OS_JavaScript*>(user_data);
+	String id = String::utf8(event->id);
+
+	// empty id is canvas
+	if (id.empty() || id=="canvas") {
+
+		OS::VideoMode vm = os->get_video_mode();
+		// this event property is the only reliable information on
+		// browser fullscreen state
+		vm.fullscreen = event->isFullscreen;
+
+		if (event->isFullscreen) {
+			vm.width = event->screenWidth;
+			vm.height = event->screenHeight;
+		}
+		else {
+			vm.width = _windowed_size.width;
+			vm.height = _windowed_size.height;
+		}
+		os->set_video_mode(vm);
+		emscripten_set_canvas_size(vm.width, vm.height);
+	}
+	return false;
+}
+
 static InputEvent _setup_key_event(const EmscriptenKeyboardEvent *emscripten_event) {
 
 	InputEvent ev;
@@ -154,7 +185,11 @@ void OS_JavaScript::initialize(const VideoMode& p_desired,int p_video_driver,int
 	if (gfx_init_func)
 		gfx_init_func(gfx_init_ud,use_gl2,p_desired.width,p_desired.height,p_desired.fullscreen);
 
-	default_videomode=p_desired;
+	// nothing to do here, can't fulfil fullscreen request due to
+	// browser security, window size is already set from HTML
+	video_mode=p_desired;
+	video_mode.fullscreen=false;
+	_windowed_size=get_window_size();
 
 	// find locale, emscripten only sets "C"
 	char locale_ptr[16];
@@ -232,26 +267,22 @@ void OS_JavaScript::initialize(const VideoMode& p_desired,int p_video_driver,int
 
 	input = memnew( InputDefault );
 
-	EMSCRIPTEN_RESULT result = emscripten_set_keydown_callback(NULL, this , true, &_keydown_callback);
-	if (result!=EMSCRIPTEN_RESULT_SUCCESS) {
-		ERR_PRINTS( "Error while setting Emscripten keydown callback: Code " + itos(result) );
-	}
-	result = emscripten_set_keypress_callback(NULL, this, true, &_keypress_callback);
-	if (result!=EMSCRIPTEN_RESULT_SUCCESS) {
-		ERR_PRINTS( "Error while setting Emscripten keypress callback: Code " + itos(result) );
-	}
-	result = emscripten_set_keyup_callback(NULL, this, true, &_keyup_callback);
-	if (result!=EMSCRIPTEN_RESULT_SUCCESS) {
-		ERR_PRINTS( "Error while setting Emscripten keyup callback: Code " + itos(result) );
-	}
-	result = emscripten_set_gamepadconnected_callback(NULL, true, &joy_callback_func);
-	if (result!=EMSCRIPTEN_RESULT_SUCCESS) {
-		ERR_PRINTS( "Error while setting Emscripten gamepadconnected callback: Code " + itos(result) );
-	}
-	result = emscripten_set_gamepaddisconnected_callback(NULL, true, &joy_callback_func);
-	if (result!=EMSCRIPTEN_RESULT_SUCCESS) {
-		ERR_PRINTS( "Error while setting Emscripten gamepaddisconnected callback: Code " + itos(result) );
-	}
+#define EM_CHECK(ev) if (result!=EMSCRIPTEN_RESULT_SUCCESS)\
+	ERR_PRINTS("Error while setting " #ev " callback: Code " + itos(result))
+#define SET_EM_CALLBACK(ev, cb) result = emscripten_set_##ev##_callback(NULL, this, true, &cb); EM_CHECK(ev)
+#define SET_EM_CALLBACK_NODATA(ev, cb) result = emscripten_set_##ev##_callback(NULL, true, &cb); EM_CHECK(ev)
+
+	EMSCRIPTEN_RESULT result;
+	SET_EM_CALLBACK(keydown, _keydown_callback)
+	SET_EM_CALLBACK(keypress, _keypress_callback)
+	SET_EM_CALLBACK(keyup, _keyup_callback)
+	SET_EM_CALLBACK(fullscreenchange, _fullscreen_change_callback)
+	SET_EM_CALLBACK_NODATA(gamepadconnected, joy_callback_func)
+	SET_EM_CALLBACK_NODATA(gamepaddisconnected, joy_callback_func)
+
+#undef SET_EM_CALLBACK_NODATA
+#undef SET_EM_CALLBACK
+#undef EM_CHECK
 }
 
 void OS_JavaScript::set_main_loop( MainLoop * p_main_loop ) {
@@ -318,22 +349,60 @@ void OS_JavaScript::set_window_title(const String& p_title) {
 
 void OS_JavaScript::set_video_mode(const VideoMode& p_video_mode,int p_screen) {
 
-
+	video_mode = p_video_mode;
 }
 
 OS::VideoMode OS_JavaScript::get_video_mode(int p_screen) const {
 
-	return default_videomode;
+	return video_mode;
+}
+
+Size2 OS_JavaScript::get_screen_size(int p_screen) const {
+
+	ERR_FAIL_COND_V(p_screen!=0, Size2());
+
+	EmscriptenFullscreenChangeEvent ev;
+	EMSCRIPTEN_RESULT result = emscripten_get_fullscreen_status(&ev);
+	ERR_FAIL_COND_V(result!=EMSCRIPTEN_RESULT_SUCCESS, Size2());
+	return Size2(ev.screenWidth, ev.screenHeight);
 }
 
 Size2 OS_JavaScript::get_window_size() const {
 
-	return Vector2(default_videomode.width,default_videomode.height);
+	int canvas[3];
+	emscripten_get_canvas_size(canvas, canvas+1, canvas+2);
+	return Size2(canvas[0], canvas[1]);
+}
+
+void OS_JavaScript::set_window_fullscreen(bool p_enable) {
+
+	if (p_enable==is_window_fullscreen()) {
+		return;
+	}
+
+	// only requesting changes here, if successful, canvas is resized in
+	// _browser_resize_callback or _fullscreen_change_callback
+	EMSCRIPTEN_RESULT result;
+	if (p_enable) {
+		EM_ASM(Module.requestFullscreen(false, false););
+	}
+	else {
+		result = emscripten_exit_fullscreen();
+		if (result!=EMSCRIPTEN_RESULT_SUCCESS) {
+			ERR_PRINTS("Failed to exit fullscreen: Code " + itos(result));
+		}
+	}
+}
+
+bool OS_JavaScript::is_window_fullscreen() const {
+
+	return video_mode.fullscreen;
 }
 
 void OS_JavaScript::get_fullscreen_mode_list(List<VideoMode> *p_list,int p_screen) const {
 
-	p_list->push_back(default_videomode);
+	Size2 screen = get_screen_size();
+	p_list->push_back(OS::VideoMode(screen.width, screen.height, true));
 }
 
 String OS_JavaScript::get_name() {
@@ -653,16 +722,10 @@ void OS_JavaScript::main_loop_request_quit() {
 		main_loop->notification(MainLoop::NOTIFICATION_WM_QUIT_REQUEST);
 }
 
-void OS_JavaScript::set_display_size(Size2 p_size) {
-
-	default_videomode.width=p_size.x;
-	default_videomode.height=p_size.y;
-}
-
 void OS_JavaScript::reload_gfx() {
 
 	if (gfx_init_func)
-		gfx_init_func(gfx_init_ud,use_gl2,default_videomode.width,default_videomode.height,default_videomode.fullscreen);
+		gfx_init_func(gfx_init_ud,use_gl2,video_mode.width,video_mode.height,video_mode.fullscreen);
 	if (rasterizer)
 		rasterizer->reload_vram();
 }
@@ -758,10 +821,6 @@ String OS_JavaScript::get_joy_guid(int p_device) const {
 }
 
 OS_JavaScript::OS_JavaScript(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, GetDataDirFunc p_get_data_dir_func) {
-	default_videomode.width=800;
-	default_videomode.height=600;
-	default_videomode.fullscreen=true;
-	default_videomode.resizable=false;
 
 	gfx_init_func=p_gfx_init_func;
 	gfx_init_ud=p_gfx_init_ud;

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -294,13 +294,15 @@ bool OS_JavaScript::is_mouse_grab_enabled() const {
 	//*sigh* technology has evolved so much since i was a kid..
 	return false;
 }
+
 Point2 OS_JavaScript::get_mouse_pos() const {
 
-	return Point2();
+	return input->get_mouse_pos();
 }
+
 int OS_JavaScript::get_mouse_button_state() const {
 
-	return 0;
+	return last_button_mask;
 }
 
 void OS_JavaScript::set_window_title(const String& p_title) {
@@ -421,6 +423,9 @@ void OS_JavaScript::push_input(const InputEvent& p_ev) {
 	ev.ID=last_id++;
 	if (ev.type==InputEvent::MOUSE_MOTION) {
 		input->set_mouse_pos(Point2(ev.mouse_motion.x, ev.mouse_motion.y));
+	}
+	else if (ev.type==InputEvent::MOUSE_BUTTON) {
+		last_button_mask = ev.mouse_button.button_mask;
 	}
 	input->parse_input_event(p_ev);
 }
@@ -760,6 +765,7 @@ OS_JavaScript::OS_JavaScript(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, Get
 
 	gfx_init_func=p_gfx_init_func;
 	gfx_init_ud=p_gfx_init_ud;
+	last_button_mask=0;
 	main_loop=NULL;
 	last_id=1;
 	gl_extensions=NULL;

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -44,9 +44,7 @@
 #include "emscripten/html5.h"
 
 typedef void (*GFXInitFunc)(void *ud,bool gl2,int w, int h, bool fs);
-typedef int (*OpenURIFunc)(const String&);
 typedef String (*GetDataDirFunc)();
-typedef String (*GetLocaleFunc)();
 
 class OS_JavaScript : public OS_Unix {
 public:
@@ -84,9 +82,7 @@ private:
 	VideoMode default_videomode;
 	MainLoop * main_loop;
 
-	OpenURIFunc open_uri_func;
 	GetDataDirFunc get_data_dir_func;
-	GetLocaleFunc get_locale_func;
 
 	static void _close_notification_funcs(const String& p_file,int p_flags);
 
@@ -116,9 +112,12 @@ public:
 
 	//static OS* get_singleton();
 
-	virtual void vprint(const char* p_format, va_list p_list, bool p_stderr=false);
-	virtual void print(const char *p_format, ... );
-	virtual void alert(const String& p_alert);
+	virtual void print_error(const char* p_function, const char* p_file, int p_line, const char *p_code, const char* p_rationale, ErrorType p_type) {
+
+		OS::print_error(p_function, p_file, p_line, p_code, p_rationale, p_type);
+	}
+
+	virtual void alert(const String& p_alert,const String& p_title="ALERT!");
 
 
 	virtual void set_mouse_show(bool p_show);
@@ -159,8 +158,8 @@ public:
 
 	virtual Error shell_open(String p_uri);
 	virtual String get_data_dir() const;
+	String get_executable_path() const;
 	virtual String get_resource_dir() const;
-	virtual String get_locale() const;
 
 	void process_accelerometer(const Vector3& p_accelerometer);
 	void process_touch(int p_what,int p_pointer, const Vector<TouchPos>& p_points);
@@ -170,7 +169,7 @@ public:
 	virtual String get_joy_guid(int p_device) const;
 	bool joy_connection_changed(int p_type, const EmscriptenGamepadEvent *p_event);
 
-	OS_JavaScript(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetDataDirFunc p_get_data_dir_func,GetLocaleFunc p_get_locale_func);
+	OS_JavaScript(GFXInitFunc p_gfx_init_func,void*p_gfx_init_ud, GetDataDirFunc p_get_data_dir_func);
 	~OS_JavaScript();
 
 };

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -80,7 +80,7 @@ private:
 	const char* gl_extensions;
 
 	InputDefault *input;
-	VideoMode default_videomode;
+	VideoMode video_mode;
 	MainLoop * main_loop;
 
 	GetDataDirFunc get_data_dir_func;
@@ -135,7 +135,12 @@ public:
 	virtual VideoMode get_video_mode(int p_screen=0) const;
 	virtual void get_fullscreen_mode_list(List<VideoMode> *p_list,int p_screen=0) const;
 
+	virtual Size2 get_screen_size(int p_screen=0) const;
+
 	virtual Size2 get_window_size() const;
+	virtual void set_window_fullscreen(bool p_enable);
+	virtual bool is_window_fullscreen() const;
+
 	virtual String get_name();
 	virtual MainLoop *get_main_loop() const;
 
@@ -153,7 +158,6 @@ public:
 	virtual bool has_touchscreen_ui_hint() const;
 
 	void set_opengl_extensions(const char* p_gl_extensions);
-	void set_display_size(Size2 p_size);
 
 	void reload_gfx();
 

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -58,6 +58,7 @@ private:
 
 	Vector<TouchPos> touch;
 	Point2 last_mouse;
+	int last_button_mask;
 	unsigned int last_id;
 	GFXInitFunc gfx_init_func;
 	void*gfx_init_ud;

--- a/tools/dist/html_fs/godot.html
+++ b/tools/dist/html_fs/godot.html
@@ -354,21 +354,30 @@
 	<script type="text/javascript" src="$GODOT_FS"></script>
 	<script>
 		(function() {
-			var memoryInitializer = "$GODOT_MEM";
-			if (typeof Module.locateFile === "function") {
-				memoryInitializer = Module.locateFile(memoryInitializer);
-			} else if (Module.memoryInitializerPrefixURL) {
-				memoryInitializer = Module.memoryInitializerPrefixURL + memoryInitializer;
-			}
-			var xhr = Module.memoryInitializerRequest = new XMLHttpRequest();
-			xhr.open("GET", memoryInitializer, true);
-			xhr.responseType = "arraybuffer";
-			xhr.send(null);
-		})();
+			var script = document.createElement('script');
+			script.src = "$GODOT_ASM";
+			script.onload = function() {
+				setTimeout(function() {
+					(function() {
+						var memoryInitializer = '$GODOT_MEM';
+						if (typeof Module.locateFile === 'function') {
+							memoryInitializer = Module.locateFile(memoryInitializer);
+						} else if (Module.memoryInitializerPrefixURL) {
+							memoryInitializer = Module.memoryInitializerPrefixURL + memoryInitializer;
+						}
+						var xhr = Module.memoryInitializerRequest = new XMLHttpRequest();
+						xhr.open('GET', memoryInitializer, true);
+						xhr.responseType = 'arraybuffer';
+						xhr.send(null);
+					})();
 
-		var script = document.createElement("script");
-		script.src = "$GODOT_JS";
-		document.body.appendChild(script);
+					var script = document.createElement('script');
+					script.src = "$GODOT_JS";
+					document.body.appendChild(script);
+				}, 1); // delaying even 1ms is enough to allow compilation memory to be reclaimed
+			};
+			document.body.appendChild(script);
+		})();
 	</script>
 </body>
 </html>


### PR DESCRIPTION
Fixes and simple additions from #7217 and #7219

The window stuff is tricky, so I'm only bringing in the fullscreen functionality, which is pretty straight forward.

For the browser lockup fix, I kept the loading code hardcoded since it's always the same without wasm. 2.1 will also need the additional `.asm.js` file zipped with these changes.