### PR TITLE
Spatial scrolling update + better default inertia values

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -677,6 +677,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	set("editors/3d/orbit_sensitivity", 0.4);
 
+	set("editors/3d/zoom_inertia", 0.1);
+	hints["editors/3d/zoom_inertia"] = PropertyInfo(Variant::REAL, "editors/3d/zoom_inertia", PROPERTY_HINT_RANGE, "0.0, 1, 0.01");
+
 	set("editors/3d/orbit_inertia", 0.2);
 	hints["editors/3d/orbit_inertia"] = PropertyInfo(Variant::REAL, "editors/3d/orbit_inertia", PROPERTY_HINT_RANGE, "0.0, 1, 0.01");
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -662,46 +662,46 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("editors/3d/default_z_far", 500.0);
 
 	// navigation
-	set("editors/3d/navigation_scheme", 0);
-	hints["editors/3d/navigation_scheme"] = PropertyInfo(Variant::INT, "editors/3d/navigation_scheme", PROPERTY_HINT_ENUM, "Godot,Maya,Modo");
-	set("editors/3d/zoom_style", 0);
-	hints["editors/3d/zoom_style"] = PropertyInfo(Variant::INT, "editors/3d/zoom_style", PROPERTY_HINT_ENUM, "Vertical, Horizontal");
+	set("editors/3d/navigation/navigation_scheme", 0);
+	hints["editors/3d/navigation/navigation_scheme"] = PropertyInfo(Variant::INT, "editors/3d/navigation/navigation_scheme", PROPERTY_HINT_ENUM, "Godot,Maya,Modo");
+	set("editors/3d/navigation/zoom_style", 0);
+	hints["editors/3d/navigation/zoom_style"] = PropertyInfo(Variant::INT, "editors/3d/navigation/zoom_style", PROPERTY_HINT_ENUM, "Vertical, Horizontal");
 
-	set("editors/3d/emulate_3_button_mouse", false);
-	set("editors/3d/orbit_modifier", 0);
-	hints["editors/3d/orbit_modifier"] = PropertyInfo(Variant::INT, "editors/3d/orbit_modifier", PROPERTY_HINT_ENUM, "None,Shift,Alt,Meta,Ctrl");
-	set("editors/3d/pan_modifier", 1);
-	hints["editors/3d/pan_modifier"] = PropertyInfo(Variant::INT, "editors/3d/pan_modifier", PROPERTY_HINT_ENUM, "None,Shift,Alt,Meta,Ctrl");
-	set("editors/3d/zoom_modifier", 4);
-	hints["editors/3d/zoom_modifier"] = PropertyInfo(Variant::INT, "editors/3d/zoom_modifier", PROPERTY_HINT_ENUM, "None,Shift,Alt,Meta,Ctrl");
+	set("editors/3d/navigation/emulate_3_button_mouse", false);
+	set("editors/3d/navigation/orbit_modifier", 3);
+	hints["editors/3d/navigation/orbit_modifier"] = PropertyInfo(Variant::INT, "editors/3d/navigation/orbit_modifier", PROPERTY_HINT_ENUM, "None,Shift,Alt,Meta,Ctrl");
+	set("editors/3d/navigation/pan_modifier", 1);
+	hints["editors/3d/navigation/pan_modifier"] = PropertyInfo(Variant::INT, "editors/3d/navigation/pan_modifier", PROPERTY_HINT_ENUM, "None,Shift,Alt,Meta,Ctrl");
+	set("editors/3d/navigation/zoom_modifier", 4);
+	hints["editors/3d/navigation/zoom_modifier"] = PropertyInfo(Variant::INT, "editors/3d/navigation/zoom_modifier", PROPERTY_HINT_ENUM, "None,Shift,Alt,Meta,Ctrl");
 
-	set("editors/3d/emulate_numpad", false);
-	set("editors/3d/warped_mouse_panning", true);
+	// set("editors/3d/navigation/emulate_numpad", false); not used at the moment
+	set("editors/3d/navigation/warped_mouse_panning", true);
 
 	// navigation feel
