### PR TITLE
Improved freelook

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -591,10 +591,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("editors/3d/emulate_3_button_mouse", false);
 	set("editors/3d/warped_mouse_panning", true);
 
-	set("editors/3d/freelook_base_speed", 5);
-	set("editors/3d/freelook_acceleration", 10);
-	set("editors/3d/freelook_max_speed", 100);
-	set("editors/3d/freelook_modifier_speed_factor", 1.0 / 5.0);
+	set("editors/3d/freelook_base_speed", 1);
+	set("editors/3d/freelook_modifier_speed_factor", 5.0);
 
 	set("editors/2d/bone_width", 5);
 	set("editors/2d/bone_color1", Color(1.0, 1.0, 1.0, 0.9));

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -113,7 +113,8 @@ private:
 	bool transforming;
 	bool orthogonal;
 	float gizmo_scale;
-	real_t freelook_speed;
+
+	bool freelook_active;
 
 	struct _RayResult {
 
@@ -217,6 +218,10 @@ private:
 		}
 	} cursor;
 
+	void scale_cursor_distance(real_t scale);
+
+	real_t zoom_indicator_delay;
+
 	RID move_gizmo_instance[3], rotate_gizmo_instance[3];
 
 	String last_message;
@@ -258,6 +263,7 @@ public:
 	void set_state(const Dictionary &p_state);
 	Dictionary get_state() const;
 	void reset();
+	bool is_freelook_active() const { return freelook_active; }
 
 	void focus_selection();
 
@@ -298,11 +304,13 @@ public:
 	};
 
 private:
+	static const unsigned int VIEWPORTS_COUNT = 4;
+
 	EditorNode *editor;
 	EditorSelection *editor_selection;
 
 	Control *viewport_base;
-	SpatialEditorViewport *viewports[4];
+	SpatialEditorViewport *viewports[VIEWPORTS_COUNT];
 	VSplitContainer *shader_split;
 	HSplitContainer *palette_split;
 
@@ -457,6 +465,8 @@ private:
 	void _update_ambient_light_color(const Color &p_color);
 	void _update_default_light_angle();
 	void _default_light_angle_input(const InputEvent &p_event);
+
+	bool is_any_freelook_active() const;
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
- Fix movement input affecting all viewports even when clicking outside
- Freelook up movement is now relative
- Prevent tool shortcut conflict when moving
- De-hardcode tool shortcuts (select, move, rotate, scale, wireframe)
- Movement speed depends on zoom distance (like panning)
- Mouse wheel controls speed (Blender-style) due to above point
- Added zoom distance indicator, hides after short delay

Continuation of https://github.com/godotengine/godot/pull/8616