### PR TITLE
Improve the script instance binding API

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1817,6 +1817,14 @@ uint32_t Object::get_edited_version() const {
 }
 #endif
 
+void Object::set_script_instance_binding(int p_script_language_index, void *p_data) {
+#ifdef DEBUG_ENABLED
+	ERR_FAIL_INDEX(p_script_language_index, MAX_SCRIPT_INSTANCE_BINDINGS);
+#endif
+
+	_script_instance_bindings[p_script_language_index] = p_data;
+}
+
 void *Object::get_script_instance_binding(int p_script_language_index) {
 #ifdef DEBUG_ENABLED
 	ERR_FAIL_INDEX_V(p_script_language_index, MAX_SCRIPT_INSTANCE_BINDINGS, NULL);
@@ -1826,10 +1834,6 @@ void *Object::get_script_instance_binding(int p_script_language_index) {
 	//just return the same pointer.
 	//if you want to put a big lock in the entire function and keep allocated pointers in a map or something, feel free to do it
 	//as it should not really affect performance much (won't be called too often), as in far most caes the condition below will be false afterwards
-
-	if (!_script_instance_bindings[p_script_language_index]) {
-		_script_instance_bindings[p_script_language_index] = ScriptServer::get_language(p_script_language_index)->alloc_instance_binding_data(this);
-	}
 
 	return _script_instance_bindings[p_script_language_index];
 }

--- a/core/object.h
+++ b/core/object.h
@@ -690,6 +690,7 @@ public:
 #endif
 
 	//used by script languages to store binding data
+	void set_script_instance_binding(int p_script_language_index, void *p_data);
 	void *get_script_instance_binding(int p_script_language_index);
 
 	void clear_internal_resource_paths();

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -274,7 +274,6 @@ public:
 	virtual int profiling_get_accumulated_data(ProfilingInfo *p_info_arr, int p_info_max) = 0;
 	virtual int profiling_get_frame_data(ProfilingInfo *p_info_arr, int p_info_max) = 0;
 
-	virtual void *alloc_instance_binding_data(Object *p_object) { return NULL; } //optional, not used by all languages
 	virtual void free_instance_binding_data(void *p_data) {} //optional, not used by all languages
 
 	virtual void frame();


### PR DESCRIPTION
As explained on IRC, there are two things wrong with the current API:
- `ScriptLanguage::alloc_instance_binding_data` has no context about what to allocate. Instead, we should call `set_script_instance_binding(int lang_idx, void* data)`. The caller is in charge of allocating the data.
- We need to know if there is data already attached. Either `get_script_instance_binding` should return null if there is nothing allocated, or there should be a `has_script_instance_binding` method. I chose the former with this PR.

