### PR TITLE
Fixed setting our system_fbo framebuffer

### DIFF
--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -109,7 +109,6 @@ void OSIPhone::initialize(const VideoMode &p_desired, int p_video_driver, int p_
 
 	RasterizerGLES3::register_config();
 	RasterizerGLES3::make_current();
-	RasterizerStorageGLES3::system_fbo = gl_view_base_fb;
 
 	visual_server = memnew(VisualServerRaster());
 	/*
@@ -121,6 +120,9 @@ void OSIPhone::initialize(const VideoMode &p_desired, int p_video_driver, int p_
 
 	visual_server->init();
 	visual_server->cursor_set_visible(false, 0);
+
+	// reset this to what it should be, it will have been set to 0 after visual_server->init() is called
+	RasterizerStorageGLES3::system_fbo = gl_view_base_fb;
 
 	audio_driver = memnew(AudioDriverIphone);
 	audio_driver->set_singleton();
@@ -434,7 +436,8 @@ bool OSIPhone::can_draw() const {
 
 int OSIPhone::set_base_framebuffer(int p_fb) {
 
-	RasterizerStorageGLES3::system_fbo = gl_view_base_fb;
+	// gl_view_base_fb has not been updated yet
+	RasterizerStorageGLES3::system_fbo = p_fb;
 
 	return 0;
 };


### PR DESCRIPTION
system_fbo was being assigned before visual_server->init() was called, the result was that it got cleared.

Also set_base_framebuffer copied the global gl_view_base_fb which hasn't been set yet when it gets called. I think its obsolete anyway because the iOS framebuffer gets created before init() is called on visual server.

Note that this whole thing should be re-examined. It creates and destroys the iOS framebuffer 3 times. I haven't had time to look into that further. It may be smart to investigate using NSOpenGLView so we piggy back on all the latest changes Apple has added into this especially since al the rendering happens in framebuffers in the render engine itself.