### PR TITLE
Add column_title_pressed signal to Tree node

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2214,6 +2214,26 @@ void Tree::_gui_input(InputEvent p_event) {
 
 				if (b.button_index == BUTTON_LEFT) {
 
+					Ref<StyleBox> bg = cache.bg;
+
+					Point2 pos = Point2(b.x, b.y) - bg->get_offset();
+					if (show_column_titles) {
+						pos.y -= _get_title_button_height();
+
+						if (pos.y < 0) {
+							pos.x += cache.offset.x;
+							int len = 0;
+							for (int i = 0; i < columns.size(); i++) {
+
+								len += get_column_width(i);
+								if (pos.x < len) {
+									emit_signal("column_title_pressed", i);
+									break;
+								}
+							}
+						}
+					}
+
 					if (single_select_defer) {
 						select_single_item(single_select_defer, root, single_select_defer_column);
 						single_select_defer = NULL;
@@ -3456,6 +3476,7 @@ void Tree::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("button_pressed", PropertyInfo(Variant::OBJECT, "item"), PropertyInfo(Variant::INT, "column"), PropertyInfo(Variant::INT, "id")));
 	ADD_SIGNAL(MethodInfo("custom_popup_edited", PropertyInfo(Variant::BOOL, "arrow_clicked")));
 	ADD_SIGNAL(MethodInfo("item_activated"));
+	ADD_SIGNAL(MethodInfo("column_title_pressed", PropertyInfo(Variant::INT, "column")));
 
 	BIND_CONSTANT(SELECT_SINGLE);
 	BIND_CONSTANT(SELECT_ROW);


### PR DESCRIPTION
The Tree node column/table form is missing the ability to capture column title presses easily via a signal.

This PR will make implementing table operations such as 'sort by column title' much simpler to invoke.

[Godot QA ref](https://godotengine.org/qa/7699)
