### PR TITLE
Add null-check to get_normal_frame

### DIFF
--- a/scene/2d/animated_sprite.h
+++ b/scene/2d/animated_sprite.h
@@ -99,7 +99,7 @@ public:
 
 		const Map<StringName, Anim>::Element *EN = animations.find(E->get().normal_name);
 
-		if (p_idx >= EN->get().frames.size())
+		if (!EN || p_idx >= EN->get().frames.size())
 			return Ref<Texture>();
 
 		return EN->get().frames[p_idx];


### PR DESCRIPTION
#9266 demonstrates a bug with AnimatedSprite that crashes Godot. I reproduced as described in the issue and captured this backtrace of the crash:

> 0x000000000150afde in Vector<Ref<Texture> >::_get_size (this=0x40) at core/vector.h:60
> 0x000000000150a59a in Vector<Ref<Texture> >::size (this=0x40) at core/vector.h:112
> 0x0000000001a93f3d in SpriteFrames::get_normal_frame (this=0x81611b0, p_anim=..., p_idx=0) at scene/2d/animated_sprite.h:102
> ...

Examining the third stack frame showed that `EN` was in fact a null pointer. After adding the null check I can no longer reproduce #9266.