### PR TITLE
Fix errors on engine startup.

### DIFF
--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1108,9 +1108,9 @@ EditorAudioBuses::EditorAudioBuses() {
 
 	file_dialog = memnew(EditorFileDialog);
 	List<String> ext;
-	ResourceLoader::get_recognized_extensions_for_type("AudioServerState", &ext);
+	ResourceLoader::get_recognized_extensions_for_type("AudioBusLayout", &ext);
 	for (List<String>::Element *E = ext.front(); E; E = E->next()) {
-		file_dialog->add_filter("*." + E->get() + "; Audio Bus State");
+		file_dialog->add_filter("*." + E->get() + "; Audio Bus Layout");
 	}
 	add_child(file_dialog);
 	file_dialog->connect("file_selected", this, "_file_dialog_callback");

--- a/editor/import/resource_importer_csv_translation.cpp
+++ b/editor/import/resource_importer_csv_translation.cpp
@@ -54,7 +54,7 @@ String ResourceImporterCSVTranslation::get_save_extension() const {
 
 String ResourceImporterCSVTranslation::get_resource_type() const {
 
-	return "StreamCSVTranslation";
+	return "Translation";
 }
 
 bool ResourceImporterCSVTranslation::get_option_visibility(const String &p_option, const Map<StringName, Variant> &p_options) const {

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -539,10 +539,12 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	/* Margins */
 
 	empty_h = memnew(Control);
+	empty_h->set_name("empty_h"); //duplicate() doesn't like nodes without a name
 	empty_h->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	empty_h->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	empty_h->set_custom_minimum_size(Size2(0, 10 * EDSCALE));
 	empty_v = memnew(Control);
+	empty_v->set_name("empty_v");
 	empty_v->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	empty_v->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	empty_v->set_custom_minimum_size(Size2(10, 0 * EDSCALE));

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -351,10 +351,6 @@ void ImageTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_lossy_storage_quality"), &ImageTexture::get_lossy_storage_quality);
 
 	ClassDB::bind_method(D_METHOD("set_size_override", "size"), &ImageTexture::set_size_override);
-	ClassDB::set_method_flags(get_class_static(), _scs_create("fix_alpha_edges"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
-	ClassDB::set_method_flags(get_class_static(), _scs_create("premultiply_alpha"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
-	ClassDB::set_method_flags(get_class_static(), _scs_create("normal_to_xy"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
-	ClassDB::set_method_flags(get_class_static(), _scs_create("shrink_x2_and_keep_size"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
 	ClassDB::bind_method(D_METHOD("_reload_hook", "rid"), &ImageTexture::_reload_hook);
 
 	BIND_CONSTANT(STORAGE_RAW);


### PR DESCRIPTION
Fixes a bunch of the most spammy console errors introduced by recent refactorings:

- `AudioServerState` does not exist, this was the only reference to it in the source. The surrounding code made it clear that `AudioServerLayout` was meant to be used instead.
- `StreamCSVTranslation` same here, it's the only reference. I went with `Translation` here, but I'm not 100% certain.
- Some methods have been moved from `Texture` to `Image`, but the old bindings were still there.
- A few `name == ""` errors related to duplicating nodes.