### PR TITLE
Fix x11 exported executables not getting the +x flag

### DIFF
--- a/core/os/file_access.h
+++ b/core/os/file_access.h
@@ -139,6 +139,8 @@ public:
 
 	virtual Error reopen(const String &p_path, int p_mode_flags); ///< does not change the AccessType
 
+	virtual Error _chmod(const String &p_path, int p_mod) {}
+
 	static FileAccess *create(AccessType p_access); /// Create a file access (for the current platform) this is the only portable way of accessing files.
 	static FileAccess *create_for_path(const String &p_path);
 	static FileAccess *open(const String &p_path, int p_mode_flags, Error *r_error = NULL); /// Create a file access (for the current platform) this is the only portable way of accessing files.

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -236,6 +236,15 @@ uint64_t FileAccessUnix::_get_modified_time(const String &p_file) {
 	};
 }
 
+Error FileAccessUnix::_chmod(const String &p_path, int p_mod) {
+	int err = chmod(p_path.utf8().get_data(), p_mod);
+	if (!err) {
+		return OK;
+	}
+
+	return FAILED;
+}
+
 FileAccess *FileAccessUnix::create_libc() {
 
 	return memnew(FileAccessUnix);

--- a/drivers/unix/file_access_unix.h
+++ b/drivers/unix/file_access_unix.h
@@ -78,6 +78,8 @@ public:
 
 	virtual uint64_t _get_modified_time(const String &p_file);
 
+	virtual Error _chmod(const String &p_path, int p_mod);
+
 	FileAccessUnix();
 	virtual ~FileAccessUnix();
 };

--- a/editor/editor_import_export.cpp
+++ b/editor/editor_import_export.cpp
@@ -511,6 +511,16 @@ void EditorExportPlatform::set_debugging_enabled(bool p_enabled) {
 	debugging_enabled = p_enabled;
 }
 
+int EditorExportPlatform::get_chmod_flags() const {
+
+	return chmod_flags;
+}
+
+void EditorExportPlatform::set_chmod_flags(int p_flags) {
+
+	chmod_flags = p_flags;
+}
+
 bool EditorExportPlatformPC::_set(const StringName &p_name, const Variant &p_value) {
 
 	String n = p_name;
@@ -1244,6 +1254,7 @@ Error EditorExportPlatform::save_pack(FileAccess *dst, bool p_make_bundles, int 
 EditorExportPlatform::EditorExportPlatform() {
 
 	debugging_enabled = true;
+	chmod_flags = 0;
 }
 
 Error EditorExportPlatformPC::export_project(const String &p_path, bool p_debug, int p_flags) {
@@ -1333,6 +1344,15 @@ Error EditorExportPlatformPC::export_project(const String &p_path, bool p_debug,
 	memdelete(src_exe);
 
 	Error err = export_mode == EXPORT_ZIP ? save_zip(dstfile, bundle) : save_pack(dst, bundle);
+	dst->close();
+
+	if (err == OK) {
+		int flags = get_chmod_flags();
+		if (flags) {
+			err = dst->_chmod(p_path, flags);
+		}
+	}
+
 	memdelete(dst);
 	return err;
 }

--- a/editor/editor_import_export.h
+++ b/editor/editor_import_export.h
@@ -86,6 +86,7 @@ public:
 
 private:
 	bool debugging_enabled;
+	int chmod_flags;
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -148,6 +149,9 @@ public:
 
 	bool is_debugging_enabled() const;
 	void set_debugging_enabled(bool p_enabled);
+
+	int get_chmod_flags() const;
+	void set_chmod_flags(int p_flags);
 
 	Error export_project_files(EditorExportSaveFunction p_func, void *p_udata, bool p_make_bundles);
 

--- a/platform/x11/export/export.cpp
+++ b/platform/x11/export/export.cpp
@@ -47,6 +47,7 @@ void register_x11_exporter() {
 		exporter->set_debug_binary64("linux_x11_64_debug");
 		exporter->set_name("Linux X11");
 		exporter->set_logo(logo);
+		exporter->set_chmod_flags(0755);
 		EditorImportExport::get_singleton()->add_export_platform(exporter);
 	}
 }


### PR DESCRIPTION
This is a partial fix for #527.
When exporting for X11 on Linux or Mac the executable will get the 0755 mode flags. This doesn't affects when exporting for X11 on Windows.