### PR TITLE
Add setting to opt-out of capitalization in property inspectors (2.1)

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -404,6 +404,7 @@ void EditorNode::_notification(int p_what) {
 
 	if (p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
 		scene_tabs->set_tab_close_display_policy((bool(EDITOR_DEF("global/always_show_close_button_in_scene_tabs", false)) ? Tabs::CLOSE_BUTTON_SHOW_ALWAYS : Tabs::CLOSE_BUTTON_SHOW_ACTIVE_ONLY));
+		property_editor->set_enable_capitalize_paths(bool(EDITOR_DEF("inspector/capitalize_properties", true)));
 	}
 }
 
@@ -5877,6 +5878,7 @@ EditorNode::EditorNode() {
 	property_editor->set_show_categories(true);
 	property_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	property_editor->set_use_doc_hints(true);
+	property_editor->set_enable_capitalize_paths(bool(EDITOR_DEF("inspector/capitalize_properties", true)));
 
 	property_editor->hide_top_label();
 	property_editor->register_text_enter(search_box);

--- a/editor/project_settings.cpp
+++ b/editor/project_settings.cpp
@@ -1293,7 +1293,7 @@ ProjectSettings::ProjectSettings(EditorData *p_data) {
 	//globals_editor->hide_top_label();
 	globals_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	globals_editor->get_property_editor()->register_text_enter(search_box);
-	globals_editor->get_property_editor()->set_capitalize_paths(false);
+	globals_editor->get_property_editor()->set_enable_capitalize_paths(false);
 	globals_editor->get_property_editor()->get_scene_tree()->connect("cell_selected", this, "_item_selected");
 	globals_editor->get_property_editor()->connect("property_toggled", this, "_item_checked", varray(), CONNECT_DEFERRED);
 	globals_editor->get_property_editor()->connect("property_edited", this, "_settings_prop_edited");

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -2428,10 +2428,7 @@ TreeItem *PropertyEditor::get_parent_node(String p_path, HashMap<String, TreeIte
 		item = tree->create_item(parent);
 
 		String name = (p_path.find("/") != -1) ? p_path.right(p_path.find_last("/") + 1) : p_path;
-		if (capitalize_paths)
-			item->set_text(0, name.capitalize());
-		else
-			item->set_text(0, name);
+		item->set_text(0, capitalize_paths ? name.capitalize() : name);
 		item->set_tooltip(0, p_path);
 		if (item->get_parent() != root) {
 			item->set_icon(0, get_icon("Folder", "EditorIcons"));
@@ -3832,9 +3829,15 @@ String PropertyEditor::get_selected_path() const {
 		return "";
 }
 
-void PropertyEditor::set_capitalize_paths(bool p_capitalize) {
+bool PropertyEditor::is_capitalize_paths_enabled() const {
+
+	return capitalize_paths;
+}
+
+void PropertyEditor::set_enable_capitalize_paths(bool p_capitalize) {
 
 	capitalize_paths = p_capitalize;
+	update_tree_pending = true;
 }
 
 void PropertyEditor::set_autoclear(bool p_enable) {

--- a/editor/property_editor.h
+++ b/editor/property_editor.h
@@ -262,7 +262,8 @@ public:
 		custom_editor->set_read_only(p_read_only);
 	}
 
-	void set_capitalize_paths(bool p_capitalize);
+	bool is_capitalize_paths_enabled() const;
+	void set_enable_capitalize_paths(bool p_capitalize);
 	void set_autoclear(bool p_enable);
 
 	void set_show_categories(bool p_show);

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1624,7 +1624,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		inspector->set_h_size_flags(SIZE_EXPAND_FILL);
 		inspector->hide_top_label();
 		inspector->get_scene_tree()->set_column_title(0, TTR("Variable"));
-		inspector->set_capitalize_paths(false);
+		inspector->set_enable_capitalize_paths(false);
 		inspector->set_read_only(true);
 		sc->add_child(inspector);
 


### PR DESCRIPTION
By default, capitalization will be on (classic behavior).

If disabled, ~~every property editor (including editor and project settings dialogs)~~ the inspector dock will show the real, undecorated name of the properties.

The new setting is named **inspector/capitalize_properties** to make its intent clear. Bonus: it's applied immediately without having to restart the editor.
