### PR TITLE
Fixing tilemap rotation for non top-left tiles.

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -459,9 +459,9 @@ void TileMap::_update_dirty_quadrants() {
 					Transform2D xform;
 					xform.set_origin(offset.floor());
 
-					_fix_cell_transform(xform, c, center_ofs, s);
+					Vector2 shape_ofs = tile_set->tile_get_shape_offset(c.id, i);
 
-					xform *= shapes[i].shape_transform;
+					_fix_cell_transform(xform, c, shape_ofs + center_ofs, s);
 
 					if (debug_canvas_item.is_valid()) {
 						vs->canvas_item_add_set_transform(debug_canvas_item, xform);

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -57,11 +57,9 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 		tile_set_region(id, p_value);
 	else if (what == "shape")
 		tile_set_shape(id, 0, p_value);
-	else if (what == "shape_offset") {
-		Transform2D xform = tile_get_shape_transform(id, 0);
-		xform.set_origin(p_value);
-		tile_set_shape_transform(id, 0, xform);
-	} else if (what == "shape_transform")
+	else if (what == "shape_offset")
+		tile_set_shape_offset(id, 0, p_value);
+	else if (what == "shape_transform")
 		tile_set_shape_transform(id, 0, p_value);
 	else if (what == "shape_one_way")
 		tile_set_shape_one_way(id, 0, p_value);
@@ -110,7 +108,7 @@ bool TileSet::_get(const StringName &p_name, Variant &r_ret) const {
 	else if (what == "shape")
 		r_ret = tile_get_shape(id, 0);
 	else if (what == "shape_offset")
-		r_ret = tile_get_shape_transform(id, 0).get_origin();
+		r_ret = tile_get_shape_offset(id, 0);
 	else if (what == "shape_transform")
 		r_ret = tile_get_shape_transform(id, 0);
 	else if (what == "shape_one_way")
@@ -311,6 +309,16 @@ Transform2D TileSet::tile_get_shape_transform(int p_id, int p_shape_id) const {
 		return tile_map[p_id].shapes_data[p_shape_id].shape_transform;
 
 	return Transform2D();
+}
+
+void TileSet::tile_set_shape_offset(int p_id, int p_shape_id, const Vector2 &p_offset) {
+	Transform2D transform = tile_get_shape_transform(p_id, p_shape_id);
+	transform.set_origin(p_offset);
+	tile_set_shape_transform(p_id, p_shape_id, transform);
+}
+
+Vector2 TileSet::tile_get_shape_offset(int p_id, int p_shape_id) const {
+	return tile_get_shape_transform(p_id, p_shape_id).get_origin();
 }
 
 void TileSet::tile_set_shape_one_way(int p_id, int p_shape_id, const bool p_one_way) {

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -108,6 +108,9 @@ public:
 	void tile_set_shape_transform(int p_id, int p_shape_id, const Transform2D &p_offset);
 	Transform2D tile_get_shape_transform(int p_id, int p_shape_id) const;
 
+	void tile_set_shape_offset(int p_id, int p_shape_id, const Vector2 &p_offset);
+	Vector2 tile_get_shape_offset(int p_id, int p_shape_id) const;
+
 	void tile_set_shape_one_way(int p_id, int p_shape_id, bool p_one_way);
 	bool tile_get_shape_one_way(int p_id, int p_shape_id) const;
 


### PR DESCRIPTION
Fixes #11876. It still seems wrong, but now it behaves the same as in 2.x.