### PR TITLE
TabContainer's signal changes (v2.1)

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -39867,13 +39867,21 @@
 			<return type="int">
 			</return>
 			<description>
-				Return the current tab that is being showed.
+				Return the current tab index that is being shown.
 			</description>
 		</method>
+		<method name="get_previous_tab" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Return the previous tab index that was being shown.
+ 			</description>
+ 		</method>
 		<method name="get_current_tab_control" qualifiers="const">
 			<return type="Control">
 			</return>
 			<description>
+				Return the current tab control that is being shown.
 			</description>
 		</method>
 		<method name="get_popup" qualifiers="const">
@@ -39976,9 +39984,16 @@
 			<argument index="0" name="tab" type="int">
 			</argument>
 			<description>
-				Emitted when the current tab changes.
+				Emitted when a tab gets selected. Same behavior as [tab_selected] signal for backward compatibility. Note: In Godot v3.0+ this will change to be only emitted when tab gets changed.
 			</description>
 		</signal>
+		<signal name="tab_selected">
+			<argument index="0" name="tab" type="int">
+			</argument>
+			<description>
+				Emitted when a tab is being selected, even if it is the same tab.
+ 			</description>
+ 		</signal>
 	</signals>
 	<constants>
 	</constants>

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -50,6 +50,7 @@ private:
 	int tabs_ofs_cache;
 	int last_tab_cache;
 	int current;
+	int previous;
 	bool tabs_visible;
 	bool buttons_visible_cache;
 	TabAlign align;
@@ -86,7 +87,8 @@ public:
 	int get_tab_count() const;
 	void set_current_tab(int p_current);
 	int get_current_tab() const;
-
+	int get_previous_tab() const;
+	
 	Control* get_tab_control(int p_idx) const;
 	Control* get_current_tab_control() const;
 


### PR DESCRIPTION
 - Added `tab_selected` signal which has same behavior as `tab_changed`
lest breaking current API, though, it is noted in the documentation of TabContainer
class, of the upcoming Godot (v3.0+) changes in behavior, that is, `tab_selected` will be
emitted for selecting any tab, while `tab_changed` only if a tab changes.
- Added `get_previous_tab()`. Which returns the previous shown tab. **Note:** In Godot v3.0+, only `tab_changed` can modify previous tab index.
- Add documentation for the added function and signals. Fix a typo too.