### PR TITLE
Improve/harmonize mobile builds (2.1)

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -232,7 +232,7 @@ def configure(env):
     elif (env["target"] == "debug"):
         env.Append(LINKFLAGS=['-O0'])
         env.Append(CPPFLAGS=['-O0', '-D_DEBUG', '-UNDEBUG', '-DDEBUG_ENABLED',
-                             '-DDEBUG_MEMORY_ALLOC', '-g', '-fno-limit-debug-info'])
+                             '-DDEBUG_MEMORY_ENABLED', '-g', '-fno-limit-debug-info'])
 
     env.Append(CPPFLAGS=['-DANDROID_ENABLED',
                          '-DUNIX_ENABLED', '-DNO_FCNTL', '-DMPC_FIXED_POINT'])


### PR DESCRIPTION
Android:
- Inexistent `DEBUG_MEMORY_ALLOC` replaced by `DEBUG_MEMORY_ENABLED`.

iOS:
- Unconditional __-fblocks__. Formerly it was being added only if _GameCenter_ enabled.
- Fix failing build if _GameCenter_ disabled by adding _GameController_ explicitly.
- Make _release_ and _release_debug_ be the same, except for `DEBUG_ENABLED` (for Android we are doing the same), which is: `-O2 -ftree-vectorize -fomit-frame-pointer -ffast-math -funsafe-math-optimizations`.
- Drop the _profile_ target.
- Enable link-time optimization (slow, but hopefully gives a faster engine).

@punto-, could you have a look?:
- I know you removed `-ffast-math` because of a possible compìler bug. Do you think that still applies?
- Do you know about anyone using the _profile_ target?
- And any other possible wrong thing you find.

__NOTE:__ The _master_ version is subject to @punto-'s opinion at least, so this shouldn't be merged before the other one is approved.