### PR TITLE
Add Color.lighten and Color.darken (like LESS.css or SASS) #2

### DIFF
--- a/core/color.h
+++ b/core/color.h
@@ -101,6 +101,24 @@ struct Color {
 		return res;
 	}
 
+	_FORCE_INLINE_ Color darkened(float p_amount) const {
+
+		Color res = *this;
+		res.r = CLAMP(res.r * (1.0f - p_amount), 0.0, 1.0);
+		res.g = CLAMP(res.g * (1.0f - p_amount), 0.0, 1.0);
+		res.b = CLAMP(res.b * (1.0f - p_amount), 0.0, 1.0);
+		return res;
+	}
+
+	_FORCE_INLINE_ Color lightened(float p_amount) const {
+
+		Color res = *this;
+		res.r = CLAMP(res.r + (1.0f - res.r) * p_amount, 0.0, 1.0);
+		res.g = CLAMP(res.g + (1.0f - res.g) * p_amount, 0.0, 1.0);
+		res.b = CLAMP(res.b + (1.0f - res.b) * p_amount, 0.0, 1.0);
+		return res;
+	}
+
 	_FORCE_INLINE_ uint32_t to_rgbe9995() const {
 
 		const float pow2to9 = 512.0f;

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -437,6 +437,8 @@ struct _VariantCall {
 	VCALL_LOCALMEM0R(Color, contrasted);
 	VCALL_LOCALMEM2R(Color, linear_interpolate);
 	VCALL_LOCALMEM1R(Color, blend);
+	VCALL_LOCALMEM1R(Color, lightened);
+	VCALL_LOCALMEM1R(Color, darkened);
 	VCALL_LOCALMEM1R(Color, to_html);
 
 	VCALL_LOCALMEM0R(RID, get_id);
@@ -1581,6 +1583,8 @@ void register_variant_methods() {
 	ADDFUNC0R(COLOR, COLOR, Color, contrasted, varray());
 	ADDFUNC2R(COLOR, COLOR, Color, linear_interpolate, COLOR, "b", REAL, "t", varray());
 	ADDFUNC1R(COLOR, COLOR, Color, blend, COLOR, "over", varray());
+	ADDFUNC1R(COLOR, COLOR, Color, lightened, REAL, "amount", varray());
+	ADDFUNC1R(COLOR, COLOR, Color, darkened, REAL, "amount", varray());
 	ADDFUNC1R(COLOR, STRING, Color, to_html, BOOL, "with_alpha", varray(true));
 
 	ADDFUNC0R(_RID, INT, RID, get_id, varray());

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -126,6 +126,32 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="lightened">
+			<return type="Color">
+			</return>
+			<argument index="0" name="amount" type="float">
+			</argument>
+			<description>
+				Returns a new color resulting from making this color lighter by the specified percentage (0-1).
+				[codeblock]
+				var green = Color(0.0, 1.0, 0.0)
+				var lightgreen = green.lightened(0.2) # 20% lighter than regular green
+				[/codeblock]
+			</description>
+		</method>
+		<method name="darkened">
+			<return type="Color">
+			</return>
+			<argument index="0" name="amount" type="float">
+			</argument>
+			<description>
+				Returns a new color resulting from making this color darker by the specified percentage (0-1).
+				[codeblock]
+				var green = Color(0.0, 1.0, 0.0)
+				var darkgreen = green.darkened(0.2) # 20% darker than regular green
+				[/codeblock]
+			</description>
+		</method>
 		<method name="linear_interpolate">
 			<return type="Color">
 			</return>


### PR DESCRIPTION
Now you can do this:

```
self.modulate = self.modulate.darkened(delta * 0.5) # 0.1 = 10%
```
or
```
self.modulate = self.modulate.lightened(delta * 0.5)
```

It favors performance over accuracy.

Original PR is https://github.com/godotengine/godot/pull/12063 but I forgot a flag when I was rebasing it, then didn't realize it would disconnect the PR if I deleted and re-created it, sorry :(

[darkened-test.zip](https://github.com/godotengine/godot/files/1409799/darkened-test.zip)

