### PR TITLE
Update build.gradle.template for jcenter

### DIFF
--- a/platform/android/build.gradle.template
+++ b/platform/android/build.gradle.template
@@ -12,6 +12,7 @@ apply plugin: 'com.android.application'
 
 allprojects {
     repositories {
+    	jcenter()
 	mavenCentral()
 	$$GRADLE_REPOSITORY_URLS$$
     }


### PR DESCRIPTION
Updating project repository,
added jcenter() since Android Studio uses it by default.

https://www.jfrog.com/knowledge-base/why-should-i-use-jcenter-over-maven-central/