### PR TITLE
Fixed a bug where clamp_uv was clamping one pixel short, stretching the last pixels.

### DIFF
--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -382,7 +382,7 @@ void main() {
 	if (clip_rect_uv) {
 
 		vec2 half_texpixel = color_texpixel_size * 0.5;
-		uv = clamp(uv,src_rect.xy+half_texpixel,src_rect.xy+abs(src_rect.zw)-color_texpixel_size);
+		uv = clamp(uv,src_rect.xy,src_rect.xy+abs(src_rect.zw));
 	}
 
 #endif


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/11417