### PR TITLE
Add the option to check if input was handled

### DIFF
--- a/scene/main/scene_main_loop.cpp
+++ b/scene/main/scene_main_loop.cpp
@@ -374,6 +374,10 @@ void SceneTree::input_text(const String &p_text) {
 	root_lock--;
 }
 
+bool SceneTree::is_input_handled() {
+	return input_handled;
+}
+
 void SceneTree::input_event(const InputEvent &p_event) {
 
 	if (is_editor_hint() && (p_event.type == InputEvent::JOYPAD_MOTION || p_event.type == InputEvent::JOYPAD_BUTTON))
@@ -2153,6 +2157,7 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_pause", "enable"), &SceneTree::set_pause);
 	ClassDB::bind_method(D_METHOD("is_paused"), &SceneTree::is_paused);
 	ClassDB::bind_method(D_METHOD("set_input_as_handled"), &SceneTree::set_input_as_handled);
+	ClassDB::bind_method(D_METHOD("is_input_handled"), &SceneTree::is_input_handled);
 
 	ClassDB::bind_method(D_METHOD("create_timer:SceneTreeTimer", "time_sec", "pause_mode_process"), &SceneTree::create_timer, DEFVAL(true));
 

--- a/scene/main/scene_main_loop.h
+++ b/scene/main/scene_main_loop.h
@@ -350,6 +350,7 @@ public:
 	void quit();
 
 	void set_input_as_handled();
+	bool is_input_handled();
 	_FORCE_INLINE_ float get_fixed_process_time() const { return fixed_process_time; }
 	_FORCE_INLINE_ float get_idle_process_time() const { return idle_process_time; }
 


### PR DESCRIPTION
When working with a viewport you should call Viewport.input() to pass
the input, but if the input was unhandled you might also want to call
Viewport.unhandled_input() so that objects in the sub-scene can handle
the event. This adds a way to check if the input was handled so that you
know whether you should call Viewport.unhandled_input() or not.