### PR TITLE
NativeScript changes and OS symbol lookup optional error handling

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -184,9 +184,9 @@ public:
 
 	virtual void set_ime_position(const Point2 &p_pos) {}
 
-	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle) { return ERR_UNAVAILABLE; };
-	virtual Error close_dynamic_library(void *p_library_handle) { return ERR_UNAVAILABLE; };
-	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle) { return ERR_UNAVAILABLE; };
+	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle) { return ERR_UNAVAILABLE; }
+	virtual Error close_dynamic_library(void *p_library_handle) { return ERR_UNAVAILABLE; }
+	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle, bool p_optional = false) { return ERR_UNAVAILABLE; }
 
 	virtual void set_keep_screen_on(bool p_enabled);
 	virtual bool is_keep_screen_on() const;

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -453,7 +453,7 @@ Error OS_Unix::close_dynamic_library(void *p_library_handle) {
 	return OK;
 }
 
-Error OS_Unix::get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle) {
+Error OS_Unix::get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle, bool p_optional) {
 	const char *error;
 	dlerror(); // Clear existing errors
 
@@ -461,8 +461,12 @@ Error OS_Unix::get_dynamic_library_symbol_handle(void *p_library_handle, const S
 
 	error = dlerror();
 	if (error != NULL) {
-		ERR_EXPLAIN("Can't resolve symbol " + p_name + ". Error: " + error);
-		ERR_FAIL_V(ERR_CANT_RESOLVE);
+		if (!p_optional) {
+			ERR_EXPLAIN("Can't resolve symbol " + p_name + ". Error: " + error);
+			ERR_FAIL_V(ERR_CANT_RESOLVE);
+		} else {
+			return ERR_CANT_RESOLVE;
+		}
 	}
 	return OK;
 }

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -85,7 +85,7 @@ public:
 
 	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle);
 	virtual Error close_dynamic_library(void *p_library_handle);
-	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle);
+	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle, bool p_optional = false);
 
 	virtual Error set_cwd(const String &p_cwd);
 

--- a/modules/gdnative/register_types.cpp
+++ b/modules/gdnative/register_types.cpp
@@ -47,7 +47,8 @@ godot_variant cb_standard_varcall(void *handle, godot_string *p_procedure, godot
 	Error err = OS::get_singleton()->get_dynamic_library_symbol_handle(
 			handle,
 			*(String *)p_procedure,
-			library_proc);
+			library_proc,
+			true); // we roll our own message
 	if (err != OK) {
 		ERR_PRINT((String("GDNative procedure \"" + *(String *)p_procedure) + "\" does not exists and can't be called").utf8().get_data());
 		godot_variant ret;

--- a/modules/nativescript/nativescript.h
+++ b/modules/nativescript/nativescript.h
@@ -106,6 +106,9 @@ class NativeScript : public Script {
 
 	String class_name;
 
+#ifndef NO_THREADS
+	Mutex *owners_lock;
+#endif
 	Set<Object *> instance_owners;
 
 protected:

--- a/modules/nativescript/register_types.cpp
+++ b/modules/nativescript/register_types.cpp
@@ -50,7 +50,8 @@ void init_call_cb(void *p_handle, godot_string *p_proc_name, void *p_data, int p
 	Error err = OS::get_singleton()->get_dynamic_library_symbol_handle(
 			p_handle,
 			*(String *)p_proc_name,
-			library_proc);
+			library_proc,
+			true); // we print our own message
 	if (err != OK) {
 		ERR_PRINT((String("GDNative procedure \"" + *(String *)p_proc_name) + "\" does not exists and can't be called").utf8().get_data());
 		return;
@@ -75,7 +76,8 @@ void thread_call_cb(void *p_handle, godot_string *p_proc_name, void *p_data, int
 	Error err = OS::get_singleton()->get_dynamic_library_symbol_handle(
 			p_handle,
 			*(String *)p_proc_name,
-			library_proc);
+			library_proc,
+			true);
 	if (err != OK) {
 		// it's fine if thread callbacks are not present in the library.
 		return;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1569,12 +1569,16 @@ Error OS_Windows::close_dynamic_library(void *p_library_handle) {
 	return OK;
 }
 
-Error OS_Windows::get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle) {
+Error OS_Windows::get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle, bool p_optional) {
 	char *error;
 	p_symbol_handle = (void *)GetProcAddress((HMODULE)p_library_handle, p_name.utf8().get_data());
 	if (!p_symbol_handle) {
-		ERR_EXPLAIN("Can't resolve symbol " + p_name + ". Error: " + String::num(GetLastError()));
-		ERR_FAIL_V(ERR_CANT_RESOLVE);
+		if (!p_optional) {
+			ERR_EXPLAIN("Can't resolve symbol " + p_name + ". Error: " + String::num(GetLastError()));
+			ERR_FAIL_V(ERR_CANT_RESOLVE);
+		} else {
+			return ERR_CANT_RESOLVE;
+		}
 	}
 	return OK;
 }

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -227,7 +227,7 @@ public:
 
 	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle);
 	virtual Error close_dynamic_library(void *p_library_handle);
-	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle);
+	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle, bool p_optional = false);
 
 	virtual MainLoop *get_main_loop() const;
 


### PR DESCRIPTION
## [NativeScript] call _init on instance creation

This also adds basic locking for the set of owners
to avoid threading problems

## added an optional parameter to OS symbol lookup

When looking up a symbol from a library, previously an error was
shown when the symbol did not exist. That caused confusion when the
lookup was completely optional.
This adds a new parameter to that method so that those errors can
be handled manually if needed.