### PR TITLE
Create separate debug info files by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,8 @@ build/
 bld/
 [Bb]in/
 [Oo]bj/
+*.debug
+*.dSYM
 
 # MSTest test Results
 [Tt]est[Rr]esult*/

--- a/platform/haiku/detect.py
+++ b/platform/haiku/detect.py
@@ -21,7 +21,7 @@ def can_build():
 def get_opts():
 
     return [
-        ('debug_release', 'Add debug symbols to release version', 'no')
+        ('debug_symbols', 'Add debug symbols to release version (yes/no/full)', 'yes')
     ]
 
 
@@ -36,16 +36,21 @@ def configure(env):
     ## Build type
 
     if (env["target"] == "release"):
-        if (env["debug_release"] == "yes"):
+        env.Prepend(CCFLAGS=['-O3', '-ffast-math'])
+        if (env["debug_symbols"] == "yes"):
+            env.Prepend(CCFLAGS=['-g1'])
+        if (env["debug_symbols"] == "full"):
             env.Prepend(CCFLAGS=['-g2'])
-        else:
-            env.Prepend(CCFLAGS=['-O3', '-ffast-math'])
 
     elif (env["target"] == "release_debug"):
         env.Prepend(CCFLAGS=['-O2', '-ffast-math', '-DDEBUG_ENABLED'])
+        if (env["debug_symbols"] == "yes"):
+            env.Prepend(CCFLAGS=['-g1'])
+        if (env["debug_symbols"] == "full"):
+            env.Prepend(CCFLAGS=['-g2'])
 
     elif (env["target"] == "debug"):
