### PR TITLE
X11: Don't reset mouse cursor theme.

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -332,12 +332,11 @@ void OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_au
 		WARN_PRINT("XCreateIC couldn't create xic");
 	}
 
-	XcursorSetTheme(x11_display, "default");
 	cursor_size = XcursorGetDefaultSize(x11_display);
 	cursor_theme = XcursorGetTheme(x11_display);
 
 	if (!cursor_theme) {
-		print_line("not found theme");
+		WARN_PRINT("Could not find cursor theme");
 		cursor_theme = "default";
 	}
 


### PR DESCRIPTION
On KDE (and possibly others) the "default" cursor theme is actually some system default, not the one you've set in the desktop setting.
This was especially annoying when using a white cursor, as Godot would then reset back to a dark one.
In my case it was also keeping the cursor from changing its shape.