### PR TITLE
Fixed freelook conflict with text inputs

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -775,6 +775,11 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 				}
 
 				freelook_active = b->is_pressed();
+				if (freelook_active && !surface->has_focus()) {
+					// Focus usually doesn't trigger on right-click, but in case of freelook it should,
+					// otherwise using keyboard navigation would misbehave
+					surface->grab_focus();
+				}
 
 			} break;
 			case BUTTON_MIDDLE: {


### PR DESCRIPTION
Selecting a text input such as shader editor or AnimationPlayer's input fields wasn't playing well with freelook, since focus isn't given to viewport on left click.

However, one thing I was unable to solve is how to capture keyboard input while freelook is active... (it uses `_process`, and viewport input doesn't uses `_forward_spatial_input` either) at the moment they are still ending up in `_unhandled_input` callbacks (found this on the way #9280)