### PR TITLE
[DLScript] added variant constructor and a function to get userdata of a script

### DIFF
--- a/modules/dlscript/api_generator.cpp
+++ b/modules/dlscript/api_generator.cpp
@@ -1,5 +1,7 @@
 #include "api_generator.h"
 
+#ifdef TOOLS_ENABLED
+
 #include "class_db.h"
 #include "core/global_config.h"
 #include "os/file_access.h"
@@ -368,15 +370,22 @@ static List<String> generate_c_api_json(const List<ClassAPI> &p_api) {
 
 //
 
+#endif
+
 /*
  * Saves the whole Godot API to a JSON file located at
  *  p_path
  */
 Error generate_c_api(const String &p_path) {
 
+#ifndef TOOLS_ENABLED
+	return ERR_BUG;
+#else
+
 	List<ClassAPI> api = generate_c_api_classes();
 
 	List<String> json_source = generate_c_api_json(api);
 
 	return save_file(p_path, json_source);
+#endif
 }

--- a/modules/dlscript/dl_script.h
+++ b/modules/dlscript/dl_script.h
@@ -241,6 +241,8 @@ class DLInstance : public ScriptInstance {
 public:
 	_FORCE_INLINE_ Object *get_owner() { return owner; }
 
+	_FORCE_INLINE_ void *get_userdata() { return userdata; }
+
 	virtual bool set(const StringName &p_name, const Variant &p_value);
 	virtual bool get(const StringName &p_name, Variant &r_ret) const;
 	virtual void get_property_list(List<PropertyInfo> *p_properties) const;

--- a/modules/dlscript/godot.cpp
+++ b/modules/dlscript/godot.cpp
@@ -175,6 +175,16 @@ void GDAPI godot_script_register_signal(const char *p_name, const godot_signal *
 	library->_register_script_signal(p_name, p_signal);
 }
 
+void GDAPI *godot_dlinstance_get_userdata(godot_object *p_instance) {
+	Object *instance = (Object *)p_instance;
+	if (!instance)
+		return NULL;
+	if (instance->get_script_instance() && instance->get_script_instance()->get_language() == DLScriptLanguage::get_singleton()) {
+		return ((DLInstance *)instance->get_script_instance())->get_userdata();
+	}
+	return NULL;
+}
+
 // System functions
 void GDAPI *godot_alloc(int p_bytes) {
 	return memalloc(p_bytes);

--- a/modules/dlscript/godot.h
+++ b/modules/dlscript/godot.h
@@ -121,8 +121,6 @@ typedef int godot_int;
 
 typedef float godot_real;
 
-typedef double godot_real64; // for Variant in 3.0
-
 /////// Object (forward declared)
 typedef void godot_object;
 
@@ -374,6 +372,8 @@ typedef struct godot_signal {
 } godot_signal;
 
 void GDAPI godot_script_register_signal(const char *p_name, const godot_signal *p_signal);
+
+void GDAPI *godot_dlinstance_get_userdata(godot_object *p_instance);
 
 ////// System Functions
 

--- a/modules/dlscript/godot/godot_variant.cpp
+++ b/modules/dlscript/godot/godot_variant.cpp
@@ -34,7 +34,12 @@ void GDAPI godot_variant_new_bool(godot_variant *p_v, const godot_bool p_b) {
 	memnew_placement_custom(v, Variant, Variant(p_b));
 }
 
-void GDAPI godot_variant_new_int(godot_variant *p_v, const uint64_t p_i) {
+void GDAPI godot_variant_new_uint(godot_variant *p_v, const uint64_t p_i) {
+	Variant *v = (Variant *)p_v;
+	memnew_placement_custom(v, Variant, Variant(p_i));
+}
+
+void GDAPI godot_variant_new_int(godot_variant *p_v, const int64_t p_i) {
 	Variant *v = (Variant *)p_v;
 	memnew_placement_custom(v, Variant, Variant(p_i));
 }
@@ -199,14 +204,19 @@ godot_bool GDAPI godot_variant_as_bool(const godot_variant *p_v) {
 	return v->operator bool();
 }
 
-uint64_t GDAPI godot_variant_as_int(const godot_variant *p_v) {
+uint64_t GDAPI godot_variant_as_uint(const godot_variant *p_v) {
 	const Variant *v = (const Variant *)p_v;
-	return v->operator godot_int();
+	return v->operator uint64_t();
 }
 
-godot_real GDAPI godot_variant_as_real(const godot_variant *p_v) {
+int64_t GDAPI godot_variant_as_int(const godot_variant *p_v) {
 	const Variant *v = (const Variant *)p_v;
-	return v->operator godot_real();
+	return v->operator int64_t();
+}
+
+double GDAPI godot_variant_as_real(const godot_variant *p_v) {
+	const Variant *v = (const Variant *)p_v;
+	return v->operator double();
 }
 
 godot_string GDAPI godot_variant_as_string(const godot_variant *p_v) {

--- a/modules/dlscript/godot/godot_variant.h
+++ b/modules/dlscript/godot/godot_variant.h
@@ -71,7 +71,8 @@ void GDAPI godot_variant_copy(godot_variant *p_dest, const godot_variant *p_src)
 void GDAPI godot_variant_new_nil(godot_variant *p_v);
 
 void GDAPI godot_variant_new_bool(godot_variant *p_v, const godot_bool p_b);
-void GDAPI godot_variant_new_int(godot_variant *p_v, const uint64_t p_i);
+void GDAPI godot_variant_new_uint(godot_variant *p_v, const uint64_t p_i);
+void GDAPI godot_variant_new_int(godot_variant *p_v, const int64_t p_i);
 void GDAPI godot_variant_new_real(godot_variant *p_v, const double p_r);
 void GDAPI godot_variant_new_string(godot_variant *p_v, const godot_string *p_s);
 void GDAPI godot_variant_new_vector2(godot_variant *p_v, const godot_vector2 *p_v2);
@@ -100,8 +101,9 @@ void GDAPI godot_variant_new_pool_vector3_array(godot_variant *p_v, const godot_
 void GDAPI godot_variant_new_pool_color_array(godot_variant *p_v, const godot_pool_color_array *p_pca);
 
 godot_bool GDAPI godot_variant_as_bool(const godot_variant *p_v);
-uint64_t GDAPI godot_variant_as_int(const godot_variant *p_v);
-godot_real GDAPI godot_variant_as_real(const godot_variant *p_v);
+uint64_t GDAPI godot_variant_as_uint(const godot_variant *p_v);
+int64_t GDAPI godot_variant_as_int(const godot_variant *p_v);
+double GDAPI godot_variant_as_real(const godot_variant *p_v);
 godot_string GDAPI godot_variant_as_string(const godot_variant *p_v);
 godot_vector2 GDAPI godot_variant_as_vector2(const godot_variant *p_v);
 godot_rect2 GDAPI godot_variant_as_rect2(const godot_variant *p_v);


### PR DESCRIPTION
The `godot_dlinstance_get_userdata()` function can be used to get the DLScript userdata pointer of any object that has a DLScript attached to it.

This is particularly useful and even required for language bindings to work properly.

----

I also added distinctive int and uint cons- and destructors for the `godot_variant` type.