### PR TITLE
Added 3D freelook navigation mode

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -589,6 +589,11 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("editors/3d/emulate_3_button_mouse", false);
 	set("editors/3d/warped_mouse_panning", true);
 
+	set("editors/3d/freelook_base_speed", 5);
+	set("editors/3d/freelook_acceleration", 10);
+	set("editors/3d/freelook_max_speed", 100);
+	set("editors/3d/freelook_modifier_speed_factor", 1.0 / 5.0);
+
 	set("editors/2d/bone_width", 5);
 	set("editors/2d/bone_color1", Color(1.0, 1.0, 1.0, 0.9));
 	set("editors/2d/bone_color2", Color(0.75, 0.75, 0.75, 0.9));

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -113,6 +113,7 @@ private:
 	bool transforming;
 	bool orthogonal;
 	float gizmo_scale;
+	real_t freelook_speed;
 
 	struct _RayResult {
 
@@ -168,7 +169,8 @@ private:
 		NAVIGATION_NONE,
 		NAVIGATION_PAN,
 		NAVIGATION_ZOOM,
-		NAVIGATION_ORBIT
+		NAVIGATION_ORBIT,
+		NAVIGATION_LOOK
 	};
 	enum TransformMode {
 		TRANSFORM_NONE,
@@ -203,8 +205,6 @@ private:
 
 	struct Cursor {
 
-		Vector3 cursor_pos;
-
 		Vector3 pos;
 		float x_rot, y_rot, distance;
 		bool region_select;
@@ -227,10 +227,12 @@ private:
 
 	//
 	void _update_camera();
+	Transform to_camera_transform(const Cursor &p_cursor) const;
 	void _draw();
 
 	void _smouseenter();
 	void _sinput(const InputEvent &p_ie);
+	void _update_freelook(real_t delta);
 	SpatialEditor *spatial_editor;
 
 	Camera *previewing;
@@ -385,7 +387,6 @@ private:
 	};
 
 	Button *tool_button[TOOL_MAX];
-	Button *instance_button;
 
 	MenuButton *transform_menu;
 	MenuButton *view_menu;


### PR DESCRIPTION
- Triggered by holding RMB
- Can look around in FPS style
- Can move with WASD, up and down with Q and E
- Movement speed accelerates over time
- Can multiply speed with a modifier key to go faster or slower
- Configurable in editor settings and shortcuts

Preview: https://www.youtube.com/watch?v=lmFVNVHTBFk&feature=youtu.be

This PR gives an alternative to the shortcomings found in #8260