### PR TITLE
Possible fix for #7676: linux hosts w. disabled ipv6 could not connect to asset lib.

### DIFF
--- a/drivers/unix/socket_helpers.h
+++ b/drivers/unix/socket_helpers.h
@@ -18,8 +18,13 @@ static bool _ipv6_available(){
 	if ( -1 == sockfd ){
 		WARN_PRINT( strerror( errno ) ); 
 		return false; // not supported 
-	} else 
-		close( sockfd );
+	} else {
+		#if defined( WIN32 ) && !defined(__CYGWIN__)
+			closesocket( sockfd );
+		#else
+			close( sockfd );
+		#endif
+	}
 	return true;
 }
 

--- a/drivers/unix/stream_peer_tcp_posix.cpp
+++ b/drivers/unix/stream_peer_tcp_posix.cpp
@@ -162,9 +162,9 @@ Error StreamPeerTCPPosix::connect(const IP_Address& p_host, uint16_t p_port) {
 	size_t addr_size = _set_sockaddr(&their_addr, p_host, p_port, ip_type);
 
 	errno = 0;
-	if (::connect(sockfd, (struct sockaddr *)&their_addr,addr_size) == -1 && errno != EINPROGRESS) {
-
+	if (::connect(sockfd, (struct sockaddr *)&their_addr,addr_size) == -1 && errno != EINPROGRESS) { // linux sockets connect() call
 		ERR_PRINT("Connection to remote host failed!");
+		ERR_PRINT(strerror(errno)); // be a little more verbose on errors
 		disconnect();
 		return FAILED;
 	};


### PR DESCRIPTION
Linux hosts with disabled ipv6 could not connect to the asset lib due to incorrect IP::TYPE_ANY processing.

Added a simple ipv6 availability checker and updated socket domain selection logic.