### PR TITLE
fix a regression (GDScript) from e00630b

### DIFF
--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -3283,7 +3283,7 @@ void GDParser::_parse_class(ClassNode *p_class) {
 							break;
 						}
 
-						if (tokenizer->is_token_literal(0, true)) {
+						if (!tokenizer->is_token_literal(0, true)) {
 							_set_error("Expected identifier in signal argument.");
 							return;
 						}

--- a/modules/gdscript/gd_tokenizer.cpp
+++ b/modules/gdscript/gd_tokenizer.cpp
@@ -250,7 +250,7 @@ bool GDTokenizer::is_token_literal(int p_offset, bool variable_safe) const {
 		case TK_BUILT_IN_FUNC:
 
 		case TK_OP_IN:
-		case TK_OP_NOT:
+		//case TK_OP_NOT:
 		//case TK_OP_OR:
 		//case TK_OP_AND:
 


### PR DESCRIPTION
This removes `not` from the variable safe list of
keywords.
Before that this was a valid expression:
    self.!(some_arg)

The other fix is just a forgotten boolean negation.