### PR TITLE
fixed PowerState enum cast

### DIFF
--- a/core/method_ptrcall.h
+++ b/core/method_ptrcall.h
@@ -115,7 +115,6 @@ MAKE_PTRARG(PoolVector2Array);
 MAKE_PTRARG(PoolVector3Array);
 MAKE_PTRARG(PoolColorArray);
 MAKE_PTRARG(Variant);
-MAKE_PTRARG(PowerState);
 
 //this is for Object
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -413,4 +413,6 @@ public:
 	virtual ~OS();
 };
 
+VARIANT_ENUM_CAST(PowerState);
+
 #endif


### PR DESCRIPTION
Quite a while ago I made a commit (131631b) where I did a weird
thing to fix compilation with PTRCALL_ENABLED. And I couldn't
sleep because of this after all these months. So here is the
proper version.




Yes, I'm weird.