### PR TITLE
CollisionShape2D: Fix warning icon not updating.

### DIFF
--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -243,6 +243,7 @@ void CollisionPolygon2D::set_polygon(const Vector<Point2>& p_polygon) {
 		_update_parent();
 	}
 	update();
+	update_configuration_warning();
 }
 
 Vector<Point2> CollisionPolygon2D::get_polygon() const {

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -159,6 +159,7 @@ void CollisionShape2D::set_shape(const Ref<Shape2D>& p_shape) {
 	if (shape.is_valid())
 		shape->connect("changed",this,"_shape_changed");
 
+	update_configuration_warning();
 }
 
 Ref<Shape2D> CollisionShape2D::get_shape() const {


### PR DESCRIPTION
`CollisionPolygon2D` also had this problem.
Fixes #7609