### PR TITLE
Project setting to control node name casing

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1309,6 +1309,17 @@ String Node::_generate_serial_child_name(Node *p_child) {
 	if (name=="") {
 
 		name = p_child->get_type();
+		// Adjust casing according to project setting. The current type name is expected to be in PascalCase.
+		switch (Globals::get_singleton()->get("node/name_casing").operator int()) {
+			case NAME_CASING_PASCAL_CASE:
+				break;
+			case NAME_CASING_CAMEL_CASE:
+				name[0] = name.to_lower()[0];
+				break;
+			case NAME_CASING_SNAKE_CASE:
+				name = name.camelcase_to_underscore(true);
+				break;
+		}
 	}
 
 	// Extract trailing number
@@ -2811,6 +2822,8 @@ void Node::_bind_methods() {
 
 	_GLOBAL_DEF("node/name_num_separator",0);
 	Globals::get_singleton()->set_custom_property_info("node/name_num_separator",PropertyInfo(Variant::INT,"node/name_num_separator",PROPERTY_HINT_ENUM, "None,Space,Underscore,Dash"));
+	_GLOBAL_DEF("node/name_casing",NAME_CASING_PASCAL_CASE);
+	Globals::get_singleton()->set_custom_property_info("node/name_casing",PropertyInfo(Variant::INT,"node/name_casing",PROPERTY_HINT_ENUM,"PascalCase,camelCase,snake_case"));
 
 
 	ObjectTypeDB::bind_method(_MD("_add_child_below_node","node:Node","child_node:Node","legible_unique_name"),&Node::add_child_below_node,DEFVAL(false));

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -143,6 +143,12 @@ private:
 
 	} data;
 
+	enum NameCasing {
+		NAME_CASING_PASCAL_CASE,
+		NAME_CASING_CAMEL_CASE,
+		NAME_CASING_SNAKE_CASE
+	};
+
 
 	void _print_tree(const Node *p_node);
 


### PR DESCRIPTION
As discussed in https://github.com/godotengine/godot/pull/7501, I modified my changes to make this a project setting.