### PR TITLE
Texture region now updates when changing an Atlas region rect

### DIFF
--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -102,14 +102,24 @@ void TextureEditor::_notification(int p_what) {
 	}
 }
 
+void TextureEditor::_changed_callback(Object *p_changed, const char *p_prop) {
+
+	if (!is_visible())
+		return;
+	update();
+}
+
 void TextureEditor::edit(Ref<Texture> p_texture) {
+
+	if (!texture.is_null())
+		texture->remove_change_receptor(this);
 
 	texture = p_texture;
 
-	if (!texture.is_null())
+	if (!texture.is_null()) {
+		texture->add_change_receptor(this);
 		update();
-	else {
-
+	} else {
 		hide();
 	}
 }

--- a/editor/plugins/texture_editor_plugin.h
+++ b/editor/plugins/texture_editor_plugin.h
@@ -43,6 +43,7 @@ class TextureEditor : public Control {
 protected:
 	void _notification(int p_what);
 	void _gui_input(Ref<InputEvent> p_event);
+	void _changed_callback(Object *p_changed, const char *p_prop);
 	static void _bind_methods();
 
 public:

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -617,38 +617,24 @@ void TextureRegionEditor::_bind_methods() {
 }
 
 void TextureRegionEditor::edit(Object *p_obj) {
-	if (node_sprite && node_sprite->is_connected("texture_changed", this, "_edit_region"))
-		node_sprite->disconnect("texture_changed", this, "_edit_region");
-	if (node_patch9 && node_patch9->is_connected("texture_changed", this, "_edit_region"))
-		node_patch9->disconnect("texture_changed", this, "_edit_region");
-	if (obj_styleBox.is_valid() && obj_styleBox->is_connected("texture_changed", this, "_edit_region"))
-		obj_styleBox->disconnect("texture_changed", this, "_edit_region");
-	if (atlas_tex.is_valid() && atlas_tex->is_connected("atlas_changed", this, "_edit_region"))
-		atlas_tex->disconnect("atlas_changed", this, "_edit_region");
+	if (node_sprite)
+		node_sprite->remove_change_receptor(this);
+	if (node_patch9)
+		node_patch9->remove_change_receptor(this);
+	if (obj_styleBox.is_valid())
+		obj_styleBox->remove_change_receptor(this);
+	if (atlas_tex.is_valid())
+		atlas_tex->remove_change_receptor(this);
 	if (p_obj) {
 		node_sprite = p_obj->cast_to<Sprite>();
 		node_patch9 = p_obj->cast_to<NinePatchRect>();
 		if (p_obj->cast_to<StyleBoxTexture>())
 			obj_styleBox = Ref<StyleBoxTexture>(p_obj->cast_to<StyleBoxTexture>());
-		if (p_obj->cast_to<AtlasTexture>()) {
+		if (p_obj->cast_to<AtlasTexture>())
 			atlas_tex = Ref<AtlasTexture>(p_obj->cast_to<AtlasTexture>());
-			atlas_tex->connect("atlas_changed", this, "_edit_region");
-		} else {
-			p_obj->connect("texture_changed", this, "_edit_region");
-		}
 		p_obj->add_change_receptor(this);
-		p_obj->connect("tree_exited", this, "_node_removed", varray(p_obj), CONNECT_ONESHOT);
 		_edit_region();
 	} else {
-		if (node_sprite)
-			node_sprite->disconnect("tree_exited", this, "_node_removed");
-		else if (node_patch9)
-			node_patch9->disconnect("tree_exited", this, "_node_removed");
-		else if (obj_styleBox.is_valid())
-			obj_styleBox->disconnect("tree_exited", this, "_node_removed");
-		else if (atlas_tex.is_valid())
-			atlas_tex->disconnect("tree_exited", this, "_node_removed");
-
 		node_sprite = NULL;
 		node_patch9 = NULL;
 		obj_styleBox = Ref<StyleBoxTexture>(NULL);
@@ -658,9 +644,11 @@ void TextureRegionEditor::edit(Object *p_obj) {
 }
 
 void TextureRegionEditor::_changed_callback(Object *p_changed, const char *p_prop) {
-	if ((String)p_prop == "region_rect") {
+
+	if (!is_visible())
+		return;
+	if (p_prop == StringName("atlas") || p_prop == StringName("texture"))
 		_edit_region();
-	}
 }
 
 void TextureRegionEditor::_edit_region() {

--- a/scene/2d/sprite.cpp
+++ b/scene/2d/sprite.cpp
@@ -122,6 +122,7 @@ void Sprite::set_texture(const Ref<Texture> &p_texture) {
 	update();
 	emit_signal("texture_changed");
 	item_rect_changed();
+	_change_notify("texture");
 }
 
 void Sprite::set_normal_map(const Ref<Texture> &p_texture) {

--- a/scene/gui/patch_9_rect.cpp
+++ b/scene/gui/patch_9_rect.cpp
@@ -99,6 +99,7 @@ void NinePatchRect::set_texture(const Ref<Texture> &p_tex) {
 	*/
 	minimum_size_changed();
 	emit_signal("texture_changed");
+	_change_notify("texture");
 }
 
 Ref<Texture> NinePatchRect::get_texture() const {

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -107,6 +107,7 @@ void StyleBoxTexture::set_texture(RES p_texture) {
 	region_rect = Rect2(Point2(), texture->get_size());
 	emit_signal("texture_changed");
 	emit_changed();
+	_change_notify("texture");
 }
 
 RES StyleBoxTexture::get_texture() const {

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -830,7 +830,7 @@ void AtlasTexture::set_atlas(const Ref<Texture> &p_atlas) {
 		return;
 	atlas = p_atlas;
 	emit_changed();
-	emit_signal("atlas_changed");
+	_change_notify("atlas");
 }
 Ref<Texture> AtlasTexture::get_atlas() const {
 
@@ -839,8 +839,11 @@ Ref<Texture> AtlasTexture::get_atlas() const {
 
 void AtlasTexture::set_region(const Rect2 &p_region) {
 
+	if (region == p_region)
+		return;
 	region = p_region;
 	emit_changed();
+	_change_notify("region");
 }
 
 Rect2 AtlasTexture::get_region() const {
@@ -850,8 +853,11 @@ Rect2 AtlasTexture::get_region() const {
 
 void AtlasTexture::set_margin(const Rect2 &p_margin) {
 
+	if (margin == p_margin)
+		return;
 	margin = p_margin;
 	emit_changed();
+	_change_notify("margin");
 }
 
 Rect2 AtlasTexture::get_margin() const {
@@ -869,8 +875,6 @@ void AtlasTexture::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_margin", "margin"), &AtlasTexture::set_margin);
 	ClassDB::bind_method(D_METHOD("get_margin"), &AtlasTexture::get_margin);
-
-	ADD_SIGNAL(MethodInfo("atlas_changed"));
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "atlas", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_atlas", "get_atlas");
 	ADD_PROPERTY(PropertyInfo(Variant::RECT2, "region"), "set_region", "get_region");


### PR DESCRIPTION
Removed atlas_changed signal for AtlasTexture
Changes are now handled by _notify_change
Removed unneccesary signal connections
Texture preview now updates in real-time