### PR TITLE
Added color presets for easy theme switching

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -511,9 +511,11 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	set("interface/separate_distraction_mode", false);
 
-	set("interface/theme/base_color", Color(0.3, 0.3, 0.3, 1));
+	set("interface/theme/preset", 0);
+	hints["interface/theme/preset"] = PropertyInfo(Variant::INT, "interface/theme/preset", PROPERTY_HINT_ENUM, "Default,Grey,Godot 2,Arc,Custom", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
+	set("interface/theme/base_color", Color::html("#273241"));
 	hints["interface/theme/highlight_color"] = PropertyInfo(Variant::COLOR, "interface/theme/highlight_color", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
-	set("interface/theme/highlight_color", Color(0.5, 0.5, 0.6, 1));
+	set("interface/theme/highlight_color", Color::html("#b79047"));
 	hints["interface/theme/base_color"] = PropertyInfo(Variant::COLOR, "interface/theme/base_color", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	set("interface/theme/contrast", 0.2);
 	hints["interface/theme/contrast"] = PropertyInfo(Variant::REAL, "interface/theme/contrast", PROPERTY_HINT_RANGE, "0.01, 1, 0.01");

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -96,8 +96,32 @@ Ref<Theme> create_editor_theme() {
 
 	// Define colors
 	Color highlight_color = EDITOR_DEF("interface/theme/highlight_color", Color::html("#b79047"));
-	Color base_color = EDITOR_DEF("interface/theme/base_color", Color::html("#213d4c"));
+	Color base_color = EDITOR_DEF("interface/theme/base_color", Color::html("#273241"));
 	float contrast = EDITOR_DEF("interface/theme/contrast", 0.25);
+	int preset = EDITOR_DEF("interface/theme/preset", 0);
+
+	switch (preset) {
+		case 0: { // Default
+			highlight_color = Color::html("#b79047");
+			base_color = Color::html("#273241");
+			contrast = 0.25;
+		} break;
+		case 1: { // Grey
+			highlight_color = Color::html("#3e3e3e");
+			base_color = Color::html("#3d3d3d");
+			contrast = 0.2;
+		} break;
+		case 2: { // Godot 2
+			highlight_color = Color::html("#86ace2");
+			base_color = Color::html("#3C3A44");
+			contrast = 0.25;
+		} break;
+		case 3: { // Arc
+			highlight_color = Color::html("#68a7f2");
+			base_color = Color::html("#434a59");
+			contrast = 0.2;
+		} break;
+	}
 
 	Color dark_color_1 = base_color.linear_interpolate(Color(0, 0, 0, 1), contrast);
 	Color dark_color_2 = base_color.linear_interpolate(Color(0, 0, 0, 1), contrast * 1.5);


### PR DESCRIPTION
- Default (for Godot 3)
- Grey
- Godot 2 (for those nostalgia days)
- Arc (a famous theme)

Also tweaked the default colors (darker and less satured)