### PR TITLE
Add underscore prefix for virtual method declaration

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1581,7 +1581,7 @@ void Object::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("is_queued_for_deletion"), &Object::is_queued_for_deletion);
 
-	ClassDB::add_virtual_method("Object", MethodInfo("free"), false);
+	ClassDB::add_virtual_method("Object", MethodInfo("_free"), false);
 
 	ADD_SIGNAL(MethodInfo("script_changed"));
 

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -393,8 +393,8 @@ void EditorPlugin::notify_scene_closed(const String &scene_filepath) {
 
 Ref<SpatialEditorGizmo> EditorPlugin::create_spatial_gizmo(Spatial *p_spatial) {
 	//??
-	if (get_script_instance() && get_script_instance()->has_method("create_spatial_gizmo")) {
-		return get_script_instance()->call("create_spatial_gizmo", p_spatial);
+	if (get_script_instance() && get_script_instance()->has_method("_create_spatial_gizmo")) {
+		return get_script_instance()->call("_create_spatial_gizmo", p_spatial);
 	}
 
 	return Ref<SpatialEditorGizmo>();
@@ -402,16 +402,16 @@ Ref<SpatialEditorGizmo> EditorPlugin::create_spatial_gizmo(Spatial *p_spatial) {
 
 bool EditorPlugin::forward_canvas_gui_input(const Transform2D &p_canvas_xform, const Ref<InputEvent> &p_event) {
 
-	if (get_script_instance() && get_script_instance()->has_method("forward_canvas_gui_input")) {
-		return get_script_instance()->call("forward_canvas_gui_input", p_canvas_xform, p_event);
+	if (get_script_instance() && get_script_instance()->has_method("_forward_canvas_gui_input")) {
+		return get_script_instance()->call("_forward_canvas_gui_input", p_canvas_xform, p_event);
 	}
 	return false;
 }
 
 void EditorPlugin::forward_draw_over_canvas(const Transform2D &p_canvas_xform, Control *p_canvas) {
 
-	if (get_script_instance() && get_script_instance()->has_method("forward_draw_over_canvas")) {
-		get_script_instance()->call("forward_draw_over_canvas", p_canvas_xform, p_canvas);
+	if (get_script_instance() && get_script_instance()->has_method("_forward_draw_over_canvas")) {
+		get_script_instance()->call("_forward_draw_over_canvas", p_canvas_xform, p_canvas);
 	}
 }
 
@@ -421,54 +421,54 @@ void EditorPlugin::update_canvas() {
 
 bool EditorPlugin::forward_spatial_gui_input(Camera *p_camera, const Ref<InputEvent> &p_event) {
 
-	if (get_script_instance() && get_script_instance()->has_method("forward_spatial_gui_input")) {
-		return get_script_instance()->call("forward_spatial_gui_input", p_camera, p_event);
+	if (get_script_instance() && get_script_instance()->has_method("_forward_spatial_gui_input")) {
+		return get_script_instance()->call("_forward_spatial_gui_input", p_camera, p_event);
 	}
 
 	return false;
 }
 String EditorPlugin::get_name() const {
 
-	if (get_script_instance() && get_script_instance()->has_method("get_plugin_name")) {
-		return get_script_instance()->call("get_plugin_name");
+	if (get_script_instance() && get_script_instance()->has_method("_get_plugin_name")) {
+		return get_script_instance()->call("_get_plugin_name");
 	}
 
 	return String();
 }
 bool EditorPlugin::has_main_screen() const {
 
-	if (get_script_instance() && get_script_instance()->has_method("has_main_screen")) {
-		return get_script_instance()->call("has_main_screen");
+	if (get_script_instance() && get_script_instance()->has_method("_has_main_screen")) {
+		return get_script_instance()->call("_has_main_screen");
 	}
 
 	return false;
 }
 void EditorPlugin::make_visible(bool p_visible) {
 
-	if (get_script_instance() && get_script_instance()->has_method("make_visible")) {
-		get_script_instance()->call("make_visible", p_visible);
+	if (get_script_instance() && get_script_instance()->has_method("_make_visible")) {
+		get_script_instance()->call("_make_visible", p_visible);
 	}
 }
 
 void EditorPlugin::edit(Object *p_object) {
 
-	if (get_script_instance() && get_script_instance()->has_method("edit")) {
-		get_script_instance()->call("edit", p_object);
+	if (get_script_instance() && get_script_instance()->has_method("_edit")) {
+		get_script_instance()->call("_edit", p_object);
 	}
 }
 
 bool EditorPlugin::handles(Object *p_object) const {
 
-	if (get_script_instance() && get_script_instance()->has_method("handles")) {
-		return get_script_instance()->call("handles", p_object);
+	if (get_script_instance() && get_script_instance()->has_method("_handles")) {
+		return get_script_instance()->call("_handles", p_object);
 	}
 
 	return false;
 }
 Dictionary EditorPlugin::get_state() const {
 
-	if (get_script_instance() && get_script_instance()->has_method("get_state")) {
-		return get_script_instance()->call("get_state");
+	if (get_script_instance() && get_script_instance()->has_method("_get_state")) {
+		return get_script_instance()->call("_get_state");
 	}
 
 	return Dictionary();
@@ -476,38 +476,38 @@ Dictionary EditorPlugin::get_state() const {
 
 void EditorPlugin::set_state(const Dictionary &p_state) {
 
-	if (get_script_instance() && get_script_instance()->has_method("set_state")) {
-		get_script_instance()->call("set_state", p_state);
+	if (get_script_instance() && get_script_instance()->has_method("_set_state")) {
+		get_script_instance()->call("_set_state", p_state);
 	}
 }
 
 void EditorPlugin::clear() {
 
-	if (get_script_instance() && get_script_instance()->has_method("clear")) {
-		get_script_instance()->call("clear");
+	if (get_script_instance() && get_script_instance()->has_method("_clear")) {
+		get_script_instance()->call("_clear");
 	}
 }
 
 // if editor references external resources/scenes, save them
 void EditorPlugin::save_external_data() {
 
-	if (get_script_instance() && get_script_instance()->has_method("save_external_data")) {
-		get_script_instance()->call("save_external_data");
+	if (get_script_instance() && get_script_instance()->has_method("_save_external_data")) {
+		get_script_instance()->call("_save_external_data");
 	}
 }
 
 // if changes are pending in editor, apply them
 void EditorPlugin::apply_changes() {
 
-	if (get_script_instance() && get_script_instance()->has_method("apply_changes")) {
-		get_script_instance()->call("apply_changes");
+	if (get_script_instance() && get_script_instance()->has_method("_apply_changes")) {
+		get_script_instance()->call("_apply_changes");
 	}
 }
 
 void EditorPlugin::get_breakpoints(List<String> *p_breakpoints) {
 
-	if (get_script_instance() && get_script_instance()->has_method("get_breakpoints")) {
-		PoolStringArray arr = get_script_instance()->call("get_breakpoints");
+	if (get_script_instance() && get_script_instance()->has_method("_get_breakpoints")) {
+		PoolStringArray arr = get_script_instance()->call("_get_breakpoints");
 		for (int i = 0; i < arr.size(); i++)
 			p_breakpoints->push_back(arr[i]);
 	}
@@ -532,15 +532,15 @@ void EditorPlugin::remove_import_plugin(const Ref<EditorImportPlugin> &p_importe
 
 void EditorPlugin::set_window_layout(Ref<ConfigFile> p_layout) {
 
-	if (get_script_instance() && get_script_instance()->has_method("set_window_layout")) {
-		get_script_instance()->call("set_window_layout", p_layout);
+	if (get_script_instance() && get_script_instance()->has_method("_set_window_layout")) {
+		get_script_instance()->call("_set_window_layout", p_layout);
 	}
 }
 
 void EditorPlugin::get_window_layout(Ref<ConfigFile> p_layout) {
 
-	if (get_script_instance() && get_script_instance()->has_method("get_window_layout")) {
-		get_script_instance()->call("get_window_layout", p_layout);
+	if (get_script_instance() && get_script_instance()->has_method("_get_window_layout")) {
+		get_script_instance()->call("_get_window_layout", p_layout);
 	}
 }
 
@@ -589,26 +589,26 @@ void EditorPlugin::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorPlugin::get_editor_interface);
 
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "forward_canvas_gui_input", PropertyInfo(Variant::TRANSFORM2D, "canvas_xform"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo("forward_draw_over_canvas", PropertyInfo(Variant::TRANSFORM2D, "canvas_xform"), PropertyInfo(Variant::OBJECT, "canvas", PROPERTY_HINT_RESOURCE_TYPE, "Control")));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "forward_spatial_gui_input", PropertyInfo(Variant::OBJECT, "camera", PROPERTY_HINT_RESOURCE_TYPE, "Camera"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
-	MethodInfo gizmo = MethodInfo(Variant::OBJECT, "create_spatial_gizmo", PropertyInfo(Variant::OBJECT, "for_spatial", PROPERTY_HINT_RESOURCE_TYPE, "Spatial"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "_forward_canvas_gui_input", PropertyInfo(Variant::TRANSFORM2D, "canvas_xform"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo("_forward_draw_over_canvas", PropertyInfo(Variant::TRANSFORM2D, "canvas_xform"), PropertyInfo(Variant::OBJECT, "canvas", PROPERTY_HINT_RESOURCE_TYPE, "Control")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "_forward_spatial_gui_input", PropertyInfo(Variant::OBJECT, "camera", PROPERTY_HINT_RESOURCE_TYPE, "Camera"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
+	MethodInfo gizmo = MethodInfo(Variant::OBJECT, "_create_spatial_gizmo", PropertyInfo(Variant::OBJECT, "for_spatial", PROPERTY_HINT_RESOURCE_TYPE, "Spatial"));
 	gizmo.return_val.hint = PROPERTY_HINT_RESOURCE_TYPE;
 	gizmo.return_val.hint_string = "EditorSpatialGizmo";
 	ClassDB::add_virtual_method(get_class_static(), gizmo);
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "get_plugin_name"));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "has_main_screen"));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo("make_visible", PropertyInfo(Variant::BOOL, "visible")));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo("edit", PropertyInfo(Variant::OBJECT, "object")));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "handles", PropertyInfo(Variant::OBJECT, "object")));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::DICTIONARY, "get_state"));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo("set_state", PropertyInfo(Variant::DICTIONARY, "state")));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo("clear"));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo("save_external_data"));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo("apply_changes"));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::POOL_STRING_ARRAY, "get_breakpoints"));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo("set_window_layout", PropertyInfo(Variant::OBJECT, "layout", PROPERTY_HINT_RESOURCE_TYPE, "ConfigFile")));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo("get_window_layout", PropertyInfo(Variant::OBJECT, "layout", PROPERTY_HINT_RESOURCE_TYPE, "ConfigFile")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "_get_plugin_name"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "_has_main_screen"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo("_make_visible", PropertyInfo(Variant::BOOL, "visible")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo("_edit", PropertyInfo(Variant::OBJECT, "object")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "_handles", PropertyInfo(Variant::OBJECT, "object")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::DICTIONARY, "_get_state"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo("_set_state", PropertyInfo(Variant::DICTIONARY, "state")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo("_clear"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo("_save_external_data"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo("_apply_changes"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::POOL_STRING_ARRAY, "_get_breakpoints"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo("_set_window_layout", PropertyInfo(Variant::OBJECT, "layout", PROPERTY_HINT_RESOURCE_TYPE, "ConfigFile")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo("_get_window_layout", PropertyInfo(Variant::OBJECT, "layout", PROPERTY_HINT_RESOURCE_TYPE, "ConfigFile")));
 
 	ADD_SIGNAL(MethodInfo("scene_changed", PropertyInfo(Variant::OBJECT, "scene_root", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
 	ADD_SIGNAL(MethodInfo("scene_closed", PropertyInfo(Variant::STRING, "filepath")));

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -39,16 +39,16 @@
 
 bool EditorResourcePreviewGenerator::handles(const String &p_type) const {
 
-	if (get_script_instance() && get_script_instance()->has_method("handles")) {
-		return get_script_instance()->call("handles", p_type);
+	if (get_script_instance() && get_script_instance()->has_method("_handles")) {
+		return get_script_instance()->call("_handles", p_type);
 	}
 	ERR_EXPLAIN("EditorResourcePreviewGenerator::handles needs to be overridden");
 	ERR_FAIL_V(false);
 }
 Ref<Texture> EditorResourcePreviewGenerator::generate(const RES &p_from) {
 
-	if (get_script_instance() && get_script_instance()->has_method("generate")) {
-		return get_script_instance()->call("generate", p_from);
+	if (get_script_instance() && get_script_instance()->has_method("_generate")) {
+		return get_script_instance()->call("_generate", p_from);
 	}
 	ERR_EXPLAIN("EditorResourcePreviewGenerator::generate needs to be overridden");
 	ERR_FAIL_V(Ref<Texture>());
@@ -56,8 +56,8 @@ Ref<Texture> EditorResourcePreviewGenerator::generate(const RES &p_from) {
 
 Ref<Texture> EditorResourcePreviewGenerator::generate_from_path(const String &p_path) {
 
-	if (get_script_instance() && get_script_instance()->has_method("generate_from_path")) {
-		return get_script_instance()->call("generate_from_path", p_path);
+	if (get_script_instance() && get_script_instance()->has_method("_generate_from_path")) {
+		return get_script_instance()->call("_generate_from_path", p_path);
 	}
 
 	RES res = ResourceLoader::load(p_path);
@@ -68,9 +68,9 @@ Ref<Texture> EditorResourcePreviewGenerator::generate_from_path(const String &p_
 
 void EditorResourcePreviewGenerator::_bind_methods() {
 
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "handles", PropertyInfo(Variant::STRING, "type")));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(CLASS_INFO(Texture), "generate", PropertyInfo(Variant::OBJECT, "from", PROPERTY_HINT_RESOURCE_TYPE, "Resource")));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(CLASS_INFO(Texture), "generate_from_path", PropertyInfo(Variant::STRING, "path", PROPERTY_HINT_FILE)));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "_handles", PropertyInfo(Variant::STRING, "type")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(CLASS_INFO(Texture), "_generate", PropertyInfo(Variant::OBJECT, "from", PROPERTY_HINT_RESOURCE_TYPE, "Resource")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(CLASS_INFO(Texture), "_generate_from_path", PropertyInfo(Variant::STRING, "path", PROPERTY_HINT_FILE)));
 }
 
 EditorResourcePreviewGenerator::EditorResourcePreviewGenerator() {

--- a/editor/import/editor_import_plugin.cpp
+++ b/editor/import/editor_import_plugin.cpp
@@ -34,50 +34,50 @@ EditorImportPlugin::EditorImportPlugin() {
 }
 
 String EditorImportPlugin::get_importer_name() const {
-	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("get_importer_name")), "");
-	return get_script_instance()->call("get_importer_name");
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("_get_importer_name")), "");
+	return get_script_instance()->call("_get_importer_name");
 }
 
 String EditorImportPlugin::get_visible_name() const {
-	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("get_visible_name")), "");
-	return get_script_instance()->call("get_visible_name");
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("_get_visible_name")), "");
+	return get_script_instance()->call("_get_visible_name");
 }
 
 void EditorImportPlugin::get_recognized_extensions(List<String> *p_extensions) const {
-	ERR_FAIL_COND(!(get_script_instance() && get_script_instance()->has_method("get_recognized_extensions")));
-	Array extensions = get_script_instance()->call("get_recognized_extensions");
+	ERR_FAIL_COND(!(get_script_instance() && get_script_instance()->has_method("_get_recognized_extensions")));
+	Array extensions = get_script_instance()->call("_get_recognized_extensions");
 	for (int i = 0; i < extensions.size(); i++) {
 		p_extensions->push_back(extensions[i]);
 	}
 }
 
 String EditorImportPlugin::get_preset_name(int p_idx) const {
-	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("get_preset_name")), "");
-	return get_script_instance()->call("get_preset_name", p_idx);
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("_get_preset_name")), "");
+	return get_script_instance()->call("_get_preset_name", p_idx);
 }
 
 int EditorImportPlugin::get_preset_count() const {
-	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("get_preset_count")), 0);
-	return get_script_instance()->call("get_preset_count");
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("_get_preset_count")), 0);
+	return get_script_instance()->call("_get_preset_count");
 }
 
 String EditorImportPlugin::get_save_extension() const {
-	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("get_save_extension")), "");
-	return get_script_instance()->call("get_save_extension");
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("_get_save_extension")), "");
+	return get_script_instance()->call("_get_save_extension");
 }
 
 String EditorImportPlugin::get_resource_type() const {
-	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("get_resource_type")), "");
-	return get_script_instance()->call("get_resource_type");
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("_get_resource_type")), "");
+	return get_script_instance()->call("_get_resource_type");
 }
 
 void EditorImportPlugin::get_import_options(List<ResourceImporter::ImportOption> *r_options, int p_preset) const {
 
-	ERR_FAIL_COND(!(get_script_instance() && get_script_instance()->has_method("get_import_options")));
+	ERR_FAIL_COND(!(get_script_instance() && get_script_instance()->has_method("_get_import_options")));
 	Array needed;
 	needed.push_back("name");
 	needed.push_back("default_value");
-	Array options = get_script_instance()->call("get_import_options", p_preset);
+	Array options = get_script_instance()->call("_get_import_options", p_preset);
 	for (int i = 0; i < options.size(); i++) {
 		Dictionary d = options[i];
 		ERR_FAIL_COND(!d.has_all(needed));
@@ -105,19 +105,19 @@ void EditorImportPlugin::get_import_options(List<ResourceImporter::ImportOption>
 }
 
 bool EditorImportPlugin::get_option_visibility(const String &p_option, const Map<StringName, Variant> &p_options) const {
-	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("get_option_visibility")), true);
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("_get_option_visibility")), true);
 	Dictionary d;
 	Map<StringName, Variant>::Element *E = p_options.front();
 	while (E) {
 		d[E->key()] = E->get();
 		E = E->next();
 	}
-	return get_script_instance()->call("get_option_visibility", p_option, d);
+	return get_script_instance()->call("_get_option_visibility", p_option, d);
 }
 
 Error EditorImportPlugin::import(const String &p_source_file, const String &p_save_path, const Map<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files) {
 
-	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("import")), ERR_UNAVAILABLE);
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("_import")), ERR_UNAVAILABLE);
 	Dictionary options;
 	Array platform_variants, gen_files;
 
