### PR TITLE
Honor the Tween's final values

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -610,6 +610,7 @@ void Tween::_tween_process(float p_delta) {
 		_apply_tween_value(data, result);
 
 		if (data.finish) {
+			_apply_tween_value(data, data.final_val);
 			emit_signal("tween_completed", object, data.key);
 			// not repeat mode, remove completed action
 			if (!repeat)


### PR DESCRIPTION
Make sure the Tween's final values are respected. Fixes issue #6565.