### PR TITLE
Tweaks ParallaxBackground to work better with zoom. 

### DIFF
--- a/scene/2d/parallax_background.cpp
+++ b/scene/2d/parallax_background.cpp
@@ -49,8 +49,8 @@ void ParallaxBackground::_notification(int p_what) {
 
 void ParallaxBackground::_camera_moved(const Transform2D &p_transform) {
 
-	set_scroll_offset(p_transform.get_origin());
 	set_scroll_scale(p_transform.get_scale().dot(Vector2(0.5, 0.5)));
+	set_scroll_offset(p_transform.get_origin() / p_transform.get_scale());
 }
 
 void ParallaxBackground::set_scroll_scale(float p_scale) {


### PR DESCRIPTION
Ensures a Parallax Layer with a (1,1) motion scale syncs perfectly with a regular stationary sprite that is outside the ParallaxBackground, regardless of the zoom level and movement of the camera.

Before this, a stationary sprite and a Parallax Layer with (1,1) motion scale would move apart or towards eachother depending on the zoom of the camera. This project file demonstrates: [ParallaxRecreate.zip](https://github.com/godotengine/godot/files/1385888/ParallaxRecreate.zip) [left, right - move camera, up,down - zoom]

Before this commit, you can see the two different "ground" images go against eachother as you zoom and move, after the commit, they overlap eachother perfectly.