### PR TITLE
Rename project file to "project.godot"

### DIFF
--- a/core/global_config.cpp
+++ b/core/global_config.cpp
@@ -242,7 +242,7 @@ Error GlobalConfig::setup(const String &p_path, const String &p_main_pack) {
 
 	if (FileAccessNetworkClient::get_singleton()) {
 
-		if (_load_settings("res://godot.cfg") == OK || _load_settings_binary("res://godot.cfb") == OK) {
+		if (_load_settings("res://project.godot") == OK || _load_settings_binary("res://godot.cfb") == OK) {
 
 			_load_settings("res://override.cfg");
 		}
@@ -259,7 +259,7 @@ Error GlobalConfig::setup(const String &p_path, const String &p_main_pack) {
 		bool ok = _load_resource_pack(p_main_pack);
 		ERR_FAIL_COND_V(!ok, ERR_CANT_OPEN);
 
-		if (_load_settings("res://godot.cfg") == OK || _load_settings_binary("res://godot.cfb") == OK) {
+		if (_load_settings("res://project.godot") == OK || _load_settings_binary("res://godot.cfb") == OK) {
 			//load override from location of the main pack
 			_load_settings(p_main_pack.get_base_dir().plus_file("override.cfg"));
 		}
@@ -272,7 +272,7 @@ Error GlobalConfig::setup(const String &p_path, const String &p_main_pack) {
 
 		if (_load_resource_pack(exec_path.get_basename() + ".pck")) {
 
-			if (_load_settings("res://godot.cfg") == OK || _load_settings_binary("res://godot.cfb") == OK) {
+			if (_load_settings("res://project.godot") == OK || _load_settings_binary("res://godot.cfb") == OK) {
 				//load override from location of executable
 				_load_settings(exec_path.get_base_dir().plus_file("override.cfg"));
 			}
@@ -293,14 +293,14 @@ Error GlobalConfig::setup(const String &p_path, const String &p_main_pack) {
 		// data.pck and data.zip are deprecated and no longer supported, apologies.
 		// make sure this is loaded from the resource path
 
-		if (_load_settings("res://godot.cfg") == OK || _load_settings_binary("res://godot.cfb") == OK) {
+		if (_load_settings("res://project.godot") == OK || _load_settings_binary("res://godot.cfb") == OK) {
 			_load_settings("res://override.cfg");
 		}
 
 		return OK;
 	}
 
-	//Nothing was found, try to find a godot.cfg somewhere!
+	//Nothing was found, try to find a project.godot somewhere!
 
 	DirAccess *d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	ERR_FAIL_COND_V(!d, ERR_CANT_CREATE);
@@ -314,7 +314,7 @@ Error GlobalConfig::setup(const String &p_path, const String &p_main_pack) {
 	while (true) {
 		//try to load settings in ascending through dirs shape!
 
-		if (_load_settings(current_dir + "/godot.cfg") == OK || _load_settings_binary(current_dir + "/godot.cfb") == OK) {
+		if (_load_settings(current_dir + "/project.godot") == OK || _load_settings_binary(current_dir + "/godot.cfb") == OK) {
 
 			_load_settings(current_dir + "/override.cfg");
 			candidate = current_dir;
@@ -474,7 +474,7 @@ void GlobalConfig::clear(const String &p_name) {
 
 Error GlobalConfig::save() {
 
-	return save_custom(get_resource_path() + "/godot.cfg");
+	return save_custom(get_resource_path() + "/project.godot");
 }
 
 Error GlobalConfig::_save_settings_binary(const String &p_file, const Map<String, List<String> > &props, const CustomMap &p_custom) {
@@ -483,7 +483,7 @@ Error GlobalConfig::_save_settings_binary(const String &p_file, const Map<String
 	FileAccess *file = FileAccess::open(p_file, FileAccess::WRITE, &err);
 	if (err != OK) {
 
-		ERR_EXPLAIN("Coudln't save godot.cfb at " + p_file);
+		ERR_EXPLAIN("Couldn't save godot.cfb at " + p_file);
 		ERR_FAIL_COND_V(err, err)
 	}
 
@@ -548,7 +548,7 @@ Error GlobalConfig::_save_settings_text(const String &p_file, const Map<String, 
 	FileAccess *file = FileAccess::open(p_file, FileAccess::WRITE, &err);
 
 	if (err) {
-		ERR_EXPLAIN("Coudln't save godot.cfg - " + p_file);
+		ERR_EXPLAIN("Couldn't save project.godot - " + p_file);
 		ERR_FAIL_COND_V(err, err)
 	}
 
@@ -674,7 +674,7 @@ Error GlobalConfig::save_custom(const String &p_path, const CustomMap &p_custom,
 	Error err = file->open(dst_file,FileAccess::WRITE);
 	if (err) {
 		memdelete(file);
-		ERR_EXPLAIN("Coudln't save godot.cfg");
+		ERR_EXPLAIN("Couldn't save project.godot");
 		ERR_FAIL_COND_V(err,err)
 	}
 

--- a/core/variant_parser.cpp
+++ b/core/variant_parser.cpp
@@ -409,7 +409,7 @@ Error VariantParser::_parse_enginecfg(Stream *p_stream, Vector<String> &strings,
 	Token token;
 	get_token(p_stream, token, line, r_err_str);
 	if (token.type != TK_PARENTHESIS_OPEN) {
-		r_err_str = "Expected '(' in old-style godot.cfg construct";
+		r_err_str = "Expected '(' in old-style project.godot construct";
 		return ERR_PARSE_ERROR;
 	}
 
@@ -420,7 +420,7 @@ Error VariantParser::_parse_enginecfg(Stream *p_stream, Vector<String> &strings,
 		CharType c = p_stream->get_char();
 
 		if (p_stream->is_eof()) {
-			r_err_str = "Unexpected EOF while parsing old-style godot.cfg construct";
+			r_err_str = "Unexpected EOF while parsing old-style project.godot construct";
 			return ERR_PARSE_ERROR;
 		}
 
@@ -1273,7 +1273,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = arr;
 
 			return OK;
-		} else if (id == "key") { // compatibility with godot.cfg
+		} else if (id == "key") { // compatibility with project.godot
 
 			Vector<String> params;
 			Error err = _parse_enginecfg(p_stream, params, line, r_err_str);
@@ -1309,7 +1309,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = ie;
 			return OK;
 
-		} else if (id == "mbutton") { // compatibility with godot.cfg
+		} else if (id == "mbutton") { // compatibility with project.godot
 
 			Vector<String> params;
 			Error err = _parse_enginecfg(p_stream, params, line, r_err_str);
@@ -1324,7 +1324,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 
 			value = ie;
 			return OK;
-		} else if (id == "jbutton") { // compatibility with godot.cfg
+		} else if (id == "jbutton") { // compatibility with project.godot
 
 			Vector<String> params;
 			Error err = _parse_enginecfg(p_stream, params, line, r_err_str);
@@ -1339,7 +1339,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = ie;
 
 			return OK;
-		} else if (id == "jaxis") { // compatibility with godot.cfg
+		} else if (id == "jaxis") { // compatibility with project.godot
 
 			Vector<String> params;
 			Error err = _parse_enginecfg(p_stream, params, line, r_err_str);
@@ -1357,19 +1357,19 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = ie;
 
 			return OK;
-		} else if (id == "img") { // compatibility with godot.cfg
+		} else if (id == "img") { // compatibility with project.godot
 
 			Token token; // FIXME: no need for this declaration? the first argument in line 509 is a Token& token.
 			get_token(p_stream, token, line, r_err_str);
 			if (token.type != TK_PARENTHESIS_OPEN) {
-				r_err_str = "Expected '(' in old-style godot.cfg construct";
+				r_err_str = "Expected '(' in old-style project.godot construct";
 				return ERR_PARSE_ERROR;
 			}
 
 			while (true) {
 				CharType c = p_stream->get_char();
 				if (p_stream->is_eof()) {
-					r_err_str = "Unexpected EOF in old style godot.cfg img()";
+					r_err_str = "Unexpected EOF in old style project.godot img()";
 					return ERR_PARSE_ERROR;
 				}
 				if (c == ')')

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -16455,7 +16455,7 @@
 		Contains global variables accessible from everywhere.
 	</brief_description>
 	<description>
-		Contains global variables accessible from everywhere. Use the normal [Object] API, such as "Globals.get(variable)", "Globals.set(variable,value)" or "Globals.has(variable)" to access them. Variables stored in godot.cfg are also loaded into globals, making this object very useful for reading custom game configuration options.
+		Contains global variables accessible from everywhere. Use the normal [Object] API, such as "Globals.get(variable)", "Globals.set(variable,value)" or "Globals.has(variable)" to access them. Variables stored in project.godot are also loaded into globals, making this object very useful for reading custom game configuration options.
 	</description>
 	<methods>
 		<method name="add_property_info">

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1381,8 +1381,8 @@ Vector<StringName> EditorExportPlatform::get_dependencies(bool p_bundles) const 
 
 	Set<StringName> exported;
 
-	if (FileAccess::exists("res://godot.cfg"))
-		exported.insert("res://godot.cfg");
+	if (FileAccess::exists("res://project.godot"))
+		exported.insert("res://project.godot");
 
 	if (EditorImportExport::get_singleton()->get_export_filter()!=EditorImportExport::EXPORT_SELECTED) {
 
@@ -1978,7 +1978,7 @@ Error EditorExportPlatform::export_project_files(EditorExportSaveFunction p_func
 	}
 
 
-	StringName engine_cfg="res://godot.cfg";
+	StringName engine_cfg="res://project.godot";
 	StringName boot_splash;
 	{
 		String splash=GlobalConfig::get_singleton()->get("application/boot_splash"); //avoid splash from being converted
@@ -2032,7 +2032,7 @@ Error EditorExportPlatform::export_project_files(EditorExportSaveFunction p_func
 
 	{
 
-		//make binary godot.cfg config
+		//make binary project.godot config
 		Map<String,Variant> custom;
 
 

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -509,7 +509,7 @@ void EditorFileSystem::_scan_new_dir(EditorFileSystemDirectory *p_dir, DirAccess
 			if (f.begins_with(".")) //ignore hidden and . / ..
 				continue;
 
-			if (FileAccess::exists(cd.plus_file(f).plus_file("godot.cfg"))) // skip if another project inside this
+			if (FileAccess::exists(cd.plus_file(f).plus_file("project.godot"))) // skip if another project inside this
 				continue;
 
 			dirs.push_back(f);
@@ -688,7 +688,7 @@ void EditorFileSystem::_scan_fs_changes(EditorFileSystemDirectory *p_dir, const 
 				int idx = p_dir->find_dir_index(f);
 				if (idx == -1) {
 
-					if (FileAccess::exists(cd.plus_file(f).plus_file("godot.cfg"))) // skip if another project inside this
+					if (FileAccess::exists(cd.plus_file(f).plus_file("project.godot"))) // skip if another project inside this
 						continue;
 
 					EditorFileSystemDirectory *efd = memnew(EditorFileSystemDirectory);

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -1863,7 +1863,7 @@ void ColladaImport::create_animations(bool p_make_tracks_in_all_bones, bool p_im
 
 				node = node_name_map[at.target];
 			} else {
-				print_line("Coudlnt find node: " + at.target);
+				print_line("Couldnt find node: " + at.target);
 				continue;
 			}
 		} else {

--- a/editor/io_plugins/editor_translation_import_plugin.cpp
+++ b/editor/io_plugins/editor_translation_import_plugin.cpp
@@ -347,7 +347,7 @@ public:
 
 		add_to_project = memnew( CheckButton);
 		add_to_project->set_pressed(true);
-		add_to_project->set_text(TTR("Add to Project (godot.cfg)"));
+		add_to_project->set_text(TTR("Add to Project (project.godot)"));
 		tcomp->add_child(add_to_project);
 
 		file_select = memnew(EditorFileDialog);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -92,18 +92,18 @@ private:
 
 		if (mode != MODE_IMPORT) {
 
-			if (d->file_exists("godot.cfg")) {
+			if (d->file_exists("project.godot")) {
 
-				error->set_text(TTR("Invalid project path, godot.cfg must not exist."));
+				error->set_text(TTR("Invalid project path, project.godot must not exist."));
 				memdelete(d);
 				return "";
 			}
 
 		} else {
 
-			if (valid_path != "" && !d->file_exists("godot.cfg")) {
+			if (valid_path != "" && !d->file_exists("project.godot")) {
 
-				error->set_text(TTR("Invalid project path, godot.cfg must exist."));
+				error->set_text(TTR("Invalid project path, project.godot must exist."));
 				memdelete(d);
 				return "";
 			}
@@ -136,7 +136,7 @@ private:
 
 		String p = p_path;
 		if (mode == MODE_IMPORT) {
-			if (p.ends_with("godot.cfg")) {
+			if (p.ends_with("project.godot")) {
 
 				p = p.get_base_dir();
 			}
@@ -162,7 +162,7 @@ private:
 
 			fdialog->set_mode(FileDialog::MODE_OPEN_FILE);
 			fdialog->clear_filters();
-			fdialog->add_filter("godot.cfg ; " _MKSTR(VERSION_NAME) " Project");
+			fdialog->add_filter("project.godot ; " _MKSTR(VERSION_NAME) " Project");
 		} else {
 			fdialog->set_mode(FileDialog::MODE_OPEN_DIR);
 		}
@@ -186,9 +186,9 @@ private:
 		} else {
 			if (mode == MODE_NEW) {
 
-				FileAccess *f = FileAccess::open(dir.plus_file("/godot.cfg"), FileAccess::WRITE);
+				FileAccess *f = FileAccess::open(dir.plus_file("/project.godot"), FileAccess::WRITE);
 				if (!f) {
-					error->set_text(TTR("Couldn't create godot.cfg in project path."));
+					error->set_text(TTR("Couldn't create project.godot in project path."));
 				} else {
 
 					f->store_line("; Engine configuration file.");
@@ -741,7 +741,7 @@ void ProjectManager::_load_recent_projects() {
 			continue;
 
 		String project = _name.get_slice("/", 1);
-		String conf = path.plus_file("godot.cfg");
+		String conf = path.plus_file("project.godot");
 		bool favorite = (_name.begins_with("favorite_projects/")) ? true : false;
 
 		uint64_t last_modified = 0;
@@ -1006,7 +1006,7 @@ void ProjectManager::_scan_dir(DirAccess *da, float pos, float total, List<Strin
 	while (n != String()) {
 		if (da->current_is_dir() && !n.begins_with(".")) {
 			subdirs.push_front(n);
-		} else if (n == "godot.cfg") {
+		} else if (n == "project.godot") {
 			r_projects->push_back(da->get_current_dir());
 		}
 		n = da->get_next();
@@ -1117,7 +1117,7 @@ void ProjectManager::_files_dropped(PoolStringArray p_files, int p_screen) {
 				dir->list_dir_begin();
 				String file = dir->get_next();
 				while (confirm && file != String()) {
-					if (!dir->current_is_dir() && file.ends_with("godot.cfg")) {
+					if (!dir->current_is_dir() && file.ends_with("project.godot")) {
 						confirm = false;
 					}
 					file = dir->get_next();

--- a/editor/project_settings.cpp
+++ b/editor/project_settings.cpp
@@ -1168,7 +1168,7 @@ void ProjectSettings::_bind_methods() {
 ProjectSettings::ProjectSettings(EditorData *p_data) {
 
 	singleton = this;
-	set_title(TTR("Project Settings (godot.cfg)"));
+	set_title(TTR("Project Settings (project.godot)"));
 	set_resizable(true);
 	undo_redo = &p_data->get_undo_redo();
 	data = p_data;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -129,7 +129,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print(VERSION_FULL_NAME " (c) 2008-2017 Juan Linietsky, Ariel Manzur.\n");
 	OS::get_singleton()->print("Usage: %s [options] [scene]\n", p_binary);
 	OS::get_singleton()->print("Options:\n");
-	OS::get_singleton()->print("\t-path [dir] : Path to a game, containing godot.cfg\n");
+	OS::get_singleton()->print("\t-path [dir] : Path to a game, containing project.godot\n");
 #ifdef TOOLS_ENABLED
 	OS::get_singleton()->print("\t-e,-editor : Bring up the editor instead of running the scene.\n");
 #endif
@@ -447,6 +447,23 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			} else {
 				goto error;
 			}
+		} else if (I->get().ends_with("project.godot")) {
+			String path;
+			String file = I->get();
+			int sep = MAX(file.find_last("/"), file.find_last("\\"));
+			if (sep == -1)
+				path = ".";
+			else {
+				path = file.substr(0, sep);
+			}
+			if (OS::get_singleton()->set_cwd(path) == OK) {
+				// path already specified, don't override
+			} else {
+				game_path = path;
+			}
+#ifdef TOOLS_ENABLED
+			editor = true;
+#endif
 		} else if (I->get() == "-bp") { // /breakpoints
 
 			if (I->next()) {
@@ -673,7 +690,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	else
 		input_map->load_from_globals(); //keys for game
 
-	if (video_driver == "") // specified in godot.cfg
+	if (video_driver == "") // specified in project.godot
 		video_driver = GLOBAL_DEF("display/driver/name", Variant((const char *)OS::get_singleton()->get_video_driver_name(0)));
 
 	if (!force_res && use_custom_res && globals->has("display/window/width"))
@@ -725,7 +742,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	/* Determine Video Driver */
 
-	if (audio_driver == "") { // specified in godot.cfg
+	if (audio_driver == "") { // specified in project.godot
 		audio_driver = GLOBAL_DEF("audio/driver", OS::get_singleton()->get_audio_driver_name(0));
 	}
 

--- a/misc/scripts/sort-demos.sh
+++ b/misc/scripts/sort-demos.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # When scanning for demos, the project manager sorts them based on their
 # timestamp, i.e. last modification date. This can make for a pretty
-# messy output, so this script 'touches' each godot.cfg file in reverse
+# messy output, so this script 'touches' each project.godot file in reverse
 # alphabetical order to ensure a nice listing.
 #
 # It's good practice to run it once before packaging demos on the build
@@ -17,7 +17,7 @@ if [ -e demos.list ]; then
 fi
 
 for dir in 2d 3d gui misc viewport; do
-  find "demos/$dir" -name "godot.cfg" |sort >> demos.list
+  find "demos/$dir" -name "project.godot" |sort >> demos.list
 done
 cat demos.list |sort -r > demos_r.list
 


### PR DESCRIPTION
Slimmed down variant from the reverted #8375.
The rationale behind the name change is to give Godot's project file a unique
extension (".godot") that can be registered on the OS to be associated with
the Godot binary (OS registration not implemented here).

This PR also adds the possibility to start the game or editor if launched
with the project.godot passed as argument, which paves the way for allowing
a similar behaviour on a double-click in the OS file manager (code originally
by @Hinsbart).

Closes #6915.