### PR TITLE
Fix #12544, arrow keys selecting objects in scene hierarchy

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2095,11 +2095,14 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 
 				if (select_mode == SELECT_MULTI) {
 
+					int col = selected_col < 0 ? 0 : selected_col;
+					while (next && !next->cells[col].selectable)
+						next = next->get_next_visible();
 					if (!next)
 						EXIT_BREAK;
 
-					selected_item = next;
-					emit_signal("cell_selected");
+					select_single_item(next, get_root(), col);
+
 					update();
 				} else {
 
@@ -2188,10 +2191,13 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 
 				if (select_mode == SELECT_MULTI) {
 
+					int col = selected_col < 0 ? 0 : selected_col;
+					while (prev && !prev->cells[col].selectable)
+						prev = prev->get_prev_visible();
 					if (!prev)
-						break;
-					selected_item = prev;
-					emit_signal("cell_selected");
+						break; // do nothing..
+					select_single_item(prev, get_root(), col);
+
 					update();
 				} else {
 


### PR DESCRIPTION
Fix for #12544, allowing objects to be automatically selected in the scene hierarchy when navigating with arrow keys through the scene tree.