### PR TITLE
Support for multiple cameras per viewport.

### DIFF
--- a/scene/3d/camera.h
+++ b/scene/3d/camera.h
@@ -60,6 +60,9 @@ public:
 	};
 
 private:
+	ObjectID physics_object_capture;
+	ObjectID physics_object_over;
+
 	bool force_change;
 	bool current;
 
@@ -77,7 +80,10 @@ private:
 
 	//String camera_group;
 
-	uint32_t layers;
+	uint32_t visible_layers;
+	uint32_t raycast_layers;
+	int32_t depth;
+	bool room_cull_enabled;
 
 	Ref<Environment> environment;
 
@@ -136,6 +142,12 @@ public:
 	void set_cull_mask(uint32_t p_layers);
 	uint32_t get_cull_mask() const;
 
+	void set_raycast_layers(uint32_t p_layers);
+	uint32_t get_raycast_layers() const;
+
+	void set_depth(int32_t p_depth);
+	int8_t get_depth() const;
+
 	Vector<Plane> get_frustum() const;
 
 	void set_environment(const Ref<Environment> &p_environment);
@@ -154,6 +166,8 @@ public:
 	DopplerTracking get_doppler_tracking() const;
 
 	Vector3 get_doppler_tracked_velocity() const;
+	void set_room_cull_enabled(bool p_room_cull_enabled);
+	bool is_room_cull_enabled() const;
 
 	Camera();
 	~Camera();

--- a/scene/3d/collision_object.cpp
+++ b/scene/3d/collision_object.cpp
@@ -85,20 +85,20 @@ void CollisionObject::_input_event(Node *p_camera, const Ref<InputEvent> &p_inpu
 	emit_signal(SceneStringNames::get_singleton()->input_event, p_camera, p_input_event, p_pos, p_normal, p_shape);
 }
 
