### PR TITLE
Enable libsquish for non-tools builds (2.1)

### DIFF
--- a/modules/squish/config.py
+++ b/modules/squish/config.py
@@ -4,8 +4,4 @@ def can_build(platform):
 
 
 def configure(env):
-    # Tools only, disabled for non-tools
-    # TODO: Find a cleaner way to achieve that
-    if (env["tools"] == "no"):
-        env["module_squish_enabled"] = "no"
-        env.disabled_modules.append("squish")
+    pass

--- a/modules/squish/register_types.cpp
+++ b/modules/squish/register_types.cpp
@@ -28,9 +28,6 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include "register_types.h"
-
-#ifdef TOOLS_ENABLED
-
 #include "image_compress_squish.h"
 
 void register_squish_types() {
@@ -40,5 +37,3 @@ void register_squish_types() {
 }
 
 void unregister_squish_types() {}
-
-#endif


### PR DESCRIPTION
Needed now that it's used for decompressing textures on the fly on platforms that don't support BC.