### PR TITLE
Fixed signal connection dialog ignoring indentation settings when creating a function

### DIFF
--- a/modules/gdscript/gd_editor.cpp
+++ b/modules/gdscript/gd_editor.cpp
@@ -365,7 +365,7 @@ String GDScriptLanguage::make_function(const String &p_class, const String &p_na
 		}
 		s += " ";
 	}
-	s += "):\n\tpass # replace with function body\n";
+	s += "):\n" + _get_indentation() + "pass # replace with function body\n";
 
 	return s;
 }


### PR DESCRIPTION
Fixes #12872