### PR TITLE
Fix #10764 LineEdit: Caret Blink & Speed Resetting

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -33,9 +33,6 @@
 #include "os/os.h"
 #include "print_string.h"
 #include "translation.h"
-#ifdef TOOLS_ENABLED
-#include "editor/editor_settings.h"
-#endif
 
 static bool _is_text_char(CharType c) {
 
@@ -532,18 +529,6 @@ void LineEdit::drop_data(const Point2 &p_point, const Variant &p_data) {
 void LineEdit::_notification(int p_what) {
 
 	switch (p_what) {
-#ifdef TOOLS_ENABLED
-		case NOTIFICATION_ENTER_TREE: {
-			if (Engine::get_singleton()->is_editor_hint()) {
-				cursor_set_blink_enabled(EDITOR_DEF("text_editor/cursor/caret_blink", false));
-				cursor_set_blink_speed(EDITOR_DEF("text_editor/cursor/caret_blink_speed", 0.65));
-
-				if (!EditorSettings::get_singleton()->is_connected("settings_changed", this, "_editor_settings_changed")) {
-					EditorSettings::get_singleton()->connect("settings_changed", this, "_editor_settings_changed");
-				}
-			}
-		} break;
-#endif
 		case NOTIFICATION_RESIZED: {
 
 			set_cursor_pos(get_cursor_pos());
@@ -1276,13 +1261,6 @@ PopupMenu *LineEdit::get_menu() const {
 	return menu;
 }
 
-#ifdef TOOLS_ENABLED
-void LineEdit::_editor_settings_changed() {
-	cursor_set_blink_enabled(EDITOR_DEF("text_editor/cursor/caret_blink", false));
-	cursor_set_blink_speed(EDITOR_DEF("text_editor/cursor/caret_blink_speed", 0.65));
-}
-#endif
-
 void LineEdit::set_expand_to_text_length(bool p_enabled) {
 
 	expand_to_text_length = p_enabled;
@@ -1313,10 +1291,6 @@ void LineEdit::_text_changed() {
 void LineEdit::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_toggle_draw_caret"), &LineEdit::_toggle_draw_caret);
-
-#ifdef TOOLS_ENABLED
-	ClassDB::bind_method("_editor_settings_changed", &LineEdit::_editor_settings_changed);
-#endif
 
 	ClassDB::bind_method(D_METHOD("set_align", "align"), &LineEdit::set_align);
 	ClassDB::bind_method(D_METHOD("get_align"), &LineEdit::get_align);

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -118,10 +118,6 @@ private:
 	void clear_internal();
 	void changed_internal();
 
-#ifdef TOOLS_ENABLED
-	void _editor_settings_changed();
-#endif
-
 	void _gui_input(Ref<InputEvent> p_event);
 	void _notification(int p_what);
 


### PR DESCRIPTION
This reverts commit 4f54e721895d44ded7b49fe6d6138a97d56d456b whgich was causing the caret to be reset to default values everytime the scene was entered.