### PR TITLE
Add stretching to `TextureProgress`

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -46114,6 +46114,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_nine_patch_stretch">
+			<return type="bool">
+			</return>
+			<description>
+				Returns true if textures are stretched as nine-patches or false otherwise.
+			</description>
+		</method>
 		<method name="get_over_texture" qualifiers="const">
 			<return type="Object">
 			</return>
@@ -46138,6 +46145,15 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_stretch_margin" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="margin" type="int">
+			</argument>
+			<description>
+				Return nine-patch texture offset for a given margin (MARGIN_LEFT, MARGIN_TOP, MARGIN_RIGHT, MARGIN_BOTTOM).
+			</description>
+		</method>
 		<method name="get_under_texture" qualifiers="const">
 			<return type="Object">
 			</return>
@@ -46154,6 +46170,13 @@
 			<argument index="0" name="mode" type="int">
 			</argument>
 			<description>
+			</description>
+		</method>
+		<method name="set_nine_patch_stretch">
+			<argument index="0" name="stretch" type="bool">
+			</argument>
+			<description>
+				Set if textures should be stretched as nine-patches.
 			</description>
 		</method>
 		<method name="set_over_texture">
@@ -46180,6 +46203,15 @@
 			<description>
 			</description>
 		</method>
+		<method name="set_stretch_margin">
+			<argument index="0" name="margin" type="int">
+			</argument>
+			<argument index="1" name="size" type="int">
+			</argument>
+			<description>
+				Set nine-patch texture offset for a given margin (MARGIN_LEFT, MARGIN_TOP, MARGIN_RIGHT, MARGIN_BOTTOM).
+			</description>
+		</method>
 		<method name="set_under_texture">
 			<argument index="0" name="tex" type="Object">
 			</argument>
@@ -46201,6 +46233,16 @@
 		<member name="texture_progress" type="Texture" setter="set_progress_texture" getter="get_progress_texture" brief="">
 		</member>
 		<member name="texture_under" type="Texture" setter="set_under_texture" getter="get_under_texture" brief="">
+		</member>
+		<member name="nine_patch_stretch" type="bool" setter="set_nine_patch_stretch" getter="get_nine_patch_stretch" brief="">
+		</member>
+		<member name="stretch_margin_left" type="int" setter="set_stretch_margin" getter="get_stretch_margin" brief="">
+		</member>
+		<member name="stretch_margin_top" type="int" setter="set_stretch_margin" getter="get_stretch_margin" brief="">
+		</member>
+		<member name="stretch_margin_right" type="int" setter="set_stretch_margin" getter="get_stretch_margin" brief="">
+		</member>
+		<member name="stretch_margin_bottom" type="int" setter="set_stretch_margin" getter="get_stretch_margin" brief="">
 		</member>
 	</members>
 	<constants>

--- a/scene/gui/texture_progress.cpp
+++ b/scene/gui/texture_progress.cpp
@@ -57,9 +57,33 @@ Ref<Texture> TextureProgress::get_over_texture() const {
 	return over;
 }
 
