### PR TITLE
[2.1] Fix text warp in color blocks with CJK

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -264,7 +264,7 @@ void RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int 
 							cw = tab_size * font->get_char_size(' ').width;
 						}
 
-						if (end > 0 && w + cw + begin > p_width) {
+						if (end > 0 && w + cw + wofs > p_width) {
 							break; //don't allow lines longer than assigned width
 						}
 


### PR DESCRIPTION
Before
![Before](https://cloud.githubusercontent.com/assets/6964556/26518611/29be588a-42e6-11e7-92d6-e25a96c7a8ab.png)

After
![After](https://cloud.githubusercontent.com/assets/6964556/26518617/5fe8dc14-42e6-11e7-9291-a26bfee603a2.png)
