### PR TITLE
StyleBoxSupport for RichTextLabel and cleanup for script+docs backgrounds fixes #10685

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1711,12 +1711,6 @@ void EditorHelp::_notification(int p_what) {
 			_update_doc();
 		} break;
 
-		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			Ref<StyleBoxFlat> style(memnew(StyleBoxFlat));
-			style->set_bg_color(EditorSettings::get_singleton()->get("text_editor/highlighting/background_color"));
-			background_panel->add_style_override("panel", style);
-		} break;
-
 		default: break;
 	}
 }
@@ -1786,14 +1780,11 @@ EditorHelp::EditorHelp() {
 
 	{
 		background_panel = memnew(Panel);
-		Ref<StyleBoxFlat> style(memnew(StyleBoxFlat));
-		style->set_bg_color(EditorSettings::get_singleton()->get("text_editor/highlighting/background_color"));
 		background_panel->set_v_size_flags(SIZE_EXPAND_FILL);
-		background_panel->add_style_override("panel", style); //get_stylebox("normal","TextEdit"));
 		vbc->add_child(background_panel);
 		class_desc = memnew(RichTextLabel);
 		background_panel->add_child(class_desc);
-		class_desc->set_area_as_parent_rect(8);
+		class_desc->set_area_as_parent_rect();
 		class_desc->connect("meta_clicked", this, "_class_desc_select");
 		class_desc->connect("gui_input", this, "_class_desc_input");
 	}
@@ -1881,10 +1872,6 @@ void EditorHelpBit::_bind_methods() {
 }
 
 void EditorHelpBit::_notification(int p_what) {
-
-	if (p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
-		add_style_override("panel", get_stylebox("ScriptPanel", "EditorStyles"));
-	}
 }
 
 void EditorHelpBit::set_text(const String &p_text) {
@@ -1897,8 +1884,7 @@ EditorHelpBit::EditorHelpBit() {
 
 	rich_text = memnew(RichTextLabel);
 	add_child(rich_text);
-	rich_text->set_area_as_parent_rect(8 * EDSCALE);
+	rich_text->set_area_as_parent_rect();
 	rich_text->connect("meta_clicked", this, "_meta_clicked");
 	set_custom_minimum_size(Size2(0, 70 * EDSCALE));
-	add_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_stylebox("ScriptPanel", "EditorStyles"));
 }

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -603,7 +603,6 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["text_editor/theme/color_theme"] = PropertyInfo(Variant::STRING, "text_editor/theme/color_theme", PROPERTY_HINT_ENUM, "Default");
 
 	set("text_editor/theme/line_spacing", 4);
-	set("text_editor/theme/adapted_code_editor_background_color", true);
 
 	_load_default_text_editor_theme();
 

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -198,6 +198,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	bool highlight_tabs = EDITOR_DEF("interface/theme/highlight_tabs", false);
 	int border_size = EDITOR_DEF("interface/theme/border_size", 1);
 
+	Color script_bg_color = EDITOR_DEF("text_editor/highlighting/background_color", Color(0, 0, 0, 0));
+
 	switch (preset) {
 		case 0: { // Default
 			highlight_color = Color::html("#699ce8");
@@ -279,8 +281,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	editor_register_fonts(theme);
 
 	// Editor background
-	Ref<StyleBoxFlat> style_panel = make_flat_stylebox(dark_color_2, 4, 4, 4, 4);
-	theme->set_stylebox("Background", "EditorStyles", style_panel);
+	theme->set_stylebox("Background", "EditorStyles", make_flat_stylebox(dark_color_2, 4, 4, 4, 4));
 
 	// Focus
 	Ref<StyleBoxFlat> focus_sbt = make_flat_stylebox(contrast_color_1, 4, 4, 4, 4);
@@ -423,12 +424,6 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_tree_bg->set_border_width_all(border_width);
 	style_tree_bg->set_border_color_all(dark_color_3);
 	theme->set_stylebox("bg", "Tree", style_tree_bg);
-
-	// Script background
-	Ref<StyleBoxFlat> style_script_bg = make_flat_stylebox(dark_color_1, 0, 0, 0, 0);
-	style_script_bg->set_border_width_all(border_width);
-	style_script_bg->set_border_color_all(dark_color_3);
-	theme->set_stylebox("ScriptPanel", "EditorStyles", style_script_bg);
 
 	// Tree
 	theme->set_icon("checked", "Tree", theme->get_icon("GuiChecked", "EditorIcons"));
@@ -614,11 +609,14 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("grabber_highlight", "VSlider", theme->get_icon("GuiSliderGrabberHl", "EditorIcons"));
 
 	//RichTextLabel
-	theme->set_color("font_color", "RichTextLabel", font_color);
+	Color rtl_combined_bg_color = dark_color_1.linear_interpolate(script_bg_color, script_bg_color.a);
+	Color rtl_font_color = (rtl_combined_bg_color.r + rtl_combined_bg_color.g + rtl_combined_bg_color.b > 0.5 * 3) ? Color(0, 0, 0) : Color(1, 1, 1);
+	theme->set_color("default_color", "RichTextLabel", rtl_font_color);
 	theme->set_stylebox("focus", "RichTextLabel", make_empty_stylebox());
+	theme->set_stylebox("normal", "RichTextLabel", make_flat_stylebox(script_bg_color, 6, 6, 6, 6));
 
 	// Panel
-	theme->set_stylebox("panel", "Panel", style_panel);
+	theme->set_stylebox("panel", "Panel", make_flat_stylebox(dark_color_1, 6, 4, 6, 4));
 
 	// Label
 	theme->set_color("font_color", "Label", font_color);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1149,8 +1149,6 @@ void ScriptEditor::_notification(int p_what) {
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 
-			tab_container->add_style_override("panel", editor->get_gui_base()->get_stylebox("ScriptPanel", "EditorStyles"));
-
 			help_search->set_icon(get_icon("HelpSearch", "EditorIcons"));
 			site_search->set_icon(get_icon("Instance", "EditorIcons"));
 			class_search->set_icon(get_icon("ClassList", "EditorIcons"));
@@ -2210,7 +2208,6 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	members_overview->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	tab_container = memnew(TabContainer);
-	tab_container->add_style_override("panel", p_editor->get_gui_base()->get_stylebox("ScriptPanel", "EditorStyles"));
 	tab_container->set_tabs_visible(false);
 	script_split->add_child(tab_container);
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -75,14 +75,9 @@ void ScriptTextEditor::_load_theme_settings() {
 
 	text_edit->clear_colors();
 
-	/* color from color_theme or from editor color */
-
-	Color background_color = EDITOR_DEF("text_editor/highlighting/background_color", Color(0, 0, 0, 0));
-	if (EDITOR_DEF("text_editor/theme/adapted_code_editor_background_color", false))
-		background_color = get_color("dark_color_1", "Editor");
-
 	/* keyword color */
-	text_edit->add_color_override("background_color", background_color);
+
+	text_edit->add_color_override("background_color", EDITOR_DEF("text_editor/highlighting/background_color", Color(0, 0, 0, 0)));
 	text_edit->add_color_override("completion_background_color", EDITOR_DEF("text_editor/highlighting/completion_background_color", Color(0, 0, 0, 0)));
 	text_edit->add_color_override("completion_selected_color", EDITOR_DEF("text_editor/highlighting/completion_selected_color", Color::html("434244")));
 	text_edit->add_color_override("completion_existing_color", EDITOR_DEF("text_editor/highlighting/completion_existing_color", Color::html("21dfdfdf")));

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -80,6 +80,10 @@ RichTextLabel::Item *RichTextLabel::_get_next_item(Item *p_item, bool p_free) {
 	return NULL;
 }
 
+Rect2 RichTextLabel::_get_text_rect() {
+	Ref<StyleBox> style = get_stylebox("normal");
+	return Rect2(style->get_offset(), get_size() - style->get_minimum_size());
+}
 void RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &y, int p_width, int p_line, ProcessMode p_mode, const Ref<Font> &p_base_font, const Color &p_base_color, const Point2i &p_click_pos, Item **r_click_item, int *r_click_char, bool *r_outside, int p_char_count) {
 
 	RID ci;
@@ -583,7 +587,7 @@ void RichTextLabel::_update_scroll() {
 
 	int total_height = 0;
 	if (main->lines.size())
-		total_height = main->lines[main->lines.size() - 1].height_accum_cache;
+		total_height = main->lines[main->lines.size() - 1].height_accum_cache + get_stylebox("normal")->get_minimum_size().height;
 
 	bool exceeds = total_height > get_size().height && scroll_active;
 
@@ -641,7 +645,11 @@ void RichTextLabel::_notification(int p_what) {
 			_update_scroll();
 
 			RID ci = get_canvas_item();
+
 			Size2 size = get_size();
+			Rect2 text_rect = _get_text_rect();
+
+			draw_style_box(get_stylebox("normal"), Rect2(Point2(), size));
 
 			if (has_focus()) {
 				VisualServer::get_singleton()->canvas_item_add_clip_ignore(ci, true);
@@ -657,10 +665,10 @@ void RichTextLabel::_notification(int p_what) {
 			int total_chars = 0;
 			while (from_line < main->lines.size()) {
 
-				if (main->lines[from_line].height_accum_cache >= ofs)
+				if (main->lines[from_line].height_accum_cache + _get_text_rect().get_position().y >= ofs)
 					break;
-				from_line++;
 				total_chars += main->lines[from_line].char_count;
+				from_line++;
 			}
 
 			if (from_line >= main->lines.size())
@@ -672,7 +680,7 @@ void RichTextLabel::_notification(int p_what) {
 
 			while (y < size.height && from_line < main->lines.size()) {
 
-				_process_line(main, Point2(), y, size.width - scroll_w, from_line, PROCESS_DRAW, base_font, base_color, Point2i(), NULL, NULL, NULL, total_chars);
+				_process_line(main, text_rect.get_position(), y, text_rect.get_size().width - scroll_w, from_line, PROCESS_DRAW, base_font, base_color, Point2i(), NULL, NULL, NULL, total_chars);
 				total_chars += main->lines[from_line].char_count;
 				from_line++;
 			}
@@ -686,7 +694,7 @@ void RichTextLabel::_find_click(ItemFrame *p_frame, const Point2i &p_click, Item
 		*r_click_item = NULL;
 
 	Size2 size = get_size();
-
+	Rect2 text_rect = _get_text_rect();
 	int ofs = vscroll->get_value();
 
 	//todo, change to binary search
@@ -706,9 +714,9 @@ void RichTextLabel::_find_click(ItemFrame *p_frame, const Point2i &p_click, Item
 	Ref<Font> base_font = get_font("normal_font");
 	Color base_color = get_color("default_color");
 
-	while (y < size.height && from_line < p_frame->lines.size()) {
+	while (y < text_rect.get_size().height && from_line < p_frame->lines.size()) {
 
-		_process_line(p_frame, Point2(), y, size.width - scroll_w, from_line, PROCESS_POINTER, base_font, base_color, p_click, r_click_item, r_click_char, r_outside);
+		_process_line(p_frame, text_rect.get_position(), y, text_rect.get_size().width - scroll_w, from_line, PROCESS_POINTER, base_font, base_color, p_click, r_click_item, r_click_char, r_outside);
 		if (r_click_item && *r_click_item)
 			return;
 		from_line++;
@@ -1015,13 +1023,14 @@ void RichTextLabel::_validate_line_caches(ItemFrame *p_frame) {
 
 	//validate invalid lines!s
 	Size2 size = get_size();
+	Rect2 text_rect = _get_text_rect();
 
 	Ref<Font> base_font = get_font("normal_font");
 
 	for (int i = p_frame->first_invalid_line; i < p_frame->lines.size(); i++) {
 
 		int y = 0;
-		_process_line(p_frame, Point2(), y, size.width - scroll_w, i, PROCESS_CACHE, base_font, Color());
+		_process_line(p_frame, text_rect.get_position(), y, text_rect.get_size().width - scroll_w, i, PROCESS_CACHE, base_font, Color());
 		p_frame->lines[i].height_cache = y;
 		p_frame->lines[i].height_accum_cache = y;
 
@@ -1031,7 +1040,7 @@ void RichTextLabel::_validate_line_caches(ItemFrame *p_frame) {
 
 	int total_height = 0;
 	if (p_frame->lines.size())
-		total_height = p_frame->lines[p_frame->lines.size() - 1].height_accum_cache;
+		total_height = p_frame->lines[p_frame->lines.size() - 1].height_accum_cache + get_stylebox("normal")->get_minimum_size().height;
 
 	main->first_invalid_line = p_frame->lines.size();
 

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -276,6 +276,8 @@ private:
 	void _gui_input(Ref<InputEvent> p_event);
 	Item *_get_next_item(Item *p_item, bool p_free = false);
 
+	Rect2 _get_text_rect();
+
 	bool use_bbcode;
 	String bbcode;
 

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -794,6 +794,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	// RichTextLabel
 
 	theme->set_stylebox("focus", "RichTextLabel", focus);
+	theme->set_stylebox("normal", "RichTextLabel", make_stylebox(tree_bg_png, 3, 3, 3, 3));
 
 	theme->set_font("normal_font", "RichTextLabel", default_font);
 	theme->set_font("bold_font", "RichTextLabel", default_font);


### PR DESCRIPTION
I reverted the option to override the bg.
Instead each script or docs panel has the same background underneath the RTL (which has a style box now). So setting the script editor bg color to transparent has the exact same effect than the override option.
(except it works with all of them not just the script panel)

Also cleaned up some code which was possible since the RTL now has it's own stylebox.

I'm pretty sure that the RTL works flawlessly with the sb_settings like margin...
But I'm not sure if the implementation is as simple as it could be.
so whoever could review 0f62db2 would be great!
