### PR TITLE
Collision mask checking for 3D physics

### DIFF
--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -1013,8 +1013,8 @@ Vector3 KinematicBody::move(const Vector3& p_motion) {
 			if (is_shape_set_as_trigger(i))
 				continue;
 
-			if (dss->collide_shape(get_shape(i)->get_rid(), get_global_transform() * get_shape_transform(i),m,sr,max_shapes,res_shapes,exclude,get_layer_mask(),mask)) {
-				collided=true;
+            if (dss->collide_shape(get_shape(i)->get_rid(), get_global_transform() * get_shape_transform(i),m,sr,max_shapes,res_shapes,exclude,get_layer_mask(),get_collision_mask(),mask)) {
+                collided=true;
 			}
 
 		}
@@ -1024,7 +1024,7 @@ Vector3 KinematicBody::move(const Vector3& p_motion) {
 		if (!collided)
 			break;
 
-		//print_line("have to recover");
+        //print_line("have to recover");
 		Vector3 recover_motion;
 		bool all_outside=true;
 		for(int j=0;j<8;j++) {
@@ -1095,7 +1095,7 @@ Vector3 KinematicBody::move(const Vector3& p_motion) {
 
 		float lsafe,lunsafe;
 		PhysicsDirectSpaceState::ShapeRestInfo lrest;
-		bool valid = dss->cast_motion(get_shape(i)->get_rid(), get_global_transform() * get_shape_transform(i), p_motion,0, lsafe,lunsafe,exclude,get_layer_mask(),mask,&lrest);
+        bool valid = dss->cast_motion(get_shape(i)->get_rid(), get_global_transform() * get_shape_transform(i), p_motion,0, lsafe,lunsafe,exclude,get_layer_mask(),get_collision_mask(),mask,&lrest);
 		//print_line("shape: "+itos(i)+" travel:"+rtos(ltravel));
 		if (!valid) {
 			safe=0;
@@ -1136,7 +1136,7 @@ Vector3 KinematicBody::move(const Vector3& p_motion) {
 			ugt.origin+=p_motion*unsafe;
 
 			PhysicsDirectSpaceState::ShapeRestInfo rest_info;
-			bool c2 = dss->rest_info(get_shape(best_shape)->get_rid(), ugt*get_shape_transform(best_shape), m,&rest,exclude,get_layer_mask(),mask);
+            bool c2 = dss->rest_info(get_shape(best_shape)->get_rid(), ugt*get_shape_transform(best_shape), m,&rest,exclude,get_layer_mask(),get_collision_mask(),mask);
 			if (!c2) {
 				//should not happen, but floating point precision is so weird..
 				colliding=false;

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -1013,8 +1013,8 @@ Vector3 KinematicBody::move(const Vector3& p_motion) {
 			if (is_shape_set_as_trigger(i))
 				continue;
 
-            if (dss->collide_shape(get_shape(i)->get_rid(), get_global_transform() * get_shape_transform(i),m,sr,max_shapes,res_shapes,exclude,get_layer_mask(),get_collision_mask(),mask)) {
-                collided=true;
+			if (dss->collide_shape(get_shape(i)->get_rid(), get_global_transform() * get_shape_transform(i),m,sr,max_shapes,res_shapes,exclude,get_layer_mask(),get_collision_mask(),mask)) {
+				collided=true;
 			}
 
 		}
@@ -1024,7 +1024,7 @@ Vector3 KinematicBody::move(const Vector3& p_motion) {
 		if (!collided)
 			break;
 
-        //print_line("have to recover");
+		//print_line("have to recover");
 		Vector3 recover_motion;
 		bool all_outside=true;
 		for(int j=0;j<8;j++) {
@@ -1095,7 +1095,7 @@ Vector3 KinematicBody::move(const Vector3& p_motion) {
 
 		float lsafe,lunsafe;
 		PhysicsDirectSpaceState::ShapeRestInfo lrest;
-        bool valid = dss->cast_motion(get_shape(i)->get_rid(), get_global_transform() * get_shape_transform(i), p_motion,0, lsafe,lunsafe,exclude,get_layer_mask(),get_collision_mask(),mask,&lrest);
+		bool valid = dss->cast_motion(get_shape(i)->get_rid(), get_global_transform() * get_shape_transform(i), p_motion,0, lsafe,lunsafe,exclude,get_layer_mask(),get_collision_mask(),mask,&lrest);
 		//print_line("shape: "+itos(i)+" travel:"+rtos(ltravel));
 		if (!valid) {
 			safe=0;
@@ -1136,7 +1136,7 @@ Vector3 KinematicBody::move(const Vector3& p_motion) {
 			ugt.origin+=p_motion*unsafe;
 
 			PhysicsDirectSpaceState::ShapeRestInfo rest_info;
-            bool c2 = dss->rest_info(get_shape(best_shape)->get_rid(), ugt*get_shape_transform(best_shape), m,&rest,exclude,get_layer_mask(),get_collision_mask(),mask);
+			bool c2 = dss->rest_info(get_shape(best_shape)->get_rid(), ugt*get_shape_transform(best_shape), m,&rest,exclude,get_layer_mask(),get_collision_mask(),mask);
 			if (!c2) {
 				//should not happen, but floating point precision is so weird..
 				colliding=false;

--- a/servers/physics/space_sw.cpp
+++ b/servers/physics/space_sw.cpp
@@ -35,13 +35,12 @@
 _FORCE_INLINE_ static bool _match_object_type_query(CollisionObjectSW *p_object, uint32_t p_layer_mask, uint32_t p_type_mask) {
 
 	if (p_object->get_type()==CollisionObjectSW::TYPE_AREA)
-        return p_type_mask&PhysicsDirectSpaceState::TYPE_MASK_AREA;
+		return p_type_mask&PhysicsDirectSpaceState::TYPE_MASK_AREA;
 
-    if (!p_object->get_layer_mask() || !p_layer_mask)
-        return false;
-
-    //if ((p_layer_mask&p_object->get_collision_mask() || p_object->get_layer_mask()&p_collision_mask) == 0)
-        //return false;
+	//originally checked layer against layer, but now we have collision masks
+	//so here we can just check both objects have a valid layer instead
+	if (!p_object->get_layer_mask() || !p_layer_mask)
+		return false;
 
 	BodySW *body = static_cast<BodySW*>(p_object);
 
@@ -231,14 +230,14 @@ bool PhysicsDirectSpaceStateSW::cast_motion(const RID& p_shape, const Transform&
 			continue;
 
 		if (p_exclude.has( space->intersection_query_results[i]->get_self()))
-            continue; //ignore excluded
+			continue; //ignore excluded
 
 
-        const CollisionObjectSW *col_obj=space->intersection_query_results[i];
+		const CollisionObjectSW *col_obj=space->intersection_query_results[i];
 		int shape_idx=space->intersection_query_subindex_results[i];
 
-        if (((p_layer_mask&col_obj->get_collision_mask()) || (col_obj->get_layer_mask()&p_collision_mask))==0)
-            continue;
+		if (((p_layer_mask&col_obj->get_collision_mask()) || (col_obj->get_layer_mask()&p_collision_mask))==0)
+			continue;
 
 		Vector3 point_A,point_B;
 		Vector3 sep_axis=p_motion.normalized();
@@ -356,30 +355,30 @@ bool PhysicsDirectSpaceStateSW::collide_shape(RID p_shape, const Transform& p_sh
 	}
 
 
-    for(int i=0;i<amount;i++) {
+	for(int i=0;i<amount;i++) {
 
-        if (!_match_object_type_query(space->intersection_query_results[i],p_layer_mask,p_object_type_mask))
-            continue;
+		if (!_match_object_type_query(space->intersection_query_results[i],p_layer_mask,p_object_type_mask))
+			continue;
 
-        const CollisionObjectSW *col_obj=space->intersection_query_results[i];
-        int shape_idx=space->intersection_query_subindex_results[i];
+		const CollisionObjectSW *col_obj=space->intersection_query_results[i];
+		int shape_idx=space->intersection_query_subindex_results[i];
 
-        if (p_exclude.has( col_obj->get_self() )) {
-            continue;
-        }
+		if (p_exclude.has( col_obj->get_self() )) {
+			continue;
+		}
 
-        if (((p_layer_mask&col_obj->get_collision_mask()) || (col_obj->get_layer_mask()&p_collision_mask))==0)
-            continue;
+		if (((p_layer_mask&col_obj->get_collision_mask()) || (col_obj->get_layer_mask()&p_collision_mask))==0)
+			continue;
 
-        //print_line("AGAINST: "+itos(col_obj->get_self().get_id())+":"+itos(shape_idx));
-        //print_line("THE ABBB: "+(col_obj->get_transform() * col_obj->get_shape_transform(shape_idx)).xform(col_obj->get_shape(shape_idx)->get_aabb()));
+		//print_line("AGAINST: "+itos(col_obj->get_self().get_id())+":"+itos(shape_idx));
+		//print_line("THE ABBB: "+(col_obj->get_transform() * col_obj->get_shape_transform(shape_idx)).xform(col_obj->get_shape(shape_idx)->get_aabb()));
 
-            if (CollisionSolverSW::solve_static(shape,p_shape_xform,col_obj->get_shape(shape_idx),col_obj->get_transform() * col_obj->get_shape_transform(shape_idx),cbkres,cbkptr,NULL,p_margin)) {
-                collided=true;
-        }
+			if (CollisionSolverSW::solve_static(shape,p_shape_xform,col_obj->get_shape(shape_idx),col_obj->get_transform() * col_obj->get_shape_transform(shape_idx),cbkres,cbkptr,NULL,p_margin)) {
+				collided=true;
+		}
 
 
-    }
+	}
 
 	r_result_count=cbk.amount;
 
@@ -444,8 +443,8 @@ bool PhysicsDirectSpaceStateSW::rest_info(RID p_shape, const Transform& p_shape_
 		if (p_exclude.has( col_obj->get_self() ))
 			continue;
 
-        if (((p_layer_mask&col_obj->get_collision_mask()) || (col_obj->get_layer_mask()&p_collision_mask))==0)
-            continue;
+		if (((p_layer_mask&col_obj->get_collision_mask()) || (col_obj->get_layer_mask()&p_collision_mask))==0)
+			continue;
 
 		rcd.object=col_obj;
 		rcd.shape=shape_idx;

--- a/servers/physics/space_sw.cpp
+++ b/servers/physics/space_sw.cpp
@@ -37,7 +37,7 @@ _FORCE_INLINE_ static bool _match_object_type_query(CollisionObjectSW *p_object,
 	if (p_object->get_type()==CollisionObjectSW::TYPE_AREA)
 		return p_type_mask&PhysicsDirectSpaceState::TYPE_MASK_AREA;
 
-	if ((p_object->get_layer_mask()&p_layer_mask)==0)
+	if (((p_object->get_layer_mask()&p_layer_mask)==0) && ((p_object->get_collision_mask()&p_layer_mask)==0))
 		return false;
 
 	BodySW *body = static_cast<BodySW*>(p_object);

--- a/servers/physics/space_sw.h
+++ b/servers/physics/space_sw.h
@@ -49,9 +49,9 @@ public:
 
 	virtual bool intersect_ray(const Vector3& p_from, const Vector3& p_to,RayResult &r_result,const Set<RID>& p_exclude=Set<RID>(),uint32_t p_layer_mask=0xFFFFFFFF,uint32_t p_object_type_mask=TYPE_MASK_COLLISION,bool p_pick_ray=false);
 	virtual int intersect_shape(const RID& p_shape, const Transform& p_xform,float p_margin,ShapeResult *r_results,int p_result_max,const Set<RID>& p_exclude=Set<RID>(),uint32_t p_layer_mask=0xFFFFFFFF,uint32_t p_object_type_mask=TYPE_MASK_COLLISION);
-	virtual bool cast_motion(const RID& p_shape, const Transform& p_xform,const Vector3& p_motion,float p_margin,float &p_closest_safe,float &p_closest_unsafe, const Set<RID>& p_exclude=Set<RID>(),uint32_t p_layer_mask=0xFFFFFFFF,uint32_t p_object_type_mask=TYPE_MASK_COLLISION,ShapeRestInfo *r_info=NULL);
-	virtual bool collide_shape(RID p_shape, const Transform& p_shape_xform,float p_margin,Vector3 *r_results,int p_result_max,int &r_result_count, const Set<RID>& p_exclude=Set<RID>(),uint32_t p_layer_mask=0xFFFFFFFF,uint32_t p_object_type_mask=TYPE_MASK_COLLISION);
-	virtual bool rest_info(RID p_shape, const Transform& p_shape_xform,float p_margin,ShapeRestInfo *r_info, const Set<RID>& p_exclude=Set<RID>(),uint32_t p_layer_mask=0xFFFFFFFF,uint32_t p_object_type_mask=TYPE_MASK_COLLISION);
+    virtual bool cast_motion(const RID& p_shape, const Transform& p_xform,const Vector3& p_motion,float p_margin,float &p_closest_safe,float &p_closest_unsafe, const Set<RID>& p_exclude=Set<RID>(),uint32_t p_layer_mask=0xFFFFFFFF,uint32_t p_collision_mask=0xFFFFFFFF,uint32_t p_object_type_mask=TYPE_MASK_COLLISION,ShapeRestInfo *r_info=NULL);
+    virtual bool collide_shape(RID p_shape, const Transform& p_shape_xform,float p_margin,Vector3 *r_results,int p_result_max,int &r_result_count, const Set<RID>& p_exclude=Set<RID>(),uint32_t p_layer_mask=0xFFFFFFFF,uint32_t p_collision_mask=0xFFFFFFFF,uint32_t p_object_type_mask=TYPE_MASK_COLLISION);
+    virtual bool rest_info(RID p_shape, const Transform& p_shape_xform,float p_margin,ShapeRestInfo *r_info, const Set<RID>& p_exclude=Set<RID>(),uint32_t p_layer_mask=0xFFFFFFFF,uint32_t p_collision_mask=0xFFFFFFFF,uint32_t p_object_type_mask=TYPE_MASK_COLLISION);
 
 	PhysicsDirectSpaceStateSW();
 };

--- a/servers/physics_server.cpp
+++ b/servers/physics_server.cpp
@@ -303,7 +303,9 @@ Array PhysicsDirectSpaceState::_intersect_shape(const Ref<PhysicsShapeQueryParam
 Array PhysicsDirectSpaceState::_cast_motion(const Ref<PhysicsShapeQueryParameters> &psq,const Vector3& p_motion){
 
 	float closest_safe,closest_unsafe;
-	bool res = cast_motion(psq->shape,psq->transform,p_motion,psq->margin,closest_safe,closest_unsafe,psq->exclude,psq->layer_mask,psq->object_type_mask);
+
+    //We want to check against the other objects layers, so we pass the layer(s) we want to test against as the collision mask
+    bool res = cast_motion(psq->shape,psq->transform,p_motion,psq->margin,closest_safe,closest_unsafe,psq->exclude,0x0,psq->layer_mask,psq->object_type_mask);
 	if (!res)
 		return Array();
 	Array ret(true);
@@ -318,7 +320,9 @@ Array PhysicsDirectSpaceState::_collide_shape(const Ref<PhysicsShapeQueryParamet
 	Vector<Vector3> ret;
 	ret.resize(p_max_results*2);
 	int rc=0;
-	bool res = collide_shape(psq->shape,psq->transform,psq->margin,ret.ptr(),p_max_results,rc,psq->exclude,psq->layer_mask,psq->object_type_mask);
+
+    //We want to check against the other objects layers, so we pass the layer(s) we want to test against as the collision mask
+    bool res = collide_shape(psq->shape,psq->transform,psq->margin,ret.ptr(),p_max_results,rc,psq->exclude,0x0,psq->layer_mask,psq->object_type_mask);
 	if (!res)
 		return Array();
 	Array r;
@@ -332,7 +336,8 @@ Dictionary PhysicsDirectSpaceState::_get_rest_info(const Ref<PhysicsShapeQueryPa
 
 	ShapeRestInfo sri;
 
-	bool res = rest_info(psq->shape,psq->transform,psq->margin,&sri,psq->exclude,psq->layer_mask,psq->object_type_mask);
+    //We want to check against the other objects layers, so we pass the layer(s) we want to test against as the collision mask
+    bool res = rest_info(psq->shape,psq->transform,psq->margin,&sri,psq->exclude,0x0,psq->layer_mask, psq->object_type_mask);
 	Dictionary r(true);
 	if (!res)
 		return r;

--- a/servers/physics_server.h
+++ b/servers/physics_server.h
@@ -194,11 +194,11 @@ public:
 
 	};
 
-	virtual bool cast_motion(const RID& p_shape, const Transform& p_xform,const Vector3& p_motion,float p_margin,float &p_closest_safe,float &p_closest_unsafe, const Set<RID>& p_exclude=Set<RID>(),uint32_t p_layer_mask=0xFFFFFFFF,uint32_t p_object_type_mask=TYPE_MASK_COLLISION,ShapeRestInfo *r_info=NULL)=0;
+    virtual bool cast_motion(const RID& p_shape, const Transform& p_xform,const Vector3& p_motion,float p_margin,float &p_closest_safe,float &p_closest_unsafe, const Set<RID>& p_exclude=Set<RID>(),uint32_t p_layer_mask=0xFFFFFFFF,uint32_t p_collision_mask=0xFFFFFFFF,uint32_t p_object_type_mask=TYPE_MASK_COLLISION,ShapeRestInfo *r_info=NULL)=0;
 
-	virtual bool collide_shape(RID p_shape, const Transform& p_shape_xform,float p_margin,Vector3 *r_results,int p_result_max,int &r_result_count, const Set<RID>& p_exclude=Set<RID>(),uint32_t p_layer_mask=0xFFFFFFFF,uint32_t p_object_type_mask=TYPE_MASK_COLLISION)=0;
+    virtual bool collide_shape(RID p_shape, const Transform& p_shape_xform,float p_margin,Vector3 *r_results,int p_result_max,int &r_result_count, const Set<RID>& p_exclude=Set<RID>(),uint32_t p_layer_mask=0xFFFFFFFF,uint32_t p_collision_mask=0xFFFFFFFF,uint32_t p_object_type_mask=TYPE_MASK_COLLISION)=0;
 
-	virtual bool rest_info(RID p_shape, const Transform& p_shape_xform,float p_margin,ShapeRestInfo *r_info, const Set<RID>& p_exclude=Set<RID>(),uint32_t p_layer_mask=0xFFFFFFFF,uint32_t p_object_type_mask=TYPE_MASK_COLLISION)=0;
+    virtual bool rest_info(RID p_shape, const Transform& p_shape_xform,float p_margin,ShapeRestInfo *r_info, const Set<RID>& p_exclude=Set<RID>(),uint32_t p_layer_mask=0xFFFFFFFF,uint32_t p_collision_mask=0xFFFFFFFF,uint32_t p_object_type_mask=TYPE_MASK_COLLISION)=0;
 
 
 	PhysicsDirectSpaceState();


### PR DESCRIPTION
This should hopefully fix issue #7227 

The collision mask info was in there, but it wasn't being used in the actual collision code, so I've added it. Not sure if it needs to be added elsewhere? Not too familiar with the physics code, but KinematicBody (3d) now appears to behave correctly when using layers/masks.

If anyone else could test, that would be great.