### PR TITLE
Fix template loading

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -321,6 +321,11 @@ Error EditorExportPlatform::_save_zip_file(void *p_userdata, const String &p_pat
 
 String EditorExportPlatform::find_export_template(String template_file_name) const {
 
+	return find_export_template(template_file_name, NULL);
+}
+
+String EditorExportPlatform::find_export_template(String template_file_name, String *err) const {
+
 	String base_name = itos(VERSION_MAJOR) + "." + itos(VERSION_MINOR) + "-" + _MKSTR(VERSION_STATUS) + "/" + template_file_name;
 	String user_file = EditorSettings::get_singleton()->get_settings_path() + "/templates/" + base_name;
 	String system_file = OS::get_singleton()->get_installed_templates_path();
@@ -340,9 +345,20 @@ String EditorExportPlatform::find_export_template(String template_file_name) con
 			return system_file;
 		}
 	}
-	print_line("none,sorry");
 
-	return String(); //not found
+	// Not found
+	if (err) {
+		*err += "No export template found at \"" + user_file + "\"";
+		if (has_system_path)
+			*err += "\n or \"" + system_file + "\".";
+		else
+			*err += ".";
+	}
+	return String(); // not found
+}
+
+bool EditorExportPlatform::exists_export_template(String template_file_name, String *err) const {
+	return find_export_template(template_file_name, err) != "";
 }
 
 Ref<EditorExportPreset> EditorExportPlatform::create_preset() {
@@ -923,19 +939,47 @@ Ref<Texture> EditorExportPlatformPC::get_logo() const {
 
 bool EditorExportPlatformPC::can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const {
 
-	r_missing_templates = false;
+	String err;
+	bool valid = true;
 
-	if (find_export_template(release_file_32) == String()) {
-		r_missing_templates = true;
-	} else if (find_export_template(debug_file_32) == String()) {
-		r_missing_templates = true;
-	} else if (find_export_template(release_file_64) == String()) {
-		r_missing_templates = true;
-	} else if (find_export_template(debug_file_64) == String()) {
-		r_missing_templates = true;
+	if (use64 && (!exists_export_template(debug_file_64, &err) || !exists_export_template(release_file_64, &err))) {
+		valid = false;
 	}
 
-	return !r_missing_templates;
+	if (!use64 && (!exists_export_template(debug_file_32, &err) || !exists_export_template(release_file_32, &err))) {
+		valid = false;
+	}
+
+	String custom_debug_binary = p_preset->get("custom_template/debug");
+	String custom_release_binary = p_preset->get("custom_template/release");
+
+	if (custom_debug_binary == "" && custom_release_binary == "") {
+		if (!err.empty())
+			r_error = err;
+		return valid;
+	}
+
+	bool dvalid = true;
+	bool rvalid = true;
+
+	if (!FileAccess::exists(custom_debug_binary)) {
+		dvalid = false;
+		err = "Custom debug binary not found.\n";
+	}
+
+	if (!FileAccess::exists(custom_release_binary)) {
+		rvalid = false;
+		err += "Custom release binary not found.\n";
+	}
+
+	if (dvalid || rvalid)
+		valid = true;
+	else
+		valid = false;
+
+	if (!err.empty())
+		r_error = err;
+	return valid;
 }
 
 String EditorExportPlatformPC::get_binary_extension() const {
@@ -1493,40 +1537,6 @@ Vector<StringName> EditorExportPlatform::get_dependencies(bool p_bundles) const 
 
 	return ret;
 
-}
-
-String EditorExportPlatform::find_export_template(String template_file_name, String *err) const {
-	String user_file = EditorSettings::get_singleton()->get_settings_path()
-		+"/templates/"+template_file_name;
-	String system_file=OS::get_singleton()->get_installed_templates_path();
-	bool has_system_path=(system_file!="");
-	system_file+=template_file_name;
-
-	// Prefer user file
-	if (FileAccess::exists(user_file)) {
-		return user_file;
-	}
-
-	// Now check system file
-	if (has_system_path) {
-		if (FileAccess::exists(system_file)) {
-			return system_file;
-		}
-	}
-
-	// Not found
-	if (err) {
-		*err+="No export template found at \""+user_file+"\"";
-		if (has_system_path)
-			*err+="\n or \""+system_file+"\".";
-		else
-			*err+=".";
-	}
-	return "";
-}
-
-bool EditorExportPlatform::exists_export_template(String template_file_name, String *err) const {
-	return find_export_template(template_file_name,err)!="";
 }
 
 ///////////////////////////////////////
@@ -2427,50 +2437,6 @@ void EditorExportPlatformPC::set_binary_extension(const String& p_extension) {
 
 	binary_extension=p_extension;
 }
-
-bool EditorExportPlatformPC::can_export(String *r_error) const {
-
-	String err;
-	bool valid=true;
-
-	if (use64 && (!exists_export_template(debug_binary64) || !exists_export_template(release_binary64))) {
-		valid=false;
-		err="No 64 bits export templates found.\nDownload and install export templates.\n";
-	}
-
-	if (!use64 && (!exists_export_template(debug_binary32) || !exists_export_template(release_binary32))) {
-		valid=false;
-		err="No 32 bits export templates found.\nDownload and install export templates.\n";
-	}
-
-	if(custom_debug_binary=="" && custom_release_binary=="") {
-		if (r_error) *r_error=err;
-		return valid;
-	}
-
-	bool dvalid = true;
-	bool rvalid = true;
-
-	if(!FileAccess::exists(custom_debug_binary)) {
-		dvalid = false;
-		err = "Custom debug binary not found.\n";
-	}
-
-	if(!FileAccess::exists(custom_release_binary)) {
-		rvalid = false;
-		err = "Custom release binary not found.\n";
-	}
-
-	if (dvalid || rvalid)
-		valid = true;
-	else
-		valid = false;
-
-	if (r_error)
-		*r_error=err;
-	return valid;
-}
-
 
 EditorExportPlatformPC::EditorExportPlatformPC() {
 

--- a/editor/editor_export.h
+++ b/editor/editor_export.h
@@ -154,7 +154,9 @@ private:
 
 protected:
 	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) = 0;
+	bool exists_export_template(String template_file_name, String *err) const;
 	String find_export_template(String template_file_name) const;
+	String find_export_template(String template_file_name, String *err) const;
 	void gen_export_flags(Vector<String> &r_flags, int p_flags);
 
 public:
@@ -257,6 +259,8 @@ class EditorExportPlatformPC : public EditorExportPlatform {
 	String release_file_64;
 	String debug_file_32;
 	String debug_file_64;
+
+	bool use64;
 
 public:
 	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features);

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -229,6 +229,8 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 		}
 		if (needs_templates)
 			export_templates_error->show();
+		else
+			export_templates_error->hide();
 
 		export_button->set_disabled(true);
 


### PR DESCRIPTION
Template loading was broken for Windows and Linux, even with custom templates it disabled the export button if default templates were not found. 

Also with binary type = 64 bits and only 64 bit templates present it still disabled the export.
This fixes said errors, although a fair cleanup of `editor_export.cpp` is due, a large part of it is `#if 0`'ed away and the code to fix this was actually there, just dead.

Just found 96de0141ccef3bb035574010816dafdbfc17eb63 which does that and states that the import / export system is due a rewrite, well hope this fix helps in the meantime.