### PR TITLE
DocData and virtual method type hints fixes

### DIFF
--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -539,8 +539,9 @@ void ClassDB::get_method_list(StringName p_class, List<MethodInfo> *p_methods, b
 			}
 
 			minfo.return_val = method->get_return_info();
-
 			minfo.flags = method->get_hint_flags();
+			minfo.default_arguments = method->get_default_arguments();
+
 			p_methods->push_back(minfo);
 		}
 

--- a/core/method_bind.h
+++ b/core/method_bind.h
@@ -334,6 +334,7 @@ public:
 		}
 		argument_types = at;
 		arguments = p_info;
+		arguments.return_val.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
 #endif
 	}
 

--- a/core/object.cpp
+++ b/core/object.cpp
@@ -274,6 +274,63 @@ MethodInfo::MethodInfo(Variant::Type ret, const String &p_name, const PropertyIn
 	arguments.push_back(p_param5);
 }
 
+MethodInfo::MethodInfo(const PropertyInfo &p_ret, const String &p_name)
+	: name(p_name),
+	  flags(METHOD_FLAG_NORMAL),
+	  id(0) {
+	return_val = p_ret;
+}
+
+MethodInfo::MethodInfo(const PropertyInfo &p_ret, const String &p_name, const PropertyInfo &p_param1)
+	: name(p_name),
+	  flags(METHOD_FLAG_NORMAL),
+	  id(0) {
+	return_val = p_ret;
+	arguments.push_back(p_param1);
+}
+
+MethodInfo::MethodInfo(const PropertyInfo &p_ret, const String &p_name, const PropertyInfo &p_param1, const PropertyInfo &p_param2)
+	: name(p_name),
+	  flags(METHOD_FLAG_NORMAL),
+	  id(0) {
+	return_val = p_ret;
+	arguments.push_back(p_param1);
+	arguments.push_back(p_param2);
+}
+
+MethodInfo::MethodInfo(const PropertyInfo &p_ret, const String &p_name, const PropertyInfo &p_param1, const PropertyInfo &p_param2, const PropertyInfo &p_param3)
+	: name(p_name),
+	  flags(METHOD_FLAG_NORMAL),
+	  id(0) {
+	return_val = p_ret;
+	arguments.push_back(p_param1);
+	arguments.push_back(p_param2);
+	arguments.push_back(p_param3);
+}
+
+MethodInfo::MethodInfo(const PropertyInfo &p_ret, const String &p_name, const PropertyInfo &p_param1, const PropertyInfo &p_param2, const PropertyInfo &p_param3, const PropertyInfo &p_param4)
+	: name(p_name),
+	  flags(METHOD_FLAG_NORMAL),
+	  id(0) {
+	return_val = p_ret;
+	arguments.push_back(p_param1);
+	arguments.push_back(p_param2);
+	arguments.push_back(p_param3);
+	arguments.push_back(p_param4);
+}
+
+MethodInfo::MethodInfo(const PropertyInfo &p_ret, const String &p_name, const PropertyInfo &p_param1, const PropertyInfo &p_param2, const PropertyInfo &p_param3, const PropertyInfo &p_param4, const PropertyInfo &p_param5)
+	: name(p_name),
+	  flags(METHOD_FLAG_NORMAL),
+	  id(0) {
+	return_val = p_ret;
+	arguments.push_back(p_param1);
+	arguments.push_back(p_param2);
+	arguments.push_back(p_param3);
+	arguments.push_back(p_param4);
+	arguments.push_back(p_param5);
+}
+
 Object::Connection::operator Variant() const {
 
 	Dictionary d;
@@ -1529,7 +1586,7 @@ void Object::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("script_changed"));
 
 	BIND_VMETHOD(MethodInfo("_notification", PropertyInfo(Variant::INT, "what")));
