### PR TITLE
Added script overview

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -554,6 +554,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("text_editor/line_numbers/line_length_guideline_column", 80);
 	hints["text_editor/line_numbers/line_length_guideline_column"] = PropertyInfo(Variant::INT, "text_editor/line_numbers/line_length_guideline_column", PROPERTY_HINT_RANGE, "20, 160, 10");
 
+	set("text_editor/open_scripts/show_members_overview", true);
+
 	set("text_editor/files/trim_trailing_whitespace_on_save", false);
 	set("text_editor/completion/idle_parse_delay", 2);
 	set("text_editor/tools/create_signal_callbacks", true);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -410,7 +410,9 @@ void ScriptEditor::_go_to_tab(int p_idx) {
 	c->set_meta("__editor_pass", ++edit_pass);
 	_update_history_arrows();
 	_update_script_colors();
+	_update_members_overview();
 	_update_selected_editor_menu();
+	_update_members_overview_visibility();
 }
 
 void ScriptEditor::_add_recent_script(String p_path) {
@@ -540,6 +542,7 @@ void ScriptEditor::_close_tab(int p_idx, bool p_save) {
 	_update_history_arrows();
 
 	_update_script_names();
+	_update_members_overview_visibility();
 	_save_layout();
 }
 
@@ -1025,6 +1028,7 @@ void ScriptEditor::_notification(int p_what) {
 		editor->connect("script_add_function_request", this, "_add_callback");
 		editor->connect("resource_saved", this, "_res_saved_callback");
 		script_list->connect("item_selected", this, "_script_selected");
+		members_overview->connect("item_selected", this, "_members_overview_selected");
 		script_split->connect("dragged", this, "_script_split_dragged");
 		autosave_timer->connect("timeout", this, "_autosave_scripts");
 		{
@@ -1272,6 +1276,16 @@ void ScriptEditor::ensure_focus_current() {
 	se->ensure_focus();
 }
 
+void ScriptEditor::_members_overview_selected(int p_idx) {
+	Node *current = tab_container->get_child(tab_container->get_current_tab());
+	ScriptEditorBase *se = current->cast_to<ScriptEditorBase>();
+	if (!se) {
+		return;
+	}
+	se->goto_line(members_overview->get_item_metadata(p_idx));
+	se->ensure_focus();
+}
+
 void ScriptEditor::_script_selected(int p_idx) {
 
 	grab_focus_block = !Input::get_singleton()->is_mouse_button_pressed(1); //amazing hack, simply amazing
@@ -1340,6 +1354,37 @@ struct _ScriptEditorItemData {
 		return category == id.category ? sort_key < id.sort_key : category < id.category;
 	}
 };
+
+void ScriptEditor::_update_members_overview_visibility() {
+	Node *current = tab_container->get_child(tab_container->get_current_tab());
+	ScriptEditorBase *se = current->cast_to<ScriptEditorBase>();
+	if (!se) {
+		members_overview->set_visible(false);
+		return;
+	}
+
+	if (members_overview_enabled && se->show_members_overview()) {
+		members_overview->set_visible(true);
+	} else {
+		members_overview->set_visible(false);
+	}
+}
+
+void ScriptEditor::_update_members_overview() {
+	members_overview->clear();
+
+	Node *current = tab_container->get_child(tab_container->get_current_tab());
+	ScriptEditorBase *se = current->cast_to<ScriptEditorBase>();
+	if (!se) {
+		return;
+	}
+
+	Vector<String> functions = se->get_functions();
+	for (int i = 0; i < functions.size(); i++) {
+		members_overview->add_item(functions[i].get_slice(":", 0));
+		members_overview->set_item_metadata(i, functions[i].get_slice(":", 1).to_int() - 1);
+	}
+}
 
 void ScriptEditor::_update_script_colors() {
 
@@ -1484,6 +1529,7 @@ void ScriptEditor::_update_script_names() {
 		}
 	}
 
+	_update_members_overview();
 	_update_script_colors();
 }
 
@@ -1731,6 +1777,9 @@ void ScriptEditor::_editor_settings_changed() {
 	trim_trailing_whitespace_on_save = EditorSettings::get_singleton()->get("text_editor/files/trim_trailing_whitespace_on_save");
 	convert_indent_on_save = EditorSettings::get_singleton()->get("text_editor/indent/convert_indent_on_save");
 	use_space_indentation = EditorSettings::get_singleton()->get("text_editor/indent/type");
+
+	members_overview_enabled = EditorSettings::get_singleton()->get("text_editor/open_scripts/show_members_overview");
+	_update_members_overview_visibility();
 
 	float autosave_time = EditorSettings::get_singleton()->get("text_editor/files/autosave_interval_secs");
 	if (autosave_time > 0) {
@@ -2078,6 +2127,7 @@ void ScriptEditor::_bind_methods() {
 	ClassDB::bind_method("_editor_settings_changed", &ScriptEditor::_editor_settings_changed);
 	ClassDB::bind_method("_update_script_names", &ScriptEditor::_update_script_names);
 	ClassDB::bind_method("_tree_changed", &ScriptEditor::_tree_changed);
+	ClassDB::bind_method("_members_overview_selected", &ScriptEditor::_members_overview_selected);
 	ClassDB::bind_method("_script_selected", &ScriptEditor::_script_selected);
 	ClassDB::bind_method("_script_created", &ScriptEditor::_script_created);
 	ClassDB::bind_method("_script_split_dragged", &ScriptEditor::_script_split_dragged);
@@ -2099,6 +2149,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	waiting_update_names = false;
 	pending_auto_reload = false;
 	auto_reload_running_scripts = false;
+	members_overview_enabled = true;
 	editor = p_editor;
 
 	menu_hb = memnew(HBoxContainer);
@@ -2108,10 +2159,19 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	add_child(script_split);
 	script_split->set_v_size_flags(SIZE_EXPAND_FILL);
 
+	list_split = memnew(VSplitContainer);
+	script_split->add_child(list_split);
+	list_split->set_v_size_flags(SIZE_EXPAND_FILL);
+
 	script_list = memnew(ItemList);
-	script_split->add_child(script_list);
+	list_split->add_child(script_list);
 	script_list->set_custom_minimum_size(Size2(0, 0));
 	script_split->set_split_offset(140);
+	list_split->set_split_offset(500);
+
+	members_overview = memnew(ItemList);
+	list_split->add_child(members_overview);
+	members_overview->set_custom_minimum_size(Size2(0, 0));
 
 	tab_container = memnew(TabContainer);
 	tab_container->add_style_override("panel", p_editor->get_gui_base()->get_stylebox("ScriptPanel", "EditorStyles"));

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -102,6 +102,8 @@ public:
 	virtual void set_debugger_active(bool p_active) = 0;
 	virtual bool can_lose_focus_on_node_selection() { return true; }
 
+	virtual bool show_members_overview() = 0;
+
 	virtual void set_tooltip_request_func(String p_method, Object *p_obj) = 0;
 	virtual Control *get_edit_menu() = 0;
 
@@ -179,6 +181,9 @@ class ScriptEditor : public VBoxContainer {
 
 	ItemList *script_list;
 	HSplitContainer *script_split;
+	ItemList *members_overview;
+	bool members_overview_enabled;
+	VSplitContainer *list_split;
 	TabContainer *tab_container;
 	EditorFileDialog *file_dialog;
 	ConfirmationDialog *erase_tab_confirm;
@@ -278,8 +283,11 @@ class ScriptEditor : public VBoxContainer {
 	void _editor_settings_changed();
 	void _autosave_scripts();
 
+	void _update_members_overview_visibility();
+	void _update_members_overview();
 	void _update_script_names();
 
+	void _members_overview_selected(int p_idx);
 	void _script_selected(int p_idx);
 
 	void _find_scripts(Node *p_base, Node *p_current, Set<Ref<Script> > &used);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -218,6 +218,10 @@ void ScriptTextEditor::add_callback(const String &p_function, PoolStringArray p_
 	code_editor->get_text_edit()->cursor_set_column(1);
 }
 
+bool ScriptTextEditor::show_members_overview() {
+	return true;
+}
+
 void ScriptTextEditor::update_settings() {
 
 	code_editor->update_editor_settings();

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -149,6 +149,8 @@ public:
 	virtual void add_callback(const String &p_function, PoolStringArray p_args);
 	virtual void update_settings();
 
+	virtual bool show_members_overview();
+
 	virtual void set_tooltip_request_func(String p_method, Object *p_obj);
 
 	virtual void set_debugger_active(bool p_active);

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -2240,6 +2240,10 @@ void VisualScriptEditor::add_callback(const String &p_function, PoolStringArray 
 	//undo_redo->clear_history();
 }
 
+bool VisualScriptEditor::show_members_overview() {
+	return false;
+}
+
 void VisualScriptEditor::update_settings() {
 
 	_update_graph();

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -248,6 +248,7 @@ public:
 	virtual void get_breakpoints(List<int> *p_breakpoints);
 	virtual void add_callback(const String &p_function, PoolStringArray p_args);
 	virtual void update_settings();
+	virtual bool show_members_overview();
 	virtual void set_debugger_active(bool p_active);
 	virtual void set_tooltip_request_func(String p_method, Object *p_obj);
 	virtual Control *get_edit_menu();


### PR DESCRIPTION
Adds a script overview to the script editor.

The overview currently just contains the functions in the current script. By clicking on the function in the list will it take you to the function.  There is also a setting to enable and disable the script overview. Below is a preview:

![screenshot 1](https://cloud.githubusercontent.com/assets/6584330/26529566/fa67a5c6-43b9-11e7-8293-b6fc6a3d6123.jpg)

This is based on @reduz in #6066 and @kirilledelman in #2732.

Closes #3238.