### PR TITLE
Implements set_margins_preset(...)

### DIFF
--- a/editor/animation_editor.cpp
+++ b/editor/animation_editor.cpp
@@ -3900,7 +3900,7 @@ AnimationKeyEditor::AnimationKeyEditor() {
 	//menu->get_popup()->connect("id_pressed",this,"_menu_callback");
 
 	hb = memnew(HBoxContainer);
-	hb->set_area_as_parent_rect();
+	hb->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	ec->add_child(hb);
 	hb->set_v_size_flags(SIZE_EXPAND_FILL);
 
@@ -3912,14 +3912,14 @@ AnimationKeyEditor::AnimationKeyEditor() {
 	track_editor->set_h_size_flags(SIZE_EXPAND_FILL);
 
 	track_pos = memnew(Control);
-	track_pos->set_area_as_parent_rect();
+	track_pos->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	track_pos->set_mouse_filter(MOUSE_FILTER_IGNORE);
 	track_editor->add_child(track_pos);
 	track_pos->connect("draw", this, "_track_position_draw");
 
 	select_anim_warning = memnew(Label);
 	track_editor->add_child(select_anim_warning);
-	select_anim_warning->set_area_as_parent_rect();
+	select_anim_warning->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	select_anim_warning->set_text(TTR("Select an AnimationPlayer from the Scene Tree to edit animations."));
 	select_anim_warning->set_autowrap(true);
 	select_anim_warning->set_align(Label::ALIGN_CENTER);
@@ -3936,7 +3936,7 @@ AnimationKeyEditor::AnimationKeyEditor() {
 	key_editor_tab->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
 
 	key_editor = memnew(PropertyEditor);
-	key_editor->set_area_as_parent_rect();
+	key_editor->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	key_editor->hide_top_label();
 	key_editor->set_name(TTR("Key"));
 	key_editor_tab->add_child(key_editor);

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1790,7 +1790,7 @@ EditorHelp::EditorHelp() {
 	{
 		class_desc = memnew(RichTextLabel);
 		vbc->add_child(class_desc);
-		class_desc->set_area_as_parent_rect();
+		class_desc->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 		class_desc->set_v_size_flags(SIZE_EXPAND_FILL);
 		class_desc->add_color_override("selection_color", EDITOR_DEF("text_editor/highlighting/selection_color", Color(0.2, 0.2, 1)));
 		class_desc->connect("meta_clicked", this, "_class_desc_select");
@@ -1900,7 +1900,7 @@ EditorHelpBit::EditorHelpBit() {
 
 	rich_text = memnew(RichTextLabel);
 	add_child(rich_text);
-	rich_text->set_area_as_parent_rect();
+	rich_text->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	rich_text->connect("meta_clicked", this, "_meta_clicked");
 	rich_text->add_color_override("selection_color", EDITOR_DEF("text_editor/highlighting/selection_color", Color(0.2, 0.2, 1)));
 	set_custom_minimum_size(Size2(0, 70 * EDSCALE));

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -158,7 +158,7 @@ EditorLog::EditorLog() {
 	log->set_selection_enabled(true);
 	log->set_focus_mode(FOCUS_CLICK);
 	log->set_custom_minimum_size(Size2(0, 180) * EDSCALE);
-	log->set_area_as_parent_rect();
+	log->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	log->set_v_size_flags(SIZE_EXPAND_FILL);
 	log->set_h_size_flags(SIZE_EXPAND_FILL);
 	vb->add_child(log);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4649,11 +4649,11 @@ EditorNode::EditorNode() {
 
 	theme_base = memnew(Control);
 	add_child(theme_base);
-	theme_base->set_area_as_parent_rect();
+	theme_base->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 
 	gui_base = memnew(Panel);
 	theme_base->add_child(gui_base);
-	gui_base->set_area_as_parent_rect();
+	gui_base->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 
 	Ref<Theme> theme = create_editor_theme();
 	theme_base->set_theme(theme);
@@ -4672,7 +4672,7 @@ EditorNode::EditorNode() {
 
 	main_vbox = memnew(VBoxContainer);
 	gui_base->add_child(main_vbox);
-	main_vbox->set_area_as_parent_rect(8);
+	main_vbox->set_anchors_and_margins_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 8);
 	main_vbox->set_margin(MARGIN_TOP, 5 * EDSCALE);
 
 	menu_hb = memnew(HBoxContainer);
@@ -5061,7 +5061,7 @@ EditorNode::EditorNode() {
 	play_cc = memnew(CenterContainer);
 	play_cc->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
 	menu_hb->add_child(play_cc);
-	play_cc->set_area_as_parent_rect();
+	play_cc->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	play_cc->set_anchor_and_margin(MARGIN_BOTTOM, Control::ANCHOR_BEGIN, 10);
 	play_cc->set_margin(MARGIN_TOP, 5);
 

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1426,7 +1426,7 @@ AnimationPlayerEditorPlugin::AnimationPlayerEditorPlugin(EditorNode *p_node) {
 	editor->add_bottom_panel_item(TTR("Animation"), anim_editor);
 	/*
 	editor->get_viewport()->add_child(anim_editor);
-	anim_editor->set_area_as_parent_rect();
+	anim_editor->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	anim_editor->set_anchor( MARGIN_TOP, Control::ANCHOR_END);
 	anim_editor->set_margin( MARGIN_TOP, 75 );
 	anim_editor->set_anchor( MARGIN_RIGHT, Control::ANCHOR_END);

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -1478,7 +1478,7 @@ AssetLibraryEditorPlugin::AssetLibraryEditorPlugin(EditorNode *p_node) {
 	addon_library = memnew(EditorAssetLibrary);
 	addon_library->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	editor->get_viewport()->add_child(addon_library);
-	addon_library->set_area_as_parent_rect();
+	addon_library->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	addon_library->hide();
 }
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3050,7 +3050,7 @@ void CanvasItemEditor::_set_full_rect() {
 
 		Control *c = Object::cast_to<Control>(E->get());
 
-		undo_redo->add_do_method(c, "set_anchors_preset", PRESET_WIDE);
+		undo_redo->add_do_method(c, "set_anchors_preset", Control::PRESET_WIDE);
 		undo_redo->add_do_method(c, "set_margin", MARGIN_LEFT, 0);
 		undo_redo->add_do_method(c, "set_margin", MARGIN_TOP, 0);
 		undo_redo->add_do_method(c, "set_margin", MARGIN_RIGHT, 0);
@@ -3301,7 +3301,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 			_set_anchors_preset(PRESET_HCENTER_WIDE);
 		} break;
 		case ANCHOR_ALIGN_WIDE: {
-			_set_anchors_preset(PRESET_WIDE);
+			_set_anchors_preset(Control::PRESET_WIDE);
 		} break;
 		case ANCHOR_ALIGN_WIDE_FIT: {
 			_set_full_rect();
@@ -3698,7 +3698,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 
 	hb = memnew(HBoxContainer);
 	add_child(hb);
-	hb->set_area_as_parent_rect();
+	hb->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 
 	bottom_split = memnew(VSplitContainer);
 	add_child(bottom_split);
@@ -3721,19 +3721,19 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	viewport_base->add_child(viewport_scrollable);
 	viewport_scrollable->set_mouse_filter(MOUSE_FILTER_PASS);
 	viewport_scrollable->set_draw_behind_parent(true);
-	viewport_scrollable->set_area_as_parent_rect();
+	viewport_scrollable->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	viewport_scrollable->set_begin(Point2(RULER_WIDTH, RULER_WIDTH));
 
 	ViewportContainer *scene_tree = memnew(ViewportContainer);
 	viewport_scrollable->add_child(scene_tree);
 	scene_tree->set_stretch(true);
-	scene_tree->set_area_as_parent_rect();
+	scene_tree->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	scene_tree->add_child(p_editor->get_scene_root());
 
 	viewport = memnew(CanvasItemEditorViewport(p_editor, this));
 	viewport_scrollable->add_child(viewport);
 	viewport->set_mouse_filter(MOUSE_FILTER_PASS);
-	viewport->set_area_as_parent_rect();
+	viewport->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	viewport->set_clip_contents(true);
 	viewport->connect("draw", this, "_draw_viewport");
 
@@ -4061,7 +4061,7 @@ CanvasItemEditorPlugin::CanvasItemEditorPlugin(EditorNode *p_node) {
 	canvas_item_editor = memnew(CanvasItemEditor(editor));
 	canvas_item_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	editor->get_viewport()->add_child(canvas_item_editor);
-	canvas_item_editor->set_area_as_parent_rect();
+	canvas_item_editor->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	canvas_item_editor->hide();
 }
 

--- a/editor/plugins/cube_grid_theme_editor_plugin.cpp
+++ b/editor/plugins/cube_grid_theme_editor_plugin.cpp
@@ -241,7 +241,7 @@ MeshLibraryEditor::MeshLibraryEditor(EditorNode *p_editor) {
 	file->connect("file_selected", this, "_import_scene_cbk");
 
 	Panel *panel = memnew(Panel);
-	panel->set_area_as_parent_rect();
+	panel->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	add_child(panel);
 	MenuButton *options = memnew(MenuButton);
 	panel->add_child(options);
@@ -289,7 +289,7 @@ MeshLibraryEditorPlugin::MeshLibraryEditorPlugin(EditorNode *p_node) {
 	theme_editor = memnew(MeshLibraryEditor(p_node));
 
 	p_node->get_viewport()->add_child(theme_editor);
-	theme_editor->set_area_as_parent_rect();
+	theme_editor->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	theme_editor->set_anchor(MARGIN_BOTTOM, Control::ANCHOR_BEGIN);
 	theme_editor->set_end(Point2(0, 22));
 	theme_editor->hide();

--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -335,7 +335,7 @@ MaterialEditor::MaterialEditor() {
 
 	HBoxContainer *hb = memnew( HBoxContainer );
 	add_child(hb);
-	hb->set_area_as_parent_rect(2);
+	hb->set_anchors_and_margins_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 2);
 
 	VBoxContainer *vb_shape = memnew( VBoxContainer );
 	hb->add_child(vb_shape);

--- a/editor/plugins/mesh_editor_plugin.cpp
+++ b/editor/plugins/mesh_editor_plugin.cpp
@@ -162,7 +162,7 @@ MeshEditor::MeshEditor() {
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	add_child(hb);
-	hb->set_area_as_parent_rect(2);
+	hb->set_anchors_and_margins_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 2);
 
 	hb->add_spacer();
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1455,7 +1455,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	code_editor = memnew(CodeTextEditor);
 	add_child(code_editor);
 	code_editor->add_constant_override("separation", 0);
-	code_editor->set_area_as_parent_rect();
+	code_editor->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	code_editor->connect("validate_script", this, "_validate_script");
 	code_editor->connect("load_theme_settings", this, "_load_theme_settings");
 	code_editor->set_code_complete_func(_code_complete_scripts, this);

--- a/editor/plugins/shader_graph_editor_plugin.cpp
+++ b/editor/plugins/shader_graph_editor_plugin.cpp
@@ -2921,7 +2921,7 @@ ShaderGraphEditorPlugin::ShaderGraphEditorPlugin(EditorNode *p_node, bool p_2d) 
 
 
 		//editor->get_viewport()->add_child(shader_editor);
-		//shader_editor->set_area_as_parent_rect();
+		//shader_editor->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 		//shader_editor->hide();
 
 }

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -2836,7 +2836,7 @@ SpatialEditorViewport::SpatialEditorViewport(SpatialEditor *p_spatial_editor, Ed
 	ViewportContainer *c = memnew(ViewportContainer);
 	c->set_stretch(true);
 	add_child(c);
-	c->set_area_as_parent_rect();
+	c->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	viewport = memnew(Viewport);
 	viewport->set_disable_input(true);
 
@@ -2844,7 +2844,7 @@ SpatialEditorViewport::SpatialEditorViewport(SpatialEditor *p_spatial_editor, Ed
 	surface = memnew(Control);
 	surface->set_drag_forwarding(this);
 	add_child(surface);
-	surface->set_area_as_parent_rect();
+	surface->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	surface->set_clip_contents(true);
 	camera = memnew(Camera);
 	camera->set_disable_gizmo(true);
@@ -4216,7 +4216,7 @@ void SpatialEditor::_toggle_maximize_view(Object *p_viewport) {
 
 		for (uint32_t i = 0; i < VIEWPORTS_COUNT; i++) {
 			if (i == (uint32_t)index)
-				viewports[i]->set_area_as_parent_rect();
+				viewports[i]->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 			else
 				viewports[i]->hide();
 		}
@@ -4642,7 +4642,7 @@ SpatialEditorPlugin::SpatialEditorPlugin(EditorNode *p_node) {
 	spatial_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	editor->get_viewport()->add_child(spatial_editor);
 
-	//spatial_editor->set_area_as_parent_rect();
+	//spatial_editor->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	spatial_editor->hide();
 	spatial_editor->connect("transform_key_request", editor, "_transform_keyed");
 

--- a/editor/plugins/style_box_editor_plugin.cpp
+++ b/editor/plugins/style_box_editor_plugin.cpp
@@ -57,7 +57,7 @@ StyleBoxEditor::StyleBoxEditor() {
 
 	panel = memnew(Panel);
 	add_child(panel);
-	panel->set_area_as_parent_rect();
+	panel->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 
 	Label *l = memnew(Label);
 	l->set_text(TTR("StyleBox Preview:"));

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -773,7 +773,7 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 
 	VBoxContainer *main_vb = memnew(VBoxContainer);
 	add_child(main_vb);
-	main_vb->set_area_as_parent_rect(0);
+	main_vb->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	HBoxContainer *hb_tools = memnew(HBoxContainer);
 	main_vb->add_child(hb_tools);
 

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -607,7 +607,7 @@ ThemeEditor::ThemeEditor() {
 
 	scroll = memnew(ScrollContainer);
 	add_child(scroll);
-	scroll->set_area_as_parent_rect(3);
+	scroll->set_anchors_and_margins_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 3);
 	scroll->set_margin(MARGIN_TOP, 30 * EDSCALE);
 	//scroll->set_enable_h_scroll(true);
 	scroll->set_enable_v_scroll(true);
@@ -621,7 +621,7 @@ ThemeEditor::ThemeEditor() {
 
 	main_vb = memnew(VBoxContainer);
 	panel->add_child(main_vb);
-	main_vb->set_area_as_parent_rect(4 * EDSCALE);
+	main_vb->set_anchors_and_margins_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 4 * EDSCALE);
 
 	HBoxContainer *hb_menu = memnew(HBoxContainer);
 	main_vb->add_child(hb_menu);
@@ -648,7 +648,7 @@ ThemeEditor::ThemeEditor() {
 	main_hb->add_child(first_vb);
 
 	//main_panel->add_child(panel);
-	//panel->set_area_as_parent_rect();
+	//panel->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	//panel->set_margin( MARGIN_TOP,20 );
 
 	first_vb->add_child(memnew(Label("Label")));

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -238,7 +238,7 @@ void TileSetEditor::_bind_methods() {
 TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 
 	Panel *panel = memnew(Panel);
-	panel->set_area_as_parent_rect();
+	panel->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	add_child(panel);
 	MenuButton *options = memnew(MenuButton);
 	panel->add_child(options);
@@ -293,7 +293,7 @@ TileSetEditorPlugin::TileSetEditorPlugin(EditorNode *p_node) {
 	tileset_editor = memnew(TileSetEditor(p_node));
 
 	p_node->get_viewport()->add_child(tileset_editor);
-	tileset_editor->set_area_as_parent_rect();
+	tileset_editor->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	tileset_editor->set_anchor(MARGIN_BOTTOM, Control::ANCHOR_BEGIN);
 	tileset_editor->set_end(Point2(0, 22));
 	tileset_editor->hide();

--- a/editor/progress_dialog.cpp
+++ b/editor/progress_dialog.cpp
@@ -49,7 +49,7 @@ void BackgroundProgress::_add_task(const String &p_task, const String &p_label, 
 	Control *ec = memnew(Control);
 	ec->set_h_size_flags(SIZE_EXPAND_FILL);
 	ec->set_v_size_flags(SIZE_EXPAND_FILL);
-	t.progress->set_area_as_parent_rect();
+	t.progress->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	ec->add_child(t.progress);
 	ec->set_custom_minimum_size(Size2(80, 5) * EDSCALE);
 	t.hb->add_child(ec);
@@ -222,7 +222,7 @@ ProgressDialog::ProgressDialog() {
 
 	main = memnew(VBoxContainer);
 	add_child(main);
-	main->set_area_as_parent_rect();
+	main->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	set_exclusive(true);
 	last_progress_tick = 0;
 	singleton = this;

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -894,7 +894,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	Panel *features_panel = memnew(Panel);
 	custom_feature_display = memnew(RichTextLabel);
 	features_panel->add_child(custom_feature_display);
-	custom_feature_display->set_area_as_parent_rect(10 * EDSCALE);
+	custom_feature_display->set_anchors_and_margins_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 10 * EDSCALE);
 	custom_feature_display->set_v_size_flags(SIZE_EXPAND_FILL);
 	feature_vb->add_margin_child(TTR("Feature List:"), features_panel, true);
 	sections->add_child(feature_vb);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1329,21 +1329,21 @@ ProjectManager::ProjectManager() {
 
 	FileDialog::set_default_show_hidden_files(EditorSettings::get_singleton()->get("filesystem/file_dialog/show_hidden_files"));
 
-	set_area_as_parent_rect();
+	set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	set_theme(create_editor_theme());
 
 	gui_base = memnew(Control);
 	add_child(gui_base);
-	gui_base->set_area_as_parent_rect();
+	gui_base->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	gui_base->set_theme(create_custom_theme());
 
 	Panel *panel = memnew(Panel);
 	gui_base->add_child(panel);
-	panel->set_area_as_parent_rect();
+	panel->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 
 	VBoxContainer *vb = memnew(VBoxContainer);
 	panel->add_child(vb);
-	vb->set_area_as_parent_rect(20 * EDSCALE);
+	vb->set_anchors_and_margins_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 20 * EDSCALE);
 	vb->set_margin(MARGIN_TOP, 4 * EDSCALE);
 	vb->set_margin(MARGIN_BOTTOM, -4 * EDSCALE);
 	vb->add_constant_override("separation", 15 * EDSCALE);

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -1504,7 +1504,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 
 	Control *input_base = memnew(Control);
 	input_base->set_name(TTR("Input Map"));
-	input_base->set_area_as_parent_rect();
+	input_base->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	tab_container->add_child(input_base);
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
@@ -1552,7 +1552,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 
 	l = memnew(Label);
 	l->set_text(TTR("Press a Key.."));
-	l->set_area_as_parent_rect();
+	l->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	l->set_align(Label::ALIGN_CENTER);
 	l->set_margin(MARGIN_TOP, 20);
 	l->set_anchor_and_margin(MARGIN_BOTTOM, ANCHOR_BEGIN, 30);

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -1811,7 +1811,7 @@ CustomPropertyEditor::CustomPropertyEditor() {
 
 	text_edit = memnew(TextEdit);
 	add_child(text_edit);
-	text_edit->set_area_as_parent_rect(5);
+	text_edit->set_anchors_and_margins_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 5);
 	text_edit->set_margin(MARGIN_BOTTOM, -30);
 
 	text_edit->hide();
@@ -1870,12 +1870,12 @@ CustomPropertyEditor::CustomPropertyEditor() {
 
 	spinbox = memnew(SpinBox);
 	add_child(spinbox);
-	spinbox->set_area_as_parent_rect(5);
+	spinbox->set_anchors_and_margins_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 5);
 	spinbox->connect("value_changed", this, "_range_modified");
 
 	slider = memnew(HSlider);
 	add_child(slider);
-	slider->set_area_as_parent_rect(5);
+	slider->set_anchors_and_margins_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 5);
 	slider->connect("value_changed", this, "_range_modified");
 
 	create_dialog = NULL;

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1622,7 +1622,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 	tabs->add_style_override("panel", editor->get_gui_base()->get_stylebox("DebuggerPanel", "EditorStyles"));
 	tabs->add_style_override("tab_fg", editor->get_gui_base()->get_stylebox("DebuggerTabFG", "EditorStyles"));
 	tabs->add_style_override("tab_bg", editor->get_gui_base()->get_stylebox("DebuggerTabBG", "EditorStyles"));
-	tabs->set_area_as_parent_rect();
+	tabs->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	add_child(tabs);
 
 	{ //debugger

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -374,7 +374,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 
 	l = memnew(Label);
 	l->set_text(TTR("Press a Key.."));
-	l->set_area_as_parent_rect();
+	l->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	l->set_align(Label::ALIGN_CENTER);
 	l->set_margin(MARGIN_TOP, 20);
 	l->set_anchor_and_margin(MARGIN_BOTTOM, ANCHOR_BEGIN, 30);

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -3267,7 +3267,7 @@ VisualScriptEditor::VisualScriptEditor() {
 
 	graph = memnew(GraphEdit);
 	add_child(graph);
-	graph->set_area_as_parent_rect();
+	graph->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	graph->set_h_size_flags(SIZE_EXPAND_FILL);
 	graph->connect("node_selected", this, "_node_selected");
 	graph->connect("_begin_node_move", this, "_begin_node_move");

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -461,7 +461,7 @@ void ColorPicker::_screen_pick_pressed() {
 		screen = memnew(Control);
 		r->add_child(screen);
 		screen->set_as_toplevel(true);
-		screen->set_area_as_parent_rect();
+		screen->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 		screen->set_default_cursor_shape(CURSOR_POINTING_HAND);
 		screen->connect("gui_input", this, "_screen_input");
 	}

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1471,6 +1471,110 @@ void Control::set_anchors_preset(LayoutPreset p_preset, bool p_keep_margin) {
 	}
 }
 
+void Control::set_margins_preset(LayoutPreset p_preset, LayoutPresetMode p_resize_mode, int p_margin) {
+	if (!is_inside_tree())
+		return;
+
+	Point2 new_pos;
+	Size2 min_size = get_minimum_size();
+	Size2 new_size = get_size();
+	Size2 parent_size = get_parent_area_size();
+
+	// Width
+	switch (p_preset) {
+		case PRESET_TOP_WIDE:
+		case PRESET_BOTTOM_WIDE:
+		case PRESET_HCENTER_WIDE:
+		case PRESET_WIDE:
+			new_size.x = parent_size.x - 2 * p_margin;
+			break;
+		default:
+			if (p_resize_mode == PRESET_MODE_MINSIZE || p_resize_mode == PRESET_MODE_KEEP_HEIGHT) {
+				new_size.x = min_size.x;
+			}
+			break;
+	}
+
+	// Height
+	switch (p_preset) {
+		case PRESET_LEFT_WIDE:
+		case PRESET_RIGHT_WIDE:
+		case PRESET_VCENTER_WIDE:
+		case PRESET_WIDE:
+			new_size.y = parent_size.y - 2 * p_margin;
+			break;
+		default:
+			if (p_resize_mode == PRESET_MODE_MINSIZE || p_resize_mode == PRESET_MODE_KEEP_WIDTH) {
+				new_size.y = min_size.y;
+			}
+			break;
+	}
+
+	// x pos
+	switch (p_preset) {
+		case PRESET_TOP_LEFT:
+		case PRESET_BOTTOM_LEFT:
+		case PRESET_CENTER_LEFT:
+		case PRESET_TOP_WIDE:
+		case PRESET_BOTTOM_WIDE:
+		case PRESET_LEFT_WIDE:
+		case PRESET_HCENTER_WIDE:
+		case PRESET_WIDE:
+			new_pos.x = p_margin;
+			break;
+
+		case PRESET_CENTER_TOP:
+		case PRESET_CENTER_BOTTOM:
+		case PRESET_CENTER:
+		case PRESET_VCENTER_WIDE:
+			new_pos.x = (parent_size.x - new_size.x) / 2.0;
+			break;
+
+		case PRESET_TOP_RIGHT:
+		case PRESET_BOTTOM_RIGHT:
+		case PRESET_CENTER_RIGHT:
+		case PRESET_RIGHT_WIDE:
+			new_pos.x = parent_size.x - new_size.x - p_margin;
+			break;
+	}
+
+	// y pos
+	switch (p_preset) {
+		case PRESET_TOP_LEFT:
+		case PRESET_TOP_RIGHT:
+		case PRESET_CENTER_TOP:
+		case PRESET_LEFT_WIDE:
+		case PRESET_RIGHT_WIDE:
+		case PRESET_TOP_WIDE:
+		case PRESET_VCENTER_WIDE:
+		case PRESET_WIDE:
+			new_pos.y = p_margin;
+			break;
+
+		case PRESET_CENTER_LEFT:
+		case PRESET_CENTER_RIGHT:
+		case PRESET_CENTER:
+		case PRESET_HCENTER_WIDE:
+			new_pos.y = (parent_size.y - new_size.y) / 2.0;
+			break;
+
+		case PRESET_BOTTOM_LEFT:
+		case PRESET_BOTTOM_RIGHT:
+		case PRESET_CENTER_BOTTOM:
+		case PRESET_BOTTOM_WIDE:
+			new_pos.y = parent_size.y - new_size.y - p_margin;
+			break;
+	}
+
+	set_position(new_pos);
+	set_size(new_size);
+}
+
+void Control::set_anchors_and_margins_preset(LayoutPreset p_preset, LayoutPresetMode p_resize_mode, int p_margin) {
+	set_anchors_preset(p_preset);
+	set_margins_preset(p_preset, p_resize_mode, p_margin);
+}
+
 float Control::get_anchor(Margin p_margin) const {
 
 	return data.anchor[p_margin];
@@ -2471,9 +2575,11 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("accept_event"), &Control::accept_event);
 	ClassDB::bind_method(D_METHOD("get_minimum_size"), &Control::get_minimum_size);
 	ClassDB::bind_method(D_METHOD("get_combined_minimum_size"), &Control::get_combined_minimum_size);
+	ClassDB::bind_method(D_METHOD("set_anchors_preset", "preset", "keep_margin"), &Control::set_anchors_preset, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("set_margins_preset", "preset", "resize_mode", "margin"), &Control::set_margins_preset, DEFVAL(PRESET_MODE_MINSIZE), DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("set_anchors_and_margins_preset", "preset", "resize_mode", "margin"), &Control::set_anchors_and_margins_preset, DEFVAL(PRESET_MODE_MINSIZE), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("set_anchor", "margin", "anchor", "keep_margin", "push_opposite_anchor"), &Control::set_anchor, DEFVAL(false), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("_set_anchor", "margin", "anchor"), &Control::_set_anchor);
-	ClassDB::bind_method(D_METHOD("set_anchors_preset", "preset", "keep_margin"), &Control::set_anchors_preset, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_anchor", "margin"), &Control::get_anchor);
 	ClassDB::bind_method(D_METHOD("set_margin", "margin", "offset"), &Control::set_margin);
 	ClassDB::bind_method(D_METHOD("set_anchor_and_margin", "margin", "anchor", "offset", "push_opposite_anchor"), &Control::set_anchor_and_margin, DEFVAL(false));
@@ -2688,6 +2794,11 @@ void Control::_bind_methods() {
 	BIND_ENUM_CONSTANT(PRESET_VCENTER_WIDE);
 	BIND_ENUM_CONSTANT(PRESET_HCENTER_WIDE);
 	BIND_ENUM_CONSTANT(PRESET_WIDE);
+
+	BIND_ENUM_CONSTANT(PRESET_MODE_MINSIZE);
+	BIND_ENUM_CONSTANT(PRESET_MODE_KEEP_HEIGHT);
+	BIND_ENUM_CONSTANT(PRESET_MODE_KEEP_WIDTH);
+	BIND_ENUM_CONSTANT(PRESET_MODE_KEEP_SIZE);
 
 	BIND_ENUM_CONSTANT(SIZE_EXPAND);
 	BIND_ENUM_CONSTANT(SIZE_FILL);

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1726,20 +1726,6 @@ Rect2 Control::get_item_rect() const {
 	return Rect2(Point2(), get_size());
 }
 
-void Control::set_area_as_parent_rect(int p_margin) {
-
-	data.anchor[MARGIN_LEFT] = ANCHOR_BEGIN;
-	data.margin[MARGIN_LEFT] = p_margin;
-	data.anchor[MARGIN_TOP] = ANCHOR_BEGIN;
-	data.margin[MARGIN_TOP] = p_margin;
-	data.anchor[MARGIN_RIGHT] = ANCHOR_END;
-	data.margin[MARGIN_RIGHT] = -p_margin;
-	data.anchor[MARGIN_BOTTOM] = ANCHOR_END;
-	data.margin[MARGIN_BOTTOM] = -p_margin;
-
-	_size_changed();
-}
-
 void Control::add_icon_override(const StringName &p_name, const Ref<Texture> &p_icon) {
 
 	ERR_FAIL_COND(p_icon.is_null());
@@ -2611,7 +2597,6 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_global_position"), &Control::get_global_position);
 	ClassDB::bind_method(D_METHOD("get_rect"), &Control::get_rect);
 	ClassDB::bind_method(D_METHOD("get_global_rect"), &Control::get_global_rect);
-	ClassDB::bind_method(D_METHOD("set_area_as_parent_rect", "margin"), &Control::set_area_as_parent_rect, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("show_modal", "exclusive"), &Control::show_modal, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("set_focus_mode", "mode"), &Control::set_focus_mode);
 	ClassDB::bind_method(D_METHOD("get_focus_mode"), &Control::get_focus_mode);

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -348,8 +348,6 @@ public:
 	void set_scale(const Vector2 &p_scale);
 	Vector2 get_scale() const;
 
-	void set_area_as_parent_rect(int p_margin = 0);
-
 	void show_modal(bool p_exclusive = false);
 
 	void set_theme(const Ref<Theme> &p_theme);

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -124,6 +124,13 @@ public:
 		PRESET_WIDE
 	};
 
+	enum LayoutPresetMode {
+		PRESET_MODE_MINSIZE,
+		PRESET_MODE_KEEP_WIDTH,
+		PRESET_MODE_KEEP_HEIGHT,
+		PRESET_MODE_KEEP_SIZE
+	};
+
 private:
 	struct CComparator {
 
@@ -294,34 +301,32 @@ public:
 
 	/* POSITIONING */
 
-	void set_anchor(Margin p_margin, float p_anchor, bool p_keep_margin = false, bool p_push_opposite_anchor = true);
-	void set_anchor_and_margin(Margin p_margin, float p_anchor, float p_pos, bool p_push_opposite_anchor = true);
 	void set_anchors_preset(LayoutPreset p_preset, bool p_keep_margin = false);
+	void set_margins_preset(LayoutPreset p_preset, LayoutPresetMode p_resize_mode = PRESET_MODE_MINSIZE, int p_margin = 0);
+	void set_anchors_and_margins_preset(LayoutPreset p_preset, LayoutPresetMode p_resize_mode = PRESET_MODE_MINSIZE, int p_margin = 0);
 
+	void set_anchor(Margin p_margin, float p_anchor, bool p_keep_margin = false, bool p_push_opposite_anchor = true);
 	float get_anchor(Margin p_margin) const;
 
 	void set_margin(Margin p_margin, float p_value);
+	float get_margin(Margin p_margin) const;
+
+	void set_anchor_and_margin(Margin p_margin, float p_anchor, float p_pos, bool p_push_opposite_anchor = true);
 
 	void set_begin(const Point2 &p_point); // helper
 	void set_end(const Point2 &p_point); // helper
 
-	void set_h_grow_direction(GrowDirection p_direction);
-	GrowDirection get_h_grow_direction() const;
-
-	void set_v_grow_direction(GrowDirection p_direction);
-	GrowDirection get_v_grow_direction() const;
-
-	float get_margin(Margin p_margin) const;
 	Point2 get_begin() const;
 	Point2 get_end() const;
 
 	void set_position(const Point2 &p_point);
-	void set_size(const Size2 &p_size);
 	void set_global_position(const Point2 &p_point);
-
 	Point2 get_position() const;
 	Point2 get_global_position() const;
+
+	void set_size(const Size2 &p_size);
 	Size2 get_size() const;
+
 	Rect2 get_rect() const;
 	Rect2 get_global_rect() const;
 	Rect2 get_window_rect() const; ///< use with care, as it blocks waiting for the visual server
@@ -330,6 +335,12 @@ public:
 	void set_rotation_deg(float p_degrees);
 	float get_rotation() const;
 	float get_rotation_deg() const;
+
+	void set_h_grow_direction(GrowDirection p_direction);
+	GrowDirection get_h_grow_direction() const;
+
+	void set_v_grow_direction(GrowDirection p_direction);
+	GrowDirection get_v_grow_direction() const;
 
 	void set_pivot_offset(const Vector2 &p_pivot);
 	Vector2 get_pivot_offset() const;
@@ -449,6 +460,7 @@ VARIANT_ENUM_CAST(Control::FocusMode);
 VARIANT_ENUM_CAST(Control::SizeFlags);
 VARIANT_ENUM_CAST(Control::CursorShape);
 VARIANT_ENUM_CAST(Control::LayoutPreset);
+VARIANT_ENUM_CAST(Control::LayoutPresetMode);
 VARIANT_ENUM_CAST(Control::MouseFilter);
 VARIANT_ENUM_CAST(Control::GrowDirection);
 VARIANT_ENUM_CAST(Control::Anchor);

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -1182,7 +1182,7 @@ GraphEdit::GraphEdit() {
 	top_layer = memnew(GraphEditFilter(this));
 	add_child(top_layer);
 	top_layer->set_mouse_filter(MOUSE_FILTER_PASS);
-	top_layer->set_area_as_parent_rect();
+	top_layer->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	top_layer->connect("draw", this, "_top_layer_draw");
 	top_layer->set_mouse_filter(MOUSE_FILTER_PASS);
 	top_layer->connect("gui_input", this, "_top_layer_input");

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -265,7 +265,7 @@ void PopupPanel::set_child_rect(Control *p_child) {
 	ERR_FAIL_NULL(p_child);
 
 	Ref<StyleBox> p = get_stylebox("panel");
-	p_child->set_area_as_parent_rect();
+	p_child->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	p_child->set_margin(MARGIN_LEFT, p->get_margin(MARGIN_LEFT));
 	p_child->set_margin(MARGIN_RIGHT, -p->get_margin(MARGIN_RIGHT));
 	p_child->set_margin(MARGIN_TOP, p->get_margin(MARGIN_TOP));

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -268,7 +268,7 @@ SpinBox::SpinBox() {
 	line_edit = memnew(LineEdit);
 	add_child(line_edit);
 
-	line_edit->set_area_as_parent_rect();
+	line_edit->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	//connect("value_changed",this,"_value_changed");
 	line_edit->connect("text_entered", this, "_text_entered", Vector<Variant>(), CONNECT_DEFERRED);
 	line_edit->connect("focus_exited", this, "_line_edit_focus_exit", Vector<Variant>(), CONNECT_DEFERRED);

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -367,7 +367,7 @@ void TabContainer::add_child_notify(Node *p_child) {
 		current = 0;
 		previous = 0;
 	}
-	c->set_area_as_parent_rect();
+	c->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	if (tabs_visible)
 		c->set_margin(MARGIN_TOP, _get_top_margin());
 	Ref<StyleBox> sb = get_stylebox("panel");
@@ -401,7 +401,7 @@ void TabContainer::set_current_tab(int p_current) {
 		Control *c = tabs[i];
 		if (i == current) {
 			c->show();
-			c->set_area_as_parent_rect();
+			c->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 			if (tabs_visible)
 				c->set_margin(MARGIN_TOP, _get_top_margin());
 			c->set_margin(Margin(MARGIN_TOP), c->get_margin(Margin(MARGIN_TOP)) + sb->get_margin(Margin(MARGIN_TOP)));


### PR DESCRIPTION
Allows to set margins using a Layout preset like for anchors.
Replaces set_area_as_parent_rect in most cases.

It should allow for a new menu to automatcally move control nodes relatively to its parent. (now it only exists for anchors)