### PR TITLE
Fix bone draw on viewport

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2704,6 +2704,7 @@ void CanvasItemEditor::_draw_viewport() {
 		over_plugin_list->forward_draw_over_canvas(transform, viewport);
 	}
 	_draw_focus();
+	_draw_bones();
 }
 
 void CanvasItemEditor::_notification(int p_what) {


### PR DESCRIPTION
Bones are not drawn on 3.0 viewport because _draw_bones() function is never called.