### PR TITLE
Uncomment lines for quick open file.

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -2076,8 +2076,8 @@ void EditorNode::_menu_option_confirm(int p_option,bool p_confirmed) {
 		case FILE_QUICK_OPEN_FILE: {
 
 
-			//quick_open->popup("Resource", false, true);
-			//quick_open->set_title("Quick Search File..");
+			quick_open->popup("Resource", false, true);
+			quick_open->set_title("Quick Open File..");
 			scenes_dock->focus_on_filter();
 
 		} break;


### PR DESCRIPTION
I'm not sure why this was commented out, but it seems to work fine, at least in the 2.1 branch. :)

The blame shows it was disabled in its initial checkin, so my guess is it was a mistake.

This should fix #7582.