### PR TITLE
Expose copy constructor for some GDNative types

### DIFF
--- a/modules/gdnative/godot/godot_array.cpp
+++ b/modules/gdnative/godot/godot_array.cpp
@@ -49,6 +49,12 @@ void GDAPI godot_array_new(godot_array *p_arr) {
 	memnew_placement(a, Array);
 }
 
+void GDAPI godot_array_new_copy(godot_array *p_dest, const godot_array *p_src) {
+	Array *dest = (Array *)p_dest;
+	const Array *src = (const Array *)p_src;
+	memnew_placement(dest, Array(*src));
+}
+
 void GDAPI godot_array_new_pool_color_array(godot_array *p_arr, const godot_pool_color_array *p_pca) {
 	Array *a = (Array *)p_arr;
 	PoolVector<Color> *pca = (PoolVector<Color> *)p_pca;

--- a/modules/gdnative/godot/godot_array.h
+++ b/modules/gdnative/godot/godot_array.h
@@ -49,6 +49,7 @@ typedef struct godot_array {
 #include "../godot.h"
 
 void GDAPI godot_array_new(godot_array *p_arr);
+void GDAPI godot_array_new_copy(godot_array *p_dest, const godot_array *p_src);
 void GDAPI godot_array_new_pool_color_array(godot_array *p_arr, const godot_pool_color_array *p_pca);
 void GDAPI godot_array_new_pool_vector3_array(godot_array *p_arr, const godot_pool_vector3_array *p_pv3a);
 void GDAPI godot_array_new_pool_vector2_array(godot_array *p_arr, const godot_pool_vector2_array *p_pv2a);

--- a/modules/gdnative/godot/godot_dictionary.cpp
+++ b/modules/gdnative/godot/godot_dictionary.cpp
@@ -44,6 +44,12 @@ void GDAPI godot_dictionary_new(godot_dictionary *r_dest) {
 	memnew_placement(dest, Dictionary);
 }
 
+void GDAPI godot_dictionary_new_copy(godot_dictionary *r_dest, const godot_dictionary *r_src) {
+	Dictionary *dest = (Dictionary *)r_dest;
+	const Dictionary *src = (const Dictionary *)r_src;
+	memnew_placement(dest, Dictionary(*src));
+}
+
 void GDAPI godot_dictionary_destroy(godot_dictionary *p_self) {
 	Dictionary *self = (Dictionary *)p_self;
 	self->~Dictionary();

--- a/modules/gdnative/godot/godot_dictionary.h
+++ b/modules/gdnative/godot/godot_dictionary.h
@@ -48,6 +48,7 @@ typedef struct godot_dictionary {
 #include "godot_variant.h"
 
 void GDAPI godot_dictionary_new(godot_dictionary *r_dest);
+void GDAPI godot_dictionary_new_copy(godot_dictionary *r_dest, const godot_dictionary *r_src);
 void GDAPI godot_dictionary_destroy(godot_dictionary *p_self);
 
 godot_int GDAPI godot_dictionary_size(const godot_dictionary *p_self);

--- a/modules/gdnative/godot/godot_pool_arrays.cpp
+++ b/modules/gdnative/godot/godot_pool_arrays.cpp
@@ -49,6 +49,12 @@ void GDAPI godot_pool_byte_array_new(godot_pool_byte_array *p_pba) {
 	memnew_placement(pba, PoolVector<uint8_t>);
 }
 
+void GDAPI godot_pool_byte_array_new_copy(godot_pool_byte_array *p_dest, const godot_pool_byte_array *p_src) {
+	PoolVector<uint8_t> *dest = (PoolVector<uint8_t> *)p_dest;
+	const PoolVector<uint8_t> *src = (const PoolVector<uint8_t> *)p_src;
+	memnew_placement(dest, PoolVector<uint8_t>(*src));
+}
+
 void GDAPI godot_pool_byte_array_new_with_array(godot_pool_byte_array *p_pba, const godot_array *p_a) {
 	PoolVector<uint8_t> *pba = (PoolVector<uint8_t> *)p_pba;
 	Array *a = (Array *)p_a;
@@ -120,6 +126,12 @@ void GDAPI godot_pool_byte_array_destroy(godot_pool_byte_array *p_pba) {
 void GDAPI godot_pool_int_array_new(godot_pool_int_array *p_pba) {
 	PoolVector<uint8_t> *pba = (PoolVector<uint8_t> *)p_pba;
 	memnew_placement(pba, PoolVector<uint8_t>);
+}
+
+void GDAPI godot_pool_int_array_new_copy(godot_pool_int_array *p_dest, const godot_pool_int_array *p_src) {
+	PoolVector<godot_int> *dest = (PoolVector<godot_int> *)p_dest;
+	const PoolVector<godot_int> *src = (const PoolVector<godot_int> *)p_src;
+	memnew_placement(dest, PoolVector<godot_int>(*src));
 }
 
 void GDAPI godot_pool_int_array_new_with_array(godot_pool_int_array *p_pba, const godot_array *p_a) {
@@ -195,6 +207,12 @@ void GDAPI godot_pool_real_array_new(godot_pool_real_array *p_pba) {
 	memnew_placement(pba, PoolVector<uint8_t>);
 }
 
+void GDAPI godot_pool_real_array_new_copy(godot_pool_real_array *p_dest, const godot_pool_real_array *p_src) {
+	PoolVector<godot_real> *dest = (PoolVector<godot_real> *)p_dest;
+	const PoolVector<godot_real> *src = (const PoolVector<godot_real> *)p_src;
+	memnew_placement(dest, PoolVector<godot_real>(*src));
+}
+
 void GDAPI godot_pool_real_array_new_with_array(godot_pool_real_array *p_pba, const godot_array *p_a) {
 	PoolVector<uint8_t> *pba = (PoolVector<uint8_t> *)p_pba;
 	Array *a = (Array *)p_a;
@@ -266,6 +284,12 @@ void GDAPI godot_pool_real_array_destroy(godot_pool_real_array *p_pba) {
 void GDAPI godot_pool_string_array_new(godot_pool_string_array *p_pba) {
 	PoolVector<String> *pba = (PoolVector<String> *)p_pba;
 	memnew_placement(pba, PoolVector<String>);
+}
+
+void GDAPI godot_pool_string_array_new_copy(godot_pool_string_array *p_dest, const godot_pool_string_array *p_src) {
+	PoolVector<String> *dest = (PoolVector<String> *)p_dest;
+	const PoolVector<String> *src = (const PoolVector<String> *)p_src;
+	memnew_placement(dest, PoolVector<String>(*src));
 }
 
 void GDAPI godot_pool_string_array_new_with_array(godot_pool_string_array *p_pba, const godot_array *p_a) {
@@ -349,6 +373,12 @@ void GDAPI godot_pool_vector2_array_new(godot_pool_vector2_array *p_pba) {
 	memnew_placement(pba, PoolVector<Vector2>);
 }
 
+void GDAPI godot_pool_vector2_array_new_copy(godot_pool_vector2_array *p_dest, const godot_pool_vector2_array *p_src) {
+	PoolVector<Vector2> *dest = (PoolVector<Vector2> *)p_dest;
+	const PoolVector<Vector2> *src = (const PoolVector<Vector2> *)p_src;
+	memnew_placement(dest, PoolVector<Vector2>(*src));
+}
+
 void GDAPI godot_pool_vector2_array_new_with_array(godot_pool_vector2_array *p_pba, const godot_array *p_a) {
 	PoolVector<Vector2> *pba = (PoolVector<Vector2> *)p_pba;
 	Array *a = (Array *)p_a;
@@ -429,6 +459,12 @@ void GDAPI godot_pool_vector3_array_new(godot_pool_vector3_array *p_pba) {
 	memnew_placement(pba, PoolVector<Vector3>);
 }
 
+void GDAPI godot_pool_vector3_array_new_copy(godot_pool_vector3_array *p_dest, const godot_pool_vector3_array *p_src) {
+	PoolVector<Vector3> *dest = (PoolVector<Vector3> *)p_dest;
+	const PoolVector<Vector3> *src = (const PoolVector<Vector3> *)p_src;
+	memnew_placement(dest, PoolVector<Vector3>(*src));
+}
+
 void GDAPI godot_pool_vector3_array_new_with_array(godot_pool_vector3_array *p_pba, const godot_array *p_a) {
 	PoolVector<Vector3> *pba = (PoolVector<Vector3> *)p_pba;
 	Array *a = (Array *)p_a;
@@ -507,6 +543,12 @@ void GDAPI godot_pool_vector3_array_destroy(godot_pool_vector3_array *p_pba) {
 void GDAPI godot_pool_color_array_new(godot_pool_color_array *p_pba) {
 	PoolVector<Color> *pba = (PoolVector<Color> *)p_pba;
 	memnew_placement(pba, PoolVector<Color>);
+}
+
+void GDAPI godot_pool_color_array_new_copy(godot_pool_color_array *p_dest, const godot_pool_color_array *p_src) {
+	PoolVector<Color> *dest = (PoolVector<Color> *)p_dest;
+	const PoolVector<Color> *src = (const PoolVector<Color> *)p_src;
+	memnew_placement(dest, PoolVector<Color>(*src));
 }
 
 void GDAPI godot_pool_color_array_new_with_array(godot_pool_color_array *p_pba, const godot_array *p_a) {

--- a/modules/gdnative/godot/godot_pool_arrays.h
+++ b/modules/gdnative/godot/godot_pool_arrays.h
@@ -102,6 +102,7 @@ typedef struct godot_pool_color_array {
 // byte
 
 void GDAPI godot_pool_byte_array_new(godot_pool_byte_array *p_pba);
+void GDAPI godot_pool_byte_array_new_copy(godot_pool_byte_array *p_dest, const godot_pool_byte_array *p_src);
 void GDAPI godot_pool_byte_array_new_with_array(godot_pool_byte_array *p_pba, const godot_array *p_a);
 
 void GDAPI godot_pool_byte_array_append(godot_pool_byte_array *p_pba, const uint8_t p_data);
@@ -128,6 +129,7 @@ void GDAPI godot_pool_byte_array_destroy(godot_pool_byte_array *p_pba);
 // int
 
 void GDAPI godot_pool_int_array_new(godot_pool_int_array *p_pia);
+void GDAPI godot_pool_int_array_new_copy(godot_pool_int_array *p_dest, const godot_pool_int_array *p_src);
 void GDAPI godot_pool_int_array_new_with_array(godot_pool_int_array *p_pia, const godot_array *p_a);
 
 void GDAPI godot_pool_int_array_append(godot_pool_int_array *p_pia, const godot_int p_data);
@@ -154,6 +156,7 @@ void GDAPI godot_pool_int_array_destroy(godot_pool_int_array *p_pia);
 // real
 
 void GDAPI godot_pool_real_array_new(godot_pool_real_array *p_pra);
+void GDAPI godot_pool_real_array_new_copy(godot_pool_real_array *p_dest, const godot_pool_real_array *p_src);
 void GDAPI godot_pool_real_array_new_with_array(godot_pool_real_array *p_pra, const godot_array *p_a);
 
 void GDAPI godot_pool_real_array_append(godot_pool_real_array *p_pra, const godot_real p_data);
@@ -180,6 +183,7 @@ void GDAPI godot_pool_real_array_destroy(godot_pool_real_array *p_pra);
 // string
 
 void GDAPI godot_pool_string_array_new(godot_pool_string_array *p_psa);
+void GDAPI godot_pool_string_array_new_copy(godot_pool_string_array *p_dest, const godot_pool_string_array *p_src);
 void GDAPI godot_pool_string_array_new_with_array(godot_pool_string_array *p_psa, const godot_array *p_a);
 
 void GDAPI godot_pool_string_array_append(godot_pool_string_array *p_psa, const godot_string *p_data);
@@ -206,6 +210,7 @@ void GDAPI godot_pool_string_array_destroy(godot_pool_string_array *p_psa);
 // vector2
 
 void GDAPI godot_pool_vector2_array_new(godot_pool_vector2_array *p_pv2a);
+void GDAPI godot_pool_vector2_array_new_copy(godot_pool_vector2_array *p_dest, const godot_pool_vector2_array *p_src);
 void GDAPI godot_pool_vector2_array_new_with_array(godot_pool_vector2_array *p_pv2a, const godot_array *p_a);
 
 void GDAPI godot_pool_vector2_array_append(godot_pool_vector2_array *p_pv2a, const godot_vector2 *p_data);
@@ -232,6 +237,7 @@ void GDAPI godot_pool_vector2_array_destroy(godot_pool_vector2_array *p_pv2a);
 // vector3
 
 void GDAPI godot_pool_vector3_array_new(godot_pool_vector3_array *p_pv3a);
+void GDAPI godot_pool_vector3_array_new_copy(godot_pool_vector3_array *p_dest, const godot_pool_vector3_array *p_src);
 void GDAPI godot_pool_vector3_array_new_with_array(godot_pool_vector3_array *p_pv3a, const godot_array *p_a);
 
 void GDAPI godot_pool_vector3_array_append(godot_pool_vector3_array *p_pv3a, const godot_vector3 *p_data);
@@ -258,6 +264,7 @@ void GDAPI godot_pool_vector3_array_destroy(godot_pool_vector3_array *p_pv3a);
 // color
 
 void GDAPI godot_pool_color_array_new(godot_pool_color_array *p_pca);
+void GDAPI godot_pool_color_array_new_copy(godot_pool_color_array *p_dest, const godot_pool_color_array *p_src);
 void GDAPI godot_pool_color_array_new_with_array(godot_pool_color_array *p_pca, const godot_array *p_a);
 
 void GDAPI godot_pool_color_array_append(godot_pool_color_array *p_pca, const godot_color *p_data);


### PR DESCRIPTION
This PR exposes the copy constructors of Array, Dictionary, and PoolVector for GDNative as `godot_..._new_copy`. For referencing an existing container, the copy constructor is better than `godot_..._new` followed by `operator=` because the default constructor [allocates a new empty container](https://github.com/godotengine/godot/blob/master/core/array.cpp#L291) first.