### PR TITLE
AStar: Add setters for point position and scale weight, cleanup

### DIFF
--- a/core/math/a_star.h
+++ b/core/math/a_star.h
@@ -33,6 +33,8 @@
 #include "reference.h"
 #include "self_list.h"
 /**
+	A* pathfinding algorithm
+
 	@author Juan Linietsky <reduzio@gmail.com>
 */
 
@@ -53,7 +55,7 @@ class AStar : public Reference {
 
 		Vector<Point *> neighbours;
 
-		//used for pathfinding
+		// Used for pathfinding
 		Point *prev_point;
 		real_t distance;
 
@@ -102,7 +104,9 @@ public:
 
 	void add_point(int p_id, const Vector3 &p_pos, real_t p_weight_scale = 1);
 	Vector3 get_point_position(int p_id) const;
+	void set_point_position(int p_id, const Vector3 &p_pos);
 	real_t get_point_weight_scale(int p_id) const;
+	void set_point_weight_scale(int p_id, real_t p_weight_scale);
 	void remove_point(int p_id);
 	bool has_point(int p_id) const;
 	Array get_points();

--- a/doc/classes/AStar.xml
+++ b/doc/classes/AStar.xml
@@ -50,6 +50,7 @@
 				
 				as.add_point(1, Vector3(1,0,0), 4) # Adds the point (1,0,0) with weight_scale=4 and id=1
 				[/codeblock]
+				If there already exists a point for the given id, its position and weight scale are updated to the given values.
 			</description>
 		</method>
 		<method name="are_points_connected" qualifiers="const">
@@ -107,7 +108,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Returns an id with no point associated to it.
+				Returns the next available point id with no point associated to it.
 			</description>
 		</method>
 		<method name="get_closest_point" qualifiers="const">
@@ -218,6 +219,28 @@
 			</argument>
 			<description>
 				Removes the point associated with the given id from the points pool.
+			</description>
+		</method>
+		<method name="set_point_position">
+			<return type="void">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<argument index="1" name="position" type="Vector3">
+			</argument>
+			<description>
+				Sets the position for the point with the given id.
+			</description>
+		</method>
+		<method name="set_point_weight_scale">
+			<return type="void">
+			</return>
+			<argument index="0" name="id" type="int">
+			</argument>
+			<argument index="1" name="weight_scale" type="float">
+			</argument>
+			<description>
+				Sets the [code]weight_scale[/code] for the point with the given id.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Adds `set_point_position` and `set_point_weight_scale` methods to `AStar`, some cleanup & docs.

Fixes #12434.