### PR TITLE
Fix failing build when ALSA is absent

### DIFF
--- a/platform/x11/godot_x11.cpp
+++ b/platform/x11/godot_x11.cpp
@@ -28,6 +28,7 @@
 /*************************************************************************/
 #include <unistd.h>
 #include <limits.h>
+#include <stdlib.h>
 
 #include "main/main.h"
 #include "os_x11.h"


### PR DESCRIPTION
There was an error about undeclared malloc()+free() when lib64alsa-devel was not installed. If ALSA is installed, then the ALSA headers provide <stdlib.h> so the problem is gone. Here are some relevant IRC logs:

```
<rindolf> Hi all.
<rindolf> Akien: does the build on mgav6 succeed for you without this commit - https://github.com/shlomif/godot/tree/fix-build-compile-error ?
* Giacom has quit (Ping timeout: 268 seconds)
<Akien> rindolf: Let me check, I built yesterday but maybe it was just before I merged that PR.
<Akien> TMM: See https://github.com/shlomif/godot/tree/fix-build-compile-error
<rindolf> Akien: thanks
<Akien> rindolf: It builds fine for me on mga6 x86_64
<Akien> With `scons p=x11 -j3`
<rindolf> Akien: ah
<rindolf> Akien: which branch - mine or master?
<Akien> rindolf: In master
<rindolf> Akien: oh
<Akien> Well upstream/master
<rindolf> Akien: hmmm
<rindolf> Akien: i'm still getting the build failure with scons platform=x11 2>&1 | tee ~/godot.build.txt
<Akien> I'll try a build from scratch
<rindolf> Akien: it seems to be fine here after I install the --buildrequires of godot
<Akien> Ah?
<rindolf> Akien: maybe there was a missing dep,
<Akien> What was the missing dep?
<rindolf> Akien: let me bisect
<rindolf> Akien: it happens with lib64alsa2-devel lib64theora-devel missing
<Akien> rindolf: It's peculiar that it would then be fixed by including stdlib.h
<Akien> Unless alsa includes it in its headers and so it happens to be there when needed by Godot
<rindolf> Akien: well, stdlib.h contains malloc() and free()
<Akien> And yeah, <alsa/asoundlib.h> includes <stdlib.h>
<Akien> So your patch seems necessary indeed
<rindolf> Akien: ah, shall I submit a pull-req?
<Akien> rindolf: sure.
<rindolf> Akien: ok
```