### PR TITLE
Travis: Add clang-format test to ensure code quality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ env:
   - GODOT_TARGET=windows
 
 matrix:
+  include:
+    - env: STATIC_CHECKS=yes
   exclude:
     - os: linux
       env: GODOT_TARGET=iphone
@@ -42,6 +44,9 @@ matrix:
 
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
+      - llvm-toolchain-trusty-3.9
     packages:
       - build-essential
       - scons
@@ -65,6 +70,9 @@ addons:
       - g++-mingw-w64-x86-64
       - mingw-w64
 
+      # For style checks.
+      - clang-format-3.9
+
 
 before_script:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; brew install scons; fi
@@ -75,4 +83,8 @@ before_script:
     fi
 
 script:
-  - scons platform=$GODOT_TARGET CXX=$CXX openssl=builtin
+  - if [ "$STATIC_CHECKS" = "yes" ]; then
+      sh ./misc/travis/clang-format.sh;
+    else
+      scons platform=$GODOT_TARGET CXX=$CXX openssl=builtin;
+    fi

--- a/misc/travis/clang-format.sh
+++ b/misc/travis/clang-format.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+CLANG_FORMAT=clang-format-3.9
+
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+    # Check the whole commit range against $TRAVIS_BRANCH, the base merge branch
+    # We could use $TRAVIS_COMMIT_RANGE but it doesn't play well with force pushes
+    RANGE="$(git rev-parse $TRAVIS_BRANCH) HEAD"
+else
+    # Test only the last commit
+    RANGE=HEAD
+fi
+
+FILES=$(git diff-tree --no-commit-id --name-only -r $RANGE | grep -v thirdparty/ | grep -e "\.cpp$" -e "\.h$" -e "\.inc$")
+echo "Checking files:\n$FILES"
+
+# create a random filename to store our generated patch
+prefix="static-check-clang-format"
+suffix="$(date +%s)"
+patch="/tmp/$prefix-$suffix.patch"
+
+for file in $FILES; do
+    "$CLANG_FORMAT" -style=file "$file" | \
+        diff -u "$file" - | \
+        sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|" >> "$patch"
+done
+
+# if no patch has been generated all is ok, clean up the file stub and exit
+if [ ! -s "$patch" ] ; then
+    printf "Files in this commit comply with the clang-format rules.\n"
+    rm -f "$patch"
+    exit 0
+fi
+
+# a patch has been created, notify the user and exit
+printf "\n*** The following differences were found between the code to commit "
+printf "and the clang-format rules:\n\n"
+cat "$patch"
+printf "\n*** Aborting, please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\n"
+exit 1

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -2,7 +2,7 @@
 
 Import('env')
 
-# Not building in a separate env as core needs it
+# Not building in a separate env as scene needs it
 
 # Thirdparty source files
 if (env['builtin_freetype'] != 'no'):
@@ -64,24 +64,20 @@ if (env['builtin_freetype'] != 'no'):
     if (env['builtin_libpng'] != 'no'):
         env.Append(CPPPATH=["#thirdparty/libpng"])
 
-    """ FIXME: Remove this commented code if Windows can handle the monolithic lib
-	# fix for Windows' shell miserably failing on long lines, split in two libraries
-	half1 = []
-	half2 = []
-	for x in thirdparty_sources:
-		if (x.find("src/base") != -1 and x.find("src/sfnt") != -1):
-			half1.append(x)
-		else:
-			half2.append(x)
-
-	lib = env.Library("freetype_builtin1", half2)
-	env.Append(LIBS = [lib])
-	lib = env.Library("freetype_builtin2", half1)
-	env.Append(LIBS = [lib])
-	"""
-
     lib = env.Library("freetype_builtin", thirdparty_sources)
-    env.Append(LIBS=[lib])
+    # Needs to be appended to arrive after libscene in the linker call,
+    # but we don't want it to arrive *after* system libs, so manual hack
+    # LIBS contains first SCons Library objects ("SCons.Node.FS.File object")
+    # and then plain strings for system library. We insert between the two.
+    inserted = False
+    print(env["LIBS"])
+    for idx, linklib in enumerate(env["LIBS"]):
+        if isinstance(linklib, basestring): # first system lib such as "X11", otherwise SCons lib object
+            env["LIBS"].insert(idx, lib)
+            inserted = True
+            break
+    if not inserted:
+        env.Append(LIBS=[lib])
 
 # Godot source files
 env.add_source_files(env.modules_sources, "*.cpp")


### PR DESCRIPTION
If the commit(s) produce a diff with clang-format 3.9, the test fails.

My script is a bit quick and dirty but seems to work. We'll improve it little by little ;)