### PR TITLE
Fix monitoring status of Area2D and doing same logic on Area too

### DIFF
--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -380,6 +380,10 @@ void Area2D::_notification(int p_what) {
 
 	switch (p_what) {
 
+		case NOTIFICATION_READY: {
+
+			is_ready = true;
+		} break;
 		case NOTIFICATION_EXIT_TREE: {
 
 			monitoring_stored = monitoring;
@@ -387,8 +391,8 @@ void Area2D::_notification(int p_what) {
 			_clear_monitoring();
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
-
-			set_enable_monitoring(monitoring_stored);
+			if (is_ready)
+				set_enable_monitoring(monitoring_stored);
 		} break;
 	}
 }
@@ -646,7 +650,8 @@ Area2D::Area2D()
 	monitorable = false;
 	collision_mask = 1;
 	layer_mask = 1;
-	monitoring_stored = true;
+	monitoring_stored = false;
+	is_ready = false;
 	set_enable_monitoring(true);
 	set_monitorable(true);
 }

--- a/scene/2d/area_2d.h
+++ b/scene/2d/area_2d.h
@@ -60,6 +60,7 @@ private:
 	bool monitoring_stored;
 	bool monitorable;
 	bool locked;
+	bool is_ready;
 
 	void _body_inout(int p_status, const RID &p_body, int p_instance, int p_body_shape, int p_area_shape);
 

--- a/scene/3d/area.h
+++ b/scene/3d/area.h
@@ -57,8 +57,10 @@ private:
 	uint32_t layer_mask;
 	int priority;
 	bool monitoring;
+	bool monitoring_stored;
 	bool monitorable;
 	bool locked;
+	bool is_ready;
 
 	void _body_inout(int p_status, const RID &p_body, int p_instance, int p_body_shape, int p_area_shape);
 


### PR DESCRIPTION
Fix #8090

5b556cab250797b4630ec34069e780ecfb68b67c makes monitoring always true when `NOTIFICATION_ENTER_TREE`
This PR fix regression but not to touch what 5b556cab250797b4630ec34069e780ecfb68b67c tried to fix.