### PR TITLE
Added a number of primitive objects

### DIFF
--- a/modules/primitives/SCsub
+++ b/modules/primitives/SCsub
@@ -1,0 +1,4 @@
+# SCsub
+Import('env')
+
+env.add_source_files(env.modules_sources,"*.cpp") # just add all cpp files to the build

--- a/modules/primitives/config.py
+++ b/modules/primitives/config.py
@@ -1,0 +1,7 @@
+# config.py
+
+def can_build(platform):
+    return True
+
+def configure(env):
+    pass

--- a/modules/primitives/cube3d.cpp
+++ b/modules/primitives/cube3d.cpp
@@ -1,0 +1,337 @@
+/*************************************************************************/
+/*  cube3d.cpp                                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#include "cube3d.h"
+#include "servers/visual_server.h"
+
+void Cube3D::_update() {
+	int   i, j, prevrow, thisrow, point;
+	float x, y, z;
+	float onethird = 1.0 / 3.0;
+	float twothirds = 2.0 / 3.0;
+
+	if (!is_inside_tree()) {
+		pending_update = true; // try again once we enter our tree...
+		return;
+	}
+
+	Vector3 start_pos = size * -0.5;
+	aabb = AABB(start_pos, size);
+
+	DVector<Vector3> points;
+	DVector<Vector3> normals;
+	DVector<float> tangents;
+	DVector<Vector2> uvs;
+	DVector<int> indices;
+	point = 0;
+
+#define ADD_TANGENT(m_x, m_y, m_z, m_d) \
+	tangents.push_back(m_x); \
+	tangents.push_back(m_y); \
+	tangents.push_back(m_z); \
+	tangents.push_back(m_d);
+
+	/* front + back */
+	y = start_pos.y;
+	thisrow = point;
+	prevrow = 0;
+	for (j = 0; j <= segments_h; j++) {
+		x = start_pos.x	;
+		for (i = 0; i <= segments_w; i++) {
+			float u = i;
+			float v = j;
+			u /= (3.0 * segments_w);
+			v /= (2.0 * segments_h);
+
+			/* front */
+			points.push_back(Vector3(x, -y, -start_pos.z)); // double negative on the Z!
+			normals.push_back(Vector3(0.0, 0.0, 1.0));
+			ADD_TANGENT(-1.0, 0.0, 0.0, -1.0);
+			uvs.push_back(Vector2(u, v));
+			point++;
+
+			/* back */
+			points.push_back(Vector3(-x, -y, start_pos.z));
+			normals.push_back(Vector3(0.0, 0.0, -1.0));
+			ADD_TANGENT(1.0, 0.0, 0.0, -1.0);
+			uvs.push_back(Vector2(twothirds + u, v));
+			point++;
+
+			if (i>0 && j>0) {
+				int i2 = i * 2;
+
+				/* front */
+				indices.push_back(prevrow + i2 - 2);
+				indices.push_back(prevrow + i2);
+				indices.push_back(thisrow + i2 - 2);
+				indices.push_back(prevrow + i2);
+				indices.push_back(thisrow + i2);
+				indices.push_back(thisrow + i2 - 2);
+
+				/* back */
+				indices.push_back(prevrow + i2 - 1);
+				indices.push_back(prevrow + i2 + 1);
+				indices.push_back(thisrow + i2 - 1);
+				indices.push_back(prevrow + i2 + 1);
+				indices.push_back(thisrow + i2 + 1);
+				indices.push_back(thisrow + i2 - 1);
+			};
+
+			x += size.x / segments_w;
+		};
+
+		y += size.y / segments_h;
+		prevrow = thisrow;
+		thisrow = point;
+	};
+
+	/* left + right */
+	y = start_pos.y;
+	thisrow = point;
+	prevrow = 0;
+	for (j = 0; j <= segments_h; j++) {
+		z = start_pos.z	;
+		for (i = 0; i <= segments_d; i++) {
+			float u = i;
+			float v = j;
+			u /= (3.0 * segments_d);
+			v /= (2.0 * segments_h);
+
+			/* right */
+			points.push_back(Vector3(-start_pos.x, -y, -z));
+			normals.push_back(Vector3(1.0, 0.0, 0.0));
+			ADD_TANGENT(0.0, 0.0, 1.0, -1.0);
+			uvs.push_back(Vector2(onethird + u, v));
+			point++;
+
+			/* left */
+			points.push_back(Vector3(start_pos.x, -y, z));
+			normals.push_back(Vector3(-1.0, 0.0, 0.0));
+			ADD_TANGENT(0.0, 0.0, -1.0, -1.0);
+			uvs.push_back(Vector2(u, 0.5 + v));
+			point++;
+
+			if (i>0 && j>0) {
+				int i2 = i * 2;
+
+				/* right */
+				indices.push_back(prevrow + i2 - 2);
+				indices.push_back(prevrow + i2);
+				indices.push_back(thisrow + i2 - 2);
+				indices.push_back(prevrow + i2);
+				indices.push_back(thisrow + i2);
+				indices.push_back(thisrow + i2 - 2);
+
+				/* left */
+				indices.push_back(prevrow + i2 - 1);
+				indices.push_back(prevrow + i2 + 1);
+				indices.push_back(thisrow + i2 - 1);
+				indices.push_back(prevrow + i2 + 1);
+				indices.push_back(thisrow + i2 + 1);
+				indices.push_back(thisrow + i2 - 1);
+			};
+
+			z += size.z / segments_d;
+		};
+
+		y += size.y / segments_h;
+		prevrow = thisrow;
+		thisrow = point;
+	};
+
+	/* top + bottom */
+	z = start_pos.z;
+	thisrow = point;
+	prevrow = 0;
+	for (j = 0; j <= segments_d; j++) {
+		x = start_pos.x;
+		for (i = 0; i <= segments_w; i++) {
+			float u = i;
+			float v = j;
+			u /= (3.0 * segments_w);
+			v /= (2.0 * segments_d);
+
+			/* top */
+			points.push_back(Vector3(-x, -start_pos.y, -z));
+			normals.push_back(Vector3(0.0, 1.0, 0.0));
+			ADD_TANGENT(1.0, 0.0, 0.0, -1.0);
+			uvs.push_back(Vector2(onethird + u, 0.5 + v));
+			point++;
+
+			/* bottom */
+			points.push_back(Vector3(x, start_pos.y, -z));
+			normals.push_back(Vector3(0.0, -1.0, 0.0));
+			ADD_TANGENT(-1.0, 0.0, 0.0, -1.0);
+			uvs.push_back(Vector2(twothirds + u, 0.5 + v));
+			point++;
+
+			if (i>0 && j>0) {
+				int i2 = i * 2;
+
+				/* top */
+				indices.push_back(prevrow + i2 - 2);
+				indices.push_back(prevrow + i2);
+				indices.push_back(thisrow + i2 - 2);
+				indices.push_back(prevrow + i2);
+				indices.push_back(thisrow + i2);
+				indices.push_back(thisrow + i2 - 2);
+
+				/* bottom */
+				indices.push_back(prevrow + i2 - 1);
+				indices.push_back(prevrow + i2 + 1);
+				indices.push_back(thisrow + i2 - 1);
+				indices.push_back(prevrow + i2 + 1);
+				indices.push_back(thisrow + i2 + 1);
+				indices.push_back(thisrow + i2 - 1);
+			};
+
+			x += size.x / segments_w;
+		};
+
+		z += size.z / segments_d;
+		prevrow = thisrow;
+		thisrow = point;
+	};
+
+	Array arr;
+	arr.resize(VS::ARRAY_MAX);
+	arr[VS::ARRAY_VERTEX] = points;
+	arr[VS::ARRAY_NORMAL] = normals;
+	arr[VS::ARRAY_TANGENT] = tangents;
+	arr[VS::ARRAY_TEX_UV] = uvs;
+	arr[VS::ARRAY_INDEX] = indices;
+
+	if (configured) {
+		VS::get_singleton()->mesh_remove_surface(mesh, 0);
+	} else {
+		configured = true;
+	}
+	VS::get_singleton()->mesh_add_surface(mesh, VS::PRIMITIVE_TRIANGLES, arr);
+
+	pending_update = false;
+}
+
+void Cube3D::_notification(int p_what) {
+
+	switch (p_what) {
+
+		case NOTIFICATION_ENTER_TREE: {
+
+			if (pending_update)
+				_update();
+
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+
+			pending_update = true;
+
+		} break;
+	}
+}
+
+void Cube3D::_bind_methods() {
+	ObjectTypeDB::bind_method(_MD("set_size", "size"), &Cube3D::set_size);
+	ObjectTypeDB::bind_method(_MD("get_size"), &Cube3D::get_size);
+
+	ObjectTypeDB::bind_method(_MD("set_segments_width", "segments"), &Cube3D::set_segments_width);
+	ObjectTypeDB::bind_method(_MD("get_segments_width"), &Cube3D::get_segments_width);
+	ObjectTypeDB::bind_method(_MD("set_segments_height", "segments"), &Cube3D::set_segments_height);
+	ObjectTypeDB::bind_method(_MD("get_segments_height"), &Cube3D::get_segments_height);
+	ObjectTypeDB::bind_method(_MD("set_segments_depth", "segments"), &Cube3D::set_segments_depth);
+	ObjectTypeDB::bind_method(_MD("get_segments_depth"), &Cube3D::get_segments_depth);
+
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "size"), _SCS("set_size"), _SCS("get_size"));
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "segments_width"), _SCS("set_segments_width"), _SCS("get_segments_width"));
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "segments_height"), _SCS("set_segments_height"), _SCS("get_segments_height"));
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "segments_depth"), _SCS("set_segments_depth"), _SCS("get_segments_depth"));
+}
+
+void Cube3D::set_size(const Vector3 &p_size) {
+	size = p_size;
+	_update();
+}
+
+Vector3 Cube3D::get_size() const {
+	return size;
+}
+
+void Cube3D::set_segments_width(const int p_segments) {
+	segments_w = p_segments > 1 ? p_segments : 1;
+	_update();
+}
+
+int Cube3D::get_segments_width() const {
+	return segments_w;
+}
+
+void Cube3D::set_segments_height(const int p_segments) {
+	segments_h = p_segments > 1 ? p_segments : 1;
+	_update();
+}
+
+int Cube3D::get_segments_height() const {
+	return segments_h;
+}
+
+void Cube3D::set_segments_depth(const int p_segments) {
+	segments_d = p_segments > 1 ? p_segments : 1;
+	_update();
+}
+
+int Cube3D::get_segments_depth() const {
+	return segments_d;
+}
+
+AABB Cube3D::get_aabb() const {
+
+	return aabb;
+}
+
+DVector<Face3> Cube3D::get_faces(uint32_t p_usage_flags) const {
+
+	return DVector<Face3>();
+}
+
+Cube3D::Cube3D() {
+	// defaults
+	size = Vector3(1.0, 1.0, 1.0);
+	segments_w = 1;
+	segments_h = 1;
+	segments_d = 1;
+
+	// empty mesh until we update
+	pending_update = true;
+	mesh = VisualServer::get_singleton()->mesh_create();
+	set_base(mesh);
+	configured = false;
+}
+
+Cube3D::~Cube3D() {
+	VisualServer::get_singleton()->free(mesh);
+}

