### PR TITLE
Scale editing Gizmo for Spatial Editor

### DIFF
--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -245,7 +245,7 @@ private:
 
 	real_t zoom_indicator_delay;
 
-	RID move_gizmo_instance[3], move_plane_gizmo_instance[3], rotate_gizmo_instance[3];
+	RID move_gizmo_instance[3], move_plane_gizmo_instance[3], rotate_gizmo_instance[3], scale_gizmo_instance[3];
 
 	String last_message;
 	String message;
@@ -319,6 +319,7 @@ class SpatialEditorSelectedItem : public Object {
 public:
 	Rect3 aabb;
 	Transform original; // original location when moving
+	Transform original_local;
 	Transform last_xform; // last transform
 	Spatial *sp;
 	RID sbox_instance;
@@ -407,7 +408,7 @@ private:
 	bool grid_enable[3]; //should be always visible if true
 	bool grid_enabled;
 
-	Ref<ArrayMesh> move_gizmo[3], move_plane_gizmo[3], rotate_gizmo[3];
+	Ref<ArrayMesh> move_gizmo[3], move_plane_gizmo[3], rotate_gizmo[3], scale_gizmo[3];
 	Ref<SpatialMaterial> gizmo_color[3];
 	Ref<SpatialMaterial> plane_gizmo_color[3];
 	Ref<SpatialMaterial> gizmo_hl;
@@ -557,6 +558,7 @@ public:
 	Ref<ArrayMesh> get_move_gizmo(int idx) const { return move_gizmo[idx]; }
 	Ref<ArrayMesh> get_move_plane_gizmo(int idx) const { return move_plane_gizmo[idx]; }
 	Ref<ArrayMesh> get_rotate_gizmo(int idx) const { return rotate_gizmo[idx]; }
+	Ref<ArrayMesh> get_scale_gizmo(int idx) const { return scale_gizmo[idx]; }
 
 	void update_transform_gizmo();
 


### PR DESCRIPTION
Added support for axis locked scaling with handles, supports both world and local space. Local space recommended for most editing tasks.
Also fixed some small bugs, polished Gizmo looks and cleaned up some dead code.

I will extend and polish transform tools and gizmos in future commits. This is most basic and already quite usable :)

![scalegizmo_03](https://user-images.githubusercontent.com/6152134/30785684-d041335c-a16a-11e7-960d-c31fb954b794.gif)

Happy scaling! :)