### PR TITLE
AutoUse "Pencil" editor tool on Polygon creation

### DIFF
--- a/editor/plugins/collision_polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_polygon_2d_editor_plugin.cpp
@@ -344,6 +344,10 @@ void CollisionPolygon2DEditor::edit(Node *p_collision_polygon) {
 	if (p_collision_polygon) {
 
 		node = Object::cast_to<CollisionPolygon2D>(p_collision_polygon);
+		//Enable the pencil tool if the polygon is empty
+		if (node->get_polygon().size() == 0) {
+			_menu_option(MODE_CREATE);
+		}		
 		if (!canvas_item_editor->get_viewport_control()->is_connected("draw", this, "_canvas_draw"))
 			canvas_item_editor->get_viewport_control()->connect("draw", this, "_canvas_draw");
 		wip.clear();

--- a/editor/plugins/collision_polygon_editor_plugin.cpp
+++ b/editor/plugins/collision_polygon_editor_plugin.cpp
@@ -465,6 +465,10 @@ void CollisionPolygonEditor::edit(Node *p_collision_polygon) {
 	if (p_collision_polygon) {
 
 		node = Object::cast_to<CollisionPolygon>(p_collision_polygon);
+		//Enable the pencil tool if the polygon is empty
+		if (node->get_polygon().size() == 0) {
+			_menu_option(MODE_CREATE);
+		}
 		wip.clear();
 		wip_active = false;
 		edited_point = -1;

--- a/editor/plugins/navigation_polygon_editor_plugin.cpp
+++ b/editor/plugins/navigation_polygon_editor_plugin.cpp
@@ -69,6 +69,7 @@ void NavigationPolygonEditor::_create_nav() {
 	undo_redo->add_do_method(node, "set_navigation_polygon", Ref<NavigationPolygon>(memnew(NavigationPolygon)));
 	undo_redo->add_undo_method(node, "set_navigation_polygon", Variant(REF()));
 	undo_redo->commit_action();
+	_menu_option(MODE_CREATE);
 }
 
 void NavigationPolygonEditor::_menu_option(int p_option) {
@@ -423,6 +424,11 @@ void NavigationPolygonEditor::edit(Node *p_collision_polygon) {
 	if (p_collision_polygon) {
 
 		node = Object::cast_to<NavigationPolygonInstance>(p_collision_polygon);
+		//Enable the pencil tool if the polygon is empty
+		if (!node->get_navigation_polygon().is_null()) {
+			if(node->get_navigation_polygon()->get_polygon_count() == 0)
+				_menu_option(MODE_CREATE);
+		}
 		if (!canvas_item_editor->get_viewport_control()->is_connected("draw", this, "_canvas_draw"))
 			canvas_item_editor->get_viewport_control()->connect("draw", this, "_canvas_draw");
 		wip.clear();

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -698,6 +698,10 @@ void Polygon2DEditor::edit(Node *p_collision_polygon) {
 	if (p_collision_polygon) {
 
 		node = Object::cast_to<Polygon2D>(p_collision_polygon);
+		//Enable the pencil tool if the polygon is empty
+		if (node->get_polygon().size() == 0) {
+			_menu_option(MODE_CREATE);
+		}
 		if (!canvas_item_editor->get_viewport_control()->is_connected("draw", this, "_canvas_draw"))
 			canvas_item_editor->get_viewport_control()->connect("draw", this, "_canvas_draw");
 


### PR DESCRIPTION
Automatically select the "pencil" tool when a Polygon is created/clicked on.
Completes #9023 . 
Affects Polygon, Polygon2D, CollisionPolygon2D, and NavigationPolygons.

First PR, be gentle :D