### PR TITLE
Comment out code that is causing project loading to fail on osx

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1734,6 +1734,16 @@ String OS_OSX::get_executable_path() const {
 }
 
 String OS_OSX::get_resource_dir() const {
+	/*
+  Bastiaan Olij - I'm leaving this code commented out but in place so we can have a further discussion about this later on.
+  For loading the package file from the resource folder it makes more sense to make this call work in ProjectSettings::setup
+  instead of relying on changing the current working folder as is the case right now (see godot_main_osx.mm).
+  The problem is that when this function returns a value we try and load a project.godot file from this resources folder and
+  stop attempting to load anything else if that fails. That breaks our tools build.
+  One possible solution is to only apply this logic in a non-tools build with an ifdef block. 
+
+  For now however, just returning this to working condition.
+
 	// start with our executable path
 	String path = get_executable_path();
 
@@ -1742,6 +1752,8 @@ String OS_OSX::get_resource_dir() const {
 		return OS::get_resource_dir();
 
 	return path.substr(0, pos) + "/Contents/Resources/";
+*/
+	return OS::get_resource_dir();
 }
 
 // Returns string representation of keys, if they are printable.


### PR DESCRIPTION
Commented out some code that I introduced that I think is the source of trouble for #11450 

I haven't removed it at this point because I think we should discuss this further, so tagging @Calinou , @akien-mga and @reduz  :)

Right now the OSX build makes the resource folder in the app bundle the current working folder so that if there is a datapack file in that folder, it will get loaded. That all works fine now.

I originally got thrown off by the get_resource_dir method as it made sense to have this return the resources path and it would open up the datapack from there. I only found out later there was a comment in the project loading code that this had become defunct and indeed, it only attempts to load a project.godot file from this location if specified. I left the code so we could have a discussion whether we want to change how this works.

What I didn't realise is that returning this value would cause the rest of the loading code to be skipped regardless of whether a project file was found. The result of this is that a tools build put inside of an app bundle won't load any projects!! (hence 11450)
Only when run directly things work as they should.

For now I've commented out the code so our tools build works again. Hope to catch you guys on IRC so we can decide whether to remove this all together or whether we do want to implement get_resource_dir the way I suggest and either make an exception for the tools build or remove the code that stops further loading if a project file can't be loaded from this location.