### PR TITLE
Include filesystem dock split offset in editor layouts

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -4514,6 +4514,8 @@ void EditorNode::_save_docks_to_config(Ref<ConfigFile> p_layout, const String& p
 		}
 	}
 
+	p_layout->set_value(p_section,"dock_filesystem_split",filesystem_dock->get_split_offset());
+
 	VSplitContainer*splits[DOCK_SLOT_MAX/2]={
 		left_l_vsplit,
 		left_r_vsplit,
@@ -4689,6 +4691,12 @@ void EditorNode::_load_docks_from_config(Ref<ConfigFile> p_layout, const String&
 			dock_slot[i]->show();
 		}
 	}
+
+	int fs_split_ofs = 0;
+	if (p_layout->has_section_key(p_section,"dock_filesystem_split")) {
+		fs_split_ofs = p_layout->get_value(p_section,"dock_filesystem_split");
+	}
+	filesystem_dock->set_split_offset(fs_split_ofs);
 
 	VSplitContainer*splits[DOCK_SLOT_MAX/2]={
 		left_l_vsplit,

--- a/tools/editor/filesystem_dock.h
+++ b/tools/editor/filesystem_dock.h
@@ -199,6 +199,9 @@ public:
 
 	void set_display_mode(int p_mode);
 
+	int get_split_offset() { return split_box->get_split_offset(); }
+	void set_split_offset(int p_offset) { split_box->set_split_offset(p_offset); }
+
 	FileSystemDock(EditorNode *p_editor);
 	~FileSystemDock();
 };


### PR DESCRIPTION
If the layout doesn't contain the relevant value, it will be set to 0, so

- this change is compatible with current layout settings file;
- the default layout doesn't need an explicit value for it.

Cherry-picked from 2ac89f65403c606ad9a3cdf65e591cb375faf024
