### PR TITLE
Add '$' to token names

### DIFF
--- a/modules/gdscript/gd_tokenizer.cpp
+++ b/modules/gdscript/gd_tokenizer.cpp
@@ -117,6 +117,7 @@ const char *GDTokenizer::token_names[TK_MAX] = {
 	"'.'",
 	"'?'",
 	"':'",
+	"'$'",
 	"'\\n'",
 	"PI",
 	"_",


### PR DESCRIPTION
It was missing from this array and would cause godot to crash or report
bad errors.

Signed-off-by: Saggi Mizrahi <saggi@mizrahi.cc>