### PR TITLE
Project Settings: Use capitalized properties.

### DIFF
--- a/editor/project_settings.cpp
+++ b/editor/project_settings.cpp
@@ -1264,7 +1264,6 @@ ProjectSettings::ProjectSettings(EditorData *p_data) {
 	//globals_editor->hide_top_label();
 	globals_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	globals_editor->get_property_editor()->register_text_enter(search_box);
-	globals_editor->get_property_editor()->set_enable_capitalize_paths(false);
 	globals_editor->get_property_editor()->get_scene_tree()->connect("cell_selected", this, "_item_selected");
 	globals_editor->get_property_editor()->connect("property_toggled", this, "_item_checked", varray(), CONNECT_DEFERRED);
 	globals_editor->get_property_editor()->connect("property_edited", this, "_settings_prop_edited");


### PR DESCRIPTION
There's been some inconsistency between the ProjectSettings and EditorSettings:
One would use `snake_case_properties`, the other `Capitalized Properties`.

This fixes that by also using capitalized properties for the project settings.
(It's actually the default, so the line setting it to false was just removed..)

Was there a strong reason for using snake_case here in the first place?