### PR TITLE
Removed transparency from spatial editor grid.

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -665,7 +665,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	_initial_set("editors/grid_map/pick_distance", 5000.0);
 
-	_initial_set("editors/3d/grid_color", Color(1, 1, 1, 0.2));
+	_initial_set("editors/3d/grid_color", Color::html("808080"));
 	hints["editors/3d/grid_color"] = PropertyInfo(Variant::COLOR, "editors/3d/grid_color", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 
 	_initial_set("editors/3d/default_fov", 55.0);


### PR DESCRIPTION
grid transparency caused some problems, with transparent objects, so it was removed, as a consequence it is not possible to use alpha values for the grid color, disabling the 'fading' grid : (

this is how it looks with this PR

![screenshot from 2017-09-24 17-33-05](https://user-images.githubusercontent.com/1103897/30787894-9921db04-a158-11e7-883a-9cbe795f5024.png)

![screenshot from 2017-09-24 17-31-18](https://user-images.githubusercontent.com/1103897/30787897-a08f4dea-a158-11e7-80db-c04e886bd2bf.png)


also, it is not visible in the screenshots but i removed the blue cursor at the center, @reduz are you okay with this?

closes #11479 
closes #11475
