### PR TITLE
Add settings to pan canvas editor instead of zoom with mouse/touchpad scrolling

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -596,6 +596,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("2d_editor/keep_margins_when_changing_anchors", false);
 
 	set("2d_editor/warped_mouse_panning", true);
+	set("2d_editor/scroll_to_pan", false);
+	set("2d_editor/pan_speed", 20);
 
 	set("game_window_placement/rect", 0);
 	hints["game_window_placement/rect"] = PropertyInfo(Variant::INT, "game_window_placement/rect", PROPERTY_HINT_ENUM, "Default,Centered,Custom Position,Force Maximized,Force Full Screen");

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1037,17 +1037,27 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent &p_event) {
 
 		if (b.button_index == BUTTON_WHEEL_DOWN) {
 
-			if (zoom < MIN_ZOOM)
-				return;
+			if (bool(EditorSettings::get_singleton()->get("2d_editor/scroll_to_pan"))) {
 
-			float prev_zoom = zoom;
-			zoom = zoom * (1 - (0.05 * b.factor));
-			{
-				Point2 ofs(b.x, b.y);
-				ofs = ofs / prev_zoom - ofs / zoom;
-				h_scroll->set_val(h_scroll->get_val() + ofs.x);
-				v_scroll->set_val(v_scroll->get_val() + ofs.y);
+				v_scroll->set_val(v_scroll->get_val() + int(EditorSettings::get_singleton()->get("2d_editor/pan_speed")) / zoom * b.factor);
+
 			}
+			else {
+
+				if (zoom < MIN_ZOOM)
+					return;
+
+				float prev_zoom = zoom;
+				zoom = zoom * (1 - (0.05 * b.factor));
+				{
+					Point2 ofs(b.x, b.y);
+					ofs = ofs / prev_zoom - ofs / zoom;
+					h_scroll->set_val(h_scroll->get_val() + ofs.x);
+					v_scroll->set_val(v_scroll->get_val() + ofs.y);
+				}
+
+			}
+
 			_update_scroll(0);
 			viewport->update();
 			return;
@@ -1055,21 +1065,56 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent &p_event) {
 
 		if (b.button_index == BUTTON_WHEEL_UP) {
 
-			if (zoom > MAX_ZOOM)
-				return;
+			if (bool(EditorSettings::get_singleton()->get("2d_editor/scroll_to_pan"))) {
 
-			float prev_zoom = zoom;
-			zoom = zoom * ((0.95 + (0.05 * b.factor)) / 0.95);
-			{
-				Point2 ofs(b.x, b.y);
-				ofs = ofs / prev_zoom - ofs / zoom;
-				h_scroll->set_val(h_scroll->get_val() + ofs.x);
-				v_scroll->set_val(v_scroll->get_val() + ofs.y);
+				v_scroll->set_val(v_scroll->get_val() - int(EditorSettings::get_singleton()->get("2d_editor/pan_speed")) / zoom * b.factor);
+
+			}
+			else {
+
+				if (zoom > MAX_ZOOM)
+					return;
+
+				float prev_zoom = zoom;
+				zoom = zoom * ((0.95 + (0.05 * b.factor)) / 0.95);
+				{
+					Point2 ofs(b.x, b.y);
+					ofs = ofs / prev_zoom - ofs / zoom;
+					h_scroll->set_val(h_scroll->get_val() + ofs.x);
+					v_scroll->set_val(v_scroll->get_val() + ofs.y);
+				}
+
 			}
 
 			_update_scroll(0);
 			viewport->update();
 			return;
+		}
+
+		if (b.button_index == BUTTON_WHEEL_LEFT) {
+
+			if (bool(EditorSettings::get_singleton()->get("2d_editor/scroll_to_pan"))) {
+
+				h_scroll->set_val(h_scroll->get_val() - int(EditorSettings::get_singleton()->get("2d_editor/pan_speed")) / zoom * b.factor);
+
+				_update_scroll(0);
+				viewport->update();
+
+			}
+
+		}
+
+		if (b.button_index == BUTTON_WHEEL_RIGHT) {
+
+			if (bool(EditorSettings::get_singleton()->get("2d_editor/scroll_to_pan"))) {
+
+				h_scroll->set_val(h_scroll->get_val() + int(EditorSettings::get_singleton()->get("2d_editor/pan_speed")) / zoom * b.factor);
+
+				_update_scroll(0);
+				viewport->update();
+
+			}
+
 		}
 
 		if (b.button_index == BUTTON_RIGHT) {


### PR DESCRIPTION
This feature is mainly designed for developers who uses touchpad instead of mouse, and want to scroll instead of zoom. Every macOS developers will like it since it feels intuitive.

2 new settings are added to `2d_editor`:

1. `scroll_to_pan`: turn on to use mouse/touchpad scroll to pan canvas item editor view instead of zoom
2. `pan_speed`: use this value to change scroll speed