### PR TITLE
Fix errors in Python 3 build

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -367,13 +367,13 @@ if selected_platform in platform_list:
         if (config.can_build(selected_platform)):
             config.configure(env)
             env.module_list.append(x)
-	    try:
-		 doc_classes = config.get_doc_classes()
-		 doc_path = config.get_doc_path()
-		 for c in doc_classes:
-		     env.doc_class_path[c]="modules/"+x+"/"+doc_path
-	    except:
-		pass
+            try:
+                 doc_classes = config.get_doc_classes()
+                 doc_path = config.get_doc_path()
+                 for c in doc_classes:
+                     env.doc_class_path[c]="modules/"+x+"/"+doc_path
+            except:
+                pass
 
 
         sys.path.remove(tmppath)

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -41,7 +41,7 @@ def make_doc_header(target, source, env):
         src = s.srcnode().abspath
         f = open_utf8(src, "r")
         content = f.read()
-	buf+=content
+        buf+=content
 
     buf = encode_utf8(docbegin + buf + docend)
     decomp_size = len(buf)
@@ -385,13 +385,13 @@ def make_license_header(target, source, env):
 
 
 def _make_doc_data_class_path(to_path):
-      g = open_utf8(os.path.join(to_path,"doc_data_class_path.gen.h"), "wb")
+      g = open_utf8(os.path.join(to_path,"doc_data_class_path.gen.h"), "w")
       g.write("static const int _doc_data_class_path_count="+str(len(env.doc_class_path))+";\n")
       g.write("struct _DocDataClassPath { const char* name; const char* path; };\n")
 
       g.write("static const _DocDataClassPath _doc_data_class_paths["+str(len(env.doc_class_path)+1)+"]={\n");
       for c in env.doc_class_path:
-	  g.write("{\""+c+"\",\""+env.doc_class_path[c]+"\"},\n")
+          g.write("{\""+c+"\",\""+env.doc_class_path[c]+"\"},\n")
       g.write("{NULL,NULL}\n")
       g.write("};\n")
 
@@ -414,7 +414,7 @@ if (env["tools"] == "yes"):
     docs=[]
     print("cdir is: "+env.Dir('#').abspath)
     for f in os.listdir(os.path.join(env.Dir('#').abspath,"doc/classes")):
-	docs.append("#doc/classes/"+f)
+        docs.append("#doc/classes/"+f)
 
     _make_doc_data_class_path(os.path.join(env.Dir('#').abspath,"editor/doc"))
 


### PR DESCRIPTION
- Replaced tabs with spaces since Python 3 doesn't allow mixed indentation.
- Opened a header file in text mode (instead of binary mode) to avoid inserting manual byte/string conversions.