### PR TITLE
Rename of two EditorPlugin methods

### DIFF
--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -175,7 +175,7 @@ Node *EditorPlugin::get_edited_scene_root() {
 	return EditorNode::get_singleton()->get_edited_scene();
 }
 
-Array EditorPlugin::get_opened_scenes_list() const {
+Array EditorPlugin::get_open_scenes() const {
 
 	Array ret;
 	Vector<EditorData::EditedScene> scenes = EditorNode::get_singleton()->get_editor_data().get_edited_scenes();
@@ -440,7 +440,7 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_import_plugin", "importer:EditorImportPlugin"), &EditorPlugin::add_import_plugin);
 	ClassDB::bind_method(D_METHOD("remove_import_plugin", "importer:EditorImportPlugin"), &EditorPlugin::remove_import_plugin);
 	ClassDB::bind_method(D_METHOD("set_input_event_forwarding_always_enabled"), &EditorPlugin::set_input_event_forwarding_always_enabled);
-	ClassDB::bind_method(D_METHOD("get_opened_scenes_list"), &EditorPlugin::get_opened_scenes_list);
+	ClassDB::bind_method(D_METHOD("get_open_scenes"), &EditorPlugin::get_open_scenes);
 	ClassDB::bind_method(D_METHOD("get_edited_scene_root:Node"), &EditorPlugin::get_edited_scene_root);
 
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "forward_canvas_gui_input", PropertyInfo(Variant::TRANSFORM2D, "canvas_xform"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -118,7 +118,7 @@ public:
 	bool is_input_event_forwarding_always_enabled() { return input_event_forwarding_always_enabled; }
 
 	Node *get_edited_scene_root();
-	Array get_opened_scenes_list() const;
+	Array get_open_scenes() const;
 	ScriptEditor *get_script_editor();
 
 	void notify_main_screen_changed(const String &screen_name);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -793,10 +793,10 @@ Ref<Script> ScriptEditor::_get_current_script() {
 	}
 }
 
-Array ScriptEditor::_get_opened_script_list() const {
+Array ScriptEditor::_get_open_scripts() const {
 
 	Array ret;
-	Vector<Ref<Script> > scripts = get_opened_scripts();
+	Vector<Ref<Script> > scripts = get_open_scripts();
 	int scrits_amount = scripts.size();
 	for (int idx_script = 0; idx_script < scrits_amount; idx_script++) {
 		ret.push_back(scripts[idx_script]);
@@ -1159,7 +1159,7 @@ void ScriptEditor::notify_script_close(const Ref<Script> &p_script) {
 }
 
 void ScriptEditor::notify_script_changed(const Ref<Script> &p_script) {
-	emit_signal("script_changed", p_script);
+	emit_signal("editor_script_changed", p_script);
 }
 
 static const Node *_find_node_with_script(const Node *p_node, const RefPtr &p_script) {
@@ -2104,7 +2104,7 @@ void ScriptEditor::_history_back() {
 	}
 }
 
-Vector<Ref<Script> > ScriptEditor::get_opened_scripts() const {
+Vector<Ref<Script> > ScriptEditor::get_open_scripts() const {
 
 	Vector<Ref<Script> > out_scripts = Vector<Ref<Script> >();
 
@@ -2213,9 +2213,9 @@ void ScriptEditor::_bind_methods() {
 	ClassDB::bind_method("_unhandled_input", &ScriptEditor::_unhandled_input);
 
 	ClassDB::bind_method(D_METHOD("get_current_script"), &ScriptEditor::_get_current_script);
-	ClassDB::bind_method(D_METHOD("get_opened_scripts_list"), &ScriptEditor::_get_opened_script_list);
+	ClassDB::bind_method(D_METHOD("get_open_scripts"), &ScriptEditor::_get_open_scripts);
 
-	ADD_SIGNAL(MethodInfo("script_changed", PropertyInfo(Variant::OBJECT, "script:Script")));
+	ADD_SIGNAL(MethodInfo("editor_script_changed", PropertyInfo(Variant::OBJECT, "script:Script")));
 	ADD_SIGNAL(MethodInfo("script_close", PropertyInfo(Variant::STRING, "script:String")));
 }
 

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -322,7 +322,7 @@ class ScriptEditor : public PanelContainer {
 	void _file_dialog_action(String p_file);
 
 	Ref<Script> _get_current_script();
-	Array _get_opened_script_list() const;
+	Array _get_open_scripts() const;
 
 	static void _open_script_request(const String &p_path);
 
@@ -357,7 +357,7 @@ public:
 	void get_window_layout(Ref<ConfigFile> p_layout);
 
 	void set_scene_root_script(Ref<Script> p_script);
-	Vector<Ref<Script> > get_opened_scripts() const;
+	Vector<Ref<Script> > get_open_scripts() const;
 
 	bool script_goto_method(Ref<Script> p_script, const String &p_method);
 


### PR DESCRIPTION
Like it was discussed in #9565, this pr will change name of those two methods:
`get_opened_scripts_list` -> `get_open_scripts`
`get_opened_scenes_list` -> `get_open_scenes`

edit:
and a signal: 
`script_changed` -> `editor_script_changed`


