### PR TITLE
Theme border settings change + updating styles

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1621,12 +1621,18 @@ void EditorHelp::_notification(int p_what) {
 	switch (p_what) {
 
 		case NOTIFICATION_READY: {
-
 			//forward->set_icon(get_icon("Forward","EditorIcons"));
 			//back->set_icon(get_icon("Back","EditorIcons"));
 			_update_doc();
-
 		} break;
+
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			Ref<StyleBoxFlat> style(memnew(StyleBoxFlat));
+			style->set_bg_color(EditorSettings::get_singleton()->get("text_editor/highlighting/background_color"));
+			background_panel->add_style_override("panel", style);
+		} break;
+
+		default: break;
 	}
 }
 
@@ -1695,14 +1701,14 @@ EditorHelp::EditorHelp() {
 	//class_list->set_selection_enabled(true);
 
 	{
-		Panel *pc = memnew(Panel);
+		background_panel = memnew(Panel);
 		Ref<StyleBoxFlat> style(memnew(StyleBoxFlat));
 		style->set_bg_color(EditorSettings::get_singleton()->get("text_editor/highlighting/background_color"));
-		pc->set_v_size_flags(SIZE_EXPAND_FILL);
-		pc->add_style_override("panel", style); //get_stylebox("normal","TextEdit"));
-		vbc->add_child(pc);
+		background_panel->set_v_size_flags(SIZE_EXPAND_FILL);
+		background_panel->add_style_override("panel", style); //get_stylebox("normal","TextEdit"));
+		vbc->add_child(background_panel);
 		class_desc = memnew(RichTextLabel);
-		pc->add_child(class_desc);
+		background_panel->add_child(class_desc);
 		class_desc->set_area_as_parent_rect(8);
 		class_desc->connect("meta_clicked", this, "_class_desc_select");
 		class_desc->connect("gui_input", this, "_class_desc_input");

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -129,6 +129,7 @@ class EditorHelp : public VBoxContainer {
 	HSplitContainer *h_split;
 	static DocData *doc;
 
+	Panel *background_panel;
 	ConfirmationDialog *search_dialog;
 	LineEdit *search;
 

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -143,7 +143,7 @@ Ref<Theme> create_editor_theme() {
 	Color light_color_1 = base_color.linear_interpolate(Color(1, 1, 1, 1), contrast);
 	Color light_color_2 = base_color.linear_interpolate(Color(1, 1, 1, 1), contrast * 1.5);
 
-	const int border_width = (border_size % 3) * EDSCALE;
+	const int border_width = MIN(border_size, 3) * EDSCALE;
 
 	Color title_color_hl = base_color;
 	if (highlight_tabs)
@@ -280,12 +280,12 @@ Ref<Theme> create_editor_theme() {
 
 	// PopupMenu
 	Ref<StyleBoxFlat> style_popup_menu = make_flat_stylebox(dark_color_1, 8, 8, 8, 8);
-	style_popup_menu->set_border_size(border_width);
+	style_popup_menu->set_border_size(MAX(EDSCALE, border_width));
 	style_popup_menu->set_light_color(light_color_1);
 	style_popup_menu->set_dark_color(light_color_1);
 	style_popup_menu->set_border_blend(false);
 	theme->set_stylebox("panel", "PopupMenu", style_popup_menu);
-	theme->set_stylebox("separator", "PopupMenu", make_line_stylebox(separator_color, border_width, 8 - border_width));
+	theme->set_stylebox("separator", "PopupMenu", make_line_stylebox(separator_color, MAX(EDSCALE, border_width), 8 - MAX(EDSCALE, border_width)));
 
 	// Tree & ItemList background
 	Ref<StyleBoxFlat> style_tree_bg = make_flat_stylebox(dark_color_1, 2, 4, 2, 4);
@@ -424,7 +424,7 @@ Ref<Theme> create_editor_theme() {
 
 	// WindowDialog
 	Ref<StyleBoxFlat> style_window = make_flat_stylebox(dark_color_2, 4, 4, 4, 4);
-	style_window->set_border_size(border_width);
+	style_window->set_border_size(MAX(EDSCALE, border_width));
 	style_window->set_border_blend(false);
 	style_window->set_light_color(title_color_hl);
 	style_window->set_dark_color(title_color_hl);
@@ -470,6 +470,9 @@ Ref<Theme> create_editor_theme() {
 	theme->set_stylebox("slider", "VSlider", make_stylebox(theme->get_icon("GuiVsliderBg", "EditorIcons"), 4, 4, 4, 4));
 	theme->set_icon("grabber", "VSlider", theme->get_icon("GuiSliderGrabber", "EditorIcons"));
 	theme->set_icon("grabber_highlight", "VSlider", theme->get_icon("GuiSliderGrabberHl", "EditorIcons"));
+
+	//RichTextLabel
+	theme->set_stylebox("focus", "RichTextLabel", make_empty_stylebox());
 
 	// Panel
 	theme->set_stylebox("panel", "Panel", style_panel);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -143,7 +143,7 @@ Ref<Theme> create_editor_theme() {
 	Color light_color_1 = base_color.linear_interpolate(Color(1, 1, 1, 1), contrast);
 	Color light_color_2 = base_color.linear_interpolate(Color(1, 1, 1, 1), contrast * 1.5);
 
-	const int border_width = MIN(border_size, 3) * EDSCALE;
+	const int border_width = CLAMP(border_size, 0, 3) * EDSCALE;
 
 	Color title_color_hl = base_color;
 	if (highlight_tabs)

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -211,9 +211,11 @@ void ScriptEditorQuickOpen::_confirmed() {
 
 void ScriptEditorQuickOpen::_notification(int p_what) {
 
-	if (p_what == NOTIFICATION_ENTER_TREE) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
 
-		connect("confirmed", this, "_confirmed");
+			connect("confirmed", this, "_confirmed");
+		} break;
 	}
 }
 
@@ -1064,58 +1066,73 @@ void ScriptEditor::_tab_changed(int p_which) {
 
 void ScriptEditor::_notification(int p_what) {
 
-	if (p_what == NOTIFICATION_ENTER_TREE) {
+	switch (p_what) {
 
-		editor->connect("play_pressed", this, "_editor_play");
-		editor->connect("pause_pressed", this, "_editor_pause");
-		editor->connect("stop_pressed", this, "_editor_stop");
-		editor->connect("script_add_function_request", this, "_add_callback");
-		editor->connect("resource_saved", this, "_res_saved_callback");
-		script_list->connect("item_selected", this, "_script_selected");
-		members_overview->connect("item_selected", this, "_members_overview_selected");
-		script_split->connect("dragged", this, "_script_split_dragged");
-		autosave_timer->connect("timeout", this, "_autosave_scripts");
-		{
-			float autosave_time = EditorSettings::get_singleton()->get("text_editor/files/autosave_interval_secs");
-			if (autosave_time > 0) {
-				autosave_timer->set_wait_time(autosave_time);
-				autosave_timer->start();
-			} else {
-				autosave_timer->stop();
+		case NOTIFICATION_ENTER_TREE: {
+
+			editor->connect("play_pressed", this, "_editor_play");
+			editor->connect("pause_pressed", this, "_editor_pause");
+			editor->connect("stop_pressed", this, "_editor_stop");
+			editor->connect("script_add_function_request", this, "_add_callback");
+			editor->connect("resource_saved", this, "_res_saved_callback");
+			script_list->connect("item_selected", this, "_script_selected");
+			members_overview->connect("item_selected", this, "_members_overview_selected");
+			script_split->connect("dragged", this, "_script_split_dragged");
+			autosave_timer->connect("timeout", this, "_autosave_scripts");
+			{
+				float autosave_time = EditorSettings::get_singleton()->get("text_editor/files/autosave_interval_secs");
+				if (autosave_time > 0) {
+					autosave_timer->set_wait_time(autosave_time);
+					autosave_timer->start();
+				} else {
+					autosave_timer->stop();
+				}
 			}
-		}
 
-		EditorSettings::get_singleton()->connect("settings_changed", this, "_editor_settings_changed");
-		help_search->set_icon(get_icon("HelpSearch", "EditorIcons"));
-		site_search->set_icon(get_icon("Instance", "EditorIcons"));
-		class_search->set_icon(get_icon("ClassList", "EditorIcons"));
+			EditorSettings::get_singleton()->connect("settings_changed", this, "_editor_settings_changed");
+			help_search->set_icon(get_icon("HelpSearch", "EditorIcons"));
+			site_search->set_icon(get_icon("Instance", "EditorIcons"));
+			class_search->set_icon(get_icon("ClassList", "EditorIcons"));
 
-		script_forward->set_icon(get_icon("Forward", "EditorIcons"));
-		script_back->set_icon(get_icon("Back", "EditorIcons"));
-	}
+			script_forward->set_icon(get_icon("Forward", "EditorIcons"));
+			script_back->set_icon(get_icon("Back", "EditorIcons"));
+		} break;
 
-	if (p_what == NOTIFICATION_READY) {
+		case NOTIFICATION_READY: {
 
-		get_tree()->connect("tree_changed", this, "_tree_changed");
-		editor->connect("request_help", this, "_request_help");
-		editor->connect("request_help_search", this, "_help_search");
-		editor->connect("request_help_index", this, "_help_index");
-	}
+			get_tree()->connect("tree_changed", this, "_tree_changed");
+			editor->connect("request_help", this, "_request_help");
+			editor->connect("request_help_search", this, "_help_search");
+			editor->connect("request_help_index", this, "_help_index");
+		} break;
 
-	if (p_what == NOTIFICATION_EXIT_TREE) {
+		case NOTIFICATION_EXIT_TREE: {
 
-		editor->disconnect("play_pressed", this, "_editor_play");
-		editor->disconnect("pause_pressed", this, "_editor_pause");
-		editor->disconnect("stop_pressed", this, "_editor_stop");
-	}
+			editor->disconnect("play_pressed", this, "_editor_play");
+			editor->disconnect("pause_pressed", this, "_editor_pause");
+			editor->disconnect("stop_pressed", this, "_editor_stop");
+		} break;
 
-	if (p_what == MainLoop::NOTIFICATION_WM_FOCUS_IN) {
+		case MainLoop::NOTIFICATION_WM_FOCUS_IN: {
 
-		_test_script_times_on_disk();
-		_update_modified_scripts_for_external_editor();
-	}
+			_test_script_times_on_disk();
+			_update_modified_scripts_for_external_editor();
+		} break;
 
-	if (p_what == NOTIFICATION_PROCESS) {
+		case NOTIFICATION_PROCESS: {
+		} break;
+
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+
+			tab_container->add_style_override("panel", editor->get_gui_base()->get_stylebox("ScriptPanel", "EditorStyles"));
+
+			Ref<StyleBox> sb = editor->get_gui_base()->get_stylebox("panel", "TabContainer")->duplicate();
+			sb->set_default_margin(MARGIN_TOP, 0);
+			add_style_override("panel", sb);
+		} break;
+
+		default:
+			break;
 	}
 }
 


### PR DESCRIPTION



Two commits:
 - one fixes that the border settings options does not remove borders in places where they are always necessary (for example pop up) which made border 0 not usable.

![noborderpopup](https://user-images.githubusercontent.com/16718859/28625423-8284dc86-721c-11e7-9103-417fdffe7035.png)

 - adds a an empty style for editor help focus so that the editor does not use the defualt theme (old theme)

![nooldthemeborderhelp](https://user-images.githubusercontent.com/16718859/28625422-827bb7a0-721c-11e7-9c13-065e9cfc0db3.png)
 - the other one fixes updating on theme changes. for help background + script panel to prevent these effects:

![script panel ncolour update](https://user-images.githubusercontent.com/16718859/28625421-827ada92-721c-11e7-97d3-e88a245095f0.PNG)