### PR TITLE
Change InputEventScreenTouch from struct to class

### DIFF
--- a/core/os/input_event.h
+++ b/core/os/input_event.h
@@ -377,7 +377,7 @@ public:
 	InputEventJoypadButton();
 };
 
-struct InputEventScreenTouch : public InputEvent {
+class InputEventScreenTouch : public InputEvent {
 	GDCLASS(InputEventScreenTouch, InputEvent)
 	int index;
 	Vector2 pos;


### PR DESCRIPTION
I'm pretty sure it was supposed to be a class too, as is every other `InputEvent` type.