### PR TITLE
Fix #7455 - script text editor's right click menu being weird

### DIFF
--- a/tools/editor/plugins/script_text_editor.cpp
+++ b/tools/editor/plugins/script_text_editor.cpp
@@ -1226,20 +1226,21 @@ void ScriptTextEditor::_make_context_menu(bool p_selection, bool p_color) {
 
 	context_menu->clear();
 	if (p_selection) {
-		context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/cut"));
-		context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/copy"));
+		context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/cut"), EDIT_CUT);
+		context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/copy"), EDIT_COPY);
 	}
 
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/paste"));
+	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/paste"), EDIT_PASTE);
 	context_menu->add_separator();
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/select_all"));
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/undo"));
+	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/select_all"), EDIT_SELECT_ALL);
+	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/undo"), EDIT_UNDO);
+	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/redo"), EDIT_REDO);
 
 	if (p_selection) {
 		context_menu->add_separator();
-		context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/indent_left"));
-		context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/indent_right"));
-		context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_comment"));
+		context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/indent_left"), EDIT_INDENT_LEFT);
+		context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/indent_right"), EDIT_INDENT_RIGHT);
+		context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_comment"), EDIT_TOGGLE_COMMENT);
 	}
 	if (p_color) {
 		context_menu->add_separator();


### PR DESCRIPTION
@akien-mga Would be a nice thing to backport to 2.2 as well.