### PR TITLE
Added support to be able to inherit from SpatialMaterial in C++

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -257,7 +257,35 @@ void SpatialMaterial::_update_shader() {
 	}
 
 	//must create a shader!
+	String code = _get_shader_string();
 
+	ShaderData shader_data;
+	shader_data.shader = VS::get_singleton()->shader_create();
+	shader_data.users = 1;
+
+	print_line(code);
+
+	VS::get_singleton()->shader_set_code(shader_data.shader, code);
+
+	shader_map[mk] = shader_data;
+
+	VS::get_singleton()->material_set_shader(_get_material(), shader_data.shader);
+}
+
+String SpatialMaterial::_get_shader_string() {
+	String code = _get_shader_parameters_string();
+	code += "\n\n";
+	code += "void vertex() {\n";
+	code += _get_shader_vertex_string();
+	code += "}\n";
+	code += "\n\n";
+	code += "void fragment() {\n";
+	code += _get_shader_fragment_string();
+	code += "}\n";
+	return code;
+}
+
+String SpatialMaterial::_get_shader_parameters_string() {
 	String code = "shader_type spatial;\nrender_mode ";
 	switch (blend_mode) {
 		case BLEND_MODE_MIX: code += "blend_mix"; break;
@@ -350,10 +378,11 @@ void SpatialMaterial::_update_shader() {
 		code += "uniform sampler2D texture_subsurface_scattering : hint_white;\n";
 	}
 
-	code += "\n\n";
+	return code;
+}
 
-	code += "void vertex() {\n";
-
+String SpatialMaterial::_get_shader_vertex_string() {
+	String code = "";
 	if (flags[FLAG_SRGB_VERTEX_COLOR]) {
 
 		code += "\tCOLOR.rgb = mix( pow((COLOR.rgb + vec3(0.055)) * (1.0 / (1.0 + 0.055)), vec3(2.4)), COLOR.rgb* (1.0 / 12.92), lessThan(COLOR.rgb,vec3(0.04045)) );\n";
@@ -418,10 +447,11 @@ void SpatialMaterial::_update_shader() {
 	if (detail_uv == DETAIL_UV_2) {
 		code += "\tUV2=UV2*uv2_scale+uv2_offset;\n";
 	}
+	return code;
+}
 
-	code += "}\n";
-	code += "\n\n";
-	code += "void fragment() {\n";
+String SpatialMaterial::_get_shader_fragment_string() {
+	String code = "";
 
 	if (flags[FLAG_USE_POINT_SIZE]) {
 		code += "\tvec4 albedo_tex = texture(texture_albedo,POINT_COORD);\n";
@@ -513,17 +543,7 @@ void SpatialMaterial::_update_shader() {
 		code += "\tROUGHNESS = specular_tex.a * roughness;\n";
 	}
 
-	code += "}\n";
-
-	ShaderData shader_data;
-	shader_data.shader = VS::get_singleton()->shader_create();
-	shader_data.users = 1;
-
-	VS::get_singleton()->shader_set_code(shader_data.shader, code);
-
-	shader_map[mk] = shader_data;
-
-	VS::get_singleton()->material_set_shader(_get_material(), shader_data.shader);
+	return code;
 }
 
 void SpatialMaterial::flush_changes() {

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -178,26 +178,29 @@ public:
 	};
 
 private:
-	union MaterialKey {
+	struct MaterialKey {
+		union {
+			struct {
+				uint32_t feature_mask : 11;
+				uint32_t detail_uv : 1;
+				uint32_t blend_mode : 2;
+				uint32_t depth_draw_mode : 2;
+				uint32_t cull_mode : 2;
+				uint32_t flags : 6;
+				uint32_t detail_blend_mode : 2;
+				uint32_t diffuse_mode : 2;
+				uint32_t invalid_key : 1;
+				uint32_t specular_mode : 1;
+				uint32_t billboard_mode : 2;
+			};
 
-		struct {
-			uint32_t feature_mask : 11;
-			uint32_t detail_uv : 1;
-			uint32_t blend_mode : 2;
-			uint32_t depth_draw_mode : 2;
-			uint32_t cull_mode : 2;
-			uint32_t flags : 6;
-			uint32_t detail_blend_mode : 2;
-			uint32_t diffuse_mode : 2;
-			uint32_t invalid_key : 1;
-			uint32_t specular_mode : 1;
-			uint32_t billboard_mode : 2;
+			uint32_t key;
 		};
 
-		uint32_t key;
+		ClassDB::ClassInfo *class_info;
 
 		bool operator<(const MaterialKey &p_key) const {
-			return key < p_key.key;
+			return key < p_key.key || class_info < p_key.class_info;
 		}
 	};
 
@@ -213,6 +216,7 @@ private:
 	_FORCE_INLINE_ MaterialKey _compute_key() const {
 
 		MaterialKey mk;
+		mk.class_info = ClassDB::classes.getptr(StringName(get_class()));
 		mk.key = 0;
 		for (int i = 0; i < FEATURE_MAX; i++) {
 			if (features[i]) {
@@ -270,8 +274,6 @@ private:
 
 	SelfList<SpatialMaterial> element;
 
-	void _update_shader();
-	_FORCE_INLINE_ void _queue_shader_change();
 	_FORCE_INLINE_ bool _is_shader_dirty() const;
 
 	Color albedo;
@@ -322,6 +324,14 @@ private:
 protected:
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &property) const;
+
+	virtual String _get_shader_string();
+	virtual String _get_shader_parameters_string();
+	virtual String _get_shader_vertex_string();
+	virtual String _get_shader_fragment_string();
+
+	virtual void _update_shader();
+	void _queue_shader_change();
 
 public:
 	void set_albedo(const Color &p_albedo);


### PR DESCRIPTION
Added support to be able to inherit from SpatialMaterial in C++.
See Issue #8767.

Some notes:
-Changes to MaterialKey so the class info is included in the comparison
-Broke up _update_shader into _get_shader_string, _get_shader_parameters_string, _get_shader_vertex_string and _get_shader_fragment_string and made protected to allow modification of shader code by inheriting classes


My sample code that uses these changes:
https://drive.google.com/open?id=0B_nQZvJoqbFmY01sVHlmb21ZTEE

