### PR TITLE
fix undo-redo crash on missing objects

### DIFF
--- a/core/undo_redo.cpp
+++ b/core/undo_redo.cpp
@@ -317,6 +317,7 @@ void UndoRedo::undo() {
 	if (current_action < 0)
 		return; //nothing to redo
 	_process_operation_list(actions[current_action].undo_ops.front());
+	ERR_FAIL_COND(current_action == -1);
 	current_action--;
 	version--;
 }


### PR DESCRIPTION
This should fix #11785 .

But I think I need help on using either this or use `ERR_FAIL_COND` to handle `current_action == -1`.

Cheers!