### PR TITLE
Ability to configure 3d camera interpolation speed

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -685,6 +685,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	set("editors/3d/freelook_modifier_speed_factor", 5.0);
 
+	set("editors/3d/camera_inertia", 0.5);
+	hints["editors/3d/camera_inertia"] = PropertyInfo(Variant::REAL, "editors/3d/camera_inertia", PROPERTY_HINT_RANGE, "0.0, 1, 0.01");
+
 	set("editors/2d/bone_width", 5);
 	set("editors/2d/bone_color1", Color(1.0, 1.0, 1.0, 0.9));
 	set("editors/2d/bone_color2", Color(0.75, 0.75, 0.75, 0.9));

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -84,8 +84,9 @@ void SpatialEditorViewport::_update_camera(float p_interp_delta) {
 
 	if (p_interp_delta && !disable_interp) {
 		//interpolate
-		float interp_speed = 14; //maybe should be made configuration
-		transform = old_transform.interpolate_with(new_transform, MIN(1.0, p_interp_delta * interp_speed));
+		float user_inertia = Math::lerp(0.0, 0.1, EditorSettings::get_singleton()->get("editors/3d/camera_inertia"));
+		float lerp = 1.0 / (1.0 + user_inertia * Engine::get_singleton()->get_frames_per_second());
+		transform = old_transform.interpolate_with(new_transform, MIN(1.0, lerp));
 	} else {
 		transform = new_transform;
 	}


### PR DESCRIPTION
Interpolation speed can be increased to have less [smooth]/[dizzy(?)]" experience when rotating editor camera around spatial.

**edit/update:**
I modified this pr to introduce inertia param instead (using Zylann equation). 
From user side: User can enter value from between 0-1 where 0 means 'no interpolation' and 1.0 means "more interpolation than previously". By default it's set to 0.5 which feels for me similar to how it works currently.

Under the hood those values are remapped to be between 0.0 and 0.2 since bigger number in equation are giving so big 'seasick' experience that I don't believe anyone would like to use them. 

**update2:**
I calibrated values better: https://youtu.be/e85LIZTGEns