### PR TITLE
Itemlist rmb now provides the same pos as Tree rmb

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -489,7 +489,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 
 				if (mb->get_button_index() == BUTTON_RIGHT) {
 
-					emit_signal("item_rmb_selected", i, pos);
+					emit_signal("item_rmb_selected", i, get_local_mouse_position());
 				}
 			} else {
 
@@ -500,7 +500,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 
 				if (items[i].selected && mb->get_button_index() == BUTTON_RIGHT) {
 
-					emit_signal("item_rmb_selected", i, pos);
+					emit_signal("item_rmb_selected", i, get_local_mouse_position());
 				} else {
 					bool selected = !items[i].selected;
 
@@ -515,7 +515,7 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 
 					if (mb->get_button_index() == BUTTON_RIGHT) {
 
-						emit_signal("item_rmb_selected", i, pos);
+						emit_signal("item_rmb_selected", i, get_local_mouse_position());
 					} else if (/*select_mode==SELECT_SINGLE &&*/ mb->is_doubleclick()) {
 
 						emit_signal("item_activated", i);


### PR DESCRIPTION
This was working fine so I added the same behavior to Itemlist
https://github.com/godotengine/godot/blob/master/editor/filesystem_dock.cpp#L1155
https://github.com/godotengine/godot/blob/master/scene/gui/tree.cpp#L1680

https://github.com/godotengine/godot/blob/master/editor/filesystem_dock.cpp#L1542

closes #12204