### PR TITLE
keep alpha when converting svg colors fixes #11289

### DIFF
--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -51,7 +51,7 @@ inline void change_nsvg_paint_color(NSVGpaint *p_paint, const uint32_t p_old, co
 
 	if (p_paint->type == NSVG_PAINT_COLOR) {
 		if (p_paint->color << 8 == p_old << 8) {
-			p_paint->color = p_new;
+			p_paint->color = (p_paint->color & 0xFF000000) | (p_new & 0x00FFFFFF);
 		}
 	}
 


### PR DESCRIPTION
@djrm Is there any icon I can immediately see if it works or not?
(the logic is correct I was able to test that, but I can guarantee that the color is used correctly by nanosvg)

from 
<img src="https://user-images.githubusercontent.com/16718859/31058751-132f2a3c-a6f9-11e7-9fae-3a9badcba7f0.png" width=400/>
to
<img src="https://user-images.githubusercontent.com/16718859/31058133-e065e528-a6ee-11e7-8978-de9faf72e8c2.png" width=400/>
