### PR TITLE
Use Animation's Name as Filename When Saving

### DIFF
--- a/tools/editor/plugins/animation_player_editor_plugin.cpp
+++ b/tools/editor/plugins/animation_player_editor_plugin.cpp
@@ -431,7 +431,12 @@ void AnimationPlayerEditor::_animation_save_as(const Ref<Resource>& p_resource) 
 
 		String existing;
 		if (extensions.size()) {
-			existing = "new_" + p_resource->get_class().to_lower() + "." + extensions.front()->get().to_lower();
+			if( p_resource->get_name() != "" ) {
+				existing = p_resource->get_name() + "." + extensions.front()->get().to_lower();
+			}
+			else {
+				existing = "new_" + p_resource->get_class().to_lower() + "." + extensions.front()->get().to_lower();
+			}
 		}
 		file->set_current_path(existing);
 


### PR DESCRIPTION
Fix for Issue #7433. When saving Animations we check to see if the Animation has a name, if so we use that as the filename; otherwise we default to the previous string ("new_" + resource name).