### PR TITLE
Do not override window setting defaults

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -797,16 +797,19 @@ Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_cust
 	return OK;
 }
 
-Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default) {
+Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_override_default) {
 
 	Variant ret;
 	if (ProjectSettings::get_singleton()->has_setting(p_var)) {
 		ret = ProjectSettings::get_singleton()->get(p_var);
 	} else {
 		ProjectSettings::get_singleton()->set(p_var, p_default);
+		p_override_default = true;
 		ret = p_default;
 	}
-	ProjectSettings::get_singleton()->set_initial_value(p_var, p_default);
+	if (p_override_default) {
+		ProjectSettings::get_singleton()->set_initial_value(p_var, p_default);
+	}
 	ProjectSettings::get_singleton()->set_builtin_order(p_var);
 	return ret;
 }

--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -168,8 +168,9 @@ public:
 };
 
 //not a macro any longer
-Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default);
-#define GLOBAL_DEF(m_var, m_value) _GLOBAL_DEF(m_var, m_value)
+Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_override_default);
+#define GLOBAL_DEF(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true)
+#define GLOBAL_DEF_MISSING(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false)
 #define GLOBAL_GET(m_var) ProjectSettings::get_singleton()->get(m_var)
 
 #endif

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -762,15 +762,19 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		}
 	}
 
-	GLOBAL_DEF("display/window/size/width", video_mode.width);
-	GLOBAL_DEF("display/window/size/height", video_mode.height);
-	GLOBAL_DEF("display/window/dpi/allow_hidpi", false);
-	GLOBAL_DEF("display/window/size/fullscreen", video_mode.fullscreen);
-	GLOBAL_DEF("display/window/size/resizable", video_mode.resizable);
-	GLOBAL_DEF("display/window/size/borderless", video_mode.borderless_window);
-	use_vsync = GLOBAL_DEF("display/window/vsync/use_vsync", use_vsync);
-	GLOBAL_DEF("display/window/size/test_width", 0);
-	GLOBAL_DEF("display/window/size/test_height", 0);
+	// these settings may have been retrieved above, we should not
+	// override their defaults with retrieved values
+	GLOBAL_DEF_MISSING("display/window/size/width", video_mode.width);
+	GLOBAL_DEF_MISSING("display/window/size/height", video_mode.height);
+	GLOBAL_DEF_MISSING("display/window/dpi/allow_hidpi", false);
+	GLOBAL_DEF_MISSING("display/window/dpi/allow_hidpi", false);
+	GLOBAL_DEF_MISSING("display/window/size/fullscreen", video_mode.fullscreen);
+	GLOBAL_DEF_MISSING("display/window/size/resizable", video_mode.resizable);
+	GLOBAL_DEF_MISSING("display/window/size/borderless", video_mode.borderless_window);
+	use_vsync = GLOBAL_DEF_MISSING("display/window/vsync/use_vsync", use_vsync);
+	GLOBAL_DEF_MISSING("display/window/size/test_width", 0);
+	GLOBAL_DEF_MISSING("display/window/size/test_height", 0);
+
 	GLOBAL_DEF("rendering/quality/intended_usage/framebuffer_allocation", 2);
 	GLOBAL_DEF("rendering/quality/intended_usage/framebuffer_allocation.mobile", 3);
 


### PR DESCRIPTION
When exporting project settings, Godot only export values not equal to
their defaults. Before this fix exporting project from command line
omitted display/window/size settings, because their default values
were set from existing values in project settings, so Godot considered
them unchanged.

This commit adds GLOBAL_DEF_MISSING macro which only overrides the
setting's default value if the setting did not already exist.