### PR TITLE
iOS GameCenter fixes

### DIFF
--- a/platform/iphone/game_center.h
+++ b/platform/iphone/game_center.h
@@ -43,11 +43,13 @@ class GameCenter : public Object {
 
 	List<Variant> pending_events;
 
-	bool connected;
+	bool authenticated;
+
+	void return_connect_error(const char *p_error_description);
 
 public:
-	Error connect();
-	bool is_connected();
+	void connect();
+	bool is_authenticated();
 
 	Error post_score(Variant p_score);
 	Error award_achievement(Variant p_params);
@@ -55,6 +57,7 @@ public:
 	void request_achievements();
 	void request_achievement_descriptions();
 	Error show_game_center(Variant p_params);
+	Error request_identity_verification_signature();
 
 	void game_center_closed();
 


### PR DESCRIPTION
There are few issues with GameCenter singleton:
1. Methods `connect` and `is_connected` are overlapped with corresponding methods of `Object` class (the ones that connect signals), therefore they are unreachable from GDScript.
2. Normally, `connect` is called automatically at the game start (from os_iphone.cpp) and sends "authentication" event with result. However if GameCenter API is not available, it returns immediately with error (which is ignored) and never sends "authentication" event. And that makes impossible to determine if authentication is already failed or still in progress.
3. Also, subsequent calls of `connect` do nothing (and that's fine according to [Apple Guidelines](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/GameKit_Guide/Users/Users.html#//apple_ref/doc/uid/TP40008304-CH8-SW15)), so it's pretty much useless to call it manually.
4. There is no method for secure authentication with third-party server, though iOS SDK has a [method for this](https://developer.apple.com/documentation/gamekit/gklocalplayer/1515407-generateidentityverificationsign?language=objc).

So, I made these changes:
1. Changed `connect` method so it sends "authentication" event with error instead of returning error. That way, "authentication" event is guaranteed to be sent.
2. Removed GDScript binding for `connect` method as it's useless anyway.
3. Renamed `is_connected` to `is_authenticated` to avoid confilct with `Object::is_connected` method.
4. For authentication with third-party server I added `request_identity_verification_signature` method which sends "identity_verification_signature" event containing all necessary information for secure authentication (tested it with my own server, works fine).