### PR TITLE
Added the ability to filter the list of locales in the Remap tab.

### DIFF
--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -49,6 +49,11 @@ class ProjectSettingsEditor : public AcceptDialog {
 		INPUT_MOUSE_BUTTON
 	};
 
+	enum LocaleFilter {
+		SHOW_ALL_LOCALES,
+		SHOW_ONLY_SELECTED_LOCALES,
+	};
+
 	TabContainer *tab_container;
 
 	Timer *timer;
@@ -95,6 +100,11 @@ class ProjectSettingsEditor : public AcceptDialog {
 	EditorFileDialog *translation_res_option_file_open;
 	Tree *translation_remap;
 	Tree *translation_remap_options;
+	Tree *translation_filter;
+	bool translation_locales_list_created;
+	OptionButton *translation_locale_filter_mode;
+	Vector<TreeItem *> translation_filter_treeitems;
+	Vector<int> translation_locales_idxs_remap;
 
 	EditorAutoloadSettings *autoload_settings;
 
@@ -141,6 +151,9 @@ class ProjectSettingsEditor : public AcceptDialog {
 	void _translation_res_option_add(const String &p_path);
 	void _translation_res_option_changed();
 	void _translation_res_option_delete(Object *p_item, int p_column, int p_button);
+
+	void _translation_filter_option_changed();
+	void _translation_filter_mode_changed(int p_mode);
 
 	void _toggle_search_bar(bool p_pressed);
 	void _clear_search_box();


### PR DESCRIPTION
With this PR no longer need to scroll through the list of all ~350 locales supported by godot.

<details>
<summary>With filter</summary>
<a href="https://user-images.githubusercontent.com/7782218/31676314-e3887846-b36f-11e7-8f69-54893a53b606.png" target="_blank"><img src="https://user-images.githubusercontent.com/7782218/31676314-e3887846-b36f-11e7-8f69-54893a53b606.png" alt="2017-10-15_03-29-46" style="max-width:100%;"></a>
</br>
<a href="https://user-images.githubusercontent.com/7782218/31676323-ec810d1e-b36f-11e7-9990-04eea4386b0e.png" target="_blank"><img src="https://user-images.githubusercontent.com/7782218/31676323-ec810d1e-b36f-11e7-9990-04eea4386b0e.png" alt="2017-10-15_03-29-46" style="max-width:100%;"></a>
</details>
<details>
<summary>Without filter</summary>
<a href="https://user-images.githubusercontent.com/7782218/31676330-f1aca50a-b36f-11e7-9f78-b6df508f1f41.png" target="_blank"><img src="https://user-images.githubusercontent.com/7782218/31676330-f1aca50a-b36f-11e7-9f78-b6df508f1f41.png" alt="2017-10-15_03-29-46" style="max-width:100%;"></a>
</details>