### PR TITLE
Enhance scene tabs

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -675,7 +675,12 @@ String EditorData::get_scene_title(int p_idx) const {
 		return "[empty]";
 	if (edited_scene[p_idx].root->get_filename() == "")
 		return "[unsaved]";
-	return edited_scene[p_idx].root->get_filename().get_file();
+	bool show_ext = EDITOR_DEF("interface/scene_tabs/show_extension", false);
+	String name = edited_scene[p_idx].root->get_filename().get_file();
+	if (!show_ext) {
+		name = name.get_basename();
+	}
+	return name;
 }
 
 String EditorData::get_scene_path(int p_idx) const {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -233,6 +233,8 @@ private:
 	//main tabs
 
 	Tabs *scene_tabs;
+	Panel *tab_preview_panel;
+	TextureRect *tab_preview;
 	int tab_closing;
 
 	bool exiting;
@@ -556,6 +558,10 @@ private:
 	void _dock_popup_exit();
 	void _scene_tab_changed(int p_tab);
 	void _scene_tab_closed(int p_tab);
+	void _scene_tab_hover(int p_tab);
+	void _scene_tab_exit();
+	void _scene_tab_input(const Ref<InputEvent> &p_input);
+	void _thumbnail_done(const String &p_path, const Ref<Texture> &p_preview, const Variant &p_udata);
 	void _scene_tab_script_edited(int p_tab);
 
 	Dictionary _get_main_scene_state();

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -522,6 +522,12 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("interface/theme/custom_theme", "");
 	hints["interface/theme/custom_theme"] = PropertyInfo(Variant::STRING, "interface/theme/custom_theme", PROPERTY_HINT_GLOBAL_FILE, "*.res,*.tres,*.theme", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 
+	set("interface/scene_tabs/show_extension", false);
+	set("interface/scene_tabs/show_thumbnail_on_hover", true);
+	set("interface/scene_tabs/resize_if_many_tabs", true);
+	set("interface/scene_tabs/minimum_width", 50);
+	hints["interface/scene_tabs/minimum_width"] = PropertyInfo(Variant::INT, "interface/scene_tabs/minimum_width", PROPERTY_HINT_RANGE, "50,500,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
+
 	set("filesystem/directories/autoscan_project_path", "");
 	hints["filesystem/directories/autoscan_project_path"] = PropertyInfo(Variant::STRING, "filesystem/directories/autoscan_project_path", PROPERTY_HINT_GLOBAL_DIR);
 	set("filesystem/directories/default_project_path", "");

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -307,6 +307,8 @@ Ref<Theme> create_editor_theme() {
 	theme->set_color("font_color_bg", "TabContainer", light_color_2);
 	theme->set_icon("menu", "TabContainer", theme->get_icon("TabMenu", "EditorIcons"));
 	theme->set_icon("menu_hl", "TabContainer", theme->get_icon("TabMenu", "EditorIcons"));
+	theme->set_stylebox("SceneTabFG", "EditorStyles", make_flat_stylebox(base_color, 10, 5, 10, 5));
+	theme->set_stylebox("SceneTabBG", "EditorStyles", make_empty_stylebox(6, 5, 6, 5));
 
 	// Debugger
 	Ref<StyleBoxFlat> style_panel_debugger = make_flat_stylebox(dark_color_2, 0, 4, 0, 0);

--- a/scene/gui/tabs.h
+++ b/scene/gui/tabs.h
@@ -59,6 +59,7 @@ private:
 		int ofs_cache;
 		bool disabled;
 		int size_cache;
+		int size_text;
 		int x_cache;
 		int x_size_cache;
 
@@ -74,7 +75,6 @@ private:
 	bool missing_right;
 	Vector<Tab> tabs;
 	int current;
-	Control *_get_tab(int idx) const;
 	int _get_top_margin() const;
 	TabAlign tab_align;
 	int rb_hover;
@@ -85,9 +85,11 @@ private:
 	CloseButtonDisplayPolicy cb_displaypolicy;
 
 	int hover; // hovered tab
+	int min_width;
 
 	int get_tab_width(int p_idx) const;
 	void _ensure_no_over_offset();
+	void _update_cache();
 
 protected:
 	void _gui_input(const Ref<InputEvent> &p_event);
@@ -117,13 +119,16 @@ public:
 	int get_tab_count() const;
 	void set_current_tab(int p_current);
 	int get_current_tab() const;
+	int get_hovered_tab() const;
 
 	void remove_tab(int p_idx);
 
 	void clear_tabs();
 
 	void ensure_tab_visible(int p_idx);
+	void set_min_width(int p_width);
 
+	Rect2 get_tab_rect(int p_tab);
 	Size2 get_minimum_size() const;
 
 	Tabs();


### PR DESCRIPTION
- show scene thumbnail on hover
- resize if has many tabs
- show full scene file name with current edited scene
- can be customized EditorSettings > Interface > Scene Tab
- close scene with mouse middle button

![scene tab 5](https://user-images.githubusercontent.com/8281454/27189154-732b4e70-522b-11e7-93bc-387f33681c36.gif)
