### PR TITLE
Fix error for loading icon image at start up

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1404,6 +1404,7 @@ bool Main::start() {
 
 				String iconpath = GLOBAL_DEF("application/icon", "Variant()");
 				if (iconpath != "") {
+					iconpath = PathRemap::get_singleton()->get_remap(iconpath);
 					Image icon;
 					if (icon.load(iconpath) == OK)
 						OS::get_singleton()->set_icon(icon);


### PR DESCRIPTION
This will fix error below at starting up game if project has converting images to webp at Project export settings > Images.
```
ERROR: load_image: Error opening file: res://icon.png
   At: core/io/image_loader.cpp:53.
```

note that this does not fix changing application icon.