### PR TITLE
Fix front face definition

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2140,7 +2140,6 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 		first = false;
 	}
 
-	glFrontFace(GL_CW);
 	glBindVertexArray(0);
 
 	state.scene_shader.set_conditional(SceneShaderGLES3::USE_INSTANCING, false);
@@ -5024,6 +5023,8 @@ void RasterizerSceneGLES3::initialize() {
 	}
 
 	state.debug_draw = VS::VIEWPORT_DEBUG_DRAW_DISABLED;
+
+	glFrontFace(GL_CW);
 }
 
 void RasterizerSceneGLES3::iteration() {


### PR DESCRIPTION
This will fix the shadow artifact reported in this issue https://github.com/godotengine/godot/issues/11848 (the first issue of the two issueses reported there).

I will explain a bit more detail even though the commit is so small.
I found that the first call of `RasterizerSceneGLES3::_render_list` (more specifically, `_render_geometry` and `glDrawXXX` from that function) uses front face mode `GL_CCW` (counter clock wise) since that's the default value and `glFrontFace(GL_CW)` is only called at the end of the `RasterizerSceneGLES3::_render_list`.
This led to the opposite front face definition when we generate shadow map for the first time in the application lifetime, which causes shadow artifact as in that issue.
Another thing to note is that shadow map is not re-drawed in every frame when scene is static, so the first wrong front face shadow map is continued to be used in that case.

I figured this type of one-time gl state setup can be in `RasterizerSceneGLES3::initialize`, so that's what my PR is.
