### PR TITLE
Fixed uninitialized local and improved msbuild search and usability

### DIFF
--- a/modules/mono/editor/GodotSharpTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotSharpTools/Build/BuildSystem.cs
@@ -19,7 +19,15 @@ namespace GodotSharpTools.Build
 
         private static string MSBuildPath
         {
-            get { return godot_icall_BuildInstance_get_MSBuildPath(); }
+            get
+            {
+                string ret = godot_icall_BuildInstance_get_MSBuildPath();
+
+                if (ret == null)
+                    throw new FileNotFoundException("Cannot find the MSBuild executable.");
+
+                return ret;
+            }
         }
 
         private string solution;

--- a/modules/mono/editor/GodotSharpTools/Project/ProjectExtensions.cs
+++ b/modules/mono/editor/GodotSharpTools/Project/ProjectExtensions.cs
@@ -27,12 +27,15 @@ namespace GodotSharpTools.Project
             return false;
         }
 
-        public static void AddItemChecked(this ProjectRootElement root, string itemType, string include)
+        public static bool AddItemChecked(this ProjectRootElement root, string itemType, string include)
         {
             if (!root.HasItem(itemType, include))
             {
                 root.AddItem(itemType, include);
+                return true;
             }
+
+            return false;
         }
 
         public static Guid GetGuid(this ProjectRootElement root)

--- a/modules/mono/editor/GodotSharpTools/Project/ProjectUtils.cs
+++ b/modules/mono/editor/GodotSharpTools/Project/ProjectUtils.cs
@@ -10,8 +10,8 @@ namespace GodotSharpTools.Project
         {
             var dir = Directory.GetParent(projectPath).FullName;
             var root = ProjectRootElement.Open(projectPath);
-            root.AddItemChecked(itemType, include.RelativeToPath(dir).Replace("/", "\\"));
-            root.Save();
+            if (root.AddItemChecked(itemType, include.RelativeToPath(dir).Replace("/", "\\")))
+                root.Save();
         }
     }
 }

--- a/modules/mono/editor/godotsharp_builds.cpp
+++ b/modules/mono/editor/godotsharp_builds.cpp
@@ -29,13 +29,14 @@
 /*************************************************************************/
 #include "godotsharp_builds.h"
 
+#include "main/main.h"
+
 #include "../godotsharp_dirs.h"
 #include "../mono_gd/gd_mono_class.h"
 #include "../mono_gd/gd_mono_marshal.h"
 #include "../utils/path_utils.h"
 #include "bindings_generator.h"
 #include "godotsharp_editor.h"
-#include "main/main.h"
 
 void godot_icall_BuildInstance_ExitCallback(MonoString *p_solution, MonoString *p_config, int p_exit_code) {
 
@@ -44,11 +45,37 @@ void godot_icall_BuildInstance_ExitCallback(MonoString *p_solution, MonoString *
 	GodotSharpBuilds::get_singleton()->build_exit_callback(MonoBuildInfo(solution, config), p_exit_code);
 }
 
+#ifdef UNIX_ENABLED
+String _find_build_engine_on_unix(const String &p_name) {
+	String ret = path_which(p_name);
+
+	if (ret.length())
+		return ret;
+
+	const char *locations[] = {
+#ifdef OSX_ENABLED
+		"/Library/Frameworks/Mono.framework/Versions/Current/bin/",
+#endif
+		"/opt/novell/mono/bin/"
+	};
+
+	for (int i = 0; i < sizeof(locations) / sizeof(char); i++) {
+		String location = locations[i];
+
+		if (FileAccess::exists(location + p_name)) {
+			return location;
+		}
+	}
+
+	return String();
+}
+#endif
+
 MonoString *godot_icall_BuildInstance_get_MSBuildPath() {
 
 	GodotSharpBuilds::BuildTool build_tool = GodotSharpBuilds::BuildTool(int(EditorSettings::get_singleton()->get("mono/builds/build_tool")));
 
-#ifdef WINDOWS_ENABLED
+#if defined(WINDOWS_ENABLED)
 	switch (build_tool) {
 		case GodotSharpBuilds::MSBUILD: {
 			static String msbuild_tools_path = MonoRegUtils::find_msbuild_tools_path();
@@ -84,14 +111,25 @@ MonoString *godot_icall_BuildInstance_get_MSBuildPath() {
 			ERR_EXPLAIN("You don't deserve to live");
 			CRASH_NOW();
 	}
-#else
-	static bool msbuild_found = path_which("msbuild").length();
+#elif defined(UNIX_ENABLED)
+	static String msbuild_path = _find_build_engine_on_unix("msbuild");
+	static String xbuild_path = _find_build_engine_on_unix("xbuild");
 
-	if (build_tool != GodotSharpBuilds::XBUILD && !msbuild_found) {
-		WARN_PRINT("Cannot find msbuild ('mono/builds/build_tool').");
+	if (build_tool != GodotSharpBuilds::XBUILD) {
+		if (msbuild_path.empty()) {
+			WARN_PRINT("Cannot find msbuild ('mono/builds/build_tool').");
+			return NULL;
+		}
+	} else {
+		if (xbuild_path.empty()) {
+			WARN_PRINT("Cannot find xbuild ('mono/builds/build_tool').");
+			return NULL;
+		}
 	}
 
-	return GDMonoMarshal::mono_string_from_godot(build_tool != GodotSharpBuilds::XBUILD ? "msbuild" : "xbuild");
+	return GDMonoMarshal::mono_string_from_godot(build_tool != GodotSharpBuilds::XBUILD ? msbuild_path : xbuild_path);
+#else
+	return NULL;
 #endif
 }
 


### PR DESCRIPTION
- Fixed uninitialized local.
- When attaching a script to an object, we add it to the C# project if it's not already in (Noticed a few issues on domain unload after this, running the GC before finalizing the domain fixed them).
- Search msbuild in a few other locations other than PATH on Unix. Notably: `/Library/Frameworks/Mono.framework/Versions/Current/bin/` on OSX.
