### PR TITLE
New Process class

### DIFF
--- a/core/os/process.cpp
+++ b/core/os/process.cpp
@@ -1,0 +1,238 @@
+/*************************************************************************/
+/*  process.cpp                                                          */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#include "process.h"
+
+Process *(*Process::_create)() = NULL;
+
+bool Process::start(const String &p_program, const Vector<String> &p_arguments) {
+	ERR_FAIL_COND_V(process_state != STATE_NOT_RUNNING, false);
+
+	set_program(p_program);
+	set_arguments(p_arguments);
+
+	return start();
+}
+
+bool Process::start() {
+	ERR_FAIL_COND_V(process_state != STATE_NOT_RUNNING, false);
+
+	exit_code = 0;
+	exit_status = EXIT_STATUS_NORMAL;
+
+	return _start();
+}
+
+bool Process::can_read_line() const {
+	return next_line_size() >= 0;
+}
+
+void Process::_set_environment_bind(const Dictionary &p_env, bool p_override) {
+	environment.clear();
+
+	List<Variant> keys;
+	p_env.get_key_list(&keys);
+
+	for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
+		environment.set(E->get(), p_env[E->get()]);
+	}
+
+	if (!p_override) {
+		_get_system_env(environment);
+	}
+}
+
+Dictionary Process::_get_environment_bind() const {
+	Dictionary dict;
+
+	const String *k = NULL;
+	while ((k = environment.next(k))) {
+		dict[k] = environment.get(*k);
+	}
+
+	return dict;
+}
+
+PoolVector<uint8_t> Process::_read_all_bind() {
+	PoolVector<uint8_t> ret;
+	ret.resize(get_available_bytes());
+	PoolVector<uint8_t>::Write w = ret.write();
+	read_all((char *)w.ptr(), ret.size());
+	return ret;
+}
+
+PoolVector<uint8_t> Process::_read_line_bind() {
+	PoolVector<uint8_t> ret;
+	int size = next_line_size();
+	if (size == -1)
+		return ret;
+	ret.resize(size);
+	PoolVector<uint8_t>::Write w = ret.write();
+	read_line((char *)w.ptr(), ret.size());
+	return ret;
+}
+
+int Process::_write_bind(const PoolVector<uint8_t> &p_bytes) {
+	PoolVector<uint8_t>::Read r = p_bytes.read();
+	return write((const char *)r.ptr(), p_bytes.size());
+}
+
+bool Process::_start_bind(const String &p_program, const Vector<String> &p_arguments) {
+	set_program(p_program);
+	set_arguments(p_arguments);
+	return start();
+}
+
+void Process::close_channel(Process::ProcessChannel p_channel) {
+	switch (p_channel) {
+		case CHANNEL_STDOUT: {
+			stdout_chan->close();
+		} break;
+		case CHANNEL_STDERR: {
+			stderr_chan->close();
+		} break;
+		case CHANNEL_STDIN: {
+			stdin_sama->close();
+		} break;
+		default: ERR_FAIL();
+	}
+}
+
+Ref<Process> Process::create_ref() {
+	if (!_create)
+		return NULL;
+	return Ref<Process>(_create());
+}
+
+Process *Process::create() {
+	if (!_create)
+		return NULL;
+	return _create();
+}
+
+void Process::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_program"), &Process::get_program);
+	ClassDB::bind_method(D_METHOD("get_arguments"), &Process::_get_arguments_bind);
+
+	ClassDB::bind_method(D_METHOD("set_cwd", "path"), &Process::set_cwd);
+	ClassDB::bind_method(D_METHOD("get_cwd"), &Process::get_cwd);
+
+	ClassDB::bind_method(D_METHOD("get_state"), &Process::get_state);
+	ClassDB::bind_method(D_METHOD("get_exit_status"), &Process::get_exit_status);
+	ClassDB::bind_method(D_METHOD("get_exit_code"), &Process::get_exit_code);
+
+	ClassDB::bind_method(D_METHOD("set_redirect_flags", "flags"), &Process::set_redirect_flags);
+	ClassDB::bind_method(D_METHOD("get_redirect_flags"), &Process::get_redirect_flags);
+
+	ClassDB::bind_method(D_METHOD("set_environment", "env", "override"), &Process::_set_environment_bind, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_environment"), &Process::_get_environment_bind);
+
+	ClassDB::bind_method(D_METHOD("set_read_channel", "channel"), &Process::set_read_channel);
+	ClassDB::bind_method(D_METHOD("get_read_channel"), &Process::get_read_channel);
+	ClassDB::bind_method(D_METHOD("close_channel", "channel"), &Process::close_channel);
+
+	ClassDB::bind_method(D_METHOD("get_pid"), &Process::get_pid);
+
+	ClassDB::bind_method(D_METHOD("start"), &Process::_start_bind);
+	ClassDB::bind_method(D_METHOD("poll"), &Process::poll);
+
+	ClassDB::bind_method(D_METHOD("wait_for_started", "msecs"), &Process::wait_for_started, DEFVAL(20000));
+	ClassDB::bind_method(D_METHOD("wait_for_finished", "msecs"), &Process::wait_for_finished, DEFVAL(20000));
+
+	ClassDB::bind_method(D_METHOD("terminate"), &Process::terminate);
+	ClassDB::bind_method(D_METHOD("kill"), &Process::kill);
+
+	ClassDB::bind_method(D_METHOD("get_available_bytes"), &Process::get_available_bytes);
+	ClassDB::bind_method(D_METHOD("can_read_line"), &Process::can_read_line);
+	ClassDB::bind_method(D_METHOD("read_all"), &Process::_read_all_bind);
+	ClassDB::bind_method(D_METHOD("read_line"), &Process::_read_line_bind);
+
+	ClassDB::bind_method(D_METHOD("can_write", "bytes"), &Process::can_write);
+	ClassDB::bind_method(D_METHOD("write", "data"), &Process::_write_bind);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "cwd", PROPERTY_HINT_DIR), "set_cwd", "get_cwd");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "redirect_flags", PROPERTY_HINT_FLAGS, "RedirectStdin,RedirectStdout,RedirectStderr,RedirectStderrToStdout"), "set_redirect_flags", "get_redirect_flags");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "read_channel", PROPERTY_HINT_ENUM, "ChannelStdout,ChannelStderr"), "set_read_channel", "get_read_channel");
+
+	BIND_CONSTANT(EXIT_STATUS_NORMAL);
+	BIND_CONSTANT(EXIT_STATUS_CRASH);
+
+	BIND_CONSTANT(STATE_NOT_RUNNING);
+	BIND_CONSTANT(STATE_STARTING);
+	BIND_CONSTANT(STATE_RUNNING);
+
+	BIND_CONSTANT(CHANNEL_STDOUT);
+	BIND_CONSTANT(CHANNEL_STDERR);
+	BIND_CONSTANT(CHANNEL_STDIN);
+
+	BIND_CONSTANT(REDIRECT_STDIN);
+	BIND_CONSTANT(REDIRECT_STDOUT);
+	BIND_CONSTANT(REDIRECT_STDERR);
+	BIND_CONSTANT(REDIRECT_ALL);
+	BIND_CONSTANT(REDIRECT_STDERR_TO_STDOUT);
+}
+
+Process::Process(Channel *p_stdin, Channel *p_stdout, Channel *p_stderr) {
+	exit_code = 0;
+	exit_status = EXIT_STATUS_NORMAL;
+	process_state = STATE_NOT_RUNNING;
+	read_channel = CHANNEL_STDOUT;
+	redirect_flags = REDIRECT_ALL;
+
+	stdin_sama = p_stdin;
+	stdout_chan = p_stdout;
+	stderr_chan = p_stderr;
+}
+
+void Process::set_environment(const HashMap<String, String> &p_env, bool p_override) {
+	environment = p_env;
+
+	if (!p_override) {
+		_get_system_env(environment);
+	}
+}
+
+void Process::set_read_channel(Process::ProcessChannel p_channel) {
+	ERR_FAIL_COND(p_channel == CHANNEL_STDIN);
+	read_channel = p_channel;
+}
+
+Process::~Process() {
+	stdout_chan->close();
+	stderr_chan->close();
+	stdin_sama->close();
+
+	memdelete(stdout_chan);
+	memdelete(stderr_chan);
+	memdelete(stdin_sama);
+}
+
+Process::Channel::Channel() {
+	closed = true;
+}

--- a/core/os/process.h
+++ b/core/os/process.h
@@ -1,0 +1,172 @@
+/*************************************************************************/
+/*  process.h                                                            */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#ifndef PROCESS_H
+#define PROCESS_H
+
+#include "dvector.h"
+#include "reference.h"
+#include "ustring.h"
+
+class Process : public Reference {
+	GDCLASS(Process, Reference)
+
+public:
+	enum ExitStatus {
+		EXIT_STATUS_NORMAL,
+		EXIT_STATUS_CRASH
+	};
+
+	enum State {
+		STATE_NOT_RUNNING,
+		STATE_STARTING,
+		STATE_RUNNING
+	};
+
+	enum ProcessChannel {
+		CHANNEL_STDOUT,
+		CHANNEL_STDERR,
+		CHANNEL_STDIN // last, for read_channel with PROPERTY_HINT_ENUM to work
+	};
+
+	enum Redirect {
+		REDIRECT_STDIN = 1,
+		REDIRECT_STDOUT = 2,
+		REDIRECT_STDERR = 4,
+		REDIRECT_ALL = REDIRECT_STDIN | REDIRECT_STDOUT | REDIRECT_STDERR,
+		REDIRECT_STDERR_TO_STDOUT = 8
+	};
+
+private:
+	String program;
+	Vector<String> arguments;
+	String cwd;
+
+	HashMap<String, String> environment;
+	ProcessChannel read_channel;
+	uint32_t redirect_flags;
+
+	void _set_environment_bind(const Dictionary &p_env, bool p_override = false);
+	Dictionary _get_environment_bind() const;
+
+	Vector<String> _get_arguments_bind() const { return arguments; }
+
+	PoolVector<uint8_t> _read_all_bind();
+	PoolVector<uint8_t> _read_line_bind();
+	int _write_bind(const PoolVector<uint8_t> &p_text);
+
+	bool _start_bind(const String &p_program, const Vector<String> &p_arguments);
+
+protected:
+	struct Channel {
+		bool closed;
+
+		virtual bool open() = 0;
+		virtual void close() = 0;
+
+		Channel();
+		virtual ~Channel() {}
+	};
+
+	Channel *stdin_sama;
+	Channel *stdout_chan;
+	Channel *stderr_chan;
+
+	State process_state;
+	ExitStatus exit_status;
+	int exit_code;
+
+	static Process *(*_create)();
+
+	static void _bind_methods();
+
+	virtual bool _start() = 0;
+	virtual void _get_system_env(HashMap<String, String> &r_env) = 0;
+
+	Process(Channel *p_stdin, Channel *p_stdout, Channel *p_stderr);
+
+public:
+	_FORCE_INLINE_ void set_arguments(const Vector<String> &p_arguments) { arguments = p_arguments; }
+	_FORCE_INLINE_ const Vector<String> &get_arguments() const { return arguments; }
+
+	_FORCE_INLINE_ void set_program(const String &p_program) { program = p_program; }
+	_FORCE_INLINE_ String get_program() const { return program; }
+
+	_FORCE_INLINE_ void set_cwd(const String &p_dir) { cwd = p_dir; }
+	_FORCE_INLINE_ String get_cwd() const { return cwd; }
+
+	_FORCE_INLINE_ State get_state() const { return process_state; }
+	_FORCE_INLINE_ ExitStatus get_exit_status() const { return exit_status; }
+	_FORCE_INLINE_ int get_exit_code() const { return exit_code; }
+
+	_FORCE_INLINE_ void set_redirect_flags(uint32_t p_redirect_flags) { redirect_flags = p_redirect_flags; }
+	_FORCE_INLINE_ uint32_t get_redirect_flags() const { return redirect_flags; }
+
+	void set_environment(const HashMap<String, String> &p_env, bool p_override = false);
+	_FORCE_INLINE_ const HashMap<String, String> &get_environment() const { return environment; }
+
+	void set_read_channel(ProcessChannel p_channel);
+	_FORCE_INLINE_ ProcessChannel get_read_channel() const { return read_channel; }
+	void close_channel(ProcessChannel p_channel);
+
+	bool start(const String &p_program, const Vector<String> &p_arguments);
+	bool start();
+
+	bool can_read_line() const;
+
+	virtual int64_t get_pid() const = 0;
+
+	virtual Error poll() = 0;
+
+	virtual bool wait_for_started(int msecs = 20000) = 0;
+	virtual bool wait_for_finished(int msecs = 20000) = 0;
+
+	virtual void terminate() = 0;
+	virtual void kill() = 0;
+
+	virtual int get_available_bytes() const = 0;
+	virtual int next_line_size() const = 0;
+	virtual int read_all(char *p_data, int p_max_size) = 0;
+	virtual int read_line(char *p_data, int p_max_size) = 0;
+
+	virtual bool can_write(int p_size) const = 0;
+	virtual int write(const char *p_text, int p_max_size) = 0;
+
+	static Ref<Process> create_ref();
+	static Process *create();
+
+	~Process();
+};
+
+VARIANT_ENUM_CAST(Process::ExitStatus)
+VARIANT_ENUM_CAST(Process::State)
+VARIANT_ENUM_CAST(Process::ProcessChannel)
+VARIANT_ENUM_CAST(Process::Redirect)
+
+#endif // PROCESS_H

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -52,6 +52,7 @@
 #include "math/triangle_mesh.h"
 #include "os/input.h"
 #include "os/main_loop.h"
+#include "os/process.h"
 #include "packed_data_container.h"
 #include "path_remap.h"
 #include "translation.h"
