### PR TITLE
Add set_camera_pos method to Camera2D

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -433,6 +433,12 @@ Vector2 Camera2D::get_camera_pos() const {
 	return camera_pos;
 }
 
+void Camera2D::set_camera_pos(Vector2 pos) {
+
+
+	camera_pos = pos;
+}
+
 void Camera2D::force_update_scroll() {
 
 
@@ -630,6 +636,7 @@ void Camera2D::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_drag_margin","margin"),&Camera2D::get_drag_margin);
 
 	ObjectTypeDB::bind_method(_MD("get_camera_pos"),&Camera2D::get_camera_pos);
+	ObjectTypeDB::bind_method(_MD("set_camera_pos"),&Camera2D::set_camera_pos);
 	ObjectTypeDB::bind_method(_MD("get_camera_screen_center"),&Camera2D::get_camera_screen_center);
 
 	ObjectTypeDB::bind_method(_MD("set_zoom","zoom"),&Camera2D::set_zoom);

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -134,6 +134,7 @@ public:
 	Node* get_custom_viewport() const;
 
 	Vector2 get_camera_pos() const;
+	void set_camera_pos(Vector2 pos);
 	void force_update_scroll();
 	void reset_smoothing();
 	void align();


### PR DESCRIPTION
This method can be handy for some custom stuff with a Camera2D.