### PR TITLE
Make the physics engine deterministic

### DIFF
--- a/servers/physics/body_sw.cpp
+++ b/servers/physics/body_sw.cpp
@@ -654,15 +654,16 @@ void BodySW::simulate_motion(const Transform& p_xform,real_t p_step) {
 
 void BodySW::wakeup_neighbours() {
 
-	for (Map<ConstraintSW *, int>::Element *E = constraint_map.front(); E; E = E->next()) {
+	for (Map<uint64_t, ConstraintMapVal>::Element *E = constraint_map.front(); E; E = E->next()) {
 
-		const ConstraintSW *c = E->key();
+		const ConstraintMapVal cmv = E->get();
+		const ConstraintSW *c = cmv.constraint;
 		BodySW **n = c->get_body_ptr();
 		int bc = c->get_body_count();
 
 		for (int i = 0; i < bc; i++) {
 
-			if (i == E->get())
+			if (i == cmv.index)
 				continue;
 			BodySW *b = n[i];
 			if (b->mode != PhysicsServer::BODY_MODE_RIGID)

--- a/servers/physics/body_sw.h
+++ b/servers/physics/body_sw.h
@@ -32,6 +32,7 @@
 
 #include "area_sw.h"
 #include "collision_object_sw.h"
+#include "constraint_sw.h"
 #include "vset.h"
 
 class ConstraintSW;
@@ -94,7 +95,15 @@ class BodySW : public CollisionObjectSW {
 	virtual void _shapes_changed();
 	Transform new_transform;
 
-	Map<ConstraintSW *, int> constraint_map;
+public:
+	struct ConstraintMapVal {
+
+		int index;
+		ConstraintSW *constraint;
+	};
+
+private:
+	Map<uint64_t, ConstraintMapVal> constraint_map;
 
 	struct AreaCMP {
 
@@ -191,9 +200,14 @@ public:
 	_FORCE_INLINE_ BodySW *get_island_list_next() const { return island_list_next; }
 	_FORCE_INLINE_ void set_island_list_next(BodySW *p_next) { island_list_next = p_next; }
 
-	_FORCE_INLINE_ void add_constraint(ConstraintSW *p_constraint, int p_pos) { constraint_map[p_constraint] = p_pos; }
-	_FORCE_INLINE_ void remove_constraint(ConstraintSW *p_constraint) { constraint_map.erase(p_constraint); }
-	const Map<ConstraintSW *, int> &get_constraint_map() const { return constraint_map; }
+	_FORCE_INLINE_ void add_constraint(ConstraintSW *p_constraint, int p_index) {
+		ConstraintMapVal cmv = { p_index, p_constraint };
+		constraint_map[p_constraint->get_constraint_id()] = cmv;
+	}
+	_FORCE_INLINE_ void remove_constraint(ConstraintSW *p_constraint) {
+		constraint_map.erase(p_constraint->get_constraint_id());
+	}
+	const Map<uint64_t, ConstraintMapVal> &get_constraint_map() const { return constraint_map; }
 	_FORCE_INLINE_ void clear_constraint_map() { constraint_map.clear(); }
 
 	_FORCE_INLINE_ void set_omit_force_integration(bool p_omit_force_integration) { omit_force_integration = p_omit_force_integration; }

--- a/servers/physics/constraint_sw.h
+++ b/servers/physics/constraint_sw.h
@@ -30,7 +30,10 @@
 #ifndef CONSTRAINT_SW_H
 #define CONSTRAINT_SW_H
 
-#include "body_sw.h"
+#include "math/math_defs.h"
+#include "rid.h"
+
+class BodySW;
 
 class ConstraintSW : public RID_Data {
 
@@ -42,18 +45,28 @@ class ConstraintSW : public RID_Data {
 	int priority;
 
 	RID self;
+	uint64_t _constraint_id;
 
 protected:
 	ConstraintSW(BodySW **p_body_ptr = NULL, int p_body_count = 0) {
+
+		// Assume ConstranitSW objects can only be instantiated from
+		// one thread, used as index in the constraint map
+		// of each body in order for the order to be deterministic.
+		static uint64_t _constranit_id_next = 0;
+
 		_body_ptr = p_body_ptr;
 		_body_count = p_body_count;
 		island_step = 0;
 		priority = 1;
+		_constraint_id = _constranit_id_next++;
 	}
 
 public:
 	_FORCE_INLINE_ void set_self(const RID &p_self) { self = p_self; }
 	_FORCE_INLINE_ RID get_self() const { return self; }
+
+	_FORCE_INLINE_ uint64_t get_constraint_id() { return _constraint_id; }
 
 	_FORCE_INLINE_ uint64_t get_island_step() const { return island_step; }
 	_FORCE_INLINE_ void set_island_step(uint64_t p_step) { island_step = p_step; }

--- a/servers/physics/physics_server_sw.cpp
+++ b/servers/physics/physics_server_sw.cpp
@@ -494,8 +494,8 @@ void PhysicsServerSW::body_set_space(RID p_body, RID p_space) {
 	if (body->get_space() == space)
 		return; //pointless
 
-	for (Map<ConstraintSW *, int>::Element *E = body->get_constraint_map().front(); E; E = E->next()) {
-		RID self = E->key()->get_self();
+	for (Map<uint64_t, BodySW::ConstraintMapVal>::Element *E = body->get_constraint_map().front(); E; E = E->next()) {
+		RID self = E->get().constraint->get_self();
 		if (!self.is_valid())
 			continue;
 		free(self);

--- a/servers/physics/step_sw.cpp
+++ b/servers/physics/step_sw.cpp
@@ -38,9 +38,10 @@ void StepSW::_populate_island(BodySW *p_body, BodySW **p_island, ConstraintSW **
 	p_body->set_island_next(*p_island);
 	*p_island = p_body;
 
-	for (Map<ConstraintSW *, int>::Element *E = p_body->get_constraint_map().front(); E; E = E->next()) {
+	for (Map<uint64_t, BodySW::ConstraintMapVal>::Element *E = p_body->get_constraint_map().front(); E; E = E->next()) {
 
-		ConstraintSW *c = (ConstraintSW *)E->key();
+		BodySW::ConstraintMapVal cmv = E->get();
+		ConstraintSW *c = cmv.constraint;
 		if (c->get_island_step() == _step)
 			continue; //already processed
 		c->set_island_step(_step);
@@ -48,7 +49,7 @@ void StepSW::_populate_island(BodySW *p_body, BodySW **p_island, ConstraintSW **
 		*p_constraint_island = c;
 
 		for (int i = 0; i < c->get_body_count(); i++) {
-			if (i == E->get())
+			if (i == cmv.index)
 				continue;
 			BodySW *b = c->get_body_ptr()[i];
 			if (b->get_island_step() == _step || b->get_mode() == PhysicsServer::BODY_MODE_STATIC || b->get_mode() == PhysicsServer::BODY_MODE_KINEMATIC)


### PR DESCRIPTION
Makes the the physics engine, *if taken in isolation* deterministic. This is useful for debugging