### PR TITLE
Physics material

### DIFF
--- a/modules/bullet/bullet_physics_server.cpp
+++ b/modules/bullet/bullet_physics_server.cpp
@@ -643,6 +643,20 @@ float BulletPhysicsServer::body_get_param(RID p_body, BodyParameter p_param) con
 	return body->get_param(p_param);
 }
 
+void BulletPhysicsServer::body_set_combine_mode(RID p_body, BodyParameter p_param, CombineMode p_mode) {
+	RigidBodyBullet *body = rigid_body_owner.get(p_body);
+	ERR_FAIL_COND(!body);
+
+	body->set_combine_mode(p_param, p_mode);
+}
+
+PhysicsServer::CombineMode BulletPhysicsServer::body_get_combine_mode(RID p_body, BodyParameter p_param) const {
+	RigidBodyBullet *body = rigid_body_owner.get(p_body);
+	ERR_FAIL_COND_V(!body, COMBINE_MODE_INHERIT);
+
+	return body->get_combine_mode(p_param);
+}
+
 void BulletPhysicsServer::body_set_kinematic_safe_margin(RID p_body, real_t p_margin) {
 	RigidBodyBullet *body = rigid_body_owner.get(p_body);
 	ERR_FAIL_COND(!body);

--- a/modules/bullet/bullet_physics_server.h
+++ b/modules/bullet/bullet_physics_server.h
@@ -213,6 +213,9 @@ public:
 	virtual void body_set_param(RID p_body, BodyParameter p_param, float p_value);
 	virtual float body_get_param(RID p_body, BodyParameter p_param) const;
 
+	virtual void body_set_combine_mode(RID p_body, BodyParameter p_param, CombineMode p_mode);
+	virtual CombineMode body_get_combine_mode(RID p_body, BodyParameter p_param) const;
+
 	virtual void body_set_kinematic_safe_margin(RID p_body, real_t p_margin);
 	virtual real_t body_get_kinematic_safe_margin(RID p_body) const;
 

--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -256,6 +256,8 @@ RigidBodyBullet::RigidBodyBullet() :
 		angularDamp(0),
 		can_sleep(true),
 		omit_forces_integration(false),
+		restitution_combine_mode(PhysicsServer::COMBINE_MODE_INHERIT),
+		friction_combine_mode(PhysicsServer::COMBINE_MODE_INHERIT),
 		force_integration_callback(NULL),
 		isTransformChanged(false),
 		previousActiveState(true),
@@ -747,6 +749,22 @@ Vector3 RigidBodyBullet::get_angular_velocity() const {
 	Vector3 gVec;
 	B_TO_G(btBody->getAngularVelocity(), gVec);
 	return gVec;
+}
+
+void RigidBodyBullet::set_combine_mode(const PhysicsServer::BodyParameter p_param, const PhysicsServer::CombineMode p_mode) {
+	if (p_param == PhysicsServer::BODY_PARAM_BOUNCE) {
+		restitution_combine_mode = p_mode;
+	} else {
+		friction_combine_mode = p_mode;
+	}
+}
+
+PhysicsServer::CombineMode RigidBodyBullet::get_combine_mode(PhysicsServer::BodyParameter p_param) const {
+	if (p_param == PhysicsServer::BODY_PARAM_BOUNCE) {
+		return restitution_combine_mode;
+	} else {
+		return friction_combine_mode;
+	}
 }
 
 void RigidBodyBullet::set_transform__bullet(const btTransform &p_global_transform) {

--- a/modules/bullet/rigid_body_bullet.h
+++ b/modules/bullet/rigid_body_bullet.h
@@ -200,6 +200,9 @@ private:
 	bool can_sleep;
 	bool omit_forces_integration;
 
+	PhysicsServer::CombineMode restitution_combine_mode;
+	PhysicsServer::CombineMode friction_combine_mode;
+
 	Vector<CollisionData> collisions;
 	// these parameters are used to avoid vector resize
 	int maxCollisionsDetection;
@@ -294,6 +297,12 @@ public:
 
 	void set_angular_velocity(const Vector3 &p_velocity);
 	Vector3 get_angular_velocity() const;
+
+	void set_combine_mode(const PhysicsServer::BodyParameter p_param, const PhysicsServer::CombineMode p_mode);
+	PhysicsServer::CombineMode get_combine_mode(PhysicsServer::BodyParameter p_param) const;
+
+	_FORCE_INLINE_ PhysicsServer::CombineMode get_restitution_combine_mode() const { return restitution_combine_mode; }
+	_FORCE_INLINE_ PhysicsServer::CombineMode get_friction_combine_mode() const { return friction_combine_mode; }
 
 	virtual void set_transform__bullet(const btTransform &p_global_transform);
 	virtual const btTransform &get_transform__bullet() const;

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -32,6 +32,7 @@
 #define PHYSICS_BODY_2D_H
 
 #include "scene/2d/collision_object_2d.h"
+#include "scene/resources/physics_material.h"
 #include "servers/physics_2d_server.h"
 #include "vset.h"
 
@@ -79,18 +80,21 @@ class StaticBody2D : public PhysicsBody2D {
 	Vector2 constant_linear_velocity;
 	real_t constant_angular_velocity;
 
-	real_t bounce;
-	real_t friction;
+	Ref<PhysicsMaterial> physics_material_override;
 
 protected:
 	static void _bind_methods();
 
 public:
+#ifndef DISABLE_DEPRECATED
 	void set_friction(real_t p_friction);
 	real_t get_friction() const;
 
 	void set_bounce(real_t p_bounce);
 	real_t get_bounce() const;
+#endif
+	void set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override);
+	Ref<PhysicsMaterial> get_physics_material_override() const;
 
 	void set_constant_linear_velocity(const Vector2 &p_vel);
 	void set_constant_angular_velocity(real_t p_vel);
@@ -100,6 +104,9 @@ public:
 
 	StaticBody2D();
 	~StaticBody2D();
+
+private:
+	void _reload_physics_characteristics();
 };
 
 class RigidBody2D : public PhysicsBody2D {
@@ -125,9 +132,8 @@ private:
 	Physics2DDirectBodyState *state;
 	Mode mode;
 
-	real_t bounce;
 	real_t mass;
-	real_t friction;
+	Ref<PhysicsMaterial> physics_material_override;
 	real_t gravity_scale;
 	real_t linear_damp;
 	real_t angular_damp;
@@ -204,11 +210,16 @@ public:
 	void set_weight(real_t p_weight);
 	real_t get_weight() const;
 
+#ifndef DISABLE_DEPRECATED
 	void set_friction(real_t p_friction);
 	real_t get_friction() const;
 
 	void set_bounce(real_t p_bounce);
 	real_t get_bounce() const;
+#endif
+
+	void set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override);
+	Ref<PhysicsMaterial> get_physics_material_override() const;
 
 	void set_gravity_scale(real_t p_gravity_scale);
 	real_t get_gravity_scale() const;
@@ -261,6 +272,9 @@ public:
 
 	RigidBody2D();
 	~RigidBody2D();
+
+private:
+	void _reload_physics_characteristics();
 };
 
 VARIANT_ENUM_CAST(RigidBody2D::Mode);

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -30,6 +30,7 @@
 
 #include "physics_body.h"
 
