### PR TITLE
Add one-way collisions and individual shape offsets for tilesets

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -111,20 +111,15 @@ void TileSetEditor::_import_node(Node *p_node, Ref<TileSet> p_library) {
 
 			for (List<uint32_t>::Element *E = shapes.front(); E; E = E->next()) {
 
+				Vector2 shape_offset = sb->shape_owner_get_transform(E->get()).get_origin();
+				bool one_way = sb->is_shape_owner_one_way_collision_enabled(E->get());
+
 				for (int k = 0; k < sb->shape_owner_get_shape_count(E->get()); k++) {
 
 					Ref<Shape> shape = sb->shape_owner_get_shape(E->get(), k);
-					collisions.push_back(shape); //uh what about transform?
+					p_library->tile_add_shape(id, shape, shape_offset, one_way);
 				}
 			}
-		}
-
-		if (collisions.size()) {
-
-			p_library->tile_set_shapes(id, collisions);
-			p_library->tile_set_shape_offset(id, -phys_offset);
-		} else {
-			p_library->tile_set_shape_offset(id, Vector2());
 		}
 
 		p_library->tile_set_texture_offset(id, mi->get_offset());

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -451,25 +451,25 @@ void TileMap::_update_dirty_quadrants() {
 				tex->draw_rect_region(canvas_item, rect, r, modulate, c.transpose);
 			}
 
-			Vector<Ref<Shape2D> > shapes = tile_set->tile_get_shapes(c.id);
+			Vector<TileSet::ShapeData> shapes = tile_set->tile_get_shapes(c.id);
 
 			for (int i = 0; i < shapes.size(); i++) {
 
-				Ref<Shape2D> shape = shapes[i];
+				Ref<Shape2D> shape = shapes[i].shape;
 				if (shape.is_valid()) {
-
-					Vector2 shape_ofs = tile_set->tile_get_shape_offset(c.id);
 					Transform2D xform;
 					xform.set_origin(offset.floor());
 
-					_fix_cell_transform(xform, c, shape_ofs + center_ofs, s);
+					_fix_cell_transform(xform, c, shapes[i].shape_offset + center_ofs, s);
 
 					if (debug_canvas_item.is_valid()) {
 						vs->canvas_item_add_set_transform(debug_canvas_item, xform);
 						shape->draw(debug_canvas_item, debug_collision_color);
 					}
 					ps->body_add_shape(q.body, shape->get_rid(), xform);
-					ps->body_set_shape_metadata(q.body, shape_idx++, Vector2(E->key().x, E->key().y));
+					shape_idx++;
+					ps->body_set_shape_as_one_way_collision(q.body, shape_idx, shapes[i].one_way_collision);
+					ps->body_set_shape_metadata(q.body, shape_idx, Vector2(E->key().x, E->key().y));
 				}
 			}
 

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -51,12 +51,14 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 		tile_set_material(id, p_value);
 	else if (what == "modulate")
 		tile_set_modulate(id, p_value);
-	else if (what == "shape_offset")
-		tile_set_shape_offset(id, p_value);
 	else if (what == "region")
 		tile_set_region(id, p_value);
 	else if (what == "shape")
-		tile_set_shape(id, p_value);
+		tile_set_shape(id, 0, p_value);
+	else if (what == "shape_offset")
+		tile_set_shape_offset(id, 0, p_value);
+	else if (what == "shape_one_way")
+		tile_set_shape_one_way(id, 0, p_value);
 	else if (what == "shapes")
 		_tile_set_shapes(id, p_value);
 	else if (what == "occluder")
