### PR TITLE
Let queue_free() work on nodes which are not in the scene tree

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2572,8 +2572,11 @@ void Node::print_stray_nodes() {
 
 void Node::queue_delete() {
 
-	ERR_FAIL_COND(!is_inside_tree());
-	get_tree()->queue_delete(this);
+	if (is_inside_tree()) {
+		get_tree()->queue_delete(this);
+	} else {
+		SceneTree::get_singleton()->queue_delete(this);
+	}
 }
 
 Array Node::_get_children() const {


### PR DESCRIPTION
In practice such nodes could directly be free()'ed, but this little change
prevents users from leaking memory by mistake.
Closes #9074.