### PR TITLE
Removed add/remove interface bindings and added get_interfaces

### DIFF
--- a/doc/classes/ARVRInterface.xml
+++ b/doc/classes/ARVRInterface.xml
@@ -33,7 +33,7 @@
 				Returns the name of this interface (OpenVR, OpenHMD, ARKit, etc).
 			</description>
 		</method>
-		<method name="get_recommended_render_targetsize">
+		<method name="get_render_targetsize">
 			<return type="Vector2">
 			</return>
 			<description>
@@ -139,7 +139,7 @@
 			This interface support AR (video background and real world tracking).
 		</constant>
 		<constant name="ARVR_EXTERNAL" value="8">
-			This interface outputs to an external device, if the main viewport is used the on screen output is an unmodified buffer of either the left or right eye (stretched if the viewport size is not changed to the same aspect ratio of get_recommended_render_targetsize. Using a seperate viewport node frees up the main viewport for other purposes.
+			This interface outputs to an external device, if the main viewport is used the on screen output is an unmodified buffer of either the left or right eye (stretched if the viewport size is not changed to the same aspect ratio of get_render_targetsize. Using a seperate viewport node frees up the main viewport for other purposes.
 		</constant>
 		<constant name="EYE_MONO" value="0">
 			Mono output, this is mostly used internally when retrieving positioning information for our camera node or when stereo scopic rendering is not supported.

--- a/doc/classes/ARVRServer.xml
+++ b/doc/classes/ARVRServer.xml
@@ -11,15 +11,6 @@
 	<demos>
 	</demos>
 	<methods>
-		<method name="add_interface">
-			<return type="void">
-			</return>
-			<argument index="0" name="interface" type="ARVRInterface">
-			</argument>
-			<description>
-				Mostly exposed for GDNative based interfaces, this is called to register an available interface with the AR/VR server.
-			</description>
-		</method>
 		<method name="center_on_hmd">
 			<return type="void">
 			</return>
@@ -61,6 +52,13 @@
 				Get the number of interfaces currently registered with the AR/VR server. If you're game supports multiple AR/VR platforms you can look throught the available interface and either present the user with a selection or simply try an initialize each interface and use the first one that returns true.
 			</description>
 		</method>
+		<method name="get_interfaces" qualifiers="const">
+			<return type="Array">
+			</return>
+			<description>
+				Returns a list of available interfaces with both id and name of the interface.
+			</description>
+		</method>
 		<method name="get_reference_frame" qualifiers="const">
 			<return type="Transform">
 			</return>
@@ -89,15 +87,6 @@
 			</return>
 			<description>
 				Returns our world scale (see ARVROrigin for more information).
-			</description>
-		</method>
-		<method name="remove_interface">
-			<return type="void">
-			</return>
-			<argument index="0" name="interface" type="ARVRInterface">
-			</argument>
-			<description>
-				Removes a registered interface, again exposed mostly for GDNative based interfaces.
 			</description>
 		</method>
 		<method name="set_primary_interface">

--- a/modules/gdnative/arvr/arvr_interface_gdnative.cpp
+++ b/modules/gdnative/arvr/arvr_interface_gdnative.cpp
@@ -166,11 +166,11 @@ void ARVRInterfaceGDNative::uninitialize() {
 	interface->uninitialize(data);
 }
 
-Size2 ARVRInterfaceGDNative::get_recommended_render_targetsize() {
+Size2 ARVRInterfaceGDNative::get_render_targetsize() {
 
 	ERR_FAIL_COND_V(interface == NULL, Size2());
 
-	godot_vector2 result = interface->get_recommended_render_targetsize(data);
+	godot_vector2 result = interface->get_render_targetsize(data);
 	Vector2 *vec = (Vector2 *)&result;
 
 	return *vec;

--- a/modules/gdnative/arvr/arvr_interface_gdnative.h
+++ b/modules/gdnative/arvr/arvr_interface_gdnative.h
@@ -68,7 +68,7 @@ public:
 	virtual void set_anchor_detection_is_enabled(bool p_enable);
 
 	/** rendering and internal **/
-	virtual Size2 get_recommended_render_targetsize();
+	virtual Size2 get_render_targetsize();
 	virtual bool is_stereo();
 	virtual Transform get_transform_for_eye(ARVRInterface::Eyes p_eye, const Transform &p_cam_transform);
 

--- a/modules/gdnative/include/arvr/godot_arvr.h
+++ b/modules/gdnative/include/arvr/godot_arvr.h
@@ -47,7 +47,7 @@ typedef struct {
 	godot_bool (*is_initialized)(const void *);
 	godot_bool (*initialize)(void *);
 	void (*uninitialize)(void *);
-	godot_vector2 (*get_recommended_render_targetsize)(const void *);
+	godot_vector2 (*get_render_targetsize)(const void *);
 	godot_transform (*get_transform_for_eye)(void *, godot_int, godot_transform *);
 	void (*fill_projection_for_eye)(void *, godot_real *, godot_int, godot_real, godot_real, godot_real);
 	void (*commit_for_eye)(void *, godot_int, godot_rid *, godot_rect2 *);

--- a/modules/mobile_vr/mobile_interface.cpp
+++ b/modules/mobile_vr/mobile_interface.cpp
@@ -323,7 +323,7 @@ void MobileVRInterface::uninitialize() {
 	};
 };
 
-Size2 MobileVRInterface::get_recommended_render_targetsize() {
+Size2 MobileVRInterface::get_render_targetsize() {
 	_THREAD_SAFE_METHOD_
 
 	// we use half our window size

--- a/modules/mobile_vr/mobile_interface.h
+++ b/modules/mobile_vr/mobile_interface.h
@@ -137,7 +137,7 @@ public:
 	virtual bool initialize();
 	virtual void uninitialize();
 
-	virtual Size2 get_recommended_render_targetsize();
+	virtual Size2 get_render_targetsize();
 	virtual bool is_stereo();
 	virtual Transform get_transform_for_eye(ARVRInterface::Eyes p_eye, const Transform &p_cam_transform);
 	virtual CameraMatrix get_projection_for_eye(ARVRInterface::Eyes p_eye, real_t p_aspect, real_t p_z_near, real_t p_z_far);

--- a/servers/arvr/arvr_interface.cpp
+++ b/servers/arvr/arvr_interface.cpp
@@ -43,7 +43,7 @@ void ARVRInterface::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_tracking_status"), &ARVRInterface::get_tracking_status);
 
-	ClassDB::bind_method(D_METHOD("get_recommended_render_targetsize"), &ARVRInterface::get_recommended_render_targetsize);
+	ClassDB::bind_method(D_METHOD("get_render_targetsize"), &ARVRInterface::get_render_targetsize);
 	ClassDB::bind_method(D_METHOD("is_stereo"), &ARVRInterface::is_stereo);
 
 	ADD_GROUP("Interface", "interface_");

--- a/servers/arvr/arvr_interface.h
+++ b/servers/arvr/arvr_interface.h
@@ -103,7 +103,7 @@ public:
 
 	/** rendering and internal **/
 
-	virtual Size2 get_recommended_render_targetsize() = 0; /* returns the recommended render target size per eye for this device */
+	virtual Size2 get_render_targetsize() = 0; /* returns the recommended render target size per eye for this device */
 	virtual bool is_stereo() = 0; /* returns true if this interface requires stereo rendering (for VR HMDs) or mono rendering (for mobile AR) */
 	virtual Transform get_transform_for_eye(ARVRInterface::Eyes p_eye, const Transform &p_cam_transform) = 0; /* get each eyes camera transform, also implement EYE_MONO */
 	virtual CameraMatrix get_projection_for_eye(ARVRInterface::Eyes p_eye, real_t p_aspect, real_t p_z_near, real_t p_z_far) = 0; /* get each eyes projection matrix */

--- a/servers/arvr_server.cpp
+++ b/servers/arvr_server.cpp
@@ -49,14 +49,12 @@ void ARVRServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_interface_count"), &ARVRServer::get_interface_count);
 	ClassDB::bind_method(D_METHOD("get_interface", "idx"), &ARVRServer::get_interface);
+	ClassDB::bind_method(D_METHOD("get_interfaces"), &ARVRServer::get_interfaces);
 	ClassDB::bind_method(D_METHOD("find_interface", "name"), &ARVRServer::find_interface);
 	ClassDB::bind_method(D_METHOD("get_tracker_count"), &ARVRServer::get_tracker_count);
 	ClassDB::bind_method(D_METHOD("get_tracker", "idx"), &ARVRServer::get_tracker);
 
 	ClassDB::bind_method(D_METHOD("set_primary_interface", "interface"), &ARVRServer::set_primary_interface);
-
-	ClassDB::bind_method(D_METHOD("add_interface", "interface"), &ARVRServer::add_interface);
-	ClassDB::bind_method(D_METHOD("remove_interface", "interface"), &ARVRServer::remove_interface);
 
 	BIND_ENUM_CONSTANT(TRACKER_CONTROLLER);
 	BIND_ENUM_CONSTANT(TRACKER_BASESTATION);
@@ -189,6 +187,21 @@ Ref<ARVRInterface> ARVRServer::find_interface(const String &p_name) const {
 	ERR_FAIL_COND_V(idx == -1, NULL);
 
 	return interfaces[idx];
+};
+
+Array ARVRServer::get_interfaces() const {
+	Array ret;
+
+	for (int i = 0; i < interfaces.size(); i++) {
+		Dictionary iface_info;
+
+		iface_info["id"] = i;
+		iface_info["name"] = interfaces[i]->get_name();
+
+		ret.push_back(iface_info);
+	};
+
+	return ret;
 };
 
 /*

--- a/servers/arvr_server.h
+++ b/servers/arvr_server.h
@@ -137,6 +137,7 @@ public:
 	int get_interface_count() const;
 	Ref<ARVRInterface> get_interface(int p_index) const;
 	Ref<ARVRInterface> find_interface(const String &p_name) const;
+	Array get_interfaces() const;
 
 	/*
 		note, more then one interface can technically be active, especially on mobile, but only one interface is used for

--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -268,7 +268,7 @@ void VisualServerViewport::draw_viewports() {
 
 		if (vp->use_arvr && arvr_interface.is_valid()) {
 			// override our size, make sure it matches our required size
-			Size2 size = arvr_interface->get_recommended_render_targetsize();
+			Size2 size = arvr_interface->get_render_targetsize();
 			VSG::storage->render_target_set_size(vp->render_target, size.x, size.y);
 
 			// render mono or left eye first


### PR DESCRIPTION
The add_interface and remove_interface methods were originally made available in GDScript to enable GDNative to register the interfaces. With the new GDNative approach this is no longer needed and just confusing so I've removed their bindings.

I have also added a get_interfaces method that returns an array of id's and name's of the available interfaces. We may add more detail to this some day but this allows us to present a dropdown of available interfaces to a user. 