### PR TITLE
Don't switch to script on breakpoint hit when using external editor.

### DIFF
--- a/tools/editor/plugins/script_editor_plugin.cpp
+++ b/tools/editor/plugins/script_editor_plugin.cpp
@@ -292,6 +292,10 @@ String ScriptEditor::_get_debug_tooltip(const String&p_text,Node *_se) {
 
 void ScriptEditor::_breaked(bool p_breaked,bool p_can_debug) {
 
+	if (bool(EditorSettings::get_singleton()->get("text_editor/external/use_external_editor"))) {
+		return;
+	}
+
 	debug_menu->get_popup()->set_item_disabled( debug_menu->get_popup()->get_item_index(DEBUG_NEXT), !(p_breaked && p_can_debug));
 	debug_menu->get_popup()->set_item_disabled( debug_menu->get_popup()->get_item_index(DEBUG_STEP), !(p_breaked && p_can_debug) );
 	debug_menu->get_popup()->set_item_disabled( debug_menu->get_popup()->get_item_index(DEBUG_BREAK), p_breaked );


### PR DESCRIPTION
Fixes #7705