### PR TITLE
Fix #7011 ScrollContainer takes into account child's EXPAND flag when scrolling is enabled

### DIFF
--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -236,14 +236,14 @@ void ScrollContainer::_notification(int p_what) {
 			child_max_size.y = MAX(child_max_size.y, minsize.y);
 
 			Rect2 r = Rect2(-scroll,minsize);
-			if (!(scroll_h || h_scroll->is_visible())) {
+			if (!scroll_h || (!h_scroll->is_visible() && c->get_h_size_flags()&SIZE_EXPAND)) {
 				r.pos.x=0;
 				if (c->get_h_size_flags()&SIZE_EXPAND)
 					r.size.width=MAX(size.width,minsize.width);
 				else
 					r.size.width=minsize.width;
 			}
-			if (!(scroll_v || v_scroll->is_visible())) {
+			if (!scroll_v || (!v_scroll->is_visible() && c->get_v_size_flags()&SIZE_EXPAND)) {
 				r.pos.y=0;
 				r.size.height=size.height;
 				if (c->get_v_size_flags()&SIZE_EXPAND)


### PR DESCRIPTION
Should be fine now.