### PR TITLE
 Add editor option for automatically closing the output when stopping the game (2.1)

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2546,6 +2546,14 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			play_custom_scene_button->set_pressed(false);
 			play_custom_scene_button->set_icon(gui_base->get_icon("PlayCustom", "EditorIcons"));
 			//pause_button->set_pressed(false);
+			if (bool(EDITOR_DEF("run/always_close_output_on_stop", false))) {
+				for (int i = 0; i < bottom_panel_items.size(); i++) {
+					if (bottom_panel_items[i].control == log) {
+						_bottom_panel_switch(false, i);
+						break;
+					}
+				}
+			}
 			emit_signal("stop_pressed");
 
 		} break;

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -641,6 +641,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("resources/save_compressed_resources", true);
 	set("resources/auto_reload_modified_images", true);
 
+	set("run/always_close_output_on_stop", false);
+
 	set("import/automatic_reimport_on_sources_changed", true);
 
 	if (p_extra_config.is_valid()) {


### PR DESCRIPTION
(back-ported from 1bd1af776c111f1efdd9a3b0259d8f916c052ef2)