### PR TITLE
Add support for OpenSSL 1.1.0.

### DIFF
--- a/modules/openssl/stream_peer_openssl.h
+++ b/modules/openssl/stream_peer_openssl.h
@@ -53,7 +53,12 @@ private:
 	static int _bio_gets(BIO *b, char *buf, int len);
 	static int _bio_puts(BIO *b, const char *str);
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	static BIO_METHOD *_bio_method;
+#else
 	static BIO_METHOD _bio_method;
+#endif
+	static BIO_METHOD *_get_bio_method();
 
 	static bool _match_host_name(const char *name, const char *hostname);
 	static Error _match_common_name(const char *hostname, const X509 *server_cert);

--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -65,15 +65,6 @@ def configure(env):
     # FIXME: Check for existence of the libs before parsing their flags with pkg-config
 
     if (env['builtin_openssl'] == 'no'):
-        # Currently not compatible with OpenSSL 1.1.0+
-        # https://github.com/godotengine/godot/issues/8624
-        import subprocess
-        openssl_version = subprocess.check_output(['pkg-config', 'openssl', '--modversion']).strip('\n')
-        if (openssl_version >= "1.1.0"):
-            print("Error: Found system-installed OpenSSL %s, currently only supporting version 1.0.x." % openssl_version)
-            print("Aborting.. You can compile with 'builtin_openssl=yes' to use the bundled version.\n")
-            sys.exit(255)
-
         env.ParseConfig('pkg-config openssl --cflags --libs')
 
     if (env['builtin_libwebp'] == 'no'):

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -134,15 +134,6 @@ def configure(env):
     # FIXME: Check for existence of the libs before parsing their flags with pkg-config
 
     if (env['builtin_openssl'] == 'no'):
-        # Currently not compatible with OpenSSL 1.1.0+
-        # https://github.com/godotengine/godot/issues/8624
-        import subprocess
-        openssl_version = subprocess.check_output(['pkg-config', 'openssl', '--modversion']).strip('\n')
-        if (openssl_version >= "1.1.0"):
-            print("Error: Found system-installed OpenSSL %s, currently only supporting version 1.0.x." % openssl_version)
-            print("Aborting.. You can compile with 'builtin_openssl=yes' to use the bundled version.\n")
-            sys.exit(255)
-
         env.ParseConfig('pkg-config openssl --cflags --libs')
 
     if (env['builtin_libwebp'] == 'no'):


### PR DESCRIPTION
This release hides many struct members which provides easier forward compatibility but is a break from previous releases. A few small macros provide compatibility between both 1.1.0 and 1.0.x.

Fixes #8624.

This PR builds against the builtin 1.0.2 and against Fedora's 1.1.0.