### PR TITLE
removed focus style for import dock LineEdit

### DIFF
--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -367,6 +367,7 @@ ImportDock::ImportDock() {
 
 	imported = memnew(LineEdit);
 	imported->set_editable(false);
+	imported->add_style_override("focus", memnew(StyleBoxEmpty));
 	add_child(imported);
 	HBoxContainer *hb = memnew(HBoxContainer);
 	add_margin_child(TTR("Import As:"), hb);


### PR DESCRIPTION
Just removing the border when focussing the line edit. The border makes users think, they could edit it but the line edit is more or less just used as a label. with a background. maybe we should change it to a label and just change the style box to give it a dark background. I don't know.
No focus makes it already much more obvious that it is just a "label".