### PR TITLE
Fix box selection to in canvas and spatial editor.

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2153,7 +2153,16 @@ void CanvasItemEditor::_viewport_draw() {
 		Point2 bsfrom = transform.xform(drag_from);
 		Point2 bsto = transform.xform(box_selecting_to);
 
-		VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(bsfrom, bsto - bsfrom), Color(0.7, 0.7, 1.0, 0.3));
+		Point2 corrected_region_begin;
+		Point2 corrected_region_end;
+
+		corrected_region_begin.x = bsfrom.x < bsto.x ? bsfrom.x : bsto.x;
+		corrected_region_begin.y = bsfrom.y < bsto.y ? bsfrom.y : bsto.y;
+
+		corrected_region_end.x = bsfrom.x < bsto.x ? bsto.x : bsfrom.x;
+		corrected_region_end.y = bsfrom.y < bsto.y ? bsto.y : bsfrom.y;
+
+		VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(corrected_region_begin, corrected_region_end - corrected_region_begin), Color(0.7, 0.7, 1.0, 0.3));
 	}
 
 	if (drag == DRAG_ROTATE) {
@@ -2268,7 +2277,6 @@ void CanvasItemEditor::_viewport_draw() {
 void CanvasItemEditor::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_FIXED_PROCESS) {
-
 
 		EditorNode::get_singleton()->get_scene_root()->set_snap_controls_to_pixels(GLOBAL_GET("gui/common/snap_controls_to_pixels"));
 

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -1949,7 +1949,16 @@ void SpatialEditorViewport::_draw() {
 
 	if (cursor.region_select) {
 
-		VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(cursor.region_begin, cursor.region_end - cursor.region_begin), Color(0.7, 0.7, 1.0, 0.3));
+		Vector2 corrected_region_begin;
+		Vector2 corrected_region_end;
+
+		corrected_region_begin.x = cursor.region_begin.x < cursor.region_end.x ? cursor.region_begin.x : cursor.region_end.x;
+		corrected_region_begin.y = cursor.region_begin.y < cursor.region_end.y ? cursor.region_begin.y : cursor.region_end.y;
+
+		corrected_region_end.x = cursor.region_begin.x < cursor.region_end.x ? cursor.region_end.x : cursor.region_begin.x;
+		corrected_region_end.y = cursor.region_begin.y < cursor.region_end.y ? cursor.region_end.y : cursor.region_begin.y;
+
+		VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(corrected_region_begin, corrected_region_end - corrected_region_begin), Color(0.7, 0.7, 1.0, 0.3));
 	}
 
 	if (message_time > 0) {


### PR DESCRIPTION
Fixes bug with the box selection where rendered box's shape gets inverted if you move the cursor left or above its origin point.