### PR TITLE
Fix for WebGL2 and HTML5 export

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.h
+++ b/drivers/gles3/rasterizer_canvas_gles3.h
@@ -42,6 +42,7 @@ public:
 
 		float projection_matrix[16];
 		float time;
+		uint8_t padding[12];
 	};
 
 	RasterizerSceneGLES3 *scene_render;
@@ -102,6 +103,7 @@ public:
 			float light_height;
 			float light_outside_alpha;
 			float shadow_distance_mult;
+			uint8_t padding[4];
 		} ubo_data;
 
 		GLuint ubo;

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -141,6 +141,7 @@ public:
 			float fog_height_min;
 			float fog_height_max;
 			float fog_height_curve;
+			uint8_t padding[8];
 
 		} ubo_data;
 
@@ -150,6 +151,7 @@ public:
 
 			float transform[16];
 			float ambient_contribution;
+			uint8_t padding[12];
 
 		} env_radiance_data;
 

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -273,6 +273,9 @@ ShaderGLES3::Version *ShaderGLES3::get_current_version() {
 	//vertex precision is high
 	strings.push_back("precision highp float;\n");
 	strings.push_back("precision highp int;\n");
+	strings.push_back("precision highp sampler2D;\n");
+	strings.push_back("precision highp samplerCube;\n");
+	strings.push_back("precision highp sampler2DArray;\n");
 
 #if 0
 	if (cc) {
@@ -371,6 +374,9 @@ ShaderGLES3::Version *ShaderGLES3::get_current_version() {
 	//fragment precision is medium
 	strings.push_back("precision highp float;\n");
 	strings.push_back("precision highp int;\n");
+	strings.push_back("precision highp sampler2D;\n");
+	strings.push_back("precision highp samplerCube;\n");
+	strings.push_back("precision highp sampler2DArray;\n");
 
 #if 0
 	if (cc) {

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -532,11 +532,11 @@ FRAGMENT_SHADER_CODE
 
 #ifdef USE_RGBA_SHADOWS
 
-#define SHADOW_DEPTH(m_tex,m_uv) dot(texture2D((m_tex),(m_uv)),vec4(1.0 / (256.0 * 256.0 * 256.0),1.0 / (256.0 * 256.0),1.0 / 256.0,1)  )
+#define SHADOW_DEPTH(m_tex,m_uv) dot(texture((m_tex),(m_uv)),vec4(1.0 / (256.0 * 256.0 * 256.0),1.0 / (256.0 * 256.0),1.0 / 256.0,1)  )
 
 #else
 
-#define SHADOW_DEPTH(m_tex,m_uv) (texture2D((m_tex),(m_uv)).r)
+#define SHADOW_DEPTH(m_tex,m_uv) (texture((m_tex),(m_uv)).r)
 
 #endif
 

--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -100,6 +100,7 @@ IP_Address IP_Unix::_resolve_hostname(const String &p_hostname, Type p_type) {
 		hints.ai_family = AF_UNSPEC;
 		hints.ai_flags = AI_ADDRCONFIG;
 	};
+	hints.ai_flags &= !AI_NUMERICHOST;
 
 	int s = getaddrinfo(p_hostname.utf8().get_data(), NULL, &hints, &result);
 	if (s != 0) {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1464,6 +1464,7 @@ bool Main::start() {
 				String iconpath = GLOBAL_DEF("application/config/icon", "Variant()");
 				if (iconpath != "") {
 					Ref<Image> icon;
+					icon.instance();
 					if (icon->load(iconpath) == OK)
 						OS::get_singleton()->set_icon(icon);
 				}


### PR DESCRIPTION
This PR is mainly about fixing shaders to work properly in a WebGL2 context:

- Add padding to UBO data to be multiple of 16 bytes [see here](https://khronos.org/registry/OpenGL/specs/gl/glspec45.core.pdf#page=159)
- Add precision definition for samplers
- Replace texture2D (deprecated) with texture in shaders

Additionally, I attached to this PR 2 other small fixes:

1 - Application icon loading was broken due to NULL pointer (*bugsquad*: fixes #10256)
2 - `getaddrinfo` was failing due to `AI_NUMERICHOST` flag being set by default on HTML5 platform (see #9624 ).
      (I really hope this won't break other platforms, as it shouldn't, but networking sucks)

I'm really a noob at OpenGL so don't hesitate to question this work.
Let me know also if you prefer to have a separate PR for the 2 small fixes

EDIT: Adding some screenshots

**PBR Materials look cool**
![3dmat](https://user-images.githubusercontent.com/1687918/29233307-8a89f6ce-7ef0-11e7-841d-64f014a05b93.png)

**3D Platformer is still somewhat broken**
![3d-plat](https://user-images.githubusercontent.com/1687918/29233335-a780d9e6-7ef0-11e7-800e-48c173a339c4.png)

**2D Effects seems to be working just fine**
![2deffects](https://user-images.githubusercontent.com/1687918/29233348-b2f7683a-7ef0-11e7-9b6a-02cfa1c00c61.png)

**Same as 2D lights**
![2dlights](https://user-images.githubusercontent.com/1687918/29233404-e796718a-7ef0-11e7-8405-f20729bede0c.png)

**2D Platformer seems to be working too, but keyboards controls are broken everywhere**
![2dplat](https://user-images.githubusercontent.com/1687918/29233457-1febc486-7ef1-11e7-9b39-2b057a1720e9.png)
