### PR TITLE
Fixing vsproj generation

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -1710,9 +1710,9 @@ def generate_vs_project(env, num_jobs):
         env.AddToVSProject(env.servers_sources)
         env.AddToVSProject(env.editor_sources)
 
-        env['MSVSBUILDCOM'] = build_commandline('scons --directory=$(ProjectDir) platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))
-        env['MSVSREBUILDCOM'] = build_commandline('scons --directory=$(ProjectDir) platform=windows target=$(Configuration) tools=!tools! vsproj=yes -j' + str(num_jobs))
-        env['MSVSCLEANCOM'] = build_commandline('scons --directory=$(ProjectDir) --clean platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))
+        env['MSVSBUILDCOM'] = build_commandline('scons --directory="$(ProjectDir)" platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))
+        env['MSVSREBUILDCOM'] = build_commandline('scons --directory="$(ProjectDir)" platform=windows target=$(Configuration) tools=!tools! vsproj=yes -j' + str(num_jobs))
+        env['MSVSCLEANCOM'] = build_commandline('scons --directory="$(ProjectDir)" --clean platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))
 
         # This version information (Win32, x64, Debug, Release, Release_Debug seems to be
         # required for Visual Studio to understand that it needs to generate an NMAKE

--- a/methods.py
+++ b/methods.py
@@ -1709,10 +1709,10 @@ def generate_vs_project(env, num_jobs):
         env.AddToVSProject(env.scene_sources)
         env.AddToVSProject(env.servers_sources)
         env.AddToVSProject(env.editor_sources)
-
-        env['MSVSBUILDCOM'] = build_commandline('scons --directory=$(ProjectDir) platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))
-        env['MSVSREBUILDCOM'] = build_commandline('scons --directory=$(ProjectDir) platform=windows target=$(Configuration) tools=!tools! vsproj=yes -j' + str(num_jobs))
-        env['MSVSCLEANCOM'] = build_commandline('scons --directory=$(ProjectDir) --clean platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))
+        
+        env['MSVSBUILDCOM'] = build_commandline('scons --directory="$(ProjectDir)" platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))
+        env['MSVSREBUILDCOM'] = build_commandline('scons --directory="$(ProjectDir)" platform=windows target=$(Configuration) tools=!tools! vsproj=yes -j' + str(num_jobs))
+        env['MSVSCLEANCOM'] = build_commandline('scons --directory="$(ProjectDir)" --clean platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))
 
         # This version information (Win32, x64, Debug, Release, Release_Debug seems to be
         # required for Visual Studio to understand that it needs to generate an NMAKE

--- a/methods.py
+++ b/methods.py
@@ -1709,8 +1709,7 @@ def generate_vs_project(env, num_jobs):
         env.AddToVSProject(env.scene_sources)
         env.AddToVSProject(env.servers_sources)
         env.AddToVSProject(env.editor_sources)
-
-        print ('scons --directory="$(ProjectDir)" platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))
+        
         env['MSVSBUILDCOM'] = build_commandline('scons --directory="$(ProjectDir)" platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))
         env['MSVSREBUILDCOM'] = build_commandline('scons --directory="$(ProjectDir)" platform=windows target=$(Configuration) tools=!tools! vsproj=yes -j' + str(num_jobs))
         env['MSVSCLEANCOM'] = build_commandline('scons --directory="$(ProjectDir)" --clean platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))

--- a/methods.py
+++ b/methods.py
@@ -1709,7 +1709,8 @@ def generate_vs_project(env, num_jobs):
         env.AddToVSProject(env.scene_sources)
         env.AddToVSProject(env.servers_sources)
         env.AddToVSProject(env.editor_sources)
-        
+
+        print ('scons --directory="$(ProjectDir)" platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))
         env['MSVSBUILDCOM'] = build_commandline('scons --directory="$(ProjectDir)" platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))
         env['MSVSREBUILDCOM'] = build_commandline('scons --directory="$(ProjectDir)" platform=windows target=$(Configuration) tools=!tools! vsproj=yes -j' + str(num_jobs))
         env['MSVSCLEANCOM'] = build_commandline('scons --directory="$(ProjectDir)" --clean platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))

--- a/methods.py
+++ b/methods.py
@@ -1710,9 +1710,10 @@ def generate_vs_project(env, num_jobs):
         env.AddToVSProject(env.servers_sources)
         env.AddToVSProject(env.editor_sources)
 
-        env['MSVSBUILDCOM'] = build_commandline('scons --directory=$(ProjectDir) platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))
-        env['MSVSREBUILDCOM'] = build_commandline('scons --directory=$(ProjectDir) platform=windows target=$(Configuration) tools=!tools! vsproj=yes -j' + str(num_jobs))
-        env['MSVSCLEANCOM'] = build_commandline('scons --directory=$(ProjectDir) --clean platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))
+        print ('scons --directory="$(ProjectDir)" platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))
+        env['MSVSBUILDCOM'] = build_commandline('scons --directory="$(ProjectDir)" platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))
+        env['MSVSREBUILDCOM'] = build_commandline('scons --directory="$(ProjectDir)" platform=windows target=$(Configuration) tools=!tools! vsproj=yes -j' + str(num_jobs))
+        env['MSVSCLEANCOM'] = build_commandline('scons --directory="$(ProjectDir)" --clean platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))
 
         # This version information (Win32, x64, Debug, Release, Release_Debug seems to be
         # required for Visual Studio to understand that it needs to generate an NMAKE

--- a/methods.py
+++ b/methods.py
@@ -1710,10 +1710,9 @@ def generate_vs_project(env, num_jobs):
         env.AddToVSProject(env.servers_sources)
         env.AddToVSProject(env.editor_sources)
 
-        print ('scons --directory="$(ProjectDir)" platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))
-        env['MSVSBUILDCOM'] = build_commandline('scons --directory="$(ProjectDir)" platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))
-        env['MSVSREBUILDCOM'] = build_commandline('scons --directory="$(ProjectDir)" platform=windows target=$(Configuration) tools=!tools! vsproj=yes -j' + str(num_jobs))
-        env['MSVSCLEANCOM'] = build_commandline('scons --directory="$(ProjectDir)" --clean platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))
+        env['MSVSBUILDCOM'] = build_commandline('scons --directory=$(ProjectDir) platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))
+        env['MSVSREBUILDCOM'] = build_commandline('scons --directory=$(ProjectDir) platform=windows target=$(Configuration) tools=!tools! vsproj=yes -j' + str(num_jobs))
+        env['MSVSCLEANCOM'] = build_commandline('scons --directory=$(ProjectDir) --clean platform=windows target=$(Configuration) tools=!tools! -j' + str(num_jobs))
 
         # This version information (Win32, x64, Debug, Release, Release_Debug seems to be
         # required for Visual Studio to understand that it needs to generate an NMAKE


### PR DESCRIPTION
Fixing vsproj generation by adding quotes arounnd $(ProjectDir). Otherwise the build will fail if the name has spaces in it