### PR TITLE
[#7212] Fixed missing 'Variant' return values in documentation.

### DIFF
--- a/core/global_config.cpp
+++ b/core/global_config.cpp
@@ -835,7 +835,7 @@ void GlobalConfig::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_singleton", "name"), &GlobalConfig::get_singleton_object);
 	ClassDB::bind_method(D_METHOD("load_resource_pack", "pack"), &GlobalConfig::_load_resource_pack);
 	ClassDB::bind_method(D_METHOD("property_can_revert", "name"), &GlobalConfig::property_can_revert);
-	ClassDB::bind_method(D_METHOD("property_get_revert", "name"), &GlobalConfig::property_get_revert);
+	ClassDB::bind_method(D_METHOD("property_get_revert:Variant", "name"), &GlobalConfig::property_get_revert);
 
 	ClassDB::bind_method(D_METHOD("save_custom", "file"), &GlobalConfig::_save_custom_bnd);
 }

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -4122,6 +4122,12 @@
 				Return the angular damp rate.
 			</description>
 		</method>
+		<method name="get_audio_bus" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="get_collision_layer" qualifiers="const">
 			<return type="int">
 			</return>
@@ -4231,6 +4237,12 @@
 				Return whether this area detects bodies/areas entering/exiting it.
 			</description>
 		</method>
+		<method name="is_overriding_audio_bus" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="overlaps_area" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -4255,6 +4267,18 @@
 			<description>
 				Set the rate at which objects stop spinning in this area, if there are not any other forces making it spin. The value is a fraction of its current speed, lost per second. Thus, a value of 1.0 should mean stopping immediately, and 0.0 means the object never stops.
 				In practice, as the fraction of speed lost gets smaller with each frame, a value of 1.0 does not mean the object will stop in exactly one second. Only when the physics calculations are done at 1 frame per second, it does stop in a second.
+			</description>
+		</method>
+		<method name="set_audio_bus">
+			<argument index="0" name="name" type="String">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_audio_bus_override">
+			<argument index="0" name="enable" type="bool">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="set_collision_layer">
@@ -4366,6 +4390,10 @@
 	</methods>
 	<members>
 		<member name="angular_damp" type="float" setter="set_angular_damp" getter="get_angular_damp" brief="">
+		</member>
+		<member name="audio_bus_name" type="String" setter="set_audio_bus" getter="get_audio_bus" brief="">
+		</member>
+		<member name="audio_bus_override" type="bool" setter="set_audio_bus_override" getter="is_overriding_audio_bus" brief="">
 		</member>
 		<member name="collision_layer" type="int" setter="set_collision_layer" getter="get_collision_layer" brief="">
 		</member>
@@ -5326,7 +5354,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_treshold" qualifiers="const">
+		<method name="get_threshold" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
@@ -5368,8 +5396,8 @@
 			<description>
 			</description>
 		</method>
-		<method name="set_treshold">
-			<argument index="0" name="treshold" type="float">
+		<method name="set_threshold">
+			<argument index="0" name="threshold" type="float">
 			</argument>
 			<description>
 			</description>
@@ -5388,7 +5416,7 @@
 		</member>
 		<member name="sidechain" type="float" setter="set_sidechain" getter="get_sidechain" brief="">
 		</member>
-		<member name="treshold" type="float" setter="set_treshold" getter="get_treshold" brief="">
+		<member name="threshold" type="float" setter="set_threshold" getter="get_threshold" brief="">
 		</member>
 	</members>
 	<constants>
@@ -5844,7 +5872,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_treshold_db" qualifiers="const">
+		<method name="get_threshold_db" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
@@ -5868,8 +5896,8 @@
 			<description>
 			</description>
 		</method>
-		<method name="set_treshold_db">
-			<argument index="0" name="treshold" type="float">
+		<method name="set_threshold_db">
+			<argument index="0" name="threshold" type="float">
 			</argument>
 			<description>
 			</description>
@@ -5882,7 +5910,7 @@
 		</member>
 		<member name="soft_clip_ratio" type="float" setter="set_soft_clip_ratio" getter="get_soft_clip_ratio" brief="">
 		</member>
-		<member name="treshold_db" type="float" setter="set_treshold_db" getter="get_treshold_db" brief="">
+		<member name="threshold_db" type="float" setter="set_threshold_db" getter="get_threshold_db" brief="">
 		</member>
 	</members>
 	<constants>
@@ -6230,118 +6258,6 @@
 	<constants>
 	</constants>
 </class>
-<class name="AudioPlayer" inherits="Node" category="Core">
-	<brief_description>
-	</brief_description>
-	<description>
-	</description>
-	<methods>
-		<method name="get_bus" qualifiers="const">
-			<return type="String">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="get_mix_target" qualifiers="const">
-			<return type="int">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="get_pos">
-			<return type="float">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="get_stream" qualifiers="const">
-			<return type="Object">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="get_volume_db" qualifiers="const">
-			<return type="float">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="is_autoplay_enabled">
-			<return type="bool">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="is_playing" qualifiers="const">
-			<return type="bool">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="play">
-			<argument index="0" name="from_pos" type="float" default="0">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="seek">
-			<argument index="0" name="to_pos" type="float">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="set_autoplay">
-			<argument index="0" name="enable" type="bool">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="set_bus">
-			<argument index="0" name="bus" type="String">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="set_mix_target">
-			<argument index="0" name="mix_target" type="int">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="set_stream">
-			<argument index="0" name="stream" type="AudioStream">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="set_volume_db">
-			<argument index="0" name="volume_db" type="float">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="stop">
-			<description>
-			</description>
-		</method>
-	</methods>
-	<members>
-		<member name="autoplay" type="bool" setter="set_autoplay" getter="is_autoplay_enabled" brief="">
-		</member>
-		<member name="bus" type="String" setter="set_bus" getter="get_bus" brief="">
-		</member>
-		<member name="mix_target" type="int" setter="set_mix_target" getter="get_mix_target" brief="">
-		</member>
-		<member name="playing" type="bool" setter="_set_playing" getter="_is_active" brief="">
-		</member>
-		<member name="stream" type="AudioStream" setter="set_stream" getter="get_stream" brief="">
-		</member>
-		<member name="volume_db" type="float" setter="set_volume_db" getter="get_volume_db" brief="">
-		</member>
-	</members>
-	<constants>
-	</constants>
-</class>
 <class name="AudioServer" inherits="Object" category="Core">
 	<brief_description>
 		Server interface for low level audio access.
@@ -6669,6 +6585,258 @@
 	</description>
 	<methods>
 	</methods>
+	<constants>
+	</constants>
+</class>
+<class name="AudioStreamPlayer" inherits="Node" category="Core">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<methods>
+		<method name="get_bus" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_mix_target" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_pos">
+			<return type="float">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_stream" qualifiers="const">
+			<return type="Object">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_volume_db" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="is_autoplay_enabled">
+			<return type="bool">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="is_playing" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="play">
+			<argument index="0" name="from_pos" type="float" default="0">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="seek">
+			<argument index="0" name="to_pos" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_autoplay">
+			<argument index="0" name="enable" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_bus">
+			<argument index="0" name="bus" type="String">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_mix_target">
+			<argument index="0" name="mix_target" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_stream">
+			<argument index="0" name="stream" type="AudioStream">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_volume_db">
+			<argument index="0" name="volume_db" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="stop">
+			<description>
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="autoplay" type="bool" setter="set_autoplay" getter="is_autoplay_enabled" brief="">
+		</member>
+		<member name="bus" type="String" setter="set_bus" getter="get_bus" brief="">
+		</member>
+		<member name="mix_target" type="int" setter="set_mix_target" getter="get_mix_target" brief="">
+		</member>
+		<member name="playing" type="bool" setter="_set_playing" getter="_is_active" brief="">
+		</member>
+		<member name="stream" type="AudioStream" setter="set_stream" getter="get_stream" brief="">
+		</member>
+		<member name="volume_db" type="float" setter="set_volume_db" getter="get_volume_db" brief="">
+		</member>
+	</members>
+	<constants>
+	</constants>
+</class>
+<class name="AudioStreamPlayer2D" inherits="Node2D" category="Core">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<methods>
+		<method name="get_area_mask" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_attenuation" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_bus" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_max_distance" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_pos">
+			<return type="float">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_stream" qualifiers="const">
+			<return type="Object">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_volume_db" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="is_autoplay_enabled">
+			<return type="bool">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="is_playing" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="play">
+			<argument index="0" name="from_pos" type="float" default="0">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="seek">
+			<argument index="0" name="to_pos" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_area_mask">
+			<argument index="0" name="mask" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_attenuation">
+			<argument index="0" name="curve" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_autoplay">
+			<argument index="0" name="enable" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_bus">
+			<argument index="0" name="bus" type="String">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_max_distance">
+			<argument index="0" name="pixels" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_stream">
+			<argument index="0" name="stream" type="AudioStream">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_volume_db">
+			<argument index="0" name="volume_db" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="stop">
+			<description>
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="area_mask" type="int" setter="set_area_mask" getter="get_area_mask" brief="">
+		</member>
+		<member name="attenuation" type="float" setter="set_attenuation" getter="get_attenuation" brief="">
+		</member>
+		<member name="autoplay" type="bool" setter="set_autoplay" getter="is_autoplay_enabled" brief="">
+		</member>
+		<member name="bus" type="String" setter="set_bus" getter="get_bus" brief="">
+		</member>
+		<member name="max_distance" type="float" setter="set_max_distance" getter="get_max_distance" brief="">
+		</member>
+		<member name="playing" type="bool" setter="_set_playing" getter="_is_active" brief="">
+		</member>
+		<member name="stream" type="AudioStream" setter="set_stream" getter="get_stream" brief="">
+		</member>
+		<member name="volume_db" type="float" setter="set_volume_db" getter="get_volume_db" brief="">
+		</member>
+	</members>
 	<constants>
 	</constants>
 </class>
@@ -8004,13 +8172,31 @@
 			<description>
 			</description>
 		</method>
+		<method name="is_limit_drawing_enabled" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="is_limit_smoothing_enabled" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
 			</description>
 		</method>
+		<method name="is_margin_drawing_enabled" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="is_rotating" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="is_screen_drawing_enabled" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
@@ -8087,12 +8273,24 @@
 				Set the scrolling limit in pixels.
 			</description>
 		</method>
+		<method name="set_limit_drawing_enabled">
+			<argument index="0" name="limit_drawing_enabled" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="set_limit_smoothing_enabled">
 			<argument index="0" name="limit_smoothing_enabled" type="bool">
 			</argument>
 			<description>
 				Smooth camera when reaching camera limits.
 				This requires camera smoothing being enabled to have a noticeable effect.
+			</description>
+		</method>
+		<method name="set_margin_drawing_enabled">
+			<argument index="0" name="margin_drawing_enabled" type="bool">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="set_offset">
@@ -8104,6 +8302,12 @@
 		</method>
 		<method name="set_rotating">
 			<argument index="0" name="rotating" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_screen_drawing_enabled">
+			<argument index="0" name="screen_drawing_enabled" type="bool">
 			</argument>
 			<description>
 			</description>
@@ -8143,6 +8347,12 @@
 		<member name="drag_margin_top" type="float" setter="set_drag_margin" getter="get_drag_margin" brief="">
 		</member>
 		<member name="drag_margin_v_enabled" type="bool" setter="set_v_drag_enabled" getter="is_v_drag_enabled" brief="">
+		</member>
+		<member name="editor_draw_drag_margin" type="bool" setter="set_margin_drawing_enabled" getter="is_margin_drawing_enabled" brief="">
+		</member>
+		<member name="editor_draw_limits" type="bool" setter="set_limit_drawing_enabled" getter="is_limit_drawing_enabled" brief="">
+		</member>
+		<member name="editor_draw_screen" type="bool" setter="set_screen_drawing_enabled" getter="is_screen_drawing_enabled" brief="">
 		</member>
 		<member name="limit_bottom" type="int" setter="set_limit" getter="get_limit" brief="">
 		</member>
@@ -8226,8 +8436,9 @@
 			</argument>
 			<argument index="3" name="texture" type="Texture" default="NULL">
 			</argument>
+			<argument index="4" name="normal_map" type="Texture" default="NULL">
+			</argument>
 			<description>
-				Draw a colored polygon of any amount of points, convex or concave.
 			</description>
 		</method>
 		<method name="draw_line">
@@ -8254,8 +8465,33 @@
 			</argument>
 			<argument index="3" name="texture" type="Texture" default="NULL">
 			</argument>
+			<argument index="4" name="normal_map" type="Texture" default="NULL">
+			</argument>
 			<description>
-				Draw a polygon of any amount of points, convex or concave.
+			</description>
+		</method>
+		<method name="draw_polyline">
+			<argument index="0" name="points" type="PoolVector2Array">
+			</argument>
+			<argument index="1" name="color" type="Color">
+			</argument>
+			<argument index="2" name="width" type="float" default="1">
+			</argument>
+			<argument index="3" name="antialiased" type="bool" default="false">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="draw_polyline_colors">
+			<argument index="0" name="points" type="PoolVector2Array">
+			</argument>
+			<argument index="1" name="colors" type="PoolColorArray">
+			</argument>
+			<argument index="2" name="width" type="float" default="1">
+			</argument>
+			<argument index="3" name="antialiased" type="bool" default="false">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="draw_primitive">
@@ -8269,8 +8505,9 @@
 			</argument>
 			<argument index="4" name="width" type="float" default="1">
 			</argument>
+			<argument index="5" name="normal_map" type="Texture" default="NULL">
+			</argument>
 			<description>
-				Draw a custom primitive, 1 point for a point, 2 points for a line, 3 points for a triangle and 4 points for a quad.
 			</description>
 		</method>
 		<method name="draw_rect">
@@ -8278,8 +8515,9 @@
 			</argument>
 			<argument index="1" name="color" type="Color">
 			</argument>
+			<argument index="2" name="filled" type="bool" default="true">
+			</argument>
 			<description>
-				Draw a colored rectangle.
 			</description>
 		</method>
 		<method name="draw_set_transform">
@@ -8330,8 +8568,9 @@
 			</argument>
 			<argument index="2" name="modulate" type="Color" default="Color(1,1,1,1)">
 			</argument>
+			<argument index="3" name="normal_map" type="Texture" default="NULL">
+			</argument>
 			<description>
-				Draw a texture at a given position.
 			</description>
 		</method>
 		<method name="draw_texture_rect">
@@ -8345,8 +8584,9 @@
 			</argument>
 			<argument index="4" name="transpose" type="bool" default="false">
 			</argument>
+			<argument index="5" name="normal_map" type="Texture" default="NULL">
+			</argument>
 			<description>
-				Draw a textured rectangle at a given position, optionally modulated by a color. Transpose swaps the x and y coordinates when reading the texture.
 			</description>
 		</method>
 		<method name="draw_texture_rect_region">
@@ -8360,8 +8600,11 @@
 			</argument>
 			<argument index="4" name="transpose" type="bool" default="false">
 			</argument>
+			<argument index="5" name="normal_map" type="Texture" default="NULL">
+			</argument>
+			<argument index="6" name="clip_uv" type="bool" default="true">
+			</argument>
 			<description>
-				Draw a textured rectangle region at a given position, optionally modulated by a color. Transpose swaps the x and y coordinates when reading the texture.
 			</description>
 		</method>
 		<method name="edit_get_state" qualifiers="const">
@@ -8462,7 +8705,7 @@
 			</description>
 		</method>
 		<method name="get_material" qualifiers="const">
-			<return type="ShaderMaterial">
+			<return type="Material">
 			</return>
 			<description>
 				Get the material of this item.
@@ -8599,10 +8842,9 @@
 			</description>
 		</method>
 		<method name="set_material">
-			<argument index="0" name="material" type="ShaderMaterial">
+			<argument index="0" name="material" type="Material">
 			</argument>
 			<description>
-				Set the material of this item.
 			</description>
 		</method>
 		<method name="set_modulate">
@@ -8660,7 +8902,7 @@
 	<members>
 		<member name="light_mask" type="int" setter="set_light_mask" getter="get_light_mask" brief="">
 		</member>
-		<member name="material" type="ShaderMaterial" setter="set_material" getter="get_material" brief="">
+		<member name="material" type="ShaderMaterial,CanvasItemMaterial" setter="set_material" getter="get_material" brief="">
 		</member>
 		<member name="modulate" type="Color" setter="set_modulate" getter="get_modulate" brief="">
 		</member>
@@ -8727,6 +8969,62 @@
 		</constant>
 		<constant name="NOTIFICATION_TRANSFORM_CHANGED" value="29">
 			Canvas item transform has changed. Only received if requested.
