### PR TITLE
Fix auto_accept_quit option to work (2.1)

### DIFF
--- a/scene/main/scene_main_loop.cpp
+++ b/scene/main/scene_main_loop.cpp
@@ -460,7 +460,6 @@ void SceneTree::input_event(const InputEvent &p_event) {
 void SceneTree::init() {
 
 	//_quit=false;
-	accept_quit = true;
 	initialized = true;
 	input_handled = false;
 
@@ -1625,6 +1624,7 @@ SceneTree::SceneTree() {
 
 	singleton = this;
 	_quit = false;
+	accept_quit = true;
 	initialized = false;
 #ifdef TOOLS_ENABLED
 	editor_hint = false;


### PR DESCRIPTION
auto_accept_quit value is set first properly with GLOBAL_DEF("application/auto_accept_quit", true) in main.cpp
after that it's reset to true in SceneTree:init() whatever value was.