@@ -95,12 +97,14 @@ bool TileSet::_get(const StringName &p_name, Variant &r_ret) const {
 		r_ret = tile_get_material(id);
 	else if (what == "modulate")
 		r_ret = tile_get_modulate(id);
-	else if (what == "shape_offset")
-		r_ret = tile_get_shape_offset(id);
 	else if (what == "region")
 		r_ret = tile_get_region(id);
 	else if (what == "shape")
-		r_ret = tile_get_shape(id);
+		r_ret = tile_get_shape(id, 0);
+	else if (what == "shape_offset")
+		r_ret = tile_get_shape_offset(id, 0);
+	else if (what == "shape_one_way")
+		r_ret = tile_get_shape_one_way(id, 0);
 	else if (what == "shapes")
 		r_ret = _tile_get_shapes(id);
 	else if (what == "occluder")
@@ -119,7 +123,7 @@ bool TileSet::_get(const StringName &p_name, Variant &r_ret) const {
 
 void TileSet::_get_property_list(List<PropertyInfo> *p_list) const {
 
-	for (Map<int, Data>::Element *E = tile_map.front(); E; E = E->next()) {
+	for (Map<int, TileData>::Element *E = tile_map.front(); E; E = E->next()) {
 
 		int id = E->key();
 		String pre = itos(id) + "/";
@@ -133,8 +137,9 @@ void TileSet::_get_property_list(List<PropertyInfo> *p_list) const {
 		p_list->push_back(PropertyInfo(Variant::OBJECT, pre + "occluder", PROPERTY_HINT_RESOURCE_TYPE, "OccluderPolygon2D"));
 		p_list->push_back(PropertyInfo(Variant::VECTOR2, pre + "navigation_offset"));
 		p_list->push_back(PropertyInfo(Variant::OBJECT, pre + "navigation", PROPERTY_HINT_RESOURCE_TYPE, "NavigationPolygon"));
-		p_list->push_back(PropertyInfo(Variant::VECTOR2, pre + "shape_offset"));
+		p_list->push_back(PropertyInfo(Variant::VECTOR2, pre + "shape_offset", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
 		p_list->push_back(PropertyInfo(Variant::OBJECT, pre + "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape2D", PROPERTY_USAGE_EDITOR));
+		p_list->push_back(PropertyInfo(Variant::BOOL, pre + "shape_one_way", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
 		p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "shapes", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 	}
 }
@@ -142,7 +147,7 @@ void TileSet::_get_property_list(List<PropertyInfo> *p_list) const {
 void TileSet::create_tile(int p_id) {
 
 	ERR_FAIL_COND(tile_map.has(p_id));
-	tile_map[p_id] = Data();
+	tile_map[p_id] = TileData();
 	_change_notify("");
 	emit_changed();
 }
@@ -199,19 +204,6 @@ Vector2 TileSet::tile_get_texture_offset(int p_id) const {
 	return tile_map[p_id].offset;
 }
 
-void TileSet::tile_set_shape_offset(int p_id, const Vector2 &p_offset) {
-
-	ERR_FAIL_COND(!tile_map.has(p_id));
-	tile_map[p_id].shape_offset = p_offset;
-	emit_changed();
-}
-
-Vector2 TileSet::tile_get_shape_offset(int p_id) const {
-
-	ERR_FAIL_COND_V(!tile_map.has(p_id), Vector2());
-	return tile_map[p_id].shape_offset;
-}
-
 void TileSet::tile_set_region(int p_id, const Rect2 &p_region) {
 
 	ERR_FAIL_COND(!tile_map.has(p_id));
@@ -238,21 +230,80 @@ String TileSet::tile_get_name(int p_id) const {
 	return tile_map[p_id].name;
 }
 
-void TileSet::tile_set_shape(int p_id, const Ref<Shape2D> &p_shape) {
+void TileSet::tile_clear_shapes(int p_id) {
+	tile_map[p_id].shapes_data.clear();
+}
+
+void TileSet::tile_add_shape(int p_id, const Ref<Shape2D> &p_shape, const Vector2 &p_offset, bool p_one_way) {
 
 	ERR_FAIL_COND(!tile_map.has(p_id));
-	tile_map[p_id].shapes.resize(1);
-	tile_map[p_id].shapes[0] = p_shape;
+
+	ShapeData new_data = ShapeData();
+	new_data.shape = p_shape;
+	new_data.shape_offset = p_offset;
+	new_data.one_way_collision = p_one_way;
+
+	tile_map[p_id].shapes_data.push_back(new_data);
+};
+int TileSet::tile_get_shape_count(int p_id) const {
+
+	ERR_FAIL_COND_V(!tile_map.has(p_id), 0);
+
+	return tile_map[p_id].shapes_data.size();
+};
+
+void TileSet::tile_set_shape(int p_id, int p_shape_id, const Ref<Shape2D> &p_shape) {
+
+	ERR_FAIL_COND(!tile_map.has(p_id));
+	if (tile_map[p_id].shapes_data.size() <= p_shape_id)
+		tile_map[p_id].shapes_data.resize(p_shape_id + 1);
+	tile_map[p_id].shapes_data[p_shape_id].shape = p_shape;
 	emit_changed();
 }
 
-Ref<Shape2D> TileSet::tile_get_shape(int p_id) const {
+Ref<Shape2D> TileSet::tile_get_shape(int p_id, int p_shape_id) const {
 
 	ERR_FAIL_COND_V(!tile_map.has(p_id), Ref<Shape2D>());
-	if (tile_map[p_id].shapes.size() > 0)
-		return tile_map[p_id].shapes[0];
+	if (tile_map[p_id].shapes_data.size() > p_shape_id)
+		return tile_map[p_id].shapes_data[p_shape_id].shape;
 
 	return Ref<Shape2D>();
+}
+
+void TileSet::tile_set_shape_offset(int p_id, int p_shape_id, const Vector2 &p_offset) {
+
+	ERR_FAIL_COND(!tile_map.has(p_id));
+	if (tile_map[p_id].shapes_data.size() <= p_shape_id)
+		tile_map[p_id].shapes_data.resize(p_shape_id + 1);
+	tile_map[p_id].shapes_data[p_shape_id].shape_offset = p_offset;
+	emit_changed();
+}
+
+Vector2 TileSet::tile_get_shape_offset(int p_id, int p_shape_id) const {
+
+	ERR_FAIL_COND_V(!tile_map.has(p_id), Vector2());
+	if (tile_map[p_id].shapes_data.size() > p_shape_id)
+		return tile_map[p_id].shapes_data[p_shape_id].shape_offset;
+
+	return Vector2();
+}
+
+void TileSet::tile_set_shape_one_way(int p_id, int p_shape_id, const bool p_one_way) {
+
+	ERR_FAIL_COND(!tile_map.has(p_id));
+	if (tile_map[p_id].shapes_data.size() <= p_shape_id)
+		tile_map[p_id].shapes_data.resize(p_shape_id + 1);
+	tile_map[p_id].shapes_data[p_shape_id].one_way_collision = p_one_way;
+	emit_changed();
+}
+
+bool TileSet::tile_get_shape_one_way(int p_id, int p_shape_id) const {
+
+	ERR_FAIL_COND_V(!tile_map.has(p_id), false);
+	if (tile_map[p_id].shapes_data.size() > p_shape_id)
+		return tile_map[p_id].shapes_data[p_shape_id].one_way_collision;
+
+	return false;
 }
 
 void TileSet::tile_set_light_occluder(int p_id, const Ref<OccluderPolygon2D> &p_light_occluder) {
@@ -301,31 +352,63 @@ Vector2 TileSet::tile_get_occluder_offset(int p_id) const {
 	return tile_map[p_id].occluder_offset;
 }
 
-void TileSet::tile_set_shapes(int p_id, const Vector<Ref<Shape2D> > &p_shapes) {
+void TileSet::tile_set_shapes(int p_id, const Vector<ShapeData> &p_shapes) {
 
 	ERR_FAIL_COND(!tile_map.has(p_id));
-	tile_map[p_id].shapes = p_shapes;
+	tile_map[p_id].shapes_data = p_shapes;
 	emit_changed();
 }
 
-Vector<Ref<Shape2D> > TileSet::tile_get_shapes(int p_id) const {
+Vector<TileSet::ShapeData> TileSet::tile_get_shapes(int p_id) const {
 
-	ERR_FAIL_COND_V(!tile_map.has(p_id), Vector<Ref<Shape2D> >());
-	return tile_map[p_id].shapes;
+	ERR_FAIL_COND_V(!tile_map.has(p_id), Vector<ShapeData>());
+
+	return tile_map[p_id].shapes_data;
 }
 
 void TileSet::_tile_set_shapes(int p_id, const Array &p_shapes) {
 
 	ERR_FAIL_COND(!tile_map.has(p_id));
-	Vector<Ref<Shape2D> > shapes;
+	Vector<ShapeData> shapes_data;
+	Vector2 default_offset = tile_get_shape_offset(p_id, 0);
+	bool default_one_way = tile_get_shape_one_way(p_id, 0);
 	for (int i = 0; i < p_shapes.size(); i++) {
+		ShapeData s = ShapeData();
 
-		Ref<Shape2D> s = p_shapes[i];
-		if (s.is_valid())
-			shapes.push_back(s);
+		if (p_shapes[i].get_type() == Variant::OBJECT) {
+			Ref<Shape2D> shape = p_shapes[i];
+			if (shape.is_null()) continue;
+
+			s.shape = shape;
+			s.shape_offset = default_offset;
+			s.one_way_collision = default_one_way;
+		} else if (p_shapes[i].get_type() == Variant::DICTIONARY) {
+			Dictionary d = p_shapes[i];
+
+			if (d.has("shape") && d["shape"].get_type() == Variant::OBJECT)
+				s.shape = d["shape"];
+			else
+				continue;
+
+			if (d.has("shape_offset") && d["shape_offset"].get_type() == Variant::VECTOR2)
+				s.shape_offset = d["shape_offset"];
+			else
+				s.shape_offset = default_offset;
+
+			if (d.has("one_way") && d["one_way"].get_type() == Variant::BOOL)
+				s.one_way_collision = d["one_way"];
+			else
+				s.one_way_collision = default_one_way;
+
+		} else {
+			ERR_EXPLAIN("Expected an array of objects or dictionaries for tile_set_shapes");
+			ERR_CONTINUE(true);
+		}
+
+		shapes_data.push_back(s);
 	}
 
-	tile_set_shapes(p_id, shapes);
+	tile_map[p_id].shapes_data = shapes_data;
 }
 
 Array TileSet::_tile_get_shapes(int p_id) const {
@@ -333,9 +416,14 @@ Array TileSet::_tile_get_shapes(int p_id) const {
 	ERR_FAIL_COND_V(!tile_map.has(p_id), Array());
 	Array arr;
 
-	Vector<Ref<Shape2D> > shp = tile_map[p_id].shapes;
-	for (int i = 0; i < shp.size(); i++)
-		arr.push_back(shp[i]);
+	Vector<ShapeData> data = tile_map[p_id].shapes_data;
+	for (int i = 0; i < data.size(); i++) {
+		Dictionary shape_data;
+		shape_data["shape"] = data[i].shape;
+		shape_data["shape_offset"] = data[i].shape_offset;
+		shape_data["one_way"] = data[i].one_way_collision;
+		arr.push_back(shape_data);
+	}
 
 	return arr;
 }
@@ -344,7 +432,7 @@ Array TileSet::_get_tiles_ids() const {
 
 	Array arr;
 
-	for (Map<int, Data>::Element *E = tile_map.front(); E; E = E->next()) {
+	for (Map<int, TileData>::Element *E = tile_map.front(); E; E = E->next()) {
 		arr.push_back(E->key());
 	}
 
@@ -353,7 +441,7 @@ Array TileSet::_get_tiles_ids() const {
 
 void TileSet::get_tile_list(List<int> *p_tiles) const {
 
-	for (Map<int, Data>::Element *E = tile_map.front(); E; E = E->next()) {
+	for (Map<int, TileData>::Element *E = tile_map.front(); E; E = E->next()) {
 
 		p_tiles->push_back(E->key());
 	}
@@ -382,7 +470,7 @@ int TileSet::get_last_unused_tile_id() const {
 
 int TileSet::find_tile_by_name(const String &p_name) const {
 
-	for (Map<int, Data>::Element *E = tile_map.front(); E; E = E->next()) {
+	for (Map<int, TileData>::Element *E = tile_map.front(); E; E = E->next()) {
 
 		if (p_name == E->get().name)
 			return E->key();
@@ -408,12 +496,16 @@ void TileSet::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("tile_get_material:ShaderMaterial", "id"), &TileSet::tile_get_material);
 	ClassDB::bind_method(D_METHOD("tile_set_texture_offset", "id", "texture_offset"), &TileSet::tile_set_texture_offset);
 	ClassDB::bind_method(D_METHOD("tile_get_texture_offset", "id"), &TileSet::tile_get_texture_offset);
-	ClassDB::bind_method(D_METHOD("tile_set_shape_offset", "id", "shape_offset"), &TileSet::tile_set_shape_offset);
-	ClassDB::bind_method(D_METHOD("tile_get_shape_offset", "id"), &TileSet::tile_get_shape_offset);
 	ClassDB::bind_method(D_METHOD("tile_set_region", "id", "region"), &TileSet::tile_set_region);
 	ClassDB::bind_method(D_METHOD("tile_get_region", "id"), &TileSet::tile_get_region);
-	ClassDB::bind_method(D_METHOD("tile_set_shape", "id", "shape:Shape2D"), &TileSet::tile_set_shape);
-	ClassDB::bind_method(D_METHOD("tile_get_shape:Shape2D", "id"), &TileSet::tile_get_shape);
+	ClassDB::bind_method(D_METHOD("tile_set_shape", "id", "shape_id", "shape:Shape2D"), &TileSet::tile_set_shape);
+	ClassDB::bind_method(D_METHOD("tile_get_shape:Shape2D", "id", "shape_id"), &TileSet::tile_get_shape);
+	ClassDB::bind_method(D_METHOD("tile_set_shape_offset", "id", "shape_id", "shape_offset"), &TileSet::tile_set_shape_offset);
+	ClassDB::bind_method(D_METHOD("tile_get_shape_offset", "id", "shape_id"), &TileSet::tile_get_shape_offset);
+	ClassDB::bind_method(D_METHOD("tile_set_shape_one_way", "id", "shape_id", "one_way"), &TileSet::tile_set_shape_one_way);
+	ClassDB::bind_method(D_METHOD("tile_get_shape_one_way", "id", "shape_id"), &TileSet::tile_get_shape_one_way);
+	ClassDB::bind_method(D_METHOD("tile_add_shape", "id", "shape:Shape2D", "shape_offset", "one_way"), &TileSet::tile_add_shape, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("tile_get_shape_count", "id"), &TileSet::tile_get_shape_count);
 	ClassDB::bind_method(D_METHOD("tile_set_shapes", "id", "shapes"), &TileSet::_tile_set_shapes);
 	ClassDB::bind_method(D_METHOD("tile_get_shapes", "id"), &TileSet::_tile_get_shapes);
 	ClassDB::bind_method(D_METHOD("tile_set_navigation_polygon", "id", "navigation_polygon:NavigationPolygon"), &TileSet::tile_set_navigation_polygon);

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -40,14 +40,25 @@ class TileSet : public Resource {
 
 	GDCLASS(TileSet, Resource);
 
-	struct Data {
+public:
+	struct ShapeData {
+		Ref<Shape2D> shape;
+		Vector2 shape_offset;
+		bool one_way_collision;
+
+		ShapeData() {
+			one_way_collision = false;
+		}
+	};
+
+private:
+	struct TileData {
 
 		String name;
 		Ref<Texture> texture;
 		Vector2 offset;
-		Vector2 shape_offset;
 		Rect2i region;
-		Vector<Ref<Shape2D> > shapes;
+		Vector<ShapeData> shapes_data;
 		Vector2 occluder_offset;
 		Ref<OccluderPolygon2D> occluder;
 		Vector2 navigation_polygon_offset;
@@ -56,11 +67,11 @@ class TileSet : public Resource {
 		Color modulate;
 
 		// Default modulate for back-compat
-		explicit Data()
+		explicit TileData()
 			: modulate(1, 1, 1) {}
 	};
 
-	Map<int, Data> tile_map;
+	Map<int, TileData> tile_map;
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -84,14 +95,24 @@ public:
 	void tile_set_texture_offset(int p_id, const Vector2 &p_offset);
 	Vector2 tile_get_texture_offset(int p_id) const;
 
-	void tile_set_shape_offset(int p_id, const Vector2 &p_offset);
-	Vector2 tile_get_shape_offset(int p_id) const;
-
 	void tile_set_region(int p_id, const Rect2 &p_region);
 	Rect2 tile_get_region(int p_id) const;
 
-	void tile_set_shape(int p_id, const Ref<Shape2D> &p_shape);
-	Ref<Shape2D> tile_get_shape(int p_id) const;
+	void tile_set_shape(int p_id, int p_shape_id, const Ref<Shape2D> &p_shape);
+	Ref<Shape2D> tile_get_shape(int p_id, int p_shape_id) const;
+
+	void tile_set_shape_offset(int p_id, int p_shape_id, const Vector2 &p_offset);
+	Vector2 tile_get_shape_offset(int p_id, int p_shape_id) const;
+
+	void tile_set_shape_one_way(int p_id, int p_shape_id, bool p_one_way);
+	bool tile_get_shape_one_way(int p_id, int p_shape_id) const;
+
+	void tile_clear_shapes(int p_id);
+	void tile_add_shape(int p_id, const Ref<Shape2D> &p_shape, const Vector2 &p_offset, bool p_one_way = false);
+	int tile_get_shape_count(int p_id) const;
+
+	void tile_set_shapes(int p_id, const Vector<ShapeData> &p_shapes);
+	Vector<ShapeData> tile_get_shapes(int p_id) const;
 
 	void tile_set_material(int p_id, const Ref<ShaderMaterial> &p_material);
 	Ref<ShaderMaterial> tile_get_material(int p_id) const;
@@ -110,9 +131,6 @@ public:
 
 	void tile_set_navigation_polygon(int p_id, const Ref<NavigationPolygon> &p_navigation_polygon);
 	Ref<NavigationPolygon> tile_get_navigation_polygon(int p_id) const;
-
-	void tile_set_shapes(int p_id, const Vector<Ref<Shape2D> > &p_shapes);
-	Vector<Ref<Shape2D> > tile_get_shapes(int p_id) const;
 
 	void remove_tile(int p_id);
 


### PR DESCRIPTION
As requested in #9318.
Accidentally fixes #2231 as well. <sub>(oh well. I made a typo in my commit message)</sub>

@reduz I couldn't test completely (though it should be working), as 
`sb->shape_owner_get_shape(E->get(), k)` always results in a `null` Ref.