### PR TITLE
Added 'blit_rect_mask' method

### DIFF
--- a/core/image.h
+++ b/core/image.h
@@ -351,6 +351,7 @@ public:
 	void normalmap_to_xy();
 
 	void blit_rect(const Image &p_src, const Rect2 &p_src_rect, const Point2 &p_dest);
+	void blit_rect_mask(const Image &p_src, const Image &p_mask, const Rect2 &p_src_rect, const Point2 &p_dest);
 	void blend_rect(const Image &p_src, const Rect2 &p_src_rect, const Point2 &p_dest);
 	void blend_rect_mask(const Image &p_src, const Image &p_mask, const Rect2 &p_src_rect, const Point2 &p_dest);
 

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -621,6 +621,7 @@ struct _VariantCall {
 	VCALL_PTR3R(Image, resized);
 	VCALL_PTR0R(Image, get_data);
 	VCALL_PTR3(Image, blit_rect);
+	VCALL_PTR4(Image, blit_rect_mask);
 	VCALL_PTR3(Image, blend_rect);
 	VCALL_PTR4(Image, blend_rect_mask);
 	VCALL_PTR1(Image, fill);
@@ -1474,6 +1475,7 @@ void register_variant_methods() {
 	ADDFUNC3(IMAGE, IMAGE, Image, resized, INT, "x", INT, "y", INT, "interpolation", varray(((int)Image::INTERPOLATE_BILINEAR)));
 	ADDFUNC0(IMAGE, RAW_ARRAY, Image, get_data, varray());
 	ADDFUNC3(IMAGE, NIL, Image, blit_rect, IMAGE, "src", RECT2, "src_rect", VECTOR2, "dest", varray(0));
+	ADDFUNC4(IMAGE, NIL, Image, blit_rect_mask, IMAGE, "src", IMAGE, "mask", RECT2, "src_rect", VECTOR2, "dest", varray(0));
 	ADDFUNC3(IMAGE, NIL, Image, blend_rect, IMAGE, "src", RECT2, "src_rect", VECTOR2, "dest", varray(0));
 	ADDFUNC4(IMAGE, NIL, Image, blend_rect_mask, IMAGE, "src", IMAGE, "mask", RECT2, "src_rect", VECTOR2, "dest", varray(0));
 	ADDFUNC1(IMAGE, NIL, Image, fill, COLOR, "color", varray(0));

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -15890,6 +15890,19 @@
 				Copy a "src_rect" [Rect2] from "src" [Image] to this [Image] on coordinates "dest".
 			</description>
 		</method>
+		<method name="blit_rect_mask">
+			<argument index="0" name="src" type="Image">
+			</argument>
+			<argument index="1" name="mask" type="Image">
+			</argument>
+			<argument index="2" name="src_rect" type="Rect2">
+			</argument>
+			<argument index="3" name="dest" type="Vector2" default="0">
+			</argument>
+			<description>
+				Blits a "src_rect" [Rect2] from "src" [Image] to this [Image] using a "mask" [Image] on coordinates "dest". Alpha channel is required for "mask", will copy src pixel onto dest if the corresponding mask pixel's alpha value is not 0. "src" [Image] and "mask" [Image] *must* have the same size (width and height) but they can have different formats
+			</description>
+		</method>
 		<method name="brush_transfer">
 			<argument index="0" name="src" type="Image">
 			</argument>
@@ -31944,6 +31957,30 @@
 				Return a copy of the [Rect2] grown a given amount of units towards all the sides.
 			</description>
 		</method>
+		<method name="grow_individual">
+			<return type="Rect2">
+			</return>
+			<argument index="0" name="left" type="float">
+			</argument>
+			<argument index="1" name="top" type="float">
+			</argument>
+			<argument index="2" name="right" type="float">
+			</argument>
+			<argument index="3" name=" bottom" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="grow_margin">
+			<return type="Rect2">
+			</return>
+			<argument index="0" name="margin" type="int">
+			</argument>
+			<argument index="1" name="by" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="has_no_area">
 			<return type="bool">
 			</return>
@@ -32651,7 +32688,7 @@
 			</description>
 		</method>
 		<method name="get_v_scroll">
-			<return type="Object">
+			<return type="VScrollBar">
 			</return>
 			<description>
 			</description>
@@ -32726,7 +32763,7 @@
 			</description>
 		</method>
 		<method name="push_font">
-			<argument index="0" name="font" type="Object">
+			<argument index="0" name="font" type="Font">
 			</argument>
 			<description>
 			</description>
@@ -37939,7 +37976,9 @@
 		</constant>
 		<constant name="FLAG_SHADED" value="1">
 		</constant>
-		<constant name="FLAG_MAX" value="2">
+		<constant name="FLAG_DOUBLE_SIDED" value="2">
+		</constant>
+		<constant name="FLAG_MAX" value="3">
 		</constant>
 		<constant name="ALPHA_CUT_DISABLED" value="0">
 		</constant>


### PR DESCRIPTION
Added a 'blit_rect_mask' method to allow blitting of parts of an image which are transparent.
I need this for erasing what's on the screen for a pixel-paint program I am working on and doing it in gdscript is very expensive.
Will add the corresponding 3.0 method shortly too.

It also incorporates #9315 bug fixes