### PR TITLE
Selected text is now deselected on ctrl+home/end

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2431,6 +2431,8 @@ void TextEdit::_gui_input(const InputEvent& p_gui_input) {
 
 					if (k.mod.shift)
 						_post_shift_selection();
+					else if(k.mod.command || k.mod.control)
+						deselect();
 
 				} break;
 #else
@@ -2440,25 +2442,30 @@ void TextEdit::_gui_input(const InputEvent& p_gui_input) {
 					if (k.mod.shift)
 						_pre_shift_selection();
 
-					// compute whitespace symbols seq length
-					int current_line_whitespace_len = 0;
-					while(current_line_whitespace_len < text[cursor.line].length()) {
-						CharType c = text[cursor.line][current_line_whitespace_len];
-						if(c != '\t' && c != ' ')
-							break;
-						current_line_whitespace_len++;
-					}
-
-					if(cursor_get_column() == current_line_whitespace_len)
-						cursor_set_column(0);
-					else
-						cursor_set_column(current_line_whitespace_len);
-
-					if (k.mod.command)
+					if (k.mod.command) {
 						cursor_set_line(0);
+						cursor_set_column(0);
+					}
+					else {
+						// compute whitespace symbols seq length
+						int current_line_whitespace_len = 0;
+						while( current_line_whitespace_len < text[cursor.line].length() ) {
+						  CharType c = text[cursor.line][current_line_whitespace_len];
+						  if( c != '\t' && c != ' ' )
+						    break;
+						  current_line_whitespace_len++;
+						}
+
+						if( cursor_get_column() == current_line_whitespace_len )
+						  cursor_set_column(0);
+						else
+						  cursor_set_column(current_line_whitespace_len);
+					}
 
 					if (k.mod.shift)
 						_post_shift_selection();
+					else if(k.mod.command || k.mod.control)
+						deselect();
 					_cancel_completion();
 					completion_hint="";
 
@@ -2481,6 +2488,8 @@ void TextEdit::_gui_input(const InputEvent& p_gui_input) {
 
 					if (k.mod.shift)
 						_post_shift_selection();
+					else if(k.mod.command || k.mod.control)
+						deselect();
 
 				} break;
 #else
@@ -2495,6 +2504,8 @@ void TextEdit::_gui_input(const InputEvent& p_gui_input) {
 
 					if (k.mod.shift)
 						_post_shift_selection();
+					else if(k.mod.command || k.mod.control)
+						deselect();
 
 					_cancel_completion();
 					completion_hint="";


### PR DESCRIPTION
This fixes Issue #7694 and also the error mentioned in the comments of that issue. When text is selected and we hit Ctrl+Home/End the text will be deselected. When we hit Ctrl+Shift+Home all text from the current column to the first column at the top of the editor will be selected.