### PR TITLE
fixed coustom bg weired offset for code editor

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -501,8 +501,7 @@ void TextEdit::_notification(int p_what) {
 
 				if (cache.background_color.a > 0.01) {
 
-					Point2i ofs = Point2i(cache.style_normal->get_offset()) / 2.0;
-					VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(ofs, get_size() - cache.style_normal->get_minimum_size() + ofs), cache.background_color);
+					VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(Point2i(), get_size()), cache.background_color);
 				}
 				//compute actual region to start (may be inside say, a comment).
 				//slow in very large documments :( but ok for source!


### PR DESCRIPTION
before:
<img width="112" alt="screen shot 2017-09-29 at 16 35 28" src="https://user-images.githubusercontent.com/16718859/31022032-e99cda7e-a537-11e7-8165-3e40a4bd70ce.png">


after:
<img width="929" alt="screen shot 2017-09-29 at 16 57 55" src="https://user-images.githubusercontent.com/16718859/31022033-e9c632ac-a537-11e7-8358-5a8eb180fd1c.png">
