### PR TITLE
Add process mode option to Particles2D (2.1)

### DIFF
--- a/scene/2d/particles_2d.h
+++ b/scene/2d/particles_2d.h
@@ -111,6 +111,11 @@ public:
 		MAX_COLOR_PHASES=4
 	};
 
+	enum ProcessMode {
+		PROCESS_FIXED,
+		PROCESS_IDLE,
+	};
+
 private:
 
 	float param[PARAM_MAX];
@@ -154,6 +159,8 @@ private:
 	Vector2 extents;
 	DVector<Vector2> emission_points;
 
+	ProcessMode process_mode;
+
 	float time;
 	int active_count;
 
@@ -178,6 +185,9 @@ public:
 
 	void set_emitting(bool p_emitting);
 	bool is_emitting() const;
+
+	void set_process_mode(ProcessMode p_mode);
+	ProcessMode get_process_mode() const;
 
 	void set_amount(int p_amount);
 	int get_amount() const;
@@ -255,6 +265,7 @@ public:
 	Particles2D();
 };
 
+VARIANT_ENUM_CAST( Particles2D::ProcessMode );
 VARIANT_ENUM_CAST( Particles2D::Parameter );
 
 #endif // PARTICLES_FRAME_H


### PR DESCRIPTION
Regarding 3D particles, the code for processing them is tightly coupled with the rasterizer's so a counterpartish change is not possible.

~~Regarding _master_, this could get revised for 2D and 3D particles so I think there is no need currently.~~
EDIT: Anyway I'm submitting one as @akien-mga uses to advise.