### PR TITLE
Duplicate error messages to macOS logging system (Console.app)

### DIFF
--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -136,6 +136,8 @@ public:
 
 	virtual String get_name();
 
+	virtual void print_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, ErrorType p_type = ERR_ERROR);
+
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
 
 	virtual void set_cursor_shape(CursorShape p_shape);


### PR DESCRIPTION
Non-bundled executables have annoying focus problems (#8907), and bundled app have `stdout` and `stderr` redirected to `/dev/null`.

This PR adds error message duplication to `Console.app` to save output from bundled app.
