### PR TITLE
SceneTreeTimer: Ability to set pause mode

### DIFF
--- a/scene/main/scene_main_loop.cpp
+++ b/scene/main/scene_main_loop.cpp
@@ -63,9 +63,19 @@ float SceneTreeTimer::get_time_left() const {
 	return time_left;
 }
 
+void SceneTreeTimer::set_pause_mode_process(bool p_pause_mode_process) {
+	if (process_pause != p_pause_mode_process) {
+		process_pause = p_pause_mode_process;
+	}
+}
+
+bool SceneTreeTimer::is_pause_mode_process() {
+	return process_pause;
+}
 
 SceneTreeTimer::SceneTreeTimer() {
 	time_left=0;
+	process_pause = true;
 }
 
 
@@ -602,7 +612,10 @@ bool SceneTree::idle(float p_time){
 	for (List<Ref<SceneTreeTimer> >::Element *E=timers.front();E;) {
 
 		List<Ref<SceneTreeTimer> >::Element *N = E->next();
-
+		if (pause && !E->get()->is_pause_mode_process()) {
+			E=N;
+			continue;
+		}
 		float time_left = E->get()->get_time_left();
 		time_left-=p_time;
 		E->get()->set_time_left(time_left);
@@ -1714,10 +1727,11 @@ void SceneTree::drop_files(const Vector<String>& p_files,int p_from_screen) {
 }
 
 
-Ref<SceneTreeTimer> SceneTree::create_timer(float p_delay_sec) {
+Ref<SceneTreeTimer> SceneTree::create_timer(float p_delay_sec, bool p_process_pause) {
 
 	Ref<SceneTreeTimer> stt;
 	stt.instance();
+	stt->set_pause_mode_process(p_process_pause);
 	stt->set_time_left(p_delay_sec);
 	timers.push_back(stt);
 	return stt;
@@ -2243,7 +2257,7 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_paused"),&SceneTree::is_paused);
 	ClassDB::bind_method(D_METHOD("set_input_as_handled"),&SceneTree::set_input_as_handled);
 
-	ClassDB::bind_method(D_METHOD("create_timer:SceneTreeTimer","time_sec"),&SceneTree::create_timer);
+	ClassDB::bind_method(D_METHOD("create_timer:SceneTreeTimer","time_sec", "pause_mode_process"),&SceneTree::create_timer, DEFVAL(true));
 
 
 	ClassDB::bind_method(D_METHOD("get_node_count"),&SceneTree::get_node_count);

--- a/scene/main/scene_main_loop.h
+++ b/scene/main/scene_main_loop.h
@@ -56,12 +56,16 @@ class SceneTreeTimer : public Reference {
 	GDCLASS(SceneTreeTimer,Reference);
 
 	float time_left;
+	bool process_pause;
 protected:
 	static void _bind_methods();
 public:
 
 	void set_time_left(float p_time);
 	float get_time_left() const;
+
+	void set_pause_mode_process(bool p_pause_mode_process);
+	bool is_pause_mode_process();
 
 	SceneTreeTimer();
 };
@@ -430,7 +434,7 @@ public:
 	Error change_scene_to(const Ref<PackedScene>& p_scene);
 	Error reload_current_scene();
 
-	Ref<SceneTreeTimer> create_timer(float p_delay_sec);
+	Ref<SceneTreeTimer> create_timer(float p_delay_sec, bool p_process_pause=true);
 
 	//used by Main::start, don't use otherwise
 	void add_current_scene(Node * p_current);


### PR DESCRIPTION
Adds an additional flag to SceneTree::create_timer() that tells it whether or not to process when the game is paused.
Defaults to false in order to not break existing functionality.
Fixes #7656