### PR TITLE
Improved WASAPI driver logic when devices are connected or disconnected

### DIFF
--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -64,7 +64,7 @@ class AudioDriverWASAPI : public AudioDriver {
 
 	static void thread_func(void *p_udata);
 
-	Error init_device();
+	Error init_device(bool reinit = false);
 	Error finish_device();
 	Error reopen();
 

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -226,7 +226,7 @@ void AudioServer::_driver_process(int p_frames, int32_t *p_buffer) {
 		static int total = 0;
 
 		ticks = OS::get_singleton()->get_ticks_msec();
-		if ((ticks - first_ticks) > 10 * 1000) {
+		if ((ticks - first_ticks) > 10 * 1000 && count > 0) {
 			print_line("Audio Driver " + String(AudioDriver::get_singleton()->get_name()) + " average latency: " + itos(total / count) + "ms (frame=" + itos(p_frames) + ")");
 			first_ticks = ticks;
 			total = 0;


### PR DESCRIPTION
Fixes #12524.
After this, if there is no other issue with the WASAPI driver, I think we could retire the RtAudio driver.