### PR TITLE
Fix crash when unsharing a range that is not shared

### DIFF
--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -208,10 +208,12 @@ void Range::_ref_shared(Shared *p_shared) {
 
 void Range::_unref_shared() {
 
-	shared->owners.erase(this);
-	if (shared->owners.size() == 0) {
-		memdelete(shared);
-		shared = NULL;
+	if (shared) {
+		shared->owners.erase(this);
+		if (shared->owners.size() == 0) {
+			memdelete(shared);
+			shared = NULL;
+		}
 	}
 }
 


### PR DESCRIPTION
Added a guard to Range::_unref_shared to prevent it from doing anything
in the event that shared is null.

Fixes Issue: #11521