### PR TITLE
Fixes infinite loop in NavPolygonInstance warnings

### DIFF
--- a/scene/2d/navigation_polygon.cpp
+++ b/scene/2d/navigation_polygon.cpp
@@ -452,7 +452,7 @@ String NavigationPolygonInstance::get_configuration_warning() const {
 			return String();
 		}
 
-		c = Object::cast_to<Node2D>(get_parent());
+		c = Object::cast_to<Node2D>(c->get_parent());
 	}
 
 	return TTR("NavigationPolygonInstance must be a child or grandchild to a Navigation2D node. It only provides navigation data.");


### PR DESCRIPTION
Fixes #11975 and #12280.
If I understand correctly the warning is supposed to check if there is a Navigation2D among the parents.
It was only checking the first parent and looping without end