### PR TITLE
PopupMenu upgrade: Hide on item selection

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -30931,6 +30931,13 @@
 				Clear the popup menu, in effect removing all items.
 			</description>
 		</method>
+		<method name="get_hide_on_item_selection">
+			<return type="bool">
+			</return>
+			<description>
+				Returns a boolean that indicates whether or not the PopupMenu will hide on item selection.
+			</description>
+		</method>
 		<method name="get_item_ID" qualifiers="const">
 			<return type="int">
 			</return>
@@ -31048,6 +31055,13 @@
 			</argument>
 			<description>
 				Removes the item at index "idx" from the menu. Note that the indexes of items after the removed item are going to be shifted by one.
+			</description>
+		</method>
+		<method name="set_hide_on_item_selection">
+			<argument index="0" name="enable" type="bool">
+			</argument>
+			<description>
+				Sets whether or not the PopupMenu will hide on item selection.
 			</description>
 		</method>
 		<method name="set_item_ID">

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -30931,7 +30931,7 @@
 				Clear the popup menu, in effect removing all items.
 			</description>
 		</method>
-		<method name="get_hide_on_item_selection">
+		<method name="is_hide_on_item_selection">
 			<return type="bool">
 			</return>
 			<description>

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -903,7 +903,10 @@ void PopupMenu::activate_item(int p_item) {
 		next = next->get_parent();
 		pop = next->cast_to<PopupMenu>();
 	}
-	hide();
+	// Hides popup by default; unless otherwise specified using set_hide_on_item_selection(p_bool)
+	if (hide_on_item_selection) {
+		hide();
+	}
 
 }
 
@@ -1019,6 +1022,16 @@ void PopupMenu::_set_items(const Array& p_items){
 
 }
 
+// Hide on Select determines whether or not the popup will close after item selection
+void PopupMenu::set_hide_on_item_selection(bool p_bool) {
+
+	hide_on_item_selection=p_bool;
+}
+
+bool PopupMenu::get_hide_on_item_selection() {
+
+	return hide_on_item_selection;
+}
 
 String PopupMenu::get_tooltip(const Point2& p_pos) const {
 
@@ -1107,9 +1120,13 @@ void PopupMenu::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("_set_items"),&PopupMenu::_set_items);
 	ObjectTypeDB::bind_method(_MD("_get_items"),&PopupMenu::_get_items);
 
+	ObjectTypeDB::bind_method(_MD("set_hide_on_item_selection","enable"),&PopupMenu::set_hide_on_item_selection);
+	ObjectTypeDB::bind_method(_MD("get_hide_on_item_selection"),&PopupMenu::get_hide_on_item_selection);
+
 	ObjectTypeDB::bind_method(_MD("_submenu_timeout"),&PopupMenu::_submenu_timeout);
 
 	ADD_PROPERTY( PropertyInfo(Variant::ARRAY,"items",PROPERTY_HINT_NONE,"",PROPERTY_USAGE_NOEDITOR), _SCS("_set_items"),_SCS("_get_items") );
+	ADD_PROPERTY( PropertyInfo(Variant::BOOL, "hide_on_item_selection" ), _SCS("set_hide_on_item_selection"), _SCS("get_hide_on_item_selection") );
 
 	ADD_SIGNAL( MethodInfo("item_pressed", PropertyInfo( Variant::INT,"ID") ) );
 
