### PR TITLE
Unify degree methods and properties

### DIFF
--- a/doc/classes/CanvasLayer.xml
+++ b/doc/classes/CanvasLayer.xml
@@ -38,7 +38,7 @@
 				Return the base rotation for this layer in radians (helper).
 			</description>
 		</method>
-		<method name="get_rotationd" qualifiers="const">
+		<method name="get_rotation_degrees" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
@@ -101,7 +101,7 @@
 				Set the base rotation for this layer in radians (helper).
 			</description>
 		</method>
-		<method name="set_rotationd">
+		<method name="set_rotation_degrees">
 			<return type="void">
 			</return>
 			<argument index="0" name="degrees" type="float">
@@ -136,7 +136,7 @@
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset">
 			The layer's base offset.
 		</member>
-		<member name="rotation" type="float" setter="set_rotationd" getter="get_rotationd">
+		<member name="rotation" type="float" setter="set_rotation_degrees" getter="get_rotation_degrees">
 			The layer's rotation in degrees.
 		</member>
 		<member name="scale" type="Vector2" setter="set_scale" getter="get_scale">

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -347,7 +347,7 @@
 				Return the rotation (in radians)
 			</description>
 		</method>
-		<method name="get_rotation_deg" qualifiers="const">
+		<method name="get_rotation_degrees" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
@@ -763,7 +763,7 @@
 				Set the rotation (in radians).
 			</description>
 		</method>
-		<method name="set_rotation_deg">
+		<method name="set_rotation_degrees">
 			<return type="void">
 			</return>
 			<argument index="0" name="degrees" type="float">
@@ -910,7 +910,7 @@
 		<member name="rect_position" type="Vector2" setter="set_position" getter="get_position">
 			The node's position, relative to its parent. It corresponds to the rectangle's top-left corner. The property is not affected by [member rect_pivot_offset].
 		</member>
-		<member name="rect_rotation" type="float" setter="set_rotation_deg" getter="get_rotation_deg">
+		<member name="rect_rotation" type="float" setter="set_rotation_degrees" getter="get_rotation_degrees">
 			The node's rotation around its pivot, in degrees. See [member rect_pivot_offset] to change the pivot's position.
 		</member>
 		<member name="rect_scale" type="Vector2" setter="set_scale" getter="get_scale">

--- a/doc/classes/Node2D.xml
+++ b/doc/classes/Node2D.xml
@@ -52,7 +52,7 @@
 				Returns the node's global rotation in radians.
 			</description>
 		</method>
-		<method name="get_global_rotation_in_degrees" qualifiers="const">
+		<method name="get_global_rotation_degrees" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
@@ -89,7 +89,7 @@
 				Returns the node's rotation in radians.
 			</description>
 		</method>
-		<method name="get_rotation_in_degrees" qualifiers="const">
+		<method name="get_rotation_degrees" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
@@ -184,7 +184,7 @@
 				Sets the node's global rotation in radians.
 			</description>
 		</method>
-		<method name="set_global_rotation_in_degrees">
+		<method name="set_global_rotation_degrees">
 			<return type="void">
 			</return>
 			<argument index="0" name="degrees" type="float">
@@ -229,7 +229,7 @@
 				Sets the node's rotation in radians.
 			</description>
 		</method>
-		<method name="set_rotation_in_degrees">
+		<method name="set_rotation_degrees">
 			<return type="void">
 			</return>
 			<argument index="0" name="degrees" type="float">
@@ -309,7 +309,7 @@
 		<member name="global_rotation" type="float" setter="set_global_rotation" getter="get_global_rotation">
 			Global rotation in radians.
 		</member>
-		<member name="global_rotation_deg" type="float" setter="set_global_rotation_in_degrees" getter="get_global_rotation_in_degrees">
+		<member name="global_rotation_degrees" type="float" setter="set_global_rotation_degrees" getter="get_global_rotation_degrees">
 			Global rotation in degrees.
 		</member>
 		<member name="global_scale" type="Vector2" setter="set_global_scale" getter="get_global_scale">
