### PR TITLE
Add run/output category

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -1928,11 +1928,11 @@ void EditorNode::_run(bool p_current,const String& p_custom) {
 		editor_data.save_editor_external_data();
 	}
 
-	if (bool(EDITOR_DEF("run/always_clear_output_on_play", true))) {
+	if (bool(EDITOR_DEF("run/output/always_clear_output_on_play", true))) {
 		log->clear();
 	}
 
-	if (bool(EDITOR_DEF("run/always_open_output_on_play", true))) {
+	if (bool(EDITOR_DEF("run/output/always_open_output_on_play", true))) {
 		make_bottom_panel_item_visible(log);
 	}
 

--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -653,6 +653,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 
 	set("run/auto_save/save_before_running",true);
+	set("run/output/always_clear_output_on_play",true);
+	set("run/output/always_open_output_on_play",true);
 	set("filesystem/resources/save_compressed_resources",true);
 	set("filesystem/resources/auto_reload_modified_images",true);
 


### PR DESCRIPTION
The properties always_clear_output_on_play and always_open_output_on_play were left uncategorized.