### PR TITLE
Fix animation before first key

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -405,6 +405,10 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, float 
 				if (a->value_track_get_update_mode(i) == Animation::UPDATE_CONTINUOUS || (p_delta == 0 && a->value_track_get_update_mode(i) == Animation::UPDATE_DISCRETE)) { //delta == 0 means seek
 
 					Variant value = a->value_track_interpolate(i, p_time);
+
+					if (value == Variant())
+						continue;
+
 					//thanks to trigger mode, this should be solved now..
 					/*
 					if (p_delta==0 && value.get_type()==Variant::STRING)

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -1171,9 +1171,7 @@ T Animation::_interpolate(const Vector<TKey<T> > &p_keys, float p_time, Interpol
 
 	ERR_FAIL_COND_V(idx == -2, T());
 
-	if (p_ok)
-		*p_ok = true;
-
+	bool result = true;
 	int next = 0;
 	float c = 0;
 	// prepare for all cases of interpolation
@@ -1243,9 +1241,18 @@ T Animation::_interpolate(const Vector<TKey<T> > &p_keys, float p_time, Interpol
 
 		} else if (idx < 0) {
 
-			idx = next = 0;
+			// only allow extending first key to anim start if looping
+			if (loop)
+				idx = next = 0;
+			else
+				result = false;
 		}
 	}
+
+	if (p_ok)
+		*p_ok = result;
+	if (!result)
+		return T();
 
 	float tr = p_keys[idx].transition;
 
@@ -1298,7 +1305,7 @@ Error Animation::transform_track_interpolate(int p_track, float p_time, Vector3 
 
 	TransformKey tk = _interpolate(tt->transforms, p_time, tt->interpolation, tt->loop_wrap, &ok);
 
-	if (!ok) // ??
+	if (!ok)
 		return ERR_UNAVAILABLE;
 
 	if (r_loc)


### PR DESCRIPTION
Prior to this, the value assumed for the interval between the start of the track and the first frame would be the one of the first key if
- *seeking/playing a continuous track*;
- *seeking a discrete track*.

And the first key would be ignored until reached -thus not modifying the target property/transform- in the remaining case; namely, *playing a discrete track*.

In other words, the inner workings of the animation system considered the unreached first key for interpolation but not for a query of every key inside a time range.

With this changes, the first key is only considered if the animation is looped and ignored otherwise. That way, in order to have a start value, you'll need an explicit key at the very beginning of the track, while having the flexibility of the animation player not touching the target value until the first key is reached.

This corresponds to the point 1) of #10752.

*NOTE:* Although this consistent behavior can be considered a bug fix, it is not meant to be backported to 2.1 as it would be potentially too breaking.