### PR TITLE
Fix/improve TouchScreenButton (2.1)

### DIFF
--- a/scene/2d/screen_button.h
+++ b/scene/2d/screen_button.h
@@ -64,6 +64,8 @@ private:
 
 	void _input(const InputEvent &p_Event);
 
+	bool _is_touch_inside(const InputEventScreenTouch &p_touch);
+
 	void _press(int p_finger_pressed);
 	void _release(bool p_exiting_tree = false);
 


### PR DESCRIPTION
- Refactor touch acceptance logic so the same is used whether passby is enabled or not.
- Remove the check for visibility during input handling as it should never fail; instead using now an ERR_FAIL_COND() just in case since we have been checking for that so far.

Fixes #9159.

__NOTE;__ I've done this pretty quickly. It seems to be OK, but if @Danathus (as the issue reporter) and others could check, that'd be nice.