### PR TITLE
Remove Duplicate Include

### DIFF
--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -30,7 +30,6 @@
 #include "animated_sprite.h"
 #include "os/os.h"
 #include "scene/scene_string_names.h"
-#include "scene/scene_string_names.h"
 
 #define NORMAL_SUFFIX "_normal"
 


### PR DESCRIPTION
Also solves a problem with AnimatedSprites, when you add sprites for the animation the engine crash (Windows 10 x64 I do not know if in the other OS too)

(Edit)
Sorry but it still crashes after this, when I remove the "extra include" and compile, the Load resource-> open on file png for animatedSprite had worked again, but crash again :c.