### PR TITLE
Fix node duplication in scene sub-inheritance

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -925,6 +925,11 @@ void EditorNode::_save_scene(String p_file, int idx) {
 		return;
 	}
 
+	// force creation of node path cache
+	// (hacky but needed for the tree to update properly)
+	Node *dummy_scene = sdata->instance(PackedScene::GEN_EDIT_STATE_INSTANCE);
+	memdelete(dummy_scene);
+
 	int flg = 0;
 	if (EditorSettings::get_singleton()->get("filesystem/on_save/compress_binary_resources"))
 		flg |= ResourceSaver::FLAG_COMPRESS;

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -995,12 +995,12 @@ int SceneState::find_node_by_path(const NodePath &p_node) const {
 		if (_get_base_scene_state().is_valid()) {
 			int idx = _get_base_scene_state()->find_node_by_path(p_node);
 			if (idx >= 0) {
-				if (!base_scene_node_remap.has(idx)) {
-					int ridx = nodes.size() + base_scene_node_remap.size();
-					base_scene_node_remap[ridx] = idx;
+				int rkey = _find_base_scene_node_remap_key(idx);
+				if (rkey == -1) {
+					rkey = nodes.size() + base_scene_node_remap.size();
+					base_scene_node_remap[rkey] = idx;
 				}
-
-				return base_scene_node_remap[idx];
+				return rkey;
 			}
 		}
 		return -1;
@@ -1013,11 +1013,24 @@ int SceneState::find_node_by_path(const NodePath &p_node) const {
 		//the node in the instanced scene, as a property may be missing
 		//from the local one
 		int idx = _get_base_scene_state()->find_node_by_path(p_node);
-		base_scene_node_remap[nid] = idx;
+		if (idx != -1) {
+			base_scene_node_remap[nid] = idx;
+		}
 	}
 
 	return nid;
 }
+
+int SceneState::_find_base_scene_node_remap_key(int p_idx) const {
+
+	for (Map<int, int>::Element *E = base_scene_node_remap.front(); E; E = E->next()) {
+		if (E->value() == p_idx) {
+			return E->key();
+		}
+	}
+	return -1;
+}
+
 Variant SceneState::get_property_value(int p_node, const StringName &p_property, bool &found) const {
 
 	found = false;

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -100,6 +100,8 @@ class SceneState : public Reference {
 
 	PoolVector<String> _get_node_groups(int p_idx) const;
 
+	int _find_base_scene_node_remap_key(int p_idx) const;
+
 protected:
 	static void _bind_methods();
 


### PR DESCRIPTION
This was initially done for 2.1, but I think that _master_ also needs it.

~~UPDATE: Still happens sometimes. :( Not ready for merging.~~

UPDATE: This may also fix some issues with properties of inherited nodes (and even connections and groups). Or even broken something there. If have no time to look for the improvements in that regard, so if someone finds this is fixing some issue of that kind, please report them as such.

UPDATE: With the last push most problems are solved. I'll open another issue report for the remaining cases.