### PR TITLE
Fix relative cursor data in CAPTURED mouse mode on Windows.

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -400,14 +400,15 @@ LRESULT OS_Windows::WndProc(HWND hWnd,UINT uMsg, WPARAM	wParam,	LPARAM	lParam) {
 			if (mouse_mode==MOUSE_MODE_CAPTURED) {
 
 				Point2i c(video_mode.width/2,video_mode.height/2);
+				old_x = c.x;
+				old_y = c.y;
+
 				if (Point2i(mm.x,mm.y)==c) {
 					center=c;
 					return 0;
 				}
 
 				Point2i ncenter(mm.x,mm.y);
-				mm.x = old_x + (mm.x-center.x);
-				mm.y = old_y + (mm.y-center.y);
 				center=ncenter;
 				POINT pos = { (int) c.x, (int) c.y };
 				ClientToScreen(hWnd, &pos);


### PR DESCRIPTION
This PR is a fix for some glitches on the Windows build concerning sampling relative mouse motion. The data would sometimes be inaccurate and give inverted results, a glitch most notable if testing with a first or third-person camera with a locked axis. Using relative mouse data to control the camera, if you push continually on a locked axis, the camera would 'jitter' as a result. I've only tested this otherwise on the Linux build, but as far as I can tell, this problem only seems to appear on Windows. This should make the behaviour consistent with the Linux build now.