### PR TITLE
Fix broken stream reading in StreamPeerBuffer

### DIFF
--- a/core/io/stream_peer.cpp
+++ b/core/io/stream_peer.cpp
@@ -459,8 +459,9 @@ Error StreamPeerBuffer::get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_
 	}
 
 	PoolVector<uint8_t>::Read r = data.read();
-	copymem(p_buffer, r.ptr(), r_received);
+	copymem(p_buffer, r.ptr() + pointer, r_received);
 
+	pointer += r_received;
 	// FIXME: return what? OK or ERR_*
 }
 


### PR DESCRIPTION
StreamPeerBuffer was not using or advancing the stream position when reading data from its array. Now it does. Address #10293.