### PR TITLE
Make build scripts Scons 3.0/Python3 compatible

### DIFF
--- a/compat.py
+++ b/compat.py
@@ -1,0 +1,31 @@
+import sys
+
+if sys.version_info < (3,):
+    def isbasestring(s):
+        return isinstance(s, basestring)
+    def open_utf8(filename, mode):
+        return open(filename, mode)
+    def byte_to_str(x):
+        return str(ord(x))
+    import cStringIO
+    def StringIO():
+        return cStringIO.StringIO()
+    def encode_utf8(x):
+        return x
+    def iteritems(d):
+        return d.iteritems()
+else:
+    def isbasestring(s):
+        return isinstance(s, (str, bytes))
+    def open_utf8(filename, mode):
+        return open(filename, mode, encoding="utf-8")
+    def byte_to_str(x):
+        return str(x)
+    import io
+    def StringIO():
+        return io.StringIO()
+    import codecs
+    def encode_utf8(x):
+        return codecs.utf_8_encode(x)[0]
+    def iteritems(d):
+        return iter(d.items())

--- a/core/SCsub
+++ b/core/SCsub
@@ -18,7 +18,7 @@ gd_cpp = '#include "globals.h"\n'
 gd_cpp += gd_inc
 gd_cpp += "void Globals::register_global_defaults() {\n" + gd_call + "\n}\n"
 
-f = open("global_defaults.gen.cpp", "wb")
+f = open("global_defaults.gen.cpp", "w")
 f.write(gd_cpp)
 f.close()
 
@@ -47,7 +47,7 @@ if ("SCRIPT_AES256_ENCRYPTION_KEY" in os.environ):
         txt = "0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0"
         print("Invalid AES256 encryption key, not 64 bits hex: " + e)
 
-f = open("script_encryption_key.gen.cpp", "wb")
+f = open("script_encryption_key.gen.cpp", "w")
 f.write("#include \"globals.h\"\nuint8_t script_encryption_key[32]={" + txt + "};\n")
 f.close()
 

--- a/drivers/gles2/shaders/SCsub
+++ b/drivers/gles2/shaders/SCsub
@@ -2,7 +2,7 @@
 
 Import('env')
 
-if env['BUILDERS'].has_key('GLSL120GLES'):
+if 'GLSL120GLES' in env['BUILDERS']:
     env.GLSL120GLES('material.glsl')
     env.GLSL120GLES('canvas.glsl')
     env.GLSL120GLES('canvas_shadow.glsl')

--- a/drivers/unix/SCsub
+++ b/drivers/unix/SCsub
@@ -8,7 +8,7 @@ g_set_p += 'String OS_Unix::get_global_settings_path() const {\n'
 g_set_p += '\treturn "' + env["unix_global_settings_path"] + '";\n'
 g_set_p += '}\n'
 g_set_p += '#endif'
-f = open("os_unix_global_settings_path.gen.cpp", "wb")
+f = open("os_unix_global_settings_path.gen.cpp", "w")
 f.write(g_set_p)
 f.close()
 

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -3,13 +3,15 @@
 Import('env')
 env.editor_sources = []
 
+from compat import encode_utf8, byte_to_str, open_utf8
+
 
 def make_certs_header(target, source, env):
 
     src = source[0].srcnode().abspath
     dst = target[0].srcnode().abspath
     f = open(src, "rb")
-    g = open(dst, "wb")
+    g = open_utf8(dst, "w")
     buf = f.read()
     decomp_size = len(buf)
     import zlib
@@ -22,7 +24,7 @@ def make_certs_header(target, source, env):
     g.write("static const int _certs_uncompressed_size=" + str(decomp_size) + ";\n")
     g.write("static const unsigned char _certs_compressed[]={\n")
     for i in range(len(buf)):
-        g.write(str(ord(buf[i])) + ",\n")
+        g.write(byte_to_str(buf[i]) + ",\n")
     g.write("};\n")
     g.write("#endif")
 
