### PR TITLE
Disabling Particles::one_shot restarts emission

### DIFF
--- a/scene/2d/particles_2d.cpp
+++ b/scene/2d/particles_2d.cpp
@@ -55,6 +55,8 @@ void Particles2D::set_one_shot(bool p_enable) {
 
 	one_shot = p_enable;
 	VS::get_singleton()->particles_set_one_shot(particles, one_shot);
+	if (!one_shot && emitting)
+		VisualServer::get_singleton()->particles_restart(particles);
 }
 void Particles2D::set_pre_process_time(float p_time) {
 

--- a/scene/3d/particles.cpp
+++ b/scene/3d/particles.cpp
@@ -63,6 +63,8 @@ void Particles::set_one_shot(bool p_one_shot) {
 
 	one_shot = p_one_shot;
 	VS::get_singleton()->particles_set_one_shot(particles, one_shot);
+	if (!one_shot && emitting)
+		VisualServer::get_singleton()->particles_restart(particles);
 }
 
 void Particles::set_pre_process_time(float p_time) {


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/185322/29239181-778f5f2a-7f7a-11e7-8bcb-55f01f8ac71a.gif)

Fixes #10181