### PR TITLE
Provide NativeScript properties in definition order

### DIFF
--- a/core/list.h
+++ b/core/list.h
@@ -291,6 +291,54 @@ public:
 			erase(_data->first);
 	}
 
+	Element *insert_after(Element *p_element, const T &p_value) {
+		CRASH_COND(p_element && (!_data || p_element->data != _data));
+
+		if (!p_element) {
+			return push_back(p_value);
+		}
+
+		Element *n = memnew_allocator(Element, A);
+		n->value = (T &)p_value;
+		n->prev_ptr = p_element;
+		n->next_ptr = p_element->next_ptr;
+		n->data = _data;
+
+		if (!p_element->next_ptr) {
+			_data->last = n;
+		}
+
+		p_element->next_ptr = n;
+
+		_data->size_cache++;
+
+		return n;
+	}
+
+	Element *insert_before(Element *p_element, const T &p_value) {
+		CRASH_COND(p_element && (!_data || p_element->data != _data));
+
+		if (!p_element) {
+			return push_back(p_value);
+		}
+
+		Element *n = memnew_allocator(Element, A);
+		n->value = (T &)p_value;
+		n->prev_ptr = p_element->prev_ptr;
+		n->next_ptr = p_element;
+		n->data = _data;
+
+		if (!p_element->prev_ptr) {
+			_data->first = n;
+		}
+
+		p_element->prev_ptr = n;
+
+		_data->size_cache++;
+
+		return n;
+	}
+
 	/**
 	 * find an element in the list,
 	 */

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -32,6 +32,7 @@
 
 #include "io/resource_loader.h"
 #include "io/resource_saver.h"
+#include "ordered_hash_map.h"
 #include "os/thread_safe.h"
 #include "resource.h"
 #include "scene/main/node.h"
@@ -65,7 +66,7 @@ struct NativeScriptDesc {
 	};
 
 	Map<StringName, Method> methods;
-	Map<StringName, Property> properties;
+	OrderedHashMap<StringName, Property> properties;
 	Map<StringName, Signal> signals_; // QtCreator doesn't like the name signals
 	StringName base;
 	StringName base_native_type;


### PR DESCRIPTION
Before this change properties of native scripts were shown in arbitrary order in the editor, and the order could even change if you focus/unfocus the editor (library gets reloaded) - very annoying.

Now the order is strict and determined by the order the properties are registered in. Base class properties go first.