### PR TITLE
Add user data directory support for ProjectSettings::globalize_path

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -114,7 +114,15 @@ String ProjectSettings::globalize_path(const String &p_path) const {
 			return p_path.replace("res:/", resource_path);
 		};
 		return p_path.replace("res://", "");
-	};
+	} else if (p_path.begins_with("user://")) {
+
+		String data_dir = OS::get_singleton()->get_data_dir();
+		if (data_dir != "") {
+
+			return p_path.replace("user:/", data_dir);
+		};
+		return p_path.replace("user://", "");
+	}
 
 	return p_path;
 }


### PR DESCRIPTION
Make it possible to get full real file path in user data directory(starts with `user://` )