+		</constant>
+	</constants>
+</class>
+<class name="CanvasItemMaterial" inherits="Material" category="Core">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<methods>
+		<method name="get_blend_mode" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_light_mode" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="set_blend_mode">
+			<argument index="0" name="blend_mode" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_light_mode">
+			<argument index="0" name="light_mode" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="blend_mode" type="int" setter="set_blend_mode" getter="get_blend_mode" brief="">
+		</member>
+		<member name="light_mode" type="int" setter="set_light_mode" getter="get_light_mode" brief="">
+		</member>
+	</members>
+	<constants>
+		<constant name="BLEND_MODE_MIX" value="0">
+		</constant>
+		<constant name="BLEND_MODE_ADD" value="1">
+		</constant>
+		<constant name="BLEND_MODE_SUB" value="2">
+		</constant>
+		<constant name="BLEND_MODE_MUL" value="3">
+		</constant>
+		<constant name="BLEND_MODE_PREMULT_ALPHA" value="4">
+		</constant>
+		<constant name="LIGHT_MODE_NORMAL" value="0">
+		</constant>
+		<constant name="LIGHT_MODE_UNSHADED" value="1">
+		</constant>
+		<constant name="LIGHT_MODE_LIGHT_ONLY" value="2">
 		</constant>
 	</constants>
 </class>
@@ -9563,50 +9861,11 @@
 			<description>
 			</description>
 		</method>
-		<method name="add_shape">
-			<argument index="0" name="shape" type="Shape2D">
-			</argument>
-			<argument index="1" name="transform" type="Transform2D" default="((1, 0), (0, 1), (0, 0))">
-			</argument>
-			<description>
-				Add a [Shape2D] to the collision body, with a given custom transform.
-			</description>
-		</method>
-		<method name="clear_shapes">
-			<description>
-				Remove all shapes.
-			</description>
-		</method>
 		<method name="get_rid" qualifiers="const">
 			<return type="RID">
 			</return>
 			<description>
 				Return the RID of this object.
-			</description>
-		</method>
-		<method name="get_shape" qualifiers="const">
-			<return type="Shape2D">
-			</return>
-			<argument index="0" name="shape_idx" type="int">
-			</argument>
-			<description>
-				Return the shape in the given index.
-			</description>
-		</method>
-		<method name="get_shape_count" qualifiers="const">
-			<return type="int">
-			</return>
-			<description>
-				Return the amount of shapes in the collision body. Because a [CollisionPolygon2D] can generate more than one [Shape2D], the amount returned does not have to match the sum of [CollisionShape2D] and [CollisionPolygon2D].
-			</description>
-		</method>
-		<method name="get_shape_transform" qualifiers="const">
-			<return type="Transform2D">
-			</return>
-			<argument index="0" name="shape_idx" type="int">
-			</argument>
-			<description>
-				Return the shape transform in the given index.
 			</description>
 		</method>
 		<method name="is_pickable" qualifiers="const">
@@ -9616,54 +9875,11 @@
 				Return whether this object is pickable.
 			</description>
 		</method>
-		<method name="is_shape_set_as_trigger" qualifiers="const">
-			<return type="bool">
-			</return>
-			<argument index="0" name="shape_idx" type="int">
-			</argument>
-			<description>
-				Return whether a shape is a trigger. A trigger shape detects collisions, but is otherwise unaffected by physics (i.e. colliding objects will not get blocked).
-			</description>
-		</method>
-		<method name="remove_shape">
-			<argument index="0" name="shape_idx" type="int">
-			</argument>
-			<description>
-				Remove the shape in the given index.
-			</description>
-		</method>
 		<method name="set_pickable">
 			<argument index="0" name="enabled" type="bool">
 			</argument>
 			<description>
 				Set whether this object is pickable. A pickable object can detect the mouse pointer enter/leave it and, if the mouse is inside it, report input events.
-			</description>
-		</method>
-		<method name="set_shape">
-			<argument index="0" name="shape_idx" type="int">
-			</argument>
-			<argument index="1" name="shape" type="Shape">
-			</argument>
-			<description>
-				Change a shape in the collision body.
-			</description>
-		</method>
-		<method name="set_shape_as_trigger">
-			<argument index="0" name="shape_idx" type="int">
-			</argument>
-			<argument index="1" name="enable" type="bool">
-			</argument>
-			<description>
-				Set whether a shape is a trigger. A trigger shape detects collisions, but is otherwise unaffected by physics (i.e. colliding objects will not get blocked).
-			</description>
-		</method>
-		<method name="set_shape_transform">
-			<argument index="0" name="shape_idx" type="int">
-			</argument>
-			<argument index="1" name="transform" type="Transform2D">
-			</argument>
-			<description>
-				Change the shape transform in the collision body.
 			</description>
 		</method>
 	</methods>
@@ -9779,22 +9995,6 @@
 				Return whether the polygon is a [ConvexPolygonShape2D] ([code]build_mode==0[/code]), or a [ConcavePolygonShape2D] ([code]build_mode==1[/code]).
 			</description>
 		</method>
-		<method name="get_collision_object_first_shape" qualifiers="const">
-			<return type="int">
-			</return>
-			<description>
-				Return the index of the first shape generated by the editor.
-				When [code]build_mode[/code] is set to generate convex polygons, the shape shown in the editor may be decomposed into many convex polygons. In that case, a range of indexes is needed to directly access the [Shape2D].
-				When [code]build_mode[/code] is set to generate concave polygons, there is only one [Shape2D] generated, so the start index and the end index are the same.
-			</description>
-		</method>
-		<method name="get_collision_object_last_shape" qualifiers="const">
-			<return type="int">
-			</return>
-			<description>
-				Return the index of the last shape generated by the editor.
-			</description>
-		</method>
 		<method name="get_polygon" qualifiers="const">
 			<return type="PoolVector2Array">
 			</return>
@@ -9802,11 +10002,16 @@
 				Return the list of points that define the polygon.
 			</description>
 		</method>
-		<method name="is_trigger" qualifiers="const">
+		<method name="is_disabled" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
-				Return whether this polygon is a trigger.
+			</description>
+		</method>
+		<method name="is_one_way_collision_enabled" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
 			</description>
 		</method>
 		<method name="set_build_mode">
@@ -9814,6 +10019,18 @@
 			</argument>
 			<description>
 				Set whether the polygon is to be a [ConvexPolygonShape2D] ([code]build_mode==0[/code]), or a [ConcavePolygonShape2D] ([code]build_mode==1[/code]).
+			</description>
+		</method>
+		<method name="set_disabled">
+			<argument index="0" name="disabled" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_one_way_collision">
+			<argument index="0" name="enabled" type="bool">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="set_polygon">
@@ -9824,22 +10041,15 @@
 				When editing the point list via the editor, depending on [method get_build_mode], it has to be a list of points (for [code]build_mode==0[/code]), or a list of lines (for [code]build_mode==1[/code]). In the second case, the even elements of the array define the start point of the line, and the odd elements the end point.
 			</description>
 		</method>
-		<method name="set_trigger">
-			<argument index="0" name="trigger" type="bool">
-			</argument>
-			<description>
-				Set whether this polygon is a trigger. A trigger polygon detects collisions, but is otherwise unaffected by physics (i.e. colliding objects will not get blocked).
-			</description>
-		</method>
 	</methods>
 	<members>
 		<member name="build_mode" type="int" setter="set_build_mode" getter="get_build_mode" brief="">
 		</member>
+		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled" brief="">
+		</member>
+		<member name="one_way_collision" type="bool" setter="set_one_way_collision" getter="is_one_way_collision_enabled" brief="">
+		</member>
 		<member name="polygon" type="PoolVector2Array" setter="set_polygon" getter="get_polygon" brief="">
-		</member>
-		<member name="shape_range" type="Vector2" setter="_set_shape_range" getter="_get_shape_range" brief="">
-		</member>
-		<member name="trigger" type="bool" setter="set_trigger" getter="is_trigger" brief="">
 		</member>
 	</members>
 	<constants>
@@ -9911,13 +10121,6 @@
 		Editor-only class. This is not present when running the game. It's used in the editor to properly edit and position collision shapes in [CollisionObject2D]. This is not accessible from regular code.
 	</description>
 	<methods>
-		<method name="get_collision_object_shape_index" qualifiers="const">
-			<return type="int">
-			</return>
-			<description>
-				Return the index of this shape inside its container [CollisionObject2D]. This can be used to directly access the underlying [Shape2D].
-			</description>
-		</method>
 		<method name="get_shape" qualifiers="const">
 			<return type="Object">
 			</return>
@@ -9925,11 +10128,28 @@
 				Return this shape's [Shape2D].
 			</description>
 		</method>
-		<method name="is_trigger" qualifiers="const">
+		<method name="is_disabled" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
-				Return whether this shape is a trigger.
+			</description>
+		</method>
+		<method name="is_one_way_collision_enabled" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="set_disabled">
+			<argument index="0" name="disabled" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_one_way_collision">
+			<argument index="0" name="enabled" type="bool">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="set_shape">
@@ -9939,20 +10159,13 @@
 				Set this shape's [Shape2D]. This will not appear as a node, but can be directly edited as a property.
 			</description>
 		</method>
-		<method name="set_trigger">
-			<argument index="0" name="enable" type="bool">
-			</argument>
-			<description>
-				Set whether this shape is a trigger. A trigger shape detects collisions, but is otherwise unaffected by physics (i.e. will not block movement of colliding objects).
-			</description>
-		</method>
 	</methods>
 	<members>
-		<member name="_update_shape_index" type="int" setter="_set_update_shape_index" getter="_get_update_shape_index" brief="">
+		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled" brief="">
+		</member>
+		<member name="one_way_collision" type="bool" setter="set_one_way_collision" getter="is_one_way_collision_enabled" brief="">
 		</member>
 		<member name="shape" type="Shape2D" setter="set_shape" getter="get_shape" brief="">
-		</member>
-		<member name="trigger" type="bool" setter="set_trigger" getter="is_trigger" brief="">
 		</member>
 	</members>
 	<constants>
@@ -10822,6 +11035,12 @@
 				Return position and size of the Control, relative to the top-left corner of the [i]window[/i] Control. This is a helper (see [method get_global_pos], [method get_size]).
 			</description>
 		</method>
+		<method name="get_h_grow_direction" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="get_h_size_flags" qualifiers="const">
 			<return type="int">
 			</return>
@@ -10870,6 +11089,12 @@
 		</method>
 		<method name="get_parent_control" qualifiers="const">
 			<return type="Control">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_pivot_offset" qualifiers="const">
+			<return type="Vector2">
 			</return>
 			<description>
 			</description>
@@ -10946,6 +11171,12 @@
 			</argument>
 			<description>
 				Return the tooltip, which will appear when the cursor is resting over this control.
+			</description>
+		</method>
+		<method name="get_v_grow_direction" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
 			</description>
 		</method>
 		<method name="get_v_size_flags" qualifiers="const">
@@ -11180,6 +11411,12 @@
 				Move the Control to a new position, relative to the top-left corner of the [i]window[/i] Control, and without changing current anchor mode. (see [method set_margin]).
 			</description>
 		</method>
+		<method name="set_h_grow_direction">
+			<argument index="0" name="direction" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="set_h_size_flags">
 			<argument index="0" name="flags" type="int">
 			</argument>
@@ -11201,6 +11438,12 @@
 			</argument>
 			<description>
 				Set when the control is ignoring mouse events (even touchpad events send mouse events). (see the MOUSE_FILTER_* constants)
+			</description>
+		</method>
+		<method name="set_pivot_offset">
+			<argument index="0" name="pivot_offset" type="Vector2">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="set_position">
@@ -11258,6 +11501,12 @@
 				Set a tooltip, which will appear when the cursor is resting over this control.
 			</description>
 		</method>
+		<method name="set_v_grow_direction">
+			<argument index="0" name="direction" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="set_v_size_flags">
 			<argument index="0" name="flags" type="int">
 			</argument>
@@ -11296,6 +11545,10 @@
 		</member>
 		<member name="focus_neighbour_top" type="NodePath" setter="set_focus_neighbour" getter="get_focus_neighbour" brief="">
 		</member>
+		<member name="grow_horizontal" type="int" setter="set_h_grow_direction" getter="get_h_grow_direction" brief="">
+		</member>
+		<member name="grow_vertical" type="int" setter="set_v_grow_direction" getter="get_v_grow_direction" brief="">
+		</member>
 		<member name="hint_tooltip" type="String" setter="set_tooltip" getter="_get_tooltip" brief="">
 		</member>
 		<member name="margin_bottom" type="int" setter="set_margin" getter="get_margin" brief="">
@@ -11311,6 +11564,8 @@
 		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" brief="">
 		</member>
 		<member name="rect_min_size" type="Vector2" setter="set_custom_minimum_size" getter="get_custom_minimum_size" brief="">
+		</member>
+		<member name="rect_pivot_offset" type="Vector2" setter="set_pivot_offset" getter="get_pivot_offset" brief="">
 		</member>
 		<member name="rect_position" type="Vector2" setter="set_position" getter="get_position" brief="">
 		</member>
@@ -11455,11 +11710,19 @@
 		</constant>
 		<constant name="SIZE_EXPAND_FILL" value="3">
 		</constant>
+		<constant name="SIZE_SHRINK_CENTER" value="4">
+		</constant>
+		<constant name="SIZE_SHRINK_END" value="8">
+		</constant>
 		<constant name="MOUSE_FILTER_STOP" value="0">
 		</constant>
 		<constant name="MOUSE_FILTER_PASS" value="1">
 		</constant>
 		<constant name="MOUSE_FILTER_IGNORE" value="2">
+		</constant>
+		<constant name="GROW_DIRECTION_BEGIN" value="0">
+		</constant>
+		<constant name="GROW_DIRECTION_END" value="1">
 		</constant>
 	</constants>
 </class>
@@ -11694,6 +11957,206 @@
 		<member name="subdivide_width" type="int" setter="set_subdivide_width" getter="get_subdivide_width" brief="">
 		</member>
 	</members>
+	<constants>
+	</constants>
+</class>
+<class name="Curve" inherits="Resource" category="Core">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<methods>
+		<method name="add_point">
+			<return type="int">
+			</return>
+			<argument index="0" name="pos" type="Vector2">
+			</argument>
+			<argument index="1" name="left_tangent" type="float" default="0">
+			</argument>
+			<argument index="2" name="right_tangent" type="float" default="0">
+			</argument>
+			<argument index="3" name="left_mode" type="int" default="0">
+			</argument>
+			<argument index="4" name="right_mode" type="int" default="0">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="bake">
+			<description>
+			</description>
+		</method>
+		<method name="clean_dupes">
+			<description>
+			</description>
+		</method>
+		<method name="clear_points">
+			<description>
+			</description>
+		</method>
+		<method name="get_bake_resolution" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_max_value" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_min_value" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_point_left_mode" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="index" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_point_left_tangent" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="index" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_point_pos" qualifiers="const">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="index" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_point_right_mode" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="index" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_point_right_tangent" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="index" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="interpolate" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="offset" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="interpolate_baked">
+			<return type="float">
+			</return>
+			<argument index="0" name="offset" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="remove_point">
+			<argument index="0" name="index" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_bake_resolution">
+			<argument index="0" name="resolution" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_max_value">
+			<argument index="0" name="max" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_min_value">
+			<argument index="0" name="min" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_point_left_mode">
+			<argument index="0" name="index" type="int">
+			</argument>
+			<argument index="1" name="mode" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_point_left_tangent">
+			<argument index="0" name="index" type="int">
+			</argument>
+			<argument index="1" name="tangent" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_point_offset">
+			<argument index="0" name="index" type="int">
+			</argument>
+			<argument index="1" name="offset" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_point_right_mode">
+			<argument index="0" name="index" type="int">
+			</argument>
+			<argument index="1" name="mode" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_point_right_tangent">
+			<argument index="0" name="index" type="int">
+			</argument>
+			<argument index="1" name="tangent" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_point_value">
+			<argument index="0" name="index" type="int">
+			</argument>
+			<argument index="1" name="y" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="_data" type="int" setter="_set_data" getter="_get_data" brief="">
+		</member>
+		<member name="bake_resolution" type="int" setter="set_bake_resolution" getter="get_bake_resolution" brief="">
+		</member>
+		<member name="max_value" type="float" setter="set_max_value" getter="get_max_value" brief="">
+		</member>
+		<member name="min_value" type="float" setter="set_min_value" getter="get_min_value" brief="">
+		</member>
+	</members>
+	<signals>
+		<signal name="range_changed">
+			<description>
+			</description>
+		</signal>
+	</signals>
 	<constants>
 	</constants>
 </class>
@@ -12091,38 +12554,14 @@
 	<description>
 	</description>
 	<methods>
-		<method name="get_max" qualifiers="const">
-			<return type="float">
+		<method name="get_curve" qualifiers="const">
+			<return type="Curve">
 			</return>
 			<description>
 			</description>
 		</method>
-		<method name="get_min" qualifiers="const">
-			<return type="float">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="get_points" qualifiers="const">
-			<return type="PoolVector2Array">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="set_max">
-			<argument index="0" name="max" type="float">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="set_min">
-			<argument index="0" name="min" type="float">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="set_points">
-			<argument index="0" name="points" type="PoolVector2Array">
+		<method name="set_curve">
+			<argument index="0" name="curve" type="Curve">
 			</argument>
 			<description>
 			</description>
@@ -12135,11 +12574,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="max" type="float" setter="set_max" getter="get_max" brief="">
-		</member>
-		<member name="min" type="float" setter="set_min" getter="get_min" brief="">
-		</member>
-		<member name="points" type="PoolVector2Array" setter="set_points" getter="get_points" brief="">
+		<member name="curve" type="Curve" setter="set_curve" getter="get_curve" brief="">
 		</member>
 		<member name="width" type="int" setter="set_width" getter="get_width" brief="">
 		</member>
