### PR TITLE
Added snapping to spatial drag and drop.

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -351,6 +351,23 @@ public:
 
 		return hf;
 	}
+
+	static _ALWAYS_INLINE_ float snap_scalar(float p_offset, float p_step, float p_target) {
+		return p_step != 0 ? Math::stepify(p_target - p_offset, p_step) + p_offset : p_target;
+	}
+
+	static _ALWAYS_INLINE_ float snap_scalar_seperation(float p_offset, float p_step, float p_target, float p_separation) {
+		if (p_step != 0) {
+			float a = Math::stepify(p_target - p_offset, p_step + p_separation) + p_offset;
+			float b = a;
+			if (p_target >= 0)
+				b -= p_separation;
+			else
+				b += p_step;
+			return (Math::abs(p_target - a) < Math::abs(p_target - b)) ? a : b;
+		}
+		return p_target;
+	}
 };
 
 #endif // MATH_FUNCS_H

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3387,7 +3387,6 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 		case ANIM_INSERT_POS_SCALE:
 		case ANIM_INSERT_ROT_SCALE:
 		case ANIM_INSERT_POS_ROT_SCALE: {
-
 			static const bool key_toggles[7][3]={
 				{true,false,false},
 				{false,true,false},
@@ -3400,12 +3399,10 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 			key_pos=key_toggles[p_op-ANIM_INSERT_POS][0];
 			key_rot=key_toggles[p_op-ANIM_INSERT_POS][1];
 			key_scale=key_toggles[p_op-ANIM_INSERT_POS][2];
-
 			for(int i=ANIM_INSERT_POS;i<=ANIM_INSERT_POS_ROT_SCALE;i++) {
 				int idx = animation_menu->get_popup()->get_item_index(i);
 				animation_menu->get_popup()->set_item_checked(idx,i==p_op);
 			}
-
 		} break;*/
 		case ANIM_COPY_POSE: {
 

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -760,14 +760,10 @@ void Polygon2DEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_snap_step_y"), &Polygon2DEditor::_set_snap_step_y);
 }
 
-inline float _snap_scalar(float p_offset, float p_step, float p_target) {
-	return p_step != 0 ? Math::stepify(p_target - p_offset, p_step) + p_offset : p_target;
-}
-
 Vector2 Polygon2DEditor::snap_point(Vector2 p_target) const {
 	if (use_snap) {
-		p_target.x = _snap_scalar(snap_offset.x * uv_draw_zoom - uv_draw_ofs.x, snap_step.x * uv_draw_zoom, p_target.x);
-		p_target.y = _snap_scalar(snap_offset.y * uv_draw_zoom - uv_draw_ofs.y, snap_step.y * uv_draw_zoom, p_target.y);
+		p_target.x = Math::snap_scalar(snap_offset.x * uv_draw_zoom - uv_draw_ofs.x, snap_step.x * uv_draw_zoom, p_target.x);
+		p_target.y = Math::snap_scalar(snap_offset.y * uv_draw_zoom - uv_draw_ofs.y, snap_step.y * uv_draw_zoom, p_target.y);
 	}
 
 	return p_target;

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -2663,7 +2663,7 @@ bool SpatialEditorViewport::_create_instance(Node *parent, String &path, const P
 	if (parent_spatial)
 		global_transform = parent_spatial->get_global_transform();
 
-	global_transform.origin = _get_instance_position(p_point);
+	global_transform.origin = spatial_editor->snap_point(_get_instance_position(p_point));
 
 	editor_data->get_undo_redo().add_do_method(instanced_scene, "set_global_transform", global_transform);
 
@@ -4616,6 +4616,15 @@ void SpatialEditorPlugin::set_state(const Dictionary &p_state) {
 void SpatialEditor::snap_cursor_to_plane(const Plane &p_plane) {
 
 	//cursor.pos=p_plane.project(cursor.pos);
+}
+
+Vector3 SpatialEditor::snap_point(Vector3 p_target, Vector3 p_start) const {
+	if (is_snap_enabled()) {
+		p_target.x = Math::snap_scalar(0.0, get_translate_snap(), p_target.x);
+		p_target.y = Math::snap_scalar(0.0, get_translate_snap(), p_target.y);
+		p_target.z = Math::snap_scalar(0.0, get_translate_snap(), p_target.z);
+	}
+	return p_target;
 }
 
 void SpatialEditorPlugin::_bind_methods() {

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -539,6 +539,8 @@ public:
 	static SpatialEditor *get_singleton() { return singleton; }
 	void snap_cursor_to_plane(const Plane &p_plane);
 
+	Vector3 snap_point(Vector3 p_target, Vector3 p_start = Vector3(0, 0, 0)) const;
+
 	float get_znear() const { return settings_znear->get_value(); }
 	float get_zfar() const { return settings_zfar->get_value(); }
 	float get_fov() const { return settings_fov->get_value(); }

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -735,23 +735,10 @@ void TextureRegionEditor::_edit_region() {
 	edit_draw->update();
 }
 
-inline float _snap_scalar(float p_offset, float p_step, float separation, float p_target) {
-	if (p_step != 0) {
-		float a = Math::stepify(p_target - p_offset, p_step + separation) + p_offset;
-		float b = a;
-		if (p_target >= 0)
-			b -= separation;
-		else
-			b += p_step;
-		return (Math::abs(p_target - a) < Math::abs(p_target - b)) ? a : b;
-	}
-	return p_target;
-}
-
 Vector2 TextureRegionEditor::snap_point(Vector2 p_target) const {
 	if (snap_mode == SNAP_GRID) {
-		p_target.x = _snap_scalar(snap_offset.x, snap_step.x, snap_separation.x, p_target.x);
-		p_target.y = _snap_scalar(snap_offset.y, snap_step.y, snap_separation.y, p_target.y);
+		p_target.x = Math::snap_scalar_seperation(snap_offset.x, snap_step.x, p_target.x, snap_separation.x);
+		p_target.y = Math::snap_scalar_seperation(snap_offset.y, snap_step.y, p_target.y, snap_separation.y);
 	}
 
 	return p_target;


### PR DESCRIPTION
Dragged and dropped objects in the spatial editor will now snap to the grid if snap is enabled. Duplicate snap functions have also been moved to the math class now.