### PR TITLE
fix issue 11873.  AudioStreamSample get_data() seems to be misaligned.

### DIFF
--- a/scene/resources/audio_stream_sample.cpp
+++ b/scene/resources/audio_stream_sample.cpp
@@ -486,7 +486,8 @@ PoolVector<uint8_t> AudioStreamSample::get_data() const {
 		{
 
 			PoolVector<uint8_t>::Write w = pv.write();
-			copymem(w.ptr(), data, data_bytes);
+			uint8_t *dataptr = (uint8_t *)data;
+			copymem(w.ptr(), dataptr + DATA_PAD, data_bytes);
 		}
 	}
 


### PR DESCRIPTION
I am using @hi-ogawa  suggestion of padding get_data in AudioStreamSample as shown here.
```
PoolVector<uint8_t>::Write w = pv.write();
uint8_t *dataptr = (uint8_t *)data;
copymem(w.ptr(), dataptr + DATA_PAD, data_bytes); // <= DATA_PAD is added here
```

Although I am trying to access the same indexes as my PoolByteArray that I use to set_data in AudioStreamSample. Somehow, the data is slight different. As I play the sample, I do not notice that much change because the byte array is probably offsetted. This patch just fixes a minor bug.

https://github.com/godotengine/godot/issues/11873