### PR TITLE
Implement input focus behavior in HTML5

### DIFF
--- a/platform/javascript/SCsub
+++ b/platform/javascript/SCsub
@@ -19,7 +19,7 @@ javascript_objects = []
 for x in javascript_files:
     javascript_objects.append(env_javascript.Object(x))
 
-env.Append(LINKFLAGS=["-s", "EXPORTED_FUNCTIONS=\"['_main','_audio_server_mix_function','_main_after_fs_sync']\""])
+env.Append(LINKFLAGS=["-s", "EXPORTED_FUNCTIONS=\"['_main','_audio_server_mix_function','_main_after_fs_sync','_send_notification']\""])
 env.Append(LINKFLAGS=["--shell-file", '"platform/javascript/godot_shell.html"'])
 
 # output file name without file extension

--- a/platform/javascript/godot_shell.html
+++ b/platform/javascript/godot_shell.html
@@ -83,6 +83,10 @@
 			color: white;
 		}
 
+		#canvas:focus {
+			outline: none;
+		}
+
 
 		/* Status display
 		 * ============== */
@@ -147,7 +151,7 @@ $GODOT_HEAD_INCLUDE
 </head>
 <body>
 	<div id="container">
-		<canvas id="canvas" width="640" height="480" onclick="canvas.ownerDocument.defaultView.focus();" oncontextmenu="event.preventDefault();">
+		<canvas id="canvas" width="640" height="480" tabindex="0" oncontextmenu="event.preventDefault();">
 			HTML5 canvas appears to be unsupported in the current browser.<br />
 			Please try updating or use a different browser.
 		</canvas>


### PR DESCRIPTION
This patch makes Godot consume input events less aggressively, making it easier to embed the canvas in HTML pages.
The behavior imitates desktop apps, with the canvas as a faux window. Could also be compared to the behavior of embedded Adobe Flash apps

 - Key and mouse events are only consumed if canvas is focused
 - NOTIFICATION_WM_MOUSE_ENTER, _MOUSE_EXIT, _FOCUS_IN and _FOCUS_OUT are
   emitted