### PR TITLE
[GDNative/NativeScript] fix -rdynamic and removed _init call

### DIFF
--- a/modules/gdnative/SCsub
+++ b/modules/gdnative/SCsub
@@ -1,15 +1,13 @@
 #!/usr/bin/env python
 
 Import('env')
-Import('env_modules')
 
-mod_env = env_modules.Clone()
-mod_env.add_source_files(env.modules_sources, "*.cpp")
-mod_env.add_source_files(env.modules_sources, "godot/*.cpp")
+env.add_source_files(env.modules_sources, "*.cpp")
+env.add_source_files(env.modules_sources, "godot/*.cpp")
 
-mod_env.Append(CPPFLAGS=['-DGDAPI_BUILT_IN'])
-mod_env.Append(CPPPATH=['#modules/gdnative/'])
+env.Append(CPPFLAGS=['-DGDAPI_BUILT_IN'])
+env.Append(CPPPATH=['#modules/gdnative/'])
 
 if "platform" in env and env["platform"] == "x11": # there has to be a better solution?
-    mod_env.Append(LINKFLAGS=["-rdynamic"])
-mod_env.use_ptrcall = True
+    env.Append(LINKFLAGS=["-rdynamic"])
+env.use_ptrcall = True

--- a/modules/nativescript/nativescript.cpp
+++ b/modules/nativescript/nativescript.cpp
@@ -213,11 +213,6 @@ ScriptInstance *NativeScript::instance_create(Object *p_this) {
 	owners_lock->unlock();
 #endif
 
-	// try to call _init
-	// we don't care if it doesn't exist, so we ignore errors.
-	Variant::CallError err;
-	call("_init", NULL, 0, err);
-
 	return nsi;
 }
 


### PR DESCRIPTION
The _init call was buggy anyway and in the end shouldn't be a
thing that's called via ClassDB, it should be something that's
language specific, so we leave this out for the bindings.

In the commit 66a7763 the SCsub file for GDNative was changed to
use a cloned environment, that bricked -rdynamic which needs to be
passed down to the linker, which didn't happen with the new env.