### PR TITLE
Resizable editor / project settings dialogs & save their bounds

### DIFF
--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -36,6 +36,34 @@ void WindowDialog::_post_popup() {
 	drag_type = DRAG_NONE; // just in case
 }
 
+void WindowDialog::_fix_size() {
+
+	// Perhaps this should be called when the viewport resizes aswell or windows go out of bounds...
+
+	// Ensure the whole window is visible.
+	Point2i pos = get_global_pos();
+	Size2i size = get_size();
+	Size2i viewport_size = get_viewport_rect().size;
+	
+	// Windows require additional padding to keep the window chrome visible.
+	Ref<StyleBox> panel = get_stylebox("panel", "WindowDialog");
+	float top = panel->get_margin(MARGIN_TOP);
+	float left = panel->get_margin(MARGIN_LEFT);
+	float bottom = panel->get_margin(MARGIN_BOTTOM);
+	float right = panel->get_margin(MARGIN_RIGHT);
+
+	pos.x = MAX(left, MIN(pos.x, viewport_size.x - size.x - right));
+	pos.y = MAX(top, MIN(pos.y, viewport_size.y - size.y - bottom));
+	set_global_pos(pos);
+
+	// Also resize the window to fit if a resize should be possible at all.
+	if (resizable) {
+		size.x = MIN(size.x, viewport_size.x - left - right);
+		size.y = MIN(size.y, viewport_size.y - top - bottom);
+		set_size(size);
+	}
+}
+
 bool WindowDialog::has_point(const Point2& p_point) const {
 
 	Rect2 r(Point2(), get_size());

--- a/scene/gui/dialogs.h
+++ b/scene/gui/dialogs.h
@@ -66,7 +66,7 @@ class WindowDialog : public Popup {
 
 protected:
 	virtual void _post_popup();
-
+	virtual void _fix_size();
 	virtual void _close_pressed()  {}
 	virtual bool has_point(const Point2& p_point) const;
 	void _notification(int p_what);

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -226,12 +226,16 @@ void Popup::popup_centered_ratio(float p_screen_ratio) {
 
 }
 
-void Popup::popup() {
+void Popup::popup(const Rect2& bounds) {
 
 	emit_signal("about_to_show");
 	show_modal(exclusive);
 
-
+	// Fit the popup into the optionally provided bounds.
+	if (!bounds.has_no_area()) {
+		set_pos(bounds.pos);
+		set_size(bounds.size);
+	}
 	_fix_size();
 
 	Control *focusable = find_next_valid_focus();
@@ -260,7 +264,7 @@ void Popup::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("popup_centered","size"),&Popup::popup_centered,DEFVAL(Size2()));
 	ClassDB::bind_method(D_METHOD("popup_centered_ratio","ratio"),&Popup::popup_centered_ratio,DEFVAL(0.75));
 	ClassDB::bind_method(D_METHOD("popup_centered_minsize","minsize"),&Popup::popup_centered_minsize,DEFVAL(Size2()));
-	ClassDB::bind_method(D_METHOD("popup"),&Popup::popup);
+	ClassDB::bind_method(D_METHOD("popup","bounds"),&Popup::popup,DEFVAL(Rect2()));
 	ClassDB::bind_method(D_METHOD("set_exclusive","enable"),&Popup::set_exclusive);
 	ClassDB::bind_method(D_METHOD("is_exclusive"),&Popup::is_exclusive);
 	ADD_SIGNAL( MethodInfo("about_to_show") );

--- a/scene/gui/popup.h
+++ b/scene/gui/popup.h
@@ -47,7 +47,7 @@ protected:
 
 	void _gui_input(InputEvent p_event);
 	void _notification(int p_what);
-	void _fix_size();
+	virtual void _fix_size();
 	static void _bind_methods();
 public:
 
@@ -63,7 +63,7 @@ public:
 	void popup_centered(const Size2& p_size=Size2());
 	void popup_centered_minsize(const Size2& p_minsize=Size2());
 	void set_as_minsize();
-	virtual void popup();
+	virtual void popup(const Rect2& p_bounds=Rect2());
 
 	virtual String get_configuration_warning() const;
 

--- a/tools/editor/project_export.cpp
+++ b/tools/editor/project_export.cpp
@@ -46,10 +46,14 @@
 
 void ProjectExportDialog::_notification(int p_what) {
 
-	if (p_what==NOTIFICATION_READY) {
-		delete_preset->set_icon(get_icon("Del","EditorIcons"));
-		connect("confirmed",this,"_export_pck_zip");
-
+	switch (p_what) {
+		case NOTIFICATION_READY: {
+			delete_preset->set_icon(get_icon("Del","EditorIcons"));
+			connect("confirmed",this,"_export_pck_zip");
+		} break;
+		case NOTIFICATION_POPUP_HIDE: {
+			EditorSettings::get_singleton()->set("interface/dialogs/export_bounds", get_rect());
+		} break;
 	}
 }
 
@@ -66,7 +70,13 @@ void ProjectExportDialog::popup_export() {
 	}
 
 	_update_presets();
-	popup_centered_ratio();
+
+	// Restore valid window bounds or pop up at default size.
+	if (EditorSettings::get_singleton()->has("interface/dialogs/export_bounds")) {
+		popup(EditorSettings::get_singleton()->get("interface/dialogs/export_bounds"));
+	} else {
+		popup_centered_ratio();
+	}
 }
 
 void ProjectExportDialog::_add_preset(int p_platform) {
@@ -663,6 +673,9 @@ void ProjectExportDialog::_bind_methods() {
 
 }
 ProjectExportDialog::ProjectExportDialog() {
+
+	set_title(TTR("Export"));
+	set_resizable(true);
 
 	HBoxContainer *hbox = memnew( HBoxContainer );
 	add_child(hbox);

--- a/tools/editor/settings_config_dialog.cpp
+++ b/tools/editor/settings_config_dialog.cpp
@@ -93,10 +93,14 @@ void EditorSettingsDialog::popup_edit_settings() {
 	search_box->grab_focus();
 
 	_update_shortcuts();
-	popup_centered_ratio(0.7);
+
+	// Restore valid window bounds or pop up at default size.
+	if (EditorSettings::get_singleton()->has("interface/dialogs/editor_settings_bounds")) {
+		popup(EditorSettings::get_singleton()->get("interface/dialogs/editor_settings_bounds"));
+	} else {
+		popup_centered_ratio(0.7);
+	}
 }
-
-
 
 void EditorSettingsDialog::_clear_search_box() {
 
@@ -121,10 +125,14 @@ void EditorSettingsDialog::_filter_shortcuts(const String& p_filter) {
 
 void EditorSettingsDialog::_notification(int p_what) {
 
-	if (p_what==NOTIFICATION_ENTER_TREE) {
-
-		clear_button->set_icon(get_icon("Close","EditorIcons"));
-		shortcut_clear_button->set_icon(get_icon("Close","EditorIcons"));
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			clear_button->set_icon(get_icon("Close", "EditorIcons"));
+			shortcut_clear_button->set_icon(get_icon("Close", "EditorIcons"));
+		} break;
+		case NOTIFICATION_POPUP_HIDE: {
+			EditorSettings::get_singleton()->set("interface/dialogs/editor_settings_bounds", get_rect());
+		} break;
 	}
 }
 
@@ -305,6 +313,7 @@ void EditorSettingsDialog::_bind_methods() {
 EditorSettingsDialog::EditorSettingsDialog() {
 
 	set_title(TTR("Editor Settings"));
+	set_resizable(true);
 
 	tabs = memnew( TabContainer );
 	add_child(tabs);


### PR DESCRIPTION
Implements https://github.com/godotengine/godot/issues/7921
Obsoletes https://github.com/godotengine/godot/pull/7543

- Editor Settings, Export and Project Settings are now resizable.
- Size and position are stored in the editor settings under Interface/Dialogs. If someone can tell me how to hide this category in the Editor Settings window, I'd be thankful as it doesn't make much sense to display it in there plus it is the only subcategory to a category which has settings itself.
- Added an optional `Rect2` parameter to `Popup::popup()` to specify the area in which it should pop up.
- Overrode `Popup::_fix_size()` in `WindowDialog` to ensure the window chrome is visible aswell when pushing a popup window back into the view (pretty useless otherwise as the complete window chrome could still be out of bounds). Resizable windows also get shrunk if the available space is insufficient.

**Discussion:** Please suggest additional windows which should become resizable and their bounds remembered. My ideas so far:

- All open / save file popups (if called from one place) - can't do it right away because some places use the default FileDialog rather than the Editor file dialog.