@@ -31,9 +33,15 @@ def make_doc_header(target, source, env):
 
     src = source[0].srcnode().abspath
     dst = target[0].srcnode().abspath
-    f = open(src, "rb")
-    g = open(dst, "wb")
-    buf = f.read()
+    f = open_utf8(src, "r")
+    g = open_utf8(dst, "w")
+    # Note: As long as we simply read the contents of `f` and immediately call
+    # `zlib.compress` on the result, we could open `f` as binary file and store
+    # the result in `buf` without passing it through `encode_utf8`. However if
+    # we ever perform any string operations on the result (as in Godot 3)
+    # we need the UTF8 decoding/encoding step, so it seems more future proof
+    # to do it this way.
+    buf = encode_utf8(f.read())
     decomp_size = len(buf)
     import zlib
     buf = zlib.compress(buf)
@@ -45,7 +53,7 @@ def make_doc_header(target, source, env):
     g.write("static const int _doc_data_uncompressed_size=" + str(decomp_size) + ";\n")
     g.write("static const unsigned char _doc_data_compressed[]={\n")
     for i in range(len(buf)):
-        g.write(str(ord(buf[i])) + ",\n")
+        g.write(byte_to_str(buf[i]) + ",\n")
     g.write("};\n")
     g.write("#endif")
 
@@ -54,7 +62,7 @@ def make_fonts_header(target, source, env):
 
     dst = target[0].srcnode().abspath
 
-    g = open(dst, "wb")
+    g = open_utf8(dst, "w")
 
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     g.write("#ifndef _EDITOR_FONTS_H\n")
@@ -72,7 +80,7 @@ def make_fonts_header(target, source, env):
         g.write("static const int _font_" + name + "_size=" + str(len(buf)) + ";\n")
         g.write("static const unsigned char _font_" + name + "[]={\n")
         for i in range(len(buf)):
-            g.write(str(ord(buf[i])) + ",\n")
+            g.write(byte_to_str(buf[i]) + ",\n")
 
         g.write("};\n")
 
@@ -83,7 +91,7 @@ def make_translations_header(target, source, env):
 
     dst = target[0].srcnode().abspath
 
-    g = open(dst, "wb")
+    g = open_utf8(dst, "w")
 
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     g.write("#ifndef _EDITOR_TRANSLATIONS_H\n")
@@ -107,7 +115,7 @@ def make_translations_header(target, source, env):
         #g.write("static const int _translation_"+name+"_uncompressed_size="+str(decomp_size)+";\n")
         g.write("static const unsigned char _translation_" + name + "_compressed[]={\n")
         for i in range(len(buf)):
-            g.write(str(ord(buf[i])) + ",\n")
+            g.write(byte_to_str(buf[i]) + ",\n")
 
         g.write("};\n")
 
@@ -131,8 +139,8 @@ def make_authors_header(target, source, env):
 
     src = source[0].srcnode().abspath
     dst = target[0].srcnode().abspath
-    f = open(src, "rb")
-    g = open(dst, "wb")
+    f = open_utf8(src, "r")
+    g = open_utf8(dst, "w")
 
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     g.write("#ifndef _EDITOR_AUTHORS_H\n")
@@ -162,7 +170,7 @@ if (env["tools"] == "yes"):
         reg_exporters += '\tregister_' + e + '_exporter();\n'
         reg_exporters_inc += '#include "platform/' + e + '/export/export.h"\n'
     reg_exporters += '}\n'
-    f = open("register_exporters.gen.cpp", "wb")
+    f = open_utf8("register_exporters.gen.cpp", "w")
     f.write(reg_exporters_inc)
     f.write(reg_exporters)
     f.close()

--- a/editor/icons/SCsub
+++ b/editor/icons/SCsub
@@ -1,17 +1,16 @@
 #!/usr/bin/env python
 
 Import('env')
-
+from compat import StringIO
 
 def make_editor_icons_action(target, source, env):
 
     import os
