### PR TITLE
Project Settings Crash fix

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -1782,6 +1782,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	tab_container->add_child(translations);
 	//remap for properly select language in popup
 	translation_locales_idxs_remap = Vector<int>();
+	translation_locales_list_created = false;
 
 	{
 


### PR DESCRIPTION
fixes #12769
sets translation_locales_list_created bool to false in the constructor; it was uninitialized before.
