### PR TITLE
[GDnative] fix crash at cleanup time when singleton_gdnatives is not empty

### DIFF
--- a/modules/gdnative/register_types.cpp
+++ b/modules/gdnative/register_types.cpp
@@ -247,6 +247,7 @@ void unregister_gdnative_types() {
 
 		singleton_gdnatives[i]->terminate();
 	}
+	singleton_gdnatives.clear();
 
 	unregister_nativescript_types();
 


### PR DESCRIPTION
When testing gdnative with godot-python, I end up with the following error message when closing Godot: 
```
pure virtual method called
terminate called without an active exception
```

Stacktrace at the time of the crash:
```
* thread #1: tid = 879, 0x00007ffff4cd1428 libc.so.6`__GI_raise(sig=6) + 56 at raise.c:54, name = 'godot.x11.tools', stop reason = signal SIGABRT
  * frame #0: 0x00007ffff4cd1428 libc.so.6`__GI_raise(sig=6) + 56 at raise.c:54
    frame #1: 0x00007ffff4cd302a libc.so.6`__GI_abort + 362 at abort.c:89
    frame #2: 0x00007ffff561484d libstdc++.so.6`__gnu_cxx::__verbose_terminate_handler() + 365
    frame #3: 0x00007ffff56126b6 libstdc++.so.6`??? + 6
    frame #4: 0x00007ffff5612701 libstdc++.so.6`std::terminate() + 17
    frame #5: 0x00007ffff561323f libstdc++.so.6`__cxa_pure_virtual + 31
    frame #6: 0x00000000023d8ae7 godot.x11.tools.64`StringName::unref(this=0x0000000004580d00) + 195 at string_db.cpp:101
    frame #7: 0x00000000023da064 godot.x11.tools.64`StringName::~StringName(this=0x0000000004580d00) + 24 at string_db.cpp:432
    frame #8: 0x0000000000f372ed godot.x11.tools.64`GDNativeLibrary::~GDNativeLibrary(this=0x0000000004580b90) + 101 at gdnative.cpp:100
    frame #9: 0x0000000000dbacbb godot.x11.tools.64`void memdelete<GDNativeLibrary>(p_class=0x0000000004580b90) + 56 at memory.h:109
    frame #10: 0x0000000000dba2dc godot.x11.tools.64`Ref<GDNativeLibrary>::unref(this=0x000000000457f468) + 74 at reference.h:262
    frame #11: 0x0000000000db9276 godot.x11.tools.64`Ref<GDNativeLibrary>::~Ref(this=0x000000000457f468) + 24 at reference.h:278
    frame #12: 0x0000000000f3820b ecgodot.x11.tools.64`GDNative::~GDNative(this=0x000000000457f370) + 43 at gdnative.cpp:186
    frame #13: 0x0000000000dbaf5b godot.x11.tools.64`void memdelete<GDNative>(p_class=0x000000000457f370) + 56 at memory.h:109
    frame #14: 0x0000000000dbada8 godot.x11.tools.64`Ref<GDNative>::unref(this=0x000000000457efd0) + 74 at reference.h:262
    frame #15: 0x0000000000dba73c godot.x11.tools.64`Ref<GDNative>::~Ref(this=0x000000000457efd0) + 24 at reference.h:278
    frame #16: 0x0000000000dba4b3 godot.x11.tools.64`Vector<Ref<GDNative> >::_unref(this=0x00000000037d68e0, p_data=0x000000000457efd0) + 153 at vector.h:205
    frame #17: 0x0000000000dbaf94 godot.x11.tools.64`Vector<Ref<GDNative> >::~Vector(this=0x00000000037d68e0) + 34 at vector.h:425
    frame #18: 0x00007ffff4cd5ff8 libc.so.6`__run_exit_handlers(status=0, listp=0x00007ffff50605f8, run_list_atexit=<unavailable>) + 232 at exit.c:82
    frame #19: 0x00007ffff4cd6045 libc.so.6`__GI_exit(status=<unavailable>) + 21 at exit.c:104
    frame #20: 0x00007ffff4cbc837 libc.so.6`__libc_start_main(main=<unavailable>, argc=<unavailable>, argv=<unavailable>, init=<unavailable>, fini=<unavailable>, rtld_fini=<unavailable>, stack_end=0x00007fffffffde38) + 247 at libc-start.c:325
    frame #21: 0x0000000000d42e49 godot.x11.tools.64`_start + 41
```

I believe the trouble is due to the fact `StringName::cleanup` has already been called when `singleton_gdnatives` is destroyed, however given this vector still contains elements (with `StringName` field inside them) at this time, they get destroyed themselves which cause the crash.
The solution is simply to reset the vector to a size of 0 in `unregister_gdnative_types`.