### PR TITLE
Added loop_begin and loop_end to OggVorbisStream

### DIFF
--- a/modules/stb_vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/stb_vorbis/audio_stream_ogg_vorbis.h
@@ -92,7 +92,11 @@ class AudioStreamOGGVorbis : public AudioStream {
 	int channels;
 	float length;
 	bool loop;
-	float loop_offset;
+	float loop_begin;
+	float loop_end;
+
+	uint32_t loop_begin_frames;
+	uint32_t loop_end_frames;
 
 protected:
 	static void _bind_methods();
@@ -101,8 +105,11 @@ public:
 	void set_loop(bool p_enable);
 	bool has_loop() const;
 
-	void set_loop_offset(float p_seconds);
-	float get_loop_offset() const;
+	void set_loop_begin(float p_seconds);
+	float get_loop_begin() const;
+
+	void set_loop_end(float p_seconds);
+	float get_loop_end() const;
 
 	virtual Ref<AudioStreamPlayback> instance_playback();
 	virtual String get_stream_name() const;

--- a/modules/stb_vorbis/resource_importer_ogg_vorbis.cpp
+++ b/modules/stb_vorbis/resource_importer_ogg_vorbis.cpp
@@ -72,13 +72,15 @@ String ResourceImporterOGGVorbis::get_preset_name(int p_idx) const {
 void ResourceImporterOGGVorbis::get_import_options(List<ImportOption> *r_options, int p_preset) const {
 
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "loop"), true));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::REAL, "loop_offset"), 0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::REAL, "loop_begin"), 0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::REAL, "loop_end"), 0));
 }
 
 Error ResourceImporterOGGVorbis::import(const String &p_source_file, const String &p_save_path, const Map<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files) {
 
 	bool loop = p_options["loop"];
-	float loop_offset = p_options["loop_offset"];
+	float loop_begin = p_options["loop_begin"];
+	float loop_end = p_options["loop_end"];
 
 	FileAccess *f = FileAccess::open(p_source_file, FileAccess::READ);
 	if (!f) {
@@ -100,7 +102,8 @@ Error ResourceImporterOGGVorbis::import(const String &p_source_file, const Strin
 
 	ogg_stream->set_data(data);
 	ogg_stream->set_loop(loop);
-	ogg_stream->set_loop_offset(loop_offset);
+	ogg_stream->set_loop_begin(loop_begin);
+	if (loop_end > 0) ogg_stream->set_loop_end(loop_end);
 
 	return ResourceSaver::save(p_save_path + ".oggstr", ogg_stream);
 }


### PR DESCRIPTION
It adds `loop_begin` and renames `loop_offset` to `loop_end`

It also fixes https://github.com/godotengine/godot/issues/11468