### PR TITLE
Added RegEx.search_all() for multiple matches

### DIFF
--- a/doc/classes/RegEx.xml
+++ b/doc/classes/RegEx.xml
@@ -1,33 +1,40 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RegEx" inherits="Reference" category="Core" version="3.0.alpha.custom_build">
 	<brief_description>
-		Simple regular expression matcher.
+		Class for searching text for patterns using regular expressions.
 	</brief_description>
 	<description>
-		Class for finding text patterns in a string using regular expressions. It can not perform replacements. Regular expressions are a way to define patterns of text to be searched. Details on writing patterns are too long to explain here but the Internet is full of tutorials and detailed explanations.
-		Once created, the RegEx object needs to be compiled with the search pattern before it can be used. The search pattern must be escaped first for gdscript before it is escaped for the expression. For example:
-		[code]var exp = RegEx.new()[/code]
-		[code]exp.compile("\\d+")[/code]
-		would be read by RegEx as [code]\d+[/code]
-		Similarly:
-		[code]exp.compile("\"(?:\\\\.|[^\"])*\"")[/code]
-		would be read as [code]"(?:\\.|[^"])*"[/code]
-		Currently supported features:
-		* Capturing [code]()[/code] and non-capturing [code](?:)[/code] groups
-		* Named capturing groups [code](?P&lt;name&gt;)[/code]
-		* Any character [code].[/code]
-		* Shorthand character classes [code]\w \W \s \S \d \D[/code]
-		* User-defined character classes such as [code][A-Za-z][/code]
-		* Simple quantifiers [code]?[/code], [code]*[/code] and [code]+[/code]
-		* Range quantifiers [code]{x,y}[/code]
-		* Lazy (non-greedy) quantifiers [code]*?[/code]
-		* Beginning [code]^[/code] and end [code]$[/code] anchors
-		* Alternation [code]|[/code]
-		* Backreferences [code]\1[/code], [code]\g{1}[/code], and [code]\g&lt;name&gt;[/code]
-		* POSIX character classes [code][[:alnum:]][/code]
-		* Lookahead [code](?=)[/code], [code](?!)[/code] and lookbehind [code](?&lt;=)[/code], [code](?&lt;!)[/code]
-		* ASCII [code]\xFF[/code] and Unicode [code]\uFFFF[/code] code points (in a style similar to Python)
-		* Word boundaries [code]\b[/code], [code]\B[/code]
+		Regular Expression (or regex) is a compact programming language that can be used to recognise strings that follow a specific pattern, such as URLs, email addresses, complete sentences, etc. For instance, a regex of [code]ab[0-9][/code] would find any string that is [code]ab[/code] followed by any number from [code]0[/code] to [code]9[/code]. For a more in-depth look, you can easily find various tutorials and detailed explainations on the Internet.
+		To begin, the RegEx object needs to be compiled with the search pattern using [method compile] before it can be used.
+		[codeblock]
+		var regex = RegEx.new()
+		regex.compile("\\w-(\\d+)")
+		[/codeblock]
+		The search pattern must be escaped first for gdscript before it is escaped for the expression. For example, [code]compile("\\d+")[/code] would be read by RegEx as [code]\d+[/code]. Similarly, [code]compile("\"(?:\\\\.|[^\"])*\"")[/code] would be read as [code]"(?:\\.|[^"])*"[/code]
+		Using [method search] you can find the pattern within the given text. If a pattern is found, [RegExMatch] is returned and you can retrieve details of the results using fuctions such as [method RegExMatch.get_string] and [method RegExMatch.get_start].
+		[codeblock]
+		var regex = RegEx.new()
+		regex.compile("\\w-(\\d+)")
+		var result = regex.search("abc n-0123")
+		if result:
+		    print(result.get_string()) # Would print n-0123
+		[/codeblock]
+		The results of capturing groups [code]()[/code] can be retrieved by passing the group number to the various functions in [RegExMatch]. Group 0 is the default and would always refer to the entire pattern. In the above example, calling [code]result.get_string(1)[/code] would give you [code]0123[/code].
+		This version of RegEx also supports named capturing groups, and the names can be used to retrieve the results. If two or more groups have the same name, the name would only refer to the first one with a match.
+		[codeblock]
+		var regex = RegEx.new()
+		regex.compile("d(?&lt;digit&gt;[0-9]+)|x(?&lt;digit&gt;[0-9a-f]+)")
+		var result = regex.search("the number is x2f")
+		if result:
+		    print(result.get_string("digit")) # Would print 2f
+		[/codeblock]
+		If you need to process multiple results, [method search_all] generates a list of all non-overlapping results. This can be combined with a for-loop for convenience.
+		[codeblock]
+		for result in regex.search_all("d01, d03, d0c, x3f and x42"):
+		    print(result.get_string("digit"))
+		# Would print 01 03 3f 42
+		# Note that d0c would not match
+		[/codeblock]
 	</description>
 	<tutorials>
 	</tutorials>
