### PR TITLE
Implements documents for modules

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1049,6 +1049,7 @@ bool Main::start() {
 
 	bool editor=false;
 	String doc_tool;
+	List<String> removal_docs;
 	bool doc_base=true;
 	String game_path;
 	String script;
@@ -1082,6 +1083,8 @@ bool Main::start() {
 			bool parsed_pair=true;
 			if (args[i]=="-doctool") {
 				doc_tool=args[i+1];
+				for(int j=i+2; j<args.size();j++)
+					removal_docs.push_back(args[j]);
 			} else if (args[i]=="-script" || args[i]=="-s") {
 				script=args[i+1];
 			} else if (args[i]=="-level" || args[i]=="-l") {
@@ -1136,6 +1139,14 @@ bool Main::start() {
 		} else {
 			print_line("No Doc exists. Generating empty.");
 
+		}
+
+		for(List<String>::Element* E= removal_docs.front(); E; E=E->next()) {
+			DocData rmdoc;
+			if (rmdoc.load(E->get()) == OK) {
+				print_line(String("Removing classes in ") + E->get());
+				doc.remove_from(rmdoc);
+			}
 		}
 
 		doc.save(doc_tool);

--- a/tools/doc/doc_data.cpp
+++ b/tools/doc/doc_data.cpp
@@ -155,6 +155,13 @@ void DocData::merge_from(const DocData& p_data) {
 
 }
 
+void DocData::remove_from(const DocData &p_data) {
+	for(Map<String,ClassDoc>::Element* E=p_data.class_list.front(); E; E=E->next()) {
+		if(class_list.has(E->key()))
+			class_list.erase(E->key());
+	}
+}
+
 void DocData::generate(bool p_basic_types) {
 
 

--- a/tools/doc/doc_data.h
+++ b/tools/doc/doc_data.h
@@ -96,6 +96,7 @@ public:
 public:
 
 	void merge_from(const DocData& p_data);
+	void remove_from(const DocData& p_data);
 	void generate(bool p_basic_types=false);
 	Error load(const String& p_path);
 	Error save(const String& p_path);

--- a/tools/editor/SCsub
+++ b/tools/editor/SCsub
@@ -1,19 +1,28 @@
 #!/usr/bin/env python
 
+import os
 Import('env')
 
 
 def make_doc_header(target, source, env):
-
-    src = source[0].srcnode().abspath
     dst = target[0].srcnode().abspath
-    f = open(src, "rb")
     g = open(dst, "wb")
-    buf = f.read()
+    buf = ""
+    docbegin = ""
+    docend = ""
+    for s in source:
+        src = s.srcnode().abspath
+        f = open(src, "rb")
+        content = f.read()
+        buf += content[content.find("<class"): content.rfind("</doc>")]
+        if len(docbegin) == 0:
+            docbegin = content[0: content.find("<class")]
+        if len(docend) == 0:
+            docend = content[content.rfind("</doc>"): len(buf)]
+    buf = docbegin + buf + docend
     decomp_size = len(buf)
     import zlib
     buf = zlib.compress(buf)
-
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     g.write("#ifndef _DOC_DATA_RAW_H\n")
     g.write("#define _DOC_DATA_RAW_H\n")
@@ -62,9 +71,15 @@ if (env["tools"] == "yes"):
     f.write(reg_exporters_inc)
     f.write(reg_exporters)
     f.close()
-
-    env.Depends("#tools/editor/doc_data_compressed.h", "#doc/base/classes.xml")
-    env.Command("#tools/editor/doc_data_compressed.h", "#doc/base/classes.xml", make_doc_header)
+    docs = ["#doc/base/classes.xml"]
+    moduledir = os.path.join(os.getcwd(), "..", "..", "modules")
+    for m in os.listdir(moduledir):
+        curmodle = os.path.join(moduledir, m)
+        docfile = os.path.join(curmodle, "classes.xml")
+        if os.path.isdir(curmodle) and os.path.isfile(docfile):
+            docs.append(docfile)
+    env.Depends("#tools/editor/doc_data_compressed.h", docs)
+    env.Command("#tools/editor/doc_data_compressed.h", docs, make_doc_header)
 
     env.Depends("#tools/editor/certs_compressed.h", "#tools/certs/ca-certificates.crt")
     env.Command("#tools/editor/certs_compressed.h", "#tools/certs/ca-certificates.crt", make_certs_header)


### PR DESCRIPTION
Editor can generate class documentations for modules in thier own xml files.
* To extract document xml of a module with `-doctool`
```
$ ./bin/godot.x11.tools.64 -doctool ./modules/editor_server/classes.xml ./doc/base/classes.xml ./modules/rawpacker/classes.x
ml
```
This command generates class documents in `modules/editor_server/classes.xml` of the module `editor_server` which is all classes exported from C++ except classes defined in `doc/base/classes.xml` and `modules/rawpacker/classes.xml`
* The xml should be put in your module folder and name with `classes.xml`
* Fill the content of the generated xml file
* Rebuild your editor
* Your module documentation works!

(*Bugsquad edit*) Fixes #4562