### PR TITLE
Fixed naming of pck file

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -307,8 +307,8 @@ Error ProjectSettings::setup(const String &p_path, const String &p_main_pack) {
 	if (exec_path != "") {
 		bool found = false;
 
-		// get our filename without our path (note, not using exec_path.get_basename anymore because not all file systems have dots in their file names!)
-		String filebase_name = exec_path.get_file();
+		// get our filename without our path (note, using exec_path.get_file before get_basename anymore because not all file systems have dots in their file names!)
+		String filebase_name = exec_path.get_file().get_basename();
 
 		// try to open at the location of executable
 		String datapack_name = exec_path.get_base_dir().plus_file(filebase_name) + ".pck";


### PR DESCRIPTION
Oops, I broke this in my haste to fix things for OSX. On OSX the get_basename function was being overzealous as there is no dot in the executable name but there is in the bundle name, but there still is a dot in the executable name on Windows.

So it is now doing a get_filename first to get the full name of the executable without the path, then calling get_basename to strip off any extension if applicable.

I am still having issues on windows with it not wanting to open up the pck file. Not sure yet why but I don't think its due to the filename anymore.