### PR TITLE
Remove ANDROID define

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -178,7 +178,7 @@ def configure(env):
 
     env.Append(CPPFLAGS=["-isystem", sysroot + "/usr/include"])
     env.Append(CPPFLAGS=string.split('-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -fvisibility=hidden -fno-strict-aliasing'))
-    env.Append(CPPFLAGS=string.split('-DANDROID -DNO_STATVFS -DGLES2_ENABLED'))
+    env.Append(CPPFLAGS=string.split('-DNO_STATVFS -DGLES2_ENABLED'))
 
     env['neon_enabled'] = False
     if env['android_arch'] == 'x86':


### PR DESCRIPTION
~~Consistent with its counterpart for other OSs and also fixes GDNative build error on Android.~~

~~Seems not to be used anywhere, so it's safe to change.~~

__UPDATE:__
It's also discouraged by Google to rely on it. In case someone needs to check, use ``__ANDROID__`` instead, provided by the very same compiler.