### PR TITLE
Removed directory scan from project load

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -261,7 +261,7 @@ bool ProjectSettings::_load_resource_pack(const String &p_pack) {
 	return true;
 }
 
-Error ProjectSettings::setup(const String &p_path, const String &p_main_pack) {
+Error ProjectSettings::setup(const String &p_path, const String &p_main_pack, bool p_upwards) {
 
 	//If looking for files in network, just use network!
 
@@ -270,11 +270,6 @@ Error ProjectSettings::setup(const String &p_path, const String &p_main_pack) {
 		if (_load_settings("res://project.godot") == OK || _load_settings_binary("res://project.binary") == OK) {
 
 			_load_settings("res://override.cfg");
-#ifdef DEBUG_ENABLED
-		} else {
-			// when debug version of godot is used, provide some feedback to the developer
-			print_line("Couldn't open project over network");
-#endif
 		}
 
 		return OK;
@@ -292,12 +287,6 @@ Error ProjectSettings::setup(const String &p_path, const String &p_main_pack) {
 		if (_load_settings("res://project.godot") == OK || _load_settings_binary("res://project.binary") == OK) {
 			//load override from location of the main pack
 			_load_settings(p_main_pack.get_base_dir().plus_file("override.cfg"));
-#ifdef DEBUG_ENABLED
-			// when debug version of godot is used, provide some feedback to the developer
-			print_line("Successfully loaded " + p_main_pack + "/project.godot or project.binary");
-		} else {
-			print_line("Couldn't load/find " + p_main_pack + "/project.godot or project.binary");
-#endif
 		}
 
 		return OK;
@@ -315,18 +304,9 @@ Error ProjectSettings::setup(const String &p_path, const String &p_main_pack) {
 		if (_load_resource_pack(datapack_name)) {
 			found = true;
 		} else {
-#ifdef DEBUG_ENABLED
-			// when debug version of godot is used, provide some feedback to the developer
-			print_line("Couldn't open " + datapack_name);
-#endif
 			datapack_name = filebase_name + ".pck";
 			if (_load_resource_pack(datapack_name)) {
 				found = true;
-#ifdef DEBUG_ENABLED
-			} else {
-				// when debug version of godot is used, provide some feedback to the developer
-				print_line("Couldn't open " + datapack_name);
-#endif
 			}
 		}
 
@@ -335,13 +315,6 @@ Error ProjectSettings::setup(const String &p_path, const String &p_main_pack) {
 			if (_load_settings("res://project.godot") == OK || _load_settings_binary("res://project.binary") == OK) {
 				// load override from location of executable
 				_load_settings(exec_path.get_base_dir().plus_file("override.cfg"));
-
-#ifdef DEBUG_ENABLED
-				// when debug version of godot is used, provide some feedback to the developer
-				print_line("Successfully loaded " + datapack_name + "/project.godot or project.binary");
-			} else {
-				print_line("Couldn't load/find " + datapack_name + "/project.godot or project.binary");
-#endif
 			}
 
 			return OK;
@@ -362,12 +335,6 @@ Error ProjectSettings::setup(const String &p_path, const String &p_main_pack) {
 
 		if (_load_settings("res://project.godot") == OK || _load_settings_binary("res://project.binary") == OK) {
 			_load_settings("res://override.cfg");
-#ifdef DEBUG_ENABLED
-			// when debug version of godot is used, provide some feedback to the developer
-			print_line("Successfully loaded " + resource_path + "/project.godot or project.binary");
-		} else {
-			print_line("Couldn't load/find " + resource_path + "/project.godot or project.binary");
-#endif
 		}
 
 		return OK;
@@ -393,18 +360,16 @@ Error ProjectSettings::setup(const String &p_path, const String &p_main_pack) {
 			candidate = current_dir;
 			found = true;
 			break;
-#ifdef DEBUG_ENABLED
-			// when debug version of godot is used, provide some feedback to the developer
-			print_line("Successfully loaded " + current_dir + "/project.godot or project.binary");
-		} else {
-			print_line("Couldn't load/find " + current_dir + "/project.godot or project.binary");
-#endif
 		}
 
-		d->change_dir("..");
-		if (d->get_current_dir() == current_dir)
-			break; //not doing anything useful
-		current_dir = d->get_current_dir();
+		if (p_upwards) {
+			d->change_dir("..");
+			if (d->get_current_dir() == current_dir)
+				break; //not doing anything useful
+			current_dir = d->get_current_dir();
+		} else {
+			break;
+		}
 	}
 
 	resource_path = candidate;

--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -139,7 +139,7 @@ public:
 	void set_order(const String &p_name, int p_order);
 	void set_builtin_order(const String &p_name);
 
-	Error setup(const String &p_path, const String &p_main_pack);
+	Error setup(const String &p_path, const String &p_main_pack, bool p_upwards = false);
 
 	Error save_custom(const String &p_path = "", const CustomMap &p_custom = CustomMap(), const Vector<String> &p_custom_features = Vector<String>(), bool p_merge_with_current = true);
 	Error save();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -162,6 +162,7 @@ void Main::print_help(const char *p_binary) {
 #endif
 	OS::get_singleton()->print("  -l, --language <locale>          Use a specific locale (<locale> being a two-letter code).\n");
 	OS::get_singleton()->print("  --path <directory>               Path to a project (<directory> must contain a 'project.godot' file).\n");
+	OS::get_singleton()->print("  -u, --upwards                    Scan folders upwards for project.godot file.\n");
 	OS::get_singleton()->print("  --main-pack <file>               Path to a pack (.pck) file to load.\n");
 	OS::get_singleton()->print("  --render-thread <mode>           Render thread mode ('unsafe', 'safe', 'separate').\n");
 	OS::get_singleton()->print("  --remote-fs <address>            Remote filesystem (<host/IP>[:<port>] address).\n");
@@ -289,6 +290,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	String video_driver = "";
 	String audio_driver = "";
 	String game_path = ".";
+	bool upwards = false;
 	String debug_mode;
 	String debug_host;
 	String main_pack;
@@ -497,6 +499,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing relative or absolute path, aborting.\n");
 				goto error;
 			}
+		} else if (I->get() == "-u" || I->get() == "--upwards") { // scan folders upwards
+			upwards = true;
 		} else if (I->get().ends_with("project.godot")) {
 			String path;
 			String file = I->get();
@@ -694,7 +698,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 #endif
 
-	if (globals->setup(game_path, main_pack) != OK) {
+	if (globals->setup(game_path, main_pack, upwards) != OK) {
 
 #ifdef TOOLS_ENABLED
 		editor = false;


### PR DESCRIPTION
After discussing this with @akien-mga today, changed the project loading code so the loop at the end which scans through each parent folder of our given path, to only loading a project at the given path.

If you start Godot without specifying a path and if no datapack can be found, it will only check for a project in the current working folder.
If you start Godot with a path (as the editor does after selecting a project) and it can't find a datapack, it will only open a project from the specified location.

It will no longer scan through parent folders.

This is a basic but potentially far reaching change so before merging I would suggest this is discussed further and tested well.

I've also removed some of the output I had added for debugging purposes as they were confusing people.

*Bugsquad edit:* Fixes #7764.