### PR TITLE
Exposing edit_resource method of EditorNode in the EditorPlugin

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -11859,6 +11859,13 @@
 				Get the main editor control. Use this as a parent for main screens.
 			</description>
 		</method>
+		<method name="edit_resource">
+			<argument index="0" name="p_resource" type="Resource">
+			</argument>
+			<description>
+				Tells the editor to handle the edit of the given resource. Ex: If you pass a Script as a argument, the editor will open the scriptEditor.
+			</description>
+		</method>
 		<method name="get_name" qualifiers="virtual">
 			<return type="String">
 			</return>

--- a/tools/editor/editor_plugin.cpp
+++ b/tools/editor/editor_plugin.cpp
@@ -78,7 +78,7 @@ Control * EditorPlugin::get_editor_viewport() {
 
 void EditorPlugin::edit_resource(const Ref<Resource>& p_resource){
 
-    EditorNode::get_singleton()->edit_resource(p_resource);
+	EditorNode::get_singleton()->edit_resource(p_resource);
 }
 
 void EditorPlugin::add_control_to_container(CustomControlContainer p_location,Control *p_control) {
@@ -375,7 +375,7 @@ void EditorPlugin::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_selection:EditorSelection"),&EditorPlugin::get_selection);
 	ObjectTypeDB::bind_method(_MD("get_editor_settings:EditorSettings"),&EditorPlugin::get_editor_settings);
 	ObjectTypeDB::bind_method(_MD("queue_save_layout"),&EditorPlugin::queue_save_layout);
-    ObjectTypeDB::bind_method(_MD("edit_resource"),&EditorPlugin::edit_resource);
+	ObjectTypeDB::bind_method(_MD("edit_resource"),&EditorPlugin::edit_resource);
 
 	ObjectTypeDB::add_virtual_method(get_type_static(),MethodInfo(Variant::BOOL,"forward_canvas_input_event",PropertyInfo(Variant::MATRIX32,"canvas_xform"),PropertyInfo(Variant::INPUT_EVENT,"event")));
 	ObjectTypeDB::add_virtual_method(get_type_static(),MethodInfo("forward_draw_over_canvas",PropertyInfo(Variant::MATRIX32,"canvas_xform"),PropertyInfo(Variant::OBJECT,"canvas:Control")));

--- a/tools/editor/editor_plugin.cpp
+++ b/tools/editor/editor_plugin.cpp
@@ -76,6 +76,11 @@ Control * EditorPlugin::get_editor_viewport() {
 	return EditorNode::get_singleton()->get_viewport();
 }
 
+void EditorPlugin::edit_resource(const Ref<Resource>& p_resource){
+
+    EditorNode::get_singleton()->edit_resource(p_resource);
+}
+
 void EditorPlugin::add_control_to_container(CustomControlContainer p_location,Control *p_control) {
 
 	switch(p_location) {
@@ -370,6 +375,7 @@ void EditorPlugin::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_selection:EditorSelection"),&EditorPlugin::get_selection);
 	ObjectTypeDB::bind_method(_MD("get_editor_settings:EditorSettings"),&EditorPlugin::get_editor_settings);
 	ObjectTypeDB::bind_method(_MD("queue_save_layout"),&EditorPlugin::queue_save_layout);
+    ObjectTypeDB::bind_method(_MD("edit_resource"),&EditorPlugin::edit_resource);
 
 	ObjectTypeDB::add_virtual_method(get_type_static(),MethodInfo(Variant::BOOL,"forward_canvas_input_event",PropertyInfo(Variant::MATRIX32,"canvas_xform"),PropertyInfo(Variant::INPUT_EVENT,"event")));
 	ObjectTypeDB::add_virtual_method(get_type_static(),MethodInfo("forward_draw_over_canvas",PropertyInfo(Variant::MATRIX32,"canvas_xform"),PropertyInfo(Variant::OBJECT,"canvas:Control")));

--- a/tools/editor/editor_plugin.h
+++ b/tools/editor/editor_plugin.h
@@ -101,6 +101,7 @@ public:
 	void remove_control_from_docks(Control *p_control);
 	void remove_control_from_bottom_panel(Control *p_control);
 	Control* get_editor_viewport();
+    void edit_resource(const Ref<Resource>& p_resource);
 
 	virtual Ref<SpatialEditorGizmo> create_spatial_gizmo(Spatial* p_spatial);
 	virtual bool forward_canvas_input_event(const Matrix32& p_canvas_xform, const InputEvent& p_event);

--- a/tools/editor/editor_plugin.h
+++ b/tools/editor/editor_plugin.h
@@ -101,7 +101,7 @@ public:
 	void remove_control_from_docks(Control *p_control);
 	void remove_control_from_bottom_panel(Control *p_control);
 	Control* get_editor_viewport();
-    void edit_resource(const Ref<Resource>& p_resource);
+	void edit_resource(const Ref<Resource>& p_resource);
 
 	virtual Ref<SpatialEditorGizmo> create_spatial_gizmo(Spatial* p_spatial);
 	virtual bool forward_canvas_input_event(const Matrix32& p_canvas_xform, const InputEvent& p_event);


### PR DESCRIPTION
I'm trying to open a script in the editor using GDScript. The easiest way that i found, was exposing the edit_resource method of EditorNode.