### PR TITLE
Fix codeblock tag in classes.xml for EditorSettings

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -12293,7 +12293,8 @@
 			</argument>
 			<description>
 				Add a custom property info to a property. The dictionary must contain: name:[String](the name of the property) and type:[int](see TYPE_* in [@Global Scope]), and optionally hint:[int](see PROPERTY_HINT_* in [@Global Scope]), hint_string:[String].
-			Example:[codeblock]
+			Example:
+			[codeblock]
 			editor_settings.set("category/property_name", 0)
 
 			var property_info = {
@@ -12303,7 +12304,8 @@
 			    "hint_string": "one,two,three"
 			}
 
-			editor_settings.add_property_info(property_info)[/codeblock]
+			editor_settings.add_property_info(property_info)
+			[/codeblock]
 			</description>
 		</method>
 		<method name="erase">


### PR DESCRIPTION
http://docs.godotengine.org/en/stable/classes/class_editorsettings.html?highlight=EditorSettings#member-function-description

codeblock tag is currently not working for there.