### PR TITLE
osx release right button event fixed

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -365,7 +365,7 @@ static int button_mask = 0;
 
 - (void)rightMouseUp:(NSEvent *)event {
 
-	button_mask |= BUTTON_MASK_RIGHT;
+	button_mask &= ~BUTTON_MASK_RIGHT;
 
 	Ref<InputEventMouseButton> mb;
 	mb.instance();


### PR DESCRIPTION
RIGHT_MOUSE_BUTTON was not removed from the button mask (instead it was added...)
fixes #9079