### PR TITLE
Stop GUI touch event propagation

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2081,6 +2081,14 @@ bool Control::is_stopping_mouse() const {
 	return data.stop_mouse;
 }
 
+void Control::set_stop_touch(const bool p_stop) {
+	data.stop_touch = p_stop;
+}
+
+bool Control::is_stopping_touch() const {
+	return data.stop_touch;
+}
+
 Control *Control::get_focus_owner() const {
 
 	ERR_FAIL_COND_V(!is_inside_tree(), NULL);
@@ -2303,6 +2311,8 @@ void Control::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("set_stop_mouse", "stop"), &Control::set_stop_mouse);
 	ObjectTypeDB::bind_method(_MD("is_stopping_mouse"), &Control::is_stopping_mouse);
+	ObjectTypeDB::bind_method(_MD("set_stop_touch", "stop"), &Control::set_stop_touch);
+	ObjectTypeDB::bind_method(_MD("is_stopping_touch"), &Control::is_stopping_touch);
 
 	ObjectTypeDB::bind_method(_MD("grab_click_focus"), &Control::grab_click_focus);
 
@@ -2340,6 +2350,7 @@ void Control::_bind_methods() {
 	ADD_PROPERTYINZ(PropertyInfo(Variant::NODE_PATH, "focus_neighbour/bottom"), _SCS("set_focus_neighbour"), _SCS("get_focus_neighbour"), MARGIN_BOTTOM);
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "focus/ignore_mouse"), _SCS("set_ignore_mouse"), _SCS("is_ignoring_mouse"));
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "focus/stop_mouse"), _SCS("set_stop_mouse"), _SCS("is_stopping_mouse"));
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "focus/stop_touch"), _SCS("set_stop_touch"), _SCS("is_stopping_touch"));
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "size_flags/horizontal", PROPERTY_HINT_FLAGS, "Expand,Fill"), _SCS("set_h_size_flags"), _SCS("get_h_size_flags"));
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "size_flags/vertical", PROPERTY_HINT_FLAGS, "Expand,Fill"), _SCS("set_v_size_flags"), _SCS("get_v_size_flags"));
@@ -2402,6 +2413,7 @@ Control::Control() {
 
 	data.ignore_mouse = false;
 	data.stop_mouse = true;
+	data.stop_touch = true;
 
 	data.SI = NULL;
 	data.MI = NULL;

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -126,6 +126,7 @@ private:
 
 		bool ignore_mouse;
 		bool stop_mouse;
+		bool stop_touch;
 
 		Control *parent;
 		ObjectID drag_owner;
@@ -320,7 +321,9 @@ public:
 	bool is_ignoring_mouse() const;
 
 	void set_stop_mouse(bool p_stop);
+	void set_stop_touch(const bool p_stop);
 	bool is_stopping_mouse() const;
+	bool is_stopping_touch() const;
 
 	/* SKINNING */
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -128,6 +128,18 @@ Viewport::GUI::GUI() {
 	tooltip_popup = NULL;
 	tooltip_label = NULL;
 	subwindow_order_dirty = false;
+
+	for (int i=0;i<GUI_TOUCH_FOCUS_MAX;++i) {
+		touch_focus[i].control = NULL;
+		touch_focus[i].index -1;
+	}
+}
+
+Viewport::GUI::TouchFocus * Viewport::GUI::get_touch_focus(const int index) {
+	for (int i=0;i<GUI_TOUCH_FOCUS_MAX;++i) {
+		if (touch_focus[i].index == index) return &(touch_focus[i]);
+	}
+	return NULL;
 }
 
 /////////////////////////////////////
@@ -1943,6 +1955,89 @@ void Viewport::_gui_input_event(InputEvent p_event) {
 				}
 				//change mouse accordingly i guess
 			}
