### PR TITLE
Prevent to stop music in another background app on iOS

### DIFF
--- a/platform/iphone/app_delegate.mm
+++ b/platform/iphone/app_delegate.mm
@@ -638,6 +638,9 @@ static int frame_count = 0;
 
 	mainViewController = view_controller;
 
+	// prevent to stop music in another background app
+	[[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error:nil];
+
 #ifdef MODULE_GAME_ANALYTICS_ENABLED
 	printf("********************* didFinishLaunchingWithOptions\n");
 	if (!ProjectSettings::get_singleton()->has("mobileapptracker/advertiser_id")) {


### PR DESCRIPTION
currently, another music app like podcast is stopped when launching godot game.
this prevents to stop music in another app.