### PR TITLE
CanvasItemEditor: Ability to show mouse position.

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -628,7 +628,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("editors/2d/warped_mouse_panning", true);
 	set("editors/2d/scroll_to_pan", false);
 	set("editors/2d/pan_speed", 20);
-
+	set("editors/2d/show_mouse_position", true);
+	set("editors/2d/mouse_position_decimals", 1);
 	set("editors/poly_editor/point_grab_radius", 8);
 
 	set("run/window_placement/rect", 1);

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -364,6 +364,14 @@ class CanvasItemEditor : public VBoxContainer {
 	HSplitContainer *palette_split;
 	VSplitContainer *bottom_split;
 
+	HBoxContainer *toolbar;
+	Label *mouse_pos_label_x;
+	Label *mouse_pos_label_y;
+	Vector2 cached_mouse_pos;
+	bool mouse_pos_changed;
+
+	void _cache_mouse_pos(const Vector2 &p_mouse_pos);
+
 	friend class CanvasItemEditorPlugin;
 
 protected:


### PR DESCRIPTION
Adds the ability to show the current mouse position on top of the 2D Editor (relative to the Game viewport of course).
Can be toggled via the editor setting `editors/2d/show_mouse_position`.

Closes #6224.

![2d_mpos](https://cloud.githubusercontent.com/assets/8281916/26600535/bc8d888c-457c-11e7-946f-5eceb43637ab.gif)

**Update:**
![mpos3](https://user-images.githubusercontent.com/8281916/27296897-1bf63732-5523-11e7-8eab-85ee26136535.gif)

