### PR TITLE
Changed the export and fix dependencies dialog cancel button names to "Close"

### DIFF
--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -494,7 +494,7 @@ DependencyErrorDialog::DependencyErrorDialog() {
 	vb->add_margin_child(TTR("Scene failed to load due to missing dependencies:"), files, true);
 	files->set_v_size_flags(SIZE_EXPAND_FILL);
 	get_ok()->set_text(TTR("Open Anyway"));
-	get_cancel()->set_text(TTR("Done"));
+	get_cancel()->set_text(TTR("Close"));
 
 	text = memnew(Label);
 	vb->add_child(text);

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -915,6 +915,7 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	updating = false;
 
+	get_cancel()->set_text(TTR("Close"));
 	get_ok()->set_text(TTR("Export PCK/Zip"));
 	export_button = add_button(TTR("Export Project"), !OS::get_singleton()->get_swap_ok_cancel(), "export");
 


### PR DESCRIPTION
This is a very basic change. "Cancel" in the export dialog leaves the impression your changes will be lost when pressing the button. "Close" implies they will be kept, as is the case.

edit: Changed from "Done" to "Close" as this seems to make more sense and it consistent with other dialogs. Also changed the "Fix Dependencies" from "Done" to "Close". "Project Settings", "Editor Settings" and "Manage Export Templates" all use the word "Close" on the cancel button.