### PR TITLE
ability to lock spatial nodes transform in editor

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -913,8 +913,8 @@ void EditorSelection::update() {
 
 	if (!changed)
 		return;
-	emit_signal("selection_changed");
 	changed = false;
+	emit_signal("selection_changed");
 }
 
 List<Node *> &EditorSelection::get_selected_node_list() {

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -387,6 +387,8 @@ public:
 		TOOL_MODE_ROTATE,
 		TOOL_MODE_SCALE,
 		TOOL_MODE_LIST_SELECT,
+		TOOL_LOCK_SELECTED,
+		TOOL_UNLOCK_SELECTED,
 		TOOL_MAX
 
 	};
@@ -475,13 +477,17 @@ private:
 		MENU_VIEW_ORIGIN,
 		MENU_VIEW_GRID,
 		MENU_VIEW_CAMERA_SETTINGS,
-
+		MENU_LOCK_SELECTED,
+		MENU_UNLOCK_SELECTED
 	};
 
 	Button *tool_button[TOOL_MAX];
 
 	MenuButton *transform_menu;
 	MenuButton *view_menu;
+
+	ToolButton *lock_button;
+	ToolButton *unlock_button;
 
 	AcceptDialog *accept;
 
@@ -538,6 +544,8 @@ private:
 	SpatialEditor();
 
 	bool is_any_freelook_active() const;
+
+	void _refresh_menu_icons();
 
 protected:
 	void _notification(int p_what);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -745,6 +745,10 @@ void SceneTreeDock::_notification(int p_what) {
 				canvas_item_plugin->get_canvas_item_editor()->connect("item_group_status_changed", scene_tree, "_update_tree");
 				scene_tree->connect("node_changed", canvas_item_plugin->get_canvas_item_editor()->get_viewport_control(), "update");
 			}
+
+			SpatialEditorPlugin *spatial_editor_plugin = Object::cast_to<SpatialEditorPlugin>(editor_data->get_editor("3D"));
+			spatial_editor_plugin->get_spatial_editor()->connect("item_lock_status_changed", scene_tree, "_update_tree");
+
 			button_add->set_icon(get_icon("Add", "EditorIcons"));
 			button_instance->set_icon(get_icon("Instance", "EditorIcons"));
 			button_create_script->set_icon(get_icon("ScriptCreate", "EditorIcons"));

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -88,7 +88,7 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 
 	} else if (p_id == BUTTON_LOCK) {
 
-		if (n->is_class("CanvasItem")) {
+		if (n->is_class("CanvasItem") || n->is_class("Spatial")) {
 			n->set_meta("_edit_lock_", Variant());
 			_update_tree();
 			emit_signal("node_changed");
@@ -265,6 +265,10 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 
 			_update_visibility_color(p_node, item);
 		} else if (p_node->is_class("Spatial")) {
+
+			bool is_locked = p_node->has_meta("_edit_lock_");
+			if (is_locked)
+				item->add_button(0, get_icon("Lock", "EditorIcons"), BUTTON_LOCK, false, TTR("Node is locked.\nClick to unlock"));
 
 			bool v = p_node->call("is_visible");
 			if (v)


### PR DESCRIPTION
Works in the same fashion as lock icon for 2d nodes:
![spatial_lock](https://user-images.githubusercontent.com/6129594/31908914-b71519e0-b838-11e7-8c98-d6b811fddfb8.gif)
It locks translation, scale and rotation.
Change in  `editor_data.cpp`  is needed because it was possible to create infinite loop of `selection_changed` signals in the case when `selection_changed`  signal was connected to the method that uses `editor_data.get_selected_node_list` (it happened when `changed` variable of `editor_data` was set to false).