### PR TITLE
Fix errors at exit (2.1)

### DIFF
--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -337,6 +337,8 @@ void AudioDriverWASAPI::finish() {
 		memdelete(mutex);
 		mutex = NULL;
 	}
+
+	samples_in.clear();
 }
 
 AudioDriverWASAPI::AudioDriverWASAPI() {


### PR DESCRIPTION
## Fix WASAPI cleanup
Audio drivers are destroyed on OS destruction, when memory management is no longer available so they must release their dynamic allocations explicitly in their `finish()` method.

~## Fix crash at editor exit related to BB10~
~Caused by a recent change in BB10 polling thread behaviour.~