### PR TITLE
Fixing magnetometer on iOS

### DIFF
--- a/platform/iphone/app_delegate.mm
+++ b/platform/iphone/app_delegate.mm
@@ -299,7 +299,7 @@ static int frame_count = 0;
  		motionManager = [[CMMotionManager alloc] init];
  		if (motionManager.deviceMotionAvailable) {
  			motionManager.deviceMotionUpdateInterval = 1.0/70.0;
- 			[motionManager startDeviceMotionUpdates];			
+ 			[motionManager startDeviceMotionUpdatesUsingReferenceFrame:CMAttitudeReferenceFrameXMagneticNorthZVertical];			
 			motionInitialised = YES;
  		};
  	};


### PR DESCRIPTION
This must be the tiniest PR I've done so far :)

This adds one extra parameter to starting device motion on iOS that enables reading out the magnetometer. 

I'm not out of the woods yet, the results returned seem weird, maybe someone else can have a look and see if they can make sense of it. My suspicion is that the magnetometer is the only output iOS does not adjust for device orientation and the counter adjustments currently done are therefor wrong.

I'll be doing more work on this in the coming few days to nail this :)