### PR TITLE
Make build scripts Python 3 compatible

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -265,17 +265,17 @@ if selected_platform in platform_list:
     CCFLAGS = env.get('CCFLAGS', '')
     env['CCFLAGS'] = ''
 
-    env.Append(CCFLAGS=string.split(str(CCFLAGS)))
+    env.Append(CCFLAGS=str(CCFLAGS).split())
 
     CFLAGS = env.get('CFLAGS', '')
     env['CFLAGS'] = ''
 
-    env.Append(CFLAGS=string.split(str(CFLAGS)))
+    env.Append(CFLAGS=str(CFLAGS).split())
 
     LINKFLAGS = env.get('LINKFLAGS', '')
     env['LINKFLAGS'] = ''
 
-    env.Append(LINKFLAGS=string.split(str(LINKFLAGS)))
+    env.Append(LINKFLAGS=str(LINKFLAGS).split())
 
     flag_list = platform_flags[selected_platform]
     for f in flag_list:

--- a/compat.py
+++ b/compat.py
@@ -1,0 +1,31 @@
+import sys
+
+if sys.version_info < (3,):
+    def isbasestring(s):
+        return isinstance(s, basestring)
+    def open_utf8(filename, mode):
+        return open(filename, mode)
+    def byte_to_str(x):
+        return str(ord(x))
+    import cStringIO
+    def StringIO():
+        return cStringIO.StringIO()
+    def encode_utf8(x):
+        return x
+    def iteritems(d):
+        return d.iteritems()
+else:
+    def isbasestring(s):
+        return isinstance(s, (str, bytes))
+    def open_utf8(filename, mode):
+        return open(filename, mode, encoding="utf-8")
+    def byte_to_str(x):
+        return str(x)
+    import io
+    def StringIO():
+        return io.StringIO()
+    import codecs
+    def encode_utf8(x):
+        return codecs.utf_8_encode(x)[0]
+    def iteritems(d):
+        return iter(d.items())

--- a/core/SCsub
+++ b/core/SCsub
@@ -18,7 +18,7 @@ gd_cpp = '#include "project_settings.h"\n'
 gd_cpp += gd_inc
 gd_cpp += "void ProjectSettings::register_global_defaults() {\n" + gd_call + "\n}\n"
 
-f = open("global_defaults.gen.cpp", "wb")
+f = open("global_defaults.gen.cpp", "w")
 f.write(gd_cpp)
 f.close()
 
@@ -47,7 +47,7 @@ if ("SCRIPT_AES256_ENCRYPTION_KEY" in os.environ):
         txt = "0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0"
         print("Invalid AES256 encryption key, not 64 bits hex: " + e)
 
-f = open("script_encryption_key.gen.cpp", "wb")
+f = open("script_encryption_key.gen.cpp", "w")
 f.write("#include \"project_settings.h\"\nuint8_t script_encryption_key[32]={" + txt + "};\n")
 f.close()
 

--- a/drivers/gles3/shaders/SCsub
+++ b/drivers/gles3/shaders/SCsub
@@ -2,7 +2,7 @@
 
 Import('env')
 
-if env['BUILDERS'].has_key('GLES3_GLSL'):
+if 'GLES3_GLSL' in env['BUILDERS']:
     env.GLES3_GLSL('copy.glsl');
     env.GLES3_GLSL('resolve.glsl');
     env.GLES3_GLSL('canvas.glsl');

--- a/drivers/unix/SCsub
+++ b/drivers/unix/SCsub
@@ -8,7 +8,7 @@ g_set_p += 'String OS_Unix::get_global_settings_path() const {\n'
 g_set_p += '\treturn "' + env["unix_global_settings_path"] + '";\n'
 g_set_p += '}\n'
 g_set_p += '#endif'
-f = open("os_unix_global_settings_path.gen.cpp", "wb")
+f = open("os_unix_global_settings_path.gen.cpp", "w")
 f.write(g_set_p)
 f.close()
 

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -351,7 +351,7 @@ if (env["tools"] == "yes"):
     reg_exporters = 'void register_exporters() {\n'
     for e in env.platform_exporters:
         env.editor_sources.append("#platform/" + e + "/export/export.cpp")
