### PR TITLE
Fix Python 3 build

### DIFF
--- a/compat.py
+++ b/compat.py
@@ -14,6 +14,17 @@ if sys.version_info < (3,):
         return x
     def iteritems(d):
         return d.iteritems()
+    def escape_string(s):
+        if isinstance(s, unicode):
+            s = s.encode('ascii')
+        result = ''
+        for c in s:
+            if not (32 <= ord(c) < 127) or c in ('\\', '"'):
+                result += '\\%03o' % ord(c)
+            else:
+                result += c
+        return result
+
 else:
     def isbasestring(s):
         return isinstance(s, (str, bytes))
@@ -29,3 +40,21 @@ else:
         return codecs.utf_8_encode(x)[0]
     def iteritems(d):
         return iter(d.items())
+    def charcode_to_c_escapes(c):
+        rev_result = []
+        while c >= 256:
+            c, low = (c // 256, c % 256)
+            rev_result.append('\\%03o' % low)
+        rev_result.append('\\%03o' % c)
+        return ''.join(reversed(rev_result))
+    def escape_string(s):
+        result = ''
+        if isinstance(s, str):
+            s = s.encode('utf-8')
+        for c in s:
+            if not(32 <= c < 127) or c in (ord('\\'), ord('"')):
+                result += charcode_to_c_escapes(c)
+            else:
+                result += chr(c)
+        return result
+

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -4,18 +4,8 @@ Import('env')
 env.editor_sources = []
 
 import os
-from compat import encode_utf8, byte_to_str, open_utf8
+from compat import encode_utf8, byte_to_str, open_utf8, escape_string
 
-def escape_string(s, encoding='ascii'):
-    if isinstance(s, unicode):
-        s = s.encode(encoding)
-    result = ''
-    for c in s:
-        if not (32 <= ord(c) < 127) or c in ('\\', '"'):
-            result += '\\%03o' % ord(c)
-        else:
-            result += c
-    return result
 
 def make_certs_header(target, source, env):
 

--- a/modules/mono/mono_reg_utils.py
+++ b/modules/mono/mono_reg_utils.py
@@ -1,7 +1,11 @@
 import os
 
 if os.name == 'nt':
-    import _winreg as winreg
+    import sys
+    if sys.version_info < (3,):
+        import _winreg as winreg
+    else:
+        import winreg
 
 
 def _reg_open_key(key, subkey):


### PR DESCRIPTION
- Take care of the differences in handling unicode characters in `escape_string` (formerly in `editor/SCsub`, now in `compat.py)`.
- Conditionally include `_winreg` or `winreg` in the Mono editor module.

I've removed the `encoding` argument from `escape_string` since it does not really make sense. (It's value is used internally to convert a Unicode string into bytes. The Python 2 version uses the `ascii` encoding, but that can't be used on Python 3 since AFAICT there is no error mode that produces the desired behavior. Therefore on Python 3 I'm encoding using UTF-8 and manually converting non-ascii code points to C escapes. But neither version will do anything sensible if called with an `encoding` argument that doesn't match its default.)

In Python 3 the manual conversion to C escapes could be avoided by using Unicode escapes in the generated C++-Files, but that would require C++11 support and is therefore probably not a feasible solution.