### PR TITLE
Remove bounds check when resuming from yield. (fixes #7796)

### DIFF
--- a/modules/gdscript/gd_function.cpp
+++ b/modules/gdscript/gd_function.cpp
@@ -171,7 +171,7 @@ Variant GDFunction::call(GDInstance *p_instance, const Variant **p_args, int p_a
 	if (p_state) {
 		//use existing (supplied) state (yielded)
 		stack=(Variant*)p_state->stack.ptr();
-		call_args=(Variant**)&p_state->stack[sizeof(Variant)*p_state->stack_size];
+		call_args=(Variant**)stack + sizeof(Variant)*p_state->stack_size;
 		line=p_state->line;
 		ip=p_state->ip;
 		alloca_size=p_state->stack.size();


### PR DESCRIPTION
The code would get a pointer to the beginning of the call_args by using
operator[] at the stack Vector. This does bound checking. When there are
no call_args this bound check fails and the error mentioned in #7796
gets triggered.

This bound check is actually not necessary as call_args just gets set to
NULL and never dereferenced. This new code will just unconditionally set
the pointer to the place where the call_args are if there are any. There
is no NULL check for call_args anywhere so this is safe.