### PR TITLE
Enable WebGL2 in web export, start fixing build

### DIFF
--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -33,6 +33,7 @@
 #ifdef NO_THREADS
 
 #define OBJTYPE_RLOCK
+#define OBJTYPE_WLOCK
 
 #else
 
@@ -776,11 +777,15 @@ void ClassDB::add_property(StringName p_class,const PropertyInfo& p_pinfo, const
 
 
 
+#ifndef NO_THREADS
 	lock->read_lock();
+#endif
 
 	ClassInfo *type=classes.getptr(p_class);
 
+#ifndef NO_THREADS
 	lock->read_unlock();
+#endif
 
 	ERR_FAIL_COND(!type);
 

--- a/core/safe_refcount.cpp
+++ b/core/safe_refcount.cpp
@@ -44,6 +44,14 @@ uint32_t atomic_conditional_increment( register uint32_t * pw ) {
 	return *pw;
 }
 
+uint32_t atomic_increment( register uint32_t * pw ) {
+
+	(*pw)++;
+
+	return *pw;
+
+}
+
 uint32_t atomic_decrement( register uint32_t * pw ) {
 
 	(*pw)--;

--- a/core/vector.h
+++ b/core/vector.h
@@ -81,7 +81,7 @@ class Vector {
 		size_t p;
 		if (_mul_overflow(p_elements, sizeof(T), &o)) return false;
 		*out = nearest_power_of_2(o);
-		if (_add_overflow(o, 32, &p)) return false; //no longer allocated here
+		if (_add_overflow(o, static_cast<size_t>(32), &p)) return false; //no longer allocated here
 		return true;
 #else
 		// Speed is more important than correctness here, do the operations unchecked

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1,8 +1,7 @@
 #include "rasterizer_canvas_gles3.h"
 #include "os/os.h"
 
-#ifdef IPHONE_ENABLED
-// for some reason glClearDepth seems to have been removed in iOS ES3.h
+#ifndef GLES_OVER_GL
 #define glClearDepth glClearDepthf
 #endif
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -3,8 +3,7 @@
 #include "os/os.h"
 #include "rasterizer_canvas_gles3.h"
 
-#ifdef IPHONE_ENABLED
-// for some reason glClearDepth seems to have been removed in iOS ES3.h
+#ifndef GLES_OVER_GL
 #define glClearDepth glClearDepthf
 #endif
 

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -135,7 +135,7 @@ Image RasterizerStorageGLES3::_get_gl_image_and_format(const Image& p_image, Ima
 
 		} break;
 		case Image::FORMAT_RGB565: {
-#ifdef IPHONE_ENABLED
+#ifndef GLES_OVER_GL
 			r_gl_internal_format=GL_RGB565;
 #else
 //#warning TODO: Convert tod 555 if 565 is not supported (GLES3.3-)

--- a/platform/javascript/audio_driver_javascript.h
+++ b/platform/javascript/audio_driver_javascript.h
@@ -36,8 +36,6 @@
 class AudioDriverJavaScript : public AudioDriver {
 public:
 
-	void set_singleton();
-
 	virtual const char* get_name() const;
 
 	virtual Error init();

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -14,9 +14,7 @@ def get_name():
 def can_build():
 
     import os
-    if (not os.environ.has_key("EMSCRIPTEN_ROOT")):
-        return False
-    return True
+    return os.environ.has_key("EMSCRIPTEN_ROOT")
 
 
 def get_opts():
@@ -79,9 +77,8 @@ def configure(env):
     # These flags help keep the file size down
     env.Append(CPPFLAGS=["-fno-exceptions", '-DNO_SAFE_CAST', '-fno-rtti'])
     env.Append(CPPFLAGS=['-DJAVASCRIPT_ENABLED', '-DUNIX_ENABLED', '-DPTHREAD_NO_RENAME', '-DNO_FCNTL', '-DMPC_FIXED_POINT', '-DTYPED_METHOD_BIND', '-DNO_THREADS'])
-    env.Append(CPPFLAGS=['-DGLES2_ENABLED'])
+    env.Append(CPPFLAGS=['-DGLES3_ENABLED'])
     env.Append(CPPFLAGS=['-DGLES_NO_CLIENT_ARRAYS'])
-#	env.Append(CPPFLAGS=['-DANDROID_ENABLED', '-DUNIX_ENABLED','-DMPC_FIXED_POINT'])
 
     if env['wasm'] == 'yes':
         env.Append(LINKFLAGS=['-s', 'BINARYEN=1'])
@@ -101,14 +98,10 @@ def configure(env):
         env.Append(CPPFLAGS=['-DJAVASCRIPT_EVAL_ENABLED'])
 
     env.Append(LINKFLAGS=['-O2'])
+    env.Append(LINKFLAGS=['-s', 'USE_WEBGL2=1'])
     # env.Append(LINKFLAGS=['-g4'])
 
     # print "CCCOM is:", env.subst('$CCCOM')
     # print "P: ", env['p'], " Platofrm: ", env['platform']
 
     import methods
-
-    env.Append(BUILDERS={'GLSL120': env.Builder(action=methods.build_legacygl_headers, suffix='glsl.h', src_suffix='.glsl')})
-    env.Append(BUILDERS={'GLSL': env.Builder(action=methods.build_glsl_headers, suffix='glsl.h', src_suffix='.glsl')})
-    env.Append(BUILDERS={'GLSL120GLES': env.Builder(action=methods.build_gles2_headers, suffix='glsl.h', src_suffix='.glsl')})
-    #env.Append( BUILDERS = { 'HLSL9' : env.Builder(action = methods.build_hlsl_dx9_headers, suffix = 'hlsl.h',src_suffix = '.hlsl') } )

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -181,8 +181,8 @@ void EditorExportPlatformJavaScript::_fix_html(Vector<uint8_t>& p_html, const St
 		String current_line = lines[i];
 		current_line = current_line.replace("$GODOT_TMEM",itos((1<<(max_memory+5))*1024*1024));
 		current_line = current_line.replace("$GODOT_BASE",p_name);
-		current_line = current_line.replace("$GODOT_CANVAS_WIDTH",GlobalConfig::get_singleton()->get("display/width"));
-		current_line = current_line.replace("$GODOT_CANVAS_HEIGHT",GlobalConfig::get_singleton()->get("display/height"));
+		current_line = current_line.replace("$GODOT_CANVAS_WIDTH",GlobalConfig::get_singleton()->get("display/window/width"));
+		current_line = current_line.replace("$GODOT_CANVAS_HEIGHT",GlobalConfig::get_singleton()->get("display/window/height"));
 		current_line = current_line.replace("$GODOT_HEAD_TITLE",!html_title.empty()?html_title:(String) GlobalConfig::get_singleton()->get("application/name"));
 		current_line = current_line.replace("$GODOT_HEAD_INCLUDE",html_head_include);
 		current_line = current_line.replace("$GODOT_STYLE_FONT_FAMILY",html_font_family);

--- a/platform/javascript/godot_shell.html
+++ b/platform/javascript/godot_shell.html
@@ -277,10 +277,10 @@ $GODOT_STYLE_INCLUDE
 					statusElement.appendChild(closeNote);
 					Presentation.setStatusVisible(true);
 				},
-				isWebGLAvailable: function isWebGLAvailable() {
+				isWebGL2Available: function isWebGL2Available() {
 					var context;
 					try {
-						context = canvasElement.getContext("webgl") || canvasElement.getContext("experimental-webgl");
+						context = canvasElement.getContext("webgl2") || canvasElement.getContext("experimental-webgl2");
 					} catch (e) {}
 					return !!context;
 				},
@@ -319,12 +319,12 @@ $GODOT_STYLE_INCLUDE
 						outputElement.firstChild.remove();
 					}
 					var msg = document.createElement("div");
-					if (text.trim().startsWith("**ERROR**")
-						|| text.startsWith("**EXCEPTION**")) {
+					if (String.prototype.trim.call(text).startsWith("**ERROR**")
+						|| String.prototype.trim.call(text).startsWith("**EXCEPTION**")) {
 						msg.style.color = "#d44";
-					} else if (text.trim().startsWith("**WARNING**")) {
+					} else if (String.prototype.trim.call(text).startsWith("**WARNING**")) {
 						msg.style.color = "#ccc000";
-					} else if (text.trim().startsWith("**SCRIPT ERROR**")) {
+					} else if (String.prototype.trim.call(text).startsWith("**SCRIPT ERROR**")) {
 						msg.style.color = "#c6d";
 					}
 					msg.textContent = text;
@@ -395,8 +395,8 @@ $GODOT_STYLE_INCLUDE
 			}
 		};
 
-		if (!Presentation.isWebGLAvailable()) {
-			Presentation.setStatus("WebGL appears to be unsupported in the current browser.\nPlease try updating or use a different browser.");
+		if (!Presentation.isWebGL2Available()) {
+			Presentation.setStatus("WebGL2 appears to be unsupported in the current browser.\nPlease try updating or use a different browser.");
 			Presentation.preventLoading = true;
 		} else {
 			Presentation.setStatus("Downloading...");

--- a/platform/javascript/javascript_eval.cpp
+++ b/platform/javascript/javascript_eval.cpp
@@ -156,7 +156,7 @@ Variant JavaScript::eval(const String& p_code, bool p_use_global_exec_context) {
 
 void JavaScript::_bind_methods() {
 
-	ObjectTypeDB::bind_method(_MD("eval", "code", "use_global_execution_context"), &JavaScript::eval, false);
+	ClassDB::bind_method(_MD("eval", "code", "use_global_execution_context"), &JavaScript::eval, false);
 }
 
 JavaScript::JavaScript() {

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -33,8 +33,6 @@
 #include "drivers/unix/os_unix.h"
 #include "os/main_loop.h"
 #include "servers/physics/physics_server_sw.h"
-#include "servers/spatial_sound/spatial_sound_server_sw.h"
-#include "servers/spatial_sound_2d/spatial_sound_2d_server_sw.h"
 #include "servers/audio_server.h"
 #include "servers/physics_2d/physics_2d_server_sw.h"
 #include "servers/visual/rasterizer.h"
@@ -70,7 +68,6 @@ private:
 	int64_t time_to_save_sync;
 	int64_t last_sync_time;
 
-	Rasterizer *rasterizer;
 	VisualServer *visual_server;
 	PhysicsServer *physics_server;
 	Physics2DServer *physics_2d_server;
@@ -164,8 +161,6 @@ public:
 	virtual bool has_touchscreen_ui_hint() const;
 
 	void set_opengl_extensions(const char* p_gl_extensions);
-
-	void reload_gfx();
 
 	virtual Error shell_open(String p_uri);
 	virtual String get_data_dir() const;


### PR DESCRIPTION
Will not yet compile, unless removing:
 - `#include "audio_server_javascript.h"` from `os_javascript.h`
 - `"audio_server_javascript.cpp",` from `SCsub`
 - `env.Append(CPPFLAGS=['-DGLES_NO_CLIENT_ARRAYS'])` from `detect.py`

Will not actually run either way.

To do:
 - update WebAudio server
 - update `GLES_NO_CLIENT_ARRAYS` code
 - adjust for [WebGL2 differences](https://www.khronos.org/registry/webgl/specs/latest/2.0/#5)