### PR TITLE
Added 'exposed' field to ClassInfo for registered classes

### DIFF
--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -205,6 +205,7 @@ ClassDB::ClassInfo::ClassInfo() {
 	creation_func = NULL;
 	inherits_ptr = NULL;
 	disabled = false;
+	exposed = false;
 }
 ClassDB::ClassInfo::~ClassInfo() {
 }
@@ -1282,6 +1283,15 @@ bool ClassDB::is_class_enabled(StringName p_class) {
 
 	ERR_FAIL_COND_V(!ti, false);
 	return !ti->disabled;
+}
+
+bool ClassDB::is_class_exposed(StringName p_class) {
+
+	OBJTYPE_RLOCK;
+
+	ClassInfo *ti = classes.getptr(p_class);
+	ERR_FAIL_COND_V(!ti, false);
+	return ti->exposed;
 }
 
 StringName ClassDB::get_category(const StringName &p_node) {

--- a/core/class_db.h
+++ b/core/class_db.h
@@ -127,6 +127,7 @@ public:
 		StringName inherits;
 		StringName name;
 		bool disabled;
+		bool exposed;
 		Object *(*creation_func)();
 		ClassInfo();
 		~ClassInfo();
@@ -168,6 +169,7 @@ public:
 		ClassInfo *t = classes.getptr(T::get_class_static());
 		ERR_FAIL_COND(!t);
 		t->creation_func = &creator<T>;
+		t->exposed = true;
 		T::register_custom_data_to_otdb();
 	}
 
@@ -176,6 +178,9 @@ public:
 
 		GLOBAL_LOCK_FUNCTION;
 		T::initialize_class();
+		ClassInfo *t = classes.getptr(T::get_class_static());
+		ERR_FAIL_COND(!t);
+		t->exposed = true;
 		//nothing
 	}
 
@@ -193,6 +198,7 @@ public:
 		ClassInfo *t = classes.getptr(T::get_class_static());
 		ERR_FAIL_COND(!t);
 		t->creation_func = &_create_ptr_func<T>;
+		t->exposed = true;
 		T::register_custom_data_to_otdb();
 	}
 
@@ -346,6 +352,8 @@ public:
 
 	static void set_class_enabled(StringName p_class, bool p_enable);
 	static bool is_class_enabled(StringName p_class);
+
+	static bool is_class_exposed(StringName p_class);
 
 	static void add_resource_base_extension(const StringName &p_extension, const StringName &p_class);
 	static void get_resource_base_extensions(List<String> *p_extensions);

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -40,6 +40,7 @@
 #include "io/config_file.h"
 #include "io/http_client.h"
 #include "io/marshalls.h"
+#include "io/networked_multiplayer_peer.h"
 #include "io/packet_peer.h"
 #include "io/packet_peer_udp.h"
 #include "io/pck_packer.h"
