### PR TITLE
Correct gdnative signatures

### DIFF
--- a/modules/gdnative/godot/godot_basis.cpp
+++ b/modules/gdnative/godot/godot_basis.cpp
@@ -38,48 +38,176 @@ extern "C" {
 void _basis_api_anchor() {
 }
 
-void GDAPI godot_basis_new(godot_basis *p_basis) {
-	Basis *basis = (Basis *)p_basis;
-	*basis = Basis();
+void GDAPI godot_basis_new(godot_basis *p_v) {
+	Basis *v = (Basis *)p_v;
+	*v = Basis();
 }
 
-void GDAPI godot_basis_new_with_euler_quat(godot_basis *p_basis, const godot_quat *p_euler) {
-	Basis *basis = (Basis *)p_basis;
+void GDAPI godot_basis_new_with_euler_quat(godot_basis *p_v, const godot_quat *p_euler) {
+	Basis *v = (Basis *)p_v;
 	Quat *euler = (Quat *)p_euler;
-	*basis = Basis(*euler);
+	*v = Basis(*euler);
 }
 
-void GDAPI godot_basis_new_with_euler(godot_basis *p_basis, const godot_vector3 *p_euler) {
-	Basis *basis = (Basis *)p_basis;
-	Vector3 *euler = (Vector3 *)p_euler;
-	*basis = Basis(*euler);
+void GDAPI godot_basis_new_with_euler(godot_basis *p_v, const godot_vector3 p_euler) {
+	Basis *v = (Basis *)p_v;
+	Vector3 *euler = (Vector3 *)&p_euler;
+	*v = Basis(*euler);
 }
 
-godot_quat GDAPI godot_basis_as_quat(const godot_basis *p_basis) {
-	const Basis *basis = (const Basis *)p_basis;
+void GDAPI godot_basis_new_with_axis_and_angle(godot_basis *p_v, const godot_vector3 p_axis, const godot_real p_phi) {
+	Basis *v = (Basis *)p_v;
+	const Vector3 *axis = (Vector3 *)&p_axis;
+	*v = Basis(*axis, p_phi);
+}
+
+void GDAPI godot_basis_new_with_rows(godot_basis *p_v, const godot_vector3 p_row0, const godot_vector3 p_row1, const godot_vector3 p_row2) {
+	Basis *v = (Basis *)p_v;
+	const Vector3 *row0 = (Vector3 *)&p_row0;
+	const Vector3 *row1 = (Vector3 *)&p_row1;
+	const Vector3 *row2 = (Vector3 *)&p_row2;
+	*v = Basis(*row0, *row1, *row2);
+}
+
+godot_quat GDAPI godot_basis_as_quat(const godot_basis *p_v) {
+	const Basis *v = (const Basis *)p_v;
 	godot_quat quat;
 	Quat *p_quat = (Quat *)&quat;
-	*p_quat = basis->operator Quat();
+	*p_quat = v->operator Quat();
 	return quat;
-}
-
-godot_vector3 GDAPI godot_basis_get_euler(const godot_basis *p_basis) {
-	const Basis *basis = (const Basis *)p_basis;
-	godot_vector3 euler;
-	Vector3 *p_euler = (Vector3 *)&euler;
-	*p_euler = basis->get_euler();
-	return euler;
 }
 
 /*
  * p_elements is a pointer to an array of 3 (!!) vector3
  */
-void GDAPI godot_basis_get_elements(godot_basis *p_basis, godot_vector3 *p_elements) {
-	Basis *basis = (Basis *)p_basis;
+void GDAPI godot_basis_get_elements(godot_basis *p_v, godot_vector3 *p_elements) {
+	Basis *v = (Basis *)p_v;
 	Vector3 *elements = (Vector3 *)p_elements;
-	elements[0] = basis->elements[0];
-	elements[1] = basis->elements[1];
-	elements[2] = basis->elements[2];
+	elements[0] = v->elements[0];
+	elements[1] = v->elements[1];
+	elements[2] = v->elements[2];
+}
+
+godot_vector3 GDAPI godot_basis_get_axis(const godot_basis *p_v, const godot_int p_axis) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	const Basis *v = (Basis *)p_v;
+	*d = v->get_axis(p_axis);
+	return dest;
+}
+
+void GDAPI godot_basis_set_axis(godot_basis *p_v, const godot_int p_axis, const godot_vector3 p_value) {
+	Basis *v = (Basis *)p_v;
+	const Vector3 *value = (Vector3 *)&p_value;
+	v->set_axis(p_axis, *value);
+}
+
+godot_vector3 GDAPI godot_basis_get_row(const godot_basis *p_v, const godot_int p_row) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	const Basis *v = (Basis *)p_v;
+	*d = v->get_row(p_row);
+	return dest;
+}
+
+void GDAPI godot_basis_set_row(godot_basis *p_v, const godot_int p_row, const godot_vector3 p_value) {
+	Basis *v = (Basis *)p_v;
+	const Vector3 *value = (Vector3 *)&p_value;
+	v->set_row(p_row, *value);
+}
+
+godot_real godot_basis_determinant(const godot_basis *p_v) {
+	Basis *v = (Basis *)p_v;
+	return v->determinant();
+}
+
+godot_vector3 godot_basis_get_euler(const godot_basis *p_v) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	const Basis *v = (Basis *)p_v;
+	*d = v->get_euler();
+	return dest;
+}
+
+godot_int godot_basis_get_orthogonal_index(const godot_basis *p_v) {
+	const Basis *v = (Basis *)p_v;
+	return v->get_orthogonal_index();
+}
+
+godot_vector3 godot_basis_get_scale(const godot_basis *p_v) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	const Basis *v = (Basis *)p_v;
+	*d = v->get_scale();
+	return dest;
+}
+
+void godot_basis_inverse(godot_basis *p_dest, const godot_basis *p_v) {
+	Basis *d = (Basis *)p_dest;
+	const Basis *v = (Basis *)p_v;
+	*d = v->inverse();
+}
+
+void godot_basis_orthonormalized(godot_basis *p_dest, const godot_basis *p_v) {
+	Basis *d = (Basis *)p_dest;
+	const Basis *v = (Basis *)p_v;
+	*d = v->orthonormalized();
+}
+
+void godot_basis_rotated(godot_basis *p_dest, const godot_basis *p_v, const godot_vector3 p_axis, const godot_real p_phi) {
+	Basis *d = (Basis *)p_dest;
+	const Basis *v = (Basis *)p_v;
+	const Vector3 *axis = (Vector3 *)&p_axis;
+	*d = v->rotated(*axis, p_phi);
+}
+
+void godot_basis_scaled(godot_basis *p_dest, const godot_basis *p_v, const godot_vector3 p_scale) {
+	Basis *d = (Basis *)p_dest;
+	const Basis *v = (Basis *)p_v;
+	const Vector3 *scale = (Vector3 *)&p_scale;
+	*d = v->scaled(*scale);
+}
+
+godot_real godot_basis_tdotx(const godot_basis *p_v, const godot_vector3 p_with) {
+	const Basis *v = (Basis *)p_v;
+	const Vector3 *with = (Vector3 *)&p_with;
+	return v->tdotx(*with);
+}
+
+godot_real godot_basis_tdoty(const godot_basis *p_v, const godot_vector3 p_with) {
+	const Basis *v = (Basis *)p_v;
+	const Vector3 *with = (Vector3 *)&p_with;
+	return v->tdoty(*with);
+}
+
+godot_real godot_basis_tdotz(const godot_basis *p_v, const godot_vector3 p_with) {
+	const Basis *v = (Basis *)p_v;
+	const Vector3 *with = (Vector3 *)&p_with;
+	return v->tdotz(*with);
+}
+
+void godot_basis_transposed(godot_basis *p_dest, const godot_basis *p_v) {
+	Basis *d = (Basis *)p_dest;
+	const Basis *v = (Basis *)p_v;
+	*d = v->transposed();
+}
+
+godot_vector3 godot_basis_xform(const godot_basis *p_v, const godot_vector3 p_vect) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	const Basis *v = (Basis *)p_v;
+	const Vector3 *vect = (Vector3 *)&p_vect;
+	*d = v->xform(*vect);
+	return dest;
+}
+
+godot_vector3 godot_basis_xform_inv(const godot_basis *p_v, const godot_vector3 p_vect) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	const Basis *v = (Basis *)p_v;
+	const Vector3 *vect = (Vector3 *)&p_vect;
+	*d = v->xform_inv(*vect);
+	return dest;
 }
 
 #ifdef __cplusplus