-	set("editors/3d/orbit_sensitivity", 0.4);
-	hints["editors/3d/orbit_sensitivity"] = PropertyInfo(Variant::REAL, "editors/3d/orbit_sensitivity", PROPERTY_HINT_RANGE, "0.0, 2, 0.01");
+	set("editors/3d/navigation_feel/orbit_sensitivity", 0.4);
+	hints["editors/3d/navigation_feel/orbit_sensitivity"] = PropertyInfo(Variant::REAL, "editors/3d/navigation_feel/orbit_sensitivity", PROPERTY_HINT_RANGE, "0.0, 2, 0.01");
 
-	set("editors/3d/orbit_inertia", 0.15);
-	hints["editors/3d/orbit_inertia"] = PropertyInfo(Variant::REAL, "editors/3d/orbit_inertia", PROPERTY_HINT_RANGE, "0.0, 1, 0.01");
-	set("editors/3d/translation_inertia", 0.15);
-	hints["editors/3d/translation_inertia"] = PropertyInfo(Variant::REAL, "editors/3d/translation_inertia", PROPERTY_HINT_RANGE, "0.0, 1, 0.01");
-	set("editors/3d/zoom_inertia", 0.1);
-	hints["editors/3d/zoom_inertia"] = PropertyInfo(Variant::REAL, "editors/3d/zoom_inertia", PROPERTY_HINT_RANGE, "0.0, 1, 0.01");
-	set("editors/3d/manipulation_orbit_inertia", 0.1);
-	hints["editors/3d/manipulation_orbit_inertia"] = PropertyInfo(Variant::REAL, "editors/3d/manipulation_orbit_inertia", PROPERTY_HINT_RANGE, "0.0, 1, 0.01");
-	set("editors/3d/manipulation_translation_inertia", 0.1);
-	hints["editors/3d/manipulation_translation_inertia"] = PropertyInfo(Variant::REAL, "editors/3d/manipulation_translation_inertia", PROPERTY_HINT_RANGE, "0.0, 1, 0.01");
+	set("editors/3d/navigation_feel/orbit_inertia", 0.15);
+	hints["editors/3d/navigation_feel/orbit_inertia"] = PropertyInfo(Variant::REAL, "editors/3d/navigation_feel/orbit_inertia", PROPERTY_HINT_RANGE, "0.0, 1, 0.01");
+	set("editors/3d/navigation_feel/translation_inertia", 0.15);
+	hints["editors/3d/navigation_feel/translation_inertia"] = PropertyInfo(Variant::REAL, "editors/3d/navigation_feel/translation_inertia", PROPERTY_HINT_RANGE, "0.0, 1, 0.01");
+	set("editors/3d/navigation_feel/zoom_inertia", 0.1);
+	hints["editors/3d/navigation_feel/zoom_inertia"] = PropertyInfo(Variant::REAL, "editors/3d/navigation_feel/zoom_inertia", PROPERTY_HINT_RANGE, "0.0, 1, 0.01");
+	set("editors/3d/navigation_feel/manipulation_orbit_inertia", 0.1);
+	hints["editors/3d/navigation_feel/manipulation_orbit_inertia"] = PropertyInfo(Variant::REAL, "editors/3d/navigation_feel/manipulation_orbit_inertia", PROPERTY_HINT_RANGE, "0.0, 1, 0.01");
+	set("editors/3d/navigation_feel/manipulation_translation_inertia", 0.1);
+	hints["editors/3d/navigation_feel/manipulation_translation_inertia"] = PropertyInfo(Variant::REAL, "editors/3d/navigation_feel/manipulation_translation_inertia", PROPERTY_HINT_RANGE, "0.0, 1, 0.01");
 
 	// freelook
