### PR TITLE
Bugfixes for Tree node

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1396,11 +1396,7 @@ void Tree::select_single_item(TreeItem *p_selected, TreeItem *p_current, int p_c
 
 		if (select_mode==SELECT_ROW) {
 
-
-			if (p_selected==p_current) {
-
-				if (!c.selected) {
-
+			if (p_selected==p_current && !c.selected) {
 					c.selected=true;
 					selected_item=p_selected;
 					selected_col=0;
@@ -1410,23 +1406,16 @@ void Tree::select_single_item(TreeItem *p_selected, TreeItem *p_current, int p_c
 						emitted_row=true;
 					}
 					//if (p_col==i)
-					//	p_current->selected_signal.call(p_col);
-				}
+					 //	p_current->selected_signal.call(p_col);
 
-			} else {
-
-				if (c.selected) {
+			} else if (c.selected) {
 
 					c.selected=false;
 					//p_current->deselected_signal.call(p_col);
-				}
-
 			}
-
 		} else if (select_mode==SELECT_SINGLE || select_mode==SELECT_MULTI) {
 
 			if (!r_in_range && &selected_cell==&c) {
-
 
 				if (!selected_cell.selected) {
 
@@ -1438,6 +1427,8 @@ void Tree::select_single_item(TreeItem *p_selected, TreeItem *p_current, int p_c
 					emit_signal("cell_selected");
 					if (select_mode==SELECT_MULTI)
 						emit_signal("multi_selected",p_current,i,true);
+					else if(select_mode == SELECT_SINGLE)
+						emit_signal("item_selected");
 
 				} else if (select_mode==SELECT_MULTI && (selected_item!=p_selected || selected_col!=i)) {
 
@@ -2923,8 +2914,7 @@ void Tree::item_selected(int p_column,TreeItem *p_item) {
 
 void Tree::item_deselected(int p_column,TreeItem *p_item) {
 
-	if (select_mode==SELECT_MULTI) {
-
+	if (select_mode==SELECT_MULTI || select_mode == SELECT_SINGLE) {
 		p_item->cells[p_column].selected=false;
 	}
 	update();


### PR DESCRIPTION
This PR fixes 2 bugs: 

-  Deselecting a TreeItem when select_mode is SELECT_SINGLE now works;
- Fixes #3549, now when select_mode is SELECT_SINGLE, the signal item_selected is emitted.