--- a/modules/gdnative/godot/godot_basis.h
+++ b/modules/gdnative/godot/godot_basis.h
@@ -45,17 +45,37 @@ typedef struct godot_basis {
 #include "../godot.h"
 #include "godot_quat.h"
 
-void GDAPI godot_basis_new(godot_basis *p_basis);
-void GDAPI godot_basis_new_with_euler_quat(godot_basis *p_basis, const godot_quat *p_euler);
-void GDAPI godot_basis_new_with_euler(godot_basis *p_basis, const godot_vector3 *p_euler);
+void GDAPI godot_basis_new(godot_basis *p_v);
+void GDAPI godot_basis_new_with_euler_quat(godot_basis *p_v, const godot_quat *p_euler);
+void GDAPI godot_basis_new_with_euler(godot_basis *p_v, const godot_vector3 p_euler);
+void GDAPI godot_basis_new_with_axis_and_angle(godot_basis *p_v, const godot_vector3 p_axis, const godot_real p_phi);
+void GDAPI godot_basis_new_with_rows(godot_basis *p_v, const godot_vector3 p_row0, const godot_vector3 p_row1, const godot_vector3 p_row2);
 
-godot_quat GDAPI godot_basis_as_quat(const godot_basis *p_basis);
-godot_vector3 GDAPI godot_basis_get_euler(const godot_basis *p_basis);
+godot_quat GDAPI godot_basis_as_quat(const godot_basis *p_v);
 
 /*
  * p_elements is a pointer to an array of 3 (!!) vector3
  */
-void GDAPI godot_basis_get_elements(godot_basis *p_basis, godot_vector3 *p_elements);
+void GDAPI godot_basis_get_elements(godot_basis *p_v, godot_vector3 *p_elements);
+godot_vector3 GDAPI godot_basis_get_axis(const godot_basis *p_v, const godot_int p_axis);
+void GDAPI godot_basis_set_axis(godot_basis *p_v, const godot_int p_axis, const godot_vector3 p_value);
+godot_vector3 GDAPI godot_basis_get_row(const godot_basis *p_v, const godot_int p_row);
+void GDAPI godot_basis_set_row(godot_basis *p_v, const godot_int p_row, const godot_vector3 p_value);
+
+godot_real godot_basis_determinant(const godot_basis *p_v);
+godot_vector3 godot_basis_get_euler(const godot_basis *p_v);
+godot_int godot_basis_get_orthogonal_index(const godot_basis *p_v);
+godot_vector3 godot_basis_get_scale(const godot_basis *p_v);
+void godot_basis_inverse(godot_basis *p_dest, const godot_basis *p_v);
+void godot_basis_orthonormalized(godot_basis *p_dest, const godot_basis *p_v);
+void godot_basis_rotated(godot_basis *p_dest, const godot_basis *p_v, const godot_vector3 p_axis, const godot_real p_phi);
+void godot_basis_scaled(godot_basis *p_dest, const godot_basis *p_v, const godot_vector3 p_scale);
+godot_real godot_basis_tdotx(const godot_basis *p_v, const godot_vector3 p_with);
+godot_real godot_basis_tdoty(const godot_basis *p_v, const godot_vector3 p_with);
+godot_real godot_basis_tdotz(const godot_basis *p_v, const godot_vector3 p_with);
+void godot_basis_transposed(godot_basis *p_dest, const godot_basis *p_v);
+godot_vector3 godot_basis_xform(const godot_basis *p_v, const godot_vector3 p_vect);
+godot_vector3 godot_basis_xform_inv(const godot_basis *p_v, const godot_vector3 p_vect);
 
 #ifdef __cplusplus
 }

