### PR TITLE
Fix crash when no audio driver is available

### DIFF
--- a/drivers/rtaudio/audio_driver_rtaudio.cpp
+++ b/drivers/rtaudio/audio_driver_rtaudio.cpp
@@ -143,7 +143,7 @@ Error AudioDriverRtAudio::init() {
 		}
 	}
 
-	return OK;
+	return active ? OK : ERR_UNAVAILABLE;
 }
 
 int AudioDriverRtAudio::get_mix_rate() const {

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -137,12 +137,7 @@ void OS_Android::initialize(const VideoMode &p_desired, int p_video_driver, int 
 	visual_server->init();
 	//	visual_server->cursor_set_visible(false, 0);
 
-	AudioDriverManager::get_driver(p_audio_driver)->set_singleton();
-
-	if (AudioDriverManager::get_driver(p_audio_driver)->init() != OK) {
-
-		ERR_PRINT("Initializing audio failed.");
-	}
+	AudioDriverManager::initialize(p_audio_driver);
 
 	physics_server = memnew(PhysicsServerSW);
 	physics_server->init();

--- a/platform/haiku/os_haiku.cpp
+++ b/platform/haiku/os_haiku.cpp
@@ -137,11 +137,7 @@ void OS_Haiku::initialize(const VideoMode &p_desired, int p_video_driver, int p_
 	//physics_2d_server = Physics2DServerWrapMT::init_server<Physics2DServerSW>();
 	physics_2d_server->init();
 
-	AudioDriverManager::get_driver(p_audio_driver)->set_singleton();
-
-	if (AudioDriverManager::get_driver(p_audio_driver)->init() != OK) {
-		ERR_PRINT("Initializing audio failed.");
-	}
+	AudioDriverManager::initialize(p_audio_driver);
 
 	power_manager = memnew(PowerHaiku);
 }

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -464,11 +464,7 @@ void OS_JavaScript::initialize(const VideoMode &p_desired, int p_video_driver, i
 	print_line("Init Audio");
 
 	AudioDriverManager::add_driver(&audio_driver_javascript);
-	audio_driver_javascript.set_singleton();
-	if (audio_driver_javascript.init() != OK) {
-
-		ERR_PRINT("Initializing audio failed.");
-	}
+	AudioDriverManager::initialize(p_audio_driver);
 
 	RasterizerGLES3::register_config();
 	RasterizerGLES3::make_current();

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1088,12 +1088,7 @@ void OS_OSX::initialize(const VideoMode &p_desired, int p_video_driver, int p_au
 	visual_server->init();
 	//	visual_server->cursor_set_visible(false, 0);
 
-	AudioDriverManager::get_driver(p_audio_driver)->set_singleton();
-
-	if (AudioDriverManager::get_driver(p_audio_driver)->init() != OK) {
-
-		ERR_PRINT("Initializing audio failed.");
-	}
+	AudioDriverManager::initialize(p_audio_driver);
 
 	//
 	physics_server = memnew(PhysicsServerSW);

--- a/platform/server/os_server.cpp
+++ b/platform/server/os_server.cpp
@@ -62,12 +62,7 @@ void OS_Server::initialize(const VideoMode &p_desired, int p_video_driver, int p
 
 	//visual_server = memnew( VisualServerRaster(rasterizer) );
 
-	AudioDriverManager::get_driver(p_audio_driver)->set_singleton();
-
-	if (AudioDriverManager::get_driver(p_audio_driver)->init() != OK) {
-
-		ERR_PRINT("Initializing audio failed.");
-	}
+	AudioDriverManager::initialize(p_audio_driver);
 
 	sample_manager = memnew(SampleManagerMallocSW);
 	audio_server = memnew(AudioServerSW(sample_manager));
@@ -232,7 +227,6 @@ void OS_Server::run() {
 
 OS_Server::OS_Server() {
 
-	AudioDriverManager::add_driver(&driver_dummy);
 	//adriver here
 	grab = false;
 };

--- a/platform/server/os_server.h
+++ b/platform/server/os_server.h
@@ -34,7 +34,6 @@
 #include "drivers/rtaudio/audio_driver_rtaudio.h"
 #include "drivers/unix/os_unix.h"
 #include "main/input_default.h"
-#include "servers/audio/audio_driver_dummy.h"
 #include "servers/audio_server.h"
 #include "servers/physics_2d/physics_2d_server_sw.h"
 #include "servers/physics_server.h"
@@ -55,7 +54,6 @@ class OS_Server : public OS_Unix {
 	List<String> args;
 	MainLoop *main_loop;
 
-	AudioDriverDummy driver_dummy;
 	bool grab;
 
 	PhysicsServer *physics_server;

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -268,12 +268,7 @@ void OSUWP::initialize(const VideoMode &p_desired, int p_video_driver, int p_aud
 	joypad = ref new JoypadUWP(input);
 	joypad->register_events();
 
-	AudioDriverManager::get_driver(p_audio_driver)->set_singleton();
-
-	if (AudioDriverManager::get_driver(p_audio_driver)->init() != OK) {
-
-		ERR_PRINT("Initializing audio failed.");
-	}
+	AudioDriverManager::initialize(p_audio_driver);
 
 	power_manager = memnew(PowerUWP);
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1081,12 +1081,7 @@ void OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int 
 
 	power_manager = memnew(PowerWindows);
 
-	AudioDriverManager::get_driver(p_audio_driver)->set_singleton();
-
-	if (AudioDriverManager::get_driver(p_audio_driver)->init() != OK) {
-
-		ERR_PRINT("Initializing audio failed.");
-	}
+	AudioDriverManager::initialize(p_audio_driver);
 
 	TRACKMOUSEEVENT tme;
 	tme.cbSize = sizeof(TRACKMOUSEEVENT);

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -313,29 +313,7 @@ void OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_au
 		XFree(xsh);
 	}
 
-	AudioDriverManager::get_driver(p_audio_driver)->set_singleton();
-
-	audio_driver_index = p_audio_driver;
-	if (AudioDriverManager::get_driver(p_audio_driver)->init() != OK) {
-
-		bool success = false;
-		audio_driver_index = -1;
-		for (int i = 0; i < AudioDriverManager::get_driver_count(); i++) {
-			if (i == p_audio_driver)
-				continue;
-			AudioDriverManager::get_driver(i)->set_singleton();
-			if (AudioDriverManager::get_driver(i)->init() == OK) {
-				success = true;
-				print_line("Audio Driver Failed: " + String(AudioDriverManager::get_driver(p_audio_driver)->get_name()));
-				print_line("Using alternate audio driver: " + String(AudioDriverManager::get_driver(i)->get_name()));
-				audio_driver_index = i;
-				break;
-			}
-		}
-		if (!success) {
-			ERR_PRINT("Initializing audio failed.");
-		}
-	}
+	AudioDriverManager::initialize(p_audio_driver);
 
 	ERR_FAIL_COND(!visual_server);
 	ERR_FAIL_COND(x11_window == 0);
@@ -2189,10 +2167,6 @@ bool OS_X11::is_disable_crash_handler() const {
 
 OS_X11::OS_X11() {
 
-#ifdef RTAUDIO_ENABLED
-	AudioDriverManager::add_driver(&driver_rtaudio);
-#endif
-
 #ifdef PULSEAUDIO_ENABLED
 	AudioDriverManager::add_driver(&driver_pulseaudio);
 #endif
@@ -2200,11 +2174,6 @@ OS_X11::OS_X11() {
 #ifdef ALSA_ENABLED
 	AudioDriverManager::add_driver(&driver_alsa);
 #endif
-
-	if (AudioDriverManager::get_driver_count() == 0) {
-		WARN_PRINT("No sound driver found... Defaulting to dummy driver");
-		AudioDriverManager::add_driver(&driver_dummy);
-	}
 
 	minimized = false;
 	xim_style = 0L;

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -38,11 +38,9 @@
 //#include "servers/visual/visual_server_wrap_mt.h"
 #include "drivers/alsa/audio_driver_alsa.h"
 #include "drivers/pulseaudio/audio_driver_pulseaudio.h"
-#include "drivers/rtaudio/audio_driver_rtaudio.h"
 #include "joypad_linux.h"
 #include "main/input_default.h"
 #include "power_x11.h"
-#include "servers/audio/audio_driver_dummy.h"
 #include "servers/audio_server.h"
 #include "servers/physics_2d/physics_2d_server_sw.h"
 #include "servers/physics_2d/physics_2d_server_wrap_mt.h"
@@ -154,10 +152,6 @@ class OS_X11 : public OS_Unix {
 	JoypadLinux *joypad;
 #endif
 
-#ifdef RTAUDIO_ENABLED
-	AudioDriverRtAudio driver_rtaudio;
-#endif
-
 #ifdef ALSA_ENABLED
 	AudioDriverALSA driver_alsa;
 #endif
@@ -165,7 +159,6 @@ class OS_X11 : public OS_Unix {
 #ifdef PULSEAUDIO_ENABLED
 	AudioDriverPulseAudio driver_pulseaudio;
 #endif
-	AudioDriverDummy driver_dummy;
 
 	Atom net_wm_icon;
 

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -35,6 +35,8 @@
 #include "servers/audio/audio_effect.h"
 #include "variant.h"
 
+class AudioDriverDummy;
+
 class AudioDriver {
 
 	static AudioDriver *singleton;
@@ -90,8 +92,11 @@ class AudioDriverManager {
 	static AudioDriver *drivers[MAX_DRIVERS];
 	static int driver_count;
 
+	static AudioDriverDummy dummy_driver;
+
 public:
 	static void add_driver(AudioDriver *p_driver);
+	static void initialize(int p_driver);
 	static int get_driver_count();
 	static AudioDriver *get_driver(int p_driver);
 };


### PR DESCRIPTION
Fixes #1684.
This unifies the initialization logic for the audio drivers on a new function AudioDriverManager::initialize, which does pretty much the same as what was being done on the x11 code that I removed. So now if no driver is available godot will fall back to the dummy driver.

I've tested the changes on Windows, Linux and OS X. If anybody can help me testing this on the rest that I've changed (android, javascript, haiku and uwp) it would be great.