### PR TITLE
Fix particles emitting when emitting is set to false in scene

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -5177,6 +5177,10 @@ void RasterizerStorageGLES3::particles_set_emitting(RID p_particles, bool p_emit
 
 	Particles *particles = particles_owner.getornull(p_particles);
 	ERR_FAIL_COND(!particles);
+	if (p_emitting != particles->emitting) {
+		// Restart is overriden by set_emitting
+		particles->restart_request = false;
+	}
 	particles->emitting = p_emitting;
 }
 void RasterizerStorageGLES3::particles_set_amount(RID p_particles, int p_amount) {


### PR DESCRIPTION
Caused by #10297 calling `particles_restart()` on the same frame as the one `set_emitting(false)` is called.
The rasterizer would then wait a frame, and then set emitting back to true.

Just in case, I tested with all 4 emitting/one_shot configurations: `emitting=false,one_shot=false`, `emitting=false,one_shot=true`, `emitting=true,one_shot=false`, and `emitting=true,one_shot=true`. All are working well now (i.e., the first two don't emit anything, the other two emit, the forth one stops after a while)