### PR TITLE
Fix initial collision pairs being cleared (2.1)

### DIFF
--- a/servers/physics/physics_server_sw.cpp
+++ b/servers/physics/physics_server_sw.cpp
@@ -232,8 +232,6 @@ void PhysicsServerSW::area_set_space(RID p_area, RID p_space) {
 	if (area->get_space() == space)
 		return; //pointless
 
-	area->set_space(space);
-
 	for (Set<ConstraintSW *>::Element *E = area->get_constraints().front(); E; E = E->next()) {
 		RID self = E->get()->get_self();
 		if (!self.is_valid())
@@ -241,6 +239,8 @@ void PhysicsServerSW::area_set_space(RID p_area, RID p_space) {
 		free(self);
 	}
 	area->clear_constraints();
+
+	area->set_space(space);
 };
 
 RID PhysicsServerSW::area_get_space(RID p_area) const {
@@ -486,8 +486,6 @@ void PhysicsServerSW::body_set_space(RID p_body, RID p_space) {
 	if (body->get_space() == space)
 		return; //pointless
 
-	body->set_space(space);
-
 	for (Map<ConstraintSW *, int>::Element *E = body->get_constraint_map().front(); E; E = E->next()) {
 		RID self = E->key()->get_self();
 		if (!self.is_valid())
@@ -495,6 +493,8 @@ void PhysicsServerSW::body_set_space(RID p_body, RID p_space) {
 		free(self);
 	}
 	body->clear_constraint_map();
+
+	body->set_space(space);
 };
 
 RID PhysicsServerSW::body_get_space(RID p_body) const {

--- a/servers/physics_2d/physics_2d_server_sw.cpp
+++ b/servers/physics_2d/physics_2d_server_sw.cpp
@@ -296,8 +296,6 @@ void Physics2DServerSW::area_set_space(RID p_area, RID p_space) {
 	if (area->get_space() == space)
 		return; //pointless
 
-	area->set_space(space);
-
 	for (Set<Constraint2DSW *>::Element *E = area->get_constraints().front(); E; E = E->next()) {
 		RID self = E->get()->get_self();
 		if (!self.is_valid())
@@ -305,6 +303,8 @@ void Physics2DServerSW::area_set_space(RID p_area, RID p_space) {
 		free(self);
 	}
 	area->clear_constraints();
+
+	area->set_space(space);
 };
 
 RID Physics2DServerSW::area_get_space(RID p_area) const {
@@ -540,8 +540,6 @@ void Physics2DServerSW::body_set_space(RID p_body, RID p_space) {
 	if (body->get_space() == space)
 		return; //pointless
 
-	body->set_space(space);
-
 	for (Map<Constraint2DSW *, int>::Element *E = body->get_constraint_map().front(); E; E = E->next()) {
 		RID self = E->key()->get_self();
 		if (!self.is_valid())
@@ -549,6 +547,8 @@ void Physics2DServerSW::body_set_space(RID p_body, RID p_space) {
 		free(self);
 	}
 	body->clear_constraint_map();
+
+	body->set_space(space);
 };
 
 RID Physics2DServerSW::body_get_space(RID p_body) const {


### PR DESCRIPTION
This was affecting both 2D & 3D physics and was a regression introduced by my physics mega-fix (#8999).

Fixes #9387.

By the way, apologies for the bug and thank you for the patience as this was delaying the new release.