### PR TITLE
Fix Android build error with SCons 3.0 (2.1)

### DIFF
--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -153,7 +153,7 @@ elif env['android_arch'] == 'armv7':
 elif env['android_arch'] == 'x86':
     lib_arch_dir = 'x86'
 else:
-    print 'WARN: Architecture not suitable for embedding into APK; keeping .so at \\bin'
+    print('WARN: Architecture not suitable for embedding into APK; keeping .so at \\bin')
 
 if lib_arch_dir != '':
     if env['target'] == 'release':


### PR DESCRIPTION
Not sure why this happens without having upgraded Python itself, but is needed now.

Not needed for _master_ because there we have b6e1e47e3a92c1b94ef327149068a8a147fc73f5 that does this and more.

This commit does not address upgrading to Python 3.0. It just makes building for Android work again after upgrading SCons while keeping Python 2.7.