### PR TITLE
Fix resource docker thumbnail bug

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -589,7 +589,7 @@ void FileSystemDock::_go_to_dir(const String &p_dir) {
 
 void FileSystemDock::_preview_invalidated(const String &p_path) {
 
-	if (p_path.get_base_dir() == path && search_box->get_text() == String() && file_list_vb->is_visible_in_tree()) {
+	if (display_mode == DISPLAY_THUMBNAILS && p_path.get_base_dir() == path && search_box->get_text() == String() && file_list_vb->is_visible_in_tree()) {
 
 		for (int i = 0; i < files->get_item_count(); i++) {
 


### PR DESCRIPTION
**Bug:**

Changing the resource docker from thumbnail mode to list mode, then playing the project causes the scene thumbnail to be loaded.

**Solution:**

Not 100% sure this is the best location for the fix, but _preview_invalidated seemed to update the the icon image of the running scene without accounting for the docker being in list mode.