@@ -126,7 +126,7 @@ Error EditorImportPlugin::import(const String &p_source_file, const String &p_sa
 		options[E->key()] = E->get();
 		E = E->next();
 	}
-	Error err = (Error)get_script_instance()->call("import", p_source_file, p_save_path, options, platform_variants, gen_files).operator int64_t();
+	Error err = (Error)get_script_instance()->call("_import", p_source_file, p_save_path, options, platform_variants, gen_files).operator int64_t();
 
 	for (int i = 0; i < platform_variants.size(); i++) {
 		r_platform_variants->push_back(platform_variants[i]);
@@ -139,14 +139,14 @@ Error EditorImportPlugin::import(const String &p_source_file, const String &p_sa
 
 void EditorImportPlugin::_bind_methods() {
 
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "get_importer_name"));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "get_visible_name"));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::INT, "get_preset_count"));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "get_preset_name", PropertyInfo(Variant::INT, "preset")));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::ARRAY, "get_recognized_extensions"));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::ARRAY, "get_import_options", PropertyInfo(Variant::INT, "preset")));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "get_save_extension"));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "get_resource_type"));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "get_option_visibility", PropertyInfo(Variant::STRING, "option"), PropertyInfo(Variant::DICTIONARY, "options")));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::INT, "import", PropertyInfo(Variant::STRING, "source_file"), PropertyInfo(Variant::STRING, "save_path"), PropertyInfo(Variant::DICTIONARY, "options"), PropertyInfo(Variant::ARRAY, "r_platform_variants"), PropertyInfo(Variant::ARRAY, "r_gen_files")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "_get_importer_name"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "_get_visible_name"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::INT, "_get_preset_count"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "_get_preset_name", PropertyInfo(Variant::INT, "preset")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::ARRAY, "_get_recognized_extensions"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::ARRAY, "_get_import_options", PropertyInfo(Variant::INT, "preset")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "_get_save_extension"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "_get_resource_type"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "_get_option_visibility", PropertyInfo(Variant::STRING, "option"), PropertyInfo(Variant::DICTIONARY, "options")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::INT, "_import", PropertyInfo(Variant::STRING, "source_file"), PropertyInfo(Variant::STRING, "save_path"), PropertyInfo(Variant::DICTIONARY, "options"), PropertyInfo(Variant::ARRAY, "r_platform_variants"), PropertyInfo(Variant::ARRAY, "r_gen_files")));
 }

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -49,13 +49,13 @@
 
 void EditorScenePostImport::_bind_methods() {
 
-	BIND_VMETHOD(MethodInfo("post_import", PropertyInfo(Variant::OBJECT, "scene")));
+	BIND_VMETHOD(MethodInfo("_post_import", PropertyInfo(Variant::OBJECT, "scene")));
 }
 
 Node *EditorScenePostImport::post_import(Node *p_scene) {
 
 	if (get_script_instance())
-		return get_script_instance()->call("post_import", p_scene);
+		return get_script_instance()->call("_post_import", p_scene);
 
 	return p_scene;
 }

