### PR TITLE
Android gravity vector Godot 2.1

### DIFF
--- a/platform/android/java/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/src/org/godotengine/godot/Godot.java
@@ -216,6 +216,7 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 
 	private SensorManager mSensorManager;
 	private Sensor mAccelerometer;
+	private Sensor mGravity;
 	private Sensor mMagnetometer;
 	private Sensor mGyroscope;
 
@@ -405,6 +406,8 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 		mSensorManager = (SensorManager) getSystemService(Context.SENSOR_SERVICE);
 		mAccelerometer = mSensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
 		mSensorManager.registerListener(this, mAccelerometer, SensorManager.SENSOR_DELAY_GAME);
+		mGravity = mSensorManager.getDefaultSensor(Sensor.TYPE_GRAVITY);
+		mSensorManager.registerListener(this, mGravity, SensorManager.SENSOR_DELAY_GAME);
 		mMagnetometer = mSensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD);
 		mSensorManager.registerListener(this, mMagnetometer, SensorManager.SENSOR_DELAY_GAME);
 		mGyroscope = mSensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE);
@@ -625,6 +628,7 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 
 		mView.onResume();
 		mSensorManager.registerListener(this, mAccelerometer, SensorManager.SENSOR_DELAY_GAME);
+		mSensorManager.registerListener(this, mGravity, SensorManager.SENSOR_DELAY_GAME);
 		mSensorManager.registerListener(this, mMagnetometer, SensorManager.SENSOR_DELAY_GAME);
 		mSensorManager.registerListener(this, mGyroscope, SensorManager.SENSOR_DELAY_GAME);
 		GodotLib.focusin();
