### PR TITLE
Fixed error when extending another class in GDscript

### DIFF
--- a/modules/gdscript/gd_function.cpp
+++ b/modules/gdscript/gd_function.cpp
@@ -909,7 +909,7 @@ Variant GDFunction::call(GDInstance *p_instance, const Variant **p_args, int p_a
 					gds = gds->base.ptr();
 					E = gds->member_functions.find(*methodname);
 					if (E)
-						OPCODE_BREAK;
+						break;
 				}
 
 				Variant::CallError err;


### PR DESCRIPTION
commit 520d84e042bcc5d211950022abb40ff7cc90b15b introduced a bug where `extend`ing from another class/script failed with `Internal Script Error - opcode #18.`

this removes the mistakenly placed `OPCODE_BREAK` and fixes #11595