### PR TITLE
Fixed syntax inconsistency in Vector3.snap and Vector3.snapped

### DIFF
--- a/core/math/quick_hull.cpp
+++ b/core/math/quick_hull.cpp
@@ -58,7 +58,7 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry::MeshData &r_me
 
 	for (int i = 0; i < p_points.size(); i++) {
 
-		Vector3 sp = p_points[i].snapped(0.0001);
+		Vector3 sp = p_points[i].snapped(Vector3(0.0001, 0.0001, 0.0001));
 		if (valid_cache.has(sp)) {
 			valid_points[i] = false;
 			//print_line("INVALIDATED: "+itos(i));

--- a/core/math/triangle_mesh.cpp
+++ b/core/math/triangle_mesh.cpp
@@ -117,7 +117,7 @@ void TriangleMesh::create(const PoolVector<Vector3> &p_faces) {
 			for (int j = 0; j < 3; j++) {
 
 				int vidx = -1;
-				Vector3 vs = v[j].snapped(0.0001);
+				Vector3 vs = v[j].snapped(Vector3(0.0001, 0.0001, 0.0001));
 				Map<Vector3, int>::Element *E = db.find(vs);
 				if (E) {
 					vidx = E->get();

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -61,13 +61,13 @@ int Vector3::max_axis() const {
 	return x < y ? (y < z ? 2 : 1) : (x < z ? 2 : 0);
 }
 
-void Vector3::snap(real_t p_val) {
+void Vector3::snap(Vector3 p_val) {
 
-	x = Math::stepify(x, p_val);
-	y = Math::stepify(y, p_val);
-	z = Math::stepify(z, p_val);
+	x = Math::stepify(x, p_val.x);
+	y = Math::stepify(y, p_val.y);
+	z = Math::stepify(z, p_val.z);
 }
-Vector3 Vector3::snapped(real_t p_val) const {
+Vector3 Vector3::snapped(Vector3 p_val) const {
 
 	Vector3 v = *this;
 	v.snap(p_val);

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -81,8 +81,8 @@ struct Vector3 {
 
 	_FORCE_INLINE_ void zero();
 
-	void snap(real_t p_val);
-	Vector3 snapped(real_t p_val) const;
+	void snap(Vector3 p_val);
+	Vector3 snapped(Vector3 p_val) const;
 
 	void rotate(const Vector3 &p_axis, real_t p_phi);
 	Vector3 rotated(const Vector3 &p_axis, real_t p_phi) const;

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -554,10 +554,10 @@ static void _generate_tangents_and_binormals(const PoolVector<int> &p_indices, c
 			tangent = Vector3();
 		} else {
 			tangent = Vector3((t2 * x1 - t1 * x2) * r, (t2 * y1 - t1 * y2) * r,
-							  (t2 * z1 - t1 * z2) * r)
+					(t2 * z1 - t1 * z2) * r)
 							  .normalized();
 			binormal = Vector3((s1 * x2 - s2 * x1) * r, (s1 * y2 - s2 * y1) * r,
-							   (s1 * z2 - s2 * z1) * r)
+					(s1 * z2 - s2 * z1) * r)
 							   .normalized();
 		}
 
@@ -867,7 +867,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ArrayMesh> &p_me
 					int normal_pos = (normal_src->stride ? normal_src->stride : 3) * p.indices[src + normal_ofs];
 					ERR_FAIL_INDEX_V(normal_pos, normal_src->array.size(), ERR_INVALID_DATA);
 					vertex.normal = Vector3(normal_src->array[normal_pos + 0], normal_src->array[normal_pos + 1], normal_src->array[normal_pos + 2]);
-					vertex.normal = vertex.normal.snapped(0.001);
+					vertex.normal.snap(Vector3(0.001, 0.001, 0.001));
 
 					if (tangent_src && binormal_src) {
 

--- a/editor/import/resource_importer_obj.cpp
+++ b/editor/import/resource_importer_obj.cpp
@@ -188,7 +188,7 @@ Error ResourceImporterOBJ::import(const String &p_source_file, const String &p_s
 
 					Vector3 vertex = vertices[vtx];
 					if (weld_vertices)
-						vertex = vertex.snapped(weld_tolerance);
+						vertex.snap(Vector3(weld_tolerance, weld_tolerance, weld_tolerance));
 					surf_tool->add_vertex(vertex);
 				}
 

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -594,7 +594,7 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
 
 			for (int i = 0; i < 3; i++) {
 
-				Vector3 v = f.vertex[i].snapped(0.01);
+				Vector3 v = f.vertex[i].snapped(Vector3(0.01, 0.01, 0.01));
 				if (!points.has(v)) {
 					points.insert(v);
 					center += v;

--- a/editor/plugins/path_editor_plugin.cpp
+++ b/editor/plugins/path_editor_plugin.cpp
@@ -104,7 +104,7 @@ void PathSpatialGizmo::set_handle(int p_idx, Camera *p_camera, const Point2 &p_p
 
 			if (SpatialEditor::get_singleton()->is_snap_enabled()) {
 				float snap = SpatialEditor::get_singleton()->get_translate_snap();
-				inters.snap(snap);
+				inters.snap(Vector3(snap, snap, snap));
 			}
 
 			Vector3 local = gi.xform(inters);

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -1180,7 +1180,7 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 						if (_edit.snap || spatial_editor->is_snap_enabled()) {
 
 							snap = spatial_editor->get_translate_snap();
-							motion.snap(snap);
+							motion.snap(Vector3(snap, snap, snap));
 						}
 
 						//set_message("Translating: "+motion);

--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -1279,8 +1279,8 @@ void RoomSpatialGizmo::redraw() {
 		for (int j = 0; j < 3; j++) {
 
 			_EdgeKey ek;
-			ek.from = r[i].vertex[j].snapped(CMP_EPSILON);
-			ek.to = r[i].vertex[(j + 1) % 3].snapped(CMP_EPSILON);
+			ek.from = r[i].vertex[j].snapped(Vector3(CMP_EPSILON, CMP_EPSILON, CMP_EPSILON));
+			ek.to = r[i].vertex[(j + 1) % 3].snapped(Vector3(CMP_EPSILON, CMP_EPSILON, CMP_EPSILON));
 			if (ek.from < ek.to)
 				SWAP(ek.from, ek.to);
 
@@ -2463,8 +2463,8 @@ void NavigationMeshSpatialGizmo::redraw() {
 
 				tw[tidx++] = f.vertex[j];
 				_EdgeKey ek;
-				ek.from = f.vertex[j].snapped(CMP_EPSILON);
-				ek.to = f.vertex[(j + 1) % 3].snapped(CMP_EPSILON);
+				ek.from = f.vertex[j].snapped(Vector3(CMP_EPSILON, CMP_EPSILON, CMP_EPSILON));
+				ek.to = f.vertex[(j + 1) % 3].snapped(Vector3(CMP_EPSILON, CMP_EPSILON, CMP_EPSILON));
 				if (ek.from < ek.to)
 					SWAP(ek.from, ek.to);
 

--- a/modules/gdnative/godot/godot_vector3.cpp
+++ b/modules/gdnative/godot/godot_vector3.cpp
@@ -90,11 +90,12 @@ godot_vector3 GDAPI godot_vector3_inverse(const godot_vector3 *p_self) {
 	return dest;
 }
 
-godot_vector3 GDAPI godot_vector3_snapped(const godot_vector3 *p_self, const godot_real p_by) {
+godot_vector3 GDAPI godot_vector3_snapped(const godot_vector3 *p_self, const godot_vector3 *p_by) {
 	godot_vector3 dest;
 	const Vector3 *self = (const Vector3 *)p_self;
+	const Vector3 *snap_axis = (const Vector3 *)p_by;
 
-	*((Vector3 *)&dest) = self->snapped(p_by);
+	*((Vector3 *)&dest) = self->snapped(*snap_axis);
 	return dest;
 }
 

--- a/modules/gdnative/godot/godot_vector3.h
+++ b/modules/gdnative/godot/godot_vector3.h
@@ -70,7 +70,7 @@ godot_vector3 GDAPI godot_vector3_normalized(const godot_vector3 *p_self);
 
 godot_vector3 GDAPI godot_vector3_inverse(const godot_vector3 *p_self);
 
-godot_vector3 GDAPI godot_vector3_snapped(const godot_vector3 *p_self, const godot_real p_by);
+godot_vector3 GDAPI godot_vector3_snapped(const godot_vector3 *p_self, const godot_vector3 *p_by);
 
 godot_vector3 GDAPI godot_vector3_rotated(const godot_vector3 *p_self, const godot_vector3 *p_axis, const godot_real p_phi);
 

--- a/scene/3d/navigation_mesh.cpp
+++ b/scene/3d/navigation_mesh.cpp
@@ -149,8 +149,8 @@ Ref<Mesh> NavigationMesh::get_debug_mesh() {
 
 				tw[tidx++] = f.vertex[j];
 				_EdgeKey ek;
-				ek.from = f.vertex[j].snapped(CMP_EPSILON);
-				ek.to = f.vertex[(j + 1) % 3].snapped(CMP_EPSILON);
+				ek.from = f.vertex[j].snapped(Vector3(CMP_EPSILON, CMP_EPSILON, CMP_EPSILON));
+				ek.to = f.vertex[(j + 1) % 3].snapped(Vector3(CMP_EPSILON, CMP_EPSILON, CMP_EPSILON));
 				if (ek.from < ek.to)
 					SWAP(ek.from, ek.to);
 


### PR DESCRIPTION
Changed Vector3.snap(real_t) to Vector3.snap(Vector3) and Vector3.snapped(real_t) to Vector3.snapped(Vector3).

Changed Vector3.snap/Vector3.snapped function calls to use the new syntax.

closes #9451