### PR TITLE
AnimationTree sliders fix

### DIFF
--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -371,6 +371,7 @@ void AnimationTreeEditor::_popup_edit_dialog() {
 				edit_label[0]->show();
 				edit_scroll[0]->set_min(0);
 				edit_scroll[0]->set_max(1);
+				edit_scroll[0]->set_step(0.01);
 				edit_scroll[0]->set_value(anim_tree->mix_node_get_amount(edited_node));
 				edit_scroll[0]->set_begin(Point2(15, 25));
 				edit_scroll[0]->show();
@@ -399,6 +400,7 @@ void AnimationTreeEditor::_popup_edit_dialog() {
 				edit_label[0]->show();
 				edit_scroll[0]->set_min(-1);
 				edit_scroll[0]->set_max(1);
+				edit_scroll[0]->set_step(0.01);
 				edit_scroll[0]->set_value(anim_tree->blend3_node_get_amount(edited_node));
 				edit_scroll[0]->set_begin(Point2(15, 25));
 				edit_scroll[0]->show();
@@ -412,6 +414,7 @@ void AnimationTreeEditor::_popup_edit_dialog() {
 				edit_label[0]->show();
 				edit_scroll[0]->set_min(0);
 				edit_scroll[0]->set_max(1);
+				edit_scroll[0]->set_step(0.01);
 				edit_scroll[0]->set_value(anim_tree->blend4_node_get_amount(edited_node).x);
 				edit_scroll[0]->set_begin(Point2(15, 25));
 				edit_scroll[0]->show();
@@ -420,6 +423,7 @@ void AnimationTreeEditor::_popup_edit_dialog() {
 				edit_label[1]->show();
 				edit_scroll[1]->set_min(0);
 				edit_scroll[1]->set_max(1);
+				edit_scroll[0]->set_step(0.01);
 				edit_scroll[1]->set_value(anim_tree->blend4_node_get_amount(edited_node).y);
 				edit_scroll[1]->set_begin(Point2(15, 75));
 				edit_scroll[1]->show();

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -29,8 +29,8 @@
 /*************************************************************************/
 #include "animation_tree_editor_plugin.h"
 
-#include "core/project_settings.h"
 #include "core/io/resource_loader.h"
+#include "core/project_settings.h"
 #include "os/input.h"
 #include "os/keyboard.h"
 #include "scene/gui/menu_button.h"
@@ -371,6 +371,7 @@ void AnimationTreeEditor::_popup_edit_dialog() {
 				edit_label[0]->show();
 				edit_scroll[0]->set_min(0);
 				edit_scroll[0]->set_max(1);
+				edit_scroll[0]->set_step(0.01);
 				edit_scroll[0]->set_value(anim_tree->mix_node_get_amount(edited_node));
 				edit_scroll[0]->set_begin(Point2(15, 25));
 				edit_scroll[0]->show();
@@ -383,6 +384,7 @@ void AnimationTreeEditor::_popup_edit_dialog() {
 				edit_label[0]->show();
 				edit_scroll[0]->set_min(0);
 				edit_scroll[0]->set_max(1);
+				edit_scroll[0]->set_step(0.01);
 				edit_scroll[0]->set_value(anim_tree->blend2_node_get_amount(edited_node));
 				edit_scroll[0]->set_begin(Point2(15, 25));
 				edit_scroll[0]->show();
@@ -398,6 +400,7 @@ void AnimationTreeEditor::_popup_edit_dialog() {
 				edit_label[0]->show();
 				edit_scroll[0]->set_min(-1);
 				edit_scroll[0]->set_max(1);
+				edit_scroll[0]->set_step(0.01);
 				edit_scroll[0]->set_value(anim_tree->blend3_node_get_amount(edited_node));
 				edit_scroll[0]->set_begin(Point2(15, 25));
 				edit_scroll[0]->show();
@@ -411,6 +414,7 @@ void AnimationTreeEditor::_popup_edit_dialog() {
 				edit_label[0]->show();
 				edit_scroll[0]->set_min(0);
 				edit_scroll[0]->set_max(1);
+				edit_scroll[0]->set_step(0.01);
 				edit_scroll[0]->set_value(anim_tree->blend4_node_get_amount(edited_node).x);
 				edit_scroll[0]->set_begin(Point2(15, 25));
 				edit_scroll[0]->show();
@@ -419,6 +423,7 @@ void AnimationTreeEditor::_popup_edit_dialog() {
 				edit_label[1]->show();
 				edit_scroll[1]->set_min(0);
 				edit_scroll[1]->set_max(1);
+				edit_scroll[0]->set_step(0.01);
 				edit_scroll[1]->set_value(anim_tree->blend4_node_get_amount(edited_node).y);
 				edit_scroll[1]->set_begin(Point2(15, 75));
 				edit_scroll[1]->show();

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -29,8 +29,8 @@
 /*************************************************************************/
 #include "animation_tree_editor_plugin.h"
 
-#include "core/project_settings.h"
 #include "core/io/resource_loader.h"
+#include "core/project_settings.h"
 #include "os/input.h"
 #include "os/keyboard.h"
 #include "scene/gui/menu_button.h"
@@ -383,6 +383,7 @@ void AnimationTreeEditor::_popup_edit_dialog() {
 				edit_label[0]->show();
 				edit_scroll[0]->set_min(0);
 				edit_scroll[0]->set_max(1);
+				edit_scroll[0]->set_step(0.01);
 				edit_scroll[0]->set_value(anim_tree->blend2_node_get_amount(edited_node));
 				edit_scroll[0]->set_begin(Point2(15, 25));
 				edit_scroll[0]->show();

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -273,8 +273,8 @@ Range::Range() {
 	shared = memnew(Shared);
 	shared->min = 0;
 	shared->max = 100;
-	shared->val =
-			shared->step = 1;
+	shared->val = 0;
+	shared->step = 1;
 	shared->page = 0;
 	shared->owners.insert(this);
 	shared->exp_ratio = false;

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -273,8 +273,8 @@ Range::Range() {
 	shared = memnew(Shared);
 	shared->min = 0;
 	shared->max = 100;
-	shared->val = 0.0;
-	shared->step = 1.0;
+	shared->val = 0;
+	shared->step = 1;
 	shared->page = 0;
 	shared->owners.insert(this);
 	shared->exp_ratio = false;

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -273,8 +273,8 @@ Range::Range() {
 	shared = memnew(Shared);
 	shared->min = 0;
 	shared->max = 100;
-	shared->val =
-			shared->step = 1;
+	shared->val = 0.0;
+	shared->step = 1.0;
 	shared->page = 0;
 	shared->owners.insert(this);
 	shared->exp_ratio = false;


### PR DESCRIPTION
This commit will ensure that `step property of concrete `Range` widgets which are used by `AnimationTreePlayer` will be set to 0.01 (one percent).

However I'm wondering why default values for step is 1.0 (100%), I don't think that makes a lot of sense. Also default range is 0-100 (0%-10 000%). 
We actually have somewhere in Godot UI such slider? Mean the one that uses those defaults? 
Current default in range: https://github.com/godotengine/godot/blob/master/scene/gui/range.cpp#L275

This pr will close #8093 

