### PR TITLE
Refresh import options when changing importer

### DIFF
--- a/editor/import_dock.h
+++ b/editor/import_dock.h
@@ -55,6 +55,7 @@ class ImportDock : public VBoxContainer {
 
 	void _preset_selected(int p_idx);
 	void _importer_selected(int i_idx);
+	void _update_options(const Ref<ConfigFile> &p_config = Ref<ConfigFile>());
 
 	void _reimport();
 


### PR DESCRIPTION
Update the options as soon as the selected importer is changed.

Related to #9286 and #12822.