### PR TITLE
[GDNative] better header include paths

### DIFF
--- a/modules/gdnative/SCsub
+++ b/modules/gdnative/SCsub
@@ -1,14 +1,15 @@
 #!/usr/bin/env python
 
 Import('env')
+Import('env_modules')
 
-env.add_source_files(env.modules_sources, "*.cpp")
-env.add_source_files(env.modules_sources, "godot/*.cpp")
+mod_env = env_modules.Clone()
+mod_env.add_source_files(env.modules_sources, "*.cpp")
+mod_env.add_source_files(env.modules_sources, "godot/*.cpp")
 
-env.Append(CPPFLAGS=['-DGDAPI_BUILT_IN'])
+mod_env.Append(CPPFLAGS=['-DGDAPI_BUILT_IN'])
+mod_env.Append(CPPPATH=['#modules/gdnative/'])
 
 if "platform" in env and env["platform"] == "x11": # there has to be a better solution?
-    env.Append(LINKFLAGS=["-rdynamic"])
-env.use_ptrcall = True
-
-Export('env')
+    mod_env.Append(LINKFLAGS=["-rdynamic"])
+mod_env.use_ptrcall = True

--- a/modules/gdnative/gdnative.h
+++ b/modules/gdnative/gdnative.h
@@ -35,7 +35,7 @@
 #include "os/thread_safe.h"
 #include "resource.h"
 
