### PR TITLE
Reset slider mouse state on hiding/removing

### DIFF
--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -157,6 +157,12 @@ void Slider::_notification(int p_what) {
 			mouse_inside = false;
 			update();
 		} break;
+		case NOTIFICATION_VISIBILITY_CHANGED: // fallthrough
+		case NOTIFICATION_EXIT_TREE: {
+
+			mouse_inside = false;
+			grab.active = false;
+		} break;
 		case NOTIFICATION_DRAW: {
 			RID ci = get_canvas_item();
 			Size2i size = get_size();


### PR DESCRIPTION
Resetting `grab.active`, but also `mouse_inside` so that after reappearing it must be hovered again -even if the mouse is still over it- in order to get a highlight. That is consistent to the way other controls in the engine, e.g. buttons, work.

Fixes #12130.