### PR TITLE
EditorPlugin ability to open and reload scenes from scn filepath

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -13313,6 +13313,22 @@
 			<description>
 			</description>
 		</method>
+		<method name="open_scene_from_path">
+			<argument index="0" name="scene_filepath" type="String">
+			</argument>
+			</return>
+			<description>
+				Opens scene in editor. Do not use during plugin initialization. If you need, then use it together with [method Object.call_deferred].
+			</description>
+		</method>
+		<method name="reload_scene_from_path">
+			<argument index="0" name="scene_filepath" type="String">
+			</argument>
+			</return>
+			<description>
+				Reloads already loaded editor scene.
+			</description>
+		</method>
 		<method name="forward_canvas_gui_input" qualifiers="virtual">
 			<return type="bool">
 			</return>

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -80,6 +80,24 @@ void EditorPlugin::edit_resource(const Ref<Resource> &p_resource) {
 	EditorNode::get_singleton()->edit_resource(p_resource);
 }
 
+void EditorPlugin::open_scene_from_path(const String &scene_path) {
+
+	if (EditorNode::get_singleton()->is_changing_scene()) {
+		return;
+	}
+
+	EditorNode::get_singleton()->open_request(scene_path);
+}
+
+void EditorPlugin::reload_scene_from_path(const String &scene_path) {
+
+	if (EditorNode::get_singleton()->is_changing_scene()) {
+		return;
+	}
+
+	EditorNode::get_singleton()->reload_scene(scene_path);
+}
+
 void EditorPlugin::add_control_to_container(CustomControlContainer p_location, Control *p_control) {
 
 	switch (p_location) {
@@ -376,6 +394,8 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_editor_settings:EditorSettings"), &EditorPlugin::get_editor_settings);
 	ClassDB::bind_method(D_METHOD("queue_save_layout"), &EditorPlugin::queue_save_layout);
 	ClassDB::bind_method(D_METHOD("edit_resource"), &EditorPlugin::edit_resource);
+	ClassDB::bind_method(D_METHOD("open_scene_from_path", "scene_filepath"), &EditorPlugin::open_scene_from_path);
+	ClassDB::bind_method(D_METHOD("reload_scene_from_path", "scene_filepath"), &EditorPlugin::reload_scene_from_path);
 	ClassDB::bind_method(D_METHOD("add_import_plugin"), &EditorPlugin::add_import_plugin);
 	ClassDB::bind_method(D_METHOD("remove_import_plugin"), &EditorPlugin::remove_import_plugin);
 	ClassDB::bind_method(D_METHOD("set_input_event_forwarding_always_enabled"), &EditorPlugin::set_input_event_forwarding_always_enabled);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -103,6 +103,8 @@ public:
 	void remove_control_from_bottom_panel(Control *p_control);
 	Control *get_editor_viewport();
 	void edit_resource(const Ref<Resource> &p_resource);
+	void open_scene_from_path(const String &scene_path);
+	void reload_scene_from_path(const String &scene_path);
 
 	void add_tool_menu_item(const String &p_name, Object *p_handler, const String &p_callback, const Variant &p_ud = Variant());
 	void add_tool_submenu_item(const String &p_name, Object *p_submenu);


### PR DESCRIPTION
EditorPlugin has new method `open_scene_from_path(filepath)`. 
It's possible to open scene from filepath inside editor with this method.