@@ -324,7 +324,7 @@
 		<member name="rotation" type="float" setter="set_rotation" getter="get_rotation">
 			Rotation in radians, relative to the node's parent.
 		</member>
-		<member name="rotation_deg" type="float" setter="set_rotation_in_degrees" getter="get_rotation_in_degrees">
+		<member name="rotation_degrees" type="float" setter="set_rotation_degrees" getter="get_rotation_degrees">
 			Rotation in degrees, relative to the node's parent.
 		</member>
 		<member name="scale" type="Vector2" setter="set_scale" getter="get_scale">

--- a/doc/classes/Polygon2D.xml
+++ b/doc/classes/Polygon2D.xml
@@ -227,7 +227,7 @@
 		<member name="texture_offset" type="Vector2" setter="set_texture_offset" getter="get_texture_offset">
 			Amount to offset the polygon's [code]texture[/code]. If [code](0, 0)[/code] the texture's origin (its top-left corner) will be placed at the polygon's [code]position[/code].
 		</member>
-		<member name="texture_rotation" type="float" setter="_set_texture_rotationd" getter="_get_texture_rotationd">
+		<member name="texture_rotation" type="float" setter="set_texture_rotation_degrees" getter="get_texture_rotation_degrees">
 			The texture's rotation in degrees.
 		</member>
 		<member name="texture_scale" type="Vector2" setter="set_texture_scale" getter="get_texture_scale">

--- a/doc/classes/Spatial.xml
+++ b/doc/classes/Spatial.xml
@@ -39,7 +39,7 @@
 				Returns the rotation (in radians).
 			</description>
 		</method>
-		<method name="get_rotation_deg" qualifiers="const">
+		<method name="get_rotation_degrees" qualifiers="const">
 			<return type="Vector3">
 			</return>
 			<description>
@@ -267,16 +267,16 @@
 		<method name="set_rotation">
 			<return type="void">
 			</return>
-			<argument index="0" name="rotation_rad" type="Vector3">
+			<argument index="0" name="radians" type="Vector3">
 			</argument>
 			<description>
 				Set the rotation (in radians).
 			</description>
 		</method>
-		<method name="set_rotation_deg">
+		<method name="set_rotation_degrees">
 			<return type="void">
 			</return>
-			<argument index="0" name="rotation_deg" type="Vector3">
+			<argument index="0" name="degrees" type="Vector3">
 			</argument>
 			<description>
 				Set the rotation (in degrees).
@@ -365,7 +365,7 @@
 		<member name="rotation" type="Vector3" setter="set_rotation" getter="get_rotation">
 			Local euler rotation in radians of this node.
 		</member>
-		<member name="rotation_deg" type="Vector3" setter="set_rotation_deg" getter="get_rotation_deg">
+		<member name="rotation_degrees" type="Vector3" setter="set_rotation_degrees" getter="get_rotation_degrees">
 			Local euler rotation in degrees of this node.
 		</member>
 		<member name="scale" type="Vector3" setter="set_scale" getter="get_scale">

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3623,7 +3623,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 					if (key_pos)
 						AnimationPlayerEditor::singleton->get_key_editor()->insert_node_value_key(n2d, "position", n2d->get_position(), existing);
 					if (key_rot)
-						AnimationPlayerEditor::singleton->get_key_editor()->insert_node_value_key(n2d, "rotation_deg", Math::rad2deg(n2d->get_rotation()), existing);
+						AnimationPlayerEditor::singleton->get_key_editor()->insert_node_value_key(n2d, "rotation_degrees", Math::rad2deg(n2d->get_rotation()), existing);
 					if (key_scale)
 						AnimationPlayerEditor::singleton->get_key_editor()->insert_node_value_key(n2d, "scale", n2d->get_scale(), existing);
 