@@ -115,6 +116,7 @@ void register_core_types() {
 	ClassDB::register_custom_instance_class<TCP_Server>();
 	ClassDB::register_custom_instance_class<PacketPeerUDP>();
 	ClassDB::register_custom_instance_class<StreamPeerSSL>();
+	ClassDB::register_custom_instance_class<Process>();
 	ClassDB::register_virtual_class<IP>();
 	ClassDB::register_virtual_class<PacketPeer>();
 	ClassDB::register_class<PacketPeerStream>();
@@ -159,6 +161,8 @@ void register_core_types() {
 void register_core_settings() {
 	//since in register core types, globals may not e present
 	GLOBAL_DEF("network/packets/packet_stream_peer_max_buffer_po2", (16));
+	GLOBAL_DEF("os/process_max_read_buffer_po2", (16));
+	GLOBAL_DEF("os/process_max_write_buffer_po2", (16));
 }
 
 void register_core_singletons() {

--- a/core/ring_buffer.h
+++ b/core/ring_buffer.h
@@ -101,6 +101,32 @@ public:
 		return p_size;
 	};
 
+	int find(const T &t, int p_offset, int p_max_size) {
+
+		int left = data_left();
+		if ((p_offset + p_max_size) > left) {
+			p_max_size -= left - p_offset;
+			if (p_max_size <= 0)
+				return 0;
+		}
+		p_max_size = MIN(left, p_max_size);
+		int pos = read_pos;
+		inc(pos, p_offset);
+		int to_read = p_max_size;
+		while (to_read) {
+			int end = pos + to_read;
+			end = MIN(end, size());
+			int total = end - pos;
+			for (int i = 0; i < total; i++) {
+				if (data[pos + i] == t)
+					return i + (p_max_size - to_read);
+			};
+			to_read -= total;
+			pos = 0;
+		};
+		return -1;
+	};
+
 	inline int advance_read(int p_n) {
 		p_n = MIN(p_n, data_left());
 		inc(read_pos, p_n);

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -34859,6 +34859,292 @@
 	<constants>
 	</constants>
 </class>
+<class name="Process" inherits="Reference" category="Core">
+	<brief_description>
+		Class for executing programs and communicating with them.
+	</brief_description>
+	<description>
+		Class for executing programs as child processes and communicating with them.
+	</description>
+	<methods>
+		<method name="can_read_line" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+				Return whether a complete line can be read from the current read channel.
+			</description>
+		</method>
+		<method name="can_write" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="bytes" type="int">
+			</argument>
+			<description>
+				Return whether the specified number of bytes can be written.
+				If the channel represented by CHANNEL_STDIN is closed, false is returned.
+				Additionally, on Windows, this method returns false if the write buffer is full.
+				The returned value does not guarantee that the next call to write will fail or succeed, or that all the bytes will be written.
+			</description>
+		</method>
+		<method name="close_channel">
+			<argument index="0" name="channel" type="int">
+			</argument>
+			<description>
+				Close the specified channel. The value of the argument channel can be any of the CHANNEL_* constants.
+				On Windows, this method may block until the current asynchronous operation in progress has finished.
+			</description>
+		</method>
+		<method name="get_arguments" qualifiers="const">
+			<return type="PoolStringArray">
+			</return>
+			<description>
+				Return the arguments that will be passed to the process on start.
+			</description>
+		</method>
+		<method name="get_available_bytes" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Return the number of bytes available in the current read channel.
+			</description>
+		</method>
+		<method name="get_cwd" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+				Return the working directory that the child process will enter on start.
+			</description>
+		</method>
+		<method name="get_environment" qualifiers="const">
+			<return type="Dictionary">
+			</return>
+			<description>
+				Return a Dictionary containing the environment that will be passed to the child process on start.
+				If this Dictionary is empty, the environment of the parent process will be passed to the child process on start.
+			</description>
+		</method>
+		<method name="get_exit_code" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Return the exit code of the last process that finished.
+				This value is not valid if the process crashed.
+			</description>
+		</method>
+		<method name="get_exit_status" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Return the exit status of the last process that finished.
+				This value can be any of the EXIT_STATUS_* constants.
+			</description>
+		</method>
+		<method name="get_pid" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Return the process ID of the running process, or 0 if the process is not running.
+			</description>
+		</method>
+		<method name="get_program" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+				Return the program the process is started with.
+			</description>
+		</method>
+		<method name="get_read_channel" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Return the current read channel. All read related calls are applied to the current read channel.
+				The value can only be CHANNEL_STDOUT or CHANNEL_STDERR.
+			</description>
+		</method>
+		<method name="get_redirect_flags" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Return the redirection flags of the process. Check the REDIRECT_* constants for more details.
+			</description>
+		</method>
+		<method name="get_state" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Return the state of the process. Check the STATE_* constants.
+			</description>
+		</method>
+		<method name="kill">
+			<description>
+				Kill the current running process, causing it to exit immediately.
+				On Windows, it uses TerminateProcess with the exit code 1.
+				On Unix, it sends a SIGKILL signal.
+			</description>
+		</method>
+		<method name="poll">
+			<return type="int">
+			</return>
+			<description>
+				This method needs to be called when communicating to the child process in a non-blocking way.
+				If the process has exited and the process state has not yet been set to STATE_NOT_RUNNING, poll() retrieves the exit code and exit status, reads any remaining data available in the read channels and does clean up.
+				On Windows, if the process is running and there is data waiting to be read/written, poll() will start the read/write asynchronous operations, if there is not one in progress.
+				On Unix, if the process is running and there is data available, poll() will read all the data possible to the read buffer of the open read channels.
+			</description>
+		</method>
+		<method name="read_all">
+			<return type="PoolByteArray">
+			</return>
+			<description>
+				Return an array of bytes containing all the data that could be read from the current read channel.
+			</description>
+		</method>
+		<method name="read_line">
+			<return type="PoolByteArray">
+			</return>
+			<description>
+				Return an array of bytes containing the next complete line that could be read, or an empty array if no complete line could be read.
+			</description>
+		</method>
+		<method name="set_cwd">
+			<argument index="0" name="path" type="String">
+			</argument>
+			<description>
+				Set the working directory that the child process will enter on start.
+			</description>
+		</method>
+		<method name="set_environment">
+			<argument index="0" name="env" type="Dictionary">
+			</argument>
+			<argument index="1" name="override" type="bool" default="false">
+			</argument>
+			<description>
+				Set the environment that will be passed to the child process.
+				The override parameter determines wheter env overrides the environment of the parent process, or is appended to it.
+				If this method is not called or env is empty, the environment of the parent process will be used.
+			</description>
+		</method>
+		<method name="set_read_channel">
+			<argument index="0" name="channel" type="int">
+			</argument>
+			<description>
+				Set the current read channel. All read related calls are applied to the current read channel.
+				The value can only be CHANNEL_STDOUT or CHANNEL_STDERR.
+			</description>
+		</method>
+		<method name="set_redirect_flags">
+			<argument index="0" name="flags" type="int">
+			</argument>
+			<description>
+				Set the redirection flags of the process. Check the REDIRECT_* constants for more details.
+			</description>
+		</method>
+		<method name="start">
+			<return type="bool">
+			</return>
+			<argument index="0" name="arg0" type="String">
+			</argument>
+			<argument index="1" name="arg1" type="PoolStringArray">
+			</argument>
+			<description>
+				Starts the program as a child process with the specified arguments.
+				Return true on success, otherwise false. If a process is already running on this object, false is returned.
+			</description>
+		</method>
+		<method name="terminate">
+			<description>
+				Attempts to terminate the running process.
+				On Windows, it posts a WM_CLOSE message.
+				On Unix, it sends a SIGTERM signal.
+			</description>
+		</method>
+		<method name="wait_for_finished">
+			<return type="bool">
+			</return>
+			<argument index="0" name="msecs" type="int" default="20000">
+			</argument>
+			<description>
+				Blocks until the process has finished or until timeout.
+				Return whether the process has finished.
+				If msecs is -1, this method will not time out. It may still return false if an error occurs.
+			</description>
+		</method>
+		<method name="wait_for_started">
+			<return type="bool">
+			</return>
+			<argument index="0" name="msecs" type="int" default="20000">
+			</argument>
+			<description>
+				Blocks until the process has started or until timeout.
+				Return whether the process has started.
+				If msecs is -1, this method will not time out. It may still return false if an error occurs.
+				On Windows, this method returns immediately and is the equivalent to [code]get_state() == STATE_RUNNING[/code].
+			</description>
+		</method>
+		<method name="write">
+			<return type="int">
+			</return>
+			<argument index="0" name="data" type="PoolByteArray">
+			</argument>
+			<description>
+				Writes data to CHANNEL_STDIN. Return the number of bytes that were successfully written, or -1 if an error ocurred or CHANNEL_STDIN is closed.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="cwd" type="String" setter="set_cwd" getter="get_cwd" brief="">
+			The working directory that the child process will enter on start.
+		</member>
+		<member name="read_channel" type="int" setter="set_read_channel" getter="get_read_channel" brief="">
+			The current read channel. All read related calls are applied to the current read channel.
+			The value can only be CHANNEL_STDOUT or CHANNEL_STDERR.
+		</member>
+		<member name="redirect_flags" type="int" setter="set_redirect_flags" getter="get_redirect_flags" brief="">
+			The redirection flags of the process. Check the REDIRECT_* constants for more details.
+		</member>
+	</members>
+	<constants>
+		<constant name="EXIT_STATUS_NORMAL" value="0">
+			The process exited normally.
+		</constant>
+		<constant name="EXIT_STATUS_CRASH" value="1">
+			The process crashed.
+		</constant>
+		<constant name="STATE_NOT_RUNNING" value="0">
+			The process is not running.
+		</constant>
+		<constant name="STATE_STARTING" value="1">
+			The process is starting, but the program has not yet been executed.
+		</constant>
+		<constant name="STATE_RUNNING" value="2">
+			The process is running and is ready for read/write operations.
+		</constant>
+		<constant name="CHANNEL_STDOUT" value="0">
+			The channel used to read from the standard output of the child process.
+		</constant>
+		<constant name="CHANNEL_STDERR" value="1">
+			The channel used to read from the standard error of the child process.
+		</constant>
+		<constant name="CHANNEL_STDIN" value="2">
+			The channel used to write to the standard input of the child process.
+		</constant>
+		<constant name="REDIRECT_STDIN" value="1">
+			Redirects the data written to CHANNEL_STDIN to the standard input of the child process. If not set, the data is redirected from the standard input of the parent process.
+		</constant>
+		<constant name="REDIRECT_STDOUT" value="2">
+			Redirects the data written to the standard output of the child process to CHANNEL_STDOUT. If not set, the data is redirected to the standard output of the parent process.
+		</constant>
+		<constant name="REDIRECT_STDERR" value="4">
+			Redirects the data written to the standard error of the child process to CHANNEL_STDERR. If not set, the data is redirected to the standard error of the parent process. This flag is ignored if REDIRECT_STDERR_TO_STDOUT is set.
+		</constant>
+		<constant name="REDIRECT_ALL" value="7">
+			Shorthand for [code]REDIRECT_STDIN | REDIRECT_STDOUT | REDIRECT_STDERR[/code].
+		</constant>
+		<constant name="REDIRECT_STDERR_TO_STDOUT" value="8">
+			Redirects the data written to the standard error of the child process to CHANNEL_STDOUT or standard output of the parent process if REDIRECT_STDOUT is not set. This flag has priority over REDIRECT_STDERR.
+		</constant>
+	</constants>
+</class>
 <class name="ProgressBar" inherits="Range" category="Core">
 	<brief_description>
 		General purpose progress bar.

--- a/drivers/unix/SCsub
+++ b/drivers/unix/SCsub
@@ -14,4 +14,7 @@ f.close()
 
 env.add_source_files(env.drivers_sources, "*.cpp")
 
+# Dependency for ProcessUnix and OS_Unix::execute()
+env.add_source_files(env.drivers_sources, ["#thirdparty/forkfd/forkfd_godot.cpp"])
+
 Export('env')

--- a/drivers/unix/process_unix.cpp
+++ b/drivers/unix/process_unix.cpp
@@ -1,0 +1,683 @@
+/*************************************************************************/
+/*  process_unix.cpp                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#include "process_unix.h"
+
+#ifdef UNIX_ENABLED
+
+#include "global_config.h"
+#include "os/file_access.h"
+#include "os/os.h"
+#include "thirdparty/forkfd/forkfd.h"
+
+#include <errno.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+
+#ifndef NO_FCNTL
+#ifdef __HAIKU__
+#include <fcntl.h>
+#else
+#include <sys/fcntl.h>
+#endif
+#define SET_NONBLOCK(m_pipe_end)                                             \
+	if (m_pipe_end != -1) {                                                  \
+		fcntl(m_pipe_end, F_SETFL, fcntl(m_pipe_end, F_GETFL) | O_NONBLOCK); \
+	}
+#else
+#define SET_NONBLOCK(m_pipe_end)           \
+	if (m_pipe_end != -1) {                \
+		int flag = 1;                      \
+		ioctl(m_pipe_end, FIONBIO, &flag); \
+	}
+#endif
+
+#define PIPE_READ 0
+#define PIPE_WRITE 1
+
+#define CLOSE_PIPE_END(m_pipe_end) \
+	if (m_pipe_end != -1) {        \
+		::close(m_pipe_end);       \
+		m_pipe_end = -1;           \
+	}
+
+#define CURRENT_READ_CHANNEL (get_read_channel() == CHANNEL_STDERR ? _stderr_rchan() : _stdout_rchan())
+
+static int create_pipe(int r_pipe[2]) {
+	CLOSE_PIPE_END(r_pipe[PIPE_READ]);
+	CLOSE_PIPE_END(r_pipe[PIPE_WRITE]);
+
+	int ret = pipe(r_pipe);
+
+	if (ret == -1)
+		return -1;
+
+#ifndef NO_FCNTL
+	fcntl(r_pipe[PIPE_READ], F_SETFD, FD_CLOEXEC);
+	fcntl(r_pipe[PIPE_WRITE], F_SETFD, FD_CLOEXEC);
+#else
+	ioctl(r_pipe[PIPE_READ], FIOCLEX);
+	ioctl(r_pipe[PIPE_WRITE], FIOCLEX);
+#endif
+
+	return ret;
+}
+
+static int get_available_bytes_in(int p_pipe) {
+	unsigned long len = 0;
+	int ret = ioctl(p_pipe, FIONREAD, &len);
+	ERR_FAIL_COND_V(ret == -1, 0);
+	return len;
+}
+
+void ProcessUnix::make_default() {
+	Process::_create = ProcessUnix::_create;
+}
+
+Process *ProcessUnix::_create() {
+	return memnew(ProcessUnix);
+}
+
+int64_t ProcessUnix::get_pid() const {
+	return pid;
+}
+
+bool ProcessUnix::_setup_channels() {
+	if (get_redirect_flags() & REDIRECT_STDIN) {
+		if (!_stdin_wchan()->open())
+			goto failed_stdin;
+	} else {
+		dup2(STDIN_FILENO, _stdin_wchan()->pipe[PIPE_READ]);
+	}
+
+	if (get_redirect_flags() & REDIRECT_STDOUT) {
+		if (!_stdout_rchan()->open())
+			goto failed_stdout;
+	} else {
+		dup2(STDOUT_FILENO, _stdout_rchan()->pipe[PIPE_WRITE]);
+	}
+
+	if (get_redirect_flags() & REDIRECT_STDERR_TO_STDOUT) {
+		_stderr_rchan()->pipe[PIPE_READ] = -1;
+		_stderr_rchan()->pipe[PIPE_WRITE] = -1;
+	} else if (get_redirect_flags() & REDIRECT_STDERR) {
+		if (!_stderr_rchan()->open())
+			goto failed_stderr;
+	} else {
+		dup2(STDERR_FILENO, _stderr_rchan()->pipe[PIPE_WRITE]);
+	}
+
+	if (create_pipe(start_notifier_pipe) == -1)
+		goto failed_start_notifier;
+
+	return true;
+
+failed_start_notifier:
+	_stderr_rchan()->close();
+failed_stderr:
+	_stdout_rchan()->close();
+failed_stdout:
+	_stdin_wchan()->close();
+failed_stdin:
+	return false;
+}
+
+bool ProcessUnix::_start() {
+	// Setup channels
+
+	if (!_setup_channels())
+		return false;
+
+	process_state = STATE_STARTING;
+
+	// Setup arguments
+
+	String prog = get_program();
+	prog = prog.replace("\\", "/"); // No backslash, please
+
+	// If the program is not a path, try to find it in PATH
+	if (prog.find("/") == -1) {
+		Vector<String> env_path = OS::get_singleton()->get_environment("PATH").split(":", false);
+
+		for (int i = 0; i < env_path.size(); i++) {
+			String p = env_path[i].plus_file(prog);
+
+			if (FileAccess::exists(p)) {
+				prog = p;
+				break;
+			}
+		}
+	} else {
+		// Fix program path
+
+		while (true) { // in case of using 2 or more slash
+			String compare = prog.replace("//", "/");
+			if (prog == compare)
+				break;
+			else
+				prog = compare;
+		}
+	}
+
+	Vector<CharString> argss;
+	Vector<char *> argv;
+
+	argss.push_back(prog.utf8());
+	argv.push_back((char *)argss[0].get_data()); // shitty C cast ;)
+
+	for (int i = 1; i <= get_arguments().size(); i++) {
+		argss.push_back(get_arguments()[i - 1].utf8());
+		argv.push_back((char *)argss[i].get_data()); // shitty C cast ;)
+	}
+
+	argv.push_back(NULL);
+
+	// Setup environment
+
+	const HashMap<String, String> &env = get_environment();
+
+	int envc = env.size();
+
+	Vector<CharString> envph;
+	Vector<char *> envp;
+
+	int envidx = 0;
+	const String *k = NULL;
+	while ((k = env.next(k))) {
+		String env_str = *k;
+		env_str += L'=';
+		env_str += env.get(*k);
+		env_str += L'\0';
+
+		envph.push_back(env_str.utf8());
+		envp.push_back((char *)envph[envidx].get_data());
+
+		++envidx;
+	}
+
+	envp.push_back(NULL);
+
+	// Fix cwd path
+
+	String cwd = get_cwd();
+	cwd = cwd.replace("\\", "/");
+	while (true) { // in case of using 2 or more slash
+		String compare = cwd.replace("//", "/");
+		if (cwd == compare)
+			break;
+		else
+			cwd = compare;
+	}
+
+	// Fork
+
+	pid_t childpid;
+	forkfd = ::forkfd(FFD_CLOEXEC, &childpid);
+
+	if (forkfd == -1) {
+		process_state = STATE_NOT_RUNNING;
+		_death_cleanup();
+		return false;
+	}
+
+	if (forkfd == FFD_CHILD_PROCESS) {
+		::signal(SIGPIPE, SIG_DFL); // if the parent was ignoring SIGPIPE
+
+		// Execute child
+
+		dup2(_stdin_wchan()->pipe[PIPE_READ], STDIN_FILENO);
+		dup2(_stdout_rchan()->pipe[PIPE_WRITE], STDOUT_FILENO);
+
+		if (get_redirect_flags() & REDIRECT_STDERR_TO_STDOUT) {
+			dup2(STDOUT_FILENO, STDERR_FILENO);
+		} else {
+			dup2(_stderr_rchan()->pipe[PIPE_WRITE], STDERR_FILENO);
+		}
+
+		CLOSE_PIPE_END(start_notifier_pipe[PIPE_READ]);
+
+		CharString cwd_utf8 = cwd.utf8();
+
+		if (cwd_utf8.length() && chdir(cwd_utf8.get_data()) != -1) { // change cwd
+			if (envc > 0) {
+				execve(argv[0], &argv[0], &envp[0]);
+			} else {
+				execvp(argv[0], &argv[0]);
+			}
+		}
+
+		// exec failed, notify parent
+
+		int errnum = errno;
+		::write(start_notifier_pipe[PIPE_WRITE], &errnum, sizeof(errnum));
+		CLOSE_PIPE_END(start_notifier_pipe[PIPE_WRITE]);
+
+		abort();
+	}
+
+	pid = childpid;
+
+	// Don't need these
+	CLOSE_PIPE_END(start_notifier_pipe[PIPE_WRITE]);
+
+	CLOSE_PIPE_END(_stdin_wchan()->pipe[PIPE_READ]);
+	CLOSE_PIPE_END(_stdout_rchan()->pipe[PIPE_WRITE]);
+	CLOSE_PIPE_END(_stderr_rchan()->pipe[PIPE_WRITE]);
+
+	SET_NONBLOCK(_stdin_wchan()->pipe[PIPE_WRITE]);
+	SET_NONBLOCK(_stdout_rchan()->pipe[PIPE_READ]);
+	SET_NONBLOCK(_stderr_rchan()->pipe[PIPE_READ]);
+
+	return true;
+}
+
+extern char **environ;
+
+void ProcessUnix::_get_system_env(HashMap<String, String> &r_env) {
+	for (char **current = environ; *current; current++) {
+		if (const char *sep = strchr(*current, '=')) {
+			String name;
+			name.parse_utf8(*current, sep - (*current));
+			String value;
+			value.parse_utf8(sep + 1);
+
+			r_env.set(name, value);
+		}
+	}
+}
+
+void ProcessUnix::_death_cleanup() {
+	pid = 0;
+
+	CLOSE_PIPE_END(start_notifier_pipe[PIPE_READ]);
+	CLOSE_PIPE_END(start_notifier_pipe[PIPE_WRITE]);
+
+	CLOSE_PIPE_END(forkfd);
+
+	stdin_sama->close();
+	stdout_chan->close();
+	stderr_chan->close();
+}
+
+void ProcessUnix::_wait_forkfd() {
+	if (forkfd != -1) {
+		forkfd_info info;
+		while (forkfd_wait(forkfd, &info, NULL) == -1 && errno == EINTR) {
+		}
+
+		exit_code = info.status;
+		exit_status = info.code == CLD_EXITED ? EXIT_STATUS_NORMAL : EXIT_STATUS_CRASH;
+
+		CLOSE_PIPE_END(forkfd);
+	}
+}
+
+void ProcessUnix::_process_start_notification() {
+	int exec_errnum;
+	int bytes = ::read(start_notifier_pipe[PIPE_READ], &exec_errnum, sizeof(exec_errnum));
+
+	if (bytes > 0) {
+		process_state = STATE_NOT_RUNNING;
+		CLOSE_PIPE_END(start_notifier_pipe[PIPE_READ]);
+		ERR_PRINTS(String() + "Child exec failed to start with errno: " + String::num_int64(exec_errnum));
+		_wait_forkfd();
+		_death_cleanup();
+	} else {
+		process_state = STATE_RUNNING;
+		CLOSE_PIPE_END(start_notifier_pipe[PIPE_READ]);
+	}
+}
+
+void ProcessUnix::_process_forkfd_notification() {
+	_wait_forkfd();
+
+	if (process_state == STATE_STARTING) {
+		wait_for_started(0);
+		if (process_state == STATE_NOT_RUNNING) {
+			// exec failed, we are done here
+			return;
+		}
+	}
+
+	_read_bytes_from_channel(_stdout_rchan(), get_available_bytes_in(_stdout_rchan()->pipe[PIPE_READ]));
+	_read_bytes_from_channel(_stderr_rchan(), get_available_bytes_in(_stderr_rchan()->pipe[PIPE_READ]));
+
+	process_state = STATE_NOT_RUNNING;
+
+	_death_cleanup();
+}
+
+Error ProcessUnix::_select_fds(int msecs) {
+
+#define FD_SET_AND_CHECK_HIGHEST(m_n, m_fd, m_fdset) \
+	{                                                \
+		FD_SET(m_fd, &m_fdset);                      \
+                                                     \
+		if (m_fd > m_n) {                            \
+			m_n = m_fd;                              \
+		}                                            \
+	}
+
+	fd_set readfds;
+	fd_set writefds;
+	int n = -1;
+
+	FD_ZERO(&readfds);
+	FD_ZERO(&writefds);
+
+	if (process_state == STATE_STARTING) {
+		FD_SET_AND_CHECK_HIGHEST(n, start_notifier_pipe[PIPE_READ], readfds);
+	} else if (process_state == STATE_RUNNING) {
+		FD_SET_AND_CHECK_HIGHEST(n, forkfd, readfds);
+	}
+
+	if (_stdout_rchan()->pipe[PIPE_READ] != -1) {
+		FD_SET_AND_CHECK_HIGHEST(n, _stdout_rchan()->pipe[PIPE_READ], readfds);
+	}
+
+	if (_stderr_rchan()->pipe[PIPE_READ] != -1) {
+		FD_SET_AND_CHECK_HIGHEST(n, _stderr_rchan()->pipe[PIPE_READ], readfds);
+	}
+
+	struct timeval tv;
+
+	if (msecs != -1) {
+		tv.tv_sec = msecs ? msecs / 1000 : 0;
+		tv.tv_usec = msecs ? (msecs % 1000) * 1000 : 0;
+	}
+
+	if (::select(n + 1, &readfds, &writefds, NULL, msecs == -1 ? NULL : &tv) <= 0) {
+		return FAILED;
+	}
+
+	if (process_state == STATE_STARTING) {
+		if (FD_ISSET(start_notifier_pipe[PIPE_READ], &readfds)) {
+			_process_start_notification();
+
+			if (process_state == STATE_NOT_RUNNING) {
+				return OK;
+			}
+		}
+	}
+
+	if (_stdout_rchan()->pipe[PIPE_READ] != -1 && FD_ISSET(_stdout_rchan()->pipe[PIPE_READ], &readfds)) {
+		_read_bytes_from_channel(_stdout_rchan(), get_available_bytes_in(_stdout_rchan()->pipe[PIPE_READ]));
+	}
+
+	if (_stderr_rchan()->pipe[PIPE_READ] != -1 && FD_ISSET(_stderr_rchan()->pipe[PIPE_READ], &readfds)) {
+		_read_bytes_from_channel(_stderr_rchan(), get_available_bytes_in(_stderr_rchan()->pipe[PIPE_READ]));
+	}
+
+	if (forkfd != -1 && FD_ISSET(forkfd, &readfds)) {
+		_process_forkfd_notification();
+
+		if (process_state == STATE_NOT_RUNNING) {
+			return OK;
+		}
+	}
+
+	return ERR_TIMEOUT;
+}
+
+Error ProcessUnix::poll() {
+	ERR_FAIL_COND_V(process_state == STATE_NOT_RUNNING, ERR_UNCONFIGURED);
+	Error err = _select_fds(0);
+	return err == ERR_TIMEOUT ? OK : err;
+}
+
+bool ProcessUnix::wait_for_started(int msecs) {
+	fd_set readfds;
+	FD_ZERO(&readfds);
+	FD_SET(start_notifier_pipe[PIPE_READ], &readfds);
+
+	struct timeval tv;
+
+	if (msecs != -1) {
+		tv.tv_sec = msecs ? msecs / 1000 : 0;
+		tv.tv_usec = msecs ? (msecs % 1000) * 1000 : 0;
+	}
+
+	if (::select(start_notifier_pipe[PIPE_READ] + 1, &readfds, NULL, NULL, msecs == -1 ? NULL : &tv)) {
+		_process_start_notification();
+		return true;
+	}
+
+	return false;
+}
+
+bool ProcessUnix::wait_for_finished(int msecs) {
+	do {
+		int last_tick = OS::get_singleton()->get_ticks_msec();
+
+		Error err = _select_fds(msecs);
+
+		if (err == OK)
+			return true;
+		if (err == FAILED)
+			return false;
+
+		// ERR_TIMEOUT
+
+		if (msecs != -1) {
+			int tdiff = OS::get_singleton()->get_ticks_msec() - last_tick;
+
+			if (tdiff > msecs) {
+				msecs = 0;
+			} else {
+				msecs -= tdiff;
+			}
+		}
+	} while (msecs || msecs == -1);
+
+	return false;
+}
+
+void ProcessUnix::terminate() {
+	if (pid) ::kill(pid, SIGTERM);
+}
+
+void ProcessUnix::kill() {
+	if (pid) ::kill(pid, SIGKILL);
+}
+
+int ProcessUnix::get_available_bytes() const {
+	return CURRENT_READ_CHANNEL->ring_buffer.data_left();
+}
+
+int ProcessUnix::next_line_size() const {
+	ReadChannel *channel = CURRENT_READ_CHANNEL;
+	return channel->ring_buffer.find('\n', 0, channel->ring_buffer.data_left());
+}
+
+int ProcessUnix::_read_bytes_from_channel(ReadChannel *p_channel, int p_max_size) {
+	if (!p_max_size)
+		return 0;
+
+	int total_read = 0;
+	int to_read = p_max_size;
+
+	do {
+		int read = p_channel->read(to_read);
+
+		if (read <= 0)
+			break;
+
+		total_read += read;
+	} while (to_read && total_read < p_max_size);
+
+	return total_read;
+}
+
+int ProcessUnix::read_all(char *p_data, int p_max_size) {
+	ReadChannel *channel = CURRENT_READ_CHANNEL;
+	int diff = p_max_size - channel->ring_buffer.data_left();
+
+	if (diff > 0) {
+		int to_read = MIN(get_available_bytes_in(CURRENT_READ_CHANNEL->pipe[PIPE_READ]), diff);
+		p_max_size = _read_bytes_from_channel(channel, to_read);
+	}
+
+	int read = channel->ring_buffer.read(p_data, p_max_size);
+	ERR_FAIL_COND_V(read != p_max_size, read);
+	return read;
+}
+
+int ProcessUnix::read_line(char *p_data, int p_max_size) {
+	ReadChannel *channel = CURRENT_READ_CHANNEL;
+	int diff = p_max_size - channel->ring_buffer.data_left();
+
+	if (diff > 0) {
+		p_max_size = _read_bytes_from_channel(channel, MIN(next_line_size(), diff));
+	}
+
+	int read = channel->ring_buffer.read(p_data, p_max_size);
+	ERR_FAIL_COND_V(read != p_max_size, read);
+	return read;
+}
+
+bool ProcessUnix::can_write(int) const {
+	return !stdin_sama->closed;
+}
+
+int ProcessUnix::write(const char *p_data, int p_max_size) {
+	return _stdin_wchan()->write(p_data, p_max_size);
+}
+
+ProcessUnix::ProcessUnix()
+	: Process(memnew(WriteChannel), memnew(ReadChannel), memnew(ReadChannel)) {
+	pid = 0;
+	forkfd = -1;
+	start_notifier_pipe[PIPE_READ] = -1;
+	start_notifier_pipe[PIPE_WRITE] = -1;
+}
+
+ProcessUnix::~ProcessUnix() {
+	_death_cleanup();
+}
+
+int ProcessUnix::ReadChannel::read(int p_bytes) {
+	ERR_FAIL_COND_V(closed, -1);
+
+	int to_read = MIN(p_bytes, ring_buffer.space_left());
+
+	if (to_read) {
+		int read = ::read(pipe[PIPE_READ], sysread_buffer.ptr(), to_read);
+
+		if (read > 0) {
+			int stored = ring_buffer.write(sysread_buffer.ptr(), read);
+			ERR_FAIL_COND_V(stored != read, stored);
+		}
+		if (read == -1 && errno != EWOULDBLOCK) {
+			ERR_PRINTS(String() + "::read failed with error code: " + String::num_int64(errno));
+		} else if (read == 0) {
+			// eof
+			close();
+		}
+
+		return read;
+	}
+
+	return 0;
+}
+
+bool ProcessUnix::ReadChannel::open() {
+	ring_buffer.clear();
+
+	if (create_pipe(pipe) != -1) {
+		closed = false;
+		return true;
+	}
+
+	return false;
+}
+
+void ProcessUnix::ReadChannel::close() {
+	if (!closed)
+		closed = true;
+
+	ChannelUnix::close(); // even if closed, may be a placeholder for pipes
+}
+
+ProcessUnix::ReadChannel::ReadChannel() {
+	int rbsize = GLOBAL_GET("os/process_max_read_buffer_po2");
+
+	ring_buffer.resize(rbsize);
+	sysread_buffer.resize(1 << rbsize);
+}
+
+int ProcessUnix::WriteChannel::write(const char *p_data, int p_max_size) {
+	if (closed)
+		return -1;
+
+	int wrote = ::write(pipe[PIPE_WRITE], p_data, p_max_size);
+
+	if (wrote == -1) {
+		if (errno == EAGAIN) {
+			return 0;
+		}
+
+		close();
+		return -1;
+	}
+
+	return wrote;
+}
+
+bool ProcessUnix::WriteChannel::open() {
+	if (create_pipe(pipe) != -1) {
+		closed = false;
+		return true;
+	}
+
+	return false;
+}
+
+void ProcessUnix::WriteChannel::close() {
+	if (!closed)
+		closed = true;
+
+	ChannelUnix::close(); // even if closed, may be a placeholder for pipes
+}
+
+ProcessUnix::WriteChannel::WriteChannel() {}
+
+void ProcessUnix::ChannelUnix::close() {
+	CLOSE_PIPE_END(pipe[PIPE_READ]);
+	CLOSE_PIPE_END(pipe[PIPE_WRITE]);
+}
+
+ProcessUnix::ChannelUnix::ChannelUnix() {
+	pipe[PIPE_READ] = -1;
+	pipe[PIPE_WRITE] = -1;
+}
+
+#endif // UNIX_ENABLED

--- a/drivers/unix/process_unix.h
+++ b/drivers/unix/process_unix.h
@@ -1,0 +1,119 @@
+/*************************************************************************/
+/*  process_unix.h                                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#ifndef PROCESS_UNIX_H
+#define PROCESS_UNIX_H
+
+#ifdef UNIX_ENABLED
+
+#include "os/process.h"
+#include "ring_buffer.h"
+
+#include <unistd.h>
+
+class ProcessUnix : public Process {
+	struct ChannelUnix : public Channel {
+		int pipe[2];
+
+		void close();
+
+		ChannelUnix();
+	};
+
+	struct ReadChannel : public ChannelUnix {
+		RingBuffer<char> ring_buffer;
+		Vector<char> sysread_buffer;
+
+		int read(int p_bytes);
+
+		bool open();
+		void close();
+
+		ReadChannel();
+	};
+
+	struct WriteChannel : public ChannelUnix {
+		int write(const char *p_data, int p_max_size);
+
+		bool open();
+		void close();
+
+		WriteChannel();
+	};
+
+	static Process *_create();
+
+	pid_t pid;
+	int forkfd;
+	int start_notifier_pipe[2];
+
+	_FORCE_INLINE_ WriteChannel *_stdin_wchan() const { return static_cast<WriteChannel *>(stdin_sama); }
+	_FORCE_INLINE_ ReadChannel *_stdout_rchan() const { return static_cast<ReadChannel *>(stdout_chan); }
+	_FORCE_INLINE_ ReadChannel *_stderr_rchan() const { return static_cast<ReadChannel *>(stderr_chan); }
+
+	bool _setup_channels();
+	void _wait_forkfd();
+	void _death_cleanup();
+	int _read_bytes_from_channel(ReadChannel *p_channel, int p_max_size);
+	void _process_start_notification();
+	void _process_forkfd_notification();
+	Error _select_fds(int msecs);
+
+protected:
+	bool _start();
+	void _get_system_env(HashMap<String, String> &r_env);
+
+public:
+	static void make_default();
+
+	int64_t get_pid() const;
+
+	bool wait_for_started(int msecs = 20000);
+	bool wait_for_finished(int msecs = 20000);
+
+	void terminate();
+	void kill();
+
+	Error poll();
+
+	int get_available_bytes() const;
+	int next_line_size() const;
+	int read_all(char *p_data, int p_max_size);
+	int read_line(char *p_data, int p_max_size);
+
+	bool can_write(int p_size) const;
+	int write(const char *p_data, int p_max_size);
+
+	ProcessUnix();
+	~ProcessUnix();
+};
+
+#endif // UNIX_ENABLED
+
+#endif // PROCESS_UNIX_H

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -44,6 +44,7 @@
 #include "io/marshalls.h"
 #include "os/memory_pool_dynamic_prealloc.h"
 #include "platform/windows/packet_peer_udp_winsock.h"
+#include "platform/windows/process_windows.h"
 #include "platform/windows/stream_peer_winsock.h"
 #include "platform/windows/tcp_server_winsock.h"
 
@@ -176,6 +177,7 @@ void OSUWP::initialize_core() {
 	TCPServerWinsock::make_default();
 	StreamPeerWinsock::make_default();
 	PacketPeerUDPWinsock::make_default();
+	ProcessWindows::make_default();
 
 	mempool_static = new MemoryPoolStaticMalloc;
 #if 1

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -12,7 +12,8 @@ common_win = [
     "packet_peer_udp_winsock.cpp",
     "stream_peer_winsock.cpp",
     "joypad.cpp",
-	"power_windows.cpp",
+    "power_windows.cpp",
+    "process_windows.cpp"
 ]
 
 restarget = "godot_res" + env["OBJSUFFIX"]

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -46,6 +46,7 @@
 #include "lang_table.h"
 #include "main/main.h"
 #include "packet_peer_udp_winsock.h"
+#include "process_windows.h"
 #include "stream_peer_winsock.h"
 #include "tcp_server_winsock.h"
 
@@ -188,6 +189,7 @@ void OS_Windows::initialize_core() {
 	TCPServerWinsock::make_default();
 	StreamPeerWinsock::make_default();
 	PacketPeerUDPWinsock::make_default();
+	ProcessWindows::make_default();
 
 	// We need to know how often the clock is updated
 	if (!QueryPerformanceFrequency((LARGE_INTEGER *)&ticks_per_second))

--- a/platform/windows/process_windows.cpp
+++ b/platform/windows/process_windows.cpp
@@ -1,0 +1,807 @@
+/*************************************************************************/
+/*  process_windows.cpp                                                  */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#include "process_windows.h"
+
+#include "global_config.h"
+#include "os/dir_access.h"
+#include "os/os.h"
+#include "pair.h"
+
+#ifndef PIPE_REJECT_REMOTE_CLIENTS
+#define PIPE_REJECT_REMOTE_CLIENTS 0x00000008
+#endif
+
+#define PIPE_READ 0
+#define PIPE_WRITE 1
+
+#define CLEAN_PROCESS_INFO(m_proc_info)     \
+	if (m_proc_info) {                      \
+		CloseHandle(m_proc_info->hThread);  \
+		CloseHandle(m_proc_info->hProcess); \
+		memdelete(m_proc_info);             \
+		m_proc_info = NULL;                 \
+	}
+
+#define CLOSE_HANDLE(m_handle)              \
+	if (m_handle != INVALID_HANDLE_VALUE) { \
+		CloseHandle(m_handle);              \
+		m_handle = INVALID_HANDLE_VALUE;    \
+	}
+
+#define CURRENT_READ_CHANNEL (get_read_channel() == CHANNEL_STDERR ? _stderr_rchan() : _stdout_rchan())
+
+enum PipeType {
+	PIPE_TYPE_INPUT,
+	PIPE_TYPE_OUTPUT
+};
+
+// Based on MyCreatePipeEx
+static BOOL CreateOverlappedPipe(LPHANDLE lpPipeRead, LPHANDLE lpPipeWrite, PipeType p_type) {
+	String pipe_name;
+	HANDLE hReadPipe;
+
+	SECURITY_ATTRIBUTES secAttrs;
+	secAttrs.nLength = sizeof(secAttrs);
+	secAttrs.lpSecurityDescriptor = NULL;
+	secAttrs.bInheritHandle = (p_type == PIPE_TYPE_INPUT);
+
+	uint32_t tries_left = 100;
+	do {
+		pipe_name = "\\\\.\\pipe\\godot-";
+		pipe_name += String::num_int64(Math::rand(), 16, true);
+
+		hReadPipe = CreateNamedPipeW(
+				pipe_name.c_str(),
+				PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED,
+				PIPE_TYPE_BYTE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
+				1, // nMaxInstances
+				0, 1 << 20, // nOutBufferSize, nInBufferSize
+				0, // nDefaultTimeOut = 50ms
+				&secAttrs);
+	} while (hReadPipe == INVALID_HANDLE_VALUE &&
+			 GetLastError() == ERROR_PIPE_BUSY && --tries_left > 0);
+
+	ERR_EXPLAIN("CreateNamedPipe failed with error code: " + String::num_int64(GetLastError()));
+	ERR_FAIL_COND_V(hReadPipe == INVALID_HANDLE_VALUE, FALSE);
+
+	secAttrs.bInheritHandle = !secAttrs.bInheritHandle;
+
+	HANDLE hWritePipe = CreateFileW(
+			pipe_name.c_str(), GENERIC_WRITE,
+			0, // dwShareMode
+			&secAttrs,
+			OPEN_EXISTING, FILE_FLAG_OVERLAPPED,
+			NULL // hTemplateFile
+			);
+
+	if (hWritePipe == INVALID_HANDLE_VALUE) {
+		ERR_PRINTS(String() + "CreateNamedPipe failed with error code: " + String::num_int64(GetLastError()));
+		CloseHandle(hReadPipe);
+		return FALSE;
+	}
+
+	ConnectNamedPipe(hReadPipe, NULL);
+
+	*lpPipeRead = hReadPipe;
+	*lpPipeWrite = hWritePipe;
+
+	return TRUE;
+}
+
+static String environment_to_string(const HashMap<String, String> &p_env_map) {
+	String env_str;
+
+	const String *k = NULL;
+	while ((k = p_env_map.next(k))) {
+		env_str += *k;
+		env_str += L'=';
+		env_str += p_env_map.get(*k);
+		env_str += L'\0';
+	}
+
+	env_str += L'\0';
+	env_str += L'\0';
+
+	return env_str;
+}
+
+void ProcessWindows::make_default() {
+	Process::_create = ProcessWindows::_create;
+}
+
+Process *ProcessWindows::_create() {
+	return memnew(ProcessWindows);
+}
+
+int64_t ProcessWindows::get_pid() const {
+	if (!lpProcessInfo)
+		return 0;
+	return lpProcessInfo->dwProcessId;
+}
+
+bool ProcessWindows::_setup_channels() {
+	HANDLE hCurrentProcess = GetCurrentProcess();
+
+	if (get_redirect_flags() & REDIRECT_STDIN) {
+		if (!_stdin_wchan()->open())
+			goto failed_stdin;
+	} else {
+		if (!DuplicateHandle(hCurrentProcess, GetStdHandle(STD_INPUT_HANDLE),
+					hCurrentProcess, &_stdin_wchan()->pipe[PIPE_READ],
+					0, TRUE, DUPLICATE_SAME_ACCESS)) {
+			ERR_PRINTS("DuplicateHandle failed with error code: " + String::num_int64(GetLastError()));
+			goto failed_stdin;
+		}
+	}
+
+	if (get_redirect_flags() & REDIRECT_STDOUT) {
+		if (!_stdout_rchan()->open())
+			goto failed_stdout;
+	} else {
+		if (!DuplicateHandle(hCurrentProcess, GetStdHandle(STD_OUTPUT_HANDLE),
+					hCurrentProcess, &_stdout_rchan()->pipe[PIPE_WRITE],
+					0, TRUE, DUPLICATE_SAME_ACCESS)) {
+			ERR_PRINTS("DuplicateHandle failed with error code: " + String::num_int64(GetLastError()));
+			goto failed_stdout;
+		}
+	}
+
+	if (get_redirect_flags() & REDIRECT_STDERR_TO_STDOUT) {
+		HANDLE hCurrentProcess = GetCurrentProcess();
+		if (!DuplicateHandle(hCurrentProcess, _stdout_rchan()->pipe[PIPE_WRITE],
+					hCurrentProcess, &_stderr_rchan()->pipe[PIPE_WRITE],
+					0, TRUE, DUPLICATE_SAME_ACCESS)) {
+			ERR_PRINTS("DuplicateHandle failed with error code: " + String::num_int64(GetLastError()));
+			return false;
+		}
+	} else if (get_redirect_flags() & REDIRECT_STDERR) {
+		if (!_stderr_rchan()->open())
+			goto failed_stderr;
+	} else {
+		if (!DuplicateHandle(hCurrentProcess, GetStdHandle(STD_ERROR_HANDLE),
+					hCurrentProcess, &_stderr_rchan()->pipe[PIPE_WRITE],
+					0, TRUE, DUPLICATE_SAME_ACCESS)) {
+			ERR_PRINTS("DuplicateHandle failed with error code: " + String::num_int64(GetLastError()));
+			goto failed_stderr;
+		}
+	}
+
+	return true;
+
+failed_stderr:
+	_stdout_rchan()->close();
+failed_stdout:
+	_stdin_wchan()->close();
+failed_stdin:
+	return false;
+}
+
+bool ProcessWindows::_start() {
+	CLEAN_PROCESS_INFO(lpProcessInfo);
+
+	lpProcessInfo = memnew(PROCESS_INFORMATION);
+	zeromem(lpProcessInfo, sizeof(PROCESS_INFORMATION));
+
+	// Setup channels and redirections
+
+	if (!_setup_channels())
+		return false;
+
+	process_state = STATE_STARTING;
+
+	DirAccessRef da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+
+	// Fix program path
+
+	String prog = get_program();
+	prog = prog.replace("/", "\\");
+	while (true) { // in case of using 2 or more backslash
+		String compare = prog.replace("\\\\", "\\");
+		if (prog == compare)
+			break;
+		else
+			prog = compare;
+	}
+	if (prog.begins_with("\\")) {
+		int current_drive = da->get_current_drive();
+		prog = da->get_drive(current_drive) + prog;
+	}
+
+	// Setup arguments
+
+	String argss;
+	argss = "\"" + prog + "\"";
+	for (int i = 0; i < get_arguments().size(); i++) {
+		const String &arg = get_arguments()[i];
+
+		if (arg.begins_with("\"") || arg.ends_with("\"")) {
+			argss += String(" ");
+			argss += arg;
+		} else {
+			argss += String(" \"");
+			argss += arg;
+			argss += "\"";
+		}
+	}
+
+	// Fix cwd path
+
+	String cwd = get_cwd();
+	prog = prog.replace("/", "\\");
+	while (true) { // in case of using 2 or more backslash
+		String compare = cwd.replace("\\\\", "\\");
+		if (cwd == compare)
+			break;
+		else
+			cwd = compare;
+	}
+	if (cwd.begins_with("\\")) {
+		int current_drive = da->get_current_drive();
+		cwd = da->get_drive(current_drive) + cwd;
+	}
+
+	// Finally execute it
+
+	DWORD dwCreationFlags = (GetConsoleWindow() ? 0 : CREATE_NO_WINDOW) | CREATE_UNICODE_ENVIRONMENT;
+	STARTUPINFOW startupInfo = {
+		sizeof(STARTUPINFO), // cb
+		0, // lpReserved
+		0, 0, // lpDesktop, lpTitle
+		(DWORD)CW_USEDEFAULT, (DWORD)CW_USEDEFAULT, // dwX, dwY
+		(DWORD)CW_USEDEFAULT, (DWORD)CW_USEDEFAULT, // dwXSize, dwYSize
+		0, 0, // dwXCountChars, dwYCountChars
+		0, // dwFillAttribute
+		STARTF_USESTDHANDLES, // dwFlags
+		0, // wShowWindow
+		0, 0, // cbReserved2, lpReserved2
+		_stdin_wchan()->pipe[PIPE_READ], _stdout_rchan()->pipe[PIPE_WRITE], _stderr_rchan()->pipe[PIPE_WRITE]
+	};
+
+	String env_str;
+	if (get_environment().size()) {
+		env_str = environment_to_string(get_environment());
+	}
+
+	BOOL success = CreateProcessW(NULL, (LPWSTR)argss.c_str(), NULL, NULL, TRUE, dwCreationFlags,
+			env_str.size() ? (LPWSTR)env_str.c_str() : NULL,
+			cwd.size() ? (LPWSTR)cwd.c_str() : NULL,
+			&startupInfo, lpProcessInfo);
+
+	if (!success) {
+		process_state = STATE_NOT_RUNNING;
+
+		stdin_sama->close();
+		stdout_chan->close();
+		stderr_chan->close();
+
+		return false;
+	}
+
+	// Don't need these
+	CLOSE_HANDLE(_stdin_wchan()->pipe[PIPE_READ]);
+	CLOSE_HANDLE(_stdout_rchan()->pipe[PIPE_WRITE]);
+	CLOSE_HANDLE(_stderr_rchan()->pipe[PIPE_WRITE]);
+
+	process_state = STATE_RUNNING;
+
+	return true;
+}
+
+void ProcessWindows::_get_system_env(HashMap<String, String> &r_env) {
+	WCHAR *env_strw = GetEnvironmentStringsW();
+
+	if (env_strw) {
+		const WCHAR *elem = env_strw;
+		while (*elem) {
+			const int elem_length = int(wcslen(elem));
+
+			if (const WCHAR *sep = wcschr(elem + 1, L'=')) {
+				int name_length = sep - elem;
+
+				String name(elem, name_length);
+				String value(sep + 1, elem_length - name_length - 1);
+
+				r_env.set(name, value);
+			}
+
+			elem += elem_length + 1;
+		}
+
+		FreeEnvironmentStringsW(env_strw);
+	}
+}
+
+Error ProcessWindows::poll() {
+	ERR_FAIL_COND_V(get_state() == STATE_NOT_RUNNING, ERR_UNCONFIGURED);
+
+	DWORD dwExitCode = 0;
+
+	if (!GetExitCodeProcess(lpProcessInfo->hProcess, &dwExitCode)) {
+		ERR_EXPLAIN(String() + "GetExitCodeProcess failed with error code: " + String::num_int64(GetLastError()));
+		ERR_FAIL_V(ERR_BUG);
+	} else if (dwExitCode == STILL_ACTIVE) {
+		// Still alive // Thanks captain obvious
+
+		// If already reading/writing, give the completion callbacks an oportunity to be called
+		// If not reading, you better start doing it
+
+		WriteChannel *stdin_wchan = _stdin_wchan();
+
+		if (!stdin_wchan->closed) {
+			if (stdin_wchan->writing)
+				SleepEx(0, TRUE);
+			else if (stdin_wchan->ring_buffer.data_left() > 0)
+				stdin_wchan->write_async();
+		}
+
+		ReadChannel *stdout_rchan = _stdout_rchan();
+
+		if (!stdout_rchan->closed && !stdout_rchan->broken_pipe) {
+			if (stdout_rchan->reading) {
+				SleepEx(0, TRUE);
+			} else {
+				stdout_rchan->read_async();
+			}
+		}
+
+		ReadChannel *stderr_rchan = _stderr_rchan();
+
+		if (!stderr_rchan->closed && !stderr_rchan->broken_pipe) {
+			if (stderr_rchan->reading) {
+				SleepEx(0, TRUE);
+			} else {
+				stderr_rchan->read_async();
+			}
+		}
+	} else {
+		// The process finished
+
+		process_state = STATE_NOT_RUNNING;
+
+		exit_code = dwExitCode;
+
+		if (/* HRESULT */ dwExitCode >= 0x80000000 && dwExitCode < 0xD0000000) { /* SEH exception >= 0xC0000000 */
+			exit_status = EXIT_STATUS_CRASH;
+		} else {
+			exit_status = EXIT_STATUS_NORMAL;
+		}
+
+		// Wait for read routines to finish
+
+		ReadChannel *stdout_rchan = _stdout_rchan();
+		ReadChannel *stderr_rchan = _stderr_rchan();
+
+		bool reading = false;
+		bool routine_completed = false;
+
+		do {
+			reading = false;
+			routine_completed = false;
+
+			if (stdout_rchan->reading) {
+				stdout_rchan->read_completed = false;
+				SleepEx(0, TRUE);
+				routine_completed |= stdout_rchan->read_completed;
+			}
+
+			reading |= stdout_rchan->reading;
+
+			if (stderr_rchan->reading) {
+				stderr_rchan->read_completed = false;
+				SleepEx(0, TRUE);
+				routine_completed |= stderr_rchan->read_completed;
+			}
+
+			reading |= stderr_rchan->reading;
+		} while (reading && routine_completed);
+
+		// Clean
+
+		stdout_chan->close();
+		stderr_chan->close();
+		stdin_sama->close();
+
+		CLEAN_PROCESS_INFO(lpProcessInfo);
+	}
+
+	return OK;
+}
+
+bool ProcessWindows::wait_for_started(int) {
+	// no need to wait for anything on windows
+	// start returns with either a running or not running state
+	return get_state() == STATE_RUNNING;
+}
+
+bool ProcessWindows::wait_for_finished(int msecs) {
+	uint64_t usecs_left = msecs * 1000;
+
+	do {
+		uint64_t last_tick = OS::get_singleton()->get_ticks_usec();
+
+		DWORD retcode = WaitForSingleObject(lpProcessInfo->hProcess, 10);
+
+		poll();
+
+		if (!lpProcessInfo || retcode == WAIT_OBJECT_0)
+			return true;
+
+		if (msecs != -1) {
+			uint64_t tdiff = OS::get_singleton()->get_ticks_usec() - last_tick;
+
+			if (tdiff > usecs_left) {
+				usecs_left = 0;
+			} else {
+				usecs_left -= tdiff;
+			}
+		}
+	} while (usecs_left || msecs == -1);
+
+	return false;
+}
+
+BOOL CALLBACK TerminateAppEnum(HWND hwnd, LPARAM lParam) {
+	DWORD dwID;
+
+	GetWindowThreadProcessId(hwnd, &dwID);
+
+	if (dwID == (DWORD)lParam) {
+		PostMessage(hwnd, WM_CLOSE, 0, 0);
+	}
+
+	return TRUE;
+}
+
+void ProcessWindows::terminate() {
+	ERR_FAIL_COND(!lpProcessInfo);
+	EnumWindows((WNDENUMPROC)TerminateAppEnum, (LPARAM)lpProcessInfo->dwProcessId);
+}
+
+void ProcessWindows::kill() {
+	ERR_FAIL_COND(!lpProcessInfo);
+	TerminateProcess(lpProcessInfo->hProcess, 1);
+}
+
+int ProcessWindows::get_available_bytes() const {
+	return CURRENT_READ_CHANNEL->ring_buffer.data_left();
+}
+
+int ProcessWindows::next_line_size() const {
+	ReadChannel *channel = CURRENT_READ_CHANNEL;
+	return channel->ring_buffer.find('\n', 0, channel->ring_buffer.data_left());
+}
+
+int ProcessWindows::read_all(char *p_data, int p_max_size) {
+	ReadChannel *channel = CURRENT_READ_CHANNEL;
+	int to_read = MIN(get_available_bytes(), p_max_size);
+
+	if (to_read) {
+		int read = channel->ring_buffer.read(p_data, to_read);
+		ERR_FAIL_COND_V(read != to_read, read);
+		return read;
+	} else if (!channel->reading) {
+		channel->read_async();
+	}
+
+	return 0;
+}
+
+int ProcessWindows::read_line(char *p_data, int p_max_size) {
+	ReadChannel *channel = CURRENT_READ_CHANNEL;
+	int to_read = MIN(next_line_size(), p_max_size);
+
+	if (to_read) {
+		int read = channel->ring_buffer.read(p_data, to_read);
+		ERR_FAIL_COND_V(read != to_read, read);
+		return read;
+	} else if (!channel->reading) {
+		channel->read_async();
+	}
+
+	return 0;
+}
+
+bool ProcessWindows::can_write(int p_size) const {
+	return !stdin_sama->closed && (p_size == -1 || _stdin_wchan()->ring_buffer.space_left() >= p_size);
+}
+
+int ProcessWindows::write(const char *p_data, int p_max_size) {
+	if (stdin_sama->closed)
+		return -1;
+
+	int to_write = MIN(_stdin_wchan()->ring_buffer.space_left(), p_max_size);
+
+	if (!to_write)
+		return 0;
+
+	int wrote = _stdin_wchan()->ring_buffer.write(p_data, to_write);
+	ERR_FAIL_COND_V(wrote != to_write, wrote);
+	_stdin_wchan()->write_async();
+
+	return wrote;
+}
+
+ProcessWindows::ProcessWindows()
+	: Process(memnew(WriteChannel), memnew(ReadChannel), memnew(ReadChannel)) {
+	lpProcessInfo = NULL;
+}
+
+ProcessWindows::~ProcessWindows() {
+	stdin_sama->close();
+	stdout_chan->close();
+	stderr_chan->close();
+
+	CLEAN_PROCESS_INFO(lpProcessInfo);
+}
+
+void ProcessWindows::ReadChannel::read_async() {
+	const DWORD dwMinReadBufferSize = 4096;
+
+	DWORD dwBytesToRead = peek();
+
+	if (dwBytesToRead < dwMinReadBufferSize)
+		dwBytesToRead = dwMinReadBufferSize;
+
+	if (broken_pipe)
+		return;
+
+	dwBytesToRead = MIN(dwBytesToRead, ring_buffer.space_left());
+
+	if (dwBytesToRead == 0)
+		return;
+
+	closed = false;
+	reading = true;
+	read_completed = false;
+
+	zeromem(&(io_context.overlapped), sizeof(OVERLAPPED));
+
+	if (!ReadFileEx(pipe[PIPE_READ], readfile_buffer.ptr(), dwBytesToRead, &io_context.overlapped,
+				(LPOVERLAPPED_COMPLETION_ROUTINE)&completion_routine)) {
+		reading = false;
+		read_completed = true;
+
+		DWORD dwError = GetLastError();
+
+		if (dwError == ERROR_BROKEN_PIPE || dwError == ERROR_PIPE_NOT_CONNECTED) {
+			broken_pipe = true;
+		} else {
+			ERR_PRINTS("ReadFileEx failed with error code: " + String::num_int64(dwError));
+		}
+	}
+}
+
+void ProcessWindows::ReadChannel::async_callback(DWORD dwErrorCode, DWORD dwNumberOfBytesTransfered) {
+	reading = false;
+	read_completed = true;
+
+	switch (dwErrorCode) {
+		case ERROR_SUCCESS:
+		case ERROR_MORE_DATA:
+			break;
+		case ERROR_OPERATION_ABORTED: {
+			if (!closed) {
+				ERR_PRINTS(String() + "ReadFileEx operation aborted");
+				broken_pipe = true;
+			}
+		} break;
+		case ERROR_BROKEN_PIPE:
+		case ERROR_PIPE_NOT_CONNECTED: {
+			broken_pipe = true;
+		} break;
+		default: {
+			ERR_PRINTS(String() + "ReadFileEx completed with error code: " + String::num_int64(dwErrorCode));
+			broken_pipe = true;
+		} break;
+	}
+
+	int stored = ring_buffer.write(readfile_buffer.ptr(), dwNumberOfBytesTransfered);
+	ERR_FAIL_COND((DWORD)stored != dwNumberOfBytesTransfered);
+
+	if (closed || broken_pipe)
+		return;
+
+	read_async();
+}
+
+DWORD ProcessWindows::ReadChannel::peek() {
+	DWORD dwTotalBytesAvail = 0;
+
+	if (!PeekNamedPipe(pipe[PIPE_READ], NULL, 0, 0, &dwTotalBytesAvail, 0)) {
+		if (!broken_pipe)
+			broken_pipe = true;
+
+		return 0;
+	}
+
+	return dwTotalBytesAvail;
+}
+
+bool ProcessWindows::ReadChannel::open() {
+	ring_buffer.clear();
+
+	if (CreateOverlappedPipe(&pipe[PIPE_READ], &pipe[PIPE_WRITE], PIPE_TYPE_OUTPUT)) {
+		closed = false;
+		broken_pipe = false;
+		read_async();
+		return true;
+	}
+
+	return false;
+}
+
+void ProcessWindows::ReadChannel::close() {
+	if (!closed) {
+		closed = true;
+
+		if (reading) {
+			if (!CancelIoEx(pipe[PIPE_READ], &io_context.overlapped)) {
+				DWORD dwError = GetLastError();
+				if (dwError != ERROR_NOT_FOUND) {
+					ERR_PRINTS(String() + "CancelIoEx failed on handle " +
+							   String::num_int64((int64_t)pipe[PIPE_READ], 16) + " with error code: " +
+							   String::num_int64(dwError));
+				}
+			}
+
+			while (SleepEx(INFINITE, TRUE) == WAIT_IO_COMPLETION && reading) {
+			}
+		}
+	}
+
+	ChannelWindows::close(); // even if closed, may be a placeholder for pipes
+}
+
+ProcessWindows::ReadChannel::ReadChannel() {
+	broken_pipe = false;
+	reading = false;
+	read_completed = true;
+
+	int rbsize = GLOBAL_GET("os/process_max_read_buffer_po2");
+
+	ring_buffer.resize(rbsize);
+	readfile_buffer.resize(1 << rbsize);
+}
+
+Error ProcessWindows::WriteChannel::write_async() {
+	if (writing)
+		return ERR_BUSY;
+
+	bytes_to_write = MIN(writefile_buffer.size(), ring_buffer.data_left());
+	ring_buffer.read(writefile_buffer.ptr(), bytes_to_write, false);
+
+	writing = true;
+	closed = false;
+
+	zeromem(&(io_context.overlapped), sizeof(OVERLAPPED));
+
+	if (!WriteFileEx(pipe[PIPE_WRITE], writefile_buffer.ptr(), bytes_to_write, &io_context.overlapped,
+				(LPOVERLAPPED_COMPLETION_ROUTINE)&completion_routine)) {
+		writing = false;
+		bytes_to_write = 0;
+		writefile_buffer.clear();
+
+		ERR_PRINTS("WriteFileEx failed with error code: " + String::num_int64(GetLastError()));
+
+		return FAILED;
+	}
+
+	return OK;
+}
+
+void ProcessWindows::WriteChannel::async_callback(DWORD dwErrorCode, DWORD dwNumberOfBytesTransfered) {
+	DWORD expected_to_write = DWORD(bytes_to_write);
+	bytes_to_write = 0;
+	writing = false;
+
+	switch (dwErrorCode) {
+		case ERROR_SUCCESS: {
+			ring_buffer.advance_read(dwNumberOfBytesTransfered);
+			ERR_FAIL_COND(dwNumberOfBytesTransfered != expected_to_write);
+		} break;
+		case ERROR_OPERATION_ABORTED: {
+			if (!closed)
+				ERR_PRINT("WriteFileEx operation aborted");
+		} break;
+		default: {
+			ERR_PRINTS(String() + "WriteFileEx completed with error code: " + String::num_int64(dwErrorCode));
+		} break;
+	}
+
+	if (closed)
+		return;
+
+	if (ring_buffer.data_left() > 0)
+		write_async();
+}
+
+bool ProcessWindows::WriteChannel::open() {
+	ring_buffer.clear();
+
+	if (CreateOverlappedPipe(&pipe[PIPE_READ], &pipe[PIPE_WRITE], PIPE_TYPE_INPUT)) {
+		closed = false;
+		return true;
+	}
+
+	return false;
+}
+
+void ProcessWindows::WriteChannel::close() {
+	if (!closed) {
+		closed = true;
+
+		if (writing) {
+			if (!CancelIoEx(pipe[PIPE_WRITE], &io_context.overlapped)) {
+				DWORD dwError = GetLastError();
+				if (dwError != ERROR_NOT_FOUND) {
+					ERR_PRINTS(String() + "CancelIoEx failed on handle " + String::num_int64((int64_t)pipe[PIPE_WRITE], 16) +
+							   " with error code: " + String::num_int64(dwError));
+				}
+			}
+
+			while (SleepEx(INFINITE, TRUE) == WAIT_IO_COMPLETION && writing) {
+			}
+		}
+	}
+
+	ChannelWindows::close(); // even if closed, may be a placeholder for pipes
+}
+
+ProcessWindows::WriteChannel::WriteChannel() {
+	writing = false;
+
+	int wbsize = GLOBAL_GET("os/process_max_write_buffer_po2");
+
+	ring_buffer.resize(wbsize);
+	writefile_buffer.resize(1 << wbsize);
+}
+
+void ProcessWindows::ChannelWindows::close() {
+	CLOSE_HANDLE(pipe[PIPE_READ]);
+	CLOSE_HANDLE(pipe[PIPE_WRITE]);
+}
+
+void ProcessWindows::ChannelWindows::completion_routine(DWORD dwErrorCode, DWORD dwNumberOfBytesTransfered, OVERLAPPED *lpOverlapped) {
+	IOContext *c = ((IOContext *)lpOverlapped);
+	c->channel->async_callback(dwErrorCode, dwNumberOfBytesTransfered);
+}
+
+ProcessWindows::ChannelWindows::ChannelWindows() {
+	pipe[PIPE_READ] = INVALID_HANDLE_VALUE;
+	pipe[PIPE_WRITE] = INVALID_HANDLE_VALUE;
+
+	io_context.channel = this;
+
+	zeromem(&(io_context.overlapped), sizeof(OVERLAPPED));
+}
+
+ProcessWindows::ChannelWindows::~ChannelWindows() {
+	io_context.channel = NULL;
+}

--- a/platform/windows/process_windows.h
+++ b/platform/windows/process_windows.h
@@ -1,0 +1,131 @@
+/*************************************************************************/
+/*  process_windows.h                                                    */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#ifndef PROCESS_WINDOWS_H
+#define PROCESS_WINDOWS_H
+
+#include "os/process.h"
+#include "ring_buffer.h"
+
+#include <windows.h>
+
+class ProcessWindows : public Process {
+	struct ChannelWindows : public Channel {
+		struct IOContext // https://blogs.msdn.microsoft.com/oldnewthing/20101217-00/?p=11983
+		{
+			OVERLAPPED overlapped;
+			ChannelWindows *channel;
+		};
+
+		HANDLE pipe[2];
+		IOContext io_context;
+
+		void close();
+
+		static void CALLBACK completion_routine(DWORD dwErrorCode, DWORD dwNumberOfBytesTransfered, OVERLAPPED *lpOverlapped);
+
+		virtual void async_callback(DWORD dwErrorCode, DWORD dwNumberOfBytesTransfered) = 0;
+
+		ChannelWindows();
+		~ChannelWindows();
+	};
+
+	struct ReadChannel : public ChannelWindows {
+		RingBuffer<char> ring_buffer;
+		Vector<char> readfile_buffer;
+		bool reading;
+		bool broken_pipe;
+		bool read_completed;
+
+		void read_async();
+		void async_callback(DWORD dwErrorCode, DWORD dwNumberOfBytesTransfered);
+
+		DWORD peek();
+
+		bool open();
+		void close();
+
+		ReadChannel();
+	};
+
+	struct WriteChannel : public ChannelWindows {
+		RingBuffer<char> ring_buffer;
+		Vector<char> writefile_buffer;
+		uint64_t bytes_to_write;
+		bool writing;
+
+		Error write_async();
+		void async_callback(DWORD dwErrorCode, DWORD dwNumberOfBytesTransfered);
+
+		bool open();
+		void close();
+
+		WriteChannel();
+	};
+
+	static Process *_create();
+
+	LPPROCESS_INFORMATION lpProcessInfo;
+
+	_FORCE_INLINE_ WriteChannel *_stdin_wchan() const { return static_cast<WriteChannel *>(stdin_sama); }
+	_FORCE_INLINE_ ReadChannel *_stdout_rchan() const { return static_cast<ReadChannel *>(stdout_chan); }
+	_FORCE_INLINE_ ReadChannel *_stderr_rchan() const { return static_cast<ReadChannel *>(stderr_chan); }
+
+	bool _setup_channels();
+
+protected:
+	bool _start();
+	void _get_system_env(HashMap<String, String> &r_env);
+
+public:
+	static void make_default();
+
+	int64_t get_pid() const;
+
+	bool wait_for_started(int msecs = 20000);
+	bool wait_for_finished(int msecs = 20000);
+
+	void terminate();
+	void kill();
+
+	Error poll();
+
+	int get_available_bytes() const;
+	int next_line_size() const;
+	int read_all(char *p_data, int p_max_size);
+	int read_line(char *p_data, int p_max_size);
+
+	bool can_write(int p_size) const;
+	int write(const char *p_data, int p_max_size);
+
+	ProcessWindows();
+	~ProcessWindows();
+};
+
+#endif // PROCESS_WINDOWS_H

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -50,6 +50,26 @@ Files extracted from upstream source:
 - `docs/{FTL.TXT,LICENSE.TXT}`
 
 
+## forkfd
+
+- Upstream: https://code.qt.io/qt/qtbase.git
+- Version: 4fc79714 (git)
+- License: MIT
+
+Files extracted from upstream source:
+
+- all the files in the src/3rdparty/forkfd/ folder
+
+Important: The following files have Godot-made changes:
+
+- `forkfd_gcc.h`: Fixed build errors with older versions of gcc.
+- `forkfd.c` and `forkfd.h`:
+ - Use `ioctl` instead of `fcntl` when `NO_FCNTL` is defined.
+ - Added `forkfd_nofd()` function (check the description for more info).
+
+The diff can be found at `forkfd_godot.patch`.
+
+
 ## glad
 
 - Upstream: https://github.com/Dav1dde/glad

--- a/thirdparty/forkfd/forkfd.c
+++ b/thirdparty/forkfd/forkfd.c
@@ -1,0 +1,923 @@
+/****************************************************************************
+**
+** Copyright (C) 2015 Intel Corporation
+** Copyright (C) 2015 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+**
+** Permission is hereby granted, free of charge, to any person obtaining a copy
+** of this software and associated documentation files (the "Software"), to deal
+** in the Software without restriction, including without limitation the rights
+** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+** copies of the Software, and to permit persons to whom the Software is
+** furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+** THE SOFTWARE.
+**
+****************************************************************************/
+
+#ifndef _GNU_SOURCE
+#  define _GNU_SOURCE
+#endif
+
+#include "forkfd.h"
+
+#include <sys/types.h>
+#if defined(__OpenBSD__) || defined(__NetBSD__)
+#  include <sys/param.h>
+#endif
+#include <sys/time.h>
+#include <sys/resource.h>
+#include <sys/wait.h>
+#include <assert.h>
+#include <errno.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#ifdef __linux__
+#  define HAVE_WAIT4    1
+#  if defined(__BIONIC__) || (defined(__GLIBC__) && (__GLIBC__ << 8) + __GLIBC_MINOR__ >= 0x207 && \
+       (!defined(__UCLIBC__) || ((__UCLIBC_MAJOR__ << 16) + (__UCLIBC_MINOR__ << 8) + __UCLIBC_SUBLEVEL__ > 0x90201)))
+#    include <sys/eventfd.h>
+#    define HAVE_EVENTFD  1
+#  endif
+#  if defined(__BIONIC__) || (defined(__GLIBC__) && (__GLIBC__ << 8) + __GLIBC_MINOR__ >= 0x209 && \
+       (!defined(__UCLIBC__) || ((__UCLIBC_MAJOR__ << 16) + (__UCLIBC_MINOR__ << 8) + __UCLIBC_SUBLEVEL__ > 0x90201)))
+#    define HAVE_PIPE2    1
+#  endif
+#endif
+#if defined(__FreeBSD__) && __FreeBSD__ >= 9
+#  include <sys/procdesc.h>
+#endif
+
+#if _POSIX_VERSION-0 >= 200809L || _XOPEN_VERSION-0 >= 500
+#  define HAVE_WAITID   1
+#endif
+#if !defined(WEXITED) || !defined(WNOWAIT)
+#  undef HAVE_WAITID
+#endif
+
+#if (defined(__FreeBSD__) && defined(__FreeBSD_version) && __FreeBSD_version >= 1000032) || \
+    (defined(__OpenBSD__) && OpenBSD >= 201505) || \
+    (defined(__NetBSD__) && __NetBSD_Version__ >= 600000000)
+#  define HAVE_PIPE2    1
+#endif
+#if defined(__FreeBSD__) || defined(__DragonFly__) || defined(__FreeBSD_kernel__) || \
+    defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__)
+#  define HAVE_WAIT4    1
+#endif
+
+#if defined(__APPLE__)
+/* Up until OS X 10.7, waitid(P_ALL, ...) will return success, but will not
+ * fill in the details of the dead child. That means waitid is not useful to us.
+ * Therefore, we only enable waitid() support if we're targetting OS X 10.8 or
+ * later.
+ */
+#  include <Availability.h>
+#  include <AvailabilityMacros.h>
+#  if MAC_OS_X_VERSION_MIN_REQUIRED <= 1070
+#    define HAVE_BROKEN_WAITID 1
+#  endif
+#endif
+
+#ifndef FFD_ATOMIC_RELAXED
+#  include "forkfd_gcc.h"
+#endif
+
+#define CHILDREN_IN_SMALL_ARRAY     16
+#define CHILDREN_IN_BIG_ARRAY       256
+#define sizeofarray(array)          (sizeof(array)/sizeof(array[0]))
+#define EINTR_LOOP(ret, call) \
+    do {                      \
+        ret = call;           \
+    } while (ret == -1 && errno == EINTR)
+
+#ifndef NO_FCNTL
+#define SET_CLOEXEC(m_fd) fcntl(m_fd, F_SETFD, FD_CLOEXEC)
+#define SET_NOCLOEXEC(m_fd) fcntl(m_fd, F_SETFD, 0)
+#define SET_NONBLOCK(m_fd) {                                     \
+        fcntl(m_fd, F_SETFL, fcntl(m_fd, F_GETFL) | O_NONBLOCK); \
+    }
+#else
+#define SET_CLOEXEC(m_fd) ioctl(m_fd, FIOCLEX)
+#define SET_NOCLOEXEC(m_fd) ioctl(m_fd, FIONCLEX)
+#define SET_NONBLOCK(m_fd) {         \
+        int flag = 1;                \
+        ioctl(m_fd, FIONBIO, &flag); \
+    }
+#endif
+
+struct pipe_payload
+{
+    struct forkfd_info info;
+    struct rusage rusage;
+};
+
+typedef struct process_info
+{
+    ffd_atomic_int pid;
+    int deathPipe;
+} ProcessInfo;
+
+struct BigArray;
+typedef struct Header
+{
+    ffd_atomic_pointer(struct BigArray) nextArray;
+    ffd_atomic_int busyCount;
+} Header;
+
+typedef struct BigArray
+{
+    Header header;
+    ProcessInfo entries[CHILDREN_IN_BIG_ARRAY];
+} BigArray;
+
+typedef struct SmallArray
+{
+    Header header;
+    ProcessInfo entries[CHILDREN_IN_SMALL_ARRAY];
+} SmallArray;
+static SmallArray children;
+
+static struct sigaction old_sigaction;
+static pthread_once_t forkfd_initialization = PTHREAD_ONCE_INIT;
+static ffd_atomic_int forkfd_status = FFD_ATOMIC_INIT(0);
+
+#ifdef HAVE_BROKEN_WAITID
+static int waitid_works = 0;
+#else
+static const int waitid_works = 1;
+#endif
+
+static ProcessInfo *tryAllocateInSection(Header *header, ProcessInfo entries[], int maxCount)
+{
+    /* we use ACQUIRE here because the signal handler might have released the PID */
+    int busyCount = ffd_atomic_add_fetch(&header->busyCount, 1, FFD_ATOMIC_ACQUIRE);
+    if (busyCount <= maxCount) {
+        /* there's an available entry in this section, find it and take it */
+        int i;
+        for (i = 0; i < maxCount; ++i) {
+            /* if the PID is 0, it's free; mark it as used by swapping it with -1 */
+            int expected_pid = 0;
+            if (ffd_atomic_compare_exchange(&entries[i].pid, &expected_pid,
+                                            -1, FFD_ATOMIC_RELAXED, FFD_ATOMIC_RELAXED))
+                return &entries[i];
+        }
+    }
+
+    /* there isn't an available entry, undo our increment */
+    ffd_atomic_add_fetch(&header->busyCount, -1, FFD_ATOMIC_RELAXED);
+    return NULL;
+}
+
+static ProcessInfo *allocateInfo(Header **header)
+{
+    Header *currentHeader = &children.header;
+
+    /* try to find an available entry in the small array first */
+    ProcessInfo *info =
+            tryAllocateInSection(currentHeader, children.entries, sizeofarray(children.entries));
+
+    /* go on to the next arrays */
+    while (info == NULL) {
+        BigArray *array = ffd_atomic_load(&currentHeader->nextArray, FFD_ATOMIC_ACQUIRE);
+        if (array == NULL) {
+            /* allocate an array and try to use it */
+            BigArray *allocatedArray = (BigArray *)calloc(1, sizeof(BigArray));
+            if (allocatedArray == NULL)
+                return NULL;
+
+            if (ffd_atomic_compare_exchange(&currentHeader->nextArray, &array, allocatedArray,
+                                             FFD_ATOMIC_RELEASE, FFD_ATOMIC_ACQUIRE)) {
+                /* success */
+                array = allocatedArray;
+            } else {
+                /* failed, the atomic updated 'array' */
+                free(allocatedArray);
+            }
+        }
+
+        currentHeader = &array->header;
+        info = tryAllocateInSection(currentHeader, array->entries, sizeofarray(array->entries));
+    }
+
+    *header = currentHeader;
+    return info;
+}
+
+#ifdef HAVE_WAITID
+static int isChildReady(pid_t pid, siginfo_t *info)
+{
+    info->si_pid = 0;
+    return waitid(P_PID, pid, info, WEXITED | WNOHANG | WNOWAIT) == 0 && info->si_pid == pid;
+}
+#endif
+
+static void convertStatusToForkfdInfo(int status, struct forkfd_info *info)
+{
+    if (WIFEXITED(status)) {
+        info->code = CLD_EXITED;
+        info->status = WEXITSTATUS(status);
+    } else if (WIFSIGNALED(status)) {
+        info->code = CLD_KILLED;
+#  ifdef WCOREDUMP
+        if (WCOREDUMP(status))
+            info->code = CLD_DUMPED;
+#  endif
+        info->status = WTERMSIG(status);
+    }
+}
+
+static int tryReaping(pid_t pid, struct pipe_payload *payload)
+{
+    /* reap the child */
+#if defined(HAVE_WAIT4)
+    int status;
+    if (wait4(pid, &status, WNOHANG, &payload->rusage) <= 0)
+        return 0;
+    convertStatusToForkfdInfo(status, &payload->info);
+#else
+#  if defined(HAVE_WAITID)
+    if (waitid_works) {
+        /* we have waitid(2), which gets us some payload values on some systems */
+        siginfo_t info;
+        info.si_pid = 0;
+        int ret = waitid(P_PID, pid, &info, WEXITED | WNOHANG) == 0 && info.si_pid == pid;
+        if (!ret)
+            return ret;
+
+        payload->info.code = info.si_code;
+        payload->info.status = info.si_status;
+#    ifdef __linux__
+        payload->rusage.ru_utime.tv_sec = info.si_utime / CLOCKS_PER_SEC;
+        payload->rusage.ru_utime.tv_usec = info.si_utime % CLOCKS_PER_SEC;
+        payload->rusage.ru_stime.tv_sec = info.si_stime / CLOCKS_PER_SEC;
+        payload->rusage.ru_stime.tv_usec = info.si_stime % CLOCKS_PER_SEC;
+#    endif
+        return 1;
+    }
+#  endif // HAVE_WAITID
+    int status;
+    if (waitpid(pid, &status, WNOHANG) <= 0)
+        return 0;     // child did not change state
+    convertStatusToForkfdInfo(status, &payload->info);
+#endif // !HAVE_WAIT4
+
+    return 1;
+}
+
+static void freeInfo(Header *header, ProcessInfo *entry)
+{
+    entry->deathPipe = -1;
+    entry->pid = 0;
+
+    ffd_atomic_add_fetch(&header->busyCount, -1, FFD_ATOMIC_RELEASE);
+    assert(header->busyCount >= 0);
+}
+
+static void notifyAndFreeInfo(Header *header, ProcessInfo *entry,
+                              const struct pipe_payload *payload)
+{
+    ssize_t ret;
+    if (entry->deathPipe != FFD_UNINITIALIZED_FD) {
+        EINTR_LOOP(ret, write(entry->deathPipe, payload, sizeof(*payload)));
+        EINTR_LOOP(ret, close(entry->deathPipe));
+    }
+
+    freeInfo(header, entry);
+}
+
+static void sigchld_handler(int signum)
+{
+    /*
+     * This is a signal handler, so we need to be careful about which functions
+     * we can call. See the full, official listing in the POSIX.1-2008
+     * specification at:
+     *   http://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html#tag_15_04_03
+     *
+     */
+
+    if (ffd_atomic_load(&forkfd_status, FFD_ATOMIC_RELAXED) == 1) {
+        /* is this one of our children? */
+        BigArray *array;
+        siginfo_t info;
+        struct pipe_payload payload;
+        int i;
+
+        memset(&info, 0, sizeof info);
+        memset(&payload, 0, sizeof payload);
+
+#ifdef HAVE_WAITID
+        if (!waitid_works)
+            goto search_arrays;
+
+        /* be optimistic: try to see if we can get the child that exited */
+search_next_child:
+        /* waitid returns -1 ECHILD if there are no further children at all;
+         * it returns 0 and sets si_pid to 0 if there are children but they are not ready
+         * to be waited (we're passing WNOHANG). We should not get EINTR because
+         * we're passing WNOHANG and we should definitely not get EINVAL or anything else.
+         * That means we can actually ignore the return code and only inspect si_pid.
+         */
+        info.si_pid = 0;
+        waitid(P_ALL, 0, &info, WNOHANG | WNOWAIT | WEXITED);
+        if (info.si_pid == 0) {
+            /* there are no further un-waited-for children, so we can just exit.
+             * But before, transfer control to the chained SIGCHLD handler.
+             */
+            goto chain_handler;
+        }
+
+        for (i = 0; i < (int)sizeofarray(children.entries); ++i) {
+            /* acquire the child first: swap the PID with -1 to indicate it's busy */
+            int pid = info.si_pid;
+            if (ffd_atomic_compare_exchange(&children.entries[i].pid, &pid, -1,
+                                            FFD_ATOMIC_ACQUIRE, FFD_ATOMIC_RELAXED)) {
+                /* this is our child, send notification and free up this entry */
+                /* ### FIXME: what if tryReaping returns false? */
+                if (tryReaping(pid, &payload))
+                    notifyAndFreeInfo(&children.header, &children.entries[i], &payload);
+                goto search_next_child;
+            }
+        }
+
+        /* try the arrays */
+        array = ffd_atomic_load(&children.header.nextArray, FFD_ATOMIC_ACQUIRE);
+        while (array != NULL) {
+            for (i = 0; i < (int)sizeofarray(array->entries); ++i) {
+                int pid = info.si_pid;
+                if (ffd_atomic_compare_exchange(&array->entries[i].pid, &pid, -1,
+                                                FFD_ATOMIC_ACQUIRE, FFD_ATOMIC_RELAXED)) {
+                    /* this is our child, send notification and free up this entry */
+                    /* ### FIXME: what if tryReaping returns false? */
+                    if (tryReaping(pid, &payload))
+                        notifyAndFreeInfo(&array->header, &array->entries[i], &payload);
+                    goto search_next_child;
+                }
+            }
+
+            array = ffd_atomic_load(&array->header.nextArray, FFD_ATOMIC_ACQUIRE);
+        }
+
+        /* if we got here, we couldn't find this child in our list. That means this child
+         * belongs to one of the chained SIGCHLD handlers. However, there might be another
+         * child that exited and does belong to us, so we need to check each one individually.
+         */
+
+search_arrays:
+#endif
+
+        for (i = 0; i < (int)sizeofarray(children.entries); ++i) {
+            int pid = ffd_atomic_load(&children.entries[i].pid, FFD_ATOMIC_ACQUIRE);
+            if (pid <= 0)
+                continue;
+#ifdef HAVE_WAITID
+            if (waitid_works) {
+                /* The child might have been reaped by the block above in another thread,
+                 * so first check if it's ready and, if it is, lock it */
+                if (!isChildReady(pid, &info) ||
+                        !ffd_atomic_compare_exchange(&children.entries[i].pid, &pid, -1,
+                                                     FFD_ATOMIC_RELAXED, FFD_ATOMIC_RELAXED))
+                    continue;
+            }
+#endif
+            if (tryReaping(pid, &payload)) {
+                /* this is our child, send notification and free up this entry */
+                notifyAndFreeInfo(&children.header, &children.entries[i], &payload);
+            }
+        }
+
+        /* try the arrays */
+        array = ffd_atomic_load(&children.header.nextArray, FFD_ATOMIC_ACQUIRE);
+        while (array != NULL) {
+            for (i = 0; i < (int)sizeofarray(array->entries); ++i) {
+                int pid = ffd_atomic_load(&array->entries[i].pid, FFD_ATOMIC_ACQUIRE);
+                if (pid <= 0)
+                    continue;
+#ifdef HAVE_WAITID
+                if (waitid_works) {
+                    /* The child might have been reaped by the block above in another thread,
+                     * so first check if it's ready and, if it is, lock it */
+                    if (!isChildReady(pid, &info) ||
+                            !ffd_atomic_compare_exchange(&array->entries[i].pid, &pid, -1,
+                                                         FFD_ATOMIC_RELAXED, FFD_ATOMIC_RELAXED))
+                        continue;
+                }
+#endif
+                if (tryReaping(pid, &payload)) {
+                    /* this is our child, send notification and free up this entry */
+                    notifyAndFreeInfo(&array->header, &array->entries[i], &payload);
+                }
+            }
+
+            array = ffd_atomic_load(&array->header.nextArray, FFD_ATOMIC_ACQUIRE);
+        }
+    }
+
+#ifdef HAVE_WAITID
+chain_handler:
+#endif
+    if (old_sigaction.sa_handler != SIG_IGN && old_sigaction.sa_handler != SIG_DFL)
+        old_sigaction.sa_handler(signum);
+}
+
+static void ignore_sigpipe()
+{
+#ifdef O_NOSIGPIPE
+    static ffd_atomic_int done = FFD_ATOMIC_INIT(0);
+    if (ffd_atomic_load(&done, FFD_ATOMIC_RELAXED))
+        return;
+#endif
+
+    struct sigaction action;
+    memset(&action, 0, sizeof action);
+    sigemptyset(&action.sa_mask);
+    action.sa_handler = SIG_IGN;
+    action.sa_flags = 0;
+    sigaction(SIGPIPE, &action, NULL);
+
+#ifdef O_NOSIGPIPE
+    ffd_atomic_store(&done, 1, FFD_ATOMIC_RELAXED);
+#endif
+}
+
+static void forkfd_initialize()
+{
+#if defined(HAVE_BROKEN_WAITID)
+    pid_t pid = fork();
+    if (pid == 0) {
+        _exit(0);
+    } else if (pid > 0) {
+        siginfo_t info;
+        waitid(P_ALL, 0, &info, WNOWAIT | WEXITED);
+        waitid_works = (info.si_pid != 0);
+        info.si_pid = 0;
+
+        // now really reap the child
+        waitid(P_PID, pid, &info, WEXITED);
+        waitid_works = waitid_works && (info.si_pid != 0);
+    }
+#endif
+
+    /* install our signal handler */
+    struct sigaction action;
+    memset(&action, 0, sizeof action);
+    sigemptyset(&action.sa_mask);
+    action.sa_flags = SA_NOCLDSTOP | SA_RESTART;
+    action.sa_handler = sigchld_handler;
+
+    /* ### RACE CONDITION
+     * The sigaction function does a memcpy from an internal buffer
+     * to old_sigaction, which we use in the SIGCHLD handler. If a
+     * SIGCHLD is delivered before or during that memcpy, the handler will
+     * see an inconsistent state.
+     *
+     * There is no solution. pthread_sigmask doesn't work here because the
+     * signal could be delivered to another thread.
+     */
+    sigaction(SIGCHLD, &action, &old_sigaction);
+
+#ifndef O_NOSIGPIPE
+    /* disable SIGPIPE too */
+    ignore_sigpipe();
+#endif
+
+#ifndef __GNUC__
+    atexit(cleanup);
+#endif
+
+    ffd_atomic_store(&forkfd_status, 1, FFD_ATOMIC_RELAXED);
+}
+
+#ifdef __GNUC__
+__attribute((destructor, unused)) static void cleanup();
+#endif
+
+static void cleanup()
+{
+    BigArray *array;
+    /* This function is not thread-safe!
+     * It must only be called when the process is shutting down.
+     * At shutdown, we expect no one to be calling forkfd(), so we don't
+     * need to be thread-safe with what is done there.
+     *
+     * But SIGCHLD might be delivered to any thread, including this one.
+     * There's no way to prevent that. The correct solution would be to
+     * cooperatively delete. We don't do that.
+     */
+    if (ffd_atomic_load(&forkfd_status, FFD_ATOMIC_RELAXED) == 0)
+        return;
+
+    /* notify the handler that we're no longer in operation */
+    ffd_atomic_store(&forkfd_status, 0, FFD_ATOMIC_RELAXED);
+
+    /* free any arrays we might have */
+    array = children.header.nextArray;
+    while (array != NULL) {
+        BigArray *next = array->header.nextArray;
+        free(array);
+        array = next;
+    }
+}
+
+static int create_pipe(int filedes[], int flags)
+{
+    int ret = -1;
+#ifdef HAVE_PIPE2
+    /* use pipe2(2) whenever possible, since it can thread-safely create a
+     * cloexec pair of pipes. Without it, we have a race condition setting
+     * FD_CLOEXEC
+     */
+
+#  ifdef O_NOSIGPIPE
+    /* try first with O_NOSIGPIPE */
+    ret = pipe2(filedes, O_CLOEXEC | O_NOSIGPIPE);
+    if (ret == -1) {
+        /* O_NOSIGPIPE not supported, ignore SIGPIPE */
+        ignore_sigpipe();
+    }
+#  endif
+    if (ret == -1)
+        ret = pipe2(filedes, O_CLOEXEC);
+    if (ret == -1)
+        return ret;
+
+    if ((flags & FFD_CLOEXEC) == 0)
+        SET_NOCLOEXEC(filedes[0]);
+#else
+    ret = pipe(filedes);
+    if (ret == -1)
+        return ret;
+
+    SET_CLOEXEC(filedes[1]);
+    if (flags & FFD_CLOEXEC)
+        SET_CLOEXEC(filedes[0]);
+#endif
+    if (flags & FFD_NONBLOCK)
+        SET_NONBLOCK(filedes[0]);
+    return ret;
+}
+
+#if defined(FORKFD_NO_SPAWNFD) && defined(__FreeBSD__) && __FreeBSD__ >= 9
+#  if __FreeBSD__ == 9
+/* PROCDESC is an optional feature in the kernel and wasn't enabled
+ * by default on FreeBSD 9. So we need to check for it at runtime. */
+static ffd_atomic_int system_has_forkfd = FFD_ATOMIC_INIT(1);
+#  else
+/* On FreeBSD 10, PROCDESC was enabled by default. On v11, it's not an option
+ * anymore and can't be disabled. */
+static const int system_has_forkfd = 1;
+#  endif
+
+static int system_forkfd(int flags, pid_t *ppid)
+{
+    int ret;
+    pid_t pid;
+    pid = pdfork(&ret, PD_DAEMON);
+    if (__builtin_expect(pid == -1, 0)) {
+#  if __FreeBSD__ == 9
+        if (errno == ENOSYS) {
+            /* PROCDESC wasn't compiled into the kernel: don't try it again. */
+            ffd_atomic_store(&system_has_forkfd, 0, FFD_ATOMIC_RELAXED);
+        }
+#  endif
+        return -1;
+    }
+    if (pid == 0) {
+        /* child process */
+        return FFD_CHILD_PROCESS;
+    }
+
+    /* parent process */
+    if (flags & FFD_CLOEXEC)
+        SET_CLOEXEC(ret);
+    if (flags & FFD_NONBLOCK)
+        SET_NONBLOCK(ret);
+    if (ppid)
+        *ppid = pid;
+    return ret;
+}
+#else
+static const int system_has_forkfd = 0;
+static int system_forkfd(int flags, pid_t *ppid)
+{
+    (void)flags;
+    (void)ppid;
+    return -1;
+}
+#endif
+
+#ifndef FORKFD_NO_FORKFD
+
+static int _forkfd(int flags, pid_t *ppid, int create_fd);
+
+/**
+ * @brief forkfd returns a file descriptor representing a child process
+ * @return a file descriptor, or -1 in case of failure
+ *
+ * forkfd() creates a file descriptor that can be used to be notified of when a
+ * child process exits. This file descriptor can be monitored using select(2),
+ * poll(2) or similar mechanisms.
+ *
+ * The @a flags parameter can contain the following values ORed to change the
+ * behaviour of forkfd():
+ *
+ * @li @c FFD_NONBLOCK Set the O_NONBLOCK file status flag on the new open file
+ * descriptor. Using this flag saves extra calls to fnctl(2) to achieve the same
+ * result.
+ *
+ * @li @c FFD_CLOEXEC Set the close-on-exec (FD_CLOEXEC) flag on the new file
+ * descriptor. You probably want to set this flag, since forkfd() does not work
+ * if the original parent process dies.
+ *
+ * The file descriptor returned by forkfd() supports the following operations:
+ *
+ * @li read(2) When the child process exits, then the buffer supplied to
+ * read(2) is used to return information about the status of the child in the
+ * form of one @c siginfo_t structure. The buffer must be at least
+ * sizeof(siginfo_t) bytes. The return value of read(2) is the total number of
+ * bytes read.
+ *
+ * @li poll(2), select(2) (and similar) The file descriptor is readable (the
+ * select(2) readfds argument; the poll(2) POLLIN flag) if the child has exited
+ * or signalled via SIGCHLD.
+ *
+ * @li close(2) When the file descriptor is no longer required it should be closed.
+ */
+int forkfd(int flags, pid_t *ppid)
+{
+    return _forkfd(flags, ppid, 1);
+}
+
+/**
+* @brief unlike forkfd, forkfd_nofd does not return any file descriptor representing the child process
+* @return a FFD_UNINITIALIZED_FD, or -1 in case of failure
+* 
+* forkfd_nofd() does not create any file descriptor to notify when a child
+* process exits. Use it if all you need is for the SIGCHLD handler to call waitpid.
+* 
+* @sa forkfd()
+* */
+int forkfd_nofd(int flags, pid_t *ppid)
+{
+    return _forkfd(flags, ppid, 0);
+}
+
+static int _forkfd(int flags, pid_t *ppid, int create_fd)
+{
+    Header *header;
+    ProcessInfo *info;
+    pid_t pid;
+    int fd = -1;
+    int death_pipe[2];
+    int sync_pipe[2];
+    int ret;
+#ifdef __linux__
+    int efd;
+#endif
+
+    if (system_has_forkfd) {
+        ret = system_forkfd(flags, ppid);
+        if (system_has_forkfd)
+            return ret;
+    }
+
+    (void) pthread_once(&forkfd_initialization, forkfd_initialize);
+
+    info = allocateInfo(&header);
+    if (info == NULL) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    /* create the pipes before we fork */
+    if (create_fd && create_pipe(death_pipe, flags) == -1)
+        goto err_free; /* failed to create the pipes, pass errno */
+
+#ifdef HAVE_EVENTFD
+    /* try using an eventfd, which consumes less resources */
+    efd = eventfd(0, EFD_CLOEXEC);
+    if (efd == -1)
+#endif
+    {
+        /* try a pipe */
+        if (create_pipe(sync_pipe, FFD_CLOEXEC) == -1) {
+            /* failed both at eventfd and pipe; fail and pass errno */
+            goto err_close;
+        }
+    }
+
+    /* now fork */
+    pid = fork();
+    if (pid == -1)
+        goto err_close2; /* failed to fork, pass errno */
+    if (ppid)
+        *ppid = pid;
+
+    /*
+     * We need to store the child's PID in the info structure, so
+     * the SIGCHLD handler knows that this child is present and it
+     * knows the writing end of the pipe to pass information on.
+     * However, the child process could exit before we stored the
+     * information (or the handler could run for other children exiting).
+     * We prevent that from happening by blocking the child process in
+     * a read(2) until we're finished storing the information.
+     */
+    if (pid == 0) {
+        /* this is the child process */
+        /* first, wait for the all clear */
+#ifdef HAVE_EVENTFD
+        if (efd != -1) {
+            eventfd_t val64;
+            EINTR_LOOP(ret, eventfd_read(efd, &val64));
+            EINTR_LOOP(ret, close(efd));
+        } else
+#endif
+        {
+            char c;
+            EINTR_LOOP(ret, close(sync_pipe[1]));
+            EINTR_LOOP(ret, read(sync_pipe[0], &c, sizeof c));
+            EINTR_LOOP(ret, close(sync_pipe[0]));
+        }
+
+        /* now close the pipes and return to the caller */
+        if (create_fd) {
+            EINTR_LOOP(ret, close(death_pipe[0]));
+            EINTR_LOOP(ret, close(death_pipe[1]));
+        }
+        fd = FFD_CHILD_PROCESS;
+    } else {
+        /* parent process */
+        if (create_fd) {
+            info->deathPipe = death_pipe[1];
+            fd = death_pipe[0];
+        } else {
+            info->deathPipe = FFD_UNINITIALIZED_FD;
+            fd = FFD_UNINITIALIZED_FD;
+        }
+        ffd_atomic_store(&info->pid, pid, FFD_ATOMIC_RELEASE);
+
+        /* release the child */
+#ifdef HAVE_EVENTFD
+        if (efd != -1) {
+            eventfd_t val64 = 42;
+            EINTR_LOOP(ret, eventfd_write(efd, val64));
+            EINTR_LOOP(ret, close(efd));
+        } else
+#endif
+        {
+            /*
+             * Usually, closing would be enough to make read(2) return and the child process
+             * continue. We need to write here: another thread could be calling forkfd at the
+             * same time, which means auxpipe[1] might be open in another child process.
+             */
+            EINTR_LOOP(ret, close(sync_pipe[0]));
+            EINTR_LOOP(ret, write(sync_pipe[1], "", 1));
+            EINTR_LOOP(ret, close(sync_pipe[1]));
+        }
+    }
+
+    return fd;
+
+err_close2:
+#ifdef HAVE_EVENTFD
+    if (efd != -1) {
+        EINTR_LOOP(ret, close(efd));
+    } else
+#endif
+    {
+        EINTR_LOOP(ret, close(sync_pipe[0]));
+        EINTR_LOOP(ret, close(sync_pipe[1]));
+    }
+err_close:
+    if (create_fd) {
+        EINTR_LOOP(ret, close(death_pipe[0]));
+        EINTR_LOOP(ret, close(death_pipe[1]));
+    }
+err_free:
+    /* free the info pointer */
+    freeInfo(header, info);
+    return -1;
+}
+#endif // FORKFD_NO_FORKFD
+
+#if _POSIX_SPAWN > 0 && !defined(FORKFD_NO_SPAWNFD)
+int spawnfd(int flags, pid_t *ppid, const char *path, const posix_spawn_file_actions_t *file_actions,
+            posix_spawnattr_t *attrp, char *const argv[], char *const envp[])
+{
+    Header *header;
+    ProcessInfo *info;
+    struct pipe_payload payload;
+    pid_t pid;
+    int death_pipe[2];
+    int ret = -1;
+    /* we can only do work if we have a way to start the child in stopped mode;
+     * otherwise, we have a major race condition. */
+
+    assert(!system_has_forkfd);
+
+    (void) pthread_once(&forkfd_initialization, forkfd_initialize);
+
+    info = allocateInfo(&header);
+    if (info == NULL) {
+        errno = ENOMEM;
+        goto out;
+    }
+
+    /* create the pipe before we spawn */
+    if (create_pipe(death_pipe, flags) == -1)
+        goto err_free; /* failed to create the pipes, pass errno */
+
+    /* start the process */
+    if (flags & FFD_SPAWN_SEARCH_PATH) {
+        /* use posix_spawnp */
+        if (posix_spawnp(&pid, path, file_actions, attrp, argv, envp) != 0)
+            goto err_close;
+    } else {
+        if (posix_spawn(&pid, path, file_actions, attrp, argv, envp) != 0)
+            goto err_close;
+    }
+
+    if (ppid)
+        *ppid = pid;
+
+    /* Store the child's PID in the info structure.
+     */
+    info->deathPipe = death_pipe[1];
+    ffd_atomic_store(&info->pid, pid, FFD_ATOMIC_RELEASE);
+
+    /* check if the child has already exited */
+    if (tryReaping(pid, &payload))
+        notifyAndFreeInfo(header, info, &payload);
+
+    ret = death_pipe[0];
+    return ret;
+
+err_close:
+    EINTR_LOOP(ret, close(death_pipe[0]));
+    EINTR_LOOP(ret, close(death_pipe[1]));
+
+err_free:
+    /* free the info pointer */
+    freeInfo(header, info);
+
+out:
+    return -1;
+}
+#endif // _POSIX_SPAWN && !FORKFD_NO_SPAWNFD
+
+
+int forkfd_wait(int ffd, forkfd_info *info, struct rusage *rusage)
+{
+    struct pipe_payload payload;
+    int ret;
+
+    if (system_has_forkfd) {
+#if defined(__FreeBSD__) && __FreeBSD__ >= 9
+        pid_t pid;
+        int status;
+        int options = WEXITED;
+
+        ret = pdgetpid(ffd, &pid);
+        if (ret == -1)
+            return ret;
+        ret = fcntl(ffd, F_GETFL);
+        if (ret == -1)
+            return ret;
+        options |= (ret & O_NONBLOCK) ? WNOHANG : 0;
+        ret = wait4(pid, &status, options, rusage);
+        if (ret != -1 && info)
+            convertStatusToForkfdInfo(status, info);
+        return ret == -1 ? -1 : 0;
+#endif
+    }
+
+    ret = read(ffd, &payload, sizeof(payload));
+    if (ret == -1)
+        return ret;     /* pass errno, probably EINTR, EBADF or EWOULDBLOCK */
+
+    assert(ret == sizeof(payload));
+    if (info)
+        *info = payload.info;
+    if (rusage)
+        *rusage = payload.rusage;
+
+    return 0;           /* success */
+}
+
+
+int forkfd_close(int ffd)
+{
+    return close(ffd);
+}

