### PR TITLE
Adds Engine::is_editor_hint() method

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2568,6 +2568,16 @@ bool _Engine::is_in_fixed_frame() const {
 	return Engine::get_singleton()->is_in_fixed_frame();
 }
 
+void _Engine::set_editor_hint(bool p_enabled) {
+
+	Engine::get_singleton()->set_editor_hint(p_enabled);
+}
+
+bool _Engine::is_editor_hint() const {
+
+	return Engine::get_singleton()->is_editor_hint();
+}
+
 void _Engine::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_iterations_per_second", "iterations_per_second"), &_Engine::set_iterations_per_second);
@@ -2588,6 +2598,9 @@ void _Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_version_info"), &_Engine::get_version_info);
 
 	ClassDB::bind_method(D_METHOD("is_in_fixed_frame"), &_Engine::is_in_fixed_frame);
+
+	ClassDB::bind_method(D_METHOD("set_editor_hint", "enabled"), &_Engine::set_editor_hint);
+	ClassDB::bind_method(D_METHOD("is_editor_hint"), &_Engine::is_editor_hint);
 }
 
 _Engine *_Engine::singleton = NULL;

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -647,6 +647,9 @@ public:
 
 	bool is_in_fixed_frame() const;
 
+	void set_editor_hint(bool p_enabled);
+	bool is_editor_hint() const;
+
 	_Engine();
 };
 

--- a/core/engine.cpp
+++ b/core/engine.cpp
@@ -121,4 +121,5 @@ Engine::Engine() {
 	_in_fixed = false;
 	_frame_ticks = 0;
 	_frame_step = 0;
+	editor_hint = false;
 }

