### PR TITLE
Prevent running the crash_handler when a debugger is present on windows

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -248,7 +248,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	performance = memnew(Performance);
 	globals->add_singleton(ProjectSettings::Singleton("Performance", performance));
 
-	GLOBAL_DEF("debug/settings/backtrace/message", String("Please include this when reporting the bug on https://github.com/godotengine/godot/issues"));
+	GLOBAL_DEF("debug/settings/crash_handler/message", String("Please include this when reporting the bug on https://github.com/godotengine/godot/issues"));
 
 	MAIN_PRINT("Main: Parse CMDLine");
 

--- a/platform/osx/crash_handler_osx.mm
+++ b/platform/osx/crash_handler_osx.mm
@@ -77,7 +77,7 @@ static void handle_crash(int sig) {
 	void *bt_buffer[256];
 	size_t size = backtrace(bt_buffer, 256);
 	String _execpath = OS::get_singleton()->get_executable_path();
-	String msg = GLOBAL_GET("debug/settings/backtrace/message");
+	String msg = GLOBAL_GET("debug/settings/crash_handler/message");
 
 	// Dump the backtrace to stderr with a message to the user
 	fprintf(stderr, "%s: Program crashed with signal %d\n", __FUNCTION__, sig);

--- a/platform/windows/crash_handler_win.cpp
+++ b/platform/windows/crash_handler_win.cpp
@@ -116,7 +116,7 @@ DWORD CrashHandlerException(EXCEPTION_POINTERS *ep) {
 	DWORD cbNeeded;
 	std::vector<HMODULE> module_handles(1);
 
-	if (OS::get_singleton() == NULL || OS::get_singleton()->is_disable_crash_handler()) {
+	if (OS::get_singleton() == NULL || OS::get_singleton()->is_disable_crash_handler() || IsDebuggerPresent()) {
 		return EXCEPTION_CONTINUE_SEARCH;
 	}
 
@@ -159,7 +159,7 @@ DWORD CrashHandlerException(EXCEPTION_POINTERS *ep) {
 	IMAGE_NT_HEADERS *h = ImageNtHeader(base);
 	DWORD image_type = h->FileHeader.Machine;
 	int n = 0;
-	String msg = GLOBAL_GET("debug/settings/backtrace/message");
+	String msg = GLOBAL_GET("debug/settings/crash_handler/message");
 
 	fprintf(stderr, "Dumping the backtrace. %ls\n", msg.c_str());
 

--- a/platform/windows/godot_win.cpp
+++ b/platform/windows/godot_win.cpp
@@ -156,32 +156,36 @@ int widechar_main(int argc, wchar_t **argv) {
 	return os.get_exit_code();
 };
 
+int _main() {
+	LPWSTR *wc_argv;
+	int argc;
+	int result;
+
+	wc_argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+
+	if (NULL == wc_argv) {
+		wprintf(L"CommandLineToArgvW failed\n");
+		return 0;
+	}
+
+	result = widechar_main(argc, wc_argv);
+
+	LocalFree(wc_argv);
+	return result;
+}
+
 int main(int _argc, char **_argv) {
 // _argc and _argv are ignored
 // we are going to use the WideChar version of them instead
 
 #ifdef CRASH_HANDLER_EXCEPTION
 	__try {
-#endif
-		LPWSTR *wc_argv;
-		int argc;
-		int result;
-
-		wc_argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-
-		if (NULL == wc_argv) {
-			wprintf(L"CommandLineToArgvW failed\n");
-			return 0;
-		}
-
-		result = widechar_main(argc, wc_argv);
-
-		LocalFree(wc_argv);
-		return result;
-#ifdef CRASH_HANDLER_EXCEPTION
+		return _main();
 	} __except (CrashHandlerException(GetExceptionInformation())) {
 		return 1;
 	}
+#else
+	return _main();
 #endif
 }
 

--- a/platform/x11/crash_handler_x11.cpp
+++ b/platform/x11/crash_handler_x11.cpp
@@ -47,7 +47,7 @@ static void handle_crash(int sig) {
 	void *bt_buffer[256];
 	size_t size = backtrace(bt_buffer, 256);
 	String _execpath = OS::get_singleton()->get_executable_path();
-	String msg = GLOBAL_GET("debug/settings/backtrace/message");
+	String msg = GLOBAL_GET("debug/settings/crash_handler/message");
 
 	// Dump the backtrace to stderr with a message to the user
 	fprintf(stderr, "%s: Program crashed with signal %d\n", __FUNCTION__, sig);


### PR DESCRIPTION
Fixes #11347.
Also renamed the "debug/settings/backtrace/message" to "debug/settings/crash_handler/message" for consistency.