### PR TITLE
Fix property warnings and hide some debug prints

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -179,10 +179,10 @@ RES ResourceLoader::load(const String &p_path, const String &p_type_hint, bool p
 		print_line("load resource: " + local_path);
 	bool found = false;
 
+	// Try all loaders and pick the first match for the type hint
 	for (int i = 0; i < loader_count; i++) {
 
 		if (!loader[i]->recognize_path(local_path, p_type_hint)) {
-			print_line("path not recognized");
 			continue;
 		}
 		found = true;

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -125,14 +125,13 @@ void RasterizerSceneGLES3::shadow_atlas_set_size(RID p_atlas, int p_size) {
 	if (p_size == shadow_atlas->size)
 		return;
 
+	// erasing atlas
 	if (shadow_atlas->fbo) {
 		glDeleteTextures(1, &shadow_atlas->depth);
 		glDeleteFramebuffers(1, &shadow_atlas->fbo);
 
 		shadow_atlas->depth = 0;
 		shadow_atlas->fbo = 0;
-
-		print_line("erasing atlas");
 	}
 	for (int i = 0; i < 4; i++) {
 		//clear subdivisions
@@ -4678,7 +4677,7 @@ void RasterizerSceneGLES3::initialize() {
 		const int ubo_light_size = 160;
 		state.ubo_light_size = ubo_light_size;
 		state.max_ubo_lights = MIN(RenderList::MAX_LIGHTS, max_ubo_size / ubo_light_size);
-		print_line("max ubo light: " + itos(state.max_ubo_lights));
+		print_line("GLES3: max ubo light: " + itos(state.max_ubo_lights));
 
 		state.spot_array_tmp = (uint8_t *)memalloc(ubo_light_size * state.max_ubo_lights);
 		state.omni_array_tmp = (uint8_t *)memalloc(ubo_light_size * state.max_ubo_lights);
@@ -4704,7 +4703,7 @@ void RasterizerSceneGLES3::initialize() {
 		state.scene_shader.add_custom_define("#define MAX_FORWARD_LIGHTS " + itos(state.max_forward_lights_per_object) + "\n");
 
 		state.max_ubo_reflections = MIN(RenderList::MAX_REFLECTIONS, max_ubo_size / sizeof(ReflectionProbeDataUBO));
-		print_line("max ubo reflections: " + itos(state.max_ubo_reflections) + "  ubo size: " + itos(sizeof(ReflectionProbeDataUBO)));
+		print_line("GLES3: max ubo reflections: " + itos(state.max_ubo_reflections) + ", ubo size: " + itos(sizeof(ReflectionProbeDataUBO)));
 
 		state.reflection_array_tmp = (uint8_t *)memalloc(sizeof(ReflectionProbeDataUBO) * state.max_ubo_reflections);
 

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -825,7 +825,6 @@ Image RasterizerStorageGLES3::texture_get_data(RID p_texture, VS::CubeMapSide p_
 	if (!texture->images[p_cube_side].empty()) {
 		return texture->images[p_cube_side];
 	}
-	print_line("GETTING FROM GL ");
 
 #ifdef GLES_OVER_GL
 
@@ -842,7 +841,7 @@ Image RasterizerStorageGLES3::texture_get_data(RID p_texture, VS::CubeMapSide p_
 
 	glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
 
-	print_line("GET FORMAT: " + Image::get_format_name(texture->format) + " mipmaps: " + itos(texture->mipmaps));
+	//print_line("GET FORMAT: " + Image::get_format_name(texture->format) + " mipmaps: " + itos(texture->mipmaps));
 
 	for (int i = 0; i < texture->mipmaps; i++) {
 
@@ -4777,7 +4776,6 @@ RID RasterizerStorageGLES3::gi_probe_dynamic_data_create(int p_width, int p_heig
 		min_size = 4;
 	}
 
-	print_line("dyndata create");
 	while (true) {
 
 		if (gipd->compression == GI_PROBE_S3TC) {
@@ -6270,7 +6268,6 @@ bool RasterizerStorageGLES3::free(RID p_rid) {
 		// delete the texture
 		GIProbeData *gi_probe_data = gi_probe_data_owner.get(p_rid);
 
-		print_line("dyndata delete");
 		glDeleteTextures(1, &gi_probe_data->tex_id);
 		gi_probe_owner.free(p_rid);
 		memdelete(gi_probe_data);
@@ -6333,9 +6330,8 @@ void RasterizerStorageGLES3::initialize() {
 	{
 
 		int max_extensions = 0;
-		print_line("getting extensions");
 		glGetIntegerv(GL_NUM_EXTENSIONS, &max_extensions);
-		print_line("total " + itos(max_extensions));
+		print_line("GLES3: max extensions: " + itos(max_extensions));
 		for (int i = 0; i < max_extensions; i++) {
 			const GLubyte *s = glGetStringi(GL_EXTENSIONS, i);
 			if (!s)

--- a/drivers/gles3/shader_compiler_gles3.cpp
+++ b/drivers/gles3/shader_compiler_gles3.cpp
@@ -410,7 +410,6 @@ String ShaderCompilerGLES3::_dump_node_code(SL::Node *p_node, int p_level, Gener
 
 				if (fnode->name == "vertex") {
 
-					print_line("vertex uses functions: " + itos(pnode->functions[i].uses_function.size()));
 					_dump_function_deps(pnode, fnode->name, function_code, r_gen_code.vertex_global, added_vtx);
 					r_gen_code.vertex = function_code["vertex"];
 				}

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -102,7 +102,6 @@ float AudioDriverPulseAudio::get_latency() {
 
 void AudioDriverPulseAudio::thread_func(void *p_udata) {
 
-	print_line("thread");
 	AudioDriverPulseAudio *ad = (AudioDriverPulseAudio *)p_udata;
 
 	while (!ad->exit_thread) {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -435,7 +435,7 @@ void EditorNode::_sources_changed(bool p_exist) {
 
 		if (defer_load_scene != "") {
 
-			print_line("loading scene DEFERED");
+			print_line("loading scene DEFERRED");
 			load_scene(defer_load_scene);
 			defer_load_scene = "";
 		}
@@ -6051,7 +6051,10 @@ EditorNode::EditorNode() {
 	{
 
 		_initializing_addons = true;
-		Vector<String> addons = GlobalConfig::get_singleton()->get("editor_plugins/enabled");
+		Vector<String> addons;
+		if (GlobalConfig::get_singleton()->has("editor_plugins/enabled")) {
+			addons = GlobalConfig::get_singleton()->get("editor_plugins/enabled");
+		}
 
 		for (int i = 0; i < addons.size(); i++) {
 			set_addon_plugin_enabled(addons[i], true);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -407,7 +407,7 @@ void EditorSettings::setup_network() {
 	IP::get_singleton()->get_local_addresses(&local_ip);
 	String lip;
 	String hint;
-	String current = get("network/debug_host");
+	String current = has("network/debug_host") ? get("network/debug_host") : "";
 
 	for (List<IP_Address>::Element *E = local_ip.front(); E; E = E->next()) {
 
@@ -591,9 +591,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("editors/2d/bone_color2", Color(0.75, 0.75, 0.75, 0.9));
 	set("editors/2d/bone_selected_color", Color(0.9, 0.45, 0.45, 0.9));
 	set("editors/2d/bone_ik_color", Color(0.9, 0.9, 0.45, 0.9));
-
 	set("editors/2d/keep_margins_when_changing_anchors", false);
-
 	set("editors/2d/warped_mouse_panning", true);
 
 	set("run/window_placement/rect", 0);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1211,7 +1211,7 @@ ProjectManager::ProjectManager() {
 		}
 	}
 
-	FileDialog::set_default_show_hidden_files(EditorSettings::get_singleton()->get("filesytem/file_dialog/show_hidden_files"));
+	FileDialog::set_default_show_hidden_files(EditorSettings::get_singleton()->get("filesystem/file_dialog/show_hidden_files"));
 
 	set_area_as_parent_rect();
 	set_theme(create_editor_theme());

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -697,7 +697,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		video_mode.width = globals->get("display/window/width");
 	if (!force_res && use_custom_res && globals->has("display/window/height"))
 		video_mode.height = globals->get("display/window/height");
-	if (!editor && (!bool(globals->get("display/window/allow_hidpi")) || force_lowdpi)) {
+	if (!editor && ((globals->has("display/window/allow_hidpi") && !globals->get("display/window/allow_hidpi")) || force_lowdpi)) {
 		OS::get_singleton()->_allow_hidpi = false;
 	}
 	if (use_custom_res && globals->has("display/window/fullscreen"))

--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -144,12 +144,14 @@ RES ResourceFormatDDS::load(const String &p_path, const String &p_original_path,
 	f->get_32();
 	f->get_32();
 
-	/*print_line("DDS width: "+itos(width));
+	/*
+	print_line("DDS width: "+itos(width));
 	print_line("DDS height: "+itos(height));
-	print_line("DDS mipmaps: "+itos(mipmaps));*/
+	print_line("DDS mipmaps: "+itos(mipmaps));
 
-	//printf("fourcc: %x fflags: %x, rgbbits: %x, fsize: %x\n",format_fourcc,format_flags,format_rgb_bits,format_size);
-	//printf("rmask: %x gmask: %x, bmask: %x, amask: %x\n",format_red_mask,format_green_mask,format_blue_mask,format_alpha_mask);
+	printf("fourcc: %x fflags: %x, rgbbits: %x, fsize: %x\n",format_fourcc,format_flags,format_rgb_bits,format_size);
+	printf("rmask: %x gmask: %x, bmask: %x, amask: %x\n",format_red_mask,format_green_mask,format_blue_mask,format_alpha_mask);
+	*/
 
 	//must avoid this later
 	while (f->get_pos() < 128)

--- a/modules/webp/image_loader_webp.cpp
+++ b/modules/webp/image_loader_webp.cpp
@@ -87,9 +87,11 @@ static Image _webp_lossy_unpack(const PoolVector<uint8_t> &p_buffer) {
 		ERR_FAIL_V(Image());
 	}
 
-	//print_line("width: "+itos(features.width));
-	//print_line("height: "+itos(features.height));
-	//print_line("alpha: "+itos(features.has_alpha));
+	/*
+	print_line("width: "+itos(features.width));
+	print_line("height: "+itos(features.height));
+	print_line("alpha: "+itos(features.has_alpha));
+	*/
 
 	PoolVector<uint8_t> dst_image;
 	int datasize = features.width * features.height * (features.has_alpha ? 4 : 3);
@@ -130,9 +132,11 @@ Error ImageLoaderWEBP::load_image(Image *p_image, FileAccess *f) {
 		ERR_FAIL_V(ERR_FILE_CORRUPT);
 	}
 
+	/*
 	print_line("width: " + itos(features.width));
 	print_line("height: " + itos(features.height));
 	print_line("alpha: " + itos(features.has_alpha));
+	*/
 
 	src_w = PoolVector<uint8_t>::Write();
 

--- a/platform/x11/context_gl_x11.cpp
+++ b/platform/x11/context_gl_x11.cpp
@@ -152,8 +152,6 @@ Error ContextGL_X11::initialize() {
 	XSync(x11_display, False);
 	XSetErrorHandler(oldHandler);
 
-	print_line("ALL IS GOOD");
-
 	glXMakeCurrent(x11_display, x11_window, p->glx_context);
 
 	/*

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -459,25 +459,27 @@ Error StreamTexture::_load_data(const String &p_path, int &tw, int &th, int &fla
 	flags = f->get_32(); //texture flags!
 	uint32_t df = f->get_32(); //data format
 
+	/*
 	print_line("width: " + itos(tw));
 	print_line("height: " + itos(th));
 	print_line("flags: " + itos(flags));
 	print_line("df: " + itos(df));
+	*/
 
 	if (request_3d_callback && df & FORMAT_BIT_DETECT_3D) {
-		print_line("request detect 3D at " + p_path);
+		//print_line("request detect 3D at " + p_path);
 		VS::get_singleton()->texture_set_detect_3d_callback(texture, _requested_3d, this);
 	} else {
-		print_line("not requesting detect 3D at " + p_path);
+		//print_line("not requesting detect 3D at " + p_path);
 		VS::get_singleton()->texture_set_detect_3d_callback(texture, NULL, NULL);
 	}
 
 	if (request_srgb_callback && df & FORMAT_BIT_DETECT_SRGB) {
-		print_line("request detect srgb at " + p_path);
+		//print_line("request detect srgb at " + p_path);
 		VS::get_singleton()->texture_set_detect_srgb_callback(texture, _requested_srgb, this);
 	} else {
+		//print_line("not requesting detect srgb at " + p_path);
 		VS::get_singleton()->texture_set_detect_srgb_callback(texture, NULL, NULL);
-		print_line("not requesting detect srgb at " + p_path);
 	}
 
 	if (!(df & FORMAT_BIT_STREAM)) {
@@ -493,7 +495,7 @@ Error StreamTexture::_load_data(const String &p_path, int &tw, int &th, int &fla
 		uint32_t mipmaps = f->get_32();
 		uint32_t size = f->get_32();
 
-		print_line("mipmaps: " + itos(mipmaps));
+		//print_line("mipmaps: " + itos(mipmaps));
 
 		while (mipmaps > 1 && p_size_limit > 0 && (sw > p_size_limit || sh > p_size_limit)) {
 
@@ -539,7 +541,7 @@ Error StreamTexture::_load_data(const String &p_path, int &tw, int &th, int &fla
 			mipmap_images.push_back(img);
 		}
 
-		print_line("mipmap read total: " + itos(mipmap_images.size()));
+		//print_line("mipmap read total: " + itos(mipmap_images.size()));
 
 		memdelete(f); //no longer needed
 
@@ -626,7 +628,7 @@ Error StreamTexture::_load_data(const String &p_path, int &tw, int &th, int &fla
 			{
 				PoolVector<uint8_t>::Write w = img_data.write();
 				int bytes = f->get_buffer(w.ptr(), total_size - ofs);
-				print_line("requested read: " + itos(total_size - ofs) + " but got: " + itos(bytes));
+				//print_line("requested read: " + itos(total_size - ofs) + " but got: " + itos(bytes));
 
 				memdelete(f);
 


### PR DESCRIPTION
"ALL IS GOOD" was a lie.

In particular, removes verbose "path not recognized" false positive.

The actual logic is to (somewhat naively) check all ResourceFormatLoaders
and to pick the first good match, so no need to warn about the formats
that do not match the type hint.

I debugged it this way to be sure:
```
diff --git a/core/io/resource_loader.cpp b/core/io/resource_loader.cpp
index 2a6e60d..baa2e3f 100644
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -181,9 +181,26 @@ RES ResourceLoader::load(const String &p_path, const String &p_type_hint, bool p
 
 	for (int i = 0; i < loader_count; i++) {
 
+		print_line("------");
 		if (!loader[i]->recognize_path(local_path, p_type_hint)) {
-			print_line("path not recognized: " + local_path);
+			print_line("BAD: path NOT recognized: '" + local_path + "' as '" + p_type_hint + "'");
+			print_line("while trying ResourceFormatLoader " + itos(i));
+
+			List<String> extensions;
+			loader[i]->get_recognized_extensions(&extensions);
+			for (List<String>::Element *E = extensions.front(); E; E = E->next()) {
+				print_line("Extensions: " + E->get());
+			}
 			continue;
+		} else {
+			print_line("GOOD: path recognized: '" + local_path + "' as '" + p_type_hint + "'");
+			print_line("while trying ResourceFormatLoader " + itos(i));
+
+			List<String> extensions;
+			loader[i]->get_recognized_extensions(&extensions);
+			for (List<String>::Element *E = extensions.front(); E; E = E->next()) {
+				print_line("Extensions: " + E->get());
+			}
 		}
 		found = true;
 		RES res = loader[i]->load(local_path, local_path, r_error);
```
```
------
BAD: path NOT recognized: 'res://ball.png' as 'Texture'
while trying ResourceFormatLoader 0
Extensions: tscn
Extensions: tres
------
BAD: path NOT recognized: 'res://ball.png' as 'Texture'
while trying ResourceFormatLoader 1
Extensions: po
------
BAD: path NOT recognized: 'res://ball.png' as 'Texture'
while trying ResourceFormatLoader 2
Extensions: anm
Extensions: asogg
Extensions: atex
Extensions: cbm
Extensions: cvtex
Extensions: fnt
Extensions: gt
Extensions: ltex
Extensions: mmsh
Extensions: msh
Extensions: mtl
Extensions: pbm
Extensions: res
Extensions: room
Extensions: sbx
Extensions: scn
Extensions: shd
Extensions: shp
Extensions: smp
Extensions: tex
Extensions: thm
Extensions: vs
Extensions: wrd
Extensions: xl
------
GOOD: path recognized: 'res://ball.png' as 'Texture'
while trying ResourceFormatLoader 3
Extensions: ogg
Extensions: dae
Extensions: obj
Extensions: png
Extensions: jpg
Extensions: jpeg
Extensions: webp
Extensions: csv
Extensions: wav
------
BAD: path NOT recognized: 'res://.import/ball.png-9a4ca347acb7532f6ae347744a6b04f7.stex' as 'StreamTexture'
while trying ResourceFormatLoader 0
Extensions: tscn
Extensions: tres
------
BAD: path NOT recognized: 'res://.import/ball.png-9a4ca347acb7532f6ae347744a6b04f7.stex' as 'StreamTexture'
while trying ResourceFormatLoader 1
Extensions: po
------
BAD: path NOT recognized: 'res://.import/ball.png-9a4ca347acb7532f6ae347744a6b04f7.stex' as 'StreamTexture'
while trying ResourceFormatLoader 2
Extensions: anm
Extensions: asogg
Extensions: atex
Extensions: cbm
Extensions: cvtex
Extensions: fnt
Extensions: gt
Extensions: ltex
Extensions: mmsh
Extensions: msh
Extensions: mtl
Extensions: pbm
Extensions: res
Extensions: room
Extensions: sbx
Extensions: scn
Extensions: shd
Extensions: shp
Extensions: smp
Extensions: tex
Extensions: thm
Extensions: vs
Extensions: wrd
Extensions: xl
------
BAD: path NOT recognized: 'res://.import/ball.png-9a4ca347acb7532f6ae347744a6b04f7.stex' as 'StreamTexture'
while trying ResourceFormatLoader 3
Extensions: ogg
Extensions: dae
Extensions: obj
Extensions: png
Extensions: jpg
Extensions: jpeg
Extensions: webp
Extensions: csv
Extensions: wav
------
BAD: path NOT recognized: 'res://.import/ball.png-9a4ca347acb7532f6ae347744a6b04f7.stex' as 'StreamTexture'
while trying ResourceFormatLoader 4
Extensions: ttf
Extensions: otf
------
GOOD: path recognized: 'res://.import/ball.png-9a4ca347acb7532f6ae347744a6b04f7.stex' as 'StreamTexture'
while trying ResourceFormatLoader 5
Extensions: stex
```

There might be a cleverer way to bind specific type hints to the proper loader than trying them all and picking the first match, but it does the job so far :)