### PR TITLE
iOS copy touch coordinate as is

### DIFF
--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -224,11 +224,9 @@ void OSIPhone::mouse_button(int p_idx, int p_x, int p_y, bool p_pressed, bool p_
 
 		Ref<InputEventMouseButton> ev;
 		ev.instance();
-		// swaped it for tilted screen
-		//ev->get_pos().x = ev.mouse_button.global_x = video_mode.height - p_y;
-		//ev->get_pos().y = ev.mouse_button.global_y = p_x;
-		ev->set_position(Vector2(video_mode.height - p_y, p_x));
-		ev->set_global_position(Vector2(video_mode.height - p_y, p_x));
+
+		ev->set_position(Vector2(p_x, p_y));
+		ev->set_global_position(Vector2(p_x, p_y));
 
 		//mouse_list.pressed[p_idx] = p_pressed;
 


### PR DESCRIPTION
This deceptively simple fix seems to solve #10080 

The change itself makes sense as the coordinate system in Godot 2.1 was indeed reversed.
What mystified me was when testing this in the morning, iOS seemed to be reacting on the orientation of the phone, an issue I had encountered with processing the orientation sensors.

Anyway I've tested this in portrait, landscape left and landscape right orientations using the material tester demo and I get consistent results. Note that portrait upsidedown crashes for me but thats an unrelated issue.