### PR TITLE
Improve HTML5 canvas management

### DIFF
--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -59,7 +59,10 @@ class OS_JavaScript : public OS_Unix {
 	const char *gl_extensions;
 
 	InputDefault *input;
+	Vector2 windowed_size;
 	bool window_maximized;
+	bool soft_fs_enabled;
+	bool canvas_size_adjustment_requested;
 	VideoMode video_mode;
 	CursorShape cursor_shape;
 	MainLoop *main_loop;
@@ -129,6 +132,8 @@ public:
 	virtual bool is_window_maximized() const { return window_maximized; }
 	virtual void set_window_fullscreen(bool p_enable);
 	virtual bool is_window_fullscreen() const;
+
+	void request_canvas_size_adjustment();
 
 	virtual String get_name();
 	virtual MainLoop *get_main_loop() const;


### PR DESCRIPTION
 - `OS.set_window_maximized` hides page content
 - Fix sporadic full-screen render-size bug in Chromium
 - Smoother resizing for maximized canvas