### PR TITLE
Add a function to get the full name of a locale

### DIFF
--- a/core/translation.cpp
+++ b/core/translation.cpp
@@ -957,6 +957,12 @@ String TranslationServer::get_locale() const {
 	return locale;
 }
 
+String TranslationServer::get_locale_name(const String &p_locale) const {
+
+	if (!locale_name_map.has(p_locale)) return String();
+	return locale_name_map[p_locale];
+}
+
 void TranslationServer::add_translation(const Ref<Translation> &p_translation) {
 
 	translations.insert(p_translation);
@@ -1122,6 +1128,8 @@ void TranslationServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_locale", "locale"), &TranslationServer::set_locale);
 	ClassDB::bind_method(D_METHOD("get_locale"), &TranslationServer::get_locale);
 
+	ClassDB::bind_method(D_METHOD("get_locale_name", "locale"), &TranslationServer::get_locale_name);
+
 	ClassDB::bind_method(D_METHOD("translate", "message"), &TranslationServer::translate);
 
 	ClassDB::bind_method(D_METHOD("add_translation", "translation"), &TranslationServer::add_translation);
@@ -1147,4 +1155,9 @@ TranslationServer::TranslationServer()
 	: locale("en"),
 	  enabled(true) {
 	singleton = this;
+
+	for (int i = 0; locale_list[i]; ++i) {
+
+		locale_name_map.insert(locale_list[i], locale_names[i]);
+	}
 }

--- a/core/translation.h
+++ b/core/translation.h
@@ -73,6 +73,8 @@ class TranslationServer : public Object {
 	Set<Ref<Translation> > translations;
 	Ref<Translation> tool_translation;
 
+	Map<String, String> locale_name_map;
+
 	bool enabled;
 
 	static TranslationServer *singleton;
@@ -90,6 +92,8 @@ public:
 
 	void set_locale(const String &p_locale);
 	String get_locale() const;
+
+	String get_locale_name(const String &p_locale) const;
 
 	void add_translation(const Ref<Translation> &p_translation);
 	void remove_translation(const Ref<Translation> &p_translation);


### PR DESCRIPTION
User-friendly language full names currently exist in an array `locale_names` in `translation.cpp`, but I couldn't find a straightforward way of getting one for a specific locale string.

This commit adds a function to retrieve the full name of a locale string from a Map in the TranslationServer singleton. Example: `TranslationServer.get_locale_name("en_US")` returns `"English (United States)"`.