### PR TITLE
Fix destruction of subclasses of Object (2.1)

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1786,6 +1786,11 @@ void postinitialize_handler(Object *p_object) {
 	p_object->_postinitialize();
 }
 
+void destruct(Object *p_object) {
+
+	p_object->_destruct();
+}
+
 HashMap<uint32_t, Object *> ObjectDB::instances;
 uint32_t ObjectDB::instance_counter = 1;
 HashMap<Object *, ObjectID, ObjectDB::ObjectPtrHash> ObjectDB::instance_checks;

--- a/core/object.h
+++ b/core/object.h
@@ -312,6 +312,11 @@ protected:                                                                      
 			m_inherits::_notificationv(p_notification, p_reversed);                                                                  \
 	}                                                                                                                                \
                                                                                                                                      \
+protected:                                                                                                                           \
+	virtual void _destruct() {                                                                                                       \
+		this->~m_type();                                                                                                             \
+	}                                                                                                                                \
+                                                                                                                                     \
 private:
 
 #define OBJ_CATEGORY(m_category)                                        \
@@ -363,6 +368,7 @@ private:
 #endif
 	friend bool predelete_handler(Object *);
 	friend void postinitialize_handler(Object *);
+	friend void destruct(Object *);
 
 	struct Signal {
 
@@ -481,6 +487,10 @@ protected:
 
 	friend class ObjectTypeDB;
 	virtual void _validate_property(PropertyInfo &property) const;
+
+	virtual void _destruct() {
+		this->~Object();
+	}
 
 public: //should be protected, but bug in clang++
 	static void initialize_type();
@@ -652,6 +662,7 @@ public:
 
 bool predelete_handler(Object *p_object);
 void postinitialize_handler(Object *p_object);
+void destruct(Object *p_object);
 
 class ObjectDB {
 

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -272,11 +272,16 @@ _ALWAYS_INLINE_ bool predelete_handler(void *) {
 }
 
 template <class T>
+_ALWAYS_INLINE_ void destruct(T *p_obj) {
+	p_obj->~T();
+}
+
+template <class T>
 void memdelete(T *p_class) {
 
 	if (!predelete_handler(p_class))
 		return; // doesn't want to be deleted
-	p_class->~T();
+	destruct(p_class);
 	Memory::free_static(p_class);
 }
 
@@ -285,7 +290,7 @@ void memdelete_allocator(T *p_class) {
 
 	if (!predelete_handler(p_class))
 		return; // doesn't want to be deleted
-	p_class->~T();
+	destruct(p_class);
 	A::free(p_class);
 }
 


### PR DESCRIPTION
`free()` and `queue_free()` were failing to call the destructor of the actual object type.

__NOTE:__ Not to be merged before #8999 as this one uncovers some several object lifetime bugs in the physics engine which leads to crashes.

__UPDATE:__ Now implemented more cleanly.