### PR TITLE
Fix AudioServer::finish not getting called while quitting

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1704,6 +1704,7 @@ void Main::cleanup() {
 #endif
 
 	if (audio_server) {
+		audio_server->finish();
 		memdelete(audio_server);
 	}
 

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -66,7 +66,8 @@ void AudioDriver::audio_server_process(int p_frames, int32_t *p_buffer, bool p_u
 void AudioDriver::update_mix_time(int p_frames) {
 
 	_mix_amount += p_frames;
-	_last_mix_time = OS::get_singleton()->get_ticks_usec();
+	if (OS::get_singleton())
+		_last_mix_time = OS::get_singleton()->get_ticks_usec();
 }
 
 double AudioDriver::get_mix_time() const {


### PR DESCRIPTION
I found out about this when I got a crash on the update_mix_time function, since the AudioServer::finish was not getting called the audio process function was still running and then I got a crash on update_mix_time (it happens rarely on quitting).