### PR TITLE
Fixed build for Visual Studio

### DIFF
--- a/editor/icons/SCsub
+++ b/editor/icons/SCsub
@@ -88,5 +88,4 @@ make_editor_icons_builder = Builder(action=make_editor_icons_action,
 env['BUILDERS']['MakeEditorIconsBuilder'] = make_editor_icons_builder
 env.Alias('editor_icons', [env.MakeEditorIconsBuilder('#editor/editor_icons.gen.h', Glob("*.svg"))])
 
-env.editor_sources.append("#editor/editor_icons.gen.h")
 Export('env')


### PR DESCRIPTION
This commit fixes an issue which breaks compilation with Visual Studio 2015. The file editor/editor_icons.gen.h does not need to be in the editor_sources list. Visual Studio does not recognize the extension .gen.h and assumes it to be an object file, causing error LNK1136.

Fixes #10532 