### PR TITLE
Change to Image::shrink_x2 function preventing it set a 0 width/height for mipmapped textures

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1013,8 +1013,8 @@ void Image::shrink_x2() {
 			copymem(w.ptr(), &r[ofs], new_size);
 		}
 
-		width /= 2;
-		height /= 2;
+		width = MAX(width / 2, 1);
+		height = MAX(height / 2, 1);
 		data = new_img;
 
 	} else {


### PR DESCRIPTION
- Fixes importing of small resolution PNG.
For example we have a PNG file with 30 width x 59 height, ResourceImporterTexture::_save_stex shrinks it 7 times because of int this line "mmc = image->get_mipmap_count() + 1;", so libpng fails because near the last iteration it adds a 0 width mipmap.
https://cdn.discordapp.com/attachments/359440300059394051/363148353527349248/unknown.png