### PR TITLE
rewrite the methods and member variables for the Node2D class

### DIFF
--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -30220,10 +30220,10 @@
 </class>
 <class name="Node2D" inherits="CanvasItem" category="Core">
 	<brief_description>
-		Base node for 2D system.
+		A 2D game object, parent of all 2D related nodes. Has a position, rotation, scale and Z-index.
 	</brief_description>
 	<description>
-		Base node for 2D system. Node2D contains a position, rotation and scale, which is used to position and animate. It can alternatively be used with a custom 2D transform ([Transform2D]). A tree of Node2Ds allows complex hierarchies for animation and positioning.
+		A 2D game object, with a position, rotation and scale. All 2D physics nodes and sprites inherit from Node2D. Use Node2D as a parent node to move, scale and rotate children in a 2D project. Also gives control on the node's render order.
 	</description>
 	<methods>
 		<method name="apply_scale">
@@ -30232,7 +30232,7 @@
 			<argument index="0" name="ratio" type="Vector2">
 			</argument>
 			<description>
-				Apply the 'ratio' scale to the 2D node, according to its current scale value.
+				Multiplies the current scale by the 'ratio' vector.
 			</description>
 		</method>
 		<method name="edit_set_pivot">
@@ -30241,7 +30241,7 @@
 			<argument index="0" name="pivot" type="Vector2">
 			</argument>
 			<description>
-				Set the pivot position of the 2D node to 'pivot' value. This method is implemented only in some nodes that inherit Node2D.
+				Set the pivot position of the 2D node to 'pivot' value. Only some Node2Ds implement this method.
 			</description>
 		</method>
 		<method name="get_angle_to" qualifiers="const">
@@ -30250,42 +30250,42 @@
 			<argument index="0" name="point" type="Vector2">
 			</argument>
 			<description>
-				Return the rotation angle in radians needed for the 2d node to point at 'point' position.
+				Returns the angle between the node and the 'point' in radians.
 			</description>
 		</method>
 		<method name="get_global_position" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<description>
-				Return the global position of the 2D node.
+				Returns the node's global position.
 			</description>
 		</method>
 		<method name="get_global_rotation" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
-				Return the global rotation in radians of the 2D node.
+				Returns the node's global rotation in radians.
 			</description>
 		</method>
 		<method name="get_global_rotation_in_degrees" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
-				Return the global rotation in degrees of the 2D node.
+				Return the node's global rotation in degrees.
 			</description>
 		</method>
 		<method name="get_global_scale" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<description>
-				Return the global scale of the 2D node.
+				Returns the node's global scale.
 			</description>
 		</method>
 		<method name="get_position" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<description>
-				Return the position of the 2D node.
+				Returns the node's position.
 			</description>
 		</method>
 		<method name="get_relative_transform_to_parent" qualifiers="const">
@@ -30294,35 +30294,35 @@
 			<argument index="0" name="parent" type="Node">
 			</argument>
 			<description>
-				Return the transform [Transform2D] calculated relatively to the parent of this 2D node.
+				Returns the [Transform2D] relative to this node's parent.
 			</description>
 		</method>
 		<method name="get_rotation" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
-				Return the rotation in radians of the 2D node.
+				Returns the node's rotation in radians.
 			</description>
 		</method>
 		<method name="get_rotation_in_degrees" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
-				Return the rotation in degrees of the 2D node.
+				Returns the node's rotation in degrees.
 			</description>
 		</method>
 		<method name="get_scale" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<description>
-				Return the scale of the 2D node.
+				Returns the node's scale.
 			</description>
 		</method>
 		<method name="get_z" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Return the Z-index of the 2D node.
+				Returns the node's Z-index.
 			</description>
 		</method>
 		<method name="global_translate">
@@ -30331,14 +30331,14 @@
 			<argument index="0" name="offset" type="Vector2">
 			</argument>
 			<description>