--- a/modules/primitives/cube3d.h
+++ b/modules/primitives/cube3d.h
@@ -1,0 +1,81 @@
+/*************************************************************************/
+/*  cube3d.h                                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#ifndef CUBE3D_H
+#define CUBE3D_H
+
+#include "rid.h"
+#include "scene/3d/visual_instance.h"
+
+/**
+	@author Bastiaan Olij <mux213@gmail.com>
+
+	Similar to test cube but with tesselation support and different texture coordinates
+*/
+class Cube3D : public GeometryInstance {
+
+	OBJ_TYPE(Cube3D, GeometryInstance);
+
+	Vector3 size;
+	int segments_w;
+	int segments_h;
+	int segments_d;
+
+	AABB aabb;
+	bool configured;
+	bool pending_update;
+	RID mesh;
+
+	void _update();
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	void set_size(const Vector3 &p_size);
+	Vector3 get_size() const;
+
+	void set_segments_width(const int p_segments);
+	int get_segments_width() const;
+
+	void set_segments_height(const int p_segments);
+	int get_segments_height() const;
+
+	void set_segments_depth(const int p_segments);
+	int get_segments_depth() const;
+
+	virtual AABB get_aabb() const;
+	virtual DVector<Face3> get_faces(uint32_t p_usage_flags) const;
+
+	Cube3D();
+	~Cube3D();
+};
+
+#endif

