### PR TITLE
Improve/add atomics

### DIFF
--- a/core/safe_refcount.h
+++ b/core/safe_refcount.h
@@ -41,12 +41,14 @@ uint32_t atomic_decrement(register uint32_t *pw);
 uint32_t atomic_increment(register uint32_t *pw);
 uint32_t atomic_sub(register uint32_t *pw, register uint32_t val);
 uint32_t atomic_add(register uint32_t *pw, register uint32_t val);
+uint32_t atomic_exchange_if_greater(register uint32_t *pw, register uint32_t val);
 
 uint64_t atomic_conditional_increment(register uint64_t *counter);
 uint64_t atomic_decrement(register uint64_t *pw);
 uint64_t atomic_increment(register uint64_t *pw);
 uint64_t atomic_sub(register uint64_t *pw, register uint64_t val);
 uint64_t atomic_add(register uint64_t *pw, register uint64_t val);
+uint64_t atomic_exchange_if_greater(register uint64_t *pw, register uint64_t val);
 
 struct SafeRefCount {
 


### PR DESCRIPTION
- Remove use of non-builtin overloaded `InterlockedExhangeSubtract()` for Windows. Moreover, it was wrongly being used as if it had a 64-bit version instead of being overloaded. (*)
- Implement exchange-if-greater (as a CAS loop).

*: @vnen, you were right regarding `InterlockedExchangeSubtract64()` not being present in UWP, but the thing is that it doesn't even exist in "normal" Windows at all. I imagined it. :)