### PR TITLE
Removed unnecessary returns and break statements

### DIFF
--- a/main/tests/test_shader_lang.cpp
+++ b/main/tests/test_shader_lang.cpp
@@ -56,8 +56,6 @@ static String _mktab(int p_level) {
 static String _typestr(SL::DataType p_type) {
 
 	return ShaderLanguage::get_datatype_name(p_type);
-
-	return "";
 }
 
 static String _prestr(SL::DataPrecision p_pres) {

--- a/modules/gdscript/gd_function.h
+++ b/modules/gdscript/gd_function.h
@@ -210,8 +210,9 @@ public:
 #ifdef TOOLS_ENABLED
 		ERR_FAIL_INDEX_V(p_idx, arg_names.size(), StringName());
 		return arg_names[p_idx];
-#endif
+#else
 		return StringName();
+#endif
 	}
 	Variant get_default_argument(int p_idx) const {
 		ERR_FAIL_INDEX_V(p_idx, default_arguments.size(), Variant());

--- a/modules/gdscript/gd_script.cpp
+++ b/modules/gdscript/gd_script.cpp
@@ -559,8 +559,9 @@ bool GDScript::_update_exports() {
 
 	return changed;
 
-#endif
+#else
 	return false;
+#endif
 }
 
 void GDScript::update_exports() {

--- a/modules/visual_script/visual_script_expression.cpp
+++ b/modules/visual_script/visual_script_expression.cpp
@@ -585,7 +585,6 @@ Error VisualScriptExpression::_get_token(Token &r_token) {
 								r_token.type = TK_BASIC_TYPE;
 								r_token.value = i;
 								return OK;
-								break;
 							}
 						}
 

--- a/platform/android/godot_android.cpp
+++ b/platform/android/godot_android.cpp
@@ -833,7 +833,6 @@ void android_main(struct android_app *app) {
 			if (engine.requested_quit) {
 				engine_term_display(&engine);
 				exit(0);
-				return;
 			}
 
 			//     LOGI("end\n");

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1839,8 +1839,6 @@ Control *Control::find_prev_valid_focus() const {
 	}
 
 	return NULL;
-
-	return NULL;
 }
 
 Control::FocusMode Control::get_focus_mode() const {


### PR DESCRIPTION
Mitigates the following `cppcheck` messages:

```
[main/tests/test_shader_lang.cpp:60]: (style, inconclusive) Consecutive return, break, continue, goto or throw statements are unnecessary.
[modules/gdscript/gd_function.h:214]: (style, inconclusive) Consecutive return, break, continue, goto or throw statements are unnecessary.
[modules/gdscript/gd_script.cpp:563]: (style, inconclusive) Consecutive return, break, continue, goto or throw statements are unnecessary.
[modules/visual_script/visual_script_expression.cpp:588]: (style) Consecutive return, break, continue, goto or throw statements are unnecessary.
[platform/android/godot_android.cpp:836]: (style) Consecutive return, break, continue, goto or throw statements are unnecessary.
[scene/gui/control.cpp:1843]: (style, inconclusive) Consecutive return, break, continue, goto or throw statements are unnecessary.
```