--- a/modules/primitives/cylinder3d.cpp
+++ b/modules/primitives/cylinder3d.cpp
@@ -1,0 +1,299 @@
+/*************************************************************************/
+/*  cylinder3d.cpp                                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#include "cylinder3d.h"
+#include "servers/visual_server.h"
+
+void Cylinder3D::_update() {
+	int   i, j, prevrow, thisrow, point;
+	float x, y, z, u, v, radius;
+
+	if (!is_inside_tree()) {
+		pending_update = true; // try again once we enter our tree...
+		return;
+	}
+
+	radius = bottom_radius > top_radius ? bottom_radius : top_radius;
+
+	aabb = AABB(Vector3(-radius, height * -0.5, -radius), Vector3(2.0 * radius, height, 2.0 * radius));
+
+	DVector<Vector3> points;
+	DVector<Vector3> normals;
+	DVector<float> tangents;
+	DVector<Vector2> uvs;
+	DVector<int> indices;
+	point = 0;
+
+#define ADD_TANGENT(m_x, m_y, m_z, m_d) \
+	tangents.push_back(m_x); \
+	tangents.push_back(m_y); \
+	tangents.push_back(m_z); \
+	tangents.push_back(m_d);
+
+	thisrow = 0;
+	prevrow = 0;
+	for (j = 0; j <= (rings + 1); j++) {
+		v = j;
+		v /= (rings + 1);
+
+		radius = top_radius + ((bottom_radius - top_radius) * v);
+
+		y = height * v;
+		y = (height * 0.5) - y;
+
+		for (i = 0; i <= segments; i++) {
+			u = i;
+			u /= segments;
+
+			x = sin(u * (Math_PI * 2.0));
+			z = cos(u * (Math_PI * 2.0));
+
+			Vector3 p = Vector3(x * radius, y, z * radius);
+			points.push_back(p);
+			normals.push_back(p.normalized());
+			ADD_TANGENT(-z, 0.0, x, -1.0)
+			uvs.push_back(Vector2(u, v * 0.5));
+			point++;
+
+			if (i>0 && j>0) {
+				indices.push_back(prevrow + i - 1);
+				indices.push_back(prevrow + i);
+				indices.push_back(thisrow + i - 1);
+
+				indices.push_back(prevrow + i);
+				indices.push_back(thisrow + i);
+				indices.push_back(thisrow + i - 1);
+			};
+		};
+
+		prevrow = thisrow;
+		thisrow = point;
+	};
+
+	// add top
+	if (top_radius > 0.0) {
+		y = height * 0.5;
+
+		thisrow = point;
+		points.push_back(Vector3(0.0, y, 0.0));
+		normals.push_back(Vector3(0.0, 1.0, 0.0));
+		ADD_TANGENT(1.0, 0.0, 0.0, 1.0)
+		uvs.push_back(Vector2(0.25, 0.75));
+		point++;
+
+		for (i = 0; i <= segments; i++) {
+			float r = i;
+			r /= segments;
+
+			x = sin(r * (Math_PI * 2.0));
+			z = cos(r * (Math_PI * 2.0));
+
+			u = ((x + 1.0) * 0.25);
+			v = 0.5 + ((z + 1.0) * 0.25);
+
+			Vector3 p = Vector3(x * top_radius, y, z * top_radius);
+			points.push_back(p);
+			normals.push_back(Vector3(0.0, 1.0, 0.0));
+			ADD_TANGENT(1.0, 0.0, 0.0, 1.0)
+			uvs.push_back(Vector2(u, v));
+			point++;
+
+			if (i > 0) {
+				indices.push_back(thisrow);
+				indices.push_back(point - 1);
+				indices.push_back(point - 2);
+			};
+		};
+	};
+
+	// add bottom
+	if (bottom_radius > 0.0) {
+		y = height * -0.5;
+
+		thisrow = point;
+		points.push_back(Vector3(0.0, y, 0.0));
+		normals.push_back(Vector3(0.0, -1.0, 0.0));
+		ADD_TANGENT(-1.0, 0.0, 0.0, -1.0)
+		uvs.push_back(Vector2(0.75, 0.75));
+		point++;
+
+		for (i = 0; i <= segments; i++) {
+			float r = i;
+			r /= segments;
+
+			x = sin(r * (Math_PI * 2.0));
+			z = cos(r * (Math_PI * 2.0));
+
+			u = 0.5 + ((x + 1.0) * 0.25);
+			v = 1.0 - ((z + 1.0) * 0.25);
+
+			Vector3 p = Vector3(x * bottom_radius, y, z * bottom_radius);
+			points.push_back(p);
+			normals.push_back(Vector3(0.0, -1.0, 0.0));
+			ADD_TANGENT(-1.0, 0.0, 0.0, -1.0)
+			uvs.push_back(Vector2(u, v));
+			point++;
+
+			if (i > 0) {
+				indices.push_back(thisrow);
+				indices.push_back(point - 2);
+				indices.push_back(point - 1);
+			};
+		};
+	};
+
+	Array arr;
+	arr.resize(VS::ARRAY_MAX);
+	arr[VS::ARRAY_VERTEX] = points;
+	arr[VS::ARRAY_NORMAL] = normals;
+	arr[VS::ARRAY_TANGENT] = tangents;
+	arr[VS::ARRAY_TEX_UV] = uvs;
+	arr[VS::ARRAY_INDEX] = indices;
+
+	if (configured) {
+		VS::get_singleton()->mesh_remove_surface(mesh, 0);
+	} else {
+		configured = true;
+	}
+	VS::get_singleton()->mesh_add_surface(mesh, VS::PRIMITIVE_TRIANGLES, arr);
+
+	pending_update = false;
+}
+
+void Cylinder3D::_notification(int p_what) {
+
+	switch (p_what) {
+
+		case NOTIFICATION_ENTER_TREE: {
+
+			if (pending_update)
+				_update();
+
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+
+			pending_update = true;
+
+		} break;
+	}
+}
+
+void Cylinder3D::_bind_methods() {
+	ObjectTypeDB::bind_method(_MD("set_top_radius", "radius"), &Cylinder3D::set_top_radius);
+	ObjectTypeDB::bind_method(_MD("get_top_radius"), &Cylinder3D::get_top_radius);
+	ObjectTypeDB::bind_method(_MD("set_bottom_radius", "radius"), &Cylinder3D::set_bottom_radius);
+	ObjectTypeDB::bind_method(_MD("get_bottom_radius"), &Cylinder3D::get_bottom_radius);
+	ObjectTypeDB::bind_method(_MD("set_height", "height"), &Cylinder3D::set_height);
+	ObjectTypeDB::bind_method(_MD("get_height"), &Cylinder3D::get_height);
+
+	ObjectTypeDB::bind_method(_MD("set_segments", "segments"), &Cylinder3D::set_segments);
+	ObjectTypeDB::bind_method(_MD("get_segments"), &Cylinder3D::get_segments);
+	ObjectTypeDB::bind_method(_MD("set_rings", "rings"), &Cylinder3D::set_rings);
+	ObjectTypeDB::bind_method(_MD("get_rings"), &Cylinder3D::get_rings);
+
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "top_radius"), _SCS("set_top_radius"), _SCS("get_top_radius"));
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "bottom_radius"), _SCS("set_bottom_radius"), _SCS("get_bottom_radius"));
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "height"), _SCS("set_height"), _SCS("get_height"));
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "segments"), _SCS("set_segments"), _SCS("get_segments"));
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "rings"), _SCS("set_rings"), _SCS("get_rings"));
+}
+
+void Cylinder3D::set_top_radius(const float p_radius) {
+	top_radius = p_radius;
+	_update();
+}
+
+float Cylinder3D::get_top_radius() const {
+	return top_radius;
+}
+
+void Cylinder3D::set_bottom_radius(const float p_radius) {
+	bottom_radius = p_radius;
+	_update();
+}
+
+float Cylinder3D::get_bottom_radius() const {
+	return bottom_radius;
+}
+
+void Cylinder3D::set_height(const float p_height) {
+	height = p_height;
+	_update();
+}
+
+float Cylinder3D::get_height() const {
+	return height;
+}
+
+void Cylinder3D::set_segments(const int p_segments) {
+	segments = p_segments > 4 ? p_segments : 4;
+	_update();
+}
+
+int Cylinder3D::get_segments() const {
+	return segments;
+}
+
+void Cylinder3D::set_rings(const int p_rings) {
+	rings = p_rings > 0 ? p_rings : 0;
+	_update();
+}
+
+int Cylinder3D::get_rings() const {
+	return rings;
+}
+
+AABB Cylinder3D::get_aabb() const {
+
+	return aabb;
+}
+
+DVector<Face3> Cylinder3D::get_faces(uint32_t p_usage_flags) const {
+
+	return DVector<Face3>();
+}
+
+Cylinder3D::Cylinder3D() {
+	// defaults
+	top_radius = 0.5;
+	bottom_radius = 0.5;
+	height = 1.0;
+	segments = 16;
+	rings = 8;
+
+	// empty mesh until we update
+	pending_update = true;
+	mesh = VisualServer::get_singleton()->mesh_create();
+	set_base(mesh);
+	configured = false;
+}
+
+Cylinder3D::~Cylinder3D() {
+	VisualServer::get_singleton()->free(mesh);
+}

--- a/modules/primitives/cylinder3d.h
+++ b/modules/primitives/cylinder3d.h
@@ -1,0 +1,83 @@
+/*************************************************************************/
+/*  cylinder.h                                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#ifndef CYLINDER3D_H
+#define CYLINDER3D_H
+
+#include "rid.h"
+#include "scene/3d/visual_instance.h"
+
+/**
+	@author Bastiaan Olij <mux213@gmail.com>
+*/
+class Cylinder3D : public GeometryInstance {
+
+	OBJ_TYPE(Cylinder3D, GeometryInstance);
+
+	float top_radius;
+	float bottom_radius;
+	float height;
+	int segments;
+	int rings;
+
+	AABB aabb;
+	bool configured;
+	bool pending_update;
+	RID mesh;
+
+	void _update();
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	void set_top_radius(const float p_radius);
+	float get_top_radius() const;
+
+	void set_bottom_radius(const float p_radius);
+	float get_bottom_radius() const;
+
+	void set_height(const float p_height);
+	float get_height() const;
+
+	void set_segments(const int p_segments);
+	int get_segments() const;
+
+	void set_rings(const int p_rings);
+	int get_rings() const;
+
+	virtual AABB get_aabb() const;
+	virtual DVector<Face3> get_faces(uint32_t p_usage_flags) const;
+
+	Cylinder3D();
+	~Cylinder3D();
+};
+
+#endif

