### PR TITLE
Fix for issue #7766

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1765,7 +1765,8 @@ String OS_OSX::get_joy_guid(int p_device) const {
 OS_OSX* OS_OSX::singleton=NULL;
 
 OS_OSX::OS_OSX() {
-
+	
+	mouse_mode=OS::MOUSE_MODE_VISIBLE
 	main_loop=NULL;
 	singleton=this;
 	autoreleasePool = [[NSAutoreleasePool alloc] init];


### PR DESCRIPTION
When calling get_mouse_mode() on OS_OSX, garbage was returned.  This is because mouse_mode was not initialized in the constructor for OS_OSX.

Add initialization for OS_OSX.mouse_mode in OS_OSX::OS_OSX().  mouse_mode now defaults to OS::MOUSE_MODE_VISIBLE.

_Bugsquad edit:_ fixes #7766