### PR TITLE
Fix LineEdit drag selection to the left

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1036,9 +1036,11 @@ void LineEdit::set_cursor_position(int p_pos) {
 	Ref<StyleBox> style = get_stylebox("normal");
 	Ref<Font> font = get_font("font");
 
-	if (cursor_pos < window_pos) {
+	if (cursor_pos <= window_pos) {
 		/* Adjust window if cursor goes too much to the left */
-		set_window_pos(cursor_pos);
+		if (window_pos > 0)
+			set_window_pos(window_pos - 1);
+
 	} else if (cursor_pos > window_pos) {
 		/* Adjust window if cursor goes too much to the right */
 		int window_width = get_size().width - style->get_minimum_size().width;


### PR DESCRIPTION
Not sure what the code for the right dragging is, maybe it is also needed with left direction dragging.

see
https://github.com/AlexHolly/godot/blob/99a3f3ec19cdb1246a548407be99fd5bd69e0e89/scene/gui/line_edit.cpp#L1046

My solution seems to work.

Closes #11948