### PR TITLE
Fix error while JSON::parse with empty string

### DIFF
--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -100,7 +100,7 @@ String JSON::print(const Variant& p_var) {
 
 Error JSON::_get_token(const CharType *p_str, int &idx, int p_len, Token& r_token,int &line,String &r_err_str) {
 
-	while (true) {
+	while (p_len > 0) {
 		switch(p_str[idx]) {
 
 			case '\n': {


### PR DESCRIPTION
Stop crash when parse json from empty string