### PR TITLE
Adding rumble support to ARVR controllers

### DIFF
--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -5308,6 +5308,13 @@
         ["godot_real", "p_value"],
         ["godot_bool", "p_can_be_negative"]
       ]
+    },
+    {
+      "name": "godot_arvr_get_controller_rumble",
+      "return_type": "godot_real",
+      "arguments": [
+        ["godot_int", "p_controller_id"]
+      ]
     }
   ]
 }

--- a/modules/gdnative/include/nativearvr/godot_nativearvr.h
+++ b/modules/gdnative/include/nativearvr/godot_nativearvr.h
@@ -70,6 +70,7 @@ void GDAPI godot_arvr_remove_controller(godot_int p_controller_id);
 void GDAPI godot_arvr_set_controller_transform(godot_int p_controller_id, godot_transform *p_transform, godot_bool p_tracks_orientation, godot_bool p_tracks_position);
 void GDAPI godot_arvr_set_controller_button(godot_int p_controller_id, godot_int p_button, godot_bool p_is_pressed);
 void GDAPI godot_arvr_set_controller_axis(godot_int p_controller_id, godot_int p_axis, godot_real p_value, godot_bool p_can_be_negative);
+godot_real GDAPI godot_arvr_get_controller_rumble(godot_int p_controller_id);
 
 #ifdef __cplusplus
 }

--- a/modules/gdnative/nativearvr/arvr_interface_gdnative.cpp
+++ b/modules/gdnative/nativearvr/arvr_interface_gdnative.cpp
@@ -383,4 +383,16 @@ void GDAPI godot_arvr_set_controller_axis(godot_int p_controller_id, godot_int p
 		}
 	}
 }
+
+godot_real GDAPI godot_arvr_get_controller_rumble(godot_int p_controller_id) {
+	ARVRServer *arvr_server = ARVRServer::get_singleton();
+	ERR_FAIL_NULL_V(arvr_server, 0.0);
+
+	ARVRPositionalTracker *tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, p_controller_id);
+	if (tracker != NULL) {
+		return tracker->get_rumble();
+	}
+
+	return 0.0;
+}
 }

--- a/scene/3d/arvr_nodes.cpp
+++ b/scene/3d/arvr_nodes.cpp
@@ -231,7 +231,7 @@ void ARVRController::_notification(int p_what) {
 void ARVRController::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_controller_id", "controller_id"), &ARVRController::set_controller_id);
 	ClassDB::bind_method(D_METHOD("get_controller_id"), &ARVRController::get_controller_id);
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "controller_id"), "set_controller_id", "get_controller_id");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "controller_id", PROPERTY_HINT_RANGE, "1,32,1"), "set_controller_id", "get_controller_id");
 	ClassDB::bind_method(D_METHOD("get_controller_name"), &ARVRController::get_controller_name);
 
 	// passthroughs to information about our related joystick
@@ -241,6 +241,10 @@ void ARVRController::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_is_active"), &ARVRController::get_is_active);
 	ClassDB::bind_method(D_METHOD("get_hand"), &ARVRController::get_hand);
+
+	ClassDB::bind_method(D_METHOD("get_rumble"), &ARVRController::get_rumble);
+	ClassDB::bind_method(D_METHOD("set_rumble", "rumble"), &ARVRController::set_rumble);
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "rumble", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), "set_rumble", "get_rumble");
 
 	ADD_SIGNAL(MethodInfo("button_pressed", PropertyInfo(Variant::INT, "button")));
 	ADD_SIGNAL(MethodInfo("button_release", PropertyInfo(Variant::INT, "button")));
@@ -297,6 +301,30 @@ float ARVRController::get_joystick_axis(int p_axis) const {
 	};
 
 	return Input::get_singleton()->get_joy_axis(joy_id, p_axis);
