### PR TITLE
Adjust Noto font metrics

### DIFF
--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -71,11 +71,13 @@ static Ref<BitmapFont> make_font(int p_height, int p_ascent, int p_valign, int p
 	m_name->add_fallback(FontJapanese); \
 	m_name->add_fallback(FontFallback);
 
-#define MAKE_DEFAULT_FONT(m_name, m_size) \
-	Ref<DynamicFont> m_name;              \
-	m_name.instance();                    \
-	m_name->set_size(m_size);             \
-	m_name->set_font_data(DefaultFont);   \
+#define MAKE_DEFAULT_FONT(m_name, m_size)                 \
+	Ref<DynamicFont> m_name;                              \
+	m_name.instance();                                    \
+	m_name->set_size(m_size);                             \
+	m_name->set_font_data(DefaultFont);                   \
+	m_name->set_spacing(DynamicFont::SPACING_TOP, -1);    \
+	m_name->set_spacing(DynamicFont::SPACING_BOTTOM, -1); \
 	MAKE_FALLBACKS(m_name);
 
 void editor_register_fonts(Ref<Theme> p_theme) {

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1022,7 +1022,8 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					cache.selected->draw(ci, r);
 				}
 				if (text_editor->is_visible()) {
-					text_editor->set_pos(get_global_pos() + r.pos);
+					Vector2 ofs(0, (text_editor->get_size().height - r.size.height) / 2);
+					text_editor->set_pos(get_global_pos() + r.pos - ofs);
 				}
 			}
 
@@ -2385,8 +2386,8 @@ bool Tree::edit_selected() {
 		return true;
 
 	} else if (c.mode == TreeItem::CELL_MODE_STRING || c.mode == TreeItem::CELL_MODE_RANGE || c.mode == TreeItem::CELL_MODE_RANGE_EXPRESSION) {
-
-		Point2i textedpos = get_global_pos() + rect.pos;
+		Vector2 ofs(0, (text_editor->get_size().height - rect.size.height) / 2);
+		Point2i textedpos = get_global_pos() + rect.pos - ofs;
 		text_editor->set_pos(textedpos);
 		text_editor->set_size(rect.size);
 		text_editor->clear();


### PR DESCRIPTION
`Tree` is used a lot of places. so need to be adjusted like old.

![image](https://user-images.githubusercontent.com/8281454/29997301-c11693ee-904a-11e7-81ad-2ae64d914c77.png)

This is just for 2.1
for the master branch, I guess @djrm @toger5 will make better PR. :)

Updated first commit as same as #10932
Final screenshot.
![image](https://user-images.githubusercontent.com/8281454/30026762-4b3ecb12-91b9-11e7-9034-a29be45fd4bb.png)
