### PR TITLE
List Control::has_point as a virtual method

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -9810,6 +9810,14 @@
 			<description>
 			</description>
 		</method>
+		<method name="has_point" qualifiers="virtual">
+			<return type="bool">
+			</return>
+			<argument index="0" name="point" type="Vector2">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="has_stylebox" qualifiers="const">
 			<return type="bool">
 			</return>

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2514,6 +2514,8 @@ void Control::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("size_flags_changed"));
 	ADD_SIGNAL(MethodInfo("minimum_size_changed"));
 	ADD_SIGNAL(MethodInfo("modal_closed"));
+
+	BIND_VMETHOD(MethodInfo("has_point", PropertyInfo(Variant::VECTOR2, "point")));
 }
 Control::Control() {
 


### PR DESCRIPTION
According to Issue #8018, a BIND_VMETHOD macro wasn't present in scene/gui/control.cpp, while it was declared to be a virtual method in scene/gui/control.h.

classes.xml was updated to also list this method in the Control class.