### PR TITLE
Fix gcc lto

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -64,6 +64,7 @@ def get_opts():
     return [
         ('mingw_prefix_32', 'MinGW prefix (Win32)', mingw32),
         ('mingw_prefix_64', 'MinGW prefix (Win64)', mingw64),
+        ('use_lto', 'Use link time optimization (when using MingW)', 'no'),
         ('debug_symbols', 'Add debug symbols to release version (yes/no/full)', 'yes')
     ]
 
@@ -256,10 +257,14 @@ def configure(env):
         env["CC"] = mingw_prefix + "gcc"
         env['AS'] = mingw_prefix + "as"
         env['CXX'] = mingw_prefix + "g++"
-        env['AR'] = mingw_prefix + "ar"
-        env['RANLIB'] = mingw_prefix + "ranlib"
+        env['AR'] = mingw_prefix + "gcc-ar"
+        env['RANLIB'] = mingw_prefix + "gcc-ranlib"
         env['LD'] = mingw_prefix + "g++"
         env["x86_libtheora_opt_gcc"] = True
+
+        if (env["use_lto"] == "yes"):
+            env.Append(CCFLAGS=['-flto'])
+            env.Append(LINKFLAGS=['-flto'])
 
         ## Compile flags
 

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -120,6 +120,9 @@ def configure(env):
     if (env["use_lto"] == "yes"):
         env.Append(CCFLAGS=['-flto'])
         env.Append(LINKFLAGS=['-flto'])
+        if (env["use_llvm"] == "no"):
+            env['RANLIB'] = 'gcc-ranlib'
+            env['AR'] = 'gcc-ar'
 
     env.Append(CCFLAGS=['-pipe'])
     env.Append(LINKFLAGS=['-pipe'])


### PR DESCRIPTION
This repairs LTO on X11 and adds it to MingW targets. The difference in
linktime is substantial, but runtime performance is quite a bit better.