### PR TITLE
Couple of small changes so our ARVRInterfaceGDNative gets constructed…

### DIFF
--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -5234,7 +5234,6 @@
       "name": "godot_arvr_register_interface",
       "return_type": "void",
       "arguments": [
-        ["const char *", "p_name"],
         ["const godot_arvr_interface_gdnative *", "p_interface"]
       ]
     },

--- a/modules/gdnative/include/nativearvr/godot_nativearvr.h
+++ b/modules/gdnative/include/nativearvr/godot_nativearvr.h
@@ -54,7 +54,7 @@ typedef struct {
 	void (*process)(void *);
 } godot_arvr_interface_gdnative;
 
-void GDAPI godot_arvr_register_interface(const char *p_name, const godot_arvr_interface_gdnative *p_interface);
+void GDAPI godot_arvr_register_interface(const godot_arvr_interface_gdnative *p_interface);
 
 // helper functions to access ARVRServer data
 godot_real GDAPI godot_arvr_get_worldscale();

--- a/modules/gdnative/nativearvr/arvr_interface_gdnative.h
+++ b/modules/gdnative/nativearvr/arvr_interface_gdnative.h
@@ -46,17 +46,15 @@ class ARVRInterfaceGDNative : public ARVRInterface {
 	void cleanup();
 
 protected:
-	godot_arvr_interface_gdnative *interface;
+	const godot_arvr_interface_gdnative *interface;
 	void *data;
-
-	static void _bind_methods();
 
 public:
 	/** general interface information **/
 	ARVRInterfaceGDNative();
 	~ARVRInterfaceGDNative();
 
-	void set_interface(StringName p_name);
+	void set_interface(const godot_arvr_interface_gdnative *p_interface);
 
 	virtual StringName get_name() const;
 	virtual int get_capabilities() const;

--- a/modules/gdnative/nativearvr/register_types.cpp
+++ b/modules/gdnative/nativearvr/register_types.cpp
@@ -29,29 +29,11 @@
 /*************************************************************************/
 
 #include "register_types.h"
-
 #include "arvr_interface_gdnative.h"
-#include "core/os/os.h"
-
-#include "oa_hash_map.h"
-#include "ustring.h"
-
-// what is this?? I can't memnew(OAHashMap<String, godot_arvr_interface_gdnative *>)
-// but with this typedef it's working just fine...
-// C++ grammar can be a joy.
-typedef OAHashMap<StringName, godot_arvr_interface_gdnative *> InterfaceMap;
-
-InterfaceMap *_registered_interfaces;
 
 void register_nativearvr_types() {
-
-	_registered_interfaces = memnew(InterfaceMap);
-
 	ClassDB::register_class<ARVRInterfaceGDNative>();
 }
 
 void unregister_nativearvr_types() {
-	memdelete(_registered_interfaces);
-
-	_registered_interfaces = NULL;
 }


### PR DESCRIPTION
Further simplification of the changes Karroffel made today. As soon as a GDNative library registers and ARVR interface it creates the ARVRInterfaceGDNative instance, binds it, and registers it with the server.

Now the code needed to activate a GDNative ARVR module is exactly the same as with a normal ARVR module:
func _ready():
	var arvr_interface = ARVRServer.find_interface("ARVRSimple")
	if arvr_interface and arvr_interface.initialize():
		get_viewport().arvr = true
