### PR TITLE
Make ysort work recursively

### DIFF
--- a/scene/2d/y_sort.cpp
+++ b/scene/2d/y_sort.cpp
@@ -41,18 +41,35 @@ bool YSort::is_sort_enabled() const {
 	return sort_enabled;
 }
 
+void YSort::set_sort_recursion_depth(int depth) {
+
+	if(depth >= 1 && depth <= 8)
+		sort_recursion_depth=depth;
+	VS::get_singleton()->canvas_item_set_sort_children_by_y_depth(get_canvas_item(),sort_recursion_depth);
+}
+
+int YSort::get_sort_recursion_depth() const {
+
+	return sort_recursion_depth;
+}
+
 void YSort::_bind_methods() {
 
 	ClassDB::bind_method(_MD("set_sort_enabled","enabled"),&YSort::set_sort_enabled);
 	ClassDB::bind_method(_MD("is_sort_enabled"),&YSort::is_sort_enabled);
+	ClassDB::bind_method(_MD("set_sort_recursion_depth","enabled"),&YSort::set_sort_recursion_depth);
+	ClassDB::bind_method(_MD("get_sort_recursion_depth"),&YSort::get_sort_recursion_depth);
 
 	ADD_GROUP("Sort","sort_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL,"sort_enabled"),_SCS("set_sort_enabled"),_SCS("is_sort_enabled"));
+	ADD_PROPERTY(PropertyInfo(Variant::INT,"sort_recursion_depth"),_SCS("set_sort_recursion_depth"),_SCS("get_sort_recursion_depth"));
 }
 
 
 YSort::YSort() {
 
 	sort_enabled=true;
+	sort_recursion_depth=1;
 	VS::get_singleton()->canvas_item_set_sort_children_by_y(get_canvas_item(),true);
+	VS::get_singleton()->canvas_item_set_sort_children_by_y_depth(get_canvas_item(),sort_recursion_depth);
 }

--- a/scene/2d/y_sort.h
+++ b/scene/2d/y_sort.h
@@ -34,11 +34,14 @@
 class YSort : public Node2D {
 	GDCLASS(YSort,Node2D);
 	bool sort_enabled;
+	int sort_recursion_depth;
 	static void _bind_methods();
 public:
 
 	void set_sort_enabled(bool p_enabled);
 	bool is_sort_enabled() const;
+	void set_sort_recursion_depth(int depth);
+	int get_sort_recursion_depth() const;
 	YSort();
 };
 

--- a/servers/visual/visual_server_canvas.h
+++ b/servers/visual/visual_server_canvas.h
@@ -22,6 +22,11 @@ public:
 		int index;
 		bool children_order_dirty;
 
+		int zidx;
+		bool draw;
+		short int ysort_depth;
+		Vector2 ysort_global_position;
+		bool ysort_deepest;
 
 		Vector<Item*> child_items;
 
@@ -36,18 +41,22 @@ public:
 			use_parent_material=false;
 			z_relative=true;
 			index=0;
+			zidx = 0;
+			draw = 0;
+			ysort_depth=1;
+			ysort_global_position = Vector2(0,0);
+			ysort_deepest = false;
 		}
 	};
-
 
 	struct ItemPtrSort {
 
 		_FORCE_INLINE_ bool operator()(const Item* p_left,const Item* p_right) const {
 
-			if(Math::abs(p_left->xform.elements[2].y - p_right->xform.elements[2].y) < CMP_EPSILON )
-				return p_left->xform.elements[2].x < p_right->xform.elements[2].x;
+			if(Math::abs(p_left->ysort_global_position.y - p_right->ysort_global_position.y) < CMP_EPSILON )
+				return p_left->ysort_global_position.x < p_right->ysort_global_position.x;
 			else
-				return p_left->xform.elements[2].y < p_right->xform.elements[2].y;
+				return p_left->ysort_global_position.y < p_right->ysort_global_position.y;
 		}
 	};
 
@@ -115,7 +124,10 @@ public:
 private:
 
 	void _render_canvas_item_tree(Item *p_canvas_item, const Transform2D& p_transform, const Rect2& p_clip_rect, const Color &p_modulate, RasterizerCanvas::Light *p_lights);
