### PR TITLE
Fix dot separated assembly names confused with file extensions

### DIFF
--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -285,8 +285,7 @@ bool GDMono::_load_assembly(const String &p_name, GDMonoAssembly **r_assembly) {
 	MonoAssembly *assembly = mono_assembly_load_full(aname, NULL, &status, false);
 	mono_assembly_name_free(aname);
 
-	if (!assembly)
-		return false;
+	ERR_FAIL_NULL_V(assembly, false);
 
 	uint32_t domain_id = mono_domain_get_id(mono_domain_get());
 

--- a/modules/mono/mono_gd/gd_mono_assembly.cpp
+++ b/modules/mono/mono_gd/gd_mono_assembly.cpp
@@ -47,17 +47,16 @@ MonoAssembly *GDMonoAssembly::_search_hook(MonoAssemblyName *aname, void *user_d
 	(void)user_data; // UNUSED
 
 	String name = mono_assembly_name_get_name(aname);
+	bool has_extension = name.ends_with(".dll") || name.ends_with(".exe");
 
 	if (no_search)
 		return NULL;
 
 	no_search = true; // Avoid the recursion madness
 
-	GDMonoAssembly **loaded_asm = GDMono::get_singleton()->get_loaded_assembly(name.get_basename());
+	GDMonoAssembly **loaded_asm = GDMono::get_singleton()->get_loaded_assembly(has_extension ? name.get_basename() : name);
 	if (loaded_asm)
 		return (*loaded_asm)->get_assembly();
-
-	bool has_extension = name.ends_with(".dll") || name.ends_with(".exe");
 
 	String path;
 	MonoAssembly *res = NULL;


### PR DESCRIPTION
e.g.: `System.Core`...