--- a/core/engine.h
+++ b/core/engine.h
@@ -51,8 +51,11 @@ class Engine {
 	float _time_scale;
 	bool _pixel_snap;
 	uint64_t _fixed_frames;
+
 	uint64_t _idle_frames;
 	bool _in_fixed;
+
+	bool editor_hint;
 
 	static Engine *singleton;
 
@@ -84,6 +87,14 @@ public:
 	uint32_t get_frame_delay() const;
 
 	_FORCE_INLINE_ bool get_use_pixel_snap() const { return _pixel_snap; }
+
+#ifdef TOOLS_ENABLED
+	_FORCE_INLINE_ void set_editor_hint(bool p_enabled) { editor_hint = p_enabled; }
+	_FORCE_INLINE_ bool is_editor_hint() const { return editor_hint; }
+#else
+	_FORCE_INLINE_ void set_editor_hint(bool p_enabled) {}
+	_FORCE_INLINE_ bool is_editor_hint() const { return false; }
+#endif
 
 	Dictionary get_version_info() const;
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -281,7 +281,6 @@ void EditorNode::_notification(int p_what) {
 
 		get_tree()->get_root()->set_disable_3d(true);
 		//MessageQueue::get_singleton()->push_call(this,"_get_scene_metadata");
-		get_tree()->set_editor_hint(true);
 		get_tree()->get_root()->set_as_audio_listener(false);
 		get_tree()->get_root()->set_as_audio_listener_2d(false);
 		get_tree()->set_auto_accept_quit(false);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -277,6 +277,8 @@ void EditorNode::_notification(int p_what) {
 	}
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
+		Engine::get_singleton()->set_editor_hint(true);
+
 		get_tree()->get_root()->set_disable_3d(true);
 		//MessageQueue::get_singleton()->push_call(this,"_get_scene_metadata");
 		get_tree()->set_editor_hint(true);

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -212,7 +212,7 @@ void AnimationTreeEditor::_edit_dialog_animation_changed() {
 
 void AnimationTreeEditor::_edit_dialog_edit_animation() {
 
-	if (get_tree()->is_editor_hint()) {
+	if (Engine::get_singleton()->is_editor_hint()) {
 		get_tree()->get_root()->get_child(0)->call("_resource_selected", property_editor->get_variant().operator RefPtr());
 	};
 };

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -561,7 +561,7 @@ bool CanvasItemEditor::_select_click_on_item(CanvasItem *item, Point2 p_click_po
 			editor_selection->clear();
 			editor_selection->add_node(item);
 			// Reselect
-			if (get_tree()->is_editor_hint()) {
+			if (Engine::get_singleton()->is_editor_hint()) {
 				editor->call("edit_node", item);
 			}
 		}

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -2893,7 +2893,7 @@ Object *SpatialEditor::_get_editor_data(Object *p_what) {
 	si->sbox_instance = VisualServer::get_singleton()->instance_create2(selection_box->get_rid(), sp->get_world()->get_scenario());
 	VS::get_singleton()->instance_geometry_set_cast_shadows_setting(si->sbox_instance, VS::SHADOW_CASTING_SETTING_OFF);
 
-	if (get_tree()->is_editor_hint())
+	if (Engine::get_singleton()->is_editor_hint())
 		editor->call("edit_node", sp);
 
 	return si;

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -465,6 +465,7 @@ void ProjectManager::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
+		Engine::get_singleton()->set_editor_hint(true);
 		get_tree()->set_editor_hint(true);
 
 	} else if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
@@ -965,7 +966,6 @@ void ProjectManager::_run_project_confirm() {
 			run_error_diag->popup_centered();
 			return;
 		}
-
 
 		const String &selected = E->key();
 		String path = EditorSettings::get_singleton()->get("projects/" + selected);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -466,7 +466,6 @@ void ProjectManager::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
 		Engine::get_singleton()->set_editor_hint(true);
-		get_tree()->set_editor_hint(true);
 
 	} else if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -660,6 +660,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	if (editor) {
+		Engine::get_singleton()->set_editor_hint(true);
 		main_args.push_back("-editor");
 		init_maximized = true;
 		use_custom_res = false;

--- a/modules/gdnative/gdnative.cpp
+++ b/modules/gdnative/gdnative.cpp
@@ -229,7 +229,7 @@ bool GDNative::initialize() {
 
 	godot_gdnative_init_options options;
 
-	options.in_editor = SceneTree::get_singleton()->is_editor_hint();
+	options.in_editor = Engine::get_singleton()->is_editor_hint();
 	options.core_api_hash = ClassDB::get_api_hash(ClassDB::API_CORE);
 	options.editor_api_hash = ClassDB::get_api_hash(ClassDB::API_EDITOR);
 	options.no_api_hash = ClassDB::get_api_hash(ClassDB::API_NONE);
@@ -265,7 +265,7 @@ bool GDNative::terminate() {
 	// TODO(karroffel): remove this? Should be part of NativeScript, not
 	// GDNative IMO
 	godot_gdnative_terminate_options options;
-	options.in_editor = SceneTree::get_singleton()->is_editor_hint();
+	options.in_editor = Engine::get_singleton()->is_editor_hint();
 
 	library_terminate_pointer(&options);
 

--- a/modules/gdscript/gd_editor.cpp
+++ b/modules/gdscript/gd_editor.cpp
@@ -35,6 +35,7 @@
 #ifdef TOOLS_ENABLED
 #include "editor/editor_file_system.h"
 #include "editor/editor_settings.h"
+#include "engine.h"
 #endif
 
 void GDScriptLanguage::get_comment_delimiters(List<String> *p_delimiters) const {
@@ -2371,7 +2372,7 @@ Error GDScriptLanguage::complete_code(const String &p_code, const String &p_base
 
 String GDScriptLanguage::_get_indentation() const {
 #ifdef TOOLS_ENABLED
-	if (SceneTree::get_singleton()->is_editor_hint()) {
+	if (Engine::get_singleton()->is_editor_hint()) {
 		bool use_space_indentation = EDITOR_DEF("text_editor/indent/type", 0);
 
 		if (use_space_indentation) {

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -273,7 +273,7 @@ void VisualScript::_node_ports_changed(int p_id) {
 	Function &func = functions[function];
 	Ref<VisualScriptNode> vsn = func.nodes[p_id].node;
 
-	if (OS::get_singleton()->get_main_loop() && OS::get_singleton()->get_main_loop()->cast_to<SceneTree>() && OS::get_singleton()->get_main_loop()->cast_to<SceneTree>()->is_editor_hint()) {
+	if (OS::get_singleton()->get_main_loop() && OS::get_singleton()->get_main_loop()->cast_to<SceneTree>() && Engine::get_singleton()->is_editor_hint()) {
 		vsn->validate_input_default_values(); //force validate default values when editing on editor
 	}
 

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -1164,7 +1164,7 @@ void VisualScriptPropertySet::_update_cache() {
 	if (!OS::get_singleton()->get_main_loop()->cast_to<SceneTree>())
 		return;
 
-	if (!OS::get_singleton()->get_main_loop()->cast_to<SceneTree>()->is_editor_hint()) //only update cache if editor exists, it's pointless otherwise
+	if (!Engine::get_singleton()->is_editor_hint()) //only update cache if editor exists, it's pointless otherwise
 		return;
 
 	if (call_mode == CALL_MODE_BASIC_TYPE) {

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -1,7 +1,10 @@
 
 #include "audio_stream_player_2d.h"
+
+#include "engine.h"
 #include "scene/2d/area_2d.h"
 #include "scene/main/viewport.h"
+
 void AudioStreamPlayer2D::_mix_audio() {
 
 	if (!stream_playback.is_valid()) {
@@ -120,7 +123,7 @@ void AudioStreamPlayer2D::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
 		AudioServer::get_singleton()->add_callback(_mix_audios, this);
-		if (autoplay && !get_tree()->is_editor_hint()) {
+		if (autoplay && !Engine::get_singleton()->is_editor_hint()) {
 			play();
 		}
 	}

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -38,7 +38,7 @@ void Camera2D::_update_scroll() {
 	if (!is_inside_tree())
 		return;
 
-	if (get_tree()->is_editor_hint()) {
+	if (Engine::get_singleton()->is_editor_hint()) {
 		update(); //will just be drawn
 		return;
 	}
@@ -85,7 +85,7 @@ Transform2D Camera2D::get_camera_transform() {
 
 		if (anchor_mode == ANCHOR_MODE_DRAG_CENTER) {
 
-			if (h_drag_enabled && !get_tree()->is_editor_hint()) {
+			if (h_drag_enabled && !Engine::get_singleton()->is_editor_hint()) {
 				camera_pos.x = MIN(camera_pos.x, (new_camera_pos.x + screen_size.x * 0.5 * drag_margin[MARGIN_RIGHT]));
 				camera_pos.x = MAX(camera_pos.x, (new_camera_pos.x - screen_size.x * 0.5 * drag_margin[MARGIN_LEFT]));
 			} else {
@@ -97,7 +97,7 @@ Transform2D Camera2D::get_camera_transform() {
 				}
 			}
 
-			if (v_drag_enabled && !get_tree()->is_editor_hint()) {
+			if (v_drag_enabled && !Engine::get_singleton()->is_editor_hint()) {
 
 				camera_pos.y = MIN(camera_pos.y, (new_camera_pos.y + screen_size.y * 0.5 * drag_margin[MARGIN_BOTTOM]));
 				camera_pos.y = MAX(camera_pos.y, (new_camera_pos.y - screen_size.y * 0.5 * drag_margin[MARGIN_TOP]));
@@ -136,7 +136,7 @@ Transform2D Camera2D::get_camera_transform() {
 				camera_pos.y -= screen_rect.position.y - limit[MARGIN_TOP];
 		}
 
-		if (smoothing_enabled && !get_tree()->is_editor_hint()) {
+		if (smoothing_enabled && !Engine::get_singleton()->is_editor_hint()) {
 
 			float c = smoothing * get_fixed_process_delta_time();
 			smoothed_camera_pos = ((camera_pos - smoothed_camera_pos) * c) + smoothed_camera_pos;
@@ -240,7 +240,7 @@ void Camera2D::_notification(int p_what) {
 			add_to_group(group_name);
 			add_to_group(canvas_group_name);
 
-			if (get_tree()->is_editor_hint()) {
+			if (Engine::get_singleton()->is_editor_hint()) {
 				set_fixed_process(false);
 			}
 
@@ -262,7 +262,7 @@ void Camera2D::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_DRAW: {
 
-			if (!is_inside_tree() || !get_tree()->is_editor_hint())
+			if (!is_inside_tree() || !Engine::get_singleton()->is_editor_hint())
 				break;
 
 			if (screen_drawing_enabled) {
@@ -497,7 +497,7 @@ void Camera2D::align() {
 void Camera2D::set_follow_smoothing(float p_speed) {
 
 	smoothing = p_speed;
-	if (smoothing > 0 && !(is_inside_tree() && get_tree()->is_editor_hint()))
+	if (smoothing > 0 && !(is_inside_tree() && Engine::get_singleton()->is_editor_hint()))
 		set_fixed_process(true);
 	else
 		set_fixed_process(false);

--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -30,6 +30,7 @@
 #include "collision_polygon_2d.h"
 
 #include "collision_object_2d.h"
+#include "engine.h"
 #include "scene/resources/concave_polygon_shape_2d.h"
 #include "scene/resources/convex_polygon_shape_2d.h"
 
@@ -134,7 +135,7 @@ void CollisionPolygon2D::_notification(int p_what) {
 				parent->shape_owner_set_one_way_collision(owner_id, one_way_collision);
 			}
 
-			/*if (get_tree()->is_editor_hint()) {
+			/*if (Engine::get_singleton()->is_editor_hint()) {
 				//display above all else
 				set_z_as_relative(false);
 				set_z(VS::CANVAS_ITEM_Z_MAX - 1);
@@ -158,7 +159,7 @@ void CollisionPolygon2D::_notification(int p_what) {
 
 		case NOTIFICATION_DRAW: {
 
-			if (!get_tree()->is_editor_hint() && !get_tree()->is_debugging_collisions_hint()) {
+			if (!Engine::get_singleton()->is_editor_hint() && !get_tree()->is_debugging_collisions_hint()) {
 				break;
 			}
 

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -28,7 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include "collision_shape_2d.h"
+
 #include "collision_object_2d.h"
+#include "engine.h"
 #include "scene/resources/capsule_shape_2d.h"
 #include "scene/resources/circle_shape_2d.h"
 #include "scene/resources/concave_polygon_shape_2d.h"
@@ -59,7 +61,7 @@ void CollisionShape2D::_notification(int p_what) {
 				parent->shape_owner_set_one_way_collision(owner_id, one_way_collision);
 			}
 
-			/*if (get_tree()->is_editor_hint()) {
+			/*if (Engine::get_singleton()->is_editor_hint()) {
 				//display above all else
 				set_z_as_relative(false);
 				set_z(VS::CANVAS_ITEM_Z_MAX - 1);
@@ -90,7 +92,7 @@ void CollisionShape2D::_notification(int p_what) {
 		} break;*/
 		case NOTIFICATION_DRAW: {
 
-			if (!get_tree()->is_editor_hint() && !get_tree()->is_debugging_collisions_hint()) {
+			if (!Engine::get_singleton()->is_editor_hint() && !get_tree()->is_debugging_collisions_hint()) {
 				break;
 			}
 

--- a/scene/2d/joints_2d.cpp
+++ b/scene/2d/joints_2d.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include "joints_2d.h"
+
+#include "engine.h"
 #include "physics_body_2d.h"
 #include "servers/physics_2d_server.h"
 
@@ -152,7 +154,7 @@ void PinJoint2D::_notification(int p_what) {
 			if (!is_inside_tree())
 				break;
 
-			if (!get_tree()->is_editor_hint() && !get_tree()->is_debugging_collisions_hint()) {
+			if (!Engine::get_singleton()->is_editor_hint() && !get_tree()->is_debugging_collisions_hint()) {
 				break;
 			}
 
@@ -227,7 +229,7 @@ void GrooveJoint2D::_notification(int p_what) {
 			if (!is_inside_tree())
 				break;
 
-			if (!get_tree()->is_editor_hint() && !get_tree()->is_debugging_collisions_hint()) {
+			if (!Engine::get_singleton()->is_editor_hint() && !get_tree()->is_debugging_collisions_hint()) {
 				break;
 			}
 
@@ -317,7 +319,7 @@ void DampedSpringJoint2D::_notification(int p_what) {
 			if (!is_inside_tree())
 				break;
 
-			if (!get_tree()->is_editor_hint() && !get_tree()->is_debugging_collisions_hint()) {
+			if (!Engine::get_singleton()->is_editor_hint() && !get_tree()->is_debugging_collisions_hint()) {
 				break;
 			}
 

--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include "light_2d.h"
+
+#include "engine.h"
 #include "servers/visual_server.h"
 
 void Light2D::edit_set_pivot(const Point2 &p_pivot) {
@@ -70,7 +72,7 @@ void Light2D::_update_light_visibility() {
 
 #ifdef TOOLS_ENABLED
 	if (editor_only) {
-		if (!get_tree()->is_editor_hint()) {
+		if (!Engine::get_singleton()->is_editor_hint()) {
 			editor_ok = false;
 		} else {
 			editor_ok = (get_tree()->get_edited_scene_root() && (this == get_tree()->get_edited_scene_root() || get_owner() == get_tree()->get_edited_scene_root()));

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -29,6 +29,8 @@
 /*************************************************************************/
 #include "light_occluder_2d.h"
 
+#include "engine.h"
+
 void OccluderPolygon2D::set_polygon(const PoolVector<Vector2> &p_polygon) {
 
 	polygon = p_polygon;
@@ -130,7 +132,7 @@ void LightOccluder2D::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_DRAW) {
 
-		if (get_tree()->is_editor_hint()) {
+		if (Engine::get_singleton()->is_editor_hint()) {
 
 			if (occluder_polygon.is_valid()) {
 

--- a/scene/2d/navigation_polygon.cpp
+++ b/scene/2d/navigation_polygon.cpp
@@ -30,6 +30,7 @@
 #include "navigation_polygon.h"
 
 #include "core_string_names.h"
+#include "engine.h"
 #include "navigation2d.h"
 
 #include "thirdparty/misc/triangulator.h"
@@ -297,7 +298,7 @@ void NavigationPolygonInstance::set_enabled(bool p_enabled) {
 		}
 	}
 
-	if (get_tree()->is_editor_hint() || get_tree()->is_debugging_navigation_hint())
+	if (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_navigation_hint())
 		update();
 
 	//update_gizmo();
@@ -352,7 +353,7 @@ void NavigationPolygonInstance::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_DRAW: {
 
-			if (is_inside_tree() && (get_tree()->is_editor_hint() || get_tree()->is_debugging_navigation_hint()) && navpoly.is_valid()) {
+			if (is_inside_tree() && (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_navigation_hint()) && navpoly.is_valid()) {
 
 				PoolVector<Vector2> verts = navpoly->get_vertices();
 				int vsize = verts.size();
@@ -432,7 +433,7 @@ Ref<NavigationPolygon> NavigationPolygonInstance::get_navigation_polygon() const
 
 void NavigationPolygonInstance::_navpoly_changed() {
 
-	if (is_inside_tree() && (get_tree()->is_editor_hint() || get_tree()->is_debugging_navigation_hint()))
+	if (is_inside_tree() && (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_navigation_hint()))
 		update();
 }
 

--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include "parallax_layer.h"
+
+#include "engine.h"
 #include "parallax_background.h"
 
 void ParallaxLayer::set_motion_scale(const Size2 &p_scale) {
@@ -111,7 +113,7 @@ void ParallaxLayer::set_base_offset_and_scale(const Point2 &p_offset, float p_sc
 
 	if (!is_inside_tree())
 		return;
-	if (get_tree()->is_editor_hint())
+	if (Engine::get_singleton()->is_editor_hint())
 		return;
 	Point2 new_ofs = ((orig_offset + p_offset) * motion_scale) * p_scale + motion_offset;
 

--- a/scene/2d/particles_2d.cpp
+++ b/scene/2d/particles_2d.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 #include "particles_2d.h"
 
+#include "engine.h"
 #include "scene/3d/particles.h"
 #include "scene/scene_string_names.h"
 
@@ -293,7 +294,7 @@ void Particles2D::_notification(int p_what) {
 		VS::get_singleton()->canvas_item_add_particles(get_canvas_item(), particles, texture_rid, normal_rid, h_frames, v_frames);
 
 #ifdef TOOLS_ENABLED
-		if (get_tree()->is_editor_hint() && (this == get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->is_a_parent_of(this))) {
+		if (Engine::get_singleton()->is_editor_hint() && (this == get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->is_a_parent_of(this))) {
 
 			draw_rect(visibility_rect, Color(0, 0.7, 0.9, 0.4), false);
 		}

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include "path_2d.h"
+
+#include "engine.h"
 #include "scene/scene_string_names.h"
 
 void Path2D::_notification(int p_what) {
@@ -35,7 +37,7 @@ void Path2D::_notification(int p_what) {
 	if (p_what == NOTIFICATION_DRAW && curve.is_valid()) {
 		//draw the curve!!
 
-		if (!get_tree()->is_editor_hint() && !get_tree()->is_debugging_navigation_hint()) {
+		if (!Engine::get_singleton()->is_editor_hint() && !get_tree()->is_debugging_navigation_hint()) {
 			return;
 		}
 
@@ -56,7 +58,7 @@ void Path2D::_notification(int p_what) {
 
 void Path2D::_curve_changed() {
 
-	if (is_inside_tree() && get_tree()->is_editor_hint())
+	if (is_inside_tree() && Engine::get_singleton()->is_editor_hint())
 		update();
 }
 

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include "physics_body_2d.h"
+
+#include "engine.h"
 #include "scene/scene_string_names.h"
 
 void PhysicsBody2D::_notification(int p_what) {
@@ -802,13 +804,13 @@ void RigidBody2D::_notification(int p_what) {
 
 #ifdef TOOLS_ENABLED
 	if (p_what == NOTIFICATION_ENTER_TREE) {
-		if (get_tree()->is_editor_hint()) {
+		if (Engine::get_singleton()->is_editor_hint()) {
 			set_notify_local_transform(true); //used for warnings and only in editor
 		}
 	}
 
 	if (p_what == NOTIFICATION_LOCAL_TRANSFORM_CHANGED) {
-		if (get_tree()->is_editor_hint()) {
+		if (Engine::get_singleton()->is_editor_hint()) {
 			update_configuration_warning();
 		}
 	}

--- a/scene/2d/position_2d.cpp
+++ b/scene/2d/position_2d.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include "position_2d.h"
+
+#include "engine.h"
 #include "scene/resources/texture.h"
 
 void Position2D::_draw_cross() {
@@ -52,7 +54,7 @@ void Position2D::_notification(int p_what) {
 		case NOTIFICATION_DRAW: {
 			if (!is_inside_tree())
 				break;
-			if (get_tree()->is_editor_hint())
+			if (Engine::get_singleton()->is_editor_hint())
 				_draw_cross();
 
 		} break;

--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -28,14 +28,16 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include "ray_cast_2d.h"
+
 #include "collision_object_2d.h"
+#include "engine.h"
 #include "physics_body_2d.h"
 #include "servers/physics_2d_server.h"
 
 void RayCast2D::set_cast_to(const Vector2 &p_point) {
 
 	cast_to = p_point;
-	if (is_inside_tree() && (get_tree()->is_editor_hint() || get_tree()->is_debugging_collisions_hint()))
+	if (is_inside_tree() && (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_collisions_hint()))
 		update();
 }
 
@@ -92,7 +94,7 @@ Vector2 RayCast2D::get_collision_normal() const {
 void RayCast2D::set_enabled(bool p_enabled) {
 
 	enabled = p_enabled;
-	if (is_inside_tree() && !get_tree()->is_editor_hint())
+	if (is_inside_tree() && !Engine::get_singleton()->is_editor_hint())
 		set_fixed_process(p_enabled);
 	if (!p_enabled)
 		collided = false;
@@ -132,7 +134,7 @@ void RayCast2D::_notification(int p_what) {
 
 		case NOTIFICATION_ENTER_TREE: {
 
-			if (enabled && !get_tree()->is_editor_hint())
+			if (enabled && !Engine::get_singleton()->is_editor_hint())
 				set_fixed_process(true);
 			else
 				set_fixed_process(false);
@@ -153,7 +155,7 @@ void RayCast2D::_notification(int p_what) {
 
 		case NOTIFICATION_DRAW: {
 
-			if (!get_tree()->is_editor_hint() && !get_tree()->is_debugging_collisions_hint())
+			if (!Engine::get_singleton()->is_editor_hint() && !get_tree()->is_debugging_collisions_hint())
 				break;
 			Transform2D xf;
 			xf.rotate(cast_to.angle());

--- a/scene/2d/screen_button.cpp
+++ b/scene/2d/screen_button.cpp
@@ -112,7 +112,7 @@ void TouchScreenButton::_notification(int p_what) {
 
 			if (!is_inside_tree())
 				return;
-			if (!get_tree()->is_editor_hint() && !OS::get_singleton()->has_touchscreen_ui_hint() && visibility == VISIBILITY_TOUCHSCREEN_ONLY)
+			if (!Engine::get_singleton()->is_editor_hint() && !OS::get_singleton()->has_touchscreen_ui_hint() && visibility == VISIBILITY_TOUCHSCREEN_ONLY)
 				return;
 
 			if (finger_pressed != -1) {
@@ -129,7 +129,7 @@ void TouchScreenButton::_notification(int p_what) {
 
 			if (!shape_visible)
 				return;
-			if (!get_tree()->is_editor_hint() && !get_tree()->is_debugging_collisions_hint())
+			if (!Engine::get_singleton()->is_editor_hint() && !get_tree()->is_debugging_collisions_hint())
 				return;
 			if (shape.is_valid()) {
 				Color draw_col = get_tree()->get_debug_collisions_color();
@@ -141,11 +141,11 @@ void TouchScreenButton::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
 
-			if (!get_tree()->is_editor_hint() && !OS::get_singleton()->has_touchscreen_ui_hint() && visibility == VISIBILITY_TOUCHSCREEN_ONLY)
+			if (!Engine::get_singleton()->is_editor_hint() && !OS::get_singleton()->has_touchscreen_ui_hint() && visibility == VISIBILITY_TOUCHSCREEN_ONLY)
 				return;
 			update();
 
-			if (!get_tree()->is_editor_hint())
+			if (!Engine::get_singleton()->is_editor_hint())
 				set_process_input(is_visible_in_tree());
 
 		} break;
@@ -154,7 +154,7 @@ void TouchScreenButton::_notification(int p_what) {
 				_release(true);
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
-			if (get_tree()->is_editor_hint())
+			if (Engine::get_singleton()->is_editor_hint())
 				break;
 			if (is_visible_in_tree()) {
 				set_process_input(true);

--- a/scene/2d/visibility_notifier_2d.cpp
+++ b/scene/2d/visibility_notifier_2d.cpp
@@ -29,12 +29,12 @@
 /*************************************************************************/
 #include "visibility_notifier_2d.h"
 
+#include "engine.h"
 #include "particles_2d.h"
 #include "scene/2d/animated_sprite.h"
 #include "scene/2d/physics_body_2d.h"
 #include "scene/animation/animation_player.h"
 #include "scene/main/viewport.h"
-#include "scene/scene_string_names.h"
 #include "scene/scene_string_names.h"
 
 void VisibilityNotifier2D::_enter_viewport(Viewport *p_viewport) {
@@ -42,7 +42,7 @@ void VisibilityNotifier2D::_enter_viewport(Viewport *p_viewport) {
 	ERR_FAIL_COND(viewports.has(p_viewport));
 	viewports.insert(p_viewport);
 
-	if (is_inside_tree() && get_tree()->is_editor_hint())
+	if (is_inside_tree() && Engine::get_singleton()->is_editor_hint())
 		return;
 
 	if (viewports.size() == 1) {
@@ -58,7 +58,7 @@ void VisibilityNotifier2D::_exit_viewport(Viewport *p_viewport) {
 	ERR_FAIL_COND(!viewports.has(p_viewport));
 	viewports.erase(p_viewport);
 
-	if (is_inside_tree() && get_tree()->is_editor_hint())
+	if (is_inside_tree() && Engine::get_singleton()->is_editor_hint())
 		return;
 
 	emit_signal(SceneStringNames::get_singleton()->viewport_exited, p_viewport);
@@ -74,7 +74,7 @@ void VisibilityNotifier2D::set_rect(const Rect2 &p_rect) {
 	rect = p_rect;
 	if (is_inside_tree()) {
 		get_world_2d()->_update_notifier(this, get_global_transform().xform(rect));
-		if (get_tree()->is_editor_hint()) {
+		if (Engine::get_singleton()->is_editor_hint()) {
 			update();
 			item_rect_changed();
 		}
@@ -108,7 +108,7 @@ void VisibilityNotifier2D::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_DRAW: {
 
-			if (get_tree()->is_editor_hint()) {
+			if (Engine::get_singleton()->is_editor_hint()) {
 
 				draw_rect(rect, Color(1, 0.5, 1, 0.2));
 			}
@@ -236,7 +236,7 @@ void VisibilityEnabler2D::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
-		if (get_tree()->is_editor_hint())
+		if (Engine::get_singleton()->is_editor_hint())
 			return;
 
 		Node *from = this;
@@ -254,7 +254,7 @@ void VisibilityEnabler2D::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_EXIT_TREE) {
 
-		if (get_tree()->is_editor_hint())
+		if (Engine::get_singleton()->is_editor_hint())
 			return;
 
 		for (Map<Node *, Variant>::Element *E = nodes.front(); E; E = E->next()) {

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -215,7 +215,7 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 
 		velocity_tracker->reset(get_global_transform().origin);
 		AudioServer::get_singleton()->add_callback(_mix_audios, this);
-		if (autoplay && !get_tree()->is_editor_hint()) {
+		if (autoplay && !Engine::get_singleton()->is_editor_hint()) {
 			play();
 		}
 	}

--- a/scene/3d/interpolated_camera.cpp
+++ b/scene/3d/interpolated_camera.cpp
@@ -29,12 +29,14 @@
 /*************************************************************************/
 #include "interpolated_camera.h"
 
+#include "engine.h"
+
 void InterpolatedCamera::_notification(int p_what) {
 
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 
-			if (get_tree()->is_editor_hint() && enabled)
+			if (Engine::get_singleton()->is_editor_hint() && enabled)
 				set_fixed_process(false);
 
 		} break;
@@ -106,7 +108,7 @@ void InterpolatedCamera::set_interpolation_enabled(bool p_enable) {
 		return;
 	enabled = p_enable;
 	if (p_enable) {
-		if (is_inside_tree() && get_tree()->is_editor_hint())
+		if (is_inside_tree() && Engine::get_singleton()->is_editor_hint())
 			return;
 		set_process(true);
 	} else

--- a/scene/3d/light.cpp
+++ b/scene/3d/light.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 #include "light.h"
 
+#include "engine.h"
 #include "project_settings.h"
 #include "scene/resources/surface_tool.h"
 
@@ -140,7 +141,7 @@ void Light::_update_visibility() {
 
 #ifdef TOOLS_ENABLED
 	if (editor_only) {
-		if (!get_tree()->is_editor_hint()) {
+		if (!Engine::get_singleton()->is_editor_hint()) {
 			editor_ok = false;
 		} else {
 			editor_ok = (get_tree()->get_edited_scene_root() && (this == get_tree()->get_edited_scene_root() || get_owner() == get_tree()->get_edited_scene_root()));

--- a/scene/3d/path.cpp
+++ b/scene/3d/path.cpp
@@ -28,11 +28,13 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include "path.h"
+
+#include "engine.h"
 #include "scene/scene_string_names.h"
 
 void Path::_notification(int p_what) {
 #if 0
-	if (p_what==NOTIFICATION_DRAW && curve.is_valid() && is_inside_scene() && get_scene()->is_editor_hint()) {
+	if (p_what==NOTIFICATION_DRAW && curve.is_valid() && is_inside_scene() && Engine::get_singleton()->is_editor_hint()) {
 		//draw the curve!!
 
 		for(int i=0;i<curve->get_point_count();i++) {
@@ -53,7 +55,7 @@ void Path::_notification(int p_what) {
 
 void Path::_curve_changed() {
 
-	if (is_inside_tree() && get_tree()->is_editor_hint())
+	if (is_inside_tree() && Engine::get_singleton()->is_editor_hint())
 		update_gizmo();
 }
 

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include "physics_body.h"
+
+#include "engine.h"
 #include "method_bind_ext.gen.inc"
 #include "scene/scene_string_names.h"
 
@@ -476,13 +478,13 @@ void RigidBody::_notification(int p_what) {
 
 #ifdef TOOLS_ENABLED
 	if (p_what == NOTIFICATION_ENTER_TREE) {
-		if (get_tree()->is_editor_hint()) {
+		if (Engine::get_singleton()->is_editor_hint()) {
 			set_notify_local_transform(true); //used for warnings and only in editor
 		}
 	}
 
 	if (p_what == NOTIFICATION_LOCAL_TRANSFORM_CHANGED) {
-		if (get_tree()->is_editor_hint()) {
+		if (Engine::get_singleton()->is_editor_hint()) {
 			update_configuration_warning();
 		}
 	}

--- a/scene/3d/ray_cast.cpp
+++ b/scene/3d/ray_cast.cpp
@@ -30,12 +30,14 @@
 #include "ray_cast.h"
 
 #include "collision_object.h"
+#include "engine.h"
 #include "mesh_instance.h"
 #include "servers/physics_server.h"
+
 void RayCast::set_cast_to(const Vector3 &p_point) {
 
 	cast_to = p_point;
-	if (is_inside_tree() && (get_tree()->is_editor_hint() || get_tree()->is_debugging_collisions_hint()))
+	if (is_inside_tree() && (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_collisions_hint()))
 		update_gizmo();
 	if (is_inside_tree() && get_tree()->is_debugging_collisions_hint())
 		_update_debug_shape();
@@ -94,7 +96,7 @@ Vector3 RayCast::get_collision_normal() const {
 void RayCast::set_enabled(bool p_enabled) {
 
 	enabled = p_enabled;
-	if (is_inside_tree() && !get_tree()->is_editor_hint())
+	if (is_inside_tree() && !Engine::get_singleton()->is_editor_hint())
 		set_fixed_process(p_enabled);
 	if (!p_enabled)
 		collided = false;
@@ -118,7 +120,7 @@ void RayCast::_notification(int p_what) {
 
 		case NOTIFICATION_ENTER_TREE: {
 
-			if (enabled && !get_tree()->is_editor_hint()) {
+			if (enabled && !Engine::get_singleton()->is_editor_hint()) {
 				set_fixed_process(true);
 
 				if (get_tree()->is_debugging_collisions_hint())

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 #include "spatial.h"
 
+#include "engine.h"
 #include "message_queue.h"
 #include "scene/main/viewport.h"
 #include "scene/scene_string_names.h"
@@ -134,7 +135,7 @@ void Spatial::_notification(int p_what) {
 			else
 				data.C = NULL;
 
-			if (data.toplevel && !get_tree()->is_editor_hint()) {
+			if (data.toplevel && !Engine::get_singleton()->is_editor_hint()) {
 
 				if (data.parent) {
 					data.local_transform = data.parent->get_global_transform() * get_transform();
@@ -178,7 +179,7 @@ void Spatial::_notification(int p_what) {
 				get_script_instance()->call_multilevel(SceneStringNames::get_singleton()->_enter_world, NULL, 0);
 			}
 #ifdef TOOLS_ENABLED
-			if (get_tree()->is_editor_hint()) {
+			if (Engine::get_singleton()->is_editor_hint()) {
 
 				//get_scene()->call_group(SceneMainLoop::GROUP_CALL_REALTIME,SceneStringNames::get_singleton()->_spatial_editor_group,SceneStringNames::get_singleton()->_request_gizmo,this);
 				get_tree()->call_group_flags(0, SceneStringNames::get_singleton()->_spatial_editor_group, SceneStringNames::get_singleton()->_request_gizmo, this);
@@ -492,7 +493,7 @@ void Spatial::set_as_toplevel(bool p_enabled) {
 
 	if (data.toplevel == p_enabled)
 		return;
-	if (is_inside_tree() && !get_tree()->is_editor_hint()) {
+	if (is_inside_tree() && !Engine::get_singleton()->is_editor_hint()) {
 
 		if (p_enabled)
 			set_transform(get_global_transform());

--- a/scene/3d/visibility_notifier.cpp
+++ b/scene/3d/visibility_notifier.cpp
@@ -29,10 +29,10 @@
 /*************************************************************************/
 #include "visibility_notifier.h"
 
+#include "engine.h"
 #include "scene/3d/camera.h"
 #include "scene/3d/physics_body.h"
 #include "scene/animation/animation_player.h"
-#include "scene/scene_string_names.h"
 #include "scene/scene_string_names.h"
 
 void VisibilityNotifier::_enter_camera(Camera *p_camera) {
@@ -187,7 +187,7 @@ void VisibilityEnabler::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
-		if (get_tree()->is_editor_hint())
+		if (Engine::get_singleton()->is_editor_hint())
 			return;
 
 		Node *from = this;
@@ -200,7 +200,7 @@ void VisibilityEnabler::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_EXIT_TREE) {
 
-		if (get_tree()->is_editor_hint())
+		if (Engine::get_singleton()->is_editor_hint())
 			return;
 
 		for (Map<Node *, Variant>::Element *E = nodes.front(); E; E = E->next()) {

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 #include "animation_player.h"
 
+#include "engine.h"
 #include "message_queue.h"
 #include "scene/scene_string_names.h"
 
@@ -199,7 +200,7 @@ void AnimationPlayer::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_READY: {
 
-			if (!get_tree()->is_editor_hint() && animation_set.has(autoplay)) {
+			if (!Engine::get_singleton()->is_editor_hint() && animation_set.has(autoplay)) {
 				play(autoplay);
 				set_autoplay(""); //this line is the fix for autoplay issues with animatio
 				_animation_process(0);
@@ -344,7 +345,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, float 
 	ERR_FAIL_COND(p_anim->node_cache.size() != p_anim->animation->get_track_count());
 
 	Animation *a = p_anim->animation.operator->();
-	bool can_call = is_inside_tree() && !get_tree()->is_editor_hint();
+	bool can_call = is_inside_tree() && !Engine::get_singleton()->is_editor_hint();
 
 	for (int i = 0; i < a->get_track_count(); i++) {
 
@@ -955,7 +956,7 @@ void AnimationPlayer::play(const StringName &p_name, float p_custom_blend, float
 
 	emit_signal(SceneStringNames::get_singleton()->animation_started, c.assigned);
 
-	if (is_inside_tree() && get_tree()->is_editor_hint())
+	if (is_inside_tree() && Engine::get_singleton()->is_editor_hint())
 		return; // no next in this case
 
 	StringName next = animation_get_next(p_name);

--- a/scene/audio/audio_player.cpp
+++ b/scene/audio/audio_player.cpp
@@ -29,6 +29,8 @@
 /*************************************************************************/
 #include "audio_player.h"
 
+#include "engine.h"
+
 void AudioStreamPlayer::_mix_audio() {
 
 	if (!stream_playback.is_valid()) {
@@ -100,7 +102,7 @@ void AudioStreamPlayer::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
 		AudioServer::get_singleton()->add_callback(_mix_audios, this);
-		if (autoplay && !get_tree()->is_editor_hint()) {
+		if (autoplay && !Engine::get_singleton()->is_editor_hint()) {
 			play();
 		}
 	}

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -204,7 +204,7 @@ void ColorPicker::_update_presets() {
 }
 
 void ColorPicker::_text_type_toggled() {
-	if (!get_tree()->is_editor_hint())
+	if (!Engine::get_singleton()->is_editor_hint())
 		return;
 	text_is_constructor = !text_is_constructor;
 	if (text_is_constructor) {

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1353,7 +1353,7 @@ void Control::set_anchor(Margin p_margin, AnchorType p_anchor, bool p_keep_margi
 
 void Control::_set_anchor(Margin p_margin, AnchorType p_anchor) {
 #ifdef TOOLS_ENABLED
-	if (is_inside_tree() && get_tree()->is_editor_hint()) {
+	if (is_inside_tree() && Engine::get_singleton()->is_editor_hint()) {
 		set_anchor(p_margin, p_anchor, EDITOR_DEF("editors/2d/keep_margins_when_changing_anchors", false));
 	} else {
 		set_anchor(p_margin, p_anchor, false);

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -227,11 +227,11 @@ void WindowDialog::_notification(int p_what) {
 		} break;
 #ifdef TOOLS_ENABLED
 		case NOTIFICATION_POST_POPUP: {
-			if (get_tree() && get_tree()->is_editor_hint() && EditorNode::get_singleton())
+			if (get_tree() && Engine::get_singleton()->is_editor_hint() && EditorNode::get_singleton())
 				EditorNode::get_singleton()->dim_editor(true);
 		} break;
 		case NOTIFICATION_POPUP_HIDE: {
-			if (get_tree() && get_tree()->is_editor_hint() && EditorNode::get_singleton())
+			if (get_tree() && Engine::get_singleton()->is_editor_hint() && EditorNode::get_singleton())
 				EditorNode::get_singleton()->dim_editor(false);
 		} break;
 #endif

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -534,7 +534,7 @@ void LineEdit::_notification(int p_what) {
 	switch (p_what) {
 #ifdef TOOLS_ENABLED
 		case NOTIFICATION_ENTER_TREE: {
-			if (get_tree()->is_editor_hint()) {
+			if (Engine::get_singleton()->is_editor_hint()) {
 				cursor_set_blink_enabled(EDITOR_DEF("text_editor/cursor/caret_blink", false));
 				cursor_set_blink_speed(EDITOR_DEF("text_editor/cursor/caret_blink_speed", 0.65));
 

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include "popup.h"
+
+#include "engine.h"
 #include "os/keyboard.h"
 
 void Popup::_gui_input(Ref<InputEvent> p_event) {
@@ -48,7 +50,7 @@ void Popup::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 //small helper to make editing of these easier in editor
 #ifdef TOOLS_ENABLED
-		if (get_tree()->is_editor_hint() && get_tree()->get_edited_scene_root() && get_tree()->get_edited_scene_root()->is_a_parent_of(this)) {
+		if (Engine::get_singleton()->is_editor_hint() && get_tree()->get_edited_scene_root() && get_tree()->get_edited_scene_root()->is_a_parent_of(this)) {
 			set_as_toplevel(false);
 		}
 #endif

--- a/scene/gui/reference_rect.cpp
+++ b/scene/gui/reference_rect.cpp
@@ -29,13 +29,15 @@
 /*************************************************************************/
 #include "reference_rect.h"
 
+#include "engine.h"
+
 void ReferenceRect::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_DRAW) {
 
 		if (!is_inside_tree())
 			return;
-		if (get_tree()->is_editor_hint())
+		if (Engine::get_singleton()->is_editor_hint())
 			draw_style_box(get_stylebox("border"), Rect2(Point2(), get_size()));
 	}
 }

--- a/scene/gui/texture_progress.cpp
+++ b/scene/gui/texture_progress.cpp
@@ -29,6 +29,8 @@
 /*************************************************************************/
 #include "texture_progress.h"
 
+#include "engine.h"
+
 void TextureProgress::set_under_texture(const Ref<Texture> &p_texture) {
 
 	under = p_texture;
@@ -179,7 +181,7 @@ void TextureProgress::_notification(int p_what) {
 							}
 							draw_polygon(points, Vector<Color>(), uvs, progress);
 						}
-						if (get_tree()->is_editor_hint()) {
+						if (Engine::get_singleton()->is_editor_hint()) {
 							Point2 p = progress->get_size();
 							p.x *= get_relative_center().x;
 							p.y *= get_relative_center().y;

--- a/scene/gui/video_player.cpp
+++ b/scene/gui/video_player.cpp
@@ -116,7 +116,7 @@ void VideoPlayer::_notification(int p_notification) {
 
 		case NOTIFICATION_ENTER_TREE: {
 
-			if (stream.is_valid() && autoplay && !get_tree()->is_editor_hint()) {
+			if (stream.is_valid() && autoplay && !Engine::get_singleton()->is_editor_hint()) {
 				play();
 			}
 		} break;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -382,7 +382,7 @@ bool SceneTree::is_input_handled() {
 
 void SceneTree::input_event(const Ref<InputEvent> &p_event) {
 
-	if (is_editor_hint() && (p_event->cast_to<InputEventJoypadButton>() || p_event->cast_to<InputEventJoypadMotion>()))
+	if (Engine::get_singleton()->is_editor_hint() && (p_event->cast_to<InputEventJoypadButton>() || p_event->cast_to<InputEventJoypadMotion>()))
 		return; //avoid joy input on editor
 
 	root_lock++;
@@ -616,7 +616,7 @@ bool SceneTree::idle(float p_time) {
 
 #ifdef TOOLS_ENABLED
 
-	if (is_editor_hint()) {
+	if (Engine::get_singleton()->is_editor_hint()) {
 		//simple hack to reload fallback environment if it changed from editor
 		String env_path = ProjectSettings::get_singleton()->get("rendering/environment/default_environment");
 		env_path = env_path.strip_edges(); //user may have added a space or two
@@ -691,7 +691,7 @@ void SceneTree::_notification(int p_notification) {
 			get_root()->propagate_notification(p_notification);
 		} break;
 		case NOTIFICATION_TRANSLATION_CHANGED: {
-			if (!is_editor_hint()) {
+			if (!Engine::get_singleton()->is_editor_hint()) {
 				get_root()->propagate_notification(Node::NOTIFICATION_TRANSLATION_CHANGED);
 			}
 		} break;
@@ -717,19 +717,10 @@ void SceneTree::set_quit_on_go_back(bool p_enable) {
 }
 
 #ifdef TOOLS_ENABLED
-void SceneTree::set_editor_hint(bool p_enabled) {
-
-	editor_hint = p_enabled;
-}
 
 bool SceneTree::is_node_being_edited(const Node *p_node) const {
 
-	return editor_hint && edited_scene_root && edited_scene_root->is_a_parent_of(p_node);
-}
-
-bool SceneTree::is_editor_hint() const {
-
-	return editor_hint;
+	return Engine::get_singleton()->is_editor_hint() && edited_scene_root && edited_scene_root->is_a_parent_of(p_node);
 }
 #endif
 
@@ -2189,8 +2180,6 @@ void SceneTree::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_auto_accept_quit", "enabled"), &SceneTree::set_auto_accept_quit);
 
-	ClassDB::bind_method(D_METHOD("set_editor_hint", "enable"), &SceneTree::set_editor_hint);
-	ClassDB::bind_method(D_METHOD("is_editor_hint"), &SceneTree::is_editor_hint);
 	ClassDB::bind_method(D_METHOD("set_debug_collisions_hint", "enable"), &SceneTree::set_debug_collisions_hint);
 	ClassDB::bind_method(D_METHOD("is_debugging_collisions_hint"), &SceneTree::is_debugging_collisions_hint);
 	ClassDB::bind_method(D_METHOD("set_debug_navigation_hint", "enable"), &SceneTree::set_debug_navigation_hint);
@@ -2315,9 +2304,6 @@ SceneTree::SceneTree() {
 	accept_quit = true;
 	quit_on_go_back = true;
 	initialized = false;
-#ifdef TOOLS_ENABLED
-	editor_hint = false;
-#endif
 #ifdef DEBUG_ENABLED
 	debug_collisions_hint = false;
 	debug_navigation_hint = false;
@@ -2387,7 +2373,7 @@ SceneTree::SceneTree() {
 			if (env.is_valid()) {
 				root->get_world()->set_fallback_environment(env);
 			} else {
-				if (is_editor_hint()) {
+				if (Engine::get_singleton()->is_editor_hint()) {
 					//file was erased, clear the field.
 					ProjectSettings::get_singleton()->set("rendering/environment/default_environment", "");
 				} else {

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -110,9 +110,6 @@ private:
 	bool quit_on_go_back;
 	uint32_t last_id;
 
-#ifdef TOOLS_ENABLED
-	bool editor_hint;
-#endif
 #ifdef DEBUG_ENABLED
 	bool debug_collisions_hint;
 	bool debug_navigation_hint;
@@ -362,14 +359,8 @@ public:
 	_FORCE_INLINE_ float get_idle_process_time() const { return idle_process_time; }
 
 #ifdef TOOLS_ENABLED
-	void set_editor_hint(bool p_enabled);
-
-	bool is_editor_hint() const;
 	bool is_node_being_edited(const Node *p_node) const;
 #else
-	void set_editor_hint(bool p_enabled) {}
-
-	bool is_editor_hint() const { return false; }
 	bool is_node_being_edited(const Node *p_node) const { return false; }
 #endif
 

--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -29,6 +29,8 @@
 /*************************************************************************/
 #include "timer.h"
 
+#include "engine.h"
+
 void Timer::_notification(int p_what) {
 
 	switch (p_what) {
@@ -37,7 +39,7 @@ void Timer::_notification(int p_what) {
 
 			if (autostart) {
 #ifdef TOOLS_ENABLED
-				if (get_tree()->is_editor_hint() && get_tree()->get_edited_scene_root() && (get_tree()->get_edited_scene_root() == this || get_tree()->get_edited_scene_root()->is_a_parent_of(this)))
+				if (Engine::get_singleton()->is_editor_hint() && get_tree()->get_edited_scene_root() && (get_tree()->get_edited_scene_root() == this || get_tree()->get_edited_scene_root()->is_a_parent_of(this)))
 					break;
 #endif
 				start();

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1354,7 +1354,7 @@ void Viewport::_vp_input(const Ref<InputEvent> &p_ev) {
 		return;
 
 #ifdef TOOLS_ENABLED
-	if (get_tree()->is_editor_hint() && get_tree()->get_edited_scene_root() && get_tree()->get_edited_scene_root()->is_a_parent_of(this)) {
+	if (Engine::get_singleton()->is_editor_hint() && get_tree()->get_edited_scene_root() && get_tree()->get_edited_scene_root()->is_a_parent_of(this)) {
 		return;
 	}
 #endif
@@ -1374,7 +1374,7 @@ void Viewport::_vp_unhandled_input(const Ref<InputEvent> &p_ev) {
 	if (disable_input)
 		return;
 #ifdef TOOLS_ENABLED
-	if (get_tree()->is_editor_hint() && get_tree()->get_edited_scene_root() && get_tree()->get_edited_scene_root()->is_a_parent_of(this)) {
+	if (Engine::get_singleton()->is_editor_hint() && get_tree()->get_edited_scene_root() && get_tree()->get_edited_scene_root()->is_a_parent_of(this)) {
 		return;
 	}
 #endif


### PR DESCRIPTION
It's sometimes desired to check this before the main loop is initialized. In my case, I need to check this somewhere in `ScriptLanguage::init()`, in order to know which assemblies to load.
