### PR TITLE
Fix filesystem update for import plugins

### DIFF
--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -284,12 +284,12 @@ void EditorPlugin::save_global_state() {}
 
 void EditorPlugin::add_import_plugin(const Ref<EditorImportPlugin> &p_importer) {
 	ResourceFormatImporter::get_singleton()->add_importer(p_importer);
-	EditorFileSystem::get_singleton()->scan_changes();
+	EditorFileSystem::get_singleton()->scan();
 }
 
 void EditorPlugin::remove_import_plugin(const Ref<EditorImportPlugin> &p_importer) {
 	ResourceFormatImporter::get_singleton()->remove_importer(p_importer);
-	EditorFileSystem::get_singleton()->scan_changes();
+	EditorFileSystem::get_singleton()->scan();
 }
 
 void EditorPlugin::set_window_layout(Ref<ConfigFile> p_layout) {


### PR DESCRIPTION
This fix is only partial as described in https://github.com/godotengine/godot/issues/9286#issuecomment-311519620, but it's still better than the current status.