### PR TITLE
Fix audio can't resume in iOS platform

### DIFF
--- a/platform/iphone/app_delegate.mm
+++ b/platform/iphone/app_delegate.mm
@@ -33,6 +33,7 @@
 #import "gl_view.h"
 #include "main/main.h"
 #include "os_iphone.h"
+#include "audio_driver_iphone.h"
 
 #ifdef MODULE_FACEBOOKSCORER_IOS_ENABLED
 #include "modules/FacebookScorer_ios/FacebookScorer.h"
@@ -735,6 +736,10 @@ static int frame_count = 0;
 	if (OSIPhone::get_singleton()->native_video_is_playing()) {
 		OSIPhone::get_singleton()->native_video_unpause();
 	};
+
+	// Fixed audio can not resume if it is interrupted cause by an incoming phone call
+	if(AudioDriverIphone::get_singleton() != NULL)
+		AudioDriverIphone::get_singleton()->start();
 }
 
 - (BOOL)application:(UIApplication *)application handleOpenURL:(NSURL *)url {

--- a/platform/iphone/audio_driver_iphone.cpp
+++ b/platform/iphone/audio_driver_iphone.cpp
@@ -148,6 +148,11 @@ OSStatus AudioDriverIphone::output_callback(void *inRefCon,
 
 void AudioDriverIphone::start() {
 	active = true;
+	// Resume audio
+	//	iOS audio-thread stoped if it is interrupted cause by an incoming phone call
+	//	Use AudioOutputUnitStart to re-create audio-thread
+	OSStatus result = AudioOutputUnitStart(audio_unit);
+	ERR_FAIL_COND(result != noErr);
 };
 
 int AudioDriverIphone::get_mix_rate() const {


### PR DESCRIPTION
Fixed audio can not resume if it is interrupted cause by an incoming phone call

Fixes #7905.