### PR TITLE
Add support for non-ISO "no" locale on Windows

### DIFF
--- a/core/translation.cpp
+++ b/core/translation.cpp
@@ -753,65 +753,17 @@ static const char *locale_names[] = {
 	0
 };
 
-bool TranslationServer::is_locale_valid(const String &p_locale) {
-
-	const char **ptr = locale_list;
-
-	while (*ptr) {
-
-		if (*ptr == p_locale)
-			return true;
-		ptr++;
-	}
-
-	return false;
-}
-
-Vector<String> TranslationServer::get_all_locales() {
-
-	Vector<String> locales;
-
-	const char **ptr = locale_list;
-
-	while (*ptr) {
-		locales.push_back(*ptr);
-		ptr++;
-	}
-
-	return locales;
-}
-
-Vector<String> TranslationServer::get_all_locale_names() {
-
-	Vector<String> locales;
-
-	const char **ptr = locale_names;
-
-	while (*ptr) {
-		locales.push_back(*ptr);
-		ptr++;
-	}
-
-	return locales;
-}
+static const char *locale_renames[][2] = {
+	{ "no", "nb" },
+	{ NULL, NULL }
+};
 
 static String get_trimmed_locale(const String &p_locale) {
 
 	return p_locale.substr(0, 2);
 }
 
-static bool is_valid_locale(const String &p_locale) {
-
-	const char **ptr = locale_list;
-
-	while (*ptr) {
-		if (p_locale == *ptr)
-			return true;
-		ptr++;
-	}
-
-	return false;
-}
+///////////////////////////////////////////////
 
 PoolVector<String> Translation::_get_messages() const {
 
@@ -857,14 +809,13 @@ void Translation::_set_messages(const PoolVector<String> &p_messages) {
 
 void Translation::set_locale(const String &p_locale) {
 
-	// replaces '-' with '_' for macOS Sierra-style locales
-	String univ_locale = p_locale.replace("-", "_");
+	String univ_locale = TranslationServer::standardize_locale(p_locale);
 
-	if (!is_valid_locale(univ_locale)) {
+	if (!TranslationServer::is_locale_valid(univ_locale)) {
 		String trimmed_locale = get_trimmed_locale(univ_locale);
 
-		ERR_EXPLAIN("Invalid Locale: " + trimmed_locale);
-		ERR_FAIL_COND(!is_valid_locale(trimmed_locale));
+		ERR_EXPLAIN("Invalid locale: " + trimmed_locale);
+		ERR_FAIL_COND(!TranslationServer::is_locale_valid(trimmed_locale));
 
 		locale = trimmed_locale;
 	} else {
@@ -929,16 +880,47 @@ Translation::Translation()
 
 ///////////////////////////////////////////////
 
-void TranslationServer::set_locale(const String &p_locale) {
+bool TranslationServer::is_locale_valid(const String &p_locale) {
 
-	// replaces '-' with '_' for macOS Sierra-style locales
+	const char **ptr = locale_list;
+
+	while (*ptr) {
+
+		if (*ptr == p_locale)
+			return true;
+		ptr++;
+	}
+
+	return false;
+}
+
+String TranslationServer::standardize_locale(const String &p_locale) {
+
+	// Replaces '-' with '_' for macOS Sierra-style locales
 	String univ_locale = p_locale.replace("-", "_");
 
-	if (!is_valid_locale(univ_locale)) {
+	// Handles known non-ISO locale names used e.g. on Windows
+	int idx = 0;
+	while (locale_renames[idx][0] != NULL) {
+		if (locale_renames[idx][0] == univ_locale) {
+			univ_locale = locale_renames[idx][1];
+			break;
+		}
+		idx++;
+	}
+
+	return univ_locale;
+}
+
+void TranslationServer::set_locale(const String &p_locale) {
+
+	String univ_locale = standardize_locale(p_locale);
+
+	if (!is_locale_valid(univ_locale)) {
 		String trimmed_locale = get_trimmed_locale(univ_locale);
 
-		ERR_EXPLAIN("Invalid Locale: " + trimmed_locale);
-		ERR_FAIL_COND(!is_valid_locale(trimmed_locale));
+		ERR_EXPLAIN("Invalid locale: " + trimmed_locale);
+		ERR_FAIL_COND(!is_locale_valid(trimmed_locale));
 
 		locale = trimmed_locale;
 	} else {
@@ -961,6 +943,34 @@ String TranslationServer::get_locale_name(const String &p_locale) const {
 
 	if (!locale_name_map.has(p_locale)) return String();
 	return locale_name_map[p_locale];
+}
+
+Vector<String> TranslationServer::get_all_locales() {
+
+	Vector<String> locales;
+
+	const char **ptr = locale_list;
+
+	while (*ptr) {
+		locales.push_back(*ptr);
+		ptr++;
+	}
+
+	return locales;
+}
+
+Vector<String> TranslationServer::get_all_locale_names() {
+
+	Vector<String> locales;
+
+	const char **ptr = locale_names;
+
+	while (*ptr) {
+		locales.push_back(*ptr);
+		ptr++;
+	}
+
+	return locales;
 }
 
 void TranslationServer::add_translation(const Ref<Translation> &p_translation) {

--- a/core/translation.h
+++ b/core/translation.h
@@ -85,8 +85,6 @@ class TranslationServer : public Object {
 public:
 	_FORCE_INLINE_ static TranslationServer *get_singleton() { return singleton; }
 
-	//yes, portuguese is supported!
-
 	void set_enabled(bool p_enabled) { enabled = p_enabled; }
 	_FORCE_INLINE_ bool is_enabled() const { return enabled; }
 
@@ -103,6 +101,7 @@ public:
 	static Vector<String> get_all_locales();
 	static Vector<String> get_all_locale_names();
 	static bool is_locale_valid(const String &p_locale);
+	static String standardize_locale(const String &p_locale);
 
 	void set_tool_translation(const Ref<Translation> &p_translation);
 	StringName tool_translate(const StringName &p_message) const;

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -544,6 +544,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	{
 		String lang_hint = "en";
 		String host_lang = OS::get_singleton()->get_locale();
+		host_lang = TranslationServer::standardize_locale(host_lang);
 
 		String best;
 


### PR DESCRIPTION
The ISO 639-1 language code is "nb", but Windows needs to mark its difference..
Fixes #12479.