### PR TITLE
removed floor so that global pos works with scale in control

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1229,8 +1229,8 @@ void Control::_size_changed() {
 		}
 	}
 
-	Point2 new_pos_cache = Point2(margin_pos[0], margin_pos[1]).floor();
-	Size2 new_size_cache = Point2(margin_pos[2], margin_pos[3]).floor() - new_pos_cache;
+	Point2 new_pos_cache = Point2(margin_pos[0], margin_pos[1]);
+	Size2 new_size_cache = Point2(margin_pos[2], margin_pos[3]) - new_pos_cache;
 
 	Size2 minimum_size = get_combined_minimum_size();
 


### PR DESCRIPTION
I had two issues with controls when using set_scale and set/get_global_position

Scaling a control to Vector2(3,3) and then setting the global_position to Vector2(6020,6020)
returned (60018,6018) on get_global_position
see #9464

Second problem was adding a (Vector <= scale value) to the global_position the result was no change at all in global_pos

This sloves both issues.

probably closes #6540

Some code if someone wants to try it

```
extends Control


func _ready():
	$ViewportContainer.set_scale(Vector2(3,3))
	
	print("Old Control: " + str(get_global_position()))
	
	print("Old Viewport: " + str($ViewportContainer.get_global_position()))
	
	print("Old Texture: " + str($ViewportContainer/TextureRect.get_global_position()))
	
	$ViewportContainer/TextureRect.set_global_position(Vector2(6020,6020))
	
	print("New Texture: " + str($ViewportContainer/TextureRect.get_global_position()))
	
	print("New Viewport: " + str($ViewportContainer.get_global_position()))
	
	print("New Control: " + str(get_global_position()))
#	set_process(true)
	
	
#func _fixed_process(delta):
#	$ViewportContainer/TextureRect.set_global_position($ViewportContainer/TextureRect.get_global_position()+Vector2(2,0))
#	print("New Texture: " + str($ViewportContainer/TextureRect.get_global_position()))
```