### PR TITLE
Moved member variables to initializer list

### DIFF
--- a/core/global_constants.cpp
+++ b/core/global_constants.cpp
@@ -45,15 +45,15 @@ struct _GlobalConstant {
 	_GlobalConstant() {}
 
 #ifdef DEBUG_METHODS_ENABLED
-	_GlobalConstant(const StringName &p_enum_name, const char *p_name, int p_value) {
-		enum_name = p_enum_name;
-		name = p_name;
-		value = p_value;
+	_GlobalConstant(const StringName &p_enum_name, const char *p_name, int p_value)
+		: enum_name(p_enum_name),
+		  name(p_name),
+		  value(p_value) {
 	}
 #else
-	_GlobalConstant(const char *p_name, int p_value) {
-		name = p_name;
-		value = p_value;
+	_GlobalConstant(const char *p_name, int p_value)
+		: name(p_name),
+		  value(p_value) {
 	}
 #endif
 };


### PR DESCRIPTION
Mitigates the following `cppcheck` message:

```
[core/global_constants.cpp:49]: (performance) Variable 'enum_name' is assigned in constructor body. Consider performing initialization in initialization list.
```