### PR TITLE
Renamed function arguments to keep them consistent between declaration and implementation

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -806,7 +806,7 @@ public:
 
 	void _render_list(RenderList::Element **p_elements, int p_element_count, const Transform &p_view_transform, const CameraMatrix &p_projection, GLuint p_base_env, bool p_reverse_cull, bool p_alpha_pass, bool p_shadow, bool p_directional_add, bool p_directional_shadows);
 
-	_FORCE_INLINE_ void _add_geometry(RasterizerStorageGLES3::Geometry *p_geometry, InstanceBase *p_instance, RasterizerStorageGLES3::GeometryOwner *p_owner, int p_material, bool p_depth_passs);
+	_FORCE_INLINE_ void _add_geometry(RasterizerStorageGLES3::Geometry *p_geometry, InstanceBase *p_instance, RasterizerStorageGLES3::GeometryOwner *p_owner, int p_material, bool p_depth_pass);
 
 	_FORCE_INLINE_ void _add_geometry_with_material(RasterizerStorageGLES3::Geometry *p_geometry, InstanceBase *p_instance, RasterizerStorageGLES3::GeometryOwner *p_owner, RasterizerStorageGLES3::Material *p_material, bool p_depth_pass);
 

--- a/editor/editor_dir_dialog.cpp
+++ b/editor/editor_dir_dialog.cpp
@@ -64,7 +64,7 @@ void EditorDirDialog::_update_dir(TreeItem *p_item, EditorFileSystemDirectory *p
 	}
 }
 
