### PR TITLE
In editor, instance DirectionalLight with an initial orientation

### DIFF
--- a/scene/3d/light.cpp
+++ b/scene/3d/light.cpp
@@ -369,6 +369,12 @@ DirectionalLight::DirectionalLight()
 	set_shadow_depth_range(SHADOW_DEPTH_RANGE_STABLE);
 
 	blend_splits = false;
+
+#ifdef TOOLS_ENABLED
+	if (Engine::get_singleton()->is_editor_hint())
+		// Create light with a default natural "sun" orientation in editor, instead of looking horizontally on X
+		set_rotation_in_degrees(Vector3(-50, 25, 30));
+#endif
 }
 
 void OmniLight::set_shadow_mode(ShadowMode p_mode) {


### PR DESCRIPTION
Just a small proposal, as everytime I create a directional light in editor it spawns horizontally on X, and I too often had to orientate it so that the scene looks more natural (Unity does this too)

![image](https://user-images.githubusercontent.com/1311555/30831660-848dee6c-a248-11e7-98a6-e465bdf69505.png)
