### PR TITLE
OBJ Importer: Fix relative path materials.

### DIFF
--- a/editor/import/resource_importer_obj.cpp
+++ b/editor/import/resource_importer_obj.cpp
@@ -395,6 +395,10 @@ Node *EditorOBJImporter::import_scene(const String &p_path, uint32_t p_flags, in
 			if (!material_map.has(current_material_library)) {
 				Map<String, Ref<SpatialMaterial> > lib;
 				Error err = _parse_material_library(current_material_library, lib, r_missing_deps);
+				if (err == ERR_CANT_OPEN) {
+					String dir = p_path.get_base_dir();
+					err = _parse_material_library(dir.plus_file(current_material_library), lib, r_missing_deps);
+				}
 				if (err == OK) {
 					material_map[current_material_library] = lib;
 				}


### PR DESCRIPTION
The `mtl`s didn't load when they were referenced by name only, instead of including a path.

P.S: Now Kenney's assets are imported with materials ^^