### PR TITLE
Added a background texture to ColorPicker

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -261,12 +261,15 @@ void ColorPicker::_update_text_value() {
 			t += ")";
 		c_text->set_text(t);
 	} else {
-		c_text->set_text(color.to_html(edit_alpha && color.a < 1));
 	}
 }
 
 void ColorPicker::_sample_draw() {
-	sample->draw_rect(Rect2(Point2(), Size2(uv_edit->get_size().width, sample->get_size().height * 0.95)), color);
+    Rect2 r = Rect2(Point2(), Size2(uv_edit->get_size().width, sample->get_size().height * 0.95));
+    if(color.a < 1) {
+        sample->draw_texture_rect(get_icon("Transparent", "EditorIcons"), r, true);
+    }
+    sample->draw_rect(r, color);
 }
 
 void ColorPicker::_hsv_draw(int p_which, Control *c) {

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -261,6 +261,7 @@ void ColorPicker::_update_text_value() {
 			t += ")";
 		c_text->set_text(t);
 	} else {
+        c_text->set_text(color.to_html(edit_alpha && color.a < 1));
 	}
 }
 

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -175,31 +175,18 @@ void ColorPicker::_update_color() {
 	updating = false;
 }
 
-void ColorPicker::_update_presets() {
+void ColorPicker::_preset_draw() {
 	Size2 size = bt_add_preset->get_size();
-	preset->set_custom_minimum_size(Size2(size.width * presets.size(), size.height));
+    Rect2 full_preset = Rect2(Point2(), Size2(size.width * presets.size(), size.height));
+    preset->set_custom_minimum_size(full_preset.size);
 
-	PoolVector<uint8_t> img;
-	img.resize(size.x * presets.size() * size.y * 3);
+    preset->draw_texture_rect(get_icon("Transparent", "EditorIcons"), full_preset, true);
 
-	{
-		PoolVector<uint8_t>::Write w = img.write();
-		for (int y = 0; y < size.y; y++) {
-			for (int x = 0; x < size.x * presets.size(); x++) {
-				int ofs = (y * (size.x * presets.size()) + x) * 3;
-				w[ofs + 0] = uint8_t(CLAMP(presets[(int)x / size.x].r * 255.0, 0, 255));
-				w[ofs + 1] = uint8_t(CLAMP(presets[(int)x / size.x].g * 255.0, 0, 255));
-				w[ofs + 2] = uint8_t(CLAMP(presets[(int)x / size.x].b * 255.0, 0, 255));
-			}
-		}
-	}
-
-	Ref<Image> i = memnew(Image(size.x * presets.size(), size.y, false, Image::FORMAT_RGB8, img));
-
-	Ref<ImageTexture> t;
-	t.instance();
-	t->create_from_image(i);
-	preset->set_texture(t);
+    Rect2 preset_rect = Rect2(Point2(), size);
+    for(int i = 0; i < presets.size(); i++) {
+        preset_rect.position.x = size.width * i;
+        preset->draw_rect(preset_rect, presets[i]);
+    }
 }
 
 void ColorPicker::_text_type_toggled() {
@@ -227,7 +214,7 @@ void ColorPicker::add_preset(const Color &p_color) {
 	} else {
 		presets.push_back(p_color);
 	}
-	_update_presets();
+    preset->update();
 	if (presets.size() == 10)
 		bt_add_preset->hide();
 }
@@ -403,7 +390,7 @@ void ColorPicker::_preset_input(const Ref<InputEvent> &p_event) {
 		} else if (bev->is_pressed() && bev->get_button_index() == BUTTON_RIGHT) {
 			int index = bev->get_position().x / (preset->get_size().x / presets.size());
 			presets.erase(presets[index]);
-			_update_presets();
+            preset->update();
 			bt_add_preset->show();
 		}
 		_update_color();
@@ -488,6 +475,7 @@ void ColorPicker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_add_preset_pressed"), &ColorPicker::_add_preset_pressed);
 	ClassDB::bind_method(D_METHOD("_screen_pick_pressed"), &ColorPicker::_screen_pick_pressed);
 	ClassDB::bind_method(D_METHOD("_sample_draw"), &ColorPicker::_sample_draw);
+    ClassDB::bind_method(D_METHOD("_preset_draw"), &ColorPicker::_preset_draw);
 	ClassDB::bind_method(D_METHOD("_hsv_draw"), &ColorPicker::_hsv_draw);
 	ClassDB::bind_method(D_METHOD("_uv_input"), &ColorPicker::_uv_input);
 	ClassDB::bind_method(D_METHOD("_w_input"), &ColorPicker::_w_input);
@@ -612,6 +600,7 @@ ColorPicker::ColorPicker()
 	bbc->add_child(preset);
 	//preset->set_ignore_mouse(false);
 	preset->connect("gui_input", this, "_preset_input");
+    preset->connect("draw", this, "_preset_draw");
 
 	bt_add_preset = memnew(Button);
 	bt_add_preset->set_icon(get_icon("add_preset"));

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -79,6 +79,7 @@ private:
 	void _update_text_value();
 	void _text_type_toggled();
 	void _sample_draw();
+    void _preset_draw();
 	void _hsv_draw(int p_which, Control *c);
 
 	void _uv_input(const Ref<InputEvent> &p_event);


### PR DESCRIPTION
So we can see how alpha affects the color.

![https://i.imgur.com/ZCWqFdU.gif](https://i.imgur.com/ZCWqFdU.gif)

For this to work the `icon_transparent.svg` needs to be added which I've already done in this other PR https://github.com/djrm/godot-design/pull/6