### PR TITLE
Changed the text from "Cancel" to "Done" in the "Fix Dependencies" dialog.

### DIFF
--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -489,6 +489,7 @@ DependencyErrorDialog::DependencyErrorDialog() {
 	vb->add_margin_child(TTR("Scene failed to load due to missing dependencies:"), files, true);
 	files->set_v_size_flags(SIZE_EXPAND_FILL);
 	get_ok()->set_text(TTR("Open Anyway"));
+	get_cancel()->set_text(TTR("Done"));
 
 	text = memnew(Label);
 	vb->add_child(text);


### PR DESCRIPTION
Changed the "Fix Dependencies" dialog button that closes the dialog to now say "Done".

Having the button the user needs to push labeled as "Cancel" is very confusing and leaves the impression that it will "cancel" the dependencies they've fixed and revert them back to being broken, which isn't the case.