### PR TITLE
[NativeScript] fix mutex double lock

### DIFF
--- a/modules/nativescript/nativescript.cpp
+++ b/modules/nativescript/nativescript.cpp
@@ -792,7 +792,7 @@ NativeScriptInstance::~NativeScriptInstance() {
 		script->instance_owners.erase(owner);
 
 #ifndef NO_THREADS
-		script->owners_lock->lock();
+		script->owners_lock->unlock();
 #endif
 	}
 }


### PR DESCRIPTION
In 3c53b35 a bug got introduced where a mutex gets locked twice
instead of locked and then unlocked.
This path fixes that.