### PR TITLE
Ignore Visual Studio 2017 workspace folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -306,6 +306,6 @@ godot.creator.*
 projects/
 platform/windows/godot_res.res
 
-# Visual Studio Code folder (and files) that are created
-# when the C/C++ extension (https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) is used
+# Visual Studio 2017 and Visual Studio Code workspace folder
+/.vs
 /.vscode


### PR DESCRIPTION
- Visual Studio 2017 stores local configuration and user settings regarding the VS workspace inside `.vs`
- Visual Studio Code creates `.vscode` as soon as you add launch or other configurations, no matter if you have the C++ support extension installed or not (removed overlay detailled comment).