### PR TITLE
Close out audio drivers when exiting on Windows.

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1289,6 +1289,11 @@ void OS_Windows::finalize() {
 
 	monitor_info.clear();
 
+	for (int i = 0; i < get_audio_driver_count(); i++)
+	{
+		AudioDriverManager::get_driver(i)->finish();
+	}
+
 }
 void OS_Windows::finalize_core() {
 


### PR DESCRIPTION
Prevents a crash when closing the project manager.