### PR TITLE
Fix duplicated string on RichTextLabel if starts with '\n'

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1179,7 +1179,8 @@ void RichTextLabel::add_text(const String& p_text) {
 			item->line=current_frame->lines.size();
 			_add_item(item,false);
 			current_frame->lines.resize(current_frame->lines.size()+1);
-			current_frame->lines[current_frame->lines.size()-1].from=item;
+			if (item->type!=ITEM_NEWLINE)
+				current_frame->lines[current_frame->lines.size()-1].from=item;
 			_invalidate_current_line(current_frame);
 
 		}


### PR DESCRIPTION
Fix #6212, fix #3773

Test result

![image](https://cloud.githubusercontent.com/assets/8281454/21410491/737b2422-c824-11e6-8c91-864817da3222.png)

dug for several hours...