### PR TITLE
Implement +,-,/, * and negate operators for Color type

### DIFF
--- a/core/color.cpp
+++ b/core/color.cpp
@@ -400,3 +400,122 @@ Color::operator String() const {
 
 	return rtos(r) + ", " + rtos(g) + ", " + rtos(b) + ", " + rtos(a);
 }
+
+Color Color::operator+(const Color &p_color) const {
+
+	return Color(
+			CLAMP(r + p_color.r, 0.0, 1.0),
+			CLAMP(g + p_color.g, 0.0, 1.0),
+			CLAMP(b + p_color.b, 0.0, 1.0),
+			CLAMP(a + p_color.a, 0.0, 1.0));
+}
+
+void Color::operator+=(const Color &p_color) {
+
+	r = CLAMP(r + p_color.r, 0.0, 1.0);
+	g = CLAMP(g + p_color.g, 0.0, 1.0);
+	b = CLAMP(b + p_color.b, 0.0, 1.0);
+	a = CLAMP(a + p_color.a, 0.0, 1.0);
+}
+
+Color Color::operator-(const Color &p_color) const {
+
+	return Color(
+			CLAMP(r - p_color.r, 0.0, 1.0),
+			CLAMP(g - p_color.g, 0.0, 1.0),
+			CLAMP(b - p_color.b, 0.0, 1.0),
+			CLAMP(a - p_color.a, 0.0, 1.0));
+}
+
+void Color::operator-=(const Color &p_color) {
+
+	r = CLAMP(r - p_color.r, 0.0, 1.0);
+	g = CLAMP(g - p_color.g, 0.0, 1.0);
+	b = CLAMP(b - p_color.b, 0.0, 1.0);
+	a = CLAMP(a - p_color.a, 0.0, 1.0);
+}
+
+Color Color::operator*(const Color &p_color) const {
+
+	return Color(
+			CLAMP(r * p_color.r, 0.0, 1.0),
+			CLAMP(g * p_color.g, 0.0, 1.0),
+			CLAMP(b * p_color.b, 0.0, 1.0),
+			CLAMP(a * p_color.a, 0.0, 1.0));
+}
+
+Color Color::operator*(const real_t &rvalue) const {
+
+	return Color(
+			CLAMP(r * rvalue, 0.0, 1.0),
+			CLAMP(g * rvalue, 0.0, 1.0),
+			CLAMP(b * rvalue, 0.0, 1.0),
+			CLAMP(a * rvalue, 0.0, 1.0));
+}
+
+void Color::operator*=(const Color &p_color) {
+
+	r = CLAMP(r * p_color.r, 0.0, 1.0);
+	g = CLAMP(g * p_color.g, 0.0, 1.0);
+	b = CLAMP(b * p_color.b, 0.0, 1.0);
+	a = CLAMP(a * p_color.a, 0.0, 1.0);
+}
+
+void Color::operator*=(const real_t &rvalue) {
+
+	r = CLAMP(r * rvalue, 0.0, 1.0);
+	g = CLAMP(g * rvalue, 0.0, 1.0);
+	b = CLAMP(b * rvalue, 0.0, 1.0);
+	a = CLAMP(a * rvalue, 0.0, 1.0);
+};
+
+Color Color::operator/(const Color &p_color) const {
+
+	return Color(
+			p_color.r == 0 ? 1 : CLAMP(r / p_color.r, 0.0, 1.0),
+			p_color.g == 0 ? 1 : CLAMP(g / p_color.g, 0.0, 1.0),
+			p_color.b == 0 ? 1 : CLAMP(b / p_color.b, 0.0, 1.0),
+			p_color.a == 0 ? 1 : CLAMP(a / p_color.a, 0.0, 1.0));
+}
+
+Color Color::operator/(const real_t &rvalue) const {
+
+	if (rvalue == 0) return Color(1.0, 1.0, 1.0, 1.0);
+	return Color(
+			CLAMP(r / rvalue, 0.0, 1.0),
+			CLAMP(g / rvalue, 0.0, 1.0),
+			CLAMP(b / rvalue, 0.0, 1.0),
+			CLAMP(a / rvalue, 0.0, 1.0));
+}
+
+void Color::operator/=(const Color &p_color) {
+
+	r = p_color.r == 0 ? 1 : CLAMP(r / p_color.r, 0.0, 1.0);
+	g = p_color.g == 0 ? 1 : CLAMP(g / p_color.g, 0.0, 1.0);
+	b = p_color.b == 0 ? 1 : CLAMP(b / p_color.b, 0.0, 1.0);
+	a = p_color.a == 0 ? 1 : CLAMP(a / p_color.a, 0.0, 1.0);
+}
+
+void Color::operator/=(const real_t &rvalue) {
+
+	if (rvalue == 0) {
+		r = 1.0;
+		g = 1.0;
+		b = 1.0;
+		a = 1.0;
+	} else {
+		r = CLAMP(r / rvalue, 0.0, 1.0);
+		g = CLAMP(g / rvalue, 0.0, 1.0);
+		b = CLAMP(b / rvalue, 0.0, 1.0);
+		a = CLAMP(a / rvalue, 0.0, 1.0);
+	}
+};
+
+Color Color::operator-() const {
+
+	return Color(
+			CLAMP(1.0 - r, 0.0, 1.0),
+			CLAMP(1.0 - g, 0.0, 1.0),
+			CLAMP(1.0 - b, 0.0, 1.0),
+			CLAMP(1.0 - a, 0.0, 1.0));
+}

