### PR TITLE
Fix FBO depth texture format

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -5534,7 +5534,7 @@ void RasterizerStorageGLES3::_render_target_allocate(RenderTarget *rt) {
 		glGenTextures(1, &rt->depth);
 		glBindTexture(GL_TEXTURE_2D, rt->depth);
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH24_STENCIL8, rt->width, rt->height, 0,
-				GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, NULL);
+				GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, NULL);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
@@ -6500,7 +6500,7 @@ void RasterizerStorageGLES3::initialize() {
 	frame.count = 0;
 	frame.prev_tick = 0;
 	frame.delta = 0;
-	frame.current_rt=NULL;
+	frame.current_rt = NULL;
 	config.keep_original_textures = false;
 }
 


### PR DESCRIPTION
2D graphics are currently broken in WebGL 2 again, this fixes it.
Also fix inconsistent formatting in the modified file.