### PR TITLE
Fix crash when change project settings

### DIFF
--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -3375,8 +3375,8 @@ void PropertyEditor::_item_edited() {
 		} break;
 		case Variant::BOOL: {
 
-			_edit_set(name, item->is_checked(1));
 			item->set_tooltip(1, item->is_checked(1) ? "True" : "False");
+			_edit_set(name, item->is_checked(1));
 		} break;
 		case Variant::INT:
 		case Variant::REAL: {


### PR DESCRIPTION
Fix #7696

TreeItem reference became invalid after calling `_edit_set` because it regenerates TreeItem again.