### PR TITLE
Expose wheel's contact to GDScript and set roll influence in editor [3.0]

### DIFF
--- a/scene/3d/vehicle_body.cpp
+++ b/scene/3d/vehicle_body.cpp
@@ -214,6 +214,18 @@ float VehicleWheel::get_friction_slip() const {
 	return m_frictionSlip;
 }
 
+void VehicleWheel::set_roll_influence(float p_value) {
+	m_rollInfluence = p_value;
+}
+
+float VehicleWheel::get_roll_influence() const {
+	return m_rollInfluence;
+}
+
+bool VehicleWheel::is_in_contact() const {
+	return m_raycastInfo.m_isInContact;
+}
+
 void VehicleWheel::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_radius", "length"), &VehicleWheel::set_radius);
@@ -246,9 +258,15 @@ void VehicleWheel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_friction_slip", "length"), &VehicleWheel::set_friction_slip);
 	ClassDB::bind_method(D_METHOD("get_friction_slip"), &VehicleWheel::get_friction_slip);
 
+	ClassDB::bind_method(D_METHOD("is_in_contact"), &VehicleWheel::is_in_contact);
+
+	ClassDB::bind_method(D_METHOD("set_roll_influence", "roll_influence"), &VehicleWheel::set_roll_influence);
+	ClassDB::bind_method(D_METHOD("get_roll_influence"), &VehicleWheel::get_roll_influence);
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_as_traction"), "set_use_as_traction", "is_used_as_traction");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_as_steering"), "set_use_as_steering", "is_used_as_steering");
 	ADD_GROUP("Wheel", "wheel_");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "wheel_roll_influence"), "set_roll_influence", "get_roll_influence");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "wheel_radius"), "set_radius", "get_radius");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "wheel_rest_length"), "set_suspension_rest_length", "get_suspension_rest_length");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "wheel_friction_slip"), "set_friction_slip", "get_friction_slip");

--- a/scene/3d/vehicle_body.h
+++ b/scene/3d/vehicle_body.h
@@ -126,6 +126,11 @@ public:
 	void set_use_as_steering(bool p_enabled);
 	bool is_used_as_steering() const;
 
+	bool is_in_contact() const;
+
+	void set_roll_influence(float p_value);
+	float get_roll_influence() const;
+
 	VehicleWheel();
 };
 


### PR DESCRIPTION
This PR aims to increase moddability of the vehicle body.

1)    It allows GDScript to read the raycast variable that checks if the wheel touches the ground. This allows users to use scripting to vary game behavior depending on whether the car is on ground or in air (e.g. don't handle input at all if we're in air or apply smaller force or smaller steering or whatever)

2)    You can now set the roll_influence variable in editor. The smaller the value, the smaller the roll the car body experiences in turns. 0.1 is still the default value, but you can now set a larger value (for even greater roll) or smaller (for roll that is only cosmetic and doesn't threaten rollover).
    This is especially important if someone wants different kinds of cars that behave differently wrt roll (e.g. a pickup truck vs a minicar vs a sports car)

P.S. I suck at cherry picking so I just copy-pasta'd the relevant lines from the 2.1. version of the PR.