### PR TITLE
unregister_gdnative_types() now checks if discoverer pointer is NULL before deleting

### DIFF
--- a/modules/gdnative/register_types.cpp
+++ b/modules/gdnative/register_types.cpp
@@ -248,7 +248,7 @@ void unregister_gdnative_types() {
 	memdelete(GDNativeCallRegistry::singleton);
 
 #ifdef TOOLS_ENABLED
-	if (Engine::get_singleton()->is_editor_hint()) {
+	if (Engine::get_singleton()->is_editor_hint() && discoverer != NULL) {
 		memdelete(discoverer);
 	}
 #endif


### PR DESCRIPTION
unregister_gdnative_types() now checks discoverer pointer to see if it is NULL
before deleting. 
Reason: When selecting a godot project to edit (Win10) in the dialog, the
discoverer_callback() wasn't called before unregister_gdnative_types() thus discoverer was NULL.