### PR TITLE
Disabled PCRE-JIT in HTML5. Fixes #10834

### DIFF
--- a/modules/regex/SCsub
+++ b/modules/regex/SCsub
@@ -8,8 +8,11 @@ env_regex.Append(CPPFLAGS=["-DPCRE2_CODE_UNIT_WIDTH=0"])
 env_regex.add_source_files(env.modules_sources, "*.cpp")
 
 if (env['builtin_pcre2'] != 'no'):
-    thirdparty_dir = "#thirdparty/pcre2/src/"
-    thirdparty_flags = ["-DPCRE2_STATIC", "-DHAVE_CONFIG_H", "-DSUPPORT_JIT"]
+    jit_blacklist = ['javascript']
+    thirdparty_dir = '#thirdparty/pcre2/src/'
+    thirdparty_flags = ['-DPCRE2_STATIC', '-DHAVE_CONFIG_H']
+    if 'platform' in env and env['platform'] not in jit_blacklist:
+        thirdparty_flags.append('-DSUPPORT_JIT')
     thirdparty_sources = [
         "pcre2_auto_possess.c",
         "pcre2_chartables.c",


### PR DESCRIPTION
This should fix #10834. Tested with emscripten.