### PR TITLE
Add more options to Node.duplicate()

### DIFF
--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -54,6 +54,14 @@ public:
 		PAUSE_MODE_PROCESS
 	};
 
+	enum DuplicateFlags {
+
+		DUPLICATE_SIGNALS=1,
+		DUPLICATE_GROUPS=2,
+		DUPLICATE_SCRIPTS=4,
+		DUPLICATE_USE_INSTANCING=8
+	};
+
 	enum NetworkMode {
 
 		NETWORK_MODE_INHERIT,
@@ -177,7 +185,7 @@ private:
 
 	void _duplicate_signals(const Node* p_original,Node* p_copy) const;
 	void _duplicate_and_reown(Node* p_new_parent, const Map<Node*,Node*>& p_reown_map) const;
-	Node *_duplicate(bool p_use_instancing) const;
+	Node *_duplicate(int p_flags) const;
 
 	Array _get_children() const;
 	Array _get_groups() const;
@@ -332,7 +340,7 @@ public:
 
 	int get_position_in_parent() const;
 
-	Node *duplicate(bool p_use_instancing=false) const;
+	Node *duplicate(int p_flags=DUPLICATE_GROUPS|DUPLICATE_SIGNALS|DUPLICATE_SCRIPTS) const;
 	Node *duplicate_and_reown(const Map<Node*,Node*>& p_reown_map) const;
 
 	//Node *clone_tree() const;


### PR DESCRIPTION
to decide whether signals, groups and/or scripts should be set in the copied nodes or not; it's default value makes the method include everything, as usual.

For 2.1 I added a `flags` parameter to keep compatibility. But for _master_ I've taken the opportunity to convert the existing `use_instancing` parameter to a flag (`DUPLICATE_USE_INSTANCING`) which will make more expresive the scripts using it. Probably also a bit more cluttered so maybe the prefix should be changed to `DUP_`-.

(This is the version for _master_ of #7855.)

Motivation: my use case is to copy a hierarchy of nodes in a behaviorless fashion because I just want a visual copy of the original node so I can apply certain effects on it. With these flags I can control what kind of duplicate I want.

Furthermore, it avoids some error prints (which lag the game) about signals with targets outside the subtree being copied.

I believe more people will find this useful.