### PR TITLE
Enable 2D physics motion fix for new projects (2.1)

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -206,6 +206,10 @@ private:
 					f->store_line("\n");
 					f->store_line("name=\"" + project_name->get_text() + "\"");
 					f->store_line("icon=\"res://icon.png\"");
+					f->store_line("\n");
+					f->store_line("[physics_2d]");
+					f->store_line("\n");
+					f->store_line("motion_fix_enabled=true");
 
 					memdelete(f);
 


### PR DESCRIPTION
As suggested by @eon-s.

And a good idea indeed so people playing with both branches get expected results. It should be only disabled for legacy projects already developed relying on the "unfixed" behavior.

Fixes  #9325.
Closes #9137.