### PR TITLE
Replicate load-as-placeholder state on node duplication

### DIFF
--- a/tools/editor/scene_tree_dock.cpp
+++ b/tools/editor/scene_tree_dock.cpp
@@ -768,6 +768,7 @@ Node *SceneTreeDock::_duplicate(Node *p_node, Map<Node*,Node*> &duplimap) {
 		ERR_FAIL_COND_V(!sd.is_valid(),NULL);
 		node = sd->instance(PackedScene::GEN_EDIT_STATE_INSTANCE);
 		ERR_FAIL_COND_V(!node,NULL);
+		node->set_scene_instance_load_placeholder(p_node->get_scene_instance_load_placeholder());
 		//node->generate_instance_state();
 	} else {
 		Object *obj = ClassDB::instance(p_node->get_class());


### PR DESCRIPTION
If you needs lots of sub-scenes loaded as placeholders and you basically are adding more by duplicating some of the existing ones, this one saves you from opening the sub-scene menu and checking the relevant option every time.

Cherry-picked from 936f2e3b4e9fb657f6c874020428f8159356d923