### PR TITLE
Fix python 3 build in osx-specific platform

### DIFF
--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -62,7 +62,7 @@ def configure(env):
 
     ## Compiler configuration
 
-    if (not os.environ.has_key("OSXCROSS_ROOT")): # regular native build
+    if "OSXCROSS_ROOT" not in os.environ: # regular native build
         if (env["bits"] == "fat"):
             env.Append(CCFLAGS=['-arch', 'i386', '-arch', 'x86_64'])
             env.Append(LINKFLAGS=['-arch', 'i386', '-arch', 'x86_64'])


### PR DESCRIPTION
Removes the legacy `has_key` to make python3 compile for the osx platform, addresses issue  #11903 - fails now at what I suspect #11843 will fix!