### PR TITLE
Script access to formatted arrays and blend_arrays in meshes.

### DIFF
--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -761,7 +761,7 @@ Array ArrayMesh::surface_get_arrays(int p_surface) const {
 Array ArrayMesh::surface_get_blend_shape_arrays(int p_surface) const {
 
 	ERR_FAIL_INDEX_V(p_surface, surfaces.size(), Array());
-	return Array();
+	return VisualServer::get_singleton()->mesh_surface_get_blend_shape_arrays(mesh, p_surface);
 }
 
 int ArrayMesh::get_surface_count() const {
@@ -1010,6 +1010,8 @@ void ArrayMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("surface_get_material", "surf_idx"), &ArrayMesh::surface_get_material);
 	ClassDB::bind_method(D_METHOD("surface_set_name", "surf_idx", "name"), &ArrayMesh::surface_set_name);
 	ClassDB::bind_method(D_METHOD("surface_get_name", "surf_idx"), &ArrayMesh::surface_get_name);
+	ClassDB::bind_method(D_METHOD("surface_get_arrays", "surf_idx"), &ArrayMesh::surface_get_arrays);
+	ClassDB::bind_method(D_METHOD("surface_get_blend_shape_arrays", "surf_idx"), &ArrayMesh::surface_get_blend_shape_arrays);
 	ClassDB::bind_method(D_METHOD("create_trimesh_shape"), &ArrayMesh::create_trimesh_shape);
 	ClassDB::bind_method(D_METHOD("create_convex_shape"), &ArrayMesh::create_convex_shape);
 	ClassDB::bind_method(D_METHOD("create_outline", "margin"), &ArrayMesh::create_outline);

--- a/scene/resources/mesh.h
+++ b/scene/resources/mesh.h
@@ -120,6 +120,7 @@ public:
 	virtual int surface_get_array_len(int p_idx) const = 0;
 	virtual int surface_get_array_index_len(int p_idx) const = 0;
 	virtual Array surface_get_arrays(int p_surface) const = 0;
+	virtual Array surface_get_blend_shape_arrays(int p_surface) const = 0;
 	virtual uint32_t surface_get_format(int p_idx) const = 0;
 	virtual PrimitiveType surface_get_primitive_type(int p_idx) const = 0;
 	virtual Ref<Material> surface_get_material(int p_idx) const = 0;
@@ -174,7 +175,7 @@ public:
 	void add_surface(uint32_t p_format, PrimitiveType p_primitive, const PoolVector<uint8_t> &p_array, int p_vertex_count, const PoolVector<uint8_t> &p_index_array, int p_index_count, const Rect3 &p_aabb, const Vector<PoolVector<uint8_t> > &p_blend_shapes = Vector<PoolVector<uint8_t> >(), const Vector<Rect3> &p_bone_aabbs = Vector<Rect3>());
 
 	Array surface_get_arrays(int p_surface) const;
-	virtual Array surface_get_blend_shape_arrays(int p_surface) const;
+	Array surface_get_blend_shape_arrays(int p_surface) const;
 
 	void add_blend_shape(const StringName &p_name);
 	int get_blend_shape_count() const;

--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -105,6 +105,15 @@ Array PrimitiveMesh::surface_get_arrays(int p_surface) const {
 	return VisualServer::get_singleton()->mesh_surface_get_arrays(mesh, 0);
 }
 
+Array PrimitiveMesh::surface_get_blend_shape_arrays(int p_surface) const {
+	ERR_FAIL_INDEX_V(p_surface, 1, Array());
+	if (pending_request) {
+		_update();
+	}
+
+	return Array();
+}
+
 uint32_t PrimitiveMesh::surface_get_format(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, 1, 0);
 	if (pending_request) {
@@ -119,6 +128,8 @@ Mesh::PrimitiveType PrimitiveMesh::surface_get_primitive_type(int p_idx) const {
 }
 
 Ref<Material> PrimitiveMesh::surface_get_material(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, 1, NULL);
+
 	return material;
 }
 
@@ -151,6 +162,8 @@ void PrimitiveMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_material", "material"), &PrimitiveMesh::set_material);
 	ClassDB::bind_method(D_METHOD("get_material"), &PrimitiveMesh::get_material);
 
+	ClassDB::bind_method(D_METHOD("get_mesh_arrays"), &PrimitiveMesh::get_mesh_arrays);
+
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "Material"), "set_material", "get_material");
 }
 
