### PR TITLE
Fix for..in range() resulting in floats instead of ints

### DIFF
--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -2236,30 +2236,30 @@ bool Variant::iter_init(Variant &r_iter, bool &valid) const {
 			return _data._int > 0;
 		} break;
 		case REAL: {
-			r_iter = 0.0;
+			r_iter = 0;
 			return _data._real > 0.0;
 		} break;
 		case VECTOR2: {
-			real_t from = reinterpret_cast<const Vector2 *>(_data._mem)->x;
-			real_t to = reinterpret_cast<const Vector2 *>(_data._mem)->y;
+			int64_t from = reinterpret_cast<const Vector2 *>(_data._mem)->x;
+			int64_t to = reinterpret_cast<const Vector2 *>(_data._mem)->y;
 
 			r_iter = from;
 
 			return from < to;
 		} break;
 		case VECTOR3: {
-			real_t from = reinterpret_cast<const Vector3 *>(_data._mem)->x;
-			real_t to = reinterpret_cast<const Vector3 *>(_data._mem)->y;
-			real_t step = reinterpret_cast<const Vector3 *>(_data._mem)->z;
+			int64_t from = reinterpret_cast<const Vector3 *>(_data._mem)->x;
+			int64_t to = reinterpret_cast<const Vector3 *>(_data._mem)->y;
+			int64_t step = reinterpret_cast<const Vector3 *>(_data._mem)->z;
 
 			r_iter = from;
 
 			if (from == to) {
 				return false;
 			} else if (from < to) {
-				return step > 0.0;
+				return step > 0;
 			} else {
-				return step < 0.0;
+				return step < 0;
 			}
 			//return true;
 		} break;
@@ -2387,7 +2387,6 @@ bool Variant::iter_next(Variant &r_iter, bool &valid) const {
 	valid = true;
 	switch (type) {
 		case INT: {
-
 			int64_t idx = r_iter;
 			idx++;
 			if (idx >= _data._int)
@@ -2396,33 +2395,36 @@ bool Variant::iter_next(Variant &r_iter, bool &valid) const {
 			return true;
 		} break;
 		case REAL: {
-
-			double idx = r_iter;
-			idx += 1.0;
+			int64_t idx = r_iter;
+			idx++;
 			if (idx >= _data._real)
 				return false;
 			r_iter = idx;
 			return true;
 		} break;
 		case VECTOR2: {
-			real_t idx = r_iter;
-			idx += 1.0;
-			if (idx >= reinterpret_cast<const Vector2 *>(_data._mem)->y)
+			int64_t to = reinterpret_cast<const Vector3 *>(_data._mem)->y;
+
+			int64_t idx = r_iter;
+			idx++;
+
+			if (idx >= to)
 				return false;
+
 			r_iter = idx;
 			return true;
 		} break;
 		case VECTOR3: {
-			real_t to = reinterpret_cast<const Vector3 *>(_data._mem)->y;
-			real_t step = reinterpret_cast<const Vector3 *>(_data._mem)->z;
+			int64_t to = reinterpret_cast<const Vector3 *>(_data._mem)->y;
+			int64_t step = reinterpret_cast<const Vector3 *>(_data._mem)->z;
 
-			real_t idx = r_iter;
+			int64_t idx = r_iter;
 			idx += step;
 
-			if (step < 0.0 && idx <= to)
+			if (step < 0 && idx <= to)
 				return false;
 
-			if (step > 0.0 && idx >= to)
+			if (step > 0 && idx >= to)
 				return false;
 
 			r_iter = idx;

--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -2626,7 +2626,7 @@ void GDParser::_parse_block(BlockNode *p_block, bool p_static) {
 
 								ConstantNode *cn = alloc_node<ConstantNode>();
 								switch (args.size()) {
-									case 1: cn->value = constants[0]; break;
+									case 1: cn->value = (int)constants[0]; break;
 									case 2: cn->value = Vector2(constants[0], constants[1]); break;
 									case 3: cn->value = Vector3(constants[0], constants[1], constants[2]); break;
 								}
@@ -2639,7 +2639,7 @@ void GDParser::_parse_block(BlockNode *p_block, bool p_static) {
 								on->arguments.push_back(tn);
 
 								switch (args.size()) {
-									case 1: tn->vtype = Variant::REAL; break;
+									case 1: tn->vtype = Variant::INT; break;
 									case 2: tn->vtype = Variant::VECTOR2; break;
 									case 3: tn->vtype = Variant::VECTOR3; break;
 								}


### PR DESCRIPTION
Fixes #8278, fixup of bfef8de1bc4f7a7b9617a7b181881129033a0b0e
Note that with this commit, there is difference between the following lines:
```gdscript
for i in range(5.0):
for i in 5:
  # i is TYPE_INT

# vs:

for i in 5.0:
  # i is TYPE_REAL
```