### PR TITLE
Fix file extensions persisting in file dialog after export

### DIFF
--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -717,6 +717,7 @@ void ProjectExportDialog::_export_project() {
 
 	export_project->set_access(FileDialog::ACCESS_FILESYSTEM);
 	export_project->clear_filters();
+	export_project->set_current_file(default_filename);
 	String extension = platform->get_binary_extension();
 	if (extension != String()) {
 		export_project->add_filter("*." + extension + " ; " + platform->get_name() + " Export");
@@ -726,6 +727,8 @@ void ProjectExportDialog::_export_project() {
 }
 
 void ProjectExportDialog::_export_project_to_path(const String &p_path) {
+	// Save this name for use in future exports (but drop the file extension)
+	default_filename = p_path.get_basename().get_file();
 
 	Ref<EditorExportPreset> current = EditorExport::get_singleton()->get_export_preset(presets->get_current());
 	ERR_FAIL_COND(current.is_null());
@@ -970,6 +973,8 @@ ProjectExportDialog::ProjectExportDialog() {
 	set_hide_on_ok(false);
 
 	editor_icons = "EditorIcons";
+
+	default_filename = String();
 }
 
 ProjectExportDialog::~ProjectExportDialog() {

--- a/editor/project_export.h
+++ b/editor/project_export.h
@@ -142,6 +142,8 @@ private:
 
 	void _tab_changed(int);
 
+	String default_filename;
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();


### PR DESCRIPTION
This caused issues if one decided to export many formats in a row. The new file extension would be appended to the previous one.

Now, the filename is retained without its extension for successive exports.

Fixes #7291

I could use a bit of review for this. I added a field to ProjectExportDialog to hold the filename, but stylistically I don't know where it belongs in the declaration.

Or let me know if there's a more-preferred solution. Thanks!