### PR TITLE
Moved class_name and return_val to initializer list

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -277,32 +277,32 @@ MethodInfo::MethodInfo(Variant::Type ret, const String &p_name, const PropertyIn
 MethodInfo::MethodInfo(const PropertyInfo &p_ret, const String &p_name)
 	: name(p_name),
 	  flags(METHOD_FLAG_NORMAL),
+	  return_val(p_ret),
 	  id(0) {
-	return_val = p_ret;
 }
 
 MethodInfo::MethodInfo(const PropertyInfo &p_ret, const String &p_name, const PropertyInfo &p_param1)
 	: name(p_name),
+	  return_val(p_ret),
 	  flags(METHOD_FLAG_NORMAL),
 	  id(0) {
-	return_val = p_ret;
 	arguments.push_back(p_param1);
 }
 
 MethodInfo::MethodInfo(const PropertyInfo &p_ret, const String &p_name, const PropertyInfo &p_param1, const PropertyInfo &p_param2)
 	: name(p_name),
+	  return_val(p_ret),
 	  flags(METHOD_FLAG_NORMAL),
 	  id(0) {
-	return_val = p_ret;
 	arguments.push_back(p_param1);
 	arguments.push_back(p_param2);
 }
 
 MethodInfo::MethodInfo(const PropertyInfo &p_ret, const String &p_name, const PropertyInfo &p_param1, const PropertyInfo &p_param2, const PropertyInfo &p_param3)
 	: name(p_name),
+	  return_val(p_ret),
 	  flags(METHOD_FLAG_NORMAL),
 	  id(0) {
-	return_val = p_ret;
 	arguments.push_back(p_param1);
 	arguments.push_back(p_param2);
 	arguments.push_back(p_param3);
@@ -310,9 +310,9 @@ MethodInfo::MethodInfo(const PropertyInfo &p_ret, const String &p_name, const Pr
 
 MethodInfo::MethodInfo(const PropertyInfo &p_ret, const String &p_name, const PropertyInfo &p_param1, const PropertyInfo &p_param2, const PropertyInfo &p_param3, const PropertyInfo &p_param4)
 	: name(p_name),
+	  return_val(p_ret),
 	  flags(METHOD_FLAG_NORMAL),
 	  id(0) {
-	return_val = p_ret;
 	arguments.push_back(p_param1);
 	arguments.push_back(p_param2);
 	arguments.push_back(p_param3);
@@ -321,9 +321,9 @@ MethodInfo::MethodInfo(const PropertyInfo &p_ret, const String &p_name, const Pr
 
 MethodInfo::MethodInfo(const PropertyInfo &p_ret, const String &p_name, const PropertyInfo &p_param1, const PropertyInfo &p_param2, const PropertyInfo &p_param3, const PropertyInfo &p_param4, const PropertyInfo &p_param5)
 	: name(p_name),
+	  return_val(p_ret),
 	  flags(METHOD_FLAG_NORMAL),
 	  id(0) {
-	return_val = p_ret;
 	arguments.push_back(p_param1);
 	arguments.push_back(p_param2);
 	arguments.push_back(p_param3);

--- a/core/object.h
+++ b/core/object.h
@@ -148,6 +148,7 @@ struct PropertyInfo {
 		  hint(PROPERTY_HINT_NONE),
 		  usage(PROPERTY_USAGE_DEFAULT) {
 	}
+
 	PropertyInfo(Variant::Type p_type, const String p_name, PropertyHint p_hint = PROPERTY_HINT_NONE, const String &p_hint_string = "", uint32_t p_usage = PROPERTY_USAGE_DEFAULT, const StringName &p_class_name = StringName())
 		: type(p_type),
 		  name(p_name),
@@ -161,12 +162,12 @@ struct PropertyInfo {
 			class_name = p_class_name;
 		}
 	}
+
 	PropertyInfo(const StringName &p_class_name)
 		: type(Variant::OBJECT),
+		  class_name(p_class_name),
 		  hint(PROPERTY_HINT_NONE),
 		  usage(PROPERTY_USAGE_DEFAULT) {
-
-		class_name = p_class_name;
 	}
 
 	bool operator<(const PropertyInfo &p_info) const {


### PR DESCRIPTION
This pull request mitigates the following `cppcheck` messages:

```
[core/object.h:169]: (performance) Variable 'class_name' is assigned in constructor body. Consider performing initialization in initialization list.
[core/object.cpp:281]: (performance) Variable 'return_val' is assigned in constructor body. Consider performing initialization in initialization list.
[core/object.cpp:288]: (performance) Variable 'return_val' is assigned in constructor body. Consider performing initialization in initialization list.
[core/object.cpp:296]: (performance) Variable 'return_val' is assigned in constructor body. Consider performing initialization in initialization list.
[core/object.cpp:305]: (performance) Variable 'return_val' is assigned in constructor body. Consider performing initialization in initialization list.
[core/object.cpp:315]: (performance) Variable 'return_val' is assigned in constructor body. Consider performing initialization in initialization list.
[core/object.cpp:326]: (performance) Variable 'return_val' is assigned in constructor body. Consider performing initialization in initialization list.
```