### PR TITLE
Sanitize Android debug

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -69,7 +69,6 @@
 #include "core/io/file_access_zip.h"
 #include "core/io/stream_peer_ssl.h"
 #include "core/io/stream_peer_tcp.h"
-#include "core/os/thread.h"
 #include "main/input_default.h"
 #include "performance.h"
 #include "translation.h"
@@ -886,7 +885,11 @@ error:
 	return ERR_INVALID_PARAMETER;
 }
 
-Error Main::setup2() {
+Error Main::setup2(Thread::ID p_main_tid_override) {
+
+	if (p_main_tid_override) {
+		Thread::_main_thread_id = p_main_tid_override;
+	}
 
 	OS::get_singleton()->initialize(video_mode, video_driver_idx, audio_driver_idx);
 	if (init_use_custom_pos) {

--- a/main/main.h
+++ b/main/main.h
@@ -34,6 +34,7 @@
 	@author Juan Linietsky <reduzio@gmail.com>
 */
 
+#include "core/os/thread.h"
 #include "error_list.h"
 #include "typedefs.h"
 
@@ -49,7 +50,7 @@ class Main {
 
 public:
 	static Error setup(const char *execpath, int argc, char *argv[], bool p_second_phase = true);
-	static Error setup2();
+	static Error setup2(Thread::ID p_main_tid_override = 0);
 	static bool start();
 	static bool iteration();
 	static void cleanup();

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -2960,11 +2960,7 @@ public:
 		//export_temp
 		ep.step("Exporting APK", 0);
 
-		bool use_adb_over_usb = bool(EDITOR_DEF("export/android/use_remote_debug_over_adb", true));
-
-		if (use_adb_over_usb) {
-			p_debug_flags |= DEBUG_FLAG_REMOTE_DEBUG_LOCALHOST;
-		}
+		p_debug_flags |= DEBUG_FLAG_REMOTE_DEBUG_LOCALHOST;
 
 		String export_to = EditorSettings::get_singleton()->get_settings_path() + "/tmp/tmpexport.apk";
 		Error err = export_project(p_preset, true, export_to, p_debug_flags);
@@ -3017,7 +3013,7 @@ public:
 			return ERR_CANT_CREATE;
 		}
 
-		if (use_adb_over_usb) {
+		if (p_debug_flags & DEBUG_FLAG_REMOTE_DEBUG) {
 
 			args.clear();
 			args.push_back("-s");
@@ -3036,6 +3032,9 @@ public:
 
 			err = OS::get_singleton()->execute(adb, args, true, NULL, NULL, &rv);
 			print_line("Reverse result: " + itos(rv));
+		}
+
+		if (p_debug_flags & DEBUG_FLAG_DUMB_CLIENT) {
 
 			int fs_port = EditorSettings::get_singleton()->get("filesystem/file_server/port");
 
@@ -3618,7 +3617,6 @@ void register_android_exporter() {
 	EDITOR_DEF("export/android/force_system_user", false);
 
 	EDITOR_DEF("export/android/timestamping_authority_url", "");
-	EDITOR_DEF("export/android/use_remote_debug_over_adb", false);
 	EDITOR_DEF("export/android/shutdown_adb_on_exit", true);
 
 	Ref<EditorExportAndroid> exporter = Ref<EditorExportAndroid>(memnew(EditorExportAndroid));

--- a/platform/android/java_glue.cpp
+++ b/platform/android/java_glue.cpp
@@ -1008,7 +1008,9 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env, job
 		ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("JavaClassWrapper", java_class_wrapper));
 		_initialize_java_modules();
 
-		Main::setup2();
+		// Since Godot is initialized on the UI thread, _main_thread_id was set to that thread's id,
+		// but for Godot purposes, the main thread is the one running the game loop
+		Main::setup2(Thread::get_caller_id());
 		++step;
 		suspend_mutex->unlock();
 		input_mutex->unlock();


### PR DESCRIPTION
~~'Remote debug over ADB' seems to be a left-behind of how Android debug worked a long time ago. Now it just breaks debugging.~~

~~What should be checked instead in order to enable remote debug and/or FS is just the fact that the project is deployed with such options toggled. Using ADB is always the case.~~

~~Also removing `DEBUG_FLAG_REMOTE_DEBUG_LOCALHOST`, which was being only used for that old Android scenario.~~

Reworked:
- _Commit 1:_ (the same as formerly but keeping localhost debug, needed for __`adb reverse`__)
'Remote debug over ADB' is removed as that will be always the case.
- _Commit 2:_
Fix Android remote debug not hitting breakpoints
RandomShaper committed an hour ago
A change in `Main`'s API is needed. Please read the comment in the diff for an explanation.