--- a/thirdparty/forkfd/forkfd.h
+++ b/thirdparty/forkfd/forkfd.h
@@ -1,0 +1,72 @@
+/****************************************************************************
+**
+** Copyright (C) 2015 Intel Corporation
+**
+** Permission is hereby granted, free of charge, to any person obtaining a copy
+** of this software and associated documentation files (the "Software"), to deal
+** in the Software without restriction, including without limitation the rights
+** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+** copies of the Software, and to permit persons to whom the Software is
+** furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+** THE SOFTWARE.
+**
+****************************************************************************/
+
+#ifndef FORKFD_H
+#define FORKFD_H
+
+#ifndef NO_FCNTL
+#include <fcntl.h>
+#else
+#include "sys/ioctl.h"
+#endif
+#include <stdint.h>
+#include <unistd.h> // to get the POSIX flags
+
+#if _POSIX_SPAWN > 0
+#  include <spawn.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define FFD_CLOEXEC  1
+#define FFD_NONBLOCK 2
+
+#define FFD_CHILD_PROCESS    (-2)
+#define FFD_UNINITIALIZED_FD (-3)
+
+struct forkfd_info {
+    int32_t code;
+    int32_t status;
+};
+
+int forkfd(int flags, pid_t *ppid);
+int forkfd_nofd(int flags, pid_t *ppid);
+int forkfd_wait(int ffd, forkfd_info *info, struct rusage *rusage);
+int forkfd_close(int ffd);
+
+#if _POSIX_SPAWN > 0
+/* only for spawnfd: */
+#  define FFD_SPAWN_SEARCH_PATH   O_RDWR
+
+int spawnfd(int flags, pid_t *ppid, const char *path, const posix_spawn_file_actions_t *file_actions,
+            posix_spawnattr_t *attrp, char *const argv[], char *const envp[]);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // FORKFD_H