@@ -166,6 +179,10 @@ void PrimitiveMesh::set_material(const Ref<Material> &p_material) {
 
 Ref<Material> PrimitiveMesh::get_material() const {
 	return material;
+}
+
+Array PrimitiveMesh::get_mesh_arrays() const {
+	return surface_get_arrays(0);
 }
 
 PrimitiveMesh::PrimitiveMesh() {

--- a/scene/resources/primitive_meshes.h
+++ b/scene/resources/primitive_meshes.h
@@ -67,6 +67,7 @@ public:
 	virtual int surface_get_array_len(int p_idx) const;
 	virtual int surface_get_array_index_len(int p_idx) const;
 	virtual Array surface_get_arrays(int p_surface) const;
+	virtual Array surface_get_blend_shape_arrays(int p_surface) const;
 	virtual uint32_t surface_get_format(int p_idx) const;
 	virtual Mesh::PrimitiveType surface_get_primitive_type(int p_idx) const;
 	virtual Ref<Material> surface_get_material(int p_idx) const;
@@ -77,6 +78,8 @@ public:
 
 	void set_material(const Ref<Material> &p_material);
 	Ref<Material> get_material() const;
+
+	Array get_mesh_arrays() const;
 
 	PrimitiveMesh();
 	~PrimitiveMesh();

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1420,6 +1420,29 @@ Array VisualServer::mesh_surface_get_arrays(RID p_mesh, int p_surface) const {
 	return _get_array_from_surface(format, vertex_data, vertex_len, index_data, index_len);
 }
 
+Array VisualServer::mesh_surface_get_blend_shape_arrays(RID p_mesh, int p_surface) const {
+
+	Vector<PoolVector<uint8_t> > blend_shape_data = mesh_surface_get_blend_shapes(p_mesh, p_surface);
+	if (blend_shape_data.size() > 0) {
+		int vertex_len = mesh_surface_get_array_len(p_mesh, p_surface);
+
+		PoolVector<uint8_t> index_data = mesh_surface_get_index_array(p_mesh, p_surface);
+		int index_len = mesh_surface_get_array_index_len(p_mesh, p_surface);
+
+		uint32_t format = mesh_surface_get_format(p_mesh, p_surface);
+
+		Array blend_shape_array;
+		blend_shape_array.resize(blend_shape_data.size());
+		for (int i = 0; i < blend_shape_data.size(); i++) {
+			blend_shape_array.set(i, _get_array_from_surface(format, blend_shape_data[i], vertex_len, index_data, index_len));
+		}
+
+		return blend_shape_array;
+	} else {
+		return Array();
+	}
+}
+
 void VisualServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("force_draw"), &VisualServer::draw);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -267,6 +267,7 @@ public:
 	virtual PoolVector<uint8_t> mesh_surface_get_index_array(RID p_mesh, int p_surface) const = 0;
 
 	virtual Array mesh_surface_get_arrays(RID p_mesh, int p_surface) const;
+	virtual Array mesh_surface_get_blend_shape_arrays(RID p_mesh, int p_surface) const;
 
 	virtual uint32_t mesh_surface_get_format(RID p_mesh, int p_surface) const = 0;
 	virtual PrimitiveType mesh_surface_get_primitive_type(RID p_mesh, int p_surface) const = 0;


### PR DESCRIPTION
Restores ability to access mesh vertex data in a set of arrays separated by type in scripts. I was using this for a custom tool to modify and combine meshes with blend shapes, more advanced than the inbuilt tools, but since the Mesh API had changed, there was no exposed method for accessing the data in this usable form. It likewise also adds a method to the PrimitiveMesh type to access its mesh data in the same form.