### PR TITLE
Better handling of joypad device IDs.

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -1214,6 +1214,15 @@ int InputDefault::get_joy_button_index_from_string(String p_button) {
 	ERR_FAIL_V(-1);
 }
 
+int InputDefault::get_unused_joy_id() {
+	for (int i=0;i<JOYPADS_MAX;i++) {
+		if (!joy_names.has(i) || !joy_names[i].connected) {
+			return i;
+		}
+	}
+	return -1;
+}
+
 String InputDefault::get_joy_axis_string(int p_axis) {
 	ERR_FAIL_INDEX_V(p_axis, JOY_AXIS_MAX, "");
 	return _axes[p_axis];

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -134,6 +134,11 @@ public:
 		HAT_LEFT,
 		HAT_MAX,
 	};
+
+	enum {
+		JOYPADS_MAX = 16,
+	};
+
 	struct JoyAxis {
 		int min;
 		float value;
@@ -242,6 +247,8 @@ public:
 	virtual String get_joy_axis_string(int p_axis);
 	virtual int    get_joy_axis_index_from_string(String p_axis);
 	virtual int    get_joy_button_index_from_string(String p_button);
+
+	int get_unused_joy_id();
 
 	bool is_joy_mapped(int p_device);
 	String get_joy_guid_remapped(int p_device) const;

--- a/platform/osx/joypad_osx.cpp
+++ b/platform/osx/joypad_osx.cpp
@@ -275,7 +275,6 @@ void JoypadOSX::_device_removed(int p_id) {
 	input->joy_connection_changed(p_id, false, "");
 	device_list[device].free();
 	device_list.remove(device);
-	attached_devices[p_id] = false;
 }
 
 static String _hex_str(uint8_t p_byte) {
@@ -307,7 +306,7 @@ bool JoypadOSX::configure_joypad(IOHIDDeviceRef p_device_ref, joypad* p_joy) {
 	}
 	name = c_name;
 
-	int id = get_free_joy_id();
+	int id = input->get_unused_joy_id();
 	ERR_FAIL_COND_V(id == -1, false);
 	p_joy->id = id;
 	int vendor = 0;
@@ -510,16 +509,6 @@ void JoypadOSX::joypad_vibration_stop(int p_id, uint64_t p_timestamp) {
 	FFEffectStop(joy->ff_object);
 }
 
-int JoypadOSX::get_free_joy_id() {
-	for (int i = 0; i < JOYPADS_MAX; i++) {
-		if (!attached_devices[i]) {
-			attached_devices[i] = true;
-			return i;
-		}
-	}
-	return -1;
-}
-
 int JoypadOSX::get_joy_index(int p_id) const {
 	for (int i = 0; i < device_list.size(); i++) {
 		if (device_list[i].id == p_id) return i;
@@ -581,10 +570,6 @@ JoypadOSX::JoypadOSX()
 {
 	self = this;
 	input = (InputDefault*)Input::get_singleton();
-
-	for (int i = 0; i < JOYPADS_MAX; i++) {
-		attached_devices[i] = false;
-	}
 
 	int okay = 1;
 	const void *vals[] = {

--- a/platform/osx/joypad_osx.h
+++ b/platform/osx/joypad_osx.h
@@ -95,14 +95,11 @@ private:
 	InputDefault *input;
 	IOHIDManagerRef hid_manager;
 
-	bool attached_devices[JOYPADS_MAX];
 	Vector<joypad> device_list;
 
 	bool have_device(IOHIDDeviceRef p_device) const;
 	bool configure_joypad(IOHIDDeviceRef p_device_ref, joypad *p_joy);
 
-
-	int get_free_joy_id();
 	int get_joy_index(int p_id) const;
 
 	void poll_joypads() const;

--- a/platform/windows/joypad.cpp
+++ b/platform/windows/joypad.cpp
@@ -87,16 +87,6 @@ bool JoypadWindows::have_device(const GUID &p_guid) {
 	return false;
 }
 
-int JoypadWindows::check_free_joy_slot() const {
-
-	for (int i = 0; i < JOYPADS_MAX; i++) {
-
-		if (!attached_joypads[i])
-			return i;
-	}
-	return -1;
-}
-
 
 // adapted from SDL2, works a lot better than the MSDN version
 bool JoypadWindows::is_xinput_device(const GUID *p_guid) {
@@ -146,7 +136,7 @@ bool JoypadWindows::is_xinput_device(const GUID *p_guid) {
 bool JoypadWindows::setup_dinput_joypad(const DIDEVICEINSTANCE* instance) {
 
 	HRESULT hr;
-	int num = check_free_joy_slot();
+	int num = input->get_unused_joy_id();
 
 	if (have_device(instance->guidInstance) || num == -1)
 		return false;
@@ -296,7 +286,7 @@ void JoypadWindows::probe_joypads() {
 		dwResult = xinput_get_state(i, &x_joypads[i].state);
 		if ( dwResult == ERROR_SUCCESS) {
 
-			int id = check_free_joy_slot();
+			int id = input->get_unused_joy_id();
 			if (id != -1 && !x_joypads[i].attached) {
 
 				x_joypads[i].attached = true;

--- a/platform/windows/joypad.h
+++ b/platform/windows/joypad.h
@@ -132,7 +132,6 @@ private:
 	void load_xinput();
 	void unload_xinput();
 
-	int check_free_joy_slot() const;
 	unsigned int post_hat(unsigned int p_last_id, int p_device, DWORD p_dpad);
 
 	bool have_device(const GUID &p_guid);

--- a/platform/x11/joypad_linux.cpp
+++ b/platform/x11/joypad_linux.cpp
@@ -219,15 +219,6 @@ void JoypadLinux::monitor_joypads() {
 	}
 }
 
-int JoypadLinux::get_free_joy_slot() const {
-
-	for (int i = 0; i < JOYPADS_MAX; i++) {
-
-		if (joypads[i].fd == -1) return i;
-	}
-	return -1;
-}
-
 int JoypadLinux::get_joy_from_path(String p_path) const {
 
 	for (int i = 0; i < JOYPADS_MAX; i++) {
@@ -329,7 +320,7 @@ void JoypadLinux::setup_joypad_properties(int p_id) {
 
 void JoypadLinux::open_joypad(const char *p_path) {
 
-	int joy_num = get_free_joy_slot();
+	int joy_num = input->get_unused_joy_id();
 	int fd = open(p_path, O_RDWR | O_NONBLOCK);
 	if (fd != -1 && joy_num != -1) {
 

--- a/platform/x11/joypad_linux.h
+++ b/platform/x11/joypad_linux.h
@@ -81,7 +81,6 @@ private:
 	static void joy_thread_func(void *p_user);
 
 	int get_joy_from_path(String path) const;
-	int get_free_joy_slot() const;
 
 	void setup_joypad_properties(int p_id);
 	void close_joypad(int p_id = -1);


### PR DESCRIPTION
Now `InputDefault` is responsible for giving out joypad device IDs to the platform, instead of each platform handling this itself.
This makes it possible for c++ modules to add their own "custom" gamepad devices without the risk of messing up events in case the user also has regular gamepads attached (using the OS code).
For now, it's implemented for the main desktop platforms.
Possible targets for future work: android, uwp, javascript