### PR TITLE
Fix out of bound array indexing (reverb_vol)

### DIFF
--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -45,7 +45,7 @@ private:
 		float pitch_scale;
 		int bus_index;
 		int reverb_bus_index;
-		AudioFrame reverb_vol[3];
+		AudioFrame reverb_vol[4];
 		Viewport *viewport; //pointer only used for reference to previous mix
 
 		Output() {


### PR DESCRIPTION
Same issue as in a3f9fe52. AudioFrame[3] being indexed at [3]