### PR TITLE
Fix switching SRGB extension happen before binding of texture

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1243,35 +1243,35 @@ bool RasterizerSceneGLES3::_setup_material(RasterizerStorageGLES3::Material *p_m
 			if (t->render_target)
 				t->render_target->used_in_frame = true;
 
-			if (storage->config.srgb_decode_supported) {
-				//if SRGB decode extension is present, simply switch the texture to whathever is needed
-				bool must_srgb = false;
-
-				if (t->srgb && (texture_hints[i] == ShaderLanguage::ShaderNode::Uniform::HINT_ALBEDO || texture_hints[i] == ShaderLanguage::ShaderNode::Uniform::HINT_BLACK_ALBEDO)) {
-					must_srgb = true;
-				}
-
-				if (t->using_srgb != must_srgb) {
-					if (must_srgb) {
-						glTexParameteri(t->target, _TEXTURE_SRGB_DECODE_EXT, _DECODE_EXT);
-#ifdef TOOLS_ENABLED
-						if (t->detect_srgb) {
-							t->detect_srgb(t->detect_srgb_ud);
-						}
-#endif
-
-					} else {
-						glTexParameteri(t->target, _TEXTURE_SRGB_DECODE_EXT, _SKIP_DECODE_EXT);
-					}
-					t->using_srgb = must_srgb;
-				}
-			}
-
 			target = t->target;
 			tex = t->tex_id;
 		}
 
 		glBindTexture(target, tex);
+
+		if (t && storage->config.srgb_decode_supported) {
+			//if SRGB decode extension is present, simply switch the texture to whathever is needed
+			bool must_srgb = false;
+
+			if (t->srgb && (texture_hints[i] == ShaderLanguage::ShaderNode::Uniform::HINT_ALBEDO || texture_hints[i] == ShaderLanguage::ShaderNode::Uniform::HINT_BLACK_ALBEDO)) {
+				must_srgb = true;
+			}
+
+			if (t->using_srgb != must_srgb) {
+				if (must_srgb) {
+					glTexParameteri(t->target, _TEXTURE_SRGB_DECODE_EXT, _DECODE_EXT);
+#ifdef TOOLS_ENABLED
+					if (t->detect_srgb) {
+						t->detect_srgb(t->detect_srgb_ud);
+					}
+#endif
+
+				} else {
+					glTexParameteri(t->target, _TEXTURE_SRGB_DECODE_EXT, _SKIP_DECODE_EXT);
+				}
+				t->using_srgb = must_srgb;
+			}
+		}
 
 		if (i == 0) {
 			state.current_main_tex = tex;


### PR DESCRIPTION
Previously, texture parameter `_TEXTURE_SRGB_DECODE_EXT` was changed before the call of `glBindTexture`, which caused modification of previously bound texture instead of desired one. Now it's changed after `glBindTexture`.