### PR TITLE
Various GDScript performance tweaks

### DIFF
--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -903,9 +903,6 @@ bool Variant::is_one() const {
 
 void Variant::reference(const Variant &p_variant) {
 
-	if (this == &p_variant)
-		return;
-
 	clear();
 
 	type = p_variant.type;
@@ -924,17 +921,14 @@ void Variant::reference(const Variant &p_variant) {
 		case INT: {
 
 			_data._int = p_variant._data._int;
-
 		} break;
 		case REAL: {
 
 			_data._real = p_variant._data._real;
-
 		} break;
 		case STRING: {
 
 			memnew_placement(_data._mem, String(*reinterpret_cast<const String *>(p_variant._data._mem)));
-
 		} break;
 
 		// math types
@@ -942,33 +936,24 @@ void Variant::reference(const Variant &p_variant) {
 		case VECTOR2: {
 
 			memnew_placement(_data._mem, Vector2(*reinterpret_cast<const Vector2 *>(p_variant._data._mem)));
-
 		} break;
 		case RECT2: {
 
 			memnew_placement(_data._mem, Rect2(*reinterpret_cast<const Rect2 *>(p_variant._data._mem)));
-
 		} break;
 		case TRANSFORM2D: {
 
 			_data._transform2d = memnew(Transform2D(*p_variant._data._transform2d));
-
 		} break;
 		case VECTOR3: {
 
 			memnew_placement(_data._mem, Vector3(*reinterpret_cast<const Vector3 *>(p_variant._data._mem)));
-
 		} break;
 		case PLANE: {
 
 			memnew_placement(_data._mem, Plane(*reinterpret_cast<const Plane *>(p_variant._data._mem)));
-
 		} break;
-		/*
-		case QUAT: {
 
-
-		} break;*/
 		case RECT3: {
 
 			_data._rect3 = memnew(Rect3(*p_variant._data._rect3));
@@ -986,7 +971,6 @@ void Variant::reference(const Variant &p_variant) {
 		case TRANSFORM: {
 
 			_data._transform = memnew(Transform(*p_variant._data._transform));
-
 		} break;
 
 		// misc types
@@ -1058,6 +1042,7 @@ void Variant::reference(const Variant &p_variant) {
 		default: {}
 	}
 }
+
 void Variant::zero() {
 	switch (type) {
 		case NIL: break;
@@ -1073,6 +1058,7 @@ void Variant::zero() {
 		default: this->clear(); break;
 	}
 }
+
 void Variant::clear() {
 
 	switch (type) {
@@ -1092,12 +1078,10 @@ void Variant::clear() {
 		case TRANSFORM2D: {
 
 			memdelete(_data._transform2d);
-
 		} break;
 		case RECT3: {
 
 			memdelete(_data._rect3);
-
 		} break;
 		case BASIS: {
 
@@ -1106,14 +1090,12 @@ void Variant::clear() {
 		case TRANSFORM: {
 
 			memdelete(_data._transform);
-
 		} break;
 
 		// misc types
 		case NODE_PATH: {
 
 			reinterpret_cast<NodePath *>(_data._mem)->~NodePath();
-
 		} break;
 		case OBJECT: {
 
@@ -1127,48 +1109,39 @@ void Variant::clear() {
 		case DICTIONARY: {
 
 			reinterpret_cast<Dictionary *>(_data._mem)->~Dictionary();
-
 		} break;
 		case ARRAY: {
 
 			reinterpret_cast<Array *>(_data._mem)->~Array();
-
 		} break;
 		// arrays
 		case POOL_BYTE_ARRAY: {
 
 			reinterpret_cast<PoolVector<uint8_t> *>(_data._mem)->~PoolVector<uint8_t>();
-
 		} break;
 		case POOL_INT_ARRAY: {
 
 			reinterpret_cast<PoolVector<int> *>(_data._mem)->~PoolVector<int>();
-
 		} break;
 		case POOL_REAL_ARRAY: {
 
 			reinterpret_cast<PoolVector<real_t> *>(_data._mem)->~PoolVector<real_t>();
-
 		} break;
 		case POOL_STRING_ARRAY: {
 
 			reinterpret_cast<PoolVector<String> *>(_data._mem)->~PoolVector<String>();
-
 		} break;
 		case POOL_VECTOR2_ARRAY: {
 
 			reinterpret_cast<PoolVector<Vector2> *>(_data._mem)->~PoolVector<Vector2>();
-
 		} break;
 		case POOL_VECTOR3_ARRAY: {
 
 			reinterpret_cast<PoolVector<Vector3> *>(_data._mem)->~PoolVector<Vector3>();
-
 		} break;
 		case POOL_COLOR_ARRAY: {
 
 			reinterpret_cast<PoolVector<Color> *>(_data._mem)->~PoolVector<Color>();
-
 		} break;
 		default: {} /* not needed */
 	}
@@ -2496,7 +2469,135 @@ Variant::Variant(const Vector<Color> &p_array) {
 
 void Variant::operator=(const Variant &p_variant) {
 
-	reference(p_variant);
+	if (this == &p_variant)
+		return;
+
+	if (type != p_variant.type) {
+		reference(p_variant);
+		return;
+	}
+
+	switch (p_variant.type) {
+		case NIL: {
+
+			// none
+		} break;
+
+		// atomic types
+		case BOOL: {
+
+			_data._bool = p_variant._data._bool;
+		} break;
+		case INT: {
+
+			_data._int = p_variant._data._int;
+		} break;
+		case REAL: {
+
+			_data._real = p_variant._data._real;
+		} break;
+		case STRING: {
+
+			*reinterpret_cast<String *>(_data._mem) = *reinterpret_cast<const String *>(p_variant._data._mem);
+		} break;
+
+		// math types
+
+		case VECTOR2: {
+
+			*reinterpret_cast<Vector2 *>(_data._mem) = *reinterpret_cast<const Vector2 *>(p_variant._data._mem);
+		} break;
+		case RECT2: {
+
+			*reinterpret_cast<Rect2 *>(_data._mem) = *reinterpret_cast<const Rect2 *>(p_variant._data._mem);
+		} break;
+		case TRANSFORM2D: {
+
+			*_data._transform2d = *(p_variant._data._transform2d);
+		} break;
+		case VECTOR3: {
+
+			*reinterpret_cast<Vector3 *>(_data._mem) = *reinterpret_cast<const Vector3 *>(p_variant._data._mem);
+		} break;
+		case PLANE: {
+
+			*reinterpret_cast<Plane *>(_data._mem) = *reinterpret_cast<const Plane *>(p_variant._data._mem);
+		} break;
+
+		case RECT3: {
+
+			*_data._rect3 = *(p_variant._data._rect3);
+		} break;
+		case QUAT: {
+
+			*reinterpret_cast<Quat *>(_data._mem) = *reinterpret_cast<const Quat *>(p_variant._data._mem);
+		} break;
+		case BASIS: {
+
+			*_data._basis = *(p_variant._data._basis);
+		} break;
+		case TRANSFORM: {
+
+			*_data._transform = *(p_variant._data._transform);
+		} break;
+
+		// misc types
+		case COLOR: {
+
+			*reinterpret_cast<Color *>(_data._mem) = *reinterpret_cast<const Color *>(p_variant._data._mem);
+		} break;
+		case _RID: {
+
+			*reinterpret_cast<RID *>(_data._mem) = *reinterpret_cast<const RID *>(p_variant._data._mem);
+		} break;
+		case OBJECT: {
+
+			*reinterpret_cast<ObjData *>(_data._mem) = p_variant._get_obj();
+		} break;
+		case NODE_PATH: {
+
+			*reinterpret_cast<NodePath *>(_data._mem) = *reinterpret_cast<const NodePath *>(p_variant._data._mem);
+		} break;
+		case DICTIONARY: {
+
+			*reinterpret_cast<Dictionary *>(_data._mem) = *reinterpret_cast<const Dictionary *>(p_variant._data._mem);
+		} break;
+		case ARRAY: {
+
+			*reinterpret_cast<Array *>(_data._mem) = *reinterpret_cast<const Array *>(p_variant._data._mem);
+		} break;
+
+		// arrays
+		case POOL_BYTE_ARRAY: {
+
+			*reinterpret_cast<PoolVector<uint8_t> *>(_data._mem) = *reinterpret_cast<const PoolVector<uint8_t> *>(p_variant._data._mem);
+		} break;
+		case POOL_INT_ARRAY: {
+
+			*reinterpret_cast<PoolVector<int> *>(_data._mem) = *reinterpret_cast<const PoolVector<int> *>(p_variant._data._mem);
+		} break;
+		case POOL_REAL_ARRAY: {
+
+			*reinterpret_cast<PoolVector<real_t> *>(_data._mem) = *reinterpret_cast<const PoolVector<real_t> *>(p_variant._data._mem);
+		} break;
+		case POOL_STRING_ARRAY: {
+
+			*reinterpret_cast<PoolVector<String> *>(_data._mem) = *reinterpret_cast<const PoolVector<String> *>(p_variant._data._mem);
+		} break;
+		case POOL_VECTOR2_ARRAY: {
+
+			*reinterpret_cast<PoolVector<Vector2> *>(_data._mem) = *reinterpret_cast<const PoolVector<Vector2> *>(p_variant._data._mem);
+		} break;
+		case POOL_VECTOR3_ARRAY: {
+
+			*reinterpret_cast<PoolVector<Vector3> *>(_data._mem) = *reinterpret_cast<const PoolVector<Vector3> *>(p_variant._data._mem);
+		} break;
+		case POOL_COLOR_ARRAY: {
+
+			*reinterpret_cast<PoolVector<Color> *>(_data._mem) = *reinterpret_cast<const PoolVector<Color> *>(p_variant._data._mem);
+		} break;
+		default: {}
+	}
 }
 
 Variant::Variant(const IP_Address &p_address) {


### PR DESCRIPTION
As a preparation for other performance enhancements to GDScript:call() start by removing more of the GDScript runtime checks on release.

This code has been tested with 2d/platformer, 3d/platformer, 3d/materials_test, and goltorus. No regressions were found.

For the people watching at home, the reason for doing this first is so that I can test part of the new control flow necessary for a faster execution loop for GDScript opcode dispatching.

I've also identified Variant::reference() as a bottleneck for tight loops. I've added a check that will prevent Variant from clearing itself in situations where it is not necessary.

Speed difference before and after 
Before: Time taken: 50952
After (removing checks): Time taken: 37515 (73% compared to baseline)
After (also speeding up reference): Time taken: 28203 (55% compared to baseline)

for this PR for the following code:
```gdscript
func _ready():
        var time_before = OS.get_ticks_msec()

        var c
        for i in range(10000000):
                var next
                var first = 1
                var second = 2
                for c in range(40):
                        next = first + second
                        first = second
                        second = next
                c = next
        print(c)

        var total_time = OS.get_ticks_msec() - time_before
        print("Time taken: " + str(total_time))
        get_tree().quit()
        pass
```

By request some comparisons with Python 2 and 3

Python2: Time taken: 17.2206029892 (60% compared to this PR)
Python3: Time taken: 20.676743745803833 (73% compared to this PR)

For the following code:
```python
import time

def main():
    start = time.time()

    c = 0
    for i in range(10000000):
            first = 1
            second = 2
            for c in range(40):
                    next = first + second
                    first = second
                    second = next
            c = next
    print(c)

    end = time.time()
    print("Time taken: " + str(end - start))


main()
```