### PR TITLE
Added ID to tracker signals and property for storing hand

### DIFF
--- a/scene/3d/arvr_nodes.cpp
+++ b/scene/3d/arvr_nodes.cpp
@@ -31,7 +31,6 @@
 #include "arvr_nodes.h"
 #include "core/os/input.h"
 #include "servers/arvr/arvr_interface.h"
-#include "servers/arvr/arvr_positional_tracker.h"
 #include "servers/arvr_server.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -142,6 +141,7 @@ void ARVRController::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_joystick_axis", "axis"), &ARVRController::get_joystick_axis);
 
 	ClassDB::bind_method(D_METHOD("get_is_active"), &ARVRController::get_is_active);
+	ClassDB::bind_method(D_METHOD("get_hand"), &ARVRController::get_hand);
 
 	ADD_SIGNAL(MethodInfo("button_pressed", PropertyInfo(Variant::INT, "button")));
 	ADD_SIGNAL(MethodInfo("button_release", PropertyInfo(Variant::INT, "button")));
@@ -202,6 +202,19 @@ float ARVRController::get_joystick_axis(int p_axis) const {
 
 bool ARVRController::get_is_active() const {
 	return is_active;
+};
+
+ARVRPositionalTracker::TrackerHand ARVRController::get_hand() const {
+	// get our ARVRServer
+	ARVRServer *arvr_server = ARVRServer::get_singleton();
+	ERR_FAIL_NULL_V(arvr_server, ARVRPositionalTracker::TRACKER_HAND_UNKNOWN);
+
+	ARVRPositionalTracker *tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, controller_id);
+	if (tracker == NULL) {
+		return ARVRPositionalTracker::TRACKER_HAND_UNKNOWN;
+	};
+
+	return tracker->get_hand();
 };
 
 String ARVRController::get_configuration_warning() const {

--- a/scene/3d/arvr_nodes.h
+++ b/scene/3d/arvr_nodes.h
@@ -33,6 +33,7 @@
 
 #include "scene/3d/camera.h"
 #include "scene/3d/spatial.h"
+#include "servers/arvr/arvr_positional_tracker.h"
 
 /**
 	@author Bastiaan Olij <mux213@gmail.com>
@@ -84,6 +85,7 @@ public:
 	float get_joystick_axis(int p_axis) const;
 
 	bool get_is_active() const;
+	ARVRPositionalTracker::TrackerHand get_hand() const;
 
 	String get_configuration_warning() const;
 

--- a/servers/arvr/arvr_positional_tracker.cpp
+++ b/servers/arvr/arvr_positional_tracker.cpp
@@ -31,6 +31,10 @@
 #include "core/os/input.h"
 
 void ARVRPositionalTracker::_bind_methods() {
+	BIND_ENUM_CONSTANT(TRACKER_HAND_UNKNOWN);
+	BIND_ENUM_CONSTANT(TRACKER_LEFT_HAND);
+	BIND_ENUM_CONSTANT(TRACKER_RIGHT_HAND);
+
 	// this class is read only from GDScript, so we only have access to getters..
 	ClassDB::bind_method(D_METHOD("get_type"), &ARVRPositionalTracker::get_type);
 	ClassDB::bind_method(D_METHOD("get_name"), &ARVRPositionalTracker::get_name);
@@ -39,6 +43,7 @@ void ARVRPositionalTracker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_orientation"), &ARVRPositionalTracker::get_orientation);
 	ClassDB::bind_method(D_METHOD("get_tracks_position"), &ARVRPositionalTracker::get_tracks_position);
 	ClassDB::bind_method(D_METHOD("get_position"), &ARVRPositionalTracker::get_position);
+	ClassDB::bind_method(D_METHOD("get_hand"), &ARVRPositionalTracker::get_hand);
 	ClassDB::bind_method(D_METHOD("get_transform", "adjust_by_reference_frame"), &ARVRPositionalTracker::get_transform);
 
 	// these functions we don't want to expose to normal users but do need to be callable from GDNative
@@ -141,6 +146,14 @@ Vector3 ARVRPositionalTracker::get_rw_position() const {
 	return rw_position;
 };
 
+ARVRPositionalTracker::TrackerHand ARVRPositionalTracker::get_hand() const {
+	return hand;
+};
+
+void ARVRPositionalTracker::set_hand(const ARVRPositionalTracker::TrackerHand p_hand) {
+	hand = p_hand;
+};
+
 Transform ARVRPositionalTracker::get_transform(bool p_adjust_by_reference_frame) const {
 	Transform new_transform;
 
@@ -164,6 +177,7 @@ ARVRPositionalTracker::ARVRPositionalTracker() {
 	tracker_id = 0;
 	tracks_orientation = false;
 	tracks_position = false;
+	hand = TRACKER_HAND_UNKNOWN;
 };
 
 ARVRPositionalTracker::~ARVRPositionalTracker(){

--- a/servers/arvr/arvr_positional_tracker.h
+++ b/servers/arvr/arvr_positional_tracker.h
@@ -48,6 +48,13 @@ class ARVRPositionalTracker : public Object {
 	GDCLASS(ARVRPositionalTracker, Object);
 	_THREAD_SAFE_CLASS_
 
+public:
+	enum TrackerHand {
+		TRACKER_HAND_UNKNOWN, /* unknown or not applicable */
+		TRACKER_LEFT_HAND, /* controller is the left hand controller */
+		TRACKER_RIGHT_HAND /* controller is the right hand controller */
+	};
+
 private:
 	ARVRServer::TrackerType type; // type of tracker
 	StringName name; // (unique) name of the tracker