-	set("editors/3d/freelook_inertia", 0.1);
-	hints["editors/3d/freelook_inertia"] = PropertyInfo(Variant::REAL, "editors/3d/freelook_inertia", PROPERTY_HINT_RANGE, "0.0, 1, 0.01");
-	set("editors/3d/freelook_base_speed", 0.5);
-	hints["editors/3d/freelook_base_speed"] = PropertyInfo(Variant::REAL, "editors/3d/freelook_base_speed", PROPERTY_HINT_RANGE, "0.0, 10, 0.1");
-	set("editors/3d/freelook_activation_modifier", 0);
-	hints["editors/3d/freelook_activation_modifier"] = PropertyInfo(Variant::INT, "editors/3d/freelook_activation_modifier", PROPERTY_HINT_ENUM, "None,Shift,Alt,Meta,Ctrl");
-	set("editors/3d/freelook_modifier_speed_factor", 3.0);
-	hints["editors/3d/freelook_modifier_speed_factor"] = PropertyInfo(Variant::REAL, "editors/3d/freelook_modifier_speed_factor", PROPERTY_HINT_RANGE, "0.0, 10.0, 0.1");
+	set("editors/3d/freelook/freelook_inertia", 0.1);
+	hints["editors/3d/freelook/freelook_inertia"] = PropertyInfo(Variant::REAL, "editors/3d/freelook/freelook_inertia", PROPERTY_HINT_RANGE, "0.0, 1, 0.01");
+	set("editors/3d/freelook/freelook_base_speed", 0.5);
+	hints["editors/3d/freelook/freelook_base_speed"] = PropertyInfo(Variant::REAL, "editors/3d/freelook/freelook_base_speed", PROPERTY_HINT_RANGE, "0.0, 10, 0.1");
+	set("editors/3d/freelook/freelook_activation_modifier", 0);
+	hints["editors/3d/freelook/freelook_activation_modifier"] = PropertyInfo(Variant::INT, "editors/3d/freelook/freelook_activation_modifier", PROPERTY_HINT_ENUM, "None,Shift,Alt,Meta,Ctrl");
+	set("editors/3d/freelook/freelook_modifier_speed_factor", 3.0);
+	hints["editors/3d/freelook/freelook_modifier_speed_factor"] = PropertyInfo(Variant::REAL, "editors/3d/freelook/freelook_modifier_speed_factor", PROPERTY_HINT_RANGE, "0.0, 10.0, 0.1");
 
 	set("editors/2d/bone_width", 5);
 	set("editors/2d/bone_color1", Color(1.0, 1.0, 1.0, 0.9));

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -661,38 +661,47 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set("editors/3d/default_z_near", 0.1);
 	set("editors/3d/default_z_far", 500.0);
 
+	// navigation
 	set("editors/3d/navigation_scheme", 0);
 	hints["editors/3d/navigation_scheme"] = PropertyInfo(Variant::INT, "editors/3d/navigation_scheme", PROPERTY_HINT_ENUM, "Godot,Maya,Modo");
 	set("editors/3d/zoom_style", 0);
 	hints["editors/3d/zoom_style"] = PropertyInfo(Variant::INT, "editors/3d/zoom_style", PROPERTY_HINT_ENUM, "Vertical, Horizontal");
+
+	set("editors/3d/emulate_3_button_mouse", false);
 	set("editors/3d/orbit_modifier", 0);
 	hints["editors/3d/orbit_modifier"] = PropertyInfo(Variant::INT, "editors/3d/orbit_modifier", PROPERTY_HINT_ENUM, "None,Shift,Alt,Meta,Ctrl");
 	set("editors/3d/pan_modifier", 1);
 	hints["editors/3d/pan_modifier"] = PropertyInfo(Variant::INT, "editors/3d/pan_modifier", PROPERTY_HINT_ENUM, "None,Shift,Alt,Meta,Ctrl");
 	set("editors/3d/zoom_modifier", 4);
 	hints["editors/3d/zoom_modifier"] = PropertyInfo(Variant::INT, "editors/3d/zoom_modifier", PROPERTY_HINT_ENUM, "None,Shift,Alt,Meta,Ctrl");
+
 	set("editors/3d/emulate_numpad", false);
-	set("editors/3d/emulate_3_button_mouse", false);
 	set("editors/3d/warped_mouse_panning", true);
 
+	// navigation feel
 	set("editors/3d/orbit_sensitivity", 0.4);
+	hints["editors/3d/orbit_sensitivity"] = PropertyInfo(Variant::REAL, "editors/3d/orbit_sensitivity", PROPERTY_HINT_RANGE, "0.0, 2, 0.01");
 
