### PR TITLE
Fixed compilation on Windows + removed debug print

### DIFF
--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -374,7 +374,7 @@ public:
 
 	//this passes directly to avoid stalling, but it's pretty dangerous, so dont call after freeing a viewport
 	virtual int viewport_get_render_info(RID p_viewport, ViewportRenderInfo p_info) {
-		visual_server->viewport_get_render_info(p_viewport, p_info);
+		return visual_server->viewport_get_render_info(p_viewport, p_info);
 	}
 
 	FUNC2(viewport_set_debug_draw, RID, ViewportDebugDraw)
@@ -554,7 +554,7 @@ public:
 
 	//this passes directly to avoid stalling
 	virtual int get_render_info(RenderInfo p_info) {
-		visual_server->get_render_info(p_info);
+		return visual_server->get_render_info(p_info);
 	}
 
 	FUNC3(set_boot_image, const Ref<Image> &, const Color &, bool)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -338,8 +338,6 @@ Error VisualServer::_surface_set_data(Array p_arrays, uint32_t p_format, uint32_
 
 	PoolVector<uint8_t>::Write iw;
 	if (r_index_array.size()) {
-		print_line("elements: " + itos(r_index_array.size()));
-
 		iw = r_index_array.write();
 	}
 


### PR DESCRIPTION
Nothing was returned by viewport_get_render_info so I added a `return`.
Also removed a spamming debug print that was slowing down procedural mesh generation.