### PR TITLE
Fixed rand_range not returning correct random values on windows

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -51,9 +51,7 @@ class Math {
 public:
 	Math() {} // useless to instance
 
-	enum {
-		RANDOM_MAX = 4294967295L
-	};
+	static const uint64_t RANDOM_MAX = 4294967295;
 
 	static _ALWAYS_INLINE_ double sin(double p_x) { return ::sin(p_x); }
 	static _ALWAYS_INLINE_ float sin(float p_x) { return ::sinf(p_x); }


### PR DESCRIPTION
This pull request fixes https://github.com/godotengine/godot/issues/8957
The Visual Studio C++ compiler seems not to automatically use unsigned int for the enums.
Declaring unsigned int explicitly for the enum fixes that problem.