### PR TITLE
Fixed the methods 'resource_changed' to be virtual since they can be overridden with GDScript.

### DIFF
--- a/core/resource.cpp
+++ b/core/resource.cpp
@@ -243,7 +243,7 @@ void Resource::notify_change_to_owners() {
 		ERR_EXPLAIN("Object was deleted, while still owning a resource");
 		ERR_CONTINUE(!obj); //wtf
 		//TODO store string
-		obj->call("resource_changed", RES(this));
+		obj->call("_resource_changed", RES(this));
 	}
 }
 

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -711,7 +711,7 @@ void GridMap::clear() {
 	_clear_internal();
 }
 
-void GridMap::resource_changed(const RES &p_res) {
+void GridMap::_resource_changed(const RES &p_res) {
 
 	_recreate_octant_data();
 }
@@ -756,7 +756,7 @@ void GridMap::_bind_methods() {
 
 	//ClassDB::bind_method(D_METHOD("_recreate_octants"),&GridMap::_recreate_octants);
 	ClassDB::bind_method(D_METHOD("_update_octants_callback"), &GridMap::_update_octants_callback);
-	ClassDB::bind_method(D_METHOD("resource_changed", "resource"), &GridMap::resource_changed);
+	ClassDB::bind_method(D_METHOD("_resource_changed", "resource"), &GridMap::_resource_changed);
 
 	ClassDB::bind_method(D_METHOD("set_center_x", "enable"), &GridMap::set_center_x);
 	ClassDB::bind_method(D_METHOD("get_center_x"), &GridMap::get_center_x);

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -180,7 +180,7 @@ class GridMap : public Spatial {
 	void _queue_octants_dirty();
 	void _update_octants_callback();
 
-	void resource_changed(const RES &p_res);
+	virtual void _resource_changed(const RES &p_res);
 
 	void _clear_internal();
 

--- a/scene/3d/collision_shape.cpp
+++ b/scene/3d/collision_shape.cpp
@@ -98,7 +98,7 @@ void CollisionShape::_notification(int p_what) {
 	}
 }
 
-void CollisionShape::resource_changed(RES res) {
+void CollisionShape::_resource_changed(RES res) {
 
 	update_gizmo();
 }
@@ -119,7 +119,7 @@ String CollisionShape::get_configuration_warning() const {
 void CollisionShape::_bind_methods() {
 
 	//not sure if this should do anything
-	ClassDB::bind_method(D_METHOD("resource_changed", "resource"), &CollisionShape::resource_changed);
+	ClassDB::bind_method(D_METHOD("_resource_changed", "resource"), &CollisionShape::_resource_changed);
 	ClassDB::bind_method(D_METHOD("set_shape", "shape"), &CollisionShape::set_shape);
 	ClassDB::bind_method(D_METHOD("get_shape"), &CollisionShape::get_shape);
 	ClassDB::bind_method(D_METHOD("set_disabled", "enable"), &CollisionShape::set_disabled);

--- a/scene/3d/collision_shape.h
+++ b/scene/3d/collision_shape.h
@@ -45,7 +45,7 @@ class CollisionShape : public Spatial {
 
 	Node *debug_shape;
 
-	void resource_changed(RES res);
+	virtual void _resource_changed(RES res);
 	bool disabled;
 
 	void _create_debug_shape();


### PR DESCRIPTION
See issue #11104 