### PR TITLE
Added support for FT_PIXEL_MODE_MONO in FreeType

### DIFF
--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -560,8 +560,23 @@ void DynamicFontAtSize::_update_char(CharType p_char) {
 
 				int ofs = ((i + tex_y + rect_margin) * tex.texture_size + j + tex_x + rect_margin) * 2;
 				ERR_FAIL_COND(ofs >= tex.imgdata.size());
-				wr[ofs + 0] = 255; //grayscale as 1
-				wr[ofs + 1] = slot->bitmap.buffer[i * slot->bitmap.width + j];
+				switch (slot->bitmap.pixel_mode) {
+					case FT_PIXEL_MODE_MONO: {
+						int byte = i * slot->bitmap.pitch + (j >> 3);
+						int bit = 1 << (7 - (j % 8));
+						wr[ofs + 0] = 255; //grayscale as 1
+						wr[ofs + 1] = slot->bitmap.buffer[byte] & bit ? 255 : 0;
+					} break;
+					case FT_PIXEL_MODE_GRAY:
+						wr[ofs + 0] = 255; //grayscale as 1
+						wr[ofs + 1] = slot->bitmap.buffer[i * slot->bitmap.pitch + j];
+						break;
+						// TODO: FT_PIXEL_MODE_LCD, FT_PIXEL_MODE_BGRA
+					default:
+						ERR_EXPLAIN("Font uses unsupported pixel format: " + itos(slot->bitmap.pixel_mode));
+						ERR_FAIL();
+						break;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The code previously incorrectly assumed the loaded pixel format in FreeType would always be 8-bit greyscale (`FT_PIXEL_MODE_GRAY`). This is not always the case. [Reference](https://www.freetype.org/freetype2/docs/reference/ft2-basic_types.html#FT_Pixel_Mode)

In particular, non-anti-aliased bitmap-only fonts created in FontForge are rendered in `FT_PIXEL_MODE_MONO`. With this change it should now be possible to use BDF and PCF fonts by opening them in FontForge and exporting them as TTF. Perfect for your retro pixel-art goodness.

For reference using MPlus Bitmap font that I converted using FontForge:
![before](https://user-images.githubusercontent.com/185322/30523654-ce14c772-9c17-11e7-904c-0be22535adcf.png)
![after](https://user-images.githubusercontent.com/185322/30523655-d16ffcd4-9c17-11e7-9863-1315a4c3657f.png)

I haven't really encountered any fonts in the wild using `FT_PIXEL_MODE_LCD`, or `FT_PIXEL_MODE_BGRA` so I can't test for them.
