### PR TITLE
Set the X11 class hint before mapping the window

### DIFF
--- a/platform/x11/context_gl_x11.cpp
+++ b/platform/x11/context_gl_x11.cpp
@@ -83,6 +83,19 @@ static int ctxErrorHandler(Display *dpy, XErrorEvent *ev) {
 	return 0;
 }
 
+static void set_class_hint(Display *p_display, Window p_window) {
+	XClassHint *classHint;
+
+	/* set the name and class hints for the window manager to use */
+	classHint = XAllocClassHint();
+	if (classHint) {
+		classHint->res_name = (char *)"Godot_Engine";
+		classHint->res_class = (char *)"Godot";
+	}
+	XSetClassHint(p_display, p_window, classHint);
+	XFree(classHint);
+}
+
 Error ContextGL_X11::initialize() {
 
 	GLXCREATECONTEXTATTRIBSARBPROC glXCreateContextAttribsARB = NULL;
@@ -127,6 +140,7 @@ Error ContextGL_X11::initialize() {
 	*/
 	x11_window = XCreateWindow(x11_display, RootWindow(x11_display, vi->screen), 0, 0, OS::get_singleton()->get_video_mode().width, OS::get_singleton()->get_video_mode().height, 0, vi->depth, InputOutput, vi->visual, CWBorderPixel | CWColormap | CWEventMask, &swa);
 	ERR_FAIL_COND_V(!x11_window, ERR_UNCONFIGURED);
+	set_class_hint(x11_display, x11_window);
 	XMapWindow(x11_display, x11_window);
 	//};
 

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -351,19 +351,8 @@ void OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_au
 
 	XChangeWindowAttributes(x11_display, x11_window, CWEventMask, &new_attr);
 
-	XClassHint *classHint;
-
 	/* set the titlebar name */
 	XStoreName(x11_display, x11_window, "Godot");
-
-	/* set the name and class hints for the window manager to use */
-	classHint = XAllocClassHint();
-	if (classHint) {
-		classHint->res_name = (char *)"Godot_Engine";
-		classHint->res_class = (char *)"Godot";
-	}
-	XSetClassHint(x11_display, x11_window, classHint);
-	XFree(classHint);
 
 	wm_delete = XInternAtom(x11_display, "WM_DELETE_WINDOW", true);
 	XSetWMProtocols(x11_display, x11_window, &wm_delete, 1);


### PR DESCRIPTION
Setting the class hint before mapping the window will allow some
window managers to determine if a window should be treated specially.
This is also in accordance with the ICCCM spec which says that
WM_CLASS should only be changed when a window is in a
withdrawn (unmapped) state.

Fixes #10429