+
+		} break;
+		case InputEvent::SCREEN_TOUCH: {
+			gui.key_event_accepted = false;
+
+			Point2 tpos = Point2(p_event.screen_touch.x, p_event.screen_touch.y);
+			Size2 pos = tpos;
+
+			if (p_event.screen_touch.pressed) {
+
+				_gui_sort_modal_stack();
+				while (!gui.modal_stack.empty()) {
+
+					Control *top = gui.modal_stack.back()->get();
+					Vector2 pos = top->get_global_transform_with_canvas().affine_inverse().xform(tpos);
+					if (!top->has_point(pos)) {
+
+						if (top->data.modal_exclusive || top->data.modal_frame == OS::get_singleton()->get_frames_drawn()) {
+							//cancel event, sorry, modal exclusive EATS UP ALL
+							//alternative, you can't pop out a window the same frame it was made modal (fixes many issues)
+							get_tree()->set_input_as_handled();
+							return; // no one gets the event if exclusive NO ONE
+						}
+
+						top->notification(Control::NOTIFICATION_MODAL_CLOSE);
+						top->_modal_stack_remove();
+						top->hide();
+					} else {
+						break;
+					}
+				}
+
+				Control *control = _gui_find_control(pos);
+				GUI::TouchFocus *focus = gui.get_touch_focus(-1);
+
+				if (!control || !focus) break;
+
+				focus->control = control;
+				focus->index = p_event.screen_touch.index;
+				pos = gui.focus_inv_xform.xform(pos);
+				p_event.screen_touch.x = pos.x;
+				p_event.screen_touch.y = pos.y;
+
+				if (control->can_process()) _gui_call_input(control, p_event);
+
+				get_tree()->call_group(SceneTree::GROUP_CALL_REALTIME, "windows", "_cancel_input_ID", p_event.ID);
+				get_tree()->set_input_as_handled();
+
+			}
+			else {
+
+				GUI::TouchFocus *focus = gui.get_touch_focus(p_event.screen_touch.index);
+				if (!focus || !focus->control) break;
+
+				pos = gui.focus_inv_xform.xform(pos);
+				p_event.screen_touch.x = pos.x;
+				p_event.screen_touch.y = pos.y;
+
+				if (focus->control->can_process()) _gui_call_input(focus->control, p_event);
+
+				focus->control = NULL;
+				focus->index = -1;
+
+				get_tree()->call_group(SceneTree::GROUP_CALL_REALTIME, "windows", "_cancel_input_ID", p_event.ID);
+				get_tree()->set_input_as_handled();
+
+			}
+
+		} break;
+		case InputEvent::SCREEN_DRAG: {
+
+			GUI::TouchFocus *focus = gui.get_touch_focus(p_event.screen_drag.index);
+			if (!focus || !focus->control) break;
+
+			Point2 tpos = Point2(p_event.screen_drag.x, p_event.screen_drag.y);
+
+			tpos = gui.focus_inv_xform.xform(tpos);
+			p_event.screen_touch.x = tpos.x;
+			p_event.screen_touch.y = tpos.y;
+
+			if (focus->control->can_process()) _gui_call_input(focus->control, p_event);
+
+			get_tree()->set_input_as_handled();
 
 		} break;
 		case InputEvent::ACTION:

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1533,7 +1533,9 @@ void Viewport::_gui_call_input(Control *p_control, const InputEvent &p_input) {
 				break;
 			if (gui.key_event_accepted)
 				break;
-			if (!cant_stop_me_now && control->data.stop_mouse && (ev.type == InputEvent::MOUSE_BUTTON || ev.type == InputEvent::MOUSE_MOTION))
+			bool stop = control->data.stop_mouse && (ev.type == InputEvent::MOUSE_BUTTON || ev.type == InputEvent::MOUSE_MOTION) ||
+						control->data.stop_touch && (ev.type == InputEvent::SCREEN_TOUCH || ev.type == InputEvent::SCREEN_DRAG);
+			if (!cant_stop_me_now && stop)
 				break;
 		}
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -170,12 +170,20 @@ private:
 	struct GUI {
 		// info used when this is a window
 
+#define GUI_TOUCH_FOCUS_MAX 10
+
+		struct TouchFocus {
+			Control *control;
+			int index = -1;
+		};
+
 		bool key_event_accepted;
 		Control *mouse_focus;
 		int mouse_focus_button;
 		Control *key_focus;
 		Control *mouse_over;
 		Control *tooltip;
+		TouchFocus touch_focus[GUI_TOUCH_FOCUS_MAX];
 		Panel *tooltip_popup;
 		Label *tooltip_label;
 		Point2 tooltip_pos;
@@ -195,6 +203,7 @@ private:
 		List<Control *> roots;
 
 		GUI();
+		TouchFocus* get_touch_focus(const int index);
 	} gui;
 
 	bool disable_input;


### PR DESCRIPTION
Mouse events on `Control` nodes are properly consumed by default. This way if a button or other `Control` with `ignore_mouse` = **false** is clicked, the event is accepted and never sent through `_unhandled_input` functions. Currently this does not apply to touch events, so tapping a button on a mobile device will still send the event to `_input` as well as `_unhandled_input`, which causes conflicts between custom game inputs and tapping UI buttons. 

This PR solves this issue by explicitly checking touch events separately from mouse events. It is designed to work with multitouch.

A `stop_touch` flag has also been added, but to be honest I didn't notice any behavior difference with  `stop_mouse`. I only added it for good measure and the ability to handle touch events separately from mouse events in such a case.

----

Tested on OSX with `emulate_touchscreen`=**true**, Android, and iOS on top of **2.1.3-stable** AND **2.1.4-stable** builds