### PR TITLE
Fixed compilation issues with Visual Studio

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2395,6 +2395,11 @@ bool OS_Windows::is_vsync_enabled() const{
 	return true;
 }
 
+bool OS_Windows::check_feature_support(const String& p_feature) {
+
+	return VisualServer::get_singleton()->has_os_feature(p_feature);
+
+}
 
 OS_Windows::OS_Windows(HINSTANCE _hInstance) {
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -286,6 +286,8 @@ public:
 	virtual void set_use_vsync(bool p_enable);
 	virtual bool is_vsync_enabled() const;
 
+	virtual bool check_feature_support(const String& p_feature);
+
 	OS_Windows(HINSTANCE _hInstance);
 	~OS_Windows();
 

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -2967,7 +2967,7 @@ void VisualServerScene::_bake_gi_downscale_light(int p_idx, int p_level, const G
 
 	}
 
-	divisor=Math::lerp(8.0,divisor,p_propagate);
+	divisor=Math::lerp((float)8.0,divisor,p_propagate);
 	sum[0]/=divisor;
 	sum[1]/=divisor;
 	sum[2]/=divisor;


### PR DESCRIPTION
This commit adds the missing `OS_Windows::check_feature_support` function and adds a float cast to a Math::lerp call that was causing VS to complain it could not pick the correct function to override.