### PR TITLE
Fix label align of button in editor

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -238,7 +238,7 @@ Ref<Theme> create_editor_theme() {
 	theme->set_stylebox("panel", "TabContainer", style_content_panel);
 	theme->set_stylebox("Content", "EditorStyles", style_content_panel_vp);
 
-	Ref<StyleBoxFlat> style_button_type = make_flat_stylebox(dark_color_1, 4, 4, 6, 4);
+	Ref<StyleBoxFlat> style_button_type = make_flat_stylebox(dark_color_1, 6, 4, 6, 4);
 	style_button_type->set_draw_center(true);
 	style_button_type->set_border_size(border_width);
 	style_button_type->set_light_color(light_color_1);


### PR DESCRIPTION
Fix #9927

![image](https://user-images.githubusercontent.com/8281454/28974128-469cd65a-7970-11e7-9d5e-5d084452ab69.png)
