### PR TITLE
Fixed help overview visibility, issue 12011 and 10407

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1409,8 +1409,10 @@ void ScriptEditor::_update_members_overview() {
 void ScriptEditor::_update_help_overview_visibility() {
 
 	int selected = tab_container->get_current_tab();
-	if (selected < 0 || selected >= tab_container->get_child_count())
+	if (selected < 0 || selected >= tab_container->get_child_count()) {
+		help_overview->set_visible(false);
 		return;
+	}
 
 	Node *current = tab_container->get_child(tab_container->get_current_tab());
 	EditorHelp *se = Object::cast_to<EditorHelp>(current);
@@ -1427,6 +1429,7 @@ void ScriptEditor::_update_help_overview_visibility() {
 }
 
 void ScriptEditor::_update_help_overview() {
+	help_overview->clear();
 
 	int selected = tab_container->get_current_tab();
 	if (selected < 0 || selected >= tab_container->get_child_count())
@@ -1438,16 +1441,11 @@ void ScriptEditor::_update_help_overview() {
 		return;
 	}
 
-	help_overview->clear();
-
 	Vector<Pair<String, int> > sections = se->get_sections();
 	for (int i = 0; i < sections.size(); i++) {
 		help_overview->add_item(sections[i].first);
 		help_overview->set_item_metadata(i, sections[i].second);
 	}
-}
-
-void _help_overview_selected(int p_idx) {
 }
 
 void ScriptEditor::_update_script_colors() {
@@ -1595,6 +1593,8 @@ void ScriptEditor::_update_script_names() {
 
 	_update_members_overview();
 	_update_help_overview();
+	_update_members_overview_visibility();
+	_update_help_overview_visibility();
 	_update_script_colors();
 }
 


### PR DESCRIPTION
The help overview will now disappear when no docs or scrips are open.
It will also switch correctly when using History next and History previous.

closes #12011
closes #10407