### PR TITLE
Added two new methods 'blend_rect_mask' and 'fill'

### DIFF
--- a/core/image.h
+++ b/core/image.h
@@ -352,6 +352,10 @@ public:
 
 	void blit_rect(const Image &p_src, const Rect2 &p_src_rect, const Point2 &p_dest);
 	void blend_rect(const Image &p_src, const Rect2 &p_src_rect, const Point2 &p_dest);
+	void blend_rect_mask(const Image &p_src, const Image &p_mask, const Rect2 &p_src_rect, const Point2 &p_dest);
+
+	void fill(const Color &p_color);
+	
 	void brush_transfer(const Image &p_src, const Image &p_brush, const Point2 &p_dest);
 	Image brushed(const Image &p_src, const Image &p_brush, const Point2 &p_dest) const;
 

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -622,6 +622,8 @@ struct _VariantCall {
 	VCALL_PTR0R(Image, get_data);
 	VCALL_PTR3(Image, blit_rect);
 	VCALL_PTR3(Image, blend_rect);
+	VCALL_PTR4(Image, blend_rect_mask);
+	VCALL_PTR1(Image, fill);
 	VCALL_PTR1R(Image, converted);
 	VCALL_PTR0(Image, fix_alpha_edges);
 
@@ -1473,6 +1475,8 @@ void register_variant_methods() {
 	ADDFUNC0(IMAGE, RAW_ARRAY, Image, get_data, varray());
 	ADDFUNC3(IMAGE, NIL, Image, blit_rect, IMAGE, "src", RECT2, "src_rect", VECTOR2, "dest", varray(0));
 	ADDFUNC3(IMAGE, NIL, Image, blend_rect, IMAGE, "src", RECT2, "src_rect", VECTOR2, "dest", varray(0));
+	ADDFUNC4(IMAGE, NIL, Image, blend_rect_mask, IMAGE, "src", IMAGE, "mask", RECT2, "src_rect", VECTOR2, "dest", varray(0));
+	ADDFUNC1(IMAGE, NIL, Image, fill, COLOR, "color", varray(0));
 	ADDFUNC1(IMAGE, IMAGE, Image, converted, INT, "format", varray(0));
 	ADDFUNC0(IMAGE, NIL, Image, fix_alpha_edges, varray());
 

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<doc version="2.1.3.stable.custom_build" name="Engine Types">
+<doc version="2.1.4.beta.custom_build" name="Engine Types">
 <class name="@GDScript" category="Core">
 	<brief_description>
 		Built-in GDScript functions.
@@ -15866,6 +15866,19 @@
 				Alpha-blends a "src_rect" [Rect2] from "src" [Image] to this [Image] on coordinates "dest".
 			</description>
 		</method>
+		<method name="blend_rect_mask">
+			<argument index="0" name="src" type="Image">
+			</argument>
+			<argument index="1" name="mask" type="Image">
+			</argument>
+			<argument index="2" name="src_rect" type="Rect2">
+			</argument>
+			<argument index="3" name="dest" type="Vector2" default="0">
+			</argument>
+			<description>
+				Alpha-blends a "src_rect" [Rect2] from "src" [Image] to this [Image] using a "mask" [Image] on coordinates "dest". Alpha channels are required for both "src" and "mask", dest pixels and src pixels will blend if the corresponding mask pixel's alpha value is not 0. "src" [Image] and "mask" [Image] *must* have the same size (width and height) but they can have different formats
+			</description>
+		</method>
 		<method name="blit_rect">
 			<argument index="0" name="src" type="Image">
 			</argument>
@@ -15931,6 +15944,13 @@
 			</return>
 			<description>
 				Return whether this [Image] is empty(no data).
+			</description>
+		</method>
+		<method name="fill">
+			<argument index="0" name="color" type="Color" default="0">
+			</argument>
+			<description>
+				Fills an [Image] with a specified [Color]
 			</description>
 		</method>
 		<method name="fix_alpha_edges">


### PR DESCRIPTION
Added two new methods in 2.1 as well, '**blend_rect_mask**' and '**fill**'.
Corresponding PR for 3.0 is : #9251 

**blend_rect_mask** blends two rectangles together using the alpha channel of a mask to specify which pixels to use.
**fill** will fill an Image resource with a specified color

Test example is provided in attachment [blendtest21.zip](https://github.com/godotengine/godot/files/1083243/blendtest21.zip)