-	reg_exporters += '\tregister_' + e + '_exporter();\n'
+        reg_exporters += '\tregister_' + e + '_exporter();\n'
         reg_exporters_inc += '#include "platform/' + e + '/export/export.h"\n'
     reg_exporters += '}\n'
     f = open("register_exporters.gen.cpp", "wb")

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -4,6 +4,7 @@ Import('env')
 env.editor_sources = []
 
 import os
+from compat import encode_utf8, byte_to_str, open_utf8
 
 
 def make_certs_header(target, source, env):
@@ -11,7 +12,7 @@ def make_certs_header(target, source, env):
     src = source[0].srcnode().abspath
     dst = target[0].srcnode().abspath
     f = open(src, "rb")
-    g = open(dst, "wb")
+    g = open_utf8(dst, "w")
     buf = f.read()
     decomp_size = len(buf)
     import zlib
@@ -24,7 +25,7 @@ def make_certs_header(target, source, env):
     g.write("static const int _certs_uncompressed_size=" + str(decomp_size) + ";\n")
     g.write("static const unsigned char _certs_compressed[]={\n")
     for i in range(len(buf)):
-        g.write(str(ord(buf[i])) + ",\n")
+        g.write(byte_to_str(buf[i]) + ",\n")
     g.write("};\n")
     g.write("#endif")
 
@@ -32,20 +33,20 @@ def make_certs_header(target, source, env):
 def make_doc_header(target, source, env):
 
     dst = target[0].srcnode().abspath
-    g = open(dst, "wb")
+    g = open_utf8(dst, "w")
     buf = ""
     docbegin = ""
     docend = ""
     for s in source:
         src = s.srcnode().abspath
-        f = open(src, "rb")
+        f = open_utf8(src, "r")
         content = f.read()
         buf += content[content.find("<class"): content.rfind("</doc>")]
         if len(docbegin) == 0:
             docbegin = content[0: content.find("<class")]
         if len(docend) == 0:
             docend = content[content.rfind("</doc>"): len(buf)]
-    buf = docbegin + buf + docend
+    buf = encode_utf8(docbegin + buf + docend)
     decomp_size = len(buf)
     import zlib
     buf = zlib.compress(buf)
@@ -57,7 +58,7 @@ def make_doc_header(target, source, env):
     g.write("static const int _doc_data_uncompressed_size=" + str(decomp_size) + ";\n")
     g.write("static const unsigned char _doc_data_compressed[]={\n")
     for i in range(len(buf)):
-        g.write(str(ord(buf[i])) + ",\n")
+        g.write(byte_to_str(buf[i]) + ",\n")
     g.write("};\n")
     g.write("#endif")
 
@@ -66,7 +67,7 @@ def make_fonts_header(target, source, env):
 
     dst = target[0].srcnode().abspath
 
-    g = open(dst, "wb")
+    g = open_utf8(dst, "w")
 
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     g.write("#ifndef _EDITOR_FONTS_H\n")
@@ -84,7 +85,7 @@ def make_fonts_header(target, source, env):
         g.write("static const int _font_" + name + "_size=" + str(len(buf)) + ";\n")
         g.write("static const unsigned char _font_" + name + "[]={\n")
         for i in range(len(buf)):
-            g.write(str(ord(buf[i])) + ",\n")
+            g.write(byte_to_str(buf[i]) + ",\n")
 
         g.write("};\n")
 
@@ -95,7 +96,7 @@ def make_translations_header(target, source, env):
 
     dst = target[0].srcnode().abspath
 
-    g = open(dst, "wb")
+    g = open_utf8(dst, "w")
 
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     g.write("#ifndef _EDITOR_TRANSLATIONS_H\n")
@@ -119,7 +120,7 @@ def make_translations_header(target, source, env):
         #g.write("static const int _translation_"+name+"_uncompressed_size="+str(decomp_size)+";\n")
         g.write("static const unsigned char _translation_" + name + "_compressed[]={\n")
         for i in range(len(buf)):
-            g.write(str(ord(buf[i])) + ",\n")
+            g.write(byte_to_str(buf[i]) + ",\n")
 
         g.write("};\n")
 
@@ -146,8 +147,8 @@ def make_authors_header(target, source, env):
 
     src = source[0].srcnode().abspath
     dst = target[0].srcnode().abspath
