### PR TITLE
X11 return to cwd at exit

### DIFF
--- a/platform/x11/godot_x11.cpp
+++ b/platform/x11/godot_x11.cpp
@@ -26,12 +26,18 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
+#include <unistd.h>
+#include <limits.h>
+
 #include "main/main.h"
 #include "os_x11.h"
 
 int main(int argc, char* argv[]) {
 
 	OS_X11 os;
+
+	char *cwd = (char*)malloc(PATH_MAX);
+	getcwd(cwd, PATH_MAX);
 
 	Error err  = Main::setup(argv[0],argc-1,&argv[1]);
 	if (err!=OK)
@@ -40,6 +46,9 @@ int main(int argc, char* argv[]) {
 	if (Main::start())
 		os.run(); // it is actually the OS that decides how to run
 	Main::cleanup();
+
+	chdir(cwd);
+	free(cwd);
 
 	return os.get_exit_code();
 }


### PR DESCRIPTION
During runtime godot calls chdir() several times. This doesn't really
matter normally but when using tools such as gprof the location of the
profiling data is kind of hard to intuit.

With this PR we simply store the current working directory at start and
restore it once we're almost done exiting.

This doesn't use the OS abstractions as when we need to get the current
workdir we haven't yet initialized it (by necessity). This would break
if we tried to build X11 for windows, but since the X11 target is
hardcoded to use the UNIX abstractions I don't think it matters.