### PR TITLE
[GDNative] added GDN_EXPORT macro for libraries

### DIFF
--- a/modules/gdnative/godot.h
+++ b/modules/gdnative/godot.h
@@ -60,6 +60,13 @@ extern "C" {
 #define GDAPI GDCALLINGCONV
 #endif
 
+// This is for libraries *using* the header, NOT GODOT EXPOSING STUFF!!
+#ifdef _WIN32
+#define GDN_EXPORT __declspec(dllexport)
+#else
+#define GDN_EXPORT
+#endif
+
 #include <stdbool.h>
 #include <stdint.h>
 


### PR DESCRIPTION
Up until now there only was GDAPI which was used
for the procedures Godot exposes.