### PR TITLE
Prevent to take too much space for long vertical texture (2.1)

### DIFF
--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -2062,6 +2062,10 @@ void PropertyEditor::set_item_text(TreeItem *p_item, int p_type, const String &p
 				RES res = obj->get(p_name).operator RefPtr();
 				if (res->is_type("Texture")) {
 					int tw = EditorSettings::get_singleton()->get("property_editor/texture_preview_width");
+					Vector2 size(res->call("get_width"), res->call("get_height"));
+					if (size.width < size.height) {
+						tw = MAX((size.width / size.height) * tw, 1);
+					}
 					p_item->set_icon_max_width(1, tw);
 					p_item->set_icon(1, res);
 					p_item->set_text(1, "");
@@ -3206,6 +3210,10 @@ void PropertyEditor::update_tree() {
 
 					if (res->is_type("Texture")) {
 						int tw = EditorSettings::get_singleton()->get("property_editor/texture_preview_width");
+						Vector2 size(res->call("get_width"), res->call("get_height"));
+						if (size.width < size.height) {
+							tw = MAX((size.width / size.height) * tw, 1);
+						}
 						item->set_icon_max_width(1, tw);
 						item->set_icon(1, res);
 						item->set_text(1, "");


### PR DESCRIPTION
fix #8176 

![texture_view](https://cloud.githubusercontent.com/assets/8281454/24907437/3777beca-1ef7-11e7-94d1-3d5d779fe99a.gif)
