### PR TITLE
Fix Node::move_child() crash if moving to the end plus one (2.1)

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -274,6 +274,11 @@ void Node::move_child(Node *p_child, int p_pos) {
 		ERR_FAIL_COND(data.blocked > 0);
 	}
 
+	// Specifying one place beyond the end
+	// means the same as moving to the last position
+	if (p_pos == data.children.size())
+		p_pos--;
+
 	data.children.remove(p_child->data.pos);
 	data.children.insert(p_pos, p_child);
 


### PR DESCRIPTION
(cherry picked from commit 6c1b7fd899f72136a1cc17eb9ae81746d8d98572)