### PR TITLE
Add one-way collision to tile-set/tile-map (2.1)

### DIFF
--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -109,7 +109,7 @@ private:
 
 		Vector2 pos;
 		List<RID> canvas_items;
-		RID body;
+		Vector<RID> bodies;
 
 		SelfList<Quadrant> dirty_list;
 
@@ -131,7 +131,7 @@ private:
 		void operator=(const Quadrant &q) {
 			pos = q.pos;
 			canvas_items = q.canvas_items;
-			body = q.body;
+			bodies = q.bodies;
 			cells = q.cells;
 			navpoly_ids = q.navpoly_ids;
 			occluder_instances = q.occluder_instances;
@@ -140,7 +140,7 @@ private:
 			: dirty_list(this) {
 			pos = q.pos;
 			canvas_items = q.canvas_items;
-			body = q.body;
+			bodies = q.bodies;
 			cells = q.cells;
 			occluder_instances = q.occluder_instances;
 			navpoly_ids = q.navpoly_ids;
@@ -232,7 +232,7 @@ public:
 
 	void set_collision_mask(uint32_t p_mask);
 	uint32_t get_collision_mask() const;
-	
+
 	void set_collision_layer_bit(int p_bit, bool p_value);
 	bool get_collision_layer_bit(int p_bit) const;
 

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -59,6 +59,10 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 		tile_set_shape(id, p_value);
 	else if (what == "shapes")
 		_tile_set_shapes(id, p_value);
+	else if (what == "one_way_collision_direction")
+		tile_set_one_way_collision_direction(id, p_value);
+	else if (what == "one_way_collision_max_depth")
+		tile_set_one_way_collision_max_depth(id, p_value);
 	else if (what == "occluder")
 		tile_set_light_occluder(id, p_value);
 	else if (what == "occluder_offset")
@@ -103,6 +107,10 @@ bool TileSet::_get(const StringName &p_name, Variant &r_ret) const {
 		r_ret = tile_get_shape(id);
 	else if (what == "shapes")
 		r_ret = _tile_get_shapes(id);
+	else if (what == "one_way_collision_direction")
+		r_ret = tile_get_one_way_collision_direction(id);
+	else if (what == "one_way_collision_max_depth")
+		r_ret = tile_get_one_way_collision_max_depth(id);
 	else if (what == "occluder")
 		r_ret = tile_get_light_occluder(id);
 	else if (what == "occluder_offset")
@@ -136,6 +144,8 @@ void TileSet::_get_property_list(List<PropertyInfo> *p_list) const {
 		p_list->push_back(PropertyInfo(Variant::VECTOR2, pre + "shape_offset"));
 		p_list->push_back(PropertyInfo(Variant::OBJECT, pre + "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape2D", PROPERTY_USAGE_EDITOR));
 		p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "shapes", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
+		p_list->push_back(PropertyInfo(Variant::VECTOR2, pre + "one_way_collision_direction"));
+		p_list->push_back(PropertyInfo(Variant::REAL, pre + "one_way_collision_max_depth"));
 	}
 }
 
@@ -338,6 +348,30 @@ Array TileSet::_tile_get_shapes(int p_id) const {
 		arr.push_back(shp[i]);
 
 	return arr;
+}
+
+void TileSet::tile_set_one_way_collision_direction(int p_id, Vector2 p_direction) {
+
+	ERR_FAIL_COND(!tile_map.has(p_id));
+	tile_map[p_id].one_way_collision_direction = p_direction;
+}
+
+Vector2 TileSet::tile_get_one_way_collision_direction(int p_id) const {
+
+	ERR_FAIL_COND_V(!tile_map.has(p_id), Vector2());
+	return tile_map[p_id].one_way_collision_direction;
+}
+
+void TileSet::tile_set_one_way_collision_max_depth(int p_id, float p_max_depth) {
+
+	ERR_FAIL_COND(!tile_map.has(p_id));
+	tile_map[p_id].one_way_collision_max_depth = p_max_depth;
+}
+
+float TileSet::tile_get_one_way_collision_max_depth(int p_id) const {
+
+	ERR_FAIL_COND_V(!tile_map.has(p_id), 0.0f);
+	return tile_map[p_id].one_way_collision_max_depth;
 }
 
 Array TileSet::_get_tiles_ids() const {

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -48,6 +48,8 @@ class TileSet : public Resource {
 		Vector2 shape_offset;
 		Rect2i region;
 		Vector<Ref<Shape2D> > shapes;
+		Vector2 one_way_collision_direction;
+		float one_way_collision_max_depth;
 		Vector2 occluder_offset;
 		Ref<OccluderPolygon2D> occluder;
 		Vector2 navigation_polygon_offset;
@@ -55,9 +57,8 @@ class TileSet : public Resource {
 		Ref<CanvasItemMaterial> material;
 		Color modulate;
 
-		// Default modulate for back-compat
 		explicit Data()
-			: modulate(1, 1, 1) {}
+			: one_way_collision_max_depth(0.0f), modulate(1, 1, 1) {}
 	};
 
 	Map<int, Data> tile_map;
@@ -113,6 +114,12 @@ public:
 
 	void tile_set_shapes(int p_id, const Vector<Ref<Shape2D> > &p_shapes);
 	Vector<Ref<Shape2D> > tile_get_shapes(int p_id) const;
+
+	void tile_set_one_way_collision_direction(int p_id, Vector2 p_direction);
+	Vector2 tile_get_one_way_collision_direction(int p_id) const;
+
+	void tile_set_one_way_collision_max_depth(int p_id, float p_max_depth);
+	float tile_get_one_way_collision_max_depth(int p_id) const;
 
 	void remove_tile(int p_id);
 


### PR DESCRIPTION
Now you can set **one_way_collision_direction**/**_max_depth** on a tile's static bodies. During conversion to a `TileSet` it will be checked whether all static bodies for a given tile have the same values for those. If that's not met, a warning will be printed and the relevant tile will be converted with one-way collision disabled (all zeroes for those properties).

At runtime multiple physics bodies will be created for `TileMap`'s quadrants as needed. That is, one physics body per quadrant per different set of one-way collision parameters. I've optimized the code as much as possible to recycle physics bodies so to avoid as much creation/freeing as possible at runtime in case tiles are changed dynamically.

_**This deserves some testing. I will be testing it heavily myself.**_

Not sure what to do about _master_. @reduz said in 3.0 those properties would be probably added to the collision shapes instead, so this implementation would be meaningless for it.

Closes #2585 (but only for _2.1_).