### PR TITLE
Make Create New Node dialog resizable and burninate old dialog

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -32,14 +32,11 @@
 #include "editor_node.h"
 #include "print_string.h"
 #include "scene/gui/box_container.h"
-
-#if 1
-
 #include "editor_help.h"
 #include "editor_settings.h"
 #include "os/keyboard.h"
 
-void CreateDialog::popup(bool p_dontclear) {
+void CreateDialog::popup_create(bool p_dontclear) {
 
 	recent->clear();
 
@@ -85,34 +82,19 @@ void CreateDialog::popup(bool p_dontclear) {
 		}
 
 		memdelete(f);
-	} else {
-#if 0
-// I think this was way too confusing
-		if (base_type=="Node") {
-			//harcode some favorites :D
-			favorite_list.push_back("Panel");
-			favorite_list.push_back("Button");
-			favorite_list.push_back("Label");
-			favorite_list.push_back("LineEdit");
-			favorite_list.push_back("Node2D");
-			favorite_list.push_back("Sprite");
-			favorite_list.push_back("Camera2D");
-			favorite_list.push_back("Area2D");
-			favorite_list.push_back("CollisionShape2D");
-			favorite_list.push_back("Spatial");
-			favorite_list.push_back("Camera");
-			favorite_list.push_back("Area");
-			favorite_list.push_back("CollisionShape");
-			favorite_list.push_back("TestCube");
-			favorite_list.push_back("AnimationPlayer");
-
-		}
-#endif
 	}
 
 	_update_favorite_list();
 
-	popup_centered_ratio();
+
+	// Restore valid window bounds or pop up at default size.
+	if (EditorSettings::get_singleton()->has("interface/dialogs/create_new_node_bounds")) {
+		popup(EditorSettings::get_singleton()->get("interface/dialogs/create_new_node_bounds"));	
+	} else {
+		popup_centered_ratio();
+	}
+
+
 	if (p_dontclear)
 		search_box->select_all();
 	else {
@@ -334,23 +316,23 @@ void CreateDialog::_confirmed() {
 
 void CreateDialog::_notification(int p_what) {
 
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-
-		connect("confirmed", this, "_confirmed");
-		favorite->set_icon(get_icon("Favorites", "EditorIcons"));
-	}
-	if (p_what == NOTIFICATION_EXIT_TREE) {
-
-		disconnect("confirmed", this, "_confirmed");
-	}
-
-	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
-
-		if (is_visible_in_tree()) {
-
-			search_box->call_deferred("grab_focus"); // still not visible
-			search_box->select_all();
-		}
+	switch (p_what)	{
+		case NOTIFICATION_ENTER_TREE: {
+			connect("confirmed", this, "_confirmed");
+			favorite->set_icon(get_icon("Favorites", "EditorIcons"));
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			disconnect("confirmed", this, "_confirmed");
+		} break;
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (is_visible_in_tree()) {
+				search_box->call_deferred("grab_focus"); // still not visible
+				search_box->select_all();
+			}
+		} break;
+		case NOTIFICATION_POPUP_HIDE: {
+			EditorSettings::get_singleton()->set("interface/dialogs/create_new_node_bounds", get_rect());
+		} break;
 	}
 }
 
@@ -608,6 +590,8 @@ void CreateDialog::_bind_methods() {
 
 CreateDialog::CreateDialog() {
 
+	set_resizable(true);
+
 	HSplitContainer *hbc = memnew(HSplitContainer);
 
 	add_child(hbc);
@@ -660,227 +644,3 @@ CreateDialog::CreateDialog() {
 	vbc->add_margin_child(TTR("Description:"), help_bit);
 	help_bit->connect("request_hide", this, "_closed");
 }
-
-#else
-
-//old create dialog, disabled
-
-void CreateDialog::_notification(int p_what) {
-
-	if (p_what == NOTIFICATION_READY) {
-		connect("confirmed", this, "_create");
-		update_tree();
-	}
-	if (p_what == NOTIFICATION_DRAW) {
-
-		//RID ci = get_canvas_item();
-		//get_stylebox("panel","PopupMenu")->draw(ci,Rect2(Point2(),get_size()));
-	}
-}
-
-void CreateDialog::_create() {
-
-	if (tree->get_selected())
-		emit_signal("create");
-	hide();
-}
-
-void CreateDialog::_cancel() {
-
-	hide();
-}
-
-void CreateDialog::_text_changed(String p_text) {
-
-	update_tree();
-}
-
-void CreateDialog::add_type(const String &p_type, HashMap<String, TreeItem *> &p_types, TreeItem *p_root) {
-
-	if (p_types.has(p_type))
-		return;
-	if (!ClassDB::is_type(p_type, base) || p_type == base)
-		return;
-
-	String inherits = ClassDB::type_inherits_from(p_type);
-
-	TreeItem *parent = p_root;
-
-	if (inherits.length()) {
-
-		if (!p_types.has(inherits)) {
-
-			add_type(inherits, p_types, p_root);
-		}
-
-		if (p_types.has(inherits))
-			parent = p_types[inherits];
-	}
-
-	TreeItem *item = tree->create_item(parent);
-	item->set_text(0, p_type);
-	if (!ClassDB::can_instance(p_type)) {
-		item->set_custom_color(0, Color(0.5, 0.5, 0.5));
-		item->set_selectable(0, false);
-	}
-
-	if (has_icon(p_type, "EditorIcons")) {
-
-		item->set_icon(0, get_icon(p_type, "EditorIcons"));
-	}
-
-	p_types[p_type] = item;
-}
-
-void CreateDialog::update_tree() {
-
-	tree->clear();
-
-	List<String> type_list;
-	ClassDB::get_type_list(&type_list);
-
-	HashMap<String, TreeItem *> types;
-
-	TreeItem *root = tree->create_item();
-
-	root->set_text(0, base);
-
-	List<String>::Element *I = type_list.front();
-
-	for (; I; I = I->next()) {
-
-		String type = I->get();
-
-		if (!ClassDB::can_instance(type))
-			continue; // cant create what can't be instanced
-		if (filter->get_text() == "")
-			add_type(type, types, root);
-		else {
-
-			bool found = false;
-			String type = I->get();
-			while (type != "" && ClassDB::is_type(type, base) && type != base) {
-				if (type.findn(filter->get_text()) != -1) {
-
-					found = true;
-					break;
-				}
-
-				type = ClassDB::type_inherits_from(type);
-			}
-
-			if (found)
-				add_type(I->get(), types, root);
-		}
-
-		if (EditorNode::get_editor_data().get_custom_types().has(type)) {
-			//there are custom types based on this... cool.
-
-			const Vector<EditorData::CustomType> &ct = EditorNode::get_editor_data().get_custom_types()[type];
-			for (int i = 0; i < ct.size(); i++) {
-
-				bool show = filter->get_text() == "" || ct[i].name.findn(filter->get_text()) != -1;
-
-				if (!show)
-					continue;
-				if (!types.has(type))
-					add_type(type, types, root);
-
-				TreeItem *ti;
-				if (types.has(type))
-					ti = types[type];
-				else
-					ti = tree->get_root();
-
-				TreeItem *item = tree->create_item(ti);
-				item->set_metadata(0, type);
-				item->set_text(0, ct[i].name);
-				if (ct[i].icon.is_valid()) {
-					item->set_icon(0, ct[i].icon);
-				}
-			}
-		}
-	}
-}
-
-Object *CreateDialog::instance_selected() {
-
-	if (!tree->get_selected())
-		return NULL;
-
-	String base = String(tree->get_selected()->get_metadata(0));
-	if (base != "") {
-
-		String name = tree->get_selected()->get_text(0);
-		if (EditorNode::get_editor_data().get_custom_types().has(base)) {
-
-			const Vector<EditorData::CustomType> &ct = EditorNode::get_editor_data().get_custom_types()[base];
-			for (int i = 0; i < ct.size(); i++) {
-
-				if (ct[i].name == name) {
-
-					Object *obj = ClassDB::instance(base);
-					ERR_FAIL_COND_V(!obj, NULL);
-					obj->set_script(ct[i].script.get_ref_ptr());
-					if (ct[i].icon.is_valid())
-						obj->set_meta("_editor_icon", ct[i].icon);
-					return obj;
-				}
-			}
-		}
-
-		ERR_FAIL_V(NULL);
-	}
-
-	return ClassDB::instance(tree->get_selected()->get_text(0));
-}
-
-void CreateDialog::_bind_methods() {
-
-	ClassDB::bind_method("_create", &CreateDialog::_create);
-	ClassDB::bind_method("_cancel", &CreateDialog::_cancel);
-	ClassDB::bind_method("_text_changed", &CreateDialog::_text_changed);
-	ADD_SIGNAL(MethodInfo("create"));
-}
-
-void CreateDialog::set_base_type(const String &p_base) {
-
-	set_title(vformat("Create %s Type", p_base));
-
-	if (base == p_base)
-		return;
-	base = p_base;
-	if (is_inside_scene())
-		update_tree();
-}
-
-String CreateDialog::get_base_type() const {
-
-	return base;
-}
-
-CreateDialog::CreateDialog() {
-
-	VBoxContainer *vbc = memnew(VBoxContainer);
-	add_child(vbc);
-
-	get_ok()->set_text("Create");
-
-	tree = memnew(Tree);
-	vbc->add_margin_child("Type:", tree, true);
-	//tree->set_hide_root(true);
-
-	filter = memnew(LineEdit);
-	vbc->add_margin_child("Filter:", filter);
-
-	base = "Node";
-	set_as_toplevel(true);
-
-	tree->connect("item_activated", this, "_create");
-	filter->connect("text_changed", this, "_text_changed");
-}
-
-CreateDialog::~CreateDialog() {
-}
-
-#endif

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -40,8 +40,6 @@
 	@author Juan Linietsky <reduzio@gmail.com>
 */
 
-#if 1
-
 class CreateDialog : public ConfirmationDialog {
 
 	GDCLASS(CreateDialog, ConfirmationDialog)
@@ -92,47 +90,9 @@ public:
 	void set_base_type(const String &p_base);
 	String get_base_type() const;
 
-	void popup(bool p_dontclear);
+	void popup_create(bool p_dontclear);
 
 	CreateDialog();
 };
-
-#else
-
-//old create dialog, disabled
-
-class CreateDialog : public ConfirmationDialog {
-
-	GDCLASS(CreateDialog, ConfirmationDialog);
-
-	Tree *tree;
-	Button *create;
-	Button *cancel;
-	LineEdit *filter;
-
-	void update_tree();
-	void _create();
-	void _cancel();
-	void add_type(const String &p_type, HashMap<String, TreeItem *> &p_types, TreeItem
-																					  *p_root);
-
-	String base;
-	void _text_changed(String p_text);
-	virtual void _post_popup() { tree->grab_focus(); }
-
-protected:
-	static void _bind_methods();
-	void _notification(int p_what);
-
-public:
-	Object *instance_selected();
-
-	void set_base_type(const String &p_base);
-	String get_base_type() const;
-	CreateDialog();
-	~CreateDialog();
-};
-
-#endif
 
 #endif

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2294,7 +2294,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 #endif
 		case RESOURCE_NEW: {
 
-			create_dialog->popup(true);
+			create_dialog->popup_create(true);
 		} break;
 		case RESOURCE_LOAD: {
 

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -541,7 +541,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 					create_dialog->set_base_type("Object");
 				}
 
-				create_dialog->popup(false);
+				create_dialog->popup_create(false);
 				hide();
 				updating = false;
 				return false;

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -276,7 +276,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			if (!_validate_no_foreign())
 				break;
 			*/
-			create_dialog->popup(true);
+			create_dialog->popup_create(true);
 		} break;
 		case TOOL_INSTANCE: {
 
@@ -316,7 +316,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 		} break;
 		case TOOL_REPLACE: {
 
-			create_dialog->popup(false);
+			create_dialog->popup_create(false);
 		} break;
 		case TOOL_CONNECT: {
 

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -2271,7 +2271,7 @@ Control *VisualScriptEditor::get_edit_menu() {
 
 void VisualScriptEditor::_change_base_type() {
 
-	select_base_type->popup(true);
+	select_base_type->popup_create(true);
 }
 
 void VisualScriptEditor::_change_base_type_callback() {


### PR DESCRIPTION
- "Create New (Node)" dialog is now resizable and stores its bounds (like the other dialogs I previously did). Renamed the `popup` method to be like in the other dialogs (distuingishable from the default `popup`).
- Trashed the commented out code of the old Create New dialog as the new one works fine since many months now.