### PR TITLE
Add methods to get and set bits of collision layers and masks for TileMaps (2.1)

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -878,6 +878,26 @@ void TileMap::set_collision_mask(uint32_t p_mask) {
 	}
 }
 
+void TileMap::set_collision_layer_bit(int p_bit, bool p_value) {
+
+	uint32_t layer = get_collision_layer();
+	if (p_value)
+		layer |= 1 << p_bit;
+	else
+		layer &= ~(1 << p_bit);
+	set_collision_layer(layer);
+}
+
+void TileMap::set_collision_mask_bit(int p_bit, bool p_value) {
+
+	uint32_t mask = get_collision_mask();
+	if (p_value)
+		mask |= 1 << p_bit;
+	else
+		mask &= ~(1 << p_bit);
+	set_collision_mask(mask);
+}
+
 bool TileMap::get_collision_use_kinematic() const {
 
 	return use_kinematic;
@@ -927,6 +947,16 @@ uint32_t TileMap::get_collision_layer() const {
 uint32_t TileMap::get_collision_mask() const {
 
 	return collision_mask;
+}
+
+bool TileMap::get_collision_layer_bit(int p_bit) const {
+
+	return get_collision_layer() & (1 << p_bit);
+}
+
+bool TileMap::get_collision_mask_bit(int p_bit) const {
+
+	return get_collision_mask() & (1 << p_bit);
 }
 
 void TileMap::set_mode(Mode p_mode) {
@@ -1198,11 +1228,17 @@ void TileMap::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_collision_use_kinematic", "use_kinematic"), &TileMap::set_collision_use_kinematic);
 	ObjectTypeDB::bind_method(_MD("get_collision_use_kinematic"), &TileMap::get_collision_use_kinematic);
 
-	ObjectTypeDB::bind_method(_MD("set_collision_layer", "mask"), &TileMap::set_collision_layer);
+	ObjectTypeDB::bind_method(_MD("set_collision_layer", "layer"), &TileMap::set_collision_layer);
 	ObjectTypeDB::bind_method(_MD("get_collision_layer"), &TileMap::get_collision_layer);
 
 	ObjectTypeDB::bind_method(_MD("set_collision_mask", "mask"), &TileMap::set_collision_mask);
 	ObjectTypeDB::bind_method(_MD("get_collision_mask"), &TileMap::get_collision_mask);
+
+	ObjectTypeDB::bind_method(_MD("set_collision_layer_bit", "bit", "value"), &TileMap::set_collision_layer_bit);
+	ObjectTypeDB::bind_method(_MD("get_collision_layer_bit", "bit"), &TileMap::get_collision_layer_bit);
+
+	ObjectTypeDB::bind_method(_MD("set_collision_mask_bit", "bit", "value"), &TileMap::set_collision_mask_bit);
+	ObjectTypeDB::bind_method(_MD("get_collision_mask_bit", "bit"), &TileMap::get_collision_mask_bit);
 
 	ObjectTypeDB::bind_method(_MD("set_collision_friction", "value"), &TileMap::set_collision_friction);
 	ObjectTypeDB::bind_method(_MD("get_collision_friction"), &TileMap::get_collision_friction);

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -231,6 +231,12 @@ public:
 
 	void set_collision_mask(uint32_t p_mask);
 	uint32_t get_collision_mask() const;
+	
+	void set_collision_layer_bit(int p_bit, bool p_value);
+	bool get_collision_layer_bit(int p_bit) const;
+
+	void set_collision_mask_bit(int p_bit, bool p_value);
+	bool get_collision_mask_bit(int p_bit) const;
 
 	void set_collision_use_kinematic(bool p_use_kinematic);
 	bool get_collision_use_kinematic() const;


### PR DESCRIPTION
Note: this is the 2.1 version of this pull request:
https://github.com/godotengine/godot/pull/8271

Add four methods to the TileMap node to make collision layers and masks be modified bit by bit (like PhysicBody2Ds and RayCast2Ds:

 * set_collision_layer_bit()
 * set_collision_mask_bit()

 * get_collision_layer_bit()
 * get_collision_mask_bit()

