### PR TITLE
Make cast_to a static member of Object. 

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2354,7 +2354,7 @@ Variant _ClassDB::instance(const StringName &p_class) const {
 	if (!obj)
 		return Variant();
 
-	Reference *r = obj->cast_to<Reference>();
+	Reference *r = Object::cast_to<Reference>(obj);
 	if (r) {
 		return REF(r);
 	} else {

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -463,8 +463,8 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 						obj->set(str, value);
 					}
 
-					if (obj->cast_to<Reference>()) {
-						REF ref = REF(obj->cast_to<Reference>());
+					if (Object::cast_to<Reference>(obj)) {
+						REF ref = REF(Object::cast_to<Reference>(obj));
 						r_variant = ref;
 					} else {
 						r_variant = obj;

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -713,7 +713,7 @@ Error ResourceInteractiveLoaderBinary::poll() {
 	}
 	ERR_FAIL_COND_V(!obj, ERR_FILE_CORRUPT);
 
-	Resource *r = obj->cast_to<Resource>();
+	Resource *r = Object::cast_to<Resource>(obj);
 	if (!r) {
 		error = ERR_FILE_CORRUPT;
 		memdelete(obj); //bye

--- a/core/make_binders.py
+++ b/core/make_binders.py
@@ -29,7 +29,7 @@ public:
 
 	virtual Variant call(Object* p_object,const Variant** p_args,int p_arg_count, Variant::CallError& r_error) {
 
-		T *instance=p_object->cast_to<T>();
+		T *instance=Object::cast_to<T>(p_object);
 		r_error.error=Variant::CallError::CALL_OK;
 #ifdef DEBUG_METHODS_ENABLED
 
@@ -57,7 +57,7 @@ public:
 #ifdef PTRCALL_ENABLED
 	virtual void ptrcall(Object*p_object,const void** p_args,void *r_ret) {
 
-		T *instance=p_object->cast_to<T>();
+		T *instance=Object::cast_to<T>(p_object);
 		$ifret PtrToArg<R>::encode( $ (instance->*method)($arg, PtrToArg<P@>::convert(p_args[@-1])$) $ifret ,r_ret)$ ;
 	}
 #endif

--- a/core/object.cpp
+++ b/core/object.cpp
@@ -654,7 +654,7 @@ void Object::call_multilevel(const StringName &p_method, const Variant **p_args,
 
 	if (p_method == CoreStringNames::get_singleton()->_free) {
 #ifdef DEBUG_ENABLED
-		if (cast_to<Reference>()) {
+		if (Object::cast_to<Reference>(this)) {
 			ERR_EXPLAIN("Can't 'free' a reference.");
 			ERR_FAIL();
 			return;
@@ -900,7 +900,7 @@ Variant Object::call(const StringName &p_method, const Variant **p_args, int p_a
 			r_error.error = Variant::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
 			return Variant();
 		}
-		if (cast_to<Reference>()) {
+		if (Object::cast_to<Reference>(this)) {
 			r_error.argument = 0;
 			r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD;
 			ERR_EXPLAIN("Can't 'free' a reference.");

--- a/core/object.h
+++ b/core/object.h
@@ -558,6 +558,46 @@ public:
 	void add_change_receptor(Object *p_receptor);
 	void remove_change_receptor(Object *p_receptor);
 
+	template <class T>
+	static T *cast_to(Object *p_object) {
+#ifdef DEBUG_ENABLED
+		// TODO there are some legitimate reasons to pass NULL as p_object.
+		// we need to figure out how to deal with that in debug mode.
+		// This code will return NULL for a NULL input in release mode also.
+		ERR_FAIL_COND_V(p_object == NULL, NULL);
+#endif
+#ifndef NO_SAFE_CAST
+		return dynamic_cast<T *>(p_object);
+#else
+		if (!p_object)
+			return NULL;
+		if (p_pobject->is_class_ptr(T::get_class_ptr_static()))
+			return static_cast<T *>(p_pobject);
+		else
+			return NULL;
+#endif
+	}
+
+	template <class T>
+	static const T *cast_to(const Object *p_object) {
+#ifdef DEBUG_ENABLED
+		// TODO there are some legitimate reasons to pass NULL as p_object.
+		// we need to figure out how to deal with that in debug mode.
+		// This code will return NULL for a NULL input in release mode also.
+		ERR_FAIL_COND_V(p_object == NULL, NULL);
+#endif
+#ifndef NO_SAFE_CAST
+		return dynamic_cast<const T *>(p_object);
+#else
+		if (!p_object)
+			return NULL;
+		if (p_pobject->is_class_ptr(T::get_class_ptr_static()))
+			return static_cast<const T *>(p_object);
+		else
+			return NULL;
+#endif
+	}
+
 // TODO: ensure 'this' is never NULL since it's UB, but by now, avoid warning flood
 #ifdef __clang__
 #pragma clang diagnostic push

--- a/core/object.h
+++ b/core/object.h
@@ -598,46 +598,6 @@ public:
 #endif
 	}
 
-// TODO: ensure 'this' is never NULL since it's UB, but by now, avoid warning flood
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wundefined-bool-conversion"
-#endif
-
-	template <class T>
-	T *cast_to() {
-
-#ifndef NO_SAFE_CAST
-		return SAFE_CAST<T *>(this);
-#else
-		if (!this)
-			return NULL;
-		if (is_class_ptr(T::get_class_ptr_static()))
-			return static_cast<T *>(this);
-		else
-			return NULL;
-#endif
-	}
-
-	template <class T>
-	const T *cast_to() const {
-
-#ifndef NO_SAFE_CAST
-		return SAFE_CAST<const T *>(this);
-#else
-		if (!this)
-			return NULL;
-		if (is_class_ptr(T::get_class_ptr_static()))
-			return static_cast<const T *>(this);
-		else
-			return NULL;
-#endif
-	}
-
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
-
 	enum {
 
 		NOTIFICATION_POSTINITIALIZE = 0,

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -171,7 +171,7 @@ static FileAccess *_OSPRF = NULL;
 
 static void _OS_printres(Object *p_obj) {
 
-	Resource *res = p_obj->cast_to<Resource>();
+	Resource *res = Object::cast_to<Resource>(p_obj);
 	if (!res)
 		return;
 

--- a/core/ref_ptr.cpp
+++ b/core/ref_ptr.cpp
@@ -69,7 +69,7 @@ RID RefPtr::get_rid() const {
 	Ref<Reference> *ref = reinterpret_cast<Ref<Reference> *>(&data[0]);
 	if (ref->is_null())
 		return RID();
-	Resource *res = (*ref)->cast_to<Resource>();
+	Resource *res = Object::cast_to<Resource>(ref->ptr());
 	if (res)
 		return res->get_rid();
 	return RID();

--- a/core/reference.cpp
+++ b/core/reference.cpp
@@ -98,7 +98,7 @@ Variant WeakRef::get_ref() const {
 	Object *obj = ObjectDB::get_instance(ref);
 	if (!obj)
 		return Variant();
-	Reference *r = obj->cast_to<Reference>();
+	Reference *r = cast_to<Reference>(obj);
 	if (r) {
 
 		return REF(r);

--- a/core/reference.h
+++ b/core/reference.h
@@ -180,7 +180,7 @@ public:
 			return;
 		}
 		Ref r;
-		r.reference = refb->cast_to<T>();
+		r.reference = Object::cast_to<T>(refb);
 		ref(r);
 		r.reference = NULL;
 	}
@@ -194,7 +194,7 @@ public:
 			return;
 		}
 		Ref r;
-		r.reference = refb->cast_to<T>();
+		r.reference = Object::cast_to<T>(refb);
 		ref(r);
 		r.reference = NULL;
 	}
@@ -209,7 +209,7 @@ public:
 			return;
 		}
 		Ref r;
-		r.reference = refb->cast_to<T>();
+		r.reference = Object::cast_to<T>(refb);
 		ref(r);
 		r.reference = NULL;
 	}
@@ -230,7 +230,7 @@ public:
 			return;
 		}
 		Ref r;
-		r.reference = refb->cast_to<T>();
+		r.reference = Object::cast_to<T>(refb);
 		ref(r);
 		r.reference = NULL;
 	}
@@ -254,7 +254,7 @@ public:
 			return;
 		}
 		Ref r;
-		r.reference = refb->cast_to<T>();
+		r.reference = Object::cast_to<T>(refb);
 		ref(r);
 		r.reference = NULL;
 	}
@@ -269,7 +269,7 @@ public:
 			return;
 		}
 		Ref r;
-		r.reference = refb->cast_to<T>();
+		r.reference = Object::cast_to<T>(refb);
 		ref(r);
 		r.reference = NULL;
 	}

--- a/core/undo_redo.cpp
+++ b/core/undo_redo.cpp
@@ -111,8 +111,8 @@ void UndoRedo::add_do_method(Object *p_object, const String &p_method, VARIANT_A
 	ERR_FAIL_COND((current_action + 1) >= actions.size());
 	Operation do_op;
 	do_op.object = p_object->get_instance_id();
-	if (p_object->cast_to<Resource>())
-		do_op.resref = Ref<Resource>(p_object->cast_to<Resource>());
+	if (Object::cast_to<Resource>(p_object))
+		do_op.resref = Ref<Resource>(Object::cast_to<Resource>(p_object));
 
 	do_op.type = Operation::TYPE_METHOD;
 	do_op.name = p_method;
@@ -135,8 +135,8 @@ void UndoRedo::add_undo_method(Object *p_object, const String &p_method, VARIANT
 
 	Operation undo_op;
 	undo_op.object = p_object->get_instance_id();
-	if (p_object->cast_to<Resource>())
-		undo_op.resref = Ref<Resource>(p_object->cast_to<Resource>());
+	if (Object::cast_to<Resource>(p_object))
+		undo_op.resref = Ref<Resource>(Object::cast_to<Resource>(p_object));
 
 	undo_op.type = Operation::TYPE_METHOD;
 	undo_op.name = p_method;
@@ -152,8 +152,8 @@ void UndoRedo::add_do_property(Object *p_object, const String &p_property, const
 	ERR_FAIL_COND((current_action + 1) >= actions.size());
 	Operation do_op;
 	do_op.object = p_object->get_instance_id();
-	if (p_object->cast_to<Resource>())
-		do_op.resref = Ref<Resource>(p_object->cast_to<Resource>());
+	if (Object::cast_to<Resource>(p_object))
+		do_op.resref = Ref<Resource>(Object::cast_to<Resource>(p_object));
 
 	do_op.type = Operation::TYPE_PROPERTY;
 	do_op.name = p_property;
@@ -171,8 +171,8 @@ void UndoRedo::add_undo_property(Object *p_object, const String &p_property, con
 
 	Operation undo_op;
 	undo_op.object = p_object->get_instance_id();
-	if (p_object->cast_to<Resource>())
-		undo_op.resref = Ref<Resource>(p_object->cast_to<Resource>());
+	if (Object::cast_to<Resource>(p_object))
+		undo_op.resref = Ref<Resource>(Object::cast_to<Resource>(p_object));
 
 	undo_op.type = Operation::TYPE_PROPERTY;
 	undo_op.name = p_property;
@@ -185,8 +185,8 @@ void UndoRedo::add_do_reference(Object *p_object) {
 	ERR_FAIL_COND((current_action + 1) >= actions.size());
 	Operation do_op;
 	do_op.object = p_object->get_instance_id();
-	if (p_object->cast_to<Resource>())
-		do_op.resref = Ref<Resource>(p_object->cast_to<Resource>());
+	if (Object::cast_to<Resource>(p_object))
+		do_op.resref = Ref<Resource>(Object::cast_to<Resource>(p_object));
 
 	do_op.type = Operation::TYPE_REFERENCE;
 	actions[current_action + 1].do_ops.push_back(do_op);
@@ -202,8 +202,8 @@ void UndoRedo::add_undo_reference(Object *p_object) {
 
 	Operation undo_op;
 	undo_op.object = p_object->get_instance_id();
-	if (p_object->cast_to<Resource>())
-		undo_op.resref = Ref<Resource>(p_object->cast_to<Resource>());
+	if (Object::cast_to<Resource>(p_object))
+		undo_op.resref = Ref<Resource>(Object::cast_to<Resource>(p_object));
 
 	undo_op.type = Operation::TYPE_REFERENCE;
 	actions[current_action + 1].undo_ops.push_back(undo_op);
@@ -270,7 +270,7 @@ void UndoRedo::_process_operation_list(List<Operation>::Element *E) {
 
 				obj->call(op.name, VARIANT_ARGS_FROM_ARRAY(op.args));
 #ifdef TOOLS_ENABLED
-				Resource *res = obj->cast_to<Resource>();
+				Resource *res = Object::cast_to<Resource>(obj);
 				if (res)
 					res->set_edited(true);
 
@@ -284,7 +284,7 @@ void UndoRedo::_process_operation_list(List<Operation>::Element *E) {
 
 				obj->set(op.name, op.args[0]);
 #ifdef TOOLS_ENABLED
-				Resource *res = obj->cast_to<Resource>();
+				Resource *res = Object::cast_to<Resource>(obj);
 				if (res)
 					res->set_edited(true);
 #endif

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -1764,14 +1764,14 @@ Variant::operator Object *() const {
 Variant::operator Node *() const {
 
 	if (type == OBJECT)
-		return _get_obj().obj ? _get_obj().obj->cast_to<Node>() : NULL;
+		return Object::cast_to<Node>(_get_obj().obj);
 	else
 		return NULL;
 }
 Variant::operator Control *() const {
 
 	if (type == OBJECT)
-		return _get_obj().obj ? _get_obj().obj->cast_to<Control>() : NULL;
+		return Object::cast_to<Control>(_get_obj().obj);
 	else
 		return NULL;
 }

--- a/core/variant_parser.cpp
+++ b/core/variant_parser.cpp
@@ -742,7 +742,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 						return err;
 
 					if (token.type == TK_PARENTHESIS_CLOSE) {
-						Reference *reference = obj->cast_to<Reference>();
+						Reference *reference = Object::cast_to<Reference>(obj);
 						if (reference) {
 							value = REF(reference);
 						} else {

--- a/drivers/png/resource_saver_png.cpp
+++ b/drivers/png/resource_saver_png.cpp
@@ -187,7 +187,7 @@ bool ResourceSaverPNG::recognize(const RES &p_resource) const {
 }
 void ResourceSaverPNG::get_recognized_extensions(const RES &p_resource, List<String> *p_extensions) const {
 
-	if (p_resource->cast_to<Texture>()) {
+	if (Object::cast_to<Texture>(*p_resource)) {
 		p_extensions->push_back("png");
 	}
 }

--- a/editor/animation_editor.cpp
+++ b/editor/animation_editor.cpp
@@ -3249,9 +3249,9 @@ void AnimationKeyEditor::insert_value_key(const String &p_property, const Varian
 	//let's build a node path
 	ERR_FAIL_COND(history->get_path_size() == 0);
 	Object *obj = ObjectDB::get_instance(history->get_path_object(0));
-	ERR_FAIL_COND(!obj || !obj->cast_to<Node>());
+	ERR_FAIL_COND(!Object::cast_to<Node>(obj));
 
-	Node *node = obj->cast_to<Node>();
+	Node *node = Object::cast_to<Node>(obj);
 
 	String path = root->get_path_to(node);
 

--- a/editor/array_property_edit.cpp
+++ b/editor/array_property_edit.cpp
@@ -273,11 +273,7 @@ void ArrayPropertyEdit::edit(Object *p_obj, const StringName &p_prop, const Stri
 
 Node *ArrayPropertyEdit::get_node() {
 
-	Object *o = ObjectDB::get_instance(obj);
-	if (!o)
-		return NULL;
-
-	return o->cast_to<Node>();
+	return Object::cast_to<Node>(ObjectDB::get_instance(obj));
 }
 
 void ArrayPropertyEdit::_bind_methods() {

--- a/editor/asset_library_editor_plugin.cpp
+++ b/editor/asset_library_editor_plugin.cpp
@@ -595,7 +595,7 @@ void EditorAssetLibrary::_install_asset() {
 
 	for (int i = 0; i < downloads_hb->get_child_count(); i++) {
 
-		EditorAssetLibraryItemDownload *d = downloads_hb->get_child(i)->cast_to<EditorAssetLibraryItemDownload>();
+		EditorAssetLibraryItemDownload *d = Object::cast_to<EditorAssetLibraryItemDownload>(downloads_hb->get_child(i));
 		if (d && d->get_asset_id() == description->get_asset_id()) {
 
 			if (EditorNode::get_singleton() != NULL)

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -664,7 +664,7 @@ void ConnectionsDock::update_tree() {
 				if (!(c.flags & CONNECT_PERSIST))
 					continue;
 
-				Node *target = c.target->cast_to<Node>();
+				Node *target = Object::cast_to<Node>(c.target);
 				if (!target)
 					continue;
 

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -50,7 +50,7 @@ void DependencyEditor::_searched(const String &p_path) {
 
 void DependencyEditor::_load_pressed(Object *p_item, int p_cell, int p_button) {
 
-	TreeItem *ti = p_item->cast_to<TreeItem>();
+	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 	String fname = ti->get_text(0);
 	replacing = ti->get_text(1);
 
@@ -626,7 +626,7 @@ void OrphanResourcesDialog::_delete_confirm() {
 
 void OrphanResourcesDialog::_button_pressed(Object *p_item, int p_column, int p_id) {
 
-	TreeItem *ti = p_item->cast_to<TreeItem>();
+	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 
 	String path = ti->get_metadata(0);
 	dep_edit->edit(path);

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -376,7 +376,7 @@ void EditorAudioBus::_effect_add(int p_which) {
 
 	Object *fx = ClassDB::instance(name);
 	ERR_FAIL_COND(!fx);
-	AudioEffect *afx = fx->cast_to<AudioEffect>();
+	AudioEffect *afx = Object::cast_to<AudioEffect>(fx);
 	ERR_FAIL_COND(!afx);
 	Ref<AudioEffect> afxr = Ref<AudioEffect>(afx);
 
@@ -865,7 +865,7 @@ void EditorAudioBuses::_update_sends() {
 
 void EditorAudioBuses::_delete_bus(Object *p_which) {
 
-	EditorAudioBus *bus = p_which->cast_to<EditorAudioBus>();
+	EditorAudioBus *bus = Object::cast_to<EditorAudioBus>(p_which);
 	int index = bus->get_index();
 	if (index == 0) {
 		EditorNode::get_singleton()->show_warning("Master bus can't be deleted!");
@@ -922,7 +922,7 @@ void EditorAudioBuses::_request_drop_end() {
 		drop_end = memnew(EditorAudioBusDrop);
 
 		bus_hb->add_child(drop_end);
-		drop_end->set_custom_minimum_size(bus_hb->get_child(0)->cast_to<Control>()->get_size());
+		drop_end->set_custom_minimum_size(Object::cast_to<Control>(bus_hb->get_child(0))->get_size());
 		drop_end->connect("dropped", this, "_drop_at_index", varray(), CONNECT_DEFERRED);
 	}
 }
@@ -1158,9 +1158,9 @@ void EditorAudioBuses::open_layout(const String &p_path) {
 
 void AudioBusesEditorPlugin::edit(Object *p_node) {
 
-	if (p_node->cast_to<AudioBusLayout>()) {
+	if (Object::cast_to<AudioBusLayout>(p_node)) {
 
-		String path = p_node->cast_to<AudioBusLayout>()->get_path();
+		String path = Object::cast_to<AudioBusLayout>(p_node)->get_path();
 		if (path.is_resource_file()) {
 			audio_bus_editor->open_layout(path);
 		}
@@ -1169,7 +1169,7 @@ void AudioBusesEditorPlugin::edit(Object *p_node) {
 
 bool AudioBusesEditorPlugin::handles(Object *p_node) const {
 
-	return (p_node->cast_to<AudioBusLayout>() != NULL);
+	return (Object::cast_to<AudioBusLayout>(p_node) != NULL);
 }
 
 void AudioBusesEditorPlugin::make_visible(bool p_visible) {

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -238,7 +238,7 @@ void EditorAutoloadSettings::_autoload_edited() {
 
 void EditorAutoloadSettings::_autoload_button_pressed(Object *p_item, int p_column, int p_button) {
 
-	TreeItem *ti = p_item->cast_to<TreeItem>();
+	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 
 	String name = "autoload/" + ti->get_text(0);
 

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -75,7 +75,7 @@ void EditorHistory::_add_object(ObjectID p_object, const String &p_property, int
 
 	Object *obj = ObjectDB::get_instance(p_object);
 	ERR_FAIL_COND(!obj);
-	Reference *r = obj->cast_to<Reference>();
+	Reference *r = Object::cast_to<Reference>(obj);
 	Obj o;
 	if (r)
 		o.ref = REF(r);

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -236,10 +236,7 @@ public:
 	T *get_node_editor_data(Node *p_node) {
 		if (!selection.has(p_node))
 			return NULL;
-		Object *obj = selection[p_node];
-		if (!obj)
-			return NULL;
-		return obj->cast_to<T>();
+		return Object::cast_to<T>(selection[p_node]);
 	}
 
 	void add_editor_plugin(Object *p_object);

--- a/editor/editor_dir_dialog.cpp
+++ b/editor/editor_dir_dialog.cpp
@@ -114,7 +114,7 @@ void EditorDirDialog::_notification(int p_what) {
 
 void EditorDirDialog::_item_collapsed(Object *p_item) {
 
-	TreeItem *item = p_item->cast_to<TreeItem>();
+	TreeItem *item = Object::cast_to<TreeItem>(p_item);
 
 	if (updating || item->is_collapsed())
 		return;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -930,7 +930,7 @@ void EditorNode::_save_scene(String p_file, int idx) {
 		// we must update it, but also let the previous scene state go, as
 		// old version still work for referencing changes in instanced or inherited scenes
 
-		sdata = Ref<PackedScene>(ResourceCache::get(p_file)->cast_to<PackedScene>());
+		sdata = Ref<PackedScene>(Object::cast_to<PackedScene>(ResourceCache::get(p_file)));
 		if (sdata.is_valid())
 			sdata->recreate_state();
 		else
@@ -1291,9 +1291,9 @@ void EditorNode::_dialog_action(String p_file) {
 			uint32_t current = editor_history.get_current();
 			Object *current_obj = current > 0 ? ObjectDB::get_instance(current) : NULL;
 
-			ERR_FAIL_COND(!current_obj->cast_to<Resource>())
+			ERR_FAIL_COND(!Object::cast_to<Resource>(current_obj))
 
-			RES current_res = RES(current_obj->cast_to<Resource>());
+			RES current_res = RES(Object::cast_to<Resource>(current_obj));
 
 			save_resource_in_path(current_res, p_file);
 
@@ -1428,8 +1428,8 @@ void EditorNode::_prepare_history() {
 			icon = base_icon;
 
 		String text;
-		if (obj->cast_to<Resource>()) {
-			Resource *r = obj->cast_to<Resource>();
+		if (Object::cast_to<Resource>(obj)) {
+			Resource *r = Object::cast_to<Resource>(obj);
 			if (r->get_path().is_resource_file())
 				text = r->get_path().get_file();
 			else if (r->get_name() != String()) {
@@ -1437,8 +1437,8 @@ void EditorNode::_prepare_history() {
 			} else {
 				text = r->get_class();
 			}
-		} else if (obj->cast_to<Node>()) {
-			text = obj->cast_to<Node>()->get_name();
+		} else if (Object::cast_to<Node>(obj)) {
+			text = Object::cast_to<Node>(obj)->get_name();
 		} else {
 			text = obj->get_class();
 		}
@@ -1536,7 +1536,7 @@ void EditorNode::_edit_current() {
 
 	if (is_resource) {
 
-		Resource *current_res = current_obj->cast_to<Resource>();
+		Resource *current_res = Object::cast_to<Resource>(current_obj);
 		ERR_FAIL_COND(!current_res);
 		scene_tree_dock->set_selected(NULL);
 		property_editor->edit(current_res);
@@ -1548,7 +1548,7 @@ void EditorNode::_edit_current() {
 		//top_pallete->set_current_tab(1);
 	} else if (is_node) {
 
-		Node *current_node = current_obj->cast_to<Node>();
+		Node *current_node = Object::cast_to<Node>(current_obj);
 		ERR_FAIL_COND(!current_node);
 		//		ERR_FAIL_COND(!current_node->is_inside_tree());
 
@@ -1688,7 +1688,7 @@ void EditorNode::_resource_created() {
 	Object *c = create_dialog->instance_selected();
 
 	ERR_FAIL_COND(!c);
-	Resource *r = c->cast_to<Resource>();
+	Resource *r = Object::cast_to<Resource>(c);
 	ERR_FAIL_COND(!r);
 
 	REF res(r);
@@ -2273,9 +2273,9 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			uint32_t current = editor_history.get_current();
 			Object *current_obj = current > 0 ? ObjectDB::get_instance(current) : NULL;
 
-			ERR_FAIL_COND(!current_obj->cast_to<Resource>())
+			ERR_FAIL_COND(!Object::cast_to<Resource>(current_obj))
 
-			RES current_res = RES(current_obj->cast_to<Resource>());
+			RES current_res = RES(Object::cast_to<Resource>(current_obj));
 
 			save_resource(current_res);
 
@@ -2285,9 +2285,9 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			uint32_t current = editor_history.get_current();
 			Object *current_obj = current > 0 ? ObjectDB::get_instance(current) : NULL;
 
-			ERR_FAIL_COND(!current_obj->cast_to<Resource>())
+			ERR_FAIL_COND(!Object::cast_to<Resource>(current_obj))
 
-			RES current_res = RES(current_obj->cast_to<Resource>());
+			RES current_res = RES(Object::cast_to<Resource>(current_obj));
 
 			save_resource_as(current_res);
 
@@ -2297,9 +2297,9 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			uint32_t current = editor_history.get_current();
 			Object *current_obj = current > 0 ? ObjectDB::get_instance(current) : NULL;
 
-			ERR_FAIL_COND(!current_obj->cast_to<Resource>())
+			ERR_FAIL_COND(!Object::cast_to<Resource>(current_obj))
 
-			RES current_res = RES(current_obj->cast_to<Resource>());
+			RES current_res = RES(Object::cast_to<Resource>(current_obj));
 			current_res->set_path("");
 			_edit_current();
 		} break;
@@ -2308,9 +2308,9 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			uint32_t current = editor_history.get_current();
 			Object *current_obj = current > 0 ? ObjectDB::get_instance(current) : NULL;
 
-			ERR_FAIL_COND(!current_obj->cast_to<Resource>())
+			ERR_FAIL_COND(!Object::cast_to<Resource>(current_obj))
 
-			RES current_res = RES(current_obj->cast_to<Resource>());
+			RES current_res = RES(Object::cast_to<Resource>(current_obj));
 
 			EditorSettings::get_singleton()->set_resource_clipboard(current_res);
 
@@ -3038,8 +3038,8 @@ void EditorNode::set_edited_scene(Node *p_scene) {
 	}
 	get_editor_data().set_edited_scene_root(p_scene);
 
-	if (p_scene && p_scene->cast_to<Popup>())
-		p_scene->cast_to<Popup>()->show(); //show popups
+	if (Object::cast_to<Popup>(p_scene))
+		Object::cast_to<Popup>(p_scene)->show(); //show popups
 	scene_tree_dock->set_edited_scene(p_scene);
 	if (get_tree())
 		get_tree()->set_edited_scene_root(p_scene);
@@ -3182,8 +3182,8 @@ void EditorNode::set_current_scene(int p_idx) {
 
 	Node *new_scene = editor_data.get_edited_scene_root();
 
-	if (new_scene && new_scene->cast_to<Popup>())
-		new_scene->cast_to<Popup>()->show(); //show popups
+	if (Object::cast_to<Popup>(new_scene))
+		Object::cast_to<Popup>(new_scene)->show(); //show popups
 
 	//print_line("set current 3 ");
 
@@ -3333,7 +3333,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 
 	if (ResourceCache::has(lpath)) {
 		//used from somewhere else? no problem! update state and replace sdata
-		Ref<PackedScene> ps = Ref<PackedScene>(ResourceCache::get(lpath)->cast_to<PackedScene>());
+		Ref<PackedScene> ps = Ref<PackedScene>(Object::cast_to<PackedScene>(ResourceCache::get(lpath)));
 		if (ps.is_valid()) {
 			ps->replace_state(sdata->get_state());
 			ps->set_last_modified_time(sdata->get_last_modified_time());
@@ -3461,7 +3461,7 @@ void EditorNode::_property_keyed(const String &p_keyed, const Variant &p_value, 
 
 void EditorNode::_transform_keyed(Object *sp, const String &p_sub, const Transform &p_key) {
 
-	Spatial *s = sp->cast_to<Spatial>();
+	Spatial *s = Object::cast_to<Spatial>(sp);
 	if (!s)
 		return;
 	AnimationPlayerEditor::singleton->get_key_editor()->insert_transform_key(s, p_sub, p_key);
@@ -3478,7 +3478,7 @@ void EditorNode::update_keying() {
 		if (editor_history.get_path_size() >= 1) {
 
 			Object *obj = ObjectDB::get_instance(editor_history.get_path_object(0));
-			if (obj && obj->cast_to<Node>()) {
+			if (Object::cast_to<Node>(obj)) {
 
 				valid = true;
 			}
@@ -4200,7 +4200,7 @@ void EditorNode::_load_docks_from_config(Ref<ConfigFile> p_layout, const String 
 			for (int k = 0; k < DOCK_SLOT_MAX; k++) {
 				if (!dock_slot[k]->has_node(name))
 					continue;
-				node = dock_slot[k]->get_node(name)->cast_to<Control>();
+				node = Object::cast_to<Control>(dock_slot[k]->get_node(name));
 				if (!node)
 					continue;
 				atidx = k;
@@ -4785,7 +4785,7 @@ void EditorNode::reload_scene(const String &p_path) {
 		if (E->get()->get_path().begins_with(p_path + "::")) //subresources of existing scene
 			to_clear.push_back(E->get());
 
-		if (!E->get()->cast_to<Texture>())
+		if (!cast_to<Texture>(E->get().ptr()))
 			continue;
 		if (!E->get()->get_path().is_resource_file() && !E->get()->get_path().is_abs_path())
 			continue;
@@ -4926,13 +4926,13 @@ void EditorNode::_dim_timeout() {
 void EditorNode::_check_gui_base_size() {
 	if (gui_base->get_size().width > 1200 * EDSCALE) {
 		for (int i = 0; i < singleton->main_editor_button_vb->get_child_count(); i++) {
-			ToolButton *btn = singleton->main_editor_button_vb->get_child(i)->cast_to<ToolButton>();
+			ToolButton *btn = Object::cast_to<ToolButton>(singleton->main_editor_button_vb->get_child(i));
 			if (btn == singleton->distraction_free) continue;
 			btn->set_text(btn->get_name());
 		}
 	} else {
 		for (int i = 0; i < singleton->main_editor_button_vb->get_child_count(); i++) {
-			ToolButton *btn = singleton->main_editor_button_vb->get_child(i)->cast_to<ToolButton>();
+			ToolButton *btn = Object::cast_to<ToolButton>(singleton->main_editor_button_vb->get_child(i));
 			if (btn == singleton->distraction_free) continue;
 			btn->set_text("");
 		}
@@ -5056,7 +5056,7 @@ EditorNode::EditorNode() {
 	ResourceLoader::clear_translation_remaps(); //no remaps using during editor
 	editor_initialize_certificates(); //for asset sharing
 
-	InputDefault *id = Input::get_singleton()->cast_to<InputDefault>();
+	InputDefault *id = Object::cast_to<InputDefault>(Input::get_singleton());
 
 	if (id) {
 

--- a/editor/editor_path.cpp
+++ b/editor/editor_path.cpp
@@ -139,9 +139,9 @@ void EditorPath::_notification(int p_what) {
 					if (left < 0)
 						continue;
 					String name;
-					if (obj->cast_to<Resource>()) {
+					if (Object::cast_to<Resource>(obj)) {
 
-						Resource *r = obj->cast_to<Resource>();
+						Resource *r = Object::cast_to<Resource>(obj);
 						if (r->get_path().is_resource_file())
 							name = r->get_path().get_file();
 						else
@@ -149,11 +149,11 @@ void EditorPath::_notification(int p_what) {
 
 						if (name == "")
 							name = r->get_class();
-					} else if (obj->cast_to<Node>()) {
+					} else if (Object::cast_to<Node>(obj)) {
 
-						name = obj->cast_to<Node>()->get_name();
-					} else if (obj->cast_to<Resource>() && obj->cast_to<Resource>()->get_name() != "") {
-						name = obj->cast_to<Resource>()->get_name();
+						name = Object::cast_to<Node>(obj)->get_name();
+					} else if (Object::cast_to<Resource>(obj) && Object::cast_to<Resource>(obj)->get_name() != "") {
+						name = Object::cast_to<Resource>(obj)->get_name();
 					} else {
 						name = obj->get_class();
 					}

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -155,7 +155,7 @@ void EditorPlugin::add_tool_menu_item(const String &p_name, Object *p_handler, c
 void EditorPlugin::add_tool_submenu_item(const String &p_name, Object *p_submenu) {
 
 	ERR_FAIL_NULL(p_submenu);
-	PopupMenu *submenu = p_submenu->cast_to<PopupMenu>();
+	PopupMenu *submenu = Object::cast_to<PopupMenu>(p_submenu);
 	ERR_FAIL_NULL(submenu);
 	//EditorNode::get_singleton()->add_tool_submenu_item(p_name, submenu);
 }

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -804,10 +804,7 @@ void EditorSettings::notify_changes() {
 
 	_THREAD_SAFE_METHOD_
 
-	SceneTree *sml = NULL;
-
-	if (OS::get_singleton()->get_main_loop())
-		sml = OS::get_singleton()->get_main_loop()->cast_to<SceneTree>();
+	SceneTree *sml = Object::cast_to<SceneTree>(OS::get_singleton()->get_main_loop());
 
 	if (!sml) {
 		return;

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -65,7 +65,7 @@ void GroupsEditor::_remove_group(Object *p_item, int p_column, int p_id) {
 	if (!node)
 		return;
 
-	TreeItem *ti = p_item->cast_to<TreeItem>();
+	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 	if (!ti)
 		return;
 

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -320,7 +320,7 @@ Error ColladaImport::_create_scene(Collada::Node *p_node, Spatial *p_parent) {
 			} else {
 				//mesh since nothing else
 				node = memnew(MeshInstance);
-				node->cast_to<MeshInstance>()->set_flag(GeometryInstance::FLAG_USE_BAKED_LIGHT, true);
+				Object::cast_to<MeshInstance>(node)->set_flag(GeometryInstance::FLAG_USE_BAKED_LIGHT, true);
 			}
 		} break;
 		case Collada::Node::TYPE_SKELETON: {
@@ -1448,9 +1448,9 @@ Error ColladaImport::_create_resources(Collada::Node *p_node) {
 		Spatial *node = node_map[p_node->id].node;
 		Collada::NodeGeometry *ng = static_cast<Collada::NodeGeometry *>(p_node);
 
-		if (node->cast_to<Path>()) {
+		if (Object::cast_to<Path>(node)) {
 
-			Path *path = node->cast_to<Path>();
+			Path *path = Object::cast_to<Path>(node);
 
 			String curve = ng->source;
 
@@ -1523,11 +1523,11 @@ Error ColladaImport::_create_resources(Collada::Node *p_node) {
 			}
 		}
 
-		if (node->cast_to<MeshInstance>()) {
+		if (Object::cast_to<MeshInstance>(node)) {
 
 			Collada::NodeGeometry *ng = static_cast<Collada::NodeGeometry *>(p_node);
 
-			MeshInstance *mi = node->cast_to<MeshInstance>();
+			MeshInstance *mi = Object::cast_to<MeshInstance>(node);
 
 			ERR_FAIL_COND_V(!mi, ERR_BUG);
 
@@ -1561,7 +1561,7 @@ Error ColladaImport::_create_resources(Collada::Node *p_node) {
 					}
 					ERR_FAIL_COND_V(!node_map.has(skname), ERR_INVALID_DATA);
 					NodeMap nmsk = node_map[skname];
-					Skeleton *sk = nmsk.node->cast_to<Skeleton>();
+					Skeleton *sk = Object::cast_to<Skeleton>(nmsk.node);
 					ERR_FAIL_COND_V(!sk, ERR_INVALID_DATA);
 					ERR_FAIL_COND_V(!skeleton_bone_map.has(sk), ERR_INVALID_DATA);
 					Map<String, int> &bone_remap_map = skeleton_bone_map[sk];
@@ -2092,7 +2092,7 @@ void ColladaImport::create_animation(int p_clip, bool p_make_tracks_in_all_bones
 
 			if (nm.bone >= 0) {
 				//make bone transform relative to rest (in case of skeleton)
-				Skeleton *sk = nm.node->cast_to<Skeleton>();
+				Skeleton *sk = Object::cast_to<Skeleton>(nm.node);
 				if (sk) {
 
 					xform = sk->get_bone_rest(nm.bone).affine_inverse() * xform;

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -172,9 +172,9 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
 		return NULL;
 	}
 #if 0
-	if (p_node->cast_to<MeshInstance>()) {
+	if (Object::cast_to<MeshInstance>(p_node)) {
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 		bool bb = false;
 
@@ -203,9 +203,9 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
 		}
 	}
 #endif
-	if (p_node->cast_to<MeshInstance>()) {
+	if (Object::cast_to<MeshInstance>(p_node)) {
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 		Ref<ArrayMesh> m = mi->get_mesh();
 
@@ -232,9 +232,9 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
 		}
 	}
 
-	if (p_node->cast_to<AnimationPlayer>()) {
+	if (Object::cast_to<AnimationPlayer>(p_node)) {
 		//remove animations referencing non-importable nodes
-		AnimationPlayer *ap = p_node->cast_to<AnimationPlayer>();
+		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node);
 
 		List<StringName> anims;
 		ap->get_animation_list(&anims);
@@ -257,9 +257,9 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
 		}
 	}
 #if 0
-	if (p_node->cast_to<MeshInstance>()) {
+	if (Object::cast_to<MeshInstance>(p_node)) {
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 		String str;
 
@@ -269,9 +269,9 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
 			str = mi->get_mesh()->get_name();
 		}
 
-		if (p_node->get_parent() && p_node->get_parent()->cast_to<MeshInstance>()) {
-			MeshInstance *mi = p_node->cast_to<MeshInstance>();
-			MeshInstance *mip = p_node->get_parent()->cast_to<MeshInstance>();
+		if (Object::cast_to<MeshInstance>(p_node->get_parent())) {
+			MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
+			MeshInstance *mip = Object::cast_to<MeshInstance>(p_node->get_parent());
 			String d = str.substr(str.find("imp") + 3, str.length());
 			if (d != "") {
 				if ((d[0] < '0' || d[0] > '9'))
@@ -307,9 +307,9 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
 
 #endif
 #if 0
-    if (p_flags&SCENE_FLAG_CREATE_LODS && p_node->cast_to<MeshInstance>()) {
+    if (p_flags&SCENE_FLAG_CREATE_LODS && Object::cast_to<MeshInstance>(p_node)) {
 
-	MeshInstance *mi = p_node->cast_to<MeshInstance>();
+	MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 	String str;
 
@@ -321,9 +321,9 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
 	}
 
 
-	if (p_node->get_parent() && p_node->get_parent()->cast_to<MeshInstance>()) {
-	    MeshInstance *mi = p_node->cast_to<MeshInstance>();
-	    MeshInstance *mip = p_node->get_parent()->cast_to<MeshInstance>();
+	if (Object::cast_to<MeshInstance>(p_node->get_parent())) {
+	    MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
+	    MeshInstance *mip = Object::cast_to<MeshInstance>(p_node->get_parent());
 	    String d=str.substr(str.find("lod")+3,str.length());
 	    if (d!="") {
 		if ((d[0]<'0' || d[0]>'9'))
@@ -356,9 +356,9 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
     }
 
 
-	if (p_flags&SCENE_FLAG_DETECT_LIGHTMAP_LAYER && _teststr(name,"lm") && p_node->cast_to<MeshInstance>()) {
+	if (p_flags&SCENE_FLAG_DETECT_LIGHTMAP_LAYER && _teststr(name,"lm") && Object::cast_to<MeshInstance>(p_node)) {
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 		String str=name;
 		int layer = str.substr(str.find("lm")+3,str.length()).to_int();
@@ -370,19 +370,18 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
 		if (isroot)
 			return p_node;
 
-		if (p_node->cast_to<MeshInstance>()) {
-			MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		if (MeshInstance *mi = Object::cast_to<MeshInstance>(p_node)) {
 			Node *col = mi->create_trimesh_collision_node();
 			ERR_FAIL_COND_V(!col, NULL);
 
 			col->set_name(_fixstr(name, "colonly"));
-			col->cast_to<Spatial>()->set_transform(mi->get_transform());
+			Object::cast_to<Spatial>(col)->set_transform(mi->get_transform());
 			p_node->replace_by(col);
 			memdelete(p_node);
 			p_node = col;
 
-			StaticBody *sb = col->cast_to<StaticBody>();
-			CollisionShape *colshape = sb->get_child(0)->cast_to<CollisionShape>();
+			StaticBody *sb = Object::cast_to<StaticBody>(col);
+			CollisionShape *colshape = Object::cast_to<CollisionShape>(sb->get_child(0));
 			colshape->set_name("shape");
 			colshape->set_owner(p_node->get_owner());
 		} else if (p_node->has_meta("empty_draw_type")) {
@@ -390,7 +389,7 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
 			print_line(empty_draw_type);
 			StaticBody *sb = memnew(StaticBody);
 			sb->set_name(_fixstr(name, "colonly"));
-			sb->cast_to<Spatial>()->set_transform(p_node->cast_to<Spatial>()->get_transform());
+			Object::cast_to<Spatial>(sb)->set_transform(Object::cast_to<Spatial>(p_node)->get_transform());
 			p_node->replace_by(sb);
 			memdelete(p_node);
 			CollisionShape *colshape = memnew(CollisionShape);
@@ -404,7 +403,7 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
 				rayShape->set_length(1);
 				colshape->set_shape(rayShape);
 				colshape->set_name("RayShape");
-				sb->cast_to<Spatial>()->rotate_x(Math_PI / 2);
+				Object::cast_to<Spatial>(sb)->rotate_x(Math_PI / 2);
 			} else if (empty_draw_type == "IMAGE") {
 				PlaneShape *planeShape = memnew(PlaneShape);
 				colshape->set_shape(planeShape);
@@ -419,13 +418,13 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
 			colshape->set_owner(sb->get_owner());
 		}
 
-	} else if (_teststr(name, "rigid") && p_node->cast_to<MeshInstance>()) {
+	} else if (_teststr(name, "rigid") && Object::cast_to<MeshInstance>(p_node)) {
 
 		if (isroot)
 			return p_node;
 
 		// get mesh instance and bounding box
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 		Rect3 aabb = mi->get_aabb();
 
 		// create a new rigid body collision node
@@ -436,12 +435,12 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
 		// remove node name postfix
 		col->set_name(_fixstr(name, "rigid"));
 		// get mesh instance xform matrix to the rigid body collision node
-		col->cast_to<Spatial>()->set_transform(mi->get_transform());
+		Object::cast_to<Spatial>(col)->set_transform(mi->get_transform());
 		// save original node by duplicating it into a new instance and correcting the name
 		Node *mesh = p_node->duplicate();
 		mesh->set_name(_fixstr(name, "rigid"));
 		// reset the xform matrix of the duplicated node so it can inherit parent node xform
-		mesh->cast_to<Spatial>()->set_transform(Transform(Basis()));
+		Object::cast_to<Spatial>(mesh)->set_transform(Transform(Basis()));
 		// reparent the new mesh node to the rigid body collision node
 		p_node->add_child(mesh);
 		mesh->set_owner(p_node->get_owner());
@@ -451,7 +450,7 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
 		p_node = col;
 
 		// create an alias for the rigid body collision node
-		RigidBody *rb = col->cast_to<RigidBody>();
+		RigidBody *rb = Object::cast_to<RigidBody>(col);
 		// create a new Box collision shape and set the right extents
 		Ref<BoxShape> shape = memnew(BoxShape);
 		shape->set_extents(aabb.get_size() * 0.5);
@@ -462,9 +461,9 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
 		rb->add_child(colshape);
 		colshape->set_owner(p_node->get_owner());
 
-	} else if (_teststr(name, "col") && p_node->cast_to<MeshInstance>()) {
+	} else if (_teststr(name, "col") && Object::cast_to<MeshInstance>(p_node)) {
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 		mi->set_name(_fixstr(name, "col"));
 		Node *col = mi->create_trimesh_collision_node();
@@ -473,19 +472,19 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
 		col->set_name("col");
 		p_node->add_child(col);
 
-		StaticBody *sb = col->cast_to<StaticBody>();
-		CollisionShape *colshape = sb->get_child(0)->cast_to<CollisionShape>();
+		StaticBody *sb = Object::cast_to<StaticBody>(col);
+		CollisionShape *colshape = Object::cast_to<CollisionShape>(sb->get_child(0));
 		colshape->set_name("shape");
 		col->add_child(colshape);
 		colshape->set_owner(p_node->get_owner());
 		sb->set_owner(p_node->get_owner());
 
-	} else if (_teststr(name, "navmesh") && p_node->cast_to<MeshInstance>()) {
+	} else if (_teststr(name, "navmesh") && Object::cast_to<MeshInstance>(p_node)) {
 
 		if (isroot)
 			return p_node;
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 		Ref<ArrayMesh> mesh = mi->get_mesh();
 		ERR_FAIL_COND_V(mesh.is_null(), NULL);
@@ -495,7 +494,7 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
 		Ref<NavigationMesh> nmesh = memnew(NavigationMesh);
 		nmesh->create_from_mesh(mesh);
 		nmi->set_navigation_mesh(nmesh);
-		nmi->cast_to<Spatial>()->set_transform(mi->get_transform());
+		Object::cast_to<Spatial>(nmi)->set_transform(mi->get_transform());
 		p_node->replace_by(nmi);
 		memdelete(p_node);
 		p_node = nmi;
@@ -505,7 +504,7 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
 			return p_node;
 
 		Node *owner = p_node->get_owner();
-		Spatial *s = p_node->cast_to<Spatial>();
+		Spatial *s = Object::cast_to<Spatial>(p_node);
 		VehicleBody *bv = memnew(VehicleBody);
 		String n = _fixstr(p_node->get_name(), "vehicle");
 		bv->set_name(n);
@@ -525,7 +524,7 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
 			return p_node;
 
 		Node *owner = p_node->get_owner();
-		Spatial *s = p_node->cast_to<Spatial>();
+		Spatial *s = Object::cast_to<Spatial>(p_node);
 		VehicleWheel *bv = memnew(VehicleWheel);
 		String n = _fixstr(p_node->get_name(), "wheel");
 		bv->set_name(n);
@@ -539,12 +538,12 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
 
 		p_node = bv;
 
-	} else if (_teststr(name, "room") && p_node->cast_to<MeshInstance>()) {
+	} else if (_teststr(name, "room") && Object::cast_to<MeshInstance>(p_node)) {
 
 		if (isroot)
 			return p_node;
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 		PoolVector<Face3> faces = mi->get_faces(VisualInstance::FACES_SOLID);
 
 		BSP_Tree bsptree(faces);
@@ -567,7 +566,7 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
 		if (isroot)
 			return p_node;
 
-		Spatial *dummy = p_node->cast_to<Spatial>();
+		Spatial *dummy = Object::cast_to<Spatial>(p_node);
 		ERR_FAIL_COND_V(!dummy, NULL);
 
 		Room *room = memnew(Room);
@@ -580,12 +579,12 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
 
 		//room->compute_room_from_subtree();
 
-	} else if (_teststr(name, "portal") && p_node->cast_to<MeshInstance>()) {
+	} else if (_teststr(name, "portal") && Object::cast_to<MeshInstance>(p_node)) {
 
 		if (isroot)
 			return p_node;
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 		PoolVector<Face3> faces = mi->get_faces(VisualInstance::FACES_SOLID);
 
 		ERR_FAIL_COND_V(faces.size() == 0, NULL);
@@ -659,11 +658,11 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Array
 		memdelete(p_node);
 		p_node = portal;
 
-	} else if (p_node->cast_to<MeshInstance>()) {
+	} else if (Object::cast_to<MeshInstance>(p_node)) {
 
 		//last attempt, maybe collision insde the mesh data
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 		Ref<ArrayMesh> mesh = mi->get_mesh();
 		if (!mesh.is_null()) {
@@ -728,7 +727,7 @@ void ResourceImporterScene::_create_clips(Node *scene, const Array &p_clips, boo
 
 	Node *n = scene->get_node(String("AnimationPlayer"));
 	ERR_FAIL_COND(!n);
-	AnimationPlayer *anim = n->cast_to<AnimationPlayer>();
+	AnimationPlayer *anim = Object::cast_to<AnimationPlayer>(n);
 	ERR_FAIL_COND(!anim);
 
 	if (!anim->has_animation("default"))
@@ -847,7 +846,7 @@ void ResourceImporterScene::_filter_tracks(Node *scene, const String &p_text) {
 		return;
 	Node *n = scene->get_node(String("AnimationPlayer"));
 	ERR_FAIL_COND(!n);
-	AnimationPlayer *anim = n->cast_to<AnimationPlayer>();
+	AnimationPlayer *anim = Object::cast_to<AnimationPlayer>(n);
 	ERR_FAIL_COND(!anim);
 
 	Vector<String> strings = p_text.split("\n");
@@ -954,7 +953,7 @@ void ResourceImporterScene::_optimize_animations(Node *scene, float p_max_lin_er
 		return;
 	Node *n = scene->get_node(String("AnimationPlayer"));
 	ERR_FAIL_COND(!n);
-	AnimationPlayer *anim = n->cast_to<AnimationPlayer>();
+	AnimationPlayer *anim = Object::cast_to<AnimationPlayer>(n);
 	ERR_FAIL_COND(!anim);
 
 	List<StringName> anim_names;
@@ -1196,10 +1195,7 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 	String root_type = p_options["nodes/root_type"];
 
 	if (scene->get_class() != root_type) {
-		Object *base = ClassDB::instance(root_type);
-		Node *base_node = NULL;
-		if (base)
-			base_node = base->cast_to<Node>();
+		Node *base_node = base_node = Object::cast_to<Node>(ClassDB::instance(root_type));
 
 		if (base_node) {
 

--- a/editor/io_plugins/editor_font_import_plugin.cpp
+++ b/editor/io_plugins/editor_font_import_plugin.cpp
@@ -1603,7 +1603,7 @@ Ref<BitmapFont> EditorFontImportPlugin::generate_font(const Ref<ResourceImportMe
 
 	if (p_existing!=String() && ResourceCache::has(p_existing)) {
 
-		font = Ref<BitmapFont>( ResourceCache::get(p_existing)->cast_to<BitmapFont>());
+		font = Ref<BitmapFont>( Object::cast_to<BitmapFont>(ResourceCache::get(p_existing)));
 	}
 
 	if (font.is_null()) {

--- a/editor/io_plugins/editor_sample_import_plugin.cpp
+++ b/editor/io_plugins/editor_sample_import_plugin.cpp
@@ -679,7 +679,7 @@ Error EditorSampleImportPlugin::import(const String& p_path, const Ref<ResourceI
 
 	if (ResourceCache::has(p_path)) {
 
-		target = Ref<Sample>( ResourceCache::get(p_path)->cast_to<Sample>() );
+		target = Ref<Sample>( Object::cast_to<Sample>(ResourceCache::get(p_path)) );
 	} else {
 
 		target = smp;

--- a/editor/io_plugins/editor_scene_import_plugin.cpp
+++ b/editor/io_plugins/editor_scene_import_plugin.cpp
@@ -1409,7 +1409,7 @@ void EditorSceneImportPlugin::_find_resources(const Variant& p_var, Map<Ref<Imag
 					for(List<PropertyInfo>::Element *E=pl.front();E;E=E->next()) {
 
 						if (E->get().type==Variant::OBJECT || E->get().type==Variant::ARRAY || E->get().type==Variant::DICTIONARY) {
-							if (E->get().type==Variant::OBJECT && res->cast_to<SpatialMaterial>() && (E->get().name=="textures/diffuse" || E->get().name=="textures/detail" || E->get().name=="textures/emission")) {
+							if (E->get().type==Variant::OBJECT && Object::cast_to<SpatialMaterial>(*res) && (E->get().name=="textures/diffuse" || E->get().name=="textures/detail" || E->get().name=="textures/emission")) {
 
 								Ref<ImageTexture> tex =res->get(E->get().name);
 								if (tex.is_valid()) {
@@ -1417,7 +1417,7 @@ void EditorSceneImportPlugin::_find_resources(const Variant& p_var, Map<Ref<Imag
 									image_map.insert(tex,TEXTURE_ROLE_DIFFUSE);
 								}
 
-							} else if (E->get().type==Variant::OBJECT && res->cast_to<SpatialMaterial>() && (E->get().name=="textures/normal")) {
+							} else if (E->get().type==Variant::OBJECT && Object::cast_to<SpatialMaterial>(*res) && (E->get().name=="textures/normal")) {
 
 								Ref<ImageTexture> tex =res->get(E->get().name);
 								if (tex.is_valid()) {
@@ -1425,7 +1425,7 @@ void EditorSceneImportPlugin::_find_resources(const Variant& p_var, Map<Ref<Imag
 									image_map.insert(tex,TEXTURE_ROLE_NORMALMAP);
 									/*
 									if (p_flags&SCENE_FLAG_CONVERT_NORMALMAPS_TO_XY)
-										res->cast_to<SpatialMaterial>()->set_fixed_flag(SpatialMaterial::FLAG_USE_XY_NORMALMAP,true);
+										Object::cast_to<SpatialMaterial>(*res)->set_fixed_flag(SpatialMaterial::FLAG_USE_XY_NORMALMAP,true);
 									*/
 								}
 
@@ -1513,9 +1513,9 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 
 
 
-	if (p_flags&SCENE_FLAG_CREATE_BILLBOARDS && p_node->cast_to<MeshInstance>()) {
+	if (p_flags&SCENE_FLAG_CREATE_BILLBOARDS && Object::cast_to<MeshInstance>(p_node)) {
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 		bool bb=false;
 
@@ -1546,9 +1546,9 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 	}
 
 
-	if (p_flags&(SCENE_FLAG_DETECT_ALPHA|SCENE_FLAG_DETECT_VCOLOR|SCENE_FLAG_SET_LIGHTMAP_TO_UV2_IF_EXISTS) && p_node->cast_to<MeshInstance>()) {
+	if (p_flags&(SCENE_FLAG_DETECT_ALPHA|SCENE_FLAG_DETECT_VCOLOR|SCENE_FLAG_SET_LIGHTMAP_TO_UV2_IF_EXISTS) && Object::cast_to<MeshInstance>(p_node)) {
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 		Ref<Mesh> m = mi->get_mesh();
 
@@ -1579,9 +1579,9 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 		}
 	}
 
-	if (p_flags&SCENE_FLAG_REMOVE_NOIMP && p_node->cast_to<AnimationPlayer>()) {
+	if (p_flags&SCENE_FLAG_REMOVE_NOIMP && Object::cast_to<AnimationPlayer>(p_node)) {
 		//remove animations referencing non-importable nodes
-		AnimationPlayer *ap = p_node->cast_to<AnimationPlayer>();
+		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node);
 
 		List<StringName> anims;
 		ap->get_animation_list(&anims);
@@ -1606,9 +1606,9 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 	}
 
 
-	if (p_flags&SCENE_FLAG_CREATE_IMPOSTORS && p_node->cast_to<MeshInstance>()) {
+	if (p_flags&SCENE_FLAG_CREATE_IMPOSTORS && Object::cast_to<MeshInstance>(p_node)) {
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 		String str;
 
@@ -1620,9 +1620,9 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 		}
 
 
-		if (p_node->get_parent() && p_node->get_parent()->cast_to<MeshInstance>()) {
-			MeshInstance *mi = p_node->cast_to<MeshInstance>();
-			MeshInstance *mip = p_node->get_parent()->cast_to<MeshInstance>();
+		if (Object::cast_to<MeshInstance>(p_node->get_parent())) {
+			MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
+			MeshInstance *mip = Object::cast_to<MeshInstance>(p_node->get_parent());
 			String d=str.substr(str.find("imp")+3,str.length());
 			if (d!="") {
 				if ((d[0]<'0' || d[0]>'9'))
@@ -1656,9 +1656,9 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 		}
 	}
 
-    if (p_flags&SCENE_FLAG_CREATE_LODS && p_node->cast_to<MeshInstance>()) {
+    if (p_flags&SCENE_FLAG_CREATE_LODS && Object::cast_to<MeshInstance>(p_node)) {
 
-	MeshInstance *mi = p_node->cast_to<MeshInstance>();
+	MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 	String str;
 
@@ -1670,9 +1670,9 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 	}
 
 
-	if (p_node->get_parent() && p_node->get_parent()->cast_to<MeshInstance>()) {
-	    MeshInstance *mi = p_node->cast_to<MeshInstance>();
-	    MeshInstance *mip = p_node->get_parent()->cast_to<MeshInstance>();
+	if (Object::cast_to<MeshInstance>(p_node->get_parent())) {
+	    MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
+	    MeshInstance *mip = Object::cast_to<MeshInstance>(p_node->get_parent());
 	    String d=str.substr(str.find("lod")+3,str.length());
 	    if (d!="") {
 		if ((d[0]<'0' || d[0]>'9'))
@@ -1705,9 +1705,9 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
     }
 
 
-	if (p_flags&SCENE_FLAG_DETECT_LIGHTMAP_LAYER && _teststr(name,"lm") && p_node->cast_to<MeshInstance>()) {
+	if (p_flags&SCENE_FLAG_DETECT_LIGHTMAP_LAYER && _teststr(name,"lm") && Object::cast_to<MeshInstance>(p_node)) {
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 		String str=name;
 		int layer = str.substr(str.find("lm")+3,str.length()).to_int();
@@ -1721,18 +1721,18 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 		if (isroot)
 			return p_node;
 
-		if (p_node->cast_to<MeshInstance>() && !is_rigid) {
-			MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		if (Object::cast_to<MeshInstance>(p_node) && !is_rigid) {
+			MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 			Node * col = mi->create_trimesh_collision_node();
 			ERR_FAIL_COND_V(!col,NULL);
 
 			col->set_name(_fixstr(name,"colonly"));
-			col->cast_to<Spatial>()->set_transform(mi->get_transform());
+			Object::cast_to<Spatial>(col)->set_transform(mi->get_transform());
 			p_node->replace_by(col);
 			memdelete(p_node);
 			p_node=col;
 
-			StaticBody *sb = col->cast_to<StaticBody>();
+			StaticBody *sb = Object::cast_to<StaticBody>(col);
 			CollisionShape *colshape = memnew( CollisionShape);
 			colshape->set_shape(sb->get_shape(0));
 			colshape->set_name("shape");
@@ -1749,7 +1749,7 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 				pb = memnew(StaticBody);
 				pb->set_name(_fixstr(name, "colonly"));
 			}
-			pb->cast_to<Spatial>()->set_transform(p_node->cast_to<Spatial>()->get_transform());
+			Object::cast_to<Spatial>(pb)->set_transform(Object::cast_to<Spatial>(p_node)->get_transform());
 			p_node->replace_by(pb);
 			memdelete(p_node);
 			CollisionShape *colshape = memnew( CollisionShape);
@@ -1763,7 +1763,7 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 				rayShape->set_length(1);
 				colshape->set_shape(rayShape);
 				colshape->set_name("RayShape");
-				pb->cast_to<Spatial>()->rotate_x(Math_PI / 2);
+				Object::cast_to<Spatial>(pb)->rotate_x(Math_PI / 2);
 			} else if (empty_draw_type == "IMAGE") {
 				PlaneShape *planeShape = memnew( PlaneShape);
 				colshape->set_shape(planeShape);
@@ -1778,13 +1778,13 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 			colshape->set_owner(pb->get_owner());
 		}
 
-	} else if (p_flags&SCENE_FLAG_CREATE_COLLISIONS && _teststr(name,"rigid") && p_node->cast_to<MeshInstance>()) {
+	} else if (p_flags&SCENE_FLAG_CREATE_COLLISIONS && _teststr(name,"rigid") && Object::cast_to<MeshInstance>(p_node)) {
 
 		if (isroot)
 			return p_node;
 
 		// get mesh instance and bounding box
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 		Rect3 aabb = mi->get_aabb();
 
 		// create a new rigid body collision node
@@ -1795,12 +1795,12 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 		// remove node name postfix
 		col->set_name(_fixstr(name,"rigid"));
 		// get mesh instance xform matrix to the rigid body collision node
-		col->cast_to<Spatial>()->set_transform(mi->get_transform());
+		Object::cast_to<Spatial>(col)->set_transform(mi->get_transform());
 		// save original node by duplicating it into a new instance and correcting the name
 		Node * mesh = p_node->duplicate();
 		mesh->set_name(_fixstr(name,"rigid"));
 		// reset the xform matrix of the duplicated node so it can inherit parent node xform
-		mesh->cast_to<Spatial>()->set_transform(Transform(Basis()));
+		Object::cast_to<Spatial>(mesh)->set_transform(Transform(Basis()));
 		// reparent the new mesh node to the rigid body collision node
 		p_node->add_child(mesh);
 		mesh->set_owner(p_node->get_owner());
@@ -1810,7 +1810,7 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 		p_node=col;
 
 		// create an alias for the rigid body collision node
-		RigidBody *rb = col->cast_to<RigidBody>();
+		RigidBody *rb = Object::cast_to<RigidBody>(col);
 		// create a new Box collision shape and set the right extents
 		Ref<BoxShape> shape = memnew( BoxShape );
 		shape->set_extents(aabb.get_size() * 0.5);
@@ -1821,10 +1821,10 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 		rb->add_child(colshape);
 		colshape->set_owner(p_node->get_owner());
 
-	} else if (p_flags&SCENE_FLAG_CREATE_COLLISIONS &&_teststr(name,"col") && p_node->cast_to<MeshInstance>()) {
+	} else if (p_flags&SCENE_FLAG_CREATE_COLLISIONS &&_teststr(name,"col") && Object::cast_to<MeshInstance>(p_node)) {
 
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 		mi->set_name(_fixstr(name,"col"));
 		Node *col= mi->create_trimesh_collision_node();
@@ -1833,7 +1833,7 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 		col->set_name("col");
 		p_node->add_child(col);
 
-		StaticBody *sb=col->cast_to<StaticBody>();
+		StaticBody *sb=Object::cast_to<StaticBody>(col);
 		CollisionShape *colshape = memnew( CollisionShape);
 		colshape->set_shape(sb->get_shape(0));
 		colshape->set_name("shape");
@@ -1841,12 +1841,12 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 		colshape->set_owner(p_node->get_owner());
 		sb->set_owner(p_node->get_owner());
 
-	} else if (p_flags&SCENE_FLAG_CREATE_NAVMESH &&_teststr(name,"navmesh") && p_node->cast_to<MeshInstance>()) {
+	} else if (p_flags&SCENE_FLAG_CREATE_NAVMESH &&_teststr(name,"navmesh") && Object::cast_to<MeshInstance>(p_node)) {
 
 		if (isroot)
 			return p_node;
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 		Ref<Mesh> mesh=mi->get_mesh();
 		ERR_FAIL_COND_V(mesh.is_null(),NULL);
@@ -1857,7 +1857,7 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 		Ref<NavigationMesh> nmesh = memnew( NavigationMesh);
 		nmesh->create_from_mesh(mesh);
 		nmi->set_navigation_mesh(nmesh);
-		nmi->cast_to<Spatial>()->set_transform(mi->get_transform());
+		Object::cast_to<Spatial>(nmi)->set_transform(mi->get_transform());
 		p_node->replace_by(nmi);
 		memdelete(p_node);
 		p_node=nmi;
@@ -1867,7 +1867,7 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 			return p_node;
 
 		Node *owner = p_node->get_owner();
-		Spatial *s = p_node->cast_to<Spatial>();
+		Spatial *s = Object::cast_to<Spatial>(p_node);
 		VehicleBody *bv = memnew( VehicleBody );
 		String n = _fixstr(p_node->get_name(),"vehicle");
 		bv->set_name(n);
@@ -1888,7 +1888,7 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 			return p_node;
 
 		Node *owner = p_node->get_owner();
-		Spatial *s = p_node->cast_to<Spatial>();
+		Spatial *s = Object::cast_to<Spatial>(p_node);
 		VehicleWheel *bv = memnew( VehicleWheel );
 		String n = _fixstr(p_node->get_name(),"wheel");
 		bv->set_name(n);
@@ -1902,13 +1902,13 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 
 		p_node=bv;
 
-	} else if (p_flags&SCENE_FLAG_CREATE_ROOMS && _teststr(name,"room") && p_node->cast_to<MeshInstance>()) {
+	} else if (p_flags&SCENE_FLAG_CREATE_ROOMS && _teststr(name,"room") && Object::cast_to<MeshInstance>(p_node)) {
 
 
 		if (isroot)
 			return p_node;
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 		PoolVector<Face3> faces = mi->get_faces(VisualInstance::FACES_SOLID);
 
 
@@ -1933,7 +1933,7 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 		if (isroot)
 			return p_node;
 
-		Spatial *dummy = p_node->cast_to<Spatial>();
+		Spatial *dummy = Object::cast_to<Spatial>(p_node);
 		ERR_FAIL_COND_V(!dummy,NULL);
 
 		Room * room = memnew( Room );
@@ -1946,12 +1946,12 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 
 		//room->compute_room_from_subtree();
 
-	} else if (p_flags&SCENE_FLAG_CREATE_PORTALS &&_teststr(name,"portal") && p_node->cast_to<MeshInstance>()) {
+	} else if (p_flags&SCENE_FLAG_CREATE_PORTALS &&_teststr(name,"portal") && Object::cast_to<MeshInstance>(p_node)) {
 
 		if (isroot)
 			return p_node;
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 		PoolVector<Face3> faces = mi->get_faces(VisualInstance::FACES_SOLID);
 
 		ERR_FAIL_COND_V(faces.size()==0,NULL);
@@ -2027,11 +2027,11 @@ Node* EditorSceneImportPlugin::_fix_node(Node *p_node,Node *p_root,Map<Ref<Mesh>
 		memdelete(p_node);
 		p_node=portal;
 
-	} else if (p_node->cast_to<MeshInstance>()) {
+	} else if (Object::cast_to<MeshInstance>(p_node)) {
 
 		//last attempt, maybe collision insde the mesh data
 
-		MeshInstance *mi = p_node->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(p_node);
 
 		Ref<Mesh> mesh = mi->get_mesh();
 		if (!mesh.is_null()) {
@@ -2111,7 +2111,7 @@ void EditorSceneImportPlugin::_tag_import_paths(Node *p_scene,Node *p_node) {
 	NodePath path = p_scene->get_path_to(p_node);
 	p_node->set_import_path( path );
 
-	Spatial *snode=p_node->cast_to<Spatial>();
+	Spatial *snode=Object::cast_to<Spatial>(p_node);
 
 	if (snode) {
 
@@ -2200,10 +2200,7 @@ Error EditorSceneImportPlugin::import1(const Ref<ResourceImportMetadata>& p_from
 
 	if (from->has_option("root_type")) {
 		String type = from->get_option("root_type");
-		Object *base = ClassDB::instance(type);
-		Node *base_node = NULL;
-		if (base)
-			base_node=base->cast_to<Node>();
+		Node *base_node = Object::cast_to<Node>(ClassDB::instance(type));
 
 		if (base_node) {
 
@@ -2228,7 +2225,7 @@ void EditorSceneImportPlugin::_create_clips(Node *scene, const Array& p_clips,bo
 
 	Node* n = scene->get_node(String("AnimationPlayer"));
 	ERR_FAIL_COND(!n);
-	AnimationPlayer *anim = n->cast_to<AnimationPlayer>();
+	AnimationPlayer *anim = Object::cast_to<AnimationPlayer>(n);
 	ERR_FAIL_COND(!anim);
 
 	if (!anim->has_animation("default"))
@@ -2357,7 +2354,7 @@ void EditorSceneImportPlugin::_filter_tracks(Node *scene, const String& p_text) 
 		return;
 	Node* n = scene->get_node(String("AnimationPlayer"));
 	ERR_FAIL_COND(!n);
-	AnimationPlayer *anim = n->cast_to<AnimationPlayer>();
+	AnimationPlayer *anim = Object::cast_to<AnimationPlayer>(n);
 	ERR_FAIL_COND(!anim);
 
 	Vector<String> strings = p_text.split("\n");
@@ -2475,7 +2472,7 @@ void EditorSceneImportPlugin::_optimize_animations(Node *scene, float p_max_lin_
 		return;
 	Node* n = scene->get_node(String("AnimationPlayer"));
 	ERR_FAIL_COND(!n);
-	AnimationPlayer *anim = n->cast_to<AnimationPlayer>();
+	AnimationPlayer *anim = Object::cast_to<AnimationPlayer>(n);
 	ERR_FAIL_COND(!anim);
 
 
@@ -2496,9 +2493,9 @@ void EditorSceneImportPlugin::_find_resources_to_merge(Node *scene, Node *node, 
 
 	String path = scene->get_path_to(node);
 
-	if (p_merge_anims && node->cast_to<AnimationPlayer>()) {
+	if (p_merge_anims && Object::cast_to<AnimationPlayer>(node)) {
 
-		AnimationPlayer *ap = node->cast_to<AnimationPlayer>();
+		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(node);
 		List<StringName> anims;
 		ap->get_animation_list(&anims);
 		for (List<StringName>::Element *E=anims.front();E;E=E->next()) {
@@ -2532,8 +2529,8 @@ void EditorSceneImportPlugin::_find_resources_to_merge(Node *scene, Node *node, 
 
 
 
-	if (p_merge_material && node->cast_to<MeshInstance>()) {
-		MeshInstance *mi=node->cast_to<MeshInstance>();
+	if (p_merge_material && Object::cast_to<MeshInstance>(node)) {
+		MeshInstance *mi=Object::cast_to<MeshInstance>(node);
 		Ref<Mesh> mesh = mi->get_mesh();
 		if (mesh.is_valid() && mesh->get_name()!=String() && !tested_meshes.has(mesh)) {
 
@@ -2596,9 +2593,8 @@ void EditorSceneImportPlugin::_merge_found_resources(Node *scene, Node *node, bo
 
 	print_line("at path: "+path);
 
-	if (node->cast_to<AnimationPlayer>()) {
+	if (AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(node)) {
 
-		AnimationPlayer *ap = node->cast_to<AnimationPlayer>();
 		List<StringName> anims;
 		ap->get_animation_list(&anims);
 		for (List<StringName>::Element *E=anims.front();E;E=E->next()) {
@@ -2630,8 +2626,8 @@ void EditorSceneImportPlugin::_merge_found_resources(Node *scene, Node *node, bo
 
 
 
-	if (node->cast_to<MeshInstance>()) {
-		MeshInstance *mi=node->cast_to<MeshInstance>();
+	if (MeshInstance *mi=Object::cast_to<MeshInstance>(node)) {
+
 		Ref<Mesh> mesh = mi->get_mesh();
 		if (mesh.is_valid() && mesh->get_name()!=String() && !tested_meshes.has(mesh)) {
 

--- a/editor/io_plugins/editor_scene_importer_fbxconv.cpp
+++ b/editor/io_plugins/editor_scene_importer_fbxconv.cpp
@@ -407,7 +407,7 @@ Error EditorSceneImporterFBXConv::_parse_nodes(State& state,const Array &p_nodes
 			print_line("IS SKELETON! ");
 		} else if (state.bones.has(id)) {
 			if (p_base)
-				node=p_base->cast_to<Spatial>();
+				node=Object::cast_to<Spatial>(p_base);
 			if (!state.bones[id].has_anim_chan) {
 				print_line("no has anim "+id);
 			}

--- a/editor/io_plugins/editor_texture_import_plugin.cpp
+++ b/editor/io_plugins/editor_texture_import_plugin.cpp
@@ -703,7 +703,7 @@ EditorTextureImportDialog::EditorTextureImportDialog(EditorTextureImportPlugin* 
 	VBoxContainer *source_vb=memnew(VBoxContainer);
 	MarginContainer *source_mc = vbc->add_margin_child(TTR("Source Texture(s):"),source_vb);
 
-	source_label = vbc->get_child(source_mc->get_index()-1)->cast_to<Label>();
+	source_label = Object::cast_to<Label>(vbc->get_child(source_mc->get_index()-1));
 
 	HBoxContainer *hbc = memnew( HBoxContainer );
 	source_vb->add_child(hbc);
@@ -733,7 +733,7 @@ EditorTextureImportDialog::EditorTextureImportDialog(EditorTextureImportPlugin* 
 
 	size->set_value(256);
 	size_mc=vbc->add_margin_child(TTR("Cell Size:"),size);
-	size_label=vbc->get_child(size_mc->get_index()-1)->cast_to<Label>();
+	size_label=Object::cast_to<Label>(vbc->get_child(size_mc->get_index()-1));
 
 
 	save_path = memnew( LineEdit );
@@ -1326,7 +1326,7 @@ Error EditorTextureImportPlugin::import2(const String& p_path, const Ref<Resourc
 
 				if (ResourceCache::has(apath)) {
 
-					at = Ref<AtlasTexture>( ResourceCache::get(apath)->cast_to<AtlasTexture>() );
+					at = Ref<AtlasTexture>( Object::cast_to<AtlasTexture>(ResourceCache::get(apath)) );
 				} else {
 
 					at = Ref<AtlasTexture>( memnew( AtlasTexture ) );
@@ -1340,7 +1340,7 @@ Error EditorTextureImportPlugin::import2(const String& p_path, const Ref<Resourc
 			}
 		}
 		if (ResourceCache::has(p_path)) {
-			texture = Ref<ImageTexture> ( ResourceCache::get(p_path)->cast_to<ImageTexture>() );
+			texture = Ref<ImageTexture> ( Object::cast_to<ImageTexture>(ResourceCache::get(p_path)) );
 		} else {
 			texture = Ref<ImageTexture>( memnew( ImageTexture ) );
 		}
@@ -1354,7 +1354,7 @@ Error EditorTextureImportPlugin::import2(const String& p_path, const Ref<Resourc
 		if (ResourceCache::has(p_path)) {
 			Resource *r = ResourceCache::get(p_path);
 
-			texture = Ref<ImageTexture> ( r->cast_to<ImageTexture>() );
+			texture = Ref<ImageTexture> ( Object::cast_to<ImageTexture>(r) );
 
 			Image img;
 			Error err = img.load(src_path);

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -656,8 +656,8 @@ void AnimationPlayerEditor::set_state(const Dictionary &p_state) {
 			return;
 
 		Node *n = EditorNode::get_singleton()->get_edited_scene()->get_node(p_state["player"]);
-		if (n && n->cast_to<AnimationPlayer>() && EditorNode::get_singleton()->get_editor_selection()->is_selected(n)) {
-			player = n->cast_to<AnimationPlayer>();
+		if (Object::cast_to<AnimationPlayer>(n) && EditorNode::get_singleton()->get_editor_selection()->is_selected(n)) {
+			player = Object::cast_to<AnimationPlayer>(n);
 			_update_player();
 			show();
 			set_process(true);
@@ -737,9 +737,9 @@ void AnimationPlayerEditor::_dialog_action(String p_file) {
 			if (current != "") {
 				Ref<Animation> anim = player->get_animation(current);
 
-				ERR_FAIL_COND(!anim->cast_to<Resource>())
+				ERR_FAIL_COND(!Object::cast_to<Resource>(*anim))
 
-				RES current_res = RES(anim->cast_to<Resource>());
+				RES current_res = RES(Object::cast_to<Resource>(*anim));
 
 				_animation_save_in_path(current_res, p_file);
 			}
@@ -1461,7 +1461,7 @@ void AnimationPlayerEditorPlugin::edit(Object *p_object) {
 	anim_editor->set_undo_redo(&get_undo_redo());
 	if (!p_object)
 		return;
-	anim_editor->edit(p_object->cast_to<AnimationPlayer>());
+	anim_editor->edit(Object::cast_to<AnimationPlayer>(p_object));
 }
 
 bool AnimationPlayerEditorPlugin::handles(Object *p_object) const {

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -281,9 +281,9 @@ void AnimationTreeEditor::_popup_edit_dialog() {
 
 			case AnimationTreePlayer::NODE_ANIMATION:
 
-				if (anim_tree->get_master_player() != NodePath() && anim_tree->has_node(anim_tree->get_master_player()) && anim_tree->get_node(anim_tree->get_master_player())->cast_to<AnimationPlayer>()) {
+				if (anim_tree->get_master_player() != NodePath() && anim_tree->has_node(anim_tree->get_master_player()) && Object::cast_to<AnimationPlayer>(anim_tree->get_node(anim_tree->get_master_player()))) {
 
-					AnimationPlayer *ap = anim_tree->get_node(anim_tree->get_master_player())->cast_to<AnimationPlayer>();
+					AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(anim_tree->get_node(anim_tree->get_master_player()));
 					master_anim_popup->clear();
 					master_anim_popup->add_item("Edit Filters");
 					master_anim_popup->add_separator();
@@ -1233,7 +1233,7 @@ void AnimationTreeEditor::_edit_filters() {
 
 			if (np.get_property() != StringName()) {
 				Node *n = base->get_node(np);
-				Skeleton *s = n->cast_to<Skeleton>();
+				Skeleton *s = Object::cast_to<Skeleton>(n);
 				if (s) {
 
 					String skelbase = E->get().substr(0, E->get().find(":"));
@@ -1439,7 +1439,7 @@ AnimationTreeEditor::AnimationTreeEditor() {
 
 void AnimationTreeEditorPlugin::edit(Object *p_object) {
 
-	anim_tree_editor->edit(p_object->cast_to<AnimationTreePlayer>());
+	anim_tree_editor->edit(Object::cast_to<AnimationTreePlayer>(p_object));
 }
 
 bool AnimationTreeEditorPlugin::handles(Object *p_object) const {

--- a/editor/plugins/baked_light_baker.cpp
+++ b/editor/plugins/baked_light_baker.cpp
@@ -301,16 +301,13 @@ void BakedLightBaker::_add_mesh(const Ref<Mesh>& p_mesh,const Ref<Material>& p_m
 
 void BakedLightBaker::_parse_geometry(Node* p_node) {
 
-	if (p_node->cast_to<MeshInstance>()) {
+	if (MeshInstance *meshi=Object::cast_to<MeshInstance>(p_node)) {
 
-		MeshInstance *meshi=p_node->cast_to<MeshInstance>();
 		Ref<Mesh> mesh=meshi->get_mesh();
 		if (mesh.is_valid()) {
 			_add_mesh(mesh,meshi->get_material_override(),base_inv * meshi->get_global_transform(),meshi->get_baked_light_texture_id());
 		}
-	} else if (p_node->cast_to<Light>()) {
-
-		Light *dl=p_node->cast_to<Light>();
+	} else if (Light *dl=Object::cast_to<Light>(p_node)) {
 
 		if (dl->get_bake_mode()!=Light::BAKE_MODE_DISABLED) {
 
@@ -340,9 +337,7 @@ void BakedLightBaker::_parse_geometry(Node* p_node) {
 			lights.push_back(dirl);
 		}
 
-	} else if (p_node->cast_to<Spatial>()){
-
-		Spatial *sp = p_node->cast_to<Spatial>();
+	} else if (Spatial *sp = Object::cast_to<Spatial>(p_node)){
 
 		Array arr = p_node->call("_get_baked_light_meshes");
 		for(int i=0;i<arr.size();i+=2) {
@@ -1741,7 +1736,7 @@ void BakedLightBaker::bake(const Ref<BakedLight> &p_light, Node* p_node) {
 		return;
 	cell_count=0;
 
-	base_inv=p_node->cast_to<Spatial>()->get_global_transform().affine_inverse();
+	base_inv=Object::cast_to<Spatial>(p_node)->get_global_transform().affine_inverse();
 	EditorProgress ep("bake",TTR("Light Baker Setup:"),5);
 	baked_light=p_light;
 	lattice_size=baked_light->get_initial_lattice_subdiv();

--- a/editor/plugins/baked_light_editor_plugin.cpp
+++ b/editor/plugins/baked_light_editor_plugin.cpp
@@ -337,7 +337,7 @@ BakedLightEditor::~BakedLightEditor() {
 
 void BakedLightEditorPlugin::edit(Object *p_object) {
 
-	baked_light_editor->edit(p_object->cast_to<BakedLightInstance>());
+	baked_light_editor->edit(Object::cast_to<BakedLightInstance>(p_object));
 }
 
 bool BakedLightEditorPlugin::handles(Object *p_object) const {

--- a/editor/plugins/camera_editor_plugin.cpp
+++ b/editor/plugins/camera_editor_plugin.cpp
@@ -97,8 +97,8 @@ CameraEditor::CameraEditor() {
 
 void CameraEditorPlugin::edit(Object *p_object) {
 
-	SpatialEditor::get_singleton()->set_can_preview(p_object->cast_to<Camera>());
-	//camera_editor->edit(p_object->cast_to<Node>());
+	SpatialEditor::get_singleton()->set_can_preview(Object::cast_to<Camera>(p_object));
+	//camera_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool CameraEditorPlugin::handles(Object *p_object) const {
@@ -109,7 +109,7 @@ bool CameraEditorPlugin::handles(Object *p_object) const {
 void CameraEditorPlugin::make_visible(bool p_visible) {
 
 	if (p_visible) {
-		//SpatialEditor::get_singleton()->set_can_preview(p_object->cast_to<Camera>());
+		//SpatialEditor::get_singleton()->set_can_preview(Object::cast_to<Camera>(p_object));
 	} else {
 		SpatialEditor::get_singleton()->set_can_preview(NULL);
 	}

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -175,7 +175,7 @@ void CanvasItemEditor::_edit_set_pivot(const Vector2 &mouse_pos) {
 
 	for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-		Node2D *n2d = E->get()->cast_to<Node2D>();
+		Node2D *n2d = Object::cast_to<Node2D>(E->get());
 		if (n2d && n2d->edit_has_pivot()) {
 
 			Vector2 offset = n2d->edit_get_pivot();
@@ -190,7 +190,7 @@ void CanvasItemEditor::_edit_set_pivot(const Vector2 &mouse_pos) {
 			undo_redo->add_undo_method(n2d, "set_global_position", gpos);
 			undo_redo->add_undo_method(n2d, "edit_set_pivot", offset);
 			for (int i = 0; i < n2d->get_child_count(); i++) {
-				Node2D *n2dc = n2d->get_child(i)->cast_to<Node2D>();
+				Node2D *n2dc = Object::cast_to<Node2D>(n2d->get_child(i));
 				if (!n2dc)
 					continue;
 
@@ -199,7 +199,7 @@ void CanvasItemEditor::_edit_set_pivot(const Vector2 &mouse_pos) {
 			}
 		}
 
-		Control *cnt = E->get()->cast_to<Control>();
+		Control *cnt = Object::cast_to<Control>(E->get());
 		if (cnt) {
 
 			Vector2 old_pivot = cnt->get_pivot_offset();
@@ -265,7 +265,7 @@ void CanvasItemEditor::_tool_select(int p_index) {
 
 Object *CanvasItemEditor::_get_editor_data(Object *p_what) {
 
-	CanvasItem *ci = p_what->cast_to<CanvasItem>();
+	CanvasItem *ci = Object::cast_to<CanvasItem>(p_what);
 	if (!ci)
 		return NULL;
 
@@ -413,7 +413,7 @@ void CanvasItemEditor::_visibility_changed(ObjectID p_canvas_item) {
 	Object *c = ObjectDB::get_instance(p_canvas_item);
 	if (!c)
 		return;
-	CanvasItem *ct = c->cast_to<CanvasItem>();
+	CanvasItem *ct = Object::cast_to<CanvasItem>(c);
 	if (!ct)
 		return;
 	canvas_items.erase(ct);
@@ -451,17 +451,17 @@ bool CanvasItemEditor::_is_part_of_subscene(CanvasItem *p_item) {
 void CanvasItemEditor::_find_canvas_items_at_pos(const Point2 &p_pos, Node *p_node, const Transform2D &p_parent_xform, const Transform2D &p_canvas_xform, Vector<_SelectResult> &r_items, unsigned int limit) {
 	if (!p_node)
 		return;
-	if (p_node->cast_to<Viewport>())
+	if (Object::cast_to<Viewport>(p_node))
 		return;
 
-	CanvasItem *c = p_node->cast_to<CanvasItem>();
+	CanvasItem *c = Object::cast_to<CanvasItem>(p_node);
 
 	for (int i = p_node->get_child_count() - 1; i >= 0; i--) {
 
 		if (c && !c->is_set_as_toplevel())
 			_find_canvas_items_at_pos(p_pos, p_node->get_child(i), p_parent_xform * c->get_transform(), p_canvas_xform, r_items);
 		else {
-			CanvasLayer *cl = p_node->cast_to<CanvasLayer>();
+			CanvasLayer *cl = Object::cast_to<CanvasLayer>(p_node);
 			_find_canvas_items_at_pos(p_pos, p_node->get_child(i), transform, cl ? cl->get_transform() : p_canvas_xform, r_items); //use base transform
 		}
 
@@ -469,13 +469,13 @@ void CanvasItemEditor::_find_canvas_items_at_pos(const Point2 &p_pos, Node *p_no
 			return;
 	}
 
-	if (c && c->is_visible_in_tree() && !c->has_meta("_edit_lock_") && !c->cast_to<CanvasLayer>()) {
+	if (c && c->is_visible_in_tree() && !c->has_meta("_edit_lock_") && !Object::cast_to<CanvasLayer>(c)) {
 
 		Rect2 rect = c->get_item_rect();
 		Point2 local_pos = (p_parent_xform * p_canvas_xform * c->get_transform()).affine_inverse().xform(p_pos);
 
 		if (rect.has_point(local_pos)) {
-			Node2D *node = c->cast_to<Node2D>();
+			Node2D *node = Object::cast_to<Node2D>(c);
 
 			_SelectResult res;
 			res.item = c;
@@ -492,10 +492,10 @@ void CanvasItemEditor::_find_canvas_items_at_rect(const Rect2 &p_rect, Node *p_n
 
 	if (!p_node)
 		return;
-	if (p_node->cast_to<Viewport>())
+	if (Object::cast_to<Viewport>(p_node))
 		return;
 
-	CanvasItem *c = p_node->cast_to<CanvasItem>();
+	CanvasItem *c = Object::cast_to<CanvasItem>(p_node);
 
 	bool inherited = p_node != get_tree()->get_edited_scene_root() && p_node->get_filename() != "";
 	bool editable = false;
@@ -509,13 +509,13 @@ void CanvasItemEditor::_find_canvas_items_at_rect(const Rect2 &p_rect, Node *p_n
 			if (c && !c->is_set_as_toplevel())
 				_find_canvas_items_at_rect(p_rect, p_node->get_child(i), p_parent_xform * c->get_transform(), p_canvas_xform, r_items);
 			else {
-				CanvasLayer *cl = p_node->cast_to<CanvasLayer>();
+				CanvasLayer *cl = Object::cast_to<CanvasLayer>(p_node);
 				_find_canvas_items_at_rect(p_rect, p_node->get_child(i), transform, cl ? cl->get_transform() : p_canvas_xform, r_items);
 			}
 		}
 	}
 
-	if (c && c->is_visible_in_tree() && !c->has_meta("_edit_lock_") && !c->cast_to<CanvasLayer>()) {
+	if (c && c->is_visible_in_tree() && !c->has_meta("_edit_lock_") && !Object::cast_to<CanvasLayer>(c)) {
 
 		Rect2 rect = c->get_item_rect();
 		Transform2D xform = p_parent_xform * p_canvas_xform * c->get_transform();
@@ -590,7 +590,7 @@ void CanvasItemEditor::_key_move(const Vector2 &p_dir, bool p_snap, KeyMoveMODE 
 
 	for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-		CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+		CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 		if (!canvas_item || !canvas_item->is_visible_in_tree())
 			continue;
 		if (canvas_item->get_viewport() != EditorNode::get_singleton()->get_scene_root())
@@ -619,7 +619,7 @@ void CanvasItemEditor::_key_move(const Vector2 &p_dir, bool p_snap, KeyMoveMODE 
 
 		} else { // p_move_mode==MOVE_LOCAL_BASE || p_move_mode==MOVE_LOCAL_WITH_ROT
 
-			if (Node2D *node_2d = canvas_item->cast_to<Node2D>()) {
+			if (Node2D *node_2d = Object::cast_to<Node2D>(canvas_item)) {
 
 				if (p_move_mode == MOVE_LOCAL_WITH_ROT) {
 					Transform2D m;
@@ -628,7 +628,7 @@ void CanvasItemEditor::_key_move(const Vector2 &p_dir, bool p_snap, KeyMoveMODE 
 				}
 				node_2d->set_position(node_2d->get_position() + drag);
 
-			} else if (Control *control = canvas_item->cast_to<Control>()) {
+			} else if (Control *control = Object::cast_to<Control>(canvas_item)) {
 
 				control->set_position(control->get_position() + drag);
 			}
@@ -648,7 +648,7 @@ Point2 CanvasItemEditor::_find_topleftmost_point() {
 
 	for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-		CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+		CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 		if (!canvas_item || !canvas_item->is_visible_in_tree())
 			continue;
 		if (canvas_item->get_viewport() != EditorNode::get_singleton()->get_scene_root())
@@ -673,7 +673,7 @@ int CanvasItemEditor::get_item_count() {
 	int ic = 0;
 	for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-		CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+		CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 		if (!canvas_item || !canvas_item->is_visible_in_tree())
 			continue;
 
@@ -694,7 +694,7 @@ CanvasItem *CanvasItemEditor::get_single_item() {
 
 	for (Map<Node *, Object *>::Element *E = selection.front(); E; E = E->next()) {
 
-		CanvasItem *canvas_item = E->key()->cast_to<CanvasItem>();
+		CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->key());
 		if (!canvas_item || !canvas_item->is_visible_in_tree())
 			continue;
 		if (canvas_item->get_viewport() != EditorNode::get_singleton()->get_scene_root())
@@ -822,7 +822,7 @@ CanvasItemEditor::DragType CanvasItemEditor::_get_anchor_handle_drag_type(const 
 	CanvasItem *canvas_item = get_single_item();
 	ERR_FAIL_COND_V(!canvas_item, DRAG_NONE);
 
-	Control *control = canvas_item->cast_to<Control>();
+	Control *control = Object::cast_to<Control>(canvas_item);
 	ERR_FAIL_COND_V(!control, DRAG_NONE);
 
 	Vector2 anchor_pos[4];
@@ -865,7 +865,7 @@ void CanvasItemEditor::_prepare_drag(const Point2 &p_click_pos) {
 
 	for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-		CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+		CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 		if (!canvas_item || !canvas_item->is_visible_in_tree())
 			continue;
 		if (canvas_item->get_viewport() != EditorNode::get_singleton()->get_scene_root())
@@ -876,15 +876,15 @@ void CanvasItemEditor::_prepare_drag(const Point2 &p_click_pos) {
 			continue;
 
 		se->undo_state = canvas_item->edit_get_state();
-		if (canvas_item->cast_to<Node2D>())
-			se->undo_pivot = canvas_item->cast_to<Node2D>()->edit_get_pivot();
-		if (canvas_item->cast_to<Control>())
-			se->undo_pivot = canvas_item->cast_to<Control>()->get_pivot_offset();
+		if (Object::cast_to<Node2D>(canvas_item))
+			se->undo_pivot = Object::cast_to<Node2D>(canvas_item)->edit_get_pivot();
+		if (Object::cast_to<Control>(canvas_item))
+			se->undo_pivot = Object::cast_to<Control>(canvas_item)->get_pivot_offset();
 	}
 
-	if (selection.size() == 1 && selection[0]->cast_to<Node2D>()) {
+	if (selection.size() == 1 && Object::cast_to<Node2D>(selection[0])) {
 		drag = DRAG_NODE_2D;
-		drag_point_from = selection[0]->cast_to<Node2D>()->get_global_position();
+		drag_point_from = Object::cast_to<Node2D>(selection[0])->get_global_position();
 	} else {
 		drag = DRAG_ALL;
 		drag_point_from = _find_topleftmost_point();
@@ -1169,7 +1169,7 @@ void CanvasItemEditor::_viewport_gui_input(const Ref<InputEvent> &p_event) {
 					List<Node *> &selection = editor_selection->get_selected_node_list();
 
 					for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-						CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+						CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 						if (!canvas_item || !canvas_item->is_visible_in_tree())
 							continue;
 						if (canvas_item->get_viewport() != EditorNode::get_singleton()->get_scene_root())
@@ -1180,10 +1180,10 @@ void CanvasItemEditor::_viewport_gui_input(const Ref<InputEvent> &p_event) {
 							continue;
 
 						canvas_item->edit_set_state(se->undo_state);
-						if (canvas_item->cast_to<Node2D>())
-							canvas_item->cast_to<Node2D>()->edit_set_pivot(se->undo_pivot);
-						if (canvas_item->cast_to<Control>())
-							canvas_item->cast_to<Control>()->set_pivot_offset(se->undo_pivot);
+						if (Object::cast_to<Node2D>(canvas_item))
+							Object::cast_to<Node2D>(canvas_item)->edit_set_pivot(se->undo_pivot);
+						if (Object::cast_to<Control>(canvas_item))
+							Object::cast_to<Control>(canvas_item)->set_pivot_offset(se->undo_pivot);
 					}
 				}
 
@@ -1251,7 +1251,7 @@ void CanvasItemEditor::_viewport_gui_input(const Ref<InputEvent> &p_event) {
 
 						for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-							CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+							CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 							if (!canvas_item || !canvas_item->is_visible_in_tree())
 								continue;
 							if (canvas_item->get_viewport() != EditorNode::get_singleton()->get_scene_root())
@@ -1265,13 +1265,13 @@ void CanvasItemEditor::_viewport_gui_input(const Ref<InputEvent> &p_event) {
 							undo_redo->add_do_method(canvas_item, "edit_set_state", state);
 							undo_redo->add_undo_method(canvas_item, "edit_set_state", se->undo_state);
 							{
-								Node2D *pvt = canvas_item->cast_to<Node2D>();
+								Node2D *pvt = Object::cast_to<Node2D>(canvas_item);
 								if (pvt && pvt->edit_has_pivot()) {
 									undo_redo->add_do_method(canvas_item, "edit_set_pivot", pvt->edit_get_pivot());
 									undo_redo->add_undo_method(canvas_item, "edit_set_pivot", se->undo_pivot);
 								}
 
-								Control *cnt = canvas_item->cast_to<Control>();
+								Control *cnt = Object::cast_to<Control>(canvas_item);
 								if (cnt) {
 									undo_redo->add_do_method(canvas_item, "set_pivot_offset", cnt->get_pivot_offset());
 									undo_redo->add_undo_method(canvas_item, "set_pivot_offset", se->undo_pivot);
@@ -1341,10 +1341,7 @@ void CanvasItemEditor::_viewport_gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 			if (Cbone) {
-				Node2D *b = NULL;
-				Object *obj = ObjectDB::get_instance(Cbone->get().bone);
-				if (obj)
-					b = obj->cast_to<Node2D>();
+				Node2D *b = Object::cast_to<Node2D>(ObjectDB::get_instance(Cbone->get().bone));
 
 				if (b) {
 
@@ -1359,7 +1356,7 @@ void CanvasItemEditor::_viewport_gui_input(const Ref<InputEvent> &p_event) {
 							break;
 
 						float len = pi->get_global_transform().get_origin().distance_to(b->get_global_position());
-						b = pi->cast_to<Node2D>();
+						b = Object::cast_to<Node2D>(pi);
 						if (!b)
 							break;
 
@@ -1405,10 +1402,10 @@ void CanvasItemEditor::_viewport_gui_input(const Ref<InputEvent> &p_event) {
 				drag = DRAG_ROTATE;
 				drag_from = transform.affine_inverse().xform(click);
 				se->undo_state = canvas_item->edit_get_state();
-				if (canvas_item->cast_to<Node2D>())
-					se->undo_pivot = canvas_item->cast_to<Node2D>()->edit_get_pivot();
-				if (canvas_item->cast_to<Control>())
-					se->undo_pivot = canvas_item->cast_to<Control>()->get_pivot_offset();
+				if (Object::cast_to<Node2D>(canvas_item))
+					se->undo_pivot = Object::cast_to<Node2D>(canvas_item)->edit_get_pivot();
+				if (Object::cast_to<Control>(canvas_item))
+					se->undo_pivot = Object::cast_to<Control>(canvas_item)->get_pivot_offset();
 				return;
 			}
 
@@ -1426,15 +1423,15 @@ void CanvasItemEditor::_viewport_gui_input(const Ref<InputEvent> &p_event) {
 				if (drag != DRAG_NONE) {
 					drag_from = transform.affine_inverse().xform(click);
 					se->undo_state = canvas_item->edit_get_state();
-					if (canvas_item->cast_to<Node2D>())
-						se->undo_pivot = canvas_item->cast_to<Node2D>()->edit_get_pivot();
-					if (canvas_item->cast_to<Control>())
-						se->undo_pivot = canvas_item->cast_to<Control>()->get_pivot_offset();
+					if (Object::cast_to<Node2D>(canvas_item))
+						se->undo_pivot = Object::cast_to<Node2D>(canvas_item)->edit_get_pivot();
+					if (Object::cast_to<Control>(canvas_item))
+						se->undo_pivot = Object::cast_to<Control>(canvas_item)->get_pivot_offset();
 					return;
 				}
 
 				// Drag anchor handles
-				if (canvas_item->cast_to<Control>()) {
+				if (Object::cast_to<Control>(canvas_item)) {
 					drag = _get_anchor_handle_drag_type(click, drag_point_from);
 					if (drag != DRAG_NONE) {
 						drag_from = transform.affine_inverse().xform(click);
@@ -1457,9 +1454,7 @@ void CanvasItemEditor::_viewport_gui_input(const Ref<InputEvent> &p_event) {
 
 		CanvasItem *c = NULL;
 		if (Cbone) {
-			Object *obj = ObjectDB::get_instance(Cbone->get().bone);
-			if (obj)
-				c = obj->cast_to<CanvasItem>();
+			c = Object::cast_to<CanvasItem>(ObjectDB::get_instance(Cbone->get().bone));
 			if (c)
 				c = c->get_parent_item();
 		}
@@ -1489,7 +1484,7 @@ void CanvasItemEditor::_viewport_gui_input(const Ref<InputEvent> &p_event) {
 		};
 
 		if (n) {
-			c = n->cast_to<CanvasItem>();
+			c = Object::cast_to<CanvasItem>(n);
 		} else {
 			c = NULL;
 		}
@@ -1537,7 +1532,7 @@ void CanvasItemEditor::_viewport_gui_input(const Ref<InputEvent> &p_event) {
 		List<Node *> &selection = editor_selection->get_selected_node_list();
 		for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-			CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+			CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 			if (!canvas_item || !canvas_item->is_visible_in_tree())
 				continue;
 			if (canvas_item->get_viewport() != EditorNode::get_singleton()->get_scene_root())
@@ -1551,10 +1546,10 @@ void CanvasItemEditor::_viewport_gui_input(const Ref<InputEvent> &p_event) {
 
 			if (!dragging_bone) {
 				canvas_item->edit_set_state(se->undo_state); //reset state and reapply
-				if (canvas_item->cast_to<Node2D>())
-					canvas_item->cast_to<Node2D>()->edit_set_pivot(se->undo_pivot);
-				if (canvas_item->cast_to<Control>())
-					canvas_item->cast_to<Control>()->set_pivot_offset(se->undo_pivot);
+				if (Object::cast_to<Node2D>(canvas_item))
+					Object::cast_to<Node2D>(canvas_item)->edit_set_pivot(se->undo_pivot);
+				if (Object::cast_to<Control>(canvas_item))
+					Object::cast_to<Control>(canvas_item)->set_pivot_offset(se->undo_pivot);
 			}
 
 			Vector2 dfrom = drag_from;
@@ -1566,7 +1561,7 @@ void CanvasItemEditor::_viewport_gui_input(const Ref<InputEvent> &p_event) {
 				// Rotate the node
 				Vector2 center = canvas_item->get_global_transform_with_canvas().get_origin();
 				{
-					Node2D *node = canvas_item->cast_to<Node2D>();
+					Node2D *node = Object::cast_to<Node2D>(canvas_item);
 
 					if (node) {
 						real_t angle = node->get_rotation();
@@ -1578,7 +1573,7 @@ void CanvasItemEditor::_viewport_gui_input(const Ref<InputEvent> &p_event) {
 				}
 
 				{
-					Control *node = canvas_item->cast_to<Control>();
+					Control *node = Object::cast_to<Control>(canvas_item);
 
 					if (node) {
 						real_t angle = node->get_rotation();
@@ -1592,7 +1587,7 @@ void CanvasItemEditor::_viewport_gui_input(const Ref<InputEvent> &p_event) {
 				continue;
 			}
 
-			Control *control = canvas_item->cast_to<Control>();
+			Control *control = Object::cast_to<Control>(canvas_item);
 			if (control) {
 				// Drag and snap the anchor
 				Vector2 anchor = _position_to_anchor(control, canvas_item->get_global_transform_with_canvas().affine_inverse().xform(dto - drag_from + drag_point_from));
@@ -1728,19 +1723,19 @@ void CanvasItemEditor::_viewport_gui_input(const Ref<InputEvent> &p_event) {
 
 				case DRAG_PIVOT:
 
-					if (canvas_item->cast_to<Node2D>()) {
-						Node2D *n2d = canvas_item->cast_to<Node2D>();
+					if (Object::cast_to<Node2D>(canvas_item)) {
+						Node2D *n2d = Object::cast_to<Node2D>(canvas_item);
 						n2d->edit_set_pivot(se->undo_pivot + drag_vector);
 					}
-					if (canvas_item->cast_to<Control>()) {
-						canvas_item->cast_to<Control>()->set_pivot_offset(se->undo_pivot + drag_vector);
+					if (Object::cast_to<Control>(canvas_item)) {
+						Object::cast_to<Control>(canvas_item)->set_pivot_offset(se->undo_pivot + drag_vector);
 					}
 					continue;
 					break;
 				case DRAG_NODE_2D:
 
-					ERR_FAIL_COND(!canvas_item->cast_to<Node2D>());
-					canvas_item->cast_to<Node2D>()->set_global_position(dto);
+					ERR_FAIL_COND(!Object::cast_to<Node2D>(canvas_item));
+					Object::cast_to<Node2D>(canvas_item)->set_global_position(dto);
 					continue;
 					break;
 			}
@@ -1754,7 +1749,7 @@ void CanvasItemEditor::_viewport_gui_input(const Ref<InputEvent> &p_event) {
 			} else {
 				//ok, all that had to be done was done, now solve IK
 
-				Node2D *n2d = canvas_item->cast_to<Node2D>();
+				Node2D *n2d = Object::cast_to<Node2D>(canvas_item);
 				Transform2D final_xform = bone_orig_xform;
 
 				if (n2d) {
@@ -1981,7 +1976,7 @@ void CanvasItemEditor::_viewport_draw() {
 
 	for (Map<Node *, Object *>::Element *E = selection.front(); E; E = E->next()) {
 
-		CanvasItem *canvas_item = E->key()->cast_to<CanvasItem>();
+		CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->key());
 		if (!canvas_item || !canvas_item->is_visible_in_tree())
 			continue;
 		if (canvas_item->get_viewport() != EditorNode::get_singleton()->get_scene_root())
@@ -2013,16 +2008,16 @@ void CanvasItemEditor::_viewport_draw() {
 
 		if (single && (tool == TOOL_SELECT || tool == TOOL_MOVE || tool == TOOL_ROTATE || tool == TOOL_EDIT_PIVOT)) { //kind of sucks
 
-			if (canvas_item->cast_to<Node2D>()) {
+			if (Object::cast_to<Node2D>(canvas_item)) {
 
-				if (canvas_item->cast_to<Node2D>()->edit_has_pivot()) {
+				if (Object::cast_to<Node2D>(canvas_item)->edit_has_pivot()) {
 					viewport->draw_texture(pivot, xform.get_origin() + (-pivot->get_size() / 2).floor());
 					can_move_pivot = true;
 					pivot_found = true;
 				}
 			}
 
-			Control *control = canvas_item->cast_to<Control>();
+			Control *control = Object::cast_to<Control>(canvas_item);
 			if (control) {
 				Vector2 pivot_ofs = control->get_pivot_offset();
 				if (pivot_ofs != Vector2()) {
@@ -2214,11 +2209,7 @@ void CanvasItemEditor::_viewport_draw() {
 			E->get().from = Vector2();
 			E->get().to = Vector2();
 
-			Object *obj = ObjectDB::get_instance(E->get().bone);
-			if (!obj)
-				continue;
-
-			Node2D *n2d = obj->cast_to<Node2D>();
+			Node2D *n2d = Object::cast_to<Node2D>(ObjectDB::get_instance(E->get().bone));
 			if (!n2d)
 				continue;
 
@@ -2227,7 +2218,7 @@ void CanvasItemEditor::_viewport_draw() {
 
 			CanvasItem *pi = n2d->get_parent_item();
 
-			Node2D *pn2d = n2d->get_parent()->cast_to<Node2D>();
+			Node2D *pn2d = Object::cast_to<Node2D>(n2d->get_parent());
 
 			if (!pn2d)
 				continue;
@@ -2283,14 +2274,14 @@ void CanvasItemEditor::_notification(int p_what) {
 
 		for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-			CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+			CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 			if (!canvas_item || !canvas_item->is_visible_in_tree())
 				continue;
 
 			if (canvas_item->get_viewport() != EditorNode::get_singleton()->get_scene_root())
 				continue;
 
-			if (canvas_item->cast_to<Control>())
+			if (Object::cast_to<Control>(canvas_item))
 				has_control = true;
 			else
 				all_control = false;
@@ -2304,12 +2295,12 @@ void CanvasItemEditor::_notification(int p_what) {
 
 			float anchors[4];
 			Vector2 pivot;
-			if (canvas_item->cast_to<Control>()) {
-				pivot = canvas_item->cast_to<Control>()->get_pivot_offset();
-				anchors[MARGIN_LEFT] = canvas_item->cast_to<Control>()->get_anchor(MARGIN_LEFT);
-				anchors[MARGIN_RIGHT] = canvas_item->cast_to<Control>()->get_anchor(MARGIN_RIGHT);
-				anchors[MARGIN_TOP] = canvas_item->cast_to<Control>()->get_anchor(MARGIN_TOP);
-				anchors[MARGIN_BOTTOM] = canvas_item->cast_to<Control>()->get_anchor(MARGIN_BOTTOM);
+			if (Object::cast_to<Control>(canvas_item)) {
+				pivot = Object::cast_to<Control>(canvas_item)->get_pivot_offset();
+				anchors[MARGIN_LEFT] = Object::cast_to<Control>(canvas_item)->get_anchor(MARGIN_LEFT);
+				anchors[MARGIN_RIGHT] = Object::cast_to<Control>(canvas_item)->get_anchor(MARGIN_RIGHT);
+				anchors[MARGIN_TOP] = Object::cast_to<Control>(canvas_item)->get_anchor(MARGIN_TOP);
+				anchors[MARGIN_BOTTOM] = Object::cast_to<Control>(canvas_item)->get_anchor(MARGIN_BOTTOM);
 			}
 
 			if (r != se->prev_rect || xform != se->prev_xform || pivot != se->prev_pivot || anchors[MARGIN_LEFT] != se->prev_anchors[MARGIN_LEFT] || anchors[MARGIN_RIGHT] != se->prev_anchors[MARGIN_RIGHT] || anchors[MARGIN_TOP] != se->prev_anchors[MARGIN_TOP] || anchors[MARGIN_BOTTOM] != se->prev_anchors[MARGIN_BOTTOM]) {
@@ -2338,7 +2329,7 @@ void CanvasItemEditor::_notification(int p_what) {
 				break;
 			}
 
-			Node2D *b2 = b->cast_to<Node2D>();
+			Node2D *b2 = Object::cast_to<Node2D>(b);
 			if (!b2) {
 				continue;
 			}
@@ -2426,7 +2417,7 @@ void CanvasItemEditor::_find_canvas_items_span(Node *p_node, Rect2 &r_rect, cons
 	if (!p_node)
 		return;
 
-	CanvasItem *c = p_node->cast_to<CanvasItem>();
+	CanvasItem *c = Object::cast_to<CanvasItem>(p_node);
 
 	for (int i = p_node->get_child_count() - 1; i >= 0; i--) {
 
@@ -2587,7 +2578,7 @@ void CanvasItemEditor::_set_anchors_preset(Control::LayoutPreset p_preset) {
 	undo_redo->create_action(TTR("Change Anchors"));
 	for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-		Control *c = E->get()->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(E->get());
 
 		undo_redo->add_do_method(c, "set_anchors_preset", p_preset);
 		undo_redo->add_undo_method(c, "set_anchor", MARGIN_LEFT, c->get_anchor(MARGIN_LEFT));
@@ -2605,7 +2596,7 @@ void CanvasItemEditor::_set_full_rect() {
 	undo_redo->create_action(TTR("Change Anchors"));
 	for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-		Control *c = E->get()->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(E->get());
 
 		undo_redo->add_do_method(c, "set_anchors_preset", PRESET_WIDE);
 		undo_redo->add_do_method(c, "set_margin", MARGIN_LEFT, 0);
@@ -2713,7 +2704,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-				CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 				if (!canvas_item || !canvas_item->is_visible_in_tree())
 					continue;
 
@@ -2731,7 +2722,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-				CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 				if (!canvas_item || !canvas_item->is_visible_in_tree())
 					continue;
 
@@ -2751,7 +2742,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-				CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 				if (!canvas_item || !canvas_item->is_visible_in_tree())
 					continue;
 
@@ -2769,7 +2760,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-				CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 				if (!canvas_item || !canvas_item->is_visible_in_tree())
 					continue;
 
@@ -2888,15 +2879,15 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			for (Map<Node *, Object *>::Element *E = selection.front(); E; E = E->next()) {
 
-				CanvasItem *canvas_item = E->key()->cast_to<CanvasItem>();
+				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->key());
 				if (!canvas_item || !canvas_item->is_visible_in_tree())
 					continue;
 
 				if (canvas_item->get_viewport() != EditorNode::get_singleton()->get_scene_root())
 					continue;
 
-				if (canvas_item->cast_to<Node2D>()) {
-					Node2D *n2d = canvas_item->cast_to<Node2D>();
+				if (Object::cast_to<Node2D>(canvas_item)) {
+					Node2D *n2d = Object::cast_to<Node2D>(canvas_item);
 
 					if (key_pos)
 						AnimationPlayerEditor::singleton->get_key_editor()->insert_node_value_key(n2d, "position", n2d->get_position(), existing);
@@ -2909,7 +2900,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 						//look for an IK chain
 						List<Node2D *> ik_chain;
 
-						Node2D *n = n2d->get_parent_item()->cast_to<Node2D>();
+						Node2D *n = Object::cast_to<Node2D>(n2d->get_parent_item());
 						bool has_chain = false;
 
 						while (n) {
@@ -2922,7 +2913,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 							if (!n->get_parent_item())
 								break;
-							n = n->get_parent_item()->cast_to<Node2D>();
+							n = Object::cast_to<Node2D>(n->get_parent_item());
 						}
 
 						if (has_chain && ik_chain.size()) {
@@ -2939,9 +2930,9 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 						}
 					}
 
-				} else if (canvas_item->cast_to<Control>()) {
+				} else if (Object::cast_to<Control>(canvas_item)) {
 
-					Control *ctrl = canvas_item->cast_to<Control>();
+					Control *ctrl = Object::cast_to<Control>(canvas_item);
 
 					if (key_pos)
 						AnimationPlayerEditor::singleton->get_key_editor()->insert_node_value_key(ctrl, "rect_position", ctrl->get_position(), existing);
@@ -2998,16 +2989,16 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			for (Map<Node *, Object *>::Element *E = selection.front(); E; E = E->next()) {
 
-				CanvasItem *canvas_item = E->key()->cast_to<CanvasItem>();
+				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->key());
 				if (!canvas_item || !canvas_item->is_visible_in_tree())
 					continue;
 
 				if (canvas_item->get_viewport() != EditorNode::get_singleton()->get_scene_root())
 					continue;
 
-				if (canvas_item->cast_to<Node2D>()) {
+				if (Object::cast_to<Node2D>(canvas_item)) {
 
-					Node2D *n2d = canvas_item->cast_to<Node2D>();
+					Node2D *n2d = Object::cast_to<Node2D>(canvas_item);
 					PoseClipboard pc;
 					pc.pos = n2d->get_position();
 					pc.rot = n2d->get_rotation();
@@ -3026,10 +3017,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 			undo_redo->create_action(TTR("Paste Pose"));
 			for (List<PoseClipboard>::Element *E = pose_clipboard.front(); E; E = E->next()) {
 
-				Object *o = ObjectDB::get_instance(E->get().id);
-				if (!o)
-					continue;
-				Node2D *n2d = o->cast_to<Node2D>();
+				Node2D *n2d = Object::cast_to<Node2D>(ObjectDB::get_instance(E->get().id));
 				if (!n2d)
 					continue;
 				undo_redo->add_do_method(n2d, "set_position", E->get().pos);
@@ -3048,15 +3036,15 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			for (Map<Node *, Object *>::Element *E = selection.front(); E; E = E->next()) {
 
-				CanvasItem *canvas_item = E->key()->cast_to<CanvasItem>();
+				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->key());
 				if (!canvas_item || !canvas_item->is_visible_in_tree())
 					continue;
 
 				if (canvas_item->get_viewport() != EditorNode::get_singleton()->get_scene_root())
 					continue;
 
-				if (canvas_item->cast_to<Node2D>()) {
-					Node2D *n2d = canvas_item->cast_to<Node2D>();
+				if (Object::cast_to<Node2D>(canvas_item)) {
+					Node2D *n2d = Object::cast_to<Node2D>(canvas_item);
 
 					if (key_pos)
 						n2d->set_position(Vector2());
@@ -3064,9 +3052,9 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 						n2d->set_rotation(0);
 					if (key_scale)
 						n2d->set_scale(Vector2(1, 1));
-				} else if (canvas_item->cast_to<Control>()) {
+				} else if (Object::cast_to<Control>(canvas_item)) {
 
-					Control *ctrl = canvas_item->cast_to<Control>();
+					Control *ctrl = Object::cast_to<Control>(canvas_item);
 
 					if (key_pos)
 						ctrl->set_position(Point2());
@@ -3090,7 +3078,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			for (Map<Node *, Object *>::Element *E = selection.front(); E; E = E->next()) {
 
-				Node2D *n2d = E->key()->cast_to<Node2D>();
+				Node2D *n2d = Object::cast_to<Node2D>(E->key());
 				if (!n2d)
 					continue;
 				if (!n2d->is_visible_in_tree())
@@ -3111,7 +3099,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			for (Map<Node *, Object *>::Element *E = selection.front(); E; E = E->next()) {
 
-				Node2D *n2d = E->key()->cast_to<Node2D>();
+				Node2D *n2d = Object::cast_to<Node2D>(E->key());
 				if (!n2d)
 					continue;
 				if (!n2d->is_visible_in_tree())
@@ -3130,7 +3118,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-				CanvasItem *canvas_item = E->get()->cast_to<CanvasItem>();
+				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->get());
 				if (!canvas_item || !canvas_item->is_visible_in_tree())
 					continue;
 
@@ -3151,7 +3139,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			for (Map<Node *, Object *>::Element *E = selection.front(); E; E = E->next()) {
 
-				CanvasItem *n2d = E->key()->cast_to<CanvasItem>();
+				CanvasItem *n2d = Object::cast_to<CanvasItem>(E->key());
 				if (!n2d)
 					continue;
 				if (!n2d->is_visible_in_tree())
@@ -3202,7 +3190,7 @@ void CanvasItemEditor::_focus_selection(int p_op) {
 
 	Map<Node *, Object *> &selection = editor_selection->get_selection();
 	for (Map<Node *, Object *>::Element *E = selection.front(); E; E = E->next()) {
-		CanvasItem *canvas_item = E->key()->cast_to<CanvasItem>();
+		CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E->key());
 		if (!canvas_item) continue;
 		if (canvas_item->get_viewport() != EditorNode::get_singleton()->get_scene_root())
 			continue;
@@ -3302,7 +3290,7 @@ void CanvasItemEditor::box_selection_start( Point2 &click ) {
 bool CanvasItemEditor::box_selection_end() {
 	print_line( "box selection end" );
 
-	Node* scene = get_scene()->get_root_node()->cast_to<EditorNode>()->get_edited_scene();
+	Node* scene = Object::cast_to<EditorNode>(get_scene()->get_root_node())->get_edited_scene();
 	if (scene) {
 
 		List<CanvasItem*> selitems;
@@ -3651,7 +3639,7 @@ CanvasItemEditor *CanvasItemEditor::singleton = NULL;
 void CanvasItemEditorPlugin::edit(Object *p_object) {
 
 	canvas_item_editor->set_undo_redo(&get_undo_redo());
-	canvas_item_editor->edit(p_object->cast_to<CanvasItem>());
+	canvas_item_editor->edit(Object::cast_to<CanvasItem>(p_object));
 }
 
 bool CanvasItemEditorPlugin::handles(Object *p_object) const {
@@ -3704,7 +3692,7 @@ void CanvasItemEditorViewport::_on_mouse_exit() {
 }
 
 void CanvasItemEditorViewport::_on_select_type(Object *selected) {
-	CheckBox *check = selected->cast_to<CheckBox>();
+	CheckBox *check = Object::cast_to<CheckBox>(selected);
 	String type = check->get_text();
 	selector_label->set_text(vformat(TTR("Add %s"), type));
 	label->set_text(vformat(TTR("Adding %s..."), type));
@@ -3714,7 +3702,7 @@ void CanvasItemEditorViewport::_on_change_type() {
 	if (!button_group->get_pressed_button())
 		return;
 
-	CheckBox *check = button_group->get_pressed_button()->cast_to<CheckBox>();
+	CheckBox *check = Object::cast_to<CheckBox>(button_group->get_pressed_button());
 	default_type = check->get_text();
 	_perform_drop_data();
 	selector->hide();
@@ -3726,8 +3714,8 @@ void CanvasItemEditorViewport::_create_preview(const Vector<String> &files) cons
 	for (int i = 0; i < files.size(); i++) {
 		String path = files[i];
 		RES res = ResourceLoader::load(path);
-		Ref<Texture> texture = Ref<Texture>(res->cast_to<Texture>());
-		Ref<PackedScene> scene = Ref<PackedScene>(res->cast_to<PackedScene>());
+		Ref<Texture> texture = Ref<Texture>(Object::cast_to<Texture>(*res));
+		Ref<PackedScene> scene = Ref<PackedScene>(Object::cast_to<PackedScene>(*res));
 		if (texture != NULL || scene != NULL) {
 			if (texture != NULL) {
 				Sprite *sprite = memnew(Sprite);
@@ -3778,7 +3766,7 @@ bool CanvasItemEditorViewport::_cyclical_dependency_exists(const String &p_targe
 
 void CanvasItemEditorViewport::_create_nodes(Node *parent, Node *child, String &path, const Point2 &p_point) {
 	child->set_name(path.get_file().get_basename());
-	Ref<Texture> texture = Ref<Texture>(ResourceCache::get(path)->cast_to<Texture>());
+	Ref<Texture> texture = Object::cast_to<Texture>(Ref<Texture>(ResourceCache::get(path)).ptr());
 	Size2 texture_size = texture->get_size();
 
 	editor_data->get_undo_redo().add_do_method(parent, "add_child", child);
@@ -3867,11 +3855,11 @@ bool CanvasItemEditorViewport::_create_instance(Node *parent, String &path, cons
 	editor_data->get_undo_redo().add_undo_method(sed, "live_debug_remove_node", NodePath(String(editor->get_edited_scene()->get_path_to(parent)) + "/" + new_name));
 
 	Point2 pos;
-	Node2D *parent_node2d = parent->cast_to<Node2D>();
+	Node2D *parent_node2d = Object::cast_to<Node2D>(parent);
 	if (parent_node2d) {
 		pos = parent_node2d->get_global_position();
 	} else {
-		Control *parent_control = parent->cast_to<Control>();
+		Control *parent_control = Object::cast_to<Control>(parent);
 		if (parent_control) {
 			pos = parent_control->get_global_position();
 		}
@@ -3879,7 +3867,7 @@ bool CanvasItemEditorViewport::_create_instance(Node *parent, String &path, cons
 	Transform2D trans = canvas->get_canvas_transform();
 	Vector2 target_pos = (p_point - trans.get_origin()) / trans.get_scale().x - pos;
 	// in relative snapping it may be useful for the user to take the original node position into account
-	Vector2 start_pos = instanced_scene->cast_to<Node2D>() ? instanced_scene->cast_to<Node2D>()->get_position() : target_pos;
+	Vector2 start_pos = Object::cast_to<Node2D>(instanced_scene) ? Object::cast_to<Node2D>(instanced_scene)->get_position() : target_pos;
 	target_pos = canvas->snap_point(target_pos, start_pos);
 	editor_data->get_undo_redo().add_do_method(instanced_scene, "set_position", target_pos);
 
@@ -3899,8 +3887,8 @@ void CanvasItemEditorViewport::_perform_drop_data() {
 		if (res.is_null()) {
 			continue;
 		}
-		Ref<Texture> texture = Ref<Texture>(res->cast_to<Texture>());
-		Ref<PackedScene> scene = Ref<PackedScene>(res->cast_to<PackedScene>());
+		Ref<Texture> texture = Ref<Texture>(Object::cast_to<Texture>(*res));
+		Ref<PackedScene> scene = Ref<PackedScene>(Object::cast_to<PackedScene>(*res));
 		if (texture != NULL) {
 			Node *child;
 			if (default_type == "Light2D")
@@ -4016,7 +4004,7 @@ void CanvasItemEditorViewport::drop_data(const Point2 &p_point, const Variant &p
 		button_group->get_buttons(&btn_list);
 
 		for (int i = 0; i < btn_list.size(); i++) {
-			CheckBox *check = btn_list[i]->cast_to<CheckBox>();
+			CheckBox *check = Object::cast_to<CheckBox>(btn_list[i]);
 			check->set_pressed(check->get_text() == default_type);
 		}
 		selector_label->set_text(vformat(TTR("Add %s"), default_type));

--- a/editor/plugins/collision_polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_polygon_2d_editor_plugin.cpp
@@ -343,7 +343,7 @@ void CollisionPolygon2DEditor::edit(Node *p_collision_polygon) {
 
 	if (p_collision_polygon) {
 
-		node = p_collision_polygon->cast_to<CollisionPolygon2D>();
+		node = Object::cast_to<CollisionPolygon2D>(p_collision_polygon);
 		if (!canvas_item_editor->get_viewport_control()->is_connected("draw", this, "_canvas_draw"))
 			canvas_item_editor->get_viewport_control()->connect("draw", this, "_canvas_draw");
 		wip.clear();
@@ -403,7 +403,7 @@ CollisionPolygon2DEditor::CollisionPolygon2DEditor(EditorNode *p_editor) {
 
 void CollisionPolygon2DEditorPlugin::edit(Object *p_object) {
 
-	collision_polygon_editor->edit(p_object->cast_to<Node>());
+	collision_polygon_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool CollisionPolygon2DEditorPlugin::handles(Object *p_object) const {

--- a/editor/plugins/collision_polygon_editor_plugin.cpp
+++ b/editor/plugins/collision_polygon_editor_plugin.cpp
@@ -464,7 +464,7 @@ void CollisionPolygonEditor::edit(Node *p_collision_polygon) {
 
 	if (p_collision_polygon) {
 
-		node = p_collision_polygon->cast_to<CollisionPolygon>();
+		node = Object::cast_to<CollisionPolygon>(p_collision_polygon);
 		wip.clear();
 		wip_active = false;
 		edited_point = -1;
@@ -555,7 +555,7 @@ CollisionPolygonEditor::~CollisionPolygonEditor() {
 
 void CollisionPolygonEditorPlugin::edit(Object *p_object) {
 
-	collision_polygon_editor->edit(p_object->cast_to<Node>());
+	collision_polygon_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool CollisionPolygonEditorPlugin::handles(Object *p_object) const {

--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -393,21 +393,21 @@ void CollisionShape2DEditor::_get_current_shape_type() {
 		return;
 	}
 
-	if (s->cast_to<CapsuleShape2D>()) {
+	if (Object::cast_to<CapsuleShape2D>(*s)) {
 		shape_type = CAPSULE_SHAPE;
-	} else if (s->cast_to<CircleShape2D>()) {
+	} else if (Object::cast_to<CircleShape2D>(*s)) {
 		shape_type = CIRCLE_SHAPE;
-	} else if (s->cast_to<ConcavePolygonShape2D>()) {
+	} else if (Object::cast_to<ConcavePolygonShape2D>(*s)) {
 		shape_type = CONCAVE_POLYGON_SHAPE;
-	} else if (s->cast_to<ConvexPolygonShape2D>()) {
+	} else if (Object::cast_to<ConvexPolygonShape2D>(*s)) {
 		shape_type = CONVEX_POLYGON_SHAPE;
-	} else if (s->cast_to<LineShape2D>()) {
+	} else if (Object::cast_to<LineShape2D>(*s)) {
 		shape_type = LINE_SHAPE;
-	} else if (s->cast_to<RayShape2D>()) {
+	} else if (Object::cast_to<RayShape2D>(*s)) {
 		shape_type = RAY_SHAPE;
-	} else if (s->cast_to<RectangleShape2D>()) {
+	} else if (Object::cast_to<RectangleShape2D>(*s)) {
 		shape_type = RECTANGLE_SHAPE;
-	} else if (s->cast_to<SegmentShape2D>()) {
+	} else if (Object::cast_to<SegmentShape2D>(*s)) {
 		shape_type = SEGMENT_SHAPE;
 	} else {
 		shape_type = -1;
@@ -530,7 +530,7 @@ void CollisionShape2DEditor::edit(Node *p_node) {
 	}
 
 	if (p_node) {
-		node = p_node->cast_to<CollisionShape2D>();
+		node = Object::cast_to<CollisionShape2D>(p_node);
 
 		if (!canvas_item_editor->get_viewport_control()->is_connected("draw", this, "_canvas_draw"))
 			canvas_item_editor->get_viewport_control()->connect("draw", this, "_canvas_draw");
@@ -570,7 +570,7 @@ CollisionShape2DEditor::CollisionShape2DEditor(EditorNode *p_editor) {
 
 void CollisionShape2DEditorPlugin::edit(Object *p_obj) {
 
-	collision_shape_2d_editor->edit(p_obj->cast_to<Node>());
+	collision_shape_2d_editor->edit(Object::cast_to<Node>(p_obj));
 }
 
 bool CollisionShape2DEditorPlugin::handles(Object *p_obj) const {

--- a/editor/plugins/cube_grid_theme_editor_plugin.cpp
+++ b/editor/plugins/cube_grid_theme_editor_plugin.cpp
@@ -72,10 +72,10 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 
 		Node *child = p_scene->get_child(i);
 
-		if (!child->cast_to<MeshInstance>()) {
+		if (!Object::cast_to<MeshInstance>(child)) {
 			if (child->get_child_count() > 0) {
 				child = child->get_child(0);
-				if (!child->cast_to<MeshInstance>()) {
+				if (!Object::cast_to<MeshInstance>(child)) {
 					continue;
 				}
 
@@ -83,7 +83,7 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 				continue;
 		}
 
-		MeshInstance *mi = child->cast_to<MeshInstance>();
+		MeshInstance *mi = Object::cast_to<MeshInstance>(child);
 		Ref<Mesh> mesh = mi->get_mesh();
 		if (mesh.is_null())
 			continue;
@@ -103,10 +103,10 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 		for (int j = 0; j < mi->get_child_count(); j++) {
 
 			Node *child2 = mi->get_child(j);
-			if (!child2->cast_to<StaticBody>())
+			if (!Object::cast_to<StaticBody>(child2))
 				continue;
 
-			StaticBody *sb = child2->cast_to<StaticBody>();
+			StaticBody *sb = Object::cast_to<StaticBody>(child2);
 			List<uint32_t> shapes;
 			sb->get_shape_owners(&shapes);
 
@@ -140,9 +140,9 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 		Ref<NavigationMesh> navmesh;
 		for (int j = 0; j < mi->get_child_count(); j++) {
 			Node *child2 = mi->get_child(j);
-			if (!child2->cast_to<NavigationMeshInstance>())
+			if (!Object::cast_to<NavigationMeshInstance>(child2))
 				continue;
-			NavigationMeshInstance *sb = child2->cast_to<NavigationMeshInstance>();
+			NavigationMeshInstance *sb = Object::cast_to<NavigationMeshInstance>(child2);
 			navmesh = sb->get_navigation_mesh();
 			if (!navmesh.is_null())
 				break;
@@ -341,8 +341,8 @@ MeshLibraryEditor::MeshLibraryEditor(EditorNode *p_editor) {
 
 void MeshLibraryEditorPlugin::edit(Object *p_node) {
 
-	if (p_node && p_node->cast_to<MeshLibrary>()) {
-		theme_editor->edit(p_node->cast_to<MeshLibrary>());
+	if (Object::cast_to<MeshLibrary>(p_node)) {
+		theme_editor->edit(Object::cast_to<MeshLibrary>(p_node));
 		theme_editor->show();
 	} else
 		theme_editor->hide();

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -786,24 +786,24 @@ void CurveEditorPlugin::edit(Object *p_object) {
 	Ref<Curve> curve_ref;
 
 	if (_current_ref.is_valid()) {
-		CurveTexture *ct = _current_ref->cast_to<CurveTexture>();
+		CurveTexture *ct = Object::cast_to<CurveTexture>(*_current_ref);
 		if (ct)
 			ct->disconnect(CoreStringNames::get_singleton()->changed, this, "_curve_texture_changed");
 	}
 
 	if (p_object) {
-		Resource *res = p_object->cast_to<Resource>();
+		Resource *res = Object::cast_to<Resource>(p_object);
 		ERR_FAIL_COND(res == NULL);
 		ERR_FAIL_COND(!handles(p_object));
 
-		_current_ref = Ref<Resource>(p_object->cast_to<Resource>());
+		_current_ref = Ref<Resource>(Object::cast_to<Resource>(p_object));
 
 		if (_current_ref.is_valid()) {
-			Curve *curve = _current_ref->cast_to<Curve>();
+			Curve *curve = Object::cast_to<Curve>(*_current_ref);
 			if (curve)
 				curve_ref = Ref<Curve>(curve);
 			else {
-				CurveTexture *ct = _current_ref->cast_to<CurveTexture>();
+				CurveTexture *ct = Object::cast_to<CurveTexture>(*_current_ref);
 				if (ct) {
 					ct->connect(CoreStringNames::get_singleton()->changed, this, "_curve_texture_changed");
 					curve_ref = ct->get_curve();
@@ -820,7 +820,7 @@ void CurveEditorPlugin::edit(Object *p_object) {
 
 bool CurveEditorPlugin::handles(Object *p_object) const {
 	// Both handled so that we can keep the curve editor open
-	return p_object->cast_to<Curve>() || p_object->cast_to<CurveTexture>();
+	return Object::cast_to<Curve>(p_object) || Object::cast_to<CurveTexture>(p_object);
 }
 
 void CurveEditorPlugin::make_visible(bool p_visible) {
@@ -837,7 +837,7 @@ void CurveEditorPlugin::make_visible(bool p_visible) {
 void CurveEditorPlugin::_curve_texture_changed() {
 	// If the curve is shown indirectly as a CurveTexture is edited,
 	// we need to monitor when the curve property gets assigned
-	CurveTexture *ct = _current_ref->cast_to<CurveTexture>();
+	CurveTexture *ct = Object::cast_to<CurveTexture>(*_current_ref);
 	if (ct) {
 		_view->set_curve(ct->get_curve());
 	}

--- a/editor/plugins/gi_probe_editor_plugin.cpp
+++ b/editor/plugins/gi_probe_editor_plugin.cpp
@@ -38,7 +38,7 @@ void GIProbeEditorPlugin::_bake() {
 
 void GIProbeEditorPlugin::edit(Object *p_object) {
 
-	GIProbe *s = p_object->cast_to<GIProbe>();
+	GIProbe *s = Object::cast_to<GIProbe>(p_object);
 	if (!s)
 		return;
 

--- a/editor/plugins/gradient_editor_plugin.cpp
+++ b/editor/plugins/gradient_editor_plugin.cpp
@@ -46,7 +46,7 @@ GradientEditorPlugin::GradientEditorPlugin(EditorNode *p_node) {
 
 void GradientEditorPlugin::edit(Object *p_object) {
 
-	Gradient *gradient = p_object->cast_to<Gradient>();
+	Gradient *gradient = Object::cast_to<Gradient>(p_object);
 	if (!gradient)
 		return;
 	gradient_ref = Ref<Gradient>(gradient);

--- a/editor/plugins/item_list_editor_plugin.cpp
+++ b/editor/plugins/item_list_editor_plugin.cpp
@@ -115,7 +115,7 @@ void ItemListPlugin::_get_property_list(List<PropertyInfo> *p_list) const {
 
 void ItemListOptionButtonPlugin::set_object(Object *p_object) {
 
-	ob = p_object->cast_to<OptionButton>();
+	ob = Object::cast_to<OptionButton>(p_object);
 }
 
 bool ItemListOptionButtonPlugin::handles(Object *p_object) const {
@@ -155,9 +155,9 @@ ItemListOptionButtonPlugin::ItemListOptionButtonPlugin() {
 void ItemListPopupMenuPlugin::set_object(Object *p_object) {
 
 	if (p_object->is_class("MenuButton"))
-		pp = p_object->cast_to<MenuButton>()->get_popup();
+		pp = Object::cast_to<MenuButton>(p_object)->get_popup();
 	else
-		pp = p_object->cast_to<PopupMenu>();
+		pp = Object::cast_to<PopupMenu>(p_object);
 }
 
 bool ItemListPopupMenuPlugin::handles(Object *p_object) const {
@@ -196,7 +196,7 @@ ItemListPopupMenuPlugin::ItemListPopupMenuPlugin() {
 
 void ItemListItemListPlugin::set_object(Object *p_object) {
 
-	pp = p_object->cast_to<ItemList>();
+	pp = Object::cast_to<ItemList>(p_object);
 }
 
 bool ItemListItemListPlugin::handles(Object *p_object) const {
@@ -384,7 +384,7 @@ ItemListEditor::~ItemListEditor() {
 
 void ItemListEditorPlugin::edit(Object *p_object) {
 
-	item_list_editor->edit(p_object->cast_to<Node>());
+	item_list_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool ItemListEditorPlugin::handles(Object *p_object) const {

--- a/editor/plugins/light_occluder_2d_editor_plugin.cpp
+++ b/editor/plugins/light_occluder_2d_editor_plugin.cpp
@@ -367,7 +367,7 @@ void LightOccluder2DEditor::edit(Node *p_collision_polygon) {
 
 	if (p_collision_polygon) {
 
-		node = p_collision_polygon->cast_to<LightOccluder2D>();
+		node = Object::cast_to<LightOccluder2D>(p_collision_polygon);
 		if (!canvas_item_editor->get_viewport_control()->is_connected("draw", this, "_canvas_draw"))
 			canvas_item_editor->get_viewport_control()->connect("draw", this, "_canvas_draw");
 		wip.clear();
@@ -441,7 +441,7 @@ LightOccluder2DEditor::LightOccluder2DEditor(EditorNode *p_editor) {
 
 void LightOccluder2DEditorPlugin::edit(Object *p_object) {
 
-	collision_polygon_editor->edit(p_object->cast_to<Node>());
+	collision_polygon_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool LightOccluder2DEditorPlugin::handles(Object *p_object) const {

--- a/editor/plugins/line_2d_editor_plugin.cpp
+++ b/editor/plugins/line_2d_editor_plugin.cpp
@@ -189,7 +189,7 @@ void Line2DEditor::edit(Node *p_line2d) {
 		canvas_item_editor = CanvasItemEditor::get_singleton();
 
 	if (p_line2d) {
-		node = p_line2d->cast_to<Line2D>();
+		node = Object::cast_to<Line2D>(p_line2d);
 		if (!canvas_item_editor->get_viewport_control()->is_connected("draw", this, "_canvas_draw"))
 			canvas_item_editor->get_viewport_control()->connect("draw", this, "_canvas_draw");
 		if (!node->is_connected("visibility_changed", this, "_node_visibility_changed"))
@@ -276,7 +276,7 @@ Line2DEditor::Line2DEditor(EditorNode *p_editor) {
 //----------------------------------------------------------------------------
 
 void Line2DEditorPlugin::edit(Object *p_object) {
-	line2d_editor->edit(p_object->cast_to<Node>());
+	line2d_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool Line2DEditorPlugin::handles(Object *p_object) const {

--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -372,7 +372,7 @@ MaterialEditor::MaterialEditor() {
 
 void MaterialEditorPlugin::edit(Object *p_object) {
 
-	Material * s = p_object->cast_to<Material>();
+	Material * s = Object::cast_to<Material>(p_object);
 	if (!s)
 		return;
 

--- a/editor/plugins/mesh_editor_plugin.cpp
+++ b/editor/plugins/mesh_editor_plugin.cpp
@@ -187,7 +187,7 @@ MeshEditor::MeshEditor() {
 
 void MeshEditorPlugin::edit(Object *p_object) {
 
-	Mesh *s = p_object->cast_to<Mesh>();
+	Mesh *s = Object::cast_to<Mesh>(p_object);
 	if (!s)
 		return;
 

--- a/editor/plugins/mesh_instance_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_editor_plugin.cpp
@@ -101,7 +101,7 @@ void MeshInstanceEditor::_menu_option(int p_option) {
 
 			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-				MeshInstance *instance = E->get()->cast_to<MeshInstance>();
+				MeshInstance *instance = Object::cast_to<MeshInstance>(E->get());
 				if (!instance)
 					continue;
 
@@ -290,7 +290,7 @@ MeshInstanceEditor::MeshInstanceEditor() {
 
 void MeshInstanceEditorPlugin::edit(Object *p_object) {
 
-	mesh_editor->edit(p_object->cast_to<MeshInstance>());
+	mesh_editor->edit(Object::cast_to<MeshInstance>(p_object));
 }
 
 bool MeshInstanceEditorPlugin::handles(Object *p_object) const {

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -77,7 +77,7 @@ void MultiMeshEditor::_populate() {
 			return;
 		}
 
-		MeshInstance *ms_instance = ms_node->cast_to<MeshInstance>();
+		MeshInstance *ms_instance = Object::cast_to<MeshInstance>(ms_node);
 
 		if (!ms_instance) {
 
@@ -112,7 +112,7 @@ void MultiMeshEditor::_populate() {
 		return;
 	}
 
-	GeometryInstance *ss_instance = ss_node->cast_to<MeshInstance>();
+	GeometryInstance *ss_instance = Object::cast_to<MeshInstance>(ss_node);
 
 	if (!ss_instance) {
 
@@ -155,7 +155,7 @@ void MultiMeshEditor::_populate() {
 	ERR_EXPLAIN("Multimesh not present.");
 	ERR_FAIL_COND(multimesh.is_null());
 
-	VisualInstance *vi = get_parent()->cast_to<VisualInstance>();
+	VisualInstance *vi = Object::cast_to<VisualInstance>(get_parent());
 	ERR_EXPLAIN("Parent is not of type VisualInstance, can't be populated.");
 	ERR_FAIL_COND(!vi);
 
@@ -402,7 +402,7 @@ MultiMeshEditor::MultiMeshEditor() {
 
 void MultiMeshEditorPlugin::edit(Object *p_object) {
 
-	multimesh_editor->edit(p_object->cast_to<MultiMeshInstance>());
+	multimesh_editor->edit(Object::cast_to<MultiMeshInstance>(p_object));
 }
 
 bool MultiMeshEditorPlugin::handles(Object *p_object) const {

--- a/editor/plugins/navigation_polygon_editor_plugin.cpp
+++ b/editor/plugins/navigation_polygon_editor_plugin.cpp
@@ -422,7 +422,7 @@ void NavigationPolygonEditor::edit(Node *p_collision_polygon) {
 
 	if (p_collision_polygon) {
 
-		node = p_collision_polygon->cast_to<NavigationPolygonInstance>();
+		node = Object::cast_to<NavigationPolygonInstance>(p_collision_polygon);
 		if (!canvas_item_editor->get_viewport_control()->is_connected("draw", this, "_canvas_draw"))
 			canvas_item_editor->get_viewport_control()->connect("draw", this, "_canvas_draw");
 		wip.clear();
@@ -486,7 +486,7 @@ NavigationPolygonEditor::NavigationPolygonEditor(EditorNode *p_editor) {
 
 void NavigationPolygonEditorPlugin::edit(Object *p_object) {
 
-	collision_polygon_editor->edit(p_object->cast_to<Node>());
+	collision_polygon_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool NavigationPolygonEditorPlugin::handles(Object *p_object) const {

--- a/editor/plugins/particles_2d_editor_plugin.cpp
+++ b/editor/plugins/particles_2d_editor_plugin.cpp
@@ -33,13 +33,10 @@
 #include "io/image_loader.h"
 #include "scene/3d/particles.h"
 #include "scene/gui/separator.h"
+
 void Particles2DEditorPlugin::edit(Object *p_object) {
 
-	if (p_object) {
-		particles = p_object->cast_to<Particles2D>();
-	} else {
-		particles = NULL;
-	}
+	particles = Object::cast_to<Particles2D>(p_object);
 }
 
 bool Particles2DEditorPlugin::handles(Object *p_object) const {

--- a/editor/plugins/particles_editor_plugin.cpp
+++ b/editor/plugins/particles_editor_plugin.cpp
@@ -51,7 +51,7 @@ void ParticlesEditor::_node_selected(const NodePath &p_path) {
 	if (!sel)
 		return;
 
-	VisualInstance *vi = sel->cast_to<VisualInstance>();
+	VisualInstance *vi = Object::cast_to<VisualInstance>(sel);
 	if (!vi) {
 
 		err_dialog->set_text(TTR("Node does not contain geometry."));
@@ -135,7 +135,7 @@ void ParticlesEditor::_menu_option(int p_option) {
 			/*
 			Node *root = get_scene()->get_root_node();
 			ERR_FAIL_COND(!root);
-			EditorNode *en = root->cast_to<EditorNode>();
+			EditorNode *en = Object::cast_to<EditorNode>(root);
 			ERR_FAIL_COND(!en);
 			Node * node = en->get_edited_scene();
 */
@@ -461,7 +461,7 @@ ParticlesEditor::ParticlesEditor() {
 
 void ParticlesEditorPlugin::edit(Object *p_object) {
 
-	particles_editor->edit(p_object->cast_to<Particles>());
+	particles_editor->edit(Object::cast_to<Particles>(p_object));
 }
 
 bool ParticlesEditorPlugin::handles(Object *p_object) const {

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -534,7 +534,7 @@ void Path2DEditor::edit(Node *p_path2d) {
 
 	if (p_path2d) {
 
-		node = p_path2d->cast_to<Path2D>();
+		node = Object::cast_to<Path2D>(p_path2d);
 		if (!canvas_item_editor->get_viewport_control()->is_connected("draw", this, "_canvas_draw"))
 			canvas_item_editor->get_viewport_control()->connect("draw", this, "_canvas_draw");
 		if (!node->is_connected("visibility_changed", this, "_node_visibility_changed"))
@@ -676,7 +676,7 @@ Path2DEditor::Path2DEditor(EditorNode *p_editor) {
 
 void Path2DEditorPlugin::edit(Object *p_object) {
 
-	path2d_editor->edit(p_object->cast_to<Node>());
+	path2d_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool Path2DEditorPlugin::handles(Object *p_object) const {

--- a/editor/plugins/path_editor_plugin.cpp
+++ b/editor/plugins/path_editor_plugin.cpp
@@ -269,9 +269,9 @@ PathSpatialGizmo::PathSpatialGizmo(Path *p_path) {
 
 Ref<SpatialEditorGizmo> PathEditorPlugin::create_spatial_gizmo(Spatial *p_spatial) {
 
-	if (p_spatial->cast_to<Path>()) {
+	if (Object::cast_to<Path>(p_spatial)) {
 
-		return memnew(PathSpatialGizmo(p_spatial->cast_to<Path>()));
+		return memnew(PathSpatialGizmo(Object::cast_to<Path>(p_spatial)));
 	}
 
 	return Ref<SpatialEditorGizmo>();
@@ -433,7 +433,7 @@ bool PathEditorPlugin::forward_spatial_gui_input(Camera *p_camera, const Ref<Inp
 void PathEditorPlugin::edit(Object *p_object) {
 
 	if (p_object) {
-		path = p_object->cast_to<Path>();
+		path = Object::cast_to<Path>(p_object);
 		if (path) {
 
 			if (path->get_curve().is_valid()) {
@@ -447,7 +447,7 @@ void PathEditorPlugin::edit(Object *p_object) {
 			pre->get_curve()->emit_signal("changed");
 		}
 	}
-	//collision_polygon_editor->edit(p_object->cast_to<Node>());
+	//collision_polygon_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool PathEditorPlugin::handles(Object *p_object) const {

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -697,7 +697,7 @@ void Polygon2DEditor::edit(Node *p_collision_polygon) {
 
 	if (p_collision_polygon) {
 
-		node = p_collision_polygon->cast_to<Polygon2D>();
+		node = Object::cast_to<Polygon2D>(p_collision_polygon);
 		if (!canvas_item_editor->get_viewport_control()->is_connected("draw", this, "_canvas_draw"))
 			canvas_item_editor->get_viewport_control()->connect("draw", this, "_canvas_draw");
 
@@ -925,7 +925,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) {
 
 void Polygon2DEditorPlugin::edit(Object *p_object) {
 
-	collision_polygon_editor->edit(p_object->cast_to<Node>());
+	collision_polygon_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool Polygon2DEditorPlugin::handles(Object *p_object) const {

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -410,7 +410,7 @@ ResourcePreloaderEditor::ResourcePreloaderEditor() {
 void ResourcePreloaderEditorPlugin::edit(Object *p_object) {
 
 	preloader_editor->set_undo_redo(&get_undo_redo());
-	ResourcePreloader *s = p_object->cast_to<ResourcePreloader>();
+	ResourcePreloader *s = Object::cast_to<ResourcePreloader>(p_object);
 	if (!s)
 		return;
 

--- a/editor/plugins/rich_text_editor_plugin.cpp
+++ b/editor/plugins/rich_text_editor_plugin.cpp
@@ -91,7 +91,7 @@ void RichTextEditor::_bind_methods() {
 
 void RichTextEditor::edit(Node *p_rich_text) {
 
-	node = p_rich_text->cast_to<RichTextLabel>();
+	node = Object::cast_to<RichTextLabel>(p_rich_text);
 }
 RichTextEditor::RichTextEditor() {
 
@@ -114,7 +114,7 @@ RichTextEditor::RichTextEditor() {
 
 void RichTextEditorPlugin::edit(Object *p_object) {
 
-	rich_text_editor->edit(p_object->cast_to<Node>());
+	rich_text_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool RichTextEditorPlugin::handles(Object *p_object) const {

--- a/editor/plugins/sample_editor_plugin.cpp
+++ b/editor/plugins/sample_editor_plugin.cpp
@@ -408,7 +408,7 @@ SampleEditor::SampleEditor() {
 
 void SampleEditorPlugin::edit(Object *p_object) {
 
-	Sample * s = p_object->cast_to<Sample>();
+	Sample * s = Object::cast_to<Sample>(p_object);
 	if (!s)
 		return;
 

--- a/editor/plugins/sample_library_editor_plugin.cpp
+++ b/editor/plugins/sample_library_editor_plugin.cpp
@@ -47,7 +47,7 @@ void SampleLibraryEditor::_notification(int p_what) {
 
 	if (p_what==NOTIFICATION_PROCESS) {
 		if (is_playing && !player->is_active()) {
-			TreeItem *tl=last_sample_playing->cast_to<TreeItem>();
+			TreeItem *tl=Object::cast_to<TreeItem>(last_sample_playing);
 			tl->set_button(0,0,get_icon("Play","EditorIcons"));
 			is_playing = false;
 			set_process(false);
@@ -109,7 +109,7 @@ void SampleLibraryEditor::_load_pressed() {
 
 void SampleLibraryEditor::_button_pressed(Object *p_item,int p_column, int p_id) {
 
-	TreeItem *ti=p_item->cast_to<TreeItem>();
+	TreeItem *ti=Object::cast_to<TreeItem>(p_item);
 	String name = ti->get_text(0);
 
 	if (p_column==0) { // Play/Stop
@@ -124,7 +124,7 @@ void SampleLibraryEditor::_button_pressed(Object *p_item,int p_column, int p_id)
 		} else {
 			player->stop_all();
 			if(last_sample_playing != p_item){
-				TreeItem *tl=last_sample_playing->cast_to<TreeItem>();
+				TreeItem *tl=Object::cast_to<TreeItem>(last_sample_playing);
 				tl->set_button(p_column,0,get_icon("Play","EditorIcons"));
 				btn_type = TTR("Stop");
 				player->play(name,true);
@@ -491,7 +491,7 @@ SampleLibraryEditor::SampleLibraryEditor() {
 void SampleLibraryEditorPlugin::edit(Object *p_object) {
 
 	sample_library_editor->set_undo_redo(&get_undo_redo());
-	SampleLibrary * s = p_object->cast_to<SampleLibrary>();
+	SampleLibrary * s = Object::cast_to<SampleLibrary>(p_object);
 	if (!s)
 		return;
 

--- a/editor/plugins/sample_player_editor_plugin.cpp
+++ b/editor/plugins/sample_player_editor_plugin.cpp
@@ -152,7 +152,7 @@ SamplePlayerEditor::SamplePlayerEditor() {
 
 void SamplePlayerEditorPlugin::edit(Object *p_object) {
 
-	sample_player_editor->edit(p_object->cast_to<Node>());
+	sample_player_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool SamplePlayerEditorPlugin::handles(Object *p_object) const {

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -256,7 +256,7 @@ ScriptEditor *ScriptEditor::script_editor = NULL;
 
 String ScriptEditor::_get_debug_tooltip(const String &p_text, Node *_se) {
 
-	//ScriptEditorBase *se=_se->cast_to<ScriptEditorBase>();
+	//ScriptEditorBase *se=Object::cast_to<ScriptEditorBase>(_se);
 
 	String val = debugger->get_var_value(p_text);
 	if (val != String()) {
@@ -280,7 +280,7 @@ void ScriptEditor::_breaked(bool p_breaked, bool p_can_debug) {
 
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
 
-		ScriptEditorBase *se = tab_container->get_child(i)->cast_to<ScriptEditorBase>();
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
 		if (!se) {
 
 			continue;
@@ -305,7 +305,7 @@ void ScriptEditor::_goto_script_line2(int p_line) {
 	if (selected < 0 || selected >= tab_container->get_child_count())
 		return;
 
-	ScriptEditorBase *current = tab_container->get_child(selected)->cast_to<ScriptEditorBase>();
+	ScriptEditorBase *current = Object::cast_to<ScriptEditorBase>(tab_container->get_child(selected));
 	if (!current)
 		return;
 
@@ -318,7 +318,7 @@ void ScriptEditor::_goto_script_line(REF p_script, int p_line) {
 
 	if (bool(EditorSettings::get_singleton()->get("text_editor/external/use_external_editor"))) {
 
-		Ref<Script> script = p_script->cast_to<Script>();
+		Ref<Script> script = Object::cast_to<Script>(*p_script);
 		if (!script.is_null() && script->get_path().is_resource_file())
 			edit(p_script, p_line, 0);
 	}
@@ -327,7 +327,7 @@ void ScriptEditor::_goto_script_line(REF p_script, int p_line) {
 	if (selected < 0 || selected >= tab_container->get_child_count())
 		return;
 
-	ScriptEditorBase *current = tab_container->get_child(selected)->cast_to<ScriptEditorBase>();
+	ScriptEditorBase *current = Object::cast_to<ScriptEditorBase>(tab_container->get_child(selected));
 	if (!current)
 		return;
 
@@ -346,13 +346,13 @@ void ScriptEditor::_save_history() {
 
 		Node *n = tab_container->get_current_tab_control();
 
-		if (n->cast_to<ScriptEditorBase>()) {
+		if (Object::cast_to<ScriptEditorBase>(n)) {
 
-			history[history_pos].state = n->cast_to<ScriptEditorBase>()->get_edit_state();
+			history[history_pos].state = Object::cast_to<ScriptEditorBase>(n)->get_edit_state();
 		}
-		if (n->cast_to<EditorHelp>()) {
+		if (Object::cast_to<EditorHelp>(n)) {
 
-			history[history_pos].state = n->cast_to<EditorHelp>()->get_scroll();
+			history[history_pos].state = Object::cast_to<EditorHelp>(n)->get_scroll();
 		}
 	}
 
@@ -369,10 +369,7 @@ void ScriptEditor::_save_history() {
 
 void ScriptEditor::_go_to_tab(int p_idx) {
 
-	Node *cn = tab_container->get_child(p_idx);
-	if (!cn)
-		return;
-	Control *c = cn->cast_to<Control>();
+	Control *c = Object::cast_to<Control>(tab_container->get_child(p_idx));
 	if (!c)
 		return;
 
@@ -380,13 +377,13 @@ void ScriptEditor::_go_to_tab(int p_idx) {
 
 		Node *n = tab_container->get_current_tab_control();
 
-		if (n->cast_to<ScriptEditorBase>()) {
+		if (Object::cast_to<ScriptEditorBase>(n)) {
 
-			history[history_pos].state = n->cast_to<ScriptEditorBase>()->get_edit_state();
+			history[history_pos].state = Object::cast_to<ScriptEditorBase>(n)->get_edit_state();
 		}
-		if (n->cast_to<EditorHelp>()) {
+		if (Object::cast_to<EditorHelp>(n)) {
 
-			history[history_pos].state = n->cast_to<EditorHelp>()->get_scroll();
+			history[history_pos].state = Object::cast_to<EditorHelp>(n)->get_scroll();
 		}
 	}
 
@@ -402,21 +399,21 @@ void ScriptEditor::_go_to_tab(int p_idx) {
 
 	c = tab_container->get_current_tab_control();
 
-	if (c->cast_to<ScriptEditorBase>()) {
+	if (Object::cast_to<ScriptEditorBase>(c)) {
 
-		script_name_label->set_text(c->cast_to<ScriptEditorBase>()->get_name());
-		script_icon->set_texture(c->cast_to<ScriptEditorBase>()->get_icon());
+		script_name_label->set_text(Object::cast_to<ScriptEditorBase>(c)->get_name());
+		script_icon->set_texture(Object::cast_to<ScriptEditorBase>(c)->get_icon());
 		if (is_visible_in_tree())
-			c->cast_to<ScriptEditorBase>()->ensure_focus();
+			Object::cast_to<ScriptEditorBase>(c)->ensure_focus();
 
-		notify_script_changed(c->cast_to<ScriptEditorBase>()->get_edited_script());
+		notify_script_changed(Object::cast_to<ScriptEditorBase>(c)->get_edited_script());
 	}
-	if (c->cast_to<EditorHelp>()) {
+	if (Object::cast_to<EditorHelp>(c)) {
 
-		script_name_label->set_text(c->cast_to<EditorHelp>()->get_class());
+		script_name_label->set_text(Object::cast_to<EditorHelp>(c)->get_class());
 		script_icon->set_texture(get_icon("Help", "EditorIcons"));
 		if (is_visible_in_tree())
-			c->cast_to<EditorHelp>()->set_focused();
+			Object::cast_to<EditorHelp>(c)->set_focused();
 	}
 
 	c->set_meta("__editor_pass", ++edit_pass);
@@ -508,7 +505,7 @@ void ScriptEditor::_close_tab(int p_idx, bool p_save) {
 		return;
 
 	Node *tselected = tab_container->get_child(selected);
-	ScriptEditorBase *current = tab_container->get_child(selected)->cast_to<ScriptEditorBase>();
+	ScriptEditorBase *current = Object::cast_to<ScriptEditorBase>(tab_container->get_child(selected));
 	if (current) {
 		_add_recent_script(current->get_edited_script()->get_path());
 		if (p_save) {
@@ -517,7 +514,7 @@ void ScriptEditor::_close_tab(int p_idx, bool p_save) {
 		current->clear_edit_menu();
 		notify_script_close(current->get_edited_script());
 	} else {
-		EditorHelp *help = tab_container->get_child(selected)->cast_to<EditorHelp>();
+		EditorHelp *help = Object::cast_to<EditorHelp>(tab_container->get_child(selected));
 		_add_recent_script(help->get_class());
 	}
 
@@ -575,7 +572,7 @@ void ScriptEditor::_close_docs_tab() {
 	int child_count = tab_container->get_child_count();
 	for (int i = child_count - 1; i >= 0; i--) {
 
-		EditorHelp *se = tab_container->get_child(i)->cast_to<EditorHelp>();
+		EditorHelp *se = Object::cast_to<EditorHelp>(tab_container->get_child(i));
 
 		if (se) {
 			_close_tab(i);
@@ -589,7 +586,7 @@ void ScriptEditor::_close_all_tabs() {
 	for (int i = child_count - 1; i >= 0; i--) {
 
 		tab_container->set_current_tab(i);
-		ScriptEditorBase *se = tab_container->get_child(i)->cast_to<ScriptEditorBase>();
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
 
 		if (se) {
 
@@ -615,7 +612,7 @@ void ScriptEditor::_resave_scripts(const String &p_str) {
 
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
 
-		ScriptEditorBase *se = tab_container->get_child(i)->cast_to<ScriptEditorBase>();
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
 		if (!se)
 			continue;
 
@@ -647,7 +644,7 @@ void ScriptEditor::_reload_scripts() {
 
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
 
-		ScriptEditorBase *se = tab_container->get_child(i)->cast_to<ScriptEditorBase>();
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
 		if (!se) {
 
 			continue;
@@ -684,7 +681,7 @@ void ScriptEditor::_res_saved_callback(const Ref<Resource> &p_res) {
 
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
 
-		ScriptEditorBase *se = tab_container->get_child(i)->cast_to<ScriptEditorBase>();
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
 		if (!se) {
 
 			continue;
@@ -727,7 +724,7 @@ bool ScriptEditor::_test_script_times_on_disk(Ref<Script> p_for_script) {
 
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
 
-		ScriptEditorBase *se = tab_container->get_child(i)->cast_to<ScriptEditorBase>();
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
 		if (se) {
 
 			Ref<Script> script = se->get_edited_script();
@@ -791,7 +788,7 @@ Ref<Script> ScriptEditor::_get_current_script() {
 	if (selected < 0 || selected >= tab_container->get_child_count())
 		return NULL;
 
-	ScriptEditorBase *current = tab_container->get_child(selected)->cast_to<ScriptEditorBase>();
+	ScriptEditorBase *current = Object::cast_to<ScriptEditorBase>(tab_container->get_child(selected));
 	if (current) {
 		return current->get_edited_script();
 	} else {
@@ -865,7 +862,7 @@ void ScriptEditor::_menu_option(int p_option) {
 			String current;
 
 			if (tab_container->get_tab_count() > 0) {
-				EditorHelp *eh = tab_container->get_child(tab_container->get_current_tab())->cast_to<EditorHelp>();
+				EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_child(tab_container->get_current_tab()));
 				if (eh) {
 					current = eh->get_class();
 				}
@@ -919,7 +916,7 @@ void ScriptEditor::_menu_option(int p_option) {
 	if (selected < 0 || selected >= tab_container->get_child_count())
 		return;
 
-	ScriptEditorBase *current = tab_container->get_child(selected)->cast_to<ScriptEditorBase>();
+	ScriptEditorBase *current = Object::cast_to<ScriptEditorBase>(tab_container->get_child(selected));
 	if (current) {
 
 		switch (p_option) {
@@ -956,7 +953,7 @@ void ScriptEditor::_menu_option(int p_option) {
 						current->convert_indent_to_tabs();
 					}
 				}
-				editor->push_item(current->get_edited_script()->cast_to<Object>());
+				editor->push_item(Object::cast_to<Object>(current->get_edited_script().ptr()));
 				editor->save_resource_as(current->get_edited_script());
 
 			} break;
@@ -1035,7 +1032,7 @@ void ScriptEditor::_menu_option(int p_option) {
 		}
 	} else {
 
-		EditorHelp *help = tab_container->get_current_tab_control()->cast_to<EditorHelp>();
+		EditorHelp *help = Object::cast_to<EditorHelp>(tab_container->get_current_tab_control());
 		if (help) {
 
 			switch (p_option) {
@@ -1139,7 +1136,7 @@ bool ScriptEditor::can_take_away_focus() const {
 	if (selected < 0 || selected >= tab_container->get_child_count())
 		return true;
 
-	ScriptEditorBase *current = tab_container->get_child(selected)->cast_to<ScriptEditorBase>();
+	ScriptEditorBase *current = Object::cast_to<ScriptEditorBase>(tab_container->get_child(selected));
 	if (!current)
 		return true;
 
@@ -1150,7 +1147,7 @@ void ScriptEditor::close_builtin_scripts_from_scene(const String &p_scene) {
 
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
 
-		ScriptEditorBase *se = tab_container->get_child(i)->cast_to<ScriptEditorBase>();
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
 
 		if (se) {
 
@@ -1205,7 +1202,7 @@ Dictionary ScriptEditor::get_state() const {
 
 	for(int i=0;i<tab_container->get_child_count();i++) {
 
-		ScriptTextEditor *se = tab_container->get_child(i)->cast_to<ScriptTextEditor>();
+		ScriptTextEditor *se = Object::cast_to<ScriptTextEditor>(tab_container->get_child(i));
 		if (!se)
 			continue;
 
@@ -1281,7 +1278,7 @@ void ScriptEditor::clear() {
 	List<ScriptTextEditor*> stes;
 	for(int i=0;i<tab_container->get_child_count();i++) {
 
-		ScriptTextEditor *se = tab_container->get_child(i)->cast_to<ScriptTextEditor>();
+		ScriptTextEditor *se = Object::cast_to<ScriptTextEditor>(tab_container->get_child(i));
 		if (!se)
 			continue;
 		stes.push_back(se);
@@ -1309,7 +1306,7 @@ void ScriptEditor::get_breakpoints(List<String> *p_breakpoints) {
 
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
 
-		ScriptEditorBase *se = tab_container->get_child(i)->cast_to<ScriptEditorBase>();
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
 		if (!se)
 			continue;
 
@@ -1335,10 +1332,8 @@ void ScriptEditor::ensure_focus_current() {
 	if (cidx < 0 || cidx >= tab_container->get_tab_count())
 		return;
 
-	Control *c = tab_container->get_child(cidx)->cast_to<Control>();
-	if (!c)
-		return;
-	ScriptEditorBase *se = c->cast_to<ScriptEditorBase>();
+	Control *c = Object::cast_to<Control>(tab_container->get_child(cidx));
+	ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(c);
 	if (!se)
 		return;
 	se->ensure_focus();
@@ -1346,7 +1341,7 @@ void ScriptEditor::ensure_focus_current() {
 
 void ScriptEditor::_members_overview_selected(int p_idx) {
 	Node *current = tab_container->get_child(tab_container->get_current_tab());
-	ScriptEditorBase *se = current->cast_to<ScriptEditorBase>();
+	ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(current);
 	if (!se) {
 		return;
 	}
@@ -1368,7 +1363,7 @@ void ScriptEditor::ensure_select_current() {
 
 		Node *current = tab_container->get_child(tab_container->get_current_tab());
 
-		ScriptEditorBase *se = current->cast_to<ScriptEditorBase>();
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(current);
 		if (se) {
 
 			Ref<Script> script = se->get_edited_script();
@@ -1380,7 +1375,7 @@ void ScriptEditor::ensure_select_current() {
 			//search_menu->show();
 		}
 
-		EditorHelp *eh = current->cast_to<EditorHelp>();
+		EditorHelp *eh = Object::cast_to<EditorHelp>(current);
 
 		if (eh) {
 			//edit_menu->hide();
@@ -1430,7 +1425,7 @@ void ScriptEditor::_update_members_overview_visibility() {
 		return;
 
 	Node *current = tab_container->get_child(tab_container->get_current_tab());
-	ScriptEditorBase *se = current->cast_to<ScriptEditorBase>();
+	ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(current);
 	if (!se) {
 		members_overview->set_visible(false);
 		return;
@@ -1451,7 +1446,7 @@ void ScriptEditor::_update_members_overview() {
 		return;
 
 	Node *current = tab_container->get_child(tab_container->get_current_tab());
-	ScriptEditorBase *se = current->cast_to<ScriptEditorBase>();
+	ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(current);
 	if (!se) {
 		return;
 	}
@@ -1525,7 +1520,7 @@ void ScriptEditor::_update_script_names() {
 
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
 
-		ScriptEditorBase *se = tab_container->get_child(i)->cast_to<ScriptEditorBase>();
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
 		if (se) {
 
 			String name = se->get_name();
@@ -1568,7 +1563,7 @@ void ScriptEditor::_update_script_names() {
 			sedata.push_back(sd);
 		}
 
-		EditorHelp *eh = tab_container->get_child(i)->cast_to<EditorHelp>();
+		EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_child(i));
 		if (eh) {
 
 			String name = eh->get_class();
@@ -1663,7 +1658,7 @@ bool ScriptEditor::edit(const Ref<Script> &p_script, int p_line, int p_col, bool
 
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
 
-		ScriptEditorBase *se = tab_container->get_child(i)->cast_to<ScriptEditorBase>();
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
 		if (!se)
 			continue;
 
@@ -1733,7 +1728,7 @@ void ScriptEditor::save_all_scripts() {
 
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
 
-		ScriptEditorBase *se = tab_container->get_child(i)->cast_to<ScriptEditorBase>();
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
 		if (!se)
 			continue;
 
@@ -1771,7 +1766,7 @@ void ScriptEditor::apply_scripts() const {
 
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
 
-		ScriptEditorBase *se = tab_container->get_child(i)->cast_to<ScriptEditorBase>();
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
 		if (!se)
 			continue;
 		se->apply_code();
@@ -1802,7 +1797,7 @@ void ScriptEditor::_editor_stop() {
 
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
 
-		ScriptEditorBase *se = tab_container->get_child(i)->cast_to<ScriptEditorBase>();
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
 		if (!se) {
 
 			continue;
@@ -1823,7 +1818,7 @@ void ScriptEditor::_add_callback(Object *p_obj, const String &p_function, const 
 
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
 
-		ScriptEditorBase *se = tab_container->get_child(i)->cast_to<ScriptEditorBase>();
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
 		if (!se)
 			continue;
 		if (se->get_edited_script() != script)
@@ -1874,7 +1869,7 @@ void ScriptEditor::_editor_settings_changed() {
 
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
 
-		ScriptEditorBase *se = tab_container->get_child(i)->cast_to<ScriptEditorBase>();
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
 		if (!se)
 			continue;
 
@@ -1977,7 +1972,7 @@ void ScriptEditor::get_window_layout(Ref<ConfigFile> p_layout) {
 
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
 
-		ScriptEditorBase *se = tab_container->get_child(i)->cast_to<ScriptEditorBase>();
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
 		if (se) {
 
 			String path = se->get_edited_script()->get_path();
@@ -1987,7 +1982,7 @@ void ScriptEditor::get_window_layout(Ref<ConfigFile> p_layout) {
 			scripts.push_back(path);
 		}
 
-		EditorHelp *eh = tab_container->get_child(i)->cast_to<EditorHelp>();
+		EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_child(i));
 
 		if (eh) {
 
@@ -2007,7 +2002,7 @@ void ScriptEditor::_help_class_open(const String &p_class) {
 
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
 
-		EditorHelp *eh = tab_container->get_child(i)->cast_to<EditorHelp>();
+		EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_child(i));
 
 		if (eh && eh->get_class() == p_class) {
 
@@ -2034,7 +2029,7 @@ void ScriptEditor::_help_class_goto(const String &p_desc) {
 
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
 
-		EditorHelp *eh = tab_container->get_child(i)->cast_to<EditorHelp>();
+		EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_child(i));
 
 		if (eh && eh->get_class() == cname) {
 
@@ -2062,7 +2057,7 @@ void ScriptEditor::_update_selected_editor_menu() {
 
 		bool current = tab_container->get_current_tab() == i;
 
-		ScriptEditorBase *se = tab_container->get_child(i)->cast_to<ScriptEditorBase>();
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
 		if (se && se->get_edit_menu()) {
 
 			if (current)
@@ -2072,10 +2067,7 @@ void ScriptEditor::_update_selected_editor_menu() {
 		}
 	}
 
-	EditorHelp *eh = NULL;
-	if (tab_container->get_current_tab_control())
-		eh = tab_container->get_current_tab_control()->cast_to<EditorHelp>();
-
+	EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_current_tab_control());
 	if (eh) {
 		script_search_menu->show();
 	} else {
@@ -2087,13 +2079,13 @@ void ScriptEditor::_update_history_pos(int p_new_pos) {
 
 	Node *n = tab_container->get_current_tab_control();
 
-	if (n->cast_to<ScriptEditorBase>()) {
+	if (Object::cast_to<ScriptEditorBase>(n)) {
 
-		history[history_pos].state = n->cast_to<ScriptEditorBase>()->get_edit_state();
+		history[history_pos].state = Object::cast_to<ScriptEditorBase>(n)->get_edit_state();
 	}
-	if (n->cast_to<EditorHelp>()) {
+	if (Object::cast_to<EditorHelp>(n)) {
 
-		history[history_pos].state = n->cast_to<EditorHelp>()->get_scroll();
+		history[history_pos].state = Object::cast_to<EditorHelp>(n)->get_scroll();
 	}
 
 	history_pos = p_new_pos;
@@ -2101,18 +2093,18 @@ void ScriptEditor::_update_history_pos(int p_new_pos) {
 
 	n = history[history_pos].control;
 
-	if (n->cast_to<ScriptEditorBase>()) {
+	if (Object::cast_to<ScriptEditorBase>(n)) {
 
-		n->cast_to<ScriptEditorBase>()->set_edit_state(history[history_pos].state);
-		n->cast_to<ScriptEditorBase>()->ensure_focus();
+		Object::cast_to<ScriptEditorBase>(n)->set_edit_state(history[history_pos].state);
+		Object::cast_to<ScriptEditorBase>(n)->ensure_focus();
 
-		notify_script_changed(n->cast_to<ScriptEditorBase>()->get_edited_script());
+		notify_script_changed(Object::cast_to<ScriptEditorBase>(n)->get_edited_script());
 	}
 
-	if (n->cast_to<EditorHelp>()) {
+	if (Object::cast_to<EditorHelp>(n)) {
 
-		n->cast_to<EditorHelp>()->set_scroll(history[history_pos].state);
-		n->cast_to<EditorHelp>()->set_focused();
+		Object::cast_to<EditorHelp>(n)->set_scroll(history[history_pos].state);
+		Object::cast_to<EditorHelp>(n)->set_focused();
 	}
 
 	n->set_meta("__editor_pass", ++edit_pass);
@@ -2140,7 +2132,7 @@ Vector<Ref<Script> > ScriptEditor::get_open_scripts() const {
 	Vector<Ref<Script> > out_scripts = Vector<Ref<Script> >();
 
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
-		ScriptEditorBase *se = tab_container->get_child(i)->cast_to<ScriptEditorBase>();
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
 		if (!se)
 			continue;
 		out_scripts.push_back(se->get_edited_script());
@@ -2510,17 +2502,17 @@ ScriptEditor::~ScriptEditor() {
 
 void ScriptEditorPlugin::edit(Object *p_object) {
 
-	if (!p_object->cast_to<Script>())
+	if (!Object::cast_to<Script>(p_object))
 		return;
 
-	script_editor->edit(p_object->cast_to<Script>());
+	script_editor->edit(Object::cast_to<Script>(p_object));
 }
 
 bool ScriptEditorPlugin::handles(Object *p_object) const {
 
-	if (p_object->cast_to<Script>()) {
+	if (Object::cast_to<Script>(p_object)) {
 
-		bool valid = _can_open_in_editor(p_object->cast_to<Script>());
+		bool valid = _can_open_in_editor(Object::cast_to<Script>(p_object));
 
 		if (!valid) { //user tried to open it by clicking
 			EditorNode::get_singleton()->show_warning(TTR("Built-in scripts can only be edited when the scene they belong to is loaded"));

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -288,7 +288,7 @@ Dictionary ShaderEditor::get_state() const {
 
 	for(int i=0;i<tab_container->get_child_count();i++) {
 
-		ShaderTextEditor *ste = tab_container->get_child(i)->cast_to<ShaderTextEditor>();
+		ShaderTextEditor *ste = tab_container->Object::cast_to<ShaderTextEditor>(get_child(i));
 		if (!ste)
 			continue;
 
@@ -397,7 +397,7 @@ void ShaderEditor::ensure_select_current() {
 	/*
 	if (tab_container->get_child_count() && tab_container->get_current_tab()>=0) {
 
-		ShaderTextEditor *ste = tab_container->get_child(tab_container->get_current_tab())->cast_to<ShaderTextEditor>();
+		ShaderTextEditor *ste = Object::cast_to<ShaderTextEditor>(tab_container->get_child(tab_container->get_current_tab()));
 		if (!ste)
 			return;
 		Ref<Shader> shader = ste->get_edited_shader();
@@ -486,16 +486,16 @@ ShaderEditor::ShaderEditor() {
 
 void ShaderEditorPlugin::edit(Object *p_object) {
 
-	Shader *s = p_object->cast_to<Shader>();
+	Shader *s = Object::cast_to<Shader>(p_object);
 	shader_editor->edit(s);
 }
 
 bool ShaderEditorPlugin::handles(Object *p_object) const {
 
 	bool handles = true;
-	Shader *shader = p_object->cast_to<Shader>();
+	Shader *shader = Object::cast_to<Shader>(p_object);
 	/*
-	if (!shader || shader->cast_to<ShaderGraph>()) // Don't handle ShaderGraph's
+	if (Object::cast_to<ShaderGraph>(shader)) // Don't handle ShaderGraph's
 		handles = false;
 	*/
 

--- a/editor/plugins/shader_graph_editor_plugin.cpp
+++ b/editor/plugins/shader_graph_editor_plugin.cpp
@@ -839,7 +839,7 @@ void ShaderGraphView::_vec_input_changed(double p_value, int p_id,Array p_arr){
 void ShaderGraphView::_xform_input_changed(int p_id, Node *p_button){
 
 
-	ToolButton *tb = p_button->cast_to<ToolButton>();
+	ToolButton *tb = Object::cast_to<ToolButton>(p_button);
 	ped_popup->set_position(tb->get_global_position()+Vector2(0,tb->get_size().height));
 	ped_popup->set_size(tb->get_size());
 	edited_id=p_id;
@@ -850,7 +850,7 @@ void ShaderGraphView::_xform_input_changed(int p_id, Node *p_button){
 }
 void ShaderGraphView::_xform_const_changed(int p_id, Node *p_button){
 
-	ToolButton *tb = p_button->cast_to<ToolButton>();
+	ToolButton *tb = Object::cast_to<ToolButton>(p_button);
 	ped_popup->set_position(tb->get_global_position()+Vector2(0,tb->get_size().height));
 	ped_popup->set_size(tb->get_size());
 	edited_id=p_id;
@@ -964,7 +964,7 @@ void ShaderGraphView::_variant_edited() {
 void ShaderGraphView::_comment_edited(int p_id,Node* p_button) {
 
 	UndoRedo *ur=EditorNode::get_singleton()->get_undo_redo();
-	TextEdit *te=p_button->cast_to<TextEdit>();
+	TextEdit *te=Object::cast_to<TextEdit>(p_button);
 	ur->create_action(TTR("Change Comment"),UndoRedo::MERGE_ENDS);
 	ur->add_do_method(graph.ptr(),"comment_node_set_text",type,p_id,te->get_text());
 	ur->add_undo_method(graph.ptr(),"comment_node_set_text",type,p_id,graph->comment_node_get_text(type,p_id));
@@ -978,7 +978,7 @@ void ShaderGraphView::_comment_edited(int p_id,Node* p_button) {
 
 void ShaderGraphView::_color_ramp_changed(int p_id,Node* p_ramp) {
 
-	GraphColorRampEdit *cr=p_ramp->cast_to<GraphColorRampEdit>();
+	GraphColorRampEdit *cr=Object::cast_to<GraphColorRampEdit>(p_ramp);
 
 	UndoRedo *ur=EditorNode::get_singleton()->get_undo_redo();
 
@@ -1020,7 +1020,7 @@ void ShaderGraphView::_color_ramp_changed(int p_id,Node* p_ramp) {
 
 void ShaderGraphView::_curve_changed(int p_id,Node* p_curve) {
 
-	GraphCurveMapEdit *cr=p_curve->cast_to<GraphCurveMapEdit>();
+	GraphCurveMapEdit *cr=Object::cast_to<GraphCurveMapEdit>(p_curve);
 
 	UndoRedo *ur=EditorNode::get_singleton()->get_undo_redo();
 
@@ -1057,7 +1057,7 @@ void ShaderGraphView::_curve_changed(int p_id,Node* p_curve) {
 
 void ShaderGraphView::_input_name_changed(const String& p_name, int p_id, Node *p_line_edit) {
 
-	LineEdit *le=p_line_edit->cast_to<LineEdit>();
+	LineEdit *le=Object::cast_to<LineEdit>(p_line_edit);
 	ERR_FAIL_COND(!le);
 
 	UndoRedo *ur=EditorNode::get_singleton()->get_undo_redo();
@@ -1074,7 +1074,7 @@ void ShaderGraphView::_input_name_changed(const String& p_name, int p_id, Node *
 
 void ShaderGraphView::_tex_edited(int p_id,Node* p_button) {
 
-	ToolButton *tb = p_button->cast_to<ToolButton>();
+	ToolButton *tb = Object::cast_to<ToolButton>(p_button);
 	ped_popup->set_position(tb->get_global_position()+Vector2(0,tb->get_size().height));
 	ped_popup->set_size(tb->get_size());
 	edited_id=p_id;
@@ -1084,7 +1084,7 @@ void ShaderGraphView::_tex_edited(int p_id,Node* p_button) {
 
 void ShaderGraphView::_cube_edited(int p_id,Node* p_button) {
 
-	ToolButton *tb = p_button->cast_to<ToolButton>();
+	ToolButton *tb = Object::cast_to<ToolButton>(p_button);
 	ped_popup->set_position(tb->get_global_position()+Vector2(0,tb->get_size().height));
 	ped_popup->set_size(tb->get_size());
 	edited_id=p_id;
@@ -1299,7 +1299,7 @@ void ShaderGraphView::_delete_nodes_request()
 
 void ShaderGraphView::_default_changed(int p_id, Node *p_button, int p_param, int v_type, String p_hint)
 {
-	ToolButton *tb = p_button->cast_to<ToolButton>();
+	ToolButton *tb = Object::cast_to<ToolButton>(p_button);
 	ped_popup->set_position(tb->get_global_position()+Vector2(0,tb->get_size().height));
 	ped_popup->set_size(tb->get_size());
 	edited_id=p_id;
@@ -2530,7 +2530,7 @@ void ShaderGraphView::_sg_updated() {
 
 Variant ShaderGraphView::get_drag_data_fw(const Point2 &p_point, Control *p_from)
 {
-	TextureRect* frame = p_from->cast_to<TextureRect>();
+	TextureRect* frame = Object::cast_to<TextureRect>(p_from);
 	if (!frame)
 		return Variant();
 
@@ -2556,7 +2556,7 @@ bool ShaderGraphView::can_drop_data_fw(const Point2 &p_point, const Variant &p_d
 
 			if (val.get_type()==Variant::OBJECT) {
 				RES res = val;
-				if (res.is_valid() && res->cast_to<Texture>())
+				if (res.is_valid() && Object::cast_to<Texture>(res))
 					return true;
 			}
 		}
@@ -2576,7 +2576,7 @@ void ShaderGraphView::drop_data_fw(const Point2 &p_point, const Variant &p_data,
 	if (!can_drop_data_fw(p_point, p_data, p_from))
 		return;
 
-	TextureRect *frame = p_from->cast_to<TextureRect>();
+	TextureRect *frame = Object::cast_to<TextureRect>(p_from);
 	if (!frame)
 		return;
 
@@ -2590,20 +2590,20 @@ void ShaderGraphView::drop_data_fw(const Point2 &p_point, const Variant &p_data,
 			if (val.get_type()==Variant::OBJECT) {
 				RES res = val;
 				if (res.is_valid())
-					tex = Ref<Texture>(res->cast_to<Texture>());
+					tex = Ref<Texture>(Object::cast_to<Texture>(*res));
 			}
 		}
 		else if (d["type"] == "files" && d.has("files")) {
 			Vector<String> files = d["files"];
 			RES res = ResourceLoader::load(files[0]);
 			if (res.is_valid())
-				tex = Ref<Texture>(res->cast_to<Texture>());
+				tex = Ref<Texture>(Object::cast_to<Texture>(*res));
 		}
 	}
 
 	if (!tex.is_valid()) return;
 
-	GraphNode *gn = frame->get_parent()->cast_to<GraphNode>();
+	GraphNode *gn = Object::cast_to<GraphNode>(frame->get_parent());
 	if (!gn) return;
 
 	int id = -1;
@@ -2896,12 +2896,12 @@ ShaderGraphEditor::ShaderGraphEditor(bool p_2d) {
 
 void ShaderGraphEditorPlugin::edit(Object *p_object) {
 
-	shader_editor->edit(p_object->cast_to<ShaderGraph>());
+	shader_editor->edit(Object::cast_to<ShaderGraph>(p_object));
 }
 
 bool ShaderGraphEditorPlugin::handles(Object *p_object) const {
 
-	ShaderGraph *shader=p_object->cast_to<ShaderGraph>();
+	ShaderGraph *shader=Object::cast_to<ShaderGraph>(p_object);
 	if (!shader)
 		return false;
 	if (_2d)

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -143,7 +143,7 @@ int SpatialEditorViewport::get_selected_count() const {
 
 	for (Map<Node *, Object *>::Element *E = selection.front(); E; E = E->next()) {
 
-		Spatial *sp = E->key()->cast_to<Spatial>();
+		Spatial *sp = Object::cast_to<Spatial>(E->key());
 		if (!sp)
 			continue;
 
@@ -218,11 +218,7 @@ void SpatialEditorViewport::_select_clicked(bool p_append, bool p_single) {
 	if (!clicked)
 		return;
 
-	Object *obj = ObjectDB::get_instance(clicked);
-	if (!obj)
-		return;
-
-	Spatial *sp = obj->cast_to<Spatial>();
+	Spatial *sp = Object::cast_to<Spatial>(ObjectDB::get_instance(clicked));
 	if (!sp)
 		return;
 
@@ -271,11 +267,7 @@ ObjectID SpatialEditorViewport::_select_ray(const Point2 &p_pos, bool p_append, 
 
 	for (int i = 0; i < instances.size(); i++) {
 
-		Object *obj = ObjectDB::get_instance(instances[i]);
-		if (!obj)
-			continue;
-
-		Spatial *spat = obj->cast_to<Spatial>();
+		Spatial *spat = Object::cast_to<Spatial>(ObjectDB::get_instance(instances[i]));
 
 		if (!spat)
 			continue;
@@ -290,7 +282,7 @@ ObjectID SpatialEditorViewport::_select_ray(const Point2 &p_pos, bool p_append, 
 			while ((subscene_candidate->get_owner() != NULL) && (subscene_candidate->get_owner() != editor->get_edited_scene()))
 				subscene_candidate = subscene_candidate->get_owner();
 
-			spat = subscene_candidate->cast_to<Spatial>();
+			spat = Object::cast_to<Spatial>(subscene_candidate);
 			if (spat && (spat->get_filename() != "") && (subscene_candidate->get_owner() != NULL)) {
 				subscenes.push_back(spat);
 				subscenes_positions.push_back(source_click_spatial_pos);
@@ -365,12 +357,7 @@ void SpatialEditorViewport::_find_items_at_pos(const Point2 &p_pos, bool &r_incl
 
 	for (int i = 0; i < instances.size(); i++) {
 
-		Object *obj = ObjectDB::get_instance(instances[i]);
-
-		if (!obj)
-			continue;
-
-		Spatial *spat = obj->cast_to<Spatial>();
+		Spatial *spat = Object::cast_to<Spatial>(ObjectDB::get_instance(instances[i]));
 
 		if (!spat)
 			continue;
@@ -480,10 +467,7 @@ void SpatialEditorViewport::_select_region() {
 
 	for (int i = 0; i < instances.size(); i++) {
 
-		Object *obj = ObjectDB::get_instance(instances[i]);
-		if (!obj)
-			continue;
-		Spatial *sp = obj->cast_to<Spatial>();
+		Spatial *sp = Object::cast_to<Spatial>(ObjectDB::get_instance(instances[i]));
 		if (!sp)
 			continue;
 
@@ -524,7 +508,7 @@ void SpatialEditorViewport::_compute_edit(const Point2 &p_point) {
 	//int nc=0;
 	for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-		Spatial *sp = E->get()->cast_to<Spatial>();
+		Spatial *sp = Object::cast_to<Spatial>(E->get());
 		if (!sp)
 			continue;
 
@@ -796,7 +780,7 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 					for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-						Spatial *sp = E->get()->cast_to<Spatial>();
+						Spatial *sp = Object::cast_to<Spatial>(E->get());
 						if (!sp)
 							continue;
 
@@ -967,22 +951,18 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 					if (clicked && gizmo_handle >= 0) {
 
-						Object *obj = ObjectDB::get_instance(clicked);
-						if (obj) {
+						Spatial *spa = Object::cast_to<Spatial>(ObjectDB::get_instance(clicked));
+						if (spa) {
 
-							Spatial *spa = obj->cast_to<Spatial>();
-							if (spa) {
+							Ref<SpatialEditorGizmo> seg = spa->get_gizmo();
+							if (seg.is_valid()) {
 
-								Ref<SpatialEditorGizmo> seg = spa->get_gizmo();
-								if (seg.is_valid()) {
-
-									_edit.gizmo = seg;
-									_edit.gizmo_handle = gizmo_handle;
-									//_edit.gizmo_initial_pos=seg->get_handle_pos(gizmo_handle);
-									_edit.gizmo_initial_value = seg->get_handle_value(gizmo_handle);
-									//print_line("GIZMO: "+itos(gizmo_handle)+" FROMPOS: "+_edit.orig_gizmo_pos);
-									break;
-								}
+								_edit.gizmo = seg;
+								_edit.gizmo_handle = gizmo_handle;
+								//_edit.gizmo_initial_pos=seg->get_handle_pos(gizmo_handle);
+								_edit.gizmo_initial_value = seg->get_handle_value(gizmo_handle);
+								//print_line("GIZMO: "+itos(gizmo_handle)+" FROMPOS: "+_edit.orig_gizmo_pos);
+								break;
 							}
 						}
 						//_compute_edit(Point2(b.x,b.y)); //in case a motion happens..
@@ -1018,7 +998,7 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 						for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-							Spatial *sp = E->get()->cast_to<Spatial>();
+							Spatial *sp = Object::cast_to<Spatial>(E->get());
 							if (!sp)
 								continue;
 
@@ -1162,7 +1142,7 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 						for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-							Spatial *sp = E->get()->cast_to<Spatial>();
+							Spatial *sp = Object::cast_to<Spatial>(E->get());
 							if (!sp)
 								continue;
 
@@ -1236,7 +1216,7 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 								Spatial *node = NULL;
 								for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-									Spatial *sp = E->get()->cast_to<Spatial>();
+									Spatial *sp = Object::cast_to<Spatial>(E->get());
 									if (!sp) {
 										continue;
 									}
@@ -1264,7 +1244,7 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 						for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-							Spatial *sp = E->get()->cast_to<Spatial>();
+							Spatial *sp = Object::cast_to<Spatial>(E->get());
 							if (!sp) {
 								continue;
 							}
@@ -1334,7 +1314,7 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 						for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-							Spatial *sp = E->get()->cast_to<Spatial>();
+							Spatial *sp = Object::cast_to<Spatial>(E->get());
 							if (!sp)
 								continue;
 
@@ -1569,7 +1549,7 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-				Spatial *sp = E->get()->cast_to<Spatial>();
+				Spatial *sp = Object::cast_to<Spatial>(E->get());
 				if (!sp)
 					continue;
 
@@ -1626,13 +1606,13 @@ void SpatialEditorViewport::_update_freelook(real_t delta) {
 	Vector3 right = camera->get_transform().basis.xform(Vector3(1, 0, 0));
 	Vector3 up = camera->get_transform().basis.xform(Vector3(0, 1, 0));
 
-	int key_left = ED_GET_SHORTCUT("spatial_editor/freelook_left")->get_shortcut()->cast_to<InputEventKey>()->get_scancode();
-	int key_right = ED_GET_SHORTCUT("spatial_editor/freelook_right")->get_shortcut()->cast_to<InputEventKey>()->get_scancode();
-	int key_forward = ED_GET_SHORTCUT("spatial_editor/freelook_forward")->get_shortcut()->cast_to<InputEventKey>()->get_scancode();
-	int key_backwards = ED_GET_SHORTCUT("spatial_editor/freelook_backwards")->get_shortcut()->cast_to<InputEventKey>()->get_scancode();
-	int key_up = ED_GET_SHORTCUT("spatial_editor/freelook_up")->get_shortcut()->cast_to<InputEventKey>()->get_scancode();
-	int key_down = ED_GET_SHORTCUT("spatial_editor/freelook_down")->get_shortcut()->cast_to<InputEventKey>()->get_scancode();
-	int key_speed_modifier = ED_GET_SHORTCUT("spatial_editor/freelook_speed_modifier")->get_shortcut()->cast_to<InputEventKey>()->get_scancode();
+	int key_left = Object::cast_to<InputEventKey>(ED_GET_SHORTCUT("spatial_editor/freelook_left")->get_shortcut().ptr())->get_scancode();
+	int key_right = Object::cast_to<InputEventKey>(ED_GET_SHORTCUT("spatial_editor/freelook_right")->get_shortcut().ptr())->get_scancode();
+	int key_forward = Object::cast_to<InputEventKey>(ED_GET_SHORTCUT("spatial_editor/freelook_forward")->get_shortcut().ptr())->get_scancode();
+	int key_backwards = Object::cast_to<InputEventKey>(ED_GET_SHORTCUT("spatial_editor/freelook_backwards")->get_shortcut().ptr())->get_scancode();
+	int key_up = Object::cast_to<InputEventKey>(ED_GET_SHORTCUT("spatial_editor/freelook_up")->get_shortcut().ptr())->get_scancode();
+	int key_down = Object::cast_to<InputEventKey>(ED_GET_SHORTCUT("spatial_editor/freelook_down")->get_shortcut().ptr())->get_scancode();
+	int key_speed_modifier = Object::cast_to<InputEventKey>(ED_GET_SHORTCUT("spatial_editor/freelook_speed_modifier")->get_shortcut().ptr())->get_scancode();
 
 	Vector3 velocity;
 	bool pressed = false;
@@ -1739,7 +1719,7 @@ void SpatialEditorViewport::_notification(int p_what) {
 
 		for (Map<Node *, Object *>::Element *E = selection.front(); E; E = E->next()) {
 
-			Spatial *sp = E->key()->cast_to<Spatial>();
+			Spatial *sp = Object::cast_to<Spatial>(E->key());
 			if (!sp)
 				continue;
 
@@ -1747,7 +1727,7 @@ void SpatialEditorViewport::_notification(int p_what) {
 			if (!se)
 				continue;
 
-			VisualInstance *vi = sp->cast_to<VisualInstance>();
+			VisualInstance *vi = Object::cast_to<VisualInstance>(sp);
 
 			if (se->aabb.has_no_surface()) {
 
@@ -2037,7 +2017,7 @@ void SpatialEditorViewport::_menu_option(int p_option) {
 			undo_redo->create_action(TTR("Align with view"));
 			for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-				Spatial *sp = E->get()->cast_to<Spatial>();
+				Spatial *sp = Object::cast_to<Spatial>(E->get());
 				if (!sp)
 					continue;
 
@@ -2327,8 +2307,8 @@ void SpatialEditorViewport::set_state(const Dictionary &p_state) {
 
 	if (p_state.has("previewing")) {
 		Node *pv = EditorNode::get_singleton()->get_edited_scene()->get_node(p_state["previewing"]);
-		if (pv && pv->cast_to<Camera>()) {
-			previewing = pv->cast_to<Camera>();
+		if (Object::cast_to<Camera>(pv)) {
+			previewing = Object::cast_to<Camera>(pv);
 			previewing->connect("tree_exited", this, "_preview_exited_scene");
 			VS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), previewing->get_camera()); //replace
 			view_menu->hide();
@@ -2397,7 +2377,7 @@ void SpatialEditorViewport::focus_selection() {
 
 	for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-		Spatial *sp = E->get()->cast_to<Spatial>();
+		Spatial *sp = Object::cast_to<Spatial>(E->get());
 		if (!sp)
 			continue;
 
@@ -2693,7 +2673,7 @@ void SpatialEditorViewportContainer::_notification(int p_what) {
 		SpatialEditorViewport *viewports[4];
 		int vc = 0;
 		for (int i = 0; i < get_child_count(); i++) {
-			viewports[vc] = get_child(i)->cast_to<SpatialEditorViewport>();
+			viewports[vc] = Object::cast_to<SpatialEditorViewport>(get_child(i));
 			if (viewports[vc]) {
 				vc++;
 			}
@@ -2864,7 +2844,7 @@ void SpatialEditor::update_transform_gizmo() {
 
 	for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-		Spatial *sp = E->get()->cast_to<Spatial>();
+		Spatial *sp = Object::cast_to<Spatial>(E->get());
 		if (!sp)
 			continue;
 
@@ -2899,7 +2879,7 @@ void SpatialEditor::update_transform_gizmo() {
 
 Object *SpatialEditor::_get_editor_data(Object *p_what) {
 
-	Spatial *sp = p_what->cast_to<Spatial>();
+	Spatial *sp = Object::cast_to<Spatial>(p_what);
 	if (!sp)
 		return NULL;
 
@@ -3139,7 +3119,7 @@ void SpatialEditor::_xform_dialog_action() {
 
 	for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 
-		Spatial *sp = E->get()->cast_to<Spatial>();
+		Spatial *sp = Object::cast_to<Spatial>(E->get());
 		if (!sp)
 			continue;
 
@@ -3562,7 +3542,7 @@ void SpatialEditor::_init_indicators() {
 
 	_generate_selection_box();
 
-	//get_scene()->get_root_node()->cast_to<EditorNode>()->get_scene_root()->add_child(camera);
+	//Object::cast_to<EditorNode>(get_scene()->get_root_node())->get_scene_root()->add_child(camera);
 
 	//current_camera=camera;
 }
@@ -3694,7 +3674,7 @@ HSplitContainer *SpatialEditor::get_palette_split() {
 
 void SpatialEditor::_request_gizmo(Object *p_obj) {
 
-	Spatial *sp = p_obj->cast_to<Spatial>();
+	Spatial *sp = Object::cast_to<Spatial>(p_obj);
 	if (!sp)
 		return;
 	if (editor->get_edited_scene() && (sp == editor->get_edited_scene() || sp->get_owner() == editor->get_edited_scene() || editor->get_edited_scene()->is_editable_instance(sp->get_owner()))) {
@@ -3725,7 +3705,7 @@ void SpatialEditor::_request_gizmo(Object *p_obj) {
 
 void SpatialEditor::_toggle_maximize_view(Object *p_viewport) {
 	if (!p_viewport) return;
-	SpatialEditorViewport *current_viewport = p_viewport->cast_to<SpatialEditorViewport>();
+	SpatialEditorViewport *current_viewport = Object::cast_to<SpatialEditorViewport>(p_viewport);
 	if (!current_viewport) return;
 
 	int index = -1;
@@ -4122,7 +4102,7 @@ void SpatialEditorPlugin::make_visible(bool p_visible) {
 }
 void SpatialEditorPlugin::edit(Object *p_object) {
 
-	spatial_editor->edit(p_object->cast_to<Spatial>());
+	spatial_editor->edit(Object::cast_to<Spatial>(p_object));
 }
 
 bool SpatialEditorPlugin::handles(Object *p_object) const {

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -334,14 +334,14 @@ static void _find_anim_sprites(Node *p_node, List<Node *> *r_nodes, Ref<SpriteFr
 		return;
 
 	{
-		AnimatedSprite *as = p_node->cast_to<AnimatedSprite>();
+		AnimatedSprite *as = Object::cast_to<AnimatedSprite>(p_node);
 		if (as && as->get_sprite_frames() == p_sfames) {
 			r_nodes->push_back(p_node);
 		}
 	}
 
 	{
-		AnimatedSprite3D *as = p_node->cast_to<AnimatedSprite3D>();
+		AnimatedSprite3D *as = Object::cast_to<AnimatedSprite3D>(p_node);
 		if (as && as->get_sprite_frames() == p_sfames) {
 			r_nodes->push_back(p_node);
 		}
@@ -842,7 +842,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 void SpriteFramesEditorPlugin::edit(Object *p_object) {
 
 	frames_editor->set_undo_redo(&get_undo_redo());
-	SpriteFrames *s = p_object->cast_to<SpriteFrames>();
+	SpriteFrames *s = Object::cast_to<SpriteFrames>(p_object);
 	if (!s)
 		return;
 

--- a/editor/plugins/stream_editor_plugin.cpp
+++ b/editor/plugins/stream_editor_plugin.cpp
@@ -100,7 +100,7 @@ StreamEditor::StreamEditor() {
 
 void StreamEditorPlugin::edit(Object *p_object) {
 
-	stream_editor->edit(p_object->cast_to<Node>());
+	stream_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool StreamEditorPlugin::handles(Object *p_object) const {

--- a/editor/plugins/style_box_editor_plugin.cpp
+++ b/editor/plugins/style_box_editor_plugin.cpp
@@ -72,8 +72,8 @@ StyleBoxEditor::StyleBoxEditor() {
 
 void StyleBoxEditorPlugin::edit(Object *p_node) {
 
-	if (p_node && p_node->cast_to<StyleBox>()) {
-		stylebox_editor->edit(p_node->cast_to<StyleBox>());
+	if (Object::cast_to<StyleBox>(p_node)) {
+		stylebox_editor->edit(Object::cast_to<StyleBox>(p_node));
 		stylebox_editor->show();
 	} else
 		stylebox_editor->hide();

--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -70,7 +70,7 @@ void TextureEditor::_notification(int p_what) {
 		int ofs_x = (size.width - tex_width) / 2;
 		int ofs_y = (size.height - tex_height) / 2;
 
-		if (texture->cast_to<CurveTexture>()) {
+		if (Object::cast_to<CurveTexture>(*texture)) {
 			// In the case of CurveTextures we know they are 1 in height, so fill the preview to see the gradient
 			ofs_y = 0;
 			tex_height = size.height;
@@ -81,10 +81,10 @@ void TextureEditor::_notification(int p_what) {
 		Ref<Font> font = get_font("font", "Label");
 
 		String format;
-		if (texture->cast_to<ImageTexture>()) {
-			format = Image::get_format_name(texture->cast_to<ImageTexture>()->get_format());
-		} else if (texture->cast_to<StreamTexture>()) {
-			format = Image::get_format_name(texture->cast_to<StreamTexture>()->get_format());
+		if (Object::cast_to<ImageTexture>(*texture)) {
+			format = Image::get_format_name(Object::cast_to<ImageTexture>(*texture)->get_format());
+		} else if (Object::cast_to<StreamTexture>(*texture)) {
+			format = Image::get_format_name(Object::cast_to<StreamTexture>(*texture)->get_format());
 		} else {
 			format = texture->get_class();
 		}
@@ -136,7 +136,7 @@ TextureEditor::TextureEditor() {
 
 void TextureEditorPlugin::edit(Object *p_object) {
 
-	Texture *s = p_object->cast_to<Texture>();
+	Texture *s = Object::cast_to<Texture>(p_object);
 	if (!s)
 		return;
 

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -626,12 +626,12 @@ void TextureRegionEditor::edit(Object *p_obj) {
 	if (atlas_tex.is_valid())
 		atlas_tex->remove_change_receptor(this);
 	if (p_obj) {
-		node_sprite = p_obj->cast_to<Sprite>();
-		node_patch9 = p_obj->cast_to<NinePatchRect>();
-		if (p_obj->cast_to<StyleBoxTexture>())
-			obj_styleBox = Ref<StyleBoxTexture>(p_obj->cast_to<StyleBoxTexture>());
-		if (p_obj->cast_to<AtlasTexture>())
-			atlas_tex = Ref<AtlasTexture>(p_obj->cast_to<AtlasTexture>());
+		node_sprite = Object::cast_to<Sprite>(p_obj);
+		node_patch9 = Object::cast_to<NinePatchRect>(p_obj);
+		if (Object::cast_to<StyleBoxTexture>(p_obj))
+			obj_styleBox = Ref<StyleBoxTexture>(Object::cast_to<StyleBoxTexture>(p_obj));
+		if (Object::cast_to<AtlasTexture>(p_obj))
+			atlas_tex = Ref<AtlasTexture>(Object::cast_to<AtlasTexture>(p_obj));
 		p_obj->add_change_receptor(this);
 		_edit_region();
 	} else {

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -44,7 +44,7 @@ void ThemeEditor::_propagate_redraw(Control *p_at) {
 	p_at->minimum_size_changed();
 	p_at->update();
 	for (int i = 0; i < p_at->get_child_count(); i++) {
-		Control *a = p_at->get_child(i)->cast_to<Control>();
+		Control *a = Object::cast_to<Control>(p_at->get_child(i));
 		if (a)
 			_propagate_redraw(a);
 	}
@@ -892,9 +892,9 @@ ThemeEditor::ThemeEditor() {
 
 void ThemeEditorPlugin::edit(Object *p_node) {
 
-	if (p_node && p_node->cast_to<Theme>()) {
+	if (Object::cast_to<Theme>(p_node)) {
 		theme_editor->show();
-		theme_editor->edit(p_node->cast_to<Theme>());
+		theme_editor->edit(Object::cast_to<Theme>(p_node));
 	} else {
 		theme_editor->edit(Ref<Theme>());
 		theme_editor->hide();

--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -1329,7 +1329,7 @@ void TileMapEditor::edit(Node *p_tile_map) {
 		node->disconnect("settings_changed", this, "_tileset_settings_changed");
 	if (p_tile_map) {
 
-		node = p_tile_map->cast_to<TileMap>();
+		node = Object::cast_to<TileMap>(p_tile_map);
 		if (!canvas_item_editor->is_connected("draw", this, "_canvas_draw"))
 			canvas_item_editor->connect("draw", this, "_canvas_draw");
 		if (!canvas_item_editor->is_connected("mouse_entered", this, "_canvas_mouse_enter"))
@@ -1407,7 +1407,7 @@ TileMapEditor::CellOp TileMapEditor::_get_op_from_cell(const Point2i &p_pos) {
 
 void TileMapEditor::_update_transform_buttons(Object *p_button) {
 	//ERR_FAIL_NULL(p_button);
-	ToolButton *b = p_button->cast_to<ToolButton>();
+	ToolButton *b = Object::cast_to<ToolButton>(p_button);
 	//ERR_FAIL_COND(!b);
 
 	if (b == rotate_0) {
@@ -1582,7 +1582,7 @@ TileMapEditor::~TileMapEditor() {
 
 void TileMapEditorPlugin::edit(Object *p_object) {
 
-	tile_map_editor->edit(p_object->cast_to<Node>());
+	tile_map_editor->edit(Object::cast_to<Node>(p_object));
 }
 
 bool TileMapEditorPlugin::handles(Object *p_object) const {

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -43,7 +43,7 @@ void TileSetEditor::_import_node(Node *p_node, Ref<TileSet> p_library) {
 
 		Node *child = p_node->get_child(i);
 
-		if (!child->cast_to<Sprite>()) {
+		if (!Object::cast_to<Sprite>(child)) {
 			if (child->get_child_count() > 0) {
 				_import_node(child, p_library);
 			}
@@ -51,7 +51,7 @@ void TileSetEditor::_import_node(Node *p_node, Ref<TileSet> p_library) {
 			continue;
 		}
 
-		Sprite *mi = child->cast_to<Sprite>();
+		Sprite *mi = Object::cast_to<Sprite>(child);
 		Ref<Texture> texture = mi->get_texture();
 		Ref<Texture> normal_map = mi->get_normal_map();
 		Ref<ShaderMaterial> material = mi->get_material();
@@ -99,18 +99,18 @@ void TileSetEditor::_import_node(Node *p_node, Ref<TileSet> p_library) {
 
 			Node *child2 = mi->get_child(j);
 
-			if (child2->cast_to<NavigationPolygonInstance>())
-				nav_poly = child2->cast_to<NavigationPolygonInstance>()->get_navigation_polygon();
+			if (Object::cast_to<NavigationPolygonInstance>(child2))
+				nav_poly = Object::cast_to<NavigationPolygonInstance>(child2)->get_navigation_polygon();
 
-			if (child2->cast_to<LightOccluder2D>())
-				occluder = child2->cast_to<LightOccluder2D>()->get_occluder_polygon();
+			if (Object::cast_to<LightOccluder2D>(child2))
+				occluder = Object::cast_to<LightOccluder2D>(child2)->get_occluder_polygon();
 
-			if (!child2->cast_to<StaticBody2D>())
+			if (!Object::cast_to<StaticBody2D>(child2))
 				continue;
 
 			found_collisions = true;
 
-			StaticBody2D *sb = child2->cast_to<StaticBody2D>();
+			StaticBody2D *sb = Object::cast_to<StaticBody2D>(child2);
 
 			List<uint32_t> shapes;
 			sb->get_shape_owners(&shapes);
@@ -268,8 +268,8 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 
 void TileSetEditorPlugin::edit(Object *p_node) {
 
-	if (p_node && p_node->cast_to<TileSet>()) {
-		tileset_editor->edit(p_node->cast_to<TileSet>());
+	if (Object::cast_to<TileSet>(p_node)) {
+		tileset_editor->edit(Object::cast_to<TileSet>(p_node));
 		tileset_editor->show();
 	} else
 		tileset_editor->hide();

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -475,7 +475,7 @@ void ProjectManager::_notification(int p_what) {
 
 void ProjectManager::_panel_draw(Node *p_hb) {
 
-	HBoxContainer *hb = p_hb->cast_to<HBoxContainer>();
+	HBoxContainer *hb = Object::cast_to<HBoxContainer>(p_hb);
 
 	hb->draw_line(Point2(0, hb->get_size().y + 1), Point2(hb->get_size().x - 10, hb->get_size().y + 1), get_color("guide_color", "Tree"));
 
@@ -487,7 +487,7 @@ void ProjectManager::_panel_draw(Node *p_hb) {
 void ProjectManager::_update_project_buttons() {
 	for (int i = 0; i < scroll_childs->get_child_count(); i++) {
 
-		CanvasItem *item = scroll_childs->get_child(i)->cast_to<CanvasItem>();
+		CanvasItem *item = Object::cast_to<CanvasItem>(scroll_childs->get_child(i));
 		item->update();
 	}
 
@@ -509,7 +509,7 @@ void ProjectManager::_panel_input(const Ref<InputEvent> &p_ev, Node *p_hb) {
 			int clicked_id = -1;
 			int last_clicked_id = -1;
 			for (int i = 0; i < scroll_childs->get_child_count(); i++) {
-				HBoxContainer *hb = scroll_childs->get_child(i)->cast_to<HBoxContainer>();
+				HBoxContainer *hb = Object::cast_to<HBoxContainer>(scroll_childs->get_child(i));
 				if (!hb) continue;
 				if (hb->get_meta("name") == clicked) clicked_id = i;
 				if (hb->get_meta("name") == last_clicked) last_clicked_id = i;
@@ -519,7 +519,7 @@ void ProjectManager::_panel_input(const Ref<InputEvent> &p_ev, Node *p_hb) {
 				int min = clicked_id < last_clicked_id ? clicked_id : last_clicked_id;
 				int max = clicked_id > last_clicked_id ? clicked_id : last_clicked_id;
 				for (int i = 0; i < scroll_childs->get_child_count(); ++i) {
-					HBoxContainer *hb = scroll_childs->get_child(i)->cast_to<HBoxContainer>();
+					HBoxContainer *hb = Object::cast_to<HBoxContainer>(scroll_childs->get_child(i));
 					if (!hb) continue;
 					if (i != clicked_id && (i < min || i > max) && !mb->get_control()) {
 						selected_list.erase(hb->get_meta("name"));
@@ -572,7 +572,7 @@ void ProjectManager::_unhandled_input(const Ref<InputEvent> &p_ev) {
 
 				for (int i = 0; i < scroll_childs->get_child_count(); i++) {
 
-					HBoxContainer *hb = scroll_childs->get_child(i)->cast_to<HBoxContainer>();
+					HBoxContainer *hb = Object::cast_to<HBoxContainer>(scroll_childs->get_child(i));
 					if (hb) {
 						selected_list.clear();
 						selected_list.insert(hb->get_meta("name"), hb->get_meta("main_scene"));
@@ -587,7 +587,7 @@ void ProjectManager::_unhandled_input(const Ref<InputEvent> &p_ev) {
 
 				for (int i = scroll_childs->get_child_count() - 1; i >= 0; i--) {
 
-					HBoxContainer *hb = scroll_childs->get_child(i)->cast_to<HBoxContainer>();
+					HBoxContainer *hb = Object::cast_to<HBoxContainer>(scroll_childs->get_child(i));
 					if (hb) {
 						selected_list.clear();
 						selected_list.insert(hb->get_meta("name"), hb->get_meta("main_scene"));
@@ -609,7 +609,7 @@ void ProjectManager::_unhandled_input(const Ref<InputEvent> &p_ev) {
 
 					for (int i = scroll_childs->get_child_count() - 1; i >= 0; i--) {
 
-						HBoxContainer *hb = scroll_childs->get_child(i)->cast_to<HBoxContainer>();
+						HBoxContainer *hb = Object::cast_to<HBoxContainer>(scroll_childs->get_child(i));
 						if (!hb) continue;
 
 						String current = hb->get_meta("name");
@@ -646,7 +646,7 @@ void ProjectManager::_unhandled_input(const Ref<InputEvent> &p_ev) {
 
 				for (int i = 0; i < scroll_childs->get_child_count(); i++) {
 
-					HBoxContainer *hb = scroll_childs->get_child(i)->cast_to<HBoxContainer>();
+					HBoxContainer *hb = Object::cast_to<HBoxContainer>(scroll_childs->get_child(i));
 					if (!hb) continue;
 
 					String current = hb->get_meta("name");
@@ -885,8 +885,8 @@ void ProjectManager::_load_recent_projects() {
 void ProjectManager::_on_project_created(const String &dir) {
 	bool has_already = false;
 	for (int i = 0; i < scroll_childs->get_child_count(); i++) {
-		HBoxContainer *hb = scroll_childs->get_child(i)->cast_to<HBoxContainer>();
-		Label *fpath = hb->get_node(NodePath("project/path"))->cast_to<Label>();
+		HBoxContainer *hb = Object::cast_to<HBoxContainer>(scroll_childs->get_child(i));
+		Label *fpath = Object::cast_to<Label>(hb->get_node(NodePath("project/path")));
 		if (fpath->get_text() == dir) {
 			has_already = true;
 			break;
@@ -903,8 +903,8 @@ void ProjectManager::_on_project_created(const String &dir) {
 
 void ProjectManager::_update_scroll_pos(const String &dir) {
 	for (int i = 0; i < scroll_childs->get_child_count(); i++) {
-		HBoxContainer *hb = scroll_childs->get_child(i)->cast_to<HBoxContainer>();
-		Label *fpath = hb->get_node(NodePath("project/path"))->cast_to<Label>();
+		HBoxContainer *hb = Object::cast_to<HBoxContainer>(scroll_childs->get_child(i));
+		Label *fpath = Object::cast_to<Label>(hb->get_node(NodePath("project/path")));
 		if (fpath->get_text() == dir) {
 			last_clicked = hb->get_meta("name");
 			selected_list.clear();

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -505,7 +505,7 @@ void ProjectSettingsEditor::_action_activated() {
 
 void ProjectSettingsEditor::_action_button_pressed(Object *p_obj, int p_column, int p_id) {
 
-	TreeItem *ti = p_obj->cast_to<TreeItem>();
+	TreeItem *ti = Object::cast_to<TreeItem>(p_obj);
 
 	ERR_FAIL_COND(!ti);
 
@@ -1010,7 +1010,7 @@ void ProjectSettingsEditor::_translation_file_open() {
 
 void ProjectSettingsEditor::_translation_delete(Object *p_item, int p_column, int p_button) {
 
-	TreeItem *ti = p_item->cast_to<TreeItem>();
+	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 	ERR_FAIL_COND(!ti);
 
 	int idx = ti->get_metadata(0);
@@ -1151,7 +1151,7 @@ void ProjectSettingsEditor::_translation_res_delete(Object *p_item, int p_column
 
 	Dictionary remaps = ProjectSettings::get_singleton()->get("locale/translation_remaps");
 
-	TreeItem *k = p_item->cast_to<TreeItem>();
+	TreeItem *k = Object::cast_to<TreeItem>(p_item);
 
 	String key = k->get_metadata(0);
 	ERR_FAIL_COND(!remaps.has(key));
@@ -1180,7 +1180,7 @@ void ProjectSettingsEditor::_translation_res_option_delete(Object *p_item, int p
 
 	TreeItem *k = translation_remap->get_selected();
 	ERR_FAIL_COND(!k);
-	TreeItem *ed = p_item->cast_to<TreeItem>();
+	TreeItem *ed = Object::cast_to<TreeItem>(p_item);
 	ERR_FAIL_COND(!ed);
 
 	String key = k->get_metadata(0);

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -176,7 +176,7 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 
 					Object *inst = ClassDB::instance(orig_type);
 
-					Ref<Resource> res = Ref<Resource>(inst->cast_to<Resource>());
+					Ref<Resource> res = Ref<Resource>(Object::cast_to<Resource>(inst));
 
 					ERR_FAIL_COND(res.is_null());
 
@@ -215,8 +215,8 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 				} break;
 				case OBJ_MENU_NEW_SCRIPT: {
 
-					if (owner->cast_to<Node>())
-						EditorNode::get_singleton()->get_scene_tree_dock()->open_script_dialog(owner->cast_to<Node>());
+					if (Object::cast_to<Node>(owner))
+						EditorNode::get_singleton()->get_scene_tree_dock()->open_script_dialog(Object::cast_to<Node>(owner));
 
 				} break;
 				case OBJ_MENU_SHOW_IN_FILE_SYSTEM: {
@@ -243,7 +243,7 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 
 					Object *obj = ClassDB::instance(intype);
 					ERR_BREAK(!obj);
-					Resource *res = obj->cast_to<Resource>();
+					Resource *res = Object::cast_to<Resource>(obj);
 					ERR_BREAK(!res);
 					if (owner && hint == PROPERTY_HINT_RESOURCE_TYPE && hint_text == "Script") {
 						//make visual script the right type
@@ -593,8 +593,8 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 				MAKE_PROPSELECT
 
 				Object *obj = ObjectDB::get_instance(hint_text.to_int64());
-				if (obj && obj->cast_to<Script>()) {
-					property_select->select_method_from_script(obj->cast_to<Script>(), v);
+				if (Object::cast_to<Script>(obj)) {
+					property_select->select_method_from_script(Object::cast_to<Script>(obj), v);
 				}
 
 				updating = false;
@@ -641,8 +641,8 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 				MAKE_PROPSELECT
 
 				Object *obj = ObjectDB::get_instance(hint_text.to_int64());
-				if (obj && obj->cast_to<Script>()) {
-					property_select->select_property_from_script(obj->cast_to<Script>(), v);
+				if (Object::cast_to<Script>(obj)) {
+					property_select->select_property_from_script(Object::cast_to<Script>(obj), v);
 				}
 
 				updating = false;
@@ -864,7 +864,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 			names.push_back(TTR("Assign"));
 			names.push_back(TTR("Clear"));
 
-			if (owner->is_class("Node") && (v.get_type() == Variant::NODE_PATH) && owner->cast_to<Node>()->has_node(v))
+			if (owner->is_class("Node") && (v.get_type() == Variant::NODE_PATH) && Object::cast_to<Node>(owner)->has_node(v))
 				names.push_back(TTR("Select Node"));
 
 			config_action_buttons(names);
@@ -878,7 +878,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 			menu->clear();
 			menu->set_size(Size2(1, 1) * EDSCALE);
 
-			if (p_name == "script" && hint_text == "Script" && owner->cast_to<Node>()) {
+			if (p_name == "script" && hint_text == "Script" && Object::cast_to<Node>(owner)) {
 				menu->add_icon_item(get_icon("Script", "EditorIcons"), TTR("New Script"), OBJ_MENU_NEW_SCRIPT);
 				menu->add_separator();
 			} else if (hint_text != "") {
@@ -1104,7 +1104,7 @@ void CustomPropertyEditor::_type_create_selected(int p_idx) {
 
 		ERR_FAIL_COND(!obj);
 
-		Resource *res = obj->cast_to<Resource>();
+		Resource *res = Object::cast_to<Resource>(obj);
 		ERR_FAIL_COND(!res);
 
 		v = Ref<Resource>(res).get_ref_ptr();
@@ -1124,7 +1124,7 @@ void CustomPropertyEditor::_node_path_selected(NodePath p_path) {
 	if (picking_viewport) {
 
 		Node *to_node = get_node(p_path);
-		if (!to_node->cast_to<Viewport>()) {
+		if (!Object::cast_to<Viewport>(to_node)) {
 			EditorNode::get_singleton()->show_warning("Selected node is not a Viewport!");
 			return;
 		}
@@ -1154,9 +1154,9 @@ void CustomPropertyEditor::_node_path_selected(NodePath p_path) {
 		Node *node = NULL;
 
 		if (owner->is_class("Node"))
-			node = owner->cast_to<Node>();
+			node = Object::cast_to<Node>(owner);
 		else if (owner->is_class("ArrayPropertyEdit"))
-			node = owner->cast_to<ArrayPropertyEdit>()->get_node();
+			node = Object::cast_to<ArrayPropertyEdit>(owner)->get_node();
 
 		if (!node) {
 			v = p_path;
@@ -1276,9 +1276,9 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 				hide();
 			} else if (p_which == 2) {
 
-				if (owner->is_class("Node") && (v.get_type() == Variant::NODE_PATH) && owner->cast_to<Node>()->has_node(v)) {
+				if (owner->is_class("Node") && (v.get_type() == Variant::NODE_PATH) && Object::cast_to<Node>(owner)->has_node(v)) {
 
-					Node *target_node = owner->cast_to<Node>()->get_node(v);
+					Node *target_node = Object::cast_to<Node>(owner)->get_node(v);
 					EditorNode::get_singleton()->get_editor_selection()->clear();
 					EditorNode::get_singleton()->get_scene_tree_dock()->set_selected(target_node);
 				}
@@ -1299,7 +1299,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 
 					Object *obj = ClassDB::instance(intype);
 					ERR_BREAK(!obj);
-					Resource *res = obj->cast_to<Resource>();
+					Resource *res = Object::cast_to<Resource>(obj);
 					ERR_BREAK(!res);
 
 					v = Ref<Resource>(res).get_ref_ptr();
@@ -2017,7 +2017,7 @@ bool PropertyEditor::_might_be_in_instance() {
 	if (!obj)
 		return false;
 
-	Node *node = obj->cast_to<Node>();
+	Node *node = Object::cast_to<Node>(obj);
 
 	Node *edited_scene = EditorNode::get_singleton()->get_edited_scene();
 
@@ -2045,7 +2045,7 @@ bool PropertyEditor::_might_be_in_instance() {
 
 bool PropertyEditor::_get_instanced_node_original_property(const StringName &p_prop, Variant &value) {
 
-	Node *node = obj->cast_to<Node>();
+	Node *node = Object::cast_to<Node>(obj);
 
 	if (!node)
 		return false;
@@ -2100,7 +2100,7 @@ bool PropertyEditor::_get_instanced_node_original_property(const StringName &p_p
 bool PropertyEditor::_is_property_different(const Variant &p_current, const Variant &p_orig, int p_usage) {
 
 	{
-		Node *node = obj->cast_to<Node>();
+		Node *node = Object::cast_to<Node>(obj);
 		if (!node)
 			return false;
 
@@ -2888,7 +2888,7 @@ void PropertyEditor::update_tree() {
 */
 
 	/*
-	if (obj->cast_to<Node>() || obj->cast_to<Resource>()) {
+	if (Object::cast_to<Node>() || Object::cast_to<Resource>(obj)) {
 		TreeItem *type = tree->create_item(root);
 
 		type->set_text(0,"Type"); // todo, fetch name if ID exists in database
@@ -2906,9 +2906,9 @@ void PropertyEditor::update_tree() {
 
 		name->set_text(0,"Name"); // todo, fetch name if ID exists in database
 		if (obj->is_type("Resource"))
-			name->set_text(1,obj->cast_to<Resource>()->get_name());
+			name->set_text(1,Object::cast_to<Resource>(obj)->get_name());
 		else if (obj->is_type("Node"))
-			name->set_text(1,obj->cast_to<Node>()->get_name());
+			name->set_text(1,Object::cast_to<Node>(obj)->get_name());
 		name->set_selectable(0,false);
 		name->set_selectable(1,false);
 	}
@@ -2919,7 +2919,7 @@ void PropertyEditor::update_tree() {
 	bool draw_red = false;
 
 	{
-		Node *nod = obj->cast_to<Node>();
+		Node *nod = Object::cast_to<Node>(obj);
 		Node *es = EditorNode::get_singleton()->get_edited_scene();
 		if (nod && es != nod && nod->get_owner() != es) {
 			draw_red = true;
@@ -3742,7 +3742,7 @@ void PropertyEditor::update_tree() {
 
 void PropertyEditor::_draw_transparency(Object *t, const Rect2 &p_rect) {
 
-	TreeItem *ti = t->cast_to<TreeItem>();
+	TreeItem *ti = Object::cast_to<TreeItem>(t);
 	if (!ti)
 		return;
 
@@ -3763,7 +3763,7 @@ void PropertyEditor::_item_folded(Object *item_obj) {
 	if (updating_folding)
 		return;
 
-	TreeItem *item = item_obj->cast_to<TreeItem>();
+	TreeItem *item = Object::cast_to<TreeItem>(item_obj);
 
 	obj->editor_set_section_unfold(item->get_metadata(0), !item->is_collapsed());
 }
@@ -3789,7 +3789,7 @@ void PropertyEditor::_edit_set(const String &p_name, const Variant &p_value, boo
 		}
 	}
 
-	if (!undo_redo || obj->cast_to<ArrayPropertyEdit>()) { //kind of hacky
+	if (!undo_redo || Object::cast_to<ArrayPropertyEdit>(obj)) { //kind of hacky
 
 		obj->set(p_name, p_value);
 		if (p_refresh_all)
@@ -3799,9 +3799,9 @@ void PropertyEditor::_edit_set(const String &p_name, const Variant &p_value, boo
 
 		emit_signal(_prop_edited, p_name);
 
-	} else if (obj->cast_to<MultiNodeEdit>()) {
+	} else if (Object::cast_to<MultiNodeEdit>(obj)) {
 
-		obj->cast_to<MultiNodeEdit>()->set_property_field(p_name, p_value, p_changed_field);
+		Object::cast_to<MultiNodeEdit>(obj)->set_property_field(p_name, p_value, p_changed_field);
 		_changed_callbacks(obj, p_name);
 		emit_signal(_prop_edited, p_name);
 	} else {
@@ -3819,7 +3819,7 @@ void PropertyEditor::_edit_set(const String &p_name, const Variant &p_value, boo
 			undo_redo->add_undo_method(this, "_changed_callback", obj, p_name);
 		}
 
-		Resource *r = obj->cast_to<Resource>();
+		Resource *r = Object::cast_to<Resource>(obj);
 		if (r) {
 			if (!r->is_edited() && String(p_name) != "resource/edited") {
 				undo_redo->add_do_method(r, "set_edited", true);
@@ -4070,7 +4070,7 @@ void PropertyEditor::edit(Object *p_object) {
 
 void PropertyEditor::_set_range_def(Object *p_item, String prop, float p_frame) {
 
-	TreeItem *ti = p_item->cast_to<TreeItem>();
+	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 	ERR_FAIL_COND(!ti);
 
 	ti->call_deferred("set_range", 1, p_frame);
@@ -4078,7 +4078,7 @@ void PropertyEditor::_set_range_def(Object *p_item, String prop, float p_frame) 
 }
 
 void PropertyEditor::_edit_button(Object *p_item, int p_column, int p_button) {
-	TreeItem *ti = p_item->cast_to<TreeItem>();
+	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 	ERR_FAIL_COND(!ti);
 
 	Dictionary d = ti->get_metadata(0);
@@ -4216,7 +4216,7 @@ void PropertyEditor::set_keying(bool p_active) {
 
 void PropertyEditor::_draw_flags(Object *p_object, const Rect2 &p_rect) {
 
-	TreeItem *ti = p_object->cast_to<TreeItem>();
+	TreeItem *ti = Object::cast_to<TreeItem>(p_object);
 	if (!ti)
 		return;
 
@@ -4268,7 +4268,7 @@ void PropertyEditor::_resource_preview_done(const String &p_path, const Ref<Text
 	if (!obj)
 		return;
 
-	TreeItem *ti = obj->cast_to<TreeItem>();
+	TreeItem *ti = Object::cast_to<TreeItem>(obj);
 
 	ERR_FAIL_COND(!ti);
 
@@ -4374,7 +4374,7 @@ void PropertyEditor::set_use_filter(bool p_use) {
 void PropertyEditor::register_text_enter(Node *p_line_edit) {
 
 	ERR_FAIL_NULL(p_line_edit);
-	search_box = p_line_edit->cast_to<LineEdit>();
+	search_box = Object::cast_to<LineEdit>(p_line_edit);
 
 	if (search_box)
 		search_box->connect("text_changed", this, "_filter_changed");

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -98,10 +98,10 @@ void PropertySelector::_update_search() {
 		} else {
 
 			Object *obj = ObjectDB::get_instance(script);
-			if (obj && obj->cast_to<Script>()) {
+			if (Object::cast_to<Script>(obj)) {
 
 				props.push_back(PropertyInfo(Variant::NIL, "Script Variables", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_CATEGORY));
-				obj->cast_to<Script>()->get_script_property_list(&props);
+				Object::cast_to<Script>(obj)->get_script_property_list(&props);
 			}
 
 			StringName base = base_type;
@@ -200,10 +200,10 @@ void PropertySelector::_update_search() {
 		} else {
 
 			Object *obj = ObjectDB::get_instance(script);
-			if (obj && obj->cast_to<Script>()) {
+			if (Object::cast_to<Script>(obj)) {
 
 				methods.push_back(MethodInfo("*Script Methods"));
-				obj->cast_to<Script>()->get_script_method_list(&methods);
+				Object::cast_to<Script>(obj)->get_script_method_list(&methods);
 			}
 
 			StringName base = base_type;

--- a/editor/resources_dock.cpp
+++ b/editor/resources_dock.cpp
@@ -279,7 +279,7 @@ void ResourcesDock::_resource_selected() {
 
 void ResourcesDock::_delete(Object *p_item, int p_column, int p_id) {
 
-	TreeItem *ti = p_item->cast_to<TreeItem>();
+	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 	ERR_FAIL_COND(!ti);
 
 	call_deferred("remove_resource", ti->get_metadata(0));
@@ -290,7 +290,7 @@ void ResourcesDock::_create() {
 	Object *c = create_dialog->instance_selected();
 
 	ERR_FAIL_COND(!c);
-	Resource *r = c->cast_to<Resource>();
+	Resource *r = Object::cast_to<Resource>(c);
 	ERR_FAIL_COND(!r);
 
 	REF res(r);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -775,7 +775,7 @@ void SceneTreeDock::_notification(int p_what) {
 				break;
 			first_enter = false;
 
-			CanvasItemEditorPlugin *canvas_item_plugin = editor_data->get_editor("2D")->cast_to<CanvasItemEditorPlugin>();
+			CanvasItemEditorPlugin *canvas_item_plugin = Object::cast_to<CanvasItemEditorPlugin>(editor_data->get_editor("2D"));
 			if (canvas_item_plugin) {
 				canvas_item_plugin->get_canvas_item_editor()->connect("item_lock_status_changed", scene_tree, "_update_tree");
 				canvas_item_plugin->get_canvas_item_editor()->connect("item_group_status_changed", scene_tree, "_update_tree");
@@ -864,7 +864,7 @@ Node *SceneTreeDock::_duplicate(Node *p_node, Map<Node *, Node *> &duplimap) {
 	} else {
 		Object *obj = ClassDB::instance(p_node->get_class());
 		ERR_FAIL_COND_V(!obj, NULL);
-		node = obj->cast_to<Node>();
+		node = Object::cast_to<Node>(obj);
 		if (!node)
 			memdelete(obj);
 		ERR_FAIL_COND_V(!node, NULL);
@@ -915,11 +915,7 @@ void SceneTreeDock::_set_owners(Node *p_owner, const Array &p_nodes) {
 
 	for (int i = 0; i < p_nodes.size(); i++) {
 
-		Object *obj = p_nodes[i];
-		if (!obj)
-			continue;
-
-		Node *n = obj->cast_to<Node>();
+		Node *n = Object::cast_to<Node>(p_nodes[i]);
 		if (!n)
 			continue;
 		n->set_owner(p_owner);
@@ -994,9 +990,9 @@ void SceneTreeDock::perform_node_renames(Node *p_base, List<Pair<NodePath, NodeP
 	if (!p_base)
 		return;
 
-	if (p_base->cast_to<AnimationPlayer>()) {
+	if (Object::cast_to<AnimationPlayer>(p_base)) {
 
-		AnimationPlayer *ap = p_base->cast_to<AnimationPlayer>();
+		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_base);
 		List<StringName> anims;
 		ap->get_animation_list(&anims);
 		Node *root = ap->get_node(ap->get_root());
@@ -1235,12 +1231,12 @@ void SceneTreeDock::_do_reparent(Node *p_new_parent, int p_position_in_parent, V
 		editor_data->get_undo_redo().add_undo_method(sed, "live_debug_reparent_node", NodePath(String(edited_scene->get_path_to(new_parent)) + "/" + new_name), edited_scene->get_path_to(node->get_parent()), node->get_name(), node->get_index());
 
 		if (p_keep_global_xform) {
-			if (node->cast_to<Node2D>())
-				editor_data->get_undo_redo().add_do_method(node, "set_global_transform", node->cast_to<Node2D>()->get_global_transform());
-			if (node->cast_to<Spatial>())
-				editor_data->get_undo_redo().add_do_method(node, "set_global_transform", node->cast_to<Spatial>()->get_global_transform());
-			if (node->cast_to<Control>())
-				editor_data->get_undo_redo().add_do_method(node, "set_global_position", node->cast_to<Control>()->get_global_position());
+			if (Object::cast_to<Node2D>(node))
+				editor_data->get_undo_redo().add_do_method(node, "set_global_transform", Object::cast_to<Node2D>(node)->get_global_transform());
+			if (Object::cast_to<Spatial>(node))
+				editor_data->get_undo_redo().add_do_method(node, "set_global_transform", Object::cast_to<Spatial>(node)->get_global_transform());
+			if (Object::cast_to<Control>(node))
+				editor_data->get_undo_redo().add_do_method(node, "set_global_position", Object::cast_to<Control>(node)->get_global_position());
 		}
 
 		editor_data->get_undo_redo().add_do_method(this, "_set_owners", edited_scene, owners);
@@ -1277,12 +1273,12 @@ void SceneTreeDock::_do_reparent(Node *p_new_parent, int p_position_in_parent, V
 			editor_data->get_undo_redo().add_undo_method(AnimationPlayerEditor::singleton->get_key_editor(), "set_root", node);
 
 		if (p_keep_global_xform) {
-			if (node->cast_to<Node2D>())
-				editor_data->get_undo_redo().add_undo_method(node, "set_transform", node->cast_to<Node2D>()->get_transform());
-			if (node->cast_to<Spatial>())
-				editor_data->get_undo_redo().add_undo_method(node, "set_transform", node->cast_to<Spatial>()->get_transform());
-			if (node->cast_to<Control>())
-				editor_data->get_undo_redo().add_undo_method(node, "set_position", node->cast_to<Control>()->get_position());
+			if (Object::cast_to<Node2D>(node))
+				editor_data->get_undo_redo().add_undo_method(node, "set_transform", Object::cast_to<Node2D>(node)->get_transform());
+			if (Object::cast_to<Spatial>(node))
+				editor_data->get_undo_redo().add_undo_method(node, "set_transform", Object::cast_to<Spatial>(node)->get_transform());
+			if (Object::cast_to<Control>(node))
+				editor_data->get_undo_redo().add_undo_method(node, "set_position", Object::cast_to<Control>(node)->get_position());
 		}
 	}
 
@@ -1421,7 +1417,7 @@ void SceneTreeDock::_create() {
 		Object *c = create_dialog->instance_selected();
 
 		ERR_FAIL_COND(!c);
-		Node *child = c->cast_to<Node>();
+		Node *child = Object::cast_to<Node>(c);
 		ERR_FAIL_COND(!child);
 
 		editor_data->get_undo_redo().create_action(TTR("Create Node"));
@@ -1450,9 +1446,9 @@ void SceneTreeDock::_create() {
 		editor_data->get_undo_redo().commit_action();
 		editor->push_item(c);
 
-		if (c->cast_to<Control>()) {
+		if (Object::cast_to<Control>(c)) {
 			//make editor more comfortable, so some controls don't appear super shrunk
-			Control *ct = c->cast_to<Control>();
+			Control *ct = Object::cast_to<Control>(c);
 
 			Size2 ms = ct->get_minimum_size();
 			if (ms.width < 4)
@@ -1469,7 +1465,7 @@ void SceneTreeDock::_create() {
 		Object *c = create_dialog->instance_selected();
 
 		ERR_FAIL_COND(!c);
-		Node *newnode = c->cast_to<Node>();
+		Node *newnode = Object::cast_to<Node>(c);
 		ERR_FAIL_COND(!newnode);
 
 		List<PropertyInfo> pinfo;
@@ -1931,10 +1927,10 @@ void SceneTreeDock::_focus_node() {
 	ERR_FAIL_COND(!node);
 
 	if (node->is_class("CanvasItem")) {
-		CanvasItemEditorPlugin *editor = editor_data->get_editor("2D")->cast_to<CanvasItemEditorPlugin>();
+		CanvasItemEditorPlugin *editor = Object::cast_to<CanvasItemEditorPlugin>(editor_data->get_editor("2D"));
 		editor->get_canvas_item_editor()->focus_selection();
 	} else {
-		SpatialEditorPlugin *editor = editor_data->get_editor("3D")->cast_to<SpatialEditorPlugin>();
+		SpatialEditorPlugin *editor = Object::cast_to<SpatialEditorPlugin>(editor_data->get_editor("3D"));
 		editor->get_spatial_editor()->get_editor_viewport(0)->focus_selection();
 	}
 }

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -46,7 +46,7 @@ Node *SceneTreeEditor::get_scene_node() {
 
 void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_id) {
 
-	TreeItem *item = p_item->cast_to<TreeItem>();
+	TreeItem *item = Object::cast_to<TreeItem>(p_item);
 	ERR_FAIL_COND(!item);
 
 	NodePath np = item->get_metadata(0);
@@ -475,7 +475,7 @@ void SceneTreeEditor::_selected_changed() {
 
 void SceneTreeEditor::_cell_multi_selected(Object *p_object, int p_cell, bool p_selected) {
 
-	TreeItem *item = p_object->cast_to<TreeItem>();
+	TreeItem *item = Object::cast_to<TreeItem>(p_object);
 	ERR_FAIL_COND(!item);
 
 	NodePath np = item->get_metadata(0);
@@ -584,7 +584,7 @@ void SceneTreeEditor::_rename_node(ObjectID p_node, const String &p_name) {
 
 	Object *o = ObjectDB::get_instance(p_node);
 	ERR_FAIL_COND(!o);
-	Node *n = o->cast_to<Node>();
+	Node *n = Object::cast_to<Node>(o);
 	ERR_FAIL_COND(!n);
 	TreeItem *item = _find(tree->get_root(), n->get_path());
 	ERR_FAIL_COND(!item);
@@ -732,7 +732,7 @@ void SceneTreeEditor::_cell_collapsed(Object *p_obj) {
 	if (!can_rename)
 		return;
 
-	TreeItem *ti = p_obj->cast_to<TreeItem>();
+	TreeItem *ti = Object::cast_to<TreeItem>(p_obj);
 	if (!ti)
 		return;
 

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -215,7 +215,7 @@ void ScriptEditorDebugger::_scene_tree_folded(Object *obj) {
 
 		return;
 	}
-	TreeItem *item = obj->cast_to<TreeItem>();
+	TreeItem *item = Object::cast_to<TreeItem>(obj);
 
 	if (!item)
 		return;
@@ -1221,7 +1221,7 @@ void ScriptEditorDebugger::_method_changed(Object *p_base, const StringName &p_n
 	if (!p_base || !live_debug || !connection.is_valid() || !editor->get_edited_scene())
 		return;
 
-	Node *node = p_base->cast_to<Node>();
+	Node *node = Object::cast_to<Node>(p_base);
 
 	VARIANT_ARGPTRS
 
@@ -1249,7 +1249,7 @@ void ScriptEditorDebugger::_method_changed(Object *p_base, const StringName &p_n
 		return;
 	}
 
-	Resource *res = p_base->cast_to<Resource>();
+	Resource *res = Object::cast_to<Resource>(p_base);
 
 	if (res && res->get_path() != String()) {
 
@@ -1277,7 +1277,7 @@ void ScriptEditorDebugger::_property_changed(Object *p_base, const StringName &p
 	if (!p_base || !live_debug || !connection.is_valid() || !editor->get_edited_scene())
 		return;
 
-	Node *node = p_base->cast_to<Node>();
+	Node *node = Object::cast_to<Node>(p_base);
 
 	if (node) {
 
@@ -1308,7 +1308,7 @@ void ScriptEditorDebugger::_property_changed(Object *p_base, const StringName &p
 		return;
 	}
 
-	Resource *res = p_base->cast_to<Resource>();
+	Resource *res = Object::cast_to<Resource>(p_base);
 
 	if (res && res->get_path() != String()) {
 

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -191,7 +191,7 @@ void EditorSettingsDialog::_update_shortcuts() {
 
 void EditorSettingsDialog::_shortcut_button_pressed(Object *p_item, int p_column, int p_idx) {
 
-	TreeItem *ti = p_item->cast_to<TreeItem>();
+	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 	ERR_FAIL_COND(!ti);
 
 	String item = ti->get_metadata(0);

--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -660,7 +660,7 @@ void LightSpatialGizmo::set_handle(int p_idx, Camera *p_camera, const Point2 &p_
 	Vector3 s[2] = { gi.xform(ray_from), gi.xform(ray_from + ray_dir * 4096) };
 	if (p_idx == 0) {
 
-		if (light->cast_to<SpotLight>()) {
+		if (Object::cast_to<SpotLight>(light)) {
 			Vector3 ra, rb;
 			Geometry::get_closest_points_between_segments(Vector3(), Vector3(0, 0, -4096), s[0], s[1], ra, rb);
 
@@ -669,7 +669,7 @@ void LightSpatialGizmo::set_handle(int p_idx, Camera *p_camera, const Point2 &p_
 				d = 0;
 
 			light->set_param(Light::PARAM_RANGE, d);
-		} else if (light->cast_to<OmniLight>()) {
+		} else if (Object::cast_to<OmniLight>(light)) {
 
 			Plane cp = Plane(gt.origin, p_camera->get_transform().basis.get_axis(2));
 
@@ -713,7 +713,7 @@ void LightSpatialGizmo::commit_handle(int p_idx, const Variant &p_restore, bool 
 
 void LightSpatialGizmo::redraw() {
 
-	if (light->cast_to<DirectionalLight>()) {
+	if (Object::cast_to<DirectionalLight>(light)) {
 
 		const int arrow_points = 5;
 		Vector3 arrow[arrow_points] = {
@@ -751,11 +751,11 @@ void LightSpatialGizmo::redraw() {
 		add_unscaled_billboard(SpatialEditorGizmos::singleton->light_material_directional_icon, 0.05);
 	}
 
-	if (light->cast_to<OmniLight>()) {
+	if (Object::cast_to<OmniLight>(light)) {
 
 		clear();
 
-		OmniLight *on = light->cast_to<OmniLight>();
+		OmniLight *on = Object::cast_to<OmniLight>(light);
 
 		float r = on->get_param(Light::PARAM_RANGE);
 
@@ -786,12 +786,12 @@ void LightSpatialGizmo::redraw() {
 		add_handles(handles, true);
 	}
 
-	if (light->cast_to<SpotLight>()) {
+	if (Object::cast_to<SpotLight>(light)) {
 
 		clear();
 
 		Vector<Vector3> points;
-		SpotLight *on = light->cast_to<SpotLight>();
+		SpotLight *on = Object::cast_to<SpotLight>(light);
 
 		float r = on->get_param(Light::PARAM_RANGE);
 		float w = r * Math::sin(Math::deg2rad(on->get_param(Light::PARAM_SPOT_ANGLE)));
@@ -1568,22 +1568,22 @@ String CollisionShapeSpatialGizmo::get_handle_name(int p_idx) const {
 	if (s.is_null())
 		return "";
 
-	if (s->cast_to<SphereShape>()) {
+	if (Object::cast_to<SphereShape>(*s)) {
 
 		return "Radius";
 	}
 
-	if (s->cast_to<BoxShape>()) {
+	if (Object::cast_to<BoxShape>(*s)) {
 
 		return "Extents";
 	}
 
-	if (s->cast_to<CapsuleShape>()) {
+	if (Object::cast_to<CapsuleShape>(*s)) {
 
 		return p_idx == 0 ? "Radius" : "Height";
 	}
 
-	if (s->cast_to<RayShape>()) {
+	if (Object::cast_to<RayShape>(*s)) {
 
 		return "Length";
 	}
@@ -1596,25 +1596,25 @@ Variant CollisionShapeSpatialGizmo::get_handle_value(int p_idx) const {
 	if (s.is_null())
 		return Variant();
 
-	if (s->cast_to<SphereShape>()) {
+	if (Object::cast_to<SphereShape>(*s)) {
 
 		Ref<SphereShape> ss = s;
 		return ss->get_radius();
 	}
 
-	if (s->cast_to<BoxShape>()) {
+	if (Object::cast_to<BoxShape>(*s)) {
 
 		Ref<BoxShape> bs = s;
 		return bs->get_extents();
 	}
 
-	if (s->cast_to<CapsuleShape>()) {
+	if (Object::cast_to<CapsuleShape>(*s)) {
 
 		Ref<CapsuleShape> cs = s;
 		return p_idx == 0 ? cs->get_radius() : cs->get_height();
 	}
 
-	if (s->cast_to<RayShape>()) {
+	if (Object::cast_to<RayShape>(*s)) {
 
 		Ref<RayShape> cs = s;
 		return cs->get_length();
@@ -1636,7 +1636,7 @@ void CollisionShapeSpatialGizmo::set_handle(int p_idx, Camera *p_camera, const P
 
 	Vector3 sg[2] = { gi.xform(ray_from), gi.xform(ray_from + ray_dir * 4096) };
 
-	if (s->cast_to<SphereShape>()) {
+	if (Object::cast_to<SphereShape>(*s)) {
 
 		Ref<SphereShape> ss = s;
 		Vector3 ra, rb;
@@ -1648,7 +1648,7 @@ void CollisionShapeSpatialGizmo::set_handle(int p_idx, Camera *p_camera, const P
 		ss->set_radius(d);
 	}
 
-	if (s->cast_to<RayShape>()) {
+	if (Object::cast_to<RayShape>(*s)) {
 
 		Ref<RayShape> rs = s;
 		Vector3 ra, rb;
@@ -1660,7 +1660,7 @@ void CollisionShapeSpatialGizmo::set_handle(int p_idx, Camera *p_camera, const P
 		rs->set_length(d);
 	}
 
-	if (s->cast_to<BoxShape>()) {
+	if (Object::cast_to<BoxShape>(*s)) {
 
 		Vector3 axis;
 		axis[p_idx] = 1.0;
@@ -1676,7 +1676,7 @@ void CollisionShapeSpatialGizmo::set_handle(int p_idx, Camera *p_camera, const P
 		bs->set_extents(he);
 	}
 
-	if (s->cast_to<CapsuleShape>()) {
+	if (Object::cast_to<CapsuleShape>(*s)) {
 
 		Vector3 axis;
 		axis[p_idx == 0 ? 0 : 2] = 1.0;
@@ -1700,7 +1700,7 @@ void CollisionShapeSpatialGizmo::commit_handle(int p_idx, const Variant &p_resto
 	if (s.is_null())
 		return;
 
-	if (s->cast_to<SphereShape>()) {
+	if (Object::cast_to<SphereShape>(*s)) {
 
 		Ref<SphereShape> ss = s;
 		if (p_cancel) {
@@ -1715,7 +1715,7 @@ void CollisionShapeSpatialGizmo::commit_handle(int p_idx, const Variant &p_resto
 		ur->commit_action();
 	}
 
-	if (s->cast_to<BoxShape>()) {
+	if (Object::cast_to<BoxShape>(*s)) {
 
 		Ref<BoxShape> ss = s;
 		if (p_cancel) {
@@ -1730,7 +1730,7 @@ void CollisionShapeSpatialGizmo::commit_handle(int p_idx, const Variant &p_resto
 		ur->commit_action();
 	}
 
-	if (s->cast_to<CapsuleShape>()) {
+	if (Object::cast_to<CapsuleShape>(*s)) {
 
 		Ref<CapsuleShape> ss = s;
 		if (p_cancel) {
@@ -1755,7 +1755,7 @@ void CollisionShapeSpatialGizmo::commit_handle(int p_idx, const Variant &p_resto
 		ur->commit_action();
 	}
 
-	if (s->cast_to<RayShape>()) {
+	if (Object::cast_to<RayShape>(*s)) {
 
 		Ref<RayShape> ss = s;
 		if (p_cancel) {
@@ -1778,7 +1778,7 @@ void CollisionShapeSpatialGizmo::redraw() {
 	if (s.is_null())
 		return;
 
-	if (s->cast_to<SphereShape>()) {
+	if (Object::cast_to<SphereShape>(*s)) {
 
 		Ref<SphereShape> sp = s;
 		float r = sp->get_radius();
@@ -1824,7 +1824,7 @@ void CollisionShapeSpatialGizmo::redraw() {
 		add_handles(handles);
 	}
 
-	if (s->cast_to<BoxShape>()) {
+	if (Object::cast_to<BoxShape>(*s)) {
 
 		Ref<BoxShape> bs = s;
 		Vector<Vector3> lines;
@@ -1853,7 +1853,7 @@ void CollisionShapeSpatialGizmo::redraw() {
 		add_handles(handles);
 	}
 
-	if (s->cast_to<CapsuleShape>()) {
+	if (Object::cast_to<CapsuleShape>(*s)) {
 
 		Ref<CapsuleShape> cs = s;
 		float radius = cs->get_radius();
@@ -1928,7 +1928,7 @@ void CollisionShapeSpatialGizmo::redraw() {
 		add_handles(handles);
 	}
 
-	if (s->cast_to<PlaneShape>()) {
+	if (Object::cast_to<PlaneShape>(*s)) {
 
 		Ref<PlaneShape> ps = s;
 		Plane p = ps->get_plane();
@@ -1959,9 +1959,9 @@ void CollisionShapeSpatialGizmo::redraw() {
 		add_collision_segments(points);
 	}
 
-	if (s->cast_to<ConvexPolygonShape>()) {
+	if (Object::cast_to<ConvexPolygonShape>(*s)) {
 
-		PoolVector<Vector3> points = s->cast_to<ConvexPolygonShape>()->get_points();
+		PoolVector<Vector3> points = Object::cast_to<ConvexPolygonShape>(*s)->get_points();
 
 		if (points.size() > 3) {
 
@@ -1983,7 +1983,7 @@ void CollisionShapeSpatialGizmo::redraw() {
 		}
 	}
 
-	if (s->cast_to<RayShape>()) {
+	if (Object::cast_to<RayShape>(*s)) {
 
 		Ref<RayShape> rs = s;
 
@@ -3098,133 +3098,133 @@ SpatialEditorGizmos *SpatialEditorGizmos::singleton = NULL;
 
 Ref<SpatialEditorGizmo> SpatialEditorGizmos::get_gizmo(Spatial *p_spatial) {
 
-	if (p_spatial->cast_to<Light>()) {
+	if (Object::cast_to<Light>(p_spatial)) {
 
-		Ref<LightSpatialGizmo> lsg = memnew(LightSpatialGizmo(p_spatial->cast_to<Light>()));
+		Ref<LightSpatialGizmo> lsg = memnew(LightSpatialGizmo(Object::cast_to<Light>(p_spatial)));
 		return lsg;
 	}
 
-	if (p_spatial->cast_to<Camera>()) {
+	if (Object::cast_to<Camera>(p_spatial)) {
 
-		Ref<CameraSpatialGizmo> lsg = memnew(CameraSpatialGizmo(p_spatial->cast_to<Camera>()));
+		Ref<CameraSpatialGizmo> lsg = memnew(CameraSpatialGizmo(Object::cast_to<Camera>(p_spatial)));
 		return lsg;
 	}
 
-	if (p_spatial->cast_to<Skeleton>()) {
+	if (Object::cast_to<Skeleton>(p_spatial)) {
 
-		Ref<SkeletonSpatialGizmo> lsg = memnew(SkeletonSpatialGizmo(p_spatial->cast_to<Skeleton>()));
+		Ref<SkeletonSpatialGizmo> lsg = memnew(SkeletonSpatialGizmo(Object::cast_to<Skeleton>(p_spatial)));
 		return lsg;
 	}
 
-	if (p_spatial->cast_to<Position3D>()) {
+	if (Object::cast_to<Position3D>(p_spatial)) {
 
-		Ref<Position3DSpatialGizmo> lsg = memnew(Position3DSpatialGizmo(p_spatial->cast_to<Position3D>()));
+		Ref<Position3DSpatialGizmo> lsg = memnew(Position3DSpatialGizmo(Object::cast_to<Position3D>(p_spatial)));
 		return lsg;
 	}
 
-	if (p_spatial->cast_to<MeshInstance>()) {
+	if (Object::cast_to<MeshInstance>(p_spatial)) {
 
-		Ref<MeshInstanceSpatialGizmo> misg = memnew(MeshInstanceSpatialGizmo(p_spatial->cast_to<MeshInstance>()));
+		Ref<MeshInstanceSpatialGizmo> misg = memnew(MeshInstanceSpatialGizmo(Object::cast_to<MeshInstance>(p_spatial)));
 		return misg;
 	}
 
-	if (p_spatial->cast_to<Room>()) {
+	if (Object::cast_to<Room>(p_spatial)) {
 
-		Ref<RoomSpatialGizmo> misg = memnew(RoomSpatialGizmo(p_spatial->cast_to<Room>()));
+		Ref<RoomSpatialGizmo> misg = memnew(RoomSpatialGizmo(Object::cast_to<Room>(p_spatial)));
 		return misg;
 	}
 
-	if (p_spatial->cast_to<NavigationMeshInstance>()) {
+	if (Object::cast_to<NavigationMeshInstance>(p_spatial)) {
 
-		Ref<NavigationMeshSpatialGizmo> misg = memnew(NavigationMeshSpatialGizmo(p_spatial->cast_to<NavigationMeshInstance>()));
+		Ref<NavigationMeshSpatialGizmo> misg = memnew(NavigationMeshSpatialGizmo(Object::cast_to<NavigationMeshInstance>(p_spatial)));
 		return misg;
 	}
 
-	if (p_spatial->cast_to<RayCast>()) {
+	if (Object::cast_to<RayCast>(p_spatial)) {
 
-		Ref<RayCastSpatialGizmo> misg = memnew(RayCastSpatialGizmo(p_spatial->cast_to<RayCast>()));
+		Ref<RayCastSpatialGizmo> misg = memnew(RayCastSpatialGizmo(Object::cast_to<RayCast>(p_spatial)));
 		return misg;
 	}
 
-	if (p_spatial->cast_to<Portal>()) {
+	if (Object::cast_to<Portal>(p_spatial)) {
 
-		Ref<PortalSpatialGizmo> misg = memnew(PortalSpatialGizmo(p_spatial->cast_to<Portal>()));
+		Ref<PortalSpatialGizmo> misg = memnew(PortalSpatialGizmo(Object::cast_to<Portal>(p_spatial)));
 		return misg;
 	}
 
-	if (p_spatial->cast_to<CollisionShape>()) {
+	if (Object::cast_to<CollisionShape>(p_spatial)) {
 
-		Ref<CollisionShapeSpatialGizmo> misg = memnew(CollisionShapeSpatialGizmo(p_spatial->cast_to<CollisionShape>()));
+		Ref<CollisionShapeSpatialGizmo> misg = memnew(CollisionShapeSpatialGizmo(Object::cast_to<CollisionShape>(p_spatial)));
 		return misg;
 	}
 
-	if (p_spatial->cast_to<VisibilityNotifier>()) {
+	if (Object::cast_to<VisibilityNotifier>(p_spatial)) {
 
-		Ref<VisibilityNotifierGizmo> misg = memnew(VisibilityNotifierGizmo(p_spatial->cast_to<VisibilityNotifier>()));
+		Ref<VisibilityNotifierGizmo> misg = memnew(VisibilityNotifierGizmo(Object::cast_to<VisibilityNotifier>(p_spatial)));
 		return misg;
 	}
 
-	if (p_spatial->cast_to<Particles>()) {
+	if (Object::cast_to<Particles>(p_spatial)) {
 
-		Ref<ParticlesGizmo> misg = memnew(ParticlesGizmo(p_spatial->cast_to<Particles>()));
+		Ref<ParticlesGizmo> misg = memnew(ParticlesGizmo(Object::cast_to<Particles>(p_spatial)));
 		return misg;
 	}
 
-	if (p_spatial->cast_to<ReflectionProbe>()) {
+	if (Object::cast_to<ReflectionProbe>(p_spatial)) {
 
-		Ref<ReflectionProbeGizmo> misg = memnew(ReflectionProbeGizmo(p_spatial->cast_to<ReflectionProbe>()));
+		Ref<ReflectionProbeGizmo> misg = memnew(ReflectionProbeGizmo(Object::cast_to<ReflectionProbe>(p_spatial)));
 		return misg;
 	}
-	if (p_spatial->cast_to<GIProbe>()) {
+	if (Object::cast_to<GIProbe>(p_spatial)) {
 
-		Ref<GIProbeGizmo> misg = memnew(GIProbeGizmo(p_spatial->cast_to<GIProbe>()));
-		return misg;
-	}
-
-	if (p_spatial->cast_to<VehicleWheel>()) {
-
-		Ref<VehicleWheelSpatialGizmo> misg = memnew(VehicleWheelSpatialGizmo(p_spatial->cast_to<VehicleWheel>()));
-		return misg;
-	}
-	if (p_spatial->cast_to<PinJoint>()) {
-
-		Ref<PinJointSpatialGizmo> misg = memnew(PinJointSpatialGizmo(p_spatial->cast_to<PinJoint>()));
+		Ref<GIProbeGizmo> misg = memnew(GIProbeGizmo(Object::cast_to<GIProbe>(p_spatial)));
 		return misg;
 	}
 
-	if (p_spatial->cast_to<HingeJoint>()) {
+	if (Object::cast_to<VehicleWheel>(p_spatial)) {
 
-		Ref<HingeJointSpatialGizmo> misg = memnew(HingeJointSpatialGizmo(p_spatial->cast_to<HingeJoint>()));
+		Ref<VehicleWheelSpatialGizmo> misg = memnew(VehicleWheelSpatialGizmo(Object::cast_to<VehicleWheel>(p_spatial)));
+		return misg;
+	}
+	if (Object::cast_to<PinJoint>(p_spatial)) {
+
+		Ref<PinJointSpatialGizmo> misg = memnew(PinJointSpatialGizmo(Object::cast_to<PinJoint>(p_spatial)));
 		return misg;
 	}
 
-	if (p_spatial->cast_to<SliderJoint>()) {
+	if (Object::cast_to<HingeJoint>(p_spatial)) {
 
-		Ref<SliderJointSpatialGizmo> misg = memnew(SliderJointSpatialGizmo(p_spatial->cast_to<SliderJoint>()));
+		Ref<HingeJointSpatialGizmo> misg = memnew(HingeJointSpatialGizmo(Object::cast_to<HingeJoint>(p_spatial)));
 		return misg;
 	}
 
-	if (p_spatial->cast_to<ConeTwistJoint>()) {
+	if (Object::cast_to<SliderJoint>(p_spatial)) {
 
-		Ref<ConeTwistJointSpatialGizmo> misg = memnew(ConeTwistJointSpatialGizmo(p_spatial->cast_to<ConeTwistJoint>()));
+		Ref<SliderJointSpatialGizmo> misg = memnew(SliderJointSpatialGizmo(Object::cast_to<SliderJoint>(p_spatial)));
 		return misg;
 	}
 
-	if (p_spatial->cast_to<Generic6DOFJoint>()) {
+	if (Object::cast_to<ConeTwistJoint>(p_spatial)) {
 
-		Ref<Generic6DOFJointSpatialGizmo> misg = memnew(Generic6DOFJointSpatialGizmo(p_spatial->cast_to<Generic6DOFJoint>()));
+		Ref<ConeTwistJointSpatialGizmo> misg = memnew(ConeTwistJointSpatialGizmo(Object::cast_to<ConeTwistJoint>(p_spatial)));
 		return misg;
 	}
 
-	if (p_spatial->cast_to<CollisionPolygon>()) {
+	if (Object::cast_to<Generic6DOFJoint>(p_spatial)) {
 
-		Ref<CollisionPolygonSpatialGizmo> misg = memnew(CollisionPolygonSpatialGizmo(p_spatial->cast_to<CollisionPolygon>()));
+		Ref<Generic6DOFJointSpatialGizmo> misg = memnew(Generic6DOFJointSpatialGizmo(Object::cast_to<Generic6DOFJoint>(p_spatial)));
 		return misg;
 	}
 
-	if (p_spatial->cast_to<AudioStreamPlayer3D>()) {
+	if (Object::cast_to<CollisionPolygon>(p_spatial)) {
 
-		Ref<AudioStreamPlayer3DSpatialGizmo> misg = memnew(AudioStreamPlayer3DSpatialGizmo(p_spatial->cast_to<AudioStreamPlayer3D>()));
+		Ref<CollisionPolygonSpatialGizmo> misg = memnew(CollisionPolygonSpatialGizmo(Object::cast_to<CollisionPolygon>(p_spatial)));
+		return misg;
+	}
+
+	if (Object::cast_to<AudioStreamPlayer3D>(p_spatial)) {
+
+		Ref<AudioStreamPlayer3DSpatialGizmo> misg = memnew(AudioStreamPlayer3DSpatialGizmo(Object::cast_to<AudioStreamPlayer3D>(p_spatial)));
 		return misg;
 	}
 

--- a/editor/spatial_editor_gizmos.h
+++ b/editor/spatial_editor_gizmos.h
@@ -93,7 +93,7 @@ class EditorSpatialGizmo : public SpatialEditorGizmo {
 	Vector<Instance> instances;
 	Spatial *spatial_node;
 
-	void _set_spatial_node(Node *p_node) { set_spatial_node(p_node->cast_to<Spatial>()); }
+	void _set_spatial_node(Node *p_node) { set_spatial_node(Object::cast_to<Spatial>(p_node)); }
 
 protected:
 	void add_lines(const Vector<Vector3> &p_lines, const Ref<Material> &p_material, bool p_billboard = false);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -981,7 +981,7 @@ Error Main::setup2() {
 	if (bool(GLOBAL_DEF("display/window/handheld/emulate_touchscreen", false))) {
 		if (!OS::get_singleton()->has_touchscreen_ui_hint() && Input::get_singleton() && !editor) {
 			//only if no touchscreen ui hint, set emulation
-			InputDefault *id = Input::get_singleton()->cast_to<InputDefault>();
+			InputDefault *id = Object::cast_to<InputDefault>(Input::get_singleton());
 			if (id)
 				id->set_emulate_touch(true);
 		}
@@ -1181,7 +1181,7 @@ bool Main::start() {
 
 			StringName instance_type = script_res->get_instance_base_type();
 			Object *obj = ClassDB::instance(instance_type);
-			MainLoop *script_loop = obj ? obj->cast_to<MainLoop>() : NULL;
+			MainLoop *script_loop = Object::cast_to<MainLoop>(obj);
 			if (!script_loop) {
 				if (obj)
 					memdelete(obj);
@@ -1215,7 +1215,7 @@ bool Main::start() {
 				ERR_FAIL_V(false);
 			}
 
-			main_loop = ml->cast_to<MainLoop>();
+			main_loop = Object::cast_to<MainLoop>(ml);
 			if (!main_loop) {
 
 				memdelete(ml);
@@ -1227,7 +1227,7 @@ bool Main::start() {
 
 	if (main_loop->is_class("SceneTree")) {
 
-		SceneTree *sml = main_loop->cast_to<SceneTree>();
+		SceneTree *sml = Object::cast_to<SceneTree>(main_loop);
 
 #ifdef DEBUG_ENABLED
 		if (debug_collisions) {
@@ -1421,7 +1421,7 @@ bool Main::start() {
 						ERR_EXPLAIN("Cannot instance script for autoload, expected 'Node' inheritance, got: " + String(ibt));
 						ERR_CONTINUE(obj == NULL);
 
-						n = obj->cast_to<Node>();
+						n = Object::cast_to<Node>(obj);
 						n->set_script(s.get_ref_ptr());
 					}
 

--- a/main/performance.cpp
+++ b/main/performance.cpp
@@ -125,9 +125,7 @@ float Performance::get_monitor(Monitor p_monitor) const {
 		case OBJECT_NODE_COUNT: {
 
 			MainLoop *ml = OS::get_singleton()->get_main_loop();
-			if (!ml)
-				return 0;
-			SceneTree *sml = ml->cast_to<SceneTree>();
+			SceneTree *sml = Object::cast_to<SceneTree>(ml);
 			if (!sml)
 				return 0;
 			return sml->get_node_count();

--- a/modules/gdnative/godot/rid.cpp
+++ b/modules/gdnative/godot/rid.cpp
@@ -50,7 +50,7 @@ godot_int GDAPI godot_rid_get_id(const godot_rid *p_self) {
 }
 
 void GDAPI godot_rid_new_with_resource(godot_rid *r_dest, const godot_object *p_from) {
-	const Resource *res_from = ((const Object *)p_from)->cast_to<Resource>();
+	const Resource *res_from = Object::cast_to<Resource>((Object *)p_from);
 	godot_rid_new(r_dest);
 	if (res_from) {
 		RID *dest = (RID *)r_dest;

--- a/modules/gdscript/gd_compiler.cpp
+++ b/modules/gdscript/gd_compiler.cpp
@@ -1971,7 +1971,7 @@ Error GDCompiler::_parse_class(GDScript *p_script, GDScript *p_owner, const GDPa
 					p_script->placeholders.erase(psi); //remove placeholder
 
 					GDInstance *instance = memnew(GDInstance);
-					instance->base_ref = E->get()->cast_to<Reference>();
+					instance->base_ref = Object::cast_to<Reference>(E->get());
 					instance->members.resize(p_script->member_indices.size());
 					instance->script = Ref<GDScript>(p_script);
 					instance->owner = E->get();

--- a/modules/gdscript/gd_editor.cpp
+++ b/modules/gdscript/gd_editor.cpp
@@ -372,8 +372,8 @@ static GDCompletionIdentifier _get_type_from_variant(const Variant &p_variant) {
 		Object *obj = p_variant;
 		if (obj) {
 			/*
-			if (obj->cast_to<GDNativeClass>()) {
-				t.obj_type=obj->cast_to<GDNativeClass>()->get_name();
+			if (Object::cast_to<GDNativeClass>(obj)) {
+				t.obj_type=Object::cast_to<GDNativeClass>(obj)->get_name();
 				t.value=Variant();
 			} else {
 			*/
@@ -597,8 +597,7 @@ static bool _guess_expression_type(GDCompletionContext &context, const GDParser:
 
 					if (id.operator String() == "new" && base.value.get_type() == Variant::OBJECT) {
 						Object *obj = base.value;
-						if (obj && obj->cast_to<GDNativeClass>()) {
-							GDNativeClass *gdnc = obj->cast_to<GDNativeClass>();
+						if (GDNativeClass *gdnc = Object::cast_to<GDNativeClass>(obj)) {
 							r_type.type = Variant::OBJECT;
 							r_type.value = Variant();
 							r_type.obj_type = gdnc->get_name();
@@ -1495,48 +1494,45 @@ static void _find_type_arguments(GDCompletionContext &context, const GDParser::N
 			if (id.value.get_type()) {
 				Object *obj = id.value;
 
-				if (obj) {
+				GDScript *scr = Object::cast_to<GDScript>(obj);
+				if (scr) {
+					while (scr) {
 
-					GDScript *scr = obj->cast_to<GDScript>();
-					if (scr) {
-						while (scr) {
-
-							for (const Map<StringName, GDFunction *>::Element *E = scr->get_member_functions().front(); E; E = E->next()) {
-								if (E->get()->is_static() && p_method == E->get()->get_name()) {
-									arghint = "static func " + String(p_method) + "(";
-									for (int i = 0; i < E->get()->get_argument_count(); i++) {
-										if (i > 0)
-											arghint += ", ";
-										else
-											arghint += " ";
-										if (i == p_argidx) {
-											arghint += String::chr(0xFFFF);
-										}
-										arghint += "var " + E->get()->get_argument_name(i);
-										int deffrom = E->get()->get_argument_count() - E->get()->get_default_argument_count();
-										if (i >= deffrom) {
-											int defidx = deffrom - i;
-											if (defidx >= 0 && defidx < E->get()->get_default_argument_count()) {
-												arghint += "=" + E->get()->get_default_argument(defidx).get_construct_string();
-											}
-										}
-										if (i == p_argidx) {
-											arghint += String::chr(0xFFFF);
+						for (const Map<StringName, GDFunction *>::Element *E = scr->get_member_functions().front(); E; E = E->next()) {
+							if (E->get()->is_static() && p_method == E->get()->get_name()) {
+								arghint = "static func " + String(p_method) + "(";
+								for (int i = 0; i < E->get()->get_argument_count(); i++) {
+									if (i > 0)
+										arghint += ", ";
+									else
+										arghint += " ";
+									if (i == p_argidx) {
+										arghint += String::chr(0xFFFF);
+									}
+									arghint += "var " + E->get()->get_argument_name(i);
+									int deffrom = E->get()->get_argument_count() - E->get()->get_default_argument_count();
+									if (i >= deffrom) {
+										int defidx = deffrom - i;
+										if (defidx >= 0 && defidx < E->get()->get_default_argument_count()) {
+											arghint += "=" + E->get()->get_default_argument(defidx).get_construct_string();
 										}
 									}
-									arghint += ")";
-									return; //found
+									if (i == p_argidx) {
+										arghint += String::chr(0xFFFF);
+									}
 								}
+								arghint += ")";
+								return; //found
 							}
-
-							if (scr->get_base().is_valid())
-								scr = scr->get_base().ptr();
-							else
-								scr = NULL;
 						}
-					} else {
-						on_script = obj->get_script();
+
+						if (scr->get_base().is_valid())
+							scr = scr->get_base().ptr();
+						else
+							scr = NULL;
 					}
+				} else {
+					on_script = obj->get_script();
 				}
 			}
 
@@ -2207,30 +2203,27 @@ Error GDScriptLanguage::complete_code(const String &p_code, const String &p_base
 					if (t.value.get_type()) {
 						Object *obj = t.value;
 
-						if (obj) {
+						GDScript *scr = Object::cast_to<GDScript>(obj);
+						if (scr) {
+							while (scr) {
 
-							GDScript *scr = obj->cast_to<GDScript>();
-							if (scr) {
-								while (scr) {
-
-									if (!isfunction) {
-										for (const Map<StringName, Variant>::Element *E = scr->get_constants().front(); E; E = E->next()) {
-											options.insert(E->key());
-										}
+								if (!isfunction) {
+									for (const Map<StringName, Variant>::Element *E = scr->get_constants().front(); E; E = E->next()) {
+										options.insert(E->key());
 									}
-									for (const Map<StringName, GDFunction *>::Element *E = scr->get_member_functions().front(); E; E = E->next()) {
-										if (E->get()->is_static())
-											options.insert(E->key());
-									}
-
-									if (scr->get_base().is_valid())
-										scr = scr->get_base().ptr();
-									else
-										scr = NULL;
 								}
-							} else {
-								on_script = obj->get_script();
+								for (const Map<StringName, GDFunction *>::Element *E = scr->get_member_functions().front(); E; E = E->next()) {
+									if (E->get()->is_static())
+										options.insert(E->key());
+								}
+
+								if (scr->get_base().is_valid())
+									scr = scr->get_base().ptr();
+								else
+									scr = NULL;
 							}
+						} else {
+							on_script = obj->get_script();
 						}
 					}
 
@@ -2822,9 +2815,9 @@ Error GDScriptLanguage::lookup_code(const String &p_code, const String &p_symbol
 							Object *obj = value;
 							if (obj) {
 
-								if (obj->cast_to<GDNativeClass>()) {
+								if (Object::cast_to<GDNativeClass>(obj)) {
 									r_result.type = ScriptLanguage::LookupResult::RESULT_CLASS;
-									r_result.class_name = obj->cast_to<GDNativeClass>()->get_name();
+									r_result.class_name = Object::cast_to<GDNativeClass>(obj)->get_name();
 
 								} else {
 									r_result.type = ScriptLanguage::LookupResult::RESULT_CLASS;

--- a/modules/gdscript/gd_function.cpp
+++ b/modules/gdscript/gd_function.cpp
@@ -371,7 +371,7 @@ Variant GDFunction::call(GDInstance *p_instance, const Variant **p_args, int p_a
 				Object *obj_A = *a;
 				Object *obj_B = *b;
 
-				GDScript *scr_B = obj_B->cast_to<GDScript>();
+				GDScript *scr_B = Object::cast_to<GDScript>(obj_B);
 
 				bool extends_ok = false;
 
@@ -397,7 +397,7 @@ Variant GDFunction::call(GDInstance *p_instance, const Variant **p_args, int p_a
 
 				} else {
 
-					GDNativeClass *nc = obj_B->cast_to<GDNativeClass>();
+					GDNativeClass *nc = Object::cast_to<GDNativeClass>(obj_B);
 
 					if (!nc) {
 
@@ -1434,7 +1434,7 @@ Variant GDFunctionState::_signal_callback(const Variant **p_args, int p_argcount
 	// If the return value is a GDFunctionState reference,
 	// then the function did yield again after resuming.
 	if (ret.is_ref()) {
-		GDFunctionState *gdfs = ret.operator Object *()->cast_to<GDFunctionState>();
+		GDFunctionState *gdfs = Object::cast_to<GDFunctionState>((Object *)&ret);
 		if (gdfs && gdfs->function == function)
 			completed = false;
 	}
@@ -1490,7 +1490,7 @@ Variant GDFunctionState::resume(const Variant &p_arg) {
 	// If the return value is a GDFunctionState reference,
 	// then the function did yield again after resuming.
 	if (ret.is_ref()) {
-		GDFunctionState *gdfs = ret.operator Object *()->cast_to<GDFunctionState>();
+		GDFunctionState *gdfs = Object::cast_to<GDFunctionState>((Object *)&ret);
 		if (gdfs && gdfs->function == function)
 			completed = false;
 	}

--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -3957,7 +3957,7 @@ void GDParser::_parse_class(ClassNode *p_class) {
 							member._export.usage |= PROPERTY_USAGE_SCRIPT_VARIABLE;
 							if (cn->value.get_type() == Variant::OBJECT) {
 								Object *obj = cn->value;
-								Resource *res = obj->cast_to<Resource>();
+								Resource *res = Object::cast_to<Resource>(obj);
 								if (res == NULL) {
 									_set_error("Exported constant not a type or resource.");
 									return;

--- a/modules/gdscript/gd_script.cpp
+++ b/modules/gdscript/gd_script.cpp
@@ -73,7 +73,7 @@ Variant GDNativeClass::_new() {
 		ERR_FAIL_COND_V(!o, Variant());
 	}
 
-	Reference *ref = o->cast_to<Reference>();
+	Reference *ref = Object::cast_to<Reference>(o);
 	if (ref) {
 		return REF(ref);
 	} else {
@@ -161,7 +161,7 @@ Variant GDScript::_new(const Variant **p_args, int p_argcount, Variant::CallErro
 		owner = memnew(Reference); //by default, no base means use reference
 	}
 
-	Reference *r = owner->cast_to<Reference>();
+	Reference *r = Object::cast_to<Reference>(owner);
 	if (r) {
 		ref = REF(r);
 	}
@@ -397,7 +397,7 @@ ScriptInstance *GDScript::instance_create(Object *p_this) {
 	}
 
 	Variant::CallError unchecked_error;
-	return _create_instance(NULL, 0, p_this, p_this->cast_to<Reference>(), unchecked_error);
+	return _create_instance(NULL, 0, p_this, Object::cast_to<Reference>(p_this), unchecked_error);
 }
 bool GDScript::instance_has(const Object *p_this) const {
 
@@ -575,9 +575,7 @@ void GDScript::update_exports() {
 	//print_line("update exports for "+get_path()+" ic: "+itos(copy.size()));
 	for (Set<ObjectID>::Element *E = copy.front(); E; E = E->next()) {
 		Object *id = ObjectDB::get_instance(E->get());
-		if (!id)
-			continue;
-		GDScript *s = id->cast_to<GDScript>();
+		GDScript *s = Object::cast_to<GDScript>(id);
 		if (!s)
 			continue;
 		s->update_exports();
@@ -2006,11 +2004,11 @@ Error ResourceFormatSaverGDScript::save(const String &p_path, const RES &p_resou
 
 void ResourceFormatSaverGDScript::get_recognized_extensions(const RES &p_resource, List<String> *p_extensions) const {
 
-	if (p_resource->cast_to<GDScript>()) {
+	if (Object::cast_to<GDScript>(*p_resource)) {
 		p_extensions->push_back("gd");
 	}
 }
 bool ResourceFormatSaverGDScript::recognize(const RES &p_resource) const {
 
-	return p_resource->cast_to<GDScript>() != NULL;
+	return Object::cast_to<GDScript>(*p_resource) != NULL;
 }

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -715,12 +715,12 @@ void GridMap::_notification(int p_what) {
 
 			Spatial *c = this;
 			while (c) {
-				navigation = c->cast_to<Navigation>();
+				navigation = Object::cast_to<Navigation>(c);
 				if (navigation) {
 					break;
 				}
 
-				c = c->get_parent()->cast_to<Spatial>();
+				c = Object::cast_to<Spatial>(c->get_parent());
 			}
 
 			if (navigation) {

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -806,7 +806,7 @@ void GridMapEditor::edit(GridMap *p_gridmap) {
 	_update_selection_transform();
 	_update_duplicate_indicator();
 
-	spatial_editor = editor->get_editor_plugin_screen()->cast_to<SpatialEditorPlugin>();
+	spatial_editor = Object::cast_to<SpatialEditorPlugin>(editor->get_editor_plugin_screen());
 
 	if (!node) {
 		set_process(false);
@@ -978,14 +978,14 @@ void GridMapEditor::_notification(int p_what) {
 
 		if (lock_view) {
 
-			EditorNode *editor = get_tree()->get_root()->get_child(0)->cast_to<EditorNode>();
+			EditorNode *editor = Object::cast_to<EditorNode>(get_tree()->get_root()->get_child(0));
 
 			Plane p;
 			p.normal[edit_axis] = 1.0;
 			p.d = edit_floor[edit_axis] * node->get_cell_size();
 			p = node->get_transform().xform(p); // plane to snap
 
-			SpatialEditorPlugin *sep = editor->get_editor_plugin_screen()->cast_to<SpatialEditorPlugin>();
+			SpatialEditorPlugin *sep = Object::cast_to<SpatialEditorPlugin>(editor->get_editor_plugin_screen());
 			if (sep)
 				sep->snap_cursor_to_plane(p);
 			//editor->get_editor_plugin_screen()->call("snap_cursor_to_plane",p);
@@ -1371,7 +1371,7 @@ GridMapEditor::~GridMapEditor() {
 
 void GridMapEditorPlugin::edit(Object *p_object) {
 
-	gridmap_editor->edit(p_object ? p_object->cast_to<GridMap>() : NULL);
+	gridmap_editor->edit(Object::cast_to<GridMap>(p_object));
 }
 
 bool GridMapEditorPlugin::handles(Object *p_object) const {

--- a/modules/nativescript/nativescript.cpp
+++ b/modules/nativescript/nativescript.cpp
@@ -399,7 +399,7 @@ Variant NativeScript::_new(const Variant **p_args, int p_argcount, Variant::Call
 		owner = memnew(Reference);
 	}
 
-	Reference *r = owner->cast_to<Reference>();
+	Reference *r = Object::cast_to<Reference>(owner);
 	if (r) {
 		ref = REF(r);
 	}
@@ -1203,11 +1203,11 @@ Error ResourceFormatSaverNativeScript::save(const String &p_path, const RES &p_r
 }
 
 bool ResourceFormatSaverNativeScript::recognize(const RES &p_resource) const {
-	return p_resource->cast_to<NativeScript>() != NULL;
+	return Object::cast_to<NativeScript>(*p_resource) != NULL;
 }
 
 void ResourceFormatSaverNativeScript::get_recognized_extensions(const RES &p_resource, List<String> *p_extensions) const {
-	if (p_resource->cast_to<NativeScript>()) {
+	if (Object::cast_to<NativeScript>(*p_resource)) {
 		p_extensions->push_back("gdns");
 	}
 }

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -273,7 +273,9 @@ void VisualScript::_node_ports_changed(int p_id) {
 	Function &func = functions[function];
 	Ref<VisualScriptNode> vsn = func.nodes[p_id].node;
 
-	if (OS::get_singleton()->get_main_loop() && OS::get_singleton()->get_main_loop()->cast_to<SceneTree>() && Engine::get_singleton()->is_editor_hint()) {
+	if (OS::get_singleton()->get_main_loop() &&
+			Object::cast_to<SceneTree>(OS::get_singleton()->get_main_loop()) &&
+			Engine::get_singleton()->is_editor_hint()) {
 		vsn->validate_input_default_values(); //force validate default values when editing on editor
 	}
 
@@ -336,7 +338,7 @@ void VisualScript::add_node(const StringName &p_func, int p_id, const Ref<Visual
 
 	Function &func = functions[p_func];
 
-	if (p_node->cast_to<VisualScriptFunction>()) {
+	if (Object::cast_to<VisualScriptFunction>(*p_node)) {
 		//the function indeed
 		ERR_EXPLAIN("A function node already has been set here.");
 		ERR_FAIL_COND(func.function_id >= 0);
@@ -393,7 +395,7 @@ void VisualScript::remove_node(const StringName &p_func, int p_id) {
 		}
 	}
 
-	if (func.nodes[p_id].node->cast_to<VisualScriptFunction>()) {
+	if (Object::cast_to<VisualScriptFunction>(func.nodes[p_id].node.ptr())) {
 		func.function_id = -1; //revert to invalid
 	}
 
@@ -1086,7 +1088,7 @@ int VisualScript::get_member_line(const StringName &p_member) const {
 #ifdef TOOLS_ENABLED
 	if (has_function(p_member)) {
 		for (Map<int, Function::NodeData>::Element *E = functions[p_member].nodes.front(); E; E = E->next()) {
-			if (E->get().node->cast_to<VisualScriptFunction>())
+			if (Object::cast_to<VisualScriptFunction>(E->get().node.ptr()))
 				return E->key();
 		}
 	}
@@ -2001,9 +2003,9 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 	max_input_args = 0;
 	max_output_args = 0;
 
-	if (p_owner->cast_to<Node>()) {
+	if (Object::cast_to<Node>(p_owner)) {
 		//turn on these if they exist and base is a node
-		Node *node = p_owner->cast_to<Node>();
+		Node *node = Object::cast_to<Node>(p_owner);
 		if (p_script->functions.has("_process"))
 			node->set_process(true);
 		if (p_script->functions.has("_fixed_process"))
@@ -2094,16 +2096,16 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 				}
 			}
 
-			if (node->cast_to<VisualScriptLocalVar>() || node->cast_to<VisualScriptLocalVarSet>()) {
+			if (Object::cast_to<VisualScriptLocalVar>(node.ptr()) || Object::cast_to<VisualScriptLocalVarSet>(*node)) {
 				//working memory is shared only for this node, for the same variables
 				Ref<VisualScriptLocalVar> vslv = node;
 
 				StringName var_name;
 
-				if (node->cast_to<VisualScriptLocalVar>())
-					var_name = String(node->cast_to<VisualScriptLocalVar>()->get_var_name()).strip_edges();
+				if (Object::cast_to<VisualScriptLocalVar>(*node))
+					var_name = String(Object::cast_to<VisualScriptLocalVar>(*node)->get_var_name()).strip_edges();
 				else
-					var_name = String(node->cast_to<VisualScriptLocalVarSet>()->get_var_name()).strip_edges();
+					var_name = String(Object::cast_to<VisualScriptLocalVarSet>(*node)->get_var_name()).strip_edges();
 
 				if (!local_var_indices.has(var_name)) {
 					local_var_indices[var_name] = function.max_stack;

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -422,7 +422,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 
 		for (int i = 0; i < graph->get_child_count(); i++) {
 
-			if (graph->get_child(i)->cast_to<GraphNode>()) {
+			if (Object::cast_to<GraphNode>(graph->get_child(i))) {
 				memdelete(graph->get_child(i));
 				i--;
 			}
@@ -506,7 +506,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 			gnode->set_show_close_button(true);
 		}
 
-		if (node->cast_to<VisualScriptExpression>()) {
+		if (Object::cast_to<VisualScriptExpression>(*node)) {
 
 			LineEdit *line_edit = memnew(LineEdit);
 			line_edit->set_text(node->get_text());
@@ -520,7 +520,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 			gnode->add_child(text);
 		}
 
-		if (node->cast_to<VisualScriptComment>()) {
+		if (Object::cast_to<VisualScriptExpression>(*node)) {
 			Ref<VisualScriptComment> vsc = node;
 			gnode->set_comment(true);
 			gnode->set_resizeable(true);
@@ -970,7 +970,7 @@ void VisualScriptEditor::_override_pressed(int p_id) {
 
 void VisualScriptEditor::_member_button(Object *p_item, int p_column, int p_button) {
 
-	TreeItem *ti = p_item->cast_to<TreeItem>();
+	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
 
 	TreeItem *root = members->get_root();
 
@@ -1117,8 +1117,8 @@ void VisualScriptEditor::_expression_text_changed(const String &p_text, int p_id
 	undo_redo->commit_action();
 
 	Node *node = graph->get_node(itos(p_id));
-	if (node->cast_to<Control>())
-		node->cast_to<Control>()->set_size(Vector2(1, 1)); //shrink if text is smaller
+	if (Object::cast_to<Control>(node))
+		Object::cast_to<Control>(node)->set_size(Vector2(1, 1)); //shrink if text is smaller
 
 	updating_graph = false;
 }
@@ -1253,7 +1253,7 @@ void VisualScriptEditor::_on_nodes_delete() {
 	List<int> to_erase;
 
 	for (int i = 0; i < graph->get_child_count(); i++) {
-		GraphNode *gn = graph->get_child(i)->cast_to<GraphNode>();
+		GraphNode *gn = Object::cast_to<GraphNode>(graph->get_child(i));
 		if (gn) {
 			if (gn->is_selected() && gn->is_close_button_visible()) {
 				to_erase.push_back(gn->get_name().operator String().to_int());
@@ -1302,7 +1302,7 @@ void VisualScriptEditor::_on_nodes_duplicate() {
 	List<int> to_duplicate;
 
 	for (int i = 0; i < graph->get_child_count(); i++) {
-		GraphNode *gn = graph->get_child(i)->cast_to<GraphNode>();
+		GraphNode *gn = Object::cast_to<GraphNode>(graph->get_child(i));
 		if (gn) {
 			if (gn->is_selected() && gn->is_close_button_visible()) {
 				to_duplicate.push_back(gn->get_name().operator String().to_int());
@@ -1335,7 +1335,7 @@ void VisualScriptEditor::_on_nodes_duplicate() {
 	undo_redo->commit_action();
 
 	for (int i = 0; i < graph->get_child_count(); i++) {
-		GraphNode *gn = graph->get_child(i)->cast_to<GraphNode>();
+		GraphNode *gn = Object::cast_to<GraphNode>(graph->get_child(i));
 		if (gn) {
 			int id = gn->get_name().operator String().to_int();
 			gn->set_selected(to_select.has(id));
@@ -1799,7 +1799,7 @@ void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 			if (!obj)
 				return;
 
-			Node *node = obj->cast_to<Node>();
+			Node *node = Object::cast_to<Node>(obj);
 			Vector2 ofs = graph->get_scroll_ofs() + p_point;
 
 			if (graph->is_using_snap()) {
@@ -1918,7 +1918,7 @@ void VisualScriptEditor::_selected_method(const String &p_method) {
 
 void VisualScriptEditor::_draw_color_over_button(Object *obj, Color p_color) {
 
-	Button *button = obj->cast_to<Button>();
+	Button *button = Object::cast_to<Button>(obj);
 	if (!button)
 		return;
 
@@ -1937,7 +1937,7 @@ void VisualScriptEditor::_button_resource_previewed(const String &p_path, const 
 	if (!obj)
 		return;
 
-	Button *b = obj->cast_to<Button>();
+	Button *b = Object::cast_to<Button>(obj);
 	ERR_FAIL_COND(!b);
 
 	if (p_preview.is_null()) {
@@ -2050,9 +2050,7 @@ void VisualScriptEditor::set_edit_state(const Variant &p_state) {
 void VisualScriptEditor::_center_on_node(int p_id) {
 
 	Node *n = graph->get_node(itos(p_id));
-	if (!n)
-		return;
-	GraphNode *gn = n->cast_to<GraphNode>();
+	GraphNode *gn = Object::cast_to<GraphNode>(n);
 	if (gn) {
 		gn->set_selected(true);
 		Vector2 new_scroll = gn->get_offset() - graph->get_size() * 0.5 + gn->get_size() * 0.5;
@@ -2270,8 +2268,8 @@ void VisualScriptEditor::_move_node(String func, int p_id, const Vector2 &p_to) 
 
 	if (func == String(edited_func)) {
 		Node *node = graph->get_node(itos(p_id));
-		if (node && node->cast_to<GraphNode>())
-			node->cast_to<GraphNode>()->set_offset(p_to);
+		if (Object::cast_to<GraphNode>(node))
+			Object::cast_to<GraphNode>(node)->set_offset(p_to);
 	}
 	script->set_node_pos(edited_func, p_id, p_to / EDSCALE);
 }
@@ -2421,10 +2419,7 @@ void VisualScriptEditor::_graph_disconnected(const String &p_from, int p_from_sl
 void VisualScriptEditor::_graph_connect_to_empty(const String &p_from, int p_from_slot, const Vector2 &p_release_pos) {
 
 	Node *node = graph->get_node(p_from);
-	if (!node)
-		return;
-
-	GraphNode *gn = node->cast_to<GraphNode>();
+	GraphNode *gn = Object::cast_to<GraphNode>(node);
 	if (!gn)
 		return;
 
@@ -2691,21 +2686,21 @@ void VisualScriptEditor::_selected_connect_node_method_or_setget(const String &p
 
 	Ref<VisualScriptNode> vsn = script->get_node(edited_func, port_action_new_node);
 
-	if (vsn->cast_to<VisualScriptFunctionCall>()) {
+	if (Object::cast_to<VisualScriptFunctionCall>(*vsn)) {
 
 		Ref<VisualScriptFunctionCall> vsfc = vsn;
 		vsfc->set_function(p_text);
 		script->data_connect(edited_func, port_action_node, port_action_output, port_action_new_node, 0);
 	}
 
-	if (vsn->cast_to<VisualScriptPropertySet>()) {
+	if (Object::cast_to<VisualScriptPropertySet>(*vsn)) {
 
 		Ref<VisualScriptPropertySet> vsp = vsn;
 		vsp->set_property(p_text);
 		script->data_connect(edited_func, port_action_node, port_action_output, port_action_new_node, 0);
 	}
 
-	if (vsn->cast_to<VisualScriptPropertyGet>()) {
+	if (Object::cast_to<VisualScriptPropertyGet>(*vsn)) {
 
 		Ref<VisualScriptPropertyGet> vsp = vsn;
 		vsp->set_property(p_text);
@@ -2752,7 +2747,7 @@ void VisualScriptEditor::_default_value_edited(Node *p_button, int p_id, int p_i
 		existing = Variant::construct(pinfo.type, &existingp, 1, ce, false);
 	}
 
-	default_value_edit->set_position(p_button->cast_to<Control>()->get_global_position() + Vector2(0, p_button->cast_to<Control>()->get_size().y));
+	default_value_edit->set_position(Object::cast_to<Control>(p_button)->get_global_position() + Vector2(0, Object::cast_to<Control>(p_button)->get_size().y));
 	default_value_edit->set_size(Size2(1, 1));
 	if (default_value_edit->edit(NULL, pinfo.name, pinfo.type, existing, pinfo.hint, pinfo.hint_string)) {
 		if (pinfo.hint == PROPERTY_HINT_MULTILINE_TEXT)
@@ -2818,9 +2813,7 @@ void VisualScriptEditor::_comment_node_resized(const Vector2 &p_new_size, int p_
 		return;
 
 	Node *node = graph->get_node(itos(p_node));
-	if (!node)
-		return;
-	GraphNode *gn = node->cast_to<GraphNode>();
+	GraphNode *gn = Object::cast_to<GraphNode>(node);
 	if (!gn)
 		return;
 
@@ -2849,7 +2842,7 @@ void VisualScriptEditor::_menu_option(int p_what) {
 
 			List<String> reselect;
 			for (int i = 0; i < graph->get_child_count(); i++) {
-				GraphNode *gn = graph->get_child(i)->cast_to<GraphNode>();
+				GraphNode *gn = Object::cast_to<GraphNode>(graph->get_child(i));
 				if (gn) {
 					if (gn->is_selected()) {
 						int id = String(gn->get_name()).to_int();
@@ -2865,7 +2858,7 @@ void VisualScriptEditor::_menu_option(int p_what) {
 			_update_graph();
 
 			for (List<String>::Element *E = reselect.front(); E; E = E->next()) {
-				GraphNode *gn = graph->get_node(E->get())->cast_to<GraphNode>();
+				GraphNode *gn = Object::cast_to<GraphNode>(graph->get_node(E->get()));
 				gn->set_selected(true);
 			}
 
@@ -2886,13 +2879,13 @@ void VisualScriptEditor::_menu_option(int p_what) {
 			clipboard->sequence_connections.clear();
 
 			for (int i = 0; i < graph->get_child_count(); i++) {
-				GraphNode *gn = graph->get_child(i)->cast_to<GraphNode>();
+				GraphNode *gn = Object::cast_to<GraphNode>(graph->get_child(i));
 				if (gn) {
 					if (gn->is_selected()) {
 
 						int id = String(gn->get_name()).to_int();
 						Ref<VisualScriptNode> node = script->get_node(edited_func, id);
-						if (node->cast_to<VisualScriptFunction>()) {
+						if (Object::cast_to<VisualScriptFunction>(*node)) {
 							EditorNode::get_singleton()->show_warning("Can't copy the function node.");
 							return;
 						}
@@ -3000,7 +2993,7 @@ void VisualScriptEditor::_menu_option(int p_what) {
 			undo_redo->commit_action();
 
 			for (int i = 0; i < graph->get_child_count(); i++) {
-				GraphNode *gn = graph->get_child(i)->cast_to<GraphNode>();
+				GraphNode *gn = Object::cast_to<GraphNode>(graph->get_child(i));
 				if (gn) {
 					int id = gn->get_name().operator String().to_int();
 					gn->set_selected(to_select.has(id));
@@ -3393,7 +3386,7 @@ VisualScriptEditor::~VisualScriptEditor() {
 
 static ScriptEditorBase *create_editor(const Ref<Script> &p_script) {
 
-	if (p_script->cast_to<VisualScript>()) {
+	if (Object::cast_to<VisualScript>(*p_script)) {
 		return memnew(VisualScriptEditor);
 	}
 

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -85,10 +85,7 @@ Node *VisualScriptFunctionCall::_get_base_node() const {
 		return NULL;
 
 	MainLoop *main_loop = OS::get_singleton()->get_main_loop();
-	if (!main_loop)
-		return NULL;
-
-	SceneTree *scene_tree = main_loop->cast_to<SceneTree>();
+	SceneTree *scene_tree = Object::cast_to<SceneTree>(main_loop);
 
 	if (!scene_tree)
 		return NULL;
@@ -776,7 +773,7 @@ public:
 		if (!p_base)
 			return false;
 
-		Node *node = p_base->cast_to<Node>();
+		Node *node = Object::cast_to<Node>(p_base);
 		if (!node)
 			return false;
 
@@ -817,7 +814,7 @@ public:
 			} break;
 			case VisualScriptFunctionCall::CALL_MODE_NODE_PATH: {
 
-				Node *node = instance->get_owner_ptr()->cast_to<Node>();
+				Node *node = Object::cast_to<Node>(instance->get_owner_ptr());
 				if (!node) {
 					r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD;
 					r_error_str = "Base object is not a Node!";
@@ -961,10 +958,8 @@ Node *VisualScriptPropertySet::_get_base_node() const {
 		return NULL;
 
 	MainLoop *main_loop = OS::get_singleton()->get_main_loop();
-	if (!main_loop)
-		return NULL;
 
-	SceneTree *scene_tree = main_loop->cast_to<SceneTree>();
+	SceneTree *scene_tree = Object::cast_to<SceneTree>(main_loop);
 
 	if (!scene_tree)
 		return NULL;
@@ -1159,9 +1154,7 @@ String VisualScriptPropertySet::get_base_script() const {
 
 void VisualScriptPropertySet::_update_cache() {
 
-	if (!OS::get_singleton()->get_main_loop())
-		return;
-	if (!OS::get_singleton()->get_main_loop()->cast_to<SceneTree>())
+	if (!Object::cast_to<SceneTree>(OS::get_singleton()->get_main_loop()))
 		return;
 
 	if (!Engine::get_singleton()->is_editor_hint()) //only update cache if editor exists, it's pointless otherwise
@@ -1595,7 +1588,7 @@ public:
 			} break;
 			case VisualScriptPropertySet::CALL_MODE_NODE_PATH: {
 
-				Node *node = instance->get_owner_ptr()->cast_to<Node>();
+				Node *node = Object::cast_to<Node>(instance->get_owner_ptr());
 				if (!node) {
 					r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD;
 					r_error_str = "Base object is not a Node!";
@@ -1730,10 +1723,8 @@ Node *VisualScriptPropertyGet::_get_base_node() const {
 		return NULL;
 
 	MainLoop *main_loop = OS::get_singleton()->get_main_loop();
-	if (!main_loop)
-		return NULL;
 
-	SceneTree *scene_tree = main_loop->cast_to<SceneTree>();
+	SceneTree *scene_tree = Object::cast_to<SceneTree>(main_loop);
 
 	if (!scene_tree)
 		return NULL;
@@ -2242,7 +2233,7 @@ public:
 			} break;
 			case VisualScriptPropertyGet::CALL_MODE_NODE_PATH: {
 
-				Node *node = instance->get_owner_ptr()->cast_to<Node>();
+				Node *node = Object::cast_to<Node>(instance->get_owner_ptr());
 				if (!node) {
 					r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD;
 					r_error_str = RTR("Base object is not a Node!");

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -2079,7 +2079,7 @@ public:
 
 	virtual int step(const Variant **p_inputs, Variant **p_outputs, StartMode p_start_mode, Variant *p_working_mem, Variant::CallError &r_error, String &r_error_str) {
 
-		Node *node = instance->get_owner_ptr()->cast_to<Node>();
+		Node *node = Object::cast_to<Node>(instance->get_owner_ptr());
 		if (!node) {
 			r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD;
 			r_error_str = "Base object is not a Node!";
@@ -2143,10 +2143,7 @@ VisualScriptSceneNode::TypeGuess VisualScriptSceneNode::guess_output_type(TypeGu
 		return tg;
 
 	MainLoop *main_loop = OS::get_singleton()->get_main_loop();
-	if (!main_loop)
-		return tg;
-
-	SceneTree *scene_tree = main_loop->cast_to<SceneTree>();
+	SceneTree *scene_tree = Object::cast_to<SceneTree>(main_loop);
 
 	if (!scene_tree)
 		return tg;
@@ -2181,10 +2178,7 @@ void VisualScriptSceneNode::_validate_property(PropertyInfo &property) const {
 			return;
 
 		MainLoop *main_loop = OS::get_singleton()->get_main_loop();
-		if (!main_loop)
-			return;
-
-		SceneTree *scene_tree = main_loop->cast_to<SceneTree>();
+		SceneTree *scene_tree = Object::cast_to<SceneTree>(main_loop);
 
 		if (!scene_tree)
 			return;
@@ -2274,7 +2268,7 @@ public:
 
 	virtual int step(const Variant **p_inputs, Variant **p_outputs, StartMode p_start_mode, Variant *p_working_mem, Variant::CallError &r_error, String &r_error_str) {
 
-		Node *node = instance->get_owner_ptr()->cast_to<Node>();
+		Node *node = Object::cast_to<Node>(instance->get_owner_ptr());
 		if (!node) {
 			r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD;
 			r_error_str = "Base object is not a Node!";

--- a/modules/visual_script/visual_script_yield_nodes.cpp
+++ b/modules/visual_script/visual_script_yield_nodes.cpp
@@ -105,7 +105,7 @@ public:
 		} else {
 			//yield
 
-			SceneTree *tree = OS::get_singleton()->get_main_loop()->cast_to<SceneTree>();
+			SceneTree *tree = Object::cast_to<SceneTree>(OS::get_singleton()->get_main_loop());
 			if (!tree) {
 				r_error_str = "Main Loop is not SceneTree";
 				r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD;
@@ -252,10 +252,7 @@ Node *VisualScriptYieldSignal::_get_base_node() const {
 		return NULL;
 
 	MainLoop *main_loop = OS::get_singleton()->get_main_loop();
-	if (!main_loop)
-		return NULL;
-
-	SceneTree *scene_tree = main_loop->cast_to<SceneTree>();
+	SceneTree *scene_tree = Object::cast_to<SceneTree>(main_loop);
 
 	if (!scene_tree)
 		return NULL;
@@ -530,7 +527,7 @@ public:
 				} break;
 				case VisualScriptYieldSignal::CALL_MODE_NODE_PATH: {
 
-					Node *node = instance->get_owner_ptr()->cast_to<Node>();
+					Node *node = Object::cast_to<Node>(instance->get_owner_ptr());
 					if (!node) {
 						r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD;
 						r_error_str = "Base object is not a Node!";

--- a/platform/android/java_class_wrapper.cpp
+++ b/platform/android/java_class_wrapper.cpp
@@ -112,7 +112,7 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 
 						Ref<Reference> ref = *p_args[i];
 						if (!ref.is_null()) {
-							if (ref->cast_to<JavaObject>()) {
+							if (Object::cast_to<JavaObject>(ref)) {
 
 								Ref<JavaObject> jo = ref;
 								//could be faster

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -869,19 +869,19 @@ class EditorExportUWP : public EditorExportPlatform {
 		StreamTexture *image;
 
 		if (p_path.find("StoreLogo") != -1) {
-			image = p_preset->get("images/store_logo").is_zero() ? NULL : ((Object *)p_preset->get("images/store_logo"))->cast_to<StreamTexture>();
+			image = p_preset->get("images/store_logo").is_zero() ? NULL : Object::cast_to<StreamTexture>(((Object *)p_preset->get("images/store_logo")));
 		} else if (p_path.find("Square44x44Logo") != -1) {
-			image = p_preset->get("images/square44x44_logo").is_zero() ? NULL : ((Object *)p_preset->get("images/square44x44_logo"))->cast_to<StreamTexture>();
+			image = p_preset->get("images/square44x44_logo").is_zero() ? NULL : Object::cast_to<StreamTexture>(((Object *)p_preset->get("images/square44x44_logo")));
 		} else if (p_path.find("Square71x71Logo") != -1) {
-			image = p_preset->get("images/square71x71_logo").is_zero() ? NULL : ((Object *)p_preset->get("images/square71x71_logo"))->cast_to<StreamTexture>();
+			image = p_preset->get("images/square71x71_logo").is_zero() ? NULL : Object::cast_to<StreamTexture>(((Object *)p_preset->get("images/square71x71_logo")));
 		} else if (p_path.find("Square150x150Logo") != -1) {
-			image = p_preset->get("images/square150x150_logo").is_zero() ? NULL : ((Object *)p_preset->get("images/square150x150_logo"))->cast_to<StreamTexture>();
+			image = p_preset->get("images/square150x150_logo").is_zero() ? NULL : Object::cast_to<StreamTexture>(((Object *)p_preset->get("images/square150x150_logo")));
 		} else if (p_path.find("Square310x310Logo") != -1) {
-			image = p_preset->get("images/square310x310_logo").is_zero() ? NULL : ((Object *)p_preset->get("images/square310x310_logo"))->cast_to<StreamTexture>();
+			image = p_preset->get("images/square310x310_logo").is_zero() ? NULL : Object::cast_to<StreamTexture>(((Object *)p_preset->get("images/square310x310_logo")));
 		} else if (p_path.find("Wide310x150Logo") != -1) {
-			image = p_preset->get("images/wide310x150_logo").is_zero() ? NULL : ((Object *)p_preset->get("images/wide310x150_logo"))->cast_to<StreamTexture>();
+			image = p_preset->get("images/wide310x150_logo").is_zero() ? NULL : Object::cast_to<StreamTexture>(((Object *)p_preset->get("images/wide310x150_logo")));
 		} else if (p_path.find("SplashScreen") != -1) {
-			image = p_preset->get("images/splash_screen").is_zero() ? NULL : ((Object *)p_preset->get("images/splash_screen"))->cast_to<StreamTexture>();
+			image = p_preset->get("images/splash_screen").is_zero() ? NULL : Object::cast_to<StreamTexture>(((Object *)p_preset->get("images/splash_screen")));
 		}
 
 		if (!image) return data;
@@ -1162,37 +1162,37 @@ public:
 			err += "\nInvalid background color.";
 		}
 
-		if (!p_preset->get("images/store_logo").is_zero() && !_valid_image(((Object *)p_preset->get("images/store_logo"))->cast_to<StreamTexture>(), 50, 50)) {
+		if (!p_preset->get("images/store_logo").is_zero() && !_valid_image((Object::cast_to<StreamTexture>((Object *)p_preset->get("images/store_logo"))), 50, 50)) {
 			valid = false;
 			err += "\nInvalid Store Logo image dimensions (should be 50x50).";
 		}
 
-		if (!p_preset->get("images/square44x44_logo").is_zero() && !_valid_image(((Object *)p_preset->get("images/square44x44_logo"))->cast_to<StreamTexture>(), 44, 44)) {
+		if (!p_preset->get("images/square44x44_logo").is_zero() && !_valid_image((Object::cast_to<StreamTexture>((Object *)p_preset->get("images/square44x44_logo"))), 44, 44)) {
 			valid = false;
 			err += "\nInvalid square 44x44 logo image dimensions (should be 44x44).";
 		}
 
-		if (!p_preset->get("images/square71x71_logo").is_zero() && !_valid_image(((Object *)p_preset->get("images/square71x71_logo"))->cast_to<StreamTexture>(), 71, 71)) {
+		if (!p_preset->get("images/square71x71_logo").is_zero() && !_valid_image((Object::cast_to<StreamTexture>((Object *)p_preset->get("images/square71x71_logo"))), 71, 71)) {
 			valid = false;
 			err += "\nInvalid square 71x71 logo image dimensions (should be 71x71).";
 		}
 
-		if (!p_preset->get("images/square150x150_logo").is_zero() && !_valid_image(((Object *)p_preset->get("images/square150x150_logo"))->cast_to<StreamTexture>(), 150, 0)) {
+		if (!p_preset->get("images/square150x150_logo").is_zero() && !_valid_image((Object::cast_to<StreamTexture>((Object *)p_preset->get("images/square150x150_logo"))), 150, 0)) {
 			valid = false;
 			err += "\nInvalid square 150x150 logo image dimensions (should be 150x150).";
 		}
 
-		if (!p_preset->get("images/square310x310_logo").is_zero() && !_valid_image(((Object *)p_preset->get("images/square310x310_logo"))->cast_to<StreamTexture>(), 310, 310)) {
+		if (!p_preset->get("images/square310x310_logo").is_zero() && !_valid_image((Object::cast_to<StreamTexture>((Object *)p_preset->get("images/square310x310_logo"))), 310, 310)) {
 			valid = false;
 			err += "\nInvalid square 310x310 logo image dimensions (should be 310x310).";
 		}
 
-		if (!p_preset->get("images/wide310x150_logo").is_zero() && !_valid_image(((Object *)p_preset->get("images/wide310x150_logo"))->cast_to<StreamTexture>(), 310, 150)) {
+		if (!p_preset->get("images/wide310x150_logo").is_zero() && !_valid_image((Object::cast_to<StreamTexture>((Object *)p_preset->get("images/wide310x150_logo"))), 310, 150)) {
 			valid = false;
 			err += "\nInvalid wide 310x150 logo image dimensions (should be 310x150).";
 		}
 
-		if (!p_preset->get("images/splash_screen").is_zero() && !_valid_image(((Object *)p_preset->get("images/splash_screen"))->cast_to<StreamTexture>(), 620, 300)) {
+		if (!p_preset->get("images/splash_screen").is_zero() && !_valid_image((Object::cast_to<StreamTexture>((Object *)p_preset->get("images/splash_screen"))), 620, 300)) {
 			valid = false;
 			err += "\nInvalid splash screen image dimensions (should be 620x300).";
 		}

--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -116,7 +116,7 @@ real_t Area2D::get_priority() const {
 void Area2D::_body_enter_tree(ObjectID p_id) {
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 
 	Map<ObjectID, BodyState>::Element *E = body_map.find(p_id);
@@ -134,7 +134,7 @@ void Area2D::_body_enter_tree(ObjectID p_id) {
 void Area2D::_body_exit_tree(ObjectID p_id) {
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 	Map<ObjectID, BodyState>::Element *E = body_map.find(p_id);
 	ERR_FAIL_COND(!E);
@@ -153,7 +153,7 @@ void Area2D::_body_inout(int p_status, const RID &p_body, int p_instance, int p_
 	ObjectID objid = p_instance;
 
 	Object *obj = ObjectDB::get_instance(objid);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 
 	Map<ObjectID, BodyState>::Element *E = body_map.find(objid);
 
@@ -217,7 +217,7 @@ void Area2D::_body_inout(int p_status, const RID &p_body, int p_instance, int p_
 void Area2D::_area_enter_tree(ObjectID p_id) {
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 
 	Map<ObjectID, AreaState>::Element *E = area_map.find(p_id);
@@ -235,7 +235,7 @@ void Area2D::_area_enter_tree(ObjectID p_id) {
 void Area2D::_area_exit_tree(ObjectID p_id) {
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 	Map<ObjectID, AreaState>::Element *E = area_map.find(p_id);
 	ERR_FAIL_COND(!E);
@@ -254,7 +254,7 @@ void Area2D::_area_inout(int p_status, const RID &p_area, int p_instance, int p_
 	ObjectID objid = p_instance;
 
 	Object *obj = ObjectDB::get_instance(objid);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 
 	Map<ObjectID, AreaState>::Element *E = area_map.find(objid);
 
@@ -330,7 +330,7 @@ void Area2D::_clear_monitoring() {
 		for (Map<ObjectID, BodyState>::Element *E = bmcopy.front(); E; E = E->next()) {
 
 			Object *obj = ObjectDB::get_instance(E->key());
-			Node *node = obj ? obj->cast_to<Node>() : NULL;
+			Node *node = Object::cast_to<Node>(obj);
 
 			if (!node) //node may have been deleted in previous frame or at other legiminate point
 				continue;
@@ -360,7 +360,7 @@ void Area2D::_clear_monitoring() {
 		for (Map<ObjectID, AreaState>::Element *E = bmcopy.front(); E; E = E->next()) {
 
 			Object *obj = ObjectDB::get_instance(E->key());
-			Node *node = obj ? obj->cast_to<Node>() : NULL;
+			Node *node = Object::cast_to<Node>(obj);
 
 			if (!node) //node may have been deleted in previous frame or at other legiminate point
 				continue;

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -157,10 +157,8 @@ void AudioStreamPlayer2D::_notification(int p_what) {
 			int areas = space_state->intersect_point(global_pos, sr, MAX_INTERSECT_AREAS, Set<RID>(), area_mask, Physics2DDirectSpaceState::TYPE_MASK_AREA);
 
 			for (int i = 0; i < areas; i++) {
-				if (!sr[i].collider)
-					continue;
 
-				Area2D *area2d = sr[i].collider->cast_to<Area2D>();
+				Area2D *area2d = Object::cast_to<Area2D>(sr[i].collider);
 				if (!area2d)
 					continue;
 

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -577,7 +577,7 @@ void Camera2D::set_custom_viewport(Node *p_viewport) {
 		remove_from_group(canvas_group_name);
 	}
 
-	custom_viewport = p_viewport->cast_to<Viewport>();
+	custom_viewport = Object::cast_to<Viewport>(p_viewport);
 
 	if (custom_viewport) {
 		custom_viewport_id = custom_viewport->get_instance_id();

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -260,7 +260,7 @@ void CanvasItem::_propagate_visibility_changed(bool p_visible) {
 
 	for (int i = 0; i < get_child_count(); i++) {
 
-		CanvasItem *c = get_child(i)->cast_to<CanvasItem>();
+		CanvasItem *c = Object::cast_to<CanvasItem>(get_child(i));
 
 		if (c && c->visible) //should the toplevels stop propagation? i think so but..
 			c->_propagate_visibility_changed(p_visible);
@@ -398,7 +398,7 @@ void CanvasItem::_toplevel_raise_self() {
 
 void CanvasItem::_enter_canvas() {
 
-	if ((!get_parent() || !get_parent()->cast_to<CanvasItem>()) || toplevel) {
+	if ((!Object::cast_to<CanvasItem>(get_parent())) || toplevel) {
 
 		Node *n = this;
 
@@ -406,7 +406,7 @@ void CanvasItem::_enter_canvas() {
 
 		while (n) {
 
-			canvas_layer = n->cast_to<CanvasLayer>();
+			canvas_layer = Object::cast_to<CanvasLayer>(n);
 			if (canvas_layer) {
 				break;
 			}
@@ -460,7 +460,7 @@ void CanvasItem::_notification(int p_what) {
 
 			first_draw = true;
 			if (get_parent()) {
-				CanvasItem *ci = get_parent()->cast_to<CanvasItem>();
+				CanvasItem *ci = Object::cast_to<CanvasItem>(get_parent());
 				if (ci)
 					C = ci->children_items.push_back(this);
 			}
@@ -488,7 +488,7 @@ void CanvasItem::_notification(int p_what) {
 				get_tree()->xform_change_list.remove(&xform_change);
 			_exit_canvas();
 			if (C) {
-				get_parent()->cast_to<CanvasItem>()->children_items.erase(C);
+				Object::cast_to<CanvasItem>(get_parent())->children_items.erase(C);
 				C = NULL;
 			}
 			global_invalid = true;
@@ -565,11 +565,7 @@ CanvasItem *CanvasItem::get_parent_item() const {
 	if (toplevel)
 		return NULL;
 
-	Node *parent = get_parent();
-	if (!parent)
-		return NULL;
-
-	return parent->cast_to<CanvasItem>();
+	return Object::cast_to<CanvasItem>(get_parent());
 }
 
 void CanvasItem::set_self_modulate(const Color &p_self_modulate) {
@@ -830,8 +826,8 @@ RID CanvasItem::get_canvas() const {
 CanvasItem *CanvasItem::get_toplevel() const {
 
 	CanvasItem *ci = const_cast<CanvasItem *>(this);
-	while (!ci->toplevel && ci->get_parent() && ci->get_parent()->cast_to<CanvasItem>()) {
-		ci = ci->get_parent()->cast_to<CanvasItem>();
+	while (!ci->toplevel && Object::cast_to<CanvasItem>(ci->get_parent())) {
+		ci = Object::cast_to<CanvasItem>(ci->get_parent());
 	}
 
 	return ci;
@@ -1062,8 +1058,8 @@ Transform2D CanvasItem::get_canvas_transform() const {
 
 	if (canvas_layer)
 		return canvas_layer->get_transform();
-	else if (get_parent()->cast_to<CanvasItem>())
-		return get_parent()->cast_to<CanvasItem>()->get_canvas_transform();
+	else if (Object::cast_to<CanvasItem>(get_parent()))
+		return Object::cast_to<CanvasItem>(get_parent())->get_canvas_transform();
 	else
 		return get_viewport()->get_canvas_transform();
 }
@@ -1122,7 +1118,7 @@ Rect2 CanvasItem::get_item_and_children_rect() const {
 	Rect2 rect = get_item_rect();
 
 	for (int i = 0; i < get_child_count(); i++) {
-		CanvasItem *c = get_child(i)->cast_to<CanvasItem>();
+		CanvasItem *c = Object::cast_to<CanvasItem>(get_child(i));
 		if (c) {
 			Rect2 sir = c->get_transform().xform(c->get_item_and_children_rect());
 			rect = rect.merge(sir);

--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -126,7 +126,7 @@ void CollisionPolygon2D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_PARENTED: {
 
-			parent = get_parent()->cast_to<CollisionObject2D>();
+			parent = Object::cast_to<CollisionObject2D>(get_parent());
 			if (parent) {
 				owner_id = parent->create_shape_owner(this);
 				_build_polygon();
@@ -257,7 +257,7 @@ Rect2 CollisionPolygon2D::get_item_rect() const {
 
 String CollisionPolygon2D::get_configuration_warning() const {
 
-	if (!get_parent()->cast_to<CollisionObject2D>()) {
+	if (!Object::cast_to<CollisionObject2D>(get_parent())) {
 		return TTR("CollisionPolygon2D only serves to provide a collision shape to a CollisionObject2D derived node. Please only use it as a child of Area2D, StaticBody2D, RigidBody2D, KinematicBody2D, etc. to give them a shape.");
 	}
 

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -50,7 +50,7 @@ void CollisionShape2D::_notification(int p_what) {
 
 		case NOTIFICATION_PARENTED: {
 
-			parent = get_parent()->cast_to<CollisionObject2D>();
+			parent = Object::cast_to<CollisionObject2D>(get_parent());
 			if (parent) {
 				owner_id = parent->create_shape_owner(this);
 				if (shape.is_valid()) {
@@ -165,7 +165,7 @@ Rect2 CollisionShape2D::get_item_rect() const {
 
 String CollisionShape2D::get_configuration_warning() const {
 
-	if (!get_parent()->cast_to<CollisionObject2D>()) {
+	if (!Object::cast_to<CollisionObject2D>(get_parent())) {
 		return TTR("CollisionShape2D only serves to provide a collision shape to a CollisionObject2D derived node. Please only use it as a child of Area2D, StaticBody2D, RigidBody2D, KinematicBody2D, etc. to give them a shape.");
 	}
 

--- a/scene/2d/joints_2d.cpp
+++ b/scene/2d/joints_2d.cpp
@@ -172,8 +172,8 @@ RID PinJoint2D::_configure_joint() {
 	if (!node_a && !node_b)
 		return RID();
 
-	PhysicsBody2D *body_a = node_a ? node_a->cast_to<PhysicsBody2D>() : (PhysicsBody2D *)NULL;
-	PhysicsBody2D *body_b = node_b ? node_b->cast_to<PhysicsBody2D>() : (PhysicsBody2D *)NULL;
+	PhysicsBody2D *body_a = Object::cast_to<PhysicsBody2D>(node_a);
+	PhysicsBody2D *body_b = Object::cast_to<PhysicsBody2D>(node_b);
 
 	if (!body_a && !body_b)
 		return RID();
@@ -249,8 +249,8 @@ RID GrooveJoint2D::_configure_joint() {
 	if (!node_a || !node_b)
 		return RID();
 
-	PhysicsBody2D *body_a = node_a->cast_to<PhysicsBody2D>();
-	PhysicsBody2D *body_b = node_b->cast_to<PhysicsBody2D>();
+	PhysicsBody2D *body_a = Object::cast_to<PhysicsBody2D>(node_a);
+	PhysicsBody2D *body_b = Object::cast_to<PhysicsBody2D>(node_b);
 
 	if (!body_a || !body_b)
 		return RID();
@@ -338,8 +338,8 @@ RID DampedSpringJoint2D::_configure_joint() {
 	if (!node_a || !node_b)
 		return RID();
 
-	PhysicsBody2D *body_a = node_a->cast_to<PhysicsBody2D>();
-	PhysicsBody2D *body_b = node_b->cast_to<PhysicsBody2D>();
+	PhysicsBody2D *body_a = Object::cast_to<PhysicsBody2D>(node_a);
+	PhysicsBody2D *body_b = Object::cast_to<PhysicsBody2D>(node_b);
 
 	if (!body_a || !body_b)
 		return RID();

--- a/scene/2d/navigation_polygon.cpp
+++ b/scene/2d/navigation_polygon.cpp
@@ -319,7 +319,7 @@ void NavigationPolygonInstance::_notification(int p_what) {
 			Node2D *c = this;
 			while (c) {
 
-				navigation = c->cast_to<Navigation2D>();
+				navigation = Object::cast_to<Navigation2D>(c);
 				if (navigation) {
 
 					if (enabled && navpoly.is_valid()) {
@@ -329,7 +329,7 @@ void NavigationPolygonInstance::_notification(int p_what) {
 					break;
 				}
 
-				c = c->get_parent()->cast_to<Node2D>();
+				c = Object::cast_to<Node2D>(get_parent());
 			}
 
 		} break;
@@ -448,11 +448,11 @@ String NavigationPolygonInstance::get_configuration_warning() const {
 	const Node2D *c = this;
 	while (c) {
 
-		if (c->cast_to<Navigation2D>()) {
+		if (Object::cast_to<Navigation2D>(c)) {
 			return String();
 		}
 
-		c = c->get_parent()->cast_to<Node2D>();
+		c = Object::cast_to<Node2D>(get_parent());
 	}
 
 	return TTR("NavigationPolygonInstance must be a child or grandchild to a Navigation2D node. It only provides navigation data.");

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -379,7 +379,7 @@ Transform2D Node2D::get_relative_transform_to_parent(const Node *p_parent) const
 	if (p_parent == this)
 		return Transform2D();
 
-	Node2D *parent_2d = get_parent()->cast_to<Node2D>();
+	Node2D *parent_2d = Object::cast_to<Node2D>(get_parent());
 
 	ERR_FAIL_COND_V(!parent_2d, Transform2D());
 	if (p_parent == parent_2d)

--- a/scene/2d/parallax_background.cpp
+++ b/scene/2d/parallax_background.cpp
@@ -101,7 +101,7 @@ void ParallaxBackground::_update_scroll() {
 
 	for (int i = 0; i < get_child_count(); i++) {
 
-		ParallaxLayer *l = get_child(i)->cast_to<ParallaxLayer>();
+		ParallaxLayer *l = Object::cast_to<ParallaxLayer>(get_child(i));
 		if (!l)
 			continue;
 

--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -36,11 +36,8 @@ void ParallaxLayer::set_motion_scale(const Size2 &p_scale) {
 
 	motion_scale = p_scale;
 
-	if (!get_parent())
-		return;
-
-	ParallaxBackground *pb = get_parent()->cast_to<ParallaxBackground>();
-	if (is_inside_tree() && pb) {
+	ParallaxBackground *pb = Object::cast_to<ParallaxBackground>(get_parent());
+	if (pb && is_inside_tree()) {
 		Vector2 ofs = pb->get_final_offset();
 		float scale = pb->get_scroll_scale();
 		set_base_offset_and_scale(ofs, scale);
@@ -56,11 +53,8 @@ void ParallaxLayer::set_motion_offset(const Size2 &p_offset) {
 
 	motion_offset = p_offset;
 
-	if (!get_parent())
-		return;
-
-	ParallaxBackground *pb = get_parent()->cast_to<ParallaxBackground>();
-	if (is_inside_tree() && pb) {
+	ParallaxBackground *pb = Object::cast_to<ParallaxBackground>(get_parent());
+	if (pb && is_inside_tree()) {
 		Vector2 ofs = pb->get_final_offset();
 		float scale = pb->get_scroll_scale();
 		set_base_offset_and_scale(ofs, scale);
@@ -74,10 +68,7 @@ Size2 ParallaxLayer::get_motion_offset() const {
 
 void ParallaxLayer::_update_mirroring() {
 
-	if (!get_parent())
-		return;
-
-	ParallaxBackground *pb = get_parent()->cast_to<ParallaxBackground>();
+	ParallaxBackground *pb = Object::cast_to<ParallaxBackground>(get_parent());
 	if (pb) {
 
 		RID c = pb->get_world_2d()->get_canvas();
@@ -139,7 +130,7 @@ void ParallaxLayer::set_base_offset_and_scale(const Point2 &p_offset, float p_sc
 
 String ParallaxLayer::get_configuration_warning() const {
 
-	if (!get_parent() || !get_parent()->cast_to<ParallaxBackground>()) {
+	if (!Object::cast_to<ParallaxBackground>(get_parent())) {
 		return TTR("ParallaxLayer node only works when set as child of a ParallaxBackground node.");
 	}
 

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -137,13 +137,8 @@ void PathFollow2D::_notification(int p_what) {
 
 		case NOTIFICATION_ENTER_TREE: {
 
-			Node *parent = get_parent();
-			if (parent) {
-
-				path = parent->cast_to<Path2D>();
-				if (path) {
-					_update_transform();
-				}
+			if ((path = Object::cast_to<Path2D>(get_parent()))) {
+				_update_transform();
 			}
 
 		} break;
@@ -231,7 +226,7 @@ String PathFollow2D::get_configuration_warning() const {
 	if (!is_visible_in_tree() || !is_inside_tree())
 		return String();
 
-	if (!get_parent() || !get_parent()->cast_to<Path2D>()) {
+	if (!Object::cast_to<Path2D>(get_parent())) {
 		return TTR("PathFollow2D only works when set as a child of a Path2D node.");
 	}
 

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -143,7 +143,7 @@ PhysicsBody2D::PhysicsBody2D(Physics2DServer::BodyMode p_mode)
 void PhysicsBody2D::add_collision_exception_with(Node *p_node) {
 
 	ERR_FAIL_NULL(p_node);
-	PhysicsBody2D *physics_body = p_node->cast_to<PhysicsBody2D>();
+	PhysicsBody2D *physics_body = Object::cast_to<PhysicsBody2D>(p_node);
 	if (!physics_body) {
 		ERR_EXPLAIN("Collision exception only works between two objects of PhysicsBody type");
 	}
@@ -154,7 +154,7 @@ void PhysicsBody2D::add_collision_exception_with(Node *p_node) {
 void PhysicsBody2D::remove_collision_exception_with(Node *p_node) {
 
 	ERR_FAIL_NULL(p_node);
-	PhysicsBody2D *physics_body = p_node->cast_to<PhysicsBody2D>();
+	PhysicsBody2D *physics_body = Object::cast_to<PhysicsBody2D>(p_node);
 	if (!physics_body) {
 		ERR_EXPLAIN("Collision exception only works between two objects of PhysicsBody type");
 	}
@@ -262,7 +262,7 @@ StaticBody2D::~StaticBody2D() {
 void RigidBody2D::_body_enter_tree(ObjectID p_id) {
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 
 	Map<ObjectID, BodyState>::Element *E = contact_monitor->body_map.find(p_id);
@@ -285,7 +285,7 @@ void RigidBody2D::_body_enter_tree(ObjectID p_id) {
 void RigidBody2D::_body_exit_tree(ObjectID p_id) {
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 	Map<ObjectID, BodyState>::Element *E = contact_monitor->body_map.find(p_id);
 	ERR_FAIL_COND(!E);
@@ -310,7 +310,7 @@ void RigidBody2D::_body_inout(int p_status, ObjectID p_instance, int p_body_shap
 	ObjectID objid = p_instance;
 
 	Object *obj = ObjectDB::get_instance(objid);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 
 	Map<ObjectID, BodyState>::Element *E = contact_monitor->body_map.find(objid);
 
@@ -393,7 +393,7 @@ void RigidBody2D::_direct_state_changed(Object *p_state) {
 //eh.. fuck
 #ifdef DEBUG_ENABLED
 
-	state = p_state->cast_to<Physics2DDirectBodyState>();
+	state = Object::cast_to<Physics2DDirectBodyState>(p_state);
 #else
 	state = (Physics2DDirectBodyState *)p_state; //trust it
 #endif
@@ -1171,12 +1171,10 @@ ObjectID KinematicBody2D::get_collision_collider_id(int p_collision) const {
 Object *KinematicBody2D::get_collision_collider_shape(int p_collision) const {
 	ERR_FAIL_INDEX_V(p_collision, colliders.size(), NULL);
 	Object *collider = get_collision_collider(p_collision);
-	if (collider) {
-		CollisionObject2D *obj2d = collider->cast_to<CollisionObject2D>();
-		if (obj2d) {
-			uint32_t owner = shape_find_owner(colliders[p_collision].collider_shape);
-			return obj2d->shape_owner_get_owner(owner);
-		}
+	CollisionObject2D *obj2d = Object::cast_to<CollisionObject2D>(collider);
+	if (obj2d) {
+		uint32_t owner = shape_find_owner(colliders[p_collision].collider_shape);
+		return obj2d->shape_owner_get_owner(owner);
 	}
 
 	return NULL;

--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -115,11 +115,11 @@ void RayCast2D::set_exclude_parent_body(bool p_exclude_parent_body) {
 	if (!is_inside_tree())
 		return;
 
-	if (get_parent()->cast_to<PhysicsBody2D>()) {
+	if (Object::cast_to<PhysicsBody2D>(get_parent())) {
 		if (exclude_parent_body)
-			exclude.insert(get_parent()->cast_to<PhysicsBody2D>()->get_rid());
+			exclude.insert(Object::cast_to<PhysicsBody2D>(get_parent())->get_rid());
 		else
-			exclude.erase(get_parent()->cast_to<PhysicsBody2D>()->get_rid());
+			exclude.erase(Object::cast_to<PhysicsBody2D>(get_parent())->get_rid());
 	}
 }
 
@@ -139,11 +139,11 @@ void RayCast2D::_notification(int p_what) {
 			else
 				set_fixed_process(false);
 
-			if (get_parent()->cast_to<PhysicsBody2D>()) {
+			if (Object::cast_to<PhysicsBody2D>(get_parent())) {
 				if (exclude_parent_body)
-					exclude.insert(get_parent()->cast_to<PhysicsBody2D>()->get_rid());
+					exclude.insert(Object::cast_to<PhysicsBody2D>(get_parent())->get_rid());
 				else
-					exclude.erase(get_parent()->cast_to<PhysicsBody2D>()->get_rid());
+					exclude.erase(Object::cast_to<PhysicsBody2D>(get_parent())->get_rid());
 			}
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
@@ -227,7 +227,7 @@ void RayCast2D::add_exception_rid(const RID &p_rid) {
 void RayCast2D::add_exception(const Object *p_object) {
 
 	ERR_FAIL_NULL(p_object);
-	CollisionObject2D *co = ((Object *)p_object)->cast_to<CollisionObject2D>();
+	const CollisionObject2D *co = Object::cast_to<CollisionObject2D>(p_object);
 	if (!co)
 		return;
 	add_exception_rid(co->get_rid());
@@ -241,7 +241,7 @@ void RayCast2D::remove_exception_rid(const RID &p_rid) {
 void RayCast2D::remove_exception(const Object *p_object) {
 
 	ERR_FAIL_NULL(p_object);
-	CollisionObject2D *co = ((Object *)p_object)->cast_to<CollisionObject2D>();
+	const CollisionObject2D *co = Object::cast_to<CollisionObject2D>(p_object);
 	if (!co)
 		return;
 	remove_exception_rid(co->get_rid());

--- a/scene/2d/remote_transform_2d.cpp
+++ b/scene/2d/remote_transform_2d.cpp
@@ -51,11 +51,7 @@ void RemoteTransform2D::_update_remote() {
 	if (!cache)
 		return;
 
-	Object *obj = ObjectDB::get_instance(cache);
-	if (!obj)
-		return;
-
-	Node2D *n = obj->cast_to<Node2D>();
+	Node2D *n = Object::cast_to<Node2D>(ObjectDB::get_instance(cache));
 	if (!n)
 		return;
 
@@ -182,7 +178,7 @@ bool RemoteTransform2D::get_update_scale() const {
 
 String RemoteTransform2D::get_configuration_warning() const {
 
-	if (!has_node(remote_node) || !get_node(remote_node) || !get_node(remote_node)->cast_to<Node2D>()) {
+	if (!has_node(remote_node) || !Object::cast_to<Node2D>(get_node(remote_node))) {
 		return TTR("Path property must point to a valid Node2D node to work.");
 	}
 

--- a/scene/2d/screen_button.cpp
+++ b/scene/2d/screen_button.cpp
@@ -196,11 +196,11 @@ void TouchScreenButton::_input(const Ref<InputEvent> &p_event) {
 
 	ERR_FAIL_COND(!is_visible_in_tree());
 
-	const InputEventScreenTouch *st = p_event->cast_to<InputEventScreenTouch>();
+	const InputEventScreenTouch *st = Object::cast_to<InputEventScreenTouch>(*p_event);
 
 	if (passby_press) {
 
-		const InputEventScreenDrag *sd = p_event->cast_to<InputEventScreenDrag>();
+		const InputEventScreenDrag *sd = Object::cast_to<InputEventScreenDrag>(*p_event);
 
 		if (st && !st->is_pressed() && finger_pressed == st->get_index()) {
 

--- a/scene/2d/sprite.cpp
+++ b/scene/2d/sprite.cpp
@@ -399,7 +399,7 @@ void ViewportSprite::_notification(int p_what) {
 
 				Node *n = get_node(viewport_path);
 				ERR_FAIL_COND(!n);
-				Viewport *vp=n->cast_to<Viewport>();
+				Viewport *vp=Object::cast_to<Viewport>(n);
 				ERR_FAIL_COND(!vp);
 
 				Ref<RenderTargetTexture> rtt = vp->get_render_target_texture();
@@ -467,7 +467,7 @@ void ViewportSprite::set_viewport_path(const NodePath& p_viewport) {
 
 	Node *n = get_node(viewport_path);
 	ERR_FAIL_COND(!n);
-	Viewport *vp=n->cast_to<Viewport>();
+	Viewport *vp=Object::cast_to<Viewport>(n);
 	ERR_FAIL_COND(!vp);
 
 	Ref<RenderTargetTexture> rtt = vp->get_render_target_texture();
@@ -544,13 +544,13 @@ Rect2 ViewportSprite::get_item_rect() const {
 
 String ViewportSprite::get_configuration_warning() const {
 
-	if (!has_node(viewport_path) || !get_node(viewport_path) || !get_node(viewport_path)->cast_to<Viewport>()) {
+	if (!has_node(viewport_path) || !Object::cast_to<Viewport>(get_node(viewport_path))) {
 		return TTR("Path property must point to a valid Viewport node to work. Such Viewport must be set to 'render target' mode.");
 	} else {
 
 		Node *n = get_node(viewport_path);
 		if (n) {
-			Viewport *vp = n->cast_to<Viewport>();
+			Viewport *vp = Object::cast_to<Viewport>(n);
 			if (!vp->is_set_as_render_target()) {
 
 				return TTR("The Viewport set in the path property must be set as 'render target' in order for this sprite to work.");

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -50,12 +50,12 @@ void TileMap::_notification(int p_what) {
 			Node2D *c = this;
 			while (c) {
 
-				navigation = c->cast_to<Navigation2D>();
+				navigation = Object::cast_to<Navigation2D>(c);
 				if (navigation) {
 					break;
 				}
 
-				c = c->get_parent()->cast_to<Node2D>();
+				c = Object::cast_to<Node2D>(c->get_parent());
 			}
 
 			pending_update = true;

--- a/scene/2d/visibility_notifier_2d.cpp
+++ b/scene/2d/visibility_notifier_2d.cpp
@@ -184,7 +184,7 @@ void VisibilityEnabler2D::_find_nodes(Node *p_node) {
 
 	if (enabler[ENABLER_FREEZE_BODIES]) {
 
-		RigidBody2D *rb2d = p_node->cast_to<RigidBody2D>();
+		RigidBody2D *rb2d = Object::cast_to<RigidBody2D>(p_node);
 		if (rb2d && ((rb2d->get_mode() == RigidBody2D::MODE_CHARACTER || (rb2d->get_mode() == RigidBody2D::MODE_RIGID && !rb2d->is_able_to_sleep())))) {
 
 			add = true;
@@ -194,7 +194,7 @@ void VisibilityEnabler2D::_find_nodes(Node *p_node) {
 
 	if (enabler[ENABLER_PAUSE_ANIMATIONS]) {
 
-		AnimationPlayer *ap = p_node->cast_to<AnimationPlayer>();
+		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node);
 		if (ap) {
 			add = true;
 		}
@@ -202,7 +202,7 @@ void VisibilityEnabler2D::_find_nodes(Node *p_node) {
 
 	if (enabler[ENABLER_PAUSE_ANIMATED_SPRITES]) {
 
-		AnimatedSprite *as = p_node->cast_to<AnimatedSprite>();
+		AnimatedSprite *as = Object::cast_to<AnimatedSprite>(p_node);
 		if (as) {
 			add = true;
 		}
@@ -210,7 +210,7 @@ void VisibilityEnabler2D::_find_nodes(Node *p_node) {
 
 	if (enabler[ENABLER_PAUSE_PARTICLES]) {
 
-		Particles2D *ps = p_node->cast_to<Particles2D>();
+		Particles2D *ps = Object::cast_to<Particles2D>(p_node);
 		if (ps) {
 			add = true;
 		}
@@ -273,7 +273,7 @@ void VisibilityEnabler2D::_change_node_state(Node *p_node, bool p_enabled) {
 	ERR_FAIL_COND(!nodes.has(p_node));
 
 	{
-		RigidBody2D *rb = p_node->cast_to<RigidBody2D>();
+		RigidBody2D *rb = Object::cast_to<RigidBody2D>(p_node);
 		if (rb) {
 
 			rb->set_sleeping(!p_enabled);
@@ -281,7 +281,7 @@ void VisibilityEnabler2D::_change_node_state(Node *p_node, bool p_enabled) {
 	}
 
 	{
-		AnimationPlayer *ap = p_node->cast_to<AnimationPlayer>();
+		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node);
 
 		if (ap) {
 
@@ -289,7 +289,7 @@ void VisibilityEnabler2D::_change_node_state(Node *p_node, bool p_enabled) {
 		}
 	}
 	{
-		AnimatedSprite *as = p_node->cast_to<AnimatedSprite>();
+		AnimatedSprite *as = Object::cast_to<AnimatedSprite>(p_node);
 
 		if (as) {
 
@@ -301,7 +301,7 @@ void VisibilityEnabler2D::_change_node_state(Node *p_node, bool p_enabled) {
 	}
 
 	{
-		Particles2D *ps = p_node->cast_to<Particles2D>();
+		Particles2D *ps = Object::cast_to<Particles2D>(p_node);
 
 		if (ps) {
 

--- a/scene/3d/area.cpp
+++ b/scene/3d/area.cpp
@@ -115,7 +115,7 @@ real_t Area::get_priority() const {
 void Area::_body_enter_tree(ObjectID p_id) {
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 
 	Map<ObjectID, BodyState>::Element *E = body_map.find(p_id);
@@ -133,7 +133,7 @@ void Area::_body_enter_tree(ObjectID p_id) {
 void Area::_body_exit_tree(ObjectID p_id) {
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 	Map<ObjectID, BodyState>::Element *E = body_map.find(p_id);
 	ERR_FAIL_COND(!E);
@@ -152,7 +152,7 @@ void Area::_body_inout(int p_status, const RID &p_body, int p_instance, int p_bo
 	ObjectID objid = p_instance;
 
 	Object *obj = ObjectDB::get_instance(objid);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 
 	Map<ObjectID, BodyState>::Element *E = body_map.find(objid);
 
@@ -228,7 +228,7 @@ void Area::_clear_monitoring() {
 		for (Map<ObjectID, BodyState>::Element *E = bmcopy.front(); E; E = E->next()) {
 
 			Object *obj = ObjectDB::get_instance(E->key());
-			Node *node = obj ? obj->cast_to<Node>() : NULL;
+			Node *node = Object::cast_to<Node>(obj);
 
 			if (!node) //node may have been deleted in previous frame or at other legiminate point
 				continue;
@@ -258,7 +258,7 @@ void Area::_clear_monitoring() {
 		for (Map<ObjectID, AreaState>::Element *E = bmcopy.front(); E; E = E->next()) {
 
 			Object *obj = ObjectDB::get_instance(E->key());
-			Node *node = obj ? obj->cast_to<Node>() : NULL;
+			Node *node = Object::cast_to<Node>(obj);
 
 			if (!node) //node may have been deleted in previous frame or at other legiminate point
 				continue;
@@ -312,7 +312,7 @@ void Area::set_monitoring(bool p_enable) {
 void Area::_area_enter_tree(ObjectID p_id) {
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 
 	Map<ObjectID, AreaState>::Element *E = area_map.find(p_id);
@@ -330,7 +330,7 @@ void Area::_area_enter_tree(ObjectID p_id) {
 void Area::_area_exit_tree(ObjectID p_id) {
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 	Map<ObjectID, AreaState>::Element *E = area_map.find(p_id);
 	ERR_FAIL_COND(!E);
@@ -349,7 +349,7 @@ void Area::_area_inout(int p_status, const RID &p_area, int p_instance, int p_ar
 	ObjectID objid = p_instance;
 
 	Object *obj = ObjectDB::get_instance(objid);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 
 	Map<ObjectID, AreaState>::Element *E = area_map.find(objid);
 

--- a/scene/3d/arvr_nodes.cpp
+++ b/scene/3d/arvr_nodes.cpp
@@ -40,14 +40,14 @@ void ARVRCamera::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			// need to find our ARVROrigin parent and let it know we're it's camera!
-			ARVROrigin *origin = get_parent()->cast_to<ARVROrigin>();
+			ARVROrigin *origin = Object::cast_to<ARVROrigin>(get_parent());
 			if (origin != NULL) {
 				origin->set_tracked_camera(this);
 			}
 		}; break;
 		case NOTIFICATION_EXIT_TREE: {
 			// need to find our ARVROrigin parent and let it know we're no longer it's camera!
-			ARVROrigin *origin = get_parent()->cast_to<ARVROrigin>();
+			ARVROrigin *origin = Object::cast_to<ARVROrigin>(get_parent());
 			if (origin != NULL) {
 				origin->clear_tracked_camera_if(this);
 			}
@@ -60,7 +60,7 @@ String ARVRCamera::get_configuration_warning() const {
 		return String();
 
 	// must be child node of ARVROrigin!
-	ARVROrigin *origin = get_parent()->cast_to<ARVROrigin>();
+	ARVROrigin *origin = Object::cast_to<ARVROrigin>(get_parent());
 	if (origin == NULL) {
 		return TTR("ARVRCamera must have an ARVROrigin node as its parent");
 	};
@@ -209,7 +209,7 @@ String ARVRController::get_configuration_warning() const {
 		return String();
 
 	// must be child node of ARVROrigin!
-	ARVROrigin *origin = get_parent()->cast_to<ARVROrigin>();
+	ARVROrigin *origin = Object::cast_to<ARVROrigin>(get_parent());
 	if (origin == NULL) {
 		return TTR("ARVRController must have an ARVROrigin node as its parent");
 	};
@@ -321,7 +321,7 @@ String ARVRAnchor::get_configuration_warning() const {
 		return String();
 
 	// must be child node of ARVROrigin!
-	ARVROrigin *origin = get_parent()->cast_to<ARVROrigin>();
+	ARVROrigin *origin = Object::cast_to<ARVROrigin>(get_parent());
 	if (origin == NULL) {
 		return TTR("ARVRAnchor must have an ARVROrigin node as its parent");
 	};

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -266,7 +266,7 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 				if (!sr[i].collider)
 					continue;
 
-				Area *tarea = sr[i].collider->cast_to<Area>();
+				Area *tarea = Object::cast_to<Area>(sr[i].collider);
 				if (!tarea)
 					continue;
 

--- a/scene/3d/bone_attachment.cpp
+++ b/scene/3d/bone_attachment.cpp
@@ -51,9 +51,7 @@ bool BoneAttachment::_set(const StringName &p_name, const Variant &p_value) {
 }
 void BoneAttachment::_get_property_list(List<PropertyInfo> *p_list) const {
 
-	Skeleton *parent = NULL;
-	if (get_parent())
-		parent = get_parent()->cast_to<Skeleton>();
+	Skeleton *parent = Object::cast_to<Skeleton>(get_parent());
 
 	if (parent) {
 
@@ -73,8 +71,8 @@ void BoneAttachment::_get_property_list(List<PropertyInfo> *p_list) const {
 
 void BoneAttachment::_check_bind() {
 
-	if (get_parent() && get_parent()->cast_to<Skeleton>()) {
-		Skeleton *sk = get_parent()->cast_to<Skeleton>();
+	if (Skeleton *sk = Object::cast_to<Skeleton>(get_parent())) {
+
 		int idx = sk->find_bone(bone_name);
 		if (idx != -1) {
 			sk->bind_child_node_to_bone(idx, this);
@@ -88,8 +86,8 @@ void BoneAttachment::_check_unbind() {
 
 	if (bound) {
 
-		if (get_parent() && get_parent()->cast_to<Skeleton>()) {
-			Skeleton *sk = get_parent()->cast_to<Skeleton>();
+		if (Skeleton *sk = Object::cast_to<Skeleton>(get_parent())) {
+
 			int idx = sk->find_bone(bone_name);
 			if (idx != -1) {
 				sk->unbind_child_node_from_bone(idx, this);

--- a/scene/3d/character_camera.cpp
+++ b/scene/3d/character_camera.cpp
@@ -369,7 +369,7 @@ void CharacterCamera::_notification(int p_what) {
 
 			Node* parent = get_parent();
 			while (parent) {
-				PhysicsBody* p = parent->cast_to<PhysicsBody>();
+				PhysicsBody* p = Object::cast_to<PhysicsBody>(parent);
 				if (p) {
 					target_body = p->get_body();
 					break;

--- a/scene/3d/collision_polygon.cpp
+++ b/scene/3d/collision_polygon.cpp
@@ -77,7 +77,7 @@ void CollisionPolygon::_notification(int p_what) {
 	switch (p_what) {
 
 		case NOTIFICATION_PARENTED: {
-			parent = get_parent()->cast_to<CollisionObject>();
+			parent = Object::cast_to<CollisionObject>(get_parent());
 			if (parent) {
 				owner_id = parent->create_shape_owner(this);
 				_build_polygon();
@@ -147,7 +147,7 @@ bool CollisionPolygon::is_disabled() const {
 
 String CollisionPolygon::get_configuration_warning() const {
 
-	if (!get_parent()->cast_to<CollisionObject>()) {
+	if (!Object::cast_to<CollisionObject>(get_parent())) {
 		return TTR("CollisionPolygon only serves to provide a collision shape to a CollisionObject derived node. Please only use it as a child of Area, StaticBody, RigidBody, KinematicBody, etc. to give them a shape.");
 	}
 

--- a/scene/3d/collision_shape.cpp
+++ b/scene/3d/collision_shape.cpp
@@ -50,9 +50,8 @@ void CollisionShape::make_convex_from_brothers() {
 	for (int i = 0; i < p->get_child_count(); i++) {
 
 		Node *n = p->get_child(i);
-		if (n->cast_to<MeshInstance>()) {
+		if (MeshInstance *mi = Object::cast_to<MeshInstance>(n)) {
 
-			MeshInstance *mi = n->cast_to<MeshInstance>();
 			Ref<Mesh> m = mi->get_mesh();
 			if (m.is_valid()) {
 
@@ -68,7 +67,7 @@ void CollisionShape::_notification(int p_what) {
 	switch (p_what) {
 
 		case NOTIFICATION_PARENTED: {
-			parent = get_parent()->cast_to<CollisionObject>();
+			parent = Object::cast_to<CollisionObject>(get_parent());
 			if (parent) {
 				owner_id = parent->create_shape_owner(this);
 				if (shape.is_valid()) {
@@ -106,7 +105,7 @@ void CollisionShape::resource_changed(RES res) {
 
 String CollisionShape::get_configuration_warning() const {
 
-	if (!get_parent()->cast_to<CollisionObject>()) {
+	if (!Object::cast_to<CollisionObject>(get_parent())) {
 		return TTR("CollisionShape only serves to provide a collision shape to a CollisionObject derived node. Please only use it as a child of Area, StaticBody, RigidBody, KinematicBody, etc. to give them a shape.");
 	}
 

--- a/scene/3d/gi_probe.cpp
+++ b/scene/3d/gi_probe.cpp
@@ -1091,7 +1091,7 @@ void GIProbe::_plot_mesh(const Transform &p_xform, Ref<Mesh> &p_mesh, Baker *p_b
 
 void GIProbe::_find_meshes(Node *p_at_node, Baker *p_baker) {
 
-	MeshInstance *mi = p_at_node->cast_to<MeshInstance>();
+	MeshInstance *mi = Object::cast_to<MeshInstance>(p_at_node);
 	if (mi && mi->get_flag(GeometryInstance::FLAG_USE_BAKED_LIGHT)) {
 		Ref<Mesh> mesh = mi->get_mesh();
 		if (mesh.is_valid()) {
@@ -1113,9 +1113,8 @@ void GIProbe::_find_meshes(Node *p_at_node, Baker *p_baker) {
 		}
 	}
 
-	if (p_at_node->cast_to<Spatial>()) {
+	if (Spatial *s = Object::cast_to<Spatial>(p_at_node)) {
 
-		Spatial *s = p_at_node->cast_to<Spatial>();
 		Array meshes = p_at_node->call("get_meshes");
 		for (int i = 0; i < meshes.size(); i += 2) {
 

--- a/scene/3d/interpolated_camera.cpp
+++ b/scene/3d/interpolated_camera.cpp
@@ -46,7 +46,7 @@ void InterpolatedCamera::_notification(int p_what) {
 				break;
 			if (has_node(target)) {
 
-				Spatial *node = get_node(target)->cast_to<Spatial>();
+				Spatial *node = Object::cast_to<Spatial>(get_node(target));
 				if (!node)
 					break;
 
@@ -56,8 +56,8 @@ void InterpolatedCamera::_notification(int p_what) {
 				local_transform = local_transform.interpolate_with(target_xform, delta);
 				set_global_transform(local_transform);
 
-				if (node->cast_to<Camera>()) {
-					Camera *cam = node->cast_to<Camera>();
+				if (Camera *cam = Object::cast_to<Camera>(node)) {
+
 					if (cam->get_projection() == get_projection()) {
 
 						float new_near = Math::lerp(get_znear(), cam->get_znear(), delta);
@@ -83,7 +83,7 @@ void InterpolatedCamera::_notification(int p_what) {
 void InterpolatedCamera::_set_target(const Object *p_target) {
 
 	ERR_FAIL_NULL(p_target);
-	set_target(p_target->cast_to<Spatial>());
+	set_target(Object::cast_to<Spatial>(p_target));
 }
 
 void InterpolatedCamera::set_target(const Spatial *p_target) {

--- a/scene/3d/mesh_instance.cpp
+++ b/scene/3d/mesh_instance.cpp
@@ -148,7 +148,7 @@ void MeshInstance::_resolve_skeleton_path() {
 	if (skeleton_path.is_empty())
 		return;
 
-	Skeleton *skeleton = get_node(skeleton_path) ? get_node(skeleton_path)->cast_to<Skeleton>() : NULL;
+	Skeleton *skeleton = Object::cast_to<Skeleton>(get_node(skeleton_path));
 	if (skeleton)
 		VisualServer::get_singleton()->instance_attach_skeleton(get_instance(), skeleton->get_skeleton());
 }
@@ -202,13 +202,13 @@ Node *MeshInstance::create_trimesh_collision_node() {
 
 void MeshInstance::create_trimesh_collision() {
 
-	StaticBody *static_body = create_trimesh_collision_node()->cast_to<StaticBody>();
+	StaticBody *static_body = Object::cast_to<StaticBody>(create_trimesh_collision_node());
 	ERR_FAIL_COND(!static_body);
 	static_body->set_name(String(get_name()) + "_col");
 
 	add_child(static_body);
 	if (get_owner()) {
-		CollisionShape *cshape = static_body->get_child(0)->cast_to<CollisionShape>();
+		CollisionShape *cshape = Object::cast_to<CollisionShape>(static_body->get_child(0));
 		static_body->set_owner(get_owner());
 		cshape->set_owner(get_owner());
 	}
@@ -232,13 +232,13 @@ Node *MeshInstance::create_convex_collision_node() {
 
 void MeshInstance::create_convex_collision() {
 
-	StaticBody *static_body = create_convex_collision_node()->cast_to<StaticBody>();
+	StaticBody *static_body = Object::cast_to<StaticBody>(create_convex_collision_node());
 	ERR_FAIL_COND(!static_body);
 	static_body->set_name(String(get_name()) + "_col");
 
 	add_child(static_body);
 	if (get_owner()) {
-		CollisionShape *cshape = static_body->get_child(0)->cast_to<CollisionShape>();
+		CollisionShape *cshape = Object::cast_to<CollisionShape>(static_body->get_child(0));
 		static_body->set_owner(get_owner());
 		cshape->set_owner(get_owner());
 	}

--- a/scene/3d/navigation.cpp
+++ b/scene/3d/navigation.cpp
@@ -584,7 +584,7 @@ Vector3 Navigation::get_closest_point_to_segment(const Vector3 &p_from, const Ve
 	}
 
 	if (closest_navmesh && closest_navmesh->owner) {
-		//print_line("navmesh is: "+closest_navmesh->owner->cast_to<Node>()->get_name());
+		//print_line("navmesh is: "+Object::cast_to<Node>(closest_navmesh->owner)->get_name());
 	}
 
 	return closest_point;

--- a/scene/3d/navigation_mesh.cpp
+++ b/scene/3d/navigation_mesh.cpp
@@ -247,7 +247,7 @@ void NavigationMeshInstance::set_enabled(bool p_enabled) {
 	}
 
 	if (debug_view) {
-		MeshInstance *dm = debug_view->cast_to<MeshInstance>();
+		MeshInstance *dm = Object::cast_to<MeshInstance>(debug_view);
 		if (is_enabled()) {
 			dm->set_material_override(get_tree()->get_debug_navigation_material());
 		} else {
@@ -273,7 +273,7 @@ void NavigationMeshInstance::_notification(int p_what) {
 			Spatial *c = this;
 			while (c) {
 
-				navigation = c->cast_to<Navigation>();
+				navigation = Object::cast_to<Navigation>(c);
 				if (navigation) {
 
 					if (enabled && navmesh.is_valid()) {
@@ -342,7 +342,7 @@ void NavigationMeshInstance::set_navigation_mesh(const Ref<NavigationMesh> &p_na
 	}
 
 	if (debug_view && navmesh.is_valid()) {
-		debug_view->cast_to<MeshInstance>()->set_mesh(navmesh->get_debug_mesh());
+		Object::cast_to<MeshInstance>(debug_view)->set_mesh(navmesh->get_debug_mesh());
 	}
 
 	update_gizmo();
@@ -365,10 +365,10 @@ String NavigationMeshInstance::get_configuration_warning() const {
 	const Spatial *c = this;
 	while (c) {
 
-		if (c->cast_to<Navigation>())
+		if (Object::cast_to<Navigation>(c))
 			return String();
 
-		c = c->get_parent()->cast_to<Spatial>();
+		c = Object::cast_to<Spatial>(c->get_parent());
 	}
 
 	return TTR("NavigationMeshInstance must be a child or grandchild to a Navigation node. It only provides navigation data.");

--- a/scene/3d/path.cpp
+++ b/scene/3d/path.cpp
@@ -174,8 +174,7 @@ void PathFollow::_notification(int p_what) {
 			Node *parent = get_parent();
 			if (parent) {
 
-				path = parent->cast_to<Path>();
-				if (path) {
+				if ((path = Object::cast_to<Path>(parent))) {
 					_update_transform();
 				}
 			}

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -116,7 +116,7 @@ bool PhysicsBody::get_collision_layer_bit(int p_bit) const {
 void PhysicsBody::add_collision_exception_with(Node *p_node) {
 
 	ERR_FAIL_NULL(p_node);
-	PhysicsBody *physics_body = p_node->cast_to<PhysicsBody>();
+	PhysicsBody *physics_body = Object::cast_to<PhysicsBody>(p_node);
 	if (!physics_body) {
 		ERR_EXPLAIN("Collision exception only works between two objects of PhysicsBody type");
 	}
@@ -127,7 +127,7 @@ void PhysicsBody::add_collision_exception_with(Node *p_node) {
 void PhysicsBody::remove_collision_exception_with(Node *p_node) {
 
 	ERR_FAIL_NULL(p_node);
-	PhysicsBody *physics_body = p_node->cast_to<PhysicsBody>();
+	PhysicsBody *physics_body = Object::cast_to<PhysicsBody>(p_node);
 	if (!physics_body) {
 		ERR_EXPLAIN("Collision exception only works between two objects of PhysicsBody type");
 	}
@@ -254,7 +254,7 @@ StaticBody::~StaticBody() {
 void RigidBody::_body_enter_tree(ObjectID p_id) {
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 
 	Map<ObjectID, BodyState>::Element *E = contact_monitor->body_map.find(p_id);
@@ -278,7 +278,7 @@ void RigidBody::_body_enter_tree(ObjectID p_id) {
 void RigidBody::_body_exit_tree(ObjectID p_id) {
 
 	Object *obj = ObjectDB::get_instance(p_id);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_COND(!node);
 	Map<ObjectID, BodyState>::Element *E = contact_monitor->body_map.find(p_id);
 	ERR_FAIL_COND(!E);
@@ -303,7 +303,7 @@ void RigidBody::_body_inout(int p_status, ObjectID p_instance, int p_body_shape,
 	ObjectID objid = p_instance;
 
 	Object *obj = ObjectDB::get_instance(objid);
-	Node *node = obj ? obj->cast_to<Node>() : NULL;
+	Node *node = Object::cast_to<Node>(obj);
 
 	Map<ObjectID, BodyState>::Element *E = contact_monitor->body_map.find(objid);
 
@@ -369,7 +369,7 @@ void RigidBody::_direct_state_changed(Object *p_state) {
 //eh.. fuck
 #ifdef DEBUG_ENABLED
 
-	state = p_state->cast_to<PhysicsDirectBodyState>();
+	state = Object::cast_to<PhysicsDirectBodyState>(p_state);
 #else
 	state = (PhysicsDirectBodyState *)p_state; //trust it
 #endif
@@ -1105,7 +1105,7 @@ Object *KinematicBody::get_collision_collider_shape(int p_collision) const {
 	ERR_FAIL_INDEX_V(p_collision, colliders.size(), NULL);
 	Object *collider = get_collision_collider(p_collision);
 	if (collider) {
-		CollisionObject *obj2d = collider->cast_to<CollisionObject>();
+		CollisionObject *obj2d = Object::cast_to<CollisionObject>(collider);
 		if (obj2d) {
 			uint32_t owner = shape_find_owner(colliders[p_collision].collider_shape);
 			return obj2d->shape_owner_get_owner(owner);

--- a/scene/3d/physics_joint.cpp
+++ b/scene/3d/physics_joint.cpp
@@ -55,8 +55,8 @@ void Joint::_update_joint(bool p_only_free) {
 	if (!node_a && !node_b)
 		return;
 
-	PhysicsBody *body_a = node_a ? node_a->cast_to<PhysicsBody>() : (PhysicsBody *)NULL;
-	PhysicsBody *body_b = node_b ? node_b->cast_to<PhysicsBody>() : (PhysicsBody *)NULL;
+	PhysicsBody *body_a = Object::cast_to<PhysicsBody>(node_a);
+	PhysicsBody *body_b = Object::cast_to<PhysicsBody>(node_b);
 
 	if (!body_a && !body_b)
 		return;
@@ -1153,8 +1153,8 @@ void PhysicsJoint::_disconnect() {
 	Node *nA = get_node(body_A);
 	Node *nB = get_node(body_B);
 
-	PhysicsBody *A = nA?nA->cast_to<PhysicsBody>():NULL;
-	PhysicsBody *B = nA?nB->cast_to<PhysicsBody>():NULL;
+	PhysicsBody *A = Object::cast_to<PhysicsBody>(nA);
+	PhysicsBody *B = Object::cast_to<PhysicsBody>(nB);
 
 	if (!A ||!B)
 		return;
@@ -1173,8 +1173,8 @@ void PhysicsJoint::_connect() {
 	Node *nA = get_node(body_A);
 	Node *nB = get_node(body_B);
 
-	PhysicsBody *A = nA?nA->cast_to<PhysicsBody>():NULL;
-	PhysicsBody *B = nA?nB->cast_to<PhysicsBody>():NULL;
+	PhysicsBody *A = Object::cast_to<PhysicsBody>(nA);
+	PhysicsBody *B = Object::cast_to<PhysicsBody>(nB);
 
 	if (!A && !B)
 		return;

--- a/scene/3d/ray_cast.cpp
+++ b/scene/3d/ray_cast.cpp
@@ -196,7 +196,7 @@ void RayCast::add_exception_rid(const RID &p_rid) {
 void RayCast::add_exception(const Object *p_object) {
 
 	ERR_FAIL_NULL(p_object);
-	CollisionObject *co = ((Object *)p_object)->cast_to<CollisionObject>();
+	const CollisionObject *co = Object::cast_to<CollisionObject>(p_object);
 	if (!co)
 		return;
 	add_exception_rid(co->get_rid());
@@ -210,7 +210,7 @@ void RayCast::remove_exception_rid(const RID &p_rid) {
 void RayCast::remove_exception(const Object *p_object) {
 
 	ERR_FAIL_NULL(p_object);
-	CollisionObject *co = ((Object *)p_object)->cast_to<CollisionObject>();
+	const CollisionObject *co = Object::cast_to<CollisionObject>(p_object);
 	if (!co)
 		return;
 	remove_exception_rid(co->get_rid());

--- a/scene/3d/remote_transform.cpp
+++ b/scene/3d/remote_transform.cpp
@@ -51,11 +51,7 @@ void RemoteTransform::_update_remote() {
 	if (!cache)
 		return;
 
-	Object *obj = ObjectDB::get_instance(cache);
-	if (!obj)
-		return;
-
-	Spatial *n = obj->cast_to<Spatial>();
+	Spatial *n = Object::cast_to<Spatial>(ObjectDB::get_instance(cache));
 	if (!n)
 		return;
 
@@ -177,7 +173,7 @@ bool RemoteTransform::get_update_scale() const {
 
 String RemoteTransform::get_configuration_warning() const {
 
-	if (!has_node(remote_node) || !get_node(remote_node) || !get_node(remote_node)->cast_to<Spatial>()) {
+	if (!has_node(remote_node) || !Object::cast_to<Spatial>(get_node(remote_node))) {
 		return TTR("Path property must point to a valid Spatial node to work.");
 	}
 

--- a/scene/3d/room_instance.cpp
+++ b/scene/3d/room_instance.cpp
@@ -45,7 +45,7 @@ void Room::_notification(int p_what) {
 
 			while (parent_room) {
 
-				Room *r = parent_room->cast_to<Room>();
+				Room *r = Object::cast_to<Room>(parent_room);
 				if (r) {
 
 					level = r->level + 1;
@@ -103,7 +103,7 @@ Ref<RoomBounds> Room::get_room() const {
 
 void Room::_parse_node_faces(PoolVector<Face3> &all_faces, const Node *p_node) const {
 
-	const VisualInstance *vi = p_node->cast_to<VisualInstance>();
+	const VisualInstance *vi = Object::cast_to<VisualInstance>(p_node);
 
 	if (vi) {
 		PoolVector<Face3> faces = vi->get_faces(FACES_ENCLOSING);

--- a/scene/3d/skeleton.cpp
+++ b/scene/3d/skeleton.cpp
@@ -111,7 +111,7 @@ bool Skeleton::_get(const StringName &p_path, Variant &r_ret) const {
 
 			Object *obj = ObjectDB::get_instance(E->get());
 			ERR_CONTINUE(!obj);
-			Node *node = obj->cast_to<Node>();
+			Node *node = Object::cast_to<Node>(obj);
 			ERR_CONTINUE(!node);
 			NodePath path = get_path_to(node);
 			children.push_back(path);
@@ -245,7 +245,7 @@ void Skeleton::_notification(int p_what) {
 
 					Object *obj = ObjectDB::get_instance(E->get());
 					ERR_CONTINUE(!obj);
-					Spatial *sp = obj->cast_to<Spatial>();
+					Spatial *sp = Object::cast_to<Spatial>(obj);
 					ERR_CONTINUE(!sp);
 					sp->set_transform(b.pose_global);
 				}
@@ -433,7 +433,7 @@ void Skeleton::get_bound_child_nodes_to_bone(int p_bone, List<Node *> *p_bound) 
 
 		Object *obj = ObjectDB::get_instance(E->get());
 		ERR_CONTINUE(!obj);
-		p_bound->push_back(obj->cast_to<Node>());
+		p_bound->push_back(Object::cast_to<Node>(obj));
 	}
 }
 

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -128,7 +128,7 @@ void Spatial::_notification(int p_what) {
 
 			Node *p = get_parent();
 			if (p)
-				data.parent = p->cast_to<Spatial>();
+				data.parent = Object::cast_to<Spatial>(p);
 
 			if (data.parent)
 				data.C = data.parent->data.children.push_back(this);
@@ -167,7 +167,7 @@ void Spatial::_notification(int p_what) {
 			data.viewport = NULL;
 			Node *parent = get_parent();
 			while (parent && !data.viewport) {
-				data.viewport = parent->cast_to<Viewport>();
+				data.viewport = Object::cast_to<Viewport>(parent);
 				parent = parent->get_parent();
 			}
 
@@ -284,7 +284,7 @@ Transform Spatial::get_global_transform() const {
 #if 0
 void Spatial::add_child_notify(Node *p_child) {
 /*
-	Spatial *s=p_child->cast_to<Spatial>();
+	Spatial *s=Object::cast_to<Spatial>(p_child);
 	if (!s)
 		return;
 
@@ -299,7 +299,7 @@ void Spatial::add_child_notify(Node *p_child) {
 
 void Spatial::remove_child_notify(Node *p_child) {
 /*
-	Spatial *s=p_child->cast_to<Spatial>();
+	Spatial *s=Object::cast_to<Spatial>(p_child);
 	if (!s)
 		return;
 

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -70,13 +70,9 @@ void SpriteBase3D::_notification(int p_what) {
 		if (!pending_update)
 			_im_update();
 
-		Node *parent = get_parent();
-		if (parent) {
-
-			parent_sprite = parent->cast_to<SpriteBase3D>();
-			if (parent_sprite) {
-				pI = parent_sprite->children.push_back(this);
-			}
+		parent_sprite = Object::cast_to<SpriteBase3D>(get_parent());
+		if (parent_sprite) {
+			pI = parent_sprite->children.push_back(this);
 		}
 	}
 

--- a/scene/3d/vehicle_body.cpp
+++ b/scene/3d/vehicle_body.cpp
@@ -81,9 +81,7 @@ void VehicleWheel::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
-		if (!get_parent())
-			return;
-		VehicleBody *cb = get_parent()->cast_to<VehicleBody>();
+		VehicleBody *cb = Object::cast_to<VehicleBody>(get_parent());
 		if (!cb)
 			return;
 		body = cb;
@@ -96,9 +94,7 @@ void VehicleWheel::_notification(int p_what) {
 	}
 	if (p_what == NOTIFICATION_EXIT_TREE) {
 
-		if (!get_parent())
-			return;
-		VehicleBody *cb = get_parent()->cast_to<VehicleBody>();
+		VehicleBody *cb = Object::cast_to<VehicleBody>(get_parent());
 		if (!cb)
 			return;
 		cb->wheels.erase(this);
@@ -416,7 +412,7 @@ real_t VehicleBody::_ray_cast(int p_idx, PhysicsDirectBodyState *s) {
 
 		wheel.m_raycastInfo.m_isInContact = true;
 		if (rr.collider)
-			wheel.m_raycastInfo.m_groundObject = rr.collider->cast_to<PhysicsBody>();
+			wheel.m_raycastInfo.m_groundObject = Object::cast_to<PhysicsBody>(rr.collider);
 
 		real_t hitDistance = param * raylen;
 		wheel.m_raycastInfo.m_suspensionLength = hitDistance - wheel.m_wheelRadius;
@@ -804,7 +800,7 @@ void VehicleBody::_update_friction(PhysicsDirectBodyState *s) {
 
 void VehicleBody::_direct_state_changed(Object *p_state) {
 
-	PhysicsDirectBodyState *s = p_state->cast_to<PhysicsDirectBodyState>();
+	PhysicsDirectBodyState *s = Object::cast_to<PhysicsDirectBodyState>(p_state);
 
 	set_ignore_transform_notification(true);
 	set_global_transform(s->get_transform());

--- a/scene/3d/visibility_notifier.cpp
+++ b/scene/3d/visibility_notifier.cpp
@@ -151,7 +151,7 @@ void VisibilityEnabler::_find_nodes(Node *p_node) {
 
 	if (enabler[ENABLER_FREEZE_BODIES]) {
 
-		RigidBody *rb = p_node->cast_to<RigidBody>();
+		RigidBody *rb = Object::cast_to<RigidBody>(p_node);
 		if (rb && ((rb->get_mode() == RigidBody::MODE_CHARACTER || (rb->get_mode() == RigidBody::MODE_RIGID && !rb->is_able_to_sleep())))) {
 
 			add = true;
@@ -161,7 +161,7 @@ void VisibilityEnabler::_find_nodes(Node *p_node) {
 
 	if (enabler[ENABLER_PAUSE_ANIMATIONS]) {
 
-		AnimationPlayer *ap = p_node->cast_to<AnimationPlayer>();
+		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node);
 		if (ap) {
 			add = true;
 		}
@@ -219,14 +219,14 @@ void VisibilityEnabler::_change_node_state(Node *p_node, bool p_enabled) {
 	ERR_FAIL_COND(!nodes.has(p_node));
 
 	{
-		RigidBody *rb = p_node->cast_to<RigidBody>();
+		RigidBody *rb = Object::cast_to<RigidBody>(p_node);
 		if (rb)
 
 			rb->set_sleeping(!p_enabled);
 	}
 
 	{
-		AnimationPlayer *ap = p_node->cast_to<AnimationPlayer>();
+		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node);
 
 		if (ap) {
 

--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -57,16 +57,16 @@ void VisualInstance::_notification(int p_what) {
 			// CHECK ROOM
 			Spatial *parent = get_parent_spatial();
 			Room *room = NULL;
-			bool is_geom = cast_to<GeometryInstance>();
+			bool is_geom = Object::cast_to<GeometryInstance>(this);
 
 			/*	while(parent) {
 
-				room = parent->cast_to<Room>();
+				room = Object::cast_to<Room>(parent);
 				if (room)
 					break;
 
-				if (is_geom && parent->cast_to<BakedLightSampler>()) {
-					VS::get_singleton()->instance_geometry_set_baked_light_sampler(get_instance(),parent->cast_to<BakedLightSampler>()->get_instance());
+				if (is_geom && Object::cast_to<BakedLightSampler>(parent)) {
+					VS::get_singleton()->instance_geometry_set_baked_light_sampler(get_instance(),Object::cast_to<BakedLightSampler>(parent)->get_instance());
 					break;
 				}
 
@@ -79,7 +79,7 @@ void VisualInstance::_notification(int p_what) {
 			}
 			// CHECK SKELETON => moving skeleton attaching logic to MeshInstance
 			/*
-			Skeleton *skeleton=get_parent()?get_parent()->cast_to<Skeleton>():NULL;
+			Skeleton *skeleton=Object::cast_to<Skeleton>(get_parent());
 			if (skeleton)
 				VisualServer::get_singleton()->instance_attach_skeleton( instance, skeleton->get_skeleton() );
 			*/

--- a/scene/animation/animation_cache.cpp
+++ b/scene/animation/animation_cache.cpp
@@ -120,7 +120,7 @@ void AnimationCache::_update_cache() {
 				StringName property = np.get_property();
 				String ps = property;
 
-				Spatial *sp = node->cast_to<Spatial>();
+				Spatial *sp = Object::cast_to<Spatial>(node);
 
 				if (!sp) {
 
@@ -131,7 +131,7 @@ void AnimationCache::_update_cache() {
 
 				if (ps != "") {
 
-					Skeleton *sk = node->cast_to<Skeleton>();
+					Skeleton *sk = Object::cast_to<Skeleton>(node);
 					if (!sk) {
 
 						path_cache.push_back(Path());

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -251,9 +251,9 @@ void AnimationPlayer::_generate_node_caches(AnimationData *p_anim) {
 		uint32_t id = resource.is_valid() ? resource->get_instance_id() : child->get_instance_id();
 		int bone_idx = -1;
 
-		if (a->track_get_path(i).get_property() && child->cast_to<Skeleton>()) {
+		if (a->track_get_path(i).get_property() && Object::cast_to<Skeleton>(child)) {
 
-			bone_idx = child->cast_to<Skeleton>()->find_bone(a->track_get_path(i).get_property());
+			bone_idx = Object::cast_to<Skeleton>(child)->find_bone(a->track_get_path(i).get_property());
 			if (bone_idx == -1) {
 
 				continue;
@@ -280,14 +280,14 @@ void AnimationPlayer::_generate_node_caches(AnimationData *p_anim) {
 			p_anim->node_cache[i]->path = a->track_get_path(i);
 			p_anim->node_cache[i]->node = child;
 			p_anim->node_cache[i]->resource = resource;
-			p_anim->node_cache[i]->node_2d = child->cast_to<Node2D>();
+			p_anim->node_cache[i]->node_2d = Object::cast_to<Node2D>(child);
 			if (a->track_get_type(i) == Animation::TYPE_TRANSFORM) {
 				// special cases and caches for transform tracks
 
 				// cache spatial
-				p_anim->node_cache[i]->spatial = child->cast_to<Spatial>();
+				p_anim->node_cache[i]->spatial = Object::cast_to<Spatial>(child);
 				// cache skeleton
-				p_anim->node_cache[i]->skeleton = child->cast_to<Skeleton>();
+				p_anim->node_cache[i]->skeleton = Object::cast_to<Skeleton>(child);
 				if (p_anim->node_cache[i]->skeleton) {
 
 					StringName bone_name = a->track_get_path(i).get_property();

--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -1487,8 +1487,8 @@ AnimationTreePlayer::Track *AnimationTreePlayer::_find_track(const NodePath &p_p
 
 	if (p_path.get_property()) {
 
-		if (child->cast_to<Skeleton>())
-			bone_idx = child->cast_to<Skeleton>()->find_bone(p_path.get_property());
+		if (Object::cast_to<Skeleton>(child))
+			bone_idx = Object::cast_to<Skeleton>(child)->find_bone(p_path.get_property());
 		if (bone_idx == -1)
 			property = p_path.get_property();
 	}
@@ -1503,8 +1503,8 @@ AnimationTreePlayer::Track *AnimationTreePlayer::_find_track(const NodePath &p_p
 		Track tr;
 		tr.id = id;
 		tr.object = resource.is_valid() ? (Object *)resource.ptr() : (Object *)child;
-		tr.skeleton = child->cast_to<Skeleton>();
-		tr.spatial = child->cast_to<Spatial>();
+		tr.skeleton = Object::cast_to<Skeleton>(child);
+		tr.spatial = Object::cast_to<Spatial>(child);
 		tr.bone_idx = bone_idx;
 		tr.property = property;
 
@@ -1644,7 +1644,7 @@ void AnimationTreePlayer::_update_sources() {
 		ERR_FAIL_COND(!m);
 	}
 
-	AnimationPlayer *ap = m->cast_to<AnimationPlayer>();
+	AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(m);
 
 	if (!ap) {
 

--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -54,7 +54,7 @@ void BoxContainer::_resort() {
 	Map<Control *, _MinSizeCache> min_size_cache;
 
 	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c || !c->is_visible_in_tree())
 			continue;
 		if (c->is_set_as_toplevel())
@@ -106,7 +106,7 @@ void BoxContainer::_resort() {
 
 		for (int i = 0; i < get_child_count(); i++) {
 
-			Control *c = get_child(i)->cast_to<Control>();
+			Control *c = Object::cast_to<Control>(get_child(i));
 			if (!c || !c->is_visible_in_tree())
 				continue;
 			if (c->is_set_as_toplevel())
@@ -159,7 +159,7 @@ void BoxContainer::_resort() {
 
 	for (int i = 0; i < get_child_count(); i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c || !c->is_visible_in_tree())
 			continue;
 		if (c->is_set_as_toplevel())
@@ -211,7 +211,7 @@ Size2 BoxContainer::get_minimum_size() const {
 	bool first = true;
 
 	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())

--- a/scene/gui/button_group.cpp
+++ b/scene/gui/button_group.cpp
@@ -56,7 +56,7 @@ void ButtonGroup::set_pressed_button(BaseButton *p_button) {
 void ButtonGroup::_pressed(Object *p_button) {
 
 	ERR_FAIL_NULL(p_button);
-	BaseButton *b=p_button->cast_to<BaseButton>();
+	BaseButton *b=Object::cast_to<BaseButton>(p_button);
 	ERR_FAIL_COND(!b);
 
 	for(Set<BaseButton*>::Element *E=buttons.front();E;E=E->next()) {

--- a/scene/gui/center_container.cpp
+++ b/scene/gui/center_container.cpp
@@ -36,7 +36,7 @@ Size2 CenterContainer::get_minimum_size() const {
 	Size2 ms;
 	for (int i = 0; i < get_child_count(); i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())
@@ -69,7 +69,7 @@ void CenterContainer::_notification(int p_what) {
 		Size2 size = get_size();
 		for (int i = 0; i < get_child_count(); i++) {
 
-			Control *c = get_child(i)->cast_to<Control>();
+			Control *c = Object::cast_to<Control>(get_child(i));
 			if (!c)
 				continue;
 			if (c->is_set_as_toplevel())

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -56,11 +56,10 @@ void ColorPicker::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
-			if (get_parent()) {
-				Popup *p = get_parent()->cast_to<Popup>();
-				if (p)
-					p->set_size(Size2(get_combined_minimum_size().width + get_constant("margin") * 2, get_combined_minimum_size().height + get_constant("margin") * 2));
-			}
+
+			Popup *p = Object::cast_to<Popup>(get_parent());
+			if (p)
+				p->set_size(Size2(get_combined_minimum_size().width + get_constant("margin") * 2, get_combined_minimum_size().height + get_constant("margin") * 2));
 		} break;
 
 		case MainLoop::NOTIFICATION_WM_QUIT_REQUEST: {

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -43,7 +43,7 @@ void Container::add_child_notify(Node *p_child) {
 
 	Control::add_child_notify(p_child);
 
-	Control *control = p_child->cast_to<Control>();
+	Control *control = Object::cast_to<Control>(p_child);
 	if (!control)
 		return;
 
@@ -57,7 +57,7 @@ void Container::move_child_notify(Node *p_child) {
 
 	Control::move_child_notify(p_child);
 
-	if (!p_child->cast_to<Control>())
+	if (!Object::cast_to<Control>(p_child))
 		return;
 
 	queue_sort();
@@ -67,7 +67,7 @@ void Container::remove_child_notify(Node *p_child) {
 
 	Control::remove_child_notify(p_child);
 
-	Control *control = p_child->cast_to<Control>();
+	Control *control = Object::cast_to<Control>(p_child);
 	if (!control)
 		return;
 

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -353,7 +353,7 @@ void Control::_resize(const Size2 &p_size) {
 
 void Control::add_child_notify(Node *p_child) {
 
-	Control *child_c = p_child->cast_to<Control>();
+	Control *child_c = Object::cast_to<Control>(p_child);
 	if (!child_c)
 		return;
 
@@ -364,7 +364,7 @@ void Control::add_child_notify(Node *p_child) {
 
 void Control::remove_child_notify(Node *p_child) {
 
-	Control *child_c = p_child->cast_to<Control>();
+	Control *child_c = Object::cast_to<Control>(p_child);
 	if (!child_c)
 		return;
 
@@ -398,7 +398,7 @@ void Control::_notification(int p_notification) {
 
 		case NOTIFICATION_ENTER_CANVAS: {
 
-			data.parent = get_parent()->cast_to<Control>();
+			data.parent = Object::cast_to<Control>(get_parent());
 
 			if (is_set_as_toplevel()) {
 				data.SI = get_viewport()->_gui_add_subwindow_control(this);
@@ -421,13 +421,13 @@ void Control::_notification(int p_notification) {
 					if (!parent)
 						break;
 
-					CanvasItem *ci = parent->cast_to<CanvasItem>();
+					CanvasItem *ci = Object::cast_to<CanvasItem>(parent);
 					if (ci && ci->is_set_as_toplevel()) {
 						subwindow = true;
 						break;
 					}
 
-					parent_control = parent->cast_to<Control>();
+					parent_control = Object::cast_to<Control>(parent);
 
 					if (parent_control) {
 						break;
@@ -624,7 +624,7 @@ Variant Control::get_drag_data(const Point2 &p_point) {
 	if (data.drag_owner) {
 		Object *obj = ObjectDB::get_instance(data.drag_owner);
 		if (obj) {
-			Control *c = obj->cast_to<Control>();
+			Control *c = Object::cast_to<Control>(obj);
 			return c->call("get_drag_data_fw", p_point, this);
 		}
 	}
@@ -646,7 +646,7 @@ bool Control::can_drop_data(const Point2 &p_point, const Variant &p_data) const 
 	if (data.drag_owner) {
 		Object *obj = ObjectDB::get_instance(data.drag_owner);
 		if (obj) {
-			Control *c = obj->cast_to<Control>();
+			Control *c = Object::cast_to<Control>(obj);
 			return c->call("can_drop_data_fw", p_point, p_data, this);
 		}
 	}
@@ -667,7 +667,7 @@ void Control::drop_data(const Point2 &p_point, const Variant &p_data) {
 	if (data.drag_owner) {
 		Object *obj = ObjectDB::get_instance(data.drag_owner);
 		if (obj) {
-			Control *c = obj->cast_to<Control>();
+			Control *c = Object::cast_to<Control>(obj);
 			c->call("drop_data_fw", p_point, p_data, this);
 			return;
 		}
@@ -749,7 +749,7 @@ Ref<Texture> Control::get_icon(const StringName &p_name, const StringName &p_typ
 			class_name = ClassDB::get_parent_class_nocheck(class_name);
 		}
 
-		Control *parent = theme_owner->get_parent() ? theme_owner->get_parent()->cast_to<Control>() : NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner = parent->data.theme_owner;
@@ -785,7 +785,7 @@ Ref<Shader> Control::get_shader(const StringName &p_name, const StringName &p_ty
 			class_name = ClassDB::get_parent_class_nocheck(class_name);
 		}
 
-		Control *parent = theme_owner->get_parent() ? theme_owner->get_parent()->cast_to<Control>() : NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner = parent->data.theme_owner;
@@ -821,7 +821,7 @@ Ref<StyleBox> Control::get_stylebox(const StringName &p_name, const StringName &
 			class_name = ClassDB::get_parent_class_nocheck(class_name);
 		}
 
-		Control *parent = theme_owner->get_parent() ? theme_owner->get_parent()->cast_to<Control>() : NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner = parent->data.theme_owner;
@@ -858,7 +858,7 @@ Ref<Font> Control::get_font(const StringName &p_name, const StringName &p_type) 
 
 		if (theme_owner->data.theme->get_default_theme_font().is_valid())
 			return theme_owner->data.theme->get_default_theme_font();
-		Control *parent = theme_owner->get_parent() ? theme_owner->get_parent()->cast_to<Control>() : NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner = parent->data.theme_owner;
@@ -892,7 +892,7 @@ Color Control::get_color(const StringName &p_name, const StringName &p_type) con
 			class_name = ClassDB::get_parent_class_nocheck(class_name);
 		}
 
-		Control *parent = theme_owner->get_parent() ? theme_owner->get_parent()->cast_to<Control>() : NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner = parent->data.theme_owner;
@@ -927,7 +927,7 @@ int Control::get_constant(const StringName &p_name, const StringName &p_type) co
 			class_name = ClassDB::get_parent_class_nocheck(class_name);
 		}
 
-		Control *parent = theme_owner->get_parent() ? theme_owner->get_parent()->cast_to<Control>() : NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner = parent->data.theme_owner;
@@ -1015,7 +1015,7 @@ bool Control::has_icon(const StringName &p_name, const StringName &p_type) const
 			class_name = ClassDB::get_parent_class_nocheck(class_name);
 		}
 
-		Control *parent = theme_owner->get_parent() ? theme_owner->get_parent()->cast_to<Control>() : NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner = parent->data.theme_owner;
@@ -1049,7 +1049,7 @@ bool Control::has_shader(const StringName &p_name, const StringName &p_type) con
 			class_name = ClassDB::get_parent_class_nocheck(class_name);
 		}
 
-		Control *parent = theme_owner->get_parent() ? theme_owner->get_parent()->cast_to<Control>() : NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner = parent->data.theme_owner;
@@ -1082,7 +1082,7 @@ bool Control::has_stylebox(const StringName &p_name, const StringName &p_type) c
 			class_name = ClassDB::get_parent_class_nocheck(class_name);
 		}
 
-		Control *parent = theme_owner->get_parent() ? theme_owner->get_parent()->cast_to<Control>() : NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner = parent->data.theme_owner;
@@ -1115,7 +1115,7 @@ bool Control::has_font(const StringName &p_name, const StringName &p_type) const
 			class_name = ClassDB::get_parent_class_nocheck(class_name);
 		}
 
-		Control *parent = theme_owner->get_parent() ? theme_owner->get_parent()->cast_to<Control>() : NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner = parent->data.theme_owner;
@@ -1149,7 +1149,7 @@ bool Control::has_color(const StringName &p_name, const StringName &p_type) cons
 			class_name = ClassDB::get_parent_class_nocheck(class_name);
 		}
 
-		Control *parent = theme_owner->get_parent() ? theme_owner->get_parent()->cast_to<Control>() : NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner = parent->data.theme_owner;
@@ -1183,7 +1183,7 @@ bool Control::has_constant(const StringName &p_name, const StringName &p_type) c
 			class_name = ClassDB::get_parent_class_nocheck(class_name);
 		}
 
-		Control *parent = theme_owner->get_parent() ? theme_owner->get_parent()->cast_to<Control>() : NULL;
+		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
 			theme_owner = parent->data.theme_owner;
@@ -1687,7 +1687,7 @@ static Control *_next_control(Control *p_from) {
 	if (p_from->is_set_as_toplevel())
 		return NULL; // can't go above
 
-	Control *parent = p_from->get_parent() ? p_from->get_parent()->cast_to<Control>() : NULL;
+	Control *parent = Object::cast_to<Control>(p_from->get_parent());
 
 	if (!parent) {
 
@@ -1698,7 +1698,7 @@ static Control *_next_control(Control *p_from) {
 	ERR_FAIL_INDEX_V(next, parent->get_child_count(), NULL);
 	for (int i = (next + 1); i < parent->get_child_count(); i++) {
 
-		Control *c = parent->get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(parent->get_child(i));
 		if (!c || !c->is_visible_in_tree() || c->is_set_as_toplevel())
 			continue;
 
@@ -1721,7 +1721,7 @@ Control *Control::find_next_valid_focus() const {
 
 		for (int i = 0; i < from->get_child_count(); i++) {
 
-			Control *c = from->get_child(i)->cast_to<Control>();
+			Control *c = Object::cast_to<Control>(from->get_child(i));
 			if (!c || !c->is_visible_in_tree() || c->is_set_as_toplevel()) {
 				continue;
 			}
@@ -1739,10 +1739,8 @@ Control *Control::find_next_valid_focus() const {
 			if (!next_child) { //nothing else.. go up and find either window or subwindow
 				next_child = const_cast<Control *>(this);
 				while (next_child && !next_child->is_set_as_toplevel()) {
-					if (next_child->get_parent()) {
-						next_child = next_child->get_parent()->cast_to<Control>();
-					} else
-						next_child = NULL;
+
+					next_child = cast_to<Control>(next_child->get_parent());
 				}
 
 				if (!next_child) {
@@ -1776,7 +1774,7 @@ static Control *_prev_control(Control *p_from) {
 	Control *child = NULL;
 	for (int i = p_from->get_child_count() - 1; i >= 0; i--) {
 
-		Control *c = p_from->get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(p_from->get_child(i));
 		if (!c || !c->is_visible_in_tree() || c->is_set_as_toplevel())
 			continue;
 
@@ -1800,7 +1798,7 @@ Control *Control::find_prev_valid_focus() const {
 
 		Control *prev_child = NULL;
 
-		if (from->is_set_as_toplevel() || !from->get_parent() || !from->get_parent()->cast_to<Control>()) {
+		if (from->is_set_as_toplevel() || !Object::cast_to<Control>(from->get_parent())) {
 
 			//find last of the childs
 
@@ -1810,7 +1808,7 @@ Control *Control::find_prev_valid_focus() const {
 
 			for (int i = (from->get_position_in_parent() - 1); i >= 0; i--) {
 
-				Control *c = from->get_parent()->get_child(i)->cast_to<Control>();
+				Control *c = Object::cast_to<Control>(from->get_parent()->get_child(i));
 
 				if (!c || !c->is_visible_in_tree() || c->is_set_as_toplevel()) {
 					continue;
@@ -1822,7 +1820,7 @@ Control *Control::find_prev_valid_focus() const {
 
 			if (!prev_child) {
 
-				prev_child = from->get_parent()->cast_to<Control>();
+				prev_child = Object::cast_to<Control>(from->get_parent());
 			} else {
 
 				prev_child = _prev_control(prev_child);
@@ -1912,14 +1910,14 @@ void Control::_modal_stack_remove() {
 
 void Control::_propagate_theme_changed(CanvasItem *p_at, Control *p_owner, bool p_assign) {
 
-	Control *c = p_at->cast_to<Control>();
+	Control *c = Object::cast_to<Control>(p_at);
 
 	if (c && c != p_owner && c->data.theme.is_valid()) // has a theme, this can't be propagated
 		return;
 
 	for (int i = 0; i < p_at->get_child_count(); i++) {
 
-		CanvasItem *child = p_at->get_child(i)->cast_to<CanvasItem>();
+		CanvasItem *child = Object::cast_to<CanvasItem>(p_at->get_child(i));
 		if (child) {
 			_propagate_theme_changed(child, p_owner, p_assign);
 		}
@@ -1955,7 +1953,7 @@ void Control::set_theme(const Ref<Theme> &p_theme) {
 		_propagate_theme_changed(this, this);
 	} else {
 
-		Control *parent = get_parent() ? get_parent()->cast_to<Control>() : NULL;
+		Control *parent = cast_to<Control>(get_parent());
 		if (parent && parent->data.theme_owner) {
 			_propagate_theme_changed(this, parent->data.theme_owner);
 		} else {
@@ -2038,7 +2036,7 @@ Control *Control::_get_focus_neighbour(Margin p_margin, int p_count) {
 		Control *c = NULL;
 		Node *n = get_node(data.focus_neighbour[p_margin]);
 		if (n) {
-			c = n->cast_to<Control>();
+			c = Object::cast_to<Control>(n);
 
 			if (!c) {
 
@@ -2095,7 +2093,7 @@ Control *Control::_get_focus_neighbour(Margin p_margin, int p_count) {
 
 	while (base) {
 
-		Control *c = base->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(base);
 		if (c) {
 			if (c->data.SI)
 				break;
@@ -2115,10 +2113,10 @@ Control *Control::_get_focus_neighbour(Margin p_margin, int p_count) {
 
 void Control::_window_find_focus_neighbour(const Vector2 &p_dir, Node *p_at, const Point2 *p_points, float p_min, float &r_closest_dist, Control **r_closest) {
 
-	if (p_at->cast_to<Viewport>())
+	if (Object::cast_to<Viewport>(p_at))
 		return; //bye
 
-	Control *c = p_at->cast_to<Control>();
+	Control *c = Object::cast_to<Control>(p_at);
 
 	if (c && c != this && c->get_focus_mode() == FOCUS_ALL && c->is_visible_in_tree()) {
 
@@ -2168,7 +2166,7 @@ void Control::_window_find_focus_neighbour(const Vector2 &p_dir, Node *p_at, con
 	for (int i = 0; i < p_at->get_child_count(); i++) {
 
 		Node *child = p_at->get_child(i);
-		Control *childc = child->cast_to<Control>();
+		Control *childc = Object::cast_to<Control>(child);
 		if (childc && childc->data.SI)
 			continue; //subwindow, ignore
 		_window_find_focus_neighbour(p_dir, p_at->get_child(i), p_points, p_min, r_closest_dist, r_closest);
@@ -2363,7 +2361,7 @@ Control *Control::get_root_parent_control() const {
 
 	while (ci) {
 
-		const Control *c = ci->cast_to<Control>();
+		const Control *c = Object::cast_to<Control>(ci);
 		if (c) {
 			root = c;
 

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -60,13 +60,13 @@ void WindowDialog::_fix_size() {
 	float right = 0;
 	// Check validity, because the theme could contain a different type of StyleBox
 	if (panel->get_class() == "StyleBoxTexture") {
-		Ref<StyleBoxTexture> panel_texture = panel->cast_to<StyleBoxTexture>();
+		Ref<StyleBoxTexture> panel_texture = Object::cast_to<StyleBoxTexture>(*panel);
 		top = panel_texture->get_expand_margin_size(MARGIN_TOP);
 		left = panel_texture->get_expand_margin_size(MARGIN_LEFT);
 		bottom = panel_texture->get_expand_margin_size(MARGIN_BOTTOM);
 		right = panel_texture->get_expand_margin_size(MARGIN_RIGHT);
 	} else if (panel->get_class() == "StyleBoxFlat") {
-		Ref<StyleBoxFlat> panel_flat = panel->cast_to<StyleBoxFlat>();
+		Ref<StyleBoxFlat> panel_flat = Object::cast_to<StyleBoxFlat>(*panel);
 		top = panel_flat->get_expand_margin_size(MARGIN_TOP);
 		left = panel_flat->get_expand_margin_size(MARGIN_LEFT);
 		bottom = panel_flat->get_expand_margin_size(MARGIN_BOTTOM);
@@ -424,7 +424,7 @@ void AcceptDialog::_update_child_rects() {
 	Vector2 csize(size.x - margin * 2, size.y - margin * 3 - hminsize.y - label_size.height);
 
 	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 
@@ -448,7 +448,7 @@ Size2 AcceptDialog::get_minimum_size() const {
 	Size2 minsize = label->get_combined_minimum_size();
 
 	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -134,7 +134,7 @@ void GraphEdit::_update_scroll_offset() {
 
 	for (int i = 0; i < get_child_count(); i++) {
 
-		GraphNode *gn = get_child(i)->cast_to<GraphNode>();
+		GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
 		if (!gn)
 			continue;
 
@@ -163,7 +163,7 @@ void GraphEdit::_update_scroll() {
 	Rect2 screen;
 	for (int i = 0; i < get_child_count(); i++) {
 
-		GraphNode *gn = get_child(i)->cast_to<GraphNode>();
+		GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
 		if (!gn)
 			continue;
 
@@ -205,7 +205,7 @@ void GraphEdit::_update_scroll() {
 
 void GraphEdit::_graph_node_raised(Node *p_gn) {
 
-	GraphNode *gn = p_gn->cast_to<GraphNode>();
+	GraphNode *gn = Object::cast_to<GraphNode>(p_gn);
 	ERR_FAIL_COND(!gn);
 	if (gn->is_comment()) {
 		move_child(gn, 0);
@@ -214,7 +214,7 @@ void GraphEdit::_graph_node_raised(Node *p_gn) {
 	}
 	int first_not_comment = 0;
 	for (int i = 0; i < get_child_count(); i++) {
-		GraphNode *gn = get_child(i)->cast_to<GraphNode>();
+		GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
 		if (gn && !gn->is_comment()) {
 			first_not_comment = i;
 			break;
@@ -228,7 +228,7 @@ void GraphEdit::_graph_node_raised(Node *p_gn) {
 
 void GraphEdit::_graph_node_moved(Node *p_gn) {
 
-	GraphNode *gn = p_gn->cast_to<GraphNode>();
+	GraphNode *gn = Object::cast_to<GraphNode>(p_gn);
 	ERR_FAIL_COND(!gn);
 	top_layer->update();
 	update();
@@ -240,7 +240,7 @@ void GraphEdit::add_child_notify(Node *p_child) {
 	Control::add_child_notify(p_child);
 
 	top_layer->call_deferred("raise"); //top layer always on top!
-	GraphNode *gn = p_child->cast_to<GraphNode>();
+	GraphNode *gn = Object::cast_to<GraphNode>(p_child);
 	if (gn) {
 		gn->set_scale(Vector2(zoom, zoom));
 		gn->connect("offset_changed", this, "_graph_node_moved", varray(gn));
@@ -256,7 +256,7 @@ void GraphEdit::remove_child_notify(Node *p_child) {
 	Control::remove_child_notify(p_child);
 
 	top_layer->call_deferred("raise"); //top layer always on top!
-	GraphNode *gn = p_child->cast_to<GraphNode>();
+	GraphNode *gn = Object::cast_to<GraphNode>(p_child);
 	if (gn) {
 		gn->disconnect("offset_changed", this, "_graph_node_moved");
 		gn->disconnect("raise_request", this, "_graph_node_raised");
@@ -345,7 +345,7 @@ bool GraphEdit::_filter_input(const Point2 &p_point) {
 	float grab_r = port->get_width() * 0.5 * grab_r_extend;
 	for (int i = get_child_count() - 1; i >= 0; i--) {
 
-		GraphNode *gn = get_child(i)->cast_to<GraphNode>();
+		GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
 		if (!gn)
 			continue;
 
@@ -379,7 +379,7 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 		float grab_r = port->get_width() * 0.5 * grab_r_extend;
 		for (int i = get_child_count() - 1; i >= 0; i--) {
 
-			GraphNode *gn = get_child(i)->cast_to<GraphNode>();
+			GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
 			if (!gn)
 				continue;
 
@@ -395,20 +395,20 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 							if (E->get().from == gn->get_name() && E->get().from_port == j) {
 
 								Node *to = get_node(String(E->get().to));
-								if (to && to->cast_to<GraphNode>()) {
+								if (Object::cast_to<GraphNode>(to)) {
 
 									connecting_from = E->get().to;
 									connecting_index = E->get().to_port;
 									connecting_out = false;
-									connecting_type = to->cast_to<GraphNode>()->get_connection_input_type(E->get().to_port);
-									connecting_color = to->cast_to<GraphNode>()->get_connection_input_color(E->get().to_port);
+									connecting_type = Object::cast_to<GraphNode>(to)->get_connection_input_type(E->get().to_port);
+									connecting_color = Object::cast_to<GraphNode>(to)->get_connection_input_color(E->get().to_port);
 									connecting_target = false;
 									connecting_to = pos;
 									just_disconected = true;
 
 									emit_signal("disconnection_request", E->get().from, E->get().from_port, E->get().to, E->get().to_port);
 									to = get_node(String(connecting_from)); //maybe it was erased
-									if (to && to->cast_to<GraphNode>()) {
+									if (Object::cast_to<GraphNode>(to)) {
 										connecting = true;
 									}
 									return;
@@ -443,20 +443,20 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 							if (E->get().to == gn->get_name() && E->get().to_port == j) {
 
 								Node *fr = get_node(String(E->get().from));
-								if (fr && fr->cast_to<GraphNode>()) {
+								if (Object::cast_to<GraphNode>(fr)) {
 
 									connecting_from = E->get().from;
 									connecting_index = E->get().from_port;
 									connecting_out = true;
-									connecting_type = fr->cast_to<GraphNode>()->get_connection_output_type(E->get().from_port);
-									connecting_color = fr->cast_to<GraphNode>()->get_connection_output_color(E->get().from_port);
+									connecting_type = Object::cast_to<GraphNode>(fr)->get_connection_output_type(E->get().from_port);
+									connecting_color = Object::cast_to<GraphNode>(fr)->get_connection_output_color(E->get().from_port);
 									connecting_target = false;
 									connecting_to = pos;
 									just_disconected = true;
 
 									emit_signal("disconnection_request", E->get().from, E->get().from_port, E->get().to, E->get().to_port);
 									fr = get_node(String(connecting_from)); //maybe it was erased
-									if (fr && fr->cast_to<GraphNode>()) {
+									if (Object::cast_to<GraphNode>(fr)) {
 										connecting = true;
 									}
 									return;
@@ -493,7 +493,7 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 		float grab_r = port->get_width() * 0.5 * grab_r_extend;
 		for (int i = get_child_count() - 1; i >= 0; i--) {
 
-			GraphNode *gn = get_child(i)->cast_to<GraphNode>();
+			GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
 			if (!gn)
 				continue;
 
@@ -667,7 +667,7 @@ void GraphEdit::_connections_layer_draw() {
 				continue;
 			}
 
-			GraphNode *gfrom = from->cast_to<GraphNode>();
+			GraphNode *gfrom = Object::cast_to<GraphNode>(from);
 
 			if (!gfrom) {
 				to_erase.push_back(E);
@@ -681,7 +681,7 @@ void GraphEdit::_connections_layer_draw() {
 				continue;
 			}
 
-			GraphNode *gto = to->cast_to<GraphNode>();
+			GraphNode *gto = Object::cast_to<GraphNode>(to);
 
 			if (!gto) {
 				to_erase.push_back(E);
@@ -710,7 +710,7 @@ void GraphEdit::_top_layer_draw() {
 
 		Node *fromn = get_node(connecting_from);
 		ERR_FAIL_COND(!fromn);
-		GraphNode *from = fromn->cast_to<GraphNode>();
+		GraphNode *from = Object::cast_to<GraphNode>(fromn);
 		ERR_FAIL_COND(!from);
 		Vector2 pos;
 		if (connecting_out)
@@ -744,7 +744,7 @@ void GraphEdit::set_selected(Node *p_child) {
 
 	for (int i = get_child_count() - 1; i >= 0; i--) {
 
-		GraphNode *gn = get_child(i)->cast_to<GraphNode>();
+		GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
 		if (!gn)
 			continue;
 
@@ -767,7 +767,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 		//drag_accum+=Vector2(mm->get_relative().x,mm->get_relative().y);
 		drag_accum = get_local_mouse_pos() - drag_origin;
 		for (int i = get_child_count() - 1; i >= 0; i--) {
-			GraphNode *gn = get_child(i)->cast_to<GraphNode>();
+			GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
 			if (gn && gn->is_selected()) {
 
 				Vector2 pos = (gn->get_drag_from() * zoom + drag_accum) / zoom;
@@ -791,7 +791,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 
 		for (int i = get_child_count() - 1; i >= 0; i--) {
 
-			GraphNode *gn = get_child(i)->cast_to<GraphNode>();
+			GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
 			if (!gn)
 				continue;
 
@@ -816,7 +816,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 				box_selecting = false;
 				for (int i = get_child_count() - 1; i >= 0; i--) {
 
-					GraphNode *gn = get_child(i)->cast_to<GraphNode>();
+					GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
 					if (!gn)
 						continue;
 
@@ -837,7 +837,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 			if (!just_selected && drag_accum == Vector2() && Input::get_singleton()->is_key_pressed(KEY_CONTROL)) {
 				//deselect current node
 				for (int i = get_child_count() - 1; i >= 0; i--) {
-					GraphNode *gn = get_child(i)->cast_to<GraphNode>();
+					GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
 
 					if (gn) {
 						Rect2 r = gn->get_rect();
@@ -853,7 +853,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 				emit_signal("_begin_node_move");
 
 				for (int i = get_child_count() - 1; i >= 0; i--) {
-					GraphNode *gn = get_child(i)->cast_to<GraphNode>();
+					GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
 					if (gn && gn->is_selected())
 						gn->set_drag(false);
 				}
@@ -874,7 +874,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 
 			for (int i = get_child_count() - 1; i >= 0; i--) {
 
-				GraphNode *gn_selected = get_child(i)->cast_to<GraphNode>();
+				GraphNode *gn_selected = Object::cast_to<GraphNode>(get_child(i));
 
 				if (gn_selected) {
 					if (gn_selected->is_resizing())
@@ -898,7 +898,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 				just_selected = !gn->is_selected();
 				if (!gn->is_selected() && !Input::get_singleton()->is_key_pressed(KEY_CONTROL)) {
 					for (int i = 0; i < get_child_count(); i++) {
-						GraphNode *o_gn = get_child(i)->cast_to<GraphNode>();
+						GraphNode *o_gn = Object::cast_to<GraphNode>(get_child(i));
 						if (o_gn)
 							o_gn->set_selected(o_gn == gn);
 					}
@@ -906,7 +906,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 
 				gn->set_selected(true);
 				for (int i = 0; i < get_child_count(); i++) {
-					GraphNode *o_gn = get_child(i)->cast_to<GraphNode>();
+					GraphNode *o_gn = Object::cast_to<GraphNode>(get_child(i));
 					if (!o_gn)
 						continue;
 					if (o_gn->is_selected())
@@ -926,7 +926,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 					previus_selected.clear();
 					for (int i = get_child_count() - 1; i >= 0; i--) {
 
-						GraphNode *gn = get_child(i)->cast_to<GraphNode>();
+						GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
 						if (!gn || !gn->is_selected())
 							continue;
 
@@ -937,7 +937,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 					previus_selected.clear();
 					for (int i = get_child_count() - 1; i >= 0; i--) {
 
-						GraphNode *gn = get_child(i)->cast_to<GraphNode>();
+						GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
 						if (!gn || !gn->is_selected())
 							continue;
 
@@ -948,7 +948,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 					previus_selected.clear();
 					for (int i = get_child_count() - 1; i >= 0; i--) {
 
-						GraphNode *gn = get_child(i)->cast_to<GraphNode>();
+						GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
 						if (!gn)
 							continue;
 

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -96,7 +96,7 @@ void GraphNode::_get_property_list(List<PropertyInfo> *p_list) const {
 
 	int idx = 0;
 	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c || c->is_set_as_toplevel())
 			continue;
 
@@ -122,7 +122,7 @@ void GraphNode::_resort() {
 	Size2 minsize;
 
 	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())
@@ -144,7 +144,7 @@ void GraphNode::_resort() {
 
 	cache_y.clear();
 	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())
@@ -375,7 +375,7 @@ Size2 GraphNode::get_minimum_size() const {
 
 	for (int i = 0; i < get_child_count(); i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())
@@ -462,7 +462,7 @@ void GraphNode::_connpos_update() {
 	int idx = 0;
 
 	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())

--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -51,7 +51,7 @@ void GridContainer::_notification(int p_what) {
 
 			for (int i = 0; i < get_child_count(); i++) {
 
-				Control *c = get_child(i)->cast_to<Control>();
+				Control *c = Object::cast_to<Control>(get_child(i));
 				if (!c || !c->is_visible_in_tree())
 					continue;
 
@@ -109,7 +109,7 @@ void GridContainer::_notification(int p_what) {
 
 			for (int i = 0; i < get_child_count(); i++) {
 
-				Control *c = get_child(i)->cast_to<Control>();
+				Control *c = Object::cast_to<Control>(get_child(i));
 				if (!c || !c->is_visible_in_tree())
 					continue;
 				int row = idx / columns;
@@ -184,7 +184,7 @@ Size2 GridContainer::get_minimum_size() const {
 
 	for (int i = 0; i < get_child_count(); i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c || !c->is_visible_in_tree())
 			continue;
 		int row = idx / columns;

--- a/scene/gui/margin_container.cpp
+++ b/scene/gui/margin_container.cpp
@@ -40,7 +40,7 @@ Size2 MarginContainer::get_minimum_size() const {
 
 	for (int i = 0; i < get_child_count(); i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())
@@ -74,7 +74,7 @@ void MarginContainer::_notification(int p_what) {
 
 		for (int i = 0; i < get_child_count(); i++) {
 
-			Control *c = get_child(i)->cast_to<Control>();
+			Control *c = Object::cast_to<Control>(get_child(i));
 			if (!c)
 				continue;
 			if (c->is_set_as_toplevel())

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -33,7 +33,7 @@
 
 void MenuButton::_unhandled_key_input(Ref<InputEvent> p_event) {
 
-	if (p_event->is_pressed() && !p_event->is_echo() && (p_event->cast_to<InputEventKey>() || p_event->cast_to<InputEventJoypadButton>() || p_event->cast_to<InputEventAction>())) {
+	if (p_event->is_pressed() && !p_event->is_echo() && (Object::cast_to<InputEventKey>(p_event.ptr()) || Object::cast_to<InputEventJoypadButton>(p_event.ptr()) || Object::cast_to<InputEventAction>(*p_event))) {
 
 		if (!get_parent() || !is_visible_in_tree() || is_disabled())
 			return;

--- a/scene/gui/panel_container.cpp
+++ b/scene/gui/panel_container.cpp
@@ -41,7 +41,7 @@ Size2 PanelContainer::get_minimum_size() const {
 	Size2 ms;
 	for (int i = 0; i < get_child_count(); i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c || !c->is_visible_in_tree())
 			continue;
 		if (c->is_set_as_toplevel())
@@ -90,7 +90,7 @@ void PanelContainer::_notification(int p_what) {
 
 		for (int i = 0; i < get_child_count(); i++) {
 
-			Control *c = get_child(i)->cast_to<Control>();
+			Control *c = Object::cast_to<Control>(get_child(i));
 			if (!c || !c->is_visible_in_tree())
 				continue;
 			if (c->is_set_as_toplevel())

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -95,7 +95,7 @@ void Popup::set_as_minsize() {
 
 	for (int i = 0; i < get_child_count(); i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (!c->is_visible())
@@ -129,7 +129,7 @@ void Popup::popup_centered_minsize(const Size2 &p_minsize) {
 
 	for (int i = 0; i < get_child_count(); i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (!c->is_visible())

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -168,7 +168,7 @@ void PopupMenu::_activate_submenu(int over) {
 	Node *n = get_node(items[over].submenu);
 	ERR_EXPLAIN("item subnode does not exist: " + items[over].submenu);
 	ERR_FAIL_COND(!n);
-	Popup *pm = n->cast_to<Popup>();
+	Popup *pm = Object::cast_to<Popup>(n);
 	ERR_EXPLAIN("item subnode is not a Popup: " + items[over].submenu);
 	ERR_FAIL_COND(!pm);
 	if (pm->is_visible_in_tree())
@@ -187,7 +187,7 @@ void PopupMenu::_activate_submenu(int over) {
 	pm->set_position(pos);
 	pm->popup();
 
-	PopupMenu *pum = pm->cast_to<PopupMenu>();
+	PopupMenu *pum = Object::cast_to<PopupMenu>(pm);
 	if (pum) {
 
 		pr.position -= pum->get_global_position();
@@ -869,7 +869,7 @@ bool PopupMenu::activate_item_by_event(const Ref<InputEvent> &p_event, bool p_fo
 			if (!n)
 				continue;
 
-			PopupMenu *pm = n->cast_to<PopupMenu>();
+			PopupMenu *pm = Object::cast_to<PopupMenu>(n);
 			if (!pm)
 				continue;
 
@@ -891,14 +891,14 @@ void PopupMenu::activate_item(int p_item) {
 
 	//hide all parent PopupMenue's
 	Node *next = get_parent();
-	PopupMenu *pop = next->cast_to<PopupMenu>();
+	PopupMenu *pop = Object::cast_to<PopupMenu>(next);
 	while (pop) {
 		// We close all parents that are chained together,
 		// with hide_on_item_selection enabled
 		if ((items[p_item].checkable && hide_on_checkable_item_selection && pop->is_hide_on_checkable_item_selection()) || (!items[p_item].checkable && hide_on_item_selection && pop->is_hide_on_item_selection())) {
 			pop->hide();
 			next = next->get_parent();
-			pop = next->cast_to<PopupMenu>();
+			pop = Object::cast_to<PopupMenu>(next);
 		} else {
 			// Break out of loop when the next parent has
 			// hide_on_item_selection disabled

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -170,7 +170,7 @@ double Range::get_as_ratio() const {
 
 void Range::_share(Node *p_range) {
 
-	Range *r = p_range->cast_to<Range>();
+	Range *r = Object::cast_to<Range>(p_range);
 	ERR_FAIL_COND(!r);
 	share(r);
 }

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -315,7 +315,7 @@ void ScrollBar::_notification(int p_what) {
 
 		if (has_node(drag_slave_path)) {
 			Node *n = get_node(drag_slave_path);
-			drag_slave = n->cast_to<Control>();
+			drag_slave = Object::cast_to<Control>(n);
 		}
 
 		if (drag_slave) {
@@ -663,7 +663,7 @@ void ScrollBar::set_drag_slave(const NodePath &p_path) {
 
 		if (has_node(p_path)) {
 			Node *n = get_node(p_path);
-			drag_slave = n->cast_to<Control>();
+			drag_slave = Object::cast_to<Control>(n);
 		}
 
 		if (drag_slave) {

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -40,7 +40,7 @@ Size2 ScrollContainer::get_minimum_size() const {
 
 	for (int i = 0; i < get_child_count(); i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())
@@ -220,7 +220,7 @@ void ScrollContainer::_notification(int p_what) {
 
 		for (int i = 0; i < get_child_count(); i++) {
 
-			Control *c = get_child(i)->cast_to<Control>();
+			Control *c = Object::cast_to<Control>(get_child(i));
 			if (!c)
 				continue;
 			if (c->is_set_as_toplevel())
@@ -423,7 +423,7 @@ String ScrollContainer::get_configuration_warning() const {
 
 	for (int i = 0; i < get_child_count(); i++) {
 
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c)
 			continue;
 		if (c->is_set_as_toplevel())

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -44,7 +44,7 @@ Control *SplitContainer::_getch(int p_idx) const {
 	int idx = 0;
 
 	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = get_child(i)->cast_to<Control>();
+		Control *c = Object::cast_to<Control>(get_child(i));
 		if (!c || !c->is_visible_in_tree())
 			continue;
 		if (c->is_set_as_toplevel())

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -230,7 +230,7 @@ void TabContainer::_notification(int p_what) {
 				tab_style->draw(canvas, tab_rect);
 
 				// Draw the tab contents.
-				Control *control = tabs[i + first_tab_cache]->cast_to<Control>();
+				Control *control = Object::cast_to<Control>(tabs[i + first_tab_cache]);
 				String text = control->has_meta("_tab_name") ? String(tr(String(control->get_meta("_tab_name")))) : String(control->get_name());
 
 				int x_content = tab_rect.position.x + tab_style->get_margin(MARGIN_LEFT);
@@ -293,7 +293,7 @@ void TabContainer::_notification(int p_what) {
 }
 
 int TabContainer::_get_tab_width(int p_index) const {
-	Control *control = _get_tabs()[p_index]->cast_to<Control>();
+	Control *control = Object::cast_to<Control>(_get_tabs()[p_index]);
 	if (!control || control->is_set_as_toplevel())
 		return 0;
 
@@ -332,7 +332,7 @@ Vector<Control *> TabContainer::_get_tabs() const {
 	Vector<Control *> controls;
 	for (int i = 0; i < get_child_count(); i++) {
 
-		Control *control = get_child(i)->cast_to<Control>();
+		Control *control = Object::cast_to<Control>(get_child(i));
 		if (!control || control->is_toplevel_control())
 			continue;
 
@@ -350,7 +350,7 @@ void TabContainer::add_child_notify(Node *p_child) {
 
 	Control::add_child_notify(p_child);
 
-	Control *c = p_child->cast_to<Control>();
+	Control *c = Object::cast_to<Control>(p_child);
 	if (!c)
 		return;
 	if (c->is_set_as_toplevel())
@@ -616,7 +616,7 @@ Size2 TabContainer::get_minimum_size() const {
 
 void TabContainer::set_popup(Node *p_popup) {
 	ERR_FAIL_NULL(p_popup);
-	popup = p_popup->cast_to<Popup>();
+	popup = Object::cast_to<Popup>(p_popup);
 	update();
 }
 

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -172,7 +172,9 @@ protected:
 
 		return d;
 	}
-	void _remove_child(Object *p_child) { remove_child(p_child->cast_to<TreeItem>()); }
+	void _remove_child(Object *p_child) {
+		remove_child(Object::cast_to<TreeItem>(p_child));
+	}
 
 public:
 	/* cell mode */
@@ -504,9 +506,17 @@ protected:
 	static void _bind_methods();
 
 	//bind helpers
-	Object *_create_item(Object *p_parent) { return create_item(p_parent->cast_to<TreeItem>()); }
-	TreeItem *_get_next_selected(Object *p_item) { return get_next_selected(p_item->cast_to<TreeItem>()); }
-	Rect2 _get_item_rect(Object *p_item, int p_column) const { return get_item_rect(p_item->cast_to<TreeItem>(), p_column); }
+	Object *_create_item(Object *p_parent) {
+		return create_item(Object::cast_to<TreeItem>(p_parent));
+	}
+
+	TreeItem *_get_next_selected(Object *p_item) {
+		return get_next_selected(Object::cast_to<TreeItem>(p_item));
+	}
+
+	Rect2 _get_item_rect(Object *p_item, int p_column) const {
+		return get_item_rect(Object::cast_to<TreeItem>(p_item), p_column);
+	}
 
 public:
 	virtual String get_tooltip(const Point2 &p_pos) const;

--- a/scene/gui/viewport_container.cpp
+++ b/scene/gui/viewport_container.cpp
@@ -38,7 +38,7 @@ Size2 ViewportContainer::get_minimum_size() const {
 	Size2 ms;
 	for (int i = 0; i < get_child_count(); i++) {
 
-		Viewport *c = get_child(i)->cast_to<Viewport>();
+		Viewport *c = Object::cast_to<Viewport>(get_child(i));
 		if (!c)
 			continue;
 
@@ -71,7 +71,7 @@ void ViewportContainer::_notification(int p_what) {
 
 		for (int i = 0; i < get_child_count(); i++) {
 
-			Viewport *c = get_child(i)->cast_to<Viewport>();
+			Viewport *c = Object::cast_to<Viewport>(get_child(i));
 			if (!c)
 				continue;
 
@@ -83,7 +83,7 @@ void ViewportContainer::_notification(int p_what) {
 
 		for (int i = 0; i < get_child_count(); i++) {
 
-			Viewport *c = get_child(i)->cast_to<Viewport>();
+			Viewport *c = Object::cast_to<Viewport>(get_child(i));
 			if (!c)
 				continue;
 
@@ -98,7 +98,7 @@ void ViewportContainer::_notification(int p_what) {
 
 		for (int i = 0; i < get_child_count(); i++) {
 
-			Viewport *c = get_child(i)->cast_to<Viewport>();
+			Viewport *c = Object::cast_to<Viewport>(get_child(i));
 			if (!c)
 				continue;
 

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -201,7 +201,7 @@ void CanvasLayer::set_custom_viewport(Node *p_viewport) {
 		viewport = RID();
 	}
 
-	custom_viewport = p_viewport->cast_to<Viewport>();
+	custom_viewport = Object::cast_to<Viewport>(p_viewport);
 
 	if (custom_viewport) {
 		custom_viewport_id = custom_viewport->get_instance_id();

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -194,7 +194,7 @@ void Node::_propagate_enter_tree() {
 		data.depth = 1;
 	}
 
-	data.viewport = cast_to<Viewport>();
+	data.viewport = Object::cast_to<Viewport>(this);
 	if (!data.viewport)
 		data.viewport = data.parent->data.viewport;
 
@@ -2160,9 +2160,9 @@ Node *Node::_duplicate(int p_flags) const {
 
 	bool instanced = false;
 
-	if (cast_to<InstancePlaceholder>()) {
+	if (Object::cast_to<InstancePlaceholder>(this)) {
 
-		const InstancePlaceholder *ip = cast_to<const InstancePlaceholder>();
+		const InstancePlaceholder *ip = Object::cast_to<const InstancePlaceholder>(this);
 		InstancePlaceholder *nip = memnew(InstancePlaceholder);
 		nip->set_instance_path(ip->get_instance_path());
 		node = nip;
@@ -2180,7 +2180,7 @@ Node *Node::_duplicate(int p_flags) const {
 
 		Object *obj = ClassDB::instance(get_class());
 		ERR_FAIL_COND_V(!obj, NULL);
-		node = obj->cast_to<Node>();
+		node = Object::cast_to<Node>(obj);
 		if (!node)
 			memdelete(obj);
 		ERR_FAIL_COND_V(!node, NULL);
@@ -2270,7 +2270,7 @@ void Node::_duplicate_and_reown(Node *p_new_parent, const Map<Node *, Node *> &p
 			print_line("could not duplicate: " + String(get_class()));
 		}
 		ERR_FAIL_COND(!obj);
-		node = obj->cast_to<Node>();
+		node = Object::cast_to<Node>(obj);
 		if (!node)
 			memdelete(obj);
 	}
@@ -2326,7 +2326,7 @@ void Node::_duplicate_signals(const Node *p_original, Node *p_copy) const {
 			NodePath p = p_original->get_path_to(this);
 			Node *copy = p_copy->get_node(p);
 
-			Node *target = E->get().target->cast_to<Node>();
+			Node *target = Object::cast_to<Node>(E->get().target);
 			if (!target) {
 				continue;
 			}
@@ -2355,7 +2355,7 @@ Node *Node::duplicate_and_reown(const Map<Node *, Node *> &p_reown_map) const {
 		print_line("could not duplicate: " + String(get_class()));
 	}
 	ERR_FAIL_COND_V(!obj, NULL);
-	node = obj->cast_to<Node>();
+	node = Object::cast_to<Node>(obj);
 	if (!node)
 		memdelete(obj);
 	ERR_FAIL_COND_V(!node, NULL);
@@ -2610,7 +2610,7 @@ void Node::_set_tree(SceneTree *p_tree) {
 
 static void _Node_debug_sn(Object *p_obj) {
 
-	Node *n = p_obj->cast_to<Node>();
+	Node *n = Object::cast_to<Node>(p_obj);
 	if (!n)
 		return;
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -383,7 +383,7 @@ bool SceneTree::is_input_handled() {
 
 void SceneTree::input_event(const Ref<InputEvent> &p_event) {
 
-	if (Engine::get_singleton()->is_editor_hint() && (p_event->cast_to<InputEventJoypadButton>() || p_event->cast_to<InputEventJoypadMotion>()))
+	if (Engine::get_singleton()->is_editor_hint() && (Object::cast_to<InputEventJoypadButton>(p_event.ptr()) || Object::cast_to<InputEventJoypadMotion>(*p_event)))
 		return; //avoid joy input on editor
 
 	root_lock++;
@@ -1400,10 +1400,7 @@ void SceneTree::_live_edit_create_node_func(const NodePath &p_parent, const Stri
 			continue;
 		Node *n2 = n->get_node(p_parent);
 
-		Object *o = ClassDB::instance(p_type);
-		if (!o)
-			continue;
-		Node *no = o->cast_to<Node>();
+		Node *no = Object::cast_to<Node>(ClassDB::instance(p_type));
 		no->set_name(p_name);
 
 		n2->add_child(no);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -68,7 +68,7 @@ void ViewportTexture::setup_local_to_scene() {
 	ERR_EXPLAIN("ViewportTexture: Path to node is invalid");
 	ERR_FAIL_COND(!vpn);
 
-	vp = vpn->cast_to<Viewport>();
+	vp = Object::cast_to<Viewport>(vpn);
 
 	ERR_EXPLAIN("ViewportTexture: Path to node does not point to a viewport");
 	ERR_FAIL_COND(!vp);
@@ -337,22 +337,18 @@ void Viewport::_test_new_mouseover(ObjectID new_collider) {
 	if (new_collider != physics_object_over) {
 
 		if (physics_object_over) {
-			Object *obj = ObjectDB::get_instance(physics_object_over);
-			if (obj) {
-				CollisionObject *co = obj->cast_to<CollisionObject>();
-				if (co) {
-					co->_mouse_exit();
-				}
+
+			CollisionObject *co = Object::cast_to<CollisionObject>(ObjectDB::get_instance(physics_object_over));
+			if (co) {
+				co->_mouse_exit();
 			}
 		}
 
 		if (new_collider) {
-			Object *obj = ObjectDB::get_instance(new_collider);
-			if (obj) {
-				CollisionObject *co = obj->cast_to<CollisionObject>();
-				if (co) {
-					co->_mouse_enter();
-				}
+
+			CollisionObject *co = Object::cast_to<CollisionObject>(ObjectDB::get_instance(new_collider));
+			if (co) {
+				co->_mouse_enter();
 			}
 		}
 
@@ -552,7 +548,7 @@ void Viewport::_notification(int p_what) {
 						for (int i = 0; i < rc; i++) {
 
 							if (res[i].collider_id && res[i].collider) {
-								CollisionObject2D *co = res[i].collider->cast_to<CollisionObject2D>();
+								CollisionObject2D *co = Object::cast_to<CollisionObject2D>(res[i].collider);
 								if (co) {
 
 									Map<ObjectID, uint64_t>::Element *E = physics_2d_mouseover.find(res[i].collider_id);
@@ -575,7 +571,7 @@ void Viewport::_notification(int p_what) {
 								Object *o = ObjectDB::get_instance(E->key());
 								if (o) {
 
-									CollisionObject2D *co = o->cast_to<CollisionObject2D>();
+									CollisionObject2D *co = Object::cast_to<CollisionObject2D>(o);
 									if (co) {
 										co->_mouse_exit();
 									}
@@ -595,19 +591,14 @@ void Viewport::_notification(int p_what) {
 
 					if (physics_object_capture != 0) {
 
-						Object *obj = ObjectDB::get_instance(physics_object_capture);
-						if (obj) {
-							CollisionObject *co = obj->cast_to<CollisionObject>();
-							if (co) {
-								co->_input_event(camera, ev, Vector3(), Vector3(), 0);
-								captured = true;
-								if (mb.is_valid() && mb->get_button_index() == 1 && !mb->is_pressed()) {
-									physics_object_capture = 0;
-								}
-
-							} else {
+						CollisionObject *co = Object::cast_to<CollisionObject>(ObjectDB::get_instance(physics_object_capture));
+						if (co) {
+							co->_input_event(camera, ev, Vector3(), Vector3(), 0);
+							captured = true;
+							if (mb.is_valid() && mb->get_button_index() == 1 && !mb->is_pressed()) {
 								physics_object_capture = 0;
 							}
+
 						} else {
 							physics_object_capture = 0;
 						}
@@ -640,18 +631,15 @@ void Viewport::_notification(int p_what) {
 								ObjectID new_collider = 0;
 								if (col) {
 
-									if (result.collider) {
+									CollisionObject *co = Object::cast_to<CollisionObject>(result.collider);
+									if (co) {
 
-										CollisionObject *co = result.collider->cast_to<CollisionObject>();
-										if (co) {
-
-											co->_input_event(camera, ev, result.position, result.normal, result.shape);
-											last_object = co;
-											last_id = result.collider_id;
-											new_collider = last_id;
-											if (co->get_capture_input_on_drag() && mb.is_valid() && mb->get_button_index() == 1 && mb->is_pressed()) {
-												physics_object_capture = last_id;
-											}
+										co->_input_event(camera, ev, result.position, result.normal, result.shape);
+										last_object = co;
+										last_id = result.collider_id;
+										new_collider = last_id;
+										if (co->get_capture_input_on_drag() && mb.is_valid() && mb->get_button_index() == 1 && mb->is_pressed()) {
+											physics_object_capture = last_id;
 										}
 									}
 								}
@@ -678,11 +666,9 @@ void Viewport::_notification(int p_what) {
 						bool col = space->intersect_ray(from, from + dir * 10000, result, Set<RID>(), 0xFFFFFFFF, 0xFFFFFFFF, true);
 						ObjectID new_collider = 0;
 						if (col) {
-							if (result.collider) {
-								CollisionObject *co = result.collider->cast_to<CollisionObject>();
-								if (co) {
-									new_collider = result.collider_id;
-								}
+							CollisionObject *co = Object::cast_to<CollisionObject>(result.collider);
+							if (co) {
+								new_collider = result.collider_id;
 							}
 						}
 
@@ -750,7 +736,7 @@ Size2 Viewport::get_size() const {
 
 void Viewport::_update_listener() {
 	/*
-	if (is_inside_tree() && audio_listener && (camera || listener) && (!get_parent() || (get_parent()->cast_to<Control>() && get_parent()->cast_to<Control>()->is_visible_in_tree())))  {
+	if (is_inside_tree() && audio_listener && (camera || listener) && (!get_parent() || (Object::cast_to<Control>(get_parent()) && Object::cast_to<Control>(get_parent())->is_visible_in_tree())))  {
 		SpatialSoundServer::get_singleton()->listener_set_space(internal_listener, find_world()->get_sound_space());
 	} else {
 		SpatialSoundServer::get_singleton()->listener_set_space(internal_listener, RID());
@@ -761,7 +747,7 @@ void Viewport::_update_listener() {
 void Viewport::_update_listener_2d() {
 
 	/*
-	if (is_inside_tree() && audio_listener && (!get_parent() || (get_parent()->cast_to<Control>() && get_parent()->cast_to<Control>()->is_visible_in_tree())))
+	if (is_inside_tree() && audio_listener && (!get_parent() || (Object::cast_to<Control>(get_parent()) && Object::cast_to<Control>(get_parent())->is_visible_in_tree())))
 		SpatialSound2DServer::get_singleton()->listener_set_space(internal_listener_2d, find_world_2d()->get_sound_space());
 	else
 		SpatialSound2DServer::get_singleton()->listener_set_space(internal_listener_2d, RID());
@@ -1029,11 +1015,11 @@ void Viewport::_propagate_enter_world(Node *p_node) {
 		if (!p_node->is_inside_tree()) //may not have entered scene yet
 			return;
 
-		if (p_node->cast_to<Spatial>() || p_node->cast_to<WorldEnvironment>()) {
+		if (Object::cast_to<Spatial>(p_node) || Object::cast_to<WorldEnvironment>(p_node)) {
 
 			p_node->notification(Spatial::NOTIFICATION_ENTER_WORLD);
 		} else {
-			Viewport *v = p_node->cast_to<Viewport>();
+			Viewport *v = Object::cast_to<Viewport>(p_node);
 			if (v) {
 
 				if (v->world.is_valid())
@@ -1053,7 +1039,7 @@ void Viewport::_propagate_viewport_notification(Node *p_node, int p_what) {
 	p_node->notification(p_what);
 	for (int i = 0; i < p_node->get_child_count(); i++) {
 		Node *c = p_node->get_child(i);
-		if (c->cast_to<Viewport>())
+		if (Object::cast_to<Viewport>(c))
 			continue;
 		_propagate_viewport_notification(c, p_what);
 	}
@@ -1066,11 +1052,11 @@ void Viewport::_propagate_exit_world(Node *p_node) {
 		if (!p_node->is_inside_tree()) //may have exited scene already
 			return;
 
-		if (p_node->cast_to<Spatial>() || p_node->cast_to<WorldEnvironment>()) {
+		if (Object::cast_to<Spatial>(p_node) || Object::cast_to<WorldEnvironment>(p_node)) {
 
 			p_node->notification(Spatial::NOTIFICATION_EXIT_WORLD);
 		} else {
-			Viewport *v = p_node->cast_to<Viewport>();
+			Viewport *v = Object::cast_to<Viewport>(p_node);
 			if (v) {
 
 				if (v->world.is_valid())
@@ -1514,12 +1500,12 @@ void Viewport::_gui_call_input(Control *p_control, const Ref<InputEvent> &p_inpu
 									 mb->get_button_index() == BUTTON_WHEEL_LEFT ||
 									 mb->get_button_index() == BUTTON_WHEEL_RIGHT));
 
-	bool ismouse = ev.is_valid() || p_input->cast_to<InputEventMouseMotion>() != NULL;
+	bool ismouse = ev.is_valid() || Object::cast_to<InputEventMouseMotion>(*p_input) != NULL;
 
 	CanvasItem *ci = p_control;
 	while (ci) {
 
-		Control *control = ci->cast_to<Control>();
+		Control *control = Object::cast_to<Control>(ci);
 		if (control) {
 			control->call_multilevel(SceneStringNames::get_singleton()->_gui_input, ev);
 			if (gui.key_event_accepted)
@@ -1592,10 +1578,10 @@ Control *Viewport::_gui_find_control(const Point2 &p_global) {
 
 Control *Viewport::_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_global, const Transform2D &p_xform, Transform2D &r_inv_xform) {
 
-	if (p_node->cast_to<Viewport>())
+	if (Object::cast_to<Viewport>(p_node))
 		return NULL;
 
-	Control *c = p_node->cast_to<Control>();
+	Control *c = Object::cast_to<Control>(p_node);
 
 	if (c) {
 		//print_line("at "+String(c->get_path())+" POS "+c->get_position()+" bt "+p_xform);
@@ -1620,7 +1606,7 @@ Control *Viewport::_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_
 			if (p_node == gui.tooltip_popup)
 				continue;
 
-			CanvasItem *ci = p_node->get_child(i)->cast_to<CanvasItem>();
+			CanvasItem *ci = Object::cast_to<CanvasItem>(p_node->get_child(i));
 			if (!ci || ci->is_set_as_toplevel())
 				continue;
 
@@ -1649,7 +1635,7 @@ bool Viewport::_gui_drop(Control *p_at_control, Point2 p_at_pos, bool p_just_che
 		CanvasItem *ci = p_at_control;
 		while (ci) {
 
-			Control *control = ci->cast_to<Control>();
+			Control *control = Object::cast_to<Control>(ci);
 			if (control) {
 
 				if (control->can_drop_data(p_at_pos, gui.drag_data)) {
@@ -1774,7 +1760,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 				CanvasItem *ci = gui.mouse_focus;
 				while (ci) {
 
-					Control *control = ci->cast_to<Control>();
+					Control *control = Object::cast_to<Control>(ci);
 					if (control) {
 						if (control->get_focus_mode() != Control::FOCUS_NONE) {
 							if (control != gui.key_focus) {
@@ -1895,7 +1881,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 					CanvasItem *ci = gui.mouse_focus;
 					while (ci) {
 
-						Control *control = ci->cast_to<Control>();
+						Control *control = Object::cast_to<Control>(ci);
 						if (control) {
 
 							gui.drag_data = control->get_drag_data(control->get_global_transform_with_canvas().affine_inverse().xform(mpos) - gui.drag_accum);
@@ -2240,7 +2226,7 @@ void Viewport::_gui_remove_from_modal_stack(List<Control *>::Element *MI, Object
 		if (!next) { //top of stack
 
 			Object *pfo = ObjectDB::get_instance(p_prev_focus_owner);
-			Control *pfoc = pfo->cast_to<Control>();
+			Control *pfoc = Object::cast_to<Control>(pfo);
 			if (!pfoc)
 				return;
 
@@ -2270,7 +2256,7 @@ void Viewport::_gui_force_drag(Control *p_base, const Variant &p_data, Control *
 void Viewport::_gui_set_drag_preview(Control *p_base, Control *p_control) {
 
 	ERR_FAIL_NULL(p_control);
-	ERR_FAIL_COND(!((Object *)p_control)->cast_to<Control>());
+	ERR_FAIL_COND(!Object::cast_to<Control>((Object *)p_control));
 	ERR_FAIL_COND(p_control->is_inside_tree());
 	ERR_FAIL_COND(p_control->get_parent() != NULL);
 
@@ -2445,14 +2431,18 @@ void Viewport::unhandled_input(const Ref<InputEvent> &p_event) {
 
 	get_tree()->_call_input_pause(unhandled_input_group, "_unhandled_input", p_event);
 	//call_group(GROUP_CALL_REVERSE|GROUP_CALL_REALTIME|GROUP_CALL_MULIILEVEL,"unhandled_input","_unhandled_input",ev);
-	if (!get_tree()->input_handled && p_event->cast_to<InputEventKey>() != NULL) {
+	if (!get_tree()->input_handled && Object::cast_to<InputEventKey>(*p_event) != NULL) {
 		get_tree()->_call_input_pause(unhandled_key_input_group, "_unhandled_key_input", p_event);
 		//call_group(GROUP_CALL_REVERSE|GROUP_CALL_REALTIME|GROUP_CALL_MULIILEVEL,"unhandled_key_input","_unhandled_key_input",ev);
 	}
 
 	if (physics_object_picking && !get_tree()->input_handled) {
 
-		if (Input::get_singleton()->get_mouse_mode() != Input::MOUSE_MODE_CAPTURED && (p_event->cast_to<InputEventMouseButton>() || p_event->cast_to<InputEventMouseMotion>() || p_event->cast_to<InputEventScreenDrag>() || p_event->cast_to<InputEventScreenTouch>())) {
+		if (Input::get_singleton()->get_mouse_mode() != Input::MOUSE_MODE_CAPTURED &&
+				(Object::cast_to<InputEventMouseButton>(*p_event) ||
+						Object::cast_to<InputEventMouseMotion>(*p_event) ||
+						Object::cast_to<InputEventScreenDrag>(*p_event) ||
+						Object::cast_to<InputEventScreenTouch>(*p_event))) {
 			physics_picking_events.push_back(p_event);
 		}
 	}
@@ -2567,7 +2557,7 @@ Control *Viewport::get_modal_stack_top() const {
 
 String Viewport::get_configuration_warning() const {
 
-	/*if (get_parent() && !get_parent()->cast_to<Control>() && !render_target) {
+	/*if (get_parent() && !Object::cast_to<Control>(get_parent()) && !render_target) {
 
 		return TTR("This viewport is not set as render target. If you intend for it to display its contents directly to the screen, make it a child of a Control so it can obtain a size. Otherwise, make it a RenderTarget and assign its internal texture to some node for display.");
 	}*/

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -151,18 +151,18 @@ Node *SceneState::instance(GenEditState p_edit_state) const {
 			//print_line("created");
 			//node belongs to this scene and must be created
 			Object *obj = ClassDB::instance(snames[n.type]);
-			if (!obj || !obj->cast_to<Node>()) {
+			if (!Object::cast_to<Node>(obj)) {
 				if (obj) {
 					memdelete(obj);
 					obj = NULL;
 				}
 				WARN_PRINT(String("Warning node of type " + snames[n.type].operator String() + " does not exist.").ascii().get_data());
 				if (n.parent >= 0 && n.parent < nc && ret_nodes[n.parent]) {
-					if (ret_nodes[n.parent]->cast_to<Spatial>()) {
+					if (Object::cast_to<Spatial>(ret_nodes[n.parent])) {
 						obj = memnew(Spatial);
-					} else if (ret_nodes[n.parent]->cast_to<Control>()) {
+					} else if (Object::cast_to<Control>(ret_nodes[n.parent])) {
 						obj = memnew(Control);
-					} else if (ret_nodes[n.parent]->cast_to<Node2D>()) {
+					} else if (Object::cast_to<Node2D>(ret_nodes[n.parent])) {
 						obj = memnew(Node2D);
 					}
 				}
@@ -172,7 +172,7 @@ Node *SceneState::instance(GenEditState p_edit_state) const {
 				}
 			}
 
-			node = obj->cast_to<Node>();
+			node = Object::cast_to<Node>(obj);
 
 		} else {
 			print_line("wtf class is disabled for: " + itos(n.type));
@@ -754,7 +754,7 @@ Error SceneState::_parse_connections(Node *p_owner, Node *p_node, Map<StringName
 			// only connections that originate or end into main saved scene are saved
 			// everything else is discarded
 
-			Node *target = c.target->cast_to<Node>();
+			Node *target = Object::cast_to<Node>(c.target);
 
 			if (!target) {
 				continue;

--- a/scene/resources/scene_format_text.cpp
+++ b/scene/resources/scene_format_text.cpp
@@ -239,7 +239,7 @@ Error ResourceInteractiveLoaderText::poll() {
 				return error;
 			}
 
-			Resource *r = obj->cast_to<Resource>();
+			Resource *r = Object::cast_to<Resource>(obj);
 			if (!r) {
 
 				error_text += "Can't create sub resource of type, because not a resource: " + type;
@@ -305,7 +305,7 @@ Error ResourceInteractiveLoaderText::poll() {
 			return error;
 		}
 
-		Resource *r = obj->cast_to<Resource>();
+		Resource *r = Object::cast_to<Resource>(obj);
 		if (!r) {
 
 			error_text += "Can't create sub resource of type, because not a resource: " + res_type;

--- a/scene/resources/shape.cpp
+++ b/scene/resources/shape.cpp
@@ -74,7 +74,7 @@ Ref<ArrayMesh> Shape::get_debug_mesh() {
 		arr.resize(Mesh::ARRAY_MAX);
 		arr[Mesh::ARRAY_VERTEX] = array;
 
-		SceneTree *st = OS::get_singleton()->get_main_loop()->cast_to<SceneTree>();
+		SceneTree *st = Object::cast_to<SceneTree>(OS::get_singleton()->get_main_loop());
 
 		debug_mesh_cache->add_surface_from_arrays(Mesh::PRIMITIVE_LINES, arr);
 

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -1030,14 +1030,13 @@ RES ResourceFormatLoaderTheme::load(const String &p_path, const String &p_origin
 					ERR_FAIL_V(RES());
 				}
 
-				if (res->cast_to<StyleBox>()) {
-
+				if (Object::cast_to<StyleBox>(*res)) {
 					theme->set_stylebox(item, control, res);
-				} else if (res->cast_to<Font>()) {
+				} else if (Object::cast_to<Font>(*res)) {
 					theme->set_font(item, control, res);
-				} else if (res->cast_to<Font>()) {
+				} else if (Object::cast_to<Font>(*res)) {
 					theme->set_font(item, control, res);
-				} else if (res->cast_to<Texture>()) {
+				} else if (Object::cast_to<Texture>(*res)) {
 					theme->set_icon(item, control, res);
 				} else {
 					memdelete(f);

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -654,8 +654,8 @@ void AudioServer::_update_bus_effects(int p_bus) {
 		buses[p_bus]->channels[i].effect_instances.resize(buses[p_bus]->effects.size());
 		for (int j = 0; j < buses[p_bus]->effects.size(); j++) {
 			Ref<AudioEffectInstance> fx = buses[p_bus]->effects[j].effect->instance();
-			if (fx->cast_to<AudioEffectCompressorInstance>()) {
-				fx->cast_to<AudioEffectCompressorInstance>()->set_current_channel(i);
+			if (Object::cast_to<AudioEffectCompressorInstance>(*fx)) {
+				Object::cast_to<AudioEffectCompressorInstance>(*fx)->set_current_channel(i);
 			}
 			buses[p_bus]->channels[i].effect_instances[j] = fx;
 		}


### PR DESCRIPTION
Currently we rely on some undefined behavior when Object->cast_to() gets
called with a Null pointer. This used to work fine with GCC < 6 but 
newer versions of GCC remove all codepaths in which the this pointer is
Null. However, the non-static cast_to() was supposed to be null safe.

This patch makes cast_to() Null safe and removes the now redundant Null
checks where they existed.

The following demos have been imported and run without issues on Fedora 26/GCC 7.1.1:

* 2d/lights_and_shadows
* 2d/physics_platformer
* 2d/platformer
* 3d/kinematic_character
* 3d/material_testers
* 3d/platformer

This validates that it at least addresses #10517 and #10515 also. These were already fixed by this commit removes those null checks again and the crashes are still gone. This suggests to me that this will likely fix other random crashes on GCC6+ also.