### PR TITLE
Make error handling more convenient (2.1)

### DIFF
--- a/core/dvector.h
+++ b/core/dvector.h
@@ -311,13 +311,9 @@ void DVector<T>::push_back(const T &p_val) {
 template <class T>
 const T DVector<T>::operator[](int p_index) const {
 
-	if (p_index < 0 || p_index >= size()) {
-		T &aux = *((T *)0); //nullreturn
-		ERR_FAIL_COND_V(p_index < 0 || p_index >= size(), aux);
-	}
+	PRAY_BAD_INDEX(p_index, size(), T);
 
 	Read r = read();
-
 	return r[p_index];
 }
 

--- a/core/hash_map.h
+++ b/core/hash_map.h
@@ -465,8 +465,7 @@ public:
 		if (!e) {
 
 			e = create_entry(p_key);
-			if (!e)
-				return *(TData *)NULL; /* panic! */
+			PRAY_COND(!e, TData);
 			check_hash_table(); // perform mantenience routine
 		}
 

--- a/core/list.h
+++ b/core/list.h
@@ -398,10 +398,7 @@ public:
 
 	T &operator[](int p_index) {
 
-		if (p_index < 0 || p_index >= size()) {
-			T &aux = *((T *)0); //nullreturn
-			ERR_FAIL_COND_V(p_index < 0 || p_index >= size(), aux);
-		}
+		PRAY_BAD_INDEX(p_index, size(), T);
 
 		Element *I = front();
 		int c = 0;
@@ -415,15 +412,12 @@ public:
 			c++;
 		}
 
-		ERR_FAIL_V(*((T *)0)); // bug!!
+		PRAY(T); // bug!!
 	}
 
 	const T &operator[](int p_index) const {
 
-		if (p_index < 0 || p_index >= size()) {
-			T &aux = *((T *)0); //nullreturn
-			ERR_FAIL_COND_V(p_index < 0 || p_index >= size(), aux);
-		}
+		PRAY_BAD_INDEX(p_index, size(), T);
 
 		const Element *I = front();
 		int c = 0;
@@ -437,7 +431,7 @@ public:
 			c++;
 		}
 
-		ERR_FAIL_V(*((T *)0)); // bug!
+		PRAY(T); // bug!!
 	}
 
 	void move_to_back(Element *p_I) {

--- a/core/map.h
+++ b/core/map.h
@@ -599,9 +599,9 @@ public:
 
 	const V &operator[](const K &p_key) const {
 
-		ERR_FAIL_COND_V(!_data._root, *(V *)NULL); // crash on purpose
+		PRAY_COND(!_data._root, V);
 		const Element *e = find(p_key);
-		ERR_FAIL_COND_V(!e, *(V *)NULL); // crash on purpose
+		PRAY_COND(!e, V);
 		return e->_value;
 	}
 	V &operator[](const K &p_key) {
@@ -613,7 +613,7 @@ public:
 		if (!e)
 			e = insert(p_key, V());
 
-		ERR_FAIL_COND_V(!e, *(V *)NULL); // crash on purpose
+		PRAY_COND(!e, V);
 		return e->_value;
 	}
 

--- a/core/object.h
+++ b/core/object.h
@@ -509,6 +509,12 @@ public:
 	void add_change_receptor(Object *p_receptor);
 	void remove_change_receptor(Object *p_receptor);
 
+// TODO: ensure 'this' is never NULL since it's UB, but by now, avoid warning flood
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundefined-bool-conversion"
+#endif
+
 	template <class T>
 	T *cast_to() {
 
@@ -538,6 +544,10 @@ public:
 			return NULL;
 #endif
 	}
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 	enum {
 

--- a/core/vector.h
+++ b/core/vector.h
@@ -133,10 +133,7 @@ public:
 
 	inline T &operator[](int p_index) {
 
-		if (p_index < 0 || p_index >= size()) {
-			T &aux = *((T *)0); //nullreturn
-			ERR_FAIL_COND_V(p_index < 0 || p_index >= size(), aux);
-		}
+		PRAY_BAD_INDEX(p_index, size(), T);
 
 		_copy_on_write(); // wants to write, so copy on write.
 
@@ -145,10 +142,8 @@ public:
 
 	inline const T &operator[](int p_index) const {
 
-		if (p_index < 0 || p_index >= size()) {
-			const T &aux = *((T *)0); //nullreturn
-			ERR_FAIL_COND_V(p_index < 0 || p_index >= size(), aux);
-		}
+		PRAY_BAD_INDEX(p_index, size(), T);
+
 		// no cow needed, since it's reading
 		return _get_data()[p_index];
 	}

--- a/core/vmap.h
+++ b/core/vmap.h
@@ -180,10 +180,8 @@ public:
 	inline const V &operator[](const T &p_key) const {
 
 		int pos = _find_exact(p_key);
-		if (pos < 0) {
-			const T &aux = *((T *)0); //nullreturn
-			ERR_FAIL_COND_V(pos < 1, aux);
-		}
+
+		PRAY_COND(pos < 0, V);
 
 		return _data[pos].value;
 	}


### PR DESCRIPTION
~~Implemented now as `__builtin_trap()` for GCC/Clang and `__debugbreak()` for MSVC, which are the recommended means of stopping a program on an unrecoverable situation.~~

~~Some  `_TRAP`-suffixed error macros added so this can be reused plus removing the need of double checks. `GENERATE_TRAP` is implemented as well.~~

~~__IMPORTANT!!!__~~

~~I'm starting to think that for 2.1, which is widely in production, the trap stuff may be too aggresive. The former solution (though being undefined behavior) helps masking bugs that may start to be uncovered if this PR is merged as it is now, making games crash when they were running with not noticeable problems so far.~~

~~Maybe for 2.1 we should just raise the perceived severity of the error situations by adding _SEVERE_ or something like that to the messages printed on these situations.~~

~~For _master_ it's fine because it allows precisely to bring those bugs to the surface so they can get a correct solution, specially now it's still unstable.~~

Current status: finally I think that for 2.1 replacing returning a null reference by a trap may break current projects. The classic way is undefined behavior, but can help games keep running instead of crashing. For _master_ it's different since we have there a good chance of actually fixing bugs before stability.

I've named the helpers `PRAY_*` (because anything can happen). They make the code cleaner as the condition doesn't need to be written twice and they encapsulate the null dereferencing stuff. They print the error message with a leading _SEVERE_ which at least differentiates an otherwise fatal error from the handleable ones.

Plus transient avoidance of the flood of warnings emitted by Clang when checking `this` for `NULL`.
~~Plus removal of the pointless `while(0)` loop in some error macros.~~