### PR TITLE
Fix UDP::wait() deadlock

### DIFF
--- a/drivers/unix/packet_peer_udp_posix.cpp
+++ b/drivers/unix/packet_peer_udp_posix.cpp
@@ -216,6 +216,8 @@ Error PacketPeerUDPPosix::_poll(bool p_wait) {
 
 		len = sizeof(struct sockaddr_storage);
 		++queue_count;
+		if (p_wait)
+			break;
 	};
 
 	// TODO: Should ECONNRESET be handled here?

--- a/platform/windows/packet_peer_udp_winsock.cpp
+++ b/platform/windows/packet_peer_udp_winsock.cpp
@@ -203,6 +203,8 @@ Error PacketPeerUDPWinsock::_poll(bool p_wait) {
 
 		len = sizeof(struct sockaddr_storage);
 		++queue_count;
+		if (p_wait)
+			break;
 	};
 
 	if (ret == SOCKET_ERROR) {


### PR DESCRIPTION
As explained in #4037 calling the UDP wait() function will lock the thread forever instead of returning after the first packet is received.
This PR fixes #4037 by just breaking the packet fetching loop when receiving in blocking mode (i.e. only when calling `wait()`).

I can cherry pick this to `2.1` along with 5f681d0b0f28cd39bc033c0cdf8eb3cb3a4acbe6 if everything looks okay.