@@ -689,6 +693,9 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 		int typeOfSensor = event.sensor.getType();
 		if (typeOfSensor == event.sensor.TYPE_ACCELEROMETER) {
 			GodotLib.accelerometer(x,y,z);
+		}
+		if (typeOfSensor == event.sensor.TYPE_GRAVITY) {
+			GodotLib.gravity(x,y,z);
 		}
 		if (typeOfSensor == event.sensor.TYPE_MAGNETIC_FIELD) {
 			GodotLib.magnetometer(x,y,z);

--- a/platform/android/java/src/org/godotengine/godot/GodotLib.java
+++ b/platform/android/java/src/org/godotengine/godot/GodotLib.java
@@ -33,37 +33,38 @@ package org.godotengine.godot;
 public class GodotLib {
 
 
-     public static GodotIO io;
+	public static GodotIO io;
 
-     static {
+	static {
 	 System.loadLibrary("godot_android");
-     }
+	}
 
-    /**
-     * @param width the current view width
-     * @param height the current view height
-     */
+	/**
+	* @param width the current view width
+	* @param height the current view height
+	*/
 
-     public static native void initialize(Godot p_instance,boolean need_reload_hook,String[] p_cmdline,Object p_asset_manager);
-     public static native void resize(int width, int height,boolean reload);
-     public static native void newcontext(boolean p_32_bits);
-     public static native void quit();
-     public static native void step();
-     public static native void touch(int what,int pointer,int howmany, int[] arr);
-     public static native void accelerometer(float x, float y, float z);
-     public static native void magnetometer(float x, float y, float z);
-     public static native void gyroscope(float x, float y, float z);
-	 public static native void key(int p_scancode, int p_unicode_char, boolean p_pressed);
-	 public static native void joybutton(int p_device, int p_but, boolean p_pressed);
-	 public static native void joyaxis(int p_device, int p_axis, float p_value);
-	 public static native void joyhat(int p_device, int p_hat_x, int p_hat_y);
-	 public static native void joyconnectionchanged(int p_device, boolean p_connected, String p_name);
-     public static native void focusin();
-     public static native void focusout();
-     public static native void audio();
-     public static native void singleton(String p_name,Object p_object);
-     public static native void method(String p_sname,String p_name,String p_ret,String[] p_params);
-     public static native String getGlobal(String p_key);
+	public static native void initialize(Godot p_instance,boolean need_reload_hook,String[] p_cmdline,Object p_asset_manager);
+	public static native void resize(int width, int height,boolean reload);
+	public static native void newcontext(boolean p_32_bits);
+	public static native void quit();
+	public static native void step();
+	public static native void touch(int what,int pointer,int howmany, int[] arr);
+	public static native void accelerometer(float x, float y, float z);
+	public static native void gravity(float x, float y, float z);
+	public static native void magnetometer(float x, float y, float z);
+	public static native void gyroscope(float x, float y, float z);
+	public static native void key(int p_scancode, int p_unicode_char, boolean p_pressed);
+	public static native void joybutton(int p_device, int p_but, boolean p_pressed);
+	public static native void joyaxis(int p_device, int p_axis, float p_value);
+	public static native void joyhat(int p_device, int p_hat_x, int p_hat_y);
+	public static native void joyconnectionchanged(int p_device, boolean p_connected, String p_name);
+	public static native void focusin();
+	public static native void focusout();
+	public static native void audio();
+	public static native void singleton(String p_name,Object p_object);
+	public static native void method(String p_sname,String p_name,String p_ret,String[] p_params);
+	public static native String getGlobal(String p_key);
 	public static native void callobject(int p_ID, String p_method, Object[] p_params);
 	public static native void calldeferred(int p_ID, String p_method, Object[] p_params);
 

--- a/platform/android/java_glue.cpp
+++ b/platform/android/java_glue.cpp
@@ -620,6 +620,7 @@ static bool resized_reload = false;
 static bool quit_request = false;
 static Size2 new_size;
 static Vector3 accelerometer;
+static Vector3 gravity;
 static Vector3 magnetometer;
 static Vector3 gyroscope;
 static HashMap<String, JNISingleton *> jni_singletons;
@@ -1051,6 +1052,8 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env, job
 
 	os_android->process_accelerometer(accelerometer);
 
+	os_android->process_gravitymeter(gravity);
+
 	os_android->process_magnetometer(magnetometer);
 
 	os_android->process_gyroscope(gyroscope);
@@ -1446,6 +1449,13 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_accelerometer(JNIEnv 
 
 	input_mutex->lock();
 	accelerometer = Vector3(x, y, z);
+	input_mutex->unlock();
+}
+
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_gravity(JNIEnv *env, jobject obj, jfloat x, jfloat y, jfloat z) {
+
+	input_mutex->lock();
+	gravity = Vector3(x, y, z);
 	input_mutex->unlock();
 }
 

--- a/platform/android/java_glue.h
+++ b/platform/android/java_glue.h
@@ -48,6 +48,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_joyhat(JNIEnv *env, j
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_joyconnectionchanged(JNIEnv *env, jobject obj, jint p_device, jboolean p_connected, jstring p_name);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_audio(JNIEnv *env, jobject obj);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_accelerometer(JNIEnv *env, jobject obj, jfloat x, jfloat y, jfloat z);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_gravity(JNIEnv *env, jobject obj, jfloat x, jfloat y, jfloat z);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_magnetometer(JNIEnv *env, jobject obj, jfloat x, jfloat y, jfloat z);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_gyroscope(JNIEnv *env, jobject obj, jfloat x, jfloat y, jfloat z);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_focusin(JNIEnv *env, jobject obj);

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -580,6 +580,11 @@ void OS_Android::process_accelerometer(const Vector3 &p_accelerometer) {
 	input->set_accelerometer(p_accelerometer);
 }
 
+void OS_Android::process_gravitymeter(const Vector3 &p_gravitymeter) {
+
+	input->set_gravity(p_gravitymeter);
+}
+
 void OS_Android::process_magnetometer(const Vector3 &p_magnetometer) {
 
 	input->set_magnetometer(p_magnetometer);

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -238,6 +238,7 @@ public:
 	virtual String get_system_dir(SystemDir p_dir) const;
 
 	void process_accelerometer(const Vector3 &p_accelerometer);
+	void process_gravitymeter(const Vector3 &p_gravitymeter);
 	void process_magnetometer(const Vector3 &p_magnetometer);
 	void process_gyroscope(const Vector3 &p_gyroscope);
 	void process_touch(int p_what, int p_pointer, const Vector<TouchPos> &p_points);


### PR DESCRIPTION
This PR adds support for reading the gravity vector sensor. This is a vector the OS calculates from the accelerometer sensor with some nice math to filter out any user vibration/movement. It is very useful in getting a more accurate "down" vector for stabilizing device orientation or for getting an approximate user movement by subtracting this vector from the accelerometer output.

Mainly it's added to create parity with the core motion changes we did for iOS for issue #7503 

In theory the test project I did for coremotion should work to test this as well:
https://github.com/BastiaanOlij/TestCoreMotion

Due to lacking a suitable android device that actually has these sensors I've not been able to actually test this so I'm hoping someone with device that has all 3 sensors could give this a go?

And since @akien-mga refactored half the 2.1 branch this probably works in Godot 3 too.