### PR TITLE
Upgrade Android build tools to the latest

### DIFF
--- a/platform/android/build.gradle.template
+++ b/platform/android/build.gradle.template
@@ -31,7 +31,7 @@ android {
 	}
 
 	compileSdkVersion 23
-	buildToolsVersion "23.0.3"
+	buildToolsVersion "25.0.3"
 	useLibrary 'org.apache.http.legacy'
 
 	packagingOptions {


### PR DESCRIPTION
After the Gradle upgrade Android builds were failing with some error message about too old build tools.