### PR TITLE
Optimize memory allocations in VariantParser::get_token

### DIFF
--- a/core/string_buffer.cpp
+++ b/core/string_buffer.cpp
@@ -1,0 +1,102 @@
+/*************************************************************************/
+/*  string_buffer.cpp                                                    */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#include "string_buffer.h"
+
+#include <string.h>
+
+StringBuffer &StringBuffer::append(CharType p_char) {
+	reserve(string_length + 2);
+	current_buffer_ptr()[string_length++] = p_char;
+	return *this;
+}
+
+StringBuffer &StringBuffer::append(const String &p_string) {
+	return append(p_string.c_str());
+}
+
+StringBuffer &StringBuffer::append(const char *p_str) {
+	int len = strlen(p_str);
+	reserve(string_length + len + 1);
+
+	CharType *buf = current_buffer_ptr();
+	for (const char *c_ptr = p_str; c_ptr; ++c_ptr) {
+		buf[string_length++] = *c_ptr;
+	}
+	return *this;
+}
+
+StringBuffer &StringBuffer::append(const CharType *p_str, int p_clip_to_len) {
+	int len = 0;
+	while ((p_clip_to_len < 0 || len < p_clip_to_len) && p_str[len]) {
+		++len;
+	}
+	reserve(string_length + len + 1);
+	memcpy(&(current_buffer_ptr()[string_length]), p_str, len * sizeof(CharType));
+	string_length += len;
+
+	return *this;
+}
+
+StringBuffer &StringBuffer::reserve(int p_size) {
+	if (p_size < SHORT_BUFFER_SIZE || p_size < buffer.size())
+		return *this;
+
+	bool need_copy = string_length > 0 && buffer.empty();
+	buffer.resize(next_power_of_2(p_size));
+	if (need_copy) {
+		memcpy(buffer.ptr(), short_buffer, string_length * sizeof(CharType));
+	}
+
+	return *this;
+}
+
+int StringBuffer::length() const {
+	return string_length;
+}
+
+String StringBuffer::as_string() {
+	current_buffer_ptr()[string_length] = '\0';
+	if (buffer.empty()) {
+		return String(short_buffer);
+	} else {
+		buffer.resize(string_length + 1);
+		return buffer;
+	}
+}
+
+double StringBuffer::as_double() {
+	current_buffer_ptr()[string_length] = '\0';
+	return String::to_double(current_buffer_ptr());
+}
+
+int64_t StringBuffer::as_int() {
+	current_buffer_ptr()[string_length] = '\0';
+	return String::to_int(current_buffer_ptr());
+}

--- a/core/string_buffer.h
+++ b/core/string_buffer.h
@@ -1,0 +1,82 @@
+/*************************************************************************/
+/*  string_buffer.h                                                      */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#ifndef STRING_BUFFER_H
+#define STRING_BUFFER_H
+
+#include "ustring.h"
+
+class StringBuffer {
+	static const int SHORT_BUFFER_SIZE = 64;
+
+	CharType short_buffer[SHORT_BUFFER_SIZE];
+	String buffer;
+	int string_length = 0;
+
+	_FORCE_INLINE_ CharType *current_buffer_ptr() {
+		return static_cast<Vector<CharType> &>(buffer).empty() ? short_buffer : buffer.ptr();
+	}
+
+public:
+	StringBuffer &append(CharType p_char);
+	StringBuffer &append(const String &p_string);
+	StringBuffer &append(const char *p_str);
+	StringBuffer &append(const CharType *p_str, int p_clip_to_len = -1);
+
+	_FORCE_INLINE_ void operator+=(CharType p_char) {
+		append(p_char);
+	}
+
+	_FORCE_INLINE_ void operator+=(const String &p_string) {
+		append(p_string);
+	}
+
+	_FORCE_INLINE_ void operator+=(const char *p_str) {
+		append(p_str);
+	}
+
+	_FORCE_INLINE_ void operator+=(const CharType *p_str) {
+		append(p_str);
+	}
+
+	StringBuffer &reserve(int p_size);
+
+	int length() const;
+
+	String as_string();
+
+	double as_double();
+	int64_t as_int();
+
+	_FORCE_INLINE_ operator String() {
+		return as_string();
+	}
+};
+
+#endif

