### PR TITLE
Fix Editor Crash on closing

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1704,7 +1704,6 @@ void Main::cleanup() {
 #endif
 
 	if (audio_server) {
-		audio_server->finish();
 		memdelete(audio_server);
 	}
 


### PR DESCRIPTION
Should fix #10034 

Edit: Tested and worked on Win 10 x64.