-    f = open(src, "rb")
-    g = open(dst, "wb")
+    f = open_utf8(src, "r")
+    g = open_utf8(dst, "w")
 
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     g.write("#ifndef _EDITOR_AUTHORS_H\n")
@@ -188,9 +189,9 @@ def make_license_header(target, source, env):
     src_copyright = source[0].srcnode().abspath
     src_license = source[1].srcnode().abspath
     dst = target[0].srcnode().abspath
-    f = open(src_license, "rb")
-    fc = open(src_copyright, "rb")
-    g = open(dst, "wb")
+    f = open_utf8(src_license, "r")
+    fc = open_utf8(src_copyright, "r")
+    g = open_utf8(dst, "w")
 
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     g.write("#ifndef _EDITOR_LICENSE_H\n")
@@ -354,7 +355,7 @@ if (env["tools"] == "yes"):
         reg_exporters += '\tregister_' + e + '_exporter();\n'
         reg_exporters_inc += '#include "platform/' + e + '/export/export.h"\n'
     reg_exporters += '}\n'
-    f = open("register_exporters.gen.cpp", "wb")
+    f = open_utf8("register_exporters.gen.cpp", "w")
     f.write(reg_exporters_inc)
     f.write(reg_exporters)
     f.close()

--- a/editor/icons/SCsub
+++ b/editor/icons/SCsub
@@ -1,18 +1,17 @@
 #!/usr/bin/env python
 
 Import('env')
-
+from compat import StringIO
 
 def make_editor_icons_action(target, source, env):
 
     import os
-    import cStringIO
 
     dst = target[0].srcnode().abspath
     svg_icons = source
 
-    whites = cStringIO.StringIO()
-    darks = cStringIO.StringIO()
+    whites = StringIO()
+    darks = StringIO()
 
     for f in svg_icons:
 
@@ -48,7 +47,7 @@ def make_editor_icons_action(target, source, env):
         whites.write('\n')
         darks.write('\n')
 
-    s = cStringIO.StringIO()
+    s = StringIO()
     s.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     s.write("#ifndef _EDITOR_ICONS_H\n")
     s.write("#define _EDITOR_ICONS_H\n")
@@ -75,7 +74,7 @@ def make_editor_icons_action(target, source, env):
     s.write("#endif\n")
 
 
-    f = open(dst, "wb")
+    f = open(dst, "w")
     f.write(s.getvalue())
     f.close()
     s.close()

--- a/main/SCsub
+++ b/main/SCsub
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 Import('env')
+from compat import byte_to_str
 
 
 def make_splash(target, source, env):
@@ -8,17 +9,17 @@ def make_splash(target, source, env):
     src = source[0].srcnode().abspath
     dst = target[0].srcnode().abspath
     f = open(src, "rb")
-    g = open(dst, "wb")
+    g = open(dst, "w")
 
     buf = f.read()
 
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     g.write("#ifndef BOOT_SPLASH_H\n")
     g.write("#define BOOT_SPLASH_H\n")
-    g.write("static const Color boot_splash_bg_color = Color(1,1,1,1);\n");
+    g.write("static const Color boot_splash_bg_color = Color(1,1,1,1);\n")
     g.write("static const unsigned char boot_splash_png[] = {\n")
     for i in range(len(buf)):
-        g.write(str(ord(buf[i])) + ",\n")
+        g.write(byte_to_str(buf[i]) + ",\n")
     g.write("};\n")
     g.write("#endif")
 
@@ -28,7 +29,7 @@ def make_app_icon(target, source, env):
     src = source[0].srcnode().abspath
     dst = target[0].srcnode().abspath
     f = open(src, "rb")
-    g = open(dst, "wb")
+    g = open(dst, "w")
 
     buf = f.read()
 
@@ -37,7 +38,7 @@ def make_app_icon(target, source, env):
     g.write("#define APP_ICON_H\n")
     g.write("static const unsigned char app_icon_png[] = {\n")
     for i in range(len(buf)):
-        g.write(str(ord(buf[i])) + ",\n")
+        g.write(byte_to_str(buf[i]) + ",\n")
     g.write("};\n")
     g.write("#endif")
 

--- a/main/SCsub
+++ b/main/SCsub
@@ -18,7 +18,7 @@ def make_splash(target, source, env):
     g.write("static const Color boot_splash_bg_color = Color(1,1,1,1);\n");
     g.write("static const unsigned char boot_splash_png[] = {\n")
     for i in range(len(buf)):
