### PR TITLE
Improved macOS window resizing behaviour (2.1)

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -191,6 +191,12 @@ static bool mouse_down_control = false;
 	OS_OSX::singleton->window_size.width = fbRect.size.width * OS_OSX::singleton->display_scale;
 	OS_OSX::singleton->window_size.height = fbRect.size.height * OS_OSX::singleton->display_scale;
 
+	if (OS_OSX::singleton->main_loop) {
+		Main::force_redraw();
+		//Event retrieval blocks until resize is over. Call Main::iteration() directly.
+		Main::iteration();
+	}
+	
 	//_GodotInputFramebufferSize(window, fbRect.size.width, fbRect.size.height);
 	//_GodotInputWindowSize(window, contentRect.size.width, contentRect.size.height);
 	//_GodotInputWindowDamage(window);


### PR DESCRIPTION
Partially fixes #9546.

Image updates only when the window size is actually changed.

![after](https://user-images.githubusercontent.com/7645683/28566633-6f1297a4-7138-11e7-8d0b-14adcc24b2a8.gif)