@@ -13499,6 +13934,10 @@
 				This method is called after the editor saves the project or when it's closed. It asks the plugin to save edited external scenes/resources.
 			</description>
 		</method>
+		<method name="set_input_event_forwarding_always_enabled">
+			<description>
+			</description>
+		</method>
 		<method name="set_state" qualifiers="virtual">
 			<argument index="0" name="state" type="Dictionary">
 			</argument>
@@ -14255,7 +14694,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_glow_hdr_bleed_treshold" qualifiers="const">
+		<method name="get_glow_hdr_bleed_threshold" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
@@ -14725,8 +15164,8 @@
 			<description>
 			</description>
 		</method>
-		<method name="set_glow_hdr_bleed_treshold">
-			<argument index="0" name="treshold" type="float">
+		<method name="set_glow_hdr_bleed_threshold">
+			<argument index="0" name="threshold" type="float">
 			</argument>
 			<description>
 			</description>
@@ -14752,7 +15191,7 @@
 			</description>
 		</method>
 		<method name="set_sky">
-			<argument index="0" name="sky" type="CubeMap">
+			<argument index="0" name="sky" type="Sky">
 			</argument>
 			<description>
 			</description>
@@ -14997,7 +15436,7 @@
 		</member>
 		<member name="glow_hdr_scale" type="float" setter="set_glow_hdr_bleed_scale" getter="get_glow_hdr_bleed_scale" brief="">
 		</member>
-		<member name="glow_hdr_treshold" type="float" setter="set_glow_hdr_bleed_treshold" getter="get_glow_hdr_bleed_treshold" brief="">
+		<member name="glow_hdr_threshold" type="float" setter="set_glow_hdr_bleed_threshold" getter="get_glow_hdr_bleed_threshold" brief="">
 		</member>
 		<member name="glow_intensity" type="float" setter="set_glow_intensity" getter="get_glow_intensity" brief="">
 		</member>
@@ -16864,7 +17303,7 @@
 		</member>
 		<member name="lod_min_hysteresis" type="int" setter="set_lod_min_hysteresis" getter="get_lod_min_hysteresis" brief="">
 		</member>
-		<member name="material_override" type="Material" setter="set_material_override" getter="get_material_override" brief="">
+		<member name="material_override" type="ShaderMaterial,SpatialMaterial" setter="set_material_override" getter="get_material_override" brief="">
 		</member>
 		<member name="use_in_baked_light" type="bool" setter="set_flag" getter="get_flag" brief="">
 		</member>
@@ -16992,6 +17431,8 @@
 			</description>
 		</method>
 		<method name="property_get_revert">
+			<return type="Variant">
+			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
 			<description>
@@ -17152,86 +17593,14 @@
 	<description>
 	</description>
 	<methods>
-		<method name="add_point">
-			<argument index="0" name="offset" type="float">
-			</argument>
-			<argument index="1" name="color" type="Color">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="get_color" qualifiers="const">
-			<return type="Color">
-			</return>
-			<argument index="0" name="point" type="int">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="get_colors" qualifiers="const">
-			<return type="PoolColorArray">
+		<method name="get_gradient" qualifiers="const">
+			<return type="Gradient">
 			</return>
 			<description>
 			</description>
 		</method>
-		<method name="get_offset" qualifiers="const">
-			<return type="float">
-			</return>
-			<argument index="0" name="point" type="int">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="get_offsets" qualifiers="const">
-			<return type="PoolRealArray">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="get_point_count" qualifiers="const">
-			<return type="int">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="interpolate">
-			<return type="Color">
-			</return>
-			<argument index="0" name="offset" type="float">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="remove_point">
-			<argument index="0" name="offset" type="int">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="set_color">
-			<argument index="0" name="point" type="int">
-			</argument>
-			<argument index="1" name="color" type="Color">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="set_colors">
-			<argument index="0" name="colors" type="PoolColorArray">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="set_offset">
-			<argument index="0" name="point" type="int">
-			</argument>
-			<argument index="1" name="offset" type="float">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="set_offsets">
-			<argument index="0" name="offsets" type="PoolRealArray">
+		<method name="set_gradient">
+			<argument index="0" name="gradient" type="Gradient">
 			</argument>
 			<description>
 			</description>
@@ -17244,9 +17613,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="colors" type="float" setter="set_colors" getter="get_colors" brief="">
-		</member>
-		<member name="offsets" type="float" setter="set_offsets" getter="get_offsets" brief="">
+		<member name="gradient" type="Gradient" setter="set_gradient" getter="get_gradient" brief="">
 		</member>
 		<member name="width" type="int" setter="set_width" getter="get_width" brief="">
 		</member>
@@ -19007,6 +19374,18 @@
 				Copy a "src_rect" [Rect2] from "src" [Image] to this [Image] on coordinates "dest".
 			</description>
 		</method>
+		<method name="blit_rect_mask">
+			<argument index="0" name="src" type="Image">
+			</argument>
+			<argument index="1" name="mask" type="Image">
+			</argument>
+			<argument index="2" name="src_rect" type="Rect2">
+			</argument>
+			<argument index="3" name="dst" type="Vector2">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="clear_mipmaps">
 			<description>
 			</description>
@@ -19218,16 +19597,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="set_pixel">
-			<argument index="0" name="x" type="int">
-			</argument>
-			<argument index="1" name="y" type="int">
-			</argument>
-			<argument index="2" name="color" type="Color">
-			</argument>
-			<description>
-			</description>
-		</method>
 		<method name="resize">
 			<argument index="0" name="width" type="int">
 			</argument>
@@ -19239,7 +19608,7 @@
 			</description>
 		</method>
 		<method name="resize_to_po2">
-			<argument index="0" name="square" type="bool" default="&quot;false&quot;">
+			<argument index="0" name="square" type="bool" default="false">
 			</argument>
 			<description>
 			</description>
@@ -19251,6 +19620,16 @@
 			</argument>
 			<description>
 				Save this [Image] as a png.
+			</description>
+		</method>
+		<method name="set_pixel">
+			<argument index="0" name="x" type="int">
+			</argument>
+			<argument index="1" name="y" type="int">
+			</argument>
+			<argument index="2" name="color" type="Color">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="shrink_x2">
@@ -19984,6 +20363,14 @@
 			<description>
 			</description>
 		</method>
+		<method name="shortcut_match" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="event" type="InputEvent">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="xformed_by" qualifiers="const">
 			<return type="InputEvent">
 			</return>
@@ -19995,6 +20382,10 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="device" type="int" setter="set_device" getter="get_device" brief="">
+		</member>
+	</members>
 	<constants>
 	</constants>
 </class>
@@ -20882,6 +21273,8 @@
 			</description>
 		</method>
 		<method name="get_item_metadata" qualifiers="const">
+			<return type="Variant">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
@@ -21151,6 +21544,26 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="allow_rmb_select" type="bool" setter="set_allow_rmb_select" getter="get_allow_rmb_select" brief="">
+		</member>
+		<member name="fixed_column_width" type="int" setter="set_fixed_column_width" getter="get_fixed_column_width" brief="">
+		</member>
+		<member name="icon_mode" type="int" setter="set_icon_mode" getter="get_icon_mode" brief="">
+		</member>
+		<member name="icon_scale" type="float" setter="set_icon_scale" getter="get_icon_scale" brief="">
+		</member>
+		<member name="items" type="Array" setter="_set_items" getter="_get_items" brief="">
+		</member>
+		<member name="max_columns" type="int" setter="set_max_columns" getter="get_max_columns" brief="">
+		</member>
+		<member name="max_text_lines" type="int" setter="set_max_text_lines" getter="get_max_text_lines" brief="">
+		</member>
+		<member name="same_column_width" type="bool" setter="set_same_column_width" getter="is_same_column_width" brief="">
+		</member>
+		<member name="select_mode" type="int" setter="set_select_mode" getter="get_select_mode" brief="">
+		</member>
+	</members>
 	<signals>
 		<signal name="item_activated">
 			<argument index="0" name="index" type="int">
@@ -21599,95 +22012,130 @@
 		Kinematic Characters: KinematicBody2D also has an api for moving objects (the [method move] method) while performing collision tests. This makes them really useful to implement characters that collide against a world, but that don't require advanced physics.
 	</description>
 	<methods>
-		<method name="get_collider" qualifiers="const">
-			<return type="Variant">
+		<method name="get_collision_collider" qualifiers="const">
+			<return type="Object">
 			</return>
+			<argument index="0" name="collision" type="int">
+			</argument>
 			<description>
-				Return the body that collided with this one.
 			</description>
 		</method>
-		<method name="get_collider_metadata" qualifiers="const">
-			<return type="Variant">
+		<method name="get_collision_collider_id" qualifiers="const">
+			<return type="int">
 			</return>
+			<argument index="0" name="collision" type="int">
+			</argument>
 			<description>
-				Return the metadata of the shape that collided with this body. If there is no collision, it will return 0, so collisions must be checked first with [method is_colliding]. Additionally, this metadata can not be set with [method Object.set_meta], it must be set with [method Physics2DServer.body_set_shape_metadata].
 			</description>
 		</method>
-		<method name="get_collider_shape" qualifiers="const">
+		<method name="get_collision_collider_metadata" qualifiers="const">
+			<argument index="0" name="collision" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_collision_collider_shape" qualifiers="const">
+			<return type="Object">
+			</return>
+			<argument index="0" name="collision" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_collision_collider_shape_index" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="collision" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_collision_collider_velocity" qualifiers="const">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="collision" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_collision_count" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Return the shape index from the body that collided with this one. If there is no collision, this method will return 0, so collisions must be checked first with [method is_colliding].
 			</description>
 		</method>
-		<method name="get_collider_velocity" qualifiers="const">
-			<return type="Vector2">
+		<method name="get_collision_local_shape" qualifiers="const">
+			<return type="Object">
 			</return>
+			<argument index="0" name="collision" type="int">
+			</argument>
 			<description>
-				Return the velocity of the body that collided with this one.
-			</description>
-		</method>
-		<method name="get_collision_margin" qualifiers="const">
-			<return type="float">
-			</return>
-			<description>
-				Return the collision margin for this object.
 			</description>
 		</method>
 		<method name="get_collision_normal" qualifiers="const">
 			<return type="Vector2">
 			</return>
+			<argument index="0" name="collision" type="int">
+			</argument>
 			<description>
-				Return the normal of the surface the body collided with. This is useful to implement sliding along a surface.
 			</description>
 		</method>
-		<method name="get_collision_pos" qualifiers="const">
+		<method name="get_collision_position" qualifiers="const">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="collision" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_collision_remainder" qualifiers="const">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="collision" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_collision_travel" qualifiers="const">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="collision" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_floor_velocity" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<description>
-				Return the point in space where the body is touching another. If there is no collision, this method will return (0,0), so collisions must be checked first with [method is_colliding].
 			</description>
 		</method>
-		<method name="get_move_and_slide_colliders" qualifiers="const">
-			<return type="Array">
+		<method name="get_safe_margin" qualifiers="const">
+			<return type="float">
 			</return>
 			<description>
 			</description>
 		</method>
-		<method name="get_travel" qualifiers="const">
-			<return type="Vector2">
-			</return>
-			<description>
-				Return the last movement done by the body.
-			</description>
-		</method>
-		<method name="is_colliding" qualifiers="const">
-			<return type="bool">
-			</return>
-			<description>
-				Return whether the body is colliding with another.
-			</description>
-		</method>
-		<method name="is_move_and_slide_on_ceiling" qualifiers="const">
+		<method name="is_on_ceiling" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
 			</description>
 		</method>
-		<method name="is_move_and_slide_on_floor" qualifiers="const">
+		<method name="is_on_floor" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
 			</description>
 		</method>
-		<method name="is_move_and_slide_on_wall" qualifiers="const">
+		<method name="is_on_wall" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
 			</description>
 		</method>
 		<method name="move">
-			<return type="Vector2">
+			<return type="Dictionary">
 			</return>
 			<argument index="0" name="rel_vec" type="Vector2">
 			</argument>
@@ -21711,26 +22159,10 @@
 			<description>
 			</description>
 		</method>
-		<method name="move_to">
-			<return type="Vector2">
-			</return>
-			<argument index="0" name="position" type="Vector2">
-			</argument>
-			<description>
-				Move the body to the given position. This is not a teleport, and the body will stop if there is an obstacle. The returned vector is how much movement was remaining before being stopped.
-				[code]floor_max_angle[/code] is in radians (default is pi/4), and filters which obstacles should be considered as floors/cellings instead of walls.
-			</description>
-		</method>
-		<method name="revert_motion">
-			<description>
-				Undo the last movement done by the body.
-			</description>
-		</method>
-		<method name="set_collision_margin">
+		<method name="set_safe_margin">
 			<argument index="0" name="pixels" type="float">
 			</argument>
 			<description>
-				Set the collision margin for this object. A collision margin is an amount (in pixels) that all shapes will grow when computing collisions, to account for numerical imprecision.
 			</description>
 		</method>
 		<method name="test_move">
@@ -21746,7 +22178,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="collision/margin" type="float" setter="set_collision_margin" getter="get_collision_margin" brief="">
+		<member name="collision/safe_margin" type="float" setter="set_safe_margin" getter="get_safe_margin" brief="">
 		</member>
 	</members>
 	<constants>
@@ -23450,7 +23882,23 @@
 		Material is a base [Resource] used for coloring and shading geometry. All materials inherit from it and almost all [VisualInstance] derived nodes carry a Material. A few flags and parameters are shared between all material types and are configured here.
 	</description>
 	<methods>
+		<method name="get_next_pass" qualifiers="const">
+			<return type="Material">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="set_next_pass">
+			<argument index="0" name="next_pass" type="Material">
+			</argument>
+			<description>
+			</description>
+		</method>
 	</methods>
+	<members>
+		<member name="next_pass" type="Material" setter="set_next_pass" getter="get_next_pass" brief="">
+		</member>
+	</members>
 	<constants>
 	</constants>
 </class>
@@ -23594,6 +24042,8 @@
 			</description>
 		</method>
 		<method name="get_edge_meta" qualifiers="const">
+			<return type="Variant">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
@@ -23626,6 +24076,8 @@
 			</description>
 		</method>
 		<method name="get_face_meta" qualifiers="const">
+			<return type="Variant">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
@@ -23708,6 +24160,8 @@
 			</description>
 		</method>
 		<method name="get_vertex_meta" qualifiers="const">
+			<return type="Variant">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
@@ -23863,6 +24317,10 @@
 			<description>
 			</description>
 		</method>
+		<method name="create_debug_tagents">
+			<description>
+			</description>
+		</method>
 		<method name="create_trimesh_collision">
 			<description>
 				This helper creates a [StaticBody] child [Node] using the mesh geometry as collision. It's mainly used for testing.
@@ -23881,6 +24339,14 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_surface_material" qualifiers="const">
+			<return type="Material">
+			</return>
+			<argument index="0" name="surface" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="set_mesh">
 			<argument index="0" name="mesh" type="Mesh">
 			</argument>
@@ -23890,6 +24356,14 @@
 		</method>
 		<method name="set_skeleton_path">
 			<argument index="0" name="skeleton_path" type="NodePath">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_surface_material">
+			<argument index="0" name="surface" type="int">
+			</argument>
+			<argument index="1" name="material" type="Material">
 			</argument>
 			<description>
 			</description>
@@ -24958,6 +25432,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_h_axis_stretch_mode" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="get_patch_margin" qualifiers="const">
 			<return type="int">
 			</return>
@@ -24978,8 +25458,20 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_v_axis_stretch_mode" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="set_draw_center">
 			<argument index="0" name="draw_center" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_h_axis_stretch_mode">
+			<argument index="0" name="mode" type="int">
 			</argument>
 			<description>
 			</description>
@@ -25004,8 +25496,18 @@
 			<description>
 			</description>
 		</method>
+		<method name="set_v_axis_stretch_mode">
+			<argument index="0" name="mode" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 	</methods>
 	<members>
+		<member name="axis_stretch_horizontal" type="int" setter="set_h_axis_stretch_mode" getter="get_h_axis_stretch_mode" brief="">
+		</member>
+		<member name="axis_stretch_vertical" type="int" setter="set_v_axis_stretch_mode" getter="get_v_axis_stretch_mode" brief="">
+		</member>
 		<member name="draw_center" type="bool" setter="set_draw_center" getter="get_draw_center" brief="">
 		</member>
 		<member name="patch_margin_bottom" type="int" setter="set_patch_margin" getter="get_patch_margin" brief="">
@@ -25028,6 +25530,12 @@
 		</signal>
 	</signals>
 	<constants>
+		<constant name="AXIS_STRETCH_MODE_STRETCH" value="0">
+		</constant>
+		<constant name="AXIS_STRETCH_MODE_TILE" value="1">
+		</constant>
+		<constant name="AXIS_STRETCH_MODE_TILE_FIT" value="2">
+		</constant>
 	</constants>
 </class>
 <class name="Node" inherits="Object" category="Core">
@@ -25208,7 +25716,7 @@
 				Return the name of the node. This name is unique among the siblings (other child nodes from the same parent).
 			</description>
 		</method>
