### PR TITLE
Refactor GlobalConfig::setup

### DIFF
--- a/core/globals.h
+++ b/core/globals.h
@@ -85,6 +85,7 @@ protected:
 
 	static GlobalConfig *singleton;
 
+	Error _load_engine_settings(const String base_path);
 	Error _load_settings(const String p_path);
 	Error _load_settings_binary(const String p_path);
 


### PR DESCRIPTION
I have tried to make the code around this constructor a bit easier
to follow and with less redundancy. The engine now no longer tried to
go all the way to the root of the filesystem tree when trying to load
packs or configurations.

Furthermore the engine now tries to find packs in all locations it
checks. The following locations are now checked, in this order:

* game path (-path <dir>)
* os-specific resource dir (if supported)
* current working directory (if supported)
* directory of the godot executable

I believe this is what most users would expect, and is as discussed
on the ticket and IRC.

This change fixes #7764