### PR TITLE
Added the ability to select files as base when creating scripts

### DIFF
--- a/core/script_language.h
+++ b/core/script_language.h
@@ -199,6 +199,7 @@ public:
 	virtual bool validate(const String &p_script, int &r_line_error, int &r_col_error, String &r_test_error, const String &p_path = "", List<String> *r_functions = NULL) const = 0;
 	virtual Script *create_script() const = 0;
 	virtual bool has_named_classes() const = 0;
+	virtual bool can_inherit_from_file() { return false; }
 	virtual int find_function(const String &p_function, const String &p_code) const = 0;
 	virtual String make_function(const String &p_class, const String &p_name, const PoolStringArray &p_args) const = 0;
 

--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -44,6 +44,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	Label *error_label;
 	Label *path_error_label;
 	LineEdit *parent_name;
+	Button *parent_browse_button;
 	OptionButton *language_menu;
 	LineEdit *file_path;
 	EditorFileDialog *file_browse;
@@ -52,6 +53,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	AcceptDialog *alert;
 	bool path_valid;
 	bool create_new;
+	bool is_browsing_parent;
 	String initial_bp;
 	EditorSettings *editor_settings;
 
@@ -60,7 +62,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	void _built_in_pressed();
 	bool _validate(const String &p_strin);
 	void _class_name_changed(const String &p_name);
-	void _browse_path();
+	void _browse_path(bool browse_parent);
 	void _file_selected(const String &p_file);
 	virtual void ok_pressed();
 	void _create_new();

--- a/modules/gdscript/gd_script.h
+++ b/modules/gdscript/gd_script.h
@@ -384,6 +384,7 @@ public:
 	virtual bool validate(const String &p_script, int &r_line_error, int &r_col_error, String &r_test_error, const String &p_path = "", List<String> *r_functions = NULL) const;
 	virtual Script *create_script() const;
 	virtual bool has_named_classes() const;
+	virtual bool can_inherit_from_file() { return true; }
 	virtual int find_function(const String &p_function, const String &p_code) const;
 	virtual String make_function(const String &p_class, const String &p_name, const PoolStringArray &p_args) const;
 	virtual Error complete_code(const String &p_code, const String &p_base_path, Object *p_owner, List<String> *r_options, String &r_call_hint);


### PR DESCRIPTION
I've found this feature very useful while I was working on my game, so I thought I would share it.
I added a new virtual function to ScriptLanguage (can_inherit_from_file) which returns false by default. This has to be overridden for new scripting languages (I did it for GDScript, don't know about VisualScript).
This is how it looks like:
![Screenshot](https://cloud.githubusercontent.com/assets/7415668/25066671/62b9040c-222d-11e7-9f58-29ef0c318c00.PNG)