### PR TITLE
Implement well-defined handling of unrecoverable errors

### DIFF
--- a/core/dvector.h
+++ b/core/dvector.h
@@ -403,14 +403,9 @@ public:
 		if (p_to < 0) {
 			p_to = size() + p_to;
 		}
-		if (p_from < 0 || p_from >= size()) {
-			PoolVector<T> &aux = *((PoolVector<T> *)0); // nullreturn
-			ERR_FAIL_COND_V(p_from < 0 || p_from >= size(), aux)
-		}
-		if (p_to < 0 || p_to >= size()) {
-			PoolVector<T> &aux = *((PoolVector<T> *)0); // nullreturn
-			ERR_FAIL_COND_V(p_to < 0 || p_to >= size(), aux)
-		}
+
+		CRASH_BAD_INDEX(p_from, size());
+		CRASH_BAD_INDEX(p_to, size());
 
 		PoolVector<T> slice;
 		int span = 1 + p_to - p_from;
@@ -500,13 +495,9 @@ void PoolVector<T>::push_back(const T &p_val) {
 template <class T>
 const T PoolVector<T>::operator[](int p_index) const {
 
-	if (p_index < 0 || p_index >= size()) {
-		T &aux = *((T *)0); //nullreturn
-		ERR_FAIL_COND_V(p_index < 0 || p_index >= size(), aux);
-	}
+	CRASH_BAD_INDEX(p_index, size());
 
 	Read r = read();
-
 	return r[p_index];
 }
 

--- a/core/hash_map.h
+++ b/core/hash_map.h
@@ -473,8 +473,7 @@ public:
 		if (!e) {
 
 			e = create_entry(p_key);
-			if (!e)
-				return *(TData *)NULL; /* panic! */
+			CRASH_COND(!e);
 			check_hash_table(); // perform mantenience routine
 		}
 

--- a/core/list.h
+++ b/core/list.h
@@ -398,10 +398,7 @@ public:
 
 	T &operator[](int p_index) {
 
-		if (p_index < 0 || p_index >= size()) {
-			T &aux = *((T *)0); //nullreturn
-			ERR_FAIL_COND_V(p_index < 0 || p_index >= size(), aux);
-		}
+		CRASH_BAD_INDEX(p_index, size());
 
 		Element *I = front();
 		int c = 0;
@@ -415,15 +412,12 @@ public:
 			c++;
 		}
 
-		ERR_FAIL_V(*((T *)0)); // bug!!
+		CRASH_NOW(); // bug!!
 	}
 
 	const T &operator[](int p_index) const {
 
-		if (p_index < 0 || p_index >= size()) {
-			T &aux = *((T *)0); //nullreturn
-			ERR_FAIL_COND_V(p_index < 0 || p_index >= size(), aux);
-		}
+		CRASH_BAD_INDEX(p_index, size());
 
 		const Element *I = front();
 		int c = 0;
@@ -437,7 +431,7 @@ public:
 			c++;
 		}
 
-		ERR_FAIL_V(*((T *)0)); // bug!
+		CRASH_NOW(); // bug!!
 	}
 
 	void move_to_back(Element *p_I) {

--- a/core/map.h
+++ b/core/map.h
@@ -599,9 +599,9 @@ public:
 
 	const V &operator[](const K &p_key) const {
 
-		ERR_FAIL_COND_V(!_data._root, *(V *)NULL); // crash on purpose
+		CRASH_COND(!_data._root);
 		const Element *e = find(p_key);
-		ERR_FAIL_COND_V(!e, *(V *)NULL); // crash on purpose
+		CRASH_COND(!e);
 		return e->_value;
 	}
 	V &operator[](const K &p_key) {
@@ -613,7 +613,7 @@ public:
 		if (!e)
 			e = insert(p_key, V());
 
-		ERR_FAIL_COND_V(!e, *(V *)NULL); // crash on purpose
+		CRASH_COND(!e);
 		return e->_value;
 	}
 

--- a/core/object.h
+++ b/core/object.h
@@ -531,6 +531,12 @@ public:
 	void add_change_receptor(Object *p_receptor);
 	void remove_change_receptor(Object *p_receptor);
 
+// TODO: ensure 'this' is never NULL since it's UB, but by now, avoid warning flood
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundefined-bool-conversion"
+#endif
+
 	template <class T>
 	T *cast_to() {
 
@@ -560,6 +566,10 @@ public:
 			return NULL;
 #endif
 	}
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 	enum {
 

--- a/core/vector.h
+++ b/core/vector.h
@@ -134,10 +134,7 @@ public:
 
 	inline T &operator[](int p_index) {
 
-		if (p_index < 0 || p_index >= size()) {
-			T &aux = *((T *)0); //nullreturn
-			ERR_FAIL_COND_V(p_index < 0 || p_index >= size(), aux);
-		}
+		CRASH_BAD_INDEX(p_index, size());
 
 		_copy_on_write(); // wants to write, so copy on write.
 
@@ -146,10 +143,8 @@ public:
 
 	inline const T &operator[](int p_index) const {
 
-		if (p_index < 0 || p_index >= size()) {
-			const T &aux = *((T *)0); //nullreturn
-			ERR_FAIL_COND_V(p_index < 0 || p_index >= size(), aux);
-		}
+		CRASH_BAD_INDEX(p_index, size());
+
 		// no cow needed, since it's reading
 		return _get_data()[p_index];
 	}

--- a/core/vmap.h
+++ b/core/vmap.h
@@ -180,10 +180,8 @@ public:
 	inline const V &operator[](const T &p_key) const {
 
 		int pos = _find_exact(p_key);
-		if (pos < 0) {
-			const T &aux = *((T *)0); //nullreturn
-			ERR_FAIL_COND_V(pos < 1, aux);
-		}
+
+		CRASH_COND(pos < 0);
 
 		return _data[pos].value;
 	}


### PR DESCRIPTION
Implemented now as `__builtin_trap()` for GCC/Clang and `__debugbreak()` for MSVC, which are the recommended means of stopping a program on an unrecoverable situation.

~~Some  `_TRAP`-suffixed~~ Some  `CRASH_`-prefixed error macros added so this can be reused plus removing the need of double checks:

- `CRASH_COND`
- `CRASH_BAD_INDEX`
- `CRASH_NOW`

`GENERATE_TRAP` is implemented as well, but not intended for direct usage.

Plus transient avoidance of the flood of warnings emitted by Clang when checking `this` for `NULL`.
~~Plus removal of the pointless `while(0)` loop in some error macros.~~

Fixes #8754.