### PR TITLE
Change Color.to_32() to Color.to_rgba32() and lowercase other functions

### DIFF
--- a/core/color.cpp
+++ b/core/color.cpp
@@ -34,7 +34,7 @@
 #include "math_funcs.h"
 #include "print_string.h"
 
-uint32_t Color::to_ARGB32() const {
+uint32_t Color::to_argb32() const {
 
 	uint32_t c = (uint8_t)(a * 255);
 	c <<= 8;
@@ -47,7 +47,7 @@ uint32_t Color::to_ARGB32() const {
 	return c;
 }
 
-uint32_t Color::to_ABGR32() const {
+uint32_t Color::to_abgr32() const {
 	uint32_t c = (uint8_t)(a * 255);
 	c <<= 8;
 	c |= (uint8_t)(b * 255);
@@ -59,15 +59,15 @@ uint32_t Color::to_ABGR32() const {
 	return c;
 }
 
-uint32_t Color::to_32() const {
+uint32_t Color::to_rgba32() const {
 
-	uint32_t c = (uint8_t)(a * 255);
-	c <<= 8;
-	c |= (uint8_t)(r * 255);
+	uint32_t c = (uint8_t)(r * 255);
 	c <<= 8;
 	c |= (uint8_t)(g * 255);
 	c <<= 8;
 	c |= (uint8_t)(b * 255);
+	c <<= 8;
+	c |= (uint8_t)(a * 255);
 
 	return c;
 }

--- a/core/color.h
+++ b/core/color.h
@@ -51,9 +51,9 @@ struct Color {
 	bool operator==(const Color &p_color) const { return (r == p_color.r && g == p_color.g && b == p_color.b && a == p_color.a); }
 	bool operator!=(const Color &p_color) const { return (r != p_color.r || g != p_color.g || b != p_color.b || a != p_color.a); }
 
-	uint32_t to_32() const;
-	uint32_t to_ARGB32() const;
-	uint32_t to_ABGR32() const;
+	uint32_t to_rgba32() const;
+	uint32_t to_argb32() const;
+	uint32_t to_abgr32() const;
 	float gray() const;
 	float get_h() const;
 	float get_s() const;

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -428,8 +428,8 @@ struct _VariantCall {
 	VCALL_LOCALMEM2R(Quat, slerpni);
 	VCALL_LOCALMEM4R(Quat, cubic_slerp);
 
-	VCALL_LOCALMEM0R(Color, to_32);
-	VCALL_LOCALMEM0R(Color, to_ARGB32);
+	VCALL_LOCALMEM0R(Color, to_rgba32);
+	VCALL_LOCALMEM0R(Color, to_argb32);
 	VCALL_LOCALMEM0R(Color, gray);
 	VCALL_LOCALMEM0R(Color, inverted);
 	VCALL_LOCALMEM0R(Color, contrasted);
@@ -1523,8 +1523,8 @@ void register_variant_methods() {
 	ADDFUNC2(QUAT, QUAT, Quat, slerpni, QUAT, "b", REAL, "t", varray());
 	ADDFUNC4(QUAT, QUAT, Quat, cubic_slerp, QUAT, "b", QUAT, "pre_a", QUAT, "post_b", REAL, "t", varray());
 
-	ADDFUNC0(COLOR, INT, Color, to_32, varray());
-	ADDFUNC0(COLOR, INT, Color, to_ARGB32, varray());
+	ADDFUNC0(COLOR, INT, Color, to_rgba32, varray());
+	ADDFUNC0(COLOR, INT, Color, to_argb32, varray());
 	ADDFUNC0(COLOR, REAL, Color, gray, varray());
 	ADDFUNC0(COLOR, COLOR, Color, inverted, varray());
 	ADDFUNC0(COLOR, COLOR, Color, contrasted, varray());

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -12292,14 +12292,14 @@
 				Return the linear interpolation with another color.
 			</description>
 		</method>
-		<method name="to_32">
+		<method name="to_rgba32">
 			<return type="int">
 			</return>
 			<description>
 				Convert the color to a 32 its integer (each byte represents a RGBA).
 			</description>
 		</method>
-		<method name="to_ARGB32">
+		<method name="to_argb32">
 			<return type="int">
 			</return>
 			<description>

--- a/modules/gdnative/gdnative/color.cpp
+++ b/modules/gdnative/gdnative/color.cpp
@@ -112,14 +112,14 @@ godot_string GDAPI godot_color_as_string(const godot_color *p_self) {
 	return ret;
 }
 
-godot_int GDAPI godot_color_to_32(const godot_color *p_self) {
+godot_int GDAPI godot_color_to_rgba32(const godot_color *p_self) {
 	const Color *self = (const Color *)p_self;
-	return self->to_32();
+	return self->to_rgba32();
 }
 
-godot_int GDAPI godot_color_to_ARGB32(const godot_color *p_self) {
+godot_int GDAPI godot_color_to_argb32(const godot_color *p_self) {
 	const Color *self = (const Color *)p_self;
-	return self->to_ARGB32();
+	return self->to_argb32();
 }
 
 godot_real GDAPI godot_color_gray(const godot_color *p_self) {

--- a/modules/gdnative/include/gdnative/color.h
+++ b/modules/gdnative/include/gdnative/color.h
@@ -69,9 +69,9 @@ godot_real godot_color_get_v(const godot_color *p_self);
 
 godot_string GDAPI godot_color_as_string(const godot_color *p_self);
 
-godot_int GDAPI godot_color_to_32(const godot_color *p_self);
+godot_int GDAPI godot_color_to_rgba32(const godot_color *p_self);
 
-godot_int GDAPI godot_color_to_ARGB32(const godot_color *p_self);
+godot_int GDAPI godot_color_to_argb32(const godot_color *p_self);
 
 godot_real GDAPI godot_color_gray(const godot_color *p_self);
 

--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -75,8 +75,8 @@ void ImageLoaderSVG::_convert_colors(NSVGimage *p_svg_image, const Dictionary p_
 		if (r_c.get_type() == Variant::COLOR && n_c.get_type() == Variant::COLOR) {
 			Color replace_color = r_c;
 			Color new_color = n_c;
-			replace_colors_i.push_back(replace_color.to_ABGR32());
-			new_colors_i.push_back(new_color.to_ABGR32());
+			replace_colors_i.push_back(replace_color.to_abgr32());
+			new_colors_i.push_back(new_color.to_abgr32());
 		}
 	}
 


### PR DESCRIPTION
Both functions Color.to_32() and Color.ARGB32() results exactly same data, even the code internally are nearly identical.

Since there's already a function for ARGB format (Color.to_ARGB32()), Color.to_32() is formatted as RGBA.