### PR TITLE
Fix crash when interacting with the 2d editor

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1531,8 +1531,8 @@ void CanvasItemEditor::_viewport_gui_input(const Ref<InputEvent> &p_event) {
 				continue;
 			}
 
-			bool uniform = b->get_shift();
-			bool symmetric = b->get_alt();
+			bool uniform = m->get_shift();
+			bool symmetric = m->get_alt();
 
 			dto = dto - (drag == DRAG_ALL || drag == DRAG_NODE_2D ? drag_from - drag_point_from : Vector2(0, 0));
 


### PR DESCRIPTION
It was caused by a typo from 5b3709d3096df737b8bb2344446be818b0389bfe.

This issue was cited in https://github.com/godotengine/godot/issues/8874#issuecomment-303392647