### PR TITLE
Input: bind parse_input_event()

### DIFF
--- a/core/os/input.cpp
+++ b/core/os/input.cpp
@@ -83,6 +83,7 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("action_press", "action"), &Input::action_press);
 	ClassDB::bind_method(D_METHOD("action_release", "action"), &Input::action_release);
 	ClassDB::bind_method(D_METHOD("set_custom_mouse_cursor", "image:Texture", "hotspot"), &Input::set_custom_mouse_cursor, DEFVAL(Vector2()));
+	ClassDB::bind_method(D_METHOD("parse_input_event", "event"), &Input::parse_input_event);
 
 	BIND_CONSTANT(MOUSE_MODE_VISIBLE);
 	BIND_CONSTANT(MOUSE_MODE_HIDDEN);

--- a/core/os/input.h
+++ b/core/os/input.h
@@ -102,6 +102,8 @@ public:
 	virtual int get_joy_button_index_from_string(String p_button) = 0;
 	virtual int get_joy_axis_index_from_string(String p_axis) = 0;
 
+	virtual void parse_input_event(const InputEvent &p_event) = 0;
+
 	Input();
 };
 

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -201,7 +201,8 @@ public:
 
 	virtual void warp_mouse_pos(const Vector2 &p_to);
 
-	void parse_input_event(const InputEvent &p_event);
+	virtual void parse_input_event(const InputEvent &p_event);
+
 	void set_gravity(const Vector3 &p_gravity);
 	void set_accelerometer(const Vector3 &p_accel);
 	void set_magnetometer(const Vector3 &p_magnetometer);


### PR DESCRIPTION
When using `get_tree().input_event(ev)`, the engine will JUST send the event down the SceneTree.
However, you won't get any of the benefits of the Input singleton:
- No InputMap actions will be emitted
- The internal input state won't be modified, so methods like `Input.get_mouse_pos()` or `Input.is_joy_button_pressed` won't return the expected output after sending the event.

This is fixed by using `Input.parse_input_event(ev)` instead.
I guess we'll also have to update the docs to reflect that this is the preferred method of sending custom InputEvents.