### PR TITLE
Small fix in core/set.h and similar fix in core/map.h

### DIFF
--- a/core/map.h
+++ b/core/map.h
@@ -438,7 +438,6 @@ private:
 
 		Element *rp = ((p_node->left == _data._nil) || (p_node->right == _data._nil)) ? p_node : p_node->_next;
 		Element *node = (rp->left == _data._nil) ? rp->right : rp->left;
-		node->parent = rp->parent;
 
 		Element *sibling;
 		if (rp == rp->parent->left) {

--- a/core/set.h
+++ b/core/set.h
@@ -424,7 +424,6 @@ private:
 
 		Element *rp = ((p_node->left == _data._nil) || (p_node->right == _data._nil)) ? p_node : p_node->_next;
 		Element *node = (rp->left == _data._nil) ? rp->right : rp->left;
-		node->parent = rp->parent;
 
 		Element *sibling;
 		if (rp == rp->parent->left) {


### PR DESCRIPTION
Just a small fix from one of my previous commits.

Details:
The node parent shouldn't be set here, just in case node is nil.
It is set correctly later on in the `if (node->color == RED)` if block.
So this line shouldn't have made the original commit.