### PR TITLE
Fix wrong app name for Android export

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -2725,7 +2725,7 @@ class EditorExportAndroid : public EditorExportPlatform {
 
 		Vector<String> string_table;
 
-		String version_name = p_preset->get("version/name");
+		String package_name = p_preset->get("package/name");
 
 		//printf("stirng block len: %i\n",string_block_len);
 		//printf("stirng count: %i\n",string_count);
@@ -2742,7 +2742,7 @@ class EditorExportAndroid : public EditorExportPlatform {
 
 				if (str == "godot-project-name") {
 					//project name
-					str = get_project_name(version_name);
+					str = get_project_name(package_name);
 
 				} else {
 
@@ -2751,7 +2751,7 @@ class EditorExportAndroid : public EditorExportPlatform {
 					if (GlobalConfig::get_singleton()->has(prop)) {
 						str = GlobalConfig::get_singleton()->get(prop);
 					} else {
-						str = get_project_name(version_name);
+						str = get_project_name(package_name);
 					}
 				}
 			}


### PR DESCRIPTION
It shows version name like "1.0" instead of package/name or project name.