### PR TITLE
Fix power management on x11 platform and removes explicit NULL pointer dereference

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -497,6 +497,8 @@ void OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_au
 	joypad = memnew(JoypadLinux(input));
 #endif
 	_ensure_data_dir();
+
+	power_manager = memnew(PowerX11);
 }
 
 void OS_X11::xim_destroy_callback(::XIM im, ::XPointer client_data,

--- a/platform/x11/power_x11.cpp
+++ b/platform/x11/power_x11.cpp
@@ -171,25 +171,18 @@ void PowerX11::check_proc_acpi_battery(const char *node, bool *have_battery, boo
 				charge = true;
 			}
 		} else if (String(key) == "remaining capacity") {
-			char *endptr = NULL;
-			//const int cvt = (int) strtol(val, &endptr, 10);
 			String sval = val;
 			const int cvt = sval.to_int();
-			if (*endptr == ' ') {
-				remaining = cvt;
-			}
+			remaining = cvt;
 		}
 	}
 
 	ptr = &info[0];
 	while (make_proc_acpi_key_val(&ptr, &key, &val)) {
 		if (String(key) == "design capacity") {
-			char *endptr = NULL;
 			String sval = val;
 			const int cvt = sval.to_int();
-			if (*endptr == ' ') {
-				maximum = cvt;
-			}
+			maximum = cvt;
 		}
 	}
 


### PR DESCRIPTION
This PR fixes calls to power management on X11 which caused a crash of the running game.
Also removes explicit NULL pointer dereferences which I previously forgot because of the translation from SDL (C) to Godot. Thanks @Marqin for pointing out.