-		<method name="get_network_mode" qualifiers="const">
+		<method name="get_network_master" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
@@ -25612,11 +26120,12 @@
 				Set the name of the [Node]. Name must be unique within parent, and setting an already existing name will cause for the node to be automatically renamed.
 			</description>
 		</method>
-		<method name="set_network_mode">
-			<argument index="0" name="mode" type="int">
+		<method name="set_network_master">
+			<argument index="0" name="id" type="int">
+			</argument>
+			<argument index="1" name="recursive" type="bool" default="true">
 			</argument>
 			<description>
-				Change the networking mode of the [Node], where [i]mode[/i] is one of the constants NETWORK_MODE_*. Master nodes will only call gdscript methods defined as [i]master func[/i] if a RPC call is received (slave nodes will only call [i]slave func[/i]; both will call [i]remote func[/i] if the call is not local, and [i]sync func[/i] in any case). Inherit mode looks at the parent node to determine the value (root node depends on the [SceneTree] having a networking peer set with [method SceneTree.set_network_peer])
 			</description>
 		</method>
 		<method name="set_owner">
@@ -25732,12 +26241,6 @@
 		<constant name="NOTIFICATION_INTERNAL_PROCESS" value="25">
 		</constant>
 		<constant name="NOTIFICATION_INTERNAL_FIXED_PROCESS" value="26">
-		</constant>
-		<constant name="NETWORK_MODE_INHERIT" value="0">
-		</constant>
-		<constant name="NETWORK_MODE_MASTER" value="1">
-		</constant>
-		<constant name="NETWORK_MODE_SLAVE" value="2">
 		</constant>
 		<constant name="RPC_MODE_DISABLED" value="0">
 		</constant>
@@ -27037,6 +27540,12 @@
 				Return the class of the object as a string.
 			</description>
 		</method>
+		<method name="get_incoming_connections" qualifiers="const">
+			<return type="Array">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="get_instance_ID" qualifiers="const">
 			<return type="int">
 			</return>
@@ -27409,6 +27918,8 @@
 			</description>
 		</method>
 		<method name="get_item_metadata" qualifiers="const">
+			<return type="Variant">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
@@ -27437,6 +27948,8 @@
 			</description>
 		</method>
 		<method name="get_selected_metadata" qualifiers="const">
+			<return type="Variant">
+			</return>
 			<description>
 			</description>
 		</method>
@@ -28080,102 +28593,6 @@
 	<constants>
 	</constants>
 </class>
-<class name="ParticleAttractor2D" inherits="Node2D" category="Core">
-	<brief_description>
-	</brief_description>
-	<description>
-	</description>
-	<methods>
-		<method name="get_absorption" qualifiers="const">
-			<return type="float">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="get_disable_radius" qualifiers="const">
-			<return type="float">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="get_gravity" qualifiers="const">
-			<return type="float">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="get_particles_path" qualifiers="const">
-			<return type="NodePath">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="get_radius" qualifiers="const">
-			<return type="float">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="is_enabled" qualifiers="const">
-			<return type="bool">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="set_absorption">
-			<argument index="0" name="absorption" type="float">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="set_disable_radius">
-			<argument index="0" name="radius" type="float">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="set_enabled">
-			<argument index="0" name="enabled" type="bool">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="set_gravity">
-			<argument index="0" name="gravity" type="float">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="set_particles_path">
-			<argument index="0" name="path" type="NodePath">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="set_radius">
-			<argument index="0" name="radius" type="float">
-			</argument>
-			<description>
-			</description>
-		</method>
-	</methods>
-	<members>
-		<member name="absorption" type="float" setter="set_absorption" getter="get_absorption" brief="">
-		</member>
-		<member name="disable_radius" type="float" setter="set_disable_radius" getter="get_disable_radius" brief="">
-		</member>
-		<member name="enabled" type="bool" setter="set_enabled" getter="is_enabled" brief="">
-		</member>
-		<member name="gravity" type="float" setter="set_gravity" getter="get_gravity" brief="">
-		</member>
-		<member name="particles_path" type="NodePath" setter="set_particles_path" getter="get_particles_path" brief="">
-		</member>
-		<member name="radius" type="float" setter="set_radius" getter="get_radius" brief="">
-		</member>
-	</members>
-	<constants>
-	</constants>
-</class>
 <class name="Particles" inherits="GeometryInstance" category="Core">
 	<brief_description>
 	</brief_description>
@@ -28238,6 +28655,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_one_shot" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="get_pre_process_time" qualifiers="const">
 			<return type="float">
 			</return>
@@ -28277,6 +28700,10 @@
 		<method name="is_emitting" qualifiers="const">
 			<return type="bool">
 			</return>
+			<description>
+			</description>
+		</method>
+		<method name="restart">
 			<description>
 			</description>
 		</method>
@@ -28332,6 +28759,12 @@
 		</method>
 		<method name="set_lifetime">
 			<argument index="0" name="secs" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_one_shot">
+			<argument index="0" name="enable" type="bool">
 			</argument>
 			<description>
 			</description>
@@ -28400,9 +28833,11 @@
 		</member>
 		<member name="local_coords" type="bool" setter="set_use_local_coordinates" getter="get_use_local_coordinates" brief="">
 		</member>
+		<member name="one_shot" type="bool" setter="set_one_shot" getter="get_one_shot" brief="">
+		</member>
 		<member name="preprocess" type="float" setter="set_pre_process_time" getter="get_pre_process_time" brief="">
 		</member>
-		<member name="process_material" type="ParticlesMaterial,ShaderMaterial" setter="set_process_material" getter="get_process_material" brief="">
+		<member name="process_material" type="ShaderMaterial,ParticlesMaterial" setter="set_process_material" getter="get_process_material" brief="">
 		</member>
 		<member name="randomness" type="float" setter="set_randomness_ratio" getter="get_randomness_ratio" brief="">
 		</member>
@@ -28430,6 +28865,12 @@
 		Particles2D is a particle system 2D [Node] that is used to simulate several types of particle effects, such as explosions, rain, snow, fireflies, or other magical-like shinny sparkles. Particles are drawn using impostors, and given their dynamic behavior, the user must provide a visibility bounding box (although helpers to create one automatically exist).
 	</description>
 	<methods>
+		<method name="capture_rect" qualifiers="const">
+			<return type="Rect2">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="get_amount" qualifiers="const">
 			<return type="int">
 			</return>
@@ -28437,83 +28878,32 @@
 				Returns the amount of particles spawned at each emission
 			</description>
 		</method>
-		<method name="get_color" qualifiers="const">
-			<return type="Color">
-			</return>
-			<description>
-				Returns the tint color for each particle.
-			</description>
-		</method>
-		<method name="get_color_phase_color" qualifiers="const">
-			<return type="Color">
-			</return>
-			<argument index="0" name="phase" type="int">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="get_color_phase_pos" qualifiers="const">
-			<return type="float">
-			</return>
-			<argument index="0" name="phase" type="int">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="get_color_phases" qualifiers="const">
+		<method name="get_draw_order" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
 			</description>
 		</method>
-		<method name="get_emission_half_extents" qualifiers="const">
-			<return type="Vector2">
-			</return>
-			<description>
-				Returns the half extents of the emission box.
-			</description>
-		</method>
-		<method name="get_emission_points" qualifiers="const">
-			<return type="PoolVector2Array">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="get_emissor_offset" qualifiers="const">
-			<return type="Vector2">
-			</return>
-			<description>
-				Returns the particle spawn origin position relative to the emitter.
-			</description>
-		</method>
-		<method name="get_emit_timeout" qualifiers="const">
-			<return type="float">
-			</return>
-			<description>
-				Returns the amount of seconds during which the emitter will spawn particles
-			</description>
-		</method>
-		<method name="get_explosiveness" qualifiers="const">
+		<method name="get_explosiveness_ratio" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
 			</description>
 		</method>
-		<method name="get_gradient" qualifiers="const">
-			<return type="Gradient">
+		<method name="get_fixed_fps" qualifiers="const">
+			<return type="int">
 			</return>
 			<description>
-				Returns the [Gradient] used to tint each particle.
+			</description>
+		</method>
+		<method name="get_fractional_delta" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
 			</description>
 		</method>
 		<method name="get_h_frames" qualifiers="const">
 			<return type="int">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="get_initial_velocity" qualifiers="const">
-			<return type="Vector2">
 			</return>
 			<description>
 			</description>
@@ -28525,13 +28915,16 @@
 				Gets the amount of seconds that each particle will be visible.
 			</description>
 		</method>
-		<method name="get_param" qualifiers="const">
-			<return type="float">
+		<method name="get_normal_map" qualifiers="const">
+			<return type="Texture">
 			</return>
-			<argument index="0" name="param" type="int">
-			</argument>
 			<description>
-				Returns the value of the specified emitter parameter
+			</description>
+		</method>
+		<method name="get_one_shot" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
 			</description>
 		</method>
 		<method name="get_pre_process_time" qualifiers="const">
@@ -28540,19 +28933,22 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_process_mode" qualifiers="const">
-			<return type="int">
+		<method name="get_process_material" qualifiers="const">
+			<return type="Material">
 			</return>
 			<description>
 			</description>
 		</method>
-		<method name="get_randomness" qualifiers="const">
+		<method name="get_randomness_ratio" qualifiers="const">
 			<return type="float">
 			</return>
-			<argument index="0" name="param" type="int">
-			</argument>
 			<description>
-				Returns the randomness value of the specified emitter parameter
+			</description>
+		</method>
+		<method name="get_speed_scale" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
 			</description>
 		</method>
 		<method name="get_texture" qualifiers="const">
@@ -28562,15 +28958,20 @@
 				Returns the texture for emitted particles
 			</description>
 		</method>
-		<method name="get_time_scale" qualifiers="const">
-			<return type="float">
+		<method name="get_use_local_coordinates" qualifiers="const">
+			<return type="bool">
 			</return>
 			<description>
-				Returns the emitter time scale
 			</description>
 		</method>
 		<method name="get_v_frames" qualifiers="const">
 			<return type="int">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_visibility_rect" qualifiers="const">
+			<return type="Rect2">
 			</return>
 			<description>
 			</description>
@@ -28582,31 +28983,7 @@
 				Returns whether this emitter is currently emitting or not
 			</description>
 		</method>
-		<method name="is_flipped_h" qualifiers="const">
-			<return type="bool">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="is_flipped_v" qualifiers="const">
-			<return type="bool">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="is_using_local_space" qualifiers="const">
-			<return type="bool">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="pre_process">
-			<argument index="0" name="time" type="float">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="reset">
+		<method name="restart">
 			<description>
 			</description>
 		</method>
@@ -28617,348 +28994,153 @@
 				Sets the amount of particles spawned at each emission
 			</description>
 		</method>
-		<method name="set_color">
-			<argument index="0" name="color" type="Color">
+		<method name="set_draw_order">
+			<argument index="0" name="order" type="int">
 			</argument>
 			<description>
-				Set the tint color for each particle.
-			</description>
-		</method>
-		<method name="set_color_phase_color">
-			<argument index="0" name="phase" type="int">
-			</argument>
-			<argument index="1" name="color" type="Color">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="set_color_phase_pos">
-			<argument index="0" name="phase" type="int">
-			</argument>
-			<argument index="1" name="pos" type="float">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="set_color_phases">
-			<argument index="0" name="phases" type="int">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="set_emission_half_extents">
-			<argument index="0" name="extents" type="Vector2">
-			</argument>
-			<description>
-				Sets the half extents of the emission box, particles will be spawned at random inside this box.
-			</description>
-		</method>
-		<method name="set_emission_points">
-			<argument index="0" name="points" type="PoolVector2Array">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="set_emissor_offset">
-			<argument index="0" name="offset" type="Vector2">
-			</argument>
-			<description>
-				Sets the particle spawn origin position relative to the emitter center. for example if this value is set to (50, 50), the particle will spawn 50 units to the right and  50 units to the bottom of the emitter center.
-			</description>
-		</method>
-		<method name="set_emit_timeout">
-			<argument index="0" name="value" type="float">
-			</argument>
-			<description>
-				Sets the amount of seconds during which the emitter will spawn particles, after the specified seconds the emitter state will be set to non emitting, so calling [method is_emitting] will return false. If the timeout is 0 the emitter will spawn forever.
 			</description>
 		</method>
 		<method name="set_emitting">
-			<argument index="0" name="active" type="bool">
+			<argument index="0" name="emitting" type="bool">
 			</argument>
 			<description>
 				If this is set to true then the particle emitter will emit particles, if its false it will not.
 			</description>
 		</method>
-		<method name="set_explosiveness">
-			<argument index="0" name="amount" type="float">
+		<method name="set_explosiveness_ratio">
+			<argument index="0" name="ratio" type="float">
 			</argument>
 			<description>
 			</description>
 		</method>
-		<method name="set_flip_h">
+		<method name="set_fixed_fps">
+			<argument index="0" name="fps" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_fractional_delta">
 			<argument index="0" name="enable" type="bool">
 			</argument>
 			<description>
-			</description>
-		</method>
-		<method name="set_flip_v">
-			<argument index="0" name="enable" type="bool">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="set_gradient">
-			<return type="Gradient">
-			</return>
-			<argument index="0" name="gradient" type="Object">
-			</argument>
-			<description>
-				Sets the [Gradient] used to tint each particle. Particle will be tinted according to their lifetimes.
 			</description>
 		</method>
 		<method name="set_h_frames">
-			<argument index="0" name="enable" type="int">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="set_initial_velocity">
-			<argument index="0" name="velocity" type="Vector2">
+			<argument index="0" name="frames" type="int">
 			</argument>
 			<description>
 			</description>
 		</method>
 		<method name="set_lifetime">
-			<argument index="0" name="lifetime" type="float">
+			<argument index="0" name="secs" type="float">
 			</argument>
 			<description>
 				Sets the amount of seconds that each particle will be visible.
 			</description>
 		</method>
-		<method name="set_param">
-			<argument index="0" name="param" type="int">
-			</argument>
-			<argument index="1" name="value" type="float">
+		<method name="set_normal_map">
+			<argument index="0" name="texture" type="Texture">
 			</argument>
 			<description>
-				Sets the value of the specified emitter parameter (see the constants secction for the list of parameters)
+			</description>
+		</method>
+		<method name="set_one_shot">
+			<argument index="0" name="secs" type="bool">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="set_pre_process_time">
-			<argument index="0" name="time" type="float">
+			<argument index="0" name="secs" type="float">
 			</argument>
 			<description>
 			</description>
 		</method>
-		<method name="set_process_mode">
-			<argument index="0" name="mode" type="int">
+		<method name="set_process_material">
+			<argument index="0" name="material" type="Material">
 			</argument>
 			<description>
 			</description>
 		</method>
-		<method name="set_randomness">
-			<argument index="0" name="param" type="int">
-			</argument>
-			<argument index="1" name="value" type="float">
+		<method name="set_randomness_ratio">
+			<argument index="0" name="ratio" type="float">
 			</argument>
 			<description>
-				Sets the randomness value of the specified emitter parameter (see the constants secction for the list of parameters), 0 means no randomness, so every particle will have the parameters specified, 1 means that the parameter will be chosen at random, the closer the randomness value gets to 0 the more conservative the variation of the parameter will be.
+			</description>
+		</method>
+		<method name="set_speed_scale">
+			<argument index="0" name="scale" type="float">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="set_texture">
-			<return type="Texture">
-			</return>
-			<argument index="0" name="texture" type="Object">
+			<argument index="0" name="texture" type="Texture">
 			</argument>
 			<description>
-				Sets the texture for each particle
 			</description>
 		</method>
-		<method name="set_time_scale">
-			<argument index="0" name="time_scale" type="float">
-			</argument>
-			<description>
-				Sets the increment or decrement for the particle lifetime. for example: if the time scale is set to 2, the particles will die and move twice as fast.
-			</description>
-		</method>
-		<method name="set_use_local_space">
+		<method name="set_use_local_coordinates">
 			<argument index="0" name="enable" type="bool">
 			</argument>
 			<description>
 			</description>
 		</method>
 		<method name="set_v_frames">
-			<argument index="0" name="enable" type="int">
+			<argument index="0" name="frames" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_visibility_rect">
+			<argument index="0" name="aabb" type="Rect2">
 			</argument>
 			<description>
 			</description>
 		</method>
 	</methods>
 	<members>
-		<member name="color/color" type="Color" setter="set_color" getter="get_color" brief="">
+		<member name="amount" type="int" setter="set_amount" getter="get_amount" brief="">
 		</member>
-		<member name="color/color_ramp" type="Gradient" setter="set_color_ramp" getter="get_color_ramp" brief="">
+		<member name="draw_order" type="int" setter="set_draw_order" getter="get_draw_order" brief="">
 		</member>
-		<member name="color_phases/count" type="int" setter="set_color_phases" getter="get_color_phases" brief="">
+		<member name="emitting" type="bool" setter="set_emitting" getter="is_emitting" brief="">
 		</member>
-		<member name="config/amount" type="int" setter="set_amount" getter="get_amount" brief="">
+		<member name="explosiveness" type="float" setter="set_explosiveness_ratio" getter="get_explosiveness_ratio" brief="">
 		</member>
-		<member name="config/emit_timeout" type="float" setter="set_emit_timeout" getter="get_emit_timeout" brief="">
+		<member name="fixed_fps" type="int" setter="set_fixed_fps" getter="get_fixed_fps" brief="">
 		</member>
