### PR TITLE
Fix render mode specular schlick ggx

### DIFF
--- a/drivers/gles3/shader_compiler_gles3.cpp
+++ b/drivers/gles3/shader_compiler_gles3.cpp
@@ -838,6 +838,7 @@ ShaderCompilerGLES3::ShaderCompilerGLES3() {
 	actions[VS::SHADER_SPATIAL].render_mode_defines["diffuse_lambert_wrap"] = "#define DIFFUSE_LAMBERT_WRAP\n";
 	actions[VS::SHADER_SPATIAL].render_mode_defines["diffuse_toon"] = "#define DIFFUSE_TOON\n";
 
+	actions[VS::SHADER_SPATIAL].render_mode_defines["specular_schlick_ggx"] = "#define SPECULAR_SCHLICK_GGX\n";
 	actions[VS::SHADER_SPATIAL].render_mode_defines["specular_blinn"] = "#define SPECULAR_BLINN\n";
 	actions[VS::SHADER_SPATIAL].render_mode_defines["specular_phong"] = "#define SPECULAR_PHONG\n";
 	actions[VS::SHADER_SPATIAL].render_mode_defines["specular_toon"] = "#define SPECULAR_TOON\n";

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -895,7 +895,7 @@ float G_GGX_2cos(float cos_theta_m, float alpha) {
 	// return 1.0 /( cos_theta_m + sqrt(cos2 + alpha*alpha*sin2) );
 }
 
-float D_GXX(float cos_theta_m, float alpha) {
+float D_GGX(float cos_theta_m, float alpha) {
 	float alpha2 = alpha*alpha;
 	float d = 1.0 + (alpha2-1.0)*cos_theta_m*cos_theta_m;
 	return alpha2/(M_PI * d * d);
@@ -909,7 +909,7 @@ float G_GGX_anisotropic_2cos(float cos_theta_m, float alpha_x, float alpha_y, fl
 	return 1.0  / (cos_theta_m + sqrt(cos2 + (s_x*s_x + s_y*s_y)*sin2 ));
 }
 
-float D_GXX_anisotropic(float cos_theta_m, float alpha_x, float alpha_y, float cos_phi, float sin_phi) {
+float D_GGX_anisotropic(float cos_theta_m, float alpha_x, float alpha_y, float cos_phi, float sin_phi) {
 	float cos2 = cos_theta_m * cos_theta_m;
 	float sin2 = (1.0-cos2);
 	float r_x = cos_phi/alpha_x;
@@ -1080,7 +1080,7 @@ LIGHT_SHADER_CODE
 		float ay = ry*ry;
 		float XdotH = dot( T, H );
 		float YdotH = dot( B, H );
-		float D = D_GXX_anisotropic(cNdotH, ax, ay, XdotH, YdotH);
+		float D = D_GGX_anisotropic(cNdotH, ax, ay, XdotH, YdotH);
 		float G = G_GGX_anisotropic_2cos(cNdotL, ax, ay, XdotH, YdotH) * G_GGX_anisotropic_2cos(cNdotV, ax, ay, XdotH, YdotH);
 
 #else
@@ -2104,5 +2104,3 @@ FRAGMENT_SHADER_CODE
 
 
 }
-
-


### PR DESCRIPTION
Following my comment https://github.com/godotengine/godot/issues/11935#issuecomment-336626892, I found that there's no code turning on the conditional for "specular_schlick_ggx", so I added `render_mode_defines` for this.
Additionally, this reveals that there's some function name typo in glsl, so I fixed that too.

This PR closes https://github.com/godotengine/godot/issues/11935.