### PR TITLE
Area2D get_audio_bus and set_audio_bus renamed to get_audio_bus_name and set_audio_bus_name

### DIFF
--- a/doc/classes/Area2D.xml
+++ b/doc/classes/Area2D.xml
@@ -18,7 +18,7 @@
 				Return the angular damp rate.
 			</description>
 		</method>
-		<method name="get_audio_bus" qualifiers="const">
+		<method name="get_audio_bus_name" qualifiers="const">
 			<return type="String">
 			</return>
 			<description>
@@ -167,7 +167,7 @@
 				In practice, as the fraction of speed lost gets smaller with each frame, a value of 1.0 does not mean the object will stop in exactly one second. Only when the physics calculations are done at 1 frame per second, it does stop in a second.
 			</description>
 		</method>
-		<method name="set_audio_bus">
+		<method name="set_audio_bus_name">
 			<return type="void">
 			</return>
 			<argument index="0" name="name" type="String">
@@ -320,7 +320,7 @@
 		<member name="angular_damp" type="float" setter="set_angular_damp" getter="get_angular_damp">
 			The rate at which objects stop spinning in this area. Represents the amount of speed lost per second. If 1.0, physics bodies in the area stop rotating immediately. If 0.0, they never slow down. Does not incorporate external forces. The physics-update's rate affects 'angular_damp'.
 		</member>
-		<member name="audio_bus_name" type="String" setter="set_audio_bus" getter="get_audio_bus">
+		<member name="audio_bus_name" type="String" setter="set_audio_bus_name" getter="get_audio_bus_name">
 			The name of the Area2D's audio bus.
 		</member>
 		<member name="audio_bus_override" type="bool" setter="set_audio_bus_override" getter="is_overriding_audio_bus">

--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -557,12 +557,12 @@ bool Area2D::is_overriding_audio_bus() const {
 	return audio_bus_override;
 }
 
-void Area2D::set_audio_bus(const StringName &p_audio_bus) {
+void Area2D::set_audio_bus_name(const StringName &p_audio_bus) {
 
 	audio_bus = p_audio_bus;
 }
 
-StringName Area2D::get_audio_bus() const {
+StringName Area2D::get_audio_bus_name() const {
 
 	for (int i = 0; i < AudioServer::get_singleton()->get_bus_count(); i++) {
 		if (AudioServer::get_singleton()->get_bus_name(i) == audio_bus) {
@@ -644,8 +644,8 @@ void Area2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("overlaps_body", "body"), &Area2D::overlaps_body);
 	ClassDB::bind_method(D_METHOD("overlaps_area", "area"), &Area2D::overlaps_area);
 
-	ClassDB::bind_method(D_METHOD("set_audio_bus", "name"), &Area2D::set_audio_bus);
-	ClassDB::bind_method(D_METHOD("get_audio_bus"), &Area2D::get_audio_bus);
+	ClassDB::bind_method(D_METHOD("set_audio_bus_name", "name"), &Area2D::set_audio_bus_name);
+	ClassDB::bind_method(D_METHOD("get_audio_bus_name"), &Area2D::get_audio_bus_name);
 
 	ClassDB::bind_method(D_METHOD("set_audio_bus_override", "enable"), &Area2D::set_audio_bus_override);
 	ClassDB::bind_method(D_METHOD("is_overriding_audio_bus"), &Area2D::is_overriding_audio_bus);
@@ -679,7 +679,7 @@ void Area2D::_bind_methods() {
 
 	ADD_GROUP("Audio Bus", "audio_bus_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "audio_bus_override"), "set_audio_bus_override", "is_overriding_audio_bus");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "audio_bus_name", PROPERTY_HINT_ENUM, ""), "set_audio_bus", "get_audio_bus");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "audio_bus_name", PROPERTY_HINT_ENUM, ""), "set_audio_bus_name", "get_audio_bus_name");
 
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_DISABLED);
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_COMBINE);

--- a/scene/2d/area_2d.h
+++ b/scene/2d/area_2d.h
@@ -186,8 +186,8 @@ public:
 	void set_audio_bus_override(bool p_override);
 	bool is_overriding_audio_bus() const;
 
-	void set_audio_bus(const StringName &p_audio_bus);
-	StringName get_audio_bus() const;
+	void set_audio_bus_name(const StringName &p_audio_bus);
+	StringName get_audio_bus_name() const;
 
 	Area2D();
 	~Area2D();

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -145,7 +145,7 @@ void AudioStreamPlayer2D::_notification(int p_what) {
 				if (!area2d->is_overriding_audio_bus())
 					continue;
 
-				StringName bus_name = area2d->get_audio_bus();
+				StringName bus_name = area2d->get_audio_bus_name();
 				bus_index = AudioServer::get_singleton()->thread_find_bus_index(bus_name);
 				break;
 			}


### PR DESCRIPTION
This pull request refers to the following issue:
https://github.com/godotengine/godot/issues/11109

I've basically renamed the functions and also updated the docs regarging those.