-		<member name="config/emitting" type="bool" setter="set_emitting" getter="is_emitting" brief="">
+		<member name="fract_delta" type="bool" setter="set_fractional_delta" getter="get_fractional_delta" brief="">
 		</member>
-		<member name="config/explosiveness" type="float" setter="set_explosiveness" getter="get_explosiveness" brief="">
+		<member name="h_frames" type="int" setter="set_h_frames" getter="get_h_frames" brief="">
 		</member>
-		<member name="config/flip_h" type="bool" setter="set_flip_h" getter="is_flipped_h" brief="">
+		<member name="lifetime" type="float" setter="set_lifetime" getter="get_lifetime" brief="">
 		</member>
-		<member name="config/flip_v" type="bool" setter="set_flip_v" getter="is_flipped_v" brief="">
+		<member name="local_coords" type="bool" setter="set_use_local_coordinates" getter="get_use_local_coordinates" brief="">
 		</member>
-		<member name="config/h_frames" type="int" setter="set_h_frames" getter="get_h_frames" brief="">
+		<member name="normal_map" type="Texture" setter="set_normal_map" getter="get_normal_map" brief="">
 		</member>
-		<member name="config/half_extents" type="Vector2" setter="set_emission_half_extents" getter="get_emission_half_extents" brief="">
+		<member name="one_shot" type="bool" setter="set_one_shot" getter="get_one_shot" brief="">
 		</member>
-		<member name="config/lifetime" type="float" setter="set_lifetime" getter="get_lifetime" brief="">
+		<member name="preprocess" type="float" setter="set_pre_process_time" getter="get_pre_process_time" brief="">
 		</member>
-		<member name="config/local_space" type="bool" setter="set_use_local_space" getter="is_using_local_space" brief="">
+		<member name="process_material" type="ShaderMaterial,ParticlesMaterial" setter="set_process_material" getter="get_process_material" brief="">
 		</member>
-		<member name="config/offset" type="Vector2" setter="set_emissor_offset" getter="get_emissor_offset" brief="">
+		<member name="randomness" type="float" setter="set_randomness_ratio" getter="get_randomness_ratio" brief="">
 		</member>
-		<member name="config/preprocess" type="float" setter="set_pre_process_time" getter="get_pre_process_time" brief="">
+		<member name="speed_scale" type="float" setter="set_speed_scale" getter="get_speed_scale" brief="">
 		</member>
-		<member name="config/process_mode" type="int" setter="set_process_mode" getter="get_process_mode" brief="">
+		<member name="texture" type="Texture" setter="set_texture" getter="get_texture" brief="">
 		</member>
-		<member name="config/texture" type="Texture" setter="set_texture" getter="get_texture" brief="">
+		<member name="v_frames" type="int" setter="set_v_frames" getter="get_v_frames" brief="">
 		</member>
-		<member name="config/time_scale" type="float" setter="set_time_scale" getter="get_time_scale" brief="">
-		</member>
-		<member name="config/v_frames" type="int" setter="set_v_frames" getter="get_v_frames" brief="">
-		</member>
-		<member name="emission_points" type="PoolVector2Array" setter="set_emission_points" getter="get_emission_points" brief="">
-		</member>
-		<member name="params/anim_initial_pos" type="float" setter="set_param" getter="get_param" brief="">
-		</member>
-		<member name="params/anim_speed_scale" type="float" setter="set_param" getter="get_param" brief="">
-		</member>
-		<member name="params/damping" type="float" setter="set_param" getter="get_param" brief="">
-		</member>
-		<member name="params/direction" type="float" setter="set_param" getter="get_param" brief="">
-		</member>
-		<member name="params/final_size" type="float" setter="set_param" getter="get_param" brief="">
-		</member>
-		<member name="params/gravity_direction" type="float" setter="set_param" getter="get_param" brief="">
-		</member>
-		<member name="params/gravity_strength" type="float" setter="set_param" getter="get_param" brief="">
-		</member>
-		<member name="params/hue_variation" type="float" setter="set_param" getter="get_param" brief="">
-		</member>
-		<member name="params/initial_angle" type="float" setter="set_param" getter="get_param" brief="">
-		</member>
-		<member name="params/initial_size" type="float" setter="set_param" getter="get_param" brief="">
-		</member>
-		<member name="params/linear_velocity" type="float" setter="set_param" getter="get_param" brief="">
-		</member>
-		<member name="params/orbit_velocity" type="float" setter="set_param" getter="get_param" brief="">
-		</member>
-		<member name="params/radial_accel" type="float" setter="set_param" getter="get_param" brief="">
-		</member>
-		<member name="params/spin_velocity" type="float" setter="set_param" getter="get_param" brief="">
-		</member>
-		<member name="params/spread" type="float" setter="set_param" getter="get_param" brief="">
-		</member>
-		<member name="params/tangential_accel" type="float" setter="set_param" getter="get_param" brief="">
-		</member>
-		<member name="phase_0/color" type="Color" setter="set_color_phase_color" getter="get_color_phase_color" brief="">
-		</member>
-		<member name="phase_0/pos" type="float" setter="set_color_phase_pos" getter="get_color_phase_pos" brief="">
-		</member>
-		<member name="phase_1/color" type="Color" setter="set_color_phase_color" getter="get_color_phase_color" brief="">
-		</member>
-		<member name="phase_1/pos" type="float" setter="set_color_phase_pos" getter="get_color_phase_pos" brief="">
-		</member>
-		<member name="phase_2/color" type="Color" setter="set_color_phase_color" getter="get_color_phase_color" brief="">
-		</member>
-		<member name="phase_2/pos" type="float" setter="set_color_phase_pos" getter="get_color_phase_pos" brief="">
-		</member>
-		<member name="phase_3/color" type="Color" setter="set_color_phase_color" getter="get_color_phase_color" brief="">
-		</member>
-		<member name="phase_3/pos" type="float" setter="set_color_phase_pos" getter="get_color_phase_pos" brief="">
-		</member>
-		<member name="randomness/anim_initial_pos" type="float" setter="set_randomness" getter="get_randomness" brief="">
-		</member>
-		<member name="randomness/anim_speed_scale" type="float" setter="set_randomness" getter="get_randomness" brief="">
-		</member>
-		<member name="randomness/damping" type="float" setter="set_randomness" getter="get_randomness" brief="">
-		</member>
-		<member name="randomness/direction" type="float" setter="set_randomness" getter="get_randomness" brief="">
-		</member>
-		<member name="randomness/final_size" type="float" setter="set_randomness" getter="get_randomness" brief="">
-		</member>
-		<member name="randomness/gravity_direction" type="float" setter="set_randomness" getter="get_randomness" brief="">
-		</member>
-		<member name="randomness/gravity_strength" type="float" setter="set_randomness" getter="get_randomness" brief="">
-		</member>
-		<member name="randomness/hue_variation" type="float" setter="set_randomness" getter="get_randomness" brief="">
-		</member>
-		<member name="randomness/initial_angle" type="float" setter="set_randomness" getter="get_randomness" brief="">
-		</member>
-		<member name="randomness/initial_size" type="float" setter="set_randomness" getter="get_randomness" brief="">
-		</member>
-		<member name="randomness/linear_velocity" type="float" setter="set_randomness" getter="get_randomness" brief="">
-		</member>
-		<member name="randomness/orbit_velocity" type="float" setter="set_randomness" getter="get_randomness" brief="">
-		</member>
-		<member name="randomness/radial_accel" type="float" setter="set_randomness" getter="get_randomness" brief="">
-		</member>
-		<member name="randomness/spin_velocity" type="float" setter="set_randomness" getter="get_randomness" brief="">
-		</member>
-		<member name="randomness/spread" type="float" setter="set_randomness" getter="get_randomness" brief="">
-		</member>
-		<member name="randomness/tangential_accel" type="float" setter="set_randomness" getter="get_randomness" brief="">
+		<member name="visibility_rect" type="Rect3" setter="set_visibility_rect" getter="get_visibility_rect" brief="">
 		</member>
 	</members>
-	<signals>
-		<signal name="emission_finished">
-			<description>
-			</description>
-		</signal>
-	</signals>
 	<constants>
-		<constant name="PARAM_DIRECTION" value="0">
-			Direction in degrees at which the particles will be launched, Notice that when the direction is set to 0 the particles will be launched to the negative
+		<constant name="DRAW_ORDER_INDEX" value="0">
 		</constant>
-		<constant name="PARAM_SPREAD" value="1">
-		</constant>
-		<constant name="PARAM_LINEAR_VELOCITY" value="2">
-			Velocity at which the particles will be launched.
-		</constant>
-		<constant name="PARAM_SPIN_VELOCITY" value="3">
-			The speed at which particles will spin around its own center.
-		</constant>
-		<constant name="PARAM_ORBIT_VELOCITY" value="4">
-			Velocity at which the particles will orbit around the emitter center
-		</constant>
-		<constant name="PARAM_GRAVITY_DIRECTION" value="5">
-			Direction in degrees at which the particles will be attracted
-		</constant>
-		<constant name="PARAM_GRAVITY_STRENGTH" value="6">
-			Strength of the gravitation attraction for each particle
-		</constant>
-		<constant name="PARAM_RADIAL_ACCEL" value="7">
-		</constant>
-		<constant name="PARAM_TANGENTIAL_ACCEL" value="8">
-		</constant>
-		<constant name="PARAM_DAMPING" value="9">
-			Amount of damping for each particle
-		</constant>
-		<constant name="PARAM_INITIAL_ANGLE" value="10">
-			Initial angle in radians at which each particle will be spawned
-		</constant>
-		<constant name="PARAM_INITIAL_SIZE" value="11">
-			Initial size of each particle
-		</constant>
-		<constant name="PARAM_FINAL_SIZE" value="12">
-			Final size of each particle, the particle size will interpolate to this value during its lifetime.
-		</constant>
-		<constant name="PARAM_HUE_VARIATION" value="13">
-		</constant>
-		<constant name="PARAM_ANIM_SPEED_SCALE" value="14">
-		</constant>
-		<constant name="PARAM_ANIM_INITIAL_POS" value="15">
-		</constant>
-		<constant name="PARAM_MAX" value="16">
-		</constant>
-		<constant name="MAX_COLOR_PHASES" value="4">
+		<constant name="DRAW_ORDER_LIFETIME" value="1">
 		</constant>
 	</constants>
 </class>
@@ -28982,6 +29164,12 @@
 		</method>
 		<method name="get_emission_box_extents" qualifiers="const">
 			<return type="Vector3">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_emission_color_texture" qualifiers="const">
+			<return type="Texture">
 			</return>
 			<description>
 			</description>
@@ -29102,6 +29290,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="set_emission_color_texture">
+			<argument index="0" name="texture" type="Texture">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="set_emission_normal_texture">
 			<argument index="0" name="texture" type="Texture">
 			</argument>
@@ -29214,6 +29408,8 @@
 		</member>
 		<member name="angular_velocity_random" type="float" setter="set_param_randomness" getter="get_param_randomness" brief="">
 		</member>
+		<member name="anim_loop" type="bool" setter="set_flag" getter="get_flag" brief="">
+		</member>
 		<member name="anim_offset" type="float" setter="set_param" getter="get_param" brief="">
 		</member>
 		<member name="anim_offset_curve" type="CurveTexture" setter="set_param_texture" getter="get_param_texture" brief="">
@@ -29238,6 +29434,8 @@
 		</member>
 		<member name="emission_box_extents" type="Vector3" setter="set_emission_box_extents" getter="get_emission_box_extents" brief="">
 		</member>
+		<member name="emission_color_texture" type="Texture" setter="set_emission_color_texture" getter="get_emission_color_texture" brief="">
+		</member>
 		<member name="emission_normal_texture" type="Texture" setter="set_emission_normal_texture" getter="get_emission_normal_texture" brief="">
 		</member>
 		<member name="emission_point_count" type="int" setter="set_emission_point_count" getter="get_emission_point_count" brief="">
@@ -29249,6 +29447,8 @@
 		<member name="emission_sphere_radius" type="float" setter="set_emission_sphere_radius" getter="get_emission_sphere_radius" brief="">
 		</member>
 		<member name="flag_align_y" type="bool" setter="set_flag" getter="get_flag" brief="">
+		</member>
+		<member name="flag_disable_z" type="bool" setter="set_flag" getter="get_flag" brief="">
 		</member>
 		<member name="flag_rotate_y" type="bool" setter="set_flag" getter="get_flag" brief="">
 		</member>
@@ -29336,7 +29536,7 @@
 		</constant>
 		<constant name="FLAG_ROTATE_Y" value="1">
 		</constant>
-		<constant name="FLAG_MAX" value="2">
+		<constant name="FLAG_MAX" value="4">
 		</constant>
 		<constant name="EMISSION_SHAPE_POINT" value="0">
 		</constant>
@@ -30273,6 +30473,16 @@
 				Substitute a given area shape by another. The old shape is selected by its index, the new one by its [RID].
 			</description>
 		</method>
+		<method name="area_set_shape_disabled">
+			<argument index="0" name="area" type="RID">
+			</argument>
+			<argument index="1" name="shape_idx" type="int">
+			</argument>
+			<argument index="2" name="disable" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="area_set_shape_transform">
 			<argument index="0" name="area" type="RID">
 			</argument>
@@ -30434,24 +30644,6 @@
 				Get the instance ID of the object the area is assigned to.
 			</description>
 		</method>
-		<method name="body_get_one_way_collision_direction" qualifiers="const">
-			<return type="Vector2">
-			</return>
-			<argument index="0" name="body" type="RID">
-			</argument>
-			<description>
-				Return the direction used for one-way collision detection.
-			</description>
-		</method>
-		<method name="body_get_one_way_collision_max_depth" qualifiers="const">
-			<return type="float">
-			</return>
-			<argument index="0" name="body" type="RID">
-			</argument>
-			<description>
-				Return how far a body can go through the given one, when it allows one-way collisions.
-			</description>
-		</method>
 		<method name="body_get_param" qualifiers="const">
 			<return type="float">
 			</return>
@@ -30528,17 +30720,6 @@
 			</argument>
 			<description>
 				Return whether a body uses a callback function to calculate its own physics (see [method body_set_force_integration_callback]).
-			</description>
-		</method>
-		<method name="body_is_shape_set_as_trigger" qualifiers="const">
-			<return type="bool">
-			</return>
-			<argument index="0" name="body" type="RID">
-			</argument>
-			<argument index="1" name="shape_idx" type="int">
-			</argument>
-			<description>
-				Return whether a body's shape is marked as a trigger.
 			</description>
 		</method>
 		<method name="body_remove_collision_exception">
@@ -30636,24 +30817,6 @@
 				Set whether a body uses a callback function to calculate its own physics (see [method body_set_force_integration_callback]).
 			</description>
 		</method>
-		<method name="body_set_one_way_collision_direction">
-			<argument index="0" name="body" type="RID">
-			</argument>
-			<argument index="1" name="normal" type="Vector2">
-			</argument>
-			<description>
-				Set a direction in which bodies can go through the given one. If this value is different from (0,0), any movement within 90 degrees of this vector is considered a valid movement. Set this direction to (0,0) to disable one-way collisions.
-			</description>
-		</method>
-		<method name="body_set_one_way_collision_max_depth">
-			<argument index="0" name="body" type="RID">
-			</argument>
-			<argument index="1" name="depth" type="float">
-			</argument>
-			<description>
-				Set how far a body can go through the given one, if it allows one-way collisions (see [method body_set_one_way_collision_direction]).
-			</description>
-		</method>
 		<method name="body_set_param">
 			<argument index="0" name="body" type="RID">
 			</argument>
@@ -30676,7 +30839,7 @@
 				Substitute a given body shape by another. The old shape is selected by its index, the new one by its [RID].
 			</description>
 		</method>
-		<method name="body_set_shape_as_trigger">
+		<method name="body_set_shape_as_one_way_collision">
 			<argument index="0" name="body" type="RID">
 			</argument>
 			<argument index="1" name="shape_idx" type="int">
@@ -30684,7 +30847,16 @@
 			<argument index="2" name="enable" type="bool">
 			</argument>
 			<description>
-				Mark a body's shape as a trigger. A trigger shape cannot affect other bodies, but detects other shapes entering and exiting it.
+			</description>
+		</method>
+		<method name="body_set_shape_disabled">
+			<argument index="0" name="body" type="RID">
+			</argument>
+			<argument index="1" name="shape_idx" type="int">
+			</argument>
+			<argument index="2" name="disable" type="bool">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="body_set_shape_metadata">
@@ -30968,11 +31140,9 @@
 		<constant name="SPACE_PARAM_BODY_MAX_ALLOWED_PENETRATION" value="2">
 			Constant to set/get the maximum distance a shape can penetrate another shape before it is considered a collision.
 		</constant>
-		<constant name="SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_TRESHOLD" value="3">
-			Constant to set/get the linear velocity threshold. Bodies slower than this will be marked as potentially inactive.
+		<constant name="SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_THRESHOLD" value="3">
 		</constant>