-	BIND_VMETHOD(MethodInfo("_set:bool", PropertyInfo(Variant::STRING, "property"), PropertyInfo(Variant::NIL, "value")));
+	BIND_VMETHOD(MethodInfo(Variant::BOOL, "_set", PropertyInfo(Variant::STRING, "property"), PropertyInfo(Variant::NIL, "value")));
 #ifdef TOOLS_ENABLED
 	MethodInfo miget("_get", PropertyInfo(Variant::STRING, "property"));
 	miget.return_val.name = "Variant";

--- a/core/object.h
+++ b/core/object.h
@@ -205,6 +205,12 @@ struct MethodInfo {
 	MethodInfo(Variant::Type ret, const String &p_name, const PropertyInfo &p_param1, const PropertyInfo &p_param2, const PropertyInfo &p_param3);
 	MethodInfo(Variant::Type ret, const String &p_name, const PropertyInfo &p_param1, const PropertyInfo &p_param2, const PropertyInfo &p_param3, const PropertyInfo &p_param4);
 	MethodInfo(Variant::Type ret, const String &p_name, const PropertyInfo &p_param1, const PropertyInfo &p_param2, const PropertyInfo &p_param3, const PropertyInfo &p_param4, const PropertyInfo &p_param5);
+	MethodInfo(const PropertyInfo &p_ret, const String &p_name);
+	MethodInfo(const PropertyInfo &p_ret, const String &p_name, const PropertyInfo &p_param1);
+	MethodInfo(const PropertyInfo &p_ret, const String &p_name, const PropertyInfo &p_param1, const PropertyInfo &p_param2);
+	MethodInfo(const PropertyInfo &p_ret, const String &p_name, const PropertyInfo &p_param1, const PropertyInfo &p_param2, const PropertyInfo &p_param3);
+	MethodInfo(const PropertyInfo &p_ret, const String &p_name, const PropertyInfo &p_param1, const PropertyInfo &p_param2, const PropertyInfo &p_param3, const PropertyInfo &p_param4);
+	MethodInfo(const PropertyInfo &p_ret, const String &p_name, const PropertyInfo &p_param1, const PropertyInfo &p_param2, const PropertyInfo &p_param3, const PropertyInfo &p_param4, const PropertyInfo &p_param5);
 };
 
 // old cast_to

