### PR TITLE
Implement OS.alert() for iOS

### DIFF
--- a/platform/iphone/ios.h
+++ b/platform/iphone/ios.h
@@ -39,6 +39,8 @@ class iOS : public Object {
 	static void _bind_methods();
 
 public:
+	static void alert(const char *p_alert, const char *p_title);
+
 	String get_rate_url(int p_app_id) const;
 
 	iOS();

--- a/platform/iphone/ios.mm
+++ b/platform/iphone/ios.mm
@@ -36,6 +36,11 @@ void iOS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_rate_url", "app_id"), &iOS::get_rate_url);
 };
 
+void iOS::alert(const char* p_alert, const char* p_title) {
+	UIAlertView *alert = [[[UIAlertView alloc] initWithTitle:[NSString stringWithUTF8String:p_title] message:[NSString stringWithUTF8String:p_alert] delegate:nil cancelButtonTitle:@"OK" otherButtonTitles:nil, nil] autorelease];
+	[alert show];
+}
+
 String iOS::get_rate_url(int p_app_id) const {
 	String templ = "itms-apps://ax.itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?type=Purple+Software&id=APP_ID";
 	String templ_iOS7 = "itms-apps://itunes.apple.com/app/idAPP_ID";

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -405,6 +405,13 @@ int OSIPhone::get_mouse_button_state() const {
 
 void OSIPhone::set_window_title(const String &p_title){};
 
+void OSIPhone::alert(const String &p_alert, const String &p_title) {
+
+	const CharString utf8_alert = p_alert.utf8();
+	const CharString utf8_title = p_title.utf8();
+	iOS::alert(utf8_alert.get_data(), utf8_title.get_data());
+}
+
 void OSIPhone::set_video_mode(const VideoMode &p_video_mode, int p_screen) {
 
 	video_mode = p_video_mode;

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -154,6 +154,8 @@ public:
 	virtual int get_mouse_button_state() const;
 	virtual void set_window_title(const String &p_title);
 
+	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
+
 	virtual void set_video_mode(const VideoMode &p_video_mode, int p_screen = 0);
 	virtual VideoMode get_video_mode(int p_screen = 0) const;
 	virtual void get_fullscreen_mode_list(List<VideoMode> *p_list, int p_screen = 0) const;


### PR DESCRIPTION
Using an already deprecated mean, but works and it's better than a no-op `alert()`.