### PR TITLE
Reduce gcc lto build time by telling the linker to use the number of jobs indicated by -j

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -265,7 +265,10 @@ def configure(env):
 
         if env['use_lto']:
             env.Append(CCFLAGS=['-flto'])
-            env.Append(LINKFLAGS=['-flto'])
+            if not env['use_llvm'] and env.GetOption("num_jobs") > 1:
+                env.Append(LINKFLAGS=['-flto=' + str(env.GetOption("num_jobs"))])
+            else:
+                env.Append(LINKFLAGS=['-flto'])
 
         ## Compile flags
 

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -120,7 +120,10 @@ def configure(env):
 
     if env['use_lto']:
         env.Append(CCFLAGS=['-flto'])
-        env.Append(LINKFLAGS=['-flto'])
+        if not env['use_llvm'] and env.GetOption("num_jobs") > 1:
+            env.Append(LINKFLAGS=['-flto=' + str(env.GetOption("num_jobs"))])
+        else:
+            env.Append(LINKFLAGS=['-flto'])
         if not env['use_llvm']:
             env['RANLIB'] = 'gcc-ranlib'
             env['AR'] = 'gcc-ar'


### PR DESCRIPTION
When building with `use_lto=yes`, the option `lto_multiprocess=yes` will tell the linker to use all available cores con the system.
For example, on an i7 740QM this reduces build time by ~9 minutes.
This option is only available for gcc. AFAIK clang doesn't support this feature (someone correct me if I'm wrong).
