### PR TITLE
Fix random crashes when using yield()

### DIFF
--- a/modules/gdscript/gd_function.cpp
+++ b/modules/gdscript/gd_function.cpp
@@ -189,7 +189,7 @@ Variant GDFunction::call(GDInstance *p_instance, const Variant **p_args, int p_a
 	if (p_state) {
 		//use existing (supplied) state (yielded)
 		stack = (Variant *)p_state->stack.ptr();
-		call_args = (Variant **)stack + sizeof(Variant) * p_state->stack_size;
+		call_args = (Variant **)&p_state->stack.ptr()[sizeof(Variant) * p_state->stack_size]; //ptr() to avoid bounds check
 		line = p_state->line;
 		ip = p_state->ip;
 		alloca_size = p_state->stack.size();


### PR DESCRIPTION
e8611966de4dfc9c28a7a4de1798f3f10ff87f80 intended to replace indexed operator by pointer arithmetic, but in the way altered the meaning of the code in a subtle way.

I was getting random crashes at random places where I was using `yield()` heavily.

This PR makes everything work again, while keeping the intent of the referred commit.

~UPDATE: Getting crashes now on Android. Looking deeper...~

UPDATE: **Now it's fixed.** I had got lost in the expression and my first attempt was wrong, more or less the same that happened to the original author. @hpvb, If only there were GPS for these, don't you think? :)