-				Apply a global translation of 'offset' to the 2D node, starting from its current global position.
+				Adds the 'offset' vector to the node's global position.
 			</description>
 		</method>
 		<method name="is_z_relative" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
-				Return true if the Z-index value of this 2D node is relative to its parent's. Else, return false.
+				Returns true if this node's Z-index is relative to its parent's. Else, returns false.
 			</description>
 		</method>
 		<method name="look_at">
@@ -30347,7 +30347,7 @@
 			<argument index="0" name="point" type="Vector2">
 			</argument>
 			<description>
-				Rotate the 2d node so it points at 'point' position.
+				Rotates the node so it points towards the 'point'.
 			</description>
 		</method>
 		<method name="move_local_x">
@@ -30358,7 +30358,7 @@
 			<argument index="1" name="scaled" type="bool" default="false">
 			</argument>
 			<description>
-				Apply a local translation on X axis to the 2D node according to the 'delta' of the process. If 'scaled' is false, the movement is normalized.
+				Apply a local translation on the node's X axis based on the process's 'delta'. If 'scaled' is false, normalizes the movement.
 			</description>
 		</method>
 		<method name="move_local_y">
@@ -30369,7 +30369,7 @@
 			<argument index="1" name="scaled" type="bool" default="false">
 			</argument>
 			<description>
-				Apply a local translation on Y axis to the 2D node according to the 'delta' of the process. If 'scaled' is false, the movement is normalized.
+				Apply a local translation on the node's Y axis based on the process's 'delta'. If 'scaled' is false, normalizes the movement.
 			</description>
 		</method>
 		<method name="rotate">
@@ -30378,7 +30378,7 @@
 			<argument index="0" name="radians" type="float">
 			</argument>
 			<description>
-				Apply a rotation (in radians) to the 2D node, starting from its current rotation.
+				Apply a rotation to the node, in radians, starting from its current rotation.
 			</description>
 		</method>
 		<method name="set_global_position">
@@ -30387,7 +30387,7 @@
 			<argument index="0" name="pos" type="Vector2">
 			</argument>
 			<description>
-				Set the global position of the 2D node.
+				Set the node's global position.
 			</description>
 		</method>
 		<method name="set_global_rotation">
@@ -30396,7 +30396,7 @@
 			<argument index="0" name="radians" type="float">
 			</argument>
 			<description>
-				Set the global rotation in radians of the 2D node
+				Set the node's global rotation in radians.
 			</description>
 		</method>
 		<method name="set_global_rotation_in_degrees">
@@ -30405,7 +30405,7 @@
 			<argument index="0" name="degrees" type="float">
 			</argument>
 			<description>
-				Set the global rotation in degrees of the 2D node
+				Set the node's global rotation in degrees.
 			</description>
 		</method>
 		<method name="set_global_scale">
@@ -30414,7 +30414,7 @@
 			<argument index="0" name="scale" type="Vector2">
 			</argument>
 			<description>
-				Set the global scale of the 2D node.
+				Set the node's global scale.
 			</description>
 		</method>
 		<method name="set_global_transform">
@@ -30423,7 +30423,7 @@
 			<argument index="0" name="xform" type="Transform2D">
 			</argument>
 			<description>
-				Set the global transform [Transform2D] of the 2D node.
+				Set the node's global [Transform2D].
 			</description>
 		</method>
 		<method name="set_position">
@@ -30432,7 +30432,7 @@
 			<argument index="0" name="pos" type="Vector2">
 			</argument>
 			<description>
-				Set the position of the 2D node.
+				Set the node's position.
 			</description>
 		</method>
 		<method name="set_rotation">
@@ -30441,7 +30441,7 @@
 			<argument index="0" name="radians" type="float">
 			</argument>
 			<description>
-				Set the rotation in radians of the 2D node.
+				Set the node's rotation in radians.
 			</description>
 		</method>
 		<method name="set_rotation_in_degrees">
@@ -30450,7 +30450,7 @@
 			<argument index="0" name="degrees" type="float">
 			</argument>
 			<description>
