### PR TITLE
Fix command-line export looping infinitely

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -373,6 +373,9 @@ void EditorNode::_fs_changed() {
 				String err = "Preset \"" + export_defer.preset + "\" doesn't have a platform.";
 				ERR_PRINT(err.utf8().get_data());
 			} else {
+				// ensures export_project does not loop infinitely, because notifications may
+				// come during the export
+				export_defer.preset = "";
 				platform->export_project(preset, export_defer.debug, export_defer.path, /*p_flags*/ 0);
 			}
 		}


### PR DESCRIPTION
EditorProgress calls Main::iteration which calls MessageQueue::flush
which may result in _fs_changed being called again. This fixes the loop
Godot enters in such case.

Fixes #11189