### PR TITLE
Align primitive defaults to default collision shape sizes

### DIFF
--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -359,8 +359,8 @@ int CapsuleMesh::get_rings() const {
 
 CapsuleMesh::CapsuleMesh() {
 	// defaults
-	radius = 0.5;
-	mid_height = 0.5;
+	radius = 1.0;
+	mid_height = 1.0;
 	radial_segments = 64;
 	rings = 8;
 }
@@ -617,7 +617,7 @@ int CubeMesh::get_subdivide_depth() const {
 
 CubeMesh::CubeMesh() {
 	// defaults
-	size = Vector3(1.0, 1.0, 1.0);
+	size = Vector3(2.0, 2.0, 2.0);
 	subdivide_w = 0;
 	subdivide_h = 0;
 	subdivide_d = 0;
@@ -834,9 +834,9 @@ int CylinderMesh::get_rings() const {
 
 CylinderMesh::CylinderMesh() {
 	// defaults
-	top_radius = 0.5;
-	bottom_radius = 0.5;
-	height = 1.0;
+	top_radius = 1.0;
+	bottom_radius = 1.0;
+	height = 2.0;
 	radial_segments = 64;
 	rings = 4;
 }
@@ -951,7 +951,7 @@ int PlaneMesh::get_subdivide_depth() const {
 
 PlaneMesh::PlaneMesh() {
 	// defaults
-	size = Size2(1.0, 1.0);
+	size = Size2(2.0, 2.0);
 	subdivide_w = 0;
 	subdivide_d = 0;
 }
@@ -1242,7 +1242,7 @@ int PrismMesh::get_subdivide_depth() const {
 PrismMesh::PrismMesh() {
 	// defaults
 	left_to_right = 0.5;
-	size = Vector3(1.0, 1.0, 1.0);
+	size = Vector3(2.0, 2.0, 2.0);
 	subdivide_w = 0;
 	subdivide_h = 0;
 	subdivide_d = 0;
@@ -1446,8 +1446,8 @@ bool SphereMesh::get_is_hemisphere() const {
 
 SphereMesh::SphereMesh() {
 	// defaults
-	radius = 0.5;
-	height = 1.0;
+	radius = 1.0;
+	height = 2.0;
 	radial_segments = 64;
 	rings = 32;
 	is_hemisphere = false;


### PR DESCRIPTION
This is in reaction to #9242, this only changes the default sizes of the primitive meshes to match the in world sizes of the collision shapes.

I do agree with the observation in 9242 that the cube collision shape is double the size it should be. I have no opinion one way or the other if the capsule should be reorientated in the mesh or as a collision shape. However since we're still debating which way this will go I haven't changed anything here. 

I suggest not merging this PR until we have a final say as there is a good argument to change the cube and prism back to size (1.0, 1.0, 1.0). I think the radius of 1.0 for our spheres and capsules are good defaults.