### PR TITLE
Fixed several memory leaks

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -294,7 +294,6 @@ EditorHelpSearch::EditorHelpSearch() {
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	add_child(vbc);
 
-	HBoxContainer *sb_hb = memnew(HBoxContainer);
 	search_box = memnew(LineEdit);
 	vbc->add_child(search_box);
 	search_box->connect("text_changed", this, "_text_changed");

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5645,21 +5645,7 @@ EditorNode::EditorNode() {
 	progress_hb = memnew(BackgroundProgress);
 	//menu_hb->add_child(progress_hb);
 
-	{
-		Control *sp = memnew(Control);
-		sp->set_custom_minimum_size(Size2(30, 0) * EDSCALE);
-		//menu_hb->add_child(sp);
-	}
-
-	{
-		Control *sp = memnew(Control);
-		sp->set_custom_minimum_size(Size2(30, 0) * EDSCALE);
-		//menu_hb->add_child(sp);
-	}
-
-	top_region = memnew(PanelContainer);
 	HBoxContainer *right_menu_hb = memnew(HBoxContainer);
-	//top_region->add_child(right_menu_hb);
 	menu_hb->add_child(right_menu_hb);
 
 	layout_dialog = memnew(EditorNameDialog);
@@ -6242,6 +6228,7 @@ EditorNode::~EditorNode() {
 	memdelete(editor_plugins_over);
 	memdelete(editor_plugins_force_input_forwarding);
 	memdelete(file_server);
+	memdelete(progress_hb);
 	EditorSettings::destroy();
 }
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -253,6 +253,7 @@ static void _create_script_templates(const String &p_path) {
 		}
 	}
 
+	memdelete(dir);
 	memdelete(file);
 }
 
@@ -280,6 +281,7 @@ void EditorSettings::create() {
 		self_contained = true;
 		extra_config->load(exe_path + "/_sc_");
 	}
+	memdelete(d);
 
 	if (self_contained) {
 		// editor is self contained

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4114,3 +4114,7 @@ CanvasItemEditorViewport::CanvasItemEditorViewport(EditorNode *p_node, CanvasIte
 	label_desc->hide();
 	editor->get_gui_base()->add_child(label_desc);
 }
+
+CanvasItemEditorViewport::~CanvasItemEditorViewport() {
+	memdelete(preview);
+}

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -512,6 +512,7 @@ public:
 	virtual void drop_data(const Point2 &p_point, const Variant &p_data);
 
 	CanvasItemEditorViewport(EditorNode *p_node, CanvasItemEditor *p_canvas);
+	~CanvasItemEditorViewport();
 };
 
 #endif

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -591,6 +591,9 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	hb->add_child(vb);
 	hb->add_child(empty_v->duplicate());
 
+	memdelete(empty_h);
+	memdelete(empty_v);
+
 	add_child(hb);
 
 	/* Language */

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -538,6 +538,8 @@ void OS_X11::finalize() {
 	physics_2d_server->finish();
 	memdelete(physics_2d_server);
 
+	memdelete(power_manager);
+
 	if (xrandr_handle)
 		dlclose(xrandr_handle);
 


### PR DESCRIPTION
From the leaks I found through `valgrind`, there's one last I haven't figured how to fix:

```
==27531== 12,096 bytes in 56 blocks are definitely lost in loss record 847 of 858
==27531==    at 0x4C2BE7F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27531==    by 0x17B1CD1: Memory::alloc_static(unsigned long, bool) (memory.cpp:62)
==27531==    by 0x6D8C39: RasterizerStorageGLES3::texture_create() (rasterizer_storage_gles3.cpp:587)
==27531==    by 0x14BEF6F: VisualServerWrapMT::textureallocn() (visual_server_wrap_mt.h:81)
==27531==    by 0x14B3586: CommandQueueMT::CommandRet0<VisualServerWrapMT, int (VisualServerWrapMT::*)(), int>::call() (command_queue_mt.h:241)
==27531==    by 0x14B058C: flush_one (command_queue_mt.h:671)
==27531==    by 0x14B058C: flush_all (command_queue_mt.h:1329)
==27531==    by 0x14B058C: VisualServerWrapMT::sync() (visual_server_wrap_mt.cpp:106)
==27531==    by 0x2A92FA: Main::iteration() (main.cpp:1572)
==27531==    by 0x2A2730: OS_X11::run() (os_x11.cpp:2125)
==27531==    by 0x29BDAB: main (godot_x11.cpp:52)
```

This is the leak summary of this pull request after just opening and closing the editor:

```
==27531== LEAK SUMMARY:
==27531==    definitely lost: 12,096 bytes in 56 blocks
==27531==    indirectly lost: 0 bytes in 0 blocks
==27531==      possibly lost: 4,630,192 bytes in 69 blocks
==27531==    still reachable: 238,132 bytes in 4,475 blocks
==27531==         suppressed: 0 bytes in 0 blocks
```
