### PR TITLE
Fix gibberish output for windows/mingw.

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1325,18 +1325,10 @@ void OS_Windows::vprint(const char* p_format, va_list p_list, bool p_stderr) {
 	MultiByteToWideChar(CP_UTF8,0,buf,len,wbuf,wlen);
 	wbuf[wlen]=0;
 
-// Recent MinGW and MSVC compilers seem to disagree on the case here
-#ifdef __MINGW32__
 	if (p_stderr)
-		fwprintf(stderr, L"%S", wbuf);
+		fwprintf(stderr, L"%ls", wbuf);
 	else
-		wprintf(L"%S", wbuf);
-#else  // MSVC
-	if (p_stderr)
-		fwprintf(stderr, L"%s", wbuf);
-	else
-		wprintf(L"%s", wbuf);
-#endif
+		wprintf(L"%ls", wbuf);
 
 #ifdef STDOUT_FILE
 	//vwfprintf(stdo,p_format,p_list);


### PR DESCRIPTION
`%ls` should be used instead of `%s` or `%S` to speficy narrow/wide charstring
in `wprintf` `fwprintf`

Fixes #6252