### PR TITLE
Revert "In editor, instance DirectionalLight with an initial orientation"

### DIFF
--- a/scene/3d/light.cpp
+++ b/scene/3d/light.cpp
@@ -369,12 +369,6 @@ DirectionalLight::DirectionalLight()
 	set_shadow_depth_range(SHADOW_DEPTH_RANGE_STABLE);
 
 	blend_splits = false;
-
-#ifdef TOOLS_ENABLED
-	if (Engine::get_singleton()->is_editor_hint())
-		// Create light with a default natural "sun" orientation in editor, instead of looking horizontally on X
-		set_rotation_in_degrees(Vector3(-50, 25, 30));
-#endif
 }
 
 void OmniLight::set_shadow_mode(ShadowMode p_mode) {


### PR DESCRIPTION
Reverts godotengine/godot#11587

While I agree that having the DirectionalLight starting at a more natural rotation would be nice, this is not the way to do it. The rotation should only be set when first creating the Light, while #11587 also overwrites the existing rotation when loading a scene.