### PR TITLE
Rename `XL_MESSAGE`/`tr` to `localize`

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1560,17 +1560,12 @@ void Object::initialize_class() {
 	initialized = true;
 }
 
-StringName Object::XL_MESSAGE(const StringName &p_message) const {
+StringName Object::localize(const StringName &p_message) const {
 
 	if (!_can_translate || !TranslationServer::get_singleton())
 		return p_message;
 
 	return TranslationServer::get_singleton()->translate(p_message);
-}
-
-StringName Object::tr(const StringName &p_message) const {
-
-	return XL_MESSAGE(p_message);
 }
 
 void Object::_clear_internal_resource_paths(const Variant &p_var) {
@@ -1712,12 +1707,11 @@ void Object::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_block_signals", "enable"), &Object::set_block_signals);
 	ClassDB::bind_method(D_METHOD("is_blocking_signals"), &Object::is_blocking_signals);
-	ClassDB::bind_method(D_METHOD("set_message_translation", "enable"), &Object::set_message_translation);
+	ClassDB::bind_method(D_METHOD("set_message_localization", "enable"), &Object::set_message_localization);
 	ClassDB::bind_method(D_METHOD("can_translate_messages"), &Object::can_translate_messages);
 	ClassDB::bind_method(D_METHOD("property_list_changed_notify"), &Object::property_list_changed_notify);
 
-	ClassDB::bind_method(D_METHOD("XL_MESSAGE", "message"), &Object::XL_MESSAGE);
-	ClassDB::bind_method(D_METHOD("tr", "message"), &Object::tr);
+	ClassDB::bind_method(D_METHOD("localize", "message"), &Object::localize);
 
 	ClassDB::bind_method(D_METHOD("is_queued_for_deletion"), &Object::is_queued_for_deletion);
 

--- a/core/object.h
+++ b/core/object.h
@@ -678,13 +678,12 @@ public:
 
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const;
 
-	StringName XL_MESSAGE(const StringName &p_message) const; //translate message (internationalization)
-	StringName tr(const StringName &p_message) const; //translate message (alternative)
+	StringName localize(const StringName &p_message) const; //translate message (internationalization)
 
 	bool _is_queued_for_deletion; // set to true by SceneTree::queue_delete()
 	bool is_queued_for_deletion() const;
 
-	_FORCE_INLINE_ void set_message_translation(bool p_enable) { _can_translate = p_enable; }
+	_FORCE_INLINE_ void set_message_localization(bool p_enable) { _can_translate = p_enable; }
 	_FORCE_INLINE_ bool can_translate_messages() const { return _can_translate; }
 
 #ifdef TOOLS_ENABLED

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -28002,15 +28002,6 @@
 		Objects also receive notifications ([method _notification]). Notifications are a simple way to notify the object about simple events, so they can all be handled together.
 	</description>
 	<methods>
-		<method name="XL_MESSAGE" qualifiers="const">
-			<return type="String">
-			</return>
-			<argument index="0" name="message" type="String">
-			</argument>
-			<description>
-				Deprecated, will go away.
-			</description>
-		</method>
 		<method name="_get" qualifiers="virtual">
 			<argument index="0" name="property" type="String">
 			</argument>
@@ -28268,6 +28259,15 @@
 			<description>
 			</description>
 		</method>
+		<method name="localize" qualifiers="const">
+			<return type="String">
+			</return>
+			<argument index="0" name="message" type="String">
+			</argument>
+			<description>
+				Localize (translate) a message. Only works if message localization is enabled (which it is by default). See [method set_message_localization].
+			</description>
+		</method>
 		<method name="notification">
 			<argument index="0" name="what" type="int">
 			</argument>
@@ -28297,11 +28297,11 @@
 				If set to true, signal emission is blocked.
 			</description>
 		</method>
-		<method name="set_message_translation">
+		<method name="set_message_localization">
 			<argument index="0" name="enable" type="bool">
 			</argument>
 			<description>
-				Set true if this object can translate strings (in calls to tr() ). Default is true.
+				Define whether this object can localize strings (with calls to [code]localize[/code]). Default is true.
 			</description>
 		</method>
 		<method name="set_meta">
@@ -28318,15 +28318,6 @@
 			</argument>
 			<description>
 				Set a script into the object, scripts extend the object functionality.
-			</description>
-		</method>
-		<method name="tr" qualifiers="const">
-			<return type="String">
-			</return>
-			<argument index="0" name="message" type="String">
-			</argument>
-			<description>
-				Translate a message. Only works in message translation is enabled (which is by default). See [method set_message_translation].
 			</description>
 		</method>
 	</methods>

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -59,7 +59,7 @@ void Button::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_TRANSLATION_CHANGED) {
 
-		xl_text = XL_MESSAGE(text);
+		xl_text = localize(text);
 		minimum_size_changed();
 		update();
 	}
@@ -172,7 +172,7 @@ void Button::set_text(const String &p_text) {
 	if (text == p_text)
 		return;
 	text = p_text;
-	xl_text = XL_MESSAGE(p_text);
+	xl_text = localize(p_text);
 	update();
 	_change_notify("text");
 	minimum_size_changed();

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -271,7 +271,7 @@ int WindowDialog::_drag_hit_test(const Point2 &pos) const {
 
 void WindowDialog::set_title(const String &p_title) {
 
-	title = XL_MESSAGE(p_title);
+	title = localize(p_title);
 	update();
 }
 String WindowDialog::get_title() const {

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -464,7 +464,7 @@ void FileDialog::update_filters() {
 		String flt = filters[i].get_slice(";", 0).strip_edges();
 		String desc = filters[i].get_slice(";", 1).strip_edges();
 		if (desc.length())
-			filter->add_item(String(XL_MESSAGE(desc)) + " ( " + flt + " )");
+			filter->add_item(String(localize(desc)) + " ( " + flt + " )");
 		else
 			filter->add_item("( " + flt + " )");
 	}

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -63,7 +63,7 @@ void Label::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_TRANSLATION_CHANGED) {
 
-		String new_text = XL_MESSAGE(text);
+		String new_text = localize(text);
 		if (new_text == xl_text)
 			return; //nothing new
 		xl_text = new_text;
@@ -526,7 +526,7 @@ void Label::set_text(const String &p_string) {
 	if (text == p_string)
 		return;
 	text = p_string;
-	xl_text = XL_MESSAGE(p_string);
+	xl_text = localize(p_string);
 	word_cache_dirty = true;
 	if (percent_visible < 1)
 		visible_chars = get_total_character_count() * percent_visible;

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -991,7 +991,7 @@ String LineEdit::get_text() const {
 
 void LineEdit::set_placeholder(String p_text) {
 
-	placeholder = XL_MESSAGE(p_text);
+	placeholder = localize(p_text);
 	update();
 }
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -96,7 +96,7 @@ Size2 PopupMenu::get_minimum_size() const {
 			size.width += check_w + hseparation;
 		}
 
-		String text = items[i].shortcut.is_valid() ? String(tr(items[i].shortcut->get_name())) : items[i].xl_text;
+		String text = items[i].shortcut.is_valid() ? String(localize(items[i].shortcut->get_name())) : items[i].xl_text;
 		size.width += font->get_string_size(text).width;
 		if (i > 0)
 			size.height += vseparation;
@@ -395,7 +395,7 @@ void PopupMenu::_notification(int p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 
 			for (int i = 0; i < items.size(); i++) {
-				items[i].xl_text = XL_MESSAGE(items[i].text);
+				items[i].xl_text = localize(items[i].text);
 			}
 
 			minimum_size_changed();
@@ -475,7 +475,7 @@ void PopupMenu::_notification(int p_what) {
 				}
 
 				item_ofs.y += font->get_ascent();
-				String text = items[i].shortcut.is_valid() ? String(tr(items[i].shortcut->get_name())) : items[i].xl_text;
+				String text = items[i].shortcut.is_valid() ? String(localize(items[i].shortcut->get_name())) : items[i].xl_text;
 				if (!items[i].separator) {
 
 					font->draw(ci, item_ofs + Point2(0, Math::floor((h - font_h) / 2.0)), text, items[i].disabled ? font_color_disabled : (i == mouse_over ? font_color_hover : font_color));
@@ -513,7 +513,7 @@ void PopupMenu::add_icon_item(const Ref<Texture> &p_icon, const String &p_label,
 	Item item;
 	item.icon = p_icon;
 	item.text = p_label;
-	item.xl_text = XL_MESSAGE(p_label);
+	item.xl_text = localize(p_label);
 	item.accel = p_accel;
 	item.ID = p_ID;
 	items.push_back(item);
@@ -523,7 +523,7 @@ void PopupMenu::add_item(const String &p_label, int p_ID, uint32_t p_accel) {
 
 	Item item;
 	item.text = p_label;
-	item.xl_text = XL_MESSAGE(p_label);
+	item.xl_text = localize(p_label);
 	item.accel = p_accel;
 	item.ID = p_ID;
 	items.push_back(item);
@@ -534,7 +534,7 @@ void PopupMenu::add_submenu_item(const String &p_label, const String &p_submenu,
 
 	Item item;
 	item.text = p_label;
-	item.xl_text = XL_MESSAGE(p_label);
+	item.xl_text = localize(p_label);
 	item.ID = p_ID;
 	item.submenu = p_submenu;
 	items.push_back(item);
@@ -546,7 +546,7 @@ void PopupMenu::add_icon_check_item(const Ref<Texture> &p_icon, const String &p_
 	Item item;
 	item.icon = p_icon;
 	item.text = p_label;
-	item.xl_text = XL_MESSAGE(p_label);
+	item.xl_text = localize(p_label);
 	item.accel = p_accel;
 	item.ID = p_ID;
 	item.checkable = true;
@@ -557,7 +557,7 @@ void PopupMenu::add_check_item(const String &p_label, int p_ID, uint32_t p_accel
 
 	Item item;
 	item.text = p_label;
-	item.xl_text = XL_MESSAGE(p_label);
+	item.xl_text = localize(p_label);
 	item.accel = p_accel;
 	item.ID = p_ID;
 	item.checkable = true;
@@ -628,7 +628,7 @@ void PopupMenu::set_item_text(int p_idx, const String &p_text) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
 	items[p_idx].text = p_text;
-	items[p_idx].xl_text = XL_MESSAGE(p_text);
+	items[p_idx].xl_text = localize(p_text);
 
 	update();
 }

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -231,7 +231,7 @@ void TabContainer::_notification(int p_what) {
 
 				// Draw the tab contents.
 				Control *control = tabs[i + first_tab_cache]->cast_to<Control>();
-				String text = control->has_meta("_tab_name") ? String(XL_MESSAGE(String(control->get_meta("_tab_name")))) : String(control->get_name());
+				String text = control->has_meta("_tab_name") ? String(localize(String(control->get_meta("_tab_name")))) : String(control->get_name());
 
 				int x_content = tab_rect.position.x + tab_style->get_margin(MARGIN_LEFT);
 				int top_margin = tab_style->get_margin(MARGIN_TOP);
@@ -299,7 +299,7 @@ int TabContainer::_get_tab_width(int p_index) const {
 
 	// Get the width of the text displayed on the tab.
 	Ref<Font> font = get_font("font");
-	String text = control->has_meta("_tab_name") ? String(XL_MESSAGE(String(control->get_meta("_tab_name")))) : String(control->get_name());
+	String text = control->has_meta("_tab_name") ? String(localize(String(control->get_meta("_tab_name")))) : String(control->get_name());
 	int width = font->get_string_size(text).width;
 
 	// Add space for a tab icon.


### PR DESCRIPTION
Also drop duplicate `tr()` method.

@reduz The documentation for `XL_MESSAGE` used to say it's meant to be drop: is it true, and if so, how to replace it in Label, Button, etc.? Or should it be dropped only from the bindings but kept internally?