### PR TITLE
Fix crash when click icon while editing node name (2.1)

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -833,6 +833,7 @@ void Tree::update_cache() {
 	cache.title_button_color = get_color("title_button_color");
 
 	v_scroll->set_custom_step(cache.font->get_height());
+	cache.click_item=get_selected();
 
 }
 


### PR DESCRIPTION
Fix #7820 