### PR TITLE
Add process mode option to Particles2D

### DIFF
--- a/scene/2d/particles_2d.cpp
+++ b/scene/2d/particles_2d.cpp
@@ -452,7 +452,7 @@ void Particles2D::_process_particles(float p_delta) {
 	time=Math::fmod( time+frame_time, lifetime );
 	if (!emitting && active_count==0) {
 		set_process(false);
-
+		set_fixed_process(false);
 	}
 
 	update();
@@ -468,6 +468,11 @@ void Particles2D::_notification(int p_what) {
 		case NOTIFICATION_PROCESS: {
 
 			_process_particles( get_process_delta_time() );
+		} break;
+
+		case NOTIFICATION_FIXED_PROCESS: {
+
+			_process_particles( get_fixed_process_delta_time() );
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
@@ -695,7 +700,8 @@ void Particles2D::set_emitting(bool p_emitting) {
 
 		if (active_count==0)
 			time=0;
-		set_process(true);
+		set_process(process_mode==PROCESS_IDLE);
+		set_fixed_process(process_mode==PROCESS_FIXED);
 		time_to_live = emit_timeout;
 	};
 	emitting=p_emitting;
@@ -705,6 +711,19 @@ void Particles2D::set_emitting(bool p_emitting) {
 bool Particles2D::is_emitting() const {
 
 	return emitting;
+}
+
+void Particles2D::set_process_mode(ProcessMode p_mode) {
+
+	process_mode=p_mode;
+	const bool should_process=emitting || active_count!=0;
+	set_process(should_process && process_mode==PROCESS_IDLE);
+	set_fixed_process(should_process && process_mode==PROCESS_FIXED);
+}
+
+Particles2D::ProcessMode Particles2D::get_process_mode() const {
+
+	return process_mode;
 }
 
 void Particles2D::set_amount(int p_amount) {
@@ -1020,6 +1039,9 @@ void Particles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_emitting","active"),&Particles2D::set_emitting);
 	ClassDB::bind_method(D_METHOD("is_emitting"),&Particles2D::is_emitting);
 
+	ClassDB::bind_method(D_METHOD("set_process_mode","mode"),&Particles2D::set_process_mode);
+	ClassDB::bind_method(D_METHOD("get_process_mode"),&Particles2D::get_process_mode);
+
 	ClassDB::bind_method(D_METHOD("set_amount","amount"),&Particles2D::set_amount);
 	ClassDB::bind_method(D_METHOD("get_amount"),&Particles2D::get_amount);
 
@@ -1098,6 +1120,7 @@ void Particles2D::_bind_methods() {
 	ADD_PROPERTYNZ(PropertyInfo(Variant::REAL,"config/preprocess",PROPERTY_HINT_EXP_RANGE,"0.1,3600,0.1"),"set_pre_process_time","get_pre_process_time") ;
 	ADD_PROPERTYNZ(PropertyInfo(Variant::REAL,"config/emit_timeout",PROPERTY_HINT_RANGE,"0,3600,0.1"),"set_emit_timeout","get_emit_timeout") ;
 	ADD_PROPERTYNO(PropertyInfo(Variant::BOOL,"config/emitting"),"set_emitting","is_emitting") ;
+	ADD_PROPERTY(PropertyInfo(Variant::INT,"config/process_mode",PROPERTY_HINT_ENUM, "Fixed,Idle"),"set_process_mode","get_process_mode");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::VECTOR2,"config/offset"),"set_emissor_offset","get_emissor_offset");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::VECTOR2,"config/half_extents"),"set_emission_half_extents","get_emission_half_extents");
 	ADD_PROPERTYNO(PropertyInfo(Variant::BOOL,"config/local_space"),"set_use_local_space","is_using_local_space");
@@ -1180,6 +1203,7 @@ Particles2D::Particles2D() {
 	particles.resize(32);
 	active_count=-1;
 	set_emitting(true);
+	process_mode=PROCESS_IDLE;
 	local_space=true;
 	preprocess=0;
 	time_scale=1.0;

--- a/scene/2d/particles_2d.h
+++ b/scene/2d/particles_2d.h
@@ -111,6 +111,11 @@ public:
 		MAX_COLOR_PHASES=4
 	};
 
+	enum ProcessMode {
+		PROCESS_FIXED,
+		PROCESS_IDLE,
+	};
+
 private:
 
 	float param[PARAM_MAX];
@@ -153,6 +158,8 @@ private:
 	Vector2 extents;
 	PoolVector<Vector2> emission_points;
 
+	ProcessMode process_mode;
+
 	float time;
 	int active_count;
 
@@ -177,6 +184,9 @@ public:
 
 	void set_emitting(bool p_emitting);
 	bool is_emitting() const;
+
+	void set_process_mode(ProcessMode p_mode);
+	ProcessMode get_process_mode() const;
 
 	void set_amount(int p_amount);
 	int get_amount() const;
@@ -254,6 +264,7 @@ public:
 	Particles2D();
 };
 
+VARIANT_ENUM_CAST( Particles2D::ProcessMode );
 VARIANT_ENUM_CAST( Particles2D::Parameter );
 
 #endif // PARTICLES_FRAME_H


### PR DESCRIPTION
Regarding 3D particles, the code for processing them is tightly coupled with the rasterizer's so a counterpartish change is not possible.