### PR TITLE
Add option to always show directories in filesystem dock

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -729,6 +729,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["docks/filesystem/display_mode"] = PropertyInfo(Variant::INT, "docks/filesystem/display_mode", PROPERTY_HINT_ENUM, "Thumbnails,List");
 	set("docks/filesystem/thumbnail_size", 64);
 	hints["docks/filesystem/thumbnail_size"] = PropertyInfo(Variant::INT, "docks/filesystem/thumbnail_size", PROPERTY_HINT_RANGE, "32,128,16");
+	set("docks/filesystem/display_mode", 0);
+	hints["docks/filesystem/display_mode"] = PropertyInfo(Variant::INT, "docks/filesystem/display_mode", PROPERTY_HINT_ENUM, "Thumbnails,List");
+	set("docks/filesystem/always_show_folders", true);
 
 	set("editors/animation/autorename_animation_tracks", true);
 	set("editors/animation/confirm_insert_track", true);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -426,8 +426,10 @@ void FileSystemDock::_update_files(bool p_keep_selection) {
 	Ref<Texture> file_thumbnail;
 	Ref<Texture> file_thumbnail_broken;
 
+	bool always_show_folders = EditorSettings::get_singleton()->get("docks/filesystem/always_show_folders");
+
 	bool use_thumbnails = (display_mode == DISPLAY_THUMBNAILS);
-	bool use_folders = search_box->get_text().length() == 0 && split_mode;
+	bool use_folders = search_box->get_text().length() == 0 && (split_mode || always_show_folders);
 
 	if (use_thumbnails) { //thumbnails
 


### PR DESCRIPTION
Adds a new simple editor setting to always show directories in the filesystem dock alongside files even when not in split_mode. May be more convenient and easier to navigate for some users.