### PR TITLE
Revive inspector property evaluation

### DIFF
--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -4774,12 +4774,11 @@ double PropertyValueEvaluator::eval(const String &p_text) {
 		return _default_eval(p_text);
 	}
 
-	ScriptInstance *script_instance = script->instance_create(this);
+	ScriptInstance *script_instance = script->instance_create(obj);
 	if (!script_instance)
 		return _default_eval(p_text);
 
 	Variant::CallError call_err;
-	script_instance->call("set_this", obj);
 	double result = script_instance->call("e", NULL, 0, call_err);
 	if (call_err.error == Variant::CallError::CALL_OK) {
 		return result;
@@ -4796,7 +4795,7 @@ void PropertyValueEvaluator::edit(Object *p_obj) {
 }
 
 String PropertyValueEvaluator::_build_script(const String &p_text) {
-	String script_text = "tool\nvar this\nfunc set_this(p_this):\n\tthis=p_this\nfunc e():\n\treturn ";
+	String script_text = "tool\nextends Object\nfunc e():\n\treturn ";
 	script_text += p_text.strip_edges();
 	script_text += "\n";
 	return script_text;

--- a/modules/gdscript/gd_script.cpp
+++ b/modules/gdscript/gd_script.cpp
@@ -615,7 +615,7 @@ Error GDScript::reload(bool p_keep_state) {
 	if (basedir != "")
 		basedir = basedir.get_base_dir();
 
-	if (basedir.find("res://") == -1 && basedir.find("user://") == -1) {
+	if (basedir != "" && basedir.find("res://") == -1 && basedir.find("user://") == -1) {
 		//loading a template, don't parse
 		return OK;
 	}


### PR DESCRIPTION
GDScript was restricted to parse only scripts beginning with __res://__ or __user://__ to avoid templates from being parsed. I've made that a bit less inclusive by allowing scripts with an empty path to be parsed too, which doesn't conflict and is needed for this to work.

Also I've removed the `this` variable of the generated script and made the relevant object to be the one the script instance refers to, so you can use `self` instead.

Now, with the shorter 3.0-style syntax, you can write things like: `self.position.x + 10`

Closes #9500.