### PR TITLE
2D Editor: Don't show lock icons for hidden nodes (2.1)

### DIFF
--- a/tools/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/tools/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2336,7 +2336,7 @@ void CanvasItemEditor::_find_canvas_items_span(Node *p_node, Rect2& r_rect, cons
 
 
 
-	if (c) {
+	if (c && c->is_visible()) {
 
 		Rect2 rect = c->get_item_rect();
 		Matrix32 xform = p_xform * c->get_transform();

--- a/tools/editor/scene_tree_editor.cpp
+++ b/tools/editor/scene_tree_editor.cpp
@@ -471,6 +471,7 @@ void SceneTreeEditor::_node_visibility_changed(Node *p_node) {
 
 	if (p_node->is_type("CanvasItem")) {
 		visible = !p_node->call("is_hidden");
+		CanvasItemEditor::get_singleton()->get_viewport_control()->update();
 	} else if (p_node->is_type("Spatial")) {
 		visible = !p_node->call("is_hidden");
 	}


### PR DESCRIPTION
Now we only draw those icons for visible Nodes.
Fixes #7518

Cherry-picked/adapted from a043ce7304c4a9b56b5d79efa4cca05160339e72