### PR TITLE
Fix EditorFileSystem duplicating root folder in new folders

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -153,6 +153,7 @@ EditorFileSystemDirectory::EditorFileSystemDirectory() {
 
 	modified_time = 0;
 	parent = NULL;
+	verified = false;
 }
 
 EditorFileSystemDirectory::~EditorFileSystemDirectory() {
@@ -1040,7 +1041,10 @@ bool EditorFileSystem::_find_file(const String &p_file, EditorFileSystemDirector
 		if (idx == -1) {
 			//does not exist, create i guess?
 			EditorFileSystemDirectory *efsd = memnew(EditorFileSystemDirectory);
+
 			efsd->name = path[i];
+			efsd->parent = fs;
+
 			int idx2 = 0;
 			for (int j = 0; j < fs->get_subdir_count(); j++) {
 
@@ -1421,6 +1425,7 @@ EditorFileSystem::EditorFileSystem() {
 
 	singleton = this;
 	filesystem = memnew(EditorFileSystemDirectory); //like, empty
+	filesystem->parent = NULL;
 
 	thread = NULL;
 	scanning = false;
@@ -1429,7 +1434,9 @@ EditorFileSystem::EditorFileSystem() {
 	thread_sources = NULL;
 	new_filesystem = NULL;
 
+	abort_scan = false;
 	scanning_changes = false;
+	scanning_changes_done = false;
 	ResourceSaver::set_save_callback(_resource_saved);
 
 	DirAccess *da = DirAccess::create(DirAccess::ACCESS_RESOURCES);

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -168,8 +168,6 @@ class EditorFileSystem : public Node {
 
 	void _scan_fs_changes(EditorFileSystemDirectory *p_dir, const ScanProgress &p_progress);
 
-	int md_count;
-
 	Set<String> valid_extensions;
 	Set<String> import_extensions;
 


### PR DESCRIPTION
Fixes #3662.

Also, add some uninitialized variables into constructors (I like to applease cppcheck).
Also, remove unused `md_count` variable.

P.S. I have no idea how this worked once, but those buggy lines had existed since the "GODOT IS OPEN SOURCE" commit. Unfortunately, this means I can't blame anyone in particular...

P.P.S. This is backportable to 2.1.x I think.