### PR TITLE
Changes the modulo operator to act like the python one

### DIFF
--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -1057,7 +1057,9 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 					_RETURN("Division By Zero");
 				}
 #endif
-				_RETURN(p_a._data._int % p_b._data._int);
+				// The modulo operator in C++ is more a "reminder" operator than a true mathematical modulo operation.
+				// This fixes the problem. It also makes the modulo operator work the same as in python.
+				_RETURN(((p_a._data._int % p_b._data._int) + p_b._data._int) % p_b._data._int);
 			}
 
 			CASE_TYPE(math, OP_MODULE, STRING) {


### PR DESCRIPTION
Following the discussion in #12035, I open a new PR to discuss replacing the behaviour of modulo by its more pythonic version. With this PR we will have `-20 % 100` returning `80` instead of `-20`.

To understand the problem a little bit more, you can read [this thread in stackoverflow](https://stackoverflow.com/questions/1907565/c-python-different-behaviour-of-the-modulo-operation).

I think this deserves a review from @reduz. ;)

