### PR TITLE
Improve reliability of memory stats

### DIFF
--- a/core/os/memory.cpp
+++ b/core/os/memory.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 #include "memory.h"
 #include "copymem.h"
+#include "core/safe_refcount.h"
 #include "error_macros.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -43,14 +44,12 @@ void *operator new(size_t p_size, void *(*p_allocfunc)(size_t p_size)) {
 	return p_allocfunc(p_size);
 }
 
-#include <stdio.h>
-
 #ifdef DEBUG_ENABLED
-size_t Memory::mem_usage = 0;
-size_t Memory::max_usage = 0;
+uint64_t Memory::mem_usage = 0;
+uint64_t Memory::max_usage = 0;
 #endif
 
-size_t Memory::alloc_count = 0;
+uint64_t Memory::alloc_count = 0;
 
 void *Memory::alloc_static(size_t p_bytes, bool p_pad_align) {
 
@@ -62,9 +61,9 @@ void *Memory::alloc_static(size_t p_bytes, bool p_pad_align) {
 
 	void *mem = malloc(p_bytes + (prepad ? PAD_ALIGN : 0));
 
-	alloc_count++;
-
 	ERR_FAIL_COND_V(!mem, NULL);
+
+	atomic_increment(&alloc_count);
 
 	if (prepad) {
 		uint64_t *s = (uint64_t *)mem;
@@ -73,10 +72,8 @@ void *Memory::alloc_static(size_t p_bytes, bool p_pad_align) {
 		uint8_t *s8 = (uint8_t *)mem;
 
 #ifdef DEBUG_ENABLED
-		mem_usage += p_bytes;
-		if (mem_usage > max_usage) {
-			max_usage = mem_usage;
-		}
+		atomic_add(&mem_usage, p_bytes);
+		atomic_exchange_if_greater(&max_usage, mem_usage);
 #endif
 		return s8 + PAD_ALIGN;
 	} else {
@@ -103,8 +100,12 @@ void *Memory::realloc_static(void *p_memory, size_t p_bytes, bool p_pad_align) {
 		uint64_t *s = (uint64_t *)mem;
 
 #ifdef DEBUG_ENABLED
-		mem_usage -= *s;
-		mem_usage += p_bytes;
+		if (p_bytes > *s) {
+			atomic_add(&mem_usage, p_bytes - *s);
+			atomic_exchange_if_greater(&max_usage, mem_usage);
+		} else {
+			atomic_sub(&mem_usage, *s - p_bytes);
+		}
 #endif
 
 		if (p_bytes == 0) {
@@ -144,14 +145,14 @@ void Memory::free_static(void *p_ptr, bool p_pad_align) {
 	bool prepad = p_pad_align;
 #endif
 
-	alloc_count--;
+	atomic_decrement(&alloc_count);
 
 	if (prepad) {
 		mem -= PAD_ALIGN;
 		uint64_t *s = (uint64_t *)mem;
 
 #ifdef DEBUG_ENABLED
-		mem_usage -= *s;
+		atomic_sub(&mem_usage, *s);
 #endif
 
 		free(mem);
@@ -161,19 +162,20 @@ void Memory::free_static(void *p_ptr, bool p_pad_align) {
 	}
 }
 
-size_t Memory::get_mem_available() {
+uint64_t Memory::get_mem_available() {
 
-	return 0xFFFFFFFFFFFFF;
+	return -1; // 0xFFFF...
 }
 
-size_t Memory::get_mem_usage() {
+uint64_t Memory::get_mem_usage() {
 #ifdef DEBUG_ENABLED
 	return mem_usage;
 #else
 	return 0;
 #endif
 }
-size_t Memory::get_mem_max_usage() {
+
+uint64_t Memory::get_mem_max_usage() {
 #ifdef DEBUG_ENABLED
 	return max_usage;
 #else

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -45,20 +45,20 @@ class Memory {
 
 	Memory();
 #ifdef DEBUG_ENABLED
-	static size_t mem_usage;
-	static size_t max_usage;
+	static uint64_t mem_usage;
+	static uint64_t max_usage;
 #endif
 
-	static size_t alloc_count;
+	static uint64_t alloc_count;
 
 public:
 	static void *alloc_static(size_t p_bytes, bool p_pad_align = false);
 	static void *realloc_static(void *p_memory, size_t p_bytes, bool p_pad_align = false);
 	static void free_static(void *p_ptr, bool p_pad_align = false);
 
-	static size_t get_mem_available();
-	static size_t get_mem_usage();
-	static size_t get_mem_max_usage();
+	static uint64_t get_mem_available();
+	static uint64_t get_mem_usage();
+	static uint64_t get_mem_max_usage();
 };
 
 class DefaultAllocator {

--- a/main/performance.cpp
+++ b/main/performance.cpp
@@ -117,8 +117,8 @@ float Performance::get_monitor(Monitor p_monitor) const {
 		case TIME_FIXED_PROCESS: return _fixed_process_time;
 		case MEMORY_STATIC: return Memory::get_mem_usage();
 		case MEMORY_DYNAMIC: return MemoryPool::total_memory;
-		case MEMORY_STATIC_MAX: return MemoryPool::max_memory;
-		case MEMORY_DYNAMIC_MAX: return 0;
+		case MEMORY_STATIC_MAX: return Memory::get_mem_max_usage();
+		case MEMORY_DYNAMIC_MAX: return MemoryPool::max_memory;
 		case MEMORY_MESSAGE_BUFFER_MAX: return MessageQueue::get_singleton()->get_max_buffer_usage();
 		case OBJECT_COUNT: return ObjectDB::get_object_count();
 		case OBJECT_RESOURCE_COUNT: return ResourceCache::get_cached_resource_count();


### PR DESCRIPTION
## Commit: _Make memory monitors query the right counters_
_(Not sure about this one, but at least now `MEMORY_STATIC` and `MEMORY_STATIC_MAX` refer to the same memory "nature".)_

## Commit: _Use atomics for memory use tracking_

Plus:
- An allocation is counted only after checking its success.
- Max usage is updated after growing reallocs as well.
- Drop unused header.
- Changed the 0xFFF.. at `get_mem_available()` to -1 with a comment telling it's the same, but more universal.