@@ -57,6 +64,7 @@ private:
 	Basis orientation; // our orientation
 	bool tracks_position; // do we track position?
 	Vector3 rw_position; // our position "in the real world, so without world_scale applied"
+	TrackerHand hand; // if known, the hand this tracker is held in
 
 protected:
 	static void _bind_methods();
@@ -77,11 +85,15 @@ public:
 	Vector3 get_position() const; // get position with world_scale applied
 	void set_rw_position(const Vector3 &p_rw_position);
 	Vector3 get_rw_position() const;
+	ARVRPositionalTracker::TrackerHand get_hand() const;
+	void set_hand(const ARVRPositionalTracker::TrackerHand p_hand);
 
 	Transform get_transform(bool p_adjust_by_reference_frame) const;
 
 	ARVRPositionalTracker();
 	~ARVRPositionalTracker();
 };
+
+VARIANT_ENUM_CAST(ARVRPositionalTracker::TrackerHand);
 
 #endif

--- a/servers/arvr_server.cpp
+++ b/servers/arvr_server.cpp
@@ -68,8 +68,8 @@ void ARVRServer::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("interface_added", PropertyInfo(Variant::STRING, "name")));
 	ADD_SIGNAL(MethodInfo("interface_removed", PropertyInfo(Variant::STRING, "name")));
 
-	ADD_SIGNAL(MethodInfo("tracker_added", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::INT, "type")));
-	ADD_SIGNAL(MethodInfo("tracker_removed", PropertyInfo(Variant::STRING, "name")));
+	ADD_SIGNAL(MethodInfo("tracker_added", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::INT, "type"), PropertyInfo(Variant::INT, "id")));
+	ADD_SIGNAL(MethodInfo("tracker_removed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::INT, "type"), PropertyInfo(Variant::INT, "id")));
 };
 
 real_t ARVRServer::get_world_scale() const {
@@ -232,7 +232,7 @@ void ARVRServer::add_tracker(ARVRPositionalTracker *p_tracker) {
 	ERR_FAIL_NULL(p_tracker);
 
 	trackers.push_back(p_tracker);
-	emit_signal("tracker_added", p_tracker->get_name(), p_tracker->get_type());
+	emit_signal("tracker_added", p_tracker->get_name(), p_tracker->get_type(), p_tracker->get_tracker_id());
 };
 
 void ARVRServer::remove_tracker(ARVRPositionalTracker *p_tracker) {
@@ -250,7 +250,7 @@ void ARVRServer::remove_tracker(ARVRPositionalTracker *p_tracker) {
 
 	ERR_FAIL_COND(idx == -1);
 
-	emit_signal("tracker_removed", p_tracker->get_name());
+	emit_signal("tracker_removed", p_tracker->get_name(), p_tracker->get_type(), p_tracker->get_tracker_id());
 	trackers.remove(idx);
 };
 


### PR DESCRIPTION
Added tracker ID to our tracker signals so we can detect which tracker came online. Makes it easier when adding ARVRController nodes as a response.

Also added a property to our tracker that indicates whether the controller is related to the players left or right hand, provided the SDK makes this available to us.