### PR TITLE
Third take at making command-line arguments more UNIX-like + main.cpp and help cleanup

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2534,11 +2534,6 @@ float _Engine::get_frames_per_second() const {
 	return Engine::get_singleton()->get_frames_per_second();
 }
 
-String _Engine::get_custom_level() const {
-
-	return Engine::get_singleton()->get_custom_level();
-}
-
 void _Engine::set_time_scale(float p_scale) {
 	Engine::get_singleton()->set_time_scale(p_scale);
 }
@@ -2587,8 +2582,6 @@ void _Engine::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_time_scale", "time_scale"), &_Engine::set_time_scale);
 	ClassDB::bind_method(D_METHOD("get_time_scale"), &_Engine::get_time_scale);
-
-	ClassDB::bind_method(D_METHOD("get_custom_level"), &_Engine::get_custom_level);
 
 	ClassDB::bind_method(D_METHOD("get_frames_drawn"), &_Engine::get_frames_drawn);
 	ClassDB::bind_method(D_METHOD("get_frames_per_second"), &_Engine::get_frames_per_second);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -639,8 +639,6 @@ public:
 	void set_time_scale(float p_scale);
 	float get_time_scale();
 
-	String get_custom_level() const;
-
 	MainLoop *get_main_loop() const;
 
 	Dictionary get_version_info() const;

