### PR TITLE
Fix formatting of debug log overflow (2.1)

### DIFF
--- a/core/script_debugger_remote.cpp
+++ b/core/script_debugger_remote.cpp
@@ -1069,15 +1069,19 @@ void ScriptDebuggerRemote::_print_handler(void *p_this, const String &p_string) 
 	}
 
 	sdr->char_count += allowed_chars;
-
-	if (sdr->char_count >= sdr->max_cps) {
-		s += "\n[output overflow, print less text!]\n";
-	}
+	bool overflowed = sdr->char_count >= sdr->max_cps;
 
 	sdr->mutex->lock();
 	if (!sdr->locking && sdr->tcp_client->is_connected()) {
 
+		if (overflowed)
+			s += "[...]";
+
 		sdr->output_strings.push_back(s);
+
+		if (overflowed) {
+			sdr->output_strings.push_back("[output overflow, print less text!]");
+		}
 	}
 	sdr->mutex->unlock();
 }


### PR DESCRIPTION
(cherry picked from commit d645b80e468da7c8dcf8d55aec96f860dd64eaec)