### PR TITLE
Improve build callbacks

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -85,7 +85,7 @@
 
 typedef void (*EditorNodeInitCallback)();
 typedef void (*EditorPluginInitializeCallback)();
-typedef void (*EditorBuildCallback)();
+typedef bool (*EditorBuildCallback)();
 
 class EditorPluginList;
 
@@ -575,7 +575,7 @@ private:
 	static EditorPluginInitializeCallback plugin_init_callbacks[MAX_INIT_CALLBACKS];
 	void _save_default_environment();
 
-	void _call_build();
+	bool _call_build();
 	static int build_callback_count;
 	static EditorBuildCallback build_callbacks[MAX_BUILD_CALLBACKS];
 


### PR DESCRIPTION
- Build callbacks now return bool to determine if the build was successful. If the build fails, the editor won't run the game.
- Makes sure build callbacks are called after saving the scene ("Save Before Running" option).
