### PR TITLE
Frustum camera mode for stereoscopic projection

### DIFF
--- a/core/math/camera_matrix.cpp
+++ b/core/math/camera_matrix.cpp
@@ -91,6 +91,46 @@ void CameraMatrix::set_perspective(float p_fovy_degrees, float p_aspect, float p
 	matrix[3][3] = 0;
 }
 
+void CameraMatrix::set_perspective(float p_fovy_degrees, float p_aspect, float p_z_near, float p_z_far, bool p_flip_fov, int p_eye, float p_intraocular_dist, float p_convergence_dist) {
+
+	if (p_flip_fov) {
+		p_fovy_degrees = get_fovy(p_fovy_degrees, 1.0 / p_aspect);
+	}
+
+  float left, right, modeltranslation, ymax, xmax, frustumshift;
+
+  ymax = p_z_near * tan(p_fovy_degrees * Math_PI / 360.0f);
+  xmax = ymax * p_aspect;
+  frustumshift = (p_intraocular_dist / 2.0) * p_z_near / p_convergence_dist;
+
+  switch (p_eye) {
+    case 1: { // left eye
+      left = -xmax + frustumshift;
+      right = xmax + frustumshift;
+      modeltranslation = p_intraocular_dist / 2.0;
+    }; break;
+    case 2: { // right eye
+      left = -xmax - frustumshift;
+      right = xmax - frustumshift;
+      modeltranslation = -p_intraocular_dist / 2.0;
+    }; break;
+    default: { // mono, should give the same result as set_perspective(p_fovy_degrees,p_aspect,p_z_near,p_z_far,p_flip_fov)
+      left = -xmax;
+      right = xmax;
+      modeltranslation = 0.0;
+    }; break;
+  };
+  
+  set_frustum(left, right, -ymax, ymax, p_z_near, p_z_far);
+
+  // translate matrix by (modeltranslation, 0.0, 0.0)
+  CameraMatrix cm;
+  cm.set_identity();
+  cm.matrix[3][0] = modeltranslation;
+  *this = *this * cm;
+  
+}
+
 void CameraMatrix::set_orthogonal(float p_left, float p_right, float p_bottom, float p_top, float p_znear, float p_zfar) {
 
 	set_identity();
@@ -116,6 +156,7 @@ void CameraMatrix::set_orthogonal(float p_size, float p_aspect, float p_znear, f
 void CameraMatrix::set_frustum(float p_left, float p_right, float p_bottom, float p_top, float p_near, float p_far) {
 #if 0
 	///@TODO, give a check to this. I'm not sure if it's working.
+	// I think columns and rows are swapped...
 	set_identity();
 
 	matrix[0][0]=(2*p_near) / (p_right-p_left);
@@ -126,6 +167,7 @@ void CameraMatrix::set_frustum(float p_left, float p_right, float p_bottom, floa
 	matrix[2][3]=-(2*p_far*p_near) / (p_far-p_near);
 	matrix[3][2]=-1;
 	matrix[3][3]=0;
+
 #else
 	float *te = &matrix[0][0];
 	float x = 2 * p_near / (p_right - p_left);
@@ -243,23 +285,47 @@ bool CameraMatrix::get_endpoints(const Transform &p_transform, Vector3 *p_8point
 			-matrix[15] + matrix[13]);
 	top_plane.normalize();
 
-	Vector3 near_endpoint;
-	Vector3 far_endpoint;
+	Vector3 near_endpoint_left, near_endpoint_right;
+	Vector3 far_endpoint_left, far_endpoint_right;
 
-	bool res = near_plane.intersect_3(right_plane, top_plane, &near_endpoint);
-	ERR_FAIL_COND_V(!res, false);
+	bool res=near_plane.intersect_3(right_plane,top_plane,&near_endpoint_right);
+	ERR_FAIL_COND_V(!res,false);
 
-	res = far_plane.intersect_3(right_plane, top_plane, &far_endpoint);
-	ERR_FAIL_COND_V(!res, false);
+	res=far_plane.intersect_3(right_plane,top_plane,&far_endpoint_right);
+	ERR_FAIL_COND_V(!res,false);
 
-	p_8points[0] = p_transform.xform(Vector3(near_endpoint.x, near_endpoint.y, near_endpoint.z));
-	p_8points[1] = p_transform.xform(Vector3(near_endpoint.x, -near_endpoint.y, near_endpoint.z));
-	p_8points[2] = p_transform.xform(Vector3(-near_endpoint.x, near_endpoint.y, near_endpoint.z));
-	p_8points[3] = p_transform.xform(Vector3(-near_endpoint.x, -near_endpoint.y, near_endpoint.z));
-	p_8points[4] = p_transform.xform(Vector3(far_endpoint.x, far_endpoint.y, far_endpoint.z));
-	p_8points[5] = p_transform.xform(Vector3(far_endpoint.x, -far_endpoint.y, far_endpoint.z));
-	p_8points[6] = p_transform.xform(Vector3(-far_endpoint.x, far_endpoint.y, far_endpoint.z));
-	p_8points[7] = p_transform.xform(Vector3(-far_endpoint.x, -far_endpoint.y, far_endpoint.z));
+	if ((matrix[8] == 0) && (matrix[9] == 0)) {
+		near_endpoint_left = near_endpoint_right;
+		near_endpoint_left.x = -near_endpoint_left.x;
+
+		far_endpoint_left = far_endpoint_right;
+		far_endpoint_left.x = -far_endpoint_left.x;
+	} else {
+		///@TODO, make sure this is correct, haven't fully tested it yet
+
+		///////--- Left Plane ---///////
+		Plane left_plane=Plane(matrix[ 0] + matrix[ 3],
+			      matrix[ 4] + matrix[ 7],
+			      matrix[ 8] + matrix[11],
+			      - matrix[15] - matrix[12]);
+		left_plane.normalize();
+
+		res=near_plane.intersect_3(left_plane,top_plane,&near_endpoint_left);
+		ERR_FAIL_COND_V(!res,false);
+
+		res=far_plane.intersect_3(left_plane,top_plane,&far_endpoint_left);
+		ERR_FAIL_COND_V(!res,false);
+
+	}
+
+	p_8points[0] = p_transform.xform(Vector3(near_endpoint_right.x, near_endpoint_right.y, near_endpoint_right.z));
+	p_8points[1] = p_transform.xform(Vector3(near_endpoint_right.x, -near_endpoint_right.y, near_endpoint_right.z));
+	p_8points[2] = p_transform.xform(Vector3(near_endpoint_left.x, near_endpoint_left.y, near_endpoint_left.z));
+	p_8points[3] = p_transform.xform(Vector3(near_endpoint_left.x, -near_endpoint_left.y, near_endpoint_left.z));
+	p_8points[4] = p_transform.xform(Vector3(far_endpoint_right.x, far_endpoint_right.y, far_endpoint_right.z));
+	p_8points[5] = p_transform.xform(Vector3(far_endpoint_right.x, -far_endpoint_right.y, far_endpoint_right.z));
+	p_8points[6] = p_transform.xform(Vector3(far_endpoint_left.x, far_endpoint_left.y, far_endpoint_left.z));
+	p_8points[7] = p_transform.xform(Vector3(far_endpoint_left.x, -far_endpoint_left.y, far_endpoint_left.z));
 
 	return true;
 }
@@ -270,6 +336,9 @@ Vector<Plane> CameraMatrix::get_projection_planes(const Transform &p_transform) 
 	 * References:
 	 * http://www.markmorley.com/opengl/frustumculling.html
 	 * http://www2.ravensoft.com/users/ggribb/plane%20extraction.pdf
+	 *
+	 * !BAS! The above to links seem broken, heres another that explains this:
+	 * http://gamedevs.org/uploads/fast-extraction-viewing-frustum-planes-from-world-view-projection-matrix.pdf
 	 */
 
 	Vector<Plane> planes;
@@ -517,7 +586,18 @@ float CameraMatrix::get_fov() const {
 			-matrix[15] + matrix[12]);
 	right_plane.normalize();
 
-	return Math::rad2deg(Math::acos(Math::abs(right_plane.normal.x))) * 2.0;
+	if ((matrix[8] == 0) && (matrix[9] == 0)) {
+		return Math::rad2deg(Math::acos(Math::abs(right_plane.normal.x))) * 2.0;
+	} else {
+		// our frustum is asymetrical need to calculate the left planes angle seperately.. 
+		Plane left_plane=Plane(matrix[ 3] + matrix[ 0],
+		      matrix[ 7] + matrix[ 4],
+		      matrix[11] + matrix[ 8],
+		      matrix[15] + matrix[12]);
+		left_plane.normalize();
+
+		return Math::rad2deg(Math::acos(Math::abs(left_plane.normal.x))) + Math::rad2deg(Math::acos(Math::abs(right_plane.normal.x)));
+	}
 }
 
 void CameraMatrix::make_scale(const Vector3 &p_scale) {

--- a/core/math/camera_matrix.h
+++ b/core/math/camera_matrix.h
@@ -52,6 +52,7 @@ struct CameraMatrix {
 	void set_zero();
 	void set_light_bias();
 	void set_perspective(float p_fovy_degrees, float p_aspect, float p_z_near, float p_z_far, bool p_flip_fov = false);
+	void set_perspective(float p_fovy_degrees, float p_aspect, float p_z_near, float p_z_far, bool p_flip_fov, int p_eye, float p_intraocular_dist, float p_convergence_dist);
 	void set_orthogonal(float p_left, float p_right, float p_bottom, float p_top, float p_znear, float p_zfar);
 	void set_orthogonal(float p_size, float p_aspect, float p_znear, float p_zfar, bool p_flip_fov = false);
 	void set_frustum(float p_left, float p_right, float p_bottom, float p_top, float p_near, float p_far);

--- a/core/math/frustum.cpp
+++ b/core/math/frustum.cpp
@@ -1,0 +1,105 @@
+/*************************************************************************/
+/*  frustum.cpp                                                          */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2016 Juan Linietsky, Ariel Manzur.                 */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#include "frustum.h"
+#include "math_funcs.h"
+
+void Frustum::set_frustum(float p_left, float p_right ,float p_top, float p_bottom) {
+	left = p_left;
+	right = p_right;
+	top = p_top;
+	bottom = p_bottom;
+};
+
+void Frustum::set_frustum(float p_fov_degrees) {
+	right = tan(p_fov_degrees * Math_PI / 360.0);
+	left = -right;
+	top = right;
+	bottom = left;
+};
+
+void Frustum::set_frustum(float p_fov_degrees, int p_eye, float p_intraocular_dist, float p_convergency_dist) {
+	right = tan(p_fov_degrees * Math_PI / 360.0);
+	left = -right;
+	top = right;
+	bottom = left;
+
+	float shift = p_intraocular_dist / (2.0 * p_convergency_dist);
+	if (p_eye == Frustum::EYE_LEFT) {
+		left += shift;
+		right += shift;
+	} else {
+		left -= shift;
+		right -= shift;
+	};
+};
+
+CameraMatrix Frustum::make_camera_matrix(float p_aspect, bool p_vaspect, float p_znear, float p_zfar) const {
+		// Slightly modified version of ComposeProjection found in: https://github.com/ValveSoftware/openvr/wiki/IVRSystem::GetProjectionRaw
+		// We are expecting a left/right/top/bottom frustum not adjusted to the near place but unified.
+
+		CameraMatrix M;
+		float *m = &M.matrix[0][0];
+		float l = left;
+		float r = right;
+		float t = top;
+		float b = bottom;
+
+		// apply aspect ratio of our viewport
+		if (p_vaspect) {
+			t /= p_aspect;
+			b /= p_aspect;
+		} else {
+			l *= p_aspect;
+			r *= p_aspect;
+		}
+
+		float idx = 1.0f / (r - l);
+		float idy = 1.0f / (t - b);
+		float idz = 1.0f / (p_zfar - p_znear);
+		float sx = r + l;
+		float sy = b + t;
+
+		m[0] = 2.0f*idx;  m[4] = 0.0f;      m[8]  = sx*idx;       m[12] = 0.0f;
+		m[1] = 0.0f;      m[5] = 2.0f*idy;  m[9]  = sy*idy;       m[13] = 0.0f;
+		m[2] = 0.0f;      m[6] = 0.0f;      m[10] = -p_zfar*idz;  m[14] = -p_zfar*p_znear*idz;
+		m[3] = 0.0f;      m[7] = 0.0f;      m[11] = -1.0f;        m[15] = 0.0f;
+
+		return M;
+};
+
+Frustum::Frustum() {
+	set_frustum(-0.5f, 0.5f, 0.5f, -0.5f);
+};
+
+Frustum::Frustum(float p_left, float p_right ,float p_top, float p_bottom) {
+	set_frustum(p_left, p_right, p_top, p_bottom);
+};
+
+Frustum::~Frustum() {
+};

--- a/core/math/frustum.h
+++ b/core/math/frustum.h
@@ -1,0 +1,56 @@
+/*************************************************************************/
+/*  frustum.h                                                            */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2016 Juan Linietsky, Ariel Manzur.                 */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#ifndef FRUSTUM_H
+#define FRUSTUM_H
+
+#include "camera_matrix.h"
+/**
+	@author Bastiaan Olij <mux213@gmail.com>
+*/
+
+struct Frustum {
+	enum Eyes {
+		EYE_LEFT,
+		EYE_RIGHT
+	};
+
+	float left, right, top, bottom;
+
+	void set_frustum(float p_left, float p_right ,float p_top, float p_bottom);
+	void set_frustum(float p_fov_degrees);
+	void set_frustum(float p_fov_degrees, int p_eye, float p_intraocular_dist, float p_convergency_dist);
+
+	CameraMatrix make_camera_matrix(float p_aspect, bool p_vaspect, float p_znear, float p_zfar) const;
+
+	Frustum();
+	Frustum(float p_left, float p_right ,float p_top, float p_bottom);
+	~Frustum();
+};
+
+#endif

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -6732,6 +6732,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_bottom" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+				In frustum mode, returns the bottom size of the frustum.
+			</description>
+		</method>
 		<method name="get_camera_transform" qualifiers="const">
 			<return type="Transform">
 			</return>
@@ -6749,36 +6756,63 @@
 			<return type="float">
 			</return>
 			<description>
+				In perspective mode, returns the Field Of View value set for the camera.
 			</description>
 		</method>
 		<method name="get_h_offset" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
+				Gets the horizontal offset added to the camera position
 			</description>
 		</method>
 		<method name="get_keep_aspect_mode" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
+				Gets the aspect ratio mode
+			</description>
+		</method>
+		<method name="get_left" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+				In frustum mode, returns the left size of the frustum.
 			</description>
 		</method>
 		<method name="get_projection" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
+				Gets the projection mode
+			</description>
+		</method>
+		<method name="get_right" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+				In frustum mode, returns the right size of the frustum.
 			</description>
 		</method>
 		<method name="get_size" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
+				In orthographic mode, returns the size
+			</description>
+		</method>
+		<method name="get_top" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+				In frustum mode, returns the top size of the frustum.
 			</description>
 		</method>
 		<method name="get_v_offset" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
+				Gets the vertical offset added to the camera position
 			</description>
 		</method>
 		<method name="get_visible_layers" qualifiers="const">
@@ -6791,12 +6825,14 @@
 			<return type="float">
 			</return>
 			<description>
+				Get the far distance for the camera, anything further away will not render
 			</description>
 		</method>
 		<method name="get_znear" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
+				Get the near distance for the camera, anything before this will not render
 			</description>
 		</method>
 		<method name="is_current" qualifiers="const">
@@ -6859,16 +6895,37 @@
 			<description>
 			</description>
 		</method>
+		<method name="set_frustum">
+			<argument index="0" name="left" type="float">
+			</argument>
+			<argument index="1" name="right" type="float">
+			</argument>
+			<argument index="2" name="top" type="float">
+			</argument>
+			<argument index="3" name="bottom" type="float">
+			</argument>
+			<argument index="4" name="z_near" type="float">
+			</argument>
+			<argument index="5" name="z_far" type="float">
+			</argument>
+			<description>
+				Set the projection mode to frustum mode, by specifying a [i]left[/i], [i]right[/i], [i]top[/i] and [i]bottom[/i] value in unit distance along with the [i]near[/i] and [i]far[/i] clip planes in worldspace units.
+				The [i]left[/i], [i]right[/i], [i]top[/i] and [i]bottom[/i] values will be adjusted by Godot based on the aspect ratio of the viewport.
+				This mode allows for assymmetric projections, required for stereoscopic rendering.
+			</description>
+		</method>
 		<method name="set_h_offset">
 			<argument index="0" name="ofs" type="float">
 			</argument>
 			<description>
+				Sets the horizontal offset added to the camera position
 			</description>
 		</method>
 		<method name="set_keep_aspect_mode">
 			<argument index="0" name="mode" type="int">
 			</argument>
 			<description>
+				Sets the aspect ratio mode
 			</description>
 		</method>
 		<method name="set_orthogonal">
@@ -6893,10 +6950,29 @@
 				Set the camera projection to perspective mode, by specifying a [i]FOV[/i] Y angle in degrees (FOV means Field of View), and the [i]near[/i] and [i]far[/i] clip planes in worldspace units.
 			</description>
 		</method>
+		<method name="set_perspective_for_eye">
+			<argument index="0" name="fov" type="float">
+			</argument>
+			<argument index="1" name="z_near" type="float">
+			</argument>
+			<argument index="2" name="z_far" type="float">
+			</argument>
+			<argument index="3" name="eye" type="int">
+			</argument>
+			<argument index="4" name="intraocular_dist" type="float">
+			</argument>
+			<argument index="5" name="convergence_dist" type="float">
+			</argument>
+			<description>
+				Set the camera projection to frustum mode, by specifying a [i]FOV[/i] Y angle in degrees (FOV means Field of View), and the [i]near[/i] and [i]far[/i] clip planes in worldspace units and by specifying the [i]eye[/i], [i]intracular_dist[/i] and [i]convergence_dist[/i] values.
+				The intra oculur distance is the distance between the two eyes and the convergence distance determines how far the focus plane lies. This function should be used for stereoscopic rendering to a 3D monitor or similar device. With the convergence distance think of the distance before which things will "pop" out of the screen and after which things seem to be inside of the screen.
+			</description>
+		</method>
 		<method name="set_v_offset">
 			<argument index="0" name="ofs" type="float">
 			</argument>
 			<description>
+				Sets the vertical offset added to the camera position
 			</description>
 		</method>
 		<method name="set_visible_layers">
@@ -6922,9 +6998,20 @@
 		<constant name="PROJECTION_ORTHOGONAL" value="1">
 			Orthogonal Projection (objects remain the same size on the screen no matter how far away they are).
 		</constant>
+		<constant name="PROJECTION_FRUSTUM" value="2">
+			Frustum projection, similar to perspective projection but with more control.
+		</constant>
+		<constant name="EYE_LEFT" value="0">
+			Left eye
+		</constant>
+		<constant name="EYE_RIGHT" value="1">
+			Right eye
+		</constant>
 		<constant name="KEEP_WIDTH" value="0">
+			As the user resizes the render area, keep the width of 3D objects constant by adjusting the height
 		</constant>
 		<constant name="KEEP_HEIGHT" value="1">
+			As the user resizes the render area, keep the height of 3D objects constant by adjusting the width
 		</constant>
 	</constants>
 </class>

--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -1034,6 +1034,53 @@ void CameraSpatialGizmo::redraw() {
 			ADD_TRIANGLE(tup, right + up + back, -right + up + back);
 
 		} break;
+		case Camera::PROJECTION_FRUSTUM: {
+
+			float hoff = camera->get_h_offset();
+ 			float voff = camera->get_v_offset();
+ 			float left = camera->get_left();
+ 			float right = camera->get_right();
+ 			float top = camera->get_top();
+ 			float bottom = camera->get_bottom();
+ 			float near = camera->get_znear();
+ 			float far = camera->get_zfar();
+
+ 			// use our default screensize to show impact of aspect ratio on our frustum
+ 			float screen_width = Globals::get_singleton()->get("display/width");
+ 			float screen_height = Globals::get_singleton()->get("display/height");
+ 			float aspect = screen_width / screen_height;
+
+ 			if (camera->get_keep_aspect_mode() == Camera::KEEP_WIDTH) {
+ 				top /= aspect;
+ 				bottom /= aspect;
+ 			} else {
+ 				left *= aspect;
+ 				right *= aspect;
+ 			}
+ 
+ 			Vector3 left_top_near = Vector3(left * near + hoff, top * near + voff, -near);
+ 			Vector3 right_top_near = Vector3(right * near + hoff, top * near + voff, -near);
+ 			Vector3 right_bottom_near = Vector3(right * near + hoff, bottom * near + voff, -near);
+ 			Vector3 left_bottom_near = Vector3(left * near + hoff, bottom * near + voff, -near);
+ 
+ 			Vector3 left_top_far = Vector3(left * far + hoff, top * far + voff, -far);
+ 			Vector3 right_top_far = Vector3(right * far + hoff, top * far + voff, -far);
+ 			Vector3 right_bottom_far = Vector3(right * far + hoff, bottom * far + voff, -far);
+ 			Vector3 left_bottom_far = Vector3(left * far + hoff, bottom * far + voff, -far);
+ 
+ 			ADD_QUAD( left_top_near, right_top_near, right_bottom_near, left_bottom_near);
+ 			ADD_QUAD( left_top_far, right_top_far, right_bottom_far, left_bottom_far);
+ 
+ 			lines.push_back(left_top_near);
+ 			lines.push_back(left_top_far);
+ 			lines.push_back(right_top_near);
+ 			lines.push_back(right_top_far);
+ 			lines.push_back(right_bottom_near);
+ 			lines.push_back(right_bottom_far);
+ 			lines.push_back(left_bottom_near);
+ 			lines.push_back(left_bottom_far);
+ 
+ 		} break;
 	}
 
 	add_lines(lines, SpatialEditorGizmos::singleton->camera_material);

--- a/scene/3d/camera.cpp
+++ b/scene/3d/camera.cpp
@@ -33,6 +33,8 @@
 #include "scene/resources/material.h"
 #include "scene/resources/surface_tool.h"
 
+#include "method_bind_ext.inc"
+
 void Camera::_update_audio_listener_state() {
 }
 
@@ -53,6 +55,10 @@ void Camera::_update_camera_mode() {
 		case PROJECTION_ORTHOGONAL: {
 			set_orthogonal(size, near, far);
 		} break;
+		case PROJECTION_FRUSTUM: {
+			set_frustum(frustum.left, frustum.right, frustum.top, frustum.bottom, near, far);
+		}
+
 	}
 }
 
@@ -66,12 +72,22 @@ bool Camera::_set(const StringName &p_name, const Variant &p_value) {
 			mode = PROJECTION_PERSPECTIVE;
 		if (proj == PROJECTION_ORTHOGONAL)
 			mode = PROJECTION_ORTHOGONAL;
+		if (proj==PROJECTION_FRUSTUM)
+			mode=PROJECTION_FRUSTUM;
 
 		changed_all = true;
 	} else if (p_name == "fov" || p_name == "fovy" || p_name == "fovx")
 		fov = p_value;
 	else if (p_name == "size" || p_name == "sizex" || p_name == "sizey")
 		size = p_value;
+	else if (p_name == "left")
+		frustum.left = p_value;
+	else if (p_name == "right")
+		frustum.right = p_value;
+	else if (p_name == "top")
+		frustum.top = p_value;
+	else if (p_name == "bottom")
+		frustum.bottom = p_value;
 	else if (p_name == "near")
 		near = p_value;
 	else if (p_name == "far")
@@ -102,6 +118,7 @@ bool Camera::_set(const StringName &p_name, const Variant &p_value) {
 		_change_notify();
 	return true;
 }
+
 bool Camera::_get(const StringName &p_name, Variant &r_ret) const {
 
 	if (p_name == "projection") {
@@ -110,6 +127,14 @@ bool Camera::_get(const StringName &p_name, Variant &r_ret) const {
 		r_ret = fov;
 	else if (p_name == "size" || p_name == "sizex" || p_name == "sizey")
 		r_ret = size;
+	else if (p_name == "left")
+		r_ret = frustum.left;
+	else if (p_name == "right")
+		r_ret = frustum.right;
+	else if (p_name == "top")
+		r_ret = frustum.top;
+	else if (p_name == "bottom")
+		r_ret = frustum.bottom;
 	else if (p_name == "near")
 		r_ret = near;
 	else if (p_name == "far")
@@ -139,7 +164,7 @@ bool Camera::_get(const StringName &p_name, Variant &r_ret) const {
 
 void Camera::_get_property_list(List<PropertyInfo> *p_list) const {
 
-	p_list->push_back(PropertyInfo(Variant::INT, "projection", PROPERTY_HINT_ENUM, "Perspective,Orthogonal"));
+	p_list->push_back(PropertyInfo(Variant::INT, "projection", PROPERTY_HINT_ENUM, "Perspective,Orthogonal,Frustum"));
 
 	switch (mode) {
 
@@ -161,6 +186,14 @@ void Camera::_get_property_list(List<PropertyInfo> *p_list) const {
 				p_list->push_back(PropertyInfo(Variant::REAL, "sizey", PROPERTY_HINT_RANGE, "0.1,16384,0.01", PROPERTY_USAGE_EDITOR));
 
 		} break;
+		case PROJECTION_FRUSTUM: {
+			p_list->push_back(PropertyInfo(Variant::REAL, "left" , PROPERTY_HINT_EXP_RANGE, "-4096.0,4096.0,0.0001"));
+			p_list->push_back(PropertyInfo(Variant::REAL, "right" , PROPERTY_HINT_EXP_RANGE, "-4096.0,4096.0,0.0001"));
+			p_list->push_back(PropertyInfo(Variant::REAL, "top" , PROPERTY_HINT_EXP_RANGE, "-4096.0,4096.0,0.0001"));
+			p_list->push_back(PropertyInfo(Variant::REAL, "bottom" , PROPERTY_HINT_EXP_RANGE, "-4096.0,4096.0,0.0001"));
+
+		} break;
+
 	}
 
 	p_list->push_back(PropertyInfo(Variant::REAL, "near", PROPERTY_HINT_EXP_RANGE, "0.01,4096.0,0.01"));
@@ -255,6 +288,7 @@ void Camera::set_perspective(float p_fovy_degrees, float p_z_near, float p_z_far
 	update_gizmo();
 	force_change = false;
 }
+
 void Camera::set_orthogonal(float p_size, float p_z_near, float p_z_far) {
 
 	if (!force_change && size == p_size && p_z_near == near && p_z_far == far && mode == PROJECTION_ORTHOGONAL)
@@ -270,6 +304,32 @@ void Camera::set_orthogonal(float p_size, float p_z_near, float p_z_far) {
 	VisualServer::get_singleton()->camera_set_orthogonal(camera, size, near, far);
 	update_gizmo();
 }
+
+void Camera::set_perspective_for_eye(float p_fovy_degrees, float p_z_near, float p_z_far, int p_eye, float p_intraocular_dist, float p_convergence_dist) {
+	Frustum eye;
+
+	eye.set_frustum(p_fovy_degrees, p_eye, p_intraocular_dist, p_convergence_dist);
+
+	set_frustum(eye.left, eye.right, eye.top, eye.bottom, p_z_near, p_z_far);
+}
+
+void Camera::set_frustum(float p_left, float p_right, float p_top, float p_bottom, float p_z_near, float p_z_far) {
+	if (!force_change && frustum.left == p_left && frustum.right == p_right && frustum.top == p_top && frustum.bottom == p_bottom && near == p_z_near && far == p_z_far && mode == PROJECTION_FRUSTUM)
+		return;
+
+	frustum.left = p_left;
+	frustum.right = p_right;
+	frustum.top = p_top;
+	frustum.bottom = p_bottom;
+	near = p_z_near;
+	far = p_z_far;
+	mode = PROJECTION_FRUSTUM;
+	force_change = false;
+
+	VisualServer::get_singleton()->camera_set_frustum(camera, frustum, near, far);
+	update_gizmo();
+}
+
 
 RID Camera::get_camera() const {
 
@@ -425,7 +485,11 @@ Vector3 Camera::project_local_ray_normal(const Point2 &p_pos) const {
 		ray = Vector3(0, 0, -1);
 	} else {
 		CameraMatrix cm;
-		cm.set_perspective(fov, viewport_size.get_aspect(), near, far, keep_aspect == KEEP_WIDTH);
+		if (mode==PROJECTION_FRUSTUM) {
+			cm = frustum.make_camera_matrix(viewport_size.get_aspect(), keep_aspect == KEEP_WIDTH, near, far);
+		} else {
+			cm.set_perspective(fov, viewport_size.get_aspect(), near, far, keep_aspect == KEEP_WIDTH);
+		}
 		float screen_w, screen_h;
 		cm.get_viewport_size(screen_w, screen_h);
 		ray = Vector3(((cpos.x / viewport_size.width) * 2.0 - 1.0) * screen_w, ((1.0 - (cpos.y / viewport_size.height)) * 2.0 - 1.0) * screen_h, -near).normalized();
@@ -454,6 +518,9 @@ Vector3 Camera::project_ray_origin(const Point2 &p_pos) const {
 	//	float aspect = viewport_size.x / viewport_size.y;
 
 	if (mode == PROJECTION_PERSPECTIVE) {
+
+		return get_camera_transform().origin;
+	} else if (mode == PROJECTION_FRUSTUM) {
 
 		return get_camera_transform().origin;
 	} else {
@@ -497,6 +564,8 @@ Point2 Camera::unproject_position(const Vector3 &p_pos) const {
 
 	if (mode == PROJECTION_ORTHOGONAL)
 		cm.set_orthogonal(size, viewport_size.get_aspect(), near, far, keep_aspect == KEEP_WIDTH);
+	else if (mode==PROJECTION_FRUSTUM)
+		cm = frustum.make_camera_matrix(viewport_size.get_aspect(), keep_aspect == KEEP_WIDTH, near, far);
 	else
 		cm.set_perspective(fov, viewport_size.get_aspect(), near, far, keep_aspect == KEEP_WIDTH);
 
@@ -525,6 +594,8 @@ Vector3 Camera::project_position(const Point2 &p_point) const {
 
 	if (mode == PROJECTION_ORTHOGONAL)
 		cm.set_orthogonal(size, viewport_size.get_aspect(), near, far, keep_aspect == KEEP_WIDTH);
+	else if (mode==PROJECTION_FRUSTUM)
+		cm = frustum.make_camera_matrix(viewport_size.get_aspect(),keep_aspect==KEEP_WIDTH, near, far);
 	else
 		cm.set_perspective(fov, viewport_size.get_aspect(), near, far, keep_aspect == KEEP_WIDTH);
 
@@ -595,11 +666,17 @@ void Camera::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("project_position", "screen_point"), &Camera::project_position);
 	ObjectTypeDB::bind_method(_MD("set_perspective", "fov", "z_near", "z_far"), &Camera::set_perspective);
 	ObjectTypeDB::bind_method(_MD("set_orthogonal", "size", "z_near", "z_far"), &Camera::set_orthogonal);
+	ObjectTypeDB::bind_method(_MD("set_perspective_for_eye", "fov", "z_near", "z_far", "eye", "intraocular_dist", "convergence_dist"), &Camera::set_perspective_for_eye);
+	ObjectTypeDB::bind_method(_MD("set_frustum", "left", "right", "top", "bottom", "z_near", "z_far"), &Camera::set_frustum);
 	ObjectTypeDB::bind_method(_MD("make_current"), &Camera::make_current);
 	ObjectTypeDB::bind_method(_MD("clear_current"), &Camera::clear_current);
 	ObjectTypeDB::bind_method(_MD("is_current"), &Camera::is_current);
 	ObjectTypeDB::bind_method(_MD("get_camera_transform"), &Camera::get_camera_transform);
 	ObjectTypeDB::bind_method(_MD("get_fov"), &Camera::get_fov);
+	ObjectTypeDB::bind_method(_MD("get_left"), &Camera::get_left );
+	ObjectTypeDB::bind_method(_MD("get_right"), &Camera::get_right );
+	ObjectTypeDB::bind_method(_MD("get_top"), &Camera::get_top );
+	ObjectTypeDB::bind_method(_MD("get_bottom"), &Camera::get_bottom );
 	ObjectTypeDB::bind_method(_MD("get_size"), &Camera::get_size);
 	ObjectTypeDB::bind_method(_MD("get_zfar"), &Camera::get_zfar);
 	ObjectTypeDB::bind_method(_MD("get_znear"), &Camera::get_znear);
@@ -618,6 +695,10 @@ void Camera::_bind_methods() {
 
 	BIND_CONSTANT(PROJECTION_PERSPECTIVE);
 	BIND_CONSTANT(PROJECTION_ORTHOGONAL);
+	BIND_CONSTANT(PROJECTION_FRUSTUM);
+
+	BIND_CONSTANT(EYE_LEFT);
+	BIND_CONSTANT(EYE_RIGHT);
 
 	BIND_CONSTANT(KEEP_WIDTH);
 	BIND_CONSTANT(KEEP_HEIGHT);
@@ -631,6 +712,22 @@ float Camera::get_fov() const {
 float Camera::get_size() const {
 
 	return size;
+}
+
+float Camera::get_left() const {
+	return frustum.left;
+}
+
+float Camera::get_right() const {
+	return frustum.right;
+}
+
+float Camera::get_top() const {
+	return frustum.top;
+}
+
+float Camera::get_bottom() const {
+	return frustum.bottom;
 }
 
 float Camera::get_znear() const {
@@ -665,11 +762,14 @@ Vector<Plane> Camera::get_frustum() const {
 
 	Size2 viewport_size = get_viewport()->get_visible_rect().size;
 	CameraMatrix cm;
-	if (mode == PROJECTION_PERSPECTIVE)
+	if (mode == PROJECTION_PERSPECTIVE) {
 		cm.set_perspective(fov, viewport_size.get_aspect(), near, far, keep_aspect == KEEP_WIDTH);
-	else
+	} else if (mode == PROJECTION_FRUSTUM) {
+		cm = frustum.make_camera_matrix(viewport_size.get_aspect(), keep_aspect == KEEP_WIDTH, near, far);
+	} else {
 		cm.set_orthogonal(size, viewport_size.get_aspect(), near, far, keep_aspect == KEEP_WIDTH);
-
+	}
+ 
 	return cm.get_projection_planes(get_camera_transform());
 }
 
@@ -699,6 +799,10 @@ Camera::Camera() {
 	camera = VisualServer::get_singleton()->camera_create();
 	size = 1;
 	fov = 0;
+	frustum.left = -0.5;
+	frustum.right = 0.5;
+	frustum.top = 0.5;
+	frustum.bottom = -0.5;
 	near = 0;
 	far = 0;
 	current = false;

--- a/scene/3d/camera.h
+++ b/scene/3d/camera.h
@@ -33,6 +33,7 @@
 #include "scene/3d/spatial.h"
 #include "scene/main/viewport.h"
 #include "scene/resources/environment.h"
+#include "core/math/frustum.h"
 /**
 	@author Juan Linietsky <reduzio@gmail.com>
 */
@@ -44,7 +45,13 @@ public:
 	enum Projection {
 
 		PROJECTION_PERSPECTIVE,
-		PROJECTION_ORTHOGONAL
+		PROJECTION_ORTHOGONAL,
+		PROJECTION_FRUSTUM
+	};
+
+	enum Eye {
+		EYE_LEFT,
+		EYE_RIGHT
 	};
 
 	enum KeepAspect {
@@ -64,6 +71,8 @@ private:
 	float v_offset;
 	float h_offset;
 	KeepAspect keep_aspect;
+
+	Frustum frustum;
 
 	RID camera;
 	RID scenario_id;
@@ -102,6 +111,8 @@ public:
 
 	void set_perspective(float p_fovy_degrees, float p_z_near, float p_z_far);
 	void set_orthogonal(float p_size, float p_z_near, float p_z_far);
+	void set_perspective_for_eye(float p_fovy_degrees, float p_z_near, float p_z_far, int p_eye, float p_intraocular_dist, float p_convergence_dist);
+	void set_frustum(float p_left, float p_right, float p_top, float p_bottom, float p_z_near, float p_z_far);
 
 	void make_current();
 	void clear_current();
@@ -111,6 +122,10 @@ public:
 
 	float get_fov() const;
 	float get_size() const;
+	float get_left() const;
+	float get_right() const;
+	float get_top() const;
+	float get_bottom() const;
 	float get_zfar() const;
 	float get_znear() const;
 	Projection get_projection() const;
@@ -146,6 +161,7 @@ public:
 };
 
 VARIANT_ENUM_CAST(Camera::Projection);
+VARIANT_ENUM_CAST(Camera::Eye);
 VARIANT_ENUM_CAST(Camera::KeepAspect);
 
 #endif

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -1372,6 +1372,16 @@ void VisualServerRaster::camera_set_orthogonal(RID p_camera, float p_size, float
 	camera->zfar = p_z_far;
 }
 
+void VisualServerRaster::camera_set_frustum(RID p_camera, const Frustum& p_frustum, float p_z_near, float p_z_far) {
+	VS_CHANGED;
+	Camera *camera = camera_owner.get( p_camera );
+	ERR_FAIL_COND(!camera);
+	camera->type=Camera::FRUSTUM;
+	camera->frustum=p_frustum;
+	camera->znear=p_z_near;
+	camera->zfar=p_z_far;
+}
+
 void VisualServerRaster::camera_set_transform(RID p_camera, const Transform &p_transform) {
 	VS_CHANGED;
 	Camera *camera = camera_owner.get(p_camera);
@@ -4493,6 +4503,15 @@ Vector<Vector3> VisualServerRaster::_camera_generate_endpoints(Instance *p_light
 					p_camera->vaspect);
 
 		} break;
+		case Camera::FRUSTUM: {
+			camera_matrix = p_camera->frustum.make_camera_matrix(
+				viewport_rect.width / (float)viewport_rect.height,
+				p_camera->vaspect,
+				p_range_min,
+				p_range_max
+			);
+
+		} break;
 	}
 
 	//obtain the frustum endpoints
@@ -4618,6 +4637,19 @@ void VisualServerRaster::_light_instance_update_pssm_shadow(Instance *p_light, S
 						p_camera->vaspect
 
 						);
+
+			} break;
+			case Camera::FRUSTUM: {
+				// FIXME well this actually changes alot in Godot 3 so maybe we don't care
+
+				camera_matrix.set_perspective(
+					60.0,
+					viewport_rect.width / (float)viewport_rect.height,
+					distances[(i==0 || !overlap )?i:i-1],
+					distances[i+1],
+					p_camera->vaspect
+
+				);
 
 			} break;
 		}
@@ -5975,6 +6007,15 @@ void VisualServerRaster::_render_camera(Viewport *p_viewport, Camera *p_camera, 
 					);
 			ortho = false;
 
+		} break;
+		case Camera::FRUSTUM: {
+			camera_matrix = p_camera->frustum.make_camera_matrix(
+				viewport_rect.width / (float) viewport_rect.height, 
+				p_camera->vaspect, 
+				p_camera->znear, 
+				p_camera->zfar
+			);
+			ortho=false;
 		} break;
 	}
 

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -117,7 +117,8 @@ class VisualServerRaster : public VisualServer {
 
 		enum Type {
 			PERSPECTIVE,
-			ORTHOGONAL
+			ORTHOGONAL,
+			FRUSTUM
 		};
 		Type type;
 		float fov;
@@ -127,6 +128,7 @@ class VisualServerRaster : public VisualServer {
 		bool vaspect;
 		RID env;
 
+		Frustum frustum;
 		Transform transform;
 
 		Camera() {
@@ -970,6 +972,7 @@ public:
 	virtual RID camera_create();
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far);
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far);
+	virtual void camera_set_frustum(RID p_camera, const Frustum& p_frustum, float p_z_near, float p_z_far);
 	virtual void camera_set_transform(RID p_camera, const Transform &p_transform);
 
 	virtual void camera_set_visible_layers(RID p_camera, uint32_t p_layers);

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -398,6 +398,7 @@ public:
 	FUNC0R(RID, camera_create);
 	FUNC4(camera_set_perspective, RID, float, float, float);
 	FUNC4(camera_set_orthogonal, RID, float, float, float);
+	FUNC4(camera_set_frustum,RID, const Frustum&, float, float);
 	FUNC2(camera_set_transform, RID, const Transform &);
 
 	FUNC2(camera_set_visible_layers, RID, uint32_t);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -36,6 +36,7 @@
 #include "object.h"
 #include "rid.h"
 #include "variant.h"
+#include "frustum.h"
 
 /**
 	@author Juan Linietsky <reduzio@gmail.com>
@@ -645,6 +646,7 @@ public:
 	virtual RID camera_create() = 0;
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
+	virtual void camera_set_frustum(RID p_camera, const Frustum& p_frustum, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_transform(RID p_camera, const Transform &p_transform) = 0;
 
 	virtual void camera_set_visible_layers(RID p_camera, uint32_t p_layers) = 0;


### PR DESCRIPTION
This is a resubmit of my PR #7121 but for the Godot 2.1 branch. I know a few people who are currently doing HMD development still in Godot 2 and as i'm about to fix 7121 for Godot 3 I figured submitting this on the 2.1 branch could be appreciated (not to mention I'm still using it for my OpenVR project :))

All this PR does is introduce a new camera mode called FRUSTUM which allows you to set a left/right/top/bottom frustum from which the projection matrix is calculated. It also adds a few methods to the camera object to set the correct values for stereo projection.

The frustum is set at unit depth, not at the near plane, so you can change the near and far plane without having to adjust the frustum. Also the frustum will be adjusted to the aspect ratio of the viewport by Godot itself so do not adjust the top/bottom of the frustum by aspect ratio, instead set up the frustum assuming a square screen. This keeps the camera independent of the viewport it is used with.

You can find a test project here that sets up the stereo camera rendering to a left/right splitscreen such as you would use with an HMD:
https://github.com/BastiaanOlij/StereoCameraTest