### PR TITLE
Removed unnecessary assignments

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -1406,11 +1406,10 @@ Error _File::open_encrypted_pass(const String &p_path, int p_mode_flags, const S
 Error _File::open_compressed(const String &p_path, int p_mode_flags, int p_compress_mode) {
 
 	FileAccessCompressed *fac = memnew(FileAccessCompressed);
-	Error err = OK;
 
 	fac->configure("GCPF", (Compression::Mode)p_compress_mode);
 
-	err = fac->_open(p_path, p_mode_flags);
+	Error err = fac->_open(p_path, p_mode_flags);
 
 	if (err) {
 		memdelete(fac);

--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -368,7 +368,6 @@ FileAccessCompressed::FileAccessCompressed() {
 
 	f = NULL;
 	magic = "GCMP";
-	block_size = 16384;
 	cmode = Compression::MODE_ZSTD;
 	writing = false;
 	write_ptr = 0;

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -654,7 +654,6 @@ Ref<Image> RasterizerGLES2::_get_gl_image_and_format(const Ref<Image> &p_image, 
 
 			} else {
 
-				r_gl_internal_format = _EXT_COMPRESSED_RGBA_PVRTC_2BPPV1_IMG;
 				r_gl_internal_format = (srgb_supported && p_flags & VS::TEXTURE_FLAG_CONVERT_TO_LINEAR) ? _EXT_COMPRESSED_SRGB_ALPHA_PVRTC_2BPPV1_EXT : _EXT_COMPRESSED_RGBA_PVRTC_2BPPV1_IMG;
 				r_gl_components = 1; //doesn't matter much
 				r_compressed = true;

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -258,7 +258,6 @@ void FindReplaceBar::_get_search_from(int &r_line, int &r_col) {
 			int selection_from_col = text_edit->get_selection_from_column();
 
 			if (r_col >= selection_from_col && r_col <= text_edit->get_selection_to_column()) {
-				r_col = selection_line;
 				r_col = selection_from_col;
 			}
 		}

--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -100,7 +100,7 @@ void EditorAssetInstaller::open(const String &p_path, int p_depth) {
 		//get filename
 		unz_file_info info;
 		char fname[16384];
-		ret = unzGetCurrentFileInfo(pkg, &info, fname, 16384, NULL, 0, NULL, 0);
+		unzGetCurrentFileInfo(pkg, &info, fname, 16384, NULL, 0, NULL, 0);
 
 		String name = fname;
 		files_sorted.insert(name);

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -195,7 +195,7 @@ void ExportTemplateManager::_install_from_file(const String &p_file) {
 			data.resize(info.uncompressed_size);
 
 			//read
-			ret = unzOpenCurrentFile(pkg);
+			unzOpenCurrentFile(pkg);
 			ret = unzReadCurrentFile(pkg, data.ptr(), data.size());
 			unzCloseCurrentFile(pkg);
 
@@ -257,7 +257,7 @@ void ExportTemplateManager::_install_from_file(const String &p_file) {
 		//get filename
 		unz_file_info info;
 		char fname[16384];
-		ret = unzGetCurrentFileInfo(pkg, &info, fname, 16384, NULL, 0, NULL, 0);
+		unzGetCurrentFileInfo(pkg, &info, fname, 16384, NULL, 0, NULL, 0);
 
 		String file = fname;
 
@@ -265,8 +265,8 @@ void ExportTemplateManager::_install_from_file(const String &p_file) {
 		data.resize(info.uncompressed_size);
 
 		//read
-		ret = unzOpenCurrentFile(pkg);
-		ret = unzReadCurrentFile(pkg, data.ptr(), data.size());
+		unzOpenCurrentFile(pkg);
+		unzReadCurrentFile(pkg, data.ptr(), data.size());
 		unzCloseCurrentFile(pkg);
 
 		print_line(fname);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1465,10 +1465,9 @@ void FileSystemDock::_files_list_rmb_select(int p_item, const Vector2 &p_pos) {
 			return;
 		}
 
-		EditorFileSystemDirectory *efsd = NULL;
 		int pos;
 
-		efsd = EditorFileSystem::get_singleton()->find_file(path, &pos);
+		EditorFileSystemDirectory *efsd = EditorFileSystem::get_singleton()->find_file(path, &pos);
 
 		if (efsd) {
 

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -1584,14 +1584,12 @@ Error ColladaImport::_create_resources(Collada::Node *p_node) {
 						apply_xform = Transform();
 					}
 
-					Collada::SkinControllerData::Source *joint_src = NULL;
-
 					ERR_FAIL_COND_V(!skin->weights.sources.has("JOINT"), ERR_INVALID_DATA);
 
 					String joint_id = skin->weights.sources["JOINT"].source;
 					ERR_FAIL_COND_V(!skin->sources.has(joint_id), ERR_INVALID_DATA);
 
-					joint_src = &skin->sources[joint_id];
+					Collada::SkinControllerData::Source *joint_src = &skin->sources[joint_id];
 
 					bone_remap.resize(joint_src->sarray.size());
 
@@ -2317,7 +2315,6 @@ Ref<Animation> EditorSceneImporterCollada::import_animation(const String &p_path
 	if (state.animations.size() == 0)
 		return Ref<Animation>();
 	Ref<Animation> anim = state.animations[0];
-	anim = state.animations[0];
 	print_line("Anim Load OK");
 	String base = p_path.get_basename().to_lower();
 	if (p_flags & IMPORT_ANIMATION_DETECT_LOOP) {

--- a/editor/plugins/particles_editor_plugin.cpp
+++ b/editor/plugins/particles_editor_plugin.cpp
@@ -270,9 +270,7 @@ void ParticlesEditor::_generate_emission_points() {
 
 				Vector3 dir;
 				dir[Math::rand() % 3] = 1.0;
-				Vector3 ofs = Vector3(1, 1, 1) - dir;
-				ofs = (Vector3(1, 1, 1) - dir) * Vector3(Math::randf(), Math::randf(), Math::randf()) * aabb.size;
-				ofs += aabb.position;
+				Vector3 ofs = (Vector3(1, 1, 1) - dir) * Vector3(Math::randf(), Math::randf(), Math::randf()) * aabb.size + aabb.position;
 
 				Vector3 ofsv = ofs + aabb.size * dir;
 

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -531,28 +531,19 @@ void ScriptCreateDialog::_bind_methods() {
 
 ScriptCreateDialog::ScriptCreateDialog() {
 
-	GridContainer *gc = memnew(GridContainer);
-	VBoxContainer *vb = memnew(VBoxContainer);
-	HBoxContainer *hb = memnew(HBoxContainer);
-	Label *l = memnew(Label);
-	Control *empty = memnew(Control);
-	Control *empty_h = memnew(Control);
-	Control *empty_v = memnew(Control);
-	PanelContainer *pc = memnew(PanelContainer);
-
 	/* DIALOG */
 
 	/* Main Controls */
 
-	gc = memnew(GridContainer);
+	GridContainer *gc = memnew(GridContainer);
 	gc->set_columns(2);
 
 	/* Error Messages Field */
 
-	vb = memnew(VBoxContainer);
+	VBoxContainer *vb = memnew(VBoxContainer);
 
-	hb = memnew(HBoxContainer);
-	l = memnew(Label);
+	HBoxContainer *hb = memnew(HBoxContainer);
+	Label *l = memnew(Label);
 	l->set_text(" - ");
 	hb->add_child(l);
 	error_label = memnew(Label);
@@ -571,19 +562,19 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	hb->add_child(path_error_label);
 	vb->add_child(hb);
 
-	pc = memnew(PanelContainer);
+	PanelContainer *pc = memnew(PanelContainer);
 	pc->set_h_size_flags(Control::SIZE_FILL);
 	pc->add_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_stylebox("bg", "Tree"));
 	pc->add_child(vb);
 
 	/* Margins */
 
-	empty_h = memnew(Control);
+	Control *empty_h = memnew(Control);
 	empty_h->set_name("empty_h"); //duplicate() doesn't like nodes without a name
 	empty_h->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	empty_h->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	empty_h->set_custom_minimum_size(Size2(0, 10 * EDSCALE));
-	empty_v = memnew(Control);
+	Control *empty_v = memnew(Control);
 	empty_v->set_name("empty_v");
 	empty_v->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	empty_v->set_v_size_flags(Control::SIZE_EXPAND_FILL);
@@ -684,7 +675,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	internal = memnew(CheckButton);
 	internal->connect("pressed", this, "_built_in_pressed");
 	hb = memnew(HBoxContainer);
-	empty = memnew(Control);
+	Control *empty = memnew(Control);
 	hb->add_child(internal);
 	hb->add_child(empty);
 	l = memnew(Label);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -904,9 +904,10 @@ Error Main::setup2() {
 
 	MAIN_PRINT("Main: Setup Logo");
 
-	bool show_logo = true;
 #ifdef JAVASCRIPT_ENABLED
-	show_logo = false;
+	bool show_logo = false;
+#else
+	bool show_logo = true;
 #endif
 
 	if (init_screen != -1) {

--- a/main/tests/test_string.cpp
+++ b/main/tests/test_string.cpp
@@ -802,7 +802,6 @@ bool test_28() {
 bool test_29() {
 
 	bool state = true;
-	bool success = false;
 
 	IP_Address ip0("2001:0db8:85a3:0000:0000:8a2e:0370:7334");
 	OS::get_singleton()->print("ip0 is %ls\n", String(ip0).c_str());
@@ -817,7 +816,7 @@ bool test_29() {
 	OS::get_singleton()->print("ip6 is %ls\n", String(ip3).c_str());
 
 	String ip4 = "192.168.0.1";
-	success = ip4.is_valid_ip_address();
+	bool success = ip4.is_valid_ip_address();
 	OS::get_singleton()->print("Is valid ipv4: %ls, %s\n", ip4.c_str(), success ? "OK" : "FAIL");
 	if (!success) state = false;
 

--- a/modules/gdnative/gdnative.cpp
+++ b/modules/gdnative/gdnative.cpp
@@ -247,9 +247,8 @@ bool GDNative::terminate() {
 		return false;
 	}
 
-	Error error = OK;
 	void *library_terminate;
-	error = OS::get_singleton()->get_dynamic_library_symbol_handle(
+	Error error = OS::get_singleton()->get_dynamic_library_symbol_handle(
 			native_handle,
 			terminate_symbol,
 			library_terminate);

--- a/modules/gdscript/gd_compiler.cpp
+++ b/modules/gdscript/gd_compiler.cpp
@@ -1451,15 +1451,13 @@ Error GDCompiler::_parse_function(GDScript *p_script, const GDParser::ClassNode 
 
 	codegen.opcodes.push_back(GDFunction::OPCODE_END);
 
-	GDFunction *gdfunc = NULL;
-
 	/*
 	if (String(p_func->name)=="") { //initializer func
 		gdfunc = &p_script->initializer;
 	*/
 	//} else { //regular func
 	p_script->member_functions[func_name] = memnew(GDFunction);
-	gdfunc = p_script->member_functions[func_name];
+	GDFunction *gdfunc = p_script->member_functions[func_name];
 	//}
 
 	if (p_func) {

--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -2381,9 +2381,7 @@ void GDParser::_parse_block(BlockNode *p_block, bool p_static) {
 				if (tokenizer->get_token() == GDTokenizer::TK_OP_ASSIGN) {
 
 					tokenizer->advance();
-					Node *subexpr = NULL;
-
-					subexpr = _parse_and_reduce_expression(p_block, p_static);
+					Node *subexpr = _parse_and_reduce_expression(p_block, p_static);
 					if (!subexpr) {
 						if (_recover_from_completion()) {
 							break;
@@ -3135,9 +3133,7 @@ void GDParser::_parse_class(ClassNode *p_class) {
 						if (tokenizer->get_token() == GDTokenizer::TK_OP_ASSIGN) {
 							defaulting = true;
 							tokenizer->advance(1);
-							Node *defval = NULL;
-
-							defval = _parse_and_reduce_expression(p_class, _static);
+							Node *defval = _parse_and_reduce_expression(p_class, _static);
 							if (!defval || error_set)
 								return;
 
@@ -3875,9 +3871,7 @@ void GDParser::_parse_class(ClassNode *p_class) {
 #endif
 					tokenizer->advance();
 
-					Node *subexpr = NULL;
-
-					subexpr = _parse_and_reduce_expression(p_class, false, autoexport);
+					Node *subexpr = _parse_and_reduce_expression(p_class, false, autoexport);
 					if (!subexpr) {
 						if (_recover_from_completion()) {
 							break;
@@ -4035,9 +4029,7 @@ void GDParser::_parse_class(ClassNode *p_class) {
 
 				tokenizer->advance();
 
-				Node *subexpr = NULL;
-
-				subexpr = _parse_and_reduce_expression(p_class, true, true);
+				Node *subexpr = _parse_and_reduce_expression(p_class, true, true);
 				if (!subexpr) {
 					if (_recover_from_completion()) {
 						break;
@@ -4103,9 +4095,7 @@ void GDParser::_parse_class(ClassNode *p_class) {
 						if (tokenizer->get_token() == GDTokenizer::TK_OP_ASSIGN) {
 							tokenizer->advance();
 
-							Node *subexpr = NULL;
-
-							subexpr = _parse_and_reduce_expression(p_class, true, true);
+							Node *subexpr = _parse_and_reduce_expression(p_class, true, true);
 							if (!subexpr) {
 								if (_recover_from_completion()) {
 									break;

--- a/modules/gdscript/gd_tokenizer.cpp
+++ b/modules/gdscript/gd_tokenizer.cpp
@@ -1187,9 +1187,7 @@ Error GDTokenizerBuffer::set_code_buffer(const Vector<uint8_t> &p_buffer) {
 	int line_count = decode_uint32(&buf[16]);
 	int token_count = decode_uint32(&buf[20]);
 
-	const uint8_t *b = buf;
-
-	b = &buf[24];
+	const uint8_t *b = &buf[24];
 	total_len -= 24;
 
 	identifiers.resize(identifier_count);

--- a/modules/nativescript/api_generator.cpp
+++ b/modules/nativescript/api_generator.cpp
@@ -155,10 +155,9 @@ List<ClassAPI> generate_c_api_classes() {
 		class_api.is_instanciable = !class_api.is_singleton && ClassDB::can_instance(class_name);
 
 		{
-			bool is_reference = false;
 			List<StringName> inheriters;
 			ClassDB::get_inheriters_from_class("Reference", &inheriters);
-			is_reference = !!inheriters.find(class_name);
+			bool is_reference = !!inheriters.find(class_name);
 			// @Unclear
 			class_api.is_reference = !class_api.is_singleton && is_reference;
 		}

--- a/modules/openssl/stream_peer_openssl.cpp
+++ b/modules/openssl/stream_peer_openssl.cpp
@@ -41,27 +41,22 @@ bool StreamPeerOpenSSL::_match_host_name(const char *name, const char *hostname)
 
 Error StreamPeerOpenSSL::_match_common_name(const char *hostname, const X509 *server_cert) {
 
-	int common_name_loc = -1;
-	X509_NAME_ENTRY *common_name_entry = NULL;
-	ASN1_STRING *common_name_asn1 = NULL;
-	char *common_name_str = NULL;
-
 	// Find the position of the CN field in the Subject field of the certificate
-	common_name_loc = X509_NAME_get_index_by_NID(X509_get_subject_name((X509 *)server_cert), NID_commonName, -1);
+	int common_name_loc = X509_NAME_get_index_by_NID(X509_get_subject_name((X509 *)server_cert), NID_commonName, -1);
 
 	ERR_FAIL_COND_V(common_name_loc < 0, ERR_INVALID_PARAMETER);
 
 	// Extract the CN field
-	common_name_entry = X509_NAME_get_entry(X509_get_subject_name((X509 *)server_cert), common_name_loc);
+	X509_NAME_ENTRY *common_name_entry = X509_NAME_get_entry(X509_get_subject_name((X509 *)server_cert), common_name_loc);
 
 	ERR_FAIL_COND_V(common_name_entry == NULL, ERR_INVALID_PARAMETER);
 
 	// Convert the CN field to a C string
-	common_name_asn1 = X509_NAME_ENTRY_get_data(common_name_entry);
+	ASN1_STRING *common_name_asn1 = X509_NAME_ENTRY_get_data(common_name_entry);
 
 	ERR_FAIL_COND_V(common_name_asn1 == NULL, ERR_INVALID_PARAMETER);
 
-	common_name_str = (char *)ASN1_STRING_data(common_name_asn1);
+	char *common_name_str = (char *)ASN1_STRING_data(common_name_asn1);
 
 	// Make sure there isn't an embedded NUL character in the CN
 	bool malformed_certificate = (size_t)ASN1_STRING_length(common_name_asn1) != strlen(common_name_str);

--- a/modules/pbm/bitmap_loader_pbm.cpp
+++ b/modules/pbm/bitmap_loader_pbm.cpp
@@ -95,6 +95,9 @@ static bool _get_token(FileAccessRef &f, uint8_t &saved, PoolVector<uint8_t> &r_
 				resized = true;
 			}
 			if (resized) {
+				// Note: Certain C++ static analyzers might point out that the following assigment is unnecessary.
+				// This is wrong since PoolVector<class T>::Write has an operator= method where the lhs gets updated under certain conditions.
+				// See core/dvector.h.
 				w = PoolVector<uint8_t>::Write();
 				r_token.resize(token_max);
 				w = r_token.write();

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -451,7 +451,6 @@ void VideoStreamPlaybackTheora::set_file(const String &p_file) {
 					ti.frame_width, ti.frame_height, ti.pic_x, ti.pic_y);
 		th_decode_ctl(td, TH_DECCTL_GET_PPLEVEL_MAX, &pp_level_max,
 				sizeof(pp_level_max));
-		pp_level = pp_level_max;
 		pp_level = 0;
 		th_decode_ctl(td, TH_DECCTL_SET_PPLEVEL, &pp_level, sizeof(pp_level));
 		pp_inc = 0;

--- a/platform/android/audio_driver_jandroid.cpp
+++ b/platform/android/audio_driver_jandroid.cpp
@@ -80,7 +80,6 @@ Error AudioDriverAndroid::init() {
 	int mix_rate = GLOBAL_DEF("audio/mix_rate", 44100);
 
 	int latency = GLOBAL_DEF("audio/output_latency", 25);
-	latency = 50;
 	unsigned int buffer_size = next_power_of_2(latency * mix_rate / 1000);
 	if (OS::get_singleton()->is_stdout_verbose()) {
 		print_line("audio buffer size: " + itos(buffer_size));

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -3024,7 +3024,7 @@ public:
 			args.push_back(devices[p_device].id);
 			args.push_back("reverse");
 			args.push_back("--remove-all");
-			err = OS::get_singleton()->execute(adb, args, true, NULL, NULL, &rv);
+			OS::get_singleton()->execute(adb, args, true, NULL, NULL, &rv);
 
 			int dbg_port = EditorSettings::get_singleton()->get("network/debug/remote_port");
 			args.clear();
@@ -3034,7 +3034,7 @@ public:
 			args.push_back("tcp:" + itos(dbg_port));
 			args.push_back("tcp:" + itos(dbg_port));
 
-			err = OS::get_singleton()->execute(adb, args, true, NULL, NULL, &rv);
+			OS::get_singleton()->execute(adb, args, true, NULL, NULL, &rv);
 			print_line("Reverse result: " + itos(rv));
 
 			int fs_port = EditorSettings::get_singleton()->get("filesystem/file_server/port");

--- a/platform/iphone/audio_driver_iphone.cpp
+++ b/platform/iphone/audio_driver_iphone.cpp
@@ -46,10 +46,8 @@ Error AudioDriverIphone::init() {
 	strdesc.mBytesPerPacket =
 			strdesc.mBytesPerFrame * strdesc.mFramesPerPacket;
 
-	OSStatus result = noErr;
 	AURenderCallbackStruct callback;
 	AudioComponentDescription desc;
-	AudioComponent comp = NULL;
 	const AudioUnitElement output_bus = 0;
 	const AudioUnitElement bus = output_bus;
 	const AudioUnitScope scope = kAudioUnitScope_Input;
@@ -57,10 +55,10 @@ Error AudioDriverIphone::init() {
 	zeromem(&desc, sizeof(desc));
 	desc.componentType = kAudioUnitType_Output;
 	desc.componentSubType = kAudioUnitSubType_RemoteIO; /* !!! FIXME: ? */
-	comp = AudioComponentFindNext(NULL, &desc);
+	AudioComponent comp = AudioComponentFindNext(NULL, &desc);
 	desc.componentManufacturer = kAudioUnitManufacturer_Apple;
 
-	result = AudioComponentInstanceNew(comp, &audio_unit);
+	OSStatus result = AudioComponentInstanceNew(comp, &audio_unit);
 	ERR_FAIL_COND_V(result != noErr, FAILED);
 	ERR_FAIL_COND_V(comp == NULL, FAILED);
 

--- a/platform/osx/joypad_osx.cpp
+++ b/platform/osx/joypad_osx.cpp
@@ -217,10 +217,9 @@ static void joypad_added_callback(void *ctx, IOReturn res, void *sender, IOHIDDe
 }
 
 static bool is_joypad(IOHIDDeviceRef p_device_ref) {
-	CFTypeRef refCF = NULL;
 	int usage_page = 0;
 	int usage = 0;
-	refCF = IOHIDDeviceGetProperty(p_device_ref, CFSTR(kIOHIDPrimaryUsagePageKey));
+	CFTypeRef refCF = IOHIDDeviceGetProperty(p_device_ref, CFSTR(kIOHIDPrimaryUsagePageKey));
 	if (refCF) {
 		CFNumberGetValue((CFNumberRef)refCF, kCFNumberSInt32Type, &usage_page);
 	}
@@ -289,13 +288,11 @@ static String _hex_str(uint8_t p_byte) {
 
 bool JoypadOSX::configure_joypad(IOHIDDeviceRef p_device_ref, joypad *p_joy) {
 
-	CFTypeRef refCF = NULL;
-
 	p_joy->device_ref = p_device_ref;
 	/* get device name */
 	String name;
 	char c_name[256];
-	refCF = IOHIDDeviceGetProperty(p_device_ref, CFSTR(kIOHIDProductKey));
+	CFTypeRef refCF = IOHIDDeviceGetProperty(p_device_ref, CFSTR(kIOHIDProductKey));
 	if (!refCF) {
 		refCF = IOHIDDeviceGetProperty(p_device_ref, CFSTR(kIOHIDManufacturerKey));
 	}
@@ -334,8 +331,7 @@ bool JoypadOSX::configure_joypad(IOHIDDeviceRef p_device_ref, joypad *p_joy) {
 		input->joy_connection_changed(id, true, name, guid);
 	}
 
-	CFArrayRef array = NULL;
-	array = IOHIDDeviceCopyMatchingElements(p_device_ref, NULL, kIOHIDOptionsTypeNone);
+	CFArrayRef array = IOHIDDeviceCopyMatchingElements(p_device_ref, NULL, kIOHIDOptionsTypeNone);
 	if (array) {
 		p_joy->add_hid_elements(array);
 		CFRelease(array);

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -716,8 +716,7 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 		} break;
 		case WM_DROPFILES: {
 
-			HDROP hDropInfo = NULL;
-			hDropInfo = (HDROP)wParam;
+			HDROP hDropInfo = (HDROP)wParam;
 			const int buffsize = 4096;
 			wchar_t buf[buffsize];
 

--- a/platform/x11/context_gl_x11.cpp
+++ b/platform/x11/context_gl_x11.cpp
@@ -98,11 +98,9 @@ static void set_class_hint(Display *p_display, Window p_window) {
 
 Error ContextGL_X11::initialize() {
 
-	GLXCREATECONTEXTATTRIBSARBPROC glXCreateContextAttribsARB = NULL;
-
 	//const char *extensions = glXQueryExtensionsString(x11_display, DefaultScreen(x11_display));
 
-	glXCreateContextAttribsARB = (GLXCREATECONTEXTATTRIBSARBPROC)glXGetProcAddress((const GLubyte *)"glXCreateContextAttribsARB");
+	GLXCREATECONTEXTATTRIBSARBPROC glXCreateContextAttribsARB = (GLXCREATECONTEXTATTRIBSARBPROC)glXGetProcAddress((const GLubyte *)"glXCreateContextAttribsARB");
 
 	ERR_FAIL_COND_V(!glXCreateContextAttribsARB, ERR_UNCONFIGURED);
 

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -191,8 +191,7 @@ void OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_au
 
 		::XIMStyles *xim_styles = NULL;
 		xim_style = 0L;
-		char *imvalret = NULL;
-		imvalret = XGetIMValues(xim, XNQueryInputStyle, &xim_styles, NULL);
+		char *imvalret = XGetIMValues(xim, XNQueryInputStyle, &xim_styles, NULL);
 		if (imvalret != NULL || xim_styles == NULL) {
 			fprintf(stderr, "Input method doesn't support any styles\n");
 		}
@@ -2140,8 +2139,7 @@ bool OS_X11::is_vsync_enabled() const {
 
 void OS_X11::set_context(int p_context) {
 
-	XClassHint *classHint = NULL;
-	classHint = XAllocClassHint();
+	XClassHint *classHint = XAllocClassHint();
 	if (classHint) {
 
 		if (p_context == CONTEXT_EDITOR)

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -143,9 +143,7 @@ void Polygon2D::_notification(int p_what) {
 
 				Transform2D texmat(tex_rot, tex_ofs);
 				texmat.scale(tex_scale);
-				Size2 tex_size = Vector2(1, 1);
-
-				tex_size = texture->get_size();
+				Size2 tex_size = texture->get_size();
 				uvs.resize(points.size());
 
 				if (points.size() == uv.size()) {

--- a/scene/3d/vehicle_body.cpp
+++ b/scene/3d/vehicle_body.cpp
@@ -559,6 +559,9 @@ void VehicleBody::_resolve_single_bilateral(PhysicsDirectBodyState *s, const Vec
 			b2invinertia,
 			b2invmass);
 
+	// FIXME: rel_vel assignment here is overwritten by the following assignment.
+	// What seemes to be intented in the next next assignment is: rel_vel = normal.dot(rel_vel);
+	// Investigate why.
 	real_t rel_vel = jac.getRelativeVelocity(
 			s->get_linear_velocity(),
 			s->get_transform().basis.transposed().xform(s->get_angular_velocity()),

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3898,10 +3898,8 @@ bool TextEdit::search(const String &p_key, uint32_t p_search_flags, int p_from_l
 
 	//search through the whole documment, but start by current line
 
-	int line = -1;
+	int line = p_from_line;
 	int pos = -1;
-
-	line = p_from_line;
 
 	for (int i = 0; i < text.size() + 1; i++) {
 		//backwards is broken...

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1459,7 +1459,6 @@ void Tree::select_single_item(TreeItem *p_selected, TreeItem *p_current, int p_c
 				c.selected = true;
 				selected_item = p_selected;
 				selected_col = 0;
-				selected_item = p_selected;
 				if (!emitted_row) {
 					emit_signal("item_selected");
 					emitted_row = true;

--- a/scene/gui/video_player.cpp
+++ b/scene/gui/video_player.cpp
@@ -399,7 +399,6 @@ VideoPlayer::VideoPlayer() {
 	paused = false;
 	autoplay = false;
 	expand = true;
-	loops = false;
 
 	audio_track = 0;
 

--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -1016,13 +1016,9 @@ void PrismMesh::_create_mesh_array(Array &p_arr) const {
 	for (j = 0; j <= (subdivide_h + 1); j++) {
 		float scale = (y - start_pos.y) / size.y;
 		float scaled_size_x = size.x * scale;
-		float start_x = start_pos.x;
-		float offset_front = 0.0;
-		float offset_back = 0.0;
-
-		start_x += (1.0 - scale) * size.x * left_to_right;
-		offset_front += (1.0 - scale) * onethird * left_to_right;
-		offset_back = (1.0 - scale) * onethird * (1.0 - left_to_right);
+		float start_x = start_pos.x + (1.0 - scale) * size.x * left_to_right;
+		float offset_front = (1.0 - scale) * onethird * left_to_right;
+		float offset_back = (1.0 - scale) * onethird * (1.0 - left_to_right);
 
 		x = 0.0;
 		for (i = 0; i <= (subdivide_w + 1); i++) {

--- a/servers/physics/broad_phase_octree.cpp
+++ b/servers/physics/broad_phase_octree.cpp
@@ -124,6 +124,5 @@ BroadPhaseOctree::BroadPhaseOctree() {
 	octree.set_unpair_callback(_unpair_callback, this);
 	pair_callback = NULL;
 	pair_userdata = NULL;
-	pair_callback = NULL;
 	unpair_userdata = NULL;
 }

--- a/servers/physics/space_sw.cpp
+++ b/servers/physics/space_sw.cpp
@@ -474,8 +474,7 @@ bool PhysicsDirectSpaceStateSW::rest_info(RID p_shape, const Transform &p_shape_
 
 Vector3 PhysicsDirectSpaceStateSW::get_closest_point_to_object_volume(RID p_object, const Vector3 p_point) const {
 
-	CollisionObjectSW *obj = NULL;
-	obj = PhysicsServerSW::singleton->area_owner.getornull(p_object);
+	CollisionObjectSW *obj = PhysicsServerSW::singleton->area_owner.getornull(p_object);
 	if (!obj) {
 		obj = PhysicsServerSW::singleton->body_owner.getornull(p_object);
 	}
@@ -598,11 +597,8 @@ bool SpaceSW::test_body_motion(BodySW *p_body, const Transform &p_from, const Ve
 			cbk.amount = 0;
 			cbk.ptr = sr;
 
-			CollisionSolverSW::CallbackResult cbkres = NULL;
-
-			PhysicsServerSW::CollCbkData *cbkptr = NULL;
-			cbkptr = &cbk;
-			cbkres = PhysicsServerSW::_shape_col_cbk;
+			PhysicsServerSW::CollCbkData *cbkptr = &cbk;
+			CollisionSolverSW::CallbackResult cbkres = PhysicsServerSW::_shape_col_cbk;
 
 			bool collided = false;
 

--- a/servers/physics_2d/joints_2d_sw.cpp
+++ b/servers/physics_2d/joints_2d_sw.cpp
@@ -408,8 +408,10 @@ bool GrooveJoint2DSW::setup(real_t p_step) {
 	//joint->bias = cpvclamp(cpvmult(delta, -joint->constraint.biasCoef*dt_inv), joint->constraint.maxBias);
 
 	Vector2 delta = (B->get_transform().get_origin() + rB) - (A->get_transform().get_origin() + rA);
-	real_t _b = get_bias();
-	_b = 0.001;
+
+	// FIXME: We used to do this assignment and then override it with 0.001 right after. Investigate why.
+	//real_t _b = get_bias();
+	real_t _b = 0.001;
 	gbias = (delta * -(_b == 0 ? space->get_constraint_bias() : _b) * (1.0 / p_step)).clamped(get_max_bias());
 
 	// apply accumulated impulse

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -532,11 +532,8 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 			cbk.amount = 0;
 			cbk.ptr = sr;
 
-			CollisionSolver2DSW::CallbackResult cbkres = NULL;
-
-			Physics2DServerSW::CollCbkData *cbkptr = NULL;
-			cbkptr = &cbk;
-			cbkres = Physics2DServerSW::_shape_col_cbk;
+			Physics2DServerSW::CollCbkData *cbkptr = &cbk;
+			CollisionSolver2DSW::CallbackResult cbkres = Physics2DServerSW::_shape_col_cbk;
 
 			bool collided = false;
 


### PR DESCRIPTION
`cppcheck` found variables whose previous values were never used before an assignment.

This pull request mitigates the following `cppcheck` messages:
```
[core/bind/core_bind.cpp:1409] -> [core/bind/core_bind.cpp:1413]: (style, inconclusive) Variable 'err' is reassigned a value before the old one has been used if variable is no semaphore variable.
[core/io/file_access_compressed.cpp:371] -> [core/io/file_access_compressed.cpp:377]: (style, inconclusive) Variable 'block_size' is reassigned a value before the old one has been used if variable is no semaphore variable.
[drivers/gles2/rasterizer_gles2.cpp:657] -> [drivers/gles2/rasterizer_gles2.cpp:658]: (style, inconclusive) Variable 'r_gl_internal_format' is reassigned a value before the old one has been used if variable is no semaphore variable.
[editor/code_editor.cpp:261] -> [editor/code_editor.cpp:262]: (style, inconclusive) Variable 'r_col' is reassigned a value before the old one has been used if variable is no semaphore variable.
[editor/editor_asset_installer.cpp:103] -> [editor/editor_asset_installer.cpp:108]: (style) Variable 'ret' is reassigned a value before the old one has been used.
[editor/export_template_manager.cpp:198] -> [editor/export_template_manager.cpp:199]: (style) Variable 'ret' is reassigned a value before the old one has been used.
[editor/export_template_manager.cpp:260] -> [editor/export_template_manager.cpp:268]: (style) Variable 'ret' is reassigned a value before the old one has been used.
[editor/export_template_manager.cpp:268] -> [editor/export_template_manager.cpp:269]: (style) Variable 'ret' is reassigned a value before the old one has been used.
[editor/export_template_manager.cpp:269] -> [editor/export_template_manager.cpp:290]: (style) Variable 'ret' is reassigned a value before the old one has been used.
[editor/filesystem_dock.cpp:1468] -> [editor/filesystem_dock.cpp:1471]: (style) Variable 'efsd' is reassigned a value before the old one has been used.
[editor/import/editor_import_collada.cpp:1587] -> [editor/import/editor_import_collada.cpp:1594]: (style) Variable 'joint_src' is reassigned a value before the old one has been used.
[editor/import/editor_import_collada.cpp:2319] -> [editor/import/editor_import_collada.cpp:2320]: (style, inconclusive) Variable 'anim' is reassigned a value before the old one has been used if variable is no semaphore variable.
[editor/plugins/particles_editor_plugin.cpp:273] -> [editor/plugins/particles_editor_plugin.cpp:274]: (style, inconclusive) Variable 'ofs' is reassigned a value before the old one has been used if variable is no semaphore variable.
[editor/script_create_dialog.cpp:534] -> [editor/script_create_dialog.cpp:547]: (style) Variable 'gc' is reassigned a value before the old one has been used.
[editor/script_create_dialog.cpp:535] -> [editor/script_create_dialog.cpp:552]: (style) Variable 'vb' is reassigned a value before the old one has been used.
[editor/script_create_dialog.cpp:536] -> [editor/script_create_dialog.cpp:554]: (style) Variable 'hb' is reassigned a value before the old one has been used.
[editor/script_create_dialog.cpp:537] -> [editor/script_create_dialog.cpp:555]: (style) Variable 'l' is reassigned a value before the old one has been used.
[editor/script_create_dialog.cpp:541] -> [editor/script_create_dialog.cpp:574]: (style) Variable 'pc' is reassigned a value before the old one has been used.
[editor/script_create_dialog.cpp:539] -> [editor/script_create_dialog.cpp:581]: (style) Variable 'empty_h' is reassigned a value before the old one has been used.
[editor/script_create_dialog.cpp:540] -> [editor/script_create_dialog.cpp:586]: (style) Variable 'empty_v' is reassigned a value before the old one has been used.
[main/main.cpp:893] -> [main/main.cpp:895]: (style) Variable 'show_logo' is reassigned a value before the old one has been used.
[main/tests/test_string.cpp:805] -> [main/tests/test_string.cpp:820]: (style) Variable 'success' is reassigned a value before the old one has been used.
[modules/gdnative/gdnative.cpp:250] -> [modules/gdnative/gdnative.cpp:252]: (style, inconclusive) Variable 'error' is reassigned a value before the old one has been used if variable is no semaphore variable.
[modules/gdscript/gd_compiler.cpp:1454] -> [modules/gdscript/gd_compiler.cpp:1462]: (style) Variable 'gdfunc' is reassigned a value before the old one has been used.
[modules/gdscript/gd_parser.cpp:2384] -> [modules/gdscript/gd_parser.cpp:2386]: (style) Variable 'subexpr' is reassigned a value before the old one has been used.
[modules/gdscript/gd_parser.cpp:3138] -> [modules/gdscript/gd_parser.cpp:3140]: (style) Variable 'defval' is reassigned a value before the old one has been used.
[modules/gdscript/gd_parser.cpp:3878] -> [modules/gdscript/gd_parser.cpp:3880]: (style) Variable 'subexpr' is reassigned a value before the old one has been used.
[modules/gdscript/gd_parser.cpp:4038] -> [modules/gdscript/gd_parser.cpp:4040]: (style) Variable 'subexpr' is reassigned a value before the old one has been used.
[modules/gdscript/gd_parser.cpp:4106] -> [modules/gdscript/gd_parser.cpp:4108]: (style) Variable 'subexpr' is reassigned a value before the old one has been used.
[modules/gdscript/gd_tokenizer.cpp:1190] -> [modules/gdscript/gd_tokenizer.cpp:1192]: (style) Variable 'b' is reassigned a value before the old one has been used.
[modules/nativescript/api_generator.cpp:158] -> [modules/nativescript/api_generator.cpp:161]: (style) Variable 'is_reference' is reassigned a value before the old one has been used.
[modules/openssl/stream_peer_openssl.cpp:44] -> [modules/openssl/stream_peer_openssl.cpp:50]: (style) Variable 'common_name_loc' is reassigned a value before the old one has been used.
[modules/openssl/stream_peer_openssl.cpp:45] -> [modules/openssl/stream_peer_openssl.cpp:55]: (style) Variable 'common_name_entry' is reassigned a value before the old one has been used.
[modules/openssl/stream_peer_openssl.cpp:46] -> [modules/openssl/stream_peer_openssl.cpp:60]: (style) Variable 'common_name_asn1' is reassigned a value before the old one has been used.
[modules/openssl/stream_peer_openssl.cpp:47] -> [modules/openssl/stream_peer_openssl.cpp:64]: (style) Variable 'common_name_str' is reassigned a value before the old one has been used.
[modules/pbm/bitmap_loader_pbm.cpp:98] -> [modules/pbm/bitmap_loader_pbm.cpp:100]: (style, inconclusive) Variable 'w' is reassigned a value before the old one has been used if variable is no semaphore variable.
[modules/theora/video_stream_theora.cpp:454] -> [modules/theora/video_stream_theora.cpp:455]: (style, inconclusive) Variable 'pp_level' is reassigned a value before the old one has been used if variable is no semaphore variable.
[platform/android/audio_driver_jandroid.cpp:82] -> [platform/android/audio_driver_jandroid.cpp:83]: (style) Variable 'latency' is reassigned a value before the old one has been used.
[platform/android/export/export.cpp:3027] -> [platform/android/export/export.cpp:3037]: (style, inconclusive) Variable 'err' is reassigned a value before the old one has been used if variable is no semaphore variable.
[platform/android/export/export.cpp:3037] -> [platform/android/export/export.cpp:3049]: (style, inconclusive) Variable 'err' is reassigned a value before the old one has been used if variable is no semaphore variable.
[platform/iphone/audio_driver_iphone.cpp:52] -> [platform/iphone/audio_driver_iphone.cpp:60]: (style, inconclusive) Variable 'comp' is reassigned a value before the old one has been used if variable is no semaphore variable.
[platform/iphone/audio_driver_iphone.cpp:49] -> [platform/iphone/audio_driver_iphone.cpp:63]: (style, inconclusive) Variable 'result' is reassigned a value before the old one has been used if variable is no semaphore variable.
[platform/osx/audio_driver_osx.cpp:56] -> [platform/osx/audio_driver_osx.cpp:66]: (style, inconclusive) Variable 'comp' is reassigned a value before the old one has been used if variable is no semaphore variable.
[platform/osx/joypad_osx.cpp:220] -> [platform/osx/joypad_osx.cpp:223]: (style, inconclusive) Variable 'refCF' is reassigned a value before the old one has been used if variable is no semaphore variable.
[platform/osx/joypad_osx.cpp:292] -> [platform/osx/joypad_osx.cpp:298]: (style, inconclusive) Variable 'refCF' is reassigned a value before the old one has been used if variable is no semaphore variable.
[platform/osx/joypad_osx.cpp:337] -> [platform/osx/joypad_osx.cpp:338]: (style, inconclusive) Variable 'array' is reassigned a value before the old one has been used if variable is no semaphore variable.
[platform/windows/os_windows.cpp:720] -> [platform/windows/os_windows.cpp:721]: (style, inconclusive) Variable 'hDropInfo' is reassigned a value before the old one has been used if variable is no semaphore variable.
[platform/x11/context_gl_x11.cpp:88] -> [platform/x11/context_gl_x11.cpp:92]: (style) Variable 'glXCreateContextAttribsARB' is reassigned a value before the old one has been used.
[platform/x11/os_x11.cpp:194] -> [platform/x11/os_x11.cpp:195]: (style) Variable 'imvalret' is reassigned a value before the old one has been used.
[platform/x11/os_x11.cpp:2154] -> [platform/x11/os_x11.cpp:2155]: (style) Variable 'classHint' is reassigned a value before the old one has been used.
[scene/2d/polygon_2d.cpp:146] -> [scene/2d/polygon_2d.cpp:148]: (style, inconclusive) Variable 'tex_size' is reassigned a value before the old one has been used if variable is no semaphore variable.
[scene/3d/vehicle_body.cpp:562] -> [scene/3d/vehicle_body.cpp:568]: (style, inconclusive) Variable 'rel_vel' is reassigned a value before the old one has been used if variable is no semaphore variable.
[scene/gui/text_edit.cpp:3824] -> [scene/gui/text_edit.cpp:3827]: (style) Variable 'line' is reassigned a value before the old one has been used.
[scene/gui/tree.cpp:1460] -> [scene/gui/tree.cpp:1462]: (style, inconclusive) Variable 'selected_item' is reassigned a value before the old one has been used if variable is no semaphore variable.
[scene/gui/video_player.cpp:398] -> [scene/gui/video_player.cpp:402]: (style, inconclusive) Variable 'loops' is reassigned a value before the old one has been used if variable is no semaphore variable.
[scene/resources/primitive_meshes.cpp:1021] -> [scene/resources/primitive_meshes.cpp:1025]: (style) Variable 'offset_back' is reassigned a value before the old one has been used.
[servers/physics/broad_phase_octree.cpp:125] -> [servers/physics/broad_phase_octree.cpp:127]: (style, inconclusive) Variable 'pair_callback' is reassigned a value before the old one has been used if variable is no semaphore variable.
[servers/physics/space_sw.cpp:477] -> [servers/physics/space_sw.cpp:478]: (style) Variable 'obj' is reassigned a value before the old one has been used.
[servers/physics/space_sw.cpp:603] -> [servers/physics/space_sw.cpp:604]: (style) Variable 'cbkptr' is reassigned a value before the old one has been used.
[servers/physics/space_sw.cpp:601] -> [servers/physics/space_sw.cpp:605]: (style) Variable 'cbkres' is reassigned a value before the old one has been used.
[servers/physics_2d/joints_2d_sw.cpp:411] -> [servers/physics_2d/joints_2d_sw.cpp:412]: (style, inconclusive) Variable '_b' is reassigned a value before the old one has been used if variable is no semaphore variable.
[servers/physics_2d/space_2d_sw.cpp:537] -> [servers/physics_2d/space_2d_sw.cpp:538]: (style) Variable 'cbkptr' is reassigned a value before the old one has been used.
[servers/physics_2d/space_2d_sw.cpp:535] -> [servers/physics_2d/space_2d_sw.cpp:539]: (style) Variable 'cbkres' is reassigned a value before the old one has been used.
```