### PR TITLE
Windows: Workaround missing includes in MinGW-w64 < 4

### DIFF
--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -42,7 +42,19 @@
   #include <windows.h>
   #include <stdio.h>
   #ifndef UWP_ENABLED
-    #include <iphlpapi.h>
+    #if defined(__MINGW32__ ) && (!defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 4)
+      // MinGW-w64 on Ubuntu 12.04 (our Travis build env) has bugs in this code where
+      // some includes are missing in dependencies of iphlpapi.h for WINVER >= 0x0600 (Vista).
+      // We don't use this Vista code for now, so working it around by disabling it.
+      // MinGW-w64 >= 4.0 seems to be better judging by its headers.
+      #undef _WIN32_WINNT
+      #define _WIN32_WINNT 0x0501 // Windows XP, disable Vista API
+      #include <iphlpapi.h>
+      #undef _WIN32_WINNT
+      #define _WIN32_WINNT 0x0600 // Reenable Vista API
+    #else
+      #include <iphlpapi.h>
+    #endif // MINGW hack
   #endif
 #else
  #include <netdb.h>


### PR DESCRIPTION
The MinGW-w64 version we have on our Travis build environment (Ubuntu 12.04,
mingw-w64 2.0.1, gcc 4.6) is old and has some missing includes in the
dependencies of the `tcpmib.h` header [0] [1] [2].
Those were not triggered before 6323779596dea0db7f58afef7d3d3d5588ef20cb
probably due to conflicting WINVER definitions which prevented triggering the code
specific to >= 0x0600 (Vista). We ensure it won't be triggered by defining the
_WIN32_WINNT macro to Windows XP compatibility.