### PR TITLE
Add double-sided flag to SpriteBase3D (fixes #8007)

### DIFF
--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -272,10 +272,12 @@ void SpriteBase3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "axis", PROPERTY_HINT_ENUM, "X-Axis,Y-Axis,Z-Axis"), _SCS("set_axis"), _SCS("get_axis"));
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "flags/transparent"), _SCS("set_draw_flag"), _SCS("get_draw_flag"), FLAG_TRANSPARENT);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "flags/shaded"), _SCS("set_draw_flag"), _SCS("get_draw_flag"), FLAG_SHADED);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "flags/double_sided"), _SCS("set_draw_flag"), _SCS("get_draw_flag"), FLAG_DOUBLE_SIDED);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "flags/alpha_cut", PROPERTY_HINT_ENUM, "Disabled,Discard,Opaque Pre-Pass"), _SCS("set_alpha_cut_mode"), _SCS("get_alpha_cut_mode"));
 
 	BIND_CONSTANT(FLAG_TRANSPARENT);
 	BIND_CONSTANT(FLAG_SHADED);
+	BIND_CONSTANT(FLAG_DOUBLE_SIDED);
 	BIND_CONSTANT(FLAG_MAX);
 
 	BIND_CONSTANT(ALPHA_CUT_DISABLED);
@@ -293,7 +295,7 @@ SpriteBase3D::SpriteBase3D() {
 	pI = NULL;
 
 	for (int i = 0; i < FLAG_MAX; i++)
-		flags[i] = i == FLAG_TRANSPARENT;
+		flags[i] = i == FLAG_TRANSPARENT || i == FLAG_DOUBLE_SIDED;
 
 	axis = Vector3::AXIS_Z;
 	pixel_size = 0.01;
@@ -386,7 +388,7 @@ void Sprite3D::_draw() {
 	int axis = get_axis();
 	normal[axis] = 1.0;
 
-	RID mat = VS::get_singleton()->material_2d_get(get_draw_flag(FLAG_SHADED), get_draw_flag(FLAG_TRANSPARENT), get_alpha_cut_mode() == ALPHA_CUT_DISCARD, get_alpha_cut_mode() == ALPHA_CUT_OPAQUE_PREPASS);
+	RID mat = VS::get_singleton()->material_2d_get(get_draw_flag(FLAG_SHADED), get_draw_flag(FLAG_TRANSPARENT), get_draw_flag(FLAG_DOUBLE_SIDED), get_alpha_cut_mode() == ALPHA_CUT_DISCARD, get_alpha_cut_mode() == ALPHA_CUT_OPAQUE_PREPASS);
 	VS::get_singleton()->immediate_set_material(immediate, mat);
 
 	VS::get_singleton()->immediate_begin(immediate, VS::PRIMITIVE_TRIANGLE_FAN, texture->get_rid());
@@ -885,7 +887,7 @@ void AnimatedSprite3D::_draw() {
 	int axis = get_axis();
 	normal[axis] = 1.0;
 
-	RID mat = VS::get_singleton()->material_2d_get(get_draw_flag(FLAG_SHADED), get_draw_flag(FLAG_TRANSPARENT), get_alpha_cut_mode() == ALPHA_CUT_DISCARD, get_alpha_cut_mode() == ALPHA_CUT_OPAQUE_PREPASS);
+	RID mat = VS::get_singleton()->material_2d_get(get_draw_flag(FLAG_SHADED), get_draw_flag(FLAG_TRANSPARENT), get_draw_flag(FLAG_DOUBLE_SIDED), get_alpha_cut_mode() == ALPHA_CUT_DISCARD, get_alpha_cut_mode() == ALPHA_CUT_OPAQUE_PREPASS);
 	VS::get_singleton()->immediate_set_material(immediate, mat);
 
 	VS::get_singleton()->immediate_begin(immediate, VS::PRIMITIVE_TRIANGLE_FAN, texture->get_rid());

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -41,6 +41,7 @@ public:
 	enum DrawFlags {
 		FLAG_TRANSPARENT,
 		FLAG_SHADED,
+		FLAG_DOUBLE_SIDED,
 		FLAG_MAX
 
 	};

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -137,7 +137,7 @@ void VisualServer::_free_internal_rids() {
 	if (test_material.is_valid())
 		free(test_material);
 
-	for (int i = 0; i < 16; i++) {
+	for (int i = 0; i < 32; i++) {
 		if (material_2d[i].is_valid())
 			free(material_2d[i]);
 	}
@@ -283,7 +283,7 @@ RID VisualServer::make_sphere_mesh(int p_lats, int p_lons, float p_radius) {
 	return mesh;
 }
 
-RID VisualServer::material_2d_get(bool p_shaded, bool p_transparent, bool p_cut_alpha, bool p_opaque_prepass) {
+RID VisualServer::material_2d_get(bool p_shaded, bool p_transparent, bool p_double_sided, bool p_cut_alpha, bool p_opaque_prepass) {
 
 	int version = 0;
 	if (p_shaded)
@@ -294,6 +294,8 @@ RID VisualServer::material_2d_get(bool p_shaded, bool p_transparent, bool p_cut_
 		version |= 4;
 	if (p_opaque_prepass)
 		version |= 8;
+	if (p_double_sided)
+		version |= 16;
 	if (material_2d[version].is_valid())
 		return material_2d[version];
 
@@ -304,7 +306,7 @@ RID VisualServer::material_2d_get(bool p_shaded, bool p_transparent, bool p_cut_
 	fixed_material_set_flag(material_2d[version], FIXED_MATERIAL_FLAG_USE_COLOR_ARRAY, true);
 	fixed_material_set_flag(material_2d[version], FIXED_MATERIAL_FLAG_DISCARD_ALPHA, p_cut_alpha);
 	material_set_flag(material_2d[version], MATERIAL_FLAG_UNSHADED, !p_shaded);
-	material_set_flag(material_2d[version], MATERIAL_FLAG_DOUBLE_SIDED, true);
+	material_set_flag(material_2d[version], MATERIAL_FLAG_DOUBLE_SIDED, p_double_sided);
 	material_set_depth_draw_mode(material_2d[version], p_opaque_prepass ? MATERIAL_DEPTH_DRAW_OPAQUE_PRE_PASS_ALPHA : MATERIAL_DEPTH_DRAW_OPAQUE_ONLY);
 	fixed_material_set_texture(material_2d[version], FIXED_MATERIAL_PARAM_DIFFUSE, get_white_texture());
 	//material cut alpha?

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -60,7 +60,7 @@ protected:
 	RID test_texture;
 	RID white_texture;
 	RID test_material;
-	RID material_2d[16];
+	RID material_2d[32];
 
 	static VisualServer *(*create_func)();
 	static void _bind_methods();
@@ -1120,7 +1120,7 @@ public:
 
 	/* Materials for 2D on 3D */
 
-	RID material_2d_get(bool p_shaded, bool p_transparent, bool p_cut_alpha, bool p_opaque_prepass);
+	RID material_2d_get(bool p_shaded, bool p_transparent, bool p_double_sided, bool p_cut_alpha, bool p_opaque_prepass);
 
 	/* TESTING */
 


### PR DESCRIPTION
Does exactly what it says on the tin. Targeting 2.1 because last time I tried it, master didn't have working rendering, and this feature would more more immediately useful to me if it was in a 2.1.x release.