### PR TITLE
AudioServer: Set singleton to NULL when destructed

### DIFF
--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1012,6 +1012,7 @@ AudioServer::AudioServer() {
 AudioServer::~AudioServer() {
 
 	memdelete(audio_data_lock);
+	singleton = NULL;
 }
 
 /////////////////////////////////


### PR DESCRIPTION
Fixes a crash I was experiencing.

Perhaps it was also the cause for #8112, someone check.
