### PR TITLE
Fix possible crash at exit on iOS

### DIFF
--- a/platform/iphone/audio_driver_iphone.cpp
+++ b/platform/iphone/audio_driver_iphone.cpp
@@ -175,8 +175,17 @@ void AudioDriverIphone::unlock() {
 };
 
 void AudioDriverIphone::finish() {
+	AURenderCallbackStruct callback;
+	zeromem(&callback, sizeof(AURenderCallbackStruct));
+	OSStatus result = AudioUnitSetProperty(audio_unit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Input, 0, &callback, sizeof(callback));
+	if (result != noErr) {
+		ERR_PRINT("AudioUnitSetProperty failed");
+	}
 
-	memdelete_arr(samples_in);
+	if (samples_in) {
+		memdelete_arr(samples_in);
+		samples_in = NULL;
+	}
 };
 
 AudioDriverIphone::AudioDriverIphone() {

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -371,6 +371,14 @@ void OSIPhone::finalize() {
 	if (main_loop) // should not happen?
 		memdelete(main_loop);
 
+	spatial_sound_server->finish();
+	memdelete(spatial_sound_server);
+	spatial_sound_2d_server->finish();
+	memdelete(spatial_sound_2d_server);
+
+	audio_server->finish();
+	memdelete(audio_server);
+
 	visual_server->finish();
 	memdelete(visual_server);
 	memdelete(rasterizer);
@@ -381,13 +389,7 @@ void OSIPhone::finalize() {
 	physics_2d_server->finish();
 	memdelete(physics_2d_server);
 
-	spatial_sound_server->finish();
-	memdelete(spatial_sound_server);
-
 	memdelete(input);
-
-	spatial_sound_2d_server->finish();
-	memdelete(spatial_sound_2d_server);
 };
 
 void OSIPhone::set_mouse_show(bool p_show){};

--- a/servers/audio/audio_server_sw.cpp
+++ b/servers/audio/audio_server_sw.cpp
@@ -726,7 +726,8 @@ void AudioServerSW::_thread_func(void *self) {
 
 	while (!as->exit_update_thread) {
 		as->_update_streams(true);
-		OS::get_singleton()->delay_usec(5000);
+		if (OS::get_singleton())
+			OS::get_singleton()->delay_usec(5000);
 	}
 }
 


### PR DESCRIPTION
Fixes the crash described at #11623 which happens when the iOS app tries to quit and the render callback keeps getting called (because AudioDriverIphone::finish wasn't clearing the property).