### PR TITLE
Reset display folded for an instanced scene if editable children is toggled off (2.1)

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1357,10 +1357,14 @@ void Node::set_editable_instance(Node *p_node, bool p_editable) {
 	ERR_FAIL_NULL(p_node);
 	ERR_FAIL_COND(!is_a_parent_of(p_node));
 	NodePath p = get_path_to(p_node);
-	if (!p_editable)
+	if (!p_editable) {
 		data.editable_instances.erase(p);
-	else
+		// Avoid this flag being needlessly saved;
+		// also give more visual feedback if editable children is reenabled
+		set_display_folded(false);
+	} else {
 		data.editable_instances[p] = true;
+	}
 }
 
 bool Node::is_editable_instance(Node *p_node) const {


### PR DESCRIPTION
I noticed this on one of my __.tscn__ files:
`editor/display_folded = true`
And that would never go away unless I re-enabled edit children, unfold it and disabled edit children back.

This avoids the display folded flag needlessly getting into the scene file (potentially forever) and also gives more visual feedback if the user re-enables editable children so it will display unfolded at first.