### PR TITLE
Add the 'finished' signal to AnimatedSprite

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -2519,6 +2519,11 @@
 				Emitted when frame is changed.
 			</description>
 		</signal>
+		<signal name="finished">
+			<description>
+				Emitted when the animation is finished (when it plays the last frame). If the animation is looping, this signal is emitted everytime the last frame is drawn, before looping.
+			</description>
+		</signal>
 	</signals>
 	<constants>
 	</constants>

--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -362,6 +362,9 @@ void AnimatedSprite::_notification(int p_what) {
 						}
 					} else {
 						frame++;
+						if (frame==fc-1) {
+							emit_signal(SceneStringNames::get_singleton()->finished);
+						}
 					}
 
 					update();
@@ -696,6 +699,7 @@ void AnimatedSprite::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("_res_changed"),&AnimatedSprite::_res_changed);
 
 	ADD_SIGNAL(MethodInfo("frame_changed"));
+	ADD_SIGNAL(MethodInfo("finished"));
 
 	ADD_PROPERTYNZ( PropertyInfo( Variant::OBJECT, "frames",PROPERTY_HINT_RESOURCE_TYPE,"SpriteFrames"), _SCS("set_sprite_frames"),_SCS("get_sprite_frames"));
 	ADD_PROPERTY( PropertyInfo( Variant::STRING, "animation"), _SCS("set_animation"),_SCS("get_animation"));


### PR DESCRIPTION
This PR adds the `finished` signal to AnimatedSprite.
If the animation is looping it will be emitted everytime the last frame is reached.

Fixes #7316 