### PR TITLE
Fix emission calculation for spatial shader

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -418,7 +418,7 @@ void SpatialMaterial::_update_shader() {
 
 	if (features[FEATURE_EMISSION]) {
 
-		code += "uniform sampler2D texture_emission : hint_black_albedo;\n";
+		code += "uniform sampler2D texture_emission : hint_white_albedo;\n";
 		code += "uniform vec4 emission : hint_color;\n";
 		code += "uniform float emission_energy;\n";
 	}
@@ -708,7 +708,7 @@ void SpatialMaterial::_update_shader() {
 		} else {
 			code += "\tvec3 emission_tex = texture(texture_emission,base_uv).rgb;\n";
 		}
-		code += "\tEMISSION = (emission.rgb+emission_tex)*emission_energy;\n";
+		code += "\tEMISSION = emission.rgb*emission_tex*emission_energy;\n";
 	}
 
 	if (features[FEATURE_REFRACTION] && !flags[FLAG_UV1_USE_TRIPLANAR]) { //refraction not supported with triplanar

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -417,8 +417,11 @@ void SpatialMaterial::_update_shader() {
 	}
 
 	if (features[FEATURE_EMISSION]) {
-
-		code += "uniform sampler2D texture_emission : hint_white_albedo;\n";
+		if (flags[FLAG_EMISSION_MULTIPLY]) {
+			code += "uniform sampler2D texture_emission : hint_white_albedo;\n";
+		} else {
+			code += "uniform sampler2D texture_emission : hint_black_albedo;\n";
+		}
 		code += "uniform vec4 emission : hint_color;\n";
 		code += "uniform float emission_energy;\n";
 	}
@@ -708,7 +711,11 @@ void SpatialMaterial::_update_shader() {
 		} else {
 			code += "\tvec3 emission_tex = texture(texture_emission,base_uv).rgb;\n";
 		}
-		code += "\tEMISSION = emission.rgb*emission_tex*emission_energy;\n";
+		if (flags[FLAG_EMISSION_MULTIPLY]) {
+			code += "\tEMISSION = emission.rgb*emission_tex*emission_energy;\n";
+		} else {
+			code += "\tEMISSION = (emission.rgb+emission_tex)*emission_energy;\n";
+		}
 	}
 
 	if (features[FEATURE_REFRACTION] && !flags[FLAG_UV1_USE_TRIPLANAR]) { //refraction not supported with triplanar
@@ -1722,6 +1729,7 @@ void SpatialMaterial::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "emission", PROPERTY_HINT_COLOR_NO_ALPHA), "set_emission", "get_emission");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "emission_energy", PROPERTY_HINT_RANGE, "0,16,0.01"), "set_emission_energy", "get_emission_energy");
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "emission_texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_texture", "get_texture", TEXTURE_EMISSION);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "emission_multiply"), "set_flag", "get_flag", FLAG_EMISSION_MULTIPLY);
 
 	ADD_GROUP("NormalMap", "normal_");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "normal_enabled"), "set_feature", "get_feature", FEATURE_NORMAL_MAPPING);
@@ -1856,6 +1864,7 @@ void SpatialMaterial::_bind_methods() {
 	BIND_ENUM_CONSTANT(FLAG_AO_ON_UV2);
 	BIND_ENUM_CONSTANT(FLAG_USE_ALPHA_SCISSOR);
 	BIND_ENUM_CONSTANT(FLAG_TRIPLANAR_USE_WORLD);
+	BIND_ENUM_CONSTANT(FLAG_EMISSION_MULTIPLY);
 	BIND_ENUM_CONSTANT(FLAG_MAX);
 
 	BIND_ENUM_CONSTANT(DIFFUSE_LAMBERT);

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -181,6 +181,7 @@ public:
 		FLAG_TRIPLANAR_USE_WORLD,
 		FLAG_AO_ON_UV2,
 		FLAG_USE_ALPHA_SCISSOR,
+		FLAG_EMISSION_MULTIPLY,
 		FLAG_MAX
 	};
 
@@ -224,7 +225,7 @@ private:
 			uint64_t blend_mode : 2;
 			uint64_t depth_draw_mode : 2;
 			uint64_t cull_mode : 2;
-			uint64_t flags : 12;
+			uint64_t flags : 13;
 			uint64_t detail_blend_mode : 2;
 			uint64_t diffuse_mode : 3;
 			uint64_t specular_mode : 2;


### PR DESCRIPTION
I think, that current emission calculation is incorrect, or at least not convenient.
Current logic sums color and value from texture. That means, that you can't use texture as mask to make some parts of mesh emitting. Or you can use black color on texture to not emit, but color become useless. And you can't use it as tint to colorize emission.

I suggest to use texture as mask by multiplying it with color instead of summation.

Also I changed hint color for case, when you don't need a texture.