### PR TITLE
.gitignore: Added VC++ cache database and temporary storage folder when debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,7 +144,9 @@ ipch/
 *.sdf
 *.cachefile
 *.VC.db
+*.VC.opendb
 *.VC.VC.opendb
+enc_temp_folder/
 
 # Visual Studio profiler
 *.psess


### PR DESCRIPTION
I added a cache file and directory steadily occuring for me when using VS2015:

- `*.VC.opendb`: Gets created when the solution is opened and has the format `$(SolutionName).VC.opendb`. Will be automatically deleted when the solution is closed. There's already a `*.VC.VC.opendb` entry, but I think that one is a typo and might be deleted.
- `enc_temp_folder`: This directory stores changes done while debugging which are then copied back to the original files when the debug session ended.