### PR TITLE
Use code font in editor log

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -85,7 +85,11 @@ void EditorLog::clear() {
 
 void EditorLog::add_message(const String &p_msg, bool p_error) {
 
+	Ref<Font> doc_code_font = get_font("doc_source", "EditorFonts");
+	log->push_font(doc_code_font);
+
 	log->add_newline();
+
 	if (p_error) {
 		log->push_color(get_color("error_color", "Editor"));
 		Ref<Texture> icon = get_icon("Error", "EditorIcons");
@@ -100,6 +104,8 @@ void EditorLog::add_message(const String &p_msg, bool p_error) {
 
 	if (p_error)
 		log->pop();
+
+	log->pop(); // pop font;
 }
 
 /*


### PR DESCRIPTION
uses the doc font in the editor log, here is a comparison

code font
![screenshot from 2017-09-15 20-06-18](https://user-images.githubusercontent.com/1103897/30507956-c3fa1b92-9a51-11e7-882b-ee20098af061.png)

regular font
![screenshot from 2017-09-15 20-10-02](https://user-images.githubusercontent.com/1103897/30507963-e30b6aea-9a51-11e7-9aa1-e18e6e07441c.png)

