### PR TITLE
Remove junk output

### DIFF
--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -62,12 +62,12 @@ Error FileAccessEncrypted::open_and_parse(FileAccess *p_base, const Vector<uint8
 		writing = false;
 		key = p_key;
 		uint32_t magic = p_base->get_32();
-		print_line("MAGIC: " + itos(magic));
 		ERR_FAIL_COND_V(magic != COMP_MAGIC, ERR_FILE_UNRECOGNIZED);
+
 		mode = Mode(p_base->get_32());
 		ERR_FAIL_INDEX_V(mode, MODE_MAX, ERR_FILE_CORRUPT);
 		ERR_FAIL_COND_V(mode == 0, ERR_FILE_CORRUPT);
-		print_line("MODE: " + itos(mode));
+
 		unsigned char md5d[16];
 		p_base->get_buffer(md5d, 16);
 		length = p_base->get_64();

--- a/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
@@ -129,7 +129,6 @@ AudioStreamPlaybackOGGVorbis::~AudioStreamPlaybackOGGVorbis() {
 Ref<AudioStreamPlayback> AudioStreamOGGVorbis::instance_playback() {
 
 	Ref<AudioStreamPlaybackOGGVorbis> ovs;
-	printf("instance at %p, data %p\n", this, data);
 
 	ERR_FAIL_COND_V(data == NULL, ovs);
 
@@ -208,8 +207,6 @@ void AudioStreamOGGVorbis::set_data(const PoolVector<uint8_t> &p_data) {
 			break;
 		}
 	}
-
-	printf("create at %p, data %p\n", this, data);
 }
 
 PoolVector<uint8_t> AudioStreamOGGVorbis::get_data() const {

--- a/scene/3d/particles.cpp
+++ b/scene/3d/particles.cpp
@@ -462,8 +462,6 @@ void ParticlesMaterial::finish_shaders() {
 
 void ParticlesMaterial::_update_shader() {
 
-	print_line("updating shader");
-
 	dirty_materials.remove(&element);
 
 	MaterialKey mk = _compute_key();
@@ -913,9 +911,7 @@ void ParticlesMaterial::_queue_shader_change() {
 	if (material_mutex)
 		material_mutex->lock();
 
-	print_line("queuing change");
 	if (!element.in_list()) {
-		print_line("not in list, adding");
 		dirty_materials.add(&element);
 	}
 

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -43,8 +43,6 @@ void Shader::set_code(const String &p_code) {
 
 	String type = ShaderLanguage::get_shader_type(p_code);
 
-	print_line("mode: " + type);
-
 	if (type == "canvas_item") {
 		mode = MODE_CANVAS_ITEM;
 	} else if (type == "particles") {


### PR DESCRIPTION
Remove several prints that were added for engine debugging, but are
of no use to the end user, and only pollute the editor and game logs.