### PR TITLE
Focus box size fix for new theme

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1897,11 +1897,6 @@ void CanvasItemEditor::_viewport_draw() {
 
 	if (viewport->has_focus()) {
 		Size2 size = viewport->get_size();
-		if (v_scroll->is_visible_in_tree())
-			size.width -= v_scroll->get_size().width;
-		if (h_scroll->is_visible_in_tree())
-			size.height -= h_scroll->get_size().height;
-
 		get_stylebox("Focus", "EditorStyles")->draw(ci, Rect2(Point2(), size));
 	}
 


### PR DESCRIPTION
the focus border looks weird with the new theme:

current version:
<img width="300" alt="screen shot 2017-07-16 at 20 05 23" src="https://user-images.githubusercontent.com/16718859/28250143-7af94928-6a62-11e7-8cd0-e172967fe759.png">

with the proposed fix:

<img width="300" alt="screen shot 2017-07-16 at 20 04 06" src="https://user-images.githubusercontent.com/16718859/28250142-7abecc08-6a62-11e7-9986-78d44e470ba2.png">
