### PR TITLE
X11: Move audio driver finalize to the start of cleanup

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -464,6 +464,10 @@ void OS_X11::finalize() {
 		memdelete(main_loop);
 	main_loop=NULL;
 
+	for (int i = 0; i < get_audio_driver_count(); i++) {
+		AudioDriverManager::get_driver(i)->finish();
+	}
+
 	/*
 	if (debugger_connection_console) {
 		memdelete(debugger_connection_console);
@@ -474,7 +478,6 @@ void OS_X11::finalize() {
 	memdelete(joypad);
 #endif
 	memdelete(input);
-
 
 	visual_server->finish();
 	memdelete(visual_server);
@@ -512,9 +515,6 @@ void OS_X11::finalize() {
 
 	args.clear();
 
-	for (int i = 0; i < get_audio_driver_count(); i++) {
-		AudioDriverManager::get_driver(i)->finish();
-	}
 }
 
 


### PR DESCRIPTION
The audio driver cleanup needs to happen at the start of finish
otherwise a race still seems to exist with the destruction of the
audioserver. I think that destroying the X resoures before has something
to do with it.

@akien-mga Sorry for the double PR, I previously tested it in this location, then noticed that win32 does it later and I apparently never retested...