### PR TITLE
Re-implemented texture action for scene import

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -961,7 +961,7 @@ void FixedSpatialMaterial::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::REAL,"emission_energy",PROPERTY_HINT_RANGE,"0,16,0.01"),_SCS("set_emission_energy"),_SCS("get_emission_energy"));
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT,"emission_texture",PROPERTY_HINT_RESOURCE_TYPE,"Texture"),_SCS("set_texture"),_SCS("get_texture"),TEXTURE_EMISSION);
 
-	ADD_GROUP("NormapMap","normal_");
+	ADD_GROUP("NormalMap","normal_");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL,"normal_enabled"),_SCS("set_feature"),_SCS("get_feature"),FEATURE_NORMAL_MAPPING);
 	ADD_PROPERTY(PropertyInfo(Variant::REAL,"normal_scale",PROPERTY_HINT_RANGE,"-16,16,0.01"),_SCS("set_normal_scale"),_SCS("get_normal_scale"));
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT,"normal_texture",PROPERTY_HINT_RESOURCE_TYPE,"Texture"),_SCS("set_texture"),_SCS("get_texture"),TEXTURE_NORMAL);

--- a/tools/editor/io_plugins/editor_import_collada.cpp
+++ b/tools/editor/io_plugins/editor_import_collada.cpp
@@ -463,6 +463,7 @@ Error ColladaImport::_create_material(const String& p_target) {
 
 			Ref<Texture> texture = ResourceLoader::load(texfile,"Texture");
 			if (texture.is_valid()) {
+				material->set_feature(FixedSpatialMaterial::FEATURE_NORMAL_MAPPING, true);
 				material->set_texture(FixedSpatialMaterial::TEXTURE_NORMAL,texture);
 				//material->set_emission(Color(1,1,1,1));
 


### PR DESCRIPTION
Removed dud "Shared" option and added option to import textures to the same folder as the source, or to just use them without importing (flags may need to be applied manually).

I did this so that I can have blender models and textures living directly within the project tree, simplifying my asset pipeline.

Preview of the UI change:
![screenshot_2017-01-25_00-07-45](https://cloud.githubusercontent.com/assets/185322/22255480/735e9036-e292-11e6-8531-b4e3da1539b7.png)