### PR TITLE
Fix duplication of node with script

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 #include "node.h"
 
+#include "core/core_string_names.h"
 #include "instance_placeholder.h"
 #include "io/resource_loader.h"
 #include "message_queue.h"
@@ -2104,12 +2105,22 @@ Node *Node::_duplicate(int p_flags) const {
 
 	get_property_list(&plist);
 
+	StringName script_property_name = CoreStringNames::get_singleton()->_script;
+
+	if (p_flags & DUPLICATE_SCRIPTS) {
+		bool is_valid = false;
+		Variant script = get(script_property_name, &is_valid);
+		if (is_valid) {
+			node->set(script_property_name, script);
+		}
+	}
+
 	for (List<PropertyInfo>::Element *E = plist.front(); E; E = E->next()) {
 
 		if (!(E->get().usage & PROPERTY_USAGE_STORAGE))
 			continue;
 		String name = E->get().name;
-		if (!(p_flags & DUPLICATE_SCRIPTS) && name == "script/script")
+		if (name == script_property_name)
 			continue;
 
 		Variant value = get(name);


### PR DESCRIPTION
When duplicating node with script, properties of script weren't copied sometimes.
It happened because properties were copied in arbitrary order, and properties of the script were setted before the "script" property itself, i.e. while script is sill NULL.

Also, DUPLICATE_SCRIPTS flag wasn't working - script was always copied because `_duplicate` looked for "script/script" property while it should be just "script".

Now "script" property is being set before all others, and "script/script" changed to `CoreStringNames::get_singleton()->_script`.