### PR TITLE
Removed get_resource_dir from osx platform

### DIFF
--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -184,7 +184,6 @@ public:
 	virtual void get_fullscreen_mode_list(List<VideoMode> *p_list, int p_screen = 0) const;
 
 	virtual String get_executable_path() const;
-	virtual String get_resource_dir() const;
 
 	virtual LatinKeyboardVariant get_latin_keyboard_variant() const;
 

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1733,29 +1733,6 @@ String OS_OSX::get_executable_path() const {
 	}
 }
 
-String OS_OSX::get_resource_dir() const {
-	/*
-  Bastiaan Olij - I'm leaving this code commented out but in place so we can have a further discussion about this later on.
-  For loading the package file from the resource folder it makes more sense to make this call work in ProjectSettings::setup
-  instead of relying on changing the current working folder as is the case right now (see godot_main_osx.mm).
-  The problem is that when this function returns a value we try and load a project.godot file from this resources folder and
-  stop attempting to load anything else if that fails. That breaks our tools build.
-  One possible solution is to only apply this logic in a non-tools build with an ifdef block. 
-
-  For now however, just returning this to working condition.
-
-	// start with our executable path
-	String path = get_executable_path();
-
-	int pos = path.find_last("/Contents/MacOS/");
-	if (pos < 0)
-		return OS::get_resource_dir();
-
-	return path.substr(0, pos) + "/Contents/Resources/";
-*/
-	return OS::get_resource_dir();
-}
-
 // Returns string representation of keys, if they are printable.
 //
 static NSString *createStringForKeys(const CGKeyCode *keyCode, int length) {


### PR DESCRIPTION
As discussed, removing get_resource_dir all together. Originally added this when I was fixing loading the right pack file on OSX, wasn't being used and caused all sorts of issues. Had already been commented out, now removed :)