### PR TITLE
DirAccess constructor sets current_dir to an absolute path

### DIFF
--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -221,37 +221,24 @@ Error DirAccessUnix::change_dir(String p_dir) {
 	if (prev_dir.parse_utf8(real_current_dir_name))
 		prev_dir = real_current_dir_name; //no utf8, maybe latin?
 
-	//print_line("directory we are changing out of (prev_dir): " + prev_dir);
-
 	// try_dir is the directory we are trying to change into
 	String try_dir = "";
 	if (p_dir.is_rel_path()) {
 		String next_dir = current_dir + "/" + p_dir;
-		//print_line("p_dir is relative: " + p_dir + " about to simplfy: " + next_dir);
 		next_dir = next_dir.simplify_path();
 		try_dir = next_dir;
 	} else {
 		try_dir = p_dir;
-		//print_line("p_dir is absolute: " + p_dir);
 	}
-
-	// if try_dir is nothing, it is not changing directory so change it to a "." otherwise chdir will fail
-	if (try_dir == "") {
-		try_dir = ".";
-	}
-
-	//print_line("directory we are changing in to (try_dir): " + try_dir);
 
 	bool worked = (chdir(try_dir.utf8().get_data()) == 0); // we can only give this utf8
 	if (!worked) {
-		//print_line("directory does not exist");
 		return ERR_INVALID_PARAMETER;
 	}
 
 	// the directory exists, so set current_dir to try_dir
 	current_dir = try_dir;
 	chdir(prev_dir.utf8().get_data());
-	//print_line("directory exists, setting current_dir to: " + current_dir);
 	return OK;
 }
 
@@ -319,10 +306,15 @@ size_t DirAccessUnix::get_space_left() {
 DirAccessUnix::DirAccessUnix() {
 
 	dir_stream = 0;
-	current_dir = ".";
 	_cisdir = false;
 
 	/* determine drive count */
+
+	// set current directory to an absolute path of the current directory
+	char real_current_dir_name[2048];
+	getcwd(real_current_dir_name, 2048);
+	if (current_dir.parse_utf8(real_current_dir_name))
+		current_dir = real_current_dir_name;
 
 	change_dir(current_dir);
 }


### PR DESCRIPTION
This should be a better fix for issue #11145. As per my comment in that issue:

To get symlinks working I've added support for relative path changes without resolving the actual physical directory name, which allows current_dir to never know if it is in a symlink directory or not: hence I am using this line: String next_dir = current_dir + "/" + p_dir;
So the cause of this problem is that in the constructor the initial path is relative, so I have changed this to start with an absolute path, so we should never end up with a directory name starting with "."

I did a test and this fixes the Show in File Manager button.
