### PR TITLE
Fix picking list flood while mouse capture enabled

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2352,7 +2352,7 @@ void Viewport::unhandled_input(const Ref<InputEvent> &p_event) {
 
 	if (physics_object_picking && !get_tree()->input_handled) {
 
-		if (p_event->cast_to<InputEventMouseButton>() || p_event->cast_to<InputEventMouseMotion>() || p_event->cast_to<InputEventScreenDrag>() || p_event->cast_to<InputEventScreenTouch>()) {
+		if (Input::get_singleton()->get_mouse_mode() != Input::MOUSE_MODE_CAPTURED && (p_event->cast_to<InputEventMouseButton>() || p_event->cast_to<InputEventMouseMotion>() || p_event->cast_to<InputEventScreenDrag>() || p_event->cast_to<InputEventScreenTouch>())) {
 			physics_picking_events.push_back(p_event);
 		}
 	}


### PR DESCRIPTION
The events were being added to the physics picking list, taking memory and also they would be processed when the mouse capturing was disabled, with unpredictable results.

Fixes #9575.