+#include "core/core_string_names.h"
 #include "engine.h"
 #include "method_bind_ext.gen.inc"
 #include "scene/scene_string_names.h"
@@ -178,28 +179,75 @@ PhysicsBody::PhysicsBody(PhysicsServer::BodyMode p_mode) :
 	collision_mask = 1;
 }
 
+#ifndef DISABLE_DEPRECATED
 void StaticBody::set_friction(real_t p_friction) {
+
+	ERR_EXPLAIN("The method set_friction has been deprecated and will be removed in the future, use physical material")
+	WARN_DEPRECATED
 
 	ERR_FAIL_COND(p_friction < 0 || p_friction > 1);
 
-	friction = p_friction;
-	PhysicsServer::get_singleton()->body_set_param(get_rid(), PhysicsServer::BODY_PARAM_FRICTION, friction);
+	if (physics_material_override.is_null()) {
+		physics_material_override.instance();
+	}
+	physics_material_override->set_friction(p_friction);
+	_reload_physics_characteristics();
 }
+
 real_t StaticBody::get_friction() const {
 
-	return friction;
+	ERR_EXPLAIN("The method get_friction has been deprecated and will be removed in the future, use physical material")
+	WARN_DEPRECATED
+
+	if (physics_material_override.is_null()) {
+		return 1;
+	}
+
+	return physics_material_override->get_friction();
 }
 
 void StaticBody::set_bounce(real_t p_bounce) {
 
+	ERR_EXPLAIN("The method set_bounce has been deprecated and will be removed in the future, use physical material")
+	WARN_DEPRECATED
+
 	ERR_FAIL_COND(p_bounce < 0 || p_bounce > 1);
 
-	bounce = p_bounce;
-	PhysicsServer::get_singleton()->body_set_param(get_rid(), PhysicsServer::BODY_PARAM_BOUNCE, bounce);
+	if (physics_material_override.is_null()) {
+		physics_material_override.instance();
+	}
+	physics_material_override->set_bounce(p_bounce);
+	_reload_physics_characteristics();
 }
