### PR TITLE
Add _ClassDB.class_[g|s]et_property to ClassDB exposed methods

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2455,8 +2455,8 @@ void _ClassDB::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("class_get_signal_list", "class", "no_inheritance"), &_ClassDB::get_signal_list, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("class_get_property_list", "class", "no_inheritance"), &_ClassDB::get_property_list, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("class_get_property", "object", "property"), &_ClassDB::get_property);
-	ClassDB::bind_method(D_METHOD("class_set_property", "object", "property", "value"), &_ClassDB::set_property);
+	ClassDB::bind_method(D_METHOD("class_get_property:Variant", "object", "property"), &_ClassDB::get_property);
+	ClassDB::bind_method(D_METHOD("class_set_property:Error", "object", "property", "value"), &_ClassDB::set_property);
 
 	ClassDB::bind_method(D_METHOD("class_has_method", "class", "method", "no_inheritance"), &_ClassDB::has_method, DEFVAL(false));
 

--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2366,6 +2366,23 @@ Array _ClassDB::get_property_list(StringName p_class, bool p_no_inheritance) con
 	return ret;
 }
 
+Variant _ClassDB::get_property(Object *p_object, const StringName &p_property) const {
+	Variant ret;
+	ClassDB::get_property(p_object, p_property, ret);
+	return ret;
+}
+
+Error _ClassDB::set_property(Object *p_object, const StringName &p_property, const Variant &p_value) const {
+	Variant ret;
+	bool valid;
+	if (!ClassDB::set_property(p_object, p_property, p_value, &valid)) {
+		return ERR_UNAVAILABLE;
+	} else if (!valid) {
+		return ERR_INVALID_DATA;
+	}
+	return OK;
+}
+
 bool _ClassDB::has_method(StringName p_class, StringName p_method, bool p_no_inheritance) const {
 
 	return ClassDB::has_method(p_class, p_method, p_no_inheritance);
@@ -2438,6 +2455,8 @@ void _ClassDB::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("class_get_signal_list", "class", "no_inheritance"), &_ClassDB::get_signal_list, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("class_get_property_list", "class", "no_inheritance"), &_ClassDB::get_property_list, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("class_get_property", "object", "property"), &_ClassDB::get_property);
+	ClassDB::bind_method(D_METHOD("class_set_property", "object", "property", "value"), &_ClassDB::set_property);
 
 	ClassDB::bind_method(D_METHOD("class_has_method", "class", "method", "no_inheritance"), &_ClassDB::has_method, DEFVAL(false));
 

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -586,6 +586,8 @@ public:
 	Array get_signal_list(StringName p_class, bool p_no_inheritance = false) const;
 
 	Array get_property_list(StringName p_class, bool p_no_inheritance = false) const;
+	Variant get_property(Object *p_object, const StringName &p_property) const;
+	Error set_property(Object *p_object, const StringName &p_property, const Variant &p_value) const;
 
 	bool has_method(StringName p_class, StringName p_method, bool p_no_inheritance = false) const;
 


### PR DESCRIPTION
Expose `ClassDB.class_get_property` and `ClassDB.class_set_property` to ClassDB in order to be able to interact with properties from dlscript (see #8330)