### PR TITLE
VisualScript: Implement ResourceFormatLoader

### DIFF
--- a/modules/visual_script/register_types.cpp
+++ b/modules/visual_script/register_types.cpp
@@ -40,12 +40,16 @@
 #include "visual_script_yield_nodes.h"
 
 VisualScriptLanguage *visual_script_language = NULL;
+ResourceFormatLoaderVisualScript *visual_script_loader = NULL;
 
 void register_visual_script_types() {
 
 	visual_script_language = memnew(VisualScriptLanguage);
+	visual_script_loader = memnew(ResourceFormatLoaderVisualScript);
+
 	//script_language_gd->init();
 	ScriptServer::register_language(visual_script_language);
+	ResourceLoader::add_resource_format_loader(visual_script_loader);
 
 	ClassDB::register_class<VisualScript>();
 	ClassDB::register_virtual_class<VisualScriptNode>();
@@ -121,4 +125,7 @@ void unregister_visual_script_types() {
 #endif
 	if (visual_script_language)
 		memdelete(visual_script_language);
+
+	if (visual_script_loader)
+		memdelete(visual_script_loader);
 }

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -2665,3 +2665,32 @@ VisualScriptLanguage::~VisualScriptLanguage() {
 	}
 	singleton = NULL;
 }
+
+RES ResourceFormatLoaderVisualScript::load(const String &p_path, const String &p_original_path, Error *r_error) {
+	if (r_error)
+		*r_error = OK;
+
+	VisualScript *script = memnew(VisualScript);
+
+	Ref<VisualScript> scriptres(script);
+
+	script->set_path(p_path);
+	script->reload_from_file();
+
+	return scriptres;
+}
+
+void ResourceFormatLoaderVisualScript::get_recognized_extensions(List<String> *p_extensions) const {
+	p_extensions->push_back("vs");
+}
+
+bool ResourceFormatLoaderVisualScript::handles_type(const String &p_type) const {
+	return (p_type == "Script" || p_type == "VisualScript");
+}
+
+String ResourceFormatLoaderVisualScript::get_resource_type(const String &p_path) const {
+	String ext = p_path.get_extension().to_lower();
+	if (ext == "vs")
+		return "VisualScript";
+	return "";
+}

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -30,6 +30,7 @@
 #ifndef VSCRIPT_H
 #define VSCRIPT_H
 
+#include "io/resource_loader.h"
 #include "os/thread.h"
 #include "script_language.h"
 
@@ -616,5 +617,13 @@ static Ref<VisualScriptNode> create_node_generic(const String &p_name) {
 	node.instance();
 	return node;
 }
+
+class ResourceFormatLoaderVisualScript : public ResourceFormatLoader {
+public:
+	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = NULL);
+	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual bool handles_type(const String &p_type) const;
+	virtual String get_resource_type(const String &p_path) const;
+};
 
 #endif // VSCRIPT_H


### PR DESCRIPTION
Implements a `ResourceFormatLoader` like the other Script languages do.
Might be just a workaround.. since VS was working at one point, and it _sometimes_ still does without this PR (under some weird conditions that I can't reliably reproduce)

Fixes #8040