### PR TITLE
fixed log colors

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -59,7 +59,6 @@ void EditorLog::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
-		log->add_color_override("default_color", get_color("font_color", "Tree"));
 		//button->set_icon(get_icon("Console","EditorIcons"));
 	}
 	if (p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
@@ -91,7 +90,7 @@ void EditorLog::add_message(const String &p_msg, bool p_error) {
 
 	log->add_newline();
 	if (p_error) {
-		log->push_color(get_color("fg_error", "Editor"));
+		log->push_color(get_color("error_color", "Editor"));
 		Ref<Texture> icon = get_icon("Error", "EditorIcons");
 		log->add_image(icon);
 		//button->set_icon(icon);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -466,8 +466,6 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("prop_category", "Editor", prop_category_color);
 	theme->set_color("prop_section", "Editor", prop_section_color);
 	theme->set_color("prop_subsection", "Editor", prop_subsection_color);
-	theme->set_color("fg_selected", "Editor", HIGHLIGHT_COLOR_BG);
-	theme->set_color("fg_error", "Editor", error_color);
 	theme->set_color("drop_position_color", "Tree", highlight_color);
 
 	// ItemList


### PR DESCRIPTION
**Issue**
<img width="629" alt="screen shot 2017-09-05 at 01 04 45" src="https://user-images.githubusercontent.com/16718859/30039857-039d2dc6-91d7-11e7-9e44-94957ed4656c.png">

**after pr**
<img width="602" alt="screen shot 2017-09-05 at 01 09 36" src="https://user-images.githubusercontent.com/16718859/30039856-037a6a5c-91d7-11e7-924b-90800ae6e366.png">

I also removed "fg_error" and "fg_selected" since it is not used anymore / wanst used.

there is now `"error_color", "Editor"`