### PR TITLE
Fix incorrect input event reference in editor_profiler.cpp

### DIFF
--- a/editor/editor_profiler.cpp
+++ b/editor/editor_profiler.cpp
@@ -523,7 +523,7 @@ void EditorProfiler::_graph_tex_input(const Ref<InputEvent> &p_ev) {
 			hover_metric = -1;
 		}
 
-		if (mb.is_valid() || mb->get_button_mask() & BUTTON_MASK_LEFT) {
+		if (mb.is_valid() || mm->get_button_mask() & BUTTON_MASK_LEFT) {
 			//cursor_metric=x;
 			updating_frame = true;
 


### PR DESCRIPTION
This fixes the segfault mentioned in #8954. See that issue for details.