### PR TITLE
Remove warning on owner re-assignment

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1719,6 +1719,9 @@ void Node::get_owned_by(Node *p_by, List<Node *> *p_owned) {
 
 void Node::_set_owner_nocheck(Node *p_owner) {
 
+	if (data.owner == p_owner)
+		return;
+
 	ERR_FAIL_COND(data.owner);
 	data.owner = p_owner;
 	data.owner->data.owned.push_back(this);


### PR DESCRIPTION
Sometimes you get a collection of warnings coming from scene instancing because it sets the owner of somes nodes repeteadly to the same owning node.

Please someone savvy about this have this checked, since I'm not completely sure this is a non-error situation indeed.