### PR TITLE
Rename pos/rot/loc/scl

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -1033,10 +1033,8 @@ void _OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_time", "utc"), &_OS::get_time, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_time_zone_info"), &_OS::get_time_zone_info);
 	ClassDB::bind_method(D_METHOD("get_unix_time"), &_OS::get_unix_time);
-	ClassDB::bind_method(D_METHOD("get_datetime_from_unix_time", "unix_time_val"),
-			&_OS::get_datetime_from_unix_time);
-	ClassDB::bind_method(D_METHOD("get_unix_time_from_datetime", "datetime"),
-			&_OS::get_unix_time_from_datetime);
+	ClassDB::bind_method(D_METHOD("get_datetime_from_unix_time", "unix_time_val"), &_OS::get_datetime_from_unix_time);
+	ClassDB::bind_method(D_METHOD("get_unix_time_from_datetime", "datetime"), &_OS::get_unix_time_from_datetime);
 	ClassDB::bind_method(D_METHOD("get_system_time_secs"), &_OS::get_system_time_secs);
 
 	ClassDB::bind_method(D_METHOD("set_icon", "icon"), &_OS::set_icon);
@@ -1337,7 +1335,7 @@ void _Geometry::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("build_box_planes", "extents"), &_Geometry::build_box_planes);
 	ClassDB::bind_method(D_METHOD("build_cylinder_planes", "radius", "height", "sides", "axis"), &_Geometry::build_cylinder_planes, DEFVAL(Vector3::AXIS_Z));
 	ClassDB::bind_method(D_METHOD("build_capsule_planes", "radius", "height", "sides", "lats", "axis"), &_Geometry::build_capsule_planes, DEFVAL(Vector3::AXIS_Z));
-	ClassDB::bind_method(D_METHOD("segment_intersects_circle", "segment_from", "segment_to", "circle_pos", "circle_radius"), &_Geometry::segment_intersects_circle);
+	ClassDB::bind_method(D_METHOD("segment_intersects_circle", "segment_from", "segment_to", "circle_position", "circle_radius"), &_Geometry::segment_intersects_circle);
 	ClassDB::bind_method(D_METHOD("segment_intersects_segment_2d", "from_a", "to_a", "from_b", "to_b"), &_Geometry::segment_intersects_segment_2d);
 
 	ClassDB::bind_method(D_METHOD("get_closest_points_between_segments_2d", "p1", "q1", "p2", "q2"), &_Geometry::get_closest_points_between_segments_2d);
@@ -1353,7 +1351,7 @@ void _Geometry::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("ray_intersects_triangle", "from", "dir", "a", "b", "c"), &_Geometry::ray_intersects_triangle);
 	ClassDB::bind_method(D_METHOD("segment_intersects_triangle", "from", "to", "a", "b", "c"), &_Geometry::segment_intersects_triangle);
-	ClassDB::bind_method(D_METHOD("segment_intersects_sphere", "from", "to", "spos", "sradius"), &_Geometry::segment_intersects_sphere);
+	ClassDB::bind_method(D_METHOD("segment_intersects_sphere", "from", "to", "sphere_position", "sphere_radius"), &_Geometry::segment_intersects_sphere);
 	ClassDB::bind_method(D_METHOD("segment_intersects_cylinder", "from", "to", "height", "radius"), &_Geometry::segment_intersects_cylinder);
 	ClassDB::bind_method(D_METHOD("segment_intersects_convex", "from", "to", "planes"), &_Geometry::segment_intersects_convex);
 	ClassDB::bind_method(D_METHOD("point_is_inside_triangle", "point", "a", "b", "c"), &_Geometry::point_is_inside_triangle);
@@ -1452,10 +1450,10 @@ void _File::seek_end(int64_t p_position) {
 	ERR_FAIL_COND(!f);
 	f->seek_end(p_position);
 }
