### PR TITLE
Added method set_hide_on_select to popup

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -903,8 +903,10 @@ void PopupMenu::activate_item(int p_item) {
 		next = next->get_parent();
 		pop = next->cast_to<PopupMenu>();
 	}
-	hide();
-
+	
+	if(hide_on_click) {
+		hide();
+        }
 }
 
 void PopupMenu::remove_item(int p_idx) {
@@ -1121,6 +1123,10 @@ void PopupMenu::set_invalidate_click_until_motion() {
 	invalidated_click=true;
 }
 
+void PopupMenu::set_hide_on_click(bool p_bool) {
+        hide_on_click=p_bool;
+}
+
 PopupMenu::PopupMenu() {
 
 
@@ -1128,7 +1134,7 @@ PopupMenu::PopupMenu() {
 
 	set_focus_mode(FOCUS_ALL);
 	set_as_toplevel(true);
-
+	set_hide_on_click(true);
 	submenu_timer = memnew( Timer );
 	submenu_timer->set_wait_time(0.3);
 	submenu_timer->set_one_shot(true);

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -903,8 +903,8 @@ void PopupMenu::activate_item(int p_item) {
 		next = next->get_parent();
 		pop = next->cast_to<PopupMenu>();
 	}
-	
-	if(hide_on_click) {
+	// Hides popup by default, unless otherwise specified using set_hide_on_select(p_bool)
+	if(hide_on_select) {
 		hide();
         }
 }
@@ -1108,11 +1108,15 @@ void PopupMenu::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("_set_items"),&PopupMenu::_set_items);
 	ObjectTypeDB::bind_method(_MD("_get_items"),&PopupMenu::_get_items);
-
+    
+    ObjectTypeDB::bind_method(_MD("set_hide_on_select","enable"),&PopupMenu::set_hide_on_select);
+    ObjectTypeDB::bind_method(_MD("get_hide_on_select"),&PopupMenu::get_hide_on_select);
+    
 	ObjectTypeDB::bind_method(_MD("_submenu_timeout"),&PopupMenu::_submenu_timeout);
 
 	ADD_PROPERTY( PropertyInfo(Variant::ARRAY,"items",PROPERTY_HINT_NONE,"",PROPERTY_USAGE_NOEDITOR), _SCS("_set_items"),_SCS("_get_items") );
-
+    ADD_PROPERTY( PropertyInfo(Variant::BOOL, "hide_on_select" ), _SCS("set_hide_on_select"), _SCS("get_hide_on_select") );
+    
 	ADD_SIGNAL( MethodInfo("item_pressed", PropertyInfo( Variant::INT,"ID") ) );
 
 }
@@ -1123,8 +1127,12 @@ void PopupMenu::set_invalidate_click_until_motion() {
 	invalidated_click=true;
 }
 
-void PopupMenu::set_hide_on_click(bool p_bool) {
-        hide_on_click=p_bool;
+// Hide on Select determines whether or not the popup will close after item selection
+void PopupMenu::set_hide_on_select(bool p_bool) {
+        hide_on_select=p_bool;
+}
+bool PopupMenu::get_hide_on_select() {
+    return hide_on_select;
 }
 
 PopupMenu::PopupMenu() {
@@ -1134,7 +1142,7 @@ PopupMenu::PopupMenu() {
 
 	set_focus_mode(FOCUS_ALL);
 	set_as_toplevel(true);
-	set_hide_on_click(true);
+	set_hide_on_select(true);
 	submenu_timer = memnew( Timer );
 	submenu_timer->set_wait_time(0.3);
 	submenu_timer->set_one_shot(true);

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -66,7 +66,7 @@ class PopupMenu : public Popup {
 	int mouse_over;
 	int submenu_over;
 	Rect2 parent_rect;
-	bool hide_on_click;
+	bool hide_on_select;
 	String _get_accel_text(int p_item) const;
 	int _get_mouse_over(const Point2& p_over) const;
 	virtual Size2 get_minimum_size() const;
@@ -154,7 +154,9 @@ public:
 	void clear_autohide_areas();
 
 	void set_invalidate_click_until_motion();
-	void set_hide_on_click(bool p_bool);
+    
+	void set_hide_on_select(bool p_bool);
+    bool get_hide_on_select();
 
 	PopupMenu();
 	~PopupMenu();

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -66,6 +66,7 @@ class PopupMenu : public Popup {
 	int mouse_over;
 	int submenu_over;
 	Rect2 parent_rect;
+	bool hide_on_click;
 	String _get_accel_text(int p_item) const;
 	int _get_mouse_over(const Point2& p_over) const;
 	virtual Size2 get_minimum_size() const;
@@ -153,6 +154,7 @@ public:
 	void clear_autohide_areas();
 
 	void set_invalidate_click_until_motion();
+	void set_hide_on_click(bool p_bool);
 
 	PopupMenu();
 	~PopupMenu();

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -5957,7 +5957,7 @@ EditorNode::EditorNode() {
 	debug_button->set_tooltip(TTR("Debug options"));
 
 	p=debug_button->get_popup();
-	p->set_hide_on_click(false);
+	p->set_hide_on_select(false);
 	p->add_check_item(TTR("Deploy with Remote Debug"),RUN_DEPLOY_REMOTE_DEBUG);
 	p->set_item_tooltip(p->get_item_count()-1,TTR("When exporting or deploying, the resulting executable will attempt to connect to the IP of this computer in order to be debugged."));
 	p->add_check_item(TTR("Small Deploy with Network FS"),RUN_FILE_SERVER);

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -5957,6 +5957,7 @@ EditorNode::EditorNode() {
 	debug_button->set_tooltip(TTR("Debug options"));
 
 	p=debug_button->get_popup();
+	p->set_hide_on_click(false);
 	p->add_check_item(TTR("Deploy with Remote Debug"),RUN_DEPLOY_REMOTE_DEBUG);
 	p->set_item_tooltip(p->get_item_count()-1,TTR("When exporting or deploying, the resulting executable will attempt to connect to the IP of this computer in order to be debugged."));
 	p->add_check_item(TTR("Small Deploy with Network FS"),RUN_FILE_SERVER);


### PR DESCRIPTION
Added method set_hide_on_select to popup, in order to give us the ability to disable hide after selecting an item, such as on the Debug Options popup.

Should solve https://github.com/godotengine/godot/issues/7262, as well as give us the ability to disable hide on select on other popups. 