### PR TITLE
Fix possible memory leak for Android and update gradle

### DIFF
--- a/platform/android/build.gradle.template
+++ b/platform/android/build.gradle.template
@@ -3,7 +3,7 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:2.1.0'
+		classpath 'com.android.tools.build:gradle:2.3.1'
 		$$GRADLE_CLASSPATH$$
 	}
 }

--- a/platform/android/java/gradle/wrapper/gradle-wrapper.properties
+++ b/platform/android/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Fri May 12 08:50:03 KST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-bin.zip
+org.gradle.jvmargs=-Xmx1536M

--- a/platform/android/java/src/com/google/android/vending/expansion/downloader/impl/DownloaderService.java
+++ b/platform/android/java/src/com/google/android/vending/expansion/downloader/impl/DownloaderService.java
@@ -569,10 +569,10 @@ public abstract class DownloaderService extends CustomIntentService implements I
      */
     void pollNetworkState() {
         if (null == mConnectivityManager) {
-            mConnectivityManager = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+            mConnectivityManager = (ConnectivityManager) getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
         }
         if (null == mWifiManager) {
-            mWifiManager = (WifiManager) getSystemService(Context.WIFI_SERVICE);
+            mWifiManager = (WifiManager) getApplicationContext().getSystemService(Context.WIFI_SERVICE);
         }
         if (mConnectivityManager == null) {
             Log.w(Constants.TAG,


### PR DESCRIPTION
there is an error message when compile with latest build tool for android.
```
/godot_dev/platform/android/java/src/com/google/android/vending/expansion/downloader/impl/DownloaderService.java:575: Error: The WIFI_SERVICE must be looked up on the Application context or memory will leak on devices < Android N. Try changing  to .getApplicationContext()  [WifiManagerLeak]
            mWifiManager = (WifiManager) getSystemService(Context.WIFI_SERVICE);
                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

   Explanation for issues of type "WifiManagerLeak":
   On versions prior to Android N (24), initializing the WifiManager via
   Context#getSystemService can cause a memory leak if the context is not the
   application context. Change context.getSystemService(...) to
   context.getApplicationContext().getSystemService(...).

1 errors, 0 warnings
```
this pr will fix the error and update to latest gradle.