### PR TITLE
added signal "button_pressed" to ButtonArray base class

### DIFF
--- a/scene/gui/button_array.cpp
+++ b/scene/gui/button_array.cpp
@@ -309,7 +309,26 @@ void ButtonArray::_gui_input(const Ref<InputEvent> &p_event) {
 		return;
 	}
 
+	if (p_event->is_action("ui_accept") && p_event->is_pressed() && selected < (buttons.size())) {
+		set_selected(selected);
+		accept_event();
+		emit_signal("button_pressed", selected);
+		return;
+	}
+
 	Ref<InputEventMouseButton> mb = p_event;
+
+	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
+
+		int ofs = orientation == HORIZONTAL ? mb->get_position().x : mb->get_position().y;
+		for (int i = 0; i < buttons.size(); i++) {
+			if (ofs >= buttons[i]._pos_cache && ofs < buttons[i]._pos_cache + buttons[i]._size_cache) {
+				set_selected(i);
+				emit_signal("button_pressed", i);
+				return;
+			}
+		}
+	}
 
 	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
 
@@ -533,6 +552,7 @@ void ButtonArray::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flat"), "set_flat", "is_flat");
 
 	ADD_SIGNAL(MethodInfo("button_selected", PropertyInfo(Variant::INT, "button_idx")));
+	ADD_SIGNAL(MethodInfo("button_pressed", PropertyInfo(Variant::INT, "button_idx")));
 }
 
 ButtonArray::ButtonArray(Orientation p_orientation) {


### PR DESCRIPTION
ButtonArray has a "button_selected" signal, but not a "button_pressed" signal, which makes code in gdscript more complex to handle situations when you want to get the button that the user really clicked, instead of just "selected". The buttons that inherit from BaseButton all have the "pressed" signal, which made this puzzling for me. So, here is said fix.

I will also attach an example project with everything setted to test this new signal with(as of now) the current master branch.
[bArrayButton_signal_pressed.zip](https://github.com/godotengine/godot/files/1071425/bArrayButton_signal_pressed.zip)
