### PR TITLE
Add a way to retrieve stack bottom of the main thread

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -512,7 +512,13 @@ bool OS::check_feature_support(const String &p_feature) {
 	return false;
 }
 
+void *OS::get_stack_bottom() const {
+	return _stack_bottom;
+}
+
 OS::OS() {
+	void *volatile stack_bottom;
+
 	last_error = NULL;
 	singleton = this;
 	_keep_screen_on = true; // set default value to true, because this had been true before godot 2.0.
@@ -525,6 +531,7 @@ OS::OS() {
 	_render_thread_mode = RENDER_THREAD_SAFE;
 
 	_allow_hidpi = true;
+	_stack_bottom = (void *)(&stack_bottom);
 }
 
 OS::~OS() {

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -60,6 +60,8 @@ class OS {
 
 	char *last_error;
 
+	void *_stack_bottom;
+
 public:
 	enum RenderThreadMode {
 
@@ -410,6 +412,13 @@ public:
 	virtual int get_power_percent_left();
 
 	bool check_feature_support(const String &p_feature);
+
+	/**
+	 * Returns the stack bottom of the main thread of the application.
+	 * This may be of use when integrating languages with garbage collectors that
+	 * need to check whether a pointer is on the stack.
+	 */
+	virtual void *get_stack_bottom() const;
 
 	bool is_hidpi_allowed() const { return _allow_hidpi; }
 	OS();

--- a/modules/gdnative/godot/gdnative.cpp
+++ b/modules/gdnative/godot/gdnative.cpp
@@ -33,6 +33,7 @@
 #include "error_macros.h"
 #include "gdnative.h"
 #include "global_constants.h"
+#include "os/os.h"
 #include "project_settings.h"
 #include "variant.h"
 
@@ -88,6 +89,10 @@ void GDAPI godot_object_destroy(godot_object *p_o) {
 godot_object GDAPI *godot_global_get_singleton(char *p_name) {
 	return (godot_object *)ProjectSettings::get_singleton()->get_singleton_object(String(p_name));
 } // result shouldn't be freed
+
+void GDAPI *godot_get_stack_bottom() {
+	return OS::get_singleton()->get_stack_bottom();
+}
 
 // MethodBind API
 

--- a/modules/gdnative/godot/gdnative.h
+++ b/modules/gdnative/godot/gdnative.h
@@ -245,6 +245,10 @@ void GDAPI godot_object_destroy(godot_object *p_o);
 
 godot_object GDAPI *godot_global_get_singleton(char *p_name); // result shouldn't be freed
 
+////// OS API
+
+void GDAPI *godot_get_stack_bottom(); //  returns stack bottom of the main thread
+
 ////// MethodBind API
 
 typedef struct {


### PR DESCRIPTION
I'm working on Nim bindings and Nim GC needs to know the stack
boundaries to check whether certain pointers are located on the stack
or in the heap. This commit adds godot_get_stack_bottom procedure
to gdnative module which returns pointer to the stack bottom of the
main thread. Later on this may be improved to return stack bottom of
the current thread.