### PR TITLE
doc_status.py: Add -t (--todo) option, show only non-empty items

### DIFF
--- a/doc/tools/doc_status.py
+++ b/doc/tools/doc_status.py
@@ -23,6 +23,7 @@ flags = {
     'o': True,
     'i': False,
     'a': True,
+    'e': False,
 }
 flag_descriptions = {
     'c': 'Toggle colors when outputting.',
@@ -35,6 +36,7 @@ flag_descriptions = {
     'o': 'Toggle overall column.',
     'i': 'Toggle collapse of class items columns.',
     'a': 'Toggle showing all items.',
+    'e': 'Toggle hiding empty items.',
 }
 long_flags = {
     'colors': 'c',
@@ -64,6 +66,8 @@ long_flags = {
     'collapse': 'i',
 
     'all': 'a',
+
+    'empty': 'e',
 }
 table_columns = ['name', 'brief_description', 'description', 'methods', 'constants', 'members', 'signals']
 table_column_names = ['Name', 'Brief Desc.', 'Desc.', 'Methods', 'Constants', 'Members', 'Signals']
@@ -191,6 +195,14 @@ class ClassStatus:
         for k in self.progresses:
             ok = ok and self.progresses[k].is_ok()
         return ok
+
+    def is_empty(self):
+        sum = 0
+        for k in self.progresses:
+            if self.progresses[k].is_ok():
+                continue
+            sum += self.progresses[k].total
+        return sum < 1
 
     def make_output(self):
         output = {}
@@ -394,6 +406,9 @@ for cn in filtered_classes:
     total_status = total_status + status
 
     if (flags['b'] and status.is_ok()) or (flags['g'] and not status.is_ok()) or (not flags['a']):
+        continue
+
+    if flags['e'] and status.is_empty():
         continue
 
     out = status.make_output()


### PR DESCRIPTION
Currently, if you use `doc_statuc.py doc\classes -b` to see where work is needed, there are a lot of lines like this one below:

`VisualScriptSwitch | ... | 0/0 | 0/0 | 0/0 | 0/0 | 0%`

This adds a `-t` or `--todo` switch which filters these lines so that only those are shown where there are still items (methods, constants, members or signals) to document.

Meaning for at least one item, the value is neither 0/0 nor full, e.g. X/X. 

(Or rather, the value is X-n/X where X and n are both > 0, and n < X, I guess. :stuck_out_tongue:)