### PR TITLE
Improve reliability of memory stats

### DIFF
--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -48,8 +48,7 @@ class Memory {
 	static size_t mem_usage;
 	static size_t max_usage;
 #endif
-
-	static size_t alloc_count;
+	static uint64_t alloc_count;
 
 public:
 	static void *alloc_static(size_t p_bytes, bool p_pad_align = false);

--- a/core/safe_refcount.h
+++ b/core/safe_refcount.h
@@ -40,6 +40,10 @@ uint32_t atomic_conditional_increment(register uint32_t *counter);
 uint32_t atomic_decrement(register uint32_t *pw);
 uint32_t atomic_increment(register uint32_t *pw);
 
+uint64_t atomic_conditional_increment(register uint64_t *counter);
+uint64_t atomic_decrement(register uint64_t *pw);
+uint64_t atomic_increment(register uint64_t *pw);
+
 struct SafeRefCount {
 
 	uint32_t count;


### PR DESCRIPTION
This PR is two-fold:

### 1) Improve reliability of mem stats

- The allocation count is managed atomically and where it actually should change (for instance, not counting an allocation before its success has been checked).

### 2) Memory block byte-tagging

- Memory just allocated or the portion of memory added to a block with a realloc is initialized with some magic number. _Helps catching bugs about unitialized members._
- Memory about to be freed or the portion of a memory block which is about to disappear by a shrinking realloc is filled with a differnt magic number. _Helps catching bugs due to dangling pointers._

Disabled by default. Can be enabled for debug builds by defining `DEBUG_MEMORY_TAGGING`.