### PR TITLE
Fix crash if TouchScreenButton is pressed while exiting the tree (2.1)

### DIFF
--- a/scene/2d/screen_button.cpp
+++ b/scene/2d/screen_button.cpp
@@ -308,12 +308,14 @@ void TouchScreenButton::_release(bool p_exiting_tree) {
 	if (action_id!=-1) {
 
 		Input::get_singleton()->action_release(action);
-		InputEvent ie;
-		ie.type=InputEvent::ACTION;
-		ie.ID=0;
-		ie.action.action=action_id;
-		ie.action.pressed=false;
-		get_tree()->input_event(ie);
+		if (!p_exiting_tree) {
+			InputEvent ie;
+			ie.type=InputEvent::ACTION;
+			ie.ID=0;
+			ie.action.action=action_id;
+			ie.action.pressed=false;
+			get_tree()->input_event(ie);
+		}
 	}
 
 	if (!p_exiting_tree) {


### PR DESCRIPTION
Now only the action in the input map is released, but an action release event is not sent to avoid a crash as  explained at #7867.

Anyway, as far as I remember, that is the same thing the original code was doing and I find it to be the correct way.