-		<constant name="SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_TRESHOLD" value="4">
-			Constant to set/get the angular velocity threshold. Bodies slower than this will be marked as potentially inactive.
+		<constant name="SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_THRESHOLD" value="4">
 		</constant>
 		<constant name="SPACE_PARAM_BODY_TIME_TO_SLEEP" value="5">
 			Constant to set/get the maximum time of activity. A body marked as potentially inactive for both linear and angular velocity will be put to sleep after this time.
@@ -31512,20 +31682,6 @@
 				Return an individual bit on the collision mask.
 			</description>
 		</method>
-		<method name="get_one_way_collision_direction" qualifiers="const">
-			<return type="Vector2">
-			</return>
-			<description>
-				Return the direction used for one-way collision detection.
-			</description>
-		</method>
-		<method name="get_one_way_collision_max_depth" qualifiers="const">
-			<return type="float">
-			</return>
-			<description>
-				Return how far a body can go through this one, when it allows one-way collisions.
-			</description>
-		</method>
 		<method name="remove_collision_exception_with">
 			<argument index="0" name="body" type="PhysicsBody2D">
 			</argument>
@@ -31567,20 +31723,6 @@
 				Set/clear individual bits on the collision mask. This makes selecting the areas scanned easier.
 			</description>
 		</method>
-		<method name="set_one_way_collision_direction">
-			<argument index="0" name="dir" type="Vector2">
-			</argument>
-			<description>
-				Set a direction in which bodies can go through this one. If this value is different from (0,0), any movement within 90 degrees of this vector is considered a valid movement. Set this direction to (0,0) to disable one-way collisions.
-			</description>
-		</method>
-		<method name="set_one_way_collision_max_depth">
-			<argument index="0" name="depth" type="float">
-			</argument>
-			<description>
-				Set how far a body can go through this one, when it allows one-way collisions (see [method set_one_way_collision_direction]).
-			</description>
-		</method>
 	</methods>
 	<members>
 		<member name="collision_layer" type="int" setter="set_collision_layer" getter="get_collision_layer" brief="">
@@ -31588,10 +31730,6 @@
 		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" brief="">
 		</member>
 		<member name="layers" type="int" setter="_set_layers" getter="_get_layers" brief="">
-		</member>
-		<member name="one_way_collision/direction" type="Vector2" setter="set_one_way_collision_direction" getter="get_one_way_collision_direction" brief="">
-		</member>
-		<member name="one_way_collision/max_depth" type="float" setter="set_one_way_collision_max_depth" getter="get_one_way_collision_max_depth" brief="">
 		</member>
 	</members>
 	<constants>
@@ -33793,7 +33931,7 @@
 			<argument index="0" name="compression_mode" type="int" default="0">
 			</argument>
 			<description>
-			Returns a new [PoolByteArray] with the data compressed. The compression mode can be set using one of the COMPRESS_* constants of [File].
+				Returns a new [PoolByteArray] with the data compressed. The compression mode can be set using one of the COMPRESS_* constants of [File].
 			</description>
 		</method>
 		<method name="decompress">
@@ -33804,7 +33942,7 @@
 			<argument index="1" name="compression_mode" type="int" default="0">
 			</argument>
 			<description>
-			Returns a new [PoolByteArray] with the data decompressed. The buffer_size should be set as the size of the uncompressed data. The compression mode can be set using one of the COMPRESS_* constants of [File].
+				Returns a new [PoolByteArray] with the data decompressed. The buffer_size should be set as the size of the uncompressed data. The compression mode can be set using one of the COMPRESS_* constants of [File].
 			</description>
 		</method>
 		<method name="get_string_from_ascii">
@@ -34678,6 +34816,8 @@
 			</description>
 		</method>
 		<method name="get_item_metadata" qualifiers="const">
+			<return type="Variant">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
@@ -34718,6 +34858,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="is_hide_on_checkable_item_selection">
+			<return type="bool">
+			</return>
+			<description>
+				Returns a boolean that indicates whether or not the PopupMenu will hide on checkable item selection.
+			</description>
+		</method>
 		<method name="is_hide_on_item_selection">
 			<return type="bool">
 			</return>
@@ -34725,13 +34872,6 @@
 				Returns a boolean that indicates whether or not the PopupMenu will hide on item selection.
 			</description>
 		</method>
-                <method name="is_hide_on_checkable_item_selection">
-                        <return type="bool">
-                        </return>
-                        <description>
-                                Returns a boolean that indicates whether or not the PopupMenu will hide on checkable item selection.
-                        </description>
-                </method>
 		<method name="is_item_checkable" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -34775,6 +34915,13 @@
 				Removes the item at index "idx" from the menu. Note that the indexes of items after the removed item are going to be shifted by one.
 			</description>
 		</method>
+		<method name="set_hide_on_checkable_item_selection">
+			<argument index="0" name="enable" type="bool">
+			</argument>
+			<description>
+				Sets whether or not the PopupMenu will hide on checkable item selection.
+			</description>
+		</method>
 		<method name="set_hide_on_item_selection">
 			<argument index="0" name="enable" type="bool">
 			</argument>
@@ -34782,13 +34929,6 @@
 				Sets whether or not the PopupMenu will hide on item selection.
 			</description>
 		</method>
-                <method name="set_hide_on_checkable_item_selection">
-                        <argument index="0" name="enable" type="bool">
-                        </argument>
-                        <description>
-                                Sets whether or not the PopupMenu will hide on checkable item selection.
-                        </description>
-                </method>
 		<method name="set_item_ID">
 			<argument index="0" name="idx" type="int">
 			</argument>
@@ -34905,6 +35045,8 @@
 		</method>
 	</methods>
 	<members>
+		<member name="hide_on_checkable_item_selection" type="bool" setter="set_hide_on_checkable_item_selection" getter="is_hide_on_checkable_item_selection" brief="">
+		</member>
 		<member name="hide_on_item_selection" type="bool" setter="set_hide_on_item_selection" getter="is_hide_on_item_selection" brief="">
 		</member>
 		<member name="items" type="Array" setter="_set_items" getter="_get_items" brief="">
@@ -36580,8 +36722,7 @@
 		<member name="end" type="Vector3" setter="" getter="" brief="">
 			Ending corner.
 		</member>
-		<member name="pos" type="Vector3" setter="" getter="" brief="">
-			Position (starting corner).
+		<member name="position" type="Vector3" setter="" getter="" brief="">
 		</member>
 		<member name="size" type="Vector3" setter="" getter="" brief="">
 			Size from position to end.
@@ -36924,7 +37065,7 @@
 			</description>
 		</method>
 		<method name="search" qualifiers="const">
-			<return type="Object">
+			<return type="RegExMatch">
 			</return>
 			<argument index="0" name="text" type="String">
 			</argument>
@@ -37472,6 +37613,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_percent_visible" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="get_tab_size" qualifiers="const">
 			<return type="int">
 			</return>
@@ -37492,7 +37639,7 @@
 			</description>
 		</method>
 		<method name="get_v_scroll">
-			<return type="Object">
+			<return type="VScrollBar">
 			</return>
 			<description>
 			</description>
@@ -37567,7 +37714,7 @@
 			</description>
 		</method>
 		<method name="push_font">
-			<argument index="0" name="font" type="Object">
+			<argument index="0" name="font" type="Font">
 			</argument>
 			<description>
 			</description>
@@ -37626,6 +37773,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="set_percent_visible">
+			<argument index="0" name="percent_visible" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="set_scroll_active">
 			<argument index="0" name="active" type="bool">
 			</argument>
@@ -37661,6 +37814,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="set_text">
+			<argument index="0" name="text" type="String">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="set_use_bbcode">
 			<argument index="0" name="enable" type="bool">
 			</argument>
@@ -37678,6 +37837,8 @@
 		<member name="bbcode_enabled" type="bool" setter="set_use_bbcode" getter="is_using_bbcode" brief="">
 		</member>
 		<member name="bbcode_text" type="String" setter="set_bbcode" getter="get_bbcode" brief="">
+		</member>
+		<member name="percent_visible" type="float" setter="set_percent_visible" getter="get_percent_visible" brief="">
 		</member>
 		<member name="visible_characters" type="int" setter="set_visible_characters" getter="get_visible_characters" brief="">
 		</member>
@@ -38761,6 +38922,8 @@
 			</description>
 		</method>
 		<method name="get_node_property_value" qualifiers="const">
+			<return type="Variant">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<argument index="1" name="prop_idx" type="int">
@@ -38858,6 +39021,12 @@
 		</method>
 		<method name="get_frame" qualifiers="const">
 			<return type="int">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_network_connected_peers" qualifiers="const">
+			<return type="PoolIntArray">
 			</return>
 			<description>
 			</description>
@@ -39507,6 +39676,8 @@
 			</description>
 		</method>
 		<method name="get_shader_param" qualifiers="const">
+			<return type="Variant">
+			</return>
 			<argument index="0" name="param" type="String">
 			</argument>
 			<description>
@@ -40497,6 +40668,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_grow" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="get_line_width" qualifiers="const">
 			<return type="float">
 			</return>
@@ -40569,6 +40746,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_specular_mode" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="get_subsurface_scattering_strength" qualifiers="const">
 			<return type="float">
 			</return>
@@ -40584,30 +40767,48 @@
 			</description>
 		</method>
 		<method name="get_uv1_offset" qualifiers="const">
-			<return type="Vector2">
+			<return type="Vector3">
 			</return>
 			<description>
 			</description>
 		</method>
 		<method name="get_uv1_scale" qualifiers="const">
-			<return type="Vector2">
+			<return type="Vector3">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_uv1_triplanar_blend_sharpness" qualifiers="const">
+			<return type="float">
 			</return>
 			<description>
 			</description>
 		</method>
 		<method name="get_uv2_offset" qualifiers="const">
-			<return type="Vector2">
+			<return type="Vector3">
 			</return>
 			<description>
 			</description>
 		</method>
 		<method name="get_uv2_scale" qualifiers="const">
-			<return type="Vector2">
+			<return type="Vector3">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_uv2_triplanar_blend_sharpness" qualifiers="const">
+			<return type="float">
 			</return>
 			<description>
 			</description>
 		</method>
 		<method name="is_depth_deep_parallax_enabled" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="is_grow_enabled" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
@@ -40731,6 +40932,18 @@
 			<description>
 			</description>
 		</method>
+		<method name="set_grow">
+			<argument index="0" name="amount" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_grow_enabled">
+			<argument index="0" name="enable" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="set_line_width">
 			<argument index="0" name="line_width" type="float">
 			</argument>
@@ -40803,6 +41016,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="set_specular_mode">
+			<argument index="0" name="specular_mode" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="set_subsurface_scattering_strength">
 			<argument index="0" name="strength" type="float">
 			</argument>
@@ -40818,25 +41037,37 @@
 			</description>
 		</method>
 		<method name="set_uv1_offset">
-			<argument index="0" name="offset" type="Vector2">
+			<argument index="0" name="offset" type="Vector3">
 			</argument>
 			<description>
 			</description>
 		</method>
 		<method name="set_uv1_scale">
-			<argument index="0" name="scale" type="Vector2">
+			<argument index="0" name="scale" type="Vector3">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_uv1_triplanar_blend_sharpness">
+			<argument index="0" name="sharpness" type="float">
 			</argument>
 			<description>
 			</description>
 		</method>
 		<method name="set_uv2_offset">
-			<argument index="0" name="offset" type="Vector2">
+			<argument index="0" name="offset" type="Vector3">
 			</argument>
 			<description>
 			</description>
 		</method>
 		<method name="set_uv2_scale">
-			<argument index="0" name="scale" type="Vector2">
+			<argument index="0" name="scale" type="Vector3">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_uv2_triplanar_blend_sharpness">
+			<argument index="0" name="sharpness" type="float">
 			</argument>
 			<description>
 			</description>
@@ -40847,7 +41078,7 @@
 		</member>
 		<member name="albedo_texture" type="Texture" setter="set_texture" getter="get_texture" brief="">
 		</member>
-		<member name="anisotropy_anisotropy" type="float" setter="set_anisotropy" getter="get_anisotropy" brief="">
+		<member name="anisotropy" type="float" setter="set_anisotropy" getter="get_anisotropy" brief="">
 		</member>
 		<member name="anisotropy_enabled" type="bool" setter="set_feature" getter="get_feature" brief="">
 		</member>
@@ -40855,9 +41086,11 @@
 		</member>
 		<member name="ao_enabled" type="bool" setter="set_feature" getter="get_feature" brief="">
 		</member>
+		<member name="ao_on_uv2" type="bool" setter="set_flag" getter="get_flag" brief="">
+		</member>
 		<member name="ao_texture" type="Texture" setter="set_texture" getter="get_texture" brief="">
 		</member>
-		<member name="clearcoat_amount" type="float" setter="set_clearcoat" getter="get_clearcoat" brief="">
+		<member name="clearcoat" type="float" setter="set_clearcoat" getter="get_clearcoat" brief="">
 		</member>
 		<member name="clearcoat_enabled" type="bool" setter="set_feature" getter="get_feature" brief="">
 		</member>
@@ -40889,7 +41122,7 @@
 		</member>
 		<member name="detail_uv_layer" type="int" setter="set_detail_uv" getter="get_detail_uv" brief="">
 		</member>
-		<member name="emission_color" type="Color" setter="set_emission" getter="get_emission" brief="">
+		<member name="emission" type="Color" setter="set_emission" getter="get_emission" brief="">
 		</member>
 		<member name="emission_enabled" type="bool" setter="set_feature" getter="get_feature" brief="">
 		</member>
@@ -40907,7 +41140,7 @@
 		</member>
 		<member name="flags_use_point_size" type="bool" setter="set_flag" getter="get_flag" brief="">
 		</member>
-		<member name="metallic_amount" type="float" setter="set_metallic" getter="get_metallic" brief="">
+		<member name="metallic" type="float" setter="set_metallic" getter="get_metallic" brief="">
 		</member>
 		<member name="metallic_specular" type="float" setter="set_specular" getter="get_specular" brief="">
 		</member>
@@ -40929,9 +41162,15 @@
 		</member>
 		<member name="params_diffuse_mode" type="int" setter="set_diffuse_mode" getter="get_diffuse_mode" brief="">
 		</member>
+		<member name="params_grow" type="bool" setter="set_grow_enabled" getter="is_grow_enabled" brief="">
+		</member>
+		<member name="params_grow_amount" type="float" setter="set_grow" getter="get_grow" brief="">
+		</member>
 		<member name="params_line_width" type="float" setter="set_line_width" getter="get_line_width" brief="">
 		</member>
 		<member name="params_point_size" type="float" setter="set_point_size" getter="get_point_size" brief="">
+		</member>
+		<member name="params_specular_mode" type="int" setter="set_specular_mode" getter="get_specular_mode" brief="">
 		</member>
 		<member name="particles_anim_h_frames" type="int" setter="set_particles_anim_h_frames" getter="get_particles_anim_h_frames" brief="">
 		</member>
@@ -40945,7 +41184,7 @@
 		</member>
 		<member name="refraction_texture" type="Texture" setter="set_texture" getter="get_texture" brief="">
 		</member>
-		<member name="rim_amount" type="float" setter="set_rim" getter="get_rim" brief="">
+		<member name="rim" type="float" setter="set_rim" getter="get_rim" brief="">
 		</member>
 		<member name="rim_enabled" type="bool" setter="set_feature" getter="get_feature" brief="">
 		</member>
@@ -40953,7 +41192,7 @@
 		</member>
 		<member name="rim_tint" type="float" setter="set_rim_tint" getter="get_rim_tint" brief="">
 		</member>
-		<member name="roughness_amount" type="float" setter="set_roughness" getter="get_roughness" brief="">
+		<member name="roughness" type="float" setter="set_roughness" getter="get_roughness" brief="">
 		</member>
 		<member name="roughness_texture" type="Texture" setter="set_texture" getter="get_texture" brief="">
 		</member>
@@ -40963,13 +41202,21 @@
 		</member>
 		<member name="subsurf_scatter_texture" type="Texture" setter="set_texture" getter="get_texture" brief="">
 		</member>
-		<member name="uv1_offset" type="Vector2" setter="set_uv1_offset" getter="get_uv1_offset" brief="">
+		<member name="uv1_offset" type="Vector3" setter="set_uv1_offset" getter="get_uv1_offset" brief="">
 		</member>
-		<member name="uv1_scale" type="Vector2" setter="set_uv1_scale" getter="get_uv1_scale" brief="">
+		<member name="uv1_scale" type="Vector3" setter="set_uv1_scale" getter="get_uv1_scale" brief="">
 		</member>
-		<member name="uv2_offset" type="Vector2" setter="set_uv2_offset" getter="get_uv2_offset" brief="">
+		<member name="uv1_triplanar" type="bool" setter="set_flag" getter="get_flag" brief="">
 		</member>
-		<member name="uv2_scale" type="Vector2" setter="set_uv2_scale" getter="get_uv2_scale" brief="">
+		<member name="uv1_triplanar_sharpness" type="float" setter="set_uv1_triplanar_blend_sharpness" getter="get_uv1_triplanar_blend_sharpness" brief="">
+		</member>
+		<member name="uv2_offset" type="Vector3" setter="set_uv2_offset" getter="get_uv2_offset" brief="">
+		</member>
+		<member name="uv2_scale" type="Vector3" setter="set_uv2_scale" getter="get_uv2_scale" brief="">
+		</member>
+		<member name="uv2_triplanar" type="bool" setter="set_flag" getter="get_flag" brief="">
+		</member>
+		<member name="uv2_triplanar_sharpness" type="float" setter="set_uv2_triplanar_blend_sharpness" getter="get_uv2_triplanar_blend_sharpness" brief="">
 		</member>
 		<member name="vertex_color_is_srgb" type="bool" setter="set_flag" getter="get_flag" brief="">
 		</member>
