### PR TITLE
Make inline blocks in GDScript more (or less) pythonic

### DIFF
--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -76,7 +76,7 @@ bool GDParser::_enter_indent_block(BlockNode *p_block) {
 
 		// be more python-like
 		int current = tab_level.back()->get();
-		tab_level.push_back(current + 1);
+		tab_level.push_back(current);
 		return true;
 		//_set_error("newline expected after ':'.");
 		//return false;
@@ -2258,7 +2258,15 @@ void GDParser::_parse_block(BlockNode *p_block, bool p_static) {
 	p_block->statements.push_back(nl);
 #endif
 
+	bool is_first_line = true;
+
 	while (true) {
+		if (!is_first_line && tab_level.back()->prev() && tab_level.back()->prev()->get() == indent_level) {
+			// pythonic single-line expression, don't parse future lines
+			tab_level.pop_back();
+			return;
+		}
+		is_first_line = false;
 
 		GDTokenizer::Token token = tokenizer->get_token();
 		if (error_set)


### PR DESCRIPTION
Fixes #8001

From https://github.com/godotengine/godot/issues/8001#issuecomment-288686466 on it: (Quoting just in case)
> So, testing with python3, the following are allowed:
> ```py3
> if 1: print(1)
> if 1:
>   print(1)
> for i in (0,1,2): print(1)
> ```
> While the following are not:
> ```py3
> if 1: print(1)
>   print(2)
> for i in (0,1,2): if 1: print(1)
> for i in (0,1,2): if 1:
>   print(1)
> ```
> 
> Currently, in GDScript, all of the first group are allowed, in addition to:
> ```gdscript
> if 1: print(1)
>   print(2)
> for i in [0,1,2]: if 1: print(1)
> ```

With this PR, GDScript now supports the following:
```gdscript
for i in (0,1,2): if 1:
  print(1)
for i in (0,1,2): if 1: print(1)
```
But, it also drop the support for the following:
```gdscript
if 1: print(1)
  print(2)
```
