### PR TITLE
Fix deleting localization remap option.

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -1189,7 +1189,7 @@ void ProjectSettingsEditor::_translation_res_option_delete(Object *p_item, int p
 
 	ERR_FAIL_COND(!remaps.has(key));
 	PoolStringArray r = remaps[key];
-	ERR_FAIL_INDEX(idx, remaps.size());
+	ERR_FAIL_INDEX(idx, r.size());
 	r.remove(idx);
 	remaps[key] = r;
 


### PR DESCRIPTION
Fixed error when you couldn't delete remap options if option have index greater then remaps count.
<details>
<summary>gif</summary>
<a href="https://user-images.githubusercontent.com/7782218/31580870-6949678c-b164-11e7-9b91-96ee3f755f71.gif" target="_blank"><img src="https://user-images.githubusercontent.com/7782218/31580870-6949678c-b164-11e7-9b91-96ee3f755f71.gif" alt="2017-10-15_03-29-46" style="max-width:100%;"></a>
</details>