### PR TITLE
[GDNative] explicit calling convention

### DIFF
--- a/modules/gdnative/gdnative.cpp
+++ b/modules/gdnative/gdnative.cpp
@@ -424,7 +424,6 @@ Variant GDNativeScript::_new(const Variant **p_args, int p_argcount, Variant::Ca
 	// @Todo support varargs for constructors.
 	GDNativeInstance *instance = (GDNativeInstance *)instance_create(owner);
 
-	owner->set_script(Ref<GDNativeScript>(this).get_ref_ptr());
 	owner->set_script_instance(instance);
 	if (!instance) {
 		if (ref.is_null()) {


### PR DESCRIPTION
There was no explicitly defined calling convention for function pointers used in GDNative.

This makes it easier (and more predicatble) for other compilers to generate working code.