### PR TITLE
Use node name as default filename when attaching script.

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -319,11 +319,13 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				editor->push_item(existing.ptr());
 			else {
 				String path = selected->get_filename();
-				if (path == "")
-				{
+				if (path == "") {
 					String root_path = editor_data->get_edited_scene_root()->get_filename();
-					if (root_path == "") path = "res://" + selected->get_name();
-					else path = root_path.get_base_dir() + "/" + selected->get_name();
+					if (root_path == "") {
+						path = "res://" + selected->get_name();
+					} else {
+						path = root_path.get_base_dir() + "/" + selected->get_name();
+					}
 				}
 				script_create_dialog->config(selected->get_class(), path);
 				script_create_dialog->popup_centered();

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -319,6 +319,12 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				editor->push_item(existing.ptr());
 			else {
 				String path = selected->get_filename();
+				if (path == "")
+				{
+					String root_path = editor_data->get_edited_scene_root()->get_filename();
+					if (root_path == "") path = "res://" + selected->get_name();
+					else path = root_path.get_base_dir() + "/" + selected->get_name();
+				}
 				script_create_dialog->config(selected->get_class(), path);
 				script_create_dialog->popup_centered();
 			}


### PR DESCRIPTION
When attaching a script to a node that isn't saved to a scene file (as scene root), use its name as default filename. If the edited scene's root node *has* been saved to a file, use that directory.