--- a/core/variant_parser.cpp
+++ b/core/variant_parser.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 #include "variant_parser.h"
 
+#include "core/string_buffer.h"
 #include "io/resource_loader.h"
 #include "os/input_event.h"
 #include "os/keyboard.h"
@@ -176,14 +177,15 @@ Error VariantParser::get_token(Stream *p_stream, Token &r_token, int &line, Stri
 			};
 			case '#': {
 
-				String color_str = "#";
+				StringBuffer color_str;
+				color_str += '#';
 				while (true) {
 					CharType ch = p_stream->get_char();
 					if (p_stream->is_eof()) {
 						r_token.type = TK_EOF;
 						return OK;
 					} else if ((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F')) {
-						color_str += String::chr(ch);
+						color_str += ch;
 
 					} else {
 						p_stream->saved = ch;
@@ -191,7 +193,7 @@ Error VariantParser::get_token(Stream *p_stream, Token &r_token, int &line, Stri
 					}
 				}
 
-				r_token.value = Color::html(color_str);
+				r_token.value = Color::html(color_str.as_string());
 				r_token.type = TK_COLOR;
 				return OK;
 			};
@@ -296,7 +298,7 @@ Error VariantParser::get_token(Stream *p_stream, Token &r_token, int &line, Stri
 				if (cchar == '-' || (cchar >= '0' && cchar <= '9')) {
 					//a number
 
-					String num;
+					StringBuffer num;
 #define READING_SIGN 0
 #define READING_INT 1
 #define READING_DEC 2
@@ -359,7 +361,7 @@ Error VariantParser::get_token(Stream *p_stream, Token &r_token, int &line, Stri
 
 						if (reading == READING_DONE)
 							break;
-						num += String::chr(c);
+						num += c;
 						c = p_stream->get_char();
 					}
 
@@ -368,19 +370,19 @@ Error VariantParser::get_token(Stream *p_stream, Token &r_token, int &line, Stri
 					r_token.type = TK_NUMBER;
 
 					if (is_float)
-						r_token.value = num.to_double();
+						r_token.value = num.as_double();
 					else
-						r_token.value = num.to_int();
+						r_token.value = num.as_int();
 					return OK;
 
 				} else if ((cchar >= 'A' && cchar <= 'Z') || (cchar >= 'a' && cchar <= 'z') || cchar == '_') {
 
-					String id;
+					StringBuffer id;
 					bool first = true;
 
 					while ((cchar >= 'A' && cchar <= 'Z') || (cchar >= 'a' && cchar <= 'z') || cchar == '_' || (!first && cchar >= '0' && cchar <= '9')) {
 
-						id += String::chr(cchar);
+						id += cchar;
 						cchar = p_stream->get_char();
 						first = false;
 					}
@@ -388,7 +390,7 @@ Error VariantParser::get_token(Stream *p_stream, Token &r_token, int &line, Stri
 					p_stream->saved = cchar;
 
 					r_token.type = TK_IDENTIFIER;
-					r_token.value = id;
+					r_token.value = id.as_string();
 					return OK;
 				} else {
 					r_err_str = "Unexpected character.";


### PR DESCRIPTION
This is optimization I made after profiling loading time of a game we're making. The game has lots of heavy scenes with meshes, animations and stuff, so parsing them became a bottleneck.
Apparently, there are a lot of redundant memory allocations inside `VariantParser::get_token`. I rewrote the code so it will use static buffer when possible.

Just a couple of screenshots - this is profiling results of loading phase of our game:
![before](https://user-images.githubusercontent.com/20835548/29955946-c136eda8-8f0d-11e7-95bd-d961f9753487.png)
And this is the same loading after my optimization:
![after](https://user-images.githubusercontent.com/20835548/29955986-0674016c-8f0e-11e7-9911-b3e35748281a.png)

And I'm aware that it's only actual for development builds (exported projects are unlikely to have this issue at all). Still, I think it won't hurt to merge.