### PR TITLE
fixed ptrcall cast for const Ref<T>

### DIFF
--- a/core/reference.h
+++ b/core/reference.h
@@ -344,7 +344,7 @@ struct PtrToArg<const Ref<T> &> {
 
 	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
 
-		return Ref<T>(reinterpret_cast<const T *>(p_ptr));
+		return Ref<T>((T *)p_ptr);
 	}
 };
 


### PR DESCRIPTION
Some methods require a const Ref<T> argument,
the ptrcall method wrappers cast `void *` to the
apropriate types. The problem is that there is no `Ref(const T *)`
constructor, but since Ref modifies the refcount of a Reference
anyway there's no point in a const version.

The problem is that with a `const T *` constructor call, the
argument gets converted to Variant first and loses all the
reference information, resulting in a null reference as the
argument to the constructor.