### PR TITLE
Fix unshaded materials render

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2300,15 +2300,12 @@ void RasterizerSceneGLES3::_add_geometry_with_material(RasterizerStorageGLES3::G
 
 	//e->light_type=0xFF; // no lights!
 
-	if (p_depth_pass) {
-		if (p_material->shader->spatial.unshaded || state.debug_draw == VS::VIEWPORT_DEBUG_DRAW_UNSHADED) {
+	if (p_depth_pass || p_material->shader->spatial.unshaded || state.debug_draw == VS::VIEWPORT_DEBUG_DRAW_UNSHADED) {
+		e->sort_key |= SORT_KEY_UNSHADED_FLAG;
+	}
 
-			e->sort_key |= SORT_KEY_UNSHADED_FLAG;
-		}
-
-		if (p_material->shader->spatial.depth_draw_mode == RasterizerStorageGLES3::Shader::Spatial::DEPTH_DRAW_ALPHA_PREPASS) {
-			e->sort_key |= RenderList::SORT_KEY_OPAQUE_PRE_PASS;
-		}
+	if (p_depth_pass && p_material->shader->spatial.depth_draw_mode == RasterizerStorageGLES3::Shader::Spatial::DEPTH_DRAW_ALPHA_PREPASS) {
+		e->sort_key |= RenderList::SORT_KEY_OPAQUE_PRE_PASS;
 	}
 
 	if (!p_depth_pass && (p_material->shader->spatial.uses_vertex_lighting || storage->config.force_vertex_shading)) {


### PR DESCRIPTION
After commit e611ff5f0110210221a6f90250bdd65f5fb3ff2d unshaded materials are rendered pitch-black. If I'm not mistaken, that's because now `SORT_KEY_UNSHADED_FLAG` is not being set for them unless `p_depth_pass` is true.
I changed back the condition for `SORT_KEY_UNSHADED_FLAG` as it were before this commit:
https://github.com/godotengine/godot/blob/44adf75cd53c22f146fc2e2dbba7d7efab3c0a0d/drivers/gles3/rasterizer_scene_gles3.cpp#L2305-L2308
*Bugsquad edit:* Fixes #10987