### PR TITLE
[2.1] Change order of Null check for ParallaxLayer

### DIFF
--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -32,10 +32,10 @@
 
 void ParallaxLayer::set_motion_scale(const Size2 &p_scale) {
 
+	motion_scale = p_scale;
+
 	if (!get_parent())
 		return;
-
-	motion_scale = p_scale;
 
 	ParallaxBackground *pb = get_parent()->cast_to<ParallaxBackground>();
 	if (is_inside_tree() && pb) {
@@ -52,10 +52,10 @@ Size2 ParallaxLayer::get_motion_scale() const {
 
 void ParallaxLayer::set_motion_offset(const Size2 &p_offset) {
 
+	motion_offset = p_offset;
+
 	if (!get_parent())
 		return;
-
-	motion_offset = p_offset;
 
 	ParallaxBackground *pb = get_parent()->cast_to<ParallaxBackground>();
 	if (is_inside_tree() && pb) {


### PR DESCRIPTION
The change in #10524 subtly changes the behavior of set_motion_scale()
and set_motion_offset() if the ParallaxLayer does not have a parent
node. Previously it would still set the corresponding property, but
after this change the property change would be discarded.

I'm not entirely sure if this actually matters as there doesn't appear
to be any code that picks up this change if the ParallaxLayer gets
re-parented later, but it's better to not change behavior regardless.