### PR TITLE
Apply is_ceiling/is_wall swap fix to 2D move_and_slide

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1199,7 +1199,7 @@ Vector2 KinematicBody2D::move_and_slide(const Vector2 &p_linear_velocity, const 
 						revert_motion();
 						return Vector2();
 					}
-				} else if (get_collision_normal().dot(-p_floor_direction) <= Math::cos(p_floor_max_angle)) { //ceiling
+				} else if (get_collision_normal().dot(-p_floor_direction) >= Math::cos(p_floor_max_angle)) { //ceiling
 					move_and_slide_on_ceiling = true;
 				} else {
 					move_and_slide_on_wall = true;


### PR DESCRIPTION
This fixes is_ceiling being swapped with is_wall.

Essentially a condition was slightly the wrong way around, though I've gone and added some comments to that area to help understand the code, partially to help myself understand it,and partially in case of future maintainers.

This project (note: Do not press "3D" in the menu, as that is meant for testing another PR.) shows the bug on master.
[kTest.zip](https://github.com/godotengine/godot/files/922179/kTest.zip)
