### PR TITLE
Fix visibility changes for Spatial

### DIFF
--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -547,10 +547,7 @@ void Spatial::show() {
 	if (!is_inside_tree())
 		return;
 
-	if (!data.parent || is_visible()) {
-
-		_propagate_visibility_changed();
-	}
+	_propagate_visibility_changed();
 }
 
 void Spatial::hide() {
@@ -558,14 +555,14 @@ void Spatial::hide() {
 	if (!data.visible)
 		return;
 
-	bool was_visible = is_visible();
 	data.visible = false;
 
-	if (!data.parent || was_visible) {
+	if (!is_inside_tree())
+		return;
 
-		_propagate_visibility_changed();
-	}
+	_propagate_visibility_changed();
 }
+
 bool Spatial::is_visible() const {
 
 	const Spatial *s = this;


### PR DESCRIPTION
Demonstate bug
![spatial](https://user-images.githubusercontent.com/8281454/27771122-7d127dae-5f83-11e7-9708-f56ba13065e4.gif)

This PR makes `Spatial::show()` & `hide()` use same logic with `CanvasItem::show()` & `hide()`