### PR TITLE
Separated Editor settings and Scene undo redo stack

### DIFF
--- a/editor/script_editor_debugger.h
+++ b/editor/script_editor_debugger.h
@@ -166,9 +166,6 @@ class ScriptEditorDebugger : public Control {
 	void _method_changed(Object *p_base, const StringName &p_name, VARIANT_ARG_DECLARE);
 	void _property_changed(Object *p_base, const StringName &p_property, const Variant &p_value);
 
-	static void _method_changeds(void *p_ud, Object *p_base, const StringName &p_name, VARIANT_ARG_DECLARE);
-	static void _property_changeds(void *p_ud, Object *p_base, const StringName &p_property, const Variant &p_value);
-
 	void _error_selected(int p_idx);
 	void _error_stack_selected(int p_idx);
 
@@ -195,6 +192,9 @@ public:
 	String get_var_value(const String &p_var) const;
 
 	void set_live_debugging(bool p_enable);
+
+	static void _method_changeds(void *p_ud, Object *p_base, const StringName &p_name, VARIANT_ARG_DECLARE);
+	static void _property_changeds(void *p_ud, Object *p_base, const StringName &p_property, const Variant &p_value);
 
 	void live_debug_create_node(const NodePath &p_parent, const String &p_type, const String &p_name);
 	void live_debug_instance_node(const NodePath &p_parent, const String &p_path, const String &p_name);

--- a/editor/settings_config_dialog.h
+++ b/editor/settings_config_dialog.h
@@ -50,6 +50,7 @@ class EditorSettingsDialog : public AcceptDialog {
 
 	Timer *timer;
 
+	UndoRedo *undo_redo;
 	Tree *shortcuts;
 
 	ConfirmationDialog *press_a_key;
@@ -65,6 +66,7 @@ class EditorSettingsDialog : public AcceptDialog {
 	void _settings_property_edited(const String &p_name);
 	void _settings_save();
 
+	void _unhandled_input(const Ref<InputEvent> &p_event);
 	void _notification(int p_what);
 
 	void _press_a_key_confirm();
@@ -78,6 +80,8 @@ class EditorSettingsDialog : public AcceptDialog {
 	void _update_shortcuts();
 	void _shortcut_button_pressed(Object *p_item, int p_column, int p_idx);
 
+	static void _undo_redo_callback(void *p_self, const String &p_name);
+
 protected:
 	static void _bind_methods();
 
@@ -85,6 +89,7 @@ public:
 	void popup_edit_settings();
 
 	EditorSettingsDialog();
+	~EditorSettingsDialog();
 };
 
 #endif // SETTINGS_CONFIG_DIALOG_H


### PR DESCRIPTION
Editor settings now has its own Undo Redo stack and will no longer interfere with the scene.  
It uses the same keyboard shortcuts.

Closes #6014