### PR TITLE
Do not allow link-local addresses to be used by editor debugger

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -460,7 +460,7 @@ void EditorSettings::setup_network() {
 
 	List<IP_Address> local_ip;
 	IP::get_singleton()->get_local_addresses(&local_ip);
-	String lip;
+	String lip = "127.0.0.1";
 	String hint;
 	String current = has("network/debug/remote_host") ? get("network/debug/remote_host") : "";
 	int port = has("network/debug/remote_port") ? (int)get("network/debug/remote_port") : 6007;
@@ -469,8 +469,9 @@ void EditorSettings::setup_network() {
 
 		String ip = E->get();
 
-		if (lip == "")
-			lip = ip;
+		// link-local IPv6 addresses don't work, skipping them
+		if (ip.begins_with("fe80:0:0:0:")) // fe80::/64
+			continue;
 		if (ip == current)
 			lip = current; //so it saves
 		if (hint != "")


### PR DESCRIPTION
Link-local addresses seems to be reserved to network/neighbor discovery https://tools.ietf.org/html/rfc4291#section-2.5.6 .
This PR disables them as an option in `Editor Settings -> Network -> Debug -> Remote Host`.

This bug appears to be causing #8563 and #10503 (and also the reopening of ~#1287~ EDIT: no, that bug is about something else ).

The PR also changes the default editor debugger address to `127.0.0.1`. This could be an issue on machines with no IPv4 support, which I don't expect to be a thing honestly (while you might have an IPv6 only link, the OS still supports IPv4 local addresses unless users manually disable it or have custom kernels with no IPv4 stack compiled).
I don't have a strong feeling about this though, so we might just leave it as "first address is the default one" (which depending on the OS might not be `127.0.0.1`).

@punto- , @reduz , @akien-mga opinions?