### PR TITLE
Remove warnings about benign situations

### DIFF
--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -331,7 +331,10 @@ void Area2D::_clear_monitoring() {
 
 			Object *obj = ObjectDB::get_instance(E->key());
 			Node *node = obj ? obj->cast_to<Node>() : NULL;
-			ERR_CONTINUE(!node);
+
+			if (!node) //node may have been deleted in previous frame or at other legiminate point
+				continue;
+			//ERR_CONTINUE(!node);
 
 			node->disconnect(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree);
 			node->disconnect(SceneStringNames::get_singleton()->tree_exited, this, SceneStringNames::get_singleton()->_body_exit_tree);
@@ -359,7 +362,7 @@ void Area2D::_clear_monitoring() {
 			Object *obj = ObjectDB::get_instance(E->key());
 			Node *node = obj ? obj->cast_to<Node>() : NULL;
 
-			if (!node) //node may have been deleted in previous frame, this should not be an error
+			if (!node) //node may have been deleted in previous frame or at other legiminate point
 				continue;
 			//ERR_CONTINUE(!node);
 

--- a/scene/3d/area.cpp
+++ b/scene/3d/area.cpp
@@ -227,7 +227,11 @@ void Area::_clear_monitoring() {
 
 			Object *obj = ObjectDB::get_instance(E->key());
 			Node *node = obj ? obj->cast_to<Node>() : NULL;
-			ERR_CONTINUE(!node);
+
+			if (!node) //node may have been deleted in previous frame or at other legiminate point
+				continue;
+			//ERR_CONTINUE(!node);
+
 			if (!E->get().in_tree)
 				continue;
 
@@ -253,7 +257,11 @@ void Area::_clear_monitoring() {
 
 			Object *obj = ObjectDB::get_instance(E->key());
 			Node *node = obj ? obj->cast_to<Node>() : NULL;
-			ERR_CONTINUE(!node);
+
+			if (!node) //node may have been deleted in previous frame or at other legiminate point
+				continue;
+			//ERR_CONTINUE(!node);
+
 			if (!E->get().in_tree)
 				continue;
 


### PR DESCRIPTION
I've extended the change done on https://github.com/godotengine/godot/commit/1e65c3c7019be69526c71aa09175010ba4a8e09f to `Area2D`-to-`Area2D` monitoring to `Area2D`-`PhysicsBody2D` and their 3D counterparts.

@akien-mga, would it be better when I submit almost identical PRs for 2.1 and 3.0 to describe one as a (back)port of the other?