### PR TITLE
Added EditorPlugin.remove_import_plugin()

### DIFF
--- a/core/io/resource_import.h
+++ b/core/io/resource_import.h
@@ -61,6 +61,7 @@ public:
 	String get_internal_resource_path(const String &p_path) const;
 
 	void add_importer(const Ref<ResourceImporter> &p_importer) { importers.insert(p_importer); }
+	void remove_importer(const Ref<ResourceImporter> &p_importer) { importers.erase(p_importer); }
 	Ref<ResourceImporter> get_importer_by_name(const String &p_name);
 	Ref<ResourceImporter> get_importer_by_extension(const String &p_extension);
 	void get_importers_for_extension(const String &p_extension, List<Ref<ResourceImporter> > *r_importers);

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -281,6 +281,11 @@ void EditorPlugin::add_import_plugin(const Ref<EditorImportPlugin> &p_importer) 
 	EditorFileSystem::get_singleton()->scan_changes();
 }
 
+void EditorPlugin::remove_import_plugin(const Ref<EditorImportPlugin> &p_importer) {
+	ResourceFormatImporter::get_singleton()->remove_importer(p_importer);
+	EditorFileSystem::get_singleton()->scan_changes();
+}
+
 void EditorPlugin::set_window_layout(Ref<ConfigFile> p_layout) {
 
 	if (get_script_instance() && get_script_instance()->has_method("set_window_layout")) {
@@ -366,6 +371,7 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("queue_save_layout"), &EditorPlugin::queue_save_layout);
 	ClassDB::bind_method(D_METHOD("edit_resource"), &EditorPlugin::edit_resource);
 	ClassDB::bind_method(D_METHOD("add_import_plugin"), &EditorPlugin::add_import_plugin);
+	ClassDB::bind_method(D_METHOD("remove_import_plugin"), &EditorPlugin::remove_import_plugin);
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "forward_canvas_gui_input", PropertyInfo(Variant::TRANSFORM2D, "canvas_xform"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo("forward_draw_over_canvas", PropertyInfo(Variant::TRANSFORM2D, "canvas_xform"), PropertyInfo(Variant::OBJECT, "canvas:Control")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "forward_spatial_gui_input", PropertyInfo(Variant::OBJECT, "camera", PROPERTY_HINT_RESOURCE_TYPE, "Camera"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -148,6 +148,7 @@ public:
 	virtual void save_global_state();
 
 	void add_import_plugin(const Ref<EditorImportPlugin> &p_importer);
+	void remove_import_plugin(const Ref<EditorImportPlugin> &p_importer);
 
 	EditorPlugin();
 	virtual ~EditorPlugin();


### PR DESCRIPTION
Allows addons with import extensions to clean up properly on removal, typically during `EditorPlugin._exit_tree()`.

Also, when using a gdscript based import plugin, the editor would segfault when quitting (as the plugin would be referenced after it is deleted) unless this function is used.