### PR TITLE
swapped up down shortcut for freelook (to fit unreal)

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -2843,8 +2843,8 @@ SpatialEditorViewport::SpatialEditorViewport(SpatialEditor *p_spatial_editor, Ed
 	ED_SHORTCUT("spatial_editor/freelook_right", TTR("Freelook Right"), KEY_D);
 	ED_SHORTCUT("spatial_editor/freelook_forward", TTR("Freelook Forward"), KEY_W);
 	ED_SHORTCUT("spatial_editor/freelook_backwards", TTR("Freelook Backwards"), KEY_S);
-	ED_SHORTCUT("spatial_editor/freelook_up", TTR("Freelook Up"), KEY_Q);
-	ED_SHORTCUT("spatial_editor/freelook_down", TTR("Freelook Down"), KEY_E);
+	ED_SHORTCUT("spatial_editor/freelook_up", TTR("Freelook Up"), KEY_E);
+	ED_SHORTCUT("spatial_editor/freelook_down", TTR("Freelook Down"), KEY_Q);
 	ED_SHORTCUT("spatial_editor/freelook_speed_modifier", TTR("Freelook Speed Modifier"), KEY_SHIFT);
 
 	preview_camera = memnew(Button);


### PR DESCRIPTION
@Zylann are you okay with that?

from:
https://docs.unrealengine.com/latest/INT/Engine/UI/LevelEditor/Viewports/ViewportControls/


Control | Action
-- | --
W \| Numpad8 \| Up | Moves the camera forward.
S \| Numpad2 \| Down | Moves the camera backward.
A \| Numpad4 \| Left | Moves the camera left.
D \| Numpad6 \| Right | Moves the camera right.
E \| Numpad9 \| Page Up | Moves the camera up.
Q \| Numpad7 \| Page Dn | Moves the camera down.
Z \| Numpad1 | Zooms the camera out (raises FOV).
C \| Numpad3 | Zooms the camera in (lowers FOV).

they also use e for up and q for down.

