### PR TITLE
Fixed segfault when hovering over tree elements and showing tooltips.

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1456,6 +1456,10 @@ void Viewport::_gui_show_tooltip() {
 		gui.tooltip_popup = NULL;
 	}
 
+	if (!gui.tooltip) {
+		return;
+	}
+
 	Control *rp = gui.tooltip->get_root_parent_control();
 	if (!rp)
 		return;


### PR DESCRIPTION
Fixes #10372 

I'm still not sure why I have to add this null pointer check in this commit when it was done [above](https://github.com/godotengine/godot/pull/10492/files#diff-b0e269beca0e7df95d035998c40ecb64R1446). For some reason after adding this check I'm not getting any segmentation fault.