### PR TITLE
X11: Turn warning about not finding cursor theme into verbose output.

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -336,7 +336,9 @@ void OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_au
 	cursor_theme = XcursorGetTheme(x11_display);
 
 	if (!cursor_theme) {
-		WARN_PRINT("Could not find cursor theme");
+		if (is_stdout_verbose()) {
+			print_line("XcursorGetTheme could not get cursor theme");
+		}
 		cursor_theme = "default";
 	}
 


### PR DESCRIPTION
Failing to get the cursor theme should not cause any issues since we're then using the default one anyway.
So I removed the warning and made it a verbose-only print instead, as people tend to mistake it for a real error.. (pretty much like `iCCP: known incorrect sRGB profile` :P)