### PR TITLE
Limit maximum width of editor settings popup

### DIFF
--- a/tools/editor/project_settings.cpp
+++ b/tools/editor/project_settings.cpp
@@ -571,9 +571,12 @@ void ProjectSettings::_update_actions() {
 
 
 void ProjectSettings::popup_project_settings() {
+	// Popup the settings window with a maximum width - otherwise property names are hard to track back to their values.
+	Size2 size = get_viewport_rect().size;
+	size = (size * 0.75).floor();
+	size.x = MIN(size.x, 800 * EDSCALE);
+	popup_centered(size);
 
-	//popup_centered(Size2(500,400));
-	popup_centered_ratio();
 	globals_editor->update_category_list();
 	_update_translations();
 	autoload_settings->update_autoload();

--- a/tools/editor/settings_config_dialog.cpp
+++ b/tools/editor/settings_config_dialog.cpp
@@ -92,7 +92,12 @@ void EditorSettingsDialog::popup_edit_settings() {
 	search_box->grab_focus();
 
 	_update_shortcuts();
-	popup_centered_ratio(0.7);
+
+	// Popup the settings window with a maximum width - otherwise property names are hard to track back to their values.
+	Size2 size = get_viewport_rect().size;
+	size = (size * 0.75).floor();
+	size.x = MIN(size.x, 800 * EDSCALE);
+	popup_centered(size);
 }
 
 


### PR DESCRIPTION
This is a quick "fix" to https://github.com/godotengine/godot/issues/6437

Settings popups were incredibly wide since they were simply opened with a ratio relative to the editor windows size. I kept that ratio, but limited the width to 800 editor units (it felt like a nice trade off between lengthy property values and trackability of them back to their names).

Applies to project and editor settings popups.

Before:
![before](https://cloud.githubusercontent.com/assets/9631152/21964664/b82279ce-db50-11e6-8c4d-0938ae675b19.png)

After:
![after](https://cloud.githubusercontent.com/assets/9631152/21964665/b944d0c2-db50-11e6-9396-d0dd84e3a2bb.png)