### PR TITLE
Added a SceneTree.is_network_peer_present, closes #7922

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -35451,6 +35451,13 @@
 				Returns true if this SceneTree's [NetworkedMultiplayerPeer] is in server mode (listening for connections).
 			</description>
 		</method>
+		<method name="has_network_peer" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+				Returns true if there is a [NetworkedMultiplayerPeer] set (with [method SceneTree.set_network_peer]).
+			</description>
+		</method>
 		<method name="is_paused" qualifiers="const">
 			<return type="bool">
 			</return>

--- a/scene/main/scene_main_loop.cpp
+++ b/scene/main/scene_main_loop.cpp
@@ -1803,6 +1803,10 @@ bool SceneTree::is_network_server() const {
 
 }
 
+bool SceneTree::has_network_peer() const {
+	return network_peer.is_valid();
+}
+
 int SceneTree::get_network_unique_id() const {
 
 	ERR_FAIL_COND_V(!network_peer.is_valid(),0);
@@ -2310,6 +2314,7 @@ void SceneTree::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_network_peer","peer:NetworkedMultiplayerPeer"),&SceneTree::set_network_peer);
 	ClassDB::bind_method(D_METHOD("is_network_server"),&SceneTree::is_network_server);
+	ClassDB::bind_method(D_METHOD("has_network_peer"),&SceneTree::has_network_peer);
 	ClassDB::bind_method(D_METHOD("get_network_unique_id"),&SceneTree::get_network_unique_id);
 	ClassDB::bind_method(D_METHOD("set_refuse_new_network_connections","refuse"),&SceneTree::set_refuse_new_network_connections);
 	ClassDB::bind_method(D_METHOD("is_refusing_new_network_connections"),&SceneTree::is_refusing_new_network_connections);

--- a/scene/main/scene_main_loop.h
+++ b/scene/main/scene_main_loop.h
@@ -447,6 +447,7 @@ public:
 
 	void set_network_peer(const Ref<NetworkedMultiplayerPeer>& p_network_peer);
 	bool is_network_server() const;
+	bool has_network_peer() const;
 	int get_network_unique_id() const;
 
 	void set_refuse_new_network_connections(bool p_refuse);


### PR DESCRIPTION
A PR that fixes #7922
Adding a simple function `SceneTree.is_network_peer_present` that checks if a valid peer has been set. Especially useful when making a mixed singleplayer/multiplayer game, where a check should be made before rpc-ing.