### PR TITLE
Fix crash with String::copy_from with NULL string parameter

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -96,6 +96,12 @@ const char *CharString::get_data() const {
 
 void String::copy_from(const char *p_cstr) {
 
+	if (!p_cstr) {
+
+		resize(0);
+		return;
+	}
+
 	int len = 0;
 	const char *ptr = p_cstr;
 	while (*(ptr++) != 0)
@@ -118,6 +124,12 @@ void String::copy_from(const char *p_cstr) {
 }
 
 void String::copy_from(const CharType *p_cstr, int p_clip_to) {
+
+	if (!p_cstr) {
+
+		resize(0);
+		return;
+	}
 
 	int len = 0;
 	const CharType *ptr = p_cstr;


### PR DESCRIPTION
Fix #9358