### PR TITLE
Do not compile Recast for Android

### DIFF
--- a/modules/recast/config.py
+++ b/modules/recast/config.py
@@ -1,6 +1,6 @@
 
 def can_build(platform):
-    return True
+    return platform != "android"
 
 
 def configure(env):


### PR DESCRIPTION
At least this makes Godot compile for Android until there is a better
solution.