### PR TITLE
Spinbox: don't ignore double clicks.

### DIFF
--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -100,8 +100,6 @@ void SpinBox::_gui_input(const InputEvent& p_event) {
 	if (p_event.type==InputEvent::MOUSE_BUTTON && p_event.mouse_button.pressed) {
 		const InputEventMouseButton &mb=p_event.mouse_button;
 
-		if (mb.doubleclick)
-			return; //ignore doubleclick
 
 		bool up = mb.y < (get_size().height/2);
 


### PR DESCRIPTION
Fixes the problem with spinboxes not updating when clicking too fast.
Fixes #7800 