### PR TITLE
Script List Reorder

### DIFF
--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -173,6 +173,7 @@ class ScriptEditor : public PanelContainer {
 	MenuButton *edit_menu;
 	MenuButton *script_search_menu;
 	MenuButton *debug_menu;
+	PopupMenu *context_menu;
 	Timer *autosave_timer;
 	uint64_t idle;
 
@@ -307,6 +308,9 @@ class ScriptEditor : public PanelContainer {
 	void _script_split_dragged(float);
 
 	void _unhandled_input(const Ref<InputEvent> &p_event);
+
+	void _script_list_gui_input(const Ref<InputEvent> &ev);
+	void _make_script_list_context_menu();
 
 	void _help_search(String p_text);
 	void _help_index(String p_text);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -150,10 +150,11 @@ class ScriptEditor : public PanelContainer {
 		SEARCH_WEBSITE,
 		HELP_SEARCH_FIND,
 		HELP_SEARCH_FIND_NEXT,
-		WINDOW_MOVE_LEFT,
-		WINDOW_MOVE_RIGHT,
+		WINDOW_MOVE_UP,
+		WINDOW_MOVE_DOWN,
 		WINDOW_NEXT,
 		WINDOW_PREV,
+		WINDOW_SORT,
 		WINDOW_SELECT_BASE = 100
 	};
 
@@ -293,6 +294,7 @@ class ScriptEditor : public PanelContainer {
 	void _update_members_overview_visibility();
 	void _update_members_overview();
 	void _update_script_names();
+	bool _sort_list_on_update;
 
 	void _members_overview_selected(int p_idx);
 	void _script_selected(int p_idx);
@@ -306,6 +308,10 @@ class ScriptEditor : public PanelContainer {
 	void _tree_changed();
 
 	void _script_split_dragged(float);
+
+	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
+	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
+	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
 
 	void _unhandled_input(const Ref<InputEvent> &p_event);
 


### PR DESCRIPTION
Note: builds off of #12846
fixes #4775
Drag and drop to add scripts from filesystem
Drag and drop to reorder scripts and help docs
Sort script list through a context menu action
Shortcuts to move scripts around, I set the default to be Shift+Alt+Down and Shift+Alt+Up
![godot_script_list_drag](https://user-images.githubusercontent.com/10054226/32703761-8d9ac73c-c7c8-11e7-9a54-573f83089c54.gif)

