### PR TITLE
Implement texture UV transpose in the gles3 renderer

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -574,6 +574,7 @@ void RasterizerCanvasGLES3::_canvas_item_render_commands(Item *p_item, Item *cur
 
 					Size2 texpixel_size(1.0 / texture->width, 1.0 / texture->height);
 					Rect2 src_rect = (rect->flags & CANVAS_RECT_REGION) ? Rect2(rect->source.position * texpixel_size, rect->source.size * texpixel_size) : Rect2(0, 0, 1, 1);
+					Rect2 dst_rect = Rect2(rect->rect.position, rect->rect.size);
 
 					if (rect->flags & CANVAS_RECT_FLIP_H) {
 						src_rect.size.x *= -1;
@@ -584,12 +585,12 @@ void RasterizerCanvasGLES3::_canvas_item_render_commands(Item *p_item, Item *cur
 					}
 
 					if (rect->flags & CANVAS_RECT_TRANSPOSE) {
-						//err..
+						dst_rect.size.x *= -1; // Encoding in the dst_rect.z uniform
 					}
 
 					state.canvas_shader.set_uniform(CanvasShaderGLES3::COLOR_TEXPIXEL_SIZE, texpixel_size);
 
-					state.canvas_shader.set_uniform(CanvasShaderGLES3::DST_RECT, Color(rect->rect.position.x, rect->rect.position.y, rect->rect.size.x, rect->rect.size.y));
+					state.canvas_shader.set_uniform(CanvasShaderGLES3::DST_RECT, Color(dst_rect.position.x, dst_rect.position.y, dst_rect.size.x, dst_rect.size.y));
 					state.canvas_shader.set_uniform(CanvasShaderGLES3::SRC_RECT, Color(src_rect.position.x, src_rect.position.y, src_rect.size.x, src_rect.size.y));
 					state.canvas_shader.set_uniform(CanvasShaderGLES3::CLIP_RECT_UV, (rect->flags & CANVAS_RECT_CLIP_UV) ? true : false);
 
@@ -1207,11 +1208,7 @@ void RasterizerCanvasGLES3::canvas_render_items(Item *p_item_list, int p_z, cons
 			last_blend_mode = blend_mode;
 		}
 
-		state.canvas_item_modulate = unshaded ? ci->final_modulate : Color(
-																			 ci->final_modulate.r * p_modulate.r,
-																			 ci->final_modulate.g * p_modulate.g,
-																			 ci->final_modulate.b * p_modulate.b,
-																			 ci->final_modulate.a * p_modulate.a);
+		state.canvas_item_modulate = unshaded ? ci->final_modulate : Color(ci->final_modulate.r * p_modulate.r, ci->final_modulate.g * p_modulate.g, ci->final_modulate.b * p_modulate.b, ci->final_modulate.a * p_modulate.a);
 
 		state.final_transform = ci->final_transform;
 		state.extra_matrix = Transform2D();

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -116,9 +116,12 @@ void main() {
 
 #ifdef USE_TEXTURE_RECT
 
-
-	uv_interp = src_rect.xy + abs(src_rect.zw) * vertex;
-	highp vec4 outvec = vec4(dst_rect.xy + dst_rect.zw * mix(vertex,vec2(1.0,1.0)-vertex,lessThan(src_rect.zw,vec2(0.0,0.0))),0.0,1.0);
+	if (dst_rect.z < 0) { // Transpose is encoded as negative dst_rect.z
+		uv_interp = src_rect.xy + abs(src_rect.zw) * vertex.yx;
+	} else {
+		uv_interp = src_rect.xy + abs(src_rect.zw) * vertex;
+	}
+	highp vec4 outvec = vec4(dst_rect.xy + abs(dst_rect.zw) * mix(vertex,vec2(1.0,1.0)-vertex,lessThan(src_rect.zw,vec2(0.0,0.0))),0.0,1.0);
 
 #else
 	uv_interp = uv_attrib;


### PR DESCRIPTION
Now tilemap rotations work again!
Here is a screen:
![image](https://user-images.githubusercontent.com/5276727/29456198-59bbe520-841d-11e7-9e46-3c9c221838bf.png)