### PR TITLE
X11: Finalize audiodrivers on exit

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -464,7 +464,6 @@ void OS_X11::finalize() {
 		memdelete(main_loop);
 	main_loop=NULL;
 
-
 	/*
 	if (debugger_connection_console) {
 		memdelete(debugger_connection_console);
@@ -512,6 +511,10 @@ void OS_X11::finalize() {
 
 
 	args.clear();
+
+	for (int i = 0; i < get_audio_driver_count(); i++) {
+		AudioDriverManager::get_driver(i)->finish();
+	}
 }
 
 


### PR DESCRIPTION
The audiodrivers loaded by OS_X11 are not destroyed before the
audioserver is. This causes a segfault on exit.

The code is taken from os_windows.cpp which did have the cleanup code.