### PR TITLE
Allow fine tuning of collision constraints

### DIFF
--- a/doc/classes/CollisionObject.xml
+++ b/doc/classes/CollisionObject.xml
@@ -125,6 +125,24 @@
 				Removes all shapes from the shape owner.
 			</description>
 		</method>
+		<method name="shape_owner_get_custom_bias" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="owner_id" type="int">
+			<description>
+				Get the custom bias for a shape of the given shape owner.
+			</description>
+		</method>
+		<method name="shape_owner_get_custom_priority" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="owner_id" type="int">
+			</argument>
+			<description>
+				Get the custom priority for a shape of the given shape owner.
+			</description>
+		</method>
+
 		<method name="shape_owner_get_owner" qualifiers="const">
 			<return type="Object">
 			</return>
@@ -182,6 +200,28 @@
 			</argument>
 			<description>
 				Removes a shape from the given shape owner.
+			</description>
+		</method>
+		<method name="shape_owner_set_custom_bias">
+			<return type="void">
+			</return>
+			<argument index="0" name="owner_id" type="int">
+			</argument>
+			<argument index="1" name="custom_bias" type="float">
+			</argument>
+			<description>
+				Set the custom bias for a shape of the given shape owner.
+			</description>
+		</method>
+		<method name="shape_owner_set_custom_priority">
+			<return type="void">
+			</return>
+			<argument index="0" name="owner_id" type="int">
+			</argument>
+			<argument index="1" name="custom_priority" type="int">
+			</argument>
+			<description>
+				Set the custom priority for a shape of the given shape owner.
 			</description>
 		</method>
 		<method name="shape_owner_set_disabled">

--- a/doc/classes/CollisionShape.xml
+++ b/doc/classes/CollisionShape.xml
@@ -11,6 +11,19 @@
 	<demos>
 	</demos>
 	<methods>
+		<method name="get_custom_bias" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method name="get_custom_priority" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+			</description>
+		</method>
+		<method>
 		<method name="get_shape" qualifiers="const">
 			<return type="Shape">
 			</return>
@@ -39,6 +52,22 @@
 				If this method exists within a script it will be called whenever the shape resource has been modified.
 			</description>
 		</method>
+		<method name="set_custom_bias">
+			<return type="void">
+			</return>
+			<argument index="0" name="bias" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_custom_priority">
+			<return type="void">
+			</return>
+			<argument index="0" name="priority" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="set_disabled">
 			<return type="void">
 			</return>
@@ -57,6 +86,12 @@
 		</method>
 	</methods>
 	<members>
+		<member name="custom_bias" type="float" setter="set_custom_bias" getter="get_custom_bias">
+			If greater than 0 overrides the bias value used in collision resolution.
+		</member>
+		<member name="custom_priority" type="int" setter="set_custom_priority" getter="get_custom_priority">
+			If greater than 0 overrides the solver priority used in collision resolution.
+		</member>
 		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled">
 			A disabled collision shape has no effect in the world.
 		</member>

--- a/doc/classes/RigidBody.xml
+++ b/doc/classes/RigidBody.xml
@@ -63,6 +63,13 @@
 				Return the current body bounciness.
 			</description>
 		</method>
+		<method name="get_center_of_mass" qualifiers="const">
+			<return type="Vector3">
+			</return>
+			<description>
+				Return the body center of mass offset with respect to the body origin in global coordinates.
+			</description>
+		</method>
 		<method name="get_colliding_bodies" qualifiers="const">
 			<return type="Array">
 			</return>
@@ -82,6 +89,21 @@
 			</return>
 			<description>
 				Return the current body gravity scale.
+			</description>
+		</method>
+		<method name="get_inertia" qualifiers="const">
+			<return type="Vector3">
+			</return>
+			<description>
+				Return the vector of inertia for the principal axes of inertia. It is the diagonal of the
+				inertia tensor in the principal axes of inertia frame of reference.
+			</description>
+		</method>
+		<method name="get_inv_inertia_tensor" qualifiers="const">
+			<return type="Basis">
+			</return>
+			<description>
+				Return the inverse inertia tensor in global coordinates.
 			</description>
 		</method>
 		<method name="get_linear_damp" qualifiers="const">
