### PR TITLE
Update GDScript completion names for Pool*Arrays

### DIFF
--- a/modules/gdscript/gd_editor.cpp
+++ b/modules/gdscript/gd_editor.cpp
@@ -1334,8 +1334,8 @@ static void _find_identifiers(GDCompletionContext &context, int p_line, bool p_o
 
 	static const char *_type_names[Variant::VARIANT_MAX] = {
 		"null", "bool", "int", "float", "String", "Vector2", "Rect2", "Vector3", "Transform2D", "Plane", "Quat", "AABB", "Basis", "Transform",
-		"Color", "NodePath", "RID", "Object", "Dictionary", "Array", "RawArray", "IntArray", "FloatArray", "StringArray",
-		"Vector2Array", "Vector3Array", "ColorArray"
+		"Color", "NodePath", "RID", "Object", "Dictionary", "Array", "PoolByteArray", "PoolIntArray", "PoolRealArray", "PoolStringArray",
+		"PoolVector2Array", "PoolVector3Array", "PoolColorArray"
 	};
 
 	for (int i = 0; i < Variant::VARIANT_MAX; i++) {

--- a/modules/gdscript/gd_tokenizer.cpp
+++ b/modules/gdscript/gd_tokenizer.cpp
@@ -808,7 +808,7 @@ void GDTokenizerText::_advance() {
 							{ Variant::ARRAY, "Array" },
 							{ Variant::POOL_BYTE_ARRAY, "PoolByteArray" },
 							{ Variant::POOL_INT_ARRAY, "PoolIntArray" },
-							{ Variant::POOL_REAL_ARRAY, "PoolFloatArray" },
+							{ Variant::POOL_REAL_ARRAY, "PoolRealArray" },
 							{ Variant::POOL_STRING_ARRAY, "PoolStringArray" },
 							{ Variant::POOL_VECTOR2_ARRAY, "PoolVector2Array" },
 							{ Variant::POOL_VECTOR3_ARRAY, "PoolVector3Array" },


### PR DESCRIPTION
Notice: GDScript tokenizer used the old `PoolFloatArray` name.
Renamed `PoolFloatArray` to `PoolRealArray`.

Fixes #9638 

P.S. My first pull request to Godot.

