### PR TITLE
Rename Input::warp_mouse_pos() to set_mouse_position()

### DIFF
--- a/core/os/input.cpp
+++ b/core/os/input.cpp
@@ -80,7 +80,7 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_mouse_button_mask"), &Input::get_mouse_button_mask);
 	ClassDB::bind_method(D_METHOD("set_mouse_mode", "mode"), &Input::set_mouse_mode);
 	ClassDB::bind_method(D_METHOD("get_mouse_mode"), &Input::get_mouse_mode);
-	ClassDB::bind_method(D_METHOD("warp_mouse_pos", "to"), &Input::warp_mouse_pos);
+	ClassDB::bind_method(D_METHOD("set_mouse_position", "to"), &Input::set_mouse_position);
 	ClassDB::bind_method(D_METHOD("action_press", "action"), &Input::action_press);
 	ClassDB::bind_method(D_METHOD("action_release", "action"), &Input::action_release);
 	ClassDB::bind_method(D_METHOD("set_custom_mouse_cursor", "image:Texture", "hotspot"), &Input::set_custom_mouse_cursor, DEFVAL(Vector2()));

--- a/core/os/input.h
+++ b/core/os/input.h
@@ -81,7 +81,7 @@ public:
 	virtual Point2 get_last_mouse_speed() const = 0;
 	virtual int get_mouse_button_mask() const = 0;
 
-	virtual void warp_mouse_pos(const Vector2 &p_to) = 0;
+	virtual void set_mouse_position(const Vector2 &p_to) = 0;
 	virtual Point2i warp_mouse_motion(const Ref<InputEventMouseMotion> &p_motion, const Rect2 &p_rect) = 0;
 
 	virtual Vector3 get_gravity() const = 0;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -144,7 +144,7 @@ public:
 	virtual void set_mouse_mode(MouseMode p_mode);
 	virtual MouseMode get_mouse_mode() const;
 
-	virtual void warp_mouse_pos(const Point2 &p_to) {}
+	virtual void set_mouse_position(const Point2 &p_to) {}
 	virtual Point2 get_mouse_position() const = 0;
 	virtual int get_mouse_button_state() const = 0;
 	virtual void set_window_title(const String &p_title) = 0;

--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -471,9 +471,9 @@ int InputDefault::get_mouse_button_mask() const {
 	return mouse_button_mask; // do not trust OS implementaiton, should remove it - OS::get_singleton()->get_mouse_button_state();
 }
 
