### PR TITLE
added highlight area to slider

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -683,14 +683,16 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("decrement_highlight", "VScrollBar", empty_icon);
 
 	// HSlider
-	theme->set_stylebox("slider", "HSlider", make_stylebox(theme->get_icon("GuiHsliderBg", "EditorIcons"), default_margin_size, default_margin_size, default_margin_size, default_margin_size));
-	theme->set_icon("grabber", "HSlider", theme->get_icon("GuiSliderGrabber", "EditorIcons"));
 	theme->set_icon("grabber_highlight", "HSlider", theme->get_icon("GuiSliderGrabberHl", "EditorIcons"));
+	theme->set_icon("grabber", "HSlider", theme->get_icon("GuiSliderGrabber", "EditorIcons"));
+	theme->set_stylebox("slider", "HSlider", make_flat_stylebox(dark_color_3, 0, default_margin_size / 2, 0, default_margin_size / 2));
+	theme->set_stylebox("grabber_area", "HSlider", make_flat_stylebox(contrast_color_1, 0, default_margin_size / 2, 0, default_margin_size / 2));
 
 	// VSlider
-	theme->set_stylebox("slider", "VSlider", make_stylebox(theme->get_icon("GuiVsliderBg", "EditorIcons"), default_margin_size, default_margin_size, default_margin_size, default_margin_size));
 	theme->set_icon("grabber", "VSlider", theme->get_icon("GuiSliderGrabber", "EditorIcons"));
 	theme->set_icon("grabber_highlight", "VSlider", theme->get_icon("GuiSliderGrabberHl", "EditorIcons"));
+	theme->set_stylebox("slider", "VSlider", make_flat_stylebox(dark_color_3, default_margin_size / 2, 0, default_margin_size / 2, 0));
+	theme->set_stylebox("grabber_area", "VSlider", make_flat_stylebox(contrast_color_1, default_margin_size / 2, 0, default_margin_size / 2, 0));
 
 	//RichTextLabel
 	Color rtl_combined_bg_color = dark_color_1.linear_interpolate(script_bg_color, script_bg_color.a);

--- a/editor/icons/icon_GUI_hslider_bg.svg
+++ b/editor/icons/icon_GUI_hslider_bg.svg
@@ -1,5 +1,0 @@
-<svg width="16" height="16" version="1.1" viewBox="0 0 16 15.999999" xmlns="http://www.w3.org/2000/svg">
-<g transform="translate(0 -1036.4)">
-<rect x="1" y="1041.4" width="14" height="6" ry="0" fill-opacity=".39216" stroke-linecap="round" stroke-linejoin="round" stroke-opacity=".32549" stroke-width="2"/>
-</g>
-</svg>

--- a/editor/icons/icon_GUI_vslider_bg.svg
+++ b/editor/icons/icon_GUI_vslider_bg.svg
@@ -1,5 +1,0 @@
-<svg width="16" height="16" version="1.1" viewBox="0 0 16 15.999999" xmlns="http://www.w3.org/2000/svg">
-<g transform="translate(0 -1036.4)">
-<rect x="6" y="1037.4" width="4" height="14" ry="0" fill-opacity=".39216" stroke-linecap="round" stroke-linejoin="round" stroke-opacity=".32549" stroke-width="2"/>
-</g>
-</svg>

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -162,18 +162,20 @@ void Slider::_notification(int p_what) {
 			Size2i size = get_size();
 			Ref<StyleBox> style = get_stylebox("slider");
 			Ref<StyleBox> focus = get_stylebox("focus");
+			Ref<StyleBox> grabber_area = get_stylebox("grabber_area");
 			Ref<Texture> grabber = get_icon(editable ? ((mouse_inside || has_focus()) ? "grabber_highlight" : "grabber") : "grabber_disabled");
 			Ref<Texture> tick = get_icon("tick");
 
 			if (orientation == VERTICAL) {
 
 				int widget_width = style->get_minimum_size().width + style->get_center_size().width;
+				float areasize = size.height - grabber->get_size().height;
 				style->draw(ci, Rect2i(Point2i(size.width / 2 - widget_width / 2, 0), Size2i(widget_width, size.height)));
+				grabber_area->draw(ci, Rect2i(Point2i((size.width - widget_width) / 2, size.height - areasize * get_as_ratio() - grabber->get_size().height / 2), Size2i(widget_width, areasize * get_as_ratio() + grabber->get_size().width / 2)));
 				/*
 				if (mouse_inside||has_focus())
 					focus->draw(ci,Rect2i(Point2i(),Size2i(style->get_minimum_size().width+style->get_center_size().width,size.height)));
 				*/
-				float areasize = size.height - grabber->get_size().height;
 				if (ticks > 1) {
 					int tickarea = size.height - tick->get_height();
 					for (int i = 0; i < ticks; i++) {
@@ -186,13 +188,15 @@ void Slider::_notification(int p_what) {
 			} else {
 
 				int widget_height = style->get_minimum_size().height + style->get_center_size().height;
-				style->draw(ci, Rect2i(Point2i(0, size.height / 2 - widget_height / 2), Size2i(size.width, widget_height)));
+				float areasize = size.width - grabber->get_size().width;
+
+				style->draw(ci, Rect2i(Point2i(0, (size.height - widget_height) / 2), Size2i(size.width, widget_height)));
+				grabber_area->draw(ci, Rect2i(Point2i(0, (size.height - widget_height) / 2), Size2i(areasize * get_as_ratio() + grabber->get_size().width / 2, widget_height)));
 				/*
 				if (mouse_inside||has_focus())
 					focus->draw(ci,Rect2i(Point2i(),Size2i(size.width,style->get_minimum_size().height+style->get_center_size().height)));
 				*/
 
-				float areasize = size.width - grabber->get_size().width;
 				if (ticks > 1) {
 					int tickarea = size.width - tick->get_width();
 					for (int i = 0; i < ticks; i++) {


### PR DESCRIPTION
removed the svg/image style box for sliders...
and implemented a feature so that the active part gets highlighted...

highlight color is still up to debate although that also could be changed In another pr...

### current color looks like this:
<img width="290" alt="screen shot 2017-09-12 at 17 03 46" src="https://user-images.githubusercontent.com/16718859/30333740-fe529dee-97dd-11e7-920e-888958e7db1b.png">
<img width="873" alt="screen shot 2017-09-12 at 17 03 41" src="https://user-images.githubusercontent.com/16718859/30333742-fe740e66-97dd-11e7-906b-15856e1b57a5.png">