-    import cStringIO
 
     dst = target[0].srcnode().abspath
     pixmaps = source
 
-    s = cStringIO.StringIO()
+    s = StringIO()
 
     s.write("#include \"editor_icons.h\"\n\n")
     s.write("#include \"editor_scale.h\"\n\n")
@@ -79,7 +78,7 @@ def make_editor_icons_action(target, source, env):
 
     s.write("\n\n}\n\n")
 
-    f = open(dst, "wb")
+    f = open(dst, "w")
     f.write(s.getvalue())
     f.close()
     s.close()

--- a/methods.py
+++ b/methods.py
@@ -1,4 +1,5 @@
 import os
+from compat import iteritems
 
 
 def add_source_files(self, sources, filetype, lib_env=None, shared=False):
@@ -21,7 +22,7 @@ def add_source_files(self, sources, filetype, lib_env=None, shared=False):
 def build_shader_header(target, source, env):
 
     for x in source:
-        print x
+        print(x)
 
         name = str(x)
         name = name[name.rfind("/") + 1:]
@@ -701,11 +702,11 @@ def include_file_in_legacygl_header(filename, header_data, depth):
             if (not included_file in header_data.vertex_included_files and header_data.reading == "vertex"):
                 header_data.vertex_included_files += [included_file]
                 if(include_file_in_legacygl_header(included_file, header_data, depth + 1) == None):
-                    print "Error in file '" + filename + "': #include " + includeline + "could not be found!"
+                    print("Error in file '" + filename + "': #include " + includeline + "could not be found!")
             elif (not included_file in header_data.fragment_included_files and header_data.reading == "fragment"):
                 header_data.fragment_included_files += [included_file]
                 if(include_file_in_legacygl_header(included_file, header_data, depth + 1) == None):
-                    print "Error in file '" + filename + "': #include " + includeline + "could not be found!"
+                    print("Error in file '" + filename + "': #include " + includeline + "could not be found!")
 
             line = fs.readline()
 
@@ -1093,7 +1094,7 @@ def update_version():
         print("Using custom revision: " + rev)
     import version
 
-    f = open("core/version_generated.gen.h", "wb")
+    f = open("core/version_generated.gen.h", "w")
     f.write("#define VERSION_SHORT_NAME " + str(version.short_name) + "\n")
     f.write("#define VERSION_NAME " + str(version.name) + "\n")
     f.write("#define VERSION_MAJOR " + str(version.major) + "\n")