+
 real_t StaticBody::get_bounce() const {
 
-	return bounce;
+	ERR_EXPLAIN("The method get_bounce has been deprecated and will be removed in the future, use physical material")
+	WARN_DEPRECATED
+
+	if (physics_material_override.is_null()) {
+		return 0;
+	}
+
+	return physics_material_override->get_bounce();
+}
+#endif
+
+void StaticBody::set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override) {
+	if (physics_material_override.is_valid()) {
+		physics_material_override->disconnect(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+	}
+
+	physics_material_override = p_physics_material_override;
+
+	if (physics_material_override.is_valid()) {
+		physics_material_override->connect(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+	}
+	_reload_physics_characteristics();
+}
+
+Ref<PhysicsMaterial> StaticBody::get_physics_material_override() const {
+	return physics_material_override;
 }
 
 void StaticBody::set_constant_linear_velocity(const Vector3 &p_vel) {
@@ -236,24 +284,39 @@ void StaticBody::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_bounce", "bounce"), &StaticBody::set_bounce);
 	ClassDB::bind_method(D_METHOD("get_bounce"), &StaticBody::get_bounce);
 
+	ClassDB::bind_method(D_METHOD("set_physics_material_override", "physics_material_override"), &StaticBody::set_physics_material_override);
+	ClassDB::bind_method(D_METHOD("get_physics_material_override"), &StaticBody::get_physics_material_override);
+
+	ClassDB::bind_method(D_METHOD("_reload_physics_characteristics"), &StaticBody::_reload_physics_characteristics);
+
 	ClassDB::bind_method(D_METHOD("add_collision_exception_with", "body"), &PhysicsBody::add_collision_exception_with);
 	ClassDB::bind_method(D_METHOD("remove_collision_exception_with", "body"), &PhysicsBody::remove_collision_exception_with);
 
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "friction", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_friction", "get_friction");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "bounce", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_bounce", "get_bounce");
-
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "physics_material_override", PROPERTY_HINT_RESOURCE_TYPE, "PhysicsMaterial"), "set_physics_material_override", "get_physics_material_override");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "constant_linear_velocity"), "set_constant_linear_velocity", "get_constant_linear_velocity");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "constant_angular_velocity"), "set_constant_angular_velocity", "get_constant_angular_velocity");
 }
 
 StaticBody::StaticBody() :
 		PhysicsBody(PhysicsServer::BODY_MODE_STATIC) {
-
-	bounce = 0;
-	friction = 1;
 }
 
-StaticBody::~StaticBody() {
+StaticBody::~StaticBody() {}
+
+void StaticBody::_reload_physics_characteristics() {
+	if (physics_material_override.is_null()) {
+		PhysicsServer::get_singleton()->body_set_param(get_rid(), PhysicsServer::BODY_PARAM_BOUNCE, 0);
+		PhysicsServer::get_singleton()->body_set_param(get_rid(), PhysicsServer::BODY_PARAM_FRICTION, 1);
+		PhysicsServer::get_singleton()->body_set_combine_mode(get_rid(), PhysicsServer::BODY_PARAM_BOUNCE, PhysicsServer::COMBINE_MODE_INHERIT);
+		PhysicsServer::get_singleton()->body_set_combine_mode(get_rid(), PhysicsServer::BODY_PARAM_FRICTION, PhysicsServer::COMBINE_MODE_INHERIT);
+	} else {
+		PhysicsServer::get_singleton()->body_set_param(get_rid(), PhysicsServer::BODY_PARAM_BOUNCE, physics_material_override->get_bounce());
+		PhysicsServer::get_singleton()->body_set_param(get_rid(), PhysicsServer::BODY_PARAM_FRICTION, physics_material_override->get_friction());
+		PhysicsServer::get_singleton()->body_set_combine_mode(get_rid(), PhysicsServer::BODY_PARAM_BOUNCE, physics_material_override->get_bounce_combine_mode());
+		PhysicsServer::get_singleton()->body_set_combine_mode(get_rid(), PhysicsServer::BODY_PARAM_FRICTION, physics_material_override->get_friction_combine_mode());
+	}
 }
 
 void RigidBody::_body_enter_tree(ObjectID p_id) {
@@ -550,28 +613,67 @@ real_t RigidBody::get_weight() const {
 	return mass * real_t(GLOBAL_DEF("physics/3d/default_gravity", 9.8));
 }
 
+#ifndef DISABLE_DEPRECATED
 void RigidBody::set_friction(real_t p_friction) {
 
+	ERR_EXPLAIN("The method set_friction has been deprecated and will be removed in the future, use physical material")
+	WARN_DEPRECATED
 	ERR_FAIL_COND(p_friction < 0 || p_friction > 1);
 
-	friction = p_friction;
-	PhysicsServer::get_singleton()->body_set_param(get_rid(), PhysicsServer::BODY_PARAM_FRICTION, friction);
+	if (physics_material_override.is_null()) {
+		physics_material_override.instance();
+	}
+	physics_material_override->set_friction(p_friction);
+	_reload_physics_characteristics();
 }
 real_t RigidBody::get_friction() const {
 
-	return friction;
+	ERR_EXPLAIN("The method get_friction has been deprecated and will be removed in the future, use physical material")
+	WARN_DEPRECATED
+	if (physics_material_override.is_null()) {
+		return 1;
+	}
+
+	return physics_material_override->get_friction();
 }
 
 void RigidBody::set_bounce(real_t p_bounce) {
-
+	ERR_EXPLAIN("The method set_bounce has been deprecated and will be removed in the future, use physical material")
+	WARN_DEPRECATED
 	ERR_FAIL_COND(p_bounce < 0 || p_bounce > 1);
 
-	bounce = p_bounce;
-	PhysicsServer::get_singleton()->body_set_param(get_rid(), PhysicsServer::BODY_PARAM_BOUNCE, bounce);
+	if (physics_material_override.is_null()) {
+		physics_material_override.instance();
+	}
+	physics_material_override->set_bounce(p_bounce);
+	_reload_physics_characteristics();
 }
 real_t RigidBody::get_bounce() const {
+	ERR_EXPLAIN("The method get_bounce has been deprecated and will be removed in the future, use physical material")
+	WARN_DEPRECATED
+	if (physics_material_override.is_null()) {
+		return 0;
+	}
 
-	return bounce;
+	return physics_material_override->get_bounce();
+}
+#endif
+
+void RigidBody::set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override) {
+	if (physics_material_override.is_valid()) {
+		physics_material_override->disconnect(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+	}
+
+	physics_material_override = p_physics_material_override;
+
+	if (physics_material_override.is_valid()) {
+		physics_material_override->connect(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+	}
+	_reload_physics_characteristics();
+}
+
+Ref<PhysicsMaterial> RigidBody::get_physics_material_override() const {
+	return physics_material_override;
 }
 
 void RigidBody::set_gravity_scale(real_t p_gravity_scale) {
@@ -812,6 +914,11 @@ void RigidBody::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_bounce", "bounce"), &RigidBody::set_bounce);
 	ClassDB::bind_method(D_METHOD("get_bounce"), &RigidBody::get_bounce);
 
+	ClassDB::bind_method(D_METHOD("set_physics_material_override", "physics_material_override"), &RigidBody::set_physics_material_override);
+	ClassDB::bind_method(D_METHOD("get_physics_material_override"), &RigidBody::get_physics_material_override);
+
+	ClassDB::bind_method(D_METHOD("_reload_physics_characteristics"), &RigidBody::_reload_physics_characteristics);
+
 	ClassDB::bind_method(D_METHOD("set_linear_velocity", "linear_velocity"), &RigidBody::set_linear_velocity);
 	ClassDB::bind_method(D_METHOD("get_linear_velocity"), &RigidBody::get_linear_velocity);
 
@@ -865,6 +972,7 @@ void RigidBody::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "weight", PROPERTY_HINT_EXP_RANGE, "0.01,65535,0.01", PROPERTY_USAGE_EDITOR), "set_weight", "get_weight");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "friction", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_friction", "get_friction");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "bounce", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_bounce", "get_bounce");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "physics_material_override", PROPERTY_HINT_RESOURCE_TYPE, "PhysicsMaterial"), "set_physics_material_override", "get_physics_material_override");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "gravity_scale", PROPERTY_HINT_RANGE, "-128,128,0.01"), "set_gravity_scale", "get_gravity_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "custom_integrator"), "set_use_custom_integrator", "is_using_custom_integrator");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "continuous_cd"), "set_use_continuous_collision_detection", "is_using_continuous_collision_detection");
@@ -903,9 +1011,7 @@ RigidBody::RigidBody() :
 
 	mode = MODE_RIGID;
 