--- a/modules/gdnative/godot/godot_vector2.cpp
+++ b/modules/gdnative/godot/godot_vector2.cpp
@@ -37,11 +37,12 @@ extern "C" {
 
 void _vector2_api_anchor() {}
 
-void GDAPI godot_vector2_new(godot_vector2 *p_v, godot_real p_x,
-		godot_real p_y) {
-	Vector2 *v = (Vector2 *)p_v;
+godot_vector2 GDAPI godot_vector2_new(const godot_real p_x, const godot_real p_y) {
+	godot_vector2 value;
+	Vector2 *v = (Vector2 *)&value;
 	v->x = p_x;
 	v->y = p_y;
+	return value;
 }
 
 void GDAPI godot_vector2_set_x(godot_vector2 *p_v, const godot_real p_x) {
@@ -55,11 +56,11 @@ void GDAPI godot_vector2_set_y(godot_vector2 *p_v, const godot_real p_y) {
 }
 
 godot_real GDAPI godot_vector2_get_x(const godot_vector2 *p_v) {
-	Vector2 *v = (Vector2 *)p_v;
+	const Vector2 *v = (Vector2 *)p_v;
 	return v->x;
 }
 godot_real GDAPI godot_vector2_get_y(const godot_vector2 *p_v) {
-	Vector2 *v = (Vector2 *)p_v;
+	const Vector2 *v = (Vector2 *)p_v;
 	return v->y;
 }
 
@@ -67,224 +68,227 @@ void GDAPI godot_vector2_normalize(godot_vector2 *p_v) {
 	Vector2 *v = (Vector2 *)p_v;
 	v->normalize();
 }
-void GDAPI godot_vector2_normalized(godot_vector2 *p_dest,
-		const godot_vector2 *p_src) {
-	Vector2 *v = (Vector2 *)p_src;
-	Vector2 *d = (Vector2 *)p_dest;
 
+godot_vector2 GDAPI godot_vector2_normalized(const godot_vector2 *p_v) {
+	godot_vector2 dest;
+	const Vector2 *v = (Vector2 *)p_v;
+	Vector2 *d = (Vector2 *)&dest;
 	*d = v->normalized();
+	return dest;
 }
 
 godot_real GDAPI godot_vector2_length(const godot_vector2 *p_v) {
-	Vector2 *v = (Vector2 *)p_v;
+	const Vector2 *v = (Vector2 *)p_v;
 	return v->length();
 }
 
 godot_real GDAPI godot_vector2_length_squared(const godot_vector2 *p_v) {
-	Vector2 *v = (Vector2 *)p_v;
+	const Vector2 *v = (Vector2 *)p_v;
 	return v->length_squared();
 }
 
-godot_real GDAPI godot_vector2_distance_to(const godot_vector2 *p_a,
-		const godot_vector2 *p_b) {
-	Vector2 *a = (Vector2 *)p_a;
-	Vector2 *b = (Vector2 *)p_b;
-	return a->distance_to(*b);
+godot_real GDAPI godot_vector2_distance_to(const godot_vector2 *p_v, const godot_vector2 p_b) {
+	const Vector2 *v = (Vector2 *)p_v;
+	const Vector2 *b = (Vector2 *)&p_b;
+	return v->distance_to(*b);
 }
 
-godot_real GDAPI godot_vector2_distance_squared_to(const godot_vector2 *p_a,
-		const godot_vector2 *p_b) {
-	Vector2 *a = (Vector2 *)p_a;
-	Vector2 *b = (Vector2 *)p_b;
-	return a->distance_squared_to(*b);
+godot_real GDAPI godot_vector2_distance_squared_to(const godot_vector2 *p_v, const godot_vector2 p_b) {
+	const Vector2 *v = (Vector2 *)p_v;
+	const Vector2 *b = (Vector2 *)&p_b;
+	return v->distance_squared_to(*b);
 }
 
-void GDAPI godot_vector2_operator_add(godot_vector2 *p_dest,
-		const godot_vector2 *p_a,
-		const godot_vector2 *p_b) {
-	Vector2 *dest = (Vector2 *)p_dest;
-	const Vector2 *a = (Vector2 *)p_a;
-	const Vector2 *b = (Vector2 *)p_b;
-	*dest = *a + *b;
+godot_vector2 GDAPI godot_vector2_operator_add(const godot_vector2 *p_v, const godot_vector2 p_b) {
+	godot_vector2 dest;
+	Vector2 *d = (Vector2 *)&dest;
+	const Vector2 *v = (Vector2 *)p_v;
+	const Vector2 *b = (Vector2 *)&p_b;
+	*d = *v + *b;
+	return dest;
 }
 
-void GDAPI godot_vector2_operator_subtract(godot_vector2 *p_dest,
-		const godot_vector2 *p_a,
-		const godot_vector2 *p_b) {
-	Vector2 *dest = (Vector2 *)p_dest;
-	const Vector2 *a = (Vector2 *)p_a;
-	const Vector2 *b = (Vector2 *)p_b;
-	*dest = *a - *b;
+godot_vector2 GDAPI godot_vector2_operator_subtract(const godot_vector2 *p_v, const godot_vector2 p_b) {
+	godot_vector2 dest;
+	Vector2 *d = (Vector2 *)&dest;
+	const Vector2 *v = (Vector2 *)p_v;
+	const Vector2 *b = (Vector2 *)&p_b;
+	*d = *v - *b;
+	return dest;
 }
 
-void GDAPI godot_vector2_operator_multiply_vector(godot_vector2 *p_dest,
-		const godot_vector2 *p_a,
-		const godot_vector2 *p_b) {
-	Vector2 *dest = (Vector2 *)p_dest;
-	const Vector2 *a = (Vector2 *)p_a;
-	const Vector2 *b = (Vector2 *)p_b;
-	*dest = *a * *b;
+godot_vector2 GDAPI godot_vector2_operator_multiply_vector(const godot_vector2 *p_v, const godot_vector2 p_b) {
+	godot_vector2 dest;
+	Vector2 *d = (Vector2 *)&dest;
+	const Vector2 *v = (Vector2 *)p_v;
+	const Vector2 *b = (Vector2 *)&p_b;
+	*d = *v * *b;
+	return dest;
 }
 
-void GDAPI godot_vector2_operator_multiply_scalar(godot_vector2 *p_dest,
-		const godot_vector2 *p_a,
-		const godot_real p_b) {
-	Vector2 *dest = (Vector2 *)p_dest;
-	const Vector2 *a = (Vector2 *)p_a;
-	*dest = *a * p_b;
+godot_vector2 GDAPI godot_vector2_operator_multiply_scalar(const godot_vector2 *p_v, const godot_real p_b) {
+	godot_vector2 dest;
+	Vector2 *d = (Vector2 *)&dest;
+	const Vector2 *v = (Vector2 *)p_v;
+	*d = *v * p_b;
+	return dest;
 }
 
-void GDAPI godot_vector2_operator_divide_vector(godot_vector2 *p_dest,
-		const godot_vector2 *p_a,
-		const godot_vector2 *p_b) {
-	Vector2 *dest = (Vector2 *)p_dest;
-	const Vector2 *a = (Vector2 *)p_a;
-	const Vector2 *b = (Vector2 *)p_b;
-	*dest = *a / *b;
+godot_vector2 GDAPI godot_vector2_operator_divide_vector(const godot_vector2 *p_v, const godot_vector2 p_b) {
+	godot_vector2 dest;
+	Vector2 *d = (Vector2 *)&dest;
+	const Vector2 *v = (Vector2 *)p_v;
+	const Vector2 *b = (Vector2 *)&p_b;
+	*d = *v / *b;
+	return dest;
 }
 
-void GDAPI godot_vector2_operator_divide_scalar(godot_vector2 *p_dest,
-		const godot_vector2 *p_a,
-		const godot_real p_b) {
-	Vector2 *dest = (Vector2 *)p_dest;
-	const Vector2 *a = (Vector2 *)p_a;
-	*dest = *a / p_b;
+godot_vector2 GDAPI godot_vector2_operator_divide_scalar(const godot_vector2 *p_v, const godot_real p_b) {
+	godot_vector2 dest;
+	Vector2 *d = (Vector2 *)&dest;
+	const Vector2 *v = (Vector2 *)p_v;
+	*d = *v / p_b;
+	return dest;
 }
 
-godot_bool GDAPI godot_vector2_operator_equal(const godot_vector2 *p_a,
-		const godot_vector2 *p_b) {
-	const Vector2 *a = (Vector2 *)p_a;
-	const Vector2 *b = (Vector2 *)p_b;
-	return *a == *b;
+godot_bool GDAPI godot_vector2_operator_equal(const godot_vector2 *p_v, const godot_vector2 p_b) {
+	const Vector2 *v = (Vector2 *)p_v;
+	const Vector2 *b = (Vector2 *)&p_b;
+	return *v == *b;
 }
 
-godot_bool GDAPI godot_vector2_operator_less(const godot_vector2 *p_a,
-		const godot_vector2 *p_b) {
-	const Vector2 *a = (Vector2 *)p_a;
-	const Vector2 *b = (Vector2 *)p_b;
-	return *a < *b;
+godot_bool GDAPI godot_vector2_operator_less(const godot_vector2 *p_v, const godot_vector2 p_b) {
+	const Vector2 *v = (Vector2 *)p_v;
+	const Vector2 *b = (Vector2 *)&p_b;
+	return *v < *b;
 }
 
-void GDAPI godot_vector2_abs(godot_vector2 *p_dest,
-		const godot_vector2 *p_src) {
-	const Vector2 *src = (Vector2 *)p_src;
-	Vector2 *dest = (Vector2 *)p_dest;
-	*dest = src->abs();
+godot_vector2 GDAPI godot_vector2_abs(const godot_vector2 *p_v) {
+	godot_vector2 dest;
+	Vector2 *d = (Vector2 *)&dest;
+	const Vector2 *v = (Vector2 *)p_v;
+	*d = v->abs();
+	return dest;
 }
 
-godot_real GDAPI godot_vector2_angle(const godot_vector2 *p_src) {
-	const Vector2 *src = (Vector2 *)p_src;
-	return src->angle();
+godot_real GDAPI godot_vector2_angle(const godot_vector2 *p_v) {
+	const Vector2 *v = (Vector2 *)p_v;
+	return v->angle();
 }
 
-godot_real GDAPI godot_vector2_angle_to(const godot_vector2 *p_src,
-		const godot_vector2 *p_to) {
-	const Vector2 *src = (Vector2 *)p_src;
-	const Vector2 *to = (Vector2 *)p_to;
-	return src->angle_to(*to);
+godot_real GDAPI godot_vector2_angle_to(const godot_vector2 *p_v, const godot_vector2 p_to) {
+	const Vector2 *v = (Vector2 *)p_v;
+	const Vector2 *to = (Vector2 *)&p_to;
+	return v->angle_to(*to);
 }
 
-godot_real GDAPI godot_vector2_angle_to_point(const godot_vector2 *p_src,
-		const godot_vector2 *p_to) {
-	const Vector2 *src = (Vector2 *)p_src;
-	const Vector2 *to = (Vector2 *)p_to;
-	return src->angle_to_point(*to);
+godot_real GDAPI godot_vector2_angle_to_point(const godot_vector2 *p_v, const godot_vector2 p_to) {
+	const Vector2 *v = (Vector2 *)p_v;
+	const Vector2 *to = (Vector2 *)&p_to;
+	return v->angle_to_point(*to);
 }
 
-void GDAPI godot_vector2_clamped(godot_vector2 *p_dest,
-		const godot_vector2 *p_src,
-		godot_real length) {
-	const Vector2 *src = (Vector2 *)p_src;
-	Vector2 *dest = (Vector2 *)p_dest;
-	*dest = src->clamped(length);
+godot_vector2 GDAPI godot_vector2_clamped(const godot_vector2 *p_v, const godot_real length) {
+	godot_vector2 dest;
+	Vector2 *d = (Vector2 *)&dest;
+	const Vector2 *v = (Vector2 *)p_v;
+	*d = v->clamped(length);
+	return dest;
 }
 
-void GDAPI godot_vector2_cubic_interpolate(
-		godot_vector2 *p_dest, const godot_vector2 *p_src, const godot_vector2 *p_b,
-		const godot_vector2 *p_pre_a, const godot_vector2 *p_post_b, godot_real t) {
-	Vector2 *dest = (Vector2 *)p_dest;
-	const Vector2 *src = (Vector2 *)p_src;
-	const Vector2 *b = (Vector2 *)p_b;
-	const Vector2 *pre_a = (Vector2 *)p_pre_a;
-	const Vector2 *post_b = (Vector2 *)p_post_b;
-	*dest = src->cubic_interpolate(*b, *pre_a, *post_b, t);
+godot_vector2 GDAPI godot_vector2_cubic_interpolate(
+		const godot_vector2 *p_v, const godot_vector2 p_b, const godot_vector2 p_pre_a,
+		const godot_vector2 p_post_b, godot_real t) {
+	godot_vector2 dest;
+	Vector2 *d = (Vector2 *)&dest;
+	const Vector2 *v = (Vector2 *)p_v;
+	const Vector2 *b = (Vector2 *)&p_b;
+	const Vector2 *pre_a = (Vector2 *)&p_pre_a;
+	const Vector2 *post_b = (Vector2 *)&p_post_b;
+	*d = v->cubic_interpolate(*b, *pre_a, *post_b, t);
+	return dest;
 }
 
-godot_real GDAPI godot_vector2_dot(const godot_vector2 *p_src,
-		const godot_vector2 *p_with) {
-	const Vector2 *src = (Vector2 *)p_src;
-	const Vector2 *with = (Vector2 *)p_with;
-	return src->dot(*with);
+godot_real GDAPI godot_vector2_dot(const godot_vector2 *p_v, const godot_vector2 p_with) {
+	const Vector2 *v = (Vector2 *)p_v;
+	const Vector2 *with = (Vector2 *)&p_with;
+	return v->dot(*with);
 }
 
-void GDAPI godot_vector2_floor(godot_vector2 *p_dest,
-		const godot_vector2 *p_src) {
-	const Vector2 *src = (Vector2 *)p_src;
-	Vector2 *dest = (Vector2 *)p_dest;
-	*dest = src->floor();
+godot_vector2 GDAPI godot_vector2_floor(const godot_vector2 *p_v) {
+	godot_vector2 dest;
+	Vector2 *d = (Vector2 *)&dest;
+	const Vector2 *v = (Vector2 *)p_v;
+	*d = v->floor();
+	return dest;
 }
 
-godot_real GDAPI godot_vector2_aspect(const godot_vector2 *p_src) {
-	const Vector2 *src = (Vector2 *)p_src;
-	return src->aspect();
+godot_real GDAPI godot_vector2_aspect(const godot_vector2 *p_v) {
+	const Vector2 *v = (Vector2 *)p_v;
+	return v->aspect();
 }
 
-void GDAPI godot_vector2_linear_interpolate(godot_vector2 *p_dest,
-		const godot_vector2 *p_src,
-		const godot_vector2 *p_b,
+godot_vector2 GDAPI godot_vector2_linear_interpolate(
+		const godot_vector2 *p_v,
+		const godot_vector2 p_b,
 		godot_real t) {
-	Vector2 *dest = (Vector2 *)p_dest;
-	const Vector2 *src = (Vector2 *)p_src;
-	const Vector2 *b = (Vector2 *)p_b;
-	*dest = src->linear_interpolate(*b, t);
+	godot_vector2 dest;
+	Vector2 *d = (Vector2 *)&dest;
+	const Vector2 *v = (Vector2 *)p_v;
+	const Vector2 *b = (Vector2 *)&p_b;
+	*d = v->linear_interpolate(*b, t);
+	return dest;
 }
 
-void GDAPI godot_vector2_reflect(godot_vector2 *p_dest,
-		const godot_vector2 *p_src,
-		const godot_vector2 *p_vec) {
-	const Vector2 *src = (Vector2 *)p_src;
-	const Vector2 *vec = (Vector2 *)p_vec;
-	Vector2 *dest = (Vector2 *)p_dest;
-	*dest = src->reflect(*vec);
+godot_vector2 GDAPI godot_vector2_reflect(const godot_vector2 *p_v, const godot_vector2 p_vec) {
+	const Vector2 *v = (Vector2 *)p_v;
+	const Vector2 *vec = (Vector2 *)&p_vec;
+	godot_vector2 dest;
+	Vector2 *d = (Vector2 *)&dest;
+	*d = v->reflect(*vec);
+	return dest;
 }
 
-void GDAPI godot_vector2_rotated(godot_vector2 *p_dest,
-		const godot_vector2 *p_src, godot_real phi) {
-	const Vector2 *src = (Vector2 *)p_src;
-	Vector2 *dest = (Vector2 *)p_dest;
-	*dest = src->rotated(phi);
+godot_vector2 GDAPI godot_vector2_rotated(const godot_vector2 *p_v, godot_real phi) {
+	const Vector2 *v = (Vector2 *)p_v;
+	godot_vector2 dest;
+	Vector2 *d = (Vector2 *)&dest;
+	*d = v->rotated(phi);
+	return dest;
 }
 
-void GDAPI godot_vector2_slide(godot_vector2 *p_dest,
-		const godot_vector2 *p_src,
-		godot_vector2 *p_vec) {
-	const Vector2 *src = (Vector2 *)p_src;
-	const Vector2 *vec = (Vector2 *)p_vec;
-	Vector2 *dest = (Vector2 *)p_dest;
-	*dest = src->slide(*vec);
+godot_vector2 GDAPI godot_vector2_slide(const godot_vector2 *p_v, godot_vector2 p_vec) {
+	godot_vector2 dest;
+	Vector2 *d = (Vector2 *)&dest;
+	const Vector2 *v = (Vector2 *)p_v;
+	const Vector2 *vec = (Vector2 *)&p_vec;
+	*d = v->slide(*vec);
+	return dest;
 }
 
-void GDAPI godot_vector2_snapped(godot_vector2 *p_dest,
-		const godot_vector2 *p_src,
-		godot_vector2 *p_by) {
-	const Vector2 *src = (Vector2 *)p_src;
-	const Vector2 *by = (Vector2 *)p_by;
-	Vector2 *dest = (Vector2 *)p_dest;
-	*dest = src->snapped(*by);
+godot_vector2 GDAPI godot_vector2_snapped(const godot_vector2 *p_v, godot_vector2 p_by) {
+	godot_vector2 dest;
+	Vector2 *d = (Vector2 *)&dest;
+	const Vector2 *v = (Vector2 *)p_v;
+	const Vector2 *by = (Vector2 *)&p_by;
+	*d = v->snapped(*by);
+	return dest;
 }
 
-void GDAPI godot_vector2_tangent(godot_vector2 *p_dest,
-		const godot_vector2 *p_src) {
-	const Vector2 *src = (Vector2 *)p_src;
-	Vector2 *dest = (Vector2 *)p_dest;
-	*dest = src->tangent();
+godot_vector2 GDAPI godot_vector2_tangent(const godot_vector2 *p_v) {
+	godot_vector2 dest;
+	Vector2 *d = (Vector2 *)&dest;
+	const Vector2 *v = (Vector2 *)p_v;
+	*d = v->tangent();
+	return dest;
 }
 
-void GDAPI godot_vector2_to_string(godot_string *p_dest,
-		const godot_vector2 *p_src) {
-	const Vector2 *src = (Vector2 *)p_src;
-	String *dest = (String *)p_dest;
-	*dest = "(" + *src + ")";
+godot_string GDAPI godot_vector2_to_string(const godot_vector2 *p_v) {
+	godot_string dest;
+	String *d = (String *)&dest;
+	const Vector2 *v = (Vector2 *)p_v;
+	*d = "(" + *v + ")";
+	return dest;
 }
 
 #ifdef __cplusplus

--- a/modules/gdnative/godot/godot_vector2.h
+++ b/modules/gdnative/godot/godot_vector2.h
@@ -45,7 +45,7 @@ typedef struct godot_vector2 {
 
 #include "../godot.h"
 
-void GDAPI godot_vector2_new(godot_vector2 *p_v, const godot_real p_x, const godot_real p_y);
+godot_vector2 GDAPI godot_vector2_new(const godot_real p_x, const godot_real p_y);
 
 void GDAPI godot_vector2_set_x(godot_vector2 *p_v, const godot_real p_x);
 void GDAPI godot_vector2_set_y(godot_vector2 *p_v, const godot_real p_y);
@@ -53,43 +53,43 @@ godot_real GDAPI godot_vector2_get_x(const godot_vector2 *p_v);
 godot_real GDAPI godot_vector2_get_y(const godot_vector2 *p_v);
 
 void GDAPI godot_vector2_normalize(godot_vector2 *p_v);
-void GDAPI godot_vector2_normalized(godot_vector2 *p_dest, const godot_vector2 *p_src);
+godot_vector2 GDAPI godot_vector2_normalized(const godot_vector2 *p_v);
 
 godot_real GDAPI godot_vector2_length(const godot_vector2 *p_v);
 godot_real GDAPI godot_vector2_length_squared(const godot_vector2 *p_v);
 
-godot_real GDAPI godot_vector2_distance_to(const godot_vector2 *p_a, const godot_vector2 *p_b);
-godot_real GDAPI godot_vector2_distance_squared_to(const godot_vector2 *p_a, const godot_vector2 *p_b);
+godot_real GDAPI godot_vector2_distance_to(const godot_vector2 *p_v, const godot_vector2 p_b);
+godot_real GDAPI godot_vector2_distance_squared_to(const godot_vector2 *p_v, const godot_vector2 p_b);
 
-void GDAPI godot_vector2_abs(godot_vector2 *p_dest, const godot_vector2 *p_src);
-godot_real GDAPI godot_vector2_angle(const godot_vector2 *p_src);
-godot_real GDAPI godot_vector2_angle_to(const godot_vector2 *p_src, const godot_vector2 *p_to);
-godot_real GDAPI godot_vector2_angle_to_point(const godot_vector2 *p_src, const godot_vector2 *p_to);
-void GDAPI godot_vector2_clamped(godot_vector2 *p_dest, const godot_vector2 *p_src, godot_real length);
-void GDAPI godot_vector2_cubic_interpolate(godot_vector2 *p_dest, const godot_vector2 *p_src,
-		const godot_vector2 *p_b, const godot_vector2 *p_pre_a,
-		const godot_vector2 *p_post_b, godot_real t);
-godot_real GDAPI godot_vector2_dot(const godot_vector2 *p_src, const godot_vector2 *p_with);
-void GDAPI godot_vector2_floor(godot_vector2 *p_dest, const godot_vector2 *p_src);
-godot_real GDAPI godot_vector2_aspect(const godot_vector2 *p_src);
-void GDAPI godot_vector2_linear_interpolate(godot_vector2 *p_dest, const godot_vector2 *p_src,
-		const godot_vector2 *p_b, godot_real t);
-void GDAPI godot_vector2_reflect(godot_vector2 *p_dest, const godot_vector2 *p_src, const godot_vector2 *p_vec);
-void GDAPI godot_vector2_rotated(godot_vector2 *p_dest, const godot_vector2 *p_src, godot_real phi);
-void GDAPI godot_vector2_slide(godot_vector2 *p_dest, const godot_vector2 *p_src, godot_vector2 *p_vec);
-void GDAPI godot_vector2_snapped(godot_vector2 *p_dest, const godot_vector2 *p_src, godot_vector2 *p_by);
-void GDAPI godot_vector2_tangent(godot_vector2 *p_dest, const godot_vector2 *p_src);
-void GDAPI godot_vector2_to_string(godot_string *p_dest, const godot_vector2 *p_src);
+godot_vector2 GDAPI godot_vector2_abs(const godot_vector2 *p_v);
+godot_real GDAPI godot_vector2_angle(const godot_vector2 *p_v);
+godot_real GDAPI godot_vector2_angle_to(const godot_vector2 *p_v, const godot_vector2 p_to);
+godot_real GDAPI godot_vector2_angle_to_point(const godot_vector2 *p_v, const godot_vector2 p_to);
+godot_vector2 GDAPI godot_vector2_clamped(const godot_vector2 *p_v, godot_real length);
+godot_vector2 GDAPI godot_vector2_cubic_interpolate(const godot_vector2 *p_v,
+		const godot_vector2 p_b, const godot_vector2 p_pre_a,
+		const godot_vector2 p_post_b, godot_real t);
+godot_real GDAPI godot_vector2_dot(const godot_vector2 *p_v, const godot_vector2 p_with);
+godot_vector2 GDAPI godot_vector2_floor(const godot_vector2 *p_v);
+godot_real GDAPI godot_vector2_aspect(const godot_vector2 *p_v);
+godot_vector2 GDAPI godot_vector2_linear_interpolate(const godot_vector2 *p_v,
+		const godot_vector2 p_b, godot_real t);
+godot_vector2 GDAPI godot_vector2_reflect(const godot_vector2 *p_v, const godot_vector2 p_vec);
+godot_vector2 GDAPI godot_vector2_rotated(const godot_vector2 *p_v, godot_real phi);
+godot_vector2 GDAPI godot_vector2_slide(const godot_vector2 *p_v, godot_vector2 p_vec);
+godot_vector2 GDAPI godot_vector2_snapped(const godot_vector2 *p_v, godot_vector2 p_by);
+godot_vector2 GDAPI godot_vector2_tangent(const godot_vector2 *p_v);
+godot_string GDAPI godot_vector2_to_string(const godot_vector2 *p_v);
 
-void GDAPI godot_vector2_operator_add(godot_vector2 *p_dest, const godot_vector2 *p_a, const godot_vector2 *p_b);
-void GDAPI godot_vector2_operator_subtract(godot_vector2 *p_dest, const godot_vector2 *p_a, const godot_vector2 *p_b);
-void GDAPI godot_vector2_operator_multiply_vector(godot_vector2 *p_dest, const godot_vector2 *p_a, const godot_vector2 *p_b);
-void GDAPI godot_vector2_operator_multiply_scalar(godot_vector2 *p_dest, const godot_vector2 *p_a, const godot_real p_b);
-void GDAPI godot_vector2_operator_divide_vector(godot_vector2 *p_dest, const godot_vector2 *p_a, const godot_vector2 *p_b);
-void GDAPI godot_vector2_operator_divide_scalar(godot_vector2 *p_dest, const godot_vector2 *p_a, const godot_real p_b);
+godot_vector2 GDAPI godot_vector2_operator_add(const godot_vector2 *p_v, const godot_vector2 p_b);
+godot_vector2 GDAPI godot_vector2_operator_subtract(const godot_vector2 *p_v, const godot_vector2 p_b);
+godot_vector2 GDAPI godot_vector2_operator_multiply_vector(const godot_vector2 *p_v, const godot_vector2 p_b);
+godot_vector2 GDAPI godot_vector2_operator_multiply_scalar(const godot_vector2 *p_v, const godot_real p_b);
+godot_vector2 GDAPI godot_vector2_operator_divide_vector(const godot_vector2 *p_v, const godot_vector2 p_b);
+godot_vector2 GDAPI godot_vector2_operator_divide_scalar(const godot_vector2 *p_v, const godot_real p_b);
 
-godot_bool GDAPI godot_vector2_operator_equal(const godot_vector2 *p_a, const godot_vector2 *p_b);
-godot_bool GDAPI godot_vector2_operator_less(const godot_vector2 *p_a, const godot_vector2 *p_b);
+godot_bool GDAPI godot_vector2_operator_equal(const godot_vector2 *p_v, const godot_vector2 p_b);
+godot_bool GDAPI godot_vector2_operator_less(const godot_vector2 *p_v, const godot_vector2 p_b);
 
 #ifdef __cplusplus
 }

--- a/modules/gdnative/godot/godot_vector3.cpp
+++ b/modules/gdnative/godot/godot_vector3.cpp
@@ -38,9 +38,11 @@ extern "C" {
 void _vector3_api_anchor() {
 }
 
-void GDAPI godot_vector3_new(godot_vector3 *p_v, const godot_real p_x, const godot_real p_y, const godot_real p_z) {
-	Vector3 *v = (Vector3 *)p_v;
+godot_vector3 GDAPI godot_vector3_new(const godot_real p_x, const godot_real p_y, const godot_real p_z) {
+	godot_vector3 value;
+	Vector3 *v = (Vector3 *)&value;
 	*v = Vector3(p_x, p_y, p_z);
+	return value;
 }
 
 void GDAPI godot_vector3_set_axis(godot_vector3 *p_v, const godot_int p_axis, const godot_real p_val) {
@@ -78,217 +80,261 @@ void GDAPI godot_vector3_normalize(godot_vector3 *p_v) {
 	v->normalize();
 }
 
-void GDAPI godot_vector3_normalized(godot_vector3 *p_dest, const godot_vector3 *p_src) {
-	Vector3 *src = (Vector3 *)p_src;
-	Vector3 *dest = (Vector3 *)p_dest;
-	*dest = src->normalized();
+godot_vector3 GDAPI godot_vector3_normalized(const godot_vector3 *p_v) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	Vector3 *v = (Vector3 *)p_v;
+	*d = v->normalized();
+	return dest;
 }
 
-void godot_vector3_inverse(godot_vector3 *p_dest, const godot_vector3 *p_src) {
-	Vector3 *dest = (Vector3 *)p_dest;
-	const Vector3 *src = (Vector3 *)p_src;
-	*dest = src->inverse();
+godot_vector3 godot_vector3_inverse(const godot_vector3 *p_v) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	const Vector3 *v = (Vector3 *)p_v;
+	*d = v->inverse();
+	return dest;
 }
 
-void godot_vector3_zero(godot_vector3 *p_src) {
-	Vector3 *src = (Vector3 *)p_src;
-	src->zero();
+void godot_vector3_zero(godot_vector3 *p_v) {
+	Vector3 *v = (Vector3 *)p_v;
+	v->zero();
 }
 
-void godot_vector3_snap(godot_vector3 *p_src, godot_real val) {
-	Vector3 *src = (Vector3 *)p_src;
-	src->snap(val);
+void godot_vector3_snap(godot_vector3 *p_v, const godot_real val) {
+	Vector3 *v = (Vector3 *)p_v;
+	v->snap(val);
 }
 
-void godot_vector3_snapped(godot_vector3 *p_dest, const godot_vector3 *p_src, godot_real val) {
-	Vector3 *dest = (Vector3 *)p_dest;
-	const Vector3 *src = (Vector3 *)p_src;
-	*dest = src->snapped(val);
+godot_vector3 godot_vector3_snapped(const godot_vector3 *p_v, const godot_real val) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	const Vector3 *v = (Vector3 *)p_v;
+	*d = v->snapped(val);
+	return dest;
 }
 
-void godot_vector3_rotate(godot_vector3 *p_src, const godot_vector3 *p_axis, godot_real phi) {
-	Vector3 *src = (Vector3 *)p_src;
-	const Vector3 *axis = (Vector3 *)p_axis;
-	src->rotate(*axis, phi);
+void godot_vector3_rotate(godot_vector3 *p_v, const godot_vector3 p_axis, const godot_real phi) {
+	Vector3 *v = (Vector3 *)p_v;
+	const Vector3 *axis = (Vector3 *)&p_axis;
+	v->rotate(*axis, phi);
 }
 
-void godot_vector3_rotated(godot_vector3 *p_dest, const godot_vector3 *p_src,
-		const godot_vector3 *p_axis, godot_real phi) {
-	Vector3 *dest = (Vector3 *)p_dest;
-	const Vector3 *src = (Vector3 *)p_src;
-	const Vector3 *axis = (Vector3 *)p_axis;
-	*dest = src->rotated(*axis, phi);
+godot_vector3 godot_vector3_rotated(const godot_vector3 *p_v, const godot_vector3 p_axis, const godot_real phi) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	const Vector3 *v = (Vector3 *)p_v;
+	const Vector3 *axis = (Vector3 *)&p_axis;
+	*d = v->rotated(*axis, phi);
+	return dest;
 }
 
-void godot_vector3_linear_interpolate(godot_vector3 *p_dest, const godot_vector3 *p_src,
-		const godot_vector3 *p_b, godot_real t) {
-	Vector3 *dest = (Vector3 *)p_dest;
-	const Vector3 *src = (Vector3 *)p_src;
-	const Vector3 *b = (Vector3 *)p_b;
-	*dest = src->linear_interpolate(*b, t);
+godot_vector3 godot_vector3_linear_interpolate(const godot_vector3 *p_v, const godot_vector3 p_b, const godot_real t) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	const Vector3 *v = (Vector3 *)p_v;
+	const Vector3 *b = (Vector3 *)&p_b;
+	*d = v->linear_interpolate(*b, t);
+	return dest;
 }
 
-void godot_vector3_cubic_interpolate(godot_vector3 *p_dest, const godot_vector3 *p_src,
-		const godot_vector3 *p_b, const godot_vector3 *p_pre_a,
-		const godot_vector3 *p_post_b, godot_real t) {
-	Vector3 *dest = (Vector3 *)p_dest;
-	const Vector3 *src = (Vector3 *)p_src;
-	const Vector3 *b = (Vector3 *)p_b;
-	const Vector3 *pre_a = (Vector3 *)p_pre_a;
-	const Vector3 *post_b = (Vector3 *)p_post_b;
-	*dest = src->cubic_interpolate(*b, *pre_a, *post_b, t);
+godot_vector3 godot_vector3_cubic_interpolate(const godot_vector3 *p_v,
+		const godot_vector3 p_b, const godot_vector3 p_pre_a,
+		const godot_vector3 p_post_b, const godot_real t) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	const Vector3 *v = (Vector3 *)p_v;
+	const Vector3 *b = (Vector3 *)&p_b;
+	const Vector3 *pre_a = (Vector3 *)&p_pre_a;
+	const Vector3 *post_b = (Vector3 *)&p_post_b;
+	*d = v->cubic_interpolate(*b, *pre_a, *post_b, t);
+	return dest;
 }
 
-void godot_vector3_cubic_interpolaten(godot_vector3 *p_dest, const godot_vector3 *p_src,
-		const godot_vector3 *p_b, const godot_vector3 *p_pre_a,
-		const godot_vector3 *p_post_b, godot_real t) {
-	Vector3 *dest = (Vector3 *)p_dest;
-	const Vector3 *src = (Vector3 *)p_src;
-	const Vector3 *b = (Vector3 *)p_b;
-	const Vector3 *pre_a = (Vector3 *)p_pre_a;
-	const Vector3 *post_b = (Vector3 *)p_post_b;
-	*dest = src->cubic_interpolaten(*b, *pre_a, *post_b, t);
+godot_vector3 godot_vector3_cubic_interpolaten(const godot_vector3 *p_v,
+		const godot_vector3 p_b, const godot_vector3 p_pre_a,
+		const godot_vector3 p_post_b, const godot_real t) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	const Vector3 *v = (Vector3 *)p_v;
+	const Vector3 *b = (Vector3 *)&p_b;
+	const Vector3 *pre_a = (Vector3 *)&p_pre_a;
+	const Vector3 *post_b = (Vector3 *)&p_post_b;
+	*d = v->cubic_interpolaten(*b, *pre_a, *post_b, t);
+	return dest;
 }
 
-void godot_vector3_cross(godot_vector3 *p_dest, const godot_vector3 *p_src, const godot_vector3 *p_b) {
-	Vector3 *dest = (Vector3 *)p_dest;
-	const Vector3 *src = (Vector3 *)p_src;
-	const Vector3 *b = (Vector3 *)p_b;
-	*dest = src->cross(*b);
+godot_vector3 godot_vector3_cross(const godot_vector3 *p_v, const godot_vector3 p_b) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	const Vector3 *v = (Vector3 *)p_v;
+	const Vector3 *b = (Vector3 *)&p_b;
+	*d = v->cross(*b);
+	return dest;
 }
 
-godot_real godot_vector3_dot(const godot_vector3 *p_src, const godot_vector3 *p_b) {
-	const Vector3 *src = (Vector3 *)p_src;
-	const Vector3 *b = (Vector3 *)p_b;
-	return src->dot(*b);
+godot_real godot_vector3_dot(const godot_vector3 *p_v, const godot_vector3 p_b) {
+	const Vector3 *v = (Vector3 *)p_v;
+	const Vector3 *b = (Vector3 *)&p_b;
+	return v->dot(*b);
 }
 
-void godot_vector3_outer(godot_basis *p_dest, const godot_vector3 *p_src, const godot_vector3 *p_b) {
-	Basis *dest = (Basis *)p_dest;
-	const Vector3 *src = (Vector3 *)p_src;
-	const Vector3 *b = (Vector3 *)p_b;
-	*dest = src->outer(*b);
+godot_basis godot_vector3_outer(const godot_vector3 *p_v, const godot_vector3 p_b) {
+	godot_basis dest;
+	Basis *d = (Basis *)&dest;
+	const Vector3 *v = (Vector3 *)p_v;
+	const Vector3 *b = (Vector3 *)&p_b;
+	*d = v->outer(*b);
+	return dest;
 }
 
-void godot_vector3_to_diagonal_matrix(godot_basis *p_dest, const godot_vector3 *p_src) {
-	Basis *dest = (Basis *)p_dest;
-	const Vector3 *src = (Vector3 *)p_src;
-	*dest = src->to_diagonal_matrix();
+godot_basis godot_vector3_to_diagonal_matrix(const godot_vector3 *p_v) {
+	godot_basis dest;
+	Basis *d = (Basis *)&dest;
+	const Vector3 *v = (Vector3 *)p_v;
+	*d = v->to_diagonal_matrix();
+	return dest;
 }
 
-void godot_vector3_abs(godot_vector3 *p_dest, const godot_vector3 *p_src) {
-	Vector3 *dest = (Vector3 *)p_dest;
-	const Vector3 *src = (Vector3 *)p_src;
-	*dest = src->abs();
+godot_vector3 godot_vector3_abs(const godot_vector3 *p_v) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	const Vector3 *v = (Vector3 *)p_v;
+	*d = v->abs();
+	return dest;
 }
 
-void godot_vector3_floor(godot_vector3 *p_dest, const godot_vector3 *p_src) {
-	Vector3 *dest = (Vector3 *)p_dest;
-	const Vector3 *src = (Vector3 *)p_src;
-	*dest = src->floor();
+godot_vector3 godot_vector3_floor(const godot_vector3 *p_v) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	const Vector3 *v = (Vector3 *)p_v;
+	*d = v->floor();
+	return dest;
 }
 
-void godot_vector3_ceil(godot_vector3 *p_dest, const godot_vector3 *p_src) {
-	const Vector3 *src = (Vector3 *)p_src;
-	Vector3 *dest = (Vector3 *)p_dest;
-	*dest = src->ceil();
+godot_vector3 godot_vector3_ceil(const godot_vector3 *p_v) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	const Vector3 *v = (Vector3 *)p_v;
+	*d = v->ceil();
+	return dest;
 }
 
-godot_real GDAPI godot_vector3_distance_to(const godot_vector3 *p_a, const godot_vector3 *p_b) {
-	Vector3 *a = (Vector3 *)p_a;
-	Vector3 *b = (Vector3 *)p_b;
-	return a->distance_to(*b);
+godot_real GDAPI godot_vector3_distance_to(const godot_vector3 *p_v, const godot_vector3 p_b) {
+	Vector3 *v = (Vector3 *)p_v;
+	Vector3 *b = (Vector3 *)&p_b;
+	return v->distance_to(*b);
 }
 
-godot_real GDAPI godot_vector3_distance_squared_to(const godot_vector3 *p_a, const godot_vector3 *p_b) {
-	Vector3 *a = (Vector3 *)p_a;
-	Vector3 *b = (Vector3 *)p_b;
-	return a->distance_squared_to(*b);
+godot_real GDAPI godot_vector3_distance_squared_to(const godot_vector3 *p_v, const godot_vector3 p_b) {
+	Vector3 *v = (Vector3 *)p_v;
+	Vector3 *b = (Vector3 *)&p_b;
+	return v->distance_squared_to(*b);
 }
 
-godot_real GDAPI godot_vector3_angle_to(const godot_vector3 *p_a, const godot_vector3 *p_b) {
-	Vector3 *a = (Vector3 *)p_a;
-	Vector3 *b = (Vector3 *)p_b;
-	return a->angle_to(*b);
+godot_real GDAPI godot_vector3_angle_to(const godot_vector3 *p_v, const godot_vector3 p_b) {
+	Vector3 *v = (Vector3 *)p_v;
+	Vector3 *b = (Vector3 *)&p_b;
+	return v->angle_to(*b);
 }
 
-void godot_vector3_slide(godot_vector3 *p_dest, const godot_vector3 *p_src, const godot_vector3 *p_vec) {
-	const Vector3 *src = (Vector3 *)p_src;
-	const Vector3 *vec = (Vector3 *)p_vec;
-	Vector3 *dest = (Vector3 *)p_dest;
-	*dest = src->slide(*vec);
+godot_vector3 godot_vector3_slide(const godot_vector3 *p_v, const godot_vector3 p_vec) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	const Vector3 *v = (Vector3 *)p_v;
+	const Vector3 *vec = (Vector3 *)&p_vec;
+	*d = v->slide(*vec);
+	return dest;
 }
 
-void godot_vector3_bounce(godot_vector3 *p_dest, const godot_vector3 *p_src, const godot_vector3 *p_vec) {
-	const Vector3 *src = (Vector3 *)p_src;
-	const Vector3 *vec = (Vector3 *)p_vec;
-	Vector3 *dest = (Vector3 *)p_dest;
-	*dest = src->bounce(*vec);
+godot_vector3 godot_vector3_bounce(const godot_vector3 *p_v, const godot_vector3 p_vec) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	const Vector3 *v = (Vector3 *)p_v;
+	const Vector3 *vec = (Vector3 *)&p_vec;
+	*d = v->bounce(*vec);
+	return dest;
 }
 
-void godot_vector3_reflect(godot_vector3 *p_dest, const godot_vector3 *p_src, const godot_vector3 *p_vec) {
-	const Vector3 *src = (Vector3 *)p_src;
-	const Vector3 *vec = (Vector3 *)p_vec;
-	Vector3 *dest = (Vector3 *)p_dest;
-	*dest = src->reflect(*vec);
+godot_vector3 godot_vector3_reflect(const godot_vector3 *p_v, const godot_vector3 p_vec) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	const Vector3 *v = (Vector3 *)p_v;
+	const Vector3 *vec = (Vector3 *)&p_vec;
+	*d = v->reflect(*vec);
+	return dest;
 }
 
-void GDAPI godot_vector3_operator_add(godot_vector3 *p_dest, const godot_vector3 *p_a, const godot_vector3 *p_b) {
-	Vector3 *dest = (Vector3 *)p_dest;
-	Vector3 *a = (Vector3 *)p_a;
-	Vector3 *b = (Vector3 *)p_b;
-	*dest = *a + *b;
+godot_vector3 GDAPI godot_vector3_operator_add(const godot_vector3 *p_v, const godot_vector3 p_b) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	Vector3 *v = (Vector3 *)p_v;
+	Vector3 *b = (Vector3 *)&p_b;
+	*d = *v + *b;
+	return dest;
 }
 
-void GDAPI godot_vector3_operator_subtract(godot_vector3 *p_dest, const godot_vector3 *p_a, const godot_vector3 *p_b) {
-	Vector3 *dest = (Vector3 *)p_dest;
-	Vector3 *a = (Vector3 *)p_a;
-	Vector3 *b = (Vector3 *)p_b;
-	*dest = *a - *b;
+godot_vector3 GDAPI godot_vector3_operator_subtract(const godot_vector3 *p_v, const godot_vector3 p_b) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	Vector3 *v = (Vector3 *)p_v;
+	Vector3 *b = (Vector3 *)&p_b;
+	*d = *v - *b;
+	return dest;
 }
 
-void GDAPI godot_vector3_operator_multiply_vector(godot_vector3 *p_dest, const godot_vector3 *p_a, const godot_vector3 *p_b) {
-	Vector3 *dest = (Vector3 *)p_dest;
-	Vector3 *a = (Vector3 *)p_a;
-	Vector3 *b = (Vector3 *)p_b;
-	*dest = *a * *b;
+godot_vector3 GDAPI godot_vector3_operator_multiply_vector(const godot_vector3 *p_v, const godot_vector3 p_b) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	Vector3 *v = (Vector3 *)p_v;
+	Vector3 *b = (Vector3 *)&p_b;
+	*d = *v * *b;
+	return dest;
 }
 
-void GDAPI godot_vector3_operator_multiply_scalar(godot_vector3 *p_dest, const godot_vector3 *p_a, const godot_real p_b) {
-	Vector3 *dest = (Vector3 *)p_dest;
-	Vector3 *a = (Vector3 *)p_a;
-	*dest = *a * p_b;
+godot_vector3 GDAPI godot_vector3_operator_multiply_scalar(const godot_vector3 *p_v, const godot_real p_b) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	Vector3 *v = (Vector3 *)p_v;
+	*d = *v * p_b;
+	return dest;
 }
 
-void GDAPI godot_vector3_operator_divide_vector(godot_vector3 *p_dest, const godot_vector3 *p_a, const godot_vector3 *p_b) {
-	Vector3 *dest = (Vector3 *)p_dest;
-	Vector3 *a = (Vector3 *)p_a;
-	Vector3 *b = (Vector3 *)p_b;
-	*dest = *a / *b;
+godot_vector3 GDAPI godot_vector3_operator_divide_vector(const godot_vector3 *p_v, const godot_vector3 p_b) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	Vector3 *v = (Vector3 *)p_v;
+	Vector3 *b = (Vector3 *)&p_b;
+	*d = *v / *b;
+	return dest;
 }
 
-void GDAPI godot_vector3_operator_divide_scalar(godot_vector3 *p_dest, const godot_vector3 *p_a, const godot_real p_b) {
-	Vector3 *dest = (Vector3 *)p_dest;
-	Vector3 *a = (Vector3 *)p_a;
-	*dest = *a / p_b;
+godot_vector3 GDAPI godot_vector3_operator_divide_scalar(const godot_vector3 *p_v, const godot_real p_b) {
+	godot_vector3 dest;
+	Vector3 *d = (Vector3 *)&dest;
+	Vector3 *v = (Vector3 *)p_v;
+	*d = *v / p_b;
+	return dest;
 }
 
-godot_bool GDAPI godot_vector3_operator_equal(const godot_vector3 *p_a, const godot_vector3 *p_b) {
-	Vector3 *a = (Vector3 *)p_a;
-	Vector3 *b = (Vector3 *)p_b;
-	return *a == *b;
+godot_bool GDAPI godot_vector3_operator_equal(const godot_vector3 *p_v, const godot_vector3 p_b) {
+	Vector3 *v = (Vector3 *)p_v;
+	Vector3 *b = (Vector3 *)&p_b;
+	return *v == *b;
 }
 
-godot_bool GDAPI godot_vector3_operator_less(const godot_vector3 *p_a, const godot_vector3 *p_b) {
-	Vector3 *a = (Vector3 *)p_a;
-	Vector3 *b = (Vector3 *)p_b;
-	return *a < *b;
+godot_bool GDAPI godot_vector3_operator_less(const godot_vector3 *p_v, const godot_vector3 p_b) {
+	Vector3 *v = (Vector3 *)p_v;
+	Vector3 *b = (Vector3 *)&p_b;
+	return *v < *b;
 }
 
-void GDAPI godot_vector3_to_string(godot_string *p_dest, const godot_vector3 *p_src) {
-	const Vector3 *src = (Vector3 *)p_src;
-	String *dest = (String *)p_dest;
-	*dest = "(" + *src + ")";
+godot_string GDAPI godot_vector3_to_string(const godot_vector3 *p_v) {
+	godot_string dest;
+	String *d = (String *)&dest;
+	const Vector3 *v = (Vector3 *)p_v;
+	*d = "(" + *v + ")";
+	return dest;
 }
 
 #ifdef __cplusplus

--- a/modules/gdnative/godot/godot_vector3.h
+++ b/modules/gdnative/godot/godot_vector3.h
@@ -49,7 +49,7 @@ typedef struct godot_vector3 {
 #include "../godot.h"
 #include "godot_basis.h"
 
-void GDAPI godot_vector3_new(godot_vector3 *p_v, const godot_real p_x, const godot_real p_y, const godot_real p_z);
+godot_vector3 GDAPI godot_vector3_new(const godot_real p_x, const godot_real p_y, const godot_real p_z);
 
 void GDAPI godot_vector3_set_axis(godot_vector3 *p_v, const godot_int p_axis, const godot_real p_val);
 godot_real GDAPI godot_vector3_get_axis(const godot_vector3 *p_v, const godot_int p_axis);
@@ -61,50 +61,50 @@ godot_real GDAPI godot_vector3_length(const godot_vector3 *p_v);
 godot_real GDAPI godot_vector3_length_squared(const godot_vector3 *p_v);
 
 void GDAPI godot_vector3_normalize(godot_vector3 *p_v);
-void GDAPI godot_vector3_normalized(godot_vector3 *p_dest, const godot_vector3 *p_src);
+godot_vector3 GDAPI godot_vector3_normalized(const godot_vector3 *p_v);
 
-void GDAPI godot_vector3_inverse(godot_vector3 *p_dest, const godot_vector3 *p_src);
-void GDAPI godot_vector3_zero(godot_vector3 *p_src);
-void GDAPI godot_vector3_snap(godot_vector3 *p_src, godot_real val);
-void GDAPI godot_vector3_snapped(godot_vector3 *p_dest, const godot_vector3 *p_src, godot_real val);
-void GDAPI godot_vector3_rotate(godot_vector3 *p_src, const godot_vector3 *p_axis, godot_real phi);
-void GDAPI godot_vector3_rotated(godot_vector3 *p_dest, const godot_vector3 *p_src,
-		const godot_vector3 *p_axis, godot_real phi);
-void GDAPI godot_vector3_linear_interpolate(godot_vector3 *p_dest, const godot_vector3 *p_src,
-		const godot_vector3 *p_b, godot_real t);
-void GDAPI godot_vector3_cubic_interpolate(godot_vector3 *p_dest, const godot_vector3 *p_src,
-		const godot_vector3 *p_b, const godot_vector3 *p_pre_a,
-		const godot_vector3 *p_post_b, godot_real t);
-void GDAPI godot_vector3_cubic_interpolaten(godot_vector3 *p_dest, const godot_vector3 *p_src,
-		const godot_vector3 *p_b, const godot_vector3 *p_pre_a,
-		const godot_vector3 *p_post_b, godot_real t);
-void GDAPI godot_vector3_cross(godot_vector3 *p_dest, const godot_vector3 *p_src, const godot_vector3 *p_b);
-godot_real GDAPI godot_vector3_dot(const godot_vector3 *p_src, const godot_vector3 *p_b);
-void GDAPI godot_vector3_outer(godot_basis *dest, const godot_vector3 *p_src, const godot_vector3 *p_b);
-void GDAPI godot_vector3_to_diagonal_matrix(godot_basis *dest, const godot_vector3 *p_src);
-void GDAPI godot_vector3_abs(godot_vector3 *p_dest, const godot_vector3 *p_src);
-void GDAPI godot_vector3_floor(godot_vector3 *p_dest, const godot_vector3 *p_src);
-void GDAPI godot_vector3_ceil(godot_vector3 *p_dest, const godot_vector3 *p_src);
+godot_vector3 GDAPI godot_vector3_inverse(const godot_vector3 *p_v);
+void GDAPI godot_vector3_zero(godot_vector3 *p_v);
+void GDAPI godot_vector3_snap(godot_vector3 *p_v, const godot_real val);
+godot_vector3 GDAPI godot_vector3_snapped(const godot_vector3 *p_v, const godot_real val);
+void GDAPI godot_vector3_rotate(godot_vector3 *p_v, const godot_vector3 p_axis, const godot_real phi);
+godot_vector3 GDAPI godot_vector3_rotated(const godot_vector3 *p_v,
+		const godot_vector3 p_axis, const godot_real phi);
+godot_vector3 GDAPI godot_vector3_linear_interpolate(const godot_vector3 *p_v,
+		const godot_vector3 p_b, const godot_real t);
+godot_vector3 GDAPI godot_vector3_cubic_interpolate(const godot_vector3 *p_v,
+		const godot_vector3 p_b, const godot_vector3 p_pre_a,
+		const godot_vector3 p_post_b, const godot_real t);
+godot_vector3 GDAPI godot_vector3_cubic_interpolaten(const godot_vector3 *p_v,
+		const godot_vector3 p_b, const godot_vector3 p_pre_a,
+		const godot_vector3 p_post_b, const godot_real t);
+godot_vector3 GDAPI godot_vector3_cross(const godot_vector3 *p_v, const godot_vector3 p_b);
+godot_real GDAPI godot_vector3_dot(const godot_vector3 *p_v, const godot_vector3 p_b);
+godot_basis GDAPI godot_vector3_outer(const godot_vector3 *p_v, const godot_vector3 p_b);
+godot_basis GDAPI godot_vector3_to_diagonal_matrix(const godot_vector3 *p_v);
+godot_vector3 GDAPI godot_vector3_abs(const godot_vector3 *p_v);
+godot_vector3 GDAPI godot_vector3_floor(const godot_vector3 *p_v);
+godot_vector3 GDAPI godot_vector3_ceil(const godot_vector3 *p_v);
 
-godot_real GDAPI godot_vector3_distance_to(const godot_vector3 *p_a, const godot_vector3 *p_b);
-godot_real GDAPI godot_vector3_distance_squared_to(const godot_vector3 *p_a, const godot_vector3 *p_b);
-godot_real GDAPI godot_vector3_angle_to(const godot_vector3 *p_a, const godot_vector3 *p_b);
+godot_real GDAPI godot_vector3_distance_to(const godot_vector3 *p_v, const godot_vector3 p_b);
+godot_real GDAPI godot_vector3_distance_squared_to(const godot_vector3 *p_v, const godot_vector3 p_b);
+godot_real GDAPI godot_vector3_angle_to(const godot_vector3 *p_v, const godot_vector3 p_b);
 
-void GDAPI godot_vector3_slide(godot_vector3 *p_dest, const godot_vector3 *p_src, const godot_vector3 *p_vec);
-void GDAPI godot_vector3_bounce(godot_vector3 *p_dest, const godot_vector3 *p_src, const godot_vector3 *p_vec);
-void GDAPI godot_vector3_reflect(godot_vector3 *p_dest, const godot_vector3 *p_src, const godot_vector3 *p_vec);
+godot_vector3 GDAPI godot_vector3_slide(const godot_vector3 *p_v, const godot_vector3 p_vec);
+godot_vector3 GDAPI godot_vector3_bounce(const godot_vector3 *p_v, const godot_vector3 p_vec);
+godot_vector3 GDAPI godot_vector3_reflect(const godot_vector3 *p_v, const godot_vector3 p_vec);
 
-void GDAPI godot_vector3_operator_add(godot_vector3 *p_dest, const godot_vector3 *p_a, const godot_vector3 *p_b);
-void GDAPI godot_vector3_operator_subtract(godot_vector3 *p_dest, const godot_vector3 *p_a, const godot_vector3 *p_b);
-void GDAPI godot_vector3_operator_multiply_vector(godot_vector3 *p_dest, const godot_vector3 *p_a, const godot_vector3 *p_b);
-void GDAPI godot_vector3_operator_multiply_scalar(godot_vector3 *p_dest, const godot_vector3 *p_a, const godot_real p_b);
-void GDAPI godot_vector3_operator_divide_vector(godot_vector3 *p_dest, const godot_vector3 *p_a, const godot_vector3 *p_b);
-void GDAPI godot_vector3_operator_divide_scalar(godot_vector3 *p_dest, const godot_vector3 *p_a, const godot_real p_b);
+godot_vector3 GDAPI godot_vector3_operator_add(const godot_vector3 *p_v, const godot_vector3 p_b);
+godot_vector3 GDAPI godot_vector3_operator_subtract(const godot_vector3 *p_v, const godot_vector3 p_b);
+godot_vector3 GDAPI godot_vector3_operator_multiply_vector(const godot_vector3 *p_v, const godot_vector3 p_b);
+godot_vector3 GDAPI godot_vector3_operator_multiply_scalar(const godot_vector3 *p_v, const godot_real p_b);
+godot_vector3 GDAPI godot_vector3_operator_divide_vector(const godot_vector3 *p_v, const godot_vector3 p_b);
+godot_vector3 GDAPI godot_vector3_operator_divide_scalar(const godot_vector3 *p_v, const godot_real p_b);
 
-godot_bool GDAPI godot_vector3_operator_equal(const godot_vector3 *p_a, const godot_vector3 *p_b);
-godot_bool GDAPI godot_vector3_operator_less(const godot_vector3 *p_a, const godot_vector3 *p_b);
+godot_bool GDAPI godot_vector3_operator_equal(const godot_vector3 *p_v, const godot_vector3 p_b);
+godot_bool GDAPI godot_vector3_operator_less(const godot_vector3 *p_v, const godot_vector3 p_b);
 
-void GDAPI godot_vector3_to_string(godot_string *p_dest, const godot_vector3 *p_src);
+godot_string GDAPI godot_vector3_to_string(const godot_vector3 *p_v);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR does two things:
- Correct Vector2&Vector3 function signature to copy Godot Variant's policy concerning passing by value vs by pointer (i.e. small object like Vector3 are always passed by value where bigger like Basis are passed by pointer), as dicussed with @karroffel 
- Implement `godot_basis` missing functions
