### PR TITLE
Remove HTTPClient::send_body_text and ::send_body_data

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -189,16 +189,6 @@ Error HTTPClient::request(Method p_method, const String &p_url, const Vector<Str
 	return OK;
 }
 
-Error HTTPClient::send_body_text(const String &p_body) {
-
-	return OK;
-}
-
-Error HTTPClient::send_body_data(const PoolByteArray &p_body) {
-
-	return OK;
-}
-
 bool HTTPClient::has_response() const {
 
 	return response_headers.size() != 0;
@@ -629,8 +619,6 @@ void HTTPClient::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_connection"), &HTTPClient::get_connection);
 	ClassDB::bind_method(D_METHOD("request_raw", "method", "url", "headers", "body"), &HTTPClient::request_raw);
 	ClassDB::bind_method(D_METHOD("request", "method", "url", "headers", "body"), &HTTPClient::request, DEFVAL(String()));
-	ClassDB::bind_method(D_METHOD("send_body_text", "body"), &HTTPClient::send_body_text);
-	ClassDB::bind_method(D_METHOD("send_body_data", "body"), &HTTPClient::send_body_data);
 	ClassDB::bind_method(D_METHOD("close"), &HTTPClient::close);
 
 	ClassDB::bind_method(D_METHOD("has_response"), &HTTPClient::has_response);

--- a/core/io/http_client.h
+++ b/core/io/http_client.h
@@ -169,8 +169,6 @@ public:
 
 	Error request_raw(Method p_method, const String &p_url, const Vector<String> &p_headers, const PoolVector<uint8_t> &p_body);
 	Error request(Method p_method, const String &p_url, const Vector<String> &p_headers, const String &p_body = String());
-	Error send_body_text(const String &p_body);
-	Error send_body_data(const PoolByteArray &p_body);
 
 	void close();
 

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -169,24 +169,6 @@
 				Sends body raw, as a byte array, does not encode it in any way.
 			</description>
 		</method>
-		<method name="send_body_data">
-			<return type="int" enum="Error">
-			</return>
-			<argument index="0" name="body" type="PoolByteArray">
-			</argument>
-			<description>
-				Stub function
-			</description>
-		</method>
-		<method name="send_body_text">
-			<return type="int" enum="Error">
-			</return>
-			<argument index="0" name="body" type="String">
-			</argument>
-			<description>
-				Stub function
-			</description>
-		</method>
 		<method name="set_blocking_mode">
 			<return type="void">
 			</return>


### PR DESCRIPTION
These were never implemented.
The methods `request` and `request_raw` provide parameters to send body data as part of the client's requests instead.