### PR TITLE
doc_status.py Python 2.7 backwards compatibility & Windows support

### DIFF
--- a/doc/tools/doc_status.py
+++ b/doc/tools/doc_status.py
@@ -91,7 +91,7 @@ def validate_tag(elem, tag):
 
 
 def color(color, string):
-    if flags['c']:
+    if flags['c'] and terminal_supports_color():
         color_format = ''
         for code in colors[color]:
             color_format += '\033[' + str(code) + 'm'
@@ -105,6 +105,15 @@ ansi_escape = re.compile(r'\x1b[^m]*m')
 def nonescape_len(s):
     return len(ansi_escape.sub('', s))
 
+def terminal_supports_color():
+    p = sys.platform
+    supported_platform = p != 'Pocket PC' and (p != 'win32' or
+                                           'ANSICON' in os.environ)
+
+    is_a_tty = hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()
+    if not supported_platform or not is_a_tty:
+        return False
+    return True
 
 ################################################################################
 #                                   Classes                                    #
@@ -134,8 +143,8 @@ class ClassStatusProgress:
             return self.to_colored_string()
 
     def to_colored_string(self, format='{has}/{total}', pad_format='{pad_described}{s}{pad_total}'):
-        ratio = self.described / self.total if self.total != 0 else 1
-        percent = round(100 * ratio)
+        ratio = float(self.described) / float(self.total) if self.total != 0 else 1
+        percent = int(round(100 * ratio))
         s = format.format(has=str(self.described), total=str(self.total), percent=str(percent))
         if self.described >= self.total:
             s = color('part_good', s)
@@ -218,6 +227,7 @@ class ClassStatus:
 
         return output
 
+    @staticmethod
     def generate_for_class(c):
         status = ClassStatus()
         status.name = c.attrib['name']
@@ -436,7 +446,7 @@ for row_i, row in enumerate(table):
         if cell_i == 0:
             row_string += table_row_chars[3] + cell + table_row_chars[3] * (padding_needed - 1)
         else:
-            row_string += table_row_chars[3] * math.floor(padding_needed / 2) + cell + table_row_chars[3] * math.ceil((padding_needed / 2))
+            row_string += table_row_chars[3] * int(math.floor(float(padding_needed) / 2)) + cell + table_row_chars[3] * int(math.ceil(float(padding_needed) / 2))
         row_string += table_column_chars
 
     print(row_string)


### PR DESCRIPTION
Because Python 2.7 is currently recommended for building, it is cumbersome that the `doc/tools/doc_status.py` script requires Python 3. (Besides, lots of Python 2.7 installs out there :))

This makes the script backwards-compatible so it runs on both Python 2.7 and Python 3.0

Additionally, color escape sequences are only used if the terminal may support them.