### PR TITLE
[WIP] Allow for constants other than integers

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2436,10 +2436,10 @@ Array _ClassDB::get_method_list(StringName p_class, bool p_no_inheritance) const
 	return ret;
 }
 
-PoolStringArray _ClassDB::get_integer_constant_list(const StringName &p_class, bool p_no_inheritance) const {
+PoolStringArray _ClassDB::get_constant_list(const StringName &p_class, bool p_no_inheritance) const {
 
 	List<String> constants;
-	ClassDB::get_integer_constant_list(p_class, &constants, p_no_inheritance);
+	ClassDB::get_constant_list(p_class, &constants, p_no_inheritance);
 
 	PoolStringArray ret;
 	ret.resize(constants.size());
@@ -2451,17 +2451,17 @@ PoolStringArray _ClassDB::get_integer_constant_list(const StringName &p_class, b
 	return ret;
 }
 
-bool _ClassDB::has_integer_constant(const StringName &p_class, const StringName &p_name) const {
+bool _ClassDB::has_constant(const StringName &p_class, const StringName &p_name) const {
 
 	bool success;
-	ClassDB::get_integer_constant(p_class, p_name, &success);
+	ClassDB::get_constant(p_class, p_name, &success);
 	return success;
 }
 
-int _ClassDB::get_integer_constant(const StringName &p_class, const StringName &p_name) const {
+Variant _ClassDB::get_constant(const StringName &p_class, const StringName &p_name) const {
 
 	bool found;
-	int c = ClassDB::get_integer_constant(p_class, p_name, &found);
+	int c = ClassDB::get_constant(p_class, p_name, &found);
 	ERR_FAIL_COND_V(!found, 0);
 	return c;
 }
@@ -2497,10 +2497,10 @@ void _ClassDB::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("class_get_method_list", "class", "no_inheritance"), &_ClassDB::get_method_list, DEFVAL(false));
 
-	ClassDB::bind_method(D_METHOD("class_get_integer_constant_list", "class", "no_inheritance"), &_ClassDB::get_integer_constant_list, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("class_get_constant_list", "class", "no_inheritance"), &_ClassDB::get_constant_list, DEFVAL(false));
 
-	ClassDB::bind_method(D_METHOD("class_has_integer_constant", "class", "name"), &_ClassDB::has_integer_constant);
-	ClassDB::bind_method(D_METHOD("class_get_integer_constant", "class", "name"), &_ClassDB::get_integer_constant);
+	ClassDB::bind_method(D_METHOD("class_has_constant", "class", "name"), &_ClassDB::has_constant);
+	ClassDB::bind_method(D_METHOD("class_get_constant", "class", "name"), &_ClassDB::get_constant);
 
 	ClassDB::bind_method(D_METHOD("class_get_category", "class"), &_ClassDB::get_category);
 	ClassDB::bind_method(D_METHOD("is_class_enabled", "class"), &_ClassDB::is_class_enabled);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -606,9 +606,9 @@ public:
 
 	Array get_method_list(StringName p_class, bool p_no_inheritance = false) const;
 
-	PoolStringArray get_integer_constant_list(const StringName &p_class, bool p_no_inheritance = false) const;
-	bool has_integer_constant(const StringName &p_class, const StringName &p_name) const;
-	int get_integer_constant(const StringName &p_class, const StringName &p_name) const;
+	PoolStringArray get_constant_list(const StringName &p_class, bool p_no_inheritance = false) const;
+	bool has_constant(const StringName &p_class, const StringName &p_name) const;
+	Variant get_constant(const StringName &p_class, const StringName &p_name) const;
 	StringName get_category(const StringName &p_node) const;
 
 	bool is_class_enabled(StringName p_class) const;

--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -583,7 +583,7 @@ MethodBind *ClassDB::get_method(StringName p_class, StringName p_name) {
 	return NULL;
 }
 
-void ClassDB::bind_integer_constant(const StringName &p_class, const StringName &p_name, int p_constant) {
+void ClassDB::bind_constant(const StringName &p_class, const StringName &p_name, Variant p_constant) {
 
 	OBJTYPE_WLOCK;
 
@@ -604,7 +604,7 @@ void ClassDB::bind_integer_constant(const StringName &p_class, const StringName 
 #endif
 }
 
-void ClassDB::get_integer_constant_list(const StringName &p_class, List<String> *p_constants, bool p_no_inheritance) {
+void ClassDB::get_constant_list(const StringName &p_class, List<String> *p_constants, bool p_no_inheritance) {
 
 	OBJTYPE_RLOCK;
 
@@ -630,7 +630,7 @@ void ClassDB::get_integer_constant_list(const StringName &p_class, List<String> 
 	}
 }
 
-int ClassDB::get_integer_constant(const StringName &p_class, const StringName &p_name, bool *p_success) {
+Variant ClassDB::get_constant(const StringName &p_class, const StringName &p_name, bool *p_success) {
 
 	OBJTYPE_RLOCK;
 
@@ -638,7 +638,7 @@ int ClassDB::get_integer_constant(const StringName &p_class, const StringName &p
 
 	while (type) {
 
-		int *constant = type->constant_map.getptr(p_name);
+		Variant *constant = type->constant_map.getptr(p_name);
 		if (constant) {
 
 			if (p_success)
@@ -923,7 +923,7 @@ bool ClassDB::get_property(Object *p_object, const StringName &p_property, Varia
 			return true;
 		}
 
-		const int *c = check->constant_map.getptr(p_property);
+		const Variant *c = check->constant_map.getptr(p_property);
 		if (c) {
 
 			r_value = *c;

--- a/core/class_db.h
+++ b/core/class_db.h
@@ -133,7 +133,7 @@ public:
 		APIType api;
 		ClassInfo *inherits_ptr;
 		HashMap<StringName, MethodBind *, StringNameHasher> method_map;
-		HashMap<StringName, int, StringNameHasher> constant_map;
+		HashMap<StringName, Variant, StringNameHasher> constant_map;
 		HashMap<StringName, MethodInfo, StringNameHasher> signal_map;
 		List<PropertyInfo> property_list;
 #ifdef DEBUG_METHODS_ENABLED
@@ -494,10 +494,14 @@ public:
 	static void add_virtual_method(const StringName &p_class, const MethodInfo &p_method, bool p_virtual = true);
 	static void get_virtual_methods(const StringName &p_class, List<MethodInfo> *p_methods, bool p_no_inheritance = false);
 
-	static void bind_integer_constant(const StringName &p_class, const StringName &p_name, int p_constant);
-	static void get_integer_constant_list(const StringName &p_class, List<String> *p_constants, bool p_no_inheritance = false);
-	static int get_integer_constant(const StringName &p_class, const StringName &p_name, bool *p_success = NULL);
+	static void bind_constant(const StringName &p_class, const StringName &p_name, Variant p_constant);
+	static void get_constant_list(const StringName &p_class, List<String> *p_constants, bool p_no_inheritance = false);
+	static Variant get_constant(const StringName &p_class, const StringName &p_name, bool *p_success = NULL);
 	static StringName get_category(const StringName &p_node);
+
+	static void bind_real_constant(const StringName &p_class, const StringName &p_name, int p_constant);
+	static void get_real_constant_list(const StringName &p_class, List<String> *p_constants, bool p_no_inheritance = false);
+	static float get_real_constant(const StringName &p_class, const StringName &p_name, bool *p_success = NULL);
 
 	static bool get_setter_and_type_for_property(const StringName &p_class, const StringName &p_prop, StringName &r_class, StringName &r_setter);
 
@@ -516,7 +520,7 @@ public:
 };
 
 #define BIND_CONSTANT(m_constant) \
-	ClassDB::bind_integer_constant(get_class_static(), #m_constant, m_constant);
+	ClassDB::bind_constant(get_class_static(), #m_constant, m_constant);
 
 #ifdef TOOLS_ENABLED
 

--- a/editor/doc/doc_data.cpp
+++ b/editor/doc/doc_data.cpp
@@ -397,13 +397,13 @@ void DocData::generate(bool p_basic_types) {
 		}
 
 		List<String> constant_list;
-		ClassDB::get_integer_constant_list(name, &constant_list, true);
+		ClassDB::get_constant_list(name, &constant_list, true);
 
 		for (List<String>::Element *E = constant_list.front(); E; E = E->next()) {
 
 			ConstantDoc constant;
 			constant.name = E->get();
-			constant.value = itos(ClassDB::get_integer_constant(name, E->get()));
+			constant.value = ClassDB::get_constant(name, E->get());
 			c.constants.push_back(constant);
 		}
 

--- a/editor/doc/doc_dump.cpp
+++ b/editor/doc/doc_dump.cpp
@@ -269,7 +269,7 @@ void DocDump::dump(const String &p_file) {
 		_write_string(f, 1, "<constants>");
 
 		List<String> constant_list;
-		ClassDB::get_integer_constant_list(name, &constant_list, true);
+		ClassDB::get_constant_list(name, &constant_list, true);
 
 		/* constants are sorted in a special way */
 
@@ -278,7 +278,7 @@ void DocDump::dump(const String &p_file) {
 		for (List<String>::Element *E = constant_list.front(); E; E = E->next()) {
 			_ConstantSort cs;
 			cs.name = E->get();
-			cs.value = ClassDB::get_integer_constant(name, E->get());
+			cs.value = ClassDB::get_constant(name, E->get());
 			constant_sort.push_back(cs);
 		}
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -666,7 +666,7 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 				StringName cname = result.class_name;
 				bool success;
 				while (true) {
-					ClassDB::get_integer_constant(cname, result.class_member, &success);
+					ClassDB::get_constant(cname, result.class_member, &success);
 					if (success) {
 						result.class_name = cname;
 						cname = ClassDB::get_parent_class(cname);

--- a/modules/gdscript/gd_compiler.cpp
+++ b/modules/gdscript/gd_compiler.cpp
@@ -235,7 +235,7 @@ int GDCompiler::_parse_expression(CodeGen &codegen, const GDParser::Node *p_expr
 				if (nc) {
 
 					bool success = false;
-					int constant = ClassDB::get_integer_constant(nc->get_name(), identifier, &success);
+					Variant constant = ClassDB::get_constant(nc->get_name(), identifier, &success);
 					if (success) {
 						Variant key = constant;
 						int idx;

--- a/modules/gdscript/gd_editor.cpp
+++ b/modules/gdscript/gd_editor.cpp
@@ -1258,7 +1258,7 @@ static void _find_identifiers_in_class(GDCompletionContext &context, bool p_stat
 			if (!p_only_functions) {
 
 				List<String> constants;
-				ClassDB::get_integer_constant_list(type, &constants);
+				ClassDB::get_constant_list(type, &constants);
 				for (List<String>::Element *E = constants.front(); E; E = E->next()) {
 					result.insert(E->get());
 				}
@@ -2099,7 +2099,7 @@ Error GDScriptLanguage::complete_code(const String &p_code, const String &p_base
 					if (gdn.is_valid()) {
 						StringName cn = gdn->get_name();
 						List<String> cnames;
-						ClassDB::get_integer_constant_list(cn, &cnames);
+						ClassDB::get_constant_list(cn, &cnames);
 						for (List<String>::Element *E = cnames.front(); E; E = E->next()) {
 							options.insert(E->get());
 						}
@@ -2236,7 +2236,7 @@ Error GDScriptLanguage::complete_code(const String &p_code, const String &p_base
 					}
 
 					if (!isfunction) {
-						ClassDB::get_integer_constant_list(t.obj_type, r_options);
+						ClassDB::get_constant_list(t.obj_type, r_options);
 
 						List<PropertyInfo> pinfo;
 						ClassDB::get_property_list(t.obj_type, &pinfo);
@@ -2789,7 +2789,7 @@ Error GDScriptLanguage::lookup_code(const String &p_code, const String &p_symbol
 					}
 
 					bool success;
-					ClassDB::get_integer_constant(t.obj_type, p_symbol, &success);
+					ClassDB::get_constant(t.obj_type, p_symbol, &success);
 					if (success) {
 						r_result.type = ScriptLanguage::LookupResult::RESULT_CLASS_CONSTANT;
 						r_result.class_name = t.obj_type;

--- a/modules/gdscript/gd_script.cpp
+++ b/modules/gdscript/gd_script.cpp
@@ -50,7 +50,7 @@ GDNativeClass::GDNativeClass(const StringName &p_name) {
 bool GDNativeClass::_get(const StringName &p_name, Variant &r_ret) const {
 
 	bool ok;
-	int v = ClassDB::get_integer_constant(name, p_name, &ok);
+	Variant v = ClassDB::get_constant(name, p_name, &ok);
 
 	if (ok) {
 		r_ret = v;

--- a/modules/nativescript/api_generator.cpp
+++ b/modules/nativescript/api_generator.cpp
@@ -166,11 +166,11 @@ List<ClassAPI> generate_c_api_classes() {
 		// constants
 		{
 			List<String> constant;
-			ClassDB::get_integer_constant_list(class_name, &constant, true);
+			ClassDB::get_constant_list(class_name, &constant, true);
 			for (List<String>::Element *c = constant.front(); c != NULL; c = c->next()) {
 				ConstantAPI constant_api;
 				constant_api.constant_name = c->get();
-				constant_api.constant_value = ClassDB::get_integer_constant(class_name, c->get());
+				constant_api.constant_value = ClassDB::get_constant(class_name, c->get());
 
 				class_api.constants.push_back(constant_api);
 			}

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -1591,7 +1591,7 @@ public:
 VisualScriptNodeInstance *VisualScriptClassConstant::instance(VisualScriptInstance *p_instance) {
 
 	VisualScriptNodeInstanceClassConstant *instance = memnew(VisualScriptNodeInstanceClassConstant);
-	instance->value = ClassDB::get_integer_constant(base_type, name, &instance->valid);
+	instance->value = ClassDB::get_constant(base_type, name, &instance->valid);
 	return instance;
 }
 
@@ -1600,7 +1600,7 @@ void VisualScriptClassConstant::_validate_property(PropertyInfo &property) const
 	if (property.name == "constant/constant") {
 
 		List<String> constants;
-		ClassDB::get_integer_constant_list(base_type, &constants, true);
+		ClassDB::get_constant_list(base_type, &constants, true);
 
 		property.hint_string = "";
 		for (List<String>::Element *E = constants.front(); E; E = E->next()) {


### PR DESCRIPTION
I wanted to have constants that were not Integers, so I replaced the integer hashmap in ClassDB by a Variant hashmap.
Can someone tell me if this is a good idea ? Or how it should be done instead ?

It still haven't checked what those modifications imply into the code, **don't merge yet** as I have to check if some occurences are not systematically casted to an int.