### PR TITLE
theme mods. reomoved border, changed stylebox for top part, tabs left aligned

### DIFF
--- a/editor/animation_editor.cpp
+++ b/editor/animation_editor.cpp
@@ -1090,7 +1090,7 @@ void AnimationKeyEditor::_track_editor_draw() {
 	Color color = get_color("font_color", "Tree");
 	Color sepcolor = get_color("guide_color", "Tree");
 	Color timecolor = get_color("prop_subsection", "Editor");
-	timecolor = Color::html("ff4a414f");
+	timecolor = Color::html("31363d");
 	Color hover_color = Color(1, 1, 1, 0.05);
 	Color select_color = Color(1, 1, 1, 0.1);
 	Color invalid_path_color = Color(1, 0.6, 0.4, 0.5);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4926,6 +4926,7 @@ EditorNode::EditorNode() {
 	main_vbox = memnew(VBoxContainer);
 	gui_base->add_child(main_vbox);
 	main_vbox->set_area_as_parent_rect(8);
+	main_vbox->set("custom_constants/separation", 15 * EDSCALE);
 
 #if 0
 	PanelContainer *top_dark_panel = memnew( PanelContainer );
@@ -5064,7 +5065,7 @@ EditorNode::EditorNode() {
 		dock_slot[i]->set_popup(dock_select_popoup);
 		dock_slot[i]->connect("pre_popup_pressed", this, "_dock_pre_popup", varray(i));
 
-		//dock_slot[i]->set_tab_align(TabContainer::ALIGN_LEFT);
+		dock_slot[i]->set_tab_align(TabContainer::ALIGN_LEFT);
 	}
 
 	dock_drag_timer = memnew(Timer);
@@ -5089,7 +5090,7 @@ EditorNode::EditorNode() {
 */
 	scene_tabs = memnew(Tabs);
 	scene_tabs->add_tab("unsaved");
-	scene_tabs->set_tab_align(Tabs::ALIGN_CENTER);
+	scene_tabs->set_tab_align(Tabs::ALIGN_LEFT);
 	scene_tabs->set_tab_close_display_policy((bool(EDITOR_DEF("interface/always_show_close_button_in_scene_tabs", false)) ? Tabs::CLOSE_BUTTON_SHOW_ALWAYS : Tabs::CLOSE_BUTTON_SHOW_ACTIVE_ONLY));
 	scene_tabs->connect("tab_changed", this, "_scene_tab_changed");
 	scene_tabs->connect("right_button_pressed", this, "_scene_tab_script_edited");
@@ -5130,7 +5131,7 @@ EditorNode::EditorNode() {
 	scene_root_parent->add_child(viewport);
 
 	PanelContainer *top_region = memnew(PanelContainer);
-	top_region->add_style_override("panel", gui_base->get_stylebox("hover", "Button"));
+	top_region->add_style_override("panel", gui_base->get_stylebox("panel", "Panel"));
 	HBoxContainer *left_menu_hb = memnew(HBoxContainer);
 	top_region->add_child(left_menu_hb);
 	menu_hb->add_child(top_region);
@@ -5213,7 +5214,7 @@ EditorNode::EditorNode() {
 	}
 
 	PanelContainer *editor_region = memnew(PanelContainer);
-	editor_region->add_style_override("panel", gui_base->get_stylebox("hover", "Button"));
+	editor_region->add_style_override("panel", gui_base->get_stylebox("panel", "Panel"));
 	main_editor_button_vb = memnew(HBoxContainer);
 	editor_region->add_child(main_editor_button_vb);
 	menu_hb->add_child(editor_region);
@@ -5296,7 +5297,7 @@ EditorNode::EditorNode() {
 	play_cc->set_margin(MARGIN_TOP, 5);
 
 	top_region = memnew(PanelContainer);
-	top_region->add_style_override("panel", gui_base->get_stylebox("hover", "Button"));
+	top_region->add_style_override("panel", gui_base->get_stylebox("normal", "LineEdit"));
 	play_cc->add_child(top_region);
 
 	HBoxContainer *play_hb = memnew(HBoxContainer);
@@ -5416,7 +5417,7 @@ EditorNode::EditorNode() {
 	}
 
 	PanelContainer *vu_cont = memnew(PanelContainer);
-	vu_cont->add_style_override("panel", gui_base->get_stylebox("hover", "Button"));
+	vu_cont->add_style_override("panel", gui_base->get_stylebox("panel", "Panel"));
 	menu_hb->add_child(vu_cont);
 
 	audio_vu = memnew(TextureProgress);

--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -239,10 +239,14 @@ void Tabs::_notification(int p_what) {
 			Ref<StyleBox> tab_bg = get_stylebox("tab_bg");
 			Ref<StyleBox> tab_fg = get_stylebox("tab_fg");
 			Ref<StyleBox> tab_disabled = get_stylebox("tab_disabled");
-			Ref<Font> font = get_font("font");
+
+			Ref<Font> normal_font = get_font("font");
+			Ref<Font> bold_font = get_font("bold_font");
+
 			Color color_fg = get_color("font_color_fg");
 			Color color_bg = get_color("font_color_bg");
 			Color color_disabled = get_color("font_color_disabled");
+
 			Ref<Texture> close = get_icon("close");
 
 			int h = get_size().height;
@@ -284,7 +288,7 @@ void Tabs::_notification(int p_what) {
 				int lsize = get_tab_width(i);
 
 				String text = tabs[i].text;
-				int slen = font->get_string_size(text).width;
+				int slen = normal_font->get_string_size(text).width;
 
 				if (w + lsize > limit) {
 					max_drawn_tab = i - 1;
@@ -295,6 +299,7 @@ void Tabs::_notification(int p_what) {
 				}
 
 				Ref<StyleBox> sb;
+				Ref<Font> fo;
 				Color col;
 
 				if (tabs[i].disabled) {
@@ -303,9 +308,11 @@ void Tabs::_notification(int p_what) {
 				} else if (i == current) {
 					sb = tab_fg;
 					col = color_fg;
+					fo = bold_font;
 				} else {
 					sb = tab_bg;
 					col = color_bg;
+					fo = normal_font;
 				}
 
 				Rect2 sb_rect = Rect2(w, 0, lsize, h);
@@ -322,7 +329,7 @@ void Tabs::_notification(int p_what) {
 						w += icon->get_width() + get_constant("hseparation");
 				}
 
-				font->draw(ci, Point2i(w, sb->get_margin(MARGIN_TOP) + ((sb_rect.size.y - sb_ms.y) - font->get_height()) / 2 + font->get_ascent()), text, col);
+				fo->draw(ci, Point2i(w, sb->get_margin(MARGIN_TOP) + ((sb_rect.size.y - sb_ms.y) - fo->get_height()) / 2 + fo->get_ascent()), text, col);
 
 				w += slen;
 

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -217,7 +217,7 @@ void fill_default_theme(Ref<Theme> &t, const Ref<Font> &default_font, const Ref<
 	Color control_font_color_low = Color::html("b0b0b0");
 	Color control_font_color_hover = Color::html("f0f0f0");
 	Color control_font_color_disabled = Color(0.9, 0.9, 0.9, 0.2);
-	Color control_font_color_pressed = Color::html("ffffff");
+	Color control_font_color_pressed = Color::html("7cc9ff");
 	Color font_color_selection = Color::html("7d7d7d");
 
 	// Panel
@@ -649,7 +649,7 @@ void fill_default_theme(Ref<Theme> &t, const Ref<Font> &default_font, const Ref<
 	t->set_color("font_color_selected", "Tree", control_font_color_pressed);
 	t->set_color("selection_color", "Tree", Color(0.1, 0.1, 1, 0.8));
 	t->set_color("cursor_color", "Tree", Color(0, 0, 0));
-	t->set_color("guide_color", "Tree", Color(0, 0, 0, 0.1));
+	t->set_color("guide_color", "Tree", Color(0, 0, 0, 0));
 	t->set_color("drop_position_color", "Tree", Color(1, 0.3, 0.2));
 	t->set_color("relationship_line_color", "Tree", Color::html("464646"));
 
@@ -683,13 +683,13 @@ void fill_default_theme(Ref<Theme> &t, const Ref<Font> &default_font, const Ref<
 
 	// TabContainer
 
-	Ref<StyleBoxTexture> tc_sb = sb_expand(make_stylebox(tab_container_bg_png, 4, 4, 4, 4, 4, 4, 4, 4), 3, 3, 3, 3);
+	Ref<StyleBoxTexture> tc_sb = sb_expand(make_stylebox(tab_container_bg_png, 4, 4, 4, 4, 0, 4, 0, 0), 0, 0, 0, 0);
 
 	tc_sb->set_expand_margin_size(MARGIN_TOP, 2 * scale);
 	tc_sb->set_default_margin(MARGIN_TOP, 8 * scale);
 
-	t->set_stylebox("tab_fg", "TabContainer", sb_expand(make_stylebox(tab_current_png, 4, 4, 4, 1, 16, 4, 16, 4), 2, 2, 2, 2));
-	t->set_stylebox("tab_bg", "TabContainer", sb_expand(make_stylebox(tab_behind_png, 5, 5, 5, 1, 16, 6, 16, 4), 3, 0, 3, 3));
+	t->set_stylebox("tab_fg", "TabContainer", sb_expand(make_stylebox(tab_current_png, 4, 4, 4, 1, 16, 2, 16, 5), 0, 3, 0, 3));
+	t->set_stylebox("tab_bg", "TabContainer", sb_expand(make_stylebox(tab_behind_png, 5, 5, 5, 1, 16, 2, 16, 5), 0, 3, 0, 3));
 	t->set_stylebox("tab_disabled", "TabContainer", sb_expand(make_stylebox(tab_disabled_png, 5, 5, 5, 1, 16, 6, 16, 4), 3, 0, 3, 3));
 	t->set_stylebox("panel", "TabContainer", tc_sb);
 
@@ -706,7 +706,6 @@ void fill_default_theme(Ref<Theme> &t, const Ref<Font> &default_font, const Ref<
 	t->set_color("font_color_bg", "TabContainer", control_font_color_low);
 	t->set_color("font_color_disabled", "TabContainer", control_font_color_disabled);
 
-	t->set_constant("side_margin", "TabContainer", 8 * scale);
 	t->set_constant("top_margin", "TabContainer", 24 * scale);
 	t->set_constant("label_valign_fg", "TabContainer", 0 * scale);
 	t->set_constant("label_valign_bg", "TabContainer", 2 * scale);
@@ -714,8 +713,8 @@ void fill_default_theme(Ref<Theme> &t, const Ref<Font> &default_font, const Ref<
 
 	// Tabs
 
-	t->set_stylebox("tab_fg", "Tabs", sb_expand(make_stylebox(tab_current_png, 4, 3, 4, 1, 16, 3, 16, 2), 2, 2, 2, 2));
-	t->set_stylebox("tab_bg", "Tabs", sb_expand(make_stylebox(tab_behind_png, 5, 4, 5, 1, 16, 5, 16, 2), 3, 3, 3, 3));
+	t->set_stylebox("tab_fg", "Tabs", sb_expand(make_stylebox(tab_current_png, 4, 4, 4, 4, 16, 1, 16, 2), 0, 3, 0, 3));
+	t->set_stylebox("tab_bg", "Tabs", sb_expand(make_stylebox(tab_behind_png, 4, 4, 4, 4, 16, 1, 16, 2), 0, 3, 0, 3));
 	t->set_stylebox("tab_disabled", "Tabs", sb_expand(make_stylebox(tab_disabled_png, 5, 4, 5, 1, 16, 5, 16, 2), 3, 3, 3, 3));
 	t->set_stylebox("panel", "Tabs", tc_sb);
 	t->set_stylebox("button_pressed", "Tabs", make_stylebox(button_pressed_png, 4, 4, 4, 4));
@@ -866,11 +865,11 @@ void fill_default_theme(Ref<Theme> &t, const Ref<Font> &default_font, const Ref<
 	Ref<StyleBoxTexture> ttnc = make_stylebox(full_panel_bg_png, 8, 8, 8, 8);
 	ttnc->set_draw_center(false);
 
-	t->set_stylebox("border", "ReferenceRect", make_stylebox(reference_border_png, 4, 4, 4, 4));
+	t->set_stylebox("border", "ReferenceRect", make_stylebox(reference_border_png, 4, 4, 4, 0));
 	t->set_stylebox("panelnc", "Panel", ttnc);
 	t->set_stylebox("panelf", "Panel", tc_sb);
 
-	Ref<StyleBoxTexture> sb_pc = make_stylebox(tab_container_bg_png, 4, 4, 4, 4, 7, 7, 7, 7);
+	Ref<StyleBoxTexture> sb_pc = make_stylebox(tab_container_bg_png, 4, 4, 4, 4, 0, 0, 0, 0);
 	t->set_stylebox("panel", "PanelContainer", sb_pc);
 
 	t->set_icon("minus", "GraphEdit", make_icon(icon_zoom_less_png));


### PR DESCRIPTION
I changed some style box numbers so that there is no border at the left and right anymore. I think it looks really cool especially combined with a new theme. to get an idea how this looks checkout this issue:
https://github.com/godotengine/godot/issues/7294

I also would love to implement bold font since that would make a nice addition to the overall editor look.

But I'm not sure how I can achieve that with minimal changes.
since the make_default_theme function only takes one param for the font. so I would need to change that. also I'm not quite sure how the font pipeline works.
I think I just add the otg file and SCons than adds that file to the font header. than it is a available as a global var stating with _

would be cool if someone can give me some help and explanation how to add bold font to the default editor theme.

I'm not sure if this is the same with other textures for the theme, but there are currently still a couple of minor issues with positioning of ui elements, they are sometimes to close to the ground. So we might need to do some position changes to the editor node.
Would be happy for any possible help.
