### PR TITLE
added style for panel class

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -145,8 +145,8 @@ Ref<Theme> create_editor_theme() {
 	theme->set_icon("unchecked", "PopupMenu", theme->get_icon("Unchecked", "EditorIcons"));
 
 	// Editor background
-	Ref<StyleBoxFlat> style_background = make_flat_stylebox(dark_color_2, 4, 4, 4, 4);
-	theme->set_stylebox("Background", "EditorStyles", style_background);
+	Ref<StyleBoxFlat> style_panel = make_flat_stylebox(dark_color_2, 4, 4, 4, 4);
+	theme->set_stylebox("Background", "EditorStyles", style_panel);
 
 	// Focus
 	Ref<StyleBoxFlat> focus_sbt = make_flat_stylebox(light_color_1, 4, 4, 4, 4);
@@ -193,9 +193,9 @@ Ref<Theme> create_editor_theme() {
 	theme->set_stylebox("MenuHover", "EditorStyles", style_menu_hover_border);
 
 	// Content of each tab
-	Ref<StyleBoxFlat> style_panel = make_flat_stylebox(base_color, 1, 4, 1, 1);
-	theme->set_stylebox("panel", "TabContainer", style_panel);
-	theme->set_stylebox("Content", "EditorStyles", style_panel);
+	Ref<StyleBoxFlat> style_content_panel = make_flat_stylebox(base_color, 1, 4, 1, 1);
+	theme->set_stylebox("panel", "TabContainer", style_content_panel);
+	theme->set_stylebox("Content", "EditorStyles", style_content_panel);
 
 	// Button
 	Ref<StyleBoxFlat> style_button = make_flat_stylebox(dark_color_1, 4, 4, 4, 4);
@@ -393,6 +393,9 @@ Ref<Theme> create_editor_theme() {
 	theme->set_stylebox("slider", "VSlider", make_stylebox(theme->get_icon("VsliderBg", "EditorIcons"), 4, 4, 4, 4));
 	theme->set_icon("grabber", "VSlider", theme->get_icon("SliderGrabber", "EditorIcons"));
 	theme->set_icon("grabber_highlight", "VSlider", theme->get_icon("SliderGrabberHl", "EditorIcons"));
+
+	// Panel
+	theme->set_stylebox("panel", "Panel", style_panel);
 
 	// TooltipPanel
 	Ref<StyleBoxFlat> style_tooltip = make_flat_stylebox(Color(1, 1, 1, 0.8), 8, 8, 8, 8);


### PR DESCRIPTION
There was no style in the default editor theme for the panel class.
the color didn't fit at all (upper image is old version, lower one with this change):
<img width="508" alt="screen shot 2017-06-06 at 20 43 30" src="https://user-images.githubusercontent.com/16718859/26862020-fc260a5c-4afc-11e7-9cc9-1c52c729716c.png">

I added a style for the background (dependent on the theme color)
This basically makes "Background", "EditorStyles" obsolete... The advantage of still having it, is, that you can customise the background independent form panels...
