### PR TITLE
Fix disable_3d=yes compile errors

### DIFF
--- a/scene/3d/SCsub
+++ b/scene/3d/SCsub
@@ -7,6 +7,9 @@ if env['disable_3d']:
 
     env.scene_sources.append("3d/spatial.cpp")
     env.scene_sources.append("3d/skeleton.cpp")
+    env.scene_sources.append("3d/particles.cpp")
+    env.scene_sources.append("3d/visual_instance.cpp")
+    env.scene_sources.append("3d/scenario_fx.cpp")
 else:
     env.add_source_files(env.scene_sources, "*.cpp")
 

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -152,6 +152,10 @@
 #include "scene/resources/world_2d.h"
 #include "scene/scene_string_names.h"
 
+#include "scene/3d/particles.h"
+#include "scene/3d/scenario_fx.h"
+#include "scene/3d/spatial.h"
+
 #ifndef _3D_DISABLED
 #include "scene/3d/area.h"
 #include "scene/3d/arvr_nodes.h"
@@ -169,7 +173,6 @@
 #include "scene/3d/multimesh_instance.h"
 #include "scene/3d/navigation.h"
 #include "scene/3d/navigation_mesh.h"
-#include "scene/3d/particles.h"
 #include "scene/3d/path.h"
 #include "scene/3d/physics_body.h"
 #include "scene/3d/physics_joint.h"
@@ -180,9 +183,7 @@
 #include "scene/3d/reflection_probe.h"
 #include "scene/3d/remote_transform.h"
 #include "scene/3d/room_instance.h"
-#include "scene/3d/scenario_fx.h"
 #include "scene/3d/skeleton.h"
-#include "scene/3d/spatial.h"
 #include "scene/3d/sprite_3d.h"
 #include "scene/3d/vehicle_body.h"
 #include "scene/3d/visibility_notifier.h"
@@ -551,7 +552,9 @@ void register_scene_types() {
 
 	ClassDB::register_class<AudioStreamPlayer>();
 	ClassDB::register_class<AudioStreamPlayer2D>();
+#ifndef _3D_DISABLED
 	ClassDB::register_class<AudioStreamPlayer3D>();
+#endif
 	ClassDB::register_virtual_class<VideoStream>();
 	ClassDB::register_class<AudioStreamSample>();
 


### PR DESCRIPTION
This fixes below command errors:
`scons platform=x11 target=release tools=no disable_3d=yes -j4`

If ParticlesMaterial and some other classes aren't 3D specific, maybe it's better to move them out of 3d directory.
