### PR TITLE
Avoid connecting signal to nonexistent methods when replacing nodes

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2499,6 +2499,7 @@ void Node::_replace_connections_target(Node *p_new_target) {
 		Connection &c = E->get();
 
 		c.source->disconnect(c.signal, this, c.method);
+		ERR_CONTINUE(!p_new_target->has_method(c.method));
 		c.source->connect(c.signal, p_new_target, c.method, c.binds, c.flags);
 	}
 }


### PR DESCRIPTION
Fixes #6602 (Only the first part)

I made it print an error once instead of silently skipping it to be consistent, since that's what happens if you try to connect a nonexisting signal when replacing nodes, e.g: Control with signal `focus_enter ` to Node. It's also better for debugging purposes, WDYT?
