### PR TITLE
[GDNative] fixed some functions that returned references

### DIFF
--- a/modules/gdnative/godot/godot_array.cpp
+++ b/modules/gdnative/godot/godot_array.cpp
@@ -139,13 +139,9 @@ void GDAPI godot_array_set(godot_array *p_arr, const godot_int p_idx, const godo
 	a->operator[](p_idx) = *val;
 }
 
-godot_variant GDAPI godot_array_get(const godot_array *p_arr, const godot_int p_idx) {
-	godot_variant raw_dest;
-	Variant *dest = (Variant *)&raw_dest;
-	memnew_placement(dest, Variant);
-	const Array *a = (const Array *)p_arr;
-	*dest = a->operator[](p_idx);
-	return raw_dest;
+godot_variant GDAPI *godot_array_get(const godot_array *p_arr, const godot_int p_idx) {
+	Array *a = (Array *)p_arr;
+	return (godot_variant *)&a->operator[](p_idx);
 }
 
 void GDAPI godot_array_append(godot_array *p_arr, const godot_variant *p_value) {

--- a/modules/gdnative/godot/godot_array.h
+++ b/modules/gdnative/godot/godot_array.h
@@ -59,7 +59,7 @@ void GDAPI godot_array_new_pool_byte_array(godot_array *p_arr, const godot_pool_
 
 void GDAPI godot_array_set(godot_array *p_arr, const godot_int p_idx, const godot_variant *p_value);
 
-godot_variant GDAPI godot_array_get(const godot_array *p_arr, const godot_int p_idx);
+godot_variant GDAPI *godot_array_get(const godot_array *p_arr, const godot_int p_idx);
 
 void GDAPI godot_array_append(godot_array *p_arr, const godot_variant *p_value);
 

--- a/modules/gdnative/godot/godot_dictionary.cpp
+++ b/modules/gdnative/godot/godot_dictionary.cpp
@@ -101,13 +101,10 @@ godot_array GDAPI godot_dictionary_values(const godot_dictionary *p_self) {
 	return dest;
 }
 
-godot_variant GDAPI godot_dictionary_operator_index(godot_dictionary *p_dict, const godot_variant *p_key) {
-	godot_variant raw_dest;
-	Variant *dest = (Variant *)&raw_dest;
-	const Dictionary *dict = (const Dictionary *)p_dict;
+godot_variant GDAPI *godot_dictionary_operator_index(godot_dictionary *p_dict, const godot_variant *p_key) {
+	Dictionary *dict = (Dictionary *)p_dict;
 	const Variant *key = (const Variant *)p_key;
-	*dest = dict->operator[](*key);
-	return raw_dest;
+	return (godot_variant *)&dict->operator[](*key);
 }
 
 godot_bool GDAPI godot_dictionary_operator_equal(const godot_dictionary *p_self, const godot_dictionary *p_b) {

--- a/modules/gdnative/godot/godot_dictionary.h
+++ b/modules/gdnative/godot/godot_dictionary.h
@@ -68,7 +68,7 @@ godot_array GDAPI godot_dictionary_keys(const godot_dictionary *p_self);
 
 godot_array GDAPI godot_dictionary_values(const godot_dictionary *p_self);
 
-godot_variant GDAPI godot_dictionary_operator_index(godot_dictionary *p_dict, const godot_variant *p_key);
+godot_variant GDAPI *godot_dictionary_operator_index(godot_dictionary *p_dict, const godot_variant *p_key);
 
 godot_bool GDAPI godot_dictionary_operator_equal(const godot_dictionary *p_self, const godot_dictionary *p_b);
 


### PR DESCRIPTION
Those errors were introduced with #8821 (6fd217d). These functions need to return reference types, otherwise setting values on those containers does not work.