### PR TITLE
Array::sort/invert now return reference to Array

### DIFF
--- a/core/array.cpp
+++ b/core/array.cpp
@@ -233,9 +233,10 @@ struct _ArrayVariantSort {
 	}
 };
 
-void Array::sort() {
+Array &Array::sort() {
 
 	_p->array.sort_custom<_ArrayVariantSort>();
+	return *this;
 }
 
 struct _ArrayVariantSortCustom {
@@ -253,19 +254,21 @@ struct _ArrayVariantSortCustom {
 		return res;
 	}
 };
-void Array::sort_custom(Object *p_obj, const StringName &p_function) {
+Array &Array::sort_custom(Object *p_obj, const StringName &p_function) {
 
-	ERR_FAIL_NULL(p_obj);
+	ERR_FAIL_NULL_V(p_obj, *this);
 
 	SortArray<Variant, _ArrayVariantSortCustom> avs;
 	avs.compare.obj = p_obj;
 	avs.compare.func = p_function;
 	avs.sort(_p->array.ptr(), _p->array.size());
+	return *this;
 }
 
-void Array::invert() {
+Array &Array::invert() {
 
 	_p->array.invert();
+	return *this;
 }
 
 void Array::push_front(const Variant &p_value) {

--- a/core/array.h
+++ b/core/array.h
@@ -68,9 +68,9 @@ public:
 	Variant front() const;
 	Variant back() const;
 
-	void sort();
-	void sort_custom(Object *p_obj, const StringName &p_function);
-	void invert();
+	Array &sort();
+	Array &sort_custom(Object *p_obj, const StringName &p_function);
+	Array &invert();
 
 	int find(const Variant &p_value, int p_from = 0) const;
 	int rfind(const Variant &p_value, int p_from = -1) const;

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -177,8 +177,10 @@
 			</description>
 		</method>
 		<method name="invert">
+			<return type="Array">
+			</return>
 			<description>
-				Reverse the order of the elements in the array (so first element will now be the last).
+				Reverse the order of the elements in the array (so first element will now be the last) and return reference to the array.
 			</description>
 		</method>
 		<method name="pop_back">
@@ -238,17 +240,21 @@
 			</description>
 		</method>
 		<method name="sort">
+			<return type="Array">
+			</return>
 			<description>
-				Sort the array using natural order.
+				Sort the array using natural order and return reference to the array.
 			</description>
 		</method>
 		<method name="sort_custom">
+			<return type="Array">
+			</return>
 			<argument index="0" name="obj" type="Object">
 			</argument>
 			<argument index="1" name="func" type="String">
 			</argument>
 			<description>
-				Sort the array using a custom method. The arguments are an object that holds the method and the name of such method. The custom method receives two arguments (a pair of elements from the array) and must return true if the first argument is less than the second, and return false otherwise. Note: you cannot randomize the return value as the heapsort algorithm expects a deterministic result. Doing so will result in unexpected behavior.
+				Sort the array using a custom method and return reference to the array. The arguments are an object that holds the method and the name of such method. The custom method receives two arguments (a pair of elements from the array) and must return true if the first argument is less than the second, and return false otherwise. Note: you cannot randomize the return value as the heapsort algorithm expects a deterministic result. Doing so will result in unexpected behavior.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
From issue [#5193](https://github.com/godotengine/godot/issues/5193)

The issue only stated Array::sort, but I figured for consistency invert should be included as well