### PR TITLE
Buildsystem: Improve detect.py readability and fix issues

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -14,22 +14,17 @@ def get_name():
 
 def can_build():
 
-    import os
-    if (not os.environ.has_key("ANDROID_NDK_ROOT")):
-        return False
-
-    return True
+    return (os.environ.has_key("ANDROID_NDK_ROOT"))
 
 
 def get_opts():
 
     return [
-        ('ANDROID_NDK_ROOT', 'the path to Android NDK',
-         os.environ.get("ANDROID_NDK_ROOT", 0)),
-	('ndk_platform', 'compile for platform: (android-<api> , example: android-18)', "android-18"),
-        ('android_arch', 'select compiler architecture: (armv7/armv6/x86)', "armv7"),
-        ('android_neon', 'enable neon (armv7 only)', "yes"),
-        ('android_stl', 'enable STL support in android port (for modules)', "no")
+        ('ANDROID_NDK_ROOT', 'Path to the Android NDK', os.environ.get("ANDROID_NDK_ROOT", 0)),
+        ('ndk_platform', 'Target platform (android-<api>, e.g. "android-18")', "android-18"),
+        ('android_arch', 'Target architecture (armv7/armv6/x86)', "armv7"),
+        ('android_neon', 'Enable NEON support (armv7 only)', "yes"),
+        ('android_stl', 'Enable Android STL support (for modules)', "no")
     ]
 
 
@@ -41,6 +36,7 @@ def get_flags():
 
 
 def create(env):
+
     tools = env['TOOLS']
     if "mingw" in tools:
         tools.remove('mingw')
@@ -54,7 +50,6 @@ def configure(env):
 
     # Workaround for MinGW. See:
     # http://www.scons.org/wiki/LongCmdLinesOnWin32
-    import os
     if (os.name == "nt"):
 
         import subprocess
@@ -92,35 +87,43 @@ def configure(env):
 
         env['SPAWN'] = mySpawn
 
-    ndk_platform = env['ndk_platform']
+    ## Build type
+
+    if (env["target"].startswith("release")):
+        env.Append(LINKFLAGS=['-O2'])
+        env.Append(CPPFLAGS=['-O2', '-DNDEBUG', '-ffast-math', '-funsafe-math-optimizations', '-fomit-frame-pointer'])
+        if (can_vectorize):
+            env.Append(CPPFLAGS=['-ftree-vectorize'])
+        if (env["target"] == "release_debug"):
+            env.Append(CPPFLAGS=['-DDEBUG_ENABLED'])
+    elif (env["target"] == "debug"):
+        env.Append(LINKFLAGS=['-O0'])
+        env.Append(CPPFLAGS=['-O0', '-D_DEBUG', '-UNDEBUG', '-DDEBUG_ENABLED',
+                             '-DDEBUG_MEMORY_ENABLED', '-g', '-fno-limit-debug-info'])
+
+    ## Architecture
 
     if env['android_arch'] not in ['armv7', 'armv6', 'x86']:
         env['android_arch'] = 'armv7'
 
-    if env['android_arch'] == 'x86':
-        env["x86_libtheora_opt_gcc"] = True
-
-    if env['PLATFORM'] == 'win32':
-        env.Tool('gcc')
-        env['SHLIBSUFFIX'] = '.so'
-
     neon_text = ""
     if env["android_arch"] == "armv7" and env['android_neon'] == 'yes':
-        neon_text = " (with neon)"
-    print("Godot Android!!!!! (" + env['android_arch'] + ")" + neon_text)
+        neon_text = " (with NEON)"
+    print("Building for Android (" + env['android_arch'] + ")" + neon_text)
 
-    env.Append(CPPPATH=['#platform/android'])
-
+    can_vectorize = True
     if env['android_arch'] == 'x86':
         env.extra_suffix = ".x86" + env.extra_suffix
         target_subpath = "x86-4.9"
         abi_subpath = "i686-linux-android"
         arch_subpath = "x86"
+        env["x86_libtheora_opt_gcc"] = True
     elif env['android_arch'] == 'armv6':
         env.extra_suffix = ".armv6" + env.extra_suffix
         target_subpath = "arm-linux-androideabi-4.9"
         abi_subpath = "arm-linux-androideabi"
         arch_subpath = "armeabi"
+        can_vectorize = False
     elif env["android_arch"] == "armv7":
         target_subpath = "arm-linux-androideabi-4.9"
         abi_subpath = "arm-linux-androideabi"
@@ -129,6 +132,14 @@ def configure(env):
             env.extra_suffix = ".armv7.neon" + env.extra_suffix
         else:
             env.extra_suffix = ".armv7" + env.extra_suffix
+
+    ## Compiler configuration
+
+    env['SHLIBSUFFIX'] = '.so'
+
+    if env['PLATFORM'] == 'win32':
+        env.Tool('gcc')
+        env.use_windows_spawn_fix()
 
     mt_link = True
     if (sys.platform.startswith("linux")):
@@ -142,10 +153,8 @@ def configure(env):
             mt_link = False
             host_subpath = "windows"
 
-    compiler_path = env["ANDROID_NDK_ROOT"] + \
-        "/toolchains/llvm/prebuilt/" + host_subpath + "/bin"
-    gcc_toolchain_path = env["ANDROID_NDK_ROOT"] + \
-        "/toolchains/" + target_subpath + "/prebuilt/" + host_subpath
+    compiler_path = env["ANDROID_NDK_ROOT"] + "/toolchains/llvm/prebuilt/" + host_subpath + "/bin"
+    gcc_toolchain_path = env["ANDROID_NDK_ROOT"] + "/toolchains/" + target_subpath + "/prebuilt/" + host_subpath
     tools_path = gcc_toolchain_path + "/" + abi_subpath + "/bin"
 
     # For Clang to find NDK tools in preference of those system-wide
@@ -162,31 +171,28 @@ def configure(env):
     else:
         env['ARCH'] = 'arch-arm'
 
-    sysroot = env["ANDROID_NDK_ROOT"] + \
-        "/platforms/" + ndk_platform + "/" + env['ARCH']
+    sysroot = env["ANDROID_NDK_ROOT"] + "/platforms/" + env['ndk_platform'] + "/" + env['ARCH']
     common_opts = ['-fno-integrated-as', '-gcc-toolchain', gcc_toolchain_path]
 
+    ## Compile flags
+
     env.Append(CPPFLAGS=["-isystem", sysroot + "/usr/include"])
-    env.Append(CPPFLAGS=string.split(
-        '-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -fvisibility=hidden -fno-strict-aliasing'))
+    env.Append(CPPFLAGS=string.split('-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -fvisibility=hidden -fno-strict-aliasing'))
     env.Append(CPPFLAGS=string.split('-DANDROID -DNO_STATVFS -DGLES2_ENABLED'))
 
     env['neon_enabled'] = False
     if env['android_arch'] == 'x86':
-        can_vectorize = True
         target_opts = ['-target', 'i686-none-linux-android']
         # The NDK adds this if targeting API < 21, so we can drop it when Godot targets it at least
         env.Append(CPPFLAGS=['-mstackrealign'])
+
     elif env["android_arch"] == "armv6":
-        can_vectorize = False
         target_opts = ['-target', 'armv6-none-linux-androideabi']
-        env.Append(CPPFLAGS=string.split(
-            '-D__ARM_ARCH_6__ -march=armv6 -mfpu=vfp -mfloat-abi=softfp'))
+        env.Append(CPPFLAGS=string.split('-D__ARM_ARCH_6__ -march=armv6 -mfpu=vfp -mfloat-abi=softfp'))
+
     elif env["android_arch"] == "armv7":
-        can_vectorize = True
         target_opts = ['-target', 'armv7-none-linux-androideabi']
-        env.Append(CPPFLAGS=string.split(
-            '-D__ARM_ARCH_7__ -D__ARM_ARCH_7A__ -march=armv7-a -mfloat-abi=softfp'))
+        env.Append(CPPFLAGS=string.split('-D__ARM_ARCH_7__ -D__ARM_ARCH_7A__ -march=armv7-a -mfloat-abi=softfp'))
         if env['android_neon'] == 'yes':
             env['neon_enabled'] = True
             env.Append(CPPFLAGS=['-mfpu=neon', '-D__ARM_NEON__'])
@@ -196,21 +202,20 @@ def configure(env):
     env.Append(CPPFLAGS=target_opts)
     env.Append(CPPFLAGS=common_opts)
 
