### PR TITLE
Implemented borderless fullscreen code on OSX.

### DIFF
--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -117,6 +117,8 @@ public:
 			return 1.0;
 	}
 
+	void _update_window();
+
 	float display_scale;
 
 protected:


### PR DESCRIPTION
With this PR it's possible to implement a "borderless fullscreen window" mode on OSX.

The following GDscript code would trigger this:
`OS.set_borderless_window(true)`
`OS.set_window_size(OS.get_screen_size())`
`OS.set_window_position(Vector2(0, 0))`

This mode can then be easily switched off with:
`OS.set_borderless_window(false)`