### PR TITLE
Script editor: fixed no key repeat for CTRL+Y

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2736,6 +2736,15 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 				else
 					undo();
 			} break;
+			case KEY_Y: {
+
+				if (!k->get_command()) {
+					scancode_handled = false;
+					break;
+				}
+
+				redo();
+			} break;
 			case KEY_V: {
 				if (readonly) {
 					break;


### PR DESCRIPTION
TextEdit::_gui_input did not handle KEY_Y, causing the event to get handled elsewhere where key repeat is not handled.

Fixes #10596 