### PR TITLE
Add IME support (macOS)

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -63,6 +63,8 @@ class OS {
 	void *_stack_bottom;
 
 public:
+	typedef void (*ImeCallback)(void *p_inp, String p_text, Point2 p_selection);
+
 	enum RenderThreadMode {
 
 		RENDER_THREAD_UNSAFE,
@@ -183,6 +185,7 @@ public:
 	virtual bool get_borderless_window() { return 0; }
 
 	virtual void set_ime_position(const Point2 &p_pos) {}
+	virtual void set_ime_intermediate_text_callback(ImeCallback p_callback, void *p_inp) {}
 
 	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle) { return ERR_UNAVAILABLE; }
 	virtual Error close_dynamic_library(void *p_library_handle) { return ERR_UNAVAILABLE; }

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -104,6 +104,10 @@ public:
 	Size2 window_size;
 	Rect2 restore_rect;
 
+	Point2 im_position;
+	ImeCallback im_callback;
+	void *im_target;
+
 	power_osx *power_manager;
 
 	float _mouse_scale(float p_scale) {
@@ -203,6 +207,8 @@ public:
 
 	virtual void set_borderless_window(int p_borderless);
 	virtual bool get_borderless_window();
+	virtual void set_ime_position(const Point2 &p_pos);
+	virtual void set_ime_intermediate_text_callback(ImeCallback p_callback, void *p_inp);
 
 	virtual PowerState get_power_state();
 	virtual int get_power_seconds_left();

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -70,6 +70,8 @@ private:
 	String text;
 	String placeholder;
 	float placeholder_alpha;
+	String ime_text;
+	Point2 ime_selection;
 
 	PopupMenu *menu;
 
@@ -92,6 +94,7 @@ private:
 
 	Timer *caret_blink_timer;
 
+	static void _ime_text_callback(void *p_self, String p_text, Point2 p_selection);
 	void _text_changed();
 	bool expand_to_text_length;
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -987,13 +987,41 @@ void TextEdit::_notification(int p_what) {
 						}
 
 						int caret_w = (str[j] == '\t') ? cache.font->get_char_size(' ').width : char_w;
-						if (draw_caret) {
-							if (insert_mode) {
-								int caret_h = (block_caret) ? 4 : 1;
-								VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(cursor_pos, Size2i(caret_w, caret_h)), cache.caret_color);
-							} else {
-								caret_w = (block_caret) ? caret_w : 1;
-								VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(cursor_pos, Size2i(caret_w, get_row_height())), cache.caret_color);
+						if (ime_text.length() > 0) {
+							int ofs = 0;
+							while (true) {
+								if (ofs >= ime_text.length())
+									break;
+
+								CharType cchar = ime_text[ofs];
+								CharType next = ime_text[ofs + 1];
+								int im_char_width = cache.font->get_char_size(cchar, next).width;
+
+								if ((char_ofs + char_margin + im_char_width) >= xmargin_end)
+									break;
+
+								bool selected = ofs >= ime_selection.x && ofs < ime_selection.x + ime_selection.y;
+								if (selected) {
+									VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(Point2(char_ofs + char_margin, ofs_y + get_row_height()), Size2(im_char_width, 3)), color);
+								} else {
+									VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(Point2(char_ofs + char_margin, ofs_y + get_row_height()), Size2(im_char_width, 1)), color);
+								}
+
+								cache.font->draw_char(ci, Point2(char_ofs + char_margin, ofs_y + ascent), cchar, next, color);
+
+								char_ofs += im_char_width;
+								ofs++;
+							}
+						}
+						if (ime_text.length() == 0) {
+							if (draw_caret) {
+								if (insert_mode) {
+									int caret_h = (block_caret) ? 4 : 1;
+									VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(cursor_pos, Size2i(caret_w, caret_h)), cache.caret_color);
+								} else {
+									caret_w = (block_caret) ? caret_w : 1;
+									VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(cursor_pos, Size2i(caret_w, get_row_height())), cache.caret_color);
+								}
 							}
 						}
 					}
