### PR TITLE
InputEvent: Restore old behaviour for matching key events to actions.

### DIFF
--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -282,7 +282,10 @@ bool InputEventKey::action_match(const Ref<InputEvent> &p_event) const {
 	if (key.is_null())
 		return false;
 
-	return get_scancode_with_modifiers() == key->get_scancode_with_modifiers();
+	uint32_t code = get_scancode_with_modifiers();
+	uint32_t event_code = key->get_scancode_with_modifiers();
+
+	return get_scancode() == key->get_scancode() && (!key->is_pressed() || (code & event_code) == code);
 }
 
 void InputEventKey::_bind_methods() {


### PR DESCRIPTION
Original code for reference in 9100db7

Fixes #8997 