### PR TITLE
add copy button to sprite_frames_editor

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -199,6 +199,20 @@ void SpriteFramesEditor::_paste_pressed() {
 	undo_redo->commit_action();
 }
 
+void SpriteFramesEditor::_copy_pressed() {
+
+	ERR_FAIL_COND(!frames->has_animation(edited_anim));
+
+	if (tree->get_current() < 0)
+		return;
+	Ref<Texture> r = frames->get_frame(edited_anim, tree->get_current());
+	if (!r.is_valid()) {
+		return;
+	}
+
+	EditorSettings::get_singleton()->set_resource_clipboard(r);
+}
+
 void SpriteFramesEditor::_empty_pressed() {
 
 	ERR_FAIL_COND(!frames->has_animation(edited_anim));
@@ -695,6 +709,7 @@ void SpriteFramesEditor::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("_empty2_pressed"), &SpriteFramesEditor::_empty2_pressed);
 	ObjectTypeDB::bind_method(_MD("_item_edited"), &SpriteFramesEditor::_item_edited);
 	ObjectTypeDB::bind_method(_MD("_delete_pressed"), &SpriteFramesEditor::_delete_pressed);
+	ObjectTypeDB::bind_method(_MD("_copy_pressed"), &SpriteFramesEditor::_copy_pressed);
 	ObjectTypeDB::bind_method(_MD("_paste_pressed"), &SpriteFramesEditor::_paste_pressed);
 	ObjectTypeDB::bind_method(_MD("_delete_confirm_pressed"), &SpriteFramesEditor::_delete_confirm_pressed);
 	ObjectTypeDB::bind_method(_MD("_file_load_request", "files", "atpos"), &SpriteFramesEditor::_file_load_request, DEFVAL(-1));
@@ -777,6 +792,10 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	load->set_tooltip(TTR("Load Resource"));
 	hbc->add_child(load);
 
+	copy = memnew(Button);
+	copy->set_text(TTR("Copy"));
+	hbc->add_child(copy);
+
 	paste = memnew(Button);
 	paste->set_text(TTR("Paste"));
 	hbc->add_child(paste);
@@ -823,6 +842,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 
 	load->connect("pressed", this, "_load_pressed");
 	_delete->connect("pressed", this, "_delete_pressed");
+	copy->connect("pressed", this, "_copy_pressed");
 	paste->connect("pressed", this, "_paste_pressed");
 	empty->connect("pressed", this, "_empty_pressed");
 	empty2->connect("pressed", this, "_empty2_pressed");

--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -44,6 +44,7 @@ class SpriteFramesEditor : public PanelContainer {
 
 	Button *load;
 	Button *_delete;
+	Button *copy;
 	Button *paste;
 	Button *empty;
 	Button *empty2;
@@ -72,6 +73,7 @@ class SpriteFramesEditor : public PanelContainer {
 	void _load_pressed();
 	void _load_scene_pressed();
 	void _file_load_request(const DVector<String> &p_path, int p_at_pos = -1);
+	void _copy_pressed();
 	void _paste_pressed();
 	void _empty_pressed();
 	void _empty2_pressed();


### PR DESCRIPTION
Add a copy button to sprite_frames_editor.
Easy to duplicate sprite in sprite frames editor,or copy to anywhere..