### PR TITLE
UI: ability to add multiple child nodes in single click

### DIFF
--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -58,6 +58,8 @@ class CreateDialog : public ConfirmationDialog {
 	EditorHelpBit *help_bit;
 
 	void _item_selected();
+	void _select_item(String name);
+	void _cell_multi_selected(Object *p_object, int p_index, bool p_selected);
 
 	void _update_search();
 	void _update_favorite_list();
@@ -86,13 +88,13 @@ protected:
 	static void _bind_methods();
 
 public:
-	Object *instance_selected();
+	void instance_selected(List<Object*> *p_list);
 	String get_selected_type();
 
 	void set_base_type(const String &p_base);
 	String get_base_type() const;
 
-	void popup(bool p_dontclear);
+	void popup(bool p_dontclear, bool p_allowmultiselect = false);
 
 	CreateDialog();
 };

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1648,15 +1648,17 @@ void EditorNode::_edit_current() {
 
 void EditorNode::_resource_created() {
 
-	Object *c = create_dialog->instance_selected();
+	List<Object*> l;
+	create_dialog->instance_selected(&l);
 
-	ERR_FAIL_COND(!c);
-	Resource *r = c->cast_to<Resource>();
-	ERR_FAIL_COND(!r);
-
-	REF res(r);
-
-	push_item(c);
+	for(List<Object*>::Element *E = l.front(); E; E = E->next()) {
+		Object* c = E->get();
+		ERR_FAIL_COND(!c);
+		Resource *r = c->cast_to<Resource>();
+		ERR_FAIL_COND(!r);
+		REF res(r);
+		push_item(c);
+	}
 }
 
 void EditorNode::_resource_selected(const RES &p_res, const String &p_property) {

--- a/editor/resources_dock.cpp
+++ b/editor/resources_dock.cpp
@@ -286,15 +286,17 @@ void ResourcesDock::_delete(Object *p_item, int p_column, int p_id) {
 
 void ResourcesDock::_create() {
 
-	Object *c = create_dialog->instance_selected();
+	List<Object*> l;
+	create_dialog->instance_selected(&l);
 
-	ERR_FAIL_COND(!c);
-	Resource *r = c->cast_to<Resource>();
-	ERR_FAIL_COND(!r);
-
-	REF res(r);
-
-	editor->push_item(c);
+	for(List<Object*>::Element *E = l.front(); E; E = E->next()) {
+		Object* c = E->get();
+		ERR_FAIL_COND(!c);
+		Resource *r = c->cast_to<Resource>();
+		ERR_FAIL_COND(!r);
+		REF res(r);
+		editor->push_item(c);
+	}
 }
 
 void ResourcesDock::_bind_methods() {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -276,7 +276,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			if (!_validate_no_foreign())
 				break;
 			*/
-			create_dialog->popup(true);
+			create_dialog->popup(true, true);
 		} break;
 		case TOOL_INSTANCE: {
 
@@ -1289,120 +1289,130 @@ void SceneTreeDock::_create() {
 			ERR_FAIL_COND(!parent);
 		}
 
-		Object *c = create_dialog->instance_selected();
+		List<Object*> l;
+		create_dialog->instance_selected(&l);
 
-		ERR_FAIL_COND(!c);
-		Node *child = c->cast_to<Node>();
-		ERR_FAIL_COND(!child);
+		for(List<Object*>::Element *E = l.front(); E; E = E->next()) {
+			Object* c = E->get();
 
-		editor_data->get_undo_redo().create_action(TTR("Create Node"));
+			ERR_FAIL_COND(!c);
+			Node *child = c->cast_to<Node>();
+			ERR_FAIL_COND(!child);
 
-		if (edited_scene) {
+			editor_data->get_undo_redo().create_action(TTR("Create Node"));
 
-			editor_data->get_undo_redo().add_do_method(parent, "add_child", child);
-			editor_data->get_undo_redo().add_do_method(child, "set_owner", edited_scene);
-			editor_data->get_undo_redo().add_do_method(editor_selection, "clear");
-			editor_data->get_undo_redo().add_do_method(editor_selection, "add_node", child);
-			editor_data->get_undo_redo().add_do_reference(child);
-			editor_data->get_undo_redo().add_undo_method(parent, "remove_child", child);
+			if (edited_scene) {
 
-			String new_name = parent->validate_child_name(child);
-			ScriptEditorDebugger *sed = ScriptEditor::get_singleton()->get_debugger();
-			editor_data->get_undo_redo().add_do_method(sed, "live_debug_create_node", edited_scene->get_path_to(parent), child->get_class(), new_name);
-			editor_data->get_undo_redo().add_undo_method(sed, "live_debug_remove_node", NodePath(String(edited_scene->get_path_to(parent)) + "/" + new_name));
+				editor_data->get_undo_redo().add_do_method(parent, "add_child", child);
+				editor_data->get_undo_redo().add_do_method(child, "set_owner", edited_scene);
+				editor_data->get_undo_redo().add_do_method(editor_selection, "clear");
+				editor_data->get_undo_redo().add_do_method(editor_selection, "add_node", child);
+				editor_data->get_undo_redo().add_do_reference(child);
+				editor_data->get_undo_redo().add_undo_method(parent, "remove_child", child);
 
-		} else {
+				String new_name = parent->validate_child_name(child);
+				ScriptEditorDebugger *sed = ScriptEditor::get_singleton()->get_debugger();
+				editor_data->get_undo_redo().add_do_method(sed, "live_debug_create_node", edited_scene->get_path_to(parent), child->get_class(), new_name);
+				editor_data->get_undo_redo().add_undo_method(sed, "live_debug_remove_node", NodePath(String(edited_scene->get_path_to(parent)) + "/" + new_name));
 
-			editor_data->get_undo_redo().add_do_method(editor, "set_edited_scene", child);
-			editor_data->get_undo_redo().add_do_reference(child);
-			editor_data->get_undo_redo().add_undo_method(editor, "set_edited_scene", (Object *)NULL);
-		}
+			} else {
 
-		editor_data->get_undo_redo().commit_action();
-		editor->push_item(c);
+				editor_data->get_undo_redo().add_do_method(editor, "set_edited_scene", child);
+				editor_data->get_undo_redo().add_do_reference(child);
+				editor_data->get_undo_redo().add_undo_method(editor, "set_edited_scene", (Object *)NULL);
+			}
 
-		if (c->cast_to<Control>()) {
-			//make editor more comfortable, so some controls don't appear super shrunk
-			Control *ct = c->cast_to<Control>();
+			editor_data->get_undo_redo().commit_action();
+			editor->push_item(c);
 
-			Size2 ms = ct->get_minimum_size();
-			if (ms.width < 4)
-				ms.width = 40;
-			if (ms.height < 4)
-				ms.height = 40;
-			ct->set_size(ms);
+			if (c->cast_to<Control>()) {
+				//make editor more comfortable, so some controls don't appear super shrunk
+				Control *ct = c->cast_to<Control>();
+	
+				Size2 ms = ct->get_minimum_size();
+				if (ms.width < 4)
+					ms.width = 40;
+				if (ms.height < 4)
+					ms.height = 40;
+				ct->set_size(ms);
+			}
 		}
 
 	} else if (current_option == TOOL_REPLACE) {
 		Node *n = scene_tree->get_selected();
 		ERR_FAIL_COND(!n);
 
-		Object *c = create_dialog->instance_selected();
+		List<Object*> l;
+		create_dialog->instance_selected(&l);
 
-		ERR_FAIL_COND(!c);
-		Node *newnode = c->cast_to<Node>();
-		ERR_FAIL_COND(!newnode);
+		for(List<Object*>::Element *E = l.front(); E; E = E->next()) {
+			Object* c = E->get();
 
-		List<PropertyInfo> pinfo;
-		n->get_property_list(&pinfo);
+			ERR_FAIL_COND(!c);
+			Node *newnode = c->cast_to<Node>();
+			ERR_FAIL_COND(!newnode);
 
-		for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
-			if (!(E->get().usage & PROPERTY_USAGE_STORAGE))
-				continue;
-			newnode->set(E->get().name, n->get(E->get().name));
-		}
+			List<PropertyInfo> pinfo;
+			n->get_property_list(&pinfo);
 
-		editor->push_item(NULL);
-
-		//reconnect signals
-		List<MethodInfo> sl;
-
-		n->get_signal_list(&sl);
-		for (List<MethodInfo>::Element *E = sl.front(); E; E = E->next()) {
-
-			List<Object::Connection> cl;
-			n->get_signal_connection_list(E->get().name, &cl);
-
-			for (List<Object::Connection>::Element *F = cl.front(); F; F = F->next()) {
-
-				Object::Connection &c = F->get();
-				if (!(c.flags & Object::CONNECT_PERSIST))
+			for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
+				if (!(E->get().usage & PROPERTY_USAGE_STORAGE))
 					continue;
-				newnode->connect(c.signal, c.target, c.method, varray(), Object::CONNECT_PERSIST);
+				newnode->set(E->get().name, n->get(E->get().name));
 			}
-		}
 
-		String newname = n->get_name();
+			editor->push_item(NULL);
 
-		List<Node *> to_erase;
-		for (int i = 0; i < n->get_child_count(); i++) {
-			if (n->get_child(i)->get_owner() == NULL && n->is_owned_by_parent()) {
-				to_erase.push_back(n->get_child(i));
+			//reconnect signals
+			List<MethodInfo> sl;
+
+			n->get_signal_list(&sl);
+			for (List<MethodInfo>::Element *E = sl.front(); E; E = E->next()) {
+
+				List<Object::Connection> cl;
+				n->get_signal_connection_list(E->get().name, &cl);
+
+				for (List<Object::Connection>::Element *F = cl.front(); F; F = F->next()) {
+	
+					Object::Connection &c = F->get();
+					if (!(c.flags & Object::CONNECT_PERSIST))
+						continue;
+					newnode->connect(c.signal, c.target, c.method, varray(), Object::CONNECT_PERSIST);
+				}
 			}
-		}
-		n->replace_by(newnode, true);
 
-		if (n == edited_scene) {
-			edited_scene = newnode;
-			editor->set_edited_scene(newnode);
-			newnode->set_editable_instances(n->get_editable_instances());
-		}
+			String newname = n->get_name();
 
-		//small hack to make collisionshapes and other kind of nodes to work
-		for (int i = 0; i < newnode->get_child_count(); i++) {
-			Node *c = newnode->get_child(i);
-			c->call("set_transform", c->call("get_transform"));
-		}
-		editor_data->get_undo_redo().clear_history();
-		newnode->set_name(newname);
+			List<Node *> to_erase;
+			for (int i = 0; i < n->get_child_count(); i++) {
+				if (n->get_child(i)->get_owner() == NULL && n->is_owned_by_parent()) {
+					to_erase.push_back(n->get_child(i));
+				}
+			}
+			n->replace_by(newnode, true);
 
-		editor->push_item(newnode);
-
-		memdelete(n);
-
-		while (to_erase.front()) {
-			memdelete(to_erase.front()->get());
-			to_erase.pop_front();
+			if (n == edited_scene) {
+				edited_scene = newnode;
+				editor->set_edited_scene(newnode);
+				newnode->set_editable_instances(n->get_editable_instances());
+			}
+	
+			//small hack to make collisionshapes and other kind of nodes to work
+			for (int i = 0; i < newnode->get_child_count(); i++) {
+				Node *c = newnode->get_child(i);
+				c->call("set_transform", c->call("get_transform"));
+			}
+			editor_data->get_undo_redo().clear_history();
+			newnode->set_name(newname);
+	
+			editor->push_item(newnode);
+	
+			memdelete(n);
+	
+			while (to_erase.front()) {
+				memdelete(to_erase.front()->get());
+				to_erase.pop_front();
+			}
 		}
 	}
 }


### PR DESCRIPTION
Usage:
When FOCUS on tree node, multiple nodes can be selected using the
[space] key . Hodling [ctrl] on single mouse click add to current
selection. [shift] mouse click also work for grouped selection.
If no node selected, [Create] button is desabled.

Nota:
* multiple node selection not active with search node feature.
* Multiselect mode is disabled for other than node creation.