### PR TITLE
Fix side effects of the bookkepping of Area/Area2D's monitoring (2.1)

### DIFF
--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -380,10 +380,6 @@ void Area2D::_notification(int p_what) {
 
 	switch (p_what) {
 
-		case NOTIFICATION_READY: {
-
-			is_ready = true;
-		} break;
 		case NOTIFICATION_EXIT_TREE: {
 
 			monitoring_stored = monitoring;
@@ -391,16 +387,25 @@ void Area2D::_notification(int p_what) {
 			_clear_monitoring();
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
-			if (is_ready)
-				set_enable_monitoring(monitoring_stored);
+
+			if (monitoring_stored) {
+				set_enable_monitoring(true);
+				monitoring_stored = false;
+			}
 		} break;
 	}
 }
 
 void Area2D::set_enable_monitoring(bool p_enable) {
 
+	if (!is_inside_tree()) {
+		monitoring_stored = p_enable;
+		return;
+	}
+
 	if (p_enable == monitoring)
 		return;
+
 	if (locked) {
 		ERR_EXPLAIN("Function blocked during in/out signal. Use call_deferred(\"set_enable_monitoring\",true/false)");
 	}
@@ -422,7 +427,7 @@ void Area2D::set_enable_monitoring(bool p_enable) {
 
 bool Area2D::is_monitoring_enabled() const {
 
-	return monitoring;
+	return monitoring || monitoring_stored;
 }
 
 void Area2D::set_monitorable(bool p_enable) {
@@ -651,7 +656,6 @@ Area2D::Area2D()
 	collision_mask = 1;
 	layer_mask = 1;
 	monitoring_stored = false;
-	is_ready = false;
 	set_enable_monitoring(true);
 	set_monitorable(true);
 }

--- a/scene/2d/area_2d.h
+++ b/scene/2d/area_2d.h
@@ -60,7 +60,6 @@ private:
 	bool monitoring_stored;
 	bool monitorable;
 	bool locked;
-	bool is_ready;
 
 	void _body_inout(int p_status, const RID &p_body, int p_instance, int p_body_shape, int p_area_shape);
 

--- a/scene/3d/area.cpp
+++ b/scene/3d/area.cpp
@@ -274,10 +274,6 @@ void Area::_notification(int p_what) {
 
 	switch (p_what) {
 
-		case NOTIFICATION_READY: {
-
-			is_ready = true;
-		} break;
 		case NOTIFICATION_EXIT_TREE: {
 
 			monitoring_stored = monitoring;
@@ -285,8 +281,11 @@ void Area::_notification(int p_what) {
 			_clear_monitoring();
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
-			if (is_ready)
-				set_enable_monitoring(monitoring_stored);
+
+			if (monitoring_stored) {
+				set_enable_monitoring(true);
+				monitoring_stored = false;
+			}
 		} break;
 	}
 }
@@ -297,6 +296,11 @@ void Area::set_enable_monitoring(bool p_enable) {
 		ERR_EXPLAIN("This function can't be used during the in/out signal.");
 	}
 	ERR_FAIL_COND(locked);
+
+	if (!is_inside_tree()) {
+		monitoring_stored = p_enable;
+		return;
+	}
 
 	if (p_enable == monitoring)
 		return;
@@ -418,7 +422,7 @@ void Area::_area_inout(int p_status, const RID &p_area, int p_instance, int p_ar
 
 bool Area::is_monitoring_enabled() const {
 
-	return monitoring;
+	return monitoring || monitoring_stored;
 }
 
 Array Area::get_overlapping_bodies() const {
@@ -644,7 +648,6 @@ Area::Area()
 	collision_mask = 1;
 	layer_mask = 1;
 	monitoring_stored = false;
-	is_ready = false;
 	set_ray_pickable(false);
 	set_enable_monitoring(true);
 	set_monitorable(true);

--- a/scene/3d/area.h
+++ b/scene/3d/area.h
@@ -60,7 +60,6 @@ private:
 	bool monitoring_stored;
 	bool monitorable;
 	bool locked;
-	bool is_ready;
 
 	void _body_inout(int p_status, const RID &p_body, int p_instance, int p_body_shape, int p_area_shape);
 


### PR DESCRIPTION
- Fix monitoring flag being reset when the scene is out of the tree (happens on save all if the current scene is not the focused one, therefore on save-on-run as well)
- Fix the inability to reset the monitoring flag while the area is out of the tree

@lonesurvivor, @volzhs, @reduz, @akien-mga,

Could you have a look at this and test if this doesn't break your use cases?
Finally, I think some or all of this should be ported to 3.0 but the code there is not in the same initial state. Any volunteer to port all the relevant recent `Area`/`Area2D` fixes to 3.0?