### PR TITLE
Parallax Fixes for dealing with Camera Scale

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -50,7 +50,11 @@ void Camera2D::_update_scroll() {
 		if (viewport) {
 			viewport->set_canvas_transform(xform);
 		}
-		get_tree()->call_group(SceneTree::GROUP_CALL_REALTIME, group_name, "_camera_moved", xform);
+
+		Size2 screen_size = viewport->get_visible_rect().size;
+		Point2 screen_offset = (anchor_mode == ANCHOR_MODE_DRAG_CENTER ? (screen_size * 0.5) : Point2());
+
+		get_tree()->call_group(SceneTree::GROUP_CALL_REALTIME, group_name, "_camera_moved", xform, screen_offset);
 	};
 }
 

--- a/scene/2d/parallax_background.cpp
+++ b/scene/2d/parallax_background.cpp
@@ -47,10 +47,12 @@ void ParallaxBackground::_notification(int p_what) {
 	}
 }
 
-void ParallaxBackground::_camera_moved(const Matrix32 &p_transform) {
+void ParallaxBackground::_camera_moved(const Matrix32 &p_transform, const Point2 &p_screen_offset) {
 
-	set_scroll_offset(p_transform.get_origin());
+	screen_offset = p_screen_offset;
+
 	set_scroll_scale(p_transform.get_scale().dot(Vector2(0.5, 0.5)));
+	set_scroll_offset(p_transform.get_origin());
 }
 
 void ParallaxBackground::set_scroll_scale(float p_scale) {
@@ -106,9 +108,9 @@ void ParallaxBackground::_update_scroll() {
 			continue;
 
 		if (ignore_camera_zoom)
-			l->set_base_offset_and_scale(ofs, 1.0);
+			l->set_base_offset_and_scale(ofs, 1.0, screen_offset);
 		else
-			l->set_base_offset_and_scale(ofs, scale);
+			l->set_base_offset_and_scale(ofs, scale, screen_offset);
 	}
 }
 

--- a/scene/2d/parallax_background.h
+++ b/scene/2d/parallax_background.h
@@ -42,6 +42,7 @@ class ParallaxBackground : public CanvasLayer {
 	float scale;
 	Point2 base_offset;
 	Point2 base_scale;
+	Point2 screen_offset;
 	String group_name;
 	Point2 limit_begin;
 	Point2 limit_end;
@@ -51,7 +52,7 @@ class ParallaxBackground : public CanvasLayer {
 	void _update_scroll();
 
 protected:
-	void _camera_moved(const Matrix32 &p_transform);
+	void _camera_moved(const Matrix32 &p_transform, const Point2 &p_screen_offset);
 
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -41,7 +41,7 @@ void ParallaxLayer::set_motion_scale(const Size2 &p_scale) {
 	if (is_inside_tree() && pb) {
 		Vector2 ofs = pb->get_final_offset();
 		float scale = pb->get_scroll_scale();
-		set_base_offset_and_scale(ofs, scale);
+		set_base_offset_and_scale(ofs, scale, screen_offset);
 	}
 }
 
@@ -61,7 +61,7 @@ void ParallaxLayer::set_motion_offset(const Size2 &p_offset) {
 	if (is_inside_tree() && pb) {
 		Vector2 ofs = pb->get_final_offset();
 		float scale = pb->get_scroll_scale();
-		set_base_offset_and_scale(ofs, scale);
+		set_base_offset_and_scale(ofs, scale, screen_offset);
 	}
 }
 
@@ -113,26 +113,28 @@ void ParallaxLayer::_notification(int p_what) {
 	}
 }
 
-void ParallaxLayer::set_base_offset_and_scale(const Point2 &p_offset, float p_scale) {
+void ParallaxLayer::set_base_offset_and_scale(const Point2 &p_offset, float p_scale, const Point2 &p_screen_offset) {
+	screen_offset = p_screen_offset;
 
 	if (!is_inside_tree())
 		return;
 	if (get_tree()->is_editor_hint())
 		return;
-	Point2 new_ofs = ((orig_offset + p_offset) * motion_scale) * p_scale + motion_offset;
+
+	Point2 new_ofs = (screen_offset + (p_offset - screen_offset) * motion_scale) + motion_offset * p_scale + orig_offset * p_scale;
+
+	Vector2 mirror = Vector2(1, 1);
 
 	if (mirroring.x) {
-		double den = mirroring.x * p_scale;
-		new_ofs.x -= den * ceil(new_ofs.x / den);
+		mirror.x = -1;
 	}
 
 	if (mirroring.y) {
-		double den = mirroring.y * p_scale;
-		new_ofs.y -= den * ceil(new_ofs.y / den);
+		mirror.y = -1;
 	}
 
 	set_pos(new_ofs);
-	set_scale(Vector2(1, 1) * p_scale);
+	set_scale(mirror * p_scale * orig_scale);
 }
 
 String ParallaxLayer::get_configuration_warning() const {

--- a/scene/2d/parallax_layer.h
+++ b/scene/2d/parallax_layer.h
@@ -43,6 +43,8 @@ class ParallaxLayer : public Node2D {
 	Vector2 mirroring;
 	void _update_mirroring();
 
+	Point2 screen_offset;
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -57,7 +59,7 @@ public:
 	void set_mirroring(const Size2 &p_mirroring);
 	Size2 get_mirroring() const;
 
-	void set_base_offset_and_scale(const Point2 &p_offsetf, float p_scale);
+	void set_base_offset_and_scale(const Point2 &p_offsetf, float p_scale, const Point2 &p_screen_offset);
 
 	virtual String get_configuration_warning() const;
 	ParallaxLayer();


### PR DESCRIPTION
Ensures Parallax Background works at different zoom levels, both when the camera is Centered and Fixed TopLeft.

Backport of: https://github.com/godotengine/godot/pull/12421 , includes work done in: https://github.com/godotengine/godot/pull/12132


Test project for testing: [parallaxScale.zip](https://github.com/godotengine/godot/files/1447545/parallaxScale.zip)

Left/Right- Scrolls left and right

Up/Down- Zooms in and out.