### PR TITLE
Fixes #7630  Editor Translation Import Crash fix

### DIFF
--- a/tools/editor/io_plugins/editor_translation_import_plugin.cpp
+++ b/tools/editor/io_plugins/editor_translation_import_plugin.cpp
@@ -114,11 +114,8 @@ public:
 
 				if (langs[j]==lname.substr(0,langs[j].length()).to_lower()) {
 					idx=j;
+					hint+=names[j].replace(","," ");
 				}
-				if (j>0) {
-					hint+=",";
-				}
-				hint+=names[j].replace(","," ");
 			}
 
 			ti->set_cell_mode(1,TreeItem::CELL_MODE_RANGE);


### PR DESCRIPTION
Hint was appending for every language.  Modified to only create a hint on the matching language.