### PR TITLE
Add interpolation qualifiers to shaders

### DIFF
--- a/drivers/gles3/shader_compiler_gles3.cpp
+++ b/drivers/gles3/shader_compiler_gles3.cpp
@@ -833,6 +833,10 @@ ShaderCompilerGLES3::ShaderCompilerGLES3() {
 	actions[VS::SHADER_SPATIAL].render_mode_defines["skip_vertex_transform"] = "#define SKIP_TRANSFORM_USED\n";
 	actions[VS::SHADER_SPATIAL].render_mode_defines["world_vertex_coords"] = "#define VERTEX_WORLD_COORDS_USED\n";
 
+	actions[VS::SHADER_SPATIAL].render_mode_defines["interpolation_flat"] = "#define INTERPOLATION_FLAT\n";
+	actions[VS::SHADER_SPATIAL].render_mode_defines["interpolation_smooth"] = "#define INTERPOLATION_SMOOTH\n";
+	actions[VS::SHADER_SPATIAL].render_mode_defines["interpolation_no_perspective"] = "#define INTERPOLATION_NO_PERSPECTIVE\n";
+
 	actions[VS::SHADER_SPATIAL].render_mode_defines["diffuse_burley"] = "#define DIFFUSE_BURLEY\n";
 	actions[VS::SHADER_SPATIAL].render_mode_defines["diffuse_oren_nayar"] = "#define DIFFUSE_OREN_NAYAR\n";
 	actions[VS::SHADER_SPATIAL].render_mode_defines["diffuse_lambert_wrap"] = "#define DIFFUSE_LAMBERT_WRAP\n";

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -215,7 +215,15 @@ out highp vec3 vertex_interp;
 out vec3 normal_interp;
 
 #if defined(ENABLE_COLOR_INTERP)
-out vec4 color_interp;
+	#if defined(INTERPOLATION_FLAT)
+		flat out vec4 color_interp;
+	#elif defined(INTERPOLATION_SMOOTH)
+		smooth out vec4 color_interp;
+	#elif defined(INTERPOLATION_NO_PERSPECTIVE)
+		noperspective out vec4 color_interp;
+	#else
+		out vec4 color_interp;
+	#endif
 #endif
 
 #if defined(ENABLE_UV_INTERP)
@@ -540,7 +548,15 @@ uniform highp mat4 world_transform;
 /* Varyings */
 
 #if defined(ENABLE_COLOR_INTERP)
-in vec4 color_interp;
+	#if defined(INTERPOLATION_FLAT)
+		flat in vec4 color_interp;
+	#elif defined(INTERPOLATION_SMOOTH)
+		smooth in vec4 color_interp;
+	#elif defined(INTERPOLATION_NO_PERSPECTIVE)
+		noperspective in vec4 color_interp;
+	#else
+		in vec4 color_interp;
+	#endif
 #endif
 
 #if defined(ENABLE_UV_INTERP)

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -364,6 +364,12 @@ void SpatialMaterial::_update_shader() {
 		case DEPTH_DRAW_ALPHA_OPAQUE_PREPASS: code += ",depth_draw_alpha_prepass"; break;
 	}
 
+	switch (interpolation_mode) {
+		case INTERPOLATION_FLAT: code += ",interpolation_flat"; break;
+		case INTERPOLATION_SMOOTH: code += ",interpolation_smooth"; break;
+		case INTERPOLATION_NO_PERSPECTIVE: code += ",interpolation_no_perspective"; break;
+	}
+
 	switch (cull_mode) {
 		case CULL_BACK: code += ",cull_back"; break;
 		case CULL_FRONT: code += ",cull_front"; break;
@@ -1129,6 +1135,19 @@ SpatialMaterial::BlendMode SpatialMaterial::get_blend_mode() const {
 	return blend_mode;
 }
 
+void SpatialMaterial::set_interpolation_mode(InterpolationMode p_mode) {
+
+	if (interpolation_mode == p_mode)
+		return;
+
+	interpolation_mode = p_mode;
+	_queue_shader_change();
+}
+SpatialMaterial::InterpolationMode SpatialMaterial::get_interpolation_mode() const {
+
+	return interpolation_mode;
+}
+
 void SpatialMaterial::set_detail_blend_mode(BlendMode p_mode) {
 
 	detail_blend_mode = p_mode;
@@ -1703,6 +1722,9 @@ void SpatialMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_blend_mode", "blend_mode"), &SpatialMaterial::set_blend_mode);
 	ClassDB::bind_method(D_METHOD("get_blend_mode"), &SpatialMaterial::get_blend_mode);
 
+	ClassDB::bind_method(D_METHOD("set_interpolation_mode", "interpolation_mode"), &SpatialMaterial::set_interpolation_mode);
+	ClassDB::bind_method(D_METHOD("get_interpolation_mode"), &SpatialMaterial::get_interpolation_mode);
+
 	ClassDB::bind_method(D_METHOD("set_depth_draw_mode", "depth_draw_mode"), &SpatialMaterial::set_depth_draw_mode);
 	ClassDB::bind_method(D_METHOD("get_depth_draw_mode"), &SpatialMaterial::get_depth_draw_mode);
 
@@ -1821,6 +1843,7 @@ void SpatialMaterial::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_diffuse_mode", PROPERTY_HINT_ENUM, "Burley,Lambert,Lambert Wrap,Oren Nayar,Toon"), "set_diffuse_mode", "get_diffuse_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_specular_mode", PROPERTY_HINT_ENUM, "SchlickGGX,Blinn,Phong,Toon,Disabled"), "set_specular_mode", "get_specular_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_blend_mode", PROPERTY_HINT_ENUM, "Mix,Add,Sub,Mul"), "set_blend_mode", "get_blend_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_interpolation_mode", PROPERTY_HINT_ENUM, "Smooth,Flat,No Perspective"), "set_interpolation_mode", "get_interpolation_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_cull_mode", PROPERTY_HINT_ENUM, "Back,Front,Disabled"), "set_cull_mode", "get_cull_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_depth_draw_mode", PROPERTY_HINT_ENUM, "Opaque Only,Always,Never,Opaque Pre-Pass"), "set_depth_draw_mode", "get_depth_draw_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "params_line_width", PROPERTY_HINT_RANGE, "0.1,128,0.1"), "set_line_width", "get_line_width");
@@ -1977,6 +2000,10 @@ void SpatialMaterial::_bind_methods() {
 	BIND_ENUM_CONSTANT(BLEND_MODE_SUB);
 	BIND_ENUM_CONSTANT(BLEND_MODE_MUL);
 
+	BIND_ENUM_CONSTANT(INTERPOLATION_SMOOTH);
+	BIND_ENUM_CONSTANT(INTERPOLATION_FLAT);
+	BIND_ENUM_CONSTANT(INTERPOLATION_NO_PERSPECTIVE);
+
 	BIND_ENUM_CONSTANT(DEPTH_DRAW_OPAQUE_ONLY);
 	BIND_ENUM_CONSTANT(DEPTH_DRAW_ALWAYS);
 	BIND_ENUM_CONSTANT(DEPTH_DRAW_DISABLED);
@@ -2080,6 +2107,7 @@ SpatialMaterial::SpatialMaterial()
 
 	detail_uv = DETAIL_UV_1;
 	blend_mode = BLEND_MODE_MIX;
+	interpolation_mode = INTERPOLATION_SMOOTH;
 	detail_blend_mode = BLEND_MODE_MIX;
 	depth_draw_mode = DEPTH_DRAW_OPAQUE_ONLY;
 	cull_mode = CULL_BACK;

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -147,6 +147,12 @@ public:
 		FEATURE_MAX
 	};
 
+	enum InterpolationMode {
+		INTERPOLATION_SMOOTH,
+		INTERPOLATION_FLAT,
+		INTERPOLATION_NO_PERSPECTIVE
+	};
+
 	enum BlendMode {
 		BLEND_MODE_MIX,
 		BLEND_MODE_ADD,
@@ -222,6 +228,7 @@ private:
 			uint64_t feature_mask : 12;
 			uint64_t detail_uv : 1;
 			uint64_t blend_mode : 2;
+			uint64_t interpolation_mode : 2;
 			uint64_t depth_draw_mode : 2;
 			uint64_t cull_mode : 2;
 			uint64_t flags : 12;
@@ -262,6 +269,7 @@ private:
 			}
 		}
 		mk.detail_uv = detail_uv;
