### PR TITLE
Fix ColorPicker not correctly updating after pasting hex html color

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -162,7 +162,7 @@ void ColorPicker::_html_entered(const String& p_html) {
 	if (!is_inside_tree())
 		return;
 
-	_update_color();
+	set_color(color);
 	emit_signal("color_changed",color);
 }
 


### PR DESCRIPTION
Fixes #7365 (ColorPicker not correctly updating after pasting hex html color)