### PR TITLE
Onion skinning

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -352,7 +352,7 @@ void RasterizerGLES3::blit_render_target_to_screen(RID p_render_target, const Re
 	canvas->canvas_end();
 }
 
-void RasterizerGLES3::end_frame() {
+void RasterizerGLES3::end_frame(bool p_swap_buffers) {
 
 #if 0
 	canvas->canvas_begin();
@@ -384,7 +384,10 @@ void RasterizerGLES3::end_frame() {
 
 	canvas->draw_generic_textured_rect(Rect2(0,0,15,15),Rect2(0,0,1,1));
 #endif
-	OS::get_singleton()->swap_buffers();
+	if (p_swap_buffers)
+		OS::get_singleton()->swap_buffers();
+	else
+		glFinish();
 
 	/*	print_line("objects: "+itos(storage->info.render_object_count));
 	print_line("material chages: "+itos(storage->info.render_material_switch_count));

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -59,7 +59,7 @@ public:
 	virtual void restore_render_target();
 	virtual void clear_render_target(const Color &p_color);
 	virtual void blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen = 0);
-	virtual void end_frame();
+	virtual void end_frame(bool p_swap_buffers);
 	virtual void finalize();
 
 	static void make_current();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5624,6 +5624,7 @@ EditorNode::EditorNode() {
 
 	editor_plugin_screen = NULL;
 	editor_plugins_over = memnew(EditorPluginList);
+	editor_plugins_force_over = memnew(EditorPluginList);
 	editor_plugins_force_input_forwarding = memnew(EditorPluginList);
 
 	_edit_current();
@@ -5748,6 +5749,7 @@ EditorNode::~EditorNode() {
 	memdelete(EditorHelp::get_doc_data());
 	memdelete(editor_selection);
 	memdelete(editor_plugins_over);
+	memdelete(editor_plugins_force_over);
 	memdelete(editor_plugins_force_input_forwarding);
 	memdelete(file_server);
 	memdelete(progress_hb);
@@ -5801,10 +5803,17 @@ bool EditorPluginList::forward_spatial_gui_input(Camera *p_camera, const Ref<Inp
 	return discard;
 }
 
-void EditorPluginList::forward_draw_over_canvas(Control *p_canvas) {
+void EditorPluginList::forward_draw_over_viewport(Control *p_overlay) {
 
 	for (int i = 0; i < plugins_list.size(); i++) {
-		plugins_list[i]->forward_draw_over_canvas(p_canvas);
+		plugins_list[i]->forward_draw_over_viewport(p_overlay);
+	}
+}
+
+void EditorPluginList::forward_force_draw_over_viewport(Control *p_overlay) {
+
+	for (int i = 0; i < plugins_list.size(); i++) {
+		plugins_list[i]->forward_force_draw_over_viewport(p_overlay);
 	}
 }
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -378,6 +378,7 @@ private:
 	Vector<EditorPlugin *> editor_plugins;
 	EditorPlugin *editor_plugin_screen;
 	EditorPluginList *editor_plugins_over;
+	EditorPluginList *editor_plugins_force_over;
 	EditorPluginList *editor_plugins_force_input_forwarding;
 
 	EditorHistory editor_history;
@@ -636,6 +637,7 @@ public:
 
 	EditorPlugin *get_editor_plugin_screen() { return editor_plugin_screen; }
 	EditorPluginList *get_editor_plugins_over() { return editor_plugins_over; }
+	EditorPluginList *get_editor_plugins_force_over() { return editor_plugins_force_over; }
 	EditorPluginList *get_editor_plugins_force_input_forwarding() { return editor_plugins_force_input_forwarding; }
 	PropertyEditor *get_property_editor() { return property_editor; }
 	VBoxContainer *get_property_editor_vb() { return prop_editor_vb; }
@@ -820,7 +822,8 @@ public:
 	void edit(Object *p_object);
 	bool forward_gui_input(const Ref<InputEvent> &p_event);
 	bool forward_spatial_gui_input(Camera *p_camera, const Ref<InputEvent> &p_event, bool serve_when_force_input_enabled);
-	void forward_draw_over_canvas(Control *p_canvas);
+	void forward_draw_over_viewport(Control *p_overlay);
+	void forward_force_draw_over_viewport(Control *p_overlay);
 	void add_plugin(EditorPlugin *p_plugin);
 	void clear();
 	bool empty();

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -102,6 +102,7 @@ class EditorPlugin : public Node {
 	UndoRedo *_get_undo_redo() { return undo_redo; }
 
 	bool input_event_forwarding_always_enabled;
+	bool force_draw_over_forwarding_enabled;
 
 	String last_main_screen_name;
 
@@ -151,13 +152,17 @@ public:
 	void set_input_event_forwarding_always_enabled();
 	bool is_input_event_forwarding_always_enabled() { return input_event_forwarding_always_enabled; }
 
+	void set_force_draw_over_forwarding_enabled();
+	bool is_force_draw_over_forwarding_enabled() { return force_draw_over_forwarding_enabled; }
+
 	void notify_main_screen_changed(const String &screen_name);
 	void notify_scene_changed(const Node *scn_root);
 	void notify_scene_closed(const String &scene_filepath);
 
 	virtual Ref<SpatialEditorGizmo> create_spatial_gizmo(Spatial *p_spatial);
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event);
-	virtual void forward_draw_over_canvas(Control *p_canvas);
+	virtual void forward_draw_over_viewport(Control *p_overlay);
+	virtual void forward_force_draw_over_viewport(Control *p_overlay);
 	virtual bool forward_spatial_gui_input(Camera *p_camera, const Ref<InputEvent> &p_event);
 	virtual String get_name() const;
 	virtual bool has_main_screen() const;
@@ -178,7 +183,7 @@ public:
 
 	EditorInterface *get_editor_interface();
 
-	void update_canvas();
+	int update_overlays() const;
 
 	void queue_save_layout() const;
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -462,6 +462,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	_initial_set("editors/animation/autorename_animation_tracks", true);
 	_initial_set("editors/animation/confirm_insert_track", true);
+	_initial_set("editors/animation/onion_layers_past_color", Color(1, 0, 0));
+	_initial_set("editors/animation/onion_layers_future_color", Color(0, 1, 0));
 
 	_initial_set("docks/property_editor/texture_preview_width", 48);
 	_initial_set("docks/property_editor/auto_refresh_interval", 0.3);

--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -490,7 +490,7 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 	return false;
 }
 
-void AbstractPolygon2DEditor::forward_draw_over_canvas(Control *p_canvas) {
+void AbstractPolygon2DEditor::forward_draw_over_viewport(Control *p_overlay) {
 	if (!_get_node())
 		return;
 

--- a/editor/plugins/abstract_polygon_2d_editor.h
+++ b/editor/plugins/abstract_polygon_2d_editor.h
@@ -136,7 +136,7 @@ protected:
 
 public:
 	bool forward_gui_input(const Ref<InputEvent> &p_event);
-	void forward_draw_over_canvas(Control *p_canvas);
+	void forward_draw_over_viewport(Control *p_overlay);
 
 	void edit(Node *p_polygon);
 	AbstractPolygon2DEditor(EditorNode *p_editor, bool p_wip_destructive = true);
@@ -152,7 +152,7 @@ class AbstractPolygon2DEditorPlugin : public EditorPlugin {
 
 public:
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) { return polygon_editor->forward_gui_input(p_event); }
-	virtual void forward_draw_over_canvas(Control *p_canvas) { polygon_editor->forward_draw_over_canvas(p_canvas); }
+	virtual void forward_draw_over_viewport(Control *p_overlay) { polygon_editor->forward_draw_over_viewport(p_overlay); }
 
 	bool has_main_screen() const { return false; }
 	virtual String get_name() const { return klass; }

--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -42,17 +42,32 @@
 	@author Juan Linietsky <reduzio@gmail.com>
 */
 class AnimationKeyEditor;
+class AnimationPlayerEditorPlugin;
 class AnimationPlayerEditor : public VBoxContainer {
 
 	GDCLASS(AnimationPlayerEditor, VBoxContainer);
 
 	EditorNode *editor;
+	AnimationPlayerEditorPlugin *plugin;
 	AnimationPlayer *player;
 
 	enum {
 		TOOL_COPY_ANIM,
 		TOOL_PASTE_ANIM,
 		TOOL_EDIT_RESOURCE
+	};
+
+	enum {
+		ONION_SKINNING_ENABLE,
+		ONION_SKINNING_PAST,
+		ONION_SKINNING_FUTURE,
+		ONION_SKINNING_1_STEP,
+		ONION_SKINNING_2_STEPS,
+		ONION_SKINNING_3_STEPS,
+		ONION_SKINNING_LAST_STEPS_OPTION = ONION_SKINNING_3_STEPS,
+		ONION_SKINNING_DIFFERENCES_ONLY,
+		ONION_SKINNING_FORCE_WHITE_MODULATE,
+		ONION_SKINNING_INCLUDE_GIZMOS,
 	};
 
 	enum {
@@ -84,6 +99,7 @@ class AnimationPlayerEditor : public VBoxContainer {
 	Button *blend_anim;
 	Button *remove_anim;
 	MenuButton *tool_anim;
+	MenuButton *onion_skinning;
 	ToolButton *pin;
 	SpinBox *frame;
 	LineEdit *scale;
@@ -114,6 +130,36 @@ class AnimationPlayerEditor : public VBoxContainer {
 	bool updating_blends;
 
 	AnimationKeyEditor *key_editor;
+
+	// Onion skinning
+	struct {
+		// Settings
+		bool enabled;
+		bool past;
+		bool future;
+		int steps;
+		bool differences_only;
+		bool force_white_modulate;
+		bool include_gizmos;
+
+		int get_needed_capture_count() const {
+			// 'Differences only' needs a capture of the present
+			return (past && future ? 2 * steps : steps) + (differences_only ? 1 : 0);
+		}
+
+		// Rendering
+		int64_t last_frame;
+		int can_overlay;
+		Size2 capture_size;
+		Vector<RID> captures;
+		Vector<bool> captures_valid;
+		struct {
+			RID canvas;
+			RID canvas_item;
+			Ref<ShaderMaterial> material;
+			Ref<Shader> shader;
+		} capture;
+	} onion;
 
 	void _select_anim_by_name(const String &p_anim);
 	void _play_pressed();
@@ -161,8 +207,19 @@ class AnimationPlayerEditor : public VBoxContainer {
 	void _unhandled_key_input(const Ref<InputEvent> &p_ev);
 	void _animation_tool_menu(int p_option);
 	void _animation_save_menu(int p_option);
+	void _onion_skinning_menu(int p_option);
+
+	void _editor_visibility_changed();
+	bool _are_onion_layers_valid();
+	void _allocate_onion_layers();
+	void _free_onion_layers();
+	void _prepare_onion_layers_1();
+	void _prepare_onion_layers_2();
+	void _start_onion_skinning();
+	void _stop_onion_skinning();
 
 	AnimationPlayerEditor();
+	~AnimationPlayerEditor();
 
 protected:
 	void _notification(int p_what);
@@ -182,7 +239,9 @@ public:
 
 	void set_undo_redo(UndoRedo *p_undo_redo) { undo_redo = p_undo_redo; }
 	void edit(AnimationPlayer *p_player);
-	AnimationPlayerEditor(EditorNode *p_editor);
+	void forward_force_draw_over_viewport(Control *p_overlay);
+
+	AnimationPlayerEditor(EditorNode *p_editor, AnimationPlayerEditorPlugin *p_plugin);
 };
 
 class AnimationPlayerEditorPlugin : public EditorPlugin {
@@ -191,6 +250,9 @@ class AnimationPlayerEditorPlugin : public EditorPlugin {
 
 	AnimationPlayerEditor *anim_editor;
 	EditorNode *editor;
+
+protected:
+	void _notification(int p_what);
 
 public:
 	virtual Dictionary get_state() const { return anim_editor->get_state(); }
@@ -201,6 +263,8 @@ public:
 	virtual void edit(Object *p_object);
 	virtual bool handles(Object *p_object) const;
 	virtual void make_visible(bool p_visible);
+
+	virtual void forward_force_draw_over_viewport(Control *p_overlay) { anim_editor->forward_force_draw_over_viewport(p_overlay); }
 
 	AnimationPlayerEditorPlugin(EditorNode *p_node);
 	~AnimationPlayerEditorPlugin();

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2955,8 +2955,13 @@ void CanvasItemEditor::_draw_viewport() {
 
 	EditorPluginList *over_plugin_list = editor->get_editor_plugins_over();
 	if (!over_plugin_list->empty()) {
-		over_plugin_list->forward_draw_over_canvas(viewport);
+		over_plugin_list->forward_draw_over_viewport(viewport);
 	}
+	EditorPluginList *force_over_plugin_list = editor->get_editor_plugins_force_over();
+	if (!force_over_plugin_list->empty()) {
+		force_over_plugin_list->forward_force_draw_over_viewport(viewport);
+	}
+
 	_draw_bones();
 }
 

--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -414,7 +414,7 @@ void CollisionShape2DEditor::_get_current_shape_type() {
 	canvas_item_editor->get_viewport_control()->update();
 }
 
-void CollisionShape2DEditor::forward_draw_over_canvas(Control *p_canvas) {
+void CollisionShape2DEditor::forward_draw_over_viewport(Control *p_overlay) {
 
 	if (!node) {
 		return;
@@ -448,8 +448,8 @@ void CollisionShape2DEditor::forward_draw_over_canvas(Control *p_canvas) {
 			handles[0] = Point2(radius, -height);
 			handles[1] = Point2(0, -(height + radius));
 
-			p_canvas->draw_texture(h, gt.xform(handles[0]) - size);
-			p_canvas->draw_texture(h, gt.xform(handles[1]) - size);
+			p_overlay->draw_texture(h, gt.xform(handles[0]) - size);
+			p_overlay->draw_texture(h, gt.xform(handles[1]) - size);
 
 		} break;
 
@@ -459,7 +459,7 @@ void CollisionShape2DEditor::forward_draw_over_canvas(Control *p_canvas) {
 			handles.resize(1);
 			handles[0] = Point2(shape->get_radius(), 0);
 
-			p_canvas->draw_texture(h, gt.xform(handles[0]) - size);
+			p_overlay->draw_texture(h, gt.xform(handles[0]) - size);
 
 		} break;
 
@@ -478,8 +478,8 @@ void CollisionShape2DEditor::forward_draw_over_canvas(Control *p_canvas) {
 			handles[0] = shape->get_normal() * shape->get_d();
 			handles[1] = shape->get_normal() * (shape->get_d() + 30.0);
 
-			p_canvas->draw_texture(h, gt.xform(handles[0]) - size);
-			p_canvas->draw_texture(h, gt.xform(handles[1]) - size);
+			p_overlay->draw_texture(h, gt.xform(handles[0]) - size);
+			p_overlay->draw_texture(h, gt.xform(handles[1]) - size);
 
 		} break;
 
@@ -489,7 +489,7 @@ void CollisionShape2DEditor::forward_draw_over_canvas(Control *p_canvas) {
 			handles.resize(1);
 			handles[0] = Point2(0, shape->get_length());
 
-			p_canvas->draw_texture(h, gt.xform(handles[0]) - size);
+			p_overlay->draw_texture(h, gt.xform(handles[0]) - size);
 
 		} break;
 
@@ -501,8 +501,8 @@ void CollisionShape2DEditor::forward_draw_over_canvas(Control *p_canvas) {
 			handles[0] = Point2(ext.x, 0);
 			handles[1] = Point2(0, -ext.y);
 
-			p_canvas->draw_texture(h, gt.xform(handles[0]) - size);
-			p_canvas->draw_texture(h, gt.xform(handles[1]) - size);
+			p_overlay->draw_texture(h, gt.xform(handles[0]) - size);
+			p_overlay->draw_texture(h, gt.xform(handles[1]) - size);
 
 		} break;
 
@@ -513,8 +513,8 @@ void CollisionShape2DEditor::forward_draw_over_canvas(Control *p_canvas) {
 			handles[0] = shape->get_a();
 			handles[1] = shape->get_b();
 
-			p_canvas->draw_texture(h, gt.xform(handles[0]) - size);
-			p_canvas->draw_texture(h, gt.xform(handles[1]) - size);
+			p_overlay->draw_texture(h, gt.xform(handles[0]) - size);
+			p_overlay->draw_texture(h, gt.xform(handles[1]) - size);
 
 		} break;
 	}

--- a/editor/plugins/collision_shape_2d_editor_plugin.h
+++ b/editor/plugins/collision_shape_2d_editor_plugin.h
@@ -74,7 +74,7 @@ protected:
 
 public:
 	bool forward_canvas_gui_input(const Ref<InputEvent> &p_event);
-	void forward_draw_over_canvas(Control *p_canvas);
+	void forward_draw_over_viewport(Control *p_overlay);
 	void edit(Node *p_node);
 
 	CollisionShape2DEditor(EditorNode *p_editor);
@@ -88,7 +88,7 @@ class CollisionShape2DEditorPlugin : public EditorPlugin {
 
 public:
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) { return collision_shape_2d_editor->forward_canvas_gui_input(p_event); }
-	virtual void forward_draw_over_canvas(Control *p_canvas) { return collision_shape_2d_editor->forward_draw_over_canvas(p_canvas); }
+	virtual void forward_draw_over_viewport(Control *p_overlay) { return collision_shape_2d_editor->forward_draw_over_viewport(p_overlay); }
 
 	virtual String get_name() const { return "CollisionShape2D"; }
 	bool has_main_screen() const { return false; }

--- a/editor/plugins/light_occluder_2d_editor_plugin.cpp
+++ b/editor/plugins/light_occluder_2d_editor_plugin.cpp
@@ -318,7 +318,7 @@ bool LightOccluder2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 	return false;
 }
 
-void LightOccluder2DEditor::forward_draw_over_canvas(Control *p_canvas) {
+void LightOccluder2DEditor::forward_draw_over_viewport(Control *p_overlay) {
 
 	if (!node || !node->get_occluder_polygon().is_valid())
 		return;

--- a/editor/plugins/light_occluder_2d_editor_plugin.h
+++ b/editor/plugins/light_occluder_2d_editor_plugin.h
@@ -82,7 +82,7 @@ protected:
 
 public:
 	Vector2 snap_point(const Vector2 &p_point) const;
-	void forward_draw_over_canvas(Control *p_canvas);
+	void forward_draw_over_viewport(Control *p_overlay);
 	bool forward_gui_input(const Ref<InputEvent> &p_event);
 	void edit(Node *p_collision_polygon);
 	LightOccluder2DEditor(EditorNode *p_editor);
@@ -97,7 +97,7 @@ class LightOccluder2DEditorPlugin : public EditorPlugin {
 
 public:
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) { return light_occluder_editor->forward_gui_input(p_event); }
-	virtual void forward_draw_over_canvas(Control *p_canvas) { return light_occluder_editor->forward_draw_over_canvas(p_canvas); }
+	virtual void forward_draw_over_viewport(Control *p_overlay) { return light_occluder_editor->forward_draw_over_viewport(p_overlay); }
 
 	virtual String get_name() const { return "LightOccluder2D"; }
 	bool has_main_screen() const { return false; }

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -269,7 +269,7 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 	return false;
 }
 
-void Path2DEditor::forward_draw_over_canvas(Control *p_canvas) {
+void Path2DEditor::forward_draw_over_viewport(Control *p_overlay) {
 
 	if (!node)
 		return;

--- a/editor/plugins/path_2d_editor_plugin.h
+++ b/editor/plugins/path_2d_editor_plugin.h
@@ -94,7 +94,7 @@ protected:
 
 public:
 	bool forward_gui_input(const Ref<InputEvent> &p_event);
-	void forward_draw_over_canvas(Control *p_canvas);
+	void forward_draw_over_viewport(Control *p_overlay);
 	void edit(Node *p_path2d);
 	Path2DEditor(EditorNode *p_editor);
 };
@@ -108,7 +108,7 @@ class Path2DEditorPlugin : public EditorPlugin {
 
 public:
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) { return path2d_editor->forward_gui_input(p_event); }
-	virtual void forward_draw_over_canvas(Control *p_canvas) { return path2d_editor->forward_draw_over_canvas(p_canvas); }
+	virtual void forward_draw_over_viewport(Control *p_overlay) { return path2d_editor->forward_draw_over_viewport(p_overlay); }
 
 	virtual String get_name() const { return "Path2D"; }
 	bool has_main_screen() const { return false; }

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -2332,6 +2332,16 @@ static void draw_indicator_bar(Control &surface, real_t fill, Ref<Texture> icon)
 
 void SpatialEditorViewport::_draw() {
 
+	EditorPluginList *over_plugin_list = EditorNode::get_singleton()->get_editor_plugins_over();
+	if (!over_plugin_list->empty()) {
+		over_plugin_list->forward_draw_over_viewport(surface);
+	}
+
+	EditorPluginList *force_over_plugin_list = editor->get_editor_plugins_force_over();
+	if (!force_over_plugin_list->empty()) {
+		force_over_plugin_list->forward_force_draw_over_viewport(surface);
+	}
+
 	if (surface->has_focus()) {
 		Size2 size = surface->get_size();
 		Rect2 r = Rect2(Point2(), size);

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -2849,6 +2849,20 @@ void SpatialEditorViewport::set_state(const Dictionary &p_state) {
 		camera->set_doppler_tracking(doppler ? Camera::DOPPLER_TRACKING_IDLE_STEP : Camera::DOPPLER_TRACKING_DISABLED);
 		view_menu->get_popup()->set_item_checked(idx, doppler);
 	}
+	if (p_state.has("gizmos")) {
+		bool gizmos = p_state["gizmos"];
+
+		int idx = view_menu->get_popup()->get_item_index(VIEW_GIZMOS);
+		if (view_menu->get_popup()->is_item_checked(idx) != gizmos)
+			_menu_option(VIEW_GIZMOS);
+	}
+	if (p_state.has("information")) {
+		bool information = p_state["information"];
+
+		int idx = view_menu->get_popup()->get_item_index(VIEW_INFORMATION);
+		if (view_menu->get_popup()->is_item_checked(idx) != information)
+			_menu_option(VIEW_INFORMATION);
+	}
 	if (p_state.has("half_res")) {
 		bool half_res = p_state["half_res"];
 
@@ -2880,6 +2894,9 @@ Dictionary SpatialEditorViewport::get_state() const {
 	d["use_environment"] = camera->get_environment().is_valid();
 	d["use_orthogonal"] = camera->get_projection() == Camera::PROJECTION_ORTHOGONAL;
 	d["listener"] = viewport->is_audio_listener();
+	d["doppler"] = view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(VIEW_AUDIO_DOPPLER));
+	d["gizmos"] = view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(VIEW_GIZMOS));
+	d["information"] = view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(VIEW_INFORMATION));
 	d["half_res"] = viewport_container->get_stretch_shrink() > 1;
 	if (previewing) {
 		d["previewing"] = EditorNode::get_singleton()->get_edited_scene()->get_path_to(previewing);

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -311,6 +311,7 @@ protected:
 	static void _bind_methods();
 
 public:
+	void update_surface() { surface->update(); }
 	void update_transform_gizmo_view();
 
 	void set_can_preview(Camera *p_preview);
@@ -389,6 +390,8 @@ class SpatialEditor : public VBoxContainer {
 	GDCLASS(SpatialEditor, VBoxContainer);
 
 public:
+	static const unsigned int VIEWPORTS_COUNT = 4;
+
 	enum ToolMode {
 
 		TOOL_MODE_SELECT,
@@ -403,8 +406,6 @@ public:
 	};
 
 private:
-	static const unsigned int VIEWPORTS_COUNT = 4;
-
 	EditorNode *editor;
 	EditorSelection *editor_selection;
 

--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -1183,7 +1183,7 @@ bool TileMapEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 	return false;
 }
 
-void TileMapEditor::forward_draw_over_canvas(Control *p_canvas) {
+void TileMapEditor::forward_draw_over_viewport(Control *p_overlay) {
 
 	if (!node)
 		return;

--- a/editor/plugins/tile_map_editor_plugin.h
+++ b/editor/plugins/tile_map_editor_plugin.h
@@ -184,7 +184,7 @@ public:
 	HBoxContainer *get_toolbar() const { return toolbar; }
 
 	bool forward_gui_input(const Ref<InputEvent> &p_event);
-	void forward_draw_over_canvas(Control *p_canvas);
+	void forward_draw_over_viewport(Control *p_overlay);
 
 	void edit(Node *p_tile_map);
 
@@ -200,7 +200,7 @@ class TileMapEditorPlugin : public EditorPlugin {
 
 public:
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) { return tile_map_editor->forward_gui_input(p_event); }
-	virtual void forward_draw_over_canvas(Control *p_canvas) { tile_map_editor->forward_draw_over_canvas(p_canvas); }
+	virtual void forward_draw_over_viewport(Control *p_overlay) { tile_map_editor->forward_draw_over_viewport(p_overlay); }
 
 	virtual String get_name() const { return "TileMap"; }
 	bool has_main_screen() const { return false; }

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -228,7 +228,11 @@ void AnimationPlayer::_notification(int p_what) {
 	}
 }
 
-void AnimationPlayer::_generate_node_caches(AnimationData *p_anim) {
+void AnimationPlayer::_ensure_node_caches(AnimationData *p_anim) {
+
+	// Already cached?
+	if (p_anim->node_cache.size() == p_anim->animation->get_track_count())
+		return;
 
 	Node *parent = get_node(root);
 
@@ -336,11 +340,7 @@ void AnimationPlayer::_generate_node_caches(AnimationData *p_anim) {
 
 void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, float p_time, float p_delta, float p_interp, bool p_allow_discrete) {
 
-	if (p_anim->node_cache.size() != p_anim->animation->get_track_count()) {
-		// animation hasn't been "node-cached"
-		_generate_node_caches(p_anim);
-	}
-
+	_ensure_node_caches(p_anim);
 	ERR_FAIL_COND(p_anim->node_cache.size() != p_anim->animation->get_track_count());
 
 	Animation *a = p_anim->animation.operator->();
@@ -1204,6 +1204,70 @@ void AnimationPlayer::get_argument_options(const StringName &p_function, int p_i
 	}
 	Node::get_argument_options(p_function, p_idx, r_options);
 }
+
+#ifdef TOOLS_ENABLED
+AnimatedValuesBackup AnimationPlayer::backup_animated_values() {
+
+	if (!playback.current.from)
+		return AnimatedValuesBackup();
+
+	_ensure_node_caches(playback.current.from);
+
+	AnimatedValuesBackup backup;
+
+	for (int i = 0; i < playback.current.from->node_cache.size(); i++) {
+		TrackNodeCache *nc = playback.current.from->node_cache[i];
+		if (!nc)
+			continue;
+
+		if (nc->skeleton) {
+			if (nc->bone_idx == -1)
+				continue;
+
+			AnimatedValuesBackup::Entry entry;
+			entry.object = nc->skeleton;
+			entry.bone_idx = nc->bone_idx;
+			entry.value = nc->skeleton->get_bone_pose(nc->bone_idx);
+			backup.entries.push_back(entry);
+		} else {
+			if (nc->spatial) {
+				AnimatedValuesBackup::Entry entry;
+				entry.object = nc->spatial;
+				entry.subpath.push_back("transform");
+				entry.value = nc->spatial->get_transform();
+				entry.bone_idx = -1;
+				backup.entries.push_back(entry);
+			} else {
+				for (Map<StringName, TrackNodeCache::PropertyAnim>::Element *E = nc->property_anim.front(); E; E = E->next()) {
+					AnimatedValuesBackup::Entry entry;
+					entry.object = E->value().object;
+					entry.subpath = E->value().subpath;
+					bool valid;
+					entry.value = E->value().object->get_indexed(E->value().subpath, &valid);
+					entry.bone_idx = -1;
+					if (valid)
+						backup.entries.push_back(entry);
+				}
+			}
+		}
+	}
+
+	return backup;
+}
+
+void AnimationPlayer::restore_animated_values(const AnimatedValuesBackup &p_backup) {
+
+	for (int i = 0; i < p_backup.entries.size(); i++) {
+
+		const AnimatedValuesBackup::Entry *entry = &p_backup.entries[i];
+		if (entry->bone_idx == -1) {
+			entry->object->set_indexed(entry->subpath, entry->value);
+		} else {
+			Object::cast_to<Skeleton>(entry->object)->set_bone_pose(entry->bone_idx, entry->value);
+		}
+	}
+}
+#endif
 
 void AnimationPlayer::_bind_methods() {
 

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -33,6 +33,17 @@
 #include "message_queue.h"
 #include "scene/scene_string_names.h"
 
+#ifdef TOOLS_ENABLED
+void AnimatedValuesBackup::update_skeletons() {
+
+	for (int i = 0; i < entries.size(); i++) {
+		if (entries[i].bone_idx != -1) {
+			Object::cast_to<Skeleton>(entries[i].object)->notification(Skeleton::NOTIFICATION_UPDATE_SKELETON);
+		}
+	}
+}
+#endif
+
 bool AnimationPlayer::_set(const StringName &p_name, const Variant &p_value) {
 
 	String name = p_name;

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -38,6 +38,21 @@
 	@author Juan Linietsky <reduzio@gmail.com>
 */
 
+#ifdef TOOLS_ENABLED
+// To save/restore animated values
+class AnimatedValuesBackup {
+	struct Entry {
+		Object *object;
+		Vector<StringName> subpath; // Unused if bone
+		int bone_idx; // -1 if not a bone
+		Variant value;
+	};
+	Vector<Entry> entries;
+
+	friend class AnimationPlayer;
+};
+#endif
+
 class AnimationPlayer : public Node {
 	GDCLASS(AnimationPlayer, Node);
 	OBJ_CATEGORY("Animation Nodes");
@@ -198,7 +213,7 @@ private:
 
 	void _animation_process_animation(AnimationData *p_anim, float p_time, float p_delta, float p_interp, bool p_allow_discrete = true);
 
-	void _generate_node_caches(AnimationData *p_anim);
+	void _ensure_node_caches(AnimationData *p_anim);
 	void _animation_process_data(PlaybackData &cd, float p_delta, float p_blend);
 	void _animation_process2(float p_delta);
 	void _animation_update_transforms();
@@ -290,6 +305,12 @@ public:
 	void clear_caches(); ///< must be called by hand if an animation was modified after added
 
 	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const;
+
+#ifdef TOOLS_ENABLED
+	// These may be interesting for games, but are too dangerous for general use
+	AnimatedValuesBackup backup_animated_values();
+	void restore_animated_values(const AnimatedValuesBackup &p_backup);
+#endif
 
 	AnimationPlayer();
 	~AnimationPlayer();

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -50,6 +50,9 @@ class AnimatedValuesBackup {
 	Vector<Entry> entries;
 
 	friend class AnimationPlayer;
+
+public:
+	void update_skeletons();
 };
 #endif
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -127,7 +127,7 @@ void SceneTree::remove_from_group(const StringName &p_group, Node *p_node) {
 		group_map.erase(E);
 }
 
-void SceneTree::_flush_transform_notifications() {
+void SceneTree::flush_transform_notifications() {
 
 	SelfList<Node> *n = xform_change_list.first();
 	while (n) {
@@ -448,7 +448,7 @@ bool SceneTree::iteration(float p_time) {
 
 	current_frame++;
 
-	_flush_transform_notifications();
+	flush_transform_notifications();
 
 	MainLoop::iteration(p_time);
 	physics_process_time = p_time;
@@ -459,7 +459,7 @@ bool SceneTree::iteration(float p_time) {
 	_notify_group_pause("physics_process", Node::NOTIFICATION_PHYSICS_PROCESS);
 	_flush_ugc();
 	MessageQueue::get_singleton()->flush(); //small little hack
-	_flush_transform_notifications();
+	flush_transform_notifications();
 	call_group_flags(GROUP_CALL_REALTIME, "_viewports", "update_worlds");
 	root_lock--;
 
@@ -487,7 +487,7 @@ bool SceneTree::idle(float p_time) {
 
 	MessageQueue::get_singleton()->flush(); //small little hack
 
-	_flush_transform_notifications();
+	flush_transform_notifications();
 
 	_notify_group_pause("idle_process_internal", Node::NOTIFICATION_INTERNAL_PROCESS);
 	_notify_group_pause("idle_process", Node::NOTIFICATION_PROCESS);
@@ -503,7 +503,7 @@ bool SceneTree::idle(float p_time) {
 
 	_flush_ugc();
 	MessageQueue::get_singleton()->flush(); //small little hack
-	_flush_transform_notifications(); //transforms after world update, to avoid unnecessary enter/exit notifications
+	flush_transform_notifications(); //transforms after world update, to avoid unnecessary enter/exit notifications
 	call_group_flags(GROUP_CALL_REALTIME, "_viewports", "update_worlds");
 
 	root_lock--;

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -157,7 +157,6 @@ private:
 	Map<UGCall, Vector<Variant> > unique_group_calls;
 	bool ugc_locked;
 	void _flush_ugc();
-	void _flush_transform_notifications();
 
 	_FORCE_INLINE_ void _update_group_order(Group &g);
 	void _update_listener();
@@ -343,6 +342,8 @@ public:
 	void call_group(const StringName &p_group, const StringName &p_function, VARIANT_ARG_LIST);
 	void notify_group(const StringName &p_group, int p_notification);
 	void set_group(const StringName &p_group, const String &p_name, const Variant &p_value);
+
+	void flush_transform_notifications();
 
 	virtual void input_text(const String &p_text);
 	virtual void input_event(const Ref<InputEvent> &p_event);

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -1027,7 +1027,7 @@ public:
 	virtual void restore_render_target() = 0;
 	virtual void clear_render_target(const Color &p_color) = 0;
 	virtual void blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen = 0) = 0;
-	virtual void end_frame() = 0;
+	virtual void end_frame(bool p_swap_buffers) = 0;
 	virtual void finalize() = 0;
 
 	virtual ~Rasterizer() {}

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -92,7 +92,7 @@ void VisualServerRaster::request_frame_drawn_callback(Object *p_where, const Str
 	frame_drawn_callbacks.push_back(fdc);
 }
 
-void VisualServerRaster::draw() {
+void VisualServerRaster::draw(bool p_swap_buffers) {
 
 	changes = 0;
 
@@ -103,7 +103,7 @@ void VisualServerRaster::draw() {
 	VSG::viewport->draw_viewports();
 	VSG::scene->render_probes();
 	_draw_margins();
-	VSG::rasterizer->end_frame();
+	VSG::rasterizer->end_frame(p_swap_buffers);
 
 	while (frame_drawn_callbacks.front()) {
 

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -77,8 +77,8 @@ class VisualServerRaster : public VisualServer {
 	static void _changes_changed() {}
 
 public:
-	//if editor is redrawing when it shouldn't, enable this and put a breakpoint in _changes_changed()
-	//#define DEBUG_CHANGES
+//if editor is redrawing when it shouldn't, enable this and put a breakpoint in _changes_changed()
+//#define DEBUG_CHANGES
 
 #ifdef DEBUG_CHANGES
 	_FORCE_INLINE_ static void redraw_request() {
@@ -96,7 +96,7 @@ public:
 #define DISPLAY_CHANGED \
 	changes++;
 #endif
-		//	print_line(String("CHANGED: ") + __FUNCTION__);
+//	print_line(String("CHANGED: ") + __FUNCTION__);
 
 #define BIND0R(m_r, m_name) \
 	m_r m_name() { return BINDBASE->m_name(); }
@@ -449,7 +449,7 @@ public:
 	BIND2R(int, viewport_get_render_info, RID, ViewportRenderInfo)
 	BIND2(viewport_set_debug_draw, RID, ViewportDebugDraw)
 
-	/* ENVIRONMENT API */
+/* ENVIRONMENT API */
 
 #undef BINDBASE
 //from now on, calls forwarded to this singleton
@@ -479,7 +479,7 @@ public:
 	BIND6(environment_set_fog_depth, RID, bool, float, float, bool, float)
 	BIND5(environment_set_fog_height, RID, bool, float, float, float)
 
-	/* SCENARIO API */
+/* SCENARIO API */
 
 #undef BINDBASE
 #define BINDBASE VSG::scene

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -625,7 +625,7 @@ public:
 
 	virtual void request_frame_drawn_callback(Object *p_where, const StringName &p_method, const Variant &p_userdata);
 
-	virtual void draw();
+	virtual void draw(bool p_swap_buffers);
 	virtual void sync();
 	virtual bool has_changed() const;
 	virtual void init();

--- a/servers/visual/visual_server_wrap_mt.cpp
+++ b/servers/visual/visual_server_wrap_mt.cpp
@@ -89,7 +89,7 @@ void VisualServerWrapMT::sync() {
 	}
 }
 
-void VisualServerWrapMT::draw() {
+void VisualServerWrapMT::draw(bool p_swap_buffers) {
 
 	if (create_thread) {
 
@@ -97,7 +97,7 @@ void VisualServerWrapMT::draw() {
 		command_queue.push(this, &VisualServerWrapMT::thread_draw);
 	} else {
 
-		visual_server->draw();
+		visual_server->draw(p_swap_buffers);
 	}
 }
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -62,7 +62,7 @@ class VisualServerWrapMT : public VisualServer {
 
 	int pool_max_size;
 
-	//#define DEBUG_SYNC
+//#define DEBUG_SYNC
 
 #ifdef DEBUG_SYNC
 #define SYNC_DEBUG print_line("sync on: " + String(__FUNCTION__));

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -542,7 +542,7 @@ public:
 
 	virtual void init();
 	virtual void finish();
-	virtual void draw();
+	virtual void draw(bool p_swap_buffers);
 	virtual void sync();
 	FUNC0RC(bool, has_changed)
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1481,7 +1481,7 @@ Array VisualServer::_mesh_surface_get_skeleton_aabb_bind(RID p_mesh, int p_surfa
 void VisualServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("force_sync"), &VisualServer::sync);
-	ClassDB::bind_method(D_METHOD("force_draw"), &VisualServer::draw);
+	ClassDB::bind_method(D_METHOD("force_draw"), &VisualServer::draw, DEFVAL(true));
 
 	ClassDB::bind_method(D_METHOD("texture_create"), &VisualServer::texture_create);
 	ClassDB::bind_method(D_METHOD("texture_create_from_image", "image", "flags"), &VisualServer::texture_create_from_image, DEFVAL(TEXTURE_FLAGS_DEFAULT));
@@ -1658,7 +1658,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("free", "rid"), &VisualServer::free);
 
 	ClassDB::bind_method(D_METHOD("request_frame_drawn_callback", "where", "method", "userdata"), &VisualServer::request_frame_drawn_callback);
-	ClassDB::bind_method(D_METHOD("draw"), &VisualServer::draw);
+	ClassDB::bind_method(D_METHOD("draw"), &VisualServer::draw, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("sync"), &VisualServer::sync);
 	ClassDB::bind_method(D_METHOD("has_changed"), &VisualServer::has_changed);
 	ClassDB::bind_method(D_METHOD("init"), &VisualServer::init);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -909,7 +909,7 @@ public:
 
 	/* EVENT QUEUING */
 
-	virtual void draw() = 0;
+	virtual void draw(bool p_swap_buffers = true) = 0;
 	virtual void sync() = 0;
 	virtual bool has_changed() const = 0;
 	virtual void init() = 0;


### PR DESCRIPTION
This allows you to see a ghosted view of the animated stuff a numbers of steps to the past or the future (based on the step value of the animation).

Some commits add some infrastructure to some areas of the engine, needed for this to be implemented on top of them.

It works better if the animated hierarchy is edited in a scene by itself because the background color is used as a hint to differentiate frames.

Closes #10425.

## Images

### Menu in the animation editor
(Nice onion icon by @djrm)

![onion-icon](https://user-images.githubusercontent.com/11797174/33038043-a763e6be-ce33-11e7-922b-d5ecec7e3cbf.png) ![onion-menu](https://user-images.githubusercontent.com/11797174/33038044-a9ad67a6-ce33-11e7-81e2-fa248d3e04af.png)

### Sample with 1-step depth, past & future
![onion](https://user-images.githubusercontent.com/11797174/32997870-b909ffe6-cd95-11e7-9380-60400de5a76e.gif)

### Sample with 3-step depth, only past, differences only
![onion-only-diff](https://user-images.githubusercontent.com/11797174/32997880-d056a280-cd95-11e7-8853-d03930c6d9bc.gif)

## Current limitations

- ~~It is always on (as long as the animation editor is visible). No UI to enable/disable or configure yet.~~
- ~~It's _very_ slow because I haven't found yet a way of working with viewport captures on VRAM.~~
- There isn't a way of seeing in realtime how the past state would be affected according to, e.g., the position of a node as you move it, until you really insert a keyframe or update the current one.
- The ghost view corresponds to one frame (engine loop frame) earlier. No big issue.

Anyway, please test and report or give suggestions.

**Spatial transform and bone transform are handled separately so it'd be nice that testers tried on these kind of properties specifically.**

## Changelog

**UPDATED 11/06**
- Viewport capture achieved and easily extensible to more past and/or future frames.

**UPDATED 11/09**
- Menu added to the animation editor. *I need a nice onion icon for it.* Currently it allows to enable/disable, but the direction and depth settings are ignored.
- Works for 3D as well.

**UPDATED 11/13**
- Now every option in the onion skinning menu work.
- Editor settings for past/future colors added.
- Some images added to the post.
- Description edited.

**UPDATED 11/18**
- Better shader.
- Much less VRAM use.
- Images updated.

**UPDATED 11/20**
- Editor stuff like grids, guides, etc. removed from the onion layer for a less cluttered view.
- That also applies to environment to keep the viewport clear color as the background as far as possible, since it's the base for the differentiation.
- New _Differences only_ mode, better described by the second animated sample above. Makes the layering much less noisy if enabled.
- Images updated.

**UPDATED 11/20 (2)**
- Added two more settings: force white modulate to override the colors for past/future in editor settings and include gizmos (3D) to have bones and other stuff in onion layers,
- Menu image updated.