### PR TITLE
Add a check to see if the current platform should use imported paths.

### DIFF
--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -138,6 +138,9 @@ public:
 	static void reload_translation_remaps();
 	static void load_translation_remaps();
 	static void clear_translation_remaps();
+
+	static String get_remapped_type(const String &p_path);
+	static String get_remapped_path(const String &p_path);
 };
 
 #endif

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -495,6 +495,10 @@ int OS::get_power_percent_left() {
 	return -1;
 }
 
+bool OS::use_imported_paths() const {
+	return false;
+}
+
 bool OS::check_feature_support(const String &p_feature) {
 
 	if (p_feature == get_name())

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -414,6 +414,8 @@ public:
 	virtual int get_power_seconds_left();
 	virtual int get_power_percent_left();
 
+	virtual bool use_imported_paths() const;
+
 	bool check_feature_support(const String &p_feature);
 
 	/**

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -553,6 +553,10 @@ void OSIPhone::native_video_stop() {
 		_stop_video();
 }
 
+bool OSIPhone::use_imported_paths() const {
+	return true;
+}
+
 bool OSIPhone::_check_internal_feature_support(const String &p_feature) {
 
 	return p_feature == "mobile" || p_feature == "etc" || p_feature == "pvrtc" || p_feature == "etc2";

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -196,6 +196,8 @@ public:
 	virtual void native_video_focus_out();
 	virtual void native_video_stop();
 
+	virtual bool use_imported_paths() const;
+
 	virtual bool _check_internal_feature_support(const String &p_feature);
 	OSIPhone(int width, int height);
 	~OSIPhone();


### PR DESCRIPTION
Need to implement this on other platforms than iPhone if it is required.

There is the question of whether or not this is the intended behavior in the first place?