### PR TITLE
Use specific size for numeric types in ptrcall

### DIFF
--- a/core/method_ptrcall.h
+++ b/core/method_ptrcall.h
@@ -60,37 +60,37 @@ struct PtrToArg {
 		}                                                              \
 	}
 
-#define MAKE_PTRARGR(m_type, m_ret)                                    \
-	template <>                                                        \
-	struct PtrToArg<m_type> {                                          \
-		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {      \
-			return *reinterpret_cast<const m_type *>(p_ptr);           \
-		}                                                              \
-		_FORCE_INLINE_ static void encode(m_type p_val, void *p_ptr) { \
-			*((m_ret *)p_ptr) = p_val;                                 \
-		}                                                              \
-	};                                                                 \
-	template <>                                                        \
-	struct PtrToArg<const m_type &> {                                  \
-		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {      \
-			return *reinterpret_cast<const m_type *>(p_ptr);           \
-		}                                                              \
-		_FORCE_INLINE_ static void encode(m_type p_val, void *p_ptr) { \
-			*((m_ret *)p_ptr) = p_val;                                 \
-		}                                                              \
+#define MAKE_PTRARGCONV(m_type, m_conv)                                           \
+	template <>                                                                   \
+	struct PtrToArg<m_type> {                                                     \
+		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {                 \
+			return static_cast<m_type>(*reinterpret_cast<const m_conv *>(p_ptr)); \
+		}                                                                         \
+		_FORCE_INLINE_ static void encode(m_type p_val, void *p_ptr) {            \
+			*((m_conv *)p_ptr) = static_cast<m_conv>(p_val);                      \
+		}                                                                         \
+	};                                                                            \
+	template <>                                                                   \
+	struct PtrToArg<const m_type &> {                                             \
+		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {                 \
+			return static_cast<m_type>(*reinterpret_cast<const m_conv *>(p_ptr)); \
+		}                                                                         \
+		_FORCE_INLINE_ static void encode(m_type p_val, void *p_ptr) {            \
+			*((m_conv *)p_ptr) = static_cast<m_conv>(p_val);                      \
+		}                                                                         \
 	}
 
 MAKE_PTRARG(bool);
-MAKE_PTRARGR(uint8_t, int);
-MAKE_PTRARGR(int8_t, int);
-MAKE_PTRARGR(uint16_t, int);
-MAKE_PTRARGR(int16_t, int);
-MAKE_PTRARGR(uint32_t, int);
-MAKE_PTRARGR(int32_t, int);
-MAKE_PTRARGR(int64_t, int);
-MAKE_PTRARGR(uint64_t, int);
-MAKE_PTRARG(float);
-MAKE_PTRARGR(double, float);
+MAKE_PTRARGCONV(uint8_t, int64_t);
+MAKE_PTRARGCONV(int8_t, int64_t);
+MAKE_PTRARGCONV(uint16_t, int64_t);
+MAKE_PTRARGCONV(int16_t, int64_t);
+MAKE_PTRARGCONV(uint32_t, int64_t);
+MAKE_PTRARGCONV(int32_t, int64_t);
+MAKE_PTRARG(int64_t);
+MAKE_PTRARG(uint64_t);
+MAKE_PTRARGCONV(float, double);
+MAKE_PTRARG(double);
 
 MAKE_PTRARG(String);
 MAKE_PTRARG(Vector2);


### PR DESCRIPTION
The script system does not provide information about specific int
sizes, so we should establish convention to use the largest size
(64 bits). For real types, 32 bits are always used, because it's the
most common size, but we lose precision when passing doubles around.