### PR TITLE
Make arm64 the default option and set minimum to iOS 9

### DIFF
--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -59,15 +59,16 @@ def configure(env):
         env["arch"] = "x86"
         env["bits"] = "32"
         env['CCFLAGS'] = string.split('-arch i386 -fobjc-abi-version=2 -fobjc-legacy-dispatch -fmessage-length=0 -fpascal-strings -fasm-blocks -D__IPHONE_OS_VERSION_MIN_REQUIRED=40100 -isysroot $IPHONESDK -mios-simulator-version-min=4.3 -DCUSTOM_MATRIX_TRANSFORM_H=\\\"build/iphone/matrix4_iphone.h\\\" -DCUSTOM_VECTOR3_TRANSFORM_H=\\\"build/iphone/vector3_iphone.h\\\"')
-    elif (env["arch"] == "arm64"):  # arm64
-        env["bits"] = "64"
-        env['CCFLAGS'] = string.split('-fno-objc-arc -arch arm64 -fmessage-length=0 -fno-strict-aliasing -fdiagnostics-print-source-range-info -fdiagnostics-show-category=id -fdiagnostics-parseable-fixits -fpascal-strings -fvisibility=hidden -MMD -MT dependencies -miphoneos-version-min=7.0 -isysroot $IPHONESDK')
-        env.Append(CPPFLAGS=['-DNEED_LONG_INT'])
-        env.Append(CPPFLAGS=['-DLIBYUV_DISABLE_NEON'])
-    else:  # armv7
+    elif (env["arch"] == "arm" or env["arch"] == "arm32" or env["arch"] == "armv7" or env["bits"] == "32"):  # arm
         env["arch"] = "arm"
         env["bits"] = "32"
-        env['CCFLAGS'] = string.split('-fno-objc-arc -arch armv7 -fmessage-length=0 -fno-strict-aliasing -fdiagnostics-print-source-range-info -fdiagnostics-show-category=id -fdiagnostics-parseable-fixits -fpascal-strings -isysroot $IPHONESDK -fvisibility=hidden -mthumb "-DIBOutlet=__attribute__((iboutlet))" "-DIBOutletCollection(ClassName)=__attribute__((iboutletcollection(ClassName)))" "-DIBAction=void)__attribute__((ibaction)" -miphoneos-version-min=7.0 -MMD -MT dependencies -isysroot $IPHONESDK')
+        env['CCFLAGS'] = string.split('-fno-objc-arc -arch armv7 -fmessage-length=0 -fno-strict-aliasing -fdiagnostics-print-source-range-info -fdiagnostics-show-category=id -fdiagnostics-parseable-fixits -fpascal-strings -isysroot $IPHONESDK -fvisibility=hidden -mthumb "-DIBOutlet=__attribute__((iboutlet))" "-DIBOutletCollection(ClassName)=__attribute__((iboutletcollection(ClassName)))" "-DIBAction=void)__attribute__((ibaction)" -miphoneos-version-min=9.0 -MMD -MT dependencies -isysroot $IPHONESDK')
+    else:  # armv64
+        env["arch"] = "arm64"
+        env["bits"] = "64"
+        env['CCFLAGS'] = string.split('-fno-objc-arc -arch arm64 -fmessage-length=0 -fno-strict-aliasing -fdiagnostics-print-source-range-info -fdiagnostics-show-category=id -fdiagnostics-parseable-fixits -fpascal-strings -fvisibility=hidden -MMD -MT dependencies -miphoneos-version-min=9.0 -isysroot $IPHONESDK')
+        env.Append(CPPFLAGS=['-DNEED_LONG_INT'])
+        env.Append(CPPFLAGS=['-DLIBYUV_DISABLE_NEON'])
 
     if (env["arch"] == "x86"):
         env['IPHONEPLATFORM'] = 'iPhoneSimulator'
@@ -93,7 +94,7 @@ def configure(env):
                               '-F$IPHONESDK',
                               ])
     elif (env["arch"] == "arm64"):
-        env.Append(LINKFLAGS=['-arch', 'arm64', '-Wl,-dead_strip', '-miphoneos-version-min=7.0',
+        env.Append(LINKFLAGS=['-arch', 'arm64', '-Wl,-dead_strip', '-miphoneos-version-min=9.0',
                                                 '-isysroot', '$IPHONESDK',
                                                 #'-stdlib=libc++',
                                                 '-framework', 'Foundation',
@@ -112,7 +113,7 @@ def configure(env):
                                                 '-framework', 'CoreMotion',
                               ])
     else:
-        env.Append(LINKFLAGS=['-arch', 'armv7', '-Wl,-dead_strip', '-miphoneos-version-min=7.0',
+        env.Append(LINKFLAGS=['-arch', 'armv7', '-Wl,-dead_strip', '-miphoneos-version-min=9.0',
                                                 '-isysroot', '$IPHONESDK',
                                                 '-framework', 'Foundation',
                                                 '-framework', 'UIKit',


### PR DESCRIPTION
We might even want to consider removing armv7 support all together because compiling and deploying your app like that makes iOS 10 give a nice big message to the user that your app won't run for much longer.

Anyway, I made ARM64 the default if you don't specify any parameters to scons, you can set either bits=32, arch=arm or arch=armv7 to compile 32bit arm and arch=x86 and simulator options work as before.

I haven't used the simulator for awhile, I'll see if I can get those up and running to. It is set to a minimum of iOS 4 which is defunct with all the new stuff we're using.

I also upped the minimum iOS to 9, latest figures give iOS 9 a market of 8 to 9% and iOS 10 a market of 90% leaving a percentile of devices unsupported, but it should allow us to access some of the newer APIs. 