### PR TITLE
Modified code completion for better tabbing with immediate hints.

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2040,6 +2040,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 
 						_confirm_completion();
 						accept_event();
+						emit_signal("request_completion");
 						return;
 					}
 


### PR DESCRIPTION
Please consider these modifications to the code completion.  This is one area of the script editor that bugs me. Currently to display the hints after tabbing (which I am so used to doing in Visual Studio) I have to back space over the '(' and then re-enter '('.  

Feels more natural and much more in-line with editors I've used in the past.