### PR TITLE
Fix android export templates build

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -87,20 +87,6 @@ def configure(env):
 
         env['SPAWN'] = mySpawn
 
-    ## Build type
-
-    if (env["target"].startswith("release")):
-        env.Append(LINKFLAGS=['-O2'])
-        env.Append(CPPFLAGS=['-O2', '-DNDEBUG', '-ffast-math', '-funsafe-math-optimizations', '-fomit-frame-pointer'])
-        if (can_vectorize):
-            env.Append(CPPFLAGS=['-ftree-vectorize'])
-        if (env["target"] == "release_debug"):
-            env.Append(CPPFLAGS=['-DDEBUG_ENABLED'])
-    elif (env["target"] == "debug"):
-        env.Append(LINKFLAGS=['-O0'])
-        env.Append(CPPFLAGS=['-O0', '-D_DEBUG', '-UNDEBUG', '-DDEBUG_ENABLED',
-                             '-DDEBUG_MEMORY_ENABLED', '-g', '-fno-limit-debug-info'])
-
     ## Architecture
 
     if env['android_arch'] not in ['armv7', 'armv6', 'x86']:
@@ -132,6 +118,20 @@ def configure(env):
             env.extra_suffix = ".armv7.neon" + env.extra_suffix
         else:
             env.extra_suffix = ".armv7" + env.extra_suffix
+
+    ## Build type
+
+    if (env["target"].startswith("release")):
+        env.Append(LINKFLAGS=['-O2'])
+        env.Append(CPPFLAGS=['-O2', '-DNDEBUG', '-ffast-math', '-funsafe-math-optimizations', '-fomit-frame-pointer'])
+        if (can_vectorize):
+            env.Append(CPPFLAGS=['-ftree-vectorize'])
+        if (env["target"] == "release_debug"):
+            env.Append(CPPFLAGS=['-DDEBUG_ENABLED'])
+    elif (env["target"] == "debug"):
+        env.Append(LINKFLAGS=['-O0'])
+        env.Append(CPPFLAGS=['-O0', '-D_DEBUG', '-UNDEBUG', '-DDEBUG_ENABLED',
+                             '-DDEBUG_MEMORY_ENABLED', '-g', '-fno-limit-debug-info'])
 
     ## Compiler configuration
 

--- a/thirdparty/libpng/pngpriv.h
+++ b/thirdparty/libpng/pngpriv.h
@@ -464,7 +464,7 @@
    static_cast<type>(static_cast<void*>(value))
 #  define png_aligncastconst(type, value) \
    static_cast<type>(static_cast<const void*>(value))
-#else
+#elif !defined(__ASSEMBLER__)
 #  define png_voidcast(type, value) (value)
 #  ifdef _WIN64
 #     ifdef __GNUC__


### PR DESCRIPTION
This commit fixes errors occurring during Android export template
builds.
This required modification in third-party library (libpng) to compile
with NEON. Most likely a similar patch will be applied by them and we
could then replace the modified version.