### PR TITLE
[GDNative] fixed a bug with ambiguous include paths

### DIFF
--- a/modules/gdnative/godot/dictionary.cpp
+++ b/modules/gdnative/godot/dictionary.cpp
@@ -29,9 +29,10 @@
 /*************************************************************************/
 #include <godot/dictionary.h>
 
+#include "core/variant.h"
+
 #include "core/dictionary.h"
 #include "core/io/json.h"
-#include "core/variant.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
fixes #10071. The problem is that the json.h file includes the
local variant.h instead of the "absolute" core/variant.h