### PR TITLE
Added a normalized offset parameter for all sprites

### DIFF
--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -394,6 +394,10 @@ void AnimatedSprite::_notification(int p_what) {
 			if (centered)
 				ofs -= s / 2;
 
+			if (anchor.x != 0 || anchor.y != 0) {
+				ofs += Point2(s.width * anchor.x, s.height * -anchor.y);
+			}
+
 			if (Engine::get_singleton()->get_use_pixel_snap()) {
 				ofs = ofs.floor();
 			}
@@ -488,6 +492,19 @@ void AnimatedSprite::set_offset(const Point2 &p_offset) {
 Point2 AnimatedSprite::get_offset() const {
 
 	return offset;
+}
+
+void AnimatedSprite::set_anchor(const Point2 &p_anchor) {
+
+	anchor = p_anchor;
+
+	update();
+	item_rect_changed();
+	_change_notify("anchor");
+}
+Point2 AnimatedSprite::get_anchor() const {
+
+	return anchor;
 }
 
 void AnimatedSprite::set_flip_h(bool p_flip) {
@@ -635,6 +652,9 @@ void AnimatedSprite::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_offset", "offset"), &AnimatedSprite::set_offset);
 	ClassDB::bind_method(D_METHOD("get_offset"), &AnimatedSprite::get_offset);
 
+	ClassDB::bind_method(D_METHOD("set_anchor", "anchor"), &AnimatedSprite::set_anchor);
+	ClassDB::bind_method(D_METHOD("get_anchor"), &AnimatedSprite::get_anchor);
+
 	ClassDB::bind_method(D_METHOD("set_flip_h", "flip_h"), &AnimatedSprite::set_flip_h);
 	ClassDB::bind_method(D_METHOD("is_flipped_h"), &AnimatedSprite::is_flipped_h);
 
@@ -655,6 +675,7 @@ void AnimatedSprite::_bind_methods() {
 	ADD_PROPERTYNZ(PropertyInfo(Variant::BOOL, "playing"), "_set_playing", "_is_playing");
 	ADD_PROPERTYNO(PropertyInfo(Variant::BOOL, "centered"), "set_centered", "is_centered");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::VECTOR2, "offset"), "set_offset", "get_offset");
+	ADD_PROPERTYNZ(PropertyInfo(Variant::VECTOR2, "anchor"), "set_anchor", "get_anchor");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::BOOL, "flip_h"), "set_flip_h", "is_flipped_h");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::BOOL, "flip_v"), "set_flip_v", "is_flipped_v");
 }

--- a/scene/2d/animated_sprite.h
+++ b/scene/2d/animated_sprite.h
@@ -131,6 +131,7 @@ class AnimatedSprite : public Node2D {
 
 	bool centered;
 	Point2 offset;
+	Point2 anchor;
 
 	float timeout;
 
@@ -171,6 +172,9 @@ public:
 
 	void set_offset(const Point2 &p_offset);
 	Point2 get_offset() const;
+
+	void set_anchor(const Point2 &p_anchor);
+	Point2 get_anchor() const;
 
 	void set_flip_h(bool p_flip);
 	bool is_flipped_h() const;

--- a/scene/2d/sprite.cpp
+++ b/scene/2d/sprite.cpp
@@ -84,6 +84,11 @@ void Sprite::_notification(int p_what) {
 			Point2 ofs = offset;
 			if (centered)
 				ofs -= s / 2;
+
+			if (anchor.x != 0 || anchor.y != 0) {
+				ofs += Point2(s.width * anchor.x, s.height * -anchor.y);
+			}
+
 			if (Engine::get_singleton()->get_use_pixel_snap()) {
 				ofs = ofs.floor();
 			}
@@ -162,6 +167,19 @@ void Sprite::set_offset(const Point2 &p_offset) {
 Point2 Sprite::get_offset() const {
 
 	return offset;
+}
+
+void Sprite::set_anchor(const Point2 &p_anchor) {
+
+	anchor = p_anchor;
+
+	update();
+	item_rect_changed();
+	_change_notify("anchor");
+}
+Point2 Sprite::get_anchor() const {
+
+	return anchor;
 }
 
 void Sprite::set_flip_h(bool p_flip) {
@@ -322,6 +340,9 @@ void Sprite::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_offset", "offset"), &Sprite::set_offset);
 	ClassDB::bind_method(D_METHOD("get_offset"), &Sprite::get_offset);
 
+	ClassDB::bind_method(D_METHOD("set_anchor", "anchor"), &Sprite::set_anchor);
+	ClassDB::bind_method(D_METHOD("get_anchor"), &Sprite::get_anchor);
+
 	ClassDB::bind_method(D_METHOD("set_flip_h", "flip_h"), &Sprite::set_flip_h);
 	ClassDB::bind_method(D_METHOD("is_flipped_h"), &Sprite::is_flipped_h);
 
@@ -354,6 +375,7 @@ void Sprite::_bind_methods() {
 	ADD_GROUP("Offset", "");
 	ADD_PROPERTYNO(PropertyInfo(Variant::BOOL, "centered"), "set_centered", "is_centered");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::VECTOR2, "offset"), "set_offset", "get_offset");
+	ADD_PROPERTYNZ(PropertyInfo(Variant::VECTOR2, "anchor"), "set_anchor", "get_anchor");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::BOOL, "flip_h"), "set_flip_h", "is_flipped_h");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::BOOL, "flip_v"), "set_flip_v", "is_flipped_v");
 	ADD_GROUP("Animation", "");

