### PR TITLE
[2.1] Remove "debug/remote_port" project setting (completrly moved to editor)

### DIFF
--- a/editor/editor_import_export.cpp
+++ b/editor/editor_import_export.cpp
@@ -1030,6 +1030,7 @@ static int _get_pad(int p_alignment, int p_n) {
 void EditorExportPlatform::gen_export_flags(Vector<String> &r_flags, int p_flags) {
 
 	String host = EditorSettings::get_singleton()->get("network/debug_host");
+	int remote_port = (int)EditorSettings::get_singleton()->get("network/debug_port");
 
 	if (p_flags & EXPORT_REMOTE_DEBUG_LOCALHOST)
 		host = "localhost";
@@ -1049,7 +1050,7 @@ void EditorExportPlatform::gen_export_flags(Vector<String> &r_flags, int p_flags
 
 		r_flags.push_back("-rdebug");
 
-		r_flags.push_back(host + ":" + String::num(GLOBAL_DEF("network/debug_port", 6007)));
+		r_flags.push_back(host + ":" + String::num(remote_port));
 
 		List<String> breakpoints;
 		ScriptEditor::get_singleton()->get_breakpoints(&breakpoints);

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -41,6 +41,7 @@ Error EditorRun::run(const String &p_scene, const String p_custom_args, const Li
 
 	String resource_path = Globals::get_singleton()->get_resource_path();
 	String remote_host = EditorSettings::get_singleton()->get("network/debug_host");
+	int remote_port = (int)EditorSettings::get_singleton()->get("network/debug_port");
 
 	if (resource_path != "") {
 		args.push_back("-path");
@@ -49,7 +50,7 @@ Error EditorRun::run(const String &p_scene, const String p_custom_args, const Li
 
 	if (true) {
 		args.push_back("-rdebug");
-		args.push_back(remote_host + ":" + String::num(GLOBAL_DEF("network/debug_port", 6007)));
+		args.push_back(remote_host + ":" + String::num(remote_port));
 	}
 
 	args.push_back("-epid");

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -413,7 +413,7 @@ void EditorSettings::setup_network() {
 	String lip;
 	String hint;
 	String current = has("network/debug_host") ? get("network/debug_host") : "";
-	int port = has("network/debug_port") ? (int)get("network/debug_port") : 6007;
+	int port = has("network/debug_port") ? (int)get("network/debug_port") : 6096;
 
 	for (List<IP_Address>::Element *E = local_ip.front(); E; E = E->next()) {
 

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1169,9 +1169,9 @@ void ScriptEditorDebugger::start() {
 		perf_max[i] = 0;
 	}
 
-	uint16_t remote_port = GLOBAL_DEF("debug/remote_port", 6007);
-	if (server->listen(remote_port) != OK) {
-		EditorNode::get_log()->add_message(String("** Error listening on port ") + itos(remote_port) + String(" **"));
+	uint16_t debug_port = (int)EditorSettings::get_singleton()->get("network/debug_port");
+	if (server->listen(debug_port) != OK) {
+		EditorNode::get_log()->add_message(String("** Error listening on port ") + itos(debug_port) + String(" **"));
 		return;
 	}
 	set_process(true);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -562,7 +562,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	if (debug_mode == "remote") {
 
 		ScriptDebuggerRemote *sdr = memnew(ScriptDebuggerRemote);
-		uint16_t debug_port = GLOBAL_DEF("debug/remote_port", 6007);
+		uint16_t debug_port = 6096;
 		if (debug_host.find(":") != -1) {
 			int sep_pos = debug_host.find_last(":");
 			debug_port = debug_host.substr(sep_pos + 1, debug_host.length()).to_int();


### PR DESCRIPTION
This was already done in master and not cherry picked.

Also updated default port from 6007 (X11) to 6096 (unspec)
This might be the reason why some OSX users are reporting the port to be busy. Port 6007 is apparently used by remote X11 but on most linux distros is disabled.
I know of OSX users that installs X (to run X applications) and maybe they leave the remote connections enabled.
It's a wild guess, but I can't reproduce the problems in #8563 #9635 so I came up with this speculation.
The new port 6096 seems not to be used by any known software (or malware, so the AV mafia should not complain).
This bit is not applied in master, if you agree to changing the default port we should change it there too.

#8744 will need some more logs to investigate, it might be a misconfiguration due to the current messed-up config state of the branch, it that's the case, this patch should fix it.

P.S.: misconfiguration can be the case also for #8563 and #9635 so again, this PR should fix it, but again again, I cannot test it because I can't reproduce it.