### PR TITLE
Fixed Line2D editor doesn't respond to input

### DIFF
--- a/tools/editor/plugins/line_2d_editor_plugin.cpp
+++ b/tools/editor/plugins/line_2d_editor_plugin.cpp
@@ -50,7 +50,7 @@ int Line2DEditor::get_point_index_at(Vector2 gpos) {
 	return -1;
 }
 
-bool Line2DEditor::forward_input_event(const InputEvent& p_event) {
+bool Line2DEditor::forward_gui_input(const InputEvent& p_event) {
 
 	if (!node)
 		return false;
@@ -84,8 +84,8 @@ bool Line2DEditor::forward_input_event(const InputEvent& p_event) {
 						undo_redo->add_undo_method(canvas_item_editor->get_viewport_control(), "update");
 						undo_redo->commit_action();
 					}
+					return true;
 				}
-				return true;
 			}
 
 			if(mb.pressed && mb.button_index == BUTTON_LEFT && ((mb.mod.command && mode == MODE_EDIT) || mode == MODE_CREATE)) {

--- a/tools/editor/plugins/line_2d_editor_plugin.h
+++ b/tools/editor/plugins/line_2d_editor_plugin.h
@@ -15,7 +15,7 @@ class Line2DEditor : public HBoxContainer {
 	GDCLASS(Line2DEditor, HBoxContainer)
 
 public:
-	bool forward_input_event(const InputEvent& p_event);
+	bool forward_gui_input(const InputEvent& p_event);
 	void edit(Node *p_line2d);
 	Line2DEditor(EditorNode *p_editor);
 
@@ -65,7 +65,12 @@ class Line2DEditorPlugin : public EditorPlugin {
 	GDCLASS( Line2DEditorPlugin, EditorPlugin )
 
 public:
-	virtual bool forward_canvas_input_event(const Transform2D& p_canvas_xform,const InputEvent& p_event) { return line2d_editor->forward_input_event(p_event); }
+	virtual bool forward_canvas_gui_input(
+			const Transform2D& p_canvas_xform,
+			const InputEvent& p_event)
+	{
+		return line2d_editor->forward_gui_input(p_event);
+	}
 
 	virtual String get_name() const { return "Line2D"; }
 	bool has_main_screen() const { return false; }


### PR DESCRIPTION
The Line2D editor was unresponsive, it needed to override the correct input function (which was renamed).
I also had to move a misplaced return statement which prevented point addition.