### PR TITLE
Remove extraneous line in .po reader, which caused it to disregard first line

### DIFF
--- a/core/io/translation_loader_po.cpp
+++ b/core/io/translation_loader_po.cpp
@@ -33,8 +33,6 @@
 
 RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error, const String &p_path) {
 
-	String l = f->get_line();
-
 	enum Status {
 
 		STATUS_NONE,


### PR DESCRIPTION
Fixes #7337