### PR TITLE
HTTPClient properly handle partial data in non-blocking mode

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -566,11 +566,13 @@ ByteArray HTTPClient::read_response_body_chunk() {
 		int to_read = MIN(body_left,read_chunk_size);
 		ByteArray ret;
 		ret.resize(to_read);
-		ByteArray::Write w = ret.write();
 		int _offset = 0;
 		while (to_read > 0) {
 			int rec=0;
-			err = _get_http_data(w.ptr()+_offset,to_read,rec);
+			{
+				ByteArray::Write w = ret.write();
+				err = _get_http_data(w.ptr()+_offset,to_read,rec);
+			}
 			if (rec>0) {
 				body_left-=rec;
 				to_read-=rec;


### PR DESCRIPTION
Use block to send DVector::Write out of scope in
HTTPClient::read_response_body_chunk()

(cherry picked from commit 833994b2949cbdd191dfdb095bb96913a7b3b03a)

Backport #7749 to `2.1` branch. Closes #7697