### PR TITLE
Add command line support to export pck or zip

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -378,7 +378,15 @@ void EditorNode::_fs_changed() {
 				// ensures export_project does not loop infinitely, because notifications may
 				// come during the export
 				export_defer.preset = "";
-				platform->export_project(preset, export_defer.debug, export_defer.path, /*p_flags*/ 0);
+				if (!preset->is_runnable() && (export_defer.path.ends_with(".pck") || export_defer.path.ends_with(".zip"))) {
+					if (export_defer.path.ends_with(".zip")) {
+						platform->save_zip(preset, export_defer.path);
+					} else if (export_defer.path.ends_with(".pck")) {
+						platform->save_pack(preset, export_defer.path);
+					}
+				} else {
+					platform->export_project(preset, export_defer.debug, export_defer.path, /*p_flags*/ 0);
+				}
 			}
 		}
 


### PR DESCRIPTION
Enable export to pck or zip from command-line in the same way as it realized in editor dialog

Fix #2923.