### PR TITLE
Use .godot as file extension for project files.

### DIFF
--- a/core/global_config.h
+++ b/core/global_config.h
@@ -111,6 +111,8 @@ protected:
 
 	void _add_property_info_bind(const Dictionary &p_info);
 
+	String project_file_name;
+
 protected:
 	static void _bind_methods();
 
@@ -124,6 +126,7 @@ public:
 	Variant property_get_revert(const String &p_name);
 
 	String get_resource_path() const;
+	String get_project_file_name() const;
 
 	static GlobalConfig *get_singleton();
 

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -16414,7 +16414,7 @@
 		Contains global variables accessible from everywhere.
 	</brief_description>
 	<description>
-		Contains global variables accessible from everywhere. Use the normal [Object] API, such as "Globals.get(variable)", "Globals.set(variable,value)" or "Globals.has(variable)" to access them. Variables stored in godot.cfg are also loaded into globals, making this object very useful for reading custom game configuration options.
+		Contains global variables accessible from everywhere. Use the normal [Object] API, such as "Globals.get(variable)", "Globals.set(variable,value)" or "Globals.has(variable)" to access them. Variables stored in the project file (*.godot) are also loaded into globals, making this object very useful for reading custom game configuration options.
 	</description>
 	<methods>
 		<method name="add_property_info">

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -50,6 +50,19 @@
 #include "scene/gui/tool_button.h"
 #include "version.h"
 
