### PR TITLE
Adds 3 and 4 digit html shortcuts to Color

### DIFF
--- a/core/color.cpp
+++ b/core/color.cpp
@@ -250,6 +250,14 @@ Color Color::html(const String &p_color) {
 		return Color();
 	if (color[0] == '#')
 		color = color.substr(1, color.length() - 1);
+	if (color.length() == 3 || color.length() == 4) {
+		String exp_color;
+		for (int i = 0; i < color.length(); i++) {
+			exp_color += color[i];
+			exp_color += color[i];
+		}
+		color = exp_color;
+	}
 
 	bool alpha = false;
 


### PR DESCRIPTION
Color::html now expands 3 and 4 digit hex values into 6 and 8 digit
values by repeating each digit. This is to bring it in line with how
html handles these values

fixes #10997