### PR TITLE
Editor now shows error when debug port is in use

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -211,6 +211,7 @@ EditorExportPreset::EditorExportPreset() {
 void EditorExportPlatform::gen_debug_flags(Vector<String> &r_flags, int p_flags) {
 
 	String host = EditorSettings::get_singleton()->get("network/debug/remote_host");
+	int remote_port = (int)EditorSettings::get_singleton()->get("network/debug/remote_port");
 
 	if (p_flags & DEBUG_FLAG_REMOTE_DEBUG_LOCALHOST)
 		host = "localhost";
@@ -230,7 +231,7 @@ void EditorExportPlatform::gen_debug_flags(Vector<String> &r_flags, int p_flags)
 
 		r_flags.push_back("-rdebug");
 
-		r_flags.push_back(host + ":" + String::num(GLOBAL_DEF("network/debug/remote_port", 6007)));
+		r_flags.push_back(host + ":" + String::num(remote_port));
 
 		List<String> breakpoints;
 		ScriptEditor::get_singleton()->get_breakpoints(&breakpoints);
@@ -621,6 +622,7 @@ Error EditorExportPlatform::save_zip(const Ref<EditorExportPreset> &p_preset, co
 void EditorExportPlatform::gen_export_flags(Vector<String> &r_flags, int p_flags) {
 
 	String host = EditorSettings::get_singleton()->get("network/debug/remote_host");
+	int remote_port = (int)EditorSettings::get_singleton()->get("network/debug/remote_port");
 
 	if (p_flags & DEBUG_FLAG_REMOTE_DEBUG_LOCALHOST)
 		host = "localhost";
@@ -640,7 +642,7 @@ void EditorExportPlatform::gen_export_flags(Vector<String> &r_flags, int p_flags
 
 		r_flags.push_back("-rdebug");
 
-		r_flags.push_back(host + ":" + String::num(GLOBAL_DEF("network/debug/remote_port", 6007)));
+		r_flags.push_back(host + ":" + String::num(remote_port));
 
 		List<String> breakpoints;
 		ScriptEditor::get_singleton()->get_breakpoints(&breakpoints);
@@ -2109,6 +2111,7 @@ static int _get_pad(int p_alignment, int p_n) {
 void EditorExportPlatform::gen_export_flags(Vector<String> &r_flags, int p_flags) {
 
 	String host = EditorSettings::get_singleton()->get("network/debug/remote_host");
+	int remote_port = (int)EditorSettings::get_singleton()->get("network/debug/remote_port");
 
 	if (p_flags&EXPORT_REMOTE_DEBUG_LOCALHOST)
 		host="localhost";
@@ -2128,7 +2131,7 @@ void EditorExportPlatform::gen_export_flags(Vector<String> &r_flags, int p_flags
 
 		r_flags.push_back("-rdebug");
 
-		r_flags.push_back(host+":"+String::num(GLOBAL_DEF("network/debug/remote_port", 6007)));
+		r_flags.push_back(host+":"+String::num(remote_port));
 
 		List<String> breakpoints;
 		ScriptEditor::get_singleton()->get_breakpoints(&breakpoints);

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -42,6 +42,7 @@ Error EditorRun::run(const String &p_scene, const String p_custom_args, const Li
 
 	String resource_path = GlobalConfig::get_singleton()->get_resource_path();
 	String remote_host = EditorSettings::get_singleton()->get("network/debug/remote_host");
+	int remote_port = (int)EditorSettings::get_singleton()->get("network/debug/remote_port");
 
 	if (resource_path != "") {
 		args.push_back("-path");
@@ -50,7 +51,7 @@ Error EditorRun::run(const String &p_scene, const String p_custom_args, const Li
 
 	if (true) {
 		args.push_back("-rdebug");
-		args.push_back(remote_host + ":" + String::num(GLOBAL_GET("network/debug/remote_port")));
+		args.push_back(remote_host + ":" + String::num(remote_port));
 	}
 
 	args.push_back("-epid");

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1035,14 +1035,17 @@ void ScriptEditorDebugger::start() {
 		EditorNode::get_singleton()->make_bottom_panel_item_visible(this);
 	}
 
-	uint16_t port = GLOBAL_GET("network/debug/remote_port");
 	perf_history.clear();
 	for (int i = 0; i < Performance::MONITOR_MAX; i++) {
 
 		perf_max[i] = 0;
 	}
 
-	server->listen(port);
+	int remote_port = (int)EditorSettings::get_singleton()->get("network/debug/remote_port");
+	if (server->listen(remote_port) != OK) {
+		EditorNode::get_log()->add_message(String("** Error listening on port ") + itos(remote_port) + String(" **"));
+		return;
+	}
 	set_process(true);
 }
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -581,12 +581,11 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	GLOBAL_DEF("memory/multithread/thread_rid_pool_prealloc", 60);
 
 	GLOBAL_DEF("network/debug/max_remote_stdout_chars_per_second", 2048);
-	GLOBAL_DEF("network/debug/remote_port", 6007);
 
 	if (debug_mode == "remote") {
 
 		ScriptDebuggerRemote *sdr = memnew(ScriptDebuggerRemote);
-		uint16_t debug_port = GLOBAL_GET("network/debug/remote_port");
+		uint16_t debug_port = 6007;
 		if (debug_host.find(":") != -1) {
 			int sep_pos = debug_host.find_last(":");
 			debug_port = debug_host.substr(sep_pos + 1, debug_host.length()).to_int();

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1714,7 +1714,7 @@ Error EditorExportPlatformAndroid::run(int p_device, int p_flags) {
 		args.push_back("--remove-all");
 		err = OS::get_singleton()->execute(adb,args,true,NULL,NULL,&rv);
 
-		int port = GlobalConfig::get_singleton()->get("network/debug/remote_port");
+		int port = (int)EditorSettings::get_singleton()->get("network/debug/remote_port");
 		args.clear();
 		args.push_back("reverse");
 		args.push_back("tcp:"+itos(port));
@@ -2993,7 +2993,7 @@ public:
 			args.push_back("--remove-all");
 			err = OS::get_singleton()->execute(adb, args, true, NULL, NULL, &rv);
 
-			int port = GlobalConfig::get_singleton()->get("network/debug/remote_port");
+			int port = (int)EditorSettings::get_singleton()->get("network/debug/remote_port");
 			args.clear();
 			args.push_back("reverse");
 			args.push_back("tcp:" + itos(port));


### PR DESCRIPTION
This PR fixes #9096 , well, actually it just notify the user that the editor cannot listen to the given host/port.

The cause for that could be more than just the port is in use, but I guess it's just the most common scenario.

The editor will still end up unable to catch output from the child process and the stop button will not work.
I don't know if there's a better fix to that second problem, but I'm pretty busy with work, and I don't have much time to fiddle around (I tried calling `stop()` immediately but it didn't work).