### PR TITLE
Fix StreamPeer put_utf8_string not working

### DIFF
--- a/core/io/stream_peer.cpp
+++ b/core/io/stream_peer.cpp
@@ -210,7 +210,7 @@ void StreamPeer::put_double(double p_val) {
 void StreamPeer::put_utf8_string(const String &p_string) {
 
 	CharString cs = p_string.utf8();
-	put_u32(p_string.length());
+	put_u32(cs.length());
 	put_data((const uint8_t *)cs.get_data(), cs.length());
 }
 void StreamPeer::put_var(const Variant &p_variant) {


### PR DESCRIPTION
`StreamPeer::put_utf8_string` was using the string length instead of the char array size when writing.
This caused read to break (and subsequent read on that buffer to break too).

EDIT: See demo: 
[buffer_utf8_test.zip](https://github.com/godotengine/godot/files/1222119/buffer_utf8_test.zip)