-#include "godot/gdnative.h"
+#include <godot/gdnative.h>
 
 class GDNativeLibrary : public Resource {
 	GDCLASS(GDNativeLibrary, Resource)

--- a/modules/gdnative/godot/array.cpp
+++ b/modules/gdnative/godot/array.cpp
@@ -27,7 +27,7 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#include "array.h"
+#include <godot/array.h>
 
 #include "core/array.h"
 #include "core/os/memory.h"

--- a/modules/gdnative/godot/array.h
+++ b/modules/gdnative/godot/array.h
@@ -46,10 +46,10 @@ typedef struct {
 } godot_array;
 #endif
 
-#include "pool_arrays.h"
-#include "variant.h"
+#include <godot/pool_arrays.h>
+#include <godot/variant.h>
 
-#include "gdnative.h"
+#include <godot/gdnative.h>
 
 void GDAPI godot_array_new(godot_array *r_dest);
 void GDAPI godot_array_new_copy(godot_array *r_dest, const godot_array *p_src);

--- a/modules/gdnative/godot/basis.cpp
+++ b/modules/gdnative/godot/basis.cpp
@@ -27,10 +27,10 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#include "basis.h"
-#include "core/variant.h"
+#include <godot/basis.h>
 
 #include "core/math/matrix3.h"
+#include "core/variant.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/gdnative/godot/basis.h
+++ b/modules/gdnative/godot/basis.h
@@ -45,9 +45,9 @@ typedef struct {
 } godot_basis;
 #endif
 
-#include "gdnative.h"
-#include "quat.h"
-#include "vector3.h"
+#include <godot/gdnative.h>
+#include <godot/quat.h>
+#include <godot/vector3.h>
 
 void GDAPI godot_basis_new_with_rows(godot_basis *r_dest, const godot_vector3 *p_x_axis, const godot_vector3 *p_y_axis, const godot_vector3 *p_z_axis);
 void GDAPI godot_basis_new_with_axis_and_angle(godot_basis *r_dest, const godot_vector3 *p_axis, const godot_real p_phi);

--- a/modules/gdnative/godot/color.cpp
+++ b/modules/gdnative/godot/color.cpp
@@ -27,10 +27,10 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#include "color.h"
-#include "core/variant.h"
+#include <godot/color.h>
 
 #include "core/color.h"
+#include "core/variant.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/gdnative/godot/color.h
+++ b/modules/gdnative/godot/color.h
@@ -45,8 +45,8 @@ typedef struct {
 } godot_color;
 #endif
 
-#include "gdnative.h"
-#include "string.h"
+#include <godot/gdnative.h>
+#include <godot/string.h>
 
 void GDAPI godot_color_new_rgba(godot_color *r_dest, const godot_real p_r, const godot_real p_g, const godot_real p_b, const godot_real p_a);
 void GDAPI godot_color_new_rgb(godot_color *r_dest, const godot_real p_r, const godot_real p_g, const godot_real p_b);

--- a/modules/gdnative/godot/dictionary.cpp
+++ b/modules/gdnative/godot/dictionary.cpp
@@ -27,11 +27,11 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#include "dictionary.h"
-#include "core/variant.h"
+#include <godot/dictionary.h>
 
 #include "core/dictionary.h"
 #include "core/io/json.h"
+#include "core/variant.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/gdnative/godot/dictionary.h
+++ b/modules/gdnative/godot/dictionary.h
@@ -45,9 +45,9 @@ typedef struct {
 } godot_dictionary;
 #endif
 
-#include "array.h"
-#include "gdnative.h"
-#include "variant.h"
+#include <godot/array.h>
+#include <godot/gdnative.h>
+#include <godot/variant.h>
 
 void GDAPI godot_dictionary_new(godot_dictionary *r_dest);
 void GDAPI godot_dictionary_new_copy(godot_dictionary *r_dest, const godot_dictionary *p_src);

--- a/modules/gdnative/godot/gdnative.cpp
+++ b/modules/gdnative/godot/gdnative.cpp
@@ -27,7 +27,7 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#include "gdnative.h"
+#include <godot/gdnative.h>
 
 #include "class_db.h"
 #include "error_macros.h"

--- a/modules/gdnative/godot/gdnative.h
+++ b/modules/gdnative/godot/gdnative.h
@@ -174,72 +174,72 @@ typedef struct godot_pool_color_array godot_pool_color_array;
 */
 /////// String
 
-#include "string.h"
+#include <godot/string.h>
 
 ////// Vector2
 
-#include "vector2.h"
+#include <godot/vector2.h>
 
 ////// Rect2
 
-#include "rect2.h"
+#include <godot/rect2.h>
 
 ////// Vector3
 
-#include "vector3.h"
+#include <godot/vector3.h>
 
 ////// Transform2D
 
-#include "transform2d.h"
+#include <godot/transform2d.h>
 
 /////// Plane
 
-#include "plane.h"
+#include <godot/plane.h>
 
 /////// Quat
 
-#include "quat.h"
+#include <godot/quat.h>
 
 /////// Rect3
 
-#include "rect3.h"
+#include <godot/rect3.h>
 
 /////// Basis
 
-#include "basis.h"
+#include <godot/basis.h>
 
 /////// Transform
 
-#include "transform.h"
+#include <godot/transform.h>
 
 /////// Color
 
-#include "color.h"
+#include <godot/color.h>
 
 /////// NodePath
 
-#include "node_path.h"
+#include <godot/node_path.h>
 
 /////// RID
 
-#include "rid.h"
+#include <godot/rid.h>
 
 /////// Dictionary
 
-#include "dictionary.h"
+#include <godot/dictionary.h>
 
 /////// Array
 
-#include "array.h"
+#include <godot/array.h>
 
 // single API file for Pool*Array
-#include "pool_arrays.h"
+#include <godot/pool_arrays.h>
 
 void GDAPI godot_object_destroy(godot_object *p_o);
 
 ////// Variant
 
-#include "variant.h"
+#include <godot/variant.h>
 
 ////// Singleton API
 

--- a/modules/gdnative/godot/node_path.cpp
+++ b/modules/gdnative/godot/node_path.cpp
@@ -27,10 +27,10 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#include "node_path.h"
-#include "core/variant.h"
+#include <godot/node_path.h>
 
 #include "core/path_db.h"
+#include "core/variant.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/gdnative/godot/node_path.h
+++ b/modules/gdnative/godot/node_path.h
@@ -45,8 +45,8 @@ typedef struct {
 } godot_node_path;
 #endif
 
-#include "gdnative.h"
-#include "string.h"
+#include <godot/gdnative.h>
+#include <godot/string.h>
 
 void GDAPI godot_node_path_new(godot_node_path *r_dest, const godot_string *p_from);
 void GDAPI godot_node_path_new_copy(godot_node_path *r_dest, const godot_node_path *p_src);

--- a/modules/gdnative/godot/plane.cpp
+++ b/modules/gdnative/godot/plane.cpp
@@ -27,10 +27,10 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#include "plane.h"
-#include "core/variant.h"
+#include <godot/plane.h>
 
 #include "core/math/plane.h"
+#include "core/variant.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/gdnative/godot/plane.h
+++ b/modules/gdnative/godot/plane.h
@@ -45,8 +45,8 @@ typedef struct {
 } godot_plane;
 #endif
 
-#include "gdnative.h"
-#include "vector3.h"
+#include <godot/gdnative.h>
+#include <godot/vector3.h>
 
 void GDAPI godot_plane_new_with_reals(godot_plane *r_dest, const godot_real p_a, const godot_real p_b, const godot_real p_c, const godot_real p_d);
 void GDAPI godot_plane_new_with_vectors(godot_plane *r_dest, const godot_vector3 *p_v1, const godot_vector3 *p_v2, const godot_vector3 *p_v3);

--- a/modules/gdnative/godot/pool_arrays.cpp
+++ b/modules/gdnative/godot/pool_arrays.cpp
@@ -27,7 +27,7 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#include "pool_arrays.h"
+#include <godot/pool_arrays.h>
 
 #include "array.h"
 #include "core/variant.h"

--- a/modules/gdnative/godot/pool_arrays.h
+++ b/modules/gdnative/godot/pool_arrays.h
@@ -113,12 +113,12 @@ typedef struct {
 } godot_pool_color_array;
 #endif
 
-#include "array.h"
-#include "color.h"
-#include "vector2.h"
-#include "vector3.h"
+#include <godot/array.h>
+#include <godot/color.h>
+#include <godot/vector2.h>
+#include <godot/vector3.h>
 
-#include "gdnative.h"
+#include <godot/gdnative.h>
 
 // byte
 

--- a/modules/gdnative/godot/quat.cpp
+++ b/modules/gdnative/godot/quat.cpp
@@ -27,10 +27,10 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#include "quat.h"
-#include "core/variant.h"
+#include <godot/quat.h>
 
 #include "core/math/quat.h"
+#include "core/variant.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/gdnative/godot/quat.h
+++ b/modules/gdnative/godot/quat.h
@@ -45,8 +45,8 @@ typedef struct {
 } godot_quat;
 #endif
 
-#include "gdnative.h"
-#include "vector3.h"
+#include <godot/gdnative.h>
+#include <godot/vector3.h>
 
 void GDAPI godot_quat_new(godot_quat *r_dest, const godot_real p_x, const godot_real p_y, const godot_real p_z, const godot_real p_w);
 void GDAPI godot_quat_new_with_axis_angle(godot_quat *r_dest, const godot_vector3 *p_axis, const godot_real p_angle);

--- a/modules/gdnative/godot/rect2.cpp
+++ b/modules/gdnative/godot/rect2.cpp
@@ -27,10 +27,10 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#include "rect2.h"
-#include "core/variant.h"
+#include <godot/rect2.h>
 
 #include "core/math/math_2d.h"
+#include "core/variant.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/gdnative/godot/rect2.h
+++ b/modules/gdnative/godot/rect2.h
@@ -43,8 +43,8 @@ typedef struct godot_rect2 {
 } godot_rect2;
 #endif
 
-#include "gdnative.h"
-#include "vector2.h"
+#include <godot/gdnative.h>
+#include <godot/vector2.h>
 
 void GDAPI godot_rect2_new_with_position_and_size(godot_rect2 *r_dest, const godot_vector2 *p_pos, const godot_vector2 *p_size);
 void GDAPI godot_rect2_new(godot_rect2 *r_dest, const godot_real p_x, const godot_real p_y, const godot_real p_width, const godot_real p_height);

--- a/modules/gdnative/godot/rect3.cpp
+++ b/modules/gdnative/godot/rect3.cpp
@@ -27,10 +27,10 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#include "rect3.h"
-#include "core/variant.h"
+#include <godot/rect3.h>
 
 #include "core/math/rect3.h"
+#include "core/variant.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/gdnative/godot/rect3.h
+++ b/modules/gdnative/godot/rect3.h
@@ -45,9 +45,9 @@ typedef struct {
 } godot_rect3;
 #endif
 
-#include "gdnative.h"
-#include "plane.h"
-#include "vector3.h"
+#include <godot/gdnative.h>
+#include <godot/plane.h>
+#include <godot/vector3.h>
 
 void GDAPI godot_rect3_new(godot_rect3 *r_dest, const godot_vector3 *p_pos, const godot_vector3 *p_size);
 

--- a/modules/gdnative/godot/rid.cpp
+++ b/modules/gdnative/godot/rid.cpp
@@ -27,11 +27,11 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#include "rid.h"
-#include "core/variant.h"
+#include <godot/rid.h>
 
 #include "core/resource.h"
 #include "core/rid.h"
+#include "core/variant.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/gdnative/godot/rid.h
+++ b/modules/gdnative/godot/rid.h
@@ -45,7 +45,7 @@ typedef struct {
 } godot_rid;
 #endif
 
-#include "gdnative.h"
+#include <godot/gdnative.h>
 
 void GDAPI godot_rid_new(godot_rid *r_dest);
 

--- a/modules/gdnative/godot/string.cpp
+++ b/modules/gdnative/godot/string.cpp
@@ -27,7 +27,7 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#include "string.h"
+#include <godot/string.h>
 
 #include "string_db.h"
 #include "ustring.h"

--- a/modules/gdnative/godot/string.h
+++ b/modules/gdnative/godot/string.h
@@ -46,7 +46,7 @@ typedef struct {
 } godot_string;
 #endif
 
-#include "gdnative.h"
+#include <godot/gdnative.h>
 
 void GDAPI godot_string_new(godot_string *r_dest);
 void GDAPI godot_string_new_copy(godot_string *r_dest, const godot_string *p_src);

--- a/modules/gdnative/godot/transform.cpp
+++ b/modules/gdnative/godot/transform.cpp
@@ -27,10 +27,10 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#include "transform.h"
-#include "core/variant.h"
+#include <godot/transform.h>
 
 #include "core/math/transform.h"
+#include "core/variant.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/gdnative/godot/transform.h
+++ b/modules/gdnative/godot/transform.h
@@ -45,10 +45,10 @@ typedef struct {
 } godot_transform;
 #endif
 
-#include "basis.h"
-#include "gdnative.h"
-#include "variant.h"
-#include "vector3.h"
+#include <godot/basis.h>
+#include <godot/gdnative.h>
+#include <godot/variant.h>
+#include <godot/vector3.h>
 
 void GDAPI godot_transform_new_with_axis_origin(godot_transform *r_dest, const godot_vector3 *p_x_axis, const godot_vector3 *p_y_axis, const godot_vector3 *p_z_axis, const godot_vector3 *p_origin);
 void GDAPI godot_transform_new(godot_transform *r_dest, const godot_basis *p_basis, const godot_vector3 *p_origin);

--- a/modules/gdnative/godot/transform2d.cpp
+++ b/modules/gdnative/godot/transform2d.cpp
@@ -27,10 +27,10 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#include "transform2d.h"
-#include "core/variant.h"
+#include <godot/transform2d.h>
 
 #include "core/math/math_2d.h"
+#include "core/variant.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/gdnative/godot/transform2d.h
+++ b/modules/gdnative/godot/transform2d.h
@@ -45,9 +45,9 @@ typedef struct {
 } godot_transform2d;
 #endif
 
-#include "gdnative.h"
-#include "variant.h"
-#include "vector2.h"
+#include <godot/gdnative.h>
+#include <godot/variant.h>
+#include <godot/vector2.h>
 
 void GDAPI godot_transform2d_new(godot_transform2d *r_dest, const godot_real p_rot, const godot_vector2 *p_pos);
 void GDAPI godot_transform2d_new_axis_origin(godot_transform2d *r_dest, const godot_vector2 *p_x_axis, const godot_vector2 *p_y_axis, const godot_vector2 *p_origin);

--- a/modules/gdnative/godot/variant.cpp
+++ b/modules/gdnative/godot/variant.cpp
@@ -27,7 +27,8 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#include "variant.h"
+#include <godot/variant.h>
+
 #include "core/variant.h"
 
 #ifdef __cplusplus

--- a/modules/gdnative/godot/variant.h
+++ b/modules/gdnative/godot/variant.h
@@ -99,25 +99,25 @@ typedef struct godot_variant_call_error {
 	godot_variant_type expected;
 } godot_variant_call_error;
 
-#include "array.h"
-#include "basis.h"
-#include "color.h"
-#include "dictionary.h"
-#include "node_path.h"
-#include "plane.h"
-#include "pool_arrays.h"
-#include "quat.h"
-#include "rect2.h"
-#include "rect3.h"
-#include "rid.h"
-#include "string.h"
-#include "transform.h"
-#include "transform2d.h"
-#include "variant.h"
-#include "vector2.h"
-#include "vector3.h"
+#include <godot/array.h>
+#include <godot/basis.h>
+#include <godot/color.h>
+#include <godot/dictionary.h>
+#include <godot/node_path.h>
+#include <godot/plane.h>
+#include <godot/pool_arrays.h>
+#include <godot/quat.h>
+#include <godot/rect2.h>
+#include <godot/rect3.h>
+#include <godot/rid.h>
+#include <godot/string.h>
+#include <godot/transform.h>
+#include <godot/transform2d.h>
+#include <godot/variant.h>
+#include <godot/vector2.h>
+#include <godot/vector3.h>
 
-#include "gdnative.h"
+#include <godot/gdnative.h>
 
 godot_variant_type GDAPI godot_variant_get_type(const godot_variant *p_v);
 

--- a/modules/gdnative/godot/vector2.cpp
+++ b/modules/gdnative/godot/vector2.cpp
@@ -27,10 +27,10 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#include "vector2.h"
-#include "core/variant.h"
+#include <godot/vector2.h>
 
 #include "core/math/math_2d.h"
+#include "core/variant.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/gdnative/godot/vector2.h
+++ b/modules/gdnative/godot/vector2.h
@@ -45,7 +45,7 @@ typedef struct {
 } godot_vector2;
 #endif
 
-#include "gdnative.h"
+#include <godot/gdnative.h>
 
 void GDAPI godot_vector2_new(godot_vector2 *r_dest, const godot_real p_x, const godot_real p_y);
 

--- a/modules/gdnative/godot/vector3.cpp
+++ b/modules/gdnative/godot/vector3.cpp
@@ -27,9 +27,9 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#include "vector3.h"
-#include "core/variant.h"
+#include <godot/vector3.h>
 
+#include "core/variant.h"
 #include "core/vector.h"
 
 #ifdef __cplusplus

--- a/modules/gdnative/godot/vector3.h
+++ b/modules/gdnative/godot/vector3.h
@@ -45,8 +45,8 @@ typedef struct {
 } godot_vector3;
 #endif
 
-#include "basis.h"
-#include "gdnative.h"
+#include <godot/basis.h>
+#include <godot/gdnative.h>
 
 typedef enum {
 	GODOT_VECTOR3_AXIS_X,

--- a/modules/gdnative/register_types.cpp
+++ b/modules/gdnative/register_types.cpp
@@ -76,4 +76,26 @@ void register_gdnative_types() {
 
 void unregister_gdnative_types() {
 	memdelete(GDNativeCallRegistry::singleton);
+
+	// This is for printing out the sizes of the core types
+
+	/*
+	print_line(String("array:\t")     + itos(sizeof(Array)));
+	print_line(String("basis:\t")     + itos(sizeof(Basis)));
+	print_line(String("color:\t")     + itos(sizeof(Color)));
+	print_line(String("dict:\t" )     + itos(sizeof(Dictionary)));
+	print_line(String("node_path:\t") + itos(sizeof(NodePath)));
+	print_line(String("plane:\t")     + itos(sizeof(Plane)));
+	print_line(String("poolarray:\t") + itos(sizeof(PoolByteArray)));
+	print_line(String("quat:\t")      + itos(sizeof(Quat)));
+	print_line(String("rect2:\t")     + itos(sizeof(Rect2)));
+	print_line(String("rect3:\t")     + itos(sizeof(Rect3)));
+	print_line(String("rid:\t")       + itos(sizeof(RID)));
+	print_line(String("string:\t")    + itos(sizeof(String)));
+	print_line(String("transform:\t") + itos(sizeof(Transform)));
+	print_line(String("transfo2D:\t") + itos(sizeof(Transform2D)));
+	print_line(String("variant:\t")   + itos(sizeof(Variant)));
+	print_line(String("vector2:\t")   + itos(sizeof(Vector2)));
+	print_line(String("vector3:\t")   + itos(sizeof(Vector3)));
+	*/
 }


### PR DESCRIPTION
The old include paths caused some problems on some compilers, for
example including "string.h" was ambiguous.