### PR TITLE
Fix crash in BC decompression (2.1)

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1673,13 +1673,16 @@ Error Image::_decompress_bc() {
 
 	//print_line("width: "+itos(wd)+" height: "+itos(ht));
 
+	int mm_w = wd;
+	int mm_h = ht;
+
 	for (int i = 0; i <= mm; i++) {
 
 		switch (format) {
 
 			case FORMAT_BC1: {
 
-				int len = (wd * ht) / 16;
+				int len = (mm_w * mm_h) / 16;
 				uint8_t *dst = &w[wofs];
 
 				uint32_t ofs_table[16];
@@ -1687,7 +1690,7 @@ Error Image::_decompress_bc() {
 
 					for (int y = 0; y < 4; y++) {
 
-						ofs_table[15 - (y * 4 + (3 - x))] = (x + y * wd) * 4;
+						ofs_table[15 - (y * 4 + (3 - x))] = (x + y * mm_w) * 4;
 					}
 				}
 
@@ -1732,9 +1735,9 @@ Error Image::_decompress_bc() {
 					block <<= 8;
 					block |= src[7];
 
-					int y = (j / (wd / 4)) * 4;
-					int x = (j % (wd / 4)) * 4;
-					int pixofs = (y * wd + x) * 4;
+					int y = (j / (mm_w / 4)) * 4;
+					int x = (j % (mm_w / 4)) * 4;
+					int pixofs = (y * mm_w + x) * 4;
 
 					for (int k = 0; k < 16; k++) {
 						int idx = pixofs + ofs_table[k];
@@ -1747,15 +1750,15 @@ Error Image::_decompress_bc() {
 				}
 
 				rofs += len * 8;
-				wofs += wd * ht * 4;
+				wofs += mm_w * mm_h * 4;
 
-				wd /= 2;
-				ht /= 2;
+				mm_w /= 2;
+				mm_h /= 2;
 
 			} break;
 			case FORMAT_BC2: {
 
-				int len = (wd * ht) / 16;
+				int len = (mm_w * mm_h) / 16;
 				uint8_t *dst = &w[wofs];
 
 				uint32_t ofs_table[16];
@@ -1763,7 +1766,7 @@ Error Image::_decompress_bc() {
 
 					for (int y = 0; y < 4; y++) {
 
-						ofs_table[15 - (y * 4 + (3 - x))] = (x + y * wd) * 4;
+						ofs_table[15 - (y * 4 + (3 - x))] = (x + y * mm_w) * 4;
 					}
 				}
 
@@ -1817,9 +1820,9 @@ Error Image::_decompress_bc() {
 					block <<= 8;
 					block |= src[7 + 8];
 
-					int y = (j / (wd / 4)) * 4;
-					int x = (j % (wd / 4)) * 4;
-					int pixofs = (y * wd + x) * 4;
+					int y = (j / (mm_w / 4)) * 4;
+					int x = (j % (mm_w / 4)) * 4;
+					int pixofs = (y * mm_w + x) * 4;
 
 					for (int k = 0; k < 16; k++) {
 						uint8_t alpha = ablock & 0xf;
@@ -1835,15 +1838,15 @@ Error Image::_decompress_bc() {
 				}
 
 				rofs += len * 16;
-				wofs += wd * ht * 4;
+				wofs += mm_w * mm_h * 4;
 
-				wd /= 2;
-				ht /= 2;
+				mm_w /= 2;
+				mm_h /= 2;
 
 			} break;
 			case FORMAT_BC3: {
 
-				int len = (wd * ht) / 16;
+				int len = (mm_w * mm_h) / 16;
 				uint8_t *dst = &w[wofs];
 
 				uint32_t ofs_table[16];
@@ -1851,7 +1854,7 @@ Error Image::_decompress_bc() {
 
 					for (int y = 0; y < 4; y++) {
 
-						ofs_table[15 - (y * 4 + (3 - x))] = (x + y * wd) * 4;
+						ofs_table[15 - (y * 4 + (3 - x))] = (x + y * mm_w) * 4;
 					}
 				}
 
@@ -1928,9 +1931,9 @@ Error Image::_decompress_bc() {
 					block <<= 8;
 					block |= src[7 + 8];
 
-					int y = (j / (wd / 4)) * 4;
-					int x = (j % (wd / 4)) * 4;
-					int pixofs = (y * wd + x) * 4;
+					int y = (j / (mm_w / 4)) * 4;
+					int x = (j % (mm_w / 4)) * 4;
+					int pixofs = (y * mm_w + x) * 4;
 
 					for (int k = 0; k < 16; k++) {
 						uint8_t alpha = ablock & 0x7;
@@ -1945,10 +1948,10 @@ Error Image::_decompress_bc() {
 				}
 
 				rofs += len * 16;
-				wofs += wd * ht * 4;
+				wofs += mm_w * mm_h * 4;
 
-				wd /= 2;
-				ht /= 2;
+				mm_w /= 2;
+				mm_h /= 2;
 
 			} break;
 		}


### PR DESCRIPTION
If mipmaps present, the final reported image size was wrong, usually 0 and that was making the subsequent steps to crash.