### PR TITLE
Fix AnimationTreePlayer::animation_node_set_filter_path prototype

### DIFF
--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -1002,7 +1002,7 @@ void AnimationTreePlayer::animation_node_set_master_animation(const StringName &
 		_update_sources();
 }
 
-void AnimationTreePlayer::animation_node_set_filter_path(const StringName &p_node, const NodePath &p_track_path, bool p_track_path) {
+void AnimationTreePlayer::animation_node_set_filter_path(const StringName &p_node, const NodePath &p_track_path, bool p_filter) {
 
 	GET_NODE(NODE_ANIMATION, AnimationNode);
 


### PR DESCRIPTION
This prototype was accidentally changed and godot would not compile.