### PR TITLE
Continue improving GDNative

### DIFF
--- a/modules/gdnative/godot/godot_array.cpp
+++ b/modules/gdnative/godot/godot_array.cpp
@@ -44,256 +44,264 @@ extern "C" {
 void _array_api_anchor() {
 }
 
-void GDAPI godot_array_new(godot_array *p_arr) {
-	Array *a = (Array *)p_arr;
-	memnew_placement(a, Array);
+void GDAPI godot_array_new(godot_array *r_dest) {
+	Array *dest = (Array *)r_dest;
+	memnew_placement(dest, Array);
 }
 
-void GDAPI godot_array_new_copy(godot_array *p_dest, const godot_array *p_src) {
-	Array *dest = (Array *)p_dest;
+void GDAPI godot_array_new_copy(godot_array *r_dest, const godot_array *p_src) {
+	Array *dest = (Array *)r_dest;
 	const Array *src = (const Array *)p_src;
 	memnew_placement(dest, Array(*src));
 }
 
-void GDAPI godot_array_new_pool_color_array(godot_array *p_arr, const godot_pool_color_array *p_pca) {
-	Array *a = (Array *)p_arr;
+void GDAPI godot_array_new_pool_color_array(godot_array *r_dest, const godot_pool_color_array *p_pca) {
+	Array *dest = (Array *)r_dest;
 	PoolVector<Color> *pca = (PoolVector<Color> *)p_pca;
-	memnew_placement(a, Array);
-	a->resize(pca->size());
+	memnew_placement(dest, Array);
+	dest->resize(pca->size());
 
-	for (size_t i = 0; i < a->size(); i++) {
+	for (size_t i = 0; i < dest->size(); i++) {
 		Variant v = pca->operator[](i);
-		a->operator[](i) = v;
+		dest->operator[](i) = v;
 	}
 }
 
-void GDAPI godot_array_new_pool_vector3_array(godot_array *p_arr, const godot_pool_vector3_array *p_pv3a) {
-	Array *a = (Array *)p_arr;
+void GDAPI godot_array_new_pool_vector3_array(godot_array *r_dest, const godot_pool_vector3_array *p_pv3a) {
+	Array *dest = (Array *)r_dest;
 	PoolVector<Vector3> *pca = (PoolVector<Vector3> *)p_pv3a;
-	memnew_placement(a, Array);
-	a->resize(pca->size());
+	memnew_placement(dest, Array);
+	dest->resize(pca->size());
 
-	for (size_t i = 0; i < a->size(); i++) {
+	for (size_t i = 0; i < dest->size(); i++) {
 		Variant v = pca->operator[](i);
-		a->operator[](i) = v;
+		dest->operator[](i) = v;
 	}
 }
 
-void GDAPI godot_array_new_pool_vector2_array(godot_array *p_arr, const godot_pool_vector2_array *p_pv2a) {
-	Array *a = (Array *)p_arr;
+void GDAPI godot_array_new_pool_vector2_array(godot_array *r_dest, const godot_pool_vector2_array *p_pv2a) {
+	Array *dest = (Array *)r_dest;
 	PoolVector<Vector2> *pca = (PoolVector<Vector2> *)p_pv2a;
-	memnew_placement(a, Array);
-	a->resize(pca->size());
+	memnew_placement(dest, Array);
+	dest->resize(pca->size());
 
-	for (size_t i = 0; i < a->size(); i++) {
+	for (size_t i = 0; i < dest->size(); i++) {
 		Variant v = pca->operator[](i);
-		a->operator[](i) = v;
+		dest->operator[](i) = v;
 	}
 }
 
-void GDAPI godot_array_new_pool_string_array(godot_array *p_arr, const godot_pool_string_array *p_psa) {
-	Array *a = (Array *)p_arr;
+void GDAPI godot_array_new_pool_string_array(godot_array *r_dest, const godot_pool_string_array *p_psa) {
+	Array *dest = (Array *)r_dest;
 	PoolVector<String> *pca = (PoolVector<String> *)p_psa;
-	memnew_placement(a, Array);
-	a->resize(pca->size());
+	memnew_placement(dest, Array);
+	dest->resize(pca->size());
 
-	for (size_t i = 0; i < a->size(); i++) {
+	for (size_t i = 0; i < dest->size(); i++) {
 		Variant v = pca->operator[](i);
-		a->operator[](i) = v;
+		dest->operator[](i) = v;
 	}
 }
 
-void GDAPI godot_array_new_pool_real_array(godot_array *p_arr, const godot_pool_real_array *p_pra) {
-	Array *a = (Array *)p_arr;
+void GDAPI godot_array_new_pool_real_array(godot_array *r_dest, const godot_pool_real_array *p_pra) {
+	Array *dest = (Array *)r_dest;
 	PoolVector<godot_real> *pca = (PoolVector<godot_real> *)p_pra;
-	memnew_placement(a, Array);
-	a->resize(pca->size());
+	memnew_placement(dest, Array);
+	dest->resize(pca->size());
 
-	for (size_t i = 0; i < a->size(); i++) {
+	for (size_t i = 0; i < dest->size(); i++) {
 		Variant v = pca->operator[](i);
-		a->operator[](i) = v;
+		dest->operator[](i) = v;
 	}
 }
 
-void GDAPI godot_array_new_pool_int_array(godot_array *p_arr, const godot_pool_int_array *p_pia) {
-	Array *a = (Array *)p_arr;
+void GDAPI godot_array_new_pool_int_array(godot_array *r_dest, const godot_pool_int_array *p_pia) {
+	Array *dest = (Array *)r_dest;
 	PoolVector<godot_int> *pca = (PoolVector<godot_int> *)p_pia;
-	memnew_placement(a, Array);
-	a->resize(pca->size());
+	memnew_placement(dest, Array);
+	dest->resize(pca->size());
 
-	for (size_t i = 0; i < a->size(); i++) {
+	for (size_t i = 0; i < dest->size(); i++) {
 		Variant v = pca->operator[](i);
-		a->operator[](i) = v;
+		dest->operator[](i) = v;
 	}
 }
 
-void GDAPI godot_array_new_pool_byte_array(godot_array *p_arr, const godot_pool_byte_array *p_pba) {
-	Array *a = (Array *)p_arr;
+void GDAPI godot_array_new_pool_byte_array(godot_array *r_dest, const godot_pool_byte_array *p_pba) {
+	Array *dest = (Array *)r_dest;
 	PoolVector<uint8_t> *pca = (PoolVector<uint8_t> *)p_pba;
-	memnew_placement(a, Array);
-	a->resize(pca->size());
+	memnew_placement(dest, Array);
+	dest->resize(pca->size());
 
-	for (size_t i = 0; i < a->size(); i++) {
+	for (size_t i = 0; i < dest->size(); i++) {
 		Variant v = pca->operator[](i);
-		a->operator[](i) = v;
+		dest->operator[](i) = v;
 	}
 }
 
-void GDAPI godot_array_set(godot_array *p_arr, const godot_int p_idx, const godot_variant *p_value) {
-	Array *a = (Array *)p_arr;
+void GDAPI godot_array_set(godot_array *p_self, const godot_int p_idx, const godot_variant *p_value) {
+	Array *self = (Array *)p_self;
 	Variant *val = (Variant *)p_value;
-	a->operator[](p_idx) = *val;
+	self->operator[](p_idx) = *val;
 }
 
-godot_variant GDAPI *godot_array_get(const godot_array *p_arr, const godot_int p_idx) {
-	Array *a = (Array *)p_arr;
-	return (godot_variant *)&a->operator[](p_idx);
+godot_variant GDAPI godot_array_get(const godot_array *p_self, const godot_int p_idx) {
+	godot_variant raw_dest;
+	Variant *dest = (Variant *)&raw_dest;
+	const Array *self = (const Array *)p_self;
+	memnew_placement(dest, Variant(self->operator[](p_idx)));
+	return raw_dest;
 }
 
-void GDAPI godot_array_append(godot_array *p_arr, const godot_variant *p_value) {
-	Array *a = (Array *)p_arr;
+godot_variant GDAPI *godot_array_operator_index(godot_array *p_self, const godot_int p_idx) {
+	Array *self = (Array *)p_self;
+	return (godot_variant *)&self->operator[](p_idx);
+}
+
+void GDAPI godot_array_append(godot_array *p_self, const godot_variant *p_value) {
+	Array *self = (Array *)p_self;
 	Variant *val = (Variant *)p_value;
-	a->append(*val);
+	self->append(*val);
 }
 
-void GDAPI godot_array_clear(godot_array *p_arr) {
-	Array *a = (Array *)p_arr;
-	a->clear();
+void GDAPI godot_array_clear(godot_array *p_self) {
+	Array *self = (Array *)p_self;
+	self->clear();
 }
 
-godot_int GDAPI godot_array_count(const godot_array *p_arr, const godot_variant *p_value) {
-	const Array *a = (const Array *)p_arr;
+godot_int GDAPI godot_array_count(const godot_array *p_self, const godot_variant *p_value) {
+	const Array *self = (const Array *)p_self;
 	const Variant *val = (const Variant *)p_value;
-	return a->count(*val);
+	return self->count(*val);
 }
 
-godot_bool GDAPI godot_array_empty(const godot_array *p_arr) {
-	const Array *a = (const Array *)p_arr;
-	return a->empty();
+godot_bool GDAPI godot_array_empty(const godot_array *p_self) {
+	const Array *self = (const Array *)p_self;
+	return self->empty();
 }
 
-void GDAPI godot_array_erase(godot_array *p_arr, const godot_variant *p_value) {
-	Array *a = (Array *)p_arr;
+void GDAPI godot_array_erase(godot_array *p_self, const godot_variant *p_value) {
+	Array *self = (Array *)p_self;
 	const Variant *val = (const Variant *)p_value;
-	a->erase(*val);
+	self->erase(*val);
 }
 
-godot_variant GDAPI godot_array_front(const godot_array *p_arr) {
-	const Array *a = (const Array *)p_arr;
+godot_variant GDAPI godot_array_front(const godot_array *p_self) {
+	const Array *self = (const Array *)p_self;
 	godot_variant v;
 	Variant *val = (Variant *)&v;
 	memnew_placement(val, Variant);
-	*val = a->front();
+	*val = self->front();
 	return v;
 }
 
-godot_variant GDAPI godot_array_back(const godot_array *p_arr) {
-	const Array *a = (const Array *)p_arr;
+godot_variant GDAPI godot_array_back(const godot_array *p_self) {
+	const Array *self = (const Array *)p_self;
 	godot_variant v;
 	Variant *val = (Variant *)&v;
 	memnew_placement(val, Variant);
-	*val = a->back();
+	*val = self->back();
 	return v;
 }
 
-godot_int GDAPI godot_array_find(const godot_array *p_arr, const godot_variant *p_what, const godot_int p_from) {
-	const Array *a = (const Array *)p_arr;
+godot_int GDAPI godot_array_find(const godot_array *p_self, const godot_variant *p_what, const godot_int p_from) {
+	const Array *self = (const Array *)p_self;
 	const Variant *val = (const Variant *)p_what;
-	return a->find(*val, p_from);
+	return self->find(*val, p_from);
 }
 
-godot_int GDAPI godot_array_find_last(const godot_array *p_arr, const godot_variant *p_what) {
-	const Array *a = (const Array *)p_arr;
+godot_int GDAPI godot_array_find_last(const godot_array *p_self, const godot_variant *p_what) {
+	const Array *self = (const Array *)p_self;
 	const Variant *val = (const Variant *)p_what;
-	return a->find_last(*val);
+	return self->find_last(*val);
 }
 
-godot_bool GDAPI godot_array_has(const godot_array *p_arr, const godot_variant *p_value) {
-	const Array *a = (const Array *)p_arr;
+godot_bool GDAPI godot_array_has(const godot_array *p_self, const godot_variant *p_value) {
+	const Array *self = (const Array *)p_self;
 	const Variant *val = (const Variant *)p_value;
-	return a->has(*val);
+	return self->has(*val);
 }
 
-uint32_t GDAPI godot_array_hash(const godot_array *p_arr) {
-	const Array *a = (const Array *)p_arr;
-	return a->hash();
+godot_int GDAPI godot_array_hash(const godot_array *p_self) {
+	const Array *self = (const Array *)p_self;
+	return self->hash();
 }
 
-void GDAPI godot_array_insert(godot_array *p_arr, const godot_int p_pos, const godot_variant *p_value) {
-	Array *a = (Array *)p_arr;
+void GDAPI godot_array_insert(godot_array *p_self, const godot_int p_pos, const godot_variant *p_value) {
+	Array *self = (Array *)p_self;
 	const Variant *val = (const Variant *)p_value;
-	a->insert(p_pos, *val);
+	self->insert(p_pos, *val);
 }
 
-void GDAPI godot_array_invert(godot_array *p_arr) {
-	Array *a = (Array *)p_arr;
-	a->invert();
+void GDAPI godot_array_invert(godot_array *p_self) {
+	Array *self = (Array *)p_self;
+	self->invert();
 }
 
-godot_variant GDAPI godot_array_pop_back(godot_array *p_arr) {
-	Array *a = (Array *)p_arr;
+godot_variant GDAPI godot_array_pop_back(godot_array *p_self) {
+	Array *self = (Array *)p_self;
 	godot_variant v;
 	Variant *val = (Variant *)&v;
 	memnew_placement(val, Variant);
-	*val = a->pop_back();
+	*val = self->pop_back();
 	return v;
 }
 
-godot_variant GDAPI godot_array_pop_front(godot_array *p_arr) {
-	Array *a = (Array *)p_arr;
+godot_variant GDAPI godot_array_pop_front(godot_array *p_self) {
+	Array *self = (Array *)p_self;
 	godot_variant v;
 	Variant *val = (Variant *)&v;
 	memnew_placement(val, Variant);
-	*val = a->pop_front();
+	*val = self->pop_front();
 	return v;
 }
 
-void GDAPI godot_array_push_back(godot_array *p_arr, const godot_variant *p_value) {
-	Array *a = (Array *)p_arr;
+void GDAPI godot_array_push_back(godot_array *p_self, const godot_variant *p_value) {
+	Array *self = (Array *)p_self;
 	const Variant *val = (const Variant *)p_value;
-	a->push_back(*val);
+	self->push_back(*val);
 }
 
-void GDAPI godot_array_push_front(godot_array *p_arr, const godot_variant *p_value) {
-	Array *a = (Array *)p_arr;
+void GDAPI godot_array_push_front(godot_array *p_self, const godot_variant *p_value) {
+	Array *self = (Array *)p_self;
 	const Variant *val = (const Variant *)p_value;
-	a->push_front(*val);
+	self->push_front(*val);
 }
 
-void GDAPI godot_array_remove(godot_array *p_arr, const godot_int p_idx) {
-	Array *a = (Array *)p_arr;
-	a->remove(p_idx);
+void GDAPI godot_array_remove(godot_array *p_self, const godot_int p_idx) {
+	Array *self = (Array *)p_self;
+	self->remove(p_idx);
 }
 
-void GDAPI godot_array_resize(godot_array *p_arr, const godot_int p_size) {
-	Array *a = (Array *)p_arr;
-	a->resize(p_size);
+void GDAPI godot_array_resize(godot_array *p_self, const godot_int p_size) {
+	Array *self = (Array *)p_self;
+	self->resize(p_size);
 }
 
-godot_int GDAPI godot_array_rfind(const godot_array *p_arr, const godot_variant *p_what, const godot_int p_from) {
-	const Array *a = (const Array *)p_arr;
+godot_int GDAPI godot_array_rfind(const godot_array *p_self, const godot_variant *p_what, const godot_int p_from) {
+	const Array *self = (const Array *)p_self;
 	const Variant *val = (const Variant *)p_what;
-	return a->rfind(*val, p_from);
+	return self->rfind(*val, p_from);
 }
 
-godot_int GDAPI godot_array_size(const godot_array *p_arr) {
-	const Array *a = (const Array *)p_arr;
-	return a->size();
+godot_int GDAPI godot_array_size(const godot_array *p_self) {
+	const Array *self = (const Array *)p_self;
+	return self->size();
 }
 
-void GDAPI godot_array_sort(godot_array *p_arr) {
-	Array *a = (Array *)p_arr;
-	a->sort();
+void GDAPI godot_array_sort(godot_array *p_self) {
+	Array *self = (Array *)p_self;
+	self->sort();
 }
 
-void GDAPI godot_array_sort_custom(godot_array *p_arr, godot_object *p_obj, const godot_string *p_func) {
-	Array *a = (Array *)p_arr;
+void GDAPI godot_array_sort_custom(godot_array *p_self, godot_object *p_obj, const godot_string *p_func) {
+	Array *self = (Array *)p_self;
 	const String *func = (const String *)p_func;
-	a->sort_custom((Object *)p_obj, *func);
+	self->sort_custom((Object *)p_obj, *func);
 }
 
-void GDAPI godot_array_destroy(godot_array *p_arr) {
-	((Array *)p_arr)->~Array();
+void GDAPI godot_array_destroy(godot_array *p_self) {
+	((Array *)p_self)->~Array();
 }
 
 #ifdef __cplusplus

--- a/modules/gdnative/godot/godot_array.h
+++ b/modules/gdnative/godot/godot_array.h
@@ -48,67 +48,69 @@ typedef struct godot_array {
 
 #include "../godot.h"
 
-void GDAPI godot_array_new(godot_array *p_arr);
-void GDAPI godot_array_new_copy(godot_array *p_dest, const godot_array *p_src);
-void GDAPI godot_array_new_pool_color_array(godot_array *p_arr, const godot_pool_color_array *p_pca);
-void GDAPI godot_array_new_pool_vector3_array(godot_array *p_arr, const godot_pool_vector3_array *p_pv3a);
-void GDAPI godot_array_new_pool_vector2_array(godot_array *p_arr, const godot_pool_vector2_array *p_pv2a);
-void GDAPI godot_array_new_pool_string_array(godot_array *p_arr, const godot_pool_string_array *p_psa);
-void GDAPI godot_array_new_pool_real_array(godot_array *p_arr, const godot_pool_real_array *p_pra);
-void GDAPI godot_array_new_pool_int_array(godot_array *p_arr, const godot_pool_int_array *p_pia);
-void GDAPI godot_array_new_pool_byte_array(godot_array *p_arr, const godot_pool_byte_array *p_pba);
+void GDAPI godot_array_new(godot_array *r_dest);
+void GDAPI godot_array_new_copy(godot_array *r_dest, const godot_array *p_src);
+void GDAPI godot_array_new_pool_color_array(godot_array *r_dest, const godot_pool_color_array *p_pca);
+void GDAPI godot_array_new_pool_vector3_array(godot_array *r_dest, const godot_pool_vector3_array *p_pv3a);
+void GDAPI godot_array_new_pool_vector2_array(godot_array *r_dest, const godot_pool_vector2_array *p_pv2a);
+void GDAPI godot_array_new_pool_string_array(godot_array *r_dest, const godot_pool_string_array *p_psa);
+void GDAPI godot_array_new_pool_real_array(godot_array *r_dest, const godot_pool_real_array *p_pra);
+void GDAPI godot_array_new_pool_int_array(godot_array *r_dest, const godot_pool_int_array *p_pia);
+void GDAPI godot_array_new_pool_byte_array(godot_array *r_dest, const godot_pool_byte_array *p_pba);
 
-void GDAPI godot_array_set(godot_array *p_arr, const godot_int p_idx, const godot_variant *p_value);
+void GDAPI godot_array_set(godot_array *p_self, const godot_int p_idx, const godot_variant *p_value);
 
-godot_variant GDAPI *godot_array_get(const godot_array *p_arr, const godot_int p_idx);
+godot_variant GDAPI godot_array_get(const godot_array *p_self, const godot_int p_idx);
 
-void GDAPI godot_array_append(godot_array *p_arr, const godot_variant *p_value);
+godot_variant GDAPI *godot_array_operator_index(godot_array *p_self, const godot_int p_idx);
 
-void GDAPI godot_array_clear(godot_array *p_arr);
+void GDAPI godot_array_append(godot_array *p_self, const godot_variant *p_value);
 
-godot_int GDAPI godot_array_count(const godot_array *p_arr, const godot_variant *p_value);
+void GDAPI godot_array_clear(godot_array *p_self);
 
-godot_bool GDAPI godot_array_empty(const godot_array *p_arr);
+godot_int GDAPI godot_array_count(const godot_array *p_self, const godot_variant *p_value);
 
-void GDAPI godot_array_erase(godot_array *p_arr, const godot_variant *p_value);
+godot_bool GDAPI godot_array_empty(const godot_array *p_self);
 
-godot_variant GDAPI godot_array_front(const godot_array *p_arr);
+void GDAPI godot_array_erase(godot_array *p_self, const godot_variant *p_value);
 
-godot_variant GDAPI godot_array_back(const godot_array *p_arr);
+godot_variant GDAPI godot_array_front(const godot_array *p_self);
 
-godot_int GDAPI godot_array_find(const godot_array *p_arr, const godot_variant *p_what, const godot_int p_from);
+godot_variant GDAPI godot_array_back(const godot_array *p_self);
 
-godot_int GDAPI godot_array_find_last(const godot_array *p_arr, const godot_variant *p_what);
+godot_int GDAPI godot_array_find(const godot_array *p_self, const godot_variant *p_what, const godot_int p_from);
 
-godot_bool GDAPI godot_array_has(const godot_array *p_arr, const godot_variant *p_value);
+godot_int GDAPI godot_array_find_last(const godot_array *p_self, const godot_variant *p_what);
 
-uint32_t GDAPI godot_array_hash(const godot_array *p_arr);
+godot_bool GDAPI godot_array_has(const godot_array *p_self, const godot_variant *p_value);
 
-void GDAPI godot_array_insert(godot_array *p_arr, const godot_int p_pos, const godot_variant *p_value);
+godot_int GDAPI godot_array_hash(const godot_array *p_self);
 
-void GDAPI godot_array_invert(godot_array *p_arr);
+void GDAPI godot_array_insert(godot_array *p_self, const godot_int p_pos, const godot_variant *p_value);
 
-godot_variant GDAPI godot_array_pop_back(godot_array *p_arr);
+void GDAPI godot_array_invert(godot_array *p_self);
 
-godot_variant GDAPI godot_array_pop_front(godot_array *p_arr);
+godot_variant GDAPI godot_array_pop_back(godot_array *p_self);
 
-void GDAPI godot_array_push_back(godot_array *p_arr, const godot_variant *p_value);
+godot_variant GDAPI godot_array_pop_front(godot_array *p_self);
 
-void GDAPI godot_array_push_front(godot_array *p_arr, const godot_variant *p_value);
+void GDAPI godot_array_push_back(godot_array *p_self, const godot_variant *p_value);
 
-void GDAPI godot_array_remove(godot_array *p_arr, const godot_int p_idx);
+void GDAPI godot_array_push_front(godot_array *p_self, const godot_variant *p_value);
 
-void GDAPI godot_array_resize(godot_array *p_arr, const godot_int p_size);
+void GDAPI godot_array_remove(godot_array *p_self, const godot_int p_idx);
 
-godot_int GDAPI godot_array_rfind(const godot_array *p_arr, const godot_variant *p_what, const godot_int p_from);
+void GDAPI godot_array_resize(godot_array *p_self, const godot_int p_size);
 
-godot_int GDAPI godot_array_size(const godot_array *p_arr);
+godot_int GDAPI godot_array_rfind(const godot_array *p_self, const godot_variant *p_what, const godot_int p_from);
 
-void GDAPI godot_array_sort(godot_array *p_arr);
+godot_int GDAPI godot_array_size(const godot_array *p_self);
 
-void GDAPI godot_array_sort_custom(godot_array *p_arr, godot_object *p_obj, const godot_string *p_func);
+void GDAPI godot_array_sort(godot_array *p_self);
 
-void GDAPI godot_array_destroy(godot_array *p_arr);
+void GDAPI godot_array_sort_custom(godot_array *p_self, godot_object *p_obj, const godot_string *p_func);
+
+void GDAPI godot_array_destroy(godot_array *p_self);
 
 #ifdef __cplusplus
 }

--- a/modules/gdnative/godot/godot_color.cpp
+++ b/modules/gdnative/godot/godot_color.cpp
@@ -50,6 +50,61 @@ void GDAPI godot_color_new_rgb(godot_color *r_dest, const godot_real p_r, const 
 	*dest = Color(p_r, p_g, p_b);
 }
 
+godot_real godot_color_get_r(const godot_color *p_self) {
+	const Color *self = (const Color *)p_self;
+	return self->r;
+}
+
+void godot_color_set_r(godot_color *p_self, const godot_real val) {
+	Color *self = (Color *)p_self;
+	self->r = val;
+}
+
+godot_real godot_color_get_g(const godot_color *p_self) {
+	const Color *self = (const Color *)p_self;
+	return self->g;
+}
+
+void godot_color_set_g(godot_color *p_self, const godot_real val) {
+	Color *self = (Color *)p_self;
+	self->g = val;
+}
+
+godot_real godot_color_get_b(const godot_color *p_self) {
+	const Color *self = (const Color *)p_self;
+	return self->b;
+}
+
+void godot_color_set_b(godot_color *p_self, const godot_real val) {
+	Color *self = (Color *)p_self;
+	self->b = val;
+}
+
+godot_real godot_color_get_a(const godot_color *p_self) {
+	const Color *self = (const Color *)p_self;
+	return self->a;
+}
+
+void godot_color_set_a(godot_color *p_self, const godot_real val) {
+	Color *self = (Color *)p_self;
+	self->a = val;
+}
+
+godot_real godot_color_get_h(const godot_color *p_self) {
+	const Color *self = (const Color *)p_self;
+	return self->get_h();
+}
+
+godot_real godot_color_get_s(const godot_color *p_self) {
+	const Color *self = (const Color *)p_self;
+	return self->get_s();
+}
+
+godot_real godot_color_get_v(const godot_color *p_self) {
+	const Color *self = (const Color *)p_self;
+	return self->get_v();
+}
+
 godot_string GDAPI godot_color_as_string(const godot_color *p_self) {
 	godot_string ret;
 	const Color *self = (const Color *)p_self;
@@ -106,7 +161,7 @@ godot_string GDAPI godot_color_to_html(const godot_color *p_self, const godot_bo
 	godot_string dest;
 	const Color *self = (const Color *)p_self;
 
-	*((String *)&dest) = self->to_html(p_with_alpha);
+	memnew_placement(&dest, String(self->to_html(p_with_alpha)));
 	return dest;
 }
 

--- a/modules/gdnative/godot/godot_color.h
+++ b/modules/gdnative/godot/godot_color.h
@@ -49,6 +49,22 @@ typedef struct godot_color {
 void GDAPI godot_color_new_rgba(godot_color *r_dest, const godot_real p_r, const godot_real p_g, const godot_real p_b, const godot_real p_a);
 void GDAPI godot_color_new_rgb(godot_color *r_dest, const godot_real p_r, const godot_real p_g, const godot_real p_b);
 
+godot_real godot_color_get_r(const godot_color *p_self);
+void godot_color_set_r(godot_color *p_self, const godot_real r);
+
+godot_real godot_color_get_g(const godot_color *p_self);
+void godot_color_set_g(godot_color *p_self, const godot_real g);
+
+godot_real godot_color_get_b(const godot_color *p_self);
+void godot_color_set_b(godot_color *p_self, const godot_real b);
+
+godot_real godot_color_get_a(const godot_color *p_self);
+void godot_color_set_a(godot_color *p_self, const godot_real a);
+
+godot_real godot_color_get_h(const godot_color *p_self);
+godot_real godot_color_get_s(const godot_color *p_self);
+godot_real godot_color_get_v(const godot_color *p_self);
+
 godot_string GDAPI godot_color_as_string(const godot_color *p_self);
 
 godot_int GDAPI godot_color_to_32(const godot_color *p_self);

--- a/modules/gdnative/godot/godot_dictionary.cpp
+++ b/modules/gdnative/godot/godot_dictionary.cpp
@@ -44,9 +44,9 @@ void GDAPI godot_dictionary_new(godot_dictionary *r_dest) {
 	memnew_placement(dest, Dictionary);
 }
 
-void GDAPI godot_dictionary_new_copy(godot_dictionary *r_dest, const godot_dictionary *r_src) {
+void GDAPI godot_dictionary_new_copy(godot_dictionary *r_dest, const godot_dictionary *p_src) {
 	Dictionary *dest = (Dictionary *)r_dest;
-	const Dictionary *src = (const Dictionary *)r_src;
+	const Dictionary *src = (const Dictionary *)p_src;
 	memnew_placement(dest, Dictionary(*src));
 }
 
@@ -107,10 +107,26 @@ godot_array GDAPI godot_dictionary_values(const godot_dictionary *p_self) {
 	return dest;
 }
 
-godot_variant GDAPI *godot_dictionary_operator_index(godot_dictionary *p_dict, const godot_variant *p_key) {
-	Dictionary *dict = (Dictionary *)p_dict;
+godot_variant GDAPI godot_dictionary_get(const godot_dictionary *p_self, const godot_variant *p_key) {
+	godot_variant raw_dest;
+	Variant *dest = (Variant *)&raw_dest;
+	const Dictionary *self = (const Dictionary *)p_self;
 	const Variant *key = (const Variant *)p_key;
-	return (godot_variant *)&dict->operator[](*key);
+	memnew_placement(dest, Variant(self->operator[](*key)));
+	return raw_dest;
+}
+
+void GDAPI godot_dictionary_set(godot_dictionary *p_self, const godot_variant *p_key, const godot_variant *p_value) {
+	Dictionary *self = (Dictionary *)p_self;
+	const Variant *key = (const Variant *)p_key;
+	const Variant *value = (const Variant *)p_value;
+	self->operator[](*key) = *value;
+}
+
+godot_variant GDAPI *godot_dictionary_operator_index(godot_dictionary *p_self, const godot_variant *p_key) {
+	Array *self = (Array *)p_self;
+	const Variant *key = (const Variant *)p_key;
+	return (godot_variant *)&self->operator[](*key);
 }
 
 godot_bool GDAPI godot_dictionary_operator_equal(const godot_dictionary *p_self, const godot_dictionary *p_b) {
@@ -119,11 +135,11 @@ godot_bool GDAPI godot_dictionary_operator_equal(const godot_dictionary *p_self,
 	return *self == *b;
 }
 
-godot_string GDAPI godot_dictionary_to_json(const godot_dictionary *p_dict) {
+godot_string GDAPI godot_dictionary_to_json(const godot_dictionary *p_self) {
 	godot_string raw_dest;
 	String *dest = (String *)&raw_dest;
-	const Dictionary *dict = (const Dictionary *)p_dict;
-	memnew_placement(dest, String(JSON::print(Variant(*dict))));
+	const Dictionary *self = (const Dictionary *)p_self;
+	memnew_placement(dest, String(JSON::print(Variant(*self))));
 	return raw_dest;
 }
 

--- a/modules/gdnative/godot/godot_dictionary.h
+++ b/modules/gdnative/godot/godot_dictionary.h
@@ -48,7 +48,7 @@ typedef struct godot_dictionary {
 #include "godot_variant.h"
 
 void GDAPI godot_dictionary_new(godot_dictionary *r_dest);
-void GDAPI godot_dictionary_new_copy(godot_dictionary *r_dest, const godot_dictionary *r_src);
+void GDAPI godot_dictionary_new_copy(godot_dictionary *r_dest, const godot_dictionary *p_src);
 void GDAPI godot_dictionary_destroy(godot_dictionary *p_self);
 
 godot_int GDAPI godot_dictionary_size(const godot_dictionary *p_self);
@@ -69,11 +69,14 @@ godot_array GDAPI godot_dictionary_keys(const godot_dictionary *p_self);
 
 godot_array GDAPI godot_dictionary_values(const godot_dictionary *p_self);
 
-godot_variant GDAPI *godot_dictionary_operator_index(godot_dictionary *p_dict, const godot_variant *p_key);
+godot_variant GDAPI godot_dictionary_get(const godot_dictionary *p_self, const godot_variant *p_key);
+void GDAPI godot_dictionary_set(godot_dictionary *p_self, const godot_variant *p_key, const godot_variant *p_value);
+
+godot_variant GDAPI *godot_dictionary_operator_index(godot_dictionary *p_self, const godot_variant *p_key);
 
 godot_bool GDAPI godot_dictionary_operator_equal(const godot_dictionary *p_self, const godot_dictionary *p_b);
 
-godot_string GDAPI godot_dictionary_to_json(const godot_dictionary *p_dict);
+godot_string GDAPI godot_dictionary_to_json(const godot_dictionary *p_self);
 
 #ifdef __cplusplus
 }

--- a/modules/gdnative/godot/godot_node_path.cpp
+++ b/modules/gdnative/godot/godot_node_path.cpp
@@ -44,6 +44,12 @@ void GDAPI godot_node_path_new(godot_node_path *r_dest, const godot_string *p_fr
 	memnew_placement(dest, NodePath(*from));
 }
 
+void GDAPI godot_node_path_new_copy(godot_node_path *r_dest, const godot_node_path *p_src) {
+	NodePath *dest = (NodePath *)r_dest;
+	const NodePath *src = (const NodePath *)p_src;
+	memnew_placement(dest, NodePath(*src));
+}
+
 void GDAPI godot_node_path_destroy(godot_node_path *p_self) {
 	NodePath *self = (NodePath *)p_self;
 	self->~NodePath();

--- a/modules/gdnative/godot/godot_node_path.h
+++ b/modules/gdnative/godot/godot_node_path.h
@@ -47,6 +47,7 @@ typedef struct godot_node_path {
 #include "godot_string.h"
 
 void GDAPI godot_node_path_new(godot_node_path *r_dest, const godot_string *p_from);
+void GDAPI godot_node_path_new_copy(godot_node_path *r_dest, const godot_node_path *p_src);
 void GDAPI godot_node_path_destroy(godot_node_path *p_self);
 
 godot_string GDAPI godot_node_path_as_string(const godot_node_path *p_self);

--- a/modules/gdnative/godot/godot_pool_arrays.cpp
+++ b/modules/gdnative/godot/godot_pool_arrays.cpp
@@ -44,584 +44,584 @@ void _pool_arrays_api_anchor() {
 
 // byte
 
-void GDAPI godot_pool_byte_array_new(godot_pool_byte_array *p_pba) {
-	PoolVector<uint8_t> *pba = (PoolVector<uint8_t> *)p_pba;
-	memnew_placement(pba, PoolVector<uint8_t>);
+void GDAPI godot_pool_byte_array_new(godot_pool_byte_array *r_dest) {
+	PoolVector<uint8_t> *dest = (PoolVector<uint8_t> *)r_dest;
+	memnew_placement(dest, PoolVector<uint8_t>);
 }
 
-void GDAPI godot_pool_byte_array_new_copy(godot_pool_byte_array *p_dest, const godot_pool_byte_array *p_src) {
-	PoolVector<uint8_t> *dest = (PoolVector<uint8_t> *)p_dest;
+void GDAPI godot_pool_byte_array_new_copy(godot_pool_byte_array *r_dest, const godot_pool_byte_array *p_src) {
+	PoolVector<uint8_t> *dest = (PoolVector<uint8_t> *)r_dest;
 	const PoolVector<uint8_t> *src = (const PoolVector<uint8_t> *)p_src;
 	memnew_placement(dest, PoolVector<uint8_t>(*src));
 }
 
-void GDAPI godot_pool_byte_array_new_with_array(godot_pool_byte_array *p_pba, const godot_array *p_a) {
-	PoolVector<uint8_t> *pba = (PoolVector<uint8_t> *)p_pba;
+void GDAPI godot_pool_byte_array_new_with_array(godot_pool_byte_array *r_dest, const godot_array *p_a) {
+	PoolVector<uint8_t> *dest = (PoolVector<uint8_t> *)r_dest;
 	Array *a = (Array *)p_a;
-	memnew_placement(pba, PoolVector<uint8_t>);
+	memnew_placement(dest, PoolVector<uint8_t>);
 
-	pba->resize(a->size());
+	dest->resize(a->size());
 	for (size_t i = 0; i < a->size(); i++) {
-		pba->set(i, (*a)[i]);
+		dest->set(i, (*a)[i]);
 	}
 }
 
-void GDAPI godot_pool_byte_array_append(godot_pool_byte_array *p_pba, const uint8_t p_data) {
-	PoolVector<uint8_t> *pba = (PoolVector<uint8_t> *)p_pba;
-	pba->append(p_data);
+void GDAPI godot_pool_byte_array_append(godot_pool_byte_array *p_self, const uint8_t p_data) {
+	PoolVector<uint8_t> *self = (PoolVector<uint8_t> *)p_self;
+	self->append(p_data);
 }
 
-void GDAPI godot_pool_byte_array_append_array(godot_pool_byte_array *p_pba, const godot_pool_byte_array *p_array) {
-	PoolVector<uint8_t> *pba = (PoolVector<uint8_t> *)p_pba;
+void GDAPI godot_pool_byte_array_append_array(godot_pool_byte_array *p_self, const godot_pool_byte_array *p_array) {
+	PoolVector<uint8_t> *self = (PoolVector<uint8_t> *)p_self;
 	PoolVector<uint8_t> *array = (PoolVector<uint8_t> *)p_array;
-	pba->append_array(*array);
+	self->append_array(*array);
 }
 
-int GDAPI godot_pool_byte_array_insert(godot_pool_byte_array *p_pba, const godot_int p_idx, const uint8_t p_data) {
-	PoolVector<uint8_t> *pba = (PoolVector<uint8_t> *)p_pba;
-	return pba->insert(p_idx, p_data);
+godot_error GDAPI godot_pool_byte_array_insert(godot_pool_byte_array *p_self, const godot_int p_idx, const uint8_t p_data) {
+	PoolVector<uint8_t> *self = (PoolVector<uint8_t> *)p_self;
+	return (godot_error)self->insert(p_idx, p_data);
 }
 
-void GDAPI godot_pool_byte_array_invert(godot_pool_byte_array *p_pba) {
-	PoolVector<uint8_t> *pba = (PoolVector<uint8_t> *)p_pba;
-	pba->invert();
+void GDAPI godot_pool_byte_array_invert(godot_pool_byte_array *p_self) {
+	PoolVector<uint8_t> *self = (PoolVector<uint8_t> *)p_self;
+	self->invert();
 }
 
-void GDAPI godot_pool_byte_array_push_back(godot_pool_byte_array *p_pba, const uint8_t p_data) {
-	PoolVector<uint8_t> *pba = (PoolVector<uint8_t> *)p_pba;
-	pba->push_back(p_data);
+void GDAPI godot_pool_byte_array_push_back(godot_pool_byte_array *p_self, const uint8_t p_data) {
+	PoolVector<uint8_t> *self = (PoolVector<uint8_t> *)p_self;
+	self->push_back(p_data);
 }
 
-void GDAPI godot_pool_byte_array_remove(godot_pool_byte_array *p_pba, const godot_int p_idx) {
-	PoolVector<uint8_t> *pba = (PoolVector<uint8_t> *)p_pba;
-	pba->remove(p_idx);
+void GDAPI godot_pool_byte_array_remove(godot_pool_byte_array *p_self, const godot_int p_idx) {
+	PoolVector<uint8_t> *self = (PoolVector<uint8_t> *)p_self;
+	self->remove(p_idx);
 }
 
-void GDAPI godot_pool_byte_array_resize(godot_pool_byte_array *p_pba, const godot_int p_size) {
-	PoolVector<uint8_t> *pba = (PoolVector<uint8_t> *)p_pba;
-	pba->resize(p_size);
+void GDAPI godot_pool_byte_array_resize(godot_pool_byte_array *p_self, const godot_int p_size) {
+	PoolVector<uint8_t> *self = (PoolVector<uint8_t> *)p_self;
+	self->resize(p_size);
 }
 
-void GDAPI godot_pool_byte_array_set(godot_pool_byte_array *p_pba, const godot_int p_idx, const uint8_t p_data) {
-	PoolVector<uint8_t> *pba = (PoolVector<uint8_t> *)p_pba;
-	pba->set(p_idx, p_data);
+void GDAPI godot_pool_byte_array_set(godot_pool_byte_array *p_self, const godot_int p_idx, const uint8_t p_data) {
+	PoolVector<uint8_t> *self = (PoolVector<uint8_t> *)p_self;
+	self->set(p_idx, p_data);
 }
 
-uint8_t GDAPI godot_pool_byte_array_get(const godot_pool_byte_array *p_pba, const godot_int p_idx) {
-	const PoolVector<uint8_t> *pba = (const PoolVector<uint8_t> *)p_pba;
-	return pba->get(p_idx);
+uint8_t GDAPI godot_pool_byte_array_get(const godot_pool_byte_array *p_self, const godot_int p_idx) {
+	const PoolVector<uint8_t> *self = (const PoolVector<uint8_t> *)p_self;
+	return self->get(p_idx);
 }
 
-godot_int GDAPI godot_pool_byte_array_size(const godot_pool_byte_array *p_pba) {
-	const PoolVector<uint8_t> *pba = (const PoolVector<uint8_t> *)p_pba;
-	return pba->size();
+godot_int GDAPI godot_pool_byte_array_size(const godot_pool_byte_array *p_self) {
+	const PoolVector<uint8_t> *self = (const PoolVector<uint8_t> *)p_self;
+	return self->size();
 }
 
-void GDAPI godot_pool_byte_array_destroy(godot_pool_byte_array *p_pba) {
-	((PoolVector<uint8_t> *)p_pba)->~PoolVector();
+void GDAPI godot_pool_byte_array_destroy(godot_pool_byte_array *p_self) {
+	((PoolVector<uint8_t> *)p_self)->~PoolVector();
 }
 
 // int
 
-void GDAPI godot_pool_int_array_new(godot_pool_int_array *p_pba) {
-	PoolVector<godot_int> *pba = (PoolVector<godot_int> *)p_pba;
-	memnew_placement(pba, PoolVector<godot_int>);
+void GDAPI godot_pool_int_array_new(godot_pool_int_array *r_dest) {
+	PoolVector<godot_int> *dest = (PoolVector<godot_int> *)r_dest;
+	memnew_placement(dest, PoolVector<godot_int>);
 }
 
-void GDAPI godot_pool_int_array_new_copy(godot_pool_int_array *p_dest, const godot_pool_int_array *p_src) {
-	PoolVector<godot_int> *dest = (PoolVector<godot_int> *)p_dest;
+void GDAPI godot_pool_int_array_new_copy(godot_pool_int_array *r_dest, const godot_pool_int_array *p_src) {
+	PoolVector<godot_int> *dest = (PoolVector<godot_int> *)r_dest;
 	const PoolVector<godot_int> *src = (const PoolVector<godot_int> *)p_src;
 	memnew_placement(dest, PoolVector<godot_int>(*src));
 }
 
-void GDAPI godot_pool_int_array_new_with_array(godot_pool_int_array *p_pba, const godot_array *p_a) {
-	PoolVector<godot_int> *pba = (PoolVector<godot_int> *)p_pba;
+void GDAPI godot_pool_int_array_new_with_array(godot_pool_int_array *r_dest, const godot_array *p_a) {
+	PoolVector<godot_int> *dest = (PoolVector<godot_int> *)r_dest;
 	Array *a = (Array *)p_a;
-	memnew_placement(pba, PoolVector<godot_int>);
+	memnew_placement(dest, PoolVector<godot_int>);
 
-	pba->resize(a->size());
+	dest->resize(a->size());
 	for (size_t i = 0; i < a->size(); i++) {
-		pba->set(i, (*a)[i]);
+		dest->set(i, (*a)[i]);
 	}
 }
 
-void GDAPI godot_pool_int_array_append(godot_pool_int_array *p_pba, const godot_int p_data) {
-	PoolVector<godot_int> *pba = (PoolVector<godot_int> *)p_pba;
-	pba->append(p_data);
+void GDAPI godot_pool_int_array_append(godot_pool_int_array *p_self, const godot_int p_data) {
+	PoolVector<godot_int> *self = (PoolVector<godot_int> *)p_self;
+	self->append(p_data);
 }
 
-void GDAPI godot_pool_int_array_append_array(godot_pool_int_array *p_pba, const godot_pool_int_array *p_array) {
-	PoolVector<godot_int> *pba = (PoolVector<godot_int> *)p_pba;
+void GDAPI godot_pool_int_array_append_array(godot_pool_int_array *p_self, const godot_pool_int_array *p_array) {
+	PoolVector<godot_int> *self = (PoolVector<godot_int> *)p_self;
 	PoolVector<godot_int> *array = (PoolVector<godot_int> *)p_array;
-	pba->append_array(*array);
+	self->append_array(*array);
 }
 
-int GDAPI godot_pool_int_array_insert(godot_pool_int_array *p_pba, const godot_int p_idx, const godot_int p_data) {
-	PoolVector<godot_int> *pba = (PoolVector<godot_int> *)p_pba;
-	return pba->insert(p_idx, p_data);
+godot_error GDAPI godot_pool_int_array_insert(godot_pool_int_array *p_self, const godot_int p_idx, const godot_int p_data) {
+	PoolVector<godot_int> *self = (PoolVector<godot_int> *)p_self;
+	return (godot_error)self->insert(p_idx, p_data);
 }
 
-void GDAPI godot_pool_int_array_invert(godot_pool_int_array *p_pba) {
-	PoolVector<godot_int> *pba = (PoolVector<godot_int> *)p_pba;
-	pba->invert();
+void GDAPI godot_pool_int_array_invert(godot_pool_int_array *p_self) {
+	PoolVector<godot_int> *self = (PoolVector<godot_int> *)p_self;
+	self->invert();
 }
 
-void GDAPI godot_pool_int_array_push_back(godot_pool_int_array *p_pba, const godot_int p_data) {
-	PoolVector<godot_int> *pba = (PoolVector<godot_int> *)p_pba;
-	pba->push_back(p_data);
+void GDAPI godot_pool_int_array_push_back(godot_pool_int_array *p_self, const godot_int p_data) {
+	PoolVector<godot_int> *self = (PoolVector<godot_int> *)p_self;
+	self->push_back(p_data);
 }
 
-void GDAPI godot_pool_int_array_remove(godot_pool_int_array *p_pba, const godot_int p_idx) {
-	PoolVector<godot_int> *pba = (PoolVector<godot_int> *)p_pba;
-	pba->remove(p_idx);
+void GDAPI godot_pool_int_array_remove(godot_pool_int_array *p_self, const godot_int p_idx) {
+	PoolVector<godot_int> *self = (PoolVector<godot_int> *)p_self;
+	self->remove(p_idx);
 }
 
-void GDAPI godot_pool_int_array_resize(godot_pool_int_array *p_pba, const godot_int p_size) {
-	PoolVector<godot_int> *pba = (PoolVector<godot_int> *)p_pba;
-	pba->resize(p_size);
+void GDAPI godot_pool_int_array_resize(godot_pool_int_array *p_self, const godot_int p_size) {
+	PoolVector<godot_int> *self = (PoolVector<godot_int> *)p_self;
+	self->resize(p_size);
 }
 
-void GDAPI godot_pool_int_array_set(godot_pool_int_array *p_pba, const godot_int p_idx, const godot_int p_data) {
-	PoolVector<godot_int> *pba = (PoolVector<godot_int> *)p_pba;
-	pba->set(p_idx, p_data);
+void GDAPI godot_pool_int_array_set(godot_pool_int_array *p_self, const godot_int p_idx, const godot_int p_data) {
+	PoolVector<godot_int> *self = (PoolVector<godot_int> *)p_self;
+	self->set(p_idx, p_data);
 }
 
-godot_int GDAPI godot_pool_int_array_get(const godot_pool_int_array *p_pba, const godot_int p_idx) {
-	const PoolVector<godot_int> *pba = (const PoolVector<godot_int> *)p_pba;
-	return pba->get(p_idx);
+godot_int GDAPI godot_pool_int_array_get(const godot_pool_int_array *p_self, const godot_int p_idx) {
+	const PoolVector<godot_int> *self = (const PoolVector<godot_int> *)p_self;
+	return self->get(p_idx);
 }
 
-godot_int GDAPI godot_pool_int_array_size(const godot_pool_int_array *p_pba) {
-	const PoolVector<godot_int> *pba = (const PoolVector<godot_int> *)p_pba;
-	return pba->size();
+godot_int GDAPI godot_pool_int_array_size(const godot_pool_int_array *p_self) {
+	const PoolVector<godot_int> *self = (const PoolVector<godot_int> *)p_self;
+	return self->size();
 }
 
-void GDAPI godot_pool_int_array_destroy(godot_pool_int_array *p_pba) {
-	((PoolVector<godot_int> *)p_pba)->~PoolVector();
+void GDAPI godot_pool_int_array_destroy(godot_pool_int_array *p_self) {
+	((PoolVector<godot_int> *)p_self)->~PoolVector();
 }
 
 // real
 
-void GDAPI godot_pool_real_array_new(godot_pool_real_array *p_pba) {
-	PoolVector<godot_real> *pba = (PoolVector<godot_real> *)p_pba;
-	memnew_placement(pba, PoolVector<godot_real>);
+void GDAPI godot_pool_real_array_new(godot_pool_real_array *r_dest) {
+	PoolVector<godot_real> *dest = (PoolVector<godot_real> *)r_dest;
+	memnew_placement(dest, PoolVector<godot_real>);
 }
 
-void GDAPI godot_pool_real_array_new_copy(godot_pool_real_array *p_dest, const godot_pool_real_array *p_src) {
-	PoolVector<godot_real> *dest = (PoolVector<godot_real> *)p_dest;
+void GDAPI godot_pool_real_array_new_copy(godot_pool_real_array *r_dest, const godot_pool_real_array *p_src) {
+	PoolVector<godot_real> *dest = (PoolVector<godot_real> *)r_dest;
 	const PoolVector<godot_real> *src = (const PoolVector<godot_real> *)p_src;
 	memnew_placement(dest, PoolVector<godot_real>(*src));
 }
 
-void GDAPI godot_pool_real_array_new_with_array(godot_pool_real_array *p_pba, const godot_array *p_a) {
-	PoolVector<godot_real> *pba = (PoolVector<godot_real> *)p_pba;
+void GDAPI godot_pool_real_array_new_with_array(godot_pool_real_array *r_dest, const godot_array *p_a) {
+	PoolVector<godot_real> *dest = (PoolVector<godot_real> *)r_dest;
 	Array *a = (Array *)p_a;
-	memnew_placement(pba, PoolVector<godot_real>);
+	memnew_placement(dest, PoolVector<godot_real>);
 
-	pba->resize(a->size());
+	dest->resize(a->size());
 	for (size_t i = 0; i < a->size(); i++) {
-		pba->set(i, (*a)[i]);
+		dest->set(i, (*a)[i]);
 	}
 }
 
-void GDAPI godot_pool_real_array_append(godot_pool_real_array *p_pba, const godot_real p_data) {
-	PoolVector<godot_real> *pba = (PoolVector<godot_real> *)p_pba;
-	pba->append(p_data);
+void GDAPI godot_pool_real_array_append(godot_pool_real_array *p_self, const godot_real p_data) {
+	PoolVector<godot_real> *self = (PoolVector<godot_real> *)p_self;
+	self->append(p_data);
 }
 
-void GDAPI godot_pool_real_array_append_array(godot_pool_real_array *p_pba, const godot_pool_real_array *p_array) {
-	PoolVector<godot_real> *pba = (PoolVector<godot_real> *)p_pba;
+void GDAPI godot_pool_real_array_append_array(godot_pool_real_array *p_self, const godot_pool_real_array *p_array) {
+	PoolVector<godot_real> *self = (PoolVector<godot_real> *)p_self;
 	PoolVector<godot_real> *array = (PoolVector<godot_real> *)p_array;
-	pba->append_array(*array);
+	self->append_array(*array);
 }
 
-int GDAPI godot_pool_real_array_insert(godot_pool_real_array *p_pba, const godot_int p_idx, const godot_real p_data) {
-	PoolVector<godot_real> *pba = (PoolVector<godot_real> *)p_pba;
-	return pba->insert(p_idx, p_data);
+godot_error GDAPI godot_pool_real_array_insert(godot_pool_real_array *p_self, const godot_int p_idx, const godot_real p_data) {
+	PoolVector<godot_real> *self = (PoolVector<godot_real> *)p_self;
+	return (godot_error)self->insert(p_idx, p_data);
 }
 
-void GDAPI godot_pool_real_array_invert(godot_pool_real_array *p_pba) {
-	PoolVector<godot_real> *pba = (PoolVector<godot_real> *)p_pba;
-	pba->invert();
+void GDAPI godot_pool_real_array_invert(godot_pool_real_array *p_self) {
+	PoolVector<godot_real> *self = (PoolVector<godot_real> *)p_self;
+	self->invert();
 }
 
-void GDAPI godot_pool_real_array_push_back(godot_pool_real_array *p_pba, const godot_real p_data) {
-	PoolVector<godot_real> *pba = (PoolVector<godot_real> *)p_pba;
-	pba->push_back(p_data);
+void GDAPI godot_pool_real_array_push_back(godot_pool_real_array *p_self, const godot_real p_data) {
+	PoolVector<godot_real> *self = (PoolVector<godot_real> *)p_self;
+	self->push_back(p_data);
 }
 
-void GDAPI godot_pool_real_array_remove(godot_pool_real_array *p_pba, const godot_int p_idx) {
-	PoolVector<godot_real> *pba = (PoolVector<godot_real> *)p_pba;
-	pba->remove(p_idx);
+void GDAPI godot_pool_real_array_remove(godot_pool_real_array *p_self, const godot_int p_idx) {
+	PoolVector<godot_real> *self = (PoolVector<godot_real> *)p_self;
+	self->remove(p_idx);
 }
 
-void GDAPI godot_pool_real_array_resize(godot_pool_real_array *p_pba, const godot_int p_size) {
-	PoolVector<godot_int> *pba = (PoolVector<godot_int> *)p_pba;
-	pba->resize(p_size);
+void GDAPI godot_pool_real_array_resize(godot_pool_real_array *p_self, const godot_int p_size) {
+	PoolVector<godot_int> *self = (PoolVector<godot_int> *)p_self;
+	self->resize(p_size);
 }
 
-void GDAPI godot_pool_real_array_set(godot_pool_real_array *p_pba, const godot_int p_idx, const godot_real p_data) {
-	PoolVector<godot_real> *pba = (PoolVector<godot_real> *)p_pba;
-	pba->set(p_idx, p_data);
+void GDAPI godot_pool_real_array_set(godot_pool_real_array *p_self, const godot_int p_idx, const godot_real p_data) {
+	PoolVector<godot_real> *self = (PoolVector<godot_real> *)p_self;
+	self->set(p_idx, p_data);
 }
 
-godot_real GDAPI godot_pool_real_array_get(const godot_pool_real_array *p_pba, const godot_int p_idx) {
-	const PoolVector<godot_real> *pba = (const PoolVector<godot_real> *)p_pba;
-	return pba->get(p_idx);
+godot_real GDAPI godot_pool_real_array_get(const godot_pool_real_array *p_self, const godot_int p_idx) {
+	const PoolVector<godot_real> *self = (const PoolVector<godot_real> *)p_self;
+	return self->get(p_idx);
 }
 
-godot_int GDAPI godot_pool_real_array_size(const godot_pool_real_array *p_pba) {
-	const PoolVector<godot_real> *pba = (const PoolVector<godot_real> *)p_pba;
-	return pba->size();
+godot_int GDAPI godot_pool_real_array_size(const godot_pool_real_array *p_self) {
+	const PoolVector<godot_real> *self = (const PoolVector<godot_real> *)p_self;
+	return self->size();
 }
 
-void GDAPI godot_pool_real_array_destroy(godot_pool_real_array *p_pba) {
-	((PoolVector<godot_real> *)p_pba)->~PoolVector();
+void GDAPI godot_pool_real_array_destroy(godot_pool_real_array *p_self) {
+	((PoolVector<godot_real> *)p_self)->~PoolVector();
 }
 
 // string
 
-void GDAPI godot_pool_string_array_new(godot_pool_string_array *p_pba) {
-	PoolVector<String> *pba = (PoolVector<String> *)p_pba;
-	memnew_placement(pba, PoolVector<String>);
+void GDAPI godot_pool_string_array_new(godot_pool_string_array *r_dest) {
+	PoolVector<String> *dest = (PoolVector<String> *)r_dest;
+	memnew_placement(dest, PoolVector<String>);
 }
 
-void GDAPI godot_pool_string_array_new_copy(godot_pool_string_array *p_dest, const godot_pool_string_array *p_src) {
-	PoolVector<String> *dest = (PoolVector<String> *)p_dest;
+void GDAPI godot_pool_string_array_new_copy(godot_pool_string_array *r_dest, const godot_pool_string_array *p_src) {
+	PoolVector<String> *dest = (PoolVector<String> *)r_dest;
 	const PoolVector<String> *src = (const PoolVector<String> *)p_src;
 	memnew_placement(dest, PoolVector<String>(*src));
 }
 
-void GDAPI godot_pool_string_array_new_with_array(godot_pool_string_array *p_pba, const godot_array *p_a) {
-	PoolVector<String> *pba = (PoolVector<String> *)p_pba;
+void GDAPI godot_pool_string_array_new_with_array(godot_pool_string_array *r_dest, const godot_array *p_a) {
+	PoolVector<String> *dest = (PoolVector<String> *)r_dest;
 	Array *a = (Array *)p_a;
-	memnew_placement(pba, PoolVector<String>);
+	memnew_placement(dest, PoolVector<String>);
 
-	pba->resize(a->size());
+	dest->resize(a->size());
 	for (size_t i = 0; i < a->size(); i++) {
-		pba->set(i, (*a)[i]);
+		dest->set(i, (*a)[i]);
 	}
 }
 
-void GDAPI godot_pool_string_array_append(godot_pool_string_array *p_pba, const godot_string *p_data) {
-	PoolVector<String> *pba = (PoolVector<String> *)p_pba;
+void GDAPI godot_pool_string_array_append(godot_pool_string_array *p_self, const godot_string *p_data) {
+	PoolVector<String> *self = (PoolVector<String> *)p_self;
 	String &s = *(String *)p_data;
-	pba->append(s);
+	self->append(s);
 }
 
-void GDAPI godot_pool_string_array_append_array(godot_pool_string_array *p_pba, const godot_pool_string_array *p_array) {
-	PoolVector<String> *pba = (PoolVector<String> *)p_pba;
+void GDAPI godot_pool_string_array_append_array(godot_pool_string_array *p_self, const godot_pool_string_array *p_array) {
+	PoolVector<String> *self = (PoolVector<String> *)p_self;
 	PoolVector<String> *array = (PoolVector<String> *)p_array;
-	pba->append_array(*array);
+	self->append_array(*array);
 }
 
-int GDAPI godot_pool_string_array_insert(godot_pool_string_array *p_pba, const godot_int p_idx, const godot_string *p_data) {
-	PoolVector<String> *pba = (PoolVector<String> *)p_pba;
+godot_error GDAPI godot_pool_string_array_insert(godot_pool_string_array *p_self, const godot_int p_idx, const godot_string *p_data) {
+	PoolVector<String> *self = (PoolVector<String> *)p_self;
 	String &s = *(String *)p_data;
-	return pba->insert(p_idx, s);
+	return (godot_error)self->insert(p_idx, s);
 }
 
-void GDAPI godot_pool_string_array_invert(godot_pool_string_array *p_pba) {
-	PoolVector<String> *pba = (PoolVector<String> *)p_pba;
-	pba->invert();
+void GDAPI godot_pool_string_array_invert(godot_pool_string_array *p_self) {
+	PoolVector<String> *self = (PoolVector<String> *)p_self;
+	self->invert();
 }
 
-void GDAPI godot_pool_string_array_push_back(godot_pool_string_array *p_pba, const godot_string *p_data) {
-	PoolVector<String> *pba = (PoolVector<String> *)p_pba;
+void GDAPI godot_pool_string_array_push_back(godot_pool_string_array *p_self, const godot_string *p_data) {
+	PoolVector<String> *self = (PoolVector<String> *)p_self;
 	String &s = *(String *)p_data;
-	pba->push_back(s);
+	self->push_back(s);
 }
 
-void GDAPI godot_pool_string_array_remove(godot_pool_string_array *p_pba, const godot_int p_idx) {
-	PoolVector<String> *pba = (PoolVector<String> *)p_pba;
-	pba->remove(p_idx);
+void GDAPI godot_pool_string_array_remove(godot_pool_string_array *p_self, const godot_int p_idx) {
+	PoolVector<String> *self = (PoolVector<String> *)p_self;
+	self->remove(p_idx);
 }
 
-void GDAPI godot_pool_string_array_resize(godot_pool_string_array *p_pba, const godot_int p_size) {
-	PoolVector<String> *pba = (PoolVector<String> *)p_pba;
-	pba->resize(p_size);
+void GDAPI godot_pool_string_array_resize(godot_pool_string_array *p_self, const godot_int p_size) {
+	PoolVector<String> *self = (PoolVector<String> *)p_self;
+	self->resize(p_size);
 }
 
-void GDAPI godot_pool_string_array_set(godot_pool_string_array *p_pba, const godot_int p_idx, const godot_string *p_data) {
-	PoolVector<String> *pba = (PoolVector<String> *)p_pba;
+void GDAPI godot_pool_string_array_set(godot_pool_string_array *p_self, const godot_int p_idx, const godot_string *p_data) {
+	PoolVector<String> *self = (PoolVector<String> *)p_self;
 	String &s = *(String *)p_data;
-	pba->set(p_idx, s);
+	self->set(p_idx, s);
 }
 
-godot_string GDAPI godot_pool_string_array_get(const godot_pool_string_array *p_pba, const godot_int p_idx) {
-	const PoolVector<String> *pba = (const PoolVector<String> *)p_pba;
+godot_string GDAPI godot_pool_string_array_get(const godot_pool_string_array *p_self, const godot_int p_idx) {
+	const PoolVector<String> *self = (const PoolVector<String> *)p_self;
 	godot_string str;
 	String *s = (String *)&str;
 	memnew_placement(s, String);
-	*s = pba->get(p_idx);
+	*s = self->get(p_idx);
 	return str;
 }
 
-godot_int GDAPI godot_pool_string_array_size(const godot_pool_string_array *p_pba) {
-	const PoolVector<String> *pba = (const PoolVector<String> *)p_pba;
-	return pba->size();
+godot_int GDAPI godot_pool_string_array_size(const godot_pool_string_array *p_self) {
+	const PoolVector<String> *self = (const PoolVector<String> *)p_self;
+	return self->size();
 }
 
-void GDAPI godot_pool_string_array_destroy(godot_pool_string_array *p_pba) {
-	((PoolVector<String> *)p_pba)->~PoolVector();
+void GDAPI godot_pool_string_array_destroy(godot_pool_string_array *p_self) {
+	((PoolVector<String> *)p_self)->~PoolVector();
 }
 
 // vector2
 
-void GDAPI godot_pool_vector2_array_new(godot_pool_vector2_array *p_pba) {
-	PoolVector<Vector2> *pba = (PoolVector<Vector2> *)p_pba;
-	memnew_placement(pba, PoolVector<Vector2>);
+void GDAPI godot_pool_vector2_array_new(godot_pool_vector2_array *r_dest) {
+	PoolVector<Vector2> *dest = (PoolVector<Vector2> *)r_dest;
+	memnew_placement(dest, PoolVector<Vector2>);
 }
 
-void GDAPI godot_pool_vector2_array_new_copy(godot_pool_vector2_array *p_dest, const godot_pool_vector2_array *p_src) {
-	PoolVector<Vector2> *dest = (PoolVector<Vector2> *)p_dest;
+void GDAPI godot_pool_vector2_array_new_copy(godot_pool_vector2_array *r_dest, const godot_pool_vector2_array *p_src) {
+	PoolVector<Vector2> *dest = (PoolVector<Vector2> *)r_dest;
 	const PoolVector<Vector2> *src = (const PoolVector<Vector2> *)p_src;
 	memnew_placement(dest, PoolVector<Vector2>(*src));
 }
 
-void GDAPI godot_pool_vector2_array_new_with_array(godot_pool_vector2_array *p_pba, const godot_array *p_a) {
-	PoolVector<Vector2> *pba = (PoolVector<Vector2> *)p_pba;
+void GDAPI godot_pool_vector2_array_new_with_array(godot_pool_vector2_array *r_dest, const godot_array *p_a) {
+	PoolVector<Vector2> *dest = (PoolVector<Vector2> *)r_dest;
 	Array *a = (Array *)p_a;
-	memnew_placement(pba, PoolVector<Vector2>);
+	memnew_placement(dest, PoolVector<Vector2>);
 
-	pba->resize(a->size());
+	dest->resize(a->size());
 	for (size_t i = 0; i < a->size(); i++) {
-		pba->set(i, (*a)[i]);
+		dest->set(i, (*a)[i]);
 	}
 }
 
-void GDAPI godot_pool_vector2_array_append(godot_pool_vector2_array *p_pba, const godot_vector2 *p_data) {
-	PoolVector<Vector2> *pba = (PoolVector<Vector2> *)p_pba;
+void GDAPI godot_pool_vector2_array_append(godot_pool_vector2_array *p_self, const godot_vector2 *p_data) {
+	PoolVector<Vector2> *self = (PoolVector<Vector2> *)p_self;
 	Vector2 &s = *(Vector2 *)p_data;
-	pba->append(s);
+	self->append(s);
 }
 
-void GDAPI godot_pool_vector2_array_append_array(godot_pool_vector2_array *p_pba, const godot_pool_vector2_array *p_array) {
-	PoolVector<Vector2> *pba = (PoolVector<Vector2> *)p_pba;
+void GDAPI godot_pool_vector2_array_append_array(godot_pool_vector2_array *p_self, const godot_pool_vector2_array *p_array) {
+	PoolVector<Vector2> *self = (PoolVector<Vector2> *)p_self;
 	PoolVector<Vector2> *array = (PoolVector<Vector2> *)p_array;
-	pba->append_array(*array);
+	self->append_array(*array);
 }
 
-int GDAPI godot_pool_vector2_array_insert(godot_pool_vector2_array *p_pba, const godot_int p_idx, const godot_vector2 *p_data) {
-	PoolVector<Vector2> *pba = (PoolVector<Vector2> *)p_pba;
+godot_error GDAPI godot_pool_vector2_array_insert(godot_pool_vector2_array *p_self, const godot_int p_idx, const godot_vector2 *p_data) {
+	PoolVector<Vector2> *self = (PoolVector<Vector2> *)p_self;
 	Vector2 &s = *(Vector2 *)p_data;
-	return pba->insert(p_idx, s);
+	return (godot_error)self->insert(p_idx, s);
 }
 
-void GDAPI godot_pool_vector2_array_invert(godot_pool_vector2_array *p_pba) {
-	PoolVector<Vector2> *pba = (PoolVector<Vector2> *)p_pba;
-	pba->invert();
+void GDAPI godot_pool_vector2_array_invert(godot_pool_vector2_array *p_self) {
+	PoolVector<Vector2> *self = (PoolVector<Vector2> *)p_self;
+	self->invert();
 }
 
-void GDAPI godot_pool_vector2_array_push_back(godot_pool_vector2_array *p_pba, const godot_vector2 *p_data) {
-	PoolVector<Vector2> *pba = (PoolVector<Vector2> *)p_pba;
+void GDAPI godot_pool_vector2_array_push_back(godot_pool_vector2_array *p_self, const godot_vector2 *p_data) {
+	PoolVector<Vector2> *self = (PoolVector<Vector2> *)p_self;
 	Vector2 &s = *(Vector2 *)p_data;
-	pba->push_back(s);
+	self->push_back(s);
 }
 
-void GDAPI godot_pool_vector2_array_remove(godot_pool_vector2_array *p_pba, const godot_int p_idx) {
-	PoolVector<Vector2> *pba = (PoolVector<Vector2> *)p_pba;
-	pba->remove(p_idx);
+void GDAPI godot_pool_vector2_array_remove(godot_pool_vector2_array *p_self, const godot_int p_idx) {
+	PoolVector<Vector2> *self = (PoolVector<Vector2> *)p_self;
+	self->remove(p_idx);
 }
 
-void GDAPI godot_pool_vector2_array_resize(godot_pool_vector2_array *p_pba, const godot_int p_size) {
-	PoolVector<Vector2> *pba = (PoolVector<Vector2> *)p_pba;
-	pba->resize(p_size);
+void GDAPI godot_pool_vector2_array_resize(godot_pool_vector2_array *p_self, const godot_int p_size) {
+	PoolVector<Vector2> *self = (PoolVector<Vector2> *)p_self;
+	self->resize(p_size);
 }
 
-void GDAPI godot_pool_vector2_array_set(godot_pool_vector2_array *p_pba, const godot_int p_idx, const godot_vector2 *p_data) {
-	PoolVector<Vector2> *pba = (PoolVector<Vector2> *)p_pba;
+void GDAPI godot_pool_vector2_array_set(godot_pool_vector2_array *p_self, const godot_int p_idx, const godot_vector2 *p_data) {
+	PoolVector<Vector2> *self = (PoolVector<Vector2> *)p_self;
 	Vector2 &s = *(Vector2 *)p_data;
-	pba->set(p_idx, s);
+	self->set(p_idx, s);
 }
 
-godot_vector2 GDAPI godot_pool_vector2_array_get(const godot_pool_vector2_array *p_pba, const godot_int p_idx) {
-	const PoolVector<Vector2> *pba = (const PoolVector<Vector2> *)p_pba;
+godot_vector2 GDAPI godot_pool_vector2_array_get(const godot_pool_vector2_array *p_self, const godot_int p_idx) {
+	const PoolVector<Vector2> *self = (const PoolVector<Vector2> *)p_self;
 	godot_vector2 v;
 	Vector2 *s = (Vector2 *)&v;
-	*s = pba->get(p_idx);
+	*s = self->get(p_idx);
 	return v;
 }
 
-godot_int GDAPI godot_pool_vector2_array_size(const godot_pool_vector2_array *p_pba) {
-	const PoolVector<Vector2> *pba = (const PoolVector<Vector2> *)p_pba;
-	return pba->size();
+godot_int GDAPI godot_pool_vector2_array_size(const godot_pool_vector2_array *p_self) {
+	const PoolVector<Vector2> *self = (const PoolVector<Vector2> *)p_self;
+	return self->size();
 }
 
-void GDAPI godot_pool_vector2_array_destroy(godot_pool_vector2_array *p_pba) {
-	((PoolVector<Vector2> *)p_pba)->~PoolVector();
+void GDAPI godot_pool_vector2_array_destroy(godot_pool_vector2_array *p_self) {
+	((PoolVector<Vector2> *)p_self)->~PoolVector();
 }
 
 // vector3
 
-void GDAPI godot_pool_vector3_array_new(godot_pool_vector3_array *p_pba) {
-	PoolVector<Vector3> *pba = (PoolVector<Vector3> *)p_pba;
-	memnew_placement(pba, PoolVector<Vector3>);
+void GDAPI godot_pool_vector3_array_new(godot_pool_vector3_array *r_dest) {
+	PoolVector<Vector3> *dest = (PoolVector<Vector3> *)r_dest;
+	memnew_placement(dest, PoolVector<Vector3>);
 }
 
-void GDAPI godot_pool_vector3_array_new_copy(godot_pool_vector3_array *p_dest, const godot_pool_vector3_array *p_src) {
-	PoolVector<Vector3> *dest = (PoolVector<Vector3> *)p_dest;
+void GDAPI godot_pool_vector3_array_new_copy(godot_pool_vector3_array *r_dest, const godot_pool_vector3_array *p_src) {
+	PoolVector<Vector3> *dest = (PoolVector<Vector3> *)r_dest;
 	const PoolVector<Vector3> *src = (const PoolVector<Vector3> *)p_src;
 	memnew_placement(dest, PoolVector<Vector3>(*src));
 }
 
-void GDAPI godot_pool_vector3_array_new_with_array(godot_pool_vector3_array *p_pba, const godot_array *p_a) {
-	PoolVector<Vector3> *pba = (PoolVector<Vector3> *)p_pba;
+void GDAPI godot_pool_vector3_array_new_with_array(godot_pool_vector3_array *r_dest, const godot_array *p_a) {
+	PoolVector<Vector3> *dest = (PoolVector<Vector3> *)r_dest;
 	Array *a = (Array *)p_a;
-	memnew_placement(pba, PoolVector<Vector3>);
+	memnew_placement(dest, PoolVector<Vector3>);
 
-	pba->resize(a->size());
+	dest->resize(a->size());
 	for (size_t i = 0; i < a->size(); i++) {
-		pba->set(i, (*a)[i]);
+		dest->set(i, (*a)[i]);
 	}
 }
 
-void GDAPI godot_pool_vector3_array_append(godot_pool_vector3_array *p_pba, const godot_vector3 *p_data) {
-	PoolVector<Vector3> *pba = (PoolVector<Vector3> *)p_pba;
+void GDAPI godot_pool_vector3_array_append(godot_pool_vector3_array *p_self, const godot_vector3 *p_data) {
+	PoolVector<Vector3> *self = (PoolVector<Vector3> *)p_self;
 	Vector3 &s = *(Vector3 *)p_data;
-	pba->append(s);
+	self->append(s);
 }
 
-void GDAPI godot_pool_vector3_array_append_array(godot_pool_vector3_array *p_pba, const godot_pool_vector3_array *p_array) {
-	PoolVector<Vector3> *pba = (PoolVector<Vector3> *)p_pba;
+void GDAPI godot_pool_vector3_array_append_array(godot_pool_vector3_array *p_self, const godot_pool_vector3_array *p_array) {
+	PoolVector<Vector3> *self = (PoolVector<Vector3> *)p_self;
 	PoolVector<Vector3> *array = (PoolVector<Vector3> *)p_array;
-	pba->append_array(*array);
+	self->append_array(*array);
 }
 
-int GDAPI godot_pool_vector3_array_insert(godot_pool_vector3_array *p_pba, const godot_int p_idx, const godot_vector3 *p_data) {
-	PoolVector<Vector3> *pba = (PoolVector<Vector3> *)p_pba;
+godot_error GDAPI godot_pool_vector3_array_insert(godot_pool_vector3_array *p_self, const godot_int p_idx, const godot_vector3 *p_data) {
+	PoolVector<Vector3> *self = (PoolVector<Vector3> *)p_self;
 	Vector3 &s = *(Vector3 *)p_data;
-	return pba->insert(p_idx, s);
+	return (godot_error)self->insert(p_idx, s);
 }
 
-void GDAPI godot_pool_vector3_array_invert(godot_pool_vector3_array *p_pba) {
-	PoolVector<Vector3> *pba = (PoolVector<Vector3> *)p_pba;
-	pba->invert();
+void GDAPI godot_pool_vector3_array_invert(godot_pool_vector3_array *p_self) {
+	PoolVector<Vector3> *self = (PoolVector<Vector3> *)p_self;
+	self->invert();
 }
 
-void GDAPI godot_pool_vector3_array_push_back(godot_pool_vector3_array *p_pba, const godot_vector3 *p_data) {
-	PoolVector<Vector3> *pba = (PoolVector<Vector3> *)p_pba;
+void GDAPI godot_pool_vector3_array_push_back(godot_pool_vector3_array *p_self, const godot_vector3 *p_data) {
+	PoolVector<Vector3> *self = (PoolVector<Vector3> *)p_self;
 	Vector3 &s = *(Vector3 *)p_data;
-	pba->push_back(s);
+	self->push_back(s);
 }
 
-void GDAPI godot_pool_vector3_array_remove(godot_pool_vector3_array *p_pba, const godot_int p_idx) {
-	PoolVector<Vector3> *pba = (PoolVector<Vector3> *)p_pba;
-	pba->remove(p_idx);
+void GDAPI godot_pool_vector3_array_remove(godot_pool_vector3_array *p_self, const godot_int p_idx) {
+	PoolVector<Vector3> *self = (PoolVector<Vector3> *)p_self;
+	self->remove(p_idx);
 }
 
-void GDAPI godot_pool_vector3_array_resize(godot_pool_vector3_array *p_pba, const godot_int p_size) {
-	PoolVector<Vector3> *pba = (PoolVector<Vector3> *)p_pba;
-	pba->resize(p_size);
+void GDAPI godot_pool_vector3_array_resize(godot_pool_vector3_array *p_self, const godot_int p_size) {
+	PoolVector<Vector3> *self = (PoolVector<Vector3> *)p_self;
+	self->resize(p_size);
 }
 
-void GDAPI godot_pool_vector3_array_set(godot_pool_vector3_array *p_pba, const godot_int p_idx, const godot_vector3 *p_data) {
-	PoolVector<Vector3> *pba = (PoolVector<Vector3> *)p_pba;
+void GDAPI godot_pool_vector3_array_set(godot_pool_vector3_array *p_self, const godot_int p_idx, const godot_vector3 *p_data) {
+	PoolVector<Vector3> *self = (PoolVector<Vector3> *)p_self;
 	Vector3 &s = *(Vector3 *)p_data;
-	pba->set(p_idx, s);
+	self->set(p_idx, s);
 }
 
-godot_vector3 GDAPI godot_pool_vector3_array_get(const godot_pool_vector3_array *p_pba, const godot_int p_idx) {
-	const PoolVector<Vector3> *pba = (const PoolVector<Vector3> *)p_pba;
+godot_vector3 GDAPI godot_pool_vector3_array_get(const godot_pool_vector3_array *p_self, const godot_int p_idx) {
+	const PoolVector<Vector3> *self = (const PoolVector<Vector3> *)p_self;
 	godot_vector3 v;
 	Vector3 *s = (Vector3 *)&v;
-	*s = pba->get(p_idx);
+	*s = self->get(p_idx);
 	return v;
 }
 
-godot_int GDAPI godot_pool_vector3_array_size(const godot_pool_vector3_array *p_pba) {
-	const PoolVector<Vector3> *pba = (const PoolVector<Vector3> *)p_pba;
-	return pba->size();
+godot_int GDAPI godot_pool_vector3_array_size(const godot_pool_vector3_array *p_self) {
+	const PoolVector<Vector3> *self = (const PoolVector<Vector3> *)p_self;
+	return self->size();
 }
 
-void GDAPI godot_pool_vector3_array_destroy(godot_pool_vector3_array *p_pba) {
-	((PoolVector<Vector3> *)p_pba)->~PoolVector();
+void GDAPI godot_pool_vector3_array_destroy(godot_pool_vector3_array *p_self) {
+	((PoolVector<Vector3> *)p_self)->~PoolVector();
 }
 
 // color
 
-void GDAPI godot_pool_color_array_new(godot_pool_color_array *p_pba) {
-	PoolVector<Color> *pba = (PoolVector<Color> *)p_pba;
-	memnew_placement(pba, PoolVector<Color>);
+void GDAPI godot_pool_color_array_new(godot_pool_color_array *r_dest) {
+	PoolVector<Color> *dest = (PoolVector<Color> *)r_dest;
+	memnew_placement(dest, PoolVector<Color>);
 }
 
-void GDAPI godot_pool_color_array_new_copy(godot_pool_color_array *p_dest, const godot_pool_color_array *p_src) {
-	PoolVector<Color> *dest = (PoolVector<Color> *)p_dest;
+void GDAPI godot_pool_color_array_new_copy(godot_pool_color_array *r_dest, const godot_pool_color_array *p_src) {
+	PoolVector<Color> *dest = (PoolVector<Color> *)r_dest;
 	const PoolVector<Color> *src = (const PoolVector<Color> *)p_src;
 	memnew_placement(dest, PoolVector<Color>(*src));
 }
 
-void GDAPI godot_pool_color_array_new_with_array(godot_pool_color_array *p_pba, const godot_array *p_a) {
-	PoolVector<Color> *pba = (PoolVector<Color> *)p_pba;
+void GDAPI godot_pool_color_array_new_with_array(godot_pool_color_array *r_dest, const godot_array *p_a) {
+	PoolVector<Color> *dest = (PoolVector<Color> *)r_dest;
 	Array *a = (Array *)p_a;
-	memnew_placement(pba, PoolVector<Color>);
+	memnew_placement(dest, PoolVector<Color>);
 
-	pba->resize(a->size());
+	dest->resize(a->size());
 	for (size_t i = 0; i < a->size(); i++) {
-		pba->set(i, (*a)[i]);
+		dest->set(i, (*a)[i]);
 	}
 }
 
-void GDAPI godot_pool_color_array_append(godot_pool_color_array *p_pba, const godot_color *p_data) {
-	PoolVector<Color> *pba = (PoolVector<Color> *)p_pba;
+void GDAPI godot_pool_color_array_append(godot_pool_color_array *p_self, const godot_color *p_data) {
+	PoolVector<Color> *self = (PoolVector<Color> *)p_self;
 	Color &s = *(Color *)p_data;
-	pba->append(s);
+	self->append(s);
 }
 
-void GDAPI godot_pool_color_array_append_array(godot_pool_color_array *p_pba, const godot_pool_color_array *p_array) {
-	PoolVector<Color> *pba = (PoolVector<Color> *)p_pba;
+void GDAPI godot_pool_color_array_append_array(godot_pool_color_array *p_self, const godot_pool_color_array *p_array) {
+	PoolVector<Color> *self = (PoolVector<Color> *)p_self;
 	PoolVector<Color> *array = (PoolVector<Color> *)p_array;
-	pba->append_array(*array);
+	self->append_array(*array);
 }
 
-int GDAPI godot_pool_color_array_insert(godot_pool_color_array *p_pba, const godot_int p_idx, const godot_color *p_data) {
-	PoolVector<Color> *pba = (PoolVector<Color> *)p_pba;
+godot_error GDAPI godot_pool_color_array_insert(godot_pool_color_array *p_self, const godot_int p_idx, const godot_color *p_data) {
+	PoolVector<Color> *self = (PoolVector<Color> *)p_self;
 	Color &s = *(Color *)p_data;
-	return pba->insert(p_idx, s);
+	return (godot_error)self->insert(p_idx, s);
 }
 
-void GDAPI godot_pool_color_array_invert(godot_pool_color_array *p_pba) {
-	PoolVector<Color> *pba = (PoolVector<Color> *)p_pba;
-	pba->invert();
+void GDAPI godot_pool_color_array_invert(godot_pool_color_array *p_self) {
+	PoolVector<Color> *self = (PoolVector<Color> *)p_self;
+	self->invert();
 }
 
-void GDAPI godot_pool_color_array_push_back(godot_pool_color_array *p_pba, const godot_color *p_data) {
-	PoolVector<Color> *pba = (PoolVector<Color> *)p_pba;
+void GDAPI godot_pool_color_array_push_back(godot_pool_color_array *p_self, const godot_color *p_data) {
+	PoolVector<Color> *self = (PoolVector<Color> *)p_self;
 	Color &s = *(Color *)p_data;
-	pba->push_back(s);
+	self->push_back(s);
 }
 
-void GDAPI godot_pool_color_array_remove(godot_pool_color_array *p_pba, const godot_int p_idx) {
-	PoolVector<Color> *pba = (PoolVector<Color> *)p_pba;
-	pba->remove(p_idx);
+void GDAPI godot_pool_color_array_remove(godot_pool_color_array *p_self, const godot_int p_idx) {
+	PoolVector<Color> *self = (PoolVector<Color> *)p_self;
+	self->remove(p_idx);
 }
 
-void GDAPI godot_pool_color_array_resize(godot_pool_color_array *p_pba, const godot_int p_size) {
-	PoolVector<Color> *pba = (PoolVector<Color> *)p_pba;
-	pba->resize(p_size);
+void GDAPI godot_pool_color_array_resize(godot_pool_color_array *p_self, const godot_int p_size) {
+	PoolVector<Color> *self = (PoolVector<Color> *)p_self;
+	self->resize(p_size);
 }
 
-void GDAPI godot_pool_color_array_set(godot_pool_color_array *p_pba, const godot_int p_idx, const godot_color *p_data) {
-	PoolVector<Color> *pba = (PoolVector<Color> *)p_pba;
+void GDAPI godot_pool_color_array_set(godot_pool_color_array *p_self, const godot_int p_idx, const godot_color *p_data) {
+	PoolVector<Color> *self = (PoolVector<Color> *)p_self;
 	Color &s = *(Color *)p_data;
-	pba->set(p_idx, s);
+	self->set(p_idx, s);
 }
 
-godot_color GDAPI godot_pool_color_array_get(const godot_pool_color_array *p_pba, const godot_int p_idx) {
-	const PoolVector<Color> *pba = (const PoolVector<Color> *)p_pba;
+godot_color GDAPI godot_pool_color_array_get(const godot_pool_color_array *p_self, const godot_int p_idx) {
+	const PoolVector<Color> *self = (const PoolVector<Color> *)p_self;
 	godot_color v;
 	Color *s = (Color *)&v;
-	*s = pba->get(p_idx);
+	*s = self->get(p_idx);
 	return v;
 }
 
-godot_int GDAPI godot_pool_color_array_size(const godot_pool_color_array *p_pba) {
-	const PoolVector<Color> *pba = (const PoolVector<Color> *)p_pba;
-	return pba->size();
+godot_int GDAPI godot_pool_color_array_size(const godot_pool_color_array *p_self) {
+	const PoolVector<Color> *self = (const PoolVector<Color> *)p_self;
+	return self->size();
 }
 
-void GDAPI godot_pool_color_array_destroy(godot_pool_color_array *p_pba) {
-	((PoolVector<Color> *)p_pba)->~PoolVector();
+void GDAPI godot_pool_color_array_destroy(godot_pool_color_array *p_self) {
+	((PoolVector<Color> *)p_self)->~PoolVector();
 }
 
 #ifdef __cplusplus

--- a/modules/gdnative/godot/godot_pool_arrays.h
+++ b/modules/gdnative/godot/godot_pool_arrays.h
@@ -101,192 +101,192 @@ typedef struct godot_pool_color_array {
 
 // byte
 
-void GDAPI godot_pool_byte_array_new(godot_pool_byte_array *p_pba);
-void GDAPI godot_pool_byte_array_new_copy(godot_pool_byte_array *p_dest, const godot_pool_byte_array *p_src);
-void GDAPI godot_pool_byte_array_new_with_array(godot_pool_byte_array *p_pba, const godot_array *p_a);
+void GDAPI godot_pool_byte_array_new(godot_pool_byte_array *r_dest);
+void GDAPI godot_pool_byte_array_new_copy(godot_pool_byte_array *r_dest, const godot_pool_byte_array *p_src);
+void GDAPI godot_pool_byte_array_new_with_array(godot_pool_byte_array *r_dest, const godot_array *p_a);
 
-void GDAPI godot_pool_byte_array_append(godot_pool_byte_array *p_pba, const uint8_t p_data);
+void GDAPI godot_pool_byte_array_append(godot_pool_byte_array *p_self, const uint8_t p_data);
 
-void GDAPI godot_pool_byte_array_append_array(godot_pool_byte_array *p_pba, const godot_pool_byte_array *p_array);
+void GDAPI godot_pool_byte_array_append_array(godot_pool_byte_array *p_self, const godot_pool_byte_array *p_array);
 
-int GDAPI godot_pool_byte_array_insert(godot_pool_byte_array *p_pba, const godot_int p_idx, const uint8_t p_data);
+godot_error GDAPI godot_pool_byte_array_insert(godot_pool_byte_array *p_self, const godot_int p_idx, const uint8_t p_data);
 
-void GDAPI godot_pool_byte_array_invert(godot_pool_byte_array *p_pba);
+void GDAPI godot_pool_byte_array_invert(godot_pool_byte_array *p_self);
 
-void GDAPI godot_pool_byte_array_push_back(godot_pool_byte_array *p_pba, const uint8_t p_data);
+void GDAPI godot_pool_byte_array_push_back(godot_pool_byte_array *p_self, const uint8_t p_data);
 
-void GDAPI godot_pool_byte_array_remove(godot_pool_byte_array *p_pba, const godot_int p_idx);
+void GDAPI godot_pool_byte_array_remove(godot_pool_byte_array *p_self, const godot_int p_idx);
 
-void GDAPI godot_pool_byte_array_resize(godot_pool_byte_array *p_pba, const godot_int p_size);
+void GDAPI godot_pool_byte_array_resize(godot_pool_byte_array *p_self, const godot_int p_size);
 
-void GDAPI godot_pool_byte_array_set(godot_pool_byte_array *p_pba, const godot_int p_idx, const uint8_t p_data);
-uint8_t GDAPI godot_pool_byte_array_get(const godot_pool_byte_array *p_pba, const godot_int p_idx);
+void GDAPI godot_pool_byte_array_set(godot_pool_byte_array *p_self, const godot_int p_idx, const uint8_t p_data);
+uint8_t GDAPI godot_pool_byte_array_get(const godot_pool_byte_array *p_self, const godot_int p_idx);
 
-godot_int GDAPI godot_pool_byte_array_size(const godot_pool_byte_array *p_pba);
+godot_int GDAPI godot_pool_byte_array_size(const godot_pool_byte_array *p_self);
 
-void GDAPI godot_pool_byte_array_destroy(godot_pool_byte_array *p_pba);
+void GDAPI godot_pool_byte_array_destroy(godot_pool_byte_array *p_self);
 
 // int
 
-void GDAPI godot_pool_int_array_new(godot_pool_int_array *p_pia);
-void GDAPI godot_pool_int_array_new_copy(godot_pool_int_array *p_dest, const godot_pool_int_array *p_src);
-void GDAPI godot_pool_int_array_new_with_array(godot_pool_int_array *p_pia, const godot_array *p_a);
+void GDAPI godot_pool_int_array_new(godot_pool_int_array *r_dest);
+void GDAPI godot_pool_int_array_new_copy(godot_pool_int_array *r_dest, const godot_pool_int_array *p_src);
+void GDAPI godot_pool_int_array_new_with_array(godot_pool_int_array *r_dest, const godot_array *p_a);
 
-void GDAPI godot_pool_int_array_append(godot_pool_int_array *p_pia, const godot_int p_data);
+void GDAPI godot_pool_int_array_append(godot_pool_int_array *p_self, const godot_int p_data);
 
-void GDAPI godot_pool_int_array_append_array(godot_pool_int_array *p_pia, const godot_pool_int_array *p_array);
+void GDAPI godot_pool_int_array_append_array(godot_pool_int_array *p_self, const godot_pool_int_array *p_array);
 
-int GDAPI godot_pool_int_array_insert(godot_pool_int_array *p_pia, const godot_int p_idx, const godot_int p_data);
+godot_error GDAPI godot_pool_int_array_insert(godot_pool_int_array *p_self, const godot_int p_idx, const godot_int p_data);
 
-void GDAPI godot_pool_int_array_invert(godot_pool_int_array *p_pia);
+void GDAPI godot_pool_int_array_invert(godot_pool_int_array *p_self);
 
-void GDAPI godot_pool_int_array_push_back(godot_pool_int_array *p_pia, const godot_int p_data);
+void GDAPI godot_pool_int_array_push_back(godot_pool_int_array *p_self, const godot_int p_data);
 
-void GDAPI godot_pool_int_array_remove(godot_pool_int_array *p_pia, const godot_int p_idx);
+void GDAPI godot_pool_int_array_remove(godot_pool_int_array *p_self, const godot_int p_idx);
 
-void GDAPI godot_pool_int_array_resize(godot_pool_int_array *p_pia, const godot_int p_size);
+void GDAPI godot_pool_int_array_resize(godot_pool_int_array *p_self, const godot_int p_size);
 
-void GDAPI godot_pool_int_array_set(godot_pool_int_array *p_pia, const godot_int p_idx, const godot_int p_data);
-godot_int GDAPI godot_pool_int_array_get(const godot_pool_int_array *p_pia, const godot_int p_idx);
+void GDAPI godot_pool_int_array_set(godot_pool_int_array *p_self, const godot_int p_idx, const godot_int p_data);
+godot_int GDAPI godot_pool_int_array_get(const godot_pool_int_array *p_self, const godot_int p_idx);
 
-godot_int GDAPI godot_pool_int_array_size(const godot_pool_int_array *p_pia);
+godot_int GDAPI godot_pool_int_array_size(const godot_pool_int_array *p_self);
 
-void GDAPI godot_pool_int_array_destroy(godot_pool_int_array *p_pia);
+void GDAPI godot_pool_int_array_destroy(godot_pool_int_array *p_self);
 
 // real
 
-void GDAPI godot_pool_real_array_new(godot_pool_real_array *p_pra);
-void GDAPI godot_pool_real_array_new_copy(godot_pool_real_array *p_dest, const godot_pool_real_array *p_src);
-void GDAPI godot_pool_real_array_new_with_array(godot_pool_real_array *p_pra, const godot_array *p_a);
+void GDAPI godot_pool_real_array_new(godot_pool_real_array *r_dest);
+void GDAPI godot_pool_real_array_new_copy(godot_pool_real_array *r_dest, const godot_pool_real_array *p_src);
+void GDAPI godot_pool_real_array_new_with_array(godot_pool_real_array *r_dest, const godot_array *p_a);
 
-void GDAPI godot_pool_real_array_append(godot_pool_real_array *p_pra, const godot_real p_data);
+void GDAPI godot_pool_real_array_append(godot_pool_real_array *p_self, const godot_real p_data);
 
-void GDAPI godot_pool_real_array_append_array(godot_pool_real_array *p_pra, const godot_pool_real_array *p_array);
+void GDAPI godot_pool_real_array_append_array(godot_pool_real_array *p_self, const godot_pool_real_array *p_array);
 
-int GDAPI godot_pool_real_array_insert(godot_pool_real_array *p_pra, const godot_int p_idx, const godot_real p_data);
+godot_error GDAPI godot_pool_real_array_insert(godot_pool_real_array *p_self, const godot_int p_idx, const godot_real p_data);
 
-void GDAPI godot_pool_real_array_invert(godot_pool_real_array *p_pra);
+void GDAPI godot_pool_real_array_invert(godot_pool_real_array *p_self);
 
-void GDAPI godot_pool_real_array_push_back(godot_pool_real_array *p_pra, const godot_real p_data);
+void GDAPI godot_pool_real_array_push_back(godot_pool_real_array *p_self, const godot_real p_data);
 
-void GDAPI godot_pool_real_array_remove(godot_pool_real_array *p_pra, const godot_int p_idx);
+void GDAPI godot_pool_real_array_remove(godot_pool_real_array *p_self, const godot_int p_idx);
 
-void GDAPI godot_pool_real_array_resize(godot_pool_real_array *p_pra, const godot_int p_size);
+void GDAPI godot_pool_real_array_resize(godot_pool_real_array *p_self, const godot_int p_size);
 
-void GDAPI godot_pool_real_array_set(godot_pool_real_array *p_pra, const godot_int p_idx, const godot_real p_data);
-godot_real GDAPI godot_pool_real_array_get(const godot_pool_real_array *p_pra, const godot_int p_idx);
+void GDAPI godot_pool_real_array_set(godot_pool_real_array *p_self, const godot_int p_idx, const godot_real p_data);
+godot_real GDAPI godot_pool_real_array_get(const godot_pool_real_array *p_self, const godot_int p_idx);
 
-godot_int GDAPI godot_pool_real_array_size(const godot_pool_real_array *p_pra);
+godot_int GDAPI godot_pool_real_array_size(const godot_pool_real_array *p_self);
 
-void GDAPI godot_pool_real_array_destroy(godot_pool_real_array *p_pra);
+void GDAPI godot_pool_real_array_destroy(godot_pool_real_array *p_self);
 
 // string
 
-void GDAPI godot_pool_string_array_new(godot_pool_string_array *p_psa);
-void GDAPI godot_pool_string_array_new_copy(godot_pool_string_array *p_dest, const godot_pool_string_array *p_src);
-void GDAPI godot_pool_string_array_new_with_array(godot_pool_string_array *p_psa, const godot_array *p_a);
+void GDAPI godot_pool_string_array_new(godot_pool_string_array *r_dest);
+void GDAPI godot_pool_string_array_new_copy(godot_pool_string_array *r_dest, const godot_pool_string_array *p_src);
+void GDAPI godot_pool_string_array_new_with_array(godot_pool_string_array *r_dest, const godot_array *p_a);
 
-void GDAPI godot_pool_string_array_append(godot_pool_string_array *p_psa, const godot_string *p_data);
+void GDAPI godot_pool_string_array_append(godot_pool_string_array *p_self, const godot_string *p_data);
 
-void GDAPI godot_pool_string_array_append_array(godot_pool_string_array *p_psa, const godot_pool_string_array *p_array);
+void GDAPI godot_pool_string_array_append_array(godot_pool_string_array *p_self, const godot_pool_string_array *p_array);
 
-int GDAPI godot_pool_string_array_insert(godot_pool_string_array *p_psa, const godot_int p_idx, const godot_string *p_data);
+godot_error GDAPI godot_pool_string_array_insert(godot_pool_string_array *p_self, const godot_int p_idx, const godot_string *p_data);
 
-void GDAPI godot_pool_string_array_invert(godot_pool_string_array *p_psa);
+void GDAPI godot_pool_string_array_invert(godot_pool_string_array *p_self);
 
-void GDAPI godot_pool_string_array_push_back(godot_pool_string_array *p_psa, const godot_string *p_data);
+void GDAPI godot_pool_string_array_push_back(godot_pool_string_array *p_self, const godot_string *p_data);
 
-void GDAPI godot_pool_string_array_remove(godot_pool_string_array *p_psa, const godot_int p_idx);
+void GDAPI godot_pool_string_array_remove(godot_pool_string_array *p_self, const godot_int p_idx);
 
-void GDAPI godot_pool_string_array_resize(godot_pool_string_array *p_psa, const godot_int p_size);
+void GDAPI godot_pool_string_array_resize(godot_pool_string_array *p_self, const godot_int p_size);
 
-void GDAPI godot_pool_string_array_set(godot_pool_string_array *p_psa, const godot_int p_idx, const godot_string *p_data);
-godot_string GDAPI godot_pool_string_array_get(const godot_pool_string_array *p_psa, const godot_int p_idx);
+void GDAPI godot_pool_string_array_set(godot_pool_string_array *p_self, const godot_int p_idx, const godot_string *p_data);
+godot_string GDAPI godot_pool_string_array_get(const godot_pool_string_array *p_self, const godot_int p_idx);
 
-godot_int GDAPI godot_pool_string_array_size(const godot_pool_string_array *p_psa);
+godot_int GDAPI godot_pool_string_array_size(const godot_pool_string_array *p_self);
 
-void GDAPI godot_pool_string_array_destroy(godot_pool_string_array *p_psa);
+void GDAPI godot_pool_string_array_destroy(godot_pool_string_array *p_self);
 
 // vector2
 
-void GDAPI godot_pool_vector2_array_new(godot_pool_vector2_array *p_pv2a);
-void GDAPI godot_pool_vector2_array_new_copy(godot_pool_vector2_array *p_dest, const godot_pool_vector2_array *p_src);
-void GDAPI godot_pool_vector2_array_new_with_array(godot_pool_vector2_array *p_pv2a, const godot_array *p_a);
+void GDAPI godot_pool_vector2_array_new(godot_pool_vector2_array *r_dest);
+void GDAPI godot_pool_vector2_array_new_copy(godot_pool_vector2_array *r_dest, const godot_pool_vector2_array *p_src);
+void GDAPI godot_pool_vector2_array_new_with_array(godot_pool_vector2_array *r_dest, const godot_array *p_a);
 
-void GDAPI godot_pool_vector2_array_append(godot_pool_vector2_array *p_pv2a, const godot_vector2 *p_data);
+void GDAPI godot_pool_vector2_array_append(godot_pool_vector2_array *p_self, const godot_vector2 *p_data);
 
-void GDAPI godot_pool_vector2_array_append_array(godot_pool_vector2_array *p_pv2a, const godot_pool_vector2_array *p_array);
+void GDAPI godot_pool_vector2_array_append_array(godot_pool_vector2_array *p_self, const godot_pool_vector2_array *p_array);
 
-int GDAPI godot_pool_vector2_array_insert(godot_pool_vector2_array *p_pv2a, const godot_int p_idx, const godot_vector2 *p_data);
+godot_error GDAPI godot_pool_vector2_array_insert(godot_pool_vector2_array *p_self, const godot_int p_idx, const godot_vector2 *p_data);
 
-void GDAPI godot_pool_vector2_array_invert(godot_pool_vector2_array *p_pv2a);
+void GDAPI godot_pool_vector2_array_invert(godot_pool_vector2_array *p_self);
 
-void GDAPI godot_pool_vector2_array_push_back(godot_pool_vector2_array *p_pv2a, const godot_vector2 *p_data);
+void GDAPI godot_pool_vector2_array_push_back(godot_pool_vector2_array *p_self, const godot_vector2 *p_data);
 
-void GDAPI godot_pool_vector2_array_remove(godot_pool_vector2_array *p_pv2a, const godot_int p_idx);
+void GDAPI godot_pool_vector2_array_remove(godot_pool_vector2_array *p_self, const godot_int p_idx);
 
-void GDAPI godot_pool_vector2_array_resize(godot_pool_vector2_array *p_pv2a, const godot_int p_size);
+void GDAPI godot_pool_vector2_array_resize(godot_pool_vector2_array *p_self, const godot_int p_size);
 
-void GDAPI godot_pool_vector2_array_set(godot_pool_vector2_array *p_pv2a, const godot_int p_idx, const godot_vector2 *p_data);
-godot_vector2 GDAPI godot_pool_vector2_array_get(const godot_pool_vector2_array *p_pv2a, const godot_int p_idx);
+void GDAPI godot_pool_vector2_array_set(godot_pool_vector2_array *p_self, const godot_int p_idx, const godot_vector2 *p_data);
+godot_vector2 GDAPI godot_pool_vector2_array_get(const godot_pool_vector2_array *p_self, const godot_int p_idx);
 
-godot_int GDAPI godot_pool_vector2_array_size(const godot_pool_vector2_array *p_pv2a);
+godot_int GDAPI godot_pool_vector2_array_size(const godot_pool_vector2_array *p_self);
 
-void GDAPI godot_pool_vector2_array_destroy(godot_pool_vector2_array *p_pv2a);
+void GDAPI godot_pool_vector2_array_destroy(godot_pool_vector2_array *p_self);
 
 // vector3
 
-void GDAPI godot_pool_vector3_array_new(godot_pool_vector3_array *p_pv3a);
-void GDAPI godot_pool_vector3_array_new_copy(godot_pool_vector3_array *p_dest, const godot_pool_vector3_array *p_src);
-void GDAPI godot_pool_vector3_array_new_with_array(godot_pool_vector3_array *p_pv3a, const godot_array *p_a);
+void GDAPI godot_pool_vector3_array_new(godot_pool_vector3_array *r_dest);
+void GDAPI godot_pool_vector3_array_new_copy(godot_pool_vector3_array *r_dest, const godot_pool_vector3_array *p_src);
+void GDAPI godot_pool_vector3_array_new_with_array(godot_pool_vector3_array *r_dest, const godot_array *p_a);
 
-void GDAPI godot_pool_vector3_array_append(godot_pool_vector3_array *p_pv3a, const godot_vector3 *p_data);
+void GDAPI godot_pool_vector3_array_append(godot_pool_vector3_array *p_self, const godot_vector3 *p_data);
 
-void GDAPI godot_pool_vector3_array_append_array(godot_pool_vector3_array *p_pv3a, const godot_pool_vector3_array *p_array);
+void GDAPI godot_pool_vector3_array_append_array(godot_pool_vector3_array *p_self, const godot_pool_vector3_array *p_array);
 
-int GDAPI godot_pool_vector3_array_insert(godot_pool_vector3_array *p_pv3a, const godot_int p_idx, const godot_vector3 *p_data);
+godot_error GDAPI godot_pool_vector3_array_insert(godot_pool_vector3_array *p_self, const godot_int p_idx, const godot_vector3 *p_data);
 
-void GDAPI godot_pool_vector3_array_invert(godot_pool_vector3_array *p_pv3a);
+void GDAPI godot_pool_vector3_array_invert(godot_pool_vector3_array *p_self);
 
-void GDAPI godot_pool_vector3_array_push_back(godot_pool_vector3_array *p_pv3a, const godot_vector3 *p_data);
+void GDAPI godot_pool_vector3_array_push_back(godot_pool_vector3_array *p_self, const godot_vector3 *p_data);
 
-void GDAPI godot_pool_vector3_array_remove(godot_pool_vector3_array *p_pv3a, const godot_int p_idx);
+void GDAPI godot_pool_vector3_array_remove(godot_pool_vector3_array *p_self, const godot_int p_idx);
 
-void GDAPI godot_pool_vector3_array_resize(godot_pool_vector3_array *p_pv3a, const godot_int p_size);
+void GDAPI godot_pool_vector3_array_resize(godot_pool_vector3_array *p_self, const godot_int p_size);
 
-void GDAPI godot_pool_vector3_array_set(godot_pool_vector3_array *p_pv3a, const godot_int p_idx, const godot_vector3 *p_data);
-godot_vector3 GDAPI godot_pool_vector3_array_get(const godot_pool_vector3_array *p_pv3a, const godot_int p_idx);
+void GDAPI godot_pool_vector3_array_set(godot_pool_vector3_array *p_self, const godot_int p_idx, const godot_vector3 *p_data);
+godot_vector3 GDAPI godot_pool_vector3_array_get(const godot_pool_vector3_array *p_self, const godot_int p_idx);
 
-godot_int GDAPI godot_pool_vector3_array_size(const godot_pool_vector3_array *p_pv3a);
+godot_int GDAPI godot_pool_vector3_array_size(const godot_pool_vector3_array *p_self);
 
-void GDAPI godot_pool_vector3_array_destroy(godot_pool_vector3_array *p_pv3a);
+void GDAPI godot_pool_vector3_array_destroy(godot_pool_vector3_array *p_self);
 
 // color
 
-void GDAPI godot_pool_color_array_new(godot_pool_color_array *p_pca);
-void GDAPI godot_pool_color_array_new_copy(godot_pool_color_array *p_dest, const godot_pool_color_array *p_src);
-void GDAPI godot_pool_color_array_new_with_array(godot_pool_color_array *p_pca, const godot_array *p_a);
+void GDAPI godot_pool_color_array_new(godot_pool_color_array *r_dest);
+void GDAPI godot_pool_color_array_new_copy(godot_pool_color_array *r_dest, const godot_pool_color_array *p_src);
+void GDAPI godot_pool_color_array_new_with_array(godot_pool_color_array *r_dest, const godot_array *p_a);
 
-void GDAPI godot_pool_color_array_append(godot_pool_color_array *p_pca, const godot_color *p_data);
+void GDAPI godot_pool_color_array_append(godot_pool_color_array *p_self, const godot_color *p_data);
 
-void GDAPI godot_pool_color_array_append_array(godot_pool_color_array *p_pca, const godot_pool_color_array *p_array);
+void GDAPI godot_pool_color_array_append_array(godot_pool_color_array *p_self, const godot_pool_color_array *p_array);
 
-int GDAPI godot_pool_color_array_insert(godot_pool_color_array *p_pca, const godot_int p_idx, const godot_color *p_data);
+godot_error GDAPI godot_pool_color_array_insert(godot_pool_color_array *p_self, const godot_int p_idx, const godot_color *p_data);
 
-void GDAPI godot_pool_color_array_invert(godot_pool_color_array *p_pca);
+void GDAPI godot_pool_color_array_invert(godot_pool_color_array *p_self);
 
-void GDAPI godot_pool_color_array_push_back(godot_pool_color_array *p_pca, const godot_color *p_data);
+void GDAPI godot_pool_color_array_push_back(godot_pool_color_array *p_self, const godot_color *p_data);
 
-void GDAPI godot_pool_color_array_remove(godot_pool_color_array *p_pca, const godot_int p_idx);
+void GDAPI godot_pool_color_array_remove(godot_pool_color_array *p_self, const godot_int p_idx);
 
-void GDAPI godot_pool_color_array_resize(godot_pool_color_array *p_pca, const godot_int p_size);
+void GDAPI godot_pool_color_array_resize(godot_pool_color_array *p_self, const godot_int p_size);
 
-void GDAPI godot_pool_color_array_set(godot_pool_color_array *p_pca, const godot_int p_idx, const godot_color *p_data);
-godot_color GDAPI godot_pool_color_array_get(const godot_pool_color_array *p_pca, const godot_int p_idx);
+void GDAPI godot_pool_color_array_set(godot_pool_color_array *p_self, const godot_int p_idx, const godot_color *p_data);
+godot_color GDAPI godot_pool_color_array_get(const godot_pool_color_array *p_self, const godot_int p_idx);
 
-godot_int GDAPI godot_pool_color_array_size(const godot_pool_color_array *p_pca);
+godot_int GDAPI godot_pool_color_array_size(const godot_pool_color_array *p_self);
 
-void GDAPI godot_pool_color_array_destroy(godot_pool_color_array *p_pca);
+void GDAPI godot_pool_color_array_destroy(godot_pool_color_array *p_self);
 
 #ifdef __cplusplus
 }

--- a/modules/gdnative/godot/godot_quat.cpp
+++ b/modules/gdnative/godot/godot_quat.cpp
@@ -50,6 +50,46 @@ void GDAPI godot_quat_new_with_axis_angle(godot_quat *r_dest, const godot_vector
 	*dest = Quat(*axis, p_angle);
 }
 
+godot_real GDAPI godot_quat_get_x(const godot_quat *p_self) {
+	const Quat *self = (const Quat *)p_self;
+	return self->x;
+}
+
+void GDAPI godot_quat_set_x(godot_quat *p_self, const godot_real val) {
+	Quat *self = (Quat *)p_self;
+	self->x = val;
+}
+
+godot_real GDAPI godot_quat_get_y(const godot_quat *p_self) {
+	const Quat *self = (const Quat *)p_self;
+	return self->y;
+}
+
+void GDAPI godot_quat_set_y(godot_quat *p_self, const godot_real val) {
+	Quat *self = (Quat *)p_self;
+	self->y = val;
+}
+
+godot_real GDAPI godot_quat_get_z(const godot_quat *p_self) {
+	const Quat *self = (const Quat *)p_self;
+	return self->z;
+}
+
+void GDAPI godot_quat_set_z(godot_quat *p_self, const godot_real val) {
+	Quat *self = (Quat *)p_self;
+	self->z = val;
+}
+
+godot_real GDAPI godot_quat_get_w(const godot_quat *p_self) {
+	const Quat *self = (const Quat *)p_self;
+	return self->w;
+}
+
+void GDAPI godot_quat_set_w(godot_quat *p_self, const godot_real val) {
+	Quat *self = (Quat *)p_self;
+	self->w = val;
+}
+
 godot_string GDAPI godot_quat_as_string(const godot_quat *p_self) {
 	godot_string ret;
 	const Quat *self = (const Quat *)p_self;

--- a/modules/gdnative/godot/godot_quat.h
+++ b/modules/gdnative/godot/godot_quat.h
@@ -49,6 +49,18 @@ typedef struct godot_quat {
 void GDAPI godot_quat_new(godot_quat *r_dest, const godot_real p_x, const godot_real p_y, const godot_real p_z, const godot_real p_w);
 void GDAPI godot_quat_new_with_axis_angle(godot_quat *r_dest, const godot_vector3 *p_axis, const godot_real p_angle);
 
+godot_real GDAPI godot_quat_get_x(const godot_quat *p_self);
+void GDAPI godot_quat_set_x(godot_quat *p_self, const godot_real val);
+
+godot_real GDAPI godot_quat_get_y(const godot_quat *p_self);
+void GDAPI godot_quat_set_y(godot_quat *p_self, const godot_real val);
+
+godot_real GDAPI godot_quat_get_z(const godot_quat *p_self);
+void GDAPI godot_quat_set_z(godot_quat *p_self, const godot_real val);
+
+godot_real GDAPI godot_quat_get_w(const godot_quat *p_self);
+void GDAPI godot_quat_set_w(godot_quat *p_self, const godot_real val);
+
 godot_string GDAPI godot_quat_as_string(const godot_quat *p_self);
 
 godot_real GDAPI godot_quat_length(const godot_quat *p_self);

--- a/modules/gdnative/godot/godot_rect3.cpp
+++ b/modules/gdnative/godot/godot_rect3.cpp
@@ -45,6 +45,34 @@ void GDAPI godot_rect3_new(godot_rect3 *r_dest, const godot_vector3 *p_pos, cons
 	*dest = Rect3(*pos, *size);
 }
 
+godot_vector3 GDAPI godot_rect3_get_pos(const godot_rect3 *p_self) {
+	godot_vector3 raw_ret;
+	const Rect3 *self = (const Rect3 *)p_self;
+	Vector3 *ret = (Vector3 *)&raw_ret;
+	*ret = self->pos;
+	return raw_ret;
+}
+
+void GDAPI godot_rect3_set_pos(const godot_rect3 *p_self, const godot_vector3 *p_v) {
+	Rect3 *self = (Rect3 *)p_self;
+	const Vector3 *v = (const Vector3 *)p_v;
+	self->pos = *v;
+}
+
+godot_vector3 GDAPI godot_rect3_get_size(const godot_rect3 *p_self) {
+	godot_vector3 raw_ret;
+	const Rect3 *self = (const Rect3 *)p_self;
+	Vector3 *ret = (Vector3 *)&raw_ret;
+	*ret = self->size;
+	return raw_ret;
+}
+
+void GDAPI godot_rect3_set_size(const godot_rect3 *p_self, const godot_vector3 *p_v) {
+	Rect3 *self = (Rect3 *)p_self;
+	const Vector3 *v = (const Vector3 *)p_v;
+	self->size = *v;
+}
+
 godot_string GDAPI godot_rect3_as_string(const godot_rect3 *p_self) {
 	godot_string ret;
 	const Rect3 *self = (const Rect3 *)p_self;

--- a/modules/gdnative/godot/godot_rect3.h
+++ b/modules/gdnative/godot/godot_rect3.h
@@ -49,6 +49,12 @@ typedef struct godot_rect3 {
 
 void GDAPI godot_rect3_new(godot_rect3 *r_dest, const godot_vector3 *p_pos, const godot_vector3 *p_size);
 
+godot_vector3 GDAPI godot_rect3_get_pos(const godot_rect3 *p_self);
+void GDAPI godot_rect3_set_pos(const godot_rect3 *p_self, const godot_vector3 *p_v);
+
+godot_vector3 GDAPI godot_rect3_get_size(const godot_rect3 *p_self);
+void GDAPI godot_rect3_set_size(const godot_rect3 *p_self, const godot_vector3 *p_v);
+
 godot_string GDAPI godot_rect3_as_string(const godot_rect3 *p_self);
 
 godot_real GDAPI godot_rect3_get_area(const godot_rect3 *p_self);

--- a/modules/gdnative/godot/godot_string.cpp
+++ b/modules/gdnative/godot/godot_string.cpp
@@ -41,81 +41,75 @@ extern "C" {
 void _string_api_anchor() {
 }
 
-void GDAPI godot_string_new(godot_string *p_str) {
-	String *p = (String *)p_str;
-	memnew_placement(p, String);
-	// *p = String(); // useless here
+void GDAPI godot_string_new(godot_string *r_dest) {
+	String *dest = (String *)r_dest;
+	memnew_placement(dest, String);
 }
 
-void GDAPI godot_string_new_data(godot_string *p_str, const char *p_contents, const int p_size) {
-	String *p = (String *)p_str;
-	memnew_placement(p, String);
-	*p = String::utf8(p_contents, p_size);
+void GDAPI godot_string_new_copy(godot_string *r_dest, const godot_string *p_src) {
+	String *dest = (String *)r_dest;
+	const String *src = (const String *)p_src;
+	memnew_placement(dest, String(*src));
 }
 
-void GDAPI godot_string_new_unicode_data(godot_string *p_str, const wchar_t *p_contents, const int p_size) {
-	String *p = (String *)p_str;
-	memnew_placement(p, String);
-	*p = String(p_contents, p_size);
+void GDAPI godot_string_new_data(godot_string *r_dest, const char *p_contents, const int p_size) {
+	String *dest = (String *)r_dest;
+	memnew_placement(dest, String(String::utf8(p_contents, p_size)));
 }
 
-void GDAPI godot_string_get_data(const godot_string *p_str, char *p_dest, int *p_size) {
-	String *p = (String *)p_str;
+void GDAPI godot_string_new_unicode_data(godot_string *r_dest, const wchar_t *p_contents, const int p_size) {
+	String *dest = (String *)r_dest;
+	memnew_placement(dest, String(p_contents, p_size));
+}
+
+void GDAPI godot_string_get_data(const godot_string *p_self, char *r_dest, int *p_size) {
+	String *self = (String *)p_self;
 	if (p_size != NULL) {
-		*p_size = p->utf8().length();
+		*p_size = self->utf8().length();
 	}
-	if (p_dest != NULL) {
-		memcpy(p_dest, p->utf8().get_data(), *p_size);
+	if (r_dest != NULL) {
+		memcpy(r_dest, self->utf8().get_data(), *p_size);
 	}
 }
 
-void GDAPI godot_string_copy_string(const godot_string *p_dest, const godot_string *p_src) {
-	String *dest = (String *)p_dest;
-	String *src = (String *)p_src;
-
-	*dest = *src;
+wchar_t GDAPI *godot_string_operator_index(godot_string *p_self, const godot_int p_idx) {
+	String *self = (String *)p_self;
+	return &(self->operator[](p_idx));
 }
 
-wchar_t GDAPI *godot_string_operator_index(godot_string *p_str, const godot_int p_idx) {
-	String *s = (String *)p_str;
-	return &(s->operator[](p_idx));
+const char GDAPI *godot_string_c_str(const godot_string *p_self) {
+	const String *self = (const String *)p_self;
+	return self->utf8().get_data();
 }
 
-const char GDAPI *godot_string_c_str(const godot_string *p_str) {
-	const String *s = (const String *)p_str;
-	return s->utf8().get_data();
+const wchar_t GDAPI *godot_string_unicode_str(const godot_string *p_self) {
+	const String *self = (const String *)p_self;
+	return self->c_str();
 }
 
-const wchar_t GDAPI *godot_string_unicode_str(const godot_string *p_str) {
-	const String *s = (const String *)p_str;
-	return s->c_str();
+godot_bool GDAPI godot_string_operator_equal(const godot_string *p_self, const godot_string *p_b) {
+	const String *self = (const String *)p_self;
+	const String *b = (const String *)p_b;
+	return *self == *b;
 }
 
-godot_bool GDAPI godot_string_operator_equal(const godot_string *p_a, const godot_string *p_b) {
-	String *a = (String *)p_a;
-	String *b = (String *)p_b;
-	return *a == *b;
+godot_bool GDAPI godot_string_operator_less(const godot_string *p_self, const godot_string *p_b) {
+	const String *self = (const String *)p_self;
+	const String *b = (const String *)p_b;
+	return *self < *b;
 }
 
-godot_bool GDAPI godot_string_operator_less(const godot_string *p_a, const godot_string *p_b) {
-	String *a = (String *)p_a;
-	String *b = (String *)p_b;
-	return *a < *b;
+godot_string GDAPI godot_string_operator_plus(const godot_string *p_self, const godot_string *p_b) {
+	godot_string ret;
+	const String *self = (const String *)p_self;
+	const String *b = (const String *)p_b;
+	memnew_placement(&ret, String(*self + *b));
+	return ret;
 }
 
-void GDAPI godot_string_operator_plus(godot_string *p_dest, const godot_string *p_a, const godot_string *p_b) {
-	String *dest = (String *)p_dest;
-	const String *a = (String *)p_a;
-	const String *b = (String *)p_b;
-
-	String tmp = *a + *b;
-	godot_string_new(p_dest);
-	*dest = tmp;
-}
-
-void GDAPI godot_string_destroy(godot_string *p_str) {
-	String *p = (String *)p_str;
-	p->~String();
+void GDAPI godot_string_destroy(godot_string *p_self) {
+	String *self = (String *)p_self;
+	self->~String();
 }
 
 #ifdef __cplusplus

--- a/modules/gdnative/godot/godot_string.h
+++ b/modules/gdnative/godot/godot_string.h
@@ -45,27 +45,26 @@ typedef struct godot_string {
 
 #include "../godot.h"
 
-void GDAPI godot_string_new(godot_string *p_str);
-void GDAPI godot_string_new_data(godot_string *p_str, const char *p_contents, const int p_size);
-void GDAPI godot_string_new_unicode_data(godot_string *p_str, const wchar_t *p_contents, const int p_size);
+void GDAPI godot_string_new(godot_string *r_dest);
+void GDAPI godot_string_new_copy(godot_string *r_dest, const godot_string *p_src);
+void GDAPI godot_string_new_data(godot_string *r_dest, const char *p_contents, const int p_size);
+void GDAPI godot_string_new_unicode_data(godot_string *r_dest, const wchar_t *p_contents, const int p_size);
 
-void GDAPI godot_string_get_data(const godot_string *p_str, char *p_dest, int *p_size);
+void GDAPI godot_string_get_data(const godot_string *p_self, char *p_dest, int *p_size);
 
-void GDAPI godot_string_copy_string(const godot_string *p_dest, const godot_string *p_src);
+wchar_t GDAPI *godot_string_operator_index(godot_string *p_self, const godot_int p_idx);
+const char GDAPI *godot_string_c_str(const godot_string *p_self);
+const wchar_t GDAPI *godot_string_unicode_str(const godot_string *p_self);
 
-wchar_t GDAPI *godot_string_operator_index(godot_string *p_str, const godot_int p_idx);
-const char GDAPI *godot_string_c_str(const godot_string *p_str);
-const wchar_t GDAPI *godot_string_unicode_str(const godot_string *p_str);
-
-godot_bool GDAPI godot_string_operator_equal(const godot_string *p_a, const godot_string *p_b);
-godot_bool GDAPI godot_string_operator_less(const godot_string *p_a, const godot_string *p_b);
-void GDAPI godot_string_operator_plus(godot_string *p_dest, const godot_string *p_a, const godot_string *p_b);
+godot_bool GDAPI godot_string_operator_equal(const godot_string *p_self, const godot_string *p_b);
+godot_bool GDAPI godot_string_operator_less(const godot_string *p_self, const godot_string *p_b);
+godot_string GDAPI godot_string_operator_plus(const godot_string *p_self, const godot_string *p_b);
 
 // @Incomplete
 // hmm, I guess exposing the whole API doesn't make much sense
 // since the language used in the library has its own string funcs
 
-void GDAPI godot_string_destroy(godot_string *p_str);
+void GDAPI godot_string_destroy(godot_string *p_self);
 
 #ifdef __cplusplus
 }

--- a/modules/gdnative/godot/godot_transform.cpp
+++ b/modules/gdnative/godot/godot_transform.cpp
@@ -57,6 +57,32 @@ void GDAPI godot_transform_new(godot_transform *r_dest, const godot_basis *p_bas
 	*dest = Transform(*basis, *origin);
 }
 
+godot_basis GDAPI godot_transform_get_basis(const godot_transform *p_self) {
+	godot_basis dest;
+	const Transform *self = (const Transform *)p_self;
+	*((Basis *)&dest) = self->basis;
+	return dest;
+}
+
+void GDAPI godot_transform_set_basis(godot_transform *p_self, godot_basis *p_v) {
+	Transform *self = (Transform *)p_self;
+	const Basis *v = (const Basis *)p_v;
+	self->basis = *v;
+}
+
+godot_vector3 GDAPI godot_transform_get_origin(const godot_transform *p_self) {
+	godot_vector3 dest;
+	const Transform *self = (const Transform *)p_self;
+	*((Vector3 *)&dest) = self->origin;
+	return dest;
+}
+
+void GDAPI godot_transform_set_origin(godot_transform *p_self, godot_vector3 *p_v) {
+	Transform *self = (Transform *)p_self;
+	const Vector3 *v = (const Vector3 *)p_v;
+	self->origin = *v;
+}
+
 godot_string GDAPI godot_transform_as_string(const godot_transform *p_self) {
 	godot_string ret;
 	const Transform *self = (const Transform *)p_self;

--- a/modules/gdnative/godot/godot_transform.h
+++ b/modules/gdnative/godot/godot_transform.h
@@ -51,6 +51,12 @@ typedef struct godot_transform {
 void GDAPI godot_transform_new_with_axis_origin(godot_transform *r_dest, const godot_vector3 *p_x_axis, const godot_vector3 *p_y_axis, const godot_vector3 *p_z_axis, const godot_vector3 *p_origin);
 void GDAPI godot_transform_new(godot_transform *r_dest, const godot_basis *p_basis, const godot_vector3 *p_origin);
 
+godot_basis GDAPI godot_transform_get_basis(const godot_transform *p_self);
+void GDAPI godot_transform_set_basis(godot_transform *p_self, godot_basis *p_v);
+
+godot_vector3 GDAPI godot_transform_get_origin(const godot_transform *p_self);
+void GDAPI godot_transform_set_origin(godot_transform *p_self, godot_vector3 *p_v);
+
 godot_string GDAPI godot_transform_as_string(const godot_transform *p_self);
 
 godot_transform GDAPI godot_transform_inverse(const godot_transform *p_self);

--- a/modules/gdnative/godot/godot_variant.cpp
+++ b/modules/gdnative/godot/godot_variant.cpp
@@ -45,10 +45,10 @@ godot_variant_type GDAPI godot_variant_get_type(const godot_variant *p_self) {
 	return (godot_variant_type)self->get_type();
 }
 
-void GDAPI godot_variant_copy(godot_variant *p_dest, const godot_variant *p_src) {
+void GDAPI godot_variant_new_copy(godot_variant *p_dest, const godot_variant *p_src) {
 	Variant *dest = (Variant *)p_dest;
 	Variant *src = (Variant *)p_src;
-	*dest = *src;
+	memnew_placement(dest, Variant(*src));
 }
 
 void GDAPI godot_variant_new_nil(godot_variant *r_dest) {

--- a/modules/gdnative/godot/godot_variant.h
+++ b/modules/gdnative/godot/godot_variant.h
@@ -68,7 +68,6 @@ typedef enum godot_variant_type {
 	GODOT_VARIANT_TYPE_NODE_PATH, // 15
 	GODOT_VARIANT_TYPE_RID,
 	GODOT_VARIANT_TYPE_OBJECT,
-	GODOT_VARIANT_TYPE_INPUT_EVENT, // TODO: remove me once input_event is removed from main Godot codebase
 	GODOT_VARIANT_TYPE_DICTIONARY,
 	GODOT_VARIANT_TYPE_ARRAY, // 20
 
@@ -119,7 +118,7 @@ typedef struct godot_variant_call_error {
 
 godot_variant_type GDAPI godot_variant_get_type(const godot_variant *p_v);
 
-void GDAPI godot_variant_copy(godot_variant *r_dest, const godot_variant *p_src);
+void GDAPI godot_variant_new_copy(godot_variant *r_dest, const godot_variant *p_src);
 
 void GDAPI godot_variant_new_nil(godot_variant *r_dest);
 


### PR DESCRIPTION
I should have submitted this last week this before going in vacation :sleeping: 

- Rename paramters in Array/Pool/Dictionary to keep consistency with the rest of the API
- Add missing properties in rect3, quat and transform
- Remove deprecated `GODOT_VARIANT_TYPE_INPUT_EVENT`
- Replace `godot_*_new_copy` by `godot_*_copy` function (simpler API, and imo more logical to consider this function as an object "method" than a standalone constructor)
- Replace Dictionary/Pool/Array item access by pointer by `set/get` functions.

@karroffel Considering the last point, I saw you [changed `godot_array_get`](https://github.com/godotengine/godot/commit/f23b56e3ecc5de8fc823dfa1c63f71d51ea12993#diff-2baa93f0b5a9942e8f39c1d7c1784faeR62) to return a pointer. I don't get the need for this (I would say it allow to be a bit faster because we can call the function once and only work on the pointer then, but it's also less user friendly than a get/set).

I've reverted to the get/set solution right now because it's what use Pythonscript right now. However I'm willing to change this PR and Pythonscript if you think your solution is better ;-)
