### PR TITLE
Fix out of bound array indexing

### DIFF
--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -40,7 +40,7 @@ private:
 
 		AudioFilterSW filter;
 		AudioFilterSW::Processor filter_process[6];
-		AudioFrame vol[3];
+		AudioFrame vol[4];
 		float filter_gain;
 		float pitch_scale;
 		int bus_index;


### PR DESCRIPTION
730d36f350 introduced introduced some code that indexes AudioFrame[3],
it is however defined as AudioFrame[3]. This increases the size to [4]