@@ -1225,7 +1226,7 @@ void unregister_module_types() {
 
 """
 
-    f = open("modules/register_module_types.gen.cpp", "wb")
+    f = open("modules/register_module_types.gen.cpp", "w")
     f.write(modules_cpp)
 
     return module_list
@@ -1245,9 +1246,9 @@ def win32_spawn(sh, escape, cmd, args, env):
     data, err = proc.communicate()
     rv = proc.wait()
     if rv:
-        print "====="
-        print err
-        print "====="
+        print("=====")
+        print(err)
+        print("=====")
     return rv
 
 """
@@ -1325,17 +1326,17 @@ def android_add_default_config(self, config):
 
 def android_add_to_manifest(self, file):
     base_path = self.Dir(".").abspath + "/modules/" + self.current_module + "/" + file
-    f = open(base_path, "rb")
+    f = open(base_path, "r")
     self.android_manifest_chunk += f.read()
 
 def android_add_to_permissions(self, file):
     base_path = self.Dir(".").abspath + "/modules/" + self.current_module + "/" + file
-    f = open(base_path, "rb")
+    f = open(base_path, "r")
     self.android_permission_chunk += f.read()
 
 def android_add_to_attributes(self, file):
     base_path = self.Dir(".").abspath + "/modules/" + self.current_module + "/" + file
-    f = open(base_path, "rb")
+    f = open(base_path, "r")
     self.android_appattributes_chunk += f.read()
 
 def disable_module(self):
@@ -1370,9 +1371,9 @@ def use_windows_spawn_fix(self, platform=None):
         data, err = proc.communicate()
         rv = proc.wait()
         if rv:
-            print "====="
-            print err
-            print "====="
+            print("=====")
+            print(err)
+            print("=====")
         return rv
 
     def mySpawn(sh, escape, cmd, args, env):
@@ -1381,7 +1382,7 @@ def use_windows_spawn_fix(self, platform=None):
         cmdline = cmd + " " + newargs
 
         rv = 0
-        env = {str(key): str(value) for key, value in env.iteritems()}
+        env = {str(key): str(value) for key, value in iteritems(env)}
         if len(cmdline) > 32000 and cmd.endswith("ar"):
             cmdline = cmd + " " + args[1] + " " + args[2] + " "
             for i in range(3, len(args)):
@@ -1458,7 +1459,7 @@ def save_active_platforms(apnames, ap):
         str += "};\n"
 
         wf = x + "/logo.gen.h"
-        logow = open(wf, "wb")
+        logow = open(wf, "w")
         logow.write(str)
 
 
@@ -1525,7 +1526,7 @@ def detect_visual_c_compiler_version(tools_env):
 
     # Start with Pre VS 2017 checks which uses VCINSTALLDIR:
     if 'VCINSTALLDIR' in tools_env:
-        # print "Checking VCINSTALLDIR"
+        # print("Checking VCINSTALLDIR")
 
         # find() works with -1 so big ifs bellow are needed... the simplest solution, in fact
         # First test if amd64 and amd64_x86 compilers are present in the path
@@ -1558,7 +1559,7 @@ def detect_visual_c_compiler_version(tools_env):
 
     # and for VS 2017 and newer we check VCTOOLSINSTALLDIR:
     if 'VCTOOLSINSTALLDIR' in tools_env:
-        # print "Checking VCTOOLSINSTALLDIR"
+        # print("Checking VCTOOLSINSTALLDIR")
 
         # Newer versions have a different path available
         vc_amd64_compiler_detection_index = tools_env["PATH"].upper().find(tools_env['VCTOOLSINSTALLDIR'].upper() + "BIN\\HOSTX64\\X64;")
@@ -1588,11 +1589,11 @@ def detect_visual_c_compiler_version(tools_env):
             vc_chosen_compiler_str = "x86_amd64"
 
     # debug help
-    # print vc_amd64_compiler_detection_index
-    # print vc_amd64_x86_compiler_detection_index
-    # print vc_x86_compiler_detection_index
-    # print vc_x86_amd64_compiler_detection_index
-    # print "chosen "+str(vc_chosen_compiler_index)+ " | "+str(vc_chosen_compiler_str)
+    # print(vc_amd64_compiler_detection_index)
+    # print(vc_amd64_x86_compiler_detection_index)
+    # print(vc_x86_compiler_detection_index)
+    # print(vc_x86_amd64_compiler_detection_index)
+    # print("chosen "+str(vc_chosen_compiler_index)+ " | "+str(vc_chosen_compiler_str))
 
     return vc_chosen_compiler_str
 

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 Import('env')
+from compat import isbasestring
 
 # Not building in a separate env as scene needs it
 
@@ -74,7 +75,7 @@ if (env['builtin_freetype'] != 'no'):
     # and then plain strings for system library. We insert between the two.
     inserted = False
     for idx, linklib in enumerate(env["LIBS"]):
-        if isinstance(linklib, basestring): # first system lib such as "X11", otherwise SCons lib object
+        if isbasestring(linklib): # first system lib such as "X11", otherwise SCons lib object
             env["LIBS"].insert(idx, lib)
             inserted = True
             break

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import shutil
+from compat import open_utf8
 
 Import('env')
 
@@ -39,8 +40,8 @@ prog = None
 abspath = env.Dir(".").abspath
 
 
-gradle_basein = open(abspath + "/build.gradle.template", "rb")
-gradle_baseout = open(abspath + "/java/build.gradle", "wb")
+gradle_basein = open_utf8(abspath + "/build.gradle.template", "r")
+gradle_baseout = open_utf8(abspath + "/java/build.gradle", "w")
 
 gradle_text = gradle_basein.read()
 
@@ -133,8 +134,8 @@ gradle_baseout.write(gradle_text)
 gradle_baseout.close()
 
 
-pp_basein = open(abspath + "/AndroidManifest.xml.template", "rb")
-pp_baseout = open(abspath + "/java/AndroidManifest.xml", "wb")
+pp_basein = open_utf8(abspath + "/AndroidManifest.xml.template", "r")
+pp_baseout = open_utf8(abspath + "/java/AndroidManifest.xml", "w")
 manifest = pp_basein.read()
 manifest = manifest.replace("$$ADD_APPLICATION_CHUNKS$$", env.android_manifest_chunk)
 manifest = manifest.replace("$$ADD_PERMISSION_CHUNKS$$", env.android_permission_chunk)

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -13,12 +13,7 @@ def get_name():
 
 
 def can_build():
-
-    import os
-    if (not os.environ.has_key("ANDROID_NDK_ROOT")):
-        return False
-
-    return True
+    return ("ANDROID_NDK_ROOT" in os.environ)
 
 
 def get_opts():
@@ -60,7 +55,7 @@ def configure(env):
         import subprocess
 
         def mySubProcess(cmdline, env):
-            # print "SPAWNED : " + cmdline
+            # print("SPAWNED : " + cmdline)
             startupinfo = subprocess.STARTUPINFO()
             startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
             proc = subprocess.Popen(cmdline, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
@@ -68,9 +63,9 @@ def configure(env):
             data, err = proc.communicate()
             rv = proc.wait()
             if rv:
-                print "====="
-                print err
-                print "====="
+                print("=====")
+                print(err)
+                print("=====")
             return rv
 
         def mySpawn(sh, escape, cmd, args, env):
@@ -167,9 +162,8 @@ def configure(env):
     common_opts = ['-fno-integrated-as', '-gcc-toolchain', gcc_toolchain_path]
 
     env.Append(CPPFLAGS=["-isystem", sysroot + "/usr/include"])
-    env.Append(CPPFLAGS=string.split(
-        '-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -fvisibility=hidden -fno-strict-aliasing'))
-    env.Append(CPPFLAGS=string.split('-DNO_STATVFS -DGLES2_ENABLED'))
+    env.Append(CPPFLAGS='-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -fvisibility=hidden -fno-strict-aliasing'.split())
+    env.Append(CPPFLAGS='-DNO_STATVFS -DGLES2_ENABLED'.split())
 
     env['neon_enabled'] = False
     if env['android_arch'] == 'x86':
@@ -180,13 +174,12 @@ def configure(env):
     elif env["android_arch"] == "armv6":
         can_vectorize = False
         target_opts = ['-target', 'armv6-none-linux-androideabi']
-        env.Append(CPPFLAGS=string.split(
-            '-D__ARM_ARCH_6__ -march=armv6 -mfpu=vfp -mfloat-abi=softfp'))
+        env.Append(CPPFLAGS='-D__ARM_ARCH_6__ -march=armv6 -mfpu=vfp -mfloat-abi=softfp'.split())
+
     elif env["android_arch"] == "armv7":
         can_vectorize = True
         target_opts = ['-target', 'armv7-none-linux-androideabi']
-        env.Append(CPPFLAGS=string.split(
-            '-D__ARM_ARCH_7__ -D__ARM_ARCH_7A__ -march=armv7-a -mfloat-abi=softfp'))
+        env.Append(CPPFLAGS='-D__ARM_ARCH_7__ -D__ARM_ARCH_7A__ -march=armv7-a -mfloat-abi=softfp'.split())
         if env['android_neon'] == 'yes':
             env['neon_enabled'] = True
             env.Append(CPPFLAGS=['-mfpu=neon', '-D__ARM_NEON__'])
@@ -205,12 +198,9 @@ def configure(env):
 
     env['LINKFLAGS'] = ['-shared', '--sysroot=' +
                         sysroot, '-Wl,--warn-shared-textrel']
-    env.Append(LINKFLAGS=string.split(
-        '-Wl,--fix-cortex-a8'))
-    env.Append(LINKFLAGS=string.split(
-        '-Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now'))
-    env.Append(LINKFLAGS=string.split(
-        '-Wl,-soname,libgodot_android.so -Wl,--gc-sections'))
+    env.Append(LINKFLAGS='-Wl,--fix-cortex-a8'.split())
+    env.Append(LINKFLAGS='-Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now'.split())
+    env.Append(LINKFLAGS='-Wl,-soname,libgodot_android.so -Wl,--gc-sections'.split())
     if mt_link:
         env.Append(LINKFLAGS=['-Wl,--threads'])
     env.Append(LINKFLAGS=target_opts)

--- a/platform/bb10/detect.py
+++ b/platform/bb10/detect.py
@@ -15,7 +15,7 @@ def get_name():
 def can_build():
 
     import os
-    if (not os.environ.has_key("QNX_TARGET")):
+    if not "QNX_TARGET" in os.environ:
         return False
     return True
 

--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -12,9 +12,7 @@ def get_name():
 
 def can_build():
 
-    import sys
-    import os
-    if sys.platform == 'darwin' or os.environ.has_key("OSXCROSS_IOS"):
+    if sys.platform == 'darwin' or ("OSXCROSS_IOS" in os.environ):
         return True
 
     return False
@@ -58,16 +56,16 @@ def configure(env):
     if (env["ios_sim"] == "yes" or env["arch"] == "x86"):  # i386, simulator
         env["arch"] = "x86"
         env["bits"] = "32"
-        env.Append(CCFLAGS=string.split('-arch i386 -fobjc-abi-version=2 -fobjc-legacy-dispatch -fmessage-length=0 -fpascal-strings -fblocks -fasm-blocks -D__IPHONE_OS_VERSION_MIN_REQUIRED=40100 -isysroot $IPHONESDK -mios-simulator-version-min=4.3 -DCUSTOM_MATRIX_TRANSFORM_H=\\\"build/iphone/matrix4_iphone.h\\\" -DCUSTOM_VECTOR3_TRANSFORM_H=\\\"build/iphone/vector3_iphone.h\\\"'))
+        env.Append(CCFLAGS='-arch i386 -fobjc-abi-version=2 -fobjc-legacy-dispatch -fmessage-length=0 -fpascal-strings -fblocks -fasm-blocks -D__IPHONE_OS_VERSION_MIN_REQUIRED=40100 -isysroot $IPHONESDK -mios-simulator-version-min=4.3 -DCUSTOM_MATRIX_TRANSFORM_H=\\\"build/iphone/matrix4_iphone.h\\\" -DCUSTOM_VECTOR3_TRANSFORM_H=\\\"build/iphone/vector3_iphone.h\\\"'.split())
     elif (env["arch"] == "arm64"):  # arm64
         env["bits"] = "64"
-        env.Append(CCFLAGS=string.split('-fno-objc-arc -arch arm64 -fmessage-length=0 -fno-strict-aliasing -fdiagnostics-print-source-range-info -fdiagnostics-show-category=id -fdiagnostics-parseable-fixits -fpascal-strings -fblocks -fvisibility=hidden -MMD -MT dependencies -miphoneos-version-min=7.0 -isysroot $IPHONESDK'))
+        env.Append(CCFLAGS='-fno-objc-arc -arch arm64 -fmessage-length=0 -fno-strict-aliasing -fdiagnostics-print-source-range-info -fdiagnostics-show-category=id -fdiagnostics-parseable-fixits -fpascal-strings -fblocks -fvisibility=hidden -MMD -MT dependencies -miphoneos-version-min=7.0 -isysroot $IPHONESDK'.split())
         env.Append(CPPFLAGS=['-DNEED_LONG_INT'])
         env.Append(CPPFLAGS=['-DLIBYUV_DISABLE_NEON'])
     else:  # armv7
         env["arch"] = "arm"
         env["bits"] = "32"
-        env.Append(CCFLAGS=string.split('-fno-objc-arc -arch armv7 -fmessage-length=0 -fno-strict-aliasing -fdiagnostics-print-source-range-info -fdiagnostics-show-category=id -fdiagnostics-parseable-fixits -fpascal-strings -fblocks -isysroot $IPHONESDK -fvisibility=hidden -mthumb "-DIBOutlet=__attribute__((iboutlet))" "-DIBOutletCollection(ClassName)=__attribute__((iboutletcollection(ClassName)))" "-DIBAction=void)__attribute__((ibaction)" -miphoneos-version-min=7.0 -MMD -MT dependencies'))
+        env.Append(CCFLAGS='-fno-objc-arc -arch armv7 -fmessage-length=0 -fno-strict-aliasing -fdiagnostics-print-source-range-info -fdiagnostics-show-category=id -fdiagnostics-parseable-fixits -fpascal-strings -fblocks -isysroot $IPHONESDK -fvisibility=hidden -mthumb "-DIBOutlet=__attribute__((iboutlet))" "-DIBOutletCollection(ClassName)=__attribute__((iboutletcollection(ClassName)))" "-DIBAction=void)__attribute__((ibaction)" -miphoneos-version-min=7.0 -MMD -MT dependencies'.split())
 
     if (env["arch"] == "x86"):
         env['IPHONEPLATFORM'] = 'iPhoneSimulator'

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -12,11 +12,7 @@ def get_name():
 
 
 def can_build():
-
-    import os
-    if (not os.environ.has_key("EMSCRIPTEN_ROOT")):
-        return False
-    return True
+    return ("EMSCRIPTEN_ROOT" in os.environ)
 
 
 def get_opts():

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -13,7 +13,7 @@ def get_name():
 
 def can_build():
 
-    if (sys.platform == "darwin" or os.environ.has_key("OSXCROSS_ROOT")):
+    if (sys.platform == "darwin" or ("OSXCROSS_ROOT" in os.environ)):
         return True
 
     return False
@@ -53,7 +53,7 @@ def configure(env):
 
         env.Append(CCFLAGS=['-g3', '-DDEBUG_ENABLED', '-DDEBUG_MEMORY_ENABLED'])
 
-    if (not os.environ.has_key("OSXCROSS_ROOT")):
+    if ("OSXCROSS_ROOT" not in os.environ):
         # regular native build
         if (env["bits"] == "64"):
             env.Append(CCFLAGS=['-arch', 'x86_64'])

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -281,7 +281,7 @@ def configure(env):
 
         # Note: this detection/override code from here onward should be here instead of in SConstruct because it's platform and compiler specific (MSVC/Windows)
         if(env["bits"] != "default"):
-            print "Error: bits argument is disabled for MSVC"
+            print("Error: bits argument is disabled for MSVC")
             print ("Bits argument is not supported for MSVC compilation. Architecture depends on the Native/Cross Compile Tools Prompt/Developer Console (or Visual Studio settings)"
                    + " that is being used to run SCons. As a consequence, bits argument is disabled. Run scons again without bits argument (example: scons p=windows) and SCons will attempt to detect what MSVC compiler"
                    + " will be executed and inform you.")
@@ -292,16 +292,16 @@ def configure(env):
         env["bits"] = "32"
         env["x86_libtheora_opt_vc"] = True
 
-        print "Detected MSVC compiler: " + compiler_version_str
+        print("Detected MSVC compiler: " + compiler_version_str)
         # If building for 64bit architecture, disable assembly optimisations for 32 bit builds (theora as of writting)... vc compiler for 64bit can not compile _asm
         if(compiler_version_str == "amd64" or compiler_version_str == "x86_amd64"):
             env["bits"] = "64"
             env["x86_libtheora_opt_vc"] = False
-            print "Compiled program architecture will be a 64 bit executable (forcing bits=64)."
+            print("Compiled program architecture will be a 64 bit executable (forcing bits=64).")
         elif (compiler_version_str == "x86" or compiler_version_str == "amd64_x86"):
-            print "Compiled program architecture will be a 32 bit executable. (forcing bits=32)."
+            print("Compiled program architecture will be a 32 bit executable. (forcing bits=32).")
         else:
-            print "Failed to detect MSVC compiler architecture version... Defaulting to 32bit executable settings (forcing bits=32). Compilation attempt will continue, but SCons can not detect for what architecture this build is compiled for. You should check your settings/compilation setup."
+            print("Failed to detect MSVC compiler architecture version... Defaulting to 32bit executable settings (forcing bits=32). Compilation attempt will continue, but SCons can not detect for what architecture this build is compiled for. You should check your settings/compilation setup.")
         if env["bits"] == "64":
             env.Append(CCFLAGS=['/D_WIN64'])
     else:

--- a/platform/winrt/detect.py
+++ b/platform/winrt/detect.py
@@ -38,7 +38,7 @@ def get_flags():
 def configure(env):
 
     if(env["bits"] != "default"):
-        print "Error: bits argument is disabled for MSVC"
+        print("Error: bits argument is disabled for MSVC")
         print ("Bits argument is not supported for MSVC compilation. Architecture depends on the Native/Cross Compile Tools Prompt/Developer Console (or Visual Studio settings)"
                +" that is being used to run SCons. As a consequence, bits argument is disabled. Run scons again without bits argument (example: scons p=winrt) and SCons will attempt to detect what MSVC compiler"
                +" will be executed and inform you.")
@@ -58,7 +58,7 @@ def configure(env):
 
     if os.getenv('Platform') == "ARM":
 
-        print "Compiled program architecture will be an ARM executable. (forcing bits=32)."
+        print("Compiled program architecture will be an ARM executable. (forcing bits=32).")
 
         arch="arm"
         env["bits"]="32"
@@ -75,12 +75,12 @@ def configure(env):
 
         if(compiler_version_str == "amd64" or compiler_version_str == "x86_amd64"):
             env["bits"]="64"
-            print "Compiled program architecture will be a x64 executable (forcing bits=64)."
+            print("Compiled program architecture will be a x64 executable (forcing bits=64).")
         elif (compiler_version_str=="x86" or compiler_version_str == "amd64_x86"):
             env["bits"]="32"
-            print "Compiled program architecture will be a x86 executable. (forcing bits=32)."
+            print("Compiled program architecture will be a x86 executable. (forcing bits=32).")
         else:
-            print "Failed to detect MSVC compiler architecture version... Defaulting to 32bit executable settings (forcing bits=32). Compilation attempt will continue, but SCons can not detect for what architecture this build is compiled for. You should check your settings/compilation setup."
+            print("Failed to detect MSVC compiler architecture version... Defaulting to 32bit executable settings (forcing bits=32). Compilation attempt will continue, but SCons can not detect for what architecture this build is compiled for. You should check your settings/compilation setup.")
             env["bits"]="32"
 
         if (env["bits"] == "32"):


### PR DESCRIPTION
- Cherry picked #10662 and fixed merge conflicts.
- Manualy merged the change from #11904.
- Did not merge #12236 since I'm not sure whether the issue affects Godot 2.1 and I don't have VS2013 to test.
- Did not merge #11843 since it doesn't seem relevant (the code is only needed for creating DONORS.md, etc.).
- Did not merge #10727 and #11752 since they seem to be already included in #11742.
- The Windows and Linux builds have been tested with Scons 3.0 using Python 3.
- OSX and iOS should hopefully work but are not tested since I don't have a Mac.
- Builds using SCons 2.5 and Python 2 should not be impacted.

Fixes #12109.