### PR TITLE
Fixed ResourceSaver::save not working with GDScript EditorPlugin

### DIFF
--- a/core/reference.h
+++ b/core/reference.h
@@ -151,20 +151,10 @@ public:
 		return refptr;
 	};
 
-#if 0
-	// go to RefPtr
-	operator RefPtr() const {
-
-		return get_ref_ptr();
-	}
-#endif
-
-#if 1
 	operator Variant() const {
 
 		return Variant(get_ref_ptr());
 	}
-#endif
 
 	void operator=(const Ref &p_from) {
 

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -2270,12 +2270,19 @@ Variant::Variant(const RID &p_rid) {
 	memnew_placement(_data._mem, RID(p_rid));
 }
 
-Variant::Variant(const Object *p_object) {
+Variant::Variant(Object *p_object) {
 
 	type = OBJECT;
 
 	memnew_placement(_data._mem, ObjData);
 	_get_obj().obj = const_cast<Object *>(p_object);
+
+	Reference *r;
+	if (p_object && (r = p_object->cast_to<Reference>())
+		&& r->is_referenced()) {
+
+		_get_obj().ref = REF(r).get_ref_ptr();
+	}
 }
 
 Variant::Variant(const Dictionary &p_dictionary) {

--- a/core/variant.h
+++ b/core/variant.h
@@ -272,7 +272,7 @@ public:
 	Variant(const NodePath &p_path);
 	Variant(const RefPtr &p_resource);
 	Variant(const RID &p_rid);
-	Variant(const Object *p_object);
+	Variant(Object *p_object);
 	Variant(const Dictionary &p_dictionary);
 
 	Variant(const Array &p_array);


### PR DESCRIPTION
Since this is my first contribution in a public repository, please note that I don't completely understand how git works, so expect mistakes in that area. With that out of the way:

**Initial behavior:** Calls to `ResourceSaver::save(path, resource)` with an edited object from a GDScript editor plugin resulted in the resource being null when it arrived at the C++ function from GDScript.

**Issue:** The edited object was passed to editor plugins through the edit() function as a Variant, which was constructed by the Variant::Variant(Object*) constructor. However the constructor did not handle the case of the passed Object being a Reference, meaning that the variant was not considered to hold a Reference at that point (Nor a Resource, in the case of `ResourceSaver::save`) so I added a special case for that.

Also, I removed the (already commented out), `operator RefPtr()` in reference.h, which seems to have now been replaced by the more direct `operator Variant()`

**Fixes Issue:**#6603