### PR TITLE
Added adaptive text editor theme

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -599,8 +599,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["global/default_project_export_path"] = PropertyInfo(Variant::STRING, "global/default_project_export_path", PROPERTY_HINT_GLOBAL_DIR);
 	set("interface/show_script_in_scene_tabs", false);
 
-	set("text_editor/theme/color_theme", "Default");
-	hints["text_editor/theme/color_theme"] = PropertyInfo(Variant::STRING, "text_editor/theme/color_theme", PROPERTY_HINT_ENUM, "Default");
+	set("text_editor/theme/color_theme", "Adaptive");
+	hints["text_editor/theme/color_theme"] = PropertyInfo(Variant::STRING, "text_editor/theme/color_theme", PROPERTY_HINT_ENUM, "Adaptive,Default");
 
 	set("text_editor/theme/line_spacing", 4);
 
@@ -924,13 +924,13 @@ void EditorSettings::load_favorites() {
 }
 
 void EditorSettings::list_text_editor_themes() {
-	String themes = "Default";
+	String themes = "Adaptive,Default";
 	DirAccess *d = DirAccess::open(settings_path + "/text_editor_themes");
 	if (d) {
 		d->list_dir_begin();
 		String file = d->get_next();
 		while (file != String()) {
-			if (file.get_extension() == "tet" && file.get_basename().to_lower() != "default") {
+			if (file.get_extension() == "tet" && file.get_basename().to_lower() != "default" && file.get_basename().to_lower() != "adaptive") {
 				themes += "," + file.get_basename();
 			}
 			file = d->get_next();
@@ -942,7 +942,7 @@ void EditorSettings::list_text_editor_themes() {
 }
 
 void EditorSettings::load_text_editor_theme() {
-	if (get("text_editor/theme/color_theme") == "Default") {
+	if (get("text_editor/theme/color_theme") == "Default" || get("text_editor/theme/color_theme") == "Adaptive") {
 		_load_default_text_editor_theme(); // sorry for "Settings changed" console spam
 		return;
 	}
@@ -999,7 +999,7 @@ bool EditorSettings::save_text_editor_theme() {
 
 	String p_file = get("text_editor/theme/color_theme");
 
-	if (p_file.get_file().to_lower() == "default") {
+	if (p_file.get_file().to_lower() == "default" || p_file.get_file().to_lower() == "adaptive") {
 		return false;
 	}
 	String theme_path = get_settings_path() + "/text_editor_themes/" + p_file + ".tet";
@@ -1011,7 +1011,7 @@ bool EditorSettings::save_text_editor_theme_as(String p_file) {
 		p_file += ".tet";
 	}
 
-	if (p_file.get_file().to_lower() == "default.tet") {
+	if (p_file.get_file().to_lower() == "default.tet" || p_file.get_file().to_lower() == "adaptive.tet") {
 		return false;
 	}
 	if (_save_text_editor_theme(p_file)) {

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -634,6 +634,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("normal", "TextEdit", style_widget);
 	theme->set_stylebox("focus", "TextEdit", style_widget_hover);
 	theme->set_constant("side_margin", "TabContainer", 0);
+	theme->set_icon("tab", "TextEdit", theme->get_icon("GuiTab", "EditorIcons"));
 
 	// H/VSplitContainer
 	theme->set_stylebox("bg", "VSplitContainer", make_stylebox(theme->get_icon("GuiVsplitBg", "EditorIcons"), 1, 1, 1, 1));
@@ -781,6 +782,80 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	// FileDialog
 	theme->set_color("files_disabled", "FileDialog", font_color_disabled);
+
+	// adaptive script theme constants
+	// for comments and elements with lower relevance
+	const Color dim_color = Color(font_color.r, font_color.g, font_color.b, 0.5);
+
+	const float mono_value = mono_color.r;
+	const Color alpha1 = Color(mono_value, mono_value, mono_value, 0.1);
+	const Color alpha2 = Color(mono_value, mono_value, mono_value, 0.3);
+	const Color alpha3 = Color(mono_value, mono_value, mono_value, 0.5);
+	const Color alpha4 = Color(mono_value, mono_value, mono_value, 0.7);
+
+	// editor main color
+	const Color main_color = Color::html(dark_theme ? "#57b3ff" : "#0480ff");
+
+	const Color symbol_color = Color::html("#5792ff").linear_interpolate(mono_color, dark_theme ? 0.5 : 0.3);
+	const Color keyword_color = main_color.linear_interpolate(mono_color, 0.4);
+	const Color basetype_color = Color::html(dark_theme ? "#42ffc2" : "#00c161");
+	const Color type_color = basetype_color.linear_interpolate(mono_color, dark_theme ? 0.7 : 0.5);
+	const Color comment_color = dim_color;
+	const Color string_color = Color::html(dark_theme ? "#ffd942" : "#ffd118").linear_interpolate(mono_color, dark_theme ? 0.5 : 0.3);
+
+	const Color te_background_color = Color(0, 0, 0, 0);
+	const Color completion_background_color = base_color;
+	const Color completion_selected_color = alpha1;
+	const Color completion_existing_color = alpha2;
+	const Color completion_scroll_color = alpha1;
+	const Color completion_font_color = font_color;
+	const Color text_color = font_color;
+	const Color line_number_color = dim_color;
+	const Color caret_color = mono_color;
+	const Color caret_background_color = mono_color.inverted();
+	const Color text_selected_color = dark_color_3;
+	const Color selection_color = alpha3;
+	const Color brace_mismatch_color = error_color;
+	const Color current_line_color = alpha1;
+	const Color line_length_guideline_color = warning_color;
+	const Color word_highlighted_color = alpha1;
+	const Color number_color = basetype_color.linear_interpolate(mono_color, dark_theme ? 0.5 : 0.3);
+	const Color function_color = main_color;
+	const Color member_variable_color = mono_color;
+	const Color mark_color = Color(error_color.r, error_color.g, error_color.b, 0.3);
+	const Color breakpoint_color = error_color;
+	const Color search_result_color = alpha1;
+	const Color search_result_border_color = alpha4;
+
+	theme->set_color("text_editor/theme/symbol_color", "Editor", symbol_color);
+	theme->set_color("text_editor/theme/keyword_color", "Editor", keyword_color);
+	theme->set_color("text_editor/theme/basetype_color", "Editor", basetype_color);
+	theme->set_color("text_editor/theme/type_color", "Editor", type_color);
+	theme->set_color("text_editor/theme/comment_color", "Editor", comment_color);
+	theme->set_color("text_editor/theme/string_color", "Editor", string_color);
+	theme->set_color("text_editor/theme/background_color", "Editor", te_background_color);
+	theme->set_color("text_editor/theme/completion_background_color", "Editor", completion_background_color);
+	theme->set_color("text_editor/theme/completion_selected_color", "Editor", completion_selected_color);
+	theme->set_color("text_editor/theme/completion_existing_color", "Editor", completion_existing_color);
+	theme->set_color("text_editor/theme/completion_scroll_color", "Editor", completion_scroll_color);
+	theme->set_color("text_editor/theme/completion_font_color", "Editor", completion_font_color);
+	theme->set_color("text_editor/theme/text_color", "Editor", text_color);
+	theme->set_color("text_editor/theme/line_number_color", "Editor", line_number_color);
+	theme->set_color("text_editor/theme/caret_color", "Editor", caret_color);
+	theme->set_color("text_editor/theme/caret_background_color", "Editor", caret_background_color);
+	theme->set_color("text_editor/theme/text_selected_color", "Editor", text_selected_color);
+	theme->set_color("text_editor/theme/selection_color", "Editor", selection_color);
+	theme->set_color("text_editor/theme/brace_mismatch_color", "Editor", brace_mismatch_color);
+	theme->set_color("text_editor/theme/current_line_color", "Editor", current_line_color);
+	theme->set_color("text_editor/theme/line_length_guideline_color", "Editor", line_length_guideline_color);
+	theme->set_color("text_editor/theme/word_highlighted_color", "Editor", word_highlighted_color);
+	theme->set_color("text_editor/theme/number_color", "Editor", number_color);
+	theme->set_color("text_editor/theme/function_color", "Editor", function_color);
+	theme->set_color("text_editor/theme/member_variable_color", "Editor", member_variable_color);
+	theme->set_color("text_editor/theme/mark_color", "Editor", mark_color);
+	theme->set_color("text_editor/theme/breakpoint_color", "Editor", breakpoint_color);
+	theme->set_color("text_editor/theme/search_result_color", "Editor", search_result_color);
+	theme->set_color("text_editor/theme/search_result_border_color", "Editor", search_result_border_color);
 
 	return theme;
 }

--- a/editor/icons/icon_GUI_tab.svg
+++ b/editor/icons/icon_GUI_tab.svg
@@ -1,0 +1,5 @@
+<svg width="8" height="8" version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg">
+<g transform="translate(0 -1044.4)">
+<path transform="translate(0 1044.4)" d="m6 0v8h2v-8h-2zm-5.0137 0.0019531a1 1 0 0 0 -0.69336 0.29102 1 1 0 0 0 0 1.4141l2.293 2.293-2.293 2.293a1 1 0 0 0 0 1.4141 1 1 0 0 0 1.4141 0l3-3a1.0001 1.0001 0 0 0 0 -1.4141l-3-3a1 1 0 0 0 -0.7207 -0.29102z" fill="#fff" fill-opacity=".19608"/>
+</g>
+</svg>

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -75,35 +75,98 @@ void ScriptTextEditor::_load_theme_settings() {
 
 	text_edit->clear_colors();
 
-	/* keyword color */
-
-	text_edit->add_color_override("background_color", EDITOR_DEF("text_editor/highlighting/background_color", Color(0, 0, 0, 0)));
-	text_edit->add_color_override("completion_background_color", EDITOR_DEF("text_editor/highlighting/completion_background_color", Color(0, 0, 0, 0)));
-	text_edit->add_color_override("completion_selected_color", EDITOR_DEF("text_editor/highlighting/completion_selected_color", Color::html("434244")));
-	text_edit->add_color_override("completion_existing_color", EDITOR_DEF("text_editor/highlighting/completion_existing_color", Color::html("21dfdfdf")));
-	text_edit->add_color_override("completion_scroll_color", EDITOR_DEF("text_editor/highlighting/completion_scroll_color", Color::html("ffffff")));
-	text_edit->add_color_override("completion_font_color", EDITOR_DEF("text_editor/highlighting/completion_font_color", Color::html("aaaaaa")));
-	text_edit->add_color_override("font_color", EDITOR_DEF("text_editor/highlighting/text_color", Color(0, 0, 0)));
-	text_edit->add_color_override("line_number_color", EDITOR_DEF("text_editor/highlighting/line_number_color", Color(0, 0, 0)));
-	text_edit->add_color_override("caret_color", EDITOR_DEF("text_editor/highlighting/caret_color", Color(0, 0, 0)));
-	text_edit->add_color_override("caret_background_color", EDITOR_DEF("text_editor/highlighting/caret_background_color", Color(0, 0, 0)));
-	text_edit->add_color_override("font_selected_color", EDITOR_DEF("text_editor/highlighting/text_selected_color", Color(1, 1, 1)));
-	text_edit->add_color_override("selection_color", EDITOR_DEF("text_editor/highlighting/selection_color", Color(0.2, 0.2, 1)));
-	text_edit->add_color_override("brace_mismatch_color", EDITOR_DEF("text_editor/highlighting/brace_mismatch_color", Color(1, 0.2, 0.2)));
-	text_edit->add_color_override("current_line_color", EDITOR_DEF("text_editor/highlighting/current_line_color", Color(0.3, 0.5, 0.8, 0.15)));
-	text_edit->add_color_override("line_length_guideline_color", EDITOR_DEF("text_editor/highlighting/line_length_guideline_color", Color(0, 0, 0)));
-	text_edit->add_color_override("word_highlighted_color", EDITOR_DEF("text_editor/highlighting/word_highlighted_color", Color(0.8, 0.9, 0.9, 0.15)));
-	text_edit->add_color_override("number_color", EDITOR_DEF("text_editor/highlighting/number_color", Color(0.9, 0.6, 0.0, 2)));
-	text_edit->add_color_override("function_color", EDITOR_DEF("text_editor/highlighting/function_color", Color(0.4, 0.6, 0.8)));
-	text_edit->add_color_override("member_variable_color", EDITOR_DEF("text_editor/highlighting/member_variable_color", Color(0.9, 0.3, 0.3)));
-	text_edit->add_color_override("mark_color", EDITOR_DEF("text_editor/highlighting/mark_color", Color(1.0, 0.4, 0.4, 0.4)));
-	text_edit->add_color_override("breakpoint_color", EDITOR_DEF("text_editor/highlighting/breakpoint_color", Color(0.8, 0.8, 0.4, 0.2)));
-	text_edit->add_color_override("search_result_color", EDITOR_DEF("text_editor/highlighting/search_result_color", Color(0.05, 0.25, 0.05, 1)));
-	text_edit->add_color_override("search_result_border_color", EDITOR_DEF("text_editor/highlighting/search_result_border_color", Color(0.1, 0.45, 0.1, 1)));
-	text_edit->add_color_override("symbol_color", EDITOR_DEF("text_editor/highlighting/symbol_color", Color::hex(0x005291ff)));
-	text_edit->add_constant_override("line_spacing", EDITOR_DEF("text_editor/theme/line_spacing", 4));
+	Color background_color = EDITOR_DEF("text_editor/highlighting/background_color", Color(0, 0, 0, 0));
+	Color completion_background_color = EDITOR_DEF("text_editor/highlighting/completion_background_color", Color(0, 0, 0, 0));
+	Color completion_selected_color = EDITOR_DEF("text_editor/highlighting/completion_selected_color", Color::html("434244"));
+	Color completion_existing_color = EDITOR_DEF("text_editor/highlighting/completion_existing_color", Color::html("21dfdfdf"));
+	Color completion_scroll_color = EDITOR_DEF("text_editor/highlighting/completion_scroll_color", Color::html("ffffff"));
+	Color completion_font_color = EDITOR_DEF("text_editor/highlighting/completion_font_color", Color::html("aaaaaa"));
+	Color text_color = EDITOR_DEF("text_editor/highlighting/text_color", Color(0, 0, 0));
+	Color line_number_color = EDITOR_DEF("text_editor/highlighting/line_number_color", Color(0, 0, 0));
+	Color caret_color = EDITOR_DEF("text_editor/highlighting/caret_color", Color(0, 0, 0));
+	Color caret_background_color = EDITOR_DEF("text_editor/highlighting/caret_background_color", Color(0, 0, 0));
+	Color text_selected_color = EDITOR_DEF("text_editor/highlighting/text_selected_color", Color(1, 1, 1));
+	Color selection_color = EDITOR_DEF("text_editor/highlighting/selection_color", Color(0.2, 0.2, 1));
+	Color brace_mismatch_color = EDITOR_DEF("text_editor/highlighting/brace_mismatch_color", Color(1, 0.2, 0.2));
+	Color current_line_color = EDITOR_DEF("text_editor/highlighting/current_line_color", Color(0.3, 0.5, 0.8, 0.15));
+	Color line_length_guideline_color = EDITOR_DEF("text_editor/highlighting/line_length_guideline_color", Color(0, 0, 0));
+	Color word_highlighted_color = EDITOR_DEF("text_editor/highlighting/word_highlighted_color", Color(0.8, 0.9, 0.9, 0.15));
+	Color number_color = EDITOR_DEF("text_editor/highlighting/number_color", Color(0.9, 0.6, 0.0, 2));
+	Color function_color = EDITOR_DEF("text_editor/highlighting/function_color", Color(0.4, 0.6, 0.8));
+	Color member_variable_color = EDITOR_DEF("text_editor/highlighting/member_variable_color", Color(0.9, 0.3, 0.3));
+	Color mark_color = EDITOR_DEF("text_editor/highlighting/mark_color", Color(1.0, 0.4, 0.4, 0.4));
+	Color breakpoint_color = EDITOR_DEF("text_editor/highlighting/breakpoint_color", Color(0.8, 0.8, 0.4, 0.2));
+	Color search_result_color = EDITOR_DEF("text_editor/highlighting/search_result_color", Color(0.05, 0.25, 0.05, 1));
+	Color search_result_border_color = EDITOR_DEF("text_editor/highlighting/search_result_border_color", Color(0.1, 0.45, 0.1, 1));
+	Color symbol_color = EDITOR_DEF("text_editor/highlighting/symbol_color", Color::hex(0x005291ff));
 
 	Color keyword_color = EDITOR_DEF("text_editor/highlighting/keyword_color", Color(0.5, 0.0, 0.2));
+	Color basetype_color = EDITOR_DEF("text_editor/highlighting/base_type_color", Color(0.3, 0.3, 0.0));
+	Color type_color = EDITOR_DEF("text_editor/highlighting/engine_type_color", Color(0.0, 0.2, 0.4));
+	Color comment_color = EDITOR_DEF("text_editor/highlighting/comment_color", Color::hex(0x797e7eff));
+	Color string_color = EDITOR_DEF("text_editor/highlighting/string_color", Color::hex(0x6b6f00ff));
+
+	// Adapt
+	if (EditorSettings::get_singleton()->get("text_editor/theme/color_theme") == "Adaptive") {
+		Ref<Theme> tm = EditorNode::get_singleton()->get_theme_base()->get_theme();
+
+		symbol_color = tm->get_color("text_editor/theme/symbol_color", "Editor");
+		keyword_color = tm->get_color("text_editor/theme/keyword_color", "Editor");
+		basetype_color = tm->get_color("text_editor/theme/basetype_color", "Editor");
+		type_color = tm->get_color("text_editor/theme/type_color", "Editor");
+		comment_color = tm->get_color("text_editor/theme/comment_color", "Editor");
+		string_color = tm->get_color("text_editor/theme/string_color", "Editor");
+		background_color = tm->get_color("text_editor/theme/background_color", "Editor");
+		completion_background_color = tm->get_color("text_editor/theme/completion_background_color", "Editor");
+		completion_selected_color = tm->get_color("text_editor/theme/completion_selected_color", "Editor");
+		completion_existing_color = tm->get_color("text_editor/theme/completion_existing_color", "Editor");
+		completion_scroll_color = tm->get_color("text_editor/theme/completion_scroll_color", "Editor");
+		completion_font_color = tm->get_color("text_editor/theme/completion_font_color", "Editor");
+		text_color = tm->get_color("text_editor/theme/text_color", "Editor");
+		line_number_color = tm->get_color("text_editor/theme/line_number_color", "Editor");
+		caret_color = tm->get_color("text_editor/theme/caret_color", "Editor");
+		caret_background_color = tm->get_color("text_editor/theme/caret_background_color", "Editor");
+		text_selected_color = tm->get_color("text_editor/theme/text_selected_color", "Editor");
+		selection_color = tm->get_color("text_editor/theme/selection_color", "Editor");
+		brace_mismatch_color = tm->get_color("text_editor/theme/brace_mismatch_color", "Editor");
+		current_line_color = tm->get_color("text_editor/theme/current_line_color", "Editor");
+		line_length_guideline_color = tm->get_color("text_editor/theme/line_length_guideline_color", "Editor");
+		word_highlighted_color = tm->get_color("text_editor/theme/word_highlighted_color", "Editor");
+		number_color = tm->get_color("text_editor/theme/number_color", "Editor");
+		function_color = tm->get_color("text_editor/theme/function_color", "Editor");
+		member_variable_color = tm->get_color("text_editor/theme/member_variable_color", "Editor");
+		mark_color = tm->get_color("text_editor/theme/mark_color", "Editor");
+		breakpoint_color = tm->get_color("text_editor/theme/breakpoint_color", "Editor");
+		search_result_color = tm->get_color("text_editor/theme/search_result_color", "Editor");
+		search_result_border_color = tm->get_color("text_editor/theme/search_result_border_color", "Editor");
+	}
+
+	text_edit->add_color_override("background_color", background_color);
+	text_edit->add_color_override("completion_background_color", completion_background_color);
+	text_edit->add_color_override("completion_selected_color", completion_selected_color);
+	text_edit->add_color_override("completion_existing_color", completion_existing_color);
+	text_edit->add_color_override("completion_scroll_color", completion_scroll_color);
+	text_edit->add_color_override("completion_font_color", completion_font_color);
+	text_edit->add_color_override("font_color", text_color);
+	text_edit->add_color_override("line_number_color", line_number_color);
+	text_edit->add_color_override("caret_color", caret_color);
+	text_edit->add_color_override("caret_background_color", caret_background_color);
+	text_edit->add_color_override("font_selected_color", text_selected_color);
+	text_edit->add_color_override("selection_color", selection_color);
+	text_edit->add_color_override("brace_mismatch_color", brace_mismatch_color);
+	text_edit->add_color_override("current_line_color", current_line_color);
+	text_edit->add_color_override("line_length_guideline_color", line_length_guideline_color);
+	text_edit->add_color_override("word_highlighted_color", word_highlighted_color);
+	text_edit->add_color_override("number_color", number_color);
+	text_edit->add_color_override("function_color", function_color);
+	text_edit->add_color_override("member_variable_color", member_variable_color);
+	text_edit->add_color_override("mark_color", mark_color);
+	text_edit->add_color_override("breakpoint_color", breakpoint_color);
+	text_edit->add_color_override("search_result_color", search_result_color);
+	text_edit->add_color_override("search_result_border_color", search_result_border_color);
+	text_edit->add_color_override("symbol_color", symbol_color);
+
+	text_edit->add_constant_override("line_spacing", EDITOR_DEF("text_editor/theme/line_spacing", 4));
 
 	List<String> keywords;
 	script->get_language()->get_reserved_words(&keywords);
@@ -113,8 +176,6 @@ void ScriptTextEditor::_load_theme_settings() {
 	}
 
 	//colorize core types
-	Color basetype_color = EDITOR_DEF("text_editor/highlighting/base_type_color", Color(0.3, 0.3, 0.0));
-
 	text_edit->add_keyword_color("String", basetype_color);
 	text_edit->add_keyword_color("Vector2", basetype_color);
 	text_edit->add_keyword_color("Rect2", basetype_color);
@@ -140,8 +201,6 @@ void ScriptTextEditor::_load_theme_settings() {
 	text_edit->add_keyword_color("PoolColorArray", basetype_color);
 
 	//colorize engine types
-	Color type_color = EDITOR_DEF("text_editor/highlighting/engine_type_color", Color(0.0, 0.2, 0.4));
-
 	List<StringName> types;
 	ClassDB::get_class_list(&types);
 
@@ -155,7 +214,6 @@ void ScriptTextEditor::_load_theme_settings() {
 	}
 
 	//colorize comments
-	Color comment_color = EDITOR_DEF("text_editor/highlighting/comment_color", Color::hex(0x797e7eff));
 	List<String> comments;
 	script->get_language()->get_comment_delimiters(&comments);
 
@@ -169,7 +227,6 @@ void ScriptTextEditor::_load_theme_settings() {
 	}
 
 	//colorize strings
-	Color string_color = EDITOR_DEF("text_editor/highlighting/string_color", Color::hex(0x6b6f00ff));
 	List<String> strings;
 	script->get_language()->get_string_delimiters(&strings);
 
@@ -209,6 +266,7 @@ void ScriptTextEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_READY) {
 
 		//emit_signal("name_changed");
+		_load_theme_settings();
 	}
 }
 
@@ -491,8 +549,6 @@ void ScriptTextEditor::set_edited_script(const Ref<Script> &p_script) {
 	ERR_FAIL_COND(!script.is_null());
 
 	script = p_script;
-
-	_load_theme_settings();
 
 	code_editor->get_text_edit()->set_text(script->get_source_code());
 	code_editor->get_text_edit()->clear_undo_history();

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -60,33 +60,96 @@ void ShaderTextEditor::_load_theme_settings() {
 
 	get_text_edit()->clear_colors();
 
-	/* keyword color */
-
-	get_text_edit()->add_color_override("background_color", EDITOR_DEF("text_editor/highlighting/background_color", Color(0, 0, 0, 0)));
-	get_text_edit()->add_color_override("completion_background_color", EDITOR_DEF("text_editor/highlighting/completion_background_color", Color(0, 0, 0, 0)));
-	get_text_edit()->add_color_override("completion_selected_color", EDITOR_DEF("text_editor/highlighting/completion_selected_color", Color::html("434244")));
-	get_text_edit()->add_color_override("completion_existing_color", EDITOR_DEF("text_editor/highlighting/completion_existing_color", Color::html("21dfdfdf")));
-	get_text_edit()->add_color_override("completion_scroll_color", EDITOR_DEF("text_editor/highlighting/completion_scroll_color", Color::html("ffffff")));
-	get_text_edit()->add_color_override("completion_font_color", EDITOR_DEF("text_editor/highlighting/completion_font_color", Color::html("aaaaaa")));
-	get_text_edit()->add_color_override("font_color", EDITOR_DEF("text_editor/highlighting/text_color", Color(0, 0, 0)));
-	get_text_edit()->add_color_override("line_number_color", EDITOR_DEF("text_editor/highlighting/line_number_color", Color(0, 0, 0)));
-	get_text_edit()->add_color_override("caret_color", EDITOR_DEF("text_editor/highlighting/caret_color", Color(0, 0, 0)));
-	get_text_edit()->add_color_override("caret_background_color", EDITOR_DEF("text_editor/highlighting/caret_background_color", Color(0, 0, 0)));
-	get_text_edit()->add_color_override("font_selected_color", EDITOR_DEF("text_editor/highlighting/text_selected_color", Color(1, 1, 1)));
-	get_text_edit()->add_color_override("selection_color", EDITOR_DEF("text_editor/highlighting/selection_color", Color(0.2, 0.2, 1)));
-	get_text_edit()->add_color_override("brace_mismatch_color", EDITOR_DEF("text_editor/highlighting/brace_mismatch_color", Color(1, 0.2, 0.2)));
-	get_text_edit()->add_color_override("current_line_color", EDITOR_DEF("text_editor/highlighting/current_line_color", Color(0.3, 0.5, 0.8, 0.15)));
-	get_text_edit()->add_color_override("word_highlighted_color", EDITOR_DEF("text_editor/highlighting/word_highlighted_color", Color(0.8, 0.9, 0.9, 0.15)));
-	get_text_edit()->add_color_override("number_color", EDITOR_DEF("text_editor/highlighting/number_color", Color(0.9, 0.6, 0.0, 2)));
-	get_text_edit()->add_color_override("function_color", EDITOR_DEF("text_editor/highlighting/function_color", Color(0.4, 0.6, 0.8)));
-	get_text_edit()->add_color_override("member_variable_color", EDITOR_DEF("text_editor/highlighting/member_variable_color", Color(0.9, 0.3, 0.3)));
-	get_text_edit()->add_color_override("mark_color", EDITOR_DEF("text_editor/highlighting/mark_color", Color(1.0, 0.4, 0.4, 0.4)));
-	get_text_edit()->add_color_override("breakpoint_color", EDITOR_DEF("text_editor/highlighting/breakpoint_color", Color(0.8, 0.8, 0.4, 0.2)));
-	get_text_edit()->add_color_override("search_result_color", EDITOR_DEF("text_editor/highlighting/search_result_color", Color(0.05, 0.25, 0.05, 1)));
-	get_text_edit()->add_color_override("search_result_border_color", EDITOR_DEF("text_editor/highlighting/search_result_border_color", Color(0.1, 0.45, 0.1, 1)));
-	get_text_edit()->add_color_override("symbol_color", EDITOR_DEF("text_editor/highlighting/symbol_color", Color::hex(0x005291ff)));
+	Color background_color = EDITOR_DEF("text_editor/highlighting/background_color", Color(0, 0, 0, 0));
+	Color completion_background_color = EDITOR_DEF("text_editor/highlighting/completion_background_color", Color(0, 0, 0, 0));
+	Color completion_selected_color = EDITOR_DEF("text_editor/highlighting/completion_selected_color", Color::html("434244"));
+	Color completion_existing_color = EDITOR_DEF("text_editor/highlighting/completion_existing_color", Color::html("21dfdfdf"));
+	Color completion_scroll_color = EDITOR_DEF("text_editor/highlighting/completion_scroll_color", Color::html("ffffff"));
+	Color completion_font_color = EDITOR_DEF("text_editor/highlighting/completion_font_color", Color::html("aaaaaa"));
+	Color text_color = EDITOR_DEF("text_editor/highlighting/text_color", Color(0, 0, 0));
+	Color line_number_color = EDITOR_DEF("text_editor/highlighting/line_number_color", Color(0, 0, 0));
+	Color caret_color = EDITOR_DEF("text_editor/highlighting/caret_color", Color(0, 0, 0));
+	Color caret_background_color = EDITOR_DEF("text_editor/highlighting/caret_background_color", Color(0, 0, 0));
+	Color text_selected_color = EDITOR_DEF("text_editor/highlighting/text_selected_color", Color(1, 1, 1));
+	Color selection_color = EDITOR_DEF("text_editor/highlighting/selection_color", Color(0.2, 0.2, 1));
+	Color brace_mismatch_color = EDITOR_DEF("text_editor/highlighting/brace_mismatch_color", Color(1, 0.2, 0.2));
+	Color current_line_color = EDITOR_DEF("text_editor/highlighting/current_line_color", Color(0.3, 0.5, 0.8, 0.15));
+	Color line_length_guideline_color = EDITOR_DEF("text_editor/highlighting/line_length_guideline_color", Color(0, 0, 0));
+	Color word_highlighted_color = EDITOR_DEF("text_editor/highlighting/word_highlighted_color", Color(0.8, 0.9, 0.9, 0.15));
+	Color number_color = EDITOR_DEF("text_editor/highlighting/number_color", Color(0.9, 0.6, 0.0, 2));
+	Color function_color = EDITOR_DEF("text_editor/highlighting/function_color", Color(0.4, 0.6, 0.8));
+	Color member_variable_color = EDITOR_DEF("text_editor/highlighting/member_variable_color", Color(0.9, 0.3, 0.3));
+	Color mark_color = EDITOR_DEF("text_editor/highlighting/mark_color", Color(1.0, 0.4, 0.4, 0.4));
+	Color breakpoint_color = EDITOR_DEF("text_editor/highlighting/breakpoint_color", Color(0.8, 0.8, 0.4, 0.2));
+	Color search_result_color = EDITOR_DEF("text_editor/highlighting/search_result_color", Color(0.05, 0.25, 0.05, 1));
+	Color search_result_border_color = EDITOR_DEF("text_editor/highlighting/search_result_border_color", Color(0.1, 0.45, 0.1, 1));
+	Color symbol_color = EDITOR_DEF("text_editor/highlighting/symbol_color", Color::hex(0x005291ff));
 
 	Color keyword_color = EDITOR_DEF("text_editor/highlighting/keyword_color", Color(0.5, 0.0, 0.2));
+	Color basetype_color = EDITOR_DEF("text_editor/highlighting/base_type_color", Color(0.3, 0.3, 0.0));
+	Color type_color = EDITOR_DEF("text_editor/highlighting/engine_type_color", Color(0.0, 0.2, 0.4));
+	Color comment_color = EDITOR_DEF("text_editor/highlighting/comment_color", Color::hex(0x797e7eff));
+	Color string_color = EDITOR_DEF("text_editor/highlighting/string_color", Color::hex(0x6b6f00ff));
+
+	// Adapt
+	if (EditorSettings::get_singleton()->get("text_editor/theme/color_theme") == "Adaptive") {
+		Ref<Theme> tm = EditorNode::get_singleton()->get_theme_base()->get_theme();
+
+		symbol_color = tm->get_color("text_editor/theme/symbol_color", "Editor");
+		keyword_color = tm->get_color("text_editor/theme/keyword_color", "Editor");
+		basetype_color = tm->get_color("text_editor/theme/basetype_color", "Editor");
+		type_color = tm->get_color("text_editor/theme/type_color", "Editor");
+		comment_color = tm->get_color("text_editor/theme/comment_color", "Editor");
+		string_color = tm->get_color("text_editor/theme/string_color", "Editor");
+		background_color = tm->get_color("text_editor/theme/background_color", "Editor");
+		completion_background_color = tm->get_color("text_editor/theme/completion_background_color", "Editor");
+		completion_selected_color = tm->get_color("text_editor/theme/completion_selected_color", "Editor");
+		completion_existing_color = tm->get_color("text_editor/theme/completion_existing_color", "Editor");
+		completion_scroll_color = tm->get_color("text_editor/theme/completion_scroll_color", "Editor");
+		completion_font_color = tm->get_color("text_editor/theme/completion_font_color", "Editor");
+		text_color = tm->get_color("text_editor/theme/text_color", "Editor");
+		line_number_color = tm->get_color("text_editor/theme/line_number_color", "Editor");
+		caret_color = tm->get_color("text_editor/theme/caret_color", "Editor");
+		caret_background_color = tm->get_color("text_editor/theme/caret_background_color", "Editor");
+		text_selected_color = tm->get_color("text_editor/theme/text_selected_color", "Editor");
+		selection_color = tm->get_color("text_editor/theme/selection_color", "Editor");
+		brace_mismatch_color = tm->get_color("text_editor/theme/brace_mismatch_color", "Editor");
+		current_line_color = tm->get_color("text_editor/theme/current_line_color", "Editor");
+		line_length_guideline_color = tm->get_color("text_editor/theme/line_length_guideline_color", "Editor");
+		word_highlighted_color = tm->get_color("text_editor/theme/word_highlighted_color", "Editor");
+		number_color = tm->get_color("text_editor/theme/number_color", "Editor");
+		function_color = tm->get_color("text_editor/theme/function_color", "Editor");
+		member_variable_color = tm->get_color("text_editor/theme/member_variable_color", "Editor");
+		mark_color = tm->get_color("text_editor/theme/mark_color", "Editor");
+		breakpoint_color = tm->get_color("text_editor/theme/breakpoint_color", "Editor");
+		search_result_color = tm->get_color("text_editor/theme/search_result_color", "Editor");
+		search_result_border_color = tm->get_color("text_editor/theme/search_result_border_color", "Editor");
+	}
+
+	get_text_edit()->add_color_override("background_color", background_color);
+	get_text_edit()->add_color_override("completion_background_color", completion_background_color);
+	get_text_edit()->add_color_override("completion_selected_color", completion_selected_color);
+	get_text_edit()->add_color_override("completion_existing_color", completion_existing_color);
+	get_text_edit()->add_color_override("completion_scroll_color", completion_scroll_color);
+	get_text_edit()->add_color_override("completion_font_color", completion_font_color);
+	get_text_edit()->add_color_override("font_color", text_color);
+	get_text_edit()->add_color_override("line_number_color", line_number_color);
+	get_text_edit()->add_color_override("caret_color", caret_color);
+	get_text_edit()->add_color_override("caret_background_color", caret_background_color);
+	get_text_edit()->add_color_override("font_selected_color", text_selected_color);
+	get_text_edit()->add_color_override("selection_color", selection_color);
+	get_text_edit()->add_color_override("brace_mismatch_color", brace_mismatch_color);
+	get_text_edit()->add_color_override("current_line_color", current_line_color);
+	get_text_edit()->add_color_override("line_length_guideline_color", line_length_guideline_color);
+	get_text_edit()->add_color_override("word_highlighted_color", word_highlighted_color);
+	get_text_edit()->add_color_override("number_color", number_color);
+	get_text_edit()->add_color_override("function_color", function_color);
+	get_text_edit()->add_color_override("member_variable_color", member_variable_color);
+	get_text_edit()->add_color_override("mark_color", mark_color);
+	get_text_edit()->add_color_override("breakpoint_color", breakpoint_color);
+	get_text_edit()->add_color_override("search_result_color", search_result_color);
+	get_text_edit()->add_color_override("search_result_border_color", search_result_border_color);
+	get_text_edit()->add_color_override("symbol_color", symbol_color);
 
 	List<String> keywords;
 	ShaderLanguage::get_keyword_list(&keywords);
@@ -115,8 +178,6 @@ void ShaderTextEditor::_load_theme_settings() {
 	//Color basetype_color= EDITOR_DEF("text_editor/base_type_color",Color(0.3,0.3,0.0));
 
 	//colorize comments
-	Color comment_color = EDITOR_DEF("text_editor/highlighting/comment_color", Color::hex(0x797e7eff));
-
 	get_text_edit()->add_color_region("/*", "*/", comment_color, false);
 	get_text_edit()->add_color_region("//", "", comment_color, false);
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 #include "text_edit.h"
 
+#include "editor/editor_scale.h"
 #include "message_queue.h"
 #include "os/input.h"
 #include "os/keyboard.h"
@@ -729,13 +730,12 @@ void TextEdit::_notification(int p_what) {
 					VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(xmargin_beg, ofs_y, xmargin_end - xmargin_beg, get_row_height()), cache.mark_color);
 				}
 
-				if (text.is_breakpoint(line)) {
-
-					VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(xmargin_beg, ofs_y, xmargin_end - xmargin_beg, get_row_height()), cache.breakpoint_color);
-				}
-
 				if (line == cursor.line) {
 					VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(0, ofs_y, xmargin_end, get_row_height()), cache.current_line_color);
+				}
+
+				if (text.is_breakpoint(line) && !draw_breakpoint_gutter) {
+					VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(xmargin_beg, ofs_y + get_row_height() - EDSCALE, xmargin_end - xmargin_beg, EDSCALE), cache.breakpoint_color);
 				}
 
 				// draw breakpoint marker


### PR DESCRIPTION
Added text editor theme that adapts according to the current theme.

**Edit**: also works with shader editor.

![screenshot from 2017-09-14 19-39-29](https://user-images.githubusercontent.com/1103897/30461952-d37bd260-9987-11e7-9a70-966d637e957f.png)
![screenshot from 2017-09-14 19-39-46](https://user-images.githubusercontent.com/1103897/30461954-d687412e-9987-11e7-8680-c2430a0c8e9b.png)
