### PR TITLE
Remove GLUT usage in HTML5 platform

### DIFF
--- a/platform/javascript/javascript_main.cpp
+++ b/platform/javascript/javascript_main.cpp
@@ -31,94 +31,50 @@
 #include "io/resource_loader.h"
 #include "main/main.h"
 #include "os_javascript.h"
-#include <GL/glut.h>
-#include <string.h>
 
 OS_JavaScript *os = NULL;
 
-static void _gfx_init(void *ud, bool gl2, int w, int h, bool fs) {
+static void main_loop() {
 
-	glutInitWindowSize(w, h);
-	glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
-	glutCreateWindow("godot");
+	os->main_loop_iterate();
 }
 
-static void _gfx_idle() {
+extern "C" void main_after_fs_sync() {
 
-	glutPostRedisplay();
-}
-
-int start_step = 0;
-
-static void _godot_draw(void) {
-
-	if (start_step == 1) {
-		start_step = 2;
-		Main::start();
-		os->main_loop_begin();
-	}
-
-	if (start_step == 2) {
-		os->main_loop_iterate();
-	}
-
-	glutSwapBuffers();
-}
-
-extern "C" {
-
-void main_after_fs_sync() {
-
-	start_step = 1;
-}
+	// Ease up compatibility
+	ResourceLoader::set_abort_on_missing_resources(false);
+	Main::start();
+	os->main_loop_begin();
+	emscripten_set_main_loop(main_loop, 0, false);
 }
 
 int main(int argc, char *argv[]) {
 
-	/* Initialize the window */
 	printf("let it go dude!\n");
-	glutInit(&argc, argv);
-	os = new OS_JavaScript(argv[0], _gfx_init, NULL, NULL);
 
-	Error err = Main::setup(argv[0], argc - 1, &argv[1]);
-
-	ResourceLoader::set_abort_on_missing_resources(false); //ease up compatibility
-
-	/* Set up glut callback functions */
-	glutIdleFunc(_gfx_idle);
-	//   glutReshapeFunc(gears_reshape);
-	glutDisplayFunc(_godot_draw);
-	//glutSpecialFunc(gears_special);
-
-	//mount persistent file system
+	// sync from persistent state into memory and then
+	// run the 'main_after_fs_sync' function
 	/* clang-format off */
 	EM_ASM(
+		Module.noExitRuntime = true;
 		FS.mkdir('/userfs');
 		FS.mount(IDBFS, {}, '/userfs');
-
-		// sync from persistent state into memory and then
-		// run the 'main_after_fs_sync' function
 		FS.syncfs(true, function(err) {
-
 			if (err) {
 				Module.setStatus('Failed to load persistent data\nPlease allow (third-party) cookies');
 				Module.printErr('Failed to populate IDB file system: ' + err.message);
-				Module.exit();
+				Module.noExitRuntime = false;
 			} else {
 				Module.print('Successfully populated IDB file system');
-				ccall('main_after_fs_sync', 'void', []);
+				ccall('main_after_fs_sync', null);
 			}
 		});
 	);
 	/* clang-format on */
 
-	glutMainLoop();
+	os = new OS_JavaScript(argv[0], NULL);
+	Error err = Main::setup(argv[0], argc - 1, &argv[1]);
 
 	return 0;
+	// continued async in main_after_fs_sync() from syncfs() callback
 }
-
-/*
- *
- *09] <azakai|2__> reduz: yes, define  TOTAL_MEMORY on Module. for example             var Module = { TOTAL_MEMORY: 12345.. };         before the main
- *
- */

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -45,15 +45,9 @@
 
 #include <emscripten/html5.h>
 
-typedef void (*GFXInitFunc)(void *ud, bool gl2, int w, int h, bool fs);
 typedef String (*GetDataDirFunc)();
 
 class OS_JavaScript : public OS_Unix {
-
-	GFXInitFunc gfx_init_func;
-	void *gfx_init_ud;
-
-	bool use_gl2;
 
 	int64_t time_to_save_sync;
 	int64_t last_sync_time;
@@ -167,7 +161,7 @@ public:
 	virtual int get_power_seconds_left();
 	virtual int get_power_percent_left();
 
-	OS_JavaScript(const char *p_execpath, GFXInitFunc p_gfx_init_func, void *p_gfx_init_ud, GetDataDirFunc p_get_data_dir_func);
+	OS_JavaScript(const char *p_execpath, GetDataDirFunc p_get_data_dir_func);
 	~OS_JavaScript();
 };
 


### PR DESCRIPTION
GLUT was useful to get the platform started, but has been slowly replaced by other Emscripten APIs due to various limitations. These changes remove the last remaining uses of the GLUT interface.