### PR TITLE
On OSX export to DMG and optionally code sign the app bundle

### DIFF
--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -41,6 +41,7 @@
 #include "platform/osx/logo.gen.h"
 #include "string.h"
 #include "version.h"
+#include <sys/stat.h>
 
 class EditorExportPlatformOSX : public EditorExportPlatform {
 
@@ -52,6 +53,10 @@ class EditorExportPlatformOSX : public EditorExportPlatform {
 
 	void _fix_plist(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &plist, const String &p_binary);
 	void _make_icon(const Ref<Image> &p_icon, Vector<uint8_t> &p_data);
+#ifdef OSX_ENABLED
+	Error _code_sign(const Ref<EditorExportPreset> &p_preset, const String &p_path);
+	Error _create_dmg(const String &p_dmg_path, const String &p_pkg_name, const String &p_app_path_name);
+#endif
 
 protected:
 	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features);
@@ -61,7 +66,11 @@ public:
 	virtual String get_name() const { return "Mac OSX"; }
 	virtual Ref<Texture> get_logo() const { return logo; }
 
+#ifdef OSX_ENABLED
+	virtual String get_binary_extension() const { return "dmg"; }
+#else
 	virtual String get_binary_extension() const { return "zip"; }
+#endif
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0);
 
 	virtual bool can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const;
@@ -90,6 +99,11 @@ void EditorExportPlatformOSX::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/copyright"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "application/bits_mode", PROPERTY_HINT_ENUM, "Fat (32 & 64 bits),64 bits,32 bits"), 0));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "display/high_res"), false));
+
+#ifdef OSX_ENABLED
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "codesign/identity"), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "codesign/entitlements"), ""));
+#endif
 }
 
 void EditorExportPlatformOSX::_make_icon(const Ref<Image> &p_icon, Vector<uint8_t> &p_data) {
@@ -177,21 +191,62 @@ void EditorExportPlatformOSX::_fix_plist(const Ref<EditorExportPreset> &p_preset
 	}
 }
 
