### PR TITLE
add spacing to tabs.

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -393,7 +393,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_default->set_draw_center(true);
 
 	// Button and widgets
-	const float extra_spacing = EDITOR_DEF("interface/theme/additional_spacing", 0.0);
+	const float extra_spacing = EDITOR_GET("interface/theme/additional_spacing");
 
 	Ref<StyleBoxFlat> style_widget = style_default->duplicate();
 	style_widget->set_default_margin(MARGIN_LEFT, (extra_spacing + 6) * EDSCALE);
@@ -437,14 +437,20 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	Ref<StyleBoxEmpty> style_empty = make_empty_stylebox(default_margin_size, default_margin_size, default_margin_size, default_margin_size);
 
 	// Tabs
+
+	const int tab_default_margin_side = 10 * EDSCALE + extra_spacing * EDSCALE;
+	const int tab_default_margin_vertical = 5 * EDSCALE + extra_spacing * EDSCALE;
+
 	Ref<StyleBoxFlat> style_tab_selected = style_widget->duplicate();
 
 	style_tab_selected->set_border_width_all(border_width);
 	style_tab_selected->set_border_width(MARGIN_BOTTOM, 0);
 	style_tab_selected->set_border_color_all(dark_color_3);
 	style_tab_selected->set_expand_margin_size(MARGIN_BOTTOM, border_width);
-	style_tab_selected->set_default_margin(MARGIN_LEFT, 10 * EDSCALE);
-	style_tab_selected->set_default_margin(MARGIN_RIGHT, 10 * EDSCALE);
+	style_tab_selected->set_default_margin(MARGIN_LEFT, tab_default_margin_side);
+	style_tab_selected->set_default_margin(MARGIN_RIGHT, tab_default_margin_side);
+	style_tab_selected->set_default_margin(MARGIN_BOTTOM, tab_default_margin_vertical);
+	style_tab_selected->set_default_margin(MARGIN_TOP, tab_default_margin_vertical);
 	style_tab_selected->set_bg_color(tab_color);
 
 	Ref<StyleBoxFlat> style_tab_unselected = style_tab_selected->duplicate();


### PR DESCRIPTION
Sadly I Couldn't get my additional spacing default through. But I'm happy with having bigger tabs since this was the biggest concern I had anyways.

So this pr is now updating the tab size only.
(and fixes use of `EDITOR_DEF` (in one case) and updated to `EDITOR_GET`)

this is how it looks:

<img width="1680" alt="screen shot 2017-09-28 at 23 45 58" src="https://user-images.githubusercontent.com/16718859/30991857-32af57d2-a4a7-11e7-8c8d-c7532f445125.png">

how it looked before can still be seen in the deprecated section...


## DEPRECATED!
old default:
<img width="1680" alt="screen shot 2017-09-28 at 17 02 07" src="https://user-images.githubusercontent.com/16718859/30974003-d6ff5c3a-a46e-11e7-83ba-c815fb74c0f7.png">

new default:
<img width="1680" alt="screen shot 2017-09-28 at 17 02 27" src="https://user-images.githubusercontent.com/16718859/30974004-d71d3138-a46e-11e7-96b1-8c40e8f32d6c.png">


<img width="384" alt="screen shot 2017-09-28 at 17 04 15" src="https://user-images.githubusercontent.com/16718859/30974116-1ed74eb4-a46f-11e7-904d-c5df099598d5.png">
<img width="378" alt="screen shot 2017-09-28 at 17 04 27" src="https://user-images.githubusercontent.com/16718859/30974117-1f01998a-a46f-11e7-981c-a3aaa49f34c3.png">