### PR TITLE
HTML5: Implement mouse lock/capture and hiding

### DIFF
--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -81,6 +81,9 @@ class OS_JavaScript : public OS_Unix {
 
 	void process_joypads();
 
+	void set_css_cursor(const char *);
+	const char *get_css_cursor() const;
+
 public:
 	// functions used by main to initialize/deintialize the OS
 	virtual int get_video_driver_count() const;
@@ -110,9 +113,8 @@ public:
 
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
 
-	virtual void set_mouse_show(bool p_show);
-	virtual void set_mouse_grab(bool p_grab);
-	virtual bool is_mouse_grab_enabled() const;
+	virtual void set_mouse_mode(MouseMode p_mode);
+	virtual MouseMode get_mouse_mode() const;
 	virtual Point2 get_mouse_position() const;
 	virtual int get_mouse_button_state() const;
 	virtual void set_window_title(const String &p_title);


### PR DESCRIPTION
Implements `set_mouse_mode` and `get_mouse_mode` for `MOUSE_MODE_VISIBLE`, `_HIDDEN` and `_CAPTURED` in HTML5 export.

For `MOUSE_MODE_CAPTURED`, [security restrictions](http://docs.godotengine.org/en/latest/learning/workflow/export/exporting_for_web.html#security-restrictions) require capturing the cursor from within an input callback.

`MOUSE_MODE_CONFINED` cannot be implemented in browsers.

Fixes #7675