-        env.Prepend(CCFLAGS=['-g2', '-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
+        env.Prepend(CCFLAGS=['-g3', '-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
 
     ## Architecture
 

--- a/platform/osx/SCsub
+++ b/platform/osx/SCsub
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 
+import os
 Import('env')
+
+def make_debug(target, source, env):
+    os.system('dsymutil %s -o %s.dSYM' % (target[0], target[0]))
 
 files = [
     'crash_handler_osx.mm',
@@ -13,8 +17,7 @@ files = [
     'power_osx.cpp',
 ]
 
-prog = env.Program('#bin/godot', files)
-if (env['target'] == "debug" or env['target'] == "release_debug"):
-    # Build the .dSYM file for atos
-    action = "dsymutil " + File(prog)[0].path + " -o " + File(prog)[0].path + ".dSYM"
-    env.AddPostAction(prog, action)
+binary = env.Program('#bin/godot', files)
+if env["debug_symbols"] == "full" or env["debug_symbols"] == "yes":
+    env.AddPostAction(binary, make_debug)
+

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -22,6 +22,7 @@ def get_opts():
 
     return [
         ('osxcross_sdk', 'OSXCross SDK version', 'darwin14'),
+        ('debug_symbols', 'Add debug symbols to release version (yes/no/full)', 'yes'),
     ]
 
 
@@ -36,10 +37,18 @@ def configure(env):
 	## Build type
 
     if (env["target"] == "release"):
-        env.Prepend(CCFLAGS=['-O2', '-ffast-math', '-fomit-frame-pointer', '-ftree-vectorize', '-msse2'])
+        env.Prepend(CCFLAGS=['-O3', '-ffast-math', '-fomit-frame-pointer', '-ftree-vectorize', '-msse2'])
+        if (env["debug_symbols"] == "yes"):
+            env.Prepend(CCFLAGS=['-g1'])
+        if (env["debug_symbols"] == "full"):
+            env.Prepend(CCFLAGS=['-g2'])
 
     elif (env["target"] == "release_debug"):
         env.Prepend(CCFLAGS=['-O2', '-DDEBUG_ENABLED'])
+        if (env["debug_symbols"] == "yes"):
+            env.Prepend(CCFLAGS=['-g1'])
+        if (env["debug_symbols"] == "full"):
+            env.Prepend(CCFLAGS=['-g2'])
 
     elif (env["target"] == "debug"):
         env.Prepend(CCFLAGS=['-g3', '-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
 
+import os
 Import('env')
 
+def make_debug_mingw(target, source, env):
+    os.system('objcopy --only-keep-debug %s %s.debug' % (target[0], target[0]))
+    os.system('strip --strip-debug --strip-unneeded %s' % (target[0]))
+    os.system('objcopy --add-gnu-debuglink=%s.debug %s' % (target[0], target[0]))
 
 common_win = [
     "context_gl_win.cpp",
@@ -22,10 +27,14 @@ obj = env.RES(restarget, 'godot_res.rc')
 
 common_win.append(obj)
 
-env.Program('#bin/godot', ['godot_win.cpp'] + common_win, PROGSUFFIX=env["PROGSUFFIX"])
+binary = env.Program('#bin/godot', ['godot_win.cpp'] + common_win, PROGSUFFIX=env["PROGSUFFIX"])
 
 # Microsoft Visual Studio Project Generation
 if (env['vsproj']) == "yes":
     env.vs_srcs = env.vs_srcs + ["platform/windows/godot_win.cpp"]
     for x in common_win:
         env.vs_srcs = env.vs_srcs + ["platform/windows/" + str(x)]
+
+if not os.getenv("VCINSTALLDIR"):
+    if env["debug_symbols"] == "full" or env["debug_symbols"] == "yes":
+        env.AddPostAction(binary, make_debug_mingw)

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -64,6 +64,7 @@ def get_opts():
     return [
         ('mingw_prefix_32', 'MinGW prefix (Win32)', mingw32),
         ('mingw_prefix_64', 'MinGW prefix (Win64)', mingw64),
+        ('debug_symbols', 'Add debug symbols to release version (yes/no/full)', 'yes')
     ]
 
 
@@ -213,11 +214,20 @@ def configure(env):
 
             env.Append(LINKFLAGS=['-Wl,--subsystem,windows'])
 
+            if (env["debug_symbols"] == "yes"):
+               env.Prepend(CCFLAGS=['-g1'])
+            if (env["debug_symbols"] == "full"):
+               env.Prepend(CCFLAGS=['-g2'])
+
         elif (env["target"] == "release_debug"):
             env.Append(CCFLAGS=['-O2', '-DDEBUG_ENABLED'])
+            if (env["debug_symbols"] == "yes"):
+               env.Prepend(CCFLAGS=['-g1'])
+            if (env["debug_symbols"] == "full"):
+               env.Prepend(CCFLAGS=['-g2'])
 
         elif (env["target"] == "debug"):
-            env.Append(CCFLAGS=['-g', '-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
+            env.Append(CCFLAGS=['-g3', '-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
 
         ## Compiler configuration
 

--- a/platform/x11/SCsub
+++ b/platform/x11/SCsub
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
 
+import os
 Import('env')
 
+def make_debug(target, source, env):
+    os.system('objcopy --only-keep-debug %s %s.debug' % (target[0], target[0]))
+    os.system('strip --strip-debug --strip-unneeded %s' % (target[0]))
+    os.system('objcopy --add-gnu-debuglink=%s.debug %s' % (target[0], target[0]))
 
 common_x11 = [
     "context_gl_x11.cpp",
@@ -12,4 +17,6 @@ common_x11 = [
     "power_x11.cpp",
 ]
 
-env.Program('#bin/godot', ['godot_x11.cpp'] + common_x11)
+binary = env.Program('#bin/godot', ['godot_x11.cpp'] + common_x11)
+if env["debug_symbols"] == "full" or env["debug_symbols"] == "yes":
+    env.AddPostAction(binary, make_debug)

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -44,7 +44,6 @@ def can_build():
 
     return True
 
-
 def get_opts():
 
     return [
@@ -55,7 +54,7 @@ def get_opts():
         ('use_lto', 'Use link time optimization', 'no'),
         ('pulseaudio', 'Detect & use pulseaudio', 'yes'),
         ('udev', 'Use udev for gamepad connection callbacks', 'no'),
-        ('debug_release', 'Add debug symbols to release version', 'no'),
+        ('debug_symbols', 'Add debug symbols to release version (yes/no/full)', 'yes')
     ]
 
 
@@ -77,16 +76,20 @@ def configure(env):
         # -O3 -ffast-math is identical to -Ofast. We need to split it out so we can selectively disable
         # -ffast-math in code for which it generates wrong results.
         env.Prepend(CCFLAGS=['-O3', '-ffast-math'])
-        if (env["debug_release"] == "yes"):
+        if (env["debug_symbols"] == "yes"):
+            env.Prepend(CCFLAGS=['-g1'])
+        if (env["debug_symbols"] == "full"):
             env.Prepend(CCFLAGS=['-g2'])
 
     elif (env["target"] == "release_debug"):
         env.Prepend(CCFLAGS=['-O2', '-ffast-math', '-DDEBUG_ENABLED'])
-        if (env["debug_release"] == "yes"):
+        if (env["debug_symbols"] == "yes"):
+            env.Prepend(CCFLAGS=['-g1'])
+        if (env["debug_symbols"] == "full"):
             env.Prepend(CCFLAGS=['-g2'])
 
     elif (env["target"] == "debug"):
-        env.Prepend(CCFLAGS=['-g2', '-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
+        env.Prepend(CCFLAGS=['-g3', '-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
         env.Append(LINKFLAGS=['-rdynamic'])
 
     ## Architecture


### PR DESCRIPTION
Now that we have a built-in stacktrace on a segfault it would be useful
to have debug information on debug_release builds so that bugreports can
include this information. Without this debug info we will still get
function names in the backtrace but not file location.

This commit will by default build all targets with minimal debug info
and then strip the information into separate files. On MacOS this is a
.dSYM file, on Linux/MingW this is a .debug file. MacOSX will
automatically load a dSYM file if it exists in its debugger. On
Linux/MingW we create a 'gnu debuglink' meaning that gdb and friends
will automatically find the debug symbols if they exist.

Existing workflow for developers does not change at all, except that we
now create two instead of one build artifact by default.

This commit also adds a 'debug_symbols' option to X11, MacOS, and MingW
targets. The default is 'yes' which corresponds to -g1. The alternatives
are 'no' (don't generate debug infos at all) or 'full' which runs with
-g2. A target=debug build will now build with -g3.