### PR TITLE
Use "Command" instead of "Meta" for macOS (#1619)

### DIFF
--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -270,16 +270,16 @@ String InputEventKey::as_text() const {
 		return kc;
 
 	if (get_metakey()) {
-		kc = "Meta+" + kc;
+		kc = find_keycode_name(KEY_META) + ("+" + kc);
 	}
 	if (get_alt()) {
-		kc = "Alt+" + kc;
+		kc = find_keycode_name(KEY_ALT) + ("+" + kc);
 	}
 	if (get_shift()) {
-		kc = "Shift+" + kc;
+		kc = find_keycode_name(KEY_SHIFT) + ("+" + kc);
 	}
 	if (get_control()) {
-		kc = "Ctrl+" + kc;
+		kc = find_keycode_name(KEY_CONTROL) + ("+" + kc);
 	}
 	return kc;
 }

--- a/core/os/keyboard.cpp
+++ b/core/os/keyboard.cpp
@@ -60,7 +60,11 @@ static const _KeyCodeText _keycodes[] = {
 		{KEY_PAGEDOWN                      ,"PageDown"},
 		{KEY_SHIFT                         ,"Shift"},
 		{KEY_CONTROL                       ,"Control"},
+#ifdef OSX_ENABLED
+		{KEY_META                          ,"Command"},
+#else
 		{KEY_META                          ,"Meta"},
+#endif
 		{KEY_ALT                           ,"Alt"},
 		{KEY_CAPSLOCK                      ,"CapsLock"},
 		{KEY_NUMLOCK                       ,"NumLock"},
@@ -390,14 +394,22 @@ bool keycode_has_unicode(uint32_t p_keycode) {
 String keycode_get_string(uint32_t p_code) {
 
 	String codestr;
-	if (p_code & KEY_MASK_SHIFT)
-		codestr += "Shift+";
-	if (p_code & KEY_MASK_ALT)
-		codestr += "Alt+";
-	if (p_code & KEY_MASK_CTRL)
-		codestr += "Ctrl+";
-	if (p_code & KEY_MASK_META)
-		codestr += "Meta+";
+	if (p_code & KEY_MASK_SHIFT) {
+		codestr += find_keycode_name(KEY_SHIFT);
+		codestr += "+";
+	}
+	if (p_code & KEY_MASK_ALT) {
+		codestr += find_keycode_name(KEY_ALT);
+		codestr += "+";
+	}
+	if (p_code & KEY_MASK_CTRL) {
+		codestr += find_keycode_name(KEY_CONTROL);
+		codestr += "+";
+	}
+	if (p_code & KEY_MASK_META) {
+		codestr += find_keycode_name(KEY_META);
+		codestr += "+";
+	}
 
 	p_code &= KEY_CODE_MASK;
 
@@ -431,6 +443,21 @@ int find_keycode(const String &p_code) {
 	}
 
 	return 0;
+}
+
+const char *find_keycode_name(int p_keycode) {
+
+	const _KeyCodeText *kct = &_keycodes[0];
+
+	while (kct->text) {
+
+		if (kct->code == p_keycode) {
+			return kct->text;
+		}
+		kct++;
+	}
+
+	return "";
 }
 
 struct _KeyCodeReplace {

--- a/core/os/keyboard.h
+++ b/core/os/keyboard.h
@@ -326,6 +326,7 @@ enum KeyModifierMask {
 String keycode_get_string(uint32_t p_code);
 bool keycode_has_unicode(uint32_t p_keycode);
 int find_keycode(const String &p_code);
+const char *find_keycode_name(int p_keycode);
 int keycode_get_count();
 int keycode_get_value_by_index(int p_index);
 const char *keycode_get_name_by_index(int p_index);

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -358,7 +358,7 @@ void ProjectSettingsEditor::_wait_for_key(const Ref<InputEvent> &p_event) {
 		last_wait_for_key = p_event;
 		String str = keycode_get_string(k->get_scancode()).capitalize();
 		if (k->get_metakey())
-			str = TTR("Meta+") + str;
+			str = vformat("%s+", find_keycode_name(KEY_META)) + str;
 		if (k->get_shift())
 			str = TTR("Shift+") + str;
 		if (k->get_alt())
@@ -640,7 +640,7 @@ void ProjectSettingsEditor::_update_actions() {
 
 				String str = keycode_get_string(k->get_scancode()).capitalize();
 				if (k->get_metakey())
-					str = TTR("Meta+") + str;
+					str = vformat("%s+", find_keycode_name(KEY_META)) + str;
 				if (k->get_shift())
 					str = TTR("Shift+") + str;
 				if (k->get_alt())

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -248,7 +248,7 @@ void EditorSettingsDialog::_wait_for_key(const Ref<InputEvent> &p_event) {
 		last_wait_for_key = k;
 		String str = keycode_get_string(k->get_scancode()).capitalize();
 		if (k->get_metakey())
-			str = TTR("Meta+") + str;
+			str = vformat("%s+", find_keycode_name(KEY_META)) + str;
 		if (k->get_shift())
 			str = TTR("Shift+") + str;
 		if (k->get_alt())

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -1388,7 +1388,7 @@ bool VisualScriptEditor::can_drop_data_fw(const Point2 &p_point, const Variant &
 			if (String(d["type"]) == "obj_property") {
 
 #ifdef OSX_ENABLED
-				const_cast<VisualScriptEditor *>(this)->_show_hint(TTR("Hold Meta to drop a Getter. Hold Shift to drop a generic signature."));
+				const_cast<VisualScriptEditor *>(this)->_show_hint(vformat(TTR("Hold %s to drop a Getter. Hold Shift to drop a generic signature."), find_keycode_name(KEY_META)));
 #else
 				const_cast<VisualScriptEditor *>(this)->_show_hint(TTR("Hold Ctrl to drop a Getter. Hold Shift to drop a generic signature."));
 #endif
@@ -1397,7 +1397,7 @@ bool VisualScriptEditor::can_drop_data_fw(const Point2 &p_point, const Variant &
 			if (String(d["type"]) == "nodes") {
 
 #ifdef OSX_ENABLED
-				const_cast<VisualScriptEditor *>(this)->_show_hint(TTR("Hold Meta to drop a simple reference to the node."));
+				const_cast<VisualScriptEditor *>(this)->_show_hint(vformat(TTR("Hold %s to drop a simple reference to the node."), find_keycode_name(KEY_META)));
 #else
 				const_cast<VisualScriptEditor *>(this)->_show_hint(TTR("Hold Ctrl to drop a simple reference to the node."));
 #endif
@@ -1406,7 +1406,7 @@ bool VisualScriptEditor::can_drop_data_fw(const Point2 &p_point, const Variant &
 			if (String(d["type"]) == "visual_script_variable_drag") {
 
 #ifdef OSX_ENABLED
-				const_cast<VisualScriptEditor *>(this)->_show_hint(TTR("Hold Meta to drop a Variable Setter."));
+				const_cast<VisualScriptEditor *>(this)->_show_hint(vformat(TTR("Hold %s to drop a Variable Setter."), find_keycode_name(KEY_META)));
 #else
 				const_cast<VisualScriptEditor *>(this)->_show_hint(TTR("Hold Ctrl to drop a Variable Setter."));
 #endif


### PR DESCRIPTION
This is a work-in-progress; not covered are translation strings. I don't know how Godot's translation system works, but ideally the key names should be translated separately using placeholders, and not included literally in the strings.