### PR TITLE
AnimatedSprite warnings should now include the path and animation nam…

### DIFF
--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -355,23 +355,32 @@ void AnimatedSprite::_notification(int p_what) {
 		case NOTIFICATION_DRAW: {
 
 			if (frames.is_null()) {
-				print_line("no draw no faemos");
+				print_line("no draw no faemos: " + String(get_path()));
 				return;
 			}
 
 			if (frame < 0) {
-				print_line("no draw frame <0");
+				print_line("no draw frame <0: " + String(get_path()));
 				return;
 			}
 
 			if (!frames->has_animation(animation)) {
-				print_line("no draw no anim: " + String(animation));
+				print_line("no draw no anim: "
+					+ String(get_path()) + " " + String(animation));
+				return;
+			}
+
+			int frames_count = frames->get_frame_count(animation);
+			if (frames_count == 0){
+				print_line("no draw frames are empty for anim: "
+					+ String(get_path()) + " " + String(animation));
 				return;
 			}
 
 			Ref<Texture> texture = frames->get_frame(animation, frame);
 			if (texture.is_null()) {
-				print_line("no draw texture is null");
+				print_line("no draw texture is null for anim: "
+					+ String(get_path()) + " " + String(animation));
 				return;
 			}
 


### PR DESCRIPTION
…e that generated the warning.