@@ -41071,7 +41318,7 @@
 		</constant>
 		<constant name="FLAG_FIXED_SIZE" value="5">
 		</constant>
-		<constant name="FLAG_MAX" value="6">
+		<constant name="FLAG_MAX" value="9">
 		</constant>
 		<constant name="DIFFUSE_LAMBERT" value="0">
 		</constant>
@@ -41080,6 +41327,18 @@
 		<constant name="DIFFUSE_OREN_NAYAR" value="2">
 		</constant>
 		<constant name="DIFFUSE_BURLEY" value="3">
+		</constant>
+		<constant name="DIFFUSE_TOON" value="4">
+		</constant>
+		<constant name="SPECULAR_SCHLICK_GGX" value="0">
+		</constant>
+		<constant name="SPECULAR_BLINN" value="1">
+		</constant>
+		<constant name="SPECULAR_PHONG" value="2">
+		</constant>
+		<constant name="SPECULAR_TOON" value="3">
+		</constant>
+		<constant name="SPECULAR_DISABLED" value="4">
 		</constant>
 		<constant name="BILLBOARD_DISABLED" value="0">
 		</constant>
@@ -41394,6 +41653,12 @@
 				Return the amount of horizontal frames. See [method set_hframes].
 			</description>
 		</method>
+		<method name="get_normal_map" qualifiers="const">
+			<return type="Texture">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="get_offset" qualifiers="const">
 			<return type="Vector2">
 			</return>
@@ -41450,6 +41715,12 @@
 				Return if the sprite reads from a region.
 			</description>
 		</method>
+		<method name="is_region_filter_clip_enabled" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="set_centered">
 			<argument index="0" name="centered" type="bool">
 			</argument>
@@ -41485,6 +41756,12 @@
 				Set the amount of horizontal frames and converts the sprite into a sprite-sheet. This is useful for animation.
 			</description>
 		</method>
+		<method name="set_normal_map">
+			<argument index="0" name="normal_map" type="Texture">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="set_offset">
 			<argument index="0" name="offset" type="Vector2">
 			</argument>
@@ -41497,6 +41774,12 @@
 			</argument>
 			<description>
 				Set the sprite as a sub-region of a bigger texture. Useful for texture-atlases.
+			</description>
+		</method>
+		<method name="set_region_filter_clip">
+			<argument index="0" name="enabled" type="bool">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="set_region_rect">
@@ -41532,9 +41815,13 @@
 		</member>
 		<member name="hframes" type="int" setter="set_hframes" getter="get_hframes" brief="">
 		</member>
+		<member name="normal_map" type="Texture" setter="set_normal_map" getter="get_normal_map" brief="">
+		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" brief="">
 		</member>
-		<member name="region" type="bool" setter="set_region" getter="is_region" brief="">
+		<member name="region_enabled" type="bool" setter="set_region" getter="is_region" brief="">
+		</member>
+		<member name="region_filter_clip" type="bool" setter="set_region_filter_clip" getter="is_region_filter_clip_enabled" brief="">
 		</member>
 		<member name="region_rect" type="Rect2" setter="set_region_rect" getter="get_region_rect" brief="">
 		</member>
@@ -41640,7 +41927,7 @@
 		</member>
 		<member name="hframes" type="int" setter="set_hframes" getter="get_hframes" brief="">
 		</member>
-		<member name="region" type="bool" setter="set_region" getter="is_region" brief="">
+		<member name="region_enabled" type="bool" setter="set_region" getter="is_region" brief="">
 		</member>
 		<member name="region_rect" type="Rect2" setter="set_region_rect" getter="get_region_rect" brief="">
 		</member>
@@ -41802,6 +42089,8 @@
 		</member>
 		<member name="centered" type="bool" setter="set_centered" getter="is_centered" brief="">
 		</member>
+		<member name="double_sided" type="bool" setter="set_draw_flag" getter="get_draw_flag" brief="">
+		</member>
 		<member name="flip_h" type="bool" setter="set_flip_h" getter="is_flipped_h" brief="">
 		</member>
 		<member name="flip_v" type="bool" setter="set_flip_v" getter="is_flipped_v" brief="">
@@ -41824,7 +42113,9 @@
 		</constant>
 		<constant name="FLAG_SHADED" value="1">
 		</constant>
-		<constant name="FLAG_MAX" value="2">
+		<constant name="FLAG_DOUBLE_SIDED" value="2">
+		</constant>
+		<constant name="FLAG_MAX" value="3">
 		</constant>
 		<constant name="ALPHA_CUT_DISABLED" value="0">
 		</constant>
@@ -43543,6 +43834,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_normal_map" qualifiers="const">
+			<return type="Texture">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="get_region_rect" qualifiers="const">
 			<return type="Rect2">
 			</return>
@@ -43583,6 +43880,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="set_normal_map">
+			<argument index="0" name="normal_map" type="Texture">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="set_region_rect">
 			<argument index="0" name="region" type="Rect2">
 			</argument>
@@ -43616,6 +43919,8 @@
 		<member name="margin_top" type="float" setter="set_margin_size" getter="get_margin_size" brief="">
 		</member>
 		<member name="modulate_color" type="Color" setter="set_modulate" getter="get_modulate" brief="">
+		</member>
+		<member name="normal_map" type="Texture" setter="set_normal_map" getter="get_normal_map" brief="">
 		</member>
 		<member name="region_rect" type="Rect2" setter="set_region_rect" getter="get_region_rect" brief="">
 		</member>
@@ -44713,6 +45018,8 @@
 			</argument>
 			<argument index="3" name="transpose" type="bool" default="false">
 			</argument>
+			<argument index="4" name="normal_map" type="Texture" default="NULL">
+			</argument>
 			<description>
 			</description>
 		</method>
@@ -44727,6 +45034,8 @@
 			</argument>
 			<argument index="4" name="transpose" type="bool" default="false">
 			</argument>
+			<argument index="5" name="normal_map" type="Texture" default="NULL">
+			</argument>
 			<description>
 			</description>
 		</method>
@@ -44740,6 +45049,10 @@
 			<argument index="3" name="modulate" type="Color" default="Color(1,1,1,1)">
 			</argument>
 			<argument index="4" name="transpose" type="bool" default="false">
+			</argument>
+			<argument index="5" name="normal_map" type="Texture" default="NULL">
+			</argument>
+			<argument index="6" name="clip_uv" type="bool" default="true">
 			</argument>
 			<description>
 			</description>
@@ -45998,6 +46311,18 @@
 				Remove the tile referenced by the given ID.
 			</description>
 		</method>
+		<method name="tile_add_shape">
+			<argument index="0" name="id" type="int">
+			</argument>
+			<argument index="1" name="shape" type="Shape2D">
+			</argument>
+			<argument index="2" name="shape_transform" type="Transform2D">
+			</argument>
+			<argument index="3" name="one_way" type="bool" default="false">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="tile_get_light_occluder" qualifiers="const">
 			<return type="OccluderPolygon2D">
 			</return>
@@ -46043,6 +46368,14 @@
 				Return the offset of the tile's navigation polygon.
 			</description>
 		</method>
+		<method name="tile_get_normal_map" qualifiers="const">
+			<return type="Texture">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="tile_get_occluder_offset" qualifiers="const">
 			<return type="Vector2">
 			</return>
@@ -46066,17 +46399,37 @@
 			</return>
 			<argument index="0" name="id" type="int">
 			</argument>
+			<argument index="1" name="shape_id" type="int">
+			</argument>
 			<description>
-				Return the shape of the tile.
 			</description>
 		</method>
-		<method name="tile_get_shape_offset" qualifiers="const">
-			<return type="Vector2">
+		<method name="tile_get_shape_count" qualifiers="const">
+			<return type="int">
 			</return>
 			<argument index="0" name="id" type="int">
 			</argument>
 			<description>
-				Return the shape offset of the tile.
+			</description>
+		</method>
+		<method name="tile_get_shape_one_way" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<argument index="1" name="shape_id" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="tile_get_shape_transform" qualifiers="const">
+			<return type="Transform2D">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<argument index="1" name="shape_id" type="int">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="tile_get_shapes" qualifiers="const">
@@ -46151,6 +46504,14 @@
 				Set an offset for the tile's navigation polygon.
 			</description>
 		</method>
+		<method name="tile_set_normal_map">
+			<argument index="0" name="id" type="int">
+			</argument>
+			<argument index="1" name="normal_map" type="Texture">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="tile_set_occluder_offset">
 			<argument index="0" name="id" type="int">
 			</argument>
@@ -46172,19 +46533,31 @@
 		<method name="tile_set_shape">
 			<argument index="0" name="id" type="int">
 			</argument>
-			<argument index="1" name="shape" type="Shape2D">
+			<argument index="1" name="shape_id" type="int">
+			</argument>
+			<argument index="2" name="shape" type="Shape2D">
 			</argument>
 			<description>
-				Set a shape for the tile, enabling physics to collide with it.
 			</description>
 		</method>
-		<method name="tile_set_shape_offset">
+		<method name="tile_set_shape_one_way">
 			<argument index="0" name="id" type="int">
 			</argument>
-			<argument index="1" name="shape_offset" type="Vector2">
+			<argument index="1" name="shape_id" type="int">
+			</argument>
+			<argument index="2" name="one_way" type="bool">
 			</argument>
 			<description>
-				Set the shape offset of the tile.
+			</description>
+		</method>
+		<method name="tile_set_shape_transform">
+			<argument index="0" name="id" type="int">
+			</argument>
+			<argument index="1" name="shape_id" type="int">
+			</argument>
+			<argument index="2" name="shape_transform" type="Transform2D">
+			</argument>
+			<description>
 			</description>
 		</method>
 		<method name="tile_set_shapes">
@@ -46830,7 +47203,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="o" type="Vector2" setter="" getter="" brief="">
+		<member name="origin" type="Vector2" setter="" getter="" brief="">
 		</member>
 		<member name="x" type="Vector2" setter="" getter="" brief="">
 		</member>
@@ -47497,6 +47870,14 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_expand_right" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="column" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="get_icon" qualifiers="const">
 			<return type="Texture">
 			</return>
@@ -47581,6 +47962,14 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_text_align" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="column" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="get_tooltip" qualifiers="const">
 			<return type="String">
 			</return>
@@ -47626,6 +48015,12 @@
 			</return>
 			<argument index="0" name="column" type="int">
 			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="is_folding_disabled" qualifiers="const">
+			<return type="bool">
+			</return>
 			<description>
 			</description>
 		</method>
@@ -47735,10 +48130,24 @@
 			<description>
 			</description>
 		</method>
+		<method name="set_disable_folding">
+			<argument index="0" name="disable" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="set_editable">
 			<argument index="0" name="column" type="int">
 			</argument>
 			<argument index="1" name="enabled" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_expand_right">
+			<argument index="0" name="column" type="int">
+			</argument>
+			<argument index="1" name="enable" type="bool">
 			</argument>
 			<description>
 			</description>
@@ -47809,6 +48218,14 @@
 			<argument index="0" name="column" type="int">
 			</argument>
 			<argument index="1" name="text" type="String">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_text_align">
+			<argument index="0" name="column" type="int">
+			</argument>
+			<argument index="1" name="text_align" type="int">
 			</argument>
 			<description>
 			</description>
@@ -48745,12 +49162,6 @@ do_property].
 		</method>
 	</methods>
 	<members>
-		<member name="height" type="float" setter="" getter="" brief="">
-			Height of the vector (Same as Y).
-		</member>
-		<member name="width" type="float" setter="" getter="" brief="">
-			Width of the vector (Same as X).
-		</member>
 		<member name="x" type="float" setter="" getter="" brief="">
 			X component of the vector.
 		</member>
@@ -50944,6 +51355,8 @@ do_property].
 			</description>
 		</method>
 		<method name="get_constant_value" qualifiers="const">
+			<return type="Variant">
+			</return>
 			<description>
 			</description>
 		</method>
@@ -50961,9 +51374,9 @@ do_property].
 		</method>
 	</methods>
 	<members>
-		<member name="constant/type" type="int" setter="set_constant_type" getter="get_constant_type" brief="">
+		<member name="type" type="int" setter="set_constant_type" getter="get_constant_type" brief="">
 		</member>
-		<member name="constant/value" type="Nil" setter="set_constant_value" getter="get_constant_value" brief="">
+		<member name="value" type="Nil" setter="set_constant_value" getter="get_constant_value" brief="">
 		</member>
 	</members>
 	<constants>
@@ -51185,7 +51598,7 @@ do_property].
 		</method>
 	</methods>
 	<members>
-		<member name="signal/signal" type="String" setter="set_signal" getter="get_signal" brief="">
+		<member name="signal" type="String" setter="set_signal" getter="get_signal" brief="">
 		</member>
 	</members>
 	<constants>
@@ -51365,27 +51778,27 @@ do_property].
 		</method>
 	</methods>
 	<members>
-		<member name="function/argument_cache" type="Dictionary" setter="_set_argument_cache" getter="_get_argument_cache" brief="">
+		<member name="argument_cache" type="Dictionary" setter="_set_argument_cache" getter="_get_argument_cache" brief="">
 		</member>
-		<member name="function/base_script" type="String" setter="set_base_script" getter="get_base_script" brief="">
+		<member name="base_script" type="String" setter="set_base_script" getter="get_base_script" brief="">
 		</member>
-		<member name="function/base_type" type="String" setter="set_base_type" getter="get_base_type" brief="">
+		<member name="base_type" type="String" setter="set_base_type" getter="get_base_type" brief="">
 		</member>
-		<member name="function/basic_type" type="int" setter="set_basic_type" getter="get_basic_type" brief="">
+		<member name="basic_type" type="int" setter="set_basic_type" getter="get_basic_type" brief="">
 		</member>
-		<member name="function/call_mode" type="int" setter="set_call_mode" getter="get_call_mode" brief="">
+		<member name="call_mode" type="int" setter="set_call_mode" getter="get_call_mode" brief="">
 		</member>
-		<member name="function/function" type="String" setter="set_function" getter="get_function" brief="">
+		<member name="function" type="String" setter="set_function" getter="get_function" brief="">
 		</member>
-		<member name="function/node_path" type="NodePath" setter="set_base_path" getter="get_base_path" brief="">
+		<member name="node_path" type="NodePath" setter="set_base_path" getter="get_base_path" brief="">
 		</member>
-		<member name="function/singleton" type="String" setter="set_singleton" getter="get_singleton" brief="">
+		<member name="rpc_call_mode" type="int" setter="set_rpc_call_mode" getter="get_rpc_call_mode" brief="">
 		</member>
-		<member name="function/use_default_args" type="int" setter="set_use_default_args" getter="get_use_default_args" brief="">
+		<member name="singleton" type="String" setter="set_singleton" getter="get_singleton" brief="">
 		</member>
-		<member name="function/validate" type="bool" setter="set_validate" getter="get_validate" brief="">
+		<member name="use_default_args" type="int" setter="set_use_default_args" getter="get_use_default_args" brief="">
 		</member>
-		<member name="rpc/call_mode" type="int" setter="set_rpc_call_mode" getter="get_rpc_call_mode" brief="">
+		<member name="validate" type="bool" setter="set_validate" getter="get_validate" brief="">
 		</member>
 	</members>
 	<constants>
@@ -51561,9 +51974,9 @@ do_property].
 		</method>
 	</methods>
 	<members>
-		<member name="variable/name" type="String" setter="set_var_name" getter="get_var_name" brief="">
+		<member name="type" type="int" setter="set_var_type" getter="get_var_type" brief="">
 		</member>
-		<member name="variable/type" type="int" setter="set_var_type" getter="get_var_type" brief="">
+		<member name="var_name" type="String" setter="set_var_name" getter="get_var_name" brief="">
 		</member>
 	</members>
 	<constants>
@@ -51601,9 +52014,9 @@ do_property].
 		</method>
 	</methods>
 	<members>
-		<member name="variable/name" type="String" setter="set_var_name" getter="get_var_name" brief="">
+		<member name="type" type="int" setter="set_var_type" getter="get_var_type" brief="">
 		</member>
-		<member name="variable/type" type="int" setter="set_var_type" getter="get_var_type" brief="">
+		<member name="var_name" type="String" setter="set_var_name" getter="get_var_name" brief="">
 		</member>
 	</members>
 	<constants>
@@ -51709,9 +52122,9 @@ do_property].
 		</method>
 	</methods>
 	<members>
-		<member name="operator_value/type" type="int" setter="set_operator" getter="get_operator" brief="">
+		<member name="operator" type="int" setter="set_operator" getter="get_operator" brief="">
 		</member>
-		<member name="typed_value/typed" type="int" setter="set_typed" getter="get_typed" brief="">
+		<member name="type" type="int" setter="set_typed" getter="get_typed" brief="">
 		</member>
 	</members>
 	<constants>
@@ -51779,6 +52192,12 @@ do_property].
 			<description>
 			</description>
 		</method>
