### PR TITLE
margins for item list

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -257,10 +257,10 @@ Ref<Theme> create_editor_theme() {
 	Ref<StyleBox> style_tree_btn = make_flat_stylebox(light_color_1, 2, 4, 2, 4);
 	theme->set_stylebox("button_pressed", "Tree", style_tree_btn);
 
-	Ref<StyleBoxFlat> style_tree_focus = make_flat_stylebox(HIGHLIGHT_COLOR_DARK, 4, 4, 4, 4);
+	Ref<StyleBoxFlat> style_tree_focus = make_flat_stylebox(HIGHLIGHT_COLOR_DARK, 2, 2, 2, 2);
 	theme->set_stylebox("selected_focus", "Tree", style_tree_focus);
 
-	Ref<StyleBoxFlat> style_tree_selected = make_flat_stylebox(light_color_1, 4, 4, 4, 4);
+	Ref<StyleBoxFlat> style_tree_selected = make_flat_stylebox(light_color_1, 2, 2, 2, 2);
 	theme->set_stylebox("selected", "Tree", style_tree_selected);
 
 	Ref<StyleBoxFlat> style_tree_cursor = make_flat_stylebox(HIGHLIGHT_COLOR_DARK, 4, 4, 4, 4);
@@ -283,17 +283,18 @@ Ref<Theme> create_editor_theme() {
 	theme->set_color("drop_position_color", "Tree", highlight_color);
 
 	// ItemList
-	Ref<StyleBoxFlat> style_itemlist_cursor = make_flat_stylebox(highlight_color, 4, 4, 4, 4);
+	Ref<StyleBoxFlat> style_itemlist_bg = make_flat_stylebox(dark_color_1, 4, 4, 4, 4);
+	Ref<StyleBoxFlat> style_itemlist_cursor = make_flat_stylebox(highlight_color, 0, 0, 0, 0);
 	style_itemlist_cursor->set_draw_center(false);
 	style_itemlist_cursor->set_border_size(1 * EDSCALE);
-	style_itemlist_cursor->set_light_color(light_color_1);
-	style_itemlist_cursor->set_dark_color(light_color_1);
+	style_itemlist_cursor->set_light_color(HIGHLIGHT_COLOR_DARK);
+	style_itemlist_cursor->set_dark_color(HIGHLIGHT_COLOR_DARK);
 	theme->set_stylebox("cursor", "ItemList", style_itemlist_cursor);
 	theme->set_stylebox("cursor_unfocused", "ItemList", style_itemlist_cursor);
 	theme->set_stylebox("selected_focus", "ItemList", style_tree_focus);
 	theme->set_stylebox("selected", "ItemList", style_tree_selected);
 	theme->set_stylebox("bg_focus", "ItemList", focus_sbt);
-	theme->set_stylebox("bg", "ItemList", style_tree_bg);
+	theme->set_stylebox("bg", "ItemList", style_itemlist_bg);
 	theme->set_constant("vseparation", "ItemList", 5 * EDSCALE);
 
 	Ref<StyleBoxFlat> style_tab_fg = make_flat_stylebox(base_color, 15, 5, 15, 5);


### PR DESCRIPTION
 - without margins there are too little gaps on the left and the selecting looks weird
 - also changed the styles for selected and focus so they both have the same size

this change is still debatable:
```cpp
-	style_itemlist_cursor->set_light_color(light_color_1);
-	style_itemlist_cursor->set_dark_color(light_color_1);
+	style_itemlist_cursor->set_light_color(HIGHLIGHT_COLOR_DARK);
+	style_itemlist_cursor->set_dark_color(HIGHLIGHT_COLOR_DARK);
```
it changes the curser colour to also be the highlight colour. Otherwise the curser is grey.

## New
<img width="234" alt="screen shot 2017-06-25 at 18 14 03" src="https://user-images.githubusercontent.com/16718859/27521620-056745b4-59d4-11e7-83db-1ac63cbb148c.png">
<img width="243" alt="screen shot 2017-06-25 at 18 14 10" src="https://user-images.githubusercontent.com/16718859/27521622-05885024-59d4-11e7-8adc-11ab6e1fc738.png">

## old
<img width="232" alt="screen shot 2017-06-25 at 18 20 48" src="https://user-images.githubusercontent.com/16718859/27521621-057ffcf8-59d4-11e7-83f7-b2f02149bd3b.png">
<img width="237" alt="screen shot 2017-06-25 at 18 20 59" src="https://user-images.githubusercontent.com/16718859/27521624-0590e9d2-59d4-11e7-8d2b-e29a81420e59.png">

the gap on the left is bigger in the new version