### PR TITLE
Various fixes for TabContainer. also Fix issue #7752 ... v2.1

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -39867,13 +39867,21 @@
 			<return type="int">
 			</return>
 			<description>
-				Return the current tab that is being showed.
+				Return the current tab index that is being shown.
+			</description>
+		</method>
+		<method name="get_previous_tab" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Return the previous tab index that was being shown.
 			</description>
 		</method>
 		<method name="get_current_tab_control" qualifiers="const">
 			<return type="Control">
 			</return>
 			<description>
+				Return the current tab control that is being shown.
 			</description>
 		</method>
 		<method name="get_popup" qualifiers="const">

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -39987,6 +39987,13 @@
 				Emitted when the current tab changes.
 			</description>
 		</signal>
+		<signal name="tab_selected">
+			<argument index="0" name="tab" type="int">
+			</argument>
+			<description>
+				Emitted when the current tab is being selected again.
+			</description>
+		</signal>
 	</signals>
 	<constants>
 	</constants>

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -761,6 +761,7 @@ TabContainer::TabContainer() {
 	buttons_visible_cache=false;
 	tabs_ofs_cache=0;
 	current=0;
+	previous=0;
 	mouse_x_cache=0;
 	align=ALIGN_CENTER;
 	tabs_visible=true;

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -415,7 +415,8 @@ void TabContainer::add_child_notify(Node *p_child) {
 		c->show();
 		//call_deferred("set_current_tab",0);
 		first=true;
-		current=0;
+		current = 0;
+		previous = 0;
 	}
 	c->set_area_as_parent_rect();
 	if (tabs_visible)
@@ -451,7 +452,8 @@ void TabContainer::set_current_tab(int p_current) {
 
 	ERR_FAIL_INDEX( p_current, get_tab_count() );
 
-	current=p_current;
+	int pending_previous = current;
+	current = p_current;
 
 	int idx=0;
 
@@ -478,13 +480,25 @@ void TabContainer::set_current_tab(int p_current) {
 	}
 
 	_change_notify("current_tab");
-	emit_signal("tab_changed",current);
+
+	if (pending_previous == current)
+		emit_signal("tab_selected", current);
+	else {
+		previous = pending_previous;
+		emit_signal("tab_changed", current);
+	}
+
 	update();
 }
 
 int TabContainer::get_current_tab() const {
 
 	return current;
+}
+
+int TabContainer::get_previous_tab() const {
+	
+	return previous;
 }
 
 Control* TabContainer::get_tab_control(int p_idx) const {
@@ -715,6 +729,7 @@ void TabContainer::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_tab_count"),&TabContainer::get_tab_count);
 	ObjectTypeDB::bind_method(_MD("set_current_tab","tab_idx"),&TabContainer::set_current_tab);
 	ObjectTypeDB::bind_method(_MD("get_current_tab"),&TabContainer::get_current_tab);
+	ObjectTypeDB::bind_method(_MD("get_previous_tab"), &TabContainer::get_previous_tab);
 	ObjectTypeDB::bind_method(_MD("get_current_tab_control:Control"),&TabContainer::get_current_tab_control);
 	ObjectTypeDB::bind_method(_MD("get_tab_control:Control","idx"),&TabContainer::get_tab_control);
 	ObjectTypeDB::bind_method(_MD("set_tab_align","align"),&TabContainer::set_tab_align);
@@ -731,6 +746,7 @@ void TabContainer::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("_child_renamed_callback"),&TabContainer::_child_renamed_callback);
 
 	ADD_SIGNAL(MethodInfo("tab_changed",PropertyInfo(Variant::INT,"tab")));
+	ADD_SIGNAL(MethodInfo("tab_selected", PropertyInfo(Variant::INT, "tab")));
 	ADD_SIGNAL(MethodInfo("pre_popup_pressed"));
 
 	ADD_PROPERTY( PropertyInfo(Variant::INT, "tab_align", PROPERTY_HINT_ENUM,"Left,Center,Right"), _SCS("set_tab_align"), _SCS("get_tab_align") );

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -50,6 +50,7 @@ private:
 	int tabs_ofs_cache;
 	int last_tab_cache;
 	int current;
+	int previous;
 	bool tabs_visible;
 	bool buttons_visible_cache;
 	TabAlign align;
@@ -86,6 +87,7 @@ public:
 	int get_tab_count() const;
 	void set_current_tab(int p_current);
 	int get_current_tab() const;
+	int get_previous_tab() const;
 
 	Control* get_tab_control(int p_idx) const;
 	Control* get_current_tab_control() const;


### PR DESCRIPTION
- Renamed `tab_changed` signal to `tab_selected`. Which still emits a signal by reselecting the active tab.
- Added `tab_changed` signal. Which emits a signal if and only if previous tab does not equal current tab.
- Added `get_previous_tab()`. Which returns the previous shown tab. **Note:** only `tab_changed` can modify previous tab index.
- Add documentation for the added function and signals. Fix a typo too.