### PR TITLE
[2.1] Fix mutex initialisation in OS X Audio Driver

### DIFF
--- a/platform/osx/audio_driver_osx.h
+++ b/platform/osx/audio_driver_osx.h
@@ -70,6 +70,7 @@ public:
 	virtual void unlock();
 	virtual void finish();
 
+	bool try_lock();
 	Error reopen();
 
 	AudioDriverOSX();


### PR DESCRIPTION
Mutex was failing to create because the create_func was not being set when the AudioDriverOSX constructor was getting called, on `AudioDriverOSX::init` is working fine now.
I've also cleaned the code a bit and replaced the `int i` to a `int j` so that it doesn't gets confused with the previous `unsigned int i`.