### PR TITLE
Add extended check option to GDFunctionState::is_valid()

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -15433,6 +15433,10 @@
 		<method name="is_valid" qualifiers="const">
 			<return type="bool">
 			</return>
+			<argument index="0" name="extended_check" type="bool" default="false">
+				If true, also check if the associated script and object still exists.
+				The extended check is done in debug mode as part of [method GDFunctionState.resume], but you can use this if you know you may be trying to resume without knowing for sure the object and/or script have survived up to that point.
+			</argument>
 			<description>
 				Check whether the function call may be resumed. This is not the case if the function state was already resumed.
 			</description>

--- a/modules/gdscript/gd_function.cpp
+++ b/modules/gdscript/gd_function.cpp
@@ -1433,9 +1433,21 @@ Variant GDFunctionState::_signal_callback(const Variant **p_args, int p_argcount
 	return ret;
 }
 
-bool GDFunctionState::is_valid() const {
+bool GDFunctionState::is_valid(bool p_extended_check) const {
 
-	return function != NULL;
+	if (function == NULL)
+		return false;
+
+	if (p_extended_check) {
+		//class instance gone?
+		if (state.instance_id && !ObjectDB::get_instance(state.instance_id))
+			return false;
+		//script gone?
+		if (state.script_id && !ObjectDB::get_instance(state.script_id))
+			return false;
+	}
+
+	return true;
 }
 
 Variant GDFunctionState::resume(const Variant &p_arg) {
@@ -1464,7 +1476,7 @@ Variant GDFunctionState::resume(const Variant &p_arg) {
 void GDFunctionState::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("resume:Variant", "arg"), &GDFunctionState::resume, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("is_valid"), &GDFunctionState::is_valid);
+	ClassDB::bind_method(D_METHOD("is_valid", "extended_check"), &GDFunctionState::is_valid, DEFVAL(false));
 	ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "_signal_callback", &GDFunctionState::_signal_callback, MethodInfo("_signal_callback"));
 }
 

--- a/modules/gdscript/gd_function.h
+++ b/modules/gdscript/gd_function.h
@@ -237,7 +237,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	bool is_valid() const;
+	bool is_valid(bool p_extended_check = false) const;
 	Variant resume(const Variant &p_arg = Variant());
 	GDFunctionState();
 	~GDFunctionState();


### PR DESCRIPTION
Whilst it may be good that the current implementation does the check only in debug builds, I think you should be able to check by hand if you are giving `GDFunctionState`s a long life span.