-    env.Append(LIBS=['OpenSLES'])
-    env.Append(LIBS=['EGL', 'OpenSLES', 'android'])
-    env.Append(LIBS=['log', 'GLESv1_CM', 'GLESv2', 'GLESv3','z'])
+    if (env['android_stl'] == 'yes'):
+        env.Append(CPPPATH=[env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/gnu-libstdc++/4.9/include"])
+        env.Append(CPPPATH=[env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/gnu-libstdc++/4.9/libs/" + arch_subpath + "/include"])
+        env.Append(LIBPATH=[env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/gnu-libstdc++/4.9/libs/" + arch_subpath])
+        env.Append(LIBS=["gnustl_static"])
+    else:
+        env.Append(CXXFLAGS=['-fno-rtti', '-fno-exceptions', '-DNO_SAFE_CAST'])
 
-    if (sys.platform.startswith("darwin")):
-        env['SHLIBSUFFIX'] = '.so'
+    ## Link flags
 
-    env['LINKFLAGS'] = ['-shared', '--sysroot=' +
-                        sysroot, '-Wl,--warn-shared-textrel']
-    env.Append(LINKFLAGS=string.split(
-        '-Wl,--fix-cortex-a8'))
-    env.Append(LINKFLAGS=string.split(
-        '-Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now'))
-    env.Append(LINKFLAGS=string.split(
-        '-Wl,-soname,libgodot_android.so -Wl,--gc-sections'))
+    env['LINKFLAGS'] = ['-shared', '--sysroot=' + sysroot, '-Wl,--warn-shared-textrel']
+    env.Append(LINKFLAGS=string.split('-Wl,--fix-cortex-a8'))
+    env.Append(LINKFLAGS=string.split('-Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now'))
+    env.Append(LINKFLAGS=string.split('-Wl,-soname,libgodot_android.so -Wl,--gc-sections'))
     if mt_link:
         env.Append(LINKFLAGS=['-Wl,--threads'])
     env.Append(LINKFLAGS=target_opts)
@@ -221,45 +226,12 @@ def configure(env):
     env.Append(LIBPATH=[env["ANDROID_NDK_ROOT"] +
                         '/toolchains/arm-linux-androideabi-4.9/prebuilt/' + host_subpath + '/' + abi_subpath + '/lib'])
 
-    if (env["target"].startswith("release")):
-        env.Append(LINKFLAGS=['-O2'])
-        env.Append(CPPFLAGS=['-O2', '-DNDEBUG', '-ffast-math',
-                             '-funsafe-math-optimizations', '-fomit-frame-pointer'])
-        if (can_vectorize):
-            env.Append(CPPFLAGS=['-ftree-vectorize'])
-        if (env["target"] == "release_debug"):
-            env.Append(CPPFLAGS=['-DDEBUG_ENABLED'])
-    elif (env["target"] == "debug"):
-        env.Append(LINKFLAGS=['-O0'])
-        env.Append(CPPFLAGS=['-O0', '-D_DEBUG', '-UNDEBUG', '-DDEBUG_ENABLED',
-                             '-DDEBUG_MEMORY_ENABLED', '-g', '-fno-limit-debug-info'])
-
-    env.Append(CPPFLAGS=['-DANDROID_ENABLED',
-                         '-DUNIX_ENABLED', '-DNO_FCNTL', '-DMPC_FIXED_POINT'])
+    env.Append(CPPPATH=['#platform/android'])
+    env.Append(CPPFLAGS=['-DANDROID_ENABLED', '-DUNIX_ENABLED', '-DNO_FCNTL', '-DMPC_FIXED_POINT'])
+    env.Append(LIBS=['OpenSLES', 'EGL', 'GLESv3', 'android', 'log', 'z'])
 
     # TODO: Move that to opus module's config
     if("module_opus_enabled" in env and env["module_opus_enabled"] != "no"):
         if (env["android_arch"] == "armv6" or env["android_arch"] == "armv7"):
             env.Append(CFLAGS=["-DOPUS_ARM_OPT"])
         env.opus_fixed_point = "yes"
-
-    if (env['android_stl'] == 'yes'):
-        env.Append(CPPPATH=[env["ANDROID_NDK_ROOT"] +
-                            "/sources/cxx-stl/gnu-libstdc++/4.9/include"])
-        env.Append(CPPPATH=[env["ANDROID_NDK_ROOT"] +
-                            "/sources/cxx-stl/gnu-libstdc++/4.9/libs/" + arch_subpath + "/include"])
-        env.Append(LIBPATH=[env["ANDROID_NDK_ROOT"] +
-                            "/sources/cxx-stl/gnu-libstdc++/4.9/libs/" + arch_subpath])
-        env.Append(LIBS=["gnustl_static"])
-    else:
-        env.Append(CXXFLAGS=['-fno-rtti', '-fno-exceptions', '-DNO_SAFE_CAST'])
-
-    import methods
-    env.Append(BUILDERS={'GLSL120': env.Builder(
-        action=methods.build_legacygl_headers, suffix='glsl.h', src_suffix='.glsl')})
-    env.Append(BUILDERS={'GLSL': env.Builder(
-        action=methods.build_glsl_headers, suffix='glsl.h', src_suffix='.glsl')})
-    env.Append(BUILDERS={'GLSL120GLES': env.Builder(
-        action=methods.build_gles2_headers, suffix='glsl.h', src_suffix='.glsl')})
-
-    env.use_windows_spawn_fix()

--- a/platform/haiku/detect.py
+++ b/platform/haiku/detect.py
@@ -11,57 +11,58 @@ def get_name():
 
 
 def can_build():
-    if (os.name != "posix"):
-        return False
 
-    if (sys.platform == "darwin"):
+    if (os.name != "posix" or sys.platform == "darwin"):
         return False
 
     return True
 
 
 def get_opts():
+
     return [
         ('debug_release', 'Add debug symbols to release version', 'no')
     ]
 
 
 def get_flags():
+
     return [
     ]
 
 
 def configure(env):
-    is64 = sys.maxsize > 2**32
 
-    if (env["bits"] == "default"):
-        if (is64):
-            env["bits"] = "64"
+    ## Build type
+
+    if (env["target"] == "release"):
+        if (env["debug_release"] == "yes"):
+            env.Prepend(CCFLAGS=['-g2'])
         else:
-            env["bits"] = "32"
+            env.Prepend(CCFLAGS=['-O3', '-ffast-math'])
 
-    env.Append(CPPPATH=['#platform/haiku'])
+    elif (env["target"] == "release_debug"):
+        env.Prepend(CCFLAGS=['-O2', '-ffast-math', '-DDEBUG_ENABLED'])
+
+    elif (env["target"] == "debug"):
+        env.Prepend(CCFLAGS=['-g2', '-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
+
+    ## Architecture
+
+    is64 = sys.maxsize > 2**32
+    if (env["bits"] == "default"):
+        env["bits"] = "64" if is64 else "32"
+
+    ## Compiler configuration
 
     env["CC"] = "gcc-x86"
     env["CXX"] = "g++-x86"
 
-    if (env["target"] == "release"):
-        if (env["debug_release"] == "yes"):
-            env.Append(CCFLAGS=['-g2'])
-        else:
-            env.Append(CCFLAGS=['-O3', '-ffast-math'])
-    elif (env["target"] == "release_debug"):
-        env.Append(CCFLAGS=['-O2', '-ffast-math', '-DDEBUG_ENABLED'])
-    elif (env["target"] == "debug"):
-        env.Append(CCFLAGS=['-g2', '-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
+    ## Flags
 
+    env.Append(CPPPATH=['#platform/haiku'])
+    env.Append(CPPFLAGS=['-DUNIX_ENABLED', '-DOPENGL_ENABLED', '-DGLES2_ENABLED', '-DGLES_OVER_GL'])
+    env.Append(CPPFLAGS=['-DMEDIA_KIT_ENABLED'])
     # env.Append(CCFLAGS=['-DFREETYPE_ENABLED'])
     env.Append(CPPFLAGS=['-DPTHREAD_NO_RENAME'])  # TODO: enable when we have pthread_setname_np
-    env.Append(CPPFLAGS=['-DOPENGL_ENABLED', '-DMEDIA_KIT_ENABLED'])
-    env.Append(CPPFLAGS=['-DUNIX_ENABLED', '-DGLES2_ENABLED', '-DGLES_OVER_GL'])
     env.Append(LIBS=['be', 'game', 'media', 'network', 'bnetapi', 'z', 'GL'])
-
-    import methods
-    env.Append(BUILDERS={'GLSL120': env.Builder(action=methods.build_legacygl_headers, suffix='glsl.h', src_suffix='.glsl')})
-    env.Append(BUILDERS={'GLSL': env.Builder(action=methods.build_glsl_headers, suffix='glsl.h', src_suffix='.glsl')})
-    env.Append(BUILDERS={'GLSL120GLES': env.Builder(action=methods.build_gles2_headers, suffix='glsl.h', src_suffix='.glsl')})

--- a/platform/iphone/SCsub
+++ b/platform/iphone/SCsub
@@ -17,16 +17,7 @@ iphone_lib = [
     'ios.mm',
 ]
 
-# env.Depends('#core/math/vector3.h', 'vector3_psp.h')
-
-#iphone_lib = env.Library('iphone', iphone_lib)
-
 env_ios = env.Clone()
-
-
-if env['ios_gles22_override'] == "yes":
-    env_ios.Append(CPPFLAGS=['-DGLES2_OVERRIDE'])
-
 
 obj = env_ios.Object('godot_iphone.cpp')
 

--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -1,4 +1,5 @@
 import os
+import string
 import sys
 
 
@@ -12,8 +13,6 @@ def get_name():
 
 def can_build():
 
-    import sys
-    import os
     if sys.platform == 'darwin' or os.environ.has_key("OSXCROSS_IOS"):
         return True
 
@@ -23,13 +22,12 @@ def can_build():
 def get_opts():
 
     return [
-        ('IPHONEPLATFORM', 'name of the iphone platform', 'iPhoneOS'),
-        ('IPHONEPATH', 'the path to iphone toolchain', '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain'),
-        ('IPHONESDK', 'path to the iphone SDK', '/Applications/Xcode.app/Contents/Developer/Platforms/${IPHONEPLATFORM}.platform/Developer/SDKs/${IPHONEPLATFORM}.sdk/'),
+        ('IPHONEPLATFORM', 'Name of the iPhone platform', 'iPhoneOS'),
+        ('IPHONEPATH', 'Path to iPhone toolchain', '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain'),
+        ('IPHONESDK', 'Path to the iPhone SDK', '/Applications/Xcode.app/Contents/Developer/Platforms/${IPHONEPLATFORM}.platform/Developer/SDKs/${IPHONEPLATFORM}.sdk/'),
         ('game_center', 'Support for game center', 'yes'),
         ('store_kit', 'Support for in-app store', 'yes'),
         ('icloud', 'Support for iCloud', 'yes'),
-        ('ios_gles22_override', 'Force GLES2.0 on iOS', 'yes'),
         ('ios_exceptions', 'Enable exceptions', 'no'),
         ('ios_triple', 'Triple for ios toolchain', ''),
         ('ios_sim', 'Build simulator binary', 'no'),
@@ -45,7 +43,32 @@ def get_flags():
 
 def configure(env):
 
-    env.Append(CPPPATH=['#platform/iphone'])
+    ## Build type
+
+    if (env["target"].startswith("release")):
+        env.Append(CPPFLAGS=['-DNDEBUG', '-DNS_BLOCK_ASSERTIONS=1'])
+        env.Append(CPPFLAGS=['-O2', '-flto', '-ftree-vectorize', '-fomit-frame-pointer', '-ffast-math', '-funsafe-math-optimizations'])
+        env.Append(LINKFLAGS=['-O2', '-flto'])
+
+        if env["target"] == "release_debug":
+            env.Append(CPPFLAGS=['-DDEBUG_ENABLED'])
+
+    elif (env["target"] == "debug"):
+        env.Append(CPPFLAGS=['-D_DEBUG', '-DDEBUG=1', '-gdwarf-2', '-O0', '-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
+
+    ## Architecture
+
+    if (env["ios_sim"] == "yes" or env["arch"] == "x86"):  # i386, simulator
+        env["arch"] = "x86"
+        env["bits"] = "32"
+    elif (env["arch"] == "arm" or env["arch"] == "arm32" or env["arch"] == "armv7" or env["bits"] == "32"):  # arm
+        env["arch"] = "arm"
+        env["bits"] = "32"
+    else:  # armv64
+        env["arch"] = "arm64"
+        env["bits"] = "64"
+
+    ## Compiler configuration
 
     env['ENV']['PATH'] = env['IPHONEPATH'] + "/Developer/usr/bin/:" + env['ENV']['PATH']
 
@@ -53,87 +76,59 @@ def configure(env):
     env['CXX'] = '$IPHONEPATH/usr/bin/${ios_triple}clang++'
     env['AR'] = '$IPHONEPATH/usr/bin/${ios_triple}ar'
     env['RANLIB'] = '$IPHONEPATH/usr/bin/${ios_triple}ranlib'
+    env['S_compiler'] = '$IPHONEPATH/Developer/usr/bin/gcc'
 
-    import string
-    if (env["ios_sim"] == "yes" or env["arch"] == "x86"):  # i386, simulator
-        env["arch"] = "x86"
-        env["bits"] = "32"
+    ## Compile flags
+
+    if (env["arch"] == "x86"):
+        env['IPHONEPLATFORM'] = 'iPhoneSimulator'
+        env['ENV']['MACOSX_DEPLOYMENT_TARGET'] = '10.6'
         env.Append(CCFLAGS=string.split('-arch i386 -fobjc-abi-version=2 -fobjc-legacy-dispatch -fmessage-length=0 -fpascal-strings -fblocks -fasm-blocks -D__IPHONE_OS_VERSION_MIN_REQUIRED=40100 -isysroot $IPHONESDK -mios-simulator-version-min=4.3 -DCUSTOM_MATRIX_TRANSFORM_H=\\\"build/iphone/matrix4_iphone.h\\\" -DCUSTOM_VECTOR3_TRANSFORM_H=\\\"build/iphone/vector3_iphone.h\\\"'))
-    elif (env["arch"] == "arm" or env["arch"] == "arm32" or env["arch"] == "armv7" or env["bits"] == "32"):  # arm
-        env["arch"] = "arm"
-        env["bits"] = "32"
+    elif (env["arch"] == "arm"):
         env.Append(CCFLAGS=string.split('-fno-objc-arc -arch armv7 -fmessage-length=0 -fno-strict-aliasing -fdiagnostics-print-source-range-info -fdiagnostics-show-category=id -fdiagnostics-parseable-fixits -fpascal-strings -fblocks -isysroot $IPHONESDK -fvisibility=hidden -mthumb "-DIBOutlet=__attribute__((iboutlet))" "-DIBOutletCollection(ClassName)=__attribute__((iboutletcollection(ClassName)))" "-DIBAction=void)__attribute__((ibaction)" -miphoneos-version-min=9.0 -MMD -MT dependencies'))
-    else:  # armv64
-        env["arch"] = "arm64"
-        env["bits"] = "64"
+    elif (env["arch"] == "arm64"):
         env.Append(CCFLAGS=string.split('-fno-objc-arc -arch arm64 -fmessage-length=0 -fno-strict-aliasing -fdiagnostics-print-source-range-info -fdiagnostics-show-category=id -fdiagnostics-parseable-fixits -fpascal-strings -fblocks -fvisibility=hidden -MMD -MT dependencies -miphoneos-version-min=9.0 -isysroot $IPHONESDK'))
         env.Append(CPPFLAGS=['-DNEED_LONG_INT'])
         env.Append(CPPFLAGS=['-DLIBYUV_DISABLE_NEON'])
 
+    if env['ios_exceptions'] == 'yes':
+        env.Append(CPPFLAGS=['-fexceptions'])
+    else:
+        env.Append(CPPFLAGS=['-fno-exceptions'])
+
+    ## Link flags
+
     if (env["arch"] == "x86"):
-        env['IPHONEPLATFORM'] = 'iPhoneSimulator'
         env.Append(LINKFLAGS=['-arch', 'i386', '-mios-simulator-version-min=4.3',
                               '-isysroot', '$IPHONESDK',
-                              #'-mmacosx-version-min=10.6',
                               '-Xlinker',
                               '-objc_abi_version',
                               '-Xlinker', '2',
-                              '-framework', 'AudioToolbox',
-                              '-framework', 'AVFoundation',
-                              '-framework', 'CoreAudio',
-                              '-framework', 'CoreGraphics',
-                              '-framework', 'CoreMedia',
-                              '-framework', 'CoreMotion',
-                              '-framework', 'Foundation',
-                              '-framework', 'Security',
-                              '-framework', 'UIKit',
-                              '-framework', 'MediaPlayer',
-                              '-framework', 'OpenGLES',
-                              '-framework', 'QuartzCore',
-                              '-framework', 'SystemConfiguration',
-                              '-framework', 'GameController',
                               '-F$IPHONESDK',
                               ])
-    elif (env["arch"] == "arm64"):
-        env.Append(LINKFLAGS=['-arch', 'arm64', '-Wl,-dead_strip', '-miphoneos-version-min=9.0',
-                                                '-isysroot', '$IPHONESDK',
-                                                #'-stdlib=libc++',
-                                                '-framework', 'Foundation',
-                                                '-framework', 'UIKit',
-                                                '-framework', 'CoreGraphics',
-                                                '-framework', 'OpenGLES',
-                                                '-framework', 'QuartzCore',
-                                                '-framework', 'CoreAudio',
-                                                '-framework', 'AudioToolbox',
-                                                '-framework', 'SystemConfiguration',
-                                                '-framework', 'Security',
-                                                #'-framework', 'AdSupport',
-                                                '-framework', 'MediaPlayer',
-                                                '-framework', 'AVFoundation',
-                                                '-framework', 'CoreMedia',
-                                                '-framework', 'CoreMotion',
-                                                '-framework', 'GameController',
-                              ])
-    else:
-        env.Append(LINKFLAGS=['-arch', 'armv7', '-Wl,-dead_strip', '-miphoneos-version-min=9.0',
-                                                '-isysroot', '$IPHONESDK',
-                                                '-framework', 'Foundation',
-                                                '-framework', 'UIKit',
-                                                '-framework', 'CoreGraphics',
-                                                '-framework', 'OpenGLES',
-                                                '-framework', 'QuartzCore',
-                                                '-framework', 'CoreAudio',
-                                                '-framework', 'AudioToolbox',
-                                                '-framework', 'SystemConfiguration',
-                                                '-framework', 'Security',
-                                                #'-framework', 'AdSupport',
-                                                '-framework', 'MediaPlayer',
-                                                '-framework', 'AVFoundation',
-                                                '-framework', 'CoreMedia',
-                                                '-framework', 'CoreMotion',
-                                                '-framework', 'GameController',
-                              ])
+    elif (env["arch"] == "arm"):
+        env.Append(LINKFLAGS=['-arch', 'armv7', '-Wl,-dead_strip', '-miphoneos-version-min=9.0'])
+    if (env["arch"] == "arm64"):
+        env.Append(LINKFLAGS=['-arch', 'arm64', '-Wl,-dead_strip', '-miphoneos-version-min=9.0'])
 
+    env.Append(LINKFLAGS=['-isysroot', '$IPHONESDK',
+                          '-framework', 'AudioToolbox',
+                          '-framework', 'AVFoundation',
+                          '-framework', 'CoreAudio',
+                          '-framework', 'CoreGraphics',
+                          '-framework', 'CoreMedia',
+                          '-framework', 'CoreMotion',
+                          '-framework', 'Foundation',
+                          '-framework', 'GameController',
+                          '-framework', 'MediaPlayer',
+                          '-framework', 'OpenGLES',
+                          '-framework', 'QuartzCore',
+                          '-framework', 'Security',
+                          '-framework', 'SystemConfiguration',
+                          '-framework', 'UIKit',
+                          ])
+
+    # Feature options
     if env['game_center'] == 'yes':
         env.Append(CPPFLAGS=['-DGAME_CENTER_ENABLED'])
         env.Append(LINKFLAGS=['-framework', 'GameKit'])
@@ -145,45 +140,20 @@ def configure(env):
     if env['icloud'] == 'yes':
         env.Append(CPPFLAGS=['-DICLOUD_ENABLED'])
 
-    env.Append(CPPPATH=['$IPHONESDK/usr/include', '$IPHONESDK/System/Library/Frameworks/OpenGLES.framework/Headers', '$IPHONESDK/System/Library/Frameworks/AudioUnit.framework/Headers'])
+    env.Append(CPPPATH=['$IPHONESDK/usr/include',
+                        '$IPHONESDK/System/Library/Frameworks/OpenGLES.framework/Headers',
+                        '$IPHONESDK/System/Library/Frameworks/AudioUnit.framework/Headers',
+                        ])
 
-    if (env["target"].startswith("release")):
-
-        env.Append(CPPFLAGS=['-DNDEBUG', '-DNS_BLOCK_ASSERTIONS=1'])
-        env.Append(CPPFLAGS=['-O2', '-flto', '-ftree-vectorize', '-fomit-frame-pointer', '-ffast-math', '-funsafe-math-optimizations'])
-        env.Append(LINKFLAGS=['-O2', '-flto'])
-
-        if env["target"] == "release_debug":
-            env.Append(CPPFLAGS=['-DDEBUG_ENABLED'])
-
-    elif (env["target"] == "debug"):
-
-        env.Append(CPPFLAGS=['-D_DEBUG', '-DDEBUG=1', '-gdwarf-2', '-O0', '-DDEBUG_ENABLED'])
-        env.Append(CPPFLAGS=['-DDEBUG_MEMORY_ENABLED'])
-
-    if (env["ios_sim"] == "yes"):  # TODO: Check if needed?
-        env['ENV']['MACOSX_DEPLOYMENT_TARGET'] = '10.6'
     env['ENV']['CODESIGN_ALLOCATE'] = '/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/codesign_allocate'
+
+    env.Append(CPPPATH=['#platform/iphone'])
     env.Append(CPPFLAGS=['-DIPHONE_ENABLED', '-DUNIX_ENABLED', '-DGLES2_ENABLED', '-DMPC_FIXED_POINT'])
 
     # TODO: Move that to opus module's config
     if("module_opus_enabled" in env and env["module_opus_enabled"] != "no"):
         env.opus_fixed_point = "yes"
-        if env["arch"] == "x86":
-            pass
-        elif(env["arch"] == "arm64"):
-            env.Append(CFLAGS=["-DOPUS_ARM64_OPT"])
-        else:
+        if (env["arch"] == "arm"):
             env.Append(CFLAGS=["-DOPUS_ARM_OPT"])
-
-    if env['ios_exceptions'] == 'yes':
-        env.Append(CPPFLAGS=['-fexceptions'])
-    else:
-        env.Append(CPPFLAGS=['-fno-exceptions'])
-    # env['neon_enabled']=True
-    env['S_compiler'] = '$IPHONEPATH/Developer/usr/bin/gcc'
-
-    import methods
-    env.Append(BUILDERS={'GLSL120': env.Builder(action=methods.build_legacygl_headers, suffix='glsl.h', src_suffix='.glsl')})
-    env.Append(BUILDERS={'GLSL': env.Builder(action=methods.build_glsl_headers, suffix='glsl.h', src_suffix='.glsl')})
-    env.Append(BUILDERS={'GLSL120GLES': env.Builder(action=methods.build_gles2_headers, suffix='glsl.h', src_suffix='.glsl')})
+        elif (env["arch"] == "arm64"):
+            env.Append(CFLAGS=["-DOPUS_ARM64_OPT"])

--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -1,4 +1,3 @@
-
 import os
 import sys
 
@@ -13,17 +12,16 @@ def get_name():
 
 def can_build():
 
-    if (os.name != "posix"):
+    if (os.name != "posix" or sys.platform == "darwin"):
         return False
 
-    return True  # enabled
+    return True
 
 
 def get_opts():
 
     return [
-        ('use_llvm', 'Use llvm compiler', 'no'),
-        ('force_32_bits', 'Force 32 bits binary', 'no')
+        ('use_llvm', 'Use the LLVM compiler', 'no'),
     ]
 
 
@@ -35,45 +33,58 @@ def get_flags():
 
 def configure(env):
 
-    env.Append(CPPPATH=['#platform/server'])
-    if (env["use_llvm"] == "yes"):
-        env["CC"] = "clang"
-        env["CXX"] = "clang++"
-        env["LD"] = "clang++"
-
-    is64 = sys.maxsize > 2**32
-
-    if (env["bits"] == "default"):
-        if (is64):
-            env["bits"] = "64"
-        else:
-            env["bits"] = "32"
-
-    # if (env["tools"]=="no"):
-    #	#no tools suffix
-    #	env['OBJSUFFIX'] = ".nt"+env['OBJSUFFIX']
-    #	env['LIBSUFFIX'] = ".nt"+env['LIBSUFFIX']
+    ## Build type
 
     if (env["target"] == "release"):
-
         env.Append(CCFLAGS=['-O2', '-ffast-math', '-fomit-frame-pointer'])
 
     elif (env["target"] == "release_debug"):
-
         env.Append(CCFLAGS=['-O2', '-ffast-math', '-DDEBUG_ENABLED'])
 
     elif (env["target"] == "debug"):
-
         env.Append(CCFLAGS=['-g2', '-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
 
+    ## Architecture
 
-    # Shared libraries, when requested
+    is64 = sys.maxsize > 2**32
+    if (env["bits"] == "default"):
+        env["bits"] = "64" if is64 else "32"
+
+    ## Compiler configuration
+
+    if (env["use_llvm"] == "yes"):
+        if ('clang++' not in env['CXX']):
+            env["CC"] = "clang"
+            env["CXX"] = "clang++"
+            env["LD"] = "clang++"
+        env.Append(CPPFLAGS=['-DTYPED_METHOD_BIND'])
+        env.extra_suffix = ".llvm" + env.extra_suffix
+
+    ## Dependencies
+
+    # FIXME: Check for existence of the libs before parsing their flags with pkg-config
 
     if (env['builtin_openssl'] == 'no'):
+        # Currently not compatible with OpenSSL 1.1.0+
+        # https://github.com/godotengine/godot/issues/8624
+        import subprocess
+        openssl_version = subprocess.check_output(['pkg-config', 'openssl', '--modversion']).strip('\n')
+        if (openssl_version >= "1.1.0"):
+            print("Error: Found system-installed OpenSSL %s, currently only supporting version 1.0.x." % openssl_version)
+            print("Aborting.. You can compile with 'builtin_openssl=yes' to use the bundled version.\n")
+            sys.exit(255)
+
         env.ParseConfig('pkg-config openssl --cflags --libs')
 
     if (env['builtin_libwebp'] == 'no'):
         env.ParseConfig('pkg-config libwebp --cflags --libs')
+
+    # freetype depends on libpng and zlib, so bundling one of them while keeping others
+    # as shared libraries leads to weird issues
+    if (env['builtin_freetype'] == 'yes' or env['builtin_libpng'] == 'yes' or env['builtin_zlib'] == 'yes'):
+        env['builtin_freetype'] = 'yes'
+        env['builtin_libpng'] = 'yes'
+        env['builtin_zlib'] = 'yes'
 
     if (env['builtin_freetype'] == 'no'):
         env.ParseConfig('pkg-config freetype2 --cflags --libs')
@@ -109,11 +120,12 @@ def configure(env):
     if (env['builtin_libogg'] == 'no'):
         env.ParseConfig('pkg-config ogg --cflags --libs')
 
+    ## Flags
 
+    # Linkflags below this line should typically stay the last ones
+    if (env['builtin_zlib'] == 'no'):
+        env.ParseConfig('pkg-config zlib --cflags --libs')
+
+    env.Append(CPPPATH=['#platform/server'])
     env.Append(CPPFLAGS=['-DSERVER_ENABLED', '-DUNIX_ENABLED'])
-    env.Append(LIBS=['pthread', 'z'])  # TODO detect linux/BSD!
-
-    if (env["CXX"] == "clang++"):
-        env.Append(CPPFLAGS=['-DTYPED_METHOD_BIND'])
-        env["CC"] = "clang"
-        env["LD"] = "clang++"
+    env.Append(LIBS=['pthread'])

--- a/platform/uwp/detect.py
+++ b/platform/uwp/detect.py
@@ -1,8 +1,7 @@
-import os
-
-import sys
-import string
 import methods
+import os
+import string
+import sys
 
 
 def is_active():
@@ -26,7 +25,9 @@ def can_build():
 
 
 def get_opts():
-    return []
+
+    return [
+    ]
 
 
 def get_flags():
@@ -39,16 +40,36 @@ def get_flags():
 
 def configure(env):
 
-    if(env["bits"] != "default"):
-        print "Error: bits argument is disabled for MSVC"
-        print ("Bits argument is not supported for MSVC compilation. Architecture depends on the Native/Cross Compile Tools Prompt/Developer Console (or Visual Studio settings)"
-               + " that is being used to run SCons. As a consequence, bits argument is disabled. Run scons again without bits argument (example: scons p=uwp) and SCons will attempt to detect what MSVC compiler"
-               + " will be executed and inform you.")
+    if (env["bits"] != "default"):
+        print("Error: bits argument is disabled for MSVC")
+        print("""
+            Bits argument is not supported for MSVC compilation. Architecture depends on the Native/Cross Compile Tools Prompt/Developer Console
+            (or Visual Studio settings) that is being used to run SCons. As a consequence, bits argument is disabled. Run scons again without bits
+            argument (example: scons p=uwp) and SCons will attempt to detect what MSVC compiler will be executed and inform you.
+            """)
         sys.exit()
 
-    arch = ""
-    env['ENV'] = os.environ
+    ## Build type
 
+    if (env["target"] == "release"):
+        env.Append(CPPFLAGS=['/O2', '/GL'])
+        env.Append(CPPFLAGS=['/MD'])
+        env.Append(LINKFLAGS=['/SUBSYSTEM:WINDOWS', '/LTCG'])
+
+    elif (env["target"] == "release_debug"):
+        env.Append(CCFLAGS=['/O2', '/Zi', '/DDEBUG_ENABLED'])
+        env.Append(CPPFLAGS=['/MD'])
+        env.Append(LINKFLAGS=['/SUBSYSTEM:CONSOLE'])
+
+    elif (env["target"] == "debug"):
+        env.Append(CCFLAGS=['/Zi', '/DDEBUG_ENABLED', '/DDEBUG_MEMORY_ENABLED'])
+        env.Append(CPPFLAGS=['/MDd'])
+        env.Append(LINKFLAGS=['/SUBSYSTEM:CONSOLE'])
+        env.Append(LINKFLAGS=['/DEBUG'])
+
+    ## Compiler configuration
+
+    env['ENV'] = os.environ
     vc_base_path = os.environ['VCTOOLSINSTALLDIR'] if "VCTOOLSINSTALLDIR" in os.environ else os.environ['VCINSTALLDIR']
 
     # ANGLE
@@ -60,9 +81,12 @@ def configure(env):
     if os.path.isfile(str(os.getenv("ANGLE_SRC_PATH")) + "/winrt/10/src/angle.sln"):
         env["build_angle"] = True
 
+    ## Architecture
+
+    arch = ""
     if os.getenv('Platform') == "ARM":
 
-        print "Compiled program architecture will be an ARM executable. (forcing bits=32)."
+        print("Compiled program architecture will be an ARM executable. (forcing bits=32).")
 
         arch = "arm"
         env["bits"] = "32"
@@ -74,17 +98,16 @@ def configure(env):
         env.Append(LIBPATH=[angle_root + '/winrt/10/src/Release_ARM/lib'])
 
     else:
-
         compiler_version_str = methods.detect_visual_c_compiler_version(env['ENV'])
 
         if(compiler_version_str == "amd64" or compiler_version_str == "x86_amd64"):
             env["bits"] = "64"
-            print "Compiled program architecture will be a x64 executable (forcing bits=64)."
+            print("Compiled program architecture will be a x64 executable (forcing bits=64).")
         elif (compiler_version_str == "x86" or compiler_version_str == "amd64_x86"):
             env["bits"] = "32"
-            print "Compiled program architecture will be a x86 executable. (forcing bits=32)."
+            print("Compiled program architecture will be a x86 executable. (forcing bits=32).")
         else:
-            print "Failed to detect MSVC compiler architecture version... Defaulting to 32bit executable settings (forcing bits=32). Compilation attempt will continue, but SCons can not detect for what architecture this build is compiled for. You should check your settings/compilation setup."
+            print("Failed to detect MSVC compiler architecture version... Defaulting to 32bit executable settings (forcing bits=32). Compilation attempt will continue, but SCons can not detect for what architecture this build is compiled for. You should check your settings/compilation setup.")
             env["bits"] = "32"
 
         if (env["bits"] == "32"):
@@ -106,48 +129,30 @@ def configure(env):
             env.Append(LIBPATH=[os.environ['VCINSTALLDIR'] + 'lib/store/amd64'])
             env.Append(LIBPATH=[angle_root + '/winrt/10/src/Release_x64/lib'])
 
+    env["PROGSUFFIX"] = "." + arch + env["PROGSUFFIX"]
+    env["OBJSUFFIX"] = "." + arch + env["OBJSUFFIX"]
+    env["LIBSUFFIX"] = "." + arch + env["LIBSUFFIX"]
+
+    ## Compile flags
+
     env.Append(CPPPATH=['#platform/uwp', '#drivers/windows'])
-    env.Append(LINKFLAGS=['/MANIFEST:NO', '/NXCOMPAT', '/DYNAMICBASE', '/WINMD', '/APPCONTAINER', '/ERRORREPORT:PROMPT', '/NOLOGO', '/TLBID:1', '/NODEFAULTLIB:"kernel32.lib"', '/NODEFAULTLIB:"ole32.lib"'])
+    env.Append(CCFLAGS=['/DUWP_ENABLED', '/DWINDOWS_ENABLED', '/DTYPED_METHOD_BIND'])
+    env.Append(CCFLAGS=['/DGLES2_ENABLED', '/DGL_GLEXT_PROTOTYPES', '/DEGL_EGLEXT_PROTOTYPES', '/DANGLE_ENABLED'])
+    winver = "0x0602" # Windows 8 is the minimum target for UWP build
+    env.Append(CCFLAGS=['/DWINVER=%s' % winver, '/D_WIN32_WINNT=%s' % winver])
+
     env.Append(CPPFLAGS=['/D', '__WRL_NO_DEFAULT_LIB__', '/D', 'WIN32'])
-    
+
     env.Append(CPPFLAGS=['/AI', vc_base_path + 'lib/store/references'])
     env.Append(CPPFLAGS=['/AI', vc_base_path + 'lib/x86/store/references'])
-
-    if (env["target"] == "release"):
-
-        env.Append(CPPFLAGS=['/O2', '/GL'])
-        env.Append(CPPFLAGS=['/MD'])
-        env.Append(LINKFLAGS=['/SUBSYSTEM:WINDOWS', '/LTCG'])
-
-    elif (env["target"] == "release_debug"):
-
-        env.Append(CCFLAGS=['/O2', '/Zi', '/DDEBUG_ENABLED'])
-        env.Append(CPPFLAGS=['/MD'])
-        env.Append(LINKFLAGS=['/SUBSYSTEM:CONSOLE'])
-
-    elif (env["target"] == "debug"):
-
-        env.Append(CCFLAGS=['/Zi', '/DDEBUG_ENABLED', '/DDEBUG_MEMORY_ENABLED'])
-        env.Append(CPPFLAGS=['/MDd'])
-        env.Append(LINKFLAGS=['/SUBSYSTEM:CONSOLE'])
-        env.Append(LINKFLAGS=['/DEBUG'])
 
     env.Append(CCFLAGS=string.split('/FS /MP /GS /wd"4453" /wd"28204" /wd"4291" /Zc:wchar_t /Gm- /fp:precise /D "_UNICODE" /D "UNICODE" /D "WINAPI_FAMILY=WINAPI_FAMILY_APP" /errorReport:prompt /WX- /Zc:forScope /Gd /EHsc /nologo'))
     env.Append(CXXFLAGS=string.split('/ZW /FS'))
     env.Append(CCFLAGS=['/AI', vc_base_path + '\\vcpackages', '/AI', os.environ['WINDOWSSDKDIR'] + '\\References\\CommonConfiguration\\Neutral'])
 
-    env["PROGSUFFIX"] = "." + arch + env["PROGSUFFIX"]
-    env["OBJSUFFIX"] = "." + arch + env["OBJSUFFIX"]
-    env["LIBSUFFIX"] = "." + arch + env["LIBSUFFIX"]
+    ## Link flags
 
-    env.Append(CCFLAGS=['/DUWP_ENABLED'])
-    env.Append(CCFLAGS=['/DWINDOWS_ENABLED'])
-    env.Append(CCFLAGS=['/DTYPED_METHOD_BIND'])
-
-    env.Append(CCFLAGS=['/DGLES2_ENABLED', '/DGL_GLEXT_PROTOTYPES', '/DEGL_EGLEXT_PROTOTYPES', '/DANGLE_ENABLED'])
-
-    winver = "0x0602" # Windows 8 is the minimum target for UWP build
-    env.Append(CCFLAGS=['/DWINVER=%s' % winver, '/D_WIN32_WINNT=%s' % winver])
+    env.Append(LINKFLAGS=['/MANIFEST:NO', '/NXCOMPAT', '/DYNAMICBASE', '/WINMD', '/APPCONTAINER', '/ERRORREPORT:PROMPT', '/NOLOGO', '/TLBID:1', '/NODEFAULTLIB:"kernel32.lib"', '/NODEFAULTLIB:"ole32.lib"'])
 
     LIBS = [
         'WindowsApp',
@@ -164,8 +169,3 @@ def configure(env):
     env['BUILDERS']['Program'] = methods.precious_program
 
     env.Append(BUILDERS={'ANGLE': env.Builder(action=angle_build_cmd)})
-
-    env.Append(BUILDERS={'GLSL120': env.Builder(action=methods.build_legacygl_headers, suffix='glsl.h', src_suffix='.glsl')})
-    env.Append(BUILDERS={'GLSL': env.Builder(action=methods.build_glsl_headers, suffix='glsl.h', src_suffix='.glsl')})
-    env.Append(BUILDERS={'HLSL9': env.Builder(action=methods.build_hlsl_dx9_headers, suffix='hlsl.h', src_suffix='.hlsl')})
-    env.Append(BUILDERS={'GLSL120GLES': env.Builder(action=methods.build_gles2_headers, suffix='glsl.h', src_suffix='.glsl')})

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -1,103 +1,6 @@
-#
-#   tested on                   | Windows native    | Linux cross-compilation
-#   ----------------------------+-------------------+---------------------------
-#   Visual C++ Build Tools 2015 | WORKS             | n/a
-#   MSVS C++ 2010 Express       | WORKS             | n/a
-#   Mingw-w64                   | WORKS             | WORKS
-#   Mingw-w32                   | WORKS             | WORKS
-#   MinGW                       | WORKS             | untested
-#
-#####
-# Note about Visual C++ Build Tools :
-#
-#	- Visual C++ Build Tools is the standalone MSVC compiler :
-#		http://landinghub.visualstudio.com/visual-cpp-build-tools
-#
-#####
-# Notes about MSVS C++ :
-#
-# 	- MSVC2010-Express compiles to 32bits only.
-#
-#####
-# Notes about Mingw-w64 and Mingw-w32 under Windows :
-#
-#	- both can be installed using the official installer :
-#		http://mingw-w64.sourceforge.net/download.php#mingw-builds
-#
-#	- if you want to compile both 32bits and 64bits, don't forget to
-#	run the installer twice to install them both.
-#
-#	- install them into a path that does not contain spaces
-#		( example : "C:/Mingw-w32", "C:/Mingw-w64" )
-#
-#	- if you want to compile faster using the "-j" option, don't forget
-#	to install the appropriate version of the Pywin32 python extension
-#	available from : http://sourceforge.net/projects/pywin32/files/
-#
-#	- before running scons, you must add into the environment path
-#	the path to the "/bin" directory of the Mingw version you want
-#	to use :
-#
-#		set PATH=C:/Mingw-w32/bin;%PATH%
-#
-#	- then, scons should be able to detect gcc.
-#	- Mingw-w32 only compiles 32bits.
-#	- Mingw-w64 only compiles 64bits.
-#
-#	- it is possible to add them both at the same time into the PATH env,
-#	if you also define the MINGW32_PREFIX and MINGW64_PREFIX environment
-#	variables.
-#	For instance, you could store that set of commands into a .bat script
-#	that you would run just before scons :
-#
-#			set PATH=C:\mingw-w32\bin;%PATH%
-#			set PATH=C:\mingw-w64\bin;%PATH%
-#			set MINGW32_PREFIX=C:\mingw-w32\bin\
-#			set MINGW64_PREFIX=C:\mingw-w64\bin\
-#
-#####
-# Notes about Mingw, Mingw-w64 and Mingw-w32 under Linux :
-#
-#	- default toolchain prefixes are :
-#		"i586-mingw32msvc-" for MinGW
-#		"i686-w64-mingw32-"	for Mingw-w32
-#		"x86_64-w64-mingw32-" for Mingw-w64
-#
-#	- if both MinGW and Mingw-w32 are installed on your system
-#	Mingw-w32 should take the priority over MinGW.
-#
-#	- it is possible to manually override prefixes by defining
-#	the MINGW32_PREFIX and MINGW64_PREFIX environment variables.
-#
-#####
-# Notes about Mingw under Windows :
-#
-#	- this is the MinGW version from http://mingw.org/
-#	- install it into a path that does not contain spaces
-#		( example : "C:/MinGW" )
-#	- several DirectX headers might be missing. You can copy them into
-#	the C:/MinGW/include" directory from this page :
-#	 https://code.google.com/p/mingw-lib/source/browse/trunk/working/avcodec_to_widget_5/directx_include/
-#	- before running scons, add the path to the "/bin" directory :
-#		set PATH=C:/MinGW/bin;%PATH%
-#	- scons should be able to detect gcc.
-#
-
-#####
-# TODO :
-#
-#	- finish to cleanup this script to remove all the remains of previous hacks and workarounds
-#	- make it work with the Windows7 SDK that is supposed to enable 64bits compilation for MSVC2010-Express
-#	- confirm it works well with other Visual Studio versions.
-#	- update the wiki about the pywin32 extension required for the "-j" option under Windows.
-#	- update the wiki to document MINGW32_PREFIX and MINGW64_PREFIX
-#
-
-import os
-
-import sys
-
 import methods
+import os
+import sys
 
 
 def is_active():
@@ -115,7 +18,7 @@ def can_build():
         if (os.getenv("VCINSTALLDIR")):
             return True
         else:
-            print("\nMSVC not detected, attempting Mingw.")
+            print("\nMSVC not detected, attempting MinGW.")
             mingw32 = ""
             mingw64 = ""
             if (os.getenv("MINGW32_PREFIX")):
@@ -126,7 +29,7 @@ def can_build():
             test = "gcc --version > NUL 2>&1"
             if os.system(test) != 0 and os.system(mingw32 + test) != 0 and os.system(mingw64 + test) != 0:
                 print("- could not detect gcc.")
-                print("Please, make sure a path to a Mingw /bin directory is accessible into the environment PATH.\n")
+                print("Please, make sure a path to a MinGW /bin directory is accessible into the environment PATH.\n")
                 return False
             else:
                 print("- gcc detected.")
@@ -172,8 +75,8 @@ def get_opts():
         mingw64 = os.getenv("MINGW64_PREFIX")
 
     return [
-        ('mingw_prefix', 'Mingw Prefix', mingw32),
-        ('mingw_prefix_64', 'Mingw Prefix 64 bits', mingw64),
+        ('mingw_prefix', 'MinGW Prefix', mingw32),
+        ('mingw_prefix_64', 'MinGW Prefix 64 bits', mingw64),
     ]
 
 
@@ -211,55 +114,86 @@ def configure(env):
     # Targeted Windows version: Vista (and later)
     winver = "0x0600" # Windows Vista is the minimum target for windows builds
 
-    env['is_mingw'] = False
-    if (os.name == "nt" and os.getenv("VCINSTALLDIR")):
-        # build using visual studio
+    if (os.name == "nt" and os.getenv("VCINSTALLDIR")): # MSVC
+
         env['ENV']['TMP'] = os.environ['TMP']
-        env.Append(CPPPATH=['#platform/windows/include'])
-        env.Append(LIBPATH=['#platform/windows/lib'])
-        env.Append(CCFLAGS=['/DWINVER=%s' % winver, '/D_WIN32_WINNT=%s' % winver])
+
+        ## Build type
 
         if (env["target"] == "release"):
-
             env.Append(CCFLAGS=['/O2'])
             env.Append(LINKFLAGS=['/SUBSYSTEM:WINDOWS'])
             env.Append(LINKFLAGS=['/ENTRY:mainCRTStartup'])
 
         elif (env["target"] == "release_debug"):
-
             env.Append(CCFLAGS=['/O2', '/DDEBUG_ENABLED'])
             env.Append(LINKFLAGS=['/SUBSYSTEM:CONSOLE'])
-        elif (env["target"] == "debug_release"):
 
+        elif (env["target"] == "debug_release"):
             env.Append(CCFLAGS=['/Z7', '/Od'])
             env.Append(LINKFLAGS=['/DEBUG'])
             env.Append(LINKFLAGS=['/SUBSYSTEM:WINDOWS'])
             env.Append(LINKFLAGS=['/ENTRY:mainCRTStartup'])
 
         elif (env["target"] == "debug"):
-
             env.Append(CCFLAGS=['/Z7', '/DDEBUG_ENABLED', '/DDEBUG_MEMORY_ENABLED', '/DD3D_DEBUG_INFO', '/Od'])
             env.Append(LINKFLAGS=['/SUBSYSTEM:CONSOLE'])
             env.Append(LINKFLAGS=['/DEBUG'])
 
-	env.Append(CCFLAGS=['/MT', '/Gd', '/GR', '/nologo'])
+        ## Architecture
+
+        # Note: this detection/override code from here onward should be here instead of in SConstruct because it's platform and compiler specific (MSVC/Windows)
+        if (env["bits"] != "default"):
+            print("Error: bits argument is disabled for MSVC")
+            print("""
+                Bits argument is not supported for MSVC compilation. Architecture depends on the Native/Cross Compile Tools Prompt/Developer Console
+                (or Visual Studio settings) that is being used to run SCons. As a consequence, bits argument is disabled. Run scons again without bits
+                argument (example: scons p=windows) and SCons will attempt to detect what MSVC compiler will be executed and inform you.
+                """)
+            sys.exit()
+
+        # Forcing bits argument because MSVC does not have a flag to set this through SCons... it's different compilers (cl.exe's) called from the proper command prompt
+        # that decide the architecture that is build for. Scons can only detect the os.getenviron (because vsvarsall.bat sets a lot of stuff for cl.exe to work with)
+        env["bits"] = "32"
+        env["x86_libtheora_opt_vc"] = True
+
+        ## Compiler configuration
+
+        env['ENV'] = os.environ
+        # This detection function needs the tools env (that is env['ENV'], not SCons's env), and that is why it's this far bellow in the code
+        compiler_version_str = methods.detect_visual_c_compiler_version(env['ENV'])
+
+        print("Detected MSVC compiler: " + compiler_version_str)
+        # If building for 64bit architecture, disable assembly optimisations for 32 bit builds (theora as of writting)... vc compiler for 64bit can not compile _asm
+        if(compiler_version_str == "amd64" or compiler_version_str == "x86_amd64"):
+            env["bits"] = "64"
+            env["x86_libtheora_opt_vc"] = False
+            print("Compiled program architecture will be a 64 bit executable (forcing bits=64).")
+        elif (compiler_version_str == "x86" or compiler_version_str == "amd64_x86"):
+            print("Compiled program architecture will be a 32 bit executable. (forcing bits=32).")
+        else:
+            print("Failed to detect MSVC compiler architecture version... Defaulting to 32bit executable settings (forcing bits=32). Compilation attempt will continue, but SCons can not detect for what architecture this build is compiled for. You should check your settings/compilation setup.")
+
+        ## Compile flags
+
+        env.Append(CCFLAGS=['/MT', '/Gd', '/GR', '/nologo'])
         env.Append(CXXFLAGS=['/TP'])
         env.Append(CPPFLAGS=['/DMSVC', '/GR', ])
         env.Append(CCFLAGS=['/I' + os.getenv("WindowsSdkDir") + "/Include"])
-        env.Append(CCFLAGS=['/DWINDOWS_ENABLED'])
-        env.Append(CCFLAGS=['/DRTAUDIO_ENABLED'])
-        env.Append(CCFLAGS=['/DWIN32'])
-        env.Append(CCFLAGS=['/DTYPED_METHOD_BIND'])
 
+        env.Append(CCFLAGS=['/DWINDOWS_ENABLED'])
         env.Append(CCFLAGS=['/DOPENGL_ENABLED'])
+        env.Append(CCFLAGS=['/DRTAUDIO_ENABLED'])
+        env.Append(CCFLAGS=['/DTYPED_METHOD_BIND'])
+        env.Append(CCFLAGS=['/DWIN32'])
+        env.Append(CCFLAGS=['/DWINVER=%s' % winver, '/D_WIN32_WINNT=%s' % winver])
+        if env["bits"] == "64":
+            env.Append(CCFLAGS=['/D_WIN64'])
+
         LIBS = ['winmm', 'opengl32', 'dsound', 'kernel32', 'ole32', 'oleaut32', 'user32', 'gdi32', 'IPHLPAPI', 'Shlwapi', 'wsock32', 'Ws2_32', 'shell32', 'advapi32', 'dinput8', 'dxguid']
         env.Append(LINKFLAGS=[p + env["LIBSUFFIX"] for p in LIBS])
 
         env.Append(LIBPATH=[os.getenv("WindowsSdkDir") + "/Lib"])
-        if (os.getenv("DXSDK_DIR")):
-            DIRECTX_PATH = os.getenv("DXSDK_DIR")
-        else:
-            DIRECTX_PATH = "C:/Program Files/Microsoft DirectX SDK (March 2009)"
 
         if (os.getenv("VCINSTALLDIR")):
             VC_PATH = os.getenv("VCINSTALLDIR")
@@ -268,51 +202,37 @@ def configure(env):
 
         env.Append(CCFLAGS=["/I" + p for p in os.getenv("INCLUDE").split(";")])
         env.Append(LIBPATH=[p for p in os.getenv("LIB").split(";")])
-        env.Append(CCFLAGS=["/I" + DIRECTX_PATH + "/Include"])
-        env.Append(LIBPATH=[DIRECTX_PATH + "/Lib/x86"])
-        env['ENV'] = os.environ
-
-        # This detection function needs the tools env (that is env['ENV'], not SCons's env), and that is why it's this far bellow in the code
-        compiler_version_str = methods.detect_visual_c_compiler_version(env['ENV'])
-
-        # Note: this detection/override code from here onward should be here instead of in SConstruct because it's platform and compiler specific (MSVC/Windows)
-        if(env["bits"] != "default"):
-            print "Error: bits argument is disabled for MSVC"
-            print ("Bits argument is not supported for MSVC compilation. Architecture depends on the Native/Cross Compile Tools Prompt/Developer Console (or Visual Studio settings)"
-                   + " that is being used to run SCons. As a consequence, bits argument is disabled. Run scons again without bits argument (example: scons p=windows) and SCons will attempt to detect what MSVC compiler"
-                   + " will be executed and inform you.")
-            sys.exit()
-
-        # Forcing bits argument because MSVC does not have a flag to set this through SCons... it's different compilers (cl.exe's) called from the proper command prompt
-        # that decide the architecture that is build for. Scons can only detect the os.getenviron (because vsvarsall.bat sets a lot of stuff for cl.exe to work with)
-        env["bits"] = "32"
-        env["x86_libtheora_opt_vc"] = True
-
-        print "Detected MSVC compiler: " + compiler_version_str
-        # If building for 64bit architecture, disable assembly optimisations for 32 bit builds (theora as of writting)... vc compiler for 64bit can not compile _asm
-        if(compiler_version_str == "amd64" or compiler_version_str == "x86_amd64"):
-            env["bits"] = "64"
-            env["x86_libtheora_opt_vc"] = False
-            print "Compiled program architecture will be a 64 bit executable (forcing bits=64)."
-        elif (compiler_version_str == "x86" or compiler_version_str == "amd64_x86"):
-            print "Compiled program architecture will be a 32 bit executable. (forcing bits=32)."
-        else:
-            print "Failed to detect MSVC compiler architecture version... Defaulting to 32bit executable settings (forcing bits=32). Compilation attempt will continue, but SCons can not detect for what architecture this build is compiled for. You should check your settings/compilation setup."
-        if env["bits"] == "64":
-            env.Append(CCFLAGS=['/D_WIN64'])
 
         # Incremental linking fix
         env['BUILDERS']['ProgramOriginal'] = env['BUILDERS']['Program']
         env['BUILDERS']['Program'] = methods.precious_program
 
-    else:
+    else: # MinGW
 
         # Workaround for MinGW. See:
         # http://www.scons.org/wiki/LongCmdLinesOnWin32
         env.use_windows_spawn_fix()
 
-        # build using mingw
-        env.Append(CCFLAGS=['-DWINVER=%s' % winver, '-D_WIN32_WINNT=%s' % winver])
+        ## Build type
+
+        if (env["target"] == "release"):
+            env.Append(CCFLAGS=['-msse2'])
+
+            if (env["bits"] == "64"):
+                env.Append(CCFLAGS=['-O3'])
+            else:
+                env.Append(CCFLAGS=['-O2'])
+
+            env.Append(LINKFLAGS=['-Wl,--subsystem,windows'])
+
+        elif (env["target"] == "release_debug"):
+            env.Append(CCFLAGS=['-O2', '-DDEBUG_ENABLED'])
+
+        elif (env["target"] == "debug"):
+            env.Append(CCFLAGS=['-g', '-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
+
+        ## Compiler configuration
+
         if (os.name == "nt"):
             env['ENV']['TMP'] = os.environ['TMP']  # way to go scons, you can be so stupid sometimes
         else:
@@ -339,30 +259,6 @@ def configure(env):
         else:
             nulstr = ">nul"
 
-        # if os.system(mingw_prefix+"gcc --version"+nulstr)!=0:
-            # #not really super consistent but..
-            # print("Can't find Windows compiler: "+mingw_prefix)
-            # sys.exit(255)
-
-        if (env["target"] == "release"):
-
-            env.Append(CCFLAGS=['-msse2'])
-
-            if (env["bits"] == "64"):
-                env.Append(CCFLAGS=['-O3'])
-            else:
-                env.Append(CCFLAGS=['-O2'])
-
-            env.Append(LINKFLAGS=['-Wl,--subsystem,windows'])
-
-        elif (env["target"] == "release_debug"):
-
-            env.Append(CCFLAGS=['-O2', '-DDEBUG_ENABLED'])
-
-        elif (env["target"] == "debug"):
-
-            env.Append(CCFLAGS=['-g', '-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
-
         env["CC"] = mingw_prefix + "gcc"
         env['AS'] = mingw_prefix + "as"
         env['CXX'] = mingw_prefix + "g++"
@@ -371,29 +267,15 @@ def configure(env):
         env['LD'] = mingw_prefix + "g++"
         env["x86_libtheora_opt_gcc"] = True
 
-        #env['CC'] = "winegcc"
-        #env['CXX'] = "wineg++"
+        ## Compile flags
 
         env.Append(CCFLAGS=['-DWINDOWS_ENABLED', '-mwindows'])
-        env.Append(CPPFLAGS=['-DRTAUDIO_ENABLED'])
         env.Append(CCFLAGS=['-DOPENGL_ENABLED'])
+        env.Append(CCFLAGS=['-DRTAUDIO_ENABLED'])
+        env.Append(CCFLAGS=['-DWINVER=%s' % winver, '-D_WIN32_WINNT=%s' % winver])
         env.Append(LIBS=['mingw32', 'opengl32', 'dsound', 'ole32', 'd3d9', 'winmm', 'gdi32', 'iphlpapi', 'shlwapi', 'wsock32', 'ws2_32', 'kernel32', 'oleaut32', 'dinput8', 'dxguid'])
 
-        # if (env["bits"]=="32"):
-        # env.Append(LIBS=['gcc_s'])
-        # #--with-arch=i686
-        # env.Append(CPPFLAGS=['-march=i686'])
-        # env.Append(LINKFLAGS=['-march=i686'])
-
-        #'d3dx9d'
         env.Append(CPPFLAGS=['-DMINGW_ENABLED'])
-        # env.Append(LINKFLAGS=['-g'])
 
         # resrc
-        env['is_mingw'] = True
         env.Append(BUILDERS={'RES': env.Builder(action=build_res_file, suffix='.o', src_suffix='.rc')})
-
-    env.Append(BUILDERS={'GLSL120': env.Builder(action=methods.build_legacygl_headers, suffix='glsl.h', src_suffix='.glsl')})
-    env.Append(BUILDERS={'GLSL': env.Builder(action=methods.build_glsl_headers, suffix='glsl.h', src_suffix='.glsl')})
-    env.Append(BUILDERS={'HLSL9': env.Builder(action=methods.build_hlsl_dx9_headers, suffix='hlsl.h', src_suffix='.hlsl')})
-    env.Append(BUILDERS={'GLSL120GLES': env.Builder(action=methods.build_gles2_headers, suffix='glsl.h', src_suffix='.glsl')})

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -1,7 +1,6 @@
-
 import os
-import sys
 import platform
+import sys
 
 
 def is_active():
@@ -14,26 +13,18 @@ def get_name():
 
 def can_build():
 
-    if (os.name != "posix"):
+    if (os.name != "posix" or sys.platform == "darwin"):
         return False
 
-    if sys.platform == "darwin":
-        return False  # no x11 on mac for now
-
-    errorval = os.system("pkg-config --version > /dev/null")
-
-    if (errorval):
+    # Check the minimal dependencies
+    x11_error = os.system("pkg-config --version > /dev/null")
+    if (x11_error):
         print("pkg-config not found.. x11 disabled.")
         return False
 
     x11_error = os.system("pkg-config x11 --modversion > /dev/null ")
     if (x11_error):
         print("X11 not found.. x11 disabled.")
-        return False
-
-    ssl_error = os.system("pkg-config openssl --modversion > /dev/null ")
-    if (ssl_error):
-        print("OpenSSL not found.. x11 disabled.")
         return False
 
     x11_error = os.system("pkg-config xcursor --modversion > /dev/null ")
@@ -51,18 +42,18 @@ def can_build():
         print("xrandr not found.. x11 disabled.")
         return False
 
-    return True  # X11 enabled
+    return True
 
 
 def get_opts():
 
     return [
-        ('use_llvm', 'Use llvm compiler', 'no'),
-        ('use_static_cpp', 'link stdc++ statically', 'no'),
-        ('use_sanitizer', 'Use llvm compiler sanitize address', 'no'),
-        ('use_leak_sanitizer', 'Use llvm compiler sanitize memory leaks', 'no'),
+        ('use_llvm', 'Use the LLVM compiler', 'no'),
+        ('use_static_cpp', 'Link stdc++ statically', 'no'),
+        ('use_sanitizer', 'Use LLVM compiler address sanitizer', 'no'),
+        ('use_leak_sanitizer', 'Use LLVM compiler memory leaks sanitizer (implies use_sanitizer)', 'no'),
         ('use_lto', 'Use link time optimization', 'no'),
-        ('pulseaudio', 'Detect & Use pulseaudio', 'yes'),
+        ('pulseaudio', 'Detect & use pulseaudio', 'yes'),
         ('udev', 'Use udev for gamepad connection callbacks', 'no'),
         ('debug_release', 'Add debug symbols to release version', 'no'),
     ]
@@ -80,45 +71,7 @@ def get_flags():
 
 def configure(env):
 
-    is64 = sys.maxsize > 2**32
-
-    if (env["bits"] == "default"):
-        if (is64):
-            env["bits"] = "64"
-        else:
-            env["bits"] = "32"
-
-    env.Append(CPPPATH=['#platform/x11'])
-    if (env["use_llvm"] == "yes"):
-        if 'clang++' not in env['CXX']:
-            env["CC"] = "clang"
-            env["CXX"] = "clang++"
-            env["LD"] = "clang++"
-        env.Append(CPPFLAGS=['-DTYPED_METHOD_BIND'])
-        env.extra_suffix = ".llvm"
-
-    if (env["use_sanitizer"] == "yes"):
-        env.Append(CCFLAGS=['-fsanitize=address', '-fno-omit-frame-pointer'])
-        env.Append(LINKFLAGS=['-fsanitize=address'])
-        env.extra_suffix += "s"
-
-    if (env["use_leak_sanitizer"] == "yes"):
-        env.Append(CCFLAGS=['-fsanitize=address', '-fno-omit-frame-pointer'])
-        env.Append(LINKFLAGS=['-fsanitize=address'])
-        env.extra_suffix += "s"
-
-    # if (env["tools"]=="no"):
-    #	#no tools suffix
-    #	env['OBJSUFFIX'] = ".nt"+env['OBJSUFFIX']
-    #	env['LIBSUFFIX'] = ".nt"+env['LIBSUFFIX']
-
-    if (env["use_lto"] == "yes"):
-        env.Append(CCFLAGS=['-flto'])
-        env.Append(LINKFLAGS=['-flto'])
-
-
-    env.Append(CCFLAGS=['-pipe'])
-    env.Append(LINKFLAGS=['-pipe'])
+    ## Build type
 
     if (env["target"] == "release"):
         env.Prepend(CCFLAGS=['-Ofast'])
@@ -126,19 +79,53 @@ def configure(env):
             env.Prepend(CCFLAGS=['-g2'])
 
     elif (env["target"] == "release_debug"):
-
         env.Prepend(CCFLAGS=['-O2', '-ffast-math', '-DDEBUG_ENABLED'])
         if (env["debug_release"] == "yes"):
             env.Prepend(CCFLAGS=['-g2'])
 
     elif (env["target"] == "debug"):
-
         env.Prepend(CCFLAGS=['-g2', '-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
 
+    ## Architecture
+
+    is64 = sys.maxsize > 2**32
+    if (env["bits"] == "default"):
+        env["bits"] = "64" if is64 else "32"
+
+    ## Compiler configuration
+
+    if (env["use_llvm"] == "yes"):
+        if ('clang++' not in env['CXX']):
+            env["CC"] = "clang"
+            env["CXX"] = "clang++"
+            env["LD"] = "clang++"
+        env.Append(CPPFLAGS=['-DTYPED_METHOD_BIND'])
+        env.extra_suffix = ".llvm" + env.extra_suffix
+
+    # leak sanitizer requires (address) sanitizer
+    if (env["use_sanitizer"] == "yes" or env["use_leak_sanitizer"] == "yes"):
+        env.Append(CCFLAGS=['-fsanitize=address', '-fno-omit-frame-pointer'])
+        env.Append(LINKFLAGS=['-fsanitize=address'])
+        env.extra_suffix += "s"
+        if (env["use_leak_sanitizer"] == "yes"):
+            env.Append(CCFLAGS=['-fsanitize=leak'])
+            env.Append(LINKFLAGS=['-fsanitize=leak'])
+
+    if (env["use_lto"] == "yes"):
+        env.Append(CCFLAGS=['-flto'])
+        env.Append(LINKFLAGS=['-flto'])
+
+    env.Append(CCFLAGS=['-pipe'])
+    env.Append(LINKFLAGS=['-pipe'])
+
+    ## Dependencies
+
     env.ParseConfig('pkg-config x11 --cflags --libs')
-    env.ParseConfig('pkg-config xinerama --cflags --libs')
     env.ParseConfig('pkg-config xcursor --cflags --libs')
+    env.ParseConfig('pkg-config xinerama --cflags --libs')
     env.ParseConfig('pkg-config xrandr --cflags --libs')
+
+    # FIXME: Check for existence of the libs before parsing their flags with pkg-config
 
     if (env['builtin_openssl'] == 'no'):
         # Currently not compatible with OpenSSL 1.1.0+
@@ -196,47 +183,51 @@ def configure(env):
     if (env['builtin_libogg'] == 'no'):
         env.ParseConfig('pkg-config ogg --cflags --libs')
 
-    env.Append(CPPFLAGS=['-DOPENGL_ENABLED'])
+    if (env['builtin_libtheora'] != 'no'):
+        list_of_x86 = ['x86_64', 'x86', 'i386', 'i586']
+        if any(platform.machine() in s for s in list_of_x86):
+            env["x86_libtheora_opt_gcc"] = True
 
-    if os.system("pkg-config --exists alsa") == 0:
+    ## Flags
+
+    if (os.system("pkg-config --exists alsa") == 0): # 0 means found
         print("Enabling ALSA")
         env.Append(CPPFLAGS=["-DALSA_ENABLED"])
         env.ParseConfig('pkg-config alsa --cflags --libs')
     else:
         print("ALSA libraries not found, disabling driver")
 
-    if (platform.system() == "Linux"):
-        env.Append(CPPFLAGS=["-DJOYDEV_ENABLED"])
-    if (env["udev"] == "yes"):
-        # pkg-config returns 0 when the lib exists...
-        found_udev = not os.system("pkg-config --exists libudev")
-
-        if (found_udev):
-            print("Enabling udev support")
-            env.Append(CPPFLAGS=["-DUDEV_ENABLED"])
-            env.ParseConfig('pkg-config libudev --cflags --libs')
-        else:
-            print("libudev development libraries not found, disabling udev support")
-
     if (env["pulseaudio"] == "yes"):
-        if not os.system("pkg-config --exists libpulse-simple"):
+        if (os.system("pkg-config --exists libpulse-simple") == 0): # 0 means found
             print("Enabling PulseAudio")
             env.Append(CPPFLAGS=["-DPULSEAUDIO_ENABLED"])
             env.ParseConfig('pkg-config --cflags --libs libpulse-simple')
         else:
             print("PulseAudio development libraries not found, disabling driver")
 
+    if (platform.system() == "Linux"):
+        env.Append(CPPFLAGS=["-DJOYDEV_ENABLED"])
+
+        if (env["udev"] == "yes"):
+            if (os.system("pkg-config --exists libudev") == 0): # 0 means found
+                print("Enabling udev support")
+                env.Append(CPPFLAGS=["-DUDEV_ENABLED"])
+                env.ParseConfig('pkg-config libudev --cflags --libs')
+            else:
+                print("libudev development libraries not found, disabling udev support")
+
+    # Linkflags below this line should typically stay the last ones
     if (env['builtin_zlib'] == 'no'):
         env.ParseConfig('pkg-config zlib --cflags --libs')
 
-    env.Append(CPPFLAGS=['-DX11_ENABLED', '-DUNIX_ENABLED', '-DGLES2_ENABLED', '-DGLES_OVER_GL'])
+    env.Append(CPPPATH=['#platform/x11'])
+    env.Append(CPPFLAGS=['-DX11_ENABLED', '-DUNIX_ENABLED', '-DOPENGL_ENABLED', '-DGLES2_ENABLED', '-DGLES_OVER_GL'])
     env.Append(LIBS=['GL', 'pthread'])
 
     if (platform.system() == "Linux"):
         env.Append(LIBS=['dl'])
-    # env.Append(CPPFLAGS=['-DMPC_FIXED_POINT'])
 
-    # host compiler is default..
+    ## Cross-compilation
 
     if (is64 and env["bits"] == "32"):
         env.Append(CPPFLAGS=['-m32'])
@@ -245,17 +236,5 @@ def configure(env):
         env.Append(CPPFLAGS=['-m64'])
         env.Append(LINKFLAGS=['-m64', '-L/usr/lib/i686-linux-gnu'])
 
-    import methods
-
-    # FIXME: Commented out when moving to gles3
-    #env.Append(BUILDERS={'GLSL120': env.Builder(action=methods.build_legacygl_headers, suffix='glsl.h', src_suffix='.glsl')})
-    #env.Append(BUILDERS={'GLSL': env.Builder(action=methods.build_glsl_headers, suffix='glsl.h', src_suffix='.glsl')})
-    #env.Append(BUILDERS={'GLSL120GLES': env.Builder(action=methods.build_gles2_headers, suffix='glsl.h', src_suffix='.glsl')})
-    #env.Append( BUILDERS = { 'HLSL9' : env.Builder(action = methods.build_hlsl_dx9_headers, suffix = 'hlsl.h',src_suffix = '.hlsl') } )
-
     if (env["use_static_cpp"] == "yes"):
         env.Append(LINKFLAGS=['-static-libstdc++'])
-
-    list_of_x86 = ['x86_64', 'x86', 'i386', 'i586']
-    if any(platform.machine() in s for s in list_of_x86):
-        env["x86_libtheora_opt_gcc"] = True


### PR DESCRIPTION
Tried to organize the configure(env) calls in sections, using the same order
for all platforms whenever possible.

Apart from cosmetic changes, the following issues were fixed:
- Android: cleanup linkage, remove GLESv1_CM and GLESv2
- iPhone: Remove obsolete "ios_gles22_override" option
- OSX:
  * Fix bits detection (default to 64) and remove obsolete "force_64_bits" option
    (closes #9449)
  * Make "fat" bits argument explicit
- Server: sync with X11
- Windows: clean up old DirectX 9 stuff
- X11:
  * Do not require system OpenSSL for building (closes #9443)
  * Fix typo'ed use_leak_sanitizer option
  * Fix .llvm suffix overriding custom extra_suffix

-----

### Testers needed for all platforms!

I'm pretty sure I messed up most of the platforms, so please test this PR for all the platforms you are used to building for, and check that no regression appeared. I'll fix them as you find them.

Tested:
- [x] Linux X11, GCC
- [x] Linux X11, Clang
- [x] Linux Server (only init, build fails due to #8361)
- [x] Windows, MSVC
- [ ] Windows, MinGW on Windows
- [x] Windows, MinGW on Linux
- [x] OSX, Clang
- [x] Android from Linux
- [ ] Android from Windows
- [ ] Android from macOS
- [x] iPhone ARM
- [x] iPhone simulator
- [ ] Javascript
- [x] UWP
- [ ] Haiku
- [ ] FreeBSD
- [ ] OpenBSD