### PR TITLE
Has_method is already provided by Object

### DIFF
--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -55,7 +55,6 @@ void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_source_code", "source"), &Script::set_source_code);
 	ClassDB::bind_method(D_METHOD("reload", "keep_state"), &Script::reload, DEFVAL(false));
 
-	ClassDB::bind_method(D_METHOD("has_method", "method_name"), &Script::has_method);
 	ClassDB::bind_method(D_METHOD("has_script_signal", "signal_name"), &Script::has_script_signal);
 
 	ClassDB::bind_method(D_METHOD("is_tool"), &Script::is_tool);


### PR DESCRIPTION
c812c17633 introduces some extra gdscript bindings for signal discovery
and adds a binding for has_method() to Script objects. This method is
already provided by the ancestor Object.

This fixes the startup message:
ERROR: bind_methodfi: Class Script already has a method has_method
   At: core/class_db.cpp:1178.