### PR TITLE
Enable command-line export

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -364,10 +364,28 @@ void EditorNode::_fs_changed() {
 		E->get()->invalidate();
 	}
 
-	if (export_defer.platform != "") {
+	if (export_defer.preset != "") {
+		Ref<EditorExportPreset> preset;
+		for (int i = 0; i < EditorExport::get_singleton()->get_export_preset_count(); ++i) {
+			preset = EditorExport::get_singleton()->get_export_preset(i);
+			if (preset->get_name() == export_defer.preset) {
+				break;
+			}
+		}
+		if (preset.is_null()) {
+			String err = "Unknown export preset: " + export_defer.preset;
+			ERR_PRINT(err.utf8().get_data());
+		} else {
+			Ref<EditorExportPlatform> platform = preset->get_platform();
+			if (platform.is_null()) {
+				String err = "Preset \"" + export_defer.preset + "\" doesn't have a platform.";
+				ERR_PRINT(err.utf8().get_data());
+			} else {
+				platform->export_project(preset, export_defer.debug, export_defer.path, /*p_flags*/ 0);
+			}
+		}
 
-		//project_export_settings->export_platform(export_defer.platform,export_defer.path,export_defer.debug,export_defer.password,true);
-		export_defer.platform = "";
+		export_defer.preset = "";
 	}
 
 	{
@@ -3844,9 +3862,9 @@ void EditorNode::_editor_file_dialog_unregister(EditorFileDialog *p_dialog) {
 
 Vector<EditorNodeInitCallback> EditorNode::_init_callbacks;
 
-Error EditorNode::export_platform(const String &p_platform, const String &p_path, bool p_debug, const String &p_password, bool p_quit_after) {
+Error EditorNode::export_preset(const String &preset, const String &p_path, bool p_debug, const String &p_password, bool p_quit_after) {
 
-	export_defer.platform = p_platform;
+	export_defer.preset = preset;
 	export_defer.path = p_path;
 	export_defer.debug = p_debug;
 	export_defer.password = p_password;

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -539,7 +539,7 @@ private:
 	}
 
 	struct ExportDefer {
-		String platform;
+		String preset;
 		String path;
 		bool debug;
 		String password;
@@ -742,7 +742,7 @@ public:
 
 	void show_warning(const String &p_text, const String &p_title = "Warning!");
 
-	Error export_platform(const String &p_platform, const String &p_path, bool p_debug, const String &p_password, bool p_quit_after = false);
+	Error export_preset(const String &p_platform, const String &p_path, bool p_debug, const String &p_password, bool p_quit_after = false);
 
 	static void register_editor_types();
 	static void unregister_editor_types();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1048,7 +1048,7 @@ bool Main::start() {
 	String script;
 	String test;
 	String screen;
-	String _export_platform;
+	String _export_preset;
 	String _import;
 	String _import_script;
 	bool noquit = false;
@@ -1083,10 +1083,10 @@ bool Main::start() {
 				test = args[i + 1];
 			} else if (args[i] == "-export") {
 				editor = true; //needs editor
-				_export_platform = args[i + 1];
+				_export_preset = args[i + 1];
 			} else if (args[i] == "-export_debug") {
 				editor = true; //needs editor
-				_export_platform = args[i + 1];
+				_export_preset = args[i + 1];
 				export_debug = true;
 			} else if (args[i] == "-import") {
 				editor = true; //needs editor
@@ -1136,7 +1136,7 @@ bool Main::start() {
 
 #endif
 
-	if (_export_platform != "") {
+	if (_export_preset != "") {
 		if (game_path == "") {
 			String err = "Command line param ";
 			err += export_debug ? "-export_debug" : "-export";
@@ -1243,9 +1243,9 @@ bool Main::start() {
 			//root_node->set_editor(editor);
 			//startup editor
 
-			if (_export_platform != "") {
+			if (_export_preset != "") {
 
-				editor_node->export_platform(_export_platform, game_path, export_debug, "", true);
+				editor_node->export_preset(_export_preset, game_path, export_debug, "", true);
 				game_path = ""; //no load anything
 			}
 		}


### PR DESCRIPTION
The syntax is identical to what it was in 2.1, but now you specify
preset name instead of platform name.