### PR TITLE
freelook_base_speed calibration

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -700,8 +700,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// freelook
 	set("editors/3d/freelook/freelook_inertia", 0.1);
 	hints["editors/3d/freelook/freelook_inertia"] = PropertyInfo(Variant::REAL, "editors/3d/freelook/freelook_inertia", PROPERTY_HINT_RANGE, "0.0, 1, 0.01");
-	set("editors/3d/freelook/freelook_base_speed", 0.5);
-	hints["editors/3d/freelook/freelook_base_speed"] = PropertyInfo(Variant::REAL, "editors/3d/freelook/freelook_base_speed", PROPERTY_HINT_RANGE, "0.0, 10, 0.1");
+	set("editors/3d/freelook/freelook_base_speed", 0.1);
+	hints["editors/3d/freelook/freelook_base_speed"] = PropertyInfo(Variant::REAL, "editors/3d/freelook/freelook_base_speed", PROPERTY_HINT_RANGE, "0.0, 10, 0.01");
 	set("editors/3d/freelook/freelook_activation_modifier", 0);
 	hints["editors/3d/freelook/freelook_activation_modifier"] = PropertyInfo(Variant::INT, "editors/3d/freelook/freelook_activation_modifier", PROPERTY_HINT_ENUM, "None,Shift,Alt,Meta,Ctrl");
 	set("editors/3d/freelook/freelook_modifier_speed_factor", 3.0);


### PR DESCRIPTION
Freelook_base_speed changed from 0.5 to 0.1
Also precision changed from 0.1 to 0.01 so it's possible to set values lower than 0.1
fixes  #11474