### PR TITLE
Clear action name text input when the action is successfully added to the Input Map

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -876,6 +876,7 @@ void ProjectSettingsEditor::_action_add() {
 	r->select(0);
 	input_editor->ensure_cursor_is_visible();
 	action_add_error->hide();
+	action_name->clear();
 }
 
 void ProjectSettingsEditor::_item_checked(const String &p_item, bool p_check) {


### PR DESCRIPTION
When editing the Input Map under Project Settings:
Clear the action name when the 'Add' button is clicked and the action is
successfully added.