### PR TITLE
Fix 2D-editor mouse wheel zoom for x11.

### DIFF
--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -461,7 +461,7 @@ void InputEventMouseButton::_bind_methods() {
 
 InputEventMouseButton::InputEventMouseButton() {
 
-	factor = 0;
+	factor = 1;
 	button_index = 0;
 	pressed = false;
 	doubleclick = false;


### PR DESCRIPTION
Let it zoom again after the InputEvent changes 5b3709d3096df737b8bb2344446be818b0389bfe .