### PR TITLE
Fixed loading package from resource folder, exporting textures to bun…

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -262,6 +262,11 @@ Error ProjectSettings::setup(const String &p_path, const String &p_main_pack) {
 		if (_load_settings("res://project.godot") == OK || _load_settings_binary("res://project.binary") == OK) {
 
 			_load_settings("res://override.cfg");
+#ifdef DEBUG_ENABLED
+		} else {
+			// when debug version of godot is used, provide some feedback to the developer
+			print_line("Couldn't open project over network");
+#endif
 		}
 
 		return OK;
@@ -279,6 +284,12 @@ Error ProjectSettings::setup(const String &p_path, const String &p_main_pack) {
 		if (_load_settings("res://project.godot") == OK || _load_settings_binary("res://project.binary") == OK) {
 			//load override from location of the main pack
 			_load_settings(p_main_pack.get_base_dir().plus_file("override.cfg"));
+#ifdef DEBUG_ENABLED
+			// when debug version of godot is used, provide some feedback to the developer
+			print_line("Successfully loaded " + p_main_pack + "/project.godot or project.binary");
+		} else {
+			print_line("Couldn't load/find " + p_main_pack + "/project.godot or project.binary");
+#endif
 		}
 
 		return OK;
@@ -286,12 +297,43 @@ Error ProjectSettings::setup(const String &p_path, const String &p_main_pack) {
 
 	//Attempt with execname.pck
 	if (exec_path != "") {
+		bool found = false;
 
-		if (_load_resource_pack(exec_path.get_basename() + ".pck")) {
+		// get our filename without our path (note, not using exec_path.get_basename anymore because not all file systems have dots in their file names!)
+		String filebase_name = exec_path.get_file();
 
+		// try to open at the location of executable
+		String datapack_name = exec_path.get_base_dir().plus_file(filebase_name) + ".pck";
+		if (_load_resource_pack(datapack_name)) {
+			found = true;
+		} else {
+#ifdef DEBUG_ENABLED
+			// when debug version of godot is used, provide some feedback to the developer
+			print_line("Couldn't open " + datapack_name);
+#endif
+			datapack_name = filebase_name + ".pck";
+			if (_load_resource_pack(datapack_name)) {
+				found = true;
+#ifdef DEBUG_ENABLED
+			} else {
+				// when debug version of godot is used, provide some feedback to the developer
+				print_line("Couldn't open " + datapack_name);
+#endif
+			}
+		}
+
+		// if we opened our package, try and load our project...
+		if (found) {
 			if (_load_settings("res://project.godot") == OK || _load_settings_binary("res://project.binary") == OK) {
-				//load override from location of executable
+				// load override from location of executable
 				_load_settings(exec_path.get_base_dir().plus_file("override.cfg"));
+
+#ifdef DEBUG_ENABLED
+				// when debug version of godot is used, provide some feedback to the developer
+				print_line("Successfully loaded " + datapack_name + "/project.godot or project.binary");
+			} else {
+				print_line("Couldn't load/find " + datapack_name + "/project.godot or project.binary");
+#endif
 			}
 
 			return OK;
@@ -312,6 +354,12 @@ Error ProjectSettings::setup(const String &p_path, const String &p_main_pack) {
 
 		if (_load_settings("res://project.godot") == OK || _load_settings_binary("res://project.binary") == OK) {
 			_load_settings("res://override.cfg");
+#ifdef DEBUG_ENABLED
+			// when debug version of godot is used, provide some feedback to the developer
+			print_line("Successfully loaded " + resource_path + "/project.godot or project.binary");
+		} else {
+			print_line("Couldn't load/find " + resource_path + "/project.godot or project.binary");
+#endif
 		}
 
 		return OK;
@@ -337,6 +385,12 @@ Error ProjectSettings::setup(const String &p_path, const String &p_main_pack) {
 			candidate = current_dir;
 			found = true;
 			break;
+#ifdef DEBUG_ENABLED
+			// when debug version of godot is used, provide some feedback to the developer
+			print_line("Successfully loaded " + current_dir + "/project.godot or project.binary");
+		} else {
+			print_line("Couldn't load/find " + current_dir + "/project.godot or project.binary");
+#endif
 		}
 
 		d->change_dir("..");

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -88,8 +88,15 @@ public:
 };
 
 void EditorExportPlatformOSX::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) {
-
-	// what does this need to do?
+	if (p_preset->get("texture_format/s3tc")) {
+		r_features->push_back("s3tc");
+	}
+	if (p_preset->get("texture_format/etc")) {
+		r_features->push_back("etc");
+	}
+	if (p_preset->get("texture_format/etc2")) {
+		r_features->push_back("etc2");
+	}
 }
 
 void EditorExportPlatformOSX::get_export_options(List<ExportOption> *r_options) {
@@ -112,6 +119,10 @@ void EditorExportPlatformOSX::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "codesign/identity"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "codesign/entitlements"), ""));
 #endif
+
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/s3tc"), true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/etc"), false));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/etc2"), false));
 }
 
 void EditorExportPlatformOSX::_make_icon(const Ref<Image> &p_icon, Vector<uint8_t> &p_data) {

--- a/platform/osx/godot_main_osx.mm
+++ b/platform/osx/godot_main_osx.mm
@@ -74,6 +74,13 @@ int main(int argc, char **argv) {
 		}
 	}
 
+#ifdef DEBUG_ENABLED
+	// lets report the path we made current after all that
+	char cwd[4096];
+	getcwd(cwd, 4096);
+	printf("Current path: %s\n", cwd);
+#endif
+
 	OS_OSX os;
 
 	Error err = Main::setup(argv[0], argc - first_arg, &argv[first_arg]);

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -181,6 +181,7 @@ public:
 	virtual void get_fullscreen_mode_list(List<VideoMode> *p_list, int p_screen = 0) const;
 
 	virtual String get_executable_path() const;
+	virtual String get_resource_dir() const;
 
 	virtual LatinKeyboardVariant get_latin_keyboard_variant() const;
 

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1736,6 +1736,17 @@ String OS_OSX::get_executable_path() const {
 	}
 }
 
+String OS_OSX::get_resource_dir() const {
+	// start with our executable path
+	String path = get_executable_path();
+
+	int pos = path.find_last("/Contents/MacOS/");
+	if (pos < 0)
+		return OS::get_resource_dir();
+
+	return path.substr(0, pos) + "/Contents/Resources/";
+}
+
 // Returns string representation of keys, if they are printable.
 //
 static NSString *createStringForKeys(const CGKeyCode *keyCode, int length) {


### PR DESCRIPTION
This fixes issue #10086 

I've made a few changes here. First off all for a debug build I'm giving a bit more feedback about Godot is attempting to load. Helps find the answer to these issues way more quickly.

There were two issues preventing the exported application bundle to run properly on OSX.

The most important was that the change in the project datapack loading code now calls exec_path.get_basename() as we want the name of the executable and the name of the datapack to be the same. This failed on OSX because the last dot in the executable path name is actually the ".app" of the bundle name stripping of far to much, and because the full path is evaluated we're not using the resource path that was made current in the startup code.

I've changed this to take the dataname from the actual filename and then checking if we can open a datapack in either the location of the executable or in the current directory.

The second issue was that the bundle wasn't exporting the textures, so that code has been added. By default it exports s3tc textures which seem to be the ones used on OSX.