### PR TITLE
Fix shape collision when tile map's origin is centered

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -459,9 +459,9 @@ void TileMap::_update_dirty_quadrants() {
 					Transform2D xform;
 					xform.set_origin(offset.floor());
 
-					_fix_cell_transform(xform, c, center_ofs, s);
+					_fix_cell_transform(xform, c, shapes[i].shape_transform.get_origin() + center_ofs, s);
 
-					xform *= shapes[i].shape_transform;
+					//xform *= shapes[i].shape_transform;
 
 					if (debug_canvas_item.is_valid()) {
 						vs->canvas_item_add_set_transform(debug_canvas_item, xform);


### PR DESCRIPTION
The behaviour should be act like it was in 2.X, but improvement should
be made in order to the shape follow its parent when it is mirrored or
transposed.

**Note:** I intentionally comment the `xform` line in order to find a better behaviour for centered origin like Top-Left or Bottom-Left.

Closes #11876.