### PR TITLE
Expose uncapped versions of closest-point-to-segment utilities (2.1)

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -1307,6 +1307,16 @@ Vector3 _Geometry::get_closest_point_to_segment(const Vector3& p_point, const Ve
 	Vector3 s[2]={p_a,p_b};
 	return Geometry::get_closest_point_to_segment(p_point,s);
 }
+Vector2 _Geometry::get_closest_point_to_segment_uncapped_2d(const Vector2& p_point, const Vector2& p_a,const Vector2& p_b) {
+
+	Vector2 s[2]={p_a,p_b};
+	return Geometry::get_closest_point_to_segment_uncapped_2d(p_point,s);
+}
+Vector3 _Geometry::get_closest_point_to_segment_uncapped(const Vector3& p_point, const Vector3& p_a,const Vector3& p_b) {
+
+	Vector3 s[2]={p_a,p_b};
+	return Geometry::get_closest_point_to_segment_uncapped(p_point,s);
+}
 Variant _Geometry::ray_intersects_triangle( const Vector3& p_from, const Vector3& p_dir, const Vector3& p_v0,const Vector3& p_v1,const Vector3& p_v2) {
 
 	Vector3 res;
@@ -1425,6 +1435,9 @@ void _Geometry::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("get_closest_point_to_segment_2d","point","s1","s2"),&_Geometry::get_closest_point_to_segment_2d);
 	ObjectTypeDB::bind_method(_MD("get_closest_point_to_segment","point","s1","s2"),&_Geometry::get_closest_point_to_segment);
+
+	ObjectTypeDB::bind_method(_MD("get_closest_point_to_segment_uncapped_2d","point","s1","s2"),&_Geometry::get_closest_point_to_segment_uncapped_2d);
+	ObjectTypeDB::bind_method(_MD("get_closest_point_to_segment_uncapped","point","s1","s2"),&_Geometry::get_closest_point_to_segment_uncapped);
 
 	ObjectTypeDB::bind_method(_MD("get_uv84_normal_bit","normal"),&_Geometry::get_uv84_normal_bit);
 

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -353,6 +353,8 @@ public:
 	DVector<Vector3> get_closest_points_between_segments(const Vector3& p1,const Vector3& p2,const Vector3& q1,const Vector3& q2);
 	Vector2 get_closest_point_to_segment_2d(const Vector2& p_point, const Vector2& p_a,const Vector2& p_b);
 	Vector3 get_closest_point_to_segment(const Vector3& p_point, const Vector3& p_a,const Vector3& p_b);
+	Vector2 get_closest_point_to_segment_uncapped_2d(const Vector2& p_point, const Vector2& p_a,const Vector2& p_b);
+	Vector3 get_closest_point_to_segment_uncapped(const Vector3& p_point, const Vector3& p_a,const Vector3& p_b);
 	Variant ray_intersects_triangle( const Vector3& p_from, const Vector3& p_dir, const Vector3& p_v0,const Vector3& p_v1,const Vector3& p_v2);
 	Variant segment_intersects_triangle( const Vector3& p_from, const Vector3& p_to, const Vector3& p_v0,const Vector3& p_v1,const Vector3& p_v2);
 	bool point_is_inside_triangle(const Vector2& s, const Vector2& a, const Vector2& b, const Vector2& c) const;


### PR DESCRIPTION
Just a couple more bindings for `Geometry`'s stuff.