### PR TITLE
Enable building against system zstd.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -171,6 +171,7 @@ opts.Add('builtin_pcre2', "Use the builtin pcre2 library (yes/no)", 'yes')
 opts.Add('builtin_recast', "Use the builtin recast library (yes/no)", 'yes')
 opts.Add('builtin_squish', "Use the builtin squish library (yes/no)", 'yes')
 opts.Add('builtin_zlib', "Use the builtin zlib library (yes/no)", 'yes')
+opts.Add('builtin_zstd', "Use the builtin zstd library (yes/no)", 'yes')
 
 # Environment setup
 opts.Add("CXX", "C++ compiler")

--- a/core/SCsub
+++ b/core/SCsub
@@ -83,24 +83,8 @@ thirdparty_minizip_sources = [
 thirdparty_minizip_sources = [thirdparty_minizip_dir + file for file in thirdparty_minizip_sources]
 env.add_source_files(env.core_sources, thirdparty_minizip_sources)
 
-thirdparty_zstd_dir = "#thirdparty/zstd/"
-thirdparty_zstd_sources = [
-	"common/entropy_common.c",
-	"common/error_private.c",
-	"common/fse_decompress.c",
-	"common/pool.c",
-	"common/threading.c",
-	"common/xxhash.c",
-	"common/zstd_common.c",
-	"compress/fse_compress.c",
-	"compress/huf_compress.c",
-	"compress/zstd_compress.c",
-	"compress/zstdmt_compress.c",
-	"decompress/huf_decompress.c",
-	"decompress/zstd_decompress.c",
-]
-thirdparty_zstd_sources = [thirdparty_zstd_dir + file for file in thirdparty_zstd_sources]
-env.add_source_files(env.core_sources, thirdparty_zstd_sources)
+if "builtin_zstd" in env and env["builtin_zstd"] == "yes":
+    SConscript("#thirdparty/zstd/SCsub")
 
 
 # Godot's own sources
@@ -123,5 +107,4 @@ SConscript('helper/SCsub')
 # Build it all as a library
 lib = env.Library("core", env.core_sources)
 env.Prepend(LIBS=[lib])
-env.Append(CPPPATH=["#thirdparty/zstd", "#thirdparty/zstd/common"])
 Export('env')

--- a/core/io/compression.cpp
+++ b/core/io/compression.cpp
@@ -33,9 +33,9 @@
 #include "zip_io.h"
 
 #include "thirdparty/misc/fastlz.h"
-#include "thirdparty/zstd/zstd.h"
 
 #include <zlib.h>
+#include <zstd.h>
 
 int Compression::compress(uint8_t *p_dst, const uint8_t *p_src, int p_src_size, Mode p_mode) {
 

--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -98,6 +98,9 @@ def configure(env):
     if (env['builtin_squish'] == 'no' and env["tools"] == "yes"):
         env.ParseConfig('pkg-config libsquish --cflags --libs')
 
+    if env['builtin_zstd'] == 'no':
+        env.ParseConfig('pkg-config libzstd --cflags --libs')
+
     # Sound and video libraries
     # Keep the order as it triggers chained dependencies (ogg needed by others, etc.)
 

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -167,6 +167,9 @@ def configure(env):
     if (env['builtin_squish'] == 'no' and env["tools"] == "yes"):
         env.ParseConfig('pkg-config libsquish --cflags --libs')
 
+    if env['builtin_zstd'] == 'no':
+        env.ParseConfig('pkg-config libzstd --cflags --libs')
+
     # Sound and video libraries
     # Keep the order as it triggers chained dependencies (ogg needed by others, etc.)
 

--- a/thirdparty/zstd/SCsub
+++ b/thirdparty/zstd/SCsub
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+Import('env')
+
+thirdparty_zstd_dir = "#thirdparty/zstd/"
+thirdparty_zstd_sources = [
+	"common/entropy_common.c",
+	"common/error_private.c",
+	"common/fse_decompress.c",
+	"common/pool.c",
+	"common/threading.c",
+	"common/xxhash.c",
+	"common/zstd_common.c",
+	"compress/fse_compress.c",
+	"compress/huf_compress.c",
+	"compress/zstd_compress.c",
+	"compress/zstdmt_compress.c",
+	"decompress/huf_decompress.c",
+	"decompress/zstd_decompress.c",
+]
+thirdparty_zstd_sources = [thirdparty_zstd_dir + file for file in thirdparty_zstd_sources]
+env.add_source_files(env.core_sources, thirdparty_zstd_sources)
+env.Append(CPPPATH=["#thirdparty/zstd", "#thirdparty/zstd/common"])


### PR DESCRIPTION
`libzstd` appears to be available in [most distros](https://pkgs.org/download/libzstd) (though Ubuntu's is a bit old) so add the option to build against it. I could not find any evidence that this code is patched, so it should be clean to do so. I'm not sure about the server change as it doesn't build on `master` for me.

I'm not sure if a version check is necessary; it doesn't look like many places use one, but I can try to add one if needed.

@akien-mga this is in reference to my comment on #8983.