### PR TITLE
Implement time scaling for the rasterizer

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -195,18 +195,18 @@ void RasterizerGLES3::begin_frame() {
 
 	uint64_t tick = OS::get_singleton()->get_ticks_usec();
 
-	double time_total = double(tick) / 1000000.0;
-
-	storage->frame.time[0] = time_total;
-	storage->frame.time[1] = Math::fmod(time_total, 3600);
-	storage->frame.time[2] = Math::fmod(time_total, 900);
-	storage->frame.time[3] = Math::fmod(time_total, 60);
-	storage->frame.count++;
-	storage->frame.delta = double(tick - storage->frame.prev_tick) / 1000000.0;
-	if (storage->frame.prev_tick == 0) {
+	if (storage->frame.prev_tick != 0) {
+		storage->frame.delta = time_scale * double(tick - storage->frame.prev_tick) / 1000000.0;
+	} else {
 		//to avoid hiccups
-		storage->frame.delta = 0.001;
+		storage->frame.delta = 0;
 	}
+
+	storage->frame.time[0] += storage->frame.delta;
+	storage->frame.time[1] = Math::fmod(storage->frame.time[0], 3600);
+	storage->frame.time[2] = Math::fmod(storage->frame.time[1], 900);
+	storage->frame.time[3] = Math::fmod(storage->frame.time[2], 60);
+	storage->frame.count++;
 
 	storage->frame.prev_tick = tick;
 
@@ -383,6 +383,11 @@ void RasterizerGLES3::end_frame() {
 */
 }
 
+void RasterizerGLES3::set_time_scale(float p_scale) {
+
+	time_scale = p_scale;
+}
+
 void RasterizerGLES3::finalize() {
 
 	storage->finalize();
@@ -415,6 +420,7 @@ RasterizerGLES3::RasterizerGLES3() {
 	storage->canvas = canvas;
 	scene->storage = storage;
 	storage->scene = scene;
+	time_scale = 1.0f;
 }
 
 RasterizerGLES3::~RasterizerGLES3() {

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -43,6 +43,8 @@ class RasterizerGLES3 : public Rasterizer {
 	RasterizerCanvasGLES3 *canvas;
 	RasterizerSceneGLES3 *scene;
 
+	float time_scale;
+
 public:
 	virtual RasterizerStorage *get_storage();
 	virtual RasterizerCanvas *get_canvas();
@@ -57,6 +59,7 @@ public:
 	virtual void clear_render_target(const Color &p_color);
 	virtual void blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen = 0);
 	virtual void end_frame();
+	virtual void set_time_scale(float p_scale);
 	virtual void finalize();
 
 	static void make_current();

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -6731,6 +6731,7 @@ void RasterizerStorageGLES3::initialize() {
 	glEnable(_EXT_TEXTURE_CUBE_MAP_SEAMLESS);
 #endif
 
+	frame.time[0] = 0;
 	frame.count = 0;
 	frame.prev_tick = 0;
 	frame.delta = 0;

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1307,7 +1307,7 @@ public:
 		bool clear_request;
 		Color clear_request_color;
 		int canvas_draw_commands;
-		float time[4];
+		double time[4];
 		float delta;
 		uint64_t prev_tick;
 		uint64_t count;

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -955,6 +955,7 @@ public:
 	virtual void clear_render_target(const Color &p_color) = 0;
 	virtual void blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen = 0) = 0;
 	virtual void end_frame() = 0;
+	virtual void set_time_scale(float p_scale) = 0;
 	virtual void finalize() = 0;
 
 	virtual ~Rasterizer() {}

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -1132,6 +1132,10 @@ public:
 	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale);
 	virtual void set_default_clear_color(const Color &p_color);
 
+#undef BINDBASE
+#define BINDBASE VSG::rasterizer
+	BIND1(set_time_scale, float)
+
 	virtual bool has_feature(Features p_feature) const;
 
 	virtual bool has_os_feature(const String &p_feature) const;

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -559,6 +559,7 @@ public:
 
 	FUNC3(set_boot_image, const Ref<Image> &, const Color &, bool)
 	FUNC1(set_default_clear_color, const Color &)
+	FUNC1(set_time_scale, float)
 
 	FUNC0R(RID, get_test_cube)
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1482,6 +1482,8 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("texture_get_height"), &VisualServer::texture_get_height);
 
 	ClassDB::bind_method(D_METHOD("texture_set_shrink_all_x2_on_set_data", "shrink"), &VisualServer::texture_set_shrink_all_x2_on_set_data);
+
+	ClassDB::bind_method(D_METHOD("set_time_scale"), &VisualServer::set_time_scale);
 }
 
 void VisualServer::_canvas_item_add_style_box(RID p_item, const Rect2 &p_rect, const Rect2 &p_source, RID p_texture, const Vector<float> &p_margins, const Color &p_modulate) {

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -924,6 +924,7 @@ public:
 
 	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale) = 0;
 	virtual void set_default_clear_color(const Color &p_color) = 0;
+	virtual void set_time_scale(float p_scale) = 0;
 
 	enum Features {
 		FEATURE_SHADERS,


### PR DESCRIPTION
~~Disabled by default.~~

Useful for instance if your game features some effects dependant on time and you want them to freeze during pause.

_Disclaimer: I've done my best to adapt this to the 3.0 style. I implemented this initially for 2.1 so I'm not sure if this is the right way. Someone should have a look._

~~Also committed the changes for 2.1 for historic reasons.~~