### PR TITLE
Some WebGL 2 and build fixes/clean-up

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -6280,8 +6280,7 @@ void RasterizerStorageGLES3::initialize() {
 	shaders.cubemap_filter.init();
 	shaders.particles.init();
 
-#ifndef GLES_OVER_GL
-
+#ifdef GLES_OVER_GL
 	glEnable(_EXT_TEXTURE_CUBE_MAP_SEAMLESS);
 #endif
 


### PR DESCRIPTION
For WebGL 2, fix an inverted `#ifndef`.
Still fails with an error about a missing buffer in uniform binding 4:
```
drawElements: Buffer for uniform block is smaller than UNIFORM_BLOCK_DATA_SIZE.
```
Debug data:

- `UserName: OmniLightData`
- `DataSize: 65440`
- `BufferSize: 0`
- `IndexedUniformBufferBindings index: 4`

For the build:

- Remove dated build settings and remains from Android
- Enable `-O3` for `release`, which reduces size by almost 1MB for asm.js builds
- Fix optimization so compiling and linking use the same `-O` level for each target
- Retain function names in `release_debug`