### PR TITLE
Fix wrong Virtual-KeyCode(0x12) pair on Windows platform

### DIFF
--- a/platform/windows/key_mapping_win.cpp
+++ b/platform/windows/key_mapping_win.cpp
@@ -50,7 +50,7 @@ static _WinTranslatePair _vk_to_keycode[] = {
 
 	{ KEY_CONTROL, VK_CONTROL }, //(0x11)
 
-	{ KEY_MENU, VK_MENU }, //(0x12)
+	{ KEY_ALT, VK_MENU }, //(0x12)
 
 	{ KEY_PAUSE, VK_PAUSE }, //(0x13)
 


### PR DESCRIPTION
According MSDN docs:

![virtual-key codes - windows os](https://user-images.githubusercontent.com/20697655/31574442-61adfc78-b0fa-11e7-8268-f73f10449941.png)

This PR should be able to solve : 
- https://github.com/godotengine/godot/issues/12073
- Changing Node type on "Drag & Drop Asset to 2D Viewport feature" via DND + Alt key never worked on Windows (worked great on Linux)
