### PR TITLE
Export nested nodes in TileSet scenes; resolves #8819.

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -37,24 +37,18 @@ void TileSetEditor::edit(const Ref<TileSet> &p_tileset) {
 	tileset = p_tileset;
 }
 
-void TileSetEditor::_import_scene(Node *scene, Ref<TileSet> p_library, bool p_merge) {
+void TileSetEditor::_import_node(Node *p_node, Ref<TileSet> p_library) {
 
-	if (!p_merge)
-		p_library->clear();
+	for (int i = 0; i < p_node->get_child_count(); i++) {
 
-	for (int i = 0; i < scene->get_child_count(); i++) {
-
-		Node *child = scene->get_child(i);
+		Node *child = p_node->get_child(i);
 
 		if (!child->cast_to<Sprite>()) {
 			if (child->get_child_count() > 0) {
-				child = child->get_child(0);
-				if (!child->cast_to<Sprite>()) {
-					continue;
-				}
+				_import_node(child, p_library);
+			}
 
-			} else
-				continue;
+			continue;
 		}
 
 		Sprite *mi = child->cast_to<Sprite>();
@@ -136,6 +130,14 @@ void TileSetEditor::_import_scene(Node *scene, Ref<TileSet> p_library, bool p_me
 		p_library->tile_set_occluder_offset(id, -phys_offset);
 		p_library->tile_set_navigation_polygon_offset(id, -phys_offset);
 	}
+}
+
+void TileSetEditor::_import_scene(Node *scene, Ref<TileSet> p_library, bool p_merge) {
+
+	if (!p_merge)
+		p_library->clear();
+
+	_import_node(scene, p_library);
 }
 
 void TileSetEditor::_menu_confirm() {

--- a/editor/plugins/tile_set_editor_plugin.h
+++ b/editor/plugins/tile_set_editor_plugin.h
@@ -59,6 +59,7 @@ class TileSetEditor : public Control {
 	void _menu_confirm();
 	void _name_dialog_confirm(const String &name);
 
+	static void _import_node(Node *p_node, Ref<TileSet> p_library);
 	static void _import_scene(Node *p_scene, Ref<TileSet> p_library, bool p_merge);
 
 protected:


### PR DESCRIPTION
Adds _import_node() that, when used in conjunction with _import_scene, recurses through the scene tree and exports all available nodes.

Important note: This is not tested with nested sprites, although it should work. More eyes on this are gladly welcome.