### PR TITLE
Extract logging logic

### DIFF
--- a/core/io/file_access_buffered_fa.h
+++ b/core/io/file_access_buffered_fa.h
@@ -76,6 +76,11 @@ protected:
 	};
 
 public:
+	void flush() {
+
+		f.flush();
+	};
+
 	void store_8(uint8_t p_dest) {
 
 		f.store_8(p_dest);

--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -338,6 +338,13 @@ Error FileAccessCompressed::get_error() const {
 	return read_eof ? ERR_FILE_EOF : OK;
 }
 
+void FileAccessCompressed::flush() {
+	ERR_FAIL_COND(!f);
+	ERR_FAIL_COND(!writing);
+
+	// compressed files keep data in memory till close()
+}
+
 void FileAccessCompressed::store_8(uint8_t p_dest) {
 
 	ERR_FAIL_COND(!f);

--- a/core/io/file_access_compressed.h
+++ b/core/io/file_access_compressed.h
@@ -84,6 +84,7 @@ public:
 
 	virtual Error get_error() const; ///< get last error
 
+	virtual void flush();
 	virtual void store_8(uint8_t p_dest); ///< store a byte
 
 	virtual bool file_exists(const String &p_name); ///< return true if a file exists

--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -268,6 +268,12 @@ void FileAccessEncrypted::store_buffer(const uint8_t *p_src, int p_length) {
 	}
 }
 
+void FileAccessEncrypted::flush() {
+	ERR_FAIL_COND(!writing);
+
+	// encrypted files keep data in memory till close()
+}
+
 void FileAccessEncrypted::store_8(uint8_t p_dest) {
 
 	ERR_FAIL_COND(!writing);

--- a/core/io/file_access_encrypted.h
+++ b/core/io/file_access_encrypted.h
@@ -71,6 +71,7 @@ public:
 
 	virtual Error get_error() const; ///< get last error
 
+	virtual void flush();
 	virtual void store_8(uint8_t p_dest); ///< store a byte
 	virtual void store_buffer(const uint8_t *p_src, int p_length); ///< store an array of bytes
 

--- a/core/io/file_access_memory.cpp
+++ b/core/io/file_access_memory.cpp
@@ -170,6 +170,10 @@ Error FileAccessMemory::get_error() const {
 	return pos >= length ? ERR_FILE_EOF : OK;
 }
 
+void FileAccessMemory::flush() {
+	ERR_FAIL_COND(!data);
+}
+
 void FileAccessMemory::store_8(uint8_t p_byte) {
 
 	ERR_FAIL_COND(!data);

--- a/core/io/file_access_memory.h
+++ b/core/io/file_access_memory.h
@@ -62,6 +62,7 @@ public:
 
 	virtual Error get_error() const; ///< get last error
 
+	virtual void flush();
 	virtual void store_8(uint8_t p_byte); ///< store a byte
 	virtual void store_buffer(const uint8_t *p_src, int p_length); ///< store an array of bytes
 

--- a/core/io/file_access_network.cpp
+++ b/core/io/file_access_network.cpp
@@ -456,6 +456,10 @@ Error FileAccessNetwork::get_error() const {
 	return pos == total_size ? ERR_FILE_EOF : OK;
 }
 
+void FileAccessNetwork::flush() {
+	ERR_FAIL();
+}
+
 void FileAccessNetwork::store_8(uint8_t p_dest) {
 
 	ERR_FAIL();

--- a/core/io/file_access_network.h
+++ b/core/io/file_access_network.h
@@ -155,6 +155,7 @@ public:
 
 	virtual Error get_error() const; ///< get last error
 
+	virtual void flush();
 	virtual void store_8(uint8_t p_dest); ///< store a byte
 
 	virtual bool file_exists(const String &p_path); ///< return true if a file exists

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -293,6 +293,11 @@ Error FileAccessPack::get_error() const {
 	return OK;
 }
 
+void FileAccessPack::flush() {
+
+	ERR_FAIL();
+}
+
 void FileAccessPack::store_8(uint8_t p_dest) {
 
 	ERR_FAIL();

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -161,6 +161,7 @@ public:
 
 	virtual Error get_error() const;
 
+	virtual void flush();
 	virtual void store_8(uint8_t p_dest);
 
 	virtual void store_buffer(const uint8_t *p_src, int p_length);

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -353,6 +353,11 @@ Error FileAccessZip::get_error() const {
 	return OK;
 };
 
+void FileAccessZip::flush() {
+
+	ERR_FAIL();
+}
+
 void FileAccessZip::store_8(uint8_t p_dest) {
 
 	ERR_FAIL();

--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -1,0 +1,252 @@
+/*************************************************************************/
+/*  logger.cpp                                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "logger.h"
+#include "os/dir_access.h"
+#include "os/os.h"
+#include "print_string.h"
+
+bool Logger::should_log(bool p_err) {
+	return (!p_err || _print_error_enabled) && (p_err || _print_line_enabled);
+}
+
+void Logger::log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, ErrorType p_type) {
+	if (!should_log(true)) {
+		return;
+	}
+
+	const char *err_type = "**ERROR**";
+	switch (p_type) {
+		case ERR_ERROR: err_type = "**ERROR**"; break;
+		case ERR_WARNING: err_type = "**WARNING**"; break;
+		case ERR_SCRIPT: err_type = "**SCRIPT ERROR**"; break;
+		case ERR_SHADER: err_type = "**SHADER ERROR**"; break;
+		default: ERR_PRINT("Unknown error type"); break;
+	}
+
+	const char *err_details;
+	if (p_rationale && *p_rationale)
+		err_details = p_rationale;
+	else
+		err_details = p_code;
+
+	logf_error("%s: %s\n", err_type, err_details);
+	logf_error("   At: %s:%i:%s() - %s\n", p_file, p_line, p_function, p_code);
+}
+
+void Logger::logf(const char *p_format, ...) {
+	if (!should_log(false)) {
+		return;
+	}
+
+	va_list argp;
+	va_start(argp, p_format);
+
+	logv(p_format, argp, false);
+
+	va_end(argp);
+}
+
+void Logger::logf_error(const char *p_format, ...) {
+	if (!should_log(true)) {
+		return;
+	}
+
+	va_list argp;
+	va_start(argp, p_format);
+
+	logv(p_format, argp, true);
+
+	va_end(argp);
+}
+
+Logger::~Logger() {}
+
+void RotatedFileLogger::close_file() {
+	if (file) {
+		memdelete(file);
+		file = NULL;
+	}
+}
+
+void RotatedFileLogger::clear_old_backups() {
+	int max_backups = max_files - 1; // -1 for the current file
+
+	String basename = base_path.get_basename();
+	String extension = "." + base_path.get_extension();
+
+	DirAccess *da = DirAccess::open(base_path.get_base_dir());
+	if (!da) {
+		return;
+	}
+
+	da->list_dir_begin();
+	String f = da->get_next();
+	Set<String> backups;
+	while (f != String()) {
+		if (!da->current_is_dir() && f.begins_with(basename) && f.ends_with(extension) && f != base_path) {
+			backups.insert(f);
+		}
+		f = da->get_next();
+	}
+	da->list_dir_end();
+
+	if (backups.size() > max_backups) {
+		// since backups are appended with timestamp and Set iterates them in sorted order,
+		// first backups are the oldest
+		int to_delete = backups.size() - max_backups;
+		for (Set<String>::Element *E = backups.front(); E && to_delete > 0; E = E->next(), --to_delete) {
+			da->remove(E->get());
+		}
+	}
+
+	memdelete(da);
+}
+
+void RotatedFileLogger::rotate_file() {
+	close_file();
+
+	if (FileAccess::exists(base_path)) {
+		if (max_files > 1) {
+			char timestamp[21];
+			OS::Date date = OS::get_singleton()->get_date();
+			OS::Time time = OS::get_singleton()->get_time();
+			sprintf(timestamp, "-%04d-%02d-%02d-%02d-%02d-%02d", date.year, date.month, date.day + 1, time.hour, time.min, time.sec);
+
+			String backup_name = base_path.get_basename() + timestamp + "." + base_path.get_extension();
+
+			DirAccess *da = DirAccess::open(base_path.get_base_dir());
+			if (da) {
+				da->copy(base_path, backup_name);
+				memdelete(da);
+			}
+			clear_old_backups();
+		}
+	} else {
+		DirAccess *da = DirAccess::create(DirAccess::ACCESS_USERDATA);
+		if (da) {
+			da->make_dir_recursive(base_path.get_base_dir());
+			memdelete(da);
+		}
+	}
+
+	file = FileAccess::open(base_path, FileAccess::WRITE);
+}
+
+RotatedFileLogger::RotatedFileLogger(const String &p_base_path, int p_max_files) {
+	file = NULL;
+	base_path = p_base_path.simplify_path();
+	max_files = p_max_files > 0 ? p_max_files : 1;
+
+	rotate_file();
+}
+
+void RotatedFileLogger::logv(const char *p_format, va_list p_list, bool p_err) {
+	if (!should_log(p_err)) {
+		return;
+	}
+
+	if (file) {
+		const int static_buf_size = 512;
+		char static_buf[static_buf_size];
+		char *buf = static_buf;
+		int len = vsnprintf(buf, static_buf_size, p_format, p_list);
+		if (len >= static_buf_size) {
+			buf = (char *)Memory::alloc_static(len + 1);
+			vsnprintf(buf, len + 1, p_format, p_list);
+		}
+		file->store_buffer((uint8_t *)buf, len);
+		if (len >= static_buf_size) {
+			Memory::free_static(buf);
+		}
+#ifdef DEBUG_ENABLED
+		const bool need_flush = true;
+#else
+		bool need_flush = p_err;
+#endif
+		if (need_flush) {
+			file->flush();
+		}
+	}
+}
+
+RotatedFileLogger::~RotatedFileLogger() {
+	close_file();
+}
+
+void StdLogger::logv(const char *p_format, va_list p_list, bool p_err) {
+	if (!should_log(p_err)) {
+		return;
+	}
+
+	if (p_err) {
+		vfprintf(stderr, p_format, p_list);
+	} else {
+		vprintf(p_format, p_list);
+#ifdef DEBUG_ENABLED
+		fflush(stdout);
+#endif
+	}
+}
+
+StdLogger::~StdLogger() {}
+
+CompositeLogger::CompositeLogger(Vector<Logger *> p_loggers) {
+	loggers = p_loggers;
+}
+
+void CompositeLogger::logv(const char *p_format, va_list p_list, bool p_err) {
+	if (!should_log(p_err)) {
+		return;
+	}
+
+	for (int i = 0; i < loggers.size(); ++i) {
+		va_list list_copy;
+		va_copy(list_copy, p_list);
+		loggers[i]->logv(p_format, list_copy, p_err);
+		va_end(list_copy);
+	}
+}
+
+void CompositeLogger::log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, ErrorType p_type) {
+	if (!should_log(true)) {
+		return;
+	}
+
+	for (int i = 0; i < loggers.size(); ++i) {
+		loggers[i]->log_error(p_function, p_file, p_line, p_code, p_rationale, p_type);
+	}
+}
+
+CompositeLogger::~CompositeLogger() {
+	for (int i = 0; i < loggers.size(); ++i) {
+		memdelete(loggers[i]);
+	}
+}

--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -55,7 +55,7 @@ FileAccess *FileAccess::create(AccessType p_access) {
 
 bool FileAccess::exists(const String &p_name) {
 
-	if (PackedData::get_singleton()->has_path(p_name))
+	if (PackedData::get_singleton() && PackedData::get_singleton()->has_path(p_name))
 		return true;
 
 	FileAccess *f = open(p_name, READ);

--- a/core/os/file_access.h
+++ b/core/os/file_access.h
@@ -119,6 +119,7 @@ public:
 
 	virtual Error get_error() const = 0; ///< get last error
 
+	virtual void flush() = 0;
 	virtual void store_8(uint8_t p_dest) = 0; ///< store a byte
 	virtual void store_16(uint16_t p_dest); ///< store 16 bits uint
 	virtual void store_32(uint32_t p_dest); ///< store 32 bits uint

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -62,20 +62,20 @@ void OS::debug_break(){
 	// something
 };
 
-void OS::print_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, ErrorType p_type) {
-
-	const char *err_type = "**ERROR**";
-	switch (p_type) {
-		case ERR_ERROR: err_type = "**ERROR**"; break;
-		case ERR_WARNING: err_type = "**WARNING**"; break;
-		case ERR_SCRIPT: err_type = "**SCRIPT ERROR**"; break;
-		case ERR_SHADER: err_type = "**SHADER ERROR**"; break;
-		default: ERR_PRINT("Unknown error type"); break;
+void OS::_set_logger(Logger *p_logger) {
+	if (_logger) {
+		memdelete(_logger);
 	}
+	_logger = p_logger;
+}
 
-	if (p_rationale && *p_rationale)
-		print("%s: %s\n ", err_type, p_rationale);
-	print("%s: At: %s:%i:%s() - %s\n", err_type, p_file, p_line, p_function, p_code);
+void OS::initialize_logger() {
+	_set_logger(memnew(StdLogger));
+}
+
+void OS::print_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, Logger::ErrorType p_type) {
+
+	_logger->log_error(p_function, p_file, p_line, p_code, p_rationale, p_type);
 }
 
 void OS::print(const char *p_format, ...) {
@@ -83,17 +83,16 @@ void OS::print(const char *p_format, ...) {
 	va_list argp;
 	va_start(argp, p_format);
 
-	vprint(p_format, argp);
+	_logger->logv(p_format, argp, false);
 
 	va_end(argp);
 };
 
 void OS::printerr(const char *p_format, ...) {
-
 	va_list argp;
 	va_start(argp, p_format);
 
-	vprint(p_format, argp, true);
+	_logger->logv(p_format, argp, true);
 
 	va_end(argp);
 };
@@ -533,9 +532,12 @@ OS::OS() {
 
 	_allow_hidpi = true;
 	_stack_bottom = (void *)(&stack_bottom);
+
+	_logger = NULL;
+	_set_logger(memnew(StdLogger));
 }
 
 OS::~OS() {
-
+	memdelete(_logger);
 	singleton = NULL;
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -32,6 +32,7 @@
 
 #include "engine.h"
 #include "image.h"
+#include "io/logger.h"
 #include "list.h"
 #include "os/main_loop.h"
 #include "ustring.h"
@@ -60,6 +61,11 @@ class OS {
 	char *last_error;
 
 	void *_stack_bottom;
+
+	Logger *_logger;
+
+protected:
+	void _set_logger(Logger *p_logger);
 
 public:
 	typedef void (*ImeCallback)(void *p_inp, String p_text, Point2 p_selection);
@@ -108,6 +114,7 @@ protected:
 	virtual int get_audio_driver_count() const = 0;
 	virtual const char *get_audio_driver_name(int p_driver) const = 0;
 
+	virtual void initialize_logger();
 	virtual void initialize_core() = 0;
 	virtual void initialize(const VideoMode &p_desired, int p_video_driver, int p_audio_driver) = 0;
 
@@ -127,18 +134,10 @@ public:
 
 	static OS *get_singleton();
 
-	enum ErrorType {
-		ERR_ERROR,
-		ERR_WARNING,
-		ERR_SCRIPT,
-		ERR_SHADER
-	};
+	void print_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, Logger::ErrorType p_type = Logger::ERR_ERROR);
+	void print(const char *p_format, ...);
+	void printerr(const char *p_format, ...);
 
-	virtual void print_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, ErrorType p_type = ERR_ERROR);
-
-	virtual void print(const char *p_format, ...);
-	virtual void printerr(const char *p_format, ...);
-	virtual void vprint(const char *p_format, va_list p_list, bool p_stderr = false) = 0;
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!") = 0;
 	virtual String get_stdin_string(bool p_block = true) = 0;
 

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -223,6 +223,12 @@ Error FileAccessUnix::get_error() const {
 	return last_error;
 }
 
+void FileAccessUnix::flush() {
+
+	ERR_FAIL_COND(!f);
+	fflush(f);
+}
+
 void FileAccessUnix::store_8(uint8_t p_dest) {
 
 	ERR_FAIL_COND(!f);

--- a/drivers/unix/file_access_unix.h
+++ b/drivers/unix/file_access_unix.h
@@ -72,6 +72,7 @@ public:
 
 	virtual Error get_error() const; ///< get last error
 
+	virtual void flush();
 	virtual void store_8(uint8_t p_dest); ///< store a byte
 
 	virtual bool file_exists(const String &p_path); ///< return true if a file exists

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -54,11 +54,11 @@ protected:
 	virtual int get_audio_driver_count() const;
 	virtual const char *get_audio_driver_name(int p_driver) const;
 
+	virtual void initialize_logger();
 	virtual void initialize_core();
 	virtual int unix_initialize_audio(int p_audio_driver);
 	//virtual void initialize(int p_video_driver,int p_audio_driver);
 
-	//virtual void finalize();
 	virtual void finalize_core();
 
 	String stdin_buf;
@@ -66,10 +66,6 @@ protected:
 	String get_global_settings_path() const;
 
 public:
-	virtual void print_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, ErrorType p_type = ERR_ERROR);
-
-	virtual void print(const char *p_format, ...);
-	virtual void vprint(const char *p_format, va_list p_list, bool p_stder = false);
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
 	virtual String get_stdin_string(bool p_block);
 
@@ -118,6 +114,12 @@ public:
 	virtual String get_data_dir() const;
 
 	//virtual void run( MainLoop * p_main_loop );
+};
+
+class UnixTerminalLogger : public StdLogger {
+public:
+	virtual void log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, ErrorType p_type = ERR_ERROR);
+	virtual ~UnixTerminalLogger();
 };
 
 #endif

--- a/drivers/unix/syslog_logger.h
+++ b/drivers/unix/syslog_logger.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  error_macros.cpp                                                     */
+/*  syslog_logger.h                                                      */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -27,73 +27,22 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#include "error_macros.h"
+
+#ifndef SYSLOG_LOGGER_H
+#define SYSLOG_LOGGER_H
+
+#ifdef UNIX_ENABLED
 
 #include "io/logger.h"
-#include "os/os.h"
 
-bool _err_error_exists = false;
+class SyslogLogger : public Logger {
+public:
+	virtual void logv(const char *p_format, va_list p_list, bool p_err);
+	virtual void print_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, ErrorType p_type);
 
-static ErrorHandlerList *error_handler_list = NULL;
+	virtual ~SyslogLogger();
+};
 
-void _err_set_last_error(const char *p_err) {
+#endif
 
-	OS::get_singleton()->set_last_error(p_err);
-}
-
-void _err_clear_last_error() {
-
-	OS::get_singleton()->clear_last_error();
-}
-
-void add_error_handler(ErrorHandlerList *p_handler) {
-
-	_global_lock();
-	p_handler->next = error_handler_list;
-	error_handler_list = p_handler;
-	_global_unlock();
-}
-
-void remove_error_handler(ErrorHandlerList *p_handler) {
-
-	_global_lock();
-
-	ErrorHandlerList *prev = NULL;
-	ErrorHandlerList *l = error_handler_list;
-
-	while (l) {
-
-		if (l == p_handler) {
-
-			if (prev)
-				prev->next = l->next;
-			else
-				error_handler_list = l->next;
-			break;
-		}
-		prev = l;
-		l = l->next;
-	}
-
-	_global_unlock();
-}
-
-void _err_print_error(const char *p_function, const char *p_file, int p_line, const char *p_error, ErrorHandlerType p_type) {
-
-	OS::get_singleton()->print_error(p_function, p_file, p_line, p_error, _err_error_exists ? OS::get_singleton()->get_last_error() : "", (Logger::ErrorType)p_type);
-
-	_global_lock();
-	ErrorHandlerList *l = error_handler_list;
-	while (l) {
-
-		l->errfunc(l->userdata, p_function, p_file, p_line, p_error, _err_error_exists ? OS::get_singleton()->get_last_error() : "", p_type);
-		l = l->next;
-	}
-
-	_global_unlock();
-
-	if (_err_error_exists) {
-		OS::get_singleton()->clear_last_error();
-		_err_error_exists = false;
-	}
-}
+#endif

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -162,10 +162,10 @@ Error DirAccessWindows::make_dir(String p_dir) {
 
 	GLOBAL_LOCK_FUNCTION
 
+	p_dir = fix_path(p_dir);
 	if (p_dir.is_rel_path())
 		p_dir = get_current_dir().plus_file(p_dir);
 
-	p_dir = fix_path(p_dir);
 	p_dir = p_dir.replace("/", "\\");
 
 	bool success;

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -207,6 +207,12 @@ Error FileAccessWindows::get_error() const {
 	return last_error;
 }
 
+void FileAccessWindows::flush() {
+
+	ERR_FAIL_COND(!f);
+	fflush(f);
+}
+
 void FileAccessWindows::store_8(uint8_t p_dest) {
 
 	ERR_FAIL_COND(!f);

--- a/drivers/windows/file_access_windows.h
+++ b/drivers/windows/file_access_windows.h
@@ -64,6 +64,7 @@ public:
 
 	virtual Error get_error() const; ///< get last error
 
+	virtual void flush();
 	virtual void store_8(uint8_t p_dest); ///< store a byte
 
 	virtual bool file_exists(const String &p_name); ///< return true if a file exists

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -231,7 +231,6 @@ void Main::print_help(const char *p_binary) {
 }
 
 Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_phase) {
-
 	RID_OwnerBase::init_rid();
 
 	OS::get_singleton()->initialize_core();
@@ -253,6 +252,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	input_map = memnew(InputMap);
 
 	register_core_settings(); //here globals is present
+
+	OS::get_singleton()->initialize_logger();
 
 	translation_server = memnew(TranslationServer);
 	performance = memnew(Performance);

--- a/platform/android/file_access_android.cpp
+++ b/platform/android/file_access_android.cpp
@@ -146,6 +146,11 @@ Error FileAccessAndroid::get_error() const {
 	return eof ? ERR_FILE_EOF : OK; //not sure what else it may happen
 }
 
+void FileAccessAndroid::flush() {
+
+	ERR_FAIL();
+}
+
 void FileAccessAndroid::store_8(uint8_t p_dest) {
 
 	ERR_FAIL();

--- a/platform/android/file_access_android.h
+++ b/platform/android/file_access_android.h
@@ -63,6 +63,7 @@ public:
 
 	virtual Error get_error() const; ///< get last error
 
+	virtual void flush();
 	virtual void store_8(uint8_t p_dest); ///< store a byte
 
 	virtual bool file_exists(const String &p_path); ///< return true if a file exists

--- a/platform/android/file_access_jandroid.cpp
+++ b/platform/android/file_access_jandroid.cpp
@@ -157,6 +157,9 @@ Error FileAccessJAndroid::get_error() const {
 	return OK;
 }
 
+void FileAccessJAndroid::flush() {
+}
+
 void FileAccessJAndroid::store_8(uint8_t p_dest) {
 }
 

--- a/platform/android/file_access_jandroid.h
+++ b/platform/android/file_access_jandroid.h
@@ -67,6 +67,7 @@ public:
 
 	virtual Error get_error() const; ///< get last error
 
+	virtual void flush();
 	virtual void store_8(uint8_t p_dest); ///< store a byte
 
 	virtual bool file_exists(const String &p_path); ///< return true if a file exists

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -149,6 +149,7 @@ public:
 	virtual int get_audio_driver_count() const;
 	virtual const char *get_audio_driver_name(int p_driver) const;
 
+	virtual void initialize_logger();
 	virtual void initialize_core();
 	virtual void initialize(const VideoMode &p_desired, int p_video_driver, int p_audio_driver);
 
@@ -161,8 +162,6 @@ public:
 
 	static OS *get_singleton();
 
-	virtual void vprint(const char *p_format, va_list p_list, bool p_stderr = false);
-	virtual void print(const char *p_format, ...);
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
 
 	virtual void set_mouse_show(bool p_show);

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -42,6 +42,7 @@
 #include "core/os/dir_access.h"
 #include "core/os/file_access.h"
 #include "core/project_settings.h"
+#include "drivers/unix/syslog_logger.h"
 
 #include "sem_iphone.h"
 
@@ -98,6 +99,13 @@ void OSIPhone::initialize_core() {
 	OS_Unix::initialize_core();
 	SemaphoreIphone::make_default();
 };
+
+void OSIPhone::initialize_logger() {
+	Vector<Logger *> loggers;
+	loggers.push_back(memnew(SyslogLogger));
+	loggers.push_back(memnew(RotatedFileLogger("user://logs/log.txt")));
+	_set_logger(memnew(CompositeLogger(loggers)));
+}
 
 void OSIPhone::initialize(const VideoMode &p_desired, int p_video_driver, int p_audio_driver) {
 
@@ -570,6 +578,8 @@ OSIPhone::OSIPhone(int width, int height) {
 	vm.resizable = false;
 	set_video_mode(vm);
 	event_count = 0;
+
+	_set_logger(memnew(SyslogLogger));
 };
 
 OSIPhone::~OSIPhone() {

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -91,6 +91,7 @@ private:
 
 	virtual VideoMode get_default_video_mode() const;
 
+	virtual void initialize_logger();
 	virtual void initialize_core();
 	virtual void initialize(const VideoMode &p_desired, int p_video_driver, int p_audio_driver);
 

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -85,6 +85,10 @@ void OS_JavaScript::initialize_core() {
 	FileAccess::make_default<FileAccessBufferedFA<FileAccessUnix> >(FileAccess::ACCESS_RESOURCES);
 }
 
+void OS_JavaScript::initialize_logger() {
+	_set_logger(memnew(StdLogger));
+}
+
 void OS_JavaScript::set_opengl_extensions(const char *p_gl_extensions) {
 
 	ERR_FAIL_COND(!p_gl_extensions);

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -92,6 +92,7 @@ public:
 	virtual int get_audio_driver_count() const;
 	virtual const char *get_audio_driver_name(int p_driver) const;
 
+	virtual void initialize_logger();
 	virtual void initialize_core();
 	virtual void initialize(const VideoMode &p_desired, int p_video_driver, int p_audio_driver);
 
@@ -103,11 +104,6 @@ public:
 	typedef int64_t ProcessID;
 
 	//static OS* get_singleton();
-
-	virtual void print_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, ErrorType p_type) {
-
-		OS::print_error(p_function, p_file, p_line, p_code, p_rationale, p_type);
-	}
 
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
 

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -129,6 +129,7 @@ protected:
 	virtual const char *get_video_driver_name(int p_driver) const;
 	virtual VideoMode get_default_video_mode() const;
 
+	virtual void initialize_logger();
 	virtual void initialize_core();
 	virtual void initialize(const VideoMode &p_desired, int p_video_driver, int p_audio_driver);
 	virtual void finalize();
@@ -142,8 +143,6 @@ public:
 	void wm_minimized(bool p_minimized);
 
 	virtual String get_name();
-
-	virtual void print_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, ErrorType p_type = ERR_ERROR);
 
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
 

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1145,43 +1145,67 @@ String OS_OSX::get_name() {
 	return "OSX";
 }
 
-void OS_OSX::print_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, ErrorType p_type) {
-
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 101200
-	if (!_print_error_enabled)
-		return;
+class OSXTerminalLogger : public StdLogger {
+public:
+	virtual void log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, ErrorType p_type = ERR_ERROR) {
+		if (!should_log(true)) {
+			return;
+		}
 
-	const char *err_details;
-	if (p_rationale && p_rationale[0])
-		err_details = p_rationale;
-	else
-		err_details = p_code;
+		const char *err_details;
+		if (p_rationale && p_rationale[0])
+			err_details = p_rationale;
+		else
+			err_details = p_code;
 
-	switch (p_type) {
-		case ERR_ERROR:
-			os_log_error(OS_LOG_DEFAULT, "ERROR: %{public}s: %{public}s\nAt: %{public}s:%i.", p_function, err_details, p_file, p_line);
-			print("\E[1;31mERROR: %s: \E[0m\E[1m%s\n", p_function, err_details);
-			print("\E[0;31m   At: %s:%i.\E[0m\n", p_file, p_line);
-			break;
-		case ERR_WARNING:
-			os_log_info(OS_LOG_DEFAULT, "WARNING: %{public}s: %{public}s\nAt: %{public}s:%i.", p_function, err_details, p_file, p_line);
-			print("\E[1;33mWARNING: %s: \E[0m\E[1m%s\n", p_function, err_details);
-			print("\E[0;33m   At: %s:%i.\E[0m\n", p_file, p_line);
-			break;
-		case ERR_SCRIPT:
-			os_log_error(OS_LOG_DEFAULT, "SCRIPT ERROR: %{public}s: %{public}s\nAt: %{public}s:%i.", p_function, err_details, p_file, p_line);
-			print("\E[1;35mSCRIPT ERROR: %s: \E[0m\E[1m%s\n", p_function, err_details);
-			print("\E[0;35m   At: %s:%i.\E[0m\n", p_file, p_line);
-			break;
-		case ERR_SHADER:
-			os_log_error(OS_LOG_DEFAULT, "SHADER ERROR: %{public}s: %{public}s\nAt: %{public}s:%i.", p_function, err_details, p_file, p_line);
-			print("\E[1;36mSHADER ERROR: %s: \E[0m\E[1m%s\n", p_function, err_details);
-			print("\E[0;36m   At: %s:%i.\E[0m\n", p_file, p_line);
-			break;
+		switch (p_type) {
+			case ERR_WARNING:
+				os_log_info(OS_LOG_DEFAULT,
+						"WARNING: %{public}s: %{public}s\nAt: %{public}s:%i.",
+						p_function, err_details, p_file, p_line);
+				logf_error("\E[1;33mWARNING: %s: \E[0m\E[1m%s\n", p_function,
+						err_details);
+				logf_error("\E[0;33m   At: %s:%i.\E[0m\n", p_file, p_line);
+				break;
+			case ERR_SCRIPT:
+				os_log_error(OS_LOG_DEFAULT,
+						"SCRIPT ERROR: %{public}s: %{public}s\nAt: %{public}s:%i.",
+						p_function, err_details, p_file, p_line);
+				logf_error("\E[1;35mSCRIPT ERROR: %s: \E[0m\E[1m%s\n", p_function,
+						err_details);
+				logf_error("\E[0;35m   At: %s:%i.\E[0m\n", p_file, p_line);
+				break;
+			case ERR_SHADER:
+				os_log_error(OS_LOG_DEFAULT,
+						"SHADER ERROR: %{public}s: %{public}s\nAt: %{public}s:%i.",
+						p_function, err_details, p_file, p_line);
+				logf_error("\E[1;36mSHADER ERROR: %s: \E[0m\E[1m%s\n", p_function,
+						err_details);
+				logf_error("\E[0;36m   At: %s:%i.\E[0m\n", p_file, p_line);
+				break;
+			case ERR_ERROR:
+			default:
+				os_log_error(OS_LOG_DEFAULT,
+						"ERROR: %{public}s: %{public}s\nAt: %{public}s:%i.",
+						p_function, err_details, p_file, p_line);
+				logf_error("\E[1;31mERROR: %s: \E[0m\E[1m%s\n", p_function, err_details);
+				logf_error("\E[0;31m   At: %s:%i.\E[0m\n", p_file, p_line);
+				break;
+		}
 	}
+};
+
 #else
-	OS_Unix::print_error(p_function, p_file, p_line, p_code, p_rationale, p_type);
+
+typedef UnixTerminalLogger OSXTerminalLogger;
 #endif
+
+void OS_OSX::initialize_logger() {
+	Vector<Logger *> loggers;
+	loggers.push_back(memnew(OSXTerminalLogger));
+	loggers.push_back(memnew(RotatedFileLogger("user://logs/log.txt")));
+	_set_logger(memnew(CompositeLogger(loggers)));
 }
 
 void OS_OSX::alert(const String &p_alert, const String &p_title) {
@@ -2003,6 +2027,8 @@ OS_OSX::OS_OSX() {
 	window_size = Vector2(1024, 600);
 	zoomed = false;
 	display_scale = 1.0;
+
+	_set_logger(memnew(OSXTerminalLogger));
 }
 
 bool OS_OSX::_check_internal_feature_support(const String &p_feature) {

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -40,6 +40,7 @@
 #include "platform/windows/packet_peer_udp_winsock.h"
 #include "platform/windows/stream_peer_winsock.h"
 #include "platform/windows/tcp_server_winsock.h"
+#include "platform/windows/windows_terminal_logger.h"
 #include "project_settings.h"
 #include "servers/audio_server.h"
 #include "servers/visual/visual_server_raster.h"
@@ -180,6 +181,13 @@ void OSUWP::initialize_core() {
 	IP_Unix::make_default();
 
 	cursor_shape = CURSOR_ARROW;
+}
+
+void OSUWP::initialize_logger() {
+	Vector<Logger *> loggers;
+	loggers.push_back(memnew(WindowsTerminalLogger));
+	loggers.push_back(memnew(RotatedFileLogger("user://logs/log.txt")));
+	_set_logger(memnew(CompositeLogger(loggers)));
 }
 
 bool OSUWP::can_draw() const {
@@ -371,32 +379,6 @@ void OSUWP::finalize() {
 void OSUWP::finalize_core() {
 }
 
-void OSUWP::vprint(const char *p_format, va_list p_list, bool p_stderr) {
-
-	char buf[16384 + 1];
-	int len = vsnprintf(buf, 16384, p_format, p_list);
-	if (len <= 0)
-		return;
-	buf[len] = 0;
-
-	int wlen = MultiByteToWideChar(CP_UTF8, 0, buf, len, NULL, 0);
-	if (wlen < 0)
-		return;
-
-	wchar_t *wbuf = (wchar_t *)malloc((len + 1) * sizeof(wchar_t));
-	MultiByteToWideChar(CP_UTF8, 0, buf, len, wbuf, wlen);
-	wbuf[wlen] = 0;
-
-	if (p_stderr)
-		fwprintf(stderr, L"%s", wbuf);
-	else
-		wprintf(L"%s", wbuf);
-
-	free(wbuf);
-
-	fflush(stdout);
-};
-
 void OSUWP::alert(const String &p_alert, const String &p_title) {
 
 	Platform::String ^ alert = ref new Platform::String(p_alert.c_str());
@@ -518,30 +500,6 @@ OS::VideoMode OSUWP::get_video_mode(int p_screen) const {
 	return video_mode;
 }
 void OSUWP::get_fullscreen_mode_list(List<VideoMode> *p_list, int p_screen) const {
-}
-
-void OSUWP::print_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, ErrorType p_type) {
-
-	const char *err_details;
-	if (p_rationale && p_rationale[0])
-		err_details = p_rationale;
-	else
-		err_details = p_code;
-
-	switch (p_type) {
-		case ERR_ERROR:
-			print("ERROR: %s: %s\n", p_function, err_details);
-			print("   At: %s:%i\n", p_file, p_line);
-			break;
-		case ERR_WARNING:
-			print("WARNING: %s: %s\n", p_function, err_details);
-			print("     At: %s:%i\n", p_file, p_line);
-			break;
-		case ERR_SCRIPT:
-			print("SCRIPT ERROR: %s: %s\n", p_function, err_details);
-			print("          At: %s:%i\n", p_file, p_line);
-			break;
-	}
 }
 
 String OSUWP::get_name() {
@@ -890,6 +848,8 @@ OSUWP::OSUWP() {
 	mouse_mode_changed = CreateEvent(NULL, TRUE, FALSE, L"os_mouse_mode_changed");
 
 	AudioDriverManager::add_driver(&audio_driver);
+
+	_set_logger(memnew(WindowsTerminalLogger));
 }
 
 OSUWP::~OSUWP() {

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -163,6 +163,7 @@ protected:
 	virtual int get_audio_driver_count() const;
 	virtual const char *get_audio_driver_name(int p_driver) const;
 
+	virtual void initialize_logger();
 	virtual void initialize_core();
 	virtual void initialize(const VideoMode &p_desired, int p_video_driver, int p_audio_driver);
 
@@ -180,9 +181,6 @@ public:
 	// Event to send to the app wrapper
 	HANDLE mouse_mode_changed;
 
-	void print_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, ErrorType p_type);
-
-	virtual void vprint(const char *p_format, va_list p_list, bool p_stderr = false);
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
 	String get_stdin_string(bool p_block);
 

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -19,6 +19,7 @@ common_win = [
     "stream_peer_winsock.cpp",
     "joypad.cpp",
     "power_windows.cpp",
+    "windows_terminal_logger.cpp"
 ]
 
 restarget = "godot_res" + env["OBJSUFFIX"]

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -152,6 +152,7 @@ protected:
 	virtual int get_audio_driver_count() const;
 	virtual const char *get_audio_driver_name(int p_driver) const;
 
+	virtual void initialize_logger();
 	virtual void initialize_core();
 	virtual void initialize(const VideoMode &p_desired, int p_video_driver, int p_audio_driver);
 
@@ -180,9 +181,6 @@ protected:
 public:
 	LRESULT WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
-	void print_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, ErrorType p_type);
-
-	virtual void vprint(const char *p_format, va_list p_list, bool p_stderr = false);
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
 	String get_stdin_string(bool p_block);
 

--- a/platform/windows/windows_terminal_logger.cpp
+++ b/platform/windows/windows_terminal_logger.cpp
@@ -1,0 +1,157 @@
+/*************************************************************************/
+/*  windows_terminal_logger.cpp                                          */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "windows_terminal_logger.h"
+
+#ifdef WINDOWS_ENABLED
+
+#include <stdio.h>
+#include <windows.h>
+
+void WindowsTerminalLogger::logv(const char *p_format, va_list p_list, bool p_err) {
+	if (!should_log(p_err)) {
+		return;
+	}
+
+	const unsigned int BUFFER_SIZE = 16384;
+	char buf[BUFFER_SIZE + 1]; // +1 for the terminating character
+	int len = vsnprintf(buf, BUFFER_SIZE, p_format, p_list);
+	if (len <= 0)
+		return;
+	if (len >= BUFFER_SIZE)
+		len = BUFFER_SIZE; // Output is too big, will be truncated
+	buf[len] = 0;
+
+	int wlen = MultiByteToWideChar(CP_UTF8, 0, buf, len, NULL, 0);
+	if (wlen < 0)
+		return;
+
+	wchar_t *wbuf = (wchar_t *)malloc((len + 1) * sizeof(wchar_t));
+	MultiByteToWideChar(CP_UTF8, 0, buf, len, wbuf, wlen);
+	wbuf[wlen] = 0;
+
+	if (p_err)
+		fwprintf(stderr, L"%ls", wbuf);
+	else
+		wprintf(L"%ls", wbuf);
+
+	free(wbuf);
+
+#ifdef DEBUG_ENABLED
+	fflush(stdout);
+#endif
+}
+
+void WindowsTerminalLogger::log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, ErrorType p_type) {
+	if (!should_log(true)) {
+		return;
+	}
+
+#ifndef UWP_ENABLED
+	HANDLE hCon = GetStdHandle(STD_OUTPUT_HANDLE);
+	if (!hCon || hCon == INVALID_HANDLE_VALUE) {
+#endif
+		StdLogger::log_error(p_function, p_file, p_line, p_code, p_rationale, p_type);
+#ifndef UWP_ENABLED
+	} else {
+
+		CONSOLE_SCREEN_BUFFER_INFO sbi; //original
+		GetConsoleScreenBufferInfo(hCon, &sbi);
+
+		WORD current_fg = sbi.wAttributes & (FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY);
+		WORD current_bg = sbi.wAttributes & (BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE | BACKGROUND_INTENSITY);
+
+		uint32_t basecol = 0;
+		switch (p_type) {
+			case ERR_ERROR: basecol = FOREGROUND_RED; break;
+			case ERR_WARNING: basecol = FOREGROUND_RED | FOREGROUND_GREEN; break;
+			case ERR_SCRIPT: basecol = FOREGROUND_RED | FOREGROUND_BLUE; break;
+			case ERR_SHADER: basecol = FOREGROUND_GREEN | FOREGROUND_BLUE; break;
+		}
+
+		basecol |= current_bg;
+
+		if (p_rationale && p_rationale[0]) {
+
+			SetConsoleTextAttribute(hCon, basecol | FOREGROUND_INTENSITY);
+			switch (p_type) {
+				case ERR_ERROR: logf("ERROR: "); break;
+				case ERR_WARNING: logf("WARNING: "); break;
+				case ERR_SCRIPT: logf("SCRIPT ERROR: "); break;
+				case ERR_SHADER: logf("SHADER ERROR: "); break;
+			}
+
+			SetConsoleTextAttribute(hCon, current_fg | current_bg | FOREGROUND_INTENSITY);
+			logf("%s\n", p_rationale);
+
+			SetConsoleTextAttribute(hCon, basecol);
+			switch (p_type) {
+				case ERR_ERROR: logf("   At: "); break;
+				case ERR_WARNING: logf("     At: "); break;
+				case ERR_SCRIPT: logf("          At: "); break;
+				case ERR_SHADER: logf("          At: "); break;
+			}
+
+			SetConsoleTextAttribute(hCon, current_fg | current_bg);
+			logf("%s:%i\n", p_file, p_line);
+
+		} else {
+
+			SetConsoleTextAttribute(hCon, basecol | FOREGROUND_INTENSITY);
+			switch (p_type) {
+				case ERR_ERROR: logf("ERROR: %s: ", p_function); break;
+				case ERR_WARNING: logf("WARNING: %s: ", p_function); break;
+				case ERR_SCRIPT: logf("SCRIPT ERROR: %s: ", p_function); break;
+				case ERR_SHADER: logf("SCRIPT ERROR: %s: ", p_function); break;
+			}
+
+			SetConsoleTextAttribute(hCon, current_fg | current_bg | FOREGROUND_INTENSITY);
+			logf("%s\n", p_code);
+
+			SetConsoleTextAttribute(hCon, basecol);
+			switch (p_type) {
+				case ERR_ERROR: logf("   At: "); break;
+				case ERR_WARNING: logf("     At: "); break;
+				case ERR_SCRIPT: logf("          At: "); break;
+				case ERR_SHADER: logf("          At: "); break;
+			}
+
+			SetConsoleTextAttribute(hCon, current_fg | current_bg);
+			logf("%s:%i\n", p_file, p_line);
+		}
+
+		SetConsoleTextAttribute(hCon, sbi.wAttributes);
+	}
+#endif
+}
+
+WindowsTerminalLogger::~WindowsTerminalLogger() {}
+
+#endif

--- a/platform/windows/windows_terminal_logger.h
+++ b/platform/windows/windows_terminal_logger.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  error_macros.cpp                                                     */
+/*  windows_terminal_logger.h                                            */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -27,73 +27,21 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#include "error_macros.h"
+
+#ifndef WINDOWS_TERMINAL_LOGGER_H
+#define WINDOWS_TERMINAL_LOGGER_H
+
+#ifdef WINDOWS_ENABLED
 
 #include "io/logger.h"
-#include "os/os.h"
 
-bool _err_error_exists = false;
+class WindowsTerminalLogger : public StdLogger {
+public:
+	virtual void logv(const char *p_format, va_list p_list, bool p_err);
+	virtual void log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, ErrorType p_type = ERR_ERROR);
+	virtual ~WindowsTerminalLogger();
+};
 
-static ErrorHandlerList *error_handler_list = NULL;
+#endif
 
-void _err_set_last_error(const char *p_err) {
-
-	OS::get_singleton()->set_last_error(p_err);
-}
-
-void _err_clear_last_error() {
-
-	OS::get_singleton()->clear_last_error();
-}
-
-void add_error_handler(ErrorHandlerList *p_handler) {
-
-	_global_lock();
-	p_handler->next = error_handler_list;
-	error_handler_list = p_handler;
-	_global_unlock();
-}
-
-void remove_error_handler(ErrorHandlerList *p_handler) {
-
-	_global_lock();
-
-	ErrorHandlerList *prev = NULL;
-	ErrorHandlerList *l = error_handler_list;
-
-	while (l) {
-
-		if (l == p_handler) {
-
-			if (prev)
-				prev->next = l->next;
-			else
-				error_handler_list = l->next;
-			break;
-		}
-		prev = l;
-		l = l->next;
-	}
-
-	_global_unlock();
-}
-
-void _err_print_error(const char *p_function, const char *p_file, int p_line, const char *p_error, ErrorHandlerType p_type) {
-
-	OS::get_singleton()->print_error(p_function, p_file, p_line, p_error, _err_error_exists ? OS::get_singleton()->get_last_error() : "", (Logger::ErrorType)p_type);
-
-	_global_lock();
-	ErrorHandlerList *l = error_handler_list;
-	while (l) {
-
-		l->errfunc(l->userdata, p_function, p_file, p_line, p_error, _err_error_exists ? OS::get_singleton()->get_last_error() : "", p_type);
-		l = l->next;
-	}
-
-	_global_unlock();
-
-	if (_err_error_exists) {
-		OS::get_singleton()->clear_last_error();
-		_err_error_exists = false;
-	}
-}
+#endif


### PR DESCRIPTION
Previously logging logic was scattered over OS class implementations
with plenty of duplication. Major changes in this commit:

 - Extracted logging logic into a separate Logger hierarchy. It allows
   easy configuration of logging mechanism depending on compile-time or
   run-time configuration.

 - Implemented RotatedFileLogger which is usually used with StdLogger,
   providing persistency of logs. It is often important to be able to
   obtain logs of the game even in production to be able to understand
   what happened prior to some problem. On mobile there previously was
   no way to obtain the logs aside from having the device connected to
   your machine.

 - flush() is not performed in release mode for every logged line. It
   is only performed for errors.