### PR TITLE
Add extended check option to GDFunctionState::is_valid() (2.1)

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -13527,6 +13527,10 @@
 		<method name="is_valid" qualifiers="const">
 			<return type="bool">
 			</return>
+			<argument index="0" name="extended_check" type="bool" default="false">
+				If true, also check if the associated script and object still exists.
+				The extended check is done in debug mode as part of [method GDFunctionState.resume], but you can use this if you know you may be trying to resume without knowing for sure the object and/or script have survived up to that point.
+			</argument>
 			<description>
 				Check whether the function call may be resumed. This is not the case if the function state was already resumed.
 			</description>

--- a/modules/gdscript/gd_function.cpp
+++ b/modules/gdscript/gd_function.cpp
@@ -1362,9 +1362,21 @@ Variant GDFunctionState::_signal_callback(const Variant **p_args, int p_argcount
 	return ret;
 }
 
-bool GDFunctionState::is_valid() const {
+bool GDFunctionState::is_valid(bool p_extended_check) const {
 
-	return function != NULL;
+	if (function == NULL)
+		return false;
+
+	if (p_extended_check) {
+		//class instance gone?
+		if (state.instance_id && !ObjectDB::get_instance(state.instance_id))
+			return false;
+		//script gone?
+		if (state.script_id && !ObjectDB::get_instance(state.script_id))
+			return false;
+	}
+
+	return true;
 }
 
 Variant GDFunctionState::resume(const Variant &p_arg) {
@@ -1393,7 +1405,7 @@ Variant GDFunctionState::resume(const Variant &p_arg) {
 void GDFunctionState::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("resume:Variant", "arg"), &GDFunctionState::resume, DEFVAL(Variant()));
-	ObjectTypeDB::bind_method(_MD("is_valid"), &GDFunctionState::is_valid);
+	ObjectTypeDB::bind_method(_MD("is_valid", "extended_check"), &GDFunctionState::is_valid, DEFVAL(false));
 	ObjectTypeDB::bind_native_method(METHOD_FLAGS_DEFAULT, "_signal_callback", &GDFunctionState::_signal_callback, MethodInfo("_signal_callback"));
 }
 

--- a/modules/gdscript/gd_function.h
+++ b/modules/gdscript/gd_function.h
@@ -194,7 +194,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	bool is_valid() const;
+	bool is_valid(bool p_extended_check = false) const;
 	Variant resume(const Variant &p_arg = Variant());
 	GDFunctionState();
 	~GDFunctionState();


### PR DESCRIPTION
Whilst it may be good that the current implementation does the check only in debug builds, I think you should be able to check by hand if you are giving `GDFunctionState`s a long life span.