### PR TITLE
Consistant scroll when using members overview, issue 11648

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1278,7 +1278,11 @@ void ScriptEditor::_members_overview_selected(int p_idx) {
 	if (!se) {
 		return;
 	}
-	se->goto_line(members_overview->get_item_metadata(p_idx));
+	Dictionary state;
+	state["scroll_position"] = members_overview->get_item_metadata(p_idx);
+	state["column"] = 0;
+	state["row"] = members_overview->get_item_metadata(p_idx);
+	se->set_edit_state(state);
 	se->ensure_focus();
 }
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -529,9 +529,9 @@ void ScriptTextEditor::ensure_focus() {
 void ScriptTextEditor::set_edit_state(const Variant &p_state) {
 
 	Dictionary state = p_state;
-	code_editor->get_text_edit()->set_v_scroll(state["scroll_position"]);
 	code_editor->get_text_edit()->cursor_set_column(state["column"]);
 	code_editor->get_text_edit()->cursor_set_line(state["row"]);
+	code_editor->get_text_edit()->set_v_scroll(state["scroll_position"]);
 	code_editor->get_text_edit()->grab_focus();
 
 	//int scroll_pos;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4287,6 +4287,14 @@ int TextEdit::get_v_scroll() const {
 }
 void TextEdit::set_v_scroll(int p_scroll) {
 
+	if (p_scroll < 0) {
+		p_scroll = 0;
+	}
+	if (!scroll_past_end_of_file_enabled) {
+		if (p_scroll + get_visible_rows() > get_line_count()) {
+			p_scroll = get_line_count() - get_visible_rows();
+		}
+	}
 	v_scroll->set_value(p_scroll);
 	cursor.line_ofs = p_scroll;
 }


### PR DESCRIPTION
When selecting a function in members overview it will now always appear as the first line.

closes #11648 