### PR TITLE
Implement auto-tiling

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -4572,9 +4572,9 @@ VSplitContainer *SpatialEditor::get_shader_split() {
 	return shader_split;
 }
 
-HSplitContainer *SpatialEditor::get_palette_split() {
+HBoxContainer *SpatialEditor::get_palette_split() {
 
-	return palette_split;
+	return palette_split_container;
 }
 
 void SpatialEditor::_request_gizmo(Object *p_obj) {
@@ -4850,6 +4850,10 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	palette_split = memnew(HSplitContainer);
 	palette_split->set_v_size_flags(SIZE_EXPAND_FILL);
 	vbc->add_child(palette_split);
+
+	palette_split_container = memnew(HBoxContainer);
+	palette_split_container->set_v_size_flags(SIZE_EXPAND_FILL);
+	palette_split->add_child(palette_split_container);
 
 	shader_split = memnew(VSplitContainer);
 	shader_split->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -405,6 +405,7 @@ private:
 	SpatialEditorViewport *viewports[VIEWPORTS_COUNT];
 	VSplitContainer *shader_split;
 	HSplitContainer *palette_split;
+	HBoxContainer *palette_split_container;
 
 	/////
 
@@ -593,7 +594,7 @@ public:
 	void add_control_to_menu_panel(Control *p_control);
 
 	VSplitContainer *get_shader_split();
-	HSplitContainer *get_palette_split();
+	HBoxContainer *get_palette_split();
 
 	Spatial *get_selected() { return selected; }
 

--- a/editor/plugins/tile_map_editor_plugin.h
+++ b/editor/plugins/tile_map_editor_plugin.h
@@ -137,6 +137,8 @@ class TileMapEditor : public VBoxContainer {
 		bool flip_h;
 		bool flip_v;
 		bool transpose;
+		int auto_x;
+		int auto_y;
 	};
 
 	List<TileData> copydata;

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 #include "tile_set_editor_plugin.h"
 
+#include "editor/plugins/canvas_item_editor_plugin.h"
 #include "scene/2d/physics_body_2d.h"
 #include "scene/2d/sprite.h"
 
@@ -271,6 +272,7 @@ void TileSetEditorPlugin::edit(Object *p_node) {
 	if (Object::cast_to<TileSet>(p_node)) {
 		tileset_editor->edit(Object::cast_to<TileSet>(p_node));
 		tileset_editor->show();
+		autotile_editor->edit(p_node);
 	} else
 		tileset_editor->hide();
 }
@@ -282,19 +284,1151 @@ bool TileSetEditorPlugin::handles(Object *p_node) const {
 
 void TileSetEditorPlugin::make_visible(bool p_visible) {
 
-	if (p_visible)
+	if (p_visible) {
 		tileset_editor->show();
-	else
+		autotile_button->show();
+		autotile_editor->side_panel->show();
+		if (autotile_button->is_pressed()) {
+			autotile_editor->show();
+		}
+	} else {
 		tileset_editor->hide();
+		autotile_editor->side_panel->hide();
+		autotile_editor->hide();
+		autotile_button->hide();
+	}
 }
 
 TileSetEditorPlugin::TileSetEditorPlugin(EditorNode *p_node) {
 
 	tileset_editor = memnew(TileSetEditor(p_node));
 
-	p_node->get_viewport()->add_child(tileset_editor);
+	add_control_to_container(CONTAINER_CANVAS_EDITOR_MENU, tileset_editor);
 	tileset_editor->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	tileset_editor->set_anchor(MARGIN_BOTTOM, Control::ANCHOR_BEGIN);
 	tileset_editor->set_end(Point2(0, 22));
 	tileset_editor->hide();
+
+	autotile_editor = memnew(AutotileEditor(p_node));
+	add_control_to_container(CONTAINER_CANVAS_EDITOR_SIDE, autotile_editor->side_panel);
+	autotile_editor->side_panel->set_anchors_and_margins_preset(Control::PRESET_WIDE);
+	autotile_editor->side_panel->set_custom_minimum_size(Size2(200, 0));
+	autotile_editor->side_panel->hide();
+	autotile_button = p_node->add_bottom_panel_item("Autotiles", autotile_editor);
+	autotile_button->hide();
+}
+
+AutotileEditor::AutotileEditor(EditorNode *p_editor) {
+
+	editor = p_editor;
+
+	//Side Panel
+	side_panel = memnew(Control);
+	side_panel->set_name("Autotiles");
+
+	VSplitContainer *split = memnew(VSplitContainer);
+	side_panel->add_child(split);
+	split->set_anchors_and_margins_preset(Control::PRESET_WIDE);
+
+	autotile_list = memnew(ItemList);
+	autotile_list->set_v_size_flags(SIZE_EXPAND_FILL);
+	autotile_list->set_h_size_flags(SIZE_EXPAND_FILL);
+	autotile_list->set_custom_minimum_size(Size2(02, 200));
+	autotile_list->connect("item_selected", this, "_on_autotile_selected");
+	split->add_child(autotile_list);
+
+	property_editor = memnew(PropertyEditor);
+	property_editor->set_v_size_flags(SIZE_EXPAND_FILL);
+	property_editor->set_h_size_flags(SIZE_EXPAND_FILL);
+	split->add_child(property_editor);
+
+	helper = memnew(AutotileEditorHelper(this));
+	property_editor->edit(helper);
+
+	// Editor
+
+	dragging_point = -1;
+	creating_shape = false;
+
+	set_custom_minimum_size(Size2(0, 150));
+
+	VBoxContainer *main_vb = memnew(VBoxContainer);
+	add_child(main_vb);
+	main_vb->set_anchors_and_margins_preset(Control::PRESET_WIDE);
+
+	HBoxContainer *tool_hb = memnew(HBoxContainer);
+	Ref<ButtonGroup> g(memnew(ButtonGroup));
+
+	String label[EDITMODE_MAX] = { "Icon", "Bitmask", "Collision", "Occlusion", "Navigation", "Priority" };
+
+	for (int i = 0; i < (int)EDITMODE_MAX; i++) {
+		tool_editmode[i] = memnew(Button);
+		tool_editmode[i]->set_text(label[i]);
+		tool_editmode[i]->set_toggle_mode(true);
+		tool_editmode[i]->set_button_group(g);
+		Vector<Variant> args;
+		args.push_back(i);
+		tool_editmode[i]->connect("pressed", this, "_on_edit_mode_changed", args);
+		tool_hb->add_child(tool_editmode[i]);
+	}
+	tool_editmode[EDITMODE_ICON]->set_pressed(true);
+
+	main_vb->add_child(tool_hb);
+	main_vb->add_child(memnew(HSeparator));
+
+	toolbar = memnew(HBoxContainer);
+	for (int i = 0; i < (int)TOOLBAR_MAX; i++) {
+		tool_containers[i] = memnew(HBoxContainer);
+		toolbar->add_child(tool_containers[i]);
+		tool_containers[i]->hide();
+	}
+
+	Ref<ButtonGroup> tg(memnew(ButtonGroup));
+
+	tools[TOOL_SELECT] = memnew(ToolButton);
+	tool_containers[TOOLBAR_DUMMY]->add_child(tools[TOOL_SELECT]);
+	tools[TOOL_SELECT]->set_tooltip("Select sub-tile to use as icon, this will be also used on invalid autotile bindings.");
+	tools[TOOL_SELECT]->set_toggle_mode(true);
+	tools[TOOL_SELECT]->set_button_group(tg);
+	tools[TOOL_SELECT]->set_pressed(true);
+	tool_containers[TOOLBAR_DUMMY]->show();
+
+	Vector<Variant> p;
+	tools[BITMASK_COPY] = memnew(ToolButton);
+	p.push_back((int)BITMASK_COPY);
+	tools[BITMASK_COPY]->connect("pressed", this, "_on_tool_clicked", p);
+	tool_containers[TOOLBAR_BITMASK]->add_child(tools[BITMASK_COPY]);
+	tools[BITMASK_PASTE] = memnew(ToolButton);
+	p = Vector<Variant>();
+	p.push_back((int)BITMASK_PASTE);
+	tools[BITMASK_PASTE]->connect("pressed", this, "_on_tool_clicked", p);
+	tool_containers[TOOLBAR_BITMASK]->add_child(tools[BITMASK_PASTE]);
+	tools[BITMASK_CLEAR] = memnew(ToolButton);
+	p = Vector<Variant>();
+	p.push_back((int)BITMASK_CLEAR);
+	tools[BITMASK_CLEAR]->connect("pressed", this, "_on_tool_clicked", p);
+	tool_containers[TOOLBAR_BITMASK]->add_child(tools[BITMASK_CLEAR]);
+
+	tools[SHAPE_NEW_POLYGON] = memnew(ToolButton);
+	tool_containers[TOOLBAR_SHAPE]->add_child(tools[SHAPE_NEW_POLYGON]);
+	tools[SHAPE_NEW_POLYGON]->set_toggle_mode(true);
+	tools[SHAPE_NEW_POLYGON]->set_button_group(tg);
+	tool_containers[TOOLBAR_SHAPE]->add_child(memnew(VSeparator));
+	tools[SHAPE_DELETE] = memnew(ToolButton);
+	p = Vector<Variant>();
+	p.push_back((int)SHAPE_DELETE);
+	tools[SHAPE_DELETE]->connect("pressed", this, "_on_tool_clicked", p);
+	tool_containers[TOOLBAR_SHAPE]->add_child(tools[SHAPE_DELETE]);
+	//tools[SHAPE_CREATE_FROM_NOT_BITMASKED] = memnew(ToolButton);
+	//tool_containers[TOOLBAR_SHAPE]->add_child(tools[SHAPE_CREATE_FROM_NOT_BITMASKED]);
+	tool_containers[TOOLBAR_SHAPE]->add_change_receptor(memnew(VSeparator));
+	tools[SHAPE_KEEP_INSIDE_TILE] = memnew(ToolButton);
+	tools[SHAPE_KEEP_INSIDE_TILE]->set_toggle_mode(true);
+	tools[SHAPE_KEEP_INSIDE_TILE]->set_pressed(true);
+	tool_containers[TOOLBAR_SHAPE]->add_child(tools[SHAPE_KEEP_INSIDE_TILE]);
+	tools[SHAPE_SNAP_TO_BITMASK_GRID] = memnew(ToolButton);
+	tools[SHAPE_SNAP_TO_BITMASK_GRID]->set_toggle_mode(true);
+	tools[SHAPE_SNAP_TO_BITMASK_GRID]->set_pressed(true);
+	tool_containers[TOOLBAR_SHAPE]->add_child(tools[SHAPE_SNAP_TO_BITMASK_GRID]);
+
+	spin_priority = memnew(SpinBox);
+	spin_priority->set_min(1);
+	spin_priority->set_max(255);
+	spin_priority->set_step(1);
+	spin_priority->set_custom_minimum_size(Size2(100, 0));
+	spin_priority->connect("value_changed", this, "_on_priority_changed");
+	spin_priority->hide();
+	toolbar->add_child(spin_priority);
+
+	Control *separator = memnew(Control);
+	separator->set_h_size_flags(SIZE_EXPAND_FILL);
+	toolbar->add_child(separator);
+
+	tools[ZOOM_OUT] = memnew(ToolButton);
+	p = Vector<Variant>();
+	p.push_back((int)ZOOM_OUT);
+	tools[ZOOM_OUT]->connect("pressed", this, "_on_tool_clicked", p);
+	toolbar->add_child(tools[ZOOM_OUT]);
+	tools[ZOOM_1] = memnew(ToolButton);
+	p = Vector<Variant>();
+	p.push_back((int)ZOOM_1);
+	tools[ZOOM_1]->connect("pressed", this, "_on_tool_clicked", p);
+	toolbar->add_child(tools[ZOOM_1]);
+	tools[ZOOM_IN] = memnew(ToolButton);
+	p = Vector<Variant>();
+	p.push_back((int)ZOOM_IN);
+	tools[ZOOM_IN]->connect("pressed", this, "_on_tool_clicked", p);
+	toolbar->add_child(tools[ZOOM_IN]);
+
+	main_vb->add_child(toolbar);
+
+	ScrollContainer *scroll = memnew(ScrollContainer);
+	main_vb->add_child(scroll);
+	scroll->set_v_size_flags(SIZE_EXPAND_FILL);
+
+	workspace_container = memnew(Control);
+	scroll->add_child(workspace_container);
+
+	workspace = memnew(Control);
+	workspace->connect("draw", this, "_on_workspace_draw");
+	workspace->connect("gui_input", this, "_on_workspace_input");
+	workspace_container->add_child(workspace);
+
+	preview = memnew(Sprite);
+	workspace->add_child(preview);
+	preview->set_centered(false);
+	preview->set_draw_behind_parent(true);
+	preview->set_region(true);
+}
+
+void AutotileEditor::_bind_methods() {
+
+	ClassDB::bind_method("_on_autotile_selected", &AutotileEditor::_on_autotile_selected);
+	ClassDB::bind_method("_on_edit_mode_changed", &AutotileEditor::_on_edit_mode_changed);
+	ClassDB::bind_method("_on_workspace_draw", &AutotileEditor::_on_workspace_draw);
+	ClassDB::bind_method("_on_workspace_input", &AutotileEditor::_on_workspace_input);
+	ClassDB::bind_method("_on_tool_clicked", &AutotileEditor::_on_tool_clicked);
+	ClassDB::bind_method("_on_priority_changed", &AutotileEditor::_on_priority_changed);
+}
+
+void AutotileEditor::_notification(int p_what) {
+
+	if (p_what == NOTIFICATION_ENTER_TREE) {
+		tools[TOOL_SELECT]->set_icon(get_icon("ToolSelect", "EditorIcons"));
+		tools[BITMASK_COPY]->set_icon(get_icon("Duplicate", "EditorIcons"));
+		tools[BITMASK_PASTE]->set_icon(get_icon("Override", "EditorIcons"));
+		tools[BITMASK_CLEAR]->set_icon(get_icon("Clear", "EditorIcons"));
+		tools[SHAPE_NEW_POLYGON]->set_icon(get_icon("CollisionPolygon2D", "EditorIcons"));
+		tools[SHAPE_DELETE]->set_icon(get_icon("Remove", "EditorIcons"));
+		tools[SHAPE_KEEP_INSIDE_TILE]->set_icon(get_icon("Snap", "EditorIcons"));
+		tools[SHAPE_SNAP_TO_BITMASK_GRID]->set_icon(get_icon("SnapGrid", "EditorIcons"));
+		tools[ZOOM_OUT]->set_icon(get_icon("ZoomLess", "EditorIcons"));
+		tools[ZOOM_1]->set_icon(get_icon("ZoomReset", "EditorIcons"));
+		tools[ZOOM_IN]->set_icon(get_icon("ZoomMore", "EditorIcons"));
+	}
+}
+
+void AutotileEditor::_on_autotile_selected(int p_index) {
+
+	if (get_current_tile() >= 0) {
+		current_item_index = p_index;
+		preview->set_texture(tile_set->tile_get_texture(get_current_tile()));
+		preview->set_region_rect(tile_set->tile_get_region(get_current_tile()));
+		workspace->set_custom_minimum_size(tile_set->tile_get_region(get_current_tile()).size);
+	} else {
+		current_item_index = -1;
+		preview->set_texture(NULL);
+		workspace->set_custom_minimum_size(Size2i());
+	}
+	helper->_change_notify("");
+	workspace->update();
+}
+
+void AutotileEditor::_on_edit_mode_changed(int p_edit_mode) {
+
+	edit_mode = (EditMode)p_edit_mode;
+	switch (edit_mode) {
+		case EDITMODE_BITMASK: {
+			tool_containers[TOOLBAR_DUMMY]->show();
+			tool_containers[TOOLBAR_BITMASK]->show();
+			tool_containers[TOOLBAR_SHAPE]->hide();
+			tools[TOOL_SELECT]->set_pressed(true);
+			tools[TOOL_SELECT]->set_tooltip("LMB: set bit on.\nRMB: set bit off.");
+			spin_priority->hide();
+		} break;
+		case EDITMODE_COLLISION:
+		case EDITMODE_NAVIGATION:
+		case EDITMODE_OCCLUSION: {
+			tool_containers[TOOLBAR_DUMMY]->show();
+			tool_containers[TOOLBAR_BITMASK]->hide();
+			tool_containers[TOOLBAR_SHAPE]->show();
+			tools[TOOL_SELECT]->set_tooltip("Select current edited sub-tile.");
+			spin_priority->hide();
+		} break;
+		default: {
+			tool_containers[TOOLBAR_DUMMY]->show();
+			tool_containers[TOOLBAR_BITMASK]->hide();
+			tool_containers[TOOLBAR_SHAPE]->hide();
+			if (edit_mode == EDITMODE_ICON) {
+				tools[TOOL_SELECT]->set_tooltip("Select sub-tile to use as icon, this will be also used on invalid autotile bindings.");
+				spin_priority->hide();
+			} else {
+				tools[TOOL_SELECT]->set_tooltip("Select sub-tile to change it's priority.");
+				spin_priority->show();
+			}
+		} break;
+	}
+	workspace->update();
+}
+
+void AutotileEditor::_on_workspace_draw() {
+
+	if (get_current_tile() >= 0 && !tile_set.is_null()) {
+		int spacing = tile_set->autotile_get_spacing(get_current_tile());
+		Vector2 size = tile_set->autotile_get_size(get_current_tile());
+		Rect2i region = tile_set->tile_get_region(get_current_tile());
+		Color c(0.347214, 0.722656, 0.617063);
+
+		switch (edit_mode) {
+			case EDITMODE_ICON: {
+				Vector2 coord = tile_set->autotile_get_icon_coordinate(get_current_tile());
+				draw_highlight_tile(coord);
+			} break;
+			case EDITMODE_BITMASK: {
+				c = Color(1, 0, 0, 0.5);
+				for (float x = 0; x < region.size.x / (spacing + size.x); x++) {
+					for (float y = 0; y < region.size.y / (spacing + size.y); y++) {
+						Vector2 coord(x, y);
+						Point2 anchor(coord.x * (spacing + size.x), coord.y * (spacing + size.y));
+						uint16_t mask = tile_set->autotile_get_bitmask(get_current_tile(), coord);
+						if (tile_set->autotile_get_bitmask_mode(get_current_tile()) == TileSet::BITMASK_2X2) {
+							if (mask & TileSet::BIND_TOPLEFT) {
+								workspace->draw_rect(Rect2(anchor, size / 2), c);
+							}
+							if (mask & TileSet::BIND_TOPRIGHT) {
+								workspace->draw_rect(Rect2(anchor + Vector2(size.x / 2, 0), size / 2), c);
+							}
+							if (mask & TileSet::BIND_BOTTOMLEFT) {
+								workspace->draw_rect(Rect2(anchor + Vector2(0, size.y / 2), size / 2), c);
+							}
+							if (mask & TileSet::BIND_BOTTOMRIGHT) {
+								workspace->draw_rect(Rect2(anchor + size / 2, size / 2), c);
+							}
+						} else if (tile_set->autotile_get_bitmask_mode(get_current_tile()) == TileSet::BITMASK_3X3) {
+							if (mask & TileSet::BIND_TOPLEFT) {
+								workspace->draw_rect(Rect2(anchor, size / 3), c);
+							}
+							if (mask & TileSet::BIND_TOP) {
+								workspace->draw_rect(Rect2(anchor + Vector2(size.x / 3, 0), size / 3), c);
+							}
+							if (mask & TileSet::BIND_TOPRIGHT) {
+								workspace->draw_rect(Rect2(anchor + Vector2((size.x / 3) * 2, 0), size / 3), c);
+							}
+							if (mask & TileSet::BIND_LEFT) {
+								workspace->draw_rect(Rect2(anchor + Vector2(0, size.y / 3), size / 3), c);
+							}
+							if (mask & TileSet::BIND_CENTER) {
+								workspace->draw_rect(Rect2(anchor + Vector2(size.x / 3, size.y / 3), size / 3), c);
+							}
+							if (mask & TileSet::BIND_RIGHT) {
+								workspace->draw_rect(Rect2(anchor + Vector2((size.x / 3) * 2, size.y / 3), size / 3), c);
+							}
+							if (mask & TileSet::BIND_BOTTOMLEFT) {
+								workspace->draw_rect(Rect2(anchor + Vector2(0, (size.y / 3) * 2), size / 3), c);
+							}
+							if (mask & TileSet::BIND_BOTTOM) {
+								workspace->draw_rect(Rect2(anchor + Vector2(size.x / 3, (size.y / 3) * 2), size / 3), c);
+							}
+							if (mask & TileSet::BIND_BOTTOMRIGHT) {
+								workspace->draw_rect(Rect2(anchor + (size / 3) * 2, size / 3), c);
+							}
+						}
+					}
+				}
+			} break;
+			case EDITMODE_COLLISION:
+			case EDITMODE_OCCLUSION:
+			case EDITMODE_NAVIGATION: {
+				Vector2 coord = edited_shape_coord;
+				draw_highlight_tile(coord);
+				draw_polygon_shapes();
+			} break;
+			case EDITMODE_PRIORITY: {
+				spin_priority->set_value(tile_set->autotile_get_subtile_priority(get_current_tile(), edited_shape_coord));
+				uint16_t mask = tile_set->autotile_get_bitmask(get_current_tile(), edited_shape_coord);
+				Vector<Vector2> queue_others;
+				int total = 0;
+				for (Map<Vector2, uint16_t>::Element *E = tile_set->autotile_get_bitmask_map(get_current_tile()).front(); E; E = E->next()) {
+					if (E->value() == mask) {
+						total += tile_set->autotile_get_subtile_priority(get_current_tile(), E->key());
+						if (E->key() != edited_shape_coord) {
+							queue_others.push_back(E->key());
+						}
+					}
+				}
+				spin_priority->set_suffix(" / " + String::num(total, 0));
+				draw_highlight_tile(edited_shape_coord, queue_others);
+			} break;
+		}
+
+		float j = -size.x; //make sure to draw at 0
+		while (j < region.size.x) {
+			j += size.x;
+			if (spacing <= 0) {
+				workspace->draw_line(Point2(j, 0), Point2(j, region.size.y), c);
+			} else {
+				workspace->draw_rect(Rect2(Point2(j, 0), Size2(spacing, region.size.y)), c);
+			}
+			j += spacing;
+		}
+		j = -size.y; //make sure to draw at 0
+		while (j < region.size.y) {
+			j += size.y;
+			if (spacing <= 0) {
+				workspace->draw_line(Point2(0, j), Point2(region.size.x, j), c);
+			} else {
+				workspace->draw_rect(Rect2(Point2(0, j), Size2(region.size.x, spacing)), c);
+			}
+			j += spacing;
+		}
+	}
+}
+
+#define MIN_DISTANCE_SQUARED 10
+void AutotileEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
+
+	if (get_current_tile() >= 0 && !tile_set.is_null()) {
+		Ref<InputEventMouseButton> mb = p_ie;
+		Ref<InputEventMouseMotion> mm = p_ie;
+
+		static bool dragging;
+		static bool erasing;
+
+		int spacing = tile_set->autotile_get_spacing(get_current_tile());
+		Vector2 size = tile_set->autotile_get_size(get_current_tile());
+		switch (edit_mode) {
+			case EDITMODE_ICON: {
+				if (mb.is_valid()) {
+					if (mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
+						Vector2 coord((int)(mb->get_position().x / (spacing + size.x)), (int)(mb->get_position().y / (spacing + size.y)));
+						tile_set->autotile_set_icon_coordinate(get_current_tile(), coord);
+						Rect2 region = tile_set->tile_get_region(get_current_tile());
+						region.size = size;
+						coord.x *= (spacing + size.x);
+						coord.y *= (spacing + size.y);
+						region.position += coord;
+						autotile_list->set_item_icon_region(current_item_index, region);
+						workspace->update();
+					}
+				}
+			} break;
+			case EDITMODE_BITMASK: {
+				if (mb.is_valid()) {
+					if (mb->is_pressed()) {
+						if (dragging) {
+							return;
+						}
+						if (mb->get_button_index() == BUTTON_RIGHT || mb->get_button_index() == BUTTON_LEFT) {
+							dragging = true;
+							erasing = (mb->get_button_index() == BUTTON_RIGHT);
+							Vector2 coord((int)(mb->get_position().x / (spacing + size.x)), (int)(mb->get_position().y / (spacing + size.y)));
+							Vector2 pos(coord.x * (spacing + size.x), coord.y * (spacing + size.y));
+							pos = mb->get_position() - pos;
+							uint16_t bit;
+							if (tile_set->autotile_get_bitmask_mode(get_current_tile()) == TileSet::BITMASK_2X2) {
+								if (pos.x < size.x / 2) {
+									if (pos.y < size.y / 2) {
+										bit = TileSet::BIND_TOPLEFT;
+									} else {
+										bit = TileSet::BIND_BOTTOMLEFT;
+									}
+								} else {
+									if (pos.y < size.y / 2) {
+										bit = TileSet::BIND_TOPRIGHT;
+									} else {
+										bit = TileSet::BIND_BOTTOMRIGHT;
+									}
+								}
+							} else if (tile_set->autotile_get_bitmask_mode(get_current_tile()) == TileSet::BITMASK_3X3) {
+								if (pos.x < size.x / 3) {
+									if (pos.y < size.y / 3) {
+										bit = TileSet::BIND_TOPLEFT;
+									} else if (pos.y > (size.y / 3) * 2) {
+										bit = TileSet::BIND_BOTTOMLEFT;
+									} else {
+										bit = TileSet::BIND_LEFT;
+									}
+								} else if (pos.x > (size.x / 3) * 2) {
+									if (pos.y < size.y / 3) {
+										bit = TileSet::BIND_TOPRIGHT;
+									} else if (pos.y > (size.y / 3) * 2) {
+										bit = TileSet::BIND_BOTTOMRIGHT;
+									} else {
+										bit = TileSet::BIND_RIGHT;
+									}
+								} else {
+									if (pos.y < size.y / 3) {
+										bit = TileSet::BIND_TOP;
+									} else if (pos.y > (size.y / 3) * 2) {
+										bit = TileSet::BIND_BOTTOM;
+									} else {
+										bit = TileSet::BIND_CENTER;
+									}
+								}
+							}
+							uint16_t mask = tile_set->autotile_get_bitmask(get_current_tile(), coord);
+							if (erasing) {
+								mask &= ~bit;
+							} else {
+								mask |= bit;
+							}
+							tile_set->autotile_set_bitmask(get_current_tile(), coord, mask);
+							workspace->update();
+						}
+					} else {
+						if ((erasing && mb->get_button_index() == BUTTON_RIGHT) || (!erasing && mb->get_button_index() == BUTTON_LEFT)) {
+							dragging = false;
+							erasing = false;
+						}
+					}
+				}
+				if (mm.is_valid()) {
+					if (dragging) {
+						Vector2 coord((int)(mm->get_position().x / (spacing + size.x)), (int)(mm->get_position().y / (spacing + size.y)));
+						Vector2 pos(coord.x * (spacing + size.x), coord.y * (spacing + size.y));
+						pos = mm->get_position() - pos;
+						uint16_t bit;
+						if (tile_set->autotile_get_bitmask_mode(get_current_tile()) == TileSet::BITMASK_2X2) {
+							if (pos.x < size.x / 2) {
+								if (pos.y < size.y / 2) {
+									bit = TileSet::BIND_TOPLEFT;
+								} else {
+									bit = TileSet::BIND_BOTTOMLEFT;
+								}
+							} else {
+								if (pos.y < size.y / 2) {
+									bit = TileSet::BIND_TOPRIGHT;
+								} else {
+									bit = TileSet::BIND_BOTTOMRIGHT;
+								}
+							}
+						} else if (tile_set->autotile_get_bitmask_mode(get_current_tile()) == TileSet::BITMASK_3X3) {
+							if (pos.x < size.x / 3) {
+								if (pos.y < size.y / 3) {
+									bit = TileSet::BIND_TOPLEFT;
+								} else if (pos.y > (size.y / 3) * 2) {
+									bit = TileSet::BIND_BOTTOMLEFT;
+								} else {
+									bit = TileSet::BIND_LEFT;
+								}
+							} else if (pos.x > (size.x / 3) * 2) {
+								if (pos.y < size.y / 3) {
+									bit = TileSet::BIND_TOPRIGHT;
+								} else if (pos.y > (size.y / 3) * 2) {
+									bit = TileSet::BIND_BOTTOMRIGHT;
+								} else {
+									bit = TileSet::BIND_RIGHT;
+								}
+							} else {
+								if (pos.y < size.y / 3) {
+									bit = TileSet::BIND_TOP;
+								} else if (pos.y > (size.y / 3) * 2) {
+									bit = TileSet::BIND_BOTTOM;
+								} else {
+									bit = TileSet::BIND_CENTER;
+								}
+							}
+						}
+						uint16_t mask = tile_set->autotile_get_bitmask(get_current_tile(), coord);
+						if (erasing) {
+							mask &= ~bit;
+						} else {
+							mask |= bit;
+						}
+						tile_set->autotile_set_bitmask(get_current_tile(), coord, mask);
+						workspace->update();
+					}
+				}
+			} break;
+			case EDITMODE_COLLISION:
+			case EDITMODE_OCCLUSION:
+			case EDITMODE_NAVIGATION:
+			case EDITMODE_PRIORITY: {
+				Vector2 shape_anchor = edited_shape_coord;
+				shape_anchor.x *= (size.x + spacing);
+				shape_anchor.y *= (size.y + spacing);
+				if (tools[TOOL_SELECT]->is_pressed()) {
+					if (mb.is_valid()) {
+						if (mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
+							if (edit_mode != EDITMODE_PRIORITY && current_shape.size() > 0) {
+								for (int i = 0; i < current_shape.size(); i++) {
+									if ((current_shape[i] - mb->get_position()).length_squared() <= MIN_DISTANCE_SQUARED) {
+										dragging_point = i;
+										workspace->update();
+										return;
+									}
+								}
+							}
+							Vector2 coord((int)(mb->get_position().x / (spacing + size.x)), (int)(mb->get_position().y / (spacing + size.y)));
+							if (edited_shape_coord != coord) {
+								edited_shape_coord = coord;
+								edited_occlusion_shape = tile_set->autotile_get_light_occluder(get_current_tile(), edited_shape_coord);
+								edited_navigation_shape = tile_set->autotile_get_navigation_polygon(get_current_tile(), edited_shape_coord);
+								shape_anchor = edited_shape_coord;
+								shape_anchor.x *= (size.x + spacing);
+								shape_anchor.y *= (size.y + spacing);
+								if (edit_mode == EDITMODE_OCCLUSION) {
+									current_shape.resize(0);
+									if (edited_occlusion_shape.is_valid()) {
+										for (int i = 0; i < edited_occlusion_shape->get_polygon().size(); i++) {
+											current_shape.push_back(edited_occlusion_shape->get_polygon()[i] + shape_anchor);
+										}
+									}
+								} else if (edit_mode == EDITMODE_NAVIGATION) {
+									current_shape.resize(0);
+									if (edited_navigation_shape.is_valid()) {
+										if (edited_navigation_shape->get_polygon_count() > 0) {
+											PoolVector<Vector2> vertices = edited_navigation_shape->get_vertices();
+											for (int i = 0; i < edited_navigation_shape->get_polygon(0).size(); i++) {
+												current_shape.push_back(vertices[edited_navigation_shape->get_polygon(0)[i]] + shape_anchor);
+											}
+										}
+									}
+								}
+							} else {
+								if (edit_mode == EDITMODE_COLLISION) {
+									Vector<TileSet::ShapeData> sd = tile_set->tile_get_shapes(get_current_tile());
+									for (int i = 0; i < sd.size(); i++) {
+										if (sd[i].autotile_coord == coord) {
+											Ref<ConcavePolygonShape2D> shape = sd[i].shape;
+											if (shape.is_valid()) {
+												//FIXME: i need a way to know if the point is countained on the polygon instead of the rect
+												Rect2 bounding_rect;
+												PoolVector2Array polygon;
+												bounding_rect.position = shape->get_segments()[0];
+												for (int j = 0; j < shape->get_segments().size(); j += 2) {
+													polygon.push_back(shape->get_segments()[j] + shape_anchor);
+													bounding_rect.expand_to(shape->get_segments()[j] + shape_anchor);
+												}
+												if (bounding_rect.has_point(mb->get_position())) {
+													current_shape = polygon;
+													edited_collision_shape = shape;
+												}
+											}
+										}
+									}
+								}
+							}
+							workspace->update();
+						} else if (!mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
+							if (edit_mode == EDITMODE_COLLISION) {
+								if (dragging_point >= 0) {
+									dragging_point = -1;
+
+									PoolVector<Vector2> segments;
+									segments.resize(current_shape.size() * 2);
+									PoolVector<Vector2>::Write w = segments.write();
+
+									for (int i = 0; i < current_shape.size(); i++) {
+										w[(i << 1) + 0] = current_shape[i] - shape_anchor;
+										w[(i << 1) + 1] = current_shape[(i + 1) % current_shape.size()] - shape_anchor;
+									}
+
+									w = PoolVector<Vector2>::Write();
+									edited_collision_shape->set_segments(segments);
+
+									workspace->update();
+								}
+							} else if (edit_mode == EDITMODE_OCCLUSION) {
+								if (dragging_point >= 0) {
+									dragging_point = -1;
+
+									PoolVector<Vector2> polygon;
+									polygon.resize(current_shape.size());
+									PoolVector<Vector2>::Write w = polygon.write();
+
+									for (int i = 0; i < current_shape.size(); i++) {
+										w[i] = current_shape[i] - shape_anchor;
+									}
+
+									w = PoolVector<Vector2>::Write();
+									edited_occlusion_shape->set_polygon(polygon);
+
+									workspace->update();
+								}
+							} else if (edit_mode == EDITMODE_NAVIGATION) {
+								if (dragging_point >= 0) {
+									dragging_point = -1;
+
+									PoolVector<Vector2> polygon;
+									Vector<int> indices;
+									polygon.resize(current_shape.size());
+									PoolVector<Vector2>::Write w = polygon.write();
+
+									for (int i = 0; i < current_shape.size(); i++) {
+										w[i] = current_shape[i] - shape_anchor;
+										indices.push_back(i);
+									}
+
+									w = PoolVector<Vector2>::Write();
+									edited_navigation_shape->set_vertices(polygon);
+									edited_navigation_shape->add_polygon(indices);
+
+									workspace->update();
+								}
+							}
+						}
+					} else if (mm.is_valid()) {
+						if (dragging_point >= 0) {
+							current_shape.set(dragging_point, snap_point(mm->get_position()));
+							workspace->update();
+						}
+					}
+				} else if (tools[SHAPE_NEW_POLYGON]->is_pressed()) {
+					if (mb.is_valid()) {
+						if (mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
+							Vector2 pos = mb->get_position();
+							pos = snap_point(pos);
+							if (creating_shape) {
+								if (current_shape.size() > 0) {
+									if ((pos - current_shape[0]).length_squared() <= MIN_DISTANCE_SQUARED) {
+										if (current_shape.size() > 2) {
+											close_shape(shape_anchor);
+											workspace->update();
+											return;
+										}
+									}
+								}
+								current_shape.push_back(pos);
+								workspace->update();
+							} else {
+								creating_shape = true;
+								current_shape.resize(0);
+								current_shape.push_back(snap_point(pos));
+							}
+						} else if (mb->is_pressed() && mb->get_button_index() == BUTTON_RIGHT) {
+							if (creating_shape) {
+								close_shape(shape_anchor);
+							}
+						}
+					} else if (mm.is_valid()) {
+						if (creating_shape) {
+							workspace->update();
+						}
+					}
+				}
+			} break;
+		}
+	}
+}
+
+void AutotileEditor::_on_tool_clicked(int p_tool) {
+	if (p_tool == BITMASK_COPY) {
+		bitmask_map_copy = tile_set->autotile_get_bitmask_map(get_current_tile());
+	} else if (p_tool == BITMASK_PASTE) {
+		tile_set->autotile_clear_bitmask_map(get_current_tile());
+		for (Map<Vector2, uint16_t>::Element *E = bitmask_map_copy.front(); E; E = E->next()) {
+			tile_set->autotile_set_bitmask(get_current_tile(), E->key(), E->value());
+		}
+		workspace->update();
+	} else if (p_tool == BITMASK_CLEAR) {
+		tile_set->autotile_clear_bitmask_map(get_current_tile());
+		workspace->update();
+	} else if (p_tool == SHAPE_DELETE) {
+		if (!edited_collision_shape.is_null()) {
+			Vector<TileSet::ShapeData> sd = tile_set->tile_get_shapes(get_current_tile());
+			int index;
+			for (int i = 0; i < sd.size(); i++) {
+				if (sd[i].shape == edited_collision_shape) {
+					index = i;
+					break;
+				}
+			}
+			if (index >= 0) {
+				sd.remove(index);
+				tile_set->tile_set_shapes(get_current_tile(), sd);
+				edited_collision_shape.unref();
+				current_shape.resize(0);
+				workspace->update();
+			}
+		}
+	} else if (p_tool == ZOOM_OUT) {
+		float scale = workspace->get_scale().x;
+		if (scale > 0.1) {
+			scale /= 2;
+			workspace->set_scale(Vector2(scale, scale));
+			workspace_container->set_custom_minimum_size(preview->get_region_rect().size * scale);
+		}
+	} else if (p_tool == ZOOM_1) {
+		workspace->set_scale(Vector2(1, 1));
+		workspace_container->set_custom_minimum_size(preview->get_region_rect().size);
+	} else if (p_tool == ZOOM_IN) {
+		float scale = workspace->get_scale().x;
+		scale *= 2;
+		workspace->set_scale(Vector2(scale, scale));
+		workspace_container->set_custom_minimum_size(preview->get_region_rect().size * scale);
+	}
+}
+
+void AutotileEditor::_on_priority_changed(float val) {
+	tile_set->autotile_set_subtile_priority(get_current_tile(), edited_shape_coord, (int)val);
+	workspace->update();
+}
+
+void AutotileEditor::draw_highlight_tile(Vector2 coord, const Vector<Vector2> &other_highlighted) {
+
+	Vector2 size = tile_set->autotile_get_size(get_current_tile());
+	int spacing = tile_set->autotile_get_spacing(get_current_tile());
+	Rect2 region = tile_set->tile_get_region(get_current_tile());
+	coord.x *= (size.x + spacing);
+	coord.y *= (size.y + spacing);
+	workspace->draw_rect(Rect2(0, 0, region.size.x, coord.y), Color(0.5, 0.5, 0.5, 0.5));
+	workspace->draw_rect(Rect2(0, coord.y, coord.x, size.y), Color(0.5, 0.5, 0.5, 0.5));
+	workspace->draw_rect(Rect2(coord.x + size.x, coord.y, region.size.x - coord.x - size.x, size.y), Color(0.5, 0.5, 0.5, 0.5));
+	workspace->draw_rect(Rect2(0, coord.y + size.y, region.size.x, region.size.y - size.y - coord.y), Color(0.5, 0.5, 0.5, 0.5));
+	coord += Vector2(1, 1);
+	workspace->draw_rect(Rect2(coord, size - Vector2(2, 2)), Color(1, 0, 0), false);
+	for (int i = 0; i < other_highlighted.size(); i++) {
+		coord = other_highlighted[i];
+		coord.x *= (size.x + spacing);
+		coord.y *= (size.y + spacing);
+		coord += Vector2(1, 1);
+		workspace->draw_rect(Rect2(coord, size - Vector2(2, 2)), Color(1, 0, 0), false);
+	}
+}
+
+void AutotileEditor::draw_polygon_shapes() {
+
+	int t_id = get_current_tile();
+	if (t_id < 0)
+		return;
+
+	switch (edit_mode) {
+		case EDITMODE_COLLISION: {
+			Vector<TileSet::ShapeData> sd = tile_set->tile_get_shapes(t_id);
+			for (int i = 0; i < sd.size(); i++) {
+				Vector2 coord = sd[i].autotile_coord;
+				Vector2 anchor = tile_set->autotile_get_size(t_id);
+				anchor.x += tile_set->autotile_get_spacing(t_id);
+				anchor.y += tile_set->autotile_get_spacing(t_id);
+				anchor.x *= coord.x;
+				anchor.y *= coord.y;
+				Ref<ConcavePolygonShape2D> shape = sd[i].shape;
+				if (shape.is_valid()) {
+					Color c_bg;
+					Color c_border;
+					if (coord == edited_shape_coord && sd[i].shape == edited_collision_shape) {
+						c_bg = Color(0, 1, 1, 0.5);
+						c_border = Color(0, 1, 1);
+					} else {
+						c_bg = Color(0.9, 0.7, 0.07, 0.5);
+						c_border = Color(0.9, 0.7, 0.07, 1);
+					}
+					Vector<Vector2> polygon;
+					Vector<Color> colors;
+					if (shape == edited_collision_shape) {
+						for (int j = 0; j < current_shape.size(); j++) {
+							polygon.push_back(current_shape[j]);
+							colors.push_back(c_bg);
+						}
+					} else {
+						for (int j = 0; j < shape->get_segments().size(); j += 2) {
+							polygon.push_back(shape->get_segments()[j] + anchor);
+							colors.push_back(c_bg);
+						}
+					}
+					workspace->draw_polygon(polygon, colors);
+					if (coord == edited_shape_coord) {
+						for (int j = 0; j < shape->get_segments().size(); j += 2) {
+							workspace->draw_line(shape->get_segments()[j] + anchor, shape->get_segments()[j + 1] + anchor, c_border, 1, true);
+						}
+						if (shape == edited_collision_shape) {
+							for (int j = 0; j < current_shape.size(); j++) {
+								workspace->draw_circle(current_shape[j], 5, Color(1, 0, 0));
+							}
+						}
+					}
+				}
+			}
+		} break;
+		case EDITMODE_OCCLUSION: {
+			Map<Vector2, Ref<OccluderPolygon2D> > map = tile_set->autotile_get_light_oclusion_map(t_id);
+			for (Map<Vector2, Ref<OccluderPolygon2D> >::Element *E = map.front(); E; E = E->next()) {
+				Vector2 coord = E->key();
+				Vector2 anchor = tile_set->autotile_get_size(t_id);
+				anchor.x += tile_set->autotile_get_spacing(t_id);
+				anchor.y += tile_set->autotile_get_spacing(t_id);
+				anchor.x *= coord.x;
+				anchor.y *= coord.y;
+				Ref<OccluderPolygon2D> shape = E->value();
+				if (shape.is_valid()) {
+					Color c_bg;
+					Color c_border;
+					if (coord == edited_shape_coord && shape == edited_occlusion_shape) {
+						c_bg = Color(0, 1, 1, 0.5);
+						c_border = Color(0, 1, 1);
+					} else {
+						c_bg = Color(0.9, 0.7, 0.07, 0.5);
+						c_border = Color(0.9, 0.7, 0.07, 1);
+					}
+					Vector<Vector2> polygon;
+					Vector<Color> colors;
+					if (shape == edited_occlusion_shape) {
+						for (int j = 0; j < current_shape.size(); j++) {
+							polygon.push_back(current_shape[j]);
+							colors.push_back(c_bg);
+						}
+					} else {
+						for (int j = 0; j < shape->get_polygon().size(); j++) {
+							polygon.push_back(shape->get_polygon()[j] + anchor);
+							colors.push_back(c_bg);
+						}
+					}
+					workspace->draw_polygon(polygon, colors);
+					if (coord == edited_shape_coord) {
+						for (int j = 0; j < shape->get_polygon().size() - 1; j++) {
+							workspace->draw_line(shape->get_polygon()[j] + anchor, shape->get_polygon()[j + 1] + anchor, c_border, 1, true);
+						}
+						workspace->draw_line(shape->get_polygon()[shape->get_polygon().size() - 1] + anchor, shape->get_polygon()[0] + anchor, c_border, 1, true);
+						if (shape == edited_occlusion_shape) {
+							for (int j = 0; j < current_shape.size(); j++) {
+								workspace->draw_circle(current_shape[j], 5, Color(1, 0, 0));
+							}
+						}
+					}
+				}
+			}
+		} break;
+		case EDITMODE_NAVIGATION: {
+			Map<Vector2, Ref<NavigationPolygon> > map = tile_set->autotile_get_navigation_map(t_id);
+			for (Map<Vector2, Ref<NavigationPolygon> >::Element *E = map.front(); E; E = E->next()) {
+				Vector2 coord = E->key();
+				Vector2 anchor = tile_set->autotile_get_size(t_id);
+				anchor.x += tile_set->autotile_get_spacing(t_id);
+				anchor.y += tile_set->autotile_get_spacing(t_id);
+				anchor.x *= coord.x;
+				anchor.y *= coord.y;
+				Ref<NavigationPolygon> shape = E->value();
+				if (shape.is_valid()) {
+					Color c_bg;
+					Color c_border;
+					if (coord == edited_shape_coord && shape == edited_navigation_shape) {
+						c_bg = Color(0, 1, 1, 0.5);
+						c_border = Color(0, 1, 1);
+					} else {
+						c_bg = Color(0.9, 0.7, 0.07, 0.5);
+						c_border = Color(0.9, 0.7, 0.07, 1);
+					}
+					Vector<Vector2> polygon;
+					Vector<Color> colors;
+					if (shape == edited_navigation_shape) {
+						for (int j = 0; j < current_shape.size(); j++) {
+							polygon.push_back(current_shape[j]);
+							colors.push_back(c_bg);
+						}
+					} else if (shape->get_polygon_count() > 0) {
+						PoolVector<Vector2> vertices = shape->get_vertices();
+						for (int j = 0; j < shape->get_polygon(0).size(); j++) {
+							polygon.push_back(vertices[shape->get_polygon(0)[j]] + anchor);
+							colors.push_back(c_bg);
+						}
+					}
+					workspace->draw_polygon(polygon, colors);
+					if (coord == edited_shape_coord) {
+						if (shape->get_polygon_count() > 0) {
+							PoolVector<Vector2> vertices = shape->get_vertices();
+							for (int j = 0; j < shape->get_polygon(0).size() - 1; j++) {
+								workspace->draw_line(vertices[shape->get_polygon(0)[j]] + anchor, vertices[shape->get_polygon(0)[j + 1]] + anchor, c_border, 1, true);
+							}
+							if (shape == edited_navigation_shape) {
+								for (int j = 0; j < current_shape.size(); j++) {
+									workspace->draw_circle(current_shape[j], 5, Color(1, 0, 0));
+								}
+							}
+						}
+					}
+				}
+			}
+		} break;
+	}
+	if (creating_shape) {
+		for (int j = 0; j < current_shape.size() - 1; j++) {
+			workspace->draw_line(current_shape[j], current_shape[j + 1], Color(0, 1, 1), 1, true);
+		}
+		workspace->draw_line(current_shape[current_shape.size() - 1], snap_point(workspace->get_local_mouse_position()), Color(0, 1, 1), 1, true);
+	}
+}
+
+void AutotileEditor::close_shape(const Vector2 &shape_anchor) {
+
+	creating_shape = false;
+
+	if (edit_mode == EDITMODE_COLLISION) {
+		Ref<ConcavePolygonShape2D> shape = memnew(ConcavePolygonShape2D);
+
+		PoolVector<Vector2> segments;
+		segments.resize(current_shape.size() * 2);
+		PoolVector<Vector2>::Write w = segments.write();
+
+		for (int i = 0; i < current_shape.size(); i++) {
+			w[(i << 1) + 0] = current_shape[i] - shape_anchor;
+			w[(i << 1) + 1] = current_shape[(i + 1) % current_shape.size()] - shape_anchor;
+		}
+
+		w = PoolVector<Vector2>::Write();
+		shape->set_segments(segments);
+
+		tile_set->tile_add_shape(get_current_tile(), shape, Transform2D(), false, edited_shape_coord);
+		edited_collision_shape = shape;
+		tools[TOOL_SELECT]->set_pressed(true);
+		workspace->update();
+	} else if (edit_mode == EDITMODE_OCCLUSION) {
+		Ref<OccluderPolygon2D> shape = memnew(OccluderPolygon2D);
+
+		PoolVector<Vector2> polygon;
+		polygon.resize(current_shape.size());
+		PoolVector<Vector2>::Write w = polygon.write();
+
+		for (int i = 0; i < current_shape.size(); i++) {
+			w[i] = current_shape[i] - shape_anchor;
+		}
+
+		w = PoolVector<Vector2>::Write();
+		shape->set_polygon(polygon);
+
+		tile_set->autotile_set_light_occluder(get_current_tile(), shape, edited_shape_coord);
+		edited_occlusion_shape = shape;
+		tools[TOOL_SELECT]->set_pressed(true);
+		workspace->update();
+	} else if (edit_mode == EDITMODE_NAVIGATION) {
+		Ref<NavigationPolygon> shape = memnew(NavigationPolygon);
+
+		PoolVector<Vector2> polygon;
+		Vector<int> indices;
+		polygon.resize(current_shape.size());
+		PoolVector<Vector2>::Write w = polygon.write();
+
+		for (int i = 0; i < current_shape.size(); i++) {
+			w[i] = current_shape[i] - shape_anchor;
+			indices.push_back(i);
+		}
+
+		w = PoolVector<Vector2>::Write();
+		shape->set_vertices(polygon);
+		shape->add_polygon(indices);
+		tile_set->autotile_set_navigation_polygon(get_current_tile(), shape, edited_shape_coord);
+		edited_navigation_shape = shape;
+		tools[TOOL_SELECT]->set_pressed(true);
+		workspace->update();
+	}
+}
+
+Vector2 AutotileEditor::snap_point(const Vector2 &point) {
+	Vector2 p = point;
+	Vector2 coord = edited_shape_coord;
+	Vector2 tile_size = tile_set->autotile_get_size(get_current_tile());
+	int spacing = tile_set->autotile_get_spacing(get_current_tile());
+	Vector2 anchor = coord;
+	anchor.x *= (tile_size.x + spacing);
+	anchor.y *= (tile_size.y + spacing);
+	Rect2 region(anchor, tile_size);
+	if (tools[SHAPE_KEEP_INSIDE_TILE]->is_pressed()) {
+		if (p.x < region.position.x)
+			p.x = region.position.x;
+		if (p.y < region.position.y)
+			p.y = region.position.y;
+		if (p.x > region.position.x + region.size.x)
+			p.x = region.position.x + region.size.x;
+		if (p.y > region.position.y + region.size.y)
+			p.y = region.position.y + region.size.y;
+	}
+	if (tools[SHAPE_SNAP_TO_BITMASK_GRID]->is_pressed()) {
+		Vector2 p2 = p;
+		if (tile_set->autotile_get_bitmask_mode(get_current_tile()) == TileSet::BITMASK_2X2) {
+			p2.x = Math::stepify(p2.x, tile_size.x / 2);
+			p2.y = Math::stepify(p2.y, tile_size.y / 2);
+			if ((p2 - p).length_squared() <= MAX(tile_size.y / 4, MIN_DISTANCE_SQUARED)) {
+				p = p2;
+			}
+		} else if (tile_set->autotile_get_bitmask_mode(get_current_tile()) == TileSet::BITMASK_3X3) {
+			p2.x = Math::stepify(p2.x, tile_size.x / 3);
+			p2.y = Math::stepify(p2.y, tile_size.y / 3);
+			if ((p2 - p).length_squared() <= MAX(tile_size.y / 6, MIN_DISTANCE_SQUARED)) {
+				p = p2;
+			}
+		}
+	}
+	p.floor();
+	return p;
+}
+
+void AutotileEditor::edit(Object *p_node) {
+
+	tile_set = Ref<TileSet>(Object::cast_to<TileSet>(p_node));
+	helper->set_tileset(tile_set);
+
+	autotile_list->clear();
+	List<int> ids;
+	tile_set->get_tile_list(&ids);
+	for (List<int>::Element *E = ids.front(); E; E = E->next()) {
+		if (tile_set->tile_get_is_autotile(E->get())) {
+			autotile_list->add_item(tile_set->tile_get_name(E->get()));
+			autotile_list->set_item_metadata(autotile_list->get_item_count() - 1, E->get());
+			autotile_list->set_item_icon(autotile_list->get_item_count() - 1, tile_set->tile_get_texture(E->get()));
+			Rect2 region = tile_set->tile_get_region(E->get());
+			region.size = tile_set->autotile_get_size(E->get());
+			Vector2 pos = tile_set->autotile_get_icon_coordinate(E->get());
+			pos.x *= (tile_set->autotile_get_spacing(E->get()) + region.size.x);
+			pos.y *= (tile_set->autotile_get_spacing(E->get()) + region.size.y);
+			region.position += pos;
+			autotile_list->set_item_icon_region(autotile_list->get_item_count() - 1, region);
+		}
+	}
+	if (autotile_list->get_item_count() > 0) {
+		autotile_list->select(0);
+		_on_autotile_selected(0);
+	}
+	helper->_change_notify("");
+}
+
+int AutotileEditor::get_current_tile() {
+
+	if (autotile_list->get_selected_items().size() == 0)
+		return -1;
+	else
+		return autotile_list->get_item_metadata(autotile_list->get_selected_items()[0]);
+}
+
+void AutotileEditorHelper::set_tileset(const Ref<TileSet> &p_tileset) {
+
+	tile_set = p_tileset;
+}
+
+bool AutotileEditorHelper::_set(const StringName &p_name, const Variant &p_value) {
+
+	if (autotile_editor->get_current_tile() < 0 || tile_set.is_null())
+		return false;
+
+	String name = p_name.operator String();
+	bool v = false;
+	if (name == "bitmask_mode") {
+		tile_set->set(String::num(autotile_editor->get_current_tile(), 0) + "/autotile/bitmask_mode", p_value, &v);
+	} else if (name.left(7) == "layout/") {
+		tile_set->set(String::num(autotile_editor->get_current_tile(), 0) + "/autotile" + name.right(6), p_value, &v);
+	}
+	if (v) {
+		tile_set->_change_notify("");
+		autotile_editor->workspace->update();
+	}
+	return v;
+}
+
+bool AutotileEditorHelper::_get(const StringName &p_name, Variant &r_ret) const {
+
+	if (autotile_editor->get_current_tile() < 0 || tile_set.is_null())
+		return false;
+
+	String name = p_name.operator String();
+	if (name == "bitmask_mode") {
+		r_ret = tile_set->get(String::num(autotile_editor->get_current_tile(), 0) + "/autotile/bitmask_mode");
+	} else if (name.left(7) == "layout/") {
+		bool v;
+		r_ret = tile_set->get(String::num(autotile_editor->get_current_tile(), 0) + "/autotile" + name.right(6), &v);
+		return v;
+	}
+}
+
+void AutotileEditorHelper::_get_property_list(List<PropertyInfo> *p_list) const {
+
+	if (autotile_editor->get_current_tile() < 0 || tile_set.is_null())
+		return;
+
+	p_list->push_back(PropertyInfo(Variant::INT, "bitmask_mode", PROPERTY_HINT_ENUM, "2x2,3x3"));
+	p_list->push_back(PropertyInfo(Variant::VECTOR2, "layout/tile_size"));
+	p_list->push_back(PropertyInfo(Variant::INT, "layout/spacing", PROPERTY_HINT_RANGE, "0,256,1"));
+}
+
+AutotileEditorHelper::AutotileEditorHelper(AutotileEditor *p_autotile_editor) {
+
+	autotile_editor = p_autotile_editor;
 }

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -365,6 +365,11 @@ void TileMap::_update_dirty_quadrants() {
 			}
 
 			Rect2 r = tile_set->tile_get_region(c.id);
+			if (tile_set->tile_get_is_autotile(c.id)) {
+				int spacing = tile_set->autotile_get_spacing(c.id);
+				r.size = tile_set->autotile_get_size(c.id);
+				r.position += (r.size + Vector2(spacing, spacing)) * Vector2(c.autotile_coord_x, c.autotile_coord_y);
+			}
 			Size2 s = tex->get_size();
 
 			if (r == Rect2())
@@ -456,21 +461,23 @@ void TileMap::_update_dirty_quadrants() {
 			for (int i = 0; i < shapes.size(); i++) {
 				Ref<Shape2D> shape = shapes[i].shape;
 				if (shape.is_valid()) {
-					Transform2D xform;
-					xform.set_origin(offset.floor());
+					if (!tile_set->tile_get_is_autotile(c.id) || (shapes[i].autotile_coord.x == c.autotile_coord_x && shapes[i].autotile_coord.y == c.autotile_coord_y)) {
+						Transform2D xform;
+						xform.set_origin(offset.floor());
 
-					Vector2 shape_ofs = tile_set->tile_get_shape_offset(c.id, i);
+						Vector2 shape_ofs = tile_set->tile_get_shape_offset(c.id, i);
 
-					_fix_cell_transform(xform, c, shape_ofs + center_ofs, s);
+						_fix_cell_transform(xform, c, shape_ofs + center_ofs, s);
 
-					if (debug_canvas_item.is_valid()) {
-						vs->canvas_item_add_set_transform(debug_canvas_item, xform);
-						shape->draw(debug_canvas_item, debug_collision_color);
+						if (debug_canvas_item.is_valid()) {
+							vs->canvas_item_add_set_transform(debug_canvas_item, xform);
+							shape->draw(debug_canvas_item, debug_collision_color);
+						}
+						ps->body_add_shape(q.body, shape->get_rid(), xform);
+						ps->body_set_shape_metadata(q.body, shape_idx, Vector2(E->key().x, E->key().y));
+						ps->body_set_shape_as_one_way_collision(q.body, shape_idx, shapes[i].one_way_collision);
+						shape_idx++;
 					}
-					ps->body_add_shape(q.body, shape->get_rid(), xform);
-					ps->body_set_shape_metadata(q.body, shape_idx, Vector2(E->key().x, E->key().y));
-					ps->body_set_shape_as_one_way_collision(q.body, shape_idx, shapes[i].one_way_collision);
-					shape_idx++;
 				}
 			}
 
@@ -479,9 +486,17 @@ void TileMap::_update_dirty_quadrants() {
 			}
 
 			if (navigation) {
-				Ref<NavigationPolygon> navpoly = tile_set->tile_get_navigation_polygon(c.id);
+				Ref<NavigationPolygon> navpoly;
+				Vector2 npoly_ofs;
+				if (tile_set->tile_get_is_autotile(c.id)) {
+					navpoly = tile_set->autotile_get_navigation_polygon(c.id, Vector2(c.autotile_coord_x, c.autotile_coord_y));
+					npoly_ofs = Vector2();
+				} else {
+					navpoly = tile_set->tile_get_navigation_polygon(c.id);
+					npoly_ofs = tile_set->tile_get_navigation_polygon_offset(c.id);
+				}
+
 				if (navpoly.is_valid()) {
-					Vector2 npoly_ofs = tile_set->tile_get_navigation_polygon_offset(c.id);
 					Transform2D xform;
 					xform.set_origin(offset.floor() + q.pos);
 					_fix_cell_transform(xform, c, npoly_ofs + center_ofs, s);
@@ -495,10 +510,17 @@ void TileMap::_update_dirty_quadrants() {
 				}
 			}
 
-			Ref<OccluderPolygon2D> occluder = tile_set->tile_get_light_occluder(c.id);
+			Ref<OccluderPolygon2D> occluder;
+			Vector2 occluder_ofs;
+			if (tile_set->tile_get_is_autotile(c.id)) {
+				occluder = tile_set->autotile_get_light_occluder(c.id, Vector2(c.autotile_coord_x, c.autotile_coord_y));
+				occluder_ofs = tile_set->tile_get_occluder_offset(c.id);
+			} else {
+				occluder = tile_set->tile_get_light_occluder(c.id);
+				occluder_ofs = Vector2();
+			}
 			if (occluder.is_valid()) {
 
-				Vector2 occluder_ofs = tile_set->tile_get_occluder_offset(c.id);
 				Transform2D xform;
 				xform.set_origin(offset.floor() + q.pos);
 				_fix_cell_transform(xform, c, occluder_ofs + center_ofs, s);
@@ -656,7 +678,7 @@ void TileMap::set_cellv(const Vector2 &p_pos, int p_tile, bool p_flip_x, bool p_
 	set_cell(p_pos.x, p_pos.y, p_tile, p_flip_x, p_flip_y, p_transpose);
 }
 
-void TileMap::set_cell(int p_x, int p_y, int p_tile, bool p_flip_x, bool p_flip_y, bool p_transpose) {
+void TileMap::set_cell(int p_x, int p_y, int p_tile, bool p_flip_x, bool p_flip_y, bool p_transpose, Vector2 p_autotile_coord) {
 
 	PosKey pk(p_x, p_y);
 
@@ -702,13 +724,103 @@ void TileMap::set_cell(int p_x, int p_y, int p_tile, bool p_flip_x, bool p_flip_
 	c.flip_h = p_flip_x;
 	c.flip_v = p_flip_y;
 	c.transpose = p_transpose;
+	c.autotile_coord_x = (uint16_t)p_autotile_coord.x;
+	c.autotile_coord_y = (uint16_t)p_autotile_coord.y;
 
 	_make_quadrant_dirty(Q);
 	used_size_cache_dirty = true;
 }
 
 int TileMap::get_cellv(const Vector2 &p_pos) const {
+
 	return get_cell(p_pos.x, p_pos.y);
+}
+
+void TileMap::make_bitmask_area_dirty(const Vector2 &p_pos) {
+
+	for (int x = p_pos.x - 1; x <= p_pos.x + 1; x++) {
+		for (int y = p_pos.y - 1; x <= p_pos.y + 1; y++) {
+			PosKey p(x, y);
+			if (dirty_bitmask.find(p) == NULL) {
+				dirty_bitmask.push_back(p);
+			}
+		}
+	}
+}
+
+void TileMap::update_bitmask_area(const Vector2 &p_pos) {
+
+	for (int x = p_pos.x - 1; x <= p_pos.x + 1; x++) {
+		for (int y = p_pos.y - 1; y <= p_pos.y + 1; y++) {
+			update_cell_bitmask(x, y);
+		}
+	}
+}
+
+void TileMap::update_cell_bitmask(int p_x, int p_y) {
+
+	PosKey p(p_x, p_y);
+	Map<PosKey, Cell>::Element *E = tile_map.find(p);
+	if (E != NULL) {
+		int id = get_cell(p_x, p_y);
+		if (tile_set->tile_get_is_autotile(id)) {
+			uint16_t mask = 0;
+			if (tile_set->autotile_get_bitmask_mode(id) == TileSet::BITMASK_2X2) {
+				if (tile_set->is_tile_bound(id, get_cell(p_x - 1, p_y - 1)) && tile_set->is_tile_bound(id, get_cell(p_x, p_y - 1)) && tile_set->is_tile_bound(id, get_cell(p_x - 1, p_y))) {
+					mask |= TileSet::BIND_TOPLEFT;
+				}
+				if (tile_set->is_tile_bound(id, get_cell(p_x + 1, p_y - 1)) && tile_set->is_tile_bound(id, get_cell(p_x, p_y - 1)) && tile_set->is_tile_bound(id, get_cell(p_x + 1, p_y))) {
+					mask |= TileSet::BIND_TOPRIGHT;
+				}
+				if (tile_set->is_tile_bound(id, get_cell(p_x - 1, p_y + 1)) && tile_set->is_tile_bound(id, get_cell(p_x, p_y + 1)) && tile_set->is_tile_bound(id, get_cell(p_x - 1, p_y))) {
+					mask |= TileSet::BIND_BOTTOMLEFT;
+				}
+				if (tile_set->is_tile_bound(id, get_cell(p_x + 1, p_y + 1)) && tile_set->is_tile_bound(id, get_cell(p_x, p_y + 1)) && tile_set->is_tile_bound(id, get_cell(p_x + 1, p_y))) {
+					mask |= TileSet::BIND_BOTTOMRIGHT;
+				}
+			} else if (tile_set->autotile_get_bitmask_mode(id) == TileSet::BITMASK_3X3) {
+				if (tile_set->is_tile_bound(id, get_cell(p_x - 1, p_y - 1)) && tile_set->is_tile_bound(id, get_cell(p_x, p_y - 1)) && tile_set->is_tile_bound(id, get_cell(p_x - 1, p_y))) {
+					mask |= TileSet::BIND_TOPLEFT;
+				}
+				if (tile_set->is_tile_bound(id, get_cell(p_x, p_y - 1))) {
+					mask |= TileSet::BIND_TOP;
+				}
+				if (tile_set->is_tile_bound(id, get_cell(p_x + 1, p_y - 1)) && tile_set->is_tile_bound(id, get_cell(p_x, p_y - 1)) && tile_set->is_tile_bound(id, get_cell(p_x + 1, p_y))) {
+					mask |= TileSet::BIND_TOPRIGHT;
+				}
+				if (tile_set->is_tile_bound(id, get_cell(p_x - 1, p_y))) {
+					mask |= TileSet::BIND_LEFT;
+				}
+				mask |= TileSet::BIND_CENTER;
+				if (tile_set->is_tile_bound(id, get_cell(p_x + 1, p_y))) {
+					mask |= TileSet::BIND_RIGHT;
+				}
+				if (tile_set->is_tile_bound(id, get_cell(p_x - 1, p_y + 1)) && tile_set->is_tile_bound(id, get_cell(p_x, p_y + 1)) && tile_set->is_tile_bound(id, get_cell(p_x - 1, p_y))) {
+					mask |= TileSet::BIND_BOTTOMLEFT;
+				}
+				if (tile_set->is_tile_bound(id, get_cell(p_x, p_y + 1))) {
+					mask |= TileSet::BIND_BOTTOM;
+				}
+				if (tile_set->is_tile_bound(id, get_cell(p_x + 1, p_y + 1)) && tile_set->is_tile_bound(id, get_cell(p_x, p_y + 1)) && tile_set->is_tile_bound(id, get_cell(p_x + 1, p_y))) {
+					mask |= TileSet::BIND_BOTTOMRIGHT;
+				}
+			}
+			Vector2 coord = tile_set->autotile_get_subtile_for_bitmask(id, mask, this, Vector2(p_x, p_y));
+			E->get().autotile_coord_x = (int)coord.x;
+			E->get().autotile_coord_y = (int)coord.y;
+		} else {
+			E->get().autotile_coord_x = 0;
+			E->get().autotile_coord_y = 0;
+		}
+	}
+}
+
+void TileMap::update_dirty_bitmask() {
+
+	while (dirty_bitmask.size() > 0) {
+		update_cell_bitmask(dirty_bitmask[0].x, dirty_bitmask[0].y);
+		dirty_bitmask.pop_front();
+	}
 }
 
 int TileMap::get_cell(int p_x, int p_y) const {
@@ -754,6 +866,30 @@ bool TileMap::is_cell_transposed(int p_x, int p_y) const {
 		return false;
 
 	return E->get().transpose;
+}
+
+int TileMap::get_cell_autotile_coord_x(int p_x, int p_y) const {
+
+	PosKey pk(p_x, p_y);
+
+	const Map<PosKey, Cell>::Element *E = tile_map.find(pk);
+
+	if (!E)
+		return 0;
+
+	return E->get().autotile_coord_x;
+}
+
+int TileMap::get_cell_autotile_coord_y(int p_x, int p_y) const {
+
+	PosKey pk(p_x, p_y);
+
+	const Map<PosKey, Cell>::Element *E = tile_map.find(pk);
+
+	if (!E)
+		return 0;
+
+	return E->get().autotile_coord_y;
 }
 
 void TileMap::_recreate_quadrants() {
@@ -823,11 +959,13 @@ void TileMap::_set_tile_data(const PoolVector<int> &p_data) {
 	int c = p_data.size();
 	PoolVector<int>::Read r = p_data.read();
 
-	for (int i = 0; i < c; i += 2) {
+	int offset = (format == FORMAT_2_1_5) ? 3 : 2;
+
+	for (int i = 0; i < c; i += offset) {
 
 		const uint8_t *ptr = (const uint8_t *)&r[i];
-		uint8_t local[8];
-		for (int j = 0; j < 8; j++)
+		uint8_t local[12];
+		for (int j = 0; j < ((format == FORMAT_2_1_5) ? 12 : 8); j++)
 			local[j] = ptr[j];
 
 #ifdef BIG_ENDIAN_ENABLED
@@ -836,6 +974,11 @@ void TileMap::_set_tile_data(const PoolVector<int> &p_data) {
 		SWAP(local[1], local[2]);
 		SWAP(local[4], local[7]);
 		SWAP(local[5], local[6]);
+		//TODO: ask someone to check this...
+		if (FORMAT == FORMAT_2_1_5) {
+			SWAP(local[8], local[11]);
+			SWAP(local[9], local[10]);
+		}
 #endif
 
 		int16_t x = decode_uint16(&local[0]);
@@ -845,24 +988,28 @@ void TileMap::_set_tile_data(const PoolVector<int> &p_data) {
 		bool flip_v = v & (1 << 30);
 		bool transpose = v & (1 << 31);
 		v &= (1 << 29) - 1;
-
+		int16_t coord_x;
+		int16_t coord_y;
+		if (format == FORMAT_2_1_5) {
+			coord_x = decode_uint16(&local[8]);
+			coord_y = decode_uint16(&local[10]);
+		}
 		/*
 		if (x<-20 || y <-20 || x>4000 || y>4000)
 			continue;
 		*/
-		set_cell(x, y, v, flip_h, flip_v, transpose);
+		set_cell(x, y, v, flip_h, flip_v, transpose, Vector2(coord_x, coord_y));
 	}
 }
 
 PoolVector<int> TileMap::_get_tile_data() const {
 
 	PoolVector<int> data;
-	data.resize(tile_map.size() * 2);
+	data.resize(tile_map.size() * 3);
 	PoolVector<int>::Write w = data.write();
 
 	int idx = 0;
 	for (const Map<PosKey, Cell>::Element *E = tile_map.front(); E; E = E->next()) {
-
 		uint8_t *ptr = (uint8_t *)&w[idx];
 		encode_uint16(E->key().x, &ptr[0]);
 		encode_uint16(E->key().y, &ptr[2]);
@@ -873,9 +1020,10 @@ PoolVector<int> TileMap::_get_tile_data() const {
 			val |= (1 << 30);
 		if (E->get().transpose)
 			val |= (1 << 31);
-
 		encode_uint32(val, &ptr[4]);
-		idx += 2;
+		encode_uint16(E->get().autotile_coord_x, &ptr[8]);
+		encode_uint16(E->get().autotile_coord_y, &ptr[10]);
+		idx += 3;
 	}
 
 	w = PoolVector<int>::Write();
@@ -1119,10 +1267,50 @@ Vector2 TileMap::_map_to_world(int p_x, int p_y, bool p_ignore_ofs) const {
 	}
 	return ret;
 }
+
+bool TileMap::_set(const StringName &p_name, const Variant &p_value) {
+
+	if (p_name == "format") {
+		if (p_value.get_type() == Variant::INT) {
+			format = (DataFormat)(p_value.operator int64_t());
+			return true;
+		}
+	} else if (p_name == "tile_data") {
+		if (p_value.is_array()) {
+			_set_tile_data(p_value);
+			return true;
+		}
+		return false;
+	}
+	return false;
+}
+
+bool TileMap::_get(const StringName &p_name, Variant &r_ret) const {
+
+	if (p_name == "format") {
+		r_ret = FORMAT_2_1_5;
+		return true;
+	} else if (p_name == "tile_data") {
+		r_ret = _get_tile_data();
+		return true;
+	}
+	return false;
+}
+
+void TileMap::_get_property_list(List<PropertyInfo> *p_list) const {
+
+	PropertyInfo p(Variant::INT, "format", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR);
+	p_list->push_back(p);
+
+	p = PropertyInfo(Variant::OBJECT, "tile_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR);
+	p_list->push_back(p);
+}
+
 Vector2 TileMap::map_to_world(const Vector2 &p_pos, bool p_ignore_ofs) const {
 
 	return _map_to_world(p_pos.x, p_pos.y, p_ignore_ofs);
 }
+
 Vector2 TileMap::world_to_map(const Vector2 &p_pos) const {
 
 	Vector2 ret = get_cell_transform().affine_inverse().xform(p_pos);
@@ -1357,8 +1545,6 @@ void TileMap::_bind_methods() {
 
 	ADD_GROUP("Occluder", "occluder_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "occluder_light_mask", PROPERTY_HINT_LAYERS_2D_RENDER), "set_occluder_light_mask", "get_occluder_light_mask");
-	ADD_GROUP("", "");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "tile_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "_set_tile_data", "_get_tile_data");
 
 	ADD_SIGNAL(MethodInfo("settings_changed"));
 
@@ -1398,6 +1584,7 @@ TileMap::TileMap() {
 	y_sort_mode = false;
 	occluder_light_mask = 1;
 	clip_uv = false;
+	format = FORMAT_2_1_4; //Always initialize with the lowest format
 
 	fp_adjust = 0.00001;
 	tile_origin = TILE_ORIGIN_TOP_LEFT;


### PR DESCRIPTION
This PR adds auto-tiling to TileMap and TileSet classes, it's not finished, but having some feedback while working on it is worth, please have in mind i'll squash commits every time i make some changes so merge this to your forks or to master is a bad idea.

How it works:
- A single tile should have a texture and asign the region of the texture where all subtiles exists. The subtiles can be sepparated by a fixed amount of pixels
- The BitmaskMode property on the tileset allows to define the size of the matrix 
- The tile is marked as autotile on the inspector
- When editing a TileSet a SideControl on the CanvasEditor and a button with the text "Autotiles" at the bottom tools will appear. these two are used to edit autotiles properties.
- Tiles with the IsAutotile property will be listed on the side list picker. When selecting one, it's autotile properties can be edited under the list, properties are: spacing and size.
- After setting up size and spacing click on the "Autotiles" button at the bottom pannel to open the sub editors. The editor will display the region of the texture used in the tile and a grid representing the subdivision according to the size and spacing configured on the autotile properties
- The "Icon" edit mode is a sinple picker to select the subtile wich represents the autotile on the TileMap Editor, also this subtile will be used when drawing a tile wich bitmask configuration is not been setled yet.
- The "Bitmask" editor allows to specify what pars of the tile belong to the same terrain, this is what the BitmaskMode property is for, depending on this proeprty, every subtile could have 4 or 9 bits to be enabled/disabled
- Collision Oclusion and Navigation editors are not functional yet, and might need some design desitions to define the UX
- Besides these editors there are two more features that should be implemented:
1. Subtile Priority: when editing bitmask, you can set the same bitmask to many subtiles, when this happens godot will pick one of them randomly when drawing, setting a priority should change how often one of them is used in comparison to all the others.
2. Afinity-Friendship: this property has not a defined name yet: when editing you might want a terrain to behabe to other tiles like if it would be of the same time, this prevents creating borders beatween, for example, two kinds of watter.

**Changes on TileSet and TileSetEditor**
- [x] New Properties for every tile: is_autotile, autotile_spacing, autotile_size, autotile_icon_coord, autotile_coord_flag
- [x] Allow to store collision oclusion and navigation shapes for every subtile
- [x] Properties to set Priority and Afinity
----------
Create editors for editing Autotile specific properties:
- [x] Icon
- [x] Bitmask
- [x] Collision
- [x] Oclusion
- [x] Navigation
- [x] Priority
- [x] Afinity/Friendship

**Changes on TileMap and TileMapEditor**
- [x] functions to interact with bitmask (make_bitmask_dirty, update_dirty_bitmask, update_cell_bitmask, update_area_bitmask)
- [x] show auto-tile icon instead of complete texture region
- [x] save auto-tile data along with cells data
- [x] update bitmask data while drawing

**Known Issues**
- ~Current TileMap Save/Load Method breaks backward compatibility (if i change this then this feature could be merged to 2.1.x)~
- ~Maps can't be saved, the process is corrupted and causes a SIGABRT when saving.~
- ~The property "IsAutotile" can be changed but it's not saved/loaded~
- ~When selecting a TileMap or TileSet to be edited, the side-editor is squashed on the left of the CanvasItemEditor~
- ~When Editing a TileSet, it is necesary to change selection of the autotile to refresh AutoTile and show the editors properly~