### PR TITLE
Rename AudioStreamPlayer2D::get_position => get_playing_position

### DIFF
--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -23,7 +23,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_position">
+		<method name="get_playback_position">
 			<return type="float">
 			</return>
 			<description>

--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -36,7 +36,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_position">
+		<method name="get_playback_position">
 			<return type="float">
 			</return>
 			<description>

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -78,7 +78,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_position">
+		<method name="get_playback_position">
 			<return type="float">
 			</return>
 			<description>

--- a/modules/opus/audio_stream_opus.cpp
+++ b/modules/opus/audio_stream_opus.cpp
@@ -247,7 +247,7 @@ void AudioStreamPlaybackOpus::play(float p_from) {
 	frames_mixed = pre_skip;
 	playing = true;
 	if (p_from > 0) {
-		seek_pos(p_from);
+		seek(p_from);
 	}
 }
 
@@ -256,7 +256,7 @@ void AudioStreamPlaybackOpus::stop() {
 	playing = false;
 }
 
-void AudioStreamPlaybackOpus::seek_pos(float p_time) {
+void AudioStreamPlaybackOpus::seek(float p_time) {
 	if (!playing) return;
 	ogg_int64_t pcm_offset = (ogg_int64_t)(p_time * osrate);
 	bool ok = op_pcm_seek(opus_file, pcm_offset) == 0;
@@ -340,7 +340,7 @@ float AudioStreamPlaybackOpus::get_length() const {
 	return length;
 }
 
-float AudioStreamPlaybackOpus::get_position() const {
+float AudioStreamPlaybackOpus::get_playback_position() const {
 
 	int32_t frames = int32_t(frames_mixed);
 	if (frames < 0)

--- a/modules/opus/audio_stream_opus.h
+++ b/modules/opus/audio_stream_opus.h
@@ -99,8 +99,8 @@ public:
 
 	virtual int get_loop_count() const { return repeats; }
 
-	virtual float get_position() const;
-	virtual void seek_pos(float p_time);
+	virtual float get_playback_position() const;
+	virtual void seek(float p_time);
 
 	virtual int get_channels() const { return stream_channels; }
 	virtual int get_mix_rate() const { return osrate; }

--- a/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
@@ -58,7 +58,7 @@ void AudioStreamPlaybackOGGVorbis::_mix_internal(AudioFrame *p_buffer, int p_fra
 			//end of file!
 			if (vorbis_stream->loop) {
 				//loop
-				seek_pos(vorbis_stream->loop_offset);
+				seek(vorbis_stream->loop_offset);
 				loops++;
 			} else {
 				for (int i = mixed; i < p_frames; i++) {
@@ -78,7 +78,7 @@ float AudioStreamPlaybackOGGVorbis::get_stream_sampling_rate() {
 void AudioStreamPlaybackOGGVorbis::start(float p_from_pos) {
 
 	active = true;
-	seek_pos(p_from_pos);
+	seek(p_from_pos);
 	loops = 0;
 	_begin_resample();
 }
@@ -97,11 +97,11 @@ int AudioStreamPlaybackOGGVorbis::get_loop_count() const {
 	return loops;
 }
 
-float AudioStreamPlaybackOGGVorbis::get_position() const {
+float AudioStreamPlaybackOGGVorbis::get_playback_position() const {
 
 	return float(frames_mixed) / vorbis_stream->sample_rate;
 }
-void AudioStreamPlaybackOGGVorbis::seek_pos(float p_time) {
+void AudioStreamPlaybackOGGVorbis::seek(float p_time) {
 
 	if (!active)
 		return;

--- a/modules/stb_vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/stb_vorbis/audio_stream_ogg_vorbis.h
@@ -67,8 +67,8 @@ public:
 
 	virtual int get_loop_count() const; //times it looped
 
-	virtual float get_position() const;
-	virtual void seek_pos(float p_time);
+	virtual float get_playback_position() const;
+	virtual void seek(float p_time);
 
 	virtual float get_length() const; //if supported, otherwise return 0
 

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -634,12 +634,12 @@ int VideoStreamPlaybackTheora::get_loop_count() const {
 	return 0;
 };
 
-float VideoStreamPlaybackTheora::get_position() const {
+float VideoStreamPlaybackTheora::get_playback_position() const {
 
 	return get_time();
 };
 
-void VideoStreamPlaybackTheora::seek_pos(float p_time){
+void VideoStreamPlaybackTheora::seek(float p_time){
 
 	// no
 };

--- a/modules/theora/video_stream_theora.h
+++ b/modules/theora/video_stream_theora.h
@@ -140,8 +140,8 @@ public:
 
 	virtual int get_loop_count() const;
 
-	virtual float get_position() const;
-	virtual void seek_pos(float p_time);
+	virtual float get_playback_position() const;
+	virtual void seek(float p_time);
 
 	void set_file(const String &p_file);
 

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -180,7 +180,7 @@ void AudioStreamPlaybackOGGVorbis::play(float p_from) {
 	frames_mixed = 0;
 	playing = true;
 	if (p_from > 0) {
-		seek_pos(p_from);
+		seek(p_from);
 	}
 }
 
@@ -203,7 +203,7 @@ void AudioStreamPlaybackOGGVorbis::stop() {
 	//_clear();
 }
 
-float AudioStreamPlaybackOGGVorbis::get_position() const {
+float AudioStreamPlaybackOGGVorbis::get_playback_position() const {
 
 	int32_t frames = int32_t(frames_mixed);
 	if (frames < 0)
@@ -211,7 +211,7 @@ float AudioStreamPlaybackOGGVorbis::get_position() const {
 	return double(frames) / stream_srate;
 }
 
-void AudioStreamPlaybackOGGVorbis::seek_pos(float p_time) {
+void AudioStreamPlaybackOGGVorbis::seek(float p_time) {
 
 	if (!playing)
 		return;

--- a/modules/vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/vorbis/audio_stream_ogg_vorbis.h
@@ -96,8 +96,8 @@ public:
 
 	virtual int get_loop_count() const;
 
-	virtual float get_position() const;
-	virtual void seek_pos(float p_time);
+	virtual float get_playback_position() const;
+	virtual void seek(float p_time);
 
 	virtual int get_channels() const { return stream_channels; }
 	virtual int get_mix_rate() const { return stream_srate; }

--- a/modules/webm/video_stream_webm.cpp
+++ b/modules/webm/video_stream_webm.cpp
@@ -204,11 +204,11 @@ float VideoStreamPlaybackWebm::get_length() const {
 	return 0.0f;
 }
 
-float VideoStreamPlaybackWebm::get_position() const {
+float VideoStreamPlaybackWebm::get_playback_position() const {
 
 	return video_pos;
 }
-void VideoStreamPlaybackWebm::seek_pos(float p_time) {
+void VideoStreamPlaybackWebm::seek(float p_time) {
 
 	//Not implemented
 }

--- a/modules/webm/video_stream_webm.h
+++ b/modules/webm/video_stream_webm.h
@@ -81,8 +81,8 @@ public:
 
 	virtual float get_length() const;
 
-	virtual float get_position() const;
-	virtual void seek_pos(float p_time);
+	virtual float get_playback_position() const;
+	virtual void seek(float p_time);
 
 	virtual void set_audio_track(int p_idx);
 

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -284,10 +284,10 @@ bool AudioStreamPlayer2D::is_playing() const {
 	return false;
 }
 
-float AudioStreamPlayer2D::get_position() {
+float AudioStreamPlayer2D::get_playback_position() {
 
 	if (stream_playback.is_valid()) {
-		return stream_playback->get_position();
+		return stream_playback->get_playback_position();
 	}
 
 	return 0;
@@ -395,7 +395,7 @@ void AudioStreamPlayer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("stop"), &AudioStreamPlayer2D::stop);
 
 	ClassDB::bind_method(D_METHOD("is_playing"), &AudioStreamPlayer2D::is_playing);
-	ClassDB::bind_method(D_METHOD("get_position"), &AudioStreamPlayer2D::get_position);
+	ClassDB::bind_method(D_METHOD("get_playback_position"), &AudioStreamPlayer2D::get_playback_position);
 
 	ClassDB::bind_method(D_METHOD("set_bus", "bus"), &AudioStreamPlayer2D::set_bus);
 	ClassDB::bind_method(D_METHOD("get_bus"), &AudioStreamPlayer2D::get_bus);

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -72,7 +72,7 @@ public:
 	void seek(float p_seconds);
 	void stop();
 	bool is_playing() const;
-	float get_position();
+	float get_playback_position();
 
 	void set_bus(const StringName &p_bus);
 	StringName get_bus() const;

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -611,10 +611,10 @@ bool AudioStreamPlayer3D::is_playing() const {
 	return false;
 }
 
-float AudioStreamPlayer3D::get_position() {
+float AudioStreamPlayer3D::get_playback_position() {
 
 	if (stream_playback.is_valid()) {
-		return stream_playback->get_position();
+		return stream_playback->get_playback_position();
 	}
 
 	return 0;
@@ -807,7 +807,7 @@ void AudioStreamPlayer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("stop"), &AudioStreamPlayer3D::stop);
 
 	ClassDB::bind_method(D_METHOD("is_playing"), &AudioStreamPlayer3D::is_playing);
-	ClassDB::bind_method(D_METHOD("get_position"), &AudioStreamPlayer3D::get_position);
+	ClassDB::bind_method(D_METHOD("get_playback_position"), &AudioStreamPlayer3D::get_playback_position);
 
 	ClassDB::bind_method(D_METHOD("set_bus", "bus"), &AudioStreamPlayer3D::set_bus);
 	ClassDB::bind_method(D_METHOD("get_bus"), &AudioStreamPlayer3D::get_bus);

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -127,7 +127,7 @@ public:
 	void seek(float p_seconds);
 	void stop();
 	bool is_playing() const;
-	float get_position();
+	float get_playback_position();
 
 	void set_bus(const StringName &p_bus);
 	StringName get_bus() const;

--- a/scene/audio/audio_player.cpp
+++ b/scene/audio/audio_player.cpp
@@ -193,10 +193,10 @@ bool AudioStreamPlayer::is_playing() const {
 	return false;
 }
 
-float AudioStreamPlayer::get_position() {
+float AudioStreamPlayer::get_playback_position() {
 
 	if (stream_playback.is_valid()) {
-		return stream_playback->get_position();
+		return stream_playback->get_playback_position();
 	}
 
 	return 0;
@@ -284,7 +284,7 @@ void AudioStreamPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("stop"), &AudioStreamPlayer::stop);
 
 	ClassDB::bind_method(D_METHOD("is_playing"), &AudioStreamPlayer::is_playing);
-	ClassDB::bind_method(D_METHOD("get_position"), &AudioStreamPlayer::get_position);
+	ClassDB::bind_method(D_METHOD("get_playback_position"), &AudioStreamPlayer::get_playback_position);
 
 	ClassDB::bind_method(D_METHOD("set_bus", "bus"), &AudioStreamPlayer::set_bus);
 	ClassDB::bind_method(D_METHOD("get_bus"), &AudioStreamPlayer::get_bus);

--- a/scene/audio/audio_player.h
+++ b/scene/audio/audio_player.h
@@ -83,7 +83,7 @@ public:
 	void seek(float p_seconds);
 	void stop();
 	bool is_playing() const;
-	float get_position();
+	float get_playback_position();
 
 	void set_bus(const StringName &p_bus);
 	StringName get_bus() const;

--- a/scene/gui/video_player.cpp
+++ b/scene/gui/video_player.cpp
@@ -282,7 +282,7 @@ float VideoPlayer::get_stream_position() const {
 
 	if (playback.is_null())
 		return 0;
-	return playback->get_position();
+	return playback->get_playback_position();
 };
 
 Ref<Texture> VideoPlayer::get_video_texture() {

--- a/scene/resources/audio_stream_sample.cpp
+++ b/scene/resources/audio_stream_sample.cpp
@@ -41,7 +41,7 @@ void AudioStreamPlaybackSample::start(float p_from_pos) {
 		ima_adpcm[i].window_ofs = 0;
 	}
 
-	seek_pos(p_from_pos);
+	seek(p_from_pos);
 	sign = 1;
 	active = true;
 }
@@ -61,11 +61,11 @@ int AudioStreamPlaybackSample::get_loop_count() const {
 	return 0;
 }
 
-float AudioStreamPlaybackSample::get_position() const {
+float AudioStreamPlaybackSample::get_playback_position() const {
 
 	return float(offset >> MIX_FRAC_BITS) / base->mix_rate;
 }
-void AudioStreamPlaybackSample::seek_pos(float p_time) {
+void AudioStreamPlaybackSample::seek(float p_time) {
 
 	if (base->format == AudioStreamSample::FORMAT_IMA_ADPCM)
 		return; //no seeking in ima-adpcm

--- a/scene/resources/audio_stream_sample.h
+++ b/scene/resources/audio_stream_sample.h
@@ -71,8 +71,8 @@ public:
 
 	virtual int get_loop_count() const; //times it looped
 
-	virtual float get_position() const;
-	virtual void seek_pos(float p_time);
+	virtual float get_playback_position() const;
+	virtual void seek(float p_time);
 
 	virtual void mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames);
 

--- a/scene/resources/video_stream.h
+++ b/scene/resources/video_stream.h
@@ -55,8 +55,8 @@ public:
 
 	virtual float get_length() const = 0;
 
-	virtual float get_position() const = 0;
-	virtual void seek_pos(float p_time) = 0;
+	virtual float get_playback_position() const = 0;
+	virtual void seek(float p_time) = 0;
 
 	virtual void set_audio_track(int p_idx) = 0;
 

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -178,16 +178,16 @@ int AudioStreamPlaybackRandomPitch::get_loop_count() const {
 	return 0;
 }
 
-float AudioStreamPlaybackRandomPitch::get_position() const {
+float AudioStreamPlaybackRandomPitch::get_playback_position() const {
 	if (playing.is_valid()) {
-		return playing->get_position();
+		return playing->get_playback_position();
 	}
 
 	return 0;
 }
-void AudioStreamPlaybackRandomPitch::seek_pos(float p_time) {
+void AudioStreamPlaybackRandomPitch::seek(float p_time) {
 	if (playing.is_valid()) {
-		playing->seek_pos(p_time);
+		playing->seek(p_time);
 	}
 }
 

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -45,8 +45,8 @@ public:
 
 	virtual int get_loop_count() const = 0; //times it looped
 
-	virtual float get_position() const = 0;
-	virtual void seek_pos(float p_time) = 0;
+	virtual float get_playback_position() const = 0;
+	virtual void seek(float p_time) = 0;
 
 	virtual void mix(AudioFrame *p_bufer, float p_rate_scale, int p_frames) = 0;
 
@@ -133,8 +133,8 @@ public:
 
 	virtual int get_loop_count() const; //times it looped
 
-	virtual float get_position() const;
-	virtual void seek_pos(float p_time);
+	virtual float get_playback_position() const;
+	virtual void seek(float p_time);
 
 	virtual void mix(AudioFrame *p_bufer, float p_rate_scale, int p_frames);
 


### PR DESCRIPTION
Fixes the error message `ERROR: bind_methodfi: Class AudioStreamPlayer2D already has a method get_position` since the pos renaming commit.