@@ -3654,7 +3654,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 								if (key_pos)
 									AnimationPlayerEditor::singleton->get_key_editor()->insert_node_value_key(F->get(), "position", F->get()->get_position(), existing);
 								if (key_rot)
-									AnimationPlayerEditor::singleton->get_key_editor()->insert_node_value_key(F->get(), "rotation_deg", Math::rad2deg(F->get()->get_rotation()), existing);
+									AnimationPlayerEditor::singleton->get_key_editor()->insert_node_value_key(F->get(), "rotation_degrees", Math::rad2deg(F->get()->get_rotation()), existing);
 								if (key_scale)
 									AnimationPlayerEditor::singleton->get_key_editor()->insert_node_value_key(F->get(), "scale", F->get()->get_scale(), existing);
 							}
@@ -3668,7 +3668,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 					if (key_pos)
 						AnimationPlayerEditor::singleton->get_key_editor()->insert_node_value_key(ctrl, "rect_position", ctrl->get_position(), existing);
 					if (key_rot)
-						AnimationPlayerEditor::singleton->get_key_editor()->insert_node_value_key(ctrl, "rect_rotation", ctrl->get_rotation_deg(), existing);
+						AnimationPlayerEditor::singleton->get_key_editor()->insert_node_value_key(ctrl, "rect_rotation", ctrl->get_rotation_degrees(), existing);
 					if (key_scale)
 						AnimationPlayerEditor::singleton->get_key_editor()->insert_node_value_key(ctrl, "rect_size", ctrl->get_size(), existing);
 				}

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -65,7 +65,7 @@ void Node2D::edit_set_state(const Variant &p_state) {
 	_scale = state[2];
 	_update_transform();
 	_change_notify("rotation");
-	_change_notify("rotation_deg");
+	_change_notify("rotation_degrees");
 	_change_notify("scale");
 	_change_notify("position");
 }
