### PR TITLE
Fix issue #7331

### DIFF
--- a/drivers/windows/dir_access_windows.h
+++ b/drivers/windows/dir_access_windows.h
@@ -44,7 +44,7 @@ struct DirAccessWindowsPrivate;
 class DirAccessWindows : public DirAccess {
 
 	enum {
-		MAX_DRIVES=25
+		MAX_DRIVES=26
 	};
 
 


### PR DESCRIPTION
A Drive with "Z" letter assigned to it on Windows will be shown.