### PR TITLE
Fix auto_accept_quit option to work

### DIFF
--- a/scene/main/scene_main_loop.cpp
+++ b/scene/main/scene_main_loop.cpp
@@ -510,8 +510,6 @@ void SceneTree::input_event(const InputEvent &p_event) {
 void SceneTree::init() {
 
 	//_quit=false;
-	accept_quit = true;
-	quit_on_go_back = true;
 	initialized = true;
 	input_handled = false;
 
@@ -2266,6 +2264,8 @@ SceneTree::SceneTree() {
 
 	singleton = this;
 	_quit = false;
+	accept_quit = true;
+	quit_on_go_back = true;
 	initialized = false;
 #ifdef TOOLS_ENABLED
 	editor_hint = false;


### PR DESCRIPTION
auto_accept_quit value is set first properly with GLOBAL_DEF("application/auto_accept_quit", true) in main.cpp
after that it's reset to true in SceneTree:init() whatever value was.