### PR TITLE
xCode added xcuserdata to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,6 +246,9 @@ node_modules/
 #Kdevelop project files
 *.kdev4
 
+# xCode
+xcuserdata
+
 # RIA/Silverlight projects
 Generated_Code/
 


### PR DESCRIPTION
this file gets autogenerted for the xcodeproject in:
```misc/dist/ios_xcode/godot_xcode/godot_ios.xcodeproj/xcuserdata```
it contains information about the current state of excode: which folders are expanded in the ProjectManager, which file is open...