### PR TITLE
Fix drag and drop collision with non-centred origin points.

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -2765,8 +2765,14 @@ Vector3 SpatialEditorViewport::_get_instance_position(const Point2 &p_pos) const
 			normal = hit_normal;
 		}
 	}
-	Vector3 center = preview_bounds->get_size() * 0.5;
-	return point + (center * normal);
+	Vector3 offset = Vector3();
+	for (int i = 0; i < 3; i++) {
+		if (normal[i] > 0.0)
+			offset[i] = (preview_bounds->get_size()[i] - (preview_bounds->get_size()[i] + preview_bounds->get_position()[i]));
+		else if (normal[i] < 0.0)
+			offset[i] = -(preview_bounds->get_size()[i] + preview_bounds->get_position()[i]);
+	}
+	return point + offset;
 }
 
 Rect3 SpatialEditorViewport::_calculate_spatial_bounds(const Spatial *p_parent, const Rect3 p_bounds) {


### PR DESCRIPTION
The initial scene drag and drop feature I created used a bounding box generated from all the meshes within a scene to provide collision detection with geometry when dragging and dropping, allowing you to place objects easily on walls and floors. However, the initial implementation assumed the origin point to be at the centre of the bounding box. This provides a fix for scenes with off-centre origin points.