### PR TITLE
Correct Image::blit_rect

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1612,11 +1612,11 @@ void Image::blit_rect(const Ref<Image> &p_src, const Rect2 &p_src_rect, const Po
 	ERR_FAIL_COND(srcdsize == 0);
 	ERR_FAIL_COND(format != p_src->format);
 
-	Rect2i local_src_rect = Rect2i(0, 0, width, height).clip(Rect2i(p_dest + p_src_rect.position, p_src_rect.size));
-
-	if (local_src_rect.size.x <= 0 || local_src_rect.size.y <= 0)
+	Rect2i clipped_src_rect = Rect2i(0, 0, p_src->width, p_src->height).clip(p_src_rect);
+	if (clipped_src_rect.size.x <= 0 || clipped_src_rect.size.y <= 0)
 		return;
-	Rect2i src_rect(p_src_rect.position + (local_src_rect.position - p_dest), local_src_rect.size);
+
+	Rect2i dest_rect = Rect2i(0, 0, width, height).clip(Rect2i(p_dest, clipped_src_rect.size));
 
 	PoolVector<uint8_t>::Write wp = data.write();
 	uint8_t *dst_data_ptr = wp.ptr();
@@ -1626,15 +1626,15 @@ void Image::blit_rect(const Ref<Image> &p_src, const Rect2 &p_src_rect, const Po
 
 	int pixel_size = get_format_pixel_size(format);
 
-	for (int i = 0; i < src_rect.size.y; i++) {
+	for (int i = 0; i < dest_rect.size.y; i++) {
 
-		for (int j = 0; j < src_rect.size.x; j++) {
+		for (int j = 0; j < dest_rect.size.x; j++) {
 
-			int src_x = src_rect.position.x + j;
-			int src_y = src_rect.position.y + i;
+			int src_x = clipped_src_rect.position.x + j;
+			int src_y = clipped_src_rect.position.y + i;
 
-			int dst_x = local_src_rect.position.x + j;
-			int dst_y = local_src_rect.position.y + i;
+			int dst_x = dest_rect.position.x + j;
+			int dst_y = dest_rect.position.y + i;
 
 			const uint8_t *src = &src_data_ptr[(src_y * p_src->width + src_x) * pixel_size];
 			uint8_t *dst = &dst_data_ptr[(dst_y * width + dst_x) * pixel_size];


### PR DESCRIPTION
#9156 shows a bug in copying a rectangular subsection of an image to a new image. This PR corrects the calculation of rectangles in `Image::blit_rect` that causes it.