### PR TITLE
UWP: Update to build with Windows SDK 10.16229.0

### DIFF
--- a/platform/uwp/detect.py
+++ b/platform/uwp/detect.py
@@ -84,7 +84,7 @@ def configure(env):
     ## Architecture
 
     arch = ""
-    if os.getenv('Platform') == "ARM":
+    if str(os.getenv('Platform')).lower() == "arm":
 
         print("Compiled program architecture will be an ARM executable. (forcing bits=32).")
 

--- a/thirdparty/openssl/uwp.cpp
+++ b/thirdparty/openssl/uwp.cpp
@@ -103,12 +103,14 @@ extern "C"
 		{
 		return 0;
 		}
+#ifndef STD_ERROR_HANDLE
 	int __cdecl GetStdHandle(
 						   _In_  DWORD nStdHandle
 						   )
 		{
 		return 0;
 		}
+#endif
 	BOOL DeregisterEventSource(
 							  _Inout_  HANDLE hEventLog
 							  )


### PR DESCRIPTION
- Update the OpenSSL shim to work with the new SDK
- Change the ARM platform detection to work with VS2017

EDIT: I made a typo in the SDK version number, it's supposed to be 10.16299.0.