### PR TITLE
etc: Append -std=gnu++11 to CCFLAGS instead of CXXFLAGS

### DIFF
--- a/modules/etc/SCsub
+++ b/modules/etc/SCsub
@@ -34,7 +34,7 @@ env_etc.Append(CPPPATH=[thirdparty_dir])
 env_etc.add_source_files(env.modules_sources, "*.cpp")
 
 # upstream uses c++11
-env_etc.Append(CXXFLAGS="-std=gnu++11")
+env_etc.Append(CCFLAGS="-std=gnu++11")
 # -ffast-math seems to be incompatible with ec2comp on recent versions of
 # GCC and Clang
 if '-ffast-math' in env_etc['CCFLAGS']:


### PR DESCRIPTION
This way it can override the -std flags passed to scons.