### PR TITLE
Add ScriptLanguage::supports_builtin_mode and improve ScriptCreateDialog

### DIFF
--- a/core/script_language.h
+++ b/core/script_language.h
@@ -202,6 +202,7 @@ public:
 	virtual bool validate(const String &p_script, int &r_line_error, int &r_col_error, String &r_test_error, const String &p_path = "", List<String> *r_functions = NULL) const = 0;
 	virtual Script *create_script() const = 0;
 	virtual bool has_named_classes() const = 0;
+	virtual bool supports_builtin_mode() const = 0;
 	virtual bool can_inherit_from_file() { return false; }
 	virtual int find_function(const String &p_function, const String &p_code) const = 0;
 	virtual String make_function(const String &p_class, const String &p_name, const PoolStringArray &p_args) const = 0;

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -145,9 +145,13 @@ void ScriptCreateDialog::ok_pressed() {
 
 void ScriptCreateDialog::_create_new() {
 
-	String cname;
-	if (has_named_classes)
-		cname = class_name->get_text();
+	String cname_param;
+
+	if (has_named_classes) {
+		cname_param = class_name->get_text();
+	} else {
+		cname_param = ProjectSettings::get_singleton()->localize_path(file_path->get_text()).get_file().get_basename();
+	}
 
 	Ref<Script> scr;
 	if (script_template != "") {
@@ -159,13 +163,16 @@ void ScriptCreateDialog::_create_new() {
 			return;
 		}
 		scr = scr->duplicate();
-		ScriptServer::get_language(language_menu->get_selected())->make_template(cname, parent_name->get_text(), scr);
+		ScriptServer::get_language(language_menu->get_selected())->make_template(cname_param, parent_name->get_text(), scr);
 	} else {
-		scr = ScriptServer::get_language(language_menu->get_selected())->get_template(cname, parent_name->get_text());
+		scr = ScriptServer::get_language(language_menu->get_selected())->get_template(cname_param, parent_name->get_text());
 	}
 
-	if (cname != "")
-		scr->set_name(cname);
+	if (has_named_classes) {
+		String cname = class_name->get_text();
+		if (cname.length())
+			scr->set_name(cname);
+	}
 
 	if (!is_built_in) {
 		String lpath = ProjectSettings::get_singleton()->localize_path(file_path->get_text());
@@ -201,10 +208,18 @@ void ScriptCreateDialog::_lang_changed(int l) {
 
 	l = language_menu->get_selected();
 	ScriptLanguage *language = ScriptServer::get_language(l);
+
 	if (language->has_named_classes()) {
 		has_named_classes = true;
 	} else {
 		has_named_classes = false;
+	}
+
+	if (language->supports_builtin_mode()) {
+		supports_built_in = true;
+	} else {
+		supports_built_in = false;
+		is_built_in = false;
 	}
 
 	if (ScriptServer::get_language(l)->can_inherit_from_file()) {
@@ -496,6 +511,9 @@ void ScriptCreateDialog::_update_dialog() {
 		}
 	}
 
+	if (!supports_built_in)
+		internal->set_pressed(false);
+
 	/* Is Script created or loaded from existing file */
 
 	if (is_new_script_created) {
@@ -503,7 +521,7 @@ void ScriptCreateDialog::_update_dialog() {
 		get_ok()->set_text(TTR("Create"));
 		parent_name->set_editable(true);
 		parent_browse_button->set_disabled(false);
-		internal->set_disabled(false);
+		internal->set_disabled(!supports_built_in);
 		if (is_built_in) {
 			_msg_path_valid(true, TTR("Built-in script (into scene file)"));
 		} else {
@@ -734,6 +752,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	is_path_valid = false;
 
 	has_named_classes = false;
+	supports_built_in = false;
 	can_inherit_from_file = false;
 	is_built_in = false;
 

--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -62,6 +62,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	bool is_new_script_created;
 	bool is_path_valid;
 	bool has_named_classes;
+	bool supports_built_in;
 	bool can_inherit_from_file;
 	bool is_parent_name_valid;
 	bool is_class_name_valid;

--- a/modules/gdnative/include/pluginscript/godot_pluginscript.h
+++ b/modules/gdnative/include/pluginscript/godot_pluginscript.h
@@ -129,6 +129,7 @@ typedef struct {
 	const char **comment_delimiters; // NULL terminated array
 	const char **string_delimiters; // NULL terminated array
 	godot_bool has_named_classes;
+	godot_bool supports_builtin_mode;
 
 	godot_string (*get_template_source_code)(godot_pluginscript_language_data *p_data, const godot_string *p_class_name, const godot_string *p_base_class_name);
 	godot_bool (*validate)(godot_pluginscript_language_data *p_data, const godot_string *p_script, int *r_line_error, int *r_col_error, godot_string *r_test_error, const godot_string *p_path, godot_pool_string_array *r_functions);

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -908,6 +908,9 @@ Script *NativeScriptLanguage::create_script() const {
 bool NativeScriptLanguage::has_named_classes() const {
 	return true;
 }
+bool NativeScriptLanguage::supports_builtin_mode() const {
+	return true;
+}
 int NativeScriptLanguage::find_function(const String &p_function, const String &p_code) const {
 	return -1;
 }

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -271,6 +271,7 @@ public:
 	virtual bool validate(const String &p_script, int &r_line_error, int &r_col_error, String &r_test_error, const String &p_path, List<String> *r_functions) const;
 	virtual Script *create_script() const;
 	virtual bool has_named_classes() const;
+	virtual bool supports_builtin_mode() const;
 	virtual int find_function(const String &p_function, const String &p_code) const;
 	virtual String make_function(const String &p_class, const String &p_name, const PoolStringArray &p_args) const;
 	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const;

--- a/modules/gdnative/pluginscript/pluginscript_language.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_language.cpp
@@ -133,6 +133,10 @@ bool PluginScriptLanguage::has_named_classes() const {
 	return _desc.has_named_classes;
 }
 
+bool PluginScriptLanguage::supports_builtin_mode() const {
+	return _desc.supports_builtin_mode;
+}
+
 int PluginScriptLanguage::find_function(const String &p_function, const String &p_code) const {
 	if (_desc.find_function) {
 		return _desc.find_function(_data, (godot_string *)&p_function, (godot_string *)&p_code);

--- a/modules/gdnative/pluginscript/pluginscript_language.h
+++ b/modules/gdnative/pluginscript/pluginscript_language.h
@@ -77,6 +77,7 @@ public:
 	virtual bool validate(const String &p_script, int &r_line_error, int &r_col_error, String &r_test_error, const String &p_path = "", List<String> *r_functions = NULL) const;
 	virtual Script *create_script() const;
 	virtual bool has_named_classes() const;
+	virtual bool supports_builtin_mode() const;
 	virtual bool can_inherit_from_file() { return true; }
 	virtual int find_function(const String &p_function, const String &p_code) const;
 	virtual String make_function(const String &p_class, const String &p_name, const PoolStringArray &p_args) const;

--- a/modules/gdscript/gd_editor.cpp
+++ b/modules/gdscript/gd_editor.cpp
@@ -127,6 +127,11 @@ bool GDScriptLanguage::has_named_classes() const {
 	return false;
 }
 
+bool GDScriptLanguage::supports_builtin_mode() const {
+
+	return true;
+}
+
 int GDScriptLanguage::find_function(const String &p_function, const String &p_code) const {
 
 	GDTokenizerText tokenizer;

--- a/modules/gdscript/gd_script.h
+++ b/modules/gdscript/gd_script.h
@@ -386,6 +386,7 @@ public:
 	virtual bool validate(const String &p_script, int &r_line_error, int &r_col_error, String &r_test_error, const String &p_path = "", List<String> *r_functions = NULL) const;
 	virtual Script *create_script() const;
 	virtual bool has_named_classes() const;
+	virtual bool supports_builtin_mode() const;
 	virtual bool can_inherit_from_file() { return true; }
 	virtual int find_function(const String &p_function, const String &p_code) const;
 	virtual String make_function(const String &p_class, const String &p_name, const PoolStringArray &p_args) const;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -279,11 +279,13 @@ Ref<Script> CSharpLanguage::get_template(const String &p_class_name, const Strin
 							 "    }\n"
 							 "}\n";
 
-	script_template = script_template.replace("%BASE_CLASS_NAME%", p_base_class_name).replace("%CLASS_NAME%", p_class_name);
+	script_template = script_template.replace("%BASE_CLASS_NAME%", p_base_class_name)
+							  .replace("%CLASS_NAME%", p_class_name);
 
 	Ref<CSharpScript> script;
 	script.instance();
 	script->set_source_code(script_template);
+	script->set_name(p_class_name);
 
 	return script;
 }
@@ -295,7 +297,12 @@ Script *CSharpLanguage::create_script() const {
 
 bool CSharpLanguage::has_named_classes() const {
 
-	return true;
+	return false;
+}
+
+bool CSharpLanguage::supports_builtin_mode() const {
+
+	return false;
 }
 
 static String variant_type_to_managed_name(const String &p_var_type_name) {

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -270,6 +270,7 @@ public:
 	/* TODO */ virtual bool validate(const String &p_script, int &r_line_error, int &r_col_error, String &r_test_error, const String &p_path, List<String> *r_functions) const { return true; }
 	virtual Script *create_script() const;
 	virtual bool has_named_classes() const;
+	virtual bool supports_builtin_mode() const;
 	/* TODO? */ virtual int find_function(const String &p_function, const String &p_code) const { return -1; }
 	virtual String make_function(const String &p_class, const String &p_name, const PoolStringArray &p_args) const;
 	/* TODO? */ Error complete_code(const String &p_code, const String &p_base_path, Object *p_owner, List<String> *r_options, String &r_call_hint) { return ERR_UNAVAILABLE; }

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -2412,6 +2412,10 @@ bool VisualScriptLanguage::has_named_classes() const {
 
 	return false;
 }
+bool VisualScriptLanguage::supports_builtin_mode() const {
+
+	return true;
+}
 int VisualScriptLanguage::find_function(const String &p_function, const String &p_code) const {
 
 	return -1;

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -569,6 +569,7 @@ public:
 	virtual bool validate(const String &p_script, int &r_line_error, int &r_col_error, String &r_test_error, const String &p_path = "", List<String> *r_functions = NULL) const;
 	virtual Script *create_script() const;
 	virtual bool has_named_classes() const;
+	virtual bool supports_builtin_mode() const;
 	virtual int find_function(const String &p_function, const String &p_code) const;
 	virtual String make_function(const String &p_class, const String &p_name, const PoolStringArray &p_args) const;
 	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const;


### PR DESCRIPTION
- Make ScriptCreateDialog disable the built-in script checked button if the language does not support it.
- ScriptLanguage's get_template and make_template now receive the script path as class name if the the script language does not have named classes.

@karroffel and @touilleMan please review GDNative and PluginScript changes.
