### PR TITLE
Previous value of time_left is added to wait_time before assigning to time_left

### DIFF
--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -66,8 +66,7 @@ void Timer::_notification(int p_what) {
 
 			if (time_left < 0) {
 				if (!one_shot)
-					//time_left = wait_time + time_left;
-					time_left = wait_time;
+					time_left = wait_time + time_left;
 				else
 					stop();
 				emit_signal("timeout");


### PR DESCRIPTION
Fixes #7530
This is my first contribution to the project, so I'm not sure whether I understood the issue correctly or not.