### PR TITLE
[2.1] Do not allow link-local addresses to be used by editor debugger

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -410,7 +410,7 @@ void EditorSettings::setup_network() {
 
 	List<IP_Address> local_ip;
 	IP::get_singleton()->get_local_addresses(&local_ip);
-	String lip;
+	String lip = "127.0.0.1";
 	String hint;
 	String current = has("network/debug_host") ? get("network/debug_host") : "";
 	int port = has("network/debug_port") ? (int)get("network/debug_port") : 6096;
@@ -419,8 +419,9 @@ void EditorSettings::setup_network() {
 
 		String ip = E->get();
 
-		if (lip == "")
-			lip = ip;
+		// link-local IPv6 addresses don't work, skipping them
+		if (ip.begins_with("fe80:0:0:0:")) // fe80::/64
+			continue;
 		if (ip == current)
 			lip = current; //so it saves
 		if (hint != "")


### PR DESCRIPTION
Disallow link-local addresses to be used by editor debugger
Default editor debugger address is now 127.0.0.1.
This fixes editor connection issues on some platforms for `2.1` branch. (see #11378 )

NOTE
---

In #1287 some people refers to this bug, but the OP issue there (no editor debugger output when printing in an infinite loop) is NOT fixed.
We need some form of TX control when sending debugger data for that as explained by reduz.

(cherry picked from commit 72b4a09a1402cb3807f1c3454ed5274dff67d0ae)