### PR TITLE
Fix export(float ...) so that step is .01 

### DIFF
--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -376,7 +376,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 			if (hint == PROPERTY_HINT_RANGE) {
 
 				int c = hint_text.get_slice_count(",");
-				float min = 0, max = 100, step = .01;
+				float min = 0, max = 100, step = type == Variant::REAL ? .01 : 1;
 				if (c >= 1) {
 
 					if (!hint_text.get_slice(",", 0).empty())
@@ -3032,7 +3032,7 @@ void PropertyEditor::update_tree() {
 				if (p.hint == PROPERTY_HINT_SPRITE_FRAME || p.hint == PROPERTY_HINT_RANGE || p.hint == PROPERTY_HINT_EXP_RANGE) {
 
 					int c = p.hint_string.get_slice_count(",");
-					float min = 0, max = 100, step = .01;
+					float min = 0, max = 100, step = p.type == Variant::REAL ? .01 : 1;
 					if (c >= 1) {
 
 						min = p.hint_string.get_slice(",", 0).to_double();

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -376,7 +376,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 			if (hint == PROPERTY_HINT_RANGE) {
 
 				int c = hint_text.get_slice_count(",");
-				float min = 0, max = 100, step = 1;
+				float min = 0, max = 100, step = .01;
 				if (c >= 1) {
 
 					if (!hint_text.get_slice(",", 0).empty())
@@ -3032,7 +3032,7 @@ void PropertyEditor::update_tree() {
 				if (p.hint == PROPERTY_HINT_SPRITE_FRAME || p.hint == PROPERTY_HINT_RANGE || p.hint == PROPERTY_HINT_EXP_RANGE) {
 
 					int c = p.hint_string.get_slice_count(",");
-					float min = 0, max = 100, step = 1;
+					float min = 0, max = 100, step = .01;
 					if (c >= 1) {
 
 						min = p.hint_string.get_slice(",", 0).to_double();


### PR DESCRIPTION
So that in the property editor the range does not increment by integer step. Fix for #11964 

@bojidar-bg pointed out those lines so I changed both. It's my first contribution to godot, so be blunt if I'm doing something wrong. Also if someone could explain to me what the functions I adjusted achieve on a higher level I'd appreciate that. I understand that it has something to do with display when the property editor is updated, but some more info would be cool. 

*Bugsquad edit:* Fixes #11964.