### PR TITLE
Fix misaligned zoom icon in Texture Region Editor plugin

### DIFF
--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -860,6 +860,7 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	hb_tools->add_child(separator);
 
 	icon_zoom = memnew(TextureRect);
+	icon_zoom->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
 	hb_tools->add_child(icon_zoom);
 
 	zoom_out = memnew(ToolButton);


### PR DESCRIPTION
The zoom icon was aligned on top compared to the others zoom buttons
from the HBox container.

Closes #12668.