### PR TITLE
Include uniform (Shift down) mode in only-one-Node2D dragging (2.1)

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1535,7 +1535,7 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent &p_event) {
 
 			dto = dto - (drag == DRAG_ALL ? drag_from - drag_point_from : Vector2(0, 0));
 
-			if (uniform && drag == DRAG_ALL) {
+			if (uniform && (drag == DRAG_ALL || drag == DRAG_NODE_2D)) {
 				if (ABS(dto.x - drag_point_from.x) > ABS(dto.y - drag_point_from.y)) {
 					dto.y = drag_point_from.y;
 				} else {


### PR DESCRIPTION
I overlooked that in #8114.

Feel free to squash them if you see fit.