### PR TITLE
Added border for tabs + container.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4857,7 +4857,7 @@ EditorNode::EditorNode() {
 	scene_root_parent = memnew(PanelContainer);
 	scene_root_parent->set_custom_minimum_size(Size2(0, 80) * EDSCALE);
 	scene_root_parent->add_style_override("panel", gui_base->get_stylebox("Content", "EditorStyles"));
-
+	scene_root_parent->set_draw_behind_parent(true);
 	srt->add_child(scene_root_parent);
 	scene_root_parent->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -369,6 +369,10 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	// Tabs
 	Ref<StyleBoxFlat> style_tab_selected = style_default->duplicate();
+	style_tab_selected->set_border_width_all(border_width);
+	style_tab_selected->set_border_width(MARGIN_BOTTOM, 0);
+	style_tab_selected->set_border_color_all(dark_color_3);
+	style_tab_selected->set_expand_margin_size(MARGIN_BOTTOM, border_width);
 	style_tab_selected->set_default_margin(MARGIN_LEFT, 10 * EDSCALE);
 	style_tab_selected->set_default_margin(MARGIN_RIGHT, 10 * EDSCALE);
 	style_tab_selected->set_bg_color(tab_color);
@@ -434,19 +438,6 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("font_color_pressed", "ToolButton", accent_color);
 
 	theme->set_stylebox("MenuHover", "EditorStyles", style_menu_hover_border);
-
-	// Content of each tab
-	Ref<StyleBoxFlat> style_content_panel = style_default->duplicate();
-	style_content_panel->set_border_color_all(base_color);
-
-	// this is the stylebox used in 3d and 2d viewports (no borders)
-	Ref<StyleBoxFlat> style_content_panel_vp = style_content_panel->duplicate();
-	style_content_panel_vp->set_default_margin(MARGIN_LEFT, border_width);
-	style_content_panel_vp->set_default_margin(MARGIN_TOP, default_margin_size);
-	style_content_panel_vp->set_default_margin(MARGIN_RIGHT, border_width);
-	style_content_panel_vp->set_default_margin(MARGIN_BOTTOM, border_width);
-	theme->set_stylebox("panel", "TabContainer", style_content_panel);
-	theme->set_stylebox("Content", "EditorStyles", style_content_panel_vp);
 
 	// Buttons
 	theme->set_stylebox("normal", "Button", style_widget);
@@ -607,6 +598,20 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("close", "Tabs", theme->get_icon("GuiClose", "EditorIcons"));
 	theme->set_stylebox("button_pressed", "Tabs", style_menu);
 	theme->set_stylebox("button", "Tabs", style_menu);
+
+	// Content of each tab
+	Ref<StyleBoxFlat> style_content_panel = style_default->duplicate();
+	style_content_panel->set_border_color_all(dark_color_3);
+	style_content_panel->set_border_width_all(border_width);
+
+	// this is the stylebox used in 3d and 2d viewports (no borders)
+	Ref<StyleBoxFlat> style_content_panel_vp = style_content_panel->duplicate();
+	style_content_panel_vp->set_default_margin(MARGIN_LEFT, border_width);
+	style_content_panel_vp->set_default_margin(MARGIN_TOP, default_margin_size);
+	style_content_panel_vp->set_default_margin(MARGIN_LEFT, border_width);
+	style_content_panel_vp->set_default_margin(MARGIN_BOTTOM, border_width);
+	theme->set_stylebox("panel", "TabContainer", style_content_panel);
+	theme->set_stylebox("Content", "EditorStyles", style_content_panel_vp);
 
 	// Separators (no separators)
 	theme->set_stylebox("separator", "HSeparator", make_line_stylebox(separator_color, border_width));

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -208,6 +208,9 @@ void TabContainer::_notification(int p_what) {
 					break;
 			}
 
+			// Draw the tab area.
+			panel->draw(canvas, Rect2(0, header_height, size.width, size.height - header_height));
+
 			// Draw all visible tabs.
 			int x = 0;
 			for (int i = 0; i < tab_widths.size(); i++) {
@@ -280,9 +283,6 @@ void TabContainer::_notification(int p_what) {
 						Point2(x, y_center - (decrement->get_height() / 2)),
 						Color(1, 1, 1, first_tab_cache > 0 ? 1.0 : 0.5));
 			}
-
-			// Draw the tab area.
-			panel->draw(canvas, Rect2(0, header_height, size.width, size.height - header_height));
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
 			if (get_tab_count() > 0) {


### PR DESCRIPTION
the highlighting also works for them main viewport now. since they are using the same sb than the other tabs.

<img width="221" alt="screen shot 2017-09-02 at 19 37 16" src="https://user-images.githubusercontent.com/16718859/29997541-3e923f4c-9016-11e7-86ef-0b8297801e61.png">
<img width="516" alt="screen shot 2017-09-02 at 19 37 28" src="https://user-images.githubusercontent.com/16718859/29997540-3e90f178-9016-11e7-9911-c55fdc5e0bec.png">

 - moved tabConetent position to be more reasonable.
 - fixed drawing order to allow those kind of styles.

## [DISCUSSION] all figured out so ready to merge

this pr is a discussion to some extend. I wanted to propose the border. but I don't know if it makes sense. It would be really easy to make it another option too. (the border already is dependent on the setting you choose for border width. setting it to 0 removes it of course)
 - The drawing order fix though makes much more sense since it allows to draw tabs over the container so more style options are possible in general. (also for games made with godot)
 - also the change, that the same sb is used for the viewport tabs and the dock tabs is good it think.

this is how it looks with the light theme:
<img width="1680" alt="screen shot 2017-09-02 at 19 42 28" src="https://user-images.githubusercontent.com/16718859/29997569-e9afc502-9016-11e7-995e-2de44056bfbc.png">