+#ifdef OSX_ENABLED
+/**
+	If we're running the OSX version of the Godot editor we'll:
+	- export our application bundle to a temporary folder
+	- attempt to code sign it
+	- and then wrap it up in a DMG
+**/
+
+Error EditorExportPlatformOSX::_code_sign(const Ref<EditorExportPreset> &p_preset, const String &p_path) {
+	List<String> args;
+	if (p_preset->get("codesign/entitlements") != "") {
+		/* this should point to our entitlements.plist file that sandboxes our application, I don't know if this should also be placed in our app bundle */
+		args.push_back("-entitlements");
+		args.push_back(p_preset->get("codesign/entitlements"));
+	}
+	args.push_back("-s");
+	args.push_back(p_preset->get("codesign/identity"));
+	args.push_back("-v"); /* provide some more feedback */
+	args.push_back(p_path);
+	Error err = OS::get_singleton()->execute("/usr/bin/codesign", args, true);
+	ERR_FAIL_COND_V(err, err);
+
+	return OK;
+}
+
+Error EditorExportPlatformOSX::_create_dmg(const String &p_dmg_path, const String &p_pkg_name, const String &p_app_path_name) {
+	List<String> args;
+	args.push_back("create");
+	args.push_back(p_dmg_path);
+	args.push_back("-volname");
+	args.push_back(p_pkg_name);
+	args.push_back("-fs");
+	args.push_back("HFS+");
+	args.push_back("-srcfolder");
+	args.push_back(p_app_path_name);
+	Error err = OS::get_singleton()->execute("/usr/bin/hdiutil", args, true);
+	ERR_FAIL_COND_V(err, err);
+
+	return OK;
+}
+
 Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {
 
-	String src_pkg;
+	String src_pkg_name;
 
-	EditorProgress ep("export", "Exporting for OSX", 104);
+	EditorProgress ep("export", "Exporting for OSX", 3);
 
 	if (p_debug)
-		src_pkg = p_preset->get("custom_package/debug");
+		src_pkg_name = p_preset->get("custom_package/debug");
 	else
-		src_pkg = p_preset->get("custom_package/release");
+		src_pkg_name = p_preset->get("custom_package/release");
 
-	if (src_pkg == "") {
+	if (src_pkg_name == "") {
 		String err;
-		src_pkg = find_export_template("osx.zip", &err);
-		if (src_pkg == "") {
+		src_pkg_name = find_export_template("osx.zip", &err);
+		if (src_pkg_name == "") {
 			EditorNode::add_io_error(err);
 			return ERR_FILE_NOT_FOUND;
 		}
@@ -202,20 +257,15 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 
 	ep.step("Creating app", 0);
 
-	unzFile pkg = unzOpen2(src_pkg.utf8().get_data(), &io);
-	if (!pkg) {
+	unzFile src_pkg_zip = unzOpen2(src_pkg_name.utf8().get_data(), &io);
+	if (!src_pkg_zip) {
 
-		EditorNode::add_io_error("Could not find template app to export:\n" + src_pkg);
+		EditorNode::add_io_error("Could not find template app to export:\n" + src_pkg_name);
 		return ERR_FILE_NOT_FOUND;
 	}
 
-	ERR_FAIL_COND_V(!pkg, ERR_CANT_OPEN);
-	int ret = unzGoToFirstFile(pkg);
-
-	zlib_filefunc_def io2 = io;
-	FileAccess *dst_f = NULL;
-	io2.opaque = &dst_f;
-	zipFile dpkg = zipOpen2(p_path.utf8().get_data(), APPEND_STATUS_CREATE, NULL, &io2);
+	ERR_FAIL_COND_V(!src_pkg_zip, ERR_CANT_OPEN);
+	int ret = unzGoToFirstFile(src_pkg_zip);
 
 	String binary_to_use = "godot_osx_" + String(p_debug ? "debug" : "release") + ".";
 	int bits_mode = p_preset->get("application/bits_mode");
@@ -230,14 +280,34 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 	else
 		pkg_name = "Unnamed";
 
+	// We're on OSX so we can export to DMG, but first we create our application bundle
+	String tmp_app_path_name = p_path.get_base_dir() + "/" + pkg_name + ".app";
+	print_line("Exporting to " + tmp_app_path_name);
+	DirAccess *tmp_app_path = DirAccess::create_for_path(tmp_app_path_name);
+	ERR_FAIL_COND_V(!tmp_app_path, ERR_CANT_CREATE)
+
+	///@TODO We should delete the existing application bundle especially if we attempt to code sign it, but what is a safe way to do this? Maybe call system function so it moves to trash?
+	// tmp_app_path->erase_contents_recursive();
+
+	// Create our folder structure or rely on unzip?
+	print_line("Creating " + tmp_app_path_name + "/Contents/MacOS");
+	Error dir_err = tmp_app_path->make_dir_recursive(tmp_app_path_name + "/Contents/MacOS");
+	ERR_FAIL_COND_V(dir_err, ERR_CANT_CREATE)
+	print_line("Creating " + tmp_app_path_name + "/Contents/Resources");
+	dir_err = tmp_app_path->make_dir_recursive(tmp_app_path_name + "/Contents/Resources");
+	ERR_FAIL_COND_V(dir_err, ERR_CANT_CREATE)
+
+	/* Now process our template */
 	bool found_binary = false;
+	int total_size = 0;
 
 	while (ret == UNZ_OK) {
+		bool is_execute = false;
 
 		//get filename
 		unz_file_info info;
 		char fname[16384];
-		ret = unzGetCurrentFileInfo(pkg, &info, fname, 16384, NULL, 0, NULL, 0);
+		ret = unzGetCurrentFileInfo(src_pkg_zip, &info, fname, 16384, NULL, 0, NULL, 0);
 
 		String file = fname;
 
@@ -246,9 +316,9 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 		data.resize(info.uncompressed_size);
 
 		//read
-		unzOpenCurrentFile(pkg);
-		unzReadCurrentFile(pkg, data.ptr(), data.size());
-		unzCloseCurrentFile(pkg);
+		unzOpenCurrentFile(src_pkg_zip);
+		unzReadCurrentFile(src_pkg_zip, data.ptr(), data.size());
+		unzCloseCurrentFile(src_pkg_zip);
 
 		//write
 
@@ -261,7 +331,202 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 
 		if (file.begins_with("Contents/MacOS/godot_")) {
 			if (file != "Contents/MacOS/" + binary_to_use) {
-				ret = unzGoToNextFile(pkg);
+				ret = unzGoToNextFile(src_pkg_zip);
+				continue; //ignore!
+			}
+			found_binary = true;
+			is_execute = true;
+			file = "Contents/MacOS/" + pkg_name;
+		}
+
+		if (file == "Contents/Resources/icon.icns") {
+			//see if there is an icon
+			String iconpath;
+			if (p_preset->get("application/icon") != "")
+				iconpath = p_preset->get("application/icon");
+			else
+				iconpath = GlobalConfig::get_singleton()->get("application/icon");
+			print_line("icon? " + iconpath);
+			if (iconpath != "") {
+				Ref<Image> icon;
+				icon.instance();
+				icon->load(iconpath);
+				if (!icon->empty()) {
+					print_line("loaded?");
+					_make_icon(icon, data);
+				}
+			}
+			//bleh?
+		}
+
+		if (data.size() > 0) {
+			print_line("ADDING: " + file + " size: " + itos(data.size()));
+			total_size += data.size();
+
+			/* write it into our application bundle */
+			file = tmp_app_path_name + "/" + file;
+
+			/* write the file, need to add chmod */
+			FileAccess *f = FileAccess::open(file, FileAccess::WRITE);
+			ERR_FAIL_COND_V(!f, ERR_CANT_CREATE)
+			f->store_buffer(data.ptr(), data.size());
+			f->close();
+			memdelete(f);
+
+			if (is_execute) {
+				// we need execute rights on this file
+				chmod(file.utf8().get_data(), 0755);
+			} else {
+				// seems to already be set correctly
+				// chmod(file.utf8().get_data(), 0644);
+			}
+		}
+
+		ret = unzGoToNextFile(src_pkg_zip);
+	}
+
+	/* we're done with our source zip */
+	unzClose(src_pkg_zip);
+
+	if (!found_binary) {
+		ERR_PRINTS("Requested template binary '" + binary_to_use + "' not found. It might be missing from your template archive.");
+		unzClose(src_pkg_zip);
+		return ERR_FILE_NOT_FOUND;
+	}
+
+	ep.step("Making PKG", 1);
+
+	String pack_path = tmp_app_path_name + "/Contents/Resources/" + pkg_name + ".pck";
+	Error err = save_pack(p_preset, pack_path);
+	//	chmod(pack_path.utf8().get_data(), 0644);
+
+	if (err) {
+		return err;
+	}
+
+	/* see if we can code sign our new package */
+	if (p_preset->get("codesign/identity") != "") {
+		ep.step("Code signing bundle", 2);
+
+		/* the order in which we code sign is important, this is a bit of a shame or we could do this in our loop that extracts the files from our ZIP */
+
+		// start with our application
+		err = _code_sign(p_preset, tmp_app_path_name + "/Contents/MacOS/" + pkg_name);
+		ERR_FAIL_COND_V(err, err);
+
+		///@TODO we should check the contents of /Contents/Frameworks for frameworks to sign
+
+		// we should probably loop through all resources and sign them?
+		err = _code_sign(p_preset, tmp_app_path_name + "/Contents/Resources/icon.icns");
+		ERR_FAIL_COND_V(err, err);
+		err = _code_sign(p_preset, pack_path);
+		ERR_FAIL_COND_V(err, err);
+		err = _code_sign(p_preset, tmp_app_path_name + "/Contents/Info.plist");
+		ERR_FAIL_COND_V(err, err);
+	}
+
+	/* and finally create a DMG */
+	ep.step("Making DMG", 3);
+	err = _create_dmg(p_path, pkg_name, tmp_app_path_name);
+	ERR_FAIL_COND_V(err, err);
+
+	return OK;
+}
+
+#else
+
+/**
+	When exporting for OSX from any other platform we don't have access to code signing or creating DMGs so we'll wrap the bundle into a zip file.
+
+	Should probably find a nicer way to have just one export method instead of duplicating the method like this but I would the code got very 
+	messy with switches inside of it.
+**/
+Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {
+
+	String src_pkg_name;
+
+	EditorProgress ep("export", "Exporting for OSX", 104);
+
+	if (p_debug)
+		src_pkg_name = p_preset->get("custom_package/debug");
+	else
+		src_pkg_name = p_preset->get("custom_package/release");
+
+	if (src_pkg_name == "") {
+		String err;
+		src_pkg_name = find_export_template("osx.zip", &err);
+		if (src_pkg_name == "") {
+			EditorNode::add_io_error(err);
+			return ERR_FILE_NOT_FOUND;
+		}
+	}
+
+	FileAccess *src_f = NULL;
+	zlib_filefunc_def io = zipio_create_io_from_file(&src_f);
+
+	ep.step("Creating app", 0);
+
+	unzFile src_pkg_zip = unzOpen2(src_pkg_name.utf8().get_data(), &io);
+	if (!src_pkg_zip) {
+
+		EditorNode::add_io_error("Could not find template app to export:\n" + src_pkg_name);
+		return ERR_FILE_NOT_FOUND;
+	}
+
+	ERR_FAIL_COND_V(!src_pkg_zip, ERR_CANT_OPEN);
+	int ret = unzGoToFirstFile(src_pkg_zip);
+
+	String binary_to_use = "godot_osx_" + String(p_debug ? "debug" : "release") + ".";
+	int bits_mode = p_preset->get("application/bits_mode");
+	binary_to_use += String(bits_mode == 0 ? "fat" : bits_mode == 1 ? "64" : "32");
+
+	print_line("binary: " + binary_to_use);
+	String pkg_name;
+	if (p_preset->get("application/name") != "")
+		pkg_name = p_preset->get("application/name"); // app_name
+	else if (String(GlobalConfig::get_singleton()->get("application/name")) != "")
+		pkg_name = String(GlobalConfig::get_singleton()->get("application/name"));
+	else
+		pkg_name = "Unnamed";
+
+	/* Open our destination zip file */
+	zlib_filefunc_def io2 = io;
+	FileAccess *dst_f = NULL;
+	io2.opaque = &dst_f;
+	zipFile dst_pkg_zip = zipOpen2(p_path.utf8().get_data(), APPEND_STATUS_CREATE, NULL, &io2);
+
+	bool found_binary = false;
+
+	while (ret == UNZ_OK) {
+
+		//get filename
+		unz_file_info info;
+		char fname[16384];
+		ret = unzGetCurrentFileInfo(src_pkg_zip, &info, fname, 16384, NULL, 0, NULL, 0);
+
+		String file = fname;
+
+		print_line("READ: " + file);
+		Vector<uint8_t> data;
+		data.resize(info.uncompressed_size);
+
+		//read
+		unzOpenCurrentFile(src_pkg_zip);
+		unzReadCurrentFile(src_pkg_zip, data.ptr(), data.size());
+		unzCloseCurrentFile(src_pkg_zip);
+
+		//write
+
+		file = file.replace_first("osx_template.app/", "");
+
+		if (file == "Contents/Info.plist") {
+			print_line("parse plist");
+			_fix_plist(p_preset, data, pkg_name);
+		}
+
+		if (file.begins_with("Contents/MacOS/godot_")) {
+			if (file != "Contents/MacOS/" + binary_to_use) {
+				ret = unzGoToNextFile(src_pkg_zip);
 				continue; //ignore!
 			}
 			found_binary = true;
@@ -288,10 +553,11 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 			//bleh?
 		}
 
-		file = pkg_name + ".app/" + file;
-
 		if (data.size() > 0) {
 			print_line("ADDING: " + file + " size: " + itos(data.size()));
+
+			/* add it to our zip file */
+			file = pkg_name + ".app/" + file;
 
 			zip_fileinfo fi;
 			fi.tmz_date.tm_hour = info.tmu_date.tm_hour;
@@ -304,7 +570,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 			fi.internal_fa = info.internal_fa;
 			fi.external_fa = info.external_fa;
 
-			int err = zipOpenNewFileInZip(dpkg,
+			int err = zipOpenNewFileInZip(dst_pkg_zip,
 					file.utf8().get_data(),
 					&fi,
 					NULL,
@@ -316,37 +582,37 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 					Z_DEFAULT_COMPRESSION);
 
 			print_line("OPEN ERR: " + itos(err));
-			err = zipWriteInFileInZip(dpkg, data.ptr(), data.size());
+			err = zipWriteInFileInZip(dst_pkg_zip, data.ptr(), data.size());
 			print_line("WRITE ERR: " + itos(err));
-			zipCloseFileInZip(dpkg);
+			zipCloseFileInZip(dst_pkg_zip);
 		}
 
-		ret = unzGoToNextFile(pkg);
+		ret = unzGoToNextFile(src_pkg_zip);
 	}
 
 	if (!found_binary) {
 		ERR_PRINTS("Requested template binary '" + binary_to_use + "' not found. It might be missing from your template archive.");
-		zipClose(dpkg, NULL);
-		unzClose(pkg);
+		zipClose(dst_pkg_zip, NULL);
+		unzClose(src_pkg_zip);
 		return ERR_FILE_NOT_FOUND;
 	}
 
 	ep.step("Making PKG", 1);
 
-	String pack_path = EditorSettings::get_singleton()->get_settings_path() + "/tmp/data.pck";
+	String pack_path = EditorSettings::get_singleton()->get_settings_path() + "/tmp/" + pkg_name + ".pck";
 	Error err = save_pack(p_preset, pack_path);
 
 	if (err) {
-		zipClose(dpkg, NULL);
-		unzClose(pkg);
+		zipClose(dst_pkg_zip, NULL);
+		unzClose(src_pkg_zip);
 		return err;
 	}
 
 	{
 		//write datapack
 
-		zipOpenNewFileInZip(dpkg,
-				(pkg_name + ".app/Contents/Resources/data.pck").utf8().get_data(),
+		zipOpenNewFileInZip(dst_pkg_zip,
+				(pkg_name + ".app/Contents/Resources/" + pkg_name + ".pck").utf8().get_data(),
 				NULL,
 				NULL,
 				0,
@@ -366,17 +632,18 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 			int r = pf->get_buffer(buf, BSIZE);
 			if (r <= 0)
 				break;
-			zipWriteInFileInZip(dpkg, buf, r);
+			zipWriteInFileInZip(dst_pkg_zip, buf, r);
 		}
-		zipCloseFileInZip(dpkg);
+		zipCloseFileInZip(dst_pkg_zip);
 		memdelete(pf);
 	}
 
-	zipClose(dpkg, NULL);
-	unzClose(pkg);
+	zipClose(dst_pkg_zip, NULL);
+	unzClose(src_pkg_zip);
 
 	return OK;
 }
+#endif
 
 bool EditorExportPlatformOSX::can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const {
 


### PR DESCRIPTION
This is still somewhat experimental but I think its nearly complete.

When exporting your game for Mac OS X from anything but Mac OS X the logic works as with earlier versions of Godot. The app bundle is produced as a zip file. The problem with this is that this app bundle isn't code signed and when unzipping the application is marked as quarantined and won't run. Also the file permissions don't seem to be correct so you'll always end up making at least some changes.

When exporting your game for Mac OS X on a Mac the logic has now changed. The application bundle is optionally signed and then packed up in a DMG. The creation of the DMG is pretty straight forward and could use a few improvements such as adding a background image and adding a link to Applications so you can drag/drop your game. 

Code signing is the experimental bit because Apple is deliberately very unclear on manually code signing applications and what their exact requirements are.
https://developer.apple.com/library/content/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html#//apple_ref/doc/uid/TP40005929-CH4-SW2
They expect you to use XCode. I'll have to start work on some documentation because manually creating the certificates you need through developer.apple.com and knowing what to download can be tricky.
Also I have no exposure deploying on the App Store, what I've done should however works for providing applications outside of the App Store and may work if you want to deploy to App Store.

In the export window there are now two new fields under a section called CodeSign
![image](https://user-images.githubusercontent.com/1945449/27769492-fe27d454-5f6d-11e7-9594-3e297c173e72.png)
Identity should be set to the name of the certificate entry of your signing certificate as its stored in keychain. I'm using my 'Mac Developer' certificate in this screenshot which is fine for testing but you're supposed to use different ones for deploying.

The entitlements setting probably isn't implemented fully yet, this allows you to point to an entitlements.plist file that is used along with the signing process but what I do not know is if this entitlements file should also be bundled into your application bundle. The entitlements file lets OSX know what it can expect your application uses, does it open network connections, does it use the camera, etc, and sandbox the application. This is optional if you control the deployment of your app but mandatory if you deploy through the App Store if I understand correctly.

