### PR TITLE
Fix issue #11695

### DIFF
--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -626,13 +626,13 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 
 		int amount = _cull_aabb_for_body(p_body, motion_aabb);
 
-		for (int j = 0; j < p_body->get_shape_count(); j++) {
+		for (int body_shape_idx = 0; body_shape_idx < p_body->get_shape_count(); body_shape_idx++) {
 
-			if (p_body->is_shape_set_as_disabled(j))
+			if (p_body->is_shape_set_as_disabled(body_shape_idx))
 				continue;
 
-			Transform2D body_shape_xform = body_transform * p_body->get_shape_transform(j);
-			Shape2DSW *body_shape = p_body->get_shape(j);
+			Transform2D body_shape_xform = body_transform * p_body->get_shape_transform(body_shape_idx);
+			Shape2DSW *body_shape = p_body->get_shape(body_shape_idx);
 
 			bool stuck = false;
 
@@ -642,14 +642,14 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 			for (int i = 0; i < amount; i++) {
 
 				const CollisionObject2DSW *col_obj = intersection_query_results[i];
-				int shape_idx = intersection_query_subindex_results[i];
-				Shape2DSW *against_shape = col_obj->get_shape(shape_idx);
+				int col_shape_idx = intersection_query_subindex_results[i];
+				Shape2DSW *against_shape = col_obj->get_shape(col_shape_idx);
 
 				bool excluded = false;
 
 				for (int k = 0; k < excluded_shape_pair_count; k++) {
 
-					if (excluded_shape_pairs[k].local_shape == body_shape && excluded_shape_pairs[k].against_object == col_obj && excluded_shape_pairs[k].against_shape_index == shape_idx) {
+					if (excluded_shape_pairs[k].local_shape == body_shape && excluded_shape_pairs[k].against_object == col_obj && excluded_shape_pairs[k].against_shape_index == col_shape_idx) {
 						excluded = true;
 						break;
 					}
@@ -660,7 +660,7 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 					continue;
 				}
 
-				Transform2D col_obj_xform = col_obj->get_transform() * col_obj->get_shape_transform(shape_idx);
+				Transform2D col_obj_xform = col_obj->get_transform() * col_obj->get_shape_transform(col_shape_idx);
 				//test initial overlap, does it collide if going all the way?
 				if (!CollisionSolver2DSW::solve(body_shape, body_shape_xform, p_motion, against_shape, col_obj_xform, Vector2(), NULL, NULL, NULL, 0)) {
 					continue;
@@ -669,7 +669,7 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 				//test initial overlap
 				if (CollisionSolver2DSW::solve(body_shape, body_shape_xform, Vector2(), against_shape, col_obj_xform, Vector2(), NULL, NULL, NULL, 0)) {
 
-					if (col_obj->is_shape_set_as_one_way_collision(j)) {
+					if (col_obj->is_shape_set_as_one_way_collision(col_shape_idx)) {
 						continue;
 					}
 
@@ -698,7 +698,7 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 					}
 				}
 
-				if (col_obj->is_shape_set_as_one_way_collision(j)) {
+				if (col_obj->is_shape_set_as_one_way_collision(col_shape_idx)) {
 
 					Vector2 cd[2];
 					Physics2DServerSW::CollCbkData cbk;
@@ -710,7 +710,7 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 					cbk.valid_depth = 10e20;
 
 					Vector2 sep = mnormal; //important optimization for this to work fast enough
-					bool collided = CollisionSolver2DSW::solve(body_shape, body_shape_xform, p_motion * (hi + contact_max_allowed_penetration), col_obj->get_shape(shape_idx), col_obj_xform, Vector2(), Physics2DServerSW::_shape_col_cbk, &cbk, &sep, 0);
+					bool collided = CollisionSolver2DSW::solve(body_shape, body_shape_xform, p_motion * (hi + contact_max_allowed_penetration), col_obj->get_shape(col_shape_idx), col_obj_xform, Vector2(), Physics2DServerSW::_shape_col_cbk, &cbk, &sep, 0);
 					if (!collided || cbk.amount == 0) {
 						continue;
 					}
@@ -726,7 +726,7 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 
 				safe = 0;
 				unsafe = 0;
-				best_shape = j; //sadly it's the best
+				best_shape = body_shape_idx; //sadly it's the best
 				break;
 			}
 			if (best_safe == 1.0) {
@@ -736,7 +736,7 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 
 				safe = best_safe;
 				unsafe = best_unsafe;
-				best_shape = j;
+				best_shape = body_shape_idx;
 			}
 		}
 	}


### PR DESCRIPTION
Fix wrong col_obj access using wrong index variable.

The real issue was in lines 672 and 701, where the wrong index variable was being used.
I renamed the two variable in question so they are less confusing to avoid this issue.

**j** to **body_shape_idx**
**shape_idx** to **col_shape_idx**

Hopefully this should be the right fix for the issue. If it's not, please, let me know!