### PR TITLE
Fix wrong fallback for locale (2.1)

### DIFF
--- a/core/translation.cpp
+++ b/core/translation.cpp
@@ -1064,7 +1064,7 @@ void TranslationServer::setup() {
 		int idx = 0;
 		while (locale_list[idx]) {
 			if (idx > 0)
-				options += ", ";
+				options += ",";
 			options += locale_list[idx];
 			idx++;
 		}


### PR DESCRIPTION
`options += ", ";` makes wrong fallback string `[ en]` (have space in front) instead of `[en]`.
only `[aa]` is correct.
so, fallback does not work properly.