### PR TITLE
Add menu item in the inspector to show file in FileSystem

### DIFF
--- a/tools/editor/filesystem_dock.cpp
+++ b/tools/editor/filesystem_dock.cpp
@@ -287,6 +287,39 @@ String FileSystemDock::get_current_path() const {
 	return path;
 }
 
+void FileSystemDock::navigate_to_path(const String& p_path) {
+	// If the path is a file, do not only go to the directory in the tree, also select the file in the file list.
+	String dir_path="";
+	String file_name="";
+	DirAccess* dirAccess=DirAccess::open("res://");
+	if (dirAccess->file_exists(p_path)) {
+		dir_path=p_path.get_base_dir();
+		file_name=p_path.get_file();
+	} else if (dirAccess->dir_exists(p_path)) {
+		dir_path=p_path;
+	} else {
+		ERR_EXPLAIN(TTR("Cannot navigate to '" + p_path + "' as it has not been found in the file system!"));
+		ERR_FAIL();
+	}
+
+	path=dir_path;
+	_update_tree();
+	tree->ensure_cursor_is_visible();
+
+	if (!file_name.empty()) {
+		_open_pressed(); // Seems to be the only way to get into the file view. This also pushes to history.
+
+		// Focus the given file.
+		for (int i=0; i<files->get_item_count(); i++) {
+			if (files->get_item_text(i) == file_name) {
+				files->select(i,true);
+				files->ensure_current_is_visible();
+				break;
+			}
+		}
+	}
+}
+
 void FileSystemDock::_thumbnail_done(const String& p_path,const Ref<Texture>& p_preview, const Variant& p_udata) {
 
 	bool valid=false;

--- a/tools/editor/filesystem_dock.h
+++ b/tools/editor/filesystem_dock.h
@@ -198,6 +198,7 @@ public:
 	String get_selected_path() const;
 
 	String get_current_path() const;
+	void navigate_to_path(const String& p_path);
 	void focus_on_filter();
 
 	void fix_dependencies(const String& p_for_file);

--- a/tools/editor/property_editor.cpp
+++ b/tools/editor/property_editor.cpp
@@ -222,6 +222,14 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 						EditorNode::get_singleton()->get_scene_tree_dock()->open_script_dialog(owner->cast_to<Node>());
 
 				} break;
+				case OBJ_MENU_SHOW_IN_FILE_SYSTEM: {
+					RES r=v;
+					FileSystemDock *file_system_dock=EditorNode::get_singleton()->get_filesystem_dock();
+					file_system_dock->navigate_to_path(r->get_path());
+					// Ensure that the FileSystem dock is visible.
+					TabContainer* tab_container=(TabContainer*)file_system_dock->get_parent_control();
+					tab_container->set_current_tab(file_system_dock->get_position_in_parent());
+				} break;
 				default: {
 
 
@@ -945,11 +953,15 @@ bool CustomPropertyEditor::edit(Object* p_owner,const String& p_name,Variant::Ty
 				menu->add_icon_item(get_icon("EditResource","EditorIcons"),"Edit",OBJ_MENU_EDIT);
 				menu->add_icon_item(get_icon("Del","EditorIcons"),"Clear",OBJ_MENU_CLEAR);
 				menu->add_icon_item(get_icon("Duplicate","EditorIcons"),"Make Unique",OBJ_MENU_MAKE_UNIQUE);
-				/*RES r = v;
-				if (r.is_valid() && r->get_path().is_resource_file() && r->get_import_metadata().is_valid()) {
+				RES r = v;
+				if (r.is_valid() && r->get_path().is_resource_file()) {
+					/*if (r->get_import_metadata().is_valid()) {
+						menu->add_separator();
+						menu->add_icon_item(get_icon("ReloadSmall","EditorIcons"),"Re-Import",OBJ_MENU_REIMPORT);
+					}*/
 					menu->add_separator();
-					menu->add_icon_item(get_icon("ReloadSmall","EditorIcons"),"Re-Import",OBJ_MENU_REIMPORT);
-				}*/
+					menu->add_item(TTR("Show in File System"),OBJ_MENU_SHOW_IN_FILE_SYSTEM);
+				}
 				/*if (r.is_valid() && r->get_path().is_resource_file()) {
 					menu->set_item_tooltip(1,r->get_path());
 				} else if (r.is_valid()) {

--- a/tools/editor/property_editor.h
+++ b/tools/editor/property_editor.h
@@ -67,8 +67,8 @@ class CustomPropertyEditor : public Popup {
 		OBJ_MENU_PASTE=5,
 		OBJ_MENU_REIMPORT=6,
 		OBJ_MENU_NEW_SCRIPT=7,
+		OBJ_MENU_SHOW_IN_FILE_SYSTEM=8,
 		TYPE_BASE_ID=100
-
 	};
 
 	enum {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/7449

- Added a method to navigate and display a given directory or file.
- To programmatically show the file view in non-split mode (dunno why the boolean variable is named `split_mode` when it's true when it's _not_ in a splitted view) I used `_open_pressed()` as it was the only method capable of doing so. Maybe needs some refactoring to switch to file view only.