--- a/modules/primitives/prism.cpp
+++ b/modules/primitives/prism.cpp
@@ -1,0 +1,397 @@
+/*************************************************************************/
+/*  cube3d.cpp                                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#include "prism3d.h"
+#include "servers/visual_server.h"
+
+void Prism3D::_update() {
+	int   i, j, prevrow, thisrow, point;
+	float x, y, z;
+	float onethird = 1.0 / 3.0;
+	float twothirds = 2.0 / 3.0;
+
+	if (!is_inside_tree()) {
+		pending_update = true; // try again once we enter our tree...
+		return;
+	}
+
+	Vector3 start_pos = size * -0.5;
+	aabb = AABB(start_pos, size);
+
+	DVector<Vector3> points;
+	DVector<Vector3> normals;
+	DVector<float> tangents;
+	DVector<Vector2> uvs;
+	DVector<int> indices;
+	point = 0;
+
+#define ADD_TANGENT(m_x, m_y, m_z, m_d) \
+	tangents.push_back(m_x); \
+	tangents.push_back(m_y); \
+	tangents.push_back(m_z); \
+	tangents.push_back(m_d);
+
+	/* front + back */
+	y = start_pos.y;
+	thisrow = point;
+	prevrow = 0;
+	for (j = 0; j <= segments_h; j++) {
+		float scale = (y - start_pos.y) / size.y;
+		float scaled_size_x = size.x * scale;
+		float start_x = start_pos.x;
+		float offset_front = 0.0;
+		float offset_back = 0.0;
+
+		if (mode == PRISM_LEFT) {
+			offset_back = (1.0 - scale) * onethird;
+		} else if (mode == PRISM_CENTER) {
+			start_x += (1.0 - scale) * size.x * 0.5;
+			offset_front += (1.0 - scale) * onethird * 0.5;
+			offset_back = (1.0 - scale) * onethird * 0.5;
+		} else if (mode == PRISM_RIGHT) {
+			start_x += (1.0 - scale) * size.x;
+			offset_front += (1.0 - scale) * onethird;
+		}
+
+		x = 0.0;
+		for (i = 0; i <= segments_w; i++) {
+			float u = i;
+			float v = j;
+			u /= (3.0 * segments_w);
+			v /= (2.0 * segments_h);
+
+			u *= scale;
+
+			/* front */
+			points.push_back(Vector3(start_x + x, -y, -start_pos.z));  // double negative on the Z!
+			normals.push_back(Vector3(0.0, 0.0, 1.0));
+			ADD_TANGENT(-1.0, 0.0, 0.0, -1.0);
+			uvs.push_back(Vector2(offset_front + u, v));
+			point++;
+
+			/* back */
+			points.push_back(Vector3(start_x + scaled_size_x - x, -y, start_pos.z));
+			normals.push_back(Vector3(0.0, 0.0, -1.0));
+			ADD_TANGENT(1.0, 0.0, 0.0, -1.0);
+			uvs.push_back(Vector2(twothirds + offset_back + u, v));
+			point++;
+
+			if (i>0 && j == 1) {
+				int i2 = i * 2;
+
+				/* front */
+				indices.push_back(prevrow + i2);
+				indices.push_back(thisrow + i2);
+				indices.push_back(thisrow + i2 - 2);
+
+				/* back */
+				indices.push_back(prevrow + i2 + 1);
+				indices.push_back(thisrow + i2 + 1);
+				indices.push_back(thisrow + i2 - 1);
+			} else if (i>0 && j>0) {
+				int i2 = i * 2;
+
+				/* front */
+				indices.push_back(prevrow + i2 - 2);
+				indices.push_back(prevrow + i2);
+				indices.push_back(thisrow + i2 - 2);
+				indices.push_back(prevrow + i2);
+				indices.push_back(thisrow + i2);
+				indices.push_back(thisrow + i2 - 2);
+
+				/* back */
+				indices.push_back(prevrow + i2 - 1);
+				indices.push_back(prevrow + i2 + 1);
+				indices.push_back(thisrow + i2 - 1);
+				indices.push_back(prevrow + i2 + 1);
+				indices.push_back(thisrow + i2 + 1);
+				indices.push_back(thisrow + i2 - 1);
+			};
+
+			x += scale * size.x / segments_w;
+		};
+
+		y += size.y / segments_h;
+		prevrow = thisrow;
+		thisrow = point;
+	};
+
+	/* left + right */
+	Vector3 normal_left, normal_right;
+
+	if (mode == PRISM_LEFT) {
+		normal_left = Vector3(-1.0, 0.0, 0.0);
+		normal_right = Vector3(size.y, size.x, 0.0);		
+	} else if (mode == PRISM_CENTER) {
+		normal_left = Vector3(-size.y, size.x * 0.5, 0.0);
+		normal_right = Vector3(size.y, size.x * 0.5, 0.0);		
+	} else if (mode == PRISM_RIGHT) {
+		normal_left = Vector3(-size.y, size.x, 0.0);
+		normal_right = Vector3(1.0, 0.0, 0.0);
+	};
+
+	normal_left.normalize();
+	normal_right.normalize();
+
+	y = start_pos.y;
+	thisrow = point;
+	prevrow = 0;
+	for (j = 0; j <= segments_h; j++) {
+		float left, right;
+		float scale = (y - start_pos.y) / size.y;
+
+		if (mode == PRISM_LEFT) {
+			left = start_pos.x;
+		} else if (mode == PRISM_CENTER) {
+			left = start_pos.x + (size.x * (1.0 - scale) * 0.5);
+		} else if (mode == PRISM_RIGHT) {
+			left = start_pos.x + (size.x * (1.0 - scale));
+		};
+		right = left + (size.x * scale);
+
+		z = start_pos.z ;
+		for (i = 0; i <= segments_d; i++) {
+			float u = i;
+			float v = j;
+			u /= (3.0 * segments_d);
+			v /= (2.0 * segments_h);
+
+			/* right */
+			points.push_back(Vector3(right, -y, -z));
+			normals.push_back(normal_right);
+			ADD_TANGENT(0.0, 0.0, 1.0, -1.0);
+			uvs.push_back(Vector2(onethird + u, v));
+			point++;
+
+			/* left */
+			points.push_back(Vector3(left, -y, z));
+			normals.push_back(normal_left);
+			ADD_TANGENT(0.0, 0.0, -1.0, -1.0);
+			uvs.push_back(Vector2(u, 0.5 + v));
+			point++;
+
+			if (i>0 && j>0) {
+				int i2 = i * 2;
+
+				/* right */
+				indices.push_back(prevrow + i2 - 2);
+				indices.push_back(prevrow + i2);
+				indices.push_back(thisrow + i2 - 2);
+				indices.push_back(prevrow + i2);
+				indices.push_back(thisrow + i2);
+				indices.push_back(thisrow + i2 - 2);
+
+				/* left */
+				indices.push_back(prevrow + i2 - 1);
+				indices.push_back(prevrow + i2 + 1);
+				indices.push_back(thisrow + i2 - 1);
+				indices.push_back(prevrow + i2 + 1);
+				indices.push_back(thisrow + i2 + 1);
+				indices.push_back(thisrow + i2 - 1);
+			};
+
+			z += size.z / segments_d;
+		};
+
+		y += size.y / segments_h;
+		prevrow = thisrow;
+		thisrow = point;
+	};
+
+	/* bottom */
+	z = start_pos.z;
+	thisrow = point;
+	prevrow = 0;
+	for (j = 0; j <= segments_d; j++) {
+		x = start_pos.x;
+		for (i = 0; i <= segments_w; i++) {
+			float u = i;
+			float v = j;
+			u /= (3.0 * segments_w);
+			v /= (2.0 * segments_d);
+
+			/* bottom */
+			points.push_back(Vector3(x, start_pos.y, -z));
+			normals.push_back(Vector3(0.0, -1.0, 0.0));
+			ADD_TANGENT(-1.0, 0.0, 0.0, -1.0);
+			uvs.push_back(Vector2(twothirds + u, 0.5 + v));
+			point++;
+
+			if (i>0 && j>0) {
+				/* bottom */
+				indices.push_back(prevrow + i - 1);
+				indices.push_back(prevrow + i);
+				indices.push_back(thisrow + i - 1);
+				indices.push_back(prevrow + i);
+				indices.push_back(thisrow + i);
+				indices.push_back(thisrow + i - 1);
+			};
+
+			x += size.x / segments_w;
+		};
+
+		z += size.z / segments_d;
+		prevrow = thisrow;
+		thisrow = point;
+	};
+
+	Array arr;
+	arr.resize(VS::ARRAY_MAX);
+	arr[VS::ARRAY_VERTEX] = points;
+	arr[VS::ARRAY_NORMAL] = normals;
+	arr[VS::ARRAY_TANGENT] = tangents;
+	arr[VS::ARRAY_TEX_UV] = uvs;
+	arr[VS::ARRAY_INDEX] = indices;
+
+	if (configured) {
+		VS::get_singleton()->mesh_remove_surface(mesh, 0);
+	} else {
+		configured = true;
+	}
+	VS::get_singleton()->mesh_add_surface(mesh, VS::PRIMITIVE_TRIANGLES, arr);
+
+	pending_update = false;
+}
+
+void Prism3D::_notification(int p_what) {
+
+	switch (p_what) {
+
+		case NOTIFICATION_ENTER_TREE: {
+
+			if (pending_update)
+				_update();
+
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+
+			pending_update = true;
+
+		} break;
+	}
+}
+
+void Prism3D::_bind_methods() {
+	BIND_CONSTANT(PRISM_LEFT);
+	BIND_CONSTANT(PRISM_CENTER);
+	BIND_CONSTANT(PRISM_RIGHT);
+
+	ObjectTypeDB::bind_method(_MD("set_mode", "mode"), &Prism3D::set_mode);
+	ObjectTypeDB::bind_method(_MD("get_mode"), &Prism3D::get_mode);
+
+	ObjectTypeDB::bind_method(_MD("set_size", "size"), &Prism3D::set_size);
+	ObjectTypeDB::bind_method(_MD("get_size"), &Prism3D::get_size);
+
+	ObjectTypeDB::bind_method(_MD("set_segments_width", "segments"), &Prism3D::set_segments_width);
+	ObjectTypeDB::bind_method(_MD("get_segments_width"), &Prism3D::get_segments_width);
+	ObjectTypeDB::bind_method(_MD("set_segments_height", "segments"), &Prism3D::set_segments_height);
+	ObjectTypeDB::bind_method(_MD("get_segments_height"), &Prism3D::get_segments_height);
+	ObjectTypeDB::bind_method(_MD("set_segments_depth", "segments"), &Prism3D::set_segments_depth);
+	ObjectTypeDB::bind_method(_MD("get_segments_depth"), &Prism3D::get_segments_depth);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "mode", PROPERTY_HINT_ENUM, "left,center,right"), _SCS("set_mode"), _SCS("get_mode"));
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "size"), _SCS("set_size"), _SCS("get_size"));
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "segments_width"), _SCS("set_segments_width"), _SCS("get_segments_width"));
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "segments_height"), _SCS("set_segments_height"), _SCS("get_segments_height"));
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "segments_depth"), _SCS("set_segments_depth"), _SCS("get_segments_depth"));
+}
+
+void Prism3D::set_mode(const Prism3D::Mode p_mode) {
+	mode = p_mode;
+	_update();
+}
+
+Prism3D::Mode Prism3D::get_mode() {
+	return mode;
+}
+
+void Prism3D::set_size(const Vector3 &p_size) {
+	size = p_size;
+	_update();
+}
+
+Vector3 Prism3D::get_size() const {
+	return size;
+}
+
+void Prism3D::set_segments_width(const int p_segments) {
+	segments_w = p_segments > 1 ? p_segments : 1;
+	_update();
+}
+
+int Prism3D::get_segments_width() const {
+	return segments_w;
+}
+
+void Prism3D::set_segments_height(const int p_segments) {
+	segments_h = p_segments > 1 ? p_segments : 1;
+	_update();
+}
+
+int Prism3D::get_segments_height() const {
+	return segments_h;
+}
+
+void Prism3D::set_segments_depth(const int p_segments) {
+	segments_d = p_segments > 1 ? p_segments : 1;
+	_update();
+}
+
+int Prism3D::get_segments_depth() const {
+	return segments_d;
+}
+
+AABB Prism3D::get_aabb() const {
+
+	return aabb;
+}
+
+DVector<Face3> Prism3D::get_faces(uint32_t p_usage_flags) const {
+
+	return DVector<Face3>();
+}
+
+Prism3D::Prism3D() {
+	// defaults
+	mode = PRISM_LEFT;
+	size = Vector3(1.0, 1.0, 1.0);
+	segments_w = 1;
+	segments_h = 1;
+	segments_d = 1;
+
+	// empty mesh until we update
+	pending_update = true;
+	mesh = VisualServer::get_singleton()->mesh_create();
+	set_base(mesh);
+	configured = false;
+}
+
+Prism3D::~Prism3D() {
+	VisualServer::get_singleton()->free(mesh);
+}

