### PR TITLE
Add error printing functions to GDNative

### DIFF
--- a/modules/gdnative/godot.cpp
+++ b/modules/gdnative/godot.cpp
@@ -30,6 +30,7 @@
 #include "godot.h"
 
 #include "class_db.h"
+#include "error_macros.h"
 #include "gdnative.h"
 #include "global_config.h"
 #include "global_constants.h"
@@ -213,6 +214,14 @@ void GDAPI *godot_realloc(void *p_ptr, int p_bytes) {
 
 void GDAPI godot_free(void *p_ptr) {
 	memfree(p_ptr);
+}
+
+void GDAPI godot_print_error(const char *p_description, const char *p_function, const char *p_file, int p_line) {
+	_err_print_error(p_function, p_file, p_line, p_description, ERR_HANDLER_ERROR);
+}
+
+void GDAPI godot_print_warning(const char *p_description, const char *p_function, const char *p_file, int p_line) {
+	_err_print_error(p_function, p_file, p_line, p_description, ERR_HANDLER_WARNING);
 }
 
 #ifdef __cplusplus

--- a/modules/gdnative/godot.h
+++ b/modules/gdnative/godot.h
@@ -404,6 +404,10 @@ void GDAPI *godot_alloc(int p_bytes);
 void GDAPI *godot_realloc(void *p_ptr, int p_bytes);
 void GDAPI godot_free(void *p_ptr);
 
+//print using Godot's error handler list
+void GDAPI godot_print_error(const char *p_description, const char *p_function, const char *p_file, int p_line);
+void GDAPI godot_print_warning(const char *p_description, const char *p_function, const char *p_file, int p_line);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Wraps `_err_print_error` (called by the error macros) for the C API. That function passes errors to the Godot debugger tab and the other error handlers.

GDNative language bindings can use `godot_print_error` to implement the [error macros](https://github.com/godotengine/godot/blob/master/core/error_macros.h) or something similar for their language.