### PR TITLE
8145 - Mouse Position is unknown until first mouse event on X11

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2167,6 +2167,9 @@ void OS_Windows::run() {
 	if (!main_loop)
 		return;
 
+	// Process all events before the main initialization so the cursor will get initialized properly
+	process_events(); // get rid of pending events
+
 	main_loop->init();
 
 	uint64_t last_ticks = get_ticks_usec();

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -1277,8 +1277,12 @@ void OS_X11::process_xevents() {
 			case EnterNotify: {
 				if (main_loop && !mouse_mode_grab)
 					main_loop->notification(MainLoop::NOTIFICATION_WM_MOUSE_ENTER);
-				if (input)
+				if (input) {
+					// Update mouse position. It is triggered before mouse motion.
+					Point2i pos(event.xmotion.x, event.xmotion.y);
+					input->set_mouse_pos(pos);
 					input->set_mouse_in_window(true);
+				}
 			} break;
 			case FocusIn:
 				minimized = false;
@@ -1899,6 +1903,9 @@ void OS_X11::run() {
 
 	if (!main_loop)
 		return;
+
+	// Process all events before the main initialization so the cursor will get initialized properly
+	process_xevents(); // get rid of pending events
 
 	main_loop->init();
 


### PR DESCRIPTION
- update input->pos on EnterNotify
- call first-time events processing before main initialization

fixes #8145 Mouse Position is unknown until first mouse event 