-int64_t _File::get_pos() const {
+int64_t _File::get_position() const {
 
 	ERR_FAIL_COND_V(!f, 0);
-	return f->get_pos();
+	return f->get_position();
 }
 
 int64_t _File::get_len() const {
@@ -1534,7 +1532,7 @@ String _File::get_as_text() const {
 	ERR_FAIL_COND_V(!f, String());
 
 	String text;
-	size_t original_pos = f->get_pos();
+	size_t original_pos = f->get_position();
 	f->seek(0);
 
 	String l = get_line();
@@ -1731,9 +1729,9 @@ void _File::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("open", "path", "flags"), &_File::open);
 	ClassDB::bind_method(D_METHOD("close"), &_File::close);
 	ClassDB::bind_method(D_METHOD("is_open"), &_File::is_open);
-	ClassDB::bind_method(D_METHOD("seek", "pos"), &_File::seek);
-	ClassDB::bind_method(D_METHOD("seek_end", "pos"), &_File::seek_end, DEFVAL(0));
-	ClassDB::bind_method(D_METHOD("get_pos"), &_File::get_pos);
+	ClassDB::bind_method(D_METHOD("seek", "position"), &_File::seek);
+	ClassDB::bind_method(D_METHOD("seek_end", "position"), &_File::seek_end, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_position"), &_File::get_position);
 	ClassDB::bind_method(D_METHOD("get_len"), &_File::get_len);
 	ClassDB::bind_method(D_METHOD("eof_reached"), &_File::eof_reached);
 	ClassDB::bind_method(D_METHOD("get_8"), &_File::get_8);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -399,7 +399,7 @@ public:
 
 	void seek(int64_t p_position); ///< seek to a given position
 	void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	int64_t get_pos() const; ///< get position in the file
+	int64_t get_position() const; ///< get position in the file
 	int64_t get_len() const; ///< get size of the file
 
 	bool eof_reached() const; ///< reading passed EOF

--- a/core/io/file_access_buffered.cpp
+++ b/core/io/file_access_buffered.cpp
@@ -76,7 +76,7 @@ void FileAccessBuffered::seek_end(int64_t p_position) {
 	file.offset = file.size + p_position;
 };
 
-size_t FileAccessBuffered::get_pos() const {
+size_t FileAccessBuffered::get_position() const {
 
 	return file.offset;
 };

--- a/core/io/file_access_buffered.h
+++ b/core/io/file_access_buffered.h
@@ -72,7 +72,7 @@ protected:
 	int get_cache_size();
 
 public:
-	virtual size_t get_pos() const; ///< get position in the file
+	virtual size_t get_position() const; ///< get position in the file
 	virtual size_t get_len() const; ///< get size of the file
 
 	virtual void seek(size_t p_position); ///< seek to a given position

--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -62,7 +62,7 @@ Error FileAccessCompressed::open_after_magic(FileAccess *p_base) {
 	block_size = f->get_32();
 	read_total = f->get_32();
 	int bc = (read_total / block_size) + 1;
-	int acc_ofs = f->get_pos() + bc * 4;
+	int acc_ofs = f->get_position() + bc * 4;
 	int max_bs = 0;
 	for (int i = 0; i < bc; i++) {
 
@@ -232,7 +232,7 @@ void FileAccessCompressed::seek_end(int64_t p_position) {
 		seek(read_total + p_position);
 	}
 }
-size_t FileAccessCompressed::get_pos() const {
+size_t FileAccessCompressed::get_position() const {
 
 	ERR_FAIL_COND_V(!f, 0);
 	if (writing) {

--- a/core/io/file_access_compressed.h
+++ b/core/io/file_access_compressed.h
@@ -74,7 +74,7 @@ public:
 
 	virtual void seek(size_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_pos() const; ///< get position in the file
+	virtual size_t get_position() const; ///< get position in the file
 	virtual size_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF

--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -71,7 +71,7 @@ Error FileAccessEncrypted::open_and_parse(FileAccess *p_base, const Vector<uint8
 		unsigned char md5d[16];
 		p_base->get_buffer(md5d, 16);
 		length = p_base->get_64();
-		base = p_base->get_pos();
+		base = p_base->get_position();
 		ERR_FAIL_COND_V(p_base->get_len() < base + length, ERR_FILE_CORRUPT);
 		uint32_t ds = length;
 		if (ds % 16) {
@@ -199,7 +199,7 @@ void FileAccessEncrypted::seek_end(int64_t p_position) {
 
 	seek(data.size() + p_position);
 }
-size_t FileAccessEncrypted::get_pos() const {
+size_t FileAccessEncrypted::get_position() const {
 
 	return pos;
 }

--- a/core/io/file_access_encrypted.h
+++ b/core/io/file_access_encrypted.h
@@ -61,7 +61,7 @@ public:
 
 	virtual void seek(size_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_pos() const; ///< get position in the file
+	virtual size_t get_position() const; ///< get position in the file
 	virtual size_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF

--- a/core/io/file_access_memory.cpp
+++ b/core/io/file_access_memory.cpp
@@ -120,7 +120,7 @@ void FileAccessMemory::seek_end(int64_t p_position) {
 	pos = length + p_position;
 }
 
-size_t FileAccessMemory::get_pos() const {
+size_t FileAccessMemory::get_position() const {
 
 	ERR_FAIL_COND_V(!data, 0);
 	return pos;

--- a/core/io/file_access_memory.h
+++ b/core/io/file_access_memory.h
@@ -51,7 +51,7 @@ public:
 
 	virtual void seek(size_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position); ///< seek from the end of file
-	virtual size_t get_pos() const; ///< get position in the file
+	virtual size_t get_position() const; ///< get position in the file
 	virtual size_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF

--- a/core/io/file_access_network.cpp
+++ b/core/io/file_access_network.cpp
@@ -350,7 +350,7 @@ void FileAccessNetwork::seek_end(int64_t p_position) {
 
 	seek(total_size + p_position);
 }
-size_t FileAccessNetwork::get_pos() const {
+size_t FileAccessNetwork::get_position() const {
 
 	ERR_FAIL_COND_V(!opened, 0);
 	return pos;

--- a/core/io/file_access_network.h
+++ b/core/io/file_access_network.h
@@ -145,7 +145,7 @@ public:
 
 	virtual void seek(size_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_pos() const; ///< get position in the file
+	virtual size_t get_position() const; ///< get position in the file
 	virtual size_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -140,17 +140,17 @@ bool PackedSourcePCK::try_open_pack(const String &p_path) {
 	if (magic != 0x43504447) {
 		//maybe at he end.... self contained exe
 		f->seek_end();
-		f->seek(f->get_pos() - 4);
+		f->seek(f->get_position() - 4);
 		magic = f->get_32();
 		if (magic != 0x43504447) {
 
 			memdelete(f);
 			return false;
 		}
-		f->seek(f->get_pos() - 12);
+		f->seek(f->get_position() - 12);
 
 		uint64_t ds = f->get_64();
-		f->seek(f->get_pos() - ds - 8);
+		f->seek(f->get_position() - ds - 8);
 
 		magic = f->get_32();
 		if (magic != 0x43504447) {
@@ -236,7 +236,7 @@ void FileAccessPack::seek_end(int64_t p_position) {
 
 	seek(pf.size + p_position);
 }
-size_t FileAccessPack::get_pos() const {
+size_t FileAccessPack::get_position() const {
 
 	return pos;
 }

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -148,7 +148,7 @@ public:
 
 	virtual void seek(size_t p_position);
 	virtual void seek_end(int64_t p_position = 0);
-	virtual size_t get_pos() const;
+	virtual size_t get_position() const;
 	virtual size_t get_len() const;
 
 	virtual bool eof_reached() const;

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -65,7 +65,7 @@ static uLong godot_write(voidpf opaque, voidpf stream, const void *buf, uLong si
 static long godot_tell(voidpf opaque, voidpf stream) {
 
 	FileAccess *f = (FileAccess *)opaque;
-	return f->get_pos();
+	return f->get_position();
 };
 
 static long godot_seek(voidpf opaque, voidpf stream, uLong offset, int origin) {
@@ -76,7 +76,7 @@ static long godot_seek(voidpf opaque, voidpf stream, uLong offset, int origin) {
 	switch (origin) {
 
 		case ZLIB_FILEFUNC_SEEK_CUR:
-			pos = f->get_pos() + offset;
+			pos = f->get_position() + offset;
 			break;
 		case ZLIB_FILEFUNC_SEEK_END:
 			pos = f->get_len() + offset;
@@ -301,7 +301,7 @@ void FileAccessZip::seek_end(int64_t p_position) {
 	unzSeekCurrentFile(zfile, get_len() + p_position);
 };
 
-size_t FileAccessZip::get_pos() const {
+size_t FileAccessZip::get_position() const {
 
 	ERR_FAIL_COND_V(!zfile, 0);
 	return unztell(zfile);

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -98,7 +98,7 @@ public:
 
 	virtual void seek(size_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_pos() const; ///< get position in the file
+	virtual size_t get_position() const; ///< get position in the file
 	virtual size_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF

--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -119,7 +119,7 @@ Error PCKPacker::flush(bool p_verbose) {
 	for (int i = 0; i < files.size(); i++) {
 
 		file->store_pascal_string(files[i].path);
-		files[i].offset_offset = file->get_pos();
+		files[i].offset_offset = file->get_position();
 		file->store_64(0); // offset
 		file->store_64(files[i].size); // size
 
@@ -130,10 +130,10 @@ Error PCKPacker::flush(bool p_verbose) {
 		file->store_32(0);
 	};
 
-	uint64_t ofs = file->get_pos();
+	uint64_t ofs = file->get_position();
 	ofs = _align(ofs, alignment);
 
-	_pad(file, ofs - file->get_pos());
+	_pad(file, ofs - file->get_position());
 
 	const uint32_t buf_max = 65536;
 	uint8_t *buf = memnew_arr(uint8_t, buf_max);
@@ -150,7 +150,7 @@ Error PCKPacker::flush(bool p_verbose) {
 			to_write -= read;
 		};
 
-		uint64_t pos = file->get_pos();
+		uint64_t pos = file->get_position();
 		file->seek(files[i].offset_offset); // go back to store the file's offset
 		file->store_64(ofs);
 		file->seek(pos);

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1179,7 +1179,7 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 
 	save_ustring(fw, get_ustring(f)); //type
 
-	size_t md_ofs = f->get_pos();
+	size_t md_ofs = f->get_position();
 	size_t importmd_ofs = f->get_64();
 	fw->store_64(0); //metadata offset
 
@@ -1227,7 +1227,7 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 		save_ustring(fw, path);
 	}
 
-	int64_t size_diff = (int64_t)fw->get_pos() - (int64_t)f->get_pos();
+	int64_t size_diff = (int64_t)fw->get_position() - (int64_t)f->get_position();
 
 	//internal resources
 	uint32_t int_resources_size = f->get_32();
@@ -1880,7 +1880,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const RES &p
 		} else {
 			save_unicode_string(r->get_path()); //actual external
 		}
-		ofs_pos.push_back(f->get_pos());
+		ofs_pos.push_back(f->get_position());
 		f->store_64(0); //offset in 64 bits
 	}
 
@@ -1891,7 +1891,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const RES &p
 
 		ResourceData &rd = E->get();
 
-		ofs_table.push_back(f->get_pos());
+		ofs_table.push_back(f->get_position());
 		save_unicode_string(rd.type);
 		f->store_32(rd.properties.size());
 

--- a/core/io/stream_peer.cpp
+++ b/core/io/stream_peer.cpp
@@ -405,9 +405,9 @@ void StreamPeer::_bind_methods() {
 
 void StreamPeerBuffer::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("seek", "pos"), &StreamPeerBuffer::seek);
+	ClassDB::bind_method(D_METHOD("seek", "position"), &StreamPeerBuffer::seek);
 	ClassDB::bind_method(D_METHOD("get_size"), &StreamPeerBuffer::get_size);
-	ClassDB::bind_method(D_METHOD("get_pos"), &StreamPeerBuffer::get_pos);
+	ClassDB::bind_method(D_METHOD("get_position"), &StreamPeerBuffer::get_position);
 	ClassDB::bind_method(D_METHOD("resize", "size"), &StreamPeerBuffer::resize);
 	ClassDB::bind_method(D_METHOD("set_data_array", "data"), &StreamPeerBuffer::set_data_array);
 	ClassDB::bind_method(D_METHOD("get_data_array"), &StreamPeerBuffer::get_data_array);
@@ -484,7 +484,7 @@ int StreamPeerBuffer::get_size() const {
 	return data.size();
 }
 
-int StreamPeerBuffer::get_pos() const {
+int StreamPeerBuffer::get_position() const {
 
 	return pointer;
 }

--- a/core/io/stream_peer.h
+++ b/core/io/stream_peer.h
@@ -111,7 +111,7 @@ public:
 
 	void seek(int p_pos);
 	int get_size() const;
-	int get_pos() const;
+	int get_position() const;
 	void resize(int p_size);
 
 	void set_data_array(const PoolVector<uint8_t> &p_data);

--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -369,7 +369,7 @@ void XMLParser::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_empty"), &XMLParser::is_empty);
 	ClassDB::bind_method(D_METHOD("get_current_line"), &XMLParser::get_current_line);
 	ClassDB::bind_method(D_METHOD("skip_section"), &XMLParser::skip_section);
-	ClassDB::bind_method(D_METHOD("seek", "pos"), &XMLParser::seek);
+	ClassDB::bind_method(D_METHOD("seek", "position"), &XMLParser::seek);
 	ClassDB::bind_method(D_METHOD("open", "file"), &XMLParser::open);
 	ClassDB::bind_method(D_METHOD("open_buffer", "buffer"), &XMLParser::open_buffer);
 

--- a/core/io/zip_io.h
+++ b/core/io/zip_io.h
@@ -72,7 +72,7 @@ static uLong zipio_write(voidpf opaque, voidpf stream, const void *buf, uLong si
 static long zipio_tell(voidpf opaque, voidpf stream) {
 
 	FileAccess *f = *(FileAccess **)opaque;
-	return f->get_pos();
+	return f->get_position();
 };
 
 static long zipio_seek(voidpf opaque, voidpf stream, uLong offset, int origin) {
@@ -83,7 +83,7 @@ static long zipio_seek(voidpf opaque, voidpf stream, uLong offset, int origin) {
 	switch (origin) {
 
 		case ZLIB_FILEFUNC_SEEK_CUR:
-			pos = f->get_pos() + offset;
+			pos = f->get_position() + offset;
 			break;
 		case ZLIB_FILEFUNC_SEEK_END:
 			pos = f->get_len() + offset;

--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -58,7 +58,7 @@ void AStar::add_point(int p_id, const Vector3 &p_pos, real_t p_weight_scale) {
 	}
 }
 
-Vector3 AStar::get_point_pos(int p_id) const {
+Vector3 AStar::get_point_position(int p_id) const {
 
 	ERR_FAIL_COND_V(!points.has(p_id), Vector3());
 
@@ -171,7 +171,7 @@ int AStar::get_closest_point(const Vector3 &p_point) const {
 
 	return closest_id;
 }
-Vector3 AStar::get_closest_pos_in_segment(const Vector3 &p_point) const {
+Vector3 AStar::get_closest_position_in_segment(const Vector3 &p_point) const {
 
 	real_t closest_dist = 1e20;
 	bool found = false;
@@ -412,8 +412,8 @@ PoolVector<int> AStar::get_id_path(int p_from_id, int p_to_id) {
 void AStar::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_available_point_id"), &AStar::get_available_point_id);
-	ClassDB::bind_method(D_METHOD("add_point", "id", "pos", "weight_scale"), &AStar::add_point, DEFVAL(1.0));
-	ClassDB::bind_method(D_METHOD("get_point_pos", "id"), &AStar::get_point_pos);
+	ClassDB::bind_method(D_METHOD("add_point", "id", "position", "weight_scale"), &AStar::add_point, DEFVAL(1.0));
+	ClassDB::bind_method(D_METHOD("get_point_position", "id"), &AStar::get_point_position);
 	ClassDB::bind_method(D_METHOD("get_point_weight_scale", "id"), &AStar::get_point_weight_scale);
 	ClassDB::bind_method(D_METHOD("remove_point", "id"), &AStar::remove_point);
 	ClassDB::bind_method(D_METHOD("has_point", "id"), &AStar::has_point);
@@ -425,8 +425,8 @@ void AStar::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("clear"), &AStar::clear);
 
-	ClassDB::bind_method(D_METHOD("get_closest_point", "to_pos"), &AStar::get_closest_point);
-	ClassDB::bind_method(D_METHOD("get_closest_pos_in_segment", "to_pos"), &AStar::get_closest_pos_in_segment);
+	ClassDB::bind_method(D_METHOD("get_closest_point", "to_position"), &AStar::get_closest_point);
+	ClassDB::bind_method(D_METHOD("get_closest_position_in_segment", "to_position"), &AStar::get_closest_position_in_segment);
 
 	ClassDB::bind_method(D_METHOD("get_point_path", "from_id", "to_id"), &AStar::get_point_path);
 	ClassDB::bind_method(D_METHOD("get_id_path", "from_id", "to_id"), &AStar::get_id_path);

--- a/core/math/a_star.h
+++ b/core/math/a_star.h
@@ -101,7 +101,7 @@ public:
 	int get_available_point_id() const;
 
 	void add_point(int p_id, const Vector3 &p_pos, real_t p_weight_scale = 1);
-	Vector3 get_point_pos(int p_id) const;
+	Vector3 get_point_position(int p_id) const;
 	real_t get_point_weight_scale(int p_id) const;
 	void remove_point(int p_id);
 	bool has_point(int p_id) const;
@@ -114,7 +114,7 @@ public:
 	void clear();
 
 	int get_closest_point(const Vector3 &p_point) const;
-	Vector3 get_closest_pos_in_segment(const Vector3 &p_point) const;
+	Vector3 get_closest_position_in_segment(const Vector3 &p_point) const;
 
 	PoolVector<Vector3> get_point_path(int p_from_id, int p_to_id);
 	PoolVector<int> get_id_path(int p_from_id, int p_to_id);

--- a/core/os/dir_access.cpp
+++ b/core/os/dir_access.cpp
@@ -312,7 +312,7 @@ Error DirAccess::copy(String p_from, String p_to, int chmod_flags) {
 	}
 
 	fsrc->seek_end(0);
-	int size = fsrc->get_pos();
+	int size = fsrc->get_position();
 	fsrc->seek(0);
 	err = OK;
 	while (size--) {

--- a/core/os/file_access.h
+++ b/core/os/file_access.h
@@ -90,7 +90,7 @@ public:
 
 	virtual void seek(size_t p_position) = 0; ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0) = 0; ///< seek from the end of file
-	virtual size_t get_pos() const = 0; ///< get position in the file
+	virtual size_t get_position() const = 0; ///< get position in the file
 	virtual size_t get_len() const = 0; ///< get size of the file
 
 	virtual bool eof_reached() const = 0; ///< reading passed EOF

--- a/core/os/input.cpp
+++ b/core/os/input.cpp
@@ -80,7 +80,7 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_mouse_button_mask"), &Input::get_mouse_button_mask);
 	ClassDB::bind_method(D_METHOD("set_mouse_mode", "mode"), &Input::set_mouse_mode);
 	ClassDB::bind_method(D_METHOD("get_mouse_mode"), &Input::get_mouse_mode);
-	ClassDB::bind_method(D_METHOD("warp_mouse_pos", "to"), &Input::warp_mouse_pos);
+	ClassDB::bind_method(D_METHOD("warp_mouse_position", "to"), &Input::warp_mouse_position);
 	ClassDB::bind_method(D_METHOD("action_press", "action"), &Input::action_press);
 	ClassDB::bind_method(D_METHOD("action_release", "action"), &Input::action_release);
 	ClassDB::bind_method(D_METHOD("set_custom_mouse_cursor", "image", "hotspot"), &Input::set_custom_mouse_cursor, DEFVAL(Vector2()));

--- a/core/os/input.h
+++ b/core/os/input.h
@@ -81,7 +81,7 @@ public:
 	virtual Point2 get_last_mouse_speed() const = 0;
 	virtual int get_mouse_button_mask() const = 0;
 
-	virtual void warp_mouse_pos(const Vector2 &p_to) = 0;
+	virtual void warp_mouse_position(const Vector2 &p_to) = 0;
 	virtual Point2i warp_mouse_motion(const Ref<InputEventMouseMotion> &p_motion, const Rect2 &p_rect) = 0;
 
 	virtual Vector3 get_gravity() const = 0;

--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -781,7 +781,7 @@ void InputEventScreenTouch::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_index", "index"), &InputEventScreenTouch::set_index);
 	ClassDB::bind_method(D_METHOD("get_index"), &InputEventScreenTouch::get_index);
 
-	ClassDB::bind_method(D_METHOD("set_position", "pos"), &InputEventScreenTouch::set_position);
+	ClassDB::bind_method(D_METHOD("set_position", "position"), &InputEventScreenTouch::set_position);
 	ClassDB::bind_method(D_METHOD("get_position"), &InputEventScreenTouch::get_position);
 
 	ClassDB::bind_method(D_METHOD("set_pressed", "pressed"), &InputEventScreenTouch::set_pressed);

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -156,7 +156,7 @@ public:
 	virtual void set_mouse_mode(MouseMode p_mode);
 	virtual MouseMode get_mouse_mode() const;
 
-	virtual void warp_mouse_pos(const Point2 &p_to) {}
+	virtual void warp_mouse_position(const Point2 &p_to) {}
 	virtual Point2 get_mouse_position() const = 0;
 	virtual int get_mouse_button_state() const = 0;
 	virtual void set_window_title(const String &p_title) = 0;

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -910,7 +910,7 @@ Variant ProjectSettings::property_get_revert(const String &p_name) {
 void ProjectSettings::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("has", "name"), &ProjectSettings::has);
-	ClassDB::bind_method(D_METHOD("set_order", "name", "pos"), &ProjectSettings::set_order);
+	ClassDB::bind_method(D_METHOD("set_order", "name", "position"), &ProjectSettings::set_order);
 	ClassDB::bind_method(D_METHOD("get_order", "name"), &ProjectSettings::get_order);
 	ClassDB::bind_method(D_METHOD("set_initial_value", "name", "value"), &ProjectSettings::set_initial_value);
 	ClassDB::bind_method(D_METHOD("add_property_info", "hint"), &ProjectSettings::_add_property_info_bind);

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1394,7 +1394,7 @@ void register_variant_methods() {
 	ADDFUNC2(STRING, STRING, String, format, NIL, "values", STRING, "placeholder", varray("{_}"));
 	ADDFUNC2(STRING, STRING, String, replace, STRING, "what", STRING, "forwhat", varray());
 	ADDFUNC2(STRING, STRING, String, replacen, STRING, "what", STRING, "forwhat", varray());
-	ADDFUNC2(STRING, STRING, String, insert, INT, "pos", STRING, "what", varray());
+	ADDFUNC2(STRING, STRING, String, insert, INT, "position", STRING, "what", varray());
 	ADDFUNC0(STRING, STRING, String, capitalize, varray());
 	ADDFUNC2(STRING, POOL_STRING_ARRAY, String, split, STRING, "divisor", BOOL, "allow_empty", varray(true));
 	ADDFUNC2(STRING, POOL_REAL_ARRAY, String, split_floats, STRING, "divisor", BOOL, "allow_empty", varray(true));
@@ -1402,14 +1402,14 @@ void register_variant_methods() {
 	ADDFUNC0(STRING, STRING, String, to_upper, varray());
 	ADDFUNC0(STRING, STRING, String, to_lower, varray());
 
-	ADDFUNC1(STRING, STRING, String, left, INT, "pos", varray());
-	ADDFUNC1(STRING, STRING, String, right, INT, "pos", varray());
+	ADDFUNC1(STRING, STRING, String, left, INT, "position", varray());
+	ADDFUNC1(STRING, STRING, String, right, INT, "position", varray());
 	ADDFUNC2(STRING, STRING, String, strip_edges, BOOL, "left", BOOL, "right", varray(true, true));
 	ADDFUNC0(STRING, STRING, String, get_extension, varray());
 	ADDFUNC0(STRING, STRING, String, get_basename, varray());
 	ADDFUNC1(STRING, STRING, String, plus_file, STRING, "file", varray());
 	ADDFUNC1(STRING, INT, String, ord_at, INT, "at", varray());
-	ADDFUNC2(STRING, NIL, String, erase, INT, "pos", INT, "chars", varray());
+	ADDFUNC2(STRING, NIL, String, erase, INT, "position", INT, "chars", varray());
 	ADDFUNC0(STRING, INT, String, hash, varray());
 	ADDFUNC0(STRING, STRING, String, md5_text, varray());
 	ADDFUNC0(STRING, STRING, String, sha256_text, varray());
@@ -1560,9 +1560,9 @@ void register_variant_methods() {
 	ADDFUNC1(ARRAY, NIL, Array, push_back, NIL, "value", varray());
 	ADDFUNC1(ARRAY, NIL, Array, push_front, NIL, "value", varray());
 	ADDFUNC1(ARRAY, NIL, Array, append, NIL, "value", varray());
-	ADDFUNC1(ARRAY, NIL, Array, resize, INT, "pos", varray());
-	ADDFUNC2(ARRAY, NIL, Array, insert, INT, "pos", NIL, "value", varray());
-	ADDFUNC1(ARRAY, NIL, Array, remove, INT, "pos", varray());
+	ADDFUNC1(ARRAY, NIL, Array, resize, INT, "size", varray());
+	ADDFUNC2(ARRAY, NIL, Array, insert, INT, "position", NIL, "value", varray());
+	ADDFUNC1(ARRAY, NIL, Array, remove, INT, "position", varray());
 	ADDFUNC1(ARRAY, NIL, Array, erase, NIL, "value", varray());
 	ADDFUNC0(ARRAY, NIL, Array, front, varray());
 	ADDFUNC0(ARRAY, NIL, Array, back, varray());
@@ -1728,10 +1728,10 @@ void register_variant_methods() {
 
 	_VariantCall::add_constructor(_VariantCall::Vector2_init1, Variant::VECTOR2, "x", Variant::REAL, "y", Variant::REAL);
 
-	_VariantCall::add_constructor(_VariantCall::Rect2_init1, Variant::RECT2, "pos", Variant::VECTOR2, "size", Variant::VECTOR2);
+	_VariantCall::add_constructor(_VariantCall::Rect2_init1, Variant::RECT2, "position", Variant::VECTOR2, "size", Variant::VECTOR2);
 	_VariantCall::add_constructor(_VariantCall::Rect2_init2, Variant::RECT2, "x", Variant::REAL, "y", Variant::REAL, "width", Variant::REAL, "height", Variant::REAL);
 
-	_VariantCall::add_constructor(_VariantCall::Transform2D_init2, Variant::TRANSFORM2D, "rot", Variant::REAL, "pos", Variant::VECTOR2);
+	_VariantCall::add_constructor(_VariantCall::Transform2D_init2, Variant::TRANSFORM2D, "rotation", Variant::REAL, "position", Variant::VECTOR2);
 	_VariantCall::add_constructor(_VariantCall::Transform2D_init3, Variant::TRANSFORM2D, "x_axis", Variant::VECTOR2, "y_axis", Variant::VECTOR2, "origin", Variant::VECTOR2);
 
 	_VariantCall::add_constructor(_VariantCall::Vector3_init1, Variant::VECTOR3, "x", Variant::REAL, "y", Variant::REAL, "z", Variant::REAL);
@@ -1746,7 +1746,7 @@ void register_variant_methods() {
 	_VariantCall::add_constructor(_VariantCall::Color_init1, Variant::COLOR, "r", Variant::REAL, "g", Variant::REAL, "b", Variant::REAL, "a", Variant::REAL);
 	_VariantCall::add_constructor(_VariantCall::Color_init2, Variant::COLOR, "r", Variant::REAL, "g", Variant::REAL, "b", Variant::REAL);
 
-	_VariantCall::add_constructor(_VariantCall::Rect3_init1, Variant::RECT3, "pos", Variant::VECTOR3, "size", Variant::VECTOR3);
+	_VariantCall::add_constructor(_VariantCall::Rect3_init1, Variant::RECT3, "position", Variant::VECTOR3, "size", Variant::VECTOR3);
 
 	_VariantCall::add_constructor(_VariantCall::Basis_init1, Variant::BASIS, "x_axis", Variant::VECTOR3, "y_axis", Variant::VECTOR3, "z_axis", Variant::VECTOR3);
 	_VariantCall::add_constructor(_VariantCall::Basis_init2, Variant::BASIS, "axis", Variant::VECTOR3, "phi", Variant::REAL);

--- a/doc/classes/AStar.xml
+++ b/doc/classes/AStar.xml
@@ -39,7 +39,7 @@
 			</return>
 			<argument index="0" name="id" type="int">
 			</argument>
-			<argument index="1" name="pos" type="Vector3">
+			<argument index="1" name="position" type="Vector3">
 			</argument>
 			<argument index="2" name="weight_scale" type="float" default="1.0">
 			</argument>
@@ -113,19 +113,19 @@
 		<method name="get_closest_point" qualifiers="const">
 			<return type="int">
 			</return>
-			<argument index="0" name="to_pos" type="Vector3">
+			<argument index="0" name="to_position" type="Vector3">
 			</argument>
 			<description>
-				Returns the id of the closest point to [code]to_pos[/code]. Returns -1 if there are no points in the points pool.
+				Returns the id of the closest point to [code]to_position[/code]. Returns -1 if there are no points in the points pool.
 			</description>
 		</method>
-		<method name="get_closest_pos_in_segment" qualifiers="const">
+		<method name="get_closest_position_in_segment" qualifiers="const">
 			<return type="Vector3">
 			</return>
-			<argument index="0" name="to_pos" type="Vector3">
+			<argument index="0" name="to_position" type="Vector3">
 			</argument>
 			<description>
-				Returns the closest position to [code]to_pos[/code] that resides inside a segment between two connected points.
+				Returns the closest position to [code]to_position[/code] that resides inside a segment between two connected points.
 				[codeblock]
 				var as = AStar.new()
 				
@@ -134,7 +134,7 @@
 				
 				as.connect_points(1, 2)
 				
-				var res = as.get_closest_pos_in_segment(Vector3(3,3,0)) # returns (0, 3, 0)
+				var res = as.get_closest_position_in_segment(Vector3(3,3,0)) # returns (0, 3, 0)
 				[/codeblock]
 				The result is in the segment that goes from [code]y=0[/code] to [code]y=5[/code]. It's the closest position in the segment to the given point.
 			</description>
@@ -178,7 +178,7 @@
 				Returns an array with the points that are in the path found by AStar between the given points. The array is ordered from the starting point to the ending point of the path.
 			</description>
 		</method>
-		<method name="get_point_pos" qualifiers="const">
+		<method name="get_point_position" qualifiers="const">
 			<return type="Vector3">
 			</return>
 			<argument index="0" name="id" type="int">

--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -17,7 +17,7 @@
 			</return>
 			<argument index="0" name="type" type="int" enum="Animation.TrackType">
 			</argument>
-			<argument index="1" name="at_pos" type="int" default="-1">
+			<argument index="1" name="at_position" type="int" default="-1">
 			</argument>
 			<description>
 				Add a track to the Animation. The track type must be specified as any of the values in the TYPE_* enumeration.
@@ -281,12 +281,12 @@
 				Remove a key by index in a given track.
 			</description>
 		</method>
-		<method name="track_remove_key_at_pos">
+		<method name="track_remove_key_at_position">
 			<return type="void">
 			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
-			<argument index="1" name="pos" type="float">
+			<argument index="1" name="position" type="float">
 			</argument>
 			<description>
 				Remove a key by position (seconds) in a given track.

--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -129,7 +129,7 @@
 				Get the length (in seconds) of the currently being played animation.
 			</description>
 		</method>
-		<method name="get_current_animation_pos" qualifiers="const">
+		<method name="get_current_animation_position" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
@@ -143,7 +143,7 @@
 				Return the default blend time between animations.
 			</description>
 		</method>
-		<method name="get_pos" qualifiers="const">
+		<method name="get_position" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
@@ -245,7 +245,7 @@
 		<method name="seek">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos_sec" type="float">
+			<argument index="0" name="seconds" type="float">
 			</argument>
 			<argument index="1" name="update" type="bool" default="false">
 			</argument>

--- a/doc/classes/AnimationTreePlayer.xml
+++ b/doc/classes/AnimationTreePlayer.xml
@@ -271,7 +271,7 @@
 				Return the input source for a given node input.
 			</description>
 		</method>
-		<method name="node_get_pos" qualifiers="const">
+		<method name="node_get_position" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<argument index="0" name="id" type="String">
@@ -300,12 +300,12 @@
 				Rename a node in the graph.
 			</description>
 		</method>
-		<method name="node_set_pos">
+		<method name="node_set_position">
 			<return type="void">
 			</return>
 			<argument index="0" name="id" type="String">
 			</argument>
-			<argument index="1" name="screen_pos" type="Vector2">
+			<argument index="1" name="screen_position" type="Vector2">
 			</argument>
 			<description>
 				Sets position of a node in the graph given its name and position.
@@ -531,7 +531,7 @@
 			</return>
 			<argument index="0" name="id" type="String">
 			</argument>
-			<argument index="1" name="pos_sec" type="float">
+			<argument index="1" name="seconds" type="float">
 			</argument>
 			<description>
 				Sets time seek value of a TimeSeek node given its name and value.

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -168,7 +168,7 @@
 			</description>
 		</method>
 		<method name="insert">
-			<argument index="0" name="pos" type="int">
+			<argument index="0" name="position" type="int">
 			</argument>
 			<argument index="1" name="value" type="var">
 			</argument>
@@ -206,14 +206,14 @@
 			</description>
 		</method>
 		<method name="remove">
-			<argument index="0" name="pos" type="int">
+			<argument index="0" name="position" type="int">
 			</argument>
 			<description>
 				Remove an element from the array by index.
 			</description>
 		</method>
 		<method name="resize">
-			<argument index="0" name="pos" type="int">
+			<argument index="0" name="position" type="int">
 			</argument>
 			<description>
 				Resize the array to contain a different number of elements. If the array size is smaller, elements are cleared, if bigger, new elements are Null.

--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -14,7 +14,7 @@
 		<method name="add_bus">
 			<return type="void">
 			</return>
-			<argument index="0" name="at_pos" type="int" default="-1">
+			<argument index="0" name="at_position" type="int" default="-1">
 			</argument>
 			<description>
 			</description>
@@ -26,7 +26,7 @@
 			</argument>
 			<argument index="1" name="effect" type="AudioEffect">
 			</argument>
-			<argument index="2" name="at_pos" type="int" default="-1">
+			<argument index="2" name="at_position" type="int" default="-1">
 			</argument>
 			<description>
 			</description>

--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -23,7 +23,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_pos">
+		<method name="get_position">
 			<return type="float">
 			</return>
 			<description>
@@ -56,16 +56,16 @@
 		<method name="play">
 			<return type="void">
 			</return>
-			<argument index="0" name="from_pos" type="float" default="0.0">
+			<argument index="0" name="from_position" type="float" default="0.0">
 			</argument>
 			<description>
-				Plays the audio from the given position 'from_pos', in seconds.
+				Plays the audio from the given position 'from_position', in seconds.
 			</description>
 		</method>
 		<method name="seek">
 			<return type="void">
 			</return>
-			<argument index="0" name="to_pos" type="float">
+			<argument index="0" name="to_position" type="float">
 			</argument>
 			<description>
 				Sets the position from which audio will be played, in seconds.

--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -36,7 +36,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_pos">
+		<method name="get_position">
 			<return type="float">
 			</return>
 			<description>
@@ -69,16 +69,16 @@
 		<method name="play">
 			<return type="void">
 			</return>
-			<argument index="0" name="from_pos" type="float" default="0.0">
+			<argument index="0" name="from_position" type="float" default="0.0">
 			</argument>
 			<description>
-				Plays the audio from the given position 'from_pos', in seconds.
+				Plays the audio from the given position 'from_position', in seconds.
 			</description>
 		</method>
 		<method name="seek">
 			<return type="void">
 			</return>
-			<argument index="0" name="to_pos" type="float">
+			<argument index="0" name="to_position" type="float">
 			</argument>
 			<description>
 				Sets the position from which audio will be played, in seconds.

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -78,7 +78,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_pos">
+		<method name="get_position">
 			<return type="float">
 			</return>
 			<description>
@@ -123,16 +123,16 @@
 		<method name="play">
 			<return type="void">
 			</return>
-			<argument index="0" name="from_pos" type="float" default="0.0">
+			<argument index="0" name="from_position" type="float" default="0.0">
 			</argument>
 			<description>
-				Plays the audio from the given position 'from_pos', in seconds.
+				Plays the audio from the given position 'from_position', in seconds.
 			</description>
 		</method>
 		<method name="seek">
 			<return type="void">
 			</return>
-			<argument index="0" name="to_pos" type="float">
+			<argument index="0" name="to_position" type="float">
 			</argument>
 			<description>
 				Sets the position from which audio will be played, in seconds.

--- a/doc/classes/BitMap.xml
+++ b/doc/classes/BitMap.xml
@@ -32,7 +32,7 @@
 		<method name="get_bit" qualifiers="const">
 			<return type="bool">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<description>
 				Returns bitmap's value at the specified position.
@@ -55,7 +55,7 @@
 		<method name="set_bit">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<argument index="1" name="bit" type="bool">
 			</argument>

--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -38,7 +38,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_camera_pos" qualifiers="const">
+		<method name="get_camera_position" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<description>

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -27,7 +27,7 @@
 			</return>
 			<argument index="0" name="font" type="Font">
 			</argument>
-			<argument index="1" name="pos" type="Vector2">
+			<argument index="1" name="position" type="Vector2">
 			</argument>
 			<argument index="2" name="char" type="String">
 			</argument>
@@ -42,7 +42,7 @@
 		<method name="draw_circle">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<argument index="1" name="radius" type="float">
 			</argument>
@@ -170,7 +170,7 @@
 		<method name="draw_set_transform">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<argument index="1" name="rot" type="float">
 			</argument>
@@ -193,7 +193,7 @@
 			</return>
 			<argument index="0" name="font" type="Font">
 			</argument>
-			<argument index="1" name="pos" type="Vector2">
+			<argument index="1" name="position" type="Vector2">
 			</argument>
 			<argument index="2" name="text" type="String">
 			</argument>
@@ -221,7 +221,7 @@
 			</return>
 			<argument index="0" name="texture" type="Texture">
 			</argument>
-			<argument index="1" name="pos" type="Vector2">
+			<argument index="1" name="position" type="Vector2">
 			</argument>
 			<argument index="2" name="modulate" type="Color" default="Color( 1, 1, 1, 1 )">
 			</argument>
@@ -367,7 +367,7 @@
 				Get this item's light mask number.
 			</description>
 		</method>
-		<method name="get_local_mouse_pos" qualifiers="const">
+		<method name="get_local_mouse_position" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<description>
@@ -476,7 +476,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="make_canvas_pos_local" qualifiers="const">
+		<method name="make_canvas_position_local" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<argument index="0" name="screen_point" type="Vector2">

--- a/doc/classes/CollisionObject.xml
+++ b/doc/classes/CollisionObject.xml
@@ -16,7 +16,7 @@
 			</argument>
 			<argument index="1" name="event" type="InputEvent">
 			</argument>
-			<argument index="2" name="click_pos" type="Vector3">
+			<argument index="2" name="click_position" type="Vector3">
 			</argument>
 			<argument index="3" name="click_normal" type="Vector3">
 			</argument>
@@ -209,7 +209,7 @@
 			</argument>
 			<argument index="1" name="event" type="Object">
 			</argument>
-			<argument index="2" name="click_pos" type="Vector3">
+			<argument index="2" name="click_position" type="Vector3">
 			</argument>
 			<argument index="3" name="click_normal" type="Vector3">
 			</argument>

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -106,7 +106,7 @@
 		<method name="can_drop_data" qualifiers="virtual">
 			<return type="bool">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<argument index="1" name="data" type="Variant">
 			</argument>
@@ -116,7 +116,7 @@
 		<method name="drop_data" qualifiers="virtual">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<argument index="1" name="data" type="Variant">
 			</argument>
@@ -177,7 +177,7 @@
 		<method name="get_cursor_shape" qualifiers="const">
 			<return type="int" enum="Control.CursorShape">
 			</return>
-			<argument index="0" name="pos" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="0" name="position" type="Vector2" default="Vector2( 0, 0 )">
 			</argument>
 			<description>
 				Return the cursor shape at a certain position in the control.
@@ -199,7 +199,7 @@
 		<method name="get_drag_data" qualifiers="virtual">
 			<return type="Object">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<description>
 			</description>
@@ -390,7 +390,7 @@
 		<method name="get_tooltip" qualifiers="const">
 			<return type="String">
 			</return>
-			<argument index="0" name="atpos" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="0" name="at_position" type="Vector2" default="Vector2( 0, 0 )">
 			</argument>
 			<description>
 				Return the tooltip, which will appear when the cursor is resting over this control.
@@ -596,7 +596,7 @@
 		<method name="set_begin">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<description>
 				Sets MARGIN_LEFT and MARGIN_TOP at the same time. This is a helper (see [method set_margin]).
@@ -646,7 +646,7 @@
 		<method name="set_end">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<description>
 				Sets MARGIN_RIGHT and MARGIN_BOTTOM at the same time. This is a helper (see [method set_margin]).
@@ -675,7 +675,7 @@
 		<method name="set_global_position">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<description>
 				Move the Control to a new position, relative to the top-left corner of the [i]window[/i] Control, and without changing current anchor mode. (see [method set_margin]).
@@ -729,7 +729,7 @@
 		<method name="set_position">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<description>
 				Move the Control to a new position, relative to the top-left corner of the parent Control, changing all margins if needed and without changing current anchor mode. This is a helper (see [method set_margin]).
@@ -826,7 +826,7 @@
 		<method name="warp_mouse">
 			<return type="void">
 			</return>
-			<argument index="0" name="to_pos" type="Vector2">
+			<argument index="0" name="to_position" type="Vector2">
 			</argument>
 			<description>
 			</description>

--- a/doc/classes/Curve.xml
+++ b/doc/classes/Curve.xml
@@ -12,7 +12,7 @@
 		<method name="add_point">
 			<return type="int">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<argument index="1" name="left_tangent" type="float" default="0">
 			</argument>
@@ -77,7 +77,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_point_pos" qualifiers="const">
+		<method name="get_point_position" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<argument index="0" name="index" type="int">

--- a/doc/classes/Curve2D.xml
+++ b/doc/classes/Curve2D.xml
@@ -15,17 +15,17 @@
 		<method name="add_point">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<argument index="1" name="in" type="Vector2" default="Vector2( 0, 0 )">
 			</argument>
 			<argument index="2" name="out" type="Vector2" default="Vector2( 0, 0 )">
 			</argument>
-			<argument index="3" name="atpos" type="int" default="-1">
+			<argument index="3" name="at_position" type="int" default="-1">
 			</argument>
 			<description>
-				Adds a point to a curve, at position "pos", with control points "in" and "out".
-				If "atpos" is given, the point is inserted before the point number "atpos", moving that point (and every point after) after the inserted point. If "atpos" is not given, or is an illegal value (atpos &lt;0 or atpos &gt;= [method get_point_count]), the point will be appended at the end of the point list.
+				Adds a point to a curve, at "position", with control points "in" and "out".
+				If "at_position" is given, the point is inserted before the point number "at_position", moving that point (and every point after) after the inserted point. If "at_position" is not given, or is an illegal value (at_position &lt;0 or at_position &gt;= [method get_point_count]), the point will be appended at the end of the point list.
 			</description>
 		</method>
 		<method name="clear_points">
@@ -80,7 +80,7 @@
 				Returns the position of the control point leading out of the vertex "idx". If the index is out of bounds, the function sends an error to the console, and returns (0, 0).
 			</description>
 		</method>
-		<method name="get_point_pos" qualifiers="const">
+		<method name="get_point_position" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<argument index="0" name="idx" type="int">
@@ -146,7 +146,7 @@
 			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
-			<argument index="1" name="pos" type="Vector2">
+			<argument index="1" name="position" type="Vector2">
 			</argument>
 			<description>
 				Sets the position of the control point leading to the vertex "idx". If the index is out of bounds, the function sends an error to the console.
@@ -157,18 +157,18 @@
 			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
-			<argument index="1" name="pos" type="Vector2">
+			<argument index="1" name="position" type="Vector2">
 			</argument>
 			<description>
 				Sets the position of the control point leading out of the vertex "idx". If the index is out of bounds, the function sends an error to the console.
 			</description>
 		</method>
-		<method name="set_point_pos">
+		<method name="set_point_position">
 			<return type="void">
 			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
-			<argument index="1" name="pos" type="Vector2">
+			<argument index="1" name="position" type="Vector2">
 			</argument>
 			<description>
 				Sets the position for the vertex "idx". If the index is out of bounds, the function sends an error to the console.

--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -15,17 +15,17 @@
 		<method name="add_point">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos" type="Vector3">
+			<argument index="0" name="position" type="Vector3">
 			</argument>
 			<argument index="1" name="in" type="Vector3" default="Vector3( 0, 0, 0 )">
 			</argument>
 			<argument index="2" name="out" type="Vector3" default="Vector3( 0, 0, 0 )">
 			</argument>
-			<argument index="3" name="atpos" type="int" default="-1">
+			<argument index="3" name="at_position" type="int" default="-1">
 			</argument>
 			<description>
-				Adds a point to a curve, at position "pos", with control points "in" and "out".
-				If "atpos" is given, the point is inserted before the point number "atpos", moving that point (and every point after) after the inserted point. If "atpos" is not given, or is an illegal value (atpos &lt;0 or atpos &gt;= [method get_point_count]), the point will be appended at the end of the point list.
+				Adds a point to a curve, at "position", with control points "in" and "out".
+				If "at_position" is given, the point is inserted before the point number "at_position", moving that point (and every point after) after the inserted point. If "at_position" is not given, or is an illegal value (at_position &lt;0 or at_position &gt;= [method get_point_count]), the point will be appended at the end of the point list.
 			</description>
 		</method>
 		<method name="clear_points">
@@ -87,7 +87,7 @@
 				Returns the position of the control point leading out of the vertex "idx". If the index is out of bounds, the function sends an error to the console, and returns (0, 0, 0).
 			</description>
 		</method>
-		<method name="get_point_pos" qualifiers="const">
+		<method name="get_point_position" qualifiers="const">
 			<return type="Vector3">
 			</return>
 			<argument index="0" name="idx" type="int">
@@ -162,7 +162,7 @@
 			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
-			<argument index="1" name="pos" type="Vector3">
+			<argument index="1" name="position" type="Vector3">
 			</argument>
 			<description>
 				Sets the position of the control point leading to the vertex "idx". If the index is out of bounds, the function sends an error to the console.
@@ -173,18 +173,18 @@
 			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
-			<argument index="1" name="pos" type="Vector3">
+			<argument index="1" name="position" type="Vector3">
 			</argument>
 			<description>
 				Sets the position of the control point leading out of the vertex "idx". If the index is out of bounds, the function sends an error to the console.
 			</description>
 		</method>
-		<method name="set_point_pos">
+		<method name="set_point_position">
 			<return type="void">
 			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
-			<argument index="1" name="pos" type="Vector3">
+			<argument index="1" name="position" type="Vector3">
 			</argument>
 			<description>
 				Sets the position for the vertex "idx". If the index is out of bounds, the function sends an error to the console.

--- a/doc/classes/File.xml
+++ b/doc/classes/File.xml
@@ -168,7 +168,7 @@
 				Get a [String] saved in Pascal format from the file.
 			</description>
 		</method>
-		<method name="get_pos" qualifiers="const">
+		<method name="get_position" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
@@ -258,7 +258,7 @@
 		<method name="seek">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos" type="int">
+			<argument index="0" name="position" type="int">
 			</argument>
 			<description>
 				Change the file reading/writing cursor to the specified position (in bytes from the beginning of the file).
@@ -267,7 +267,7 @@
 		<method name="seek_end">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos" type="int" default="0">
+			<argument index="0" name="position" type="int" default="0">
 			</argument>
 			<description>
 				Change the file reading/writing cursor to the specified position (in bytes from the end of the file). Note that this is an offset, so you should use negative numbers or the cursor will be at the end of the file.

--- a/doc/classes/Font.xml
+++ b/doc/classes/Font.xml
@@ -16,7 +16,7 @@
 			</return>
 			<argument index="0" name="canvas_item" type="RID">
 			</argument>
-			<argument index="1" name="pos" type="Vector2">
+			<argument index="1" name="position" type="Vector2">
 			</argument>
 			<argument index="2" name="string" type="String">
 			</argument>
@@ -25,7 +25,7 @@
 			<argument index="4" name="clip_w" type="int" default="-1">
 			</argument>
 			<description>
-				Draw "string" into a canvas item using the font at a given "pos" position, with "modulate" color, and optionally clipping the width. "pos" specifies the baseline, not the top. To draw from the top, [i]ascent[/i] must be added to the Y axis.
+				Draw "string" into a canvas item using the font at a given position, with "modulate" color, and optionally clipping the width. "position" specifies the baseline, not the top. To draw from the top, [i]ascent[/i] must be added to the Y axis.
 			</description>
 		</method>
 		<method name="draw_char" qualifiers="const">
@@ -33,7 +33,7 @@
 			</return>
 			<argument index="0" name="canvas_item" type="RID">
 			</argument>
-			<argument index="1" name="pos" type="Vector2">
+			<argument index="1" name="position" type="Vector2">
 			</argument>
 			<argument index="2" name="char" type="int">
 			</argument>
@@ -42,7 +42,7 @@
 			<argument index="4" name="modulate" type="Color" default="Color( 1, 1, 1, 1 )">
 			</argument>
 			<description>
-				Draw character "char" into a canvas item using the font at a given "pos" position, with "modulate" color, and optionally kerning if "next" is passed. clipping the width. "pos" specifies the baseline, not the top. To draw from the top, [i]ascent[/i] must be added to the Y axis. The width used by the character is returned, making this function useful for drawing strings character by character.
+				Draw character "char" into a canvas item using the font at a given position, with "modulate" color, and optionally kerning if "next" is passed. clipping the width. "position" specifies the baseline, not the top. To draw from the top, [i]ascent[/i] must be added to the Y axis. The width used by the character is returned, making this function useful for drawing strings character by character.
 			</description>
 		</method>
 		<method name="get_ascent" qualifiers="const">

--- a/doc/classes/Geometry.xml
+++ b/doc/classes/Geometry.xml
@@ -176,7 +176,7 @@
 			</argument>
 			<argument index="1" name="segment_to" type="Vector2">
 			</argument>
-			<argument index="2" name="circle_pos" type="Vector2">
+			<argument index="2" name="circle_position" type="Vector2">
 			</argument>
 			<argument index="3" name="circle_radius" type="float">
 			</argument>
@@ -230,9 +230,9 @@
 			</argument>
 			<argument index="1" name="to" type="Vector3">
 			</argument>
-			<argument index="2" name="spos" type="Vector3">
+			<argument index="2" name="sphere_position" type="Vector3">
 			</argument>
-			<argument index="3" name="sradius" type="float">
+			<argument index="3" name="sphere_radius" type="float">
 			</argument>
 			<description>
 			</description>

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -177,7 +177,7 @@
 			</argument>
 			<argument index="1" name="from_slot" type="int">
 			</argument>
-			<argument index="2" name="release_pos" type="Vector2">
+			<argument index="2" name="release_position" type="Vector2">
 			</argument>
 			<description>
 			</description>
@@ -230,7 +230,7 @@
 	<theme_items>
 		<theme_item name="bezier_len_neg" type="int">
 		</theme_item>
-		<theme_item name="bezier_len_pos" type="int">
+		<theme_item name="bezier_len_position" type="int">
 		</theme_item>
 		<theme_item name="bg" type="StyleBox">
 		</theme_item>

--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -43,7 +43,7 @@
 				Return the number of enabled input slots (connections) to the GraphNode.
 			</description>
 		</method>
-		<method name="get_connection_input_pos">
+		<method name="get_connection_input_position">
 			<return type="Vector2">
 			</return>
 			<argument index="0" name="idx" type="int">
@@ -77,7 +77,7 @@
 				Return the number of enabled output slots (connections) of the GraphNode.
 			</description>
 		</method>
-		<method name="get_connection_output_pos">
+		<method name="get_connection_output_position">
 			<return type="Vector2">
 			</return>
 			<argument index="0" name="idx" type="int">

--- a/doc/classes/ImmediateGeometry.xml
+++ b/doc/classes/ImmediateGeometry.xml
@@ -28,7 +28,7 @@
 		<method name="add_vertex">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos" type="Vector3">
+			<argument index="0" name="position" type="Vector3">
 			</argument>
 			<description>
 				Add a vertex with the currently set color/uv/etc.

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -298,7 +298,7 @@
 				Stops the vibration of the joypad.
 			</description>
 		</method>
-		<method name="warp_mouse_pos">
+		<method name="warp_mouse_position">
 			<return type="void">
 			</return>
 			<argument index="0" name="to" type="Vector2">

--- a/doc/classes/InputEventScreenTouch.xml
+++ b/doc/classes/InputEventScreenTouch.xml
@@ -33,7 +33,7 @@
 		<method name="set_position">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<description>
 			</description>

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -85,10 +85,10 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_item_at_pos" qualifiers="const">
+		<method name="get_item_at_position" qualifiers="const">
 			<return type="int">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<argument index="1" name="exact" type="bool" default="false">
 			</argument>
@@ -490,7 +490,7 @@
 		<signal name="item_rmb_selected">
 			<argument index="0" name="index" type="int">
 			</argument>
-			<argument index="1" name="atpos" type="Vector2">
+			<argument index="1" name="at_position" type="Vector2">
 			</argument>
 			<description>
 				Fired when specified list item has been selected via right mouse clicking.

--- a/doc/classes/Line2D.xml
+++ b/doc/classes/Line2D.xml
@@ -14,7 +14,7 @@
 		<method name="add_point">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<description>
 				Add a point at the x/y position in the supplied [Vector2]
@@ -56,7 +56,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_point_pos" qualifiers="const">
+		<method name="get_point_position" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<argument index="0" name="i" type="int">
@@ -149,12 +149,12 @@
 			<description>
 			</description>
 		</method>
-		<method name="set_point_pos">
+		<method name="set_point_position">
 			<return type="void">
 			</return>
 			<argument index="0" name="i" type="int">
 			</argument>
-			<argument index="1" name="pos" type="Vector2">
+			<argument index="1" name="position" type="Vector2">
 			</argument>
 			<description>
 			</description>

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -66,7 +66,7 @@
 				Return the align mode of the [LineEdit].
 			</description>
 		</method>
-		<method name="get_cursor_pos" qualifiers="const">
+		<method name="get_cursor_position" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
@@ -169,10 +169,10 @@
 				Set text alignment of the [LineEdit].
 			</description>
 		</method>
-		<method name="set_cursor_pos">
+		<method name="set_cursor_position">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos" type="int">
+			<argument index="0" name="position" type="int">
 			</argument>
 			<description>
 				Set the cursor position inside the [LineEdit], causing it to scroll if needed.

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -441,7 +441,7 @@
 			</return>
 			<argument index="0" name="child_node" type="Node">
 			</argument>
-			<argument index="1" name="to_pos" type="int">
+			<argument index="1" name="to_position" type="int">
 			</argument>
 			<description>
 				Move a child node to a different position (order) amongst the other children. Since calls, signals, etc are performed by tree order, changing the order of children nodes may be useful.

--- a/doc/classes/Node2D.xml
+++ b/doc/classes/Node2D.xml
@@ -169,7 +169,7 @@
 		<method name="set_global_position">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<description>
 				Set the node's global position.
@@ -214,7 +214,7 @@
 		<method name="set_position">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<description>
 				Set the node's position.

--- a/doc/classes/Physics2DDirectBodyState.xml
+++ b/doc/classes/Physics2DDirectBodyState.xml
@@ -45,7 +45,7 @@
 				Return the collider object, this depends on how it was created (will return a scene node if such was used to create it).
 			</description>
 		</method>
-		<method name="get_contact_collider_pos" qualifiers="const">
+		<method name="get_contact_collider_position" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<argument index="0" name="contact_idx" type="int">
@@ -72,7 +72,7 @@
 				Return the metadata of the collided shape. This metadata is different from [method Object.get_meta], and is set with [method Physics2DServer.shape_set_data].
 			</description>
 		</method>
-		<method name="get_contact_collider_velocity_at_pos" qualifiers="const">
+		<method name="get_contact_collider_velocity_at_position" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<argument index="0" name="contact_idx" type="int">
@@ -97,7 +97,7 @@
 				Return the local normal (of this body) of the contact point.
 			</description>
 		</method>
-		<method name="get_contact_local_pos" qualifiers="const">
+		<method name="get_contact_local_position" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<argument index="0" name="contact_idx" type="int">

--- a/doc/classes/Physics2DServer.xml
+++ b/doc/classes/Physics2DServer.xml
@@ -306,7 +306,7 @@
 			</return>
 			<argument index="0" name="body" type="RID">
 			</argument>
-			<argument index="1" name="pos" type="Vector2">
+			<argument index="1" name="position" type="Vector2">
 			</argument>
 			<argument index="2" name="impulse" type="Vector2">
 			</argument>

--- a/doc/classes/PhysicsDirectBodyState.xml
+++ b/doc/classes/PhysicsDirectBodyState.xml
@@ -14,7 +14,7 @@
 			</return>
 			<argument index="0" name="force" type="Vector3">
 			</argument>
-			<argument index="1" name="pos" type="Vector3">
+			<argument index="1" name="position" type="Vector3">
 			</argument>
 			<description>
 			</description>
@@ -22,7 +22,7 @@
 		<method name="apply_impulse">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos" type="Vector3">
+			<argument index="0" name="position" type="Vector3">
 			</argument>
 			<argument index="1" name="j" type="Vector3">
 			</argument>
@@ -73,7 +73,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_contact_collider_pos" qualifiers="const">
+		<method name="get_contact_collider_position" qualifiers="const">
 			<return type="Vector3">
 			</return>
 			<argument index="0" name="contact_idx" type="int">
@@ -89,7 +89,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_contact_collider_velocity_at_pos" qualifiers="const">
+		<method name="get_contact_collider_velocity_at_position" qualifiers="const">
 			<return type="Vector3">
 			</return>
 			<argument index="0" name="contact_idx" type="int">
@@ -111,7 +111,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_contact_local_pos" qualifiers="const">
+		<method name="get_contact_local_position" qualifiers="const">
 			<return type="Vector3">
 			</return>
 			<argument index="0" name="contact_idx" type="int">

--- a/doc/classes/PhysicsServer.xml
+++ b/doc/classes/PhysicsServer.xml
@@ -268,7 +268,7 @@
 			</return>
 			<argument index="0" name="body" type="RID">
 			</argument>
-			<argument index="1" name="pos" type="Vector3">
+			<argument index="1" name="position" type="Vector3">
 			</argument>
 			<argument index="2" name="impulse" type="Vector3">
 			</argument>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -147,7 +147,7 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="pos" type="int">
+			<argument index="1" name="position" type="int">
 			</argument>
 			<description>
 				Set the order of a configuration value (influences when saved to the config file).

--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -14,7 +14,7 @@
 		<method name="Rect2">
 			<return type="Rect2">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<argument index="1" name="size" type="Vector2">
 			</argument>

--- a/doc/classes/Rect3.xml
+++ b/doc/classes/Rect3.xml
@@ -14,7 +14,7 @@
 		<method name="Rect3">
 			<return type="Rect3">
 			</return>
-			<argument index="0" name="pos" type="Vector3">
+			<argument index="0" name="position" type="Vector3">
 			</argument>
 			<argument index="1" name="size" type="Vector3">
 			</argument>

--- a/doc/classes/RigidBody.xml
+++ b/doc/classes/RigidBody.xml
@@ -27,7 +27,7 @@
 		<method name="apply_impulse">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos" type="Vector3">
+			<argument index="0" name="position" type="Vector3">
 			</argument>
 			<argument index="1" name="impulse" type="Vector3">
 			</argument>

--- a/doc/classes/Spatial.xml
+++ b/doc/classes/Spatial.xml
@@ -145,10 +145,10 @@
 				Rotates itself to point into direction of target position. Operations take place in global space.
 			</description>
 		</method>
-		<method name="look_at_from_pos">
+		<method name="look_at_from_position">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos" type="Vector3">
+			<argument index="0" name="position" type="Vector3">
 			</argument>
 			<argument index="1" name="target" type="Vector3">
 			</argument>

--- a/doc/classes/SpriteFrames.xml
+++ b/doc/classes/SpriteFrames.xml
@@ -26,7 +26,7 @@
 			</argument>
 			<argument index="1" name="frame" type="Texture">
 			</argument>
-			<argument index="2" name="atpos" type="int" default="-1">
+			<argument index="2" name="at_position" type="int" default="-1">
 			</argument>
 			<description>
 			</description>

--- a/doc/classes/StreamPeerBuffer.xml
+++ b/doc/classes/StreamPeerBuffer.xml
@@ -27,7 +27,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_pos" qualifiers="const">
+		<method name="get_position" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
@@ -50,7 +50,7 @@
 		<method name="seek">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos" type="int">
+			<argument index="0" name="position" type="int">
 			</argument>
 			<description>
 			</description>

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -266,12 +266,12 @@
 			</description>
 		</method>
 		<method name="erase">
-			<argument index="0" name="pos" type="int">
+			<argument index="0" name="position" type="int">
 			</argument>
 			<argument index="1" name="chars" type="int">
 			</argument>
 			<description>
-				Erase [code]chars[/code] characters from the string starting from [code]pos[/code].
+				Erase [code]chars[/code] characters from the string starting from [code]position[/code].
 			</description>
 		</method>
 		<method name="find">
@@ -360,7 +360,7 @@
 		<method name="insert">
 			<return type="String">
 			</return>
-			<argument index="0" name="pos" type="int">
+			<argument index="0" name="position" type="int">
 			</argument>
 			<argument index="1" name="what" type="String">
 			</argument>
@@ -445,7 +445,7 @@
 		<method name="left">
 			<return type="String">
 			</return>
-			<argument index="0" name="pos" type="int">
+			<argument index="0" name="position" type="int">
 			</argument>
 			<description>
 				Return an amount of characters from the left of the string.
@@ -596,7 +596,7 @@
 		<method name="right">
 			<return type="String">
 			</return>
-			<argument index="0" name="pos" type="int">
+			<argument index="0" name="position" type="int">
 			</argument>
 			<description>
 				Return the right side of the string from a given position.

--- a/doc/classes/Texture.xml
+++ b/doc/classes/Texture.xml
@@ -16,7 +16,7 @@
 			</return>
 			<argument index="0" name="canvas_item" type="RID">
 			</argument>
-			<argument index="1" name="pos" type="Vector2">
+			<argument index="1" name="position" type="Vector2">
 			</argument>
 			<argument index="2" name="modulate" type="Color" default="Color( 1, 1, 1, 1 )">
 			</argument>

--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -39,7 +39,7 @@
 		<method name="get_cellv" qualifiers="const">
 			<return type="int">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<description>
 				Return the tile index of the cell referenced by a Vector2.
@@ -222,7 +222,7 @@
 		<method name="map_to_world" qualifiers="const">
 			<return type="Vector2">
 			</return>
-			<argument index="0" name="mappos" type="Vector2">
+			<argument index="0" name="map_position" type="Vector2">
 			</argument>
 			<argument index="1" name="ignore_half_ofs" type="bool" default="false">
 			</argument>
@@ -264,7 +264,7 @@
 		<method name="set_cellv">
 			<return type="void">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<argument index="1" name="tile" type="int">
 			</argument>
@@ -442,7 +442,7 @@
 		<method name="world_to_map" qualifiers="const">
 			<return type="Vector2">
 			</return>
-			<argument index="0" name="worldpos" type="Vector2">
+			<argument index="0" name="world_position" type="Vector2">
 			</argument>
 			<description>
 				Return the tilemap (grid-based) coordinates corresponding to the absolute world position given as an argument.

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -38,7 +38,7 @@
 			</return>
 			<argument index="0" name="rot" type="float">
 			</argument>
-			<argument index="1" name="pos" type="Vector2">
+			<argument index="1" name="position" type="Vector2">
 			</argument>
 			<description>
 				Constructs the [Transform2D] from rotation angle in radians and position [Vector2].

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -65,10 +65,10 @@
 				Get whether a right click can select items.
 			</description>
 		</method>
-		<method name="get_column_at_pos" qualifiers="const">
+		<method name="get_column_at_position" qualifiers="const">
 			<return type="int">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<description>
 				Get the column index under the given point.
@@ -113,10 +113,10 @@
 				Get the flags of the current drop mode.
 			</description>
 		</method>
-		<method name="get_drop_section_at_pos" qualifiers="const">
+		<method name="get_drop_section_at_position" qualifiers="const">
 			<return type="int">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<description>
 			</description>
@@ -146,10 +146,10 @@
 				Get the rectangle area of the the specified item. If column is specified, only get the position and size of that column, otherwise get the rectangle containing all columns.
 			</description>
 		</method>
-		<method name="get_item_at_pos" qualifiers="const">
+		<method name="get_item_at_position" qualifiers="const">
 			<return type="TreeItem">
 			</return>
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<description>
 				Get the tree item at the specified position (relative to the tree origin position).
@@ -342,7 +342,7 @@
 			</description>
 		</signal>
 		<signal name="empty_tree_rmb_selected">
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<description>
 				Emitted when the right mouse button is pressed if RMB selection is active and the tree is empty.
@@ -378,7 +378,7 @@
 			</description>
 		</signal>
 		<signal name="item_rmb_selected">
-			<argument index="0" name="pos" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<description>
 				Emitted when an item is selected with right mouse button.

--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -8,7 +8,7 @@
 		Because it is easy to get it wrong, here is a quick usage example:
 		[codeblock]
 		var tween = get_node("Tween")
-		tween.interpolate_property(get_node("Node2D_to_move"), "transform/pos", Vector2(0,0), Vector2(100,100), 1, Tween.TRANS_LINEAR, Tween.EASE_IN_OUT)
+		tween.interpolate_property(get_node("Node2D_to_move"), "transform/origin", Vector2(0,0), Vector2(100,100), 1, Tween.TRANS_LINEAR, Tween.EASE_IN_OUT)
 		tween.start()
 		[/codeblock]
 		Some of the methods of this class require a property name. You can get the property name by hovering over the property in the inspector of the editor.

--- a/doc/classes/VideoPlayer.xml
+++ b/doc/classes/VideoPlayer.xml
@@ -39,7 +39,7 @@
 				Get the name of the video stream.
 			</description>
 		</method>
-		<method name="get_stream_pos" qualifiers="const">
+		<method name="get_stream_position" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -528,7 +528,7 @@
 		<method name="warp_mouse">
 			<return type="void">
 			</return>
-			<argument index="0" name="to_pos" type="Vector2">
+			<argument index="0" name="to_position" type="Vector2">
 			</argument>
 			<description>
 				Warp the mouse to a position, relative to the viewport.

--- a/doc/classes/VisualScript.xml
+++ b/doc/classes/VisualScript.xml
@@ -34,7 +34,7 @@
 			</argument>
 			<argument index="2" name="node" type="VisualScriptNode">
 			</argument>
-			<argument index="3" name="pos" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="3" name="position" type="Vector2" default="Vector2( 0, 0 )">
 			</argument>
 			<description>
 			</description>
@@ -197,7 +197,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_node_pos" qualifiers="const">
+		<method name="get_node_position" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<argument index="0" name="func" type="String">
@@ -405,14 +405,14 @@
 			<description>
 			</description>
 		</method>
-		<method name="set_node_pos">
+		<method name="set_node_position">
 			<return type="void">
 			</return>
 			<argument index="0" name="func" type="String">
 			</argument>
 			<argument index="1" name="id" type="int">
 			</argument>
-			<argument index="2" name="pos" type="Vector2">
+			<argument index="2" name="position" type="Vector2">
 			</argument>
 			<description>
 			</description>

--- a/doc/classes/XMLParser.xml
+++ b/doc/classes/XMLParser.xml
@@ -133,7 +133,7 @@
 		<method name="seek">
 			<return type="int" enum="Error">
 			</return>
-			<argument index="0" name="pos" type="int">
+			<argument index="0" name="position" type="int">
 			</argument>
 			<description>
 				Move the buffer cursor to a certain offset (since the beginning) and read the next node there. This returns an error code.

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -168,7 +168,7 @@ void FileAccessUnix::seek_end(int64_t p_position) {
 		check_errors();
 }
 
-size_t FileAccessUnix::get_pos() const {
+size_t FileAccessUnix::get_position() const {
 
 	ERR_FAIL_COND_V(!f, 0);
 

--- a/drivers/unix/file_access_unix.h
+++ b/drivers/unix/file_access_unix.h
@@ -62,7 +62,7 @@ public:
 
 	virtual void seek(size_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_pos() const; ///< get position in the file
+	virtual size_t get_position() const; ///< get position in the file
 	virtual size_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -156,7 +156,7 @@ void FileAccessWindows::seek_end(int64_t p_position) {
 	if (fseek(f, p_position, SEEK_END))
 		check_errors();
 }
-size_t FileAccessWindows::get_pos() const {
+size_t FileAccessWindows::get_position() const {
 
 	size_t aux_position = 0;
 	aux_position = ftell(f);
@@ -169,9 +169,9 @@ size_t FileAccessWindows::get_len() const {
 
 	ERR_FAIL_COND_V(!f, 0);
 
-	size_t pos = get_pos();
+	size_t pos = get_position();
 	fseek(f, 0, SEEK_END);
-	int size = get_pos();
+	int size = get_position();
 	fseek(f, pos, SEEK_SET);
 
 	return size;

--- a/drivers/windows/file_access_windows.h
+++ b/drivers/windows/file_access_windows.h
@@ -54,7 +54,7 @@ public:
 
 	virtual void seek(size_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_pos() const; ///< get position in the file
+	virtual size_t get_position() const; ///< get position in the file
 	virtual size_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF

--- a/editor/animation_editor.cpp
+++ b/editor/animation_editor.cpp
@@ -322,7 +322,7 @@ public:
 			undo_redo->add_do_method(animation.ptr(), "track_remove_key", track, key);
 			undo_redo->add_do_method(animation.ptr(), "track_insert_key", track, new_time, val, trans);
 			undo_redo->add_do_method(this, "_key_ofs_changed", animation, key_ofs, new_time);
-			undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_pos", track, new_time);
+			undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", track, new_time);
 			undo_redo->add_undo_method(animation.ptr(), "track_insert_key", track, key_ofs, val, trans);
 			undo_redo->add_undo_method(this, "_key_ofs_changed", animation, new_time, key_ofs);
 
@@ -563,8 +563,8 @@ public:
 
 			case Animation::TYPE_TRANSFORM: {
 
-				p_list->push_back(PropertyInfo(Variant::VECTOR3, "loc"));
-				p_list->push_back(PropertyInfo(Variant::QUAT, "rot"));
+				p_list->push_back(PropertyInfo(Variant::VECTOR3, "location"));
+				p_list->push_back(PropertyInfo(Variant::QUAT, "rotation"));
 				p_list->push_back(PropertyInfo(Variant::VECTOR3, "scale"));
 
 			} break;
@@ -719,7 +719,7 @@ void AnimationKeyEditor::_anim_duplicate_keys(bool transpose) {
 			int existing_idx = animation->track_find_key(dst_track, dst_time, true);
 
 			undo_redo->add_do_method(animation.ptr(), "track_insert_key", dst_track, dst_time, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
-			undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_pos", dst_track, dst_time);
+			undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", dst_track, dst_time);
 
 			Pair<int, float> p;
 			p.first = dst_track;
@@ -1016,7 +1016,7 @@ float AnimationKeyEditor::_get_zoom_scale() const {
 	}
 }
 
-void AnimationKeyEditor::_track_pos_draw() {
+void AnimationKeyEditor::_track_position_draw() {
 
 	if (!animation.is_valid()) {
 		return;
@@ -2301,8 +2301,8 @@ void AnimationKeyEditor::_track_editor_gui_input(const Ref<InputEvent> &p_input)
 
 						if (tt == Animation::TYPE_TRANSFORM) {
 							Dictionary d;
-							d["loc"] = Vector3();
-							d["rot"] = Quat();
+							d["location"] = Vector3();
+							d["rotation"] = Quat();
 							d["scale"] = Vector3();
 							newval = d;
 
@@ -2337,7 +2337,7 @@ void AnimationKeyEditor::_track_editor_gui_input(const Ref<InputEvent> &p_input)
 						undo_redo->create_action(TTR("Anim Add Key"));
 
 						undo_redo->add_do_method(animation.ptr(), "track_insert_key", idx, pos, newval, 1);
-						undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_pos", idx, pos);
+						undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", idx, pos);
 
 						if (existing != -1) {
 							Variant v = animation->track_get_key_value(idx, existing);
@@ -2506,7 +2506,7 @@ void AnimationKeyEditor::_track_editor_gui_input(const Ref<InputEvent> &p_input)
 							if (selection.has(sk))
 								continue; //already in selection, don't save
 
-							undo_redo->add_do_method(animation.ptr(), "track_remove_key_at_pos", E->key().track, newtime);
+							undo_redo->add_do_method(animation.ptr(), "track_remove_key_at_position", E->key().track, newtime);
 							_AnimMoveRestore amr;
 
 							amr.key = animation->track_get_key_value(E->key().track, idx);
@@ -2536,7 +2536,7 @@ void AnimationKeyEditor::_track_editor_gui_input(const Ref<InputEvent> &p_input)
 							if (newpos<0)
 								continue; //no remove what no inserted
 							*/
-							undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_pos", E->key().track, newpos);
+							undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", E->key().track, newpos);
 						}
 
 						// 5-(undo) reinsert keys
@@ -2753,10 +2753,10 @@ void AnimationKeyEditor::_track_editor_gui_input(const Ref<InputEvent> &p_input)
 						case Animation::TYPE_TRANSFORM: {
 
 							Dictionary d = animation->track_get_key_value(idx, mouse_over.over_key);
-							if (d.has("loc"))
-								text += "loc: " + String(d["loc"]) + "\n";
-							if (d.has("rot"))
-								text += "rot: " + String(d["rot"]) + "\n";
+							if (d.has("location"))
+								text += "location: " + String(d["location"]) + "\n";
+							if (d.has("rotation"))
+								text += "rot: " + String(d["rotation"]) + "\n";
 							if (d.has("scale"))
 								text += "scale: " + String(d["scale"]) + "\n";
 						} break;
@@ -3359,9 +3359,9 @@ int AnimationKeyEditor::_confirm_insert(InsertData p_id, int p_last_track) {
 
 			Transform tr = p_id.value;
 			Dictionary d;
-			d["loc"] = tr.origin;
+			d["location"] = tr.origin;
 			d["scale"] = tr.basis.get_scale();
-			d["rot"] = Quat(tr.basis); //.orthonormalized();
+			d["rotation"] = Quat(tr.basis); //.orthonormalized();
 			value = d;
 		} break;
 		default: {}
@@ -3376,7 +3376,7 @@ int AnimationKeyEditor::_confirm_insert(InsertData p_id, int p_last_track) {
 		p_last_track++;
 	} else {
 
-		undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_pos", p_id.track_idx, time);
+		undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", p_id.track_idx, time);
 		int existing = animation->track_find_key(p_id.track_idx, time, true);
 		if (existing != -1) {
 			Variant v = animation->track_get_key_value(p_id.track_idx, existing);
@@ -3451,7 +3451,7 @@ void AnimationKeyEditor::_create_value_item(int p_type) {
 	Variant::CallError ce;
 	Variant v = Variant::construct(Variant::Type(p_type), NULL, 0, ce);
 	undo_redo->add_do_method(animation.ptr(), "track_insert_key", cvi_track, cvi_pos, v);
-	undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_pos", cvi_track, cvi_pos);
+	undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", cvi_track, cvi_pos);
 
 	int existing = animation->track_find_key(cvi_track, cvi_pos, true);
 
@@ -3586,7 +3586,7 @@ void AnimationKeyEditor::_scale() {
 		if (selection.has(sk))
 			continue; //already in selection, don't save
 
-		undo_redo->add_do_method(animation.ptr(), "track_remove_key_at_pos", E->key().track, newtime);
+		undo_redo->add_do_method(animation.ptr(), "track_remove_key_at_position", E->key().track, newtime);
 		_AnimMoveRestore amr;
 
 		amr.key = animation->track_get_key_value(E->key().track, idx);
@@ -3609,7 +3609,7 @@ void AnimationKeyEditor::_scale() {
 	for (Map<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 
 		float newpos = _NEW_POS(E->get().pos);
-		undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_pos", E->key().track, newpos);
+		undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", E->key().track, newpos);
 	}
 
 	// 5-(undo) reinsert keys
@@ -3696,7 +3696,7 @@ void AnimationKeyEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_menu_track"), &AnimationKeyEditor::_menu_track);
 	ClassDB::bind_method(D_METHOD("_clear_selection_for_anim"), &AnimationKeyEditor::_clear_selection_for_anim);
 	ClassDB::bind_method(D_METHOD("_select_at_anim"), &AnimationKeyEditor::_select_at_anim);
-	ClassDB::bind_method(D_METHOD("_track_pos_draw"), &AnimationKeyEditor::_track_pos_draw);
+	ClassDB::bind_method(D_METHOD("_track_position_draw"), &AnimationKeyEditor::_track_position_draw);
 	ClassDB::bind_method(D_METHOD("_insert_delay"), &AnimationKeyEditor::_insert_delay);
 	ClassDB::bind_method(D_METHOD("_step_changed"), &AnimationKeyEditor::_step_changed);
 
@@ -3715,7 +3715,7 @@ void AnimationKeyEditor::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("resource_selected", PropertyInfo(Variant::OBJECT, "res"), PropertyInfo(Variant::STRING, "prop")));
 	ADD_SIGNAL(MethodInfo("keying_changed"));
-	ADD_SIGNAL(MethodInfo("timeline_changed", PropertyInfo(Variant::REAL, "pos"), PropertyInfo(Variant::BOOL, "drag")));
+	ADD_SIGNAL(MethodInfo("timeline_changed", PropertyInfo(Variant::REAL, "position"), PropertyInfo(Variant::BOOL, "drag")));
 	ADD_SIGNAL(MethodInfo("animation_len_changed", PropertyInfo(Variant::REAL, "len")));
 	ADD_SIGNAL(MethodInfo("animation_step_changed", PropertyInfo(Variant::REAL, "step")));
 	ADD_SIGNAL(MethodInfo("key_edited", PropertyInfo(Variant::INT, "track"), PropertyInfo(Variant::INT, "key")));
@@ -3915,7 +3915,7 @@ AnimationKeyEditor::AnimationKeyEditor() {
 	track_pos->set_area_as_parent_rect();
 	track_pos->set_mouse_filter(MOUSE_FILTER_IGNORE);
 	track_editor->add_child(track_pos);
-	track_pos->connect("draw", this, "_track_pos_draw");
+	track_pos->connect("draw", this, "_track_position_draw");
 
 	select_anim_warning = memnew(Label);
 	track_editor->add_child(select_anim_warning);

--- a/editor/animation_editor.h
+++ b/editor/animation_editor.h
@@ -273,7 +273,7 @@ class AnimationKeyEditor : public VBoxContainer {
 
 	void _track_editor_draw();
 	void _track_editor_gui_input(const Ref<InputEvent> &p_input);
-	void _track_pos_draw();
+	void _track_position_draw();
 
 	void _track_name_changed(const String &p_name);
 	void _track_menu_selected(int p_idx);

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -367,7 +367,7 @@ void FindReplaceBar::_show_search() {
 
 	if (!get_search_text().empty()) {
 		search_text->select_all();
-		search_text->set_cursor_pos(search_text->get_text().length());
+		search_text->set_cursor_position(search_text->get_text().length());
 		search_current();
 	}
 }

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -513,7 +513,7 @@ void CreateDialog::_favorite_activated() {
 
 Variant CreateDialog::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
 
-	TreeItem *ti = favorites->get_item_at_pos(p_point);
+	TreeItem *ti = favorites->get_item_at_position(p_point);
 	if (ti) {
 		Dictionary d;
 		d["type"] = "create_favorite_drag";
@@ -544,12 +544,12 @@ void CreateDialog::drop_data_fw(const Point2 &p_point, const Variant &p_data, Co
 
 	Dictionary d = p_data;
 
-	TreeItem *ti = favorites->get_item_at_pos(p_point);
+	TreeItem *ti = favorites->get_item_at_position(p_point);
 	if (!ti)
 		return;
 
 	String drop_at = ti->get_text(0);
-	int ds = favorites->get_drop_section_at_pos(p_point);
+	int ds = favorites->get_drop_section_at_position(p_point);
 
 	int drop_idx = favorite_list.find(drop_at);
 	if (drop_idx < 0)

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -459,7 +459,7 @@ void EditorAudioBus::drop_data(const Point2 &p_point, const Variant &p_data) {
 Variant EditorAudioBus::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
 
 	print_line("drag fw");
-	TreeItem *item = effects->get_item_at_pos(p_point);
+	TreeItem *item = effects->get_item_at_position(p_point);
 	if (!item) {
 		print_line("no item");
 		return Variant();
@@ -489,7 +489,7 @@ bool EditorAudioBus::can_drop_data_fw(const Point2 &p_point, const Variant &p_da
 	if (!d.has("type") || String(d["type"]) != "audio_bus_effect")
 		return false;
 
-	TreeItem *item = effects->get_item_at_pos(p_point);
+	TreeItem *item = effects->get_item_at_position(p_point);
 	if (!item)
 		return false;
 
@@ -502,10 +502,10 @@ void EditorAudioBus::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 
 	Dictionary d = p_data;
 
-	TreeItem *item = effects->get_item_at_pos(p_point);
+	TreeItem *item = effects->get_item_at_position(p_point);
 	if (!item)
 		return;
-	int pos = effects->get_drop_section_at_pos(p_point);
+	int pos = effects->get_drop_section_at_position(p_point);
 	Variant md = item->get_metadata(0);
 
 	int paste_at;

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -419,12 +419,12 @@ bool EditorAutoloadSettings::can_drop_data_fw(const Point2 &p_point, const Varia
 		return false;
 
 	if (drop_data.has("type")) {
-		TreeItem *ti = tree->get_item_at_pos(p_point);
+		TreeItem *ti = tree->get_item_at_position(p_point);
 
 		if (!ti)
 			return false;
 
-		int section = tree->get_drop_section_at_pos(p_point);
+		int section = tree->get_drop_section_at_position(p_point);
 
 		if (section < -1)
 			return false;
@@ -437,12 +437,12 @@ bool EditorAutoloadSettings::can_drop_data_fw(const Point2 &p_point, const Varia
 
 void EditorAutoloadSettings::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_control) {
 
-	TreeItem *ti = tree->get_item_at_pos(p_point);
+	TreeItem *ti = tree->get_item_at_position(p_point);
 
 	if (!ti)
 		return;
 
-	int section = tree->get_drop_section_at_pos(p_point);
+	int section = tree->get_drop_section_at_position(p_point);
 
 	if (section < -1)
 		return;

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -278,7 +278,7 @@ Error EditorExportPlatform::_save_pack_file(void *p_userdata, const String &p_pa
 
 	SavedData sd;
 	sd.path_utf8 = p_path.utf8();
-	sd.ofs = pd->f->get_pos();
+	sd.ofs = pd->f->get_position();
 	sd.size = p_data.size();
 
 	pd->f->store_buffer(p_data.ptr(), p_data.size());
@@ -736,7 +736,7 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, c
 
 	f->store_32(pd.file_ofs.size()); //amount of files
 
-	size_t header_size = f->get_pos();
+	size_t header_size = f->get_position();
 
 	//precalculate header size
 

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1258,11 +1258,11 @@ bool FileSystemDock::can_drop_data_fw(const Point2 &p_point, const Variant &p_da
 	if (drag_data.has("type") && String(drag_data["type"]) == "favorite") {
 
 		//moving favorite around
-		TreeItem *ti = tree->get_item_at_pos(p_point);
+		TreeItem *ti = tree->get_item_at_position(p_point);
 		if (!ti)
 			return false;
 
-		int what = tree->get_drop_section_at_pos(p_point);
+		int what = tree->get_drop_section_at_position(p_point);
 
 		if (ti == tree->get_root()->get_children()) {
 			return (what == 1); //the parent, first fav
@@ -1288,7 +1288,7 @@ bool FileSystemDock::can_drop_data_fw(const Point2 &p_point, const Variant &p_da
 
 		if (p_from == files) {
 
-			int at_pos = files->get_item_at_pos(p_point);
+			int at_pos = files->get_item_at_position(p_point);
 			if (at_pos != -1) {
 
 				String dir = files->get_item_metadata(at_pos);
@@ -1299,7 +1299,7 @@ bool FileSystemDock::can_drop_data_fw(const Point2 &p_point, const Variant &p_da
 
 		if (p_from == tree) {
 
-			TreeItem *ti = tree->get_item_at_pos(p_point);
+			TreeItem *ti = tree->get_item_at_position(p_point);
 			if (!ti)
 				return false;
 			String path = ti->get_metadata(0);
@@ -1323,7 +1323,7 @@ void FileSystemDock::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 	if (drag_data.has("type") && String(drag_data["type"]) == "favorite") {
 
 		//moving favorite around
-		TreeItem *ti = tree->get_item_at_pos(p_point);
+		TreeItem *ti = tree->get_item_at_position(p_point);
 		if (!ti)
 			return;
 
@@ -1336,7 +1336,7 @@ void FileSystemDock::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 			swap = swap.substr(0, swap.length() - 1);
 		}
 
-		int what = tree->get_drop_section_at_pos(p_point);
+		int what = tree->get_drop_section_at_position(p_point);
 
 		TreeItem *swap_item = NULL;
 
@@ -1391,7 +1391,7 @@ void FileSystemDock::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 
 		if (p_from == tree) {
 
-			TreeItem *ti = tree->get_item_at_pos(p_point);
+			TreeItem *ti = tree->get_item_at_position(p_point);
 			if (!ti)
 				return;
 			String path = ti->get_metadata(0);
@@ -1406,7 +1406,7 @@ void FileSystemDock::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 		if (p_from == files) {
 			String save_path = path;
 
-			int at_pos = files->get_item_at_pos(p_point);
+			int at_pos = files->get_item_at_position(p_point);
 			if (at_pos != -1) {
 				String to_dir = files->get_item_metadata(at_pos);
 				if (to_dir.ends_with("/")) {
@@ -1429,11 +1429,11 @@ void FileSystemDock::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 
 			if (p_from == files) {
 
-				int at_pos = files->get_item_at_pos(p_point);
+				int at_pos = files->get_item_at_position(p_point);
 				ERR_FAIL_COND(at_pos == -1);
 				to_dir = files->get_item_metadata(at_pos);
 			} else {
-				TreeItem *ti = tree->get_item_at_pos(p_point);
+				TreeItem *ti = tree->get_item_at_position(p_point);
 				if (!ti)
 					return;
 				to_dir = ti->get_metadata(0);

--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -141,7 +141,7 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 
 		/* chunk size */
 		uint32_t chunksize = file->get_32();
-		uint32_t file_pos = file->get_pos(); //save file pos, so we can skip to next chunk safely
+		uint32_t file_pos = file->get_position(); //save file pos, so we can skip to next chunk safely
 
 		if (file->eof_reached()) {
 

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -76,14 +76,14 @@ void AnimationPlayerEditor::_notification(int p_what) {
 						}
 					}
 				}
-				frame->set_value(player->get_current_animation_pos());
-				key_editor->set_anim_pos(player->get_current_animation_pos());
+				frame->set_value(player->get_current_animation_position());
+				key_editor->set_anim_pos(player->get_current_animation_position());
 				EditorNode::get_singleton()->get_property_editor()->refresh();
 
 			} else if (last_active) {
 				//need the last frame after it stopped
 
-				frame->set_value(player->get_current_animation_pos());
+				frame->set_value(player->get_current_animation_position());
 			}
 
 			last_active = player->is_playing();
@@ -197,7 +197,7 @@ void AnimationPlayerEditor::_play_from_pressed() {
 
 	if (current != "") {
 
-		float time = player->get_current_animation_pos();
+		float time = player->get_current_animation_position();
 
 		if (current == player->get_current_animation() && player->is_playing()) {
 
@@ -245,7 +245,7 @@ void AnimationPlayerEditor::_play_bw_from_pressed() {
 
 	if (current != "") {
 
-		float time = player->get_current_animation_pos();
+		float time = player->get_current_animation_position();
 		if (current == player->get_current_animation())
 			player->stop(); //so it wont blend with itself
 
@@ -944,7 +944,7 @@ void AnimationPlayerEditor::_seek_value_changed(float p_value, bool p_set) {
 	}
 
 	if (player->is_valid() && !p_set) {
-		float cpos = player->get_current_animation_pos();
+		float cpos = player->get_current_animation_position();
 
 		player->seek_delta(pos, pos - cpos);
 	} else {

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -63,7 +63,7 @@ Size2 AnimationTreeEditor::_get_maximum_size() {
 
 	for (List<StringName>::Element *E = order.front(); E; E = E->next()) {
 
-		Point2 pos = anim_tree->node_get_pos(E->get());
+		Point2 pos = anim_tree->node_get_position(E->get());
 
 		if (click_type == CLICK_NODE && click_node == E->get()) {
 
@@ -257,7 +257,7 @@ void AnimationTreeEditor::_popup_edit_dialog() {
 	filter_button->hide();
 	edit_check->hide();
 
-	Point2 pos = anim_tree->node_get_pos(edited_node) - Point2(h_scroll->get_value(), v_scroll->get_value());
+	Point2 pos = anim_tree->node_get_position(edited_node) - Point2(h_scroll->get_value(), v_scroll->get_value());
 	Ref<StyleBox> style = get_stylebox("panel", "PopupMenu");
 	Size2 size = get_node_size(edited_node);
 	Point2 popup_pos(pos.x + style->get_margin(MARGIN_LEFT), pos.y + size.y - style->get_margin(MARGIN_BOTTOM));
@@ -479,7 +479,7 @@ void AnimationTreeEditor::_draw_node(const StringName &p_node) {
 	Ref<Texture> slot_icon = get_icon("VisualShaderPort", "EditorIcons");
 
 	Size2 size = get_node_size(p_node);
-	Point2 pos = anim_tree->node_get_pos(p_node);
+	Point2 pos = anim_tree->node_get_position(p_node);
 	if (click_type == CLICK_NODE && click_node == p_node) {
 
 		pos += click_motion - click_pos;
@@ -618,7 +618,7 @@ AnimationTreeEditor::ClickType AnimationTreeEditor::_locate_click(const Point2 &
 
 		AnimationTreePlayer::NodeType type = anim_tree->node_get_type(node);
 
-		Point2 pos = anim_tree->node_get_pos(node);
+		Point2 pos = anim_tree->node_get_position(node);
 		Size2 size = get_node_size(node);
 
 		pos -= Point2(h_scroll->get_value(), v_scroll->get_value());
@@ -674,7 +674,7 @@ Point2 AnimationTreeEditor::_get_slot_pos(const StringName &p_node_id, bool p_in
 	Ref<Texture> slot_icon = get_icon("VisualShaderPort", "EditorIcons");
 
 	Size2 size = get_node_size(p_node_id);
-	Point2 pos = anim_tree->node_get_pos(p_node_id);
+	Point2 pos = anim_tree->node_get_position(p_node_id);
 
 	if (click_type == CLICK_NODE && click_node == p_node_id) {
 
@@ -806,12 +806,12 @@ void AnimationTreeEditor::_gui_input(Ref<InputEvent> p_event) {
 
 					} break;
 					case CLICK_NODE: {
-						Point2 new_pos = anim_tree->node_get_pos(click_node) + (click_motion - click_pos);
+						Point2 new_pos = anim_tree->node_get_position(click_node) + (click_motion - click_pos);
 						if (new_pos.x < 5)
 							new_pos.x = 5;
 						if (new_pos.y < 5)
 							new_pos.y = 5;
-						anim_tree->node_set_pos(click_node, new_pos);
+						anim_tree->node_set_position(click_node, new_pos);
 
 					} break;
 					default: {}
@@ -1081,7 +1081,7 @@ StringName AnimationTreeEditor::_add_node(int p_item) {
 	}
 
 	anim_tree->add_node((AnimationTreePlayer::NodeType)p_item, name);
-	anim_tree->node_set_pos(name, Point2(last_x, last_y));
+	anim_tree->node_set_position(name, Point2(last_x, last_y));
 	order.push_back(name);
 	last_x += 10;
 	last_y += 10;

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -368,7 +368,7 @@ void CanvasItemEditor::_unhandled_key_input(const Ref<InputEvent> &p_ev) {
 		} else if (set_pivot_shortcut.is_valid() && set_pivot_shortcut->is_shortcut(p_ev) && drag == DRAG_NONE && can_move_pivot) {
 			if (!Input::get_singleton()->is_mouse_button_pressed(0)) {
 				List<Node *> &selection = editor_selection->get_selected_node_list();
-				Vector2 mouse_pos = viewport->get_local_mouse_pos();
+				Vector2 mouse_pos = viewport->get_local_mouse_position();
 				if (selection.size() && viewport->get_rect().has_point(mouse_pos)) {
 					//just in case, make it work if over viewport
 					mouse_pos = transform.affine_inverse().xform(mouse_pos);
@@ -4188,13 +4188,13 @@ void CanvasItemEditorViewport::_create_nodes(Node *parent, Node *child, String &
 		pos = parent->call("get_global_position");
 	}
 	Transform2D trans = canvas->get_canvas_transform();
-	Point2 target_pos = (p_point - trans.get_origin()) / trans.get_scale().x - pos;
+	Point2 target_position = (p_point - trans.get_origin()) / trans.get_scale().x - pos;
 	if (default_type == "Polygon2D" || default_type == "TouchScreenButton" || default_type == "TextureRect" || default_type == "Patch9Rect") {
-		target_pos -= texture_size / 2;
+		target_position -= texture_size / 2;
 	}
 	// there's nothing to be used as source position so snapping will work as absolute if enabled
-	target_pos = canvas->snap_point(target_pos);
-	editor_data->get_undo_redo().add_do_method(child, "set_position", target_pos);
+	target_position = canvas->snap_point(target_position);
+	editor_data->get_undo_redo().add_do_method(child, "set_position", target_position);
 }
 
 bool CanvasItemEditorViewport::_create_instance(Node *parent, String &path, const Point2 &p_point) {

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -188,7 +188,7 @@ void CurveEditor::on_gui_input(const Ref<InputEvent> &p_event) {
 				} else {
 					// Drag tangent
 
-					Vector2 point_pos = curve.get_point_pos(_selected_point);
+					Vector2 point_pos = curve.get_point_position(_selected_point);
 					Vector2 control_pos = get_world_pos(mpos);
 
 					Vector2 dir = (control_pos - point_pos).normalized();
@@ -378,7 +378,7 @@ int CurveEditor::get_point_at(Vector2 pos) const {
 	const float r = _hover_radius * _hover_radius;
 
 	for (int i = 0; i < curve.get_point_count(); ++i) {
-		Vector2 p = get_view_pos(curve.get_point_pos(i));
+		Vector2 p = get_view_pos(curve.get_point_position(i));
 		if (p.distance_squared_to(pos) <= r) {
 			return i;
 		}
@@ -525,8 +525,8 @@ Vector2 CurveEditor::get_tangent_view_pos(int i, TangentIndex tangent) const {
 	else
 		dir = Vector2(1, _curve_ref->get_point_right_tangent(i));
 
-	Vector2 point_pos = get_view_pos(_curve_ref->get_point_pos(i));
-	Vector2 control_pos = get_view_pos(_curve_ref->get_point_pos(i) + dir);
+	Vector2 point_pos = get_view_pos(_curve_ref->get_point_position(i));
+	Vector2 control_pos = get_view_pos(_curve_ref->get_point_position(i) + dir);
 
 	return point_pos + _tangents_length * (control_pos - point_pos).normalized();
 }
@@ -549,8 +549,8 @@ static void plot_curve_accurate(const Curve &curve, float step, T plot_func) {
 		plot_func(Vector2(0, y), Vector2(1.f, y), true);
 
 	} else {
-		Vector2 first_point = curve.get_point_pos(0);
-		Vector2 last_point = curve.get_point_pos(curve.get_point_count() - 1);
+		Vector2 first_point = curve.get_point_position(0);
+		Vector2 last_point = curve.get_point_position(curve.get_point_count() - 1);
 
 		// Edge lines
 		plot_func(Vector2(0, first_point.y), first_point, false);
@@ -559,8 +559,8 @@ static void plot_curve_accurate(const Curve &curve, float step, T plot_func) {
 		// Draw section by section, so that we get maximum precision near points.
 		// It's an accurate representation, but slower than using the baked one.
 		for (int i = 1; i < curve.get_point_count(); ++i) {
-			Vector2 a = curve.get_point_pos(i - 1);
-			Vector2 b = curve.get_point_pos(i);
+			Vector2 a = curve.get_point_position(i - 1);
+			Vector2 b = curve.get_point_position(i);
 
 			Vector2 pos = a;
 			Vector2 prev_pos = a;
@@ -667,7 +667,7 @@ void CurveEditor::_draw() {
 		const Color tangent_color(0.5, 0.5, 1, 1);
 
 		int i = _selected_point;
-		Vector2 pos = curve.get_point_pos(i);
+		Vector2 pos = curve.get_point_position(i);
 
 		if (i != 0) {
 			Vector2 control_pos = get_tangent_view_pos(i, TANGENT_LEFT);
@@ -718,7 +718,7 @@ void CurveEditor::_draw() {
 	const Color selected_point_color(1, 0.5, 0.5);
 
 	for (int i = 0; i < curve.get_point_count(); ++i) {
-		Vector2 pos = curve.get_point_pos(i);
+		Vector2 pos = curve.get_point_position(i);
 		draw_rect(Rect2(get_view_pos(pos), Vector2(1, 1)).grow(3), i == _selected_point ? selected_point_color : point_color);
 		// TODO Circles are prettier. Needs a fix! Or a texture
 		//draw_circle(pos, 2, point_color);
@@ -728,7 +728,7 @@ void CurveEditor::_draw() {
 
 	if (_hover_point != -1) {
 		const Color hover_color = line_color;
-		Vector2 pos = curve.get_point_pos(_hover_point);
+		Vector2 pos = curve.get_point_position(_hover_point);
 		stroke_rect(Rect2(get_view_pos(pos), Vector2(1, 1)).grow(_hover_radius), hover_color);
 	}
 

--- a/editor/plugins/line_2d_editor_plugin.cpp
+++ b/editor/plugins/line_2d_editor_plugin.cpp
@@ -66,7 +66,7 @@ int Line2DEditor::get_point_index_at(Vector2 gpos) {
 	Transform2D xform = canvas_item_editor->get_canvas_transform() * node->get_global_transform();
 
 	for (int i = 0; i < node->get_point_count(); ++i) {
-		Point2 p = xform.xform(node->get_point_pos(i));
+		Point2 p = xform.xform(node->get_point_position(i));
 		if (gpos.distance_to(p) < grab_threshold) {
 			return i;
 		}
@@ -96,12 +96,12 @@ bool Line2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 				if (mb->get_button_index() == BUTTON_LEFT && !mb->get_shift() && mode == MODE_EDIT) {
 					_dragging = true;
 					action_point = i;
-					moving_from = node->get_point_pos(i);
+					moving_from = node->get_point_position(i);
 					moving_screen_from = gpoint;
 				} else if ((mb->get_button_index() == BUTTON_RIGHT && mode == MODE_EDIT) || (mb->get_button_index() == BUTTON_LEFT && mode == MODE_DELETE)) {
 					undo_redo->create_action(TTR("Remove Point from Line2D"));
 					undo_redo->add_do_method(node, "remove_point", i);
-					undo_redo->add_undo_method(node, "add_point", node->get_point_pos(i), i);
+					undo_redo->add_undo_method(node, "add_point", node->get_point_position(i), i);
 					undo_redo->add_do_method(canvas_item_editor->get_viewport_control(), "update");
 					undo_redo->add_undo_method(canvas_item_editor->get_viewport_control(), "update");
 					undo_redo->commit_action();
@@ -121,7 +121,7 @@ bool Line2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 
 			_dragging = true;
 			action_point = node->get_point_count() - 1;
-			moving_from = node->get_point_pos(action_point);
+			moving_from = node->get_point_position(action_point);
 			moving_screen_from = gpoint;
 
 			canvas_item_editor->get_viewport_control()->update();
@@ -131,8 +131,8 @@ bool Line2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 
 		if (!mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT && _dragging) {
 			undo_redo->create_action(TTR("Move Point in Line2D"));
-			undo_redo->add_do_method(node, "set_point_pos", action_point, cpoint);
-			undo_redo->add_undo_method(node, "set_point_pos", action_point, moving_from);
+			undo_redo->add_do_method(node, "set_point_position", action_point, cpoint);
+			undo_redo->add_undo_method(node, "set_point_position", action_point, moving_from);
 			undo_redo->add_do_method(canvas_item_editor->get_viewport_control(), "update");
 			undo_redo->add_undo_method(canvas_item_editor->get_viewport_control(), "update");
 			undo_redo->commit_action();
@@ -147,7 +147,7 @@ bool Line2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 
 		if (_dragging) {
 			Vector2 cpoint = mouse_to_local_pos(mm->get_position(), mm->get_alt());
-			node->set_point_pos(action_point, cpoint);
+			node->set_point_position(action_point, cpoint);
 			canvas_item_editor->get_viewport_control()->update();
 			return true;
 		}
@@ -172,7 +172,7 @@ void Line2DEditor::_canvas_draw() {
 	Control *vpc = canvas_item_editor->get_viewport_control();
 
 	for (int i = 0; i < len; ++i) {
-		Vector2 point = xform.xform(node->get_point_pos(i));
+		Vector2 point = xform.xform(node->get_point_position(i));
 		vpc->draw_texture_rect(handle, Rect2(point - handle_size * 0.5, handle_size), false);
 	}
 }

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -89,9 +89,9 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 
 			for (int i = 0; i < curve->get_point_count(); i++) {
 
-				real_t dist_to_p = gpoint.distance_to(xform.xform(curve->get_point_pos(i)));
-				real_t dist_to_p_out = gpoint.distance_to(xform.xform(curve->get_point_pos(i) + curve->get_point_out(i)));
-				real_t dist_to_p_in = gpoint.distance_to(xform.xform(curve->get_point_pos(i) + curve->get_point_in(i)));
+				real_t dist_to_p = gpoint.distance_to(xform.xform(curve->get_point_position(i)));
+				real_t dist_to_p_out = gpoint.distance_to(xform.xform(curve->get_point_position(i) + curve->get_point_out(i)));
+				real_t dist_to_p_in = gpoint.distance_to(xform.xform(curve->get_point_position(i) + curve->get_point_in(i)));
 
 				// Check for point movement start (for point + in/out controls).
 				if (mb->get_button_index() == BUTTON_LEFT) {
@@ -100,7 +100,7 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 
 						action = ACTION_MOVING_POINT;
 						action_point = i;
-						moving_from = curve->get_point_pos(i);
+						moving_from = curve->get_point_position(i);
 						moving_screen_from = gpoint;
 						return true;
 					} else if (mode == MODE_EDIT || mode == MODE_EDIT_CURVE) {
@@ -129,7 +129,7 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 
 						undo_redo->create_action(TTR("Remove Point from Curve"));
 						undo_redo->add_do_method(curve.ptr(), "remove_point", i);
-						undo_redo->add_undo_method(curve.ptr(), "add_point", curve->get_point_pos(i), curve->get_point_in(i), curve->get_point_out(i), i);
+						undo_redo->add_undo_method(curve.ptr(), "add_point", curve->get_point_position(i), curve->get_point_in(i), curve->get_point_out(i), i);
 						undo_redo->add_do_method(canvas_item_editor->get_viewport_control(), "update");
 						undo_redo->add_undo_method(canvas_item_editor->get_viewport_control(), "update");
 						undo_redo->commit_action();
@@ -171,7 +171,7 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 
 			action = ACTION_MOVING_POINT;
 			action_point = curve->get_point_count() - 1;
-			moving_from = curve->get_point_pos(action_point);
+			moving_from = curve->get_point_position(action_point);
 			moving_screen_from = gpoint;
 
 			canvas_item_editor->get_viewport_control()->update();
@@ -194,8 +194,8 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 				case ACTION_MOVING_POINT: {
 
 					undo_redo->create_action(TTR("Move Point in Curve"));
-					undo_redo->add_do_method(curve.ptr(), "set_point_pos", action_point, cpoint);
-					undo_redo->add_undo_method(curve.ptr(), "set_point_pos", action_point, moving_from);
+					undo_redo->add_do_method(curve.ptr(), "set_point_position", action_point, cpoint);
+					undo_redo->add_undo_method(curve.ptr(), "set_point_position", action_point, moving_from);
 					undo_redo->add_do_method(canvas_item_editor->get_viewport_control(), "update");
 					undo_redo->add_undo_method(canvas_item_editor->get_viewport_control(), "update");
 					undo_redo->commit_action();
@@ -255,7 +255,7 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 					break;
 
 				case ACTION_MOVING_POINT: {
-					curve->set_point_pos(action_point, cpoint);
+					curve->set_point_position(action_point, cpoint);
 				} break;
 
 				case ACTION_MOVING_IN: {
@@ -296,17 +296,17 @@ void Path2DEditor::_canvas_draw() {
 
 	for (int i = 0; i < len; i++) {
 
-		Vector2 point = xform.xform(curve->get_point_pos(i));
+		Vector2 point = xform.xform(curve->get_point_position(i));
 		vpc->draw_texture_rect(handle, Rect2(point - handle_size * 0.5, handle_size), false, Color(1, 1, 1, 1));
 
 		if (i < len - 1) {
-			Vector2 pointout = xform.xform(curve->get_point_pos(i) + curve->get_point_out(i));
+			Vector2 pointout = xform.xform(curve->get_point_position(i) + curve->get_point_out(i));
 			vpc->draw_line(point, pointout, Color(0.5, 0.5, 1.0, 0.8), 1.0);
 			vpc->draw_texture_rect(handle, Rect2(pointout - handle_size * 0.5, handle_size), false, Color(1, 0.5, 1, 0.3));
 		}
 
 		if (i > 0) {
-			Vector2 pointin = xform.xform(curve->get_point_pos(i) + curve->get_point_in(i));
+			Vector2 pointin = xform.xform(curve->get_point_position(i) + curve->get_point_in(i));
 			vpc->draw_line(point, pointin, Color(0.5, 0.5, 1.0, 0.8), 1.0);
 			vpc->draw_texture_rect(handle, Rect2(pointin - handle_size * 0.5, handle_size), false, Color(1, 0.5, 1, 0.3));
 		}
@@ -389,8 +389,8 @@ void Path2DEditor::_mode_selected(int p_mode) {
 		if (node->get_curve()->get_point_count() < 3)
 			return;
 
-		Vector2 begin = node->get_curve()->get_point_pos(0);
-		Vector2 end = node->get_curve()->get_point_pos(node->get_curve()->get_point_count() - 1);
+		Vector2 begin = node->get_curve()->get_point_position(0);
+		Vector2 end = node->get_curve()->get_point_position(node->get_curve()->get_point_count() - 1);
 		if (begin.distance_to(end) < CMP_EPSILON)
 			return;
 

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -254,7 +254,7 @@ void ResourcePreloaderEditor::edit(ResourcePreloader *p_preloader) {
 
 Variant ResourcePreloaderEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
 
-	TreeItem *ti = tree->get_item_at_pos(p_point);
+	TreeItem *ti = tree->get_item_at_position(p_point);
 	if (!ti)
 		return Variant();
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -306,7 +306,7 @@ Variant ScriptTextEditor::get_edit_state() {
 
 	Dictionary state;
 
-	state["scroll_pos"] = code_editor->get_text_edit()->get_v_scroll();
+	state["scroll_position"] = code_editor->get_text_edit()->get_v_scroll();
 	state["column"] = code_editor->get_text_edit()->cursor_get_column();
 	state["row"] = code_editor->get_text_edit()->cursor_get_line();
 
@@ -509,7 +509,7 @@ void ScriptTextEditor::ensure_focus() {
 void ScriptTextEditor::set_edit_state(const Variant &p_state) {
 
 	Dictionary state = p_state;
-	code_editor->get_text_edit()->set_v_scroll(state["scroll_pos"]);
+	code_editor->get_text_edit()->set_v_scroll(state["scroll_position"]);
 	code_editor->get_text_edit()->cursor_set_column(state["column"]);
 	code_editor->get_text_edit()->cursor_set_line(state["row"]);
 	code_editor->get_text_edit()->grab_focus();
@@ -1397,7 +1397,7 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 						float alpha = color.size() > 3 ? color[3] : 1.0f;
 						color_picker->set_pick_color(Color(color[0], color[1], color[2], alpha));
 					}
-					color_panel->set_position(get_global_transform().xform(get_local_mouse_pos()));
+					color_panel->set_position(get_global_transform().xform(get_local_mouse_position()));
 				} else {
 					have_color = false;
 				}
@@ -1445,7 +1445,7 @@ void ScriptTextEditor::_make_context_menu(bool p_selection, bool p_color) {
 		context_menu->add_separator();
 		context_menu->add_item(TTR("Pick Color"), EDIT_PICK_COLOR);
 	}
-	context_menu->set_position(get_global_transform().xform(get_local_mouse_pos()));
+	context_menu->set_position(get_global_transform().xform(get_local_mouse_position()));
 	context_menu->set_size(Vector2(1, 1));
 	context_menu->popup();
 }

--- a/editor/plugins/shader_graph_editor_plugin.cpp
+++ b/editor/plugins/shader_graph_editor_plugin.cpp
@@ -54,7 +54,7 @@ void GraphColorRampEdit::_gui_input(const InputEvent& p_event) {
 	if (p_event.type==InputEvent::MOUSE_BUTTON && p_event->get_button_index()==1 && p_event->is_pressed()) {
 
 		update();
-		int x = p_event->get_pos().x;
+		int x = p_event->get_position().x;
 		int total_w = get_size().width-get_size().height-3;
 		if (x>total_w+3) {
 
@@ -333,7 +333,7 @@ void GraphCurveMapEdit::_gui_input(const InputEvent& p_event) {
 	if (p_event.type==InputEvent::MOUSE_BUTTON && p_event->get_button_index()==1 && p_event->is_pressed()) {
 
 		update();
-		Point2 p = Vector2(p_event->get_pos().x,p_event->get_pos().y)/get_size();
+		Point2 p = Vector2(p_event->get_position().x,p_event->get_position().y)/get_size();
 		p.y=1.0-p.y;
 		grabbed=-1;
 		grabbing=true;
@@ -384,7 +384,7 @@ void GraphCurveMapEdit::_gui_input(const InputEvent& p_event) {
 
 	if (p_event.type==InputEvent::MOUSE_MOTION && grabbing  && grabbed != -1) {
 
-		Point2 p = Vector2(p_event->get_pos().x,p_event->get_pos().y)/get_size();
+		Point2 p = Vector2(p_event->get_position().x,p_event->get_position().y)/get_size();
 		p.y=1.0-p.y;
 
 		p.x = CLAMP(p.x,0.0,1.0);
@@ -1205,7 +1205,7 @@ void ShaderGraphView::_move_node(int p_id,const Vector2& p_to) {
 
 	ERR_FAIL_COND(!node_map.has(p_id));
 	node_map[p_id]->set_offset(p_to);
-	graph->node_set_pos(type,p_id,p_to);
+	graph->node_set_position(type,p_id,p_to);
 }
 
 void ShaderGraphView::_duplicate_nodes_request()
@@ -2463,7 +2463,7 @@ void ShaderGraphView::_create_node(int p_id) {
 	gn->connect("close_request",this,"_node_removed",varray(p_id),CONNECT_DEFERRED);
 	graph_edit->add_child(gn);
 	node_map[p_id]=gn;
-	gn->set_offset(graph->node_get_pos(type,p_id));
+	gn->set_offset(graph->node_get_position(type,p_id));
 
 
 }
@@ -2657,7 +2657,7 @@ void ShaderGraphView::add_node(int p_type, const Vector2 &location) {
 	while(true) {
 		bool valid=true;
 		for(List<int>::Element *E=existing.front();E;E=E->next()) {
-			Vector2 pos = graph->node_get_pos(type,E->get());
+			Vector2 pos = graph->node_get_position(type,E->get());
 			if (init_ofs==pos) {
 				init_ofs+=Vector2(20,20);
 				valid=false;
@@ -2672,7 +2672,7 @@ void ShaderGraphView::add_node(int p_type, const Vector2 &location) {
 	UndoRedo *ur=EditorNode::get_singleton()->get_undo_redo();
 	ur->create_action(TTR("Add Shader Graph Node"));
 	ur->add_do_method(graph.ptr(),"node_add",type,p_type,newid);
-	ur->add_do_method(graph.ptr(),"node_set_pos",type,newid,init_ofs);
+	ur->add_do_method(graph.ptr(),"node_set_position",type,newid,init_ofs);
 	ur->add_undo_method(graph.ptr(),"node_remove",type,newid);
 	ur->add_do_method(this,"_update_graph");
 	ur->add_undo_method(this,"_update_graph");
@@ -2765,7 +2765,7 @@ void ShaderGraphEditor::_add_node(int p_type) {
 void ShaderGraphEditor::_popup_requested(const Vector2 &p_position)
 {
 	Vector2 scroll_ofs=graph_edits[tabs->get_current_tab()]->get_graph_edit()->get_scroll_ofs();
-	next_location = get_local_mouse_pos() + scroll_ofs;
+	next_location = get_local_mouse_position() + scroll_ofs;
 	popup->set_global_position(p_position);
 	popup->set_size( Size2( 200, 0) );
 	popup->popup();

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -217,7 +217,7 @@ Transform SpatialEditorViewport::_get_camera_transform() const {
 	return camera->get_global_transform();
 }
 
-Vector3 SpatialEditorViewport::_get_camera_pos() const {
+Vector3 SpatialEditorViewport::_get_camera_position() const {
 
 	return _get_camera_transform().origin;
 }
@@ -464,7 +464,7 @@ void SpatialEditorViewport::_select_region() {
 
 	Vector<Plane> frustum;
 
-	Vector3 cam_pos = _get_camera_pos();
+	Vector3 cam_pos = _get_camera_position();
 	Set<Ref<SpatialEditorGizmo> > found_gizmos;
 
 	for (int i = 0; i < 4; i++) {
@@ -2366,9 +2366,9 @@ void SpatialEditorViewport::update_transform_gizmo_view() {
 
 void SpatialEditorViewport::set_state(const Dictionary &p_state) {
 
-	cursor.pos = p_state["pos"];
-	cursor.x_rot = p_state["x_rot"];
-	cursor.y_rot = p_state["y_rot"];
+	cursor.pos = p_state["position"];
+	cursor.x_rot = p_state["x_rotation"];
+	cursor.y_rot = p_state["y_rotation"];
 	cursor.distance = p_state["distance"];
 	bool env = p_state["use_environment"];
 	bool orth = p_state["use_orthogonal"];
@@ -2410,9 +2410,9 @@ void SpatialEditorViewport::set_state(const Dictionary &p_state) {
 Dictionary SpatialEditorViewport::get_state() const {
 
 	Dictionary d;
-	d["pos"] = cursor.pos;
-	d["x_rot"] = cursor.x_rot;
-	d["y_rot"] = cursor.y_rot;
+	d["position"] = cursor.pos;
+	d["x_rotation"] = cursor.x_rot;
+	d["y_rotation"] = cursor.y_rot;
 	d["distance"] = cursor.distance;
 	d["use_environment"] = camera->get_environment().is_valid();
 	d["use_orthogonal"] = camera->get_projection() == Camera::PROJECTION_ORTHOGONAL;

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -157,7 +157,7 @@ private:
 	Transform _get_camera_transform() const;
 	int get_selected_count() const;
 
-	Vector3 _get_camera_pos() const;
+	Vector3 _get_camera_position() const;
 	Vector3 _get_camera_normal() const;
 	Vector3 _get_screen_to_space(const Vector3 &p_vector3);
 

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -544,7 +544,7 @@ Variant SpriteFramesEditor::get_drag_data_fw(const Point2 &p_point, Control *p_f
 	if (!frames->has_animation(edited_anim))
 		return false;
 
-	int idx = tree->get_item_at_pos(p_point, true);
+	int idx = tree->get_item_at_position(p_point, true);
 
 	if (idx < 0 || idx >= frames->get_frame_count(edited_anim))
 		return Variant();
@@ -609,7 +609,7 @@ void SpriteFramesEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 	if (!d.has("type"))
 		return;
 
-	int at_pos = tree->get_item_at_pos(p_point, true);
+	int at_pos = tree->get_item_at_position(p_point, true);
 
 	if (String(d["type"]) == "resource" && d.has("resource")) {
 		RES r = d["resource"];
@@ -643,7 +643,7 @@ void SpriteFramesEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_empty2_pressed"), &SpriteFramesEditor::_empty2_pressed);
 	ClassDB::bind_method(D_METHOD("_delete_pressed"), &SpriteFramesEditor::_delete_pressed);
 	ClassDB::bind_method(D_METHOD("_paste_pressed"), &SpriteFramesEditor::_paste_pressed);
-	ClassDB::bind_method(D_METHOD("_file_load_request", "files", "atpos"), &SpriteFramesEditor::_file_load_request, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("_file_load_request", "files", "at_position"), &SpriteFramesEditor::_file_load_request, DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("_update_library", "skipsel"), &SpriteFramesEditor::_update_library, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("_up_pressed"), &SpriteFramesEditor::_up_pressed);
 	ClassDB::bind_method(D_METHOD("_down_pressed"), &SpriteFramesEditor::_down_pressed);

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -434,7 +434,7 @@ void ProjectExportDialog::_delete_preset_confirm() {
 Variant ProjectExportDialog::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
 
 	if (p_from == presets) {
-		int pos = presets->get_item_at_pos(p_point, true);
+		int pos = presets->get_item_at_position(p_point, true);
 
 		if (pos >= 0) {
 			Dictionary d;
@@ -455,7 +455,7 @@ Variant ProjectExportDialog::get_drag_data_fw(const Point2 &p_point, Control *p_
 		}
 	} else if (p_from == patches) {
 
-		TreeItem *item = patches->get_item_at_pos(p_point);
+		TreeItem *item = patches->get_item_at_position(p_point);
 
 		if (item && item->get_cell_mode(0) == TreeItem::CELL_MODE_CHECK) {
 
@@ -482,7 +482,7 @@ bool ProjectExportDialog::can_drop_data_fw(const Point2 &p_point, const Variant 
 		if (!d.has("type") || String(d["type"]) != "export_preset")
 			return false;
 
-		if (presets->get_item_at_pos(p_point, true) < 0 && !presets->is_pos_at_end_of_items(p_point))
+		if (presets->get_item_at_position(p_point, true) < 0 && !presets->is_pos_at_end_of_items(p_point))
 			return false;
 	} else if (p_from == patches) {
 
@@ -492,7 +492,7 @@ bool ProjectExportDialog::can_drop_data_fw(const Point2 &p_point, const Variant 
 
 		patches->set_drop_mode_flags(Tree::DROP_MODE_ON_ITEM);
 
-		TreeItem *item = patches->get_item_at_pos(p_point);
+		TreeItem *item = patches->get_item_at_position(p_point);
 
 		if (!item) {
 
@@ -511,8 +511,8 @@ void ProjectExportDialog::drop_data_fw(const Point2 &p_point, const Variant &p_d
 
 		int to_pos = -1;
 
-		if (presets->get_item_at_pos(p_point, true) >= 0) {
-			to_pos = presets->get_item_at_pos(p_point, true);
+		if (presets->get_item_at_position(p_point, true) >= 0) {
+			to_pos = presets->get_item_at_position(p_point, true);
 		}
 
 		if (to_pos == -1 && !presets->is_pos_at_end_of_items(p_point))
@@ -541,7 +541,7 @@ void ProjectExportDialog::drop_data_fw(const Point2 &p_point, const Variant &p_d
 
 		int from_pos = d["patch"];
 
-		TreeItem *item = patches->get_item_at_pos(p_point);
+		TreeItem *item = patches->get_item_at_position(p_point);
 		if (!item)
 			return;
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -987,15 +987,15 @@ void ProjectManager::_on_project_created(const String &dir) {
 		}
 	}
 	if (has_already) {
-		_update_scroll_pos(dir);
+		_update_scroll_position(dir);
 	} else {
 		_load_recent_projects();
-		_update_scroll_pos(dir);
+		_update_scroll_position(dir);
 	}
 	_open_project();
 }
 
-void ProjectManager::_update_scroll_pos(const String &dir) {
+void ProjectManager::_update_scroll_position(const String &dir) {
 	for (int i = 0; i < scroll_childs->get_child_count(); i++) {
 		HBoxContainer *hb = Object::cast_to<HBoxContainer>(scroll_childs->get_child(i));
 		Label *fpath = Object::cast_to<Label>(hb->get_node(NodePath("project/path")));
@@ -1294,7 +1294,7 @@ void ProjectManager::_bind_methods() {
 	ClassDB::bind_method("_load_recent_projects", &ProjectManager::_load_recent_projects);
 	ClassDB::bind_method("_on_project_renamed", &ProjectManager::_on_project_renamed);
 	ClassDB::bind_method("_on_project_created", &ProjectManager::_on_project_created);
-	ClassDB::bind_method("_update_scroll_pos", &ProjectManager::_update_scroll_pos);
+	ClassDB::bind_method("_update_scroll_position", &ProjectManager::_update_scroll_position);
 	ClassDB::bind_method("_panel_draw", &ProjectManager::_panel_draw);
 	ClassDB::bind_method("_panel_input", &ProjectManager::_panel_input);
 	ClassDB::bind_method("_unhandled_input", &ProjectManager::_unhandled_input);

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -90,7 +90,7 @@ class ProjectManager : public Control {
 	void _load_recent_projects();
 	void _on_project_created(const String &dir);
 	void _on_project_renamed();
-	void _update_scroll_pos(const String &dir);
+	void _update_scroll_position(const String &dir);
 	void _scan_dir(DirAccess *da, float pos, float total, List<String> *r_projects);
 
 	void _install_project(const String &p_zip_path, const String &p_title);

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -2368,7 +2368,7 @@ void PropertyEditor::_mark_drop_fields(TreeItem *p_at) {
 
 Variant PropertyEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
 
-	TreeItem *item = tree->get_item_at_pos(p_point);
+	TreeItem *item = tree->get_item_at_position(p_point);
 	if (!item)
 		return Variant();
 
@@ -2376,7 +2376,7 @@ Variant PropertyEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from)
 	if (!d.has("name"))
 		return Variant();
 
-	int col = tree->get_column_at_pos(p_point);
+	int col = tree->get_column_at_position(p_point);
 	if (col == 0) {
 
 		Dictionary dp;
@@ -2407,11 +2407,11 @@ Variant PropertyEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from)
 
 bool PropertyEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
 
-	TreeItem *item = tree->get_item_at_pos(p_point);
+	TreeItem *item = tree->get_item_at_position(p_point);
 	if (!item)
 		return false;
 
-	int col = tree->get_column_at_pos(p_point);
+	int col = tree->get_column_at_position(p_point);
 	if (col != 1)
 		return false;
 
@@ -2419,11 +2419,11 @@ bool PropertyEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_da
 }
 void PropertyEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
 
-	TreeItem *item = tree->get_item_at_pos(p_point);
+	TreeItem *item = tree->get_item_at_position(p_point);
 	if (!item)
 		return;
 
-	int col = tree->get_column_at_pos(p_point);
+	int col = tree->get_column_at_position(p_point);
 	if (col != 1)
 		return;
 

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -817,11 +817,11 @@ bool SceneTreeEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_d
 	if (!d.has("type"))
 		return false;
 
-	TreeItem *item = tree->get_item_at_pos(p_point);
+	TreeItem *item = tree->get_item_at_position(p_point);
 	if (!item)
 		return false;
 
-	int section = tree->get_drop_section_at_pos(p_point);
+	int section = tree->get_drop_section_at_position(p_point);
 	if (section < -1 || (section == -1 && !item->get_parent()))
 		return false;
 
@@ -860,10 +860,10 @@ void SceneTreeEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data,
 	if (!can_drop_data_fw(p_point, p_data, p_from))
 		return;
 
-	TreeItem *item = tree->get_item_at_pos(p_point);
+	TreeItem *item = tree->get_item_at_position(p_point);
 	if (!item)
 		return;
-	int section = tree->get_drop_section_at_pos(p_point);
+	int section = tree->get_drop_section_at_position(p_point);
 	if (section < -1)
 		return;
 
@@ -950,7 +950,7 @@ void SceneTreeEditor::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("nodes_rearranged", PropertyInfo(Variant::ARRAY, "paths"), PropertyInfo(Variant::NODE_PATH, "to_path"), PropertyInfo(Variant::INT, "type")));
 	ADD_SIGNAL(MethodInfo("files_dropped", PropertyInfo(Variant::POOL_STRING_ARRAY, "files"), PropertyInfo(Variant::NODE_PATH, "to_path"), PropertyInfo(Variant::INT, "type")));
 	ADD_SIGNAL(MethodInfo("script_dropped", PropertyInfo(Variant::STRING, "file"), PropertyInfo(Variant::NODE_PATH, "to_path")));
-	ADD_SIGNAL(MethodInfo("rmb_pressed", PropertyInfo(Variant::VECTOR2, "pos")));
+	ADD_SIGNAL(MethodInfo("rmb_pressed", PropertyInfo(Variant::VECTOR2, "position")));
 
 	ADD_SIGNAL(MethodInfo("open"));
 	ADD_SIGNAL(MethodInfo("open_script"));

--- a/editor/translations/ar.po
+++ b/editor/translations/ar.po
@@ -4449,15 +4449,15 @@ msgid "Curve Point #"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/bg.po
+++ b/editor/translations/bg.po
@@ -4470,15 +4470,15 @@ msgid "Curve Point #"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/bn.po
+++ b/editor/translations/bn.po
@@ -4621,15 +4621,15 @@ msgid "Curve Point #"
 msgstr "বক্ররেখার বিন্দু #"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr "বক্ররেখার বিন্দুর স্থান নির্ধারণ করুন"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr "আন্ত-বক্ররেখার স্থান নির্ধারণ করুন"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr "বহিঃ-বক্ররেখার স্থান নির্ধারণ করুন"
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/ca.po
+++ b/editor/translations/ca.po
@@ -4582,15 +4582,15 @@ msgid "Curve Point #"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/cs.po
+++ b/editor/translations/cs.po
@@ -4495,15 +4495,15 @@ msgid "Curve Point #"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/da.po
+++ b/editor/translations/da.po
@@ -4485,15 +4485,15 @@ msgid "Curve Point #"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/de.po
+++ b/editor/translations/de.po
@@ -4593,15 +4593,15 @@ msgid "Curve Point #"
 msgstr "Kurvenpunkt #"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr "Position des Kurvenpunkts setzen"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr "Position der Eingangskurve setzen"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr "Position der Ausgangskurve setzen"
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/de_CH.po
+++ b/editor/translations/de_CH.po
@@ -4496,15 +4496,15 @@ msgid "Curve Point #"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/editor.pot
+++ b/editor/translations/editor.pot
@@ -4436,15 +4436,15 @@ msgid "Curve Point #"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/el.po
+++ b/editor/translations/el.po
@@ -4577,15 +4577,15 @@ msgid "Curve Point #"
 msgstr "Σημείο καμπύλης #"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr "Ορισμός θέσης σημείου καμπύλης"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr "Ορισμός θέσης εισόδου καμπύλης"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr "Ορισμός θέσης εξόδου καμπύλης"
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/es.po
+++ b/editor/translations/es.po
@@ -4672,15 +4672,15 @@ msgid "Curve Point #"
 msgstr "Nº de punto en curva"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr "Establecer pos. de punto de curva"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr "Establecer pos. de entrada de curva"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr "Establecer pos. de salida de curva"
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/es_AR.po
+++ b/editor/translations/es_AR.po
@@ -4572,15 +4572,15 @@ msgid "Curve Point #"
 msgstr "Punto # de Curva"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr "Setear Pos. de Punto de Curva"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr "Setear Pos. In de Curva"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr "Setear Pos. Out de Curva"
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/fa.po
+++ b/editor/translations/fa.po
@@ -4514,15 +4514,15 @@ msgid "Curve Point #"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/fi.po
+++ b/editor/translations/fi.po
@@ -4577,15 +4577,15 @@ msgid "Curve Point #"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/fr.po
+++ b/editor/translations/fr.po
@@ -4662,15 +4662,15 @@ msgid "Curve Point #"
 msgstr "Point de courbe #"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr "Définir la position du point de la courbe"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/hu.po
+++ b/editor/translations/hu.po
@@ -4441,15 +4441,15 @@ msgid "Curve Point #"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/id.po
+++ b/editor/translations/id.po
@@ -4564,15 +4564,15 @@ msgid "Curve Point #"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/it.po
+++ b/editor/translations/it.po
@@ -4573,15 +4573,15 @@ msgid "Curve Point #"
 msgstr "Punto Curva #"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr "Imposta Posizione Punti curva"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr "Imposta Posizione Curve In"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr "Imposta Posizione Curve Out"
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/ja.po
+++ b/editor/translations/ja.po
@@ -5250,17 +5250,17 @@ msgstr "曲線のポイント#"
 
 #: editor/plugins/path_editor_plugin.cpp
 #, fuzzy
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr "曲線のポイントの位置を指定"
 
 #: editor/plugins/path_editor_plugin.cpp
 #, fuzzy
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr "曲線のIn-ハンドルの位置を指定"
 
 #: editor/plugins/path_editor_plugin.cpp
 #, fuzzy
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr "曲線のOut-ハンドルの位置を指定"
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/ko.po
+++ b/editor/translations/ko.po
@@ -4606,15 +4606,15 @@ msgid "Curve Point #"
 msgstr "커브 포인트 #"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr "커브 포인트 위치 설정"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr "커브 포인트 In 설정"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr "커브 포인트 Out 설정"
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/nb.po
+++ b/editor/translations/nb.po
@@ -4454,15 +4454,15 @@ msgid "Curve Point #"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/nl.po
+++ b/editor/translations/nl.po
@@ -4517,15 +4517,15 @@ msgid "Curve Point #"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/pl.po
+++ b/editor/translations/pl.po
@@ -4644,15 +4644,15 @@ msgid "Curve Point #"
 msgstr "Punkt Krzywej #"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr "Ustaw pozycje punktu krzywej"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/pr.po
+++ b/editor/translations/pr.po
@@ -4452,15 +4452,15 @@ msgid "Curve Point #"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/pt_BR.po
+++ b/editor/translations/pt_BR.po
@@ -4599,15 +4599,15 @@ msgid "Curve Point #"
 msgstr "Ponto da Curva nº"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr "Definir Pos do Ponto da Curva"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr "Definir Pos da Entrada da Curva"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr "Definir Pos da Saída da Curva"
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/pt_PT.po
+++ b/editor/translations/pt_PT.po
@@ -4451,15 +4451,15 @@ msgid "Curve Point #"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/ru.po
+++ b/editor/translations/ru.po
@@ -4571,15 +4571,15 @@ msgid "Curve Point #"
 msgstr "Точка Кривой #"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr "Установить позицию точки кривой"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr "Установить позицию входа кривой"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr "Установить позицию выхода кривой"
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/sk.po
+++ b/editor/translations/sk.po
@@ -4462,15 +4462,15 @@ msgid "Curve Point #"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/sl.po
+++ b/editor/translations/sl.po
@@ -4452,15 +4452,15 @@ msgid "Curve Point #"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/th.po
+++ b/editor/translations/th.po
@@ -4531,15 +4531,15 @@ msgid "Curve Point #"
 msgstr "จุดเส้นโค้ง #"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr "กำหนดพิกัดจุดเส้นโค้ง"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr "กำหนดเส้นโค้งขาเข้า"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr "กำหนดเส้นโค้งขาออก"
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/tr.po
+++ b/editor/translations/tr.po
@@ -4610,15 +4610,15 @@ msgid "Curve Point #"
 msgstr "Eğrisel Nokta #"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr "Eğri Noktası Konumu Ayarla"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr "Eğriyi Konumda Ayarla"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr "Eğri Çıkış Konumunu Ayarla"
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/ur_PK.po
+++ b/editor/translations/ur_PK.po
@@ -4455,15 +4455,15 @@ msgid "Curve Point #"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/zh_CN.po
+++ b/editor/translations/zh_CN.po
@@ -4525,15 +4525,15 @@ msgid "Curve Point #"
 msgstr "曲线定点 #"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr "设置曲线顶点坐标"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr "设置的曲线输入位置（Pos）"
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr "设置曲线输出位置（Pos）"
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/zh_HK.po
+++ b/editor/translations/zh_HK.po
@@ -4515,15 +4515,15 @@ msgid "Curve Point #"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/editor/translations/zh_TW.po
+++ b/editor/translations/zh_TW.po
@@ -4474,15 +4474,15 @@ msgid "Curve Point #"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Point Pos"
+msgid "Set Curve Point Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve In Pos"
+msgid "Set Curve In Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp
-msgid "Set Curve Out Pos"
+msgid "Set Curve Out Position"
 msgstr ""
 
 #: editor/plugins/path_editor_plugin.cpp

--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -422,9 +422,9 @@ int InputDefault::get_mouse_button_mask() const {
 	return mouse_button_mask; // do not trust OS implementaiton, should remove it - OS::get_singleton()->get_mouse_button_state();
 }
 
-void InputDefault::warp_mouse_pos(const Vector2 &p_to) {
+void InputDefault::warp_mouse_position(const Vector2 &p_to) {
 
-	OS::get_singleton()->warp_mouse_pos(p_to);
+	OS::get_singleton()->warp_mouse_position(p_to);
 }
 
 Point2i InputDefault::warp_mouse_motion(const Ref<InputEventMouseMotion> &p_motion, const Rect2 &p_rect) {
@@ -447,7 +447,7 @@ Point2i InputDefault::warp_mouse_motion(const Ref<InputEventMouseMotion> &p_moti
 	const Point2i pos_local = p_motion->get_global_position() - p_rect.position;
 	const Point2i pos_warped(Math::fposmod(pos_local.x, p_rect.size.x), Math::fposmod(pos_local.y, p_rect.size.y));
 	if (pos_warped != pos_local) {
-		OS::get_singleton()->warp_mouse_pos(pos_warped + p_rect.position);
+		OS::get_singleton()->warp_mouse_position(pos_warped + p_rect.position);
 	}
 
 	return rel_warped;

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -200,7 +200,7 @@ public:
 	virtual Point2 get_last_mouse_speed() const;
 	virtual int get_mouse_button_mask() const;
 
-	virtual void warp_mouse_pos(const Vector2 &p_to);
+	virtual void warp_mouse_position(const Vector2 &p_to);
 	virtual Point2i warp_mouse_motion(const Ref<InputEventMouseMotion> &p_motion, const Rect2 &p_rect);
 
 	virtual void parse_input_event(const Ref<InputEvent> &p_event);

--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -152,7 +152,7 @@ RES ResourceFormatDDS::load(const String &p_path, const String &p_original_path,
 	*/
 
 	//must avoid this later
-	while (f->get_pos() < 128)
+	while (f->get_position() < 128)
 		f->get_8();
 
 	DDSFormat dds_format;

--- a/modules/opus/audio_stream_opus.cpp
+++ b/modules/opus/audio_stream_opus.cpp
@@ -56,7 +56,7 @@ int AudioStreamPlaybackOpus::_op_seek_func(void *_stream, opus_int64 _offset, in
 			fa->seek(_offset);
 		} break;
 		case SEEK_CUR: {
-			fa->seek(fa->get_pos() + _offset);
+			fa->seek(fa->get_position() + _offset);
 		} break;
 		case SEEK_END: {
 			fa->seek_end(_offset);
@@ -83,7 +83,7 @@ int AudioStreamPlaybackOpus::_op_close_func(void *_stream) {
 
 opus_int64 AudioStreamPlaybackOpus::_op_tell_func(void *_stream) {
 	FileAccess *_fa = (FileAccess *)_stream;
-	return (opus_int64)_fa->get_pos();
+	return (opus_int64)_fa->get_position();
 }
 
 void AudioStreamPlaybackOpus::_clear_stream() {
@@ -340,7 +340,7 @@ float AudioStreamPlaybackOpus::get_length() const {
 	return length;
 }
 
-float AudioStreamPlaybackOpus::get_pos() const {
+float AudioStreamPlaybackOpus::get_position() const {
 
 	int32_t frames = int32_t(frames_mixed);
 	if (frames < 0)

--- a/modules/opus/audio_stream_opus.h
+++ b/modules/opus/audio_stream_opus.h
@@ -99,7 +99,7 @@ public:
 
 	virtual int get_loop_count() const { return repeats; }
 
-	virtual float get_pos() const;
+	virtual float get_position() const;
 	virtual void seek_pos(float p_time);
 
 	virtual int get_channels() const { return stream_channels; }

--- a/modules/pvr/texture_loader_pvr.cpp
+++ b/modules/pvr/texture_loader_pvr.cpp
@@ -74,7 +74,7 @@ RES ResourceFormatPVR::load(const String &p_path, const String &p_original_path,
 	uint32_t mipmaps = f->get_32();
 	uint32_t flags = f->get_32();
 	uint32_t surfsize = f->get_32();
-	f->seek(f->get_pos() + 20); // bpp, rmask, gmask, bmask, amask
+	f->seek(f->get_position() + 20); // bpp, rmask, gmask, bmask, amask
 	uint8_t pvrid[5] = { 0, 0, 0, 0, 0 };
 	f->get_buffer(pvrid, 4);
 	ERR_FAIL_COND_V(String((char *)pvrid) != "PVR!", RES());

--- a/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
@@ -97,7 +97,7 @@ int AudioStreamPlaybackOGGVorbis::get_loop_count() const {
 	return loops;
 }
 
-float AudioStreamPlaybackOGGVorbis::get_pos() const {
+float AudioStreamPlaybackOGGVorbis::get_position() const {
 
 	return float(frames_mixed) / vorbis_stream->sample_rate;
 }

--- a/modules/stb_vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/stb_vorbis/audio_stream_ogg_vorbis.h
@@ -67,7 +67,7 @@ public:
 
 	virtual int get_loop_count() const; //times it looped
 
-	virtual float get_pos() const;
+	virtual float get_position() const;
 	virtual void seek_pos(float p_time);
 
 	virtual float get_length() const; //if supported, otherwise return 0

--- a/modules/tga/image_loader_tga.cpp
+++ b/modules/tga/image_loader_tga.cpp
@@ -253,7 +253,7 @@ Error ImageLoaderTGA::load_image(Ref<Image> p_image, FileAccess *f, bool p_force
 		err = FAILED;
 
 	if (err == OK) {
-		f->seek(f->get_pos() + tga_header.id_length);
+		f->seek(f->get_position() + tga_header.id_length);
 
 		PoolVector<uint8_t> palette;
 
@@ -269,7 +269,7 @@ Error ImageLoaderTGA::load_image(Ref<Image> p_image, FileAccess *f, bool p_force
 		}
 
 		PoolVector<uint8_t>::Write src_image_w = src_image.write();
-		f->get_buffer(&src_image_w[0], src_image_len - f->get_pos());
+		f->get_buffer(&src_image_w[0], src_image_len - f->get_position());
 
 		PoolVector<uint8_t>::Read src_image_r = src_image.read();
 

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -634,7 +634,7 @@ int VideoStreamPlaybackTheora::get_loop_count() const {
 	return 0;
 };
 
-float VideoStreamPlaybackTheora::get_pos() const {
+float VideoStreamPlaybackTheora::get_position() const {
 
 	return get_time();
 };

--- a/modules/theora/video_stream_theora.h
+++ b/modules/theora/video_stream_theora.h
@@ -140,7 +140,7 @@ public:
 
 	virtual int get_loop_count() const;
 
-	virtual float get_pos() const;
+	virtual float get_position() const;
 	virtual void seek_pos(float p_time);
 
 	void set_file(const String &p_file);

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -423,7 +423,7 @@ Ref<VisualScriptNode> VisualScript::get_node(const StringName &p_func, int p_id)
 	return func.nodes[p_id].node;
 }
 
-void VisualScript::set_node_pos(const StringName &p_func, int p_id, const Point2 &p_pos) {
+void VisualScript::set_node_position(const StringName &p_func, int p_id, const Point2 &p_pos) {
 
 	ERR_FAIL_COND(instances.size());
 	ERR_FAIL_COND(!functions.has(p_func));
@@ -433,7 +433,7 @@ void VisualScript::set_node_pos(const StringName &p_func, int p_id, const Point2
 	func.nodes[p_id].pos = p_pos;
 }
 
-Point2 VisualScript::get_node_pos(const StringName &p_func, int p_id) const {
+Point2 VisualScript::get_node_position(const StringName &p_func, int p_id) const {
 
 	ERR_FAIL_COND_V(!functions.has(p_func), Point2());
 	const Function &func = functions[p_func];
@@ -1273,14 +1273,14 @@ void VisualScript::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_function_scroll", "name", "ofs"), &VisualScript::set_function_scroll);
 	ClassDB::bind_method(D_METHOD("get_function_scroll", "name"), &VisualScript::get_function_scroll);
 
-	ClassDB::bind_method(D_METHOD("add_node", "func", "id", "node", "pos"), &VisualScript::add_node, DEFVAL(Point2()));
+	ClassDB::bind_method(D_METHOD("add_node", "func", "id", "node", "position"), &VisualScript::add_node, DEFVAL(Point2()));
 	ClassDB::bind_method(D_METHOD("remove_node", "func", "id"), &VisualScript::remove_node);
 	ClassDB::bind_method(D_METHOD("get_function_node_id", "name"), &VisualScript::get_function_node_id);
 
 	ClassDB::bind_method(D_METHOD("get_node", "func", "id"), &VisualScript::get_node);
 	ClassDB::bind_method(D_METHOD("has_node", "func", "id"), &VisualScript::has_node);
-	ClassDB::bind_method(D_METHOD("set_node_pos", "func", "id", "pos"), &VisualScript::set_node_pos);
-	ClassDB::bind_method(D_METHOD("get_node_pos", "func", "id"), &VisualScript::get_node_pos);
+	ClassDB::bind_method(D_METHOD("set_node_position", "func", "id", "position"), &VisualScript::set_node_position);
+	ClassDB::bind_method(D_METHOD("get_node_position", "func", "id"), &VisualScript::get_node_position);
 
 	ClassDB::bind_method(D_METHOD("sequence_connect", "func", "from_node", "from_output", "to_node"), &VisualScript::sequence_connect);
 	ClassDB::bind_method(D_METHOD("sequence_disconnect", "func", "from_node", "from_output", "to_node"), &VisualScript::sequence_disconnect);

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -278,8 +278,8 @@ public:
 	void remove_node(const StringName &p_func, int p_id);
 	bool has_node(const StringName &p_func, int p_id) const;
 	Ref<VisualScriptNode> get_node(const StringName &p_func, int p_id) const;
-	void set_node_pos(const StringName &p_func, int p_id, const Point2 &p_pos);
-	Point2 get_node_pos(const StringName &p_func, int p_id) const;
+	void set_node_position(const StringName &p_func, int p_id, const Point2 &p_pos);
+	Point2 get_node_position(const StringName &p_func, int p_id) const;
 	void get_node_list(const StringName &p_func, List<int> *r_nodes) const;
 
 	void sequence_connect(const StringName &p_func, int p_from_node, int p_from_output, int p_to_node);

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -481,7 +481,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 			continue;
 
 		Ref<VisualScriptNode> node = script->get_node(edited_func, E->get());
-		Vector2 pos = script->get_node_pos(edited_func, E->get());
+		Vector2 pos = script->get_node_position(edited_func, E->get());
 
 		GraphNode *gnode = memnew(GraphNode);
 		gnode->set_title(node->get_caption());
@@ -1065,7 +1065,7 @@ void VisualScriptEditor::_available_node_doubleclicked() {
 		List<int> existing;
 		script->get_node_list(edited_func, &existing);
 		for (List<int>::Element *E = existing.front(); E; E = E->next()) {
-			Point2 pos = script->get_node_pos(edited_func, E->get());
+			Point2 pos = script->get_node_position(edited_func, E->get());
 			if (pos.distance_to(ofs) < 15) {
 				ofs += Vector2(graph->get_snap(), graph->get_snap());
 				exists = true;
@@ -1186,7 +1186,7 @@ void VisualScriptEditor::_on_nodes_delete() {
 	for (List<int>::Element *F = to_erase.front(); F; F = F->next()) {
 
 		undo_redo->add_do_method(script.ptr(), "remove_node", edited_func, F->get());
-		undo_redo->add_undo_method(script.ptr(), "add_node", edited_func, F->get(), script->get_node(edited_func, F->get()), script->get_node_pos(edited_func, F->get()));
+		undo_redo->add_undo_method(script.ptr(), "add_node", edited_func, F->get(), script->get_node(edited_func, F->get()), script->get_node_position(edited_func, F->get()));
 
 		List<VisualScript::SequenceConnection> sequence_conns;
 		script->get_sequence_connection_list(edited_func, &sequence_conns);
@@ -1243,7 +1243,7 @@ void VisualScriptEditor::_on_nodes_duplicate() {
 
 		int new_id = idc++;
 		to_select.insert(new_id);
-		undo_redo->add_do_method(script.ptr(), "add_node", edited_func, new_id, dupe, script->get_node_pos(edited_func, F->get()) + Vector2(20, 20));
+		undo_redo->add_do_method(script.ptr(), "add_node", edited_func, new_id, dupe, script->get_node_position(edited_func, F->get()) + Vector2(20, 20));
 		undo_redo->add_undo_method(script.ptr(), "remove_node", edited_func, new_id);
 	}
 	undo_redo->add_do_method(this, "_update_graph");
@@ -1277,7 +1277,7 @@ Variant VisualScriptEditor::get_drag_data_fw(const Point2 &p_point, Control *p_f
 
 	if (p_from == nodes) {
 
-		TreeItem *it = nodes->get_item_at_pos(p_point);
+		TreeItem *it = nodes->get_item_at_position(p_point);
 		if (!it)
 			return Variant();
 		String type = it->get_metadata(0);
@@ -1296,7 +1296,7 @@ Variant VisualScriptEditor::get_drag_data_fw(const Point2 &p_point, Control *p_f
 
 	if (p_from == members) {
 
-		TreeItem *it = members->get_item_at_pos(p_point);
+		TreeItem *it = members->get_item_at_position(p_point);
 		if (!it)
 			return Variant();
 
@@ -2197,7 +2197,7 @@ void VisualScriptEditor::_move_node(String func, int p_id, const Vector2 &p_to) 
 		if (Object::cast_to<GraphNode>(node))
 			Object::cast_to<GraphNode>(node)->set_offset(p_to);
 	}
-	script->set_node_pos(edited_func, p_id, p_to / EDSCALE);
+	script->set_node_position(edited_func, p_id, p_to / EDSCALE);
 }
 
 void VisualScriptEditor::_node_moved(Vector2 p_from, Vector2 p_to, int p_id) {
@@ -2211,7 +2211,7 @@ void VisualScriptEditor::_remove_node(int p_id) {
 	undo_redo->create_action(TTR("Remove VisualScript Node"));
 
 	undo_redo->add_do_method(script.ptr(), "remove_node", edited_func, p_id);
-	undo_redo->add_undo_method(script.ptr(), "add_node", edited_func, p_id, script->get_node(edited_func, p_id), script->get_node_pos(edited_func, p_id));
+	undo_redo->add_undo_method(script.ptr(), "add_node", edited_func, p_id, script->get_node(edited_func, p_id), script->get_node_position(edited_func, p_id));
 
 	List<VisualScript::SequenceConnection> sequence_conns;
 	script->get_sequence_connection_list(edited_func, &sequence_conns);
@@ -2895,7 +2895,7 @@ void VisualScriptEditor::_menu_option(int p_what) {
 						}
 						if (node.is_valid()) {
 							clipboard->nodes[id] = node->duplicate();
-							clipboard->nodes_positions[id] = script->get_node_pos(edited_func, id);
+							clipboard->nodes_positions[id] = script->get_node_position(edited_func, id);
 						}
 					}
 				}
@@ -2955,7 +2955,7 @@ void VisualScriptEditor::_menu_option(int p_what) {
 				List<int> nodes;
 				script->get_node_list(edited_func, &nodes);
 				for (List<int>::Element *E = nodes.front(); E; E = E->next()) {
-					Vector2 pos = script->get_node_pos(edited_func, E->get()).snapped(Vector2(2, 2));
+					Vector2 pos = script->get_node_position(edited_func, E->get()).snapped(Vector2(2, 2));
 					existing_positions.insert(pos);
 				}
 			}
@@ -3069,7 +3069,7 @@ void VisualScriptEditor::_member_option(int p_option) {
 				List<int> nodes;
 				script->get_node_list(name, &nodes);
 				for (List<int>::Element *E = nodes.front(); E; E = E->next()) {
-					undo_redo->add_undo_method(script.ptr(), "add_node", name, E->get(), script->get_node(name, E->get()), script->get_node_pos(name, E->get()));
+					undo_redo->add_undo_method(script.ptr(), "add_node", name, E->get(), script->get_node(name, E->get()), script->get_node_position(name, E->get()));
 				}
 
 				List<VisualScript::SequenceConnection> seq_connections;

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -58,7 +58,7 @@ int AudioStreamPlaybackOGGVorbis::_ov_seek_func(void *_f, ogg_int64_t offs, int 
 		fa->seek(offs);
 	} else if (whence == SEEK_CUR) {
 
-		fa->seek(fa->get_pos() + offs);
+		fa->seek(fa->get_position() + offs);
 	} else if (whence == SEEK_END) {
 
 		fa->seek_end(offs);
@@ -89,7 +89,7 @@ long AudioStreamPlaybackOGGVorbis::_ov_tell_func(void *_f) {
 	//printf("close %p\n",_f);
 
 	FileAccess *fa = (FileAccess *)_f;
-	return fa->get_pos();
+	return fa->get_position();
 }
 
 int AudioStreamPlaybackOGGVorbis::mix(int16_t *p_bufer, int p_frames) {
@@ -203,7 +203,7 @@ void AudioStreamPlaybackOGGVorbis::stop() {
 	//_clear();
 }
 
-float AudioStreamPlaybackOGGVorbis::get_pos() const {
+float AudioStreamPlaybackOGGVorbis::get_position() const {
 
 	int32_t frames = int32_t(frames_mixed);
 	if (frames < 0)

--- a/modules/vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/vorbis/audio_stream_ogg_vorbis.h
@@ -96,7 +96,7 @@ public:
 
 	virtual int get_loop_count() const;
 
-	virtual float get_pos() const;
+	virtual float get_position() const;
 	virtual void seek_pos(float p_time);
 
 	virtual int get_channels() const { return stream_channels; }

--- a/modules/webm/video_stream_webm.cpp
+++ b/modules/webm/video_stream_webm.cpp
@@ -59,7 +59,7 @@ public:
 
 		if (file) {
 
-			if (file->get_pos() != (size_t)pos)
+			if (file->get_position() != (size_t)pos)
 				file->seek(pos);
 			if (file->get_buffer(buf, len) == len)
 				return 0;
@@ -204,7 +204,7 @@ float VideoStreamPlaybackWebm::get_length() const {
 	return 0.0f;
 }
 
-float VideoStreamPlaybackWebm::get_pos() const {
+float VideoStreamPlaybackWebm::get_position() const {
 
 	return video_pos;
 }

--- a/modules/webm/video_stream_webm.h
+++ b/modules/webm/video_stream_webm.h
@@ -81,7 +81,7 @@ public:
 
 	virtual float get_length() const;
 
-	virtual float get_pos() const;
+	virtual float get_position() const;
 	virtual void seek_pos(float p_time);
 
 	virtual void set_audio_track(int p_idx);

--- a/platform/android/file_access_android.cpp
+++ b/platform/android/file_access_android.cpp
@@ -95,7 +95,7 @@ void FileAccessAndroid::seek_end(int64_t p_position) {
 	pos = len + p_position;
 }
 
-size_t FileAccessAndroid::get_pos() const {
+size_t FileAccessAndroid::get_position() const {
 
 	return pos;
 }

--- a/platform/android/file_access_android.h
+++ b/platform/android/file_access_android.h
@@ -53,7 +53,7 @@ public:
 
 	virtual void seek(size_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_pos() const; ///< get position in the file
+	virtual size_t get_position() const; ///< get position in the file
 	virtual size_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF

--- a/platform/android/file_access_jandroid.cpp
+++ b/platform/android/file_access_jandroid.cpp
@@ -106,7 +106,7 @@ void FileAccessJAndroid::seek_end(int64_t p_position) {
 	seek(get_len());
 }
 
-size_t FileAccessJAndroid::get_pos() const {
+size_t FileAccessJAndroid::get_position() const {
 
 	JNIEnv *env = ThreadAndroid::get_env();
 	ERR_FAIL_COND_V(!is_open(), 0);

--- a/platform/android/file_access_jandroid.h
+++ b/platform/android/file_access_jandroid.h
@@ -57,7 +57,7 @@ public:
 
 	virtual void seek(size_t p_position); ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual size_t get_pos() const; ///< get position in the file
+	virtual size_t get_position() const; ///< get position in the file
 	virtual size_t get_len() const; ///< get size of the file
 
 	virtual bool eof_reached() const; ///< reading passed EOF

--- a/platform/haiku/haiku_direct_window.cpp
+++ b/platform/haiku/haiku_direct_window.cpp
@@ -157,8 +157,8 @@ void HaikuDirectWindow::HandleMouseButton(BMessage *message) {
 
 	mouse_event.mouse_button.mod = GetKeyModifierState(modifiers);
 	mouse_event->get_button_mask() = GetMouseButtonState(buttons);
-	mouse_event->get_pos().x = where.x;
-	mouse_event->get_pos().y = where.y;
+	mouse_event->get_position().x = where.x;
+	mouse_event->get_position().y = where.y;
 	mouse_event.mouse_button.global_x = where.x;
 	mouse_event.mouse_button.global_y = where.y;
 
@@ -242,8 +242,8 @@ void HaikuDirectWindow::HandleMouseWheelChanged(BMessage *message) {
 	mouse_event->get_button_index() = wheel_delta_y < 0 ? 4 : 5;
 	mouse_event.mouse_button.mod = GetKeyModifierState(last_key_modifier_state);
 	mouse_event->get_button_mask() = last_button_mask;
-	mouse_event->get_pos().x = last_mouse_position.x;
-	mouse_event->get_pos().y = last_mouse_position.y;
+	mouse_event->get_position().x = last_mouse_position.x;
+	mouse_event->get_position().y = last_mouse_position.y;
 	mouse_event.mouse_button.global_x = last_mouse_position.x;
 	mouse_event.mouse_button.global_y = last_mouse_position.y;
 

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -152,7 +152,7 @@ public:
 	virtual void set_mouse_show(bool p_show);
 	virtual void set_mouse_grab(bool p_grab);
 	virtual bool is_mouse_grab_enabled() const;
-	virtual void warp_mouse_pos(const Point2 &p_to);
+	virtual void warp_mouse_position(const Point2 &p_to);
 	virtual Point2 get_mouse_position() const;
 	virtual int get_mouse_button_state() const;
 	virtual void set_window_title(const String &p_title);

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1240,7 +1240,7 @@ bool OS_OSX::is_mouse_grab_enabled() const {
 	return mouse_grab;
 }
 
-void OS_OSX::warp_mouse_pos(const Point2 &p_to) {
+void OS_OSX::warp_mouse_position(const Point2 &p_to) {
 
 	//copied from windows impl with osx native calls
 	if (mouse_mode == MOUSE_MODE_CAPTURED) {

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -471,7 +471,7 @@ void AppxPackager::add_file(String p_file_name, const uint8_t *p_buffer, size_t 
 	meta.uncompressed_size = p_len;
 	meta.compressed_size = p_len;
 	meta.compressed = p_compress;
-	meta.zip_offset = package->get_pos();
+	meta.zip_offset = package->get_position();
 
 	Vector<uint8_t> file_buffer;
 
@@ -619,11 +619,11 @@ void AppxPackager::finish() {
 
 	// Write central directory
 	EditorNode::progress_task_step("export", "Finishing package...", 6);
-	central_dir_offset = package->get_pos();
+	central_dir_offset = package->get_position();
 	package->store_buffer(central_dir_data.ptr(), central_dir_data.size());
 
 	// End record
-	end_of_central_dir_offset = package->get_pos();
+	end_of_central_dir_offset = package->get_position();
 	Vector<uint8_t> end_record = make_end_of_central_record();
 	package->store_buffer(end_record.ptr(), end_record.size());
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1304,7 +1304,7 @@ OS_Windows::MouseMode OS_Windows::get_mouse_mode() const {
 	return mouse_mode;
 }
 
-void OS_Windows::warp_mouse_pos(const Point2 &p_to) {
+void OS_Windows::warp_mouse_position(const Point2 &p_to) {
 
 	if (mouse_mode == MOUSE_MODE_CAPTURED) {
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -189,7 +189,7 @@ public:
 	void set_mouse_mode(MouseMode p_mode);
 	MouseMode get_mouse_mode() const;
 
-	virtual void warp_mouse_pos(const Point2 &p_to);
+	virtual void warp_mouse_position(const Point2 &p_to);
 	virtual Point2 get_mouse_position() const;
 	virtual int get_mouse_button_state() const;
 	virtual void set_window_title(const String &p_title);

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -613,7 +613,7 @@ void OS_X11::set_mouse_mode(MouseMode p_mode) {
 	XFlush(x11_display);
 }
 
-void OS_X11::warp_mouse_pos(const Point2 &p_to) {
+void OS_X11::warp_mouse_position(const Point2 &p_to) {
 
 	if (mouse_mode == MOUSE_MODE_CAPTURED) {
 

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -201,7 +201,7 @@ public:
 	void set_mouse_mode(MouseMode p_mode);
 	MouseMode get_mouse_mode() const;
 
-	virtual void warp_mouse_pos(const Point2 &p_to);
+	virtual void warp_mouse_position(const Point2 &p_to);
 	virtual Point2 get_mouse_position() const;
 	virtual int get_mouse_button_state() const;
 	virtual void set_window_title(const String &p_title);

--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -223,7 +223,7 @@ void SpriteFrames::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_animation_loop", "anim", "loop"), &SpriteFrames::set_animation_loop);
 	ClassDB::bind_method(D_METHOD("get_animation_loop", "anim"), &SpriteFrames::get_animation_loop);
 
-	ClassDB::bind_method(D_METHOD("add_frame", "anim", "frame", "atpos"), &SpriteFrames::add_frame, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("add_frame", "anim", "frame", "at_position"), &SpriteFrames::add_frame, DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("get_frame_count", "anim"), &SpriteFrames::get_frame_count);
 	ClassDB::bind_method(D_METHOD("get_frame", "anim", "idx"), &SpriteFrames::get_frame);
 	ClassDB::bind_method(D_METHOD("set_frame", "anim", "idx", "txt"), &SpriteFrames::set_frame);

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -284,10 +284,10 @@ bool AudioStreamPlayer2D::is_playing() const {
 	return false;
 }
 
-float AudioStreamPlayer2D::get_pos() {
+float AudioStreamPlayer2D::get_position() {
 
 	if (stream_playback.is_valid()) {
-		return stream_playback->get_pos();
+		return stream_playback->get_position();
 	}
 
 	return 0;
@@ -390,12 +390,12 @@ void AudioStreamPlayer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_volume_db", "volume_db"), &AudioStreamPlayer2D::set_volume_db);
 	ClassDB::bind_method(D_METHOD("get_volume_db"), &AudioStreamPlayer2D::get_volume_db);
 
-	ClassDB::bind_method(D_METHOD("play", "from_pos"), &AudioStreamPlayer2D::play, DEFVAL(0.0));
-	ClassDB::bind_method(D_METHOD("seek", "to_pos"), &AudioStreamPlayer2D::seek);
+	ClassDB::bind_method(D_METHOD("play", "from_position"), &AudioStreamPlayer2D::play, DEFVAL(0.0));
+	ClassDB::bind_method(D_METHOD("seek", "to_position"), &AudioStreamPlayer2D::seek);
 	ClassDB::bind_method(D_METHOD("stop"), &AudioStreamPlayer2D::stop);
 
 	ClassDB::bind_method(D_METHOD("is_playing"), &AudioStreamPlayer2D::is_playing);
-	ClassDB::bind_method(D_METHOD("get_pos"), &AudioStreamPlayer2D::get_pos);
+	ClassDB::bind_method(D_METHOD("get_position"), &AudioStreamPlayer2D::get_position);
 
 	ClassDB::bind_method(D_METHOD("set_bus", "bus"), &AudioStreamPlayer2D::set_bus);
 	ClassDB::bind_method(D_METHOD("get_bus"), &AudioStreamPlayer2D::get_bus);

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -72,7 +72,7 @@ public:
 	void seek(float p_seconds);
 	void stop();
 	bool is_playing() const;
-	float get_pos();
+	float get_position();
 
 	void set_bus(const StringName &p_bus);
 	StringName get_bus() const;

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -452,7 +452,7 @@ float Camera2D::get_drag_margin(Margin p_margin) const {
 	return drag_margin[p_margin];
 }
 
-Vector2 Camera2D::get_camera_pos() const {
+Vector2 Camera2D::get_camera_position() const {
 
 	return camera_pos;
 }
@@ -673,7 +673,7 @@ void Camera2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_drag_margin", "margin", "drag_margin"), &Camera2D::set_drag_margin);
 	ClassDB::bind_method(D_METHOD("get_drag_margin", "margin"), &Camera2D::get_drag_margin);
 
-	ClassDB::bind_method(D_METHOD("get_camera_pos"), &Camera2D::get_camera_pos);
+	ClassDB::bind_method(D_METHOD("get_camera_position"), &Camera2D::get_camera_position);
 	ClassDB::bind_method(D_METHOD("get_camera_screen_center"), &Camera2D::get_camera_screen_center);
 
 	ClassDB::bind_method(D_METHOD("set_zoom", "zoom"), &Camera2D::set_zoom);

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -137,7 +137,7 @@ public:
 	void set_custom_viewport(Node *p_viewport);
 	Node *get_custom_viewport() const;
 
-	Vector2 get_camera_pos() const;
+	Vector2 get_camera_position() const;
 	void force_update_scroll();
 	void reset_smoothing();
 	void align();

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -902,7 +902,7 @@ Ref<Material> CanvasItem::get_material() const {
 	return material;
 }
 
-Vector2 CanvasItem::make_canvas_pos_local(const Vector2 &screen_point) const {
+Vector2 CanvasItem::make_canvas_position_local(const Vector2 &screen_point) const {
 
 	ERR_FAIL_COND_V(!is_inside_tree(), screen_point);
 
@@ -923,7 +923,8 @@ Vector2 CanvasItem::get_global_mouse_position() const {
 	ERR_FAIL_COND_V(!get_viewport(), Vector2());
 	return get_canvas_transform().affine_inverse().xform(get_viewport()->get_mouse_position());
 }
-Vector2 CanvasItem::get_local_mouse_pos() const {
+
+Vector2 CanvasItem::get_local_mouse_position() const {
 
 	ERR_FAIL_COND_V(!get_viewport(), Vector2());
 
@@ -976,18 +977,18 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("draw_polyline", "points", "color", "width", "antialiased"), &CanvasItem::draw_polyline, DEFVAL(1.0), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("draw_polyline_colors", "points", "colors", "width", "antialiased"), &CanvasItem::draw_polyline_colors, DEFVAL(1.0), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("draw_rect", "rect", "color", "filled"), &CanvasItem::draw_rect, DEFVAL(true));
-	ClassDB::bind_method(D_METHOD("draw_circle", "pos", "radius", "color"), &CanvasItem::draw_circle);
-	ClassDB::bind_method(D_METHOD("draw_texture", "texture", "pos", "modulate", "normal_map"), &CanvasItem::draw_texture, DEFVAL(Color(1, 1, 1, 1)), DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("draw_circle", "position", "radius", "color"), &CanvasItem::draw_circle);
+	ClassDB::bind_method(D_METHOD("draw_texture", "texture", "position", "modulate", "normal_map"), &CanvasItem::draw_texture, DEFVAL(Color(1, 1, 1, 1)), DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("draw_texture_rect", "texture", "rect", "tile", "modulate", "transpose", "normal_map"), &CanvasItem::draw_texture_rect, DEFVAL(Color(1, 1, 1)), DEFVAL(false), DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("draw_texture_rect_region", "texture", "rect", "src_rect", "modulate", "transpose", "normal_map", "clip_uv"), &CanvasItem::draw_texture_rect_region, DEFVAL(Color(1, 1, 1)), DEFVAL(false), DEFVAL(Variant()), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("draw_style_box", "style_box", "rect"), &CanvasItem::draw_style_box);
 	ClassDB::bind_method(D_METHOD("draw_primitive", "points", "colors", "uvs", "texture", "width", "normal_map"), &CanvasItem::draw_primitive, DEFVAL(Variant()), DEFVAL(1.0), DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("draw_polygon", "points", "colors", "uvs", "texture", "normal_map", "antialiased"), &CanvasItem::draw_polygon, DEFVAL(PoolVector2Array()), DEFVAL(Variant()), DEFVAL(Variant()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("draw_colored_polygon", "points", "color", "uvs", "texture", "normal_map", "antialiased"), &CanvasItem::draw_colored_polygon, DEFVAL(PoolVector2Array()), DEFVAL(Variant()), DEFVAL(Variant()), DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("draw_string", "font", "pos", "text", "modulate", "clip_w"), &CanvasItem::draw_string, DEFVAL(Color(1, 1, 1)), DEFVAL(-1));
-	ClassDB::bind_method(D_METHOD("draw_char", "font", "pos", "char", "next", "modulate"), &CanvasItem::draw_char, DEFVAL(Color(1, 1, 1)));
+	ClassDB::bind_method(D_METHOD("draw_string", "font", "position", "text", "modulate", "clip_w"), &CanvasItem::draw_string, DEFVAL(Color(1, 1, 1)), DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("draw_char", "font", "position", "char", "next", "modulate"), &CanvasItem::draw_char, DEFVAL(Color(1, 1, 1)));
 
-	ClassDB::bind_method(D_METHOD("draw_set_transform", "pos", "rot", "scale"), &CanvasItem::draw_set_transform);
+	ClassDB::bind_method(D_METHOD("draw_set_transform", "position", "rotation", "scale"), &CanvasItem::draw_set_transform);
 	ClassDB::bind_method(D_METHOD("draw_set_transform_matrix", "xform"), &CanvasItem::draw_set_transform_matrix);
 	ClassDB::bind_method(D_METHOD("get_transform"), &CanvasItem::get_transform);
 	ClassDB::bind_method(D_METHOD("get_global_transform"), &CanvasItem::get_global_transform);
@@ -995,7 +996,7 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_viewport_transform"), &CanvasItem::get_viewport_transform);
 	ClassDB::bind_method(D_METHOD("get_viewport_rect"), &CanvasItem::get_viewport_rect);
 	ClassDB::bind_method(D_METHOD("get_canvas_transform"), &CanvasItem::get_canvas_transform);
-	ClassDB::bind_method(D_METHOD("get_local_mouse_pos"), &CanvasItem::get_local_mouse_pos);
+	ClassDB::bind_method(D_METHOD("get_local_mouse_position"), &CanvasItem::get_local_mouse_position);
 	ClassDB::bind_method(D_METHOD("get_global_mouse_position"), &CanvasItem::get_global_mouse_position);
 	ClassDB::bind_method(D_METHOD("get_canvas"), &CanvasItem::get_canvas);
 	ClassDB::bind_method(D_METHOD("get_world_2d"), &CanvasItem::get_world_2d);
@@ -1013,8 +1014,7 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_notify_transform", "enable"), &CanvasItem::set_notify_transform);
 	ClassDB::bind_method(D_METHOD("is_transform_notification_enabled"), &CanvasItem::is_transform_notification_enabled);
 
-	ClassDB::bind_method(D_METHOD("make_canvas_pos_local", "screen_point"),
-			&CanvasItem::make_canvas_pos_local);
+	ClassDB::bind_method(D_METHOD("make_canvas_position_local", "screen_point"), &CanvasItem::make_canvas_position_local);
 	ClassDB::bind_method(D_METHOD("make_input_local", "event"), &CanvasItem::make_input_local);
 
 	BIND_VMETHOD(MethodInfo("_draw"));

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -298,10 +298,10 @@ public:
 	bool get_use_parent_material() const;
 
 	Ref<InputEvent> make_input_local(const Ref<InputEvent> &p_event) const;
-	Vector2 make_canvas_pos_local(const Vector2 &screen_point) const;
+	Vector2 make_canvas_position_local(const Vector2 &screen_point) const;
 
 	Vector2 get_global_mouse_position() const;
-	Vector2 get_local_mouse_pos() const;
+	Vector2 get_local_mouse_position() const;
 
 	void set_notify_local_transform(bool p_enable);
 	bool is_local_transform_notification_enabled() const;

--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -68,12 +68,12 @@ PoolVector<Vector2> Line2D::get_points() const {
 	return _points;
 }
 
-void Line2D::set_point_pos(int i, Vector2 pos) {
+void Line2D::set_point_position(int i, Vector2 pos) {
 	_points.set(i, pos);
 	update();
 }
 
-Vector2 Line2D::get_point_pos(int i) const {
+Vector2 Line2D::get_point_position(int i) const {
 	return _points.get(i);
 }
 
@@ -270,12 +270,12 @@ void Line2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_points", "points"), &Line2D::set_points);
 	ClassDB::bind_method(D_METHOD("get_points"), &Line2D::get_points);
 
-	ClassDB::bind_method(D_METHOD("set_point_pos", "i", "pos"), &Line2D::set_point_pos);
-	ClassDB::bind_method(D_METHOD("get_point_pos", "i"), &Line2D::get_point_pos);
+	ClassDB::bind_method(D_METHOD("set_point_position", "i", "position"), &Line2D::set_point_position);
+	ClassDB::bind_method(D_METHOD("get_point_position", "i"), &Line2D::get_point_position);
 
 	ClassDB::bind_method(D_METHOD("get_point_count"), &Line2D::get_point_count);
 
-	ClassDB::bind_method(D_METHOD("add_point", "pos"), &Line2D::add_point);
+	ClassDB::bind_method(D_METHOD("add_point", "position"), &Line2D::add_point);
 	ClassDB::bind_method(D_METHOD("remove_point", "i"), &Line2D::remove_point);
 
 	ClassDB::bind_method(D_METHOD("set_width", "width"), &Line2D::set_width);

--- a/scene/2d/line_2d.h
+++ b/scene/2d/line_2d.h
@@ -60,8 +60,8 @@ public:
 	void set_points(const PoolVector<Vector2> &p_points);
 	PoolVector<Vector2> get_points() const;
 
-	void set_point_pos(int i, Vector2 pos);
-	Vector2 get_point_pos(int i) const;
+	void set_point_position(int i, Vector2 pos);
+	Vector2 get_point_position(int i) const;
 
 	int get_point_count() const;
 

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -414,7 +414,7 @@ void Node2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_get_rotd"), &Node2D::_get_rotd);
 	ClassDB::bind_method(D_METHOD("_set_rotd", "degrees"), &Node2D::_set_rotd);
 
-	ClassDB::bind_method(D_METHOD("set_position", "pos"), &Node2D::set_position);
+	ClassDB::bind_method(D_METHOD("set_position", "position"), &Node2D::set_position);
 	ClassDB::bind_method(D_METHOD("set_rotation", "radians"), &Node2D::set_rotation);
 	ClassDB::bind_method(D_METHOD("set_rotation_in_degrees", "degrees"), &Node2D::set_rotation_in_degrees);
 	ClassDB::bind_method(D_METHOD("set_scale", "scale"), &Node2D::set_scale);
@@ -431,7 +431,7 @@ void Node2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("global_translate", "offset"), &Node2D::global_translate);
 	ClassDB::bind_method(D_METHOD("apply_scale", "ratio"), &Node2D::apply_scale);
 
-	ClassDB::bind_method(D_METHOD("set_global_position", "pos"), &Node2D::set_global_position);
+	ClassDB::bind_method(D_METHOD("set_global_position", "position"), &Node2D::set_global_position);
 	ClassDB::bind_method(D_METHOD("get_global_position"), &Node2D::get_global_position);
 	ClassDB::bind_method(D_METHOD("set_global_rotation", "radians"), &Node2D::set_global_rotation);
 	ClassDB::bind_method(D_METHOD("get_global_rotation"), &Node2D::get_global_rotation);

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -43,7 +43,7 @@ void Path2D::_notification(int p_what) {
 
 		for (int i = 0; i < curve->get_point_count(); i++) {
 
-			Vector2 prev_p = curve->get_point_pos(i);
+			Vector2 prev_p = curve->get_point_position(i);
 
 			for (int j = 1; j <= 8; j++) {
 

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1294,9 +1294,9 @@ void TileMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_occluder_light_mask"), &TileMap::get_occluder_light_mask);
 
 	ClassDB::bind_method(D_METHOD("set_cell", "x", "y", "tile", "flip_x", "flip_y", "transpose"), &TileMap::set_cell, DEFVAL(false), DEFVAL(false), DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("set_cellv", "pos", "tile", "flip_x", "flip_y", "transpose"), &TileMap::set_cellv, DEFVAL(false), DEFVAL(false), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("set_cellv", "position", "tile", "flip_x", "flip_y", "transpose"), &TileMap::set_cellv, DEFVAL(false), DEFVAL(false), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_cell", "x", "y"), &TileMap::get_cell);
-	ClassDB::bind_method(D_METHOD("get_cellv", "pos"), &TileMap::get_cellv);
+	ClassDB::bind_method(D_METHOD("get_cellv", "position"), &TileMap::get_cellv);
 	ClassDB::bind_method(D_METHOD("is_cell_x_flipped", "x", "y"), &TileMap::is_cell_x_flipped);
 	ClassDB::bind_method(D_METHOD("is_cell_y_flipped", "x", "y"), &TileMap::is_cell_y_flipped);
 	ClassDB::bind_method(D_METHOD("is_cell_transposed", "x", "y"), &TileMap::is_cell_transposed);
@@ -1307,8 +1307,8 @@ void TileMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_used_cells_by_id", "id"), &TileMap::get_used_cells_by_id);
 	ClassDB::bind_method(D_METHOD("get_used_rect"), &TileMap::get_used_rect);
 
-	ClassDB::bind_method(D_METHOD("map_to_world", "mappos", "ignore_half_ofs"), &TileMap::map_to_world, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("world_to_map", "worldpos"), &TileMap::world_to_map);
+	ClassDB::bind_method(D_METHOD("map_to_world", "map_position", "ignore_half_ofs"), &TileMap::map_to_world, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("world_to_map", "world_position"), &TileMap::world_to_map);
 
 	ClassDB::bind_method(D_METHOD("_clear_quadrants"), &TileMap::_clear_quadrants);
 	ClassDB::bind_method(D_METHOD("_recreate_quadrants"), &TileMap::_recreate_quadrants);

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -611,10 +611,10 @@ bool AudioStreamPlayer3D::is_playing() const {
 	return false;
 }
 
-float AudioStreamPlayer3D::get_pos() {
+float AudioStreamPlayer3D::get_position() {
 
 	if (stream_playback.is_valid()) {
-		return stream_playback->get_pos();
+		return stream_playback->get_position();
 	}
 
 	return 0;
@@ -802,12 +802,12 @@ void AudioStreamPlayer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_max_db", "max_db"), &AudioStreamPlayer3D::set_max_db);
 	ClassDB::bind_method(D_METHOD("get_max_db"), &AudioStreamPlayer3D::get_max_db);
 
-	ClassDB::bind_method(D_METHOD("play", "from_pos"), &AudioStreamPlayer3D::play, DEFVAL(0.0));
-	ClassDB::bind_method(D_METHOD("seek", "to_pos"), &AudioStreamPlayer3D::seek);
+	ClassDB::bind_method(D_METHOD("play", "from_position"), &AudioStreamPlayer3D::play, DEFVAL(0.0));
+	ClassDB::bind_method(D_METHOD("seek", "to_position"), &AudioStreamPlayer3D::seek);
 	ClassDB::bind_method(D_METHOD("stop"), &AudioStreamPlayer3D::stop);
 
 	ClassDB::bind_method(D_METHOD("is_playing"), &AudioStreamPlayer3D::is_playing);
-	ClassDB::bind_method(D_METHOD("get_pos"), &AudioStreamPlayer3D::get_pos);
+	ClassDB::bind_method(D_METHOD("get_position"), &AudioStreamPlayer3D::get_position);
 
 	ClassDB::bind_method(D_METHOD("set_bus", "bus"), &AudioStreamPlayer3D::set_bus);
 	ClassDB::bind_method(D_METHOD("get_bus"), &AudioStreamPlayer3D::get_bus);

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -127,7 +127,7 @@ public:
 	void seek(float p_seconds);
 	void stop();
 	bool is_playing() const;
-	float get_pos();
+	float get_position();
 
 	void set_bus(const StringName &p_bus);
 	StringName get_bus() const;

--- a/scene/3d/collision_object.cpp
+++ b/scene/3d/collision_object.cpp
@@ -145,9 +145,9 @@ void CollisionObject::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("shape_owner_clear_shapes", "owner_id"), &CollisionObject::shape_owner_clear_shapes);
 	ClassDB::bind_method(D_METHOD("shape_find_owner", "shape_index"), &CollisionObject::shape_find_owner);
 
-	BIND_VMETHOD(MethodInfo("_input_event", PropertyInfo(Variant::OBJECT, "camera"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent"), PropertyInfo(Variant::VECTOR3, "click_pos"), PropertyInfo(Variant::VECTOR3, "click_normal"), PropertyInfo(Variant::INT, "shape_idx")));
+	BIND_VMETHOD(MethodInfo("_input_event", PropertyInfo(Variant::OBJECT, "camera"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent"), PropertyInfo(Variant::VECTOR3, "click_position"), PropertyInfo(Variant::VECTOR3, "click_normal"), PropertyInfo(Variant::INT, "shape_idx")));
 
-	ADD_SIGNAL(MethodInfo("input_event", PropertyInfo(Variant::OBJECT, "camera"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent"), PropertyInfo(Variant::VECTOR3, "click_pos"), PropertyInfo(Variant::VECTOR3, "click_normal"), PropertyInfo(Variant::INT, "shape_idx")));
+	ADD_SIGNAL(MethodInfo("input_event", PropertyInfo(Variant::OBJECT, "camera"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent"), PropertyInfo(Variant::VECTOR3, "click_position"), PropertyInfo(Variant::VECTOR3, "click_normal"), PropertyInfo(Variant::INT, "shape_idx")));
 	ADD_SIGNAL(MethodInfo("mouse_entered"));
 	ADD_SIGNAL(MethodInfo("mouse_exited"));
 

--- a/scene/3d/immediate_geometry.cpp
+++ b/scene/3d/immediate_geometry.cpp
@@ -149,7 +149,7 @@ void ImmediateGeometry::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_color", "color"), &ImmediateGeometry::set_color);
 	ClassDB::bind_method(D_METHOD("set_uv", "uv"), &ImmediateGeometry::set_uv);
 	ClassDB::bind_method(D_METHOD("set_uv2", "uv"), &ImmediateGeometry::set_uv2);
-	ClassDB::bind_method(D_METHOD("add_vertex", "pos"), &ImmediateGeometry::add_vertex);
+	ClassDB::bind_method(D_METHOD("add_vertex", "position"), &ImmediateGeometry::add_vertex);
 	ClassDB::bind_method(D_METHOD("add_sphere", "lats", "lons", "radius", "add_uv"), &ImmediateGeometry::add_sphere, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("end"), &ImmediateGeometry::end);
 	ClassDB::bind_method(D_METHOD("clear"), &ImmediateGeometry::clear);

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -825,7 +825,7 @@ void RigidBody::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_using_continuous_collision_detection"), &RigidBody::is_using_continuous_collision_detection);
 
 	ClassDB::bind_method(D_METHOD("set_axis_velocity", "axis_velocity"), &RigidBody::set_axis_velocity);
-	ClassDB::bind_method(D_METHOD("apply_impulse", "pos", "impulse"), &RigidBody::apply_impulse);
+	ClassDB::bind_method(D_METHOD("apply_impulse", "position", "impulse"), &RigidBody::apply_impulse);
 
 	ClassDB::bind_method(D_METHOD("set_sleeping", "sleeping"), &RigidBody::set_sleeping);
 	ClassDB::bind_method(D_METHOD("is_sleeping"), &RigidBody::is_sleeping);

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -651,7 +651,7 @@ void Spatial::look_at(const Vector3 &p_target, const Vector3 &p_up_normal) {
 	set_global_transform(lookat);
 }
 
-void Spatial::look_at_from_pos(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up_normal) {
+void Spatial::look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up_normal) {
 
 	Transform lookat;
 	lookat.origin = p_pos;
@@ -749,7 +749,7 @@ void Spatial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_identity"), &Spatial::set_identity);
 
 	ClassDB::bind_method(D_METHOD("look_at", "target", "up"), &Spatial::look_at);
-	ClassDB::bind_method(D_METHOD("look_at_from_pos", "pos", "target", "up"), &Spatial::look_at_from_pos);
+	ClassDB::bind_method(D_METHOD("look_at_from_position", "position", "target", "up"), &Spatial::look_at_from_position);
 
 	ClassDB::bind_method(D_METHOD("to_local", "global_point"), &Spatial::to_local);
 	ClassDB::bind_method(D_METHOD("to_global", "local_point"), &Spatial::to_global);

--- a/scene/3d/spatial.h
+++ b/scene/3d/spatial.h
@@ -172,7 +172,7 @@ public:
 	void global_translate(const Vector3 &p_offset);
 
 	void look_at(const Vector3 &p_target, const Vector3 &p_up_normal);
-	void look_at_from_pos(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up_normal);
+	void look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up_normal);
 
 	Vector3 to_local(Vector3 p_global) const;
 	Vector3 to_global(Vector3 p_local) const;

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1045,7 +1045,7 @@ bool AnimationPlayer::is_valid() const {
 	return (playback.current.from);
 }
 
-float AnimationPlayer::get_current_animation_pos() const {
+float AnimationPlayer::get_current_animation_position() const {
 
 	ERR_FAIL_COND_V(!playback.current.from, 0);
 	return playback.current.pos;
@@ -1238,8 +1238,8 @@ void AnimationPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_root", "path"), &AnimationPlayer::set_root);
 	ClassDB::bind_method(D_METHOD("get_root"), &AnimationPlayer::get_root);
 
-	ClassDB::bind_method(D_METHOD("seek", "pos_sec", "update"), &AnimationPlayer::seek, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("get_pos"), &AnimationPlayer::get_current_animation_pos);
+	ClassDB::bind_method(D_METHOD("seek", "seconds", "update"), &AnimationPlayer::seek, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_position"), &AnimationPlayer::get_current_animation_position);
 
 	ClassDB::bind_method(D_METHOD("find_animation", "animation"), &AnimationPlayer::find_animation);
 
@@ -1248,7 +1248,7 @@ void AnimationPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_animation_process_mode", "mode"), &AnimationPlayer::set_animation_process_mode);
 	ClassDB::bind_method(D_METHOD("get_animation_process_mode"), &AnimationPlayer::get_animation_process_mode);
 
-	ClassDB::bind_method(D_METHOD("get_current_animation_pos"), &AnimationPlayer::get_current_animation_pos);
+	ClassDB::bind_method(D_METHOD("get_current_animation_position"), &AnimationPlayer::get_current_animation_position);
 	ClassDB::bind_method(D_METHOD("get_current_animation_length"), &AnimationPlayer::get_current_animation_length);
 
 	ClassDB::bind_method(D_METHOD("advance", "delta"), &AnimationPlayer::advance);

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -279,7 +279,7 @@ public:
 
 	void seek(float p_time, bool p_update = false);
 	void seek_delta(float p_time, float p_delta);
-	float get_current_animation_pos() const;
+	float get_current_animation_position() const;
 	float get_current_animation_length() const;
 
 	void advance(float p_time);

--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -92,7 +92,7 @@ bool AnimationTreePlayer::_set(const StringName &p_name, const Variant &p_value)
 		Dictionary node = nodes[i];
 
 		StringName id = node.get_valid("id");
-		Point2 pos = node.get_valid("pos");
+		Point2 pos = node.get_valid("position");
 
 		NodeType nt = NODE_MAX;
 		String type = node.get_valid("type");
@@ -122,7 +122,7 @@ bool AnimationTreePlayer::_set(const StringName &p_name, const Variant &p_value)
 
 		if (nt != NODE_OUTPUT)
 			add_node(nt, id);
-		node_set_pos(id, pos);
+		node_set_position(id, pos);
 
 		switch (nt) {
 			case NODE_OUTPUT: {
@@ -245,7 +245,7 @@ bool AnimationTreePlayer::_get(const StringName &p_name, Variant &r_ret) const {
 
 		Dictionary node;
 		node["id"] = E->key();
-		node["pos"] = n->pos;
+		node["position"] = n->pos;
 
 		switch (n->type) {
 			case NODE_OUTPUT: node["type"] = "output"; break;
@@ -1176,7 +1176,7 @@ void AnimationTreePlayer::transition_node_set_current(const StringName &p_node, 
 	n->set_current(p_current);
 }
 
-void AnimationTreePlayer::node_set_pos(const StringName &p_node, const Vector2 &p_pos) {
+void AnimationTreePlayer::node_set_position(const StringName &p_node, const Vector2 &p_pos) {
 
 	ERR_FAIL_COND(!node_map.has(p_node));
 	node_map[p_node]->pos = p_pos;
@@ -1187,7 +1187,7 @@ AnimationTreePlayer::NodeType AnimationTreePlayer::node_get_type(const StringNam
 	ERR_FAIL_COND_V(!node_map.has(p_node), NODE_OUTPUT);
 	return node_map[p_node]->type;
 }
-Point2 AnimationTreePlayer::node_get_pos(const StringName &p_node) const {
+Point2 AnimationTreePlayer::node_get_position(const StringName &p_node) const {
 
 	ERR_FAIL_COND_V(!node_map.has(p_node), Point2());
 	return node_map[p_node]->pos;
@@ -1752,7 +1752,7 @@ void AnimationTreePlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("timescale_node_set_scale", "id", "scale"), &AnimationTreePlayer::timescale_node_set_scale);
 	ClassDB::bind_method(D_METHOD("timescale_node_get_scale", "id"), &AnimationTreePlayer::timescale_node_get_scale);
 
-	ClassDB::bind_method(D_METHOD("timeseek_node_seek", "id", "pos_sec"), &AnimationTreePlayer::timeseek_node_seek);
+	ClassDB::bind_method(D_METHOD("timeseek_node_seek", "id", "seconds"), &AnimationTreePlayer::timeseek_node_seek);
 
 	ClassDB::bind_method(D_METHOD("transition_node_set_input_count", "id", "count"), &AnimationTreePlayer::transition_node_set_input_count);
 	ClassDB::bind_method(D_METHOD("transition_node_get_input_count", "id"), &AnimationTreePlayer::transition_node_get_input_count);
@@ -1767,8 +1767,8 @@ void AnimationTreePlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("transition_node_set_current", "id", "input_idx"), &AnimationTreePlayer::transition_node_set_current);
 	ClassDB::bind_method(D_METHOD("transition_node_get_current", "id"), &AnimationTreePlayer::transition_node_get_current);
 
-	ClassDB::bind_method(D_METHOD("node_set_pos", "id", "screen_pos"), &AnimationTreePlayer::node_set_pos);
-	ClassDB::bind_method(D_METHOD("node_get_pos", "id"), &AnimationTreePlayer::node_get_pos);
+	ClassDB::bind_method(D_METHOD("node_set_position", "id", "screen_position"), &AnimationTreePlayer::node_set_position);
+	ClassDB::bind_method(D_METHOD("node_get_position", "id"), &AnimationTreePlayer::node_get_position);
 
 	ClassDB::bind_method(D_METHOD("remove_node", "id"), &AnimationTreePlayer::remove_node);
 	ClassDB::bind_method(D_METHOD("connect_nodes", "id", "dst_id", "dst_input_idx"), &AnimationTreePlayer::connect_nodes);

--- a/scene/animation/animation_tree_player.h
+++ b/scene/animation/animation_tree_player.h
@@ -417,10 +417,10 @@ public:
 	void transition_node_set_current(const StringName &p_node, int p_current);
 	int transition_node_get_current(const StringName &p_node) const;
 
-	void node_set_pos(const StringName &p_node, const Vector2 &p_pos); //for display
+	void node_set_position(const StringName &p_node, const Vector2 &p_pos); //for display
 
 	/* GETS */
-	Point2 node_get_pos(const StringName &p_node) const; //for display
+	Point2 node_get_position(const StringName &p_node) const; //for display
 
 	NodeType node_get_type(const StringName &p_node) const;
 

--- a/scene/audio/audio_player.cpp
+++ b/scene/audio/audio_player.cpp
@@ -193,10 +193,10 @@ bool AudioStreamPlayer::is_playing() const {
 	return false;
 }
 
-float AudioStreamPlayer::get_pos() {
+float AudioStreamPlayer::get_position() {
 
 	if (stream_playback.is_valid()) {
-		return stream_playback->get_pos();
+		return stream_playback->get_position();
 	}
 
 	return 0;
@@ -279,12 +279,12 @@ void AudioStreamPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_volume_db", "volume_db"), &AudioStreamPlayer::set_volume_db);
 	ClassDB::bind_method(D_METHOD("get_volume_db"), &AudioStreamPlayer::get_volume_db);
 
-	ClassDB::bind_method(D_METHOD("play", "from_pos"), &AudioStreamPlayer::play, DEFVAL(0.0));
-	ClassDB::bind_method(D_METHOD("seek", "to_pos"), &AudioStreamPlayer::seek);
+	ClassDB::bind_method(D_METHOD("play", "from_position"), &AudioStreamPlayer::play, DEFVAL(0.0));
+	ClassDB::bind_method(D_METHOD("seek", "to_position"), &AudioStreamPlayer::seek);
 	ClassDB::bind_method(D_METHOD("stop"), &AudioStreamPlayer::stop);
 
 	ClassDB::bind_method(D_METHOD("is_playing"), &AudioStreamPlayer::is_playing);
-	ClassDB::bind_method(D_METHOD("get_pos"), &AudioStreamPlayer::get_pos);
+	ClassDB::bind_method(D_METHOD("get_position"), &AudioStreamPlayer::get_position);
 
 	ClassDB::bind_method(D_METHOD("set_bus", "bus"), &AudioStreamPlayer::set_bus);
 	ClassDB::bind_method(D_METHOD("get_bus"), &AudioStreamPlayer::get_bus);

--- a/scene/audio/audio_player.h
+++ b/scene/audio/audio_player.h
@@ -83,7 +83,7 @@ public:
 	void seek(float p_seconds);
 	void stop();
 	bool is_playing() const;
-	float get_pos();
+	float get_position();
 
 	void set_bus(const StringName &p_bus);
 	StringName get_bus() const;

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -49,7 +49,7 @@ Variant Control::edit_get_state() const {
 
 	Dictionary s;
 	s["rect"] = get_rect();
-	s["rot"] = get_rotation();
+	s["rotation"] = get_rotation();
 	s["scale"] = get_scale();
 	Array anchors;
 	anchors.push_back(get_anchor(MARGIN_LEFT));
@@ -66,7 +66,7 @@ void Control::edit_set_state(const Variant &p_state) {
 	Rect2 state = s["rect"];
 	set_position(state.position);
 	set_size(state.size);
-	set_rotation(s["rot"]);
+	set_rotation(s["rotation"]);
 	set_scale(s["scale"]);
 	Array anchors = s["anchors"];
 	set_anchor(MARGIN_LEFT, anchors[0]);
@@ -2477,12 +2477,12 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_anchor", "margin"), &Control::get_anchor);
 	ClassDB::bind_method(D_METHOD("set_margin", "margin", "offset"), &Control::set_margin);
 	ClassDB::bind_method(D_METHOD("set_anchor_and_margin", "margin", "anchor", "offset", "push_opposite_anchor"), &Control::set_anchor_and_margin, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("set_begin", "pos"), &Control::set_begin);
-	ClassDB::bind_method(D_METHOD("set_end", "pos"), &Control::set_end);
-	ClassDB::bind_method(D_METHOD("set_position", "pos"), &Control::set_position);
+	ClassDB::bind_method(D_METHOD("set_begin", "position"), &Control::set_begin);
+	ClassDB::bind_method(D_METHOD("set_end", "position"), &Control::set_end);
+	ClassDB::bind_method(D_METHOD("set_position", "position"), &Control::set_position);
 	ClassDB::bind_method(D_METHOD("set_size", "size"), &Control::set_size);
 	ClassDB::bind_method(D_METHOD("set_custom_minimum_size", "size"), &Control::set_custom_minimum_size);
-	ClassDB::bind_method(D_METHOD("set_global_position", "pos"), &Control::set_global_position);
+	ClassDB::bind_method(D_METHOD("set_global_position", "position"), &Control::set_global_position);
 	ClassDB::bind_method(D_METHOD("set_rotation", "radians"), &Control::set_rotation);
 	ClassDB::bind_method(D_METHOD("set_rotation_deg", "degrees"), &Control::set_rotation_deg);
 	// TODO: Obsolete this method (old name) properly (GH-4397)
@@ -2560,12 +2560,12 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_v_grow_direction"), &Control::get_v_grow_direction);
 
 	ClassDB::bind_method(D_METHOD("set_tooltip", "tooltip"), &Control::set_tooltip);
-	ClassDB::bind_method(D_METHOD("get_tooltip", "atpos"), &Control::get_tooltip, DEFVAL(Point2()));
+	ClassDB::bind_method(D_METHOD("get_tooltip", "at_position"), &Control::get_tooltip, DEFVAL(Point2()));
 	ClassDB::bind_method(D_METHOD("_get_tooltip"), &Control::_get_tooltip);
 
 	ClassDB::bind_method(D_METHOD("set_default_cursor_shape", "shape"), &Control::set_default_cursor_shape);
 	ClassDB::bind_method(D_METHOD("get_default_cursor_shape"), &Control::get_default_cursor_shape);
-	ClassDB::bind_method(D_METHOD("get_cursor_shape", "pos"), &Control::get_cursor_shape, DEFVAL(Point2()));
+	ClassDB::bind_method(D_METHOD("get_cursor_shape", "position"), &Control::get_cursor_shape, DEFVAL(Point2()));
 
 	ClassDB::bind_method(D_METHOD("set_focus_neighbour", "margin", "neighbour"), &Control::set_focus_neighbour);
 	ClassDB::bind_method(D_METHOD("get_focus_neighbour", "margin"), &Control::get_focus_neighbour);
@@ -2583,7 +2583,7 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_drag_forwarding", "target"), &Control::set_drag_forwarding);
 	ClassDB::bind_method(D_METHOD("set_drag_preview", "control"), &Control::set_drag_preview);
 
-	ClassDB::bind_method(D_METHOD("warp_mouse", "to_pos"), &Control::warp_mouse);
+	ClassDB::bind_method(D_METHOD("warp_mouse", "to_position"), &Control::warp_mouse);
 
 	ClassDB::bind_method(D_METHOD("minimum_size_changed"), &Control::minimum_size_changed);
 
@@ -2593,9 +2593,9 @@ void Control::_bind_methods() {
 
 	BIND_VMETHOD(MethodInfo("_gui_input", PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
 	BIND_VMETHOD(MethodInfo(Variant::VECTOR2, "_get_minimum_size"));
-	BIND_VMETHOD(MethodInfo(Variant::OBJECT, "get_drag_data", PropertyInfo(Variant::VECTOR2, "pos")));
-	BIND_VMETHOD(MethodInfo(Variant::BOOL, "can_drop_data", PropertyInfo(Variant::VECTOR2, "pos"), PropertyInfo(Variant::NIL, "data")));
-	BIND_VMETHOD(MethodInfo("drop_data", PropertyInfo(Variant::VECTOR2, "pos"), PropertyInfo(Variant::NIL, "data")));
+	BIND_VMETHOD(MethodInfo(Variant::OBJECT, "get_drag_data", PropertyInfo(Variant::VECTOR2, "position")));
+	BIND_VMETHOD(MethodInfo(Variant::BOOL, "can_drop_data", PropertyInfo(Variant::VECTOR2, "position"), PropertyInfo(Variant::NIL, "data")));
+	BIND_VMETHOD(MethodInfo("drop_data", PropertyInfo(Variant::VECTOR2, "position"), PropertyInfo(Variant::NIL, "data")));
 
 	ADD_GROUP("Anchor", "anchor_");
 	ADD_PROPERTYI(PropertyInfo(Variant::REAL, "anchor_left", PROPERTY_HINT_RANGE, "0,1,0.01"), "_set_anchor", "get_anchor", MARGIN_LEFT);

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -352,14 +352,14 @@ bool GraphEdit::_filter_input(const Point2 &p_point) {
 
 		for (int j = 0; j < gn->get_connection_output_count(); j++) {
 
-			Vector2 pos = gn->get_connection_output_pos(j) + gn->get_position();
+			Vector2 pos = gn->get_connection_output_position(j) + gn->get_position();
 			if (pos.distance_to(p_point) < grab_r)
 				return true;
 		}
 
 		for (int j = 0; j < gn->get_connection_input_count(); j++) {
 
-			Vector2 pos = gn->get_connection_input_pos(j) + gn->get_position();
+			Vector2 pos = gn->get_connection_input_position(j) + gn->get_position();
 			if (pos.distance_to(p_point) < grab_r) {
 				return true;
 			}
@@ -386,7 +386,7 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 
 			for (int j = 0; j < gn->get_connection_output_count(); j++) {
 
-				Vector2 pos = gn->get_connection_output_pos(j) + gn->get_position();
+				Vector2 pos = gn->get_connection_output_position(j) + gn->get_position();
 				if (pos.distance_to(mpos) < grab_r) {
 
 					if (valid_left_disconnect_types.has(gn->get_connection_output_type(j))) {
@@ -433,7 +433,7 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 
 			for (int j = 0; j < gn->get_connection_input_count(); j++) {
 
-				Vector2 pos = gn->get_connection_input_pos(j) + gn->get_position();
+				Vector2 pos = gn->get_connection_input_position(j) + gn->get_position();
 
 				if (pos.distance_to(mpos) < grab_r) {
 
@@ -501,7 +501,7 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 			if (!connecting_out) {
 				for (int j = 0; j < gn->get_connection_output_count(); j++) {
 
-					Vector2 pos = gn->get_connection_output_pos(j) + gn->get_position();
+					Vector2 pos = gn->get_connection_output_position(j) + gn->get_position();
 					int type = gn->get_connection_output_type(j);
 					if ((type == connecting_type || valid_connection_types.has(ConnType(type, connecting_type))) && pos.distance_to(mpos) < grab_r) {
 
@@ -516,7 +516,7 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 
 				for (int j = 0; j < gn->get_connection_input_count(); j++) {
 
-					Vector2 pos = gn->get_connection_input_pos(j) + gn->get_position();
+					Vector2 pos = gn->get_connection_input_position(j) + gn->get_position();
 					int type = gn->get_connection_input_type(j);
 					if ((type == connecting_type || valid_connection_types.has(ConnType(type, connecting_type))) && pos.distance_to(mpos) < grab_r) {
 						connecting_target = true;
@@ -657,9 +657,9 @@ void GraphEdit::_connections_layer_draw() {
 			continue;
 		}
 
-		Vector2 frompos = gfrom->get_connection_output_pos(E->get().from_port) + gfrom->get_offset() * zoom;
+		Vector2 frompos = gfrom->get_connection_output_position(E->get().from_port) + gfrom->get_offset() * zoom;
 		Color color = gfrom->get_connection_output_color(E->get().from_port);
-		Vector2 topos = gto->get_connection_input_pos(E->get().to_port) + gto->get_offset() * zoom;
+		Vector2 topos = gto->get_connection_input_position(E->get().to_port) + gto->get_offset() * zoom;
 		Color tocolor = gto->get_connection_input_color(E->get().to_port);
 		_draw_cos_line(connections_layer, frompos, topos, color, tocolor);
 	}
@@ -682,9 +682,9 @@ void GraphEdit::_top_layer_draw() {
 		ERR_FAIL_COND(!from);
 		Vector2 pos;
 		if (connecting_out)
-			pos = from->get_connection_output_pos(connecting_index);
+			pos = from->get_connection_output_position(connecting_index);
 		else
-			pos = from->get_connection_input_pos(connecting_index);
+			pos = from->get_connection_input_position(connecting_index);
 		pos += from->get_position();
 
 		Vector2 topos;
@@ -733,7 +733,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 		just_selected = true;
 		// TODO: Remove local mouse pos hack if/when InputEventMouseMotion is fixed to support floats
 		//drag_accum+=Vector2(mm->get_relative().x,mm->get_relative().y);
-		drag_accum = get_local_mouse_pos() - drag_origin;
+		drag_accum = get_local_mouse_position() - drag_origin;
 		for (int i = get_child_count() - 1; i >= 0; i--) {
 			GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
 			if (gn && gn->is_selected()) {
@@ -750,7 +750,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 	}
 
 	if (mm.is_valid() && box_selecting) {
-		box_selecting_to = get_local_mouse_pos();
+		box_selecting_to = get_local_mouse_position();
 
 		box_selecting_rect = Rect2(MIN(box_selecting_from.x, box_selecting_to.x),
 				MIN(box_selecting_from.y, box_selecting_to.y),
@@ -810,7 +810,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 					if (gn) {
 						Rect2 r = gn->get_rect();
 						r.size *= zoom;
-						if (r.has_point(get_local_mouse_pos()))
+						if (r.has_point(get_local_mouse_position()))
 							gn->set_selected(false);
 					}
 				}
@@ -848,7 +848,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 					if (gn_selected->is_resizing())
 						continue;
 
-					if (gn_selected->has_point(gn_selected->get_local_mouse_pos())) {
+					if (gn_selected->has_point(gn_selected->get_local_mouse_position())) {
 						gn = gn_selected;
 						break;
 					}
@@ -862,7 +862,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 
 				dragging = true;
 				drag_accum = Vector2();
-				drag_origin = get_local_mouse_pos();
+				drag_origin = get_local_mouse_position();
 				just_selected = !gn->is_selected();
 				if (!gn->is_selected() && !Input::get_singleton()->is_key_pressed(KEY_CONTROL)) {
 					for (int i = 0; i < get_child_count(); i++) {
@@ -888,7 +888,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 					return;
 
 				box_selecting = true;
-				box_selecting_from = get_local_mouse_pos();
+				box_selecting_from = get_local_mouse_position();
 				if (b->get_control()) {
 					box_selection_mode_aditive = true;
 					previus_selected.clear();
@@ -1167,7 +1167,7 @@ void GraphEdit::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("popup_request", PropertyInfo(Variant::VECTOR2, "p_position")));
 	ADD_SIGNAL(MethodInfo("duplicate_nodes_request"));
 	ADD_SIGNAL(MethodInfo("node_selected", PropertyInfo(Variant::OBJECT, "node")));
-	ADD_SIGNAL(MethodInfo("connection_to_empty", PropertyInfo(Variant::STRING, "from"), PropertyInfo(Variant::INT, "from_slot"), PropertyInfo(Variant::VECTOR2, "release_pos")));
+	ADD_SIGNAL(MethodInfo("connection_to_empty", PropertyInfo(Variant::STRING, "from"), PropertyInfo(Variant::INT, "from_slot"), PropertyInfo(Variant::VECTOR2, "release_position")));
 	ADD_SIGNAL(MethodInfo("delete_nodes_request"));
 	ADD_SIGNAL(MethodInfo("_begin_node_move"));
 	ADD_SIGNAL(MethodInfo("_end_node_move"));

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -518,7 +518,7 @@ int GraphNode::get_connection_output_count() {
 	return conn_output_cache.size();
 }
 
-Vector2 GraphNode::get_connection_input_pos(int p_idx) {
+Vector2 GraphNode::get_connection_input_position(int p_idx) {
 
 	if (connpos_dirty)
 		_connpos_update();
@@ -548,7 +548,7 @@ Color GraphNode::get_connection_input_color(int p_idx) {
 	return conn_input_cache[p_idx].color;
 }
 
-Vector2 GraphNode::get_connection_output_pos(int p_idx) {
+Vector2 GraphNode::get_connection_output_position(int p_idx) {
 
 	if (connpos_dirty)
 		_connpos_update();
@@ -690,10 +690,10 @@ void GraphNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_connection_output_count"), &GraphNode::get_connection_output_count);
 	ClassDB::bind_method(D_METHOD("get_connection_input_count"), &GraphNode::get_connection_input_count);
 
-	ClassDB::bind_method(D_METHOD("get_connection_output_pos", "idx"), &GraphNode::get_connection_output_pos);
+	ClassDB::bind_method(D_METHOD("get_connection_output_position", "idx"), &GraphNode::get_connection_output_position);
 	ClassDB::bind_method(D_METHOD("get_connection_output_type", "idx"), &GraphNode::get_connection_output_type);
 	ClassDB::bind_method(D_METHOD("get_connection_output_color", "idx"), &GraphNode::get_connection_output_color);
-	ClassDB::bind_method(D_METHOD("get_connection_input_pos", "idx"), &GraphNode::get_connection_input_pos);
+	ClassDB::bind_method(D_METHOD("get_connection_input_position", "idx"), &GraphNode::get_connection_input_position);
 	ClassDB::bind_method(D_METHOD("get_connection_input_type", "idx"), &GraphNode::get_connection_input_type);
 	ClassDB::bind_method(D_METHOD("get_connection_input_color", "idx"), &GraphNode::get_connection_input_color);
 

--- a/scene/gui/graph_node.h
+++ b/scene/gui/graph_node.h
@@ -138,10 +138,10 @@ public:
 
 	int get_connection_input_count();
 	int get_connection_output_count();
-	Vector2 get_connection_input_pos(int p_idx);
+	Vector2 get_connection_input_position(int p_idx);
 	int get_connection_input_type(int p_idx);
 	Color get_connection_input_color(int p_idx);
-	Vector2 get_connection_output_pos(int p_idx);
+	Vector2 get_connection_output_position(int p_idx);
 	int get_connection_output_type(int p_idx);
 	Color get_connection_output_color(int p_idx);
 

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1117,7 +1117,7 @@ void ItemList::_scroll_changed(double) {
 	update();
 }
 
-int ItemList::get_item_at_pos(const Point2 &p_pos, bool p_exact) const {
+int ItemList::get_item_at_position(const Point2 &p_pos, bool p_exact) const {
 
 	Vector2 pos = p_pos;
 	Ref<StyleBox> bg = get_stylebox("bg");
@@ -1165,7 +1165,7 @@ bool ItemList::is_pos_at_end_of_items(const Point2 &p_pos) const {
 
 String ItemList::get_tooltip(const Point2 &p_pos) const {
 
-	int closest = get_item_at_pos(p_pos);
+	int closest = get_item_at_position(p_pos);
 
 	if (closest != -1) {
 		if (!items[closest].tooltip_enabled) {
@@ -1362,7 +1362,7 @@ void ItemList::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_auto_height", "enable"), &ItemList::set_auto_height);
 	ClassDB::bind_method(D_METHOD("has_auto_height"), &ItemList::has_auto_height);
 
-	ClassDB::bind_method(D_METHOD("get_item_at_pos", "pos", "exact"), &ItemList::get_item_at_pos, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_item_at_position", "position", "exact"), &ItemList::get_item_at_position, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("ensure_current_is_visible"), &ItemList::ensure_current_is_visible);
 
@@ -1395,7 +1395,7 @@ void ItemList::_bind_methods() {
 	BIND_ENUM_CONSTANT(SELECT_MULTI);
 
 	ADD_SIGNAL(MethodInfo("item_selected", PropertyInfo(Variant::INT, "index")));
-	ADD_SIGNAL(MethodInfo("item_rmb_selected", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::VECTOR2, "atpos")));
+	ADD_SIGNAL(MethodInfo("item_rmb_selected", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::VECTOR2, "at_position")));
 	ADD_SIGNAL(MethodInfo("multi_selected", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::BOOL, "selected")));
 	ADD_SIGNAL(MethodInfo("item_activated", PropertyInfo(Variant::INT, "index")));
 

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -199,7 +199,7 @@ public:
 	int find_metadata(const Variant &p_metadata) const;
 
 	virtual String get_tooltip(const Point2 &p_pos) const;
-	int get_item_at_pos(const Point2 &p_pos, bool p_exact = false) const;
+	int get_item_at_position(const Point2 &p_pos, bool p_exact = false) const;
 	bool is_pos_at_end_of_items(const Point2 &p_pos) const;
 
 	void set_icon_scale(real_t p_scale);

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -49,7 +49,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 	if (b.is_valid()) {
 
 		if (b->is_pressed() && b->get_button_index() == BUTTON_RIGHT) {
-			menu->set_position(get_global_transform().xform(get_local_mouse_pos()));
+			menu->set_position(get_global_transform().xform(get_local_mouse_position()));
 			menu->set_size(Vector2(1, 1));
 			menu->popup();
 			grab_focus();
@@ -186,7 +186,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 								cached_width += font->get_char_size(text[i]).width;
 						}
 
-						set_cursor_pos(0);
+						set_cursor_position(0);
 						_text_changed();
 					}
 
@@ -273,7 +273,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 
 						delete_text(cc, cursor_pos);
 
-						set_cursor_pos(cc);
+						set_cursor_position(cc);
 
 					} else {
 						undo_text = text;
@@ -297,7 +297,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 
 #ifdef APPLE_STYLE_KEYS
 					if (k->get_command()) {
-						set_cursor_pos(0);
+						set_cursor_position(0);
 					} else if (k->get_alt()) {
 
 #else
@@ -319,10 +319,10 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 							cc--;
 						}
 
-						set_cursor_pos(cc);
+						set_cursor_position(cc);
 
 					} else {
-						set_cursor_pos(get_cursor_pos() - 1);
+						set_cursor_position(get_cursor_position() - 1);
 					}
 
 					shift_selection_check_post(k->get_shift());
@@ -341,7 +341,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 
 #ifdef APPLE_STYLE_KEYS
 					if (k->get_command()) {
-						set_cursor_pos(text.length());
+						set_cursor_position(text.length());
 					} else if (k->get_alt()) {
 #else
 					if (k->get_alt()) {
@@ -362,10 +362,10 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 							cc++;
 						}
 
-						set_cursor_pos(cc);
+						set_cursor_position(cc);
 
 					} else {
-						set_cursor_pos(get_cursor_pos() + 1);
+						set_cursor_position(get_cursor_position() + 1);
 					}
 
 					shift_selection_check_post(k->get_shift());
@@ -418,7 +418,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 
 					} else {
 						undo_text = text;
-						set_cursor_pos(cursor_pos + 1);
+						set_cursor_position(cursor_pos + 1);
 						delete_char();
 					}
 
@@ -433,7 +433,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 				case KEY_HOME: {
 
 					shift_selection_check_pre(k->get_shift());
-					set_cursor_pos(0);
+					set_cursor_position(0);
 					shift_selection_check_post(k->get_shift());
 				} break;
 				case KEY_KP_1: {
@@ -446,7 +446,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 				case KEY_END: {
 
 					shift_selection_check_pre(k->get_shift());
-					set_cursor_pos(text.length());
+					set_cursor_position(text.length());
 					shift_selection_check_post(k->get_shift());
 				} break;
 
@@ -546,7 +546,7 @@ void LineEdit::_notification(int p_what) {
 #endif
 		case NOTIFICATION_RESIZED: {
 
-			set_cursor_pos(get_cursor_pos());
+			set_cursor_position(get_cursor_position());
 
 		} break;
 		case MainLoop::NOTIFICATION_WM_FOCUS_IN: {
@@ -742,7 +742,7 @@ void LineEdit::_notification(int p_what) {
 				draw_caret = true;
 			}
 
-			Point2 cursor_pos = Point2(get_cursor_pos(), 1) * get_minimum_size().height;
+			Point2 cursor_pos = Point2(get_cursor_position(), 1) * get_minimum_size().height;
 			OS::get_singleton()->set_ime_position(get_global_position() + cursor_pos);
 			OS::get_singleton()->set_ime_intermediate_text_callback(_ime_text_callback, this);
 
@@ -806,9 +806,9 @@ void LineEdit::undo() {
 		cached_width += font->get_char_size(text[i]).width;
 
 	if (old_cursor_pos > text.length()) {
-		set_cursor_pos(text.length());
+		set_cursor_position(text.length());
 	} else {
-		set_cursor_pos(old_cursor_pos);
+		set_cursor_position(old_cursor_pos);
 	}
 
 	_text_changed();
@@ -869,14 +869,14 @@ void LineEdit::set_cursor_at_pixel_pos(int p_x) {
 		ofs++;
 	}
 
-	set_cursor_pos(ofs);
+	set_cursor_position(ofs);
 
 	/*
 	int new_cursor_pos=p_x;
 	int charwidth=draw_area->get_font_char_width(' ',0);
 	new_cursor_pos=( ( (new_cursor_pos-2)+ (charwidth/2) ) /charwidth );
 	if (new_cursor_pos>(int)text.length()) new_cursor_pos=text.length();
-	set_cursor_pos(window_pos+new_cursor_pos); */
+	set_cursor_position(window_pos+new_cursor_pos); */
 }
 
 bool LineEdit::cursor_get_blink_enabled() const {
@@ -929,7 +929,7 @@ void LineEdit::delete_char() {
 
 	text.erase(cursor_pos - 1, 1);
 
-	set_cursor_pos(get_cursor_pos() - 1);
+	set_cursor_position(get_cursor_position() - 1);
 
 	if (cursor_pos == window_pos) {
 
@@ -1011,7 +1011,7 @@ float LineEdit::get_placeholder_alpha() const {
 	return placeholder_alpha;
 }
 
-void LineEdit::set_cursor_pos(int p_pos) {
+void LineEdit::set_cursor_position(int p_pos) {
 
 	if (p_pos > (int)text.length())
 		p_pos = text.length();
@@ -1065,7 +1065,7 @@ void LineEdit::set_cursor_pos(int p_pos) {
 	update();
 }
 
-int LineEdit::get_cursor_pos() const {
+int LineEdit::get_cursor_position() const {
 
 	return cursor_pos;
 }
@@ -1093,7 +1093,7 @@ void LineEdit::append_at_cursor(String p_text) {
 		String pre = text.substr(0, cursor_pos);
 		String post = text.substr(cursor_pos, text.length() - cursor_pos);
 		text = pre + p_text + post;
-		set_cursor_pos(cursor_pos + p_text.length());
+		set_cursor_position(cursor_pos + p_text.length());
 	}
 }
 
@@ -1330,8 +1330,8 @@ void LineEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_placeholder"), &LineEdit::get_placeholder);
 	ClassDB::bind_method(D_METHOD("set_placeholder_alpha", "alpha"), &LineEdit::set_placeholder_alpha);
 	ClassDB::bind_method(D_METHOD("get_placeholder_alpha"), &LineEdit::get_placeholder_alpha);
-	ClassDB::bind_method(D_METHOD("set_cursor_pos", "pos"), &LineEdit::set_cursor_pos);
-	ClassDB::bind_method(D_METHOD("get_cursor_pos"), &LineEdit::get_cursor_pos);
+	ClassDB::bind_method(D_METHOD("set_cursor_position", "position"), &LineEdit::set_cursor_position);
+	ClassDB::bind_method(D_METHOD("get_cursor_position"), &LineEdit::get_cursor_position);
 	ClassDB::bind_method(D_METHOD("set_expand_to_text_length", "enabled"), &LineEdit::set_expand_to_text_length);
 	ClassDB::bind_method(D_METHOD("get_expand_to_text_length"), &LineEdit::get_expand_to_text_length);
 	ClassDB::bind_method(D_METHOD("cursor_set_blink_enabled", "enabled"), &LineEdit::cursor_set_blink_enabled);

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -149,8 +149,8 @@ public:
 	String get_placeholder() const;
 	void set_placeholder_alpha(float p_alpha);
 	float get_placeholder_alpha() const;
-	void set_cursor_pos(int p_pos);
-	int get_cursor_pos() const;
+	void set_cursor_position(int p_pos);
+	int get_cursor_position() const;
 	void set_max_length(int p_max_length);
 	int get_max_length() const;
 	void append_at_cursor(String p_text);

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -182,7 +182,7 @@ void ScrollContainer::_gui_input(const Ref<InputEvent> &p_gui_input) {
 	}
 }
 
-void ScrollContainer::_update_scrollbar_pos() {
+void ScrollContainer::_update_scrollbar_position() {
 
 	Size2 hmin = h_scroll->get_combined_minimum_size();
 	Size2 vmin = v_scroll->get_combined_minimum_size();
@@ -205,7 +205,7 @@ void ScrollContainer::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
 
-		call_deferred("_update_scrollbar_pos");
+		call_deferred("_update_scrollbar_position");
 	};
 
 	if (p_what == NOTIFICATION_SORT_CHILDREN) {
@@ -448,7 +448,7 @@ void ScrollContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_h_scroll_enabled"), &ScrollContainer::is_h_scroll_enabled);
 	ClassDB::bind_method(D_METHOD("set_enable_v_scroll", "enable"), &ScrollContainer::set_enable_v_scroll);
 	ClassDB::bind_method(D_METHOD("is_v_scroll_enabled"), &ScrollContainer::is_v_scroll_enabled);
-	ClassDB::bind_method(D_METHOD("_update_scrollbar_pos"), &ScrollContainer::_update_scrollbar_pos);
+	ClassDB::bind_method(D_METHOD("_update_scrollbar_position"), &ScrollContainer::_update_scrollbar_position);
 	ClassDB::bind_method(D_METHOD("set_h_scroll", "val"), &ScrollContainer::set_h_scroll);
 	ClassDB::bind_method(D_METHOD("get_h_scroll"), &ScrollContainer::get_h_scroll);
 	ClassDB::bind_method(D_METHOD("set_v_scroll", "val"), &ScrollContainer::set_v_scroll);

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -70,7 +70,7 @@ protected:
 	void _scroll_moved(float);
 	static void _bind_methods();
 
-	void _update_scrollbar_pos();
+	void _update_scrollbar_position();
 
 public:
 	int get_v_scroll() const;

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -72,7 +72,7 @@ void SpinBox::_range_click_timeout() {
 
 	if (!drag.enabled && Input::get_singleton()->is_mouse_button_pressed(BUTTON_LEFT)) {
 
-		bool up = get_local_mouse_pos().y < (get_size().height / 2);
+		bool up = get_local_mouse_position().y < (get_size().height / 2);
 		set_value(get_value() + (up ? get_step() : -get_step()));
 
 		if (range_click_timer->is_one_shot()) {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1773,7 +1773,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 
 			if (mb->get_button_index() == BUTTON_RIGHT && context_menu_enabled) {
 
-				menu->set_position(get_global_transform().xform(get_local_mouse_pos()));
+				menu->set_position(get_global_transform().xform(get_local_mouse_position()));
 				menu->set_size(Vector2(1, 1));
 				menu->popup();
 				grab_focus();
@@ -1844,7 +1844,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 
 				if (k->is_pressed()) {
 
-					highlighted_word = get_word_at_pos(get_local_mouse_pos());
+					highlighted_word = get_word_at_pos(get_local_mouse_position());
 					update();
 
 				} else {
@@ -3499,7 +3499,7 @@ String TextEdit::get_text() {
 String TextEdit::get_text_for_lookup_completion() {
 
 	int row, col;
-	_get_mouse_pos(get_local_mouse_pos(), row, col);
+	_get_mouse_pos(get_local_mouse_position(), row, col);
 
 	String longthing;
 	int len = text.size();

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1528,7 +1528,7 @@ void Tree::_range_click_timeout() {
 
 	if (range_item_last && !range_drag_enabled && Input::get_singleton()->is_mouse_button_pressed(BUTTON_LEFT)) {
 
-		Point2 pos = get_local_mouse_pos() - cache.bg->get_offset();
+		Point2 pos = get_local_mouse_position() - cache.bg->get_offset();
 		if (show_column_titles) {
 			pos.y -= _get_title_button_height();
 
@@ -1676,7 +1676,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool
 					p_item->select(col);
 					emit_signal("multi_selected", p_item, col, true);
 					if (p_button == BUTTON_RIGHT) {
-						emit_signal("item_rmb_selected", get_local_mouse_pos());
+						emit_signal("item_rmb_selected", get_local_mouse_position());
 					}
 
 					//p_item->selected_signal.call(col);
@@ -1697,7 +1697,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool
 
 						select_single_item(p_item, root, col, selected_item, &inrange);
 						if (p_button == BUTTON_RIGHT) {
-							emit_signal("item_rmb_selected", get_local_mouse_pos());
+							emit_signal("item_rmb_selected", get_local_mouse_position());
 						}
 					} else {
 
@@ -1713,7 +1713,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool
 							}
 
 							if (p_button == BUTTON_RIGHT) {
-								emit_signal("item_rmb_selected", get_local_mouse_pos());
+								emit_signal("item_rmb_selected", get_local_mouse_position());
 							}
 						}
 					}
@@ -1914,7 +1914,7 @@ void Tree::_text_editor_modal_close() {
 		return;
 	}
 
-	if (value_editor->has_point(value_editor->get_local_mouse_pos()))
+	if (value_editor->has_point(value_editor->get_local_mouse_position()))
 		return;
 
 	text_editor_enter(text_editor->get_text());
@@ -2470,7 +2470,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 
 				if (cache.click_type == Cache::CLICK_BUTTON) {
 					// make sure in case of wrong reference after reconstructing whole TreeItems
-					cache.click_item = get_item_at_pos(cache.click_pos);
+					cache.click_item = get_item_at_position(cache.click_pos);
 					emit_signal("button_pressed", cache.click_item, cache.click_column, cache.click_id);
 				}
 				cache.click_type = Cache::CLICK_NONE;
@@ -2530,7 +2530,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 				}
 				if (!root || (!root->get_children() && hide_root)) {
 					if (b->get_button_index() == BUTTON_RIGHT && allow_rmb_select) {
-						emit_signal("empty_tree_rmb_selected", get_local_mouse_pos());
+						emit_signal("empty_tree_rmb_selected", get_local_mouse_position());
 					}
 					break;
 				}
@@ -3428,7 +3428,7 @@ TreeItem *Tree::_find_item_at_pos(TreeItem *p_item, const Point2 &p_pos, int &r_
 	return NULL;
 }
 
-int Tree::get_column_at_pos(const Point2 &p_pos) const {
+int Tree::get_column_at_position(const Point2 &p_pos) const {
 
 	if (root) {
 
@@ -3454,7 +3454,7 @@ int Tree::get_column_at_pos(const Point2 &p_pos) const {
 	return -1;
 }
 
-int Tree::get_drop_section_at_pos(const Point2 &p_pos) const {
+int Tree::get_drop_section_at_position(const Point2 &p_pos) const {
 
 	if (root) {
 
@@ -3479,7 +3479,7 @@ int Tree::get_drop_section_at_pos(const Point2 &p_pos) const {
 
 	return -100;
 }
-TreeItem *Tree::get_item_at_pos(const Point2 &p_pos) const {
+TreeItem *Tree::get_item_at_position(const Point2 &p_pos) const {
 
 	if (root) {
 
@@ -3652,9 +3652,9 @@ void Tree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_edited_column"), &Tree::get_edited_column);
 	ClassDB::bind_method(D_METHOD("get_custom_popup_rect"), &Tree::get_custom_popup_rect);
 	ClassDB::bind_method(D_METHOD("get_item_area_rect", "item", "column"), &Tree::_get_item_rect, DEFVAL(-1));
-	ClassDB::bind_method(D_METHOD("get_item_at_pos", "pos"), &Tree::get_item_at_pos);
-	ClassDB::bind_method(D_METHOD("get_column_at_pos", "pos"), &Tree::get_column_at_pos);
-	ClassDB::bind_method(D_METHOD("get_drop_section_at_pos", "pos"), &Tree::get_drop_section_at_pos);
+	ClassDB::bind_method(D_METHOD("get_item_at_position", "position"), &Tree::get_item_at_position);
+	ClassDB::bind_method(D_METHOD("get_column_at_position", "position"), &Tree::get_column_at_position);
+	ClassDB::bind_method(D_METHOD("get_drop_section_at_position", "position"), &Tree::get_drop_section_at_position);
 
 	ClassDB::bind_method(D_METHOD("ensure_cursor_is_visible"), &Tree::ensure_cursor_is_visible);
 
@@ -3680,8 +3680,8 @@ void Tree::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("item_selected"));
 	ADD_SIGNAL(MethodInfo("cell_selected"));
 	ADD_SIGNAL(MethodInfo("multi_selected", PropertyInfo(Variant::OBJECT, "item"), PropertyInfo(Variant::INT, "column"), PropertyInfo(Variant::BOOL, "selected")));
-	ADD_SIGNAL(MethodInfo("item_rmb_selected", PropertyInfo(Variant::VECTOR2, "pos")));
-	ADD_SIGNAL(MethodInfo("empty_tree_rmb_selected", PropertyInfo(Variant::VECTOR2, "pos")));
+	ADD_SIGNAL(MethodInfo("item_rmb_selected", PropertyInfo(Variant::VECTOR2, "position")));
+	ADD_SIGNAL(MethodInfo("empty_tree_rmb_selected", PropertyInfo(Variant::VECTOR2, "position")));
 	ADD_SIGNAL(MethodInfo("item_edited"));
 	ADD_SIGNAL(MethodInfo("item_rmb_edited"));
 	ADD_SIGNAL(MethodInfo("item_custom_button_pressed"));

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -525,9 +525,9 @@ protected:
 public:
 	virtual String get_tooltip(const Point2 &p_pos) const;
 
-	TreeItem *get_item_at_pos(const Point2 &p_pos) const;
-	int get_column_at_pos(const Point2 &p_pos) const;
-	int get_drop_section_at_pos(const Point2 &p_pos) const;
+	TreeItem *get_item_at_position(const Point2 &p_pos) const;
+	int get_column_at_position(const Point2 &p_pos) const;
+	int get_drop_section_at_position(const Point2 &p_pos) const;
 
 	void clear();
 

--- a/scene/gui/video_player.cpp
+++ b/scene/gui/video_player.cpp
@@ -278,11 +278,11 @@ String VideoPlayer::get_stream_name() const {
 	return stream->get_name();
 };
 
-float VideoPlayer::get_stream_pos() const {
+float VideoPlayer::get_stream_position() const {
 
 	if (playback.is_null())
 		return 0;
-	return playback->get_pos();
+	return playback->get_position();
 };
 
 Ref<Texture> VideoPlayer::get_video_texture() {
@@ -327,7 +327,7 @@ void VideoPlayer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_stream_name"), &VideoPlayer::get_stream_name);
 
-	ClassDB::bind_method(D_METHOD("get_stream_pos"), &VideoPlayer::get_stream_pos);
+	ClassDB::bind_method(D_METHOD("get_stream_position"), &VideoPlayer::get_stream_position);
 
 	ClassDB::bind_method(D_METHOD("set_autoplay", "enabled"), &VideoPlayer::set_autoplay);
 	ClassDB::bind_method(D_METHOD("has_autoplay"), &VideoPlayer::has_autoplay);

--- a/scene/gui/video_player.h
+++ b/scene/gui/video_player.h
@@ -92,7 +92,7 @@ public:
 	float get_volume_db() const;
 
 	String get_stream_name() const;
-	float get_stream_pos() const;
+	float get_stream_position() const;
 
 	void set_autoplay(bool p_enable);
 	bool has_autoplay() const;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2693,7 +2693,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_to_group", "group", "persistent"), &Node::add_to_group, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_from_group", "group"), &Node::remove_from_group);
 	ClassDB::bind_method(D_METHOD("is_in_group", "group"), &Node::is_in_group);
-	ClassDB::bind_method(D_METHOD("move_child", "child_node", "to_pos"), &Node::move_child);
+	ClassDB::bind_method(D_METHOD("move_child", "child_node", "to_position"), &Node::move_child);
 	ClassDB::bind_method(D_METHOD("get_groups"), &Node::_get_groups);
 	ClassDB::bind_method(D_METHOD("raise"), &Node::raise);
 	ClassDB::bind_method(D_METHOD("set_owner", "owner"), &Node::set_owner);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1339,7 +1339,7 @@ Vector2 Viewport::get_mouse_position() const {
 void Viewport::warp_mouse(const Vector2 &p_pos) {
 
 	Vector2 gpos = (get_final_transform().affine_inverse() * _get_input_pre_xform()).affine_inverse().xform(p_pos);
-	Input::get_singleton()->warp_mouse_pos(gpos);
+	Input::get_singleton()->warp_mouse_position(gpos);
 }
 
 void Viewport::_gui_sort_subwindows() {
@@ -2673,7 +2673,7 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_attach_to_screen_rect", "rect"), &Viewport::set_attach_to_screen_rect);
 
 	ClassDB::bind_method(D_METHOD("get_mouse_position"), &Viewport::get_mouse_position);
-	ClassDB::bind_method(D_METHOD("warp_mouse", "to_pos"), &Viewport::warp_mouse);
+	ClassDB::bind_method(D_METHOD("warp_mouse", "to_position"), &Viewport::warp_mouse);
 
 	ClassDB::bind_method(D_METHOD("gui_has_modal_stack"), &Viewport::gui_has_modal_stack);
 	ClassDB::bind_method(D_METHOD("gui_get_drag_data"), &Viewport::gui_get_drag_data);

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -613,7 +613,7 @@ int Animation::transform_track_insert_key(int p_track, float p_time, const Vecto
 	return ret;
 }
 
-void Animation::track_remove_key_at_pos(int p_track, float p_pos) {
+void Animation::track_remove_key_at_position(int p_track, float p_pos) {
 
 	int idx = track_find_key(p_track, p_pos, true);
 	ERR_FAIL_COND(idx < 0);
@@ -707,12 +707,12 @@ void Animation::track_insert_key(int p_track, float p_time, const Variant &p_key
 
 			Dictionary d = p_key;
 			Vector3 loc;
-			if (d.has("loc"))
-				loc = d["loc"];
+			if (d.has("location"))
+				loc = d["location"];
 
 			Quat rot;
-			if (d.has("rot"))
-				rot = d["rot"];
+			if (d.has("rotation"))
+				rot = d["rotation"];
 
 			Vector3 scale;
 			if (d.has("scale"))
@@ -799,8 +799,8 @@ Variant Animation::track_get_key_value(int p_track, int p_key_idx) const {
 			ERR_FAIL_INDEX_V(p_key_idx, tt->transforms.size(), Variant());
 
 			Dictionary d;
-			d["loc"] = tt->transforms[p_key_idx].value.loc;
-			d["rot"] = tt->transforms[p_key_idx].value.rot;
+			d["location"] = tt->transforms[p_key_idx].value.loc;
+			d["rotation"] = tt->transforms[p_key_idx].value.rot;
 			d["scale"] = tt->transforms[p_key_idx].value.scale;
 
 			return d;
@@ -903,10 +903,10 @@ void Animation::track_set_key_value(int p_track, int p_key_idx, const Variant &p
 			TransformTrack *tt = static_cast<TransformTrack *>(t);
 			ERR_FAIL_INDEX(p_key_idx, tt->transforms.size());
 			Dictionary d = p_value;
-			if (d.has("loc"))
-				tt->transforms[p_key_idx].value.loc = d["loc"];
-			if (d.has("rot"))
-				tt->transforms[p_key_idx].value.rot = d["rot"];
+			if (d.has("location"))
+				tt->transforms[p_key_idx].value.loc = d["location"];
+			if (d.has("rotation"))
+				tt->transforms[p_key_idx].value.rot = d["rotation"];
 			if (d.has("scale"))
 				tt->transforms[p_key_idx].value.scale = d["scale"];
 
@@ -1590,7 +1590,7 @@ float Animation::get_step() const {
 
 void Animation::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("add_track", "type", "at_pos"), &Animation::add_track, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("add_track", "type", "at_position"), &Animation::add_track, DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("remove_track", "idx"), &Animation::remove_track);
 	ClassDB::bind_method(D_METHOD("get_track_count"), &Animation::get_track_count);
 	ClassDB::bind_method(D_METHOD("track_get_type", "idx"), &Animation::track_get_type);
@@ -1604,10 +1604,10 @@ void Animation::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("track_set_imported", "idx", "imported"), &Animation::track_set_imported);
 	ClassDB::bind_method(D_METHOD("track_is_imported", "idx"), &Animation::track_is_imported);
 
-	ClassDB::bind_method(D_METHOD("transform_track_insert_key", "idx", "time", "loc", "rot", "scale"), &Animation::transform_track_insert_key);
+	ClassDB::bind_method(D_METHOD("transform_track_insert_key", "idx", "time", "location", "rotation", "scale"), &Animation::transform_track_insert_key);
 	ClassDB::bind_method(D_METHOD("track_insert_key", "idx", "time", "key", "transition"), &Animation::track_insert_key, DEFVAL(1));
 	ClassDB::bind_method(D_METHOD("track_remove_key", "idx", "key_idx"), &Animation::track_remove_key);
-	ClassDB::bind_method(D_METHOD("track_remove_key_at_pos", "idx", "pos"), &Animation::track_remove_key_at_pos);
+	ClassDB::bind_method(D_METHOD("track_remove_key_at_position", "idx", "position"), &Animation::track_remove_key_at_position);
 	ClassDB::bind_method(D_METHOD("track_set_key_value", "idx", "key", "value"), &Animation::track_set_key_value);
 	ClassDB::bind_method(D_METHOD("track_set_key_transition", "idx", "key_idx", "transition"), &Animation::track_set_key_transition);
 	ClassDB::bind_method(D_METHOD("track_get_key_transition", "idx", "key_idx"), &Animation::track_get_key_transition);

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -245,7 +245,7 @@ public:
 	void track_set_key_value(int p_track, int p_key_idx, const Variant &p_value);
 	int track_find_key(int p_track, float p_time, bool p_exact = false) const;
 	void track_remove_key(int p_track, int p_idx);
-	void track_remove_key_at_pos(int p_track, float p_pos);
+	void track_remove_key_at_position(int p_track, float p_pos);
 	int track_get_key_count(int p_track) const;
 	Variant track_get_key_value(int p_track, int p_key_idx) const;
 	float track_get_key_time(int p_track, int p_key_idx) const;

--- a/scene/resources/audio_stream_sample.cpp
+++ b/scene/resources/audio_stream_sample.cpp
@@ -61,7 +61,7 @@ int AudioStreamPlaybackSample::get_loop_count() const {
 	return 0;
 }
 
-float AudioStreamPlaybackSample::get_pos() const {
+float AudioStreamPlaybackSample::get_position() const {
 
 	return float(offset >> MIX_FRAC_BITS) / base->mix_rate;
 }

--- a/scene/resources/audio_stream_sample.h
+++ b/scene/resources/audio_stream_sample.h
@@ -71,7 +71,7 @@ public:
 
 	virtual int get_loop_count() const; //times it looped
 
-	virtual float get_pos() const;
+	virtual float get_position() const;
 	virtual void seek_pos(float p_time);
 
 	virtual void mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames);

--- a/scene/resources/bit_mask.cpp
+++ b/scene/resources/bit_mask.cpp
@@ -172,8 +172,8 @@ void BitMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create", "size"), &BitMap::create);
 	ClassDB::bind_method(D_METHOD("create_from_image_alpha", "image"), &BitMap::create_from_image_alpha);
 
-	ClassDB::bind_method(D_METHOD("set_bit", "pos", "bit"), &BitMap::set_bit);
-	ClassDB::bind_method(D_METHOD("get_bit", "pos"), &BitMap::get_bit);
+	ClassDB::bind_method(D_METHOD("set_bit", "position", "bit"), &BitMap::set_bit);
+	ClassDB::bind_method(D_METHOD("get_bit", "position"), &BitMap::get_bit);
 
 	ClassDB::bind_method(D_METHOD("set_bit_rect", "p_rect", "bit"), &BitMap::set_bit_rect);
 	ClassDB::bind_method(D_METHOD("get_true_bit_count"), &BitMap::get_true_bit_count);

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -241,7 +241,7 @@ int Curve::set_point_offset(int p_index, float offset) {
 	return i;
 }
 
-Vector2 Curve::get_point_pos(int p_index) const {
+Vector2 Curve::get_point_position(int p_index) const {
 	ERR_FAIL_INDEX_V(p_index, _points.size(), Vector2(0, 0));
 	return _points[p_index].pos;
 }
@@ -480,11 +480,10 @@ real_t Curve::interpolate_baked(real_t offset) {
 
 void Curve::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("add_point", "pos", "left_tangent", "right_tangent", "left_mode", "right_mode"),
-			&Curve::add_point, DEFVAL(0), DEFVAL(0), DEFVAL(TANGENT_FREE), DEFVAL(TANGENT_FREE));
+	ClassDB::bind_method(D_METHOD("add_point", "position", "left_tangent", "right_tangent", "left_mode", "right_mode"), &Curve::add_point, DEFVAL(0), DEFVAL(0), DEFVAL(TANGENT_FREE), DEFVAL(TANGENT_FREE));
 	ClassDB::bind_method(D_METHOD("remove_point", "index"), &Curve::remove_point);
 	ClassDB::bind_method(D_METHOD("clear_points"), &Curve::clear_points);
-	ClassDB::bind_method(D_METHOD("get_point_pos", "index"), &Curve::get_point_pos);
+	ClassDB::bind_method(D_METHOD("get_point_position", "index"), &Curve::get_point_position);
 	ClassDB::bind_method(D_METHOD("set_point_value", "index", "y"), &Curve::set_point_value);
 	ClassDB::bind_method(D_METHOD("set_point_offset", "index", "offset"), &Curve::set_point_value);
 	ClassDB::bind_method(D_METHOD("interpolate", "offset"), &Curve::interpolate);
@@ -539,7 +538,7 @@ void Curve2D::add_point(const Vector2 &p_pos, const Vector2 &p_in, const Vector2
 	emit_signal(CoreStringNames::get_singleton()->changed);
 }
 
-void Curve2D::set_point_pos(int p_index, const Vector2 &p_pos) {
+void Curve2D::set_point_position(int p_index, const Vector2 &p_pos) {
 
 	ERR_FAIL_INDEX(p_index, points.size());
 
@@ -547,7 +546,7 @@ void Curve2D::set_point_pos(int p_index, const Vector2 &p_pos) {
 	baked_cache_dirty = true;
 	emit_signal(CoreStringNames::get_singleton()->changed);
 }
-Vector2 Curve2D::get_point_pos(int p_index) const {
+Vector2 Curve2D::get_point_position(int p_index) const {
 
 	ERR_FAIL_INDEX_V(p_index, points.size(), Vector2());
 	return points[p_index].pos;
@@ -891,12 +890,12 @@ PoolVector2Array Curve2D::tessellate(int p_max_stages, float p_tolerance) const 
 void Curve2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_point_count"), &Curve2D::get_point_count);
-	ClassDB::bind_method(D_METHOD("add_point", "pos", "in", "out", "atpos"), &Curve2D::add_point, DEFVAL(Vector2()), DEFVAL(Vector2()), DEFVAL(-1));
-	ClassDB::bind_method(D_METHOD("set_point_pos", "idx", "pos"), &Curve2D::set_point_pos);
-	ClassDB::bind_method(D_METHOD("get_point_pos", "idx"), &Curve2D::get_point_pos);
-	ClassDB::bind_method(D_METHOD("set_point_in", "idx", "pos"), &Curve2D::set_point_in);
+	ClassDB::bind_method(D_METHOD("add_point", "position", "in", "out", "at_position"), &Curve2D::add_point, DEFVAL(Vector2()), DEFVAL(Vector2()), DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("set_point_position", "idx", "position"), &Curve2D::set_point_position);
+	ClassDB::bind_method(D_METHOD("get_point_position", "idx"), &Curve2D::get_point_position);
+	ClassDB::bind_method(D_METHOD("set_point_in", "idx", "position"), &Curve2D::set_point_in);
 	ClassDB::bind_method(D_METHOD("get_point_in", "idx"), &Curve2D::get_point_in);
-	ClassDB::bind_method(D_METHOD("set_point_out", "idx", "pos"), &Curve2D::set_point_out);
+	ClassDB::bind_method(D_METHOD("set_point_out", "idx", "position"), &Curve2D::set_point_out);
 	ClassDB::bind_method(D_METHOD("get_point_out", "idx"), &Curve2D::get_point_out);
 	ClassDB::bind_method(D_METHOD("remove_point", "idx"), &Curve2D::remove_point);
 	ClassDB::bind_method(D_METHOD("clear_points"), &Curve2D::clear_points);
@@ -916,9 +915,6 @@ void Curve2D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "bake_interval", PROPERTY_HINT_RANGE, "0.01,512,0.01"), "set_bake_interval", "get_bake_interval");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "_set_data", "_get_data");
-	/*ADD_PROPERTY( PropertyInfo( Variant::VECTOR3_ARRAY, "points_out"), "set_points_out","get_points_out");
-	ADD_PROPERTY( PropertyInfo( Variant::VECTOR3_ARRAY, "points_pos"), "set_points_pos","get_points_pos");
-*/
 }
 
 Curve2D::Curve2D() {
@@ -955,7 +951,7 @@ void Curve3D::add_point(const Vector3 &p_pos, const Vector3 &p_in, const Vector3
 	baked_cache_dirty = true;
 	emit_signal(CoreStringNames::get_singleton()->changed);
 }
-void Curve3D::set_point_pos(int p_index, const Vector3 &p_pos) {
+void Curve3D::set_point_position(int p_index, const Vector3 &p_pos) {
 
 	ERR_FAIL_INDEX(p_index, points.size());
 
@@ -963,7 +959,7 @@ void Curve3D::set_point_pos(int p_index, const Vector3 &p_pos) {
 	baked_cache_dirty = true;
 	emit_signal(CoreStringNames::get_singleton()->changed);
 }
-Vector3 Curve3D::get_point_pos(int p_index) const {
+Vector3 Curve3D::get_point_position(int p_index) const {
 
 	ERR_FAIL_INDEX_V(p_index, points.size(), Vector3());
 	return points[p_index].pos;
@@ -1386,14 +1382,14 @@ PoolVector3Array Curve3D::tessellate(int p_max_stages, float p_tolerance) const 
 void Curve3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_point_count"), &Curve3D::get_point_count);
-	ClassDB::bind_method(D_METHOD("add_point", "pos", "in", "out", "atpos"), &Curve3D::add_point, DEFVAL(Vector3()), DEFVAL(Vector3()), DEFVAL(-1));
-	ClassDB::bind_method(D_METHOD("set_point_pos", "idx", "pos"), &Curve3D::set_point_pos);
-	ClassDB::bind_method(D_METHOD("get_point_pos", "idx"), &Curve3D::get_point_pos);
+	ClassDB::bind_method(D_METHOD("add_point", "position", "in", "out", "at_position"), &Curve3D::add_point, DEFVAL(Vector3()), DEFVAL(Vector3()), DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("set_point_position", "idx", "position"), &Curve3D::set_point_position);
+	ClassDB::bind_method(D_METHOD("get_point_position", "idx"), &Curve3D::get_point_position);
 	ClassDB::bind_method(D_METHOD("set_point_tilt", "idx", "tilt"), &Curve3D::set_point_tilt);
 	ClassDB::bind_method(D_METHOD("get_point_tilt", "idx"), &Curve3D::get_point_tilt);
-	ClassDB::bind_method(D_METHOD("set_point_in", "idx", "pos"), &Curve3D::set_point_in);
+	ClassDB::bind_method(D_METHOD("set_point_in", "idx", "position"), &Curve3D::set_point_in);
 	ClassDB::bind_method(D_METHOD("get_point_in", "idx"), &Curve3D::get_point_in);
-	ClassDB::bind_method(D_METHOD("set_point_out", "idx", "pos"), &Curve3D::set_point_out);
+	ClassDB::bind_method(D_METHOD("set_point_out", "idx", "position"), &Curve3D::set_point_out);
 	ClassDB::bind_method(D_METHOD("get_point_out", "idx"), &Curve3D::get_point_out);
 	ClassDB::bind_method(D_METHOD("remove_point", "idx"), &Curve3D::remove_point);
 	ClassDB::bind_method(D_METHOD("clear_points"), &Curve3D::clear_points);
@@ -1414,9 +1410,6 @@ void Curve3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "bake_interval", PROPERTY_HINT_RANGE, "0.01,512,0.01"), "set_bake_interval", "get_bake_interval");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "_set_data", "_get_data");
-	/*ADD_PROPERTY( PropertyInfo( Variant::VECTOR3_ARRAY, "points_out"), "set_points_out","get_points_out");
-	ADD_PROPERTY( PropertyInfo( Variant::VECTOR3_ARRAY, "points_pos"), "set_points_pos","get_points_pos");
-*/
 }
 
 Curve3D::Curve3D() {

--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -92,7 +92,7 @@ public:
 
 	void set_point_value(int p_index, real_t pos);
 	int set_point_offset(int p_index, float offset);
-	Vector2 get_point_pos(int p_index) const;
+	Vector2 get_point_position(int p_index) const;
 
 	Point get_point(int p_index) const;
 
@@ -180,8 +180,8 @@ protected:
 public:
 	int get_point_count() const;
 	void add_point(const Vector2 &p_pos, const Vector2 &p_in = Vector2(), const Vector2 &p_out = Vector2(), int p_atpos = -1);
-	void set_point_pos(int p_index, const Vector2 &p_pos);
-	Vector2 get_point_pos(int p_index) const;
+	void set_point_position(int p_index, const Vector2 &p_pos);
+	Vector2 get_point_position(int p_index) const;
 	void set_point_in(int p_index, const Vector2 &p_in);
 	Vector2 get_point_in(int p_index) const;
 	void set_point_out(int p_index, const Vector2 &p_out);
@@ -245,8 +245,8 @@ protected:
 public:
 	int get_point_count() const;
 	void add_point(const Vector3 &p_pos, const Vector3 &p_in = Vector3(), const Vector3 &p_out = Vector3(), int p_atpos = -1);
-	void set_point_pos(int p_index, const Vector3 &p_pos);
-	Vector3 get_point_pos(int p_index) const;
+	void set_point_position(int p_index, const Vector3 &p_pos);
+	Vector3 get_point_position(int p_index) const;
 	void set_point_tilt(int p_index, float p_tilt);
 	float get_point_tilt(int p_index) const;
 	void set_point_in(int p_index, const Vector3 &p_in);

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -397,7 +397,7 @@ unsigned long DynamicFontAtSize::_ft_stream_io(FT_Stream stream, unsigned long o
 
 	FileAccess *f = (FileAccess *)stream->descriptor.pointer;
 
-	if (f->get_pos() != offset) {
+	if (f->get_position() != offset) {
 		f->seek(offset);
 	}
 

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -80,13 +80,13 @@ void Font::update_changes() {
 
 void Font::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("draw", "canvas_item", "pos", "string", "modulate", "clip_w"), &Font::draw, DEFVAL(Color(1, 1, 1)), DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("draw", "canvas_item", "position", "string", "modulate", "clip_w"), &Font::draw, DEFVAL(Color(1, 1, 1)), DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("get_ascent"), &Font::get_ascent);
 	ClassDB::bind_method(D_METHOD("get_descent"), &Font::get_descent);
 	ClassDB::bind_method(D_METHOD("get_height"), &Font::get_height);
 	ClassDB::bind_method(D_METHOD("is_distance_field_hint"), &Font::is_distance_field_hint);
 	ClassDB::bind_method(D_METHOD("get_string_size", "string"), &Font::get_string_size);
-	ClassDB::bind_method(D_METHOD("draw_char", "canvas_item", "pos", "char", "next", "modulate"), &Font::draw_char, DEFVAL(-1), DEFVAL(Color(1, 1, 1)));
+	ClassDB::bind_method(D_METHOD("draw_char", "canvas_item", "position", "char", "next", "modulate"), &Font::draw_char, DEFVAL(-1), DEFVAL(Color(1, 1, 1)));
 	ClassDB::bind_method(D_METHOD("update_changes"), &Font::update_changes);
 }
 

--- a/scene/resources/scene_format_text.cpp
+++ b/scene/resources/scene_format_text.cpp
@@ -679,7 +679,7 @@ Error ResourceInteractiveLoaderText::rename_dependencies(FileAccess *p_f, const 
 
 	String base_path = local_path.get_base_dir();
 
-	uint64_t tag_end = f->get_pos();
+	uint64_t tag_end = f->get_position();
 
 	while (true) {
 
@@ -741,7 +741,7 @@ Error ResourceInteractiveLoaderText::rename_dependencies(FileAccess *p_f, const 
 
 			fw->store_line("[ext_resource path=\"" + path + "\" type=\"" + type + "\" id=" + itos(index) + "]");
 
-			tag_end = f->get_pos();
+			tag_end = f->get_position();
 		}
 	}
 

--- a/scene/resources/shader_graph.cpp
+++ b/scene/resources/shader_graph.cpp
@@ -172,8 +172,8 @@ void ShaderGraph::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("node_add","shader_type","node_type","id"),&ShaderGraph::node_add);
 	ClassDB::bind_method(D_METHOD("node_remove","shader_type","id"),&ShaderGraph::node_remove);
-	ClassDB::bind_method(D_METHOD("node_set_pos","shader_type","id","pos"),&ShaderGraph::node_set_pos);
-	ClassDB::bind_method(D_METHOD("node_get_pos","shader_type","id"),&ShaderGraph::node_get_pos);
+	ClassDB::bind_method(D_METHOD("node_set_position","shader_type","id","position"),&ShaderGraph::node_set_position);
+	ClassDB::bind_method(D_METHOD("node_get_position","shader_type","id"),&ShaderGraph::node_get_position);
 
 	ClassDB::bind_method(D_METHOD("node_get_type","shader_type","id"),&ShaderGraph::node_get_type);
 
@@ -501,7 +501,7 @@ void ShaderGraph::node_add(ShaderType p_type, NodeType p_node_type,int p_id) {
 	_request_update();
 }
 
-void ShaderGraph::node_set_pos(ShaderType p_type,int p_id, const Vector2& p_pos) {
+void ShaderGraph::node_set_position(ShaderType p_type,int p_id, const Vector2& p_pos) {
 	ERR_FAIL_INDEX(p_type,3);
 
 	ERR_FAIL_COND(!shader[p_type].node_map.has(p_id));
@@ -509,7 +509,7 @@ void ShaderGraph::node_set_pos(ShaderType p_type,int p_id, const Vector2& p_pos)
 	_request_update();
 
 }
-Vector2 ShaderGraph::node_get_pos(ShaderType p_type,int p_id) const {
+Vector2 ShaderGraph::node_get_position(ShaderType p_type,int p_id) const {
 	ERR_FAIL_INDEX_V(p_type,3,Vector2());
 
 	ERR_FAIL_COND_V(!shader[p_type].node_map.has(p_id),Vector2());
@@ -1245,7 +1245,7 @@ Variant ShaderGraph::node_get_state(ShaderType p_type,int p_id) const {
 	ERR_FAIL_COND_V(!shader[p_type].node_map.has(p_id),Variant());
 	const Node& n = shader[p_type].node_map[p_id];
 	Dictionary s;
-	s["pos"]=n.pos;
+	s["position"]=n.pos;
 	s["param1"]=n.param1;
 	s["param2"]=n.param2;
 	Array keys;
@@ -1263,12 +1263,12 @@ void ShaderGraph::node_set_state(ShaderType p_type,int p_id,const Variant& p_sta
 	ERR_FAIL_COND(!shader[p_type].node_map.has(p_id));
 	Node& n = shader[p_type].node_map[p_id];
 	Dictionary d = p_state;
-	ERR_FAIL_COND(!d.has("pos"));
+	ERR_FAIL_COND(!d.has("position"));
 	ERR_FAIL_COND(!d.has("param1"));
 	ERR_FAIL_COND(!d.has("param2"));
 	ERR_FAIL_COND(!d.has("default_keys"));
 
-	n.pos=d["pos"];
+	n.pos=d["position"];
 	n.param1=d["param1"];
 	n.param2=d["param2"];
 	Array keys = d["default_keys"];

--- a/scene/resources/shader_graph.h
+++ b/scene/resources/shader_graph.h
@@ -195,8 +195,8 @@ public:
 
 	void node_add(ShaderType p_type, NodeType p_node_type, int p_id);
 	void node_remove(ShaderType p_which,int p_id);
-	void node_set_pos(ShaderType p_which,int p_id,const Point2& p_pos);
-	Point2 node_get_pos(ShaderType p_which,int p_id) const;
+	void node_set_position(ShaderType p_which,int p_id,const Point2& p_pos);
+	Point2 node_get_position(ShaderType p_which,int p_id) const;
 
 	void get_node_list(ShaderType p_which,List<int> *p_node_list) const;
 	NodeType node_get_type(ShaderType p_which,int p_id) const;

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -70,7 +70,7 @@ void Texture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_alpha"), &Texture::has_alpha);
 	ClassDB::bind_method(D_METHOD("set_flags", "flags"), &Texture::set_flags);
 	ClassDB::bind_method(D_METHOD("get_flags"), &Texture::get_flags);
-	ClassDB::bind_method(D_METHOD("draw", "canvas_item", "pos", "modulate", "transpose", "normal_map"), &Texture::draw, DEFVAL(Color(1, 1, 1)), DEFVAL(false), DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("draw", "canvas_item", "position", "modulate", "transpose", "normal_map"), &Texture::draw, DEFVAL(Color(1, 1, 1)), DEFVAL(false), DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("draw_rect", "canvas_item", "rect", "tile", "modulate", "transpose", "normal_map"), &Texture::draw_rect, DEFVAL(Color(1, 1, 1)), DEFVAL(false), DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("draw_rect_region", "canvas_item", "rect", "src_rect", "modulate", "transpose", "normal_map", "clip_uv"), &Texture::draw_rect_region, DEFVAL(Color(1, 1, 1)), DEFVAL(false), DEFVAL(Variant()), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("get_data"), &Texture::get_data);
@@ -488,7 +488,7 @@ Error StreamTexture::_load_data(const String &p_path, int &tw, int &th, int &fla
 
 		while (mipmaps > 1 && p_size_limit > 0 && (sw > p_size_limit || sh > p_size_limit)) {
 
-			f->seek(f->get_pos() + size);
+			f->seek(f->get_position() + size);
 			mipmaps = f->get_32();
 			size = f->get_32();
 
@@ -610,7 +610,7 @@ Error StreamTexture::_load_data(const String &p_path, int &tw, int &th, int &fla
 				ERR_FAIL_V(ERR_FILE_CORRUPT);
 			}
 
-			f->seek(f->get_pos() + ofs);
+			f->seek(f->get_position() + ofs);
 
 			PoolVector<uint8_t> img_data;
 			img_data.resize(total_size - ofs);

--- a/scene/resources/video_stream.h
+++ b/scene/resources/video_stream.h
@@ -55,7 +55,7 @@ public:
 
 	virtual float get_length() const = 0;
 
-	virtual float get_pos() const = 0;
+	virtual float get_position() const = 0;
 	virtual void seek_pos(float p_time) = 0;
 
 	virtual void set_audio_track(int p_idx) = 0;

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -178,9 +178,9 @@ int AudioStreamPlaybackRandomPitch::get_loop_count() const {
 	return 0;
 }
 
-float AudioStreamPlaybackRandomPitch::get_pos() const {
+float AudioStreamPlaybackRandomPitch::get_position() const {
 	if (playing.is_valid()) {
-		return playing->get_pos();
+		return playing->get_position();
 	}
 
 	return 0;

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -45,7 +45,7 @@ public:
 
 	virtual int get_loop_count() const = 0; //times it looped
 
-	virtual float get_pos() const = 0;
+	virtual float get_position() const = 0;
 	virtual void seek_pos(float p_time) = 0;
 
 	virtual void mix(AudioFrame *p_bufer, float p_rate_scale, int p_frames) = 0;
@@ -133,7 +133,7 @@ public:
 
 	virtual int get_loop_count() const; //times it looped
 
-	virtual float get_pos() const;
+	virtual float get_position() const;
 	virtual void seek_pos(float p_time);
 
 	virtual void mix(AudioFrame *p_bufer, float p_rate_scale, int p_frames);

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1088,7 +1088,7 @@ void AudioServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_bus_count"), &AudioServer::get_bus_count);
 
 	ClassDB::bind_method(D_METHOD("remove_bus", "index"), &AudioServer::remove_bus);
-	ClassDB::bind_method(D_METHOD("add_bus", "at_pos"), &AudioServer::add_bus, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("add_bus", "at_position"), &AudioServer::add_bus, DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("move_bus", "index", "to_index"), &AudioServer::move_bus);
 
 	ClassDB::bind_method(D_METHOD("set_bus_name", "bus_idx", "name"), &AudioServer::set_bus_name);
@@ -1110,7 +1110,7 @@ void AudioServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_bus_bypass_effects", "bus_idx", "enable"), &AudioServer::set_bus_bypass_effects);
 	ClassDB::bind_method(D_METHOD("is_bus_bypassing_effects", "bus_idx"), &AudioServer::is_bus_bypassing_effects);
 
-	ClassDB::bind_method(D_METHOD("add_bus_effect", "bus_idx", "effect", "at_pos"), &AudioServer::add_bus_effect, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("add_bus_effect", "bus_idx", "effect", "at_position"), &AudioServer::add_bus_effect, DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("remove_bus_effect", "bus_idx", "effect_idx"), &AudioServer::remove_bus_effect);
 
 	ClassDB::bind_method(D_METHOD("get_bus_effect_count", "bus_idx"), &AudioServer::get_bus_effect_count);

--- a/servers/physics/body_sw.h
+++ b/servers/physics/body_sw.h
@@ -399,7 +399,7 @@ public:
 
 	virtual int get_contact_count() const { return body->contact_count; }
 
-	virtual Vector3 get_contact_local_pos(int p_contact_idx) const {
+	virtual Vector3 get_contact_local_position(int p_contact_idx) const {
 		ERR_FAIL_INDEX_V(p_contact_idx, body->contact_count, Vector3());
 		return body->contacts[p_contact_idx].local_pos;
 	}
@@ -416,7 +416,7 @@ public:
 		ERR_FAIL_INDEX_V(p_contact_idx, body->contact_count, RID());
 		return body->contacts[p_contact_idx].collider;
 	}
-	virtual Vector3 get_contact_collider_pos(int p_contact_idx) const {
+	virtual Vector3 get_contact_collider_position(int p_contact_idx) const {
 		ERR_FAIL_INDEX_V(p_contact_idx, body->contact_count, Vector3());
 		return body->contacts[p_contact_idx].collider_pos;
 	}
@@ -428,7 +428,7 @@ public:
 		ERR_FAIL_INDEX_V(p_contact_idx, body->contact_count, 0);
 		return body->contacts[p_contact_idx].collider_shape;
 	}
-	virtual Vector3 get_contact_collider_velocity_at_pos(int p_contact_idx) const {
+	virtual Vector3 get_contact_collider_velocity_at_position(int p_contact_idx) const {
 		ERR_FAIL_INDEX_V(p_contact_idx, body->contact_count, Vector3());
 		return body->contacts[p_contact_idx].collider_velocity_at_pos;
 	}

--- a/servers/physics/joints/pin_joint_sw.h
+++ b/servers/physics/joints/pin_joint_sw.h
@@ -86,8 +86,8 @@ public:
 	void set_pos_a(const Vector3 &p_pos) { m_pivotInA = p_pos; }
 	void set_pos_b(const Vector3 &p_pos) { m_pivotInB = p_pos; }
 
-	Vector3 get_pos_a() { return m_pivotInB; }
-	Vector3 get_pos_b() { return m_pivotInA; }
+	Vector3 get_position_a() { return m_pivotInB; }
+	Vector3 get_position_b() { return m_pivotInA; }
 
 	PinJointSW(BodySW *p_body_a, const Vector3 &p_pos_a, BodySW *p_body_b, const Vector3 &p_pos_b);
 	~PinJointSW();

--- a/servers/physics/physics_server_sw.cpp
+++ b/servers/physics/physics_server_sw.cpp
@@ -968,7 +968,7 @@ Vector3 PhysicsServerSW::pin_joint_get_local_a(RID p_joint) const {
 	ERR_FAIL_COND_V(!joint, Vector3());
 	ERR_FAIL_COND_V(joint->get_type() != JOINT_PIN, Vector3());
 	PinJointSW *pin_joint = static_cast<PinJointSW *>(joint);
-	return pin_joint->get_pos_a();
+	return pin_joint->get_position_a();
 }
 
 void PhysicsServerSW::pin_joint_set_local_b(RID p_joint, const Vector3 &p_B) {
@@ -985,7 +985,7 @@ Vector3 PhysicsServerSW::pin_joint_get_local_b(RID p_joint) const {
 	ERR_FAIL_COND_V(!joint, Vector3());
 	ERR_FAIL_COND_V(joint->get_type() != JOINT_PIN, Vector3());
 	PinJointSW *pin_joint = static_cast<PinJointSW *>(joint);
-	return pin_joint->get_pos_b();
+	return pin_joint->get_position_b();
 }
 
 RID PhysicsServerSW::joint_create_hinge(RID p_body_A, const Transform &p_frame_A, RID p_body_B, const Transform &p_frame_B) {

--- a/servers/physics_2d/body_2d_sw.h
+++ b/servers/physics_2d/body_2d_sw.h
@@ -353,7 +353,7 @@ public:
 
 	virtual int get_contact_count() const { return body->contact_count; }
 
-	virtual Vector2 get_contact_local_pos(int p_contact_idx) const {
+	virtual Vector2 get_contact_local_position(int p_contact_idx) const {
 		ERR_FAIL_INDEX_V(p_contact_idx, body->contact_count, Vector2());
 		return body->contacts[p_contact_idx].local_pos;
 	}
@@ -370,7 +370,7 @@ public:
 		ERR_FAIL_INDEX_V(p_contact_idx, body->contact_count, RID());
 		return body->contacts[p_contact_idx].collider;
 	}
-	virtual Vector2 get_contact_collider_pos(int p_contact_idx) const {
+	virtual Vector2 get_contact_collider_position(int p_contact_idx) const {
 		ERR_FAIL_INDEX_V(p_contact_idx, body->contact_count, Vector2());
 		return body->contacts[p_contact_idx].collider_pos;
 	}
@@ -384,7 +384,7 @@ public:
 	}
 	virtual Variant get_contact_collider_shape_metadata(int p_contact_idx) const;
 
-	virtual Vector2 get_contact_collider_velocity_at_pos(int p_contact_idx) const {
+	virtual Vector2 get_contact_collider_velocity_at_position(int p_contact_idx) const {
 		ERR_FAIL_INDEX_V(p_contact_idx, body->contact_count, Vector2());
 		return body->contacts[p_contact_idx].collider_velocity_at_pos;
 	}

--- a/servers/physics_2d_server.cpp
+++ b/servers/physics_2d_server.cpp
@@ -92,16 +92,16 @@ void Physics2DDirectBodyState::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_contact_count"), &Physics2DDirectBodyState::get_contact_count);
 
-	ClassDB::bind_method(D_METHOD("get_contact_local_pos", "contact_idx"), &Physics2DDirectBodyState::get_contact_local_pos);
+	ClassDB::bind_method(D_METHOD("get_contact_local_position", "contact_idx"), &Physics2DDirectBodyState::get_contact_local_position);
 	ClassDB::bind_method(D_METHOD("get_contact_local_normal", "contact_idx"), &Physics2DDirectBodyState::get_contact_local_normal);
 	ClassDB::bind_method(D_METHOD("get_contact_local_shape", "contact_idx"), &Physics2DDirectBodyState::get_contact_local_shape);
 	ClassDB::bind_method(D_METHOD("get_contact_collider", "contact_idx"), &Physics2DDirectBodyState::get_contact_collider);
-	ClassDB::bind_method(D_METHOD("get_contact_collider_pos", "contact_idx"), &Physics2DDirectBodyState::get_contact_collider_pos);
+	ClassDB::bind_method(D_METHOD("get_contact_collider_position", "contact_idx"), &Physics2DDirectBodyState::get_contact_collider_position);
 	ClassDB::bind_method(D_METHOD("get_contact_collider_id", "contact_idx"), &Physics2DDirectBodyState::get_contact_collider_id);
 	ClassDB::bind_method(D_METHOD("get_contact_collider_object", "contact_idx"), &Physics2DDirectBodyState::get_contact_collider_object);
 	ClassDB::bind_method(D_METHOD("get_contact_collider_shape", "contact_idx"), &Physics2DDirectBodyState::get_contact_collider_shape);
 	ClassDB::bind_method(D_METHOD("get_contact_collider_shape_metadata", "contact_idx"), &Physics2DDirectBodyState::get_contact_collider_shape_metadata);
-	ClassDB::bind_method(D_METHOD("get_contact_collider_velocity_at_pos", "contact_idx"), &Physics2DDirectBodyState::get_contact_collider_velocity_at_pos);
+	ClassDB::bind_method(D_METHOD("get_contact_collider_velocity_at_position", "contact_idx"), &Physics2DDirectBodyState::get_contact_collider_velocity_at_position);
 	ClassDB::bind_method(D_METHOD("get_step"), &Physics2DDirectBodyState::get_step);
 	ClassDB::bind_method(D_METHOD("integrate_forces"), &Physics2DDirectBodyState::integrate_forces);
 	ClassDB::bind_method(D_METHOD("get_space_state"), &Physics2DDirectBodyState::get_space_state);
@@ -561,7 +561,7 @@ void Physics2DServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("body_set_state", "body", "state", "value"), &Physics2DServer::body_set_state);
 	ClassDB::bind_method(D_METHOD("body_get_state", "body", "state"), &Physics2DServer::body_get_state);
 
-	ClassDB::bind_method(D_METHOD("body_apply_impulse", "body", "pos", "impulse"), &Physics2DServer::body_apply_impulse);
+	ClassDB::bind_method(D_METHOD("body_apply_impulse", "body", "position", "impulse"), &Physics2DServer::body_apply_impulse);
 	ClassDB::bind_method(D_METHOD("body_add_force", "body", "offset", "force"), &Physics2DServer::body_add_force);
 	ClassDB::bind_method(D_METHOD("body_set_axis_velocity", "body", "axis_velocity"), &Physics2DServer::body_set_axis_velocity);
 

--- a/servers/physics_2d_server.h
+++ b/servers/physics_2d_server.h
@@ -65,17 +65,17 @@ public:
 
 	virtual int get_contact_count() const = 0;
 
-	virtual Vector2 get_contact_local_pos(int p_contact_idx) const = 0;
+	virtual Vector2 get_contact_local_position(int p_contact_idx) const = 0;
 	virtual Vector2 get_contact_local_normal(int p_contact_idx) const = 0;
 	virtual int get_contact_local_shape(int p_contact_idx) const = 0;
 
 	virtual RID get_contact_collider(int p_contact_idx) const = 0;
-	virtual Vector2 get_contact_collider_pos(int p_contact_idx) const = 0;
+	virtual Vector2 get_contact_collider_position(int p_contact_idx) const = 0;
 	virtual ObjectID get_contact_collider_id(int p_contact_idx) const = 0;
 	virtual Object *get_contact_collider_object(int p_contact_idx) const;
 	virtual int get_contact_collider_shape(int p_contact_idx) const = 0;
 	virtual Variant get_contact_collider_shape_metadata(int p_contact_idx) const = 0;
-	virtual Vector2 get_contact_collider_velocity_at_pos(int p_contact_idx) const = 0;
+	virtual Vector2 get_contact_collider_velocity_at_position(int p_contact_idx) const = 0;
 
 	virtual real_t get_step() const = 0;
 	virtual void integrate_forces();

--- a/servers/physics_server.cpp
+++ b/servers/physics_server.cpp
@@ -89,8 +89,8 @@ void PhysicsDirectBodyState::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_transform", "transform"), &PhysicsDirectBodyState::set_transform);
 	ClassDB::bind_method(D_METHOD("get_transform"), &PhysicsDirectBodyState::get_transform);
 
-	ClassDB::bind_method(D_METHOD("add_force", "force", "pos"), &PhysicsDirectBodyState::add_force);
-	ClassDB::bind_method(D_METHOD("apply_impulse", "pos", "j"), &PhysicsDirectBodyState::apply_impulse);
+	ClassDB::bind_method(D_METHOD("add_force", "force", "position"), &PhysicsDirectBodyState::add_force);
+	ClassDB::bind_method(D_METHOD("apply_impulse", "position", "j"), &PhysicsDirectBodyState::apply_impulse);
 	ClassDB::bind_method(D_METHOD("apply_torqe_impulse", "j"), &PhysicsDirectBodyState::apply_torque_impulse);
 
 	ClassDB::bind_method(D_METHOD("set_sleep_state", "enabled"), &PhysicsDirectBodyState::set_sleep_state);
@@ -98,15 +98,15 @@ void PhysicsDirectBodyState::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_contact_count"), &PhysicsDirectBodyState::get_contact_count);
 
-	ClassDB::bind_method(D_METHOD("get_contact_local_pos", "contact_idx"), &PhysicsDirectBodyState::get_contact_local_pos);
+	ClassDB::bind_method(D_METHOD("get_contact_local_position", "contact_idx"), &PhysicsDirectBodyState::get_contact_local_position);
 	ClassDB::bind_method(D_METHOD("get_contact_local_normal", "contact_idx"), &PhysicsDirectBodyState::get_contact_local_normal);
 	ClassDB::bind_method(D_METHOD("get_contact_local_shape", "contact_idx"), &PhysicsDirectBodyState::get_contact_local_shape);
 	ClassDB::bind_method(D_METHOD("get_contact_collider", "contact_idx"), &PhysicsDirectBodyState::get_contact_collider);
-	ClassDB::bind_method(D_METHOD("get_contact_collider_pos", "contact_idx"), &PhysicsDirectBodyState::get_contact_collider_pos);
+	ClassDB::bind_method(D_METHOD("get_contact_collider_position", "contact_idx"), &PhysicsDirectBodyState::get_contact_collider_position);
 	ClassDB::bind_method(D_METHOD("get_contact_collider_id", "contact_idx"), &PhysicsDirectBodyState::get_contact_collider_id);
 	ClassDB::bind_method(D_METHOD("get_contact_collider_object", "contact_idx"), &PhysicsDirectBodyState::get_contact_collider_object);
 	ClassDB::bind_method(D_METHOD("get_contact_collider_shape", "contact_idx"), &PhysicsDirectBodyState::get_contact_collider_shape);
-	ClassDB::bind_method(D_METHOD("get_contact_collider_velocity_at_pos", "contact_idx"), &PhysicsDirectBodyState::get_contact_collider_velocity_at_pos);
+	ClassDB::bind_method(D_METHOD("get_contact_collider_velocity_at_position", "contact_idx"), &PhysicsDirectBodyState::get_contact_collider_velocity_at_position);
 	ClassDB::bind_method(D_METHOD("get_step"), &PhysicsDirectBodyState::get_step);
 	ClassDB::bind_method(D_METHOD("integrate_forces"), &PhysicsDirectBodyState::integrate_forces);
 	ClassDB::bind_method(D_METHOD("get_space_state"), &PhysicsDirectBodyState::get_space_state);
@@ -482,7 +482,7 @@ void PhysicsServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("body_set_state", "body", "state", "value"), &PhysicsServer::body_set_state);
 	ClassDB::bind_method(D_METHOD("body_get_state", "body", "state"), &PhysicsServer::body_get_state);
 
-	ClassDB::bind_method(D_METHOD("body_apply_impulse", "body", "pos", "impulse"), &PhysicsServer::body_apply_impulse);
+	ClassDB::bind_method(D_METHOD("body_apply_impulse", "body", "position", "impulse"), &PhysicsServer::body_apply_impulse);
 	ClassDB::bind_method(D_METHOD("body_apply_torque_impulse", "body", "impulse"), &PhysicsServer::body_apply_torque_impulse);
 	ClassDB::bind_method(D_METHOD("body_set_axis_velocity", "body", "axis_velocity"), &PhysicsServer::body_set_axis_velocity);
 

--- a/servers/physics_server.h
+++ b/servers/physics_server.h
@@ -71,16 +71,16 @@ public:
 
 	virtual int get_contact_count() const = 0;
 
-	virtual Vector3 get_contact_local_pos(int p_contact_idx) const = 0;
+	virtual Vector3 get_contact_local_position(int p_contact_idx) const = 0;
 	virtual Vector3 get_contact_local_normal(int p_contact_idx) const = 0;
 	virtual int get_contact_local_shape(int p_contact_idx) const = 0;
 
 	virtual RID get_contact_collider(int p_contact_idx) const = 0;
-	virtual Vector3 get_contact_collider_pos(int p_contact_idx) const = 0;
+	virtual Vector3 get_contact_collider_position(int p_contact_idx) const = 0;
 	virtual ObjectID get_contact_collider_id(int p_contact_idx) const = 0;
 	virtual Object *get_contact_collider_object(int p_contact_idx) const;
 	virtual int get_contact_collider_shape(int p_contact_idx) const = 0;
-	virtual Vector3 get_contact_collider_velocity_at_pos(int p_contact_idx) const = 0;
+	virtual Vector3 get_contact_collider_velocity_at_position(int p_contact_idx) const = 0;
 
 	virtual real_t get_step() const = 0;
 	virtual void integrate_forces();


### PR DESCRIPTION
Renames `pos` to `positon`, `rot` to `rotation`, `loc` to `location` and `scl` to `scale`.

See #11119.