### PR TITLE
ray cast 2d arrow fix

### DIFF
--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -127,16 +127,16 @@ void RayCast2D::_notification(int p_what) {
 				break;
 			Matrix32 xf;
 			xf.rotate(cast_to.angle());
-			xf.translate(Vector2(cast_to.length(), 0));
+			xf.translate(Vector2(0, cast_to.length()));
 
 			//Vector2 tip = Vector2(0,s->get_length());
 			Color dcol = get_tree()->get_debug_collisions_color(); //0.9,0.2,0.2,0.4);
 			draw_line(Vector2(), cast_to, dcol, 3);
 			Vector<Vector2> pts;
 			float tsize = 4;
-			pts.push_back(xf.xform(Vector2(tsize, 0)));
-			pts.push_back(xf.xform(Vector2(0, 0.707 * tsize)));
-			pts.push_back(xf.xform(Vector2(0, -0.707 * tsize)));
+			pts.push_back(xf.xform(Vector2(0, tsize)));
+			pts.push_back(xf.xform(Vector2(0.707 * tsize, 0)));
+			pts.push_back(xf.xform(Vector2(-0.707 * tsize, 0)));
 			Vector<Color> cols;
 			for (int i = 0; i < 3; i++)
 				cols.push_back(dcol);


### PR DESCRIPTION
fixes #9636 

The problem was #8694 fixed the arrow in the master which works, but then someone cherry picked the commit to 2.1 which doesn't work. So I changed the code back to the working code in 2.1.