### PR TITLE
Add format loader for ImageTexture to load supported images directly.

### DIFF
--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -244,6 +244,7 @@ static ResourceFormatLoaderText *resource_loader_text = NULL;
 static ResourceFormatLoaderDynamicFont *resource_loader_dynamic_font = NULL;
 
 static ResourceFormatLoaderStreamTexture *resource_loader_stream_texture = NULL;
+static ResourceFormatLoaderImageTexture *resource_loader_image_texture = NULL;
 
 //static SceneStringNames *string_names;
 
@@ -262,6 +263,9 @@ void register_scene_types() {
 
 	resource_loader_stream_texture = memnew(ResourceFormatLoaderStreamTexture);
 	ResourceLoader::add_resource_format_loader(resource_loader_stream_texture);
+
+	resource_loader_image_texture = memnew(ResourceFormatLoaderImageTexture);
+	ResourceLoader::add_resource_format_loader(resource_loader_image_texture);
 
 #ifdef TOOLS_ENABLED
 
@@ -664,6 +668,7 @@ void unregister_scene_types() {
 	//	memdelete( resource_loader_wav );
 	memdelete(resource_loader_dynamic_font);
 	memdelete(resource_loader_stream_texture);
+	memdelete(resource_loader_image_texture);
 
 #ifdef TOOLS_ENABLED
 

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -225,12 +225,15 @@ Image::Format ImageTexture::get_format() const {
 	return format;
 }
 
-void ImageTexture::load(const String &p_path) {
+Error ImageTexture::load(const String &p_path) {
 
 	Ref<Image> img;
 	img.instance();
-	img->load(p_path);
+
+	Error err = img->load(p_path);
 	create_from_image(img);
+
+	return err;
 }
 
 void ImageTexture::set_data(const Ref<Image> &p_image) {
@@ -378,6 +381,37 @@ ImageTexture::ImageTexture() {
 ImageTexture::~ImageTexture() {
 
 	VisualServer::get_singleton()->free(texture);
+}
+
+RES ResourceFormatLoaderImageTexture::load(const String &p_path, const String &p_original_path, Error *r_error) {
+
+	Ref<ImageTexture> tex;
+	tex.instance();
+	Error err = tex->load(p_path);
+
+	if (r_error)
+		*r_error = err;
+	if (err != OK)
+		return RES();
+
+	return tex;
+}
+
+void ResourceFormatLoaderImageTexture::get_recognized_extensions(List<String> *p_extensions) const {
+
+	ImageLoader::get_recognized_extensions(p_extensions);
+}
+
+bool ResourceFormatLoaderImageTexture::handles_type(const String &p_type) const {
+
+	return p_type == "ImageTexture";
+}
+
+String ResourceFormatLoaderImageTexture::get_resource_type(const String &p_path) const {
+
+	if (ImageLoader::recognize(p_path.get_extension().to_lower()))
+		return "ImageTexture";
+	return "";
 }
 
 //////////////////////////////////////////

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -123,7 +123,7 @@ public:
 	void set_flags(uint32_t p_flags);
 	uint32_t get_flags() const;
 	Image::Format get_format() const;
-	void load(const String &p_path);
+	Error load(const String &p_path);
 	void set_data(const Ref<Image> &p_image);
 	Ref<Image> get_data() const;
 
@@ -148,6 +148,16 @@ public:
 
 	ImageTexture();
 	~ImageTexture();
+};
+
+VARIANT_ENUM_CAST(ImageTexture::Storage);
+
+class ResourceFormatLoaderImageTexture : public ResourceFormatLoader {
+public:
+	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = NULL);
+	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual bool handles_type(const String &p_type) const;
+	virtual String get_resource_type(const String &p_path) const;
 };
 
 class StreamTexture : public Texture {
@@ -225,8 +235,6 @@ public:
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;
 };
-
-VARIANT_ENUM_CAST(ImageTexture::Storage);
 
 class AtlasTexture : public Texture {
 


### PR DESCRIPTION
Sometimes we really need to load images without import them(such as a gui tool to open and show images in the disk) so I made this.