### PR TITLE
fixed Import LineEdit to label + label stylebox

### DIFF
--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -28,6 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include "import_dock.h"
+#include "editor_node.h"
 
 class ImportDockParameters : public Object {
 	GDCLASS(ImportDockParameters, Object)
@@ -365,8 +366,8 @@ void ImportDock::initialize_import_options() const {
 
 ImportDock::ImportDock() {
 
-	imported = memnew(LineEdit);
-	imported->set_editable(false);
+	imported = memnew(Label);
+	imported->add_style_override("normal", EditorNode::get_singleton()->get_gui_base()->get_stylebox("normal", "LineEdit"));
 	add_child(imported);
 	HBoxContainer *hb = memnew(HBoxContainer);
 	add_margin_child(TTR("Import As:"), hb);

--- a/editor/import_dock.h
+++ b/editor/import_dock.h
@@ -41,7 +41,7 @@ class ImportDockParameters;
 class ImportDock : public VBoxContainer {
 	GDCLASS(ImportDock, VBoxContainer)
 
-	LineEdit *imported;
+	Label *imported;
 	OptionButton *import_as;
 	MenuButton *preset;
 	PropertyEditor *import_opts;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -408,6 +408,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	// Label
 
+	theme->set_stylebox("normal", "Label", memnew(StyleBoxEmpty));
 	theme->set_font("font", "Label", default_font);
 
 	theme->set_color("font_color", "Label", Color(1, 1, 1));


### PR DESCRIPTION
 - added a `normal` stylebox to label. default is StyleBoxEmpty
 - changed drawing for label, so that it draws correct with styleboxes with margins
 - changed the `LineEdit` in the import to use a `Label` with the style box of a lineEdit node.