### PR TITLE
Reworked change_dir to support symlinks 

### DIFF
--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -222,36 +222,38 @@ Error DirAccessUnix::make_dir(String p_dir) {
 Error DirAccessUnix::change_dir(String p_dir) {
 
 	GLOBAL_LOCK_FUNCTION
-	p_dir = fix_path(p_dir);
-
-	char real_current_dir_name[2048];
-	getcwd(real_current_dir_name, 2048);
-	String prev_dir;
-	if (prev_dir.parse_utf8(real_current_dir_name))
-		prev_dir = real_current_dir_name; //no utf8, maybe latin?
-
-	chdir(current_dir.utf8().get_data()); //ascii since this may be unicode or wathever the host os wants
-	bool worked = (chdir(p_dir.utf8().get_data()) == 0); // we can only give this utf8
-
-	String base = _get_root_path();
-	if (base != "") {
-
-		getcwd(real_current_dir_name, 2048);
-		String new_dir;
-		new_dir.parse_utf8(real_current_dir_name);
-		if (!new_dir.begins_with(base))
-			worked = false;
+		
+	// make sure current_dir is valid absolute path
+	if (current_dir == "." || current_dir == "") {
+		char real_current_dir_name[2048];
+		getcwd(real_current_dir_name,2048);
+		current_dir.parse_utf8(real_current_dir_name);
 	}
 
-	if (worked) {
+	if (p_dir == ".") {
+		return OK;
+	}
+		
+	p_dir=fix_path(p_dir);
 
-		getcwd(real_current_dir_name, 2048);
-		if (current_dir.parse_utf8(real_current_dir_name))
-			current_dir = real_current_dir_name; //no utf8, maybe latin?
+	String prev_dir = current_dir;
+
+	if (p_dir.is_rel_path()) {
+		String next_dir = current_dir + "/" + p_dir;
+		next_dir = next_dir.simplify_path();
+		current_dir = next_dir;
+	}
+	else {
+		current_dir = p_dir;
+	} 
+
+	bool worked=(chdir(current_dir.utf8().get_data())==0); // we can only give this utf8
+	if (!worked) {
+		current_dir = prev_dir;
+		return ERR_INVALID_PARAMETER;
 	}
 
-	chdir(prev_dir.utf8().get_data());
-	return worked ? OK : ERR_INVALID_PARAMETER;
+	return OK;
 }
 
 String DirAccessUnix::get_current_dir() {

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -237,38 +237,38 @@ Error DirAccessUnix::make_dir(String p_dir) {
 Error DirAccessUnix::change_dir(String p_dir) {
 
 	GLOBAL_LOCK_FUNCTION
+		
+	// make sure current_dir is valid absolute path
+	if (current_dir == "." || current_dir == "") {
+		char real_current_dir_name[2048];
+		getcwd(real_current_dir_name,2048);
+		current_dir.parse_utf8(real_current_dir_name);
+	}
+
+	if (p_dir == ".") {
+		return OK;
+	}
+		
 	p_dir=fix_path(p_dir);
 
+	String prev_dir = current_dir;
 
-	char real_current_dir_name[2048];
-	getcwd(real_current_dir_name,2048);
-	String prev_dir;
-	if (prev_dir.parse_utf8(real_current_dir_name))
-		prev_dir=real_current_dir_name; //no utf8, maybe latin?
+	if (p_dir.is_rel_path()) {
+		String next_dir = current_dir + "/" + p_dir;
+		next_dir = next_dir.simplify_path();
+		current_dir = next_dir;
+	}
+	else {
+		current_dir = p_dir;
+	} 
 
-	chdir(current_dir.utf8().get_data()); //ascii since this may be unicode or wathever the host os wants
-	bool worked=(chdir(p_dir.utf8().get_data())==0); // we can only give this utf8
-
-	String base = _get_root_path();
-	if (base!="") {
-
-		getcwd(real_current_dir_name,2048);
-		String new_dir;
-		new_dir.parse_utf8(real_current_dir_name);
-		if (!new_dir.begins_with(base))
-			worked=false;
+	bool worked=(chdir(current_dir.utf8().get_data())==0); // we can only give this utf8
+	if (!worked) {
+		current_dir = prev_dir;
+		return ERR_INVALID_PARAMETER;
 	}
 
-	if (worked) {
-
-		getcwd(real_current_dir_name,2048);
-		if (current_dir.parse_utf8(real_current_dir_name))
-			current_dir=real_current_dir_name; //no utf8, maybe latin?
-	}
-
-	chdir(prev_dir.utf8().get_data());
-	return worked?OK:ERR_INVALID_PARAMETER;
-
+	return OK;
 }
 
 String DirAccessUnix::get_current_dir() {
@@ -281,7 +281,6 @@ String DirAccessUnix::get_current_dir() {
 			return _get_root_string()+bd.substr(1,bd.length());
 		else
 			return _get_root_string()+bd;
-
 	}
 	return current_dir;
 }
@@ -345,7 +344,6 @@ DirAccessUnix::DirAccessUnix() {
 	/* determine drive count */
 
 	change_dir(current_dir);
-
 }
 
 


### PR DESCRIPTION
Same as https://github.com/godotengine/godot/pull/7935
But I put it in a branch at my end so I can work on other stuff (accidentally had it in my master branch):
Original note for reference:


I have rewritten change_dir to support symlinks.
This works by allowing current_dir to diverge from what getcwd deems is the current directory as getcwd resolves symlinks to the actual real directory which we do not want to do.

This is a potential fix for #6539, #6047 and #5700