### PR TITLE
Add indent and sort keys support for JSON.print

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2669,12 +2669,12 @@ Variant JSONParseResult::get_result() const {
 }
 
 void _JSON::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("print", "value"), &_JSON::print);
+	ClassDB::bind_method(D_METHOD("print", "value", "indent", "sort_keys"), &_JSON::print, DEFVAL(String()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("parse", "json"), &_JSON::parse);
 }
 
-String _JSON::print(const Variant &p_value) {
-	return JSON::print(p_value);
+String _JSON::print(const Variant &p_value, const String &p_indent, bool p_sort_keys) {
+	return JSON::print(p_value, p_indent, p_sort_keys);
 }
 
 Ref<JSONParseResult> _JSON::parse(const String &p_json) {

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -714,7 +714,7 @@ protected:
 public:
 	static _JSON *get_singleton() { return singleton; }
 
-	String print(const Variant &p_value);
+	String print(const Variant &p_value, const String &p_indent = "", bool p_sort_keys = false);
 	Ref<JSONParseResult> parse(const String &p_json);
 
 	_JSON();

--- a/core/io/json.h
+++ b/core/io/json.h
@@ -64,7 +64,7 @@ class JSON {
 
 	static const char *tk_name[TK_MAX];
 
-	static String _print_var(const Variant &p_var);
+	static String _print_var(const Variant &p_var, const String& p_indent, int p_cur_indent, bool p_sort_keys);
 
 	static Error _get_token(const CharType *p_str, int &index, int p_len, Token &r_token, int &line, String &r_err_str);
 	static Error _parse_value(Variant &value, Token &token, const CharType *p_str, int &index, int p_len, int &line, String &r_err_str);
@@ -72,7 +72,7 @@ class JSON {
 	static Error _parse_object(Dictionary &object, const CharType *p_str, int &index, int p_len, int &line, String &r_err_str);
 
 public:
-	static String print(const Variant &p_var);
+	static String print(const Variant &p_var, const String& p_indent = "", bool p_sort_keys = true);
 	static Error parse(const String &p_json, Variant &r_ret, String &r_err_str, int &r_err_line);
 };
 


### PR DESCRIPTION
We can export the same json text content with same dictionary.
The VCS will be happy for that :)