### PR TITLE
Adds init callbacks to SceneTree

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -522,6 +522,8 @@ void SceneTree::init() {
 
 	root->_set_tree(this);
 	MainLoop::init();
+	
+	_call_init_callbacks();
 }
 
 bool SceneTree::iteration(float p_time) {
@@ -2287,6 +2289,21 @@ void SceneTree::_bind_methods() {
 }
 
 SceneTree *SceneTree::singleton = NULL;
+
+SceneTree::InitCallback SceneTree::init_callbacks[SceneTree::MAX_INIT_CALLBACKS];
+int SceneTree::init_callback_count = 0;
+
+void SceneTree::_call_init_callbacks() {
+
+	for (int i = 0; i < init_callback_count; i++) {
+		init_callbacks[i]();
+	}
+}
+
+void SceneTree::add_init_callback(InitCallback p_callback) {
+	ERR_FAIL_COND(init_callback_count >= MAX_INIT_CALLBACKS);
+	init_callbacks[init_callback_count++] = p_callback;
+}
 
 SceneTree::IdleCallback SceneTree::idle_callbacks[SceneTree::MAX_IDLE_CALLBACKS];
 int SceneTree::idle_callback_count = 0;

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -75,6 +75,7 @@ class SceneTree : public MainLoop {
 	GDCLASS(SceneTree, MainLoop);
 
 public:
+	typedef void (*InitCallback)();
 	typedef void (*IdleCallback)();
 
 	enum StretchMode {
@@ -305,8 +306,13 @@ private:
 #endif
 
 	enum {
+		MAX_INIT_CALLBACKS = 256,
 		MAX_IDLE_CALLBACKS = 256
 	};
+
+	static InitCallback init_callbacks[MAX_INIT_CALLBACKS];
+	static int init_callback_count;
+	void _call_init_callbacks();
 
 	static IdleCallback idle_callbacks[MAX_IDLE_CALLBACKS];
 	static int idle_callback_count;
@@ -456,7 +462,9 @@ public:
 	void set_refuse_new_network_connections(bool p_refuse);
 	bool is_refusing_new_network_connections() const;
 
+	static void add_init_callback(InitCallback p_callback);
 	static void add_idle_callback(IdleCallback p_callback);
+
 	SceneTree();
 	~SceneTree();
 };


### PR DESCRIPTION
I need this for doing some initializations after the SceneTree is initialized.
It's a clone of the idle callback. Is there a reason not to use Vector for this?