### PR TITLE
Add Colemak keybindings to editor for osx

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -413,6 +413,7 @@ String _OS::get_latin_keyboard_variant() const {
 		case OS::LATIN_KEYBOARD_QZERTY: return "QZERTY";
 		case OS::LATIN_KEYBOARD_DVORAK: return "DVORAK";
 		case OS::LATIN_KEYBOARD_NEO: return "NEO";
+		case OS::LATIN_KEYBOARD_COLEMAK: return "COLEMAK";
 		default: return "ERROR";
 	}
 }

--- a/core/os/keyboard.cpp
+++ b/core/os/keyboard.cpp
@@ -505,6 +505,27 @@ static const _KeyCodeReplace _keycode_replace_neo[] = {
 	{ 0, 0 }
 };
 
+static const _KeyCodeReplace _keycode_replace_colemak[] = {
+	{ KEY_E, KEY_F },
+	{ KEY_R, KEY_P },
+	{ KEY_T, KEY_G },
+	{ KEY_Y, KEY_J },
+	{ KEY_U, KEY_L },
+	{ KEY_I, KEY_U },
+	{ KEY_O, KEY_Y },
+	{ KEY_P, KEY_SEMICOLON },
+	{ KEY_S, KEY_R },
+	{ KEY_D, KEY_S },
+	{ KEY_F, KEY_T },
+	{ KEY_G, KEY_D },
+	{ KEY_J, KEY_N },
+	{ KEY_K, KEY_E },
+	{ KEY_L, KEY_I },
+	{ KEY_SEMICOLON, KEY_O },
+	{ KEY_N, KEY_K },
+	{ 0, 0 }
+};
+
 int keycode_get_count() {
 
 	const _KeyCodeText *kct = &_keycodes[0];
@@ -537,6 +558,7 @@ int latin_keyboard_keycode_convert(int p_keycode) {
 		case OS::LATIN_KEYBOARD_QZERTY: kcr = _keycode_replace_qzerty; break;
 		case OS::LATIN_KEYBOARD_DVORAK: kcr = _keycode_replace_dvorak; break;
 		case OS::LATIN_KEYBOARD_NEO: kcr = _keycode_replace_neo; break;
+		case OS::LATIN_KEYBOARD_COLEMAK: kcr = _keycode_replace_colemak; break;
 		default: return p_keycode;
 	}
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -409,6 +409,7 @@ public:
 		LATIN_KEYBOARD_QZERTY,
 		LATIN_KEYBOARD_DVORAK,
 		LATIN_KEYBOARD_NEO,
+		LATIN_KEYBOARD_COLEMAK,
 	};
 
 	virtual LatinKeyboardVariant get_latin_keyboard_variant() const;

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -196,7 +196,7 @@
 			</return>
 			<description>
 				Returns the current latin keyboard variant as a String.
-				Possible return values are: "QWERTY", "AZERTY", "QZERTY", "DVORAK", "NEO" or "ERROR"
+				Possible return values are: "QWERTY", "AZERTY", "QZERTY", "DVORAK", "NEO", "COLEMAK" or "ERROR"
 			</description>
 		</method>
 		<method name="get_locale" qualifiers="const">

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1832,6 +1832,8 @@ OS::LatinKeyboardVariant OS_OSX::get_latin_keyboard_variant() const {
 			layout = LATIN_KEYBOARD_DVORAK;
 		} else if ([test isEqualToString:@"xvlcwk"]) {
 			layout = LATIN_KEYBOARD_NEO;
+		} else if ([test isEqualToString:@"qwfpgj"]) {
+			layout = LATIN_KEYBOARD_COLEMAK;
 		}
 
 		[test release];


### PR DESCRIPTION
*Bugsquad edit*: fixes #12379

This adds Colemak to the engine, although it only does so for Macs.  I'm unable to figure out the hex value for colemak on windows, and couldn't find where this might need to go for linux (I used `ag -r "DVORAK"` to search), but its a simple fix after this PR if somebody wants it fixed!

Addresses: #12379 