### PR TITLE
update shadow for theme

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -351,9 +351,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_popup->set_default_margin(MARGIN_BOTTOM, default_margin_size * 2);
 	style_popup->set_border_color_all(contrast_color_1);
 	style_popup->set_border_width_all(MAX(EDSCALE, border_width));
-	const Color shadow_color = Color(0, 0, 0, dark_theme ? 0.3 : 0.1);
-	style_popup->set_shadow_color(shadow_color);
-	style_popup->set_shadow_size(4 * EDSCALE);
+
+	const Color shadow_color = Color(0, 0, 0, dark_theme ? 0.2 : 0.05);
 
 	Ref<StyleBoxEmpty> style_empty = make_empty_stylebox(default_margin_size, default_margin_size, default_margin_size, default_margin_size);
 
@@ -640,6 +639,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_window->set_border_color_all(tab_color);
 	style_window->set_border_width(MARGIN_TOP, 24 * EDSCALE);
 	style_window->set_expand_margin_size(MARGIN_TOP, 24 * EDSCALE);
+	style_window->set_shadow_color(shadow_color);
+	style_window->set_shadow_size(20 * EDSCALE);
 	theme->set_stylebox("panel", "WindowDialog", style_window);
 	theme->set_color("title_color", "WindowDialog", font_color);
 	theme->set_icon("close", "WindowDialog", theme->get_icon("GuiClose", "EditorIcons"));


### PR DESCRIPTION
 - removed shadow from popup menu
 - made shadow lighter but bigger

<img width="538" alt="screen shot 2017-09-13 at 00 48 07" src="https://user-images.githubusercontent.com/16718859/30351817-85c741dc-981d-11e7-845e-c88fe4804251.png">
<img width="611" alt="screen shot 2017-09-13 at 00 47 22" src="https://user-images.githubusercontent.com/16718859/30351819-85ea9e5c-981d-11e7-9add-582599c3c4d4.png">

this shows how it looked. this pr changes it to look like before.
<img width="530" alt="screen shot 2017-09-13 at 00 33 55" src="https://user-images.githubusercontent.com/16718859/30351820-85ef19aa-981d-11e7-9d71-59397878fd8f.png">