### PR TITLE
Show description box on create new node window

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1786,7 +1786,7 @@ void EditorHelpBit::_bind_methods() {
 void EditorHelpBit::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
-		add_style_override("panel", get_stylebox("normal", "TextEdit"));
+		add_style_override("panel", get_stylebox("ScriptPanel", "EditorStyles"));
 	}
 }
 


### PR DESCRIPTION
before
![image](https://cloud.githubusercontent.com/assets/8281454/26309285/6035fdb2-3f37-11e7-81ee-90502f5a46c5.png)

after
![image](https://cloud.githubusercontent.com/assets/8281454/26309299/6d45f4bc-3f37-11e7-91da-995247b63ed8.png)

it's only about showing box of description, grid fitting is from #8862 