### PR TITLE
Fix inconsistent toggle button behavior

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -87,14 +87,14 @@ void BaseButton::_gui_input(Ref<InputEvent> p_event) {
 
 					status.pressed = !status.pressed;
 					pressed();
-					if (get_script_instance()) {
-						Variant::CallError ce;
-						get_script_instance()->call(SceneStringNames::get_singleton()->_pressed, NULL, 0, ce);
-					}
+
 					emit_signal("pressed");
 					_unpress_group();
 
 					toggled(status.pressed);
+					if (get_script_instance()) {
+						get_script_instance()->call(SceneStringNames::get_singleton()->_toggled, status.pressed);
+					}
 					emit_signal("toggled", status.pressed);
 				}
 
@@ -143,10 +143,10 @@ void BaseButton::_gui_input(Ref<InputEvent> p_event) {
 					emit_signal("pressed");
 
 					toggled(status.pressed);
-					emit_signal("toggled", status.pressed);
 					if (get_script_instance()) {
 						get_script_instance()->call(SceneStringNames::get_singleton()->_toggled, status.pressed);
 					}
+					emit_signal("toggled", status.pressed);
 				}
 
 				_unpress_group();


### PR DESCRIPTION
Fixes #10759.

I moved the `emit_signal("toggled", status.pressed)` after the call to the script instance so that the script is invoked before the signal is emitted, since this is the case for the "pressed" case as well. (It probably doesn't matter in most cases.)

Currently the call to `_unpress_group_` is handled slightly differently in the `ACTION_MODE_BUTTON_PRESS` and `ACTION_MODE_BUTTON_RELEASE` cases. Since I'm not sure if there is a reason why this was done differently (in lines 84 vs. 92, and in 152) I've left this unchanged. Perhaps it would make sense to insert `_unpress_group_()` in line 100 and remove the calls in lines 84 and 92.