### PR TITLE
Fix wall detection on move_and_slide (2.1).

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1211,7 +1211,7 @@ Vector2 KinematicBody2D::move_to(const Vector2 &p_position) {
 	return move(p_position - get_global_pos());
 }
 
-Vector2 KinematicBody2D::move_and_slide(const Vector2 &p_linear_velocity, const Vector2 &p_floor_direction, float p_slope_stop_min_velocity, int p_max_bounces) {
+Vector2 KinematicBody2D::move_and_slide(const Vector2 &p_linear_velocity, const Vector2 &p_floor_direction, float p_slope_stop_min_velocity, int p_max_bounces, float p_floor_max_angle) {
 
 	Vector2 motion = (move_and_slide_floor_velocity + p_linear_velocity) * get_fixed_process_delta_time();
 	Vector2 lv = p_linear_velocity;
@@ -1232,8 +1232,7 @@ Vector2 KinematicBody2D::move_and_slide(const Vector2 &p_linear_velocity, const 
 				//all is a wall
 				move_and_slide_on_wall = true;
 			} else {
-				if (get_collision_normal().dot(p_floor_direction) > Math::cos(Math::deg2rad((float)45))) { //floor
-
+				if (get_collision_normal().dot(p_floor_direction) >= Math::cos(p_floor_max_angle)) { //floor
 					move_and_slide_on_floor = true;
 					move_and_slide_floor_velocity = get_collider_velocity();
 
@@ -1241,7 +1240,7 @@ Vector2 KinematicBody2D::move_and_slide(const Vector2 &p_linear_velocity, const 
 						revert_motion();
 						return Vector2();
 					}
-				} else if (get_collision_normal().dot(p_floor_direction) < Math::cos(Math::deg2rad((float)45))) { //ceiling
+				} else if (get_collision_normal().dot(-p_floor_direction) >= Math::cos(p_floor_max_angle)) { //ceiling
 					move_and_slide_on_ceiling = true;
 				} else {
 					move_and_slide_on_wall = true;
@@ -1359,7 +1358,7 @@ void KinematicBody2D::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("move", "rel_vec"), &KinematicBody2D::move);
 	ObjectTypeDB::bind_method(_MD("move_to", "position"), &KinematicBody2D::move_to);
-	ObjectTypeDB::bind_method(_MD("move_and_slide", "linear_velocity", "floor_normal", "slope_stop_min_velocity", "max_bounces"), &KinematicBody2D::move_and_slide, DEFVAL(Vector2(0, 0)), DEFVAL(5), DEFVAL(4));
+	ObjectTypeDB::bind_method(_MD("move_and_slide", "linear_velocity", "floor_normal", "slope_stop_min_velocity", "max_bounces", "floor_max_angle"), &KinematicBody2D::move_and_slide, DEFVAL(Vector2(0, 0)), DEFVAL(5), DEFVAL(4), DEFVAL(Math::deg2rad((float)45)));
 
 	ObjectTypeDB::bind_method(_MD("get_move_and_slide_colliders"), &KinematicBody2D::get_move_and_slide_colliders);
 	ObjectTypeDB::bind_method(_MD("is_move_and_slide_on_floor"), &KinematicBody2D::is_move_and_slide_on_floor);

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -323,7 +323,7 @@ public:
 	void set_collision_margin(float p_margin);
 	float get_collision_margin() const;
 
-	Vector2 move_and_slide(const Vector2 &p_linear_velocity, const Vector2 &p_floor_direction = Vector2(0, 0), float p_slope_stop_min_velocity = 5, int p_max_bounces = 4);
+	Vector2 move_and_slide(const Vector2 &p_linear_velocity, const Vector2 &p_floor_direction = Vector2(0, 0), float p_slope_stop_min_velocity = 5, int p_max_bounces = 4, float p_floor_max_angle = Math::deg2rad((float)45));
 	bool is_move_and_slide_on_floor() const;
 	bool is_move_and_slide_on_wall() const;
 	bool is_move_and_slide_on_ceiling() const;


### PR DESCRIPTION
Fixed a bug on wall detection (walls were never detected). 
Now  `is_move_and_slide_on_wall/ceiling/floor` methods give the correct results.

Also added floor angle as optional parameter like on the 3.0 counterpart (floor and ceiling share the same parameter).