+void TextureProgress::set_stretch_margin(Margin p_margin, int p_size) {
+	ERR_FAIL_INDEX(p_margin, 4);
+	stretch_margin[p_margin] = p_size;
+	update();
+	minimum_size_changed();
+}
+
+int TextureProgress::get_stretch_margin(Margin p_margin) const {
+	ERR_FAIL_INDEX_V(p_margin, 4, 0);
+	return stretch_margin[p_margin];
+}
+
+void TextureProgress::set_nine_patch_stretch(bool p_stretch) {
+	nine_patch_stretch = p_stretch;
+	update();
+	minimum_size_changed();
+}
+
+bool TextureProgress::get_nine_patch_stretch() const {
+	return nine_patch_stretch;
+}
+
 Size2 TextureProgress::get_minimum_size() const {
 
-	if (under.is_valid())
+	if (nine_patch_stretch)
+		return Size2(stretch_margin[MARGIN_LEFT] + stretch_margin[MARGIN_RIGHT], stretch_margin[MARGIN_TOP] + stretch_margin[MARGIN_BOTTOM]);
+	else if (under.is_valid())
 		return under->get_size();
 	else if (over.is_valid())
 		return over->get_size();
@@ -122,80 +146,165 @@ Point2 TextureProgress::get_relative_center() {
 	return p;
 }
 
+void TextureProgress::draw_nine_patch_stretched(const Ref<Texture> &p_texture, FillMode p_mode, double p_ratio) {
+	Vector2 texture_size = p_texture->get_size();
+	Vector2 topleft = Vector2(stretch_margin[MARGIN_LEFT], stretch_margin[MARGIN_TOP]);
+	Vector2 bottomright = Vector2(stretch_margin[MARGIN_RIGHT], stretch_margin[MARGIN_BOTTOM]);
+
+	Rect2 src_rect = Rect2(Point2(), texture_size);
+	Rect2 dst_rect = Rect2(Point2(), get_size());
+
+	if (p_ratio < 1.0) {
+		// Drawing a partially-filled 9-patch is a little tricky -
+		// texture is divided by 3 sections toward fill direction,
+		// then middle section is streching while the other two aren't.
+
+		double width_total = 0.0;
+		double width_texture = 0.0;
+		double first_section_size = 0.0;
+		double last_section_size = 0.0;
+		switch (mode) {
+			case FILL_LEFT_TO_RIGHT:
+			case FILL_RIGHT_TO_LEFT: {
+				width_total = dst_rect.size.x;
+				width_texture = texture_size.x;
+				first_section_size = topleft.x;
+				last_section_size = bottomright.x;
+			} break;
+			case FILL_TOP_TO_BOTTOM:
+			case FILL_BOTTOM_TO_TOP: {
+				width_total = dst_rect.size.y;
+				width_texture = texture_size.y;
+				first_section_size = topleft.y;
+				last_section_size = bottomright.y;
+			} break;
+		}
+
+		double width_filled = width_total * p_ratio;
+		double middle_section_size = MAX(0.0, width_texture - first_section_size - last_section_size);
+
+		middle_section_size *= MIN(1.0, (MAX(0.0, width_filled - first_section_size) / MAX(1.0, width_total - first_section_size - last_section_size)));
+		last_section_size = MAX(0.0, last_section_size - (width_total - width_filled));
+		width_texture = MIN(width_texture, first_section_size + middle_section_size + last_section_size);
+
+		switch (mode) {
+			case FILL_LEFT_TO_RIGHT: {
+				src_rect.size.x = width_texture;
+				dst_rect.size.x = width_filled;
+				bottomright.x = last_section_size;
+			} break;
+			case FILL_RIGHT_TO_LEFT: {
+				src_rect.position.x += src_rect.size.x - width_texture;
+				src_rect.size.x = width_texture;
+				dst_rect.position.x += width_total - width_filled;
+				dst_rect.size.x = width_filled;
+				topleft.x = last_section_size;
+			} break;
+			case FILL_TOP_TO_BOTTOM: {
+				src_rect.size.y = width_texture;
+				dst_rect.size.y = width_filled;
+				bottomright.y = last_section_size;
+			} break;
+			case FILL_BOTTOM_TO_TOP: {
+				src_rect.position.y += src_rect.size.y - width_texture;
+				src_rect.size.y = width_texture;
+				dst_rect.position.y += width_total - width_filled;
+				dst_rect.size.y = width_filled;
+				topleft.y = last_section_size;
+			} break;
+		}
+	}
+
+	RID ci = get_canvas_item();
+	VS::get_singleton()->canvas_item_add_nine_patch(ci, dst_rect, src_rect, p_texture->get_rid(), topleft, bottomright);
+}
+
 void TextureProgress::_notification(int p_what) {
 	const float corners[12] = { -0.125, -0.375, -0.625, -0.875, 0.125, 0.375, 0.625, 0.875, 1.125, 1.375, 1.625, 1.875 };
 	switch (p_what) {
 
 		case NOTIFICATION_DRAW: {
 
-			if (under.is_valid())
-				draw_texture(under, Point2());
-			if (progress.is_valid()) {
-				Size2 s = progress->get_size();
-				switch (mode) {
-					case FILL_LEFT_TO_RIGHT: {
-						Rect2 region = Rect2(Point2(), Size2(s.x * get_as_ratio(), s.y));
-						draw_texture_rect_region(progress, region, region);
-					} break;
-					case FILL_RIGHT_TO_LEFT: {
-						Rect2 region = Rect2(Point2(s.x - s.x * get_as_ratio(), 0), Size2(s.x * get_as_ratio(), s.y));
-						draw_texture_rect_region(progress, region, region);
-					} break;
-					case FILL_TOP_TO_BOTTOM: {
-						Rect2 region = Rect2(Point2(), Size2(s.x, s.y * get_as_ratio()));
-						draw_texture_rect_region(progress, region, region);
-					} break;
-					case FILL_BOTTOM_TO_TOP: {
-						Rect2 region = Rect2(Point2(0, s.y - s.y * get_as_ratio()), Size2(s.x, s.y * get_as_ratio()));
-						draw_texture_rect_region(progress, region, region);
-					} break;
-					case FILL_CLOCKWISE:
-					case FILL_COUNTER_CLOCKWISE: {
-						float val = get_as_ratio() * rad_max_degrees / 360;
-						if (val == 1) {
-							Rect2 region = Rect2(Point2(), s);
-							draw_texture_rect_region(progress, region, region);
-						} else if (val != 0) {
-							Array pts;
-							float direction = mode == FILL_CLOCKWISE ? 1 : -1;
-							float start = rad_init_angle / 360;
-							float end = start + direction * val;
-							pts.append(start);
-							pts.append(end);
-							float from = MIN(start, end);
-							float to = MAX(start, end);
-							for (int i = 0; i < 12; i++)
-								if (corners[i] > from && corners[i] < to)
-									pts.append(corners[i]);
-							pts.sort();
-							Vector<Point2> uvs;
-							Vector<Point2> points;
-							uvs.push_back(get_relative_center());
-							points.push_back(Point2(s.x * get_relative_center().x, s.y * get_relative_center().y));
-							for (int i = 0; i < pts.size(); i++) {
-								Point2 uv = unit_val_to_uv(pts[i]);
-								if (uvs.find(uv) >= 0)
-									continue;
-								uvs.push_back(uv);
-								points.push_back(Point2(uv.x * s.x, uv.y * s.y));
-							}
-							draw_polygon(points, Vector<Color>(), uvs, progress);
-						}
-						if (Engine::get_singleton()->is_editor_hint()) {
-							Point2 p = progress->get_size();
-							p.x *= get_relative_center().x;
-							p.y *= get_relative_center().y;
-							p = p.floor();
-							draw_line(p - Point2(8, 0), p + Point2(8, 0), Color(0.9, 0.5, 0.5), 2);
-							draw_line(p - Point2(0, 8), p + Point2(0, 8), Color(0.9, 0.5, 0.5), 2);
-						}
-					} break;
-					default:
-						draw_texture_rect_region(progress, Rect2(Point2(), Size2(s.x * get_as_ratio(), s.y)), Rect2(Point2(), Size2(s.x * get_as_ratio(), s.y)));
+			if (nine_patch_stretch && (mode == FILL_LEFT_TO_RIGHT || mode == FILL_RIGHT_TO_LEFT || mode == FILL_TOP_TO_BOTTOM || mode == FILL_BOTTOM_TO_TOP)) {
+				if (under.is_valid()) {
+					draw_nine_patch_stretched(under, FILL_LEFT_TO_RIGHT, 1.0);
 				}
+				if (progress.is_valid()) {
+					draw_nine_patch_stretched(progress, mode, get_as_ratio());
+				}
+				if (over.is_valid()) {
+					draw_nine_patch_stretched(over, FILL_LEFT_TO_RIGHT, 1.0);
+				}
+			} else {
+				if (under.is_valid())
+					draw_texture(under, Point2());
+				if (progress.is_valid()) {
+					Size2 s = progress->get_size();
+					switch (mode) {
+						case FILL_LEFT_TO_RIGHT: {
+							Rect2 region = Rect2(Point2(), Size2(s.x * get_as_ratio(), s.y));
+							draw_texture_rect_region(progress, region, region);
+						} break;
+						case FILL_RIGHT_TO_LEFT: {
+							Rect2 region = Rect2(Point2(s.x - s.x * get_as_ratio(), 0), Size2(s.x * get_as_ratio(), s.y));
+							draw_texture_rect_region(progress, region, region);
+						} break;
+						case FILL_TOP_TO_BOTTOM: {
+							Rect2 region = Rect2(Point2(), Size2(s.x, s.y * get_as_ratio()));
+							draw_texture_rect_region(progress, region, region);
+						} break;
+						case FILL_BOTTOM_TO_TOP: {
+							Rect2 region = Rect2(Point2(0, s.y - s.y * get_as_ratio()), Size2(s.x, s.y * get_as_ratio()));
+							draw_texture_rect_region(progress, region, region);
+						} break;
+						case FILL_CLOCKWISE:
+						case FILL_COUNTER_CLOCKWISE: {
+							float val = get_as_ratio() * rad_max_degrees / 360;
+							if (val == 1) {
+								Rect2 region = Rect2(Point2(), s);
+								draw_texture_rect_region(progress, region, region);
+							} else if (val != 0) {
+								Array pts;
+								float direction = mode == FILL_CLOCKWISE ? 1 : -1;
+								float start = rad_init_angle / 360;
+								float end = start + direction * val;
+								pts.append(start);
+								pts.append(end);
+								float from = MIN(start, end);
+								float to = MAX(start, end);
+								for (int i = 0; i < 12; i++)
+									if (corners[i] > from && corners[i] < to)
+										pts.append(corners[i]);
+								pts.sort();
+								Vector<Point2> uvs;
+								Vector<Point2> points;
+								uvs.push_back(get_relative_center());
+								points.push_back(Point2(s.x * get_relative_center().x, s.y * get_relative_center().y));
+								for (int i = 0; i < pts.size(); i++) {
+									Point2 uv = unit_val_to_uv(pts[i]);
+									if (uvs.find(uv) >= 0)
+										continue;
+									uvs.push_back(uv);
+									points.push_back(Point2(uv.x * s.x, uv.y * s.y));
+								}
+								draw_polygon(points, Vector<Color>(), uvs, progress);
+							}
+							if (Engine::get_singleton()->is_editor_hint()) {
+								Point2 p = progress->get_size();
+								p.x *= get_relative_center().x;
+								p.y *= get_relative_center().y;
+								p = p.floor();
+								draw_line(p - Point2(8, 0), p + Point2(8, 0), Color(0.9, 0.5, 0.5), 2);
+								draw_line(p - Point2(0, 8), p + Point2(0, 8), Color(0.9, 0.5, 0.5), 2);
+							}
+						} break;
+						default:
+							draw_texture_rect_region(progress, Rect2(Point2(), Size2(s.x * get_as_ratio(), s.y)), Rect2(Point2(), Size2(s.x * get_as_ratio(), s.y)));
+					}
+				}
+				if (over.is_valid())
+					draw_texture(over, Point2());
 			}
-			if (over.is_valid())
-				draw_texture(over, Point2());
 
 		} break;
 	}
@@ -265,6 +374,12 @@ void TextureProgress::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_fill_degrees", "mode"), &TextureProgress::set_fill_degrees);
 	ClassDB::bind_method(D_METHOD("get_fill_degrees"), &TextureProgress::get_fill_degrees);
 
+	ClassDB::bind_method(D_METHOD("set_stretch_margin", "margin", "value"), &TextureProgress::set_stretch_margin);
+	ClassDB::bind_method(D_METHOD("get_stretch_margin", "margin"), &TextureProgress::get_stretch_margin);
+
+	ClassDB::bind_method(D_METHOD("set_nine_patch_stretch", "stretch"), &TextureProgress::set_nine_patch_stretch);
+	ClassDB::bind_method(D_METHOD("get_nine_patch_stretch"), &TextureProgress::get_nine_patch_stretch);
+
 	ADD_GROUP("Textures", "texture_");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "texture_under", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_under_texture", "get_under_texture");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "texture_over", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_over_texture", "get_over_texture");
@@ -274,6 +389,12 @@ void TextureProgress::_bind_methods() {
 	ADD_PROPERTYNZ(PropertyInfo(Variant::REAL, "radial_initial_angle", PROPERTY_HINT_RANGE, "0.0,360.0,0.1,slider"), "set_radial_initial_angle", "get_radial_initial_angle");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::REAL, "radial_fill_degrees", PROPERTY_HINT_RANGE, "0.0,360.0,0.1,slider"), "set_fill_degrees", "get_fill_degrees");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "radial_center_offset"), "set_radial_center_offset", "get_radial_center_offset");
