### PR TITLE
Fixed line lenght guideline, and added colour option

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -482,14 +482,6 @@ void TextEdit::_notification(int p_what) {
 			Color color = cache.font_color;
 			int in_region=-1;
 
-			if (line_length_guideline) {
-				int x=xmargin_beg+cache.font->get_char_size('0').width*line_length_guideline_col-cursor.x_ofs;
-				if (x>xmargin_beg && x<xmargin_end) {
-					Color guideline_color(color.r,color.g,color.b,color.a*0.25f);
-					VisualServer::get_singleton()->canvas_item_add_line(ci,Point2(x,0),Point2(x,cache.size.height),guideline_color);
-				}
-			}
-
 			if (syntax_coloring) {
 
 				if (cache.background_color.a>0.01) {
@@ -1079,6 +1071,14 @@ void TextEdit::_notification(int p_what) {
 					}
 				}
 			}
+
+			if (line_length_guideline) {
+				int x=xmargin_beg+cache.font->get_char_size('0').width*line_length_guideline_col-cursor.x_ofs;
+				if (x>xmargin_beg && x<xmargin_end) {
+					VisualServer::get_singleton()->canvas_item_add_line(ci,Point2(x,0),Point2(x,cache.size.height),cache.line_length_guideline_color);
+				}
+			}
+
 
 			bool completion_below = false;
 			if (completion_active) {
@@ -3484,6 +3484,7 @@ void TextEdit::_update_caches() {
 	cache.selection_color=get_color("selection_color");
 	cache.mark_color=get_color("mark_color");
 	cache.current_line_color=get_color("current_line_color");
+	cache.line_length_guideline_color=get_color("line_length_guideline_color");
 	cache.breakpoint_color=get_color("breakpoint_color");
 	cache.brace_mismatch_color=get_color("brace_mismatch_color");
 	cache.word_highlighted_color=get_color("word_highlighted_color");

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -91,6 +91,7 @@ class TextEdit : public Control  {
 		Color mark_color;
 		Color breakpoint_color;
 		Color current_line_color;
+		Color line_length_guideline_color;
 		Color brace_mismatch_color;
 		Color word_highlighted_color;
 		Color search_result_color;

--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -715,6 +715,7 @@ void EditorSettings::_load_default_text_editor_theme() {
 	set("text_editor/highlighting/selection_color",Color::html("7b5dbe"));
 	set("text_editor/highlighting/brace_mismatch_color",Color(1,0.2,0.2));
 	set("text_editor/highlighting/current_line_color",Color(0.3,0.5,0.8,0.15));
+	set("text_editor/highlighting/line_length_guideline_color",Color(0.3,0.5,0.8,0.1));
 	set("text_editor/highlighting/mark_color", Color(1.0,0.4,0.4,0.4));
 	set("text_editor/highlighting/breakpoint_color", Color(0.8,0.8,0.4,0.2));
 	set("text_editor/highlighting/word_highlighted_color",Color(0.8,0.9,0.9,0.15));
@@ -972,6 +973,7 @@ bool EditorSettings::_save_text_editor_theme(String p_file) {
 	cf->set_value(theme_section, "selection_color", ((Color)get("text_editor/highlighting/selection_color")).to_html());
 	cf->set_value(theme_section, "brace_mismatch_color", ((Color)get("text_editor/highlighting/brace_mismatch_color")).to_html());
 	cf->set_value(theme_section, "current_line_color", ((Color)get("text_editor/highlighting/current_line_color")).to_html());
+	cf->set_value(theme_section, "line_length_guideline_color", ((Color)get("text_editor/highlighting/line_length_guideline_color")).to_html());
 	cf->set_value(theme_section, "mark_color", ((Color)get("text_editor/highlighting/mark_color")).to_html());
 	cf->set_value(theme_section, "breakpoint_color", ((Color)get("text_editor/highlighting/breakpoint_color")).to_html());
 	cf->set_value(theme_section, "word_highlighted_color", ((Color)get("text_editor/highlighting/word_highlighted_color")).to_html());

--- a/tools/editor/plugins/script_text_editor.cpp
+++ b/tools/editor/plugins/script_text_editor.cpp
@@ -115,6 +115,7 @@ void ScriptTextEditor::_load_theme_settings() {
 	text_edit->add_color_override("selection_color",EDITOR_DEF("text_editor/highlighting/selection_color",Color(0.2,0.2,1)));
 	text_edit->add_color_override("brace_mismatch_color",EDITOR_DEF("text_editor/highlighting/brace_mismatch_color",Color(1,0.2,0.2)));
 	text_edit->add_color_override("current_line_color",EDITOR_DEF("text_editor/highlighting/current_line_color",Color(0.3,0.5,0.8,0.15)));
+	text_edit->add_color_override("line_length_guideline_color", EDITOR_DEF("text_editor/highlighting/line_length_guideline_color", Color(0,0,0)));
 	text_edit->add_color_override("word_highlighted_color",EDITOR_DEF("text_editor/highlighting/word_highlighted_color",Color(0.8,0.9,0.9,0.15)));
 	text_edit->add_color_override("number_color",EDITOR_DEF("text_editor/highlighting/number_color",Color(0.9,0.6,0.0,2)));
 	text_edit->add_color_override("function_color",EDITOR_DEF("text_editor/highlighting/function_color",Color(0.4,0.6,0.8)));


### PR DESCRIPTION
Fixed line length guideline drawing behind everything. Now draws in front, apart from the auto completion box. Also added an option to change its colour.