### PR TITLE
Fix InputEventJoypadMotion::action_match for 0 axis values.

### DIFF
--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -637,7 +637,7 @@ bool InputEventJoypadMotion::action_match(const Ref<InputEvent> &p_event) const 
 	if (jm.is_null())
 		return false;
 
-	return (axis == jm->axis && (axis_value < 0) == (jm->axis_value < 0));
+	return (axis == jm->axis && ((axis_value < 0) == (jm->axis_value < 0) || jm->axis_value == 0));
 }
 
 String InputEventJoypadMotion::as_text() const {


### PR DESCRIPTION
Make action_match ignore the sign if axis value is 0.
This means that an axis value of 0 will match actions defined for both positive and negative values, as expected. Previously only actions with positive values would be matched.

Fixes #12223