### PR TITLE
Forward frame call to GDNative libraries

### DIFF
--- a/modules/nativescript/nativescript.h
+++ b/modules/nativescript/nativescript.h
@@ -220,7 +220,10 @@ private:
 	void register_script(NativeScript *script);
 	void unregister_script(NativeScript *script);
 
+	void call_libraries_cb(const StringName &name);
+
 public:
+	// These two maps must only be touched on the main thread
 	Map<String, Map<StringName, NativeScriptDesc> > library_classes;
 	Map<String, Ref<GDNative> > library_gdnatives;
 
@@ -229,9 +232,14 @@ public:
 	const StringName _init_call_type = "nativescript_init";
 	const StringName _init_call_name = "godot_nativescript_init";
 
-	const StringName _thread_cb_call_type = "godot_nativescript_thread_cb";
+	const StringName _noarg_call_type = "nativescript_no_arg";
+
+	const StringName _frame_call_name = "godot_nativescript_frame";
+
+#ifndef NO_THREADS
 	const StringName _thread_enter_call_name = "godot_nativescript_thread_enter";
 	const StringName _thread_exit_call_name = "godot_nativescript_thread_exit";
+#endif
 
 	NativeScriptLanguage();
 	~NativeScriptLanguage();
@@ -245,9 +253,9 @@ public:
 #ifndef NO_THREADS
 	virtual void thread_enter();
 	virtual void thread_exit();
+#endif
 
 	virtual void frame();
-#endif
 
 	virtual String get_name() const;
 	virtual void init();

--- a/modules/nativescript/register_types.cpp
+++ b/modules/nativescript/register_types.cpp
@@ -62,13 +62,11 @@ void init_call_cb(void *p_handle, godot_string *p_proc_name, void *p_data, int p
 	fn(args[0]);
 }
 
-#ifndef NO_THREADS
-
 typedef void (*native_script_empty_callback)();
 
-void thread_call_cb(void *p_handle, godot_string *p_proc_name, void *p_data, int p_num_args, void **args, void *r_ret) {
+void noarg_call_cb(void *p_handle, godot_string *p_proc_name, void *p_data, int p_num_args, void **args, void *r_ret) {
 	if (p_handle == NULL) {
-		ERR_PRINT("No valid library handle, can't call nativescript thread enter/exit callback");
+		ERR_PRINT("No valid library handle, can't call nativescript callback");
 		return;
 	}
 
@@ -87,8 +85,6 @@ void thread_call_cb(void *p_handle, godot_string *p_proc_name, void *p_data, int
 	fn();
 }
 
-#endif // NO_THREADS
-
 ResourceFormatLoaderNativeScript *resource_loader_gdns = NULL;
 ResourceFormatSaverNativeScript *resource_saver_gdns = NULL;
 
@@ -100,9 +96,7 @@ void register_nativescript_types() {
 	ScriptServer::register_language(native_script_language);
 
 	GDNativeCallRegistry::singleton->register_native_raw_call_type(native_script_language->_init_call_type, init_call_cb);
-#ifndef NO_THREADS
-	GDNativeCallRegistry::singleton->register_native_raw_call_type(native_script_language->_thread_cb_call_type, thread_call_cb);
-#endif
+	GDNativeCallRegistry::singleton->register_native_raw_call_type(native_script_language->_noarg_call_type, noarg_call_cb);
 
 	resource_saver_gdns = memnew(ResourceFormatSaverNativeScript);
 	ResourceSaver::add_resource_format_saver(resource_saver_gdns);


### PR DESCRIPTION
At the moment there is no way for a GDNative library to do something during frame idle time. To temporarily solve that in [godot-nim](https://pragmagic.github.io/godot-nim/master/index.html) I implemented [NimRuntime](https://github.com/pragmagic/godot-nim/blob/master/godot/nimruntime.nim) class, which is supposed to be added as an AutoLoad singleton. But this approach has drawbacks:

1. It adds burden on the user of adding the class to the project.
2. It doesn't work in the editor. I could also add `NimEditorRuntime` plugin, but this again has issue (1) of burdening end user.

So the library itself becomes not self-contained, since you can't just add it to the project and expect it to work.
A simple solution is to forward frame() call to the library where necessary actions could be performed. It's called during idle time, so it is perfectly fit for this use case.