### PR TITLE
Fix TreeItem::get_metadata documentation

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -48775,6 +48775,8 @@
 			</description>
 		</method>
 		<method name="get_metadata" qualifiers="const">
+			<return type="Variant">
+			</return>
 			<argument index="0" name="column" type="int">
 			</argument>
 			<description>


### PR DESCRIPTION
Missing return type makes it `void` in the docs and GDNative.