### PR TITLE
Renamed 'script_changed' signal in the script editor plugin to 'edited_script_changed'

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -47,7 +47,7 @@
 void ScriptEditorBase::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("name_changed"));
-	ADD_SIGNAL(MethodInfo("script_changed"));
+	ADD_SIGNAL(MethodInfo("edited_script_changed"));
 	ADD_SIGNAL(MethodInfo("request_help_search", PropertyInfo(Variant::STRING, "topic")));
 	ADD_SIGNAL(MethodInfo("request_help_index"));
 	ADD_SIGNAL(MethodInfo("request_open_script_at_line", PropertyInfo(Variant::OBJECT, "script"), PropertyInfo(Variant::INT, "line")));
@@ -1622,7 +1622,7 @@ bool ScriptEditor::edit(const Ref<Script> &p_script, int p_line, int p_col, bool
 	_update_script_names();
 	_save_layout();
 	se->connect("name_changed", this, "_update_script_names");
-	se->connect("script_changed", this, "_script_changed");
+	se->connect("edited_script_changed", this, "_script_changed");
 	se->connect("request_help_search", this, "_help_search");
 	se->connect("request_open_script_at_line", this, "_goto_script_line");
 	se->connect("go_to_help", this, "_help_class_goto");

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -529,7 +529,7 @@ void ScriptTextEditor::_validate_script() {
 	}
 
 	emit_signal("name_changed");
-	emit_signal("script_changed");
+	emit_signal("edited_script_changed");
 }
 
 static Node *_find_node_for_script(Node *p_base, Node *p_current, const Ref<Script> &p_script) {

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -197,8 +197,6 @@ void ShaderTextEditor::_validate_script() {
 }
 
 void ShaderTextEditor::_bind_methods() {
-
-	//ADD_SIGNAL( MethodInfo("script_changed") );
 }
 
 ShaderTextEditor::ShaderTextEditor() {

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -886,8 +886,8 @@ void VisualScriptEditor::_member_edited() {
 		undo_redo->add_undo_method(this, "_update_members");
 		undo_redo->add_do_method(this, "_update_graph");
 		undo_redo->add_undo_method(this, "_update_graph");
-		undo_redo->add_do_method(this, "emit_signal", "script_changed");
-		undo_redo->add_undo_method(this, "emit_signal", "script_changed");
+		undo_redo->add_do_method(this, "emit_signal", "edited_script_changed");
+		undo_redo->add_undo_method(this, "emit_signal", "edited_script_changed");
 		undo_redo->commit_action();
 
 		//		_update_graph();
@@ -903,8 +903,8 @@ void VisualScriptEditor::_member_edited() {
 		undo_redo->add_undo_method(script.ptr(), "rename_variable", new_name, name);
 		undo_redo->add_do_method(this, "_update_members");
 		undo_redo->add_undo_method(this, "_update_members");
-		undo_redo->add_do_method(this, "emit_signal", "script_changed");
-		undo_redo->add_undo_method(this, "emit_signal", "script_changed");
+		undo_redo->add_do_method(this, "emit_signal", "edited_script_changed");
+		undo_redo->add_undo_method(this, "emit_signal", "edited_script_changed");
 		undo_redo->commit_action();
 
 		return; //or crash because it will become invalid
@@ -918,8 +918,8 @@ void VisualScriptEditor::_member_edited() {
 		undo_redo->add_undo_method(script.ptr(), "rename_custom_signal", new_name, name);
 		undo_redo->add_do_method(this, "_update_members");
 		undo_redo->add_undo_method(this, "_update_members");
-		undo_redo->add_do_method(this, "emit_signal", "script_changed");
-		undo_redo->add_undo_method(this, "emit_signal", "script_changed");
+		undo_redo->add_do_method(this, "emit_signal", "edited_script_changed");
+		undo_redo->add_undo_method(this, "emit_signal", "edited_script_changed");
 		undo_redo->commit_action();
 
 		return; //or crash because it will become invalid
@@ -1057,8 +1057,8 @@ void VisualScriptEditor::_member_button(Object *p_item, int p_column, int p_butt
 				undo_redo->add_undo_method(this, "_update_members");
 				undo_redo->add_do_method(this, "_update_graph");
 				undo_redo->add_undo_method(this, "_update_graph");
-				undo_redo->add_do_method(this, "emit_signal", "script_changed");
-				undo_redo->add_undo_method(this, "emit_signal", "script_changed");
+				undo_redo->add_do_method(this, "emit_signal", "edited_script_changed");
+				undo_redo->add_undo_method(this, "emit_signal", "edited_script_changed");
 				undo_redo->commit_action();
 
 				_update_graph();
@@ -1077,8 +1077,8 @@ void VisualScriptEditor::_member_button(Object *p_item, int p_column, int p_butt
 			undo_redo->add_undo_method(script.ptr(), "remove_variable", name);
 			undo_redo->add_do_method(this, "_update_members");
 			undo_redo->add_undo_method(this, "_update_members");
-			undo_redo->add_do_method(this, "emit_signal", "script_changed");
-			undo_redo->add_undo_method(this, "emit_signal", "script_changed");
+			undo_redo->add_do_method(this, "emit_signal", "edited_script_changed");
+			undo_redo->add_undo_method(this, "emit_signal", "edited_script_changed");
 			undo_redo->commit_action();
 			return; //or crash because it will become invalid
 		}
@@ -1093,8 +1093,8 @@ void VisualScriptEditor::_member_button(Object *p_item, int p_column, int p_butt
 			undo_redo->add_undo_method(script.ptr(), "remove_custom_signal", name);
 			undo_redo->add_do_method(this, "_update_members");
 			undo_redo->add_undo_method(this, "_update_members");
-			undo_redo->add_do_method(this, "emit_signal", "script_changed");
-			undo_redo->add_undo_method(this, "emit_signal", "script_changed");
+			undo_redo->add_do_method(this, "emit_signal", "edited_script_changed");
+			undo_redo->add_undo_method(this, "emit_signal", "edited_script_changed");
 			undo_redo->commit_action();
 			return; //or crash because it will become invalid
 		}


### PR DESCRIPTION
As far as I can tell, the `script_changed` signal was already added in the `Object` base class.

https://github.com/godotengine/godot/blob/28c85922b12cb0fa8c2cd1465cbeb0c0d226b880/core/object.cpp#L1529

Fixes #10715