### PR TITLE
fix crash after click on MeshInstance with no owner

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -285,11 +285,11 @@ ObjectID SpatialEditorViewport::_select_ray(const Point2 &p_pos, bool p_append, 
 
 			Node *subscene_candidate = spat;
 
-			while (subscene_candidate->get_owner() != editor->get_edited_scene())
+			while ((subscene_candidate->get_owner() != NULL) && (subscene_candidate->get_owner() != editor->get_edited_scene()))
 				subscene_candidate = subscene_candidate->get_owner();
 
 			spat = subscene_candidate->cast_to<Spatial>();
-			if (spat && (spat->get_filename() != ""))
+			if (spat && (spat->get_filename() != "") && (subscene_candidate->get_owner() != NULL))
 				subscenes.push_back(spat);
 
 			continue;


### PR DESCRIPTION
Due to how spatial selection works, after clicking on MeshInstance that had no owner editor was crashing.
In my case node didn't had an owner because it was created dynamically in `ready`, based on exported variable value.