### PR TITLE
Fix _Directory::get_current_drive error condition from breaking the build

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -1865,7 +1865,7 @@ String _Directory::get_drive(int p_drive){
 	return d->get_drive(p_drive);
 }
 int _Directory::get_current_drive() {
-	ERR_FAIL_COND_V(!d,"");
+	ERR_FAIL_COND_V(!d,0);
 	return d->get_current_drive();
 }
 


### PR DESCRIPTION
`_Directory::get_current_drive` returns an `int`, so `ERR_FAIL_COND_V(!d,"")` broke the build by returning a `String` instead.