### PR TITLE
Fix importer not applying default settings

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1383,7 +1383,7 @@ void EditorFileSystem::_reimport_file(const String &p_file) {
 		}
 	}
 
-	if (load_default && ProjectSettings::get_singleton()->get("importer_defaults/" + importer->get_importer_name())) {
+	if (load_default && ProjectSettings::get_singleton()->has("importer_defaults/" + importer->get_importer_name())) {
 		//use defaults if exist
 		Dictionary d = ProjectSettings::get_singleton()->get("importer_defaults/" + importer->get_importer_name());
 		List<Variant> v;


### PR DESCRIPTION
## **Pull Request Description:**

As I previously mentioned on PR #10821, this PR fixes the remaining issues when re-importing assets using previously saved default settings.

## **Steps to reproduce:**

1. Open Godot editor (built using PR #10821 changes, so you can save defaults).
2. Select an importable asset from the FileSystem dock.
3. Navigate to the "Import" dock tab.
4. Modify any of the importer properties.
5. Click on "Preset > Set as default for 'type'".
6. Remove any '*.import' files from the project's FileSystem to trigger a re-import of those files.

**Results:** Assets get imported properly, but default setings do not get applied.
**Expected Results:** Assets should be re-imported and if there are any default settings saved they should be applied.