### PR TITLE
Fix passing Refs via ptrcall

### DIFF
--- a/core/reference.h
+++ b/core/reference.h
@@ -330,7 +330,7 @@ struct PtrToArg<Ref<T> > {
 
 	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
 
-		return Ref<T>(reinterpret_cast<const T *>(p_ptr));
+		return Ref<T>(const_cast<T *>(reinterpret_cast<const T *>(p_ptr)));
 	}
 
 	_FORCE_INLINE_ static void encode(Ref<T> p_val, const void *p_ptr) {
@@ -355,7 +355,7 @@ struct PtrToArg<RefPtr> {
 
 	_FORCE_INLINE_ static RefPtr convert(const void *p_ptr) {
 
-		return Ref<Reference>(reinterpret_cast<const Reference *>(p_ptr)).get_ref_ptr();
+		return Ref<Reference>(const_cast<Reference *>(reinterpret_cast<const Reference *>(p_ptr))).get_ref_ptr();
 	}
 
 	_FORCE_INLINE_ static void encode(RefPtr p_val, const void *p_ptr) {
@@ -370,7 +370,7 @@ struct PtrToArg<const RefPtr &> {
 
 	_FORCE_INLINE_ static RefPtr convert(const void *p_ptr) {
 
-		return Ref<Reference>(reinterpret_cast<const Reference *>(p_ptr)).get_ref_ptr();
+		return Ref<Reference>(const_cast<Reference *>(reinterpret_cast<const Reference *>(p_ptr))).get_ref_ptr();
 	}
 };
 


### PR DESCRIPTION
There was no constructor for Ref from const pointer, so compiler decided
to construct Variant from pointer and then construct Ref from Variant
which turned it into NULL, because the Variant had null ref field.