-void CollisionObject::_mouse_enter() {
+void CollisionObject::_mouse_enter(Node *p_camera) {
 
 	if (get_script_instance()) {
-		get_script_instance()->call(SceneStringNames::get_singleton()->_mouse_enter);
+		get_script_instance()->call(SceneStringNames::get_singleton()->_mouse_enter, p_camera);
 	}
-	emit_signal(SceneStringNames::get_singleton()->mouse_entered);
+	emit_signal(SceneStringNames::get_singleton()->mouse_entered, p_camera);
 }
 
-void CollisionObject::_mouse_exit() {
+void CollisionObject::_mouse_exit(Node *p_camera) {
 
 	if (get_script_instance()) {
-		get_script_instance()->call(SceneStringNames::get_singleton()->_mouse_exit);
+		get_script_instance()->call(SceneStringNames::get_singleton()->_mouse_exit, p_camera);
 	}
-	emit_signal(SceneStringNames::get_singleton()->mouse_exited);
+	emit_signal(SceneStringNames::get_singleton()->mouse_exited, p_camera);
 }
 
 void CollisionObject::_update_pickable() {
@@ -148,8 +148,8 @@ void CollisionObject::_bind_methods() {
 	BIND_VMETHOD(MethodInfo("_input_event", PropertyInfo(Variant::OBJECT, "camera"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent"), PropertyInfo(Variant::VECTOR3, "click_position"), PropertyInfo(Variant::VECTOR3, "click_normal"), PropertyInfo(Variant::INT, "shape_idx")));
 
 	ADD_SIGNAL(MethodInfo("input_event", PropertyInfo(Variant::OBJECT, "camera"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent"), PropertyInfo(Variant::VECTOR3, "click_position"), PropertyInfo(Variant::VECTOR3, "click_normal"), PropertyInfo(Variant::INT, "shape_idx")));
-	ADD_SIGNAL(MethodInfo("mouse_entered"));
-	ADD_SIGNAL(MethodInfo("mouse_exited"));
+	ADD_SIGNAL(MethodInfo("mouse_entered", PropertyInfo(Variant::OBJECT, "camera")));
+	ADD_SIGNAL(MethodInfo("mouse_exited", PropertyInfo(Variant::OBJECT, "camera")));
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "input_ray_pickable"), "set_ray_pickable", "is_ray_pickable");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "input_capture_on_drag"), "set_capture_input_on_drag", "get_capture_input_on_drag");

--- a/scene/3d/collision_object.h
+++ b/scene/3d/collision_object.h
@@ -74,8 +74,8 @@ protected:
 	static void _bind_methods();
 	friend class Viewport;
 	virtual void _input_event(Node *p_camera, const Ref<InputEvent> &p_input_event, const Vector3 &p_pos, const Vector3 &p_normal, int p_shape);
-	virtual void _mouse_enter();
-	virtual void _mouse_exit();
+	virtual void _mouse_enter(Node *p_camera);
+	virtual void _mouse_exit(Node *p_camera);
 
 public:
 	uint32_t create_shape_owner(Object *p_owner);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -158,7 +158,7 @@ private:
 
 	bool arvr;
 
-	Camera *camera;
+	Set<Camera *> active_cameras;
 	Set<Camera *> cameras;
 
 	RID viewport;
@@ -198,10 +198,8 @@ private:
 
 	bool physics_object_picking;
 	List<Ref<InputEvent> > physics_picking_events;
-	ObjectID physics_object_capture;
-	ObjectID physics_object_over;
 	Vector2 physics_last_mousepos;
-	void _test_new_mouseover(ObjectID new_collider);
+	void _test_new_mouseover(Camera *p_camera, ObjectID new_collider);
 	Map<ObjectID, uint64_t> physics_2d_mouseover;
 
 	void _update_rect();
@@ -349,9 +347,9 @@ private:
 	friend class Camera;
 	void _camera_transform_changed_notify();
 	void _camera_set(Camera *p_camera);
-	bool _camera_add(Camera *p_camera); //true if first
+	void _camera_unset(Camera *p_camera);
+	void _camera_add(Camera *p_camera);
 	void _camera_remove(Camera *p_camera);
-	void _camera_make_next_current(Camera *p_exclude);
 
 protected:
 	void _notification(int p_what);
@@ -359,7 +357,7 @@ protected:
 
 public:
 	Listener *get_listener() const;
-	Camera *get_camera() const;
+	Array get_active_cameras() const;
 
 	void set_use_arvr(bool p_use_arvr);
 	bool use_arvr();

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -889,8 +889,10 @@ public:
 	BIND4(camera_set_orthogonal, RID, float, float, float)
 	BIND2(camera_set_transform, RID, const Transform &)
 	BIND2(camera_set_cull_mask, RID, uint32_t)
+	BIND2(camera_set_depth, RID, int32_t)
 	BIND2(camera_set_environment, RID, RID)
 	BIND2(camera_set_use_vertical_aspect, RID, bool)
+	BIND2(camera_set_room_cull_enabled, RID, bool)
 
 #undef BINDBASE
 //from now on, calls forwarded to this singleton
@@ -922,6 +924,7 @@ public:
 	BIND2(viewport_set_disable_3d, RID, bool)
 
 	BIND2(viewport_attach_camera, RID, RID)
+	BIND2(viewport_detach_camera, RID, RID)
 	BIND2(viewport_set_scenario, RID, RID)
 	BIND2(viewport_attach_canvas, RID, RID)
 

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -74,6 +74,14 @@ void VisualServerScene::camera_set_cull_mask(RID p_camera, uint32_t p_layers) {
 	camera->visible_layers = p_layers;
 }
 
+void VisualServerScene::camera_set_depth(RID p_camera, int32_t p_depth) {
+
+	Camera *camera = camera_owner.get(p_camera);
+	ERR_FAIL_COND(!camera);
+
+	camera->depth = p_depth;
+}
+
 void VisualServerScene::camera_set_environment(RID p_camera, RID p_env) {
 
 	Camera *camera = camera_owner.get(p_camera);
@@ -86,6 +94,12 @@ void VisualServerScene::camera_set_use_vertical_aspect(RID p_camera, bool p_enab
 	Camera *camera = camera_owner.get(p_camera);
 	ERR_FAIL_COND(!camera);
 	camera->vaspect = p_enable;
+}
+
+void VisualServerScene::camera_set_room_cull_enabled(RID p_camera, bool p_enabled) {
+	Camera *camera = camera_owner.get(p_camera);
+	ERR_FAIL_COND(!camera);
+	camera->room_cull_enabled = p_enabled;
 }
 
 /* SCENARIO API */

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -112,7 +112,9 @@ public:
 		float znear, zfar;
 		float size;
 		uint32_t visible_layers;
+		int32_t depth;
 		bool vaspect;
+		bool room_cull_enabled;
 		RID env;
 
 		Transform transform;
@@ -120,12 +122,14 @@ public:
 		Camera() {
 
 			visible_layers = 0xFFFFFFFF;
+			depth = -1;
 			fov = 65;
 			type = PERSPECTIVE;
 			znear = 0.1;
 			zfar = 100;
 			size = 1.0;
 			vaspect = false;
+			room_cull_enabled = true;
 		}
 	};
 
@@ -136,8 +140,10 @@ public:
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far);
 	virtual void camera_set_transform(RID p_camera, const Transform &p_transform);
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers);
+	virtual void camera_set_depth(RID p_camera, int32_t p_depth);
 	virtual void camera_set_environment(RID p_camera, RID p_env);
 	virtual void camera_set_use_vertical_aspect(RID p_camera, bool p_enable);
+	virtual void camera_set_room_cull_enabled(RID p_camera, bool p_enabled);
 
 	/* SCENARIO API */
 

--- a/servers/visual/visual_server_viewport.h
+++ b/servers/visual/visual_server_viewport.h
@@ -48,7 +48,7 @@ public:
 		bool use_arvr; /* use arvr interface to override camera positioning and projection matrices and control output */
 
 		Size2i size;
-		RID camera;
+		Vector<RID> active_cameras;
 		RID scenario;
 
 		VS::ViewportUpdateMode update_mode;
@@ -162,6 +162,7 @@ public:
 	void viewport_set_disable_3d(RID p_viewport, bool p_disable);
 
 	void viewport_attach_camera(RID p_viewport, RID p_camera);
+	void viewport_detach_camera(RID p_viewport, RID p_camera);
 	void viewport_set_scenario(RID p_viewport, RID p_scenario);
 	void viewport_attach_canvas(RID p_viewport, RID p_canvas);
 	void viewport_remove_canvas(RID p_viewport, RID p_canvas);

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -323,8 +323,10 @@ public:
 	FUNC4(camera_set_orthogonal, RID, float, float, float)
 	FUNC2(camera_set_transform, RID, const Transform &)
 	FUNC2(camera_set_cull_mask, RID, uint32_t)
+	FUNC2(camera_set_depth, RID, int32_t);
 	FUNC2(camera_set_environment, RID, RID)
 	FUNC2(camera_set_use_vertical_aspect, RID, bool)
+	FUNC2(camera_set_room_cull_enabled, RID, bool)
 
 	/* VIEWPORT TARGET API */
 
@@ -353,6 +355,7 @@ public:
 	FUNC2(viewport_set_disable_3d, RID, bool)
 
 	FUNC2(viewport_attach_camera, RID, RID)
+	FUNC2(viewport_detach_camera, RID, RID)
 	FUNC2(viewport_set_scenario, RID, RID)
 	FUNC2(viewport_attach_canvas, RID, RID)
 

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -515,8 +515,10 @@ public:
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_transform(RID p_camera, const Transform &p_transform) = 0;
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers) = 0;
+	virtual void camera_set_depth(RID p_camera, int32_t p_depth) = 0;
 	virtual void camera_set_environment(RID p_camera, RID p_env) = 0;
 	virtual void camera_set_use_vertical_aspect(RID p_camera, bool p_enable) = 0;
+	virtual void camera_set_room_cull_enabled(RID p_camera, bool p_enable) = 0;
 
 	/*
 	enum ParticlesCollisionMode {
@@ -566,6 +568,7 @@ public:
 	virtual void viewport_set_disable_3d(RID p_viewport, bool p_disable) = 0;
 
 	virtual void viewport_attach_camera(RID p_viewport, RID p_camera) = 0;
+	virtual void viewport_detach_camera(RID p_viewport, RID p_camera) = 0;
 	virtual void viewport_set_scenario(RID p_viewport, RID p_scenario) = 0;
 	virtual void viewport_attach_canvas(RID p_viewport, RID p_canvas) = 0;
 	virtual void viewport_remove_canvas(RID p_viewport, RID p_canvas) = 0;


### PR DESCRIPTION
Feature I spoke briefly with @reduz about including for the new renderer, although I've had this feature in my own branch for a while. It basically allows you to have multiple active 3D cameras for a single viewport which can be rendered one after another in an order specified by the new 'depth' parameter. By using this, you can create a variety of effects such as a first-person-shooter gun model which receives correct lighting but doesn't intersect with other geometry and can even have it's own independent FOV, or a mesh-based skybox rendered before everything else. The changes are fairly benign, but the multiple cameras can incur significant overhead in certain situations due to the way the VisualServerScene organises instances. To overcome this, I propose using the changes from this PR (https://github.com/godotengine/godot/pull/8216).