### PR TITLE
Added annotations to GDScript

### DIFF
--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -92,17 +92,26 @@ bool GDParser:: _is_keyword() {
 			return false;
 	}
 }
+
 bool GDParser::_is_valid_annotation(bool is_block_mode) {
-	bool allow_keywords = false;
+	const bool allow_keywords = false;
+
+	AnnotationNode *annotation = alloc_node<AnnotationNode>();
 
 	if ((tokenizer->get_token(1) == GDTokenizer::TK_IDENTIFIER) || (allow_keywords && _is_keyword())) {
 		tokenizer->advance();
+
+		annotation->name = StringName(tokenizer->get_token_identifier()) ;
+
 		while ((tokenizer->get_token(1) == GDTokenizer::TK_CONSTANT)
 			|| (tokenizer->get_token(1) == GDTokenizer::TK_CONST_INF)
 			|| (tokenizer->get_token(1) == GDTokenizer::TK_CONST_NAN)
 			|| (tokenizer->get_token(1) == GDTokenizer::TK_CONST_PI)
 			|| (tokenizer->get_token(1) == GDTokenizer::TK_IDENTIFIER)
-			|| (tokenizer->get_token(1) == GDTokenizer::TK_BUILT_IN_TYPE)) tokenizer->advance();
+			|| (tokenizer->get_token(1) == GDTokenizer::TK_BUILT_IN_TYPE)) {
+
+			tokenizer->advance();
+		}
 
 		if ((tokenizer->get_token(1) == GDTokenizer::TK_NEWLINE) || (tokenizer->get_token() == GDTokenizer::TK_EOF)) {
 			if (is_block_mode) {

--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -50,6 +50,86 @@ T *GDParser::alloc_node() {
 	return t;
 }
 
+
+bool GDParser:: _is_keyword() {
+	switch (tokenizer->get_token()) {
+		case GDTokenizer::TK_CF_IF:
+		case GDTokenizer::TK_CF_ELIF:
+		case GDTokenizer::TK_CF_ELSE:
+		case GDTokenizer::TK_CF_FOR:
+		case GDTokenizer::TK_CF_DO:
+		case GDTokenizer::TK_CF_WHILE:
+		case GDTokenizer::TK_CF_SWITCH:
+		case GDTokenizer::TK_CF_CASE:
+		case GDTokenizer::TK_CF_BREAK:
+		case GDTokenizer::TK_CF_CONTINUE:
+		case GDTokenizer::TK_CF_PASS:
+		case GDTokenizer::TK_CF_RETURN:
+		case GDTokenizer::TK_CF_MATCH:
+		case GDTokenizer::TK_PR_FUNCTION:
+		case GDTokenizer::TK_PR_CLASS:
+		case GDTokenizer::TK_PR_EXTENDS:
+		case GDTokenizer::TK_PR_IS:
+		case GDTokenizer::TK_PR_ONREADY:
+		case GDTokenizer::TK_PR_TOOL:
+		case GDTokenizer::TK_PR_STATIC:
+		case GDTokenizer::TK_PR_EXPORT:
+		case GDTokenizer::TK_PR_SETGET:
+		case GDTokenizer::TK_PR_CONST:
+		case GDTokenizer::TK_PR_VAR:
+		case GDTokenizer::TK_PR_ENUM:
+		case GDTokenizer::TK_PR_PRELOAD:
+		case GDTokenizer::TK_PR_ASSERT:
+		case GDTokenizer::TK_PR_YIELD:
+		case GDTokenizer::TK_PR_SIGNAL:
+		case GDTokenizer::TK_PR_BREAKPOINT:
+		case GDTokenizer::TK_PR_REMOTE:
+		case GDTokenizer::TK_PR_SYNC:
+		case GDTokenizer::TK_PR_MASTER:
+		case GDTokenizer::TK_PR_SLAVE:
+			return true;
+		default:
+			return false;
+	}
+}
+bool GDParser::_is_valid_annotation(bool is_block_mode) {
+	bool allow_keywords = false;
+	//tokenizer->advance();
+
+	if ((tokenizer->get_token(1) == GDTokenizer::TK_IDENTIFIER) || (allow_keywords && _is_keyword())) {
+		tokenizer->advance();
+		while ((tokenizer->get_token(1) == GDTokenizer::TK_CONSTANT)
+			|| (tokenizer->get_token(1) == GDTokenizer::TK_CONST_INF)
+			|| (tokenizer->get_token(1) == GDTokenizer::TK_CONST_NAN)
+			|| (tokenizer->get_token(1) == GDTokenizer::TK_CONST_PI)
+			|| (tokenizer->get_token(1) == GDTokenizer::TK_IDENTIFIER)
+			|| (tokenizer->get_token(1) == GDTokenizer::TK_BUILT_IN_TYPE)) tokenizer->advance();
+
+		if ((tokenizer->get_token(1) == GDTokenizer::TK_NEWLINE) || (tokenizer->get_token() == GDTokenizer::TK_EOF)) {
+			if(is_block_mode) {
+				if(tokenizer->get_token(2) != GDTokenizer::TK_PR_VAR) {
+					_set_error("Invalid annotation: annotations can only be inserted before 'var' declaration.");
+					return false;
+				}
+			}
+			tokenizer->advance();
+			return true;
+		} else {
+			tokenizer->advance();
+			_set_error("Invalid annotation: only constants ir build in types can be used as parameters.");
+			return false;
+		}
+	} else {
+		tokenizer->advance();
+		if((!allow_keywords)  && _is_keyword()) {
+			_set_error("Invalid annotation: keywords are not allowed as annotation names.");
+		} else {
+			_set_error("Invalid annotation: expected identifier.");
+		}
+		return false;
+	}
+}
+
 bool GDParser::_end_statement() {
 
 	if (tokenizer->get_token() == GDTokenizer::TK_SEMICOLON) {
@@ -2325,6 +2405,11 @@ void GDParser::_parse_block(BlockNode *p_block, bool p_static) {
 				p_block->statements.push_back(nl);
 
 			} break;
+			case GDTokenizer::TK_ANNOTATION: {
+				if(!_is_valid_annotation(true)) {
+					return;
+				}
+			} break;
 			case GDTokenizer::TK_CF_PASS: {
 				if (tokenizer->get_token(1) != GDTokenizer::TK_SEMICOLON && tokenizer->get_token(1) != GDTokenizer::TK_NEWLINE && tokenizer->get_token(1) != GDTokenizer::TK_EOF) {
 
@@ -2967,6 +3052,9 @@ void GDParser::_parse_class(ClassNode *p_class) {
 					}
 					return;
 				}
+			} break;
+			case GDTokenizer::TK_ANNOTATION: {
+				_is_valid_annotation(false);
 			} break;
 			case GDTokenizer::TK_PR_EXTENDS: {
 

--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -94,7 +94,6 @@ bool GDParser:: _is_keyword() {
 }
 bool GDParser::_is_valid_annotation(bool is_block_mode) {
 	bool allow_keywords = false;
-	//tokenizer->advance();
 
 	if ((tokenizer->get_token(1) == GDTokenizer::TK_IDENTIFIER) || (allow_keywords && _is_keyword())) {
 		tokenizer->advance();
@@ -106,8 +105,8 @@ bool GDParser::_is_valid_annotation(bool is_block_mode) {
 			|| (tokenizer->get_token(1) == GDTokenizer::TK_BUILT_IN_TYPE)) tokenizer->advance();
 
 		if ((tokenizer->get_token(1) == GDTokenizer::TK_NEWLINE) || (tokenizer->get_token() == GDTokenizer::TK_EOF)) {
-			if(is_block_mode) {
-				if(tokenizer->get_token(2) != GDTokenizer::TK_PR_VAR) {
+			if (is_block_mode) {
+				if (tokenizer->get_token(2) != GDTokenizer::TK_PR_VAR) {
 					_set_error("Invalid annotation: annotations can only be inserted before 'var' declaration.");
 					return false;
 				}
@@ -121,7 +120,7 @@ bool GDParser::_is_valid_annotation(bool is_block_mode) {
 		}
 	} else {
 		tokenizer->advance();
-		if((!allow_keywords)  && _is_keyword()) {
+		if ((!allow_keywords) && _is_keyword()) {
 			_set_error("Invalid annotation: keywords are not allowed as annotation names.");
 		} else {
 			_set_error("Invalid annotation: expected identifier.");
@@ -2406,7 +2405,7 @@ void GDParser::_parse_block(BlockNode *p_block, bool p_static) {
 
 			} break;
 			case GDTokenizer::TK_ANNOTATION: {
-				if(!_is_valid_annotation(true)) {
+				if (!_is_valid_annotation(true)) {
 					return;
 				}
 			} break;

--- a/modules/gdscript/gd_parser.h
+++ b/modules/gdscript/gd_parser.h
@@ -67,6 +67,10 @@ public:
 		virtual ~Node() {}
 	};
 
+	struct AnnotationNode : public Node {
+		StringName name;
+	};
+
 	struct FunctionNode;
 	struct BlockNode;
 

--- a/modules/gdscript/gd_parser.h
+++ b/modules/gdscript/gd_parser.h
@@ -508,6 +508,8 @@ private:
 	void _parse_block(BlockNode *p_block, bool p_static);
 	void _parse_extends(ClassNode *p_class);
 	void _parse_class(ClassNode *p_class);
+	bool _is_keyword();
+	bool _is_valid_annotation(bool is_block_mode);
 	bool _end_statement();
 
 	Error _parse(const String &p_base_path);

--- a/modules/gdscript/gd_script.cpp
+++ b/modules/gdscript/gd_script.cpp
@@ -1424,6 +1424,10 @@ void GDScriptLanguage::add_global_constant(const StringName &p_variable, const V
 
 void GDScriptLanguage::init() {
 
+	GLOBAL_DEF("gdscript/annotation_processor", "");
+	PropertyInfo prop_info(Variant::STRING, "gdscript/annotation_processor", PROPERTY_HINT_FILE, "");
+	GlobalConfig::get_singleton()->set_custom_property_info("gdscript/annotation_processor", prop_info);
+
 	//populate global constants
 	int gcc = GlobalConstants::get_global_constant_count();
 	for (int i = 0; i < gcc; i++) {

--- a/modules/gdscript/gd_tokenizer.cpp
+++ b/modules/gdscript/gd_tokenizer.cpp
@@ -553,7 +553,7 @@ void GDTokenizerText::_advance() {
 				if (_is_text_char(GETCHAR(1))) {
 					_make_token(TK_ANNOTATION);
 					break;
-				}else if (CharType(GETCHAR(1)) != '"' && CharType(GETCHAR(1)) != '\'') {
+				} else if (CharType(GETCHAR(1)) != '"' && CharType(GETCHAR(1)) != '\'') {
 					_make_error("Unexpected '@'");
 				}
 				INCPOS(1);

--- a/modules/gdscript/gd_tokenizer.cpp
+++ b/modules/gdscript/gd_tokenizer.cpp
@@ -128,6 +128,7 @@ const char *GDTokenizer::token_names[TK_MAX] = {
 	"Error",
 	"EOF",
 	"Cursor"
+	"@"
 };
 
 const char *GDTokenizer::get_token_name(Token p_token) {
@@ -549,9 +550,11 @@ void GDTokenizerText::_advance() {
 				}
 			} break;
 			case '@':
-				if (CharType(GETCHAR(1)) != '"' && CharType(GETCHAR(1)) != '\'') {
+				if (_is_text_char(GETCHAR(1))) {
+					_make_token(TK_ANNOTATION);
+					break;
+				}else if (CharType(GETCHAR(1)) != '"' && CharType(GETCHAR(1)) != '\'') {
 					_make_error("Unexpected '@'");
-					return;
 				}
 				INCPOS(1);
 				is_node_path = true;

--- a/modules/gdscript/gd_tokenizer.h
+++ b/modules/gdscript/gd_tokenizer.h
@@ -134,7 +134,8 @@ public:
 		TK_ERROR,
 		TK_EOF,
 		TK_CURSOR, //used for code completion
-		TK_MAX
+		TK_MAX,
+		TK_ANNOTATION
 	};
 
 protected:


### PR DESCRIPTION
**Annotations for GDScript!**

Annotations can be used with the following syntax examples:

@annotation_name
@annotation_name optional_parameter_1 optional_parameter_n

* At mark (@) to start the annotation
* annotation_name: a valid GDScript identifer (keywords can be enable as
valid annotation name by setting allow_keywords to true)
* 0 or more parameters separated by spaces. Valid parameters are GDScript
constants, identifiers or build-in types.

**What are annotations used for?**

Annotations by themselves are pretty much useless. However it can be a
great way to provide meta information to external tools processing the
GDscript source files. The example bellow should be self explained for
possible uses of annotations in GDScript and external tools like doc
autogeneration.

**Example (GDScript code bellow):**

```
# Annotations can be used in the top level
@vendor "com.example"
@module "my_game_lib"
@package "hello"

@author "John Doe"
@description "An example class for GDScript annotations."
@description "Can have multiline descriptions."

extends Node

@private
@type string
var message = "hello, world!"

@private
@type Vector2
var values = Vector2(1, 2)

func _ready():
	example()

@public
@param int arg_value "Value added to the internal number"
@return_type void
@description "Prints a message and a number"
func example(arg_value):
	#Annotations can also be used in local variables (only)

	@type int
	var x = values.x

	@type int
	var y = values.y

	print(message)
	print(str(x + y + arg_value))

```