### PR TITLE
Fixed AudioStreamPlaybackOGGVorbis::_mix_internal getting stuck in in…

### DIFF
--- a/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
@@ -39,7 +39,7 @@ void AudioStreamPlaybackOGGVorbis::_mix_internal(AudioFrame *p_buffer, int p_fra
 
 	int todo = p_frames;
 
-	while (todo) {
+	while (todo && active) {
 
 		int mixed = stb_vorbis_get_samples_float_interleaved(ogg_stream, 2, (float *)p_buffer, todo * 2);
 		todo -= mixed;


### PR DESCRIPTION
Fixed AudioStreamPlaybackOGGVorbis::_mix_internal getting stuck in in finite loop causing audio to freeze.

More info:
When no audio is playing stb_vorbis_get_samples_float_interleaved returns 0, which means todo is never reduced and the while(todo) loop never exists.