-	void _render_canvas_item(Item *p_canvas_item, const Transform2D& p_transform, const Rect2& p_clip_rect, const Color &p_modulate, int p_z, RasterizerCanvas::Item **z_list, RasterizerCanvas::Item **z_last_list, Item *p_canvas_clip, Item *p_material_owner);
+	void _render_canvas_item(Item *p_canvas_item, const Transform2D& p_transform, const Rect2& p_clip_rect, const Color &p_modulate, int p_z, RasterizerCanvas::Item **z_list, RasterizerCanvas::Item **z_last_list, Item *p_canvas_clip,Item *p_material_owner);
+	void _apply_parameters(Item *p_canvas_item, const Transform2D& p_transform, const Transform2D& p_global_transform_inverse, const Rect2& p_clip_rect, const Color &p_modulate, int p_z, Item *p_canvas_clip, Item *p_material_owner, int ysort_depth = 0);
+	void _create_render_list(Item* item, RasterizerCanvas::Item **z_list,RasterizerCanvas::Item **z_last_list, int ysort_depth = 0, Vector<Item*>* ysort_list = NULL);
+	void _add_to_z_list(Item* p_canvas_item, int zidx, RasterizerCanvas::Item **z_list,RasterizerCanvas::Item **z_last_list);
 	void _light_mask_canvas_items(int p_z,RasterizerCanvas::Item *p_canvas_item,RasterizerCanvas::Light *p_masked_lights);
 public:
 
@@ -156,6 +168,7 @@ public:
 	void canvas_item_add_set_transform(RID p_item,const Transform2D& p_transform);
 	void canvas_item_add_clip_ignore(RID p_item, bool p_ignore);
 	void canvas_item_set_sort_children_by_y(RID p_item, bool p_enable);
+	void canvas_item_set_sort_children_by_y_depth(RID p_item, int depth);
 	void canvas_item_set_z(RID p_item, int p_z);
 	void canvas_item_set_z_as_relative_to_parent(RID p_item, bool p_enable);
 	void canvas_item_set_copy_to_backbuffer(RID p_item, bool p_enable,const Rect2& p_rect);

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -1042,6 +1042,7 @@ public:
 	BIND2(canvas_item_add_set_transform,RID,const Transform2D& )
 	BIND2(canvas_item_add_clip_ignore,RID, bool )
 	BIND2(canvas_item_set_sort_children_by_y,RID, bool )
+	BIND2(canvas_item_set_sort_children_by_y_depth,RID, int )
 	BIND2(canvas_item_set_z,RID, int )
 	BIND2(canvas_item_set_z_as_relative_to_parent,RID, bool )
 	BIND3(canvas_item_set_copy_to_backbuffer,RID, bool ,const Rect2& )

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -796,6 +796,7 @@ public:
 	virtual void canvas_item_add_set_transform(RID p_item,const Transform2D& p_transform)=0;
 	virtual void canvas_item_add_clip_ignore(RID p_item, bool p_ignore)=0;
 	virtual void canvas_item_set_sort_children_by_y(RID p_item, bool p_enable)=0;
+	virtual void canvas_item_set_sort_children_by_y_depth(RID p_item, int depth)=0;
 	virtual void canvas_item_set_z(RID p_item, int p_z)=0;
 	virtual void canvas_item_set_z_as_relative_to_parent(RID p_item, bool p_enable)=0;
 	virtual void canvas_item_set_copy_to_backbuffer(RID p_item, bool p_enable,const Rect2& p_rect)=0;


### PR DESCRIPTION
This adds a recusion depth option to the YSort node which allows nodes from multiple sub-nodes to be drawn in y-order. This is especially helpful when you want to use multiple tilemaps which should be y-sorted together (which isn't possible at the moment).

To achieve this, I had to rewrite a bit of the canvas item rendering code. It is now a little bit more complicated and every canvas item uses a bit more memory, even if YSort isn't being used at all. I ran some tests though (Bunnymark) with and without the modification and it seems that there is no noticable difference for me. 

I don't know if anyone  but me wants this feature at all, but I decided to make a PR anyway because why not. As I said, it doesn't have any noticable impact for me, and if it's fine for anyone else it could as well be merged. So test and discuss please.