### PR TITLE
Added functionality for resizable WindowDialogs

### DIFF
--- a/scene/gui/dialogs.h
+++ b/scene/gui/dialogs.h
@@ -44,12 +44,26 @@ class WindowDialog : public Popup {
 
 	GDCLASS(WindowDialog,Popup);
 
+	enum DRAG_TYPE {
+		DRAG_NONE = 0,
+		DRAG_MOVE = 1,
+		DRAG_RESIZE_TOP = 1 << 1,
+		DRAG_RESIZE_RIGHT = 1 << 2,
+		DRAG_RESIZE_BOTTOM = 1 << 3,
+		DRAG_RESIZE_LEFT = 1 << 4
+	};
+
 	TextureButton *close_button;
 	String title;
-	bool dragging;
+	int drag_type;
+	Point2 drag_offset;
+	Point2 drag_offset_far;
+	bool resizable;
 
 	void _gui_input(const InputEvent& p_event);
 	void _closed();
+	int _drag_hit_test(const Point2& pos) const;
+
 protected:
 	virtual void _post_popup();
 
@@ -63,6 +77,8 @@ public:
 
 	void set_title(const String& p_title);
 	String get_title() const;
+	void set_resizable(bool p_resizable);
+	bool get_resizable() const;
 
 	Size2 get_minimum_size() const;
 

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -583,24 +583,19 @@ void fill_default_theme(Ref<Theme>& t, const Ref<Font> & default_font, const Ref
 
 	// WindowDialog
 
-	Ref<StyleBoxTexture> style_pp_win = sb_expand(make_stylebox( popup_window_png,10,30,10,8),8,26,8,4);
-	/*for(int i=0;i<4;i++)
-		style_pp_win->set_expand_margin_size((Margin)i,3);
-	style_pp_win->set_expand_margin_size(MARGIN_TOP,26);*/
+	Ref<StyleBoxTexture> style_pp_win = sb_expand(make_stylebox(popup_window_png, 10, 26, 10, 8), 8, 24, 8, 6);
+	t->set_stylebox("panel", "WindowDialog", style_pp_win);
+	t->set_constant("titlebar_height", "WindowDialog", 20 * scale);
+	t->set_constant("scaleborder_size", "WindowDialog", 4);
 
-	t->set_stylebox("panel","WindowDialog", style_pp_win );
+	t->set_font("title_font", "WindowDialog", large_font);
+	t->set_color("title_color", "WindowDialog", Color(0, 0, 0));
+	t->set_constant("title_height", "WindowDialog", 18 * scale);
 
-	t->set_icon("close","WindowDialog", make_icon( close_png ) );
-	t->set_icon("close_hilite","WindowDialog", make_icon( close_hl_png ) );
-
-	t->set_font("title_font","WindowDialog", large_font );
-
-	t->set_color("title_color","WindowDialog", Color(0,0,0) );
-
-	t->set_constant("close_h_ofs","WindowDialog", 22 *scale);
-	t->set_constant("close_v_ofs","WindowDialog", 20 *scale);
-	t->set_constant("titlebar_height","WindowDialog", 18 *scale);
-	t->set_constant("title_height","WindowDialog", 20 *scale);
+	t->set_icon("close", "WindowDialog", make_icon(close_png));
+	t->set_icon("close_hilite", "WindowDialog", make_icon(close_hl_png));
+	t->set_constant("close_h_ofs", "WindowDialog", 18 * scale);
+	t->set_constant("close_v_ofs", "WindowDialog", 18 * scale);
 
 
 	// File Dialog


### PR DESCRIPTION
In an effort to get https://github.com/godotengine/godot/issues/6437 done sooner or later, I extended the `WindowDialog` functionality:

- Added a methods `set_resizable(bool resizable)` and `bool get_resizable()`. If set to `true`, any `WindowDialog` control can be resized with the mouse by hovering over the border and dragging it.
- Rewrote the movement code (initiated with the titlebar) to no longer make the cursor move away from the dragging point when the cursor leaves the game window to the top.
- Prevented windows to be moved so far to negative Y coordinates so that the title bar would disappear (and making it impossible to move the window back later on). I do not prevent them to be moved out of view into any other direction at the moment.
- Fixed weird style boxes for the popup_dialog image, also aligned the close button more exactly to the right corner of the title bar.

The cursor is changed when hovering over the borders of resizable dialogs just like in any window manager I know.
Sadly, due to https://github.com/godotengine/godot/issues/7622 this does not reset the cursor when the mouse moves off the window, but is still hovering another control.