+	ADD_GROUP("Stretch", "stretch_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "nine_patch_stretch"), "set_nine_patch_stretch", "get_nine_patch_stretch");
+	ADD_PROPERTYINZ(PropertyInfo(Variant::INT, "stretch_margin_left", PROPERTY_HINT_RANGE, "0,16384,1"), "set_stretch_margin", "get_stretch_margin", MARGIN_LEFT);
+	ADD_PROPERTYINZ(PropertyInfo(Variant::INT, "stretch_margin_top", PROPERTY_HINT_RANGE, "0,16384,1"), "set_stretch_margin", "get_stretch_margin", MARGIN_TOP);
+	ADD_PROPERTYINZ(PropertyInfo(Variant::INT, "stretch_margin_right", PROPERTY_HINT_RANGE, "0,16384,1"), "set_stretch_margin", "get_stretch_margin", MARGIN_RIGHT);
+	ADD_PROPERTYINZ(PropertyInfo(Variant::INT, "stretch_margin_bottom", PROPERTY_HINT_RANGE, "0,16384,1"), "set_stretch_margin", "get_stretch_margin", MARGIN_BOTTOM);
 
 	BIND_ENUM_CONSTANT(FILL_LEFT_TO_RIGHT);
 	BIND_ENUM_CONSTANT(FILL_RIGHT_TO_LEFT);
@@ -289,4 +410,10 @@ TextureProgress::TextureProgress() {
 	rad_center_off = Point2();
 	rad_max_degrees = 360;
 	set_mouse_filter(MOUSE_FILTER_PASS);
+
+	nine_patch_stretch = false;
+	stretch_margin[MARGIN_LEFT] = 0;
+	stretch_margin[MARGIN_RIGHT] = 0;
+	stretch_margin[MARGIN_BOTTOM] = 0;
+	stretch_margin[MARGIN_TOP] = 0;
 }

--- a/scene/gui/texture_progress.h
+++ b/scene/gui/texture_progress.h
@@ -75,6 +75,12 @@ public:
 	void set_over_texture(const Ref<Texture> &p_texture);
 	Ref<Texture> get_over_texture() const;
 
+	void set_stretch_margin(Margin p_margin, int p_size);
+	int get_stretch_margin(Margin p_margin) const;
+
+	void set_nine_patch_stretch(bool p_stretch);
+	bool get_nine_patch_stretch() const;
+
 	Size2 get_minimum_size() const;
 
 	TextureProgress();
@@ -84,9 +90,12 @@ private:
 	float rad_init_angle;
 	float rad_max_degrees;
 	Point2 rad_center_off;
+	bool nine_patch_stretch;
+	int stretch_margin[4];
 
 	Point2 unit_val_to_uv(float val);
 	Point2 get_relative_center();
+	void draw_nine_patch_stretched(const Ref<Texture> &p_texture, FillMode p_mode, double p_ratio);
 };
 
 VARIANT_ENUM_CAST(TextureProgress::FillMode);


### PR DESCRIPTION
Now `TextureProgress` has `stretch` flag. With this flag enabled,
it's being rendered as 9-path using `stretch_margin_*` properties
as texture margins.

Stretching doesn't support `FILL_CLOCKWISE` and `FILL_COUNTER_CLOCKWISE` fill modes.