-	bounce = 0;
 	mass = 1;
-	friction = 1;
 	max_contacts_reported = 0;
 	state = NULL;
 
@@ -929,6 +1035,21 @@ RigidBody::~RigidBody() {
 	if (contact_monitor)
 		memdelete(contact_monitor);
 }
+
+void RigidBody::_reload_physics_characteristics() {
+	if (physics_material_override.is_null()) {
+		PhysicsServer::get_singleton()->body_set_param(get_rid(), PhysicsServer::BODY_PARAM_BOUNCE, 0);
+		PhysicsServer::get_singleton()->body_set_param(get_rid(), PhysicsServer::BODY_PARAM_FRICTION, 1);
+		PhysicsServer::get_singleton()->body_set_combine_mode(get_rid(), PhysicsServer::BODY_PARAM_BOUNCE, PhysicsServer::COMBINE_MODE_INHERIT);
+		PhysicsServer::get_singleton()->body_set_combine_mode(get_rid(), PhysicsServer::BODY_PARAM_FRICTION, PhysicsServer::COMBINE_MODE_INHERIT);
+	} else {
+		PhysicsServer::get_singleton()->body_set_param(get_rid(), PhysicsServer::BODY_PARAM_BOUNCE, physics_material_override->get_bounce());
+		PhysicsServer::get_singleton()->body_set_param(get_rid(), PhysicsServer::BODY_PARAM_FRICTION, physics_material_override->get_friction());
+		PhysicsServer::get_singleton()->body_set_combine_mode(get_rid(), PhysicsServer::BODY_PARAM_BOUNCE, physics_material_override->get_bounce_combine_mode());
+		PhysicsServer::get_singleton()->body_set_combine_mode(get_rid(), PhysicsServer::BODY_PARAM_FRICTION, physics_material_override->get_friction_combine_mode());
+	}
+}
+
 //////////////////////////////////////////////////////
 //////////////////////////
 
@@ -2231,6 +2352,7 @@ void PhysicalBone::set_bounce(real_t p_bounce) {
 	bounce = p_bounce;
 	PhysicsServer::get_singleton()->body_set_param(get_rid(), PhysicsServer::BODY_PARAM_BOUNCE, bounce);
 }
