### PR TITLE
Remove 10778 related methods from GDNative

### DIFF
--- a/modules/gdnative/godot/basis.cpp
+++ b/modules/gdnative/godot/basis.cpp
@@ -107,24 +107,6 @@ godot_basis GDAPI godot_basis_scaled(const godot_basis *p_self, const godot_vect
 	return dest;
 }
 
-void GDAPI godot_basis_set_scale(godot_basis *p_self, const godot_vector3 *p_scale) {
-	Basis *self = (Basis *)p_self;
-	const Vector3 *scale = (const Vector3 *)p_scale;
-	self->set_scale(*scale);
-}
-
-void GDAPI godot_basis_set_rotation_euler(godot_basis *p_self, const godot_vector3 *p_euler) {
-	Basis *self = (Basis *)p_self;
-	const Vector3 *euler = (const Vector3 *)p_euler;
-	self->set_rotation_euler(*euler);
-}
-
-void GDAPI godot_basis_set_rotation_axis_angle(godot_basis *p_self, const godot_vector3 *p_axis, const godot_real p_angle) {
-	Basis *self = (Basis *)p_self;
-	const Vector3 *axis = (const Vector3 *)p_axis;
-	self->set_rotation_axis_angle(*axis, p_angle);
-}
-
 godot_vector3 GDAPI godot_basis_get_scale(const godot_basis *p_self) {
 	godot_vector3 dest;
 	const Basis *self = (const Basis *)p_self;

--- a/modules/gdnative/godot/basis.h
+++ b/modules/gdnative/godot/basis.h
@@ -67,12 +67,6 @@ godot_basis GDAPI godot_basis_rotated(const godot_basis *p_self, const godot_vec
 
 godot_basis GDAPI godot_basis_scaled(const godot_basis *p_self, const godot_vector3 *p_scale);
 
-void GDAPI godot_basis_set_scale(godot_basis *p_self, const godot_vector3 *p_scale);
-
-void GDAPI godot_basis_set_rotation_euler(godot_basis *p_self, const godot_vector3 *p_euler);
-
-void GDAPI godot_basis_set_rotation_axis_angle(godot_basis *p_self, const godot_vector3 *p_axis, const godot_real p_angle);
-
 godot_vector3 GDAPI godot_basis_get_scale(const godot_basis *p_self);
 
 godot_vector3 GDAPI godot_basis_get_euler(const godot_basis *p_self);


### PR DESCRIPTION
After #10778 master didn't build any longer with GDNative. This removes
the methods removed in that PR from the GDNative bindings for Basis
also.