### PR TITLE
TextEdit: Fix line padding triggering too early.

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -436,7 +436,7 @@ void TextEdit::_notification(int p_what) {
 			int line_number_char_count = 0;
 
 			{
-				int lc = text.size() + 1;
+				int lc = text.size();
 				cache.line_number_w = 0;
 				while (lc) {
 					cache.line_number_w += 1;


### PR DESCRIPTION
off-by-one error in the line count calculation.

Fixes #10411