### PR TITLE
Ignore gprof output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ platform/android/java/assets
 .deps/*
 .dirstamp
 
+# Gprof output
+gmon.out
+
 # Vim temp files
 *.swo
 *.swp


### PR DESCRIPTION
When building a profile build it is easy to accidentally create gmon.out
files all over the place. Ignore these so they won't get accidentally
pushed.