### PR TITLE
Web builds: Zip automatically; Fix on Windows; Parallel wasm/asm.js builds

### DIFF
--- a/platform/javascript/SCsub
+++ b/platform/javascript/SCsub
@@ -32,7 +32,7 @@ basename = "godot" + env["PROGSUFFIX"] # output file name without file extension
 # placeholder while leaving extension; also change `.html.mem` to just `.mem`
 fixup_html = env.Substfile(html_file, SUBST_DICT=[(basename, '$$GODOT_BASE'), ('.html.mem', '.mem')], SUBSTFILESUFFIX='.fixup.html')
 
-zip_dir = env.Dir('#bin/js_zip')
+zip_dir = env.Dir('#bin/.javascript_zip')
 zip_files = []
 js_file = env.SideEffect(html_file.File(basename+'.js'), html_file)
 zip_files.append(env.InstallAs(


### PR DESCRIPTION
This goes with my previous commits 335fdea581f677fea55d20f0e23b4c7d7c75664b and 6e2bf31e5a8f3dbe18e31b1aff9c26ee184ad8c8.
This commit in particular fixes WebAssembly builds on Windows.

These changes modify the build process for `platform=javascript` so that no manual zipping is necessary, the output is a `godot.opt(.debug)(.webassembly).zip` file that must only be renamed to either `javascript_release.zip` or `javascript_debug.zip`.

Also correctly sets the unique suffix for WebAssembly build files, so it's possible to switch between building asm.js and WebAssembly without completely rebuilding every time.

Also fix building WebAssembly and asm.js on Windows
Actually building and running 3.0 web builds is not yet working though, see #7689