### PR TITLE
[2.1] Convert shaders to binary format when exporting

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -107,6 +107,7 @@
 #include "editor/io_plugins/editor_mesh_import_plugin.h"
 #include "editor/io_plugins/editor_sample_import_plugin.h"
 #include "editor/io_plugins/editor_scene_import_plugin.h"
+#include "editor/io_plugins/editor_shader_export_plugin.h"
 #include "editor/io_plugins/editor_texture_import_plugin.h"
 #include "editor/io_plugins/editor_translation_import_plugin.h"
 
@@ -6132,6 +6133,7 @@ EditorNode::EditorNode() {
 	editor_import_export->add_export_plugin(Ref<EditorTextureExportPlugin>(memnew(EditorTextureExportPlugin)));
 	editor_import_export->add_export_plugin(Ref<EditorSampleExportPlugin>(memnew(EditorSampleExportPlugin)));
 	editor_import_export->add_export_plugin(Ref<EditorSceneExportPlugin>(memnew(EditorSceneExportPlugin)));
+	editor_import_export->add_export_plugin(Ref<EditorShaderExportPlugin>(memnew(EditorShaderExportPlugin)));
 
 	add_editor_plugin(memnew(AnimationPlayerEditorPlugin(this)));
 	add_editor_plugin(memnew(CanvasItemEditorPlugin(this)));

--- a/editor/io_plugins/editor_shader_export_plugin.cpp
+++ b/editor/io_plugins/editor_shader_export_plugin.cpp
@@ -1,0 +1,132 @@
+/*************************************************************************/
+/*  editor_export_scene.cpp                                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#include "editor_shader_export_plugin.h"
+#include "editor/editor_settings.h"
+#include "globals.h"
+#include "io/resource_loader.h"
+#include "io/resource_saver.h"
+#include "os/dir_access.h"
+#include "os/file_access.h"
+#include "scene/resources/shader.h"
+
+Vector<uint8_t> EditorShaderExportPlugin::custom_export(String &p_path, const Ref<EditorExportPlatform> &p_platform) {
+
+	if (!EditorImportExport::get_singleton()->get_convert_text_scenes()) {
+		return Vector<uint8_t>();
+	}
+
+	String extension = p_path.extension();
+
+	//step 1 check if shader
+
+	if (extension == "tres" || extension == "xml") {
+
+		String type = ResourceLoader::get_resource_type(p_path);
+
+		if (!type.ends_with("Shader"))
+			return Vector<uint8_t>();
+
+	} else if (extension != "xshd") {
+		return Vector<uint8_t>();
+	}
+
+	//step 2 check if cached
+
+	uint64_t sd = 0;
+	String smd5;
+	String gp = Globals::get_singleton()->globalize_path(p_path);
+	String md5 = gp.md5_text();
+	String tmp_path = EditorSettings::get_singleton()->get_settings_path().plus_file("tmp/");
+
+	bool valid = false;
+	{
+		//if existing, make sure it's valid
+		FileAccessRef f = FileAccess::open(tmp_path + "shdexp-" + md5 + ".txt", FileAccess::READ);
+		if (f) {
+
+			uint64_t d = f->get_line().strip_edges().to_int64();
+			sd = FileAccess::get_modified_time(p_path);
+
+			if (d == sd) {
+				valid = true;
+			} else {
+				String cmd5 = f->get_line().strip_edges();
+				smd5 = FileAccess::get_md5(p_path);
+				if (cmd5 == smd5) {
+					valid = true;
+				}
+			}
+		}
+	}
+
+	if (!valid) {
+		//cache failed, convert
+		DirAccess *da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+
+		String copy = p_path + ".convert." + extension;
+
+		// a copy will allow loading the internal resources without conflicting with opened shaders
+		da->copy(p_path, copy);
+
+		Ref<Shader> copyres = ResourceLoader::load(copy, "Shader");
+
+		da->remove(copy);
+
+		memdelete(da);
+
+		ERR_FAIL_COND_V(!copyres.is_valid(), Vector<uint8_t>());
+
+		Error err = ResourceSaver::save(tmp_path + "shdexp-" + md5 + ".shd", copyres);
+
+		copyres = Ref<Shader>();
+
+		ERR_FAIL_COND_V(err != OK, Vector<uint8_t>());
+
+		FileAccessRef f = FileAccess::open(tmp_path + "shdexp-" + md5 + ".txt", FileAccess::WRITE);
+
+		if (sd == 0)
+			sd = FileAccess::get_modified_time(p_path);
+		if (smd5 == String())
+			smd5 = FileAccess::get_md5(p_path);
+
+		f->store_line(String::num(sd));
+		f->store_line(smd5);
+		f->store_line(gp); //source path for reference
+	}
+
+	Vector<uint8_t> ret = FileAccess::get_file_as_array(tmp_path + "shdexp-" + md5 + ".shd");
+
+	p_path += ".converted.shd";
+
+	return ret;
+}
+
+EditorShaderExportPlugin::EditorShaderExportPlugin() {
+}

--- a/editor/io_plugins/editor_shader_export_plugin.h
+++ b/editor/io_plugins/editor_shader_export_plugin.h
@@ -1,0 +1,44 @@
+/*************************************************************************/
+/*  editor_export_scene.h                                                */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                    http://www.godotengine.org                         */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#ifndef EDITOR_SHADER_EXPORT_H
+#define EDITOR_SHADER_EXPORT_H
+
+#include "editor/editor_import_export.h"
+
+class EditorShaderExportPlugin : public EditorExportPlugin {
+	OBJ_TYPE(EditorShaderExportPlugin, EditorExportPlugin);
+
+public:
+	virtual Vector<uint8_t> custom_export(String &p_path, const Ref<EditorExportPlatform> &p_platform);
+
+	EditorShaderExportPlugin();
+};
+
+#endif // EDITOR_SHADER_EXPORT_H


### PR DESCRIPTION
When exporting a project with "convert text scenes" option enabled the editor now also convert text shaders (tres/xshd/xml) to binary format (`.shd`).

This does not implement encryption, I can work on it if there is interest.

Partial fix for #8860 .
This does not apply to GraphShaders, only regular text Shaders.

Resource conversion is not supported on 3.0 as far as I know, so I'm proposing this for `2.1`.

It's quite a preliminary patch, but I'd like your comments on encryption and converting graph shaders before implementing it.