### PR TITLE
Fix uncheckable checkboxes in RMB menu. closes #9625

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -663,13 +663,16 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			if (List<Node *>::Element *e = selection.front()) {
 				if (Node *node = e->get()) {
 					bool editable = EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(node);
+					int editable_item_idx = menu->get_item_idx_from_text(TTR("Editable Children"));
+					int placeholder_item_idx = menu->get_item_idx_from_text(TTR("Load As Placeholder"));
 					editable = !editable;
 
 					EditorNode::get_singleton()->get_edited_scene()->set_editable_instance(node, editable);
-					menu->set_item_checked(18, editable);
+
+					menu->set_item_checked(editable_item_idx, editable);
 					if (editable) {
 						node->set_scene_instance_load_placeholder(false);
-						menu->set_item_checked(19, false);
+						menu->set_item_checked(placeholder_item_idx, false);
 					}
 					scene_tree->update_tree();
 				}
@@ -681,12 +684,14 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				if (Node *node = e->get()) {
 					bool placeholder = node->get_scene_instance_load_placeholder();
 					placeholder = !placeholder;
+					int editable_item_idx = menu->get_item_idx_from_text(TTR("Editable Children"));
+					int placeholder_item_idx = menu->get_item_idx_from_text(TTR("Load As Placeholder"));
 					if (placeholder)
 						EditorNode::get_singleton()->get_edited_scene()->set_editable_instance(node, false);
 
 					node->set_scene_instance_load_placeholder(placeholder);
-					menu->set_item_checked(18, false);
-					menu->set_item_checked(19, placeholder);
+					menu->set_item_checked(editable_item_idx, false);
+					menu->set_item_checked(placeholder_item_idx, placeholder);
 					scene_tree->update_tree();
 				}
 			}
@@ -1892,8 +1897,8 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 				menu->add_check_item(TTR("Load As Placeholder"), TOOL_SCENE_USE_PLACEHOLDER);
 				menu->add_item(TTR("Discard Instancing"), TOOL_SCENE_CLEAR_INSTANCING);
 				menu->add_icon_item(get_icon("Load", "EditorIcons"), TTR("Open in Editor"), TOOL_SCENE_OPEN);
-				menu->set_item_checked(18, editable);
-				menu->set_item_checked(19, placeholder);
+				menu->set_item_checked(menu->get_item_idx_from_text(TTR("Editable Children")), editable);
+				menu->set_item_checked(menu->get_item_idx_from_text(TTR("Load As Placeholder")), placeholder);
 			}
 		}
 	}

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -696,6 +696,17 @@ String PopupMenu::get_item_text(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, items.size(), "");
 	return items[p_idx].text;
 }
+
+int PopupMenu::get_item_idx_from_text(const String &text) const {
+
+	for (int idx = 0; idx < items.size(); idx++) {
+		if (items[idx].text == text)
+			return idx;
+	}
+
+	return -1;
+}
+
 Ref<Texture> PopupMenu::get_item_icon(int p_idx) const {
 
 	ERR_FAIL_INDEX_V(p_idx, items.size(), Ref<Texture>());

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -132,6 +132,7 @@ public:
 	void toggle_item_checked(int p_idx);
 
 	String get_item_text(int p_idx) const;
+	int get_item_idx_from_text(const String &text) const;
 	Ref<Texture> get_item_icon(int p_idx) const;
 	bool is_item_checked(int p_idx) const;
 	int get_item_ID(int p_idx) const;


### PR DESCRIPTION
When node has a script (or any other resource), then all items in RMB menu will change their position since "Sub resource" section will appear at the top. 
Setting checkboxes for `Editable children` and `Load as placeholder` were hard-coded for concrete items ids and that was the reason of the issue. 
This pr will fix this for "Editable children" and "Load as placeholder" options, by adding new method to `PopupMenu` that can return `idx` of an item basing on it's text.