@@ -1128,6 +1145,7 @@ PopupMenu::PopupMenu() {
 
 	set_focus_mode(FOCUS_ALL);
 	set_as_toplevel(true);
+	set_hide_on_item_selection(true);
 
 	submenu_timer = memnew( Timer );
 	submenu_timer->set_wait_time(0.3);

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -899,11 +899,21 @@ void PopupMenu::activate_item(int p_item) {
 	Node *next = get_parent();
 	PopupMenu *pop = next->cast_to<PopupMenu>();
 	while (pop) {
-		pop->hide();
-		next = next->get_parent();
-		pop = next->cast_to<PopupMenu>();
+		// We close all parents that are chained together, 
+		// with hide_on_item_selection enabled
+		if(hide_on_item_selection && pop->is_hide_on_item_selection()) {
+			pop->hide();
+			next = next->get_parent();
+			pop = next->cast_to<PopupMenu>();
+		}
+		else {
+			// Break out of loop when the next parent has 
+			// hide_on_item_selection disabled
+			break;
+		}
 	}
-	// Hides popup by default; unless otherwise specified using set_hide_on_item_selection(p_bool)
+	// Hides popup by default; unless otherwise specified 
+	// by using set_hide_on_item_selection
 	if (hide_on_item_selection) {
 		hide();
 	}
@@ -1022,13 +1032,13 @@ void PopupMenu::_set_items(const Array& p_items){
 
 }
 
-// Hide on Select determines whether or not the popup will close after item selection
-void PopupMenu::set_hide_on_item_selection(bool p_bool) {
+// Hide on item selection determines whether or not the popup will close after item selection
+void PopupMenu::set_hide_on_item_selection(bool p_enabled) {
 
-	hide_on_item_selection=p_bool;
+	hide_on_item_selection=p_enabled;
 }
 
-bool PopupMenu::get_hide_on_item_selection() {
+bool PopupMenu::is_hide_on_item_selection() {
 
 	return hide_on_item_selection;
 }
@@ -1121,12 +1131,12 @@ void PopupMenu::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("_get_items"),&PopupMenu::_get_items);
 
 	ObjectTypeDB::bind_method(_MD("set_hide_on_item_selection","enable"),&PopupMenu::set_hide_on_item_selection);
-	ObjectTypeDB::bind_method(_MD("get_hide_on_item_selection"),&PopupMenu::get_hide_on_item_selection);
+	ObjectTypeDB::bind_method(_MD("is_hide_on_item_selection"),&PopupMenu::is_hide_on_item_selection);
 
 	ObjectTypeDB::bind_method(_MD("_submenu_timeout"),&PopupMenu::_submenu_timeout);
 
 	ADD_PROPERTY( PropertyInfo(Variant::ARRAY,"items",PROPERTY_HINT_NONE,"",PROPERTY_USAGE_NOEDITOR), _SCS("_set_items"),_SCS("_get_items") );
-	ADD_PROPERTY( PropertyInfo(Variant::BOOL, "hide_on_item_selection" ), _SCS("set_hide_on_item_selection"), _SCS("get_hide_on_item_selection") );
+	ADD_PROPERTYNO( PropertyInfo(Variant::BOOL, "hide_on_item_selection" ), _SCS("set_hide_on_item_selection"), _SCS("is_hide_on_item_selection") );
 
 	ADD_SIGNAL( MethodInfo("item_pressed", PropertyInfo( Variant::INT,"ID") ) );
 

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -74,6 +74,7 @@ class PopupMenu : public Popup {
 	void _submenu_timeout();
 
 	bool invalidated_click;
+	bool hide_on_item_selection;
 	Vector2 moved;
 
 	Array _get_items() const;
@@ -153,6 +154,8 @@ public:
 	void clear_autohide_areas();
 
 	void set_invalidate_click_until_motion();
+	void set_hide_on_item_selection(bool p_bool);
+	bool get_hide_on_item_selection();
 
 	PopupMenu();
 	~PopupMenu();

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -154,8 +154,8 @@ public:
 	void clear_autohide_areas();
 
 	void set_invalidate_click_until_motion();
-	void set_hide_on_item_selection(bool p_bool);
-	bool get_hide_on_item_selection();
+	void set_hide_on_item_selection(bool p_enabled);
+	bool is_hide_on_item_selection();
 
 	PopupMenu();
 	~PopupMenu();

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -5957,6 +5957,7 @@ EditorNode::EditorNode() {
 	debug_button->set_tooltip(TTR("Debug options"));
 
 	p=debug_button->get_popup();
+	p->set_hide_on_item_selection(false);
 	p->add_check_item(TTR("Deploy with Remote Debug"),RUN_DEPLOY_REMOTE_DEBUG);
 	p->set_item_tooltip(p->get_item_count()-1,TTR("When exporting or deploying, the resulting executable will attempt to connect to the IP of this computer in order to be debugged."));
 	p->add_check_item(TTR("Small Deploy with Network FS"),RUN_FILE_SERVER);


### PR DESCRIPTION
Added the option to set hide on item selection. Usable in GDScript and from within the source code when you want to specify popup menus you don't want to close immediately when selecting an item.

_(Sorry about Git, still learning and messing up..!)_