### PR TITLE
Fix double finalisation of audio drivers

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1192,10 +1192,6 @@ void OS_Windows::finalize() {
 
 	main_loop = NULL;
 
-	for (int i = 0; i < get_audio_driver_count(); i++) {
-		AudioDriverManager::get_driver(i)->finish();
-	}
-
 	memdelete(joypad);
 	memdelete(input);
 

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -529,10 +529,6 @@ void OS_X11::finalize() {
 		memdelete(main_loop);
 	main_loop = NULL;
 
-	for (int i = 0; i < get_audio_driver_count(); i++) {
-		AudioDriverManager::get_driver(i)->finish();
-	}
-
 /*
 	if (debugger_connection_console) {
 		memdelete(debugger_connection_console);

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -772,10 +772,11 @@ void AudioServer::finish() {
 
 	buses.clear();
 
-	if (AudioDriver::get_singleton()) {
-		AudioDriver::get_singleton()->finish();
+	for (int i = 0; i < AudioDriverManager::get_driver_count(); i++) {
+		AudioDriverManager::get_driver(i)->finish();
 	}
 }
+
 void AudioServer::update() {
 }
 


### PR DESCRIPTION
Fixes #10034

After I've added the audio_server->finish call the audio drivers were being finalised twice on X11 and Windows, so with this commit the audio drivers are only finalised by AudioServer::finish (I think this is correct but @reduz might want to check this).

I've also improved the RtAudio driver to create the mutex at the top of init() to prevent multiple mutex creation, and also improved the finish() function to lock the mutex before using dac functions (to prevent any race condition with the callback func).