### PR TITLE
Fix "Save/Delete Layout" text field goes outside of the popup

### DIFF
--- a/editor/editor_name_dialog.cpp
+++ b/editor/editor_name_dialog.cpp
@@ -79,9 +79,11 @@ void EditorNameDialog::_bind_methods() {
 }
 
 EditorNameDialog::EditorNameDialog() {
+	makevb = memnew(VBoxContainer);
+	add_child(makevb);
 	name = memnew(LineEdit);
-	add_child(name);
-	move_child(name, get_label()->get_index() + 1);
+	makevb->add_child(name);
+	makevb->move_child(name, get_label()->get_index() + 1);
 	name->set_margin(MARGIN_TOP, 5);
 	name->set_anchor_and_margin(MARGIN_LEFT, ANCHOR_BEGIN, 5);
 	name->set_anchor_and_margin(MARGIN_RIGHT, ANCHOR_END, 5);

--- a/editor/editor_name_dialog.h
+++ b/editor/editor_name_dialog.h
@@ -38,6 +38,7 @@ class EditorNameDialog : public ConfirmationDialog {
 
 	GDCLASS(EditorNameDialog, ConfirmationDialog);
 
+	VBoxContainer *makevb;
 	LineEdit *name;
 
 	void _line_gui_input(const InputEvent &p_event);


### PR DESCRIPTION
Fixes #8481.