### PR TITLE
More uniform reuse fix (2.1)

### DIFF
--- a/drivers/gles2/shader_compiler_gles2.cpp
+++ b/drivers/gles2/shader_compiler_gles2.cpp
@@ -571,15 +571,12 @@ Error ShaderCompilerGLES2::compile_node(SL::ProgramNode *p_program) {
 
 		global_code+=uline;
 		if (uniforms) {
-			//if (uniforms->has(E->key())) {
-			//	//repeated uniform, error
-		//		ERR_EXPLAIN("Uniform already exists from other shader: "+String(E->key()));
-		//		ERR_FAIL_COND_V(uniforms->has(E->key()),ERR_ALREADY_EXISTS);
-//
-//			}
-			SL::Uniform u = E->get();
-			u.order+=ubase;
-			uniforms->insert(E->key(),u);
+			// Check to avoid uniforms with the same name being re-added to avoid overwriting entries
+			if (!uniforms->has(E->key())) {
+				SL::Uniform u = E->get();
+				u.order+=ubase;
+				uniforms->insert(E->key(),u);
+			}
 		}
 	}
 


### PR DESCRIPTION
Follow-up of #7344 

Covers some cases in which the order of the uniforms in the source makes some of the disappear from the material params list so they don't get a correct value at runtime nor one can be set in the editor.