### PR TITLE
Use memset to zero z_list

### DIFF
--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -37,10 +37,8 @@ void VisualServerCanvas::_render_canvas_item_tree(Item *p_canvas_item, const Tra
 	RasterizerCanvas::Item *z_list[z_range];
 	RasterizerCanvas::Item *z_last_list[z_range];
 
-	for (int i = 0; i < z_range; i++) {
-		z_list[i] = NULL;
-		z_last_list[i] = NULL;
-	}
+	memset(z_list, 0, z_range * sizeof(RasterizerCanvas::Item *));
+	memset(z_last_list, 0, z_range * sizeof(RasterizerCanvas::Item *));
 
 	_render_canvas_item(p_canvas_item, p_transform, p_clip_rect, Color(1, 1, 1, 1), 0, z_list, z_last_list, NULL, NULL);
 
@@ -200,10 +198,9 @@ void VisualServerCanvas::render_canvas(Canvas *p_canvas, const Transform2D &p_tr
 		RasterizerCanvas::Item *z_list[z_range];
 		RasterizerCanvas::Item *z_last_list[z_range];
 
-		for (int i = 0; i < z_range; i++) {
-			z_list[i] = NULL;
-			z_last_list[i] = NULL;
-		}
+		memset(z_list, 0, z_range * sizeof(RasterizerCanvas::Item *));
+		memset(z_last_list, 0, z_range * sizeof(RasterizerCanvas::Item *));
+
 		for (int i = 0; i < l; i++) {
 			_render_canvas_item(ci[i].item, p_transform, p_clip_rect, Color(1, 1, 1, 1), 0, z_list, z_last_list, NULL, NULL);
 		}


### PR DESCRIPTION
Using gprof I found the engine spending 10 - 20% of time in the
_render_canvas_item_tree function. The function profiles as using
about 0.09ms. Swapping the loop with two memset() calls reduces
the time spent in this function a lot, and the time per call to
about 0.02ms.
    
Likewise the render_canvas function was using ~10% of time, replacing
the loop there dropped per-call time from 0.22ms to 0.18ms.

This profiling was done on the platformer 2d demo.
