### PR TITLE
[GDNative] fixed msvc build

### DIFF
--- a/modules/gdnative/godot.h
+++ b/modules/gdnative/godot.h
@@ -40,10 +40,10 @@ extern "C" {
 
 #ifdef _WIN32
 #if defined(GDAPI_EXPORT)
-#define GDCALLINGCONV __cdecl
+#define GDCALLINGCONV
 #define GDAPI __declspec(dllexport) GDCALLINGCONV
 #else
-#define GDCALLINGCONV __cdecl
+#define GDCALLINGCONV
 #define GDAPI __declspec(dllimport) GDCALLINGCONV
 #endif
 #elif defined(__APPLE__)


### PR DESCRIPTION
On windows `__cdecl` is the default anyway