--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -82,8 +82,8 @@ void EditorSpatialGizmo::clear() {
 
 void EditorSpatialGizmo::redraw() {
 
-	if (get_script_instance() && get_script_instance()->has_method("redraw"))
-		get_script_instance()->call("redraw");
+	if (get_script_instance() && get_script_instance()->has_method("_redraw"))
+		get_script_instance()->call("_redraw");
 }
 
 void EditorSpatialGizmo::Instance::create_instance(Spatial *p_base) {
@@ -643,14 +643,14 @@ void EditorSpatialGizmo::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_spatial_node", "node"), &EditorSpatialGizmo::_set_spatial_node);
 	ClassDB::bind_method(D_METHOD("clear"), &EditorSpatialGizmo::clear);
 
-	BIND_VMETHOD(MethodInfo("redraw"));
+	BIND_VMETHOD(MethodInfo("_redraw"));
 	BIND_VMETHOD(MethodInfo(Variant::STRING, "get_handle_name", PropertyInfo(Variant::INT, "index")));
 
 	MethodInfo hvget(Variant::NIL, "get_handle_value", PropertyInfo(Variant::INT, "index"));
 	hvget.return_val.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
 	BIND_VMETHOD(hvget);
 
-	BIND_VMETHOD(MethodInfo("set_handle", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::OBJECT, "camera", PROPERTY_HINT_RESOURCE_TYPE, "Camera"), PropertyInfo(Variant::VECTOR2, "point")));
+	BIND_VMETHOD(MethodInfo("_set_handle", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::OBJECT, "camera", PROPERTY_HINT_RESOURCE_TYPE, "Camera"), PropertyInfo(Variant::VECTOR2, "point")));
 	MethodInfo cm = MethodInfo("commit_handle", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::NIL, "restore"), PropertyInfo(Variant::BOOL, "cancel"));
 	cm.default_arguments.push_back(false);
 	BIND_VMETHOD(cm);

