### PR TITLE
Show disabled item with proper color on FileDialog of editor theme

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -413,6 +413,11 @@ Ref<Theme> create_editor_theme() {
 	theme->set_stylebox("comment", "GraphNode", graphsbcomment);
 	theme->set_stylebox("commentfocus", "GraphNode", graphsbcommentselected);
 
+	// FileDialog
+	Color disable_color = light_color_2;
+	disable_color.a = 0.7;
+	theme->set_color("files_disabled", "FileDialog", disable_color);
+
 	return theme;
 }
 


### PR DESCRIPTION
Fix #8635

![image](https://cloud.githubusercontent.com/assets/8281454/26305200/50e0655e-3f29-11e7-9511-fbfff6e91691.png)