### PR TITLE
Added freelook inertia

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -672,6 +672,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("editors/3d/warped_mouse_panning", true);
 
 	set("editors/3d/orbit_sensitivity", 0.4);
+	set("editors/3d/freelook_inertia", 3);
 
 	set("editors/3d/freelook_base_speed", 1);
 

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -122,6 +122,7 @@ private:
 	float gizmo_scale;
 
 	bool freelook_active;
+	Vector3 freelook_velocity;
 
 	PanelContainer *info;
 	Label *info_label;


### PR DESCRIPTION
As mentionned in https://github.com/godotengine/godot/issues/10463#issuecomment-325148756
It's nice to have because unlike mouse-based navigation, keyboard movement is all-or-nothing, so it makes it smoother.

Here is a video of the inertia I implemented:
https://www.youtube.com/watch?v=jFpizpEM5o8&feature=youtu.be
It's basically a setting where 0 = no inertia, and the higher it is, the more inertia it applies.
It's still based on lerp, but I inverted the value, because using lerp speed would mean that "no inertia" would be +inf speed, while I find it more natural to have more inertia if the number is higher, zero consistenly turning it off as a result.