### PR TITLE
Improve Mac/UNIX conformance/reliability

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -315,7 +315,9 @@ OS::TimeZoneInfo OS_Unix::get_time_zone_info() const {
 
 void OS_Unix::delay_usec(uint32_t p_usec) const {
 
-	usleep(p_usec);
+	struct timespec rem = { p_usec / 1000000, (p_usec % 1000000) * 1000 };
+	while (nanosleep(&rem, &rem) == EINTR) {
+	}
 }
 uint64_t OS_Unix::get_ticks_usec() const {
 

--- a/drivers/unix/thread_posix.cpp
+++ b/drivers/unix/thread_posix.cpp
@@ -36,7 +36,17 @@
 #include <pthread_np.h>
 #endif
 
+#include "core/safe_refcount.h"
 #include "os/memory.h"
+
+static pthread_key_t _create_thread_id_key() {
+	pthread_key_t key;
+	pthread_key_create(&key, NULL);
+	return key;
+}
+
+pthread_key_t ThreadPosix::thread_id_key = _create_thread_id_key();
+Thread::ID ThreadPosix::next_thread_id = 0;
 
 Thread::ID ThreadPosix::get_id() const {
 
@@ -51,7 +61,8 @@ Thread *ThreadPosix::create_thread_posix() {
 void *ThreadPosix::thread_callback(void *userdata) {
 
 	ThreadPosix *t = reinterpret_cast<ThreadPosix *>(userdata);
-	t->id = (ID)pthread_self();
+	t->id = atomic_increment(&next_thread_id);
+	pthread_setspecific(thread_id_key, (void *)t->id);
 
 	ScriptServer::thread_enter(); //scripts may need to attach a stack
 
@@ -77,7 +88,7 @@ Thread *ThreadPosix::create_func_posix(ThreadCreateCallback p_callback, void *p_
 }
 Thread::ID ThreadPosix::get_thread_id_func_posix() {
 
-	return (ID)pthread_self();
+	return (ID)pthread_getspecific(thread_id_key);
 }
 void ThreadPosix::wait_to_finish_func_posix(Thread *p_thread) {
 

--- a/drivers/unix/thread_posix.h
+++ b/drivers/unix/thread_posix.h
@@ -42,6 +42,9 @@
 
 class ThreadPosix : public Thread {
 
+	static pthread_key_t thread_id_key;
+	static ID next_thread_id;
+
 	pthread_t pthread;
 	pthread_attr_t pthread_attr;
 	ThreadCreateCallback callback;

--- a/platform/android/thread_jandroid.h
+++ b/platform/android/thread_jandroid.h
@@ -41,6 +41,9 @@
 
 class ThreadAndroid : public Thread {
 
+	static pthread_key_t thread_id_key;
+	static ID next_thread_id;
+
 	pthread_t pthread;
 	pthread_attr_t pthread_attr;
 	ThreadCreateCallback callback;


### PR DESCRIPTION
### Commit 1:  _Make `OS::delay_usec()` more reliable on UNIX_

Implemented with `nanosleep()`. `usleep()` is deprecated.
Also loops to ensure that __at least__ the requested time is waited, accounting for spurious interruptions.

May help in situations like reattempting to connect to the debugger.

### Commit 2 __(UPDATED)__:  _Implement custom thread numbering for POSIX_

For every UNIX-derived (Android, Linux, macOS, iOS) flavor, a global counter is atomically incremented on thread start. That id is kept as thread-local storage.

Therefore, thread ids are sequential numbers, trivially comparable. This improves the previous state of things, in which `pthread_t` were casted to `Thread::ID` and unportabily compared. Also big, ugly thread ids appeared.