### PR TITLE
styleBoxFlat: clamp corner_detail + aa_size

### DIFF
--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -463,7 +463,7 @@ bool StyleBoxFlat::is_anti_aliased() const {
 }
 
 void StyleBoxFlat::set_aa_size(const int &p_aa_size) {
-	aa_size = p_aa_size;
+	aa_size = CLAMP(p_aa_size, 1, 5);
 	emit_changed();
 }
 int StyleBoxFlat::get_aa_size() const {
@@ -471,7 +471,7 @@ int StyleBoxFlat::get_aa_size() const {
 }
 
 void StyleBoxFlat::set_corner_detail(const int &p_corner_detail) {
-	corner_detail = p_corner_detail;
+	corner_detail = CLAMP(p_corner_detail, 1, 128);
 	emit_changed();
 }
 int StyleBoxFlat::get_corner_detail() const {
@@ -776,7 +776,7 @@ void StyleBoxFlat::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "corner_radius_bottom_right", PROPERTY_HINT_RANGE, "0,1024,1"), "set_corner_radius", "get_corner_radius", CORNER_BOTTOM_RIGHT);
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "corner_radius_bottom_left", PROPERTY_HINT_RANGE, "0,1024,1"), "set_corner_radius", "get_corner_radius", CORNER_BOTTOM_LEFT);
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "corner_detail"), "set_corner_detail", "get_corner_detail");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "corner_detail", PROPERTY_HINT_RANGE, "1,128,1"), "set_corner_detail", "get_corner_detail");
 
 	ADD_GROUP("Expand Margin", "expand_margin_");
 	ADD_PROPERTYI(PropertyInfo(Variant::REAL, "expand_margin_left", PROPERTY_HINT_RANGE, "0,2048,1"), "set_expand_margin", "get_expand_margin", MARGIN_LEFT);


### PR DESCRIPTION
fixes the option too choose dumb/broken values for aasize and corner_detail.

ping @Calinou 