### PR TITLE
DirAccessWindows: fix wrong path given to CreateDirectoryW, fixes #12019

### DIFF
--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -164,7 +164,7 @@ Error DirAccessWindows::make_dir(String p_dir) {
 
 	p_dir = fix_path(p_dir);
 	if (p_dir.is_rel_path())
-		p_dir = get_current_dir().plus_file(p_dir);
+		p_dir = current_dir.plus_file(p_dir);
 
 	p_dir = p_dir.replace("/", "\\");
 


### PR DESCRIPTION
*Bugsquad edit*: Fixes #12019

get_current_dir() prepends "res:/" to the path, which the CreateWindowsW function can't handle. The now used current_dir variable contains an absolute path, which the function can handle.

This prevented the editor from creating new folders in the "Save scene as.." dialogue, as well as creating a subdir when reimporting assets.