### PR TITLE
Ported move_and_slide to KinematicBody (3D)

### DIFF
--- a/scene/3d/physics_body.h
+++ b/scene/3d/physics_body.h
@@ -275,6 +275,13 @@ class KinematicBody : public PhysicsBody {
 	Vector3 collider_vel;
 	ObjectID collider;
 	int collider_shape;
+	Vector3 travel;
+
+	Vector3 move_and_slide_floor_velocity;
+	bool move_and_slide_on_floor;
+	bool move_and_slide_on_ceiling;
+	bool move_and_slide_on_wall;
+	Array move_and_slide_colliders;
 
 	Variant _get_collider() const;
 
@@ -295,6 +302,10 @@ public:
 
 	bool can_teleport_to(const Vector3 &p_position);
 	bool is_colliding() const;
+
+	Vector3 get_travel() const; // Set by move and others. Consider unreliable except immediately after a move call.
+	void revert_motion();
+
 	Vector3 get_collision_pos() const;
 	Vector3 get_collision_normal() const;
 	Vector3 get_collider_velocity() const;
@@ -315,6 +326,12 @@ public:
 
 	void set_collision_margin(float p_margin);
 	float get_collision_margin() const;
+
+	Vector3 move_and_slide(const Vector3 &p_linear_velocity, const Vector3 &p_floor_direction = Vector3(0, 0, 0), const Vector3 &p_ceil_direction = Vector3(0, 0, 0), float p_slope_stop_min_velocity = 5, int p_max_bounces = 4, float p_floor_max_angle = Math::deg2rad((float)45), float p_ceil_max_angle = Math::deg2rad((float)45));
+	bool is_move_and_slide_on_floor() const;
+	bool is_move_and_slide_on_wall() const;
+	bool is_move_and_slide_on_ceiling() const;
+	Array get_move_and_slide_colliders() const;
 
 	KinematicBody();
 	~KinematicBody();


### PR DESCRIPTION
move_and_slide is rather useful for FPS character-controllers, etc - it reduces the amount of boilerplate code.
(It's also a bit inconsistent that it doesn't exist in the 3D scene.)

It might be nice to figure out a way to share the code between the two move_and_slide implementations, but that's for someone who knows what the policy is on shared code like that.

(EDIT: I've attached a test project, which includes both a 3D scene and a basic 2D scene for comparison. This is 1. for some basic testing, and 2. so that if/when the inevitable "why does is_ceiling get set when is_wall is meant" bug report comes, there is something that ought to be extendable into a testbed, as it is consistent between 2D and 3D, through rather wrong behavior as far as I can tell. It could be user error on my part, though if it was, then why does it detect floors as floors?)

(EDIT2: I have a fix for the is_ceiling / is_wall issues in both 2D and 3D, but I'm waiting on this PR to put it into the pipeline since it applies changes to both.)

(EDIT3: On recommendation, I've applied the fix - see #8408 for the 2D version of the fix.)

[ktest.zip](https://github.com/godotengine/godot/files/920728/ktest.zip)