### PR TITLE
[DLScript] API fixed and removed STL imports

### DIFF
--- a/modules/dlscript/api_generator.cpp
+++ b/modules/dlscript/api_generator.cpp
@@ -230,15 +230,17 @@ List<ClassAPI> generate_c_api_classes() {
 				method_api.has_varargs = method_bind && method_bind->is_vararg();
 
 				// Method flags
-				if (method_bind && method_bind->get_hint_flags()) {
+				if (method_info.flags) {
 					const uint32_t flags = method_info.flags;
 					method_api.is_editor = flags & METHOD_FLAG_EDITOR;
 					method_api.is_noscript = flags & METHOD_FLAG_NOSCRIPT;
 					method_api.is_const = flags & METHOD_FLAG_CONST;
 					method_api.is_reverse = flags & METHOD_FLAG_REVERSE;
-					method_api.is_virtual = flags & METHOD_FLAG_VIRTUAL || method_info.name[0] == '_';
+					method_api.is_virtual = flags & METHOD_FLAG_VIRTUAL;
 					method_api.is_from_script = flags & METHOD_FLAG_FROM_SCRIPT;
 				}
+
+				method_api.is_virtual = method_api.is_virtual || method_api.method_name[0] == '_';
 
 				// method argument name and type
 
@@ -346,6 +348,7 @@ static List<String> generate_c_api_json(const List<ClassAPI> &p_api) {
 			source.push_back(String("\t\t\t\t\"is_const\": ") + (e->get().is_const ? "true" : "false") + ",\n");
 			source.push_back(String("\t\t\t\t\"is_reverse\": ") + (e->get().is_reverse ? "true" : "false") + ",\n");
 			source.push_back(String("\t\t\t\t\"is_virtual\": ") + (e->get().is_virtual ? "true" : "false") + ",\n");
+			source.push_back(String("\t\t\t\t\"has_varargs\": ") + (e->get().has_varargs ? "true" : "false") + ",\n");
 			source.push_back(String("\t\t\t\t\"is_from_script\": ") + (e->get().is_from_script ? "true" : "false") + ",\n");
 			source.push_back("\t\t\t\t\"arguments\": [\n");
 			for (int i = 0; i < e->get().argument_names.size(); i++) {

--- a/modules/dlscript/godot.cpp
+++ b/modules/dlscript/godot.cpp
@@ -28,14 +28,10 @@
 /*************************************************************************/
 #include "godot.h"
 
-#include <cstdlib>
-
 #include "class_db.h"
 #include "dl_script.h"
 #include "global_config.h"
 #include "variant.h"
-
-#include <memory.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/dlscript/godot/godot_node_path.cpp
+++ b/modules/dlscript/godot/godot_node_path.cpp
@@ -2,8 +2,6 @@
 
 #include "path_db.h"
 
-#include <memory.h> // why is there no <cmemory> btw?
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/modules/dlscript/godot/godot_node_path.cpp
+++ b/modules/dlscript/godot/godot_node_path.cpp
@@ -20,6 +20,12 @@ void GDAPI godot_node_path_new(godot_node_path *p_np, const godot_string *p_from
 	memnew_placement_custom(np, NodePath, NodePath(*from));
 }
 
+void GDAPI godot_node_path_copy(godot_node_path *p_np, const godot_node_path *p_from) {
+	NodePath *np = (NodePath *)p_np;
+	NodePath *from = (NodePath *)p_from;
+	*np = *from;
+}
+
 godot_string GDAPI godot_node_path_get_name(const godot_node_path *p_np, const godot_int p_idx) {
 	const NodePath *np = (const NodePath *)p_np;
 	godot_string str;

--- a/modules/dlscript/godot/godot_node_path.h
+++ b/modules/dlscript/godot/godot_node_path.h
@@ -16,6 +16,7 @@ typedef struct godot_node_path {
 #include "../godot.h"
 
 void GDAPI godot_node_path_new(godot_node_path *p_np, const godot_string *p_from);
+void GDAPI godot_node_path_copy(godot_node_path *p_np, const godot_node_path *p_from);
 
 godot_string GDAPI godot_node_path_get_name(const godot_node_path *p_np, const godot_int p_idx);
 godot_int GDAPI godot_node_path_get_name_count(const godot_node_path *p_np);

--- a/modules/dlscript/godot/godot_quat.cpp
+++ b/modules/dlscript/godot/godot_quat.cpp
@@ -2,8 +2,6 @@
 
 #include "math/quat.h"
 
-#include <memory.h> // why is there no <cmemory> btw?
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/modules/dlscript/godot/godot_string.cpp
+++ b/modules/dlscript/godot/godot_string.cpp
@@ -3,7 +3,7 @@
 #include "string_db.h"
 #include "ustring.h"
 
-#include <memory.h> // why is there no <cmemory> btw?
+#include <memory.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/dlscript/godot/godot_transform.cpp
+++ b/modules/dlscript/godot/godot_transform.cpp
@@ -2,8 +2,6 @@
 
 #include "math/transform.h"
 
-#include <memory.h> // why is there no <cmemory> btw?
-
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Android doesn't have STL enabled by default, it's better to keep it that way. Hopefully this fixes it and doesn't break anything. It compiled fine on Linux.