### PR TITLE
Fix cvs files freezing the editor when a double quote is not closed

### DIFF
--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -300,6 +300,8 @@ Vector<String> FileAccess::get_csv_line(String delim) const {
 	String l;
 	int qc = 0;
 	do {
+		ERR_FAIL_COND_V(eof_reached(), Vector<String>());
+
 		l += get_line() + "\n";
 		qc = 0;
 		for (int i = 0; i < l.length(); i++) {


### PR DESCRIPTION
When a translation file contained a missing double quote the editor would try to load the file forever.