### PR TITLE
fixed update import label in importer dock

### DIFF
--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -351,6 +351,15 @@ void ImportDock::_reimport() {
 	EditorFileSystem::get_singleton()->emit_signal("filesystem_changed"); //it changed, so force emitting the signal
 }
 
+void ImportDock::_notification(int p_what) {
+	switch (p_what) {
+
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+
+			imported->add_style_override("normal", get_stylebox("normal", "LineEdit"));
+		} break;
+	}
+}
 void ImportDock::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_reimport"), &ImportDock::_reimport);

--- a/editor/import_dock.h
+++ b/editor/import_dock.h
@@ -65,6 +65,7 @@ class ImportDock : public VBoxContainer {
 
 protected:
 	static void _bind_methods();
+	void _notification(int p_what);
 
 public:
 	void set_edit_path(const String &p_path);


### PR DESCRIPTION
Without this update the label keeps the same style box than on editor open. 