### PR TITLE
Fix several drawing and logic issues in TabContainer

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -31,366 +31,309 @@
 #include "message_queue.h"
 
 
-
 int TabContainer::_get_top_margin() const {
 
+	if (!tabs_visible)
+		return 0;
+
+	// Respect the minimum tab height.
 	Ref<StyleBox> tab_bg = get_stylebox("tab_bg");
 	Ref<StyleBox> tab_fg = get_stylebox("tab_fg");
+
+	int tab_height = MAX(tab_bg->get_minimum_size().height, tab_fg->get_minimum_size().height);
+
+	// Font height or higher icon wins.
 	Ref<Font> font = get_font("font");
+	int content_height = font->get_height();
 
-	int h = MAX( tab_bg->get_minimum_size().height,tab_fg->get_minimum_size().height);
+	Vector<Control*> tabs = _get_tabs();
+	for (int i = 0; i < tabs.size(); i++) {
 
-	int ch = font->get_height();
-	for(int i=0;i<get_child_count();i++) {
-
-		Control *c = get_child(i)->cast_to<Control>();
-		if (!c)
-			continue;
-		if (c->is_set_as_toplevel())
-			continue;
+		Control *c = tabs[i];
 		if (!c->has_meta("_tab_icon"))
 			continue;
 
 		Ref<Texture> tex = c->get_meta("_tab_icon");
 		if (!tex.is_valid())
 			continue;
-		ch = MAX( ch, tex->get_size().height );
+		content_height = MAX(content_height, tex->get_size().height);
 	}
 
-	h+=ch;
-
-	return h;
-
+	return tab_height + content_height;
 }
 
 
 
 void TabContainer::_gui_input(const InputEvent& p_event) {
 
-	if (p_event.type==InputEvent::MOUSE_BUTTON &&
-	    p_event.mouse_button.pressed &&
-	    p_event.mouse_button.button_index==BUTTON_LEFT) {
+	if (p_event.type == InputEvent::MOUSE_BUTTON
+		&& p_event.mouse_button.pressed
+		&& p_event.mouse_button.button_index == BUTTON_LEFT) {
 
-		// clicks
-		Point2 pos( p_event.mouse_button.x, p_event.mouse_button.y );
+		Point2 pos(p_event.mouse_button.x, p_event.mouse_button.y);
+		Size2 size = get_size();
 
-		int top_margin = _get_top_margin();
-		if (pos.y>top_margin)
-			return; // no click (too far down)
+		// Click must be on tabs in the tab header area.
+		if (pos.x < tabs_ofs_cache || pos.y > _get_top_margin())
+			return;
 
-		if (pos.x<tabs_ofs_cache)
-			return; // no click (too far left)
-
-		Ref<StyleBox> tab_bg = get_stylebox("tab_bg");
-		Ref<StyleBox> tab_fg = get_stylebox("tab_fg");
-		Ref<Font> font = get_font("font");
-		Ref<Texture> incr = get_icon("increment");
-		Ref<Texture> decr = get_icon("decrement");
+		// Handle menu button.
 		Ref<Texture> menu = get_icon("menu");
-		Ref<Texture> menu_hl = get_icon("menu_hl");
-
-		if (popup && pos.x>get_size().width-menu->get_width()) {
-
-
+		if (popup && pos.x > size.width - menu->get_width()) {
 			emit_signal("pre_popup_pressed");
-			Vector2 pp_pos = get_global_pos();
-			pp_pos.x+=get_size().width;
-			pp_pos.x-=popup->get_size().width;
-			pp_pos.y+=menu->get_height();
 
-			popup->set_global_pos( pp_pos );
+			Vector2 popup_pos = get_global_pos();
+			popup_pos.x += size.width - popup->get_size().width;
+			popup_pos.y += menu->get_height();
+
+			popup->set_global_pos(popup_pos);
 			popup->popup();
 			return;
 		}
-		pos.x-=tabs_ofs_cache;
 
-		int idx=0;
-		int found=-1;
-		bool rightroom=false;
+		Vector<Control*> tabs = _get_tabs();
 
-		for(int i=0;i<get_child_count();i++) {
-
-			Control *c = get_child(i)->cast_to<Control>();
-			if (!c)
-				continue;
-			if (c->is_set_as_toplevel())
-				continue;
-
-			if (idx<tab_display_ofs) {
-				idx++;
-				continue;
-			}
-
-			if (idx>last_tab_cache) {
-				rightroom=true;
-				break;
-			}
-
-			String s = c->has_meta("_tab_name")?String(XL_MESSAGE(String(c->get_meta("_tab_name")))):String(c->get_name());
-			int tab_width=font->get_string_size(s).width;
-
-			if (c->has_meta("_tab_icon")) {
-				Ref<Texture> icon = c->get_meta("_tab_icon");
-				if (icon.is_valid()) {
-					tab_width+=icon->get_width();
-					if (s!="")
-						tab_width+=get_constant("hseparation");
-
-				}
-			}
-
-			if (idx==current) {
-
-				tab_width+=tab_fg->get_minimum_size().width;
-			} else {
-				tab_width+=tab_bg->get_minimum_size().width;
-			}
-
-			if (pos.x < tab_width) {
-
-				found=idx;
-				break;
-			}
-
-			pos.x-=tab_width;
-			idx++;
-		}
-
+		// Handle navigation buttons.
 		if (buttons_visible_cache) {
-
-			if (p_event.mouse_button.x>get_size().width-incr->get_width()) {
-				if (rightroom) {
-					tab_display_ofs+=1;
+			Ref<Texture> increment = get_icon("increment");
+			Ref<Texture> decrement = get_icon("decrement");
+			if (pos.x > size.width - increment->get_width()) {
+				if (last_tab_cache < tabs.size() - 1) {
+					first_tab_cache += 1;
 					update();
 				}
-			} else if (p_event.mouse_button.x>get_size().width-incr->get_width()-decr->get_width()) {
-
-				if (tab_display_ofs>0) {
-					tab_display_ofs-=1;
+				return;
+			} else if (pos.x > size.width - increment->get_width() - decrement->get_width()) {
+				if (first_tab_cache > 0) {
+					first_tab_cache -= 1;
 					update();
 				}
-
+				return;
 			}
 		}
 
-
-		if (found!=-1) {
-
-			set_current_tab(found);
+		// Activate the clicked tab.
+		pos.x -= tabs_ofs_cache;
+		for (int i = first_tab_cache; i <= last_tab_cache; i++) {
+			int tab_width = _get_tab_width(i);
+			if (pos.x < tab_width) {
+				set_current_tab(i);
+				break;
+			}
+			pos.x -= tab_width;
 		}
 	}
-
 }
 
 void TabContainer::_notification(int p_what) {
 
-
-	switch(p_what) {
-
+	switch (p_what) {
 
 		case NOTIFICATION_DRAW: {
 
-			RID ci = get_canvas_item();
-			Ref<StyleBox> panel = get_stylebox("panel");
+			RID canvas = get_canvas_item();
 			Size2 size = get_size();
 
+			// Draw only the tab area if the header is hidden.
+			Ref<StyleBox> panel = get_stylebox("panel");
 			if (!tabs_visible) {
-
-				panel->draw(ci, Rect2( 0, 0, size.width, size.height));
+				panel->draw(canvas, Rect2(0, 0, size.width, size.height));
 				return;
 			}
 
-
-
+			Vector<Control*> tabs = _get_tabs();
 			Ref<StyleBox> tab_bg = get_stylebox("tab_bg");
 			Ref<StyleBox> tab_fg = get_stylebox("tab_fg");
-			Ref<Texture> incr = get_icon("increment");
-			Ref<Texture> decr = get_icon("decrement");
+			Ref<Texture> increment = get_icon("increment");
+			Ref<Texture> decrement = get_icon("decrement");
 			Ref<Texture> menu = get_icon("menu");
 			Ref<Texture> menu_hl = get_icon("menu_hl");
 			Ref<Font> font = get_font("font");
-			Color color_fg = get_color("font_color_fg");
-			Color color_bg = get_color("font_color_bg");
-
+			Color font_color_fg = get_color("font_color_fg");
+			Color font_color_bg = get_color("font_color_bg");
 			int side_margin = get_constant("side_margin");
-			int top_margin = _get_top_margin();
+			int icon_text_distance = get_constant("hseparation");
 
+			// Find out start and width of the header area.
+			int header_x = side_margin;
+			int header_width = size.width - side_margin * 2;
+			int header_height = _get_top_margin();
+			if (popup)
+				header_width -= menu->get_width();
 
-			Size2 top_size = Size2( size.width, top_margin );
+			// Check if all tabs would fit into the header area.
+			int all_tabs_width = 0;
+			for (int i = 0; i < tabs.size(); i++) {
+				int tab_width = _get_tab_width(i);
+				all_tabs_width += tab_width;
 
-
-
-			int w=0;
-			int idx=0;
-			Vector<int> offsets;
-			Vector<Control*> controls;
-			int from=0;
-			int limit=get_size().width;
-			if (popup) {
-				top_size.width-=menu->get_width();
-				limit-=menu->get_width();
-			}
-
-			bool notdone=false;
-			last_tab_cache=-1;
-
-			for(int i=0;i<get_child_count();i++) {
-
-				Control *c = get_child(i)->cast_to<Control>();
-				if (!c)
-					continue;
-				if (c->is_set_as_toplevel())
-					continue;
-				if (idx<tab_display_ofs) {
-					idx++;
-					from=idx;
-					continue;
-				}
-
-				if (w>=get_size().width) {
-					buttons_visible_cache=true;
-					notdone=true;
+				if (all_tabs_width > header_width) {
+					// Not all tabs are visible at the same time - reserve space for navigation buttons.
+					buttons_visible_cache = true;
+					header_width -= decrement->get_width() + increment->get_width();
 					break;
-				}
-
-				offsets.push_back(w);
-				controls.push_back(c);
-
-				String s = c->has_meta("_tab_name")?String(XL_MESSAGE(String(c->get_meta("_tab_name")))):String(c->get_name());
-				w+=font->get_string_size(s).width;
-				if (c->has_meta("_tab_icon")) {
-					Ref<Texture> icon = c->get_meta("_tab_icon");
-					if (icon.is_valid()) {
-						w+=icon->get_width();
-						if (s!="")
-						     w+=get_constant("hseparation");
-
-					}
-				}
-
-				if (idx==current) {
-
-					w+=tab_fg->get_minimum_size().width;
 				} else {
-					w+=tab_bg->get_minimum_size().width;
+					buttons_visible_cache = false;
 				}
-
-				if (idx<tab_display_ofs) {
-
-				}
-				last_tab_cache=idx;
-
-				idx++;
+			}
+			// With buttons, a right side margin does not need to be respected.
+			if (popup || buttons_visible_cache) {
+				header_width += side_margin;
 			}
 
+			// Go through the visible tabs to find the width they occupy.
+			all_tabs_width = 0;
+			Vector<int> tab_widths;
+			for (int i = first_tab_cache; i < tabs.size(); i++) {
+				int tab_width = _get_tab_width(i);
+				if (all_tabs_width + tab_width > header_width && tab_widths.size() > 0)
+					break;
+				all_tabs_width += tab_width;
+				tab_widths.push_back(tab_width);
+			}
 
-			int ofs;
+			// Find the offset at which to draw tabs, according to the alignment.
+			switch (align) {
+				case ALIGN_LEFT:
+					tabs_ofs_cache = header_x;
+					break;
+				case ALIGN_CENTER:
+					tabs_ofs_cache = header_x + (header_width / 2) - (all_tabs_width / 2);
+					break;
+				case ALIGN_RIGHT:
+					tabs_ofs_cache = header_x + header_width - all_tabs_width;
+					break;
+			}
 
-			switch(align) {
-
-				case ALIGN_LEFT: ofs = side_margin; break;
-				case ALIGN_CENTER: ofs = (int(limit) - w)/2; break;
-				case ALIGN_RIGHT: ofs = int(limit) - w - side_margin; break;
-			};
-
-			tab_display_ofs=0;
-
-
-			tabs_ofs_cache=ofs;
-			idx=0;
-
-
-
-			for(int i=0;i<controls.size();i++) {
-
-				idx=i+from;
-				if (current>=from && current<from+controls.size()-1) {
-					//current is visible! draw it last.
-					if (i==controls.size()-1) {
-						idx=current;
-					} else if (idx>=current) {
-						idx+=1;
-					}
-				}
-
-				Control *c = controls[idx-from];
-
-				String s = c->has_meta("_tab_name")?String(c->get_meta("_tab_name")):String(c->get_name());
-				int w=font->get_string_size(s).width;
-				Ref<Texture> icon;
-				if (c->has_meta("_tab_icon")) {
-					icon = c->get_meta("_tab_icon");
-					if (icon.is_valid()) {
-
-						w+=icon->get_width();
-						if (s!="")
-							w+=get_constant("hseparation");
-
-					}
-				}
-
-
-				Ref<StyleBox> sb;
-				Color col;
-
-				if (idx==current) {
-
-					sb=tab_fg;
-					col=color_fg;
+			// Draw all visible tabs.
+			int x = 0;
+			for (int i = 0; i < tab_widths.size(); i++) {
+				Ref<StyleBox> tab_style;
+				Color font_color;
+				if (i + first_tab_cache == current) {
+					tab_style = tab_fg;
+					font_color = font_color_fg;
 				} else {
-					sb=tab_bg;
-					col=color_bg;
+					tab_style = tab_bg;
+					font_color = font_color_bg;
 				}
 
-				int lofs = ofs + offsets[idx-from];
+				// Draw the tab background.
+				int tab_width = tab_widths[i];
+				Rect2 tab_rect(tabs_ofs_cache + x, 0, tab_width, header_height);
+				tab_style->draw(canvas, tab_rect);
 
-				Size2i sb_ms = sb->get_minimum_size();
-				Rect2 sb_rect = Rect2( lofs, 0, w+sb_ms.width, top_margin);
+				// Draw the tab contents.
+				Control *control = tabs[i + first_tab_cache]->cast_to<Control>();
+				String text = control->has_meta("_tab_name")
+					? String(XL_MESSAGE(String(control->get_meta("_tab_name"))))
+					: String(control->get_name());
 
+				int x_content = tab_rect.pos.x + tab_style->get_margin(MARGIN_LEFT);
+				int top_margin = tab_style->get_margin(MARGIN_TOP);
+				int y_center = top_margin + (tab_rect.size.y - tab_style->get_minimum_size().y) / 2;
 
-				sb->draw(ci, sb_rect );
-
-				Point2i lpos = sb_rect.pos;
-				lpos.x+=sb->get_margin(MARGIN_LEFT);
-				if (icon.is_valid()) {
-
-					icon->draw(ci, Point2i( lpos.x, sb->get_margin(MARGIN_TOP)+((sb_rect.size.y-sb_ms.y)-icon->get_height())/2 ) );
-					if (s!="")
-						lpos.x+=icon->get_width()+get_constant("hseparation");
-
+				// Draw the tab icon.
+				if (control->has_meta("_tab_icon")) {
+					Ref<Texture> icon = control->get_meta("_tab_icon");
+					if (icon.is_valid()) {
+						int y = y_center - (icon->get_height() / 2);
+						icon->draw(canvas, Point2i(x_content, y));
+						if (text != "")
+							x_content += icon->get_width() + icon_text_distance;
+					}
 				}
 
-				font->draw(ci, Point2i( lpos.x, sb->get_margin(MARGIN_TOP)+((sb_rect.size.y-sb_ms.y)-font->get_height())/2+font->get_ascent() ), s, col );
+				// Draw the tab text.
+				Point2i text_pos(x_content, y_center - (font->get_height() / 2) + font->get_ascent());
+				font->draw(canvas, text_pos, text, font_color);
 
-				idx++;
+				x += tab_width;
+				last_tab_cache = i + first_tab_cache;
 			}
 
-
-			if (buttons_visible_cache) {
-
-				int vofs = (top_margin-incr->get_height())/2;
-				decr->draw(ci,Point2(limit,vofs),Color(1,1,1,tab_display_ofs==0?0.5:1.0));
-				incr->draw(ci,Point2(limit+incr->get_width(),vofs),Color(1,1,1,notdone?1.0:0.5));
-			}
-
+			// Draw the popup menu.
+			x = get_size().width;
 			if (popup) {
-				int from = get_size().width-menu->get_width();
-
-				if (mouse_x_cache > from)
-					menu_hl->draw(get_canvas_item(),Size2(from,0));
+				x -= menu->get_width();
+				if (mouse_x_cache > x)
+					menu_hl->draw(get_canvas_item(), Size2(x, 0));
 				else
-					menu->draw(get_canvas_item(),Size2(from,0));
+					menu->draw(get_canvas_item(), Size2(x, 0));
 			}
 
-			panel->draw(ci, Rect2( 0, top_size.height, size.width, size.height-top_size.height));
+			// Draw the navigation buttons.
+			if (buttons_visible_cache) {
+				int y_center = header_height / 2;
 
+				x -= increment->get_width();
+				increment->draw(canvas,
+					Point2(x, y_center - (increment->get_height() / 2)),
+					Color(1, 1, 1, last_tab_cache < tabs.size() - 1 ? 1.0 : 0.5));
+
+				x -= decrement->get_width();
+				decrement->draw(canvas,
+					Point2(x, y_center - (decrement->get_height() / 2)),
+					Color(1, 1, 1, first_tab_cache > 0 ? 1.0 : 0.5));
+			}
+
+			// Draw the tab area.
+			panel->draw(canvas, Rect2(0, header_height, size.width, size.height - header_height));
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
 			if (get_tab_count() > 0) {
-				call_deferred("set_current_tab",get_current_tab()); //wait until all changed theme
+				call_deferred("set_current_tab", get_current_tab()); //wait until all changed theme
 			}
 		} break;
 	}
+}
+
+int TabContainer::_get_tab_width(int p_index) const {
+	Control *control = _get_tabs()[p_index]->cast_to<Control>();
+	if (!control || control->is_set_as_toplevel())
+		return 0;
+
+	// Get the width of the text displayed on the tab.
+	Ref<Font> font = get_font("font");
+	String text = control->has_meta("_tab_name")
+		? String(XL_MESSAGE(String(control->get_meta("_tab_name"))))
+		: String(control->get_name());
+	int width = font->get_string_size(text).width;
+
+	// Add space for a tab icon.
+	if (control->has_meta("_tab_icon")) {
+		Ref<Texture> icon = control->get_meta("_tab_icon");
+		if (icon.is_valid()) {
+			width += icon->get_width();
+			if (text != "")
+				width += get_constant("hseparation");
+		}
+	}
+
+	// Respect a minimum size.
+	Ref<StyleBox> tab_bg = get_stylebox("tab_bg");
+	Ref<StyleBox> tab_fg = get_stylebox("tab_fg");
+	if (p_index == current) {
+		width += tab_fg->get_minimum_size().width;
+	} else {
+		width += tab_bg->get_minimum_size().width;
+	}
+
+	return width;
+}
+
+Vector<Control*> TabContainer::_get_tabs() const {
+
+	Vector<Control*> controls;
+	for (int i = 0; i < get_child_count(); i++) {
+
+		Control *control = get_child(i)->cast_to<Control>();
+		if (!control || control->is_toplevel_control())
+			continue;
+
+		controls.push_back(control);
+	}
+	return controls;
 }
 
 void TabContainer::_child_renamed_callback() {
@@ -408,78 +351,62 @@ void TabContainer::add_child_notify(Node *p_child) {
 	if (c->is_set_as_toplevel())
 		return;
 
-	bool first=false;
+	bool first = false;
 
-	if (get_tab_count()!=1)
+	if (get_tab_count() != 1)
 		c->hide();
 	else {
 		c->show();
 		//call_deferred("set_current_tab",0);
-		first=true;
-		current=0;
+		first = true;
+		current = 0;
 	}
 	c->set_area_as_parent_rect();
 	if (tabs_visible)
-		c->set_margin(MARGIN_TOP,_get_top_margin());
+		c->set_margin(MARGIN_TOP, _get_top_margin());
 	Ref<StyleBox> sb = get_stylebox("panel");
-	for(int i=0;i<4;i++)
-		c->set_margin(Margin(i),c->get_margin(Margin(i))+sb->get_margin(Margin(i)));
+	for (int i = 0; i < 4; i++)
+		c->set_margin(Margin(i), c->get_margin(Margin(i)) + sb->get_margin(Margin(i)));
 
 
 	update();
-	p_child->connect("renamed", this,"_child_renamed_callback");
-	if(first)
-		emit_signal("tab_changed",current);
+	p_child->connect("renamed", this, "_child_renamed_callback");
+	if (first)
+		emit_signal("tab_changed", current);
 }
 
 int TabContainer::get_tab_count() const {
 
-	int count=0;
-
-	for(int i=0;i<get_child_count();i++) {
-
-		Control *c = get_child(i)->cast_to<Control>();
-		if (!c)
-			continue;
-		count++;
-	}
-
-	return count;
+	return _get_tabs().size();
 }
 
 
 void TabContainer::set_current_tab(int p_current) {
 
-	ERR_FAIL_INDEX( p_current, get_tab_count() );
+	ERR_FAIL_INDEX(p_current, get_tab_count());
 
-	current=p_current;
+	current = p_current;
 
-	int idx=0;
+	Ref<StyleBox> sb = get_stylebox("panel");
+	Vector<Control*> tabs = _get_tabs();
+	for (int i = 0; i < tabs.size(); i++) {
 
-	Ref<StyleBox> sb=get_stylebox("panel");
-	for(int i=0;i<get_child_count();i++) {
-
-		Control *c = get_child(i)->cast_to<Control>();
-		if (!c)
-			continue;
-		if (c->is_set_as_toplevel())
-			continue;
-		if (idx==current) {
+		Control *c = tabs[i];
+		if (i == current) {
 			c->show();
 			c->set_area_as_parent_rect();
 			if (tabs_visible)
-				c->set_margin(MARGIN_TOP,_get_top_margin());
-			for(int i=0;i<4;i++)
-				c->set_margin(Margin(i),c->get_margin(Margin(i))+sb->get_margin(Margin(i)));
+				c->set_margin(MARGIN_TOP, _get_top_margin());
+			for (int i = 0; i < 4; i++)
+				c->set_margin(Margin(i), c->get_margin(Margin(i)) + sb->get_margin(Margin(i)));
 
 
 		} else
 			c->hide();
-		idx++;
 	}
 
 	_change_notify("current_tab");
-	emit_signal("tab_changed",current);
+	emit_signal("tab_changed", current);
 	update();
 }
 
@@ -490,45 +417,19 @@ int TabContainer::get_current_tab() const {
 
 Control* TabContainer::get_tab_control(int p_idx) const {
 
-	int idx=0;
-
-
-	for(int i=0;i<get_child_count();i++) {
-
-		Control *c = get_child(i)->cast_to<Control>();
-		if (!c)
-			continue;
-		if (c->is_set_as_toplevel())
-			continue;
-		if (idx==p_idx) {
-			return c;
-
-		}
-		idx++;
-	}
-
-	return NULL;
+	Vector<Control*> tabs = _get_tabs();
+	if (p_idx >= 0 && p_idx < tabs.size())
+		return tabs[p_idx];
+	else
+		return NULL;
 }
 Control* TabContainer::get_current_tab_control() const {
 
-	int idx=0;
-
-
-	for(int i=0;i<get_child_count();i++) {
-
-		Control *c = get_child(i)->cast_to<Control>();
-		if (!c)
-			continue;
-		if (c->is_set_as_toplevel())
-			continue;
-		if (idx==current) {
-			return c;
-
-		}
-		idx++;
-	}
-
-	return NULL;
+	Vector<Control*> tabs = _get_tabs();
+	if (current >= 0 && current < tabs.size())
+		return tabs[current];
+	else
+		return NULL;
 }
 
 void TabContainer::remove_child_notify(Node *p_child) {
@@ -536,24 +437,24 @@ void TabContainer::remove_child_notify(Node *p_child) {
 	Control::remove_child_notify(p_child);
 
 	int tc = get_tab_count();
-	if (current==tc-1) {
+	if (current == tc - 1) {
 		current--;
-		if (current<0)
-			current=0;
+		if (current < 0)
+			current = 0;
 		else {
-			call_deferred("set_current_tab",current);
+			call_deferred("set_current_tab", current);
 		}
 	}
 
-	p_child->disconnect("renamed", this,"_child_renamed_callback");
+	p_child->disconnect("renamed", this, "_child_renamed_callback");
 
 	update();
 }
 
 void TabContainer::set_tab_align(TabAlign p_align) {
 
-	ERR_FAIL_INDEX(p_align,3);
-	align=p_align;
+	ERR_FAIL_INDEX(p_align, 3);
+	align = p_align;
 	update();
 
 	_change_notify("tab_align");
@@ -565,20 +466,19 @@ TabContainer::TabAlign TabContainer::get_tab_align() const {
 
 void TabContainer::set_tabs_visible(bool p_visibe) {
 
-	if (p_visibe==tabs_visible)
+	if (p_visibe == tabs_visible)
 		return;
 
-	tabs_visible=p_visibe;
+	tabs_visible = p_visibe;
 
-	for(int i=0;i<get_child_count();i++) {
+	Vector<Control*> tabs = _get_tabs();
+	for (int i = 0; i < tabs.size(); i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
-		if (!c)
-			continue;
+		Control *c = tabs[i];
 		if (p_visibe)
-			c->set_margin(MARGIN_TOP,_get_top_margin());
+			c->set_margin(MARGIN_TOP, _get_top_margin());
 		else
-			c->set_margin(MARGIN_TOP,0);
+			c->set_margin(MARGIN_TOP, 0);
 
 	}
 	update();
@@ -593,36 +493,22 @@ bool TabContainer::are_tabs_visible() const {
 
 Control *TabContainer::_get_tab(int p_idx) const {
 
-	int idx=0;
-
-	for(int i=0;i<get_child_count();i++) {
-
-		Control *c = get_child(i)->cast_to<Control>();
-		if (!c)
-			continue;
-		if (c->is_set_as_toplevel())
-			continue;
-		if (idx==p_idx)
-			return c;
-		idx++;
-
-	}
-	return NULL;
+	return get_tab_control(p_idx);
 
 }
 
-void TabContainer::set_tab_title(int p_tab,const String& p_title) {
+void TabContainer::set_tab_title(int p_tab, const String& p_title) {
 
 	Control *child = _get_tab(p_tab);
 	ERR_FAIL_COND(!child);
-	child->set_meta("_tab_name",p_title);
+	child->set_meta("_tab_name", p_title);
 
 }
 
-String TabContainer::get_tab_title(int p_tab) const{
+String TabContainer::get_tab_title(int p_tab) const {
 
 	Control *child = _get_tab(p_tab);
-	ERR_FAIL_COND_V(!child,"");
+	ERR_FAIL_COND_V(!child, "");
 	if (child->has_meta("_tab_name"))
 		return child->get_meta("_tab_name");
 	else
@@ -630,17 +516,17 @@ String TabContainer::get_tab_title(int p_tab) const{
 
 }
 
-void TabContainer::set_tab_icon(int p_tab,const Ref<Texture>& p_icon){
+void TabContainer::set_tab_icon(int p_tab, const Ref<Texture>& p_icon) {
 
 	Control *child = _get_tab(p_tab);
 	ERR_FAIL_COND(!child);
-	child->set_meta("_tab_icon",p_icon);
+	child->set_meta("_tab_icon", p_icon);
 
 }
-Ref<Texture> TabContainer::get_tab_icon(int p_tab) const{
+Ref<Texture> TabContainer::get_tab_icon(int p_tab) const {
 
 	Control *child = _get_tab(p_tab);
-	ERR_FAIL_COND_V(!child,Ref<Texture>());
+	ERR_FAIL_COND_V(!child, Ref<Texture>());
 	if (child->has_meta("_tab_icon"))
 		return child->get_meta("_tab_icon");
 	else
@@ -649,20 +535,17 @@ Ref<Texture> TabContainer::get_tab_icon(int p_tab) const{
 
 void TabContainer::get_translatable_strings(List<String> *p_strings) const {
 
-	for(int i=0;i<get_child_count();i++) {
+	Vector<Control*> tabs = _get_tabs();
+	for (int i = 0; i < tabs.size(); i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
-		if (!c)
-			continue;
-		if (c->is_set_as_toplevel())
-			continue;
+		Control *c = tabs[i];
 
 		if (!c->has_meta("_tab_name"))
 			continue;
 
 		String name = c->get_meta("_tab_name");
 
-		if (name!="")
+		if (name != "")
 			p_strings->push_back(name);
 	}
 }
@@ -672,38 +555,35 @@ Size2 TabContainer::get_minimum_size() const {
 
 	Size2 ms;
 
-	for(int i=0;i<get_child_count();i++) {
+	Vector<Control*> tabs = _get_tabs();
+	for (int i = 0; i < tabs.size(); i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
-		if (!c)
-			continue;
-		if (c->is_set_as_toplevel())
-			continue;
+		Control *c = tabs[i];
 
 		if (!c->is_visible_in_tree())
 			continue;
 
 		Size2 cms = c->get_combined_minimum_size();
-		ms.x=MAX(ms.x,cms.x);
-		ms.y=MAX(ms.y,cms.y);
+		ms.x = MAX(ms.x, cms.x);
+		ms.y = MAX(ms.y, cms.y);
 	}
 
 	Ref<StyleBox> tab_bg = get_stylebox("tab_bg");
 	Ref<StyleBox> tab_fg = get_stylebox("tab_fg");
 	Ref<Font> font = get_font("font");
 
-	ms.y+=MAX(tab_bg->get_minimum_size().y,tab_fg->get_minimum_size().y);
-	ms.y+=font->get_height();
+	ms.y += MAX(tab_bg->get_minimum_size().y, tab_fg->get_minimum_size().y);
+	ms.y += font->get_height();
 
 	Ref<StyleBox> sb = get_stylebox("panel");
-	ms+=sb->get_minimum_size();
+	ms += sb->get_minimum_size();
 
 	return ms;
 }
 
 void TabContainer::set_popup(Node *p_popup) {
 	ERR_FAIL_NULL(p_popup);
-	popup=p_popup->cast_to<Popup>();
+	popup = p_popup->cast_to<Popup>();
 	update();
 }
 
@@ -714,43 +594,43 @@ Popup* TabContainer::get_popup() const {
 
 void TabContainer::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_gui_input"),&TabContainer::_gui_input);
-	ClassDB::bind_method(D_METHOD("get_tab_count"),&TabContainer::get_tab_count);
-	ClassDB::bind_method(D_METHOD("set_current_tab","tab_idx"),&TabContainer::set_current_tab);
-	ClassDB::bind_method(D_METHOD("get_current_tab"),&TabContainer::get_current_tab);
-	ClassDB::bind_method(D_METHOD("get_current_tab_control:Control"),&TabContainer::get_current_tab_control);
-	ClassDB::bind_method(D_METHOD("get_tab_control:Control","idx"),&TabContainer::get_tab_control);
-	ClassDB::bind_method(D_METHOD("set_tab_align","align"),&TabContainer::set_tab_align);
-	ClassDB::bind_method(D_METHOD("get_tab_align"),&TabContainer::get_tab_align);
-	ClassDB::bind_method(D_METHOD("set_tabs_visible","visible"),&TabContainer::set_tabs_visible);
-	ClassDB::bind_method(D_METHOD("are_tabs_visible"),&TabContainer::are_tabs_visible);
-	ClassDB::bind_method(D_METHOD("set_tab_title","tab_idx","title"),&TabContainer::set_tab_title);
-	ClassDB::bind_method(D_METHOD("get_tab_title","tab_idx"),&TabContainer::get_tab_title);
-	ClassDB::bind_method(D_METHOD("set_tab_icon","tab_idx","icon:Texture"),&TabContainer::set_tab_icon);
-	ClassDB::bind_method(D_METHOD("get_tab_icon:Texture","tab_idx"),&TabContainer::get_tab_icon);
-	ClassDB::bind_method(D_METHOD("set_popup","popup:Popup"),&TabContainer::set_popup);
-	ClassDB::bind_method(D_METHOD("get_popup:Popup"),&TabContainer::get_popup);
+	ClassDB::bind_method(D_METHOD("_gui_input"), &TabContainer::_gui_input);
+	ClassDB::bind_method(D_METHOD("get_tab_count"), &TabContainer::get_tab_count);
+	ClassDB::bind_method(D_METHOD("set_current_tab", "tab_idx"), &TabContainer::set_current_tab);
+	ClassDB::bind_method(D_METHOD("get_current_tab"), &TabContainer::get_current_tab);
+	ClassDB::bind_method(D_METHOD("get_current_tab_control:Control"), &TabContainer::get_current_tab_control);
+	ClassDB::bind_method(D_METHOD("get_tab_control:Control", "idx"), &TabContainer::get_tab_control);
+	ClassDB::bind_method(D_METHOD("set_tab_align", "align"), &TabContainer::set_tab_align);
+	ClassDB::bind_method(D_METHOD("get_tab_align"), &TabContainer::get_tab_align);
+	ClassDB::bind_method(D_METHOD("set_tabs_visible", "visible"), &TabContainer::set_tabs_visible);
+	ClassDB::bind_method(D_METHOD("are_tabs_visible"), &TabContainer::are_tabs_visible);
+	ClassDB::bind_method(D_METHOD("set_tab_title", "tab_idx", "title"), &TabContainer::set_tab_title);
+	ClassDB::bind_method(D_METHOD("get_tab_title", "tab_idx"), &TabContainer::get_tab_title);
+	ClassDB::bind_method(D_METHOD("set_tab_icon", "tab_idx", "icon:Texture"), &TabContainer::set_tab_icon);
+	ClassDB::bind_method(D_METHOD("get_tab_icon:Texture", "tab_idx"), &TabContainer::get_tab_icon);
+	ClassDB::bind_method(D_METHOD("set_popup", "popup:Popup"), &TabContainer::set_popup);
+	ClassDB::bind_method(D_METHOD("get_popup:Popup"), &TabContainer::get_popup);
 
-	ClassDB::bind_method(D_METHOD("_child_renamed_callback"),&TabContainer::_child_renamed_callback);
+	ClassDB::bind_method(D_METHOD("_child_renamed_callback"), &TabContainer::_child_renamed_callback);
 
-	ADD_SIGNAL(MethodInfo("tab_changed",PropertyInfo(Variant::INT,"tab")));
+	ADD_SIGNAL(MethodInfo("tab_changed", PropertyInfo(Variant::INT, "tab")));
 	ADD_SIGNAL(MethodInfo("pre_popup_pressed"));
 
-	ADD_PROPERTY( PropertyInfo(Variant::INT, "tab_align", PROPERTY_HINT_ENUM,"Left,Center,Right"), "set_tab_align", "get_tab_align") ;
-	ADD_PROPERTY( PropertyInfo(Variant::INT, "current_tab", PROPERTY_HINT_RANGE,"-1,4096,1",PROPERTY_USAGE_EDITOR), "set_current_tab", "get_current_tab") ;
-	ADD_PROPERTY( PropertyInfo(Variant::BOOL, "tabs_visible"), "set_tabs_visible", "are_tabs_visible") ;
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "tab_align", PROPERTY_HINT_ENUM, "Left,Center,Right"), "set_tab_align", "get_tab_align");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "current_tab", PROPERTY_HINT_RANGE, "-1,4096,1", PROPERTY_USAGE_EDITOR), "set_current_tab", "get_current_tab");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "tabs_visible"), "set_tabs_visible", "are_tabs_visible");
 
 }
 
 TabContainer::TabContainer() {
 
-	tab_display_ofs=0;
-	buttons_visible_cache=false;
-	tabs_ofs_cache=0;
-	current=0;
-	mouse_x_cache=0;
-	align=ALIGN_CENTER;
-	tabs_visible=true;
-	popup=NULL;
+	first_tab_cache = 0;
+	buttons_visible_cache = false;
+	tabs_ofs_cache = 0;
+	current = 0;
+	mouse_x_cache = 0;
+	align = ALIGN_CENTER;
+	tabs_visible = true;
+	popup = NULL;
 
 }

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -46,7 +46,7 @@ public:
 private:
 
 	int mouse_x_cache;
-	int tab_display_ofs;
+	int first_tab_cache;
 	int tabs_ofs_cache;
 	int last_tab_cache;
 	int current;
@@ -57,6 +57,8 @@ private:
 	int _get_top_margin() const;
 	Popup *popup;
 
+	Vector<Control*> _get_tabs() const;
+	int _get_tab_width(int p_index) const;
 
 protected:
 


### PR DESCRIPTION
Tabs in `TabContainer` were drawn incorrectly and clicking the navigation buttons had no effect. This issue was probably introduced in an effort to allow tab alignment for https://github.com/godotengine/godot/issues/2207

- Fixes https://github.com/godotengine/godot/issues/7546: Navigation buttons left / right did not work.
- Fixes https://github.com/godotengine/godot/issues/6997: Navigation buttons were drawn outside of the control.
- Tabs were drawn outside of the available area and incorrectly aligned.
- Navigation buttons were drawn above tabs, making it impossible to use them.

Beyond rewriting the drawing and GUI logic which was required because the previous code was patchwork, I also changed the method of retrieving all the nodes which are handled as tabs (this does not include non-`Control` children and toplevel ones). Most methods reimplemented iterating through the children and checking the controls, now the method `_get_tabs()` is used in each.

- Fixes a bug that caused `get_tab_count()` to return a wrong number of tabs as it did not check for toplevel controls.