### PR TITLE
Fixes setting visibility on GridMap, issue #907

### DIFF
--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -655,6 +655,24 @@ void GridMap::_notification(int p_what) {
 			//_update_area_instances();
 
 		} break;
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			_update_visibility();
+		} break;
+	}
+}
+
+void GridMap::_update_visibility() {
+	if (!is_inside_tree())
+		return;
+
+	_change_notify("visible");
+
+	for (Map<OctantKey, Octant *>::Element *e = octant_map.front(); e; e = e->next()) {
+		Octant *octant = e->value();
+		for (int i = 0; i < octant->multimesh_instances.size(); i++) {
+			Octant::MultimeshInstance &mi = octant->multimesh_instances[i];
+			VS::get_singleton()->instance_set_visible(mi.instance, is_visible());
+		}
 	}
 }
 
@@ -720,6 +738,7 @@ void GridMap::_update_octants_callback() {
 		to_delete.pop_back();
 	}
 
+	_update_visibility();
 	awaiting_update = false;
 }
 

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -190,6 +190,7 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
 	void _notification(int p_what);
+	void _update_visibility();
 	static void _bind_methods();
 
 public:


### PR DESCRIPTION
Basically, `GridMap` wasn't reacting to the `NOTIFICATION_VISIBILITY_CHANGED` event. This reacts to such event and walks over the set of `Octants` and all of their `MultiMeshInstances` to set their visibility on the `VisualServer`.