### PR TITLE
Implement index shifting for physics shapes

### DIFF
--- a/servers/physics/area_pair_sw.cpp
+++ b/servers/physics/area_pair_sw.cpp
@@ -34,7 +34,9 @@ bool AreaPairSW::setup(real_t p_step) {
 
 	bool result = false;
 
-	if (area->is_shape_set_as_disabled(area_shape) || body->is_shape_set_as_disabled(body_shape)) {
+	if (area_shape == -1 || body_shape == -1) {
+		result = false;
+	} else if (area->is_shape_set_as_disabled(area_shape) || body->is_shape_set_as_disabled(body_shape)) {
 		result = false;
 	} else if (area->test_collision_mask(body) && CollisionSolverSW::solve_static(body->get_shape(body_shape), body->get_transform() * body->get_shape_transform(body_shape), area->get_shape(area_shape), area->get_transform() * area->get_shape_transform(area_shape), NULL, this)) {
 		result = true;
@@ -64,6 +66,21 @@ bool AreaPairSW::setup(real_t p_step) {
 }
 
 void AreaPairSW::solve(real_t p_step) {
+}
+
+void AreaPairSW::shift_shape_indices(const CollisionObjectSW *p_object, int p_removed_index) {
+
+	if (p_object == body) {
+		if (body_shape == p_removed_index)
+			body_shape = -1;
+		else if (body_shape > p_removed_index)
+			body_shape--;
+	} else if (p_object == area) {
+		if (area_shape == p_removed_index)
+			area_shape = -1;
+		else if (area_shape > p_removed_index)
+			area_shape--;
+	}
 }
 
 AreaPairSW::AreaPairSW(BodySW *p_body, int p_body_shape, AreaSW *p_area, int p_area_shape) {
@@ -97,7 +114,9 @@ AreaPairSW::~AreaPairSW() {
 bool Area2PairSW::setup(real_t p_step) {
 
 	bool result = false;
-	if (area_a->is_shape_set_as_disabled(shape_a) || area_b->is_shape_set_as_disabled(shape_b)) {
+	if (shape_a == -1 || shape_b == -1) {
+		result = false;
+	} else if (area_a->is_shape_set_as_disabled(shape_a) || area_b->is_shape_set_as_disabled(shape_b)) {
 		result = false;
 	} else if (area_a->test_collision_mask(area_b) && CollisionSolverSW::solve_static(area_a->get_shape(shape_a), area_a->get_transform() * area_a->get_shape_transform(shape_a), area_b->get_shape(shape_b), area_b->get_transform() * area_b->get_shape_transform(shape_b), NULL, this)) {
 		result = true;
@@ -129,6 +148,21 @@ bool Area2PairSW::setup(real_t p_step) {
 }
 
 void Area2PairSW::solve(real_t p_step) {
+}
+
+void Area2PairSW::shift_shape_indices(const CollisionObjectSW *p_object, int p_removed_index) {
+
+	if (p_object == area_a) {
+		if (shape_a == p_removed_index)
+			shape_a = -1;
+		else if (shape_a > p_removed_index)
+			shape_a--;
+	} else if (p_object == area_b) {
+		if (shape_b == p_removed_index)
+			shape_b = -1;
+		else if (shape_b > p_removed_index)
+			shape_b--;
+	}
 }
 
 Area2PairSW::Area2PairSW(AreaSW *p_area_a, int p_shape_a, AreaSW *p_area_b, int p_shape_b) {

--- a/servers/physics/area_pair_sw.h
+++ b/servers/physics/area_pair_sw.h
@@ -46,6 +46,8 @@ public:
 	bool setup(real_t p_step);
 	void solve(real_t p_step);
 
+	virtual void shift_shape_indices(const CollisionObjectSW *p_object, int p_removed_index);
+
 	AreaPairSW(BodySW *p_body, int p_body_shape, AreaSW *p_area, int p_area_shape);
 	~AreaPairSW();
 };
@@ -61,6 +63,8 @@ class Area2PairSW : public ConstraintSW {
 public:
 	bool setup(real_t p_step);
 	void solve(real_t p_step);
+
+	virtual void shift_shape_indices(const CollisionObjectSW *p_object, int p_removed_index);
 
 	Area2PairSW(AreaSW *p_area_a, int p_shape_a, AreaSW *p_area_b, int p_shape_b);
 	~Area2PairSW();

--- a/servers/physics/area_sw.cpp
+++ b/servers/physics/area_sw.cpp
@@ -47,6 +47,13 @@ AreaSW::BodyKey::BodyKey(AreaSW *p_body, uint32_t p_body_shape, uint32_t p_area_
 void AreaSW::_shapes_changed() {
 }
 
+void AreaSW::_shape_index_removed(int p_index) {
+
+	for (Set<ConstraintSW *>::Element *E = constraints.front(); E; E = E->next()) {
+		E->get()->shift_shape_indices(this, p_index);
+	}
+}
+
 void AreaSW::set_transform(const Transform &p_transform) {
 
 	if (!moved_list.in_list() && get_space())

--- a/servers/physics/area_sw.h
+++ b/servers/physics/area_sw.h
@@ -105,6 +105,9 @@ class AreaSW : public CollisionObjectSW {
 	virtual void _shapes_changed();
 	void _queue_monitor_update();
 
+protected:
+	virtual void _shape_index_removed(int p_index);
+
 public:
 	//_FORCE_INLINE_ const Transform& get_inverse_transform() const { return inverse_transform; }
 	//_FORCE_INLINE_ SpaceSW* get_owner() { return owner; }

--- a/servers/physics/body_pair_sw.cpp
+++ b/servers/physics/body_pair_sw.cpp
@@ -209,6 +209,11 @@ bool BodyPairSW::_test_ccd(real_t p_step, BodySW *p_A, int p_shape_A, const Tran
 
 bool BodyPairSW::setup(real_t p_step) {
 
+	if (shape_A == -1 || shape_B == -1) {
+		collided = false;
+		return false;
+	}
+
 	//cannot collide
 	if (!A->test_collision_mask(B) || A->has_exception(B->get_self()) || B->has_exception(A->get_self()) || (A->get_mode() <= PhysicsServer::BODY_MODE_KINEMATIC && B->get_mode() <= PhysicsServer::BODY_MODE_KINEMATIC && A->get_max_contacts_reported() == 0 && B->get_max_contacts_reported() == 0)) {
 		collided = false;
@@ -443,6 +448,21 @@ void BodyPairSW::solve(real_t p_step) {
 
 			c.active = true;
 		}
+	}
+}
+
+void BodyPairSW::shift_shape_indices(const CollisionObjectSW *p_object, int p_removed_index) {
+
+	if (p_object == A) {
+		if (shape_A == p_removed_index)
+			shape_A = -1;
+		else if (shape_A > p_removed_index)
+			shape_A--;
+	} else if (p_object == B) {
+		if (shape_B == p_removed_index)
+			shape_B = -1;
+		else if (shape_B > p_removed_index)
+			shape_B--;
 	}
 }
 

--- a/servers/physics/body_pair_sw.h
+++ b/servers/physics/body_pair_sw.h
@@ -89,6 +89,8 @@ public:
 	bool setup(real_t p_step);
 	void solve(real_t p_step);
 
+	virtual void shift_shape_indices(const CollisionObjectSW *p_object, int p_removed_index);
+
 	BodyPairSW(BodySW *p_A, int p_shape_A, BodySW *p_B, int p_shape_B);
 	~BodyPairSW();
 };

--- a/servers/physics/body_sw.cpp
+++ b/servers/physics/body_sw.cpp
@@ -277,6 +277,13 @@ void BodySW::_shapes_changed() {
 	_update_inertia();
 }
 
+void BodySW::_shape_index_removed(int p_index) {
+
+	for (Map<ConstraintSW *, int>::Element *E = constraint_map.front(); E; E = E->next()) {
+		E->key()->shift_shape_indices(this, p_index);
+	}
+}
+
 void BodySW::set_state(PhysicsServer::BodyState p_state, const Variant &p_variant) {
 
 	switch (p_state) {

--- a/servers/physics/body_sw.h
+++ b/servers/physics/body_sw.h
@@ -146,6 +146,9 @@ class BodySW : public CollisionObjectSW {
 
 	friend class PhysicsDirectBodyStateSW; // i give up, too many functions to expose
 
+protected:
+	virtual void _shape_index_removed(int p_index);
+
 public:
 	void set_force_integration_callback(ObjectID p_id, const StringName &p_method, const Variant &p_udata = Variant());
 

--- a/servers/physics/collision_object_sw.cpp
+++ b/servers/physics/collision_object_sw.cpp
@@ -87,6 +87,7 @@ void CollisionObjectSW::remove_shape(int p_index) {
 		space->get_broadphase()->remove(shapes[i].bpid);
 		shapes[i].bpid = 0;
 	}
+	_shape_index_removed(p_index);
 	shapes[p_index].shape->remove_owner(this);
 	shapes.remove(p_index);
 

--- a/servers/physics/collision_object_sw.h
+++ b/servers/physics/collision_object_sw.h
@@ -98,6 +98,7 @@ protected:
 	void _set_static(bool p_static);
 
 	virtual void _shapes_changed() = 0;
+	virtual void _shape_index_removed(int p_index) = 0;
 	void _set_space(SpaceSW *p_space);
 
 	bool ray_pickable;

--- a/servers/physics/constraint_sw.h
+++ b/servers/physics/constraint_sw.h
@@ -73,6 +73,8 @@ public:
 	virtual bool setup(real_t p_step) = 0;
 	virtual void solve(real_t p_step) = 0;
 
+	virtual void shift_shape_indices(const CollisionObjectSW *p_object, int p_removed_index) {}
+
 	virtual ~ConstraintSW() {}
 };
 

--- a/servers/physics_2d/area_2d_sw.cpp
+++ b/servers/physics_2d/area_2d_sw.cpp
@@ -47,6 +47,13 @@ Area2DSW::BodyKey::BodyKey(Area2DSW *p_body, uint32_t p_body_shape, uint32_t p_a
 void Area2DSW::_shapes_changed() {
 }
 
+void Area2DSW::_shape_index_removed(int p_index) {
+
+	for (Set<Constraint2DSW *>::Element *E = constraints.front(); E; E = E->next()) {
+		E->get()->shift_shape_indices(this, p_index);
+	}
+}
+
 void Area2DSW::set_transform(const Transform2D &p_transform) {
 
 	if (!moved_list.in_list() && get_space())

--- a/servers/physics_2d/area_2d_sw.h
+++ b/servers/physics_2d/area_2d_sw.h
@@ -104,6 +104,9 @@ class Area2DSW : public CollisionObject2DSW {
 	virtual void _shapes_changed();
 	void _queue_monitor_update();
 
+protected:
+	virtual void _shape_index_removed(int p_index);
+
 public:
 	//_FORCE_INLINE_ const Matrix32& get_inverse_transform() const { return inverse_transform; }
 	//_FORCE_INLINE_ SpaceSW* get_owner() { return owner; }

--- a/servers/physics_2d/area_pair_2d_sw.cpp
+++ b/servers/physics_2d/area_pair_2d_sw.cpp
@@ -34,7 +34,9 @@ bool AreaPair2DSW::setup(real_t p_step) {
 
 	bool result = false;
 
-	if (area->is_shape_set_as_disabled(area_shape) || body->is_shape_set_as_disabled(body_shape)) {
+	if (area_shape == -1 || body_shape == -1) {
+		result = false;
+	} else if (area->is_shape_set_as_disabled(area_shape) || body->is_shape_set_as_disabled(body_shape)) {
 		result = false;
 	} else if (area->test_collision_mask(body) && CollisionSolver2DSW::solve(body->get_shape(body_shape), body->get_transform() * body->get_shape_transform(body_shape), Vector2(), area->get_shape(area_shape), area->get_transform() * area->get_shape_transform(area_shape), Vector2(), NULL, this)) {
 		result = true;
@@ -64,6 +66,21 @@ bool AreaPair2DSW::setup(real_t p_step) {
 }
 
 void AreaPair2DSW::solve(real_t p_step) {
+}
+
+void AreaPair2DSW::shift_shape_indices(const CollisionObject2DSW *p_object, int p_removed_index) {
+
+	if (p_object == body) {
+		if (body_shape == p_removed_index)
+			body_shape = -1;
+		else if (body_shape > p_removed_index)
+			body_shape--;
+	} else if (p_object == area) {
+		if (area_shape == p_removed_index)
+			area_shape = -1;
+		else if (area_shape > p_removed_index)
+			area_shape--;
+	}
 }
 
 AreaPair2DSW::AreaPair2DSW(Body2DSW *p_body, int p_body_shape, Area2DSW *p_area, int p_area_shape) {
@@ -97,7 +114,10 @@ AreaPair2DSW::~AreaPair2DSW() {
 bool Area2Pair2DSW::setup(real_t p_step) {
 
 	bool result = false;
-	if (area_a->is_shape_set_as_disabled(shape_a) || area_b->is_shape_set_as_disabled(shape_b)) {
+
+	if (shape_a == -1 || shape_b == -1) {
+		result = false;
+	} else if (area_a->is_shape_set_as_disabled(shape_a) || area_b->is_shape_set_as_disabled(shape_b)) {
 		result = false;
 	} else if (area_a->test_collision_mask(area_b) && CollisionSolver2DSW::solve(area_a->get_shape(shape_a), area_a->get_transform() * area_a->get_shape_transform(shape_a), Vector2(), area_b->get_shape(shape_b), area_b->get_transform() * area_b->get_shape_transform(shape_b), Vector2(), NULL, this)) {
 		result = true;
@@ -129,6 +149,21 @@ bool Area2Pair2DSW::setup(real_t p_step) {
 }
 
 void Area2Pair2DSW::solve(real_t p_step) {
+}
+
+void Area2Pair2DSW::shift_shape_indices(const CollisionObject2DSW *p_object, int p_removed_index) {
+
+	if (p_object == area_a) {
+		if (shape_a == p_removed_index)
+			shape_a = -1;
+		else if (shape_a > p_removed_index)
+			shape_a--;
+	} else if (p_object == area_b) {
+		if (shape_b == p_removed_index)
+			shape_b = -1;
+		else if (shape_b > p_removed_index)
+			shape_b--;
+	}
 }
 
 Area2Pair2DSW::Area2Pair2DSW(Area2DSW *p_area_a, int p_shape_a, Area2DSW *p_area_b, int p_shape_b) {

--- a/servers/physics_2d/area_pair_2d_sw.h
+++ b/servers/physics_2d/area_pair_2d_sw.h
@@ -46,6 +46,8 @@ public:
 	bool setup(real_t p_step);
 	void solve(real_t p_step);
 
+	virtual void shift_shape_indices(const CollisionObject2DSW *p_object, int p_removed_index);
+
 	AreaPair2DSW(Body2DSW *p_body, int p_body_shape, Area2DSW *p_area, int p_area_shape);
 	~AreaPair2DSW();
 };
@@ -61,6 +63,8 @@ class Area2Pair2DSW : public Constraint2DSW {
 public:
 	bool setup(real_t p_step);
 	void solve(real_t p_step);
+
+	virtual void shift_shape_indices(const CollisionObject2DSW *p_object, int p_removed_index);
 
 	Area2Pair2DSW(Area2DSW *p_area_a, int p_shape_a, Area2DSW *p_area_b, int p_shape_b);
 	~Area2Pair2DSW();

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -257,6 +257,13 @@ void Body2DSW::_shapes_changed() {
 	wakeup_neighbours();
 }
 
+void Body2DSW::_shape_index_removed(int p_index) {
+
+	for (Map<Constraint2DSW *, int>::Element *E = constraint_map.front(); E; E = E->next()) {
+		E->key()->shift_shape_indices(this, p_index);
+	}
+}
+
 void Body2DSW::set_state(Physics2DServer::BodyState p_state, const Variant &p_variant) {
 
 	switch (p_state) {

--- a/servers/physics_2d/body_2d_sw.h
+++ b/servers/physics_2d/body_2d_sw.h
@@ -132,6 +132,9 @@ class Body2DSW : public CollisionObject2DSW {
 
 	friend class Physics2DDirectBodyStateSW; // i give up, too many functions to expose
 
+protected:
+	virtual void _shape_index_removed(int p_index);
+
 public:
 	void set_force_integration_callback(ObjectID p_id, const StringName &p_method, const Variant &p_udata = Variant());
 

--- a/servers/physics_2d/body_pair_2d_sw.cpp
+++ b/servers/physics_2d/body_pair_2d_sw.cpp
@@ -219,6 +219,11 @@ bool BodyPair2DSW::_test_ccd(real_t p_step, Body2DSW *p_A, int p_shape_A, const 
 
 bool BodyPair2DSW::setup(real_t p_step) {
 
+	if (shape_A == -1 || shape_B == -1) {
+		collided = false;
+		return false;
+	}
+
 	//cannot collide
 	if (!A->test_collision_mask(B) || A->has_exception(B->get_self()) || B->has_exception(A->get_self()) || (A->get_mode() <= Physics2DServer::BODY_MODE_KINEMATIC && B->get_mode() <= Physics2DServer::BODY_MODE_KINEMATIC && A->get_max_contacts_reported() == 0 && B->get_max_contacts_reported() == 0)) {
 		collided = false;
@@ -497,6 +502,21 @@ void BodyPair2DSW::solve(real_t p_step) {
 
 		A->apply_impulse(c.rA, -j);
 		B->apply_impulse(c.rB, j);
+	}
+}
+
+void BodyPair2DSW::shift_shape_indices(const CollisionObject2DSW *p_object, int p_removed_index) {
+
+	if (p_object == A) {
+		if (shape_A == p_removed_index)
+			shape_A = -1;
+		else if (shape_A > p_removed_index)
+			shape_A--;
+	} else if (p_object == B) {
+		if (shape_B == p_removed_index)
+			shape_B = -1;
+		else if (shape_B > p_removed_index)
+			shape_B--;
 	}
 }
 

--- a/servers/physics_2d/body_pair_2d_sw.h
+++ b/servers/physics_2d/body_pair_2d_sw.h
@@ -88,6 +88,8 @@ public:
 	bool setup(real_t p_step);
 	void solve(real_t p_step);
 
+	virtual void shift_shape_indices(const CollisionObject2DSW *p_object, int p_removed_index);
+
 	BodyPair2DSW(Body2DSW *p_A, int p_shape_A, Body2DSW *p_B, int p_shape_B);
 	~BodyPair2DSW();
 };

--- a/servers/physics_2d/collision_object_2d_sw.cpp
+++ b/servers/physics_2d/collision_object_2d_sw.cpp
@@ -96,6 +96,7 @@ void CollisionObject2DSW::remove_shape(int p_index) {
 		space->get_broadphase()->remove(shapes[i].bpid);
 		shapes[i].bpid = 0;
 	}
+	_shape_index_removed(p_index);
 	shapes[p_index].shape->remove_owner(this);
 	shapes.remove(p_index);
 

--- a/servers/physics_2d/collision_object_2d_sw.h
+++ b/servers/physics_2d/collision_object_2d_sw.h
@@ -90,6 +90,7 @@ protected:
 	void _set_static(bool p_static);
 
 	virtual void _shapes_changed() = 0;
+	virtual void _shape_index_removed(int p_index) = 0;
 	void _set_space(Space2DSW *p_space);
 
 	CollisionObject2DSW(Type p_type);

--- a/servers/physics_2d/constraint_2d_sw.h
+++ b/servers/physics_2d/constraint_2d_sw.h
@@ -68,6 +68,8 @@ public:
 	virtual bool setup(real_t p_step) = 0;
 	virtual void solve(real_t p_step) = 0;
 
+	virtual void shift_shape_indices(const CollisionObject2DSW *p_object, int p_removed_index) {}
+
 	virtual ~Constraint2DSW() {}
 };
 


### PR DESCRIPTION
So that collision pairs always point to the same shape as when they were created. It's achieved by shifting the shape index as needed if others with a lower index are removed and setting -1 for pairs referencing the very removed shape.

Obviously, the -1s are checked where relevant.

This should make physics more stable.

I originally did this for 2.1 (as part of #8999), but I hadn't yet ported it to 3.0 as the need for it wasn't ever confirmed to me. @reduz, what can you tell me now?