### PR TITLE
Set Android minSdkVersion to 18

### DIFF
--- a/platform/android/AndroidManifest.xml.template
+++ b/platform/android/AndroidManifest.xml.template
@@ -17,7 +17,7 @@
                   android:launchMode="singleTask"
                   android:screenOrientation="landscape"
                   android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize">
-                                                                                                  
+
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -26,7 +26,7 @@
 	<service android:name="org.godotengine.godot.GodotDownloaderService" />
 
 
-  
+
 
 $$ADD_APPLICATION_CHUNKS$$
 
@@ -200,6 +200,6 @@ $$ADD_PERMISSION_CHUNKS$$
 <uses-permission android:name="godot.custom.18"/>
 <uses-permission android:name="godot.custom.19"/>
 
-<uses-sdk android:minSdkVersion="10" android:targetSdkVersion="23"/>
-         
-</manifest> 
+<uses-sdk android:minSdkVersion="18" android:targetSdkVersion="23"/>
+
+</manifest>

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -73,7 +73,7 @@ for x in env.android_gradle_plugins:
 gradle_classpath = ""
 for x in env.android_gradle_classpath:
 	gradle_classpath += "\t\tclasspath \"" + x + "\"\n"
-	
+
 gradle_res_dirs_text = ""
 
 for x in env.android_res_dirs:
@@ -93,13 +93,13 @@ gradle_asset_dirs_text = ""
 
 gradle_default_config_text = ""
 
-minSdk = 14
+minSdk = 18
 targetSdk = 23
 
 for x in env.android_default_config:
-    if x.startswith("minSdkVersion") and int(x.split(" ")[-1]) < minSdk: 
+    if x.startswith("minSdkVersion") and int(x.split(" ")[-1]) < minSdk:
         x = "minSdkVersion " + str(minSdk)
-    if x.startswith("targetSdkVersion") and int(x.split(" ")[-1]) > targetSdk: 
+    if x.startswith("targetSdkVersion") and int(x.split(" ")[-1]) > targetSdk:
         x = "targetSdkVersion " + str(targetSdk)
 
     gradle_default_config_text += x + "\n\t\t"


### PR DESCRIPTION
It's the minimum version where GLES 3 API is available. It is already
the version Godot binary is compiled with for Android, but the config
files were not updated in time.