### PR TITLE
Fix one-way collision detection (2.1)

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -27203,7 +27203,7 @@
 			<argument index="1" name="normal" type="Vector2">
 			</argument>
 			<description>
-				Set a direction in which bodies can go through the given one. If this value is different from (0,0), any movement within 90 degrees of this vector is considered a valid movement. Set this direction to (0,0) to disable one-way collisions.
+				Set a direction from which bodies can go through the given one; that is, the passed vector is the normal of the pass-through side of the surface. If this value is different from (0,0), any movement within 90 degrees of the opposite of this vector is considered an valid movement. Set this direction to (0,0) to disable one-way collisions.
 			</description>
 		</method>
 		<method name="body_set_one_way_collision_max_depth">
@@ -27212,7 +27212,7 @@
 			<argument index="1" name="depth" type="float">
 			</argument>
 			<description>
-				Set how far a body can go through the given one, if it allows one-way collisions (see [method body_set_one_way_collision_direction]).
+				Set how deep at most a body can be with respect to the given one for the physics server to force it to a non-overlapping position, if it allows one-way collisions (see [method body_set_one_way_collision_direction]).
 			</description>
 		</method>
 		<method name="body_set_param">
@@ -28140,14 +28140,14 @@
 			<argument index="0" name="dir" type="Vector2">
 			</argument>
 			<description>
-				Set a direction in which bodies can go through this one. If this value is different from (0,0), any movement within 90 degrees of this vector is considered a valid movement. Set this direction to (0,0) to disable one-way collisions.
+				Set a direction from which bodies can go through this one; that is, the passed vector is the normal of the pass-through side of the surface. If this value is different from (0,0), any movement within 90 degrees of the opposite of this vector is considered an valid movement. Set this direction to (0,0) to disable one-way collisions.
 			</description>
 		</method>
 		<method name="set_one_way_collision_max_depth">
 			<argument index="0" name="depth" type="float">
 			</argument>
 			<description>
-				Set how far a body can go through this one, when it allows one-way collisions (see [method set_one_way_collision_direction]).
+				Set how deep at most a body can be with respect to this one for the physics server to force it to a non-overlapping position, if it allows one-way collisions (see [method body_set_one_way_collision_direction]).
 			</description>
 		</method>
 	</methods>

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -405,13 +405,10 @@ static void _rest_cbk_result(const Vector2 &p_point_A, const Vector2 &p_point_B,
 	_RestCallbackData2D *rd = (_RestCallbackData2D *)p_userdata;
 
 	if (rd->valid_dir != Vector2()) {
-
-		if (rd->valid_dir != Vector2()) {
-			if (p_point_A.distance_squared_to(p_point_B) > rd->valid_depth * rd->valid_depth)
-				return;
-			if (rd->valid_dir.dot((p_point_A - p_point_B).normalized()) < Math_PI * 0.25)
-				return;
-		}
+		if (p_point_A.distance_squared_to(p_point_B) > rd->valid_depth * rd->valid_depth)
+			return;
+		if (rd->valid_dir.dot((p_point_A - p_point_B).normalized()) < Math_PI * 0.25)
+			return;
 	}
 
 	Vector2 contact_rel = p_point_B - p_point_A;
@@ -744,7 +741,7 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Matrix32 &p_from, const
 						cbk.amount = 0;
 						cbk.ptr = cd;
 						cbk.valid_dir = body->get_one_way_collision_direction();
-						cbk.valid_depth = body->get_one_way_collision_max_depth();
+						cbk.valid_depth = 10e20; //body is already unstuck; no need for depth testing at this stage
 
 						Vector2 sep = mnormal; //important optimization for this to work fast enough
 						bool collided = CollisionSolver2DSW::solve(body_shape, body_shape_xform, p_motion * (hi + contact_max_allowed_penetration), col_obj->get_shape(shape_idx), col_obj_xform, Vector2(), Physics2DServerSW::_shape_col_cbk, &cbk, &sep, 0);


### PR DESCRIPTION
This one makes the "max depth" parameter of OWC to be used only during the "unstuck" phase of the body motion algorithm. This is the only way I've found for this to work correctly.

Without this PR, the algorithm usually pushes the kinematic body up to the solid side of the platforms. It's noticebale, for instance, in the kinematic character demo. And if you try to fix that by setting a low or even close to zero "max depth", your character falls through the platform.

With this PR, the mentioned demo as well as the 2D platformer demo keep working as usual, but you can improve them by setting a lower value for the "max depth" on their OWC platforms. Namely, you can fix the noticeable push in the KC demo with a "max depth" of 1.

That is, now "max depth" has this meaning (which I think was always its intended purpose): _how deep at most a body can be with respect to this one for the physics server to force it to a non-overlapping position_.

Also, I've changed the explanation of the one-way collision direction in the docs to reflect how it is actually used by the engine and I've cleared up the usage of the "max depth" property.

@reduz, please have a look and tell me if it's correct and if I have to port it to 3.0. Also note the description and actual meaning of the one way collision direction were inverted, so you can decide how to define it for 3.0.

This might also helps fixing some of the issues people are having with KBs.