### PR TITLE
Fix Spatial::is_visible and editor calls to CanvasItem/Spatial::is_visible

### DIFF
--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -620,7 +620,7 @@ void Spatial::set_visible(bool p_visible) {
 
 bool Spatial::is_visible() const {
 
-	return !data.visible;
+	return data.visible;
 }
 
 void Spatial::rotate(const Vector3& p_normal,float p_radians) {

--- a/tools/editor/scene_tree_editor.cpp
+++ b/tools/editor/scene_tree_editor.cpp
@@ -208,14 +208,15 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item,int p_column,int p_id)
 
 		if (n->is_class("Spatial")) {
 
-			bool v = !bool(n->call("is_hidden"));
+			bool v = bool(n->call("is_visible"));
 			undo_redo->create_action(TTR("Toggle Spatial Visible"));
-			undo_redo->add_do_method(n,"_set_visible_",!v);
-			undo_redo->add_undo_method(n,"_set_visible_",v);
+			undo_redo->add_do_method(n,"set_visible",!v);
+			undo_redo->add_undo_method(n,"set_visible",v);
 			undo_redo->commit_action();
+
 		} else if (n->is_class("CanvasItem")) {
 
-			bool v = !bool(n->call("is_hidden"));
+			bool v = bool(n->call("is_visible"));
 			undo_redo->create_action(TTR("Toggle CanvasItem Visible"));
 			undo_redo->add_do_method(n,v?"hide":"show");
 			undo_redo->add_undo_method(n,v?"show":"hide");
@@ -393,11 +394,11 @@ bool SceneTreeEditor::_add_nodes(Node *p_node,TreeItem *p_parent) {
 			if (is_grouped)
 				item->add_button(0,get_icon("Group", "EditorIcons"), BUTTON_GROUP);
 
-			bool h = p_node->call("is_hidden");
-			if (h)
-				item->add_button(0,get_icon("Hidden","EditorIcons"),BUTTON_VISIBILITY);
-			else
+			bool v = p_node->call("is_visible");
+			if (v)
 				item->add_button(0,get_icon("Visible","EditorIcons"),BUTTON_VISIBILITY);
+			else
+				item->add_button(0,get_icon("Hidden","EditorIcons"),BUTTON_VISIBILITY);
 
 			if (!p_node->is_connected("visibility_changed",this,"_node_visibility_changed"))
 				p_node->connect("visibility_changed",this,"_node_visibility_changed",varray(p_node));
@@ -405,11 +406,11 @@ bool SceneTreeEditor::_add_nodes(Node *p_node,TreeItem *p_parent) {
 			_update_visibility_color(p_node, item);
 		} else if (p_node->is_class("Spatial")) {
 
-			bool h = p_node->call("is_hidden");
-			if (h)
-				item->add_button(0,get_icon("Hidden","EditorIcons"),BUTTON_VISIBILITY);
-			else
+			bool v = p_node->call("is_visible");
+			if (v)
 				item->add_button(0,get_icon("Visible","EditorIcons"),BUTTON_VISIBILITY);
+			else
+				item->add_button(0,get_icon("Hidden","EditorIcons"),BUTTON_VISIBILITY);
 
 			if (!p_node->is_connected("visibility_changed",this,"_node_visibility_changed"))
 				p_node->connect("visibility_changed",this,"_node_visibility_changed",varray(p_node));
@@ -469,16 +470,14 @@ void SceneTreeEditor::_node_visibility_changed(Node *p_node) {
 
 	bool visible=false;
 
-	if (p_node->is_class("CanvasItem")) {
-		visible = !p_node->call("is_hidden");
-	} else if (p_node->is_class("Spatial")) {
-		visible = !p_node->call("is_hidden");
+	if (p_node->is_class("CanvasItem") || p_node->is_class("Spatial")) {
+		visible = p_node->call("is_visible");
 	}
 
-	if (!visible)
-		item->set_button(0,idx,get_icon("Hidden","EditorIcons"));
-	else
+	if (visible)
 		item->set_button(0,idx,get_icon("Visible","EditorIcons"));
+	else
+		item->set_button(0,idx,get_icon("Hidden","EditorIcons"));
 
 	_update_visibility_color(p_node, item);
 }


### PR DESCRIPTION
It looks like there was some unfinished work which removed `is_hidden` for `CanvasItem` and `Spatial` to leave only `is_visible`.

- While the method was removed, editor calls to it were not.
- `is_visible` in `Spatial` returned `!data.visible`, quite self explaining what I fixed here.
- There seems to have been some `_set_visible_` method in `Spatial`, but only `set_visible` exists by now.

I also removed unnecessary negation in the visibility boolean checks in the editor code.

This fixes hiden and showing thus nodes in the editor.