### PR TITLE
Editor: Run validation on every text change, not only inserts

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1025,8 +1025,9 @@ void CodeTextEditor::_text_changed() {
 
 	if (text_editor->is_insert_text_operation()) {
 		code_complete_timer->start();
-		idle->start();
 	}
+
+	idle->start();
 }
 
 void CodeTextEditor::_code_complete_timer_timeout() {


### PR DESCRIPTION
Fixes #11616 by running validation on every code change in the editor, not only on inserts.

Tested locally, seems to work fine - not sure if there was any reason to only do this on inserts though :)