-	g.write(str(ord(buf[i])) + ",\n")
+        g.write(str(ord(buf[i])) + ",\n")
     g.write("};\n")
     g.write("#endif")
 
@@ -37,7 +37,7 @@ def make_app_icon(target, source, env):
     g.write("#define APP_ICON_H\n")
     g.write("static const unsigned char app_icon_png[] = {\n")
     for i in range(len(buf)):
-	g.write(str(ord(buf[i])) + ",\n")
+        g.write(str(ord(buf[i])) + ",\n")
     g.write("};\n")
     g.write("#endif")
 

--- a/methods.py
+++ b/methods.py
@@ -1,4 +1,5 @@
 import os
+from compat import iteritems
 
 
 def add_source_files(self, sources, filetype, lib_env=None, shared=False):
@@ -21,7 +22,7 @@ def add_source_files(self, sources, filetype, lib_env=None, shared=False):
 def build_shader_header(target, source, env):
 
     for x in source:
-        print x
+        print(x)
 
         name = str(x)
         name = name[name.rfind("/") + 1:]
@@ -704,11 +705,11 @@ def include_file_in_legacygl_header(filename, header_data, depth):
             if (not included_file in header_data.vertex_included_files and header_data.reading == "vertex"):
                 header_data.vertex_included_files += [included_file]
                 if(include_file_in_legacygl_header(included_file, header_data, depth + 1) == None):
-                    print "Error in file '" + filename + "': #include " + includeline + "could not be found!"
+                    print("Error in file '" + filename + "': #include " + includeline + "could not be found!")
             elif (not included_file in header_data.fragment_included_files and header_data.reading == "fragment"):
                 header_data.fragment_included_files += [included_file]
                 if(include_file_in_legacygl_header(included_file, header_data, depth + 1) == None):
-                    print "Error in file '" + filename + "': #include " + includeline + "could not be found!"
+                    print("Error in file '" + filename + "': #include " + includeline + "could not be found!")
 
             line = fs.readline()
 
@@ -1160,7 +1161,7 @@ def update_version():
         print("Using custom revision: " + rev)
     import version
 
-    f = open("core/version_generated.gen.h", "wb")
+    f = open("core/version_generated.gen.h", "w")
     f.write("#define VERSION_SHORT_NAME " + str(version.short_name) + "\n")
     f.write("#define VERSION_NAME " + str(version.name) + "\n")
     f.write("#define VERSION_MAJOR " + str(version.major) + "\n")
@@ -1173,14 +1174,14 @@ def update_version():
     f.write("#define VERSION_YEAR " + str(datetime.datetime.now().year) + "\n")
     f.close()
 
-    fhash = open("core/version_hash.gen.h", "wb")
+    fhash = open("core/version_hash.gen.h", "w")
     githash = ""
     if os.path.isfile(".git/HEAD"):
-        head = open(".git/HEAD", "rb").readline().strip()
+        head = open(".git/HEAD", "r").readline().strip()
         if head.startswith("ref: "):
             head = ".git/" + head[5:]
             if os.path.isfile(head):
-                githash = open(head, "rb").readline().strip()
+                githash = open(head, "r").readline().strip()
         else:
             githash = head
     fhash.write("#define VERSION_HASH \"" + githash + "\"")
