### PR TITLE
Implement OS.has_touchscreen_ui_hint() in HTML5 platform

### DIFF
--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -857,7 +857,11 @@ void OS_JavaScript::process_accelerometer(const Vector3 &p_accelerometer) {
 
 bool OS_JavaScript::has_touchscreen_ui_hint() const {
 
-	return false; //???
+	/* clang-format off */
+	return EM_ASM_INT_V(
+		return 'ontouchstart' in window;
+	);
+	/* clang-format on */
 }
 
 void OS_JavaScript::main_loop_request_quit() {


### PR DESCRIPTION
Allows checking for touch screen availability on the HTML5 platform.

If this implementation turns out unreliable, we'll probably have to resort to waiting for touch events and return `false` until then