### PR TITLE
Use binary names instead of absolute paths in calls to OS::execute.

### DIFF
--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -397,7 +397,7 @@ Error EditorExportPlatformIOS::_codesign(String p_file, void *p_userdata) {
 		codesign_args.push_back("-s");
 		codesign_args.push_back(data->preset->get(data->debug ? "application/code_sign_identity_debug" : "application/code_sign_identity_release"));
 		codesign_args.push_back(p_file);
-		return OS::get_singleton()->execute("/usr/bin/codesign", codesign_args, true);
+		return OS::get_singleton()->execute("codesign", codesign_args, true);
 	}
 	return OK;
 }
@@ -608,7 +608,7 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 	archive_args.push_back("archive");
 	archive_args.push_back("-archivePath");
 	archive_args.push_back(archive_path);
-	err = OS::get_singleton()->execute("/usr/bin/xcodebuild", archive_args, true);
+	err = OS::get_singleton()->execute("xcodebuild", archive_args, true);
 	ERR_FAIL_COND_V(err, err);
 
 	ep.step("Code-signing dylibs", 3);
@@ -628,7 +628,7 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 	export_args.push_back(dest_dir + "export_options.plist");
 	export_args.push_back("-exportPath");
 	export_args.push_back(dest_dir);
-	err = OS::get_singleton()->execute("/usr/bin/xcodebuild", export_args, true);
+	err = OS::get_singleton()->execute("xcodebuild", export_args, true);
 	ERR_FAIL_COND_V(err, err);
 #else
 	print_line(".ipa can only be built on macOS. Leaving XCode project without building the package.");

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -244,7 +244,7 @@ Error EditorExportPlatformOSX::_code_sign(const Ref<EditorExportPreset> &p_prese
 	args.push_back(p_path);
 
 	String str;
-	Error err = OS::get_singleton()->execute("/usr/bin/codesign", args, true, NULL, &str, NULL, true);
+	Error err = OS::get_singleton()->execute("codesign", args, true, NULL, &str, NULL, true);
 	ERR_FAIL_COND_V(err != OK, err);
 
 	print_line("codesign: " + str);
@@ -271,7 +271,7 @@ Error EditorExportPlatformOSX::_create_dmg(const String &p_dmg_path, const Strin
 	args.push_back(p_app_path_name);
 
 	String str;
-	Error err = OS::get_singleton()->execute("/usr/bin/hdiutil", args, true, NULL, &str, NULL, true);
+	Error err = OS::get_singleton()->execute("hdiutil", args, true, NULL, &str, NULL, true);
 	ERR_FAIL_COND_V(err != OK, err);
 
 	print_line("hdiutil returned: " + str);

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -1939,7 +1939,7 @@ Error OS_X11::shell_open(String p_uri) {
 	Error ok;
 	List<String> args;
 	args.push_back(p_uri);
-	ok = execute("/usr/bin/xdg-open", args, false);
+	ok = execute("xdg-open", args, false);
 	if (ok == OK)
 		return OK;
 	ok = execute("gnome-open", args, false);
@@ -2003,7 +2003,7 @@ String OS_X11::get_system_dir(SystemDir p_dir) const {
 	String pipe;
 	List<String> arg;
 	arg.push_back(xdgparam);
-	Error err = const_cast<OS_X11 *>(this)->execute("/usr/bin/xdg-user-dir", arg, true, NULL, &pipe);
+	Error err = const_cast<OS_X11 *>(this)->execute("xdg-user-dir", arg, true, NULL, &pipe);
 	if (err != OK)
 		return ".";
 	return pipe.strip_edges();
@@ -2053,7 +2053,7 @@ void OS_X11::alert(const String &p_alert, const String &p_title) {
 	args.push_back(p_title);
 	args.push_back(p_alert);
 
-	execute("/usr/bin/xmessage", args, true);
+	execute("xmessage", args, true);
 }
 
 void OS_X11::set_icon(const Ref<Image> &p_icon) {
@@ -2236,12 +2236,12 @@ Error OS_X11::move_to_trash(const String &p_path) {
 	List<String> args;
 	args.push_back("-p");
 	args.push_back(trashcan);
-	Error err = execute("/bin/mkdir", args, true);
+	Error err = execute("mkdir", args, true);
 	if (err == OK) {
 		List<String> args2;
 		args2.push_back(p_path);
 		args2.push_back(trashcan);
-		err = execute("/bin/mv", args2, true);
+		err = execute("mv", args2, true);
 	}
 
 	return err;


### PR DESCRIPTION
Now that #12009 is merged, we should let the system find the binary on
the users $PATH and don't assume we know where to look for them in
different distributions.