@@ -119,11 +141,20 @@
 				Return the current body mode, see [method set_mode].
 			</description>
 		</method>
+		<method name="get_principal_inertia_axes" qualifiers="const">
+			<return type="Basis">
+			</return>
+			<description>
+				Return the principal axes of inertia in global coordinates as columns of a Basis.
+				The returned basis can be used as transform from coordinates in the principal axes frame
+				of reference to the global frame of reference.
+			</description>
+		</method>
 		<method name="get_weight" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
-				Return the current body weight, given standard earth-weight (gravity 9.8).
+				Return the current body weight.
 			</description>
 		</method>
 		<method name="is_able_to_sleep" qualifiers="const">

--- a/scene/3d/collision_object.cpp
+++ b/scene/3d/collision_object.cpp
@@ -137,6 +137,10 @@ void CollisionObject::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("shape_owner_get_owner", "owner_id"), &CollisionObject::shape_owner_get_owner);
 	ClassDB::bind_method(D_METHOD("shape_owner_set_disabled", "owner_id", "disabled"), &CollisionObject::shape_owner_set_disabled);
 	ClassDB::bind_method(D_METHOD("is_shape_owner_disabled", "owner_id"), &CollisionObject::is_shape_owner_disabled);
+	ClassDB::bind_method(D_METHOD("shape_owner_set_custom_bias", "owner_id", "custom_bias"), &CollisionObject::shape_owner_set_custom_bias);
+	ClassDB::bind_method(D_METHOD("shape_owner_get_custom_bias", "owner_id"), &CollisionObject::shape_owner_get_custom_bias);
+	ClassDB::bind_method(D_METHOD("shape_owner_set_custom_priority", "owner_id", "custom_priority"), &CollisionObject::shape_owner_set_custom_priority);
+	ClassDB::bind_method(D_METHOD("shape_owner_get_custom_priority", "owner_id"), &CollisionObject::shape_owner_get_custom_priority);
 	ClassDB::bind_method(D_METHOD("shape_owner_add_shape", "owner_id", "shape"), &CollisionObject::shape_owner_add_shape);
 	ClassDB::bind_method(D_METHOD("shape_owner_get_shape_count", "owner_id"), &CollisionObject::shape_owner_get_shape_count);
 	ClassDB::bind_method(D_METHOD("shape_owner_get_shape", "owner_id", "shape_id"), &CollisionObject::shape_owner_get_shape);
