### PR TITLE
Implement time scaling for the rasterizer (2.1)

### DIFF
--- a/drivers/gles2/rasterizer_gles2.h
+++ b/drivers/gles2/rasterizer_gles2.h
@@ -1250,6 +1250,7 @@ class RasterizerGLES2 : public Rasterizer {
 	Size2 window_size;
 	VS::ViewportRect viewport;
 	double last_time;
+	double scaled_time;
 	double time_delta;
 	uint64_t frame;
 	uint64_t scene_pass;
@@ -1258,6 +1259,7 @@ class RasterizerGLES2 : public Rasterizer {
 	VS::ScenarioDebugMode current_debug;
 	RID overdraw_material;
 	float shader_time_rollback;
+	float time_scale;
 
 	mutable MaterialShaderGLES2 material_shader;
 	mutable CanvasShaderGLES2 canvas_shader;
@@ -1651,6 +1653,8 @@ public:
 	virtual bool is_shader(const RID &p_rid) const;
 
 	virtual bool is_canvas_light_occluder(const RID &p_rid) const;
+
+	virtual void set_time_scale(float p_scale);
 
 	virtual void free(const RID &p_rid);
 

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -1046,6 +1046,8 @@ public:
 
 	virtual bool is_canvas_light_occluder(const RID &p_rid) const = 0;
 
+	virtual void set_time_scale(float p_scale) = 0;
+
 	virtual void free(const RID &p_rid) = 0;
 
 	virtual void init() = 0;

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -7016,6 +7016,11 @@ Color VisualServerRaster::get_default_clear_color() const {
 	return clear_color;
 }
 
+void VisualServerRaster::set_time_scale(float p_scale) {
+
+	rasterizer->set_time_scale(p_scale);
+}
+
 void VisualServerRaster::set_boot_image(const Image &p_image, const Color &p_color, bool p_scale) {
 
 	if (p_image.empty())

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -1257,6 +1257,8 @@ public:
 	virtual void set_default_clear_color(const Color &p_color);
 	virtual Color get_default_clear_color() const;
 
+	virtual void set_time_scale(float p_scale);
+
 	VisualServerRaster(Rasterizer *p_rasterizer);
 	~VisualServerRaster();
 };

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -688,6 +688,7 @@ public:
 	FUNC3(set_boot_image, const Image &, const Color &, bool);
 	FUNC1(set_default_clear_color, const Color &);
 	FUNC0RC(Color, get_default_clear_color);
+	FUNC1(set_time_scale, float);
 
 	FUNC0R(RID, get_test_cube);
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -534,6 +534,8 @@ void VisualServer::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_default_clear_color"), &VisualServer::set_default_clear_color);
 	ObjectTypeDB::bind_method(_MD("get_default_clear_color"), &VisualServer::get_default_clear_color);
 
+	ObjectTypeDB::bind_method(_MD("set_time_scale"), &VisualServer::set_time_scale);
+
 	ObjectTypeDB::bind_method(_MD("get_render_info"), &VisualServer::get_render_info);
 
 	BIND_CONSTANT(NO_INDEX_ARRAY);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -1137,6 +1137,8 @@ public:
 	virtual void set_default_clear_color(const Color &p_color) = 0;
 	virtual Color get_default_clear_color() const = 0;
 
+	virtual void set_time_scale(float p_scale) = 0;
+
 	enum Features {
 		FEATURE_SHADERS,
 		FEATURE_MULTITHREADED,


### PR DESCRIPTION
Useful for instance if your game features some effects dependant on time and you want them to freeze during pause.