### PR TITLE
Make MessageQueue::flush() reentrant (2.1)

### DIFF
--- a/core/message_queue.cpp
+++ b/core/message_queue.cpp
@@ -316,11 +316,18 @@ void MessageQueue::flush() {
 
 	while (read_pos < buffer_end) {
 
-		_THREAD_SAFE_UNLOCK_
-
 		//lock on each interation, so a call can re-add itself to the message queue
 
 		Message *message = (Message *)&buffer[read_pos];
+
+		uint32_t advance = sizeof(Message);
+		if ((message->type & FLAG_MASK) != TYPE_NOTIFICATION)
+			advance += sizeof(Variant) * message->args;
+
+		//pre-advance so this function is reentrant
+		read_pos += advance;
+
+		_THREAD_SAFE_UNLOCK_
 
 		Object *target = ObjectDB::get_instance(message->instance_ID);
 
@@ -357,13 +364,9 @@ void MessageQueue::flush() {
 			}
 		}
 
-		uint32_t advance = sizeof(Message);
-		if ((message->type & FLAG_MASK) != TYPE_NOTIFICATION)
-			advance += sizeof(Variant) * message->args;
 		message->~Message();
 
 		_THREAD_SAFE_LOCK_
-		read_pos += advance;
 	}
 
 	buffer_end = 0; // reset buffer


### PR DESCRIPTION
Given that the message queue can be flushed potentially during an outer flush (that is, reentrantly), this function needs to be reentrant.

Currently it's only done for a hack involving input handling (https://github.com/godotengine/godot/blame/21bf3778d5c291e1587cddb154a5cc0e02b0aecc/scene/main/scene_main_loop.cpp#L432 and https://github.com/godotengine/godot/blame/21bf3778d5c291e1587cddb154a5cc0e02b0aecc/scene/main/scene_main_loop.cpp#L453).

**And that is a source of headache bugs, because it can make you get duplicated signals, deferred calls, etc. And only depending on whether an input event is produced.**

But in the future who knows where else that may happen.