### PR TITLE
Fix crash when scene has LineEdit and run from editor

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -534,7 +534,7 @@ void LineEdit::_notification(int p_what) {
 	switch (p_what) {
 #ifdef TOOLS_ENABLED
 		case NOTIFICATION_ENTER_TREE: {
-			if (!get_tree()->is_node_being_edited(this)) {
+			if (Engine::get_singleton()->is_editor_hint() && !get_tree()->is_node_being_edited(this)) {
 				cursor_set_blink_enabled(EDITOR_DEF("text_editor/cursor/caret_blink", false));
 				cursor_set_blink_speed(EDITOR_DEF("text_editor/cursor/caret_blink_speed", 0.65));
 


### PR DESCRIPTION
regression from 5567cbe

```
[1] /lib/x86_64-linux-gnu/libc.so.6(+0x354b0) [0x7f60b7c1e4b0] (??:0)
[2] EditorSettings::has(String) const (??:?)
[3] _EDITOR_DEF(String const&, Variant const&) (??:?)
[4] LineEdit::_notification(int) (??:?)
[5] Object::notification(int, bool) (??:?)
[6] Node::_propagate_enter_tree() (??:?)
[7] Node::_propagate_enter_tree() (??:?)
[8] Node::_propagate_enter_tree() (??:?)
[9] Node::_propagate_enter_tree() (??:?)
[10] Node::_propagate_enter_tree() (??:?)
[11] Node::_set_tree(SceneTree*) (??:?)
[12] SceneTree::init() (??:?)
[13] OS_X11::run() (??:?)
[14] /mnt/2TB/Godot/Godot 3/godot.tools.64(main+0xd3) [0x8f4073] (??:?)
[15] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0) [0x7f60b7c09830] (??:0)
[16] /mnt/2TB/Godot/Godot 3/godot.tools.64(_start+0x29) [0x8f50f9] (??:?)
-- END OF BACKTRACE --
```