### PR TITLE
Code editor: Don't play hide and seek with error label

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1093,12 +1093,7 @@ void CodeTextEditor::update_editor_settings() {
 
 void CodeTextEditor::set_error(const String &p_error) {
 
-	if (p_error != "") {
-		error->set_text(p_error);
-		error->show();
-	} else {
-		error->hide();
-	}
+	error->set_text(p_error);
 }
 
 void CodeTextEditor::_update_font() {
@@ -1223,12 +1218,10 @@ CodeTextEditor::CodeTextEditor() {
 
 	error = memnew(Label);
 	status_bar->add_child(error);
-	error->hide();
 	error->set_clip_text(true); //do not change, or else very long errors can push the whole container to the right
 	error->set_valign(Label::VALIGN_CENTER);
 	error->add_color_override("font_color", Color(1, 0.7, 0.6, 0.9));
 	error->set_h_size_flags(SIZE_EXPAND_FILL); //required for it to display, given now it's clipping contents, do not touch
-	//status_bar->add_spacer();
 
 	Label *line_txt = memnew(Label);
 	status_bar->add_child(line_txt);


### PR DESCRIPTION
I found it annoying that the line/column count would jump based on whether an error is displayed or not.
I'm not sure why it was being hidden/shown in the first place, as it has no stylebox so just clearing the text is enough when there are no errors IMO.

Before:
![spectacle q27549](https://user-images.githubusercontent.com/4701338/29741436-5639da6e-8a6d-11e7-8d4d-25f2ef9b5cbe.png)
![spectacle f27549](https://user-images.githubusercontent.com/4701338/29741441-69921e96-8a6d-11e7-9547-dac6450f3259.png)

After:
![spectacle m27549](https://user-images.githubusercontent.com/4701338/29741428-1bcec722-8a6d-11e7-831e-5bbe15f7dea5.png)
![spectacle x27549](https://user-images.githubusercontent.com/4701338/29741430-2c0dbf8a-8a6d-11e7-8374-cb183f6579d6.png)