### PR TITLE
Track LightInstance::shadow_atlases so that it will be freed properly

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -379,6 +379,7 @@ bool RasterizerSceneGLES3::shadow_atlas_update_light(RID p_atlas, RID p_light_in
 			sh->owner = p_light_intance;
 			sh->alloc_tick = tick;
 			sh->version = p_light_version;
+			li->shadow_atlases.insert(p_atlas);
 
 			//make new key
 			key = new_quadrant << ShadowAtlas::QUADRANT_SHIFT;
@@ -414,6 +415,7 @@ bool RasterizerSceneGLES3::shadow_atlas_update_light(RID p_atlas, RID p_light_in
 		sh->owner = p_light_intance;
 		sh->alloc_tick = tick;
 		sh->version = p_light_version;
+		li->shadow_atlases.insert(p_atlas);
 
 		//make new key
 		uint32_t key = new_quadrant << ShadowAtlas::QUADRANT_SHIFT;


### PR DESCRIPTION
This will fix the issues https://github.com/godotengine/godot/issues/11848 (the second issuse (endless error message on scene change) of two issues reported there) and its duplicate https://github.com/godotengine/godot/issues/10346.

My observation on this issue is as follows.

`LightInstance::shadow_atlases` is supposed to be freed from `RasterizerSceneGLES3::free(RID p_rid)`, but currently it turns out nothing is added to the `Set` data structure `light_instance->shadow_atlases`. So what I changed in this commit is adding `light_instance->shadow_atlases.insert(...)` where it seems appropriate, which is after successful `RasterizerSceneGLES3::_shadow_atlas_find_shadow`.