### PR TITLE
Forward refcount changes to NativeScriptInstance

### DIFF
--- a/core/reference.cpp
+++ b/core/reference.cpp
@@ -74,7 +74,8 @@ bool Reference::unreference() {
 	bool die = refcount.unref();
 
 	if (get_script_instance()) {
-		die = die && get_script_instance()->refcount_decremented();
+		bool script_ret = get_script_instance()->refcount_decremented();
+		die = die && script_ret;
 	}
 
 	return die;

--- a/modules/nativescript/nativescript.cpp
+++ b/modules/nativescript/nativescript.cpp
@@ -650,6 +650,28 @@ void NativeScriptInstance::notification(int p_notification) {
 	call_multilevel("_notification", args, 1);
 }
 
+void NativeScriptInstance::refcount_incremented() {
+	Variant::CallError err;
+	call("_refcount_incremented", NULL, 0, err);
+	if (err.error != Variant::CallError::CALL_OK && err.error != Variant::CallError::CALL_ERROR_INVALID_METHOD) {
+		ERR_PRINT("Failed to invoke _refcount_incremented - should not happen");
+	}
+}
+
+bool NativeScriptInstance::refcount_decremented() {
+	Variant::CallError err;
+	Variant ret = call("_refcount_decremented", NULL, 0, err);
+	if (err.error != Variant::CallError::CALL_OK && err.error != Variant::CallError::CALL_ERROR_INVALID_METHOD) {
+		ERR_PRINT("Failed to invoke _refcount_decremented - should not happen");
+		return true; // assume we can destroy the object
+	}
+	if (err.error == Variant::CallError::CALL_ERROR_INVALID_METHOD) {
+		// the method does not exist, default is true
+		return true;
+	}
+	return ret;
+}
+
 Ref<Script> NativeScriptInstance::get_script() const {
 	return script;
 }

--- a/modules/nativescript/nativescript.h
+++ b/modules/nativescript/nativescript.h
@@ -181,6 +181,9 @@ public:
 	virtual void call_multilevel(const StringName &p_method, const Variant **p_args, int p_argcount);
 	virtual void call_multilevel_reversed(const StringName &p_method, const Variant **p_args, int p_argcount);
 
+	virtual void refcount_incremented();
+	virtual bool refcount_decremented();
+
 	~NativeScriptInstance();
 };
 


### PR DESCRIPTION
This also changes Reference::unreference() to always invoke
refcount_decremented. Previously it was not invoked until the count
reached zero due to short-circuit evalution of boolean expressions.