### PR TITLE
TileMap: Respect self_modulate property

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -458,6 +458,9 @@ void TileMap::_update_dirty_quadrants() {
 
 
 			Color modulate = tile_set->tile_get_modulate(c.id);
+			Color self_modulate = get_self_modulate();
+			modulate = Color(modulate.r*self_modulate.r, modulate.g*self_modulate.g,
+					 modulate.b*self_modulate.b, modulate.a*self_modulate.a);
 			if (r==Rect2()) {
 				tex->draw_rect(canvas_item,rect,false,modulate,c.transpose);
 			} else {


### PR DESCRIPTION
Now `TileMap`s make use of the `self_modulate` property.

There's still a bug: The Editor doesn't re-draw with the new color when you change the TileMaps `self_modulate` in the inspector. You'll have to make it update manually (by placing a tile, changing the transform, etc..).
I'll open an issue for that after this is merged (If I don't fix it in the meantime ^^).