### PR TITLE
String: plus_file(String) no longer adds a root

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -3822,8 +3822,9 @@ String String::extension() const {
 }
 
 String String::plus_file(const String& p_file) const {
-
-	if (length()>0 && operator [](length()-1)=='/')
+	if (empty())
+		return p_file;
+	if (operator [](length()-1)=='/' || p_file.operator [](0)=='/')
 		return *this+p_file;
 	else
 		return *this+"/"+p_file;


### PR DESCRIPTION
`String::plus_file(String)` is a helper method to join paths. It's similar to Python's `os.path.join`. However, unlike the latter, `plus_file` can add a root to the path if the first string is empty, e.g:

``` GDScript
# Python
os.path.join("", "file") # Returns "file"
# GDScript
"".plus_file("file") # Returns "/file"
```

This shouldn't be the correct behaviour. It forces you to add lot of `if str.empty()` conditions to avoid bugs when working with relative paths.

This PR fixes that. Now the user has to explicitly specify if he wants an absolute path:

``` GDScript
# Python
os.path.join("", "file") # Returns "file"
os.path.join(os.sep, "file") # Returns "/file"
# GDScript
"".plus_file("file") # Returns "file"
"/".plus_file("file") # Returns "/file"
```

Also this PR fixes possible duplicated separators:

``` GDScript
"whatever".plus_file("/usr").plus_file("bin")
# Before
"whatever//usr/bin"
# After
"whatever/usr/bin"
```

There is still a difference with `os.path.join` here though:

``` GDScript
os.path.join("whatever", "/usr", "bin") # Returns "/usr/bin"
"whatever".plus_file("/usr").plus_file("bin") # Returns "whatever/usr/bin"
```

But I don't really agree with `os.path.join` here anyway and we don't have to use exactly the same, so...

WDYT?