### PR TITLE
Fix crash when running a game with the profiler enabled

### DIFF
--- a/modules/nativescript/nativescript.cpp
+++ b/modules/nativescript/nativescript.cpp
@@ -974,11 +974,11 @@ void NativeScriptLanguage::profiling_stop() {
 }
 
 int NativeScriptLanguage::profiling_get_accumulated_data(ProfilingInfo *p_info_arr, int p_info_max) {
-	return -1;
+	return 0;
 }
 
 int NativeScriptLanguage::profiling_get_frame_data(ProfilingInfo *p_info_arr, int p_info_max) {
-	return -1;
+	return 0;
 }
 
 #ifndef NO_THREADS


### PR DESCRIPTION
NativeScriptLanguage::profiling_get_accumulated_data and NativeScriptLanguage::profiling_get_frame_data were returning a negative value and that made a crash on ScriptDebuggerRemote::_send_profiling_data, since the value was added to the ofs and then it was trying to access profile_info at a negative index.
Closes #10157