### PR TITLE
Fixed RichTextLabel::add_newline() Fixes #12564

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1195,8 +1195,9 @@ void RichTextLabel::add_newline() {
 		return;
 	ItemNewline *item = memnew(ItemNewline);
 	item->line = current_frame->lines.size();
-	current_frame->lines.resize(current_frame->lines.size() + 1);
 	_add_item(item, false);
+	current_frame->lines.resize(current_frame->lines.size() + 1);
+	_invalidate_current_line(current_frame);
 }
 
 bool RichTextLabel::remove_line(const int p_line) {


### PR DESCRIPTION
Fixes #12564

![screenshot_20171102_084503](https://user-images.githubusercontent.com/185322/32304497-b23c7958-bfaa-11e7-9123-99f3518965e6.png)

You could recreate this in *any* RichTextLabel with:

    extends RichTextLabel
    func _ready():
        push_color(Color(0, 0, 0))
        add_text("abc\n")
        pop()
        newline();
        add_text("def\n")
        push_color(Color(0, 0, 0))
        add_text("ghi")
        pop()