### PR TITLE
Fix a crash when an early dialog tries to appear

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4773,6 +4773,38 @@ EditorNode::EditorNode() {
 	prev_scene->set_position(Point2(3, 24));
 	prev_scene->hide();
 
+	accept = memnew(AcceptDialog);
+	gui_base->add_child(accept);
+	accept->connect("confirmed", this, "_menu_confirm_current");
+
+	project_export = memnew(ProjectExportDialog);
+	gui_base->add_child(project_export);
+
+	dependency_error = memnew(DependencyErrorDialog);
+	gui_base->add_child(dependency_error);
+
+	dependency_fixer = memnew(DependencyEditor);
+	gui_base->add_child(dependency_fixer);
+
+	settings_config_dialog = memnew(EditorSettingsDialog);
+	gui_base->add_child(settings_config_dialog);
+
+	project_settings = memnew(ProjectSettingsEditor(&editor_data));
+	gui_base->add_child(project_settings);
+
+	run_settings_dialog = memnew(RunSettingsDialog);
+	gui_base->add_child(run_settings_dialog);
+
+	export_template_manager = memnew(ExportTemplateManager);
+	gui_base->add_child(export_template_manager);
+
+	about = memnew(EditorAbout);
+	about->get_logo()->set_texture(gui_base->get_icon("Logo", "EditorIcons"));
+	gui_base->add_child(about);
+
+	warning = memnew(AcceptDialog);
+	gui_base->add_child(warning);
+
 	ED_SHORTCUT("editor/next_tab", TTR("Next tab"), KEY_MASK_CMD + KEY_TAB);
 	ED_SHORTCUT("editor/prev_tab", TTR("Previous tab"), KEY_MASK_CMD + KEY_MASK_SHIFT + KEY_TAB);
 	ED_SHORTCUT("editor/filter_files", TTR("Filter Files.."), KEY_MASK_ALT + KEY_MASK_CMD + KEY_P);
@@ -5196,38 +5228,6 @@ EditorNode::EditorNode() {
 	gui_base->add_child(save_confirmation);
 	save_confirmation->connect("confirmed", this, "_menu_confirm_current");
 	save_confirmation->connect("custom_action", this, "_discard_changes");
-
-	accept = memnew(AcceptDialog);
-	gui_base->add_child(accept);
-	accept->connect("confirmed", this, "_menu_confirm_current");
-
-	project_export = memnew(ProjectExportDialog);
-	gui_base->add_child(project_export);
-
-	dependency_error = memnew(DependencyErrorDialog);
-	gui_base->add_child(dependency_error);
-
-	dependency_fixer = memnew(DependencyEditor);
-	gui_base->add_child(dependency_fixer);
-
-	settings_config_dialog = memnew(EditorSettingsDialog);
-	gui_base->add_child(settings_config_dialog);
-
-	project_settings = memnew(ProjectSettingsEditor(&editor_data));
-	gui_base->add_child(project_settings);
-
-	run_settings_dialog = memnew(RunSettingsDialog);
-	gui_base->add_child(run_settings_dialog);
-
-	export_template_manager = memnew(ExportTemplateManager);
-	gui_base->add_child(export_template_manager);
-
-	about = memnew(EditorAbout);
-	about->get_logo()->set_texture(gui_base->get_icon("Logo", "EditorIcons"));
-	gui_base->add_child(about);
-
-	warning = memnew(AcceptDialog);
-	gui_base->add_child(warning);
 
 	file_templates = memnew(FileDialog);
 	file_templates->set_title(TTR("Import Templates From ZIP File"));


### PR DESCRIPTION
This changes the order of creating some of the dialogs that may appear
during project import/startup. It is possible for the 'accept' dialog to
be required before it is initialized.

This moves all of these dialogs to earlier in the constructor so this
can't happen.

Backtrace of the crash:
```
Thread 1 "godot.x11.tools" received signal SIGSEGV, Segmentation fault.
0x0000000000e9ae6e in AcceptDialog::get_ok (this=0x0)
    at ./scene/gui/dialogs.h:137
137		Button *get_ok() { return ok; }
(gdb) bt
#0  0x0000000000e9ae6e in AcceptDialog::get_ok (this=0x0)
    at ./scene/gui/dialogs.h:137
#1  0x00000000011cc777 in EditorNode::_menu_option_confirm (this=0x4d2b760, 
    p_option=52, p_confirmed=false) at editor/editor_node.cpp:2234
#2  0x00000000011bde6f in EditorNode::_menu_option (this=0x4d2b760, 
    p_option=52) at editor/editor_node.cpp:554
#3  0x00000000011e989e in EditorNode::EditorNode (this=0x4d2b760)
    at editor/editor_node.cpp:5002
#4  0x0000000000d3d3db in Main::start () at main/main.cpp:1249
#5  0x0000000000d138a6 in main (argc=2, argv=0x7fffffffdfd8)
    at platform/x11/godot_x11.cpp:53
(gdb) 
```

reported on IRC