### PR TITLE
[Nativescript] fix crash when loading a library with missing godot_nativescript_init

### DIFF
--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -1011,10 +1011,13 @@ void NativeScriptLanguage::init_library(const Ref<GDNativeLibrary> &lib) {
 
 		void *proc_ptr;
 
-		gdn->get_symbol(_init_call_name, proc_ptr);
+		Error err = gdn->get_symbol(_init_call_name, proc_ptr);
 
-		((void (*)(godot_string *))proc_ptr)((godot_string *)&lib_path);
-
+		if (err != OK) {
+			ERR_PRINT(String("No " + _init_call_name + " in \"" + lib_path + "\" found").utf8().get_data());
+		} else {
+			((void (*)(godot_string *))proc_ptr)((godot_string *)&lib_path);
+		}
 	} else {
 		// already initialized. Nice.
 	}
@@ -1138,9 +1141,12 @@ void NativeReloadNode::_notification(int p_what) {
 				// here the library registers all the classes and stuff.
 
 				void *proc_ptr;
-				L->get()->get_symbol("godot_nativescript_init", proc_ptr);
-
-				((void (*)(void *))proc_ptr)((void *)&L->key());
+				Error err = L->get()->get_symbol("godot_nativescript_init", proc_ptr);
+				if (err != OK) {
+					ERR_PRINT(String("No godot_nativescript_init in \"" + L->key() + "\" found").utf8().get_data());
+				} else {
+					((void (*)(void *))proc_ptr)((void *)&L->key());
+				}
 
 				for (Map<String, Set<NativeScript *> >::Element *U = NSL->library_script_users.front(); U; U = U->next()) {
 					for (Set<NativeScript *>::Element *S = U->get().front(); S; S = S->next()) {


### PR DESCRIPTION
Copy check done by gdnative on `godot_gdnative_singleton`, to apply it to nativescript way of loading/excuting `godot_nativescript_init` function.

@karroffel btw I don't see the point of having `godot_nativescript_init`, `godot_gdnative_init` and `godot_gdnative_singleton` callbacks. I thought we said a single entry point callback for the library would be enough given from there we would use the gdnative API to call registering functions (like `godot_pluginscript_register_language` for instance)
Beside given there is a `godot_nativescript_init`, should I provide my own `godot_pluginscript_init` callback as well ? even if using `godot_gdnative_init` works fine for the needs of pluginscript ?
And last but no least the we get big bad errors messages every time one of those callback are not defined in the library to load, so we have to implement the three of them even if there are not used or the library feels buggy...