+
 real_t PhysicalBone::get_bounce() const {
 
 	return bounce;

--- a/scene/3d/physics_body.h
+++ b/scene/3d/physics_body.h
@@ -32,6 +32,7 @@
 #define PHYSICS_BODY__H
 
 #include "scene/3d/collision_object.h"
+#include "scene/resources/physics_material.h"
 #include "servers/physics_server.h"
 #include "skeleton.h"
 #include "vset.h"
@@ -81,18 +82,22 @@ class StaticBody : public PhysicsBody {
 	Vector3 constant_linear_velocity;
 	Vector3 constant_angular_velocity;
 
-	real_t bounce;
-	real_t friction;
+	Ref<PhysicsMaterial> physics_material_override;
 
 protected:
 	static void _bind_methods();
 
 public:
+#ifndef DISABLE_DEPRECATED
 	void set_friction(real_t p_friction);
 	real_t get_friction() const;
 
 	void set_bounce(real_t p_bounce);
 	real_t get_bounce() const;
+#endif
+
+	void set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override);
+	Ref<PhysicsMaterial> get_physics_material_override() const;
 
 	void set_constant_linear_velocity(const Vector3 &p_vel);
 	void set_constant_angular_velocity(const Vector3 &p_vel);
@@ -102,6 +107,9 @@ public:
 
 	StaticBody();
 	~StaticBody();
+
+private:
+	void _reload_physics_characteristics();
 };
 
 class RigidBody : public PhysicsBody {
@@ -121,9 +129,8 @@ protected:
 	PhysicsDirectBodyState *state;
 	Mode mode;
 
-	real_t bounce;
 	real_t mass;
-	real_t friction;
+	Ref<PhysicsMaterial> physics_material_override;
 
 	Vector3 linear_velocity;
 	Vector3 angular_velocity;
@@ -196,11 +203,16 @@ public:
 	void set_weight(real_t p_weight);
 	real_t get_weight() const;
 
+#ifndef DISABLE_DEPRECATED
 	void set_friction(real_t p_friction);
 	real_t get_friction() const;
 
 	void set_bounce(real_t p_bounce);
 	real_t get_bounce() const;
+#endif
+
+	void set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override);
+	Ref<PhysicsMaterial> get_physics_material_override() const;
 
 	void set_linear_velocity(const Vector3 &p_velocity);
 	Vector3 get_linear_velocity() const;
@@ -249,6 +261,9 @@ public:
 
 	RigidBody();
 	~RigidBody();
+
+private:
+	void _reload_physics_characteristics();
 };
 
 VARIANT_ENUM_CAST(RigidBody::Mode);

--- a/scene/3d/vehicle_body.cpp
+++ b/scene/3d/vehicle_body.cpp
@@ -944,8 +944,6 @@ VehicleBody::VehicleBody() :
 	engine_force = 0;
 	brake = 0;
 
-	friction = 1;
-
 	state = NULL;
 	ccd = false;
 

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -192,6 +192,7 @@
 #include "scene/3d/vehicle_body.h"
 #include "scene/3d/visibility_notifier.h"
 #include "scene/resources/environment.h"
+#include "scene/resources/physics_material.h"
 #endif
 
 static ResourceFormatLoaderTheme *resource_loader_theme = NULL;
@@ -519,6 +520,8 @@ void register_scene_types() {
 	OS::get_singleton()->yield(); //may take time to init
 
 	ClassDB::register_class<SpatialVelocityTracker>();
+
+	ClassDB::register_class<PhysicsMaterial>();
 #endif
 	ClassDB::register_class<World>();
 	ClassDB::register_class<Environment>();

--- a/scene/resources/physics_material.cpp
+++ b/scene/resources/physics_material.cpp
@@ -1,0 +1,94 @@
+/*************************************************************************/
+/*  physics_material.cpp                                                 */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#include "physics_material.h"
+
+bool PhysicsMaterial::_set(const StringName &p_name, const Variant &p_value) {
+	if (p_name == "bounce") {
+		set_bounce(p_value);
+	} else if (p_name == "bounce_combine_mode") {
+		set_bounce_combine_mode(static_cast<PhysicsServer::CombineMode>(int(p_value)));
+	} else if (p_name == "friction") {
+		set_friction(p_value);
+	} else if (p_name == "friction_combine_mode") {
+		set_friction_combine_mode(static_cast<PhysicsServer::CombineMode>(int(p_value)));
+	} else {
+		return false;
+	}
+
+	emit_changed();
+	return true;
+}
+
+bool PhysicsMaterial::_get(const StringName &p_name, Variant &r_ret) const {
+	if (p_name == "bounce") {
+		r_ret = bounce;
+	} else if (p_name == "bounce_combine_mode") {
+		r_ret = int(bounce_combine_mode);
+	} else if (p_name == "friction") {
+		r_ret = friction;
+	} else if (p_name == "friction_combine_mode") {
+		r_ret = int(friction_combine_mode);
+	} else {
+		return false;
+	}
+
+	return true;
+}
+
+void PhysicsMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
+	p_list->push_back(PropertyInfo(Variant::REAL, "bounce"));
+	p_list->push_back(PropertyInfo(Variant::INT, "bounce_combine_mode", PROPERTY_HINT_ENUM, "Max,Min,Multiply,Average"));
+	p_list->push_back(PropertyInfo(Variant::REAL, "friction"));
+	p_list->push_back(PropertyInfo(Variant::INT, "friction_combine_mode", PROPERTY_HINT_ENUM, "Max,Min,Multiply,Average"));
+}
+
+void PhysicsMaterial::_bind_methods() {}
+
+void PhysicsMaterial::set_bounce(real_t p_val) {
+	bounce = p_val;
+}
+
+void PhysicsMaterial::set_bounce_combine_mode(PhysicsServer::CombineMode p_val) {
+	bounce_combine_mode = p_val;
+}
+
+void PhysicsMaterial::set_friction(real_t p_val) {
+	friction = p_val;
+}
+
+void PhysicsMaterial::set_friction_combine_mode(PhysicsServer::CombineMode p_val) {
+	friction_combine_mode = p_val;
+}
+
+PhysicsMaterial::PhysicsMaterial() :
+		bounce(0),
+		bounce_combine_mode(PhysicsServer::COMBINE_MODE_MAX),
+		friction(0),
+		friction_combine_mode(PhysicsServer::COMBINE_MODE_MULTIPLY) {}

