### PR TITLE
tree fix drawing order for header and removed indentation for custom bg colours

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1032,20 +1032,6 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 
 	if (!skip && (p_pos.y + label_h - cache.offset.y) > 0) {
 
-		if (!p_item->disable_folding && !hide_folding && p_item->childs) { //has childs, draw the guide box
-
-			Ref<Texture> arrow;
-
-			if (p_item->collapsed) {
-
-				arrow = cache.arrow_collapsed;
-			} else {
-				arrow = cache.arrow;
-			}
-
-			arrow->draw(ci, p_pos + p_draw_ofs + Point2i(0, (label_h - arrow->get_height()) / 2) - cache.offset);
-		}
-
 		//draw separation.
 		//if (p_item->get_parent()!=root || !hide_root)
 
@@ -1154,8 +1140,13 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			if (p_item->cells[i].custom_bg_color) {
 
 				Rect2 r = cell_rect;
-				r.position.x -= cache.hseparation;
-				r.size.x += cache.hseparation;
+				if (i == 0) {
+					r.position.x = p_draw_ofs.x;
+					r.size.x = w + ofs;
+				} else {
+					r.position.x -= cache.hseparation;
+					r.size.x += cache.hseparation;
+				}
 				if (p_item->cells[i].custom_bg_outline) {
 					VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x, r.position.y, r.size.x, 1), p_item->cells[i].bg_color);
 					VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x, r.position.y + r.size.y - 1, r.size.x, 1), p_item->cells[i].bg_color);
@@ -1352,6 +1343,19 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			}
 		}
 
+		if (!p_item->disable_folding && !hide_folding && p_item->childs) { //has childs, draw the guide box
+
+			Ref<Texture> arrow;
+
+			if (p_item->collapsed) {
+
+				arrow = cache.arrow_collapsed;
+			} else {
+				arrow = cache.arrow;
+			}
+
+			arrow->draw(ci, p_pos + p_draw_ofs + Point2i(0, (label_h - arrow->get_height()) / 2) - cache.offset);
+		}
 		//separator
 		//get_painter()->draw_fill_rect( Point2i(0,pos.y),Size2i(get_size().width,1),color( COLOR_TREE_GRID) );
 


### PR DESCRIPTION
 - the collapse arrow gets drawn after the background so its not hidden underneath anymore
 - custom_bg_color no offset anymore

## issue:
<img width="200" alt="screen shot 2017-06-25 at 17 16 02" src="https://user-images.githubusercontent.com/16718859/27521046-51047e72-59cc-11e7-9fed-36aa34f5bd31.png">
### before:
<img width="313" alt="screen shot 2017-06-25 at 17 16 16" src="https://user-images.githubusercontent.com/16718859/27521044-3fe71780-59cc-11e7-9b0e-fa11a7f99663.png">

## after:
<img width="305" alt="screen shot 2017-06-25 at 16 33 52" src="https://user-images.githubusercontent.com/16718859/27521050-59e4161a-59cc-11e7-8f73-abdb5590b25a.png">

the collapse arrow is now drawn after the bg so it is not cut of.
also the offset doesn't affect the background anymore as a result the inspector looks even less chaotic, less distraction.