### PR TITLE
Fix bottom panel visibility on play

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -1922,6 +1922,9 @@ void EditorNode::_run(bool p_current,const String& p_custom) {
 		log->clear();
 	}
 
+	if (bool(EDITOR_DEF("run/always_open_output_on_play", true))) {
+		make_bottom_panel_item_visible(log);
+	}
 
 	List<String> breakpoints;
 	editor_data.get_editor_breakpoints(&breakpoints);

--- a/tools/editor/script_editor_debugger.cpp
+++ b/tools/editor/script_editor_debugger.cpp
@@ -581,7 +581,6 @@ void ScriptEditorDebugger::_parse_message(const String& p_msg,const Array& p_dat
 			//LOG
 
 			if (EditorNode::get_log()->is_hidden()) {
-				log_forced_visible=true;
 				if (EditorNode::get_singleton()->are_bottom_panels_hidden()) {
 					EditorNode::get_singleton()->make_bottom_panel_item_visible(EditorNode::get_log());
 				}
@@ -957,7 +956,6 @@ void ScriptEditorDebugger::_notification(int p_what) {
 						break;
 
 					EditorNode::get_log()->add_message("** Debug Process Started **");
-					log_forced_visible=false;
 
 					ppeer->set_stream_peer(connection);
 
@@ -1089,8 +1087,8 @@ void ScriptEditorDebugger::start() {
 
 	stop();
 
-	if (!EditorNode::get_log()->is_visible()) {
-		EditorNode::get_singleton()->make_bottom_panel_item_visible(EditorNode::get_log());
+	if (is_visible()) {
+		EditorNode::get_singleton()->make_bottom_panel_item_visible(this);
 	}
 
 	uint16_t port = GLOBAL_DEF("debug/remote_port",6007);
@@ -1131,13 +1129,6 @@ void ScriptEditorDebugger::stop(){
 
 	pending_in_queue=0;
 	message.clear();
-
-	if (log_forced_visible) {
-		//EditorNode::get_singleton()->make_bottom_panel_item_visible(this);
-		if (EditorNode::get_log()->is_visible())
-			EditorNode::get_singleton()->hide_bottom_panel();
-		log_forced_visible=false;
-	}
 
 	node_path_cache.clear();
 	res_path_cache.clear();
@@ -1979,8 +1970,6 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor){
 
 	msgdialog = memnew( AcceptDialog );
 	add_child(msgdialog);
-
-	log_forced_visible=false;
 
 	p_editor->get_undo_redo()->set_method_notify_callback(_method_changeds,this);
 	p_editor->get_undo_redo()->set_property_notify_callback(_property_changeds,this);

--- a/tools/editor/script_editor_debugger.h
+++ b/tools/editor/script_editor_debugger.h
@@ -96,7 +96,6 @@ class ScriptEditorDebugger : public Control {
 	TabContainer *tabs;
 
 	LineEdit *reason;
-	bool log_forced_visible;
 	ScriptEditorDebuggerVariables *variables;
 
 	Button *step;


### PR DESCRIPTION
**Before this patch:**
When you click play button, "Output" console always open, even if the debugger
or other panel was open. This is very annoying IMO.

**After this patch:**
Let the users choose what panel they want, if the output console is open, then
will stay opened, if the debugger is open, it will stay opened (only if you checked the option in the script panel), etc. 

**I added a new option called "run/always_open_output_on_play" setted to true to keep the old behavior too.**
