### PR TITLE
Prevent to uncheck selected item with button group

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -38,6 +38,8 @@ void BaseButton::_unpress_group() {
 	if (!button_group.is_valid())
 		return;
 
+	status.pressed = true;
+
 	for (Set<BaseButton *>::Element *E = button_group->buttons.front(); E; E = E->next()) {
 		if (E->get() == this)
 			continue;


### PR DESCRIPTION
for current version(1c480698ce0e881cbd28f1f0ddba95cee74ca834), selected button with `ButtonGroup` can be unchecked.
![button_group2](https://cloud.githubusercontent.com/assets/8281454/24846501/ebe0e876-1df5-11e7-8815-decdabed0d6f.gif)

This PR will fix it.
![button_group1](https://cloud.githubusercontent.com/assets/8281454/24846503/edaed9ec-1df5-11e7-844c-c12e26ae14f7.gif)

note that 2.1.x doesn't have this problem.