### PR TITLE
Increase the default perspective camera FOV

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -598,7 +598,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("editors/3d/grid_color", Color(0, 1, 0, 0.2));
 	hints["editors/3d/grid_color"] = PropertyInfo(Variant::COLOR, "editors/3d/grid_color", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 
-	set("editors/3d/default_fov", 45.0);
+	set("editors/3d/default_fov", 55.0);
 	set("editors/3d/default_z_near", 0.1);
 	set("editors/3d/default_z_far", 500.0);
 

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -3682,7 +3682,7 @@ void SpatialEditor::_bind_methods() {
 
 void SpatialEditor::clear() {
 
-	settings_fov->set_value(EDITOR_DEF("editors/3d/default_fov", 60.0));
+	settings_fov->set_value(EDITOR_DEF("editors/3d/default_fov", 55.0));
 	settings_znear->set_value(EDITOR_DEF("editors/3d/default_z_near", 0.1));
 	settings_zfar->set_value(EDITOR_DEF("editors/3d/default_z_far", 1500.0));
 
@@ -3900,7 +3900,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	settings_fov->set_max(179);
 	settings_fov->set_min(1);
 	settings_fov->set_step(0.01);
-	settings_fov->set_value(EDITOR_DEF("editors/3d/default_fov", 60.0));
+	settings_fov->set_value(EDITOR_DEF("editors/3d/default_fov", 55.0));
 	settings_vbc->add_margin_child(TTR("Perspective FOV (deg.):"), settings_fov);
 
 	settings_znear = memnew(SpinBox);

--- a/scene/3d/camera.cpp
+++ b/scene/3d/camera.cpp
@@ -626,7 +626,7 @@ Camera::Camera() {
 	current = false;
 	force_change = false;
 	mode = PROJECTION_PERSPECTIVE;
-	set_perspective(60.0, 0.1, 100.0);
+	set_perspective(65.0, 0.1, 100.0);
 	keep_aspect = KEEP_HEIGHT;
 	layers = 0xfffff;
 	v_offset = 0;

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -118,7 +118,7 @@ public:
 		Camera() {
 
 			visible_layers = 0xFFFFFFFF;
-			fov = 60;
+			fov = 65;
 			type = PERSPECTIVE;
 			znear = 0.1;
 			zfar = 100;


### PR DESCRIPTION
This makes the editor and game views feel less cramped by default, as you can see more things on your screen thanks to the higher field of view. This does not affect existing projects, but will affect newly-created editor settings and Camera nodes.

**Old default editor FOV (45), non-distraction-free mode:**
![fov_45_no_df](https://user-images.githubusercontent.com/180032/27222466-a2612474-528c-11e7-8b68-3ba1dabea99f.jpg)

**Old default editor FOV (45), distraction-free mode:**
![fov_45_df](https://user-images.githubusercontent.com/180032/27222463-a25f6846-528c-11e7-8c0e-3407292c5162.jpg)

**New default editor FOV (55), non-distraction-free mode:**
![fov_55_no_df](https://user-images.githubusercontent.com/180032/27222464-a260ea9a-528c-11e7-9bdb-f4cca4cf545d.jpg)

**New default editor FOV (55), distraction-free mode:**
![fov_55_df](https://user-images.githubusercontent.com/180032/27222465-a261109c-528c-11e7-84bb-b3e651080080.jpg)

This pull request also increases the default FOV of perspective cameras to 65 (from 60).

Feel free to discuss and test by yourself; freelooking around in the editor is a good way to see if it looks right or not.