### PR TITLE
Add OS::is_userfs_persistent, allow starting HTML5 platform in private mode

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -755,6 +755,11 @@ bool _OS::can_draw() const {
 	return OS::get_singleton()->can_draw();
 }
 
+bool _OS::is_userfs_persistent() const {
+
+	return OS::get_singleton()->is_userfs_persistent();
+}
+
 int _OS::get_processor_count() const {
 
 	return OS::get_singleton()->get_processor_count();
@@ -1051,6 +1056,7 @@ void _OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_model_name"), &_OS::get_model_name);
 
 	ClassDB::bind_method(D_METHOD("can_draw"), &_OS::can_draw);
+	ClassDB::bind_method(D_METHOD("is_userfs_persistent"), &_OS::is_userfs_persistent);
 	ClassDB::bind_method(D_METHOD("is_stdout_verbose"), &_OS::is_stdout_verbose);
 
 	ClassDB::bind_method(D_METHOD("can_use_threads"), &_OS::can_use_threads);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -266,6 +266,8 @@ public:
 
 	bool can_draw() const;
 
+	bool is_userfs_persistent() const;
+
 	bool is_stdout_verbose() const;
 
 	int get_processor_count() const;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -284,6 +284,8 @@ public:
 
 	virtual bool can_draw() const = 0;
 
+	virtual bool is_userfs_persistent() const { return true; }
+
 	bool is_stdout_verbose() const;
 
 	virtual void disable_crash_handler() {}

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -472,6 +472,13 @@
 				Return true if the engine was executed with -v (verbose stdout).
 			</description>
 		</method>
+		<method name="is_userfs_persistent" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+				If [code]true[/code], the [code]user://[/code] file system is persistent, so that its state is the same after a player quits and starts the game again. Relevant to the HTML5 platform, where this persistence may be unavailable.
+			</description>
+		</method>
 		<method name="is_vsync_enabled" qualifiers="const">
 			<return type="bool">
 			</return>

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -49,6 +49,7 @@ typedef String (*GetDataDirFunc)();
 
 class OS_JavaScript : public OS_Unix {
 
+	bool idbfs_available;
 	int64_t time_to_save_sync;
 	int64_t last_sync_time;
 
@@ -140,6 +141,8 @@ public:
 
 	virtual bool can_draw() const;
 
+	virtual bool is_userfs_persistent() const;
+
 	virtual void set_cursor_shape(CursorShape p_shape);
 
 	void main_loop_begin();
@@ -170,6 +173,8 @@ public:
 	virtual int get_power_percent_left();
 
 	virtual bool _check_internal_feature_support(const String &p_feature);
+
+	void set_idbfs_available(bool p_idbfs_available);
 
 	OS_JavaScript(const char *p_execpath, GetDataDirFunc p_get_data_dir_func);
 	~OS_JavaScript();


### PR DESCRIPTION
In the HTML5 platform, persistence for `user://` may not be available. Possible reasons include:

 - Using a private/incognito window
 - Disabling cookies
 - Disabling only third-party cookies and running the game in an `<iframe>`

Currently these cases will cause start-up to fail, so the game never starts. For many games persistence is irrelevant, so this is undesirable.

This PR adds `OS.is_userfs_persistent()` as an API for game developers to check if the `user://` file system is persistent. This way, developers can decide for themselves how to handle this situation.
By itself, Godot now just prints an error to the console during start-up if persistence is unavailable.