### PR TITLE
Tweak command-line arguments to make them more UNIX-like

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2803,9 +2803,9 @@ void EditorNode::_discard_changes(const String &p_str) {
 			String exec = OS::get_singleton()->get_executable_path();
 
 			List<String> args;
-			args.push_back("-path");
+			args.push_back("--path");
 			args.push_back(exec.get_base_dir());
-			args.push_back("-pm");
+			args.push_back("--project-manager");
 
 			OS::ProcessID pid = 0;
 			Error err = OS::get_singleton()->execute(exec, args, false, &pid);

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -45,24 +45,24 @@ Error EditorRun::run(const String &p_scene, const String p_custom_args, const Li
 	int remote_port = (int)EditorSettings::get_singleton()->get("network/debug/remote_port");
 
 	if (resource_path != "") {
-		args.push_back("-path");
+		args.push_back("--path");
 		args.push_back(resource_path.replace(" ", "%20"));
 	}
 
 	if (true) {
-		args.push_back("-rdebug");
+		args.push_back("--remote-debug");
 		args.push_back(remote_host + ":" + String::num(remote_port));
 	}
 
-	args.push_back("-epid");
+	args.push_back("--editor-pid");
 	args.push_back(String::num(OS::get_singleton()->get_process_ID()));
 
 	if (debug_collisions) {
-		args.push_back("-debugcol");
+		args.push_back("--debug-collision");
 	}
 
 	if (debug_navigation) {
-		args.push_back("-debugnav");
+		args.push_back("--debug-navigation");
 	}
 
 	int screen = EditorSettings::get_singleton()->get("run/window_placement/screen");
@@ -101,33 +101,33 @@ Error EditorRun::run(const String &p_scene, const String p_custom_args, const Li
 		case 1: { // centered
 			Vector2 pos = screen_rect.position + ((screen_rect.size - desired_size) / 2).floor();
 			args.push_back("-p");
-			args.push_back(itos(pos.x) + "x" + itos(pos.y));
+			args.push_back(itos(pos.x) + "," + itos(pos.y));
 		} break;
 		case 2: { // custom pos
 			Vector2 pos = EditorSettings::get_singleton()->get("run/window_placement/rect_custom_position");
 			pos += screen_rect.position;
 			args.push_back("-p");
-			args.push_back(itos(pos.x) + "x" + itos(pos.y));
+			args.push_back(itos(pos.x) + "," + itos(pos.y));
 		} break;
 		case 3: { // force maximized
 			Vector2 pos = screen_rect.position;
 			args.push_back("-p");
-			args.push_back(itos(pos.x) + "x" + itos(pos.y));
-			args.push_back("-mx");
+			args.push_back(itos(pos.x) + "," + itos(pos.y));
+			args.push_back("-m");
 
 		} break;
 		case 4: { // force fullscreen
 
 			Vector2 pos = screen_rect.position;
 			args.push_back("-p");
-			args.push_back(itos(pos.x) + "x" + itos(pos.y));
+			args.push_back(itos(pos.x) + "," + itos(pos.y));
 			args.push_back("-f");
 		} break;
 	}
 
 	if (p_breakpoints.size()) {
 
-		args.push_back("-bp");
+		args.push_back("-b");
 		String bpoints;
 		for (const List<String>::Element *E = p_breakpoints.front(); E; E = E->next()) {
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -935,10 +935,10 @@ void ProjectManager::_open_project_confirm() {
 
 		List<String> args;
 
-		args.push_back("-path");
+		args.push_back("--path");
 		args.push_back(path);
 
-		args.push_back("-editor");
+		args.push_back("--editor");
 
 		String exec = OS::get_singleton()->get_executable_path();
 
@@ -977,7 +977,7 @@ void ProjectManager::_run_project_confirm() {
 
 		List<String> args;
 
-		args.push_back("-path");
+		args.push_back("--path");
 		args.push_back(path);
 
 		String exec = OS::get_singleton()->get_executable_path();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -127,62 +127,62 @@ static String unescape_cmdline(const String &p_str) {
 void Main::print_help(const char *p_binary) {
 
 	OS::get_singleton()->print(VERSION_FULL_NAME " (c) 2008-2017 Juan Linietsky, Ariel Manzur.\n");
-	OS::get_singleton()->print("Usage: %s [options] [scene]\n", p_binary);
+	OS::get_singleton()->print("Usage: %s [options] [path to scene or 'project.godot' file]\n", p_binary);
 	OS::get_singleton()->print("Options:\n");
-	OS::get_singleton()->print("\t-path [dir] : Path to a game, containing project.godot\n");
+	OS::get_singleton()->print("  -h, --help                       Display this help message.\n");
+	OS::get_singleton()->print("  --path <directory>               Path to the project (<directory> must contain a 'project.godot' file).\n");
 #ifdef TOOLS_ENABLED
-	OS::get_singleton()->print("\t-e,-editor : Bring up the editor instead of running the scene.\n");
+	OS::get_singleton()->print("  -e, --editor                     Bring up the editor instead of running the scene.\n");
 #endif
-	OS::get_singleton()->print("\t-test [test] : Run a test.\n");
-	OS::get_singleton()->print("\t\t(");
+	OS::get_singleton()->print("  --test <test>                    Run a test (");
 	const char **test_names = tests_get_names();
 	const char *coma = "";
 	while (*test_names) {
 
-		OS::get_singleton()->print("%s%s", coma, *test_names);
+		OS::get_singleton()->print("%s'%s'", coma, *test_names);
 		test_names++;
 		coma = ", ";
 	}
-	OS::get_singleton()->print(")\n");
+	OS::get_singleton()->print(").\n");
 
-	OS::get_singleton()->print("\t-r WIDTHxHEIGHT\t : Request Window Resolution\n");
-	OS::get_singleton()->print("\t-p XxY\t : Request Window Position\n");
-	OS::get_singleton()->print("\t-f\t\t : Request Fullscreen\n");
-	OS::get_singleton()->print("\t-mx\t\t Request Maximized\n");
-	OS::get_singleton()->print("\t-w\t\t Request Windowed\n");
-	OS::get_singleton()->print("\t-vd DRIVER\t : Video Driver (");
+	OS::get_singleton()->print("  -r, --resolution <W>x<H>         Request window resolution.\n");
+	OS::get_singleton()->print("  -p, --position <X>,<Y>           Request window position.\n");
+	OS::get_singleton()->print("  -f, --fullscreen                 Request fullscreen mode.\n");
+	OS::get_singleton()->print("  -m, --maximized                  Request a maximized window.\n");
+	OS::get_singleton()->print("  -w, --windowed                   Request windowed mode.\n");
+	OS::get_singleton()->print("  --video-driver <driver>          Video driver (");
 	for (int i = 0; i < OS::get_singleton()->get_video_driver_count(); i++) {
 
 		if (i != 0)
 			OS::get_singleton()->print(", ");
-		OS::get_singleton()->print("%s", OS::get_singleton()->get_video_driver_name(i));
+		OS::get_singleton()->print("'%s'", OS::get_singleton()->get_video_driver_name(i));
 	}
-	OS::get_singleton()->print(")\n");
-	OS::get_singleton()->print("\t-ldpi\t : Force low-dpi mode (OSX Only)\n");
+	OS::get_singleton()->print(").\n");
+	OS::get_singleton()->print("  --low-dpi                        Force low-DPI mode (macOS only).\n");
 
-	OS::get_singleton()->print("\t-ad DRIVER\t : Audio Driver (");
+	OS::get_singleton()->print("  --audio-driver <driver>          Audio driver (");
 	for (int i = 0; i < OS::get_singleton()->get_audio_driver_count(); i++) {
 
 		if (i != 0)
 			OS::get_singleton()->print(", ");
-		OS::get_singleton()->print("%s", OS::get_singleton()->get_audio_driver_name(i));
+		OS::get_singleton()->print("'%s'", OS::get_singleton()->get_audio_driver_name(i));
 	}
-	OS::get_singleton()->print(")\n");
-	OS::get_singleton()->print("\t-rthread <mode>\t : Render Thread Mode ('unsafe', 'safe', 'separate').\n");
-	OS::get_singleton()->print("\t-s,-script [script] : Run a script.\n");
-	OS::get_singleton()->print("\t-d,-debug : Debug (local stdout debugger).\n");
-	OS::get_singleton()->print("\t-rdebug ADDRESS : Remote debug (<ip>:<port> host address).\n");
-	OS::get_singleton()->print("\t-fdelay [msec]: Simulate high CPU load (delay each frame by [msec]).\n");
-	OS::get_singleton()->print("\t-timescale [msec]: Simulate high CPU load (delay each frame by [msec]).\n");
-	OS::get_singleton()->print("\t-bp : breakpoint list as source::line comma separated pairs, no spaces (%%20,%%2C,etc instead).\n");
-	OS::get_singleton()->print("\t-v : Verbose stdout mode\n");
-	OS::get_singleton()->print("\t-lang [locale]: Use a specific locale\n");
-	OS::get_singleton()->print("\t-rfs <host/ip>[:<port>] : Remote FileSystem.\n");
-	OS::get_singleton()->print("\t-rfs_pass <password> : Password for Remote FileSystem.\n");
+	OS::get_singleton()->print(").\n");
+	OS::get_singleton()->print("  --render-thread <mode>           Render thread mode ('unsafe', 'safe', 'separate').\n");
+	OS::get_singleton()->print("  -s, --script <script>            Run a script.\n");
+	OS::get_singleton()->print("  -d, --debug                      Debug (local stdout debugger).\n");
+	OS::get_singleton()->print("  -r, --remote-debug <address>     Remote debug (<ip>:<port> host address).\n");
+	OS::get_singleton()->print("  --frame-delay <ms>               Simulate high CPU load (delay each frame by <ms> milliseconds).\n");
+	OS::get_singleton()->print("  --time-scale <scale>             Force time scale (higher values are faster, 1.0 is normal speed).\n");
+	OS::get_singleton()->print("  -b, --breakpoints                Breakpoint list as source::line comma-separated pairs, no spaces (use %%20, %%2C, ... instead).\n");
+	OS::get_singleton()->print("  -v, --verbose                    Use verbose stdout mode.\n");
+	OS::get_singleton()->print("  -l, --language <locale>          Use a specific locale (<locale> being a two-letter code).\n");
+	OS::get_singleton()->print("  --remote-fs <host/IP>[:<port>]   Remote filesystem.\n");
+	OS::get_singleton()->print("  --remote-fs-password <password>  Password for remote filesystem.\n");
 #ifdef TOOLS_ENABLED
-	OS::get_singleton()->print("\t-doctool FILE: Dump the whole engine api to FILE in XML format. If FILE exists, it will be merged.\n");
-	OS::get_singleton()->print("\t-nodocbase: Disallow dump the base types (used with -doctool).\n");
-	OS::get_singleton()->print("\t-export [target] Export the project using given export target.\n");
+	OS::get_singleton()->print("  --doctool <file>                 Dump the whole engine API to <file> in XML format. If <file> exists, it will be merged.\n");
+	OS::get_singleton()->print("  --no-docbase                     Disallow dumping the base types (used with --doctool).\n");
+	OS::get_singleton()->print("  --export <target>                Export the project using the given export target.\n");
 #endif
 }
 
@@ -281,14 +281,14 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 		List<String>::Element *N = I->next();
 
-		if (I->get() == "-noop") {
+		if (I->get() == "--noop") {
 
 			// no op
-		} else if (I->get() == "-h" || I->get() == "--help" || I->get() == "/?") { // resolution
+		} else if (I->get() == "-h" || I->get() == "--help" || I->get() == "/?") { // display help
 
 			goto error;
 
-		} else if (I->get() == "-r") { // resolution
+		} else if (I->get() == "-r" || I->get() == "--resolution") { // force resolution
 
 			if (I->next()) {
 
@@ -296,7 +296,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 				if (vm.find("x") == -1) { // invalid parameter format
 
-					OS::get_singleton()->print("Invalid -r argument: %s\n", vm.utf8().get_data());
+					OS::get_singleton()->print("Invalid resolution argument: %s\n", vm.utf8().get_data());
 					goto error;
 				}
 
@@ -305,7 +305,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 				if (w == 0 || h == 0) {
 
-					OS::get_singleton()->print("Invalid -r resolution, x and y must be >0\n");
+					OS::get_singleton()->print("Invalid resolution, width and height must be above 0\n");
 					goto error;
 				}
 
@@ -315,66 +315,66 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 				N = I->next()->next();
 			} else {
-				OS::get_singleton()->print("Invalid -p argument, needs resolution\n");
+				OS::get_singleton()->print("Invalid resolution argument, needs resolution\n");
 				goto error;
 			}
-		} else if (I->get() == "-p") { // position
+		} else if (I->get() == "-p" || I->get() == "--position") { // position
 
 			if (I->next()) {
 
 				String vm = I->next()->get();
 
-				if (vm.find("x") == -1) { // invalid parameter format
+				if (vm.find(",") == -1) { // invalid parameter format
 
-					OS::get_singleton()->print("Invalid -p argument: %s\n", vm.utf8().get_data());
+					OS::get_singleton()->print("Invalid position argument: %s\n", vm.utf8().get_data());
 					goto error;
 				}
 
-				int x = vm.get_slice("x", 0).to_int();
-				int y = vm.get_slice("x", 1).to_int();
+				int x = vm.get_slice(",", 0).to_int();
+				int y = vm.get_slice(",", 1).to_int();
 
 				init_custom_pos = Point2(x, y);
 				init_use_custom_pos = true;
 
 				N = I->next()->next();
 			} else {
-				OS::get_singleton()->print("Invalid -r argument, needs position\n");
+				OS::get_singleton()->print("Invalid position argument, needs position\n");
 				goto error;
 			}
 
-		} else if (I->get() == "-mx") { // video driver
+		} else if (I->get() == "-m" || I->get() == "--maximized") { // force maximized window
 
 			init_maximized = true;
-		} else if (I->get() == "-w") { // video driver
+		} else if (I->get() == "-w" || I->get() == "--windowed") { // force windowed window
 
 			init_windowed = true;
-		} else if (I->get() == "-profile") { // video driver
+		} else if (I->get() == "--profile") { // enable profiler
 
 			use_debug_profiler = true;
-		} else if (I->get() == "-vd") { // video driver
+		} else if (I->get() == "--video-driver") { // force video driver
 
 			if (I->next()) {
 
 				video_driver = I->next()->get();
 				N = I->next()->next();
 			} else {
-				OS::get_singleton()->print("Invalid -cd argument, needs driver name\n");
+				OS::get_singleton()->print("Invalid --video-driver argument, needs driver name\n");
 				goto error;
 			}
-		} else if (I->get() == "-lang") { // language
+		} else if (I->get() == "-l" || I->get() == "--language") { // language
 
 			if (I->next()) {
 
 				locale = I->next()->get();
 				N = I->next()->next();
 			} else {
-				OS::get_singleton()->print("Invalid -lang argument, needs language code\n");
+				OS::get_singleton()->print("Invalid language argument, needs language code\n");
 				goto error;
 			}
-		} else if (I->get() == "-ldpi") { // language
+		} else if (I->get() == "--low-dpi") { // force low DPI
 
 			force_lowdpi = true;
-		} else if (I->get() == "-rfs") { // language
+		} else if (I->get() == "--remote-fs") { // remote filesystem
 
 			if (I->next()) {
 
@@ -383,7 +383,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			} else {
 				goto error;
 			}
-		} else if (I->get() == "-rfs_pass") { // language
+		} else if (I->get() == "--remote-fs-password") { // remote filesystem password
 
 			if (I->next()) {
 
@@ -392,7 +392,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			} else {
 				goto error;
 			}
-		} else if (I->get() == "-rthread") { // language
+		} else if (I->get() == "--render-thread") { // rendering thread
 
 			if (I->next()) {
 
@@ -408,7 +408,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			}
 
-		} else if (I->get() == "-ad") { // video driver
+		} else if (I->get() == "--audio-driver") { // audio driver
 
 			if (I->next()) {
 
@@ -418,22 +418,22 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			}
 
-		} else if (I->get() == "-f") { // fullscreen
+		} else if (I->get() == "-f" || I->get() == "--fullscreen") { // force fullscreen
 
 			//video_mode.fullscreen=false;
 			init_fullscreen = true;
-		} else if (I->get() == "-e" || I->get() == "-editor") { // fonud editor
+		} else if (I->get() == "-e" || I->get() == "--editor") { // starts editor
 
 			editor = true;
-		} else if (I->get() == "-nowindow") { // fullscreen
+		} else if (I->get() == "--no-window") { // disable window creation
 
 			OS::get_singleton()->set_no_window_mode(true);
-		} else if (I->get() == "-quiet") { // fullscreen
+		} else if (I->get() == "--quiet") { // quieter output
 
 			quiet_stdout = true;
-		} else if (I->get() == "-v") { // fullscreen
+		} else if (I->get() == "-v" || I->get() == "--verbose") { // verbose output
 			OS::get_singleton()->_verbose_stdout = true;
-		} else if (I->get() == "-path") { // resolution
+		} else if (I->get() == "--path") { // set path of project to start or edit
 
 			if (I->next()) {
 
@@ -464,7 +464,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #ifdef TOOLS_ENABLED
 			editor = true;
 #endif
-		} else if (I->get() == "-bp") { // /breakpoints
+		} else if (I->get() == "-b" || I->get() == "--breakpoints") { // add breakpoints
 
 			if (I->next()) {
 
@@ -475,7 +475,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			}
 
-		} else if (I->get() == "-fdelay") { // resolution
+		} else if (I->get() == "--frame-delay") { // force frame delay
 
 			if (I->next()) {
 
@@ -485,7 +485,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			}
 
-		} else if (I->get() == "-timescale") { // resolution
+		} else if (I->get() == "--time-scale") { // force time scale
 
 			if (I->next()) {
 
@@ -495,7 +495,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			}
 
-		} else if (I->get() == "-pack") {
+		} else if (I->get() == "--pack") {
 
 			if (I->next()) {
 
@@ -506,7 +506,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			};
 
-		} else if (I->get() == "-main_pack") {
+		} else if (I->get() == "--main-pack") {
 
 			if (I->next()) {
 
@@ -517,15 +517,15 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			};
 
-		} else if (I->get() == "-debug" || I->get() == "-d") {
+		} else if (I->get() == "--debug" || I->get() == "-d") {
 			debug_mode = "local";
 #ifdef DEBUG_ENABLED
-		} else if (I->get() == "-debugcol" || I->get() == "-dc") {
+		} else if (I->get() == "--debug-collision") {
 			debug_collisions = true;
-		} else if (I->get() == "-debugnav" || I->get() == "-dn") {
+		} else if (I->get() == "--debug-navigation") {
 			debug_navigation = true;
 #endif
-		} else if (I->get() == "-editor_scene") {
+		} else if (I->get() == "--editor-scene") {
 
 			if (I->next()) {
 
@@ -534,7 +534,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			}
 
-		} else if (I->get() == "-rdebug") {
+		} else if (I->get() == "-r" || I->get() == "--remote-debug") {
 			if (I->next()) {
 
 				debug_mode = "remote";
@@ -547,7 +547,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			} else {
 				goto error;
 			}
-		} else if (I->get() == "-epid") {
+		} else if (I->get() == "--editor-pid") {
 			if (I->next()) {
 
 				int editor_pid = I->next()->get().to_int();
@@ -660,7 +660,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	if (editor) {
-		main_args.push_back("-editor");
+		main_args.push_back("--editor");
 		init_maximized = true;
 		use_custom_res = false;
 	}
@@ -1057,13 +1057,13 @@ bool Main::start() {
 	List<String> args = OS::get_singleton()->get_cmdline_args();
 	for (int i = 0; i < args.size(); i++) {
 		//parameters that do not have an argument to the right
-		if (args[i] == "-nodocbase") {
+		if (args[i] == "--no-docbase") {
 			doc_base = false;
-		} else if (args[i] == "-noquit") {
+		} else if (args[i] == "--no-quit") {
 			noquit = true;
-		} else if (args[i] == "-editor" || args[i] == "-e") {
+		} else if (args[i] == "--editor" || args[i] == "-e") {
 			editor = true;
-		} else if (args[i] == "-pm" || args[i] == "-project_manager") {
+		} else if (args[i] == "-P" || args[i] == "--project-manager") {
 			project_manager_request = true;
 		} else if (args[i].length() && args[i][0] != '-' && game_path == "") {
 			game_path = args[i];
@@ -1071,27 +1071,27 @@ bool Main::start() {
 		//parameters that have an argument to the right
 		else if (i < (args.size() - 1)) {
 			bool parsed_pair = true;
-			if (args[i] == "-doctool") {
+			if (args[i] == "--doctool") {
 				doc_tool = args[i + 1];
 				for (int j = i + 2; j < args.size(); j++)
 					removal_docs.push_back(args[j]);
-			} else if (args[i] == "-script" || args[i] == "-s") {
+			} else if (args[i] == "--script" || args[i] == "-s") {
 				script = args[i + 1];
-			} else if (args[i] == "-level" || args[i] == "-l") {
+			} else if (args[i] == "--level" || args[i] == "-l") {
 				Engine::get_singleton()->_custom_level = args[i + 1];
-			} else if (args[i] == "-test") {
+			} else if (args[i] == "--test") {
 				test = args[i + 1];
-			} else if (args[i] == "-export") {
+			} else if (args[i] == "--export") {
 				editor = true; //needs editor
 				_export_platform = args[i + 1];
-			} else if (args[i] == "-export_debug") {
+			} else if (args[i] == "--export-debug") {
 				editor = true; //needs editor
 				_export_platform = args[i + 1];
 				export_debug = true;
-			} else if (args[i] == "-import") {
+			} else if (args[i] == "--import") {
 				editor = true; //needs editor
 				_import = args[i + 1];
-			} else if (args[i] == "-import_script") {
+			} else if (args[i] == "--import-script") {
 				editor = true; //needs editor
 				_import_script = args[i + 1];
 			} else {
@@ -1139,7 +1139,7 @@ bool Main::start() {
 	if (_export_platform != "") {
 		if (game_path == "") {
 			String err = "Command line param ";
-			err += export_debug ? "-export_debug" : "-export";
+			err += export_debug ? "--export-debug" : "--export";
 			err += " passed but no destination path given.\n";
 			err += "Please specify the binary's file path to export to. Aborting export.";
 			ERR_PRINT(err.utf8().get_data());


### PR DESCRIPTION
Also improves the command-line help text readability.

**Note: this pull request may break some things (such as automation scripts), since it does not leave aliases for compatibility.**

The help text now looks like this:
```
Godot Engine v3.0.alpha.custom_build (c) 2008-2017 Juan Linietsky, Ariel Manzur.
Usage: godot.windows.opt.tools.64.exe [options] [path to scene or 'project.godot' file]
Options:
  -h, --help                       Display this help message.
  --path <directory>               Play the project (<directory> must contain a 'project.godot' file).
  -e, --editor                     Bring up the editor instead of running the scene.
  --test <test>                    Run a test ('string', 'containers', 'math', 'render', 'multimesh', 'gui', 'io', 'shaderlang', 'physics').
  -r, --resolution <W>x<H>         Request window resolution.
  -p, --position <X>,<Y>           Request window position.
  -f, --fullscreen                 Request fullscreen mode.
  -m, --maximized                  Request a maximized window.
  -w, --windowed                   Request windowed mode.
  --video-driver <driver>          Video driver ('GLES2').
  --low-dpi                        Force low-DPI mode (macOS only).
  --audio-driver <driver>          Audio driver ('RtAudio-DirectSound').
  --render-thread <mode>           Render thread mode ('unsafe', 'safe', 'separate').
  -s, --script <script>            Run a script.
  -d, --debug                      Debug (local stdout debugger).
  -r, --remote-debug <address>     Remote debug (<ip>:<port> host address).
  --frame-delay <ms>               Simulate high CPU load (delay each frame by <ms> milliseconds).
  --time-scale <scale>             Force time scale (higher values are faster, 1.0 is normal speed).
  -b, --breakpoints                Breakpoint list as source::line comma-separated pairs, no spaces (use %20, %2C, ... instead).
  -v, --verbose                    Use verbose stdout mode.
  -l, --language <locale>          Use a specific locale (<locale> being a two-letter code).
  --remote-fs <host/IP>[:<port>]   Remote filesystem.
  --remote-fs-password <password>  Password for remote filesystem.
  --doctool <file>                 Dump the whole engine API to <file> in XML format. If <file> exists, it will be merged.
  --no-docbase                     Disallow dumping the base types (used with --doctool).
  --export <target>                Export the project using the given export target.
```