-void InputDefault::warp_mouse_pos(const Vector2 &p_to) {
+void InputDefault::set_mouse_position(const Vector2 &p_to) {
 
-	OS::get_singleton()->warp_mouse_pos(p_to);
+	OS::get_singleton()->set_mouse_position(p_to);
 }
 
 Point2i InputDefault::warp_mouse_motion(const Ref<InputEventMouseMotion> &p_motion, const Rect2 &p_rect) {
@@ -496,7 +496,7 @@ Point2i InputDefault::warp_mouse_motion(const Ref<InputEventMouseMotion> &p_moti
 	const Point2i pos_local = p_motion->get_global_position() - p_rect.position;
 	const Point2i pos_warped(Math::fposmod(pos_local.x, p_rect.size.x), Math::fposmod(pos_local.y, p_rect.size.y));
 	if (pos_warped != pos_local) {
-		OS::get_singleton()->warp_mouse_pos(pos_warped + p_rect.position);
+		OS::get_singleton()->set_mouse_position(pos_warped + p_rect.position);
 	}
 
 	return rel_warped;

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -200,7 +200,7 @@ public:
 	virtual Point2 get_last_mouse_speed() const;
 	virtual int get_mouse_button_mask() const;
 
-	virtual void warp_mouse_pos(const Vector2 &p_to);
+	virtual void set_mouse_position(const Vector2 &p_to);
 	virtual Point2i warp_mouse_motion(const Ref<InputEventMouseMotion> &p_motion, const Rect2 &p_rect);
 
 	virtual void parse_input_event(const Ref<InputEvent> &p_event);

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -145,7 +145,7 @@ public:
 	virtual void set_mouse_show(bool p_show);
 	virtual void set_mouse_grab(bool p_grab);
 	virtual bool is_mouse_grab_enabled() const;
-	virtual void warp_mouse_pos(const Point2 &p_to);
+	virtual void set_mouse_position(const Point2 &p_to);
 	virtual Point2 get_mouse_position() const;
 	virtual int get_mouse_button_state() const;
 	virtual void set_window_title(const String &p_title);

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1095,7 +1095,7 @@ bool OS_OSX::is_mouse_grab_enabled() const {
 	return mouse_grab;
 }
 
-void OS_OSX::warp_mouse_pos(const Point2 &p_to) {
+void OS_OSX::set_mouse_position(const Point2 &p_to) {
 
 	//copied from windows impl with osx native calls
 	if (mouse_mode == MOUSE_MODE_CAPTURED) {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1301,7 +1301,7 @@ OS_Windows::MouseMode OS_Windows::get_mouse_mode() const {
 	return mouse_mode;
 }
 
-void OS_Windows::warp_mouse_pos(const Point2 &p_to) {
+void OS_Windows::set_mouse_position(const Point2 &p_to) {
 
 	if (mouse_mode == MOUSE_MODE_CAPTURED) {
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -190,7 +190,7 @@ public:
 	void set_mouse_mode(MouseMode p_mode);
 	MouseMode get_mouse_mode() const;
 
-	virtual void warp_mouse_pos(const Point2 &p_to);
+	virtual void set_mouse_position(const Point2 &p_to);
 	virtual Point2 get_mouse_position() const;
 	virtual int get_mouse_button_state() const;
 	virtual void set_window_title(const String &p_title);

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -637,7 +637,7 @@ void OS_X11::set_mouse_mode(MouseMode p_mode) {
 	XFlush(x11_display);
 }
 
-void OS_X11::warp_mouse_pos(const Point2 &p_to) {
+void OS_X11::set_mouse_position(const Point2 &p_to) {
 
 	if (mouse_mode == MOUSE_MODE_CAPTURED) {
 

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -205,7 +205,7 @@ public:
 	void set_mouse_mode(MouseMode p_mode);
 	MouseMode get_mouse_mode() const;
 
-	virtual void warp_mouse_pos(const Point2 &p_to);
+	virtual void set_mouse_position(const Point2 &p_to);
 	virtual Point2 get_mouse_position() const;
 	virtual int get_mouse_button_state() const;
 	virtual void set_window_title(const String &p_title);

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2136,9 +2136,9 @@ Control *Control::get_focus_owner() const {
 	return get_viewport()->_gui_get_focus_owner();
 }
 
-void Control::warp_mouse(const Point2 &p_to_pos) {
+void Control::set_mouse_position(const Point2 &p_to_pos) {
 	ERR_FAIL_COND(!is_inside_tree());
-	get_viewport()->warp_mouse(get_global_transform().xform(p_to_pos));
+	get_viewport()->set_mouse_position(get_global_transform().xform(p_to_pos));
 }
 
 bool Control::is_text_field() const {
@@ -2412,7 +2412,7 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_drag_forwarding", "target:Control"), &Control::set_drag_forwarding);
 	ClassDB::bind_method(D_METHOD("set_drag_preview", "control:Control"), &Control::set_drag_preview);
 
-	ClassDB::bind_method(D_METHOD("warp_mouse", "to_pos"), &Control::warp_mouse);
+	ClassDB::bind_method(D_METHOD("set_mouse_position", "to_pos"), &Control::set_mouse_position);
 
 	ClassDB::bind_method(D_METHOD("minimum_size_changed"), &Control::minimum_size_changed);
 

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -383,7 +383,7 @@ public:
 
 	void grab_click_focus();
 
-	void warp_mouse(const Point2 &p_to_pos);
+	void set_mouse_position(const Point2 &p_to_pos);
 
 	virtual bool is_text_field() const;
 

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -147,7 +147,7 @@ void SpinBox::_gui_input(const Ref<InputEvent> &p_event) {
 		if (drag.enabled) {
 			drag.enabled = false;
 			Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
-			warp_mouse(drag.capture_pos);
+			set_mouse_position(drag.capture_pos);
 		}
 	}
 

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2403,7 +2403,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 
 						range_drag_enabled = false;
 						Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
-						warp_mouse(range_drag_capture_pos);
+						set_mouse_position(range_drag_capture_pos);
 					} else {
 						Rect2 rect = get_selected()->get_meta("__focus_rect");
 						if (rect.has_point(Point2(b->get_position().x, b->get_position().y))) {
@@ -2957,7 +2957,7 @@ void Tree::clear() {
 		if (range_drag_enabled) {
 			range_drag_enabled = false;
 			Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
-			warp_mouse(range_drag_capture_pos);
+			set_mouse_position(range_drag_capture_pos);
 		}
 		pressing_for_editor = false;
 	}

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1389,10 +1389,10 @@ Vector2 Viewport::get_mouse_position() const {
 	return (get_final_transform().affine_inverse() * _get_input_pre_xform()).xform(Input::get_singleton()->get_mouse_position() - _get_window_offset());
 }
 
-void Viewport::warp_mouse(const Vector2 &p_pos) {
+void Viewport::set_mouse_position(const Vector2 &p_pos) {
 
 	Vector2 gpos = (get_final_transform().affine_inverse() * _get_input_pre_xform()).affine_inverse().xform(p_pos);
-	Input::get_singleton()->warp_mouse_pos(gpos);
+	Input::get_singleton()->set_mouse_position(gpos);
 }
 
 void Viewport::_gui_sort_subwindows() {
@@ -2620,7 +2620,7 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_attach_to_screen_rect", "rect"), &Viewport::set_attach_to_screen_rect);
 
 	ClassDB::bind_method(D_METHOD("get_mouse_position"), &Viewport::get_mouse_position);
-	ClassDB::bind_method(D_METHOD("warp_mouse", "to_pos"), &Viewport::warp_mouse);
+	ClassDB::bind_method(D_METHOD("set_mouse_position", "to_pos"), &Viewport::set_mouse_position);
 
 	ClassDB::bind_method(D_METHOD("gui_has_modal_stack"), &Viewport::gui_has_modal_stack);
 	ClassDB::bind_method(D_METHOD("gui_get_drag_data:Variant"), &Viewport::gui_get_drag_data);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -429,7 +429,7 @@ public:
 	Rect2 get_attach_to_screen_rect() const;
 
 	Vector2 get_mouse_position() const;
-	void warp_mouse(const Vector2 &p_pos);
+	void set_mouse_position(const Vector2 &p_pos);
 
 	void set_physics_object_picking(bool p_enable);
 	bool get_physics_object_picking();


### PR DESCRIPTION
- `pos` -> `position` to meet the new naming conventions;
- `warp` -> `set` because `warp` can be confused with that from `warp_mouse_motion`, with a different meaning; also this name is clearer.

Also `Viewport:warp_mouse()` to `set_mouse_position()`; a bit more verbose but for coherency.