@@ -106,7 +106,7 @@ void Node2D::edit_rotate(float p_rot) {
 	angle += p_rot;
 	_update_transform();
 	_change_notify("rotation");
-	_change_notify("rotation_deg");
+	_change_notify("rotation_degrees");
 }
 
 void Node2D::_update_xform_values() {
@@ -147,10 +147,10 @@ void Node2D::set_rotation(float p_radians) {
 	angle = p_radians;
 	_update_transform();
 	_change_notify("rotation");
-	_change_notify("rotation_deg");
+	_change_notify("rotation_degrees");
 }
 
-void Node2D::set_rotation_in_degrees(float p_degrees) {
+void Node2D::set_rotation_degrees(float p_degrees) {
 
 	set_rotation(Math::deg2rad(p_degrees));
 }
@@ -182,7 +182,7 @@ float Node2D::get_rotation() const {
 	return angle;
 }
 
-float Node2D::get_rotation_in_degrees() const {
+float Node2D::get_rotation_degrees() const {
 
 	return Math::rad2deg(get_rotation());
 }
@@ -287,12 +287,12 @@ void Node2D::set_global_rotation(float p_radians) {
 	}
 }
 
-float Node2D::get_global_rotation_in_degrees() const {
+float Node2D::get_global_rotation_degrees() const {
 
 	return Math::rad2deg(get_global_rotation());
 }
 
-void Node2D::set_global_rotation_in_degrees(float p_degrees) {
+void Node2D::set_global_rotation_degrees(float p_degrees) {
 
 	set_global_rotation(Math::deg2rad(p_degrees));
 }
@@ -400,12 +400,12 @@ void Node2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_position", "position"), &Node2D::set_position);
 	ClassDB::bind_method(D_METHOD("set_rotation", "radians"), &Node2D::set_rotation);
-	ClassDB::bind_method(D_METHOD("set_rotation_in_degrees", "degrees"), &Node2D::set_rotation_in_degrees);
+	ClassDB::bind_method(D_METHOD("set_rotation_degrees", "degrees"), &Node2D::set_rotation_degrees);
 	ClassDB::bind_method(D_METHOD("set_scale", "scale"), &Node2D::set_scale);
 
 	ClassDB::bind_method(D_METHOD("get_position"), &Node2D::get_position);
 	ClassDB::bind_method(D_METHOD("get_rotation"), &Node2D::get_rotation);
-	ClassDB::bind_method(D_METHOD("get_rotation_in_degrees"), &Node2D::get_rotation_in_degrees);
+	ClassDB::bind_method(D_METHOD("get_rotation_degrees"), &Node2D::get_rotation_degrees);
 	ClassDB::bind_method(D_METHOD("get_scale"), &Node2D::get_scale);
 
 	ClassDB::bind_method(D_METHOD("rotate", "radians"), &Node2D::rotate);
@@ -419,8 +419,8 @@ void Node2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_global_position"), &Node2D::get_global_position);
 	ClassDB::bind_method(D_METHOD("set_global_rotation", "radians"), &Node2D::set_global_rotation);
 	ClassDB::bind_method(D_METHOD("get_global_rotation"), &Node2D::get_global_rotation);
-	ClassDB::bind_method(D_METHOD("set_global_rotation_in_degrees", "degrees"), &Node2D::set_global_rotation_in_degrees);
-	ClassDB::bind_method(D_METHOD("get_global_rotation_in_degrees"), &Node2D::get_global_rotation_in_degrees);
+	ClassDB::bind_method(D_METHOD("set_global_rotation_degrees", "degrees"), &Node2D::set_global_rotation_degrees);
+	ClassDB::bind_method(D_METHOD("get_global_rotation_degrees"), &Node2D::get_global_rotation_degrees);
 	ClassDB::bind_method(D_METHOD("set_global_scale", "scale"), &Node2D::set_global_scale);
 	ClassDB::bind_method(D_METHOD("get_global_scale"), &Node2D::get_global_scale);
 
@@ -446,13 +446,13 @@ void Node2D::_bind_methods() {
 	ADD_GROUP("Transform", "");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::VECTOR2, "position"), "set_position", "get_position");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::REAL, "rotation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_rotation", "get_rotation");
-	ADD_PROPERTYNZ(PropertyInfo(Variant::REAL, "rotation_deg", PROPERTY_HINT_RANGE, "-1440,1440,0.1", PROPERTY_USAGE_EDITOR), "set_rotation_in_degrees", "get_rotation_in_degrees");
+	ADD_PROPERTYNZ(PropertyInfo(Variant::REAL, "rotation_degrees", PROPERTY_HINT_RANGE, "-1440,1440,0.1", PROPERTY_USAGE_EDITOR), "set_rotation_degrees", "get_rotation_degrees");
 	ADD_PROPERTYNO(PropertyInfo(Variant::VECTOR2, "scale"), "set_scale", "get_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM2D, "transform", PROPERTY_HINT_NONE, "", 0), "set_transform", "get_transform");
 
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "global_position", PROPERTY_HINT_NONE, "", 0), "set_global_position", "get_global_position");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "global_rotation", PROPERTY_HINT_NONE, "", 0), "set_global_rotation", "get_global_rotation");
-	ADD_PROPERTY(PropertyInfo(Variant::REAL, "global_rotation_deg", PROPERTY_HINT_NONE, "", 0), "set_global_rotation_in_degrees", "get_global_rotation_in_degrees");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "global_rotation_degrees", PROPERTY_HINT_NONE, "", 0), "set_global_rotation_degrees", "get_global_rotation_degrees");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "global_scale", PROPERTY_HINT_NONE, "", 0), "set_global_scale", "get_global_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM2D, "global_transform", PROPERTY_HINT_NONE, "", 0), "set_global_transform", "get_global_transform");
 

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -66,7 +66,7 @@ public:
 
 	void set_position(const Point2 &p_pos);
 	void set_rotation(float p_radians);
