### PR TITLE
make use of 2 cores in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,8 +88,8 @@ script:
       sh ./misc/travis/clang-format.sh;
     else
       if [ "$TRAVIS_OS_NAME" = "windows" ]; then
-        scons platform=$GODOT_TARGET progress=no verbose=yes CXX=$CXX openssl=builtin;
+        scons -j 2 platform=$GODOT_TARGET progress=no verbose=yes CXX=$CXX openssl=builtin;
       else
-        scons platform=$GODOT_TARGET progress=no verbose=yes bits=64 CXX=$CXX openssl=builtin;
+        scons -j 2 platform=$GODOT_TARGET progress=no verbose=yes bits=64 CXX=$CXX openssl=builtin;
       fi
     fi


### PR DESCRIPTION
Hi, I'm back with some developer QoL changes. This time it's making Travis CI work faster.

Example:

master - https://travis-ci.org/Marqin/godot/builds/255939053
`-j 2` - https://travis-ci.org/Marqin/godot/builds/255934290