### PR TITLE
Fix viewport vflip

### DIFF
--- a/drivers/gles3/shaders/tonemap.glsl
+++ b/drivers/gles3/shaders/tonemap.glsl
@@ -175,12 +175,9 @@ vec3 tonemap_reindhart(vec3 color,float white) {
 	return ( color * ( 1.0 + ( color / ( white) ) ) ) / ( 1.0 + color );
 }
 
-
 void main() {
 
-	ivec2 coord = ivec2(gl_FragCoord.xy);
-	vec3 color = texelFetch(source,coord,0).rgb;
-
+	vec4 color = textureLod(source, uv_interp, 0.0);
 
 #ifdef USE_AUTO_EXPOSURE
 
@@ -324,5 +321,3 @@ void main() {
 
 	frag_color=vec4(color.rgb,1.0);
 }
-
-


### PR DESCRIPTION
Following my comment here https://github.com/godotengine/godot/pull/11067#issuecomment-336030908, this will fix viewport vflip in a way that it still keeps post process specified from WorldEnvironment (eg dof, bloom, tonemap).

Here I use `uv_interp` instread of `gl_FragCoord` since `uv_interp` is already vertically flipped in the vertex shader.