--- a/modules/primitives/prism3d.h
+++ b/modules/primitives/prism3d.h
@@ -1,0 +1,95 @@
+/*************************************************************************/
+/*  prism3d.h                                                            */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#ifndef PRISM3D_H
+#define PRISM3D_H
+
+#include "rid.h"
+#include "scene/3d/visual_instance.h"
+
+/**
+	@author Bastiaan Olij <mux213@gmail.com>
+
+	Similar to test cube but with tesselation support and different texture coordinates
+*/
+class Prism3D : public GeometryInstance {
+
+	OBJ_TYPE(Prism3D, GeometryInstance);
+
+public:
+	enum Mode {
+		PRISM_LEFT,
+		PRISM_CENTER,
+		PRISM_RIGHT
+	};
+
+private:
+	Vector3 size;
+	int segments_w;
+	int segments_h;
+	int segments_d;
+	Mode mode;
+
+	AABB aabb;
+	bool configured;
+	bool pending_update;
+	RID mesh;
+
+	void _update();
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	void set_mode(const Prism3D::Mode p_mode);
+	Prism3D::Mode get_mode();
+
+	void set_size(const Vector3 &p_size);
+	Vector3 get_size() const;
+
+	void set_segments_width(const int p_segments);
+	int get_segments_width() const;
+
+	void set_segments_height(const int p_segments);
+	int get_segments_height() const;
+
+	void set_segments_depth(const int p_segments);
+	int get_segments_depth() const;
+
+	virtual AABB get_aabb() const;
+	virtual DVector<Face3> get_faces(uint32_t p_usage_flags) const;
+
+	Prism3D();
+	~Prism3D();
+};
+
+VARIANT_ENUM_CAST(Prism3D::Mode);
+
+#endif

