### PR TITLE
Fix include path for builtin libpng.

### DIFF
--- a/drivers/png/SCsub
+++ b/drivers/png/SCsub
@@ -28,6 +28,7 @@ if (env['builtin_libpng'] != 'no'):
 
     env_png.add_source_files(env.drivers_sources, thirdparty_sources)
     env_png.Append(CPPPATH=[thirdparty_dir])
+    env.Append(CPPPATH=[thirdparty_dir])
 
     # Currently .ASM filter_neon.S does not compile on NT.
     import os


### PR DESCRIPTION
Previously, this only added the libpng directory to the include path for the local (cloned) env.
So the rest of the codebase still tried to use the system headers when building with `builtin_libpng=yes`.