### PR TITLE
Make clickable properly in editor help

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -540,14 +540,6 @@ void RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int 
 
 		it = _get_next_item(it);
 
-		if (p_mode == PROCESS_POINTER && r_click_item && itp && !it && p_click_pos.y > p_ofs.y + y + lh) {
-			//at the end of all, return this
-			if (r_outside) *r_outside = true;
-			*r_click_item = itp;
-			*r_click_char = rchar;
-			return;
-		}
-
 		if (it && (p_line + 1 < p_frame->lines.size()) && p_frame->lines[p_line + 1].from == it) {
 
 			if (p_mode == PROCESS_POINTER && r_click_item && p_click_pos.y >= p_ofs.y + y && p_click_pos.y <= p_ofs.y + y + lh) {


### PR DESCRIPTION
fixes #3671

```cpp
p_mode == PROCESS_POINTER && r_click_item && itp && !it && p_click_pos.y > p_ofs.y + y + lh
```
This condition is also true with table cell.
`r_click_item` will be the first cell shown on screen.
if no table cell on screen, click or drag works.

in Godot 3.0 help,
- clicking empty space goes to undesired position with **Members**
- clicking **Public Method** does not work.
- dragging selection is not working if any **Members** or **Public Method** table is on screen.

Here is current version demo.
![richtext_1](https://user-images.githubusercontent.com/8281454/30495176-df2f86d4-9a85-11e7-8e61-66888e6d417f.gif)

This is fixed version demo.
![richtext_2](https://user-images.githubusercontent.com/8281454/30495184-eb75d6d2-9a85-11e7-89b5-071d2fd91e07.gif)
