### PR TITLE
Keyboard Input modifiers do not block actions.

### DIFF
--- a/core/input_map.cpp
+++ b/core/input_map.cpp
@@ -107,7 +107,7 @@ List<StringName> InputMap::get_actions() const {
 	return actions;
 }
 
-List<InputEvent>::Element *InputMap::_find_event(List<InputEvent> &p_list,const InputEvent& p_event, bool p_mod_ignore=false) const {
+List<InputEvent>::Element *InputMap::_find_event(List<InputEvent> &p_list,const InputEvent& p_event, bool p_action_test) const {
 
 	for (List<InputEvent>::Element *E=p_list.front();E;E=E->next()) {
 
@@ -123,7 +123,13 @@ List<InputEvent>::Element *InputMap::_find_event(List<InputEvent> &p_list,const 
 
 			case InputEvent::KEY: {
 
-				same=(e.key.scancode==p_event.key.scancode && (p_mod_ignore || e.key.mod == p_event.key.mod));
+				if(p_action_test) {
+					uint32_t code = e.key.get_scancode_with_modifiers();
+					uint32_t event_code = p_event.key.get_scancode_with_modifiers();
+					same=(e.key.scancode==p_event.key.scancode && (!p_event.key.pressed || ((code & event_code) == code)));
+				} else {
+					same=(e.key.scancode==p_event.key.scancode && e.key.mod == p_event.key.mod);
+				}
 
 			} break;
 			case InputEvent::JOYPAD_BUTTON: {
@@ -230,7 +236,7 @@ bool InputMap::event_is_action(const InputEvent& p_event, const StringName& p_ac
 		return p_event.action.action==E->get().id;
 	}
 
-	return _find_event(E->get().inputs,p_event,!p_event.is_pressed())!=NULL;
+	return _find_event(E->get().inputs,p_event,true)!=NULL;
 }
 
 const Map<StringName, InputMap::Action>& InputMap::get_action_map() const {

--- a/core/input_map.h
+++ b/core/input_map.h
@@ -46,7 +46,7 @@ private:
 	mutable Map<StringName, Action> input_map;
 	mutable Map<int,StringName> input_id_map;
 
-	List<InputEvent>::Element *_find_event(List<InputEvent> &p_list,const InputEvent& p_event, bool p_mod_ignore) const;
+	List<InputEvent>::Element *_find_event(List<InputEvent> &p_list,const InputEvent& p_event, bool p_action_test=false) const;
 
 	Array _get_action_list(const StringName& p_action);
 	Array _get_actions();

--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -381,15 +381,12 @@ void InputDefault::parse_input_event(const InputEvent& p_event) {
 	if (!p_event.is_echo()) {
 		for (const Map<StringName,InputMap::Action>::Element *E=InputMap::get_singleton()->get_action_map().front();E;E=E->next()) {
 
-			if (InputMap::get_singleton()->event_is_action(p_event,E->key())) {
-
-				if(is_action_pressed(E->key()) != p_event.is_pressed()) {
-					Action action;
-					action.fixed_frame=Engine::get_singleton()->get_fixed_frames();
-					action.idle_frame=Engine::get_singleton()->get_idle_frames();
-					action.pressed=p_event.is_pressed();
-					action_state[E->key()]=action;
-				}
+			if (InputMap::get_singleton()->event_is_action(p_event,E->key()) && is_action_pressed(E->key()) != p_event.is_pressed()) {
+				Action action;
+				action.fixed_frame=Engine::get_singleton()->get_fixed_frames();
+				action.idle_frame=Engine::get_singleton()->get_idle_frames();
+				action.pressed=p_event.is_pressed();
+				action_state[E->key()]=action;
 			}
 		}
 	}


### PR DESCRIPTION
This means, if you press <kbd>F</kbd> while holding <kbd>shift</kbd> and there is and
action registered for <kbd>F</kbd> that action should be pressed.
This commit restore this behaviour, lost when implementing
`is_action_just_pressed`.
If you want "blocking modifiers" you should code it via script.

After a brief discussion with @reduz we concluded that this was the behaviour of previous versions and it should not change.
Closes #6826 .

You can test it with [this (3.0 branch)](https://github.com/Faless/godot-input-test/tree/3.0) . Binded keys are <kbd>shift</kbd>, <kbd>shift+a</kbd>, <kbd>a</kbd>