### PR TITLE
HTML5: Cursor style control

### DIFF
--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -513,6 +513,31 @@ void OS_JavaScript::alert(const String &p_alert, const String &p_title) {
 	/* clang-format on */
 }
 
+static const char *godot2dom_cursor(OS::CursorShape p_shape) {
+
+	switch (p_shape) {
+		case OS::CURSOR_ARROW:
+		default:
+			return "auto";
+		case OS::CURSOR_IBEAM: return "text";
+		case OS::CURSOR_POINTING_HAND: return "pointer";
+		case OS::CURSOR_CROSS: return "crosshair";
+		case OS::CURSOR_WAIT: return "progress";
+		case OS::CURSOR_BUSY: return "wait";
+		case OS::CURSOR_DRAG: return "grab";
+		case OS::CURSOR_CAN_DROP: return "grabbing";
+		case OS::CURSOR_FORBIDDEN: return "no-drop";
+		case OS::CURSOR_VSIZE: return "ns-resize";
+		case OS::CURSOR_HSIZE: return "ew-resize";
+		case OS::CURSOR_BDIAGSIZE: return "nesw-resize";
+		case OS::CURSOR_FDIAGSIZE: return "nwse-resize";
+		case OS::CURSOR_MOVE: return "move";
+		case OS::CURSOR_VSPLIT: return "row-resize";
+		case OS::CURSOR_HSPLIT: return "col-resize";
+		case OS::CURSOR_HELP: return "help";
+	}
+}
+
 void OS_JavaScript::set_css_cursor(const char *p_cursor) {
 
 	/* clang-format off */
@@ -543,7 +568,7 @@ void OS_JavaScript::set_mouse_mode(OS::MouseMode p_mode) {
 
 	if (p_mode == MOUSE_MODE_VISIBLE) {
 
-		set_css_cursor("auto");
+		set_css_cursor(godot2dom_cursor(cursor_shape));
 		emscripten_exit_pointerlock();
 
 	} else if (p_mode == MOUSE_MODE_HIDDEN) {
@@ -557,7 +582,7 @@ void OS_JavaScript::set_mouse_mode(OS::MouseMode p_mode) {
 		ERR_EXPLAIN("MOUSE_MODE_CAPTURED can only be entered from within an appropriate input callback");
 		ERR_FAIL_COND(result == EMSCRIPTEN_RESULT_FAILED_NOT_DEFERRED);
 		ERR_FAIL_COND(result != EMSCRIPTEN_RESULT_SUCCESS);
-		set_css_cursor("auto");
+		set_css_cursor(godot2dom_cursor(cursor_shape));
 	}
 }
 
@@ -702,7 +727,11 @@ bool OS_JavaScript::can_draw() const {
 
 void OS_JavaScript::set_cursor_shape(CursorShape p_shape) {
 
-	//javascript really really really has no mouse.. how amazing..
+	ERR_FAIL_INDEX(p_shape, CURSOR_MAX);
+
+	cursor_shape = p_shape;
+	if (get_mouse_mode() != MOUSE_MODE_HIDDEN)
+		set_css_cursor(godot2dom_cursor(cursor_shape));
 }
 
 void OS_JavaScript::main_loop_begin() {

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -67,6 +67,7 @@ class OS_JavaScript : public OS_Unix {
 	InputDefault *input;
 	bool window_maximized;
 	VideoMode video_mode;
+	CursorShape cursor_shape;
 	MainLoop *main_loop;
 
 	GetDataDirFunc get_data_dir_func;


### PR DESCRIPTION
Implement `OS::set_cursor_shape` for the HTML5 platform.
Basically, hovering over a LineEdit displays a text-cursor now