-	void set_rotation_in_degrees(float p_degrees);
+	void set_rotation_degrees(float p_degrees);
 	void set_scale(const Size2 &p_scale);
 
 	void rotate(float p_radians);
@@ -78,12 +78,12 @@ public:
 
 	Point2 get_position() const;
 	float get_rotation() const;
-	float get_rotation_in_degrees() const;
+	float get_rotation_degrees() const;
 	Size2 get_scale() const;
 
 	Point2 get_global_position() const;
 	float get_global_rotation() const;
-	float get_global_rotation_in_degrees() const;
+	float get_global_rotation_degrees() const;
 	Size2 get_global_scale() const;
 	virtual Rect2 get_item_rect() const;
 
@@ -91,7 +91,7 @@ public:
 	void set_global_transform(const Transform2D &p_transform);
 	void set_global_position(const Point2 &p_pos);
 	void set_global_rotation(float p_radians);
-	void set_global_rotation_in_degrees(float p_degrees);
+	void set_global_rotation_degrees(float p_degrees);
 	void set_global_scale(const Size2 &p_scale);
 
 	void set_z(int p_z);

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -264,11 +264,11 @@ float Polygon2D::get_texture_rotation() const {
 	return tex_rot;
 }
 
-void Polygon2D::_set_texture_rotationd(float p_rot) {
+void Polygon2D::set_texture_rotation_degrees(float p_rot) {
 
 	set_texture_rotation(Math::deg2rad(p_rot));
 }
-float Polygon2D::_get_texture_rotationd() const {
+float Polygon2D::get_texture_rotation_degrees() const {
 
 	return Math::rad2deg(get_texture_rotation());
 }
@@ -348,8 +348,8 @@ void Polygon2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_texture_rotation", "texture_rotation"), &Polygon2D::set_texture_rotation);
 	ClassDB::bind_method(D_METHOD("get_texture_rotation"), &Polygon2D::get_texture_rotation);
 
-	ClassDB::bind_method(D_METHOD("_set_texture_rotationd", "texture_rotation"), &Polygon2D::_set_texture_rotationd);
-	ClassDB::bind_method(D_METHOD("_get_texture_rotationd"), &Polygon2D::_get_texture_rotationd);
+	ClassDB::bind_method(D_METHOD("set_texture_rotation_degrees", "texture_rotation"), &Polygon2D::set_texture_rotation_degrees);
+	ClassDB::bind_method(D_METHOD("get_texture_rotation_degrees"), &Polygon2D::get_texture_rotation_degrees);
 
 	ClassDB::bind_method(D_METHOD("set_texture_scale", "texture_scale"), &Polygon2D::set_texture_scale);
 	ClassDB::bind_method(D_METHOD("get_texture_scale"), &Polygon2D::get_texture_scale);
@@ -377,7 +377,7 @@ void Polygon2D::_bind_methods() {
 	ADD_GROUP("Texture", "texture_");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "texture_offset"), "set_texture_offset", "get_texture_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "texture_scale"), "set_texture_scale", "get_texture_scale");
-	ADD_PROPERTY(PropertyInfo(Variant::REAL, "texture_rotation", PROPERTY_HINT_RANGE, "-1440,1440,0.1"), "_set_texture_rotationd", "_get_texture_rotationd");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "texture_rotation", PROPERTY_HINT_RANGE, "-1440,1440,0.1"), "set_texture_rotation_degrees", "get_texture_rotation_degrees");
 
 	ADD_GROUP("Invert", "invert_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "invert_enable"), "set_invert", "get_invert");

--- a/scene/2d/polygon_2d.h
+++ b/scene/2d/polygon_2d.h
@@ -53,9 +53,6 @@ class Polygon2D : public Node2D {
 	mutable bool rect_cache_dirty;
 	mutable Rect2 item_rect;
 
-	void _set_texture_rotationd(float p_rot);
-	float _get_texture_rotationd() const;
-
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -81,6 +78,9 @@ public:
 
 	void set_texture_rotation(float p_rot);
 	float get_texture_rotation() const;
+
+	void set_texture_rotation_degrees(float p_rot);
+	float get_texture_rotation_degrees() const;
 
 	void set_texture_scale(const Size2 &p_scale);
 	Size2 get_texture_scale() const;

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -233,7 +233,7 @@ void Spatial::set_transform(const Transform &p_transform) {
 	data.dirty |= DIRTY_VECTORS;
 	_change_notify("translation");
 	_change_notify("rotation");
-	_change_notify("rotation_deg");
+	_change_notify("rotation_degrees");
 	_change_notify("scale");
 	_propagate_transform_changed(this);
 	if (data.notify_local_transform) {
@@ -327,7 +327,7 @@ void Spatial::set_rotation(const Vector3 &p_euler_rad) {
 	}
 }
 
-void Spatial::set_rotation_in_degrees(const Vector3 &p_euler_deg) {
+void Spatial::set_rotation_degrees(const Vector3 &p_euler_deg) {
 
 	set_rotation(p_euler_deg * Math_PI / 180.0);
 }
@@ -364,7 +364,7 @@ Vector3 Spatial::get_rotation() const {
 	return data.rotation;
 }
 
-Vector3 Spatial::get_rotation_in_degrees() const {
+Vector3 Spatial::get_rotation_degrees() const {
 
 	return get_rotation() * 180.0 / Math_PI;
 }
@@ -677,10 +677,10 @@ void Spatial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_transform"), &Spatial::get_transform);
 	ClassDB::bind_method(D_METHOD("set_translation", "translation"), &Spatial::set_translation);
 	ClassDB::bind_method(D_METHOD("get_translation"), &Spatial::get_translation);
-	ClassDB::bind_method(D_METHOD("set_rotation", "rotation_rad"), &Spatial::set_rotation);
+	ClassDB::bind_method(D_METHOD("set_rotation", "radians"), &Spatial::set_rotation);
 	ClassDB::bind_method(D_METHOD("get_rotation"), &Spatial::get_rotation);
-	ClassDB::bind_method(D_METHOD("set_rotation_deg", "rotation_deg"), &Spatial::set_rotation_in_degrees);
-	ClassDB::bind_method(D_METHOD("get_rotation_deg"), &Spatial::get_rotation_in_degrees);
+	ClassDB::bind_method(D_METHOD("set_rotation_degrees", "degrees"), &Spatial::set_rotation_degrees);
+	ClassDB::bind_method(D_METHOD("get_rotation_degrees"), &Spatial::get_rotation_degrees);
 	ClassDB::bind_method(D_METHOD("set_scale", "scale"), &Spatial::set_scale);
 	ClassDB::bind_method(D_METHOD("get_scale"), &Spatial::get_scale);
 	ClassDB::bind_method(D_METHOD("set_global_transform", "global"), &Spatial::set_global_transform);
@@ -746,7 +746,7 @@ void Spatial::_bind_methods() {
 	ADD_PROPERTYNZ(PropertyInfo(Variant::TRANSFORM, "transform", PROPERTY_HINT_NONE, ""), "set_transform", "get_transform");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::TRANSFORM, "global_transform", PROPERTY_HINT_NONE, "", 0), "set_global_transform", "get_global_transform");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "translation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_translation", "get_translation");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "rotation_deg", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_rotation_deg", "get_rotation_deg");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "rotation_degrees", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_rotation_degrees", "get_rotation_degrees");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "rotation", PROPERTY_HINT_NONE, "", 0), "set_rotation", "get_rotation");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "scale", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_scale", "get_scale");
 	ADD_GROUP("Visibility", "");

