### PR TITLE
More fixes for iOS Godot 3.0

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -4831,7 +4831,12 @@ void RasterizerSceneGLES3::initialize() {
 
 		glGenTextures(1, &e.color);
 		glBindTexture(GL_TEXTURE_2D, e.color);
+#ifdef IPHONE_ENABLED
+		///@TODO ugly hack to get around iOS not supporting 32bit single channel floating point textures...  
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_R16F, max_exposure_shrink_size, max_exposure_shrink_size, 0, GL_RED, GL_FLOAT, NULL);
+#else
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_R32F, max_exposure_shrink_size, max_exposure_shrink_size, 0, GL_RED, GL_FLOAT, NULL);
+#endif
 		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, e.color, 0);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/platform/iphone/app_delegate.mm
+++ b/platform/iphone/app_delegate.mm
@@ -604,7 +604,12 @@ static int frame_count = 0;
 	glGetRenderbufferParameterivOES(GL_RENDERBUFFER_OES,
 			GL_RENDERBUFFER_HEIGHT_OES, &backingHeight);
 
-	iphone_main(backingWidth, backingHeight, gargc, gargv);
+	int err = iphone_main(backingWidth, backingHeight, gargc, gargv);
+	if (err != 0) {
+		// bail, things did not go very well for us, should probably output a message on screen with our error code...
+		exit(0);
+		return;
+	};
 
 	view_controller = [[ViewController alloc] init];
 	view_controller.view = glView;
@@ -668,6 +673,7 @@ static int frame_count = 0;
 												  isAdvertisingTrackingEnabled]];
 
 #endif
+
 };
 
 - (void)applicationWillTerminate:(UIApplication *)application {

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -196,8 +196,8 @@ bool OSIPhone::iterate() {
 void OSIPhone::key(uint32_t p_key, bool p_pressed) {
 
 	Ref<InputEventKey> ev;
-	ev.instance()
-			ev->set_echo(false);
+	ev.instance();
+	ev->set_echo(false);
 	ev->set_pressed(p_pressed);
 	ev->set_scancode(p_key);
 	ev->set_unicode(p_key);
@@ -207,7 +207,7 @@ void OSIPhone::key(uint32_t p_key, bool p_pressed) {
 void OSIPhone::mouse_button(int p_idx, int p_x, int p_y, bool p_pressed, bool p_doubleclick, bool p_use_as_mouse) {
 
 	if (!GLOBAL_DEF("debug/disable_touch", false)) {
-		Ref<InputEventSreenTouch> ev;
+		Ref<InputEventScreenTouch> ev;
 		ev.instance();
 
 		ev->set_index(p_idx);
@@ -216,7 +216,7 @@ void OSIPhone::mouse_button(int p_idx, int p_x, int p_y, bool p_pressed, bool p_
 		queue_event(ev);
 	};
 
-	mouse_list->is_pressed()[p_idx] = p_pressed;
+	mouse_list.pressed[p_idx] = p_pressed;
 
 	if (p_use_as_mouse) {
 
@@ -225,10 +225,10 @@ void OSIPhone::mouse_button(int p_idx, int p_x, int p_y, bool p_pressed, bool p_
 		// swaped it for tilted screen
 		//ev->get_pos().x = ev.mouse_button.global_x = video_mode.height - p_y;
 		//ev->get_pos().y = ev.mouse_button.global_y = p_x;
-		ev->set_pos(Vector2(ev.mouse_button.global_x, ev.mouse_button.global_y));
-		ev->set_global_pos(Vector2(ev.mouse_button.global_x, ev.mouse_button.global_y));
+		ev->set_pos(Vector2(video_mode.height - p_y, p_x));
+		ev->set_global_pos(Vector2(video_mode.height - p_y, p_x));
 
-		//mouse_list->is_pressed()[p_idx] = p_pressed;
+		//mouse_list.pressed[p_idx] = p_pressed;
 
 		input->set_mouse_position(ev->get_pos());
 		ev->set_button_index(BUTTON_LEFT);
@@ -278,7 +278,7 @@ void OSIPhone::touches_cancelled() {
 
 	for (int i = 0; i < MAX_MOUSE_COUNT; i++) {
 
-		if (mouse_list->is_pressed()[i]) {
+		if (mouse_list.pressed[i]) {
 
 			// send a mouse_up outside the screen
 			mouse_button(i, -1, -1, false, false, false);
@@ -398,7 +398,7 @@ Point2 OSIPhone::get_mouse_position() const {
 
 int OSIPhone::get_mouse_button_state() const {
 
-	return mouse_list->is_pressed()[0];
+	return mouse_list.pressed[0];
 };
 
 void OSIPhone::set_window_title(const String &p_title){};


### PR DESCRIPTION
- nicely exit if initialisation fails
- fix a few issues around new event handling
- use 16bit single channel framebuffer as 32bit is not supported on iOS ( @reduz  you'll probably want me to do this differently)