### PR TITLE
Added "Scots" locale name, fixing #7630

### DIFF
--- a/core/translation.cpp
+++ b/core/translation.cpp
@@ -670,6 +670,7 @@ static const char* locale_names[]={
 "Sanskrit (India)",
 "Santali (India)",
 "Sardinian (Italy)",
+"Scots (Scotland)",
 "Sindhi (India)",
 "Northern Sami (Norway)",
 "Samogitian (Lithuania)",


### PR DESCRIPTION
Scots lang code was added, but the name was not, creating a different size in both arrays and causing the crash reported in #7630.
No other fix is needed.