### PR TITLE
Detect newer Visual Studio compilers correctly like VS2017.

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -1623,6 +1623,33 @@ def detect_visual_c_compiler_version(tools_env):
         vc_chosen_compiler_index = vc_x86_amd64_compiler_detection_index
         vc_chosen_compiler_str = "x86_amd64"
 
+    # Newer versions have a different path available
+    vc_amd64_compiler_detection_index = tools_env["PATH"].upper().find(tools_env['VCTOOLSINSTALLDIR'].upper() + "BIN\\HOSTX64\\X64;")
+    if(vc_amd64_compiler_detection_index > -1):
+        vc_chosen_compiler_index = vc_amd64_compiler_detection_index
+        vc_chosen_compiler_str = "amd64"
+
+    vc_amd64_x86_compiler_detection_index = tools_env["PATH"].upper().find(tools_env['VCTOOLSINSTALLDIR'].upper() + "BIN\\HOSTX64\\X86;")
+    if(vc_amd64_x86_compiler_detection_index > -1
+       and (vc_chosen_compiler_index == -1
+            or vc_chosen_compiler_index > vc_amd64_x86_compiler_detection_index)):
+        vc_chosen_compiler_index = vc_amd64_x86_compiler_detection_index
+        vc_chosen_compiler_str = "amd64_x86"
+
+    vc_x86_compiler_detection_index = tools_env["PATH"].upper().find(tools_env['VCTOOLSINSTALLDIR'].upper() + "BIN\\HOSTX86\\X86;")
+    if(vc_x86_compiler_detection_index > -1
+       and (vc_chosen_compiler_index == -1
+            or vc_chosen_compiler_index > vc_x86_compiler_detection_index)):
+        vc_chosen_compiler_index = vc_x86_compiler_detection_index
+        vc_chosen_compiler_str = "x86"
+
+    vc_x86_amd64_compiler_detection_index = tools_env["PATH"].upper().find(tools_env['VCTOOLSINSTALLDIR'].upper() + "BIN\\HOSTX86\\X64;")
+    if(vc_x86_amd64_compiler_detection_index > -1
+       and (vc_chosen_compiler_index == -1
+            or vc_chosen_compiler_index > vc_x86_amd64_compiler_detection_index)):
+        vc_chosen_compiler_index = vc_x86_amd64_compiler_detection_index
+        vc_chosen_compiler_str = "x86_amd64"
+
     # debug help
     # print vc_amd64_compiler_detection_index
     # print vc_amd64_x86_compiler_detection_index


### PR DESCRIPTION
Currently the compiler isn't detected correctly and will default always to an x86 build.
This should correct this for newer compilers.