### PR TITLE
Fixed typo in gdscript autocompletion.

### DIFF
--- a/modules/gdscript/gd_editor.cpp
+++ b/modules/gdscript/gd_editor.cpp
@@ -405,7 +405,7 @@ static Ref<Reference> _get_parent_class(GDCompletionContext &context) {
 			if (script.is_null()) {
 				return REF();
 			}
-			if (script->is_valid()) {
+			if (!script->is_valid()) {
 
 				return REF();
 			}


### PR DESCRIPTION
There was a missing '!' sign, but now autocompletion shows parent script members too.
And that's cool.