### PR TITLE
Updated ios x86 simulator build to match target version of real devices.

### DIFF
--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -99,7 +99,7 @@ def configure(env):
     ## Link flags
 
     if (env["arch"] == "x86"):
-        env.Append(LINKFLAGS=['-arch', 'i386', '-mios-simulator-version-min=4.3',
+        env.Append(LINKFLAGS=['-arch', 'i386', '-mios-simulator-version-min=9.0',
                               '-isysroot', '$IPHONESDK',
                               '-Xlinker',
                               '-objc_abi_version',


### PR DESCRIPTION
On ios the x86 build uses an old target that does not support c++11, I have updated the x86 to match the one used on real device