### PR TITLE
Fix Editor/Debugger connection problems.

### DIFF
--- a/drivers/unix/socket_helpers.h
+++ b/drivers/unix/socket_helpers.h
@@ -100,12 +100,20 @@ static size_t _set_listen_sockaddr(struct sockaddr_storage *p_addr, int p_port, 
 	};
 };
 
-static int _socket_create(IP::Type p_type, int type, int protocol) {
+static int _socket_create(IP::Type &p_type, int type, int protocol) {
 
 	ERR_FAIL_COND_V(p_type > IP::TYPE_ANY || p_type < IP::TYPE_NONE, ERR_INVALID_PARAMETER);
 
 	int family = p_type == IP::TYPE_IPV4 ? AF_INET : AF_INET6;
 	int sockfd = socket(family, type, protocol);
+
+	if (sockfd == -1 && p_type == IP::TYPE_ANY) {
+		// Careful here, changing the referenced parameter so the caller knows that we are using an IPv4 socket
+		// in place of a dual stack one, and further calls to _set_sock_addr will work as expected.
+		p_type = IP::TYPE_IPV4;
+		family = AF_INET;
+		sockfd = socket(family, type, protocol);
+	}
 
 	ERR_FAIL_COND_V(sockfd == -1, -1);
 

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -210,7 +210,7 @@ EditorExportPreset::EditorExportPreset() {
 
 void EditorExportPlatform::gen_debug_flags(Vector<String> &r_flags, int p_flags) {
 
-	String host = EditorSettings::get_singleton()->get("network/debug_host");
+	String host = EditorSettings::get_singleton()->get("network/debug/remote_host");
 
 	if (p_flags & DEBUG_FLAG_REMOTE_DEBUG_LOCALHOST)
 		host = "localhost";
@@ -620,7 +620,7 @@ Error EditorExportPlatform::save_zip(const Ref<EditorExportPreset> &p_preset, co
 
 void EditorExportPlatform::gen_export_flags(Vector<String> &r_flags, int p_flags) {
 
-	String host = EditorSettings::get_singleton()->get("network/debug_host");
+	String host = EditorSettings::get_singleton()->get("network/debug/remote_host");
 
 	if (p_flags & DEBUG_FLAG_REMOTE_DEBUG_LOCALHOST)
 		host = "localhost";
@@ -2108,7 +2108,7 @@ static int _get_pad(int p_alignment, int p_n) {
 
 void EditorExportPlatform::gen_export_flags(Vector<String> &r_flags, int p_flags) {
 
-	String host = EditorSettings::get_singleton()->get("network/debug_host");
+	String host = EditorSettings::get_singleton()->get("network/debug/remote_host");
 
 	if (p_flags&EXPORT_REMOTE_DEBUG_LOCALHOST)
 		host="localhost";

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -41,7 +41,7 @@ Error EditorRun::run(const String &p_scene, const String p_custom_args, const Li
 	List<String> args;
 
 	String resource_path = GlobalConfig::get_singleton()->get_resource_path();
-	String remote_host = EditorSettings::get_singleton()->get("network/debug_host");
+	String remote_host = EditorSettings::get_singleton()->get("network/debug/remote_host");
 
 	if (resource_path != "") {
 		args.push_back("-path");

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -41,6 +41,7 @@ Error EditorRun::run(const String &p_scene, const String p_custom_args, const Li
 	List<String> args;
 
 	String resource_path = GlobalConfig::get_singleton()->get_resource_path();
+	String remote_host = EditorSettings::get_singleton()->get("network/debug_host");
 
 	if (resource_path != "") {
 		args.push_back("-path");
@@ -49,7 +50,7 @@ Error EditorRun::run(const String &p_scene, const String p_custom_args, const Li
 
 	if (true) {
 		args.push_back("-rdebug");
-		args.push_back("localhost:" + String::num(GLOBAL_GET("network/debug/remote_port")));
+		args.push_back(remote_host + ":" + String::num(GLOBAL_GET("network/debug/remote_port")));
 	}
 
 	args.push_back("-epid");

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -407,7 +407,8 @@ void EditorSettings::setup_network() {
 	IP::get_singleton()->get_local_addresses(&local_ip);
 	String lip;
 	String hint;
-	String current = has("network/debug_host") ? get("network/debug_host") : "";
+	String current = has("network/debug/remote_host") ? get("network/debug/remote_host") : "";
+	int port = has("network/debug/remote_port") ? (int)get("network/debug/remote_port") : 6007;
 
 	for (List<IP_Address>::Element *E = local_ip.front(); E; E = E->next()) {
 
@@ -422,8 +423,11 @@ void EditorSettings::setup_network() {
 		hint += ip;
 	}
 
-	set("network/debug_host", lip);
-	add_property_hint(PropertyInfo(Variant::STRING, "network/debug_host", PROPERTY_HINT_ENUM, hint));
+	set("network/debug/remote_host", lip);
+	add_property_hint(PropertyInfo(Variant::STRING, "network/debug/remote_host", PROPERTY_HINT_ENUM, hint));
+
+	set("network/debug/remote_port", port);
+	add_property_hint(PropertyInfo(Variant::INT, "network/debug/remote_port", PROPERTY_HINT_RANGE, "1,65535,1"));
 }
 
 void EditorSettings::save() {

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -412,8 +412,6 @@ void EditorSettings::setup_network() {
 	for (List<IP_Address>::Element *E = local_ip.front(); E; E = E->next()) {
 
 		String ip = E->get();
-		if (ip == "127.0.0.1")
-			continue;
 
 		if (lip == "")
 			lip = ip;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -588,8 +588,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		ScriptDebuggerRemote *sdr = memnew(ScriptDebuggerRemote);
 		uint16_t debug_port = GLOBAL_GET("network/debug/remote_port");
 		if (debug_host.find(":") != -1) {
-			debug_port = debug_host.get_slicec(':', 1).to_int();
-			debug_host = debug_host.get_slicec(':', 0);
+			int sep_pos = debug_host.find_last(":");
+			debug_port = debug_host.substr(sep_pos + 1, debug_host.length()).to_int();
+			debug_host = debug_host.substr(0, sep_pos);
 		}
 		Error derr = sdr->connect_to_host(debug_host, debug_port);
 


### PR DESCRIPTION
In this PR:

- `_socket_create` now falls back to IPv4 when requesting type IP_ANY and the current machine does not allow IPv6 sockets
- Fix local interface address detection (we where recognizing non-INET addresses as local IP addresses)
- The editor now respects the `debug_host` option pushing it as the `rdebug` argument host.
- The `network/debug_host` option is now renamed to `network/debug/remote_host` for consistency with `network/debug/remote_port`. (do you like this location? Do you want to move it to `run/debug`?)

Fixes #7544 #8563 #5828
Possibly also #2604 (but I think that the `gethostbyname` error is actually unrelated to the real problem).