+	set("editors/3d/orbit_inertia", 0.15);
+	hints["editors/3d/orbit_inertia"] = PropertyInfo(Variant::REAL, "editors/3d/orbit_inertia", PROPERTY_HINT_RANGE, "0.0, 1, 0.01");
+	set("editors/3d/translation_inertia", 0.15);
+	hints["editors/3d/translation_inertia"] = PropertyInfo(Variant::REAL, "editors/3d/translation_inertia", PROPERTY_HINT_RANGE, "0.0, 1, 0.01");
 	set("editors/3d/zoom_inertia", 0.1);
 	hints["editors/3d/zoom_inertia"] = PropertyInfo(Variant::REAL, "editors/3d/zoom_inertia", PROPERTY_HINT_RANGE, "0.0, 1, 0.01");
+	set("editors/3d/manipulation_orbit_inertia", 0.1);
+	hints["editors/3d/manipulation_orbit_inertia"] = PropertyInfo(Variant::REAL, "editors/3d/manipulation_orbit_inertia", PROPERTY_HINT_RANGE, "0.0, 1, 0.01");
+	set("editors/3d/manipulation_translation_inertia", 0.1);
+	hints["editors/3d/manipulation_translation_inertia"] = PropertyInfo(Variant::REAL, "editors/3d/manipulation_translation_inertia", PROPERTY_HINT_RANGE, "0.0, 1, 0.01");
 
-	set("editors/3d/orbit_inertia", 0.2);
-	hints["editors/3d/orbit_inertia"] = PropertyInfo(Variant::REAL, "editors/3d/orbit_inertia", PROPERTY_HINT_RANGE, "0.0, 1, 0.01");
-
-	set("editors/3d/freelook_inertia", 0.2);
+	// freelook
+	set("editors/3d/freelook_inertia", 0.1);
 	hints["editors/3d/freelook_inertia"] = PropertyInfo(Variant::REAL, "editors/3d/freelook_inertia", PROPERTY_HINT_RANGE, "0.0, 1, 0.01");
-
 	set("editors/3d/freelook_base_speed", 0.5);
 	hints["editors/3d/freelook_base_speed"] = PropertyInfo(Variant::REAL, "editors/3d/freelook_base_speed", PROPERTY_HINT_RANGE, "0.0, 10, 0.1");
-
 	set("editors/3d/freelook_activation_modifier", 0);
 	hints["editors/3d/freelook_activation_modifier"] = PropertyInfo(Variant::INT, "editors/3d/freelook_activation_modifier", PROPERTY_HINT_ENUM, "None,Shift,Alt,Meta,Ctrl");
