### PR TITLE
Fix VC++ build by using math_funcs constants for M_PI and M_SQRT2

### DIFF
--- a/servers/audio/effects/audio_effect_chorus.cpp
+++ b/servers/audio/effects/audio_effect_chorus.cpp
@@ -1,5 +1,6 @@
 #include "audio_effect_chorus.h"
 #include "servers/audio_server.h"
+#include "math_funcs.h"
 
 void AudioEffectChorusInstance::process(const AudioFrame *p_src_frames,AudioFrame *p_dst_frames,int p_frame_count) {
 
@@ -61,7 +62,7 @@ void AudioEffectChorusInstance::_process_chunk(const AudioFrame *p_src_frames,Au
 		//low pass filter
 		if (v.cutoff==0)
 			continue;
-		float auxlp=expf(-2.0*M_PI*v.cutoff/mix_rate);
+		float auxlp=expf(-2.0*Math_PI*v.cutoff/mix_rate);
 		float c1=1.0-auxlp;
 		float c2=auxlp;
 		AudioFrame h=filter_h[vc];
@@ -83,7 +84,7 @@ void AudioEffectChorusInstance::_process_chunk(const AudioFrame *p_src_frames,Au
 
 			float phase=(float)(local_cycles&AudioEffectChorus::CYCLES_MASK)/(float)(1<<AudioEffectChorus::CYCLES_FRAC);
 
-			float wave_delay=sinf(phase*2.0*M_PI)*max_depth_frames;
+			float wave_delay=sinf(phase*2.0*Math_PI)*max_depth_frames;
 
 			int wave_delay_frames=lrint(floor(wave_delay));
 			float wave_delay_frac=wave_delay-(float)wave_delay_frames;

--- a/servers/audio/effects/audio_effect_delay.cpp
+++ b/servers/audio/effects/audio_effect_delay.cpp
@@ -1,5 +1,6 @@
 #include "audio_effect_delay.h"
 #include "servers/audio_server.h"
+#include "math_funcs.h"
 
 void AudioEffectDelayInstance::process(const AudioFrame *p_src_frames,AudioFrame *p_dst_frames,int p_frame_count) {
 
@@ -48,7 +49,7 @@ void AudioEffectDelayInstance::_process_chunk(const AudioFrame *p_src_frames,Aud
 	tap2_vol.r*=CLAMP( 1.0 + base->tap_2_pan, 0, 1);
 
 	// feedback lowpass here
-	float lpf_c=expf(-2.0*M_PI*base->feedback_lowpass/mix_rate); // 0 .. 10khz
+	float lpf_c=expf(-2.0*Math_PI*base->feedback_lowpass/mix_rate); // 0 .. 10khz
 	float lpf_ic=1.0-lpf_c;
 
 	const AudioFrame *src=p_src_frames;

--- a/servers/audio/effects/audio_effect_distortion.cpp
+++ b/servers/audio/effects/audio_effect_distortion.cpp
@@ -1,5 +1,6 @@
 #include "audio_effect_distortion.h"
 #include "servers/audio_server.h"
+#include "math_funcs.h"
 
 
 
@@ -8,8 +9,8 @@ void AudioEffectDistortionInstance::process(const AudioFrame *p_src_frames,Audio
 	const float *src = (const float*)p_src_frames;
 	float *dst = (float*)p_dst_frames;
 
-	//float lpf_c=expf(-2.0*M_PI*keep_hf_hz.get()/(mix_rate*(float)OVERSAMPLE));
-	float lpf_c=expf(-2.0*M_PI*base->keep_hf_hz/(AudioServer::get_singleton()->get_mix_rate()));
+	//float lpf_c=expf(-2.0*Math_PI*keep_hf_hz.get()/(mix_rate*(float)OVERSAMPLE));
+	float lpf_c=expf(-2.0*Math_PI*base->keep_hf_hz/(AudioServer::get_singleton()->get_mix_rate()));
 	float lpf_ic=1.0-lpf_c;
 
 	float drive_f=base->drive;

--- a/servers/audio/effects/audio_effect_phaser.cpp
+++ b/servers/audio/effects/audio_effect_phaser.cpp
@@ -1,5 +1,6 @@
 #include "audio_effect_phaser.h"
 #include "servers/audio_server.h"
+#include "math_funcs.h"
 
 void AudioEffectPhaserInstance::process(const AudioFrame *p_src_frames,AudioFrame *p_dst_frames,int p_frame_count) {
 
@@ -8,14 +9,14 @@ void AudioEffectPhaserInstance::process(const AudioFrame *p_src_frames,AudioFram
 	float dmin = base->range_min / (sampling_rate/2.0);
 	float dmax = base->range_max / (sampling_rate/2.0);
 
-	float increment = 2.f * M_PI * (base->rate / sampling_rate);
+	float increment = 2.f * Math_PI * (base->rate / sampling_rate);
 
 	for(int i=0;i<p_frame_count;i++) {
 
 		phase += increment;
 
-		while ( phase >= M_PI * 2.f ) {
-			phase -= M_PI * 2.f;
+		while ( phase >= Math_PI * 2.f ) {
+			phase -= Math_PI * 2.f;
 		}
 
 		float d  = dmin + (dmax-dmin) * ((sin( phase ) + 1.f)/2.f);

--- a/servers/audio/effects/audio_effect_pitch_shift.cpp
+++ b/servers/audio/effects/audio_effect_pitch_shift.cpp
@@ -1,5 +1,6 @@
 #include "audio_effect_pitch_shift.h"
 #include "servers/audio_server.h"
+#include "math_funcs.h"
 /****************************************************************************
 *
 * NAME: smbPitchShift.cpp
@@ -57,7 +58,7 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 	fftFrameSize2 = fftFrameSize/2;
 	stepSize = fftFrameSize/osamp;
 	freqPerBin = sampleRate/(double)fftFrameSize;
-	expct = 2.*M_PI*(double)stepSize/(double)fftFrameSize;
+	expct = 2.*Math_PI*(double)stepSize/(double)fftFrameSize;
 	inFifoLatency = fftFrameSize-stepSize;
 	if (gRover == 0) gRover = inFifoLatency;
 
@@ -77,7 +78,7 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 
 			/* do windowing and re,im interleave */
 			for (k = 0; k < fftFrameSize;k++) {
-				window = -.5*cos(2.*M_PI*(double)k/(double)fftFrameSize)+.5;
+				window = -.5*cos(2.*Math_PI*(double)k/(double)fftFrameSize)+.5;
 				gFFTworksp[2*k] = gInFIFO[k] * window;
 				gFFTworksp[2*k+1] = 0.;
 			}
@@ -106,13 +107,13 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 				tmp -= (double)k*expct;
 
 				/* map delta phase into +/- Pi interval */
-				qpd = tmp/M_PI;
+				qpd = tmp/Math_PI;
 				if (qpd >= 0) qpd += qpd&1;
 				else qpd -= qpd&1;
-				tmp -= M_PI*(double)qpd;
+				tmp -= Math_PI*(double)qpd;
 
 				/* get deviation from bin frequency from the +/- Pi interval */
-				tmp = osamp*tmp/(2.*M_PI);
+				tmp = osamp*tmp/(2.*Math_PI);
 
 				/* compute the k-th partials' true frequency */
 				tmp = (double)k*freqPerBin + tmp*freqPerBin;
@@ -150,7 +151,7 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 				tmp /= freqPerBin;
 
 				/* take osamp into account */
-				tmp = 2.*M_PI*tmp/osamp;
+				tmp = 2.*Math_PI*tmp/osamp;
 
 				/* add the overlap phase advance back in */
 				tmp += (double)k*expct;
@@ -172,7 +173,7 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 
 			/* do windowing and add to output accumulator */
 			for(k=0; k < fftFrameSize; k++) {
-				window = -.5*cos(2.*M_PI*(double)k/(double)fftFrameSize)+.5;
+				window = -.5*cos(2.*Math_PI*(double)k/(double)fftFrameSize)+.5;
 				gOutputAccum[k] += 2.*window*gFFTworksp[2*k]/(fftFrameSize2*osamp);
 			}
 			for (k = 0; k < stepSize; k++) gOutFIFO[k] = gOutputAccum[k];
@@ -224,7 +225,7 @@ void SMBPitchShift::smbFft(float *fftBuffer, long fftFrameSize, long sign)
 		le2 = le>>1;
 		ur = 1.0;
 		ui = 0.0;
-		arg = M_PI / (le2>>1);
+		arg = Math_PI / (le2>>1);
 		wr = cos(arg);
 		wi = sign*sin(arg);
 		for (j = 0; j < le2; j += 2) {

--- a/servers/audio/effects/eq.cpp
+++ b/servers/audio/effects/eq.cpp
@@ -12,6 +12,7 @@
 #include "eq.h"
 #include <math.h>
 #include "error_macros.h"
+#include "math_funcs.h"
 
 #define POW2(v) ((v)*(v))
 
@@ -19,23 +20,23 @@
  static int solve_quadratic(double a,double b,double c,double *r1, double *r2) {
 //solves quadractic and returns number of roots
 
-    double base=2*a;
-    if (base == 0.0f)
-	    return 0;
+	double base=2*a;
+	if (base == 0.0f)
+		return 0;
 
-    double squared=b*b-4*a*c;
-    if (squared<0.0)
-	    return 0;
+	double squared=b*b-4*a*c;
+	if (squared<0.0)
+		return 0;
 
-    squared=sqrt(squared);
+	squared=sqrt(squared);
 
-    *r1=(-b+squared)/base;
-    *r2=(-b-squared)/base;
+	*r1=(-b+squared)/base;
+	*r2=(-b-squared)/base;
 
-    if (*r1==*r2)
-	    return 1;
-    else
-	    return 2;
+	if (*r1==*r2)
+		return 1;
+	else
+		return 2;
  }
 
 EQ::BandProcess::BandProcess() {
@@ -73,9 +74,9 @@ void EQ::recalculate_band_coefficients() {
 
 
 
-		double side_gain2=POW2(1.0/M_SQRT2);
-		double th=2.0*M_PI*frq/mix_rate;
-		double th_l=2.0*M_PI*frq_l/mix_rate;
+		double side_gain2=POW2(Math_SQRT12);
+		double th=2.0*Math_PI*frq/mix_rate;
+		double th_l=2.0*Math_PI*frq_l/mix_rate;
 
 		double c2a=side_gain2 * POW2(cos(th))
 					- 2.0 * side_gain2 * cos(th_l) * cos(th)

--- a/servers/audio/effects/reverb.cpp
+++ b/servers/audio/effects/reverb.cpp
@@ -12,6 +12,7 @@
 
 #include "reverb.h"
 #include <math.h>
+#include "math_funcs.h"
 
 
 const float Reverb::comb_tunings[MAX_COMBS]={
@@ -68,7 +69,7 @@ void Reverb::process(float *p_src,float *p_dst,int p_frames) {
 	}
 
 	if (params.hpf>0) {
-		float hpaux=expf(-2.0*M_PI*params.hpf*6000/params.mix_rate);
+		float hpaux=expf(-2.0*Math_PI*params.hpf*6000/params.mix_rate);
 		float hp_a1=(1.0+hpaux)/2.0;
 		float hp_a2=-(1.0+hpaux)/2.0;
 		float hp_b1=hpaux;
@@ -299,7 +300,7 @@ void Reverb::update_parameters() {
 		float auxdmp=params.damp/2.0+0.5; //only half the range (0.5 .. 1.0  is enough)
 		auxdmp*=auxdmp;
 
-		c.damp=expf(-2.0*M_PI*auxdmp*10000/params.mix_rate); // 0 .. 10khz
+		c.damp=expf(-2.0*Math_PI*auxdmp*10000/params.mix_rate); // 0 .. 10khz
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/7608

The recent changes in the audio server introduced the usage of some non-standardized C++ constants, namely `M_PI` and `M_SQRT2`.

I changed them to constants from `math_funcs.h` as suggested by Akien. Also required adding a constant for `sqrt(2)` as `Math_SQRT2`.