### PR TITLE
Queue RPC packet before calling method locally to ensure correct RPC …

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -753,11 +753,11 @@ void Node::rpcp(int p_peer_id, bool p_unreliable, const StringName &p_method, co
 	ERR_FAIL_COND(!is_inside_tree());
 
 	bool skip_rpc = false;
+	bool call_local_native = false;
+	bool call_local_script = false;
 
 	if (p_peer_id == 0 || p_peer_id == get_tree()->get_network_unique_id() || (p_peer_id < 0 && p_peer_id != -get_tree()->get_network_unique_id())) {
 		//check that send mode can use local call
-
-		bool call_local = false;
 
 		Map<StringName, RPCMode>::Element *E = data.rpc_methods.find(p_method);
 		if (E) {
@@ -772,29 +772,22 @@ void Node::rpcp(int p_peer_id, bool p_unreliable, const StringName &p_method, co
 				} break;
 				case RPC_MODE_SYNC: {
 					//call it, sync always results in call
-					call_local = true;
+					call_local_native = true;
 				} break;
 				case RPC_MODE_MASTER: {
-					call_local = is_network_master();
-					if (call_local) {
+					call_local_native = is_network_master();
+					if (call_local_native) {
 						skip_rpc = true; //no other master so..
 					}
 				} break;
 				case RPC_MODE_SLAVE: {
-					call_local = !is_network_master();
+					call_local_native = !is_network_master();
 				} break;
 			}
 		}
 
-		if (call_local) {
-			Variant::CallError ce;
-			call(p_method, p_arg, p_argcount, ce);
-			if (ce.error != Variant::CallError::CALL_OK) {
-				String error = Variant::get_call_error_text(this, p_method, p_arg, p_argcount, ce);
-				error = "rpc() aborted in local call:  - " + error;
-				ERR_PRINTS(error);
-				return;
-			}
+		if (call_local_native) {
+			// done below
 		} else if (get_script_instance()) {
 			//attempt with script
 			ScriptInstance::RPCMode rpc_mode = get_script_instance()->get_rpc_mode(p_method);
@@ -809,37 +802,47 @@ void Node::rpcp(int p_peer_id, bool p_unreliable, const StringName &p_method, co
 				} break;
 				case ScriptInstance::RPC_MODE_SYNC: {
 					//call it, sync always results in call
-					call_local = true;
+					call_local_script = true;
 				} break;
 				case ScriptInstance::RPC_MODE_MASTER: {
-					call_local = is_network_master();
-					if (call_local) {
+					call_local_script = is_network_master();
+					if (call_local_script) {
 						skip_rpc = true; //no other master so..
 					}
 				} break;
 				case ScriptInstance::RPC_MODE_SLAVE: {
-					call_local = !is_network_master();
+					call_local_script = !is_network_master();
 				} break;
-			}
-
-			if (call_local) {
-				Variant::CallError ce;
-				ce.error = Variant::CallError::CALL_OK;
-				get_script_instance()->call(p_method, p_arg, p_argcount, ce);
-				if (ce.error != Variant::CallError::CALL_OK) {
-					String error = Variant::get_call_error_text(this, p_method, p_arg, p_argcount, ce);
-					error = "rpc() aborted in script local call:  - " + error;
-					ERR_PRINTS(error);
-					return;
-				}
 			}
 		}
 	}
 
-	if (skip_rpc)
-		return;
+	if (!skip_rpc) {
+		get_tree()->_rpc(this, p_peer_id, p_unreliable, false, p_method, p_arg, p_argcount);
+	}
 
-	get_tree()->_rpc(this, p_peer_id, p_unreliable, false, p_method, p_arg, p_argcount);
+	if (call_local_native) {
+		Variant::CallError ce;
+		call(p_method, p_arg, p_argcount, ce);
+		if (ce.error != Variant::CallError::CALL_OK) {
+			String error = Variant::get_call_error_text(this, p_method, p_arg, p_argcount, ce);
+			error = "rpc() aborted in local call:  - " + error;
+			ERR_PRINTS(error);
+			return;
+		}
+	}
+
+	if (call_local_script) {
+		Variant::CallError ce;
+		ce.error = Variant::CallError::CALL_OK;
+		get_script_instance()->call(p_method, p_arg, p_argcount, ce);
+		if (ce.error != Variant::CallError::CALL_OK) {
+			String error = Variant::get_call_error_text(this, p_method, p_arg, p_argcount, ce);
+			error = "rpc() aborted in script local call:  - " + error;
+			ERR_PRINTS(error);
+			return;
+		}
+	}
 }
 
 /******** RSET *********/


### PR DESCRIPTION
Queue RPC packet before calling method locally to ensure correct RPC packet order.
Fixes #9151

example of what this fixes:

rpc("a");

sync func a
  rpc("b");

sync func b
  return;

on the server of execution will be: a is called, then b is called.
on the clients: b is called, then a is called.

this occurs as the server calls the local method before sending off the network packet about the RPC. 
this code changes it so the RPC is queued then calls the method.


