### PR TITLE
unified headers fix (2.1)

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -2,7 +2,7 @@ import os
 import sys
 import string
 import platform
-
+from distutils.version import LooseVersion
 
 def is_active():
     return True
@@ -24,8 +24,7 @@ def get_opts():
         ('ndk_platform', 'compile for platform: (android-<api> , example: android-14)', "android-14"),
         ('android_arch', 'select compiler architecture: (armv7/armv6/x86)', "armv7"),
         ('android_neon', 'enable neon (armv7 only)', "yes"),
-        ('android_stl', 'enable STL support in android port (for modules)', "no"),
-        ('ndk_unified_headers', 'enable NDK unified headers', "yes")
+        ('android_stl', 'enable STL support in android port (for modules)', "no")
     ]
 
 
@@ -158,24 +157,20 @@ def configure(env):
     else:
         env['ARCH'] = 'arch-arm'
 
-    ndk_unified_headers = env['ndk_unified_headers'] == 'yes'
-    ndk_version = get_ndk_version(env["ANDROID_NDK_ROOT"])
-
     common_opts = ['-fno-integrated-as', '-gcc-toolchain', gcc_toolchain_path]
-
-    if not ndk_unified_headers and ndk_version != None and ndk_version[0] >= 16:
-        ndk_unified_headers = True
-        print("Turning NDK unified headers on (starting from r16)")
 
     lib_sysroot = env["ANDROID_NDK_ROOT"] + "/platforms/" + ndk_platform + "/" + env['ARCH']
 
-    if ndk_unified_headers:
+    ndk_version = get_ndk_version(env["ANDROID_NDK_ROOT"])
+    if ndk_version != None and LooseVersion(ndk_version) >= LooseVersion("15.0.4075724"):
+        print("Using NDK unified headers")
         sysroot = env["ANDROID_NDK_ROOT"] + "/sysroot"
         env.Append(CPPFLAGS=["-isystem", sysroot + "/usr/include"])
         env.Append(CPPFLAGS=["-isystem", sysroot + "/usr/include/" + abi_subpath])
         # For unified headers this define has to be set manually
         env.Append(CPPFLAGS=["-D__ANDROID_API__=" + str(int(ndk_platform.split("-")[1]))])
     else:
+        print("Using NDK deprecated headers")
         env.Append(CPPFLAGS=["-isystem", lib_sysroot + "/usr/include"])
 
     env.Append(CPPFLAGS='-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -fvisibility=hidden -fno-strict-aliasing'.split())
@@ -269,8 +264,8 @@ def configure(env):
 
     env.use_windows_spawn_fix()
 
-# Return NDK version as [<major>,<minor>,<build>] or None if cannot be figured out (adapted from the Chromium project).
-def get_ndk_version (path):
+# Return NDK version string in source.properties (adapted from the Chromium project).
+def get_ndk_version(path):
     if path == None:
         return None
     prop_file_path = os.path.join(path, "source.properties")
@@ -279,8 +274,7 @@ def get_ndk_version (path):
             for line in prop_file:
                 key_value = map(lambda x: string.strip(x), line.split("="))
                 if key_value[0] == "Pkg.Revision":
-                    version_parts = key_value[1].split("-")[0].split(".")
-                    return map(int, version_parts[0:3])
+                    return key_value[1]
     except:
         print("Could not read source prop file '%s'" % prop_file_path)
     return None


### PR DESCRIPTION
Enable using NDK unified headers when available and opt-out ([more info](https://android.googlesource.com/platform/ndk.git/+/master/docs/Roadmap.md))