### PR TITLE
Use const reference where favorable

### DIFF
--- a/core/class_db.h
+++ b/core/class_db.h
@@ -45,7 +45,7 @@ struct ParamHint {
 	String hint_text;
 	Variant default_val;
 
-	ParamHint(const String &p_name = "", PropertyHint p_hint = PROPERTY_HINT_NONE, const String &p_hint_text = "", Variant p_default_val = Variant())
+	ParamHint(const String &p_name = "", PropertyHint p_hint = PROPERTY_HINT_NONE, const String &p_hint_text = "", const Variant &p_default_val = Variant())
 		: name(p_name),
 		  hint(p_hint),
 		  hint_text(p_hint_text),

--- a/core/io/packet_peer_udp.h
+++ b/core/io/packet_peer_udp.h
@@ -49,7 +49,7 @@ protected:
 public:
 	void set_blocking_mode(bool p_enable);
 
-	virtual Error listen(int p_port, IP_Address p_bind_address = IP_Address("*"), int p_recv_buffer_size = 65536) = 0;
+	virtual Error listen(int p_port, const IP_Address &p_bind_address = IP_Address("*"), int p_recv_buffer_size = 65536) = 0;
 	virtual void close() = 0;
 	virtual Error wait() = 0;
 	virtual bool is_listening() const = 0;

--- a/core/io/tcp_server.h
+++ b/core/io/tcp_server.h
@@ -45,7 +45,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	virtual Error listen(uint16_t p_port, const IP_Address p_bind_address = IP_Address("*")) = 0;
+	virtual Error listen(uint16_t p_port, const IP_Address &p_bind_address = IP_Address("*")) = 0;
 	virtual bool is_connection_available() const = 0;
 	virtual Ref<StreamPeerTCP> take_connection() = 0;
 

--- a/core/math/plane.cpp
+++ b/core/math/plane.cpp
@@ -103,7 +103,7 @@ bool Plane::intersect_3(const Plane &p_plane1, const Plane &p_plane2, Vector3 *r
 	return true;
 }
 
-bool Plane::intersects_ray(Vector3 p_from, Vector3 p_dir, Vector3 *p_intersection) const {
+bool Plane::intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, Vector3 *p_intersection) const {
 
 	Vector3 segment = p_dir;
 	real_t den = normal.dot(segment);
@@ -128,7 +128,7 @@ bool Plane::intersects_ray(Vector3 p_from, Vector3 p_dir, Vector3 *p_intersectio
 	return true;
 }
 
-bool Plane::intersects_segment(Vector3 p_begin, Vector3 p_end, Vector3 *p_intersection) const {
+bool Plane::intersects_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 *p_intersection) const {
 
 	Vector3 segment = p_begin - p_end;
 	real_t den = normal.dot(segment);

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -56,8 +56,8 @@ public:
 	/* intersections */
 
 	bool intersect_3(const Plane &p_plane1, const Plane &p_plane2, Vector3 *r_result = 0) const;
-	bool intersects_ray(Vector3 p_from, Vector3 p_dir, Vector3 *p_intersection) const;
-	bool intersects_segment(Vector3 p_begin, Vector3 p_end, Vector3 *p_intersection) const;
+	bool intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, Vector3 *p_intersection) const;
+	bool intersects_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 *p_intersection) const;
 
 	_FORCE_INLINE_ Vector3 project(const Vector3 &p_point) const {
 

--- a/core/method_ptrcall.h
+++ b/core/method_ptrcall.h
@@ -80,6 +80,26 @@ struct PtrToArg {
 		}                                                                         \
 	}
 
+#define MAKE_PTRARG_BY_REFERENCE(m_type)                                      \
+	template <>                                                               \
+	struct PtrToArg<m_type> {                                                 \
+		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {             \
+			return *reinterpret_cast<const m_type *>(p_ptr);                  \
+		}                                                                     \
+		_FORCE_INLINE_ static void encode(const m_type &p_val, void *p_ptr) { \
+			*((m_type *)p_ptr) = p_val;                                       \
+		}                                                                     \
+	};                                                                        \
+	template <>                                                               \
+	struct PtrToArg<const m_type &> {                                         \
+		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {             \
+			return *reinterpret_cast<const m_type *>(p_ptr);                  \
+		}                                                                     \
+		_FORCE_INLINE_ static void encode(const m_type &p_val, void *p_ptr) { \
+			*((m_type *)p_ptr) = p_val;                                       \
+		}                                                                     \
+	}
+
 MAKE_PTRARG(bool);
 MAKE_PTRARGCONV(uint8_t, int64_t);
 MAKE_PTRARGCONV(int8_t, int64_t);
@@ -95,14 +115,14 @@ MAKE_PTRARG(double);
 MAKE_PTRARG(String);
 MAKE_PTRARG(Vector2);
 MAKE_PTRARG(Rect2);
-MAKE_PTRARG(Vector3);
+MAKE_PTRARG_BY_REFERENCE(Vector3);
 MAKE_PTRARG(Transform2D);
-MAKE_PTRARG(Plane);
+MAKE_PTRARG_BY_REFERENCE(Plane);
 MAKE_PTRARG(Quat);
-MAKE_PTRARG(Rect3);
-MAKE_PTRARG(Basis);
-MAKE_PTRARG(Transform);
-MAKE_PTRARG(Color);
+MAKE_PTRARG_BY_REFERENCE(Rect3);
+MAKE_PTRARG_BY_REFERENCE(Basis);
+MAKE_PTRARG_BY_REFERENCE(Transform);
+MAKE_PTRARG_BY_REFERENCE(Color);
 MAKE_PTRARG(NodePath);
 MAKE_PTRARG(RID);
 MAKE_PTRARG(Dictionary);
@@ -114,7 +134,7 @@ MAKE_PTRARG(PoolStringArray);
 MAKE_PTRARG(PoolVector2Array);
 MAKE_PTRARG(PoolVector3Array);
 MAKE_PTRARG(PoolColorArray);
-MAKE_PTRARG(Variant);
+MAKE_PTRARG_BY_REFERENCE(Variant);
 
 //this is for Object
 
@@ -311,8 +331,29 @@ MAKE_DVECARR(Plane);
 		}                                                              \
 	}
 
