### PR TITLE
Fix. resizeable -> resizable.

### DIFF
--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -523,7 +523,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 		if (Object::cast_to<VisualScriptExpression>(*node)) {
 			Ref<VisualScriptComment> vsc = node;
 			gnode->set_comment(true);
-			gnode->set_resizeable(true);
+			gnode->set_resizable(true);
 			gnode->set_custom_minimum_size(vsc->get_size() * EDSCALE);
 			gnode->connect("resize_request", this, "_comment_node_resized", varray(E->get()));
 		}

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -270,7 +270,7 @@ void GraphNode::_notification(int p_what) {
 			}
 		}
 
-		if (resizeable) {
+		if (resizable) {
 			draw_texture(resizer, get_size() - resizer->get_size());
 		}
 	}
@@ -594,7 +594,7 @@ void GraphNode::_gui_input(const Ref<InputEvent> &p_ev) {
 
 			Ref<Texture> resizer = get_icon("resizer");
 
-			if (resizeable && mpos.x > get_size().x - resizer->get_width() && mpos.y > get_size().y - resizer->get_height()) {
+			if (resizable && mpos.x > get_size().x - resizer->get_width() && mpos.y > get_size().y - resizer->get_height()) {
 
 				resizing = true;
 				resizing_from = mpos;
@@ -645,15 +645,15 @@ bool GraphNode::is_comment() const {
 	return comment;
 }
 
-void GraphNode::set_resizeable(bool p_enable) {
+void GraphNode::set_resizable(bool p_enable) {
 
-	resizeable = p_enable;
+	resizable = p_enable;
 	update();
 }
 
-bool GraphNode::is_resizeable() const {
+bool GraphNode::is_resizable() const {
 
-	return resizeable;
+	return resizable;
 }
 
 void GraphNode::_bind_methods() {
@@ -678,8 +678,8 @@ void GraphNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_comment", "comment"), &GraphNode::set_comment);
 	ClassDB::bind_method(D_METHOD("is_comment"), &GraphNode::is_comment);
 
-	ClassDB::bind_method(D_METHOD("set_resizeable", "resizeable"), &GraphNode::set_resizeable);
-	ClassDB::bind_method(D_METHOD("is_resizeable"), &GraphNode::is_resizeable);
+	ClassDB::bind_method(D_METHOD("set_resizable", "resizable"), &GraphNode::set_resizable);
+	ClassDB::bind_method(D_METHOD("is_resizable"), &GraphNode::is_resizable);
 
 	ClassDB::bind_method(D_METHOD("set_selected", "selected"), &GraphNode::set_selected);
 	ClassDB::bind_method(D_METHOD("is_selected"), &GraphNode::is_selected);
@@ -702,7 +702,7 @@ void GraphNode::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "title"), "set_title", "get_title");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_close"), "set_show_close_button", "is_close_button_visible");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "resizeable"), "set_resizeable", "is_resizeable");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "resizable"), "set_resizable", "is_resizable");
 
 	ADD_SIGNAL(MethodInfo("offset_changed"));
 	ADD_SIGNAL(MethodInfo("dragged", PropertyInfo(Variant::VECTOR2, "from"), PropertyInfo(Variant::VECTOR2, "to")));
@@ -722,7 +722,7 @@ GraphNode::GraphNode() {
 	connpos_dirty = true;
 	set_mouse_filter(MOUSE_FILTER_STOP);
 	comment = false;
-	resizeable = false;
+	resizable = false;
 	resizing = false;
 	selected = false;
 }

--- a/scene/gui/graph_node.h
+++ b/scene/gui/graph_node.h
@@ -68,7 +68,7 @@ private:
 	bool show_close;
 	Vector2 offset;
 	bool comment;
-	bool resizeable;
+	bool resizable;
 
 	bool resizing;
 	Vector2 resizing_from;
@@ -151,8 +151,8 @@ public:
 	void set_comment(bool p_enable);
 	bool is_comment() const;
 
-	void set_resizeable(bool p_enable);
-	bool is_resizeable() const;
+	void set_resizable(bool p_enable);
+	bool is_resizable() const;
 
 	virtual Size2 get_minimum_size() const;
 


### PR DESCRIPTION
(not actually a typo, but the rest of the API uses resizable)