### PR TITLE
Add methods to get and set bits of collision layers and masks for TileMaps (3.0)

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -876,6 +876,26 @@ void TileMap::set_collision_mask(uint32_t p_mask) {
 	}
 }
 
+void TileMap::set_collision_layer_bit(int p_bit, bool p_value) {
+
+	uint32_t layer = get_collision_layer();
+	if (p_value)
+		layer |= 1 << p_bit;
+	else
+		layer &= ~(1 << p_bit);
+	set_collision_layer(layer);
+}
+
+void TileMap::set_collision_mask_bit(int p_bit, bool p_value) {
+
+	uint32_t mask = get_collision_mask();
+	if (p_value)
+		mask |= 1 << p_bit;
+	else
+		mask &= ~(1 << p_bit);
+	set_collision_mask(mask);
+}
+
 bool TileMap::get_collision_use_kinematic() const {
 
 	return use_kinematic;
@@ -925,6 +945,16 @@ uint32_t TileMap::get_collision_layer() const {
 uint32_t TileMap::get_collision_mask() const {
 
 	return collision_mask;
+}
+
+bool TileMap::get_collision_layer_bit(int p_bit) const {
+
+	return get_collision_layer() & (1 << p_bit);
+}
+
+bool TileMap::get_collision_mask_bit(int p_bit) const {
+
+	return get_collision_mask() & (1 << p_bit);
 }
 
 void TileMap::set_mode(Mode p_mode) {
@@ -1196,11 +1226,17 @@ void TileMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_collision_use_kinematic", "use_kinematic"), &TileMap::set_collision_use_kinematic);
 	ClassDB::bind_method(D_METHOD("get_collision_use_kinematic"), &TileMap::get_collision_use_kinematic);
 
-	ClassDB::bind_method(D_METHOD("set_collision_layer", "mask"), &TileMap::set_collision_layer);
+	ClassDB::bind_method(D_METHOD("set_collision_layer", "layer"), &TileMap::set_collision_layer);
 	ClassDB::bind_method(D_METHOD("get_collision_layer"), &TileMap::get_collision_layer);
 
 	ClassDB::bind_method(D_METHOD("set_collision_mask", "mask"), &TileMap::set_collision_mask);
 	ClassDB::bind_method(D_METHOD("get_collision_mask"), &TileMap::get_collision_mask);
+
+	ClassDB::bind_method(D_METHOD("set_collision_layer_bit", "bit", "value"), &TileMap::set_collision_layer_bit);
+	ClassDB::bind_method(D_METHOD("get_collision_layer_bit", "bit"), &TileMap::get_collision_layer_bit);
+
+	ClassDB::bind_method(D_METHOD("set_collision_mask_bit", "bit", "value"), &TileMap::set_collision_mask_bit);
+	ClassDB::bind_method(D_METHOD("get_collision_mask_bit", "bit"), &TileMap::get_collision_mask_bit);
 
 	ClassDB::bind_method(D_METHOD("set_collision_friction", "value"), &TileMap::set_collision_friction);
 	ClassDB::bind_method(D_METHOD("get_collision_friction"), &TileMap::get_collision_friction);

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -232,6 +232,12 @@ public:
 	void set_collision_mask(uint32_t p_mask);
 	uint32_t get_collision_mask() const;
 
+	void set_collision_layer_bit(int p_bit, bool p_value);
+	bool get_collision_layer_bit(int p_bit) const;
+
+	void set_collision_mask_bit(int p_bit, bool p_value);
+	bool get_collision_mask_bit(int p_bit) const;
+
 	void set_collision_use_kinematic(bool p_use_kinematic);
 	bool get_collision_use_kinematic() const;
 


### PR DESCRIPTION
Add four methods to the TileMap node to make collision layers and masks be modified bit by bit (like PhysicBody2Ds and RayCast2Ds:

 * set_collision_layer_bit()
 * set_collision_mask_bit()

 * get_collision_layer_bit()
 * get_collision_mask_bit()

To comply with collision layers' renaming from godotengine#5696 , the method names are NOT set/get_layer_mask_bit()

