### PR TITLE
Ignore Eclipse CDT project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,10 @@ platform/android/java/assets
 *.files
 *.includes
 
+# Eclipse CDT files
+.cproject
+.settings/
+
 # Misc
 .DS_Store
 


### PR DESCRIPTION
Since we have explicit .gitignore rules for QT creator and several other
editor-specific swap/utility files I'd like to add Eclipse CDT projects
also as this is my editor of choice.