### PR TITLE
Input: Remove usage of platform dependent event IDs.

### DIFF
--- a/main/input_default.h
+++ b/main/input_default.h
@@ -169,8 +169,8 @@ private:
 	Vector<JoyDeviceMapping> map_db;
 
 	JoyEvent _find_to_event(String p_to);
-	uint32_t _button_event(uint32_t p_last_id, int p_device, int p_index, bool p_pressed);
-	uint32_t _axis_event(uint32_t p_last_id, int p_device, int p_axis, float p_value);
+	void _button_event(int p_device, int p_index, bool p_pressed);
+	void _axis_event(int p_device, int p_axis, float p_value);
 	float _handle_deadzone(int p_device, int p_axis, float p_value);
 
 public:
@@ -228,9 +228,9 @@ public:
 	virtual void set_mouse_in_window(bool p_in_window);
 
 	void parse_mapping(String p_mapping);
-	uint32_t joy_button(uint32_t p_last_id, int p_device, int p_button, bool p_pressed);
-	uint32_t joy_axis(uint32_t p_last_id, int p_device, int p_axis, const JoyAxis &p_value);
-	uint32_t joy_hat(uint32_t p_last_id, int p_device, int p_val);
+	void joy_button(int p_device, int p_button, bool p_pressed);
+	void joy_axis(int p_device, int p_axis, const JoyAxis &p_value);
+	void joy_hat(int p_device, int p_val);
 
 	virtual void add_joy_mapping(String p_mapping, bool p_update_existing = false);
 	virtual void remove_joy_mapping(String p_guid);

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -129,7 +129,7 @@ void OS_Android::initialize(const VideoMode &p_desired, int p_video_driver, int 
 	RasterizerGLES3::make_current();
 
 	visual_server = memnew(VisualServerRaster);
-/*	if (get_render_thread_mode() != RENDER_THREAD_UNSAFE) {
+	/*	if (get_render_thread_mode() != RENDER_THREAD_UNSAFE) {
 
 		visual_server = memnew(VisualServerWrapMT(visual_server, false));
 	};*/
@@ -343,16 +343,16 @@ void OS_Android::process_joy_event(OS_Android::JoypadEvent p_event) {
 
 	switch (p_event.type) {
 		case JOY_EVENT_BUTTON:
-			last_id = input->joy_button(last_id, p_event.device, p_event.index, p_event.pressed);
+			input->joy_button(p_event.device, p_event.index, p_event.pressed);
 			break;
 		case JOY_EVENT_AXIS:
 			InputDefault::JoyAxis value;
 			value.min = -1;
 			value.value = p_event.value;
-			last_id = input->joy_axis(last_id, p_event.device, p_event.index, value);
+			input->joy_axis(p_event.device, p_event.index, value);
 			break;
 		case JOY_EVENT_HAT:
-			last_id = input->joy_hat(last_id, p_event.device, p_event.hat);
+			input->joy_hat(p_event.device, p_event.hat);
 			break;
 		default:
 			return;
@@ -361,7 +361,6 @@ void OS_Android::process_joy_event(OS_Android::JoypadEvent p_event) {
 
 void OS_Android::process_event(InputEvent p_event) {
 
-	p_event.ID = last_id++;
 	input->parse_input_event(p_event);
 }
 
@@ -376,7 +375,6 @@ void OS_Android::process_touch(int p_what, int p_pointer, const Vector<TouchPos>
 				//end all if exist
 				InputEvent ev;
 				ev.type = InputEvent::MOUSE_BUTTON;
-				ev.ID = last_id++;
 				ev.mouse_button.button_index = BUTTON_LEFT;
 				ev.mouse_button.button_mask = BUTTON_MASK_LEFT;
 				ev.mouse_button.pressed = false;
@@ -390,7 +388,6 @@ void OS_Android::process_touch(int p_what, int p_pointer, const Vector<TouchPos>
 
 					InputEvent ev;
 					ev.type = InputEvent::SCREEN_TOUCH;
-					ev.ID = last_id++;
 					ev.screen_touch.index = touch[i].id;
 					ev.screen_touch.pressed = false;
 					ev.screen_touch.x = touch[i].pos.x;
@@ -409,7 +406,6 @@ void OS_Android::process_touch(int p_what, int p_pointer, const Vector<TouchPos>
 				//send mouse
 				InputEvent ev;
 				ev.type = InputEvent::MOUSE_BUTTON;
-				ev.ID = last_id++;
 				ev.mouse_button.button_index = BUTTON_LEFT;
 				ev.mouse_button.button_mask = BUTTON_MASK_LEFT;
 				ev.mouse_button.pressed = true;
@@ -417,7 +413,7 @@ void OS_Android::process_touch(int p_what, int p_pointer, const Vector<TouchPos>
 				ev.mouse_button.y = touch[0].pos.y;
 				ev.mouse_button.global_x = touch[0].pos.x;
 				ev.mouse_button.global_y = touch[0].pos.y;
-				input->set_mouse_pos(Point2(touch[0].pos.x,touch[0].pos.y));
+				input->set_mouse_pos(Point2(touch[0].pos.x, touch[0].pos.y));
 				last_mouse = touch[0].pos;
 				input->parse_input_event(ev);
 			}
@@ -427,7 +423,6 @@ void OS_Android::process_touch(int p_what, int p_pointer, const Vector<TouchPos>
 
 				InputEvent ev;
 				ev.type = InputEvent::SCREEN_TOUCH;
-				ev.ID = last_id++;
 				ev.screen_touch.index = touch[i].id;
 				ev.screen_touch.pressed = true;
 				ev.screen_touch.x = touch[i].pos.x;
@@ -442,7 +437,6 @@ void OS_Android::process_touch(int p_what, int p_pointer, const Vector<TouchPos>
 				//send mouse, should look for point 0?
 				InputEvent ev;
 				ev.type = InputEvent::MOUSE_MOTION;
-				ev.ID = last_id++;
 				ev.mouse_motion.button_mask = BUTTON_MASK_LEFT;
 				ev.mouse_motion.x = p_points[0].pos.x;
 				ev.mouse_motion.y = p_points[0].pos.y;
@@ -475,7 +469,6 @@ void OS_Android::process_touch(int p_what, int p_pointer, const Vector<TouchPos>
 
 				InputEvent ev;
 				ev.type = InputEvent::SCREEN_DRAG;
-				ev.ID = last_id++;
 				ev.screen_drag.index = touch[i].id;
 				ev.screen_drag.x = p_points[idx].pos.x;
 				ev.screen_drag.y = p_points[idx].pos.y;
@@ -492,7 +485,6 @@ void OS_Android::process_touch(int p_what, int p_pointer, const Vector<TouchPos>
 				//end all if exist
 				InputEvent ev;
 				ev.type = InputEvent::MOUSE_BUTTON;
-				ev.ID = last_id++;
 				ev.mouse_button.button_index = BUTTON_LEFT;
 				ev.mouse_button.button_mask = BUTTON_MASK_LEFT;
 				ev.mouse_button.pressed = false;
@@ -500,14 +492,13 @@ void OS_Android::process_touch(int p_what, int p_pointer, const Vector<TouchPos>
 				ev.mouse_button.y = touch[0].pos.y;
 				ev.mouse_button.global_x = touch[0].pos.x;
 				ev.mouse_button.global_y = touch[0].pos.y;
-				input->set_mouse_pos(Point2(touch[0].pos.x,touch[0].pos.y));
+				input->set_mouse_pos(Point2(touch[0].pos.x, touch[0].pos.y));
 				input->parse_input_event(ev);
 
 				for (int i = 0; i < touch.size(); i++) {
 
 					InputEvent ev;
 					ev.type = InputEvent::SCREEN_TOUCH;
-					ev.ID = last_id++;
 					ev.screen_touch.index = touch[i].id;
 					ev.screen_touch.pressed = false;
 					ev.screen_touch.x = touch[i].pos.x;
@@ -527,7 +518,6 @@ void OS_Android::process_touch(int p_what, int p_pointer, const Vector<TouchPos>
 
 			InputEvent ev;
 			ev.type = InputEvent::SCREEN_TOUCH;
-			ev.ID = last_id++;
 			ev.screen_touch.index = tp.id;
 			ev.screen_touch.pressed = true;
 			ev.screen_touch.x = tp.pos.x;
@@ -542,7 +532,6 @@ void OS_Android::process_touch(int p_what, int p_pointer, const Vector<TouchPos>
 
 					InputEvent ev;
 					ev.type = InputEvent::SCREEN_TOUCH;
-					ev.ID = last_id++;
 					ev.screen_touch.index = touch[i].id;
 					ev.screen_touch.pressed = false;
 					ev.screen_touch.x = touch[i].pos.x;
@@ -627,8 +616,8 @@ void OS_Android::reload_gfx() {
 
 	if (gfx_init_func)
 		gfx_init_func(gfx_init_ud, use_gl2);
-//	if (rasterizer)
-//		rasterizer->reload_vram();
+	//if (rasterizer)
+	//	rasterizer->reload_vram();
 }
 
 Error OS_Android::shell_open(String p_uri) {
@@ -746,9 +735,9 @@ void OS_Android::native_video_stop() {
 
 void OS_Android::set_context_is_16_bits(bool p_is_16) {
 
-//	use_16bits_fbo = p_is_16;
-//	if (rasterizer)
-//		rasterizer->set_force_16_bits_fbo(p_is_16);
+	//use_16bits_fbo = p_is_16;
+	//if (rasterizer)
+	//	rasterizer->set_force_16_bits_fbo(p_is_16);
 }
 
 void OS_Android::joy_connection_changed(int p_device, bool p_connected, String p_name) {
@@ -774,9 +763,8 @@ OS_Android::OS_Android(GFXInitFunc p_gfx_init_func, void *p_gfx_init_ud, OpenURI
 	gfx_init_func = p_gfx_init_func;
 	gfx_init_ud = p_gfx_init_ud;
 	main_loop = NULL;
-	last_id = 1;
 	gl_extensions = NULL;
-//	rasterizer = NULL;
+	//rasterizer = NULL;
 	use_gl2 = false;
 
 	open_uri_func = p_open_uri_func;

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -94,7 +94,6 @@ private:
 	Vector<TouchPos> touch;
 
 	Point2 last_mouse;
-	unsigned int last_id;
 	GFXInitFunc gfx_init_func;
 	void *gfx_init_ud;
 

--- a/platform/bb10/os_bb10.cpp
+++ b/platform/bb10/os_bb10.cpp
@@ -282,7 +282,6 @@ void OSBB10::handle_screen_event(bps_event_t *event) {
 
 			InputEvent ievent;
 			ievent.type = InputEvent::SCREEN_TOUCH;
-			ievent.ID = ++last_id;
 			ievent.device = 0;
 			ievent.screen_touch.pressed = (screen_val == SCREEN_EVENT_MTOUCH_TOUCH);
 			ievent.screen_touch.x = pos[0];
@@ -301,7 +300,6 @@ void OSBB10::handle_screen_event(bps_event_t *event) {
 
 				InputEvent ievent;
 				ievent.type = InputEvent::MOUSE_BUTTON;
-				ievent.ID = ++last_id;
 				ievent.device = 0;
 				ievent.mouse_button.pressed = (screen_val == SCREEN_EVENT_MTOUCH_TOUCH);
 				ievent.mouse_button.button_index = BUTTON_LEFT;
@@ -318,7 +316,6 @@ void OSBB10::handle_screen_event(bps_event_t *event) {
 
 			InputEvent ievent;
 			ievent.type = InputEvent::SCREEN_DRAG;
-			ievent.ID = ++last_id;
 			ievent.device = 0;
 			ievent.screen_drag.x = pos[0];
 			ievent.screen_drag.y = pos[1];
@@ -347,7 +344,6 @@ void OSBB10::handle_screen_event(bps_event_t *event) {
 
 				InputEvent ievent;
 				ievent.type = InputEvent::MOUSE_MOTION;
-				ievent.ID = ++last_id;
 				ievent.device = 0;
 				ievent.mouse_motion.x = ievent.mouse_motion.global_x = mpos.x;
 				ievent.mouse_motion.y = ievent.mouse_motion.global_y = mpos.y;
@@ -366,7 +362,6 @@ void OSBB10::handle_screen_event(bps_event_t *event) {
 
 			InputEvent ievent;
 			ievent.type = InputEvent::KEY;
-			ievent.ID = ++last_id;
 			ievent.device = 0;
 			int val = 0;
 			screen_get_event_property_iv(screen_event, SCREEN_PROPERTY_KEY_SCAN, &val);
@@ -595,7 +590,6 @@ int OSBB10::get_power_percent_left() {
 OSBB10::OSBB10() {
 
 	main_loop = NULL;
-	last_id = 1;
 	minimized = false;
 	fullscreen = true;
 	flip_accelerometer = true;

--- a/platform/bb10/os_bb10.h
+++ b/platform/bb10/os_bb10.h
@@ -48,8 +48,6 @@
 
 class OSBB10 : public OS_Unix {
 
-	unsigned int last_id;
-
 	screen_context_t screen_cxt;
 	float fullscreen_mixer_volume;
 	float fullscreen_stream_volume;

--- a/platform/haiku/haiku_direct_window.cpp
+++ b/platform/haiku/haiku_direct_window.cpp
@@ -151,7 +151,6 @@ void HaikuDirectWindow::HandleMouseButton(BMessage *message) {
 	*/
 
 	InputEvent mouse_event;
-	mouse_event.ID = ++event_id;
 	mouse_event.type = InputEvent::MOUSE_BUTTON;
 	mouse_event.device = 0;
 
@@ -208,7 +207,6 @@ void HaikuDirectWindow::HandleMouseMoved(BMessage *message) {
 	Point2i rel = pos - last_mouse_position;
 
 	InputEvent motion_event;
-	motion_event.ID = ++event_id;
 	motion_event.type = InputEvent::MOUSE_MOTION;
 	motion_event.device = 0;
 
@@ -237,7 +235,6 @@ void HaikuDirectWindow::HandleMouseWheelChanged(BMessage *message) {
 	}
 
 	InputEvent mouse_event;
-	mouse_event.ID = ++event_id;
 	mouse_event.type = InputEvent::MOUSE_BUTTON;
 	mouse_event.device = 0;
 
@@ -252,7 +249,6 @@ void HaikuDirectWindow::HandleMouseWheelChanged(BMessage *message) {
 	mouse_event.mouse_button.pressed = true;
 	input->parse_input_event(mouse_event);
 
-	mouse_event.ID = ++event_id;
 	mouse_event.mouse_button.pressed = false;
 	input->parse_input_event(mouse_event);
 }
@@ -275,7 +271,6 @@ void HaikuDirectWindow::HandleKeyboardEvent(BMessage *message) {
 	}
 
 	InputEvent event;
-	event.ID = ++event_id;
 	event.type = InputEvent::KEY;
 	event.device = 0;
 	event.key.mod = GetKeyModifierState(modifiers);
@@ -313,7 +308,6 @@ void HaikuDirectWindow::HandleKeyboardModifierEvent(BMessage *message) {
 	int32 key = old_modifiers ^ modifiers;
 
 	InputEvent event;
-	event.ID = ++event_id;
 	event.type = InputEvent::KEY;
 	event.device = 0;
 	event.key.mod = GetKeyModifierState(modifiers);

--- a/platform/haiku/haiku_direct_window.h
+++ b/platform/haiku/haiku_direct_window.h
@@ -43,7 +43,6 @@
 
 class HaikuDirectWindow : public BDirectWindow {
 private:
-	unsigned int event_id;
 	Point2i last_mouse_position;
 	bool last_mouse_pos_valid;
 	uint32 last_buttons_state;

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -196,7 +196,6 @@ void OSIPhone::key(uint32_t p_key, bool p_pressed) {
 
 	InputEvent ev;
 	ev.type = InputEvent::KEY;
-	ev.ID = ++last_event_id;
 	ev.key.echo = false;
 	ev.key.pressed = p_pressed;
 	ev.key.scancode = p_key;
@@ -209,7 +208,6 @@ void OSIPhone::mouse_button(int p_idx, int p_x, int p_y, bool p_pressed, bool p_
 	if (!GLOBAL_DEF("debug/disable_touch", false)) {
 		InputEvent ev;
 		ev.type = InputEvent::SCREEN_TOUCH;
-		ev.ID = ++last_event_id;
 		ev.screen_touch.index = p_idx;
 		ev.screen_touch.pressed = p_pressed;
 		ev.screen_touch.x = p_x;
@@ -225,7 +223,6 @@ void OSIPhone::mouse_button(int p_idx, int p_x, int p_y, bool p_pressed, bool p_
 		ev.type = InputEvent::MOUSE_BUTTON;
 		ev.device = 0;
 		ev.mouse_button.pointer_index = p_idx;
-		ev.ID = ++last_event_id;
 
 		// swaped it for tilted screen
 		//ev.mouse_button.x = ev.mouse_button.global_x = video_mode.height - p_y;
@@ -250,7 +247,6 @@ void OSIPhone::mouse_move(int p_idx, int p_prev_x, int p_prev_y, int p_x, int p_
 
 		InputEvent ev;
 		ev.type = InputEvent::SCREEN_DRAG;
-		ev.ID = ++last_event_id;
 		ev.screen_drag.index = p_idx;
 		ev.screen_drag.x = p_x;
 		ev.screen_drag.y = p_y;
@@ -264,7 +260,6 @@ void OSIPhone::mouse_move(int p_idx, int p_prev_x, int p_prev_y, int p_x, int p_
 		ev.type = InputEvent::MOUSE_MOTION;
 		ev.device = 0;
 		ev.mouse_motion.pointer_index = p_idx;
-		ev.ID = ++last_event_id;
 
 		if (true) { // vertical
 
@@ -327,7 +322,6 @@ void OSIPhone::update_accelerometer(float p_x, float p_y, float p_z) {
 		ev.device = 0;
 		ev.joy_motion.axis = JOY_ANALOG_0;
 		ev.joy_motion.axis_value = (p_x / (float)ACCEL_RANGE);
-		ev.ID = ++last_event_id;
 		last_accel.x = p_x;
 		queue_event(ev);
 	};
@@ -338,7 +332,6 @@ void OSIPhone::update_accelerometer(float p_x, float p_y, float p_z) {
 		ev.device = 0;
 		ev.joy_motion.axis = JOY_ANALOG_1;
 		ev.joy_motion.axis_value = (p_y / (float)ACCEL_RANGE);
-		ev.ID = ++last_event_id;
 		last_accel.y = p_y;
 		queue_event(ev);
 	};
@@ -349,7 +342,6 @@ void OSIPhone::update_accelerometer(float p_x, float p_y, float p_z) {
 		ev.device = 0;
 		ev.joy_motion.axis = JOY_ANALOG_2;
 		ev.joy_motion.axis_value = ( (1.0 - p_z) / (float)ACCEL_RANGE);
-		ev.ID = ++last_event_id;
 		last_accel.z = p_z;
 		queue_event(ev);
 	};
@@ -566,7 +558,6 @@ OSIPhone::OSIPhone(int width, int height) {
 	vm.resizable = false;
 	set_video_mode(vm);
 	event_count = 0;
-	last_event_id = 0;
 };
 
 OSIPhone::~OSIPhone() {

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -119,7 +119,6 @@ private:
 
 	InputEvent event_queue[MAX_EVENTS];
 	int event_count;
-	int last_event_id;
 	void queue_event(const InputEvent &p_event);
 
 	String data_dir;

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -520,7 +520,6 @@ void OS_JavaScript::main_loop_focusin() {
 void OS_JavaScript::push_input(const InputEvent &p_ev) {
 
 	InputEvent ev = p_ev;
-	ev.ID = last_id++;
 	if (ev.type == InputEvent::MOUSE_MOTION) {
 		input->set_mouse_pos(Point2(ev.mouse_motion.x, ev.mouse_motion.y));
 	} else if (ev.type == InputEvent::MOUSE_BUTTON) {
@@ -540,7 +539,6 @@ void OS_JavaScript::process_touch(int p_what, int p_pointer, const Vector<TouchP
 				//end all if exist
 				InputEvent ev;
 				ev.type = InputEvent::MOUSE_BUTTON;
-				ev.ID = last_id++;
 				ev.mouse_button.button_index = BUTTON_LEFT;
 				ev.mouse_button.button_mask = BUTTON_MASK_LEFT;
 				ev.mouse_button.pressed = false;
@@ -554,7 +552,6 @@ void OS_JavaScript::process_touch(int p_what, int p_pointer, const Vector<TouchP
 
 					InputEvent ev;
 					ev.type = InputEvent::SCREEN_TOUCH;
-					ev.ID = last_id++;
 					ev.screen_touch.index = touch[i].id;
 					ev.screen_touch.pressed = false;
 					ev.screen_touch.x = touch[i].pos.x;
@@ -573,7 +570,6 @@ void OS_JavaScript::process_touch(int p_what, int p_pointer, const Vector<TouchP
 				//send mouse
 				InputEvent ev;
 				ev.type = InputEvent::MOUSE_BUTTON;
-				ev.ID = last_id++;
 				ev.mouse_button.button_index = BUTTON_LEFT;
 				ev.mouse_button.button_mask = BUTTON_MASK_LEFT;
 				ev.mouse_button.pressed = true;
@@ -590,7 +586,6 @@ void OS_JavaScript::process_touch(int p_what, int p_pointer, const Vector<TouchP
 
 				InputEvent ev;
 				ev.type = InputEvent::SCREEN_TOUCH;
-				ev.ID = last_id++;
 				ev.screen_touch.index = touch[i].id;
 				ev.screen_touch.pressed = true;
 				ev.screen_touch.x = touch[i].pos.x;
@@ -605,7 +600,6 @@ void OS_JavaScript::process_touch(int p_what, int p_pointer, const Vector<TouchP
 				//send mouse, should look for point 0?
 				InputEvent ev;
 				ev.type = InputEvent::MOUSE_MOTION;
-				ev.ID = last_id++;
 				ev.mouse_motion.button_mask = BUTTON_MASK_LEFT;
 				ev.mouse_motion.x = p_points[0].pos.x;
 				ev.mouse_motion.y = p_points[0].pos.y;
@@ -638,7 +632,6 @@ void OS_JavaScript::process_touch(int p_what, int p_pointer, const Vector<TouchP
 
 				InputEvent ev;
 				ev.type = InputEvent::SCREEN_DRAG;
-				ev.ID = last_id++;
 				ev.screen_drag.index = touch[i].id;
 				ev.screen_drag.x = p_points[idx].pos.x;
 				ev.screen_drag.y = p_points[idx].pos.y;
@@ -655,7 +648,6 @@ void OS_JavaScript::process_touch(int p_what, int p_pointer, const Vector<TouchP
 				//end all if exist
 				InputEvent ev;
 				ev.type = InputEvent::MOUSE_BUTTON;
-				ev.ID = last_id++;
 				ev.mouse_button.button_index = BUTTON_LEFT;
 				ev.mouse_button.button_mask = BUTTON_MASK_LEFT;
 				ev.mouse_button.pressed = false;
@@ -669,7 +661,6 @@ void OS_JavaScript::process_touch(int p_what, int p_pointer, const Vector<TouchP
 
 					InputEvent ev;
 					ev.type = InputEvent::SCREEN_TOUCH;
-					ev.ID = last_id++;
 					ev.screen_touch.index = touch[i].id;
 					ev.screen_touch.pressed = false;
 					ev.screen_touch.x = touch[i].pos.x;
@@ -689,7 +680,6 @@ void OS_JavaScript::process_touch(int p_what, int p_pointer, const Vector<TouchP
 
 			InputEvent ev;
 			ev.type = InputEvent::SCREEN_TOUCH;
-			ev.ID = last_id++;
 			ev.screen_touch.index = tp.id;
 			ev.screen_touch.pressed = true;
 			ev.screen_touch.x = tp.pos.x;
@@ -704,7 +694,6 @@ void OS_JavaScript::process_touch(int p_what, int p_pointer, const Vector<TouchP
 
 					InputEvent ev;
 					ev.type = InputEvent::SCREEN_TOUCH;
-					ev.ID = last_id++;
 					ev.screen_touch.index = touch[i].id;
 					ev.screen_touch.pressed = false;
 					ev.screen_touch.x = touch[i].pos.x;
@@ -790,9 +779,9 @@ void OS_JavaScript::process_joypads() {
 					InputDefault::JoyAxis jx;
 					jx.min = 0;
 					jx.value = value;
-					last_id = input->joy_axis(last_id, i, j, jx);
+					input->joy_axis(i, j, jx);
 				} else {
-					last_id = input->joy_button(last_id, i, j, value);
+					input->joy_button(i, j, value);
 				}
 			}
 			for (int j = 0; j < num_axes; j++) {
@@ -800,7 +789,7 @@ void OS_JavaScript::process_joypads() {
 				InputDefault::JoyAxis jx;
 				jx.min = -1;
 				jx.value = state.axis[j];
-				last_id = input->joy_axis(last_id, i, j, jx);
+				input->joy_axis(i, j, jx);
 			}
 		}
 	}
@@ -844,7 +833,6 @@ OS_JavaScript::OS_JavaScript(GFXInitFunc p_gfx_init_func, void *p_gfx_init_ud, G
 	gfx_init_ud = p_gfx_init_ud;
 	last_button_mask = 0;
 	main_loop = NULL;
-	last_id = 1;
 	gl_extensions = NULL;
 	window_maximized = false;
 

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -58,7 +58,6 @@ private:
 	Vector<TouchPos> touch;
 	Point2 last_mouse;
 	int last_button_mask;
-	unsigned int last_id;
 	GFXInitFunc gfx_init_func;
 	void *gfx_init_ud;
 

--- a/platform/osx/joypad_osx.cpp
+++ b/platform/osx/joypad_osx.cpp
@@ -458,7 +458,7 @@ static const InputDefault::JoyAxis axis_correct(int p_value, int p_min, int p_ma
 	return jx;
 }
 
-uint32_t JoypadOSX::process_joypads(uint32_t p_last_id) {
+void JoypadOSX::process_joypads() {
 	poll_joypads();
 
 	for (int i = 0; i < device_list.size(); i++) {
@@ -467,17 +467,17 @@ uint32_t JoypadOSX::process_joypads(uint32_t p_last_id) {
 		for (int j = 0; j < joy.axis_elements.size(); j++) {
 			rec_element &elem = joy.axis_elements[j];
 			int value = joy.get_hid_element_state(&elem);
-			p_last_id = input->joy_axis(p_last_id, joy.id, j, axis_correct(value, elem.min, elem.max));
+			input->joy_axis(joy.id, j, axis_correct(value, elem.min, elem.max));
 		}
 		for (int j = 0; j < joy.button_elements.size(); j++) {
 			int value = joy.get_hid_element_state(&joy.button_elements[j]);
-			p_last_id = input->joy_button(p_last_id, joy.id, j, (value >= 1));
+			input->joy_button(joy.id, j, (value >= 1));
 		}
 		for (int j = 0; j < joy.hat_elements.size(); j++) {
 			rec_element &elem = joy.hat_elements[j];
 			int value = joy.get_hid_element_state(&elem);
 			int hat_value = process_hat_value(elem.min, elem.max, value);
-			p_last_id = input->joy_hat(p_last_id, joy.id, hat_value);
+			input->joy_hat(joy.id, hat_value);
 		}
 
 		if (joy.ffservice) {
@@ -494,7 +494,6 @@ uint32_t JoypadOSX::process_joypads(uint32_t p_last_id) {
 			}
 		}
 	}
-	return p_last_id;
 }
 
 void JoypadOSX::joypad_vibration_start(int p_id, float p_magnitude, float p_duration, uint64_t p_timestamp) {

--- a/platform/osx/joypad_osx.h
+++ b/platform/osx/joypad_osx.h
@@ -110,7 +110,7 @@ private:
 	void joypad_vibration_stop(int p_id, uint64_t p_timestamp);
 
 public:
-	uint32_t process_joypads(uint32_t p_last_id);
+	void process_joypads();
 
 	void _device_added(IOReturn p_res, IOHIDDeviceRef p_device);
 	void _device_removed(int p_id);

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -61,7 +61,6 @@ public:
 
 	List<String> args;
 	MainLoop *main_loop;
-	unsigned int event_id;
 
 	PhysicsServer *physics_server;
 	Physics2DServer *physics_2d_server;
@@ -83,7 +82,6 @@ public:
 	//          pthread_key_t   current;
 	bool mouse_grab;
 	Point2 mouse_pos;
-	uint32_t last_id;
 
 	id delegate;
 	id window_delegate;

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1698,7 +1698,6 @@ void OS_OSX::process_events() {
 void OS_OSX::push_input(const InputEvent& p_event) {
 
 	InputEvent ev=p_event;
-	ev.ID=last_id++;
 	//print_line("EV: "+String(ev));
 	input->parse_input_event(ev);
 }
@@ -1725,7 +1724,7 @@ void OS_OSX::run() {
 	while (!force_quit) {
 
 		process_events(); // get rid of pending events
-		last_id = joypad_osx->process_joypads(last_id);
+		joypad_osx->process_joypads();
 		if (Main::iteration()==true)
 			break;
 	};
@@ -1822,7 +1821,6 @@ OS_OSX::OS_OSX() {
 	[NSApp setDelegate:delegate];
 
 
-	last_id=1;
 	cursor_shape=CURSOR_ARROW;
 
 	current_screen = 0;

--- a/platform/uwp/joypad_uwp.cpp
+++ b/platform/uwp/joypad_uwp.cpp
@@ -40,7 +40,7 @@ void JoypadUWP::register_events() {
 			ref new EventHandler<Gamepad ^>(this, &JoypadUWP::OnGamepadRemoved);
 }
 
-uint32_t JoypadUWP::process_controllers(uint32_t p_last_id) {
+void JoypadUWP::process_controllers() {
 
 	for (int i = 0; i < MAX_CONTROLLERS; i++) {
 
@@ -55,23 +55,21 @@ uint32_t JoypadUWP::process_controllers(uint32_t p_last_id) {
 				int button_mask = (int)GamepadButtons::Menu;
 				for (int j = 0; j < 14; j++) {
 
-					p_last_id = input->joy_button(p_last_id, controllers[i].id, j, (int)reading.Buttons & button_mask);
+					input->joy_button(controllers[i].id, j, (int)reading.Buttons & button_mask);
 					button_mask *= 2;
 				}
 
-				p_last_id = input->joy_axis(p_last_id, controllers[i].id, JOY_AXIS_0, axis_correct(reading.LeftThumbstickX));
-				p_last_id = input->joy_axis(p_last_id, controllers[i].id, JOY_AXIS_1, axis_correct(reading.LeftThumbstickY, true));
-				p_last_id = input->joy_axis(p_last_id, controllers[i].id, JOY_AXIS_2, axis_correct(reading.RightThumbstickX));
-				p_last_id = input->joy_axis(p_last_id, controllers[i].id, JOY_AXIS_3, axis_correct(reading.RightThumbstickY, true));
-				p_last_id = input->joy_axis(p_last_id, controllers[i].id, JOY_AXIS_4, axis_correct(reading.LeftTrigger, false, true));
-				p_last_id = input->joy_axis(p_last_id, controllers[i].id, JOY_AXIS_5, axis_correct(reading.RightTrigger, false, true));
+				input->joy_axis(controllers[i].id, JOY_AXIS_0, axis_correct(reading.LeftThumbstickX));
+				input->joy_axis(controllers[i].id, JOY_AXIS_1, axis_correct(reading.LeftThumbstickY, true));
+				input->joy_axis(controllers[i].id, JOY_AXIS_2, axis_correct(reading.RightThumbstickX));
+				input->joy_axis(controllers[i].id, JOY_AXIS_3, axis_correct(reading.RightThumbstickY, true));
+				input->joy_axis(controllers[i].id, JOY_AXIS_4, axis_correct(reading.LeftTrigger, false, true));
+				input->joy_axis(controllers[i].id, JOY_AXIS_5, axis_correct(reading.RightTrigger, false, true));
 
 				break;
 			}
 		}
 	}
-
-	return p_last_id;
 }
 
 JoypadUWP::JoypadUWP() {

--- a/platform/uwp/joypad_uwp.h
+++ b/platform/uwp/joypad_uwp.h
@@ -37,7 +37,7 @@ ref class JoypadUWP sealed {
 	/* clang-format off */
 internal:
 	void register_events();
-	uint32_t process_controllers(uint32_t p_last_id);
+	void process_controllers();
 	/* clang-format on */
 
 	JoypadUWP();

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -344,15 +344,12 @@ String OSUWP::get_clipboard() const {
 
 void OSUWP::input_event(InputEvent &p_event) {
 
-	p_event.ID = ++last_id;
-
 	input->parse_input_event(p_event);
 
 	if (p_event.type == InputEvent::MOUSE_BUTTON && p_event.mouse_button.pressed && p_event.mouse_button.button_index > 3) {
 
 		//send release for mouse wheel
 		p_event.mouse_button.pressed = false;
-		p_event.ID = ++last_id;
 		input->parse_input_event(p_event);
 	}
 };
@@ -680,7 +677,7 @@ uint64_t OSUWP::get_ticks_usec() const {
 
 void OSUWP::process_events() {
 
-	last_id = joypad->process_controllers(last_id);
+	joypad->process_controllers();
 	process_key_events();
 }
 
@@ -907,7 +904,6 @@ OSUWP::OSUWP() {
 
 	pressrc = 0;
 	old_invalid = true;
-	last_id = 0;
 	mouse_mode = MOUSE_MODE_VISIBLE;
 #ifdef STDOUT_FILE
 	stdo = fopen("stdout.txt", "wb");

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -92,7 +92,6 @@ private:
 	bool outside;
 	int old_x, old_y;
 	Point2i center;
-	unsigned int last_id;
 	VisualServer *visual_server;
 	Rasterizer *rasterizer;
 	PhysicsServer *physics_server;

--- a/platform/windows/joypad.cpp
+++ b/platform/windows/joypad.cpp
@@ -319,7 +319,7 @@ void JoypadWindows::probe_joypads() {
 	}
 }
 
-unsigned int JoypadWindows::process_joypads(unsigned int p_last_id) {
+void JoypadWindows::process_joypads() {
 
 	HRESULT hr;
 
@@ -337,16 +337,16 @@ unsigned int JoypadWindows::process_joypads(unsigned int p_last_id) {
 			int button_mask = XINPUT_GAMEPAD_DPAD_UP;
 			for (int i = 0; i <= 16; i++) {
 
-				p_last_id = input->joy_button(p_last_id, joy.id, i, joy.state.Gamepad.wButtons & button_mask);
+				input->joy_button(joy.id, i, joy.state.Gamepad.wButtons & button_mask);
 				button_mask = button_mask * 2;
 			}
 
-			p_last_id = input->joy_axis(p_last_id, joy.id, JOY_AXIS_0, axis_correct(joy.state.Gamepad.sThumbLX, true));
-			p_last_id = input->joy_axis(p_last_id, joy.id, JOY_AXIS_1, axis_correct(joy.state.Gamepad.sThumbLY, true, false, true));
-			p_last_id = input->joy_axis(p_last_id, joy.id, JOY_AXIS_2, axis_correct(joy.state.Gamepad.sThumbRX, true));
-			p_last_id = input->joy_axis(p_last_id, joy.id, JOY_AXIS_3, axis_correct(joy.state.Gamepad.sThumbRY, true, false, true));
-			p_last_id = input->joy_axis(p_last_id, joy.id, JOY_AXIS_4, axis_correct(joy.state.Gamepad.bLeftTrigger, true, true));
-			p_last_id = input->joy_axis(p_last_id, joy.id, JOY_AXIS_5, axis_correct(joy.state.Gamepad.bRightTrigger, true, true));
+			input->joy_axis(joy.id, JOY_AXIS_0, axis_correct(joy.state.Gamepad.sThumbLX, true));
+			input->joy_axis(joy.id, JOY_AXIS_1, axis_correct(joy.state.Gamepad.sThumbLY, true, false, true));
+			input->joy_axis(joy.id, JOY_AXIS_2, axis_correct(joy.state.Gamepad.sThumbRX, true));
+			input->joy_axis(joy.id, JOY_AXIS_3, axis_correct(joy.state.Gamepad.sThumbRY, true, false, true));
+			input->joy_axis(joy.id, JOY_AXIS_4, axis_correct(joy.state.Gamepad.bLeftTrigger, true, true));
+			input->joy_axis(joy.id, JOY_AXIS_5, axis_correct(joy.state.Gamepad.bRightTrigger, true, true));
 			joy.last_packet = joy.state.dwPacketNumber;
 		}
 		uint64_t timestamp = input->get_joy_vibration_timestamp(joy.id);
@@ -384,7 +384,7 @@ unsigned int JoypadWindows::process_joypads(unsigned int p_last_id) {
 			continue;
 		}
 
-		p_last_id = post_hat(p_last_id, joy->id, js.rgdwPOV[0]);
+		post_hat(joy->id, js.rgdwPOV[0]);
 
 		for (int j = 0; j < 128; j++) {
 
@@ -392,14 +392,14 @@ unsigned int JoypadWindows::process_joypads(unsigned int p_last_id) {
 
 				if (!joy->last_buttons[j]) {
 
-					p_last_id = input->joy_button(p_last_id, joy->id, j, true);
+					input->joy_button(joy->id, j, true);
 					joy->last_buttons[j] = true;
 				}
 			} else {
 
 				if (joy->last_buttons[j]) {
 
-					p_last_id = input->joy_button(p_last_id, joy->id, j, false);
+					input->joy_button(joy->id, j, false);
 					joy->last_buttons[j] = false;
 				}
 			}
@@ -414,16 +414,16 @@ unsigned int JoypadWindows::process_joypads(unsigned int p_last_id) {
 
 			for (int k = 0; k < count; k++) {
 				if (joy->joy_axis[j] == axes[k]) {
-					p_last_id = input->joy_axis(p_last_id, joy->id, j, axis_correct(values[k]));
+					input->joy_axis(joy->id, j, axis_correct(values[k]));
 					break;
 				};
 			};
 		};
 	}
-	return p_last_id;
+	return;
 }
 
-unsigned int JoypadWindows::post_hat(unsigned int p_last_id, int p_device, DWORD p_dpad) {
+void JoypadWindows::post_hat(int p_device, DWORD p_dpad) {
 
 	int dpad_val = 0;
 
@@ -462,7 +462,7 @@ unsigned int JoypadWindows::post_hat(unsigned int p_last_id, int p_device, DWORD
 
 		dpad_val = (InputDefault::HAT_MASK_LEFT | InputDefault::HAT_MASK_UP);
 	}
-	return input->joy_hat(p_last_id, p_device, dpad_val);
+	input->joy_hat(p_device, dpad_val);
 };
 
 InputDefault::JoyAxis JoypadWindows::axis_correct(int p_val, bool p_xinput, bool p_trigger, bool p_negate) const {

--- a/platform/windows/joypad.h
+++ b/platform/windows/joypad.h
@@ -53,7 +53,7 @@ public:
 	~JoypadWindows();
 
 	void probe_joypads();
-	unsigned int process_joypads(unsigned int p_last_id);
+	void process_joypads();
 
 private:
 	enum {
@@ -130,7 +130,7 @@ private:
 	void load_xinput();
 	void unload_xinput();
 
-	unsigned int post_hat(unsigned int p_last_id, int p_device, DWORD p_dpad);
+	void post_hat(int p_device, DWORD p_dpad);
 
 	bool have_device(const GUID &p_guid);
 	bool is_xinput_device(const GUID *p_guid);

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -216,7 +216,6 @@ void OS_Windows::_touch_event(bool p_pressed, int p_x, int p_y, int idx) {
 
 	InputEvent event;
 	event.type = InputEvent::SCREEN_TOUCH;
-	event.ID = ++last_id;
 	event.screen_touch.index = idx;
 
 	event.screen_touch.pressed = p_pressed;
@@ -233,7 +232,6 @@ void OS_Windows::_drag_event(int p_x, int p_y, int idx) {
 
 	InputEvent event;
 	event.type = InputEvent::SCREEN_DRAG;
-	event.ID = ++last_id;
 	event.screen_drag.index = idx;
 
 	event.screen_drag.x = p_x;
@@ -370,7 +368,6 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 
 			InputEvent event;
 			event.type = InputEvent::MOUSE_MOTION;
-			event.ID = ++last_id;
 			InputEventMouseMotion &mm = event.mouse_motion;
 
 			mm.mod.control = (wParam & MK_CONTROL) != 0;
@@ -451,7 +448,6 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 
 				InputEvent event;
 				event.type = InputEvent::MOUSE_BUTTON;
-				event.ID = ++last_id;
 				InputEventMouseButton &mb = event.mouse_button;
 
 				switch (uMsg) {
@@ -582,7 +578,6 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 					if (mb.pressed && mb.button_index > 3) {
 						//send release for mouse wheel
 						mb.pressed = false;
-						event.ID = ++last_id;
 						input->parse_input_event(event);
 					}
 				}
@@ -780,7 +775,6 @@ void OS_Windows::process_key_events() {
 				if ((i == 0 && ke.uMsg == WM_CHAR) || (i > 0 && key_event_buffer[i - 1].uMsg == WM_CHAR)) {
 					InputEvent event;
 					event.type = InputEvent::KEY;
-					event.ID = ++last_id;
 					InputEventKey &k = event.key;
 
 					k.mod = ke.mod_state;
@@ -805,7 +799,6 @@ void OS_Windows::process_key_events() {
 
 				InputEvent event;
 				event.type = InputEvent::KEY;
-				event.ID = ++last_id;
 				InputEventKey &k = event.key;
 
 				k.mod = ke.mod_state;
@@ -1819,7 +1812,7 @@ void OS_Windows::process_events() {
 
 	MSG msg;
 
-	last_id = joypad->process_joypads(last_id);
+	joypad->process_joypads();
 
 	while (PeekMessageW(&msg, NULL, 0, 0, PM_REMOVE)) {
 
@@ -2303,7 +2296,6 @@ OS_Windows::OS_Windows(HINSTANCE _hInstance) {
 	hInstance = _hInstance;
 	pressrc = 0;
 	old_invalid = true;
-	last_id = 0;
 	mouse_mode = MOUSE_MODE_VISIBLE;
 #ifdef STDOUT_FILE
 	stdo = fopen("stdout.txt", "wb");

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -83,7 +83,6 @@ class OS_Windows : public OS {
 	bool outside;
 	int old_x, old_y;
 	Point2i center;
-	unsigned int last_id;
 #if defined(OPENGL_ENABLED)
 	ContextGL_Win *gl_context;
 #endif

--- a/platform/x11/joypad_linux.cpp
+++ b/platform/x11/joypad_linux.cpp
@@ -454,10 +454,10 @@ InputDefault::JoyAxis JoypadLinux::axis_correct(const input_absinfo *p_abs, int 
 	return jx;
 }
 
-uint32_t JoypadLinux::process_joypads(uint32_t p_event_id) {
+void JoypadLinux::process_joypads() {
 
 	if (joy_mutex->try_lock() != OK) {
-		return p_event_id;
+		return;
 	}
 	for (int i = 0; i < JOYPADS_MAX; i++) {
 
@@ -477,11 +477,11 @@ uint32_t JoypadLinux::process_joypads(uint32_t p_event_id) {
 				// ev may be tainted and out of MAX_KEY range, which will cause
 				// joy->key_map[ev.code] to crash
 				if (ev.code < 0 || ev.code >= MAX_KEY)
-					return p_event_id;
+					return;
 
 				switch (ev.type) {
 					case EV_KEY:
-						p_event_id = input->joy_button(p_event_id, i, joy->key_map[ev.code], ev.value);
+						input->joy_button(i, joy->key_map[ev.code], ev.value);
 						break;
 
 					case EV_ABS:
@@ -496,7 +496,7 @@ uint32_t JoypadLinux::process_joypads(uint32_t p_event_id) {
 								} else
 									joy->dpad &= ~(InputDefault::HAT_MASK_LEFT | InputDefault::HAT_MASK_RIGHT);
 
-								p_event_id = input->joy_hat(p_event_id, i, joy->dpad);
+								input->joy_hat(i, joy->dpad);
 								break;
 
 							case ABS_HAT0Y:
@@ -508,7 +508,7 @@ uint32_t JoypadLinux::process_joypads(uint32_t p_event_id) {
 								} else
 									joy->dpad &= ~(InputDefault::HAT_MASK_UP | InputDefault::HAT_MASK_DOWN);
 
-								p_event_id = input->joy_hat(p_event_id, i, joy->dpad);
+								input->joy_hat(i, joy->dpad);
 								break;
 
 							default:
@@ -525,7 +525,7 @@ uint32_t JoypadLinux::process_joypads(uint32_t p_event_id) {
 		for (int j = 0; j < MAX_ABS; j++) {
 			int index = joy->abs_map[j];
 			if (index != -1) {
-				p_event_id = input->joy_axis(p_event_id, i, index, joy->curr_axis[index]);
+				input->joy_axis(i, index, joy->curr_axis[index]);
 			}
 		}
 		if (len == 0 || (len < 0 && errno != EAGAIN)) {
@@ -546,6 +546,5 @@ uint32_t JoypadLinux::process_joypads(uint32_t p_event_id) {
 		}
 	}
 	joy_mutex->unlock();
-	return p_event_id;
 }
 #endif

--- a/platform/x11/joypad_linux.h
+++ b/platform/x11/joypad_linux.h
@@ -42,7 +42,7 @@ class JoypadLinux {
 public:
 	JoypadLinux(InputDefault *in);
 	~JoypadLinux();
-	uint32_t process_joypads(uint32_t p_event_id);
+	void process_joypads();
 
 private:
 	enum {

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -94,7 +94,6 @@ void OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_au
 	last_button_state = 0;
 
 	xmbstring = NULL;
-	event_id = 0;
 	x11_window = 0;
 	last_click_ms = 0;
 	args = OS::get_singleton()->get_cmdline_args();
@@ -1143,7 +1142,6 @@ void OS_X11::handle_key_event(XKeyEvent *p_event, bool p_echo) {
 	/* Phase 7, send event to Window */
 
 	InputEvent event;
-	event.ID = ++event_id;
 	event.type = InputEvent::KEY;
 	event.device = 0;
 	event.key.mod = state;
@@ -1334,7 +1332,6 @@ void OS_X11::process_xevents() {
 				}
 
 				InputEvent mouse_event;
-				mouse_event.ID = ++event_id;
 				mouse_event.type = InputEvent::MOUSE_BUTTON;
 				mouse_event.device = 0;
 				mouse_event.mouse_button.mod = get_key_modifier_state(event.xbutton.state);
@@ -1360,7 +1357,6 @@ void OS_X11::process_xevents() {
 						last_click_ms = 0;
 						last_click_pos = Point2(-100, -100);
 						mouse_event.mouse_button.doubleclick = true;
-						mouse_event.ID = ++event_id;
 
 					} else {
 						last_click_ms += diff;
@@ -1447,7 +1443,6 @@ void OS_X11::process_xevents() {
 				Point2i rel = pos - last_mouse_pos;
 
 				InputEvent motion_event;
-				motion_event.ID = ++event_id;
 				motion_event.type = InputEvent::MOUSE_MOTION;
 				motion_event.device = 0;
 
@@ -1916,7 +1911,7 @@ void OS_X11::run() {
 
 		process_xevents(); // get rid of pending events
 #ifdef JOYDEV_ENABLED
-		event_id = joypad->process_joypads(event_id);
+		joypad->process_joypads();
 #endif
 		if (Main::iteration() == true)
 			break;

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -116,7 +116,6 @@ class OS_X11 : public OS_Unix {
 	bool last_mouse_pos_valid;
 	Point2i last_click_pos;
 	uint64_t last_click_ms;
-	unsigned int event_id;
 	uint32_t last_button_state;
 
 	PhysicsServer *physics_server;


### PR DESCRIPTION
The `ID` property for InputEvents is set by `SceneTree` when sending the event down the tree.
https://github.com/godotengine/godot/blob/master/scene/main/scene_main_loop.cpp#L388
So there's no need for the platform specific code to set this value when it will later be overriden anyway...