--- a/scene/resources/physics_material.h
+++ b/scene/resources/physics_material.h
@@ -1,0 +1,70 @@
+/*************************************************************************/
+/*  physics_material.h                                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#ifndef physics_material_override_H
+#define physics_material_override_H
+
+#include "resource.h"
+#include "servers/physics_server.h"
+
+class PhysicsMaterial : public Resource {
+
+	GDCLASS(PhysicsMaterial, Resource);
+	OBJ_SAVE_TYPE(PhysicsMaterial);
+	RES_BASE_EXTENSION("PhyMat");
+
+	real_t bounce;
+	PhysicsServer::CombineMode bounce_combine_mode;
+	real_t friction;
+	PhysicsServer::CombineMode friction_combine_mode;
+
+protected:
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
+
+	static void _bind_methods();
+
+public:
+	void set_bounce(real_t p_val);
+	_FORCE_INLINE_ real_t get_bounce() const { return bounce; }
+
+	void set_bounce_combine_mode(PhysicsServer::CombineMode p_val);
+	_FORCE_INLINE_ PhysicsServer::CombineMode get_bounce_combine_mode() const { return bounce_combine_mode; }
+
+	void set_friction(real_t p_val);
+	_FORCE_INLINE_ real_t get_friction() const { return friction; }
+
+	void set_friction_combine_mode(PhysicsServer::CombineMode p_val);
+	_FORCE_INLINE_ PhysicsServer::CombineMode get_friction_combine_mode() const { return friction_combine_mode; }
+
+	PhysicsMaterial();
+};
+
+#endif // physics_material_override_H

--- a/servers/physics/body_sw.cpp
+++ b/servers/physics/body_sw.cpp
@@ -423,6 +423,22 @@ void BodySW::_compute_area_gravity_and_dampenings(const AreaSW *p_area) {
 	area_angular_damp += p_area->get_angular_damp();
 }
 
+void BodySW::set_combine_mode(PhysicsServer::BodyParameter p_param, PhysicsServer::CombineMode p_mode) {
+	if (p_param == PhysicsServer::BODY_PARAM_BOUNCE) {
+		bounce_combine_mode = p_mode;
+	} else {
+		friction_combine_mode = p_mode;
+	}
+}
+
+PhysicsServer::CombineMode BodySW::get_combine_mode(PhysicsServer::BodyParameter p_param) const {
+	if (p_param == PhysicsServer::BODY_PARAM_BOUNCE) {
+		return bounce_combine_mode;
+	} else {
+		return friction_combine_mode;
+	}
+}
+
 void BodySW::set_axis_lock(PhysicsServer::BodyAxis p_axis, bool lock) {
 	if (lock) {
 		locked_axis |= p_axis;

--- a/servers/physics/body_sw.h
+++ b/servers/physics/body_sw.h
@@ -49,6 +49,8 @@ class BodySW : public CollisionObjectSW {
 	real_t mass;
 	real_t bounce;
 	real_t friction;
+	PhysicsServer::CombineMode bounce_combine_mode;
+	PhysicsServer::CombineMode friction_combine_mode;
 
 	real_t linear_damp;
 	real_t angular_damp;
@@ -297,6 +299,12 @@ public:
 	_FORCE_INLINE_ real_t get_friction() const { return friction; }
 	_FORCE_INLINE_ Vector3 get_gravity() const { return gravity; }
 	_FORCE_INLINE_ real_t get_bounce() const { return bounce; }
+
+	void set_combine_mode(PhysicsServer::BodyParameter p_param, PhysicsServer::CombineMode p_mode);
+	PhysicsServer::CombineMode get_combine_mode(PhysicsServer::BodyParameter p_param) const;
+
+	_FORCE_INLINE_ PhysicsServer::CombineMode get_bounce_combine_mode() const { return bounce_combine_mode; }
+	_FORCE_INLINE_ PhysicsServer::CombineMode get_friction_combine_mode() const { return friction_combine_mode; }
 
 	void set_axis_lock(PhysicsServer::BodyAxis p_axis, bool lock);
 	bool is_axis_locked(PhysicsServer::BodyAxis p_axis) const;

--- a/servers/physics/physics_server_sw.cpp
+++ b/servers/physics/physics_server_sw.cpp
@@ -696,6 +696,20 @@ real_t PhysicsServerSW::body_get_param(RID p_body, BodyParameter p_param) const 
 	return body->get_param(p_param);
 };
 
+void PhysicsServerSW::body_set_combine_mode(RID p_body, BodyParameter p_param, CombineMode p_mode) {
+	BodySW *body = body_owner.get(p_body);
+	ERR_FAIL_COND(!body);
+
+	body->set_combine_mode(p_param, p_mode);
+}
+
+PhysicsServer::CombineMode PhysicsServerSW::body_get_combine_mode(RID p_body, BodyParameter p_param) const {
+	BodySW *body = body_owner.get(p_body);
+	ERR_FAIL_COND_V(!body, COMBINE_MODE_INHERIT);
+
+	return body->get_combine_mode(p_param);
+}
+
 void PhysicsServerSW::body_set_kinematic_safe_margin(RID p_body, real_t p_margin) {
 	BodySW *body = body_owner.get(p_body);
 	ERR_FAIL_COND(!body);

--- a/servers/physics/physics_server_sw.h
+++ b/servers/physics/physics_server_sw.h
@@ -188,6 +188,10 @@ public:
 	virtual void body_set_param(RID p_body, BodyParameter p_param, real_t p_value);
 	virtual real_t body_get_param(RID p_body, BodyParameter p_param) const;
 
+	/// p_param accept only Bounce and Friction
+	virtual void body_set_combine_mode(RID p_body, BodyParameter p_param, CombineMode p_mode);
+	virtual CombineMode body_get_combine_mode(RID p_body, BodyParameter p_param) const;
+
 	virtual void body_set_kinematic_safe_margin(RID p_body, real_t p_margin);
 	virtual real_t body_get_kinematic_safe_margin(RID p_body) const;
 

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -405,6 +405,22 @@ void Body2DSW::_compute_area_gravity_and_dampenings(const Area2DSW *p_area) {
 	area_angular_damp += p_area->get_angular_damp();
 }
 
+void Body2DSW::set_combine_mode(Physics2DServer::BodyParameter p_param, Physics2DServer::CombineMode p_mode) {
+	if (p_param == Physics2DServer::BODY_PARAM_BOUNCE) {
+		bounce_combine_mode = p_mode;
+	} else {
+		friction_combine_mode = p_mode;
+	}
+}
+
+Physics2DServer::CombineMode Body2DSW::get_combine_mode(Physics2DServer::BodyParameter p_param) const {
+	if (p_param == Physics2DServer::BODY_PARAM_BOUNCE) {
+		return bounce_combine_mode;
+	} else {
+		return friction_combine_mode;
+	}
+}
+
 void Body2DSW::integrate_forces(real_t p_step) {
 
 	if (mode == Physics2DServer::BODY_MODE_STATIC)

--- a/servers/physics_2d/body_2d_sw.h
+++ b/servers/physics_2d/body_2d_sw.h
@@ -54,6 +54,8 @@ class Body2DSW : public CollisionObject2DSW {
 	real_t mass;
 	real_t bounce;
 	real_t friction;
+	Physics2DServer::CombineMode bounce_combine_mode;
+	Physics2DServer::CombineMode friction_combine_mode;
 
 	real_t _inv_mass;
 	real_t _inv_inertia;
@@ -255,6 +257,12 @@ public:
 	_FORCE_INLINE_ real_t get_bounce() const { return bounce; }
 	_FORCE_INLINE_ real_t get_linear_damp() const { return linear_damp; }
 	_FORCE_INLINE_ real_t get_angular_damp() const { return angular_damp; }
+
+	void set_combine_mode(Physics2DServer::BodyParameter p_param, Physics2DServer::CombineMode p_mode);
+	Physics2DServer::CombineMode get_combine_mode(Physics2DServer::BodyParameter p_param) const;
+
+	_FORCE_INLINE_ Physics2DServer::CombineMode get_bounce_combine_mode() const { return bounce_combine_mode; }
+	_FORCE_INLINE_ Physics2DServer::CombineMode get_friction_combine_mode() const { return friction_combine_mode; }
 
 	void integrate_forces(real_t p_step);
 	void integrate_velocities(real_t p_step);

--- a/servers/physics_2d/physics_2d_server_sw.cpp
+++ b/servers/physics_2d/physics_2d_server_sw.cpp
@@ -789,6 +789,22 @@ real_t Physics2DServerSW::body_get_param(RID p_body, BodyParameter p_param) cons
 	return body->get_param(p_param);
 };
 
+void Physics2DServerSW::body_set_combine_mode(RID p_body, BodyParameter p_param, CombineMode p_mode) {
+
+	Body2DSW *body = body_owner.get(p_body);
+	ERR_FAIL_COND(!body);
+
+	body->set_combine_mode(p_param, p_mode);
+}
+
+Physics2DServer::CombineMode Physics2DServerSW::body_get_combine_mode(RID p_body, BodyParameter p_param) const {
+
+	Body2DSW *body = body_owner.get(p_body);
+	ERR_FAIL_COND_V(!body, COMBINE_MODE_INHERIT);
+
+	return body->get_combine_mode(p_param);
+}
+
 void Physics2DServerSW::body_set_state(RID p_body, BodyState p_state, const Variant &p_variant) {
 
 	Body2DSW *body = body_owner.get(p_body);

--- a/servers/physics_2d/physics_2d_server_sw.h
+++ b/servers/physics_2d/physics_2d_server_sw.h
@@ -200,6 +200,10 @@ public:
 	virtual void body_set_param(RID p_body, BodyParameter p_param, real_t p_value);
 	virtual real_t body_get_param(RID p_body, BodyParameter p_param) const;
 
+	/// p_param accept only Bounce and Friction
+	virtual void body_set_combine_mode(RID p_body, BodyParameter p_param, CombineMode p_mode);
+	virtual CombineMode body_get_combine_mode(RID p_body, BodyParameter p_param) const;
+
 	virtual void body_set_state(RID p_body, BodyState p_state, const Variant &p_variant);
 	virtual Variant body_get_state(RID p_body, BodyState p_state) const;
 

--- a/servers/physics_2d/physics_2d_server_wrap_mt.h
+++ b/servers/physics_2d/physics_2d_server_wrap_mt.h
@@ -211,6 +211,9 @@ public:
 	FUNC3(body_set_param, RID, BodyParameter, real_t);
 	FUNC2RC(real_t, body_get_param, RID, BodyParameter);
 
+	FUNC3(body_set_combine_mode, RID, BodyParameter, CombineMode);
+	FUNC2RC(CombineMode, body_get_combine_mode, RID, BodyParameter);
+
 	FUNC3(body_set_state, RID, BodyState, const Variant &);
 	FUNC2RC(Variant, body_get_state, RID, BodyState);
 

--- a/servers/physics_2d_server.h
+++ b/servers/physics_2d_server.h
@@ -416,6 +416,19 @@ public:
 	virtual void body_set_param(RID p_body, BodyParameter p_param, float p_value) = 0;
 	virtual float body_get_param(RID p_body, BodyParameter p_param) const = 0;
 
+	enum CombineMode {
+		COMBINE_MODE_MAX,
+		COMBINE_MODE_MIN,
+		COMBINE_MODE_MULTIPLY,
+		COMBINE_MODE_AVERAGE,
+
+		COMBINE_MODE_INHERIT /// Inherit from other body or use COMBINE_MODE_MAX (Restitution) COMBINE_MODE_MULTIPLY (Friction)
+	};
+
+	/// p_param accept only Bounce and Friction
+	virtual void body_set_combine_mode(RID p_body, BodyParameter p_param, CombineMode p_mode) = 0;
+	virtual CombineMode body_get_combine_mode(RID p_body, BodyParameter p_param) const = 0;
+
 	//state
 	enum BodyState {
 		BODY_STATE_TRANSFORM,

--- a/servers/physics_server.h
+++ b/servers/physics_server.h
@@ -398,6 +398,19 @@ public:
 	virtual void body_set_param(RID p_body, BodyParameter p_param, float p_value) = 0;
 	virtual float body_get_param(RID p_body, BodyParameter p_param) const = 0;
 
+	enum CombineMode {
+		COMBINE_MODE_MAX,
+		COMBINE_MODE_MIN,
+		COMBINE_MODE_MULTIPLY,
+		COMBINE_MODE_AVERAGE,
+
+		COMBINE_MODE_INHERIT /// Inherit from other body or use COMBINE_MODE_MAX (Restitution) COMBINE_MODE_MULTIPLY (Friction)
+	};
+
+	/// p_param accept only Bounce and Friction
+	virtual void body_set_combine_mode(RID p_body, BodyParameter p_param, CombineMode p_mode) = 0;
+	virtual CombineMode body_get_combine_mode(RID p_body, BodyParameter p_param) const = 0;
+
 	virtual void body_set_kinematic_safe_margin(RID p_body, real_t p_margin) = 0;
 	virtual real_t body_get_kinematic_safe_margin(RID p_body) const = 0;
 


### PR DESCRIPTION
The physics material is a resource and is useful to share a particular physical characteristic to some objects.

For example if we have some ice floors with different shapes, instead of change one by one its friction we can create and set an **ice_physics_material**. This characteristic is shared by all ice floors and make the edit very easy since you need only change the physics material friction.

In the physics material is possible to set:

- bouncing
- friction
- bouncing combining mode (Max, Min, Multiply, Average).
- friction combining mode (Max, Min, Multiply, Average).

# NOTE

In this moment I've implemented only Physics API and the Resource, I will implement the code that handle it with Bullet when this PR will be merged, the implementation of Godot Physics could be implemented by @reduz or some one else.