+static String _find_project_file(DirAccess *p_da) {
+	p_da->list_dir_begin();
+	while (true) {
+		String f = p_da->get_next();
+		if (f == "")
+			break;
+		if (f.get_extension() == "godot")
+			return p_da->get_current_dir() + "/" + f;
+	}
+	p_da->list_dir_end();
+	return "";
+}
+
 class NewProjectDialog : public ConfirmationDialog {
 
 	GDCLASS(NewProjectDialog, ConfirmationDialog);
@@ -92,18 +105,18 @@ private:
 
 		if (mode != MODE_IMPORT) {
 
-			if (d->file_exists("godot.cfg")) {
+			if (_find_project_file(d) != "") {
 
-				error->set_text(TTR("Invalid project path, godot.cfg must not exist."));
+				error->set_text(TTR("Invalid project path, *.godot must not exist."));
 				memdelete(d);
 				return "";
 			}
 
 		} else {
 
-			if (valid_path != "" && !d->file_exists("godot.cfg")) {
+			if (valid_path != "" && _find_project_file(d) == "") {
 
-				error->set_text(TTR("Invalid project path, godot.cfg must exist."));
+				error->set_text(TTR("Invalid project path, *.godot must exist."));
 				memdelete(d);
 				return "";
 			}
@@ -136,7 +149,7 @@ private:
 
 		String p = p_path;
 		if (mode == MODE_IMPORT) {
-			if (p.ends_with("godot.cfg")) {
+			if (p.get_extension() == "godot") {
 
 				p = p.get_base_dir();
 			}
@@ -162,7 +175,7 @@ private:
 
 			fdialog->set_mode(FileDialog::MODE_OPEN_FILE);
 			fdialog->clear_filters();
-			fdialog->add_filter("godot.cfg ; " _MKSTR(VERSION_NAME) " Project");
+			fdialog->add_filter("*.godot ; " _MKSTR(VERSION_NAME) " Project");
 		} else {
 			fdialog->set_mode(FileDialog::MODE_OPEN_DIR);
 		}
@@ -186,9 +199,9 @@ private:
 		} else {
 			if (mode == MODE_NEW) {
 
-				FileAccess *f = FileAccess::open(dir.plus_file("/godot.cfg"), FileAccess::WRITE);
+				FileAccess *f = FileAccess::open(dir.plus_file("/" + project_name->get_text().replace(" ", "_") + ".godot"), FileAccess::WRITE);
 				if (!f) {
-					error->set_text(TTR("Couldn't create godot.cfg in project path."));
+					error->set_text(TTR("Couldn't create *.godot project file in project path."));
 				} else {
 
 					f->store_line("; Engine configuration file.");
@@ -741,10 +754,17 @@ void ProjectManager::_load_recent_projects() {
 			continue;
 
 		String project = _name.get_slice("/", 1);
-		String conf = path.plus_file("godot.cfg");
+		DirAccess *dir_access = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+		if (dir_access->change_dir(path) != OK) {
+			EditorSettings::get_singleton()->erase(_name);
+			continue;
+		}
+		String conf = _find_project_file(dir_access);
+		memdelete(dir_access);
 		bool favorite = (_name.begins_with("favorite_projects/")) ? true : false;
 
 		uint64_t last_modified = 0;
+
 		if (FileAccess::exists(conf)) {
 			last_modified = FileAccess::get_modified_time(conf);
 
@@ -1006,7 +1026,7 @@ void ProjectManager::_scan_dir(DirAccess *da, float pos, float total, List<Strin
 	while (n != String()) {
 		if (da->current_is_dir() && !n.begins_with(".")) {
 			subdirs.push_front(n);
-		} else if (n == "godot.cfg") {
+		} else if (n.get_extension() == "godot") {
 			r_projects->push_back(da->get_current_dir());
 		}
 		n = da->get_next();
@@ -1117,7 +1137,7 @@ void ProjectManager::_files_dropped(PoolStringArray p_files, int p_screen) {
 				dir->list_dir_begin();
 				String file = dir->get_next();
 				while (confirm && file != String()) {
-					if (!dir->current_is_dir() && file.ends_with("godot.cfg")) {
+					if (!dir->current_is_dir() && file.get_extension() == "godot") {
 						confirm = false;
 					}
 					file = dir->get_next();

--- a/editor/project_settings.cpp
+++ b/editor/project_settings.cpp
@@ -1168,7 +1168,8 @@ void ProjectSettings::_bind_methods() {
 ProjectSettings::ProjectSettings(EditorData *p_data) {
 
 	singleton = this;
-	set_title(TTR("Project Settings (godot.cfg)"));
+	String project_file = "(" + GlobalConfig::get_singleton()->get_project_file_name() + ")";
+	set_title(TTR("Project Settings " + project_file));
 	set_resizable(true);
 	undo_redo = &p_data->get_undo_redo();
 	data = p_data;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -129,7 +129,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print(VERSION_FULL_NAME " (c) 2008-2017 Juan Linietsky, Ariel Manzur.\n");
 	OS::get_singleton()->print("Usage: %s [options] [scene]\n", p_binary);
 	OS::get_singleton()->print("Options:\n");
-	OS::get_singleton()->print("\t-path [dir] : Path to a game, containing godot.cfg\n");
+	OS::get_singleton()->print("\t-path [dir] : Path to a game, containing *.godot\n");
 #ifdef TOOLS_ENABLED
 	OS::get_singleton()->print("\t-e,-editor : Bring up the editor instead of running the scene.\n");
 #endif
@@ -447,6 +447,23 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			} else {
 				goto error;
 			}
+		} else if (I->get().ends_with(".godot")) {
+			String path;
+			String file = I->get();
+			int sep = MAX(file.find_last("/"), file.find_last("\\"));
+			if (sep == -1)
+				path = ".";
+			else {
+				path = file.substr(0, sep);
+			}
+			if (OS::get_singleton()->set_cwd(path) == OK) {
+
+			} else {
+				game_path = path;
+			}
+#ifdef TOOLS_ENABLED
+			editor = true;
+#endif
 		} else if (I->get() == "-bp") { // /breakpoints
 
 			if (I->next()) {
@@ -673,7 +690,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	else
 		input_map->load_from_globals(); //keys for game
 
-	if (video_driver == "") // specified in godot.cfg
+	if (video_driver == "") // specified in *.godot
 		video_driver = GLOBAL_DEF("display/driver/name", Variant((const char *)OS::get_singleton()->get_video_driver_name(0)));
 
 	if (!force_res && use_custom_res && globals->has("display/window/width"))
@@ -725,7 +742,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	/* Determine Video Driver */
 
-	if (audio_driver == "") { // specified in godot.cfg
+	if (audio_driver == "") { // specified in *.godot
 		audio_driver = GLOBAL_DEF("audio/driver", OS::get_singleton()->get_audio_driver_name(0));
 	}
 


### PR DESCRIPTION
Now project files don't have to be named "godot.cfg" anymore, they can have any name so as long as it ends with *.godot.
Also godot will automatically start the editor now if launched with a project file as an argument.
This allows for double-clicking of projects to open them :)

Code-wise this should be complete, but there's still work to do:

- Make a nice icon for godot projects. (ping @djrm)
- Work on installers/packaging -> register the extension and icon with godot. (ping @Calinou)
- Update the 2.1 to 3.0 exporter.

Tested on linux and windows so far.
Closes #6915