### PR TITLE
Allow for getting/setting "dotted" properties of objects

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -387,6 +387,22 @@ void Object::set(const StringName &p_name, const Variant &p_value, bool *r_valid
 	_edited = true;
 #endif
 
+	// Check for dotted properties, and attempt to recursively get/set them
+	{
+		String name_str = p_name;
+		int dot_pos = name_str.rfind(".");
+		if (dot_pos > -1) {
+			StringName property = name_str.left(dot_pos);
+			bool success = false;
+			Variant current_value = get(property, &success);
+			if (success) {
+				current_value.set(name_str.right(dot_pos + 1), p_value);
+				set(property, current_value, r_valid);
+				return;
+			}
+		}
+	}
+
 	if (script_instance) {
 
 		if (script_instance->set(p_name, p_value)) {
@@ -434,6 +450,20 @@ void Object::set(const StringName &p_name, const Variant &p_value, bool *r_valid
 Variant Object::get(const StringName &p_name, bool *r_valid) const {
 
 	Variant ret;
+
+	// Check for dotted properties, and attempt to recursively get them
+	{
+		String name_str = p_name;
+		int dot_pos = name_str.rfind(".");
+		if (dot_pos > -1) {
+			StringName property = name_str.left(dot_pos);
+			bool success = false;
+			Variant current_value = get(property, &success);
+			if (success) {
+				return current_value.get(name_str.right(dot_pos + 1), r_valid);
+			}
+		}
+	}
 
 	if (script_instance) {
 

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -1002,6 +1002,8 @@ bool Tween::interpolate_property(Object *p_object, String p_property, Variant p_
 		_add_pending_command("interpolate_property", p_object, p_property, p_initial_val, p_final_val, p_duration, p_trans_type, p_ease_type, p_delay);
 		return true;
 	}
+	if (p_initial_val.get_type() == Variant::NIL) p_initial_val = p_object->get(p_property);
+
 	// convert INT to REAL is better for interpolaters
 	if (p_initial_val.get_type() == Variant::INT) p_initial_val = p_initial_val.operator real_t();
 	if (p_final_val.get_type() == Variant::INT) p_final_val = p_final_val.operator real_t();
@@ -1192,6 +1194,8 @@ bool Tween::follow_property(Object *p_object, String p_property, Variant p_initi
 		_add_pending_command("follow_property", p_object, p_property, p_initial_val, p_target, p_target_property, p_duration, p_trans_type, p_ease_type, p_delay);
 		return true;
 	}
+	if (p_initial_val.get_type() == Variant::NIL) p_initial_val = p_object->get(p_initial_val);
+
 	// convert INT to REAL is better for interpolaters
 	if (p_initial_val.get_type() == Variant::INT) p_initial_val = p_initial_val.operator real_t();
 


### PR DESCRIPTION
**Do not merge without proper review!** This might prove detrimental to `Object::get/set` performance.

Additionally includes a commit that makes it easier to use `Tween::{interpolate,targeting}_property`, by auto-`get()`-ing the initial value if `null` is given.

I'm open to discussions about better solutions, either here or on the original issue (#8257).

[GIF Recording of work](https://cloud.githubusercontent.com/assets/5276727/26603684/6afa37a4-4590-11e7-82ef-57cc1b9ab4f9.gif) (its dimensions are a bit too large, so I won't inline it here)
Code used for recording:
`main.gd`
```gdscript
extends Node2D

func _ready():
	var tween = get_node("Tween")
	tween.interpolate_property(get_node("KinematicBody2D"), "position.x", null, 500, 2, Tween.TRANS_BOUNCE, Tween.EASE_OUT, 0)
	# Without second commit:
	#tween.interpolate_property(get_node("KinematicBody2D"), "position.x", get_node("KinematicBody2D").position.x, 500, 2, Tween.TRANS_BOUNCE, Tween.EASE_OUT, 0)
	tween.start()
```
`kinematic_body_2d.gd`
```gdscript
extends KinematicBody2D

func _fixed_process(delta): # Note: 3.0, thus doesn't need set_fixed_process(true)
	move(Vector2(-50, 50) * delta)
```

As you can see, the Tween applies to the X axis only, while the Y axis is moved by the KinematicBody2D.

Closes #8257.