### PR TITLE
JSON::parse reports errors on open-ended objects (master)

### DIFF
--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -374,7 +374,7 @@ Error JSON::_parse_array(Array &array,const CharType *p_str,int &index, int p_le
 
 	}
 
-	return OK;
+	return ERR_PARSE_ERROR;
 
 }
 
@@ -446,7 +446,7 @@ Error JSON::_parse_object(Dictionary &object,const CharType *p_str,int &index, i
 		}
 	}
 
-	return OK;
+	return ERR_PARSE_ERROR;
 }
 
 


### PR DESCRIPTION
fixes #7741 