### PR TITLE
Fix Alpha Border bugfix

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -2474,6 +2474,7 @@ void Image::fix_alpha_edges() {
 					if (rp[3] < alpha_threshold)
 						continue;
 
+					closest_dist = dist;
 					closest_color[0] = rp[0];
 					closest_color[1] = rp[1];
 					closest_color[2] = rp[2];


### PR DESCRIPTION
This PR fixes Alpha Border fix, which was in this issue by art-kandy:
https://github.com/godotengine/godot/issues/12033

Fix Alpha Border in import now works well
<img width="1034" alt="2017-10-13 16 07 13" src="https://user-images.githubusercontent.com/6551114/31547597-a263823a-b030-11e7-99e5-df090ab2ca7d.png">

