### PR TITLE
Skip unhandled input events on asset library tab. (3.0)

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -750,6 +750,9 @@ void ProjectManager::_unhandled_input(const Ref<InputEvent> &p_ev) {
 		if (!k->is_pressed())
 			return;
 
+		if (tabs->get_current_tab() != 0)
+			return;
+
 		bool scancode_handled = true;
 
 		switch (k->get_scancode()) {


### PR DESCRIPTION
Ported https://github.com/godotengine/godot/pull/11977 on 3.0 