### PR TITLE
Fix build with Python 3 on Windows

### DIFF
--- a/compat.py
+++ b/compat.py
@@ -12,6 +12,8 @@ if sys.version_info < (3,):
         return cStringIO.StringIO()
     def encode_utf8(x):
         return x
+    def decode_utf8(x):
+        return x
     def iteritems(d):
         return d.iteritems()
     def escape_string(s):
@@ -38,6 +40,8 @@ else:
     import codecs
     def encode_utf8(x):
         return codecs.utf_8_encode(x)[0]
+    def decode_utf8(x):
+        return codecs.utf_8_decode(x)[0]
     def iteritems(d):
         return iter(d.items())
     def charcode_to_c_escapes(c):

--- a/modules/mono/mono_reg_utils.py
+++ b/modules/mono/mono_reg_utils.py
@@ -1,6 +1,8 @@
 import os
 import platform
 
+from compat import decode_utf8
+
 if os.name == 'nt':
     import sys
     if sys.version_info < (3,):
@@ -12,7 +14,7 @@ if os.name == 'nt':
 def _reg_open_key(key, subkey):
     try:
         return winreg.OpenKey(key, subkey)
-    except WindowsError, OSError:
+    except (WindowsError, OSError):
         if platform.architecture()[0] == '32bit':
             bitness_sam = winreg.KEY_WOW64_64KEY
         else:
@@ -40,7 +42,7 @@ def _find_mono_in_reg(subkey, bits):
         with _reg_open_key_bits(winreg.HKEY_LOCAL_MACHINE, subkey, bits) as hKey:
             value, regtype = winreg.QueryValueEx(hKey, 'SdkInstallRoot')
             return value
-    except WindowsError, OSError:
+    except (WindowsError, OSError):
         return None
 
 
@@ -79,7 +81,7 @@ def find_msbuild_tools_path_reg():
         lines = subprocess.check_output([vswhere] + vswhere_args).splitlines()
 
         for line in lines:
-            parts = line.split(':', 1)
+            parts = decode_utf8(line).split(':', 1)
 
             if len(parts) < 2 or parts[0] != 'installationPath':
                 continue
@@ -96,7 +98,7 @@ def find_msbuild_tools_path_reg():
         print('Error reading output from vswhere: ' + e.message)
     except WindowsError:
         pass # Fine, vswhere not found
-    except subprocess.CalledProcessError, OSError:
+    except (subprocess.CalledProcessError, OSError):
         pass
 
     # Try to find 14.0 in the Registry
@@ -106,7 +108,7 @@ def find_msbuild_tools_path_reg():
         with _reg_open_key(winreg.HKEY_LOCAL_MACHINE, subkey) as hKey:
             value, regtype = winreg.QueryValueEx(hKey, 'MSBuildToolsPath')
             return value
-    except WindowsError, OSError:
+    except (WindowsError, OSError):
         return ''
 
     return ''


### PR DESCRIPTION
Fix some build issues with Pyton3/VS2017 on Windows 10:

- Python 3 doesn't allow multiple classes in `except` clauses unless they are contained in a tuple.
- A `string`/`bytes` incompatibility, as usual. I haven't checked whether converting to UTF-8 works if the path actually contains non-ASCII characters, or if the path has to be encoded in some strange Windows codepage to make this work. PEP 529 seems to indicate that, starting with Python 3.6, UTF-8 is the correct encoding, but I've only tested with the default path for `msbuild` and Python 3.6.  I would hope that `msbuild` is typically in a directory that doesn't have a weird name, but, well...