### PR TITLE
Update GDScript completion names for Pool*Arrays

### DIFF
--- a/core/variant_parser.cpp
+++ b/core/variant_parser.cpp
@@ -1099,7 +1099,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 
 			return OK;
 
-		} else if (id == "PoolFloatArray" || id == "FloatArray") {
+		} else if (id == "PoolRealArray" || id == "FloatArray") {
 
 			Vector<float> args;
 			Error err = _parse_construct<float>(p_stream, args, line, r_err_str);
@@ -1855,7 +1855,7 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 		} break;
 		case Variant::POOL_REAL_ARRAY: {
 
-			p_store_string_func(p_store_string_ud, "PoolFloatArray( ");
+			p_store_string_func(p_store_string_ud, "PoolRealArray( ");
 			PoolVector<real_t> data = p_variant;
 			int len = data.size();
 			PoolVector<real_t>::Read r = data.read();

--- a/modules/gdscript/gd_editor.cpp
+++ b/modules/gdscript/gd_editor.cpp
@@ -1334,8 +1334,8 @@ static void _find_identifiers(GDCompletionContext &context, int p_line, bool p_o
 
 	static const char *_type_names[Variant::VARIANT_MAX] = {
 		"null", "bool", "int", "float", "String", "Vector2", "Rect2", "Vector3", "Transform2D", "Plane", "Quat", "AABB", "Basis", "Transform",
-		"Color", "NodePath", "RID", "Object", "Dictionary", "Array", "RawArray", "IntArray", "FloatArray", "StringArray",
-		"Vector2Array", "Vector3Array", "ColorArray"
+		"Color", "NodePath", "RID", "Object", "Dictionary", "Array", "PoolByteArray", "PoolIntArray", "PoolRealArray", "PoolStringArray",
+		"PoolVector2Array", "PoolVector3Array", "PoolColorArray"
 	};
 
 	for (int i = 0; i < Variant::VARIANT_MAX; i++) {

--- a/modules/gdscript/gd_tokenizer.cpp
+++ b/modules/gdscript/gd_tokenizer.cpp
@@ -159,7 +159,7 @@ static const _bit _type_list[] = {
 	{ Variant::ARRAY, "Array" },
 	{ Variant::POOL_BYTE_ARRAY, "PoolByteArray" },
 	{ Variant::POOL_INT_ARRAY, "PoolIntArray" },
-	{ Variant::POOL_REAL_ARRAY, "PoolFloatArray" },
+	{ Variant::POOL_REAL_ARRAY, "PoolRealArray" },
 	{ Variant::POOL_STRING_ARRAY, "PoolStringArray" },
 	{ Variant::POOL_VECTOR2_ARRAY, "PoolVector2Array" },
 	{ Variant::POOL_VECTOR3_ARRAY, "PoolVector3Array" },


### PR DESCRIPTION
Notice: GDScript tokenizer used the old `PoolFloatArray` name.
Renamed `PoolFloatArray` to `PoolRealArray`.

Moved "project_settings.h" down one line to comply with the clang-format rules.

Fixes #9638

Closed pull request #9714 because I messed up with commits and panicked, sorry!