### PR TITLE
x11: don't wait for window to be mapped

### DIFF
--- a/platform/x11/context_gl_x11.cpp
+++ b/platform/x11/context_gl_x11.cpp
@@ -130,13 +130,6 @@ Error ContextGL_X11::initialize() {
 		x11_window = XCreateWindow(x11_display, RootWindow(x11_display, vi->screen), 0, 0, OS::get_singleton()->get_video_mode().width, OS::get_singleton()->get_video_mode().height, 0, vi->depth, InputOutput, vi->visual, CWBorderPixel|CWColormap|CWEventMask, &swa);
 		ERR_FAIL_COND_V(!x11_window,ERR_UNCONFIGURED);
 		XMapWindow(x11_display, x11_window);
-		while(true) {
-			// wait for mapnotify (window created)
-			XEvent e;
-			XNextEvent(x11_display, &e);
-			if (e.type == MapNotify)
-				break;
-		}
 		//};
 
 


### PR DESCRIPTION
This fixes situations when you want to wait until the game has finished loading before you map the window.