### PR TITLE
Specify sampler precision where missing

### DIFF
--- a/drivers/gles3/shaders/cubemap_filter.glsl
+++ b/drivers/gles3/shaders/cubemap_filter.glsl
@@ -24,7 +24,7 @@ uniform sampler2D source_panorama; //texunit:0
 #endif
 
 #ifdef USE_SOURCE_DUAL_PARABOLOID_ARRAY
-uniform sampler2DArray source_dual_paraboloid_array; //texunit:0
+uniform lowp sampler2DArray source_dual_paraboloid_array; //texunit:0
 uniform int source_array_index;
 #endif
 

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -579,9 +579,9 @@ layout(std140) uniform Radiance { //ubo:2
 
 #ifdef USE_RADIANCE_MAP_ARRAY
 
-uniform sampler2DArray radiance_map; //texunit:-2
+uniform lowp sampler2DArray radiance_map; //texunit:-2
 
-vec3 textureDualParaboloid(sampler2DArray p_tex, vec3 p_vec,float p_roughness) {
+vec3 textureDualParaboloid(lowp sampler2DArray p_tex, vec3 p_vec,float p_roughness) {
 
 	vec3 norm = normalize(p_vec);
 	norm.xy/=1.0+abs(norm.z);
@@ -1348,7 +1348,7 @@ uniform highp float gi_probe_normal_bias2;
 uniform bool gi_probe2_enabled;
 uniform bool gi_probe_blend_ambient2;
 
-vec3 voxel_cone_trace(sampler3D probe, vec3 cell_size, vec3 pos, vec3 ambient, bool blend_ambient, vec3 direction, float tan_half_angle, float max_distance, float p_bias) {
+vec3 voxel_cone_trace(mediump sampler3D probe, vec3 cell_size, vec3 pos, vec3 ambient, bool blend_ambient, vec3 direction, float tan_half_angle, float max_distance, float p_bias) {
 
 	float dist = p_bias;//1.0; //dot(direction,mix(vec3(-1.0),vec3(1.0),greaterThan(direction,vec3(0.0))))*2.0;
 	float alpha=0.0;
@@ -1370,7 +1370,7 @@ vec3 voxel_cone_trace(sampler3D probe, vec3 cell_size, vec3 pos, vec3 ambient, b
 	return color;
 }
 
-void gi_probe_compute(sampler3D probe, mat4 probe_xform, vec3 bounds,vec3 cell_size,vec3 pos, vec3 ambient, vec3 environment, bool blend_ambient,float multiplier, mat3 normal_mtx,vec3 ref_vec, float roughness,float p_bias,float p_normal_bias, inout vec4 out_spec, inout vec4 out_diff) {
+void gi_probe_compute(mediump sampler3D probe, mat4 probe_xform, vec3 bounds,vec3 cell_size,vec3 pos, vec3 ambient, vec3 environment, bool blend_ambient,float multiplier, mat3 normal_mtx,vec3 ref_vec, float roughness,float p_bias,float p_normal_bias, inout vec4 out_spec, inout vec4 out_diff) {
 
 
 


### PR DESCRIPTION
Sampler types other than `sampler2D` and `samplerCube` don't have default precision, so specify where missing.
Reported for CubeMap filter shader in #11197