### PR TITLE
Bullet: apply newly added collision exceptions to current collisions

### DIFF
--- a/modules/bullet/bullet_physics_server.cpp
+++ b/modules/bullet/bullet_physics_server.cpp
@@ -720,6 +720,8 @@ void BulletPhysicsServer::body_add_collision_exception(RID p_body, RID p_body_b)
 	ERR_FAIL_COND(!other_body);
 
 	body->add_collision_exception(other_body);
+	body->on_collision_filters_change();
+	body->scratch_space_override_modificator();
 }
 
 void BulletPhysicsServer::body_remove_collision_exception(RID p_body, RID p_body_b) {
@@ -730,6 +732,8 @@ void BulletPhysicsServer::body_remove_collision_exception(RID p_body, RID p_body
 	ERR_FAIL_COND(!other_body);
 
 	body->remove_collision_exception(other_body);
+	body->on_collision_filters_change();
+	body->scratch_space_override_modificator();
 }
 
 void BulletPhysicsServer::body_get_collision_exceptions(RID p_body, List<RID> *p_exceptions) {


### PR DESCRIPTION
Currently with bullet physics if two objects are colliding and a collision exception is added between them, the objects will continue to collide.  This is not in line with godot's physics and it also makes a few behaviors hard to achieve.

For example, you have a cube resting on a platform and you want it to fall through the platform.  You would expect a collision exception to work for that scenario.

Example project illustrating the problem: 
[Bullet-Collision-Exception.zip](https://github.com/godotengine/godot/files/1444391/Bullet-Collision-Exception.zip)

Without these changes, the cube continues to sit on the platform when a collision exception is added.

With these changes the cube falls through the platform.