### PR TITLE
Fix InputEvent actions.

### DIFF
--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -62,11 +62,11 @@ bool InputEvent::is_action(const StringName &p_action) const {
 
 bool InputEvent::is_action_pressed(const StringName &p_action) const {
 
-	return false; // InputMap::get_singleton()->event_is_action(Ref<InputEvent>(this),p_action);
+	return (is_pressed() && !is_echo() && is_action(p_action));
 }
 bool InputEvent::is_action_released(const StringName &p_action) const {
 
-	return false;
+	return (!is_pressed() && is_action(p_action));
 }
 
 bool InputEvent::is_echo() const {

--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -369,7 +369,7 @@ void InputDefault::parse_input_event(const Ref<InputEvent> &p_event) {
 		set_joy_axis(jm->get_device(), jm->get_axis(), jm->get_axis_value());
 	}
 
-	if (p_event->is_echo()) {
+	if (!p_event->is_echo()) {
 		for (const Map<StringName, InputMap::Action>::Element *E = InputMap::get_singleton()->get_action_map().front(); E; E = E->next()) {
 
 			if (InputMap::get_singleton()->event_is_action(p_event, E->key()) && is_action_pressed(E->key()) != p_event->is_pressed()) {


### PR DESCRIPTION
The `InputEvent::is_action(pressed|released)` methods weren't implemented yet.
Also fixed a typo in `InputDefault` that prevented `Input.is_action(pressed|released)` from working.

Fixes #8914 