### PR TITLE
Expose compression functions to GDScript

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -31,6 +31,7 @@
 
 #include "core/global_config.h"
 #include "geometry.h"
+#include "io/file_access_compressed.h"
 #include "io/file_access_encrypted.h"
 #include "io/marshalls.h"
 #include "os/keyboard.h"
@@ -1395,6 +1396,24 @@ Error _File::open_encrypted_pass(const String &p_path, int p_mode_flags, const S
 	return OK;
 }
 
+Error _File::open_compressed(const String &p_path, int p_mode_flags, int p_compress_mode) {
+
+	FileAccessCompressed *fac = memnew(FileAccessCompressed);
+	Error err = OK;
+
+	fac->configure("GCPF", (Compression::Mode)p_compress_mode);
+
+	err = fac->_open(p_path, p_mode_flags);
+
+	if (err) {
+		memdelete(fac);
+		return err;
+	}
+
+	f = fac;
+	return OK;
+}
+
 Error _File::open(const String &p_path, int p_mode_flags) {
 
 	close();
@@ -1700,6 +1719,7 @@ void _File::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("open_encrypted", "path", "mode_flags", "key"), &_File::open_encrypted);
 	ClassDB::bind_method(D_METHOD("open_encrypted_with_pass", "path", "mode_flags", "pass"), &_File::open_encrypted_pass);
+	ClassDB::bind_method(D_METHOD("open_compressed", "path", "mode_flags", "compression_mode"), &_File::open_compressed, DEFVAL(0));
 
 	ClassDB::bind_method(D_METHOD("open", "path", "flags"), &_File::open);
 	ClassDB::bind_method(D_METHOD("close"), &_File::close);
@@ -1749,6 +1769,10 @@ void _File::_bind_methods() {
 	BIND_CONSTANT(WRITE);
 	BIND_CONSTANT(READ_WRITE);
 	BIND_CONSTANT(WRITE_READ);
+
+	BIND_CONSTANT(COMPRESSION_FASTLZ);
+	BIND_CONSTANT(COMPRESSION_DEFLATE);
+	BIND_CONSTANT(COMPRESSION_ZSTD);
 }
 
 _File::_File() {

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -31,6 +31,7 @@
 #define CORE_BIND_H
 
 #include "image.h"
+#include "io/compression.h"
 #include "io/resource_loader.h"
 #include "io/resource_saver.h"
 #include "os/dir_access.h"
@@ -366,8 +367,15 @@ public:
 		WRITE_READ = 7,
 	};
 
+	enum CompressionMode {
+		COMPRESSION_FASTLZ = Compression::MODE_FASTLZ,
+		COMPRESSION_DEFLATE = Compression::MODE_DEFLATE,
+		COMPRESSION_ZSTD = Compression::MODE_ZSTD
+	};
+
 	Error open_encrypted(const String &p_path, int p_mode_flags, const Vector<uint8_t> &p_key);
 	Error open_encrypted_pass(const String &p_path, int p_mode_flags, const String &p_pass);
+	Error open_compressed(const String &p_path, int p_mode_flags, int p_compress_mode = 0);
 
 	Error open(const String &p_path, int p_mode_flags); ///< open a file
 	void close(); ///< close a file

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -15299,6 +15299,19 @@
 				Open the file for writing or reading, depending on the flags.
 			</description>
 		</method>
+		<method name="open_compressed">
+			<return type="int">
+			</return>
+			<argument index="0" name="path" type="String">
+			</argument>
+			<argument index="1" name="mode_flags" type="int">
+			</argument>
+			<argument index="2" name="compression_mode" type="int" default="0">
+			</argument>
+			<description>
+				Open a compressed file for reading or writing. The compression_mode can be set as one of the COMPRESSION_* constants.
+			</description>
+		</method>
 		<method name="open_encrypted">
 			<return type="int">
 			</return>
@@ -15444,6 +15457,15 @@
 		</constant>
 		<constant name="WRITE_READ" value="7">
 			Open the file for reading and writing. Create it if the file not exists and truncate if it exists.
+		</constant>
+		<constant name="COMPRESSION_FASTLZ" value="0">
+			Use the FastLZ compression method.
+		</constant>
+		<constant name="COMPRESSION_DEFLATE" value="1">
+			Use the Deflate compression method.
+		</constant>
+		<constant name="COMPRESSION_ZSTD" value="2">
+			Use the Zstd compression method.
 		</constant>
 	</constants>
 </class>
@@ -33731,6 +33753,26 @@
 			</argument>
 			<description>
 				Append an [PoolByteArray] at the end of this array.
+			</description>
+		</method>
+		<method name="compress">
+			<return type="PoolByteArray">
+			</return>
+			<argument index="0" name="compression_mode" type="int" default="0">
+			</argument>
+			<description>
+			Returns a new [PoolByteArray] with the data compressed. The compression mode can be set using one of the COMPRESS_* constants of [File].
+			</description>
+		</method>
+		<method name="decompress">
+			<return type="PoolByteArray">
+			</return>
+			<argument index="0" name="buffer_size" type="int">
+			</argument>
+			<argument index="1" name="compression_mode" type="int" default="0">
+			</argument>
+			<description>
+			Returns a new [PoolByteArray] with the data decompressed. The buffer_size should be set as the size of the uncompressed data. The compression mode can be set using one of the COMPRESS_* constants of [File].
 			</description>
 		</method>
 		<method name="get_string_from_ascii">


### PR DESCRIPTION
- Add `compress`/`decompress` functions to PoolByteArray.
- Add `open_file_compressed` function to File.

Closes #6536.