### PR TITLE
zstd: Apply upstream patch to fix UWP ARM build

### DIFF
--- a/thirdparty/zstd/common/zstd_internal.h
+++ b/thirdparty/zstd/common/zstd_internal.h
@@ -331,4 +331,16 @@ size_t ZSTD_compressStream_generic(ZSTD_CStream* zcs,
 ZSTD_parameters ZSTD_getParamsFromCDict(const ZSTD_CDict* cdict);
 
 
+typedef struct {
+    blockType_e blockType;
+    U32 lastBlock;
+    U32 origSize;
+} blockProperties_t;
+
+/*! ZSTD_getcBlockSize() :
+ *   Provides the size of compressed block from block header `src` */
+ size_t ZSTD_getcBlockSize(const void* src, size_t srcSize,
+                           blockProperties_t* bpPtr);
+
+
 #endif   /* ZSTD_CCOMMON_H_MODULE */

--- a/thirdparty/zstd/decompress/zstd_decompress.c
+++ b/thirdparty/zstd/decompress/zstd_decompress.c
@@ -53,7 +53,7 @@
 #  include "zstd_legacy.h"
 #endif
 
-#if defined(_MSC_VER) && !defined(_M_IA64)  /* _mm_prefetch() is not defined for ia64 */
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_I86))  /* _mm_prefetch() is not defined outside of x86/x64 */
 #  include <mmintrin.h>   /* https://msdn.microsoft.com/fr-fr/library/84szxsww(v=vs.90).aspx */
 #  define ZSTD_PREFETCH(ptr)   _mm_prefetch((const char*)ptr, _MM_HINT_T0)
 #elif defined(__GNUC__)
@@ -465,13 +465,6 @@ static size_t ZSTD_decodeFrameHeader(ZSTD_DCtx* dctx, const void* src, size_t he
     return 0;
 }
 
-
-typedef struct
-{
-    blockType_e blockType;
-    U32 lastBlock;
-    U32 origSize;
-} blockProperties_t;
 
 /*! ZSTD_getcBlockSize() :
 *   Provides the size of compressed block from block header `src` */


### PR DESCRIPTION
Following upstream commit https://github.com/facebook/zstd/commit/f04deff4fc.