### PR TITLE
Change AnimationPlayer looping logic

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -545,7 +545,14 @@ void AnimationPlayer::_animation_process_data(PlaybackData &cd, float p_delta, f
 
 	} else {
 
-		next_pos = Math::fposmod(next_pos, len);
+		float looped_next_pos = Math::fposmod(next_pos, len);
+		if (looped_next_pos == 0 && next_pos != 0) {
+			// Loop multiples of the length to it, rather than 0
+			// so state at time=length is previewable in the editor
+			next_pos = len;
+		} else {
+			next_pos = looped_next_pos;
+		}
 	}
 
 	cd.pos = next_pos;


### PR DESCRIPTION
So now it can seek to the actual values at time=length when instructed to seek to time=N*length.

That is, formerly in the editor you had no way of seeing the actual state at time=length other than temporarily disabling looping. Now you can preview both endpoints.

As a side effect, the values at anim time 0 will only be applied when actually seeking to 0, instead of at every time=N*length, as formerly. No issue.

**Not meant to be back-ported to 2.1. I don't remember the behavior there, but this is a potentially breaking change.**