### PR TITLE
Implement per-instance custom bounding box

### DIFF
--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -504,6 +504,8 @@ public:
 	BIND3(instance_set_surface_material, RID, int, RID)
 	BIND2(instance_set_visible, RID, bool)
 
+	BIND2(instance_set_custom_aabb, RID, AABB)
+
 	BIND2(instance_attach_skeleton, RID, RID)
 	BIND2(instance_set_exterior, RID, bool)
 

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -197,6 +197,7 @@ public:
 
 		AABB aabb;
 		AABB transformed_aabb;
+		AABB *custom_aabb; // <Zylann> would using aabb directly with a bool be better?
 		float extra_margin;
 		uint32_t object_ID;
 
@@ -251,12 +252,16 @@ public:
 			last_frame_pass = 0;
 			version = 1;
 			base_data = NULL;
+
+			custom_aabb = NULL;
 		}
 
 		~Instance() {
 
 			if (base_data)
 				memdelete(base_data);
+			if (custom_aabb)
+				memdelete(custom_aabb);
 		}
 	};
 
@@ -459,6 +464,8 @@ public:
 	virtual void instance_set_blend_shape_weight(RID p_instance, int p_shape, float p_weight);
 	virtual void instance_set_surface_material(RID p_instance, int p_surface, RID p_material);
 	virtual void instance_set_visible(RID p_instance, bool p_visible);
+
+	virtual void instance_set_custom_aabb(RID p_insatnce, AABB aabb);
 
 	virtual void instance_attach_skeleton(RID p_instance, RID p_skeleton);
 	virtual void instance_set_exterior(RID p_instance, bool p_enabled);

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -424,6 +424,7 @@ public:
 	FUNC3(instance_set_blend_shape_weight, RID, int, float)
 	FUNC3(instance_set_surface_material, RID, int, RID)
 	FUNC2(instance_set_visible, RID, bool)
+	FUNC2(instance_set_custom_aabb, RID, AABB)
 
 	FUNC2(instance_attach_skeleton, RID, RID)
 	FUNC2(instance_set_exterior, RID, bool)

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -753,6 +753,8 @@ public:
 	virtual void instance_set_surface_material(RID p_instance, int p_surface, RID p_material) = 0;
 	virtual void instance_set_visible(RID p_instance, bool p_visible) = 0;
 
+	virtual void instance_set_custom_aabb(RID p_instance, AABB aabb) = 0;
+
 	virtual void instance_attach_skeleton(RID p_instance, RID p_skeleton) = 0;
 	virtual void instance_set_exterior(RID p_instance, bool p_enabled) = 0;
 


### PR DESCRIPTION
Allows to set custom bounding box for `GeometryInstances`. An example use case is when shader displacement is used, like with particles or heightmaps.
Note: this PR only implements the feature on VisualServer API.

Fixes https://github.com/godotengine/godot/issues/9544

This is the first time I modify VisualServer, tell me if I did anything wrong.

Note: I see that Particles already have customizable AABB for the same reason, however it is stored in RasterizerStorageGLES3... should I remove it now?