### PR TITLE
Added a node_added signal to the SceneTree

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -212,6 +212,8 @@ void Node::_propagate_enter_tree() {
 
 	emit_signal(SceneStringNames::get_singleton()->tree_entered);
 
+	data.tree->node_added(this);
+
 	data.blocked++;
 	//block while adding children
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -85,6 +85,11 @@ void SceneTree::tree_changed() {
 	emit_signal(tree_changed_name);
 }
 
+void SceneTree::node_added(Node *p_node) {
+
+	emit_signal(node_added_name, p_node);
+}
+
 void SceneTree::node_removed(Node *p_node) {
 
 	if (current_scene == p_node) {
@@ -2189,6 +2194,7 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_server_disconnected"), &SceneTree::_server_disconnected);
 
 	ADD_SIGNAL(MethodInfo("tree_changed"));
+	ADD_SIGNAL(MethodInfo("node_added", PropertyInfo(Variant::OBJECT, "node")));
 	ADD_SIGNAL(MethodInfo("node_removed", PropertyInfo(Variant::OBJECT, "node")));
 	ADD_SIGNAL(MethodInfo("screen_resized"));
 	ADD_SIGNAL(MethodInfo("node_configuration_warning_changed", PropertyInfo(Variant::OBJECT, "node")));
@@ -2260,6 +2266,7 @@ SceneTree::SceneTree() {
 	root = NULL;
 	current_frame = 0;
 	tree_changed_name = "tree_changed";
+	node_added_name = "node_added";
 	node_removed_name = "node_removed";
 	ugc_locked = false;
 	call_lock = 0;

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -124,6 +124,7 @@ private:
 	bool input_handled;
 	Size2 last_screen_size;
 	StringName tree_changed_name;
+	StringName node_added_name;
 	StringName node_removed_name;
 
 	int64_t current_frame;
@@ -233,6 +234,7 @@ private:
 	void _rpc(Node *p_from, int p_to, bool p_unreliable, bool p_set, const StringName &p_name, const Variant **p_arg, int p_argcount);
 
 	void tree_changed();
+	void node_added(Node *p_node);
 	void node_removed(Node *p_node);
 
 	Group *add_to_group(const StringName &p_group, Node *p_node);


### PR DESCRIPTION
This is a signal to accompany SceneTree.node_removed. It has the same behavior as node_removed only that it emits when a node is added.

Backstory, if needed:

This solves a major real world problem I'm having for a reusable library I'm writing where when an arbitrary code file, that another arbitrary developer adds to the scene, my only available options for them to use my library are:

1) Have developer add a block of code to every code file that needs to use my library. IE: Lots of repeated code = bad programming practice (For example, I'm wanting to port a project that has about 750 code files, I would have to repeat this line in most of them)
2) Have my library search the entire hierarchy every frame to see if their arbitrary code was on a new node added to the scene = very bad programming practice

Currently, there seams to be no good programming practice available in Godot to see when a node has been added to the scene tree, but there is one for when a node is removed, thus this pull request.

Thanks :)