### PR TITLE
Fix trailing whitespaces in project settings header comment

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -667,8 +667,8 @@ Error ProjectSettings::_save_settings_text(const String &p_file, const Map<Strin
 	file->store_line("; Engine configuration file.");
 	file->store_line("; It's best edited using the editor UI and not directly,");
 	file->store_line("; since the parameters that go here are not all obvious.");
-	file->store_line("; ");
-	file->store_line("; Format: ");
+	file->store_line(";");
+	file->store_line("; Format:");
 	file->store_line(";   [section] ; section goes between []");
 	file->store_line(";   param=value ; assign values to parameters");
 	file->store_line("");


### PR DESCRIPTION
Because it hurts to see those red squared when doing a `git diff` otherwise ;-)