### PR TITLE
Exposed create_from_mesh in Navmesh

### DIFF
--- a/scene/3d/navigation_mesh.cpp
+++ b/scene/3d/navigation_mesh.cpp
@@ -208,6 +208,8 @@ void NavigationMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_polygon", "idx"), &NavigationMesh::get_polygon);
 	ClassDB::bind_method(D_METHOD("clear_polygons"), &NavigationMesh::clear_polygons);
 
+	ClassDB::bind_method(D_METHOD("create_from_mesh", "mesh"), &NavigationMesh::create_from_mesh);
+
 	ClassDB::bind_method(D_METHOD("_set_polygons", "polygons"), &NavigationMesh::_set_polygons);
 	ClassDB::bind_method(D_METHOD("_get_polygons"), &NavigationMesh::_get_polygons);
 


### PR DESCRIPTION
Would kinda close #4301

This pull request would allow the creation of navmeshes using a mesh by exposing create_from_mesh in navmesh.

this would make generating navmeshes from code way easier because we could use the surface tool to generate a mesh and then use that mesh to make the navmesh. This would also make it where you're not forced to define the verticies and indicies to generate a mesh, which can be confusing to new users (I only kinda understand how it works because I've looked through the code, and have done some OpenGL before)

I can provide a sample project with generating mazes from code with a navmesh later if desired, which would (probably) fully close #4301