### PR TITLE
Added/Fixed null pointer checks

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -247,11 +247,8 @@ void RasterizerGLES3::set_current_render_target(RID p_render_target) {
 
 	if (p_render_target.is_valid()) {
 		RasterizerStorageGLES3::RenderTarget *rt = storage->render_target_owner.getornull(p_render_target);
-		if (!rt) {
-			storage->frame.current_rt = NULL;
-		}
-		ERR_FAIL_COND(!rt);
 		storage->frame.current_rt = rt;
+		ERR_FAIL_COND(!rt);
 		storage->frame.clear_request = false;
 
 		glViewport(0, 0, rt->width, rt->height);

--- a/editor/animation_editor.cpp
+++ b/editor/animation_editor.cpp
@@ -1646,7 +1646,7 @@ PropertyInfo AnimationKeyEditor::_find_hint_for_track(int p_idx, NodePath &r_bas
 	List<PropertyInfo> pinfo;
 	if (res.is_valid())
 		res->get_property_list(&pinfo);
-	else
+	else if (node)
 		node->get_property_list(&pinfo);
 
 	for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -253,8 +253,8 @@ static void _create_script_templates(const String &p_path) {
 	dir->change_dir(p_path);
 	for (int i = 0; i < keys.size(); i++) {
 		if (!dir->file_exists(keys[i])) {
-			file->reopen(p_path.plus_file((String)keys[i]), FileAccess::WRITE);
-			ERR_FAIL_COND(!file);
+			Error err = file->reopen(p_path.plus_file((String)keys[i]), FileAccess::WRITE);
+			ERR_FAIL_COND(err != OK);
 			file->store_string(templates[keys[i]]);
 			file->close();
 		}

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3766,7 +3766,7 @@ bool CanvasItemEditorViewport::_cyclical_dependency_exists(const String &p_targe
 
 void CanvasItemEditorViewport::_create_nodes(Node *parent, Node *child, String &path, const Point2 &p_point) {
 	child->set_name(path.get_file().get_basename());
-	Ref<Texture> texture = Object::cast_to<Texture>(Ref<Texture>(ResourceCache::get(path)).ptr());
+	Ref<Texture> texture = Ref<Texture>(Object::cast_to<Texture>(ResourceCache::get(path)));
 	Size2 texture_size = texture->get_size();
 
 	editor_data->get_undo_redo().add_do_method(parent, "add_child", child);

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -822,7 +822,7 @@ public:
 				}
 
 				Node *another = node->get_node(node_path);
-				if (!node) {
+				if (!another) {
 					r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD;
 					r_error_str = "Path does not lead Node!";
 					return 0;
@@ -1596,7 +1596,7 @@ public:
 				}
 
 				Node *another = node->get_node(node_path);
-				if (!node) {
+				if (!another) {
 					r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD;
 					r_error_str = "Path does not lead Node!";
 					return 0;
@@ -2241,7 +2241,7 @@ public:
 				}
 
 				Node *another = node->get_node(node_path);
-				if (!node) {
+				if (!another) {
 					r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD;
 					r_error_str = RTR("Path does not lead Node!");
 					return 0;

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -2087,7 +2087,7 @@ public:
 		}
 
 		Node *another = node->get_node(path);
-		if (!node) {
+		if (!another) {
 			r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD;
 			r_error_str = "Path does not lead Node!";
 			return 0;

--- a/modules/visual_script/visual_script_yield_nodes.cpp
+++ b/modules/visual_script/visual_script_yield_nodes.cpp
@@ -535,7 +535,7 @@ public:
 					}
 
 					Node *another = node->get_node(node_path);
-					if (!node) {
+					if (!another) {
 						r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD;
 						r_error_str = "Path does not lead Node!";
 						return 0;

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -116,24 +116,22 @@ void OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_au
 	/** XLIB INITIALIZATION **/
 	x11_display = XOpenDisplay(NULL);
 
+	char *modifiers = NULL;
 	Bool xkb_dar = False;
 	if (x11_display) {
 		XAutoRepeatOn(x11_display);
 		xkb_dar = XkbSetDetectableAutoRepeat(x11_display, True, NULL);
-	}
 
-	char *modifiers = NULL;
-
-	// Try to support IME if detectable auto-repeat is supported
-
-	if (xkb_dar == True) {
+		// Try to support IME if detectable auto-repeat is supported
+		if (xkb_dar == True) {
 
 // Xutf8LookupString will be used later instead of XmbLookupString before
 // the multibyte sequences can be converted to unicode string.
 
 #ifdef X_HAVE_UTF8_STRING
-		modifiers = XSetLocaleModifiers("");
+			modifiers = XSetLocaleModifiers("");
 #endif
+		}
 	}
 
 	if (modifiers == NULL) {
@@ -141,8 +139,6 @@ void OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_au
 			WARN_PRINT("IME is disabled");
 		}
 		modifiers = XSetLocaleModifiers("@im=none");
-	}
-	if (modifiers == NULL) {
 		WARN_PRINT("Error setting locale modifiers");
 	}
 

--- a/platform/x11/power_x11.cpp
+++ b/platform/x11/power_x11.cpp
@@ -58,6 +58,7 @@ Adapted from corresponding SDL 2.0 code.
 #include <stdio.h>
 #include <unistd.h>
 
+#include "core/error_macros.h"
 #include <dirent.h>
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -254,9 +255,9 @@ bool PowerX11::GetPowerInfo_Linux_proc_acpi() {
 	this->power_state = POWERSTATE_UNKNOWN;
 
 	dirp->change_dir(proc_acpi_battery_path);
-	dirp->list_dir_begin();
+	Error err = dirp->list_dir_begin();
 
-	if (dirp == NULL) {
+	if (err != OK) {
 		return false; /* can't use this interface. */
 	} else {
 		node = dirp->get_next();
@@ -268,8 +269,8 @@ bool PowerX11::GetPowerInfo_Linux_proc_acpi() {
 	}
 
 	dirp->change_dir(proc_acpi_ac_adapter_path);
-	dirp->list_dir_begin();
-	if (dirp == NULL) {
+	err = dirp->list_dir_begin();
+	if (err != OK) {
 		return false; /* can't use this interface. */
 	} else {
 		node = dirp->get_next();
@@ -438,9 +439,9 @@ bool PowerX11::GetPowerInfo_Linux_sys_class_power_supply(/*PowerState *state, in
 
 	DirAccess *dirp = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	dirp->change_dir(base);
-	dirp->list_dir_begin();
+	Error err = dirp->list_dir_begin();
 
-	if (!dirp) {
+	if (err != OK) {
 		return false;
 	}
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -215,8 +215,8 @@ void TextEdit::Text::_update_line_cache(int p_line) const {
 
 const Map<int, TextEdit::Text::ColorRegionInfo> &TextEdit::Text::get_color_region_info(int p_line) {
 
-	Map<int, ColorRegionInfo> *cri = NULL;
-	ERR_FAIL_INDEX_V(p_line, text.size(), *cri); //enjoy your crash
+	static Map<int, ColorRegionInfo> cri;
+	ERR_FAIL_INDEX_V(p_line, text.size(), cri);
 
 	if (text[p_line].width_cache == -1) {
 		_update_line_cache(p_line);

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2868,8 +2868,8 @@ TreeItem *Tree::create_item(TreeItem *p_parent) {
 
 	TreeItem *ti = memnew(TreeItem(this));
 
-	ti->cells.resize(columns.size());
 	ERR_FAIL_COND_V(!ti, NULL);
+	ti->cells.resize(columns.size());
 
 	if (p_parent) {
 

--- a/servers/physics/broad_phase_basic.cpp
+++ b/servers/physics/broad_phase_basic.cpp
@@ -30,17 +30,14 @@
 #include "broad_phase_basic.h"
 #include "list.h"
 #include "print_string.h"
-BroadPhaseSW::ID BroadPhaseBasic::create(CollisionObjectSW *p_object_, int p_subindex) {
+BroadPhaseSW::ID BroadPhaseBasic::create(CollisionObjectSW *p_object, int p_subindex) {
 
-	if (p_object_ == NULL) {
-
-		ERR_FAIL_COND_V(p_object_ == NULL, 0);
-	}
+	ERR_FAIL_COND_V(p_object == NULL, NULL);
 
 	current++;
 
 	Element e;
-	e.owner = p_object_;
+	e.owner = p_object;
 	e._static = false;
 	e.subindex = p_subindex;
 

--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -1099,13 +1099,15 @@ void VisualServerCanvas::canvas_light_occluder_set_polygon(RID p_occluder, RID p
 
 	if (occluder->polygon.is_valid()) {
 		LightOccluderPolygon *occluder_poly = canvas_light_occluder_polygon_owner.get(p_polygon);
-		if (!occluder_poly)
+		if (!occluder_poly) {
 			occluder->polygon = RID();
-		ERR_FAIL_COND(!occluder_poly);
-		occluder_poly->owners.insert(occluder);
-		occluder->polygon_buffer = occluder_poly->occluder;
-		occluder->aabb_cache = occluder_poly->aabb;
-		occluder->cull_cache = occluder_poly->cull_mode;
+			ERR_FAIL_COND(!occluder_poly);
+		} else {
+			occluder_poly->owners.insert(occluder);
+			occluder->polygon_buffer = occluder_poly->occluder;
+			occluder->aabb_cache = occluder_poly->aabb;
+			occluder->cull_cache = occluder_poly->cull_mode;
+		}
 	}
 }
 void VisualServerCanvas::canvas_light_occluder_set_transform(RID p_occluder, const Transform2D &p_xform) {

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -1482,11 +1482,10 @@ void VisualServerScene::_render_scene(const Transform p_cam_transform, const Cam
 
 			if (light && p_shadow_atlas.is_valid() && VSG::storage->light_has_shadow(E->get()->base)) {
 				lights_with_shadow[directional_shadow_count++] = E->get();
+
+				//add to list
+				directional_light_ptr[directional_light_count++] = light->instance;
 			}
-
-			//add to list
-
-			directional_light_ptr[directional_light_count++] = light->instance;
 		}
 
 		VSG::scene_render->set_directional_shadow_count(directional_shadow_count);


### PR DESCRIPTION
This pull request mitigates some `cppcheck` messages related to null pointer
dereferencing. Hopefully this will cover most of the segfaults that could occur when compiling with GCC 7.1.1:

Starting to edit a collision shape and clicking on a different node of the scene tree will trigger a segmentation fault. A fix was applied and mitigates the following message:
```
[editor/plugins/collision_shape_2d_editor_plugin.cpp:573]: (warning, inconclusive) Possible null pointer dereference: p_obj
```

The following messages were also mitigates which seemed like bugs or unneeded code:
```
[editor/plugins/rich_text_editor_plugin.cpp:94]: (warning, inconclusive) Possible null pointer dereference: p_rich_text
[editor/animation_editor.cpp:1638] -> [editor/animation_editor.cpp:1650]: (warning, inconclusive) Either the condition 'node' is redundant or there is possible null pointer dereference: node.
[modules/visual_script/visual_script_func_nodes.cpp:828] -> [modules/visual_script/visual_script_func_nodes.cpp:827]: (warning, inconclusive) Either the condition '!node' is redundant or there is possible null pointer dereference: node.
[modules/visual_script/visual_script_func_nodes.cpp:1606] -> [modules/visual_script/visual_script_func_nodes.cpp:1605]: (warning, inconclusive) Either the condition '!node' is redundant or there is possible null pointer dereference: node.
[modules/visual_script/visual_script_func_nodes.cpp:2253] -> [modules/visual_script/visual_script_func_nodes.cpp:2252]: (warning, inconclusive) Either the condition '!node' is redundant or there is possible null pointer dereference: node.
[modules/visual_script/visual_script_nodes.cpp:2090] -> [modules/visual_script/visual_script_nodes.cpp:2089]: (warning, inconclusive) Either the condition '!node' is redundant or there is possible null pointer dereference: node.
[modules/visual_script/visual_script_yield_nodes.cpp:541] -> [modules/visual_script/visual_script_yield_nodes.cpp:540]: (warning, inconclusive) Either the condition '!node' is redundant or there is possible null pointer dereference: node.
[servers/visual/visual_server_scene.cpp:2058] -> [servers/visual/visual_server_scene.cpp:2064]: (warning) Either the condition 'light' is redundant or there is possible null pointer dereference: light.
[editor/editor_node.cpp:1294]: (warning, inconclusive) Possible null pointer dereference: current_obj
[editor/editor_node.cpp:1296]: (warning, inconclusive) Possible null pointer dereference: current_obj
[editor/editor_node.cpp:2276]: (warning, inconclusive) Possible null pointer dereference: current_obj
[editor/editor_node.cpp:2278]: (warning, inconclusive) Possible null pointer dereference: current_obj
[editor/editor_node.cpp:2288]: (warning, inconclusive) Possible null pointer dereference: current_obj
[editor/editor_node.cpp:2290]: (warning, inconclusive) Possible null pointer dereference: current_obj
[editor/editor_node.cpp:2300]: (warning, inconclusive) Possible null pointer dereference: current_obj
[editor/editor_node.cpp:2302]: (warning, inconclusive) Possible null pointer dereference: current_obj
[editor/editor_node.cpp:2311]: (warning, inconclusive) Possible null pointer dereference: current_obj
[editor/editor_node.cpp:2313]: (warning, inconclusive) Possible null pointer dereference: current_obj
[drivers/gles3/rasterizer_gles3.cpp:250] -> [drivers/gles3/rasterizer_gles3.cpp:257]: (warning) Either the condition '!rt' is redundant or there is possible null pointer dereference: rt.
[platform/x11/power_x11.cpp:259] -> [platform/x11/power_x11.cpp:256]: (warning, inconclusive) Either the condition 'dirp==NULL' is redundant or there is possible null pointer dereference: dirp.
[platform/x11/power_x11.cpp:259] -> [platform/x11/power_x11.cpp:257]: (warning, inconclusive) Either the condition 'dirp==NULL' is redundant or there is possible null pointer dereference: dirp.
[platform/x11/power_x11.cpp:272] -> [platform/x11/power_x11.cpp:270]: (warning, inconclusive) Either the condition 'dirp==NULL' is redundant or there is possible null pointer dereference: dirp.
[platform/x11/power_x11.cpp:272] -> [platform/x11/power_x11.cpp:271]: (warning, inconclusive) Either the condition 'dirp==NULL' is redundant or there is possible null pointer dereference: dirp.
[platform/x11/power_x11.cpp:443] -> [platform/x11/power_x11.cpp:440]: (warning, inconclusive) Either the condition '!dirp' is redundant or there is possible null pointer dereference: dirp.
[platform/x11/power_x11.cpp:443] -> [platform/x11/power_x11.cpp:441]: (warning, inconclusive) Either the condition '!dirp' is redundant or there is possible null pointer dereference: dirp.
[editor/editor_settings.cpp:250] -> [editor/editor_settings.cpp:249]: (warning, inconclusive) Either the condition '!file' is redundant or there is possible null pointer dereference: file.
[scene/gui/tree.cpp:2872] -> [scene/gui/tree.cpp:2871]: (warning) Either the condition '!ti' is redundant or there is possible null pointer dereference: ti.
[servers/visual/visual_server_canvas.cpp:1102] -> [servers/visual/visual_server_canvas.cpp:1105]: (warning) Either the condition '!occluder_poly' is redundant or there is possible null pointer dereference: occluder_poly.
[servers/visual/visual_server_canvas.cpp:1102] -> [servers/visual/visual_server_canvas.cpp:1106]: (warning) Either the condition '!occluder_poly' is redundant or there is possible null pointer dereference: occluder_poly.
[servers/visual/visual_server_canvas.cpp:1102] -> [servers/visual/visual_server_canvas.cpp:1107]: (warning) Either the condition '!occluder_poly' is redundant or there is possible null pointer dereference: occluder_poly.
[servers/visual/visual_server_canvas.cpp:1102] -> [servers/visual/visual_server_canvas.cpp:1108]: (warning) Either the condition '!occluder_poly' is redundant or there is possible null pointer dereference: occluder_poly.
```

As far as I can tell, all of the following possible null dereferences seem to have already been
accounted for previously and I did not provide any fixes for these. I'm
including their relevant code blocks in any case for easier inspection, but I don't mind mitigating these messages if required:


**cppcheck message:**

```
[drivers/gles3/shader_compiler_gles3.cpp:243]: (warning) Possible null pointer dereference: fnode
```

**relevant codeblock:**

* `fnode` was already accounted for in line 239
https://github.com/godotengine/godot/blob/b4ad899ef64df6e341a4cbe52a15109cd3d6b2eb/drivers/gles3/shader_compiler_gles3.cpp#L230-L244

**cppcheck message:**

```
[editor/editor_dir_dialog.cpp:149] -> [editor/editor_dir_dialog.cpp:157]: (warning, inconclusive) Either the condition 'p' is redundant or there is possible null pointer dereference: p.
```
**relevant codeblock:**
* `p` was accounted for in line 156

https://github.com/godotengine/godot/blob/b4ad899ef64df6e341a4cbe52a15109cd3d6b2eb/editor/editor_dir_dialog.cpp#L148-L157



**cppcheck message:**

```
[editor/editor_export.cpp:661] -> [editor/editor_export.cpp:671]: (warning, inconclusive) Either the condition '!ftmp' is redundant or there is possible null pointer dereference: ftmp.
```

**relevant codeblock:**
* `ftmp` was accounted for in the first `if` statement below

https://github.com/godotengine/godot/blob/b4ad899ef64df6e341a4cbe52a15109cd3d6b2eb/editor/editor_export.cpp#L660-L675



**cppcheck message:**

```
[editor/editor_node.cpp:4659]: (warning, inconclusive) Possible null pointer dereference: dock
```
**relevant codeblock:**
* `dock` was accounted for in line 4657

https://github.com/godotengine/godot/blob/b4ad899ef64df6e341a4cbe52a15109cd3d6b2eb/editor/editor_node.cpp#L4646-L4661


**cppcheck message:**
```
[editor/scene_tree_dock.cpp:1695]: (warning, inconclusive) Possible null pointer dereference: to_node
[editor/scene_tree_dock.cpp:1696]: (warning, inconclusive) Possible null pointer dereference: to_node
```
**relevant codeblocks:**

* I don't think we need a fix for this -- `to_node` only comes from two
different sources:

* `to_node` was already accounted for in line 1751 as the `node` variable:

https://github.com/godotengine/godot/blob/b4ad899ef64df6e341a4cbe52a15109cd3d6b2eb/editor/scene_tree_dock.cpp#L1748-L1756

* `to_node` was already accounted for in line 1783:

https://github.com/godotengine/godot/blob/b4ad899ef64df6e341a4cbe52a15109cd3d6b2eb/editor/scene_tree_dock.cpp#L1767-L1790

* And this is the code block `cppcheck` points to:

https://github.com/godotengine/godot/blob/b4ad899ef64df6e341a4cbe52a15109cd3d6b2eb/editor/scene_tree_dock.cpp#L1683-L1696
