### PR TITLE
Add editor option for closing the output when stopping the game.

### DIFF
--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -2599,6 +2599,14 @@ void EditorNode::_menu_option_confirm(int p_option,bool p_confirmed) {
 			play_custom_scene_button->set_pressed(false);
 			play_custom_scene_button->set_icon(gui_base->get_icon("PlayCustom","EditorIcons"));
 			//pause_button->set_pressed(false);
+			if (bool(EDITOR_DEF("run/output/always_close_output_on_stop", true))) {
+				for(int i=0;i<bottom_panel_items.size();i++) {
+					if (bottom_panel_items[i].control==log) {
+						_bottom_panel_switch(false,i);
+						break;
+					}
+				}
+			}
 			emit_signal("stop_pressed");
 
 		} break;

--- a/tools/editor/editor_settings.cpp
+++ b/tools/editor/editor_settings.cpp
@@ -655,6 +655,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("run/auto_save/save_before_running",true);
 	set("run/output/always_clear_output_on_play",true);
 	set("run/output/always_open_output_on_play",true);
+	set("run/output/always_close_output_on_stop",false);
 	set("filesystem/resources/save_compressed_resources",true);
 	set("filesystem/resources/auto_reload_modified_images",true);
 


### PR DESCRIPTION
I had to reopen  #7733  because somehow I closed that one
By default the option is disabled.
Fixes: #7726 
