### PR TITLE
EditorPlugin can request user inputs from editor 3d view

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6069,6 +6069,7 @@ EditorNode::EditorNode() {
 
 	editor_plugin_screen = NULL;
 	editor_plugins_over = memnew(EditorPluginList);
+	editor_plugins_force_input_forwarding = memnew(EditorPluginList);
 
 	//force_top_viewport(true);
 	_edit_current();
@@ -6217,6 +6218,7 @@ EditorNode::~EditorNode() {
 	memdelete(EditorHelp::get_doc_data());
 	memdelete(editor_selection);
 	memdelete(editor_plugins_over);
+	memdelete(editor_plugins_force_input_forwarding);
 	memdelete(file_server);
 	EditorSettings::destroy();
 }
@@ -6252,10 +6254,14 @@ bool EditorPluginList::forward_gui_input(const Transform2D &p_canvas_xform, cons
 	return discard;
 }
 
-bool EditorPluginList::forward_spatial_gui_input(Camera *p_camera, const Ref<InputEvent> &p_event) {
+bool EditorPluginList::forward_spatial_gui_input(Camera *p_camera, const Ref<InputEvent> &p_event, bool serve_when_force_input_enabled) {
 	bool discard = false;
 
 	for (int i = 0; i < plugins_list.size(); i++) {
+		if ((!serve_when_force_input_enabled) && plugins_list[i]->is_input_event_forwarding_always_enabled()) {
+			continue;
+		}
+
 		if (plugins_list[i]->forward_spatial_gui_input(p_camera, p_event)) {
 			discard = true;
 		}
@@ -6269,6 +6275,10 @@ void EditorPluginList::forward_draw_over_canvas(const Transform2D &p_canvas_xfor
 	for (int i = 0; i < plugins_list.size(); i++) {
 		plugins_list[i]->forward_draw_over_canvas(p_canvas_xform, p_canvas);
 	}
+}
+
+void EditorPluginList::add_plugin(EditorPlugin *p_plugin) {
+	plugins_list.push_back(p_plugin);
 }
 
 bool EditorPluginList::empty() {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -396,6 +396,7 @@ private:
 	Vector<EditorPlugin *> editor_plugins;
 	EditorPlugin *editor_plugin_screen;
 	EditorPluginList *editor_plugins_over;
+	EditorPluginList *editor_plugins_force_input_forwarding;
 
 	EditorHistory editor_history;
 	EditorData editor_data;
@@ -641,6 +642,7 @@ public:
 
 	EditorPlugin *get_editor_plugin_screen() { return editor_plugin_screen; }
 	EditorPluginList *get_editor_plugins_over() { return editor_plugins_over; }
+	EditorPluginList *get_editor_plugins_force_input_forwarding() { return editor_plugins_force_input_forwarding; }
 	PropertyEditor *get_property_editor() { return property_editor; }
 	VBoxContainer *get_property_editor_vb() { return prop_editor_vb; }
 
@@ -817,8 +819,9 @@ public:
 	void make_visible(bool p_visible);
 	void edit(Object *p_object);
 	bool forward_gui_input(const Transform2D &p_canvas_xform, const Ref<InputEvent> &p_event);
-	bool forward_spatial_gui_input(Camera *p_camera, const Ref<InputEvent> &p_event);
+	bool forward_spatial_gui_input(Camera *p_camera, const Ref<InputEvent> &p_event, bool serve_when_force_input_enabled);
 	void forward_draw_over_canvas(const Transform2D &p_canvas_xform, Control *p_canvas);
+	void add_plugin(EditorPlugin *p_plugin);
 	void clear();
 	bool empty();
 

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -147,6 +147,12 @@ void EditorPlugin::remove_tool_menu_item(const String &p_name) {
 	//EditorNode::get_singleton()->remove_tool_menu_item(p_name);
 }
 
+void EditorPlugin::set_input_event_forwarding_always_enabled() {
+	input_event_forwarding_always_enabled = true;
+	EditorPluginList *always_input_forwarding_list = EditorNode::get_singleton()->get_editor_plugins_force_input_forwarding();
+	always_input_forwarding_list->add_plugin(this);
+}
+
 Ref<SpatialEditorGizmo> EditorPlugin::create_spatial_gizmo(Spatial *p_spatial) {
 	//??
 	if (get_script_instance() && get_script_instance()->has_method("create_spatial_gizmo")) {
@@ -372,6 +378,7 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("edit_resource"), &EditorPlugin::edit_resource);
 	ClassDB::bind_method(D_METHOD("add_import_plugin"), &EditorPlugin::add_import_plugin);
 	ClassDB::bind_method(D_METHOD("remove_import_plugin"), &EditorPlugin::remove_import_plugin);
+	ClassDB::bind_method(D_METHOD("set_input_event_forwarding_always_enabled"), &EditorPlugin::set_input_event_forwarding_always_enabled);
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "forward_canvas_gui_input", PropertyInfo(Variant::TRANSFORM2D, "canvas_xform"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo("forward_draw_over_canvas", PropertyInfo(Variant::TRANSFORM2D, "canvas_xform"), PropertyInfo(Variant::OBJECT, "canvas:Control")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "forward_spatial_gui_input", PropertyInfo(Variant::OBJECT, "camera", PROPERTY_HINT_RESOURCE_TYPE, "Camera"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
@@ -414,6 +421,7 @@ void EditorPlugin::_bind_methods() {
 
 EditorPlugin::EditorPlugin() {
 	undo_redo = NULL;
+	input_event_forwarding_always_enabled = false;
 }
 
 EditorPlugin::~EditorPlugin() {

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -61,6 +61,8 @@ class EditorPlugin : public Node {
 
 	UndoRedo *_get_undo_redo() { return undo_redo; }
 
+	bool input_event_forwarding_always_enabled;
+
 protected:
 	static void _bind_methods();
 	UndoRedo &get_undo_redo() { return *undo_redo; }
@@ -105,6 +107,9 @@ public:
 	void add_tool_menu_item(const String &p_name, Object *p_handler, const String &p_callback, const Variant &p_ud = Variant());
 	void add_tool_submenu_item(const String &p_name, Object *p_submenu);
 	void remove_tool_menu_item(const String &p_name);
+
+	void set_input_event_forwarding_always_enabled();
+	bool is_input_event_forwarding_always_enabled() { return input_event_forwarding_always_enabled; }
 
 	virtual Ref<SpatialEditorGizmo> create_spatial_gizmo(Spatial *p_spatial);
 	virtual bool forward_canvas_gui_input(const Transform2D &p_canvas_xform, const Ref<InputEvent> &p_event);

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -696,12 +696,19 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 		return; //do NONE
 
 	{
-
+		EditorNode *en = editor;
+		EditorPluginList *force_input_forwarding_list = en->get_editor_plugins_force_input_forwarding();
+		if (!force_input_forwarding_list->empty()) {
+			bool discard = force_input_forwarding_list->forward_spatial_gui_input(camera, p_event, true);
+			if (discard)
+				return;
+		}
+	}
+	{
 		EditorNode *en = editor;
 		EditorPluginList *over_plugin_list = en->get_editor_plugins_over();
-
 		if (!over_plugin_list->empty()) {
-			bool discard = over_plugin_list->forward_spatial_gui_input(camera, p_event);
+			bool discard = over_plugin_list->forward_spatial_gui_input(camera, p_event, false);
 			if (discard)
 				return;
 		}


### PR DESCRIPTION
There is new method in EditorPlugin `set_input_event_forwarding_always_enabled()`. If plugin will use it then it will receive camera and input events of the editor 3d view in `forward_spatial_gui_input`. 
This changes might be handy if we want for example write plugin that will be able to fetch information from 3d scene without introducing any new node (originally we could get this info only when we were editing some node). 
This api was discussed with reduzio on IRC couple days ago.

