### PR TITLE
Respect style boxes for Button states other than "normal"

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -74,17 +74,21 @@ void Button::_notification(int p_what) {
 
 		//print_line(get_text()+": "+itos(is_flat())+" hover "+itos(get_draw_mode()));
 
+		Ref<StyleBox> style = get_stylebox("normal");
+
 		switch( get_draw_mode() ) {
 
 			case DRAW_NORMAL: {
 
+				style = get_stylebox("normal");
 				if (!flat)
-					get_stylebox("normal" )->draw(  ci, Rect2(Point2(0,0), size) );
+					style->draw(  ci, Rect2(Point2(0,0), size) );
 				color=get_color("font_color");
 			} break;
 			case DRAW_PRESSED: {
 
-				get_stylebox("pressed" )->draw(  ci, Rect2(Point2(0,0), size) );
+				style = get_stylebox("pressed");
+				style->draw(  ci, Rect2(Point2(0,0), size) );
 				if (has_color("font_color_pressed"))
 					color=get_color("font_color_pressed");
 				else
@@ -93,13 +97,15 @@ void Button::_notification(int p_what) {
 			} break;
 			case DRAW_HOVER: {
 
-				get_stylebox("hover" )->draw(  ci, Rect2(Point2(0,0), size) );
+				style = get_stylebox("hover");
+				style->draw(  ci, Rect2(Point2(0,0), size) );
 				color=get_color("font_color_hover");
 
 			} break;
 			case DRAW_DISABLED: {
 
-				get_stylebox("disabled" )->draw(  ci, Rect2(Point2(0,0), size) );
+				style = get_stylebox("disabled");
+				style->draw(  ci, Rect2(Point2(0,0), size) );
 				color=get_color("font_color_disabled");
 
 			} break;
@@ -111,7 +117,6 @@ void Button::_notification(int p_what) {
 			style->draw(ci,Rect2(Point2(),size));
 		}
 
-		Ref<StyleBox> style = get_stylebox("normal" );
 		Ref<Font> font=get_font("font");
 		Ref<Texture> _icon;
 		if (icon.is_null() && has_icon("icon"))


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/7570

Previously, only the "normal" state `Button` style box had an effect on the content alignment in the button. I made it respect whichever state is current and the one used to draw the background.