### PR TITLE
Improved parse_json() doc about numerical values conversion.

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -388,7 +388,8 @@
 			<argument index="0" name="json" type="String">
 			</argument>
 			<description>
-				Parse json text to a Variant (use [method typeof] to check if it is what you expect).
+				Parse JSON text to a Variant (use [method typeof] to check if it is what you expect).
+				Be aware that the JSON specification does not define integer or float types, but only a number type. Therefore, parsing a JSON text will convert every numerical values to [float] types.
 			</description>
 		</method>
 		<method name="pow">


### PR DESCRIPTION
Added information on how numerical values are converted to float in Dictionary.parse_json()

Following the conversation in the [#9499 issue](https://github.com/godotengine/godot/issues/9499)