@@ -1308,7 +1309,7 @@ void unregister_module_types() {
 
 """
 
-    f = open("modules/register_module_types.gen.cpp", "wb")
+    f = open("modules/register_module_types.gen.cpp", "w")
     f.write(modules_cpp)
 
     return module_list
@@ -1328,9 +1329,9 @@ def win32_spawn(sh, escape, cmd, args, env):
     data, err = proc.communicate()
     rv = proc.wait()
     if rv:
-        print "====="
-        print err
-        print "====="
+        print("=====")
+        print(err)
+        print("=====")
     return rv
 
 """
@@ -1404,17 +1405,17 @@ def android_add_default_config(self, config):
 
 def android_add_to_manifest(self, file):
     base_path = self.Dir(".").abspath + "/modules/" + self.current_module + "/" + file
-    f = open(base_path, "rb")
+    f = open(base_path, "r")
     self.android_manifest_chunk += f.read()
 
 def android_add_to_permissions(self, file):
     base_path = self.Dir(".").abspath + "/modules/" + self.current_module + "/" + file
-    f = open(base_path, "rb")
+    f = open(base_path, "r")
     self.android_permission_chunk += f.read()
 
 def android_add_to_attributes(self, file):
     base_path = self.Dir(".").abspath + "/modules/" + self.current_module + "/" + file
-    f = open(base_path, "rb")
+    f = open(base_path, "r")
     self.android_appattributes_chunk += f.read()
 
 def disable_module(self):
@@ -1449,9 +1450,9 @@ def use_windows_spawn_fix(self, platform=None):
         data, err = proc.communicate()
         rv = proc.wait()
         if rv:
-            print "====="
-            print err
-            print "====="
+            print("=====")
+            print(err)
+            print("=====")
         return rv
 
     def mySpawn(sh, escape, cmd, args, env):
@@ -1460,7 +1461,7 @@ def use_windows_spawn_fix(self, platform=None):
         cmdline = cmd + " " + newargs
 
         rv = 0
-        env = {str(key): str(value) for key, value in env.iteritems()}
+        env = {str(key): str(value) for key, value in iteritems(env)}
         if len(cmdline) > 32000 and cmd.endswith("ar"):
             cmdline = cmd + " " + args[1] + " " + args[2] + " "
             for i in range(3, len(args)):
@@ -1540,7 +1541,7 @@ def save_active_platforms(apnames, ap):
             str += "};\n"
 
             wf = x + "/" + name + ".gen.h"
-            pngw = open(wf, "wb")
+            pngw = open(wf, "w")
             pngw.write(str)
 
 
@@ -1608,7 +1609,7 @@ def detect_visual_c_compiler_version(tools_env):
 
     # Start with Pre VS 2017 checks which uses VCINSTALLDIR:
     if 'VCINSTALLDIR' in tools_env:
-        # print "Checking VCINSTALLDIR"
+        # print("Checking VCINSTALLDIR")
 
         # find() works with -1 so big ifs bellow are needed... the simplest solution, in fact
         # First test if amd64 and amd64_x86 compilers are present in the path
@@ -1641,7 +1642,7 @@ def detect_visual_c_compiler_version(tools_env):
 
     # and for VS 2017 and newer we check VCTOOLSINSTALLDIR:
     if 'VCTOOLSINSTALLDIR' in tools_env:
-        # print "Checking VCTOOLSINSTALLDIR"
+        # print("Checking VCTOOLSINSTALLDIR")
 
         # Newer versions have a different path available
         vc_amd64_compiler_detection_index = tools_env["PATH"].upper().find(tools_env['VCTOOLSINSTALLDIR'].upper() + "BIN\\HOSTX64\\X64;")
@@ -1671,11 +1672,11 @@ def detect_visual_c_compiler_version(tools_env):
             vc_chosen_compiler_str = "x86_amd64"
 
     # debug help
-    # print vc_amd64_compiler_detection_index
-    # print vc_amd64_x86_compiler_detection_index
-    # print vc_x86_compiler_detection_index
-    # print vc_x86_amd64_compiler_detection_index
-    # print "chosen "+str(vc_chosen_compiler_index)+ " | "+str(vc_chosen_compiler_str)
+    # print(vc_amd64_compiler_detection_index)
+    # print(vc_amd64_x86_compiler_detection_index)
+    # print(vc_x86_compiler_detection_index)
+    # print(vc_x86_amd64_compiler_detection_index)
+    # print("chosen "+str(vc_chosen_compiler_index)+ " | "+str(vc_chosen_compiler_str))
 
     return vc_chosen_compiler_str
 

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 Import('env')
+from compat import isbasestring
 
 # Not building in a separate env as scene needs it
 
@@ -74,7 +75,7 @@ if (env['builtin_freetype'] != 'no'):
     # and then plain strings for system library. We insert between the two.
     inserted = False
     for idx, linklib in enumerate(env["LIBS"]):
-        if isinstance(linklib, basestring): # first system lib such as "X11", otherwise SCons lib object
+        if isbasestring(linklib): # first system lib such as "X11", otherwise SCons lib object
             env["LIBS"].insert(idx, lib)
             inserted = True
             break

--- a/modules/svg/SCsub
+++ b/modules/svg/SCsub
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 Import('env')
+from compat import isbasestring
 
 # Thirdparty source files
 thirdparty_dir = "#thirdparty/nanosvg/"
@@ -18,7 +19,7 @@ lib = env.Library("svg_builtin", thirdparty_sources)
 # and then plain strings for system library. We insert between the two.
 inserted = False
 for idx, linklib in enumerate(env["LIBS"]):
-    if isinstance(linklib, basestring): # first system lib such as "X11", otherwise SCons lib object
+    if isbasestring(linklib): # first system lib such as "X11", otherwise SCons lib object
         env["LIBS"].insert(idx, lib)
         inserted = True
         break

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import shutil
+from compat import open_utf8
 
 Import('env')
 
@@ -40,8 +41,8 @@ prog = None
 abspath = env.Dir(".").abspath
 
 
-gradle_basein = open(abspath + "/build.gradle.template", "rb")
-gradle_baseout = open(abspath + "/java/build.gradle", "wb")
+gradle_basein = open_utf8(abspath + "/build.gradle.template", "r")
+gradle_baseout = open_utf8(abspath + "/java/build.gradle", "w")
 
 gradle_text = gradle_basein.read()
 
@@ -124,8 +125,8 @@ gradle_baseout.write(gradle_text)
 gradle_baseout.close()
 
 
-pp_basein = open(abspath + "/AndroidManifest.xml.template", "rb")
-pp_baseout = open(abspath + "/java/AndroidManifest.xml", "wb")
+pp_basein = open_utf8(abspath + "/AndroidManifest.xml.template", "r")
+pp_baseout = open_utf8(abspath + "/java/AndroidManifest.xml", "w")
 manifest = pp_basein.read()
 manifest = manifest.replace("$$ADD_APPLICATION_CHUNKS$$", env.android_manifest_chunk)
 manifest = manifest.replace("$$ADD_PERMISSION_CHUNKS$$", env.android_permission_chunk)
@@ -146,7 +147,7 @@ elif env['android_arch'] == 'arm64v8':
 elif env['android_arch'] == 'x86':
     lib_arch_dir = 'x86'
 else:
-    print 'WARN: Architecture not suitable for embedding into APK; keeping .so at \\bin'
+    print('WARN: Architecture not suitable for embedding into APK; keeping .so at \\bin')
 
 if lib_arch_dir != '':
     if env['target'] == 'release':

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -14,7 +14,7 @@ def get_name():
 
 def can_build():
 
-    return (os.environ.has_key("ANDROID_NDK_ROOT"))
+    return ("ANDROID_NDK_ROOT" in os.environ)
 
 
 def get_opts():
@@ -55,7 +55,7 @@ def configure(env):
         import subprocess
 
         def mySubProcess(cmdline, env):
-            # print "SPAWNED : " + cmdline
+            # print("SPAWNED : " + cmdline)
             startupinfo = subprocess.STARTUPINFO()
             startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
             proc = subprocess.Popen(cmdline, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
@@ -63,9 +63,9 @@ def configure(env):
             data, err = proc.communicate()
             rv = proc.wait()
             if rv:
-                print "====="
-                print err
-                print "====="
+                print("=====")
+                print(err)
+                print("=====")
             return rv
 
         def mySpawn(sh, escape, cmd, args, env):
@@ -183,8 +183,8 @@ def configure(env):
     ## Compile flags
 
     env.Append(CPPFLAGS=["-isystem", sysroot + "/usr/include"])
-    env.Append(CPPFLAGS=string.split('-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -fvisibility=hidden -fno-strict-aliasing'))
-    env.Append(CPPFLAGS=string.split('-DNO_STATVFS -DGLES2_ENABLED'))
+    env.Append(CPPFLAGS='-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -fvisibility=hidden -fno-strict-aliasing'.split())
+    env.Append(CPPFLAGS='-DNO_STATVFS -DGLES2_ENABLED'.split())
 
     env['neon_enabled'] = False
     if env['android_arch'] == 'x86':
@@ -194,11 +194,11 @@ def configure(env):
 
     elif env["android_arch"] == "armv6":
         target_opts = ['-target', 'armv6-none-linux-androideabi']
-        env.Append(CPPFLAGS=string.split('-D__ARM_ARCH_6__ -march=armv6 -mfpu=vfp -mfloat-abi=softfp'))
+        env.Append(CPPFLAGS='-D__ARM_ARCH_6__ -march=armv6 -mfpu=vfp -mfloat-abi=softfp'.split())
 
     elif env["android_arch"] == "armv7":
         target_opts = ['-target', 'armv7-none-linux-androideabi']
-        env.Append(CPPFLAGS=string.split('-D__ARM_ARCH_7__ -D__ARM_ARCH_7A__ -march=armv7-a -mfloat-abi=softfp'))
+        env.Append(CPPFLAGS='-D__ARM_ARCH_7__ -D__ARM_ARCH_7A__ -march=armv7-a -mfloat-abi=softfp'.split())
         if env['android_neon'] == 'yes':
             env['neon_enabled'] = True
             env.Append(CPPFLAGS=['-mfpu=neon', '-D__ARM_NEON__'])
@@ -225,9 +225,9 @@ def configure(env):
 
     env['LINKFLAGS'] = ['-shared', '--sysroot=' + sysroot, '-Wl,--warn-shared-textrel']
     if env["android_arch"] == "armv7":
-        env.Append(LINKFLAGS=string.split('-Wl,--fix-cortex-a8'))
-    env.Append(LINKFLAGS=string.split('-Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now'))
-    env.Append(LINKFLAGS=string.split('-Wl,-soname,libgodot_android.so -Wl,--gc-sections'))
+        env.Append(LINKFLAGS='-Wl,--fix-cortex-a8'.split())
+    env.Append(LINKFLAGS='-Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now'.split())
+    env.Append(LINKFLAGS='-Wl,-soname,libgodot_android.so -Wl,--gc-sections'.split())
     if mt_link:
         env.Append(LINKFLAGS=['-Wl,--threads'])
     env.Append(LINKFLAGS=target_opts)

--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -13,7 +13,7 @@ def get_name():
 
 def can_build():
 
-    if sys.platform == 'darwin' or os.environ.has_key("OSXCROSS_IOS"):
+    if sys.platform == 'darwin' or ("OSXCROSS_IOS" in os.environ):
         return True
 
     return False
@@ -83,11 +83,11 @@ def configure(env):
     if (env["arch"] == "x86"):
         env['IPHONEPLATFORM'] = 'iPhoneSimulator'
         env['ENV']['MACOSX_DEPLOYMENT_TARGET'] = '10.6'
-        env.Append(CCFLAGS=string.split('-arch i386 -fobjc-abi-version=2 -fobjc-legacy-dispatch -fmessage-length=0 -fpascal-strings -fblocks -fasm-blocks -D__IPHONE_OS_VERSION_MIN_REQUIRED=40100 -isysroot $IPHONESDK -mios-simulator-version-min=4.3 -DCUSTOM_MATRIX_TRANSFORM_H=\\\"build/iphone/matrix4_iphone.h\\\" -DCUSTOM_VECTOR3_TRANSFORM_H=\\\"build/iphone/vector3_iphone.h\\\"'))
+        env.Append(CCFLAGS='-arch i386 -fobjc-abi-version=2 -fobjc-legacy-dispatch -fmessage-length=0 -fpascal-strings -fblocks -fasm-blocks -D__IPHONE_OS_VERSION_MIN_REQUIRED=40100 -isysroot $IPHONESDK -mios-simulator-version-min=4.3 -DCUSTOM_MATRIX_TRANSFORM_H=\\\"build/iphone/matrix4_iphone.h\\\" -DCUSTOM_VECTOR3_TRANSFORM_H=\\\"build/iphone/vector3_iphone.h\\\"'.split())
     elif (env["arch"] == "arm"):
-        env.Append(CCFLAGS=string.split('-fno-objc-arc -arch armv7 -fmessage-length=0 -fno-strict-aliasing -fdiagnostics-print-source-range-info -fdiagnostics-show-category=id -fdiagnostics-parseable-fixits -fpascal-strings -fblocks -isysroot $IPHONESDK -fvisibility=hidden -mthumb "-DIBOutlet=__attribute__((iboutlet))" "-DIBOutletCollection(ClassName)=__attribute__((iboutletcollection(ClassName)))" "-DIBAction=void)__attribute__((ibaction)" -miphoneos-version-min=9.0 -MMD -MT dependencies'))
+        env.Append(CCFLAGS='-fno-objc-arc -arch armv7 -fmessage-length=0 -fno-strict-aliasing -fdiagnostics-print-source-range-info -fdiagnostics-show-category=id -fdiagnostics-parseable-fixits -fpascal-strings -fblocks -isysroot $IPHONESDK -fvisibility=hidden -mthumb "-DIBOutlet=__attribute__((iboutlet))" "-DIBOutletCollection(ClassName)=__attribute__((iboutletcollection(ClassName)))" "-DIBAction=void)__attribute__((ibaction)" -miphoneos-version-min=9.0 -MMD -MT dependencies'.split())
     elif (env["arch"] == "arm64"):
-        env.Append(CCFLAGS=string.split('-fno-objc-arc -arch arm64 -fmessage-length=0 -fno-strict-aliasing -fdiagnostics-print-source-range-info -fdiagnostics-show-category=id -fdiagnostics-parseable-fixits -fpascal-strings -fblocks -fvisibility=hidden -MMD -MT dependencies -miphoneos-version-min=9.0 -isysroot $IPHONESDK'))
+        env.Append(CCFLAGS='-fno-objc-arc -arch arm64 -fmessage-length=0 -fno-strict-aliasing -fdiagnostics-print-source-range-info -fdiagnostics-show-category=id -fdiagnostics-parseable-fixits -fpascal-strings -fblocks -fvisibility=hidden -MMD -MT dependencies -miphoneos-version-min=9.0 -isysroot $IPHONESDK'.split())
         env.Append(CPPFLAGS=['-DNEED_LONG_INT'])
         env.Append(CPPFLAGS=['-DLIBYUV_DISABLE_NEON'])
 

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -13,7 +13,7 @@ def get_name():
 
 def can_build():
 
-    return (os.environ.has_key("EMSCRIPTEN_ROOT"))
+    return ("EMSCRIPTEN_ROOT" in os.environ)
 
 
 def get_opts():

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -12,7 +12,7 @@ def get_name():
 
 def can_build():
 
-    if (sys.platform == "darwin" or os.environ.has_key("OSXCROSS_ROOT")):
+    if (sys.platform == "darwin" or ("OSXCROSS_ROOT" in os.environ)):
         return True
 
     return False

--- a/platform/uwp/detect.py
+++ b/platform/uwp/detect.py
@@ -145,8 +145,8 @@ def configure(env):
     env.Append(CPPFLAGS=['/AI', vc_base_path + 'lib/store/references'])
     env.Append(CPPFLAGS=['/AI', vc_base_path + 'lib/x86/store/references'])
 
-    env.Append(CCFLAGS=string.split('/FS /MP /GS /wd"4453" /wd"28204" /wd"4291" /Zc:wchar_t /Gm- /fp:precise /D "_UNICODE" /D "UNICODE" /D "WINAPI_FAMILY=WINAPI_FAMILY_APP" /errorReport:prompt /WX- /Zc:forScope /Gd /EHsc /nologo'))
-    env.Append(CXXFLAGS=string.split('/ZW /FS'))
+    env.Append(CCFLAGS='/FS /MP /GS /wd"4453" /wd"28204" /wd"4291" /Zc:wchar_t /Gm- /fp:precise /D "_UNICODE" /D "UNICODE" /D "WINAPI_FAMILY=WINAPI_FAMILY_APP" /errorReport:prompt /WX- /Zc:forScope /Gd /EHsc /nologo'.split())
+    env.Append(CXXFLAGS='/ZW /FS'.split())
     env.Append(CCFLAGS=['/AI', vc_base_path + '\\vcpackages', '/AI', os.environ['WINDOWSSDKDIR'] + '\\References\\CommonConfiguration\\Neutral'])
 
     ## Link flags


### PR DESCRIPTION
SCons 3.0 alpha supports Python 3. These changes update the build files so that Godot can be built with Python 3 when using the new Scons version. 

I've tested the build process with Python 2.7 and 3.6 on Windows. I'm not sure if there are incompatibilities when building with Python < 2.7.

I haven't updated the build scripts for platforms other than Windows but I can do so if the consensus is that this is the right way to move forward.