### PR TITLE
fixed a bug where saving a GDScript file crashed the editor

### DIFF
--- a/modules/gdscript/gd_script.cpp
+++ b/modules/gdscript/gd_script.cpp
@@ -1696,9 +1696,9 @@ void GDScriptLanguage::reload_tool_script(const Ref<Script> &p_script, bool p_so
 //same thing for placeholders
 #ifdef TOOLS_ENABLED
 
-			for (Set<PlaceHolderScriptInstance *>::Element *P = E->get()->placeholders.front(); P; P = P->next()) {
+			while (E->get()->placeholders.size()) {
+				Object *obj = E->get()->placeholders.front()->get()->get_owner();
 
-				Object *obj = P->get()->get_owner();
 				//save instance info
 				List<Pair<StringName, Variant> > state;
 				if (obj->get_script_instance()) {
@@ -1706,6 +1706,9 @@ void GDScriptLanguage::reload_tool_script(const Ref<Script> &p_script, bool p_so
 					obj->get_script_instance()->get_property_state(state);
 					map[obj->get_instance_ID()] = state;
 					obj->set_script(RefPtr());
+				} else {
+					// no instance found. Let's remove it so we don't loop forever
+					E->get()->placeholders.erase(E->get()->placeholders.front()->get());
 				}
 			}
 #endif


### PR DESCRIPTION
I changed the loop in #8502, turns out it fixed the error I was facing but introduced a new one. This fixes both