### PR TITLE
Bump required scons version to 0.98.1.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,7 +1,7 @@
 
 #!/usr/bin/env python
 
-EnsureSConsVersion(0, 14)
+EnsureSConsVersion(0, 98, 1)
 
 
 import string


### PR DESCRIPTION
* Environment.AddPostAction() and the global AlwaysBuild() were added in 0.93, so requiring 0.14 is broken.
* Environment.Decider and Glob were added in some intermediate 0.97 release.
* The Variables object was added in 0.98.1.

This is entirely based on function calls; if behaviour has changed that may require a newer version, but I don't really feel liking looking that up as I'm not that crazy about scons.