### PR TITLE
optimized color conversion for svg generation

### DIFF
--- a/modules/svg/image_loader_svg.h
+++ b/modules/svg/image_loader_svg.h
@@ -52,13 +52,17 @@ public:
 };
 
 class ImageLoaderSVG : public ImageFormatLoader {
-
+	static struct ReplaceColors {
+		List<uint32_t> old_colors;
+		List<uint32_t> new_colors;
+	} replace_colors;
 	static SVGRasterizer rasterizer;
-	static void _convert_colors(NSVGimage *p_svg_imge, const Dictionary p_colors);
-	static Error _create_image(Ref<Image> p_image, const PoolVector<uint8_t> *p_data, float p_scale, bool upsample, const Dictionary *p_replace_color = NULL);
+	static void _convert_colors(NSVGimage *p_svg_imge);
+	static Error _create_image(Ref<Image> p_image, const PoolVector<uint8_t> *p_data, float p_scale, bool upsample, bool convert_colors = false);
 
 public:
-	static Error create_image_from_string(Ref<Image> p_image, const char *p_svg_str, float p_scale, bool upsample, const Dictionary *p_replace_color = NULL);
+	static void set_convert_colors(Dictionary *p_replace_color = NULL);
+	static Error create_image_from_string(Ref<Image> p_image, const char *p_svg_str, float p_scale, bool upsample, bool convert_colors = false);
 
 	virtual Error load_image(Ref<Image> p_image, FileAccess *f, bool p_force_linear, float p_scale);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;


### PR DESCRIPTION
After this pr:
```
+ SVG_GENERATION TIME: 0.680435  (with conversion)
- SVG_GENERATION TIME: 0.690145  (without conversion)
+ SVG_GENERATION TIME: 0.677619  (with conversion)
- SVG_GENERATION TIME: 0.719461  (without conversion)
+ SVG_GENERATION TIME: 0.694041  (with conversion)
- SVG_GENERATION TIME: 0.669586  (without conversion)
+ SVG_GENERATION TIME: 0.685164  (with conversion)
```
(0.680435 + 0.677619 + 0.694041 +  0.685164) / 4 -> 0.6843147 (with conversion)
(0.690145 + 0.719461 + 0.669586) / 3 -> 0.693064 (without)
-> so basically the same (in this test it was even faster with the conversion... but I only tested 7 times ...)

before the change:

```
- SVG_GENERATION TIME: 0.677409 (without conversion)
+ SVG_GENERATION TIME: 0.800365 (with conversion)
- SVG_GENERATION TIME: 0.669492 (without conversion)
+ SVG_GENERATION TIME: 0.791202 (with conversion)
- SVG_GENERATION TIME: 0.669209 (without conversion)
+ SVG_GENERATION TIME: 0.778514 (with conversion)
- SVG_GENERATION TIME: 0.6814 (without conversion)
+ SVG_GENERATION TIME: 0.789975 (with conversion)
```
(0.800365 + 0.791202 + 0.778514 + 0.789975) / 4 -> 0.790014 (with conversion)
(0.677409 + 0.669492 +  0.669209 + 0.6814) / 4 -> 0.6743775 (without)
-> definitely a difference. (more than 10%)