### PR TITLE
Tree: Clear search string on selection.

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1518,6 +1518,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool
 			if (p_doubleclick && (!c.editable || c.mode == TreeItem::CELL_MODE_CUSTOM || c.mode == TreeItem::CELL_MODE_ICON /*|| c.mode==TreeItem::CELL_MODE_CHECK*/)) { //it' s confusing for check
 
 				emit_signal("item_activated");
+				incr_search.clear();
 				return -1;
 			}
 
@@ -2071,6 +2072,7 @@ void Tree::_gui_input(InputEvent p_event) {
 						//bring up editor if possible
 						if (!edit_selected()) {
 							emit_signal("item_activated");
+							incr_search.clear();
 						}
 					}
 					accept_event();


### PR DESCRIPTION
The Tree node has the ability to jump to a specific item by typing the first few chars of it's name.
But on selection (`item_activated` signal), it didn't clear the search string used for that. It was especially annoying in `FileDialog`s and has been bugging me for ages :P

With this, you can traverse a directory structure in a FileDiag quickly with the keyboard (like you'd expect from pretty much any modern file browser) :)