### PR TITLE
Added a SceneTree.has_network_peer (2.2-legacy)

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -35419,6 +35419,13 @@
 				Returns true if this SceneTree's [NetworkedMultiplayerPeer] is in server mode (listening for connections).
 			</description>
 		</method>
+		<method name="has_network_peer" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+				Returns true if there is a [NetworkedMultiplayerPeer] set (with [method SceneTree.set_network_peer]).
+			</description>
+		</method>
 		<method name="is_paused" qualifiers="const">
 			<return type="bool">
 			</return>

--- a/scene/main/scene_main_loop.cpp
+++ b/scene/main/scene_main_loop.cpp
@@ -1723,6 +1723,10 @@ bool SceneTree::is_network_server() const {
 
 }
 
+bool SceneTree::has_network_peer() const {
+	return network_peer.is_valid();
+}
+
 int SceneTree::get_network_unique_id() const {
 
 	ERR_FAIL_COND_V(!network_peer.is_valid(),0);
@@ -2217,6 +2221,7 @@ void SceneTree::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("set_network_peer","peer:NetworkedMultiplayerPeer"),&SceneTree::set_network_peer);
 	ObjectTypeDB::bind_method(_MD("is_network_server"),&SceneTree::is_network_server);
+	ObjectTypeDB::bind_method(_MD("has_network_peer"),&SceneTree::has_network_peer);
 	ObjectTypeDB::bind_method(_MD("get_network_unique_id"),&SceneTree::get_network_unique_id);
 	ObjectTypeDB::bind_method(_MD("set_refuse_new_network_connections","refuse"),&SceneTree::set_refuse_new_network_connections);
 	ObjectTypeDB::bind_method(_MD("is_refusing_new_network_connections"),&SceneTree::is_refusing_new_network_connections);

--- a/scene/main/scene_main_loop.h
+++ b/scene/main/scene_main_loop.h
@@ -425,6 +425,7 @@ public:
 
 	void set_network_peer(const Ref<NetworkedMultiplayerPeer>& p_network_peer);
 	bool is_network_server() const;
+	bool has_network_peer() const;
 	int get_network_unique_id() const;
 
 	void set_refuse_new_network_connections(bool p_refuse);


### PR DESCRIPTION
PR #7923 (SceneTree.has_network_peer) rebased onto 2.2-legacy with fixed conflicts. I guess this is ok, since 2.2-legacy already branched away from the current master.