### PR TITLE
Cache DynamicFont resource for Android (2.1)

### DIFF
--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -29,6 +29,7 @@
 #ifdef FREETYPE_ENABLED
 #include "dynamic_font.h"
 #include "os/file_access.h"
+#include "os/os.h"
 
 bool DynamicFontData::CacheID::operator< (CacheID right) const{
 
@@ -106,6 +107,7 @@ DynamicFontData::~DynamicFontData()
 
 
 ////////////////////
+HashMap< String, Vector<uint8_t> > DynamicFontAtSize::_fontdata;
 
 Error DynamicFontAtSize::_load() {
 
@@ -115,7 +117,30 @@ Error DynamicFontAtSize::_load() {
 	ERR_EXPLAIN(TTR("Error initializing FreeType."));
 	ERR_FAIL_COND_V( error !=0, ERR_CANT_CREATE );
 
-	if (font->font_path!=String()) {
+	// FT_OPEN_STREAM is extremely slow only on Android.
+	if (OS::get_singleton()->get_name()=="Android" && font->font_mem==NULL && font->font_path!=String()) {
+		// cache font only once for each font->font_path
+		if (_fontdata.has(font->font_path)) {
+
+			font->set_font_ptr(_fontdata[font->font_path].ptr(), _fontdata[font->font_path].size());
+
+		} else {
+
+			FileAccess *f=FileAccess::open(font->font_path,FileAccess::READ);
+			ERR_FAIL_COND_V(!f,ERR_CANT_OPEN);
+
+			size_t len=f->get_len();
+			_fontdata[font->font_path]=Vector<uint8_t>();
+			Vector<uint8_t>& fontdata=_fontdata[font->font_path];
+			fontdata.resize(len);
+			f->get_buffer(fontdata.ptr(), len);
+			font->set_font_ptr(fontdata.ptr(), len);
+			f->close();
+
+		}
+	}
+
+	if (font->font_mem==NULL && font->font_path!=String()) {
 
 		FileAccess *f=FileAccess::open(font->font_path,FileAccess::READ);
 		ERR_FAIL_COND_V(!f,ERR_CANT_OPEN);

--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -140,7 +140,7 @@ friend class DynamicFontData;
 	DynamicFontData::CacheID id;
 
 
-
+	static HashMap< String, Vector<uint8_t> > _fontdata;
 	Error _load();
 protected:
 


### PR DESCRIPTION
Tested with 16.5MB otf font file
* NotoSansCJKkr-Medium.otf - https://www.google.com/get/noto/#sans-kore )

Measure time between changing scenes has Label with DynamicFont

First & Third scene
![screenshot from 2017-02-20 22-33-59](https://cloud.githubusercontent.com/assets/8281454/23127342/0bbba7fc-f7be-11e6-9edb-bd4729e8ff15.png)
Second scene
![screenshot from 2017-02-20 22-39-28](https://cloud.githubusercontent.com/assets/8281454/23127348/0efa92d4-f7be-11e6-855a-d58b84a0ab85.png)



test result with 2.1.2 official templates

Device  | first scene | second scene | third scene
--------|---------|--------|-------
PC-Linux|32ms     |11ms    |9ms
Nexus 6p |101,621ms|54,098ms|92,951ms
iPhone 4s | 451ms | 212ms | 183ms

test result with caching font (based on 2.1.2) ~~ON at Project Settings > Locale~~

Device  | first scene | second scene | third scene
--------|--------|--------|------
PC-Linux|103ms   |49ms    |46ms
Nexus 6p |258ms |53ms    |52ms
iPhone 4s | 498ms|170ms|145ms

Fix #7428

I will make for another PR for master after this accepted.
Because, I can't test on Android device with current master branch.

update : add iPhone 4s test result

edit : test result changed after changing a way to cache