### PR TITLE
Get all addresses when resolving hostname

### DIFF
--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -82,8 +82,7 @@ struct _IP_ResolverPrivate {
 			if (queue[i].status != IP::RESOLVER_STATUS_WAITING)
 				continue;
 			IP::get_singleton()->_resolve_hostname(queue[i].response, queue[i].hostname, queue[i].type);
-			queue[i].status = queue[i].response.empty()
-				? IP::RESOLVER_STATUS_ERROR : IP::RESOLVER_STATUS_DONE;
+			queue[i].status = queue[i].response.empty() ? IP::RESOLVER_STATUS_ERROR : IP::RESOLVER_STATUS_DONE;
 		}
 	}
 
@@ -121,7 +120,7 @@ IP_Address IP::resolve_hostname(const String &p_hostname, IP::Type p_type) {
 		_resolve_hostname(res, p_hostname, p_type);
 		resolver->cache[key] = res;
 	}
-	resolver->mutex->unlock();		
+	resolver->mutex->unlock();
 
 	for (int i = 0; i < res.size(); ++i) {
 		if (res[i].is_valid()) {
@@ -140,7 +139,7 @@ Array IP::resolve_hostname_addresses(const String &p_hostname, Type p_type) {
 		_resolve_hostname(resolver->cache[key], p_hostname, p_type);
 	}
 
-	List<IP_Address> res = resolver->cache[key];	
+	List<IP_Address> res = resolver->cache[key];
 	resolver->mutex->unlock();
 
 	Array result;

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -235,6 +235,7 @@ Array IP::_get_local_addresses() const {
 void IP::_bind_methods() {
 
 	ObjectTypeDB::bind_method(_MD("resolve_hostname", "host", "ip_type"), &IP::resolve_hostname, DEFVAL(IP::TYPE_ANY));
+	ObjectTypeDB::bind_method(_MD("resolve_hostname_addresses", "host", "ip_type"), &IP::resolve_hostname_addresses);
 	ObjectTypeDB::bind_method(_MD("resolve_hostname_queue_item", "host", "ip_type"), &IP::resolve_hostname_queue_item, DEFVAL(IP::TYPE_ANY));
 	ObjectTypeDB::bind_method(_MD("get_resolve_item_status", "id"), &IP::get_resolve_item_status);
 	ObjectTypeDB::bind_method(_MD("get_resolve_item_address", "id"), &IP::get_resolve_item_address);

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -101,7 +101,7 @@ struct _IP_ResolverPrivate {
 		}
 	}
 
-	HashMap<String, List<IP_Address>> cache;
+	HashMap<String, List<IP_Address> > cache;
 
 	static String get_cache_key(String p_hostname, IP::Type p_type) {
 		return itos(p_type) + p_hostname;

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -47,7 +47,7 @@ struct _IP_ResolverPrivate {
 
 		void clear() {
 			status = IP::RESOLVER_STATUS_NONE;
-			response = List<IP_Address>();
+			response.clear();
 			type = IP::TYPE_NONE;
 			hostname = "";
 		};
@@ -81,7 +81,7 @@ struct _IP_ResolverPrivate {
 
 			if (queue[i].status != IP::RESOLVER_STATUS_WAITING)
 				continue;
-			queue[i].response = IP::get_singleton()->_resolve_hostname(queue[i].hostname, queue[i].type);
+			IP::get_singleton()->_resolve_hostname(queue[i].response, queue[i].hostname, queue[i].type);
 			queue[i].status = queue[i].response.empty()
 				? IP::RESOLVER_STATUS_ERROR : IP::RESOLVER_STATUS_DONE;
 		}
@@ -118,7 +118,7 @@ IP_Address IP::resolve_hostname(const String &p_hostname, IP::Type p_type) {
 	if (resolver->cache.has(key)) {
 		res = resolver->cache[key];
 	} else {
-		res = _resolve_hostname(p_hostname, p_type);
+		_resolve_hostname(res, p_hostname, p_type);
 		resolver->cache[key] = res;
 	}
 	resolver->mutex->unlock();		
@@ -137,7 +137,7 @@ Array IP::resolve_hostname_addresses(const String &p_hostname, Type p_type) {
 
 	String key = _IP_ResolverPrivate::get_cache_key(p_hostname, p_type);
 	if (!resolver->cache.has(key)) {
-		resolver->cache[key] = _resolve_hostname(p_hostname, p_type);
+		_resolve_hostname(resolver->cache[key], p_hostname, p_type);
 	}
 
 	List<IP_Address> res = resolver->cache[key];	

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -223,7 +223,7 @@ IP_Address IP::get_resolve_item_address(ResolverID p_id) const {
 	return IP_Address();
 }
 
-Array IP::get_resolve_addresses(ResolverID p_id) const {
+Array IP::get_resolve_item_addresses(ResolverID p_id) const {
 
 	ERR_FAIL_INDEX_V(p_id, IP::RESOLVER_MAX_QUERIES, Array());
 
@@ -294,7 +294,7 @@ void IP::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("resolve_hostname_queue_item", "host", "ip_type"), &IP::resolve_hostname_queue_item, DEFVAL(IP::TYPE_ANY));
 	ObjectTypeDB::bind_method(_MD("get_resolve_item_status", "id"), &IP::get_resolve_item_status);
 	ObjectTypeDB::bind_method(_MD("get_resolve_item_address", "id"), &IP::get_resolve_item_address);
-	ObjectTypeDB::bind_method(_MD("get_resolve_addresses", "id"), &IP::get_resolve_addresses);
+	ObjectTypeDB::bind_method(_MD("get_resolve_item_addresses", "id"), &IP::get_resolve_item_addresses);
 	ObjectTypeDB::bind_method(_MD("erase_resolve_item", "id"), &IP::erase_resolve_item);
 	ObjectTypeDB::bind_method(_MD("get_local_addresses"), &IP::_get_local_addresses);
 	ObjectTypeDB::bind_method(_MD("clear_cache"), &IP::clear_cache, DEFVAL(""));

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -41,13 +41,13 @@ struct _IP_ResolverPrivate {
 	struct QueueItem {
 
 		volatile IP::ResolverStatus status;
-		IP_Address response;
+		List<IP_Address> response;
 		String hostname;
 		IP::Type type;
 
 		void clear() {
 			status = IP::RESOLVER_STATUS_NONE;
-			response = IP_Address();
+			response = List<IP_Address>();
 			type = IP::TYPE_NONE;
 			hostname = "";
 		};
@@ -81,12 +81,9 @@ struct _IP_ResolverPrivate {
 
 			if (queue[i].status != IP::RESOLVER_STATUS_WAITING)
 				continue;
-			queue[i].response = IP::get_singleton()->resolve_hostname(queue[i].hostname, queue[i].type);
-
-			if (!queue[i].response.is_valid())
-				queue[i].status = IP::RESOLVER_STATUS_ERROR;
-			else
-				queue[i].status = IP::RESOLVER_STATUS_DONE;
+			queue[i].response = IP::get_singleton()->_resolve_hostname(queue[i].hostname, queue[i].type);
+			queue[i].status = queue[i].response.empty()
+				? IP::RESOLVER_STATUS_ERROR : IP::RESOLVER_STATUS_DONE;
 		}
 	}
 
@@ -104,7 +101,7 @@ struct _IP_ResolverPrivate {
 		}
 	}
 
-	HashMap<String, IP_Address> cache;
+	HashMap<String, List<IP_Address>> cache;
 
 	static String get_cache_key(String p_hostname, IP::Type p_type) {
 		return itos(p_type) + p_hostname;
@@ -115,17 +112,44 @@ IP_Address IP::resolve_hostname(const String &p_hostname, IP::Type p_type) {
 
 	resolver->mutex->lock();
 
+	List<IP_Address> res;
+
 	String key = _IP_ResolverPrivate::get_cache_key(p_hostname, p_type);
 	if (resolver->cache.has(key)) {
-		IP_Address res = resolver->cache[key];
-		resolver->mutex->unlock();
-		return res;
+		res = resolver->cache[key];
+	} else {
+		res = _resolve_hostname(p_hostname, p_type);
+		resolver->cache[key] = res;
+	}
+	resolver->mutex->unlock();		
+
+	for (int i = 0; i < res.size(); ++i) {
+		if (res[i].is_valid()) {
+			return res[i];
+		}
+	}
+	return IP_Address();
+}
+
+Array IP::resolve_hostname_addresses(const String &p_hostname, Type p_type) {
+
+	resolver->mutex->lock();
+
+	String key = _IP_ResolverPrivate::get_cache_key(p_hostname, p_type);
+	if (!resolver->cache.has(key)) {
+		resolver->cache[key] = _resolve_hostname(p_hostname, p_type);
 	}
 
-	IP_Address res = _resolve_hostname(p_hostname, p_type);
-	resolver->cache[key] = res;
+	List<IP_Address> res = resolver->cache[key];	
 	resolver->mutex->unlock();
-	return res;
+
+	Array result;
+	for (int i = 0; i < res.size(); ++i) {
+		if (res[i].is_valid()) {
+			result.push_back(String(res[i]));
+		}
+	}
+	return result;
 }
 
 IP::ResolverID IP::resolve_hostname_queue_item(const String &p_hostname, IP::Type p_type) {
@@ -147,7 +171,7 @@ IP::ResolverID IP::resolve_hostname_queue_item(const String &p_hostname, IP::Typ
 		resolver->queue[id].response = resolver->cache[key];
 		resolver->queue[id].status = IP::RESOLVER_STATUS_DONE;
 	} else {
-		resolver->queue[id].response = IP_Address();
+		resolver->queue[id].response = List<IP_Address>();
 		resolver->queue[id].status = IP::RESOLVER_STATUS_WAITING;
 		if (resolver->thread)
 			resolver->sem->post();
@@ -187,10 +211,41 @@ IP_Address IP::get_resolve_item_address(ResolverID p_id) const {
 		return IP_Address();
 	}
 
-	IP_Address res = resolver->queue[p_id].response;
+	List<IP_Address> res = resolver->queue[p_id].response;
 
 	resolver->mutex->unlock();
-	return res;
+
+	for (int i = 0; i < res.size(); ++i) {
+		if (res[i].is_valid()) {
+			return res[i];
+		}
+	}
+	return IP_Address();
+}
+
+Array IP::get_resolve_addresses(ResolverID p_id) const {
+
+	ERR_FAIL_INDEX_V(p_id, IP::RESOLVER_MAX_QUERIES, Array());
+
+	resolver->mutex->lock();
+
+	if (resolver->queue[p_id].status != IP::RESOLVER_STATUS_DONE) {
+		ERR_PRINTS("Resolve of '" + resolver->queue[p_id].hostname + "'' didn't complete yet.");
+		resolver->mutex->unlock();
+		return Array();
+	}
+
+	List<IP_Address> res = resolver->queue[p_id].response;
+
+	resolver->mutex->unlock();
+
+	Array result;
+	for (int i = 0; i < res.size(); ++i) {
+		if (res[i].is_valid()) {
+			result.push_back(String(res[i]));
+		}
+	}
+	return result;
 }
 
 void IP::erase_resolve_item(ResolverID p_id) {
@@ -239,6 +294,7 @@ void IP::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("resolve_hostname_queue_item", "host", "ip_type"), &IP::resolve_hostname_queue_item, DEFVAL(IP::TYPE_ANY));
 	ObjectTypeDB::bind_method(_MD("get_resolve_item_status", "id"), &IP::get_resolve_item_status);
 	ObjectTypeDB::bind_method(_MD("get_resolve_item_address", "id"), &IP::get_resolve_item_address);
+	ObjectTypeDB::bind_method(_MD("get_resolve_addresses", "id"), &IP::get_resolve_addresses);
 	ObjectTypeDB::bind_method(_MD("erase_resolve_item", "id"), &IP::erase_resolve_item);
 	ObjectTypeDB::bind_method(_MD("get_local_addresses"), &IP::_get_local_addresses);
 	ObjectTypeDB::bind_method(_MD("clear_cache"), &IP::clear_cache, DEFVAL(""));

--- a/core/io/ip.h
+++ b/core/io/ip.h
@@ -77,6 +77,7 @@ protected:
 
 public:
 	IP_Address resolve_hostname(const String &p_hostname, Type p_type = TYPE_ANY);
+	virtual Array resolve_hostname_addresses(const String &p_hostname, Type p_type = TYPE_ANY) const = 0;
 	// async resolver hostname
 	ResolverID resolve_hostname_queue_item(const String &p_hostname, Type p_type = TYPE_ANY);
 	ResolverStatus get_resolve_item_status(ResolverID p_id) const;

--- a/core/io/ip.h
+++ b/core/io/ip.h
@@ -82,7 +82,7 @@ public:
 	ResolverStatus get_resolve_item_status(ResolverID p_id) const;
 	IP_Address get_resolve_item_address(ResolverID p_id) const;
 	Array get_resolve_addresses(ResolverID p_id) const;
-	virtual List<IP_Address> _resolve_hostname(const String &p_hostname, Type p_type = TYPE_ANY) const = 0;
+	virtual void _resolve_hostname(List<IP_Address> & r_addresses, const String &p_hostname, Type p_type = TYPE_ANY) const = 0;
 	virtual void get_local_addresses(List<IP_Address> *r_addresses) const = 0;
 	void erase_resolve_item(ResolverID p_id);
 

--- a/core/io/ip.h
+++ b/core/io/ip.h
@@ -71,9 +71,9 @@ protected:
 	static void _bind_methods();
 
 	Array _get_local_addresses() const;
-	
+
 	static IP *(*_create)();
-	
+
 public:
 	IP_Address resolve_hostname(const String &p_hostname, Type p_type = TYPE_ANY);
 	Array resolve_hostname_addresses(const String &p_hostname, Type p_type = TYPE_ANY);

--- a/core/io/ip.h
+++ b/core/io/ip.h
@@ -82,7 +82,7 @@ public:
 	ResolverStatus get_resolve_item_status(ResolverID p_id) const;
 	IP_Address get_resolve_item_address(ResolverID p_id) const;
 	Array get_resolve_item_addresses(ResolverID p_id) const;
-	virtual void _resolve_hostname(List<IP_Address> & r_addresses, const String &p_hostname, Type p_type = TYPE_ANY) const = 0;
+	virtual void _resolve_hostname(List<IP_Address> &r_addresses, const String &p_hostname, Type p_type = TYPE_ANY) const = 0;
 	virtual void get_local_addresses(List<IP_Address> *r_addresses) const = 0;
 	void erase_resolve_item(ResolverID p_id);
 

--- a/core/io/ip.h
+++ b/core/io/ip.h
@@ -70,18 +70,19 @@ protected:
 	static IP *singleton;
 	static void _bind_methods();
 
-	virtual IP_Address _resolve_hostname(const String &p_hostname, Type p_type = TYPE_ANY) = 0;
 	Array _get_local_addresses() const;
-
+	
 	static IP *(*_create)();
-
+	
 public:
 	IP_Address resolve_hostname(const String &p_hostname, Type p_type = TYPE_ANY);
-	virtual Array resolve_hostname_addresses(const String &p_hostname, Type p_type = TYPE_ANY) const = 0;
+	Array resolve_hostname_addresses(const String &p_hostname, Type p_type = TYPE_ANY);
 	// async resolver hostname
 	ResolverID resolve_hostname_queue_item(const String &p_hostname, Type p_type = TYPE_ANY);
 	ResolverStatus get_resolve_item_status(ResolverID p_id) const;
 	IP_Address get_resolve_item_address(ResolverID p_id) const;
+	Array get_resolve_addresses(ResolverID p_id) const;
+	virtual List<IP_Address> _resolve_hostname(const String &p_hostname, Type p_type = TYPE_ANY) const = 0;
 	virtual void get_local_addresses(List<IP_Address> *r_addresses) const = 0;
 	void erase_resolve_item(ResolverID p_id);
 

--- a/core/io/ip.h
+++ b/core/io/ip.h
@@ -81,7 +81,7 @@ public:
 	ResolverID resolve_hostname_queue_item(const String &p_hostname, Type p_type = TYPE_ANY);
 	ResolverStatus get_resolve_item_status(ResolverID p_id) const;
 	IP_Address get_resolve_item_address(ResolverID p_id) const;
-	Array get_resolve_addresses(ResolverID p_id) const;
+	Array get_resolve_item_addresses(ResolverID p_id) const;
 	virtual void _resolve_hostname(List<IP_Address> & r_addresses, const String &p_hostname, Type p_type = TYPE_ANY) const = 0;
 	virtual void get_local_addresses(List<IP_Address> *r_addresses) const = 0;
 	void erase_resolve_item(ResolverID p_id);

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -15782,7 +15782,7 @@
 				Return a resolved item address, or an empty string if an error happened or resolution didn't happen yet (see [method get_resolve_item_status]).
 			</description>
 		</method>
-		<method name="get_resolve_addresses" qualifiers="const">
+		<method name="get_resolve_item_addresses" qualifiers="const">
 			<return type="Array">
 			</return>
 			<argument index="0" name="id" type="int">

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -15782,6 +15782,15 @@
 				Return a resolved item address, or an empty string if an error happened or resolution didn't happen yet (see [method get_resolve_item_status]).
 			</description>
 		</method>
+		<method name="get_resolve_addresses" qualifiers="const">
+			<return type="Array">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<description>
+				Return resolved addresses, or an empty array if an error happened or resolution didn't happen yet (see [method get_resolve_item_status]).
+			</description>
+		</method>
 		<method name="get_resolve_item_status" qualifiers="const">
 			<return type="int">
 			</return>
@@ -15800,6 +15809,17 @@
 			</argument>
 			<description>
 				Resolve a given hostname, blocking. Resolved hostname is returned as an IPv4 or IPv6 depending on "ip_type".
+			</description>
+		</method>
+		<method name="resolve_hostname_addresses">
+			<return type="Array">
+			</return>
+			<argument index="0" name="host" type="String">
+			</argument>
+			<argument index="1" name="ip_type" type="int" default="3">
+			</argument>
+			<description>
+				Resolve a given hostname, blocking. Resolved addresses is returned as an IPv4 or IPv6 depending on "ip_type".
 			</description>
 		</method>
 		<method name="resolve_hostname_queue_item">

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -15819,7 +15819,7 @@
 			<argument index="1" name="ip_type" type="int" default="3">
 			</argument>
 			<description>
-				Resolve a given hostname, blocking. Resolved addresses is returned as an IPv4 or IPv6 depending on "ip_type".
+				Resolve a given hostname, blocking. Addresses are returned as an Array of IPv4 or IPv6 depending on "ip_type".
 			</description>
 		</method>
 		<method name="resolve_hostname_queue_item">

--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -116,7 +116,13 @@ void IP_Unix::_resolve_hostname(List<IP_Address> & r_addresses, const String &p_
 	struct addrinfo *next = result;
 
 	do {
-		r_addresses.push_back(_sockaddr2ip(next->ai_addr));
+		if (next->ai_addr == NULL) {
+			next = next->ai_next;
+			continue;
+		}
+		IP_Address ip = _sockaddr2ip(next->ai_addr);
+		if (!r_addresses.find(ip))
+			r_addresses.push_back(ip);
 		next = next->ai_next;
 	} while (next);
 

--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -120,6 +120,52 @@ IP_Address IP_Unix::_resolve_hostname(const String &p_hostname, Type p_type) {
 	return ip;
 }
 
+Array IP_Unix::resolve_hostname_addresses(const String &p_hostname, Type p_type) const {
+
+	struct addrinfo hints;
+	struct addrinfo *result;
+
+	memset(&hints, 0, sizeof(struct addrinfo));
+	if (p_type == TYPE_IPV4) {
+		hints.ai_family = AF_INET;
+	} else if (p_type == TYPE_IPV6) {
+		hints.ai_family = AF_INET6;
+		hints.ai_flags = 0;
+	} else {
+		hints.ai_family = AF_UNSPEC;
+		hints.ai_flags = AI_ADDRCONFIG;
+	};
+	hints.ai_flags &= !AI_NUMERICHOST;
+
+	int s = getaddrinfo(p_hostname.utf8().get_data(), NULL, &hints, &result);
+	if (s != 0) {
+		ERR_PRINT("getaddrinfo failed!");
+		return Array();
+	};
+
+	if (result == NULL || result->ai_addr == NULL) {
+		ERR_PRINT("Invalid response from getaddrinfo");
+		return Array();
+	};
+
+	struct addrinfo *next = result;
+
+	Array addresses;
+	IP_Address ip;
+
+	do {
+		ip = _sockaddr2ip(next->ai_addr);
+		if (ip.is_valid()) {
+			addresses.push_back(ip);
+		}
+		next = next->ai_next;
+	} while (next);
+
+	freeaddrinfo(result);
+
+	return addresses;
+}
+
 #if defined(WINDOWS_ENABLED)
 
 #if defined(WINRT_ENABLED)

--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -85,7 +85,7 @@ static IP_Address _sockaddr2ip(struct sockaddr *p_addr) {
 	return ip;
 };
 
-void IP_Unix::_resolve_hostname(List<IP_Address> & r_addresses, const String &p_hostname, Type p_type) const {
+void IP_Unix::_resolve_hostname(List<IP_Address> &r_addresses, const String &p_hostname, Type p_type) const {
 
 	struct addrinfo hints;
 	struct addrinfo *result;
@@ -105,12 +105,12 @@ void IP_Unix::_resolve_hostname(List<IP_Address> & r_addresses, const String &p_
 	int s = getaddrinfo(p_hostname.utf8().get_data(), NULL, &hints, &result);
 	if (s != 0) {
 		ERR_PRINT("getaddrinfo failed!");
-		return ;
+		return;
 	};
 
 	if (result == NULL || result->ai_addr == NULL) {
 		ERR_PRINT("Invalid response from getaddrinfo");
-		return ;
+		return;
 	};
 
 	struct addrinfo *next = result;

--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -85,7 +85,7 @@ static IP_Address _sockaddr2ip(struct sockaddr *p_addr) {
 	return ip;
 };
 
-List<IP_Address> IP_Unix::_resolve_hostname(const String &p_hostname, Type p_type) const {
+void IP_Unix::_resolve_hostname(List<IP_Address> & r_addresses, const String &p_hostname, Type p_type) const {
 
 	struct addrinfo hints;
 	struct addrinfo *result;
@@ -105,26 +105,22 @@ List<IP_Address> IP_Unix::_resolve_hostname(const String &p_hostname, Type p_typ
 	int s = getaddrinfo(p_hostname.utf8().get_data(), NULL, &hints, &result);
 	if (s != 0) {
 		ERR_PRINT("getaddrinfo failed!");
-		return List<IP_Address>();
+		return ;
 	};
 
 	if (result == NULL || result->ai_addr == NULL) {
 		ERR_PRINT("Invalid response from getaddrinfo");
-		return List<IP_Address>();
+		return ;
 	};
 
 	struct addrinfo *next = result;
 
-	List<IP_Address> addresses;
-
 	do {
-		addresses.push_back(_sockaddr2ip(next->ai_addr));
+		r_addresses.push_back(_sockaddr2ip(next->ai_addr));
 		next = next->ai_next;
 	} while (next);
 
 	freeaddrinfo(result);
-
-	return addresses;
 }
 
 #if defined(WINDOWS_ENABLED)

--- a/drivers/unix/ip_unix.h
+++ b/drivers/unix/ip_unix.h
@@ -40,7 +40,7 @@ class IP_Unix : public IP {
 	static IP *_create_unix();
 	
 public:
-	virtual List<IP_Address> _resolve_hostname(const String &p_hostname, Type p_type = TYPE_ANY) const;
+	virtual void _resolve_hostname(List<IP_Address> & r_addresses, const String &p_hostname, Type p_type = TYPE_ANY) const;
 	virtual void get_local_addresses(List<IP_Address> *r_addresses) const;
 
 	static void make_default();

--- a/drivers/unix/ip_unix.h
+++ b/drivers/unix/ip_unix.h
@@ -40,7 +40,7 @@ class IP_Unix : public IP {
 	static IP *_create_unix();
 
 public:
-	virtual void _resolve_hostname(List<IP_Address> & r_addresses, const String &p_hostname, Type p_type = TYPE_ANY) const;
+	virtual void _resolve_hostname(List<IP_Address> &r_addresses, const String &p_hostname, Type p_type = TYPE_ANY) const;
 	virtual void get_local_addresses(List<IP_Address> *r_addresses) const;
 
 	static void make_default();

--- a/drivers/unix/ip_unix.h
+++ b/drivers/unix/ip_unix.h
@@ -43,6 +43,7 @@ class IP_Unix : public IP {
 
 public:
 	virtual void get_local_addresses(List<IP_Address> *r_addresses) const;
+	virtual Array resolve_hostname_addresses(const String &p_hostname, Type p_type = TYPE_ANY) const;
 
 	static void make_default();
 	IP_Unix();

--- a/drivers/unix/ip_unix.h
+++ b/drivers/unix/ip_unix.h
@@ -38,7 +38,7 @@ class IP_Unix : public IP {
 	OBJ_TYPE(IP_Unix, IP);
 
 	static IP *_create_unix();
-	
+
 public:
 	virtual void _resolve_hostname(List<IP_Address> & r_addresses, const String &p_hostname, Type p_type = TYPE_ANY) const;
 	virtual void get_local_addresses(List<IP_Address> *r_addresses) const;

--- a/drivers/unix/ip_unix.h
+++ b/drivers/unix/ip_unix.h
@@ -37,13 +37,11 @@
 class IP_Unix : public IP {
 	OBJ_TYPE(IP_Unix, IP);
 
-	virtual IP_Address _resolve_hostname(const String &p_hostname, IP::Type p_type);
-
 	static IP *_create_unix();
-
+	
 public:
+	virtual List<IP_Address> _resolve_hostname(const String &p_hostname, Type p_type = TYPE_ANY) const;
 	virtual void get_local_addresses(List<IP_Address> *r_addresses) const;
-	virtual Array resolve_hostname_addresses(const String &p_hostname, Type p_type = TYPE_ANY) const;
 
 	static void make_default();
 	IP_Unix();


### PR DESCRIPTION
For a test I had to resolve a hostname and randomly pick one address but IP::resolve_hostname only returns the first address.
I've seen something were done for issue #414 but it seems like the code wasn't merged.
So I've implement two new methods :
`Array IP::resolve_hostname_addresses(const String &p_hostname, Type p_type)`
`Array IP::get_resolve_addresses(ResolverID p_id) const`

Any comments are welcome.