--- a/modules/primitives/register_types.cpp
+++ b/modules/primitives/register_types.cpp
@@ -1,0 +1,48 @@
+/*************************************************************************/
+/*  register_types.cpp                                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "register_types.h"
+#include "object_type_db.h"
+#include "cube3d.h"
+#include "sphere3d.h"
+#include "prism3d.h"
+#include "cylinder3d.h"
+
+void register_primitives_types() {
+
+	ObjectTypeDB::register_type<Cube3D>();
+	ObjectTypeDB::register_type<Sphere3D>();
+  ObjectTypeDB::register_type<Prism3D>();
+  ObjectTypeDB::register_type<Cylinder3D>();
+}
+
+void unregister_primitives_types() {
+	 //nothing to do here
+}

--- a/modules/primitives/register_types.h
+++ b/modules/primitives/register_types.h
@@ -1,0 +1,32 @@
+/*************************************************************************/
+/*  register_types.h                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+void register_primitives_types();
+void unregister_primitives_types();

--- a/modules/primitives/sphere3d.cpp
+++ b/modules/primitives/sphere3d.cpp
@@ -1,0 +1,230 @@
+/*************************************************************************/
+/*  sphere3d.cpp                                                         */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#include "sphere3d.h"
+#include "servers/visual_server.h"
+
+void Sphere3D::_update() {
+	int   i, j, prevrow, thisrow, point;
+	float x, y, z;
+
+	if (!is_inside_tree()) {
+		pending_update = true; // try again once we enter our tree...
+		return;
+	}
+
+	aabb = AABB(Vector3(-radius, height * (is_hemisphere ? 0.0 : -0.5), -radius), Vector3(2.0 * radius, height, 2.0 * radius));
+
+	DVector<Vector3> points;
+	DVector<Vector3> normals;
+	DVector<float> tangents;
+	DVector<Vector2> uvs;
+	DVector<int> indices;
+	point = 0;
+
+#define ADD_TANGENT(m_x, m_y, m_z, m_d) \
+	tangents.push_back(m_x); \
+	tangents.push_back(m_y); \
+	tangents.push_back(m_z); \
+	tangents.push_back(m_d);
+
+	thisrow = 0;
+	prevrow = 0;
+	for (j = 0; j <= (rings + 1); j++) {
+		float v = j;
+		float w;
+
+		v /= (rings + 1);
+		w = sin(Math_PI * v);
+		y =  height * (is_hemisphere ? 1.0 : 0.5) * cos(Math_PI * v);
+
+		for (i = 0; i <= segments; i++) {
+			float u = i;
+			u /= segments;
+
+			x = sin(u * (Math_PI * 2.0));
+			z = cos(u * (Math_PI * 2.0));
+
+			if (is_hemisphere && y < 0.0) {
+				points.push_back(Vector3(x * radius * w, 0.0, z * radius * w));
+				normals.push_back(Vector3(0.0, -1.0, 0.0));
+			} else {
+				Vector3 p = Vector3(x * radius * w, y, z * radius * w);
+				points.push_back(p);
+				normals.push_back(p.normalized());
+			};
+			ADD_TANGENT(-z, 0.0, x, -1.0)
+			uvs.push_back(Vector2(u, v));
+			point++;
+
+			if (i>0 && j>0) {
+				indices.push_back(prevrow + i - 1);
+				indices.push_back(prevrow + i);
+				indices.push_back(thisrow + i - 1);
+
+				indices.push_back(prevrow + i);
+				indices.push_back(thisrow + i);
+				indices.push_back(thisrow + i - 1);
+			};
+		};
+
+		prevrow = thisrow;
+		thisrow = point;
+	};
+
+	Array arr;
+	arr.resize(VS::ARRAY_MAX);
+	arr[VS::ARRAY_VERTEX] = points;
+	arr[VS::ARRAY_NORMAL] = normals;
+	arr[VS::ARRAY_TANGENT] = tangents;
+	arr[VS::ARRAY_TEX_UV] = uvs;
+	arr[VS::ARRAY_INDEX] = indices;
+
+	if (configured) {
+		VS::get_singleton()->mesh_remove_surface(mesh, 0);
+	} else {
+		configured = true;
+	}
+	VS::get_singleton()->mesh_add_surface(mesh, VS::PRIMITIVE_TRIANGLES, arr);
+
+	pending_update = false;
+}
+
+void Sphere3D::_notification(int p_what) {
+
+	switch (p_what) {
+
+		case NOTIFICATION_ENTER_TREE: {
+
+			if (pending_update)
+				_update();
+
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+
+			pending_update = true;
+
+		} break;
+	}
+}
+
+void Sphere3D::_bind_methods() {
+	ObjectTypeDB::bind_method(_MD("set_radius", "radius"), &Sphere3D::set_radius);
+	ObjectTypeDB::bind_method(_MD("get_radius"), &Sphere3D::get_radius);
+	ObjectTypeDB::bind_method(_MD("set_height", "height"), &Sphere3D::set_height);
+	ObjectTypeDB::bind_method(_MD("get_height"), &Sphere3D::get_height);
+
+	ObjectTypeDB::bind_method(_MD("set_segments", "segments"), &Sphere3D::set_segments);
+	ObjectTypeDB::bind_method(_MD("get_segments"), &Sphere3D::get_segments);
+	ObjectTypeDB::bind_method(_MD("set_rings", "rings"), &Sphere3D::set_rings);
+	ObjectTypeDB::bind_method(_MD("get_rings"), &Sphere3D::get_rings);
+
+	ObjectTypeDB::bind_method(_MD("set_is_hemisphere", "is_hemisphere"), &Sphere3D::set_is_hemisphere);
+	ObjectTypeDB::bind_method(_MD("get_is_hemisphere"), &Sphere3D::get_is_hemisphere);
+
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "radius"), _SCS("set_radius"), _SCS("get_radius"));
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "height"), _SCS("set_height"), _SCS("get_height"));
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "segments"), _SCS("set_segments"), _SCS("get_segments"));
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "rings"), _SCS("set_rings"), _SCS("get_rings"));
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "is_hemisphere"), _SCS("set_is_hemisphere"), _SCS("get_is_hemisphere"));
+}
+
+void Sphere3D::set_radius(const float p_radius) {
+	radius = p_radius;
+	_update();
+}
+
+float Sphere3D::get_radius() const {
+	return radius;
+}
+
+void Sphere3D::set_height(const float p_height) {
+	height = p_height;
+	_update();
+}
+
+float Sphere3D::get_height() const {
+	return height;
+}
+
+void Sphere3D::set_segments(const int p_segments) {
+	segments = p_segments > 4 ? p_segments : 4;
+	_update();
+}
+
+int Sphere3D::get_segments() const {
+	return segments;
+}
+
+void Sphere3D::set_rings(const int p_rings) {
+	rings = p_rings > 1 ? p_rings : 1;
+	_update();
+}
+
+int Sphere3D::get_rings() const {
+	return rings;
+}
+
+void Sphere3D::set_is_hemisphere(const bool p_is_hemisphere) {
+	is_hemisphere = p_is_hemisphere;
+	_update();
+}
+
+bool Sphere3D::get_is_hemisphere() const {
+	return is_hemisphere;
+}
+
+AABB Sphere3D::get_aabb() const {
+
+	return aabb;
+}
+
+DVector<Face3> Sphere3D::get_faces(uint32_t p_usage_flags) const {
+
+	return DVector<Face3>();
+}
+
+Sphere3D::Sphere3D() {
+	// defaults
+	radius = 0.5;
+	height = 1.0;
+	segments = 16;
+	rings = 8;
+	is_hemisphere = false;
+
+	// empty mesh until we update
+	pending_update = true;
+	mesh = VisualServer::get_singleton()->mesh_create();
+	set_base(mesh);
+	configured = false;
+}
+
+Sphere3D::~Sphere3D() {
+	VisualServer::get_singleton()->free(mesh);
+}