--- a/thirdparty/forkfd/forkfd_gcc.h
+++ b/thirdparty/forkfd/forkfd_gcc.h
@@ -1,0 +1,69 @@
+/****************************************************************************
+**
+** Copyright (C) 2015 Intel Corporation
+**
+** Permission is hereby granted, free of charge, to any person obtaining a copy
+** of this software and associated documentation files (the "Software"), to deal
+** in the Software without restriction, including without limitation the rights
+** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+** copies of the Software, and to permit persons to whom the Software is
+** furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+** THE SOFTWARE.
+**
+****************************************************************************/
+
+#ifndef FFD_ATOMIC_GCC_H
+#define FFD_ATOMIC_GCC_H
+
+/* atomics */
+/* we'll use the GCC 4.7 atomic builtins
+ * See http://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html#_005f_005fatomic-Builtins
+ * Or in texinfo: C Extensions > __atomic Builtins
+ */
+typedef int ffd_atomic_int;
+#define ffd_atomic_pointer(type)    type*
+
+#define FFD_ATOMIC_INIT(val)    (val)
+// acq_rel & cst not necessary
+
+#if !defined(__GNUC__) || \
+    ((__GNUC__ - 0) * 100 + (__GNUC_MINOR__ - 0)) < 407 || \
+    (defined(__INTEL_COMPILER) && __INTEL_COMPILER-0 < 1310) || \
+    (defined(__clang__) && ((__clang_major__-0) * 100 + (__clang_minor-0)) < 303)
+
+#define FFD_ATOMIC_RELAXED  ((void)0)
+#define FFD_ATOMIC_ACQUIRE  ((void)0)
+#define FFD_ATOMIC_RELEASE  ((void)0)
+
+#define ffd_atomic_load(ptr,order) *(ptr)
+#define ffd_atomic_store(ptr,val,order) (*(ptr) = (val), (void)0)
+#define ffd_atomic_exchange(ptr,val,order) __sync_lock_test_and_set(ptr, val)
+#define ffd_atomic_compare_exchange(ptr,expected,desired,order1,order2) \
+    __sync_bool_compare_and_swap(ptr, *(expected), desired) ? 1 : \
+    (*(expected) = *(ptr), 0)
+#define ffd_atomic_add_fetch(ptr,val,order) __sync_add_and_fetch(ptr, val)
+#else
+
+#define FFD_ATOMIC_RELAXED  __ATOMIC_RELAXED
+#define FFD_ATOMIC_ACQUIRE  __ATOMIC_ACQUIRE
+#define FFD_ATOMIC_RELEASE  __ATOMIC_RELEASE
+
+#define ffd_atomic_load(ptr,order) __atomic_load_n(ptr, order)
+#define ffd_atomic_store(ptr,val,order) __atomic_store_n(ptr, val, order)
+#define ffd_atomic_exchange(ptr,val,order) __atomic_exchange_n(ptr, val, order)
+#define ffd_atomic_compare_exchange(ptr,expected,desired,order1,order2) \
+    __atomic_compare_exchange_n(ptr, expected, desired, 1, order1, order2)
+#define ffd_atomic_add_fetch(ptr,val,order) __atomic_add_fetch(ptr, val, order)
+#endif
+
+#endif