-void EditorDirDialog::reload(const String &p_with_path) {
+void EditorDirDialog::reload(const String &p_path) {
 
 	if (!is_visible_in_tree()) {
 		must_reload = true;
@@ -73,7 +73,7 @@ void EditorDirDialog::reload(const String &p_with_path) {
 
 	tree->clear();
 	TreeItem *root = tree->create_item();
-	_update_dir(root, EditorFileSystem::get_singleton()->get_filesystem(), p_with_path);
+	_update_dir(root, EditorFileSystem::get_singleton()->get_filesystem(), p_path);
 	_item_collapsed(root);
 	must_reload = false;
 }

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3306,9 +3306,9 @@ void EditorNode::_editor_file_dialog_unregister(EditorFileDialog *p_dialog) {
 
 Vector<EditorNodeInitCallback> EditorNode::_init_callbacks;
 
-Error EditorNode::export_preset(const String &preset, const String &p_path, bool p_debug, const String &p_password, bool p_quit_after) {
+Error EditorNode::export_preset(const String &p_preset, const String &p_path, bool p_debug, const String &p_password, bool p_quit_after) {
 
-	export_defer.preset = preset;
+	export_defer.preset = p_preset;
 	export_defer.path = p_path;
 	export_defer.debug = p_debug;
 	export_defer.password = p_password;

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -712,7 +712,7 @@ public:
 
 	void show_warning(const String &p_text, const String &p_title = "Warning!");
 
-	Error export_preset(const String &p_platform, const String &p_path, bool p_debug, const String &p_password, bool p_quit_after = false);
+	Error export_preset(const String &p_preset, const String &p_path, bool p_debug, const String &p_password, bool p_quit_after = false);
 
 	static void register_editor_types();
 	static void unregister_editor_types();

--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -119,7 +119,7 @@ public:
 	virtual void get_import_options(List<ImportOption> *r_options, int p_preset = 0) const;
 	virtual bool get_option_visibility(const String &p_option, const Map<StringName, Variant> &p_options) const;
 
-	void _make_external_resources(Node *p_node, const String &p_base_path, bool p_make_animations, bool p_make_materials, bool p_keep_materials, bool p_make_meshes, Map<Ref<Animation>, Ref<Animation> > &p_animation, Map<Ref<Material>, Ref<Material> > &p_materials, Map<Ref<ArrayMesh>, Ref<ArrayMesh> > &p_meshes);
+	void _make_external_resources(Node *p_node, const String &p_base_path, bool p_make_animations, bool p_make_materials, bool p_keep_materials, bool p_make_meshes, Map<Ref<Animation>, Ref<Animation> > &p_animations, Map<Ref<Material>, Ref<Material> > &p_materials, Map<Ref<ArrayMesh>, Ref<ArrayMesh> > &p_meshes);
 
 	Node *_fix_node(Node *p_node, Node *p_root, Map<Ref<ArrayMesh>, Ref<Shape> > &collision_map);
 

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -315,7 +315,7 @@ class CanvasItemEditor : public VBoxContainer {
 	void _prepare_drag(const Point2 &p_click_pos);
 	DragType _get_anchor_handle_drag_type(const Point2 &p_click, Vector2 &r_point);
 
-	float _anchor_snap(float anchor, bool *snapped = NULL, float p_opposite_anchor = -1);
+	float _anchor_snap(float p_anchor, bool *p_snapped = NULL, float p_opposite_anchor = -1);
 	Vector2 _anchor_to_position(Control *p_control, Vector2 anchor);
 	Vector2 _position_to_anchor(Control *p_control, Vector2 position);
 

--- a/editor/plugins/navigation_mesh_editor_plugin.h
+++ b/editor/plugins/navigation_mesh_editor_plugin.h
@@ -56,7 +56,7 @@ class NavigationMeshEditor : public Control {
 protected:
 	void _node_removed(Node *p_node);
 	static void _bind_methods();
-	void _notification(int p_what);
+	void _notification(int p_option);
 
 public:
 	void edit(NavigationMeshInstance *p_nav_mesh_instance);
@@ -74,8 +74,8 @@ class NavigationMeshEditorPlugin : public EditorPlugin {
 public:
 	virtual String get_name() const { return "NavigationMesh"; }
 	bool has_main_screen() const { return false; }
-	virtual void edit(Object *p_node);
-	virtual bool handles(Object *p_node) const;
+	virtual void edit(Object *p_object);
+	virtual bool handles(Object *p_object) const;
 	virtual void make_visible(bool p_visible);
 
 	NavigationMeshEditorPlugin(EditorNode *p_node);

--- a/editor/plugins/navigation_mesh_generator.h
+++ b/editor/plugins/navigation_mesh_generator.h
@@ -56,7 +56,7 @@ protected:
 			rcPolyMeshDetail *detail_mesh, Vector<float> &verticies, Vector<int> &indices);
 
 public:
-	static void bake(Ref<NavigationMesh> p_nav_mesh, Node *p_base);
+	static void bake(Ref<NavigationMesh> p_nav_mesh, Node *p_node);
 	static void clear(Ref<NavigationMesh> p_nav_mesh);
 };
 

--- a/editor/script_editor_debugger.h
+++ b/editor/script_editor_debugger.h
@@ -150,7 +150,7 @@ class ScriptEditorDebugger : public Control {
 	void _scene_tree_selected();
 	void _scene_tree_request();
 	void _parse_message(const String &p_msg, const Array &p_data);
-	void _set_reason_text(const String &p_msg, MessageType p_type);
+	void _set_reason_text(const String &p_reason, MessageType p_type);
 	void _scene_tree_property_select_object(ObjectID p_object);
 	void _scene_tree_property_value_edited(const String &p_prop, const Variant &p_value);
 

--- a/modules/regex/regex.h
+++ b/modules/regex/regex.h
@@ -87,8 +87,8 @@ public:
 	Error compile(const String &p_pattern);
 	void _init(const String &p_pattern = "");
 
-	Ref<RegExMatch> search(const String &p_subject, int offset = 0, int end = -1) const;
-	String sub(const String &p_subject, const String &p_replacement, bool p_all = false, int p_start = 0, int p_end = -1) const;
+	Ref<RegExMatch> search(const String &p_subject, int p_offset = 0, int p_end = -1) const;
+	String sub(const String &p_subject, const String &p_replacement, bool p_all = false, int p_offset = 0, int p_end = -1) const;
 
 	bool is_valid() const;
 	String get_pattern() const;

--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -128,13 +128,13 @@ Error ImageLoaderSVG::_create_image(Ref<Image> p_image, const PoolVector<uint8_t
 	return OK;
 }
 
-Error ImageLoaderSVG::create_image_from_string(Ref<Image> p_image, const char *svg_str, float p_scale, bool upsample, bool convert_colors) {
+Error ImageLoaderSVG::create_image_from_string(Ref<Image> p_image, const char *p_svg_str, float p_scale, bool upsample, bool convert_colors) {
 
-	size_t str_len = strlen(svg_str);
+	size_t str_len = strlen(p_svg_str);
 	PoolVector<uint8_t> src_data;
 	src_data.resize(str_len + 1);
 	PoolVector<uint8_t>::Write src_w = src_data.write();
-	memcpy(src_w.ptr(), svg_str, str_len + 1);
+	memcpy(src_w.ptr(), p_svg_str, str_len + 1);
 
 	return _create_image(p_image, &src_data, p_scale, upsample, convert_colors);
 }

--- a/modules/svg/image_loader_svg.h
+++ b/modules/svg/image_loader_svg.h
@@ -57,7 +57,7 @@ class ImageLoaderSVG : public ImageFormatLoader {
 		List<uint32_t> new_colors;
 	} replace_colors;
 	static SVGRasterizer rasterizer;
-	static void _convert_colors(NSVGimage *p_svg_imge);
+	static void _convert_colors(NSVGimage *p_svg_image);
 	static Error _create_image(Ref<Image> p_image, const PoolVector<uint8_t> *p_data, float p_scale, bool upsample, bool convert_colors = false);
 
 public:

--- a/scene/3d/light.h
+++ b/scene/3d/light.h
@@ -150,7 +150,7 @@ public:
 	void set_shadow_mode(ShadowMode p_mode);
 	ShadowMode get_shadow_mode() const;
 
-	void set_shadow_depth_range(ShadowDepthRange p_mode);
+	void set_shadow_depth_range(ShadowDepthRange p_range);
 	ShadowDepthRange get_shadow_depth_range() const;
 
 	void set_blend_splits(bool p_enable);

--- a/scene/resources/sky_box.cpp
+++ b/scene/resources/sky_box.cpp
@@ -419,10 +419,10 @@ void ProceduralSky::_queue_update() {
 	call_deferred("_update_sky");
 }
 
-void ProceduralSky::_thread_done(const Ref<Image> &image) {
+void ProceduralSky::_thread_done(const Ref<Image> &p_image) {
 
-	VS::get_singleton()->texture_allocate(texture, image->get_width(), image->get_height(), Image::FORMAT_RGBE9995, VS::TEXTURE_FLAG_FILTER | VS::TEXTURE_FLAG_REPEAT);
-	VS::get_singleton()->texture_set_data(texture, image);
+	VS::get_singleton()->texture_allocate(texture, p_image->get_width(), p_image->get_height(), Image::FORMAT_RGBE9995, VS::TEXTURE_FLAG_FILTER | VS::TEXTURE_FLAG_REPEAT);
+	VS::get_singleton()->texture_set_data(texture, p_image);
 	_radiance_changed();
 	Thread::wait_to_finish(sky_thread);
 	memdelete(sky_thread);

--- a/scene/resources/style_box.h
+++ b/scene/resources/style_box.h
@@ -178,7 +178,7 @@ public:
 	void set_border_width_all(int p_size);
 	int get_border_width_min() const;
 
-	void set_border_width(Margin p_margin, int p_size);
+	void set_border_width(Margin p_margin, int p_width);
 	int get_border_width(Margin p_margin) const;
 
 	//blend
@@ -214,7 +214,7 @@ public:
 	int get_shadow_size() const;
 
 	//ANTI_ALIASING
-	void set_anti_aliased(const bool &p_anit_aliasing);
+	void set_anti_aliased(const bool &p_anti_aliased);
 	bool is_anti_aliased() const;
 	//tempAA
 	void set_aa_size(const int &p_aa_size);

--- a/servers/physics/broad_phase_basic.h
+++ b/servers/physics/broad_phase_basic.h
@@ -82,7 +82,7 @@ class BroadPhaseBasic : public BroadPhaseSW {
 
 public:
 	// 0 is an invalid ID
-	virtual ID create(CollisionObjectSW *p_object_, int p_subindex = 0);
+	virtual ID create(CollisionObjectSW *p_object, int p_subindex = 0);
 	virtual void move(ID p_id, const Rect3 &p_aabb);
 	virtual void set_static(ID p_id, bool p_static);
 	virtual void remove(ID p_id);


### PR DESCRIPTION
This pull request mitigates the following `cppcheck` messages:

```
[drivers/gles3/rasterizer_scene_gles3.h:809] -> [drivers/gles3/rasterizer_scene_gles3.cpp:2164]: (style, inconclusive) Function '_add_geometry' argument 5 names different: declaration 'p_depth_passs' definition 'p_depth_pass'.
[editor/editor_dir_dialog.h:66] -> [editor/editor_dir_dialog.cpp:67]: (style, inconclusive) Function 'reload' argument 1 names different: declaration 'p_path' definition 'p_with_path'.
[editor/editor_node.h:715] -> [editor/editor_node.cpp:3309]: (style, inconclusive) Function 'export_preset' argument 1 names different: declaration 'p_platform' definition 'preset'.
[editor/import/resource_importer_scene.h:122] -> [editor/import/resource_importer_scene.cpp:819]: (style, inconclusive) Function '_make_external_resources' argument 7 names different: declaration 'p_animation' definition 'p_animations'.
[editor/plugins/canvas_item_editor_plugin.h:318] -> [editor/plugins/canvas_item_editor_plugin.cpp:741]: (style, inconclusive) Function '_anchor_snap' argument 1 names different: declaration 'anchor' definition 'p_anchor'.
[editor/plugins/canvas_item_editor_plugin.h:318] -> [editor/plugins/canvas_item_editor_plugin.cpp:741]: (style, inconclusive) Function '_anchor_snap' argument 2 names different: declaration 'snapped' definition 'p_snapped'.
[editor/plugins/navigation_mesh_editor_plugin.h:59] -> [editor/plugins/navigation_mesh_editor_plugin.cpp:47]: (style, inconclusive) Function '_notification' argument 1 names different: declaration 'p_what' definition 'p_option'.
[editor/plugins/navigation_mesh_editor_plugin.h:77] -> [editor/plugins/navigation_mesh_editor_plugin.cpp:129]: (style, inconclusive) Function 'edit' argument 1 names different: declaration 'p_node' definition 'p_object'.
[editor/plugins/navigation_mesh_editor_plugin.h:78] -> [editor/plugins/navigation_mesh_editor_plugin.cpp:134]: (style, inconclusive) Function 'handles' argument 1 names different: declaration 'p_node' definition 'p_object'.
[editor/plugins/navigation_mesh_generator.h:59] -> [editor/plugins/navigation_mesh_generator.cpp:258]: (style, inconclusive) Function 'bake' argument 2 names different: declaration 'p_base' definition 'p_node'.
[editor/script_editor_debugger.h:153] -> [editor/script_editor_debugger.cpp:763]: (style, inconclusive) Function '_set_reason_text' argument 1 names different: declaration 'p_msg' definition 'p_reason'.
[modules/regex/regex.h:90] -> [modules/regex/regex.cpp:231]: (style, inconclusive) Function 'search' argument 2 names different: declaration 'offset' definition 'p_offset'.
[modules/regex/regex.h:90] -> [modules/regex/regex.cpp:231]: (style, inconclusive) Function 'search' argument 3 names different: declaration 'end' definition 'p_end'.
[modules/regex/regex.h:91] -> [modules/regex/regex.cpp:327]: (style, inconclusive) Function 'sub' argument 4 names different: declaration 'p_start' definition 'p_offset'.
[modules/svg/image_loader_svg.h:60] -> [modules/svg/image_loader_svg.cpp:67]: (style, inconclusive) Function '_convert_colors' argument 1 names different: declaration 'p_svg_imge' definition 'p_svg_image'.
[modules/svg/image_loader_svg.h:65] -> [modules/svg/image_loader_svg.cpp:131]: (style, inconclusive) Function 'create_image_from_string' argument 2 names different: declaration 'p_svg_str' definition 'svg_str'.
[scene/3d/light.h:153] -> [scene/3d/light.cpp:310]: (style, inconclusive) Function 'set_shadow_depth_range' argument 1 names different: declaration 'p_mode' definition 'p_range'.
[scene/resources/sky_box.h:129] -> [scene/resources/sky_box.cpp:422]: (style, inconclusive) Function '_thread_done' argument 1 names different: declaration 'p_image' definition 'image'.
[scene/resources/style_box.h:181] -> [scene/resources/style_box.cpp:383]: (style, inconclusive) Function 'set_border_width' argument 2 names different: declaration 'p_size' definition 'p_width'.
[scene/resources/style_box.h:217] -> [scene/resources/style_box.cpp:493]: (style, inconclusive) Function 'set_anti_aliased' argument 1 names different: declaration 'p_anit_aliasing' definition 'p_anti_aliased'.
[servers/physics/broad_phase_basic.h:85] -> [servers/physics/broad_phase_basic.cpp:34]: (style, inconclusive) Function 'create' argument 1 names different: declaration 'p_object_' definition 'p_object'.
```