--- a/servers/arvr/arvr_script_interface.cpp
+++ b/servers/arvr/arvr_script_interface.cpp
@@ -15,8 +15,8 @@ ARVRScriptInterface::~ARVRScriptInterface() {
 }
 
 StringName ARVRScriptInterface::get_name() const {
-	if (get_script_instance() && get_script_instance()->has_method("get_name")) {
-		return get_script_instance()->call("get_name");
+	if (get_script_instance() && get_script_instance()->has_method("_get_name")) {
+		return get_script_instance()->call("_get_name");
 	} else {
 		// just return something for now
 		return "ARVR Script interface";
@@ -24,33 +24,33 @@ StringName ARVRScriptInterface::get_name() const {
 }
 
 bool ARVRScriptInterface::is_installed() {
-	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("is_installed")), false);
-	return get_script_instance()->call("is_installed");
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("_is_installed")), false);
+	return get_script_instance()->call("_is_installed");
 }
 
 bool ARVRScriptInterface::hmd_is_present() {
-	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("hmd_is_present")), false);
-	return get_script_instance()->call("hmd_is_present");
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("_hmd_is_present")), false);
+	return get_script_instance()->call("_hmd_is_present");
 }
 
 bool ARVRScriptInterface::supports_hmd() {
-	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("supports_hmd")), false);
-	return get_script_instance()->call("supports_hmd");
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("_supports_hmd")), false);
+	return get_script_instance()->call("_supports_hmd");
 }
 
 bool ARVRScriptInterface::is_stereo() {
-	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("is_stereo")), false);
-	return get_script_instance()->call("is_stereo");
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("_is_stereo")), false);
+	return get_script_instance()->call("_is_stereo");
 }
 
 bool ARVRScriptInterface::is_initialized() {
-	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("is_initialized")), false);
-	return get_script_instance()->call("is_initialized");
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("_is_initialized")), false);
+	return get_script_instance()->call("_is_initialized");
 }
 
 bool ARVRScriptInterface::initialize() {
-	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("initialize")), false);
-	return get_script_instance()->call("initialize");
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("_initialize")), false);
+	return get_script_instance()->call("_initialize");
 }
 
 void ARVRScriptInterface::uninitialize() {
@@ -60,18 +60,18 @@ void ARVRScriptInterface::uninitialize() {
 		arvr_server->clear_primary_interface_if(this);
 	}
 
-	ERR_FAIL_COND(!(get_script_instance() && get_script_instance()->has_method("uninitialize")));
-	get_script_instance()->call("uninitialize");
+	ERR_FAIL_COND(!(get_script_instance() && get_script_instance()->has_method("_uninitialize")));
+	get_script_instance()->call("_uninitialize");
 }
 
 Size2 ARVRScriptInterface::get_recommended_render_targetsize() {
-	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("get_recommended_render_targetsize")), Size2());
-	return get_script_instance()->call("get_recommended_render_targetsize");
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("_get_recommended_render_targetsize")), Size2());
+	return get_script_instance()->call("_get_recommended_render_targetsize");
 }
 
 Transform ARVRScriptInterface::get_transform_for_eye(Eyes p_eye, const Transform &p_cam_transform) {
-	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("get_transform_for_eye")), Transform());
-	return get_script_instance()->call("get_transform_for_eye", p_eye, p_cam_transform);
+	ERR_FAIL_COND_V(!(get_script_instance() && get_script_instance()->has_method("_get_transform_for_eye")), Transform());
+	return get_script_instance()->call("_get_transform_for_eye", p_eye, p_cam_transform);
 }
 
 // Suggestion from Reduz, as we can't return a CameraMatrix, return a PoolVector with our 16 floats
