### PR TITLE
Avoid adding built-in script path to csproj

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1352,12 +1352,15 @@ bool CSharpScript::can_instance() const {
 
 #ifdef TOOLS_ENABLED
 	if (Engine::get_singleton()->is_editor_hint()) {
-		if (_create_project_solution_if_needed()) {
-			CSharpProject::add_item(GodotSharpDirs::get_project_csproj_path(),
-					"Compile",
-					ProjectSettings::get_singleton()->globalize_path(get_path()));
-		} else {
-			ERR_PRINTS("Cannot add " + get_path() + " to the C# project because it could not be created.");
+
+		if (get_path().find("::") == -1) { // Ignore if built-in script. Can happen if the file is deleted...
+			if (_create_project_solution_if_needed()) {
+				CSharpProject::add_item(GodotSharpDirs::get_project_csproj_path(),
+						"Compile",
+						ProjectSettings::get_singleton()->globalize_path(get_path()));
+			} else {
+				ERR_PRINTS("Cannot add " + get_path() + " to the C# project because it could not be created.");
+			}
 		}
 	}
 #endif


### PR DESCRIPTION
When a script is deleted outside of Godot, it becomes a built-in script in the scene, for whatever reason... So we must make sure not to add the path of built-in scripts as include items to the msbuild project.
