### PR TITLE
Sets Windows process to be PER_MONITOR_DPI_AWARE (2.1.4-stable) - #11760

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -56,6 +56,8 @@
 #include <process.h>
 #include <regstr.h>
 
+#include <ShellScalingApi.h>
+
 static const WORD MAX_CONSOLE_LINES = 1500;
 
 extern "C" {
@@ -892,6 +894,41 @@ static int QueryDpiForMonitor(HMONITOR hmon, _MonitorDpiType dpiType = MDT_Defau
 }
 
 void OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int p_audio_driver) {
+
+    // The following code addresses https://github.com/godotengine/godot/issues/11760 by
+    // setting the Windows process to be PER_MONITOR_DPI_AWARE. This seems to resolve the
+    // issue from the ticket. I attempted to follow the same pattern of dll usage as
+    // the QueryDpiForMonitor function.
+    //printf("Attempting to make process DPI Aware\n");
+    static HMODULE Shcore = NULL;
+    typedef HRESULT(WINAPI * SetProcessDPIAwareness_t)(PROCESS_DPI_AWARENESS awareness);
+    static SetProcessDPIAwareness_t setProcessDPIAwareness = NULL;
+
+    if (Shcore == NULL) {
+        Shcore = LoadLibraryW(L"Shcore.dll");
+        setProcessDPIAwareness = Shcore ? (SetProcessDPIAwareness_t)GetProcAddress(Shcore,"SetProcessDpiAwareness") : NULL;
+        if ((Shcore == NULL) || (setProcessDPIAwareness == NULL)) {
+            if (Shcore)
+                FreeLibrary(Shcore);
+            Shcore = (HMODULE)INVALID_HANDLE_VALUE;
+        }
+    }
+
+    if(Shcore != NULL && Shcore != INVALID_HANDLE_VALUE) {
+        if(setProcessDPIAwareness != NULL) {
+            HRESULT hr = E_FAIL;
+            hr = setProcessDPIAwareness(PROCESS_PER_MONITOR_DPI_AWARE);
+
+            if (hr != S_OK) {
+                printf("ERROR using SetProcessDpiAwareness for Windows process.\n");
+            }
+            else {
+                printf("DPI Awareness set for Windows process.\n");
+            }
+        }
+
+    }
+    // End https://github.com/godotengine/godot/issues/11760 fix
 
 	main_loop = NULL;
 	outside = true;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -56,8 +56,6 @@
 #include <process.h>
 #include <regstr.h>
 
-#include <ShellScalingApi.h>
-
 static const WORD MAX_CONSOLE_LINES = 1500;
 
 extern "C" {
@@ -893,15 +891,22 @@ static int QueryDpiForMonitor(HMONITOR hmon, _MonitorDpiType dpiType = MDT_Defau
 	return (dpiX + dpiY) / 2;
 }
 
+
+// Same enums reduz is using in GD3.0
+typedef enum _SHC_PROCESS_DPI_AWARENESS {
+	SHC_PROCESS_DPI_UNAWARE = 0,
+	SHC_PROCESS_SYSTEM_DPI_AWARE = 1,
+	SHC_PROCESS_PER_MONITOR_DPI_AWARE = 2
+} SHC_PROCESS_DPI_AWARENESS;
+
 void OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int p_audio_driver) {
 
 	// The following code addresses https://github.com/godotengine/godot/issues/11760 by
 	// setting the Windows process to be PER_MONITOR_DPI_AWARE. This seems to resolve the
 	// issue from the ticket. I attempted to follow the same pattern of dll usage as
 	// the QueryDpiForMonitor function.
-	//printf("Attempting to make process DPI Aware\n");
 	static HMODULE Shcore = NULL;
-	typedef HRESULT(WINAPI * SetProcessDPIAwareness_t)(PROCESS_DPI_AWARENESS awareness);
+	typedef HRESULT(WINAPI * SetProcessDPIAwareness_t)(SHC_PROCESS_DPI_AWARENESS awareness);
 	static SetProcessDPIAwareness_t setProcessDPIAwareness = NULL;
 
 	if (Shcore == NULL) {
@@ -917,7 +922,7 @@ void OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int 
 	if(Shcore != NULL && Shcore != INVALID_HANDLE_VALUE) {
 		if(setProcessDPIAwareness != NULL) {
 			HRESULT hr = E_FAIL;
-			hr = setProcessDPIAwareness(PROCESS_PER_MONITOR_DPI_AWARE);
+			hr = setProcessDPIAwareness(SHC_PROCESS_PER_MONITOR_DPI_AWARE);
 
 			if (hr != S_OK) {
 				printf("ERROR using SetProcessDpiAwareness for Windows process.\n");
@@ -926,7 +931,6 @@ void OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int 
 				printf("DPI Awareness set for Windows process.\n");
 			}
 		}
-
 	}
 	// End https://github.com/godotengine/godot/issues/11760 fix
 


### PR DESCRIPTION
NOTE: this code is from the 2.1.4 release tag - I'm assuming it should merge well into the 2.1 branch and maybe 3.0 . This sets Windows process to be PER_MONITOR_DPI_AWARE addressing #11760  - This seems to resolve the issue for the ticket. I was able to test on 3 separate Windows boxes all on Windows 10 against NVIDIA GTX660m, NVIDIA 1070, and Intel HD Graphics 620. All seemed to perform well. I attempted to follow the same pattern of dll usage as QueryDpiForMonitor function. 

Hopefully this is helpful to merge - I needed it for my deployments but hope it gets rolled into production. Feel free to ping me if you have questions.