--- a/core/engine.h
+++ b/core/engine.h
@@ -39,7 +39,6 @@ class Engine {
 
 	friend class Main;
 
-	String _custom_level;
 	uint64_t frames_drawn;
 	uint32_t _frame_delay;
 	uint64_t _frame_ticks;
@@ -69,8 +68,6 @@ public:
 	virtual float get_target_fps() const;
 
 	virtual float get_frames_per_second() const { return _fps; }
-
-	String get_custom_level() const { return _custom_level; }
 
 	uint64_t get_frames_drawn();
 

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -14960,13 +14960,6 @@
 	<description>
 	</description>
 	<methods>
-		<method name="get_custom_level" qualifiers="const">
-			<return type="String">
-			</return>
-			<description>
-				Returns the value of the commandline argument "-level".
-			</description>
-		</method>
 		<method name="get_frames_drawn">
 			<return type="int">
 			</return>

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -229,17 +229,17 @@ void EditorExportPlatform::gen_debug_flags(Vector<String> &r_flags, int p_flags)
 	if (p_flags & DEBUG_FLAG_DUMB_CLIENT) {
 		int port = EditorSettings::get_singleton()->get("filesystem/file_server/port");
 		String passwd = EditorSettings::get_singleton()->get("filesystem/file_server/password");
-		r_flags.push_back("-rfs");
+		r_flags.push_back("--remote-fs");
 		r_flags.push_back(host + ":" + itos(port));
 		if (passwd != "") {
-			r_flags.push_back("-rfs_pass");
+			r_flags.push_back("--remote-fs-password");
 			r_flags.push_back(passwd);
 		}
 	}
 
 	if (p_flags & DEBUG_FLAG_REMOTE_DEBUG) {
 
-		r_flags.push_back("-rdebug");
+		r_flags.push_back("--remote-debug");
 
 		r_flags.push_back(host + ":" + String::num(remote_port));
 
@@ -248,7 +248,7 @@ void EditorExportPlatform::gen_debug_flags(Vector<String> &r_flags, int p_flags)
 
 		if (breakpoints.size()) {
 
-			r_flags.push_back("-bp");
+			r_flags.push_back("--breakpoints");
 			String bpoints;
 			for (const List<String>::Element *E = breakpoints.front(); E; E = E->next()) {
 
@@ -263,12 +263,12 @@ void EditorExportPlatform::gen_debug_flags(Vector<String> &r_flags, int p_flags)
 
 	if (p_flags & DEBUG_FLAG_VIEW_COLLISONS) {
 
-		r_flags.push_back("-debugcol");
+		r_flags.push_back("--debug-collisions");
 	}
 
 	if (p_flags & DEBUG_FLAG_VIEW_NAVIGATION) {
 
-		r_flags.push_back("-debugnav");
+		r_flags.push_back("--debug-navigation");
 	}
 }
 
@@ -714,17 +714,17 @@ void EditorExportPlatform::gen_export_flags(Vector<String> &r_flags, int p_flags
 	if (p_flags & DEBUG_FLAG_DUMB_CLIENT) {
 		int port = EditorSettings::get_singleton()->get("filesystem/file_server/port");
 		String passwd = EditorSettings::get_singleton()->get("filesystem/file_server/password");
-		r_flags.push_back("-rfs");
+		r_flags.push_back("--remote-fs");
 		r_flags.push_back(host + ":" + itos(port));
 		if (passwd != "") {
-			r_flags.push_back("-rfs_pass");
+			r_flags.push_back("--remote-fs-password");
 			r_flags.push_back(passwd);
 		}
 	}
 
 	if (p_flags & DEBUG_FLAG_REMOTE_DEBUG) {
 
-		r_flags.push_back("-rdebug");
+		r_flags.push_back("--remote-debug");
 
 		r_flags.push_back(host + ":" + String::num(remote_port));
 
@@ -733,7 +733,7 @@ void EditorExportPlatform::gen_export_flags(Vector<String> &r_flags, int p_flags
 
 		if (breakpoints.size()) {
 
-			r_flags.push_back("-bp");
+			r_flags.push_back("--breakpoints");
 			String bpoints;
 			for (const List<String>::Element *E = breakpoints.front(); E; E = E->next()) {
 
@@ -748,12 +748,12 @@ void EditorExportPlatform::gen_export_flags(Vector<String> &r_flags, int p_flags
 
 	if (p_flags & DEBUG_FLAG_VIEW_COLLISONS) {
 
-		r_flags.push_back("-debugcol");
+		r_flags.push_back("--debug-collisions");
 	}
 
 	if (p_flags & DEBUG_FLAG_VIEW_NAVIGATION) {
 
-		r_flags.push_back("-debugnav");
+		r_flags.push_back("--debug-navigation");
 	}
 }
 EditorExportPlatform::EditorExportPlatform() {
@@ -2231,17 +2231,17 @@ void EditorExportPlatform::gen_export_flags(Vector<String> &r_flags, int p_flags
 	if (p_flags&EXPORT_DUMB_CLIENT) {
 		int port = EditorSettings::get_singleton()->get("filesystem/file_server/port");
 		String passwd = EditorSettings::get_singleton()->get("filesystem/file_server/password");
-		r_flags.push_back("-rfs");
+		r_flags.push_back("--remote-fs");
 		r_flags.push_back(host+":"+itos(port));
 		if (passwd!="") {
-			r_flags.push_back("-rfs_pass");
+			r_flags.push_back("--remote-fs-password");
 			r_flags.push_back(passwd);
 		}
 	}
 
 	if (p_flags&EXPORT_REMOTE_DEBUG) {
 
-		r_flags.push_back("-rdebug");
+		r_flags.push_back("--remote-debug");
 
 		r_flags.push_back(host+":"+String::num(remote_port));
 
@@ -2251,7 +2251,7 @@ void EditorExportPlatform::gen_export_flags(Vector<String> &r_flags, int p_flags
 
 		if (breakpoints.size()) {
 
-			r_flags.push_back("-bp");
+			r_flags.push_back("--breakpoints");
 			String bpoints;
 			for(const List<String>::Element *E=breakpoints.front();E;E=E->next()) {
 
@@ -2267,12 +2267,12 @@ void EditorExportPlatform::gen_export_flags(Vector<String> &r_flags, int p_flags
 
 	if (p_flags&EXPORT_VIEW_COLLISONS) {
 
-		r_flags.push_back("-debugcol");
+		r_flags.push_back("--debug-collisions");
 	}
 
 	if (p_flags&EXPORT_VIEW_NAVIGATION) {
 
-		r_flags.push_back("-debugnav");
+		r_flags.push_back("--debug-navigation");
 	}
 
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1851,47 +1851,6 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 	_playing_edited = p_current;
 }
 
-void EditorNode::_cleanup_scene() {
-
-#if 0
-	Node *scene = editor_data.get_edited_scene_root();
-	editor_selection->clear();
-	editor_data.clear_editor_states();
-	editor_history.clear();
-	_hide_top_editors();
-	animation_editor->cleanup();
-	property_editor->edit(NULL);
-	resources_dock->cleanup();
-	scene_import_metadata.unref();
-	//set_edited_scene(NULL);
-	if (scene) {
-		if (scene->get_filename()!="") {
-			previous_scenes.push_back(scene->get_filename());
-		}
-
-		memdelete(scene);
-	}
-	editor_data.get_undo_redo().clear_history();
-	saved_version=editor_data.get_undo_redo().get_version();
-	run_settings_dialog->set_run_mode(0);
-	run_settings_dialog->set_custom_arguments("-l $scene");
-
-	List<Ref<Resource> > cached;
-	ResourceCache::get_cached_resources(&cached);
-
-	for(List<Ref<Resource> >::Element *E=cached.front();E;E=E->next()) {
-
-		String path = E->get()->get_path();
-		if (path.is_resource_file()) {
-			ERR_PRINT(("Stray resource not cleaned:"+path).utf8().get_data());
-		}
-
-	}
-
-	_update_title();
-#endif
-}
-
 void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 	//print_line("option "+itos(p_option)+" confirm "+itos(p_confirmed));
@@ -1914,8 +1873,6 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			int idx = editor_data.add_edited_scene(-1);
 			_scene_tab_changed(idx);
 			editor_data.clear_editor_states();
-
-			//_cleanup_scene();
 
 		} break;
 		case FILE_NEW_INHERITED_SCENE:
@@ -2737,8 +2694,6 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 				import_reload_fn = scene->get_filename();
 				_save_scene(import_reload_fn);
-				_cleanup_scene();
-
 
 			}
 
@@ -3327,8 +3282,6 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 	} else {
 		_scene_tab_changed(idx);
 	}
-
-	//_cleanup_scene(); // i'm sorry but this MUST happen to avoid modified resources to not be reloaded.
 
 	dependency_errors.clear();
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2824,9 +2824,9 @@ void EditorNode::_discard_changes(const String &p_str) {
 			String exec = OS::get_singleton()->get_executable_path();
 
 			List<String> args;
-			args.push_back("-path");
+			args.push_back("--path");
 			args.push_back(exec.get_base_dir());
-			args.push_back("-pm");
+			args.push_back("--project-manager");
 
 			OS::ProcessID pid = 0;
 			Error err = OS::get_singleton()->execute(exec, args, false, &pid);

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -58,7 +58,7 @@ Error EditorRun::run(const String &p_scene, const String p_custom_args, const Li
 	args.push_back(itos(OS::get_singleton()->get_process_id()));
 
 	if (debug_collisions) {
-		args.push_back("--debug-collision");
+		args.push_back("--debug-collisions");
 	}
 
 	if (debug_navigation) {
@@ -66,7 +66,6 @@ Error EditorRun::run(const String &p_scene, const String p_custom_args, const Li
 	}
 
 	int screen = EditorSettings::get_singleton()->get("run/window_placement/screen");
-
 	if (screen == 0) {
 		screen = OS::get_singleton()->get_current_screen();
 	} else {
@@ -78,7 +77,6 @@ Error EditorRun::run(const String &p_scene, const String p_custom_args, const Li
 	screen_rect.size = OS::get_singleton()->get_screen_size(screen);
 
 	Size2 desired_size;
-
 	desired_size.x = ProjectSettings::get_singleton()->get("display/window/size/width");
 	desired_size.y = ProjectSettings::get_singleton()->get("display/window/size/height");
 
@@ -95,39 +93,39 @@ Error EditorRun::run(const String &p_scene, const String p_custom_args, const Li
 	switch (window_placement) {
 		case 0: { // top left
 
-			args.push_back("-p");
-			args.push_back(itos(screen_rect.position.x) + "x" + itos(screen_rect.position.y));
+			args.push_back("--position");
+			args.push_back(itos(screen_rect.position.x) + "," + itos(screen_rect.position.y));
 		} break;
 		case 1: { // centered
 			Vector2 pos = screen_rect.position + ((screen_rect.size - desired_size) / 2).floor();
-			args.push_back("-p");
+			args.push_back("--position");
 			args.push_back(itos(pos.x) + "," + itos(pos.y));
 		} break;
 		case 2: { // custom pos
 			Vector2 pos = EditorSettings::get_singleton()->get("run/window_placement/rect_custom_position");
 			pos += screen_rect.position;
-			args.push_back("-p");
+			args.push_back("--position");
 			args.push_back(itos(pos.x) + "," + itos(pos.y));
 		} break;
 		case 3: { // force maximized
 			Vector2 pos = screen_rect.position;
-			args.push_back("-p");
+			args.push_back("--position");
 			args.push_back(itos(pos.x) + "," + itos(pos.y));
-			args.push_back("-m");
+			args.push_back("--maximized");
 
 		} break;
 		case 4: { // force fullscreen
 
 			Vector2 pos = screen_rect.position;
-			args.push_back("-p");
+			args.push_back("--position");
 			args.push_back(itos(pos.x) + "," + itos(pos.y));
-			args.push_back("-f");
+			args.push_back("--fullscreen");
 		} break;
 	}
 
 	if (p_breakpoints.size()) {
 
-		args.push_back("-b");
+		args.push_back("--breakpoints");
 		String bpoints;
 		for (const List<String>::Element *E = p_breakpoints.front(); E; E = E->next()) {
 
@@ -152,7 +150,7 @@ Error EditorRun::run(const String &p_scene, const String p_custom_args, const Li
 
 	String exec = OS::get_singleton()->get_executable_path();
 
-	printf("running: %ls", exec.c_str());
+	printf("Running: %ls", exec.c_str());
 	for (List<String>::Element *E = args.front(); E; E = E->next()) {
 
 		printf(" %ls", E->get().c_str());

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -45,24 +45,24 @@ Error EditorRun::run(const String &p_scene, const String p_custom_args, const Li
 	int remote_port = (int)EditorSettings::get_singleton()->get("network/debug/remote_port");
 
 	if (resource_path != "") {
-		args.push_back("-path");
+		args.push_back("--path");
 		args.push_back(resource_path.replace(" ", "%20"));
 	}
 
 	if (true) {
-		args.push_back("-rdebug");
+		args.push_back("--remote-debug");
 		args.push_back(remote_host + ":" + String::num(remote_port));
 	}
 
-	args.push_back("-allow_focus_steal_pid");
+	args.push_back("--allow_focus_steal_pid");
 	args.push_back(itos(OS::get_singleton()->get_process_id()));
 
 	if (debug_collisions) {
-		args.push_back("-debugcol");
+		args.push_back("--debug-collision");
 	}
 
 	if (debug_navigation) {
-		args.push_back("-debugnav");
+		args.push_back("--debug-navigation");
 	}
 
 	int screen = EditorSettings::get_singleton()->get("run/window_placement/screen");
@@ -101,33 +101,33 @@ Error EditorRun::run(const String &p_scene, const String p_custom_args, const Li
 		case 1: { // centered
 			Vector2 pos = screen_rect.position + ((screen_rect.size - desired_size) / 2).floor();
 			args.push_back("-p");
-			args.push_back(itos(pos.x) + "x" + itos(pos.y));
+			args.push_back(itos(pos.x) + "," + itos(pos.y));
 		} break;
 		case 2: { // custom pos
 			Vector2 pos = EditorSettings::get_singleton()->get("run/window_placement/rect_custom_position");
 			pos += screen_rect.position;
 			args.push_back("-p");
-			args.push_back(itos(pos.x) + "x" + itos(pos.y));
+			args.push_back(itos(pos.x) + "," + itos(pos.y));
 		} break;
 		case 3: { // force maximized
 			Vector2 pos = screen_rect.position;
 			args.push_back("-p");
-			args.push_back(itos(pos.x) + "x" + itos(pos.y));
-			args.push_back("-mx");
+			args.push_back(itos(pos.x) + "," + itos(pos.y));
+			args.push_back("-m");
 
 		} break;
 		case 4: { // force fullscreen
 
 			Vector2 pos = screen_rect.position;
 			args.push_back("-p");
-			args.push_back(itos(pos.x) + "x" + itos(pos.y));
+			args.push_back(itos(pos.x) + "," + itos(pos.y));
 			args.push_back("-f");
 		} break;
 	}
 
 	if (p_breakpoints.size()) {
 
-		args.push_back("-bp");
+		args.push_back("-b");
 		String bpoints;
 		for (const List<String>::Element *E = p_breakpoints.front(); E; E = E->next()) {
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -929,10 +929,10 @@ void ProjectManager::_open_project_confirm() {
 
 		List<String> args;
 
-		args.push_back("-path");
+		args.push_back("--path");
 		args.push_back(path);
 
-		args.push_back("-editor");
+		args.push_back("--editor");
 
 		String exec = OS::get_singleton()->get_executable_path();
 
@@ -982,7 +982,7 @@ void ProjectManager::_run_project_confirm() {
 
 		List<String> args;
 
-		args.push_back("-path");
+		args.push_back("--path");
 		args.push_back(path);
 
 		String exec = OS::get_singleton()->get_executable_path();

--- a/editor/run_settings_dialog.cpp
+++ b/editor/run_settings_dialog.cpp
@@ -88,7 +88,5 @@ RunSettingsDialog::RunSettingsDialog() {
 	get_ok()->set_text(TTR("Close"));
 	//get_cancel()->set_text("Close");
 
-	arguments->set_text("-l $scene");
-
 	set_title(TTR("Scene Run Settings"));
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -28,6 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include "main.h"
+
 #include "app_icon.gen.h"
 #include "core/register_core_types.h"
 #include "drivers/register_driver_types.h"
@@ -110,6 +111,7 @@ static bool force_lowdpi = false;
 static int init_screen = -1;
 static bool use_vsync = true;
 static bool editor = false;
+static bool show_help = false;
 
 static OS::ProcessID allow_focus_steal_pid = 0;
 
@@ -128,63 +130,88 @@ static String unescape_cmdline(const String &p_str) {
 
 void Main::print_help(const char *p_binary) {
 
-	OS::get_singleton()->print(VERSION_FULL_NAME " (c) 2008-2017 Juan Linietsky, Ariel Manzur.\n");
+	OS::get_singleton()->print(VERSION_FULL_NAME " - https://godotengine.org\n");
+	OS::get_singleton()->print("(c) 2007-2017 Juan Linietsky, Ariel Manzur.\n");
+	OS::get_singleton()->print("(c) 2014-2017 Godot Engine contributors.\n");
+	OS::get_singleton()->print("\n");
 	OS::get_singleton()->print("Usage: %s [options] [path to scene or 'project.godot' file]\n", p_binary);
-	OS::get_singleton()->print("Options:\n");
+	OS::get_singleton()->print("\n");
+
+	OS::get_singleton()->print("General options:\n");
 	OS::get_singleton()->print("  -h, --help                       Display this help message.\n");
-	OS::get_singleton()->print("  --path <directory>               Path to the project (<directory> must contain a 'project.godot' file).\n");
+	OS::get_singleton()->print("  -v, --verbose                    Use verbose stdout mode.\n");
+	OS::get_singleton()->print("  --quiet                          Quiet mode, silences stdout messages. Errors are still displayed.\n");
+	OS::get_singleton()->print("\n");
+
+	OS::get_singleton()->print("Run options:\n");
 #ifdef TOOLS_ENABLED
-	OS::get_singleton()->print("  -e, --editor                     Bring up the editor instead of running the scene.\n");
+	OS::get_singleton()->print("  -e, --editor                     Start the editor instead of running the scene.\n");
+	OS::get_singleton()->print("  -p, --project-manager            Start the project manager, even if a project is auto-detected.\n");
 #endif
-	OS::get_singleton()->print("  --test <test>                    Run a test (");
-	const char **test_names = tests_get_names();
-	const char *coma = "";
-	while (*test_names) {
-
-		OS::get_singleton()->print("%s'%s'", coma, *test_names);
-		test_names++;
-		coma = ", ";
-	}
-	OS::get_singleton()->print(").\n");
-
-	OS::get_singleton()->print("  -r, --resolution <W>x<H>         Request window resolution.\n");
-	OS::get_singleton()->print("  -p, --position <X>,<Y>           Request window position.\n");
-	OS::get_singleton()->print("  -f, --fullscreen                 Request fullscreen mode.\n");
-	OS::get_singleton()->print("  -m, --maximized                  Request a maximized window.\n");
-	OS::get_singleton()->print("  -w, --windowed                   Request windowed mode.\n");
-	OS::get_singleton()->print("  --video-driver <driver>          Video driver (");
-	for (int i = 0; i < OS::get_singleton()->get_video_driver_count(); i++) {
-
-		if (i != 0)
-			OS::get_singleton()->print(", ");
-		OS::get_singleton()->print("'%s'", OS::get_singleton()->get_video_driver_name(i));
-	}
-	OS::get_singleton()->print(").\n");
-	OS::get_singleton()->print("  --low-dpi                        Force low-DPI mode (macOS only).\n");
-
+	OS::get_singleton()->print("  -l, --language <locale>          Use a specific locale (<locale> being a two-letter code).\n");
+	OS::get_singleton()->print("  --path <directory>               Path to a project (<directory> must contain a 'project.godot' file).\n");
+	OS::get_singleton()->print("  --main-pack <file>               Path to a pack (.pck) file to load.\n");
+	OS::get_singleton()->print("  --render-thread <mode>           Render thread mode ('unsafe', 'safe', 'separate').\n");
+	OS::get_singleton()->print("  --remote-fs <address>            Remote filesystem (<host/IP>[:<port>] address).\n");
+	OS::get_singleton()->print("  --remote-fs-password <password>  Password for remote filesystem.\n");
 	OS::get_singleton()->print("  --audio-driver <driver>          Audio driver (");
 	for (int i = 0; i < OS::get_singleton()->get_audio_driver_count(); i++) {
-
 		if (i != 0)
 			OS::get_singleton()->print(", ");
 		OS::get_singleton()->print("'%s'", OS::get_singleton()->get_audio_driver_name(i));
 	}
 	OS::get_singleton()->print(").\n");
-	OS::get_singleton()->print("  --render-thread <mode>           Render thread mode ('unsafe', 'safe', 'separate').\n");
-	OS::get_singleton()->print("  -s, --script <script>            Run a script.\n");
+	OS::get_singleton()->print("  --video-driver <driver>          Video driver (");
+	for (int i = 0; i < OS::get_singleton()->get_video_driver_count(); i++) {
+		if (i != 0)
+			OS::get_singleton()->print(", ");
+		OS::get_singleton()->print("'%s'", OS::get_singleton()->get_video_driver_name(i));
+	}
+	OS::get_singleton()->print(").\n");
+	OS::get_singleton()->print("\n");
+
+	OS::get_singleton()->print("Display options:\n");
+	OS::get_singleton()->print("  -f, --fullscreen                 Request fullscreen mode.\n");
+	OS::get_singleton()->print("  -m, --maximized                  Request a maximized window.\n");
+	OS::get_singleton()->print("  -w, --windowed                   Request windowed mode.\n");
+	OS::get_singleton()->print("  --resolution <W>x<H>             Request window resolution.\n");
+	OS::get_singleton()->print("  --position <X>,<Y>               Request window position.\n");
+	OS::get_singleton()->print("  --low-dpi                        Force low-DPI mode (macOS only).\n");
+	OS::get_singleton()->print("  --no-window                      Disable window creation (Windows only). Useful together with --script.\n");
+	OS::get_singleton()->print("\n");
+
+	OS::get_singleton()->print("Debug options:\n");
 	OS::get_singleton()->print("  -d, --debug                      Debug (local stdout debugger).\n");
+	OS::get_singleton()->print("  -b, --breakpoints                Breakpoint list as source::line comma-separated pairs, no spaces (use %%20 instead).\n");
+	OS::get_singleton()->print("  --profiling                      Enable profiling in the script debugger.\n");
+	OS::get_singleton()->print("  --remote-debug <address>         Remote debug (<host/IP>:<port> address).\n");
+#ifdef DEBUG_ENABLED
+	OS::get_singleton()->print("  --debug-collisions               Show collisions shapes when running the scene.\n");
+	OS::get_singleton()->print("  --debug-navigation               Show navigation polygons when running the scene.\n");
+#endif
 	OS::get_singleton()->print("  --frame-delay <ms>               Simulate high CPU load (delay each frame by <ms> milliseconds).\n");
 	OS::get_singleton()->print("  --time-scale <scale>             Force time scale (higher values are faster, 1.0 is normal speed).\n");
-	OS::get_singleton()->print("  -b, --breakpoints                Breakpoint list as source::line comma-separated pairs, no spaces (use %%20, %%2C, ... instead).\n");
-	OS::get_singleton()->print("  -v, --verbose                    Use verbose stdout mode.\n");
-	OS::get_singleton()->print("  -l, --language <locale>          Use a specific locale (<locale> being a two-letter code).\n");
-	OS::get_singleton()->print("  --remote-debug <address>         Remote debug (<ip>:<port> host address).\n");
-	OS::get_singleton()->print("  --remote-fs <host/IP>[:<port>]   Remote filesystem.\n");
-	OS::get_singleton()->print("  --remote-fs-password <password>  Password for remote filesystem.\n");
+	OS::get_singleton()->print("\n");
+
+	OS::get_singleton()->print("Standalone tools:\n");
+	OS::get_singleton()->print("  -s, --script <script>            Run a script.\n");
 #ifdef TOOLS_ENABLED
+	OS::get_singleton()->print("  --export <target>                Export the project using the given export target.\n");
+	OS::get_singleton()->print("  --export-debug                   Use together with --export, enables debug mode for the template.\n");
 	OS::get_singleton()->print("  --doctool <file>                 Dump the whole engine API to <file> in XML format. If <file> exists, it will be merged.\n");
 	OS::get_singleton()->print("  --no-docbase                     Disallow dumping the base types (used with --doctool).\n");
-	OS::get_singleton()->print("  --export <target>                Export the project using the given export target.\n");
+#ifdef DEBUG_METHODS_ENABLED
+	OS::get_singleton()->print("  --gdnative-generate-json-api     Generate JSON dump of the Godot API for GDNative bindings.\n");
+#endif
+	OS::get_singleton()->print("  --test <test>                    Run a unit test (");
+	const char **test_names = tests_get_names();
+	const char *comma = "";
+	while (*test_names) {
+		OS::get_singleton()->print("%s'%s'", comma, *test_names);
+		test_names++;
+		comma = ", ";
+	}
+	OS::get_singleton()->print(").\n");
 #endif
 }
 
@@ -254,14 +281,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	String remotefs;
 	String remotefs_pass;
 
-	String screen = "";
-
-	List<String> pack_list;
 	Vector<String> breakpoints;
 	bool use_custom_res = true;
 	bool force_res = false;
-
-	I = args.front();
 
 	packed_data = PackedData::get_singleton();
 	if (!packed_data)
@@ -279,18 +301,17 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	packed_data->add_pack_source(zip_packed_data);
 #endif
 
+	I = args.front();
 	while (I) {
 
 		List<String>::Element *N = I->next();
 
-		if (I->get() == "--noop") {
+		if (I->get() == "-h" || I->get() == "--help" || I->get() == "/?") { // display help
 
-			// no op
-		} else if (I->get() == "-h" || I->get() == "--help" || I->get() == "/?") { // display help
-
+			show_help = true;
 			goto error;
 
-		} else if (I->get() == "-r" || I->get() == "--resolution") { // force resolution
+		} else if (I->get() == "--resolution") { // force resolution
 
 			if (I->next()) {
 
@@ -298,16 +319,16 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 				if (vm.find("x") == -1) { // invalid parameter format
 
-					OS::get_singleton()->print("Invalid resolution argument: %s\n", vm.utf8().get_data());
+					OS::get_singleton()->print("Invalid resolution '%s', it should be e.g. '1280x720'.\n", vm.utf8().get_data());
 					goto error;
 				}
 
 				int w = vm.get_slice("x", 0).to_int();
 				int h = vm.get_slice("x", 1).to_int();
 
-				if (w == 0 || h == 0) {
+				if (w <= 0 || h <= 0) {
 
-					OS::get_singleton()->print("Invalid resolution, width and height must be above 0\n");
+					OS::get_singleton()->print("Invalid resolution '%s', width and height must be above 0.\n", vm.utf8().get_data());
 					goto error;
 				}
 
@@ -317,10 +338,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 				N = I->next()->next();
 			} else {
-				OS::get_singleton()->print("Invalid resolution argument, needs resolution\n");
+				OS::get_singleton()->print("Missing resolution argument, aborting.\n");
 				goto error;
 			}
-		} else if (I->get() == "-p" || I->get() == "--position") { // position
+		} else if (I->get() == "--position") { // set window position
 
 			if (I->next()) {
 
@@ -328,7 +349,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 				if (vm.find(",") == -1) { // invalid parameter format
 
-					OS::get_singleton()->print("Invalid position argument: %s\n", vm.utf8().get_data());
+					OS::get_singleton()->print("Invalid position '%s', it should be e.g. '80,128'.\n", vm.utf8().get_data());
 					goto error;
 				}
 
@@ -340,7 +361,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 				N = I->next()->next();
 			} else {
-				OS::get_singleton()->print("Invalid position argument, needs position\n");
+				OS::get_singleton()->print("Missing position argument, aborting.\n");
 				goto error;
 			}
 
@@ -350,7 +371,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (I->get() == "-w" || I->get() == "--windowed") { // force windowed window
 
 			init_windowed = true;
-		} else if (I->get() == "--profile") { // enable profiler
+		} else if (I->get() == "--profiling") { // enable profiling
 
 			use_debug_profiler = true;
 		} else if (I->get() == "--video-driver") { // force video driver
@@ -360,7 +381,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				video_driver = I->next()->get();
 				N = I->next()->next();
 			} else {
-				OS::get_singleton()->print("Invalid --video-driver argument, needs driver name\n");
+				OS::get_singleton()->print("Missing video driver argument, aborting.\n");
 				goto error;
 			}
 		} else if (I->get() == "-l" || I->get() == "--language") { // language
@@ -370,10 +391,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				locale = I->next()->get();
 				N = I->next()->next();
 			} else {
-				OS::get_singleton()->print("Invalid language argument, needs language code\n");
+				OS::get_singleton()->print("Missing language argument, aborting.\n");
 				goto error;
 			}
-		} else if (I->get() == "--low-dpi") { // force low DPI
+		} else if (I->get() == "--low-dpi") { // force low DPI (macOS only)
 
 			force_lowdpi = true;
 		} else if (I->get() == "--remote-fs") { // remote filesystem
@@ -383,6 +404,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				remotefs = I->next()->get();
 				N = I->next()->next();
 			} else {
+				OS::get_singleton()->print("Missing remote filesystem address, aborting.\n");
 				goto error;
 			}
 		} else if (I->get() == "--remote-fs-password") { // remote filesystem password
@@ -392,9 +414,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				remotefs_pass = I->next()->get();
 				N = I->next()->next();
 			} else {
+				OS::get_singleton()->print("Missing remote filesystem password, aborting.\n");
 				goto error;
 			}
-		} else if (I->get() == "--render-thread") { // rendering thread
+		} else if (I->get() == "--render-thread") { // render thread mode
 
 			if (I->next()) {
 
@@ -407,6 +430,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 				N = I->next()->next();
 			} else {
+				OS::get_singleton()->print("Missing render thread mode argument, aborting.\n");
 				goto error;
 			}
 
@@ -417,6 +441,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				audio_driver = I->next()->get();
 				N = I->next()->next();
 			} else {
+				OS::get_singleton()->print("Missing audio driver argument, aborting.\n");
 				goto error;
 			}
 
@@ -427,7 +452,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (I->get() == "-e" || I->get() == "--editor") { // starts editor
 
 			editor = true;
-		} else if (I->get() == "--no-window") { // disable window creation
+		} else if (I->get() == "--no-window") { // disable window creation, Windows only
 
 			OS::get_singleton()->set_no_window_mode(true);
 		} else if (I->get() == "--quiet") { // quieter output
@@ -447,6 +472,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				}
 				N = I->next()->next();
 			} else {
+				OS::get_singleton()->print("Missing relative or absolute path, aborting.\n");
 				goto error;
 			}
 		} else if (I->get().ends_with("project.godot")) {
@@ -474,6 +500,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				breakpoints = bplist.split(",");
 				N = I->next()->next();
 			} else {
+				OS::get_singleton()->print("Missing list of breakpoints, aborting.\n");
 				goto error;
 			}
 
@@ -484,6 +511,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				frame_delay = I->next()->get().to_int();
 				N = I->next()->next();
 			} else {
+				OS::get_singleton()->print("Missing frame delay argument, aborting.\n");
 				goto error;
 			}
 
@@ -494,19 +522,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				Engine::get_singleton()->set_time_scale(I->next()->get().to_double());
 				N = I->next()->next();
 			} else {
+				OS::get_singleton()->print("Missing time scale argument, aborting.\n");
 				goto error;
 			}
-
-		} else if (I->get() == "--pack") {
-
-			if (I->next()) {
-
-				pack_list.push_back(I->next()->get());
-				N = I->next()->next();
-			} else {
-
-				goto error;
-			};
 
 		} else if (I->get() == "--main-pack") {
 
@@ -515,46 +533,39 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				main_pack = I->next()->get();
 				N = I->next()->next();
 			} else {
-
+				OS::get_singleton()->print("Missing path to main pack file, aborting.\n");
 				goto error;
 			};
 
-		} else if (I->get() == "--debug" || I->get() == "-d") {
+		} else if (I->get() == "-d" || I->get() == "--debug") {
 			debug_mode = "local";
 #ifdef DEBUG_ENABLED
-		} else if (I->get() == "--debug-collision") {
+		} else if (I->get() == "--debug-collisions") {
 			debug_collisions = true;
 		} else if (I->get() == "--debug-navigation") {
 			debug_navigation = true;
 #endif
-		} else if (I->get() == "--editor-scene") {
-
-			if (I->next()) {
-
-				ProjectSettings::get_singleton()->set("editor_scene", game_path = I->next()->get());
-			} else {
-				goto error;
-			}
-
 		} else if (I->get() == "--remote-debug") {
 			if (I->next()) {
 
 				debug_mode = "remote";
 				debug_host = I->next()->get();
-				if (debug_host.find(":") == -1) { //wrong host
-					OS::get_singleton()->print("Invalid debug host string\n");
+				if (debug_host.find(":") == -1) { // wrong address
+					OS::get_singleton()->print("Invalid debug host address, it should be of the form <host/IP>:<port>.\n");
 					goto error;
 				}
 				N = I->next()->next();
 			} else {
+				OS::get_singleton()->print("Missing remote debug host address, aborting.\n");
 				goto error;
 			}
-		} else if (I->get() == "--allow_focus_steal_pid") {
+		} else if (I->get() == "--allow_focus_steal_pid") { // not exposed to user
 			if (I->next()) {
 
 				allow_focus_steal_pid = I->next()->get().to_int64();
 				N = I->next()->next();
 			} else {
+				OS::get_singleton()->print("Missing editor PID argument, aborting.\n");
 				goto error;
 			}
 		} else {
@@ -618,7 +629,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 		Error err = file_access_network_client->connect(remotefs, port, remotefs_pass);
 		if (err) {
-			OS::get_singleton()->printerr("Could not connect to remotefs: %s:%i\n", remotefs.utf8().get_data(), port);
+			OS::get_singleton()->printerr("Could not connect to remotefs: %s:%i.\n", remotefs.utf8().get_data(), port);
 			goto error;
 		}
 
@@ -654,7 +665,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #ifdef TOOLS_ENABLED
 		editor = false;
 #else
-		OS::get_singleton()->print("error: Couldn't load game path '%s'\n", game_path.ascii().get_data());
+		OS::get_singleton()->print("Error: Could not load game path '%s'.\n", game_path.ascii().get_data());
 
 		goto error;
 #endif
@@ -744,11 +755,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		OS::get_singleton()->_render_thread_mode = OS::RenderThreadMode(rtm);
 	}
 
-	/* Determine Video Driver */
-
-	if (audio_driver == "") { // specified in project.godot
-		audio_driver = GLOBAL_DEF("audio/driver", OS::get_singleton()->get_audio_driver_name(0));
-	}
+	/* Determine audio and video drivers */
 
 	for (int i = 0; i < OS::get_singleton()->get_video_driver_count(); i++) {
 
@@ -764,6 +771,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		//OS::get_singleton()->alert("Invalid Video Driver: " + video_driver);
 		video_driver_idx = 0;
 		//goto error;
+	}
+
+	if (audio_driver == "") { // specified in project.godot
+		audio_driver = GLOBAL_DEF("audio/driver", OS::get_singleton()->get_audio_driver_name(0));
 	}
 
 	for (int i = 0; i < OS::get_singleton()->get_audio_driver_count(); i++) {
@@ -833,7 +844,8 @@ error:
 	args.clear();
 	main_args.clear();
 
-	print_help(execpath);
+	if (show_help)
+		print_help(execpath);
 
 	if (performance)
 		memdelete(performance);
@@ -1053,23 +1065,18 @@ bool Main::start() {
 	String game_path;
 	String script;
 	String test;
-	String screen;
 	String _export_preset;
-	String _import;
-	String _import_script;
-	bool noquit = false;
 	bool export_debug = false;
 	bool project_manager_request = false;
+
 	List<String> args = OS::get_singleton()->get_cmdline_args();
 	for (int i = 0; i < args.size(); i++) {
 		//parameters that do not have an argument to the right
 		if (args[i] == "--no-docbase") {
 			doc_base = false;
-		} else if (args[i] == "--no-quit") {
-			noquit = true;
-		} else if (args[i] == "--editor" || args[i] == "-e") {
+		} else if (args[i] == "-e" || args[i] == "--editor") {
 			editor = true;
-		} else if (args[i] == "-P" || args[i] == "--project-manager") {
+		} else if (args[i] == "-p" || args[i] == "--project-manager") {
 			project_manager_request = true;
 		} else if (args[i].length() && args[i][0] != '-' && game_path == "") {
 			game_path = args[i];
@@ -1081,10 +1088,8 @@ bool Main::start() {
 				doc_tool = args[i + 1];
 				for (int j = i + 2; j < args.size(); j++)
 					removal_docs.push_back(args[j]);
-			} else if (args[i] == "--script" || args[i] == "-s") {
+			} else if (args[i] == "-s" || args[i] == "--script") {
 				script = args[i + 1];
-			} else if (args[i] == "--level" || args[i] == "-l") {
-				Engine::get_singleton()->_custom_level = args[i + 1];
 			} else if (args[i] == "--test") {
 				test = args[i + 1];
 			} else if (args[i] == "--export") {
@@ -1094,12 +1099,6 @@ bool Main::start() {
 				editor = true; //needs editor
 				_export_preset = args[i + 1];
 				export_debug = true;
-			} else if (args[i] == "--import") {
-				editor = true; //needs editor
-				_import = args[i + 1];
-			} else if (args[i] == "--import-script") {
-				editor = true; //needs editor
-				_import_script = args[i + 1];
 			} else {
 				// The parameter does not match anything known, don't skip the next argument
 				parsed_pair = false;
@@ -1205,7 +1204,7 @@ bool Main::start() {
 
 	if (!main_loop) {
 		if (!ClassDB::class_exists(main_loop_type)) {
-			OS::get_singleton()->alert("godot: error: MainLoop type doesn't exist: " + main_loop_type);
+			OS::get_singleton()->alert("Error: MainLoop type doesn't exist: " + main_loop_type);
 			return false;
 		} else {
 
@@ -1355,19 +1354,8 @@ bool Main::start() {
 #ifdef TOOLS_ENABLED
 			if (editor) {
 
-				if (_import != "") {
-
-					//editor_node->import_scene(_import,local_game_path,_import_script);
-					if (!noquit)
-						sml->quit();
-					game_path = ""; //no load anything
-				} else {
-
-					Error serr = editor_node->load_scene(local_game_path);
-				}
+				Error serr = editor_node->load_scene(local_game_path);
 				OS::get_singleton()->set_context(OS::CONTEXT_EDITOR);
-
-				//editor_node->set_edited_scene(game);
 			}
 #endif
 		}
@@ -1441,7 +1429,6 @@ bool Main::start() {
 					n->set_name(name);
 
 					//defer so references are all valid on _ready()
-					//sml->get_root()->add_child(n);
 					to_add.push_back(n);
 
 					if (global_var) {
@@ -1466,7 +1453,6 @@ bool Main::start() {
 
 				ERR_EXPLAIN("Failed loading scene: " + local_game_path);
 				ERR_FAIL_COND_V(!scene, false)
-				//sml->get_root()->add_child(scene);
 				sml->add_current_scene(scene);
 
 				String iconpath = GLOBAL_DEF("application/config/icon", "Variant()");
@@ -1480,27 +1466,6 @@ bool Main::start() {
 		}
 
 #ifdef TOOLS_ENABLED
-
-		/*if (_export_platform!="") {
-
-			sml->quit();
-		}*/
-
-		/*
-		if (sml->get_root_node()) {
-
-			Console *console = memnew( Console );
-
-			sml->get_root_node()->cast_to<RootNode>()->set_console(console);
-			if (GLOBAL_DEF("console/visible_default",false).operator bool()) {
-
-				console->show();
-			} else {P
-
-				console->hide();
-			};
-		}
-*/
 		if (project_manager_request || (script == "" && test == "" && game_path == "" && !editor)) {
 
 			ProjectManager *pmanager = memnew(ProjectManager);
@@ -1509,7 +1474,6 @@ bool Main::start() {
 			sml->get_root()->add_child(pmanager);
 			OS::get_singleton()->set_context(OS::CONTEXT_PROJECTMAN);
 		}
-
 #endif
 	}
 
@@ -1590,10 +1554,6 @@ bool Main::iteration() {
 
 		time_accum -= frame_slice;
 		message_queue->flush();
-		/*
-		if (AudioServer::get_singleton())
-			AudioServer::get_singleton()->update();
-		*/
 
 		fixed_process_ticks = MAX(fixed_process_ticks, OS::get_singleton()->get_ticks_usec() - fixed_begin); // keep the largest one for reference
 		fixed_process_max = MAX(OS::get_singleton()->get_ticks_usec() - fixed_begin, fixed_process_max);
@@ -1642,7 +1602,6 @@ bool Main::iteration() {
 		script_debugger->idle_poll();
 	}
 
-	//x11_delay_usec(10000);
 	frames++;
 	Engine::get_singleton()->_idle_frames++;
 
@@ -1744,7 +1703,6 @@ void Main::cleanup() {
 	unregister_core_driver_types();
 	unregister_core_types();
 
-	//PerformanceMetrics::finish();
 	OS::get_singleton()->clear_last_error();
 	OS::get_singleton()->finalize_core();
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -129,62 +129,62 @@ static String unescape_cmdline(const String &p_str) {
 void Main::print_help(const char *p_binary) {
 
 	OS::get_singleton()->print(VERSION_FULL_NAME " (c) 2008-2017 Juan Linietsky, Ariel Manzur.\n");
-	OS::get_singleton()->print("Usage: %s [options] [scene]\n", p_binary);
+	OS::get_singleton()->print("Usage: %s [options] [path to scene or 'project.godot' file]\n", p_binary);
 	OS::get_singleton()->print("Options:\n");
-	OS::get_singleton()->print("\t-path [dir] : Path to a game, containing project.godot\n");
+	OS::get_singleton()->print("  -h, --help                       Display this help message.\n");
+	OS::get_singleton()->print("  --path <directory>               Path to the project (<directory> must contain a 'project.godot' file).\n");
 #ifdef TOOLS_ENABLED
-	OS::get_singleton()->print("\t-e,-editor : Bring up the editor instead of running the scene.\n");
+	OS::get_singleton()->print("  -e, --editor                     Bring up the editor instead of running the scene.\n");
 #endif
-	OS::get_singleton()->print("\t-test [test] : Run a test.\n");
-	OS::get_singleton()->print("\t\t(");
+	OS::get_singleton()->print("  --test <test>                    Run a test (");
 	const char **test_names = tests_get_names();
 	const char *coma = "";
 	while (*test_names) {
 
-		OS::get_singleton()->print("%s%s", coma, *test_names);
+		OS::get_singleton()->print("%s'%s'", coma, *test_names);
 		test_names++;
 		coma = ", ";
 	}
-	OS::get_singleton()->print(")\n");
+	OS::get_singleton()->print(").\n");
 
-	OS::get_singleton()->print("\t-r WIDTHxHEIGHT\t : Request Window Resolution\n");
-	OS::get_singleton()->print("\t-p XxY\t : Request Window Position\n");
-	OS::get_singleton()->print("\t-f\t\t : Request Fullscreen\n");
-	OS::get_singleton()->print("\t-mx\t\t Request Maximized\n");
-	OS::get_singleton()->print("\t-w\t\t Request Windowed\n");
-	OS::get_singleton()->print("\t-vd DRIVER\t : Video Driver (");
+	OS::get_singleton()->print("  -r, --resolution <W>x<H>         Request window resolution.\n");
+	OS::get_singleton()->print("  -p, --position <X>,<Y>           Request window position.\n");
+	OS::get_singleton()->print("  -f, --fullscreen                 Request fullscreen mode.\n");
+	OS::get_singleton()->print("  -m, --maximized                  Request a maximized window.\n");
+	OS::get_singleton()->print("  -w, --windowed                   Request windowed mode.\n");
+	OS::get_singleton()->print("  --video-driver <driver>          Video driver (");
 	for (int i = 0; i < OS::get_singleton()->get_video_driver_count(); i++) {
 
 		if (i != 0)
 			OS::get_singleton()->print(", ");
-		OS::get_singleton()->print("%s", OS::get_singleton()->get_video_driver_name(i));
+		OS::get_singleton()->print("'%s'", OS::get_singleton()->get_video_driver_name(i));
 	}
-	OS::get_singleton()->print(")\n");
-	OS::get_singleton()->print("\t-ldpi\t : Force low-dpi mode (OSX Only)\n");
+	OS::get_singleton()->print(").\n");
+	OS::get_singleton()->print("  --low-dpi                        Force low-DPI mode (macOS only).\n");
 
-	OS::get_singleton()->print("\t-ad DRIVER\t : Audio Driver (");
+	OS::get_singleton()->print("  --audio-driver <driver>          Audio driver (");
 	for (int i = 0; i < OS::get_singleton()->get_audio_driver_count(); i++) {
 
 		if (i != 0)
 			OS::get_singleton()->print(", ");
-		OS::get_singleton()->print("%s", OS::get_singleton()->get_audio_driver_name(i));
+		OS::get_singleton()->print("'%s'", OS::get_singleton()->get_audio_driver_name(i));
 	}
-	OS::get_singleton()->print(")\n");
-	OS::get_singleton()->print("\t-rthread <mode>\t : Render Thread Mode ('unsafe', 'safe', 'separate').\n");
-	OS::get_singleton()->print("\t-s,-script [script] : Run a script.\n");
-	OS::get_singleton()->print("\t-d,-debug : Debug (local stdout debugger).\n");
-	OS::get_singleton()->print("\t-rdebug ADDRESS : Remote debug (<ip>:<port> host address).\n");
-	OS::get_singleton()->print("\t-fdelay [msec]: Simulate high CPU load (delay each frame by [msec]).\n");
-	OS::get_singleton()->print("\t-timescale [msec]: Simulate high CPU load (delay each frame by [msec]).\n");
-	OS::get_singleton()->print("\t-bp : breakpoint list as source::line comma separated pairs, no spaces (%%20,%%2C,etc instead).\n");
-	OS::get_singleton()->print("\t-v : Verbose stdout mode\n");
-	OS::get_singleton()->print("\t-lang [locale]: Use a specific locale\n");
-	OS::get_singleton()->print("\t-rfs <host/ip>[:<port>] : Remote FileSystem.\n");
-	OS::get_singleton()->print("\t-rfs_pass <password> : Password for Remote FileSystem.\n");
+	OS::get_singleton()->print(").\n");
+	OS::get_singleton()->print("  --render-thread <mode>           Render thread mode ('unsafe', 'safe', 'separate').\n");
+	OS::get_singleton()->print("  -s, --script <script>            Run a script.\n");
+	OS::get_singleton()->print("  -d, --debug                      Debug (local stdout debugger).\n");
+	OS::get_singleton()->print("  --frame-delay <ms>               Simulate high CPU load (delay each frame by <ms> milliseconds).\n");
+	OS::get_singleton()->print("  --time-scale <scale>             Force time scale (higher values are faster, 1.0 is normal speed).\n");
+	OS::get_singleton()->print("  -b, --breakpoints                Breakpoint list as source::line comma-separated pairs, no spaces (use %%20, %%2C, ... instead).\n");
+	OS::get_singleton()->print("  -v, --verbose                    Use verbose stdout mode.\n");
+	OS::get_singleton()->print("  -l, --language <locale>          Use a specific locale (<locale> being a two-letter code).\n");
+	OS::get_singleton()->print("  --remote-debug <address>         Remote debug (<ip>:<port> host address).\n");
+	OS::get_singleton()->print("  --remote-fs <host/IP>[:<port>]   Remote filesystem.\n");
+	OS::get_singleton()->print("  --remote-fs-password <password>  Password for remote filesystem.\n");
 #ifdef TOOLS_ENABLED
-	OS::get_singleton()->print("\t-doctool FILE: Dump the whole engine api to FILE in XML format. If FILE exists, it will be merged.\n");
-	OS::get_singleton()->print("\t-nodocbase: Disallow dump the base types (used with -doctool).\n");
-	OS::get_singleton()->print("\t-export [target] Export the project using given export target.\n");
+	OS::get_singleton()->print("  --doctool <file>                 Dump the whole engine API to <file> in XML format. If <file> exists, it will be merged.\n");
+	OS::get_singleton()->print("  --no-docbase                     Disallow dumping the base types (used with --doctool).\n");
+	OS::get_singleton()->print("  --export <target>                Export the project using the given export target.\n");
 #endif
 }
 
@@ -283,14 +283,14 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 		List<String>::Element *N = I->next();
 
-		if (I->get() == "-noop") {
+		if (I->get() == "--noop") {
 
 			// no op
-		} else if (I->get() == "-h" || I->get() == "--help" || I->get() == "/?") { // resolution
+		} else if (I->get() == "-h" || I->get() == "--help" || I->get() == "/?") { // display help
 
 			goto error;
 
-		} else if (I->get() == "-r") { // resolution
+		} else if (I->get() == "-r" || I->get() == "--resolution") { // force resolution
 
 			if (I->next()) {
 
@@ -298,7 +298,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 				if (vm.find("x") == -1) { // invalid parameter format
 
-					OS::get_singleton()->print("Invalid -r argument: %s\n", vm.utf8().get_data());
+					OS::get_singleton()->print("Invalid resolution argument: %s\n", vm.utf8().get_data());
 					goto error;
 				}
 
@@ -307,7 +307,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 				if (w == 0 || h == 0) {
 
-					OS::get_singleton()->print("Invalid -r resolution, x and y must be >0\n");
+					OS::get_singleton()->print("Invalid resolution, width and height must be above 0\n");
 					goto error;
 				}
 
@@ -317,66 +317,66 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 				N = I->next()->next();
 			} else {
-				OS::get_singleton()->print("Invalid -p argument, needs resolution\n");
+				OS::get_singleton()->print("Invalid resolution argument, needs resolution\n");
 				goto error;
 			}
-		} else if (I->get() == "-p") { // position
+		} else if (I->get() == "-p" || I->get() == "--position") { // position
 
 			if (I->next()) {
 
 				String vm = I->next()->get();
 
-				if (vm.find("x") == -1) { // invalid parameter format
+				if (vm.find(",") == -1) { // invalid parameter format
 
-					OS::get_singleton()->print("Invalid -p argument: %s\n", vm.utf8().get_data());
+					OS::get_singleton()->print("Invalid position argument: %s\n", vm.utf8().get_data());
 					goto error;
 				}
 
-				int x = vm.get_slice("x", 0).to_int();
-				int y = vm.get_slice("x", 1).to_int();
+				int x = vm.get_slice(",", 0).to_int();
+				int y = vm.get_slice(",", 1).to_int();
 
 				init_custom_pos = Point2(x, y);
 				init_use_custom_pos = true;
 
 				N = I->next()->next();
 			} else {
-				OS::get_singleton()->print("Invalid -r argument, needs position\n");
+				OS::get_singleton()->print("Invalid position argument, needs position\n");
 				goto error;
 			}
 
-		} else if (I->get() == "-mx") { // video driver
+		} else if (I->get() == "-m" || I->get() == "--maximized") { // force maximized window
 
 			init_maximized = true;
-		} else if (I->get() == "-w") { // video driver
+		} else if (I->get() == "-w" || I->get() == "--windowed") { // force windowed window
 
 			init_windowed = true;
-		} else if (I->get() == "-profile") { // video driver
+		} else if (I->get() == "--profile") { // enable profiler
 
 			use_debug_profiler = true;
-		} else if (I->get() == "-vd") { // video driver
+		} else if (I->get() == "--video-driver") { // force video driver
 
 			if (I->next()) {
 
 				video_driver = I->next()->get();
 				N = I->next()->next();
 			} else {
-				OS::get_singleton()->print("Invalid -cd argument, needs driver name\n");
+				OS::get_singleton()->print("Invalid --video-driver argument, needs driver name\n");
 				goto error;
 			}
-		} else if (I->get() == "-lang") { // language
+		} else if (I->get() == "-l" || I->get() == "--language") { // language
 
 			if (I->next()) {
 
 				locale = I->next()->get();
 				N = I->next()->next();
 			} else {
-				OS::get_singleton()->print("Invalid -lang argument, needs language code\n");
+				OS::get_singleton()->print("Invalid language argument, needs language code\n");
 				goto error;
 			}
-		} else if (I->get() == "-ldpi") { // language
+		} else if (I->get() == "--low-dpi") { // force low DPI
 
 			force_lowdpi = true;
-		} else if (I->get() == "-rfs") { // language
+		} else if (I->get() == "--remote-fs") { // remote filesystem
 
 			if (I->next()) {
 
@@ -385,7 +385,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			} else {
 				goto error;
 			}
-		} else if (I->get() == "-rfs_pass") { // language
+		} else if (I->get() == "--remote-fs-password") { // remote filesystem password
 
 			if (I->next()) {
 
@@ -394,7 +394,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			} else {
 				goto error;
 			}
-		} else if (I->get() == "-rthread") { // language
+		} else if (I->get() == "--render-thread") { // rendering thread
 
 			if (I->next()) {
 
@@ -410,7 +410,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			}
 
-		} else if (I->get() == "-ad") { // video driver
+		} else if (I->get() == "--audio-driver") { // audio driver
 
 			if (I->next()) {
 
@@ -420,22 +420,22 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			}
 
-		} else if (I->get() == "-f") { // fullscreen
+		} else if (I->get() == "-f" || I->get() == "--fullscreen") { // force fullscreen
 
 			//video_mode.fullscreen=false;
 			init_fullscreen = true;
-		} else if (I->get() == "-e" || I->get() == "-editor") { // fonud editor
+		} else if (I->get() == "-e" || I->get() == "--editor") { // starts editor
 
 			editor = true;
-		} else if (I->get() == "-nowindow") { // fullscreen
+		} else if (I->get() == "--no-window") { // disable window creation
 
 			OS::get_singleton()->set_no_window_mode(true);
-		} else if (I->get() == "-quiet") { // fullscreen
+		} else if (I->get() == "--quiet") { // quieter output
 
 			quiet_stdout = true;
-		} else if (I->get() == "-v") { // fullscreen
+		} else if (I->get() == "-v" || I->get() == "--verbose") { // verbose output
 			OS::get_singleton()->_verbose_stdout = true;
-		} else if (I->get() == "-path") { // resolution
+		} else if (I->get() == "--path") { // set path of project to start or edit
 
 			if (I->next()) {
 
@@ -466,7 +466,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #ifdef TOOLS_ENABLED
 			editor = true;
 #endif
-		} else if (I->get() == "-bp") { // /breakpoints
+		} else if (I->get() == "-b" || I->get() == "--breakpoints") { // add breakpoints
 
 			if (I->next()) {
 
@@ -477,7 +477,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			}
 
-		} else if (I->get() == "-fdelay") { // resolution
+		} else if (I->get() == "--frame-delay") { // force frame delay
 
 			if (I->next()) {
 
@@ -487,7 +487,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			}
 
-		} else if (I->get() == "-timescale") { // resolution
+		} else if (I->get() == "--time-scale") { // force time scale
 
 			if (I->next()) {
 
@@ -497,7 +497,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			}
 
-		} else if (I->get() == "-pack") {
+		} else if (I->get() == "--pack") {
 
 			if (I->next()) {
 
@@ -508,7 +508,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			};
 
-		} else if (I->get() == "-main_pack") {
+		} else if (I->get() == "--main-pack") {
 
 			if (I->next()) {
 
@@ -519,15 +519,15 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			};
 
-		} else if (I->get() == "-debug" || I->get() == "-d") {
+		} else if (I->get() == "--debug" || I->get() == "-d") {
 			debug_mode = "local";
 #ifdef DEBUG_ENABLED
-		} else if (I->get() == "-debugcol" || I->get() == "-dc") {
+		} else if (I->get() == "--debug-collision") {
 			debug_collisions = true;
-		} else if (I->get() == "-debugnav" || I->get() == "-dn") {
+		} else if (I->get() == "--debug-navigation") {
 			debug_navigation = true;
 #endif
-		} else if (I->get() == "-editor_scene") {
+		} else if (I->get() == "--editor-scene") {
 
 			if (I->next()) {
 
@@ -536,7 +536,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			}
 
-		} else if (I->get() == "-rdebug") {
+		} else if (I->get() == "--remote-debug") {
 			if (I->next()) {
 
 				debug_mode = "remote";
@@ -549,7 +549,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			} else {
 				goto error;
 			}
-		} else if (I->get() == "-allow_focus_steal_pid") {
+		} else if (I->get() == "--allow_focus_steal_pid") {
 			if (I->next()) {
 
 				allow_focus_steal_pid = I->next()->get().to_int64();
@@ -662,7 +662,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	if (editor) {
 		Engine::get_singleton()->set_editor_hint(true);
-		main_args.push_back("-editor");
+		main_args.push_back("--editor");
 		init_maximized = true;
 		use_custom_res = false;
 	}
@@ -1063,13 +1063,13 @@ bool Main::start() {
 	List<String> args = OS::get_singleton()->get_cmdline_args();
 	for (int i = 0; i < args.size(); i++) {
 		//parameters that do not have an argument to the right
-		if (args[i] == "-nodocbase") {
+		if (args[i] == "--no-docbase") {
 			doc_base = false;
-		} else if (args[i] == "-noquit") {
+		} else if (args[i] == "--no-quit") {
 			noquit = true;
-		} else if (args[i] == "-editor" || args[i] == "-e") {
+		} else if (args[i] == "--editor" || args[i] == "-e") {
 			editor = true;
-		} else if (args[i] == "-pm" || args[i] == "-project_manager") {
+		} else if (args[i] == "-P" || args[i] == "--project-manager") {
 			project_manager_request = true;
 		} else if (args[i].length() && args[i][0] != '-' && game_path == "") {
 			game_path = args[i];
@@ -1077,27 +1077,27 @@ bool Main::start() {
 		//parameters that have an argument to the right
 		else if (i < (args.size() - 1)) {
 			bool parsed_pair = true;
-			if (args[i] == "-doctool") {
+			if (args[i] == "--doctool") {
 				doc_tool = args[i + 1];
 				for (int j = i + 2; j < args.size(); j++)
 					removal_docs.push_back(args[j]);
-			} else if (args[i] == "-script" || args[i] == "-s") {
+			} else if (args[i] == "--script" || args[i] == "-s") {
 				script = args[i + 1];
-			} else if (args[i] == "-level" || args[i] == "-l") {
+			} else if (args[i] == "--level" || args[i] == "-l") {
 				Engine::get_singleton()->_custom_level = args[i + 1];
-			} else if (args[i] == "-test") {
+			} else if (args[i] == "--test") {
 				test = args[i + 1];
-			} else if (args[i] == "-export") {
+			} else if (args[i] == "--export") {
 				editor = true; //needs editor
 				_export_preset = args[i + 1];
-			} else if (args[i] == "-export_debug") {
+			} else if (args[i] == "--export-debug") {
 				editor = true; //needs editor
 				_export_preset = args[i + 1];
 				export_debug = true;
-			} else if (args[i] == "-import") {
+			} else if (args[i] == "--import") {
 				editor = true; //needs editor
 				_import = args[i + 1];
-			} else if (args[i] == "-import_script") {
+			} else if (args[i] == "--import-script") {
 				editor = true; //needs editor
 				_import_script = args[i + 1];
 			} else {
@@ -1145,7 +1145,7 @@ bool Main::start() {
 	if (_export_preset != "") {
 		if (game_path == "") {
 			String err = "Command line param ";
-			err += export_debug ? "-export_debug" : "-export";
+			err += export_debug ? "--export-debug" : "--export";
 			err += " passed but no destination path given.\n";
 			err += "Please specify the binary's file path to export to. Aborting export.";
 			ERR_PRINT(err.utf8().get_data());

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1220,10 +1220,10 @@ Error EditorExportPlatformAndroid::export_project(const String& p_path, bool p_d
 		/*String host = EditorSettings::get_singleton()->get("filesystem/file_server/host");
 		int port = EditorSettings::get_singleton()->get("filesystem/file_server/post");
 		String passwd = EditorSettings::get_singleton()->get("filesystem/file_server/password");
-		cl.push_back("-rfs");
+		cl.push_back("--remote-fs");
 		cl.push_back(host+":"+itos(port));
 		if (passwd!="") {
-			cl.push_back("-rfs_pass");
+			cl.push_back("--remote-fs-password");
 			cl.push_back(passwd);
 		}*/
 
@@ -1243,10 +1243,10 @@ Error EditorExportPlatformAndroid::export_project(const String& p_path, bool p_d
 			err = save_pack(pf);
 			memdelete(pf);
 
-			cl.push_back("-use_apk_expansion");
-			cl.push_back("-apk_expansion_md5");
+			cl.push_back("--use_apk_expansion");
+			cl.push_back("--apk_expansion_md5");
 			cl.push_back(FileAccess::get_md5(fullpath));
-			cl.push_back("-apk_expansion_key");
+			cl.push_back("--apk_expansion_key");
 			cl.push_back(apk_expansion_pkey.strip_edges());
 
 		} else {
@@ -1262,10 +1262,10 @@ Error EditorExportPlatformAndroid::export_project(const String& p_path, bool p_d
 	}
 
 	if (use_32_fb)
-		cl.push_back("-use_depth_32");
+		cl.push_back("--use_depth_32");
 
 	if (immersive)
-		cl.push_back("-use_immersive");
+		cl.push_back("--use_immersive");
 
 	if (cl.size()) {
 		//add comandline
@@ -3330,10 +3330,10 @@ public:
 			/*String host = EditorSettings::get_singleton()->get("filesystem/file_server/host");
 			int port = EditorSettings::get_singleton()->get("filesystem/file_server/post");
 			String passwd = EditorSettings::get_singleton()->get("filesystem/file_server/password");
-			cl.push_back("-rfs");
+			cl.push_back("--remote-fs");
 			cl.push_back(host+":"+itos(port));
 			if (passwd!="") {
-				cl.push_back("-rfs_pass");
+				cl.push_back("--remote-fs-password");
 				cl.push_back(passwd);
 			}*/
 
@@ -3350,10 +3350,10 @@ public:
 					return OK;
 				}
 
-				cl.push_back("-use_apk_expansion");
-				cl.push_back("-apk_expansion_md5");
+				cl.push_back("--use_apk_expansion");
+				cl.push_back("--apk_expansion_md5");
 				cl.push_back(FileAccess::get_md5(fullpath));
-				cl.push_back("-apk_expansion_key");
+				cl.push_back("--apk_expansion_key");
 				cl.push_back(apk_expansion_pkey.strip_edges());
 
 			} else {
@@ -3367,10 +3367,10 @@ public:
 		}
 
 		if (use_32_fb)
-			cl.push_back("-use_depth_32");
+			cl.push_back("--use_depth_32");
 
 		if (immersive)
-			cl.push_back("-use_immersive");
+			cl.push_back("--use_immersive");
 
 		if (cl.size()) {
 			//add comandline

--- a/platform/android/godot_android.cpp
+++ b/platform/android/godot_android.cpp
@@ -616,7 +616,6 @@ static void engine_handle_cmd(struct android_app *app, int32_t cmd) {
 					//do initialization here, when there's OpenGL! hackish but the only way
 					engine->os = new OS_Android(_gfx_init, engine);
 
-					//char *args[]={"-test","gui",NULL};
 					__android_log_print(ANDROID_LOG_INFO, "godot", "pre asdasd setup...");
 #if 0
 				Error err  = Main::setup("apk",2,args);

--- a/platform/android/java/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/src/org/godotengine/godot/Godot.java
@@ -387,7 +387,7 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 				new_cmdline = new String[ 2 ];
 			}
 
-			new_cmdline[cll]="-main_pack";
+			new_cmdline[cll]="--main_pack";
 			new_cmdline[cll+1]=expansion_pack_path;
 			command_line=new_cmdline;
 		}
@@ -452,9 +452,9 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 			for(int i=0;i<command_line.length;i++) {
 
 				boolean has_extra = i< command_line.length -1;
-				if (command_line[i].equals("-use_depth_32")) {
+				if (command_line[i].equals("--use_depth_32")) {
 					use_32_bits=true;
-				} else if (command_line[i].equals("-use_immersive")) {
+				} else if (command_line[i].equals("--use_immersive")) {
 					use_immersive=true;
 					if(Build.VERSION.SDK_INT >= 19.0){ // check if the application runs on an android 4.4+
 						window.getDecorView().setSystemUiVisibility(
@@ -467,12 +467,12 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 
 						UiChangeListener();
 					}
-				} else if (command_line[i].equals("-use_apk_expansion")) {
+				} else if (command_line[i].equals("--use_apk_expansion")) {
 					use_apk_expansion=true;
-				} else if (has_extra && command_line[i].equals("-apk_expansion_md5")) {
+				} else if (has_extra && command_line[i].equals("--apk_expansion_md5")) {
 					main_pack_md5=command_line[i+1];
 					i++;
-				} else if (has_extra && command_line[i].equals("-apk_expansion_key")) {
+				} else if (has_extra && command_line[i].equals("--apk_expansion_key")) {
 					main_pack_key=command_line[i+1];
 					SharedPreferences prefs = getSharedPreferences("app_data_keys", MODE_PRIVATE);
 					Editor editor = prefs.edit();

--- a/platform/android/java_glue.cpp
+++ b/platform/android/java_glue.cpp
@@ -844,7 +844,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_initialize(JNIEnv *en
 				} else {
 					//__android_log_print(ANDROID_LOG_INFO,"godot","cmdline arg %i is: %s\n",i,rawString);
 
-					if (strcmp(rawString, "-main_pack") == 0)
+					if (strcmp(rawString, "--main_pack") == 0)
 						use_apk_expansion = true;
 				}
 
@@ -867,7 +867,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_initialize(JNIEnv *en
 	__android_log_print(ANDROID_LOG_INFO, "godot", "**SETUP");
 
 #if 0
-	char *args[]={"-test","render",NULL};
+	char *args[]={"--test","render",NULL};
 	__android_log_print(ANDROID_LOG_INFO,"godot","pre asdasd setup...");
 	Error err  = Main::setup("apk",2,args,false);
 #else

--- a/platform/iphone/view_controller.mm
+++ b/platform/iphone/view_controller.mm
@@ -42,7 +42,7 @@ int add_path(int p_argc, char **p_args) {
 	if (!str)
 		return p_argc;
 
-	p_args[p_argc++] = "-path";
+	p_args[p_argc++] = "--path";
 	[str retain]; // memory leak lol (maybe make it static here and delete it in ViewController destructor? @todo
 	p_args[p_argc++] = (char *)[str cString];
 	p_args[p_argc] = NULL;

--- a/platform/uwp/app.cpp
+++ b/platform/uwp/app.cpp
@@ -512,7 +512,7 @@ void App::UpdateWindowSize(Size size) {
 
 char **App::get_command_line(unsigned int *out_argc) {
 
-	static char *fail_cl[] = { "-path", "game", NULL };
+	static char *fail_cl[] = { "--path", "game", NULL };
 	*out_argc = 2;
 
 	FILE *f = _wfopen(L"__cl__.cl", L"rb");

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -1330,7 +1330,7 @@ public:
 		}
 
 		if (!(p_flags & DEBUG_FLAG_DUMB_CLIENT)) {
-			cl.push_back("-path");
+			cl.push_back("--path");
 			cl.push_back("game");
 		}
 


### PR DESCRIPTION
Same as #10445 which was reverted, but so far I can't see what caused the problem that triggered its revert since I can't reproduce it.

This needs to be tested thoroughly before merging, I'm growing weary of the merge/revert ping-pong game :)

Please test and report any issue, including when trying to export (I believe the PR can be tested even with alpha1 export templates, the resulting binary would of course be buggy but the export process should work I think).

------

Help output:
```
Godot Engine v3.0.alpha.custom_build - https://godotengine.org
(c) 2007-2017 Juan Linietsky, Ariel Manzur.
(c) 2014-2017 Godot Engine contributors.

Usage: godot-git [options] [path to scene or 'project.godot' file]

General options:
  -h, --help                       Display this help message.
  -v, --verbose                    Use verbose stdout mode.
  --quiet                          Quiet mode, silences stdout messages. Errors are still displayed.

Run options:
  -e, --editor                     Start the editor instead of running the scene.
  -p, --project-manager            Start the project manager, even if a project is auto-detected.
  -l, --language <locale>          Use a specific locale (<locale> being a two-letter code).
  --path <directory>               Path to a project (<directory> must contain a 'project.godot' file).
  --main-pack <file>               Path to a pack (.pck) file to load.
  --render-thread <mode>           Render thread mode ('unsafe', 'safe', 'separate').
  --remote-fs <address>            Remote filesystem (<host/IP>[:<port>] address).
  --remote-fs-password <password>  Password for remote filesystem.
  --audio-driver <driver>          Audio driver ('PulseAudio', 'ALSA').
  --video-driver <driver>          Video driver ('GLES3').

Display options:
  -f, --fullscreen                 Request fullscreen mode.
  -m, --maximized                  Request a maximized window.
  -w, --windowed                   Request windowed mode.
  --resolution <W>x<H>             Request window resolution.
  --position <X>,<Y>               Request window position.
  --low-dpi                        Force low-DPI mode (macOS only).
  --no-window                      Disable window creation (Windows only). Useful together with --script.

Debug options:
  -d, --debug                      Debug (local stdout debugger).
  -b, --breakpoints                Breakpoint list as source::line comma-separated pairs, no spaces (use %20 instead).
  --profiling                      Enable profiling in the script debugger.
  --remote-debug <address>         Remote debug (<host/IP>:<port> address).
  --debug-collisions               Show collisions shapes when running the scene.
  --debug-navigation               Show navigation polygons when running the scene.
  --frame-delay <ms>               Simulate high CPU load (delay each frame by <ms> milliseconds).
  --time-scale <scale>             Force time scale (higher values are faster, 1.0 is normal speed).

Standalone tools:
  -s, --script <script>            Run a script.
  --export <target>                Export the project using the given export target.
  --export-debug                   Use together with --export, enables debug mode for the template.
  --doctool <file>                 Dump the whole engine API to <file> in XML format. If <file> exists, it will be merged.
  --no-docbase                     Disallow dumping the base types (used with --doctool).
  --gdnative-generate-json-api     Generate JSON dump of the Godot API for GDNative bindings.
  --test <test>                    Run a unit test ('string', 'containers', 'math', 'render', 'multimesh', 'gui', 'io', 'shaderlang', 'physics').
```