### PR TITLE
Non-realtime simulation

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -111,6 +111,8 @@ static int init_screen = -1;
 static bool use_vsync = true;
 static bool editor = false;
 static bool show_help = false;
+static bool disable_render_loop = false;
+static int fixed_fps = -1;
 
 static OS::ProcessID allow_focus_steal_pid = 0;
 
@@ -190,6 +192,8 @@ void Main::print_help(const char *p_binary) {
 #endif
 	OS::get_singleton()->print("  --frame-delay <ms>               Simulate high CPU load (delay each frame by <ms> milliseconds).\n");
 	OS::get_singleton()->print("  --time-scale <scale>             Force time scale (higher values are faster, 1.0 is normal speed).\n");
+	OS::get_singleton()->print("  --disable-render-loop            Disable render loop so rendering only occurs when called explicitly from script.\n");
+	OS::get_singleton()->print("  --fixed-fps <fps>                Forces a fixed ratio between process and fixed_process timing, for use when precision is required, or when rendering to video files. Setting this will disable real-time syncronization, so that run speed is only capped by performance\n");
 	OS::get_singleton()->print("\n");
 
 	OS::get_singleton()->print("Standalone tools:\n");
@@ -565,6 +569,16 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				N = I->next()->next();
 			} else {
 				OS::get_singleton()->print("Missing editor PID argument, aborting.\n");
+				goto error;
+			}
+		} else if (I->get() == "--disable-render-loop") {
+			disable_render_loop = true;
+		} else if (I->get() == "--fixed-fps") {
+			if (I->next()) {
+				fixed_fps = I->next()->get().to_int();
+				N = I->next()->next();
+			} else {
+				OS::get_singleton()->print("Missing fixed-fps argument, aborting.\n");
 				goto error;
 			}
 		} else {
@@ -1505,6 +1519,9 @@ bool Main::iteration() {
 	uint64_t ticks_elapsed = ticks - last_ticks;
 
 	double step = (double)ticks_elapsed / 1000000.0;
+	if (fixed_fps != -1)
+		step = 1.0 / fixed_fps;
+
 	float frame_slice = 1.0 / Engine::get_singleton()->get_iterations_per_second();
 
 	Engine::get_singleton()->_frame_step = step;
@@ -1521,7 +1538,7 @@ bool Main::iteration() {
 
 	last_ticks = ticks;
 
-	if (step > frame_slice * 8)
+	if (fixed_fps == -1 && step > frame_slice * 8)
 		step = frame_slice * 8;
 
 	time_accum += step;
@@ -1574,7 +1591,7 @@ bool Main::iteration() {
 
 	VisualServer::get_singleton()->sync(); //sync if still drawing from previous frames.
 
-	if (OS::get_singleton()->can_draw()) {
+	if (OS::get_singleton()->can_draw() && !disable_render_loop) {
 
 		if ((!force_redraw_requested) && OS::get_singleton()->is_in_low_processor_usage_mode()) {
 			if (VisualServer::get_singleton()->has_changed()) {
@@ -1624,6 +1641,9 @@ bool Main::iteration() {
 		frame %= 1000000;
 		frames = 0;
 	}
+
+	if (fixed_fps != -1)
+		return exit;
 
 	if (OS::get_singleton()->is_in_low_processor_usage_mode() || !OS::get_singleton()->can_draw())
 		OS::get_singleton()->delay_usec(16600); //apply some delay to force idle time (results in about 60 FPS max)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1422,6 +1422,7 @@ Array VisualServer::mesh_surface_get_arrays(RID p_mesh, int p_surface) const {
 
 void VisualServer::_bind_methods() {
 
+	ClassDB::bind_method(D_METHOD("force_draw"), &VisualServer::draw);
 	ClassDB::bind_method(D_METHOD("texture_create"), &VisualServer::texture_create);
 	ClassDB::bind_method(D_METHOD("texture_create_from_image", "image", "flags"), &VisualServer::texture_create_from_image, DEFVAL(TEXTURE_FLAGS_DEFAULT));
 	//ClassDB::bind_method(D_METHOD("texture_allocate"),&VisualServer::texture_allocate,DEFVAL( TEXTURE_FLAGS_DEFAULT ) );


### PR DESCRIPTION
Added support for running Godot as a game simulator.

Two cmd-line flags can be set to use the functionality
- fixed_fps [int fps]: can be set to disable the frame delay turning the application into a non-realtime one.
- disable_render_loop: can be set to disable rendering completely in the main loop, speeding up the
 simulation.

The fps set, is the frames pr. game second, allowing the game to speed up or slow down 
according to processing speed.
It is useful for using Godot to simulate many game outcomes quickly, which can f.ex. be used for AI 
training.

We can also render frames to files using these flags, by controlling the rendering from script (i used a 
simple .gd script in my project that queued a screenshot, called draw, and then got the screenshot in the 
_process() function)