### PR TITLE
Make property editor display dictionaries (read only)

### DIFF
--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -3406,6 +3406,13 @@ void PropertyEditor::update_tree() {
 					item->set_icon(0, get_icon("ArrayData", "EditorIcons"));
 
 			} break;
+			case Variant::DICTIONARY: {
+
+				item->set_cell_mode(1, TreeItem::CELL_MODE_STRING);
+				item->set_editable(1, false);
+				item->set_text(1, obj->get(p.name).operator String());
+
+			} break;
 
 			case Variant::POOL_INT_ARRAY: {
 


### PR DESCRIPTION
Resolves the original issue in #4103
For now, it only converts the dictionaries to string, then displays them as static text, but a proper dictionary editor and the ability to inspect all kinds of object in the debugger (as suggested by @bojidar-bg in the issue) is in the works too.
