### PR TITLE
Shader Editor context menu and line operations and style fix

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -850,7 +850,8 @@ void ScriptTextEditor::_edit_option(int p_op) {
 					if (line_id == 0 || next_id < 0)
 						return;
 
-					swap_lines(tx, line_id, next_id);
+					tx->swap_lines(line_id, next_id);
+					tx->cursor_set_line(next_id);
 				}
 				int from_line_up = from_line > 0 ? from_line - 1 : from_line;
 				int to_line_up = to_line > 0 ? to_line - 1 : to_line;
@@ -862,7 +863,8 @@ void ScriptTextEditor::_edit_option(int p_op) {
 				if (line_id == 0 || next_id < 0)
 					return;
 
-				swap_lines(tx, line_id, next_id);
+				tx->swap_lines(line_id, next_id);
+				tx->cursor_set_line(next_id);
 			}
 			tx->end_complex_operation();
 			tx->update();
@@ -889,7 +891,8 @@ void ScriptTextEditor::_edit_option(int p_op) {
 					if (line_id == tx->get_line_count() - 1 || next_id > tx->get_line_count())
 						return;
 
-					swap_lines(tx, line_id, next_id);
+					tx->swap_lines(line_id, next_id);
+					tx->cursor_set_line(next_id);
 				}
 				int from_line_down = from_line < tx->get_line_count() ? from_line + 1 : from_line;
 				int to_line_down = to_line < tx->get_line_count() ? to_line + 1 : to_line;
@@ -901,7 +904,8 @@ void ScriptTextEditor::_edit_option(int p_op) {
 				if (line_id == tx->get_line_count() - 1 || next_id > tx->get_line_count())
 					return;
 
-				swap_lines(tx, line_id, next_id);
+				tx->swap_lines(line_id, next_id);
+				tx->cursor_set_line(next_id);
 			}
 			tx->end_complex_operation();
 			tx->update();

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -33,6 +33,7 @@
 #include "editor/code_editor.h"
 #include "editor/editor_plugin.h"
 #include "scene/gui/menu_button.h"
+#include "scene/gui/panel_container.h"
 #include "scene/gui/tab_container.h"
 #include "scene/gui/text_edit.h"
 #include "scene/main/timer.h"
@@ -61,9 +62,9 @@ public:
 	ShaderTextEditor();
 };
 
-class ShaderEditor : public VBoxContainer {
+class ShaderEditor : public PanelContainer {
 
-	GDCLASS(ShaderEditor, VBoxContainer);
+	GDCLASS(ShaderEditor, PanelContainer);
 
 	enum {
 
@@ -73,6 +74,14 @@ class ShaderEditor : public VBoxContainer {
 		EDIT_COPY,
 		EDIT_PASTE,
 		EDIT_SELECT_ALL,
+		EDIT_MOVE_LINE_UP,
+		EDIT_MOVE_LINE_DOWN,
+		EDIT_INDENT_LEFT,
+		EDIT_INDENT_RIGHT,
+		EDIT_DELETE_LINE,
+		EDIT_CLONE_DOWN,
+		EDIT_TOGGLE_COMMENT,
+		EDIT_COMPLETE,
 		SEARCH_FIND,
 		SEARCH_FIND_NEXT,
 		SEARCH_FIND_PREV,
@@ -84,6 +93,7 @@ class ShaderEditor : public VBoxContainer {
 	MenuButton *edit_menu;
 	MenuButton *search_menu;
 	MenuButton *settings_menu;
+	PopupMenu *context_menu;
 	uint64_t idle;
 
 	GotoLineDialog *goto_line_dialog;
@@ -100,6 +110,8 @@ class ShaderEditor : public VBoxContainer {
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+	void _make_context_menu(bool p_selection);
+	void _text_edit_gui_input(const Ref<InputEvent> &ev);
 
 public:
 	void apply_shaders();
@@ -110,7 +122,7 @@ public:
 	virtual Size2 get_minimum_size() const { return Size2(0, 200); }
 	void save_external_data();
 
-	ShaderEditor();
+	ShaderEditor(EditorNode *p_node);
 };
 
 class ShaderEditorPlugin : public EditorPlugin {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3900,7 +3900,12 @@ void TextEdit::select(int p_from_line, int p_from_column, int p_to_line, int p_t
 
 	update();
 }
-
+void TextEdit::swap_lines(int line1, int line2) {
+	String tmp = get_line(line1);
+	String tmp2 = get_line(line2);
+	set_line(line2, tmp);
+	set_line(line1, tmp2);
+}
 bool TextEdit::is_selection_active() const {
 
 	return selection.active;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -463,6 +463,7 @@ public:
 	void select_all();
 	void select(int p_from_line, int p_from_column, int p_to_line, int p_to_column);
 	void deselect();
+	void swap_lines(int line1, int line2);
 
 	void set_search_text(const String &p_search_text);
 	void set_search_flags(uint32_t p_flags);


### PR DESCRIPTION
Improvements and fixes to Shader Editor
fixes #12702 and #12910
fixes multiple errors being highlighted, as mentioned in #11613
adds line edit operations to menu with shortcuts for `EDIT_MOVE_LINE_UP, EDIT_MOVE_LINE_DOWN, EDIT_INDENT_LEFT, EDIT_INDENT_RIGHT, EDIT_DELETE_LINE, EDIT_CLONE_DOWN, EDIT_TOGGLE_COMMENT, EDIT_COMPLETE.` These were copied from script_text_editor.cpp
context-sensitive context menu (eg. can only copy when text is selected).
fixes style of shader editor to be more similar to the script editor.
also moves swap_lines from script_text_editor.cpp to text_edit.cpp
![image](https://user-images.githubusercontent.com/10054226/32692513-28a98f48-c6e7-11e7-8483-8147f7983791.png)

