### PR TITLE
Vertical alignement (TabContainer menu button)

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -264,9 +264,9 @@ void TabContainer::_notification(int p_what) {
 			if (popup) {
 				x -= menu->get_width();
 				if (mouse_x_cache > x)
-					menu_hl->draw(get_canvas_item(), Size2(x, 0));
+					menu_hl->draw(get_canvas_item(), Size2(x, (header_height - menu_hl->get_height()) / 2));
 				else
-					menu->draw(get_canvas_item(), Size2(x, 0));
+					menu->draw(get_canvas_item(), Size2(x, (header_height - menu->get_height()) / 2));
 			}
 
 			// Draw the navigation buttons.


### PR DESCRIPTION
<img width="331" alt="screen shot 2017-09-29 at 13 21 05" src="https://user-images.githubusercontent.com/16718859/31014076-7a95d5b8-a519-11e7-93e0-27b369fc0d83.png">

The dots are in the centre (vertically) of the tabs section.

fixes issue brought up by @puppetmaster- in #11660 