### PR TITLE
[2.1] Fix item list scroll speed

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -521,13 +521,11 @@ void ItemList::_input_event(const InputEvent &p_event) {
 
 		scroll_bar->set_val(scroll_bar->get_val() - scroll_bar->get_page() * p_event.mouse_button.factor / 8);
 
-		scroll_bar->set_val(scroll_bar->get_val() - scroll_bar->get_page() / 8);
 	}
 	if (p_event.type == InputEvent::MOUSE_BUTTON && p_event.mouse_button.button_index == BUTTON_WHEEL_DOWN && p_event.mouse_button.pressed) {
 
 		scroll_bar->set_val(scroll_bar->get_val() + scroll_bar->get_page() * p_event.mouse_button.factor / 8);
 
-		scroll_bar->set_val(scroll_bar->get_val() + scroll_bar->get_page() / 8);
 	}
 
 	if (p_event.is_pressed() && items.size() > 0) {


### PR DESCRIPTION
Remove the extra `set_val` action after the proper one, so the right scroll value won’t get overrided any more.