### PR TITLE
Allow changing importers in the import dock.

### DIFF
--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -263,6 +263,14 @@ void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
 	imported->set_text(itos(p_paths.size()) + TTR(" Files"));
 }
 
+void ImportDock::_importer_selected(int i_idx) {
+	String name = import_as->get_selected_metadata();
+	Ref<ResourceImporter> importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(name);
+	ERR_FAIL_COND(importer.is_null());
+
+	params->importer = importer;
+}
+
 void ImportDock::_preset_selected(int p_idx) {
 
 	int item_id = preset->get_popup()->get_item_id(p_idx);
@@ -336,6 +344,7 @@ void ImportDock::_reimport() {
 		Error err = config->load(params->paths[i] + ".import");
 		ERR_CONTINUE(err != OK);
 
+		config->set_value("remap", "importer", params->importer->get_importer_name());
 		config->erase_section("params");
 
 		for (List<PropertyInfo>::Element *E = params->properties.front(); E; E = E->next()) {
@@ -367,6 +376,7 @@ void ImportDock::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_reimport"), &ImportDock::_reimport);
 	ClassDB::bind_method(D_METHOD("_preset_selected"), &ImportDock::_preset_selected);
+	ClassDB::bind_method(D_METHOD("_importer_selected"), &ImportDock::_importer_selected);
 }
 
 void ImportDock::initialize_import_options() const {
@@ -384,6 +394,7 @@ ImportDock::ImportDock() {
 	HBoxContainer *hb = memnew(HBoxContainer);
 	add_margin_child(TTR("Import As:"), hb);
 	import_as = memnew(OptionButton);
+	import_as->connect("item_selected", this, "_importer_selected");
 	hb->add_child(import_as);
 	import_as->set_h_size_flags(SIZE_EXPAND_FILL);
 	preset = memnew(MenuButton);

--- a/editor/import_dock.h
+++ b/editor/import_dock.h
@@ -54,6 +54,7 @@ class ImportDock : public VBoxContainer {
 	ImportDockParameters *params;
 
 	void _preset_selected(int p_idx);
+	void _importer_selected(int i_idx);
 
 	void _reimport();
 


### PR DESCRIPTION
(Partially) Fixes #11749.

This PR allows OBJ files to be imported as a Mesh instead of a PackedScene, without having to manually change the `.import` file.

The import dock still needs a refactor to allow editing the new importer properties without having to reimport and re-select the items again.