### PR TITLE
Add Color ctor 0-255 value support

### DIFF
--- a/core/color.h
+++ b/core/color.h
@@ -177,6 +177,16 @@ struct Color {
 		b = p_b;
 		a = p_a;
 	}
+
+	/**
+	 * RGB / RGBA construct parameters. Alpha is optional, but defaults to 255
+	 */
+	_FORCE_INLINE_ Color(int p_r, int p_g, int p_b, int p_a = 255) {
+		r = float(p_r) / 255.0;
+		g = float(p_g) / 255.0;
+		b = float(p_b) / 255.0;
+		a = float(p_a) / 255.0;
+	}
 };
 
 bool Color::operator<(const Color &p_color) const {

--- a/modules/gdnative/gdnative/color.cpp
+++ b/modules/gdnative/gdnative/color.cpp
@@ -50,6 +50,18 @@ void GDAPI godot_color_new_rgb(godot_color *r_dest, const godot_real p_r, const 
 	*dest = Color(p_r, p_g, p_b);
 }
 
+void GDAPI godot_color_new_rgba(godot_color *r_dest, const godot_int p_r, const godot_int p_g, const godot_int p_b, const godot_int p_a) {
+
+	Color *dest = (Color *)r_dest;
+	*dest = Color(p_r, p_g, p_b, p_a);
+}
+
+void GDAPI godot_color_new_rgb(godot_color *r_dest, const godot_int p_r, const godot_int p_g, const godot_int p_b) {
+	
+		Color *dest = (Color *)r_dest;
+		*dest = Color(p_r, p_g, p_b);
+}
+
 godot_real godot_color_get_r(const godot_color *p_self) {
 	const Color *self = (const Color *)p_self;
 	return self->r;

--- a/modules/gdnative/include/gdnative/color.h
+++ b/modules/gdnative/include/gdnative/color.h
@@ -51,6 +51,9 @@ typedef struct {
 void GDAPI godot_color_new_rgba(godot_color *r_dest, const godot_real p_r, const godot_real p_g, const godot_real p_b, const godot_real p_a);
 void GDAPI godot_color_new_rgb(godot_color *r_dest, const godot_real p_r, const godot_real p_g, const godot_real p_b);
 
+void GDAPI godot_color_new_rgba(godot_color *r_dest, const godot_int p_r, const godot_int p_g, const godot_int p_b, const godot_int p_a);
+void GDAPI godot_color_new_rgb(godot_color *r_dest, const godot_int p_r, const godot_int p_g, const godot_int p_b);
+
 godot_real godot_color_get_r(const godot_color *p_self);
 void godot_color_set_r(godot_color *p_self, const godot_real r);
 


### PR DESCRIPTION
I know I'm not alone in making the mistake of using 0-255 values to set color for Color(r,g,b,a) when it's supposed to be 0.0-1.0 value. I've seen couple others make the same mistake, especially live on Twitch!

So I added in the new constructors that supports RGB and RGBA. But I'm not sure if there's anything else I needed to add/change in order to make it work.