### PR TITLE
A little fix in the italian traslation

### DIFF
--- a/tools/translations/it.po
+++ b/tools/translations/it.po
@@ -718,7 +718,7 @@ msgstr "Attenzione!"
 
 #: scene/gui/dialogs.cpp
 msgid "Please Confirm..."
-msgstr "Si Prega Di Confermare..."
+msgstr "Per Favore Conferma..."
 
 #: scene/gui/file_dialog.cpp tools/editor/editor_file_dialog.cpp
 msgid "File Exists, Overwrite?"


### PR DESCRIPTION
Modified the "Please Confirm ..." which was translated in Italian with "Si Prega di Confermare..." (which is also wrong because it would be translated "You Pray to Confirm...") creating problems (the word came out from the box). In its place I put a "Per Favore Conferma..." That keeps the same meaning but should not create that little problem.