### PR TITLE
Fix shader function calls being assignable

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -1041,6 +1041,12 @@ bool ShaderLanguage::_validate_operator(OperatorNode *p_op, DataType *r_ret_type
 			}
 		} break;
 		case OP_ASSIGN: {
+
+			if (p_op->arguments[0]->type != Node::TYPE_MEMBER && p_op->arguments[0]->type != Node::TYPE_VARIABLE) {
+				valid = false;
+				break;
+			}
+
 			DataType na = p_op->arguments[0]->get_datatype();
 			DataType nb = p_op->arguments[1]->get_datatype();
 			valid = na == nb;


### PR DESCRIPTION
Added a check in ShaderLanguage::_validate_operator to make sure the item being assigned is either a member or variable.   

Fixes #10589 