### PR TITLE
VisualScript crashfix when returns are too few

### DIFF
--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -763,7 +763,7 @@ public:
 	NodePath node_path;
 	int input_args;
 	bool validate;
-	bool returns;
+	int returns;
 	VisualScriptFunctionCall::RPCCallMode rpc_mode;
 	StringName function;
 	StringName singleton;
@@ -856,7 +856,13 @@ public:
 					}
 				} else if (returns) {
 					if (call_mode == VisualScriptFunctionCall::CALL_MODE_INSTANCE) {
-						*p_outputs[1] = v.call(function, p_inputs + 1, input_args, r_error);
+						if (returns >= 2) {
+							*p_outputs[1] = v.call(function, p_inputs + 1, input_args, r_error);
+						} else {
+							r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD;
+							r_error_str = "Invalid returns count for call_mode == CALL_MODE_INSTANCE";
+							return 0;
+						}
 					} else {
 						*p_outputs[0] = v.call(function, p_inputs + 1, input_args, r_error);
 					}


### PR DESCRIPTION
Fixes #11637

@reduz I think this is the right way to fix this but if you can please check the changes. Also maybe we should add a CALL_ERROR_TOO_FEW_RETURNS error code?