### PR TITLE
Make spatial AudioServers prefer inactive voices (2.1)

### DIFF
--- a/servers/spatial_sound/spatial_sound_server_sw.cpp
+++ b/servers/spatial_sound/spatial_sound_server_sw.cpp
@@ -398,9 +398,18 @@ SpatialSoundServer::SourceVoiceID SpatialSoundServerSW::source_play_sample(RID p
 	int to_play = 0;
 
 	if (p_voice == SOURCE_NEXT_VOICE) {
-		to_play = source->last_voice + 1;
-		if (to_play >= source->voices.size())
-			to_play = 0;
+		const int num_voices = source->voices.size();
+		bool free_found = false;
+		for (int i = 0; i < num_voices; i++) {
+			const int candidate = (source->last_voice + 1 + i) % num_voices;
+			if (!source->voices[candidate].active && !source->voices[candidate].restart) {
+				free_found = true;
+				to_play = candidate;
+				break;
+			}
+		}
+		if (!free_found)
+			to_play = (source->last_voice + 1) % num_voices;
 
 	} else
 		to_play = p_voice;

--- a/servers/spatial_sound_2d/spatial_sound_2d_server_sw.cpp
+++ b/servers/spatial_sound_2d/spatial_sound_2d_server_sw.cpp
@@ -395,9 +395,18 @@ SpatialSound2DServer::SourceVoiceID SpatialSound2DServerSW::source_play_sample(R
 	int to_play = 0;
 
 	if (p_voice == SOURCE_NEXT_VOICE) {
-		to_play = source->last_voice + 1;
-		if (to_play >= source->voices.size())
-			to_play = 0;
+		const int num_voices = source->voices.size();
+		bool free_found = false;
+		for (int i = 0; i < num_voices; i++) {
+			const int candidate = (source->last_voice + 1 + i) % num_voices;
+			if (!source->voices[candidate].active && !source->voices[candidate].restart) {
+				free_found = true;
+				to_play = candidate;
+				break;
+			}
+		}
+		if (!free_found)
+			to_play = (source->last_voice + 1) % num_voices;
 
 	} else
 		to_play = p_voice;


### PR DESCRIPTION
...instead of unconditionally playing on the next voice slot; that will be the fallback if no inactive voice is found.

This gives further chances for inactive voices to take the work instead of force-stopping active ones.

This PR can't be ported to _master_ due to the new architecture of the `AudioServer' or perhaps due to the point its implementation is at. Anyway, if @reduz could confirm...