### PR TITLE
made _ a special token in GDScript

### DIFF
--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -1704,7 +1704,7 @@ GDParser::PatternNode *GDParser::_parse_pattern(bool p_static)
 	}
 	
 	switch (token) {
-		// dictionary
+		// array
 		case GDTokenizer::TK_BRACKET_OPEN: {
 			tokenizer->advance();
 			pattern->pt_type = GDParser::PatternNode::PT_ARRAY;
@@ -1759,7 +1759,7 @@ GDParser::PatternNode *GDParser::_parse_pattern(bool p_static)
 			pattern->bind = tokenizer->get_token_identifier();
 			tokenizer->advance();
 		} break;
-		// array
+		// dictionary
 		case GDTokenizer::TK_CURLY_BRACKET_OPEN: {
 			tokenizer->advance();
 			pattern->pt_type = GDParser::PatternNode::PT_DICTIONARY;
@@ -1826,16 +1826,15 @@ GDParser::PatternNode *GDParser::_parse_pattern(bool p_static)
 				}
 			}
 		} break;
+		case GDTokenizer::TK_WILDCARD: {
+			tokenizer->advance();
+			pattern->pt_type = PatternNode::PT_WILDCARD;
+		} break;
 		// all the constants like strings and numbers
 		default: {
 			Node *value = _parse_and_reduce_expression(pattern, p_static);
 			if (error_set) {
 				return NULL;
-			}
-			if (value->type == Node::TYPE_IDENTIFIER && static_cast<IdentifierNode*>(value)->name == "_") {
-				// wildcard pattern
-				pattern->pt_type = PatternNode::PT_WILDCARD;
-				break;
 			}
 			
 			if (value->type != Node::TYPE_IDENTIFIER && value->type != Node::TYPE_CONSTANT) {

--- a/modules/gdscript/gd_tokenizer.cpp
+++ b/modules/gdscript/gd_tokenizer.cpp
@@ -119,6 +119,7 @@ const char* GDTokenizer::token_names[TK_MAX]={
 "':'",
 "'\\n'",
 "PI",
+"_",
 "Error",
 "EOF",
 "Cursor"};
@@ -899,6 +900,7 @@ void GDTokenizerText::_advance() {
 								{TK_CF_PASS,"pass"},
 								{TK_SELF,"self"},
 								{TK_CONST_PI,"PI"},
+								{TK_WILDCARD,"_"},
 								{TK_ERROR,NULL}
 							};
 

--- a/modules/gdscript/gd_tokenizer.h
+++ b/modules/gdscript/gd_tokenizer.h
@@ -127,6 +127,7 @@ public:
 		TK_DOLLAR,
 		TK_NEWLINE,
 		TK_CONST_PI,
+		TK_WILDCARD,
 		TK_ERROR,
 		TK_EOF,
 		TK_CURSOR, //used for code completion


### PR DESCRIPTION
As discussed in #7575 the `_` was made a new token and connot be used as a regular identifier anymore. Names using `_` are still valid. Only the single `_` is special.

GDScripts pattern matching was modified to support this new token.