### PR TITLE
Improvements to scons defined WINVER/_WIN32_WINNT

### DIFF
--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -33,10 +33,6 @@
 #include <string.h>
 
 #ifdef WINDOWS_ENABLED
-  // Workaround mingw missing flags!
-  #ifndef AI_ADDRCONFIG
-    #define AI_ADDRCONFIG 0x00000400
-  #endif
   #include <ws2tcpip.h>
   #include <winsock2.h>
   #include <windows.h>

--- a/drivers/unix/socket_helpers.h
+++ b/drivers/unix/socket_helpers.h
@@ -3,15 +3,11 @@
 
 #include <string.h>
 
-#ifdef WINDOWS_ENABLED
- // Workaround mingw missing flags!
- #ifndef IPV6_V6ONLY
-  #define IPV6_V6ONLY 27
- #endif
-#endif
-
-#ifdef UWP_ENABLED
-#define in6addr_any IN6ADDR_ANY_INIT
+#if defined(__MINGW32__ ) && (!defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 4)
+  // Workaround for mingw-w64 < 4.0
+  #ifndef IPV6_V6ONLY
+    #define IPV6_V6ONLY 27
+  #endif
 #endif
 
 // helpers for sockaddr -> IP_Address and back, should work for posix and winsock. All implementations should use this

--- a/platform/uwp/detect.py
+++ b/platform/uwp/detect.py
@@ -145,9 +145,13 @@ def configure(env):
 
     env.Append(CCFLAGS=['/DGLES2_ENABLED', '/DGL_GLEXT_PROTOTYPES', '/DEGL_EGLEXT_PROTOTYPES', '/DANGLE_ENABLED'])
 
+    winver = "0x0602" # Windows 8 is the minimum target for UWP build
+    env.Append(CCFLAGS=['/DWINVER=%s' % winver, '/D_WIN32_WINNT=%s' % winver])
+
     LIBS = [
         'WindowsApp',
         'mincore',
+        'ws2_32',
         'libANGLE',
         'libEGL',
         'libGLESv2',

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -209,7 +209,7 @@ def configure(env):
     env.Append(CPPPATH=['#platform/windows'])
 
     # Targeted Windows version: Vista (and later)
-    env.Append(CPPFLAGS=['-D_WIN32_WINNT=0x0600'])
+    winver = "0x0600" # Windows Vista is the minimum target for windows builds
 
     env['is_mingw'] = False
     if (os.name == "nt" and os.getenv("VCINSTALLDIR")):
@@ -217,6 +217,7 @@ def configure(env):
         env['ENV']['TMP'] = os.environ['TMP']
         env.Append(CPPPATH=['#platform/windows/include'])
         env.Append(LIBPATH=['#platform/windows/lib'])
+        env.Append(CCFLAGS=['/DWINVER=%s' % winver, '/D_WIN32_WINNT=%s' % winver])
 
         if (env["target"] == "release"):
 
@@ -311,6 +312,7 @@ def configure(env):
         env.use_windows_spawn_fix()
 
         # build using mingw
+        env.Append(CCFLAGS=['-DWINVER=%s' % winver, '-D_WIN32_WINNT=%s' % winver])
         if (os.name == "nt"):
             env['ENV']['TMP'] = os.environ['TMP']  # way to go scons, you can be so stupid sometimes
         else:


### PR DESCRIPTION
This PR continues the work in 6323779596dea0db7f58afef7d3d3d5588ef20cb .
It defines both WINVER and _WIN32_NT for UWP and Windows builds removing more workarounds and hacks for various build env (mingw,uwp).