### PR TITLE
Fix redundant connections (2.1)

### DIFF
--- a/core/string_db.cpp
+++ b/core/string_db.cpp
@@ -288,6 +288,9 @@ StringName::StringName(const String& p_name) {
 
 	ERR_FAIL_COND(!configured);
 
+	if (p_name.empty())
+		return;
+
 	_global_lock();
 
 	uint32_t hash = p_name.hash();

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -1548,34 +1548,41 @@ Array SceneState::get_connection_binds(int p_idx) const {
 	return binds;
 }
 
-bool SceneState::has_connection(const NodePath& p_node_from, const StringName& p_signal, const NodePath& p_node_to, const StringName& p_method) const {
+bool SceneState::has_connection(const NodePath& p_node_from, const StringName& p_signal, const NodePath& p_node_to, const StringName& p_method) {
 
-	for(int i=0;i<connections.size();i++) {
-		const ConnectionData &c = connections[i];
+	// this method cannot be const because of this
+	Ref<SceneState> ss=this;
 
-		NodePath np_from;
+	do {
+		for(int i=0;i<ss->connections.size();i++) {
+			const ConnectionData &c = ss->connections[i];
 
-		if (c.from&FLAG_ID_IS_PATH) {
-			np_from=node_paths[c.from&FLAG_MASK];
-		} else {
-			np_from=get_node_path(c.from);
+			NodePath np_from;
+
+			if (c.from&FLAG_ID_IS_PATH) {
+				np_from=ss->node_paths[c.from&FLAG_MASK];
+			} else {
+				np_from=ss->get_node_path(c.from);
+			}
+
+			NodePath np_to;
+
+			if (c.to&FLAG_ID_IS_PATH) {
+				np_to=ss->node_paths[c.to&FLAG_MASK];
+			} else {
+				np_to=ss->get_node_path(c.to);
+			}
+
+			StringName sn_signal=ss->names[c.signal];
+			StringName sn_method=ss->names[c.method];
+
+			if (np_from==p_node_from && sn_signal==p_signal && np_to==p_node_to && sn_method==p_method) {
+				return true;
+			}
 		}
 
-		NodePath np_to;
-
-		if (c.to&FLAG_ID_IS_PATH) {
-			np_to=node_paths[c.to&FLAG_MASK];
-		} else {
-			np_to=get_node_path(c.to);
-		}
-
-		StringName sn_signal=names[c.signal];
-		StringName sn_method=names[c.method];
-
-		if (np_from==p_node_from && sn_signal==p_signal && np_to==p_node_to && sn_method==p_method) {
-			return true;
-		}
-	}
+		ss=ss->_get_base_scene_state();
+	} while (ss.is_valid());
 
 	return false;
 }

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -165,7 +165,7 @@ public:
 	int get_connection_flags(int p_idx) const;
 	Array get_connection_binds(int p_idx) const;
 
-	bool has_connection(const NodePath &p_node_from, const StringName& p_signal, const NodePath &p_node_to, const StringName& p_method) const;
+	bool has_connection(const NodePath &p_node_from, const StringName& p_signal, const NodePath &p_node_to, const StringName& p_method);
 
 	Vector<NodePath> get_editable_instances() const;
 


### PR DESCRIPTION
Fixes #7664.
Fixes #6106.

Regarding the first commit, it's needed for the fix and may also affect (positively) in a lot of places, so I'm not squashing it.

I've found almost the same thing was already done in master (in https://github.com/godotengine/godot/commit/cbbcf727035c8b481889f605337a96a9e58ed970).