### PR TITLE
Fix connection errors when replacing node

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2498,8 +2498,11 @@ void Node::_replace_connections_target(Node *p_new_target) {
 
 		Connection &c = E->get();
 
-		c.source->disconnect(c.signal, this, c.method);
-		c.source->connect(c.signal, p_new_target, c.method, c.binds, c.flags);
+		if (c.flags & CONNECT_PERSIST) {
+			c.source->disconnect(c.signal, this, c.method);
+			ERR_CONTINUE(!p_new_target->has_method(c.method));
+			c.source->connect(c.signal, p_new_target, c.method, c.binds, c.flags);
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #6602

- Avoid connecting the signals to nonexistent methods
- Preserve only persistent connections