@@ -100,28 +100,28 @@ CameraMatrix ARVRScriptInterface::get_projection_for_eye(Eyes p_eye, real_t p_as
 }
 
 void ARVRScriptInterface::commit_for_eye(ARVRInterface::Eyes p_eye, RID p_render_target, const Rect2 &p_screen_rect) {
-	ERR_FAIL_COND(!(get_script_instance() && get_script_instance()->has_method("commit_for_eye")));
-	get_script_instance()->call("commit_for_eye");
+	ERR_FAIL_COND(!(get_script_instance() && get_script_instance()->has_method("_commit_for_eye")));
+	get_script_instance()->call("_commit_for_eye");
 }
 
 void ARVRScriptInterface::process() {
-	ERR_FAIL_COND(!(get_script_instance() && get_script_instance()->has_method("process")));
-	get_script_instance()->call("process");
+	ERR_FAIL_COND(!(get_script_instance() && get_script_instance()->has_method("_process")));
+	get_script_instance()->call("_process");
 }
 
 void ARVRScriptInterface::_bind_methods() {
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "is_installed"));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "hmd_is_present"));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "supports_hmd"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "_is_installed"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "_hmd_is_present"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "_supports_hmd"));
 
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "is_initialized"));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "initialize"));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo("uninitialize"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "_is_initialized"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "_initialize"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo("_uninitialize"));
 
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "is_stereo"));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::VECTOR2, "get_recommended_render_targetsize"));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::TRANSFORM, "get_transform_for_eye", PropertyInfo(Variant::INT, "eye"), PropertyInfo(Variant::TRANSFORM, "cam_transform")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "_is_stereo"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::VECTOR2, "_get_recommended_render_targetsize"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::TRANSFORM, "_get_transform_for_eye", PropertyInfo(Variant::INT, "eye"), PropertyInfo(Variant::TRANSFORM, "cam_transform")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo("_get_projection_for_eye"));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo("commit_for_eye", PropertyInfo(Variant::INT, "eye"), PropertyInfo(Variant::_RID, "render_target")));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo("process"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo("_commit_for_eye", PropertyInfo(Variant::INT, "eye"), PropertyInfo(Variant::_RID, "render_target")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo("_process"));
 }


### PR DESCRIPTION
I have added undescode prefix for virtual methods of some classes (editor plugins, gizmo, etc) to be consistent with the rest script methods notation