### PR TITLE
Bring back EditorImportPlugin

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3566,7 +3566,7 @@ bool EditorNode::is_scene_in_use(const String &p_path) {
 void EditorNode::register_editor_types() {
 
 	ClassDB::register_class<EditorPlugin>();
-	//	ClassDB::register_class<EditorImportPlugin>();
+	ClassDB::register_class<EditorImportPlugin>();
 	//	ClassDB::register_class<EditorExportPlugin>();
 	//	ClassDB::register_class<EditorScenePostImport>();
 	ClassDB::register_class<EditorScript>();

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -276,6 +276,11 @@ bool EditorPlugin::get_remove_list(List<Node *> *p_list) {
 void EditorPlugin::restore_global_state() {}
 void EditorPlugin::save_global_state() {}
 
+void EditorPlugin::add_import_plugin(const Ref<EditorImportPlugin> &p_importer) {
+	ResourceFormatImporter::get_singleton()->add_importer(p_importer);
+	EditorFileSystem::get_singleton()->scan_changes();
+}
+
 void EditorPlugin::set_window_layout(Ref<ConfigFile> p_layout) {
 
 	if (get_script_instance() && get_script_instance()->has_method("set_window_layout")) {
@@ -360,7 +365,7 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_editor_settings:EditorSettings"), &EditorPlugin::get_editor_settings);
 	ClassDB::bind_method(D_METHOD("queue_save_layout"), &EditorPlugin::queue_save_layout);
 	ClassDB::bind_method(D_METHOD("edit_resource"), &EditorPlugin::edit_resource);
-
+	ClassDB::bind_method(D_METHOD("add_import_plugin"), &EditorPlugin::add_import_plugin);
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "forward_canvas_gui_input", PropertyInfo(Variant::TRANSFORM2D, "canvas_xform"), PropertyInfo(Variant::INPUT_EVENT, "event")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo("forward_draw_over_canvas", PropertyInfo(Variant::TRANSFORM2D, "canvas_xform"), PropertyInfo(Variant::OBJECT, "canvas:Control")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "forward_spatial_gui_input", PropertyInfo(Variant::OBJECT, "camera", PROPERTY_HINT_RESOURCE_TYPE, "Camera"), PropertyInfo(Variant::INPUT_EVENT, "event")));

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -30,6 +30,7 @@
 #ifndef EDITOR_PLUGIN_H
 #define EDITOR_PLUGIN_H
 
+#include "editor/import/editor_import_plugin.h"
 #include "io/config_file.h"
 #include "scene/gui/tool_button.h"
 #include "scene/main/node.h"
@@ -145,6 +146,8 @@ public:
 
 	virtual void restore_global_state();
 	virtual void save_global_state();
+
+	void add_import_plugin(const Ref<EditorImportPlugin> &p_importer);
 
 	EditorPlugin();
 	virtual ~EditorPlugin();

--- a/editor/import/editor_import_plugin.cpp
+++ b/editor/import/editor_import_plugin.cpp
@@ -1,0 +1,152 @@
+/*************************************************************************/
+/*  editor_import_plugin.cpp                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#include "editor_import_plugin.h"
+#include "core/script_language.h"
+
+EditorImportPlugin::EditorImportPlugin() {
+}
+
+String EditorImportPlugin::get_importer_name() const {
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("get_importer_name")), "");
+	return get_script_instance()->call("get_importer_name");
+}
+
+String EditorImportPlugin::get_visible_name() const {
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("get_visible_name")), "");
+	return get_script_instance()->call("get_visible_name");
+}
+
+void EditorImportPlugin::get_recognized_extensions(List<String> *p_extensions) const {
+	ERR_FAIL_COND(!(get_script_instance() && get_script_instance()->has_method("get_recognized_extensions")));
+	Array extensions = get_script_instance()->call("get_recognized_extensions");
+	for (int i = 0; i < extensions.size(); i++) {
+		p_extensions->push_back(extensions[i]);
+	}
+}
+
+String EditorImportPlugin::get_preset_name(int p_idx) const {
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("get_preset_name")), "");
+	return get_script_instance()->call("get_preset_name", p_idx);
+}
+
+int EditorImportPlugin::get_preset_count() {
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("get_preset_count")), 0);
+	return get_script_instance()->call("get_preset_count");
+}
+
+String EditorImportPlugin::get_save_extension() const {
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("get_save_extension")), "");
+	return get_script_instance()->call("get_save_extension");
+}
+
+String EditorImportPlugin::get_resource_type() const {
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("get_resource_type")), "");
+	return get_script_instance()->call("get_resource_type");
+}
+
+void EditorImportPlugin::get_import_options(List<ResourceImporter::ImportOption> *r_options, int p_preset) const {
+
+	ERR_FAIL_COND(!(get_script_instance() && get_script_instance()->has_method("get_import_options")));
+	Array needed;
+	needed.push_back("name");
+	needed.push_back("default_value");
+	Array options = get_script_instance()->call("get_import_options", p_preset);
+	for (int i = 0; i < options.size(); i++) {
+		Dictionary d = options[i];
+		ERR_FAIL_COND(!d.has_all(needed));
+		String name = d["name"];
+		Variant default_value = d["default_value"];
+
+		PropertyHint hint = PROPERTY_HINT_NONE;
+		if (d.has("property_hint")) {
+			hint = (PropertyHint)d["property_hint"].operator int64_t();
+		}
+
+		String hint_string;
+		if (d.has("hint_string")) {
+			hint_string = d["hint_string"];
+		}
+
+		uint32_t usage = PROPERTY_USAGE_DEFAULT;
+		if (d.has("usage")) {
+			usage = d["usage"];
+		}
+
+		ImportOption option(PropertyInfo(default_value.get_type(), name, hint, hint_string, usage), default_value);
+		r_options->push_back(option);
+	}
+}
+
+bool EditorImportPlugin::get_option_visibility(const String &p_option, const Map<StringName, Variant> &p_options) const {
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("get_option_visibility")), true);
+	Dictionary d;
+	Map<StringName, Variant>::Element *E = p_options.front();
+	while (E) {
+		d[E->key()] = E->get();
+		E = E->next();
+	}
+	return get_script_instance()->call("get_option_visibility", p_option, d);
+}
+
+Error EditorImportPlugin::import(const String &p_source_file, const String &p_save_path, const Map<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files) {
+
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("import")), ERR_UNAVAILABLE);
+	Dictionary options;
+	Array platform_variants, gen_files;
+
+	Map<StringName, Variant>::Element *E = p_options.front();
+	while (E) {
+		options[E->key()] = E->get();
+		E = E->next();
+	}
+	Error err = (Error)get_script_instance()->call("import", p_source_file, p_save_path, options, platform_variants, gen_files).operator int64_t();
+
+	for (int i = 0; i < platform_variants.size(); i++) {
+		r_platform_variants->push_back(platform_variants[i]);
+	}
+	for (int i = 0; i < gen_files.size(); i++) {
+		r_gen_files->push_back(gen_files[i]);
+	}
+	return err;
+}
+
+void EditorImportPlugin::_bind_methods() {
+
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "get_importer_name"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "get_visible_name"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::INT, "get_preset_count"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "get_preset_name", PropertyInfo(Variant::INT, "preset")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::ARRAY, "get_recognized_extensions"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::ARRAY, "get_import_options", PropertyInfo(Variant::INT, "preset")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "get_save_extension"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "get_resource_type"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "get_option_visibility", PropertyInfo(Variant::STRING, "option"), PropertyInfo(Variant::DICTIONARY, "options")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::INT, "import", PropertyInfo(Variant::STRING, "source_file"), PropertyInfo(Variant::STRING, "save_path"), PropertyInfo(Variant::DICTIONARY, "options"), PropertyInfo(Variant::ARRAY, "r_platform_variants"), PropertyInfo(Variant::ARRAY, "r_gen_files")));
+}

--- a/editor/import/editor_import_plugin.h
+++ b/editor/import/editor_import_plugin.h
@@ -1,0 +1,54 @@
+/*************************************************************************/
+/*  editor_import_plugin.h                                               */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#ifndef EDITOR_IMPORT_PLUGIN_H
+#define EDITOR_IMPORT_PLUGIN_H
+
+#include "io/resource_import.h"
+
+class EditorImportPlugin : public ResourceImporter {
+	GDCLASS(EditorImportPlugin, Reference)
+protected:
+	static void _bind_methods();
+
+public:
+	EditorImportPlugin();
+	virtual String get_importer_name() const;
+	virtual String get_visible_name() const;
+	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual String get_preset_name(int p_idx) const;
+	virtual int get_preset_count();
+	virtual String get_save_extension() const;
+	virtual String get_resource_type() const;
+	virtual void get_import_options(List<ImportOption> *r_options, int p_preset) const;
+	virtual bool get_option_visibility(const String &p_option, const Map<StringName, Variant> &p_options) const;
+	virtual Error import(const String &p_source_file, const String &p_save_path, const Map<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files);
+};
+
+#endif //EDITOR_IMPORT_PLUGIN_H


### PR DESCRIPTION
This adds a new implementation of the `EditorImportPlugin` class, allowing to leverage the new importing system via tool scripts.
Will be especially useful when used together with GDNative, to support formats like fbx :)

I'll write docs and a demo soon.