### PR TITLE
Fixed a string class bug

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -65,7 +65,7 @@ bool CharString::operator<(const CharString &p_right) const {
 	}
 
 	const char *this_str = get_data();
-	const char *that_str = get_data();
+	const char *that_str = p_right.get_data();
 	while (true) {
 
 		if (*that_str == 0 && *this_str == 0)


### PR DESCRIPTION
that_str is supposed to identify with the passed parameter, otherwise the comparison makes no sense