### PR TITLE
Fix pre-Lollipop Android debug (2.1)

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -237,7 +237,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 		String id;
 		String name;
 		String description;
-		int release;
+		int api_level;
 	};
 
 	Vector<Device> devices;
@@ -1495,7 +1495,7 @@ void EditorExportPlatformAndroid::_device_poll_thread(void *ud) {
 						if (ea->devices[j].id == ldevices[i]) {
 							d.description = ea->devices[j].description;
 							d.name = ea->devices[j].name;
-							d.release = ea->devices[j].release;
+							d.api_level = ea->devices[j].api_level;
 						}
 					}
 
@@ -1516,7 +1516,7 @@ void EditorExportPlatformAndroid::_device_poll_thread(void *ud) {
 						String vendor;
 						String device;
 						d.description + "Device ID: " + d.id + "\n";
-						d.release = 0;
+						d.api_level = 0;
 						for (int j = 0; j < props.size(); j++) {
 
 							String p = props[j];
@@ -1527,9 +1527,9 @@ void EditorExportPlatformAndroid::_device_poll_thread(void *ud) {
 							} else if (p.begins_with("ro.build.display.id=")) {
 								d.description += "Build: " + p.get_slice("=", 1).strip_edges() + "\n";
 							} else if (p.begins_with("ro.build.version.release=")) {
-								const String release_str = p.get_slice("=", 1).strip_edges();
-								d.description += "Release: " + release_str + "\n";
-								d.release = release_str.to_int();
+								d.description += "Release: " + p.get_slice("=", 1).strip_edges() + "\n";
+							} else if (p.begins_with("ro.build.version.sdk=")) {
+								d.api_level = p.get_slice("=", 1).to_int();
 							} else if (p.begins_with("ro.product.cpu.abi=")) {
 								d.description += "CPU: " + p.get_slice("=", 1).strip_edges() + "\n";
 							} else if (p.begins_with("ro.product.manufacturer=")) {
@@ -1688,7 +1688,7 @@ Error EditorExportPlatformAndroid::run(int p_device, int p_flags) {
 	args.push_back("shell");
 	args.push_back("am");
 	args.push_back("start");
-	if (bool(EDITOR_DEF("android/force_system_user", false)) && devices[p_device].release >= 17) { // Multi-user introduced in Android 17
+	if (bool(EDITOR_DEF("android/force_system_user", false)) && devices[p_device].api_level >= 17) { // Multi-user introduced in Android 17
 		args.push_back("--user");
 		args.push_back("0");
 	}


### PR DESCRIPTION
Namely, automatically pick debug over Wi-Fi for devices with an older release and debug over USB otherwise.

A message is printed both in editor output window and console (uppercase here) to let the user know about what mechanism is being used and why.

Fixes #10458.