### PR TITLE
Add _process(delta) to new script templates. Closes #11994.

### DIFF
--- a/modules/gdscript/gd_editor.cpp
+++ b/modules/gdscript/gd_editor.cpp
@@ -61,7 +61,11 @@ Ref<Script> GDScriptLanguage::get_template(const String &p_class_name, const Str
 					   "func _ready():\n" +
 					   "%TS%# Called every time the node is added to the scene.\n" +
 					   "%TS%# Initialization here\n" +
-					   "%TS%pass\n";
+					   "%TS%pass\n\n" +
+					   "#func _process(delta):\n" +
+					   "#%TS%# Called every frame. Delta is time since last frame.\n" +
+					   "#%TS%# Update game logic here.\n" +
+					   "#%TS%pass\n";
 
 	_template = _template.replace("%BASE%", p_base_class_name);
 	_template = _template.replace("%TS%", _get_indentation());

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -277,7 +277,14 @@ Ref<Script> CSharpLanguage::get_template(const String &p_class_name, const Strin
 							 "        // Initialization here\n"
 							 "        \n"
 							 "    }\n"
-							 "}\n";
+							 "\n"
+							 "//    public override void _Process(float delta)\n"
+							 "//    {\n"
+							 "//        // Called every frame. Delta is time since last frame.\n"
+							 "//        // Update game logic here.\n"
+							 "//        \n"
+							 "//    }\n"
+							 "//}\n";
 
 	script_template = script_template.replace("%BASE_CLASS_NAME%", p_base_class_name).replace("%CLASS_NAME%", p_class_name);
 


### PR DESCRIPTION
As discussed in #11994, this adds the `_process(delta)` method with a description to the templates for newly created scripts, but leaves it commented out by default as to not affect performance if it is not used.
