### PR TITLE
Fix mutating project.godot

### DIFF
--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -138,7 +138,7 @@ public:
 
 	Error setup(const String &p_path, const String &p_main_pack);
 
-	Error save_custom(const String &p_path = "", const CustomMap &p_custom = CustomMap(), const Vector<String> &p_custom_features = Vector<String>());
+	Error save_custom(const String &p_path = "", const CustomMap &p_custom = CustomMap(), const Vector<String> &p_custom_features = Vector<String>(), bool p_merge_with_current = true);
 	Error save();
 	void set_custom_property_info(const String &p_prop, const PropertyInfo &p_info);
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -187,30 +187,17 @@ private:
 		} else {
 			if (mode == MODE_NEW) {
 
-				FileAccess *f = FileAccess::open(dir.plus_file("/project.godot"), FileAccess::WRITE);
-				if (!f) {
+				ProjectSettings::CustomMap initial_settings;
+				initial_settings["application/config/name"] = project_name->get_text();
+				initial_settings["application/config/icon"] = "res://icon.png";
+				initial_settings["rendering/environment/default_environment"] = "res://default_env.tres";
+
+				if (ProjectSettings::get_singleton()->save_custom(dir.plus_file("/project.godot"), initial_settings, Vector<String>(), false)) {
 					error->set_text(TTR("Couldn't create project.godot in project path."));
 				} else {
-
-					f->store_line("; Engine configuration file.");
-					f->store_line("; It's best edited using the editor UI and not directly,");
-					f->store_line("; since the parameters that go here are not all obvious.");
-					f->store_line("; ");
-					f->store_line("; Format: ");
-					f->store_line(";   [section] ; section goes between []");
-					f->store_line(";   param=value ; assign values to parameters");
-					f->store_line("\n");
-					f->store_line("[application]");
-					f->store_line("\n");
-					f->store_line("config/name=\"" + project_name->get_text() + "\"");
-					f->store_line("config/icon=\"res://icon.png\"");
-					f->store_line("[rendering]");
-					f->store_line("environment/default_environment=\"res://default_env.tres\"");
-					memdelete(f);
-
 					ResourceSaver::save(dir.plus_file("/icon.png"), get_icon("DefaultProjectIcon", "EditorIcons"));
 
-					f = FileAccess::open(dir.plus_file("/default_env.tres"), FileAccess::WRITE);
+					FileAccess *f = FileAccess::open(dir.plus_file("/default_env.tres"), FileAccess::WRITE);
 					if (!f) {
 						error->set_text(TTR("Couldn't create project.godot in project path."));
 					} else {


### PR DESCRIPTION
Namely:
- comment block lost on first save;
- `config_version` doubled as 3 and null on second save;
- format change on first save.

## Concerns

- Without the added `p_merge_with_current` parameter set to `false`, the initial settings would have properties for display width and height. that would go away on first save. I can't think of any bad side effect of this new flag, but can't be sure it hasn't either.
- This will have the top comment block added for project export as well. But that's not a problem provided it will eventually get converted to binary, is it?
- Also code is added to make the order of the properties be the same between the first and second saves. That wasn't happening with the hard-coded settings, but this one introduces that to ensure the same order on both code paths. May this break something?

## Before

- Initial content:

```
; Engine configuration file.
; It's best edited using the editor UI and not directly,
; since the parameters that go here are not all obvious.
; 
; Format: 
;   [section] ; section goes between []
;   param=value ; assign values to parameters


[application]


config/name="Awesome game"
config/icon="res://icon.png"
[rendering]
environment/default_environment="res://default_env.tres"
```

- After changing settings for the first time (__comment gone, format changes__):

```
config_version=3

[application]

config/name="Awesome game"
config/icon="res://icon.png"

[rendering]

environment/default_environment="res://default_env.tres"
```

- After reloading project and changing settings again (__spurious null-valued `config_version`__):

```
config_version=3

config_version=null

[application]

config/name="Awesome game"
config/icon="res://icon.png"

[rendering]

environment/default_environment="res://default_env.tres"
```

## After

Always the same:

```
; Engine configuration file.
; It's best edited using the editor UI and not directly,
; since the parameters that go here are not all obvious.
; 
; Format: 
;   [section] ; section goes between []
;   param=value ; assign values to parameters

config_version=3

[application]

config/name="Awesome game"
config/icon="res://icon.png"

[rendering]

environment/default_environment="res://default_env.tres"
```