### PR TITLE
Fix compile error when use "android_add_jni_dir"

### DIFF
--- a/platform/android/build.gradle.template
+++ b/platform/android/build.gradle.template
@@ -66,6 +66,7 @@ android {
 				$$GRADLE_ASSET_DIRS$$
 			]
 			jniLibs.srcDirs = [
+				'libs'
 				$$GRADLE_JNI_DIRS$$
 			]
 		}


### PR DESCRIPTION
`$$GRADLE_JNI_DIRS$$` is replaced `,'path/lib1', 'path/lib2'`