### PR TITLE
Keep shapes bound to out-of-tree 3D physics objects

### DIFF
--- a/scene/3d/collision_shape.cpp
+++ b/scene/3d/collision_shape.cpp
@@ -89,13 +89,6 @@ void CollisionShape::_notification(int p_what) {
 				parent->shape_owner_set_transform(owner_id, get_transform());
 			}
 		} break;
-		case NOTIFICATION_EXIT_TREE: {
-			if (parent) {
-				parent->remove_shape_owner(owner_id);
-			}
-			owner_id = 0;
-			parent = NULL;
-		} break;
 		case NOTIFICATION_UNPARENTED: {
 			if (parent) {
 				parent->remove_shape_owner(owner_id);


### PR DESCRIPTION
Now the shape in the physics server is unbound only when it's unparented from its body, because if it's unbound when just exiting the tree, a later readd would have the body shapeless in the server.

It's the same currently being done in 2D physics.

Fixes #10074.