### PR TITLE
Expose wheel's contact to GDScript and set roll influence in editor [2.1]

### DIFF
--- a/scene/3d/vehicle_body.cpp
+++ b/scene/3d/vehicle_body.cpp
@@ -214,6 +214,18 @@ float VehicleWheel::get_friction_slip() const {
 	return m_frictionSlip;
 }
 
+void VehicleWheel::set_roll_influence(float p_value) {
+	m_rollInfluence = p_value;
+}
+
+float VehicleWheel::get_roll_influence() const {
+	return m_rollInfluence;
+}
+
+bool VehicleWheel::is_in_contact() const {
+	return m_raycastInfo.m_isInContact;
+}
+
 void VehicleWheel::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("set_radius", "length"), &VehicleWheel::set_radius);
@@ -246,8 +258,14 @@ void VehicleWheel::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("set_friction_slip", "length"), &VehicleWheel::set_friction_slip);
 	ObjectTypeDB::bind_method(_MD("get_friction_slip"), &VehicleWheel::get_friction_slip);
 
+	ObjectTypeDB::bind_method(_MD("is_in_contact"), &VehicleWheel::is_in_contact);
+
+	ObjectTypeDB::bind_method(_MD("set_roll_influence", "roll_influence"), &VehicleWheel::set_roll_influence);
+	ObjectTypeDB::bind_method(_MD("get_roll_influence"), &VehicleWheel::get_roll_influence);
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "type/traction"), _SCS("set_use_as_traction"), _SCS("is_used_as_traction"));
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "type/steering"), _SCS("set_use_as_steering"), _SCS("is_used_as_steering"));
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "wheel/roll_influence"), _SCS("set_roll_influence"), _SCS("get_roll_influence"));
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "wheel/radius"), _SCS("set_radius"), _SCS("get_radius"));
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "wheel/rest_length"), _SCS("set_suspension_rest_length"), _SCS("get_suspension_rest_length"));
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "wheel/friction_slip"), _SCS("set_friction_slip"), _SCS("get_friction_slip"));

--- a/scene/3d/vehicle_body.h
+++ b/scene/3d/vehicle_body.h
@@ -126,6 +126,11 @@ public:
 	void set_use_as_steering(bool p_enabled);
 	bool is_used_as_steering() const;
 
+	bool is_in_contact() const;
+
+	void set_roll_influence(float p_value);
+	float get_roll_influence() const;
+
 	VehicleWheel();
 };
 


### PR DESCRIPTION
This PR aims to increase moddability of the vehicle body.

1) It allows GDScript to read the raycast variable that checks if the wheel touches the ground. This allows users to use scripting to vary game behavior depending on whether the car is on ground or in air (e.g. don't handle input at all if we're in air or apply smaller force or smaller steering or whatever)

2) You can now set the roll_influence variable in editor. The smaller the value, the smaller the roll the car body experiences in turns. 0.1 is still the default value, but you can now set a larger value (for even greater roll) or smaller (for roll that is only cosmetic and doesn't threaten rollover).
This is especially important if someone wants different kinds of cars that behave differently wrt roll (e.g. a pickup truck vs a minicar vs a sports car)

EDIT: Made for 2.1. but easily pickable into master (by someone who actually can cherry pick as opposed to me)