### PR TITLE
Allow animations to be saved to external files during scene import.

### DIFF
--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -85,8 +85,15 @@ class ResourceImporterScene : public ResourceImporter {
 	enum Presets {
 		PRESET_SEPARATE_MATERIALS,
 		PRESET_SEPARATE_MESHES,
+		PRESET_SEPERATE_ANIMATIONS,
+
 		PRESET_SINGLE_SCENE,
+
 		PRESET_SEPARATE_MESHES_AND_MATERIALS,
+		PRESET_SEPARATE_MESHES_AND_ANIMATIONS,
+		PRESET_SEPERATE_MATERIALS_AND_ANIMATIONS,
+		PRESET_SEPERATE_MESHES_MATERIALS_AND_ANIMATIONS,
+
 		PRESET_MULTIPLE_SCENES,
 		PRESET_MULTIPLE_SCENES_AND_MATERIALS,
 	};
@@ -112,7 +119,7 @@ public:
 	virtual void get_import_options(List<ImportOption> *r_options, int p_preset = 0) const;
 	virtual bool get_option_visibility(const String &p_option, const Map<StringName, Variant> &p_options) const;
 
-	void _make_external_resources(Node *p_node, const String &p_base_path, bool p_make_materials, bool p_keep_materials, bool p_make_meshes, Map<Ref<Material>, Ref<Material> > &p_materials, Map<Ref<ArrayMesh>, Ref<ArrayMesh> > &p_meshes);
+	void _make_external_resources(Node *p_node, const String &p_base_path, bool p_make_animations, bool p_make_materials, bool p_keep_materials, bool p_make_meshes, Map<Ref<Animation>, Ref<Animation> > &p_animation, Map<Ref<Material>, Ref<Material> > &p_materials, Map<Ref<ArrayMesh>, Ref<ArrayMesh> > &p_meshes);
 
 	Node *_fix_node(Node *p_node, Node *p_root, Map<Ref<ArrayMesh>, Ref<Shape> > &collision_map);
 


### PR DESCRIPTION
Allows the animations generated from importing GLTF or Collada files to be saved to external files during the import process in the same way meshes and materials can already be. This is useful if you want to import animations which can be reused across multiple objects. I originally had scripts which could do this for the Godot 2.0, but with the new import pipeline and the fact that this functionality already exists for meshes and materials, I thought it should be added too.