### PR TITLE
Added texture_get_texid

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -970,6 +970,14 @@ Image::Format RasterizerStorageGLES3::texture_get_format(RID p_texture) const {
 
 	return texture->format;
 }
+uint32_t RasterizerStorageGLES3::texture_get_texid(RID p_texture) const {
+
+	Texture *texture = texture_owner.get(p_texture);
+
+	ERR_FAIL_COND_V(!texture, 0);
+
+	return texture->tex_id;
+}
 uint32_t RasterizerStorageGLES3::texture_get_width(RID p_texture) const {
 
 	Texture *texture = texture_owner.get(p_texture);

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -289,6 +289,7 @@ public:
 	virtual void texture_set_flags(RID p_texture, uint32_t p_flags);
 	virtual uint32_t texture_get_flags(RID p_texture) const;
 	virtual Image::Format texture_get_format(RID p_texture) const;
+	virtual uint32_t texture_get_texid(RID p_texture) const;
 	virtual uint32_t texture_get_width(RID p_texture) const;
 	virtual uint32_t texture_get_height(RID p_texture) const;
 	virtual void texture_set_size_override(RID p_texture, int p_width, int p_height);

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -168,6 +168,7 @@ public:
 	virtual void texture_set_flags(RID p_texture, uint32_t p_flags) = 0;
 	virtual uint32_t texture_get_flags(RID p_texture) const = 0;
 	virtual Image::Format texture_get_format(RID p_texture) const = 0;
+	virtual uint32_t texture_get_texid(RID p_texture) const = 0;
 	virtual uint32_t texture_get_width(RID p_texture) const = 0;
 	virtual uint32_t texture_get_height(RID p_texture) const = 0;
 	virtual void texture_set_size_override(RID p_texture, int p_width, int p_height) = 0;

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -628,6 +628,7 @@ public:
 	BIND2(texture_set_flags, RID, uint32_t)
 	BIND1RC(uint32_t, texture_get_flags, RID)
 	BIND1RC(Image::Format, texture_get_format, RID)
+	BIND1RC(uint32_t, texture_get_texid, RID)
 	BIND1RC(uint32_t, texture_get_width, RID)
 	BIND1RC(uint32_t, texture_get_height, RID)
 	BIND3(texture_set_size_override, RID, int, int)

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -114,6 +114,7 @@ public:
 	virtual void texture_set_flags(RID p_texture, uint32_t p_flags) = 0;
 	virtual uint32_t texture_get_flags(RID p_texture) const = 0;
 	virtual Image::Format texture_get_format(RID p_texture) const = 0;
+	virtual uint32_t texture_get_texid(RID p_texture) const = 0;
 	virtual uint32_t texture_get_width(RID p_texture) const = 0;
 	virtual uint32_t texture_get_height(RID p_texture) const = 0;
 	virtual void texture_set_size_override(RID p_texture, int p_width, int p_height) = 0;


### PR DESCRIPTION
This is a change originally made for OpenVR which is needed to apply to core if we want to implement OpenVR as a GDNative module.

It simply exposes the OpenGL texture ID of a texture to the outside world. In OpenVR you need to send this texture ID for the render targets of the two eyes to OpenVR for further processing and output to the HMD (you don't have direct access to the HMDs screen and OpenVR handles lens distortion). 

@reduz , @Hinsbart 