### PR TITLE
Fix node duplication in scene sub-inheritance (2.1)

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -1001,12 +1001,12 @@ int SceneState::find_node_by_path(const NodePath& p_node) const {
 		if (_get_base_scene_state().is_valid()) {
 			int idx = _get_base_scene_state()->find_node_by_path(p_node);
 			if (idx>=0) {
-				if (!base_scene_node_remap.has(idx)) {
-					int ridx = nodes.size() + base_scene_node_remap.size();
-					base_scene_node_remap[ridx]=idx;
+				int rkey=_find_base_scene_node_remap_key(idx);
+				if (rkey==-1) {
+					rkey=nodes.size() + base_scene_node_remap.size();
+					base_scene_node_remap[rkey]=idx;
 				}
-
-				return base_scene_node_remap[idx];
+				return rkey;
 			}
 		}
 		return -1;
@@ -1019,12 +1019,24 @@ int SceneState::find_node_by_path(const NodePath& p_node) const {
 		//the node in the instanced scene, as a property may be missing
 		//from the local one
 		int idx = _get_base_scene_state()->find_node_by_path(p_node);
-		base_scene_node_remap[nid]=idx;
-
+		if (idx!=-1) {
+			base_scene_node_remap[nid]=idx;
+		}
 	}
 
 	return nid;
 }
+
+int SceneState::_find_base_scene_node_remap_key(int p_idx) const {
+
+	for (Map<int, int>::Element* E=base_scene_node_remap.front();E;E=E->next()) {
+		if (E->value()==p_idx) {
+			return E->key();
+		}
+	}
+	return -1;
+}
+
 Variant SceneState::get_property_value(int p_node, const StringName& p_property, bool &found) const {
 
 	found=false;

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -104,6 +104,8 @@ class SceneState : public Reference {
 
 	DVector<String> _get_node_groups(int p_idx) const;
 
+	int _find_base_scene_node_remap_key(int p_idx) const;
+
 protected:
 
 	static void _bind_methods();

--- a/tools/editor/editor_node.cpp
+++ b/tools/editor/editor_node.cpp
@@ -1013,6 +1013,11 @@ void EditorNode::_save_scene(String p_file, int idx) {
 		return;
 	}
 
+	// force creation of node path cache
+	// (hacky but needed for the tree to update properly)
+	Node* dummy_scene=sdata->instance(true);
+	memdelete(dummy_scene);
+
 	sdata->set_import_metadata(editor_data.get_edited_scene_import_metadata(idx));
 	int flg=0;
 	if (EditorSettings::get_singleton()->get("on_save/compress_binary_resources"))
@@ -1023,6 +1028,7 @@ void EditorNode::_save_scene(String p_file, int idx) {
 
 
 	err = ResourceSaver::save(p_file,sdata,flg);
+
 	Map<RES,bool> processed;
 	_save_edited_subresources(scene,processed,flg);
 	editor_data.save_editor_external_data();


### PR DESCRIPTION
Fixes #7976.

And hopefully doesn't break anything. Some testing won't harm.

~~UPDATE: Still happens sometimes. :( Not ready for merging.~~

UPDATE: This may also fix some issues with properties of inherited nodes (and even connections and groups). Or even broken something there. If have no time to look for the improvements in that regard, so if someone finds this is fixing some issue of that kind, please report them as such. 

UPDATE: With the last push most problems are solved. I'll open another issue report for the remaining cases.