### PR TITLE
Moved paragraph spacing to XML files in help docs

### DIFF
--- a/doc/classes/@GDScript.xml
+++ b/doc/classes/@GDScript.xml
@@ -24,10 +24,12 @@
 			</argument>
 			<description>
 				Returns a 32 bit color with red, green, blue and alpha channels. Each channel has 8 bits of information ranging from 0 to 255.
+
 				[code]r8[/code] red channel
 				[code]g8[/code] green channel
 				[code]b8[/code] blue channel
 				[code]a8[/code] alpha channel
+
 				[codeblock]
 				red = Color8(255, 0, 0)
 				[/codeblock]
@@ -42,6 +44,7 @@
 			</argument>
 			<description>
 				Returns color [code]name[/code] with [code]alpha[/code] ranging from 0 to 1. Note: [code]name[/code] is defined in color_names.inc.
+
 				[codeblock]
 				red = ColorN('red')
 				[/codeblock]
@@ -54,6 +57,7 @@
 			</argument>
 			<description>
 				Returns the absolute value of parameter [code]s[/code]  (i.e. unsigned value, works for integer and float).
+
 				[codeblock]
 				# a is 1
 				a = abs(-1)
@@ -67,6 +71,7 @@
 			</argument>
 			<description>
 				Returns the arc cosine of [code]s[/code] in radians. Use to get the angle of cosine [code]s[/code].
+
 				[codeblock]
 				# c is 0.523599 or 30 degrees if converted with rad2deg(s)
 				c = acos(0.866025)
@@ -80,6 +85,7 @@
 			</argument>
 			<description>
 				Returns the arc sine of [code]s[/code] in radians. Use to get the angle of sine [code]s[/code].
+
 				[codeblock]
 				# s is 0.523599 or 30 degrees if converted with rad2deg(s)
 				s = asin(0.5)
@@ -93,6 +99,7 @@
 			</argument>
 			<description>
 				Assert that the [code]condition[/code] is true. If the [code]condition[/code] is false a fatal error is generated and the program is halted. Useful for debugging to make sure a value is always true.
+
 				[codeblock]
 				# Speed should always be between 0 and 20
 				speed = -10
@@ -109,6 +116,7 @@
 			</argument>
 			<description>
 				Returns the arc tangent of [code]s[/code] in radians. Use it to get the angle from an angle's tangent in trigonometry: [code]atan(tan(angle)) == angle[/code].
+
 				The method cannot know in which quadrant the angle should fall. See [method atan2] if you always want an exact angle.
 				[codeblock]
 				a = atan(0.5) # a is 0.463648
@@ -177,6 +185,7 @@
 			</argument>
 			<description>
 				Clamps [code]val[/code] and returns a value not less than [code]min[/code] and not more than [code]max[/code].
+
 				[codeblock]
 				speed = 1000
 				# a is 20
@@ -361,9 +370,10 @@
 				[codeblock]
 				var i = -10;
 				while i &lt; 0:
-				    prints(i, fposmod(i, 10))
-				    i += 1
+					prints(i, fposmod(i, 10))
+					i += 1
 				[/codeblock]
+
 				Produces:
 				[codeblock]
 				-10 10
@@ -390,7 +400,7 @@
 				Returns a reference to the specified function [code]funcname[/code] in the [code]instance[/code] node. As functions aren't first-class objects in GDscript, use [code]funcref[/code] to store a [FuncRef] in a variable and call it later.
 				[codeblock]
 				func foo():
-				    return("bar")
+					return("bar")
 
 				a = funcref(self, "foo")
 				print(a.call_func()) # prints bar
@@ -419,10 +429,11 @@
 				[codeblock]
 				var foo = "bar"
 				func _ready():
-				    var d = inst2dict(self)
-				    print(d.keys())
-				    print(d.values())
+					var d = inst2dict(self)
+					print(d.keys())
+					print(d.values())
 				[/codeblock]
+
 				Prints out:
 				[codeblock]
 				[@subpath, @path, foo]
@@ -440,9 +451,9 @@
 				[codeblock]
 				var foo = "bar"
 				func _ready():
-				    var id = get_instance_id()
-				    var inst = instance_from_id(id)
-				    print(inst.foo) # prints bar
+					var id = get_instance_id()
+					var inst = instance_from_id(id)
+					print(inst.foo) # prints bar
 				[/codeblock]
 			</description>
 		</method>
@@ -594,13 +605,14 @@
 			</argument>
 			<description>
 				Parse JSON text to a Variant (use [method typeof] to check if it is what you expect).
+
 				Be aware that the JSON specification does not define integer or float types, but only a number type. Therefore, parsing a JSON text will convert all numerical values to [float] types.
 				[codeblock]
 				p = parse_json('["a", "b", "c"]')
 				if typeof(p) == TYPE_ARRAY:
-				    print(p[0]) # prints a
+					print(p[0]) # prints a
 				else:
-				    print("unexpected results")
+					print("unexpected results")
 				[/codeblock]
 			</description>
 		</method>
@@ -647,6 +659,7 @@
 			</return>
 			<description>
 				Prints a stack track at code location, only works when running with debugger turned on.
+
 				Output in the console would look something like this:
 				[codeblock]
 				Frame 0 - res://test.gd:16 in function '_process'
@@ -759,7 +772,7 @@
 				Randomizes the seed (or the internal state) of the random number generator. Current implementation reseeds using a number based on time.
 				[codeblock]
 				func _ready():
-				    randomize()
+					randomize()
 				[/codeblock]
 			</description>
 		</method>
@@ -770,12 +783,13 @@
 				Returns an array with the given range. Range can be 1 argument N (0 to N-1), two arguments (initial, final-1) or three arguments (initial, final-1, increment).
 				[codeblock]
 				for i in range(4):
-				    print(i)
+					print(i)
 				for i in range(2, 5):
-				    print(i)
+					print(i)
 				for i in range(0, 6, 2):
-				    print(i)
+					print(i)
 				[/codeblock]
+
 				Output:
 				[codeblock]
 				0
@@ -988,9 +1002,9 @@
 				[codeblock]
 				p = parse_json('["a", "b", "c"]')
 				if typeof(p) == TYPE_ARRAY:
-				    print(p[0]) # prints a
+					print(p[0]) # prints a
 				else:
-				    print("unexpected results")
+					print("unexpected results")
 				[/codeblock]
 			</description>
 		</method>
@@ -1005,9 +1019,9 @@
 				j = to_json([1, 2, 3])
 				v = validate_json(j)
 				if not v:
-				    print("valid")
+					print("valid")
 				else:
-				    prints("invalid", v)
+					prints("invalid", v)
 				[/codeblock]
 			</description>
 		</method>
@@ -1031,7 +1045,8 @@
 				a = { 'a': 1, 'b': 2 }
 				print(var2str(a))
 				[/codeblock]
