### PR TITLE
Make the InputEvent device property get saved

### DIFF
--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -140,6 +140,8 @@ void InputEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_action_type"), &InputEvent::is_action_type);
 
 	ClassDB::bind_method(D_METHOD("xformed_by:InputEvent", "xform", "local_ofs"), &InputEvent::xformed_by, DEFVAL(Vector2()));
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "device"), "set_device", "get_device");
 }
 
 InputEvent::InputEvent() {


### PR DESCRIPTION
Fixes #9299.

I'm not completely sure this should exist on all types of InputEvent (since key doesn't use it AFAIK), but since the getter and setter were registered there, I guess this had to be as well.