### PR TITLE
Add handy get_size() method to Image class

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -343,6 +343,11 @@ int Image::get_height() const {
 	return height;
 }
 
+Vector2 Image::get_size() const {
+
+	return Vector2(width, height);
+}
+
 bool Image::has_mipmaps() const {
 
 	return mipmaps;
@@ -2215,6 +2220,7 @@ void Image::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_width"), &Image::get_width);
 	ClassDB::bind_method(D_METHOD("get_height"), &Image::get_height);
+	ClassDB::bind_method(D_METHOD("get_size"), &Image::get_size);
 	ClassDB::bind_method(D_METHOD("has_mipmaps"), &Image::has_mipmaps);
 	ClassDB::bind_method(D_METHOD("get_format"), &Image::get_format);
 	ClassDB::bind_method(D_METHOD("get_data"), &Image::get_data);

--- a/core/image.h
+++ b/core/image.h
@@ -177,6 +177,7 @@ private:
 public:
 	int get_width() const; ///< Get image width
 	int get_height() const; ///< Get image height
+	Vector2 get_size() const;
 	bool has_mipmaps() const;
 	int get_mipmap_count() const;
 


### PR DESCRIPTION
Instead of always doing:

`Vector2 image_size = Vector2(image.get_width(), image.get_height())`

Simplifies to this:

`Vector2 image_size = image.get_size()`