### PR TITLE
ScriptEditor: Fixes bug where menu option would be handled twice

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -878,28 +878,29 @@ void ScriptEditor::_menu_option(int p_option) {
 				}
 			}
 		}
-	}
+	} else {
 
-	EditorHelp *help = tab_container->get_current_tab_control()->cast_to<EditorHelp>();
-	if (help) {
+		EditorHelp *help = tab_container->get_current_tab_control()->cast_to<EditorHelp>();
+		if (help) {
 
-		switch (p_option) {
+			switch (p_option) {
 
-			case HELP_SEARCH_FIND: {
-				help->popup_search();
-			} break;
-			case HELP_SEARCH_FIND_NEXT: {
-				help->search_again();
-			} break;
-			case FILE_CLOSE: {
-				_close_current_tab();
-			} break;
-			case CLOSE_DOCS: {
-				_close_docs_tab();
-			} break;
-			case CLOSE_ALL: {
-				_close_all_tabs();
-			} break;
+				case HELP_SEARCH_FIND: {
+					help->popup_search();
+				} break;
+				case HELP_SEARCH_FIND_NEXT: {
+					help->search_again();
+				} break;
+				case FILE_CLOSE: {
+					_close_current_tab();
+				} break;
+				case CLOSE_DOCS: {
+					_close_docs_tab();
+				} break;
+				case CLOSE_ALL: {
+					_close_all_tabs();
+				} break;
+			}
 		}
 	}
 }


### PR DESCRIPTION
For example, if the current selected tab was a script and the next one a help view, closing the script either via _File -> Close_ or <kbd>Ctrl</kbd>+<kbd>W</kbd> would close both the script and the help view.
