### PR TITLE
Fix get_node() and $ autocompletion when using single quotes

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -2476,6 +2476,11 @@ bool String::begins_with(const char *p_string) const {
 	return *p_string == 0;
 }
 
+bool String::is_enclosed_in(const String &p_string) const {
+
+	return begins_with(p_string) && ends_with(p_string);
+}
+
 bool String::is_subsequence_of(const String &p_string) const {
 
 	return _base_is_subsequence_of(p_string, false);
@@ -2484,6 +2489,11 @@ bool String::is_subsequence_of(const String &p_string) const {
 bool String::is_subsequence_ofi(const String &p_string) const {
 
 	return _base_is_subsequence_of(p_string, true);
+}
+
+bool String::is_quoted() const {
+
+	return is_enclosed_in("\"") || is_enclosed_in("'");
 }
 
 bool String::_base_is_subsequence_of(const String &p_string, bool case_insensitive) const {
@@ -3904,6 +3914,18 @@ String String::sprintf(const Array &values, bool *error) const {
 
 	*error = false;
 	return formatted;
+}
+
+String String::quote(String quotechar) const {
+	return quotechar + *this + quotechar;
+}
+
+String String::unquote() const {
+	if (!is_quoted()) {
+		return *this;
+	}
+
+	return substr(1, length() - 2);
 }
 
 #include "translation.h"

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -118,8 +118,10 @@ public:
 	bool begins_with(const String &p_string) const;
 	bool begins_with(const char *p_string) const;
 	bool ends_with(const String &p_string) const;
+	bool is_enclosed_in(const String &p_string) const;
 	bool is_subsequence_of(const String &p_string) const;
 	bool is_subsequence_ofi(const String &p_string) const;
+	bool is_quoted() const;
 	Vector<String> bigrams() const;
 	float similarity(const String &p_string) const;
 	String format(const Variant &values, String placeholder = "{_}") const;
@@ -132,6 +134,8 @@ public:
 	String lpad(int min_length, const String &character = " ") const;
 	String rpad(int min_length, const String &character = " ") const;
 	String sprintf(const Array &values, bool *error) const;
+	String quote(String quotechar = "\"") const;
+	String unquote() const;
 	static String num(double p_num, int p_decimals = -1);
 	static String num_scientific(double p_num);
 	static String num_real(double p_num);

--- a/modules/gdscript/gd_editor.cpp
+++ b/modules/gdscript/gd_editor.cpp
@@ -2111,9 +2111,9 @@ Error GDScriptLanguage::complete_code(const String &p_code, const String &p_base
 				for (List<String>::Element *E = opts.front(); E; E = E->next()) {
 
 					String opt = E->get().strip_edges();
-					if (opt.begins_with("\"") && opt.ends_with("\"")) {
+					if (opt.is_quoted()) {
 						r_forced = true;
-						String idopt = opt.substr(1, opt.length() - 2);
+						String idopt = opt.unquote();
 						if (idopt.replace("/", "_").is_valid_identifier()) {
 							options.insert(idopt);
 						} else {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4489,7 +4489,13 @@ void TextEdit::_update_completion_candidates() {
 	completion_index = 0;
 	completion_base = s;
 	Vector<float> sim_cache;
+	bool single_quote = s.begins_with("'");
+
 	for (int i = 0; i < completion_strings.size(); i++) {
+		if (single_quote && completion_strings[i].is_quoted()) {
+			completion_strings[i] = completion_strings[i].unquote().quote("'");
+		}
+
 		if (s == completion_strings[i]) {
 			// A perfect match, stop completion
 			_cancel_completion();


### PR DESCRIPTION
This fixes autocompletion when using single quotes as discussed in issue #9056.

Additionally, this adds the following new utility methods to `ustring`:

`bool String::is_enclosed_in(string)`
Returns whether the string starts and ends with the given string

`bool String::is_quoted()`
Returns whether the string is enclosed in either single or double quotes

`String String::quote(String quotechar)`
Returns the String enclosed by the given string, double quotes by default

`String String::unquote()`
Removes single or double quotes if the String is enclosed by them

No idea how to expose those to GDScript, though, any pointers?
They clean up the code in some places for the engine source though :)

Fixes  #9056.