+		mk.interpolation_mode = interpolation_mode;
 		mk.blend_mode = blend_mode;
 		mk.depth_draw_mode = depth_draw_mode;
 		mk.cull_mode = cull_mode;
@@ -386,6 +394,7 @@ private:
 	float distance_fade_max_distance;
 	float distance_fade_min_distance;
 
+	InterpolationMode interpolation_mode;
 	BlendMode blend_mode;
 	BlendMode detail_blend_mode;
 	DepthDrawMode depth_draw_mode;
@@ -489,6 +498,9 @@ public:
 
 	void set_blend_mode(BlendMode p_mode);
 	BlendMode get_blend_mode() const;
+
+	void set_interpolation_mode(InterpolationMode p_mode);
+	InterpolationMode get_interpolation_mode() const;
 
 	void set_detail_blend_mode(BlendMode p_mode);
 	BlendMode get_detail_blend_mode() const;
@@ -595,6 +607,7 @@ public:
 VARIANT_ENUM_CAST(SpatialMaterial::TextureParam)
 VARIANT_ENUM_CAST(SpatialMaterial::DetailUV)
 VARIANT_ENUM_CAST(SpatialMaterial::Feature)
+VARIANT_ENUM_CAST(SpatialMaterial::InterpolationMode)
 VARIANT_ENUM_CAST(SpatialMaterial::BlendMode)
 VARIANT_ENUM_CAST(SpatialMaterial::DepthDrawMode)
 VARIANT_ENUM_CAST(SpatialMaterial::CullMode)

--- a/servers/visual/shader_types.cpp
+++ b/servers/visual/shader_types.cpp
@@ -159,6 +159,10 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[VS::SHADER_SPATIAL].modes.insert("diffuse_burley");
 	shader_modes[VS::SHADER_SPATIAL].modes.insert("diffuse_toon");
 
+	shader_modes[VS::SHADER_SPATIAL].modes.insert("interpolation_flat");
+	shader_modes[VS::SHADER_SPATIAL].modes.insert("interpolation_smooth");
+	shader_modes[VS::SHADER_SPATIAL].modes.insert("interpolation_no_perspective");
+
 	shader_modes[VS::SHADER_SPATIAL].modes.insert("specular_schlick_ggx");
 	shader_modes[VS::SHADER_SPATIAL].modes.insert("specular_blinn");
 	shader_modes[VS::SHADER_SPATIAL].modes.insert("specular_phong");


### PR DESCRIPTION
Adds an option for [interpolation qualifiers](https://www.khronos.org/opengl/wiki/Type_Qualifier_(GLSL)#Interpolation_qualifiers) to spatial materials. 
Im not really experienced with this kind of stuff, so this might need some reviewing. :v: 