### PR TITLE
Fix RANDOM_MAX, which is 2^32-1 with PCG32.

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -50,7 +50,7 @@ public:
 	Math() {} // useless to instance
 
 	enum {
-		RANDOM_MAX=2147483647L
+		RANDOM_MAX=4294967295L
 	};
 
 


### PR DESCRIPTION
It seems that Math::RANDOM_MAX wasn't updated when the RNG implementation changed. Currently, randf() generates numbers out of the 0..1 range. This change fixes this issue.