### PR TITLE
Fix depth draw alpha prepass for shadow

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -2430,7 +2430,9 @@ void RasterizerStorageGLES3::_update_material(Material *material) {
 
 		if (material->shader && material->shader->mode == VS::SHADER_SPATIAL) {
 
-			if (!material->shader->spatial.uses_alpha && material->shader->spatial.blend_mode == Shader::Spatial::BLEND_MODE_MIX) {
+			Shader::Spatial spatial = material->shader->spatial;
+			if (spatial.blend_mode == Shader::Spatial::BLEND_MODE_MIX &&
+					(!spatial.uses_alpha || (spatial.uses_alpha && spatial.depth_draw_mode == Shader::Spatial::DEPTH_DRAW_ALPHA_PREPASS))) {
 				can_cast_shadow = true;
 			}
 


### PR DESCRIPTION
I added one simple condition so that `DEPTH_DRAW_ALPHA_PREPASS` will cast shadow when shader uses alpha (`uses_alpha`).
This will fix https://github.com/godotengine/godot/issues/12058

Here is a screenshot of the example scene from the issue:

![alpha_cast_shadow](https://user-images.githubusercontent.com/4232207/31756404-ce158d76-b4de-11e7-8e89-34af23a4346c.png)
