### PR TITLE
Fix AnimatedSprite frame property slider in editor

### DIFF
--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -298,10 +298,8 @@ void AnimatedSprite::_validate_property(PropertyInfo &property) const {
 
 		property.hint = PROPERTY_HINT_SPRITE_FRAME;
 
-		if (frames->has_animation(animation)) {
+		if (frames->has_animation(animation) && frames->get_frame_count(animation) > 1) {
 			property.hint_string = "0," + itos(frames->get_frame_count(animation) - 1) + ",1";
-		} else {
-			property.hint_string = "0,0,0";
 		}
 	}
 }


### PR DESCRIPTION
This will fix https://github.com/godotengine/godot/issues/11898.

I was thinking about handling the case where `Range::get_as_ratio` returns NAN when minimum == maximum, but I felt what's wrong in the first place is the AnimatedSprite's property hint producing such range. So, I work around this issue in the way that it produces property range hint only when it holds that minimum < maximum.

When there's no `hint_string` given, property editor fallback to `min = 0, max = 100, step = 1` and it seems wrong, but `AnimatedSprite::set_frame` anyway validates new value to be correct, so I think that's all right.