### PR TITLE
Fix margin with tree drawing

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1126,7 +1126,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 
 			if (p_item->cells[i].selected && select_mode != SELECT_ROW) {
 
-				Rect2i r(item_rect.position, item_rect.size);
+				Rect2i r(cell_rect.position, cell_rect.size);
 				if (p_item->cells[i].text.size() > 0) {
 					float icon_width = p_item->cells[i].get_icon_size().width;
 					r.position.x += icon_width;


### PR DESCRIPTION
One problem with the commit is that the margin value is not a constant. I just hard coded in -6 so would like feedback about it. Should it be a constant in the function or a value that could be changed for the class? If anyone is wondering about -6 I just thought it looked best and did not seem to cause any other issue.

Signed-off-by: Jakob Sinclair <sinclair.jakob@mailbox.org>

Edit from groud: Removed the "Fixes ..." to avoid automatic closing