--- a/modules/primitives/sphere3d.h
+++ b/modules/primitives/sphere3d.h
@@ -1,0 +1,83 @@
+/*************************************************************************/
+/*  sphere3d.h                                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#ifndef SPHERE3D_H
+#define SPHERE3D_H
+
+#include "rid.h"
+#include "scene/3d/visual_instance.h"
+
+/**
+	@author Bastiaan Olij <mux213@gmail.com>
+*/
+class Sphere3D : public GeometryInstance {
+
+	OBJ_TYPE(Sphere3D, GeometryInstance);
+
+	float radius;
+	float height;
+	int segments;
+	int rings;
+	bool is_hemisphere;
+
+	AABB aabb;
+	bool configured;
+	bool pending_update;
+	RID mesh;
+
+	void _update();
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	void set_radius(const float p_radius);
+	float get_radius() const;
+
+	void set_height(const float p_height);
+	float get_height() const;
+
+	void set_segments(const int p_segments);
+	int get_segments() const;
+
+	void set_rings(const int p_rings);
+	int get_rings() const;
+
+	void set_is_hemisphere(const bool p_is_hemisphere);
+	bool get_is_hemisphere() const;
+
+	virtual AABB get_aabb() const;
+	virtual DVector<Face3> get_faces(uint32_t p_usage_flags) const;
+
+	Sphere3D();
+	~Sphere3D();
+};
+
+#endif


### PR DESCRIPTION
This PR adds a number of new 3D objects to the node tree. Each object is generated by code in a similar fashion as the TestCube and Quad objects are.

They differ in a number of ways:
- UV coordinates ensure no overlapping on the surfaces
- Mapping contains tangent information so normal maps can be used
- Each object can be subdivided, this allows for vertex shaders to be used to further modify the objects.

Here is a test project that showcases the new objects:
https://github.com/BastiaanOlij/TestPrimitives