### PR TITLE
Fix color_ramp indexing negative elements

### DIFF
--- a/scene/resources/color_ramp.cpp
+++ b/scene/resources/color_ramp.cpp
@@ -149,7 +149,7 @@ void Gradient::set_offset(int pos, const float offset) {
 }
 
 float Gradient::get_offset(int pos) const {
-	if (points.size() > pos)
+	if (points.size() && points.size() > pos)
 		return points[pos].offset;
 	return 0; //TODO: Maybe throw some error instead?
 }
@@ -164,7 +164,7 @@ void Gradient::set_color(int pos, const Color &color) {
 }
 
 Color Gradient::get_color(int pos) const {
-	if (points.size() > pos)
+	if (points.size() && points.size() > pos)
 		return points[pos].color;
 	return Color(0, 0, 0, 1); //TODO: Maybe throw some error instead?
 }


### PR DESCRIPTION
The 'pos' variable passed to get_color() and get_offset() can be
negative if the color ramp itself is empty. This causes a lookup in an
empty position in the color Vector which leads to a crash.

We add a check so we never do a lookup in the color Vector if the
gradient is empty.

This fixes #10501