### PR TITLE
Expose 'request_frame_drawn_callback' to script.

### DIFF
--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -24,6 +24,20 @@
 			<description>
 			</description>
 		</method>
+		<method name="request_frame_drawn_callback">
+			<return type="void">
+			</return>
+			<argument index="0" name="where" type="Object">
+			</argument>
+			<argument index="1" name="method" type="String">
+			</argument>
+			<argument index="2" name="userdata" type="Variant">
+			</argument>
+			<description>
+				Schedules a callback to the corresponding named 'method' on 'where' after a frame has been drawn.
+				The callback method must use only 1 argument which will be called with 'userdata'.
+			</description>
+		</method>
 		<method name="texture_create">
 			<return type="RID">
 			</return>

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1447,6 +1447,7 @@ void VisualServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("force_sync"), &VisualServer::sync);
 	ClassDB::bind_method(D_METHOD("force_draw"), &VisualServer::draw);
+	ClassDB::bind_method(D_METHOD("request_frame_drawn_callback", "where", "method", "userdata"), &VisualServer::request_frame_drawn_callback);
 	ClassDB::bind_method(D_METHOD("texture_create"), &VisualServer::texture_create);
 	ClassDB::bind_method(D_METHOD("texture_create_from_image", "image", "flags"), &VisualServer::texture_create_from_image, DEFVAL(TEXTURE_FLAGS_DEFAULT));
 	//ClassDB::bind_method(D_METHOD("texture_allocate"),&VisualServer::texture_allocate,DEFVAL( TEXTURE_FLAGS_DEFAULT ) );


### PR DESCRIPTION
Allows this method to be accessed through the scripting API. Also includes documentation. This method is useful for generating screenshots, since it schedules the callback to occur after the frame has been rendered, ensuring correct timing.