-				prints
+
+				Prints:
 				[codeblock]
 				{
 				"a": 1,
@@ -1047,6 +1062,7 @@
 			</argument>
 			<description>
 				Returns a weak reference to an object.
+
 				A weak reference to an object is not enough to keep the object alive: when the only remaining references to a referent are weak references, garbage collection is free to destroy the referent and reuse its memory for something else. However, until the object is actually destroyed the weak reference may return the object even if there are no strong references to it.
 			</description>
 		</method>
@@ -1059,6 +1075,7 @@
 			</argument>
 			<description>
 				Stops the function execution and returns the current state. Call [method GDFunctionState.resume] on the state to resume execution. This invalidates the state.
+
 				Returns anything that was passed to the resume function call. If passed an object and a signal, the execution is resumed when the object's signal is emitted.
 			</description>
 		</method>
@@ -1072,6 +1089,7 @@
 		</constant>
 		<constant name="NAN" value="nan" enum="">
 			Macro constant that expands to an expression of type float that represents a NaN.
+
 			The NaN values are used to identify undefined or non-representable values for floating-point elements, such as the square root of negative numbers or the result of 0/0.
 		</constant>
 	</constants>

--- a/doc/classes/@Global Scope.xml
+++ b/doc/classes/@Global Scope.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Global scope constants and variables. This is all that resides in the globals, constants regarding error codes, scancodes, property hints, etc. It's not much.
+
 		Singletons are also documented here, since they can be accessed from anywhere.
 	</description>
 	<tutorials>

--- a/doc/classes/ARVRAnchor.xml
+++ b/doc/classes/ARVRAnchor.xml
@@ -5,7 +5,9 @@
 	</brief_description>
 	<description>
 		The ARVR Anchor point is a spatial node that maps a real world location identified by the AR platform to a position within the game world. For example, as long as plane detection in ARKit is on, ARKit will identify and update the position of planes (tables, floors, etc) and create anchors for them.
+
 		This node is mapped to one of the anchors through its unique id. When you receive a signal that a new anchor is available you should add this node to your scene for that anchor. You can predefine nodes and set the id and the nodes will simply remain on 0,0,0 until a plane is recognised.
+
 		Keep in mind that as long as plane detection is enable the size, placing and orientation of an anchor will be updates as the detection logic learns more about the real world out there especially if only part of the surface is in view.
 	</description>
 	<tutorials>

--- a/doc/classes/ARVRCamera.xml
+++ b/doc/classes/ARVRCamera.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		This is a helper spatial node for our camera, note that if stereoscopic rendering is applicable (VR-HMD) most of the camera properties are ignored as the HMD information overrides them. The only properties that can be trusted are the near and far planes.
+
 		The position and orientation of this node is automatically updated by the ARVR Server to represent the location of the HMD if such tracking is available and can thus be used by game logic. Note that in contrast to the ARVR Controller the render thread has access to the most up to date tracking data of the HMD and the location of the ARVRCamera can lag a few milliseconds behind what is used for rendering as a result.
 	</description>
 	<tutorials>

--- a/doc/classes/ARVRController.xml
+++ b/doc/classes/ARVRController.xml
@@ -5,7 +5,9 @@
 	</brief_description>
 	<description>
 		This is a helper spatial node that is linked to the tracking of controllers. It also offers several handy pass throughs to the state of buttons and such on the controllers.
+
 		Controllers are linked by their id. You can create controller nodes before the controllers are available. Say your game always uses two controllers (one for each hand) you can predefine the controllers with id 1 and 2 and they will become active as soon as the controllers are identified. If you expect additional controllers to be used you should react to the signals and add ARVRController nodes to your scene.
+
 		The position of the controller node is automatically updated by the ARVR Server. This makes this node ideal to add child  nodes to visualise the controller.
 	</description>
 	<tutorials>

--- a/doc/classes/ARVRInterface.xml
+++ b/doc/classes/ARVRInterface.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		This class needs to be implemented to make an AR or VR platform available to Godot and these should be implemented as C++ modules or GDNative modules (note that for GDNative the subclass ARVRScriptInterface should be used). Part of the interface is exposed to GDScript so you can detect, enable and configure an AR or VR platform.
+
 		Interfaces should be written in such a way that simply enabling them will give us a working setup. You can query the available interfaces through ARVRServer.
 	</description>
 	<tutorials>
@@ -52,9 +53,11 @@
 			</return>
 			<description>
 				Call this to initialize this interface. The first interface that is initialized is identified as the primary interface and it will be used for rendering output.
-				After initializing the interface you want to use you then need to enable the AR/VR mode of a viewport and rendering should commence. 
-				Note that you must enable the AR/VR mode on the main viewport for any device that uses the main output of Godot such as for mobile VR. 
-				If you do this for a platform that handles its own output (such as OpenVR) Godot will show just one eye without distortion on screen. Alternatively you can add a separate viewport node to your scene and enable AR/VR on that viewport and it will be used to output to the HMD leaving you free to do anything you like in the main window such as using a separate camera as a spectator camera or render out something completely different.
+
+				After initializing the interface you want to use you then need to enable the AR/VR mode of a viewport and rendering should commence.
+
+				Note that you must enable the AR/VR mode on the main viewport for any device that uses the main output of Godot such as for mobile VR. If you do this for a platform that handles its own output (such as OpenVR) Godot will show just one eye without distortion on screen. Alternatively you can add a separate viewport node to your scene and enable AR/VR on that viewport and it will be used to output to the HMD leaving you free to do anything you like in the main window such as using a separate camera as a spectator camera or render out something completely different.
+
 				While currently not used you can activate additional interfaces, you may wish to do this if you want to track controllers from other platforms. However at this point in time only one interface can render to an HMD.
 			</description>
 		</method>

--- a/doc/classes/ARVROrigin.xml
+++ b/doc/classes/ARVROrigin.xml
@@ -5,8 +5,9 @@
 	</brief_description>
 	<description>
 		This is a special node within the AR/VR system that maps the physical location of the center of our tracking space to the virtual location within our game world.
-		There should be only one of these nodes in your scene and you must have one. All the ARVRCamera, ARVRController and ARVRAnchor nodes should be direct children of this node for spatial tracking to work correctly.
-		It is the position of this node that you update when you're character needs to move through your game world while we're not moving in the real world. Movement in the real world is always in relation to this origin point.
+
+		There should be only one of these nodes in your scene and you must have one. All the ARVRCamera, ARVRController and ARVRAnchor nodes should be direct children of this node for spatial tracking to work correctly. It is the position of this node that you update when you're character needs to move through your game world while we're not moving in the real world. Movement in the real world is always in relation to this origin point.
+
 		So say that your character is driving a car, the ARVROrigin node should be a child node of this car. If you implement a teleport system to move your character, you change the position of this node. Etc.
 	</description>
 	<tutorials>
@@ -28,7 +29,9 @@
 			</argument>
 			<description>
 				Changes the world scaling factor.
+
 				Most AR/VR platforms will assume a unit size of 1 unit in your game world = 1 meter in the real world. This scale allows you to adjust this to the unit system you use in your game. 
+
 				Note that this method is a passthrough to the ARVRServer itself.
 			</description>
 		</method>
@@ -36,6 +39,7 @@
 	<members>
 		<member name="world_scale" type="float" setter="set_world_scale" getter="get_world_scale">
 			Allows you to adjust the scale to your game's units. Most AR/VR platforms assume a scale of 1 game world unit = 1 meter in the real world.
+
 			Note that this method is a passthrough to the [ARVRServer] itself.
 		</member>
 	</members>

--- a/doc/classes/ARVRPositionalTracker.xml
+++ b/doc/classes/ARVRPositionalTracker.xml
@@ -5,7 +5,9 @@
 	</brief_description>
 	<description>
 		An instance of this object represents a device that is tracked such as a controller or anchor point. HMDs aren't represented here as they are fully handled internally.
-		As controllers are turned on and the AR/VR interface detects them instances of this object are automatically added to this list of active tracking objects accessible through the ARVRServer
+
+		As controllers are turned on and the AR/VR interface detects them instances of this object are automatically added to this list of active tracking objects accessible through the ARVRServer.
+
 		The ARVRController and ARVRAnchor both consume objects of this type and should be the objects you use in game. The positional trackers are just the under the hood objects that make this all work and are mostly exposed so GDNative based interfaces can interact with them.
 	</description>
 	<tutorials>

--- a/doc/classes/ARVRServer.xml
+++ b/doc/classes/ARVRServer.xml
@@ -29,10 +29,15 @@
 			</argument>
 			<description>
 				This is a really important function to understand correctly. AR and VR platforms all handle positioning slightly differently.
+
 				For platforms that do not offer spatial tracking our origin point (0,0,0) is the location of our HMD but you have little control over the direction the player is facing in the real world.
+
 				For platforms that do offer spatial tracking our origin point depends very much on the system. For OpenVR our origin point is usually the center of the tracking space, on the ground. For other platforms its often the location of the tracking camera.
+
 				This method allows you to center our tracker on the location of the HMD, it will take the current location of the HMD and use that to adjust all our tracking data in essence realigning the real world to your players current position in your game world.
+
 				For this method to produce usable results tracking information should be available and this often takes a few frames after starting your game.
+
 				You should call this method after a few seconds have passed, when the user requests a realignment of the display holding a designated button on a controller for a short period of time, and when implementing a teleport mechanism.
 			</description>
 		</method>

--- a/doc/classes/AStar.xml
+++ b/doc/classes/AStar.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A* (A star) is a computer algorithm that is widely used in pathfinding and graph traversal, the process of plotting an efficiently directed path between multiple points. It enjoys widespread use due to its performance and accuracy. Godot's A* implementation make use of vectors as points.
+
 		You must add points manually with [method AStar.add_point] and create segments manually with [method AStar.connect_points]. So you can test if there is a path between two points with the [method AStar.are_points_connected] function, get the list of existing ids in the found path with [method AStar.get_id_path], or the points list with [method AStar.get_point_path].
 	</description>
 	<tutorials>
@@ -47,9 +48,10 @@
 				Adds a new point at the given position with the given identifier. The algorithm prefers points with lower [code]weight_scale[/code] to form a path. The [code]id[/code] must be 0 or larger, and the [code]weight_scale[/code] must be 1 or larger.
 				[codeblock]
 				var as = AStar.new()
-				
+
 				as.add_point(1, Vector3(1,0,0), 4) # Adds the point (1,0,0) with weight_scale=4 and id=1
 				[/codeblock]
+
 				If there already exists a point for the given id, its position and weight scale are updated to the given values.
 			</description>
 		</method>
@@ -84,12 +86,12 @@
 				Creates a segment between the given points.
 				[codeblock]
 				var as = AStar.new()
-				
+
 				as.add_point(1, Vector3(1,1,0))
 				as.add_point(2, Vector3(0,5,0))
-				
-				as.connect_points(1, 2, false) # If bidirectional=false it's only possible to go from point 1 to point 2
-				                               # and not from point 2 to point 1.
+
+				as.connect_points(1, 2, false)  # If bidirectional=false it's only possible to go from point 1 to point 2
+												# and not from point 2 to point 1.
 				[/codeblock]
 			</description>
 		</method>
@@ -137,6 +139,7 @@
 				
 				var res = as.get_closest_position_in_segment(Vector3(3,3,0)) # returns (0, 3, 0)
 				[/codeblock]
+
 				The result is in the segment that goes from [code]y=0[/code] to [code]y=5[/code]. It's the closest position in the segment to the given point.
 			</description>
 		</method>
@@ -165,6 +168,7 @@
 				
 				var res = as.get_id_path(1, 3) # returns [1, 2, 3]
 				[/codeblock]
+
 				If you change the 2nd point's weight to 3, then the result will be [code][1, 4, 3][/code] instead, because now even though the distance is longer, it's "easier" to get through point 4 than through point 2.
 			</description>
 		</method>

--- a/doc/classes/AcceptDialog.xml
+++ b/doc/classes/AcceptDialog.xml
@@ -22,6 +22,7 @@
 			</argument>
 			<description>
 				Adds a button with label [i]text[/i] and a custom [i]action[/i] to the dialog and returns the created button. [i]action[/i] will be passed to the [custom_action] signal when pressed.
+
 				If [code]true[/code], [i]right[/i] will place the button to the right of any sibling buttons. Default value: [code]false[/code].
 			</description>
 		</method>

--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		An Animation resource contains data used to animate everything in the engine. Animations are divided into tracks, and each track must be linked to a node. The state of that node can be changed through time, by adding timed keys (events) to the track.
+
 		Animations are just data containers, and must be added to odes such as an [AnimationPlayer] or [AnimationTreePlayer] to be played back.
 	</description>
 	<tutorials>

--- a/doc/classes/Area.xml
+++ b/doc/classes/Area.xml
@@ -188,6 +188,7 @@
 			</argument>
 			<description>
 				Set the rate at which objects stop spinning in this area, if there are not any other forces making it spin. The value is a fraction of its current speed, lost per second. Thus, a value of 1.0 should mean stopping immediately, and 0.0 means the object never stops.
+
 				In practice, as the fraction of speed lost gets smaller with each frame, a value of 1.0 does not mean the object will stop in exactly one second. Only when the physics calculations are done at 1 frame per second, it does stop in a second.
 			</description>
 		</method>
@@ -214,7 +215,9 @@
 			</argument>
 			<description>
 				Set the physics layers this area is in.
+
 				Collidable objects can exist in any of 32 different layers. These layers are not visual, but more of a tagging system instead. A collidable can use these layers/tags to select with which objects it can collide, using [method set_collision_mask].
+
 				A contact is detected if object A is in any of the layers that object B scans, or object B is in any layer scanned by object A.
 			</description>
 		</method>
@@ -256,6 +259,7 @@
 			</argument>
 			<description>
 				Set the gravity intensity. This is useful to alter the force of gravity without altering its direction.
+
 				This value multiplies the gravity vector, whether it is the given vector ([method set_gravity_vector]), or a calculated one (when using a center of gravity).
 			</description>
 		</method>
@@ -284,6 +288,7 @@
 			</argument>
 			<description>
 				Set the gravity vector. This vector does not have to be normalized.
+
 				If gravity is a point (see [method is_gravity_a_point]), this will be the attraction center.
 			</description>
 		</method>
@@ -294,6 +299,7 @@
 			</argument>
 			<description>
 				Set the rate at which objects stop moving in this area, if there are not any other forces moving it. The value is a fraction of its current speed, lost per second. Thus, a value of 1.0 should mean stopping immediately, and 0.0 means the object never stops.
+
 				In practice, as the fraction of speed lost gets smaller with each frame, a value of 1.0 does not mean the object will stop in exactly one second. Only when the physics calculations are done at 1 frame per second, it does stop in a second.
 			</description>
 		</method>
@@ -322,6 +328,7 @@
 			</argument>
 			<description>
 				Set the order in which the area is processed. Greater values mean the area gets processed first. This is useful for areas which have a space override different from AREA_SPACE_OVERRIDE_DISABLED or AREA_SPACE_OVERRIDE_COMBINE, as they replace values, and are thus order-dependent.
+
 				Areas with the same priority value get evaluated in an unpredictable order, and should be differentiated if evaluation order is to be important.
 			</description>
 		</method>
@@ -356,11 +363,12 @@
 			</argument>
 			<description>
 				Set the space override mode. This mode controls how an area affects gravity and damp.
-				AREA_SPACE_OVERRIDE_DISABLED: This area does not affect gravity/damp. These are generally areas that exist only to detect collisions, and objects entering or exiting them.
-				AREA_SPACE_OVERRIDE_COMBINE: This area adds its gravity/damp values to whatever has been calculated so far. This way, many overlapping areas can combine their physics to make interesting effects.
-				AREA_SPACE_OVERRIDE_COMBINE_REPLACE: This area adds its gravity/damp values to whatever has been calculated so far. Then stops taking into account the rest of the areas, even the default one.
-				AREA_SPACE_OVERRIDE_REPLACE: This area replaces any gravity/damp, even the default one, and stops taking into account the rest of the areas.
-				AREA_SPACE_OVERRIDE_REPLACE_COMBINE: This area replaces any gravity/damp calculated so far, but keeps calculating the rest of the areas, down to the default one.
+
+				[code]AREA_SPACE_OVERRIDE_DISABLED[/code]: This area does not affect gravity/damp. These are generally areas that exist only to detect collisions, and objects entering or exiting them.
+				[code]AREA_SPACE_OVERRIDE_COMBINE[/code]: This area adds its gravity/damp values to whatever has been calculated so far. This way, many overlapping areas can combine their physics to make interesting effects.
+				[code]AREA_SPACE_OVERRIDE_COMBINE_REPLACE[/code]: This area adds its gravity/damp values to whatever has been calculated so far. Then stops taking into account the rest of the areas, even the default one.
+				[code]AREA_SPACE_OVERRIDE_REPLACE[/code]: This area replaces any gravity/damp, even the default one, and stops taking into account the rest of the areas.
+				[code]AREA_SPACE_OVERRIDE_REPLACE_COMBINE[/code]: This area replaces any gravity/damp calculated so far, but keeps calculating the rest of the areas, down to the default one.
 			</description>
 		</method>
 		<method name="set_use_reverb_bus">

--- a/doc/classes/Area2D.xml
+++ b/doc/classes/Area2D.xml
@@ -164,6 +164,7 @@
 			</argument>
 			<description>
 				Set the rate at which objects stop spinning in this area, if there are not any other forces making it spin. The value is a fraction of its current speed, lost per second. Thus, a value of 1.0 should mean stopping immediately, and 0.0 means the object never stops.
+
 				In practice, as the fraction of speed lost gets smaller with each frame, a value of 1.0 does not mean the object will stop in exactly one second. Only when the physics calculations are done at 1 frame per second, it does stop in a second.
 			</description>
 		</method>
@@ -190,7 +191,9 @@
 			</argument>
 			<description>
 				Set the physics layers this area is in.
+
 				Collidable objects can exist in any of 32 different layers. These layers are not visual, but more of a tagging system instead. A collidable can use these layers/tags to select with which objects it can collide, using [method set_collision_mask].
+
 				A contact is detected if object A is in any of the layers that object B scans, or object B is in any layer scanned by object A.
 			</description>
 		</method>
@@ -232,6 +235,7 @@
 			</argument>
 			<description>
 				Set the gravity intensity. This is useful to alter the force of gravity without altering its direction.
+
 				This value multiplies the gravity vector, whether it is the given vector ([method set_gravity_vector]), or a calculated one (when using a center of gravity).
 			</description>
 		</method>
@@ -260,6 +264,7 @@
 			</argument>
 			<description>
 				Set the gravity vector. This vector does not have to be normalized.
+
 				If gravity is a point (see [method is_gravity_a_point]), this will be the attraction center.
 			</description>
 		</method>
@@ -270,6 +275,7 @@
 			</argument>
 			<description>
 				Set the rate at which objects stop moving in this area, if there are not any other forces moving it. The value is a fraction of its current speed, lost per second. Thus, a value of 1.0 should mean stopping immediately, and 0.0 means the object never stops.
+
 				In practice, as the fraction of speed lost gets smaller with each frame, a value of 1.0 does not mean the object will stop in exactly one second. Only when the physics calculations are done at 1 frame per second, it does stop in a second.
 			</description>
 		</method>
@@ -298,6 +304,7 @@
 			</argument>
 			<description>
 				Set the order in which the area is processed. Greater values mean the area gets processed first. This is useful for areas which have a space override different from AREA_SPACE_OVERRIDE_DISABLED or AREA_SPACE_OVERRIDE_COMBINE, as they replace values, and are thus order-dependent.
+
 				Areas with the same priority value get evaluated in an unpredictable order, and should be differentiated if evaluation order is to be important.
 			</description>
 		</method>
@@ -308,11 +315,12 @@
 			</argument>
 			<description>
 				Set the space override mode. This mode controls how an area affects gravity and damp.
-				AREA_SPACE_OVERRIDE_DISABLED: This area does not affect gravity/damp. These are generally areas that exist only to detect collisions, and objects entering or exiting them.
-				AREA_SPACE_OVERRIDE_COMBINE: This area adds its gravity/damp values to whatever has been calculated so far. This way, many overlapping areas can combine their physics to make interesting effects.
-				AREA_SPACE_OVERRIDE_COMBINE_REPLACE: This area adds its gravity/damp values to whatever has been calculated so far. Then stops taking into account the rest of the areas, even the default one.
-				AREA_SPACE_OVERRIDE_REPLACE: This area replaces any gravity/damp, even the default one, and stops taking into account the rest of the areas.
-				AREA_SPACE_OVERRIDE_REPLACE_COMBINE: This area replaces any gravity/damp calculated so far, but keeps calculating the rest of the areas, down to the default one.
+
+				[code]AREA_SPACE_OVERRIDE_DISABLED[/code]: This area does not affect gravity/damp. These are generally areas that exist only to detect collisions, and objects entering or exiting them.
+				[code]AREA_SPACE_OVERRIDE_COMBINE[/code]: This area adds its gravity/damp values to whatever has been calculated so far. This way, many overlapping areas can combine their physics to make interesting effects.
+				[code]AREA_SPACE_OVERRIDE_COMBINE_REPLACE[/code]: This area adds its gravity/damp values to whatever has been calculated so far. Then stops taking into account the rest of the areas, even the default one.
+				[code]AREA_SPACE_OVERRIDE_REPLACE[/code]: This area replaces any gravity/damp, even the default one, and stops taking into account the rest of the areas.
+				[code]AREA_SPACE_OVERRIDE_REPLACE_COMBINE[/code]: This area replaces any gravity/damp calculated so far, but keeps calculating the rest of the areas, down to the default one.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ArrayMesh.xml
+++ b/doc/classes/ArrayMesh.xml
@@ -30,6 +30,7 @@
 			</argument>
 			<description>
 				Create a new surface ([method get_surface_count] that will become surf_idx for this.
+
 				Surfaces are created to be rendered using a "primitive", which may be PRIMITIVE_POINTS, PRIMITIVE_LINES, PRIMITIVE_LINE_STRIP, PRIMITIVE_LINE_LOOP, PRIMITIVE_TRIANGLES, PRIMITIVE_TRIANGLE_STRIP, PRIMITIVE_TRIANGLE_FAN. (As a note, when using indices, it is recommended to only use just points, lines or triangles).
 			</description>
 		</method>

--- a/doc/classes/AtlasTexture.xml
+++ b/doc/classes/AtlasTexture.xml
@@ -4,8 +4,7 @@
 		Packs multiple small textures in a single, bigger one. Helps to optimize video memory costs and render calls.
 	</brief_description>
 	<description>
-		[Texture] resource aimed at managing big textures files that pack multiple smaller textures. Consists of a [Texture], a margin that defines the border width,
-		and a region that defines the actual area of the AtlasTexture.
+		[Texture] resource aimed at managing big textures files that pack multiple smaller textures. Consists of a [Texture], a margin that defines the border width, and a region that defines the actual area of the AtlasTexture.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/AudioEffectAmplify.xml
+++ b/doc/classes/AudioEffectAmplify.xml
@@ -2,6 +2,7 @@
 <class name="AudioEffectAmplify" inherits="AudioEffect" category="Core" version="3.0.alpha.custom_build">
 	<brief_description>
 		Adds a Amplify audio effect to an Audio bus.
+
 		Increases or decreases the volume of the selected audio bus.
 	</brief_description>
 	<description>

--- a/doc/classes/AudioEffectCompressor.xml
+++ b/doc/classes/AudioEffectCompressor.xml
@@ -2,10 +2,12 @@
 <class name="AudioEffectCompressor" inherits="AudioEffect" category="Core" version="3.0.alpha.custom_build">
 	<brief_description>
 		Adds a Compressor audio effect to an Audio bus.
+
 		Reduces sounds that exceed a certain threshold level, smooths out the dynamics and increases the overall volume.
 	</brief_description>
 	<description>
 		Dynamic range compressor reduces the level of the sound when the amplitude goes over a certain threshold in Decibels. One of the main uses of a compressor is to increase the dynamic range by clipping as little as possible (when sound goes over 0dB).
+
 		Compressor has many uses in the mix:
 		- In the Master bus to compress the whole output (Although a [AudioEffectLimiter] is probably better)
 		- In voice channels to ensure they sound as balanced as possible.

--- a/doc/classes/AudioEffectDelay.xml
+++ b/doc/classes/AudioEffectDelay.xml
@@ -2,6 +2,7 @@
 <class name="AudioEffectDelay" inherits="AudioEffect" category="Core" version="3.0.alpha.custom_build">
 	<brief_description>
 		Adds a Delay audio effect to an Audio bus. Plays input signal back after a period of time.
+
 		Two tap delay and feedback options.
 	</brief_description>
 	<description>

--- a/doc/classes/AudioEffectDistortion.xml
+++ b/doc/classes/AudioEffectDistortion.xml
@@ -2,10 +2,12 @@
 <class name="AudioEffectDistortion" inherits="AudioEffect" category="Core" version="3.0.alpha.custom_build">
 	<brief_description>
 		Adds a Distortion audio effect to an Audio bus.
+
 		Modify the sound to make it dirty.
 	</brief_description>
 	<description>
 		Modify the sound and make it dirty. Different types are available : clip, tan, lofi (bit crushing), overdrive, or waveshape.
+
 		By distorting the waveform the frequency content change, which will often make the sound "crunchy" or "abrasive". For games, it can simulate sound coming from some saturated device or speaker very efficiently.
 	</description>
 	<tutorials>

--- a/doc/classes/AudioEffectEQ.xml
+++ b/doc/classes/AudioEffectEQ.xml
@@ -2,6 +2,7 @@
 <class name="AudioEffectEQ" inherits="AudioEffect" category="Core" version="3.0.alpha.custom_build">
 	<brief_description>
 		Base class for audio equalizers. Gives you control over frequencies.
+
 		Use it to create a custom equalizer if [AudioEffectEQ6], [AudioEffectEQ10] or [AudioEffectEQ21] don't fit your needs.
 	</brief_description>
 	<description>

--- a/doc/classes/AudioEffectEQ10.xml
+++ b/doc/classes/AudioEffectEQ10.xml
@@ -2,6 +2,7 @@
 <class name="AudioEffectEQ10" inherits="AudioEffectEQ" category="Core" version="3.0.alpha.custom_build">
 	<brief_description>
 		Adds a 10-band equalizer audio effect to an Audio bus. Gives you control over frequencies from 31 Hz to 16000 Hz.
+
 		Each frequency can be modulated between -60/+24 dB.
 	</brief_description>
 	<description>

--- a/doc/classes/AudioEffectEQ21.xml
+++ b/doc/classes/AudioEffectEQ21.xml
@@ -2,6 +2,7 @@
 <class name="AudioEffectEQ21" inherits="AudioEffectEQ" category="Core" version="3.0.alpha.custom_build">
 	<brief_description>
 		Adds a 21-band equalizer audio effect to an Audio bus. Gives you control over frequencies from 22 Hz to 22000 Hz.
+
 		Each frequency can be modulated between -60/+24 dB.
 	</brief_description>
 	<description>

--- a/doc/classes/AudioEffectEQ6.xml
+++ b/doc/classes/AudioEffectEQ6.xml
@@ -2,6 +2,7 @@
 <class name="AudioEffectEQ6" inherits="AudioEffectEQ" category="Core" version="3.0.alpha.custom_build">
 	<brief_description>
 		Adds a 6-band equalizer audio effect to an Audio bus. Gives you control over frequencies from 32 Hz to 10000 Hz.
+
 		Each frequency can be modulated between -60/+24 dB.
 	</brief_description>
 	<description>

--- a/doc/classes/AudioEffectLimiter.xml
+++ b/doc/classes/AudioEffectLimiter.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A limiter is similar to a compressor, but it’s less flexible and designed to disallow sound going over a given dB threshold. Adding one in the Master Bus is always recommended to reduce the effects of clipping.
+
 		Soft clipping starts to reduce the peaks a little below the threshold level and progressively increases its effect as the input level increases such that the threshold is never exceeded.
 	</description>
 	<tutorials>

--- a/doc/classes/AudioEffectPhaser.xml
+++ b/doc/classes/AudioEffectPhaser.xml
@@ -2,6 +2,7 @@
 <class name="AudioEffectPhaser" inherits="AudioEffect" category="Core" version="3.0.alpha.custom_build">
 	<brief_description>
 		Adds a Phaser audio effect to an Audio bus.
+
 		Combines the original signal with a copy that is slightly out of phase with the original.
 	</brief_description>
 	<description>

--- a/doc/classes/AudioEffectPitchShift.xml
+++ b/doc/classes/AudioEffectPitchShift.xml
@@ -2,6 +2,7 @@
 <class name="AudioEffectPitchShift" inherits="AudioEffect" category="Core" version="3.0.alpha.custom_build">
 	<brief_description>
 		Adds a Pitch shift audio effect to an Audio bus.
+
 		Raises or lowers the pitch of original sound.
 	</brief_description>
 	<description>

--- a/doc/classes/AudioEffectReverb.xml
+++ b/doc/classes/AudioEffectReverb.xml
@@ -2,6 +2,7 @@
 <class name="AudioEffectReverb" inherits="AudioEffect" category="Core" version="3.0.alpha.custom_build">
 	<brief_description>
 		Adds a Reverb audio effect to an Audio bus.
+
 		Simulates the sound of acoustic environments such as rooms, concert halls, caverns, or an open spaces.
 	</brief_description>
 	<description>

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		3x3 matrix used for 3D rotation and scale. Contains 3 vector fields x,y and z as its columns, which can be interpreted as the local basis vectors of a transformation. Can also be accessed as array of 3D vectors. These vectors are orthogonal to each other, but are not necessarily normalized. Almost always used as orthogonal basis for a [Transform].
+
 		For such use, it is composed of a scaling and a rotation matrix, in that order (M = R.S).
 	</description>
 	<tutorials>

--- a/doc/classes/BitMap.xml
+++ b/doc/classes/BitMap.xml
@@ -77,7 +77,8 @@
 	</methods>
 	<members>
 		<member name="data" type="Dictionary" setter="_set_data" getter="_get_data">
-			Returns a [Dictionary] with two keys :
+			Returns a [Dictionary] with two keys:
+
 			[code]data[/code] : [PoolByteArray] with [code]true[/code]/[code]false[/code] [code]BitMap[/code] data.
 			[code]size[/code] : The [code]Bitmap[/code]'s size.
 		</member>

--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Camera node for 2D scenes. It forces the screen (current layer) to scroll following this node. This makes it easier (and faster) to program scrollable scenes than manually changing the position of [CanvasItem] based nodes.
+
 		This node is intended to be a simple helper to get things going quickly and it may happen often that more functionality is desired to change how the camera works. To make your own custom camera node, simply inherit from [Node2D] and change the transform of the canvas by calling get_viewport().set_canvas_transform(m) in [Viewport].
 	</description>
 	<tutorials>
@@ -173,6 +174,7 @@
 			</return>
 			<description>
 				Set the camera's position immediately to its current smoothing destination.
+
 				This has no effect if smoothing is disabled.
 			</description>
 		</method>
@@ -261,6 +263,7 @@
 			</argument>
 			<description>
 				Smooth camera when reaching camera limits.
+
 				This requires camera smoothing being enabled to have a noticeable effect.
 			</description>
 		</method>

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -5,9 +5,13 @@
 	</brief_description>
 	<description>
 		Base class of anything 2D. Canvas items are laid out in a tree and children inherit and extend the transform of their parent. CanvasItem is extended by [Control], for anything GUI related, and by [Node2D] for anything 2D engine related.
+
 		Any CanvasItem can draw. For this, the "update" function must be called, then NOTIFICATION_DRAW will be received on idle time to request redraw. Because of this, canvas items don't need to be redraw on every frame, improving the performance significantly. Several functions for drawing on the CanvasItem are provided (see draw_* functions). They can only be used inside the notification, signal or _draw() overrides function, though.
+
 		Canvas items are draw in tree order. By default, children are on top of their parents so a root CanvasItem will be drawn behind everything (this can be changed per item though).
+
 		Canvas items can also be hidden (hiding also their subtree). They provide many means for changing standard parameters such as opacity (for it and the subtree) and self opacity, blend mode.
+
 		Ultimately, a transform notification can be requested, which will notify the node that its global position changed in case the parent tree changed.
 	</description>
 	<tutorials>
@@ -578,6 +582,7 @@
 			</argument>
 			<description>
 				Set whether this item should be visible or not.
+
 				Note that a hidden CanvasItem will make all children hidden too, so no matter what is set here this item won't be shown if its parent or grandparents nodes are hidden.
 			</description>
 		</method>

--- a/doc/classes/CollisionPolygon2D.xml
+++ b/doc/classes/CollisionPolygon2D.xml
@@ -69,6 +69,7 @@
 			</argument>
 			<description>
 				Set the array of points forming the polygon.
+
 				When editing the point list via the editor, depending on [method get_build_mode], it has to be a list of points (for [code]build_mode==0[/code]), or a list of lines (for [code]build_mode==1[/code]). In the second case, the even elements of the array define the start point of the line, and the odd elements the end point.
 			</description>
 		</method>

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -64,13 +64,15 @@
 			</argument>
 			<description>
 				Constructs a color from an HTML hexadecimal color string in ARGB or RGB format.
+
 				The following string formats are supported:
-					[code]"#ff00ff00"[/code] - ARGB format with '#'
-					[code]"ff00ff00"[/code] - ARGB format
-					[code]"#ff00ff"[/code] - RGB format with '#'
-					[code]"ff00ff"[/code] - RGB format
+				[code]"#ff00ff00"[/code] - ARGB format with '#'
+				[code]"ff00ff00"[/code] - ARGB format
+				[code]"#ff00ff"[/code] - RGB format with '#'
+				[code]"ff00ff"[/code] - RGB format
+
+				The following code creates the same color of an RGBA(178, 217, 10, 255)
 				[codeblock]
-				# The following code creates the same color of an RGBA(178, 217, 10, 255)
 				var c1 = Color("#ffb2d90a") # ARGB format with '#'
 				var c2 = Color("ffb2d90a")  # ARGB format
 				var c3 = Color("#b2d90a")   # RGB format with '#'
@@ -108,6 +110,7 @@
 			</return>
 			<description>
 				Returns the color's grayscale.
+
 				The gray is calculated by (r + g + b) / 3.
 				[codeblock]
 				var c = Color(0.2, 0.45, 0.82)
@@ -160,6 +163,7 @@
 			</argument>
 			<description>
 				Returns the color's HTML hexadecimal color string in ARGB format (ex: [code]ff34f822[/code]).
+
 				Optionally flag 'false' to not include alpha in hexadecimal string.
 				[codeblock]
 				var c = Color(1, 1, 1, .5)
@@ -178,7 +182,7 @@
 				print(str(c.to_32())) # prints 4294934323
 				[/codeblock]
 
-				[i]This is same as [method to_ARGB32] but may be changed later to support RGBA format instead[/i].
+				[b]Note:[/b] This is same as [method to_ARGB32] but may be changed later to support RGBA format instead.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ColorPickerButton.xml
+++ b/doc/classes/ColorPickerButton.xml
@@ -46,11 +46,10 @@
 			</argument>
 			<description>
 				Set new color to ColorRect.
-
-			[codeblock]
-			var cr = get_node("colorrect_node")
-			cr.set_frame_color(Color(1, 0, 0, 1)) # Set color rect node to red
-			[/codeblock]
+				[codeblock]
+				var cr = get_node("colorrect_node")
+				cr.set_frame_color(Color(1, 0, 0, 1)) # Set color rect node to red
+				[/codeblock]
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ConcavePolygonShape2D.xml
+++ b/doc/classes/ConcavePolygonShape2D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Concave polygon 2D shape resource for physics. It is made out of segments and is very optimal for complex polygonal concave collisions. It is really not advised to use for [RigidBody2D] nodes. A CollisionPolygon2D in convex decomposition mode (solids) or several convex objects are advised for that instead. Otherwise, a concave polygon 2D shape is better for static collisions.
+
 		The main difference between a [ConvexPolygonShape2D] and a [code]ConcavePolygonShape2D[/code] is that a concave polygon assumes it is concave and uses a more complex method of collision detection, and a convex one forces itself to be convex in order to speed up collision detection.
 	</description>
 	<tutorials>

--- a/doc/classes/ConeTwistJoint.xml
+++ b/doc/classes/ConeTwistJoint.xml
@@ -5,8 +5,8 @@
 	</brief_description>
 	<description>
 		The joint can rotate the bodies across an axis defined by the local x-axes of the [Joint].
-		The twist axis is initiated as the x-axis of the [Joint].
-		Once the Bodies swing, the twist axis is calculated as the middle of the x-axes of the Joint in the local space of the two Bodies.
+
+		The twist axis is initiated as the x-axis of the [Joint]. Once the Bodies swing, the twist axis is calculated as the middle of the x-axes of the Joint in the local space of the two Bodies.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -34,8 +34,7 @@
 	</methods>
 	<members>
 		<member name="bias" type="float" setter="set_param" getter="get_param">
-			The speed with which the swing or twist will take place.
-			The higher, the faster.
+			The speed with which the swing or twist will take place. The higher, the faster.
 		</member>
 		<member name="relaxation" type="float" setter="set_param" getter="get_param">
 			Defines, how fast the swing- and twist-speed-difference on both sides gets synced.
@@ -45,29 +44,32 @@
 		</member>
 		<member name="swing_span" type="float" setter="_set_swing_span" getter="_get_swing_span">
 			Swing is rotation from side to side, around the axis perpendicular to the twist axis.
-			The swing span defines, how much rotation will not get corrected allong the swing axis.
-			Could be defined as looseness in the [code]ConeTwistJoint[/code].
-			If below 0.05, this behaviour is locked. Default value: [code]PI/4[/code].
+
+			The swing span defines how much rotation will not get corrected allong the swing axis.
+
+			Could be defined as looseness in the [code]ConeTwistJoint[/code]. If below 0.05, this behaviour is locked. Default value: [code]PI/4[/code].
 		</member>
 		<member name="twist_span" type="float" setter="_set_twist_span" getter="_get_twist_span">
 			Twist is the rotation around the twist axis, this value defined how far the joint can twist.
+
 			Twist is locked if below 0.05.
 		</member>
 	</members>
 	<constants>
 		<constant name="PARAM_SWING_SPAN" value="0">
 			Swing is rotation from side to side, around the axis perpendicular to the twist axis.
-			The swing span defines, how much rotation will not get corrected allong the swing axis.
-			Could be defined as looseness in the [code]ConeTwistJoint[/code].
+
+			The swing span defines how much rotation will not get corrected allong the swing axis. Could be defined as looseness in the [code]ConeTwistJoint[/code].
+
 			If below 0.05, this behaviour is locked. Default value: [code]PI/4[/code].
 		</constant>
 		<constant name="PARAM_TWIST_SPAN" value="1">
 			Twist is the rotation around the twist axis, this value defined how far the joint can twist.
+
 			Twist is locked if below 0.05.
 		</constant>
 		<constant name="PARAM_BIAS" value="2">
-			The speed with which the swing or twist will take place.
-			The higher, the faster.
+			The speed with which the swing or twist will take place. The higher, the faster.
 		</constant>
 		<constant name="PARAM_SOFTNESS" value="3">
 			The ease with which the joint starts to twist. If it's too low, it takes more force to start twisting the joint.

--- a/doc/classes/ConfigFile.xml
+++ b/doc/classes/ConfigFile.xml
@@ -11,19 +11,21 @@
 		string_example="Hello World!"
 		a_vector=Vector3( 1, 0, 2 )
 		[/codeblock]
+
 		The stored data can be saved to or parsed from a file, though ConfigFile objects can also be used directly without accessing the filesystem.
+
 		The following example shows how to parse an INI-style file from the system, read its contents and store new values in it:
 		[codeblock]
 		var config = ConfigFile.new()
 		var err = config.load("user://settings.cfg")
 		if err == OK: # if not, something went wrong with the file loading
-		    # Look for the display/width pair, and default to 1024 if missing
-		    var screen_width = get_value("display", "width", 1024)
-		    # Store a variable if and only if it hasn't been defined yet
-		    if not config.has_section_key("audio", "mute"):
-		        config.set_value("audio", "mute", false)
-		    # Save the changes by overwriting the previous file
-		    config.save("user://settings.cfg")
+			# Look for the display/width pair, and default to 1024 if missing
+			var screen_width = get_value("display", "width", 1024)
+			# Store a variable if and only if it hasn't been defined yet
+			if not config.has_section_key("audio", "mute"):
+				config.set_value("audio", "mute", false)
+			# Save the changes by overwriting the previous file
+			config.save("user://settings.cfg")
 		[/codeblock]
 	</description>
 	<tutorials>

--- a/doc/classes/Container.xml
+++ b/doc/classes/Container.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Base node for containers. A [code]Container[/code] contains other controls and automatically arranges them in a certain way.
+
 		A Control can inherit this to create custom container classes.
 	</description>
 	<tutorials>

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -5,11 +5,17 @@
 	</brief_description>
 	<description>
 		Base class for all User Interface or [i]UI[/i] related nodes. [code]Control[/code] features a bounding rectangle that defines its extents, an anchor position relative to its parent and margins that represent an offset to the anchor. The margins update automatically when the node, any of its parents, or the screen size change.
+
 		For more information on Godot's UI system, anchors, margins, and containers, see the related tutorials in the manual. To build flexible UIs, you'll need a mix of UI elements that inherit from [code]Control[/code] and [Container] nodes.
+
 		[b]User Interface nodes and input[/b]
+
 		Godot sends input events to the scene's root node first, by calling [method Node._input]. [method Node._input] forwards the event down the node tree to the nodes under the mouse cursor, or on keyboard focus. To do so, it calls [method MainLoop._input_event]. Call [method accept_event] so no other node receives the event. Once you accepted an input, it becomes handled so [method Node._unhandled_input] will not process it.
+
 		Only one [code]Control[/code] node can be in keyboard focus. Only the node in focus will receive keyboard events. To get the foucs, call [method set_focus_mode]. [code]Control[/code] nodes lose focus when another node grabs it, or if you hide the node in focus.
+
 		Call [method set_ignore_mouse] to tell a [code]Control[/code] node to ignore mouse or touch events. You'll need it if you place an icon on top of a button.
+
 		[Theme] resources change the Control's appearance. If you change the [Theme] on a [code]Control[/code] node, it affects all of its children. To override some of the theme's parameters, call one of the [code]add_*_override[/code] methods, like [method add_font_override]. You can override the theme with the inspector.
 	</description>
 	<tutorials>
@@ -31,6 +37,7 @@
 			</argument>
 			<description>
 				The node's parent forwards input events to this method. Use it to process and accept inputs on UI elements. See [method accept_event].
+
 				Replaces Godot 2's [code]_input_event[/code].
 			</description>
 		</method>
@@ -866,6 +873,7 @@
 		</member>
 		<member name="focus_neighbour_bottom" type="NodePath" setter="set_focus_neighbour" getter="get_focus_neighbour">
 			Tells Godot which node it should give keyboard focus to if the user presses Tab, the down arrow on the keyboard, or down on a gamepad. The node must be a [code]Control[/code]. If this property is not set, Godot will give focus to the closest [code]Control[/code] to the bottom of this one.
+
 			If the user presses Tab, Godot will give focus to the closest node to the right first, then to the bottom. If the user presses Shift+Tab, Godot will look to the left of the node, then above it.
 		</member>
 		<member name="focus_neighbour_left" type="NodePath" setter="set_focus_neighbour" getter="get_focus_neighbour">
@@ -886,6 +894,7 @@
 		</member>
 		<member name="margin_bottom" type="float" setter="set_margin" getter="get_margin">
 			Distance between the node's bottom edge and its parent container, based on [member anchor_bottom].
+
 			Margins are often controlled by one or multiple parent [Container] nodes. Margins update automatically when you move or resize the node.
 		</member>
 		<member name="margin_left" type="float" setter="set_margin" getter="get_margin">

--- a/doc/classes/ConvexPolygonShape2D.xml
+++ b/doc/classes/ConvexPolygonShape2D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Convex Polygon Shape for 2D physics. A convex polygon, whatever its shape, is internally decomposed into as many convex polygons as needed to ensure all collision checks against it are always done on convex polygons (which are faster to check).
+
 		The main difference between a [code]ConvexPolygonShape2D[/code] and a [ConcavePolygonShape2D] is that a concave polygon assumes it is concave and uses a more complex method of collision detection, and a convex one forces itself to be convex in order to speed up collision detection.
 	</description>
 	<tutorials>

--- a/doc/classes/Curve2D.xml
+++ b/doc/classes/Curve2D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		This class describes a Bezier curve in 2D space. It is mainly used to give a shape to a [Path2D], but can be manually sampled for other purposes.
+
 		It keeps a cache of precalculated points along the curve, to speed further calculations up.
 	</description>
 	<tutorials>
@@ -25,6 +26,7 @@
 			</argument>
 			<description>
 				Adds a point to a curve, at "position", with control points "in" and "out".
+
 				If "at_position" is given, the point is inserted before the point number "at_position", moving that point (and every point after) after the inserted point. If "at_position" is not given, or is an illegal value (at_position &lt;0 or at_position &gt;= [method get_point_count]), the point will be appended at the end of the point list.
 			</description>
 		</method>
@@ -99,6 +101,7 @@
 			</argument>
 			<description>
 				Returns the position between the vertex "idx" and the vertex "idx"+1, where "t" controls if the point is the first vertex (t = 0.0), the last vertex (t = 1.0), or in between. Values of "t" outside the range (0.0 &gt;= t  &lt;=1) give strange, but predictable results.
+
 				If "idx" is out of bounds it is truncated to the first or last vertex, and "t" is ignored. If the curve has no points, the function sends an error to the console, and returns (0, 0).
 			</description>
 		</method>
@@ -111,7 +114,9 @@
 			</argument>
 			<description>
 				Returns a point within the curve at position "offset", where "offset" is measured as a pixel distance along the curve.
+
 				To do that, it finds the two cached points where the "offset" lies between, then interpolates the values. This interpolation is cubic if "cubic" is set to true, or linear if set to false.
+
 				Cubic interpolation tends to follow the curves better, but linear is faster (and often, precise enough).
 			</description>
 		</method>
@@ -184,6 +189,7 @@
 			</argument>
 			<description>
 				Returns a list of points along the curve, with a curvature controlled point density. That is, the curvier parts will have more points than the straighter parts.
+
 				This approximation makes straight segments between each point, then subdivides those segments until the resulting shape is similar enough.
 				"max_stages" controls how many subdivisions a curve segment may face before it is considered approximate enough. Each subdivision splits the segment in half, so the default 5 stages may mean up to 32 subdivisions per curve segment. Increase with care!
 				"tolerance_degrees" controls how many degrees the midpoint of a segment may deviate from the real curve, before the segment has to be subdivided.

--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		This class describes a Bezier curve in 3D space. It is mainly used to give a shape to a [Path], but can be manually sampled for other purposes.
+
 		It keeps a cache of precalculated points along the curve, to speed further calculations up.
 	</description>
 	<tutorials>
@@ -25,6 +26,7 @@
 			</argument>
 			<description>
 				Adds a point to a curve, at "position", with control points "in" and "out".
+
 				If "at_position" is given, the point is inserted before the point number "at_position", moving that point (and every point after) after the inserted point. If "at_position" is not given, or is an illegal value (at_position &lt;0 or at_position &gt;= [method get_point_count]), the point will be appended at the end of the point list.
 			</description>
 		</method>
@@ -114,6 +116,7 @@
 			</argument>
 			<description>
 				Returns the position between the vertex "idx" and the vertex "idx"+1, where "t" controls if the point is the first vertex (t = 0.0), the last vertex (t = 1.0), or in between. Values of "t" outside the range (0.0 &gt;= t  &lt;=1) give strange, but predictable results.
+
 				If "idx" is out of bounds it is truncated to the first or last vertex, and "t" is ignored. If the curve has no points, the function sends an error to the console, and returns (0, 0, 0).
 			</description>
 		</method>
@@ -126,7 +129,9 @@
 			</argument>
 			<description>
 				Returns a point within the curve at position "offset", where "offset" is measured as a distance in 3D units along the curve.
+
 				To do that, it finds the two cached points where the "offset" lies between, then interpolates the values. This interpolation is cubic if "cubic" is set to true, or linear if set to false.
+
 				Cubic interpolation tends to follow the curves better, but linear is faster (and often, precise enough).
 			</description>
 		</method>
@@ -199,6 +204,7 @@
 			</argument>
 			<description>
 				Sets the tilt angle in radians for the point "idx". If the index is out of bounds, the function sends an error to the console.
+
 				The tilt controls the rotation along the look-at axis an object traveling the path would have. In the case of a curve controlling a [PathFollow], this tilt is an offset over the natural tilt the PathFollow calculates.
 			</description>
 		</method>
@@ -211,6 +217,7 @@
 			</argument>
 			<description>
 				Returns a list of points along the curve, with a curvature controlled point density. That is, the curvier parts will have more points than the straighter parts.
+
 				This approximation makes straight segments between each point, then subdivides those segments until the resulting shape is similar enough.
 				"max_stages" controls how many subdivisions a curve segment may face before it is considered approximate enough. Each subdivision splits the segment in half, so the default 5 stages may mean up to 32 subdivisions per curve segment. Increase with care!
 				"tolerance_degrees" controls how many degrees the midpoint of a segment may deviate from the real curve, before the segment has to be subdivided.

--- a/doc/classes/Directory.xml
+++ b/doc/classes/Directory.xml
@@ -5,21 +5,22 @@
 	</brief_description>
 	<description>
 		Directory type. It is used to manage directories and their content (not restricted to the project folder).
+
 		Here is an example on how to iterate through the files of a directory:
 		[codeblock]
 		func dir_contents(path):
-		    var dir = Directory.new()
-		    if dir.open(path) == OK:
-		        dir.list_dir_begin()
-		        var file_name = dir.get_next()
-		        while (file_name != ""):
-		            if dir.current_is_dir():
-		                print("Found directory: " + file_name)
-		            else:
-		                print("Found file: " + file_name)
-		            file_name = dir.get_next()
-		    else:
-		        print("An error occurred when trying to access the path.")
+			var dir = Directory.new()
+			if dir.open(path) == OK:
+				dir.list_dir_begin()
+				var file_name = dir.get_next()
+				while (file_name != ""):
+					if dir.current_is_dir():
+						print("Found directory: " + file_name)
+					else:
+						print("Found file: " + file_name)
+					file_name = dir.get_next()
+			else:
+				print("An error occurred when trying to access the path.")
 		[/codeblock]
 	</description>
 	<tutorials>
@@ -34,6 +35,7 @@
 			</argument>
 			<description>
 				Change the currently opened directory to the one passed as an argument. The argument can be relative to the current directory (e.g. [code]newdir[/code] or [code]../newdir[/code]), or an absolute path (e.g. [code]/tmp/newdir[/code] or [code]res://somedir/newdir[/code]).
+
 				The method returns one of the error code constants defined in [@Global Scope] (OK or ERR_*).
 			</description>
 		</method>
@@ -46,6 +48,7 @@
 			</argument>
 			<description>
 				Copy the [i]from[/i] file to the [i]to[/i] destination. Both arguments should be paths to files, either relative or absolute. If the destination file exists and is not access-protected, it will be overwritten.
+
 				Returns one of the error code constants defined in [@Global Scope] (OK, FAILED or ERR_*).
 			</description>
 		</method>
@@ -109,6 +112,7 @@
 			</return>
 			<description>
 				Return the next element (file or directory) in the current directory (including [code].[/code] and [code]..[/code], unless [code]skip_navigational[/code] was given to [method list_dir_begin]).
+
 				The name of the file or directory is returned (and not its full path). Once the stream has been fully processed, the method returns an empty String and closes the stream automatically (i.e. [method list_dir_end] would not be mandatory in such a case).
 			</description>
 		</method>
@@ -128,7 +132,9 @@
 			</argument>
 			<description>
 				Initialise the stream used to list all files and directories using the [method get_next] function, closing the current opened stream if needed. Once the stream has been processed, it should typically be closed with [method list_dir_end].
+
 				If you pass [code]skip_navigational[/code], then [code].[/code] and [code]..[/code] would be filtered out.
+
 				If you pass [code]skip_hidden[/code], then hidden files would be filtered out.
 			</description>
 		</method>
@@ -146,6 +152,7 @@
 			</argument>
 			<description>
 				Create a directory. The argument can be relative to the current directory, or an absolute path. The target directory should be placed in an already existing directory (to create the full path recursively, see [method make_dir_recursive]).
+
 				The method returns one of the error code constants defined in [@Global Scope] (OK, FAILED or ERR_*).
 			</description>
 		</method>
@@ -156,6 +163,7 @@
 			</argument>
 			<description>
 				Create a target directory and all necessary intermediate directories in its path, by calling [method make_dir] recursively. The argument can be relative to the current directory, or an absolute path.
+
 				Return one of the error code constants defined in [@Global Scope] (OK, FAILED or ERR_*).
 			</description>
 		</method>
@@ -166,6 +174,7 @@
 			</argument>
 			<description>
 				Open an existing directory of the filesystem. The [i]path[/i] argument can be within the project tree ([code]res://folder[/code]), the user directory ([code]user://folder[/code]) or an absolute path of the user filesystem (e.g. [code]/tmp/folder[/code] or [code]C:\tmp\folder[/code]).
+
 				The method returns one of the error code constants defined in [@Global Scope] (OK or ERR_*).
 			</description>
 		</method>
@@ -176,6 +185,7 @@
 			</argument>
 			<description>
 				Delete the target file or an empty directory. The argument can be relative to the current directory, or an absolute path. If the target directory is not empty, the operation will fail.
+
 				Return one of the error code constants defined in [@Global Scope] (OK or FAILED).
 			</description>
 		</method>
@@ -188,6 +198,7 @@
 			</argument>
 			<description>
 				Rename (move) the [i]from[/i] file to the [i]to[/i] destination. Both arguments should be paths to files, either relative or absolute. If the destination file exists and is not access-protected, it will be overwritten.
+
 				Return one of the error code constants defined in [@Global Scope] (OK or FAILED).
 			</description>
 		</method>

--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -15,39 +15,39 @@
 		extends EditorImportPlugin
 
 		func get_importer_name():
-		    return "my.special.plugin"
+			return "my.special.plugin"
 
 		func get_visible_name():
-		    return "Special Mesh Importer"
+			return "Special Mesh Importer"
 
 		func get_recognized_extensions():
-		    return ["special", "spec"]
+			return ["special", "spec"]
 
 		func get_save_extension():
-		    return "mesh"
+			return "mesh"
 
 		func get_resource_type():
-		    return "Mesh"
+			return "Mesh"
 
 		func get_preset_count():
-		    return 1
+			return 1
 
 		func get_preset_name(i):
-		    return "Default"
+			return "Default"
 
 		func get_import_options(i):
-		    return [{"name": "my_option", "default_value": false}]
+			return [{"name": "my_option", "default_value": false}]
 
 		func load(src, dst, opts, r_platform_variants, r_gen_files):
-		    var file = File.new()
-		    if file.open(src, File.READ) != OK:
-		        return FAILED
+			var file = File.new()
+			if file.open(src, File.READ) != OK:
+				return FAILED
 
-		    var mesh = Mesh.new()
+			var mesh = Mesh.new()
 
-		    var save = dst + "." + get_save_extension()
-		    ResourceSaver.save(file, mesh)
-		    return OK
+			var save = dst + "." + get_save_extension()
+			ResourceSaver.save(file, mesh)
+			return OK
 		[/codeblock]
 	</description>
 	<tutorials>

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -31,7 +31,9 @@
 			</argument>
 			<description>
 				Add a custom control to a container (see CONTAINER_* enum). There are many locations where custom controls can be added in the editor UI.
+
 				Please remember that you have to manage the visibility of your custom controls yourself (and likely hide it after adding it).
+
 				If your plugin is being removed, also make sure to remove your custom controls too.
 			</description>
 		</method>
@@ -44,7 +46,9 @@
 			</argument>
 			<description>
 				Add the control to a specific dock slot (see DOCK_* enum for options).
+
 				If the dock is repositioned and as long as the plugin is active, the editor will save the dock position on further sessions.
+
 				If your plugin is being removed, also make sure to remove your control by calling [method remove_control_from_docks].
 			</description>
 		</method>
@@ -60,9 +64,10 @@
 			<argument index="3" name="icon" type="Texture">
 			</argument>
 			<description>
-				Add a custom type, which will appear in the list of nodes or resources. An icon can be optionally passed.
-				When given node or resource is selected, the base type will be instanced (ie, "Spatial", "Control", "Resource"), then the script will be loaded and set to this object.
+				Add a custom type, which will appear in the list of nodes or resources. An icon can be optionally passed. When given node or resource is selected, the base type will be instanced (ie, "Spatial", "Control", "Resource"), then the script will be loaded and set to this object.
+
 				You can use the [method EditorPlugin.handles] to check if your custom object is being edited by checking the script or using 'is' keyword.
+
 				During run-time, this will be a simple object with a script so this function does not need to be called then.
 			</description>
 		</method>
@@ -97,6 +102,7 @@
 			</return>
 			<description>
 				This method is called when the editor is about to save the project, switch to another tab, etc. It asks the plugin to apply any pending state changes to ensure consistency.
+
 				This is used, for example, in shader editors to let the plugin know that it must apply the shader code being written by the user to the object.
 			</description>
 		</method>
@@ -155,6 +161,7 @@
 			</argument>
 			<description>
 				Implement this function if you are interested in 3D view screen input events. It will be called only if currently selected node is handled by your plugin.
+
 				If you would like to always gets those input events then additionally use [method set_input_forwarding_always_enabled].
 			</description>
 		</method>
@@ -237,6 +244,7 @@
 			</argument>
 			<description>
 				This function will be called when the editor is requested to become visible. It is used for plugins that edit a specific object type.
+
 				Remember that you have to manage the visibility of all your editor controls manually.
 			</description>
 		</method>

--- a/doc/classes/EditorResourcePreviewGenerator.xml
+++ b/doc/classes/EditorResourcePreviewGenerator.xml
@@ -17,9 +17,9 @@
 			<argument index="0" name="from" type="Resource">
 			</argument>
 			<description>
-				Generate a preview from a given resource. This must be always implemented.
-			Returning an empty texture is an OK way to fail and let another generator take care.
-			Care must be taken because this function is always called from a thread (not the main thread).
+				Generate a preview from a given resource. This must be always implemented. Returning an empty texture is an OK way to fail and let another generator take care.
+
+				Care must be taken because this function is always called from a thread (not the main thread).
 			</description>
 		</method>
 		<method name="generate_from_path" qualifiers="virtual">
@@ -28,9 +28,9 @@
 			<argument index="0" name="path" type="String">
 			</argument>
 			<description>
-				Generate a preview directly from a path, implementing this is optional, as default code will load and call generate()
-			Returning an empty texture is an OK way to fail and let another generator take care.
-			Care must be taken because this function is always called from a thread (not the main thread).
+				Generate a preview directly from a path, implementing this is optional, as default code will load and call [method generate]. Returning an empty texture is an OK way to fail and let another generator take care.
+
+				Care must be taken because this function is always called from a thread (not the main thread).
 			</description>
 		</method>
 		<method name="handles" qualifiers="virtual">

--- a/doc/classes/EditorScript.xml
+++ b/doc/classes/EditorScript.xml
@@ -5,14 +5,16 @@
 	</brief_description>
 	<description>
 		Scripts extending this class and implementing its [code]_run()[/code] method can be executed from the Script Editor's [code]File -&gt; Run[/code] menu option (or by pressing [code]CTRL+Shift+X[/code]) while the editor is running. This is useful for adding custom in-editor functionality to Godot. For more complex additions, consider using [EditorPlugin]s instead. Note that extending scripts need to have [code]tool mode[/code] enabled.
+
 		Example script:
 		[codeblock]
 		tool
 		extends EditorScript
 		
 		func _run():
-		    print("Hello from the Godot Editor!")
+			print("Hello from the Godot Editor!")
 		[/codeblock]
+
 		Note that the script is run in the Editor context, which means the output is visible in the console window started with the Editor (STDOUT) instead of the usual Godot [i]Output[/i] dock.
 	</description>
 	<tutorials>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Object that holds the project-independent editor settings. These settings are generally visible in the Editor Settings menu.
+
 		Accessing the settings is done by using the regular [Object] API, such as:
 		[codeblock]
 		settings.set(prop,value)
@@ -24,15 +25,16 @@
 			</argument>
 			<description>
 				Add a custom property info to a property. The dictionary must contain: name:[String](the name of the property) and type:[int](see TYPE_* in [@Global Scope]), and optionally hint:[int](see PROPERTY_HINT_* in [@Global Scope]), hint_string:[String].
-				Example:
+
+				For example:
 				[codeblock]
 				editor_settings.set("category/property_name", 0)
 
 				var property_info = {
-				    "name": "category/property_name",
-				    "type": TYPE_INT,
-				    "hint": PROPERTY_HINT_ENUM,
-				    "hint_string": "one,two,three"
+					"name": "category/property_name",
+					"type": TYPE_INT,
+					"hint": PROPERTY_HINT_ENUM,
+					"hint_string": "one,two,three"
 				}
 
 				editor_settings.add_property_info(property_info)
@@ -82,8 +84,9 @@
 			</return>
 			<description>
 				Get the global settings path for the engine. Inside this path you can find some standard paths such as:
-				settings/tmp - used for temporary storage of files
-				settings/templates - where export templates are located
+
+				[code]settings/tmp[/code] - used for temporary storage of files
+				[code]settings/templates[/code] - where export templates are located
 			</description>
 		</method>
 		<method name="has_setting" qualifiers="const">

--- a/doc/classes/EditorSpatialGizmo.xml
+++ b/doc/classes/EditorSpatialGizmo.xml
@@ -41,6 +41,7 @@
 			</argument>
 			<description>
 				Add a list of handles (points) which can be used to deform the object being edited.
+
 				There are virtual functions which will be called upon editing of these handles. Call this function during [method redraw].
 			</description>
 		</method>
@@ -97,6 +98,7 @@
 			</argument>
 			<description>
 				Commit a handle being edited (handles must have been previously added by [method add_handles]).
+
 				If the cancel parameter is true, an option to restore the edited value to the original is provided.
 			</description>
 		</method>
@@ -107,6 +109,7 @@
 			</argument>
 			<description>
 				Get the name of an edited handle (handles must have been previously added by [method add_handles]).
+
 				Handles can be named for reference to the user when editing.
 			</description>
 		</method>
@@ -137,6 +140,7 @@
 			</argument>
 			<description>
 				This function is used when the user drags a gizmo handle (previously added with [method add_handles]) in screen coordinates.
+
 				The [Camera] is also provided so screen coordinates can be converted to raycasts.
 			</description>
 		</method>

--- a/doc/classes/File.xml
+++ b/doc/classes/File.xml
@@ -5,20 +5,21 @@
 	</brief_description>
 	<description>
 		File type. This is used to permanently store data into the user device's file system and to read from it. This can be used to store game save data or player configuration files, for example.
+
 		Here's a sample on how to write and read from a file:
 		[codeblock]
 		func save(content):
-		    var file = File.new()
-		    file.open("user://save_game.dat", file.WRITE)
-		    file.store_string(content)
-		    file.close()
+			var file = File.new()
+			file.open("user://save_game.dat", file.WRITE)
+			file.store_string(content)
+			file.close()
 
 		func load():
-		    var file = File.new()
-		    file.open("user://save_game.dat", file.READ)
-		    var content = file.get_as_text()
-		    file.close()
-		    return content
+			var file = File.new()
+			file.open("user://save_game.dat", file.READ)
+			var content = file.get_as_text()
+			file.close()
+			return content
 		[/codeblock]
 	</description>
 	<tutorials>
@@ -281,6 +282,7 @@
 			</argument>
 			<description>
 				If [code]true[/code] the file's endianness is swapped. Use this if you're dealing with files written in big endian machines.
+
 				Note that this is about the file format, not CPU type. This is always reseted to [code]false[/code] whenever you open the file.
 			</description>
 		</method>

--- a/doc/classes/FuncRef.xml
+++ b/doc/classes/FuncRef.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		In GDScript, functions are not [i]first-class objects[/i]. This means it is impossible to store them directly as variables, return them from another function, or pass them as arguments.
+
 		However, by creating a [code]FuncRef[/code] using the [method @GDScript.funcref] function, a reference to a function in a given object can be created, passed around and called.
 	</description>
 	<tutorials>

--- a/doc/classes/GDFunctionState.xml
+++ b/doc/classes/GDFunctionState.xml
@@ -18,6 +18,7 @@
 			</argument>
 			<description>
 				Check whether the function call may be resumed. This is not the case if the function state was already resumed.
+
 				If [code]extended_check[/code] is enabled, it also checks if the associated script and object still exist. The extended check is done in debug mode as part of [method GDFunctionState.resume], but you can use this if you know you may be trying to resume without knowing for sure the object and/or script have survived up to that point.
 			</description>
 		</method>
@@ -28,7 +29,9 @@
 			</argument>
 			<description>
 				Resume execution of the yielded function call.
+
 				If handed an argument, return the argument from the [method @GDScript.yield] call in the yielded function call. You can pass e.g. an [Array] to hand multiple arguments.
+
 				This function returns what the resumed function call returns, possibly another function state if yielded again.
 			</description>
 		</method>

--- a/doc/classes/GDScript.xml
+++ b/doc/classes/GDScript.xml
@@ -24,6 +24,7 @@
 			</return>
 			<description>
 				Returns a new instance of the script.
+
 				For example:
 				[codeblock]
 				var MyClass = load("myclass.gd")

--- a/doc/classes/Generic6DOFJoint.xml
+++ b/doc/classes/Generic6DOFJoint.xml
@@ -122,8 +122,7 @@
 	</methods>
 	<members>
 		<member name="angular_limit_x/damping" type="float" setter="set_param_x" getter="get_param_x">
-			The amount of rotational damping across the x-axis.
-			The lower, the longer an impulse from one side takes to travel to the other side.
+			The amount of rotational damping across the x-axis. The lower, the longer an impulse from one side takes to travel to the other side.
 		</member>
 		<member name="angular_limit_x/enabled" type="bool" setter="set_flag_x" getter="get_flag_x">
 			If [code]true[/code] rotation across the x-axis is enabled.

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		GraphEdit manages the showing of GraphNodes it contains, as well as connections and disconnections between them. Signals are sent for each of these two events. Disconnection between GraphNodes slots is disabled by default.
+
 		It is greatly advised to enable low processor usage mode (see [method OS.set_low_processor_usage_mode]) when using GraphEdits.
 	</description>
 	<tutorials>

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Hyper-text transfer protocol client. Supports SSL and SSL server certificate verification.
+
 		Can be reused to connect to different hosts and make many requests.
 	</description>
 	<tutorials>
@@ -32,8 +33,10 @@
 			</argument>
 			<description>
 				Connect to a host. This needs to be done before any requests are sent.
+
 				The host should not have http:// prepended but will strip the protocol identifier if provided.
-				verify_host will check the SSL identity of the host if set to true.
+
+				[code]verify_host[/code] will check the SSL identity of the host if set to true.
 			</description>
 		</method>
 		<method name="get_connection" qualifiers="const">
@@ -69,8 +72,9 @@
 			</return>
 			<description>
 				Returns all response headers as dictionary where the case-sensitivity of the keys and values is kept like the server delivers it. A value is a simple String, this string can have more than one value where "; " is used as separator.
-				Structure: ("key":"value1; value2")
-				Example: (content-length:12), (Content-Type:application/json; charset=UTF-8)
+
+				Structure: [code]("key":"value1; value2")[/code]
+				Example: [code](content-length:12), (Content-Type:application/json; charset=UTF-8)[/code]
 			</description>
 		</method>
 		<method name="get_status" qualifiers="const">
@@ -141,8 +145,10 @@
 			<argument index="3" name="body" type="String" default="&quot;&quot;">
 			</argument>
 			<description>
-				Sends a request to the connected host. The url is what is normally behind the hostname, i.e. in [code]http://somehost.com/index.php[/code], url would be "index.php".
-				Headers are HTTP request headers.
+				Sends a request to the connected host. The url is what is normally behind the hostname, i.e. in [code]http://somehost.com/index.php[/code], [code]url[/code] would be "index.php".
+
+				[code]headers[/code] is an array of HTTP request headers.
+
 				To create a POST request with query strings to push to the server, do:
 				[codeblock]
 				var fields = {"username" : "user", "password" : "pass"}
@@ -164,8 +170,10 @@
 			<argument index="3" name="body" type="PoolByteArray">
 			</argument>
 			<description>
-				Sends a raw request to the connected host. The url is what is normally behind the hostname, i.e. in [code]http://somehost.com/index.php[/code], url would be "index.php".
-				Headers are HTTP request headers.
+				Sends a raw request to the connected host. The url is what is normally behind the hostname, i.e. in [code]http://somehost.com/index.php[/code], [code]url[/code] would be "index.php".
+
+				[code]headers[/code] is an array of HTTP request headers.
+
 				Sends body raw, as a byte array, does not encode it in any way.
 			</description>
 		</method>

--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A Node with the ability to send HTTP requests. Uses a [HTTPClient] internally, supports HTTPS.
+
 		Can be used to make HTTP requests or download files via HTTP.
 	</description>
 	<tutorials>

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -376,7 +376,7 @@
 			<argument index="2" name="color" type="Color">
 			</argument>
 			<description>
-				Sets the [Color] of the pixel at [code](x, y)[/code] if the image is unlocked. Example:
+				Sets the [Color] of the pixel at [code](x, y)[/code] if the image is unlocked. For example:
 				[code]
 				var img = Image.new()
 				img.lock()

--- a/doc/classes/ImmediateGeometry.xml
+++ b/doc/classes/ImmediateGeometry.xml
@@ -44,7 +44,8 @@
 			</argument>
 			<description>
 				Begin drawing (And optionally pass a texture override). When done call end(). For more information on how this works, search for glBegin() glEnd() references.
-			For the type of primitive, use the [Mesh].PRIMITIVE_* enumerations.
+
+				For the type of primitive, use the [Mesh].PRIMITIVE_* enumerations.
 			</description>
 		</method>
 		<method name="clear">

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -302,7 +302,8 @@
 			</argument>
 			<description>
 				Starts to vibrate the joypad. Joypads usually come with two rumble motors, a strong and a weak one. weak_magnitude is the strength of the weak motor (between 0 and 1) and strong_magnitude is the strength of the strong motor (between 0 and 1). duration is the duration of the effect in seconds (a duration of 0 will try to play the vibration indefinitely).
-				Note that not every hardware is compatible with long effect durations, it is recommended to restart an effect if in need to play it for more than a few seconds.
+
+				Note that not every hardware is compatible with long effect durations, it is recommended to restart an effect if you need to play it for more than a few seconds.
 			</description>
 		</method>
 		<method name="stop_joy_vibration">

--- a/doc/classes/InstancePlaceholder.xml
+++ b/doc/classes/InstancePlaceholder.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Turning on the option [b]Load As Placeholder[/b] for an instanced scene in the editor causes it to be replaced by an InstacePlaceholder when running the game. This makes it possible to delay actually loading the scene until calling [method replace_by_instance]. This is useful to avoid loading large scenes all at once by loading parts of it selectively.
+
 		The InstancePlaceholder does not have a transform. This causes any child nodes to be positioned relatively to the Viewport from point (0,0), rather than their parent as displayed in the editor. Replacing the placeholder with a scene with a transform will transform children relatively to their parent again.
 	</description>
 	<tutorials>

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -4,10 +4,9 @@
 		Control that provides a list of selectable items (and/or icons) in a single column, or optionally in multiple columns.
 	</brief_description>
 	<description>
-		This control provides a selectable list of items that may be in a single (or multiple columns) with option of text, icons,
-		or both text and icon.  Tooltips are supported and may be different for every item in the list.  Selectable items in the list
-		may be selected or deselected and multiple selection may be enabled.  Selection with right mouse button may also be enabled
-		to allow use of popup context menus.  Items may also be 'activated' with a double click (or Enter key).
+		This control provides a selectable list of items that may be in a single (or multiple columns) with option of text, icons, or both text and icon. Tooltips are also supported and may be different for every item in the list.
+
+		Selectable items in the list may be selected or deselected and multiple selection may be enabled.  Selection with right mouse button may also be enabled to allow use of popup context menus.  Items may also be 'activated' with a double click (or Enter key).
 	</description>
 	<tutorials>
 	</tutorials>
@@ -36,7 +35,8 @@
 			</argument>
 			<description>
 				Adds an item to the item list with specified text.  Specify an icon of null for a list item with no icon.
-				If selectable is true the list item will be selectable.
+
+				If [code]selectable[/code] is true the list item will be selectable.
 			</description>
 		</method>
 		<method name="clear">
@@ -254,7 +254,8 @@
 			</argument>
 			<description>
 				Select the item at the specified index.
-				Note:  This method does not trigger the item selection signal.
+
+				[b]Note:[/b] This method does not trigger the item selection signal.
 			</description>
 		</method>
 		<method name="set_allow_rmb_select">
@@ -325,8 +326,7 @@
 			<argument index="1" name="disabled" type="bool">
 			</argument>
 			<description>
-				Disable (or enable) item at specified index.
-				Disabled items are not be selectable and do not fire activation (Enter or double-click) signals.
+				Disable (or enable) item at specified index. Disabled items can not be selected and do not fire activation (Enter or double-click) signals.
 			</description>
 		</method>
 		<method name="set_item_icon">
@@ -494,8 +494,8 @@
 			</argument>
 			<description>
 				Fired when specified list item has been selected via right mouse clicking.
-				The click position is also provided to allow appropriate popup of context menus
-				at the correct location.
+
+				The click position is also provided to allow appropriate popup of context menus at the correct location.
 			</description>
 		</signal>
 		<signal name="item_selected">

--- a/doc/classes/JSONParseResult.xml
+++ b/doc/classes/JSONParseResult.xml
@@ -80,7 +80,9 @@
 		</member>
 		<member name="result" type="Variant" setter="set_result" getter="get_result">
 			A [Variant] containing the parsed JSON. Use typeof() to check if it is what you expect. For example, if JSON source starts with braces [code]{}[/code] a [Dictionary] will be returned, if JSON source starts with array braces [code][][/code] an [Array] will be returned.
-			[i]Be aware that the JSON specification does not define integer or float types, but only a number type. Therefore, parsing a JSON text will convert all numerical values to float types.[/i]
+
+			[b]Note:[/b] Be aware that the JSON specification does not define integer or float types, but only a number type. Therefore, parsing a JSON text will convert all numerical values to float types.
+
 			[codeblock]
 			p = JSON.parse('["hello", "world", "!"]')
 			if typeof(p) == TYPE_ARRAY:

--- a/doc/classes/KinematicBody.xml
+++ b/doc/classes/KinematicBody.xml
@@ -5,7 +5,9 @@
 	</brief_description>
 	<description>
 		Kinematic bodies are special types of bodies that are meant to be user-controlled. They are not affected by physics at all (to other types of bodies, such a character or a rigid body, these are the same as a static body). They have however, two main uses:
+
 		Simulated Motion: When these bodies are moved manually, either from code or from an AnimationPlayer (with process mode set to fixed), the physics will automatically compute an estimate of their linear and angular velocity. This makes them very useful for moving platforms or other AnimationPlayer-controlled objects (like a door, a bridge that opens, etc).
+
 		Kinematic Characters: KinematicBody also has an API for moving objects (the [method move_and_collide] and [method move_and_slide] methods) while performing collision tests. This makes them really useful to implement characters that collide against a world, but that don't require advanced physics.
 	</description>
 	<tutorials>
@@ -87,11 +89,16 @@
 			</argument>
 			<description>
 				Moves the body along a vector. If the body collides with another, it will slide along the other body rather than stop immediately. If the other body is a [code]KinematicBody[/code] or [RigidBody], it will also be affected by the motion of the other body. You can use this to make moving or rotating platforms, or to make nodes push other nodes.
+
 				[code]linear_velocity[/code] is a value in pixels per second. Unlike in for example [method move_and_collide], you should [i]not[/i] multiply it with [code]delta[/code] — this is done by the method.
+
 				[code]floor_normal[/code] is the up direction, used to determine what is a wall and what is a floor or a ceiling. If set to the default value of [code]Vector2(0, 0)[/code], everything is considered a wall. This is useful for topdown games.
+
 				If the body is standing on a slope and the horizontal speed (relative to the floor's speed) goes below [code]slope_stop_min_velocity[/code], the body will stop completely. This prevents the body from sliding down slopes when you include gravity in [code]linear_velocity[/code]. When set to lower values, the body will not be able to stand still on steep slopes.
+
 				If the body collides, it will change direction a maximum of [code]max_bounces[/code] times before it stops.
 				[code]floor_max_angle[/code] is the maximum angle (in radians) where a slope is still considered a floor (or a ceiling), rather than a wall. The default value equals 45 degrees.
+
 				Returns the movement that remained when the body stopped. To get more detailed information about collisions that occured, use [method get_slide_collision].
 			</description>
 		</method>

--- a/doc/classes/KinematicBody2D.xml
+++ b/doc/classes/KinematicBody2D.xml
@@ -5,7 +5,9 @@
 	</brief_description>
 	<description>
 		Kinematic bodies are special types of bodies that are meant to be user-controlled. They are not affected by physics at all (to other types of bodies, such a character or a rigid body, these are the same as a static body). They have however, two main uses:
+
 		Simulated Motion: When these bodies are moved manually, either from code or from an AnimationPlayer (with process mode set to fixed), the physics will automatically compute an estimate of their linear and angular velocity. This makes them very useful for moving platforms or other AnimationPlayer-controlled objects (like a door, a bridge that opens, etc).
+
 		Kinematic Characters: KinematicBody2D also has an API for moving objects (the [method move_and_collide] and [method move_and_slide] methods) while performing collision tests. This makes them really useful to implement characters that collide against a world, but that don't require advanced physics.
 	</description>
 	<tutorials>
@@ -87,11 +89,17 @@
 			</argument>
 			<description>
 				Moves the body along a vector. If the body collides with another, it will slide along the other body rather than stop immediately. If the other body is a [code]KinematicBody2D[/code] or [RigidBody2D], it will also be affected by the motion of the other body. You can use this to make moving or rotating platforms, or to make nodes push other nodes.
+
 				[code]linear_velocity[/code] is a value in pixels per second. Unlike in for example [method move_and_collide], you should [i]not[/i] multiply it with [code]delta[/code] — this is done by the method.
+
 				[code]floor_normal[/code] is the up direction, used to determine what is a wall and what is a floor or a ceiling. If set to the default value of [code]Vector2(0, 0)[/code], everything is considered a wall. This is useful for topdown games.
+
 				If the body is standing on a slope and the horizontal speed (relative to the floor's speed) goes below [code]slope_stop_min_velocity[/code], the body will stop completely. This prevents the body from sliding down slopes when you include gravity in [code]linear_velocity[/code]. When set to lower values, the body will not be able to stand still on steep slopes.
+
 				If the body collides, it will change direction a maximum of [code]max_bounces[/code] times before it stops.
+
 				[code]floor_max_angle[/code] is the maximum angle (in radians) where a slope is still considered a floor (or a ceiling), rather than a wall. The default value equals 45 degrees.
+
 				Returns the movement that remained when the body stopped. To get more detailed information about collisions that occured, use [method get_slide_collision].
 			</description>
 		</method>

--- a/doc/classes/KinematicCollision.xml
+++ b/doc/classes/KinematicCollision.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Contains collision data for KinematicBody collisions. When a [KinematicBody] is moved using [method KinematicBody.move_and_collide], it stops if it detects a collision with another body. If a collision is detected, a KinematicCollision object is returned.
+
 		This object contains information about the collision, including the colliding object, the remaining motion, and the collision position. This information can be used to calculate a collision response.
 	</description>
 	<tutorials>

--- a/doc/classes/KinematicCollision2D.xml
+++ b/doc/classes/KinematicCollision2D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Contains collision data for KinematicBody2D collisions. When a [KinematicBody2D] is moved using [method KinematicBody2D.move_and_collide], it stops if it detects a collision with another body. If a collision is detected, a KinematicCollision2D object is returned.
+
 		This object contains information about the collision, including the colliding object, the remaining motion, and the collision position. This information can be used to calculate a collision response.
 	</description>
 	<tutorials>

--- a/doc/classes/LargeTexture.xml
+++ b/doc/classes/LargeTexture.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A Texture capable of storing many smaller Textures with offsets.
+
 		You can dynamically add pieces([Texture]) to this [code]LargeTexture[/code] using different offsets.
 	</description>
 	<tutorials>
@@ -90,6 +91,7 @@
 	<members>
 		<member name="_data" type="Array" setter="_set_data" getter="_get_data">
 			Returns an [Array] with offsets and textures data of each added piece. Schema is [offsets1, texture1, offsets2, texture2, large_texture_size].
+
 			[code]offsets[/code] : [Vector2] offsets of the texture piece.
 			[code]second[/code] : [StreamTexture] data of the texture piece.
 			[code]last entry[/code] : [Vector2] size of the entire large texture.

--- a/doc/classes/MultiMesh.xml
+++ b/doc/classes/MultiMesh.xml
@@ -5,8 +5,11 @@
 	</brief_description>
 	<description>
 		MultiMesh provides low level mesh instancing. If the amount of [Mesh] instances needed goes from hundreds to thousands (and most need to be visible at close proximity) creating such a large amount of [MeshInstance] nodes may affect performance by using too much CPU or video memory.
+
 		For this case a MultiMesh becomes very useful, as it can draw thousands of instances with little API overhead.
+
 		As a drawback, if the instances are too far away of each other, performance may be reduced as every single instance will always rendered (they are spatially indexed as one, for the whole object).
+
 		Since instances may have any behavior, the Rect3 used for visibility must be provided by the user.
 	</description>
 	<tutorials>

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -5,15 +5,29 @@
 	</brief_description>
 	<description>
 		Nodes are the base bricks with which Godot games are developed. They can be set as children of other nodes, resulting in a tree arrangement. A given node can contain any number of nodes as children (but there is only one scene tree root node) with the requirement that all siblings (direct children of a node) should have unique names.
+
 		Any tree of nodes is called a [i]scene[/i]. Scenes can be saved to the disk and then instanced into other scenes. This allows for very high flexibility in the architecture and data model of the projects. Nodes can optionally be added to groups. This makes it easy to reach a number of nodes from the code (for example an "enemies" group) to perform grouped actions.
-		[b]Scene tree:[/b] The [SceneTree] contains the active tree of nodes. When a node is added to the scene tree, it receives the NOTIFICATION_ENTER_TREE notification and its [method _enter_tree] callback is triggered. Children nodes are always added [i]after[/i] their parent node, i.e. the [method _enter_tree] callback of a parent node will be triggered before its child's.
+
+		[b]Scene tree:[/b]
+
+		The [SceneTree] contains the active tree of nodes. When a node is added to the scene tree, it receives the NOTIFICATION_ENTER_TREE notification and its [method _enter_tree] callback is triggered. Children nodes are always added [i]after[/i] their parent node, i.e. the [method _enter_tree] callback of a parent node will be triggered before its child's.
+
 		Once all nodes have been added in the scene tree, they receive the NOTIFICATION_READY notification and their respective [method _ready] callbacks are triggered. For groups of nodes, the [method _ready] callback is called in reverse order, from the children up to the parent nodes.
+
 		It means that when adding a scene to the scene tree, the following order will be used for the callbacks: [method _enter_tree] of the parent, [method _enter_tree] of the children, [method _ready] of the children and finally [method _ready] of the parent (and that recursively for the whole scene).
-		[b]Processing:[/b] Nodes can be set to the "process" state, so that they receive a callback on each frame requesting them to process (do something). Normal processing (callback [method _process], toggled with [method set_process]) happens as fast as possible and is dependent on the frame rate, so the processing time [i]delta[/i] is variable. Physics processing (callback [method _physics_process], toggled with [method set_physics_process]) happens a fixed amount of times per second (by default 60) and is useful to link itself to the physics.
+
+		[b]Processing:[/b]
+
+		Nodes can be set to the "process" state, so that they receive a callback on each frame requesting them to process (do something). Normal processing (callback [method _process], toggled with [method set_process]) happens as fast as possible and is dependent on the frame rate, so the processing time [i]delta[/i] is variable. Physics processing (callback [method _physics_process], toggled with [method set_physics_process]) happens a fixed amount of times per second (by default 60) and is useful to link itself to the physics.
+
 		Nodes can also process input events. When set, the [method _input] function will be called for each input that the program receives. In many cases, this can be overkill (unless used for simple projects), and the [method _unhandled_input] function might be preferred; it is called when the input event was not handled by anyone else (typically, GUI [Control] nodes), ensuring that the node only receives the events that were meant for it.
 		To keep track of the scene hierarchy (especially when instancing scenes into other scenes), an "owner" can be set for the node with [method set_owner]. This keeps track of who instanced what. This is mostly useful when writing editors and tools, though.
+
 		Finally, when a node is freed with [method free] or [method queue_free], it will also free all its children.
-		[b]Networking with nodes:[/b] After connecting to a server (or making one, see [NetworkedMultiplayerENet]) it is possible to use the built-in RPC (remote procedure call) system to easily communicate over the network. By calling [method rpc] with a method name, it will be called locally, and in all connected peers (peers = clients and the server that accepts connections), with behaviour varying depending on the network mode ([method set_network_mode]) on the receiving peer. To identify which [code]Node[/code] receives the RPC call Godot will use its [NodePath] (make sure node names are the same on all peers).
+
+		[b]Networking with nodes:[/b]
+
+		After connecting to a server (or making one, see [NetworkedMultiplayerENet]) it is possible to use the built-in RPC (remote procedure call) system to easily communicate over the network. By calling [method rpc] with a method name, it will be called locally, and in all connected peers (peers = clients and the server that accepts connections), with behaviour varying depending on the network mode ([method set_network_mode]) on the receiving peer. To identify which [code]Node[/code] receives the RPC call Godot will use its [NodePath] (make sure node names are the same on all peers).
 	</description>
 	<tutorials>
 	</tutorials>
@@ -25,6 +39,7 @@
 			</return>
 			<description>
 				Called when the node enters the [SceneTree] (e.g. upon instancing, scene changing or after calling [method add_child] in a script). If the node has children, its [method _enter_tree] callback will be called first, and then that of the children.
+
 				Corresponds to the NOTIFICATION_ENTER_TREE notification in [method Object._notification].
 			</description>
 		</method>
@@ -33,6 +48,7 @@
 			</return>
 			<description>
 				Called when the node leaves the [SceneTree] (e.g. upon freeing, scene changing or after calling [method remove_child] in a script). If the node has children, its [method _exit_tree] callback will be called last, after all its children have left the tree.
+
 				Corresponds to the NOTIFICATION_EXIT_TREE notification in [method Object._notification].
 			</description>
 		</method>
@@ -52,7 +68,9 @@
 			</argument>
 			<description>
 				Called during the physics processing step of the main loop. Physics processing means that the frame rate is synced to the physics, i.e. the [code]delta[/code] variable should be constant.
+
 				It is only called if physics processing has been enabled with [method set_physics_process].
+
 				Corresponds to the NOTIFICATION_PHYSICS_PROCESS notification in [method Object._notification].
 			</description>
 		</method>
@@ -63,7 +81,9 @@
 			</argument>
 			<description>
 				Called during the processing step of the main loop. Processing happens at every frame and as fast as possible, so the [code]delta[/code] time since the previous frame is not constant.
+
 				It is only called if processing has been enabled with [method set_process].
+
 				Corresponds to the NOTIFICATION_PROCESS notification in [method Object._notification].
 			</description>
 		</method>
@@ -72,6 +92,7 @@
 			</return>
 			<description>
 				Called when the node is "ready", i.e. when both the node and its children have entered the scene tree. If the node has children, their [method _ready] callback gets triggered first, and the node will receive the ready notification only afterwards.
+
 				Corresponds to the NOTIFICATION_READY notification in [method Object._notification].
 			</description>
 		</method>
@@ -101,6 +122,7 @@
 			</argument>
 			<description>
 				Add a child [code]Node[/code]. Nodes can have as many children as they want, but every child must have a unique name. Children nodes are automatically deleted when the parent node is deleted, so deleting a whole scene is performed by deleting its topmost node.
+
 				The optional boolean argument enforces creating child nodes with human-readable names, based on the name of the node being instanced instead of its type only.
 			</description>
 		</method>
@@ -141,6 +163,7 @@
 			</argument>
 			<description>
 				Duplicate the node, returning a new [code]Node[/code].
+
 				You can fine-tune the behavior using the [code]flags[/code], which are based on the DUPLICATE_* constants.
 			</description>
 		</method>
@@ -221,8 +244,10 @@
 			</argument>
 			<description>
 				Fetch a node. The [NodePath] must be valid (or else an error will be raised) and can be either the path to child node, a relative path (from the current node to another node), or an absolute path to a node.
-				Note: fetching absolute paths only works when the node is inside the scene tree (see [method is_inside_tree]).
-				[i]Example:[/i] Assume your current node is Character and the following tree:
+
+				[b]Note:[/b] fetching absolute paths only works when the node is inside the scene tree (see [method is_inside_tree]).
+
+				For example, assume your current node is Character and the following tree:
 				[codeblock]
 				/root
 				/root/Character
@@ -233,6 +258,7 @@
 				/root/Swamp/Mosquito
 				/root/Swamp/Goblin
 				[/codeblock]
+
 				Possible paths are:
 				[codeblock]
 				get_node("Sword")

--- a/doc/classes/NodePath.xml
+++ b/doc/classes/NodePath.xml
@@ -5,7 +5,9 @@
 	</brief_description>
 	<description>
 		A pre-parsed relative or absolute path in a scene tree, for use with [method Node.get_node] and similar functions. It can reference a node, a resource within a node, or a property of a node or resource. For instance, [code]"Path2D/PathFollow2D/Sprite:texture:size"[/code] would refer to the size property of the texture resource on the node named "Sprite" which is a child of the other named nodes in the path. Note that if you want to get a resource, you must end the path with a colon, otherwise the last element will be used as a property name.
+
 		You will usually just pass a string to [method Node.get_node] and it will be automatically converted, but you may occasionally want to parse a path ahead of time with [code]NodePath[/code] or the literal syntax [code]@"path"[/code]. Exporting a [code]NodePath[/code] variable will give you a node selection widget in the properties panel of the editor, which can often be useful.
+
 		A [code]NodePath[/code] is made up of a list of node names, a list of "subnode" (resource) names, and the name of a property in the final node or resource.
 	</description>
 	<tutorials>

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -61,7 +61,8 @@
 			</argument>
 			<description>
 				Dumps the memory allocation ringlist to a file (only works in debug).
-				Entry format per line: "Address - Size - Description"
+
+				Entry format per line: [code]Address - Size - Description[/code]
 			</description>
 		</method>
 		<method name="dump_resources_to_file">
@@ -71,7 +72,9 @@
 			</argument>
 			<description>
 				Dumps all used resources to file (only works in debug).
-				Entry format per line: "Resource Type : Resource Location"
+
+				Entry format per line: [code]Resource Type : Resource Location[/code]
+
 				At the end of the file is a statistic of all used Resource Types.
 			</description>
 		</method>
@@ -159,6 +162,7 @@
 			</argument>
 			<description>
 				Get a dictionary of time values when given epoch time.
+
 				Dictionary Time values will be a union of values from [method get_time] and [method get_date] dictionaries (with the exception of dst = day light standard time, as it cannot be determined from epoch).
 			</description>
 		</method>
@@ -196,6 +200,7 @@
 			</return>
 			<description>
 				Returns the current latin keyboard variant as a String.
+
 				Possible return values are: "QWERTY", "AZERTY", "QZERTY", "DVORAK", "NEO", "COLEMAK" or "ERROR".
 			</description>
 		</method>
@@ -393,7 +398,9 @@
 			</argument>
 			<description>
 				Get an epoch time value from a dictionary of time values.
+
 				[code]datetime[/code] must be populated with the following keys: year, month, day, hour, minute, second.
+
 				You can pass the output from [method get_datetime_from_unix_time] directly into this function. Daylight savings time (dst), if present, is ignored.
 			</description>
 		</method>
@@ -460,7 +467,9 @@
 			</return>
 			<description>
 				Returns [code]true[/code] if the build is a debug build.
+
 				Returns [code]true[/code] when running in the editor.
+
 				Returns [code]false[/code] if the build is a release build.
 			</description>
 		</method>
@@ -812,9 +821,11 @@
 			<argument index="0" name="uri" type="String">
 			</argument>
 			<description>
-				Requests the OS to open a resource with the most appropriate program. For example.
-					[code]OS.shell_open("C:\\Users\name\Downloads")[/code] on Windows opens the file explorer at the downloads folders of the user.
-					[code]OS.shell_open("http://godotengine.org")[/code] opens the default web browser on the official Godot website.
+				Requests the OS to open a resource with the most appropriate program. For example:
+
+				[code]OS.shell_open("C:\\Users\name\Downloads")[/code] on Windows opens the file explorer at the downloads folders of the user.
+
+				[code]OS.shell_open("http://godotengine.org")[/code] opens the default web browser on the official Godot website.
 			</description>
 		</method>
 		<method name="show_virtual_keyboard">

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -5,9 +5,13 @@
 	</brief_description>
 	<description>
 		Base class for all non built-in types. Everything not a built-in type starts the inheritance chain from this class.
+
 		Objects do not manage memory, if inheriting from one the object will most likely have to be deleted manually (call the [method free] function from the script or delete from C++).
+
 		Some derivatives add memory management, such as [Reference] (which keeps a reference count and deletes itself automatically when no longer referenced) and [Node], which deletes the children tree when deleted.
+
 		Objects export properties, which are mainly useful for storage and editing, but not really so much in programming. Properties are exported in [method _get_property_list] and handled in [method _get] and [method _set]. However, scripting languages and C++ have simpler means to export them.
+
 		Objects also receive notifications ([method _notification]). Notifications are a simple way to notify the object about simple events, so they can all be handled together.
 	</description>
 	<tutorials>
@@ -166,6 +170,7 @@
 			</return>
 			<description>
 				Returns an [Array] of dictionaries with information about signals that are connected to this object.
+
 				Inside each [Dictionary] there are 3 fields:
 				- "source" is a reference to signal emitter.
 				- "signal_name" is name of connected signal.

--- a/doc/classes/PacketPeerUDP.xml
+++ b/doc/classes/PacketPeerUDP.xml
@@ -49,10 +49,13 @@
 			<argument index="2" name="recv_buf_size" type="int" default="65536">
 			</argument>
 			<description>
-				Make this [code]PacketPeerUDP[/code] listen on the "port" binding to "bind_address" with a buffer size "recv_buf_size".
-				If "bind_address" is set as "*" (default), the peer will listen on all available addresses (both IPv4 and IPv6).
-				If "bind_address" is set as "0.0.0.0" (for IPv4) or "::" (for IPv6), the peer will listen on all available addresses matching that IP type.
-				If "bind_address" is set to any valid address (e.g. "192.168.1.101", "::1", etc), the peer will only listen on the interface with that addresses (or fail if no interface with the given address exists).
+				Make this [code]PacketPeerUDP[/code] listen on the [code]port[/code] binding to [code]bind_address[/code] with a buffer size [code]recv_buf_size[/code].
+
+				If [code]bind_address[/code] is set as "*" (default), the peer will listen on all available addresses (both IPv4 and IPv6).
+
+				If [code]bind_address[/code] is set as "0.0.0.0" (for IPv4) or "::" (for IPv6), the peer will listen on all available addresses matching that IP type.
+
+				If [code]bind_address[/code] is set to any valid address (e.g. "192.168.1.101", "::1", etc), the peer will only listen on the interface with that addresses (or fail if no interface with the given address exists).
 			</description>
 		</method>
 		<method name="set_dest_address">

--- a/doc/classes/ParallaxLayer.xml
+++ b/doc/classes/ParallaxLayer.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A ParallaxLayer must be the child of a [ParallaxBackground] node. Each ParallaxLayer can be set to move at different speeds relative to the camera movement or the [member ParallaxBackground.scroll_offset] value.
+
 		This node's children will be affected by its scroll offset.
 	</description>
 	<tutorials>

--- a/doc/classes/Particles.xml
+++ b/doc/classes/Particles.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		3D particle node used to create a variety of particle systems and effects. [code]Particles[/code] features an emitter that generates some number of particles at a given rate.
+
 		Use the [code]process_material[/code] property to add a [ParticlesMaterial] to configure particle appearance and behavior. Alternatively, you can add a [ShaderMaterial] which will be applied to all particles.
 	</description>
 	<tutorials>

--- a/doc/classes/Particles2D.xml
+++ b/doc/classes/Particles2D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		2D particle node used to create a variety of particle systems and effects. [code]Particles2D[/code] features an emitter that generates some number of particles at a given rate.
+
 		Use the [code]process_material[/code] property to add a [ParticlesMaterial] to configure particle appearance and behavior. Alternatively, you can add a [ShaderMaterial] which will be applied to all particles.
 	</description>
 	<tutorials>

--- a/doc/classes/ParticlesMaterial.xml
+++ b/doc/classes/ParticlesMaterial.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		ParticlesMaterial defines particle properties and behavior. It is used in the [code]process_material[/code] of [Particles] and [Particles2D] emitter nodes.
+
 		Some of this material's properties are applied to each particle when emitted, while others can have a [CurveTexture] applied to vary values over the lifetime of the particle.
 	</description>
 	<tutorials>

--- a/doc/classes/PathFollow.xml
+++ b/doc/classes/PathFollow.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		This node takes its parent [Path], and returns the coordinates of a point within it, given a distance from the first vertex.
+
 		It is useful for making other nodes follow a path, without coding the movement pattern. For that, the nodes must be descendants of this node. Then, when setting an offset in this node, the descendant nodes will move accordingly.
 	</description>
 	<tutorials>
@@ -68,7 +69,9 @@
 			</argument>
 			<description>
 				The points along the [Curve3D] of the [Path] are precomputed before use, for faster calculations. The point at the requested offset is then calculated interpolating between two adjacent cached points. This may present a problem if the curve makes sharp turns, as the cached points may not follow the curve closely enough.
+
 				There are two answers to this problem: Either increase the number of cached points and increase memory consumption, or make a cubic interpolation between two points at the cost of (slightly) slower calculations.
+
 				This method controls whether the position between two cached points is interpolated linearly, or cubicly.
 			</description>
 		</method>
@@ -79,6 +82,7 @@
 			</argument>
 			<description>
 				Moves this node in the X axis. As this node's position will be set every time its offset is set, this allows many PathFollow to share the same curve (and thus the same movement pattern), yet not return the same position for a given path offset.
+
 				A similar effect may be achieved moving the this node's descendants.
 			</description>
 		</method>

--- a/doc/classes/PathFollow2D.xml
+++ b/doc/classes/PathFollow2D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		This node takes its parent [Path2D], and returns the coordinates of a point within it, given a distance from the first vertex.
+
 		It is useful for making other nodes follow a path, without coding the movement pattern. For that, the nodes must be descendants of this node. Then, when setting an offset in this node, the descendant nodes will move accordingly.
 	</description>
 	<tutorials>
@@ -68,7 +69,9 @@
 			</argument>
 			<description>
 				The points along the [Curve2D] of the [Path2D] are precomputed before use, for faster calculations. The point at the requested offset is then calculated interpolating between two adjacent cached points. This may present a problem if the curve makes sharp turns, as the cached points may not follow the curve closely enough.
+
 				There are two answers to this problem: Either increase the number of cached points and increase memory consumption, or make a cubic interpolation between two points at the cost of (slightly) slower calculations.
+
 				This method controls whether the position between two cached points is interpolated linearly, or cubicly.
 			</description>
 		</method>
@@ -79,6 +82,7 @@
 			</argument>
 			<description>
 				Moves this node horizontally. As this node's position will be set every time its offset is set, this allows many PathFollow2D to share the same curve (and thus the same movement pattern), yet not return the same position for a given path offset.
+
 				A similar effect may be achieved moving this node's descendants.
 			</description>
 		</method>

--- a/doc/classes/Performance.xml
+++ b/doc/classes/Performance.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		This class provides access to a number of different monitors related to performance, such as memory usage, draw calls, and FPS. These are the same as the values displayed in the [i]Monitor[/i] tab in the editor's [i]Debugger[/i] panel. By using the [method get_monitor] method of this class, you can access this data from your code. Note that a few of these monitors are only available in debug mode and will always return 0 when used in a release build.
+
 		Many of these monitors are not updated in real-time, so there may be a short delay between changes.
 	</description>
 	<tutorials>

--- a/doc/classes/Physics2DDirectSpaceState.xml
+++ b/doc/classes/Physics2DDirectSpaceState.xml
@@ -18,7 +18,8 @@
 			</argument>
 			<description>
 				Check whether the shape can travel to a point. If it can, the method will return an array with two floats: The first is the distance the shape can move in that direction without colliding, and the second is the distance at which it will collide.
-	If the shape can not move, the array will be empty.
+
+				If the shape can not move, the array will be empty.
 			</description>
 		</method>
 		<method name="collide_shape">
@@ -39,6 +40,7 @@
 			</argument>
 			<description>
 				Check the intersections of a shape, given through a [Physics2DShapeQueryParameters] object, against the space. If it collides with more than a shape, the nearest one is selected. The returned object is a dictionary containing the following fields:
+
 				pointo: Place where the shapes intersect.
 				normal: Normal of the object at the point where the shapes intersect.
 				shape: Shape index within the object against which the shape intersected.
@@ -47,6 +49,7 @@
 				collider: Object against which the shape intersected.
 				rid: [RID] of the object against which the shape intersected.
 				linear_velocity: The movement vector of the object the shape intersected, if it was a body. If it was an area, it is (0,0).
+
 				If the shape did not intersect anything, then an empty dictionary (dir.empty()==true) is returned instead.
 			</description>
 		</method>
@@ -65,11 +68,13 @@
 			</argument>
 			<description>
 				Check whether a point is inside any shape. The shapes the point is inside of are returned in an array containing dictionaries with the following fields:
+
 				shape: Shape index within the object the point is in.
 				metadata: Metadata of the shape the point is in. This metadata is different from [method Object.get_meta], and is set with [method Physics2DServer.shape_set_data].
 				collider_id: Id of the object the point is in.
 				collider: Object the point is inside of.
 				rid: [RID] of the object the point is in.
+
 				Additionally, the method can take an array of objects or [RID]s that are to be excluded from collisions, a bitmask representing the physics layers to check in, and another bitmask for the types of objects to check (see TYPE_MASK_* constants).
 			</description>
 		</method>
@@ -88,6 +93,7 @@
 			</argument>
 			<description>
 				Intersect a ray in a given space. The returned object is a dictionary with the following fields:
+
 				position: Place where ray is stopped.
 				normal: Normal of the object at the point where the ray was stopped.
 				shape: Shape index within the object against which the ray was stopped.
@@ -96,6 +102,7 @@
 				collider: Object against which the ray was stopped.
 				rid: [RID] of the object against which the ray was stopped.
 				If the ray did not intersect anything, then an empty dictionary (dir.empty()==true) is returned instead.
+
 				Additionally, the method can take an array of objects or [RID]s that are to be excluded from collisions, a bitmask representing the physics layers to check in, and another bitmask for the types of objects to check (see TYPE_MASK_* constants).
 			</description>
 		</method>
@@ -108,11 +115,13 @@
 			</argument>
 			<description>
 				Check the intersections of a shape, given through a [Physics2DShapeQueryParameters] object, against the space. The intersected shapes are returned in an array containing dictionaries with the following fields:
+
 				shape: Shape index within the object the shape intersected.
 				metadata: Metadata of the shape intersected by the shape given through the [Physics2DShapeQueryParameters]. This metadata is different from [method Object.get_meta], and is set with [method Physics2DServer.shape_set_data].
 				collider_id: Id of the object the shape intersected.
 				collider: Object the shape intersected.
 				rid: [RID] of the object the shape intersected.
+
 				The number of intersections can be limited with the second parameter, to reduce the processing time.
 			</description>
 		</method>

--- a/doc/classes/Physics2DServer.xml
+++ b/doc/classes/Physics2DServer.xml
@@ -173,6 +173,7 @@
 			</argument>
 			<description>
 				Sets the function to call when any body/area enters or exits the area. This callback will be called for any object interacting with the area, and takes five parameters:
+
 				1: AREA_BODY_ADDED or AREA_BODY_REMOVED, depending on whether the object entered or exited the area.
 				2: [RID] of the object that entered/exited the area.
 				3: Instance ID of the object that entered/exited the area.
@@ -555,6 +556,7 @@
 			</argument>
 			<description>
 				Sets the continuous collision detection mode from any of the CCD_MODE_* constants.
+
 				Continuous collision detection tries to predict where a moving body will collide, instead of moving it and correcting its movement if it collided.
 			</description>
 		</method>

--- a/doc/classes/PhysicsBody.xml
+++ b/doc/classes/PhysicsBody.xml
@@ -97,7 +97,9 @@
 	<members>
 		<member name="collision_layer" type="int" setter="set_collision_layer" getter="get_collision_layer">
 			The physics layers this area is in.
+
 			Collidable objects can exist in any of 32 different layers. These layers work like a tagging system, and are not visual. A collidable can use these layers to select with which objects it can collide, using the collision_mask property.
+
 			A contact is detected if object A is in any of the layers that object B scans, or object B is in any layer scanned by object A.
 		</member>
 		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask">

--- a/doc/classes/PhysicsBody2D.xml
+++ b/doc/classes/PhysicsBody2D.xml
@@ -68,7 +68,9 @@
 			</argument>
 			<description>
 				Set the physics layers this area is in.
+
 				Collidable objects can exist in any of 32 different layers. These layers are not visual, but more of a tagging system instead. A collidable can use these layers/tags to select with which objects it can collide, using [method set_collision_mask].
+
 				A contact is detected if object A is in any of the layers that object B scans, or object B is in any layer scanned by object A.
 			</description>
 		</method>
@@ -107,7 +109,9 @@
 	<members>
 		<member name="collision_layer" type="int" setter="set_collision_layer" getter="get_collision_layer">
 			The physics layers this area is in.
+
 			Collidable objects can exist in any of 32 different layers. These layers work like a tagging system, and are not visual. A collidable can use these layers to select with which objects it can collide, using the collision_mask property.
+
 			A contact is detected if object A is in any of the layers that object B scans, or object B is in any layer scanned by object A.
 		</member>
 		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask">

--- a/doc/classes/PhysicsServer.xml
+++ b/doc/classes/PhysicsServer.xml
@@ -182,6 +182,7 @@
 			</argument>
 			<description>
 				Sets the function to call when any body/area enters or exits the area. This callback will be called for any object interacting with the area, and takes five parameters:
+
 				1: AREA_BODY_ADDED or AREA_BODY_REMOVED, depending on whether the object entered or exited the area.
 				2: [RID] of the object that entered/exited the area.
 				3: Instance ID of the object that entered/exited the area.
@@ -513,6 +514,7 @@
 			</argument>
 			<description>
 				Removes a body from the list of bodies exempt from collisions.
+
 				Continuous collision detection tries to predict where a moving body will collide, instead of moving it and correcting its movement if it collided.
 			</description>
 		</method>
@@ -580,6 +582,7 @@
 			</argument>
 			<description>
 				If [code]true[/code] the continuous collision detection mode is enabled.
+
 				Continuous collision detection tries to predict where a moving body will collide, instead of moving it and correcting its movement if it collided.
 			</description>
 		</method>
@@ -1168,12 +1171,10 @@
 			The [Joint] is a [Generic6DOFJoint].
 		</constant>
 		<constant name="PIN_JOINT_BIAS" value="0">
-			The strength with which the pinned objects try to stay in positional relation to each other.
-			The higher, the stronger.
+			The strength with which the pinned objects try to stay in positional relation to each other. The higher, the stronger.
 		</constant>
 		<constant name="PIN_JOINT_DAMPING" value="1">
-			The strength with which the pinned objects try to stay in velocity relation to each other.
-			The higher, the stronger.
+			The strength with which the pinned objects try to stay in velocity relation to each other. The higher, the stronger.
 		</constant>
 		<constant name="PIN_JOINT_IMPULSE_CLAMP" value="2">
 			If above 0, this value is the maximum value for an impulse that this Joint puts on it's ends.
@@ -1283,12 +1284,10 @@
 			If below 0.05, this behaviour is locked. Default value: [code]PI/4[/code].
 		</constant>
 		<constant name="CONE_TWIST_JOINT_TWIST_SPAN" value="1">
-			Twist is the rotation around the twist axis, this value defined how far the joint can twist.
-			Twist is locked if below 0.05.
+			Twist is the rotation around the twist axis, this value defined how far the joint can twist. Twist is locked if below 0.05.
 		</constant>
 		<constant name="CONE_TWIST_JOINT_BIAS" value="2">
-			The speed with which the swing or twist will take place.
-			The higher, the faster.
+			The speed with which the swing or twist will take place. The higher, the faster.
 		</constant>
 		<constant name="CONE_TWIST_JOINT_SOFTNESS" value="3">
 			The ease with which the Joint twists, if it's too low, it takes more force to twist the joint.

--- a/doc/classes/PinJoint.xml
+++ b/doc/classes/PinJoint.xml
@@ -32,12 +32,10 @@
 	</methods>
 	<members>
 		<member name="params/bias" type="float" setter="set_param" getter="get_param">
-			The force with wich the pinned objects stay in positional relation to each other.
-			The higher, the stronger.
+			The force with wich the pinned objects stay in positional relation to each other. The higher, the stronger.
 		</member>
 		<member name="params/damping" type="float" setter="set_param" getter="get_param">
-			The force with wich the pinned objects stay in velocity relation to each other.
-			The higher, the stronger.
+			The force with wich the pinned objects stay in velocity relation to each other. The higher, the stronger.
 		</member>
 		<member name="params/impulse_clamp" type="float" setter="set_param" getter="get_param">
 			If above 0, this value is the maximum value for an impulse that this Joint produces.
@@ -45,12 +43,10 @@
 	</members>
 	<constants>
 		<constant name="PARAM_BIAS" value="0">
-			The force with wich the pinned objects stay in positional relation to each other.
-			The higher, the stronger.
+			The force with wich the pinned objects stay in positional relation to each other. The higher, the stronger.
 		</constant>
 		<constant name="PARAM_DAMPING" value="1">
-			The force with wich the pinned objects stay in velocity relation to each other.
-			The higher, the stronger.
+			The force with wich the pinned objects stay in velocity relation to each other. The higher, the stronger.
 		</constant>
 		<constant name="PARAM_IMPULSE_CLAMP" value="2">
 			If above 0, this value is the maximum value for an impulse that this Joint produces.

--- a/doc/classes/Polygon2D.xml
+++ b/doc/classes/Polygon2D.xml
@@ -198,7 +198,8 @@
 			</argument>
 			<description>
 				Set the color for each vertex of the polygon. There should be one color for every vertex in the polygon. If there are less, the undefined ones will be assumed to be [method get_color]. Extra color entries are ignored.
-	Colors are interpolated between vertices, resulting in smooth gradients when they differ.
+
+				Colors are interpolated between vertices, resulting in smooth gradients when they differ.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -48,8 +48,7 @@
 			<argument index="3" name="accel" type="int" default="0">
 			</argument>
 			<description>
-				Add a new checkable item with text "label" and icon "texture". An id can optionally be provided, as well as an accelerator. If no id is provided, one will be
-				created from the index. Note that checkable items just display a checkmark, but don't have any built-in checking behavior and must be checked/unchecked manually.
+				Add a new checkable item with text "label" and icon "texture". An id can optionally be provided, as well as an accelerator. If no id is provided, one will be created from the index. Note that checkable items just display a checkmark, but don't have any built-in checking behavior and must be checked/unchecked manually.
 			</description>
 		</method>
 		<method name="add_icon_check_shortcut">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -17,16 +17,15 @@
 			<argument index="0" name="hint" type="Dictionary">
 			</argument>
 			<description>
-				Add a custom property info to a property. The dictionary must contain: name:[String](the name of the property) and type:[int](see TYPE_* in [@Global Scope]), and optionally hint:[int](see PROPERTY_HINT_* in [@Global Scope]), hint_string:[String].
-				Example:
+				Add a custom property info to a property. The dictionary must contain: name:[String](the name of the property) and type:[int](see TYPE_* in [@Global Scope]), and optionally hint:[int](see PROPERTY_HINT_* in [@Global Scope]), hint_string:[String]. For example:
 				[codeblock]
 				ProjectSettings.set("category/property_name", 0)
 
 				var property_info = {
-				    "name": "category/property_name",
-				    "type": TYPE_INT,
-				    "hint": PROPERTY_HINT_ENUM,
-				    "hint_string": "one,two,three"
+					"name": "category/property_name",
+					"type": TYPE_INT,
+					"hint": PROPERTY_HINT_ENUM,
+					"hint_string": "one,two,three"
 				}
 
 				ProjectSettings.add_property_info(property_info)

--- a/doc/classes/Quat.xml
+++ b/doc/classes/Quat.xml
@@ -5,8 +5,11 @@
 	</brief_description>
 	<description>
 		A 4-dimensional vector representing a rotation.
+
 		The vector represents a 4 dimensional complex number where multiplication of the basis elements is not commutative (multiplying i with j gives a different result than multiplying j with i).
+
 		Multiplying quaternions reproduces rotation sequences. However quaternions need to be often renormalized, or else they suffer from precision issues.
+
 		It can be used to perform SLERP (spherical-linear interpolation) between two rotations.
 	</description>
 	<tutorials>

--- a/doc/classes/RayCast.xml
+++ b/doc/classes/RayCast.xml
@@ -5,8 +5,11 @@
 	</brief_description>
 	<description>
 		A RayCast represents a line from its origin to its destination position, [code]cast_to[/code]. It is used to query the 3D space in order to find the closest object along the path of the ray.
+
 		RayCast can ignore some objects by adding them to the exception list via [code]add_exception[/code], by setting proper filtering with collision layers, or by filtering object types with type masks.
+
 		Only enabled raycasts will be able to query the space and report collisions.
+
 		RayCast calculates intersection every physics frame (see [Node]), and the result is cached so it can be used later until the next frame. If multiple queries are required between physics frames (or during the same frame) use [method force_raycast_update] after adjusting the raycast.
 	</description>
 	<tutorials>
@@ -44,6 +47,7 @@
 			</return>
 			<description>
 				Updates the collision information for the ray.
+
 				Use this method to update the collision information immediately instead of waiting for the next [code]_physics_process[/code] call, for example if the ray or its parent has changed state. Note: [code]enabled == true[/code] is not required for this to work.
 			</description>
 		</method>
@@ -58,11 +62,10 @@
 			<return type="Object">
 			</return>
 			<description>
-				Return the closest object the ray is pointing to. Note that this does not consider the length of the ray, so you must also use [method is_colliding] to check if the object returned is actually colliding with the ray.
-				Example:
+				Return the closest object the ray is pointing to. Note that this does not consider the length of the ray, so you must also use [method is_colliding] to check if the object returned is actually colliding with the ray. For example:
 				[codeblock]
 				if RayCast.is_colliding():
-				    var collider = RayCast.get_collider()
+					var collider = RayCast.get_collider()
 				[/codeblock]
 			</description>
 		</method>
@@ -70,11 +73,10 @@
 			<return type="int">
 			</return>
 			<description>
-				Returns the collision shape of the closest object the ray is pointing to.  Note that this does not consider the length of the ray, so you must also use [method is_colliding] to check if the object returned is actually colliding with the ray.
-				Example:
+				Returns the collision shape of the closest object the ray is pointing to.  Note that this does not consider the length of the ray, so you must also use [method is_colliding] to check if the object returned is actually colliding with the ray. For example:
 				[codeblock]
 				if RayCast.is_colliding():
-				    var shape = RayCast.get_collider_shape()
+					var shape = RayCast.get_collider_shape()
 				[/codeblock]
 			</description>
 		</method>
@@ -204,8 +206,7 @@
 			If [code]true[/code], collisions will be reported. Default value: [code]false[/code].
 		</member>
 		<member name="type_mask" type="int" setter="set_type_mask" getter="get_type_mask">
-			Object types to detect using a logical sum (OR operation) of type constants defined in [Physics2DDirectSpaceState].
-			Example:
+			Object types to detect using a logical sum (OR operation) of type constants defined in [Physics2DDirectSpaceState]. For example:
 			[codeblock]
 			RayCast.type_mask = Physics2DDirectSpaceState.TYPE_MASK_STATIC_BODY | Physics2DDirectSpaceState.TYPE_MASK_KINEMATIC_BODY
 			[/codeblock]

--- a/doc/classes/RayCast2D.xml
+++ b/doc/classes/RayCast2D.xml
@@ -5,8 +5,11 @@
 	</brief_description>
 	<description>
 		A RayCast represents a line from its origin to its destination position, [code]cast_to[/code]. It is used to query the 2D space in order to find the closest object along the path of the ray.
+
 		RayCast2D can ignore some objects by adding them to the exception list via [code]add_exception[/code], by setting proper filtering with collision layers, or by filtering object types with type masks.
+
 		Only enabled raycasts will be able to query the space and report collisions.
+
 		RayCast2D calculates intersection every physics frame (see [Node]), and the result is cached so it can be used later until the next frame. If multiple queries are required between physics frames (or during the same frame) use [method force_raycast_update] after adjusting the raycast.
 	</description>
 	<tutorials>
@@ -57,8 +60,7 @@
 			<return type="Object">
 			</return>
 			<description>
-				Returns the closest object the ray is pointing to. Note that this does not consider the length of the ray, so you must also use [method is_colliding] to check if the object returned is actually colliding with the ray.
-				Example:
+				Returns the closest object the ray is pointing to. Note that this does not consider the length of the ray, so you must also use [method is_colliding] to check if the object returned is actually colliding with the ray. For example:
 				[codeblock]
 				if RayCast2D.is_colliding():
 					var collider = RayCast2D.get_collider()
@@ -69,8 +71,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Returns the collision shape of the closest object the ray is pointing to.  Note that this does not consider the length of the ray, so you must also use [method is_colliding] to check if the object returned is actually colliding with the ray.
-				Example:
+				Returns the collision shape of the closest object the ray is pointing to.  Note that this does not consider the length of the ray, so you must also use [method is_colliding] to check if the object returned is actually colliding with the ray. For example:
 				[codeblock]
 				if RayCast2D.is_colliding():
 					var shape = RayCast2D.get_collider_shape()
@@ -222,8 +223,7 @@
 			If [code]true[/code], the parent node will be excluded from collision detection. Default value: [code]true[/code].
 		</member>
 		<member name="type_mask" type="int" setter="set_type_mask" getter="get_type_mask">
-			Object types to detect using a logical sum (OR operation) of type constants defined in [Physics2DDirectSpaceState].
-			Example:
+			Object types to detect using a logical sum (OR operation) of type constants defined in [Physics2DDirectSpaceState]. For example:
 			[codeblock]
 			RayCast.type_mask = Physics2DDirectSpaceState.TYPE_MASK_STATIC_BODY | Physics2DDirectSpaceState.TYPE_MASK_KINEMATIC_BODY
 			[/codeblock]

--- a/doc/classes/RegEx.xml
+++ b/doc/classes/RegEx.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Class for finding text patterns in a string using regular expressions. It can not perform replacements. Regular expressions are a way to define patterns of text to be searched. Details on writing patterns are too long to explain here but the Internet is full of tutorials and detailed explanations.
+
 		Once created, the RegEx object needs to be compiled with the search pattern before it can be used. The search pattern must be escaped first for gdscript before it is escaped for the expression. For example:
 		[code]var exp = RegEx.new()[/code]
 		[code]exp.compile("\\d+")[/code]

--- a/doc/classes/RemoteTransform.xml
+++ b/doc/classes/RemoteTransform.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		RemoteTransform mirrors the [Transform] of another [Spatial] derived Node (called the remote node) in the scene.
+
 		It can be set to track another Node's position, rotation and/or scale and update its own accordingly, using either global or local coordinates.
 	</description>
 	<tutorials>

--- a/doc/classes/RemoteTransform2D.xml
+++ b/doc/classes/RemoteTransform2D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		RemoteTransform2D mirrors the [Transform2D] of another [CanvasItem] derived Node (called the remote node) in the scene.
+
 		It can be set to track another Node's position, rotation and/or and update its own accordingly, using either global or local coordinates.
 	</description>
 	<tutorials>

--- a/doc/classes/RigidBody.xml
+++ b/doc/classes/RigidBody.xml
@@ -5,9 +5,13 @@
 	</brief_description>
 	<description>
 		This is the node that implements full 3D physics. This means that you do not control a RigidBody directly. Instead you can apply forces to it (gravity, impulses, etc.), and the physics simulation will calculate the resulting movement, collision, bouncing, rotating, etc.
+
 		This node can use custom force integration, for writing complex physics motion behavior per node.
+
 		This node can shift state between regular Rigid body, Kinematic, Character or Static.
+
 		Character mode forbids this node from being rotated.
+
 		As a warning, don't change RigidBody's position every frame or very often. Sporadic changes work fine, but physics runs at a different granularity (fixed hz) than usual rendering (process callback) and maybe even in a separate thread, so changing this from a process loop will yield strange behavior.
 	</description>
 	<tutorials>
@@ -213,6 +217,7 @@
 			</argument>
 			<description>
 				Set the body ability to fall asleep when not moving. This saves an enormous amount of processor time when there are plenty of rigid bodies (non static) in a scene.
+
 				Sleeping bodies are not affected by forces until a collision or an [method apply_impulse] / [method set_applied_force] wakes them up. Until then, they behave like a static body.
 			</description>
 		</method>
@@ -304,6 +309,7 @@
 			</argument>
 			<description>
 				Set the continuous collision detection mode from the enum CCD_MODE_*.
+
 				Continuous collision detection tries to predict where a moving body will collide, instead of moving it and correcting its movement if it collided. The first is more precise, and misses less impacts by small, fast-moving objects. The second is faster to compute, but can miss small, fast-moving objects.
 			</description>
 		</method>
@@ -350,6 +356,7 @@
 		</member>
 		<member name="continuous_cd" type="bool" setter="set_use_continuous_collision_detection" getter="is_using_continuous_collision_detection">
 			If [code]true[/code] continuous collision detection is used.
+
 			Continuous collision detection tries to predict where a moving body will collide, instead of moving it and correcting its movement if it collided. Continuous collision detection is more precise, and misses less impacts by small, fast-moving objects. Not using continuous collision detection is faster to compute, but can miss small, fast-moving objects.
 		</member>
 		<member name="custom_integrator" type="bool" setter="set_use_custom_integrator" getter="is_using_custom_integrator">
@@ -406,6 +413,7 @@
 			</argument>
 			<description>
 				Emitted when a body enters into contact with this one. Contact monitor and contacts reported must be enabled for this to work.
+
 				This signal not only receives the body that collided with this one, but also its [RID] (body_id), the shape index from the colliding body (body_shape), and the shape index from this body (local_shape) the other body collided with.
 			</description>
 		</signal>
@@ -420,6 +428,7 @@
 			</argument>
 			<description>
 				Emitted when a body shape exits contact with this one. Contact monitor and contacts reported must be enabled for this to work.
+
 				This signal not only receives the body that stopped colliding with this one, but also its [RID] (body_id), the shape index from the colliding body (body_shape), and the shape index from this body (local_shape) the other body stopped colliding with.
 			</description>
 		</signal>

--- a/doc/classes/RigidBody2D.xml
+++ b/doc/classes/RigidBody2D.xml
@@ -5,12 +5,15 @@
 	</brief_description>
 	<description>
 		This node implements simulated 2D physics. You do not control a RigidBody2D directly. Instead you apply forces to it (gravity, impulses, etc.) and the physics simulation calculates the resulting movement based on its mass, friction, and other physical properties.
+
 		A RigidBody2D has 4 behavior modes (see [member mode]):
 		- [b]Rigid[/b]: The body behaves as a physical object. It collides with other bodies and responds to forces applied to it. This is the default mode.
 		- [b]Static[/b]: The body behaves like a [StaticBody2D] and does not move.
 		- [b]Character[/b]: Similar to [code]Rigid[/code] mode, but the body can not rotate.
 		- [b]Kinematic[/b]: The body behaves like a [KinematicBody2D], and must be moved by code.
+
 		[b]Note:[/b] You should not change a RigidBody2D's [code]position[/code] or [code]linear_velocity[/code] every frame or even very often. If you need to directly affect the body's state, use [method _integrate_forces], which allows you to directly access the physics state.
+
 		If you need to override the default physics behavior, you can write a custom force integration. See [member custom_integrator].
 	</description>
 	<tutorials>
@@ -250,6 +253,7 @@
 			</argument>
 			<description>
 				Set the body ability to fall asleep when not moving. This saves an enormous amount of processor time when there are plenty of rigid bodies (non static) in a scene.
+
 				Sleeping bodies are not affected by forces until a collision or an [method apply_impulse] / [method set_applied_force] wakes them up. Until then, they behave like a static body.
 			</description>
 		</method>
@@ -269,6 +273,7 @@
 			</argument>
 			<description>
 				Set the continuous collision detection mode from the enum CCD_MODE_*.
+
 				Continuous collision detection tries to predict where a moving body will collide, instead of moving it and correcting its movement if it collided. The first is more precise, and misses less impacts by small, fast-moving objects. The second is faster to compute, but can miss small, fast-moving objects.
 			</description>
 		</method>
@@ -406,6 +411,7 @@
 		</member>
 		<member name="continuous_cd" type="int" setter="set_continuous_collision_detection_mode" getter="get_continuous_collision_detection_mode" enum="RigidBody2D.CCDMode">
 			Continuous collision detection mode. Default value: [code]CCD_MODE_DISABLED[/code].
+
 			Continuous collision detection tries to predict where a moving body will collide instead of moving it and correcting its movement after collision. Continuous collision detection is slower, but more precise and misses fewer collisions with small, fast-moving objects. Raycasting and shapecasting methods are available. See [code]CCD_MODE_[/code] constants for details.
 		</member>
 		<member name="custom_integrator" type="bool" setter="set_use_custom_integrator" getter="is_using_custom_integrator">

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A class stored as a resource. The script exends the functionality of all objects that instance it.
+
 		The 'new' method of a script subclass creates a new instance. [method Object.set_script] extends an existing object, if that object's class matches one of the script's base classes.
 	</description>
 	<tutorials>

--- a/doc/classes/Shape2D.xml
+++ b/doc/classes/Shape2D.xml
@@ -22,6 +22,7 @@
 			</argument>
 			<description>
 				Return whether this shape is colliding with another.
+
 				This method needs the transformation matrix for this shape ([code]local_xform[/code]), the shape to check collisions with ([code]with_shape[/code]), and the transformation matrix of that shape ([code]shape_xform[/code]).
 			</description>
 		</method>
@@ -36,6 +37,7 @@
 			</argument>
 			<description>
 				Return a list of the points where this shape touches another. If there are no collisions, the list is empty.
+
 				This method needs the transformation matrix for this shape ([code]local_xform[/code]), the shape to check collisions with ([code]with_shape[/code]), and the transformation matrix of that shape ([code]shape_xform[/code]).
 			</description>
 		</method>
@@ -54,6 +56,7 @@
 			</argument>
 			<description>
 				Return whether this shape would collide with another, if a given movement was applied.
+
 				This method needs the transformation matrix for this shape ([code]local_xform[/code]), the movement to test on this shape ([code]local_motion[/code]), the shape to check collisions with ([code]with_shape[/code]), the transformation matrix of that shape ([code]shape_xform[/code]), and the movement to test onto the other object ([code]shape_motion[/code]).
 			</description>
 		</method>
@@ -72,6 +75,7 @@
 			</argument>
 			<description>
 				Return a list of the points where this shape would touch another, if a given movement was applied. If there are no collisions, the list is empty.
+
 				This method needs the transformation matrix for this shape ([code]local_xform[/code]), the movement to test on this shape ([code]local_motion[/code]), the shape to check collisions with ([code]with_shape[/code]), the transformation matrix of that shape ([code]shape_xform[/code]), and the movement to test onto the other object ([code]shape_motion[/code]).
 			</description>
 		</method>
@@ -89,6 +93,7 @@
 			</argument>
 			<description>
 				Use a custom solver bias. No need to change this unless you really know what you are doing.
+
 				The solver bias is a factor controlling how much two objects "rebound" off each other, when colliding, to avoid them getting into each other because of numerical imprecision.
 			</description>
 		</method>

--- a/doc/classes/SliderJoint.xml
+++ b/doc/classes/SliderJoint.xml
@@ -32,19 +32,16 @@
 	</methods>
 	<members>
 		<member name="angular_limit/damping" type="float" setter="set_param" getter="get_param">
-			The amount of damping of the rotation when the limit is surpassed.
-			A lower damping value allows a rotation initiated by body A to travel to body B slower.
+			The amount of damping of the rotation when the limit is surpassed. A lower damping value allows a rotation initiated by body A to travel to body B slower.
 		</member>
 		<member name="angular_limit/lower_angle" type="float" setter="_set_lower_limit_angular" getter="_get_lower_limit_angular">
 			The lower limit of rotation in the slider.
 		</member>
 		<member name="angular_limit/restitution" type="float" setter="set_param" getter="get_param">
-			The amount of restitution of the rotation when the limit is surpassed.
-			Does not affect damping.
+			The amount of restitution of the rotation when the limit is surpassed. Does not affect damping.
 		</member>
 		<member name="angular_limit/softness" type="float" setter="set_param" getter="get_param">
-			A factor applied to the all rotation once the limit is surpassed.
-			Makes all rotation slower when between 0 and 1.
+			A factor applied to the all rotation once the limit is surpassed. Makes all rotation slower when between 0 and 1.
 		</member>
 		<member name="angular_limit/upper_angle" type="float" setter="_set_upper_limit_angular" getter="_get_upper_limit_angular">
 			The upper limit of rotation in the slider.

--- a/doc/classes/Spatial.xml
+++ b/doc/classes/Spatial.xml
@@ -391,6 +391,7 @@
 	<constants>
 		<constant name="NOTIFICATION_TRANSFORM_CHANGED" value="29" enum="">
 			Spatial nodes receives this notification when their global transform changes. This means that either the current or a parent node changed its transform.
+
 			In order for NOTIFICATION_TRANSFORM_CHANGED to work user first needs to ask for it, with set_notify_transform(true).
 		</constant>
 		<constant name="NOTIFICATION_ENTER_WORLD" value="41" enum="">

--- a/doc/classes/StaticBody.xml
+++ b/doc/classes/StaticBody.xml
@@ -5,7 +5,9 @@
 	</brief_description>
 	<description>
 		Static body for 3D Physics. A static body is a simple body that is not intended to move. They don't consume any CPU resources in contrast to a [RigidBody3D] so they are great for scenario collision.
+
 		A static body can also be animated by using simulated motion mode. This is useful for implementing functionalities such as moving platforms. When this mode is active the body can be animated and automatically computes linear and angular velocity to apply in that frame and to influence other bodies.
+
 		Alternatively, a constant linear or angular velocity can be set for the static body, so even if it doesn't move, it affects other bodies as if it was moving (this is useful for simulating conveyor belts or conveyor wheels).
 	</description>
 	<tutorials>

--- a/doc/classes/StaticBody2D.xml
+++ b/doc/classes/StaticBody2D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Static body for 2D Physics. A StaticBody2D is a body that is not intended to move. It is ideal for implementing objects in the environment, such as walls or platforms.
+
 		Additionally, a constant linear or angular velocity can be set for the static body, which will affect colliding bodies as if it were moving (for example, a conveyor belt).
 	</description>
 	<tutorials>

--- a/doc/classes/StyleBoxFlat.xml
+++ b/doc/classes/StyleBoxFlat.xml
@@ -16,6 +16,7 @@
 			corner_radius_top_left = 50
 			corner_radius_bottom_left = 100
 			[/codeblock]
+
 			The relative system now would take the 1:2 ratio of the two left corners to calculate the actual corner width. Both corners added will [b]never[/b] be more than the height. Result:
 			[codeblock]
 			corner_radius_top_left: 10
@@ -296,8 +297,9 @@
 		</member>
 		<member name="corner_detail" type="int" setter="set_corner_detail" getter="get_corner_detail">
 			This sets the amount of vertices used for each corner. Higher values result in rounder corners but take more processing power to compute. When choosing a value you should take the corner radius ([method set_corner_radius]) into account.
+
 			For corner radius smaller than 10: 4-5 should be enough
-			For corner radius smaller than 30: 8-12 should be enough ...
+			For corner radius smaller than 30: 8-12 should be enough
 		</member>
 		<member name="corner_radius_bottom_left" type="int" setter="set_corner_radius" getter="get_corner_radius">
 			The corner radius of the bottom left corner. When set to 0 the corner is not rounded.

--- a/doc/classes/SurfaceTool.xml
+++ b/doc/classes/SurfaceTool.xml
@@ -12,7 +12,9 @@
 		st.add_uv(Vector2(0, 0))
 		st.add_vertex(Vector3(0, 0, 0))
 		[/codeblock]
+
 		The [code]SurfaceTool[/code] now contains one vertex of a triangle which has a UV coordinate and a specified [Color]. If another vertex were added without calls to [method add_uv] or [method add_color] then the last values would be used.
+
 		It is very important that vertex attributes are passed [b]before[/b] the call to [method add_vertex], failure to do this will result in an error when committing the vertex information to a mesh.
 	</description>
 	<tutorials>

--- a/doc/classes/TCP_Server.xml
+++ b/doc/classes/TCP_Server.xml
@@ -26,10 +26,13 @@
 			<argument index="1" name="bind_address" type="String" default="&quot;*&quot;">
 			</argument>
 			<description>
-				Listen on the "port" binding to "bind_address".
-				If "bind_address" is set as "*" (default), the server will listen on all available addresses (both IPv4 and IPv6).
-				If "bind_address" is set as "0.0.0.0" (for IPv4) or "::" (for IPv6), the server will listen on all available addresses matching that IP type.
-				If "bind_address" is set to any valid address (e.g. "192.168.1.101", "::1", etc), the server will only listen on the interface with that addresses (or fail if no interface with the given address exists).
+				Listen on the [code]port[/code] binding to [code]bind_address[/code].
+
+				If [code]bind_address[/code] is set as "*" (default), the server will listen on all available addresses (both IPv4 and IPv6).
+
+				If [code]bind_address[/code] is set as "0.0.0.0" (for IPv4) or "::" (for IPv6), the server will listen on all available addresses matching that IP type.
+
+				If [code]bind_address[/code] is set to any valid address (e.g. "192.168.1.101", "::1", etc), the server will only listen on the interface with that addresses (or fail if no interface with the given address exists).
 			</description>
 		</method>
 		<method name="stop">

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -5,8 +5,11 @@
 	</brief_description>
 	<description>
 		Sets the active tab's [code]visible[/code] property to the value [code]true[/code]. Sets all other children's to [code]false[/code].
+
 		Ignores non-[Control] children.
+
 		Individual tabs are always visible unless you use [method set_tab_disabled] and [method set_tab_title] to hide it.
+
 		To hide only a tab's content, nest the content inside a child [Control], so it receives the [code]TabContainer[/code]'s visibility setting instead.
 	</description>
 	<tutorials>

--- a/doc/classes/TextureButton.xml
+++ b/doc/classes/TextureButton.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		[code]TextureButton[/code] has the same functionality as [Button], except it uses sprites instead of Godot's [Theme] resource. It is faster to create, but it doesn't support localization like more complex Controls.
+
 		The Normal state's texture is required. Others are optional.
 	</description>
 	<tutorials>

--- a/doc/classes/TextureProgress.xml
+++ b/doc/classes/TextureProgress.xml
@@ -158,6 +158,7 @@
 		</member>
 		<member name="radial_fill_degrees" type="float" setter="set_fill_degrees" getter="get_fill_degrees">
 			Upper limit for the fill of [member texture_progress] if [member fill_mode] is [code]FILL_CLOCKWISE[/code] or [code]FILL_COUNTER_CLOCKWISE[/code]. When the node's [code]value[/code] is equal to its [code]max_value[/code], the texture fills up to this angle.
+
 			See [member Range.value], [member Range.max_value].
 		</member>
 		<member name="radial_initial_angle" type="float" setter="set_radial_initial_angle" getter="get_radial_initial_angle">
@@ -180,6 +181,7 @@
 		</member>
 		<member name="texture_progress" type="Texture" setter="set_progress_texture" getter="get_progress_texture">
 			[Texture] that clips based on the node's [code]value[/code] and [member fill_mode]. As [code]value[/code] increased, the texture fills up. It shows entirely when [code]value[/code] reaches [code]max_value[/code]. It doesn't show at all if [code]value[/code] is equal to [code]min_value[/code].
+
 			The [code]value[/code] property comes from [Range]. See [member Range.value], [member Range.min_value], [member Range.max_value].
 		</member>
 		<member name="texture_under" type="Texture" setter="set_under_texture" getter="get_under_texture">

--- a/doc/classes/Theme.xml
+++ b/doc/classes/Theme.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Theme for skinning controls. Controls can be skinned individually, but for complex applications it's more efficient to just create a global theme that defines everything. This theme can be applied to any [Control], and it and its children will automatically use it.
+
 		Theme resources can be alternatively loaded by writing them in a .theme file, see docs for more info.
 	</description>
 	<tutorials>

--- a/doc/classes/Thread.xml
+++ b/doc/classes/Thread.xml
@@ -38,6 +38,7 @@
 			</argument>
 			<description>
 				Starts a new [code]Thread[/code] that runs "method" on object "instance" with "userdata" passed as an argument. The "priority" of the [code]Thread[/code] can be changed by passing a PRIORITY_* enum.
+
 				Returns OK on success, or ERR_CANT_CREATE on failure.
 			</description>
 		</method>

--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -228,6 +228,7 @@
 			</argument>
 			<description>
 				Return the absolute world position corresponding to the tilemap (grid-based) coordinates given as an argument.
+
 				Optionally, the tilemap's potential half offset can be ignored.
 			</description>
 		</method>
@@ -248,7 +249,9 @@
 			</argument>
 			<description>
 				Set the tile index for the cell referenced by its grid-based X and Y coordinates.
-				A tile index of -1 clears the cell.
+
+				A [code]tile[/code] index of -1 clears the cell.
+
 				Optionally, the tile can also be flipped over the X and Y coordinates or transposed.
 			</description>
 		</method>
@@ -276,7 +279,9 @@
 			</argument>
 			<description>
 				Set the tile index for the cell referenced by a Vector2 of grid-based coordinates.
-				A tile index of -1 clears the cell.
+
+				A [code]tile[/code] index of -1 clears the cell.
+
 				Optionally, the tile can also be flipped over the X and Y axes or transposed.
 			</description>
 		</method>
@@ -323,6 +328,7 @@
 			</argument>
 			<description>
 				Set the collision layer.
+
 				Layers are referenced by binary indexes, so allowable values to describe the 20 available layers range from 0 to 2^20-1.
 			</description>
 		</method>
@@ -343,6 +349,7 @@
 			</argument>
 			<description>
 				Set the collision masks.
+
 				Masks are referenced by binary indexes, so allowable values to describe the 20 available masks range from 0 to 2^20-1.
 			</description>
 		</method>
@@ -381,6 +388,7 @@
 			</argument>
 			<description>
 				Set a half offset on the X coordinate, Y coordinate, or none (use HALF_OFFSET_* constants as argument).
+
 				Half offset sets every other tile off by a half tile size in the specified direction.
 			</description>
 		</method>
@@ -408,6 +416,7 @@
 			</argument>
 			<description>
 				Set the quadrant size, this optimizes drawing by batching chunks of map at draw/cull time.
+
 				Allowed values are integers ranging from 1 to 128.
 			</description>
 		</method>
@@ -436,6 +445,7 @@
 			</argument>
 			<description>
 				Set the Y sort mode. Enabled Y sort mode means that children of the tilemap will be drawn in the order defined by their Y coordinate.
+
 				A tile with a higher Y coordinate will therefore be drawn later, potentially covering up the tile(s) above it if its sprite is higher than its cell size.
 			</description>
 		</method>

--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A TileSet is a library of tiles for a [TileMap]. It contains a list of tiles, each consisting of a sprite and optional collision shapes.
+
 		Tiles are referenced by a unique integer ID.
 	</description>
 	<tutorials>

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -5,16 +5,17 @@
 	</brief_description>
 	<description>
 		This shows a tree of items that can be selected, expanded and collapsed. The tree can have multiple columns with custom controls like text editing, buttons and popups. It can be useful for structured displays and interactions.
+
 		Trees are built via code, using [TreeItem] objects to create the structure. They have a single root but multiple roots can be simulated if a dummy hidden root is added.
 		[codeblock]
 		func _ready():
-		    var tree = Tree.new()
-		    var root = tree.create_item()
-		    tree.set_hide_root(true)
-		    var child1 = tree.create_item(root)
-		    var child2 = tree.create_item(root)
-		    var subchild1 = tree.create_item(child1)
-		    subchild1.set_text(0, "Subchild1")
+			var tree = Tree.new()
+			var root = tree.create_item()
+			tree.set_hide_root(true)
+			var child1 = tree.create_item(root)
+			var child2 = tree.create_item(root)
+			var subchild1 = tree.create_item(child1)
+			subchild1.set_text(0, "Subchild1")
 		[/codeblock]
 	</description>
 	<tutorials>

--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -5,13 +5,16 @@
 	</brief_description>
 	<description>
 		Node useful for animations with unknown start and end points, procedural animations, making one node follow another, and other simple behavior.
+
 		Because it is easy to get it wrong, here is a quick usage example:
 		[codeblock]
 		var tween = get_node("Tween")
 		tween.interpolate_property(get_node("Node2D_to_move"), "transform/origin", Vector2(0,0), Vector2(100,100), 1, Tween.TRANS_LINEAR, Tween.EASE_IN_OUT)
 		tween.start()
 		[/codeblock]
+
 		Some of the methods of this class require a property name. You can get the property name by hovering over the property in the inspector of the editor.
+
 		Many of the methods accept [code]trans_type[/code] and [code]ease_type[/code]. The first accepts an TRANS_* constant, and refers to the way the timing of the animation is handled (you might want to see [code]http://easings.net/[/code] for some examples). The second accepts an EASE_* constant, and controls the where [code]trans_type[/code] is applied to the interpolation (in the beginning, the end, or both). If you don't know which transition and easing to pick, you can try different TRANS_* constants with EASE_IN_OUT, and use the one that looks best.
 	</description>
 	<tutorials>
@@ -42,6 +45,7 @@
 			</argument>
 			<description>
 				Follow [code]method[/code] of [code]object[/code] and apply the returned value on [code]target_method[/code] of [code]target[/code], beginning from [code]initial_val[/code] for [code]duration[/code] seconds, [code]delay[/code] later. Methods are animated by calling them with consequitive values.
+
 				[code]trans_type[/code] accepts TRANS_* constants, and is the way the animation is interpolated, while [code]ease_type[/code] accepts EASE_* constants, and controls the place of the interpolation (the beginning, the end, or both). You can read more about them in the class description.
 			</description>
 		</method>
@@ -68,6 +72,7 @@
 			</argument>
 			<description>
 				Follow [code]property[/code] of [code]object[/code] and apply it on [code]target_property[/code] of [code]target[/code], beginning from [code]initial_val[/code] for [code]duration[/code] seconds, [code]delay[/code] seconds later. Note that [code]target:target_property[/code] would equal [code]object:property[/code] at the end of the tween.
+
 				[code]trans_type[/code] accepts TRANS_* constants, and is the way the animation is interpolated, while [code]ease_type[/code] accepts EASE_* constants, and controls the place of the interpolation (the beginning, the end, or both). You can read more about them in the class description.
 			</description>
 		</method>
@@ -159,6 +164,7 @@
 			</argument>
 			<description>
 				Animate [code]method[/code] of [code]object[/code] from [code]initial_val[/code] to [code]final_val[/code] for [code]duration[/code] seconds, [code]delay[/code] seconds later. Methods are animated by calling them with consecutive values.
+
 				[code]trans_type[/code] accepts TRANS_* constants, and is the way the animation is interpolated, while [code]ease_type[/code] accepts EASE_* constants, and controls the place of the interpolation (the beginning, the end, or both). You can read more about them in the class description.
 			</description>
 		</method>
@@ -183,6 +189,7 @@
 			</argument>
 			<description>
 				Animate [code]property[/code] of [code]object[/code] from [code]initial_val[/code] to [code]final_val[/code] for [code]duration[/code] seconds, [code]delay[/code] seconds later.
+
 				[code]trans_type[/code] accepts TRANS_* constants, and is the way the animation is interpolated, while [code]ease_type[/code] accepts EASE_* constants, and controls the place of the interpolation (the beginning, the end, or both). You can read more about them in the class description.
 			</description>
 		</method>
@@ -347,6 +354,7 @@
 			</argument>
 			<description>
 				Animate [code]method[/code] of [code]object[/code] from the value returned by [code]initial.initial_method[/code] to [code]final_val[/code] for [code]duration[/code] seconds, [code]delay[/code] seconds later. Methods are animated by calling them with consecutive values.
+
 				[code]trans_type[/code] accepts TRANS_* constants, and is the way the animation is interpolated, while [code]ease_type[/code] accepts EASE_* constants, and controls the place of the interpolation (the beginning, the end, or both). You can read more about them in the class description.
 			</description>
 		</method>
@@ -373,6 +381,7 @@
 			</argument>
 			<description>
 				Animate [code]property[/code] of [code]object[/code] from the current value of the [code]initial_val[/code] property of [code]initial[/code] to [code]final_val[/code] for [code]duration[/code] seconds, [code]delay[/code] seconds later.
+
 				[code]trans_type[/code] accepts TRANS_* constants, and is the way the animation is interpolated, while [code]ease_type[/code] accepts EASE_* constants, and controls the place of the interpolation (the beginning, the end, or both). You can read more about them in the class description.
 			</description>
 		</method>

--- a/doc/classes/UndoRedo.xml
+++ b/doc/classes/UndoRedo.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Helper to manage UndoRedo in the editor or custom tools. It works by storing calls to functions in both 'do' an 'undo' lists.
+
 		Common behavior is to create an action, then add do/undo calls to functions or property changes, then committing the action.
 	</description>
 	<tutorials>
@@ -119,6 +120,7 @@
 			</return>
 			<description>
 				Get the version, each time a new action is committed, the version number of the UndoRedo is increased automatically.
+
 				This is useful mostly to check if something changed from a saved version.
 			</description>
 		</method>

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -33,8 +33,9 @@
 			<return type="float">
 			</return>
 			<description>
-				Returns the result of atan2 when called with the Vector's x and y as parameters (Math::atan2(x,y)).
-				Be aware that it therefore returns an angle oriented clockwise with regard to the (0, 1) unit vector, and not an angle oriented counter-clockwise with regard to the (1, 0) unit vector (which would be the typical trigonometric representation of the angle when calling Math::atan2(y,x)).
+				Returns the result of atan2 when called with the Vector's x and y as parameters ([code]Math::atan2(x,y)[/code]).
+
+				Be aware that it therefore returns an angle oriented clockwise with regard to the (0, 1) unit vector, and not an angle oriented counter-clockwise with regard to the (1, 0) unit vector (which would be the typical trigonometric representation of the angle when calling [code]Math::atan2(y,x)[/code]).
 			</description>
 		</method>
 		<method name="angle_to">

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -5,10 +5,15 @@
 	</brief_description>
 	<description>
 		A Viewport creates a different view into the screen, or a sub-view inside another viewport. Children 2D Nodes will display on it, and children Camera 3D nodes will render on it too.
+
 		Optionally, a viewport can have its own 2D or 3D world, so they don't share what they draw with other viewports.
+
 		If a viewport is a child of a [Control], it will automatically take up its same rect and position, otherwise they must be set manually.
+
 		Viewports can also choose to be audio listeners, so they generate positional audio depending on a 2D or 3D camera child of it.
+
 		Also, viewports can be assigned to different screens in case the devices have multiple screens.
+
 		Finally, viewports can also behave as render targets, in which case they will not be visible unless the associated texture is used to draw.
 	</description>
 	<tutorials>
@@ -463,8 +468,11 @@
 			</argument>
 			<description>
 				If true this viewport will be bound to our ARVR Server.
+
 				If this is our main Godot viewport our AR/VR output will be displayed on screen.
-				If output is redirected to an HMD we'll see the output of just one of the eyes without any distortion applied else we'll see the stereo buffer with distortion applied if applicable
+
+				If output is redirected to an HMD we'll see the output of just one of the eyes without any distortion applied else we'll see the stereo buffer with distortion applied if applicable.
+
 				If this is an extra viewport output will only work if redirection to an HMD is supported by the interface. The render target will allow you to use the undistorted output for the right eye in the display.
 			</description>
 		</method>

--- a/doc/classes/VisualScript.xml
+++ b/doc/classes/VisualScript.xml
@@ -6,6 +6,7 @@
 	<description>
 		A script implemented in the  Visual Script programming environment. The script extends the functionality of all objects that instance it.
 		[method Object.set_script] extends an existing object, if that object's class matches one of the script's base classes.
+
 		You are most likely to use this class via the Visual Script editor or when writing plugins for it.
 	</description>
 	<tutorials>
@@ -410,6 +411,7 @@
 			</argument>
 			<description>
 				Connect two sequence ports. The execution will flow from of [code]from_node[/code]'s [code]from_output[/code] into [code]to_node[/code].
+
 				Unlike [method data_connect], there isn't a [code]to_port[/code], since the target node can have only one sequence port.
 			</description>
 		</method>

--- a/doc/classes/VisualScriptBuiltinFunc.xml
+++ b/doc/classes/VisualScriptBuiltinFunc.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A built-in function used inside a [VisualScript]. It is usually a math function or an utility function.
+
 		See also [@GDScript], for the same functions in the GDScript language.
 	</description>
 	<tutorials>

--- a/doc/classes/VisualScriptClassConstant.xml
+++ b/doc/classes/VisualScriptClassConstant.xml
@@ -5,8 +5,10 @@
 	</brief_description>
 	<description>
 		This node returns a constant from a given class, such as [@GlobalScope.TYPE_INT]. See the given class' documentation for available constants.
+
 		[b]Input Ports:[/b]
 		none
+
 		[b]Output Ports:[/b]
 		- Data (variant): [code]value[/code]
 	</description>

--- a/doc/classes/VisualScriptComment.xml
+++ b/doc/classes/VisualScriptComment.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A Visual Script node used to display annotations in the script, so that code may be documented.
+
 		Comment nodes can be resized so they encompass a group of nodes.
 	</description>
 	<tutorials>

--- a/doc/classes/VisualScriptCondition.xml
+++ b/doc/classes/VisualScriptCondition.xml
@@ -5,9 +5,11 @@
 	</brief_description>
 	<description>
 		A Visual Script node that checks a [bool] input port. If [code]true[/code] it will exit via the “true” sequence port. If [code]false[/code] it will exit via the "false" sequence port. After exiting either, it exits via the “done” port. Sequence ports may be left disconnected.
+
 		[b]Input Ports:[/b]
 		- Sequence: [code]if (cond) is[/code]
 		- Data (boolean): [code]cond[/code]
+
 		[b]Output Ports:[/b]
 		- Sequence: [code]true[/code]
 		- Sequence: [code]false[/code]

--- a/doc/classes/VisualScriptConstant.xml
+++ b/doc/classes/VisualScriptConstant.xml
@@ -5,8 +5,10 @@
 	</brief_description>
 	<description>
 		This node returns a constant's value.
+
 		[b]Input Ports:[/b]
 		none
+
 		[b]Output Ports:[/b]
 		- Data (variant): [code]get[/code]
 	</description>

--- a/doc/classes/VisualScriptCustomNode.xml
+++ b/doc/classes/VisualScriptCustomNode.xml
@@ -125,12 +125,15 @@
 			</argument>
 			<description>
 				Execute the custom node's logic, returning the index of the output sequence port to use or a [String] when there is an error.
-				
-				The [code]inputs[/code] array contains the values of the input ports.
+
+				[code]inputs[/code] is an array containing the values of the input ports.
+
 				[code]outputs[/code] is an array whose indices should be set to the respective outputs.
-				The [code]start_mode[/code] is usually [code]START_MODE_BEGIN_SEQUENCE[/code], unless you have used the STEP_* constants.
+
+				[code]start_mode[/code] is usually [code]START_MODE_BEGIN_SEQUENCE[/code], unless you have used the STEP_* constants.
+
 				[code]working_mem[/code] is an array which can be used to persist information between runs of the custom node.
-				
+
 				When returning, you can mask the returned value with one of the STEP_* constants.
 			</description>
 		</method>
@@ -147,6 +150,7 @@
 		</constant>
 		<constant name="STEP_PUSH_STACK_BIT" value="16777216" enum="">
 			Hint used by [method _step] to tell that control should return to it when there is no other node left to execute.
+
 			This is used by [VisualScriptCondition] to redirect the sequence to the "Done" port after the true/false branch has finished execution.
 		</constant>
 		<constant name="STEP_GO_BACK_BIT" value="33554432" enum="">
@@ -159,6 +163,7 @@
 		</constant>
 		<constant name="STEP_YIELD_BIT" value="268435456" enum="">
 			Hint used by [method _step] to tell that the function should be yielded.
+
 			Using this requires you to have at least one working memory slot, which is used for the [VisualScriptFunctionState].
 		</constant>
 	</constants>

--- a/doc/classes/VisualScriptEmitSignal.xml
+++ b/doc/classes/VisualScriptEmitSignal.xml
@@ -5,8 +5,10 @@
 	</brief_description>
 	<description>
 		Emits a specified signal when it is executed.
+
 		[b]Input Ports:[/b]
 		- Sequence: [code]emit[/code]
+
 		[b]Output Ports:[/b]
 		- Sequence
 	</description>

--- a/doc/classes/VisualScriptIterator.xml
+++ b/doc/classes/VisualScriptIterator.xml
@@ -5,9 +5,11 @@
 	</brief_description>
 	<description>
 		This node steps through each item in a given input. Input can be any sequence data type, such as an [Array] or [String]. When each item has been processed, execution passed out the [code]exit[/code] Sequence port.
+
 		[b]Input Ports:[/b]
 		- Sequence: [code]for (elem) in (input)[/code]
 		- Data (variant): [code]input[/code]
+
 		[b]Output Ports:[/b]
 		- Sequence: [code]each[/code]
 		- Sequence: [code]exit[/code]

--- a/doc/classes/VisualScriptLocalVar.xml
+++ b/doc/classes/VisualScriptLocalVar.xml
@@ -5,8 +5,10 @@
 	</brief_description>
 	<description>
 		Returns a local variable's value. "Var Name" must be supplied, with an optional type.
+
 		[b]Input Ports:[/b]
 		none
+
 		[b]Output Ports:[/b]
 		- Data (variant): [code]get[/code]
 	</description>

--- a/doc/classes/VisualScriptLocalVarSet.xml
+++ b/doc/classes/VisualScriptLocalVarSet.xml
@@ -5,9 +5,11 @@
 	</brief_description>
 	<description>
 		Changes a local variable's value to the given input. The new value is also provided on an output Data port.
+
 		[b]Input Ports:[/b]
 		- Sequence
 		- Data (variant): [code]set[/code]
+
 		[b]Output Ports:[/b]
 		- Sequence
 		- Data (variant): [code]get[/code]

--- a/doc/classes/VisualScriptMathConstant.xml
+++ b/doc/classes/VisualScriptMathConstant.xml
@@ -5,8 +5,10 @@
 	</brief_description>
 	<description>
 		Provides common math constants, such as Pi or Euler's constant, on an output Data port.
+
 		[b]Input Ports:[/b]
 		none
+
 		[b]Output Ports:[/b]
 		- Data (variant): [code]get[/code]
 	</description>

--- a/doc/classes/VisualScriptOperator.xml
+++ b/doc/classes/VisualScriptOperator.xml
@@ -6,6 +6,7 @@
 		[b]Input Ports:[/b]
 		- Data (variant): [code]A[/code]
 		- Data (variant): [code]B[/code]
+
 		[b]Output Ports:[/b]
 		- Data (variant): [code]result[/code]
 	</description>

--- a/doc/classes/VisualScriptPreload.xml
+++ b/doc/classes/VisualScriptPreload.xml
@@ -5,8 +5,10 @@
 	</brief_description>
 	<description>
 		Creates a new [Resource] or loads one from the filesystem.
+
 		[b]Input Ports:[/b]
 		none
+
 		[b]Output Ports:[/b]
 		- Data (object): [code]res[/code]
 	</description>

--- a/doc/classes/VisualScriptReturn.xml
+++ b/doc/classes/VisualScriptReturn.xml
@@ -5,9 +5,11 @@
 	</brief_description>
 	<description>
 		Ends the execution of a function and returns control to the calling function. Optionally, it can return a [Variant] value.
+
 		[b]Input Ports:[/b]
 		- Sequence
 		- Data (variant): [code]result[/code] (optional)
+
 		[b]Output Ports:[/b]
 		none
 	</description>

--- a/doc/classes/VisualScriptSceneNode.xml
+++ b/doc/classes/VisualScriptSceneNode.xml
@@ -5,8 +5,10 @@
 	</brief_description>
 	<description>
 		A direct reference to a node.
+
 		[b]Input Ports:[/b]
 		none
+
 		[b]Output Ports:[/b]
 		- Data: [code]node[/code] (obj)
 	</description>

--- a/doc/classes/VisualScriptSelect.xml
+++ b/doc/classes/VisualScriptSelect.xml
@@ -5,10 +5,12 @@
 	</brief_description>
 	<description>
 		Chooses between two input values based on a Boolean condition.
+
 		[b]Input Ports:[/b]
 		- Data (boolean): [code]cond[/code]
 		- Data (variant): [code]a[/code]
 		- Data (variant): [code]b[/code]
+
 		[b]Output Ports:[/b]
 		- Data (variant): [code]out[/code]
 	</description>

--- a/doc/classes/VisualScriptSelf.xml
+++ b/doc/classes/VisualScriptSelf.xml
@@ -5,8 +5,10 @@
 	</brief_description>
 	<description>
 		Provides a reference to the node running the visual script.
+
 		[b]Input Ports:[/b]
 		none
+
 		[b]Output Ports:[/b]
 		- Data (object): [code]instance[/code]
 	</description>

--- a/doc/classes/VisualScriptSequence.xml
+++ b/doc/classes/VisualScriptSequence.xml
@@ -5,8 +5,10 @@
 	</brief_description>
 	<description>
 		Steps through a series of one or more output Sequence ports. The [code]current[/code] data port outputs the currently executing item.
+
 		[b]Input Ports:[/b]
 		- Sequence: [code]in order[/code]
+
 		[b]Output Ports:[/b]
 		- Sequence: [code]1[/code]
 		- Sequence: [code]2 - n[/code] (optional)

--- a/doc/classes/VisualScriptSwitch.xml
+++ b/doc/classes/VisualScriptSwitch.xml
@@ -5,11 +5,13 @@
 	</brief_description>
 	<description>
 		Branches the flow based on an input's value. Use "Case Count" in the Inspector to set the number of branches and each comparison's optional type.
+
 		[b]Input Ports:[/b]
 		- Sequence: [code]'input' is[/code]
 		- Data (variant): [code]=[/code]
 		- Data (variant): [code]=[/code] (optional)
 		- Data (variant): [code]input[/code]
+
 		[b]Output Ports:[/b]
 		- Sequence
 		- Sequence (optional)

--- a/doc/classes/VisualScriptVariableGet.xml
+++ b/doc/classes/VisualScriptVariableGet.xml
@@ -5,8 +5,10 @@
 	</brief_description>
 	<description>
 		Returns a variable's value. "Var Name" must be supplied, with an optional type.
+
 		[b]Input Ports:[/b]
 		none
+
 		[b]Output Ports:[/b]
 		- Data (variant): [code]value[/code]
 	</description>

--- a/doc/classes/VisualScriptVariableSet.xml
+++ b/doc/classes/VisualScriptVariableSet.xml
@@ -5,9 +5,11 @@
 	</brief_description>
 	<description>
 		Changes a variable's value to the given input.
+
 		[b]Input Ports:[/b]
 		- Sequence
 		- Data (variant): [code]set[/code]
+
 		[b]Output Ports:[/b]
 		- Sequence
 	</description>

--- a/doc/classes/VisualScriptWhile.xml
+++ b/doc/classes/VisualScriptWhile.xml
@@ -5,9 +5,11 @@
 	</brief_description>
 	<description>
 		Loops while a condition is [code]true[/code]. Execution continues out the [code]exit[/code] Sequence port when the loop terminates.
+
 		[b]Input Ports:[/b]
 		- Sequence: [code]while(cond)[/code]
 		- Data (bool): [code]cond[/code]
+
 		[b]Output Ports:[/b]
 		- Sequence: [code]repeat[/code]
 		- Sequence: [code]exit[/code]

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Server for anything visible. The visual server is the API backend for everything visible. The whole scene system mounts on it to display.
+
 		The visual server is completely opaque, the internals are entirely implementation specific and cannot be accessed.
 	</description>
 	<tutorials>

--- a/editor/doc/doc_data.cpp
+++ b/editor/doc/doc_data.cpp
@@ -617,7 +617,7 @@ void DocData::generate(bool p_basic_types) {
 
 static String _format_description(const String &string) {
 
-	return string.dedent().strip_edges().replace("\n", "\n\n");
+	return string.dedent().strip_edges();
 }
 
 static Error _parse_methods(Ref<XMLParser> &parser, Vector<DocData::MethodDoc> &methods) {
@@ -790,11 +790,11 @@ Error DocData::_load(Ref<XMLParser> parser) {
 				} else if (name == "tutorials") {
 					parser->read();
 					if (parser->get_node_type() == XMLParser::NODE_TEXT)
-						c.tutorials = parser->get_node_data().strip_edges();
+						c.tutorials = _format_description(parser->get_node_data());
 				} else if (name == "demos") {
 					parser->read();
 					if (parser->get_node_type() == XMLParser::NODE_TEXT)
-						c.demos = parser->get_node_data().strip_edges();
+						c.demos = _format_description(parser->get_node_data());
 				} else if (name == "methods") {
 
 					Error err = _parse_methods(parser, c.methods);
@@ -857,7 +857,7 @@ Error DocData::_load(Ref<XMLParser> parser) {
 								prop.type = parser->get_attribute_value("type");
 								parser->read();
 								if (parser->get_node_type() == XMLParser::NODE_TEXT)
-									prop.description = parser->get_node_data().strip_edges();
+									prop.description = _format_description(parser->get_node_data());
 								c.theme_properties.push_back(prop);
 							} else {
 								ERR_EXPLAIN("Invalid tag in doc file: " + name);
@@ -888,7 +888,7 @@ Error DocData::_load(Ref<XMLParser> parser) {
 								}
 								parser->read();
 								if (parser->get_node_type() == XMLParser::NODE_TEXT)
-									constant.description = parser->get_node_data().strip_edges();
+									constant.description = _format_description(parser->get_node_data());
 								c.constants.push_back(constant);
 							} else {
 								ERR_EXPLAIN("Invalid tag in doc file: " + name);

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1459,7 +1459,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 	Color font_color_hl = p_rt->get_color("headline_color", "EditorHelp");
 	Color link_color = p_rt->get_color("accent_color", "Editor").linear_interpolate(font_color_hl, 0.8);
 
-	String bbcode = p_bbcode.replace("\t", " ").replace("\r", " ").strip_edges();
+	String bbcode = p_bbcode.replace("\r", "").strip_edges();
 
 	List<String> tag_stack;
 


### PR DESCRIPTION
Rather than being generated automatically (and inaccurately).

Also, using dedent() the use of tabs in code blocks works now, so you can easily copy/paste code from the help files.

I also did a quick pass-over, doing minor corrections wherever I see them.