### PR TITLE
Depth test mode support added to materials.

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1112,6 +1112,36 @@ bool RasterizerSceneGLES3::_setup_material(RasterizerStorageGLES3::Material *p_m
 		state.current_depth_test = !p_material->shader->spatial.no_depth_test;
 	}
 
+	if (state.current_depth_test_mode != (p_material->shader->spatial.depth_test_mode)) {
+		switch (p_material->shader->spatial.depth_test_mode) {
+			case RasterizerStorageGLES3::Shader::Spatial::DEPTH_TEST_NEVER: {
+				glDepthFunc(GL_NEVER);
+			} break;
+			case RasterizerStorageGLES3::Shader::Spatial::DEPTH_TEST_LESS: {
+				glDepthFunc(GL_LESS);
+			} break;
+			case RasterizerStorageGLES3::Shader::Spatial::DEPTH_TEST_EQUAL: {
+				glDepthFunc(GL_EQUAL);
+			} break;
+			case RasterizerStorageGLES3::Shader::Spatial::DEPTH_TEST_LEQUAL: {
+				glDepthFunc(GL_LEQUAL);
+			} break;
+			case RasterizerStorageGLES3::Shader::Spatial::DEPTH_TEST_GREATER: {
+				glDepthFunc(GL_GREATER);
+			} break;
+			case RasterizerStorageGLES3::Shader::Spatial::DEPTH_TEST_NOTEQUAL: {
+				glDepthFunc(GL_NOTEQUAL);
+			} break;
+			case RasterizerStorageGLES3::Shader::Spatial::DEPTH_TEST_GEQUAL: {
+				glDepthFunc(GL_GEQUAL);
+			} break;
+			case RasterizerStorageGLES3::Shader::Spatial::DEPTH_TEST_ALWAYS: {
+				glDepthFunc(GL_ALWAYS);
+			} break;
+		}
+		state.current_depth_test_mode = p_material->shader->spatial.depth_test_mode;
+	}
+
 	if (state.current_depth_draw != p_material->shader->spatial.depth_draw_mode) {
 		switch (p_material->shader->spatial.depth_draw_mode) {
 			case RasterizerStorageGLES3::Shader::Spatial::DEPTH_DRAW_ALPHA_PREPASS:
@@ -1917,6 +1947,9 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 
 	state.current_depth_test = true;
 	glEnable(GL_DEPTH_TEST);
+
+	state.current_depth_test_mode = RasterizerStorageGLES3::Shader::Spatial::DEPTH_TEST_LEQUAL;
+	glDepthFunc(GL_LEQUAL);
 
 	state.scene_shader.set_conditional(SceneShaderGLES3::USE_SKELETON, false);
 

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -93,6 +93,7 @@ public:
 		float current_line_width;
 		int current_depth_draw;
 		bool current_depth_test;
+		int current_depth_test_mode;
 		GLuint current_main_tex;
 
 		SceneShaderGLES3 scene_shader;

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -1589,6 +1589,7 @@ void RasterizerStorageGLES3::_update_shader(Shader *p_shader) const {
 
 			p_shader->spatial.blend_mode = Shader::Spatial::BLEND_MODE_MIX;
 			p_shader->spatial.depth_draw_mode = Shader::Spatial::DEPTH_DRAW_OPAQUE;
+			p_shader->spatial.depth_test_mode = Shader::Spatial::DEPTH_TEST_LEQUAL;
 			p_shader->spatial.cull_mode = Shader::Spatial::CULL_MODE_BACK;
 			p_shader->spatial.uses_alpha = false;
 			p_shader->spatial.uses_alpha_scissor = false;
@@ -1611,6 +1612,15 @@ void RasterizerStorageGLES3::_update_shader(Shader *p_shader) const {
 			shaders.actions_scene.render_mode_values["depth_draw_always"] = Pair<int *, int>(&p_shader->spatial.depth_draw_mode, Shader::Spatial::DEPTH_DRAW_ALWAYS);
 			shaders.actions_scene.render_mode_values["depth_draw_never"] = Pair<int *, int>(&p_shader->spatial.depth_draw_mode, Shader::Spatial::DEPTH_DRAW_NEVER);
 			shaders.actions_scene.render_mode_values["depth_draw_alpha_prepass"] = Pair<int *, int>(&p_shader->spatial.depth_draw_mode, Shader::Spatial::DEPTH_DRAW_ALPHA_PREPASS);
+
+			shaders.actions_scene.render_mode_values["depth_test_never"] = Pair<int *, int>(&p_shader->spatial.depth_test_mode, Shader::Spatial::DEPTH_TEST_NEVER);
+			shaders.actions_scene.render_mode_values["depth_test_less"] = Pair<int *, int>(&p_shader->spatial.depth_test_mode, Shader::Spatial::DEPTH_TEST_LESS);
+			shaders.actions_scene.render_mode_values["depth_test_equal"] = Pair<int *, int>(&p_shader->spatial.depth_test_mode, Shader::Spatial::DEPTH_TEST_EQUAL);
+			shaders.actions_scene.render_mode_values["depth_test_lequal"] = Pair<int *, int>(&p_shader->spatial.depth_test_mode, Shader::Spatial::DEPTH_TEST_LEQUAL);
+			shaders.actions_scene.render_mode_values["depth_test_greater"] = Pair<int *, int>(&p_shader->spatial.depth_test_mode, Shader::Spatial::DEPTH_TEST_GREATER);
+			shaders.actions_scene.render_mode_values["depth_test_notequal"] = Pair<int *, int>(&p_shader->spatial.depth_test_mode, Shader::Spatial::DEPTH_TEST_NOTEQUAL);
+			shaders.actions_scene.render_mode_values["depth_test_gequal"] = Pair<int *, int>(&p_shader->spatial.depth_test_mode, Shader::Spatial::DEPTH_TEST_GEQUAL);
+			shaders.actions_scene.render_mode_values["depth_test_always"] = Pair<int *, int>(&p_shader->spatial.depth_test_mode, Shader::Spatial::DEPTH_TEST_ALWAYS);
 
 			shaders.actions_scene.render_mode_values["cull_front"] = Pair<int *, int>(&p_shader->spatial.cull_mode, Shader::Spatial::CULL_MODE_FRONT);
 			shaders.actions_scene.render_mode_values["cull_back"] = Pair<int *, int>(&p_shader->spatial.cull_mode, Shader::Spatial::CULL_MODE_BACK);

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -434,6 +434,19 @@ public:
 
 			int depth_draw_mode;
 
+			enum DepthTestMode {
+				DEPTH_TEST_NEVER,
+				DEPTH_TEST_LESS,
+				DEPTH_TEST_EQUAL,
+				DEPTH_TEST_LEQUAL,
+				DEPTH_TEST_GREATER,
+				DEPTH_TEST_NOTEQUAL,
+				DEPTH_TEST_GEQUAL,
+				DEPTH_TEST_ALWAYS
+			};
+
+			int depth_test_mode;
+
 			enum CullMode {
 				CULL_MODE_FRONT,
 				CULL_MODE_BACK,

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -364,6 +364,17 @@ void SpatialMaterial::_update_shader() {
 		case DEPTH_DRAW_ALPHA_OPAQUE_PREPASS: code += ",depth_draw_alpha_prepass"; break;
 	}
 
+	switch (depth_test_mode) {
+		case DEPTH_TEST_NEVER: code += ",depth_test_never"; break;
+		case DEPTH_TEST_LESS: code += ",depth_test_less"; break;
+		case DEPTH_TEST_EQUAL: code += ",depth_test_equal"; break;
+		case DEPTH_TEST_LEQUAL: code += ",depth_test_lequal"; break;
+		case DEPTH_TEST_GREATER: code += ",depth_test_greater"; break;
+		case DEPTH_TEST_NOTEQUAL: code += ",depth_test_notequal"; break;
+		case DEPTH_TEST_GEQUAL: code += ",depth_test_gequal"; break;
+		case DEPTH_TEST_ALWAYS: code += ",depth_test_always"; break;
+	}
+
 	switch (cull_mode) {
 		case CULL_BACK: code += ",cull_back"; break;
 		case CULL_FRONT: code += ",cull_front"; break;
@@ -1152,6 +1163,20 @@ SpatialMaterial::DepthDrawMode SpatialMaterial::get_depth_draw_mode() const {
 	return depth_draw_mode;
 }
 
+void SpatialMaterial::set_depth_test_mode(DepthTestMode p_mode) {
+
+	if (depth_test_mode == p_mode)
+		return;
+
+	depth_test_mode = p_mode;
+	_queue_shader_change();
+}
+
+SpatialMaterial::DepthTestMode SpatialMaterial::get_depth_test_mode() const {
+
+	return depth_test_mode;
+}
+
 void SpatialMaterial::set_cull_mode(CullMode p_mode) {
 
 	if (cull_mode == p_mode)
@@ -1697,6 +1722,9 @@ void SpatialMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_depth_draw_mode", "depth_draw_mode"), &SpatialMaterial::set_depth_draw_mode);
 	ClassDB::bind_method(D_METHOD("get_depth_draw_mode"), &SpatialMaterial::get_depth_draw_mode);
 
+	ClassDB::bind_method(D_METHOD("set_depth_test_mode", "depth_test_mode"), &SpatialMaterial::set_depth_test_mode);
+	ClassDB::bind_method(D_METHOD("get_depth_test_mode"), &SpatialMaterial::get_depth_test_mode);
+
 	ClassDB::bind_method(D_METHOD("set_cull_mode", "cull_mode"), &SpatialMaterial::set_cull_mode);
 	ClassDB::bind_method(D_METHOD("get_cull_mode"), &SpatialMaterial::get_cull_mode);
 
@@ -1814,6 +1842,7 @@ void SpatialMaterial::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_blend_mode", PROPERTY_HINT_ENUM, "Mix,Add,Sub,Mul"), "set_blend_mode", "get_blend_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_cull_mode", PROPERTY_HINT_ENUM, "Back,Front,Disabled"), "set_cull_mode", "get_cull_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_depth_draw_mode", PROPERTY_HINT_ENUM, "Opaque Only,Always,Never,Opaque Pre-Pass"), "set_depth_draw_mode", "get_depth_draw_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_depth_test_mode", PROPERTY_HINT_ENUM, "Never,Less,Equal,Lesser-or-Equal,Greater,Not Equal,Greater-or-Equal,Always"), "set_depth_test_mode", "get_depth_test_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "params_line_width", PROPERTY_HINT_RANGE, "0.1,128,0.1"), "set_line_width", "get_line_width");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "params_point_size", PROPERTY_HINT_RANGE, "0.1,128,0.1"), "set_point_size", "get_point_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_billboard_mode", PROPERTY_HINT_ENUM, "Disabled,Enabled,Y-Billboard,Particle Billboard"), "set_billboard_mode", "get_billboard_mode");
@@ -1973,6 +2002,15 @@ void SpatialMaterial::_bind_methods() {
 	BIND_ENUM_CONSTANT(DEPTH_DRAW_DISABLED);
 	BIND_ENUM_CONSTANT(DEPTH_DRAW_ALPHA_OPAQUE_PREPASS);
 
+	BIND_ENUM_CONSTANT(DEPTH_TEST_NEVER);
+	BIND_ENUM_CONSTANT(DEPTH_TEST_LESS);
+	BIND_ENUM_CONSTANT(DEPTH_TEST_EQUAL);
+	BIND_ENUM_CONSTANT(DEPTH_TEST_LEQUAL);
+	BIND_ENUM_CONSTANT(DEPTH_TEST_GREATER);
+	BIND_ENUM_CONSTANT(DEPTH_TEST_NOTEQUAL);
+	BIND_ENUM_CONSTANT(DEPTH_TEST_GEQUAL);
+	BIND_ENUM_CONSTANT(DEPTH_TEST_ALWAYS);
+
 	BIND_ENUM_CONSTANT(CULL_BACK);
 	BIND_ENUM_CONSTANT(CULL_FRONT);
 	BIND_ENUM_CONSTANT(CULL_DISABLED);
@@ -2073,6 +2111,7 @@ SpatialMaterial::SpatialMaterial()
 	blend_mode = BLEND_MODE_MIX;
 	detail_blend_mode = BLEND_MODE_MIX;
 	depth_draw_mode = DEPTH_DRAW_OPAQUE_ONLY;
+	depth_test_mode = DEPTH_TEST_LEQUAL;
 	cull_mode = CULL_BACK;
 	for (int i = 0; i < FLAG_MAX; i++) {
 		flags[i] = 0;

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -162,6 +162,17 @@ public:
 
 	};
 
+	enum DepthTestMode {
+		DEPTH_TEST_NEVER,
+		DEPTH_TEST_LESS,
+		DEPTH_TEST_EQUAL,
+		DEPTH_TEST_LEQUAL,
+		DEPTH_TEST_GREATER,
+		DEPTH_TEST_NOTEQUAL,
+		DEPTH_TEST_GEQUAL,
+		DEPTH_TEST_ALWAYS
+	};
+
 	enum CullMode {
 		CULL_BACK,
 		CULL_FRONT,
@@ -223,6 +234,7 @@ private:
 			uint64_t detail_uv : 1;
 			uint64_t blend_mode : 2;
 			uint64_t depth_draw_mode : 2;
+			uint64_t depth_test_mode : 3;
 			uint64_t cull_mode : 2;
 			uint64_t flags : 12;
 			uint64_t detail_blend_mode : 2;
@@ -264,6 +276,7 @@ private:
 		mk.detail_uv = detail_uv;
 		mk.blend_mode = blend_mode;
 		mk.depth_draw_mode = depth_draw_mode;
+		mk.depth_test_mode = depth_test_mode;
 		mk.cull_mode = cull_mode;
 		for (int i = 0; i < FLAG_MAX; i++) {
 			if (flags[i]) {
@@ -389,6 +402,7 @@ private:
 	BlendMode blend_mode;
 	BlendMode detail_blend_mode;
 	DepthDrawMode depth_draw_mode;
+	DepthTestMode depth_test_mode;
 	CullMode cull_mode;
 	bool flags[FLAG_MAX];
 	SpecularMode specular_mode;
@@ -496,6 +510,9 @@ public:
 	void set_depth_draw_mode(DepthDrawMode p_mode);
 	DepthDrawMode get_depth_draw_mode() const;
 
+	void set_depth_test_mode(DepthTestMode p_mode);
+	DepthTestMode get_depth_test_mode() const;
+
 	void set_cull_mode(CullMode p_mode);
 	CullMode get_cull_mode() const;
 
@@ -595,6 +612,7 @@ VARIANT_ENUM_CAST(SpatialMaterial::DetailUV)
 VARIANT_ENUM_CAST(SpatialMaterial::Feature)
 VARIANT_ENUM_CAST(SpatialMaterial::BlendMode)
 VARIANT_ENUM_CAST(SpatialMaterial::DepthDrawMode)
+VARIANT_ENUM_CAST(SpatialMaterial::DepthTestMode)
 VARIANT_ENUM_CAST(SpatialMaterial::CullMode)
 VARIANT_ENUM_CAST(SpatialMaterial::Flags)
 VARIANT_ENUM_CAST(SpatialMaterial::DiffuseMode)

--- a/servers/visual/shader_types.cpp
+++ b/servers/visual/shader_types.cpp
@@ -134,6 +134,15 @@ ShaderTypes::ShaderTypes() {
 
 	shader_modes[VS::SHADER_SPATIAL].modes.insert("depth_test_disable");
 
+	shader_modes[VS::SHADER_SPATIAL].modes.insert("depth_test_never");
+	shader_modes[VS::SHADER_SPATIAL].modes.insert("depth_test_less");
+	shader_modes[VS::SHADER_SPATIAL].modes.insert("depth_test_equal");
+	shader_modes[VS::SHADER_SPATIAL].modes.insert("depth_test_lequal");
+	shader_modes[VS::SHADER_SPATIAL].modes.insert("depth_test_greater");
+	shader_modes[VS::SHADER_SPATIAL].modes.insert("depth_test_notequal");
+	shader_modes[VS::SHADER_SPATIAL].modes.insert("depth_test_gequal");
+	shader_modes[VS::SHADER_SPATIAL].modes.insert("depth_test_always");
+
 	shader_modes[VS::SHADER_SPATIAL].modes.insert("cull_front");
 	shader_modes[VS::SHADER_SPATIAL].modes.insert("cull_back");
 	shader_modes[VS::SHADER_SPATIAL].modes.insert("cull_disabled");


### PR DESCRIPTION
This adds the ability to override depth function operand on materials. The default depth function is lesser or equal, but by overriding this, you can create some potentially interesting special effects. For example, you could have a two pass material with the second pass being a flat shaded colour using the greater-than depth function so that it can appear as a silhouette when obscured by geometry.

![depth](https://user-images.githubusercontent.com/12756047/30890630-ed10ee7a-a325-11e7-993f-d88a8a97a2d3.png)

There is already a flag in materials to outright disable depth testing, and this PR might make that redundant, but I've decided to leave it for now.

There's  also an important limitation of this PR which I feel needs to be addressed in a separate issue. Right now, the renderer only batches two render lists, one for opaque and one for translucent objects, with the translucent list being rendered last. Since materials using the greater-than operand needs to always be rendered AFTER what it is being rendered behind, the only current way to handle this is make sure that the material using the greater-than operand is marked as translucent, so that it will render after all the opaque objects have already been rendered. This is not ideal since you don't have much fine-grained control, and translucent objects obviously are marked to not further contribute to the depth buffer. A way to solve this issue would be to provide more fine-grained access to the order in which objects are rendered, maybe some kind of ID to ensure a particular group of materials are always rendered after another group. This actually should be very easy to implement, but does probably require some discussion on the best way to go about it.