### PR TITLE
#7215 try to fix adb bad targeting user on device

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1748,6 +1748,7 @@ Error EditorExportPlatformAndroid::run(int p_device, int p_flags) {
 	args.push_back("shell");
 	args.push_back("am");
 	args.push_back("start");
+	args.push_back("--user 0");
 	args.push_back("-a");
 	args.push_back("android.intent.action.MAIN");
 	args.push_back("-n");
@@ -1912,4 +1913,3 @@ void register_android_exporter() {
 	EditorImportExport::get_singleton()->add_export_platform(exporter);
 
 }
-


### PR DESCRIPTION
Android -> USB debugging

Regarding to the issue #7215, try to force the targeted user 0 on device. Need to talk about this, forcing the user number isn't the right solution, we must find why the problem appear only on the device of toby3d 