### PR TITLE
Fix typo in plist export for OSX export

### DIFF
--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -185,8 +185,8 @@ void EditorExportPlatformOSX::_fix_plist(const Ref<EditorExportPreset> &p_preset
 	}
 
 	CharString cs = strnew.utf8();
-	plist.resize(cs.size());
-	for (int i = 9; i < cs.size(); i++) {
+	plist.resize(cs.size() - 1);
+	for (int i = 0; i < cs.size() - 1; i++) {
 		plist[i] = cs[i];
 	}
 }


### PR DESCRIPTION
Noticed this while doing the iPhone export, it exports the zero terminator and for some reason skipped the first 9 characters... Unless there was a good reason for this I'm guessing it shouldn't be doing this :)