### PR TITLE
Add simple spacebar panning setting for 2D editor

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -733,6 +733,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("editors/2d/bone_ik_color", Color(0.9, 0.9, 0.45, 0.9));
 	_initial_set("editors/2d/keep_margins_when_changing_anchors", false);
 	_initial_set("editors/2d/warped_mouse_panning", true);
+	_initial_set("editors/2d/simple_spacebar_panning", false);
 	_initial_set("editors/2d/scroll_to_pan", false);
 	_initial_set("editors/2d/pan_speed", 20);
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1632,7 +1632,17 @@ void CanvasItemEditor::_viewport_base_gui_input(const Ref<InputEvent> &p_event) 
 		}
 
 		if (drag == DRAG_NONE) {
-			if (((m->get_button_mask() & BUTTON_MASK_LEFT) && tool == TOOL_PAN) || (m->get_button_mask() & BUTTON_MASK_MIDDLE) || ((m->get_button_mask() & BUTTON_MASK_LEFT) && Input::get_singleton()->is_key_pressed(KEY_SPACE))) {
+			bool space_pressed = Input::get_singleton()->is_key_pressed(KEY_SPACE);
+			bool simple_panning = EditorSettings::get_singleton()->get("editors/2d/simple_spacebar_panning");
+			int button = m->get_button_mask();
+
+			// Check if any of the panning triggers are activated
+			bool panning_tool = (button & BUTTON_MASK_LEFT) && tool == TOOL_PAN;
+			bool panning_middle_button = button & BUTTON_MASK_MIDDLE;
+			bool panning_spacebar = (button & BUTTON_MASK_LEFT) && space_pressed;
+			bool panning_spacebar_simple = space_pressed && simple_panning;
+
+			if (panning_tool || panning_middle_button || panning_spacebar || panning_spacebar_simple) {
 				// Pan the viewport
 				Point2i relative;
 				if (bool(EditorSettings::get_singleton()->get("editors/2d/warped_mouse_panning"))) {


### PR DESCRIPTION
I'm a new contributor, so I'll be starting small with an usability-focused contribution.

This PR adds a new option to the 2D editor settings called "Simple Spacebar Panning", which changes the spacebar panning behavior so that it doesn't require the left mouse button to be held down anymore. This addition is mainly geared towards trackpad users, but it might also be useful to people with dodgy mouse buttons, and isn't intrusive at all.

However, the setting probably needs a better name before it's merged. "Simple" isn't really descriptive about what it does, and the lack of tooltips in the rest of the settings menu makes it a bit awkward to add one just for this setting.