### PR TITLE
Mono: Use "UnnamedProject" if "application/config/name" is empty

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -488,13 +488,17 @@ void CSharpLanguage::reload_assemblies_if_needed(bool p_soft_reload) {
 
 		GDMonoAssembly *proj_assembly = gdmono->get_project_assembly();
 
+		String name = ProjectSettings::get_singleton()->get("application/config/name");
+		if (name.empty()) {
+			name = "UnnamedProject";
+		}
+
 		if (proj_assembly) {
 			String proj_asm_path = proj_assembly->get_path();
 
 			if (!FileAccess::exists(proj_assembly->get_path())) {
 				// Maybe it wasn't loaded from the default path, so check this as well
-				String proj_asm_name = ProjectSettings::get_singleton()->get("application/config/name");
-				proj_asm_path = GodotSharpDirs::get_res_temp_assemblies_dir().plus_file(proj_asm_name);
+				proj_asm_path = GodotSharpDirs::get_res_temp_assemblies_dir().plus_file(name);
 				if (!FileAccess::exists(proj_asm_path))
 					return; // No assembly to load
 			}
@@ -502,8 +506,7 @@ void CSharpLanguage::reload_assemblies_if_needed(bool p_soft_reload) {
 			if (FileAccess::get_modified_time(proj_asm_path) <= proj_assembly->get_modified_time())
 				return; // Already up to date
 		} else {
-			String proj_asm_name = ProjectSettings::get_singleton()->get("application/config/name");
-			if (!FileAccess::exists(GodotSharpDirs::get_res_temp_assemblies_dir().plus_file(proj_asm_name)))
+			if (!FileAccess::exists(GodotSharpDirs::get_res_temp_assemblies_dir().plus_file(name)))
 				return; // No assembly to load
 		}
 	}

--- a/modules/mono/editor/godotsharp_editor.cpp
+++ b/modules/mono/editor/godotsharp_editor.cpp
@@ -71,6 +71,10 @@ bool GodotSharpEditor::_create_project_solution() {
 
 	String path = OS::get_singleton()->get_resource_dir();
 	String name = ProjectSettings::get_singleton()->get("application/config/name");
+	if (name.empty()) {
+		name = "UnnamedProject";
+	}
+
 	String guid = CSharpProject::generate_game_project(path, name);
 
 	if (guid.length()) {

--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -122,7 +122,14 @@ private:
 #ifdef TOOLS_ENABLED
 		mono_solutions_dir = mono_user_dir.plus_file("solutions");
 		build_logs_dir = mono_user_dir.plus_file("build_logs");
-		String base_path = String("res://") + ProjectSettings::get_singleton()->get("application/config/name");
+
+		String name = ProjectSettings::get_singleton()->get("application/config/name");
+		if (name.empty()) {
+			name = "UnnamedProject";
+		}
+
+		String base_path = String("res://") + name;
+
 		sln_filepath = ProjectSettings::get_singleton()->globalize_path(base_path + ".sln");
 		csproj_filepath = ProjectSettings::get_singleton()->globalize_path(base_path + ".csproj");
 #endif

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -369,9 +369,12 @@ bool GDMono::_load_project_assembly() {
 	if (project_assembly)
 		return true;
 
-	String project_assembly_name = ProjectSettings::get_singleton()->get("application/config/name");
+	String name = ProjectSettings::get_singleton()->get("application/config/name");
+	if (name.empty()) {
+		name = "UnnamedProject";
+	}
 
-	bool success = _load_assembly(project_assembly_name, &project_assembly);
+	bool success = _load_assembly(name, &project_assembly);
 
 	if (success)
 		mono_assembly_set_main(project_assembly->get_assembly());


### PR DESCRIPTION
Uses "UnnamedProject" for Mono when the application name is empty.

Other platforms already seem to handle an empty application name, checked all places I could find; e.g. Android uses "noname" instead.

Fixes #12427.