### PR TITLE
Use the gravity constant to calculate weights

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -554,11 +554,12 @@ real_t RigidBody2D::get_inertia() const {
 
 void RigidBody2D::set_weight(real_t p_weight) {
 
-	set_mass(p_weight / 9.8);
+	set_mass(p_weight / real_t(GLOBAL_DEF("physics/2d/default_gravity", 98)) / 10);
 }
+
 real_t RigidBody2D::get_weight() const {
 
-	return mass * 9.8;
+	return mass * real_t(GLOBAL_DEF("physics/2d/default_gravity", 98)) / 10;
 }
 
 void RigidBody2D::set_friction(real_t p_friction) {

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -520,11 +520,11 @@ real_t RigidBody::get_mass() const {
 
 void RigidBody::set_weight(real_t p_weight) {
 
-	set_mass(p_weight / 9.8);
+	set_mass(p_weight / real_t(GLOBAL_DEF("physics/3d/default_gravity", 9.8)));
 }
 real_t RigidBody::get_weight() const {
 
-	return mass * 9.8;
+	return mass * real_t(GLOBAL_DEF("physics/3d/default_gravity", 9.8));
 }
 
 void RigidBody::set_friction(real_t p_friction) {

--- a/scene/resources/world_2d.cpp
+++ b/scene/resources/world_2d.cpp
@@ -32,7 +32,6 @@
 #include "servers/visual_server.h"
 //#include "servers/spatial_sound_2d_server.h"
 #include "global_config.h"
-#include "global_config.h"
 #include "scene/2d/camera_2d.h"
 #include "scene/2d/visibility_notifier_2d.h"
 #include "scene/main/viewport.h"


### PR DESCRIPTION
Fixes #9150.
The issue was indeed also present in 3D.
Notice how in 2D the constant is multiplied by 10 and is an integer whereas in 3D it  isn't scaled and is a float. It seems a bit weird to me but I left it as is.