### PR TITLE
[2.1] Some improvements for debugger

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -86,6 +86,20 @@ void EditorHistory::_add_object(ObjectID p_object, const String &p_property, int
 	bool has_prev = current >= 0 && current < history.size();
 
 	if (has_prev) {
+
+		if (obj->is_type("ScriptEditorDebuggerInspectedObject")) {
+			for (int i = current; i >= 0; i--) {
+				Object *pre_obj = ObjectDB::get_instance(get_history_obj(i));
+				if (pre_obj->is_type("ScriptEditorDebuggerInspectedObject")) {
+					if (pre_obj->call("get_remote_object_id") == obj->call("get_remote_object_id")) {
+						History &pr = history[i];
+						pr.path[pr.path.size() - 1] = o;
+						current = i;
+						return;
+					}
+				}
+			}
+		}
 		history.resize(current + 1); //clip history to next
 	}
 

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -43,12 +43,14 @@
 #include "os/input.h"
 #include "os/keyboard.h"
 #include "pair.h"
+#include "plugins/script_editor_plugin.h"
 #include "print_string.h"
 #include "scene/gui/label.h"
 #include "scene/main/viewport.h"
 #include "scene/resources/font.h"
 #include "scene/resources/packed_scene.h"
 #include "scene/scene_string_names.h"
+#include "script_editor_debugger.h"
 
 void CustomPropertyEditor::_notification(int p_what) {
 
@@ -3619,8 +3621,14 @@ void PropertyEditor::edit(Object *p_object) {
 		obj->remove_change_receptor(this);
 
 		if (obj->is_type("ScriptEditorDebuggerInspectedObject")) {
-			set_enable_capitalize_paths(false);
-			emit_signal("object_id_selected", obj->call("get_remote_object_id"));
+			ScriptEditorDebugger *sed = ScriptEditor::get_singleton()->get_debugger();
+			if (sed->is_connected()) {
+				set_enable_capitalize_paths(false);
+				emit_signal("object_id_selected", obj->call("get_remote_object_id"));
+			} else {
+				obj = NULL;
+				p_object = NULL;
+			}
 		}
 	}
 

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -3618,6 +3618,7 @@ void PropertyEditor::edit(Object *p_object) {
 
 	if (obj) {
 
+		set_enable_capitalize_paths(true);
 		obj->remove_change_receptor(this);
 
 		if (obj->is_type("ScriptEditorDebuggerInspectedObject")) {

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -3618,8 +3618,10 @@ void PropertyEditor::edit(Object *p_object) {
 
 		obj->remove_change_receptor(this);
 
-		if (obj->is_type("ScriptEditorDebuggerInspectedObject"))
+		if (obj->is_type("ScriptEditorDebuggerInspectedObject")) {
 			set_enable_capitalize_paths(false);
+			emit_signal("object_id_selected", obj->call("get_remote_object_id"));
+		}
 	}
 
 	evaluator->edit(p_object);

--- a/editor/property_editor.h
+++ b/editor/property_editor.h
@@ -213,6 +213,7 @@ class PropertyEditor : public Control {
 	void _node_removed(Node *p_node);
 
 	friend class ProjectExportDialog;
+	friend class ScriptEditorDebugger;
 	void _edit_set(const String &p_name, const Variant &p_value, const String &p_changed_field = "");
 	void _draw_flags(Object *ti, const Rect2 &p_rect);
 

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -312,6 +312,9 @@ void ScriptEditorDebugger::_scene_tree_variable_value_edited(const String &p_pro
 
 void ScriptEditorDebugger::_scene_tree_property_select_object(ObjectID p_object) {
 
+	if (p_object == inspected_object_id)
+		return;
+
 	inspected_object_id = p_object;
 	Array msg;
 	msg.push_back("inspect_object");
@@ -489,6 +492,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 			debugObj->update_single(pinfo.name.ascii().get_data());
 		}
 
+		inspected_object_id = id;
 		debugObj->update();
 		editor->push_item(debugObj, "");
 
@@ -985,33 +989,23 @@ void ScriptEditorDebugger::_notification(int p_what) {
 		case NOTIFICATION_PROCESS: {
 
 			if (connection.is_valid()) {
-				inspect_scene_tree_timeout -= get_process_delta_time();
-				if (inspect_scene_tree_timeout < 0) {
-					inspect_scene_tree_timeout = EditorSettings::get_singleton()->get("debugger/scene_tree_refresh_interval");
-					if (inspect_scene_tree->is_visible()) {
-						_scene_tree_request();
-
-						if (inspected_object_id != 0) {
-							//take the chance and re-inspect selected object
-							Array msg;
-							msg.push_back("inspect_object");
-							msg.push_back(inspected_object_id);
-							ppeer->put_var(msg);
-							inspected_object_id = 0;
-						}
-					}
-				}
-
 				inspect_edited_object_timeout -= get_process_delta_time();
 				if (inspect_edited_object_timeout < 0) {
 					inspect_edited_object_timeout = EditorSettings::get_singleton()->get("debugger/remote_inspect_refresh_interval");
-					if (inspect_scene_tree->is_visible() && inspected_object_id) {
-						//take the chance and re-inspect selected object
+
+					if (inspect_scene_tree->is_visible())
+						_scene_tree_request();
+
+					bool need_query_instance = inspected_object_id != 0;
+					need_query_instance = need_query_instance && editor->get_property_editor()->is_visible();
+					need_query_instance = need_query_instance && (editor->get_property_editor()->obj != NULL);
+					need_query_instance = need_query_instance && editor->get_property_editor()->obj->is_type("ScriptEditorDebuggerInspectedObject");
+					need_query_instance = need_query_instance && ((ObjectID)editor->get_property_editor()->obj->call("get_remote_object_id") != 0);
+					if (need_query_instance) {
 						Array msg;
 						msg.push_back("inspect_object");
 						msg.push_back(inspected_object_id);
 						ppeer->put_var(msg);
-						inspected_object_id = 0;
 					}
 				}
 			}
@@ -1210,7 +1204,6 @@ void ScriptEditorDebugger::stop() {
 	le_set->set_disabled(true);
 	profiler->set_enabled(true);
 
-	inspect_properties->edit(NULL);
 	inspect_scene_tree->clear();
 
 	EditorNode::get_singleton()->get_pause_button()->set_pressed(false);
@@ -1680,9 +1673,6 @@ void ScriptEditorDebugger::_clear_remote_objects() {
 	if (inspector)
 		inspector->edit(NULL);
 
-	if (inspect_properties)
-		inspect_properties->edit(NULL);
-
 	for (Map<ObjectID, ScriptEditorDebuggerInspectedObject *>::Element *E = remote_objects.front(); E; E = E->next()) {
 		memdelete(E->value());
 	}
@@ -1817,6 +1807,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		inspector->set_read_only(true);
 		inspector->connect("object_id_selected", this, "_scene_tree_property_select_object");
 		sc->add_child(inspector);
+		editor->get_property_editor()->connect("object_id_selected", this, "_scene_tree_property_select_object");
 
 		server = TCP_Server::create_ref();
 
@@ -1855,29 +1846,12 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 
 	{ // inquire
 
-		inspect_info = memnew(HSplitContainer);
-		inspect_info->set_name(TTR("Remote Inspector"));
-		tabs->add_child(inspect_info);
-
-		VBoxContainer *info_left = memnew(VBoxContainer);
-		info_left->set_h_size_flags(SIZE_EXPAND_FILL);
-		inspect_info->add_child(info_left);
-
 		inspect_scene_tree = memnew(Tree);
-		info_left->add_margin_child(TTR("Live Scene Tree:"), inspect_scene_tree, true);
+		inspect_scene_tree->set_name(TTR("Live Scene Tree"));
 		inspect_scene_tree->connect("cell_selected", this, "_scene_tree_selected");
 		inspect_scene_tree->connect("item_collapsed", this, "_scene_tree_folded");
 
-		VBoxContainer *info_right = memnew(VBoxContainer);
-		info_right->set_h_size_flags(SIZE_EXPAND_FILL);
-		inspect_info->add_child(info_right);
-
-		inspect_properties = memnew(PropertyEditor);
-		//inspect_properties->hide_top_label();
-		inspect_properties->set_show_categories(true);
-		inspect_properties->connect("object_id_selected", this, "_scene_tree_property_select_object");
-
-		info_right->add_margin_child(TTR("Remote Object Properties: "), inspect_properties, true);
+		tabs->add_child(inspect_scene_tree);
 
 		inspect_scene_tree_timeout = EDITOR_DEF("debugger/scene_tree_refresh_interval", 1.0);
 		inspect_edited_object_timeout = EDITOR_DEF("debugger/remote_inspect_refresh_interval", 0.2);
@@ -2032,7 +2006,6 @@ ScriptEditorDebugger::~ScriptEditorDebugger() {
 	ppeer->set_stream_peer(Ref<StreamPeer>());
 
 	inspector = NULL;
-	inspect_properties = NULL;
 
 	server->stop();
 	_clear_remote_objects();

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -497,7 +497,6 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		}
 
 		inspected_object_id = id;
-		debugObj->update();
 		editor->push_item(debugObj, "");
 
 	} else if (p_msg == "message:video_mem") {
@@ -1000,12 +999,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 					if (inspect_scene_tree->is_visible())
 						_scene_tree_request();
 
-					bool need_query_instance = inspected_object_id != 0;
-					need_query_instance = need_query_instance && editor->get_property_editor()->is_visible();
-					need_query_instance = need_query_instance && (editor->get_property_editor()->obj != NULL);
-					need_query_instance = need_query_instance && editor->get_property_editor()->obj->is_type("ScriptEditorDebuggerInspectedObject");
-					need_query_instance = need_query_instance && ((ObjectID)editor->get_property_editor()->obj->call("get_remote_object_id") != 0);
-					if (need_query_instance) {
+					if (inspected_object_id != 0 && editor->get_property_editor()->is_visible() && (editor->get_property_editor()->obj != NULL) && editor->get_property_editor()->obj->is_type("ScriptEditorDebuggerInspectedObject") && ((ObjectID)editor->get_property_editor()->obj->call("get_remote_object_id") != 0)) {
 						Array msg;
 						msg.push_back("inspect_object");
 						msg.push_back(inspected_object_id);

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -250,6 +250,10 @@ void ScriptEditorDebugger::debug_continue() {
 	ppeer->put_var(msg);
 }
 
+bool ScriptEditorDebugger::is_connected() const {
+	return connection.is_valid() && connection->is_connected();
+}
+
 void ScriptEditorDebugger::_scene_tree_folded(Object *obj) {
 
 	if (updating_scene_tree) {

--- a/editor/script_editor_debugger.h
+++ b/editor/script_editor_debugger.h
@@ -185,6 +185,8 @@ public:
 	void debug_break();
 	void debug_continue();
 
+	bool is_connected() const;
+
 	String get_var_value(const String &p_var) const;
 
 	void set_live_debugging(bool p_enable);

--- a/editor/script_editor_debugger.h
+++ b/editor/script_editor_debugger.h
@@ -67,8 +67,6 @@ class ScriptEditorDebugger : public Control {
 	Button *le_clear;
 
 	Tree *inspect_scene_tree;
-	HSplitContainer *inspect_info;
-	PropertyEditor *inspect_properties;
 	float inspect_scene_tree_timeout;
 	float inspect_edited_object_timeout;
 	ObjectID inspected_object_id;


### PR DESCRIPTION
- [x] Fix continous update of the remote properties
- [x] Remove useless debugger property panel
- [x] Rename Remote Inspector to Live Scene Tree
- [x] Editor crashes when edit remote object instances from inspector edit history after debugging finshed.
- [x] Fix the continous update of the remote properties push tons of objects into edit history.
~~Improve data serialization/desrialization with the debug remote and client.~~