### PR TITLE
Don't set editor_hint true for project manager

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -465,7 +465,7 @@ void ProjectManager::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
-		Engine::get_singleton()->set_editor_hint(true);
+		Engine::get_singleton()->set_editor_hint(false);
 
 	} else if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
 


### PR DESCRIPTION
Due to this setting several callbacks get initialized but never used.
For instance void discoverer_callback(). This callback only initializes
the GDNativeSingletonDiscover *discoverer when called. This doesn't
happen in project manager and this in turn causes a call to
memdelete(NULL) which is invalid. This also seems to speed up startup a
little.

This fixes #11043 and fixes #10992

(maybe a candidate for backporting to 2.1)