+#define MAKE_STRINGCONV_BY_REFERENCE(m_type)                                  \
+	template <>                                                               \
+	struct PtrToArg<m_type> {                                                 \
+		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {             \
+			m_type s = *reinterpret_cast<const String *>(p_ptr);              \
+			return s;                                                         \
+		}                                                                     \
+		_FORCE_INLINE_ static void encode(const m_type &p_vec, void *p_ptr) { \
+			String *arr = reinterpret_cast<String *>(p_ptr);                  \
+			*arr = p_vec;                                                     \
+		}                                                                     \
+	};                                                                        \
+                                                                              \
+	template <>                                                               \
+	struct PtrToArg<const m_type &> {                                         \
+		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {             \
+			m_type s = *reinterpret_cast<const String *>(p_ptr);              \
+			return s;                                                         \
+		}                                                                     \
+	}
+
 MAKE_STRINGCONV(StringName);
-MAKE_STRINGCONV(IP_Address);
+MAKE_STRINGCONV_BY_REFERENCE(IP_Address);
 
 template <>
 struct PtrToArg<PoolVector<Face3> > {

--- a/core/pair.h
+++ b/core/pair.h
@@ -37,7 +37,7 @@ struct Pair {
 	S second;
 
 	Pair() {}
-	Pair(F p_first, S p_second)
+	Pair(F p_first, const S &p_second)
 		: first(p_first),
 		  second(p_second) {
 	}

--- a/core/vector.h
+++ b/core/vector.h
@@ -117,7 +117,7 @@ public:
 	}
 	_FORCE_INLINE_ bool empty() const { return _ptr == 0; }
 	Error resize(int p_size);
-	bool push_back(T p_elem);
+	bool push_back(const T &p_elem);
 
 	void remove(int p_index);
 	void erase(const T &p_val) {
@@ -129,7 +129,7 @@ public:
 	template <class T_val>
 	int find(const T_val &p_val, int p_from = 0) const;
 
-	void set(int p_index, T p_elem);
+	void set(int p_index, const T &p_elem);
 	T get(int p_index) const;
 
 	inline T &operator[](int p_index) {
@@ -336,7 +336,7 @@ void Vector<T>::invert() {
 }
 
 template <class T>
-void Vector<T>::set(int p_index, T p_elem) {
+void Vector<T>::set(int p_index, const T &p_elem) {
 
 	operator[](p_index) = p_elem;
 }
@@ -348,7 +348,7 @@ T Vector<T>::get(int p_index) const {
 }
 
 template <class T>
-bool Vector<T>::push_back(T p_elem) {
+bool Vector<T>::push_back(const T &p_elem) {
 
 	Error err = resize(size() + 1);
 	ERR_FAIL_COND_V(err, true)

--- a/drivers/unix/packet_peer_udp_posix.cpp
+++ b/drivers/unix/packet_peer_udp_posix.cpp
@@ -127,7 +127,7 @@ int PacketPeerUDPPosix::get_max_packet_size() const {
 	return 512; // uhm maybe not
 }
 
-Error PacketPeerUDPPosix::listen(int p_port, IP_Address p_bind_address, int p_recv_buffer_size) {
+Error PacketPeerUDPPosix::listen(int p_port, const IP_Address &p_bind_address, int p_recv_buffer_size) {
 
 	ERR_FAIL_COND_V(sockfd != -1, ERR_ALREADY_IN_USE);
 	ERR_FAIL_COND_V(!p_bind_address.is_valid() && !p_bind_address.is_wildcard(), ERR_INVALID_PARAMETER);

--- a/drivers/unix/packet_peer_udp_posix.h
+++ b/drivers/unix/packet_peer_udp_posix.h
@@ -67,7 +67,7 @@ public:
 
 	virtual int get_max_packet_size() const;
 
-	virtual Error listen(int p_port, IP_Address p_bind_address = IP_Address("*"), int p_recv_buffer_size = 65536);
+	virtual Error listen(int p_port, const IP_Address &p_bind_address = IP_Address("*"), int p_recv_buffer_size = 65536);
 	virtual void close();
 	virtual Error wait();
 	virtual bool is_listening() const;

--- a/drivers/unix/tcp_server_posix.cpp
+++ b/drivers/unix/tcp_server_posix.cpp
@@ -69,7 +69,7 @@ void TCPServerPosix::make_default() {
 	TCP_Server::_create = TCPServerPosix::_create;
 };
 
-Error TCPServerPosix::listen(uint16_t p_port, const IP_Address p_bind_address) {
+Error TCPServerPosix::listen(uint16_t p_port, const IP_Address &p_bind_address) {
 
 	ERR_FAIL_COND_V(listen_sockfd != -1, ERR_ALREADY_IN_USE);
 	ERR_FAIL_COND_V(!p_bind_address.is_valid() && !p_bind_address.is_wildcard(), ERR_INVALID_PARAMETER);

--- a/drivers/unix/tcp_server_posix.h
+++ b/drivers/unix/tcp_server_posix.h
@@ -41,7 +41,7 @@ class TCPServerPosix : public TCP_Server {
 	static TCP_Server *_create();
 
 public:
-	virtual Error listen(uint16_t p_port, IP_Address p_bind_address = IP_Address("*"));
+	virtual Error listen(uint16_t p_port, const IP_Address &p_bind_address = IP_Address("*"));
 	virtual bool is_connection_available() const;
 	virtual Ref<StreamPeerTCP> take_connection();
 

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -171,7 +171,7 @@ class AppxPackager {
 	}
 
 	Vector<uint8_t> make_file_header(FileMeta p_file_meta);
-	void store_central_dir_header(const FileMeta p_file, bool p_do_hash = true);
+	void store_central_dir_header(const FileMeta &p_file, bool p_do_hash = true);
 	Vector<uint8_t> make_end_of_central_record();
 
 	String content_type(String p_extension);
@@ -329,7 +329,7 @@ Vector<uint8_t> AppxPackager::make_file_header(FileMeta p_file_meta) {
 	return buf;
 }
 
-void AppxPackager::store_central_dir_header(const FileMeta p_file, bool p_do_hash) {
+void AppxPackager::store_central_dir_header(const FileMeta &p_file, bool p_do_hash) {
 
 	Vector<uint8_t> &buf = central_dir_data;
 	int offs = buf.size();

--- a/platform/windows/packet_peer_udp_winsock.cpp
+++ b/platform/windows/packet_peer_udp_winsock.cpp
@@ -118,7 +118,7 @@ void PacketPeerUDPWinsock::_set_sock_blocking(bool p_blocking) {
 	};
 }
 
-Error PacketPeerUDPWinsock::listen(int p_port, IP_Address p_bind_address, int p_recv_buffer_size) {
+Error PacketPeerUDPWinsock::listen(int p_port, const IP_Address &p_bind_address, int p_recv_buffer_size) {
 
 	ERR_FAIL_COND_V(sockfd != -1, ERR_ALREADY_IN_USE);
 	ERR_FAIL_COND_V(!p_bind_address.is_valid() && !p_bind_address.is_wildcard(), ERR_INVALID_PARAMETER);

--- a/platform/windows/packet_peer_udp_winsock.h
+++ b/platform/windows/packet_peer_udp_winsock.h
@@ -67,7 +67,7 @@ public:
 
 	virtual int get_max_packet_size() const;
 
-	virtual Error listen(int p_port, IP_Address p_bind_address = IP_Address("*"), int p_recv_buffer_size = 65536);
+	virtual Error listen(int p_port, const IP_Address &p_bind_address = IP_Address("*"), int p_recv_buffer_size = 65536);
 	virtual void close();
 	virtual Error wait();
 	virtual bool is_listening() const;

--- a/platform/windows/tcp_server_winsock.cpp
+++ b/platform/windows/tcp_server_winsock.cpp
@@ -63,7 +63,7 @@ void TCPServerWinsock::cleanup() {
 	};
 };
 
-Error TCPServerWinsock::listen(uint16_t p_port, const IP_Address p_bind_address) {
+Error TCPServerWinsock::listen(uint16_t p_port, const IP_Address &p_bind_address) {
 
 	ERR_FAIL_COND_V(listen_sockfd != -1, ERR_ALREADY_IN_USE);
 	ERR_FAIL_COND_V(!p_bind_address.is_valid() && !p_bind_address.is_wildcard(), ERR_INVALID_PARAMETER);

--- a/platform/windows/tcp_server_winsock.h
+++ b/platform/windows/tcp_server_winsock.h
@@ -40,7 +40,7 @@ class TCPServerWinsock : public TCP_Server {
 	static TCP_Server *_create();
 
 public:
-	virtual Error listen(uint16_t p_port, const IP_Address p_bind_address = IP_Address("*"));
+	virtual Error listen(uint16_t p_port, const IP_Address &p_bind_address = IP_Address("*"));
 	virtual bool is_connection_available() const;
 	virtual Ref<StreamPeerTCP> take_connection();
 


### PR DESCRIPTION
This pull request applies some performance suggestions given by `cppcheck`, namely using const references on certain function parameters to avoid passing non primitive types by value. The performance gained is barely noticeable but it's there. 

This pull request mitigates the following `cppcheck` messages:

```
[core/class_db.h:48]: (performance, inconclusive) Function parameter 'p_default_val' should be passed by reference.
[core/pair.h:40]: (performance, inconclusive) Function parameter 'p_second' should be passed by reference.
[core/method_ptrcall.h:98]: (performance) Function parameter 'p_val' should be passed by reference.
[core/method_ptrcall.h:100]: (performance) Function parameter 'p_val' should be passed by reference.
[core/method_ptrcall.h:102]: (performance) Function parameter 'p_val' should be passed by reference.
[core/method_ptrcall.h:103]: (performance) Function parameter 'p_val' should be passed by reference.
[core/method_ptrcall.h:104]: (performance) Function parameter 'p_val' should be passed by reference.
[core/method_ptrcall.h:105]: (performance) Function parameter 'p_val' should be passed by reference.
[core/method_ptrcall.h:117]: (performance, inconclusive) Function parameter 'p_val' should be passed by reference.
[core/method_ptrcall.h:315]: (performance) Function parameter 'p_vec' should be passed by reference.
[core/math/plane.cpp:106]: (performance) Function parameter 'p_dir' should be passed by reference.
[core/math/plane.cpp:131]: (performance) Function parameter 'p_end' should be passed by reference.
[core/vector.h:339]: (performance) Function parameter 'p_elem' should be passed by reference.
[core/vector.h:351]: (performance) Function parameter 'p_elem' should be passed by reference.
[platform/uwp/export/export.cpp:332]: (performance) Function parameter 'p_file' should be passed by reference.
[core/io/tcp_server.h:48]: (performance) Function parameter 'p_bind_address' should be passed by reference.
```

The following performance suggestions from `cppcheck` were not be implemented since for some reason they make the editor get stuck in some sort of loop (godot seems to stay responsive but the editor is never rendered):

```
[core/sort.h:93]: (performance, inconclusive) Function parameter 'p_value' should be passed by reference.
[core/sort.h:103]: (performance, inconclusive) Function parameter 'p_value' should be passed by reference.
[core/sort.h:93]: (performance) Function parameter 'p_value' should be passed by reference.
[core/sort.h:103]: (performance) Function parameter 'p_value' should be passed by reference.
```

The following performance suggestions are unneeded since they modify C code that does not benefit from using const references due to the fact that references do not exist in C. Thanks to @karroffel for pointing it out.

```
[modules/nativescript/godot_nativescript.cpp:52]: (performance) Function parameter 'p_create_func' should be passed by reference.
[modules/nativescript/godot_nativescript.cpp:52]: (performance) Function parameter 'p_destroy_func' should be passed by reference.
[modules/nativescript/godot_nativescript.cpp:77]: (performance) Function parameter 'p_create_func' should be passed by reference.
[modules/nativescript/godot_nativescript.cpp:77]: (performance) Function parameter 'p_destroy_func' should be passed by reference.
[modules/nativescript/godot_nativescript.cpp:101]: (performance) Function parameter 'p_method' should be passed by reference.
[modules/nativescript/godot_nativescript.cpp:120]: (performance) Function parameter 'p_set_func' should be passed by reference.
[modules/nativescript/godot_nativescript.cpp:120]: (performance) Function parameter 'p_get_func' should be passed by reference.
```

The only difference between `MAKE_PTRARG` and the new `MAKE_PTRARG_BY_REFERENCE` macro is just that the `encode` function receives `p_val` by const reference. This same difference applies to `MAKE_STRINGCONV` and `MAKE_STRINGCONV_BY_REFERENCE`. I wasn't sure how to name these.