### PR TITLE
scons: default to cpu_count concurrent jobs

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -13,6 +13,25 @@ import methods
 
 methods.update_version()
 
+auto_jobs = True
+for opt in sys.argv:
+    if opt.startswith('-j') or opt.startswith('--jobs'):
+        auto_jobs = False
+        break
+
+if auto_jobs:
+    sf = os.environ.get('SCONSFLAGS')
+    if sf and ('-j' in sf or '--jobs' in sf):
+        auto_jobs = False
+
+if auto_jobs:
+    j = methods.cpu_count()
+    if j:
+        SetOption('num_jobs', j)
+        print("Running with %d concurrent jobs (-j%d)." % (j, j))
+
+
+
 # scan possible build platforms
 
 platform_list = []  # list of platforms

--- a/methods.py
+++ b/methods.py
@@ -1689,3 +1689,11 @@ def precious_program(env, program, sources, **args):
     program = env.ProgramOriginal(program, sources, **args)
     env.Precious(program)
     return program
+
+def cpu_count():
+    try:
+        import multiprocessing
+        return multiprocessing.cpu_count()
+    except:
+        return 0
+


### PR DESCRIPTION
The scons -j1 ... -jx option overrides this default setting.