### PR TITLE
Document exhaustive licensing info of all files

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -1,0 +1,1139 @@
+# Exhaustive licensing information for files in the Godot Engine repository
+# =========================================================================
+#
+# This file aims at documenting the copyright and license for every source
+# file in the Godot Engine repository, and especially outline the files
+# whose license differs from the MIT/Expat license used by Godot Engine.
+#
+# It is written as a machine-readable format following the debian/copyright
+# specification. Globbing patterns (e.g. "Files: *") mean that they affect
+# all corresponding files (also recursively in subfolders), apart from those
+# with a more explicit copyright statement.
+#
+# Licenses are given with their SPDX identifier, and are all included in
+# plain text at the end of this file (in alphabetical order).
+#
+# Disclaimer for thirdparty libraries:
+# ------------------------------------
+#
+# Licensing details for thirdparty libraries in the 'thirdparty/' directory
+# are given in summarized form, i.e. with only the "main" license described
+# in the library's license statement. Different licenses of single files or
+# code snippets in thirdparty libraries are not documented here.
+# For example:
+#   Files: ./thirdparty/zlib/
+#   Copyright: 1995-2017, Jean-loup Gailly and Mark Adler
+#   License: Zlib
+# The exact copyright for each file in that library *may* differ, and some
+# files or code snippets might be distributed under other compatible licenses
+# (e.g. a public domain dedication), but as far as Godot Engine is concerned
+# the library is considered as a whole under the Zlib license.
+#
+# Nota: When linking dynamically against thirdparty libraries instead of
+# building them into the Godot binary, you may remove the corresponding
+# license details from this file.
+
+-----------------------------------------------------------------------
+
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: Godot Engine
+Upstream-Contact: Rémi Verschelde <contact@godotengine.org>
+Source: https://github.com/godotengine/godot
+
+Files: *
+Copyright: 2007-2017, Juan Linietsky, Ariel Manzur.
+  2014-2017, Godot Engine contributors (cf. AUTHORS.md)
+License: Expat
+
+Files: ./icon.png
+ ./icon.svg
+ ./logo.png
+ ./logo.svg
+Copyright: Andrea Calabró
+License: CC-BY-3.0
+
+Files: ./platform/android/android_native_app_glue.c
+ ./platform/android/android_native_app_glue.h
+ ./platform/android/java/aidl/com/android/vending/billing/IInAppBillingService.aidl
+ ./platform/android/java/res/layout/status_bar_ongoing_event_progress_bar.xml
+ ./platform/android/java/src/com/android/vending/licensing/*
+ ./platform/android/java/src/com/google/android/vending/expansion/downloader/*
+ ./platform/android/java/src/org/godotengine/godot/input/InputManagerCompat.java
+ ./platform/android/java/src/org/godotengine/godot/input/InputManagerV16.java
+ ./platform/android/java/src/org/godotengine/godot/input/InputManagerV9.java
+Copyright: 2008-2013, The Android Open Source Project
+License: Apache-2.0
+
+Files: ./platform/android/cpu-features.c
+ ./platform/android/cpu-features.h
+Copyright: 2010, The Android Open Source Project
+License: BSD-2-clause
+
+Files: ./platform/android/ifaddrs_android.cpp
+ ./platform/android/ifaddrs_android.h
+Copyright: 2012-2013, Google Inc.
+License: BSD-3-clause
+
+Files: ./platform/android/java/src/com/android/vending/licensing/util/Base64.java
+ ./platform/android/java/src/com/android/vending/licensing/util/Base64DecoderException.java
+Copyright: 2002, Google Inc.
+License: Apache-2.0
+
+Files: ./platform/android/power_android.cpp
+ ./platform/osx/power_osx.cpp
+ ./platform/windows/power_windows.cpp
+ ./platform/x11/power_x11.cpp
+Copyright: 1997-2017, Sam Lantinga
+  2007-2017, Juan Linietsky, Ariel Manzur.
+  2014-2017, Godot Engine contributors (cf. AUTHORS.md)
+License: Expat and Zlib
+
+Files: ./platform/uwp/export/export.cpp
+Copyright: 2016, Facebook, Inc. All rights reserved.
+  2007-2017, Juan Linietsky, Ariel Manzur.
+  2014-2017, Godot Engine contributors (cf. AUTHORS.md)
+License: BSD-3-clause and Expat
+
+Files: ./servers/physics/gjk_epa.cpp
+ ./servers/physics/joints/generic_6dof_joint_sw.cpp
+ ./servers/physics/joints/generic_6dof_joint_sw.h
+ ./servers/physics/joints/hinge_joint_sw.cpp
+ ./servers/physics/joints/hinge_joint_sw.h
+ ./servers/physics/joints/jacobian_entry_sw.h
+ ./servers/physics/joints/pin_joint_sw.cpp
+ ./servers/physics/joints/pin_joint_sw.h
+ ./servers/physics/joints/slider_joint_sw.cpp
+ ./servers/physics/joints/slider_joint_sw.h
+Copyright: 2003-2008, Erwin Coumans
+  2007-2017, Juan Linietsky, Ariel Manzur.
+  2014-2017, Godot Engine contributors (cf. AUTHORS.md)
+License: Expat and Zlib
+
+Files: ./servers/physics/joints/cone_twist_joint_sw.cpp
+ ./servers/physics/joints/cone_twist_joint_sw.h
+Copyright: 2007, Starbreeze Studios
+  2007-2017, Juan Linietsky, Ariel Manzur.
+  2014-2017, Godot Engine contributors (cf. AUTHORS.md)
+License: Expat and Zlib
+
+Files: ./thirdparty/b2d_convexdecomp/
+Copyright: 2007, Eric Jordan
+Copyright: 2006-2009, Erin Catto
+License: Zlib
+
+Files: ./thirdparty/certs/ca-certificates.crt
+Copyright: FIXME
+License: FIXME
+
+Files: ./thirdparty/enet/
+Copyright: 2002-2016, Lee Salzman
+License: Expat
+
+Files: ./thirdparty/fonts/DroidSans*.ttf
+Copyright: 2008, The Android Open Source Project
+License: Apache-2.0
+
+Files: ./thirdparty/fonts/source_code_pro.otf
+Copyright: 2010, 2012, Adobe Systems Incorporated
+License: OFL-1.1
+
+Files: ./thirdparty/freetype/
+Copyright: 1996-2016, David Turner, Robert Wilhelm, and Werner Lemberg.
+License: FTL
+
+Files: ./thirdparty/glad/
+Copyright: 2013, David Herberth
+License: Expat
+
+Files: ./thirdparty/jpeg_compressor/
+Copyright: 2012, Rich Geldreich
+License: public-domain
+
+Files: ./thirdparty/libogg/
+Copyright: 2002, Xiph.org Foundation
+License: BSD-3-clause
+
+Files: ./thirdparty/libpng/
+Copyright: 1995-1996, Guy Eric Schalnat, Group 42, Inc.
+ 1996-1997, Andreas Dilger
+ 1998-2016, Glenn Randers-Pehrson
+License: Zlib
+
+Files: ./thirdparty/libsimplewebm/
+Copyright: 2016, Błażej Szczygieł
+License: Expat
+
+Files: ./thirdparty/libsimplewebm/libwebm/
+Copyright: 2010, Google Inc.
+License: BSD-3-clause
+
+Files: ./thirdparty/libtheora/
+Copyright: 2002-2009, Xiph.org Foundation
+License: BSD-3-clause
+
+Files: ./thirdparty/libvorbis/
+Copyright: 2002-2015, Xiph.org Foundation
+License: BSD-3-clause
+
+Files: ./thirdparty/libvpx/
+Copyright: 2010, The WebM Project authors.
+License: BSD-3-clause
+
+Files: ./thirdparty/libwebp/COPYING
+Copyright: 2010, Google Inc.
+License: BSD-3-clause
+
+Files: ./thirdparty/minizip/
+Copyright: 1998-2010, Gilles Vollant
+  2007-2008, Even Rouault
+  2009-2010, Mathias Svensson
+License: Zlib
+
+Files: ./thirdparty/misc/aes256.cpp
+ ./thirdparty/misc/aes256.h
+ ./thirdparty/misc/sha256.c
+ ./thirdparty/misc/sha256.h
+Copyright: 2007-2011, Ilya O. Levin
+License: ISC
+
+Files: ./thirdparty/misc/base64.c
+ ./thirdparty/misc/base64.h
+Copyright: Ari Edelkind
+License: public-domain
+
+Files: ./thirdparty/misc/curl_hostcheck.c
+ ./thirdparty/misc/curl_hostcheck.h
+Copyright: 1998-2012, Daniel Stenberg et al.
+License: curl
+
+Files: ./thirdparty/misc/fastlz.c
+ ./thirdparty/misc/fastlz.h
+Copyright: 2005-2007, Ariya Hidayat
+License: Expat
+
+Files: ./thirdparty/misc/hq2x.cpp
+ ./thirdparty/misc/hq2x.h
+Copyright: 2016, Bruno Ribeiro
+License: Apache-2.0
+
+Files: ./thirdparty/misc/md5.cpp
+ ./thirdparty/misc/md5.h
+Copyright: 1990, RSA Data Security, Inc.
+License: RSA-MD
+
+Files: ./thirdparty/misc/mikktspace.c
+ ./thirdparty/misc/mikktspace.h
+Copyright: 2011, Morten S. Mikkelsen
+License: Zlib
+
+Files: ./thirdparty/misc/pcg.cpp
+ ./thirdparty/misc/pcg.h
+Copyright: 2014, M.E. O'Neill
+License: Apache-2.0
+
+Files: ./thirdparty/misc/smaz.c
+ ./thirdparty/misc/smaz.h
+Copyright: 2006-2009, Salvatore Sanfilippo
+License: BSD-3-clause
+
+Files: ./thirdparty/misc/stb_truetype.h
+ ./thirdparty/misc/stb_vorbis.c
+Copyright: 2007-2015, Sean Barrett
+License: public-domain
+
+Files: ./thirdparty/misc/triangulator.cpp
+ ./thirdparty/misc/triangulator.h
+Copyright: 2011, Ivan Fratric
+License: Expat
+
+Files: ./thirdparty/misc/yuv2rgb.h
+Copyright: 2008-2011, Robin Watts
+License: BSD-2-clause
+
+Files: ./thirdparty/openssl/
+Copyright: 1998-2016, The OpenSSL Project.
+License: OpenSSL
+
+Files: ./thirdparty/opus/
+Copyright: 2001-2011, Xiph.Org, Skype Limited, Octasic,
+ Jean-Marc Valin, Timothy B. Terriberry,
+ CSIRO, Gregory Maxwell, Mark Borgerding,
+ Erik de Castro Lopo
+License: BSD-3-clause
+
+Files: ./thirdparty/pvrtccompressor/
+Copyright: 2014, Jeffrey Lim.
+License: BSD-3-clause
+
+Files: ./thirdparty/rg-etc1/
+Copyright: 2012, Rich Geldreich
+License: Zlib
+
+Files: ./thirdparty/rtaudio/
+Copyright: 2001-2016, Gary P. Scavone
+License: Expat
+
+Files: ./thirdparty/squish/
+Copyright: 2006, Simon Brown
+License: Expat
+
+Files: ./thirdparty/zlib/
+Copyright: 1995-2017, Jean-loup Gailly and Mark Adler
+License: Zlib
+
+
+
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+     http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+License: BSD-2-clause
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ .
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ .
+ Redistributions in binary form must reproduce the above copyright notice, this
+ list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution. Neither the name of the author
+ nor the names of its contributors may be used to endorse or promote products
+ derived from this software without specific prior written permission.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+License: BSD-3-clause
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ .
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ .
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ .
+ 3. Neither the name of the University nor the names of its contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ SUCH DAMAGE.
+
+License: CC-BY-3.0
+ Creative Commons Attribution 3.0 Unported
+ .
+ CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+ LEGAL SERVICES. DISTRIBUTION OF THIS LICENSE DOES NOT CREATE AN
+ ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS INFORMATION
+ ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES REGARDING THE
+ INFORMATION PROVIDED, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+ ITS USE.
+ .
+ License
+ .
+ THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS CREATIVE
+ COMMONS PUBLIC LICENSE ("CCPL" OR "LICENSE"). THE WORK IS PROTECTED BY
+ COPYRIGHT AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS
+ AUTHORIZED UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+ .
+ BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HERE, YOU ACCEPT AND AGREE
+ TO BE BOUND BY THE TERMS OF THIS LICENSE. TO THE EXTENT THIS LICENSE MAY
+ BE CONSIDERED TO BE A CONTRACT, THE LICENSOR GRANTS YOU THE RIGHTS
+ CONTAINED HERE IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+ CONDITIONS.
+ .
+ 1. Definitions
+ .
+ a. "Adaptation" means a work based upon the Work, or upon the Work and
+ other pre-existing works, such as a translation, adaptation, derivative
+ work, arrangement of music or other alterations of a literary or
+ artistic work, or phonogram or performance and includes cinematographic
+ adaptations or any other form in which the Work may be recast,
+ transformed, or adapted including in any form recognizably derived from
+ the original, except that a work that constitutes a Collection will not
+ be considered an Adaptation for the purpose of this License. For the
+ avoidance of doubt, where the Work is a musical work, performance or
+ phonogram, the synchronization of the Work in timed-relation with a
+ moving image ("synching") will be considered an Adaptation for the
+ purpose of this License.
+ .
+ b. "Collection" means a collection of literary or artistic works, such
+ as encyclopedias and anthologies, or performances, phonograms or
+ broadcasts, or other works or subject matter other than works listed in
+ Section 1(f) below, which, by reason of the selection and arrangement of
+ their contents, constitute intellectual creations, in which the Work is
+ included in its entirety in unmodified form along with one or more other
+ contributions, each constituting separate and independent works in
+ themselves, which together are assembled into a collective whole. A work
+ that constitutes a Collection will not be considered an Adaptation (as
+ defined above) for the purposes of this License.
+ .
+ c.  "Distribute" means to make available to the public the original and
+ copies of the Work or Adaptation, as appropriate, through sale or other
+ transfer of ownership.
+ .
+ d. "Licensor" means the individual, individuals, entity or entities that
+ offer(s) the Work under the terms of this License.
+ .
+ e. "Original Author" means, in the case of a literary or artistic work,
+ the individual, individuals, entity or entities who created the Work or
+ if no individual or entity can be identified, the publisher; and in
+ addition (i) in the case of a performance the actors, singers,
+ musicians, dancers, and other persons who act, sing, deliver, declaim,
+ play in, interpret or otherwise perform literary or artistic works or
+ expressions of folklore; (ii) in the case of a phonogram the producer
+ being the person or legal entity who first fixes the sounds of a
+ performance or other sounds; and, (iii) in the case of broadcasts, the
+ organization that transmits the broadcast.
+ .
+ f. "Work" means the literary and/or artistic work offered under the
+ terms of this License including without limitation any production in the
+ literary, scientific and artistic domain, whatever may be the mode or
+ form of its expression including digital form, such as a book, pamphlet
+ and other writing; a lecture, address, sermon or other work of the same
+ nature; a dramatic or dramatico-musical work; a choreographic work or
+ entertainment in dumb show; a musical composition with or without words;
+ a cinematographic work to which are assimilated works expressed by a
+ process analogous to cinematography; a work of drawing, painting,
+ architecture, sculpture, engraving or lithography; a photographic work
+ to which are assimilated works expressed by a process analogous to
+ photography; a work of applied art; an illustration, map, plan, sketch
+ or three-dimensional work relative to geography, topography,
+ architecture or science; a performance; a broadcast; a phonogram; a
+ compilation of data to the extent it is protected as a copyrightable
+ work; or a work performed by a variety or circus performer to the extent
+ it is not otherwise considered a literary or artistic work.
+ .
+ g. "You" means an individual or entity exercising rights under this
+ License who has not previously violated the terms of this License with
+ respect to the Work, or who has received express permission from the
+ Licensor to exercise rights under this License despite a previous
+ violation.
+ .
+ h. "Publicly Perform" means to perform public recitations of the Work
+ and to communicate to the public those public recitations, by any means
+ or process, including by wire or wireless means or public digital
+ performances; to make available to the public Works in such a way that
+ members of the public may access these Works from a place and at a place
+ individually chosen by them; to perform the Work to the public by any
+ means or process and the communication to the public of the performances
+ of the Work, including by public digital performance; to broadcast and
+ rebroadcast the Work by any means including signs, sounds or images.
+ .
+ i. "Reproduce" means to make copies of the Work by any means including
+ without limitation by sound or visual recordings and the right of
+ fixation and reproducing fixations of the Work, including storage of a
+ protected performance or phonogram in digital form or other electronic
+ medium.
+ .
+ 2. Fair Dealing Rights. Nothing in this License is intended to reduce,
+ limit, or restrict any uses free from copyright or rights arising from
+ limitations or exceptions that are provided for in connection with the
+ copyright protection under copyright law or other applicable laws.
+ .
+ 3. License Grant. Subject to the terms and conditions of this License,
+ Licensor hereby grants You a worldwide, royalty-free, non-exclusive,
+ perpetual (for the duration of the applicable copyright) license to
+ exercise the rights in the Work as stated below:
+ .
+ a. to Reproduce the Work, to incorporate the Work into one or more
+ Collections, and to Reproduce the Work as incorporated in the
+ Collections;
+ .
+ b. to create and Reproduce Adaptations provided that any such
+ Adaptation, including any translation in any medium, takes reasonable
+ steps to clearly label, demarcate or otherwise identify that changes
+ were made to the original Work. For example, a translation could be
+ marked "The original work was translated from English to Spanish," or a
+ modification could indicate "The original work has been modified.";
+ .
+ c. to Distribute and Publicly Perform the Work including as incorporated
+ in Collections; and,
+ .
+ d. to Distribute and Publicly Perform Adaptations.
+ .
+ e. For the avoidance of doubt:
+ .
+ i. Non-waivable Compulsory License Schemes. In those jurisdictions in
+ which the right to collect royalties through any statutory or compulsory
+ licensing scheme cannot be waived, the Licensor reserves the exclusive
+ right to collect such royalties for any exercise by You of the rights
+ granted under this License;
+ .
+ ii. Waivable Compulsory License Schemes. In those jurisdictions in which
+ the right to collect royalties through any statutory or compulsory
+ licensing scheme can be waived, the Licensor waives the exclusive right
+ to collect such royalties for any exercise by You of the rights granted
+ under this License; and,
+ .
+ iii. Voluntary License Schemes. The Licensor waives the right to collect
+ royalties, whether individually or, in the event that the Licensor is a
+ member of a collecting society that administers voluntary licensing
+ schemes, via that society, from any exercise by You of the rights
+ granted under this License.
+ .
+ The above rights may be exercised in all media and formats whether now
+ known or hereafter devised. The above rights include the right to make
+ such modifications as are technically necessary to exercise the rights
+ in other media and formats. Subject to Section 8(f), all rights not
+ expressly granted by Licensor are hereby reserved.
+ .
+ 4. Restrictions. The license granted in Section 3 above is expressly
+ made subject to and limited by the following restrictions:
+ .
+ a. You may Distribute or Publicly Perform the Work only under the terms
+ of this License. You must include a copy of, or the Uniform Resource
+ Identifier (URI) for, this License with every copy of the Work You
+ Distribute or Publicly Perform. You may not offer or impose any terms on
+ the Work that restrict the terms of this License or the ability of the
+ recipient of the Work to exercise the rights granted to that recipient
+ under the terms of the License. You may not sublicense the Work. You
+ must keep intact all notices that refer to this License and to the
+ disclaimer of warranties with every copy of the Work You Distribute or
+ Publicly Perform. When You Distribute or Publicly Perform the Work, You
+ may not impose any effective technological measures on the Work that
+ restrict the ability of a recipient of the Work from You to exercise the
+ rights granted to that recipient under the terms of the License. This
+ Section 4(a) applies to the Work as incorporated in a Collection, but
+ this does not require the Collection apart from the Work itself to be
+ made subject to the terms of this License. If You create a Collection,
+ upon notice from any Licensor You must, to the extent practicable,
+ remove from the Collection any credit as required by Section 4(b), as
+ requested. If You create an Adaptation, upon notice from any Licensor
+ You must, to the extent practicable, remove from the Adaptation any
+ credit as required by Section 4(b), as requested.
+ .
+ b. If You Distribute, or Publicly Perform the Work or any Adaptations or
+ Collections, You must, unless a request has been made pursuant to
+ Section 4(a), keep intact all copyright notices for the Work and
+ provide, reasonable to the medium or means You are utilizing: (i) the
+ name of the Original Author (or pseudonym, if applicable) if supplied,
+ and/or if the Original Author and/or Licensor designate another party or
+ parties (e.g., a sponsor institute, publishing entity, journal) for
+ attribution ("Attribution Parties") in Licensor's copyright notice,
+ terms of service or by other reasonable means, the name of such party or
+ parties; (ii) the title of the Work if supplied; (iii) to the extent
+ reasonably practicable, the URI, if any, that Licensor specifies to be
+ associated with the Work, unless such URI does not refer to the
+ copyright notice or licensing information for the Work; and (iv) ,
+ consistent with Section 3(b), in the case of an Adaptation, a credit
+ identifying the use of the Work in the Adaptation (e.g., "French
+ translation of the Work by Original Author," or "Screenplay based on
+ original Work by Original Author"). The credit required by this Section
+ 4 (b) may be implemented in any reasonable manner; provided, however,
+ that in the case of a Adaptation or Collection, at a minimum such credit
+ will appear, if a credit for all contributing authors of the Adaptation
+ or Collection appears, then as part of these credits and in a manner at
+ least as prominent as the credits for the other contributing authors.
+ For the avoidance of doubt, You may only use the credit required by this
+ Section for the purpose of attribution in the manner set out above and,
+ by exercising Your rights under this License, You may not implicitly or
+ explicitly assert or imply any connection with, sponsorship or
+ endorsement by the Original Author, Licensor and/or Attribution Parties,
+ as appropriate, of You or Your use of the Work, without the separate,
+ express prior written permission of the Original Author, Licensor and/or
+ Attribution Parties.
+ .
+ c. Except as otherwise agreed in writing by the Licensor or as may be
+ otherwise permitted by applicable law, if You Reproduce, Distribute or
+ Publicly Perform the Work either by itself or as part of any Adaptations
+ or Collections, You must not distort, mutilate, modify or take other
+ derogatory action in relation to the Work which would be prejudicial to
+ the Original Author's honor or reputation. Licensor agrees that in those
+ jurisdictions (e.g. Japan), in which any exercise of the right granted
+ in Section 3(b) of this License (the right to make Adaptations) would be
+ deemed to be a distortion, mutilation, modification or other derogatory
+ action prejudicial to the Original Author's honor and reputation, the
+ Licensor will waive or not assert, as appropriate, this Section, to the
+ fullest extent permitted by the applicable national law, to enable You
+ to reasonably exercise Your right under Section 3(b) of this License
+ (right to make Adaptations) but not otherwise.
+ .
+ 5. Representations, Warranties and Disclaimer
+ .
+ UNLESS OTHERWISE MUTUALLY AGREED TO BY THE PARTIES IN WRITING, LICENSOR
+ OFFERS THE WORK AS-IS AND MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY
+ KIND CONCERNING THE WORK, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE,
+ INCLUDING, WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTIBILITY,
+ FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT, OR THE ABSENCE OF
+ LATENT OR OTHER DEFECTS, ACCURACY, OR THE PRESENCE OF ABSENCE OF ERRORS,
+ WHETHER OR NOT DISCOVERABLE. SOME JURISDICTIONS DO NOT ALLOW THE
+ EXCLUSION OF IMPLIED WARRANTIES, SO SUCH EXCLUSION MAY NOT APPLY TO YOU.
+ .
+ 6. Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE
+ LAW, IN NO EVENT WILL LICENSOR BE LIABLE TO YOU ON ANY LEGAL THEORY FOR
+ ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY DAMAGES
+ ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK, EVEN IF LICENSOR HAS
+ BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+ .
+ 7. Termination
+ .
+ a. This License and the rights granted hereunder will terminate
+ automatically upon any breach by You of the terms of this License.
+ Individuals or entities who have received Adaptations or Collections
+ from You under this License, however, will not have their licenses
+ terminated provided such individuals or entities remain in full
+ compliance with those licenses. Sections 1, 2, 5, 6, 7, and 8 will
+ survive any termination of this License.
+ .
+ b. Subject to the above terms and conditions, the license granted here
+ is perpetual (for the duration of the applicable copyright in the Work).
+ Notwithstanding the above, Licensor reserves the right to release the
+ Work under different license terms or to stop distributing the Work at
+ any time; provided, however that any such election will not serve to
+ withdraw this License (or any other license that has been, or is
+ required to be, granted under the terms of this License), and this
+ License will continue in full force and effect unless terminated as
+ stated above.
+ .
+ 8. Miscellaneous
+ .
+ a. Each time You Distribute or Publicly Perform the Work or a
+ Collection, the Licensor offers to the recipient a license to the Work
+ on the same terms and conditions as the license granted to You under
+ this License.
+ .
+ b. Each time You Distribute or Publicly Perform an Adaptation, Licensor
+ offers to the recipient a license to the original Work on the same terms
+ and conditions as the license granted to You under this License.
+ .
+ c. If any provision of this License is invalid or unenforceable under
+ applicable law, it shall not affect the validity or enforceability of
+ the remainder of the terms of this License, and without further action
+ by the parties to this agreement, such provision shall be reformed to
+ the minimum extent necessary to make such provision valid and
+ enforceable.
+ .
+ d. No term or provision of this License shall be deemed waived and no
+ breach consented to unless such waiver or consent shall be in writing
+ and signed by the party to be charged with such waiver or consent. This
+ License constitutes the entire agreement between the parties with
+ respect to the Work licensed here. There are no understandings,
+ agreements or representations with respect to the Work not specified
+ here. Licensor shall not be bound by any additional provisions that may
+ appear in any communication from You.
+ .
+ e. This License may not be modified without the mutual written agreement
+ of the Licensor and You.
+ .
+ f. The rights granted under, and the subject matter referenced, in this
+ License were drafted utilizing the terminology of the Berne Convention
+ for the Protection of Literary and Artistic Works (as amended on
+ September 28, 1979), the Rome Convention of 1961, the WIPO Copyright
+ Treaty of 1996, the WIPO Performances and Phonograms Treaty of 1996 and
+ the Universal Copyright Convention (as revised on July 24, 1971). These
+ rights and subject matter take effect in the relevant jurisdiction in
+ which the License terms are sought to be enforced according to the
+ corresponding provisions of the implementation of those treaty
+ provisions in the applicable national law. If the standard suite of
+ rights granted under applicable copyright law includes additional rights
+ not granted under this License, such additional rights are deemed to be
+ included in the License; this License is not intended to restrict the
+ license of any rights under applicable law.
+ .
+ Creative Commons Notice
+ .
+ Creative Commons is not a party to this License, and makes no warranty
+ whatsoever in connection with the Work. Creative Commons will not be
+ liable to You or any party on any legal theory for any damages
+ whatsoever, including without limitation any general, special,
+ incidental or consequential damages arising in connection to this
+ license. Notwithstanding the foregoing two (2) sentences, if Creative
+ Commons has expressly identified itself as the Licensor hereunder, it
+ shall have all rights and obligations of Licensor.
+ .
+ Except for the limited purpose of indicating to the public that the Work
+ is licensed under the CCPL, Creative Commons does not authorize the use
+ by either party of the trademark "Creative Commons" or any related
+ trademark or logo of Creative Commons without the prior written consent
+ of Creative Commons. Any permitted use will be in compliance with
+ Creative Commons' then-current trademark usage guidelines, as may be
+ published on its website or otherwise made available upon request from
+ time to time. For the avoidance of doubt, this trademark restriction
+ does not form part of this License.
+ .
+ Creative Commons may be contacted at http://creativecommons.org/.
+
+License: curl
+ All rights reserved.
+ .
+ Permission to use, copy, modify, and distribute this software for any purpose
+ with or without fee is hereby granted, provided that the above copyright
+ notice and this permission notice appear in all copies.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS. IN
+ NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ OR OTHER DEALINGS IN THE SOFTWARE.
+ .
+ Except as contained in this notice, the name of a copyright holder shall not
+ be used in advertising or otherwise to promote the sale, use or other dealings
+ in this Software without prior written authorization of the copyright holder.
+
+License: Expat
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+ .
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+License: FTL
+                    The FreeType Project LICENSE
+                    ----------------------------
+ .
+                            2000-Feb-08
+ .
+                       Copyright 1996-2000 by
+          David Turner, Robert Wilhelm, and Werner Lemberg
+ .
+ .
+ .
+ Introduction
+ ============
+ .
+ The FreeType  Project is distributed in  several archive packages;
+ some of them may contain, in addition to the FreeType font engine,
+ various tools and  contributions which rely on, or  relate to, the
+ FreeType Project.
+ .
+ This  license applies  to all  files found  in such  packages, and
+ which do not  fall under their own explicit  license.  The license
+ affects  thus  the  FreeType   font  engine,  the  test  programs,
+ documentation and makefiles, at the very least.
+ .
+ This  license   was  inspired  by  the  BSD,   Artistic,  and  IJG
+ (Independent JPEG  Group) licenses, which  all encourage inclusion
+ and  use of  free  software in  commercial  and freeware  products
+ alike.  As a consequence, its main points are that:
+ .
+   o We don't promise that this software works. However, we will be
+     interested in any kind of bug reports. (`as is' distribution)
+ .
+   o You can  use this software for whatever you  want, in parts or
+     full form, without having to pay us. (`royalty-free' usage)
+ .
+   o You may not pretend that  you wrote this software.  If you use
+     it, or  only parts of it,  in a program,  you must acknowledge
+     somewhere  in  your  documentation  that  you  have  used  the
+     FreeType code. (`credits')
+ .
+ We  specifically  permit  and  encourage  the  inclusion  of  this
+ software, with  or without modifications,  in commercial products.
+ We  disclaim  all warranties  covering  The  FreeType Project  and
+ assume no liability related to The FreeType Project.
+ .
+ .
+ Legal Terms
+ ===========
+ .
+ 0. Definitions
+ --------------
+ .
+ Throughout this license,  the terms `package', `FreeType Project',
+ and  `FreeType  archive' refer  to  the  set  of files  originally
+ distributed  by the  authors  (David Turner,  Robert Wilhelm,  and
+ Werner Lemberg) as the `FreeType Project', be they named as alpha,
+ beta or final release.
+ .
+ `You' refers to  the licensee, or person using  the project, where
+ `using' is a generic term including compiling the project's source
+ code as  well as linking it  to form a  `program' or `executable'.
+ This  program is  referred to  as  `a program  using the  FreeType
+ engine'.
+ .
+ This  license applies  to all  files distributed  in  the original
+ FreeType  Project,   including  all  source   code,  binaries  and
+ documentation,  unless  otherwise  stated   in  the  file  in  its
+ original, unmodified form as  distributed in the original archive.
+ If you are  unsure whether or not a particular  file is covered by
+ this license, you must contact us to verify this.
+ .
+ The FreeType  Project is copyright (C) 1996-2000  by David Turner,
+ Robert Wilhelm, and Werner Lemberg.  All rights reserved except as
+ specified below.
+ .
+ 1. No Warranty
+ --------------
+ .
+ THE FREETYPE PROJECT  IS PROVIDED `AS IS' WITHOUT  WARRANTY OF ANY
+ KIND, EITHER  EXPRESS OR IMPLIED,  INCLUDING, BUT NOT  LIMITED TO,
+ WARRANTIES  OF  MERCHANTABILITY   AND  FITNESS  FOR  A  PARTICULAR
+ PURPOSE.  IN NO EVENT WILL ANY OF THE AUTHORS OR COPYRIGHT HOLDERS
+ BE LIABLE  FOR ANY DAMAGES CAUSED  BY THE USE OR  THE INABILITY TO
+ USE, OF THE FREETYPE PROJECT.
+ .
+ 2. Redistribution
+ -----------------
+ .
+ This  license  grants  a  worldwide, royalty-free,  perpetual  and
+ irrevocable right  and license to use,  execute, perform, compile,
+ display,  copy,   create  derivative  works   of,  distribute  and
+ sublicense the  FreeType Project (in  both source and  object code
+ forms)  and  derivative works  thereof  for  any  purpose; and  to
+ authorize others  to exercise  some or all  of the  rights granted
+ herein, subject to the following conditions:
+ .
+   o Redistribution  of source code  must retain this  license file
+     (`LICENSE.TXT') unaltered; any additions, deletions or changes
+     to   the  original   files  must   be  clearly   indicated  in
+     accompanying  documentation.   The  copyright notices  of  the
+     unaltered, original  files must be preserved in  all copies of
+     source files.
+ .
+   o Redistribution in binary form must provide a  disclaimer  that
+     states  that  the software is based in part of the work of the
+     FreeType Team,  in  the  distribution  documentation.  We also
+     encourage you to put an URL to the FreeType web page  in  your
+     documentation, though this isn't mandatory.
+ .
+ These conditions  apply to any  software derived from or  based on
+ the FreeType Project,  not just the unmodified files.   If you use
+ our work, you  must acknowledge us.  However, no  fee need be paid
+ to us.
+ .
+ 3. Advertising
+ --------------
+ .
+ Neither the  FreeType authors and  contributors nor you  shall use
+ the name of the  other for commercial, advertising, or promotional
+ purposes without specific prior written permission.
+ .
+ We suggest,  but do not require, that  you use one or  more of the
+ following phrases to refer  to this software in your documentation
+ or advertising  materials: `FreeType Project',  `FreeType Engine',
+ `FreeType library', or `FreeType Distribution'.
+ .
+ As  you have  not signed  this license,  you are  not  required to
+ accept  it.   However,  as  the FreeType  Project  is  copyrighted
+ material, only  this license, or  another one contracted  with the
+ authors, grants you  the right to use, distribute,  and modify it.
+ Therefore,  by  using,  distributing,  or modifying  the  FreeType
+ Project, you indicate that you understand and accept all the terms
+ of this license.
+ .
+ 4. Contacts
+ -----------
+ .
+ There are two mailing lists related to FreeType:
+ .
+   o freetype@freetype.org
+ .
+     Discusses general use and applications of FreeType, as well as
+     future and  wanted additions to the  library and distribution.
+     If  you are looking  for support,  start in  this list  if you
+     haven't found anything to help you in the documentation.
+ .
+   o devel@freetype.org
+ .
+     Discusses bugs,  as well  as engine internals,  design issues,
+     specific licenses, porting, etc.
+ .
+   o http://www.freetype.org
+ .
+     Holds the current  FreeType web page, which will  allow you to
+     download  our  latest  development  version  and  read  online
+     documentation.
+ .
+ You can also contact us individually at:
+ .
+   David Turner      <david.turner@freetype.org>
+   Robert Wilhelm    <robert.wilhelm@freetype.org>
+   Werner Lemberg    <werner.lemberg@freetype.org>
+
+License: ISC
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+License: OFL-1.1
+ PREAMBLE
+ The goals of the Open Font License (OFL) are to stimulate worldwide
+ development of collaborative font projects, to support the font creation
+ efforts of academic and linguistic communities, and to provide a free and
+ open framework in which fonts may be shared and improved in partnership
+ with others.
+ .
+ The OFL allows the licensed fonts to be used, studied, modified and
+ redistributed freely as long as they are not sold by themselves. The
+ fonts, including any derivative works, can be bundled, embedded,
+ redistributed and/or sold with any software provided that any reserved
+ names are not used by derivative works. The fonts and derivatives,
+ however, cannot be released under any other type of license. The
+ requirement for fonts to remain under this license does not apply
+ to any document created using the fonts or their derivatives.
+ .
+ DEFINITIONS
+ "Font Software" refers to the set of files released by the Copyright
+ Holder(s) under this license and clearly marked as such. This may
+ include source files, build scripts and documentation.
+ .
+ "Reserved Font Name" refers to any names specified as such after the
+ copyright statement(s).
+ .
+ "Original Version" refers to the collection of Font Software components as
+ distributed by the Copyright Holder(s).
+ .
+ "Modified Version" refers to any derivative made by adding to, deleting,
+ or substituting -- in part or in whole -- any of the components of the
+ Original Version, by changing formats or by porting the Font Software to a
+ new environment.
+ .
+ "Author" refers to any designer, engineer, programmer, technical
+ writer or other person who contributed to the Font Software.
+ .
+ PERMISSION & CONDITIONS
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of the Font Software, to use, study, copy, merge, embed, modify,
+ redistribute, and sell modified and unmodified copies of the Font
+ Software, subject to the following conditions:
+ .
+ 1) Neither the Font Software nor any of its individual components,
+ in Original or Modified Versions, may be sold by itself.
+ .
+ 2) Original or Modified Versions of the Font Software may be bundled,
+ redistributed and/or sold with any software, provided that each copy
+ contains the above copyright notice and this license. These can be
+ included either as stand-alone text files, human-readable headers or
+ in the appropriate machine-readable metadata fields within text or
+ binary files as long as those fields can be easily viewed by the user.
+ .
+ 3) No Modified Version of the Font Software may use the Reserved Font
+ Name(s) unless explicit written permission is granted by the corresponding
+ Copyright Holder. This restriction only applies to the primary font name as
+ presented to the users.
+ .
+ 4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+ Software shall not be used to promote, endorse or advertise any
+ Modified Version, except to acknowledge the contribution(s) of the
+ Copyright Holder(s) and the Author(s) or with their explicit written
+ permission.
+ .
+ 5) The Font Software, modified or unmodified, in part or in whole,
+ must be distributed entirely under this license, and must not be
+ distributed under any other license. The requirement for fonts to
+ remain under this license does not apply to any document created
+ using the Font Software.
+ .
+ TERMINATION
+ This license becomes null and void if any of the above conditions are
+ not met.
+ .
+ DISCLAIMER
+ THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+ COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+ DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE.
+
+License: OpenSSL
+ LICENSE ISSUES
+ ==============
+ .
+ The OpenSSL toolkit stays under a double license, i.e. both the conditions of
+ the OpenSSL License and the original SSLeay license apply to the toolkit.
+ See below for the actual license texts.
+ .
+ OpenSSL License
+ ---------------
+ .
+ ====================================================================
+ Copyright (c) 1998-2017 The OpenSSL Project.  All rights reserved.
+ .
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ .
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ .
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+ .
+ 3. All advertising materials mentioning features or use of this
+    software must display the following acknowledgment:
+    "This product includes software developed by the OpenSSL Project
+    for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
+ .
+ 4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
+    endorse or promote products derived from this software without
+    prior written permission. For written permission, please contact
+    openssl-core@openssl.org.
+ .
+ 5. Products derived from this software may not be called "OpenSSL"
+    nor may "OpenSSL" appear in their names without prior written
+    permission of the OpenSSL Project.
+ .
+ 6. Redistributions of any form whatsoever must retain the following
+    acknowledgment:
+    "This product includes software developed by the OpenSSL Project
+    for use in the OpenSSL Toolkit (http://www.openssl.org/)"
+ .
+ THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
+ EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
+ ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ OF THE POSSIBILITY OF SUCH DAMAGE.
+ ====================================================================
+ .
+ This product includes cryptographic software written by Eric Young
+ (eay@cryptsoft.com).  This product includes software written by Tim
+ Hudson (tjh@cryptsoft.com).
+ .
+ Original SSLeay License
+ -----------------------
+ .
+ Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
+ All rights reserved.
+ .
+ This package is an SSL implementation written
+ by Eric Young (eay@cryptsoft.com).
+ The implementation was written so as to conform with Netscapes SSL.
+ .
+ This library is free for commercial and non-commercial use as long as
+ the following conditions are aheared to.  The following conditions
+ apply to all code found in this distribution, be it the RC4, RSA,
+ lhash, DES, etc., code; not just the SSL code.  The SSL documentation
+ included with this distribution is covered by the same copyright terms
+ except that the holder is Tim Hudson (tjh@cryptsoft.com).
+ .
+ Copyright remains Eric Young's, and as such any Copyright notices in
+ the code are not to be removed.
+ If this package is used in a product, Eric Young should be given attribution
+ as the author of the parts of the library used.
+ This can be in the form of a textual message at program startup or
+ in documentation (online or textual) provided with the package.
+ .
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. All advertising materials mentioning features or use of this software
+    must display the following acknowledgement:
+    "This product includes cryptographic software written by
+     Eric Young (eay@cryptsoft.com)"
+    The word 'cryptographic' can be left out if the rouines from the library
+    being used are not cryptographic related :-).
+ 4. If you include any Windows specific code (or a derivative thereof) from
+    the apps directory (application code) you must include an acknowledgement:
+    "This product includes software written by Tim Hudson (tjh@cryptsoft.com)"
+ .
+ THIS SOFTWARE IS PROVIDED BY ERIC YOUNG ``AS IS'' AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ SUCH DAMAGE.
+ .
+ The licence and distribution terms for any publically available version or
+ derivative of this code cannot be changed.  i.e. this code cannot simply be
+ copied and put under another distribution licence
+ [including the GNU Public Licence.]
+
+License: RSA-MD
+ License to copy and use this software is granted provided that it is
+ identified as the "RSA Data Security, Inc. MD5 Message-Digest Algorithm"
+ in all material mentioning or referencing this software or this function.
+ .
+ License is also granted to make and use derivative works provided that such
+ works are identified as "derived from the RSA Data Security, Inc. MD5
+ Message-Digest Algorithm" in all material mentioning or referencing the
+ derived work.
+ .
+ RSA Data Security, Inc. makes no representations concerning either the
+ merchantability of this software or the suitability of this software for
+ any particular purpose. It is provided "as is" without express or implied
+ warranty of any kind.
+ .
+ These notices must be retained in any copies of any part of this
+ documentation and/or software.
+
+License: Zlib
+ This software is provided 'as-is', without any express or implied
+ warranty.  In no event will the authors be held liable for any damages
+ arising from the use of this software.
+ .
+ Permission is granted to anyone to use this software for any purpose,
+ including commercial applications, and to alter it and redistribute it
+ freely, subject to the following restrictions:
+ .
+ 1. The origin of this software must not be misrepresented; you must not
+    claim that you wrote the original software. If you use this software
+    in a product, an acknowledgment in the product documentation would be
+    appreciated but is not required.
+ 2. Altered source versions must be plainly marked as such, and must not be
+    misrepresented as being the original software.
+ 3. This notice may not be removed or altered from any source distribution.


### PR DESCRIPTION
Uses the machine-readable debian/copyright standard to be explicit
about both the licenses and the corresponding copyright attributions
for Godot source files and thirdparty libraries bundled in the source
repository.

Fixes #7388.

A second step will be to make a human-readable version ;)