### PR TITLE
Physics server plug

### DIFF
--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -155,11 +155,6 @@ void OS_Android::initialize(const VideoMode &p_desired, int p_video_driver, int 
 
 	AudioDriverManager::initialize(p_audio_driver);
 
-	physics_server = memnew(PhysicsServerSW);
-	physics_server->init();
-	physics_2d_server = Physics2DServerWrapMT::init_server<Physics2DServerSW>();
-	physics_2d_server->init();
-
 	input = memnew(InputDefault);
 	input->set_fallback_mapping("Default Android Gamepad");
 

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -38,9 +38,6 @@
 #include "os/main_loop.h"
 //#include "power_android.h"
 #include "servers/audio_server.h"
-#include "servers/physics/physics_server_sw.h"
-#include "servers/physics_2d/physics_2d_server_sw.h"
-#include "servers/physics_2d/physics_2d_server_wrap_mt.h"
 #include "servers/visual/rasterizer.h"
 
 #ifdef ANDROID_NATIVE_ACTIVITY
@@ -106,8 +103,6 @@ private:
 	bool use_16bits_fbo;
 
 	VisualServer *visual_server;
-	PhysicsServer *physics_server;
-	Physics2DServer *physics_2d_server;
 
 	mutable String data_dir_cache;
 

--- a/platform/haiku/os_haiku.cpp
+++ b/platform/haiku/os_haiku.cpp
@@ -130,13 +130,6 @@ void OS_Haiku::initialize(const VideoMode &p_desired, int p_video_driver, int p_
 	window->Show();
 	visual_server->init();
 
-	physics_server = memnew(PhysicsServerSW);
-	physics_server->init();
-	physics_2d_server = memnew(Physics2DServerSW);
-	// TODO: enable multithreaded PS
-	//physics_2d_server = Physics2DServerWrapMT::init_server<Physics2DServerSW>();
-	physics_2d_server->init();
-
 	AudioDriverManager::initialize(p_audio_driver);
 
 	power_manager = memnew(PowerHaiku);
@@ -152,12 +145,6 @@ void OS_Haiku::finalize() {
 	visual_server->finish();
 	memdelete(visual_server);
 	memdelete(rasterizer);
-
-	physics_server->finish();
-	memdelete(physics_server);
-
-	physics_2d_server->finish();
-	memdelete(physics_2d_server);
 
 	memdelete(input);
 

--- a/platform/haiku/os_haiku.h
+++ b/platform/haiku/os_haiku.h
@@ -38,8 +38,6 @@
 #include "main/input_default.h"
 #include "power_haiku.h"
 #include "servers/audio_server.h"
-#include "servers/physics_2d/physics_2d_server_sw.h"
-#include "servers/physics_server.h"
 #include "servers/visual/rasterizer.h"
 #include "servers/visual_server.h"
 
@@ -52,8 +50,6 @@ private:
 	Rasterizer *rasterizer;
 	VisualServer *visual_server;
 	VideoMode current_video_mode;
-	PhysicsServer *physics_server;
-	Physics2DServer *physics_2d_server;
 	PowerHaiku *power_manager;
 
 #ifdef MEDIA_KIT_ENABLED

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -136,13 +136,6 @@ void OSIPhone::initialize(const VideoMode &p_desired, int p_video_driver, int p_
 	AudioDriverManager::add_driver(&audio_driver);
 	AudioDriverManager::initialize(p_audio_driver);
 
-	// init physics servers
-	physics_server = memnew(PhysicsServerSW);
-	physics_server->init();
-	//physics_2d_server = memnew( Physics2DServerSW );
-	physics_2d_server = Physics2DServerWrapMT::init_server<Physics2DServerSW>();
-	physics_2d_server->init();
-
 	input = memnew(InputDefault);
 
 /*
@@ -381,12 +374,6 @@ void OSIPhone::finalize() {
 	visual_server->finish();
 	memdelete(visual_server);
 	//	memdelete(rasterizer);
-
-	physics_server->finish();
-	memdelete(physics_server);
-
-	physics_2d_server->finish();
-	memdelete(physics_2d_server);
 
 	memdelete(input);
 };

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -41,9 +41,6 @@
 #include "in_app_store.h"
 #include "main/input_default.h"
 #include "servers/audio_server.h"
-#include "servers/physics/physics_server_sw.h"
-#include "servers/physics_2d/physics_2d_server_sw.h"
-#include "servers/physics_2d/physics_2d_server_wrap_mt.h"
 #include "servers/visual/rasterizer.h"
 #include "servers/visual_server.h"
 
@@ -66,8 +63,6 @@ private:
 	uint8_t supported_orientations;
 
 	VisualServer *visual_server;
-	PhysicsServer *physics_server;
-	Physics2DServer *physics_2d_server;
 
 	AudioDriverCoreAudio audio_driver;
 

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -480,11 +480,6 @@ void OS_JavaScript::initialize(const VideoMode &p_desired, int p_video_driver, i
 
 	print_line("Init Physicsserver");
 
-	physics_server = memnew(PhysicsServerSW);
-	physics_server->init();
-	physics_2d_server = memnew(Physics2DServerSW);
-	physics_2d_server->init();
-
 	input = memnew(InputDefault);
 	_input = input;
 

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -39,8 +39,6 @@
 #include "os/main_loop.h"
 #include "power_javascript.h"
 #include "servers/audio_server.h"
-#include "servers/physics/physics_server_sw.h"
-#include "servers/physics_2d/physics_2d_server_sw.h"
 #include "servers/visual/rasterizer.h"
 
 #include <emscripten/html5.h>
@@ -54,8 +52,6 @@ class OS_JavaScript : public OS_Unix {
 	int64_t last_sync_time;
 
 	VisualServer *visual_server;
-	PhysicsServer *physics_server;
-	Physics2DServer *physics_2d_server;
 	AudioDriverJavaScript audio_driver_javascript;
 	const char *gl_extensions;
 

--- a/platform/osx/crash_handler_osx.mm
+++ b/platform/osx/crash_handler_osx.mm
@@ -29,6 +29,7 @@
 /*************************************************************************/
 #include "main/main.h"
 #include "os_osx.h"
+#include "project_settings.h"
 
 #include <string.h>
 #include <unistd.h>

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -38,9 +38,6 @@
 #include "os/input.h"
 #include "power_osx.h"
 #include "servers/audio_server.h"
-#include "servers/physics_2d/physics_2d_server_sw.h"
-#include "servers/physics_2d/physics_2d_server_wrap_mt.h"
-#include "servers/physics_server.h"
 #include "servers/visual/rasterizer.h"
 #include "servers/visual/visual_server_wrap_mt.h"
 #include "servers/visual_server.h"
@@ -61,9 +58,6 @@ public:
 
 	List<String> args;
 	MainLoop *main_loop;
-
-	PhysicsServer *physics_server;
-	Physics2DServer *physics_2d_server;
 
 	IP_Unix *ip_unix;
 

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -35,7 +35,6 @@
 #include "os/keyboard.h"
 #include "print_string.h"
 #include "sem_osx.h"
-#include "servers/physics/physics_server_sw.h"
 #include "servers/visual/visual_server_raster.h"
 
 #include <Carbon/Carbon.h>
@@ -1092,13 +1091,6 @@ void OS_OSX::initialize(const VideoMode &p_desired, int p_video_driver, int p_au
 
 	AudioDriverManager::initialize(p_audio_driver);
 
-	//
-	physics_server = memnew(PhysicsServerSW);
-	physics_server->init();
-	//physics_2d_server = memnew( Physics2DServerSW );
-	physics_2d_server = Physics2DServerWrapMT::init_server<Physics2DServerSW>();
-	physics_2d_server->init();
-
 	input = memnew(InputDefault);
 	joypad_osx = memnew(JoypadOSX);
 
@@ -1120,12 +1112,6 @@ void OS_OSX::finalize() {
 	visual_server->finish();
 	memdelete(visual_server);
 	//memdelete(rasterizer);
-
-	physics_server->finish();
-	memdelete(physics_server);
-
-	physics_2d_server->finish();
-	memdelete(physics_2d_server);
 }
 
 void OS_OSX::set_main_loop(MainLoop *p_main_loop) {

--- a/platform/server/os_server.cpp
+++ b/platform/server/os_server.cpp
@@ -31,7 +31,6 @@
 //#include "servers/visual/rasterizer_dummy.h"
 #include "os_server.h"
 #include "print_string.h"
-#include "servers/physics/physics_server_sw.h"
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -75,11 +74,6 @@ void OS_Server::initialize(const VideoMode &p_desired, int p_video_driver, int p
 	ERR_FAIL_COND(!visual_server);
 
 	visual_server->init();
-	//
-	physics_server = memnew(PhysicsServerSW);
-	physics_server->init();
-	physics_2d_server = memnew(Physics2DServerSW);
-	physics_2d_server->init();
 
 	input = memnew(InputDefault);
 
@@ -110,12 +104,6 @@ void OS_Server::finalize() {
 	visual_server->finish();
 	memdelete(visual_server);
 	//memdelete(rasterizer);
-
-	physics_server->finish();
-	memdelete(physics_server);
-
-	physics_2d_server->finish();
-	memdelete(physics_2d_server);
 
 	memdelete(input);
 

--- a/platform/server/os_server.h
+++ b/platform/server/os_server.h
@@ -35,8 +35,6 @@
 #include "drivers/unix/os_unix.h"
 #include "main/input_default.h"
 #include "servers/audio_server.h"
-#include "servers/physics_2d/physics_2d_server_sw.h"
-#include "servers/physics_server.h"
 #include "servers/visual/rasterizer.h"
 #include "servers/visual_server.h"
 
@@ -55,9 +53,6 @@ class OS_Server : public OS_Unix {
 	MainLoop *main_loop;
 
 	bool grab;
-
-	PhysicsServer *physics_server;
-	Physics2DServer *physics_2d_server;
 
 	virtual void delete_main_loop();
 	IP_Unix *ip_unix;

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -262,13 +262,6 @@ void OSUWP::initialize(const VideoMode &p_desired, int p_video_driver, int p_aud
 	}
 	*/
 
-	//
-	physics_server = memnew(PhysicsServerSW);
-	physics_server->init();
-
-	physics_2d_server = memnew(Physics2DServerSW);
-	physics_2d_server->init();
-
 	visual_server->init();
 
 	input = memnew(InputDefault);
@@ -366,12 +359,6 @@ void OSUWP::finalize() {
 #endif
 
 	memdelete(input);
-
-	physics_server->finish();
-	memdelete(physics_server);
-
-	physics_2d_server->finish();
-	memdelete(physics_2d_server);
 
 	joypad = nullptr;
 }

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -40,8 +40,6 @@
 #include "os/os.h"
 #include "power_uwp.h"
 #include "servers/audio_server.h"
-#include "servers/physics/physics_server_sw.h"
-#include "servers/physics_2d/physics_2d_server_sw.h"
 #include "servers/visual/rasterizer.h"
 #include "servers/visual_server.h"
 
@@ -94,8 +92,6 @@ private:
 	int old_x, old_y;
 	Point2i center;
 	VisualServer *visual_server;
-	PhysicsServer *physics_server;
-	Physics2DServer *physics_2d_server;
 	int pressrc;
 
 	ContextEGL *gl_context;

--- a/platform/windows/crash_handler_win.cpp
+++ b/platform/windows/crash_handler_win.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 #include "main/main.h"
 #include "os_windows.h"
+#include "project_settings.h"
 
 #ifdef CRASH_HANDLER_EXCEPTION
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -42,7 +42,6 @@
 #include "lang_table.h"
 #include "main/main.h"
 #include "packet_peer_udp_winsock.h"
-#include "project_settings.h"
 #include "servers/audio_server.h"
 #include "servers/visual/visual_server_raster.h"
 #include "servers/visual/visual_server_wrap_mt.h"
@@ -1056,12 +1055,6 @@ void OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int 
 		visual_server = memnew(VisualServerWrapMT(visual_server, get_render_thread_mode() == RENDER_SEPARATE_THREAD));
 	}
 
-	physics_server = memnew(PhysicsServerSW);
-	physics_server->init();
-
-	physics_2d_server = Physics2DServerWrapMT::init_server<Physics2DServerSW>();
-	physics_2d_server->init();
-
 	if (!is_no_window_mode_enabled()) {
 		ShowWindow(hWnd, SW_SHOW); // Show The Window
 		SetForegroundWindow(hWnd); // Slightly Higher Priority
@@ -1223,12 +1216,6 @@ void OS_Windows::finalize() {
 		memdelete(debugger_connection_console);
 	}
 	*/
-
-	physics_server->finish();
-	memdelete(physics_server);
-
-	physics_2d_server->finish();
-	memdelete(physics_2d_server);
 }
 
 void OS_Windows::finalize_core() {

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -29,8 +29,8 @@
 /*************************************************************************/
 #ifndef OS_WINDOWS_H
 #define OS_WINDOWS_H
-
 #include "context_gl_win.h"
+#include "core/project_settings.h"
 #include "crash_handler_win.h"
 #include "drivers/rtaudio/audio_driver_rtaudio.h"
 #include "drivers/wasapi/audio_driver_wasapi.h"
@@ -38,7 +38,6 @@
 #include "os/os.h"
 #include "power_windows.h"
 #include "servers/audio_server.h"
-#include "servers/physics/physics_server_sw.h"
 #include "servers/visual/rasterizer.h"
 #include "servers/visual_server.h"
 #ifdef XAUDIO2_ENABLED
@@ -47,8 +46,6 @@
 #include "drivers/unix/ip_unix.h"
 #include "key_mapping_win.h"
 #include "main/input_default.h"
-#include "servers/physics_2d/physics_2d_server_sw.h"
-#include "servers/physics_2d/physics_2d_server_wrap_mt.h"
 
 #include <fcntl.h>
 #include <io.h>
@@ -90,8 +87,6 @@ class OS_Windows : public OS {
 	ContextGL_Win *gl_context;
 #endif
 	VisualServer *visual_server;
-	PhysicsServer *physics_server;
-	Physics2DServer *physics_2d_server;
 	int pressrc;
 	HDC hDC; // Private GDI Device Context
 	HINSTANCE hInstance; // Holds The Instance Of The Application

--- a/platform/x11/crash_handler_x11.cpp
+++ b/platform/x11/crash_handler_x11.cpp
@@ -33,6 +33,7 @@
 
 #include "main/main.h"
 #include "os_x11.h"
+#include "project_settings.h"
 
 #ifdef CRASH_HANDLER_ENABLED
 #include <cxxabi.h>

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -32,7 +32,6 @@
 #include "errno.h"
 #include "key_mapping_x11.h"
 #include "print_string.h"
-#include "servers/physics/physics_server_sw.h"
 #include "servers/visual/visual_server_raster.h"
 #include "servers/visual/visual_server_wrap_mt.h"
 #include <mntent.h>
@@ -458,12 +457,6 @@ void OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_au
 	requested = None;
 
 	visual_server->init();
-	//
-	physics_server = memnew(PhysicsServerSW);
-	physics_server->init();
-	//physics_2d_server = memnew( Physics2DServerSW );
-	physics_2d_server = Physics2DServerWrapMT::init_server<Physics2DServerSW>();
-	physics_2d_server->init();
 
 	input = memnew(InputDefault);
 
@@ -518,12 +511,6 @@ void OS_X11::finalize() {
 	visual_server->finish();
 	memdelete(visual_server);
 	//memdelete(rasterizer);
-
-	physics_server->finish();
-	memdelete(physics_server);
-
-	physics_2d_server->finish();
-	memdelete(physics_2d_server);
 
 	memdelete(power_manager);
 

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -42,9 +42,6 @@
 #include "main/input_default.h"
 #include "power_x11.h"
 #include "servers/audio_server.h"
-#include "servers/physics_2d/physics_2d_server_sw.h"
-#include "servers/physics_2d/physics_2d_server_wrap_mt.h"
-#include "servers/physics_server.h"
 #include "servers/visual/rasterizer.h"
 
 #include <X11/Xcursor/Xcursor.h>
@@ -121,10 +118,8 @@ class OS_X11 : public OS_Unix {
 	uint64_t last_click_ms;
 	uint32_t last_button_state;
 
-	PhysicsServer *physics_server;
 	unsigned int get_mouse_button_state(unsigned int p_x11_state);
 	void get_key_modifier_state(unsigned int p_x11_state, Ref<InputEventWithModifiers> state);
-	Physics2DServer *physics_2d_server;
 
 	MouseMode mouse_mode;
 	Point2i center;

--- a/servers/physics_2d_server.cpp
+++ b/servers/physics_2d_server.cpp
@@ -28,7 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include "physics_2d_server.h"
+#include "core/project_settings.h"
 #include "print_string.h"
+
 Physics2DServer *Physics2DServer::singleton = NULL;
 
 void Physics2DDirectBodyState::integrate_forces() {
@@ -690,4 +692,69 @@ Physics2DServer::Physics2DServer() {
 Physics2DServer::~Physics2DServer() {
 
 	singleton = NULL;
+}
+
+Vector<Physics2DServerManager::ClassInfo> Physics2DServerManager::physics_2d_servers;
+int Physics2DServerManager::default_server_id = -1;
+int Physics2DServerManager::default_server_priority = -1;
+const String Physics2DServerManager::setting_property_name("physics/2d/physics_engine");
+
+void Physics2DServerManager::on_servers_changed() {
+
+	String physics_servers("DEFAULT");
+	for (int i = get_servers_count() - 1; 0 <= i; --i) {
+		physics_servers += "," + get_server_name(i);
+	}
+	ProjectSettings::get_singleton()->set_custom_property_info(setting_property_name, PropertyInfo(Variant::STRING, setting_property_name, PROPERTY_HINT_ENUM, physics_servers));
+}
+
+void Physics2DServerManager::register_server(const String &p_name, CreatePhysics2DServerCallback p_creat_callback) {
+
+	ERR_FAIL_COND(!p_creat_callback);
+	ERR_FAIL_COND(find_server_id(p_name) != -1);
+	physics_2d_servers.push_back(ClassInfo(p_name, p_creat_callback));
+	on_servers_changed();
+}
+
+void Physics2DServerManager::set_default_server(const String &p_name, int p_priority) {
+
+	const int id = find_server_id(p_name);
+	ERR_FAIL_COND(id == -1); // Not found
+	if (default_server_priority < p_priority) {
+		default_server_id = id;
+		default_server_priority = p_priority;
+	}
+}
+
+int Physics2DServerManager::find_server_id(const String &p_name) {
+
+	for (int i = physics_2d_servers.size() - 1; 0 <= i; --i) {
+		if (p_name == physics_2d_servers[i].name) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+int Physics2DServerManager::get_servers_count() {
+	return physics_2d_servers.size();
+}
+
+String Physics2DServerManager::get_server_name(int p_id) {
+	ERR_FAIL_INDEX_V(p_id, get_servers_count(), "");
+	return physics_2d_servers[p_id].name;
+}
+
+Physics2DServer *Physics2DServerManager::new_default_server() {
+	ERR_FAIL_COND_V(default_server_id == -1, NULL);
+	return physics_2d_servers[default_server_id].create_callback();
+}
+
+Physics2DServer *Physics2DServerManager::new_server(const String &p_name) {
+	int id = find_server_id(p_name);
+	if (id == -1) {
+		return NULL;
+	} else {
+		return physics_2d_servers[id].create_callback();
+	}
 }

--- a/servers/physics_2d_server.h
+++ b/servers/physics_2d_server.h
@@ -590,6 +590,43 @@ public:
 	Physics2DTestMotionResult();
 };
 
+typedef Physics2DServer *(*CreatePhysics2DServerCallback)();
+
+class Physics2DServerManager {
+	struct ClassInfo {
+		String name;
+		CreatePhysics2DServerCallback create_callback;
+
+		ClassInfo()
+			: name(""), create_callback(NULL) {}
+
+		ClassInfo(String p_name, CreatePhysics2DServerCallback p_create_callback)
+			: name(p_name), create_callback(p_create_callback) {}
+
+		ClassInfo(const ClassInfo &p_ci)
+			: name(p_ci.name), create_callback(p_ci.create_callback) {}
+	};
+
+	static Vector<ClassInfo> physics_2d_servers;
+	static int default_server_id;
+	static int default_server_priority;
+
+public:
+	static const String setting_property_name;
+
+private:
+	static void on_servers_changed();
+
+public:
+	static void register_server(const String &p_name, CreatePhysics2DServerCallback p_creat_callback);
+	static void set_default_server(const String &p_name, int p_priority = 0);
+	static int find_server_id(const String &p_name);
+	static int get_servers_count();
+	static String get_server_name(int p_id);
+	static Physics2DServer *new_default_server();
+	static Physics2DServer *new_server(const String &p_name);
+};
+
 VARIANT_ENUM_CAST(Physics2DServer::ShapeType);
 VARIANT_ENUM_CAST(Physics2DServer::SpaceParameter);
 VARIANT_ENUM_CAST(Physics2DServer::AreaParameter);

--- a/servers/physics_server.h
+++ b/servers/physics_server.h
@@ -658,6 +658,43 @@ public:
 	~PhysicsServer();
 };
 
+typedef PhysicsServer *(*CreatePhysicsServerCallback)();
+
+class PhysicsServerManager {
+	struct ClassInfo {
+		String name;
+		CreatePhysicsServerCallback create_callback;
+
+		ClassInfo()
+			: name(""), create_callback(NULL) {}
+
+		ClassInfo(String p_name, CreatePhysicsServerCallback p_create_callback)
+			: name(p_name), create_callback(p_create_callback) {}
+
+		ClassInfo(const ClassInfo &p_ci)
+			: name(p_ci.name), create_callback(p_ci.create_callback) {}
+	};
+
+	static Vector<ClassInfo> physics_servers;
+	static int default_server_id;
+	static int default_server_priority;
+
+public:
+	static const String setting_property_name;
+
+private:
+	static void on_servers_changed();
+
+public:
+	static void register_server(const String &p_name, CreatePhysicsServerCallback p_creat_callback);
+	static void set_default_server(const String &p_name, int p_priority = 0);
+	static int find_server_id(const String &p_name);
+	static int get_servers_count();
+	static String get_server_name(int p_id);
+	static PhysicsServer *new_default_server();
+	static PhysicsServer *new_server(const String &p_name);
+};
+
 VARIANT_ENUM_CAST(PhysicsServer::ShapeType);
 VARIANT_ENUM_CAST(PhysicsServer::SpaceParameter);
 VARIANT_ENUM_CAST(PhysicsServer::AreaParameter);

--- a/servers/register_server_types.h
+++ b/servers/register_server_types.h
@@ -33,4 +33,6 @@
 void register_server_types();
 void unregister_server_types();
 
+void register_server_singletons();
+
 #endif // REGISTER_SERVER_TYPES_H


### PR DESCRIPTION
I've implemented the possibility to plug the physics server.

To register new physics server you have to register it in this way: 

> ClassDB::register_class<PhysicsServerSW>();
> PhysicsServerManager::register_class<PhysicsServerSW>();

Optionally you can set new default physics server by using: 
> PhysicsServerManager::set_default_class(int p_priority = 0);

New server can be put into the "modules" directory.

After the registration of server you can select the one to use in the project settings under physics 3D.

---
@Reduz As you can see the default "Godot physics" is registered by register_server_types and all other servers can be set into modules and registered by its own registering function.
For this reason is necessary start the physics server after the registration of both servers and modules, so all registered physics server are taken
So I created these new functions: 

**FILE:** core/os/os.h
> virtual void initialize_physics() = 0;

**FILE:** servers/register_server_types.h
> void register_server_singletons();

Here the code where is handled the physics start: https://github.com/AndreaCatania/godot/blob/36e6024dcbc036c43a722cac9949ff3e1f3edde9/main/main.cpp#L1075-L1084

I've checked and my modification doesn't make any problem on my machine, but I'm not 100% sure if the registration of server's singletons and the physics server after the module registration may cause some problems, So @reduz please let me know if it's wrong or it's fine.