### PR TITLE
Fix crash when saving root node by "Save Branch as Scene" with unsaved scene

### DIFF
--- a/tools/editor/scene_tree_dock.cpp
+++ b/tools/editor/scene_tree_dock.cpp
@@ -646,6 +646,13 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 			Node *tocopy = selection.front()->get();
 
+			if (tocopy==scene){
+				accept->get_ok()->set_text(TTR("I see.."));
+				accept->set_text(TTR("Can not perform with the root node."));
+				accept->popup_centered_minsize();
+				break;
+			}
+
 			if (tocopy!=editor_data->get_edited_scene_root() && tocopy->get_filename()!="") {
 				accept->get_ok()->set_text(TTR("I see.."));
 				accept->set_text(TTR("This operation can't be done on instanced scenes."));


### PR DESCRIPTION
Fix #7667 

"Save Branch as Scene" for root node is not allowed already.
https://github.com/godotengine/godot/blob/6ab023fab552dbba19787da4c4ccb904022644d3/tools/editor/scene_tree_dock.cpp#L1596-L1599

But this only works with saved scene.
This PR is for 2.1
I will make another PR for master if it's OK.