### PR TITLE
Fix spatial shader conversion with texture

### DIFF
--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -449,8 +449,16 @@ Ref<Resource> SpatialMaterialConversionPlugin::convert(const Ref<Resource> &p_re
 	VS::get_singleton()->shader_get_param_list(mat->get_shader_rid(), &params);
 
 	for (List<PropertyInfo>::Element *E = params.front(); E; E = E->next()) {
-		Variant value = VS::get_singleton()->material_get_param(mat->get_rid(), E->get().name);
-		smat->set_shader_param(E->get().name, value);
+
+		// Texture parameter has to be treated specially since SpatialMaterial saved it
+		// as RID but ShaderMaterial needs Texture itself
+		Ref<Texture> texture = mat->get_texture_by_name(E->get().name);
+		if (texture.is_valid()) {
+			smat->set_shader_param(E->get().name, texture);
+		} else {
+			Variant value = VS::get_singleton()->material_get_param(mat->get_rid(), E->get().name);
+			smat->set_shader_param(E->get().name, value);
+		}
 	}
 
 	smat->set_render_priority(mat->get_render_priority());

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1242,6 +1242,15 @@ Ref<Texture> SpatialMaterial::get_texture(TextureParam p_param) const {
 	return textures[p_param];
 }
 
+Ref<Texture> SpatialMaterial::get_texture_by_name(StringName p_name) const {
+	for (int i = 0; i < (int)SpatialMaterial::TEXTURE_MAX; i++) {
+		TextureParam param = TextureParam(i);
+		if (p_name == shader_names->texture_names[param])
+			return textures[param];
+	}
+	return Ref<Texture>();
+}
+
 void SpatialMaterial::_validate_feature(const String &text, Feature feature, PropertyInfo &property) const {
 	if (property.name.begins_with(text) && property.name != text + "_enabled" && !features[feature]) {
 		property.usage = 0;

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -510,6 +510,8 @@ public:
 
 	void set_texture(TextureParam p_param, const Ref<Texture> &p_texture);
 	Ref<Texture> get_texture(TextureParam p_param) const;
+	// Used only for shader material conversion
+	Ref<Texture> get_texture_by_name(StringName p_name) const;
 
 	void set_feature(Feature p_feature, bool p_enabled);
 	bool get_feature(Feature p_feature) const;


### PR DESCRIPTION
This fixes https://github.com/godotengine/godot/issues/11729
This PR looks hacky workaround, so I added comment in source, but if contributors don't prefer these comments, I will remove that. So let me know if that's the case.
I can apply the same thing to unmerged PR https://github.com/godotengine/godot/pull/12052 for ParticlesMaterial conversion as well.