### PR TITLE
Disable -ffast-math for etc2comp

### DIFF
--- a/modules/etc/SCsub
+++ b/modules/etc/SCsub
@@ -35,3 +35,7 @@ env_etc.add_source_files(env.modules_sources, "*.cpp")
 
 # upstream uses c++11
 env_etc.Append(CXXFLAGS="-std=gnu++11")
+# -ffast-math seems to be incompatible with ec2comp on recent versions of
+# GCC and Clang
+if '-ffast-math' in env_etc['CCFLAGS']:
+	env_etc['CCFLAGS'].remove('-ffast-math')

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -74,7 +74,9 @@ def configure(env):
     ## Build type
 
     if (env["target"] == "release"):
-        env.Prepend(CCFLAGS=['-Ofast'])
+        # -O3 -ffast-math is identical to -Ofast. We need to split it out so we can selectively disable
+        # -ffast-math in code for which it generates wrong results.
+        env.Prepend(CCFLAGS=['-O3', '-ffast-math'])
         if (env["debug_release"] == "yes"):
             env.Prepend(CCFLAGS=['-g2'])
 


### PR DESCRIPTION
Apparently -ffast-math generates incorrect code with recent versions of
GCC and Clang. The manual page for GCC warns about this possibility.

In my tests it doesn't actually appear to be measurably slower in this
case, and this is used in a batch process so it seems safe to disable
this.

This fixes #10758 and fixes #10070 