### PR TITLE
Fix Particles2D process mode back-compat issue (2.1)

### DIFF
--- a/scene/2d/particles_2d.cpp
+++ b/scene/2d/particles_2d.cpp
@@ -453,6 +453,9 @@ void Particles2D::_notification(int p_what) {
 
 		case NOTIFICATION_ENTER_TREE: {
 
+			// For projects saved before "process_mode" was introduced
+			set_process_mode(process_mode);
+
 			float ppt = preprocess;
 			while (ppt > 0) {
 				_process_particles(0.1);


### PR DESCRIPTION
Since scene files before `process_mode` was introduced don't have a value for that, particle systems don't get its `set_process_mode()` called.

This workarounds that by forcing it to be called.

Fixes #8089.