### PR TITLE
Fix set_item_icon error when starting editor

### DIFF
--- a/editor/animation_editor.cpp
+++ b/editor/animation_editor.cpp
@@ -2898,10 +2898,6 @@ void AnimationKeyEditor::_notification(int p_what) {
 			zoomicon->set_custom_minimum_size(Size2(24 * EDSCALE, 0));
 			zoomicon->set_stretch_mode(TextureRect::STRETCH_KEEP_CENTERED);
 
-			menu_add_track->get_popup()->add_icon_item(get_icon("KeyValue", "EditorIcons"), "Add Normal Track", ADD_TRACK_MENU_ADD_VALUE_TRACK);
-			menu_add_track->get_popup()->add_icon_item(get_icon("KeyXform", "EditorIcons"), "Add Transform Track", ADD_TRACK_MENU_ADD_TRANSFORM_TRACK);
-			menu_add_track->get_popup()->add_icon_item(get_icon("KeyCall", "EditorIcons"), "Add Call Func Track", ADD_TRACK_MENU_ADD_CALL_TRACK);
-
 			menu_track->set_icon(get_icon("Tools", "EditorIcons"));
 			menu_track->get_popup()->add_item(TTR("Scale Selection"), TRACK_MENU_SCALE);
 			menu_track->get_popup()->add_item(TTR("Scale From Cursor"), TRACK_MENU_SCALE_PIVOT);
@@ -3817,6 +3813,9 @@ AnimationKeyEditor::AnimationKeyEditor() {
 	hb->add_child(menu_add_track);
 	menu_add_track->get_popup()->connect("id_pressed", this, "_menu_add_track");
 	menu_add_track->set_tooltip(TTR("Add new tracks."));
+	menu_add_track->get_popup()->add_icon_item(get_icon("KeyValue", "EditorIcons"), "Add Normal Track", ADD_TRACK_MENU_ADD_VALUE_TRACK);
+	menu_add_track->get_popup()->add_icon_item(get_icon("KeyXform", "EditorIcons"), "Add Transform Track", ADD_TRACK_MENU_ADD_TRANSFORM_TRACK);
+	menu_add_track->get_popup()->add_icon_item(get_icon("KeyCall", "EditorIcons"), "Add Call Func Track", ADD_TRACK_MENU_ADD_CALL_TRACK);
 
 	move_up_button = memnew(ToolButton);
 	hb->add_child(move_up_button);


### PR DESCRIPTION
Below error occurs when start editor.
```
ERROR: set_item_icon: Index p_idx out of size (items.size()).
   At: scene/gui/popup_menu.cpp:637.
```

it has happened since a6e03b4aed4a2dbfb73d6554eceb915fe0adb740

[menu_add_track->get_popup()->set_item_icon(ADD_TRACK_MENU_ADD_VALUE_TRACK, get_icon("KeyValue", "EditorIcons"));](https://github.com/godotengine/godot/commit/a6e03b4aed4a2dbfb73d6554eceb915fe0adb740#diff-8a9eeb20c380919522f23ccd9ceb6709R2954)
in `NOTIFICATION_THEME_CHANGED` is called before `add_item_icon` at `NOTIFICATION_ENTER_TREE`
