### PR TITLE
Setting to control node name casing of nodes created in the editor

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1309,6 +1309,17 @@ String Node::_generate_serial_child_name(Node *p_child) {
 	if (name=="") {
 
 		name = p_child->get_type();
+		// Adjust casing according to project setting. The current type name is expected to be in PascalCase.
+		switch (Globals::get_singleton()->get("node/name_casing").operator int()) {
+			case NAME_CASING_PASCAL_CASE:
+				break;
+			case NAME_CASING_CAMEL_CASE:
+				name[0] = name.to_lower()[0];
+				break;
+			case NAME_CASING_SNAKE_CASE:
+				name = name.camelcase_to_underscore(true);
+				break;
+		}
 	}
 
 	// Extract trailing number
@@ -2811,6 +2822,8 @@ void Node::_bind_methods() {
 
 	_GLOBAL_DEF("node/name_num_separator",0);
 	Globals::get_singleton()->set_custom_property_info("node/name_num_separator",PropertyInfo(Variant::INT,"node/name_num_separator",PROPERTY_HINT_ENUM, "None,Space,Underscore,Dash"));
+	_GLOBAL_DEF("node/name_casing",0);
+	Globals::get_singleton()->set_custom_property_info("node/name_casing",PropertyInfo(Variant::INT,"node/name_casing",PROPERTY_HINT_ENUM,"PascalCase,camelCase,snake_case"));
 
 
 	ObjectTypeDB::bind_method(_MD("_add_child_below_node","node:Node","child_node:Node","legible_unique_name"),&Node::add_child_below_node,DEFVAL(false));

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -143,6 +143,11 @@ private:
 
 	} data;
 
+	enum NameCasing {
+		NAME_CASING_PASCAL_CASE,
+		NAME_CASING_CAMEL_CASE,
+		NAME_CASING_SNAKE_CASE
+	};
 
 	void _print_tree(const Node *p_node);
 

--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -575,6 +575,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("scenetree_editor/start_create_dialog_fully_expanded",false);
 	set("scenetree_editor/draw_relationship_lines",false);
 	set("scenetree_editor/relationship_line_color",Color::html("464646"));
+	set("scenetree_editor/new_node_name_casing",0);
+	hints["scenetree_editor/new_node_name_casing"]=PropertyInfo(Variant::INT,"scenetree_editor/new_node_name_casing",PROPERTY_HINT_ENUM,"PascalCase,camelCase,snake_case");
 
 	set("grid_map/pick_distance", 5000.0);
 

--- a/tools/editor/scene_tree_dock.h
+++ b/tools/editor/scene_tree_dock.h
@@ -159,6 +159,14 @@ class SceneTreeDock : public VBoxContainer {
 	void _replace_with_branch_scene(const String& p_file,Node* base);
 
 	void _file_selected(String p_file);
+
+	enum NodeNameCasing {
+		NODE_NAME_CASING_PASCAL_CASE,
+		NODE_NAME_CASING_CAMEL_CASE,
+		NODE_NAME_CASING_SNAKE_CASE
+	};
+	NodeNameCasing _get_node_name_casing(const String& p_property);
+
 protected:
 
 	void _notification(int p_what);


### PR DESCRIPTION
Implementation of feature proposal https://github.com/godotengine/godot/issues/7319

I added a setting under **Scenetree Editor > New Node Name Casing** to select from `PascalCase` (default), `camelCase` or `snake_case`.

It should be noted that I used the `String::camelcase_to_underscore` method for snake_case, which turns **Node2D** into **node2_d**, not very nice (I would've expected **node_2d**). I don't know if that should be fixed in the `camelcase_to_underscore` method or if I should use another, new and custom method for node names.

_Since this is my very first PR to this repository, I wasn't sure if everything is implemented as expected. I'd love to hear feedback on the few lines I changed and what I all did wrong in them_ 😝