--- a/scene/3d/spatial.h
+++ b/scene/3d/spatial.h
@@ -132,12 +132,12 @@ public:
 
 	void set_translation(const Vector3 &p_translation);
 	void set_rotation(const Vector3 &p_euler_rad);
-	void set_rotation_in_degrees(const Vector3 &p_euler_deg);
+	void set_rotation_degrees(const Vector3 &p_euler_deg);
 	void set_scale(const Vector3 &p_scale);
 
 	Vector3 get_translation() const;
 	Vector3 get_rotation() const;
-	Vector3 get_rotation_in_degrees() const;
+	Vector3 get_rotation_degrees() const;
 	Vector3 get_scale() const;
 
 	void set_transform(const Transform &p_transform);

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2416,11 +2416,11 @@ float Control::get_rotation() const {
 	return data.rotation;
 }
 
-void Control::set_rotation_deg(float p_degrees) {
+void Control::set_rotation_degrees(float p_degrees) {
 	set_rotation(Math::deg2rad(p_degrees));
 }
 
-float Control::get_rotation_deg() const {
+float Control::get_rotation_degrees() const {
 	return Math::rad2deg(get_rotation());
 }
 
@@ -2596,7 +2596,7 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_custom_minimum_size", "size"), &Control::set_custom_minimum_size);
 	ClassDB::bind_method(D_METHOD("set_global_position", "position"), &Control::set_global_position);
 	ClassDB::bind_method(D_METHOD("set_rotation", "radians"), &Control::set_rotation);
-	ClassDB::bind_method(D_METHOD("set_rotation_deg", "degrees"), &Control::set_rotation_deg);
+	ClassDB::bind_method(D_METHOD("set_rotation_degrees", "degrees"), &Control::set_rotation_degrees);
 	ClassDB::bind_method(D_METHOD("set_scale", "scale"), &Control::set_scale);
 	ClassDB::bind_method(D_METHOD("set_pivot_offset", "pivot_offset"), &Control::set_pivot_offset);
 	ClassDB::bind_method(D_METHOD("get_margin", "margin"), &Control::get_margin);
@@ -2605,7 +2605,7 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_position"), &Control::get_position);
 	ClassDB::bind_method(D_METHOD("get_size"), &Control::get_size);
 	ClassDB::bind_method(D_METHOD("get_rotation"), &Control::get_rotation);
-	ClassDB::bind_method(D_METHOD("get_rotation_deg"), &Control::get_rotation_deg);
+	ClassDB::bind_method(D_METHOD("get_rotation_degrees"), &Control::get_rotation_degrees);
 	ClassDB::bind_method(D_METHOD("get_scale"), &Control::get_scale);
 	ClassDB::bind_method(D_METHOD("get_pivot_offset"), &Control::get_pivot_offset);
 	ClassDB::bind_method(D_METHOD("get_custom_minimum_size"), &Control::get_custom_minimum_size);
@@ -2724,7 +2724,7 @@ void Control::_bind_methods() {
 	ADD_PROPERTYNZ(PropertyInfo(Variant::VECTOR2, "rect_position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_position", "get_position");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::VECTOR2, "rect_size", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_size", "get_size");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::VECTOR2, "rect_min_size"), "set_custom_minimum_size", "get_custom_minimum_size");
-	ADD_PROPERTYNZ(PropertyInfo(Variant::REAL, "rect_rotation", PROPERTY_HINT_RANGE, "-1080,1080,0.01"), "set_rotation_deg", "get_rotation_deg");
+	ADD_PROPERTYNZ(PropertyInfo(Variant::REAL, "rect_rotation", PROPERTY_HINT_RANGE, "-1080,1080,0.01"), "set_rotation_degrees", "get_rotation_degrees");
 	ADD_PROPERTYNO(PropertyInfo(Variant::VECTOR2, "rect_scale"), "set_scale", "get_scale");
 	ADD_PROPERTYNO(PropertyInfo(Variant::VECTOR2, "rect_pivot_offset"), "set_pivot_offset", "get_pivot_offset");
 	ADD_PROPERTYNO(PropertyInfo(Variant::BOOL, "rect_clip_content"), "set_clip_contents", "is_clipping_contents");

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -328,9 +328,9 @@ public:
 	Rect2 get_window_rect() const; ///< use with care, as it blocks waiting for the visual server
 
 	void set_rotation(float p_radians);
-	void set_rotation_deg(float p_degrees);
+	void set_rotation_degrees(float p_degrees);
 	float get_rotation() const;
-	float get_rotation_deg() const;
+	float get_rotation_degrees() const;
 
 	void set_h_grow_direction(GrowDirection p_direction);
 	GrowDirection get_h_grow_direction() const;

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -105,12 +105,12 @@ real_t CanvasLayer::get_rotation() const {
 	return rot;
 }
 
-void CanvasLayer::set_rotationd(real_t p_degrees) {
+void CanvasLayer::set_rotation_degrees(real_t p_degrees) {
 
 	set_rotation(Math::deg2rad(p_degrees));
 }
 
-real_t CanvasLayer::get_rotationd() const {
+real_t CanvasLayer::get_rotation_degrees() const {
 
 	return Math::rad2deg(get_rotation());
 }
@@ -238,8 +238,8 @@ void CanvasLayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_rotation", "radians"), &CanvasLayer::set_rotation);
 	ClassDB::bind_method(D_METHOD("get_rotation"), &CanvasLayer::get_rotation);
 
-	ClassDB::bind_method(D_METHOD("set_rotationd", "degrees"), &CanvasLayer::set_rotationd);
-	ClassDB::bind_method(D_METHOD("get_rotationd"), &CanvasLayer::get_rotationd);
+	ClassDB::bind_method(D_METHOD("set_rotation_degrees", "degrees"), &CanvasLayer::set_rotation_degrees);
+	ClassDB::bind_method(D_METHOD("get_rotation_degrees"), &CanvasLayer::get_rotation_degrees);
 
 	ClassDB::bind_method(D_METHOD("set_scale", "scale"), &CanvasLayer::set_scale);
 	ClassDB::bind_method(D_METHOD("get_scale"), &CanvasLayer::get_scale);
@@ -253,7 +253,7 @@ void CanvasLayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "layer", PROPERTY_HINT_RANGE, "-128,128,1"), "set_layer", "get_layer");
 	//ADD_PROPERTY( PropertyInfo(Variant::MATRIX32,"transform",PROPERTY_HINT_RANGE),"set_transform","get_transform") ;
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "offset"), "set_offset", "get_offset");
-	ADD_PROPERTY(PropertyInfo(Variant::REAL, "rotation"), "set_rotationd", "get_rotationd");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "rotation"), "set_rotation_degrees", "get_rotation_degrees");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "scale"), "set_scale", "get_scale");
 }
 

--- a/scene/main/canvas_layer.h
+++ b/scene/main/canvas_layer.h
@@ -74,8 +74,8 @@ public:
 	void set_rotation(real_t p_radians);
 	real_t get_rotation() const;
 
-	void set_rotationd(real_t p_degrees);
-	real_t get_rotationd() const;
+	void set_rotation_degrees(real_t p_degrees);
+	real_t get_rotation_degrees() const;
 
 	void set_scale(const Size2 &p_scale);
 	Size2 get_scale() const;

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -143,7 +143,7 @@ SceneStringNames::SceneStringNames() {
 	v_offset = StaticCString::create("v_offset");
 
 	transform_pos = StaticCString::create("position");
-	transform_rot = StaticCString::create("rotation_deg");
+	transform_rot = StaticCString::create("rotation_degrees");
 	transform_scale = StaticCString::create("scale");
 
 	_update_remote = StaticCString::create("_update_remote");


### PR DESCRIPTION
Tentative unification of "degrees" methods and properties before the freeze.

Just tell me if some of those should remain the way they are currently or if you'd prefer a different convention than `_degrees`.