### PR TITLE
Fix two problems with Area2D and remove_child()

### DIFF
--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -357,6 +357,10 @@ void Area2D::_clear_monitoring() {
 			Object *obj = ObjectDB::get_instance(E->key());
 			Node *node = obj ? obj->cast_to<Node>() : NULL;
 			ERR_CONTINUE(!node);
+
+			node->disconnect(SceneStringNames::get_singleton()->tree_entered,this,SceneStringNames::get_singleton()->_body_enter_tree);
+			node->disconnect(SceneStringNames::get_singleton()->tree_exited,this,SceneStringNames::get_singleton()->_body_exit_tree);
+
 			if (!E->get().in_tree)
 				continue;
 
@@ -366,9 +370,6 @@ void Area2D::_clear_monitoring() {
 			}
 
 			emit_signal(SceneStringNames::get_singleton()->body_exited,obj);
-
-			node->disconnect(SceneStringNames::get_singleton()->tree_entered,this,SceneStringNames::get_singleton()->_body_enter_tree);
-			node->disconnect(SceneStringNames::get_singleton()->tree_exited,this,SceneStringNames::get_singleton()->_body_exit_tree);
 		}
 
 	}
@@ -388,6 +389,9 @@ void Area2D::_clear_monitoring() {
 				continue;
 			//ERR_CONTINUE(!node);
 
+			node->disconnect(SceneStringNames::get_singleton()->tree_entered,this,SceneStringNames::get_singleton()->_area_enter_tree);
+			node->disconnect(SceneStringNames::get_singleton()->tree_exited,this,SceneStringNames::get_singleton()->_area_exit_tree);
+
 			if (!E->get().in_tree)
 				continue;
 
@@ -397,9 +401,6 @@ void Area2D::_clear_monitoring() {
 			}
 
 			emit_signal(SceneStringNames::get_singleton()->area_exited,obj);
-
-			node->disconnect(SceneStringNames::get_singleton()->tree_entered,this,SceneStringNames::get_singleton()->_area_enter_tree);
-			node->disconnect(SceneStringNames::get_singleton()->tree_exited,this,SceneStringNames::get_singleton()->_area_exit_tree);
 		}
 	}
 


### PR DESCRIPTION
- When one of two or more overlapping Area2Ds is removed with remove_child(), it doesn't try to report to the other one anymore
- When overlappinng Area2Ds are removed woth remove_child(), _enter_tree and _exit_tree signals are now properly disconnected upon removal

Fixes #7507.
Since the master branch doesn't compile for me at the moment without reverting some earlier commits and due to the many bugs it has right now, testing it is a bit difficult (but it works fine on 2.2). It should be fine though since the changes are minimal.

Also removed some unnessecary empty lines from the file.