### PR TITLE
Fit script editor grid with others

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -295,6 +295,10 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("panel", "PanelContainer", style_menu);
 	theme->set_stylebox("MenuPanel", "EditorStyles", style_menu);
 
+	// Script Editor
+	theme->set_stylebox("ScriptEditorPanel", "EditorStyles", make_empty_stylebox(4, 0, 4, 4));
+	theme->set_stylebox("ScriptEditor", "EditorStyles", make_empty_stylebox(0, 0, 0, 0));
+
 	// Play button group
 	theme->set_stylebox("PlayButtonPanel", "EditorStyles", make_empty_stylebox(8, 4, 8, 4)); //make_stylebox(theme->get_icon("GuiPlayButtonGroup", "EditorIcons"), 16, 16, 16, 16, 8, 4, 8, 4));
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2416,6 +2416,9 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	use_space_indentation = false;
 
 	ScriptServer::edit_request_func = _open_script_request;
+
+	add_style_override("panel", editor->get_gui_base()->get_stylebox("ScriptEditorPanel", "EditorStyles"));
+	tab_container->add_style_override("panel", editor->get_gui_base()->get_stylebox("ScriptEditor", "EditorStyles"));
 }
 
 ScriptEditor::~ScriptEditor() {


### PR DESCRIPTION
Fixes #10876 and #11037

![image](https://user-images.githubusercontent.com/8281454/30135418-9c41d116-9395-11e7-8f83-6f4ca6e30da3.png)

fit text editor also. here is an old screenshot.
![image](https://user-images.githubusercontent.com/8281454/30135499-e79ca3c0-9395-11e7-85c8-303b855686d0.png)
