### PR TITLE
Support MSVC (2015) build tools

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -62,7 +62,7 @@ platform_arg = ARGUMENTS.get("platform", ARGUMENTS.get("p", False))
 if (os.name == "posix"):
     pass
 elif (os.name == "nt"):
-    if (os.getenv("VSINSTALLDIR") == None or platform_arg == "android"):
+    if (os.getenv("VCINSTALLDIR") == None or platform_arg == "android"):
         custom_tools = ['mingw']
 
 env_base = Environment(tools=custom_tools)
@@ -283,7 +283,15 @@ if selected_platform in platform_list:
     if (env["warnings"] == 'yes'):
         print("WARNING: warnings=yes is deprecated; assuming warnings=all")
 
-    if (os.name == "nt" and os.getenv("VSINSTALLDIR")): # MSVC, needs to stand out of course
+    if (os.name == "nt" and os.getenv("VCINSTALLDIR")): # MSVC, needs to stand out of course
+        # This is an ugly hack.  It's possible (and common in the case of having older versions of MSVC installed)
+        # to have MSVC installed but not Visual Studio itself.  If this happens the environment variable
+        # "VSINSTALLDIR" is never set as Visual Studio isn't installed.  However, near as I can figure out,
+        # internally scons uses the "VSINSTALLDIR" environment variable for something so it needs to be set.
+        # So we set it to the same directory as MSVC itself.  It's an ugly hack but it works without side effects.
+        if os.getenv("VSINSTALLDIR") is None:
+            os.environ["VSINSTALLDIR"] = os.getenv("VCINSTALLDIR")
+
         disable_nonessential_warnings = ['/wd4267', '/wd4244', '/wd4305', '/wd4800'] # Truncations, narrowing conversions...
         if (env["warnings"] == 'extra'):
             env.Append(CCFLAGS=['/Wall']) # Implies /W4

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -114,7 +114,7 @@ def can_build():
 
     if (os.name == "nt"):
         # building natively on windows!
-        if (os.getenv("VSINSTALLDIR")):
+        if (os.getenv("VCINSTALLDIR")):
             return True
         else:
             print("\nMSVC not detected, attempting Mingw.")
@@ -214,7 +214,7 @@ def configure(env):
     winver = "0x0600" # Windows Vista is the minimum target for windows builds
 
     env['is_mingw'] = False
-    if (os.name == "nt" and os.getenv("VSINSTALLDIR") != None):
+    if (os.name == "nt" and os.getenv("VCINSTALLDIR")):
         # build using visual studio
         env['ENV']['TMP'] = os.environ['TMP']
         env.Append(CPPPATH=['#platform/windows/include'])


### PR DESCRIPTION
The Godot 2.x branch is in an odd place in terms of MSVC and Visual Studio.  Godot 2.x doesn't currently support Visual Studio 2017 and Microsoft no longer offers Visual Studio 2015 for download unless you're a Visual Studio subscriber.

However, as usual, Microsoft does provide the compiler and other [build tools for VS2015](http://landinghub.visualstudio.com/visual-cpp-build-tools) for free, just without VS itself.  Godot's current build scripts however, for whatever reason, check for Visual Studio rather than the presence of the MSVC compiler tool chain.  This PR fixes that.  A similar fix is likely to be required for the master branch.

EDIT:  Apparently VS2015 is available as part of the free tier of the Visual Studio subscription.  That makes this PR less critical, but it's still worth merging for those that need to target earlier MSVC tool chains without having the associated release of VS installed as well.