### PR TITLE
Fixed memory leaks

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -3107,6 +3107,7 @@ void RasterizerStorageGLES3::mesh_remove_surface(RID p_mesh, int p_surface) {
 	}
 
 	glDeleteVertexArrays(1, &surface->array_id);
+	glDeleteVertexArrays(1, &surface->instancing_array_id);
 
 	for (int i = 0; i < surface->blend_shapes.size(); i++) {
 


### PR DESCRIPTION
- PoolVector leak
- mesh_remove_surface leak

Discussed with Reduz on IRC, fixes https://github.com/godotengine/godot/issues/8225

(there are certainly more leaks to fix)