### PR TITLE
Add ability to use custom script templates.

### DIFF
--- a/core/script_language.h
+++ b/core/script_language.h
@@ -196,6 +196,8 @@ public:
 	virtual void get_comment_delimiters(List<String> *p_delimiters) const = 0;
 	virtual void get_string_delimiters(List<String> *p_delimiters) const = 0;
 	virtual Ref<Script> get_template(const String &p_class_name, const String &p_base_class_name) const = 0;
+	virtual void make_template(const String &p_class_name, const String &p_base_class_name, Ref<Script> &p_script) {}
+	virtual bool is_using_templates() { return false; }
 	virtual bool validate(const String &p_script, int &r_line_error, int &r_col_error, String &r_test_error, const String &p_path = "", List<String> *r_functions = NULL) const = 0;
 	virtual Script *create_script() const = 0;
 	virtual bool has_named_classes() const = 0;

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -292,6 +292,12 @@ void EditorSettings::create() {
 			dir->change_dir("..");
 		}
 
+		if (dir->change_dir("script_templates") != OK) {
+			dir->make_dir("script_templates");
+		} else {
+			dir->change_dir("..");
+		}
+
 		if (dir->change_dir("tmp") != OK) {
 			dir->make_dir("tmp");
 		} else {
@@ -944,6 +950,25 @@ bool EditorSettings::save_text_editor_theme_as(String p_file) {
 		return true;
 	}
 	return false;
+}
+
+Vector<String> EditorSettings::get_script_templates(const String &p_extension) {
+
+	Vector<String> templates;
+	DirAccess *d = DirAccess::open(settings_path + "/script_templates");
+	if (d) {
+		d->list_dir_begin();
+		String file = d->get_next();
+		while (file != String()) {
+			if (file.get_extension() == p_extension) {
+				templates.push_back(file.get_basename());
+			}
+			file = d->get_next();
+		}
+		d->list_dir_end();
+		memdelete(d);
+	}
+	return templates;
 }
 
 bool EditorSettings::_save_text_editor_theme(String p_file) {

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -159,6 +159,8 @@ public:
 	bool save_text_editor_theme();
 	bool save_text_editor_theme_as(String p_file);
 
+	Vector<String> get_script_templates(const String &p_extension);
+
 	void add_shortcut(const String &p_name, Ref<ShortCut> &p_shortcut);
 	bool is_shortcut(const String &p_name, const Ref<InputEvent> &p_event) const;
 	Ref<ShortCut> get_shortcut(const String &p_name) const;

--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -48,6 +48,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	LineEdit *parent_name;
 	Button *parent_browse_button;
 	OptionButton *language_menu;
+	OptionButton *template_menu;
 	LineEdit *file_path;
 	Button *path_button;
 	EditorFileDialog *file_browse;
@@ -68,6 +69,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	bool is_built_in;
 	int current_language;
 	bool re_check_path;
+	String script_template;
 
 	void _path_changed(const String &p_path = String());
 	void _lang_changed(int l = 0);
@@ -75,6 +77,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	bool _validate(const String &p_strin);
 	void _class_name_changed(const String &p_name);
 	void _parent_name_changed(const String &p_parent);
+	void _template_changed(int p_template = 0);
 	void _browse_path(bool browse_parent);
 	void _file_selected(const String &p_file);
 	virtual void ok_pressed();

--- a/modules/gdscript/gd_editor.cpp
+++ b/modules/gdscript/gd_editor.cpp
@@ -69,6 +69,19 @@ Ref<Script> GDScriptLanguage::get_template(const String &p_class_name, const Str
 	return script;
 }
 
+bool GDScriptLanguage::is_using_templates() {
+
+	return true;
+}
+
+void GDScriptLanguage::make_template(const String &p_class_name, const String &p_base_class_name, Ref<Script> &p_script) {
+
+	String src = p_script->get_source_code();
+	src = src.replace("%BASE%", p_base_class_name);
+	src = src.replace("%TS%", _get_indentation());
+	p_script->set_source_code(src);
+}
+
 bool GDScriptLanguage::validate(const String &p_script, int &r_line_error, int &r_col_error, String &r_test_error, const String &p_path, List<String> *r_functions) const {
 
 	GDParser parser;

--- a/modules/gdscript/gd_script.cpp
+++ b/modules/gdscript/gd_script.cpp
@@ -615,6 +615,11 @@ Error GDScript::reload(bool p_keep_state) {
 	if (basedir != "")
 		basedir = basedir.get_base_dir();
 
+	if (basedir.find("res://") == -1 && basedir.find("user://") == -1) {
+		//loading a template, don't parse
+		return OK;
+	}
+
 	valid = false;
 	GDParser parser;
 	Error err = parser.parse(source, basedir, false, path);

--- a/modules/gdscript/gd_script.h
+++ b/modules/gdscript/gd_script.h
@@ -381,6 +381,8 @@ public:
 	virtual void get_comment_delimiters(List<String> *p_delimiters) const;
 	virtual void get_string_delimiters(List<String> *p_delimiters) const;
 	virtual Ref<Script> get_template(const String &p_class_name, const String &p_base_class_name) const;
+	virtual bool is_using_templates();
+	virtual void make_template(const String &p_class_name, const String &p_base_class_name, Ref<Script> &p_script);
 	virtual bool validate(const String &p_script, int &r_line_error, int &r_col_error, String &r_test_error, const String &p_path = "", List<String> *r_functions = NULL) const;
 	virtual Script *create_script() const;
 	virtual bool has_named_classes() const;

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -2369,6 +2369,17 @@ Ref<Script> VisualScriptLanguage::get_template(const String &p_class_name, const
 	script->set_instance_base_type(p_base_class_name);
 	return script;
 }
+
+bool VisualScriptLanguage::is_using_templates() {
+
+	return true;
+}
+
+void VisualScriptLanguage::make_template(const String &p_class_name, const String &p_base_class_name, Ref<Script> &p_script) {
+	Ref<VisualScript> script = p_script;
+	script->set_instance_base_type(p_base_class_name);
+}
+
 bool VisualScriptLanguage::validate(const String &p_script, int &r_line_error, int &r_col_error, String &r_test_error, const String &p_path, List<String> *r_functions) const {
 
 	return false;

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -564,6 +564,8 @@ public:
 	virtual void get_comment_delimiters(List<String> *p_delimiters) const;
 	virtual void get_string_delimiters(List<String> *p_delimiters) const;
 	virtual Ref<Script> get_template(const String &p_class_name, const String &p_base_class_name) const;
+	virtual bool is_using_templates();
+	virtual void make_template(const String &p_class_name, const String &p_base_class_name, Ref<Script> &p_script);
 	virtual bool validate(const String &p_script, int &r_line_error, int &r_col_error, String &r_test_error, const String &p_path = "", List<String> *r_functions = NULL) const;
 	virtual Script *create_script() const;
 	virtual bool has_named_classes() const;


### PR DESCRIPTION
Templates will be loaded from .godot/script_templates
For now they're disabled for GDNative.

![templates](https://user-images.githubusercontent.com/8281916/27102260-1baf2c9c-5074-11e7-87ae-ba48ce221efe.png)

Ideas for further improvements:

- Supply a bunch of default templates.
- Add a "Save as Template" option to the script editor, as it can normally only save to res://
- Support more placeholders / custom placeholders

Fixes #4132