### PR TITLE
Fixes to AudioListener2D

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -697,7 +697,7 @@ void Viewport::_update_listener() {
 
 void Viewport::_update_listener_2d() {
 
-	if (is_inside_tree() && audio_listener && (!get_parent() || (get_parent()->cast_to<Control>() && get_parent()->cast_to<Control>()->is_visible())))
+	if (is_inside_tree() && audio_listener_2d && (!get_parent() || (get_parent()->cast_to<Control>() && get_parent()->cast_to<Control>()->is_visible())))
 		SpatialSound2DServer::get_singleton()->listener_set_space(internal_listener_2d, find_world_2d()->get_sound_space());
 	else
 		SpatialSound2DServer::get_singleton()->listener_set_space(internal_listener_2d, RID());

--- a/servers/spatial_sound_2d/spatial_sound_2d_server_sw.cpp
+++ b/servers/spatial_sound_2d/spatial_sound_2d_server_sw.cpp
@@ -832,10 +832,7 @@ void SpatialSound2DServerSW::update(float p_delta) {
 		float total_distance = 0;
 		for (Set<RID>::Element *L = space->listeners.front(); L; L = L->next()) {
 			Listener *listener = listener_owner.get(L->get());
-			float d = listener->transform.get_origin().distance_to(source->transform.get_origin());
-			if (d == 0)
-				d = 0.1;
-			total_distance += d;
+			total_distance += MAX(0.1, listener->transform.get_origin().distance_to(source->transform.get_origin()));
 		}
 
 		//compute spatialization variables, weighted according to distance
@@ -852,7 +849,7 @@ void SpatialSound2DServerSW::update(float p_delta) {
 			Vector2 rel_vector = -listener->transform.xform_inv(source->transform.get_origin());
 			//Vector2 source_rel_vector = source->transform.xform_inv(listener->transform.get_origin()).normalized();
 			float distance = rel_vector.length();
-			float weight = distance / total_distance;
+			float weight = MAX(0.1, distance) / total_distance;
 			float pscale = 1.0;
 
 			float distance_scale = listener->params[LISTENER_PARAM_ATTENUATION_SCALE] * room->params[ROOM_PARAM_ATTENUATION_SCALE];


### PR DESCRIPTION
This PR fixes a typo in Viewport setting the listener 2D based on the option for the 3D one.
Additionally, when calculating the distance between the camera and the voice for computing the weight of each listener, it was was not correctly normalized.

The typo is also present in `master` branch but that part is commented out since I think spatial sounds are still a work in progress.

Fixes #4195.