### PR TITLE
Fix auto-enable of _input processing when _input() method is set.

### DIFF
--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -115,6 +115,7 @@ SceneStringNames::SceneStringNames() {
 	_area_enter_tree = StaticCString::create("_area_enter_tree");
 	_area_exit_tree = StaticCString::create("_area_exit_tree");
 
+	_input = StaticCString::create("_input");
 	_input_event=StaticCString::create("_input_event");
 
 	gui_input=StaticCString::create("gui_input");


### PR DESCRIPTION
Since f3f4a11c processing of callbacks such as `_process`, `_fixed_process`, etc will be
automatically enabled when the corresponding method is found in the script.
However, for _input() this wasn't working.
That's simply because `_input` wasn't initialized in `SceneStringNames` ^^