### PR TITLE
use icons for pos/rot/scale animation key buttons

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2816,6 +2816,9 @@ void CanvasItemEditor::_notification(int p_what) {
 		unlock_button->set_icon(get_icon("Unlock", "EditorIcons"));
 		group_button->set_icon(get_icon("Group", "EditorIcons"));
 		ungroup_button->set_icon(get_icon("Ungroup", "EditorIcons"));
+		key_pos_button->set_icon(get_icon("KeyMove", "EditorIcons"));
+		key_rot_button->set_icon(get_icon("KeyRotate", "EditorIcons"));
+		key_scale_button->set_icon(get_icon("KeyScale", "EditorIcons"));
 		key_insert_button->set_icon(get_icon("Key", "EditorIcons"));
 
 		zoom_minus->set_icon(get_icon("ZoomLess", "EditorIcons"));
@@ -2867,6 +2870,9 @@ void CanvasItemEditor::_notification(int p_what) {
 		unlock_button->set_icon(get_icon("Unlock", "EditorIcons"));
 		group_button->set_icon(get_icon("Group", "EditorIcons"));
 		ungroup_button->set_icon(get_icon("Ungroup", "EditorIcons"));
+		key_pos_button->set_icon(get_icon("KeyMove", "EditorIcons"));
+		key_rot_button->set_icon(get_icon("KeyRotate", "EditorIcons"));
+		key_scale_button->set_icon(get_icon("KeyScale", "EditorIcons"));
 		key_insert_button->set_icon(get_icon("Key", "EditorIcons"));
 
 		anchor_menu->set_icon(get_icon("Anchor", "EditorIcons"));
@@ -3383,15 +3389,18 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 		} break;
 		case ANIM_INSERT_POS: {
 
-			key_pos = key_loc_button->is_pressed();
+			key_pos = key_pos_button->is_pressed();
+
 		} break;
 		case ANIM_INSERT_ROT: {
 
 			key_rot = key_rot_button->is_pressed();
+
 		} break;
 		case ANIM_INSERT_SCALE: {
 
 			key_scale = key_scale_button->is_pressed();
+
 		} break;
 		/*
 		case ANIM_INSERT_POS_ROT
@@ -3916,39 +3925,44 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	animation_hb->add_child(memnew(VSeparator));
 	animation_hb->hide();
 
-	key_loc_button = memnew(Button("loc"));
-	key_loc_button->set_toggle_mode(true);
-	key_loc_button->set_flat(true);
-	key_loc_button->set_pressed(true);
-	key_loc_button->set_focus_mode(FOCUS_NONE);
-	key_loc_button->add_color_override("font_color", Color(1, 0.6, 0.6));
-	key_loc_button->add_color_override("font_color_pressed", Color(0.6, 1, 0.6));
-	key_loc_button->connect("pressed", this, "_popup_callback", varray(ANIM_INSERT_POS));
-	animation_hb->add_child(key_loc_button);
-	key_rot_button = memnew(Button("rot"));
+	const Color key_accent_color = Color::html("84FFB1");
+  const Color key_icon_color = Color(key_accent_color.r * 1.15, key_accent_color.g * 1.15, key_accent_color.b * 1.15);
+
+	key_pos_button = memnew(Button);
+	key_pos_button->set_toggle_mode(true);
+	key_pos_button->set_flat(true);
+	key_pos_button->set_pressed(true);
+	key_pos_button->set_focus_mode(FOCUS_NONE);
+	key_pos_button->add_color_override("icon_color_pressed", key_icon_color);
+	key_pos_button->connect("pressed", this, "_popup_callback", varray(ANIM_INSERT_POS));
+	key_pos_button->set_tooltip(TTR("Toggle location key insertion"));
+	animation_hb->add_child(key_pos_button);
+
+	key_rot_button = memnew(Button);
 	key_rot_button->set_toggle_mode(true);
 	key_rot_button->set_flat(true);
 	key_rot_button->set_pressed(true);
 	key_rot_button->set_focus_mode(FOCUS_NONE);
-	key_rot_button->add_color_override("font_color", Color(1, 0.6, 0.6));
-	key_rot_button->add_color_override("font_color_pressed", Color(0.6, 1, 0.6));
+	key_rot_button->add_color_override("icon_color_pressed", key_icon_color);
 	key_rot_button->connect("pressed", this, "_popup_callback", varray(ANIM_INSERT_ROT));
+	key_rot_button->set_tooltip(TTR("Toggle rotation key insertion"));
 	animation_hb->add_child(key_rot_button);
-	key_scale_button = memnew(Button("scl"));
+
+	key_scale_button = memnew(Button);
 	key_scale_button->set_toggle_mode(true);
 	key_scale_button->set_flat(true);
 	key_scale_button->set_focus_mode(FOCUS_NONE);
-	key_scale_button->add_color_override("font_color", Color(1, 0.6, 0.6));
-	key_scale_button->add_color_override("font_color_pressed", Color(0.6, 1, 0.6));
+	key_scale_button->add_color_override("icon_color_pressed", key_icon_color);
 	key_scale_button->connect("pressed", this, "_popup_callback", varray(ANIM_INSERT_SCALE));
+	key_scale_button->set_tooltip(TTR("Toggle scale key insertion"));
 	animation_hb->add_child(key_scale_button);
+
 	key_insert_button = memnew(Button);
 	key_insert_button->set_flat(true);
 	key_insert_button->set_focus_mode(FOCUS_NONE);
 	key_insert_button->connect("pressed", this, "_popup_callback", varray(ANIM_INSERT_KEY));
 	key_insert_button->set_tooltip(TTR("Insert Keys"));
 	key_insert_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/anim_insert_key", TTR("Insert Key"), KEY_INSERT));
-
 	animation_hb->add_child(key_insert_button);
 
 	animation_menu = memnew(MenuButton);

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -280,7 +280,7 @@ class CanvasItemEditor : public VBoxContainer {
 	MenuButton *animation_menu;
 	MenuButton *anchor_menu;
 
-	Button *key_loc_button;
+	Button *key_pos_button;
 	Button *key_rot_button;
 	Button *key_scale_button;
 	Button *key_insert_button;


### PR DESCRIPTION
* implements the icons for the animation key buttons.
* renames `key_loc_button` to `key_pos_button`

However I'm a bit unhappy about the current result. If you read [this PR][icons PR] you'll see I started by matching the current buttons, which is why I made enabled/disabled pairs of icons in the beginning. This does not fit very well with the current theme though, which is flat with a blue overlay for toggled icons.

* with both types:
![en-dis][]
Confusing, looks like the scale key button is disabled and not just toggled off.
* with enabled type only:
![en][] ![en2][]
Also confusing, the scale key doesn't look toggled off. It gets really non-obvious I think with everything toggled off.

It seems to me the problem is that the button style does not look togglable and the overlay is inadequate for that.

A quick workaround is to set/unset flat but that's a bit of a hack:
![no-flat][]

Thoughts?

[icons PR]: https://github.com/djrm/godot-design/pull/7
[en-dis]: https://user-images.githubusercontent.com/5330692/30744807-0a1a9cd0-9fa4-11e7-97d9-dd7142f43b48.png
[en]: https://user-images.githubusercontent.com/5330692/30744839-2f7fbc12-9fa4-11e7-8391-8275f4e193dd.png
[en2]: https://user-images.githubusercontent.com/5330692/30745155-62e49c84-9fa5-11e7-80fb-e2b0eb9f500b.png
[no-flat]: https://user-images.githubusercontent.com/5330692/30745591-2567238e-9fa7-11e7-8d19-0c4692145754.png
