### PR TITLE
Cleaned up logic in Tween::_tween_process(), fixes #9187

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -559,12 +559,16 @@ void Tween::_tween_process(float p_delta) {
 
 		switch (data.type) {
 			case INTER_PROPERTY:
-			case INTER_METHOD:
-				break;
+			case INTER_METHOD: {
+				Variant result = _run_equation(data);
+				emit_signal("tween_step", object, data.key, data.elapsed, result);
+				_apply_tween_value(data, result);
+				if (data.finish)
+					_apply_tween_value(data, data.final_val);
+			} break;
+
 			case INTER_CALLBACK:
 				if (data.finish) {
-
-					Variant::CallError error;
 					if (data.call_deferred) {
 
 						switch (data.args) {
@@ -587,8 +591,8 @@ void Tween::_tween_process(float p_delta) {
 								object->call_deferred(data.key, data.arg[0], data.arg[1], data.arg[2], data.arg[3], data.arg[4]);
 								break;
 						}
-
 					} else {
+						Variant::CallError error;
 						Variant *arg[5] = {
 							&data.arg[0],
 							&data.arg[1],
@@ -598,19 +602,11 @@ void Tween::_tween_process(float p_delta) {
 						};
 						object->call(data.key, (const Variant **)arg, data.args, error);
 					}
-					if (!repeat)
-						call_deferred("remove", object, data.key);
 				}
-				continue;
+				break;
 		}
 
-		Variant result = _run_equation(data);
-		emit_signal("tween_step", object, data.key, data.elapsed, result);
-
-		_apply_tween_value(data, result);
-
 		if (data.finish) {
-			_apply_tween_value(data, data.final_val);
 			emit_signal("tween_complete", object, data.key);
 			// not repeat mode, remove completed action
 			if (!repeat)


### PR DESCRIPTION
Fixes the issue of `tween_complete` not being emitted for `interpolate_callback()`/`interpolate_deferred_callback()`.
The logic was also cleaned up a bit to make it, IMHO, more clear.

This issue is also present in the master branch but I'm submitting this PR to the 2.1 branch as I think it'd be nice to get in to 2.1.4 before the release candidate period is up.