### PR TITLE
second attempt on fixing the indent glitch.

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2113,15 +2113,15 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 
 				//keep indentation
 				int space_count = 0;
-				for (int i = 0; i < text[cursor.line].length(); i++) {
-					if (text[cursor.line][i] == '\t' && cursor.column > 0) {
+				for (int i = 0; i < cursor.column; i++) {
+					if (text[cursor.line][i] == '\t') {
 						if (indent_using_spaces) {
 							ins += space_indent;
 						} else {
 							ins += "\t";
 						}
 						space_count = 0;
-					} else if (text[cursor.line][i] == ' ' && cursor.column > 0) {
+					} else if (text[cursor.line][i] == ' ') {
 						space_count++;
 
 						if (space_count == indent_size) {


### PR DESCRIPTION
I've reverted the first attempt (https://github.com/godotengine/godot/pull/10653).
I was very naive and didn't consider that the glitch happens also if you're not in the first column, ex. if you have 2 tabs and press return in between them.
Hope this will solve the problem without messing anything else.