### PR TITLE
Performance improvement for new styleBoxFlat.

### DIFF
--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -514,6 +514,7 @@ inline void draw_ring(Vector<Vector2> &verts, Vector<int> &indices, Vector<Color
 	if (!vert_offset) {
 		vert_offset = 0;
 	}
+	int adapted_corner_detail = (corner_radius[0] == 0 && corner_radius[1] == 0 && corner_radius[2] == 0 && corner_radius[3] == 0) ? 1 : corner_detail;
 	int rings = (border_width[0] == 0 && border_width[1] == 0 && border_width[2] == 0 && border_width[3] == 0) ? 1 : 2;
 	rings = 2;
 
@@ -540,7 +541,7 @@ inline void draw_ring(Vector<Vector2> &verts, Vector<int> &indices, Vector<Color
 
 	//calculate the vert array
 	for (int corner_index = 0; corner_index < 4; corner_index++) {
-		for (int detail = 0; detail <= corner_detail; detail++) {
+		for (int detail = 0; detail <= adapted_corner_detail; detail++) {
 			for (int inner_outer = (2 - rings); inner_outer < 2; inner_outer++) {
 				float radius;
 				Color color;
@@ -554,8 +555,8 @@ inline void draw_ring(Vector<Vector2> &verts, Vector<int> &indices, Vector<Color
 					color = *outer_color;
 					corner_point = outer_points[corner_index];
 				}
-				float x = radius * (float)cos((double)corner_index * Math_PI / 2.0 + (double)detail / (double)corner_detail * Math_PI / 2.0 + Math_PI) + corner_point.x;
-				float y = radius * (float)sin((double)corner_index * Math_PI / 2.0 + (double)detail / (double)corner_detail * Math_PI / 2.0 + Math_PI) + corner_point.y;
+				float x = radius * (float)cos((double)corner_index * Math_PI / 2.0 + (double)detail / (double)adapted_corner_detail * Math_PI / 2.0 + Math_PI) + corner_point.x;
+				float y = radius * (float)sin((double)corner_index * Math_PI / 2.0 + (double)detail / (double)adapted_corner_detail * Math_PI / 2.0 + Math_PI) + corner_point.y;
 				verts.push_back(Vector2(x, y));
 				colors.push_back(color);
 			}
@@ -563,7 +564,7 @@ inline void draw_ring(Vector<Vector2> &verts, Vector<int> &indices, Vector<Color
 	}
 
 	if (rings == 2) {
-		int vert_count = (corner_detail + 1) * 4 * rings;
+		int vert_count = (adapted_corner_detail + 1) * 4 * rings;
 		//fill the indices and the colors for the border
 		for (int i = 0; i < vert_count; i++) {
 			//poly 1


### PR DESCRIPTION
style box flat was always drawn with 8 verts per corner in case it was a rounded corner... now it uses only one vert if it has norounded corner.