### PR TITLE
Fix zero padding formatting

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -3945,12 +3945,8 @@ String String::sprintf(const Array& values, bool* error) const {
 						case 'X': base = 16; capitalize = true; break;
 					}
 					// Get basic number.
-					String str = String::num_int64(value, base, capitalize);
-
-					// Sign.
-					if (show_sign && value >= 0) {
-						str = str.insert(0, "+");
-					}
+					String str = String::num_int64(ABS(value), base, capitalize);
+					int number_len = str.length();
 
 					// Padding.
 					String pad_char = pad_with_zeroes ? String("0") : String(" ");
@@ -3958,6 +3954,13 @@ String String::sprintf(const Array& values, bool* error) const {
 						str = str.rpad(min_chars, pad_char);
 					} else {
 						str = str.lpad(min_chars, pad_char);
+					}
+
+					// Sign.
+					if (show_sign && value >= 0) {
+						str = str.insert(pad_with_zeroes?0:str.length()-number_len, "+");
+					} else if (value < 0) {
+						str = str.insert(pad_with_zeroes?0:str.length()-number_len, "-");
 					}
 
 					formatted += str;


### PR DESCRIPTION
Fix #7602

Test code
```gdscript
func _ready():
	print("%+d" % 1)
	print("%+d" % -22)
	print("%d" % -333)
	print("%+05d" % 1)
	print("%+05d" % -22)
	print("%05d" % -333)
	print("%+5d" % 1)
	print("%+5d" % -22)
	print("%5d" % -333)
```

Result
```
+1
-22
-333
+00001
-00022
-00333
    +1
   -22
  -333
```

This is for 2.1 branch, master should cherrypick this.