### PR TITLE
Implement godot_new to allow instancing of binding types

### DIFF
--- a/modules/nativescript/godot_nativescript.cpp
+++ b/modules/nativescript/godot_nativescript.cpp
@@ -190,6 +190,21 @@ void GDAPI godot_nativescript_register_signal(void *p_gdnative_handle, const cha
 	E->get().signals_.insert(*(String *)&p_signal->name, signal);
 }
 
+godot_object GDAPI *godot_nativescript_new(const char *p_classname) {
+	StringName name = StringName(p_classname);
+	ClassDB::ClassInfo *class_info = ClassDB::classes.getptr(name);
+	if (class_info)
+		return ((godot_class_constructor)class_info->creation_func)();
+
+	NativeScript *script = NativeScriptLanguage::get_singleton()->get_script(name);
+	if (script) {
+		Variant::CallError err;
+		return (godot_object *)((Object *)(script->_new(NULL, 0, err)));
+	}
+
+	return NULL;
+}
+
 void GDAPI *godot_nativescript_get_userdata(godot_object *p_instance) {
 	Object *instance = (Object *)p_instance;
 	if (!instance)

--- a/modules/nativescript/godot_nativescript.h
+++ b/modules/nativescript/godot_nativescript.h
@@ -217,6 +217,7 @@ typedef struct {
 } godot_signal;
 
 void GDAPI godot_nativescript_register_signal(void *p_gdnative_handle, const char *p_name, const godot_signal *p_signal);
+godot_object GDAPI *godot_nativescript_new(const char *p_classname);
 
 void GDAPI *godot_nativescript_get_userdata(godot_object *p_instance);
 

--- a/modules/nativescript/nativescript.h
+++ b/modules/nativescript/nativescript.h
@@ -104,6 +104,15 @@ class NativeScript : public Script {
 
 	Set<Object *> instance_owners;
 
+	/**
+	 * Registers the script in the library's script map.
+	 */
+	void register_script();
+	/**
+	 * Unregisters the script from the library's script map.
+	 */
+	void unregister_script();
+
 protected:
 	static void _bind_methods();
 
@@ -197,11 +206,13 @@ private:
 
 	void _unload_stuff();
 
+	NativeScriptDesc *get_script_desc(const StringName p_name, String &r_lib_name) const;
+
 public:
 	Map<String, Map<StringName, NativeScriptDesc> > library_classes;
 	Map<String, Ref<GDNative> > library_gdnatives;
 
-	Map<String, Set<NativeScript *> > library_script_users;
+	Map<String, Map<StringName, Set<NativeScript *> > > library_script_users;
 
 	const StringName _init_call_type = "nativescript_init";
 	const StringName _init_call_name = "godot_nativescript_init";
@@ -214,6 +225,7 @@ public:
 	}
 
 	void _hacky_api_anchor();
+	NativeScript *get_script(const StringName p_name);
 
 	virtual String get_name() const;
 	virtual void init();


### PR DESCRIPTION
Previously there was no way to create an object passing a class name
previously registered by a native library. This commit adds
implementation of godot_new in gdnative module. It can instantiate
the native script with the specified name, if the name does not belong
to a native type.