### PR TITLE
tab container arrows don't work when a popup was set

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -94,15 +94,20 @@ void TabContainer::_gui_input(const Ref<InputEvent> &p_event) {
 
 		// Handle navigation buttons.
 		if (buttons_visible_cache) {
+			int popup_ofs = 0;
+			if (popup) {
+				popup_ofs = menu->get_width();
+			}
+
 			Ref<Texture> increment = get_icon("increment");
 			Ref<Texture> decrement = get_icon("decrement");
-			if (pos.x > size.width - increment->get_width()) {
+			if (pos.x > size.width - increment->get_width() - popup_ofs) {
 				if (last_tab_cache < tabs.size() - 1) {
 					first_tab_cache += 1;
 					update();
 				}
 				return;
-			} else if (pos.x > size.width - increment->get_width() - decrement->get_width()) {
+			} else if (pos.x > size.width - increment->get_width() - decrement->get_width() - popup_ofs) {
 				if (first_tab_cache > 0) {
 					first_tab_cache -= 1;
 					update();


### PR DESCRIPTION
You can't press the arrow buttons in the tab container when there is a popup set for the container. To reproduce, move everything in the godot editor to one dock and try pressing the arrows next to the tabs.