### PR TITLE
Fix import dock "Set as default" actions

### DIFF
--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -265,16 +265,14 @@ void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
 
 void ImportDock::_preset_selected(int p_idx) {
 
-	switch (p_idx) {
+	int item_id = preset->get_popup()->get_item_id(p_idx);
+
+	switch (item_id) {
 		case ITEM_SET_AS_DEFAULT: {
-			List<ResourceImporter::ImportOption> options;
-
-			params->importer->get_import_options(&options, p_idx);
-
 			Dictionary d;
-			for (List<ResourceImporter::ImportOption>::Element *E = options.front(); E; E = E->next()) {
 
-				d[E->get().option.name] = E->get().default_value;
+			for (const List<PropertyInfo>::Element *E = params->properties.front(); E; E = E->next()) {
+				d[E->get().name] = params->values[E->get().name];
 			}
 
 			ProjectSettings::get_singleton()->set("importer_defaults/" + params->importer->get_importer_name(), d);


### PR DESCRIPTION
## **Pull Request Description:**

This PR fixes importer dock "Set as default" and other related actions functionality. It ensures that when clicking this button, the currently edited importer properties get saved as the importer defaults.

## **Steps to reproduce:**

1. Open Godot editor v3.0.alpha.build1.
2. Select an importable asset from the FileSystem dock.
3. Navigate to the "Import" dock tab.
4. Modify any of the importer properties.
5. Click on "Preset > Set as default for 'type'".

**Results:** Modified importer properties get reset to their original (default) values.
**Expected Results:** Modified importer properties get saved as the global default properties for the importer type.

---

I believe there's still work to be done in the importer process, since re-importing assets doesn't apply this previously saved configurations. I'll confirm this and either create a new issue or try and find a fix and create a new PR.