### PR TITLE
Move Variant::evaluate() switch to computed goto

### DIFF
--- a/core/variant.h
+++ b/core/variant.h
@@ -70,6 +70,7 @@ typedef PoolVector<Color> PoolColorArray;
 
 class Variant {
 public:
+	// If this changes the table in variant_op must be updated
 	enum Type {
 
 		NIL,
@@ -288,6 +289,7 @@ public:
 
 	Variant(const IP_Address &p_address);
 
+	// If this changes the table in variant_op must be updated
 	enum Operator {
 
 		//comparation
@@ -299,7 +301,7 @@ public:
 		OP_GREATER_EQUAL,
 		//mathematic
 		OP_ADD,
-		OP_SUBSTRACT,
+		OP_SUBTRACT,
 		OP_MULTIPLY,
 		OP_DIVIDE,
 		OP_NEGATE,

--- a/modules/gdscript/gd_compiler.cpp
+++ b/modules/gdscript/gd_compiler.cpp
@@ -131,7 +131,7 @@ int GDCompiler::_parse_assign_right_expression(CodeGen &codegen, const GDParser:
 	switch (p_expression->op) {
 
 		case GDParser::OperatorNode::OP_ASSIGN_ADD: var_op = Variant::OP_ADD; break;
-		case GDParser::OperatorNode::OP_ASSIGN_SUB: var_op = Variant::OP_SUBSTRACT; break;
+		case GDParser::OperatorNode::OP_ASSIGN_SUB: var_op = Variant::OP_SUBTRACT; break;
 		case GDParser::OperatorNode::OP_ASSIGN_MUL: var_op = Variant::OP_MULTIPLY; break;
 		case GDParser::OperatorNode::OP_ASSIGN_DIV: var_op = Variant::OP_DIVIDE; break;
 		case GDParser::OperatorNode::OP_ASSIGN_MOD: var_op = Variant::OP_MODULE; break;
@@ -759,7 +759,7 @@ int GDCompiler::_parse_expression(CodeGen &codegen, const GDParser::Node *p_expr
 					if (!_create_binary_operator(codegen, on, Variant::OP_ADD, p_stack_level)) return -1;
 				} break;
 				case GDParser::OperatorNode::OP_SUB: {
-					if (!_create_binary_operator(codegen, on, Variant::OP_SUBSTRACT, p_stack_level)) return -1;
+					if (!_create_binary_operator(codegen, on, Variant::OP_SUBTRACT, p_stack_level)) return -1;
 				} break;
 				case GDParser::OperatorNode::OP_MUL: {
 					if (!_create_binary_operator(codegen, on, Variant::OP_MULTIPLY, p_stack_level)) return -1;

--- a/modules/gdscript/gd_editor.cpp
+++ b/modules/gdscript/gd_editor.cpp
@@ -908,7 +908,7 @@ static bool _guess_expression_type(GDCompletionContext &context, const GDParser:
 			Variant::Operator vop = Variant::OP_MAX;
 			switch (op->op) {
 				case GDParser::OperatorNode::OP_ADD: vop = Variant::OP_ADD; break;
-				case GDParser::OperatorNode::OP_SUB: vop = Variant::OP_SUBSTRACT; break;
+				case GDParser::OperatorNode::OP_SUB: vop = Variant::OP_SUBTRACT; break;
 				case GDParser::OperatorNode::OP_MUL: vop = Variant::OP_MULTIPLY; break;
 				case GDParser::OperatorNode::OP_DIV: vop = Variant::OP_DIVIDE; break;
 				case GDParser::OperatorNode::OP_MOD: vop = Variant::OP_MODULE; break;

--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -1699,7 +1699,7 @@ GDParser::Node *GDParser::_reduce_expression(Node *p_node, bool p_to_const) {
 					_REDUCE_BINARY(Variant::OP_ADD);
 				} break;
 				case OperatorNode::OP_SUB: {
-					_REDUCE_BINARY(Variant::OP_SUBSTRACT);
+					_REDUCE_BINARY(Variant::OP_SUBTRACT);
 				} break;
 				case OperatorNode::OP_MUL: {
 					_REDUCE_BINARY(Variant::OP_MULTIPLY);

--- a/modules/visual_script/visual_script_expression.cpp
+++ b/modules/visual_script/visual_script_expression.cpp
@@ -1023,7 +1023,7 @@ VisualScriptExpression::ENode *VisualScriptExpression::_parse_expression() {
 			case TK_OP_OR: op = Variant::OP_OR; break;
 			case TK_OP_NOT: op = Variant::OP_NOT; break;
 			case TK_OP_ADD: op = Variant::OP_ADD; break;
-			case TK_OP_SUB: op = Variant::OP_SUBSTRACT; break;
+			case TK_OP_SUB: op = Variant::OP_SUBTRACT; break;
 			case TK_OP_MUL: op = Variant::OP_MULTIPLY; break;
 			case TK_OP_DIV: op = Variant::OP_DIVIDE; break;
 			case TK_OP_MOD: op = Variant::OP_MODULE; break;
@@ -1085,7 +1085,7 @@ VisualScriptExpression::ENode *VisualScriptExpression::_parse_expression() {
 				case Variant::OP_MODULE: priority = 2; break;
 
 				case Variant::OP_ADD: priority = 3; break;
-				case Variant::OP_SUBSTRACT: priority = 3; break;
+				case Variant::OP_SUBTRACT: priority = 3; break;
 
 				case Variant::OP_SHIFT_LEFT: priority = 4; break;
 				case Variant::OP_SHIFT_RIGHT: priority = 4; break;

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -1546,7 +1546,7 @@ public:
 					value = Variant::evaluate(Variant::OP_ADD, value, p_argument);
 				} break;
 				case VisualScriptPropertySet::ASSIGN_OP_SUB: {
-					value = Variant::evaluate(Variant::OP_SUBSTRACT, value, p_argument);
+					value = Variant::evaluate(Variant::OP_SUBTRACT, value, p_argument);
 				} break;
 				case VisualScriptPropertySet::ASSIGN_OP_MUL: {
 					value = Variant::evaluate(Variant::OP_MULTIPLY, value, p_argument);

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -3762,7 +3762,7 @@ void register_visual_script_nodes() {
 	VisualScriptLanguage::singleton->add_register_func("operators/compare/greater_equal", create_op_node<Variant::OP_GREATER_EQUAL>);
 	//mathematic
 	VisualScriptLanguage::singleton->add_register_func("operators/math/add", create_op_node<Variant::OP_ADD>);
-	VisualScriptLanguage::singleton->add_register_func("operators/math/subtract", create_op_node<Variant::OP_SUBSTRACT>);
+	VisualScriptLanguage::singleton->add_register_func("operators/math/subtract", create_op_node<Variant::OP_SUBTRACT>);
 	VisualScriptLanguage::singleton->add_register_func("operators/math/multiply", create_op_node<Variant::OP_MULTIPLY>);
 	VisualScriptLanguage::singleton->add_register_func("operators/math/divide", create_op_node<Variant::OP_DIVIDE>);
 	VisualScriptLanguage::singleton->add_register_func("operators/math/negate", create_op_node<Variant::OP_NEGATE>);


### PR DESCRIPTION
In an effort to make GDScript a little faster replace the double
switch() with a computed goto on compilers that set `__GNUC__`. For
compilers that don't support computed goto it will fall back to regular
switch/case statements.

In addition disable using boolean values in a mathematical context. Now
boolean values can only be compared with other booleans. Booleans will
also no longer be coerced to integers.

This PR replaces #11308 and fixes #11291 

This change was extensively discussed with @reduz before this work began.