### PR TITLE
Tabs enhancements: get_tab_rect(), move_tab()

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -44112,12 +44112,30 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_tab_rect">
+			<return type="Rect2">
+			</return>
+			<argument index="0" name="tab_idx" type="int">
+			</argument>
+			<description>
+				Returns tab [Rect2] with local position and size.
+			</description>
+		</method>
 		<method name="get_tab_title" qualifiers="const">
 			<return type="String">
 			</return>
 			<argument index="0" name="tab_idx" type="int">
 			</argument>
 			<description>
+			</description>
+		</method>
+		<method name="move_tab">
+			<argument index="0" name="from" type="int">
+			</argument>
+			<argument index="1" name="to" type="int">
+			</argument>
+			<description>
+				Rearrange tab.
 			</description>
 		</method>
 		<method name="remove_tab">

--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -639,6 +639,22 @@ Tabs::TabAlign Tabs::get_tab_align() const {
 	return tab_align;
 }
 
+void Tabs::move_tab(int from, int to) {
+
+	if (from == to)
+		return;
+
+	ERR_FAIL_INDEX(from, tabs.size());
+	ERR_FAIL_INDEX(to, tabs.size());
+
+	Tab tab_from = tabs[from];
+	tabs.remove(from);
+	tabs.insert(to, tab_from);
+
+	_update_cache();
+	update();
+}
+
 int Tabs::get_tab_width(int p_idx) const {
 
 	ERR_FAIL_INDEX_V(p_idx, tabs.size(), 0);
@@ -773,6 +789,8 @@ void Tabs::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_tab_align", "align"), &Tabs::set_tab_align);
 	ClassDB::bind_method(D_METHOD("get_tab_align"), &Tabs::get_tab_align);
 	ClassDB::bind_method(D_METHOD("ensure_tab_visible", "idx"), &Tabs::ensure_tab_visible);
+	ClassDB::bind_method(D_METHOD("get_tab_rect", "tab_idx"), &Tabs::get_tab_rect);
+	ClassDB::bind_method(D_METHOD("move_tab", "from", "to"), &Tabs::move_tab);
 
 	ADD_SIGNAL(MethodInfo("tab_changed", PropertyInfo(Variant::INT, "tab")));
 	ADD_SIGNAL(MethodInfo("right_button_pressed", PropertyInfo(Variant::INT, "tab")));

--- a/scene/gui/tabs.h
+++ b/scene/gui/tabs.h
@@ -119,6 +119,8 @@ public:
 	void set_tab_align(TabAlign p_align);
 	TabAlign get_tab_align() const;
 
+	void move_tab(int from, int to);
+
 	void set_tab_close_display_policy(CloseButtonDisplayPolicy p_policy);
 
 	int get_tab_count() const;


### PR DESCRIPTION
exposed: `get_tab_rect(tab_idx)` can be used to determine position and size of concrete tab 
new and exposed: `move_tab_from_to(idx_from, idx_to)` can be used to rearrange tabs more easily