### PR TITLE
Add closest_power_of_2 func and implement mix_rate/latency on OS X

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -676,8 +676,8 @@ void Image::resize_to_po2(bool p_square) {
 		ERR_FAIL();
 	}
 
-	int w = nearest_power_of_2(width);
-	int h = nearest_power_of_2(height);
+	int w = next_power_of_2(width);
+	int h = next_power_of_2(height);
 
 	if (w == width && h == height) {
 
@@ -1060,7 +1060,7 @@ Error Image::generate_mipmaps() {
 
 	PoolVector<uint8_t>::Write wp = data.write();
 
-	if (nearest_power_of_2(width) == uint32_t(width) && nearest_power_of_2(height) == uint32_t(height)) {
+	if (next_power_of_2(width) == uint32_t(width) && next_power_of_2(height) == uint32_t(height)) {
 		//use fast code for powers of 2
 		int prev_ofs = 0;
 		int prev_h = height;

--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -43,16 +43,16 @@ void FileAccessCompressed::configure(const String &p_magic, Compression::Mode p_
 	block_size = p_block_size;
 }
 
-#define WRITE_FIT(m_bytes)                                     \
-	{                                                          \
-		if (write_pos + (m_bytes) > write_max) {               \
-			write_max = write_pos + (m_bytes);                 \
-		}                                                      \
-		if (write_max > write_buffer_size) {                   \
-			write_buffer_size = nearest_power_of_2(write_max); \
-			buffer.resize(write_buffer_size);                  \
-			write_ptr = buffer.ptr();                          \
-		}                                                      \
+#define WRITE_FIT(m_bytes)                                  \
+	{                                                       \
+		if (write_pos + (m_bytes) > write_max) {            \
+			write_max = write_pos + (m_bytes);              \
+		}                                                   \
+		if (write_max > write_buffer_size) {                \
+			write_buffer_size = next_power_of_2(write_max); \
+			buffer.resize(write_buffer_size);               \
+			write_ptr = buffer.ptr();                       \
+		}                                                   \
 	}
 
 Error FileAccessCompressed::open_after_magic(FileAccess *p_base) {

--- a/core/io/packet_peer.cpp
+++ b/core/io/packet_peer.cpp
@@ -265,12 +265,12 @@ void PacketPeerStream::set_input_buffer_max_size(int p_max_size) {
 	ERR_EXPLAIN("Buffer in use, resizing would cause loss of data");
 	ERR_FAIL_COND(ring_buffer.data_left());
 	ring_buffer.resize(nearest_shift(p_max_size + 4));
-	input_buffer.resize(nearest_power_of_2(p_max_size + 4));
+	input_buffer.resize(next_power_of_2(p_max_size + 4));
 }
 
 void PacketPeerStream::set_output_buffer_max_size(int p_max_size) {
 
-	output_buffer.resize(nearest_power_of_2(p_max_size + 4));
+	output_buffer.resize(next_power_of_2(p_max_size + 4));
 }
 
 PacketPeerStream::PacketPeerStream() {

--- a/core/math/geometry.cpp
+++ b/core/math/geometry.cpp
@@ -1076,8 +1076,8 @@ void Geometry::make_atlas(const Vector<Size2i> &p_rects, Vector<Point2i> &r_resu
 
 	for (int i = 0; i < results.size(); i++) {
 
-		real_t h = nearest_power_of_2(results[i].max_h);
-		real_t w = nearest_power_of_2(results[i].max_w);
+		real_t h = next_power_of_2(results[i].max_h);
+		real_t w = next_power_of_2(results[i].max_w);
 		real_t aspect = h > w ? h / w : w / h;
 		if (aspect < best_aspect) {
 			best = i;

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -162,9 +162,9 @@ inline void __swap_tmpl(T &x, T &y) {
 #define _add_overflow __builtin_add_overflow
 #endif
 
-/** Function to find the nearest (bigger) power of 2 to an integer */
+/** Function to find the next power of 2 to an integer */
 
-static _FORCE_INLINE_ unsigned int nearest_power_of_2(unsigned int x) {
+static _FORCE_INLINE_ unsigned int next_power_of_2(unsigned int x) {
 
 	--x;
 	x |= x >> 1;
@@ -174,6 +174,23 @@ static _FORCE_INLINE_ unsigned int nearest_power_of_2(unsigned int x) {
 	x |= x >> 16;
 
 	return ++x;
+}
+
+static _FORCE_INLINE_ unsigned int previous_power_of_2(unsigned int x) {
+
+	x |= x >> 1;
+	x |= x >> 2;
+	x |= x >> 4;
+	x |= x >> 8;
+	x |= x >> 16;
+	return x - (x >> 1);
+}
+
+static _FORCE_INLINE_ unsigned int closest_power_of_2(unsigned int x) {
+
+	unsigned int nx = next_power_of_2(x);
+	unsigned int px = previous_power_of_2(x);
+	return (nx - x) > (x - px) ? px : nx;
 }
 
 // We need this definition inside the function below.

--- a/core/vector.h
+++ b/core/vector.h
@@ -71,7 +71,7 @@ class Vector {
 
 	_FORCE_INLINE_ size_t _get_alloc_size(size_t p_elements) const {
 		//return nearest_power_of_2_templated(p_elements*sizeof(T)+sizeof(SafeRefCount)+sizeof(int));
-		return nearest_power_of_2(p_elements * sizeof(T));
+		return next_power_of_2(p_elements * sizeof(T));
 	}
 
 	_FORCE_INLINE_ bool _get_alloc_size_checked(size_t p_elements, size_t *out) const {
@@ -79,7 +79,7 @@ class Vector {
 		size_t o;
 		size_t p;
 		if (_mul_overflow(p_elements, sizeof(T), &o)) return false;
-		*out = nearest_power_of_2(o);
+		*out = next_power_of_2(o);
 		if (_add_overflow(o, static_cast<size_t>(32), &p)) return false; //no longer allocated here
 		return true;
 #else

--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -87,7 +87,7 @@ Error AudioDriverALSA::init() {
 	CHECK_FAIL(status < 0);
 
 	int latency = GLOBAL_DEF("audio/output_latency", 25);
-	buffer_size = nearest_power_of_2(latency * mix_rate / 1000);
+	buffer_size = closest_power_of_2(latency * mix_rate / 1000);
 
 	// set buffer size from project settings
 	status = snd_pcm_hw_params_set_buffer_size_near(pcm_handle, hwparams, &buffer_size);

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -857,8 +857,8 @@ void RasterizerGLES2::texture_allocate(RID p_texture, int p_width, int p_height,
 	GLenum internal_format;
 	bool compressed;
 
-	int po2_width = nearest_power_of_2(p_width);
-	int po2_height = nearest_power_of_2(p_height);
+	int po2_width = next_power_of_2(p_width);
+	int po2_height = next_power_of_2(p_height);
 
 	if (p_flags & VS::TEXTURE_FLAG_VIDEO_SURFACE) {
 		p_flags &= ~VS::TEXTURE_FLAG_MIPMAPS; // no mipies for video
@@ -977,7 +977,7 @@ void RasterizerGLES2::texture_set_data(RID p_texture, const Image &p_image, VS::
 		glTexParameteri(texture->target, GL_TEXTURE_MAG_FILTER, GL_NEAREST); // raw Filtering
 	}
 
-	bool force_clamp_to_edge = !(texture->flags & VS::TEXTURE_FLAG_MIPMAPS && !texture->ignore_mipmaps) && (nearest_power_of_2(texture->alloc_height) != texture->alloc_height || nearest_power_of_2(texture->alloc_width) != texture->alloc_width);
+	bool force_clamp_to_edge = !(texture->flags & VS::TEXTURE_FLAG_MIPMAPS && !texture->ignore_mipmaps) && (next_power_of_2(texture->alloc_height) != texture->alloc_height || next_power_of_2(texture->alloc_width) != texture->alloc_width);
 
 	if (!force_clamp_to_edge && (texture->flags & VS::TEXTURE_FLAG_REPEAT || texture->flags & VS::TEXTURE_FLAG_MIRRORED_REPEAT) && texture->target != GL_TEXTURE_CUBE_MAP) {
 
@@ -1234,7 +1234,7 @@ void RasterizerGLES2::texture_set_flags(RID p_texture, uint32_t p_flags) {
 	uint32_t cube = texture->flags & VS::TEXTURE_FLAG_CUBEMAP;
 	texture->flags = p_flags | cube; // can't remove a cube from being a cube
 
-	bool force_clamp_to_edge = !(p_flags & VS::TEXTURE_FLAG_MIPMAPS && !texture->ignore_mipmaps) && (nearest_power_of_2(texture->alloc_height) != texture->alloc_height || nearest_power_of_2(texture->alloc_width) != texture->alloc_width);
+	bool force_clamp_to_edge = !(p_flags & VS::TEXTURE_FLAG_MIPMAPS && !texture->ignore_mipmaps) && (next_power_of_2(texture->alloc_height) != texture->alloc_height || next_power_of_2(texture->alloc_width) != texture->alloc_width);
 
 	if (!force_clamp_to_edge && (texture->flags & VS::TEXTURE_FLAG_REPEAT || texture->flags & VS::TEXTURE_FLAG_MIRRORED_REPEAT) && texture->target != GL_TEXTURE_CUBE_MAP) {
 
@@ -2701,7 +2701,7 @@ void RasterizerGLES2::multimesh_set_instance_count(RID p_multimesh, int p_count)
 
 	if (use_texture_instancing) {
 
-		if (nearest_power_of_2(p_count) != nearest_power_of_2(multimesh->elements.size())) {
+		if (next_power_of_2(p_count) != next_power_of_2(multimesh->elements.size())) {
 			if (multimesh->tex_id) {
 				glDeleteTextures(1, &multimesh->tex_id);
 				multimesh->tex_id = 0;
@@ -2709,7 +2709,7 @@ void RasterizerGLES2::multimesh_set_instance_count(RID p_multimesh, int p_count)
 
 			if (p_count) {
 
-				uint32_t po2 = nearest_power_of_2(p_count);
+				uint32_t po2 = next_power_of_2(p_count);
 				if (po2 & 0xAAAAAAAA) {
 					//half width
 
@@ -3333,7 +3333,7 @@ void RasterizerGLES2::skeleton_resize(RID p_skeleton, int p_bones) {
 	};
 	if (use_hw_skeleton_xform) {
 
-		if (nearest_power_of_2(p_bones) != nearest_power_of_2(skeleton->bones.size())) {
+		if (next_power_of_2(p_bones) != next_power_of_2(skeleton->bones.size())) {
 			if (skeleton->tex_id) {
 				glDeleteTextures(1, &skeleton->tex_id);
 				skeleton->tex_id = 0;
@@ -3344,7 +3344,7 @@ void RasterizerGLES2::skeleton_resize(RID p_skeleton, int p_bones) {
 				glGenTextures(1, &skeleton->tex_id);
 				glActiveTexture(GL_TEXTURE0);
 				glBindTexture(GL_TEXTURE_2D, skeleton->tex_id);
-				int ps = nearest_power_of_2(p_bones * 3);
+				int ps = next_power_of_2(p_bones * 3);
 #ifdef GLEW_ENABLED
 				glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F, ps, 1, 0, GL_RGBA, GL_FLOAT, skel_default.ptr());
 #else
@@ -3998,7 +3998,7 @@ void RasterizerGLES2::begin_frame() {
 
 		glActiveTexture(GL_TEXTURE0);
 		glBindTexture(GL_TEXTURE_2D, s->tex_id);
-		glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, nearest_power_of_2(s->bones.size() * 3), 1, GL_RGBA, GL_FLOAT, sk_float);
+		glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, next_power_of_2(s->bones.size() * 3), 1, GL_RGBA, GL_FLOAT, sk_float);
 		_skeleton_dirty_list.remove(_skeleton_dirty_list.first());
 	}
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -120,7 +120,7 @@ void RasterizerSceneGLES3::shadow_atlas_set_size(RID p_atlas, int p_size) {
 	ERR_FAIL_COND(!shadow_atlas);
 	ERR_FAIL_COND(p_size < 0);
 
-	p_size = nearest_power_of_2(p_size);
+	p_size = next_power_of_2(p_size);
 
 	if (p_size == shadow_atlas->size)
 		return;
@@ -185,7 +185,7 @@ void RasterizerSceneGLES3::shadow_atlas_set_quadrant_subdivision(RID p_atlas, in
 	ERR_FAIL_INDEX(p_quadrant, 4);
 	ERR_FAIL_INDEX(p_subdivision, 16384);
 
-	uint32_t subdiv = nearest_power_of_2(p_subdivision);
+	uint32_t subdiv = next_power_of_2(p_subdivision);
 	if (subdiv & 0xaaaaaaaa) { //sqrt(subdiv) must be integer
 		subdiv <<= 1;
 	}
@@ -310,7 +310,7 @@ bool RasterizerSceneGLES3::shadow_atlas_update_light(RID p_atlas, RID p_light_in
 	}
 
 	uint32_t quad_size = shadow_atlas->size >> 1;
-	int desired_fit = MIN(quad_size / shadow_atlas->smallest_subdiv, nearest_power_of_2(quad_size * p_coverage));
+	int desired_fit = MIN(quad_size / shadow_atlas->smallest_subdiv, next_power_of_2(quad_size * p_coverage));
 
 	int valid_quadrants[4];
 	int valid_quadrant_count = 0;
@@ -479,7 +479,7 @@ void RasterizerSceneGLES3::reflection_atlas_set_size(RID p_ref_atlas, int p_size
 	ReflectionAtlas *reflection_atlas = reflection_atlas_owner.getornull(p_ref_atlas);
 	ERR_FAIL_COND(!reflection_atlas);
 
-	int size = nearest_power_of_2(p_size);
+	int size = next_power_of_2(p_size);
 
 	if (size == reflection_atlas->size)
 		return;
@@ -554,7 +554,7 @@ void RasterizerSceneGLES3::reflection_atlas_set_subdivision(RID p_ref_atlas, int
 	ReflectionAtlas *reflection_atlas = reflection_atlas_owner.getornull(p_ref_atlas);
 	ERR_FAIL_COND(!reflection_atlas);
 
-	uint32_t subdiv = nearest_power_of_2(p_subdiv);
+	uint32_t subdiv = next_power_of_2(p_subdiv);
 	if (subdiv & 0xaaaaaaaa) { //sqrt(subdiv) must be integer
 		subdiv <<= 1;
 	}
@@ -4757,7 +4757,7 @@ void RasterizerSceneGLES3::initialize() {
 	{
 		//directional light shadow
 		directional_shadow.light_count = 0;
-		directional_shadow.size = nearest_power_of_2(GLOBAL_GET("rendering/quality/directional_shadow/size"));
+		directional_shadow.size = next_power_of_2(GLOBAL_GET("rendering/quality/directional_shadow/size"));
 		glGenFramebuffers(1, &directional_shadow.fbo);
 		glBindFramebuffer(GL_FRAMEBUFFER, directional_shadow.fbo);
 		glGenTextures(1, &directional_shadow.depth);

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -54,7 +54,7 @@ Error AudioDriverPulseAudio::init() {
 	spec.rate = mix_rate;
 
 	int latency = GLOBAL_DEF("audio/output_latency", 25);
-	buffer_size = nearest_power_of_2(latency * mix_rate / 1000);
+	buffer_size = closest_power_of_2(latency * mix_rate / 1000);
 
 	pa_buffer_attr attr;
 	// set to appropriate buffer size from global settings

--- a/drivers/rtaudio/audio_driver_rtaudio.cpp
+++ b/drivers/rtaudio/audio_driver_rtaudio.cpp
@@ -118,7 +118,7 @@ Error AudioDriverRtAudio::init() {
 
 	int latency = GLOBAL_DEF("audio/output_latency", 25);
 	// calculate desired buffer_size, taking the desired numberOfBuffers into account (latency depends on numberOfBuffers*buffer_size)
-	unsigned int buffer_size = nearest_power_of_2(latency * mix_rate / 1000 / target_number_of_buffers);
+	unsigned int buffer_size = closest_power_of_2(latency * mix_rate / 1000 / target_number_of_buffers);
 
 	if (OS::get_singleton()->is_stdout_verbose()) {
 		print_line("audio buffer size: " + itos(buffer_size));

--- a/drivers/xaudio2/audio_driver_xaudio2.cpp
+++ b/drivers/xaudio2/audio_driver_xaudio2.cpp
@@ -50,7 +50,7 @@ Error AudioDriverXAudio2::init() {
 	channels = 2;
 
 	int latency = GLOBAL_DEF("audio/output_latency", 25);
-	buffer_size = nearest_power_of_2(latency * mix_rate / 1000);
+	buffer_size = closest_power_of_2(latency * mix_rate / 1000);
 
 	samples_in = memnew_arr(int32_t, buffer_size * channels);
 	for (int i = 0; i < AUDIO_BUFFERS; i++) {

--- a/editor/io_plugins/editor_font_import_plugin.cpp
+++ b/editor/io_plugins/editor_font_import_plugin.cpp
@@ -1536,8 +1536,8 @@ Ref<BitmapFont> EditorFontImportPlugin::generate_font(const Ref<ResourceImportMe
 	Vector<Point2i> res;
 	Size2i res_size;
 	EditorAtlas::fit(sizes,res,res_size);
-	res_size.x=nearest_power_of_2(res_size.x);
-	res_size.y=nearest_power_of_2(res_size.y);
+	res_size.x=next_power_of_2(res_size.x);
+	res_size.y=next_power_of_2(res_size.y);
 	print_line("Atlas size: "+res_size);
 
 	Image atlas(res_size.x,res_size.y,0,Image::FORMAT_RGBA8);

--- a/editor/io_plugins/editor_texture_import_plugin.cpp
+++ b/editor/io_plugins/editor_texture_import_plugin.cpp
@@ -1280,8 +1280,8 @@ Error EditorTextureImportPlugin::import2(const String& p_path, const Ref<Resourc
 		int atlas_w=dst_size.width;
 		int atlas_h=dst_size.height;
 		if (blit_to_po2) {
-			atlas_w=nearest_power_of_2(dst_size.width);
-			atlas_h=nearest_power_of_2(dst_size.height);
+			atlas_w=next_power_of_2(dst_size.width);
+			atlas_h=next_power_of_2(dst_size.height);
 		}
 		Image atlas;
 		atlas.create(atlas_w,atlas_h,0,alpha?Image::FORMAT_RGBA8:Image::FORMAT_RGB8);

--- a/editor/plugins/baked_light_baker.cpp
+++ b/editor/plugins/baked_light_baker.cpp
@@ -1460,7 +1460,7 @@ void BakedLightBaker::_make_octree_texture() {
 		} else {
 
 			baked_light_texture_w=otex_w;
-			baked_light_texture_h=nearest_power_of_2(row);
+			baked_light_texture_h=next_power_of_2(row);
 			print_line("w: "+itos(otex_w));
 			print_line("h: "+itos(row));
 			break;
@@ -1558,7 +1558,7 @@ void BakedLightBaker::_make_octree_texture() {
 	}
 
 
-	baked_octree_texture_h=nearest_power_of_2(baked_octree_texture_h);
+	baked_octree_texture_h=next_power_of_2(baked_octree_texture_h);
 	print_line("RESULT! "+itos(baked_octree_texture_w)+","+itos(baked_octree_texture_h));
 
 }

--- a/modules/etc/image_etc.cpp
+++ b/modules/etc/image_etc.cpp
@@ -118,7 +118,7 @@ static void _compress_etc(Image *p_img, float p_lossy_quality, bool force_etc1_f
 	}
 
 	int imgw = p_img->get_width(), imgh = p_img->get_height();
-	ERR_FAIL_COND(nearest_power_of_2(imgw) != imgw || nearest_power_of_2(imgh) != imgh);
+	ERR_FAIL_COND(next_power_of_2(imgw) != imgw || next_power_of_2(imgh) != imgh);
 
 	Image::Format etc_format = force_etc1_format ? Image::FORMAT_ETC : _get_etc2_mode(detected_channels);
 

--- a/modules/gdscript/gd_functions.cpp
+++ b/modules/gdscript/gd_functions.cpp
@@ -446,7 +446,7 @@ void GDFunctions::call(Function p_func, const Variant **p_args, int p_arg_count,
 			VALIDATE_ARG_COUNT(1);
 			VALIDATE_ARG_NUM(0);
 			int64_t num = *p_args[0];
-			r_ret = nearest_power_of_2(num);
+			r_ret = next_power_of_2(num);
 		} break;
 		case OBJ_WEAKREF: {
 			VALIDATE_ARG_COUNT(1);

--- a/modules/visual_script/visual_script_builtin_funcs.cpp
+++ b/modules/visual_script/visual_script_builtin_funcs.cpp
@@ -915,7 +915,7 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 
 			VALIDATE_ARG_NUM(0);
 			int64_t num = *p_inputs[0];
-			*r_return = nearest_power_of_2(num);
+			*r_return = next_power_of_2(num);
 		} break;
 		case VisualScriptBuiltinFunc::OBJ_WEAKREF: {
 

--- a/platform/android/audio_driver_jandroid.cpp
+++ b/platform/android/audio_driver_jandroid.cpp
@@ -81,7 +81,7 @@ Error AudioDriverAndroid::init() {
 
 	int latency = GLOBAL_DEF("audio/output_latency", 25);
 	latency = 50;
-	unsigned int buffer_size = nearest_power_of_2(latency * mix_rate / 1000);
+	unsigned int buffer_size = next_power_of_2(latency * mix_rate / 1000);
 	if (OS::get_singleton()->is_stdout_verbose()) {
 		print_line("audio buffer size: " + itos(buffer_size));
 	}

--- a/platform/haiku/audio_driver_media_kit.cpp
+++ b/platform/haiku/audio_driver_media_kit.cpp
@@ -43,7 +43,7 @@ Error AudioDriverMediaKit::init() {
 	channels = 2;
 
 	int latency = GLOBAL_DEF("audio/output_latency", 25);
-	buffer_size = nearest_power_of_2(latency * mix_rate / 1000);
+	buffer_size = next_power_of_2(latency * mix_rate / 1000);
 	samples_in = memnew_arr(int32_t, buffer_size * channels);
 
 	media_raw_audio_format format;

--- a/platform/osx/audio_driver_osx.h
+++ b/platform/osx/audio_driver_osx.h
@@ -44,9 +44,11 @@ class AudioDriverOSX : public AudioDriver {
 	bool active;
 	Mutex *mutex;
 
+	int mix_rate;
 	int channels;
-	int32_t *samples_in;
 	int buffer_frames;
+
+	Vector<int32_t> samples_in;
 
 	static OSStatus output_callback(void *inRefCon,
 			AudioUnitRenderActionFlags *ioActionFlags,

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -524,7 +524,7 @@ void DynamicFontAtSize::_update_char(CharType p_char) {
 		if (mh > texsize)
 			texsize = mh; //special case, adapt to it?
 
-		texsize = nearest_power_of_2(texsize);
+		texsize = next_power_of_2(texsize);
 
 		texsize = MIN(texsize, 4096);
 

--- a/scene/resources/dynamic_font_stb.cpp
+++ b/scene/resources/dynamic_font_stb.cpp
@@ -289,7 +289,7 @@ void DynamicFontAtSize::_update_char(CharType p_char) {
 		if (mh > texsize)
 			texsize = mh; //special case, adapt to it?
 
-		texsize = nearest_power_of_2(texsize);
+		texsize = next_power_of_2(texsize);
 
 		texsize = MIN(texsize, 4096);
 

--- a/servers/audio/audio_driver_dummy.cpp
+++ b/servers/audio/audio_driver_dummy.cpp
@@ -45,7 +45,7 @@ Error AudioDriverDummy::init() {
 	channels = 2;
 
 	int latency = GLOBAL_DEF("audio/output_latency", 25);
-	buffer_size = nearest_power_of_2(latency * mix_rate / 1000);
+	buffer_size = next_power_of_2(latency * mix_rate / 1000);
 
 	samples_in = memnew_arr(int32_t, buffer_size * channels);
 

--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -1001,11 +1001,11 @@ void VisualServerCanvas::canvas_light_set_shadow_buffer_size(RID p_light, int p_
 	RasterizerCanvas::Light *clight = canvas_light_owner.get(p_light);
 	ERR_FAIL_COND(!clight);
 
-	int new_size = nearest_power_of_2(p_size);
+	int new_size = next_power_of_2(p_size);
 	if (new_size == clight->shadow_buffer_size)
 		return;
 
-	clight->shadow_buffer_size = nearest_power_of_2(p_size);
+	clight->shadow_buffer_size = next_power_of_2(p_size);
 
 	if (clight->shadow_buffer.is_valid()) {
 		VSG::storage->free(clight->shadow_buffer);

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -4376,7 +4376,7 @@ void VisualServerRaster::canvas_light_set_shadow_buffer_size(RID p_light, int p_
 
 	ERR_FAIL_COND(p_size<32 || p_size>16384);
 
-	clight->shadow_buffer_size=nearest_power_of_2(p_size);
+	clight->shadow_buffer_size=next_power_of_2(p_size);
 
 
 	if (clight->shadow_buffer.is_valid()) {


### PR DESCRIPTION
This PR does the following:

- Add two new functions on core/typedefs.h: previous_power_of_2 and closest_power_of_2.
- Rename nearest_power_of_2 to next_power_of_2.
- Implement mix_rate and latency settings on the OS X audio driver.
- Change samples_in from int32_t * to Vector<int32_t> for easier resizing of the array, on the OS X audio driver.
- Clean a bit the OS X audio driver code and add a missing kAudioUnitProperty_SetRenderCallback on the AudioDriverOSX::finish function to clear the callback.
- Use the new closest_power_of_2 function when calculating the buffer_size on the audio drivers.

Note/explanation: I've changed the name of nearest_power_of_2 to next_power_of_2 since it will always get the next power of 2. I found this out while implementing the latency setting on the OS X audio driver, the most common math for the buffer_size is: 25 * 44100 / 1000 (latency * mix_rate / 1000), which gives 1102, when calling nearest_power_of_2 it returned 2048 which is the next power of 2 (instead of 1024 which I was expecting), so that's why I added closest_power_of_2 which returns 1024 when called with 1102.