### PR TITLE
Optimize-out some debug and/or non-tools methods (2.1)

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -94,8 +94,10 @@ static bool init_maximized = false;
 static bool init_windowed = false;
 static bool init_fullscreen = false;
 static bool init_use_custom_pos = false;
+#ifdef DEBUG_ENABLED
 static bool debug_collisions = false;
 static bool debug_navigation = false;
+#endif
 static int frame_delay = 0;
 static Vector2 init_custom_pos;
 static int video_driver_idx = -1;
@@ -496,10 +498,12 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 		} else if (I->get() == "-debug" || I->get() == "-d") {
 			debug_mode = "local";
+#ifdef DEBUG_ENABLED
 		} else if (I->get() == "-debugcol" || I->get() == "-dc") {
 			debug_collisions = true;
 		} else if (I->get() == "-debugnav" || I->get() == "-dn") {
 			debug_navigation = true;
+#endif
 		} else if (I->get() == "-editor_scene") {
 
 			if (I->next()) {
@@ -1169,12 +1173,15 @@ bool Main::start() {
 
 		SceneTree *sml = main_loop->cast_to<SceneTree>();
 
+#ifdef DEBUG_ENABLED
 		if (debug_collisions) {
 			sml->set_debug_collisions_hint(true);
 		}
 		if (debug_navigation) {
 			sml->set_debug_navigation_hint(true);
 		}
+#endif
+
 #ifdef TOOLS_ENABLED
 
 		EditorNode *editor_node = NULL;

--- a/scene/main/scene_main_loop.cpp
+++ b/scene/main/scene_main_loop.cpp
@@ -587,24 +587,24 @@ void SceneTree::set_auto_accept_quit(bool p_enable) {
 	accept_quit = p_enable;
 }
 
+#ifdef TOOLS_ENABLED
 void SceneTree::set_editor_hint(bool p_enabled) {
 
 	editor_hint = p_enabled;
 }
 
 bool SceneTree::is_node_being_edited(const Node *p_node) const {
-#ifdef TOOLS_ENABLED
+
 	return editor_hint && edited_scene_root && edited_scene_root->is_a_parent_of(p_node);
-#else
-	return false;
-#endif
 }
 
 bool SceneTree::is_editor_hint() const {
 
 	return editor_hint;
 }
+#endif
 
+#ifdef DEBUG_ENABLED
 void SceneTree::set_debug_collisions_hint(bool p_enabled) {
 
 	debug_collisions_hint = p_enabled;
@@ -624,6 +624,7 @@ bool SceneTree::is_debugging_navigation_hint() const {
 
 	return debug_navigation_hint;
 }
+#endif
 
 void SceneTree::set_debug_collisions_color(const Color &p_color) {
 
@@ -1624,9 +1625,13 @@ SceneTree::SceneTree() {
 	singleton = this;
 	_quit = false;
 	initialized = false;
+#ifdef TOOLS_ENABLED
 	editor_hint = false;
+#endif
+#ifdef DEBUG_ENABLED
 	debug_collisions_hint = false;
 	debug_navigation_hint = false;
+#endif
 	debug_collisions_color = GLOBAL_DEF("debug/collision_shape_color", Color(0.0, 0.6, 0.7, 0.5));
 	debug_collision_contact_color = GLOBAL_DEF("debug/collision_contact_color", Color(1.0, 0.2, 0.1, 0.8));
 	debug_navigation_color = GLOBAL_DEF("debug/navigation_geometry_color", Color(0.1, 1.0, 0.7, 0.4));

--- a/scene/main/scene_main_loop.h
+++ b/scene/main/scene_main_loop.h
@@ -84,9 +84,13 @@ private:
 	bool accept_quit;
 	uint32_t last_id;
 
+#ifdef TOOLS_ENABLED
 	bool editor_hint;
+#endif
+#ifdef DEBUG_ENABLED
 	bool debug_collisions_hint;
 	bool debug_navigation_hint;
+#endif
 	bool pause;
 	int root_lock;
 
@@ -266,10 +270,17 @@ public:
 	_FORCE_INLINE_ float get_fixed_process_time() const { return fixed_process_time; }
 	_FORCE_INLINE_ float get_idle_process_time() const { return idle_process_time; }
 
+#ifdef TOOLS_ENABLED
 	void set_editor_hint(bool p_enabled);
-	bool is_editor_hint() const;
 
+	bool is_editor_hint() const;
 	bool is_node_being_edited(const Node *p_node) const;
+#else
+	void set_editor_hint(bool p_enabled) {}
+
+	bool is_editor_hint() const { return false; }
+	bool is_node_being_edited(const Node *p_node) const { return false; }
+#endif
 
 	void set_pause(bool p_enabled);
 	bool is_paused() const;
@@ -277,11 +288,19 @@ public:
 	void set_camera(const RID &p_camera);
 	RID get_camera() const;
 
+#ifdef DEBUG_ENABLED
 	void set_debug_collisions_hint(bool p_enabled);
 	bool is_debugging_collisions_hint() const;
 
 	void set_debug_navigation_hint(bool p_enabled);
 	bool is_debugging_navigation_hint() const;
+#else
+	void set_debug_collisions_hint(bool p_enabled) {}
+	bool is_debugging_collisions_hint() const { return false; }
+
+	void set_debug_navigation_hint(bool p_enabled) {}
+	bool is_debugging_navigation_hint() const { return false; }
+#endif
 
 	void set_debug_collisions_color(const Color &p_color);
 	Color get_debug_collisions_color() const;


### PR DESCRIPTION
Collisions and nav debug are conditionally compiled depending on DEBUG_ENABLED
is_editor_hint() and is_node_being_edited() are compiled only with TOOLS_ENABLED
Every affected method is implemented in the header in case its macro is not present (the getters just returning false and the setters having an empty body) so the compiler can inline and finally no-op-out them as likely as possible.
is_node_being_edited() already showed a similar optimization effort and has been adapted to this change.
Furthermore, and as a consequence, -debugcol and -debugnav will not work on non-debug (strict release) builds.
This can bring a little bit of runtime performance on release and non-tooled builds (less code, so less cycles to spend and maybe more cache friendly).