### PR TITLE
Scene Tree: double click on subscene icon will open it

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -164,7 +164,10 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 		item_rect.position.y -= tree->get_scroll().y;
 		item_rect.position += tree->get_global_position();
 
-		if (n == get_scene_node()) {
+		if ((subscene_previously_clicked_at_time + 350) > OS::get_singleton()->get_ticks_msec()) {
+			instance_node = n->get_instance_ID();
+			_subscene_option(SCENE_MENU_OPEN);
+		} else if (n == get_scene_node()) {
 			inheritance_menu->set_position(item_rect.position + Vector2(0, item_rect.size.y));
 			inheritance_menu->set_size(Vector2(item_rect.size.x, 0));
 			inheritance_menu->popup();
@@ -190,6 +193,8 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 			instance_menu->popup();
 			instance_node = n->get_instance_ID();
 		}
+		subscene_previously_clicked_at_time = OS::get_singleton()->get_ticks_msec();
+
 		//emit_signal("open",n->get_filename());
 	} else if (p_id == BUTTON_SCRIPT) {
 		RefPtr script = n->get_script();
@@ -1176,6 +1181,8 @@ SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_ope
 
 	script_types = memnew(List<StringName>);
 	ClassDB::get_inheriters_from_class("Script", script_types);
+
+	subscene_previously_clicked_at_time = 0;
 }
 
 SceneTreeEditor::~SceneTreeEditor() {

--- a/editor/scene_tree_editor.h
+++ b/editor/scene_tree_editor.h
@@ -141,6 +141,8 @@ class SceneTreeEditor : public Control {
 	List<StringName> *script_types;
 	bool _is_script_type(const StringName &p_type) const;
 
+	int subscene_previously_clicked_at_time;
+
 public:
 	void set_filter(const String &p_filter);
 	String get_filter() const;


### PR DESCRIPTION
It's possible to double click scene icon inside tree view, to open it quickly:
![quick_open_subscene](https://user-images.githubusercontent.com/6129594/27397069-6c3ba126-56b5-11e7-9461-a9f38a002dd4.gif)