--- a/scene/2d/sprite.h
+++ b/scene/2d/sprite.h
@@ -42,6 +42,7 @@ class Sprite : public Node2D {
 
 	bool centered;
 	Point2 offset;
+	Point2 anchor;
 
 	bool hflip;
 	bool vflip;
@@ -77,6 +78,9 @@ public:
 
 	void set_offset(const Point2 &p_offset);
 	Point2 get_offset() const;
+
+	void set_anchor(const Point2 &p_anchor);
+	Point2 get_anchor() const;
 
 	void set_flip_h(bool p_flip);
 	bool is_flipped_h() const;

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -112,6 +112,15 @@ Point2 SpriteBase3D::get_offset() const {
 	return offset;
 }
 
+void SpriteBase3D::set_anchor(const Point2 &p_anchor) {
+	anchor = p_anchor;
+	anchor.x = CLAMP(anchor.x, -1, 1);
+	anchor.y = CLAMP(anchor.y, -1, 1);
+}
+Point2 SpriteBase3D::get_anchor() const {
+	return anchor;
+}
+
 void SpriteBase3D::set_flip_h(bool p_flip) {
 
 	hflip = p_flip;
@@ -233,6 +242,9 @@ void SpriteBase3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_offset", "offset"), &SpriteBase3D::set_offset);
 	ClassDB::bind_method(D_METHOD("get_offset"), &SpriteBase3D::get_offset);
 
+	ClassDB::bind_method(D_METHOD("set_anchor", "anchor"), &SpriteBase3D::set_anchor);
+	ClassDB::bind_method(D_METHOD("get_anchor"), &SpriteBase3D::get_anchor);
+
 	ClassDB::bind_method(D_METHOD("set_flip_h", "flip_h"), &SpriteBase3D::set_flip_h);
 	ClassDB::bind_method(D_METHOD("is_flipped_h"), &SpriteBase3D::is_flipped_h);
 
@@ -264,6 +276,8 @@ void SpriteBase3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "centered"), "set_centered", "is_centered");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "offset"), "set_offset", "get_offset");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_anchor"), "set_use_anchor", "get_use_anchor");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "anchor"), "set_anchor", "get_anchor");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_h"), "set_flip_h", "is_flipped_h");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_v"), "set_flip_v", "is_flipped_v");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "modulate"), "set_modulate", "get_modulate");
@@ -344,6 +358,10 @@ void Sprite3D::_draw() {
 	Point2i ofs = get_offset();
 	if (is_centered())
 		ofs -= s / 2;
+
+	if (anchor.x != 0 || anchor.y != 0) {
+		ofs += Point2(s.width * anchor.x, s.height * -anchor.y);
+	}
 
 	Rect2i dst_rect(ofs, s);
 
@@ -561,6 +579,9 @@ void Sprite3D::_validate_property(PropertyInfo &property) const {
 }
 
 void Sprite3D::_bind_methods() {
+
+	ClassDB::bind_method(D_METHOD("set_anchor", "anchor"), &Sprite3D::set_anchor);
+	ClassDB::bind_method(D_METHOD("get_anchor"), &Sprite3D::get_anchor);
 
 	ClassDB::bind_method(D_METHOD("set_texture", "texture:Texture"), &Sprite3D::set_texture);
 	ClassDB::bind_method(D_METHOD("get_texture:Texture"), &Sprite3D::get_texture);
@@ -847,6 +868,10 @@ void AnimatedSprite3D::_draw() {
 	Point2i ofs = get_offset();
 	if (is_centered())
 		ofs -= s / 2;
+
+	if (anchor.x != 0 || anchor.y != 0) {
+		ofs += Point2(s.width * anchor.x, s.height * -anchor.y);
+	}
 
 	Rect2i dst_rect(ofs, s);
 
@@ -1266,6 +1291,7 @@ void AnimatedSprite3D::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("frame_changed"));
 
 	ADD_PROPERTYNZ(PropertyInfo(Variant::OBJECT, "frames", PROPERTY_HINT_RESOURCE_TYPE, "SpriteFrames"), "set_sprite_frames", "get_sprite_frames");
+	ADD_PROPERTYNZ(PropertyInfo(Variant::VECTOR2, "anchor"), "set_anchor", "get_anchor");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "animation"), "set_animation", "get_animation");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::INT, "frame", PROPERTY_HINT_SPRITE_FRAME), "set_frame", "get_frame");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::BOOL, "playing"), "_set_playing", "_is_playing");

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -60,9 +60,6 @@ private:
 	List<SpriteBase3D *> children;
 	List<SpriteBase3D *>::Element *pI;
 
-	bool centered;
-	Point2 offset;
-
 	bool hflip;
 	bool vflip;
 
@@ -83,6 +80,11 @@ private:
 	void _propagate_color_changed();
 
 protected:
+	bool centered;
+	Point2 offset;
+	Point2 anchor;
+
+protected:
 	Color _get_color_accum();
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -97,6 +99,9 @@ public:
 
 	void set_offset(const Point2 &p_offset);
 	Point2 get_offset() const;
+
+	void set_anchor(const Point2 &p_anchor);
+	Point2 get_anchor() const;
 
 	void set_flip_h(bool p_flip);
 	bool is_flipped_h() const;


### PR DESCRIPTION
Added a normalized offset parameter for all sprites, including all of the 3D sprites, named "anchor".
Closes #9490

I'm not totally sure the code for Sprite3D and AnimatedSprite3D is working, because I wasn't able to make a visible Sprite3D or AnimatedSprite3D for testing. I think the code works, but someone should probably look it over just to be sure.

Another thing I'm not sure about is having a use_anchor property for Sprite2D andAnimatedSprite2D. I had to included it for Sprite3D, which makes me think I probably should include it in Sprite2D and AnimatedSprite2D. What do you guys think?