### PR TITLE
Remove mutex-locking from non-debug memory routines (2.1)

### DIFF
--- a/drivers/unix/memory_pool_static_malloc.cpp
+++ b/drivers/unix/memory_pool_static_malloc.cpp
@@ -67,9 +67,9 @@ void *MemoryPoolStaticMalloc::_alloc(size_t p_bytes, const char *p_description) 
 
 	ERR_FAIL_COND_V(p_bytes == 0, 0);
 
-	MutexLock lock(mutex);
-
 #ifdef DEBUG_MEMORY_ENABLED
+
+	MutexLock lock(mutex);
 
 	size_t total;
 #if defined(_add_overflow)
@@ -176,9 +176,9 @@ void *MemoryPoolStaticMalloc::_realloc(void *p_memory, size_t p_bytes) {
 		return NULL;
 	}
 
-	MutexLock lock(mutex);
-
 #ifdef DEBUG_MEMORY_ENABLED
+
+	MutexLock lock(mutex);
 
 	RingPtr *ringptr = (RingPtr *)p_memory;
 	ringptr--; /* go back an element to find the tingptr */
@@ -240,9 +240,9 @@ void MemoryPoolStaticMalloc::free(void *p_ptr) {
 
 void MemoryPoolStaticMalloc::_free(void *p_ptr) {
 
-	MutexLock lock(mutex);
-
 #ifdef DEBUG_MEMORY_ENABLED
+
+	MutexLock lock(mutex);
 
 	if (p_ptr == 0) {
 		printf("**ERROR: STATIC ALLOC: Attempted free of NULL pointer.\n");
@@ -298,7 +298,7 @@ void MemoryPoolStaticMalloc::_free(void *p_ptr) {
 	total_mem -= ringptr->size;
 	total_pointers--;
 	// catch more errors
-	zeromem(ringptr, sizeof(RingPtr) + ringptr->size);
+	memset(ringptr, 0xEA, sizeof(RingPtr) + ringptr->size);
 	::free(ringptr); //just free that pointer
 
 #else


### PR DESCRIPTION
since the malloc() suite is nowadays thread-safe by itself (from MSVC 2010 you don't even have a non-MT runtime and for POSIX-based OSs it's mandatory by the spec.

NOTE: _master_'s memory routines are already lockless.

Bonus: Clear about-to-be-released blocks with a better magic number for better debugging of dangling pointers.