### PR TITLE
Fixed a blit_rect crash with out-of-bounds coords

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -2189,11 +2189,11 @@ void Image::blit_rect(const Image &p_src, const Rect2 &p_src_rect, const Point2 
 
 		for (int i = 0; i < rrect.size.y; i++) {
 
-			if (i < 0 || i >= height)
+			if (i + desti.y < 0 || i + desti.y >= height)
 				continue;
 			for (int j = 0; j < rrect.size.x; j++) {
 
-				if (j < 0 || j >= width)
+				if (j + desti.x < 0 || j + desti.x >= width)
 					continue;
 
 				dst_data_ptr[width * (desti.y + i) + desti.x + j] = src_data_ptr[p_src.width * (srci.y + i) + srci.x + j];
@@ -2204,11 +2204,11 @@ void Image::blit_rect(const Image &p_src, const Rect2 &p_src_rect, const Point2 
 
 		for (int i = 0; i < rrect.size.y; i++) {
 
-			if (i < 0 || i >= height)
+			if (i + p_dest.y < 0 || i + p_dest.y >= height)
 				continue;
 			for (int j = 0; j < rrect.size.x; j++) {
 
-				if (j < 0 || j >= width)
+				if (j + p_dest.x < 0 || j + p_dest.x >= width)
 					continue;
 
 				_put_pixel(p_dest.x + j, p_dest.y + i, p_src._get_pixel(rrect.pos.x + j, rrect.pos.y + i, src_data_ptr, srcdsize), dst_data_ptr);

--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -401,7 +401,7 @@ void AStar::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("get_point_weight_scale", "id"), &AStar::get_point_weight_scale);
 	ObjectTypeDB::bind_method(_MD("remove_point", "id"), &AStar::remove_point);
 
-	ObjectTypeDB::bind_method(_MD("connect_points", "id", "to_id"), &AStar::connect_points, DEFVAL(true));
+	ObjectTypeDB::bind_method(_MD("connect_points", "id", "to_id", "bidirectional"), &AStar::connect_points, DEFVAL(true));
 	ObjectTypeDB::bind_method(_MD("disconnect_points", "id", "to_id"), &AStar::disconnect_points);
 	ObjectTypeDB::bind_method(_MD("are_points_connected", "id", "to_id"), &AStar::are_points_connected);
 

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<doc version="2.1.stable.custom_build" name="Engine Types">
+<doc version="2.1.3.stable.custom_build" name="Engine Types">
 <class name="@GDScript" category="Core">
 	<brief_description>
 		Built-in GDScript functions.
@@ -2181,9 +2181,9 @@
 			<argument index="1" name="pos" type="Vector3">
 			</argument>
 			<argument index="2" name="weight_scale" type="float" default="1">
-				Weight scale has to be 1 or larger.
 			</argument>
 			<description>
+				Add a new point at the given position. The [code]weight_scale[/code] has to be 1 or larger.
 			</description>
 		</method>
 		<method name="are_points_connected" qualifiers="const">
@@ -2204,6 +2204,8 @@
 			<argument index="0" name="id" type="int">
 			</argument>
 			<argument index="1" name="to_id" type="int">
+			</argument>
+			<argument index="2" name="bidirectional" type="bool" default="true">
 			</argument>
 			<description>
 			</description>
@@ -13529,11 +13531,10 @@
 			<return type="bool">
 			</return>
 			<argument index="0" name="extended_check" type="bool" default="false">
-				If true, also check if the associated script and object still exists.
-				The extended check is done in debug mode as part of [method GDFunctionState.resume], but you can use this if you know you may be trying to resume without knowing for sure the object and/or script have survived up to that point.
 			</argument>
 			<description>
 				Check whether the function call may be resumed. This is not the case if the function state was already resumed.
+				If [code]extended_check[/code] is enabled, it also checks if the associated script and object still exist. The extended check is done in debug mode as part of [method GDFunctionState.resume], but you can use this if you know you may be trying to resume without knowing for sure the object and/or script have survived up to that point.
 			</description>
 		</method>
 		<method name="resume">
@@ -20760,8 +20761,40 @@
 			<description>
 			</description>
 		</method>
+		<method name="create_convex_shape" qualifiers="const">
+			<return type="Shape">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="create_outline" qualifiers="const">
+			<return type="Mesh">
+			</return>
+			<argument index="0" name="margin" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="create_trimesh_shape" qualifiers="const">
+			<return type="Shape">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="generate_triangle_mesh" qualifiers="const">
+			<return type="TriangleMesh">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="get_custom_aabb" qualifiers="const">
 			<return type="AABB">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_faces" qualifiers="const">
+			<return type="Vector3Array">
 			</return>
 			<description>
 			</description>
@@ -41104,6 +41137,10 @@
 		</method>
 	</methods>
 	<constants>
+		<constant name="RESIZE_SCALE" value="0">
+		</constant>
+		<constant name="RESIZE_STRETCH" value="1">
+		</constant>
 		<constant name="STRETCH_SCALE_ON_EXPAND" value="0">
 		</constant>
 		<constant name="STRETCH_SCALE" value="1">
@@ -41710,11 +41747,27 @@
 				Return the collision layer.
 			</description>
 		</method>
+		<method name="get_collision_layer_bit" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="bit" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="get_collision_mask" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
 				Return the collision mask.
+			</description>
+		</method>
+		<method name="get_collision_mask_bit" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="bit" type="int">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="get_collision_use_kinematic" qualifiers="const">
@@ -41909,11 +41962,19 @@
 			</description>
 		</method>
 		<method name="set_collision_layer">
-			<argument index="0" name="mask" type="int">
+			<argument index="0" name="layer" type="int">
 			</argument>
 			<description>
 				Set the collision layer.
 				Layers are referenced by binary indexes, so allowable values to describe the 20 available layers range from 0 to 2^20-1.
+			</description>
+		</method>
+		<method name="set_collision_layer_bit">
+			<argument index="0" name="bit" type="int">
+			</argument>
+			<argument index="1" name="value" type="bool">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="set_collision_mask">
@@ -41922,6 +41983,14 @@
 			<description>
 				Set the collision masks.
 				Masks are referenced by binary indexes, so allowable values to describe the 20 available masks range from 0 to 2^20-1.
+			</description>
+		</method>
+		<method name="set_collision_mask_bit">
+			<argument index="0" name="bit" type="int">
+			</argument>
+			<argument index="1" name="value" type="bool">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="set_collision_use_kinematic">
@@ -43145,6 +43214,12 @@
 				Emitted when a cell is selected.
 			</description>
 		</signal>
+		<signal name="column_title_pressed">
+			<argument index="0" name="column" type="int">
+			</argument>
+			<description>
+			</description>
+		</signal>
 		<signal name="custom_popup_edited">
 			<argument index="0" name="arrow_clicked" type="bool">
 			</argument>
@@ -43298,6 +43373,8 @@
 			<argument index="2" name="button_idx" type="int" default="-1">
 			</argument>
 			<argument index="3" name="disabled" type="bool" default="false">
+			</argument>
+			<argument index="4" name="tooltip" type="String" default="&quot;&quot;">
 			</argument>
 			<description>
 			</description>
@@ -45152,6 +45229,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_roll_influence" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="get_suspension_max_force" qualifiers="const">
 			<return type="float">
 			</return>
@@ -45172,6 +45255,12 @@
 		</method>
 		<method name="get_suspension_travel" qualifiers="const">
 			<return type="float">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="is_in_contact" qualifiers="const">
+			<return type="bool">
 			</return>
 			<description>
 			</description>
@@ -45208,6 +45297,12 @@
 		</method>
 		<method name="set_radius">
 			<argument index="0" name="length" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_roll_influence">
+			<argument index="0" name="roll_influence" type="float">
 			</argument>
 			<description>
 			</description>
@@ -47992,7 +48087,7 @@
 		Sets environment properties for the entire scene
 	</brief_description>
 	<description>
-		The [WorldEnvironment] node can be added to a scene in order to set default [Environment] variables for the scene. The [WorldEnvironment] can be overridden by an [Environment] node set on the current [Camera]. Additionally, only one [WorldEnvironment] may be instanced in a given scene at a time. The [WorldEnvironment] allows the user to specify default lighting parameters (e.g. ambient lighting), various post-processing effects (e.g. SSAO, DOF, Tonemapping), and how to draw the background (e.g. solid color, skybox). 
+		The [WorldEnvironment] node can be added to a scene in order to set default [Environment] variables for the scene. The [WorldEnvironment] can be overridden by an [Environment] node set on the current [Camera]. Additionally, only one [WorldEnvironment] may be instanced in a given scene at a time. The [WorldEnvironment] allows the user to specify default lighting parameters (e.g. ambient lighting), various post-processing effects (e.g. SSAO, DOF, Tonemapping), and how to draw the background (e.g. solid color, skybox).
 	</description>
 	<methods>
 		<method name="get_environment" qualifiers="const">
@@ -48323,4 +48418,3 @@
 	</constants>
 </class>
 </doc>
-

--- a/doc/tools/makemd.py
+++ b/doc/tools/makemd.py
@@ -273,6 +273,12 @@ def make_doku_class(node):
         f.write('\n###  Signals  \n')
         for m in list(events):
             make_method(f, node.attrib['name'], m, True, True)
+            d = m.find('description')
+            if d == None or d.text.strip() == '':
+                continue
+            f.write('\n')
+            f.write(dokuize_text(d.text.strip()))
+            f.write('\n')
 
     members = node.find('members')
 

--- a/doc/tools/makerst.py
+++ b/doc/tools/makerst.py
@@ -441,6 +441,12 @@ def make_rst_class(node):
         f.write(make_heading('Signals', '-'))
         for m in list(events):
             make_method(f, node.attrib['name'], m, True, name, True)
+            d = m.find('description')
+            if d == None or d.text.strip() == '':
+                continue
+            f.write(rstize_text(d.text.strip(), name))
+            f.write("\n\n")
+            
         f.write('\n')
 
     members = node.find('members')

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -9871,10 +9871,13 @@ void RasterizerGLES2::_update_framebuffer() {
 	glGenTextures(1, &framebuffer.sample_color);
 	glBindTexture(GL_TEXTURE_2D, framebuffer.sample_color);
 	glTexImage2D(GL_TEXTURE_2D, 0, format_rgba, framebuffer.width, framebuffer.height, 0, format_internal, format_type, NULL);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-	//	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	//	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	if (bool(GLOBAL_DEF("rasterizer/texscreen_filtered", false))) {
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	} else {
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	}
 	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, framebuffer.sample_color, 0);

--- a/drivers/gles2/shader_compiler_gles2.h
+++ b/drivers/gles2/shader_compiler_gles2.h
@@ -44,6 +44,8 @@ private:
 	Error compile_node(ShaderLanguage::ProgramNode *p_program);
 	static Error create_glsl_120_code(void *p_str, ShaderLanguage::ProgramNode *p_program);
 
+	bool _is_condition_preprocessable(ShaderLanguage::Node *p_condition) const;
+
 	bool uses_light;
 	bool uses_texscreen;
 	bool uses_texpos;

--- a/drivers/gles2/shaders/canvas.glsl
+++ b/drivers/gles2/shaders/canvas.glsl
@@ -39,6 +39,9 @@ uniform vec2 normal_flip;
 varying highp vec2 pos;
 #endif
 
+#define at_light_pass 1
+#else
+#define at_light_pass 0
 #endif
 
 #if defined(ENABLE_VAR1_INTERP)
@@ -176,6 +179,9 @@ uniform float shadow_esm_multiplier;
 
 #endif
 
+#define at_light_pass 1
+#else
+#define at_light_pass 0
 #endif
 
 #if defined(USE_TEXPIXEL_SIZE)

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -596,6 +596,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("2d_editor/keep_margins_when_changing_anchors", false);
 
 	set("2d_editor/warped_mouse_panning", true);
+	set("2d_editor/scroll_to_pan", false);
+	set("2d_editor/pan_speed", 20);
 
 	set("game_window_placement/rect", 0);
 	hints["game_window_placement/rect"] = PropertyInfo(Variant::INT, "game_window_placement/rect", PROPERTY_HINT_ENUM, "Default,Centered,Custom Position,Force Maximized,Force Full Screen");

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -599,7 +599,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("2d_editor/scroll_to_pan", false);
 	set("2d_editor/pan_speed", 20);
 
-	set("game_window_placement/rect", 0);
+	set("game_window_placement/rect", 1);
 	hints["game_window_placement/rect"] = PropertyInfo(Variant::INT, "game_window_placement/rect", PROPERTY_HINT_ENUM, "Default,Centered,Custom Position,Force Maximized,Force Full Screen");
 	String screen_hints = TTR("Default (Same as Editor)");
 	for (int i = 0; i < OS::get_singleton()->get_screen_count(); i++) {

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1037,17 +1037,27 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent &p_event) {
 
 		if (b.button_index == BUTTON_WHEEL_DOWN) {
 
-			if (zoom < MIN_ZOOM)
-				return;
+			if (bool(EditorSettings::get_singleton()->get("2d_editor/scroll_to_pan"))) {
 
-			float prev_zoom = zoom;
-			zoom = zoom * (1 - (0.05 * b.factor));
-			{
-				Point2 ofs(b.x, b.y);
-				ofs = ofs / prev_zoom - ofs / zoom;
-				h_scroll->set_val(h_scroll->get_val() + ofs.x);
-				v_scroll->set_val(v_scroll->get_val() + ofs.y);
+				v_scroll->set_val(v_scroll->get_val() + int(EditorSettings::get_singleton()->get("2d_editor/pan_speed")) / zoom * b.factor);
+
 			}
+			else {
+
+				if (zoom < MIN_ZOOM)
+					return;
+
+				float prev_zoom = zoom;
+				zoom = zoom * (1 - (0.05 * b.factor));
+				{
+					Point2 ofs(b.x, b.y);
+					ofs = ofs / prev_zoom - ofs / zoom;
+					h_scroll->set_val(h_scroll->get_val() + ofs.x);
+					v_scroll->set_val(v_scroll->get_val() + ofs.y);
+				}
+
+			}
+
 			_update_scroll(0);
 			viewport->update();
 			return;
@@ -1055,21 +1065,56 @@ void CanvasItemEditor::_viewport_input_event(const InputEvent &p_event) {
 
 		if (b.button_index == BUTTON_WHEEL_UP) {
 
-			if (zoom > MAX_ZOOM)
-				return;
+			if (bool(EditorSettings::get_singleton()->get("2d_editor/scroll_to_pan"))) {
 
-			float prev_zoom = zoom;
-			zoom = zoom * ((0.95 + (0.05 * b.factor)) / 0.95);
-			{
-				Point2 ofs(b.x, b.y);
-				ofs = ofs / prev_zoom - ofs / zoom;
-				h_scroll->set_val(h_scroll->get_val() + ofs.x);
-				v_scroll->set_val(v_scroll->get_val() + ofs.y);
+				v_scroll->set_val(v_scroll->get_val() - int(EditorSettings::get_singleton()->get("2d_editor/pan_speed")) / zoom * b.factor);
+
+			}
+			else {
+
+				if (zoom > MAX_ZOOM)
+					return;
+
+				float prev_zoom = zoom;
+				zoom = zoom * ((0.95 + (0.05 * b.factor)) / 0.95);
+				{
+					Point2 ofs(b.x, b.y);
+					ofs = ofs / prev_zoom - ofs / zoom;
+					h_scroll->set_val(h_scroll->get_val() + ofs.x);
+					v_scroll->set_val(v_scroll->get_val() + ofs.y);
+				}
+
 			}
 
 			_update_scroll(0);
 			viewport->update();
 			return;
+		}
+
+		if (b.button_index == BUTTON_WHEEL_LEFT) {
+
+			if (bool(EditorSettings::get_singleton()->get("2d_editor/scroll_to_pan"))) {
+
+				h_scroll->set_val(h_scroll->get_val() - int(EditorSettings::get_singleton()->get("2d_editor/pan_speed")) / zoom * b.factor);
+
+				_update_scroll(0);
+				viewport->update();
+
+			}
+
+		}
+
+		if (b.button_index == BUTTON_WHEEL_RIGHT) {
+
+			if (bool(EditorSettings::get_singleton()->get("2d_editor/scroll_to_pan"))) {
+
+				h_scroll->set_val(h_scroll->get_val() + int(EditorSettings::get_singleton()->get("2d_editor/pan_speed")) / zoom * b.factor);
+
+				_update_scroll(0);
+				viewport->update();
+
+			}
+
 		}
 
 		if (b.button_index == BUTTON_RIGHT) {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -511,8 +511,7 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 						if (motion < 0) {
 							mb.button_index = BUTTON_WHEEL_LEFT;
 							mb.factor = fabs((double)motion / (double)WHEEL_DELTA);
-						}
-						else {
+						} else {
 							mb.button_index = BUTTON_WHEEL_RIGHT;
 							mb.factor = fabs((double)motion / (double)WHEEL_DELTA);
 						}
@@ -550,9 +549,6 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 					mb.y = old_y;
 				}
 
-				mb.global_x = mb.x;
-				mb.global_y = mb.y;
-
 				if (uMsg != WM_MOUSEWHEEL) {
 					if (mb.pressed) {
 
@@ -576,6 +572,9 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 					mb.x = coords.x;
 					mb.y = coords.y;
 				}
+
+				mb.global_x = mb.x;
+				mb.global_y = mb.y;
 
 				if (main_loop) {
 					input->parse_input_event(event);

--- a/scene/2d/screen_button.h
+++ b/scene/2d/screen_button.h
@@ -64,6 +64,8 @@ private:
 
 	void _input(const InputEvent &p_Event);
 
+	bool _is_touch_inside(const InputEventScreenTouch &p_touch);
+
 	void _press(int p_finger_pressed);
 	void _release(bool p_exiting_tree = false);
 

--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -1124,6 +1124,7 @@ const ShaderLanguage::BuiltinsDef ShaderLanguage::ci_vertex_builtins_defs[] = {
 	{ "PROJECTION_MATRIX", TYPE_MAT4 },
 	{ "EXTRA_MATRIX", TYPE_MAT4 },
 	{ "TIME", TYPE_FLOAT },
+	{ "AT_LIGHT_PASS", TYPE_BOOL },
 	{ NULL, TYPE_VOID },
 };
 const ShaderLanguage::BuiltinsDef ShaderLanguage::ci_fragment_builtins_defs[] = {
@@ -1145,6 +1146,7 @@ const ShaderLanguage::BuiltinsDef ShaderLanguage::ci_fragment_builtins_defs[] = 
 	//	{ "SCREEN_POS", TYPE_VEC2},
 	//	{ "SCREEN_TEXEL_SIZE", TYPE_VEC2},
 	{ "TIME", TYPE_FLOAT },
+	{ "AT_LIGHT_PASS", TYPE_BOOL },
 	{ NULL, TYPE_VOID }
 
 };


### PR DESCRIPTION
{Fixes the previous PR}
There is an issue with blit_rect leading to a crash and out-of-bounds write when the blitted sprite exceeds the destination sprite coordinates.
I attached a simple example project to this PR
[blittest.zip](https://github.com/godotengine/godot/files/1073322/blittest.zip)
