### PR TITLE
Fix Tileset/tilemap issues related to my adding of one-way collisions to them

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -90,9 +90,10 @@ void TileSetEditor::_import_node(Node *p_node, Ref<TileSet> p_library) {
 			phys_offset += -s / 2;
 		}
 
-		Vector<Ref<Shape2D> > collisions;
+		Vector<TileSet::ShapeData> collisions;
 		Ref<NavigationPolygon> nav_poly;
 		Ref<OccluderPolygon2D> occluder;
+		bool found_collisions = false;
 
 		for (int j = 0; j < mi->get_child_count(); j++) {
 
@@ -106,22 +107,36 @@ void TileSetEditor::_import_node(Node *p_node, Ref<TileSet> p_library) {
 
 			if (!child2->cast_to<StaticBody2D>())
 				continue;
+
+			found_collisions = true;
+
 			StaticBody2D *sb = child2->cast_to<StaticBody2D>();
 
 			List<uint32_t> shapes;
 			sb->get_shape_owners(&shapes);
 
 			for (List<uint32_t>::Element *E = shapes.front(); E; E = E->next()) {
+				if (sb->is_shape_owner_disabled(E->get())) continue;
 
-				Vector2 shape_offset = sb->shape_owner_get_transform(E->get()).get_origin();
+				Transform2D shape_transform = sb->shape_owner_get_transform(E->get());
 				bool one_way = sb->is_shape_owner_one_way_collision_enabled(E->get());
+
+				shape_transform.set_origin(shape_transform.get_origin() - phys_offset);
 
 				for (int k = 0; k < sb->shape_owner_get_shape_count(E->get()); k++) {
 
-					Ref<Shape> shape = sb->shape_owner_get_shape(E->get(), k);
-					p_library->tile_add_shape(id, shape, shape_offset, one_way);
+					Ref<Shape2D> shape = sb->shape_owner_get_shape(E->get(), k);
+					TileSet::ShapeData shape_data;
+					shape_data.shape = shape;
+					shape_data.shape_transform = shape_transform;
+					shape_data.one_way_collision = one_way;
+					collisions.push_back(shape_data);
 				}
 			}
+		}
+
+		if (found_collisions) {
+			p_library->tile_set_shapes(id, collisions);
 		}
 
 		p_library->tile_set_texture_offset(id, mi->get_offset());

--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -204,10 +204,10 @@ int CollisionObject2D::shape_owner_get_shape_count(uint32_t p_owner) const {
 
 	return shapes[p_owner].shapes.size();
 }
-Ref<Shape> CollisionObject2D::shape_owner_get_shape(uint32_t p_owner, int p_shape) const {
+Ref<Shape2D> CollisionObject2D::shape_owner_get_shape(uint32_t p_owner, int p_shape) const {
 
-	ERR_FAIL_COND_V(!shapes.has(p_owner), Ref<Shape>());
-	ERR_FAIL_INDEX_V(p_shape, shapes[p_owner].shapes.size(), Ref<Shape>());
+	ERR_FAIL_COND_V(!shapes.has(p_owner), Ref<Shape2D>());
+	ERR_FAIL_INDEX_V(p_shape, shapes[p_owner].shapes.size(), Ref<Shape2D>());
 
 	return shapes[p_owner].shapes[p_shape].shape;
 }

--- a/scene/2d/collision_object_2d.h
+++ b/scene/2d/collision_object_2d.h
@@ -94,7 +94,7 @@ public:
 
 	void shape_owner_add_shape(uint32_t p_owner, const Ref<Shape2D> &p_shape);
 	int shape_owner_get_shape_count(uint32_t p_owner) const;
-	Ref<Shape> shape_owner_get_shape(uint32_t p_owner, int p_shape) const;
+	Ref<Shape2D> shape_owner_get_shape(uint32_t p_owner, int p_shape) const;
 	int shape_owner_get_shape_index(uint32_t p_owner, int p_shape) const;
 
 	void shape_owner_remove_shape(uint32_t p_owner, int p_shape);

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -461,16 +461,18 @@ void TileMap::_update_dirty_quadrants() {
 					Transform2D xform;
 					xform.set_origin(offset.floor());
 
-					_fix_cell_transform(xform, c, shapes[i].shape_offset + center_ofs, s);
+					_fix_cell_transform(xform, c, center_ofs, s);
+
+					xform *= shapes[i].shape_transform;
 
 					if (debug_canvas_item.is_valid()) {
 						vs->canvas_item_add_set_transform(debug_canvas_item, xform);
 						shape->draw(debug_canvas_item, debug_collision_color);
 					}
 					ps->body_add_shape(q.body, shape->get_rid(), xform);
-					shape_idx++;
-					ps->body_set_shape_as_one_way_collision(q.body, shape_idx, shapes[i].one_way_collision);
 					ps->body_set_shape_metadata(q.body, shape_idx, Vector2(E->key().x, E->key().y));
+					ps->body_set_shape_as_one_way_collision(q.body, shape_idx, shapes[i].one_way_collision);
+					shape_idx++;
 				}
 			}
 

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -57,8 +57,8 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 		tile_set_region(id, p_value);
 	else if (what == "shape")
 		tile_set_shape(id, 0, p_value);
-	else if (what == "shape_offset")
-		tile_set_shape_offset(id, 0, p_value);
+	else if (what == "shape_transform")
+		tile_set_shape_transform(id, 0, p_value);
 	else if (what == "shape_one_way")
 		tile_set_shape_one_way(id, 0, p_value);
 	else if (what == "shapes")
@@ -105,8 +105,8 @@ bool TileSet::_get(const StringName &p_name, Variant &r_ret) const {
 		r_ret = tile_get_region(id);
 	else if (what == "shape")
 		r_ret = tile_get_shape(id, 0);
-	else if (what == "shape_offset")
-		r_ret = tile_get_shape_offset(id, 0);
+	else if (what == "shape_transform")
+		r_ret = tile_get_shape_transform(id, 0);
 	else if (what == "shape_one_way")
 		r_ret = tile_get_shape_one_way(id, 0);
 	else if (what == "shapes")
@@ -142,7 +142,7 @@ void TileSet::_get_property_list(List<PropertyInfo> *p_list) const {
 		p_list->push_back(PropertyInfo(Variant::OBJECT, pre + "occluder", PROPERTY_HINT_RESOURCE_TYPE, "OccluderPolygon2D"));
 		p_list->push_back(PropertyInfo(Variant::VECTOR2, pre + "navigation_offset"));
 		p_list->push_back(PropertyInfo(Variant::OBJECT, pre + "navigation", PROPERTY_HINT_RESOURCE_TYPE, "NavigationPolygon"));
-		p_list->push_back(PropertyInfo(Variant::VECTOR2, pre + "shape_offset", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
+		p_list->push_back(PropertyInfo(Variant::VECTOR2, pre + "shape_transform", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
 		p_list->push_back(PropertyInfo(Variant::OBJECT, pre + "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape2D", PROPERTY_USAGE_EDITOR));
 		p_list->push_back(PropertyInfo(Variant::BOOL, pre + "shape_one_way", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
 		p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "shapes", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
@@ -252,13 +252,13 @@ void TileSet::tile_clear_shapes(int p_id) {
 	tile_map[p_id].shapes_data.clear();
 }
 
-void TileSet::tile_add_shape(int p_id, const Ref<Shape2D> &p_shape, const Vector2 &p_offset, bool p_one_way) {
+void TileSet::tile_add_shape(int p_id, const Ref<Shape2D> &p_shape, const Transform2D &p_transform, bool p_one_way) {
 
 	ERR_FAIL_COND(!tile_map.has(p_id));
 
 	ShapeData new_data = ShapeData();
 	new_data.shape = p_shape;
-	new_data.shape_offset = p_offset;
+	new_data.shape_transform = p_transform;
 	new_data.one_way_collision = p_one_way;
 
 	tile_map[p_id].shapes_data.push_back(new_data);
@@ -288,22 +288,22 @@ Ref<Shape2D> TileSet::tile_get_shape(int p_id, int p_shape_id) const {
 	return Ref<Shape2D>();
 }
 
-void TileSet::tile_set_shape_offset(int p_id, int p_shape_id, const Vector2 &p_offset) {
+void TileSet::tile_set_shape_transform(int p_id, int p_shape_id, const Transform2D &p_offset) {
 
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	if (tile_map[p_id].shapes_data.size() <= p_shape_id)
 		tile_map[p_id].shapes_data.resize(p_shape_id + 1);
-	tile_map[p_id].shapes_data[p_shape_id].shape_offset = p_offset;
+	tile_map[p_id].shapes_data[p_shape_id].shape_transform = p_offset;
 	emit_changed();
 }
 
-Vector2 TileSet::tile_get_shape_offset(int p_id, int p_shape_id) const {
+Transform2D TileSet::tile_get_shape_transform(int p_id, int p_shape_id) const {
 
-	ERR_FAIL_COND_V(!tile_map.has(p_id), Vector2());
+	ERR_FAIL_COND_V(!tile_map.has(p_id), Transform2D());
 	if (tile_map[p_id].shapes_data.size() > p_shape_id)
-		return tile_map[p_id].shapes_data[p_shape_id].shape_offset;
+		return tile_map[p_id].shapes_data[p_shape_id].shape_transform;
 
-	return Vector2();
+	return Transform2D();
 }
 
 void TileSet::tile_set_shape_one_way(int p_id, int p_shape_id, const bool p_one_way) {
@@ -388,7 +388,7 @@ void TileSet::_tile_set_shapes(int p_id, const Array &p_shapes) {
 
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	Vector<ShapeData> shapes_data;
-	Vector2 default_offset = tile_get_shape_offset(p_id, 0);
+	Transform2D default_transform = tile_get_shape_transform(p_id, 0);
 	bool default_one_way = tile_get_shape_one_way(p_id, 0);
 	for (int i = 0; i < p_shapes.size(); i++) {
 		ShapeData s = ShapeData();
@@ -398,7 +398,7 @@ void TileSet::_tile_set_shapes(int p_id, const Array &p_shapes) {
 			if (shape.is_null()) continue;
 
 			s.shape = shape;
-			s.shape_offset = default_offset;
+			s.shape_transform = default_transform;
 			s.one_way_collision = default_one_way;
 		} else if (p_shapes[i].get_type() == Variant::DICTIONARY) {
 			Dictionary d = p_shapes[i];
@@ -408,10 +408,12 @@ void TileSet::_tile_set_shapes(int p_id, const Array &p_shapes) {
 			else
 				continue;
 
-			if (d.has("shape_offset") && d["shape_offset"].get_type() == Variant::VECTOR2)
-				s.shape_offset = d["shape_offset"];
+			if (d.has("shape_transform") && d["shape_transform"].get_type() == Variant::TRANSFORM2D)
+				s.shape_transform = d["shape_transform"];
+			else if (d.has("shape_offset") && d["shape_offset"].get_type() == Variant::VECTOR2)
+				s.shape_transform = Transform2D(0, (Vector2)d["shape_offset"]);
 			else
-				s.shape_offset = default_offset;
+				s.shape_transform = default_transform;
 
 			if (d.has("one_way") && d["one_way"].get_type() == Variant::BOOL)
 				s.one_way_collision = d["one_way"];
@@ -438,7 +440,7 @@ Array TileSet::_tile_get_shapes(int p_id) const {
 	for (int i = 0; i < data.size(); i++) {
 		Dictionary shape_data;
 		shape_data["shape"] = data[i].shape;
-		shape_data["shape_offset"] = data[i].shape_offset;
+		shape_data["shape_transform"] = data[i].shape_transform;
 		shape_data["one_way"] = data[i].one_way_collision;
 		arr.push_back(shape_data);
 	}
@@ -520,11 +522,11 @@ void TileSet::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("tile_get_region", "id"), &TileSet::tile_get_region);
 	ClassDB::bind_method(D_METHOD("tile_set_shape", "id", "shape_id", "shape:Shape2D"), &TileSet::tile_set_shape);
 	ClassDB::bind_method(D_METHOD("tile_get_shape:Shape2D", "id", "shape_id"), &TileSet::tile_get_shape);
-	ClassDB::bind_method(D_METHOD("tile_set_shape_offset", "id", "shape_id", "shape_offset"), &TileSet::tile_set_shape_offset);
-	ClassDB::bind_method(D_METHOD("tile_get_shape_offset", "id", "shape_id"), &TileSet::tile_get_shape_offset);
+	ClassDB::bind_method(D_METHOD("tile_set_shape_transform", "id", "shape_id", "shape_transform"), &TileSet::tile_set_shape_transform);
+	ClassDB::bind_method(D_METHOD("tile_get_shape_transform", "id", "shape_id"), &TileSet::tile_get_shape_transform);
 	ClassDB::bind_method(D_METHOD("tile_set_shape_one_way", "id", "shape_id", "one_way"), &TileSet::tile_set_shape_one_way);
 	ClassDB::bind_method(D_METHOD("tile_get_shape_one_way", "id", "shape_id"), &TileSet::tile_get_shape_one_way);
-	ClassDB::bind_method(D_METHOD("tile_add_shape", "id", "shape:Shape2D", "shape_offset", "one_way"), &TileSet::tile_add_shape, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("tile_add_shape", "id", "shape:Shape2D", "shape_transform", "one_way"), &TileSet::tile_add_shape, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("tile_get_shape_count", "id"), &TileSet::tile_get_shape_count);
 	ClassDB::bind_method(D_METHOD("tile_set_shapes", "id", "shapes"), &TileSet::_tile_set_shapes);
 	ClassDB::bind_method(D_METHOD("tile_get_shapes", "id"), &TileSet::_tile_get_shapes);

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -43,7 +43,7 @@ class TileSet : public Resource {
 public:
 	struct ShapeData {
 		Ref<Shape2D> shape;
-		Vector2 shape_offset;
+		Transform2D shape_transform;
 		bool one_way_collision;
 
 		ShapeData() {
@@ -105,14 +105,14 @@ public:
 	void tile_set_shape(int p_id, int p_shape_id, const Ref<Shape2D> &p_shape);
 	Ref<Shape2D> tile_get_shape(int p_id, int p_shape_id) const;
 
-	void tile_set_shape_offset(int p_id, int p_shape_id, const Vector2 &p_offset);
-	Vector2 tile_get_shape_offset(int p_id, int p_shape_id) const;
+	void tile_set_shape_transform(int p_id, int p_shape_id, const Transform2D &p_transform);
+	Transform2D tile_get_shape_transform(int p_id, int p_shape_id) const;
 
 	void tile_set_shape_one_way(int p_id, int p_shape_id, bool p_one_way);
 	bool tile_get_shape_one_way(int p_id, int p_shape_id) const;
 
 	void tile_clear_shapes(int p_id);
-	void tile_add_shape(int p_id, const Ref<Shape2D> &p_shape, const Vector2 &p_offset, bool p_one_way = false);
+	void tile_add_shape(int p_id, const Ref<Shape2D> &p_shape, const Transform2D &p_transform, bool p_one_way = false);
 	int tile_get_shape_count(int p_id) const;
 
 	void tile_set_shapes(int p_id, const Vector<ShapeData> &p_shapes);


### PR DESCRIPTION
Also, turn `shape_offset` into `shape_transform`, since otherwise you can have only down-pointing one-way collisions.

Fix bad return type in CollisionObject2D, Shape -> Shape2D. Was causing unintended null when casting. (#9409)
Fix a misplaced ++ operator. (#9370)
Fix merging with exiting tileset duplicating shapes. (#9370)