### PR TITLE
Show script filename instead of thumbnail (2.1)

### DIFF
--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -2101,7 +2101,9 @@ void PropertyEditor::set_item_text(TreeItem *p_item, int p_type, const String &p
 					}
 				}
 
-				if (!res->is_type("Texture")) {
+				if (res->is_type("Script")) {
+					p_item->set_text(1, res->get_path().get_file());
+				} else if (!res->is_type("Texture")) {
 					//texture already previews via itself
 					EditorResourcePreview::get_singleton()->queue_edited_resource_preview(res, this, "_resource_preview_done", p_item->get_instance_ID());
 				}
@@ -3229,7 +3231,9 @@ void PropertyEditor::update_tree() {
 					} else if (res.is_valid()) {
 						item->set_tooltip(1, res->get_name() + " (" + res->get_type() + ")");
 					}
-					if (!res->is_type("Texture")) {
+					if (res->is_type("Script")) {
+						item->set_text(1, res->get_path().get_file());
+					} else if (!res->is_type("Texture")) {
 						//texture already previews via itself
 						EditorResourcePreview::get_singleton()->queue_edited_resource_preview(res, this, "_resource_preview_done", item->get_instance_ID());
 					}


### PR DESCRIPTION
fix #7483 

![script1](https://cloud.githubusercontent.com/assets/8281454/24909163/bf3e6542-1efd-11e7-870c-115a0a804052.png)
![script2](https://cloud.githubusercontent.com/assets/8281454/24909165/c0a8613a-1efd-11e7-904b-77b8b4938a7d.png)
