### PR TITLE
added generic pointer type to variant

### DIFF
--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -188,6 +188,10 @@ String Variant::get_type_name(Variant::Type p_type) {
 			return "PoolColorArray";
 
 		} break;
+		case GENERIC_POINTER: {
+
+			return "void*";
+		}
 		default: {}
 	}
 
@@ -1996,6 +2000,12 @@ Variant::operator PoolVector<Plane>() const {
 	return planes;
 }
 
+void *Variant::get_generic_pointer() const {
+	if (type != GENERIC_POINTER)
+		return NULL;
+	return _data._ptr;
+}
+
 Variant::operator PoolVector<Face3>() const {
 
 	PoolVector<Vector3> va = operator PoolVector<Vector3>();
@@ -2565,6 +2575,11 @@ Variant::Variant(const Vector<Color> &p_array) {
 void Variant::operator=(const Variant &p_variant) {
 
 	reference(p_variant);
+}
+
+Variant::Variant(const void *p_pointer) {
+	type = GENERIC_POINTER;
+	_data._ptr = (void *)p_pointer;
 }
 
 Variant::Variant(const IP_Address &p_address) {

--- a/core/variant.h
+++ b/core/variant.h
@@ -114,6 +114,8 @@ public:
 		POOL_VECTOR3_ARRAY,
 		POOL_COLOR_ARRAY,
 
+		GENERIC_POINTER,
+
 		VARIANT_MAX
 
 	};
@@ -305,6 +307,8 @@ public:
 	Variant(const Vector<Vector2> &p_array); // helper
 	Variant(const PoolVector<Vector2> &p_array); // helper
 
+	Variant(const void *p_pointer);
+
 	Variant(const IP_Address &p_address);
 
 	enum Operator {
@@ -408,6 +412,8 @@ public:
 
 	bool hash_compare(const Variant &p_variant) const;
 	bool booleanize(bool &valid) const;
+
+	void *get_generic_pointer() const;
 
 	void static_assign(const Variant &p_variant);
 	static void get_constructor_list(Variant::Type p_type, List<MethodInfo> *p_list);

--- a/modules/dlscript/dl_script.h
+++ b/modules/dlscript/dl_script.h
@@ -241,6 +241,8 @@ class DLInstance : public ScriptInstance {
 public:
 	_FORCE_INLINE_ Object *get_owner() { return owner; }
 
+	_FORCE_INLINE_ void *get_userdata() { return userdata; }
+
 	virtual bool set(const StringName &p_name, const Variant &p_value);
 	virtual bool get(const StringName &p_name, Variant &r_ret) const;
 	virtual void get_property_list(List<PropertyInfo> *p_properties) const;

--- a/modules/dlscript/godot.cpp
+++ b/modules/dlscript/godot.cpp
@@ -175,6 +175,16 @@ void GDAPI godot_script_register_signal(const char *p_name, const godot_signal *
 	library->_register_script_signal(p_name, p_signal);
 }
 
+void GDAPI *godot_dlinstance_get_userdata(godot_object *p_instance) {
+	Object *instance = (Object *)p_instance;
+	if (!instance)
+		return NULL;
+	DLInstance *script = (DLInstance *)instance->get_script_instance();
+	if (!script)
+		return NULL;
+	return script->get_userdata();
+}
+
 // System functions
 void GDAPI *godot_alloc(int p_bytes) {
 	return memalloc(p_bytes);

--- a/modules/dlscript/godot.h
+++ b/modules/dlscript/godot.h
@@ -375,6 +375,8 @@ typedef struct godot_signal {
 
 void GDAPI godot_script_register_signal(const char *p_name, const godot_signal *p_signal);
 
+void GDAPI *godot_dlinstance_get_userdata(godot_object *p_instance);
+
 ////// System Functions
 
 //using these will help Godot track how much memory is in use in debug mode

--- a/modules/dlscript/godot/godot_variant.cpp
+++ b/modules/dlscript/godot/godot_variant.cpp
@@ -194,6 +194,11 @@ void GDAPI godot_variant_new_pool_color_array(godot_variant *p_v, const godot_po
 	memnew_placement_custom(v, Variant, Variant(*pca));
 }
 
+void GDAPI godot_variant_new_generic_pointer(godot_variant *p_v, const void *p_ptr) {
+	Variant *v = (Variant *)p_v;
+	memnew_placement_custom(v, Variant, Variant(p_ptr));
+}
+
 godot_bool GDAPI godot_variant_as_bool(const godot_variant *p_v) {
 	const Variant *v = (const Variant *)p_v;
 	return v->operator bool();
@@ -418,6 +423,11 @@ godot_pool_color_array GDAPI godot_variant_as_pool_color_array(const godot_varia
 	return pba;
 }
 
+void GDAPI *godot_variant_as_generic_pointer(const godot_variant *p_v) {
+	const Variant *v = (const Variant *)p_v;
+	return v->get_generic_pointer();
+}
+
 godot_variant GDAPI godot_variant_call(godot_variant *p_v, const godot_string *p_method, const godot_variant **p_args, const godot_int p_argcount /*, godot_variant_call_error *r_error */) {
 	Variant *v = (Variant *)p_v;
 	String *method = (String *)p_method;
@@ -455,6 +465,11 @@ godot_bool GDAPI godot_variant_booleanize(const godot_variant *p_v, godot_bool *
 	const Variant *v = (const Variant *)p_v;
 	bool &valid = *p_valid;
 	return v->booleanize(valid);
+}
+
+void GDAPI *godot_variant_get_generic_pointer(const godot_variant *p_v) {
+	const Variant *v = (const Variant *)p_v;
+	return v->get_generic_pointer();
 }
 
 void GDAPI godot_variant_destroy(godot_variant *p_v) {

--- a/modules/dlscript/godot/godot_variant.h
+++ b/modules/dlscript/godot/godot_variant.h
@@ -62,6 +62,8 @@ typedef enum godot_variant_type {
 	GODOT_VARIANT_TYPE_POOL_VECTOR2_ARRAY,
 	GODOT_VARIANT_TYPE_POOL_VECTOR3_ARRAY,
 	GODOT_VARIANT_TYPE_POOL_COLOR_ARRAY,
+
+	GODOT_VARIANT_TYPE_GENERIC_POINTER,
 } godot_variant_type;
 
 godot_variant_type GDAPI godot_variant_get_type(const godot_variant *p_v);
@@ -98,6 +100,7 @@ void GDAPI godot_variant_new_pool_string_array(godot_variant *p_v, const godot_p
 void GDAPI godot_variant_new_pool_vector2_array(godot_variant *p_v, const godot_pool_vector2_array *p_pv2a);
 void GDAPI godot_variant_new_pool_vector3_array(godot_variant *p_v, const godot_pool_vector3_array *p_pv3a);
 void GDAPI godot_variant_new_pool_color_array(godot_variant *p_v, const godot_pool_color_array *p_pca);
+void GDAPI godot_variant_new_generic_pointer(godot_variant *p_v, const void *p_ptr);
 
 godot_bool GDAPI godot_variant_as_bool(const godot_variant *p_v);
 uint64_t GDAPI godot_variant_as_int(const godot_variant *p_v);
@@ -127,6 +130,7 @@ godot_pool_string_array GDAPI godot_variant_as_pool_string_array(const godot_var
 godot_pool_vector2_array GDAPI godot_variant_as_pool_vector2_array(const godot_variant *p_v);
 godot_pool_vector3_array GDAPI godot_variant_as_pool_vector3_array(const godot_variant *p_v);
 godot_pool_color_array GDAPI godot_variant_as_pool_color_array(const godot_variant *p_v);
+void GDAPI *godot_variant_as_generic_pointer(const godot_variant *p_v);
 
 godot_variant GDAPI godot_variant_call(godot_variant *p_v, const godot_string *p_method, const godot_variant **p_args, const godot_int p_argcount /*, godot_variant_call_error *r_error */);
 


### PR DESCRIPTION
Now that the DLScript module is in master it would be nice to have a way to pass generic pointers between DLScripts or a DLScript and a module.

This new Variant field is not intended to be used in GDScript, you can't interact with it. (only like you can with null, but even less since null can be casted to a number).

This is great for datatypes that have no proper representation in Godots Variant type.

For example, I once made a small OpenCL module for Godot. There was no way I could easily pass a `cl_mem` object to GDScript. GDScript used this `cl_mem` object only as a handle. This is what this PR is about.

You can't create a pointer from GDScript, you can't get the value of that pointer. You can't cast it to anything. It's only possible in C++/DLScript, so when using it in a script there's no danger of using it in unintended ways.

------

I also added a function to the C API that lets you retrieve the pointer to the userdata for a ScriptInstance.