### PR TITLE
near and far are reserved for near and far pointers in MSVC

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2369,11 +2369,11 @@ void RasterizerSceneGLES3::_draw_sky(RasterizerStorageGLES3::Sky *p_sky, const C
 
 	if (p_custom_fov) {
 
-		float near = p_projection.get_z_near();
-		float far = p_projection.get_z_far();
+		float near_plane = p_projection.get_z_near();
+		float far_plane = p_projection.get_z_far();
 		float aspect = p_projection.get_aspect();
 
-		camera.set_perspective(p_custom_fov, aspect, near, far);
+		camera.set_perspective(p_custom_fov, aspect, near_plane, far_plane);
 
 	} else {
 		camera = p_projection;


### PR DESCRIPTION
near and far are reserved words on MSVR so reduz's change broke the windows build :)