### PR TITLE
TabContainer's signal changes (v3)

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -40626,9 +40626,16 @@
 			<return type="int">
 			</return>
 			<description>
-				Return the current tab that is being showed.
+				Return the current tab index that is being shown.
 			</description>
 		</method>
+		<method name="get_previous_tab" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Return the previous tab index that was being shown.
+ 			</description>
+ 		</method>
 		<method name="get_current_tab_control" qualifiers="const">
 			<return type="Control">
 			</return>
@@ -40654,6 +40661,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
+				Return the current tab control that is being shown.
 			</description>
 		</method>
 		<method name="get_tab_count" qualifiers="const">
@@ -40735,7 +40743,14 @@
 			<argument index="0" name="tab" type="int">
 			</argument>
 			<description>
-				Emitted when the current tab changes.
+				Emitted only when the current tab changes.
+			</description>
+		</signal>
+			<signal name="tab_selected">
+			<argument index="0" name="tab" type="int">
+			</argument>
+			<description>
+				Emitted when a tab is being selected, even if it is the same tab.
 			</description>
 		</signal>
 	</signals>

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -371,6 +371,7 @@ void TabContainer::add_child_notify(Node *p_child) {
 		//call_deferred("set_current_tab",0);
 		first = true;
 		current = 0;
+		previous = 0;
 	}
 	c->set_area_as_parent_rect();
 	if (tabs_visible)
@@ -396,6 +397,7 @@ void TabContainer::set_current_tab(int p_current) {
 
 	ERR_FAIL_INDEX(p_current, get_tab_count());
 
+	int pending_previous = current;
 	current = p_current;
 
 	Ref<StyleBox> sb = get_stylebox("panel");
@@ -412,18 +414,32 @@ void TabContainer::set_current_tab(int p_current) {
 				c->set_margin(Margin(i), c->get_margin(Margin(i)) + sb->get_margin(Margin(i)));
 
 
-		} else
+		}
+		else
 			c->hide();
 	}
 
 	_change_notify("current_tab");
-	emit_signal("tab_changed", current);
+
+	if (pending_previous == current)
+		emit_signal("tab_selected", current);
+	else {
+		previous = pending_previous;
+		emit_signal("tab_selected", current);
+		emit_signal("tab_changed", current);
+	}
+
 	update();
 }
 
 int TabContainer::get_current_tab() const {
 
 	return current;
+}
+
+int TabContainer::get_previous_tab() const {
+	
+		return previous;
 }
 
 Control* TabContainer::get_tab_control(int p_idx) const {
@@ -434,6 +450,7 @@ Control* TabContainer::get_tab_control(int p_idx) const {
 	else
 		return NULL;
 }
+
 Control* TabContainer::get_current_tab_control() const {
 
 	Vector<Control*> tabs = _get_tabs();
@@ -501,7 +518,6 @@ bool TabContainer::are_tabs_visible() const {
 
 }
 
-
 Control *TabContainer::_get_tab(int p_idx) const {
 
 	return get_tab_control(p_idx);
@@ -551,6 +567,7 @@ void TabContainer::set_tab_disabled(int p_tab, bool p_enabled) {
 	child->set_meta("_tab_disabled", p_enabled);
 	update();
 }
+
 bool TabContainer::get_tab_disabled(int p_tab) const {
 
 	Control *child = _get_tab(p_tab);
@@ -577,7 +594,6 @@ void TabContainer::get_translatable_strings(List<String> *p_strings) const {
 			p_strings->push_back(name);
 	}
 }
-
 
 Size2 TabContainer::get_minimum_size() const {
 
@@ -620,13 +636,13 @@ Popup* TabContainer::get_popup() const {
 	return popup;
 }
 
-
 void TabContainer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_gui_input"), &TabContainer::_gui_input);
 	ClassDB::bind_method(D_METHOD("get_tab_count"), &TabContainer::get_tab_count);
 	ClassDB::bind_method(D_METHOD("set_current_tab", "tab_idx"), &TabContainer::set_current_tab);
 	ClassDB::bind_method(D_METHOD("get_current_tab"), &TabContainer::get_current_tab);
+	ClassDB::bind_method(D_METHOD("get_previous_tab"), &TabContainer::get_previous_tab);
 	ClassDB::bind_method(D_METHOD("get_current_tab_control:Control"), &TabContainer::get_current_tab_control);
 	ClassDB::bind_method(D_METHOD("get_tab_control:Control", "idx"), &TabContainer::get_tab_control);
 	ClassDB::bind_method(D_METHOD("set_tab_align", "align"), &TabContainer::set_tab_align);
@@ -645,6 +661,7 @@ void TabContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_child_renamed_callback"), &TabContainer::_child_renamed_callback);
 
 	ADD_SIGNAL(MethodInfo("tab_changed", PropertyInfo(Variant::INT, "tab")));
+	ADD_SIGNAL(MethodInfo("tab_selected", PropertyInfo(Variant::INT, "tab")));
 	ADD_SIGNAL(MethodInfo("pre_popup_pressed"));
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tab_align", PROPERTY_HINT_ENUM, "Left,Center,Right"), "set_tab_align", "get_tab_align");
@@ -659,6 +676,7 @@ TabContainer::TabContainer() {
 	buttons_visible_cache = false;
 	tabs_ofs_cache = 0;
 	current = 0;
+	previous = 0;
 	mouse_x_cache = 0;
 	align = ALIGN_CENTER;
 	tabs_visible = true;

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -50,6 +50,7 @@ private:
 	int tabs_ofs_cache;
 	int last_tab_cache;
 	int current;
+	int previous;
 	bool tabs_visible;
 	bool buttons_visible_cache;
 	TabAlign align;
@@ -91,6 +92,7 @@ public:
 	int get_tab_count() const;
 	void set_current_tab(int p_current);
 	int get_current_tab() const;
+	int get_previous_tab() const;
 
 	Control* get_tab_control(int p_idx) const;
 	Control* get_current_tab_control() const;


### PR DESCRIPTION
- `tab_changed` signal emits only by selecting a different tab.
- Added `tab_selected` signal. Which emits a signal by selecting any tab, even if current tab is being selected again.
- Added `get_previous_tab()`. Which returns the previous shown tab index. **Note:** only `tab_changed` can modify previous tab index.
- Add documentation for the added function and signals. Fix a typo too.
- Fix #7752 