### PR TITLE
Fix wrong argument name, that fails the build

### DIFF
--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -1002,7 +1002,7 @@ void AnimationTreePlayer::animation_node_set_master_animation(const StringName &
 		_update_sources();
 }
 
-void AnimationTreePlayer::animation_node_set_filter_path(const StringName &p_node, const NodePath &p_track_path, bool p_track_path) {
+void AnimationTreePlayer::animation_node_set_filter_path(const StringName &p_node, const NodePath &p_track_path, bool p_filter) {
 
 	GET_NODE(NODE_ANIMATION, AnimationNode);
 


### PR DESCRIPTION
@reduz made small mistake in last commit 6fa6149517b974fccd97e41f6b0a6466c83473fc
There is fix.