### PR TITLE
Rename Godot-specific resource extensions

### DIFF
--- a/core/translation.h
+++ b/core/translation.h
@@ -36,7 +36,7 @@ class Translation : public Resource {
 
 	GDCLASS(Translation, Resource);
 	OBJ_SAVE_TYPE(Translation);
-	RES_BASE_EXTENSION("xl");
+	RES_BASE_EXTENSION("translation");
 
 	String locale;
 	Map<StringName, StringName> translation_map;

--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -113,13 +113,13 @@ void EditorAssetInstaller::open(const String &p_path, int p_depth) {
 		extension_guess["png"] = get_icon("Texture", "EditorIcons");
 		extension_guess["jpg"] = get_icon("Texture", "EditorIcons");
 		extension_guess["tex"] = get_icon("Texture", "EditorIcons");
-		extension_guess["atex"] = get_icon("Texture", "EditorIcons");
+		extension_guess["atlastex"] = get_icon("Texture", "EditorIcons");
 		extension_guess["dds"] = get_icon("Texture", "EditorIcons");
 		extension_guess["scn"] = get_icon("PackedScene", "EditorIcons");
 		extension_guess["tscn"] = get_icon("PackedScene", "EditorIcons");
 		extension_guess["xml"] = get_icon("PackedScene", "EditorIcons");
 		extension_guess["xscn"] = get_icon("PackedScene", "EditorIcons");
-		extension_guess["mtl"] = get_icon("Material", "EditorIcons");
+		extension_guess["material"] = get_icon("Material", "EditorIcons");
 		extension_guess["shd"] = get_icon("Shader", "EditorIcons");
 		extension_guess["gd"] = get_icon("GDScript", "EditorIcons");
 	}

--- a/editor/import/resource_importer_obj.cpp
+++ b/editor/import/resource_importer_obj.cpp
@@ -49,7 +49,7 @@ void ResourceImporterOBJ::get_recognized_extensions(List<String> *p_extensions) 
 	p_extensions->push_back("obj");
 }
 String ResourceImporterOBJ::get_save_extension() const {
-	return "msh";
+	return "mesh";
 }
 
 String ResourceImporterOBJ::get_resource_type() const {

--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -48,7 +48,7 @@ void ResourceImporterWAV::get_recognized_extensions(List<String> *p_extensions) 
 	p_extensions->push_back("wav");
 }
 String ResourceImporterWAV::get_save_extension() const {
-	return "smp";
+	return "sample";
 }
 
 String ResourceImporterWAV::get_resource_type() const {

--- a/editor/io_plugins/editor_font_import_plugin.cpp
+++ b/editor/io_plugins/editor_font_import_plugin.cpp
@@ -533,16 +533,16 @@ class EditorFontImportDialog : public ConfirmationDialog {
 			return;
 		}
 
-		if (dest->get_line_edit()->get_text().get_file()==".fnt") {
-			dest->get_line_edit()->set_text(dest->get_line_edit()->get_text().get_base_dir() + "/" + source->get_line_edit()->get_text().get_file().get_basename() + ".fnt" );
+		if (dest->get_line_edit()->get_text().get_file()==".font") {
+			dest->get_line_edit()->set_text(dest->get_line_edit()->get_text().get_base_dir() + "/" + source->get_line_edit()->get_text().get_file().get_basename() + ".font" );
 		}
 
 		if (dest->get_line_edit()->get_text().get_extension() == dest->get_line_edit()->get_text()) {
-			dest->get_line_edit()->set_text(dest->get_line_edit()->get_text() + ".fnt");
+			dest->get_line_edit()->set_text(dest->get_line_edit()->get_text() + ".font");
 		}
 
-		if (dest->get_line_edit()->get_text().get_extension().to_lower() != "fnt") {
-			error_dialog->set_text(TTR("Invalid file extension.\nPlease use .fnt."));
+		if (dest->get_line_edit()->get_text().get_extension().to_lower() != "font") {
+			error_dialog->set_text(TTR("Invalid file extension.\nPlease use .font."));
 			error_dialog->popup_centered(Size2(200,100));
 			return;
 		}
@@ -665,7 +665,7 @@ public:
 		//
 		List<String> fl;
 		Ref<BitmapFont> font= memnew(BitmapFont);
-		dest->get_file_dialog()->add_filter("*.fnt ; Font" );
+		dest->get_file_dialog()->add_filter("*.font ; Font" );
 		/*
 		ResourceSaver::get_recognized_extensions(font,&fl);
 		for(List<String>::Element *E=fl.front();E;E=E->next()) {
@@ -1690,7 +1690,7 @@ void EditorFontImportPlugin::import_from_drop(const Vector<String>& p_drop, cons
 		if (ext=="ttf" || ext=="otf" || ext=="fnt") {
 
 			import_dialog();
-			dialog->set_source_and_dest(p_drop[i],p_dest_path.plus_file(file.get_basename()+".fnt"));
+			dialog->set_source_and_dest(p_drop[i],p_dest_path.plus_file(file.get_basename()+".font"));
 			break;
 		}
 	}

--- a/editor/io_plugins/editor_texture_import_plugin.cpp
+++ b/editor/io_plugins/editor_texture_import_plugin.cpp
@@ -596,7 +596,7 @@ void EditorTextureImportDialog::_mode_changed(int p_mode) {
 		size->show();
 
 		file_select->set_mode(EditorFileDialog::MODE_OPEN_FILE);
-		save_file_select->add_filter("*.ltex;"+TTR("Large Texture"));
+		save_file_select->add_filter("*.largetex;"+TTR("Large Texture"));
 
 		texture_options->set_flags(EditorTextureImportPlugin::IMAGE_FLAG_FIX_BORDER_ALPHA|EditorTextureImportPlugin::IMAGE_FLAG_NO_MIPMAPS|EditorTextureImportPlugin::IMAGE_FLAG_FILTER);
 		texture_options->set_quality(0.7);

--- a/modules/stb_vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/stb_vorbis/audio_stream_ogg_vorbis.h
@@ -77,7 +77,7 @@ class AudioStreamOGGVorbis : public AudioStream {
 
 	GDCLASS(AudioStreamOGGVorbis, AudioStream)
 	OBJ_SAVE_TYPE(AudioStream) //children are all saved as AudioStream, so they can be exchanged
-	RES_BASE_EXTENSION("asogg");
+	RES_BASE_EXTENSION("oggstr");
 
 	friend class AudioStreamPlaybackOGGVorbis;
 

--- a/modules/stb_vorbis/resource_importer_ogg_vorbis.cpp
+++ b/modules/stb_vorbis/resource_importer_ogg_vorbis.cpp
@@ -48,7 +48,7 @@ void ResourceImporterOGGVorbis::get_recognized_extensions(List<String> *p_extens
 }
 
 String ResourceImporterOGGVorbis::get_save_extension() const {
-	return "asogg";
+	return "oggstr";
 }
 
 String ResourceImporterOGGVorbis::get_resource_type() const {

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -37,7 +37,7 @@
 class Animation : public Resource {
 
 	GDCLASS(Animation, Resource);
-	RES_BASE_EXTENSION("anm");
+	RES_BASE_EXTENSION("anim");
 
 public:
 	enum TrackType {

--- a/scene/resources/audio_stream_sample.h
+++ b/scene/resources/audio_stream_sample.h
@@ -84,7 +84,7 @@ public:
 
 class AudioStreamSample : public AudioStream {
 	GDCLASS(AudioStreamSample, AudioStream)
-	RES_BASE_EXTENSION("smp")
+	RES_BASE_EXTENSION("sample")
 
 public:
 	enum Format {

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -66,7 +66,7 @@ public:
 class BitmapFont : public Font {
 
 	GDCLASS(BitmapFont, Font);
-	RES_BASE_EXTENSION("fnt");
+	RES_BASE_EXTENSION("font");
 
 	Vector<Ref<Texture> > textures;
 

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -43,7 +43,7 @@
 class Material : public Resource {
 
 	GDCLASS(Material, Resource);
-	RES_BASE_EXTENSION("mtl");
+	RES_BASE_EXTENSION("material");
 	OBJ_SAVE_TYPE(Material);
 
 	RID material;

--- a/scene/resources/mesh.h
+++ b/scene/resources/mesh.h
@@ -140,7 +140,7 @@ public:
 class ArrayMesh : public Mesh {
 
 	GDCLASS(ArrayMesh, Mesh);
-	RES_BASE_EXTENSION("msh");
+	RES_BASE_EXTENSION("mesh");
 
 private:
 	struct Surface {

--- a/scene/resources/mesh_library.h
+++ b/scene/resources/mesh_library.h
@@ -39,7 +39,7 @@
 class MeshLibrary : public Resource {
 
 	GDCLASS(MeshLibrary, Resource);
-	RES_BASE_EXTENSION("gt");
+	RES_BASE_EXTENSION("meshlib");
 
 	struct Item {
 		String name;

--- a/scene/resources/multimesh.h
+++ b/scene/resources/multimesh.h
@@ -36,7 +36,7 @@
 class MultiMesh : public Resource {
 
 	GDCLASS(MultiMesh, Resource);
-	RES_BASE_EXTENSION("mmsh");
+	RES_BASE_EXTENSION("multimesh");
 
 public:
 	enum TransformFormat {

--- a/scene/resources/shader_graph.h
+++ b/scene/resources/shader_graph.h
@@ -37,7 +37,7 @@
 class ShaderGraph : public Shader {
 
 	GDCLASS( ShaderGraph, Shader );
-	RES_BASE_EXTENSION("sgp");
+	RES_BASE_EXTENSION("vshader");
 
 public:
 

--- a/scene/resources/shape.h
+++ b/scene/resources/shape.h
@@ -37,7 +37,7 @@ class Shape : public Resource {
 
 	GDCLASS(Shape, Resource);
 	OBJ_SAVE_TYPE(Shape);
-	RES_BASE_EXTENSION("shp");
+	RES_BASE_EXTENSION("shape");
 	RID shape;
 
 	Ref<ArrayMesh> debug_mesh_cache;

--- a/scene/resources/style_box.h
+++ b/scene/resources/style_box.h
@@ -39,7 +39,7 @@
 class StyleBox : public Resource {
 
 	GDCLASS(StyleBox, Resource);
-	RES_BASE_EXTENSION("sbx");
+	RES_BASE_EXTENSION("stylebox");
 	OBJ_SAVE_TYPE(StyleBox);
 	float margin[4];
 

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -226,7 +226,7 @@ VARIANT_ENUM_CAST(ImageTexture::Storage);
 class AtlasTexture : public Texture {
 
 	GDCLASS(AtlasTexture, Texture);
-	RES_BASE_EXTENSION("atex");
+	RES_BASE_EXTENSION("atlastex");
 
 protected:
 	Ref<Texture> atlas;
@@ -265,7 +265,7 @@ public:
 class LargeTexture : public Texture {
 
 	GDCLASS(LargeTexture, Texture);
-	RES_BASE_EXTENSION("ltex");
+	RES_BASE_EXTENSION("largetex");
 
 protected:
 	struct Piece {
@@ -312,7 +312,7 @@ public:
 class CubeMap : public Resource {
 
 	GDCLASS(CubeMap, Resource);
-	RES_BASE_EXTENSION("cbm");
+	RES_BASE_EXTENSION("cubemap");
 
 public:
 	enum Storage {
@@ -393,7 +393,7 @@ VARIANT_ENUM_CAST(CubeMap::Storage);
 class CurveTexture : public Texture {
 
 	GDCLASS(CurveTexture, Texture);
-	RES_BASE_EXTENSION("cvtex");
+	RES_BASE_EXTENSION("curvetex");
 
 private:
 	RID texture;

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -43,7 +43,7 @@
 class Theme : public Resource {
 
 	GDCLASS(Theme, Resource);
-	RES_BASE_EXTENSION("thm");
+	RES_BASE_EXTENSION("theme");
 
 	static Ref<Theme> default_theme;
 

--- a/scene/resources/world.h
+++ b/scene/resources/world.h
@@ -41,7 +41,7 @@ class VisibilityNotifier;
 
 class World : public Resource {
 	GDCLASS(World, Resource);
-	RES_BASE_EXTENSION("wrd");
+	RES_BASE_EXTENSION("world");
 
 private:
 	RID space;


### PR DESCRIPTION
Let's break compatibility a little more for a good cause.

Closes #9199.