### PR TITLE
Unfocus active control after exterior click

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1709,14 +1709,17 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 
 			if (mb->get_button_index() == BUTTON_LEFT) { //assign focus
 				CanvasItem *ci = gui.mouse_focus;
+				bool should_release_focus = true;
 				while (ci) {
 
 					Control *control = Object::cast_to<Control>(ci);
 					if (control) {
 						if (control->get_focus_mode() != Control::FOCUS_NONE) {
 							if (control != gui.key_focus) {
+								// grabbing focus also releases existing focus
 								control->grab_focus();
 							}
+							should_release_focus = false;
 							break;
 						}
 
@@ -1728,6 +1731,11 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 						break;
 
 					ci = ci->get_parent_item();
+				}
+
+				// if no item to grab the focus was found, simply release currently focused item
+				if (should_release_focus) {
+					get_tree()->call_group_flags(SceneTree::GROUP_CALL_REALTIME, "_viewports", "_gui_remove_focus");
 				}
 			}
 


### PR DESCRIPTION
This is especially important and visible for input box - when you
click outside of it, you expect the focus to be gone. On mobile devices
this also makes the virtual keyboard disappear when tapping outside of
a focused element.