### PR TITLE
Skip asserts on non-debug builds at compiler level (2.1)

### DIFF
--- a/modules/gdscript/gd_compiler.cpp
+++ b/modules/gdscript/gd_compiler.cpp
@@ -1189,6 +1189,7 @@ Error GDCompiler::_parse_block(CodeGen& codegen,const GDParser::BlockNode *p_blo
 				}
 			} break;
 			case GDParser::Node::TYPE_ASSERT: {
+#ifdef DEBUG_ENABLED
 				// try subblocks
 
 				const GDParser::AssertNode *as = static_cast<const GDParser::AssertNode*>(s);
@@ -1199,6 +1200,7 @@ Error GDCompiler::_parse_block(CodeGen& codegen,const GDParser::BlockNode *p_blo
 
 				codegen.opcodes.push_back(GDFunction::OPCODE_ASSERT);
 				codegen.opcodes.push_back(ret);
+#endif
 			} break;
 			case GDParser::Node::TYPE_BREAKPOINT: {
 #ifdef DEBUG_ENABLED


### PR DESCRIPTION
Probably not a big gain, but at least avoids useless work.