### PR TITLE
Fix wrong TreeItem reference after reconstructing (2.1)

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -833,7 +833,6 @@ void Tree::update_cache() {
 	cache.title_button_color = get_color("title_button_color");
 
 	v_scroll->set_custom_step(cache.font->get_height());
-	cache.click_item=get_selected();
 
 }
 
@@ -1581,6 +1580,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos,int x_ofs,int y_ofs,bool p_
 				cache.click_id=c.buttons[j].id;
 				cache.click_item=p_item;
 				cache.click_column=col;
+				cache.click_pos=get_global_mouse_pos()-get_global_pos();
 				update();
 				//emit_signal("button_pressed");
 				return -1;
@@ -2352,6 +2352,8 @@ void Tree::_input_event(InputEvent p_event) {
 
 
 					if (cache.click_type==Cache::CLICK_BUTTON) {
+						// make sure in case of wrong reference after reconstructing whole TreeItems
+						cache.click_item=get_item_at_pos(cache.click_pos);
 						emit_signal("button_pressed",cache.click_item,cache.click_column,cache.click_id);
 
 					}
@@ -2937,7 +2939,6 @@ void Tree::clear() {
 	selected_item=NULL;
 	edited_item=NULL;
 	popup_edited_item=NULL;
-	selected_item=NULL;
 
 	update();
 };

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -405,6 +405,7 @@ friend class TreeItem;
 		TreeItem *click_item;
 		int click_column;
 		int hover_index;
+		Point2 click_pos;
 
 	} cache;
 


### PR DESCRIPTION
Fix #7902 

![7902](https://cloud.githubusercontent.com/assets/8281454/23522237/961ced84-ffc5-11e6-9e85-19f64a4b50ba.gif)
