### PR TITLE
Fix get_shader_type index upper bound

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -3751,7 +3751,7 @@ String ShaderLanguage::get_shader_type(const String &p_code) {
 
 	String cur_identifier;
 
-	for (int i = 0; i < p_code.length() + 1; i++) {
+	for (int i = 0; i < p_code.length(); i++) {
 
 		if (p_code[i] == ';') {
 			break;


### PR DESCRIPTION
This should fix part of the "editing shader code crashes the editor" problem from issues #8595 and #8314.  Using the "create new material shader" repro steps from #8314 as an example, p_code (the code text from the shader editor) starts as a string of length zero which results in an invalid p_code[0] reference in line 3756.

This now properly extracts the shader type (you can verify this by creating a new ShaderMaterial, editing it, and typing a valid shader type declaration, such as "shader_type spatial;"

From what I have gathered there are actually two bugs with similar symptoms:
1. This indexing problem fixed here (which results in a segmentation fault), which is current hit every time you try to type in the shader editor.
2. a segmentation fault on line 2291 of rasterizer_storage_gles3.cpp when attempting to call material->shader->uniforms.front().  This is sometimes hit right after clicking "New Shader" in the ShaderMaterial dropdown menu, but the failure seems to be nondeterministic.  Sometimes it fails on the first click, sometimes it takes multiple tries.  I couldn't figure it out after a cursory glance.  I'm hoping someone with a little more context can help me out.  I'm new to this code :)

If you encounter an error when validating this fix, make sure you didn't hit the second bug mentioned above (because when it does occur, it happens first) 