### PR TITLE
2D Editor: Don't show lock icons for hidden nodes.

### DIFF
--- a/tools/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/tools/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2354,7 +2354,7 @@ void CanvasItemEditor::_find_canvas_items_span(Node *p_node, Rect2& r_rect, cons
 
 
 
-	if (c) {
+	if (c && c->is_visible_in_tree()) {
 
 		Rect2 rect = c->get_item_rect();
 		Transform2D xform = p_xform * c->get_transform();

--- a/tools/editor/scene_tree_editor.cpp
+++ b/tools/editor/scene_tree_editor.cpp
@@ -470,7 +470,10 @@ void SceneTreeEditor::_node_visibility_changed(Node *p_node) {
 
 	bool visible=false;
 
-	if (p_node->is_class("CanvasItem") || p_node->is_class("Spatial")) {
+	if (p_node->is_class("CanvasItem")) {
+		visible = p_node->call("is_visible");
+		CanvasItemEditor::get_singleton()->get_viewport_control()->update();
+	} else if (p_node->is_class("Spatial")) {
 		visible = p_node->call("is_visible");
 	}
 


### PR DESCRIPTION
Now we only draw those icons for visible Nodes.
Fixes #7518