### PR TITLE
Fix a pesky bug in marshalls.cpp/encode_variant

### DIFF
--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -862,7 +862,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len) {
 			} else {
 
 				if (buf) {
-					encode_double(p_variant.operator float(), buf);
+					encode_float(p_variant.operator float(), buf);
 				}
 
 				r_len += 4;


### PR DESCRIPTION
Fixes #7556 - running game from editor on LLVM builds.

Yay :star:! Achievement got: Fix a paranormal bug.

(Note: this doesn't need cherrypicking, as the commit that initially got the code there is 13cdccf23b)