### PR TITLE
Added a warning message when a VehicleWheel is not a child of a VehicleBody.

### DIFF
--- a/scene/3d/vehicle_body.cpp
+++ b/scene/3d/vehicle_body.cpp
@@ -102,6 +102,14 @@ void VehicleWheel::_notification(int p_what) {
 	}
 }
 
+String VehicleWheel::get_configuration_warning() const {
+	if (!Object::cast_to<VehicleBody>(get_parent())) {
+		return TTR("VehicleWheel serves to provide a wheel system to a VehicleBody. Please use it as a child of a VehicleBody.");
+	}
+
+	return String();
+}
+
 void VehicleWheel::_update(PhysicsDirectBodyState *s) {
 
 	if (m_raycastInfo.m_isInContact)

--- a/scene/3d/vehicle_body.h
+++ b/scene/3d/vehicle_body.h
@@ -131,6 +131,8 @@ public:
 	void set_roll_influence(float p_value);
 	float get_roll_influence() const;
 
+	String get_configuration_warning() const;
+
 	VehicleWheel();
 };
 


### PR DESCRIPTION
Added a warning message to be consistent with other physics nodes that need a parent.