### PR TITLE
[GDnative] create generated include/gdnative_wrapper_code.gen.h

### DIFF
--- a/modules/gdnative/SCsub
+++ b/modules/gdnative/SCsub
@@ -74,7 +74,6 @@ def build_gdnative_api_struct(target, source, env):
     from collections import OrderedDict
 
     with open(source[0].path, 'r') as fd:
-        # Keep the json ordered
         api = json.load(fd)
 
     header, source = target
@@ -109,7 +108,7 @@ def _build_gdnative_wrapper_code(api):
 
     for funcdef in api['api']:
         args = ', '.join(['%s%s' % (_spaced(t), n) for t, n in funcdef['arguments']])
-        out.append('%s %s(%s) {' % (_spaced(funcdef['return_type']), funcdef['name'], args))
+        out.append('%s%s(%s) {' % (_spaced(funcdef['return_type']), funcdef['name'], args))
 
         args = ', '.join(['%s' % n for t, n in funcdef['arguments']])
 
@@ -132,7 +131,6 @@ def _build_gdnative_wrapper_code(api):
 def build_gdnative_wrapper_code(target, source, env):
     import json
     with open(source[0].path, 'r') as fd:
-#Keep the json ordered
         api = json.load(fd)
 
     wrapper_file = target[0]
@@ -143,7 +141,7 @@ def build_gdnative_wrapper_code(target, source, env):
 
 if ARGUMENTS.get('gdnative_wrapper', False):
     #build wrapper code
-    gdn_env.Command('gdnative_wrapper_code.gen.cpp', 'gdnative_api.json', build_gdnative_wrapper_code)
+    gensource, = gdn_env.Command('gdnative_wrapper_code.gen.cpp', 'gdnative_api.json', build_gdnative_wrapper_code)
 
     gd_wrapper_env = env.Clone()
     gd_wrapper_env.Append(CPPPATH=['#modules/gdnative/include/'])
@@ -151,4 +149,4 @@ if ARGUMENTS.get('gdnative_wrapper', False):
     # I think this doesn't work on MSVC yet...
     gd_wrapper_env.Append(CCFLAGS=['-fPIC'])
 
-    gd_wrapper_env.Library("#bin/gdnative_wrapper_code", ["#modules/gdnative/gdnative_wrapper_code.gen.cpp"])
+    gd_wrapper_env.Library("#bin/gdnative_wrapper_code", [gensource])


### PR DESCRIPTION
To use the generated `libgdnative_wrapper_code.*.a` wrapper library, a corresponding header file should be defined.

This PR also fix small related stuff:
- remove now useless comment about json order
- fix style in generated code
- `gd_wrapper_env.Library` use `gensource` object provided by scons instead of it path to avoid errors when the file is not yet generated