### PR TITLE
Editor: Dim UI when a WindowDialog is shown.

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -598,6 +598,13 @@ private:
 	void _tool_menu_insert_item(const ToolMenuItem &p_item);
 	void _rebuild_tool_menu() const;
 
+	bool _dimming;
+	float _dim_time;
+	Timer *_dim_timer;
+
+	void _start_dimming(bool p_dimming);
+	void _dim_timeout();
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -752,6 +759,8 @@ public:
 	void add_tool_menu_item(const String &p_name, Object *p_handler, const String &p_callback, const Variant &p_ud = Variant());
 	void add_tool_submenu_item(const String &p_name, PopupMenu *p_submenu);
 	void remove_tool_menu_item(const String &p_name);
+
+	void dim_editor(bool p_dimming);
 
 	EditorNode();
 	~EditorNode();

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -502,6 +502,11 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["interface/custom_font"] = PropertyInfo(Variant::STRING, "interface/custom_font", PROPERTY_HINT_GLOBAL_FILE, "*.fnt", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	set("interface/custom_theme", "");
 	hints["interface/custom_theme"] = PropertyInfo(Variant::STRING, "interface/custom_theme", PROPERTY_HINT_GLOBAL_FILE, "*.res,*.tres,*.theme", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
+	set("interface/dim_editor_on_dialog_popup", true);
+	set("interface/dim_amount", 0.6f);
+	hints["interface/dim_amount"] = PropertyInfo(Variant::REAL, "interface/dim_amount", PROPERTY_HINT_RANGE, "0,1,0.01", PROPERTY_USAGE_DEFAULT);
+	set("interface/dim_transition_time", 0.11f);
+	hints["interface/dim_transition_time"] = PropertyInfo(Variant::REAL, "interface/dim_transition_time", PROPERTY_HINT_RANGE, "0,1,0.001", PROPERTY_USAGE_DEFAULT);
 
 	set("filesystem/directories/autoscan_project_path", "");
 	hints["filesystem/directories/autoscan_project_path"] = PropertyInfo(Variant::STRING, "filesystem/directories/autoscan_project_path", PROPERTY_HINT_GLOBAL_DIR);

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -31,6 +31,10 @@
 #include "print_string.h"
 #include "translation.h"
 
+#ifdef TOOLS_ENABLED
+#include "editor/editor_node.h"
+#endif
+
 void WindowDialog::_post_popup() {
 
 	drag_type = DRAG_NONE; // just in case
@@ -199,6 +203,16 @@ void WindowDialog::_notification(int p_what) {
 					set_default_cursor_shape(CURSOR_ARROW);
 			}
 		} break;
+#ifdef TOOLS_ENABLED
+		case NOTIFICATION_POST_POPUP: {
+			if (get_tree() && get_tree()->is_editor_hint())
+				EditorNode::get_singleton()->dim_editor(true);
+		} break;
+		case NOTIFICATION_POPUP_HIDE: {
+			if (get_tree() && get_tree()->is_editor_hint())
+				EditorNode::get_singleton()->dim_editor(false);
+		} break;
+#endif
 	}
 }
 


### PR DESCRIPTION
Darkens the editor on WindowDialog popups.

This adds the following new Editor settings:

- `interface/dim_editor_on_dialog_popup (true)` # Enable/Disable editor dimming
- `interface/dim_amount (0.6)` # Percentage of how much the editor will be darkened (0-1)
- `interface/dim_transition_time (0.11)` # The duration (in seconds) of the color blending effect (0-1), 0 is instant.

Please test this thoroughly, I haven't yet seen a case where it fails to work properly but I'm sure I didn't test all windows of the editor :P 
Closes #7900 

![darken2](https://cloud.githubusercontent.com/assets/8281916/23625863/fb87b2e8-02aa-11e7-8da5-2adb2d1dbd53.gif)
