### PR TITLE
Fix Node::move_child() crash if moving to the end plus one

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -311,6 +311,11 @@ void Node::move_child(Node *p_child, int p_pos) {
 		ERR_FAIL_COND(data.blocked > 0);
 	}
 
+	// Specifying one place beyond the end
+	// means the same as moving to the last position
+	if (p_pos == data.children.size())
+		p_pos--;
+
 	if (p_child->data.pos == p_pos)
 		return; //do nothing
 


### PR DESCRIPTION
Fixes #9820.