### PR TITLE
Removes Script::get_node_type()

### DIFF
--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -58,7 +58,6 @@ void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_script_signal", "signal_name"), &Script::has_script_signal);
 
 	ClassDB::bind_method(D_METHOD("is_tool"), &Script::is_tool);
-	ClassDB::bind_method(D_METHOD("get_node_type"), &Script::get_node_type);
 }
 
 void ScriptServer::set_scripting_enabled(bool p_enabled) {

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -107,8 +107,6 @@ public:
 
 	virtual bool is_tool() const = 0;
 
-	virtual String get_node_type() const = 0;
-
 	virtual ScriptLanguage *get_language() const = 0;
 
 	virtual bool has_script_signal(const StringName &p_signal) const = 0;

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -19,12 +19,6 @@
 				Returns true if the script can be instanced.
 			</description>
 		</method>
-		<method name="get_node_type" qualifiers="const">
-			<return type="String">
-			</return>
-			<description>
-			</description>
-		</method>
 		<method name="get_source_code" qualifiers="const">
 			<return type="String">
 			</return>

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -270,10 +270,6 @@ bool NativeScript::is_tool() const {
 	return false;
 }
 
-String NativeScript::get_node_type() const {
-	return ""; // NOTE(karroffel): uhm?
-}
-
 ScriptLanguage *NativeScript::get_language() const {
 	return NativeScriptLanguage::get_singleton();
 }

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -142,8 +142,6 @@ public:
 
 	virtual bool is_tool() const;
 
-	virtual String get_node_type() const;
-
 	virtual ScriptLanguage *get_language() const;
 
 	virtual bool has_script_signal(const StringName &p_signal) const;

--- a/modules/gdnative/pluginscript/pluginscript_script.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_script.cpp
@@ -346,11 +346,6 @@ bool PluginScript::get_property_default_value(const StringName &p_property, Vari
 	return false;
 }
 
-String PluginScript::get_node_type() const {
-	// Even GDscript doesn't know what to put here !
-	return ""; // ?
-}
-
 ScriptLanguage *PluginScript::get_language() const {
 	return _language;
 }

--- a/modules/gdnative/pluginscript/pluginscript_script.h
+++ b/modules/gdnative/pluginscript/pluginscript_script.h
@@ -103,8 +103,6 @@ public:
 
 	bool is_tool() const { return _tool; }
 
-	virtual String get_node_type() const;
-
 	virtual ScriptLanguage *get_language() const;
 
 	virtual bool has_script_signal(const StringName &p_signal) const;

--- a/modules/gdscript/gd_script.cpp
+++ b/modules/gdscript/gd_script.cpp
@@ -609,11 +609,6 @@ Error GDScript::reload(bool p_keep_state) {
 	return OK;
 }
 
-String GDScript::get_node_type() const {
-
-	return ""; // ?
-}
-
 ScriptLanguage *GDScript::get_language() const {
 
 	return GDScriptLanguage::get_singleton();

--- a/modules/gdscript/gd_script.h
+++ b/modules/gdscript/gd_script.h
@@ -172,7 +172,6 @@ public:
 
 	virtual Error reload(bool p_keep_state = false);
 
-	virtual String get_node_type() const;
 	void set_script_path(const String &p_path) { path = p_path; } //because subclasses need a path too...
 	Error load_source_code(const String &p_path);
 	Error load_byte_code(const String &p_path);

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1720,11 +1720,6 @@ Error CSharpScript::reload(bool p_keep_state) {
 	return ERR_FILE_MISSING_DEPENDENCIES;
 }
 
-String CSharpScript::get_node_type() const {
-
-	return ""; // ?
-}
-
 ScriptLanguage *CSharpScript::get_language() const {
 
 	return CSharpLanguage::get_singleton();

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -138,7 +138,6 @@ public:
 
 	virtual bool is_tool() const { return tool; }
 	virtual Ref<Script> get_base_script() const;
-	virtual String get_node_type() const;
 	virtual ScriptLanguage *get_language() const;
 
 	/* TODO */ virtual void get_script_method_list(List<MethodInfo> *p_list) const {}

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -974,11 +974,6 @@ bool VisualScript::is_tool() const {
 	return false;
 }
 
-String VisualScript::get_node_type() const {
-
-	return String();
-}
-
 ScriptLanguage *VisualScript::get_language() const {
 
 	return VisualScriptLanguage::singleton;

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -339,8 +339,6 @@ public:
 
 	virtual bool is_tool() const;
 
-	virtual String get_node_type() const;
-
 	virtual ScriptLanguage *get_language() const;
 
 	virtual bool has_script_signal(const StringName &p_signal) const;


### PR DESCRIPTION
used before GDScript, with squirrel apparently.
fell on this because I was doing the Script doc.