### PR TITLE
fix for crash when no ALSA or Pulse installed on linux

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -1990,6 +1990,11 @@ OS_X11::OS_X11() {
 	AudioDriverManagerSW::add_driver(&driver_alsa);
 #endif
 
+	if(AudioDriverManagerSW::get_driver_count() == 0){
+		WARN_PRINT("No sound driver found... Defaulting to dummy driver");
+		AudioDriverManagerSW::add_driver(&driver_dummy);
+	}
+
 	minimized = false;
 	xim_style=0L;
 	mouse_mode=MOUSE_MODE_VISIBLE;

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -44,6 +44,7 @@
 #include "drivers/rtaudio/audio_driver_rtaudio.h"
 #include "drivers/alsa/audio_driver_alsa.h"
 #include "drivers/pulseaudio/audio_driver_pulseaudio.h"
+#include "servers/audio/audio_driver_dummy.h"
 #include "servers/physics_2d/physics_2d_server_sw.h"
 #include "servers/physics_2d/physics_2d_server_wrap_mt.h"
 #include "main/input_default.h"
@@ -168,6 +169,7 @@ class OS_X11 : public OS_Unix {
 #ifdef PULSEAUDIO_ENABLED
 	AudioDriverPulseAudio driver_pulseaudio;
 #endif
+	AudioDriverDummy driver_dummy;
 
 	Atom net_wm_icon;
 


### PR DESCRIPTION
When no ALSA or Pulse libraries are installed on Linux. Godot (x11 version) will crash, since no audio driver can be loaded.
By loading the dummy audio driver (used in Godot's server version), when no other driver is available, we avoid this issue.

May be related to #1684