### PR TITLE
Fix/improve TouchScreenButton

### DIFF
--- a/scene/2d/screen_button.h
+++ b/scene/2d/screen_button.h
@@ -63,6 +63,8 @@ private:
 
 	void _input(const Ref<InputEvent> &p_Event);
 
+	bool _is_point_inside(const Point2 &p_point);
+
 	void _press(int p_finger_pressed);
 	void _release(bool p_exiting_tree = false);
 


### PR DESCRIPTION
- Refactor touch acceptance logic so the same is used whether passby is enabled or not.
- Remove the check for visibility during input handling as it should never fail; instead using now an ERR_FAIL_COND() just in case since we have been checking for that so far.
- Fix cast to wrong InputEventScreenTouch when it should be InputEventScreenDrag.
- Replaced use of references by plain pointers for a more readable code and maybe a little performance gain.