### PR TITLE
Allow to extends constant class variable

### DIFF
--- a/modules/gdscript/gd_compiler.cpp
+++ b/modules/gdscript/gd_compiler.cpp
@@ -1537,21 +1537,44 @@ Error GDCompiler::_parse_class(GDScript *p_script, GDScript *p_owner, const GDPa
 					base_class = p->subclasses[base];
 					break;
 				}
+
+				if (p->constants.has(base)) {
+
+					base_class = p->constants[base];
+					if (base_class.is_null()) {
+						_set_error("Constant not a class: " + base, p_class);
+						return ERR_SCRIPT_FAILED;
+					}
+					break;
+				}
+
 				p = p->_owner;
 			}
 
 			if (base_class.is_valid()) {
 
+				String ident = base;
+
 				for (int i = 1; i < p_class->extends_class.size(); i++) {
 
 					String subclass = p_class->extends_class[i];
 
+					ident += ("." + subclass);
+
 					if (base_class->subclasses.has(subclass)) {
 
 						base_class = base_class->subclasses[subclass];
+					} else if (base_class->constants.has(subclass)) {
+
+						Ref<GDScript> base = base_class->constants[subclass];
+						if (base.is_null()) {
+							_set_error("Constant not a class: " + ident, p_class);
+							return ERR_SCRIPT_FAILED;
+						}
+						base_class = base;
 					} else {
 
-						_set_error("Could not find subclass: " + subclass, p_class);
+						_set_error("Could not find subclass: " + ident, p_class);
 						return ERR_FILE_NOT_FOUND;
 					}
 				}

--- a/modules/gdscript/gd_parser.cpp
+++ b/modules/gdscript/gd_parser.cpp
@@ -2132,18 +2132,37 @@ void GDParser::_parse_extends(ClassNode *p_class) {
 	}
 
 	while (true) {
-		if (tokenizer->get_token() != GDTokenizer::TK_IDENTIFIER) {
 
-			_set_error("Invalid 'extends' syntax, expected string constant (path) and/or identifier (parent class).");
-			return;
+		switch (tokenizer->get_token()) {
+
+			case GDTokenizer::TK_IDENTIFIER: {
+
+					StringName identifier = tokenizer->get_token_identifier();
+					p_class->extends_class.push_back(identifier);
+				}
+				break;
+
+			case GDTokenizer::TK_PERIOD:
+				break;
+
+			default: {
+
+				_set_error("Invalid 'extends' syntax, expected string constant (path) and/or identifier (parent class).");
+				return;
+			}
 		}
 
-		StringName identifier = tokenizer->get_token_identifier();
-		p_class->extends_class.push_back(identifier);
-
 		tokenizer->advance(1);
-		if (tokenizer->get_token() != GDTokenizer::TK_PERIOD)
-			return;
+
+		switch (tokenizer->get_token()) {
+
+			case GDTokenizer::TK_IDENTIFIER:
+			case GDTokenizer::TK_PERIOD:
+				continue;
+
+			default:
+				return;
+		}
 	}
 }
 


### PR DESCRIPTION
Like this:

> subject.gd
```gdscript
class Slot:
    func _init(p_obj, p_cb, p_args):
        pass
```
> main.gd
```gdscript
const subject = preload("subject.gd")

class MySlot extends subject.Slot:
    func _init():
        pass
```

Or

```gdscript
const subject = preload("subject.gd")

class MySubject extends subject:
    func _init():
        pass
```
this pr may fixed: https://github.com/godotengine/godot/issues/10304
