### PR TITLE
Fix window display shrink can't set to float numbers

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -133,7 +133,7 @@ static String get_full_version_string() {
 	return String(VERSION_MKSTRING) + hash;
 }
 
-//#define DEBUG_INIT
+	//#define DEBUG_INIT
 
 #ifdef DEBUG_INIT
 #define MAIN_PRINT(m_txt) print_line(m_txt)
@@ -1350,7 +1350,7 @@ bool Main::start() {
 			String stretch_mode = GLOBAL_DEF("display/window/stretch/mode", "disabled");
 			String stretch_aspect = GLOBAL_DEF("display/window/stretch/aspect", "ignore");
 			Size2i stretch_size = Size2(GLOBAL_DEF("display/window/size/width", 0), GLOBAL_DEF("display/window/size/height", 0));
-			int stretch_shrink = GLOBAL_DEF("display/window/stretch/shrink", 1);
+			real_t stretch_shrink = GLOBAL_DEF("display/window/stretch/shrink", 1.0f);
 
 			SceneTree::StretchMode sml_sm = SceneTree::STRETCH_MODE_DISABLED;
 			if (stretch_mode == "2d")

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1172,7 +1172,7 @@ void SceneTree::_update_root_rect() {
 	}
 }
 
-void SceneTree::set_screen_stretch(StretchMode p_mode, StretchAspect p_aspect, const Size2 p_minsize, int p_shrink) {
+void SceneTree::set_screen_stretch(StretchMode p_mode, StretchAspect p_aspect, const Size2 p_minsize, real_t p_shrink) {
 
 	stretch_mode = p_mode;
 	stretch_aspect = p_aspect;

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -147,7 +147,7 @@ private:
 	StretchMode stretch_mode;
 	StretchAspect stretch_aspect;
 	Size2i stretch_min;
-	int stretch_shrink;
+	real_t stretch_shrink;
 
 	void _update_root_rect();
 
@@ -415,10 +415,10 @@ public:
 	void get_nodes_in_group(const StringName &p_group, List<Node *> *p_list);
 	bool has_group(const StringName &p_identifier) const;
 
-	void set_screen_stretch(StretchMode p_mode, StretchAspect p_aspect, const Size2 p_minsize, int p_shrink = 1);
+	void set_screen_stretch(StretchMode p_mode, StretchAspect p_aspect, const Size2 p_minsize, real_t p_shrink = 1);
 
-//void change_scene(const String& p_path);
-//Node *get_loaded_scene();
+	//void change_scene(const String& p_path);
+	//Node *get_loaded_scene();
 
 #ifdef TOOLS_ENABLED
 	void set_edited_scene_root(Node *p_node);


### PR DESCRIPTION
Fix the `Project Settings/Display/Window/Stretch/Shrink` cannot set to float numbers