### PR TITLE
Remove addition border

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -84,19 +84,6 @@ static Ref<StyleBoxFlat> change_border_color(Ref<StyleBoxFlat> p_style, Color p_
 	return style;
 }
 
-static Ref<StyleBoxFlat> add_additional_border(Ref<StyleBoxFlat> p_style, int p_left, int p_top, int p_right, int p_bottom) {
-	Ref<StyleBoxFlat> style = p_style->duplicate();
-	style->set_border_width(MARGIN_LEFT, p_left * EDSCALE + style->get_border_width(MARGIN_LEFT));
-	style->set_border_width(MARGIN_RIGHT, p_right * EDSCALE + style->get_border_width(MARGIN_RIGHT));
-	style->set_border_width(MARGIN_TOP, p_top * EDSCALE + style->get_border_width(MARGIN_TOP));
-	style->set_border_width(MARGIN_BOTTOM, p_bottom * EDSCALE + style->get_border_width(MARGIN_BOTTOM));
-	style->set_expand_margin_size(MARGIN_LEFT, p_left * EDSCALE);
-	style->set_expand_margin_size(MARGIN_RIGHT, p_right * EDSCALE);
-	style->set_expand_margin_size(MARGIN_TOP, p_top * EDSCALE);
-	style->set_expand_margin_size(MARGIN_BOTTOM, p_bottom * EDSCALE);
-	return style;
-}
-
 #define HIGHLIGHT_COLOR_LIGHT highlight_color.linear_interpolate(Color(1, 1, 1, 1), 0.3)
 #define HIGHLIGHT_COLOR_DARK highlight_color.linear_interpolate(Color(0, 0, 0, 1), 0.5)
 
@@ -491,7 +478,8 @@ Ref<Theme> create_editor_theme() {
 	// PopupPanel
 	Ref<StyleBoxFlat> style_dock_select = make_flat_stylebox(base_color);
 	style_dock_select->set_border_color_all(light_color_1);
-	style_dock_select = add_additional_border(style_dock_select, 2, 2, 2, 2);
+	style_dock_select->set_expand_margin_size_all(2);
+	style_dock_select->set_border_width_all(2);
 	theme->set_stylebox("panel", "PopupPanel", style_dock_select);
 
 	// SpinBox

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -191,6 +191,22 @@ void StyleBoxTexture::set_expand_margin_size(Margin p_expand_margin, float p_siz
 	emit_changed();
 }
 
+void StyleBoxTexture::set_expand_margin_size_individual(float p_left, float p_top, float p_right, float p_bottom) {
+	expand_margin[MARGIN_LEFT] = p_left;
+	expand_margin[MARGIN_TOP] = p_top;
+	expand_margin[MARGIN_RIGHT] = p_right;
+	expand_margin[MARGIN_BOTTOM] = p_bottom;
+	emit_changed();
+}
+
+void StyleBoxTexture::set_expand_margin_size_all(float p_expand_margin_size) {
+	for (int i = 0; i < 4; i++) {
+
+		expand_margin[i] = p_expand_margin_size;
+	}
+	emit_changed();
+}
+
 float StyleBoxTexture::get_expand_margin_size(Margin p_expand_margin) const {
 
 	ERR_FAIL_INDEX_V(p_expand_margin, 4, 0);
@@ -257,6 +273,8 @@ void StyleBoxTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_margin_size", "margin"), &StyleBoxTexture::get_margin_size);
 
 	ClassDB::bind_method(D_METHOD("set_expand_margin_size", "margin", "size"), &StyleBoxTexture::set_expand_margin_size);
+	ClassDB::bind_method(D_METHOD("set_expand_margin_all", "size"), &StyleBoxFlat::set_expand_margin_size_all);
+	ClassDB::bind_method(D_METHOD("set_expand_margin_individual", "size_left", "size_top", "size_right", "size_bottom"), &StyleBoxFlat::set_expand_margin_size_individual);
 	ClassDB::bind_method(D_METHOD("get_expand_margin_size", "margin"), &StyleBoxTexture::get_expand_margin_size);
 
 	ClassDB::bind_method(D_METHOD("set_region_rect", "region"), &StyleBoxTexture::set_region_rect);
@@ -421,7 +439,25 @@ void StyleBoxFlat::set_expand_margin_size(Margin p_expand_margin, float p_size) 
 	expand_margin[p_expand_margin] = p_size;
 	emit_changed();
 }
+
+void StyleBoxFlat::set_expand_margin_size_individual(float p_left, float p_top, float p_right, float p_bottom) {
+	expand_margin[MARGIN_LEFT] = p_left;
+	expand_margin[MARGIN_TOP] = p_top;
+	expand_margin[MARGIN_RIGHT] = p_right;
+	expand_margin[MARGIN_BOTTOM] = p_bottom;
+	emit_changed();
+}
+
+void StyleBoxFlat::set_expand_margin_size_all(float p_expand_margin_size) {
+	for (int i = 0; i < 4; i++) {
+
+		expand_margin[i] = p_expand_margin_size;
+	}
+	emit_changed();
+}
+
 float StyleBoxFlat::get_expand_margin_size(Margin p_expand_margin) const {
+
 	return expand_margin[p_expand_margin];
 }
 void StyleBoxFlat::set_filled(bool p_filled) {
@@ -736,6 +772,8 @@ void StyleBoxFlat::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_corner_radius", "corner"), &StyleBoxFlat::get_corner_radius);
 
 	ClassDB::bind_method(D_METHOD("set_expand_margin", "margin", "size"), &StyleBoxFlat::set_expand_margin_size);
+	ClassDB::bind_method(D_METHOD("set_expand_margin_all", "size"), &StyleBoxFlat::set_expand_margin_size_all);
+	ClassDB::bind_method(D_METHOD("set_expand_margin_individual", "size_left", "size_top", "size_right", "size_bottom"), &StyleBoxFlat::set_expand_margin_size_individual);
 	ClassDB::bind_method(D_METHOD("get_expand_margin", "margin"), &StyleBoxFlat::get_expand_margin_size);
 
 	ClassDB::bind_method(D_METHOD("set_filled", "filled"), &StyleBoxFlat::set_filled);

--- a/scene/resources/style_box.h
+++ b/scene/resources/style_box.h
@@ -101,6 +101,8 @@ protected:
 
 public:
 	void set_expand_margin_size(Margin p_expand_margin, float p_size);
+	void set_expand_margin_size_all(float p_expand_margin_size);
+	void set_expand_margin_size_individual(float p_left, float p_top, float p_right, float p_bottom);
 	float get_expand_margin_size(Margin p_expand_margin) const;
 
 	void set_margin_size(Margin p_margin, float p_size);
@@ -196,6 +198,8 @@ public:
 
 	//EXPANDS
 	void set_expand_margin_size(Margin p_expand_margin, float p_size);
+	void set_expand_margin_size_all(float p_expand_margin_size);
+	void set_expand_margin_size_individual(float p_left, float p_top, float p_right, float p_bottom);
 	float get_expand_margin_size(Margin p_expand_margin) const;
 
 	//FILLED


### PR DESCRIPTION
the additional border function is not really necessary anymore since borders now can be achieved with:
```
sb->set_border_width_inidvidual(l, t, r, b);
sb->set_expand_margin_size_inidvidual(l, t, r, b);
```
this pr removes the function and adds convenience functions to StyleBox. so that additional border really is not necessary anymore.
[additional border function](https://github.com/godotengine/godot/compare/master...toger5:remove_addition_border?expand=1#diff-a303f0e6ee369856bcaf5dcf959c40e7L87)