### PR TITLE
Overhauled the ParallaxBackground system

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -52,7 +52,11 @@ void Camera2D::_update_scroll() {
 		if (viewport) {
 			viewport->set_canvas_transform(xform);
 		}
-		get_tree()->call_group_flags(SceneTree::GROUP_CALL_REALTIME, group_name, "_camera_moved", xform);
+
+		Size2 screen_size = viewport->get_visible_rect().size;
+		Point2 screen_offset = (anchor_mode == ANCHOR_MODE_DRAG_CENTER ? (screen_size * 0.5) : Point2());
+
+		get_tree()->call_group_flags(SceneTree::GROUP_CALL_REALTIME, group_name, "_camera_moved", xform, screen_offset);
 	};
 }
 

--- a/scene/2d/parallax_background.cpp
+++ b/scene/2d/parallax_background.cpp
@@ -47,10 +47,12 @@ void ParallaxBackground::_notification(int p_what) {
 	}
 }
 
-void ParallaxBackground::_camera_moved(const Transform2D &p_transform) {
+void ParallaxBackground::_camera_moved(const Transform2D &p_transform, const Point2 &p_screen_offset) {
+
+	screen_offset = p_screen_offset;
 
 	set_scroll_scale(p_transform.get_scale().dot(Vector2(0.5, 0.5)));
-	set_scroll_offset(p_transform.get_origin() / p_transform.get_scale());
+	set_scroll_offset(p_transform.get_origin());
 }
 
 void ParallaxBackground::set_scroll_scale(float p_scale) {
@@ -106,9 +108,9 @@ void ParallaxBackground::_update_scroll() {
 			continue;
 
 		if (ignore_camera_zoom)
-			l->set_base_offset_and_scale(ofs, 1.0);
+			l->set_base_offset_and_scale(ofs, 1.0, screen_offset);
 		else
-			l->set_base_offset_and_scale(ofs, scale);
+			l->set_base_offset_and_scale(ofs, scale, screen_offset);
 	}
 }
 

--- a/scene/2d/parallax_background.h
+++ b/scene/2d/parallax_background.h
@@ -42,6 +42,7 @@ class ParallaxBackground : public CanvasLayer {
 	float scale;
 	Point2 base_offset;
 	Point2 base_scale;
+	Point2 screen_offset;
 	String group_name;
 	Point2 limit_begin;
 	Point2 limit_end;
@@ -51,7 +52,7 @@ class ParallaxBackground : public CanvasLayer {
 	void _update_scroll();
 
 protected:
-	void _camera_moved(const Transform2D &p_transform);
+	void _camera_moved(const Transform2D &p_transform, const Point2 &p_screen_offset);
 
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -40,7 +40,7 @@ void ParallaxLayer::set_motion_scale(const Size2 &p_scale) {
 	if (pb && is_inside_tree()) {
 		Vector2 ofs = pb->get_final_offset();
 		float scale = pb->get_scroll_scale();
-		set_base_offset_and_scale(ofs, scale);
+		set_base_offset_and_scale(ofs, scale, screen_offset);
 	}
 }
 
@@ -57,7 +57,7 @@ void ParallaxLayer::set_motion_offset(const Size2 &p_offset) {
 	if (pb && is_inside_tree()) {
 		Vector2 ofs = pb->get_final_offset();
 		float scale = pb->get_scroll_scale();
-		set_base_offset_and_scale(ofs, scale);
+		set_base_offset_and_scale(ofs, scale, screen_offset);
 	}
 }
 
@@ -106,26 +106,28 @@ void ParallaxLayer::_notification(int p_what) {
 	}
 }
 
-void ParallaxLayer::set_base_offset_and_scale(const Point2 &p_offset, float p_scale) {
+void ParallaxLayer::set_base_offset_and_scale(const Point2 &p_offset, float p_scale, const Point2 &p_screen_offset) {
+	screen_offset = p_screen_offset;
 
 	if (!is_inside_tree())
 		return;
 	if (Engine::get_singleton()->is_editor_hint())
 		return;
-	Point2 new_ofs = ((orig_offset + p_offset) * motion_scale) * p_scale + motion_offset;
+
+	Point2 new_ofs = (screen_offset + (p_offset - screen_offset) * motion_scale) + motion_offset * p_scale + orig_offset * p_scale;
+
+	Vector2 mirror = Vector2(1, 1);
 
 	if (mirroring.x) {
-		double den = mirroring.x * p_scale;
-		new_ofs.x -= den * ceil(new_ofs.x / den);
+		mirror.x = -1;
 	}
 
 	if (mirroring.y) {
-		double den = mirroring.y * p_scale;
-		new_ofs.y -= den * ceil(new_ofs.y / den);
+		mirror.y = -1;
 	}
 
 	set_position(new_ofs);
-	set_scale(Vector2(1, 1) * p_scale);
+	set_scale(mirror * p_scale * orig_scale);
 }
 
 String ParallaxLayer::get_configuration_warning() const {

--- a/scene/2d/parallax_layer.h
+++ b/scene/2d/parallax_layer.h
@@ -43,6 +43,8 @@ class ParallaxLayer : public Node2D {
 	Vector2 mirroring;
 	void _update_mirroring();
 
+	Point2 screen_offset;
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -57,7 +59,7 @@ public:
 	void set_mirroring(const Size2 &p_mirroring);
 	Size2 get_mirroring() const;
 
-	void set_base_offset_and_scale(const Point2 &p_offset, float p_scale);
+	void set_base_offset_and_scale(const Point2 &p_offset, float p_scale, const Point2 &p_screen_offset);
 
 	virtual String get_configuration_warning() const;
 	ParallaxLayer();


### PR DESCRIPTION
Overhauled the ParallaxBackground so that it works properly regardless of Camera Zoom or Camera anchor point.
It builds on my previous ParallaxBackground work: https://github.com/godotengine/godot/pull/12132 and both try to fix the bug I submitted here: https://github.com/godotengine/godot/issues/11555

Essentially, the Parallax Background previously acted weirdly depending on Camera2D's zoom, and whether it was anchored the the center or top left.

I've coded the camera to send more information to the ParallaxBackground, using this information it's able to have a properly behaved Parallax Background behaviour, regardless of the camera's zoom or anchor point. It operates consistently and in line with the other elements on the screen.

I should note, this patch does NOT fix "Ignore Camera Zoom" setting. While that mode behaviour acts fine on a superficial level, it acts weird when you zoom in and out. The reason for this is that the Camera2D only sends screen space coordinates to the ParallaxBackground, and in order to fix it the camera would need to send it's actual real world position.

Example project used for testing:
[ParallaxRecreate.zip](https://github.com/godotengine/godot/files/1419861/ParallaxRecreate.zip)

Left/Right- Scrolls left and right

Up/Down- Zooms in and out.

PgUp/PgDown - Scrolls up and down (not needed much)