### PR TITLE
Add get_points() method to AStar

### DIFF
--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -129,6 +129,16 @@ bool AStar::has_point(int p_id) const {
 	return points.has(p_id);
 }
 
+Array AStar::get_points() {
+	Array point_list;
+
+	for (const Map<int, Point *>::Element *E = points.front(); E; E = E->next()) {
+		point_list.push_back(E->key());
+	}
+
+	return point_list;
+}
+
 bool AStar::are_points_connected(int p_id, int p_with_id) const {
 
 	Segment s(p_id, p_with_id);
@@ -407,6 +417,7 @@ void AStar::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_point_weight_scale", "id"), &AStar::get_point_weight_scale);
 	ClassDB::bind_method(D_METHOD("remove_point", "id"), &AStar::remove_point);
 	ClassDB::bind_method(D_METHOD("has_point", "id"), &AStar::has_point);
+	ClassDB::bind_method(D_METHOD("get_points"), &AStar::get_points);
 
 	ClassDB::bind_method(D_METHOD("connect_points", "id", "to_id", "bidirectional"), &AStar::connect_points, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("disconnect_points", "id", "to_id"), &AStar::disconnect_points);

--- a/core/math/a_star.h
+++ b/core/math/a_star.h
@@ -105,6 +105,7 @@ public:
 	real_t get_point_weight_scale(int p_id) const;
 	void remove_point(int p_id);
 	bool has_point(int p_id) const;
+	Array get_points();
 
 	void connect_points(int p_id, int p_with_id, bool bidirectional = true);
 	void disconnect_points(int p_id, int p_with_id);


### PR DESCRIPTION
Adds the get_points() method to AStar, which will return an Array of the indexes of all points. 
This is not strictly necessary, but i can imagine a lot of cases in which this could be helpful,
As of now there no way to get a list of all points. 