### PR TITLE
Make buttons closer in Scene tree

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -1113,6 +1113,7 @@ SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_ope
 	tree->set_anchor(MARGIN_BOTTOM, ANCHOR_END);
 	tree->set_begin(Point2(0, p_label ? 18 : 0));
 	tree->set_end(Point2(0, 0));
+	tree->add_constant_override("button_margin", 0);
 
 	add_child(tree);
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/8281454/24598274/8aa18072-1885-11e7-9051-ddc45cfd60ec.png)

buttons have too much space.