### PR TITLE
Improved *_FAIL_INDEX error macros to print the index/size

### DIFF
--- a/core/error_macros.cpp
+++ b/core/error_macros.cpp
@@ -97,3 +97,10 @@ void _err_print_error(const char *p_function, const char *p_file, int p_line, co
 		_err_error_exists = false;
 	}
 }
+
+void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, bool fatal) {
+
+	String fstr(fatal ? "FATAL: " : "");
+	String err(fstr + "Index" + p_index_str + "=" + itos(p_index) + " out of size (" + p_size_str + "=" + itos(p_size) + ")");
+	_err_print_error(p_function, p_file, p_line, err.utf8().get_data());
+}

--- a/core/error_macros.h
+++ b/core/error_macros.h
@@ -76,6 +76,7 @@ void add_error_handler(ErrorHandlerList *p_handler);
 void remove_error_handler(ErrorHandlerList *p_handler);
 
 void _err_print_error(const char *p_function, const char *p_file, int p_line, const char *p_error, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
+void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, bool fatal = false);
 
 #ifndef _STR
 #define _STR(m_x) #m_x
@@ -129,13 +130,13 @@ extern bool _err_error_exists;
 
 // (*): See https://stackoverflow.com/questions/257418/do-while-0-what-is-it-good-for
 
-#define ERR_FAIL_INDEX(m_index, m_size)                                                                                    \
-	do {                                                                                                                   \
-		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                            \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Index " _STR(m_index) " out of size (" _STR(m_size) ")."); \
-			return;                                                                                                        \
-		} else                                                                                                             \
-			_err_error_exists = false;                                                                                     \
+#define ERR_FAIL_INDEX(m_index, m_size)                                                                             \
+	do {                                                                                                            \
+		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
+			return;                                                                                                 \
+		} else                                                                                                      \
+			_err_error_exists = false;                                                                              \
 	} while (0); // (*)
 
 /** An index has failed if m_index<0 or m_index >=m_size, the function exists.
@@ -143,24 +144,24 @@ extern bool _err_error_exists;
 * appropriate error condition from error_macros.h
 */
 
-#define ERR_FAIL_INDEX_V(m_index, m_size, m_retval)                                                                        \
-	do {                                                                                                                   \
-		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                            \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Index " _STR(m_index) " out of size (" _STR(m_size) ")."); \
-			return m_retval;                                                                                               \
-		} else                                                                                                             \
-			_err_error_exists = false;                                                                                     \
+#define ERR_FAIL_INDEX_V(m_index, m_size, m_retval)                                                                 \
+	do {                                                                                                            \
+		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
+			return m_retval;                                                                                        \
+		} else                                                                                                      \
+			_err_error_exists = false;                                                                              \
 	} while (0); // (*)
 
 /** Use this one if there is no sensible fallback, that is, the error is unrecoverable.
 *   We'll return a null reference and try to keep running.
 */
-#define CRASH_BAD_INDEX(m_index, m_size)                                                                                          \
-	do {                                                                                                                          \
-		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                   \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Index " _STR(m_index) " out of size (" _STR(m_size) ")."); \
-			GENERATE_TRAP                                                                                                         \
-		}                                                                                                                         \
+#define CRASH_BAD_INDEX(m_index, m_size)                                                                                  \
+	do {                                                                                                                  \
+		if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                           \
+			_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), true); \
+			GENERATE_TRAP                                                                                                 \
+		}                                                                                                                 \
 	} while (0); // (*)
 
 /** An error condition happened (m_cond tested true) (WARNING this is the opposite as assert().

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -98,10 +98,10 @@ T *_nullptr() {
 #undef OK
 #endif
 
+#include "int_types.h"
+
 #include "error_list.h"
 #include "error_macros.h"
-
-#include "int_types.h"
 
 /** Generic ABS function, for math uses please use Math::abs */
 


### PR DESCRIPTION
This will make the _FAIL_INDEX macro print the actual values, like this (testing image):
![screen shot 2017-10-17 at 12 42 24 pm](https://user-images.githubusercontent.com/10578225/31674600-809665fc-b362-11e7-9ccc-8149c7528b2c.png)