+		<method name="get_index" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="get_property" qualifiers="const">
 			<return type="String">
 			</return>
@@ -51815,6 +52234,12 @@ do_property].
 			<description>
 			</description>
 		</method>
+		<method name="set_index">
+			<argument index="0" name="index" type="String">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="set_property">
 			<argument index="0" name="property" type="String">
 			</argument>
@@ -51823,19 +52248,21 @@ do_property].
 		</method>
 	</methods>
 	<members>
-		<member name="property/base_script" type="String" setter="set_base_script" getter="get_base_script" brief="">
+		<member name="base_script" type="String" setter="set_base_script" getter="get_base_script" brief="">
 		</member>
-		<member name="property/base_type" type="String" setter="set_base_type" getter="get_base_type" brief="">
+		<member name="base_type" type="String" setter="set_base_type" getter="get_base_type" brief="">
 		</member>
-		<member name="property/basic_type" type="int" setter="set_basic_type" getter="get_basic_type" brief="">
+		<member name="basic_type" type="int" setter="set_basic_type" getter="get_basic_type" brief="">
 		</member>
-		<member name="property/node_path" type="NodePath" setter="set_base_path" getter="get_base_path" brief="">
+		<member name="index" type="String" setter="set_index" getter="get_index" brief="">
 		</member>
-		<member name="property/property" type="String" setter="set_property" getter="get_property" brief="">
+		<member name="node_path" type="NodePath" setter="set_base_path" getter="get_base_path" brief="">
 		</member>
-		<member name="property/set_mode" type="int" setter="set_call_mode" getter="get_call_mode" brief="">
+		<member name="property" type="String" setter="set_property" getter="get_property" brief="">
 		</member>
-		<member name="property/type_cache" type="int" setter="_set_type_cache" getter="_get_type_cache" brief="">
+		<member name="set_mode" type="int" setter="set_call_mode" getter="get_call_mode" brief="">
+		</member>
+		<member name="type_cache" type="int" setter="_set_type_cache" getter="_get_type_cache" brief="">
 		</member>
 	</members>
 	<constants>
@@ -51853,6 +52280,12 @@ do_property].
 	<description>
 	</description>
 	<methods>
+		<method name="get_assign_op" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="get_base_path" qualifiers="const">
 			<return type="NodePath">
 			</return>
@@ -51883,9 +52316,21 @@ do_property].
 			<description>
 			</description>
 		</method>
+		<method name="get_index" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="get_property" qualifiers="const">
 			<return type="String">
 			</return>
+			<description>
+			</description>
+		</method>
+		<method name="set_assign_op">
+			<argument index="0" name="assign_op" type="int">
+			</argument>
 			<description>
 			</description>
 		</method>
@@ -51919,6 +52364,12 @@ do_property].
 			<description>
 			</description>
 		</method>
+		<method name="set_index">
+			<argument index="0" name="index" type="String">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="set_property">
 			<argument index="0" name="property" type="String">
 			</argument>
@@ -51927,19 +52378,23 @@ do_property].
 		</method>
 	</methods>
 	<members>
-		<member name="property/base_script" type="String" setter="set_base_script" getter="get_base_script" brief="">
+		<member name="assign_op" type="int" setter="set_assign_op" getter="get_assign_op" brief="">
 		</member>
-		<member name="property/base_type" type="String" setter="set_base_type" getter="get_base_type" brief="">
+		<member name="base_script" type="String" setter="set_base_script" getter="get_base_script" brief="">
 		</member>
-		<member name="property/basic_type" type="int" setter="set_basic_type" getter="get_basic_type" brief="">
+		<member name="base_type" type="String" setter="set_base_type" getter="get_base_type" brief="">
 		</member>
-		<member name="property/node_path" type="NodePath" setter="set_base_path" getter="get_base_path" brief="">
+		<member name="basic_type" type="int" setter="set_basic_type" getter="get_basic_type" brief="">
 		</member>
-		<member name="property/property" type="String" setter="set_property" getter="get_property" brief="">
+		<member name="index" type="String" setter="set_index" getter="get_index" brief="">
 		</member>
-		<member name="property/set_mode" type="int" setter="set_call_mode" getter="get_call_mode" brief="">
+		<member name="node_path" type="NodePath" setter="set_base_path" getter="get_base_path" brief="">
 		</member>
-		<member name="property/type_cache" type="int" setter="_set_type_cache" getter="_get_type_cache" brief="">
+		<member name="property" type="String" setter="set_property" getter="get_property" brief="">
+		</member>
+		<member name="set_mode" type="int" setter="set_call_mode" getter="get_call_mode" brief="">
+		</member>
+		<member name="type_cache" type="int" setter="_set_type_cache" getter="_get_type_cache" brief="">
 		</member>
 	</members>
 	<constants>
@@ -52009,9 +52464,9 @@ do_property].
 		</method>
 	</methods>
 	<members>
-		<member name="return_value/enabled" type="bool" setter="set_enable_return_value" getter="is_return_value_enabled" brief="">
+		<member name="return_enabled" type="bool" setter="set_enable_return_value" getter="is_return_value_enabled" brief="">
 		</member>
-		<member name="return_value/type" type="int" setter="set_return_type" getter="get_return_type" brief="">
+		<member name="return_type" type="int" setter="set_return_type" getter="get_return_type" brief="">
 		</member>
 	</members>
 	<constants>
@@ -52050,6 +52505,32 @@ do_property].
 	</description>
 	<methods>
 	</methods>
+	<constants>
+	</constants>
+</class>
+<class name="VisualScriptSelect" inherits="VisualScriptNode" category="Core">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<methods>
+		<method name="get_typed" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="set_typed">
+			<argument index="0" name="type" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="type" type="int" setter="set_typed" getter="get_typed" brief="">
+		</member>
+	</members>
 	<constants>
 	</constants>
 </class>
@@ -52147,9 +52628,9 @@ do_property].
 		</method>
 	</methods>
 	<members>
-		<member name="function/base_type" type="String" setter="set_base_type" getter="get_base_type" brief="">
+		<member name="base_script" type="String" setter="set_base_script" getter="get_base_script" brief="">
 		</member>
-		<member name="property/base_script" type="String" setter="set_base_script" getter="get_base_script" brief="">
+		<member name="base_type" type="String" setter="set_base_type" getter="get_base_type" brief="">
 		</member>
 	</members>
 	<constants>
@@ -52175,7 +52656,7 @@ do_property].
 		</method>
 	</methods>
 	<members>
-		<member name="variable/name" type="String" setter="set_variable" getter="get_variable" brief="">
+		<member name="var_name" type="String" setter="set_variable" getter="get_variable" brief="">
 		</member>
 	</members>
 	<constants>
@@ -52201,7 +52682,7 @@ do_property].
 		</method>
 	</methods>
 	<members>
-		<member name="variable/name" type="String" setter="set_variable" getter="get_variable" brief="">
+		<member name="var_name" type="String" setter="set_variable" getter="get_variable" brief="">
 		</member>
 	</members>
 	<constants>
@@ -52319,13 +52800,13 @@ do_property].
 		</method>
 	</methods>
 	<members>
-		<member name="signal/base_type" type="String" setter="set_base_type" getter="get_base_type" brief="">
+		<member name="base_type" type="String" setter="set_base_type" getter="get_base_type" brief="">
 		</member>
-		<member name="signal/call_mode" type="int" setter="set_call_mode" getter="get_call_mode" brief="">
+		<member name="call_mode" type="int" setter="set_call_mode" getter="get_call_mode" brief="">
 		</member>
-		<member name="signal/node_path" type="NodePath" setter="set_base_path" getter="get_base_path" brief="">
+		<member name="node_path" type="NodePath" setter="set_base_path" getter="get_base_path" brief="">
 		</member>
-		<member name="signal/signal" type="String" setter="set_signal" getter="get_signal" brief="">
+		<member name="signal" type="String" setter="set_signal" getter="get_signal" brief="">
 		</member>
 	</members>
 	<constants>
@@ -52576,13 +53057,6 @@ do_property].
 				Retrieve the state of this world's physics space. This allows arbitrary querying for collision.
 			</description>
 		</method>
-		<method name="get_sound_space">
-			<return type="RID">
-			</return>
-			<description>
-				Retrieve the [RID] of this world's sound space resource. Used by the [SpatialSound2DServer] for 2D spatial audio.
-			</description>
-		</method>
 		<method name="get_space">
 			<return type="RID">
 			</return>
@@ -52594,7 +53068,7 @@ do_property].
 	<constants>
 	</constants>
 </class>
-<class name="WorldEnvironment" inherits="Spatial" category="Core">
+<class name="WorldEnvironment" inherits="Node" category="Core">
 	<brief_description>
 		Sets environment properties for the entire scene
 	</brief_description>

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -1076,7 +1076,7 @@ void VisualScriptConstant::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_constant_type"), &VisualScriptConstant::get_constant_type);
 
 	ClassDB::bind_method(D_METHOD("set_constant_value", "value"), &VisualScriptConstant::set_constant_value);
-	ClassDB::bind_method(D_METHOD("get_constant_value"), &VisualScriptConstant::get_constant_value);
+	ClassDB::bind_method(D_METHOD("get_constant_value:Variant"), &VisualScriptConstant::get_constant_value);
 
 	String argt = "Null";
 	for (int i = 1; i < Variant::VARIANT_MAX; i++) {

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1274,7 +1274,7 @@ void ItemList::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_item_disabled", "idx"), &ItemList::is_item_disabled);
 
 	ClassDB::bind_method(D_METHOD("set_item_metadata", "idx", "metadata"), &ItemList::set_item_metadata);
-	ClassDB::bind_method(D_METHOD("get_item_metadata", "idx"), &ItemList::get_item_metadata);
+	ClassDB::bind_method(D_METHOD("get_item_metadata:Variant", "idx"), &ItemList::get_item_metadata);
 
 	ClassDB::bind_method(D_METHOD("set_item_custom_bg_color", "idx", "custom_bg_color"), &ItemList::set_item_custom_bg_color);
 	ClassDB::bind_method(D_METHOD("get_item_custom_bg_color", "idx"), &ItemList::get_item_custom_bg_color);

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -283,7 +283,7 @@ void OptionButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_item_text", "idx"), &OptionButton::get_item_text);
 	ClassDB::bind_method(D_METHOD("get_item_icon:Texture", "idx"), &OptionButton::get_item_icon);
 	ClassDB::bind_method(D_METHOD("get_item_ID", "idx"), &OptionButton::get_item_ID);
-	ClassDB::bind_method(D_METHOD("get_item_metadata", "idx"), &OptionButton::get_item_metadata);
+	ClassDB::bind_method(D_METHOD("get_item_metadata:Variant", "idx"), &OptionButton::get_item_metadata);
 	ClassDB::bind_method(D_METHOD("is_item_disabled", "idx"), &OptionButton::is_item_disabled);
 	ClassDB::bind_method(D_METHOD("get_item_count"), &OptionButton::get_item_count);
 	ClassDB::bind_method(D_METHOD("add_separator"), &OptionButton::add_separator);
@@ -291,7 +291,7 @@ void OptionButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("select", "idx"), &OptionButton::select);
 	ClassDB::bind_method(D_METHOD("get_selected"), &OptionButton::get_selected);
 	ClassDB::bind_method(D_METHOD("get_selected_ID"), &OptionButton::get_selected_ID);
-	ClassDB::bind_method(D_METHOD("get_selected_metadata"), &OptionButton::get_selected_metadata);
+	ClassDB::bind_method(D_METHOD("get_selected_metadata:Variant"), &OptionButton::get_selected_metadata);
 	ClassDB::bind_method(D_METHOD("remove_item", "idx"), &OptionButton::remove_item);
 	ClassDB::bind_method(D_METHOD("_select_int"), &OptionButton::_select_int);
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1096,7 +1096,7 @@ void PopupMenu::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_item_ID", "idx"), &PopupMenu::get_item_ID);
 	ClassDB::bind_method(D_METHOD("get_item_index", "id"), &PopupMenu::get_item_index);
 	ClassDB::bind_method(D_METHOD("get_item_accelerator", "idx"), &PopupMenu::get_item_accelerator);
-	ClassDB::bind_method(D_METHOD("get_item_metadata", "idx"), &PopupMenu::get_item_metadata);
+	ClassDB::bind_method(D_METHOD("get_item_metadata:Variant", "idx"), &PopupMenu::get_item_metadata);
 	ClassDB::bind_method(D_METHOD("is_item_disabled", "idx"), &PopupMenu::is_item_disabled);
 	ClassDB::bind_method(D_METHOD("get_item_submenu", "idx"), &PopupMenu::get_item_submenu);
 	ClassDB::bind_method(D_METHOD("is_item_separator", "idx"), &PopupMenu::is_item_separator);

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -163,7 +163,7 @@ void ShaderMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_shader", "shader:Shader"), &ShaderMaterial::set_shader);
 	ClassDB::bind_method(D_METHOD("get_shader:Shader"), &ShaderMaterial::get_shader);
 	ClassDB::bind_method(D_METHOD("set_shader_param", "param", "value"), &ShaderMaterial::set_shader_param);
-	ClassDB::bind_method(D_METHOD("get_shader_param", "param"), &ShaderMaterial::get_shader_param);
+	ClassDB::bind_method(D_METHOD("get_shader_param:Variant", "param"), &ShaderMaterial::get_shader_param);
 }
 
 void ShaderMaterial::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {

--- a/scene/resources/mesh_data_tool.cpp
+++ b/scene/resources/mesh_data_tool.cpp
@@ -554,7 +554,7 @@ void MeshDataTool::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_vertex_weights", "idx"), &MeshDataTool::get_vertex_weights);
 
 	ClassDB::bind_method(D_METHOD("set_vertex_meta", "idx", "meta"), &MeshDataTool::set_vertex_meta);
-	ClassDB::bind_method(D_METHOD("get_vertex_meta", "idx"), &MeshDataTool::get_vertex_meta);
+	ClassDB::bind_method(D_METHOD("get_vertex_meta:Variant", "idx"), &MeshDataTool::get_vertex_meta);
 
 	ClassDB::bind_method(D_METHOD("get_vertex_edges", "idx"), &MeshDataTool::get_vertex_edges);
 	ClassDB::bind_method(D_METHOD("get_vertex_faces", "idx"), &MeshDataTool::get_vertex_faces);
@@ -563,13 +563,13 @@ void MeshDataTool::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_edge_faces", "idx", "faces"), &MeshDataTool::get_edge_faces);
 
 	ClassDB::bind_method(D_METHOD("set_edge_meta", "idx", "meta"), &MeshDataTool::set_edge_meta);
-	ClassDB::bind_method(D_METHOD("get_edge_meta", "idx"), &MeshDataTool::get_edge_meta);
+	ClassDB::bind_method(D_METHOD("get_edge_meta:Variant", "idx"), &MeshDataTool::get_edge_meta);
 
 	ClassDB::bind_method(D_METHOD("get_face_vertex", "idx", "vertex"), &MeshDataTool::get_face_vertex);
 	ClassDB::bind_method(D_METHOD("get_face_edge", "idx", "edge"), &MeshDataTool::get_face_edge);
 
 	ClassDB::bind_method(D_METHOD("set_face_meta", "idx", "meta"), &MeshDataTool::set_face_meta);
-	ClassDB::bind_method(D_METHOD("get_face_meta", "idx"), &MeshDataTool::get_face_meta);
+	ClassDB::bind_method(D_METHOD("get_face_meta:Variant", "idx"), &MeshDataTool::get_face_meta);
 
 	ClassDB::bind_method(D_METHOD("get_face_normal", "idx"), &MeshDataTool::get_face_normal);
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -1671,7 +1671,7 @@ void SceneState::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_node_groups", "idx"), &SceneState::_get_node_groups);
 	ClassDB::bind_method(D_METHOD("get_node_property_count", "idx"), &SceneState::get_node_property_count);
 	ClassDB::bind_method(D_METHOD("get_node_property_name", "idx", "prop_idx"), &SceneState::get_node_property_name);
-	ClassDB::bind_method(D_METHOD("get_node_property_value", "idx", "prop_idx"), &SceneState::get_node_property_value);
+	ClassDB::bind_method(D_METHOD("get_node_property_value:Variant", "idx", "prop_idx"), &SceneState::get_node_property_value);
 	ClassDB::bind_method(D_METHOD("get_connection_count"), &SceneState::get_connection_count);
 	ClassDB::bind_method(D_METHOD("get_connection_source", "idx"), &SceneState::get_connection_source);
 	ClassDB::bind_method(D_METHOD("get_connection_signal", "idx"), &SceneState::get_connection_signal);


### PR DESCRIPTION
I fixed some missing Variant return value in the documentation.

I'm am not done yet: there are still missing Variant return values in the `Dictionary` and `Geometry` documentation for
* Dictionary::back()
* Dictionary:: front()
* Dictionary::pop_back()
* Dictionary::pop_front()
* Geometry::ray_intersects_triangle()
* Geometry::segment_intersects_segment_2d()

There is no `_bind_methods()` defined in `Dictionary.h`: do I need to create one ?

Ps: I opened a [previous PR](https://github.com/godotengine/godot/pull/9590) for this issue but I'm not able to select the correct branch when reopening it... sorry for that :/