### PR TITLE
ios expose buffer and framebuffer issue fix

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -6160,7 +6160,12 @@ void RasterizerStorageGLES3::_render_target_allocate(RenderTarget *rt) {
 
 			glGenTextures(1, &rt->exposure.color);
 			glBindTexture(GL_TEXTURE_2D, rt->exposure.color);
+#ifdef IPHONE_ENABLED
+			///@TODO ugly hack to get around iOS not supporting 32bit single channel floating point textures...
+			glTexImage2D(GL_TEXTURE_2D, 0, GL_R16F, 1, 1, 0, GL_RED, GL_FLOAT, NULL);
+#else
 			glTexImage2D(GL_TEXTURE_2D, 0, GL_R32F, 1, 1, 0, GL_RED, GL_FLOAT, NULL);
+#endif
 			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->exposure.color, 0);
 
 			status = glCheckFramebufferStatus(GL_FRAMEBUFFER);

--- a/platform/iphone/gl_view.mm
+++ b/platform/iphone/gl_view.mm
@@ -29,8 +29,8 @@
 /*************************************************************************/
 #import "gl_view.h"
 
-#include "core/project_settings.h"
 #include "core/os/keyboard.h"
+#include "core/project_settings.h"
 #include "os_iphone.h"
 #include "servers/audio_server.h"
 
@@ -46,7 +46,7 @@
 @end
 */
 
-int gl_view_base_fb;
+int gl_view_base_fb = 0;
 static String keyboard_text;
 static GLView *_instance = NULL;
 
@@ -310,7 +310,7 @@ static void clear_touches() {
 - (BOOL)createFramebuffer {
 	// Generate IDs for a framebuffer object and a color renderbuffer
 	UIScreen *mainscr = [UIScreen mainScreen];
-	printf("******** screen size %i, %i\n", (int)mainscr.currentMode.size.width, (int)mainscr.currentMode.size.height);
+	NSLog(@"******** screen size %i, %i", (int)mainscr.currentMode.size.width, (int)mainscr.currentMode.size.height);
 	float minPointSize = MIN(mainscr.bounds.size.width, mainscr.bounds.size.height);
 	float minScreenSize = MIN(mainscr.currentMode.size.width, mainscr.currentMode.size.height);
 	self.contentScaleFactor = minScreenSize / minPointSize;
@@ -458,7 +458,7 @@ static void clear_touches() {
 #ifdef DEBUG_ENABLED
 	GLenum err = glGetError();
 	if (err)
-		NSLog(@"%x error", err);
+		NSLog(@"gl_view.drawView: %x error", err);
 #endif
 }
 

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -109,9 +109,9 @@ void OSIPhone::initialize(const VideoMode &p_desired, int p_video_driver, int p_
 
 	RasterizerGLES3::register_config();
 	RasterizerGLES3::make_current();
-	RasterizerStorageGLES3::system_fbo = gl_view_base_fb;
 
 	visual_server = memnew(VisualServerRaster());
+
 	/*
 		FIXME: Reimplement threaded rendering? Or remove?
 	if (get_render_thread_mode() != RENDER_THREAD_UNSAFE) {
@@ -121,6 +121,7 @@ void OSIPhone::initialize(const VideoMode &p_desired, int p_video_driver, int p_
 
 	visual_server->init();
 	visual_server->cursor_set_visible(false, 0);
+	RasterizerStorageGLES3::system_fbo = gl_view_base_fb;
 
 	audio_driver = memnew(AudioDriverIphone);
 	audio_driver->set_singleton();
@@ -434,7 +435,8 @@ bool OSIPhone::can_draw() const {
 
 int OSIPhone::set_base_framebuffer(int p_fb) {
 
-	RasterizerStorageGLES3::system_fbo = gl_view_base_fb;
+	// gl_view_base_fb has not been updated yet
+	RasterizerStorageGLES3::system_fbo = p_fb;
 
 	return 0;
 };


### PR DESCRIPTION
@reduz probably needs a neater fix, there is a similar change that was already added in rasterizer_scene_gles3.cpp

iPhone does not like 32bit float single channel buffers, but accepts 16bit.. 