### PR TITLE
Add .to_local/.to_global methods on Node2D and Spatial

### DIFF
--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -398,6 +398,16 @@ float Node2D::get_angle_to(const Vector2 &p_pos) const {
 	return (get_global_transform().affine_inverse().xform(p_pos)).angle();
 }
 
+Point2 Node2D::to_local(Point2 p_global) const {
+
+	return get_global_transform().affine_inverse().xform(p_global);
+}
+
+Point2 Node2D::to_global(Point2 p_local) const {
+
+	return get_global_transform().xform(p_local);
+}
+
 void Node2D::_bind_methods() {
 
 	// TODO: Obsolete those two methods (old name) properly (GH-4397)
@@ -435,6 +445,9 @@ void Node2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("look_at", "point"), &Node2D::look_at);
 	ClassDB::bind_method(D_METHOD("get_angle_to", "point"), &Node2D::get_angle_to);
+
+	ClassDB::bind_method(D_METHOD("to_local", "global_point"), &Node2D::to_local);
+	ClassDB::bind_method(D_METHOD("to_global", "local_point"), &Node2D::to_global);
 
 	ClassDB::bind_method(D_METHOD("set_z", "z"), &Node2D::set_z);
 	ClassDB::bind_method(D_METHOD("get_z"), &Node2D::get_z);

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -104,6 +104,9 @@ public:
 	void look_at(const Vector2 &p_pos);
 	float get_angle_to(const Vector2 &p_pos) const;
 
+	Point2 to_local(Point2 p_global) const;
+	Point2 to_global(Point2 p_local) const;
+
 	void set_z_as_relative(bool p_enabled);
 	bool is_z_relative() const;
 

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -674,6 +674,16 @@ void Spatial::look_at_from_pos(const Vector3 &p_pos, const Vector3 &p_target, co
 	set_global_transform(lookat);
 }
 
+Vector3 Spatial::to_local(Vector3 p_global) const {
+
+	return get_global_transform().affine_inverse().xform(p_global);
+}
+
+Vector3 Spatial::to_global(Vector3 p_local) const {
+
+	return get_global_transform().xform(p_local);
+}
+
 void Spatial::set_notify_transform(bool p_enable) {
 	data.notify_transform = p_enable;
 }
@@ -755,6 +765,9 @@ void Spatial::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("look_at", "target", "up"), &Spatial::look_at);
 	ClassDB::bind_method(D_METHOD("look_at_from_pos", "pos", "target", "up"), &Spatial::look_at_from_pos);
+
+	ClassDB::bind_method(D_METHOD("to_local", "global_point"), &Spatial::to_local);
+	ClassDB::bind_method(D_METHOD("to_global", "local_point"), &Spatial::to_global);
 
 	BIND_CONSTANT(NOTIFICATION_TRANSFORM_CHANGED);
 	BIND_CONSTANT(NOTIFICATION_ENTER_WORLD);

--- a/scene/3d/spatial.h
+++ b/scene/3d/spatial.h
@@ -173,6 +173,9 @@ public:
 	void look_at(const Vector3 &p_target, const Vector3 &p_up_normal);
 	void look_at_from_pos(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up_normal);
 
+	Vector3 to_local(Vector3 p_global) const;
+	Vector3 to_global(Vector3 p_local) const;
+
 	void set_notify_transform(bool p_enable);
 	bool is_transform_notification_enabled() const;
 


### PR DESCRIPTION
Those are just helpers around `get_global_transform().affine_inverse().xform()` and `get_global_transform().xform()`.
Closes #6087