### PR TITLE
RegEx fixes #9382

### DIFF
--- a/modules/regex/regex.cpp
+++ b/modules/regex/regex.cpp
@@ -603,10 +603,8 @@ struct RegExNodeGroup : public RegExNode {
 
 			int res = childset[i]->test(s, pos);
 
-			if (s.complete)
-				return res;
-
 			if (inverse) {
+				s.complete = false;
 				if (res < 0)
 					res = pos + 1;
 				else
@@ -615,6 +613,9 @@ struct RegExNodeGroup : public RegExNode {
 				if (i + 1 < childset.size())
 					continue;
 			}
+
+			if (s.complete)
+				return res;
 
 			if (res >= 0) {
 				if (reset_pos)

--- a/modules/regex/regex.cpp
+++ b/modules/regex/regex.cpp
@@ -590,6 +590,11 @@ struct RegExNodeGroup : public RegExNode {
 			memdelete(childset[i]);
 	}
 
+	virtual void test_success(RegExSearch &s, int pos) const {
+
+		return;
+	}
+
 	virtual int test(RegExSearch &s, int pos) const {
 
 		for (int i = 0; i < childset.size(); ++i) {
@@ -614,6 +619,7 @@ struct RegExNodeGroup : public RegExNode {
 			if (res >= 0) {
 				if (reset_pos)
 					res = pos;
+				this->test_success(s, res);
 				return next ? next->test(s, res) : res;
 			}
 		}
@@ -668,6 +674,12 @@ struct RegExNodeCapturing : public RegExNodeGroup {
 		id = p_id;
 	}
 
+	virtual void test_success(RegExSearch &s, int pos) const {
+
+		RegExMatch::Group &ref = s.match->captures[id];
+		ref.length = pos - ref.start;
+	}
+
 	virtual int test(RegExSearch &s, int pos) const {
 
 		RegExMatch::Group &ref = s.match->captures[id];
@@ -676,13 +688,8 @@ struct RegExNodeCapturing : public RegExNodeGroup {
 
 		int res = RegExNodeGroup::test(s, pos);
 
-		if (res >= 0) {
-			if (!s.complete)
-				ref.length = res - pos;
-		} else {
+		if (res < 0)
 			ref.start = old_start;
-		}
-
 		return res;
 	}
 


### PR DESCRIPTION
As they are two separate fixes in one pull request, there's no need to squash. Should be possible to cherry-pick into 2.1 as well.

Fixes #9382 and another one I caught in debugging.