### PR TITLE
Make more informations available for Tool Plugins about the editor

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -353,6 +353,7 @@ void EditorData::notify_edited_scene_changed() {
 	for (int i = 0; i < editor_plugins.size(); i++) {
 
 		editor_plugins[i]->edited_scene_changed();
+		editor_plugins[i]->notify_scene_changed(get_edited_scene_root());
 	}
 }
 
@@ -488,8 +489,14 @@ void EditorData::move_edited_scene_index(int p_idx, int p_to_idx) {
 }
 void EditorData::remove_scene(int p_idx) {
 	ERR_FAIL_INDEX(p_idx, edited_scene.size());
-	if (edited_scene[p_idx].root)
+	if (edited_scene[p_idx].root) {
+
+		for (int i = 0; i < editor_plugins.size(); i++) {
+			editor_plugins[i]->notify_scene_closed(edited_scene[p_idx].root->get_filename());
+		}
+
 		memdelete(edited_scene[p_idx].root);
+	}
 
 	if (current_edited_scene > p_idx)
 		current_edited_scene--;
@@ -613,6 +620,17 @@ void EditorData::set_edited_scene_root(Node *p_root) {
 int EditorData::get_edited_scene_count() const {
 
 	return edited_scene.size();
+}
+
+Vector<EditorData::EditedScene> EditorData::get_edited_scenes() const {
+
+	Vector<EditedScene> out_edited_scenes_list = Vector<EditedScene>();
+
+	for (int i = 0; i < edited_scene.size(); i++) {
+		out_edited_scenes_list.push_back(edited_scene[i]);
+	}
+
+	return out_edited_scenes_list;
 }
 
 void EditorData::set_edited_scene_version(uint64_t version, int scene_idx) {

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -31,6 +31,7 @@
 #define EDITOR_DATA_H
 
 #include "editor/editor_plugin.h"
+#include "editor/plugins/script_editor_plugin.h"
 #include "list.h"
 #include "pair.h"
 #include "scene/resources/texture.h"
@@ -109,6 +110,17 @@ public:
 		Ref<Texture> icon;
 	};
 
+	struct EditedScene {
+		Node *root;
+		Dictionary editor_states;
+		List<Node *> selection;
+		Vector<EditorHistory::History> history_stored;
+		int history_current;
+		Dictionary custom_state;
+		uint64_t version;
+		NodePath live_edit_root;
+	};
+
 private:
 	Vector<EditorPlugin *> editor_plugins;
 
@@ -123,17 +135,6 @@ private:
 	UndoRedo undo_redo;
 
 	void _cleanup_history();
-
-	struct EditedScene {
-		Node *root;
-		Dictionary editor_states;
-		List<Node *> selection;
-		Vector<EditorHistory::History> history_stored;
-		int history_current;
-		Dictionary custom_state;
-		uint64_t version;
-		NodePath live_edit_root;
-	};
 
 	Vector<EditedScene> edited_scene;
 	int current_edited_scene;
@@ -180,6 +181,7 @@ public:
 	int get_edited_scene() const;
 	Node *get_edited_scene_root(int p_idx = -1);
 	int get_edited_scene_count() const;
+	Vector<EditedScene> get_edited_scenes() const;
 	String get_scene_title(int p_idx) const;
 	String get_scene_path(int p_idx) const;
 	String get_scene_type(int p_idx) const;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1575,6 +1575,11 @@ void EditorNode::_edit_current() {
 
 				editor_plugin_screen->make_visible(true);
 
+				int plugin_count = editor_data.get_editor_plugin_count();
+				for (int i = 0; i < plugin_count; i++) {
+					editor_data.get_editor_plugin(i)->notify_main_screen_changed(editor_plugin_screen->get_name());
+				}
+
 				for (int i = 0; i < editor_table.size(); i++) {
 
 					main_editor_buttons[i]->set_pressed(editor_table[i] == main_plugin);
@@ -2865,6 +2870,11 @@ void EditorNode::_editor_select(int p_which) {
 	editor_plugin_screen->make_visible(true);
 	editor_plugin_screen->selected_notify();
 
+	int plugin_count = editor_data.get_editor_plugin_count();
+	for (int i = 0; i < plugin_count; i++) {
+		editor_data.get_editor_plugin(i)->notify_main_screen_changed(editor_plugin_screen->get_name());
+	}
+
 	if (EditorSettings::get_singleton()->get("interface/separate_distraction_mode")) {
 		if (p_which == EDITOR_SCRIPT) {
 			set_distraction_free_mode(script_distraction);
@@ -3756,6 +3766,7 @@ void EditorNode::register_editor_types() {
 	ClassDB::register_class<EditorResourcePreviewGenerator>();
 	ClassDB::register_class<EditorFileSystem>();
 	ClassDB::register_class<EditorFileSystemDirectory>();
+	ClassDB::register_virtual_class<ScriptEditor>();
 
 	//ClassDB::register_type<EditorImporter>();
 	//ClassDB::register_type<EditorPostImport>();

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -52,6 +52,8 @@ class EditorImportPlugin;
 class EditorExportPlugin;
 class EditorResourcePreview;
 class EditorFileSystem;
+class EditorToolAddons;
+class ScriptEditor;
 
 class EditorPlugin : public Node {
 
@@ -62,6 +64,8 @@ class EditorPlugin : public Node {
 	UndoRedo *_get_undo_redo() { return undo_redo; }
 
 	bool input_event_forwarding_always_enabled;
+
+	String last_main_screen_name;
 
 protected:
 	static void _bind_methods();
@@ -112,6 +116,14 @@ public:
 
 	void set_input_event_forwarding_always_enabled();
 	bool is_input_event_forwarding_always_enabled() { return input_event_forwarding_always_enabled; }
+
+	Node *get_edited_scene_root();
+	Array get_opened_scenes_list() const;
+	ScriptEditor *get_script_editor();
+
+	void notify_main_screen_changed(const String &screen_name);
+	void notify_scene_changed(const Node *scn_root);
+	void notify_scene_closed(const String &scene_filepath);
 
 	virtual Ref<SpatialEditorGizmo> create_spatial_gizmo(Spatial *p_spatial);
 	virtual bool forward_canvas_gui_input(const Transform2D &p_canvas_xform, const Ref<InputEvent> &p_event);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -321,6 +321,9 @@ class ScriptEditor : public VBoxContainer {
 	int file_dialog_option;
 	void _file_dialog_action(String p_file);
 
+	Ref<Script> _get_current_script();
+	Array _get_opened_script_list() const;
+
 	static void _open_script_request(const String &p_path);
 
 	static ScriptEditor *script_editor;
@@ -354,10 +357,14 @@ public:
 	void get_window_layout(Ref<ConfigFile> p_layout);
 
 	void set_scene_root_script(Ref<Script> p_script);
+	Vector<Ref<Script> > get_opened_scripts() const;
 
 	bool script_goto_method(Ref<Script> p_script, const String &p_method);
 
 	virtual void edited_scene_changed();
+
+	void notify_script_close(const Ref<Script> &p_script);
+	void notify_script_changed(const Ref<Script> &p_script);
 
 	void close_builtin_scripts_from_scene(const String &p_scene);
 


### PR DESCRIPTION
This PR will add new method to EditorPlugin called `get_editor_tool_addons()`.
This method will return an object which provides api to gain more informations about current state of the editor.

For start such signals are available:
`script_changed` `script_closed` `scene_changed` `scene_closed` `main_screen_changed`
_Each signal provides parameter with content._

And such methods:
`get_open_scenes_list` `get_open_scripts_list` `get_edited_scene_root`

Example usage:
```
tool
extends EditorPlugin

func _enter_tree():
	get_editor_tool_addons().connect("script_changed", self, "onScriptChanged"); 
	get_editor_tool_addons().connect("scene_changed", self, "onSceneChanged");
	get_editor_tool_addons().connect("main_screen_changed", self, "onMainScreenChanged");
	get_editor_tool_addons().connect("script_closed", self, "onScriptClosed");
	get_editor_tool_addons().connect("scene_closed", self,  "onSceneClosed");

func _exit_tree():
	get_editor_tool_addons().disconnect("script_changed", self, "onScriptChanged"); 
	get_editor_tool_addons().disconnect("scene_changed", self, "onSceneChanged");
	get_editor_tool_addons().disconnect("main_screen_changed", self, "onMainScreenChanged");
	get_editor_tool_addons().disconnect("script_closed", self, "onScriptClosed");
	get_editor_tool_addons().disconnect("scene_closed", self, "onSceneClosed");
	
func get_name():
	return "Plugin Addons Tester";

func has_main_screen():
	return false;

##################################################################################
#########                       Connected Signals                        #########
##################################################################################
func onScriptChanged(inScript):
	print("Signal: onScriptChanged: ", str(inScript.resource_path));

func onSceneChanged(inRootNode):
	print("Signal: onSceneChanged: ", str(inRootNode.get_filename()));

func onSceneClosed(inSceneFilepath):
	print("Signal: Scene closed: ", inSceneFilepath);

func onScriptClosed(inScript):
	print("Signal: Script is closed: ", str(inScript.resource_path));

func onMainScreenChanged(inNewScreenName):
	print("Signal: onMainScreenChanged: ", inNewScreenName);
	if(inNewScreenName == "3D"):
		print("Currently opened scripts: ", get_editor_tool_addons().get_open_scripts_list());
		print("Currently opened scenes: ", get_editor_tool_addons().get_open_scenes_list());
		print("Currently active scene: ", get_editor_tool_addons().get_edited_scene_root().get_filename());

```