### PR TITLE
Fix Python 3 incompatibility in Mono build

### DIFF
--- a/modules/mono/SCsub
+++ b/modules/mono/SCsub
@@ -2,9 +2,10 @@
 
 Import('env')
 
+from compat import byte_to_str
 
 def make_cs_files_header(src, dst):
-    with open(dst, 'wb') as header:
+    with open(dst, 'w') as header:
         header.write('/* This is an automatically generated file; DO NOT EDIT! OK THX */\n')
         header.write('#ifndef _CS_FILES_DATA_H\n')
         header.write('#define _CS_FILES_DATA_H\n\n')
@@ -26,7 +27,7 @@ def make_cs_files_header(src, dst):
                     for i, buf_idx in enumerate(range(len(buf))):
                         if i > 0:
                             header.write(', ')
-                        header.write(str(ord(buf[buf_idx])))
+                        header.write(byte_to_str(buf[buf_idx]))
                     inserted_files += '\tr_files.insert(\"' + file + '\", ' \
                                         'CompressedFile(_cs_' + name + '_compressed_size, ' \
                                         '_cs_' + name + '_uncompressed_size, ' \


### PR DESCRIPTION
This fixes the Python 3 incompatibility when trying to build the Mono module mentioned in #11860.

[Edit: removed comment about unrelated build failure. The Python 3 build passes after building Godot with `mono_glue=yes`]