### PR TITLE
Fixed crash on exist, change to only use audio driver manager to finaize drivers

### DIFF
--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -771,10 +771,6 @@ void AudioServer::finish() {
 	}
 
 	buses.clear();
-
-	if (AudioDriver::get_singleton()) {
-		AudioDriver::get_singleton()->finish();
-	}
 }
 void AudioServer::update() {
 }


### PR DESCRIPTION
Previous PR: #10126, I had to do a hard reset to fix the encoding issue with that commit.

Related to #10045 #10028 #10034

I figured that the crash was caused by deleting the audio driver Singleton twice in the cleanup.

Once in AudioServer::finish(), Once in OS_Windows::finalize().

Since the names suggest that Audio Driver Manager is used for driver management, I feel like it is better to do all the driver finalization with it instead of inside AudioServer class.

This is my first time submitting a pull request in my life, Please let me know if I am doing anything wrong or inappropriate. I sincerely appreciate the chance to be able to contribute to the Godot community.

Thank you.

Code detail:

**void AudioServer::finish() {**

	for (int i = 0; i < buses.size(); i++) {
		memdelete(buses[i]);
	}
	buses.clear();

**}**

**void OS_Windows::finalize() {**

	if (main_loop)
		memdelete(main_loop);

	main_loop = NULL;

	for (int i = 0; i < get_audio_driver_count(); i++) {
		AudioDriverManager::get_driver(i)->finish();
	}
        ... ...
**}**