### PR TITLE
[2.1]  Add null check to ParallaxLayer get_parent() calls

### DIFF
--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -32,6 +32,9 @@
 
 void ParallaxLayer::set_motion_scale(const Size2 &p_scale) {
 
+	if (!get_parent())
+		return;
+
 	motion_scale = p_scale;
 
 	ParallaxBackground *pb = get_parent()->cast_to<ParallaxBackground>();
@@ -48,6 +51,9 @@ Size2 ParallaxLayer::get_motion_scale() const {
 }
 
 void ParallaxLayer::set_motion_offset(const Size2 &p_offset) {
+
+	if (!get_parent())
+		return;
 
 	motion_offset = p_offset;
 


### PR DESCRIPTION
This fixes #10515