### PR TITLE
Fix destruction of subclasses of Object

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1831,6 +1831,11 @@ void postinitialize_handler(Object *p_object) {
 	p_object->_postinitialize();
 }
 
+void destruct(Object *p_object) {
+
+	p_object->_destruct();
+}
+
 HashMap<ObjectID, Object *> ObjectDB::instances;
 ObjectID ObjectDB::instance_counter = 1;
 HashMap<Object *, ObjectID, ObjectDB::ObjectPtrHash> ObjectDB::instance_checks;

--- a/core/object.h
+++ b/core/object.h
@@ -335,6 +335,11 @@ protected:                                                                      
 			m_inherits::_notificationv(p_notification, p_reversed);                                                                     \
 	}                                                                                                                                   \
                                                                                                                                         \
+protected:                                                                                                                              \
+	virtual void _destruct() {                                                                                                          \
+		this->~m_class();                                                                                                               \
+	}                                                                                                                                   \
+                                                                                                                                        \
 private:
 
 #define OBJ_CATEGORY(m_category)                                        \
@@ -386,6 +391,7 @@ private:
 #endif
 	friend bool predelete_handler(Object *);
 	friend void postinitialize_handler(Object *);
+	friend void destruct(Object *);
 
 	struct Signal {
 
@@ -503,6 +509,10 @@ protected:
 
 	friend class ClassDB;
 	virtual void _validate_property(PropertyInfo &property) const;
+
+	virtual void _destruct() {
+		this->~Object();
+	}
 
 public: //should be protected, but bug in clang++
 	static void initialize_class();
@@ -674,6 +684,7 @@ public:
 
 bool predelete_handler(Object *p_object);
 void postinitialize_handler(Object *p_object);
+void destruct(Object *p_object);
 
 class ObjectDB {
 

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -97,8 +97,13 @@ _ALWAYS_INLINE_ void *operator new(size_t p_size, void *p_pointer, size_t check,
 #define memnew_allocator(m_class, m_allocator) _post_initialize(new (m_allocator::alloc) m_class)
 #define memnew_placement(m_placement, m_class) _post_initialize(new (m_placement, sizeof(m_class), "") m_class)
 
-_ALWAYS_INLINE_ bool predelete_handler(void *) {
+_ALWAYS_INLINE_ bool predelete_handler(void *p_obj) {
 	return true;
+}
+
+template <class T>
+_ALWAYS_INLINE_ void destruct(T *p_obj) {
+	p_obj->~T();
 }
 
 template <class T>
@@ -106,7 +111,7 @@ void memdelete(T *p_class) {
 
 	if (!predelete_handler(p_class))
 		return; // doesn't want to be deleted
-	p_class->~T();
+	destruct(p_class);
 	Memory::free_static(p_class, false);
 }
 
@@ -115,7 +120,7 @@ void memdelete_allocator(T *p_class) {
 
 	if (!predelete_handler(p_class))
 		return; // doesn't want to be deleted
-	p_class->~T();
+	destruct(p_class);
 	A::free(p_class);
 }
 


### PR DESCRIPTION
`free()` and `queue_free()` were failing to call the destructor of the actual object type.

~~__UPDATE:__ Causing issues in 3.0 while 2.1 seems to be fine with it. I'll research and report.~~

__UPDATE:__ Now implemented more cleanly and with no issues so far.