### PR TITLE
Added an experimental convert scripts option for godot3 export

### DIFF
--- a/editor/editor_export_godot3.h
+++ b/editor/editor_export_godot3.h
@@ -87,10 +87,12 @@ class EditorExportGodot3 {
 	void _unpack_packed_scene(ExportData &resource);
 	void _pack_packed_scene(ExportData &resource);
 
+	Error _convert_script(const String &p_path, const String &p_target_path);
+
 	void _find_files(EditorFileSystemDirectory *p_dir, List<String> *r_files);
 
 public:
-	Error export_godot3(const String &p_path);
+	Error export_godot3(const String &p_path, bool convert_scripts);
 
 	EditorExportGodot3();
 };

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5077,7 +5077,7 @@ void EditorNode::_bind_methods() {
 
 void EditorNode::_export_godot3_path(const String &p_path) {
 
-	Error err = export_godot3.export_godot3(p_path);
+	Error err = export_godot3.export_godot3(p_path, export_godot3_dialog_convert_scripts->is_pressed());
 	if (err != OK) {
 		show_warning("Error exporting to Godot 3.0");
 	}
@@ -6345,6 +6345,10 @@ EditorNode::EditorNode() {
 	export_godot3_dialog = memnew(FileDialog);
 	export_godot3_dialog->set_access(FileDialog::ACCESS_FILESYSTEM);
 	export_godot3_dialog->set_mode(FileDialog::MODE_OPEN_DIR);
+	export_godot3_dialog_convert_scripts = memnew(CheckButton);
+	export_godot3_dialog_convert_scripts->set_text(TTR("Convert scripts (experimental)"));
+	export_godot3_dialog_convert_scripts->set_pressed(false);
+	export_godot3_dialog->get_vbox()->add_child(export_godot3_dialog_convert_scripts);
 	gui_base->add_child(export_godot3_dialog);
 	export_godot3_dialog->connect("dir_selected", this, "_export_godot3_path");
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -279,6 +279,7 @@ private:
 
 	EditorExportGodot3 export_godot3;
 	FileDialog *export_godot3_dialog;
+	CheckButton *export_godot3_dialog_convert_scripts;
 
 	CreateDialog *create_dialog;
 


### PR DESCRIPTION
If enabled this option will convert gdscripts using regexp. So far it converts:

- _fixed_process( => _physics_process(
- _pos( => _position(
- KEY_RETURN => KEY_ENTER
- RawArray() => PoolByteArray()
- Vector2Array() => PoolVector2Array()
- .get_opacity() => .get_modulate().a
- .set_opacity(var) => .modulate.a = var
- .connect( => .connect_to_host( _// (A HTTPClient object is detected first)_
- ReferenceFrame => Control
- var.type == InputEvent.KEY => var.get_name() == "InputEventKey"
- var.type == InputEvent.MOUSE_MOTION => var.get_name() == "InputEventMouseMotion"
- var.type == InputEvent.MOUSE_BUTTON => var.get_name() == "InputEventMouseButton"
- var.type == InputEvent.JOYSTICK_MOTION => var.get_name() == "InputEventJoypadMotion"
- var.type == InputEvent.JOYSTICK_BUTTON => var.get_name() == "InputEventJoypadButton"
- is_move_and_slide_on_floor() => is_on_floor()
- is_move_and_slide_on_ceiling() => is_on_ceiling()
- is_move_and_slide_on_wall() => is_on_wall()