### PR TITLE
Camera2D enhancements (V2)

### DIFF
--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -79,6 +79,10 @@ protected:
 
 	void _set_old_smoothing(float p_enable);
 
+	bool screen_drawing_enabled;
+	bool limit_drawing_enabled;
+	bool margin_drawing_enabled;
+
 protected:
 	virtual Transform2D get_camera_transform();
 	void _notification(int p_what);
@@ -137,6 +141,15 @@ public:
 	void force_update_scroll();
 	void reset_smoothing();
 	void align();
+
+	void set_screen_drawing_enabled(bool enable);
+	bool is_screen_drawing_enabled() const;
+
+	void set_limit_drawing_enabled(bool enable);
+	bool is_limit_drawing_enabled() const;
+
+	void set_margin_drawing_enabled(bool enable);
+	bool is_margin_drawing_enabled() const;
 
 	Camera2D();
 };


### PR DESCRIPTION
![camera2d_enhancements](https://user-images.githubusercontent.com/25082678/27355809-4ea61c4e-55da-11e7-9677-359e0b1741fa.png)
I added various enhancements for Camera2D:

    Added an option to draw Camera2D's limits
    Added an option to draw Camera2D's drag margin
    Made drawing the Camera's screen bounds optional
    Put all of these option under a new group, "Editor helpers", in Camera2D
    Made Camera2D's editor lines less transparent if is set to current
    Added function calls to _update_scroll() in various places so the editor lines are updated when the values change
    Added variables and set/get functions for toggling the editor lines.

I can remove or change anything if needed. I'm not sure on changing the transparency on the editor lines, but I liked being able to see if a camera was current or not at a glance.

There is one issue I couldn't figure out how to fix. If you scale the Camera2D node by a negative value, the limit bounds editor lines start moving.

(Accidentally messed up git on previous pull request. Made a new pull request to fix the git issues.)

Closes #8175