@@ -109,6 +110,8 @@ void register_core_types() {
 
 	ClassDB::register_class<Object>();
 
+	ClassDB::register_virtual_class<Script>();
+
 	ClassDB::register_class<Reference>();
 	ClassDB::register_class<WeakRef>();
 	ClassDB::register_class<Resource>();
@@ -136,6 +139,7 @@ void register_core_types() {
 	ClassDB::register_virtual_class<IP>();
 	ClassDB::register_virtual_class<PacketPeer>();
 	ClassDB::register_class<PacketPeerStream>();
+	ClassDB::register_virtual_class<NetworkedMultiplayerPeer>();
 	ClassDB::register_class<MainLoop>();
 	//ClassDB::register_type<OptimizedSaver>();
 	ClassDB::register_class<Translation>();
@@ -184,6 +188,20 @@ void register_core_settings() {
 }
 
 void register_core_singletons() {
+
+	ClassDB::register_class<ProjectSettings>();
+	ClassDB::register_virtual_class<IP>();
+	ClassDB::register_class<_Geometry>();
+	ClassDB::register_class<_ResourceLoader>();
+	ClassDB::register_class<_ResourceSaver>();
+	ClassDB::register_class<_OS>();
+	ClassDB::register_class<_Engine>();
+	ClassDB::register_class<_ClassDB>();
+	ClassDB::register_class<_Marshalls>();
+	ClassDB::register_class<TranslationServer>();
+	ClassDB::register_virtual_class<Input>();
+	ClassDB::register_class<InputMap>();
+	ClassDB::register_class<_JSON>();
 
 	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("ProjectSettings", ProjectSettings::get_singleton()));
 	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("IP", IP::get_singleton()));

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -256,6 +256,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	translation_server = memnew(TranslationServer);
 	performance = memnew(Performance);
+	ClassDB::register_class<Performance>();
 	globals->add_singleton(ProjectSettings::Singleton("Performance", performance));
 
 	GLOBAL_DEF("debug/settings/crash_handler/message", String("Please include this when reporting the bug on https://github.com/godotengine/godot/issues"));

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -654,6 +654,13 @@ void *CSharpLanguage::alloc_instance_binding_data(Object *p_object) {
 
 	StringName type_name = p_object->get_class_name();
 
+	// ¯\_(ツ)_/¯
+	const ClassDB::ClassInfo *classinfo = ClassDB::classes.getptr(type_name);
+	while (classinfo && !classinfo->exposed)
+		classinfo = classinfo->inherits_ptr;
+	ERR_FAIL_NULL_V(classinfo, NULL);
+	type_name = classinfo->name;
+
 	GDMonoClass *type_class = GDMonoUtils::type_get_proxy_class(type_name);
 
 	ERR_FAIL_NULL_V(type_class, NULL);

--- a/modules/mono/register_types.cpp
+++ b/modules/mono/register_types.cpp
@@ -44,6 +44,7 @@ void register_mono_types() {
 
 	_godotsharp = memnew(_GodotSharp);
 
+	ClassDB::register_class<_GodotSharp>();
 	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("GodotSharp", _GodotSharp::get_singleton()));
 
 	script_language_cs = memnew(CSharpLanguage);

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -261,9 +261,11 @@ void register_scene_types() {
 	ClassDB::register_class<Control>();
 	ClassDB::register_class<Button>();
 	ClassDB::register_class<Label>();
+	ClassDB::register_class<ScrollBar>();
 	ClassDB::register_class<HScrollBar>();
 	ClassDB::register_class<VScrollBar>();
 	ClassDB::register_class<ProgressBar>();
+	ClassDB::register_class<Slider>();
 	ClassDB::register_class<HSlider>();
 	ClassDB::register_class<VSlider>();
 	ClassDB::register_class<Popup>();
@@ -347,6 +349,7 @@ void register_scene_types() {
 #ifndef _3D_DISABLED
 	ClassDB::register_class<BoneAttachment>();
 	ClassDB::register_virtual_class<VisualInstance>();
+	ClassDB::register_virtual_class<GeometryInstance>();
 	ClassDB::register_class<Camera>();
 	ClassDB::register_class<Listener>();
 	ClassDB::register_class<ARVRCamera>();
@@ -356,6 +359,7 @@ void register_scene_types() {
 	ClassDB::register_class<InterpolatedCamera>();
 	ClassDB::register_class<MeshInstance>();
 	ClassDB::register_class<ImmediateGeometry>();
+	ClassDB::register_virtual_class<SpriteBase3D>();
 	ClassDB::register_class<Sprite3D>();
 	ClassDB::register_class<AnimatedSprite3D>();
 	ClassDB::register_virtual_class<Light>();
@@ -375,6 +379,7 @@ void register_scene_types() {
 	OS::get_singleton()->yield(); //may take time to init
 
 	ClassDB::register_virtual_class<CollisionObject>();
+	ClassDB::register_virtual_class<PhysicsBody>();
 	ClassDB::register_class<StaticBody>();
 	ClassDB::register_class<RigidBody>();
 	ClassDB::register_class<KinematicCollision>();
@@ -489,6 +494,7 @@ void register_scene_types() {
 
 	OS::get_singleton()->yield(); //may take time to init
 
+	ClassDB::register_virtual_class<Shape>();
 	ClassDB::register_class<RayShape>();
 	ClassDB::register_class<SphereShape>();
 	ClassDB::register_class<BoxShape>();
@@ -526,6 +532,7 @@ void register_scene_types() {
 	ClassDB::register_class<DynamicFontData>();
 	ClassDB::register_class<DynamicFont>();
 
+	ClassDB::register_virtual_class<StyleBox>();
 	ClassDB::register_class<StyleBoxEmpty>();
 	ClassDB::register_class<StyleBoxTexture>();
 	ClassDB::register_class<StyleBoxFlat>();

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -79,6 +79,12 @@ ARVRServer *arvr_server = NULL;
 void register_server_types() {
 	arvr_server = memnew(ARVRServer);
 
+	ClassDB::register_virtual_class<VisualServer>();
+	ClassDB::register_class<AudioServer>();
+	ClassDB::register_virtual_class<PhysicsServer>();
+	ClassDB::register_virtual_class<Physics2DServer>();
+	ClassDB::register_class<ARVRServer>();
+
 	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("VisualServer", VisualServer::get_singleton()));
 	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("AudioServer", AudioServer::get_singleton()));
 	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("PhysicsServer", PhysicsServer::get_singleton()));
@@ -95,6 +101,8 @@ void register_server_types() {
 	ClassDB::register_virtual_class<AudioStreamPlayback>();
 	ClassDB::register_class<AudioStreamRandomPitch>();
 	ClassDB::register_virtual_class<AudioEffect>();
+	ClassDB::register_class<AudioEffectEQ>();
+	ClassDB::register_class<AudioEffectFilter>();
 	ClassDB::register_class<AudioBusLayout>();
 
 	{


### PR DESCRIPTION
Closes #11913

This is my proposal at fixing the issue I [describe here](https://github.com/godotengine/godot/issues/11913#issuecomment-334967216).

It's a radical change because it forces classes to be registered manually in order to be exposed to scripting languages. However, I think this is the way to go.

I didn't change anything regarding the class reference generation myself, but it should ignore classes that are not exposed.
