### PR TITLE
y_sort: make clear which item has to be drawn first when two have the same y-coordinate

### DIFF
--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -407,7 +407,10 @@ class VisualServerRaster : public VisualServer {
 
 		_FORCE_INLINE_ bool operator()(const CanvasItem* p_left,const CanvasItem* p_right) const {
 
-			return p_left->xform.elements[2].y < p_right->xform.elements[2].y;
+			if(Math::abs(p_left->xform.elements[2].y - p_right->xform.elements[2].y) < CMP_EPSILON )
+				return p_left->xform.elements[2].x < p_right->xform.elements[2].x;
+			else
+				return p_left->xform.elements[2].y < p_right->xform.elements[2].y;
 		}
 	};
 


### PR DESCRIPTION
If you use y_sort and you have the sprites of two entities with the same y-coordinate overlapping horizontally, it is undefined which one has to be drawn first which causes flickering.
This is especially bad when you are using tiles which are larger than the cell size of the grid so they can overlap (which I do a lot).
I added an additional comparation between the x-coordinates to the y-sorter. Not sure if this is wanted in the official build (dont know how much it actually affects performance), but I decided to give it a try.