### PR TITLE
Fixing compilation errors for gles3 for Mac OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ os:
 
 env:
   #- GODOT_TARGET=iphone
-  #- GODOT_TARGET=osx
+  - GODOT_TARGET=osx
   - GODOT_TARGET=x11
   #- GODOT_TARGET=android
   - GODOT_TARGET=windows

--- a/drivers/gl_context/glad/glad.h
+++ b/drivers/gl_context/glad/glad.h
@@ -150,12 +150,26 @@ typedef unsigned int GLhandleARB;
 typedef unsigned short GLhalfARB;
 typedef unsigned short GLhalf;
 typedef GLint GLfixed;
+// Temporary work around for upstream issue: https://github.com/Dav1dde/glad/issues/70
+// Originally fixed by Algorithmus, reapplied in master
+#if defined(__APPLE__)
+typedef long GLintptr;
+typedef long GLsizeiptr;
+#else
 typedef ptrdiff_t GLintptr;
 typedef ptrdiff_t GLsizeiptr;
+#endif
 typedef int64_t GLint64;
 typedef uint64_t GLuint64;
+// Temporary work around for upstream issue: https://github.com/Dav1dde/glad/issues/70
+// Originally fixed by Algorithmus, reapplied in master
+#if defined(__APPLE__)
+typedef long GLintptrARB;
+typedef long GLsizeiptrARB;
+#else
 typedef ptrdiff_t GLintptrARB;
 typedef ptrdiff_t GLsizeiptrARB;
+#endif
 typedef int64_t GLint64EXT;
 typedef uint64_t GLuint64EXT;
 typedef struct __GLsync *GLsync;

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -136,9 +136,13 @@ void RasterizerGLES3::initialize() {
 		ERR_PRINT("Error initializing GLAD");
 	}
 
+#ifdef __APPLE__
+	// FIXME glDebugMessageCallbackARB does not seem to work on Mac OS X and opengl 3, this may be an issue with our opengl canvas..
+#else
 	glEnable(_EXT_DEBUG_OUTPUT_SYNCHRONOUS_ARB);
 	glDebugMessageCallbackARB(_gl_debug_print, NULL);
 	glEnable(_EXT_DEBUG_OUTPUT);
+#endif
 
 #endif
 

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -35,7 +35,7 @@
 #include "drivers/unix/os_unix.h"
 #include "main/input_default.h"
 #include "servers/visual_server.h"
-#include "servers/visual/visual_server_wrap_mt.h"
+// #include "servers/visual/visual_server_wrap_mt.h"
 #include "servers/visual/rasterizer.h"
 #include "servers/physics_server.h"
 #include "servers/audio/audio_server_sw.h"
