### PR TITLE
fixed loading old theme styleboxes

### DIFF
--- a/editor/asset_library_editor_plugin.cpp
+++ b/editor/asset_library_editor_plugin.cpp
@@ -281,7 +281,7 @@ EditorAssetLibraryItemDescription::EditorAssetLibraryItemDescription() {
 	description = memnew(RichTextLabel);
 	description->connect("meta_clicked", this, "_link_click");
 	desc_bg->add_child(description);
-	desc_bg->add_style_override("panel", get_stylebox("normal", "TextEdit"));
+	desc_bg->add_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_stylebox("normal", "TextEdit"));
 
 	preview = memnew(TextureRect);
 	preview->set_custom_minimum_size(Size2(640, 345));
@@ -290,7 +290,7 @@ EditorAssetLibraryItemDescription::EditorAssetLibraryItemDescription() {
 	PanelContainer *previews_bg = memnew(PanelContainer);
 	vbox->add_child(previews_bg);
 	previews_bg->set_custom_minimum_size(Size2(0, 85));
-	previews_bg->add_style_override("panel", get_stylebox("normal", "TextEdit"));
+	previews_bg->add_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_stylebox("normal", "TextEdit"));
 
 	previews = memnew(ScrollContainer);
 	previews_bg->add_child(previews);
@@ -1362,7 +1362,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 
 	PanelContainer *library_scroll_bg = memnew(PanelContainer);
 	library_main->add_child(library_scroll_bg);
-	library_scroll_bg->add_style_override("panel", get_stylebox("normal", "TextEdit"));
+	library_scroll_bg->add_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_stylebox("bg", "Tree"));
 	library_scroll_bg->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	library_scroll = memnew(ScrollContainer);

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1782,7 +1782,7 @@ void EditorHelpBit::_bind_methods() {
 void EditorHelpBit::_notification(int p_what) {
 
 	if (p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
-		add_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_stylebox("ScriptPanel", "EditorStyles"));
+		add_style_override("panel", get_stylebox("ScriptPanel", "EditorStyles"));
 	}
 }
 

--- a/editor/io_plugins/editor_scene_import_plugin.cpp
+++ b/editor/io_plugins/editor_scene_import_plugin.cpp
@@ -1307,7 +1307,7 @@ EditorSceneImportDialog::EditorSceneImportDialog(EditorNode *p_editor, EditorSce
 	//confirm_import->set_child_rect(cvb);
 
 	PanelContainer *pc = memnew( PanelContainer );
-	pc->add_style_override("panel",get_stylebox("normal","TextEdit"));
+	pc->add_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_stylebox("normal","TextEdit"));
 	//ec->add_child(pc);
 	missing_files = memnew( RichTextLabel );
 	cvb->add_margin_child(TTR("The Following Files are Missing:"),pc,true);

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1246,7 +1246,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor) {
 	set_focus_mode(FOCUS_ALL);
 
 	player = NULL;
-	add_style_override("panel", get_stylebox("panel", "Panel"));
+	add_style_override("panel", editor->get_gui_base()->get_stylebox("panel", "Panel"));
 
 	Label *l;
 

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -362,7 +362,7 @@ void ResourcePreloaderEditor::_bind_methods() {
 
 ResourcePreloaderEditor::ResourcePreloaderEditor() {
 
-	//add_style_override("panel", get_stylebox("panel","Panel"));
+	//add_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_stylebox("panel","Panel"));
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	add_child(vbc);

--- a/editor/plugins/sample_editor_plugin.cpp
+++ b/editor/plugins/sample_editor_plugin.cpp
@@ -360,7 +360,7 @@ SampleEditor::SampleEditor() {
 
 	player = memnew(SamplePlayer);
 	add_child(player);
-	add_style_override("panel", get_stylebox("panel","Panel"));
+	add_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_stylebox("panel","Panel"));
 	library = Ref<SampleLibrary>(memnew(SampleLibrary));
 	player->set_sample_library(library);
 	sample_texframe = memnew( TextureRect );

--- a/editor/plugins/sample_library_editor_plugin.cpp
+++ b/editor/plugins/sample_library_editor_plugin.cpp
@@ -432,7 +432,7 @@ SampleLibraryEditor::SampleLibraryEditor() {
 
 	player = memnew(SamplePlayer);
 	add_child(player);
-	add_style_override("panel", get_stylebox("panel","Panel"));
+	add_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_stylebox("panel","Panel"));
 
 
 	load = memnew( Button );

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -714,7 +714,7 @@ void SpriteFramesEditor::_bind_methods() {
 
 SpriteFramesEditor::SpriteFramesEditor() {
 
-	//add_style_override("panel", get_stylebox("panel","Panel"));
+	//add_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_stylebox("panel","Panel"));
 
 	split = memnew(HSplitContainer);
 	add_child(split);


### PR DESCRIPTION
often `get_stylebox("some_name", "some_type")` was used in constructors.
since the node wasn't part of the editor node tree at this point in time it wasn't loading the editor theme. Instead it loaded the `default_theme`. the is the reason that some UI Elements were purple.
see screenshot:
<img width="400" alt="screen shot 2017-08-04 at 21 44 20" src="https://user-images.githubusercontent.com/16718859/28984405-18342fe6-795e-11e7-82da-45289df1cc04.png">
