### PR TITLE
Fix Dictionary set_named

### DIFF
--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -1519,7 +1519,7 @@ void Variant::set_named(const StringName &p_index, const Variant &p_value, bool 
 
 		} break;
 		default: {
-			set(p_index.operator String(), p_value, r_valid);
+			set(p_index.operator String(), p_value, &valid);
 		} break;
 	}
 


### PR DESCRIPTION
Reduz optimized field indexing in 3c85703 but the changes didn't apply
to dictionary so this code remained untouched. However, the logic for
validity checking was changed but not updated for the dictionary case.

This fixes #11543