### PR TITLE
Join text menus on the top-left, move shortcut buttons to new locations (Preliminary work towards achieving the changes discussed in #8865.)

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -269,28 +269,7 @@ void EditorNode::_notification(int p_what) {
 				update_menu->set_icon(gui_base->get_icon("Progress" + itos(circle_step + 1), "EditorIcons"));
 			}
 		}
-
 		editor_selection->update();
-
-		{
-			uint32_t p32 = 0; //AudioServer::get_singleton()->read_output_peak()>>8;
-
-			float peak = p32 == 0 ? -80 : Math::linear2db(p32 / 65535.0);
-
-			if (peak < -80)
-				peak = -80;
-			float vu = audio_vu->get_value();
-
-			if (peak > vu) {
-				audio_vu->set_value(peak);
-			} else {
-				float new_vu = vu - get_process_delta_time() * 70.0;
-				if (new_vu < -80)
-					new_vu = -80;
-				if (new_vu != -80 && vu != -80)
-					audio_vu->set_value(new_vu);
-			}
-		}
 
 		ResourceImporterTexture::get_singleton()->update_imports();
 	}
@@ -2457,28 +2436,28 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		case RUN_FILE_SERVER: {
 
 			//file_server
-			bool ischecked = debug_button->get_popup()->is_item_checked(debug_button->get_popup()->get_item_index(RUN_FILE_SERVER));
+			bool ischecked = debug_menu->get_popup()->is_item_checked(debug_menu->get_popup()->get_item_index(RUN_FILE_SERVER));
 
 			if (ischecked) {
 				file_server->stop();
 				run_native->set_deploy_dumb(false);
-				//debug_button->set_icon(gui_base->get_icon("FileServer","EditorIcons"));
-				//debug_button->get_popup()->set_item_text( debug_button->get_popup()->get_item_index(RUN_FILE_SERVER),"Enable File Server");
+				//debug_menu->set_icon(gui_base->get_icon("FileServer","EditorIcons"));
+				//debug_menu->get_popup()->set_item_text( debug_menu->get_popup()->get_item_index(RUN_FILE_SERVER),"Enable File Server");
 			} else {
 				file_server->start();
 				run_native->set_deploy_dumb(true);
-				//debug_button->set_icon(gui_base->get_icon("FileServerActive","EditorIcons"));
-				//debug_button->get_popup()->set_item_text( debug_button->get_popup()->get_item_index(RUN_FILE_SERVER),"Disable File Server");
+				//debug_menu->set_icon(gui_base->get_icon("FileServerActive","EditorIcons"));
+				//debug_menu->get_popup()->set_item_text( debug_menu->get_popup()->get_item_index(RUN_FILE_SERVER),"Disable File Server");
 			}
 
-			debug_button->get_popup()->set_item_checked(debug_button->get_popup()->get_item_index(RUN_FILE_SERVER), !ischecked);
+			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_FILE_SERVER), !ischecked);
 			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_file_server", !ischecked);
 		} break;
 		case RUN_LIVE_DEBUG: {
 
-			bool ischecked = debug_button->get_popup()->is_item_checked(debug_button->get_popup()->get_item_index(RUN_LIVE_DEBUG));
+			bool ischecked = debug_menu->get_popup()->is_item_checked(debug_menu->get_popup()->get_item_index(RUN_LIVE_DEBUG));
 
-			debug_button->get_popup()->set_item_checked(debug_button->get_popup()->get_item_index(RUN_LIVE_DEBUG), !ischecked);
+			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_LIVE_DEBUG), !ischecked);
 			ScriptEditor::get_singleton()->get_debugger()->set_live_debugging(!ischecked);
 			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_live_debug", !ischecked);
 
