### PR TITLE
Viewport: Fix undefined behaviour found by llvm sanitizer.

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1401,7 +1401,7 @@ void Viewport::_vp_input(const InputEvent &p_ev) {
 		return;
 
 #ifdef TOOLS_ENABLED
-	if (get_tree()->is_editor_hint() && get_tree()->get_edited_scene_root()->is_a_parent_of(this)) {
+	if (get_tree()->is_editor_hint() && get_tree()->get_edited_scene_root() && get_tree()->get_edited_scene_root()->is_a_parent_of(this)) {
 		return;
 	}
 #endif
@@ -1422,7 +1422,7 @@ void Viewport::_vp_unhandled_input(const InputEvent &p_ev) {
 	if (disable_input)
 		return;
 #ifdef TOOLS_ENABLED
-	if (get_tree()->is_editor_hint() && get_tree()->get_edited_scene_root()->is_a_parent_of(this)) {
+	if (get_tree()->is_editor_hint() && get_tree()->get_edited_scene_root() && get_tree()->get_edited_scene_root()->is_a_parent_of(this)) {
 		return;
 	}
 #endif


### PR DESCRIPTION
When godot was running as the project manager, it tried to call a method on a null pointer (`get_tree()->get_edited_scene_root()`).
This is undefined behaviour and caused a crash when compiled with sanitizing enabled.