@@ -47,28 +54,28 @@
 			<argument index="0" name="pattern" type="String">
 			</argument>
 			<description>
-				Compiles and assign the search pattern to use.
+				Compiles and assign the search pattern to use. Returns OK if the compilation is successful. If an error is encountered the details are printed to STDOUT and FAILED is returned.
 			</description>
 		</method>
 		<method name="get_group_count" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Returns the number of numeric capturing groups.
+				Returns the number of capturing groups in compiled pattern.
 			</description>
 		</method>
 		<method name="get_names" qualifiers="const">
 			<return type="Array">
 			</return>
 			<description>
-				Returns an array of names of named capturing groups.
+				Returns an array of names of named capturing groups in the compiled pattern. They are ordered by appearance.
 			</description>
 		</method>
 		<method name="get_pattern" qualifiers="const">
 			<return type="String">
 			</return>
 			<description>
-				Returns the search pattern used to compile the code.
+				Returns the original search pattern that was compiled.
 			</description>
 		</method>
 		<method name="is_valid" qualifiers="const">
@@ -89,6 +96,19 @@
 			</argument>
 			<description>
 				Searches the text for the compiled pattern. Returns a [RegExMatch] container of the first matching result if found, otherwise null. The region to search within can be specified without modifying where the start and end anchor would be.
+			</description>
+		</method>
+		<method name="search_all" qualifiers="const">
+			<return type="Array">
+			</return>
+			<argument index="0" name="subject" type="String">
+			</argument>
+			<argument index="1" name="offset" type="int" default="0">
+			</argument>
+			<argument index="2" name="end" type="int" default="-1">
+			</argument>
+			<description>
+				Searches the text for the compiled pattern. Returns an array of [RegExMatch] containers for each non-overlapping result. If no results were found an empty array is returned instead. The region to search within can be specified without modifying where the start and end anchor would be.
 			</description>
 		</method>
 		<method name="sub" qualifiers="const">

--- a/doc/classes/RegExMatch.xml
+++ b/doc/classes/RegExMatch.xml
@@ -4,7 +4,7 @@
 		Contains the results of a regex search.
 	</brief_description>
 	<description>
-		Contains the results of a regex search. [method RegEx.search] returns an instance of [code]RegExMatch[/code] if it finds the search pattern in the [source] string.
+		Contains the results of a single regex match returned by [method RegEx.search] and [method.RegEx.search_all]. It can be used to find the position and range of the match and its capturing groups, and it can extract its sub-string for you.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -17,21 +17,22 @@
 			<argument index="0" name="name" type="Variant" default="0">
 			</argument>
 			<description>
