### PR TITLE
Align sensors and implement gravity sensor for Android

### DIFF
--- a/modules/mobile_vr/mobile_interface.cpp
+++ b/modules/mobile_vr/mobile_interface.cpp
@@ -156,17 +156,6 @@ void MobileVRInterface::set_position_from_sensors() {
 		has_gyro = true;
 	};
 
-#ifdef ANDROID_ENABLED
-	///@TODO needs testing, i don't have a gyro, potentially can be removed depending on what comes out of issue #8101
-	// On Android x and z axis seem inverted
-	gyro.x = -gyro.x;
-	gyro.z = -gyro.z;
-	grav.x = -grav.x;
-	grav.z = -grav.z;
-	magneto.x = -magneto.x;
-	magneto.z = -magneto.z;
-#endif
-
 	if (has_gyro) {
 		// start with applying our gyro (do NOT smooth our gyro!)
 		Basis rotate;

--- a/platform/android/godot_android.cpp
+++ b/platform/android/godot_android.cpp
@@ -669,6 +669,14 @@ static void engine_handle_cmd(struct android_app *app, int32_t cmd) {
 				ASensorEventQueue_setEventRate(engine->sensorEventQueue,
 						engine->accelerometerSensor, (1000L / 60) * 1000);
 			}
+			// start monitoring gravity
+			if (engine->gravitySensor != NULL) {
+				ASensorEventQueue_enableSensor(engine->sensorEventQueue,
+						engine->gravitySensor);
+				// We'd like to get 60 events per second (in us).
+				ASensorEventQueue_setEventRate(engine->sensorEventQueue,
+						engine->gravitySensor, (1000L / 60) * 1000);
+			}
 			// Also start monitoring the magnetometer.
 			if (engine->magnetometerSensor != NULL) {
 				ASensorEventQueue_enableSensor(engine->sensorEventQueue,
@@ -693,6 +701,10 @@ static void engine_handle_cmd(struct android_app *app, int32_t cmd) {
 			if (engine->accelerometerSensor != NULL) {
 				ASensorEventQueue_disableSensor(engine->sensorEventQueue,
 						engine->accelerometerSensor);
+			}
+			if (engine->gravitySensor != NULL) {
+				ASensorEventQueue_disableSensor(engine->sensorEventQueue,
+						engine->gravitySensor);
 			}
 			if (engine->magnetometerSensor != NULL) {
 				ASensorEventQueue_disableSensor(engine->sensorEventQueue,
@@ -729,6 +741,8 @@ void android_main(struct android_app *app) {
 	engine.sensorManager = ASensorManager_getInstance();
 	engine.accelerometerSensor = ASensorManager_getDefaultSensor(engine.sensorManager,
 			ASENSOR_TYPE_ACCELEROMETER);
+	engine.gravitySensor = ASensorManager_getDefaultSensor(engine.sensorManager,
+			ASENSOR_TYPE_GRAVITY);
 	engine.magnetometerSensor = ASensorManager_getDefaultSensor(engine.sensorManager,
 			ASENSOR_TYPE_MAGNETIC_FIELD);
 	engine.gyroscopeSensor = ASensorManager_getDefaultSensor(engine.sensorManager,

--- a/platform/android/java/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/src/org/godotengine/godot/Godot.java
@@ -219,6 +219,7 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 
 	private SensorManager mSensorManager;
 	private Sensor mAccelerometer;
+	private Sensor mGravity;
 	private Sensor mMagnetometer;
 	private Sensor mGyroscope;
 
@@ -435,6 +436,8 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 		mSensorManager = (SensorManager) getSystemService(Context.SENSOR_SERVICE);
 		mAccelerometer = mSensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
 		mSensorManager.registerListener(this, mAccelerometer, SensorManager.SENSOR_DELAY_GAME);
+		mGravity = mSensorManager.getDefaultSensor(Sensor.TYPE_GRAVITY);
+		mSensorManager.registerListener(this, mGravity, SensorManager.SENSOR_DELAY_GAME);
 		mMagnetometer = mSensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD);
 		mSensorManager.registerListener(this, mMagnetometer, SensorManager.SENSOR_DELAY_GAME);
 		mGyroscope = mSensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE);
@@ -667,6 +670,7 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 			}
 		});
 		mSensorManager.registerListener(this, mAccelerometer, SensorManager.SENSOR_DELAY_GAME);
+		mSensorManager.registerListener(this, mGravity, SensorManager.SENSOR_DELAY_GAME);
 		mSensorManager.registerListener(this, mMagnetometer, SensorManager.SENSOR_DELAY_GAME);
 		mSensorManager.registerListener(this, mGyroscope, SensorManager.SENSOR_DELAY_GAME);
 
@@ -734,13 +738,16 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 				@Override
 				public void run() {
 					if (typeOfSensor == Sensor.TYPE_ACCELEROMETER) {
-						GodotLib.accelerometer(x,y,z);
+						GodotLib.accelerometer(-x,y,-z);
+					}
+					if (typeOfSensor == Sensor.TYPE_GRAVITY) {
+						GodotLib.gravity(-x,y,-z);
 					}
 					if (typeOfSensor == Sensor.TYPE_MAGNETIC_FIELD) {
-						GodotLib.magnetometer(x,y,z);
+						GodotLib.magnetometer(-x,y,-z);
 					}
 					if (typeOfSensor == Sensor.TYPE_GYROSCOPE) {
-						GodotLib.gyroscope(x,y,z);
+						GodotLib.gyroscope(x,-y,z);
 					}
 				}
 			});

--- a/platform/android/java/src/org/godotengine/godot/GodotLib.java
+++ b/platform/android/java/src/org/godotengine/godot/GodotLib.java
@@ -53,6 +53,7 @@ public class GodotLib {
      public static native void step();
      public static native void touch(int what,int pointer,int howmany, int[] arr);
      public static native void accelerometer(float x, float y, float z);
+     public static native void gravity(float x, float y, float z);
      public static native void magnetometer(float x, float y, float z);
      public static native void gyroscope(float x, float y, float z);
 	 public static native void key(int p_scancode, int p_unicode_char, boolean p_pressed);

--- a/platform/android/java_glue.cpp
+++ b/platform/android/java_glue.cpp
@@ -608,6 +608,7 @@ static bool resized = false;
 static bool resized_reload = false;
 static Size2 new_size;
 static Vector3 accelerometer;
+static Vector3 gravity;
 static Vector3 magnetometer;
 static Vector3 gyroscope;
 static HashMap<String, JNISingleton *> jni_singletons;
@@ -1012,6 +1013,8 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env, job
 
 	os_android->process_accelerometer(accelerometer);
 
+	os_android->process_gravity(gravity);
+
 	os_android->process_magnetometer(magnetometer);
 
 	os_android->process_gyroscope(gyroscope);
@@ -1384,6 +1387,10 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_key(JNIEnv *env, jobj
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_accelerometer(JNIEnv *env, jobject obj, jfloat x, jfloat y, jfloat z) {
 	accelerometer = Vector3(x, y, z);
+}
+
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_gravity(JNIEnv *env, jobject obj, jfloat x, jfloat y, jfloat z) {
+	gravity = Vector3(x, y, z);
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_magnetometer(JNIEnv *env, jobject obj, jfloat x, jfloat y, jfloat z) {

--- a/platform/android/java_glue.h
+++ b/platform/android/java_glue.h
@@ -50,6 +50,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_joyhat(JNIEnv *env, j
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_joyconnectionchanged(JNIEnv *env, jobject obj, jint p_device, jboolean p_connected, jstring p_name);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_audio(JNIEnv *env, jobject obj);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_accelerometer(JNIEnv *env, jobject obj, jfloat x, jfloat y, jfloat z);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_gravity(JNIEnv *env, jobject obj, jfloat x, jfloat y, jfloat z);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_magnetometer(JNIEnv *env, jobject obj, jfloat x, jfloat y, jfloat z);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_gyroscope(JNIEnv *env, jobject obj, jfloat x, jfloat y, jfloat z);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_focusin(JNIEnv *env, jobject obj);

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -490,6 +490,11 @@ void OS_Android::process_accelerometer(const Vector3 &p_accelerometer) {
 	input->set_accelerometer(p_accelerometer);
 }
 
+void OS_Android::process_gravity(const Vector3 &p_gravity) {
+
+	input->set_gravity(p_gravity);
+}
+
 void OS_Android::process_magnetometer(const Vector3 &p_magnetometer) {
 
 	input->set_magnetometer(p_magnetometer);

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -219,6 +219,7 @@ public:
 	virtual String get_system_dir(SystemDir p_dir) const;
 
 	void process_accelerometer(const Vector3 &p_accelerometer);
+	void process_gravity(const Vector3 &p_gravity);
 	void process_magnetometer(const Vector3 &p_magnetometer);
 	void process_gyroscope(const Vector3 &p_gyroscope);
 	void process_touch(int p_what, int p_pointer, const Vector<TouchPos> &p_points);


### PR DESCRIPTION
Tested on a Samsung Note 4 using:
https://github.com/godotengine/godot-demo-projects/tree/master/misc/sensors

The different sensors are now aligned with the axis in a 3D scene. So the accelerator actually points down :)

I have also implemented the gravity sensor which is only available on devices that have all 3 input sensors. It filters out user movement and gives the best approximation in what direction gravity/the ground is.