-				Set the rotation in degrees of the 2D node.
+				Set the node's rotation in degrees.
 			</description>
 		</method>
 		<method name="set_scale">
@@ -30459,7 +30459,7 @@
 			<argument index="0" name="scale" type="Vector2">
 			</argument>
 			<description>
-				Set the scale of the 2D node.
+				Set the node's scale.
 			</description>
 		</method>
 		<method name="set_transform">
@@ -30468,7 +30468,7 @@
 			<argument index="0" name="xform" type="Transform2D">
 			</argument>
 			<description>
-				Set the local transform [Transform2D] of the 2D node.
+				Set the node's local [Transform2D].
 			</description>
 		</method>
 		<method name="set_z">
@@ -30477,7 +30477,7 @@
 			<argument index="0" name="z" type="int">
 			</argument>
 			<description>
-				Set the Z-index value of the 2D node.
+				Set the node's Z-index.
 			</description>
 		</method>
 		<method name="set_z_as_relative">
@@ -30486,7 +30486,7 @@
 			<argument index="0" name="enable" type="bool">
 			</argument>
 			<description>
-				Set the Z-index value as relative to the parent node of this 2D node. Thus, if this 2D node's Z-index value is 2 and its parent's effective Z-index is 3, then the effective Z-index value of this 2D node would be 3 + 2 = 5.
+				Make the node's Z-index relative to its parent's Z-index. If this node's Z-index is 2 and its parent's effective Z-index is 3, then this node's effective Z-index will be 2 + 3 = 5.
 			</description>
 		</method>
 		<method name="to_global" qualifiers="const">
@@ -30511,34 +30511,46 @@
 			<argument index="0" name="offset" type="Vector2">
 			</argument>
 			<description>
-				Apply a local translation of 'offset' to the 2D node, starting from its current local position.
+				Translate the node locally by the 'offset' vector, starting from its current local position.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="global_position" type="Vector2" setter="set_global_position" getter="get_global_position" brief="">
+			Global position.
 		</member>
 		<member name="global_rotation" type="float" setter="set_global_rotation" getter="get_global_rotation" brief="">
+			Global rotation in radians.
 		</member>
 		<member name="global_rotation_deg" type="float" setter="set_global_rotation_in_degrees" getter="get_global_rotation_in_degrees" brief="">
+			Global rotation in degrees.
 		</member>
 		<member name="global_scale" type="Vector2" setter="set_global_scale" getter="get_global_scale" brief="">
+			Global scale.
 		</member>
 		<member name="global_transform" type="Transform2D" setter="set_global_transform" getter="get_global_transform" brief="">
+			Global [Transform2D].
 		</member>
 		<member name="position" type="Vector2" setter="set_position" getter="get_position" brief="">
+			Position, relative to the node's parent.
 		</member>
 		<member name="rotation" type="float" setter="set_rotation" getter="get_rotation" brief="">
+			Rotation in radians.
 		</member>
 		<member name="rotation_deg" type="float" setter="set_rotation_in_degrees" getter="get_rotation_in_degrees" brief="">
+			Rotation in degrees.
 		</member>
 		<member name="scale" type="Vector2" setter="set_scale" getter="get_scale" brief="">
+			Rotation in degrees.
 		</member>
 		<member name="transform" type="Transform2D" setter="set_transform" getter="get_transform" brief="">
+			Local [Transform2D].
 		</member>
 		<member name="z" type="int" setter="set_z" getter="get_z" brief="">
+			Z-index. Controls the order in which the nodes render. A node with a higher Z-index will display in front of others.
 		</member>
 		<member name="z_as_relative" type="bool" setter="set_z_as_relative" getter="is_z_relative" brief="">
+			Make the node's Z-index relative to its parent's Z-index. If this node's Z-index is 2 and its parent's effective Z-index is 3, then this node's effective Z-index will be 2 + 3 = 5.
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
I didn't rewrite all the set and get methods as we talked with Juan: set/get methods will be dropped in Godot 3.0's documentation.