### PR TITLE
Fix signals disconnecting on changing target node type

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2411,7 +2411,9 @@ void Node::_replace_connections_target(Node *p_new_target) {
 
 		if (c.flags & CONNECT_PERSIST) {
 			c.source->disconnect(c.signal, this, c.method);
-			ERR_CONTINUE(!p_new_target->has_method(c.method));
+			bool valid = p_new_target->has_method(c.method) || p_new_target->get_script().is_null() || Ref<Script>(p_new_target->get_script())->has_method(c.method);
+			ERR_EXPLAIN("Attempt to connect signal \'" + c.source->get_class() + "." + c.signal + "\' to nonexistent method \'" + c.target->get_class() + "." + c.method + "\'");
+			ERR_CONTINUE(!valid);
 			c.source->connect(c.signal, p_new_target, c.method, c.binds, c.flags);
 		}
 	}


### PR DESCRIPTION
fixes #11673
I removed the ERR_CONTINUE that checked if the target has the signal method, it seemed unnecessary and was causing the problem.