### PR TITLE
Add flags parameter to Node.duplicate()

### DIFF
--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -53,6 +53,12 @@ public:
 		PAUSE_MODE_PROCESS
 	};
 
+	enum DuplicateFlags {
+
+		DUPLICATE_SIGNALS=1,
+		DUPLICATE_GROUPS=2,
+		DUPLICATE_SCRIPTS=4
+	};
 
 	struct Comparator {
 
@@ -139,7 +145,7 @@ private:
 
 	void _duplicate_signals(const Node* p_original,Node* p_copy) const;
 	void _duplicate_and_reown(Node* p_new_parent, const Map<Node*,Node*>& p_reown_map) const;
-	Node *_duplicate(bool p_use_instancing) const;
+	Node *_duplicate(bool p_use_instancing,int p_flags) const;
 
 	Array _get_children() const;
 	Array _get_groups() const;
@@ -278,7 +284,7 @@ public:
 
 	int get_position_in_parent() const;
 
-	Node *duplicate(bool p_use_instancing=false) const;
+	Node *duplicate(bool p_use_instancing=false,int p_flags=DUPLICATE_GROUPS|DUPLICATE_SIGNALS|DUPLICATE_SCRIPTS) const;
 	Node *duplicate_and_reown(const Map<Node*,Node*>& p_reown_map) const;
 
 	//Node *clone_tree() const;


### PR DESCRIPTION
to decide whether signals, groups and/or scripts should be set in the copied nodes or not; it's default value makes the method work as usual, that is, including everything. So **non-breaking change.**

(This is the version for _2.1_ of #7856.)

Motivation: my use case is to copy a hierarchy of nodes in a behaviorless fashion because I just want a visual copy of the original node so I can apply certain effects on it. With these flags I can control what kind of duplicate I want.

Furthermore, it avoids some error prints (which lag the game) about signals with targets outside the subtree being copied.

I believe more people will find this useful.