@@ -58,7 +58,8 @@
 class OS_OSX : public OS_Unix {
 public:
 	bool force_quit;
-	Rasterizer *rasterizer;
+//  rasterizer seems to no longer be given to visual server, its using GLES3 directly?
+//	Rasterizer *rasterizer;
 	VisualServer *visual_server;
 
 	List<String> args;

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -987,13 +987,11 @@ void OS_OSX::initialize(const VideoMode& p_desired,int p_video_driver,int p_audi
 	window_size.width = p_desired.width;
 	window_size.height = p_desired.height;
 
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
 	if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6 && display_scale>1) {
 	    [window_view setWantsBestResolutionOpenGLSurface:YES];
 	    //if (current_videomode.resizable)
 		[window_object setCollectionBehavior:NSWindowCollectionBehaviorFullScreenPrimary];
 	}
-#endif /*MAC_OS_X_VERSION_MAX_ALLOWED*/
 
 //	[window_object setTitle:[NSString stringWithUTF8String:"GodotEnginies"]];
 	[window_object setContentView:window_view];
@@ -1001,10 +999,8 @@ void OS_OSX::initialize(const VideoMode& p_desired,int p_video_driver,int p_audi
 	[window_object setAcceptsMouseMovedEvents:YES];
 	[window_object center];
 
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
 	if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6)
 		[window_object setRestorable:NO];
-#endif /*MAC_OS_X_VERSION_MAX_ALLOWED*/
 
 	unsigned int attributeCount = 0;
 
@@ -1023,10 +1019,8 @@ void OS_OSX::initialize(const VideoMode& p_desired,int p_video_driver,int p_audi
 	ADD_ATTR(NSOpenGLPFADoubleBuffer);
 	ADD_ATTR(NSOpenGLPFAClosestPolicy);
 
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
-	if (false/* use gl3*/)
-		ADD_ATTR2(NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersion3_2Core);
-#endif /*MAC_OS_X_VERSION_MAX_ALLOWED*/
+//	we now need OpenGL 3 or better, maybe even change this to 3_3Core ?
+	ADD_ATTR2(NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersion3_2Core);
 
 	ADD_ATTR2(NSOpenGLPFAColorSize, colorBits);
 

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -38,13 +38,14 @@
 #include "servers/visual/visual_server_raster.h"
 //#include "drivers/opengl/rasterizer_gl.h"
 //#include "drivers/gles2/rasterizer_gles2.h"
+#include "drivers/gles3/rasterizer_gles3.h"
 #include "os_osx.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include "print_string.h"
 #include "servers/physics/physics_server_sw.h"
-#include "drivers/gles2/rasterizer_instance_gles2.h"
-#include "servers/visual/visual_server_wrap_mt.h"
+// #include "drivers/gles2/rasterizer_instance_gles2.h"
+// #include "servers/visual/visual_server_wrap_mt.h"
 #include "main/main.h"
 #include "os/keyboard.h"
 #include "dir_access_osx.h"
@@ -1084,15 +1085,19 @@ void OS_OSX::initialize(const VideoMode& p_desired,int p_video_driver,int p_audi
 
 	AudioDriverManagerSW::add_driver(&audio_driver_osx);
 
+	// only opengl support here... 
+	RasterizerGLES3::register_config();
+	RasterizerGLES3::make_current();
 
-	rasterizer = instance_RasterizerGLES2();
+//	rasterizer = instance_RasterizerGLES2();
+//	visual_server = memnew( VisualServerRaster(rasterizer) );
 
-	visual_server = memnew( VisualServerRaster(rasterizer) );
-
-	if (get_render_thread_mode()!=RENDER_THREAD_UNSAFE) {
-
-		visual_server =memnew(VisualServerWrapMT(visual_server,get_render_thread_mode()==RENDER_SEPARATE_THREAD));
-	}
+	visual_server = memnew( VisualServerRaster );
+	// FIXME: Reimplement threaded rendering? Or remove?
+//	if (get_render_thread_mode()!=RENDER_THREAD_UNSAFE) {
+//
+//		visual_server =memnew(VisualServerWrapMT(visual_server,get_render_thread_mode()==RENDER_SEPARATE_THREAD));
+//	}
 	visual_server->init();
 	visual_server->cursor_set_visible(false, 0);
 
@@ -1176,7 +1181,7 @@ void OS_OSX::finalize() {
 
 	visual_server->finish();
 	memdelete(visual_server);
-	memdelete(rasterizer);
+//	memdelete(rasterizer);
 
 	physics_server->finish();
 	memdelete(physics_server);

--- a/platform/osx/platform_config.h
+++ b/platform/osx/platform_config.h
@@ -28,6 +28,7 @@
 /*************************************************************************/
 #include <alloca.h>
 
-#define GLES2_INCLUDE_H "GL/glew.h"
-#define GLES3_INCLUDE_H "GL/glew.h"
+//#define GLES2_INCLUDE_H "GL/glew.h"
+//#define GLES3_INCLUDE_H "GL/glew.h"
+#define GLES3_INCLUDE_H "gl_context/glad/glad.h"
 #define PTHREAD_RENAME_SELF

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1087,13 +1087,15 @@ void OS_Windows::initialize(const VideoMode& p_desired,int p_video_driver,int p_
 
 	RasterizerGLES3::make_current();
 #else
- #ifdef DX9_ENABLED
+	// FIXME: Does DX support still work now that rasterizer is no longer used?
+#ifdef DX9_ENABLED
 	rasterizer = memnew( RasterizerDX9(hWnd) );
- #endif
+#endif
 #endif
 
 	visual_server = memnew( VisualServerRaster );
-	//if (get_render_thread_mode()!=RENDER_THREAD_UNSAFE) {
+ 	// FIXME: Reimplement threaded rendering? Or remove?
+//	if (get_render_thread_mode()!=RENDER_THREAD_UNSAFE) {
 //
 //		visual_server =memnew(VisualServerWrapMT(visual_server,get_render_thread_mode()==RENDER_SEPARATE_THREAD));
 //	}

--- a/servers/visual/shader_language.h
+++ b/servers/visual/shader_language.h
@@ -151,6 +151,11 @@ public:
 
 	/* COMPILER */
 
+	// lame work around to Apple defining this as a macro in 10.12 SDK
+	#ifdef TYPE_BOOL
+	#undef TYPE_BOOL
+	#endif
+
 	enum DataType {
 		TYPE_VOID,
 		TYPE_BOOL,


### PR DESCRIPTION
This is so far the first round of changes to get the compilation errors fixed on Mac OS X. More to follow. It compiles but is still broken at this point in time. Some of the fixes are coming from earlier PRs that went into the glew3 branch and didn't make it into the master.

Also there is a temporary fix in here until this issue is fixed upstream:
https://github.com/Dav1dde/glad/issues/70

(hopefully resolved this weekend..)

