### PR TITLE
Make OS.get_locale() returns same value

### DIFF
--- a/platform/iphone/app_delegate.mm
+++ b/platform/iphone/app_delegate.mm
@@ -398,8 +398,7 @@ static int frame_count = 0;
 		OSIPhone::get_singleton()->set_data_dir(
 				String::utf8([documentsDirectory UTF8String]));
 
-		NSString *locale_code =
-				[[[NSLocale preferredLanguages] objectAtIndex:0] substringToIndex:2];
+		NSString *locale_code = [[NSLocale currentLocale] localeIdentifier];
 		OSIPhone::get_singleton()->set_locale(
 				String::utf8([locale_code UTF8String]));
 

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1341,8 +1341,8 @@ Error OS_OSX::shell_open(String p_uri) {
 }
 
 String OS_OSX::get_locale() const {
-	NSString *preferredLang = [[NSLocale preferredLanguages] objectAtIndex:0];
-	return [preferredLang UTF8String];
+	NSString *locale_code = [[NSLocale currentLocale] localeIdentifier];
+	return [locale_code UTF8String];
 }
 
 void OS_OSX::swap_buffers() {


### PR DESCRIPTION
current OS.get_locale() returns

platform | returns
----- | -----
x11, Android | en_US, en_GB, ko_KR
OSX | en-US, en-GB, ko-KR
iOS, Windows | en, ko

with this PR

platform | returns
----- | -----
x11, Android, OSX, iOS | en_US, en_GB, ko_KR
Windows | en, ko

tried to do with Windows too, but I'm not familiar with it.
I wish somebody checks for Windows.