### PR TITLE
Ability to get a list of signals that are targeting given object

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1332,6 +1332,21 @@ Array Object::_get_signal_connection_list(const String &p_signal) const {
 	return ret;
 }
 
+Array Object::_get_incoming_connections() const {
+
+	Array ret;
+	int connections_amount = connections.size();
+	for (int idx_conn = 0; idx_conn < connections_amount; idx_conn++) {
+		Dictionary conn_data;
+		conn_data["source"] = connections[idx_conn].source;
+		conn_data["signal_name"] = connections[idx_conn].signal;
+		conn_data["method_name"] = connections[idx_conn].method;
+		ret.push_back(conn_data);
+	}
+
+	return ret;
+}
+
 void Object::get_signal_list(List<MethodInfo> *p_signals) const {
 
 	if (!script.is_null()) {
@@ -1641,6 +1656,7 @@ void Object::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_signal_list"), &Object::_get_signal_list);
 	ClassDB::bind_method(D_METHOD("get_signal_connection_list", "signal"), &Object::_get_signal_connection_list);
+	ClassDB::bind_method(D_METHOD("get_incoming_connections"), &Object::_get_incoming_connections);
 
 	ClassDB::bind_method(D_METHOD("connect", "signal", "target:Object", "method", "binds", "flags"), &Object::connect, DEFVAL(Array()), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("disconnect", "signal", "target:Object", "method"), &Object::disconnect);

--- a/core/object.h
+++ b/core/object.h
@@ -442,6 +442,7 @@ private:
 	Variant _emit_signal(const Variant **p_args, int p_argcount, Variant::CallError &r_error);
 	Array _get_signal_list() const;
 	Array _get_signal_connection_list(const String &p_signal) const;
+	Array _get_incoming_connections() const;
 	void _set_bind(const String &p_set, const Variant &p_value);
 	Variant _get_bind(const String &p_name) const;
 


### PR DESCRIPTION
Object has new method "get_incoming_connections" that's returning an array of dictionaries with informations about signals that are connected to this object.
Inside each dictionary there are 3 fields:
- "source" is a reference to signal emitter
- "signal_name" is name of signal that's connected
- "method_name" is a name of method to which signal is connected