### PR TITLE
made tabs visible in debugger fixes: #11212

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4033,6 +4033,15 @@ void EditorNode::_bottom_panel_switch(bool p_enable, int p_idx) {
 			bottom_panel_items[i].button->set_pressed(i == p_idx);
 			bottom_panel_items[i].control->set_visible(i == p_idx);
 		}
+		// ScriptEditor::get_singleton()->get_debugger() == bottom_panel_items[i].control
+		if (ScriptEditor::get_singleton()->get_debugger() == bottom_panel_items[p_idx].control) { // this is the debug panel wich uses tabs, so the top section should be smaller
+			Ref<StyleBoxFlat> style_panel_invisible_top = gui_base->get_stylebox("panel", "TabContainer")->duplicate();
+			int stylebox_offset = gui_base->get_font("font", "Tabs")->get_height() + gui_base->get_stylebox("tab_fg", "Tabs")->get_minimum_size().height + gui_base->get_stylebox("panel", "TabContainer")->get_default_margin(MARGIN_TOP);
+			style_panel_invisible_top->set_expand_margin_size(MARGIN_TOP, -stylebox_offset);
+			bottom_panel->add_style_override("panel", style_panel_invisible_top);
+		} else {
+			bottom_panel->add_style_override("panel", gui_base->get_stylebox("panel", "TabContainer"));
+		}
 		center_split->set_dragger_visibility(SplitContainer::DRAGGER_VISIBLE);
 		center_split->set_collapsed(false);
 	} else {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4033,7 +4033,6 @@ void EditorNode::_bottom_panel_switch(bool p_enable, int p_idx) {
 			bottom_panel_items[i].button->set_pressed(i == p_idx);
 			bottom_panel_items[i].control->set_visible(i == p_idx);
 		}
-		// ScriptEditor::get_singleton()->get_debugger() == bottom_panel_items[i].control
 		if (ScriptEditor::get_singleton()->get_debugger() == bottom_panel_items[p_idx].control) { // this is the debug panel wich uses tabs, so the top section should be smaller
 			Ref<StyleBoxFlat> style_panel_invisible_top = gui_base->get_stylebox("panel", "TabContainer")->duplicate();
 			int stylebox_offset = gui_base->get_font("font", "Tabs")->get_height() + gui_base->get_stylebox("tab_fg", "Tabs")->get_minimum_size().height + gui_base->get_stylebox("panel", "TabContainer")->get_default_margin(MARGIN_TOP);

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1622,8 +1622,9 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 	tabs->add_style_override("panel", editor->get_gui_base()->get_stylebox("DebuggerPanel", "EditorStyles"));
 	tabs->add_style_override("tab_fg", editor->get_gui_base()->get_stylebox("DebuggerTabFG", "EditorStyles"));
 	tabs->add_style_override("tab_bg", editor->get_gui_base()->get_stylebox("DebuggerTabBG", "EditorStyles"));
-	tabs->set_v_size_flags(SIZE_EXPAND_FILL);
 	tabs->set_area_as_parent_rect();
+	tabs->set_margin(MARGIN_LEFT, -EditorNode::get_singleton()->get_gui_base()->get_stylebox("panel", "TabContainer")->get_margin(MARGIN_LEFT));
+	tabs->set_margin(MARGIN_RIGHT, EditorNode::get_singleton()->get_gui_base()->get_stylebox("panel", "TabContainer")->get_margin(MARGIN_LEFT));
 	add_child(tabs);
 
 	{ //debugger


### PR DESCRIPTION
 - the stylebox is changed so the top part is transparent when the
   debugger is selected

the implementation is pretty damn hacky... so I don't know if it is even worth.
pseudocode how it's done
```
func switch tab:
...
    if tab is Debugger:
        sb = load and copy normal style box
        sb -> make the top expand margin negative so it fits the theme, font height...
        override bg panel style box with sb
    else:
        load stylbox from theme
...
```