### PR TITLE
Corrections to audio buffer size calculations

### DIFF
--- a/drivers/alsa/audio_driver_alsa.h
+++ b/drivers/alsa/audio_driver_alsa.h
@@ -51,6 +51,7 @@ class AudioDriverALSA : public AudioDriver {
 	unsigned int mix_rate;
 	SpeakerMode speaker_mode;
 
+	snd_pcm_uframes_t buffer_frames;
 	snd_pcm_uframes_t buffer_size;
 	snd_pcm_uframes_t period_size;
 	int channels;

--- a/drivers/pulseaudio/audio_driver_pulseaudio.h
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.h
@@ -51,6 +51,7 @@ class AudioDriverPulseAudio : public AudioDriver {
 	unsigned int mix_rate;
 	SpeakerMode speaker_mode;
 
+	unsigned int buffer_frames;
 	unsigned int buffer_size;
 	int channels;
 

--- a/drivers/rtaudio/audio_driver_rtaudio.cpp
+++ b/drivers/rtaudio/audio_driver_rtaudio.cpp
@@ -107,14 +107,13 @@ Error AudioDriverRtAudio::init() {
 	options.numberOfBuffers = 4;
 
 	parameters.firstChannel = 0;
-	mix_rate = GLOBAL_DEF("audio/mix_rate", 44100);
+	mix_rate = GLOBAL_DEF("audio/mix_rate", DEFAULT_MIX_RATE);
 
-	int latency = GLOBAL_DEF("audio/output_latency", 25);
-	// calculate desired buffer_size
-	unsigned int buffer_size = closest_power_of_2(latency * mix_rate / 1000);
+	int latency = GLOBAL_DEF("audio/output_latency", DEFAULT_OUTPUT_LATENCY);
+	unsigned int buffer_frames = closest_power_of_2(latency * mix_rate / 1000);
 
 	if (OS::get_singleton()->is_stdout_verbose()) {
-		print_line("audio buffer size: " + itos(buffer_size));
+		print_line("audio buffer frames: " + itos(buffer_frames) + " calculated latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
 	}
 
 	short int tries = 2;
@@ -127,7 +126,7 @@ Error AudioDriverRtAudio::init() {
 		};
 
 		try {
-			dac->openStream(&parameters, NULL, RTAUDIO_SINT32, mix_rate, &buffer_size, &callback, this, &options);
+			dac->openStream(&parameters, NULL, RTAUDIO_SINT32, mix_rate, &buffer_frames, &callback, this, &options);
 			active = true;
 
 			break;
@@ -199,7 +198,7 @@ AudioDriverRtAudio::AudioDriverRtAudio() {
 	active = false;
 	mutex = NULL;
 	dac = NULL;
-	mix_rate = 44100;
+	mix_rate = DEFAULT_MIX_RATE;
 	speaker_mode = SPEAKER_MODE_STEREO;
 }
 

--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -48,7 +48,6 @@ class AudioDriverWASAPI : public AudioDriver {
 	Mutex *mutex;
 	Thread *thread;
 
-	UINT32 max_frames;
 	WORD format_tag;
 	WORD bits_per_sample;
 

--- a/platform/osx/audio_driver_osx.h
+++ b/platform/osx/audio_driver_osx.h
@@ -45,8 +45,9 @@ class AudioDriverOSX : public AudioDriver {
 	Mutex *mutex;
 
 	int mix_rate;
-	int channels;
-	int buffer_frames;
+	unsigned int channels;
+	unsigned int buffer_frames;
+	unsigned int buffer_size;
 
 	Vector<int32_t> samples_in;
 

--- a/servers/audio/audio_driver_dummy.h
+++ b/servers/audio/audio_driver_dummy.h
@@ -43,8 +43,8 @@ class AudioDriverDummy : public AudioDriver {
 	int32_t *samples_in;
 
 	static void thread_func(void *p_udata);
-	int buffer_size;
 
+	unsigned int buffer_frames;
 	unsigned int mix_rate;
 	SpeakerMode speaker_mode;
 
@@ -53,7 +53,6 @@ class AudioDriverDummy : public AudioDriver {
 	bool active;
 	bool thread_exited;
 	mutable bool exit_thread;
-	bool pcm_open;
 
 public:
 	const char *get_name() const {

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -155,6 +155,29 @@ void AudioServer::_driver_process(int p_frames, int32_t *p_buffer) {
 		todo -= to_copy;
 		to_mix -= to_copy;
 	}
+
+#ifdef DEBUG_ENABLED
+	if (OS::get_singleton() && OS::get_singleton()->is_stdout_verbose()) {
+		static uint64_t first_ticks = 0;
+		static uint64_t last_ticks = 0;
+		static uint64_t ticks = 0;
+		static int count = 0;
+		static int total = 0;
+
+		ticks = OS::get_singleton()->get_ticks_msec();
+		if ((ticks - first_ticks) > 10 * 1000) {
+			print_line("Audio Driver " + String(AudioDriver::get_singleton()->get_name()) + " average latency: " + itos(total / count) + "ms (frame=" + itos(p_frames) + ")");
+			first_ticks = ticks;
+			total = 0;
+			count = 0;
+		}
+
+		total += ticks - last_ticks;
+		count++;
+
+		last_ticks = ticks;
+	}
+#endif
 }
 
 void AudioServer::_mix_step() {

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -54,6 +54,9 @@ public:
 		SPEAKER_SURROUND_71,
 	};
 
+	static const int DEFAULT_MIX_RATE = 44100;
+	static const int DEFAULT_OUTPUT_LATENCY = 15;
+
 	static AudioDriver *get_singleton();
 	void set_singleton();
 


### PR DESCRIPTION
Quick explanation: The number of channels wasn't being used in the total buffer_size. A second of sound has actually `sample rate * channels`, so our buffer_size must be equal to `buffer_frames * channels`, ref: https://stackoverflow.com/questions/11048825/audio-sample-frequency-rely-on-channels


Long explanation: I found about this issue while working on the surround fixes.
The calculation for the buffer_size before this PR was:
```
buffer_size = closest_power_of_2(latency * mix_rate / 1000);
samples_in.resize(buffer_size);
buffer_frames = buffer_size / channels;
```
And the new one:
```
buffer_frames = closest_power_of_2(latency * mix_rate / 1000);
buffer_size = buffer_frames * channels;
samples_in.resize(buffer_size);
```
With for example latency=25, mix_rate=44100 and channels=6
Old one:
```
buffer_size = 25 * 44100 / 1000 = 1102 => closest_power_of_2(1102) = 1024
buffer_frames = 1024 / 6 = 170
```

New one:
```
buffer_frames = 25 * 44100 / 1000 = 1102 => closest_power_of_2(1102) = 1024
buffer_size = 1024 * 6 = 6144
```

So the old one gave a buffer size really small with 6 channels (it was also incorrect for 2 or 8 channels of course).

Note: I've modified only alsa, pulseaudio, osx, rtaudio and wasapi drivers, the rest needs to be checked/tested.