### PR TITLE
Fix get_screen_* funcs returning old values after resolution changes on OS X

### DIFF
--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -101,9 +101,6 @@ public:
 	bool maximized;
 	bool zoomed;
 
-	Vector<Rect2> screens;
-	Vector<int> screen_dpi;
-
 	Size2 window_size;
 	Rect2 restore_rect;
 


### PR DESCRIPTION
Tested on OS X Yosemite 10.10.1.