--- a/core/type_info.h
+++ b/core/type_info.h
@@ -51,15 +51,15 @@ struct GetTypeInfo {
 	template <>                                                         \
 	struct GetTypeInfo<m_type> {                                        \
 		enum { VARIANT_TYPE = m_var_type };                             \
-		static inline PropertyInfo get_class_info() {                     \
-			return PropertyInfo((Variant::Type)VARIANT_TYPE,String()); \
+		static inline PropertyInfo get_class_info() {                   \
+			return PropertyInfo((Variant::Type)VARIANT_TYPE, String()); \
 		}                                                               \
 	};                                                                  \
 	template <>                                                         \
 	struct GetTypeInfo<const m_type &> {                                \
 		enum { VARIANT_TYPE = m_var_type };                             \
-		static inline PropertyInfo get_class_info() {                     \
-			return PropertyInfo((Variant::Type)VARIANT_TYPE,String()); \
+		static inline PropertyInfo get_class_info() {                   \
+			return PropertyInfo((Variant::Type)VARIANT_TYPE, String()); \
 		}                                                               \
 	};
 
@@ -110,49 +110,47 @@ template <>
 struct GetTypeInfo<RefPtr> {
 	enum { VARIANT_TYPE = Variant::OBJECT };
 	static inline PropertyInfo get_class_info() {
-		return PropertyInfo(Variant::OBJECT,String(),PROPERTY_HINT_RESOURCE_TYPE,"Reference");
+		return PropertyInfo(Variant::OBJECT, String(), PROPERTY_HINT_RESOURCE_TYPE, "Reference");
 	}
 };
 template <>
 struct GetTypeInfo<const RefPtr &> {
 	enum { VARIANT_TYPE = Variant::OBJECT };
 	static inline PropertyInfo get_class_info() {
-		return PropertyInfo(Variant::OBJECT,String(),PROPERTY_HINT_RESOURCE_TYPE,"Reference");
+		return PropertyInfo(Variant::OBJECT, String(), PROPERTY_HINT_RESOURCE_TYPE, "Reference");
 	}
 };
 
-
 //for variant
-template<>
+template <>
 struct GetTypeInfo<Variant> {
 	enum { VARIANT_TYPE = Variant::NIL };
 	static inline PropertyInfo get_class_info() {
-		return PropertyInfo(Variant::NIL,String(),PROPERTY_HINT_NONE,String(),PROPERTY_USAGE_DEFAULT|PROPERTY_USAGE_NIL_IS_VARIANT);
+		return PropertyInfo(Variant::NIL, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT);
 	}
 };
 
-template<>
-struct GetTypeInfo<const Variant&> {
+template <>
+struct GetTypeInfo<const Variant &> {
 	enum { VARIANT_TYPE = Variant::NIL };
 	static inline PropertyInfo get_class_info() {
-		return PropertyInfo(Variant::NIL,String(),PROPERTY_HINT_NONE,String(),PROPERTY_USAGE_DEFAULT|PROPERTY_USAGE_NIL_IS_VARIANT);
+		return PropertyInfo(Variant::NIL, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT);
 	}
 };
-
 
 #define MAKE_TEMPLATE_TYPE_INFO(m_template, m_type, m_var_type)         \
 	template <>                                                         \
 	struct GetTypeInfo<m_template<m_type> > {                           \
 		enum { VARIANT_TYPE = m_var_type };                             \
-		static inline PropertyInfo get_class_info() {                     \
-			return PropertyInfo((Variant::Type)VARIANT_TYPE,String()); \
+		static inline PropertyInfo get_class_info() {                   \
+			return PropertyInfo((Variant::Type)VARIANT_TYPE, String()); \
 		}                                                               \
 	};                                                                  \
 	template <>                                                         \
 	struct GetTypeInfo<const m_template<m_type> &> {                    \
 		enum { VARIANT_TYPE = m_var_type };                             \
-		static inline PropertyInfo get_class_info() {                     \
-			return PropertyInfo((Variant::Type)VARIANT_TYPE,String()); \
+		static inline PropertyInfo get_class_info() {                   \
+			return PropertyInfo((Variant::Type)VARIANT_TYPE, String()); \
 		}                                                               \
 	};
 
@@ -178,7 +176,6 @@ struct GetTypeInfo<T *, typename EnableIf<TypeInherits<Object, T>::value>::type>
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(StringName(T::get_class_static()));
 	}
-
 };
 
 template <typename T>
@@ -190,13 +187,13 @@ struct GetTypeInfo<const T *, typename EnableIf<TypeInherits<Object, T>::value>:
 	}
 };
 
-#define TEMPL_MAKE_ENUM_TYPE_INFO(m_enum, m_impl)                             \
-	template <>                                                               \
-	struct GetTypeInfo<m_impl> {                                              \
-		enum { VARIANT_TYPE = Variant::INT };                                 \
-		static inline PropertyInfo get_class_info() { \
-			return PropertyInfo(Variant::INT,String(),PROPERTY_HINT_NONE,String(),PROPERTY_USAGE_DEFAULT|PROPERTY_USAGE_CLASS_IS_ENUM,String(#m_enum).replace("::","."));  \
-		}  	\
+#define TEMPL_MAKE_ENUM_TYPE_INFO(m_enum, m_impl)                                                                                                                                 \
+	template <>                                                                                                                                                                   \
+	struct GetTypeInfo<m_impl> {                                                                                                                                                  \
+		enum { VARIANT_TYPE = Variant::INT };                                                                                                                                     \
+		static inline PropertyInfo get_class_info() {                                                                                                                             \
+			return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_ENUM, String(#m_enum).replace("::", ".")); \
+		}                                                                                                                                                                         \
 	};
 
 #define MAKE_ENUM_TYPE_INFO(m_enum)                 \
@@ -212,9 +209,15 @@ inline StringName __constant_get_enum_name(T param, const String &p_constant) {
 	return GetTypeInfo<T>::get_class_info().class_name;
 }
 
+#define CLASS_INFO(m_type)                                    \
+	(GetTypeInfo<m_type *>::VARIANT_TYPE != Variant::NIL ?    \
+					GetTypeInfo<m_type *>::get_class_info() : \
+					GetTypeInfo<m_type>::get_class_info())
+
 #else
 
 #define MAKE_ENUM_TYPE_INFO(m_enum)
+#define CLASS_INFO(m_type)
 
 #endif // DEBUG_METHODS_ENABLED
 

--- a/editor/doc/doc_data.cpp
+++ b/editor/doc/doc_data.cpp
@@ -576,6 +576,12 @@ void DocData::generate(bool p_basic_types) {
 				MethodDoc md;
 				md.name = mi.name;
 
+				if (mi.flags & METHOD_FLAG_VARARG) {
+					if (md.qualifiers != "")
+						md.qualifiers += " ";
+					md.qualifiers += "vararg";
+				}
+
 				return_doc_from_retinfo(md, mi.return_val);
 
 				for (int i = 0; i < mi.arguments.size(); i++) {

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -478,9 +478,9 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorPlugin::get_editor_interface);
 
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "forward_canvas_gui_input", PropertyInfo(Variant::TRANSFORM2D, "canvas_xform"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo("forward_draw_over_canvas", PropertyInfo(Variant::TRANSFORM2D, "canvas_xform"), PropertyInfo(Variant::OBJECT, "canvas:Control")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo("forward_draw_over_canvas", PropertyInfo(Variant::TRANSFORM2D, "canvas_xform"), PropertyInfo(Variant::OBJECT, "canvas", PROPERTY_HINT_RESOURCE_TYPE, "Control")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "forward_spatial_gui_input", PropertyInfo(Variant::OBJECT, "camera", PROPERTY_HINT_RESOURCE_TYPE, "Camera"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
-	MethodInfo gizmo = MethodInfo(Variant::OBJECT, "create_spatial_gizmo", PropertyInfo(Variant::OBJECT, "for_spatial:Spatial"));
+	MethodInfo gizmo = MethodInfo(Variant::OBJECT, "create_spatial_gizmo", PropertyInfo(Variant::OBJECT, "for_spatial", PROPERTY_HINT_RESOURCE_TYPE, "Spatial"));
 	gizmo.return_val.hint = PROPERTY_HINT_RESOURCE_TYPE;
 	gizmo.return_val.hint_string = "EditorSpatialGizmo";
 	ClassDB::add_virtual_method(get_class_static(), gizmo);
@@ -498,9 +498,9 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo("set_window_layout", PropertyInfo(Variant::OBJECT, "layout", PROPERTY_HINT_RESOURCE_TYPE, "ConfigFile")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo("get_window_layout", PropertyInfo(Variant::OBJECT, "layout", PROPERTY_HINT_RESOURCE_TYPE, "ConfigFile")));
 
-	ADD_SIGNAL(MethodInfo("scene_changed", PropertyInfo(Variant::OBJECT, "scene_root:Node")));
-	ADD_SIGNAL(MethodInfo("scene_closed", PropertyInfo(Variant::STRING, "filepath:String")));
-	ADD_SIGNAL(MethodInfo("main_screen_changed", PropertyInfo(Variant::STRING, "screen_name:String")));
+	ADD_SIGNAL(MethodInfo("scene_changed", PropertyInfo(Variant::OBJECT, "scene_root", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
+	ADD_SIGNAL(MethodInfo("scene_closed", PropertyInfo(Variant::STRING, "filepath")));
+	ADD_SIGNAL(MethodInfo("main_screen_changed", PropertyInfo(Variant::STRING, "screen_name")));
 
 	BIND_ENUM_CONSTANT(CONTAINER_TOOLBAR);
 	BIND_ENUM_CONSTANT(CONTAINER_SPATIAL_EDITOR_MENU);

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -69,8 +69,8 @@ Ref<Texture> EditorResourcePreviewGenerator::generate_from_path(const String &p_
 void EditorResourcePreviewGenerator::_bind_methods() {
 
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "handles", PropertyInfo(Variant::STRING, "type")));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::OBJECT, "generate:Texture", PropertyInfo(Variant::OBJECT, "from", PROPERTY_HINT_RESOURCE_TYPE, "Resource")));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::OBJECT, "generate_from_path:Texture", PropertyInfo(Variant::STRING, "path", PROPERTY_HINT_FILE)));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(CLASS_INFO(Texture), "generate", PropertyInfo(Variant::OBJECT, "from", PROPERTY_HINT_RESOURCE_TYPE, "Resource")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(CLASS_INFO(Texture), "generate_from_path", PropertyInfo(Variant::STRING, "path", PROPERTY_HINT_FILE)));
 }
 
 EditorResourcePreviewGenerator::EditorResourcePreviewGenerator() {

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2134,8 +2134,8 @@ void ScriptEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_current_script"), &ScriptEditor::_get_current_script);
 	ClassDB::bind_method(D_METHOD("get_open_scripts"), &ScriptEditor::_get_open_scripts);
 
-	ADD_SIGNAL(MethodInfo("editor_script_changed", PropertyInfo(Variant::OBJECT, "script:Script")));
-	ADD_SIGNAL(MethodInfo("script_close", PropertyInfo(Variant::OBJECT, "script:Script")));
+	ADD_SIGNAL(MethodInfo("editor_script_changed", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));
+	ADD_SIGNAL(MethodInfo("script_close", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));
 }
 
 ScriptEditor::ScriptEditor(EditorNode *p_editor) {

--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -623,9 +623,13 @@ void EditorSpatialGizmo::_bind_methods() {
 
 	BIND_VMETHOD(MethodInfo("redraw"));
 	BIND_VMETHOD(MethodInfo(Variant::STRING, "get_handle_name", PropertyInfo(Variant::INT, "index")));
-	BIND_VMETHOD(MethodInfo("get_handle_value:Variant", PropertyInfo(Variant::INT, "index")));
-	BIND_VMETHOD(MethodInfo("set_handle", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::OBJECT, "camera:Camera"), PropertyInfo(Variant::VECTOR2, "point")));
-	MethodInfo cm = MethodInfo("commit_handle", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::NIL, "restore:Variant"), PropertyInfo(Variant::BOOL, "cancel"));
+
+	MethodInfo hvget(Variant::NIL, "get_handle_value", PropertyInfo(Variant::INT, "index"));
+	hvget.return_val.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
+	BIND_VMETHOD(hvget);
+
+	BIND_VMETHOD(MethodInfo("set_handle", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::OBJECT, "camera", PROPERTY_HINT_RESOURCE_TYPE, "Camera"), PropertyInfo(Variant::VECTOR2, "point")));
+	MethodInfo cm = MethodInfo("commit_handle", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::NIL, "restore"), PropertyInfo(Variant::BOOL, "cancel"));
 	cm.default_arguments.push_back(false);
 	BIND_VMETHOD(cm);
 }

--- a/modules/gdscript/gd_editor.cpp
+++ b/modules/gdscript/gd_editor.cpp
@@ -297,23 +297,25 @@ void GDScriptLanguage::get_public_functions(List<MethodInfo> *p_functions) const
 	//not really "functions", but..
 	{
 		MethodInfo mi;
-		mi.name = "preload:Resource";
+		mi.name = "preload";
 		mi.arguments.push_back(PropertyInfo(Variant::STRING, "path"));
 		mi.return_val = PropertyInfo(Variant::OBJECT, "", PROPERTY_HINT_RESOURCE_TYPE, "Resource");
 		p_functions->push_back(mi);
 	}
 	{
 		MethodInfo mi;
-		mi.name = "yield:GDFunctionState";
+		mi.name = "yield";
 		mi.arguments.push_back(PropertyInfo(Variant::OBJECT, "object"));
 		mi.arguments.push_back(PropertyInfo(Variant::STRING, "signal"));
 		mi.default_arguments.push_back(Variant::NIL);
 		mi.default_arguments.push_back(Variant::STRING);
+		mi.return_val = PropertyInfo(Variant::OBJECT, "", PROPERTY_HINT_RESOURCE_TYPE, "GDFunctionState");
 		p_functions->push_back(mi);
 	}
 	{
 		MethodInfo mi;
 		mi.name = "assert";
+		mi.return_val.type = Variant::NIL;
 		mi.arguments.push_back(PropertyInfo(Variant::BOOL, "condition"));
 		p_functions->push_back(mi);
 	}

--- a/modules/gdscript/gd_editor.cpp
+++ b/modules/gdscript/gd_editor.cpp
@@ -1863,11 +1863,11 @@ static void _find_call_arguments(GDCompletionContext &context, const GDParser::N
 				arghint += ", ";
 			else
 				arghint += " ";
-			if (i == p_argidx) {
+			if (i == p_argidx || (mi.flags & METHOD_FLAG_VARARG && i > p_argidx)) {
 				arghint += String::chr(0xFFFF);
 			}
 			arghint += _get_visual_datatype(mi.arguments[i]) + " " + mi.arguments[i].name;
-			if (i == p_argidx) {
+			if (i == p_argidx || (mi.flags & METHOD_FLAG_VARARG && i > p_argidx)) {
 				arghint += String::chr(0xFFFF);
 			}
 		}

--- a/modules/gdscript/gd_functions.cpp
+++ b/modules/gdscript/gd_functions.cpp
@@ -1620,8 +1620,9 @@ MethodInfo GDFunctions::get_info(Function p_func) {
 		} break;
 		case STR_TO_VAR: {
 
-			MethodInfo mi("str2var:Variant", PropertyInfo(Variant::STRING, "string"));
+			MethodInfo mi(Variant::NIL, "str2var", PropertyInfo(Variant::STRING, "string"));
 			mi.return_val.type = Variant::NIL;
+			mi.return_val.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
 			return mi;
 		} break;
 		case VAR_TO_BYTES: {
@@ -1632,8 +1633,9 @@ MethodInfo GDFunctions::get_info(Function p_func) {
 		} break;
 		case BYTES_TO_VAR: {
 
-			MethodInfo mi("bytes2var:Variant", PropertyInfo(Variant::POOL_BYTE_ARRAY, "bytes"));
+			MethodInfo mi(Variant::NIL, "bytes2var", PropertyInfo(Variant::POOL_BYTE_ARRAY, "bytes"));
 			mi.return_val.type = Variant::NIL;
+			mi.return_val.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
 			return mi;
 		} break;
 		case GEN_RANGE: {
@@ -1663,14 +1665,15 @@ MethodInfo GDFunctions::get_info(Function p_func) {
 		} break;
 		case VALIDATE_JSON: {
 
-			MethodInfo mi("validate_json:Variant", PropertyInfo(Variant::STRING, "json"));
+			MethodInfo mi("validate_json", PropertyInfo(Variant::STRING, "json"));
 			mi.return_val.type = Variant::STRING;
 			return mi;
 		} break;
 		case PARSE_JSON: {
 
-			MethodInfo mi("parse_json:Variant", PropertyInfo(Variant::STRING, "json"));
+			MethodInfo mi(Variant::NIL, "parse_json", PropertyInfo(Variant::STRING, "json"));
 			mi.return_val.type = Variant::NIL;
+			mi.return_val.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
 			return mi;
 		} break;
 		case TO_JSON: {

--- a/modules/gdscript/gd_functions.cpp
+++ b/modules/gdscript/gd_functions.cpp
@@ -1572,43 +1572,49 @@ MethodInfo GDFunctions::get_info(Function p_func) {
 		} break;
 		case TEXT_STR: {
 
-			MethodInfo mi("str", PropertyInfo(Variant::NIL, "what"), PropertyInfo(Variant::NIL, "..."));
+			MethodInfo mi("str");
 			mi.return_val.type = Variant::STRING;
+			mi.flags |= METHOD_FLAG_VARARG;
 			return mi;
 
 		} break;
 		case TEXT_PRINT: {
 
-			MethodInfo mi("print", PropertyInfo(Variant::NIL, "what"), PropertyInfo(Variant::NIL, "..."));
+			MethodInfo mi("print");
 			mi.return_val.type = Variant::NIL;
+			mi.flags |= METHOD_FLAG_VARARG;
 			return mi;
 
 		} break;
 		case TEXT_PRINT_TABBED: {
 
-			MethodInfo mi("printt", PropertyInfo(Variant::NIL, "what"), PropertyInfo(Variant::NIL, "..."));
+			MethodInfo mi("printt");
 			mi.return_val.type = Variant::NIL;
+			mi.flags |= METHOD_FLAG_VARARG;
 			return mi;
 
 		} break;
 		case TEXT_PRINT_SPACED: {
 
-			MethodInfo mi("prints", PropertyInfo(Variant::NIL, "what"), PropertyInfo(Variant::NIL, "..."));
+			MethodInfo mi("prints");
 			mi.return_val.type = Variant::NIL;
+			mi.flags |= METHOD_FLAG_VARARG;
 			return mi;
 
 		} break;
 		case TEXT_PRINTERR: {
 
-			MethodInfo mi("printerr", PropertyInfo(Variant::NIL, "what"), PropertyInfo(Variant::NIL, "..."));
+			MethodInfo mi("printerr");
 			mi.return_val.type = Variant::NIL;
+			mi.flags |= METHOD_FLAG_VARARG;
 			return mi;
 
 		} break;
 		case TEXT_PRINTRAW: {
 
-			MethodInfo mi("printraw", PropertyInfo(Variant::NIL, "what"), PropertyInfo(Variant::NIL, "..."));
+			MethodInfo mi("printraw");
 			mi.return_val.type = Variant::NIL;
+			mi.flags |= METHOD_FLAG_VARARG;
 			return mi;
 
 		} break;
@@ -1640,8 +1646,9 @@ MethodInfo GDFunctions::get_info(Function p_func) {
 		} break;
 		case GEN_RANGE: {
 
-			MethodInfo mi("range", PropertyInfo(Variant::NIL, "..."));
+			MethodInfo mi("range");
 			mi.return_val.type = Variant::ARRAY;
+			mi.flags |= METHOD_FLAG_VARARG;
 			return mi;
 		} break;
 		case RESOURCE_LOAD: {

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -2702,7 +2702,10 @@ void VisualScriptCustomNode::_bind_methods() {
 	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_category"));
 
 	BIND_VMETHOD(MethodInfo(Variant::INT, "_get_working_memory_size"));
-	BIND_VMETHOD(MethodInfo(Variant::NIL, "_step:Variant", PropertyInfo(Variant::ARRAY, "inputs"), PropertyInfo(Variant::ARRAY, "outputs"), PropertyInfo(Variant::INT, "start_mode"), PropertyInfo(Variant::ARRAY, "working_mem")));
+
+	MethodInfo stepmi(Variant::NIL, "_step", PropertyInfo(Variant::ARRAY, "inputs"), PropertyInfo(Variant::ARRAY, "outputs"), PropertyInfo(Variant::INT, "start_mode"), PropertyInfo(Variant::ARRAY, "working_mem"));
+	stepmi.return_val.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
+	BIND_VMETHOD(stepmi);
 
 	ClassDB::bind_method(D_METHOD("_script_changed"), &VisualScriptCustomNode::_script_changed);
 
@@ -2839,7 +2842,9 @@ VisualScriptNodeInstance *VisualScriptSubCall::instance(VisualScriptInstance *p_
 
 void VisualScriptSubCall::_bind_methods() {
 
-	BIND_VMETHOD(MethodInfo(Variant::NIL, "_subcall:Variant", PropertyInfo(Variant::NIL, "arguments:Variant")));
+	MethodInfo scmi(Variant::NIL, "_subcall", PropertyInfo(Variant::NIL, "arguments"));
+	scmi.return_val.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
+	BIND_VMETHOD(scmi);
 }
 
 VisualScriptSubCall::VisualScriptSubCall() {

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -883,7 +883,7 @@ void RigidBody2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_colliding_bodies"), &RigidBody2D::get_colliding_bodies);
 
-	BIND_VMETHOD(MethodInfo("_integrate_forces", PropertyInfo(Variant::OBJECT, "state:Physics2DDirectBodyState")));
+	BIND_VMETHOD(MethodInfo("_integrate_forces", PropertyInfo(Variant::OBJECT, "state", PROPERTY_HINT_RESOURCE_TYPE, "Physics2DDirectBodyState")));
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mode", PROPERTY_HINT_ENUM, "Rigid,Static,Character,Kinematic"), "set_mode", "get_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "mass", PROPERTY_HINT_EXP_RANGE, "0.01,65535,0.01"), "set_mass", "get_mass");

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -842,7 +842,7 @@ void RigidBody::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_colliding_bodies"), &RigidBody::get_colliding_bodies);
 
-	BIND_VMETHOD(MethodInfo("_integrate_forces", PropertyInfo(Variant::OBJECT, "state:PhysicsDirectBodyState")));
+	BIND_VMETHOD(MethodInfo("_integrate_forces", PropertyInfo(Variant::OBJECT, "state", PROPERTY_HINT_RESOURCE_TYPE, "PhysicsDirectBodyState")));
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mode", PROPERTY_HINT_ENUM, "Rigid,Static,Character,Kinematic"), "set_mode", "get_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "mass", PROPERTY_HINT_EXP_RANGE, "0.01,65535,0.01"), "set_mass", "get_mass");

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2703,7 +2703,7 @@ void Control::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("minimum_size_changed"));
 	ADD_SIGNAL(MethodInfo("modal_closed"));
 
-	BIND_VMETHOD(MethodInfo("has_point:bool", PropertyInfo(Variant::VECTOR2, "point")));
+	BIND_VMETHOD(MethodInfo(Variant::BOOL, "has_point", PropertyInfo(Variant::VECTOR2, "point")));
 }
 Control::Control() {
 


### PR DESCRIPTION
- `DocData` and type hints fixes:
  - Makes vararg methods automatically use `PROPERTY_USAGE_NIL_IS_VARIANT` on return types
  - Completely removes the `:type` suffix for method names. Virtual methods must use the `MethodInfo` constructors that takes `Variant::Type` or `PropertyHint` as the first parameter for the return type (with `CLASS_INFO` as a helper to get the `PropertyInfo`). Parameters must use `PROPERTY_HINT_RESOURCE_TYPE` and hint string.
  - `PROPERTY_USAGE_NIL_IS_VARIANT` is no longer needed for parameters, because parameters cannot be void.
  - Adds missing `PROPERTY_USAGE_NIL_IS_VARIANT` to virtual and built-in methods that return Variant.
- Fixes missing default arguments in `MethodInfo`.
- Makes built-in vararg methods actual vararg methods:
  - Removes hardcoded parameters from built-in vararg methods and adds `METHOD_FLAG_VARARG` to them.
  - Makes `EditorHelp` display built-in vararg methods correctly