-				Returns the end position of the match in the [source] string. An integer can be specified for numeric groups or a string for named groups. Returns -1 if that group wasn't found or doesn't exist. Defaults to 0 (whole pattern).
+				Returns the end position of the match within the source string. The end position of capturing groups can be retrieved by providing its group number as an integer or its string name (if it's a named group). The default value of 0 refers to the whole pattern.
+				Returns -1 if the group did not match or doesn't exist.
 			</description>
 		</method>
 		<method name="get_group_count" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Returns the number of numeric capturing groups.
+				Returns the number of capturing groups.
 			</description>
 		</method>
 		<method name="get_names" qualifiers="const">
 			<return type="Dictionary">
 			</return>
 			<description>
-				Returns an array of names of named capturing groups.
+				Returns a dictionary of named groups and its corresponding group number. Only groups with that were matched are included. If multiple groups have the same name, that name would refer to the first matching one.
 			</description>
 		</method>
 		<method name="get_start" qualifiers="const">
@@ -40,7 +41,8 @@
 			<argument index="0" name="name" type="Variant" default="0">
 			</argument>
 			<description>
-				Returns the starting position of the match in the [source] string. An integer can be specified for numeric groups or a string for named groups. Returns -1 if that group wasn't found or doesn't exist. Defaults to 0 (whole pattern).
+				Returns the starting position of the match within the source string. The starting position of capturing groups can be retrieved by providing its group number as an integer or its string name (if it's a named group). The default value of 0 refers to the whole pattern.
+				Returns -1 if the group did not match or doesn't exist.
 			</description>
 		</method>
 		<method name="get_string" qualifiers="const">
@@ -49,21 +51,22 @@
 			<argument index="0" name="name" type="Variant" default="0">
 			</argument>
 			<description>
-				Returns the result of the match in the [source] string. An integer can be specified for numeric groups or a string for named groups. Returns -1 if that group wasn't found or doesn't exist. Defaults to 0 (whole pattern).
+				Returns the substring of the match from the source string. Capturing groups can be retrieved by providing its group number as an integer or its string name (if it's a named group). The default value of 0 refers to the whole pattern.
+				Returns an empty string if the group did not match or doesn't exist.
 			</description>
 		</method>
 		<method name="get_strings" qualifiers="const">
 			<return type="Array">
 			</return>
 			<description>
-				Returns an [Array] of the matches in the [source] string.
+				Returns an [Array] of the match and its capturing groups.
 			</description>
 		</method>
 		<method name="get_subject" qualifiers="const">
 			<return type="String">
 			</return>
 			<description>
-				Returns the [source] string used with the search pattern to find this matching result.
+				Returns the source string used with the search pattern to find this matching result.
 			</description>
 		</method>
 	</methods>

--- a/modules/regex/regex.cpp
+++ b/modules/regex/regex.cpp
@@ -324,6 +324,21 @@ Ref<RegExMatch> RegEx::search(const String &p_subject, int p_offset, int p_end) 
 	return result;
 }
 
+Array RegEx::search_all(const String &p_subject, int p_offset, int p_end) const {
+
+	int last_end = -1;
+	Array result;
+	Ref<RegExMatch> match = search(p_subject, p_offset, p_end);
+	while (match.is_valid()) {
+		if (last_end == match->get_end(0))
+			break;
+		result.push_back(match);
+		last_end = match->get_end(0);
+		match = search(p_subject, match->get_end(0), p_end);
+	}
+	return result;
+}
+
 String RegEx::sub(const String &p_subject, const String &p_replacement, bool p_all, int p_offset, int p_end) const {
 
 	ERR_FAIL_COND_V(!is_valid(), String());
@@ -489,6 +504,7 @@ void RegEx::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear"), &RegEx::clear);
 	ClassDB::bind_method(D_METHOD("compile", "pattern"), &RegEx::compile);
 	ClassDB::bind_method(D_METHOD("search", "subject", "offset", "end"), &RegEx::search, DEFVAL(0), DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("search_all", "subject", "offset", "end"), &RegEx::search_all, DEFVAL(0), DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("sub", "subject", "replacement", "all", "offset", "end"), &RegEx::sub, DEFVAL(false), DEFVAL(0), DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("is_valid"), &RegEx::is_valid);
 	ClassDB::bind_method(D_METHOD("get_pattern"), &RegEx::get_pattern);

--- a/modules/regex/regex.h
+++ b/modules/regex/regex.h
@@ -88,6 +88,7 @@ public:
 	void _init(const String &p_pattern = "");
 
 	Ref<RegExMatch> search(const String &p_subject, int p_offset = 0, int p_end = -1) const;
+	Array search_all(const String &p_subject, int p_offset = 0, int p_end = -1) const;
 	String sub(const String &p_subject, const String &p_replacement, bool p_all = false, int p_offset = 0, int p_end = -1) const;
 
 	bool is_valid() const;


### PR DESCRIPTION
And updated the docs

Lets you do fancy stuff like:

```
var regex = RegEx.new()
regex.compile("d(?<digit>[0-9]+)|x(?<digit>[0-9a-f]+)")
for result in regex.search_all("d01, d03, d0c, x3f and x42"):
	print(result.get_string("digit"))
	# Would print 01 03 3f 42
	# Note that d0c would not match
```