### PR TITLE
Remove debug msg from Script Editor

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2115,8 +2115,6 @@ void ScriptEditor::_unhandled_input(const Ref<InputEvent> &p_event) {
 	if (ED_IS_SHORTCUT("script_editor/window_move_down", p_event)) {
 		_menu_option(WINDOW_MOVE_DOWN);
 	}
-	ERR_EXPLAIN("uh: " + p_event->as_text());
-	ERR_FAIL_COND(true);
 }
 
 void ScriptEditor::_script_list_gui_input(const Ref<InputEvent> &ev) {


### PR DESCRIPTION
Removes error message that was being used to debug script editor list shortcuts from #12869.