--- a/core/color.h
+++ b/core/color.h
@@ -67,6 +67,23 @@ struct Color {
 		return components[idx];
 	}
 
+	Color operator+(const Color &p_color) const;
+	void operator+=(const Color &p_color);
+
+	Color operator-() const;
+	Color operator-(const Color &p_color) const;
+	void operator-=(const Color &p_color);
+
+	Color operator*(const Color &p_color) const;
+	Color operator*(const real_t &rvalue) const;
+	void operator*=(const Color &p_color);
+	void operator*=(const real_t &rvalue);
+
+	Color operator/(const Color &p_color) const;
+	Color operator/(const real_t &rvalue) const;
+	void operator/=(const Color &p_color);
+	void operator/=(const real_t &rvalue);
+
 	void invert();
 	void contrast();
 	Color inverted() const;

--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -493,7 +493,7 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a, const Variant &
 				DEFAULT_OP_FAIL(BASIS);
 				DEFAULT_OP_FAIL(TRANSFORM);
 
-				DEFAULT_OP_FAIL(COLOR);
+				DEFAULT_OP_LOCALMEM(+, COLOR, Color);
 
 				DEFAULT_OP_FAIL(NODE_PATH);
 				DEFAULT_OP_FAIL(_RID);
@@ -549,7 +549,7 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a, const Variant &
 				DEFAULT_OP_FAIL(BASIS);
 				DEFAULT_OP_FAIL(TRANSFORM);
 
-				DEFAULT_OP_FAIL(COLOR);
+				DEFAULT_OP_LOCALMEM(-, COLOR, Color);
 
 				DEFAULT_OP_FAIL(NODE_PATH);
 				DEFAULT_OP_FAIL(_RID);
@@ -645,7 +645,7 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a, const Variant &
 					r_valid = false;
 					return;
 				} break;
-					DEFAULT_OP_FAIL(COLOR);
+					DEFAULT_OP_LOCALMEM_NUM(*, COLOR, Color);
 
 					DEFAULT_OP_FAIL(NODE_PATH);
 					DEFAULT_OP_FAIL(_RID);
@@ -717,7 +717,7 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a, const Variant &
 					DEFAULT_OP_FAIL(BASIS);
 					DEFAULT_OP_FAIL(TRANSFORM);
 
-					DEFAULT_OP_FAIL(COLOR);
+					DEFAULT_OP_LOCALMEM_NUM(/, COLOR, Color);
 
 					DEFAULT_OP_FAIL(NODE_PATH);
 					DEFAULT_OP_FAIL(_RID);
@@ -797,7 +797,7 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a, const Variant &
 				DEFAULT_OP_FAIL(BASIS);
 				DEFAULT_OP_FAIL(TRANSFORM);
 
-				DEFAULT_OP_FAIL(COLOR);
+				DEFAULT_OP_LOCALMEM_NEG(COLOR, Color);
 
 				DEFAULT_OP_FAIL(NODE_PATH);
 				DEFAULT_OP_FAIL(_RID);


### PR DESCRIPTION
Implement +,-,/, * and negate operators for Color type.
~~Note: Currently, none of the operations affect the alpha value of the
color.~~
This pull request addresses issue #11129