### PR TITLE
Add .xml to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@ drivers/* linguist-vendored
 *.h eol=lf
 *.py eol=lf
 *.hpp eol=lf
+*.xml eol=lf


### PR DESCRIPTION
Note sure if I did anything wrong and this isn't needed, or if this is the right thing to do, but I got the feeling that git wanted to change all the documentation to CRLF when running --doctools on windows...