### PR TITLE
Renames properties and methods to avoid ambiguities

### DIFF
--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -243,7 +243,7 @@ void Node2D::global_translate(const Vector2 &p_amount) {
 	set_global_position(get_global_position() + p_amount);
 }
 
-void Node2D::scale(const Size2 &p_amount) {
+void Node2D::apply_scale(const Size2 &p_amount) {
 
 	set_scale(get_scale() * p_amount);
 }
@@ -419,7 +419,7 @@ void Node2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("move_local_y", "delta", "scaled"), &Node2D::move_y, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("translate", "offset"), &Node2D::translate);
 	ClassDB::bind_method(D_METHOD("global_translate", "offset"), &Node2D::global_translate);
-	ClassDB::bind_method(D_METHOD("scale", "ratio"), &Node2D::scale);
+	ClassDB::bind_method(D_METHOD("apply_scale", "ratio"), &Node2D::apply_scale);
 
 	ClassDB::bind_method(D_METHOD("set_global_position", "pos"), &Node2D::set_global_position);
 	ClassDB::bind_method(D_METHOD("get_global_position"), &Node2D::get_global_position);

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -78,7 +78,7 @@ public:
 	void move_y(float p_delta, bool p_scaled = false);
 	void translate(const Vector2 &p_amount);
 	void global_translate(const Vector2 &p_amount);
-	void scale(const Size2 &p_amount);
+	void apply_scale(const Size2 &p_amount);
 
 	Point2 get_position() const;
 	float get_rotation() const;

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -508,7 +508,7 @@ void BaseButton::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("toggled", PropertyInfo(Variant::BOOL, "pressed")));
 	ADD_PROPERTYNZ(PropertyInfo(Variant::BOOL, "disabled"), "set_disabled", "is_disabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "toggle_mode"), "set_toggle_mode", "is_toggle_mode");
-	ADD_PROPERTYNZ(PropertyInfo(Variant::BOOL, "is_pressed"), "set_pressed", "is_pressed");
+	ADD_PROPERTYNZ(PropertyInfo(Variant::BOOL, "pressed"), "set_pressed", "is_pressed");
 	ADD_PROPERTYNO(PropertyInfo(Variant::INT, "action_mode", PROPERTY_HINT_ENUM, "Button Press,Button Release"), "set_action_mode", "get_action_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "enabled_focus_mode", PROPERTY_HINT_ENUM, "None,Click,All"), "set_enabled_focus_mode", "get_enabled_focus_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shortcut", PROPERTY_HINT_RESOURCE_TYPE, "ShortCut"), "set_shortcut", "get_shortcut");


### PR DESCRIPTION
- Method `Node2D.scale(Vector2)` renamed to `Node2D.apply_scale(Vector2)`
- Property `BaseButton.is_pressed` renamed to `BaseButton.pressed`
