### PR TITLE
Fix VisibilityNotifier2D viewport offset issue (2.1)

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -253,7 +253,8 @@ void Viewport::update_worlds() {
 	if (!is_inside_tree())
 		return;
 
-	Rect2 xformed_rect = (global_canvas_transform * canvas_transform).affine_inverse().xform(get_visible_rect());
+	Rect2 abstracted_rect = Rect2(Vector2(), get_visible_rect().size);
+	Rect2 xformed_rect = (global_canvas_transform * canvas_transform).affine_inverse().xform(abstracted_rect);
 	find_world_2d()->_update_viewport(this, xformed_rect);
 	find_world_2d()->_update();
 


### PR DESCRIPTION
It seems when the root viewport is not at (0, 0) `VisibilityNotifier2D` seems to be offset as much as the viewport in relation to the window.

What this does is passing the viewport rect positioned at (0, 0) before applying the viewport transform.

This should be tested with other stretch mode/aspect settings. If any knowledgeable member can give his impressions about this, it'd be helpful.

This would partially solve #4803.