### PR TITLE
External editor improvements and fixes 

### DIFF
--- a/core/script_language.h
+++ b/core/script_language.h
@@ -119,7 +119,7 @@ public:
 	virtual void get_script_method_list(List<MethodInfo> *p_list) const = 0;
 	virtual void get_script_property_list(List<PropertyInfo> *p_list) const = 0;
 
-	virtual int get_member_line(const StringName &p_member) const { return 0; }
+	virtual int get_member_line(const StringName &p_member) const { return -1; }
 
 	Script() {}
 };
@@ -201,6 +201,7 @@ public:
 	virtual bool has_named_classes() const = 0;
 	virtual int find_function(const String &p_function, const String &p_code) const = 0;
 	virtual String make_function(const String &p_class, const String &p_name, const PoolStringArray &p_args) const = 0;
+	virtual Error open_in_external_editor(const Ref<Script> &p_script, int p_line, int p_col) { return ERR_UNAVAILABLE; }
 
 	virtual Error complete_code(const String &p_code, const String &p_base_path, Object *p_owner, List<String> *r_options, String &r_call_hint) { return ERR_UNAVAILABLE; }
 

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -767,7 +767,7 @@ void ConnectionsDock::_something_activated() {
 
 		Ref<Script> script = c.target->get_script();
 
-		if (script.is_valid() && ScriptEditor::get_singleton()->script_go_to_method(script, c.method)) {
+		if (script.is_valid() && ScriptEditor::get_singleton()->script_goto_method(script, c.method)) {
 			editor->call("_editor_select", EditorNode::EDITOR_SCRIPT);
 		}
 	}

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -95,7 +95,6 @@ public:
 	virtual void tag_saved_version() = 0;
 	virtual void reload(bool p_soft) = 0;
 	virtual void get_breakpoints(List<int> *p_breakpoints) = 0;
-	virtual bool goto_method(const String &p_method) = 0;
 	virtual void add_callback(const String &p_function, PoolStringArray p_args) = 0;
 	virtual void update_settings() = 0;
 	virtual void set_debugger_active(bool p_active) = 0;
@@ -312,7 +311,9 @@ public:
 	void apply_scripts() const;
 
 	void ensure_select_current();
-	void edit(const Ref<Script> &p_script, bool p_grab_focus = true);
+
+	_FORCE_INLINE_ bool edit(const Ref<Script> &p_script, bool p_grab_focus = true) { return edit(p_script, -1, 0, p_grab_focus); }
+	bool edit(const Ref<Script> &p_script, int p_line, int p_col, bool p_grab_focus = true);
 
 	Dictionary get_state() const;
 	void set_state(const Dictionary &p_state);
@@ -329,7 +330,7 @@ public:
 
 	void set_scene_root_script(Ref<Script> p_script);
 
-	bool script_go_to_method(Ref<Script> p_script, const String &p_method);
+	bool script_goto_method(Ref<Script> p_script, const String &p_method);
 
 	virtual void edited_scene_changed();
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -69,26 +69,6 @@ Ref<Script> ScriptTextEditor::get_edited_script() const {
 	return script;
 }
 
-bool ScriptTextEditor::goto_method(const String &p_method) {
-
-	Vector<String> functions = get_functions();
-
-	String method_search = p_method + ":";
-
-	for (int i = 0; i < functions.size(); i++) {
-		String function = functions[i];
-
-		if (function.begins_with(method_search)) {
-
-			int line = function.get_slice(":", 1).to_int();
-			goto_line(line - 1);
-			return true;
-		}
-	}
-
-	return false;
-}
-
 void ScriptTextEditor::_load_theme_settings() {
 
 	TextEdit *text_edit = code_editor->get_text_edit();
@@ -296,7 +276,7 @@ void ScriptTextEditor::tag_saved_version() {
 }
 
 void ScriptTextEditor::goto_line(int p_line, bool p_with_error) {
-	code_editor->get_text_edit()->cursor_set_line(p_line);
+	code_editor->get_text_edit()->call_deferred("cursor_set_line", p_line);
 }
 
 void ScriptTextEditor::ensure_focus() {

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -134,7 +134,6 @@ public:
 
 	virtual void add_callback(const String &p_function, PoolStringArray p_args);
 	virtual void update_settings();
-	virtual bool goto_method(const String &p_method);
 
 	virtual void set_tooltip_request_func(String p_method, Object *p_obj);
 

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -1073,6 +1073,18 @@ void VisualScript::get_script_property_list(List<PropertyInfo> *p_list) const {
 	}
 }
 
+int VisualScript::get_member_line(const StringName &p_member) const {
+#ifdef TOOLS_ENABLED
+	if (has_function(p_member)) {
+		for (Map<int, Function::NodeData>::Element *E = functions[p_member].nodes.front(); E; E = E->next()) {
+			if (E->get().node->cast_to<VisualScriptFunction>())
+				return E->key();
+		}
+	}
+#endif
+	return -1;
+}
+
 #ifdef TOOLS_ENABLED
 bool VisualScript::are_subnodes_edited() const {
 

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -356,6 +356,8 @@ public:
 
 	virtual void get_script_property_list(List<PropertyInfo> *p_list) const;
 
+	virtual int get_member_line(const StringName &p_member) const;
+
 #ifdef TOOLS_ENABLED
 	virtual bool are_subnodes_edited() const;
 #endif

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -2153,7 +2153,7 @@ void VisualScriptEditor::goto_line(int p_line, bool p_with_error) {
 			_update_graph();
 			_update_members();
 
-			call_deferred("_center_on_node", p_line); //editor might be just created and size might not exist yet
+			call_deferred("call_deferred", "_center_on_node", p_line); //editor might be just created and size might not exist yet
 
 			return;
 		}
@@ -2190,18 +2190,6 @@ void VisualScriptEditor::get_breakpoints(List<int> *p_breakpoints) {
 			}
 		}
 	}
-}
-
-bool VisualScriptEditor::goto_method(const String &p_method) {
-
-	if (!script->has_function(p_method))
-		return false;
-
-	edited_func = p_method;
-	selected = edited_func;
-	_update_members();
-	_update_graph();
-	return true;
 }
 
 void VisualScriptEditor::add_callback(const String &p_function, PoolStringArray p_args) {

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -244,7 +244,6 @@ public:
 	virtual void tag_saved_version();
 	virtual void reload(bool p_soft);
 	virtual void get_breakpoints(List<int> *p_breakpoints);
-	virtual bool goto_method(const String &p_method);
 	virtual void add_callback(const String &p_function, PoolStringArray p_args);
 	virtual void update_settings();
 	virtual void set_debugger_active(bool p_active);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4448,8 +4448,8 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_text"), &TextEdit::get_text);
 	ClassDB::bind_method(D_METHOD("get_line", "line"), &TextEdit::get_line);
 
-	ClassDB::bind_method(D_METHOD("cursor_set_column", "column", "adjust_viewport"), &TextEdit::cursor_set_column, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("cursor_set_line", "line", "adjust_viewport"), &TextEdit::cursor_set_line, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("cursor_set_column", "column", "adjust_viewport"), &TextEdit::cursor_set_column, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("cursor_set_line", "line", "adjust_viewport"), &TextEdit::cursor_set_line, DEFVAL(true));
 
 	ClassDB::bind_method(D_METHOD("cursor_get_column"), &TextEdit::cursor_get_column);
 	ClassDB::bind_method(D_METHOD("cursor_get_line"), &TextEdit::cursor_get_line);


### PR DESCRIPTION
Notable changes:
- Now ScriptLanguages have the option to override the global external editor setting (_This is specially important now that we have more than one language_).
If `ScriptLanguage::open_in_external_editor()` returns `ERR_UNAVAILABLE` (which it does by default), then the global external editor option will be used.
- Added formatting to the external editor execution arguments. Now it's possible to write something like this: `{project} -g {file}:{line}:{col}`.
- `VisualScript::get_member_line()` now can return the line of functions (well, it returns the id of the _Function_ node of the function). I guess there is nothing else we can get a "line" from.

This commit also introduces a few fixes in the process:
- Fixes a bug where `ScriptEditor::script_goto_method()` would not work if the script is not already open in the built-in editor.
- Fixes wrong DEFVAL for `cursor_set_column` and `cursor_set_line` in TextEdit.
- `Script::get_member_line()` now returns -1 (_"found nothing"_) by default.

Thoughts?
