### PR TITLE
Always size project icons to default icon size

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -805,7 +805,8 @@ void ProjectManager::_load_recent_projects() {
 				Error err = img->load(appicon.replace_first("res://", path + "/"));
 				if (err == OK) {
 
-					img->resize(64, 64);
+					Ref<Texture> default_icon = get_icon("DefaultProjectIcon", "EditorIcons");
+					img->resize(default_icon->get_width(), default_icon->get_height());
 					Ref<ImageTexture> it = memnew(ImageTexture);
 					it->create_from_image(img);
 					icon = it;


### PR DESCRIPTION
I wasn't able to reproduce the issue, but this should fix #10620