--- a/thirdparty/forkfd/forkfd_godot.cpp
+++ b/thirdparty/forkfd/forkfd_godot.cpp
@@ -1,0 +1,35 @@
+/*************************************************************************/
+/*  forkfd_godot.cpp                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifdef UNIX_ENABLED
+extern "C" {
+#include "forkfd.c"
+}
+#endif

--- a/thirdparty/forkfd/forkfd_godot.patch
+++ b/thirdparty/forkfd/forkfd_godot.patch
@@ -1,0 +1,242 @@
+diff -u old/forkfd.c new/forkfd.c
+--- old/forkfd.c
++++ new/forkfd.c
+@@ -103,6 +103,21 @@
+         ret = call;           \
+     } while (ret == -1 && errno == EINTR)
+ 
++#ifndef NO_FCNTL
++#define SET_CLOEXEC(m_fd) fcntl(m_fd, F_SETFD, FD_CLOEXEC)
++#define SET_NOCLOEXEC(m_fd) fcntl(m_fd, F_SETFD, 0)
++#define SET_NONBLOCK(m_fd) {                                     \
++        fcntl(m_fd, F_SETFL, fcntl(m_fd, F_GETFL) | O_NONBLOCK); \
++    }
++#else
++#define SET_CLOEXEC(m_fd) ioctl(m_fd, FIOCLEX)
++#define SET_NOCLOEXEC(m_fd) ioctl(m_fd, FIONCLEX)
++#define SET_NONBLOCK(m_fd) {         \
++        int flag = 1;                \
++        ioctl(m_fd, FIONBIO, &flag); \
++    }
++#endif
++
+ struct pipe_payload
+ {
+     struct forkfd_info info;
+@@ -275,8 +290,10 @@
+                               const struct pipe_payload *payload)
+ {
+     ssize_t ret;
+-    EINTR_LOOP(ret, write(entry->deathPipe, payload, sizeof(*payload)));
+-    EINTR_LOOP(ret, close(entry->deathPipe));
++    if (entry->deathPipe != FFD_UNINITIALIZED_FD) {
++        EINTR_LOOP(ret, write(entry->deathPipe, payload, sizeof(*payload)));
++        EINTR_LOOP(ret, close(entry->deathPipe));
++    }
+ 
+     freeInfo(header, entry);
+ }
+@@ -457,7 +474,7 @@
+     struct sigaction action;
+     memset(&action, 0, sizeof action);
+     sigemptyset(&action.sa_mask);
+-    action.sa_flags = SA_NOCLDSTOP;
++    action.sa_flags = SA_NOCLDSTOP | SA_RESTART;
+     action.sa_handler = sigchld_handler;
+ 
+     /* ### RACE CONDITION
+@@ -536,19 +553,19 @@
+     if (ret == -1)
+         return ret;
+ 
+-    if ((flags & FFD_CLOEXEC) == 0)
+-        fcntl(filedes[0], F_SETFD, 0);
++	if ((flags & FFD_CLOEXEC) == 0)
++        SET_NOCLOEXEC(filedes[0]);
+ #else
+     ret = pipe(filedes);
+     if (ret == -1)
+         return ret;
+ 
+-    fcntl(filedes[1], F_SETFD, FD_CLOEXEC);
++    SET_CLOEXEC(filedes[1]);
+     if (flags & FFD_CLOEXEC)
+-        fcntl(filedes[0], F_SETFD, FD_CLOEXEC);
++        SET_CLOEXEC(filedes[0]);
+ #endif
+     if (flags & FFD_NONBLOCK)
+-        fcntl(filedes[0], F_SETFL, fcntl(filedes[0], F_GETFL) | O_NONBLOCK);
++        SET_NONBLOCK(filedes[0]);
+     return ret;
+ }
+ 
+@@ -584,9 +601,9 @@
+ 
+     /* parent process */
+     if (flags & FFD_CLOEXEC)
+-        fcntl(ret, F_SETFD, FD_CLOEXEC);
++        SET_CLOEXEC(ret);
+     if (flags & FFD_NONBLOCK)
+-        fcntl(ret, F_SETFL, fcntl(ret, F_GETFL) | O_NONBLOCK);
++        SET_NONBLOCK(ret);
+     if (ppid)
+         *ppid = pid;
+     return ret;
+@@ -602,6 +619,9 @@
+ #endif
+ 
+ #ifndef FORKFD_NO_FORKFD
++
++static int _forkfd(int flags, pid_t *ppid, int create_fd);
++
+ /**
+  * @brief forkfd returns a file descriptor representing a child process
+  * @return a file descriptor, or -1 in case of failure
+@@ -637,6 +657,25 @@
+  */
+ int forkfd(int flags, pid_t *ppid)
+ {
++    return _forkfd(flags, ppid, 1);
++}
++
++/**
++* @brief unlike forkfd, forkfd_nofd does not return any file descriptor representing the child process
++* @return a FFD_UNINITIALIZED_FD, or -1 in case of failure
++* 
++* forkfd_nofd() does not create any file descriptor to notify when a child
++* process exits. Use it if all you need is for the SIGCHLD handler to call waitpid.
++* 
++* @sa forkfd()
++* */
++int forkfd_nofd(int flags, pid_t *ppid)
++{
++    return _forkfd(flags, ppid, 0);
++}
++
++static int _forkfd(int flags, pid_t *ppid, int create_fd)
++{
+     Header *header;
+     ProcessInfo *info;
+     pid_t pid;
+@@ -663,7 +702,7 @@
+     }
+ 
+     /* create the pipes before we fork */
+-    if (create_pipe(death_pipe, flags) == -1)
++    if (create_fd && create_pipe(death_pipe, flags) == -1)
+         goto err_free; /* failed to create the pipes, pass errno */
+ 
+ #ifdef HAVE_EVENTFD
+@@ -713,13 +752,20 @@
+         }
+ 
+         /* now close the pipes and return to the caller */
+-        EINTR_LOOP(ret, close(death_pipe[0]));
+-        EINTR_LOOP(ret, close(death_pipe[1]));
++        if (create_fd) {
++            EINTR_LOOP(ret, close(death_pipe[0]));
++            EINTR_LOOP(ret, close(death_pipe[1]));
++        }
+         fd = FFD_CHILD_PROCESS;
+     } else {
+         /* parent process */
+-        info->deathPipe = death_pipe[1];
+-        fd = death_pipe[0];
++        if (create_fd) {
++            info->deathPipe = death_pipe[1];
++            fd = death_pipe[0];
++        } else {
++            info->deathPipe = FFD_UNINITIALIZED_FD;
++            fd = FFD_UNINITIALIZED_FD;
++        }
+         ffd_atomic_store(&info->pid, pid, FFD_ATOMIC_RELEASE);
+ 
+         /* release the child */
+@@ -755,8 +801,10 @@
+         EINTR_LOOP(ret, close(sync_pipe[1]));
+     }
+ err_close:
+-    EINTR_LOOP(ret, close(death_pipe[0]));
+-    EINTR_LOOP(ret, close(death_pipe[1]));
++    if (create_fd) {
++        EINTR_LOOP(ret, close(death_pipe[0]));
++        EINTR_LOOP(ret, close(death_pipe[1]));
++    }
+ err_free:
+     /* free the info pointer */
+     freeInfo(header, info);
+diff -u old/forkfd_gcc.h new/forkfd_gcc.h
+--- old/forkfd_gcc.h
++++ new/forkfd_gcc.h
+@@ -34,24 +34,30 @@
+ #define ffd_atomic_pointer(type)    type*
+ 
+ #define FFD_ATOMIC_INIT(val)    (val)
+-
+-#define FFD_ATOMIC_RELAXED  __ATOMIC_RELAXED
+-#define FFD_ATOMIC_ACQUIRE  __ATOMIC_ACQUIRE
+-#define FFD_ATOMIC_RELEASE  __ATOMIC_RELEASE
+ // acq_rel & cst not necessary
+ 
+ #if !defined(__GNUC__) || \
+     ((__GNUC__ - 0) * 100 + (__GNUC_MINOR__ - 0)) < 407 || \
+     (defined(__INTEL_COMPILER) && __INTEL_COMPILER-0 < 1310) || \
+     (defined(__clang__) && ((__clang_major__-0) * 100 + (__clang_minor-0)) < 303)
+-#define ffd_atomic_load_n(ptr,order) *(ptr)
+-#define ffd_atomic_store_n(ptr,val,order) (*(ptr) = (val), (void)0)
+-#define ffd_atomic_exchange_n(ptr,val,order) __sync_lock_test_and_set(ptr, val)
+-#define ffd_atomic_compare_exchange_n(ptr,expected,desired,weak,order1,order2) \
++
++#define FFD_ATOMIC_RELAXED  ((void)0)
++#define FFD_ATOMIC_ACQUIRE  ((void)0)
++#define FFD_ATOMIC_RELEASE  ((void)0)
++
++#define ffd_atomic_load(ptr,order) *(ptr)
++#define ffd_atomic_store(ptr,val,order) (*(ptr) = (val), (void)0)
++#define ffd_atomic_exchange(ptr,val,order) __sync_lock_test_and_set(ptr, val)
++#define ffd_atomic_compare_exchange(ptr,expected,desired,order1,order2) \
+     __sync_bool_compare_and_swap(ptr, *(expected), desired) ? 1 : \
+     (*(expected) = *(ptr), 0)
+ #define ffd_atomic_add_fetch(ptr,val,order) __sync_add_and_fetch(ptr, val)
+ #else
++
++#define FFD_ATOMIC_RELAXED  __ATOMIC_RELAXED
++#define FFD_ATOMIC_ACQUIRE  __ATOMIC_ACQUIRE
++#define FFD_ATOMIC_RELEASE  __ATOMIC_RELEASE
++
+ #define ffd_atomic_load(ptr,order) __atomic_load_n(ptr, order)
+ #define ffd_atomic_store(ptr,val,order) __atomic_store_n(ptr, val, order)
+ #define ffd_atomic_exchange(ptr,val,order) __atomic_exchange_n(ptr, val, order)
+diff -u old/forkfd.h new/forkfd.h
+--- old/forkfd.h
++++ new/forkfd.h
+@@ -25,7 +25,11 @@
+ #ifndef FORKFD_H
+ #define FORKFD_H
+ 
++#ifndef NO_FCNTL
+ #include <fcntl.h>
++#else
++#include "sys/ioctl.h"
++#endif
+ #include <stdint.h>
+ #include <unistd.h> // to get the POSIX flags
+ 
+@@ -40,7 +44,8 @@
+ #define FFD_CLOEXEC  1
+ #define FFD_NONBLOCK 2
+ 
+-#define FFD_CHILD_PROCESS (-2)
++#define FFD_CHILD_PROCESS    (-2)
++#define FFD_UNINITIALIZED_FD (-3)
+ 
+ struct forkfd_info {
+     int32_t code;
+@@ -48,6 +53,7 @@
+ };
+ 
+ int forkfd(int flags, pid_t *ppid);
++int forkfd_nofd(int flags, pid_t *ppid);
+ int forkfd_wait(int ffd, forkfd_info *info, struct rusage *rusage);
+ int forkfd_close(int ffd);
+ 


