### PR TITLE
Expose Dictionary::next to GDNative

### DIFF
--- a/modules/gdnative/godot/godot_dictionary.cpp
+++ b/modules/gdnative/godot/godot_dictionary.cpp
@@ -124,9 +124,15 @@ void GDAPI godot_dictionary_set(godot_dictionary *p_self, const godot_variant *p
 }
 
 godot_variant GDAPI *godot_dictionary_operator_index(godot_dictionary *p_self, const godot_variant *p_key) {
-	Array *self = (Array *)p_self;
+	Dictionary *self = (Dictionary *)p_self;
 	const Variant *key = (const Variant *)p_key;
 	return (godot_variant *)&self->operator[](*key);
+}
+
+godot_variant GDAPI *godot_dictionary_next(const godot_dictionary *p_self, const godot_variant *p_key) {
+	Dictionary *self = (Dictionary *)p_self;
+	const Variant *key = (const Variant *)p_key;
+	return (godot_variant *)self->next(key);
 }
 
 godot_bool GDAPI godot_dictionary_operator_equal(const godot_dictionary *p_self, const godot_dictionary *p_b) {

--- a/modules/gdnative/godot/godot_dictionary.h
+++ b/modules/gdnative/godot/godot_dictionary.h
@@ -74,6 +74,8 @@ void GDAPI godot_dictionary_set(godot_dictionary *p_self, const godot_variant *p
 
 godot_variant GDAPI *godot_dictionary_operator_index(godot_dictionary *p_self, const godot_variant *p_key);
 
+godot_variant GDAPI *godot_dictionary_next(const godot_dictionary *p_self, const godot_variant *p_key);
+
 godot_bool GDAPI godot_dictionary_operator_equal(const godot_dictionary *p_self, const godot_dictionary *p_b);
 
 godot_string GDAPI godot_dictionary_to_json(const godot_dictionary *p_self);


### PR DESCRIPTION
For iterating over the keys one at a time. In GDNative D bindings, this and godot_dictionary_operator_index allow implementing the loop `foreach(key, ref value; dictionary) { ... }`.

Also fix typo in godot_dictionary_operator_index.