### PR TITLE
Allows to start the scene with custom arguments within the editor

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -1848,7 +1848,6 @@ void EditorNode::_run(bool p_current,const String& p_custom) {
 
 			run_filename=scene->get_filename();
 		} else {
-			args=run_settings_dialog->get_custom_arguments();
 			current_filename=scene->get_filename();
 		}
 
@@ -1926,6 +1925,8 @@ void EditorNode::_run(bool p_current,const String& p_custom) {
 
 	List<String> breakpoints;
 	editor_data.get_editor_breakpoints(&breakpoints);
+    
+	args = Globals::get_singleton()->get("editor/main_run_args");
 
 	Error error = editor_run.run(run_filename,args,breakpoints,current_filename);
 
@@ -5458,7 +5459,7 @@ EditorNode::EditorNode() {
 
 	editor_import_export->load_config();
 
-	GLOBAL_DEF("editor/main_run_args","$exec -path $path -scene $scene $main_scene");
+	GLOBAL_DEF("editor/main_run_args","$scene");
 
 	ObjectTypeDB::set_type_enabled("CollisionShape",true);
 	ObjectTypeDB::set_type_enabled("CollisionShape2D",true);

--- a/tools/editor/editor_run.cpp
+++ b/tools/editor/editor_run.cpp
@@ -55,15 +55,6 @@ Error EditorRun::run(const String& p_scene,const String p_custom_args,const List
 	args.push_back("-epid");
 	args.push_back(String::num(OS::get_singleton()->get_process_ID()));
 
-	if (p_custom_args!="") {
-
-		Vector<String> cargs=p_custom_args.split(" ",false);
-		for(int i=0;i<cargs.size();i++) {
-
-			args.push_back(cargs[i].replace("%20"," ").replace("$scene",p_edited_scene.replace(" ","%20")));
-		}
-	}
-
 	if (debug_collisions) {
 		args.push_back("-debugcol");
 	}
@@ -150,7 +141,12 @@ Error EditorRun::run(const String& p_scene,const String p_custom_args,const List
 		args.push_back(bpoints);
 	}
 
-	args.push_back(p_scene);
+	if (p_custom_args!="") {
+		Vector<String> cargs=p_custom_args.split(" ",false);
+		for(int i=0;i<cargs.size();i++) {
+			args.push_back(cargs[i].replace("$scene",p_scene).replace(" ","%20"));
+		}
+	}
 
 	String exec = OS::get_singleton()->get_executable_path();
 


### PR DESCRIPTION
fixes #7346

Path from the current scene isn't added too the argumens anymore by default and needs to be added throug the custom arguments, with $scene. Matches the behaviour of the executable without any arguments.
Custom Arguments are read from editor/main_run_args