### PR TITLE
Fit grid with label and component of editor

### DIFF
--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -308,6 +308,7 @@ MarginContainer *VBoxContainer::add_margin_child(const String &p_label, Control 
 	l->set_text(p_label);
 	add_child(l);
 	MarginContainer *mc = memnew(MarginContainer);
+	mc->add_constant_override("margin_left", 0);
 	mc->add_child(p_control);
 	add_child(mc);
 	if (p_expand)


### PR DESCRIPTION
see component and it's label position.

before
![margin1-1](https://cloud.githubusercontent.com/assets/8281454/26306194/65adc586-3f2d-11e7-8a74-9c90da5e58a3.png)
after
![margin1](https://cloud.githubusercontent.com/assets/8281454/26306199/68fb4fb0-3f2d-11e7-907f-5d02c437960d.png)

before
![margin2-1](https://cloud.githubusercontent.com/assets/8281454/26306202/6b610db2-3f2d-11e7-85e0-166685c2c262.png)
after
![margin2](https://cloud.githubusercontent.com/assets/8281454/26306208/6d3bd432-3f2d-11e7-9355-cb76a83fb5ff.png)
