### PR TITLE
Fix freeze on close of game using 2D physics introduced by #9832

### DIFF
--- a/servers/physics/physics_server_sw.cpp
+++ b/servers/physics/physics_server_sw.cpp
@@ -493,8 +493,8 @@ void PhysicsServerSW::body_set_space(RID p_body, RID p_space) {
 	if (body->get_space() == space)
 		return; //pointless
 
-	while (body->get_constraint_map().size()) {
-		RID self = body->get_constraint_map().front()->key()->get_self();
+	for (Map<ConstraintSW *, int>::Element *E = body->get_constraint_map().front(); E; E = E->next()) {
+		RID self = E->key()->get_self();
 		if (!self.is_valid())
 			continue;
 		free(self);

--- a/servers/physics_2d/physics_2d_server_sw.cpp
+++ b/servers/physics_2d/physics_2d_server_sw.cpp
@@ -548,8 +548,8 @@ void Physics2DServerSW::body_set_space(RID p_body, RID p_space) {
 	if (body->get_space() == space)
 		return; //pointless
 
-	while (body->get_constraint_map().size()) {
-		RID self = body->get_constraint_map().front()->key()->get_self();
+	for (Map<Constraint2DSW *, int>::Element *E = body->get_constraint_map().front(); E; E = E->next()) {
+		RID self = E->key()->get_self();
 		if (!self.is_valid())
 			continue;
 		free(self);


### PR DESCRIPTION
Additionally, port the fix to 3D physics, just in case.

Not completely sure why the code was written that way, though I can confirm that freezes go away with my patch. I just copy-pasted the code from area_set_space.

Seems done properly for 2.1.