### PR TITLE
Improve directional shadow filtering by using linear interpolation

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -4515,8 +4515,8 @@ void RasterizerSceneGLES3::initialize() {
 		glGenTextures(1, &directional_shadow.depth);
 		glBindTexture(GL_TEXTURE_2D, directional_shadow.depth);
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, directional_shadow.size, directional_shadow.size, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, NULL);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);


### PR DESCRIPTION
Example project: [directional_light.zip](https://github.com/godotengine/godot/files/835774/directional_light.zip) (use Godot Git master to open it; run it, then use WASD or arrow keys and the mouse to fly around)

___

This fixes directional shadows looking blocky. There doesn't seem to be any noticeable performance difference. Note that moving shadows still have some artifacts, this can be fixed by using multisampling or supersampling (at a performance cost).

**Platforms to test before merging:**

- [x] AMD on Linux
- [ ] AMD on macOS
- [x] AMD on Windows
- [x] Intel on Linux
- [ ] Intel on macOS
- [ ] Intel on Windows
- [x] NVIDIA on Linux
- [ ] NVIDIA on macOS
- [x] NVIDIA on Windows
- [ ] Android
- [ ] iOS
- [ ] WebAssembly

Example screenshot of new shadows:

![screenshot_20170310_222845](https://cloud.githubusercontent.com/assets/180032/23822934/81ce111c-0657-11e7-8cad-254cafda51b8.png)

Please test locally.