### PR TITLE
Windows: Close audiodriver sooner on exit

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1255,6 +1255,10 @@ void OS_Windows::finalize() {
 
 	main_loop=NULL;
 
+	for (int i = 0; i < get_audio_driver_count(); i++) {
+		AudioDriverManager::get_driver(i)->finish();
+	}
+
 	memdelete(joypad);
 	memdelete(input);
 
@@ -1282,13 +1286,8 @@ void OS_Windows::finalize() {
 	memdelete(physics_2d_server);
 
 	monitor_info.clear();
-
-	for (int i = 0; i < get_audio_driver_count(); i++)
-	{
-		AudioDriverManager::get_driver(i)->finish();
-	}
-
 }
+
 void OS_Windows::finalize_core() {
 
 	memdelete(process_map);


### PR DESCRIPTION
In #7839 I see the same error that was fixed in #7833 occuring on the
Windows platform. This moves the audio driver closing to the same place
in OS_Windows::finalize() as it is in OS_X11::finalize()

This fixes #7839