### PR TITLE
Fixing previous merger's "not" vs. "!" mistake in C++

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4400,10 +4400,10 @@ void EditorNode::_toggle_distraction_free_mode() {
 		}
 
 		if (screen == EDITOR_SCRIPT) {
-			script_distraction = not script_distraction;
+			script_distraction = !script_distraction;
 			set_distraction_free_mode(script_distraction);
 		} else {
-			scene_distraction = not scene_distraction;
+			scene_distraction = !scene_distraction;
 			set_distraction_free_mode(scene_distraction);
 		}
 	} else {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1651,7 +1651,7 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 
 			current_option = -1;
 			//accept->get_cancel()->hide();
-			pick_main_scene->set_text(TTR("No main scene has ever been defined, select one?\nYou can change it later in later in \"Project Settings\" under the 'application' category."));
+			pick_main_scene->set_text(TTR("No main scene has ever been defined, select one?\nYou can change it later in \"Project Settings\" under the 'application' category."));
 			pick_main_scene->popup_centered_minsize();
 			return;
 		}


### PR DESCRIPTION
pull request #8532 from RameshRavone/patch-4 resulted in 2 lines referencing the non-existent keyword "not" in C++, causing build errors.