### PR TITLE
Fix godot project extension not recognized (again)

### DIFF
--- a/core/global_config.cpp
+++ b/core/global_config.cpp
@@ -658,7 +658,7 @@ Error GlobalConfig::save_custom(const String &p_path, const CustomMap &p_custom,
 		props[category].push_back(name);
 	}
 
-	if (p_path.ends_with(".godot"))
+	if (p_path.ends_with(".cfg"))
 		return _save_settings_text(p_path, props, p_custom);
 	else if (p_path.ends_with(".cfb"))
 		return _save_settings_binary(p_path, props, p_custom);


### PR DESCRIPTION
This fixes that playing a godot project opens the project manager.