### PR TITLE
Make script debugger display all kinds of objects

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -90,11 +90,13 @@ public:
 		return "";
 	}
 
-	void add_property(const String &p_name, const Variant &p_value) {
+	void add_property(const String &p_name, const Variant &p_value, const PropertyHint &p_hint, const String p_hint_string) {
 
 		PropertyInfo pinfo;
 		pinfo.name = p_name;
 		pinfo.type = p_value.get_type();
+		pinfo.hint = p_hint;
+		pinfo.hint_string = p_hint_string;
 		props.push_back(pinfo);
 		values[p_name] = p_value;
 	}
@@ -437,7 +439,11 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 
 		inspected_object->last_edited_id = id;
 
-		inspect_properties->edit(inspected_object);
+		if (tabs->get_current_tab() == 2) {
+			inspect_properties->edit(inspected_object);
+		} else {
+			editor->push_item(inspected_object);
+		}
 
 	} else if (p_msg == "message:video_mem") {
 
@@ -499,13 +505,20 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 
 			String n = p_data[ofs + i * 2 + 0];
 			Variant v = p_data[ofs + i * 2 + 1];
+			PropertyHint h = PROPERTY_HINT_NONE;
+			String hs = String();
 
 			if (n.begins_with("*")) {
 
 				n = n.substr(1, n.length());
+				h = PROPERTY_HINT_OBJECT_ID;
+				String s = v;
+				s = s.replace("[", "");
+				hs = s.get_slice(":", 0);
+				v = s.get_slice(":", 1).to_int();
 			}
 
-			variables->add_property("members/" + n, v);
+			variables->add_property("members/" + n, v, h, hs);
 		}
 		ofs += mcount * 2;
 
@@ -516,13 +529,20 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 
 			String n = p_data[ofs + i * 2 + 0];
 			Variant v = p_data[ofs + i * 2 + 1];
+			PropertyHint h = PROPERTY_HINT_NONE;
+			String hs = String();
 
 			if (n.begins_with("*")) {
 
 				n = n.substr(1, n.length());
+				h = PROPERTY_HINT_OBJECT_ID;
+				String s = v;
+				s = s.replace("[", "");
+				hs = s.get_slice(":", 0);
+				v = s.get_slice(":", 1).to_int();
 			}
 
-			variables->add_property("locals/" + n, v);
+			variables->add_property("locals/" + n, v, h, hs);
 		}
 
 		variables->update();
@@ -1055,6 +1075,9 @@ void ScriptEditorDebugger::stop() {
 
 	EditorNode::get_singleton()->get_pause_button()->set_pressed(false);
 	EditorNode::get_singleton()->get_pause_button()->set_disabled(true);
+
+	//avoid confusion when stopped debugging but an object is still edited
+	EditorNode::get_singleton()->push_item(NULL);
 
 	if (hide_on_stop) {
 		if (is_visible_in_tree())
@@ -1627,6 +1650,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		inspector->get_scene_tree()->set_column_title(0, TTR("Variable"));
 		inspector->set_capitalize_paths(false);
 		inspector->set_read_only(true);
+		inspector->connect("object_id_selected", this, "_scene_tree_property_select_object");
 		sc->add_child(inspector);
 
 		server = TCP_Server::create_ref();


### PR DESCRIPTION
Makes @bojidar-bg 's idea from #4103 reality.
After some thinking, I decided to use the inspector in the left dock since the arrays are displayed there too, but that can be changed, to e. g. the remote inspector tab in the debugger, although that may be a bit weird.