### PR TITLE
Remove meaningless print_line from editor Console

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -83,7 +83,6 @@ static void GLAPIENTRY _gl_debug_print(GLenum source, GLenum type, GLuint id, GL
 	if (type == _EXT_DEBUG_TYPE_OTHER_ARB)
 		return;
 
-	print_line("mesege");
 	char debSource[256], debType[256], debSev[256];
 	if (source == _EXT_DEBUG_SOURCE_API_ARB)
 		strcpy(debSource, "OpenGL");


### PR DESCRIPTION
After watching this review by GameFromScratch : 
https://www.youtube.com/watch?v=p0MXsx79KQ8

I felt there is a weird print_line inside the editor console (output-debugger) that could be potentially effecting Godot's reputation (go to 3:01 -> 11:25 & 15:49 -> 17:57). So, I decided to make this PR in hope could help Godot to stay Professional. :-)