@@ -2486,23 +2465,23 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 		/*case RUN_DEPLOY_DUMB_CLIENTS: {
 
-			bool ischecked = debug_button->get_popup()->is_item_checked( debug_button->get_popup()->get_item_index(RUN_DEPLOY_DUMB_CLIENTS));
-			debug_button->get_popup()->set_item_checked( debug_button->get_popup()->get_item_index(RUN_DEPLOY_DUMB_CLIENTS),!ischecked);
+			bool ischecked = debug_menu->get_popup()->is_item_checked( debug_menu->get_popup()->get_item_index(RUN_DEPLOY_DUMB_CLIENTS));
+			debug_menu->get_popup()->set_item_checked( debug_menu->get_popup()->get_item_index(RUN_DEPLOY_DUMB_CLIENTS),!ischecked);
 			run_native->set_deploy_dumb(!ischecked);
 
 		} break;*/
 		case RUN_DEPLOY_REMOTE_DEBUG: {
 
-			bool ischecked = debug_button->get_popup()->is_item_checked(debug_button->get_popup()->get_item_index(RUN_DEPLOY_REMOTE_DEBUG));
-			debug_button->get_popup()->set_item_checked(debug_button->get_popup()->get_item_index(RUN_DEPLOY_REMOTE_DEBUG), !ischecked);
+			bool ischecked = debug_menu->get_popup()->is_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEPLOY_REMOTE_DEBUG));
+			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEPLOY_REMOTE_DEBUG), !ischecked);
 			run_native->set_deploy_debug_remote(!ischecked);
 			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_deploy_remote_debug", !ischecked);
 
 		} break;
 		case RUN_DEBUG_COLLISONS: {
 
-			bool ischecked = debug_button->get_popup()->is_item_checked(debug_button->get_popup()->get_item_index(RUN_DEBUG_COLLISONS));
-			debug_button->get_popup()->set_item_checked(debug_button->get_popup()->get_item_index(RUN_DEBUG_COLLISONS), !ischecked);
+			bool ischecked = debug_menu->get_popup()->is_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEBUG_COLLISONS));
+			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEBUG_COLLISONS), !ischecked);
 			run_native->set_debug_collisions(!ischecked);
 			editor_run.set_debug_collisions(!ischecked);
 			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_collisons", !ischecked);
@@ -2510,8 +2489,8 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		} break;
 		case RUN_DEBUG_NAVIGATION: {
 
-			bool ischecked = debug_button->get_popup()->is_item_checked(debug_button->get_popup()->get_item_index(RUN_DEBUG_NAVIGATION));
-			debug_button->get_popup()->set_item_checked(debug_button->get_popup()->get_item_index(RUN_DEBUG_NAVIGATION), !ischecked);
+			bool ischecked = debug_menu->get_popup()->is_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEBUG_NAVIGATION));
+			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEBUG_NAVIGATION), !ischecked);
 			run_native->set_debug_navigation(!ischecked);
 			editor_run.set_debug_navigation(!ischecked);
 			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_navigation", !ischecked);
@@ -2519,8 +2498,8 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		} break;
 		case RUN_RELOAD_SCRIPTS: {
 
-			bool ischecked = debug_button->get_popup()->is_item_checked(debug_button->get_popup()->get_item_index(RUN_RELOAD_SCRIPTS));
-			debug_button->get_popup()->set_item_checked(debug_button->get_popup()->get_item_index(RUN_RELOAD_SCRIPTS), !ischecked);
+			bool ischecked = debug_menu->get_popup()->is_item_checked(debug_menu->get_popup()->get_item_index(RUN_RELOAD_SCRIPTS));
+			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_RELOAD_SCRIPTS), !ischecked);
 
 			ScriptEditor::get_singleton()->set_live_auto_reload_running_scripts(!ischecked);
 			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_reload_scripts", !ischecked);