-
-	set("editors/3d/freelook_modifier_speed_factor", 5.0);
+	set("editors/3d/freelook_modifier_speed_factor", 3.0);
+	hints["editors/3d/freelook_modifier_speed_factor"] = PropertyInfo(Variant::REAL, "editors/3d/freelook_modifier_speed_factor", PROPERTY_HINT_RANGE, "0.0, 10.0, 0.1");
 
 	set("editors/2d/bone_width", 5);
 	set("editors/2d/bone_color1", Color(1.0, 1.0, 1.0, 0.9));

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -77,11 +77,11 @@ void SpatialEditorViewport::_update_camera(float p_interp_delta) {
 		camera->set_perspective(get_fov(), get_znear(), get_zfar());
 
 	//when not being manipulated, move softly
-	float free_orbit_inertia = EDITOR_DEF("editors/3d/free_orbit_inertia", 0.15);
-	float free_translation_inertia = EDITOR_DEF("editors/3d/free_translation_inertia", 0.15);
+	float free_orbit_inertia = EDITOR_DEF("editors/3d/orbit_inertia", 0.15);
+	float free_translation_inertia = EDITOR_DEF("editors/3d/translation_inertia", 0.15);
 	//when being manipulated, move more quickly
-	float manip_orbit_inertia = EDITOR_DEF("editors/3d/manipulation_orbit_inertia", 0.075);
-	float manip_translation_inertia = EDITOR_DEF("editors/3d/manipulation_translation_inertia", 0.075);
+	float manip_orbit_inertia = EDITOR_DEF("editors/3d/manipulation_orbit_inertia", 0.1);
+	float manip_translation_inertia = EDITOR_DEF("editors/3d/manipulation_translation_inertia", 0.1);
 
 	float zoom_inertia = EDITOR_DEF("editors/3d/zoom_inertia", 0.0);
 

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -799,15 +799,15 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> b = p_event;
 
 	if (b.is_valid()) {
-
+		float zoom_factor = 1 + (ZOOM_MULTIPLIER - 1) * b->get_factor();
 		switch (b->get_button_index()) {
 
 			case BUTTON_WHEEL_UP: {
-				scale_cursor_distance(is_freelook_active() ? ZOOM_MULTIPLIER : 1.0 / ZOOM_MULTIPLIER);
+				scale_cursor_distance(is_freelook_active() ? zoom_factor : 1.0 / zoom_factor);
 			} break;
 
 			case BUTTON_WHEEL_DOWN: {
-				scale_cursor_distance(is_freelook_active() ? 1.0 / ZOOM_MULTIPLIER : ZOOM_MULTIPLIER);
+				scale_cursor_distance(is_freelook_active() ? 1.0 / zoom_factor : zoom_factor);
 			} break;
 
 			case BUTTON_RIGHT: {

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -77,13 +77,13 @@ void SpatialEditorViewport::_update_camera(float p_interp_delta) {
 		camera->set_perspective(get_fov(), get_znear(), get_zfar());
 
 	//when not being manipulated, move softly
-	float free_orbit_inertia = EDITOR_DEF("editors/3d/orbit_inertia", 0.15);
-	float free_translation_inertia = EDITOR_DEF("editors/3d/translation_inertia", 0.15);
+	float free_orbit_inertia = EDITOR_DEF("editors/3d/navigation_feel/orbit_inertia", 0.15);
+	float free_translation_inertia = EDITOR_DEF("editors/3d/navigation_feel/translation_inertia", 0.15);
 	//when being manipulated, move more quickly
-	float manip_orbit_inertia = EDITOR_DEF("editors/3d/manipulation_orbit_inertia", 0.1);
-	float manip_translation_inertia = EDITOR_DEF("editors/3d/manipulation_translation_inertia", 0.1);
+	float manip_orbit_inertia = EDITOR_DEF("editors/3d/navigation_feel/manipulation_orbit_inertia", 0.1);
+	float manip_translation_inertia = EDITOR_DEF("editors/3d/navigation_feel/manipulation_translation_inertia", 0.1);
 
-	float zoom_inertia = EDITOR_DEF("editors/3d/zoom_inertia", 0.0);
+	float zoom_inertia = EDITOR_DEF("editors/3d/navigation_feel/zoom_inertia", 0.1);
 
 	//determine if being manipulated
 	bool manipulated = (Input::get_singleton()->get_mouse_button_mask() & (2 | 4)) || Input::get_singleton()->is_key_pressed(KEY_SHIFT) || Input::get_singleton()->is_key_pressed(KEY_ALT) || Input::get_singleton()->is_key_pressed(KEY_CONTROL);
@@ -812,7 +812,7 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 			case BUTTON_RIGHT: {
 
-				NavigationScheme nav_scheme = (NavigationScheme)EditorSettings::get_singleton()->get("editors/3d/navigation_scheme").operator int();
+				NavigationScheme nav_scheme = (NavigationScheme)EditorSettings::get_singleton()->get("editors/3d/navigation/navigation_scheme").operator int();
 
 				if (b->is_pressed() && _edit.gizmo.is_valid()) {
 					//restore
@@ -858,7 +858,7 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 				if (b->is_pressed()) {
 					int mod = _get_key_modifier(b);
-					if (mod == _get_key_modifier_setting("editors/3d/freelook_activation_modifier")) {
+					if (mod == _get_key_modifier_setting("editors/3d/freelook/freelook_activation_modifier")) {
 						freelook_active = true;
 					}
 				} else {
@@ -910,7 +910,7 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 				if (b->is_pressed()) {
 
-					NavigationScheme nav_scheme = (NavigationScheme)EditorSettings::get_singleton()->get("editors/3d/navigation_scheme").operator int();
+					NavigationScheme nav_scheme = (NavigationScheme)EditorSettings::get_singleton()->get("editors/3d/navigation/navigation_scheme").operator int();
 					if ((nav_scheme == NAVIGATION_MAYA || nav_scheme == NAVIGATION_MODO) && b->get_alt()) {
 						break;
 					}
@@ -1119,7 +1119,7 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 			_gizmo_select(_edit.mouse_pos, true);
 		}
 
-		NavigationScheme nav_scheme = (NavigationScheme)EditorSettings::get_singleton()->get("editors/3d/navigation_scheme").operator int();
+		NavigationScheme nav_scheme = (NavigationScheme)EditorSettings::get_singleton()->get("editors/3d/navigation/navigation_scheme").operator int();
 		NavigationMode nav_mode = NAVIGATION_NONE;
 
 		if (_edit.gizmo.is_valid()) {
@@ -1442,11 +1442,11 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 				int mod = _get_key_modifier(m);
 
-				if (mod == _get_key_modifier_setting("editors/3d/pan_modifier"))
+				if (mod == _get_key_modifier_setting("editors/3d/navigation/pan_modifier"))
 					nav_mode = NAVIGATION_PAN;
-				else if (mod == _get_key_modifier_setting("editors/3d/zoom_modifier"))
+				else if (mod == _get_key_modifier_setting("editors/3d/navigation/zoom_modifier"))
 					nav_mode = NAVIGATION_ZOOM;
-				else if (mod == _get_key_modifier_setting("editors/3d/orbit_modifier"))
+				else if (mod == _get_key_modifier_setting("editors/3d/navigation/orbit_modifier"))
 					nav_mode = NAVIGATION_ORBIT;
 
 			} else if (nav_scheme == NAVIGATION_MAYA) {
@@ -1454,16 +1454,16 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 					nav_mode = NAVIGATION_PAN;
 			}
 
-		} else if (EditorSettings::get_singleton()->get("editors/3d/emulate_3_button_mouse")) {
+		} else if (EditorSettings::get_singleton()->get("editors/3d/navigation/emulate_3_button_mouse")) {
 			// Handle trackpad (no external mouse) use case
 			int mod = _get_key_modifier(m);
 
 			if (mod) {
-				if (mod == _get_key_modifier_setting("editors/3d/pan_modifier"))
+				if (mod == _get_key_modifier_setting("editors/3d/navigation/pan_modifier"))
 					nav_mode = NAVIGATION_PAN;
-				else if (mod == _get_key_modifier_setting("editors/3d/zoom_modifier"))
+				else if (mod == _get_key_modifier_setting("editors/3d/navigation/zoom_modifier"))
 					nav_mode = NAVIGATION_ZOOM;
-				else if (mod == _get_key_modifier_setting("editors/3d/orbit_modifier"))
+				else if (mod == _get_key_modifier_setting("editors/3d/navigation/orbit_modifier"))
 					nav_mode = NAVIGATION_ORBIT;
 			}
 		}
@@ -1496,7 +1496,7 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 				if (nav_scheme == NAVIGATION_MAYA && m->get_shift())
 					zoom_speed *= zoom_speed_modifier;
 
-				NavigationZoomStyle zoom_style = (NavigationZoomStyle)EditorSettings::get_singleton()->get("editors/3d/zoom_style").operator int();
+				NavigationZoomStyle zoom_style = (NavigationZoomStyle)EditorSettings::get_singleton()->get("editors/3d/navigation/zoom_style").operator int();
 				if (zoom_style == NAVIGATION_ZOOM_HORIZONTAL) {
 					if (m->get_relative().x > 0)
 						scale_cursor_distance(1 - m->get_relative().x * zoom_speed);
@@ -1514,7 +1514,7 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 			case NAVIGATION_ORBIT: {
 				Point2i relative = _get_warped_mouse_motion(m);
 
-				real_t degrees_per_pixel = EditorSettings::get_singleton()->get("editors/3d/orbit_sensitivity");
+				real_t degrees_per_pixel = EditorSettings::get_singleton()->get("editors/3d/navigation_feel/orbit_sensitivity");
 				real_t radians_per_pixel = Math::deg2rad(degrees_per_pixel);
 
 				cursor.x_rot += relative.y * radians_per_pixel;
@@ -1533,7 +1533,7 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 				if (!orthogonal) {
 					Point2i relative = _get_warped_mouse_motion(m);
 
-					real_t degrees_per_pixel = EditorSettings::get_singleton()->get("editors/3d/orbit_sensitivity");
+					real_t degrees_per_pixel = EditorSettings::get_singleton()->get("editors/3d/navigation_feel/orbit_sensitivity");
 					real_t radians_per_pixel = Math::deg2rad(degrees_per_pixel);
 
 					cursor.x_rot += relative.y * radians_per_pixel;
@@ -1670,7 +1670,7 @@ void SpatialEditorViewport::scale_cursor_distance(real_t scale) {
 
 Point2i SpatialEditorViewport::_get_warped_mouse_motion(const Ref<InputEventMouseMotion> &p_ev_mouse_motion) const {
 	Point2i relative;
-	if (bool(EDITOR_DEF("editors/3d/warped_mouse_panning", false))) {
+	if (bool(EDITOR_DEF("editors/3d/navigation/warped_mouse_panning", false))) {
 		relative = Input::get_singleton()->warp_mouse_motion(p_ev_mouse_motion, surface->get_global_rect());
 	} else {
 		relative = p_ev_mouse_motion->get_relative();
@@ -1724,10 +1724,10 @@ void SpatialEditorViewport::_update_freelook(real_t delta) {
 		speed_modifier = true;
 	}
 
-	real_t inertia = EDITOR_DEF("editors/3d/freelook_inertia", 0.2);
+	real_t inertia = EDITOR_DEF("editors/3d/freelook/freelook_inertia", 0.1);
 	inertia = MAX(0, inertia);
-	const real_t base_speed = EDITOR_DEF("editors/3d/freelook_base_speed", 0.5);
-	const real_t modifier_speed_factor = EDITOR_DEF("editors/3d/freelook_modifier_speed_factor", 5);
+	const real_t base_speed = EDITOR_DEF("editors/3d/freelook/freelook_base_speed", 0.5);
+	const real_t modifier_speed_factor = EDITOR_DEF("editors/3d/freelook/freelook_modifier_speed_factor", 3);
 
 	real_t speed = base_speed * cursor.distance;
 	if (speed_modifier)

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -83,6 +83,8 @@ void SpatialEditorViewport::_update_camera(float p_interp_delta) {
 	float manip_orbit_inertia = EDITOR_DEF("editors/3d/manipulation_orbit_inertia", 0.075);
 	float manip_translation_inertia = EDITOR_DEF("editors/3d/manipulation_translation_inertia", 0.075);
 
+	float zoom_inertia = EDITOR_DEF("editors/3d/zoom_inertia", 0.0);
+
 	//determine if being manipulated
 	bool manipulated = (Input::get_singleton()->get_mouse_button_mask() & (2 | 4)) || Input::get_singleton()->is_key_pressed(KEY_SHIFT) || Input::get_singleton()->is_key_pressed(KEY_ALT) || Input::get_singleton()->is_key_pressed(KEY_CONTROL);
 
@@ -96,7 +98,7 @@ void SpatialEditorViewport::_update_camera(float p_interp_delta) {
 	camera_cursor.y_rot = Math::lerp(old_camera_cursor.y_rot, cursor.y_rot, MIN(1.f, p_interp_delta * (1 / orbit_inertia)));
 
 	camera_cursor.pos = old_camera_cursor.pos.linear_interpolate(cursor.pos, MIN(1.f, p_interp_delta * (1 / translation_inertia)));
-	camera_cursor.distance = Math::lerp(old_camera_cursor.distance, cursor.distance, MIN(1.f, p_interp_delta * (1 / translation_inertia)));
+	camera_cursor.distance = Math::lerp(old_camera_cursor.distance, cursor.distance, MIN(1.f, p_interp_delta * (1 / zoom_inertia)));
 
 	if (p_interp_delta == 0 || is_freelook_active()) {
 		camera_cursor = cursor;


### PR DESCRIPTION
`push -f`
Additions the 3d navigation.

## UPDATE

 - adds trackpad support for 3d editor zooming. (precision trackpads... was much to fast and not scrolling speed dependant)
 - adds setting for zoom inertia + hints for orbit sensitivity
 - categorised settings:
<img width="1188" alt="screen shot 2017-09-19 at 02 29 05" src="https://user-images.githubusercontent.com/16718859/30570793-c9eff2f8-9ce3-11e7-9e79-a6f84b2b8172.png">

Discussion
 - settings naming
 - default values (although they are really close to what was used before. The only big change was made to: `manipulation_translation_inertia` since it was really low and you will only use manipulation (shift needs to be pressed for panning) so it was almost invisible when panning.