### PR TITLE
Fixed issues with borderless windows on Windows

### DIFF
--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -133,6 +133,8 @@ class OS_Windows : public OS {
 	void _drag_event(int p_x, int p_y, int idx);
 	void _touch_event(bool p_pressed, int p_x, int p_y, int idx);
 
+	void _update_window_style(bool repaint = true);
+
 	// functions used by main to initialize/deintialize the OS
 protected:
 	virtual int get_video_driver_count() const;


### PR DESCRIPTION
Fixes setting / unsetting borderless windows on the run on windows (fixes #7186).
Also makes it possible to use a borderless fullscreen window using this GDscript:

```
OS.set_borderless_window(true)
OS.set_window_size(OS.get_screen_size())
OS.set_window_position(Vector2(0, 0))
```

And unsetting this mode with a simple:

`
OS.set_borderless_window(false)
`