### PR TITLE
Fix bug in pause mode propagation

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -463,7 +463,7 @@ Node::PauseMode Node::get_pause_mode() const {
 
 void Node::_propagate_pause_owner(Node *p_owner) {
 
-	if (data.pause_mode != PAUSE_MODE_INHERIT)
+	if (this != p_owner && data.pause_mode != PAUSE_MODE_INHERIT)
 		return;
 	data.pause_owner = p_owner;
 	for (int i = 0; i < data.children.size(); i++) {


### PR DESCRIPTION
Pause mode was not correctly propagating effectively stopping
immediately when the mode was not PAUSE_MODE_INHERIT.

Closes #8662 