### PR TITLE
Fix crash when destroying AudioStreamPlaybackOGGVorbis

### DIFF
--- a/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
@@ -112,8 +112,8 @@ float AudioStreamPlaybackOGGVorbis::get_length() const {
 
 AudioStreamPlaybackOGGVorbis::~AudioStreamPlaybackOGGVorbis() {
 	if (ogg_alloc.alloc_buffer) {
-		AudioServer::get_singleton()->audio_data_free(ogg_alloc.alloc_buffer);
 		stb_vorbis_close(ogg_stream);
+		AudioServer::get_singleton()->audio_data_free(ogg_alloc.alloc_buffer);
 	}
 }
 


### PR DESCRIPTION
Closing `ogg_stream` after freeing `ogg_alloc.alloc_buffer` may cause crash. That's because `ogg_stream` may be allocated _inside_ `ogg_alloc.alloc_buffer` .
Simply closing `ogg_stream` before freeing buffer fixes the crash.

**Why this happens:**
1. `ogg_stream` is allocated using `stb_vorbis_open_memory` with `alloc` argument specified:
https://github.com/godotengine/godot/blob/7c76e0c8c3dda5c88f761176cb93445b3214ea21/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp#L135

2. And here we see, that `setup_malloc` (which handles all allocations inside vorbis module) is trying to allocate memory inside `alloc_buffer`.
https://github.com/godotengine/godot/blob/7c76e0c8c3dda5c88f761176cb93445b3214ea21/thirdparty/misc/stb_vorbis.c#L906-L917

