### PR TITLE
NodePath option to find target in editor node tree

### DIFF
--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -45,7 +45,6 @@
 #include "pair.h"
 #include "print_string.h"
 #include "project_settings.h"
-#include "project_settings.h"
 #include "property_selector.h"
 #include "scene/gui/label.h"
 #include "scene/main/viewport.h"
@@ -863,6 +862,10 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 			List<String> names;
 			names.push_back(TTR("Assign"));
 			names.push_back(TTR("Clear"));
+
+			if (owner->is_class("Node") && (v.get_type() == Variant::NODE_PATH) && owner->cast_to<Node>()->has_node(v))
+				names.push_back(TTR("Select Node"));
+
 			config_action_buttons(names);
 
 		} break;
@@ -1270,7 +1273,18 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 				v = NodePath();
 				emit_signal("variant_changed");
 				hide();
+			} else if (p_which == 2) {
+
+				if (owner->is_class("Node") && (v.get_type() == Variant::NODE_PATH) && owner->cast_to<Node>()->has_node(v)) {
+
+					Node *target_node = owner->cast_to<Node>()->get_node(v);
+					EditorNode::get_singleton()->get_editor_selection()->clear();
+					EditorNode::get_singleton()->get_scene_tree_dock()->set_selected(target_node);
+				}
+
+				hide();
 			}
+
 		} break;
 		case Variant::OBJECT: {
 


### PR DESCRIPTION
Adds new option "Find" to the exported NodePath. It will be visible only if target node is on the currently loaded scene. After clicking it, given node will be selected in editor node tree.
![path_find_target](https://user-images.githubusercontent.com/6129594/28997053-7d984f4e-7a0c-11e7-99e5-cfa7df8a24ee.gif)