@@ -1024,16 +1052,43 @@ void TextEdit::_notification(int p_what) {
 					if (insert_mode) {
 						cursor_pos.y += (get_row_height() - 3);
 					}
+					if (ime_text.length() > 0) {
+						int ofs = 0;
+						while (true) {
+							if (ofs >= ime_text.length())
+								break;
 
-					if (draw_caret) {
-						if (insert_mode) {
-							int char_w = cache.font->get_char_size(' ').width;
-							int caret_h = (block_caret) ? 4 : 1;
-							VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(cursor_pos, Size2i(char_w, caret_h)), cache.caret_color);
-						} else {
-							int char_w = cache.font->get_char_size(' ').width;
-							int caret_w = (block_caret) ? char_w : 1;
-							VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(cursor_pos, Size2i(caret_w, get_row_height())), cache.caret_color);
+							CharType cchar = ime_text[ofs];
+							CharType next = ime_text[ofs + 1];
+							int im_char_width = cache.font->get_char_size(cchar, next).width;
+
+							if ((char_ofs + char_margin + im_char_width) >= xmargin_end)
+								break;
+
+							bool selected = ofs >= ime_selection.x && ofs < ime_selection.x + ime_selection.y;
+							if (selected) {
+								VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(Point2(char_ofs + char_margin, ofs_y + get_row_height()), Size2(im_char_width, 3)), color);
+							} else {
+								VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(Point2(char_ofs + char_margin, ofs_y + get_row_height()), Size2(im_char_width, 1)), color);
+							}
+
+							cache.font->draw_char(ci, Point2(char_ofs + char_margin, ofs_y + ascent), cchar, next, color);
+
+							char_ofs += im_char_width;
+							ofs++;
+						}
+					}
+					if (ime_text.length() == 0) {
+						if (draw_caret) {
+							if (insert_mode) {
+								int char_w = cache.font->get_char_size(' ').width;
+								int caret_h = (block_caret) ? 4 : 1;
+								VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(cursor_pos, Size2i(char_w, caret_h)), cache.caret_color);
+							} else {
+								int char_w = cache.font->get_char_size(' ').width;
+								int caret_w = (block_caret) ? char_w : 1;
+								VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(cursor_pos, Size2i(caret_w, get_row_height())), cache.caret_color);
+							}
 						}
 					}
 				}
@@ -1197,6 +1252,7 @@ void TextEdit::_notification(int p_what) {
 
 			if (has_focus()) {
 				OS::get_singleton()->set_ime_position(get_global_position() + cursor_pos + Point2(0, get_row_height()));
+				OS::get_singleton()->set_ime_intermediate_text_callback(_ime_text_callback, this);
 			}
 		} break;
 		case NOTIFICATION_FOCUS_ENTER: {
@@ -1207,6 +1263,7 @@ void TextEdit::_notification(int p_what) {
 
 			Point2 cursor_pos = Point2(cursor_get_column(), cursor_get_line()) * get_row_height();
 			OS::get_singleton()->set_ime_position(get_global_position() + cursor_pos);
+			OS::get_singleton()->set_ime_intermediate_text_callback(_ime_text_callback, this);
 
 			if (OS::get_singleton()->has_virtual_keyboard())
 				OS::get_singleton()->show_virtual_keyboard(get_text(), get_global_rect());
@@ -1218,6 +1275,9 @@ void TextEdit::_notification(int p_what) {
 		case NOTIFICATION_FOCUS_EXIT: {
 
 			OS::get_singleton()->set_ime_position(Point2());
+			OS::get_singleton()->set_ime_intermediate_text_callback(NULL, NULL);
+			ime_text = "";
+			ime_selection = Point2();
 
 			if (OS::get_singleton()->has_virtual_keyboard())
 				OS::get_singleton()->hide_virtual_keyboard();
@@ -1226,6 +1286,13 @@ void TextEdit::_notification(int p_what) {
 			}
 		} break;
 	}
+}
+
+void TextEdit::_ime_text_callback(void *p_self, String p_text, Point2 p_selection) {
+	TextEdit *self = (TextEdit *)p_self;
+	self->ime_text = p_text;
+	self->ime_selection = p_selection;
+	self->update();
 }
 
 void TextEdit::_consume_pair_symbol(CharType ch) {

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -184,6 +184,9 @@ class TextEdit : public Control {
 		bool chain_backward;
 	};
 
+	String ime_text;
+	Point2 ime_selection;
+
 	TextOperation current_op;
 
 	List<TextOperation> undo_stack;
@@ -298,6 +301,8 @@ class TextEdit : public Control {
 
 	void _scroll_lines_up();
 	void _scroll_lines_down();
+
+	static void _ime_text_callback(void *p_self, String p_text, Point2 p_selection);
 
 	//void mouse_motion(const Point& p_pos, const Point& p_rel, int p_button_mask);
 	Size2 get_minimum_size() const;


### PR DESCRIPTION
Fixes #4403 

`NSTextInputClient` protocol implementation based on GLFW code.
Adds support for dead keys and IME character composition, and on-the-spot intermediate text display for `line_edit` and `text_edit`.

![output_quick](https://user-images.githubusercontent.com/7645683/29084146-c3a862bc-7c73-11e7-8940-224765ae8a23.gif)

This PR needs to be tested as it might lead to other bugs.