### PR TITLE
Switch back to project folder after making data folder

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -373,8 +373,14 @@ OS::ScreenOrientation OS::get_screen_orientation() const {
 void OS::_ensure_data_dir() {
 
 	String dd = get_data_dir();
-	DirAccess *da = DirAccess::open(dd);
+	DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	String current_dir = da->get_current_dir();
+
+	memdelete(da);
+
+	da = DirAccess::open(dd);
 	if (da) {
+		da->change_dir(current_dir);
 		memdelete(da);
 		return;
 	}
@@ -385,6 +391,8 @@ void OS::_ensure_data_dir() {
 		ERR_EXPLAIN("Error attempting to create data dir: " + dd);
 	}
 	ERR_FAIL_COND(err != OK);
+
+	da->change_dir(current_dir);
 
 	memdelete(da);
 }


### PR DESCRIPTION
This is in reference to #10454 

I believe I found the real root of the problem. There was a new bug exposed due to the bug fix in #8144 where the directory would never actually switch on *nix systems in the DirAccessUnix::change_dir function, but now does as intended.

So, the cause of the problem is that OS::_ensure_data_dir would create the data directory such as "/home/nathan/.godot/MyGodotProject" and then change to it and keep it as the current directory. The previous behavior is that it would stay in the current directory such as "/home/nathan/Projects/MyGodotProject". So, in my particular case it was looking for the C# assembly in the .godot user data directory instead of the project directory as it was correctly doing before.

What this code does is caches the current project directory location and then switches back to it once the data directory is created. This maintains the previous behavior while not reintroducing the previous bug. If the desired behavior is that the current directory be the project's directory in the editor then this fix should be the correct one. If the desired behavior is that the data directory should persist as the current directory and that the project directory should be switched to when loading C# assemblies or other files, then this is not the correct fix.

Here's a 6 minute screen recording in case you would like to see the issue in action.
https://drive.google.com/open?id=0B8iCxych7qVBdTlFVDNnc3BrNGc

Thanks!