### PR TITLE
Added "is_readonly()" to TextEdit and made it a property

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -259,6 +259,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="is_readonly" qualifiers="const">
++			<return type="bool">
++			</return>
++			<description>
++				Return true if the text editor is in read-only mode (see [method set_readonly]).
++			</description>
++		</method>
 		<method name="is_selection_active" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -458,6 +465,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="readonly" type="bool" setter="set_readonly" getter="is_readonly">
+			If [code]true[/code] read-only mode is enabled. Existing text cannot be modified and new text cannot be added.
+		</member>
 		<member name="caret_blink" type="bool" setter="cursor_set_blink_enabled" getter="cursor_get_blink_enabled">
 		</member>
 		<member name="caret_blink_speed" type="float" setter="cursor_set_blink_speed" getter="cursor_get_blink_speed">

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3668,6 +3668,11 @@ void TextEdit::set_readonly(bool p_readonly) {
 	readonly = p_readonly;
 }
 
+bool TextEdit::is_readonly() const {
+
+	return readonly;
+}
+
 void TextEdit::set_wrap(bool p_wrap) {
 
 	wrap = p_wrap;
@@ -4914,6 +4919,8 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("cursor_is_block_mode"), &TextEdit::cursor_is_block_mode);
 
 	ClassDB::bind_method(D_METHOD("set_readonly", "enable"), &TextEdit::set_readonly);
+	ClassDB::bind_method(D_METHOD("is_readonly"), &TextEdit::is_readonly);
+
 	ClassDB::bind_method(D_METHOD("set_wrap", "enable"), &TextEdit::set_wrap);
 	ClassDB::bind_method(D_METHOD("set_max_chars", "amount"), &TextEdit::set_max_chars);
 	ClassDB::bind_method(D_METHOD("set_context_menu_enabled", "enable"), &TextEdit::set_context_menu_enabled);
@@ -4964,6 +4971,7 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("menu_option", "option"), &TextEdit::menu_option);
 	ClassDB::bind_method(D_METHOD("get_menu"), &TextEdit::get_menu);
 
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "readonly"), "set_readonly", "is_readonly");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "highlight_current_line"), "set_highlight_current_line", "is_highlight_current_line_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "syntax_highlighting"), "set_syntax_coloring", "is_syntax_coloring_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_line_numbers"), "set_show_line_numbers", "is_show_line_numbers_enabled");

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -448,6 +448,7 @@ public:
 	bool cursor_is_block_mode() const;
 
 	void set_readonly(bool p_readonly);
+	bool is_readonly() const;
 
 	void set_max_chars(int p_max_chars);
 	void set_wrap(bool p_wrap);


### PR DESCRIPTION
As far as I am aware, there is no way to check if a TextEdit node is in read-only mode. So I added a function for it.

My first experience with git, as well as my first contribution to the engine, I hope I didn't screw anything up.

**EDIT:** Made it a property. Partially addresses https://github.com/godotengine/godot/issues/10115