### PR TITLE
Fix warnings comparing enums of different types

### DIFF
--- a/core/type_info.h
+++ b/core/type_info.h
@@ -39,28 +39,27 @@ struct TypeInherits {
 
 template <class T, typename = void>
 struct GetTypeInfo {
-	enum { VARIANT_TYPE = Variant::NIL };
-
+	static const Variant::Type VARIANT_TYPE = Variant::NIL;
 	static inline PropertyInfo get_class_info() {
 		ERR_PRINT("GetTypeInfo fallback. Bug!");
 		return PropertyInfo(); // Not "Nil", this is an error
 	}
 };
 
-#define MAKE_TYPE_INFO(m_type, m_var_type)                              \
-	template <>                                                         \
-	struct GetTypeInfo<m_type> {                                        \
-		enum { VARIANT_TYPE = m_var_type };                             \
-		static inline PropertyInfo get_class_info() {                   \
-			return PropertyInfo((Variant::Type)VARIANT_TYPE, String()); \
-		}                                                               \
-	};                                                                  \
-	template <>                                                         \
-	struct GetTypeInfo<const m_type &> {                                \
-		enum { VARIANT_TYPE = m_var_type };                             \
-		static inline PropertyInfo get_class_info() {                   \
-			return PropertyInfo((Variant::Type)VARIANT_TYPE, String()); \
-		}                                                               \
+#define MAKE_TYPE_INFO(m_type, m_var_type)                    \
+	template <>                                               \
+	struct GetTypeInfo<m_type> {                              \
+		static const Variant::Type VARIANT_TYPE = m_var_type; \
+		static inline PropertyInfo get_class_info() {         \
+			return PropertyInfo(VARIANT_TYPE, String());      \
+		}                                                     \
+	};                                                        \
+	template <>                                               \
+	struct GetTypeInfo<const m_type &> {                      \
+		static const Variant::Type VARIANT_TYPE = m_var_type; \
+		static inline PropertyInfo get_class_info() {         \
+			return PropertyInfo(VARIANT_TYPE, String());      \
+		}                                                     \
 	};
 
 MAKE_TYPE_INFO(bool, Variant::BOOL)
@@ -108,14 +107,14 @@ MAKE_TYPE_INFO(BSP_Tree, Variant::DICTIONARY)
 //for RefPtr
 template <>
 struct GetTypeInfo<RefPtr> {
-	enum { VARIANT_TYPE = Variant::OBJECT };
+	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::OBJECT, String(), PROPERTY_HINT_RESOURCE_TYPE, "Reference");
 	}
 };
 template <>
 struct GetTypeInfo<const RefPtr &> {
-	enum { VARIANT_TYPE = Variant::OBJECT };
+	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::OBJECT, String(), PROPERTY_HINT_RESOURCE_TYPE, "Reference");
 	}
@@ -124,7 +123,7 @@ struct GetTypeInfo<const RefPtr &> {
 //for variant
 template <>
 struct GetTypeInfo<Variant> {
-	enum { VARIANT_TYPE = Variant::NIL };
+	static const Variant::Type VARIANT_TYPE = Variant::NIL;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::NIL, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT);
 	}
@@ -132,26 +131,26 @@ struct GetTypeInfo<Variant> {
 
 template <>
 struct GetTypeInfo<const Variant &> {
-	enum { VARIANT_TYPE = Variant::NIL };
+	static const Variant::Type VARIANT_TYPE = Variant::NIL;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(Variant::NIL, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT);
 	}
 };
 
-#define MAKE_TEMPLATE_TYPE_INFO(m_template, m_type, m_var_type)         \
-	template <>                                                         \
-	struct GetTypeInfo<m_template<m_type> > {                           \
-		enum { VARIANT_TYPE = m_var_type };                             \
-		static inline PropertyInfo get_class_info() {                   \
-			return PropertyInfo((Variant::Type)VARIANT_TYPE, String()); \
-		}                                                               \
-	};                                                                  \
-	template <>                                                         \
-	struct GetTypeInfo<const m_template<m_type> &> {                    \
-		enum { VARIANT_TYPE = m_var_type };                             \
-		static inline PropertyInfo get_class_info() {                   \
-			return PropertyInfo((Variant::Type)VARIANT_TYPE, String()); \
-		}                                                               \
+#define MAKE_TEMPLATE_TYPE_INFO(m_template, m_type, m_var_type) \
+	template <>                                                 \
+	struct GetTypeInfo<m_template<m_type> > {                   \
+		static const Variant::Type VARIANT_TYPE = m_var_type;   \
+		static inline PropertyInfo get_class_info() {           \
+			return PropertyInfo(VARIANT_TYPE, String());        \
+		}                                                       \
+	};                                                          \
+	template <>                                                 \
+	struct GetTypeInfo<const m_template<m_type> &> {            \
+		static const Variant::Type VARIANT_TYPE = m_var_type;   \
+		static inline PropertyInfo get_class_info() {           \
+			return PropertyInfo(VARIANT_TYPE, String());        \
+		}                                                       \
 	};
 
 MAKE_TEMPLATE_TYPE_INFO(Vector, uint8_t, Variant::POOL_BYTE_ARRAY)
@@ -171,8 +170,7 @@ MAKE_TEMPLATE_TYPE_INFO(PoolVector, Face3, Variant::POOL_VECTOR3_ARRAY)
 
 template <typename T>
 struct GetTypeInfo<T *, typename EnableIf<TypeInherits<Object, T>::value>::type> {
-	enum { VARIANT_TYPE = Variant::OBJECT };
-
+	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(StringName(T::get_class_static()));
 	}
@@ -180,8 +178,7 @@ struct GetTypeInfo<T *, typename EnableIf<TypeInherits<Object, T>::value>::type>
 
 template <typename T>
 struct GetTypeInfo<const T *, typename EnableIf<TypeInherits<Object, T>::value>::type> {
-	enum { VARIANT_TYPE = Variant::OBJECT };
-
+	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(StringName(T::get_class_static()));
 	}
@@ -190,7 +187,7 @@ struct GetTypeInfo<const T *, typename EnableIf<TypeInherits<Object, T>::value>:
 #define TEMPL_MAKE_ENUM_TYPE_INFO(m_enum, m_impl)                                                                                                                                 \
 	template <>                                                                                                                                                                   \
 	struct GetTypeInfo<m_impl> {                                                                                                                                                  \
-		enum { VARIANT_TYPE = Variant::INT };                                                                                                                                     \
+		static const Variant::Type VARIANT_TYPE = Variant::INT;                                                                                                                   \
 		static inline PropertyInfo get_class_info() {                                                                                                                             \
 			return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_ENUM, String(#m_enum).replace("::", ".")); \
 		}                                                                                                                                                                         \


### PR DESCRIPTION
This fixes a source of many compiler warnings regarding comparing the
enum VARIANT_TYPE to Variant::Type. This changes the local value to a
static const Variant::Type value rather than an unrelated enum, this
also saves us a cast.

(This removes 215 warnings from the build)