+};
+
+real_t ARVRController::get_rumble() const {
+	// get our ARVRServer
+	ARVRServer *arvr_server = ARVRServer::get_singleton();
+	ERR_FAIL_NULL_V(arvr_server, 0.0);
+
+	ARVRPositionalTracker *tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, controller_id);
+	if (tracker == NULL) {
+		return 0.0;
+	};
+
+	return tracker->get_rumble();
+};
+
+void ARVRController::set_rumble(real_t p_rumble) {
+	// get our ARVRServer
+	ARVRServer *arvr_server = ARVRServer::get_singleton();
+	ERR_FAIL_NULL(arvr_server);
+
+	ARVRPositionalTracker *tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, controller_id);
+	if (tracker != NULL) {
+		tracker->set_rumble(p_rumble);
+	};
 };
 
 bool ARVRController::get_is_active() const {

--- a/scene/3d/arvr_nodes.h
+++ b/scene/3d/arvr_nodes.h
@@ -89,6 +89,9 @@ public:
 	int is_button_pressed(int p_button) const;
 	float get_joystick_axis(int p_axis) const;
 
+	real_t get_rumble() const;
+	void set_rumble(real_t p_rumble);
+
 	bool get_is_active() const;
 	ARVRPositionalTracker::TrackerHand get_hand() const;
 

--- a/servers/arvr/arvr_positional_tracker.cpp
+++ b/servers/arvr/arvr_positional_tracker.cpp
@@ -52,6 +52,11 @@ void ARVRPositionalTracker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_joy_id", "joy_id"), &ARVRPositionalTracker::set_joy_id);
 	ClassDB::bind_method(D_METHOD("_set_orientation", "orientation"), &ARVRPositionalTracker::set_orientation);
 	ClassDB::bind_method(D_METHOD("_set_rw_position", "rw_position"), &ARVRPositionalTracker::set_rw_position);
+
+	ClassDB::bind_method(D_METHOD("get_rumble"), &ARVRPositionalTracker::get_rumble);
+	ClassDB::bind_method(D_METHOD("set_rumble", "rumble"), &ARVRPositionalTracker::set_rumble);
+
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "rumble"), "set_rumble", "get_rumble");
 };
 
 void ARVRPositionalTracker::set_type(ARVRServer::TrackerType p_type) {
@@ -170,6 +175,18 @@ Transform ARVRPositionalTracker::get_transform(bool p_adjust_by_reference_frame)
 	return new_transform;
 };
 
+real_t ARVRPositionalTracker::get_rumble() const {
+	return rumble;
+};
+
+void ARVRPositionalTracker::set_rumble(real_t p_rumble) {
+	if (p_rumble > 0.0) {
+		rumble = p_rumble;
+	} else {
+		rumble = 0.0;
+	};
+};
+
 ARVRPositionalTracker::ARVRPositionalTracker() {
 	type = ARVRServer::TRACKER_UNKNOWN;
 	name = "Unknown";
@@ -178,6 +195,7 @@ ARVRPositionalTracker::ARVRPositionalTracker() {
 	tracks_orientation = false;
 	tracks_position = false;
 	hand = TRACKER_HAND_UNKNOWN;
+	rumble = 0.0;
 };
 
 ARVRPositionalTracker::~ARVRPositionalTracker(){

--- a/servers/arvr/arvr_positional_tracker.h
+++ b/servers/arvr/arvr_positional_tracker.h
@@ -65,6 +65,7 @@ private:
 	bool tracks_position; // do we track position?
 	Vector3 rw_position; // our position "in the real world, so without world_scale applied"
 	TrackerHand hand; // if known, the hand this tracker is held in
+	real_t rumble; // rumble strength, 0.0 is off, 1.0 is maximum, note that we only record here, arvr_interface is responsible for execution
 
 protected:
 	static void _bind_methods();
@@ -87,6 +88,8 @@ public:
 	Vector3 get_rw_position() const;
 	ARVRPositionalTracker::TrackerHand get_hand() const;
 	void set_hand(const ARVRPositionalTracker::TrackerHand p_hand);
+	real_t get_rumble() const;
+	void set_rumble(real_t p_rumble);
 
 	Transform get_transform(bool p_adjust_by_reference_frame) const;
 


### PR DESCRIPTION
This PR exposes a rumble setting on the ARVR controllers. The actual rumble needs to be implemented in the ARVR interface. The rumble can be set to a value between 0.0 (off) and 1.0 (on).

The accompanying change in the OpenVR plugin can be found here:
https://github.com/BastiaanOlij/godot_openvr/pull/5

There is one small enhancement still required for which I need access to OS.get_ticks_msec
@karroffel are you ok with me adding an api method to gdnative that returns this value? maybe godot_os_get_ticks_msec ?