### PR TITLE
Fix directional light specular

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2569,8 +2569,8 @@ void RasterizerSceneGLES3::_setup_directional_light(int p_index, const Transform
 	ubo_data.light_direction_attenuation[3] = 1.0;
 
 	ubo_data.light_params[0] = 0;
-	ubo_data.light_params[1] = li->light_ptr->param[VS::LIGHT_PARAM_SPECULAR];
-	ubo_data.light_params[2] = 0;
+	ubo_data.light_params[1] = 0;
+	ubo_data.light_params[2] = li->light_ptr->param[VS::LIGHT_PARAM_SPECULAR];
 	ubo_data.light_params[3] = 0;
 
 	Color shadow_color = li->light_ptr->shadow_color.to_linear();


### PR DESCRIPTION
I spotted that uniform data for directional light is setup in a wrong way, which is causing specular factor to be zero. If you read scene.glsl, you'll see it's using "z" entry, which is 3rd element of `light_params` as specular factor.

https://github.com/godotengine/godot/blob/1b2e09355e890ae32fe172aad19dcda137ed636f/drivers/gles3/shaders/scene.glsl#L1919

This fixes https://github.com/godotengine/godot/issues/11935#issuecomment-337124171 and https://github.com/godotengine/godot/issues/10250.