### PR TITLE
grammar fixes, it's -> its

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -667,7 +667,7 @@
 	</methods>
 	<constants>
 		<constant name="PI" value="3.141593">
-			Constant that represents how many times the diameter of a circumference fits around it's perimeter.
+			Constant that represents how many times the diameter of a circumference fits around its perimeter.
 		</constant>
 	</constants>
 </class>
@@ -8025,7 +8025,7 @@
 		Circular Shape for 2D Physics.
 	</brief_description>
 	<description>
-		Circular Shape for 2D Physics. This shape is useful for modeling balls or small characters and it's collision detection with everything else is very fast.
+		Circular Shape for 2D Physics. This shape is useful for modeling balls or small characters and its collision detection with everything else is very fast.
 	</description>
 	<methods>
 		<method name="get_radius" qualifiers="const">
@@ -11258,7 +11258,7 @@
 				This function is called for each file exported and depending from the return value one of many things might happen.
 				1) If returned value is null, the file is exported as is.
 				2) If the returned value is a RawAray (array of bytes), the content of that array becomes the new file being exported.
-				3) If the file must also change it's name when exported, then a [Dictionary] must be returned with two fields: 'name' with the new filename and 'data' with a [RawArray] containing the raw contents of the file. Even if the name is changed, the run-time will redirect the old file to the new file automatically when accessed.
+				3) If the file must also change its name when exported, then a [Dictionary] must be returned with two fields: 'name' with the new filename and 'data' with a [RawArray] containing the raw contents of the file. Even if the name is changed, the run-time will redirect the old file to the new file automatically when accessed.
 			</description>
 		</method>
 	</methods>
@@ -11706,7 +11706,7 @@
 </class>
 <class name="EditorPlugin" inherits="Node" category="Core">
 	<brief_description>
-		Used by the editor to extend it's functionality.
+		Used by the editor to extend its functionality.
 	</brief_description>
 	<description>
 		Plugins are used by the editor to extend functionality. The most common types of plugins are those which edit a given node or resource type, import plugins and export plugins.
@@ -12005,7 +12005,7 @@
 		</method>
 		<method name="save_external_data" qualifiers="virtual">
 			<description>
-				This method is called after the editor save the project or when the it's closed. It asks the plugin to save edited external scenes/resources.
+				This method is called after the editor saves the project or when it's closed. It asks the plugin to save edited external scenes/resources.
 			</description>
 		</method>
 		<method name="set_state" qualifiers="virtual">
@@ -15970,7 +15970,7 @@
 			Request does not have a response(yet).
 		</constant>
 		<constant name="RESULT_BODY_SIZE_LIMIT_EXCEEDED" value="7">
-			Request exceded it's maximum size limit, see [method set_body_size_limit].
+			Request exceded its maximum size limit, see [method set_body_size_limit].
 		</constant>
 		<constant name="RESULT_REQUEST_FAILED" value="8">
 			Request failed. (unused)
@@ -15982,7 +15982,7 @@
 			HTTPRequest couldn't write to the download file.
 		</constant>
 		<constant name="RESULT_REDIRECT_LIMIT_REACHED" value="11">
-			Request reached it's maximum redirect limit, see [method set_max_redirects].
+			Request reached its maximum redirect limit, see [method set_max_redirects].
 		</constant>
 	</constants>
 </class>
@@ -16088,7 +16088,7 @@
 			<argument index="0" name="id" type="int">
 			</argument>
 			<description>
-				Return the status of hostname queued for resolving, given it's queue ID. Returned status can be any of the RESOLVER_STATUS_* enumeration.
+				Return the status of hostname queued for resolving, given its queue ID. Returned status can be any of the RESOLVER_STATUS_* enumeration.
 			</description>
 		</method>
 		<method name="resolve_hostname">
@@ -22660,7 +22660,7 @@
 		Nodes can also process input events. When set, the [method _input] function will be called for each input that the program receives. In many cases, this can be overkill (unless used for simple projects), and the [method _unhandled_input] function might be preferred; it is called when the input event was not handled by anyone else (typically, GUI [Control] nodes), ensuring that the node only receives the events that were meant for it.
 		To keep track of the scene hierarchy (especially when instancing scenes into other scenes), an "owner" can be set for the node with [method set_owner]. This keeps track of who instanced what. This is mostly useful when writing editors and tools, though.
 		Finally, when a node is freed with [method free] or [method queue_free], it will also free all its children.
-		[b]Networking with nodes:[/b] After connecting to a server (or making one, see [NetworkedMultiplayerENet]) it is possible to use the built-in RPC (remote procedure call) system to easily communicate over the network. By calling [method rpc] with a method name, it will be called locally, and in all connected peers (peers = clients and the server that accepts connections), with behaviour varying depending on the network mode ([method set_network_mode]) on the receiving peer. To identify which [Node] receives the RPC call Godot will use it's [NodePath] (make sure node names are the same on all peers).
+		[b]Networking with nodes:[/b] After connecting to a server (or making one, see [NetworkedMultiplayerENet]) it is possible to use the built-in RPC (remote procedure call) system to easily communicate over the network. By calling [method rpc] with a method name, it will be called locally, and in all connected peers (peers = clients and the server that accepts connections), with behaviour varying depending on the network mode ([method set_network_mode]) on the receiving peer. To identify which [Node] receives the RPC call Godot will use its [NodePath] (make sure node names are the same on all peers).
 	</description>
 	<methods>
 		<method name="_enter_tree" qualifiers="virtual">
@@ -33832,7 +33832,7 @@
 		</signal>
 		<signal name="sleeping_state_changed">
 			<description>
-				Emitted when the body changes it's sleeping state. Either by sleeping or waking up.
+				Emitted when the body changes its sleeping state. Either by sleeping or waking up.
 			</description>
 		</signal>
 	</signals>
@@ -34227,7 +34227,7 @@
 		</signal>
 		<signal name="sleeping_state_changed">
 			<description>
-				Emitted when the body changes it's sleeping state. Either by sleeping or waking up.
+				Emitted when the body changes its sleeping state. Either by sleeping or waking up.
 			</description>
 		</signal>
 	</signals>
@@ -35889,7 +35889,7 @@
 			<return type="Error">
 			</return>
 			<description>
-				Tries to wait for the [Semaphore], if it's value is zero, blocks until non-zero.
+				Tries to wait for the [Semaphore], if its value is zero, blocks until non-zero.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Fixed these in the docs, but since some of the docs are autogenerated from this xml, we need them here too (thanks akien-mga).