### PR TITLE
Update import dock when editing a resource from the inspector

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1623,6 +1623,7 @@ void EditorNode::_resource_selected(const RES &p_res, const String &p_property) 
 		return;
 
 	RES r = p_res;
+	EditorNode::get_singleton()->get_import_dock()->set_edit_path(r->get_path());
 	push_item(r.operator->(), p_property);
 }
 


### PR DESCRIPTION
If you need to change the import settings of a resource you are editing, its very boring to have to find said file in the FS dock first.
With this change, once you select the resource to edit it, it will update the import dock to reflect that file.

not sure if this is totally clean the way it is now, or if we should reset the import dock when something different is selected in the scene tree. Not very relevant, but..... WDYT? :)