### PR TITLE
Update theme property respectively

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -54,7 +54,7 @@ EditorSettings *EditorSettings::get_singleton() {
 	return singleton.ptr();
 }
 
-bool EditorSettings::_set(const StringName &p_name, const Variant &p_value) {
+bool EditorSettings::_set(const StringName &p_name, const Variant &p_value, bool p_emit_signal) {
 
 	_THREAD_SAFE_METHOD_
 
@@ -90,7 +90,9 @@ bool EditorSettings::_set(const StringName &p_name, const Variant &p_value) {
 		}
 	}
 
-	emit_signal("settings_changed");
+	if (p_emit_signal) {
+		emit_signal("settings_changed");
+	}
 	return true;
 }
 

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -85,7 +85,7 @@ private:
 	HashMap<String, VariantContainer> props;
 	String resource_path;
 
-	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _set(const StringName &p_name, const Variant &p_value, bool p_emit_signal = true);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
@@ -126,6 +126,9 @@ public:
 		NOTIFICATION_EDITOR_SETTINGS_CHANGED = 10000
 	};
 
+	void set_manually(const StringName &p_name, const Variant &p_value, bool p_emit_signal = false) {
+		_set(p_name, p_value, p_emit_signal);
+	}
 	bool has(String p_var) const;
 	static EditorSettings *get_singleton();
 	void erase(String p_var);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -227,8 +227,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const float default_contrast = 0.25;
 
 	//Theme settings
-	Color accent_color = EDITOR_DEF("interface/theme/accent_color", Color::html("#000000"));
-	Color base_color = EDITOR_DEF("interface/theme/base_color", Color::html("#000000"));
+	Color accent_color = EDITOR_DEF("interface/theme/accent_color", Color::html("#699ce8"));
+	Color base_color = EDITOR_DEF("interface/theme/base_color", Color::html("#323b4f"));
 	float contrast = EDITOR_DEF("interface/theme/contrast", default_contrast);
 
 	int preset = EDITOR_DEF("interface/theme/preset", 0);
@@ -240,33 +240,54 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	Color script_bg_color = EDITOR_DEF("text_editor/highlighting/background_color", Color(0, 0, 0, 0));
 
+	Color preset_accent_color;
+	Color preset_base_color;
+	float preset_contrast;
 	switch (preset) {
 		case 0: { // Default
-			accent_color = Color::html("#699ce8");
-			base_color = Color::html("#323b4f");
-			contrast = default_contrast;
+			preset_accent_color = Color::html("#699ce8");
+			preset_base_color = Color::html("#323b4f");
+			preset_contrast = default_contrast;
 		} break;
 		case 1: { // Grey
-			accent_color = Color::html("#3e3e3e");
-			base_color = Color::html("#3d3d3d");
-			contrast = 0.2;
+			preset_accent_color = Color::html("#3e3e3e");
+			preset_base_color = Color::html("#3d3d3d");
+			preset_contrast = 0.2;
 		} break;
 		case 2: { // Godot 2
-			accent_color = Color::html("#86ace2");
-			base_color = Color::html("#3C3A44");
-			contrast = 0.25;
+			preset_accent_color = Color::html("#86ace2");
+			preset_base_color = Color::html("#3C3A44");
+			preset_contrast = 0.25;
 		} break;
 		case 3: { // Arc
-			accent_color = Color::html("#5294e2");
-			base_color = Color::html("#383c4a");
-			contrast = 0.25;
+			preset_accent_color = Color::html("#5294e2");
+			preset_base_color = Color::html("#383c4a");
+			preset_contrast = 0.25;
 		} break;
 		case 4: { // Light
-			accent_color = Color::html("#2070ff");
-			base_color = Color::html("#ffffff");
-			contrast = 0.08;
+			preset_accent_color = Color::html("#2070ff");
+			preset_base_color = Color::html("#ffffff");
+			preset_contrast = 0.08;
 		} break;
+		default: { // Custom
+			accent_color = EDITOR_DEF("interface/theme/accent_color", Color::html("#699ce8"));
+			base_color = EDITOR_DEF("interface/theme/base_color", Color::html("#323b4f"));
+			contrast = EDITOR_DEF("interface/theme/contrast", default_contrast);
+		}
 	}
+
+	if (preset != 5) {
+		accent_color = preset_accent_color;
+		base_color = preset_base_color;
+		contrast = preset_contrast;
+		EditorSettings::get_singleton()->set_initial_value("interface/theme/accent_color", accent_color);
+		EditorSettings::get_singleton()->set_initial_value("interface/theme/base_color", base_color);
+		EditorSettings::get_singleton()->set_initial_value("interface/theme/contrast", contrast);
+	}
+	EditorSettings::get_singleton()->set_manually("interface/theme/preset", preset);
+	EditorSettings::get_singleton()->set_manually("interface/theme/accent_color", accent_color);
+	EditorSettings::get_singleton()->set_manually("interface/theme/base_color", base_color);
+	EditorSettings::get_singleton()->set_manually("interface/theme/contrast", contrast);
 
 	//Colors
 	int AUTO_COLOR = 0;

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -58,6 +58,8 @@ void EditorSettingsDialog::_settings_property_edited(const String &p_name) {
 	// color theme is changed
 	if (full_name == "text_editor/theme/color_theme") {
 		property_editor->get_property_editor()->update_tree();
+	} else if (full_name == "interface/theme/accent_color" || full_name == "interface/theme/base_color" || full_name == "interface/theme/contrast") {
+		EditorSettings::get_singleton()->set_manually("interface/theme/preset", 5); // set preset to Custom
 	}
 }
 


### PR DESCRIPTION
![theme](https://user-images.githubusercontent.com/8281454/30857502-e76471f6-a2f6-11e7-8354-1e18a1d77ea8.gif)

- Base color, Accent color, contrast value are updated to match the color theme.
- Preset will be set to "Custom" if any value is changed.
- Default color & contrast value are set to selected preset color theme to revert back easily to last preset color.