@@ -201,6 +205,48 @@ bool CollisionObject::is_shape_owner_disabled(uint32_t p_owner) const {
 	ERR_FAIL_COND_V(!shapes.has(p_owner), false);
 
 	return shapes[p_owner].disabled;
+}
+
+void CollisionObject::shape_owner_set_custom_bias(uint32_t p_owner, real_t p_bias) {
+	ERR_FAIL_COND(!shapes.has(p_owner));
+	if (area) {
+		return;
+	}
+
+	ShapeData &sd = shapes[p_owner];
+	sd.custom_bias = p_bias;
+
+	for (int i = 0; i < sd.shapes.size(); i++) {
+		PhysicsServer::get_singleton()->body_set_shape_custom_solver_bias(rid, sd.shapes[i].index, p_bias);
+	}
+}
+
+real_t CollisionObject::shape_owner_get_custom_bias(uint32_t p_owner) const {
+
+	ERR_FAIL_COND_V(!shapes.has(p_owner), false);
+
+	return shapes[p_owner].custom_bias;
+}
+
+void CollisionObject::shape_owner_set_custom_priority(uint32_t p_owner, int p_priority) {
+	ERR_FAIL_COND(!shapes.has(p_owner));
+	if (area) {
+		return;
+	}
+
+	ShapeData &sd = shapes[p_owner];
+	sd.custom_priority = p_priority;
+
+	for (int i = 0; i < sd.shapes.size(); i++) {
+		PhysicsServer::get_singleton()->body_set_shape_custom_solver_priority(rid, sd.shapes[i].index, p_priority);
+	}
+}
+
+int CollisionObject::shape_owner_get_custom_priority(uint32_t p_owner) const {
+
+	ERR_FAIL_COND_V(!shapes.has(p_owner), false);
+
+	return shapes[p_owner].custom_priority;
 }
 
 void CollisionObject::get_shape_owners(List<uint32_t> *r_owners) {

--- a/scene/3d/collision_object.h
+++ b/scene/3d/collision_object.h
@@ -51,6 +51,8 @@ class CollisionObject : public Spatial {
 
 		Vector<ShapeBase> shapes;
 		bool disabled;
+		real_t custom_bias;
+		int custom_priority;
 
 		ShapeData() {
 			disabled = false;
@@ -89,6 +91,12 @@ public:
 
 	void shape_owner_set_disabled(uint32_t p_owner, bool p_disabled);
 	bool is_shape_owner_disabled(uint32_t p_owner) const;
+
+	void shape_owner_set_custom_bias(uint32_t p_owner, real_t p_bias);
+	real_t shape_owner_get_custom_bias(uint32_t p_owner) const;
+
+	void shape_owner_set_custom_priority(uint32_t p_owner, int p_priority);
+	int shape_owner_get_custom_priority(uint32_t p_owner) const;
 
 	void shape_owner_add_shape(uint32_t p_owner, const Ref<Shape> &p_shape);
 	int shape_owner_get_shape_count(uint32_t p_owner) const;

--- a/scene/3d/collision_shape.cpp
+++ b/scene/3d/collision_shape.cpp
@@ -76,6 +76,8 @@ void CollisionShape::_notification(int p_what) {
 				}
 				parent->shape_owner_set_transform(owner_id, get_transform());
 				parent->shape_owner_set_disabled(owner_id, disabled);
+				parent->shape_owner_set_custom_bias(owner_id, custom_bias);
+				parent->shape_owner_set_custom_priority(owner_id, custom_priority);
 			}
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
@@ -125,11 +127,17 @@ void CollisionShape::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_shape"), &CollisionShape::get_shape);
 	ClassDB::bind_method(D_METHOD("set_disabled", "enable"), &CollisionShape::set_disabled);
 	ClassDB::bind_method(D_METHOD("is_disabled"), &CollisionShape::is_disabled);
+	ClassDB::bind_method(D_METHOD("set_custom_bias", "custom_bias"), &CollisionShape::set_custom_bias);
+	ClassDB::bind_method(D_METHOD("get_custom_bias"), &CollisionShape::get_custom_bias);
+	ClassDB::bind_method(D_METHOD("set_custom_priority", "custom_priority"), &CollisionShape::set_custom_priority);
+	ClassDB::bind_method(D_METHOD("get_custom_priority"), &CollisionShape::get_custom_priority);
 	ClassDB::bind_method(D_METHOD("make_convex_from_brothers"), &CollisionShape::make_convex_from_brothers);
 	ClassDB::set_method_flags("CollisionShape", "make_convex_from_brothers", METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape"), "set_shape", "get_shape");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disabled"), "set_disabled", "is_disabled");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "custom_bias", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_custom_bias", "get_custom_bias");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "custom_priority", PROPERTY_HINT_RANGE, "0,8,1"), "set_custom_priority", "get_custom_priority");
 }
 
 void CollisionShape::set_shape(const Ref<Shape> &p_shape) {
@@ -169,10 +177,38 @@ bool CollisionShape::is_disabled() const {
 	return disabled;
 }
 
+void CollisionShape::set_custom_bias(real_t p_bias) {
+
+	custom_bias = MIN(MAX(p_bias, 0.0), 1.0);
+	if (parent) {
+		parent->shape_owner_set_custom_bias(owner_id, custom_bias);
+	}
+}
+
+real_t CollisionShape::get_custom_bias() const {
+
+	return custom_bias;
+}
+
+void CollisionShape::set_custom_priority(int p_priority) {
+
+	custom_priority = MIN(MAX(p_priority, 0), 8);
+	if (parent) {
+		parent->shape_owner_set_custom_priority(owner_id, custom_priority);
+	}
+}
+
+int CollisionShape::get_custom_priority() const {
+
+	return custom_priority;
+}
+
 CollisionShape::CollisionShape() {
 
 	//indicator = VisualServer::get_singleton()->mesh_create();
 	disabled = false;
+	custom_bias = 0;
+	custom_priority = 0;
 	debug_shape = NULL;
 	parent = NULL;
 	owner_id = 0;

--- a/scene/3d/collision_shape.h
+++ b/scene/3d/collision_shape.h
@@ -48,6 +48,9 @@ class CollisionShape : public Spatial {
 	void resource_changed(RES res);
 	bool disabled;
 
+	real_t custom_bias;
+	int custom_priority;
+
 	void _create_debug_shape();
 
 protected:
@@ -62,6 +65,12 @@ public:
 
 	void set_disabled(bool p_disabled);
 	bool is_disabled() const;
+
+	void set_custom_bias(real_t p_bias);
+	real_t get_custom_bias() const;
+
+	void set_custom_priority(int p_bias);
+	int get_custom_priority() const;
 
 	String get_configuration_warning() const;
 

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -530,6 +530,7 @@ void RigidBody::set_mass(real_t p_mass) {
 	_change_notify("weight");
 	PhysicsServer::get_singleton()->body_set_param(get_rid(), PhysicsServer::BODY_PARAM_MASS, mass);
 }
+
 real_t RigidBody::get_mass() const {
 
 	return mass;
@@ -542,6 +543,26 @@ void RigidBody::set_weight(real_t p_weight) {
 real_t RigidBody::get_weight() const {
 
 	return mass * real_t(GLOBAL_DEF("physics/3d/default_gravity", 9.8));
+}
+
+Vector3 RigidBody::get_center_of_mass() const {
+
+	return PhysicsServer::get_singleton()->body_get_center_of_mass(get_rid());
+}
+
+Basis RigidBody::get_principal_inertia_axes() const {
+
+	return PhysicsServer::get_singleton()->body_get_principal_inertia_axes(get_rid());
+}
+
+Vector3 RigidBody::get_inertia() const {
+
+	return PhysicsServer::get_singleton()->body_get_inv_inertia(get_rid()).inverse();
+}
+
+Basis RigidBody::get_inv_inertia_tensor() const {
+
+	return PhysicsServer::get_singleton()->body_get_inv_inertia_tensor(get_rid());
 }
 
 void RigidBody::set_friction(real_t p_friction) {
@@ -790,6 +811,14 @@ void RigidBody::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_weight", "weight"), &RigidBody::set_weight);
 	ClassDB::bind_method(D_METHOD("get_weight"), &RigidBody::get_weight);
+
+	ClassDB::bind_method(D_METHOD("get_center_of_mass"), &RigidBody::get_center_of_mass);
+
+	ClassDB::bind_method(D_METHOD("get_principal_inertia_axes"), &RigidBody::get_principal_inertia_axes);
+
+	ClassDB::bind_method(D_METHOD("get_inertia"), &RigidBody::get_inertia);
+
+	ClassDB::bind_method(D_METHOD("get_inv_inertia_tensor"), &RigidBody::get_inv_inertia_tensor);
 
 	ClassDB::bind_method(D_METHOD("set_friction", "friction"), &RigidBody::set_friction);
 	ClassDB::bind_method(D_METHOD("get_friction"), &RigidBody::get_friction);

--- a/scene/3d/physics_body.h
+++ b/scene/3d/physics_body.h
@@ -204,6 +204,14 @@ public:
 	void set_weight(real_t p_weight);
 	real_t get_weight() const;
 
+	Vector3 get_center_of_mass() const;
+
+	Basis get_principal_inertia_axes() const;
+
+	Vector3 get_inertia() const;
+
+	Basis get_inv_inertia_tensor() const;
+
 	void set_friction(real_t p_friction);
 	real_t get_friction() const;
 

--- a/servers/physics/body_pair_sw.cpp
+++ b/servers/physics/body_pair_sw.cpp
@@ -253,19 +253,23 @@ bool BodyPairSW::setup(real_t p_step) {
 		return false;
 	}
 
+	// Update priority
+	int space_priority = space->get_constraint_priority();
+	int shape_priority_a = A->get_shape_custom_priority(shape_A);
+	int shape_priority_b = B->get_shape_custom_priority(shape_B);
+	int priority_a = shape_priority_a > 0 ? shape_priority_a : space_priority;
+	int priority_b = shape_priority_b > 0 ? shape_priority_b : space_priority;
+	set_priority(MAX(priority_a, priority_b));
+
+	// Compute bias
+	real_t space_bias = space->get_constraint_bias();
+	real_t shape_bias_a = A->get_shape_custom_bias(shape_A);
+	real_t shape_bias_b = B->get_shape_custom_bias(shape_B);
+	real_t bias_a = shape_bias_a > 0 ? shape_bias_a : space_bias;
+	real_t bias_b = shape_bias_b > 0 ? shape_bias_b : space_bias;
+	real_t bias = MAX(bias_a, bias_b);
+
 	real_t max_penetration = space->get_contact_max_allowed_penetration();
-
-	real_t bias = (real_t)0.3;
-
-	if (shape_A_ptr->get_custom_bias() || shape_B_ptr->get_custom_bias()) {
-
-		if (shape_A_ptr->get_custom_bias() == 0)
-			bias = shape_B_ptr->get_custom_bias();
-		else if (shape_B_ptr->get_custom_bias() == 0)
-			bias = shape_A_ptr->get_custom_bias();
-		else
-			bias = (shape_B_ptr->get_custom_bias() + shape_A_ptr->get_custom_bias()) * 0.5;
-	}
 
 	real_t inv_dt = 1.0 / p_step;
 

--- a/servers/physics/collision_object_sw.h
+++ b/servers/physics/collision_object_sw.h
@@ -66,7 +66,16 @@ private:
 		ShapeSW *shape;
 		bool disabled;
 
-		Shape() { disabled = false; }
+		// only used for rigid bodies
+		real_t custom_bias;
+		int custom_priority;
+
+		Shape() {
+
+			disabled = false;
+			custom_bias = 0;
+			custom_priority = 0;
+		}
 	};
 
 	Vector<Shape> shapes;
@@ -135,6 +144,12 @@ public:
 
 	_FORCE_INLINE_ void set_shape_as_disabled(int p_idx, bool p_enable) { shapes[p_idx].disabled = p_enable; }
 	_FORCE_INLINE_ bool is_shape_set_as_disabled(int p_idx) const { return shapes[p_idx].disabled; }
+
+	_FORCE_INLINE_ void set_shape_custom_bias(int p_idx, real_t p_bias) { shapes[p_idx].custom_bias = p_bias; }
+	_FORCE_INLINE_ real_t get_shape_custom_bias(int p_idx) const { return shapes[p_idx].custom_bias; }
+
+	_FORCE_INLINE_ void set_shape_custom_priority(int p_idx, int p_priority) { shapes[p_idx].custom_priority = p_priority; }
+	_FORCE_INLINE_ int get_shape_custom_priority(int p_idx) const { return shapes[p_idx].custom_priority; }
 
 	_FORCE_INLINE_ void set_collision_layer(uint32_t p_layer) { collision_layer = p_layer; }
 	_FORCE_INLINE_ uint32_t get_collision_layer() const { return collision_layer; }

--- a/servers/physics/physics_server_sw.cpp
+++ b/servers/physics/physics_server_sw.cpp
@@ -96,13 +96,6 @@ void PhysicsServerSW::shape_set_data(RID p_shape, const Variant &p_data) {
 	shape->set_data(p_data);
 };
 
-void PhysicsServerSW::shape_set_custom_solver_bias(RID p_shape, real_t p_bias) {
-
-	ShapeSW *shape = shape_owner.get(p_shape);
-	ERR_FAIL_COND(!shape);
-	shape->set_custom_bias(p_bias);
-}
-
 PhysicsServer::ShapeType PhysicsServerSW::shape_get_type(RID p_shape) const {
 
 	const ShapeSW *shape = shape_owner.get(p_shape);
@@ -117,13 +110,6 @@ Variant PhysicsServerSW::shape_get_data(RID p_shape) const {
 	ERR_FAIL_COND_V(!shape->is_configured(), Variant());
 	return shape->get_data();
 };
-
-real_t PhysicsServerSW::shape_get_custom_solver_bias(RID p_shape) const {
-
-	const ShapeSW *shape = shape_owner.get(p_shape);
-	ERR_FAIL_COND_V(!shape, 0);
-	return shape->get_custom_bias();
-}
 
 RID PhysicsServerSW::space_create() {
 
@@ -175,6 +161,21 @@ real_t PhysicsServerSW::space_get_param(RID p_space, SpaceParameter p_param) con
 	const SpaceSW *space = space_owner.get(p_space);
 	ERR_FAIL_COND_V(!space, 0);
 	return space->get_param(p_param);
+}
+
+void PhysicsServerSW::space_set_constraint_priority(RID p_space, int p_priority) {
+
+	SpaceSW *space = space_owner.get(p_space);
+	ERR_FAIL_COND(!space);
+
+	space->set_constraint_priority(p_priority);
+}
+
+int PhysicsServerSW::space_get_constraint_priority(RID p_space) const {
+
+	const SpaceSW *space = space_owner.get(p_space);
+	ERR_FAIL_COND_V(!space, 0);
+	return space->get_constraint_priority();
 }
 
 PhysicsDirectSpaceState *PhysicsServerSW::space_get_direct_state(RID p_space) {
@@ -586,6 +587,50 @@ void PhysicsServerSW::body_set_shape_disabled(RID p_body, int p_shape_idx, bool 
 	ERR_FAIL_COND(!body);
 	ERR_FAIL_INDEX(p_shape_idx, body->get_shape_count());
 	body->set_shape_as_disabled(p_shape_idx, p_disabled);
+}
+
+void PhysicsServerSW::body_set_shape_custom_solver_bias(RID p_body, int p_shape_idx, real_t p_bias) {
+
+	BodySW *body = body_owner.get(p_body);
+	ERR_FAIL_COND(!body);
+	ERR_FAIL_INDEX(p_shape_idx, body->get_shape_count());
+	body->set_shape_custom_bias(p_shape_idx, p_bias);
+}
+
+void PhysicsServerSW::body_set_shape_custom_solver_priority(RID p_body, int p_shape_idx, int p_priority) {
+
+	BodySW *body = body_owner.get(p_body);
+	ERR_FAIL_COND(!body);
+	ERR_FAIL_INDEX(p_shape_idx, body->get_shape_count());
+	body->set_shape_custom_priority(p_shape_idx, p_priority);
+}
+
+Vector3 PhysicsServerSW::PhysicsServerSW::body_get_center_of_mass(RID p_body) const {
+
+	BodySW *body = body_owner.get(p_body);
+	ERR_FAIL_COND_V(!body, Vector3());
+	return body->get_center_of_mass();
+}
+
+Basis PhysicsServerSW::body_get_principal_inertia_axes(RID p_body) const {
+
+	BodySW *body = body_owner.get(p_body);
+	ERR_FAIL_COND_V(!body, Basis());
+	return body->get_principal_inertia_axes();
+}
+
+Vector3 PhysicsServerSW::body_get_inv_inertia(RID p_body) const {
+
+	BodySW *body = body_owner.get(p_body);
+	ERR_FAIL_COND_V(!body, Vector3());
+	return body->get_inv_inertia();
+}
+
+Basis PhysicsServerSW::body_get_inv_inertia_tensor(RID p_body) const {
+
+	BodySW *body = body_owner.get(p_body);
+	ERR_FAIL_COND_V(!body, Basis());
+	return body->get_inv_inertia_tensor();
 }
 
 Transform PhysicsServerSW::body_get_shape_transform(RID p_body, int p_shape_idx) const {

--- a/servers/physics/physics_server_sw.h
+++ b/servers/physics/physics_server_sw.h
@@ -80,11 +80,9 @@ public:
 
 	virtual RID shape_create(ShapeType p_shape);
 	virtual void shape_set_data(RID p_shape, const Variant &p_data);
-	virtual void shape_set_custom_solver_bias(RID p_shape, real_t p_bias);
 
 	virtual ShapeType shape_get_type(RID p_shape) const;
 	virtual Variant shape_get_data(RID p_shape) const;
-	virtual real_t shape_get_custom_solver_bias(RID p_shape) const;
 
 	/* SPACE API */
 
@@ -94,6 +92,9 @@ public:
 
 	virtual void space_set_param(RID p_space, SpaceParameter p_param, real_t p_value);
 	virtual real_t space_get_param(RID p_space, SpaceParameter p_param) const;
+
+	virtual void space_set_constraint_priority(RID p_space, int p_priority);
+	virtual int space_get_constraint_priority(RID p_space) const;
 
 	// this function only works on physics process, errors and returns null otherwise
 	virtual PhysicsDirectSpaceState *space_get_direct_state(RID p_space);
@@ -165,6 +166,16 @@ public:
 	virtual Transform body_get_shape_transform(RID p_body, int p_shape_idx) const;
 
 	virtual void body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled);
+	virtual void body_set_shape_custom_solver_bias(RID p_body, int p_shape_idx, real_t p_bias);
+	virtual void body_set_shape_custom_solver_priority(RID p_body, int p_shape_idx, int p_priority);
+
+	virtual Vector3 body_get_center_of_mass(RID p_body) const;
+
+	virtual Basis body_get_principal_inertia_axes(RID p_body) const;
+
+	virtual Vector3 body_get_inv_inertia(RID p_body) const;
+
+	virtual Basis body_get_inv_inertia_tensor(RID p_body) const;
 
 	virtual void body_remove_shape(RID p_body, int p_shape_idx);
 	virtual void body_clear_shapes(RID p_body);

--- a/servers/physics/shape_sw.cpp
+++ b/servers/physics/shape_sw.cpp
@@ -85,7 +85,6 @@ const Map<ShapeOwnerSW *, int> &ShapeSW::get_owners() const {
 
 ShapeSW::ShapeSW() {
 
-	custom_bias = 0;
 	configured = false;
 }
 
@@ -1023,7 +1022,7 @@ void FaceShapeSW::get_supports(const Vector3 &p_normal, int p_max, Vector3 *r_su
 	Vector3 n = p_normal;
 
 	/** TEST FACE AS SUPPORT **/
-	if (normal.dot(n) > _FACE_IS_VALID_SUPPORT_THRESHOLD) {
+	if (Math::abs(normal.dot(n)) > _FACE_IS_VALID_SUPPORT_THRESHOLD) {
 
 		r_amount = 3;
 		for (int i = 0; i < 3; i++) {

--- a/servers/physics/shape_sw.h
+++ b/servers/physics/shape_sw.h
@@ -60,7 +60,6 @@ class ShapeSW : public RID_Data {
 	RID self;
 	Rect3 aabb;
 	bool configured;
-	real_t custom_bias;
 
 	Map<ShapeOwnerSW *, int> owners;
 
@@ -94,9 +93,6 @@ public:
 
 	virtual void set_data(const Variant &p_data) = 0;
 	virtual Variant get_data() const = 0;
-
-	_FORCE_INLINE_ void set_custom_bias(real_t p_bias) { custom_bias = p_bias; }
-	_FORCE_INLINE_ real_t get_custom_bias() const { return custom_bias; }
 
 	void add_owner(ShapeOwnerSW *p_owner);
 	void remove_owner(ShapeOwnerSW *p_owner);

--- a/servers/physics/space_sw.cpp
+++ b/servers/physics/space_sw.cpp
@@ -1045,7 +1045,8 @@ SpaceSW::SpaceSW() {
 	contact_max_separation = 0.05;
 	contact_max_allowed_penetration = 0.01;
 
-	constraint_bias = 0.01;
+	constraint_bias = GLOBAL_DEF("physics/3d/collision_bias", 0.3);
+	constraint_priority = GLOBAL_DEF("physics/3d/collision_priority", 4);
 	body_linear_velocity_sleep_threshold = GLOBAL_DEF("physics/3d/sleep_threshold_linear", 0.1);
 	body_angular_velocity_sleep_threshold = GLOBAL_DEF("physics/3d/sleep_threshold_angular", (8.0 / 180.0 * Math_PI));
 	body_time_to_sleep = GLOBAL_DEF("physics/3d/time_before_sleep", 0.5);

--- a/servers/physics/space_sw.h
+++ b/servers/physics/space_sw.h
@@ -95,6 +95,7 @@ private:
 	real_t contact_max_separation;
 	real_t contact_max_allowed_penetration;
 	real_t constraint_bias;
+	int constraint_priority;
 
 	enum {
 
@@ -156,6 +157,7 @@ public:
 	_FORCE_INLINE_ real_t get_contact_max_separation() const { return contact_max_separation; }
 	_FORCE_INLINE_ real_t get_contact_max_allowed_penetration() const { return contact_max_allowed_penetration; }
 	_FORCE_INLINE_ real_t get_constraint_bias() const { return constraint_bias; }
+	_FORCE_INLINE_ int get_constraint_priority() const { return constraint_priority; }
 	_FORCE_INLINE_ real_t get_body_linear_velocity_sleep_threshold() const { return body_linear_velocity_sleep_threshold; }
 	_FORCE_INLINE_ real_t get_body_angular_velocity_sleep_threshold() const { return body_angular_velocity_sleep_threshold; }
 	_FORCE_INLINE_ real_t get_body_time_to_sleep() const { return body_time_to_sleep; }
@@ -171,6 +173,8 @@ public:
 
 	void set_param(PhysicsServer::SpaceParameter p_param, real_t p_value);
 	real_t get_param(PhysicsServer::SpaceParameter p_param) const;
+
+	void set_constraint_priority(int p_priority) { constraint_priority = p_priority; }
 
 	void set_island_count(int p_island_count) { island_count = p_island_count; }
 	int get_island_count() const { return island_count; }

--- a/servers/physics_server.h
+++ b/servers/physics_server.h
@@ -249,11 +249,9 @@ public:
 
 	virtual RID shape_create(ShapeType p_shape) = 0;
 	virtual void shape_set_data(RID p_shape, const Variant &p_data) = 0;
-	virtual void shape_set_custom_solver_bias(RID p_shape, real_t p_bias) = 0;
 
 	virtual ShapeType shape_get_type(RID p_shape) const = 0;
 	virtual Variant shape_get_data(RID p_shape) const = 0;
-	virtual real_t shape_get_custom_solver_bias(RID p_shape) const = 0;
 
 	/* SPACE API */
 
@@ -275,6 +273,9 @@ public:
 
 	virtual void space_set_param(RID p_space, SpaceParameter p_param, real_t p_value) = 0;
 	virtual real_t space_get_param(RID p_space, SpaceParameter p_param) const = 0;
+
+	virtual void space_set_constraint_priority(RID p_space, int p_priority) = 0;
+	virtual int space_get_constraint_priority(RID p_space) const = 0;
 
 	// this function only works on physics process, errors and returns null otherwise
 	virtual PhysicsDirectSpaceState *space_get_direct_state(RID p_space) = 0;
@@ -381,6 +382,16 @@ public:
 	virtual void body_clear_shapes(RID p_body) = 0;
 
 	virtual void body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled) = 0;
+	virtual void body_set_shape_custom_solver_bias(RID p_body, int p_shape_idx, real_t p_bias) = 0;
+	virtual void body_set_shape_custom_solver_priority(RID p_body, int p_shape_idx, int p_priority) = 0;
+
+	virtual Vector3 body_get_center_of_mass(RID p_body) const = 0;
+
+	virtual Basis body_get_principal_inertia_axes(RID p_body) const = 0;
+
+	virtual Vector3 body_get_inv_inertia(RID p_body) const = 0;
+
+	virtual Basis body_get_inv_inertia_tensor(RID p_body) const = 0;
 
 	virtual void body_attach_object_instance_id(RID p_body, uint32_t p_ID) = 0;
 	virtual uint32_t body_get_object_instance_id(RID p_body) const = 0;


### PR DESCRIPTION
Allow to set a default priority and bias for collision resolution. Also allow to override these values for a given collision shape.

The values used in the body pair are computed as the max value of the values of the two participating shapes (or the default ones)

Also expose some physics body state values such as center of mass, principal inertia axes and inertia vector/inertia tensor at the physics body level

Fix a bug in the FaceShapeSW::get_supports() method