### PR TITLE
Fit stylebox on ItemList

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -754,7 +754,7 @@ void ItemList::_notification(int p_what) {
 
 		int width = size.width - bg->get_minimum_size().width;
 		if (scroll_bar->is_visible()) {
-			width -= mw + bg->get_margin(MARGIN_RIGHT);
+			width -= mw;
 		}
 
 		draw_style_box(bg, Rect2(Point2(), size));
@@ -1107,7 +1107,7 @@ void ItemList::_notification(int p_what) {
 		}
 
 		for (int i = 0; i < separators.size(); i++) {
-			draw_line(Vector2(bg->get_margin(MARGIN_LEFT), base_ofs.y + separators[i]), Vector2(size.width - bg->get_margin(MARGIN_RIGHT), base_ofs.y + separators[i]), guide_color);
+			draw_line(Vector2(bg->get_margin(MARGIN_LEFT), base_ofs.y + separators[i]), Vector2(width, base_ofs.y + separators[i]), guide_color);
 		}
 	}
 }


### PR DESCRIPTION
Fix #12901
and fit separation line also

| Before  | After  |
|---|---|
| ![selected_theme](https://user-images.githubusercontent.com/8281454/32728000-0795a120-c8c2-11e7-9d66-ef796c4e1cd1.gif) | ![selected_theme_fix](https://user-images.githubusercontent.com/8281454/32727892-a5538a0e-c8c1-11e7-9161-20e591a6f296.gif)  |
