### PR TITLE
Add font size setting for output panel

### DIFF
--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -158,6 +158,16 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 
 	p_theme->set_font("doc_source", "EditorFonts", df_doc_code);
 
+	Ref<DynamicFont> df_output_code;
+	df_output_code.instance();
+	df_output_code->set_size(int(EDITOR_DEF("run/output/font_size", 13)) * EDSCALE);
+	df_output_code->set_spacing(DynamicFont::SPACING_TOP, -EDSCALE);
+	df_output_code->set_spacing(DynamicFont::SPACING_BOTTOM, -EDSCALE);
+	df_output_code->set_font_data(dfmono);
+	MAKE_FALLBACKS(df_output_code);
+
+	p_theme->set_font("output_source", "EditorFonts", df_output_code);
+
 	//replace default theme
 	Ref<Texture> di;
 	Ref<StyleBox> ds;

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -31,6 +31,7 @@
 
 #include "editor_node.h"
 #include "scene/gui/center_container.h"
+#include "scene/resources/dynamic_font.h"
 #include "version.h"
 
 void EditorLog::_error_handler(void *p_self, const char *p_func, const char *p_file, int p_line, const char *p_error, const char *p_errorexp, ErrorHandlerType p_type) {
@@ -51,7 +52,6 @@ void EditorLog::_error_handler(void *p_self, const char *p_func, const char *p_f
 		self->emit_signal("show_request");
 	*/
 
-	err_str = " " + err_str;
 	self->add_message(err_str, true);
 }
 
@@ -60,6 +60,13 @@ void EditorLog::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
 		//button->set_icon(get_icon("Console","EditorIcons"));
+		log->add_font_override("normal_font", get_font("output_source", "EditorFonts"));
+	} else if (p_what == NOTIFICATION_THEME_CHANGED) {
+		Ref<DynamicFont> df_output_code = get_font("output_source", "EditorFonts");
+		if (df_output_code.is_valid()) {
+			df_output_code->set_size(int(EDITOR_DEF("run/output/font_size", 13)) * EDSCALE);
+			log->add_font_override("normal_font", get_font("output_source", "EditorFonts"));
+		}
 	}
 
 	/*if (p_what==NOTIFICATION_DRAW) {
@@ -85,15 +92,13 @@ void EditorLog::clear() {
 
 void EditorLog::add_message(const String &p_msg, bool p_error) {
 
-	Ref<Font> doc_code_font = get_font("doc_source", "EditorFonts");
-	log->push_font(doc_code_font);
-
 	log->add_newline();
 
 	if (p_error) {
 		log->push_color(get_color("error_color", "Editor"));
 		Ref<Texture> icon = get_icon("Error", "EditorIcons");
 		log->add_image(icon);
+		log->add_text(" ");
 		//button->set_icon(icon);
 	} else {
 		//button->set_icon(Ref<Texture>());
@@ -104,8 +109,6 @@ void EditorLog::add_message(const String &p_msg, bool p_error) {
 
 	if (p_error)
 		log->pop();
-
-	log->pop(); // pop font;
 }
 
 /*

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1065,7 +1065,7 @@ void ScriptEditorDebugger::start() {
 
 	int remote_port = (int)EditorSettings::get_singleton()->get("network/debug/remote_port");
 	if (server->listen(remote_port) != OK) {
-		EditorNode::get_log()->add_message(String("** Error listening on port ") + itos(remote_port) + String(" **"));
+		EditorNode::get_log()->add_message(String("Error listening on port ") + itos(remote_port), true);
 		return;
 	}
 	set_process(true);


### PR DESCRIPTION
- current font size for output panel is too big. adjusted default size
![image](https://user-images.githubusercontent.com/8281454/30813434-66f20b86-a248-11e7-975b-6cc06e645dc8.png)

- add font size setting for output panel
![image](https://user-images.githubusercontent.com/8281454/30813600-d51fbc8e-a248-11e7-9d7c-25cc02a69abd.png)

- show "Error listening on port" error with error format (dot with red color)
![image](https://user-images.githubusercontent.com/8281454/30814463-3fb78aac-a24b-11e7-89bd-f77398c17852.png)