### PR DESCRIPTION
### DO NOT MERGE GUARD

This class allows spawning child processes in a non-blocking way while, unlike `OS::execute()`, allowing to keep track of its lifetime and doing IO operations.

The interface is heavily inspired on QProcess and a bit on D's std.process (redirect flags and env).

Notes:
- This commit removes our old SIGCHLD handler (introduced by #7774), which would conflict with forkfd's one that is used by the Process class. OS_Unix::execute() now depends on forkfd, which is used instead of fork() if the condition `!p_blocking` is met.
- `OS_Unix::execute()` calls forkfd_nofd() instead of forkfd(). Unlike the latter, forkfd_nofd() does not create any file descriptor to track the child process. This allows forkfd to be used by `OS_Unix::execute()` without gdb notifying (unless a startup command is specified) of SIGPIPE signals, since `OS_Unix::execute()` would immediately close the returned file descriptor otherwise.

Tested on the following platforms:

- [x] x11 (Ubuntu 16.04 64bit)
- [ ] server
- [x] windows (Windows 7 64bit)
- [ ] osx
- [ ] iphone
- [ ] android
- [ ] haiku
- [ ] bb10
- [ ] uwp

I can't test on the unchecked platforms, I don't have access to them (well, android, but...).

Example: https://gist.github.com/neikeq/5b3ab0461733d1100561b0ba227a19e0

Docs will come later.
