### PR TITLE
Fix 2 typos, rename "/constant" to "constant"

### DIFF
--- a/doc/classes/VisualScriptEngineSingleton.xml
+++ b/doc/classes/VisualScriptEngineSingleton.xml
@@ -25,7 +25,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="/constant" type="String" setter="set_singleton" getter="get_singleton">
+		<member name="constant" type="String" setter="set_singleton" getter="get_singleton">
 		</member>
 	</members>
 	<constants>

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -2002,7 +2002,7 @@ void VisualScriptEngineSingleton::_bind_methods() {
 		cc += E->get().name;
 	}
 
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "/constant", PROPERTY_HINT_ENUM, cc), "set_singleton", "get_singleton");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "constant", PROPERTY_HINT_ENUM, cc), "set_singleton", "get_singleton");
 }
 
 VisualScriptEngineSingleton::VisualScriptEngineSingleton() {


### PR DESCRIPTION
At least, i think they are typos looking at the other uses and the fact they were called "constant/constant" before.