### PR TITLE
Fixed .hdr support to compile on windows

### DIFF
--- a/modules/hdr/image_loader_hdr.cpp
+++ b/modules/hdr/image_loader_hdr.cpp
@@ -125,7 +125,7 @@ Error ImageLoaderHDR::load_image(Ref<Image> p_image, FileAccess *f) {
 		//convert
 		for (int i = 0; i < width * height; i++) {
 
-			float exp = pow(2, ptr[3] - 128);
+			float exp = pow(2.0f, ptr[3] - 128.0f);
 
 			Color c(
 					ptr[0] * exp / 255.0,


### PR DESCRIPTION
Added "static_cast" when calling "pow" as the windows compiler threw an error about casting.
Edit: changed from "static_cast" to writing writing 2.0f and 128.0f instead
Edit2: squashed it
Edit3: changed commit msg