### PR TITLE
Remove memdelete of button in GIProbeEditor exit

### DIFF
--- a/tools/editor/plugins/gi_probe_editor_plugin.cpp
+++ b/tools/editor/plugins/gi_probe_editor_plugin.cpp
@@ -80,6 +80,4 @@ GIProbeEditorPlugin::GIProbeEditorPlugin(EditorNode *p_node) {
 
 
 GIProbeEditorPlugin::~GIProbeEditorPlugin() {
-
-	memdelete(bake);
 }


### PR DESCRIPTION
This was causing a heap corruption when exiting on windows.