### PR TITLE
Enable asset store for Godot 3.0

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -33,6 +33,8 @@
 #include "editor_settings.h"
 #include "io/json.h"
 
+#include "version_generated.gen.h"
+
 void EditorAssetLibraryItem::configure(const String &p_title, int p_asset_id, const String &p_category, int p_category_id, const String &p_author, int p_author_id, int p_rating, const String &p_cost) {
 
 	title->set_text(p_title);
@@ -867,6 +869,8 @@ void EditorAssetLibrary::_search(int p_page) {
 	}
 	args += String() + "sort=" + sort_key[sort->get_selected()];
 
+	args += "&godot_version=" + itos(VERSION_MAJOR) + "." + itos(VERSION_MINOR);
+
 	String support_list;
 	for (int i = 0; i < SUPPORT_MAX; i++) {
 		if (support->get_popup()->is_item_checked(i)) {
@@ -1348,13 +1352,11 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	search_hb2->add_child(memnew(Label(TTR("Site:") + " ")));
 	repository = memnew(OptionButton);
 
-	// FIXME: Reenable me once GH-7147 is fixed.
-	/*
 	repository->add_item("godotengine.org");
 	repository->set_item_metadata(0, "https://godotengine.org/asset-library/api");
-	*/
 	repository->add_item("localhost");
-	repository->set_item_metadata(/*1*/ 0, "http://127.0.0.1/asset-library/api");
+	repository->set_item_metadata(1, "http://127.0.0.1/asset-library/api");
+
 	repository->connect("item_selected", this, "_repository_changed");
 
 	search_hb2->add_child(repository);


### PR DESCRIPTION
 I enabled it and allow loads only 3.0 assets from site - This is simple fix in http request line, I wonder why nobody touches this...

fix for https://github.com/godotengine/godot/issues/7147

![image](https://user-images.githubusercontent.com/3036176/32609165-bd66f446-c56f-11e7-8f6d-d7333a172e98.png)
