### PR TITLE
Make nan==nan true for GDScript

### DIFF
--- a/core/math/math_2d.cpp
+++ b/core/math/math_2d.cpp
@@ -157,6 +157,13 @@ bool Vector2::operator!=(const Vector2& p_vec2) const {
 
 	return x!=p_vec2.x || y!=p_vec2.y;
 }
+bool Vector2::nan_equals(const Vector2& p_vec2) const {
+
+	return (x==p_vec2.x && y==p_vec2.y) ||
+			(x==p_vec2.x && isnan(y) && isnan(p_vec2.y)) ||
+			(isnan(x) && isnan(p_vec2.x) && y == p_vec2.y);
+}
+
 Vector2 Vector2::floor() const {
 
 	return Vector2( Math::floor(x), Math::floor(y) );

--- a/core/math/math_2d.h
+++ b/core/math/math_2d.h
@@ -133,6 +133,7 @@ struct Vector2 {
 	bool operator<(const Vector2& p_vec2) const { return (x==p_vec2.x)?(y<p_vec2.y):(x<p_vec2.x); }
 	bool operator<=(const Vector2& p_vec2) const { return (x==p_vec2.x)?(y<=p_vec2.y):(x<=p_vec2.x); }
 
+	bool nan_equals(const Vector2& p_vec2) const;
 	real_t angle() const;
 
 	void set_rotation(real_t p_radians) {
@@ -318,6 +319,8 @@ struct Rect2 {
 
 	bool operator==(const Rect2& p_rect) const { return pos==p_rect.pos && size==p_rect.size; }
 	bool operator!=(const Rect2& p_rect) const { return pos!=p_rect.pos || size!=p_rect.size; }
+
+	bool nan_equals(const Rect2& p_rect) const { return pos.nan_equals(p_rect.pos) && size == p_rect.size; }
 
 	inline Rect2 grow(real_t p_by) const {
 

--- a/core/math/plane.cpp
+++ b/core/math/plane.cpp
@@ -164,3 +164,8 @@ Plane::operator String() const {
 
 	return normal.operator String() + ", " + rtos(d);
 }
+
+bool Plane::nan_equals(const Plane& p_plane) const {
+
+	return normal.nan_equals(p_plane.normal) && d == p_plane.d;
+}

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -73,6 +73,7 @@ public:
 
 	_FORCE_INLINE_ bool operator==(const Plane& p_plane) const;
 	_FORCE_INLINE_ bool operator!=(const Plane& p_plane) const;
+	bool nan_equals(const Plane& p_plane) const;
 	operator String() const;
 
 	_FORCE_INLINE_ Plane() { d=0; }

--- a/core/math/quat.cpp
+++ b/core/math/quat.cpp
@@ -284,3 +284,22 @@ Quat::Quat(const Vector3& axis, const real_t& angle) {
 			cos_angle);
 	}
 }
+
+bool Quat::nan_equals(const Quat& q2) const {
+	return (x == q2.x && y == q2.y && z == q2.z && w == q2.w) ||
+			(x == q2.x && y == q2.y && z == q2.z && isnan(w) && isnan(q2.w)) ||
+			(x == q2.x && y == q2.y && isnan(z) && isnan(q2.z) && w == q2.w) ||
+			(x == q2.x && y == q2.y && isnan(z) && isnan(q2.z) && isnan(w) && isnan(q2.w)) ||
+			(x == q2.x && isnan(y) && isnan(q2.y) && z == q2.z && w == q2.w) ||
+			(x == q2.x && isnan(y) && isnan(q2.y) && z == q2.z && isnan(w) && isnan(q2.w)) ||
+			(x == q2.x && isnan(y) && isnan(q2.y) && isnan(z) && isnan(q2.z) && w == q2.w) ||
+			(x == q2.x && isnan(y) && isnan(q2.y) && isnan(z) && isnan(q2.z) && isnan(w) && isnan(q2.w)) ||
+			(isnan(x) && isnan(q2.x) && y == q2.y && z == q2.z && w == q2.w) ||
+			(isnan(x) && isnan(q2.x) && y == q2.y && z == q2.z && isnan(w) && isnan(q2.w)) ||
+			(isnan(x) && isnan(q2.x) && y == q2.y && isnan(z) && isnan(q2.z) && w == q2.w) ||
+			(isnan(x) && isnan(q2.x) && y == q2.y && isnan(z) && isnan(q2.z) && isnan(w) && isnan(q2.w)) ||
+			(isnan(x) && isnan(q2.x) && isnan(y) && isnan(q2.y) && z == q2.z && w == q2.w) ||
+			(isnan(x) && isnan(q2.x) && isnan(y) && isnan(q2.y) && z == q2.z && isnan(w) && isnan(q2.w)) ||
+			(isnan(x) && isnan(q2.x) && isnan(y) && isnan(q2.y) && isnan(z) && isnan(q2.z) && w == q2.w) ||
+			(isnan(x) && isnan(q2.x) && isnan(y) && isnan(q2.y) && isnan(z) && isnan(q2.z) && isnan(w) && isnan(q2.w));
+}

--- a/core/math/quat.h
+++ b/core/math/quat.h
@@ -93,6 +93,7 @@ public:
 	_FORCE_INLINE_ Quat operator*(const real_t& s) const;
 	_FORCE_INLINE_ Quat operator/(const real_t& s) const;
 
+	bool nan_equals(const Quat& q2) const;
 
 	_FORCE_INLINE_ bool operator==(const Quat& p_quat) const;
 	_FORCE_INLINE_ bool operator!=(const Quat& p_quat) const;
@@ -192,6 +193,5 @@ bool Quat::operator==(const Quat& p_quat) const {
 bool Quat::operator!=(const Quat& p_quat) const {
 	return x!=p_quat.x || y!=p_quat.y || z!=p_quat.z || w!=p_quat.w;
 }
-
 
 #endif

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -176,6 +176,17 @@ Vector3 Vector3::cubic_interpolate(const Vector3& p_b,const Vector3& p_pre_a, co
 	return out;
 }
 # endif
+bool Vector3::nan_equals(const Vector3& p_v) const {
+	return (x == p_v.x && y == p_v.y && z == p_v.z) ||
+			(x == p_v.x && y == p_v.y && isnan(z) && isnan(p_v.z)) ||
+			(x == p_v.x && isnan(y) && isnan(p_v.y) && z == p_v.z) ||
+			(isnan(x) && isnan(p_v.x) && y == p_v.y && z == p_v.z) ||
+			(x == p_v.x && isnan(y) && isnan(p_v.y) && isnan(z) && isnan(p_v.z)) ||
+			(isnan(x) && isnan(p_v.x) && y == p_v.y && isnan(z) && isnan(p_v.z)) ||
+			(isnan(x) && isnan(p_v.x) && isnan(y) && isnan(p_v.y) && z == p_v.z) ||
+			(isnan(x) && isnan(p_v.x) && isnan(y) && isnan(p_v.y) && isnan(z) && isnan(p_v.z));
+}
+
 Vector3::operator String() const {
 
 	return (rtos(x)+", "+rtos(y)+", "+rtos(z));

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -134,6 +134,7 @@ struct Vector3 {
 	_FORCE_INLINE_ bool operator<(const Vector3& p_v) const;
 	_FORCE_INLINE_ bool operator<=(const Vector3& p_v) const;
 
+	bool nan_equals(const Vector3& p_v) const;
 	operator String() const;
 
 	_FORCE_INLINE_ Vector3() { x=y=z=0; }


### PR DESCRIPTION
After discussing this with Reduz this seemed like the best way to
fix #7354. This will make composite values that contain NaN in the same
places as well as the same other values compare as the same.

Additionally non-composite values now also compare equal if they are
both NaN. This breaks IEEE specifications but this is probably what most
users expect. There is a GDScript function check for NaN if the user
needs this information.

This fixes #7354 and probably also fixes #6947