@@ -5166,7 +5145,17 @@ EditorNode::EditorNode() {
 	scene_tabs->connect("right_button_pressed", this, "_scene_tab_script_edited");
 	scene_tabs->connect("tab_close", this, "_scene_tab_closed");
 
-	srt->add_child(scene_tabs);
+	HBoxContainer *tabbar_container = memnew(HBoxContainer);
+	scene_tabs->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+
+	srt->add_child(tabbar_container);
+	tabbar_container->add_child(scene_tabs);
+	distraction_free = memnew(ToolButton);
+	tabbar_container->add_child(distraction_free);
+	distraction_free->set_shortcut(ED_SHORTCUT("editor/distraction_free_mode", TTR("Distraction Free Mode"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_F11));
+	distraction_free->connect("pressed", this, "_toggle_distraction_free_mode");
+	distraction_free->set_icon(gui_base->get_icon("DistractionFree", "EditorIcons"));
+	distraction_free->set_toggle_mode(true);
 
 	scene_root_parent = memnew(PanelContainer);
 	scene_root_parent->set_custom_minimum_size(Size2(0, 80) * EDSCALE);
@@ -5209,6 +5198,33 @@ EditorNode::EditorNode() {
 	menu_hb->add_child(top_region);
 
 	PopupMenu *p;
+
+	project_menu = memnew(MenuButton);
+	project_menu->set_tooltip(TTR("Miscellaneous project or scene-wide tools."));
+	project_menu->set_text(TTR("Project"));
+	project_menu->add_style_override("hover", gui_base->get_stylebox("MenuHover", "EditorStyles"));
+	left_menu_hb->add_child(project_menu);
+
+	p = project_menu->get_popup();
+	p->connect("id_pressed", this, "_menu_option");
+	p->add_item(TTR("Run Script"), FILE_RUN_SCRIPT, KEY_MASK_SHIFT + KEY_MASK_CMD + KEY_R);
+	p->add_item(TTR("Export"), FILE_EXPORT_PROJECT);
+
+	PopupMenu *tool_menu = memnew(PopupMenu);
+	tool_menu->set_name("Tools");
+	tool_menu->connect("id_pressed", this, "_menu_option");
+	p->add_child(tool_menu);
+	p->add_submenu_item(TTR("Tools"), "Tools");
+	tool_menu->add_item(TTR("Orphan Resource Explorer"), TOOLS_ORPHAN_RESOURCES);
+	p->add_separator();
+	p->add_item(TTR("Project Settings"), RUN_SETTINGS);
+	p->add_separator();
+#ifdef OSX_ENABLED
+	p->add_item(TTR("Quit to Project List"), RUN_PROJECT_MANAGER, KEY_MASK_SHIFT + KEY_MASK_ALT + KEY_Q);
+#else
+	p->add_item(TTR("Quit to Project List"), RUN_PROJECT_MANAGER, KEY_MASK_SHIFT + KEY_MASK_CTRL + KEY_Q);
+#endif
+	p->add_item(TTR("Quit"), FILE_QUIT, KEY_MASK_CMD + KEY_Q);
 
 	file_menu = memnew(MenuButton);
 	file_menu->set_text(TTR("Scene"));
@@ -5262,18 +5278,7 @@ EditorNode::EditorNode() {
 	p->add_shortcut(ED_SHORTCUT("editor/undo", TTR("Undo"), KEY_MASK_CMD + KEY_Z), EDIT_UNDO, true);
 	p->add_shortcut(ED_SHORTCUT("editor/redo", TTR("Redo"), KEY_MASK_SHIFT + KEY_MASK_CMD + KEY_Z), EDIT_REDO, true);
 	p->add_separator();
-	p->add_item(TTR("Run Script"), FILE_RUN_SCRIPT, KEY_MASK_SHIFT + KEY_MASK_CMD + KEY_R);
-	p->add_separator();
-	p->add_item(TTR("Project Settings"), RUN_SETTINGS);
-	p->add_separator();
 	p->add_item(TTR("Revert Scene"), EDIT_REVERT);
-	p->add_separator();
-#ifdef OSX_ENABLED
-	p->add_item(TTR("Quit to Project List"), RUN_PROJECT_MANAGER, KEY_MASK_SHIFT + KEY_MASK_ALT + KEY_Q);
-#else
-	p->add_item(TTR("Quit to Project List"), RUN_PROJECT_MANAGER, KEY_MASK_SHIFT + KEY_MASK_CTRL + KEY_Q);
-#endif
-	p->add_item(TTR("Quit"), FILE_QUIT, KEY_MASK_CMD + KEY_Q);
 
 	recent_scenes = memnew(PopupMenu);
 	recent_scenes->set_name("RecentScenes");
@@ -5289,14 +5294,9 @@ EditorNode::EditorNode() {
 	PanelContainer *editor_region = memnew(PanelContainer);
 	main_editor_button_vb = memnew(HBoxContainer);
 	editor_region->add_child(main_editor_button_vb);
-	menu_hb->add_child(editor_region);
 
-	distraction_free = memnew(ToolButton);
-	main_editor_button_vb->add_child(distraction_free);
-	distraction_free->set_shortcut(ED_SHORTCUT("editor/distraction_free_mode", TTR("Distraction Free Mode"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_F11));
-	distraction_free->connect("pressed", this, "_toggle_distraction_free_mode");
-	distraction_free->set_icon(gui_base->get_icon("DistractionFree", "EditorIcons"));
-	distraction_free->set_toggle_mode(true);
+	menu_hb->add_spacer();
+	menu_hb->add_child(editor_region);
 
 //menu_hb->add_spacer();
 #if 0
@@ -5327,27 +5327,54 @@ EditorNode::EditorNode() {
 	menu_panel->add_child( resource_menu );
 #endif
 
-	tool_menu = memnew(MenuButton);
-	tool_menu->set_tooltip(TTR("Miscellaneous project or scene-wide tools."));
-	tool_menu->set_text(TTR("Tools"));
-	tool_menu->add_style_override("hover", gui_base->get_stylebox("MenuHover", "EditorStyles"));
-
-	//tool_menu->set_icon(gui_base->get_icon("Save","EditorIcons"));
-	left_menu_hb->add_child(tool_menu);
-
-	p = tool_menu->get_popup();
+	debug_menu = memnew(MenuButton);
+	debug_menu->set_text(TTR("Debug"));
+	debug_menu->add_style_override("hover", gui_base->get_stylebox("MenuHover", "EditorStyles"));
+	left_menu_hb->add_child(debug_menu);
+	p = debug_menu->get_popup();
+	p->set_hide_on_item_selection(false);
+	p->add_check_item(TTR("Deploy with Remote Debug"), RUN_DEPLOY_REMOTE_DEBUG);
+	p->set_item_tooltip(p->get_item_count() - 1, TTR("When exporting or deploying, the resulting executable will attempt to connect to the IP of this computer in order to be debugged."));
+	p->add_check_item(TTR("Small Deploy with Network FS"), RUN_FILE_SERVER);
+	p->set_item_tooltip(p->get_item_count() - 1, TTR("When this option is enabled, export or deploy will produce a minimal executable.\nThe filesystem will be provided from the project by the editor over the network.\nOn Android, deploy will use the USB cable for faster performance. This option speeds up testing for games with a large footprint."));
+	p->add_separator();
+	p->add_check_item(TTR("Visible Collision Shapes"), RUN_DEBUG_COLLISONS);
+	p->set_item_tooltip(p->get_item_count() - 1, TTR("Collision shapes and raycast nodes (for 2D and 3D) will be visible on the running game if this option is turned on."));
+	p->add_check_item(TTR("Visible Navigation"), RUN_DEBUG_NAVIGATION);
+	p->set_item_tooltip(p->get_item_count() - 1, TTR("Navigation meshes and polygons will be visible on the running game if this option is turned on."));
+	p->add_separator();
+	p->add_check_item(TTR("Sync Scene Changes"), RUN_LIVE_DEBUG);
+	p->set_item_tooltip(p->get_item_count() - 1, TTR("When this option is turned on, any changes made to the scene in the editor will be replicated in the running game.\nWhen used remotely on a device, this is more efficient with network filesystem."));
+	p->add_check_item(TTR("Sync Script Changes"), RUN_RELOAD_SCRIPTS);
+	p->set_item_tooltip(p->get_item_count() - 1, TTR("When this option is turned on, any script that is saved will be reloaded on the running game.\nWhen used remotely on a device, this is more efficient with network filesystem."));
 	p->connect("id_pressed", this, "_menu_option");
-	p->add_item(TTR("Orphan Resource Explorer"), TOOLS_ORPHAN_RESOURCES);
-
-	export_button = memnew(ToolButton);
-	export_button->set_tooltip(TTR("Export the project to many platforms."));
-	export_button->set_text(TTR("Export"));
-	export_button->connect("pressed", this, "_menu_option", varray(FILE_EXPORT_PROJECT));
-	export_button->set_focus_mode(Control::FOCUS_NONE);
-	export_button->add_style_override("hover", gui_base->get_stylebox("MenuHover", "EditorStyles"));
-	left_menu_hb->add_child(export_button);
 
 	menu_hb->add_spacer();
+
+	settings_menu = memnew(MenuButton);
+	left_menu_hb->add_child(settings_menu);
+	settings_menu->set_text(TTR("Editor"));
+	settings_menu->add_style_override("hover", gui_base->get_stylebox("MenuHover", "EditorStyles"));
+	settings_menu->add_style_override("hover", gui_base->get_stylebox("MenuHover", "EditorStyles"));
+	//settings_menu->set_anchor(MARGIN_RIGHT,ANCHOR_END);
+	p = settings_menu->get_popup();
+
+	//p->add_item("Export Settings",SETTINGS_EXPORT_PREFERENCES);
+	p->add_item(TTR("Editor Settings"), SETTINGS_PREFERENCES);
+	//p->add_item("Optimization Presets",SETTINGS_OPTIMIZED_PRESETS);
+	p->add_separator();
+	editor_layouts = memnew(PopupMenu);
+	editor_layouts->set_name("Layouts");
+	p->add_child(editor_layouts);
+	editor_layouts->connect("id_pressed", this, "_layout_menu_option");
+	p->add_submenu_item(TTR("Editor Layout"), "Layouts");
+
+	p->add_shortcut(ED_SHORTCUT("editor/fullscreen_mode", TTR("Toggle Fullscreen"), KEY_MASK_SHIFT | KEY_F11), SETTINGS_TOGGLE_FULLSCREN);
+
+	p->add_separator();
+	p->add_item(TTR("Manage Export Templates"), SETTINGS_MANAGE_EXPORT_TEMPLATES);
+	p->add_separator();
+	p->add_item(TTR("About"), SETTINGS_ABOUT);
 
 	//Separator *s1 = memnew( VSeparator );
 	//menu_panel->add_child(s1);
@@ -5356,7 +5383,7 @@ EditorNode::EditorNode() {
 
 	play_cc = memnew(CenterContainer);
 	play_cc->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
-	gui_base->add_child(play_cc);
+	menu_hb->add_child(play_cc);
 	play_cc->set_area_as_parent_rect();
 	play_cc->set_anchor_and_margin(MARGIN_BOTTOM, Control::ANCHOR_BEGIN, 10);
 	play_cc->set_margin(MARGIN_TOP, 5);
@@ -5427,33 +5454,6 @@ EditorNode::EditorNode() {
 	play_custom_scene_button->set_tooltip(TTR("Play custom scene"));
 	play_custom_scene_button->set_shortcut(ED_SHORTCUT("editor/play_custom_scene", TTR("Play Custom Scene"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_F5));
 
-	debug_button = memnew(MenuButton);
-	debug_button->set_flat(true);
-	play_hb->add_child(debug_button);
-	//debug_button->set_toggle_mode(true);
-	debug_button->set_focus_mode(Control::FOCUS_NONE);
-	debug_button->set_icon(gui_base->get_icon("Remote", "EditorIcons"));
-	//debug_button->connect("pressed", this,"_menu_option",make_binds(RUN_LIVE_DEBUG));
-	debug_button->set_tooltip(TTR("Debug options"));
-
-	p = debug_button->get_popup();
-	p->set_hide_on_item_selection(false);
-	p->add_check_item(TTR("Deploy with Remote Debug"), RUN_DEPLOY_REMOTE_DEBUG);
-	p->set_item_tooltip(p->get_item_count() - 1, TTR("When exporting or deploying, the resulting executable will attempt to connect to the IP of this computer in order to be debugged."));
-	p->add_check_item(TTR("Small Deploy with Network FS"), RUN_FILE_SERVER);
-	p->set_item_tooltip(p->get_item_count() - 1, TTR("When this option is enabled, export or deploy will produce a minimal executable.\nThe filesystem will be provided from the project by the editor over the network.\nOn Android, deploy will use the USB cable for faster performance. This option speeds up testing for games with a large footprint."));
-	p->add_separator();
-	p->add_check_item(TTR("Visible Collision Shapes"), RUN_DEBUG_COLLISONS);
-	p->set_item_tooltip(p->get_item_count() - 1, TTR("Collision shapes and raycast nodes (for 2D and 3D) will be visible on the running game if this option is turned on."));
-	p->add_check_item(TTR("Visible Navigation"), RUN_DEBUG_NAVIGATION);
-	p->set_item_tooltip(p->get_item_count() - 1, TTR("Navigation meshes and polygons will be visible on the running game if this option is turned on."));
-	p->add_separator();
-	p->add_check_item(TTR("Sync Scene Changes"), RUN_LIVE_DEBUG);
-	p->set_item_tooltip(p->get_item_count() - 1, TTR("When this option is turned on, any changes made to the scene in the editor will be replicated in the running game.\nWhen used remotely on a device, this is more efficient with network filesystem."));
-	p->add_check_item(TTR("Sync Script Changes"), RUN_RELOAD_SCRIPTS);
-	p->set_item_tooltip(p->get_item_count() - 1, TTR("When this option is turned on, any script that is saved will be reloaded on the running game.\nWhen used remotely on a device, this is more efficient with network filesystem."));
-	p->connect("id_pressed", this, "_menu_option");
-
 	/*
 	run_settings_button = memnew( ToolButton );
 	//menu_hb->add_child(run_settings_button);
@@ -5473,62 +5473,24 @@ EditorNode::EditorNode() {
 */
 
 	progress_hb = memnew(BackgroundProgress);
-	menu_hb->add_child(progress_hb);
+	//menu_hb->add_child(progress_hb);
 
 	{
 		Control *sp = memnew(Control);
 		sp->set_custom_minimum_size(Size2(30, 0) * EDSCALE);
-		menu_hb->add_child(sp);
+		//menu_hb->add_child(sp);
 	}
 
-	PanelContainer *vu_cont = memnew(PanelContainer);
-	menu_hb->add_child(vu_cont);
-
-	audio_vu = memnew(TextureProgress);
-	CenterContainer *vu_cc = memnew(CenterContainer);
-	vu_cc->add_child(audio_vu);
-	vu_cont->add_child(vu_cc);
-	audio_vu->set_under_texture(gui_base->get_icon("VuEmpty", "EditorIcons"));
-	audio_vu->set_progress_texture(gui_base->get_icon("VuFull", "EditorIcons"));
-	audio_vu->set_max(24);
-	audio_vu->set_min(-80);
-	audio_vu->set_step(0.01);
-	audio_vu->set_value(0);
-
 	{
 		Control *sp = memnew(Control);
 		sp->set_custom_minimum_size(Size2(30, 0) * EDSCALE);
-		menu_hb->add_child(sp);
+		//menu_hb->add_child(sp);
 	}
 
 	top_region = memnew(PanelContainer);
 	HBoxContainer *right_menu_hb = memnew(HBoxContainer);
-	top_region->add_child(right_menu_hb);
-	menu_hb->add_child(top_region);
-
-	settings_menu = memnew(MenuButton);
-	settings_menu->set_text(TTR("Settings"));
-	settings_menu->add_style_override("hover", gui_base->get_stylebox("MenuHover", "EditorStyles"));
-	//settings_menu->set_anchor(MARGIN_RIGHT,ANCHOR_END);
-	right_menu_hb->add_child(settings_menu);
-	p = settings_menu->get_popup();
-
-	//p->add_item("Export Settings",SETTINGS_EXPORT_PREFERENCES);
-	p->add_item(TTR("Editor Settings"), SETTINGS_PREFERENCES);
-	//p->add_item("Optimization Presets",SETTINGS_OPTIMIZED_PRESETS);
-	p->add_separator();
-	editor_layouts = memnew(PopupMenu);
-	editor_layouts->set_name("Layouts");
-	p->add_child(editor_layouts);
-	editor_layouts->connect("id_pressed", this, "_layout_menu_option");
-	p->add_submenu_item(TTR("Editor Layout"), "Layouts");
-
-	p->add_shortcut(ED_SHORTCUT("editor/fullscreen_mode", TTR("Toggle Fullscreen"), KEY_MASK_SHIFT | KEY_F11), SETTINGS_TOGGLE_FULLSCREN);
-
-	p->add_separator();
-	p->add_item(TTR("Manage Export Templates"), SETTINGS_MANAGE_EXPORT_TEMPLATES);
-	p->add_separator();
-	p->add_item(TTR("About"), SETTINGS_ABOUT);
+	//top_region->add_child(right_menu_hb);
+	menu_hb->add_child(right_menu_hb);
 
 	layout_dialog = memnew(EditorNameDialog);
 	gui_base->add_child(layout_dialog);
@@ -5536,16 +5498,11 @@ EditorNode::EditorNode() {
 	layout_dialog->set_size(Size2(175, 70) * EDSCALE);
 	layout_dialog->connect("name_confirmed", this, "_dialog_action");
 
-	sources_button = memnew(ToolButton);
-	right_menu_hb->add_child(sources_button);
-	sources_button->set_icon(gui_base->get_icon("DependencyOk", "EditorIcons"));
-	sources_button->connect("pressed", this, "_menu_option", varray(SOURCES_REIMPORT));
-	sources_button->set_tooltip(TTR("Alerts when an external resource has changed."));
-
 	update_menu = memnew(MenuButton);
 	update_menu->set_tooltip(TTR("Spins when the editor window repaints!"));
 	right_menu_hb->add_child(update_menu);
 	update_menu->set_icon(gui_base->get_icon("Progress1", "EditorIcons"));
+	update_menu->get_popup()->connect("id_pressed", this, "_menu_option");
 	p = update_menu->get_popup();
 	p->add_check_item(TTR("Update Always"), SETTINGS_UPDATE_ALWAYS);
 	p->add_check_item(TTR("Update Changes"), SETTINGS_UPDATE_CHANGES);
@@ -5930,7 +5887,6 @@ EditorNode::EditorNode() {
 	file_menu->get_popup()->connect("id_pressed", this, "_menu_option");
 	object_menu->get_popup()->connect("id_pressed", this, "_menu_option");
 
-	update_menu->get_popup()->connect("id_pressed", this, "_menu_option");
 	settings_menu->get_popup()->connect("id_pressed", this, "_menu_option");
 
 	file->connect("file_selected", this, "_dialog_action");

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -244,7 +244,9 @@ private:
 	HBoxContainer *menu_hb;
 	Control *viewport;
 	MenuButton *file_menu;
-	MenuButton *tool_menu;
+	MenuButton *project_menu;
+	MenuButton *debug_menu;
+	PopupMenu *tool_menu;
 	ToolButton *export_button;
 	ToolButton *prev_scene;
 	MenuButton *object_menu;
@@ -256,7 +258,6 @@ private:
 	ToolButton *run_settings_button;
 	ToolButton *play_scene_button;
 	ToolButton *play_custom_scene_button;
-	MenuButton *debug_button;
 	ToolButton *search_button;
 	TextureProgress *audio_vu;
 	//MenuButton *fileserver_menu;
@@ -312,7 +313,7 @@ private:
 	LineEdit *file_export_password;
 	String current_path;
 	MenuButton *update_menu;
-	ToolButton *sources_button;
+
 	//TabContainer *prop_pallete;
 	//TabContainer *top_pallete;
 	String defer_load_scene;


### PR DESCRIPTION
Let's test the proposed changes in #8865 so far and see if the new locations for the menus and buttons are a good idea.

Note: The old stuff in the top-right (volume, updates, etc), are still being created but simply not added to the GUI. This is because it needs to be disconnected first from other places inside Godot, otherwise it will crash.