### PR TITLE
Add optimizing AT_LIGHT_PASS builtin to canvas shaders (2.1)

### DIFF
--- a/drivers/gles2/shader_compiler_gles2.h
+++ b/drivers/gles2/shader_compiler_gles2.h
@@ -44,6 +44,8 @@ private:
 	Error compile_node(ShaderLanguage::ProgramNode *p_program);
 	static Error create_glsl_120_code(void *p_str, ShaderLanguage::ProgramNode *p_program);
 
+	bool _is_condition_preprocessable(ShaderLanguage::Node *p_condition) const;
+
 	bool uses_light;
 	bool uses_texscreen;
 	bool uses_texpos;

--- a/drivers/gles2/shaders/canvas.glsl
+++ b/drivers/gles2/shaders/canvas.glsl
@@ -39,6 +39,9 @@ uniform vec2 normal_flip;
 varying highp vec2 pos;
 #endif
 
+#define at_light_pass 1
+#else
+#define at_light_pass 0
 #endif
 
 #if defined(ENABLE_VAR1_INTERP)
@@ -176,6 +179,9 @@ uniform float shadow_esm_multiplier;
 
 #endif
 
+#define at_light_pass 1
+#else
+#define at_light_pass 0
 #endif
 
 #if defined(USE_TEXPIXEL_SIZE)

--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -1124,6 +1124,7 @@ const ShaderLanguage::BuiltinsDef ShaderLanguage::ci_vertex_builtins_defs[] = {
 	{ "PROJECTION_MATRIX", TYPE_MAT4 },
 	{ "EXTRA_MATRIX", TYPE_MAT4 },
 	{ "TIME", TYPE_FLOAT },
+	{ "AT_LIGHT_PASS", TYPE_BOOL },
 	{ NULL, TYPE_VOID },
 };
 const ShaderLanguage::BuiltinsDef ShaderLanguage::ci_fragment_builtins_defs[] = {
@@ -1145,6 +1146,7 @@ const ShaderLanguage::BuiltinsDef ShaderLanguage::ci_fragment_builtins_defs[] = 
 	//	{ "SCREEN_POS", TYPE_VEC2},
 	//	{ "SCREEN_TEXEL_SIZE", TYPE_VEC2},
 	{ "TIME", TYPE_FLOAT },
+	{ "AT_LIGHT_PASS", TYPE_BOOL },
 	{ NULL, TYPE_VOID }
 
 };


### PR DESCRIPTION
This one allows for complex shaders paired with a simple lighting shader to skip code that would otherwise be pointlessly (and wastefully) run during the light pass.

You can use `if (AT_LIGHT_PASS)`, negated or not, and that will be converted to a preprocessed #if when the shader is compiled.

Depending on your game (number of items and lights), this can be a *significant* performance gain, or at least avoids relying on the driver's optimizing abilities.

~~I don't think this is relevant for _master_.~~ @Zireael07 is right; now I'm porting it.