### PR TITLE
ability to reposition scene tabs with drag & drop

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4436,6 +4436,11 @@ void EditorNode::_scene_tab_input(const Ref<InputEvent> &p_input) {
 	}
 }
 
+void EditorNode::_reposition_active_tab(int idx_to) {
+	editor_data.move_edited_scene_to_index(idx_to);
+	_update_scene_tabs();
+}
+
 void EditorNode::_thumbnail_done(const String &p_path, const Ref<Texture> &p_preview, const Variant &p_udata) {
 	int p_tab = p_udata.operator signed int();
 	if (p_preview.is_valid()) {
@@ -5025,6 +5030,7 @@ void EditorNode::_bind_methods() {
 	ClassDB::bind_method("_scene_tab_hover", &EditorNode::_scene_tab_hover);
 	ClassDB::bind_method("_scene_tab_exit", &EditorNode::_scene_tab_exit);
 	ClassDB::bind_method("_scene_tab_input", &EditorNode::_scene_tab_input);
+	ClassDB::bind_method("_reposition_active_tab", &EditorNode::_reposition_active_tab);
 	ClassDB::bind_method("_thumbnail_done", &EditorNode::_thumbnail_done);
 	ClassDB::bind_method("_scene_tab_script_edited", &EditorNode::_scene_tab_script_edited);
 	ClassDB::bind_method("_set_main_scene_state", &EditorNode::_set_main_scene_state);
@@ -5399,6 +5405,7 @@ EditorNode::EditorNode() {
 	scene_tabs->connect("tab_hover", this, "_scene_tab_hover");
 	scene_tabs->connect("mouse_exited", this, "_scene_tab_exit");
 	scene_tabs->connect("gui_input", this, "_scene_tab_input");
+	scene_tabs->connect("reposition_active_tab_request", this, "_reposition_active_tab");
 
 	HBoxContainer *tabbar_container = memnew(HBoxContainer);
 	scene_tabs->set_h_size_flags(Control::SIZE_EXPAND_FILL);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -572,6 +572,7 @@ private:
 	void _scene_tab_hover(int p_tab);
 	void _scene_tab_exit();
 	void _scene_tab_input(const Ref<InputEvent> &p_input);
+	void _reposition_active_tab(int idx_to);
 	void _thumbnail_done(const String &p_path, const Ref<Texture> &p_preview, const Variant &p_udata);
 	void _scene_tab_script_edited(int p_tab);
 

--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -593,6 +593,41 @@ void Tabs::remove_tab(int p_idx) {
 	_ensure_no_over_offset();
 }
 
+Variant Tabs::get_drag_data(const Point2 &p_point) {
+
+	return get_tab_idx_at_point(p_point);
+}
+
+bool Tabs::can_drop_data(const Point2 &p_point, const Variant &p_data) const {
+
+	return get_tab_idx_at_point(p_point) > -1;
+}
+
+void Tabs::drop_data(const Point2 &p_point, const Variant &p_data) {
+
+	int hover_now = get_tab_idx_at_point(p_point);
+
+	ERR_FAIL_INDEX(hover_now, tabs.size());
+	emit_signal("reposition_active_tab_request", hover_now);
+}
+
+int Tabs::get_tab_idx_at_point(const Point2 &p_point) const {
+
+	int hover_now = -1;
+	for (int i = 0; i < tabs.size(); i++) {
+
+		if (i < offset)
+			continue;
+
+		Rect2 rect = get_tab_rect(i);
+		if (rect.has_point(p_point)) {
+			hover_now = i;
+		}
+	}
+
+	return hover_now;
+}
+
 void Tabs::set_tab_align(TabAlign p_align) {
 
 	tab_align = p_align;
@@ -708,7 +743,7 @@ void Tabs::ensure_tab_visible(int p_idx) {
 	}
 }
 
-Rect2 Tabs::get_tab_rect(int p_tab) {
+Rect2 Tabs::get_tab_rect(int p_tab) const {
 	return Rect2(tabs[p_tab].ofs_cache, 0, tabs[p_tab].size_cache, get_size().height);
 }
 
@@ -743,6 +778,7 @@ void Tabs::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("right_button_pressed", PropertyInfo(Variant::INT, "tab")));
 	ADD_SIGNAL(MethodInfo("tab_close", PropertyInfo(Variant::INT, "tab")));
 	ADD_SIGNAL(MethodInfo("tab_hover", PropertyInfo(Variant::INT, "tab")));
+	ADD_SIGNAL(MethodInfo("reposition_active_tab_request", PropertyInfo(Variant::INT, "idx_to")));
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "current_tab", PROPERTY_HINT_RANGE, "-1,4096,1", PROPERTY_USAGE_EDITOR), "set_current_tab", "get_current_tab");
 

--- a/scene/gui/tabs.h
+++ b/scene/gui/tabs.h
@@ -96,6 +96,11 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+	Variant get_drag_data(const Point2 &p_point);
+	bool can_drop_data(const Point2 &p_point, const Variant &p_data) const;
+	void drop_data(const Point2 &p_point, const Variant &p_data);
+	int get_tab_idx_at_point(const Point2 &p_point) const;
+
 public:
 	void add_tab(const String &p_str = "", const Ref<Texture> &p_icon = Ref<Texture>());
 
@@ -128,7 +133,7 @@ public:
 	void ensure_tab_visible(int p_idx);
 	void set_min_width(int p_width);
 
-	Rect2 get_tab_rect(int p_tab);
+	Rect2 get_tab_rect(int p_tab) const;
 	Size2 get_minimum_size() const;
 
 	Tabs();


### PR DESCRIPTION
In short I'm glad I have found `EditorData.move_edited_scene_to_index(idx);` 
![tab](https://user-images.githubusercontent.com/6129594/27867993-a2568dc0-619b-11e7-9c79-15a6540eeb5d.gif)


