### PR TITLE
Touch button shape (2.1)

### DIFF
--- a/scene/2d/screen_button.cpp
+++ b/scene/2d/screen_button.cpp
@@ -63,6 +63,38 @@ Ref<BitMap> TouchScreenButton::get_bitmask() const{
 	return bitmask;
 }
 
+void TouchScreenButton::set_shape(const Ref<Shape2D>& p_shape){
+
+	shape=p_shape;
+
+	if (!is_inside_tree())
+		return;
+	if (!get_tree()->is_editor_hint() && !get_tree()->is_debugging_collisions_hint())
+		return;
+	update();
+}
+
+Ref<Shape2D> TouchScreenButton::get_shape() const{
+
+	return shape;
+}
+
+void TouchScreenButton::set_shape_centered(bool p_shape_centered) {
+
+	shape_centered=p_shape_centered;
+
+	if (!is_inside_tree())
+		return;
+	if (!get_tree()->is_editor_hint() && !get_tree()->is_debugging_collisions_hint())
+		return;
+	update();
+}
+
+bool TouchScreenButton::is_shape_centered() const {
+
+	return shape_centered;
+}
+
 void TouchScreenButton::_notification(int p_what) {
 
 	switch(p_what) {
@@ -84,6 +116,15 @@ void TouchScreenButton::_notification(int p_what) {
 			} else {
 				if (texture.is_valid())
 					draw_texture(texture,Point2());
+			}
+
+			if (!get_tree()->is_editor_hint() && !get_tree()->is_debugging_collisions_hint())
+				return;
+			if (shape.is_valid()) {
+				Color draw_col=get_tree()->get_debug_collisions_color();
+				Vector2 pos=shape_centered ? get_item_rect().size*0.5f : Vector2();
+				draw_set_transform_matrix(get_canvas_transform().translated(pos));
+				shape->draw(get_canvas_item(),draw_col);
 			}
 
 		} break;
@@ -243,18 +284,30 @@ void TouchScreenButton::_input(const InputEvent& p_event) {
 					return; //already fingering
 
 				Point2 coord = (get_global_transform_with_canvas()).affine_inverse().xform(Point2(p_event.screen_touch.x,p_event.screen_touch.y));
+				Rect2 item_rect = get_item_rect();
 
 				bool touched=false;
+				bool check_rect=true;
+				if (shape.is_valid()) {
+
+					check_rect=false;
+					Matrix32 xform=shape_centered ? Matrix32().translated(get_item_rect().size*0.5f) : Matrix32();
+					touched=shape->collide(xform, unit_rect, Matrix32(0, coord + Vector2(0.5,0.5)));
+				}
+
 				if (bitmask.is_valid()) {
 
-					if (Rect2(Point2(),bitmask->get_size()).has_point(coord)) {
+					check_rect=false;
+					if (!touched && Rect2(Point2(),bitmask->get_size()).has_point(coord)) {
 
 						if (bitmask->get_bit(coord))
 							touched=true;
 					}
-				} else {
+				}
+
+				if (!touched && check_rect) {
 					if (!texture.is_null())
-						touched=Rect2(Point2(),texture->get_size()).has_point(coord);
+						touched=item_rect.has_point(coord);
 				}
 
 
@@ -347,6 +400,12 @@ void TouchScreenButton::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_bitmask","bitmask"),&TouchScreenButton::set_bitmask);
 	ObjectTypeDB::bind_method(_MD("get_bitmask"),&TouchScreenButton::get_bitmask);
 
+	ObjectTypeDB::bind_method(_MD("set_shape","shape"),&TouchScreenButton::set_shape);
+	ObjectTypeDB::bind_method(_MD("get_shape"),&TouchScreenButton::get_shape);
+
+	ObjectTypeDB::bind_method(_MD("set_shape_centered","bool"),&TouchScreenButton::set_shape_centered);
+	ObjectTypeDB::bind_method(_MD("is_shape_centered"),&TouchScreenButton::is_shape_centered);
+
 	ObjectTypeDB::bind_method(_MD("set_action","action"),&TouchScreenButton::set_action);
 	ObjectTypeDB::bind_method(_MD("get_action"),&TouchScreenButton::get_action);
 
@@ -363,6 +422,8 @@ void TouchScreenButton::_bind_methods() {
 	ADD_PROPERTY( PropertyInfo(Variant::OBJECT,"normal",PROPERTY_HINT_RESOURCE_TYPE,"Texture"),_SCS("set_texture"),_SCS("get_texture"));
 	ADD_PROPERTY( PropertyInfo(Variant::OBJECT,"pressed",PROPERTY_HINT_RESOURCE_TYPE,"Texture"),_SCS("set_texture_pressed"),_SCS("get_texture_pressed"));
 	ADD_PROPERTY( PropertyInfo(Variant::OBJECT,"bitmask",PROPERTY_HINT_RESOURCE_TYPE,"BitMap"),_SCS("set_bitmask"),_SCS("get_bitmask"));
+	ADD_PROPERTY( PropertyInfo(Variant::OBJECT,"shape",PROPERTY_HINT_RESOURCE_TYPE,"Shape2D"),_SCS("set_shape"),_SCS("get_shape"));
+	ADD_PROPERTY( PropertyInfo(Variant::BOOL,"shape_centered"),_SCS("set_shape_centered"),_SCS("is_shape_centered"));
 	ADD_PROPERTY( PropertyInfo(Variant::BOOL,"passby_press"),_SCS("set_passby_press"),_SCS("is_passby_press_enabled"));
 	ADD_PROPERTY( PropertyInfo(Variant::STRING,"action"),_SCS("set_action"),_SCS("get_action"));
 	ADD_PROPERTY( PropertyInfo(Variant::INT,"visibility_mode",PROPERTY_HINT_ENUM,"Always,TouchScreen Only"),_SCS("set_visibility_mode"),_SCS("get_visibility_mode"));
@@ -380,4 +441,7 @@ TouchScreenButton::TouchScreenButton() {
 	action_id=-1;
 	passby_press=false;
 	visibility=VISIBILITY_ALWAYS;
+	shape_centered=true;
+	unit_rect=Ref<RectangleShape2D>(memnew(RectangleShape2D));
+	unit_rect->set_extents(Vector2(0.5,0.5));
 }

--- a/scene/2d/screen_button.h
+++ b/scene/2d/screen_button.h
@@ -32,6 +32,7 @@
 #include "scene/2d/node_2d.h"
 #include "scene/resources/texture.h"
 #include "scene/resources/bit_mask.h"
+#include "scene/resources/rectangle_shape_2d.h"
 
 class TouchScreenButton : public Node2D {
 
@@ -47,6 +48,10 @@ private:
 	Ref<Texture> texture;
 	Ref<Texture> texture_pressed;
 	Ref<BitMap> bitmask;
+	Ref<Shape2D> shape;
+	bool shape_centered;
+
+	Ref<RectangleShape2D> unit_rect;
 
 	StringName action;
 	bool passby_press;
@@ -72,6 +77,12 @@ public:
 
 	void set_bitmask(const Ref<BitMap>& p_bitmask);
 	Ref<BitMap> get_bitmask() const;
+
+	void set_shape(const Ref<Shape2D>& p_shape);
+	Ref<Shape2D> get_shape() const;
+
+	void set_shape_centered(bool p_shape_centered);
+	bool is_shape_centered() const;
 
 	void set_action(const String& p_action);
 	String get_action() const;


### PR DESCRIPTION
Adds a `shape` property for `TouchScreenButton` that lets you specify a non-rectangular hot area (namely, a `Shape2D`) for it.

Also adds a `shape_centered` boolean which keeps the shape centered on the button; useful for regular shapes like rectangles and circles. Since those are the most probable use cases, the centering is on by default. For a polygon you'll probably want to keep it left-top-aligned by unchecking this one.

If both a bitmask and a shape are provided, both will be checked for press in an 'or' fashion. The raw item rect will be checked only if neither of those are set, exactly what happens currently: if a bit mask is present, the raw rect is not checked. As a consequence, **this enhancement is backwards compatible**.

You can see the shape in the editor at all times and at runtime only if the _Visible Collision Shapes_ is on. Maybe I should provide a way of turning its visibility off, but I haven't been able to think of a good way. Suggestions welcome.

# Example use case

My own use case is to let the player press the on-screen buttons by touching along all the height of the screen, rather than just the actual button bounds. I didn't want to use `bitmask` for the stated reasons and I also didn't want to add a huge transparent area to the button textures to expand their bounds.

I've added this script as a built-in one to my touch buttons:
```
extends TouchScreenButton

func _ready():
	# Detect touch along all the height of the screen
	var rect = RectangleShape2D.new()
	var width = get_item_rect().size.x
	var screen_h = OS.get_window_size().y
	rect.set_extents(Vector2(width * 0.5, screen_h))
	set_shape(rect)
```

# Design rationale

* While there is already a `bitmask` property by which you can supply a non-rectangular shape, it allocates memory proportionally to the size of bounding rect of the hot area. Thus the `shape` way is more lightweight. And more user-friendly.

* I considered letting the button have `CollisionShape2D` children so more complex shapes could be created by combining primitives. I dropped that idea because

    - you can loosely (but accurately enough) match an irregular button shape with a polygon;
    - the API and editor experience are more user-friendly;
    - the implementation doesn't get complex.

# 2.1 only?

No!

@akien-mga, I will make the version for _master_ if this one is accepted. :)