### PR TITLE
Fix logging on iOS

### DIFF
--- a/platform/iphone/app_delegate.mm
+++ b/platform/iphone/app_delegate.mm
@@ -81,7 +81,7 @@ void _set_keep_screen_on(bool p_enabled) {
 
 extern int gargc;
 extern char **gargv;
-extern int iphone_main(int, int, int, char **);
+extern int iphone_main(int, int, int, char **, String);
 extern void iphone_finish();
 
 CMMotionManager *motionManager;
@@ -393,15 +393,6 @@ static int frame_count = 0;
 			};
 			++frame_count;
 
-			NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory,
-					NSUserDomainMask, YES);
-			NSString *documentsDirectory = [paths objectAtIndex:0];
-			// NSString *documentsDirectory = [[[NSFileManager defaultManager]
-			// URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask]
-			// lastObject];
-			OSIPhone::get_singleton()->set_data_dir(
-					String::utf8([documentsDirectory UTF8String]));
-
 			NSString *locale_code = [[NSLocale currentLocale] localeIdentifier];
 			OSIPhone::get_singleton()->set_locale(
 					String::utf8([locale_code UTF8String]));
@@ -604,7 +595,11 @@ static int frame_count = 0;
 	glGetRenderbufferParameterivOES(GL_RENDERBUFFER_OES,
 			GL_RENDERBUFFER_HEIGHT_OES, &backingHeight);
 
-	int err = iphone_main(backingWidth, backingHeight, gargc, gargv);
+	NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory,
+			NSUserDomainMask, YES);
+	NSString *documentsDirectory = [paths objectAtIndex:0];
+
+	int err = iphone_main(backingWidth, backingHeight, gargc, gargv, String::utf8([documentsDirectory UTF8String]));
 	if (err != 0) {
 		// bail, things did not go very well for us, should probably output a message on screen with our error code...
 		exit(0);

--- a/platform/iphone/godot_iphone.cpp
+++ b/platform/iphone/godot_iphone.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 #include "main/main.h"
 #include "os_iphone.h"
+#include "ustring.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -41,9 +42,9 @@ int add_path(int p_argc, char **p_args);
 int add_cmdline(int p_argc, char **p_args);
 };
 
-int iphone_main(int, int, int, char **);
+int iphone_main(int, int, int, char **, String);
 
-int iphone_main(int width, int height, int argc, char **argv) {
+int iphone_main(int width, int height, int argc, char **argv, String data_dir) {
 
 	int len = strlen(argv[0]);
 
@@ -63,7 +64,7 @@ int iphone_main(int width, int height, int argc, char **argv) {
 	char cwd[512];
 	getcwd(cwd, sizeof(cwd));
 	printf("cwd %s\n", cwd);
-	os = new OSIPhone(width, height);
+	os = new OSIPhone(width, height, data_dir);
 
 	char *fargv[64];
 	for (int i = 0; i < argc; i++) {

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -97,6 +97,8 @@ void OSIPhone::initialize_core() {
 
 	OS_Unix::initialize_core();
 	SemaphoreIphone::make_default();
+
+	set_data_dir(data_dir);
 };
 
 void OSIPhone::initialize_logger() {
@@ -564,7 +566,7 @@ bool OSIPhone::_check_internal_feature_support(const String &p_feature) {
 	return p_feature == "mobile" || p_feature == "etc" || p_feature == "pvrtc" || p_feature == "etc2";
 }
 
-OSIPhone::OSIPhone(int width, int height) {
+OSIPhone::OSIPhone(int width, int height, String p_data_dir) {
 
 	main_loop = NULL;
 	visual_server = NULL;
@@ -576,6 +578,10 @@ OSIPhone::OSIPhone(int width, int height) {
 	vm.resizable = false;
 	set_video_mode(vm);
 	event_count = 0;
+
+	// can't call set_data_dir from here, since it requires DirAccess
+	// which is initialized in initialize_core
+	data_dir = p_data_dir;
 
 	_set_logger(memnew(SyslogLogger));
 };

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -197,7 +197,7 @@ public:
 	virtual void native_video_stop();
 
 	virtual bool _check_internal_feature_support(const String &p_feature);
-	OSIPhone(int width, int height);
+	OSIPhone(int width, int height, String p_data_dir);
 	~OSIPhone();
 };
 


### PR DESCRIPTION
RotatedFileLogger needs data_dir on iOS to be initialized, so setting
data_dir has been moved to initialize_core.