### PR TITLE
Add support for ARMv8 (64-bit) on Android

### DIFF
--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -141,6 +141,8 @@ if env['android_arch'] == 'armv6':
     lib_arch_dir = 'armeabi'
 elif env['android_arch'] == 'armv7':
     lib_arch_dir = 'armeabi-v7a'
+elif env['android_arch'] == 'arm64v8':
+    lib_arch_dir = 'arm64-v8a'
 elif env['android_arch'] == 'x86':
     lib_arch_dir = 'x86'
 else:

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -219,6 +219,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 	bool use_32_fb;
 	bool immersive;
 	bool export_arm;
+	bool export_arm64;
 	bool export_x86;
 	String apk_expansion_salt;
 	String apk_expansion_pkey;
@@ -319,6 +320,8 @@ bool EditorExportPlatformAndroid::_set(const StringName& p_name, const Variant& 
 		_signed=p_value;
 	else if (n=="architecture/arm")
 		export_arm=p_value;
+	else if (n=="architecture/arm64")
+		export_arm64=p_value;
 	else if (n=="architecture/x86")
 		export_x86=p_value;
 	else if (n=="screen/use_32_bits_view")
@@ -392,6 +395,8 @@ bool EditorExportPlatformAndroid::_get(const StringName& p_name,Variant &r_ret) 
 		r_ret=_signed;
 	else if (n=="architecture/arm")
 		r_ret=export_arm;
+	else if (n=="architecture/arm64")
+		r_ret=export_arm64;
 	else if (n=="architecture/x86")
 		r_ret=export_x86;
 	else if (n=="screen/use_32_bits_view")
@@ -1164,6 +1169,10 @@ Error EditorExportPlatformAndroid::export_project(const String& p_path, bool p_d
 			skip=true;
 		}
 
+		if (file.match("lib/arm64*/libgodot_android.so") && !export_arm64) {
+			skip = true;
+		}
+
 		if (file.begins_with("META-INF") && _signed) {
 			skip=true;
 		}
@@ -1801,6 +1810,7 @@ EditorExportPlatformAndroid::EditorExportPlatformAndroid() {
 	immersive=true;
 
 	export_arm=true;
+	export_arm64=false;
 	export_x86=false;
 
 
@@ -3162,6 +3172,7 @@ public:
 
 		bool export_x86 = p_preset->get("architecture/x86");
 		bool export_arm = p_preset->get("architecture/arm");
+		bool export_arm64 = p_preset->get("architecture/arm64");
 
 		bool use_32_fb = p_preset->get("screen/use_32_bits_view");
 		bool immersive = p_preset->get("screen/immersive_mode");
@@ -3250,6 +3261,10 @@ public:
 			}
 
 			if (file.match("lib/armeabi*/libgodot_android.so") && !export_arm) {
+				skip = true;
+			}
+
+			if (file.match("lib/arm64*/libgodot_android.so") && !export_arm64) {
 				skip = true;
 			}
 

--- a/platform/android/java_class_wrapper.cpp
+++ b/platform/android/java_class_wrapper.cpp
@@ -190,7 +190,7 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 				argv[i].i = *p_args[i];
 			} break;
 			case ARG_TYPE_LONG: {
-				argv[i].j = *p_args[i];
+				argv[i].j = (int64_t)*p_args[i];
 			} break;
 			case ARG_TYPE_FLOAT: {
 				argv[i].f = *p_args[i];
@@ -350,7 +350,7 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 				Array arr = *p_args[i];
 				jlongArray a = env->NewLongArray(arr.size());
 				for (int j = 0; j < arr.size(); j++) {
-					jlong val = arr[j];
+					jlong val = (int64_t)arr[j];
 					env->SetLongArrayRegion(a, j, 1, &val);
 				}
 				argv[i].l = a;
@@ -460,9 +460,9 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 		case ARG_TYPE_LONG: {
 
 			if (method->_static) {
-				ret = env->CallStaticLongMethodA(_class, method->method, argv);
+				ret = (int64_t)env->CallStaticLongMethodA(_class, method->method, argv);
 			} else {
-				ret = env->CallLongMethodA(p_instance->instance, method->method, argv);
+				ret = (int64_t)env->CallLongMethodA(p_instance->instance, method->method, argv);
 			}
 
 		} break;
@@ -680,7 +680,7 @@ bool JavaClass::_convert_object_to_variant(JNIEnv *env, jobject obj, Variant &va
 		} break;
 		case ARG_TYPE_LONG | ARG_NUMBER_CLASS_BIT: {
 
-			var = env->CallLongMethod(obj, JavaClassWrapper::singleton->Long_longValue);
+			var = (int64_t)env->CallLongMethod(obj, JavaClassWrapper::singleton->Long_longValue);
 			return true;
 
 		} break;
@@ -802,7 +802,7 @@ bool JavaClass::_convert_object_to_variant(JNIEnv *env, jobject obj, Variant &va
 
 				jlong val;
 				env->GetLongArrayRegion((jlongArray)arr, 0, 1, &val);
-				ret.push_back(val);
+				ret.push_back((int64_t)val);
 			}
 
 			var = ret;


### PR DESCRIPTION
This should be tested.

For 64-bit archs (both x64 and ARM64) you have to tell NDK you want `android-21` at least. By the NDK docs, that's not a problem even if you keep your `minSdkVersion` to something lower, because you are telling it to use specific 64-bit system headers & libs and they won't be usable from a lower Android version so no binary compatibility problems will arise.

The problem is that I'm not sure how to proceed:

- letting __`detect.py`__ force `android-21` for ARMv8 if the default is kept or an otherwise lower value has been passed to it (but then how to specify the default if it can only be a fixed value?, or just do the change under the hood without making it explicit --not good I think--);
- telling people to manually add `android-21` or higher to the SCons command line for ARMv8 and document it (__as this PR is now you have to do that__).

Closes #9628.

P. S.: Maybe I have over-labeled this one. If you are from the team, feel free to remove some.
