### PR TITLE
Fix parsing bug which causes range(variable) to crash the engine

### DIFF
--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -2577,7 +2577,7 @@ void GDParser::_parse_block(BlockNode *p_block,bool p_static) {
 						Vector<Node*> args;
 						Vector<double> constants;
 
-						bool constant=true;
+						bool constant=false;
 
 						for(int i=1;i<op->arguments.size();i++) {
 							args.push_back(op->arguments[i]);
@@ -2585,13 +2585,12 @@ void GDParser::_parse_block(BlockNode *p_block,bool p_static) {
 								ConstantNode *c = static_cast<ConstantNode*>(op->arguments[i]);
 								if (c->value.get_type()==Variant::REAL || c->value.get_type()==Variant::INT) {
 									constants.push_back(c->value);
-								} else {
-									constant=false;
+									constant=true;
 								}
 							}
 						}
 
-						if (args.size()>0 || args.size()<4) {
+						if (args.size()>0 && args.size()<4) {
 
 							if (constant) {
 


### PR DESCRIPTION
problem was a segmentation fault caused by trying to access Vector constants[0] which isn't there if op->arguments.size() is not bigger than one.

- the changed OR condition didn't make sense (always true), should be AND
- changes the "constant" variable to be false per default and gets set to true when there is actually something pushed to "constants"

Fixes #7662