### PR TITLE
Quit after command-line export

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -371,6 +371,7 @@ void EditorNode::_fs_changed() {
 			if (preset->get_name() == export_defer.preset) {
 				break;
 			}
+			preset.unref();
 		}
 		if (preset.is_null()) {
 			String err = "Unknown export preset: " + export_defer.preset;
@@ -385,7 +386,7 @@ void EditorNode::_fs_changed() {
 			}
 		}
 
-		export_defer.preset = "";
+		get_tree()->quit();
 	}
 
 	{


### PR DESCRIPTION
Continuing what was discussed in #10337. Also fixes the bug with the last preset being selected if the name is incorrect.