### PR TITLE
Singleton management changes

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2592,6 +2592,16 @@ bool _Engine::is_in_physics_frame() const {
 	return Engine::get_singleton()->is_in_physics_frame();
 }
 
+bool _Engine::has_singleton(const String &p_name) const {
+
+	return Engine::get_singleton()->has_singleton(p_name);
+}
+
+Object *_Engine::get_singleton_object(const String &p_name) const {
+
+	return Engine::get_singleton()->get_singleton_object(p_name);
+}
+
 void _Engine::set_editor_hint(bool p_enabled) {
 
 	Engine::get_singleton()->set_editor_hint(p_enabled);
@@ -2620,6 +2630,9 @@ void _Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_version_info"), &_Engine::get_version_info);
 
 	ClassDB::bind_method(D_METHOD("is_in_physics_frame"), &_Engine::is_in_physics_frame);
+
+	ClassDB::bind_method(D_METHOD("has_singleton", "name"), &_Engine::has_singleton);
+	ClassDB::bind_method(D_METHOD("get_singleton", "name"), &_Engine::get_singleton_object);
 
 	ClassDB::bind_method(D_METHOD("set_editor_hint", "enabled"), &_Engine::set_editor_hint);
 	ClassDB::bind_method(D_METHOD("is_editor_hint"), &_Engine::is_editor_hint);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -670,6 +670,9 @@ public:
 
 	bool is_in_physics_frame() const;
 
+	bool has_singleton(const String &p_name) const;
+	Object *get_singleton_object(const String &p_name) const;
+
 	void set_editor_hint(bool p_enabled);
 	bool is_editor_hint() const;
 

--- a/core/engine.cpp
+++ b/core/engine.cpp
@@ -109,15 +109,14 @@ void Engine::add_singleton(const Singleton &p_singleton) {
 Object *Engine::get_singleton_object(const String &p_name) const {
 
 	const Map<StringName, Object *>::Element *E = singleton_ptrs.find(p_name);
-	if (!E)
-		return NULL;
-	else
-		return E->get();
+	ERR_EXPLAIN("Failed to retrieve non-existent singleton '" + p_name + "'");
+	ERR_FAIL_COND_V(!E, NULL);
+	return E->get();
 };
 
 bool Engine::has_singleton(const String &p_name) const {
 
-	return get_singleton_object(p_name) != NULL;
+	return singleton_ptrs.has(p_name);
 };
 
 void Engine::get_singletons(List<Singleton> *p_singletons) {

--- a/core/engine.cpp
+++ b/core/engine.cpp
@@ -100,6 +100,32 @@ Dictionary Engine::get_version_info() const {
 	return dict;
 }
 
+void Engine::add_singleton(const Singleton &p_singleton) {
+
+	singletons.push_back(p_singleton);
+	singleton_ptrs[p_singleton.name] = p_singleton.ptr;
+}
+
+Object *Engine::get_singleton_object(const String &p_name) const {
+
+	const Map<StringName, Object *>::Element *E = singleton_ptrs.find(p_name);
+	if (!E)
+		return NULL;
+	else
+		return E->get();
+};
+
+bool Engine::has_singleton(const String &p_name) const {
+
+	return get_singleton_object(p_name) != NULL;
+};
+
+void Engine::get_singletons(List<Singleton> *p_singletons) {
+
+	for (List<Singleton>::Element *E = singletons.front(); E; E = E->next())
+		p_singletons->push_back(E->get());
+}
+
 Engine *Engine::singleton = NULL;
 
 Engine *Engine::get_singleton() {

--- a/core/engine.h
+++ b/core/engine.h
@@ -37,6 +37,17 @@
 
 class Engine {
 
+public:
+	struct Singleton {
+		StringName name;
+		Object *ptr;
+		Singleton(const StringName &p_name = StringName(), Object *p_ptr = NULL)
+			: name(p_name),
+			  ptr(p_ptr) {
+		}
+	};
+
+private:
 	friend class Main;
 
 	uint64_t frames_drawn;
@@ -53,6 +64,9 @@ class Engine {
 
 	uint64_t _idle_frames;
 	bool _in_physics;
+
+	List<Singleton> singletons;
+	Map<StringName, Object *> singleton_ptrs;
 
 	bool editor_hint;
 
@@ -82,6 +96,11 @@ public:
 
 	void set_frame_delay(uint32_t p_msec);
 	uint32_t get_frame_delay() const;
+
+	void add_singleton(const Singleton &p_singleton);
+	void get_singletons(List<Singleton> *p_singletons);
+	bool has_singleton(const String &p_name) const;
+	Object *get_singleton_object(const String &p_name) const;
 
 	_FORCE_INLINE_ bool get_use_pixel_snap() const { return _pixel_snap; }
 

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -776,32 +776,6 @@ Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default) {
 	return ret;
 }
 
-void ProjectSettings::add_singleton(const Singleton &p_singleton) {
-
-	singletons.push_back(p_singleton);
-	singleton_ptrs[p_singleton.name] = p_singleton.ptr;
-}
-
-Object *ProjectSettings::get_singleton_object(const String &p_name) const {
-
-	const Map<StringName, Object *>::Element *E = singleton_ptrs.find(p_name);
-	if (!E)
-		return NULL;
-	else
-		return E->get();
-};
-
-bool ProjectSettings::has_singleton(const String &p_name) const {
-
-	return get_singleton_object(p_name) != NULL;
-};
-
-void ProjectSettings::get_singletons(List<Singleton> *p_singletons) {
-
-	for (List<Singleton>::Element *E = singletons.front(); E; E = E->next())
-		p_singletons->push_back(E->get());
-}
-
 Vector<String> ProjectSettings::get_optimizer_presets() const {
 
 	List<PropertyInfo> pi;
@@ -893,8 +867,6 @@ void ProjectSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("localize_path", "path"), &ProjectSettings::localize_path);
 	ClassDB::bind_method(D_METHOD("globalize_path", "path"), &ProjectSettings::globalize_path);
 	ClassDB::bind_method(D_METHOD("save"), &ProjectSettings::save);
-	ClassDB::bind_method(D_METHOD("has_singleton", "name"), &ProjectSettings::has_singleton);
-	ClassDB::bind_method(D_METHOD("get_singleton", "name"), &ProjectSettings::get_singleton_object);
 	ClassDB::bind_method(D_METHOD("load_resource_pack", "pack"), &ProjectSettings::_load_resource_pack);
 	ClassDB::bind_method(D_METHOD("property_can_revert", "name"), &ProjectSettings::property_can_revert);
 	ClassDB::bind_method(D_METHOD("property_get_revert", "name"), &ProjectSettings::property_get_revert);

--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -45,14 +45,6 @@ class ProjectSettings : public Object {
 public:
 	typedef Map<String, Variant> CustomMap;
 
-	struct Singleton {
-		StringName name;
-		Object *ptr;
-		Singleton(const StringName &p_name = StringName(), Object *p_ptr = NULL)
-			: name(p_name),
-			  ptr(p_ptr) {
-		}
-	};
 	enum {
 		//properties that are not for built in values begin from this value, so builtin ones are displayed first
 		NO_BUILTIN_ORDER_BASE = 1 << 16
@@ -106,9 +98,6 @@ protected:
 	Error _save_settings_text(const String &p_file, const Map<String, List<String> > &props, const CustomMap &p_custom = CustomMap(), const String &p_custom_features = String());
 	Error _save_settings_binary(const String &p_file, const Map<String, List<String> > &props, const CustomMap &p_custom = CustomMap(), const String &p_custom_features = String());
 
-	List<Singleton> singletons;
-	Map<StringName, Object *> singleton_ptrs;
-
 	Error _save_custom_bnd(const String &p_file);
 
 	bool _load_resource_pack(const String &p_pack);
@@ -145,17 +134,11 @@ public:
 	Error save();
 	void set_custom_property_info(const String &p_prop, const PropertyInfo &p_info);
 
-	void add_singleton(const Singleton &p_singleton);
-	void get_singletons(List<Singleton> *p_singletons);
-
-	bool has_singleton(const String &p_name) const;
-
 	Vector<String> get_optimizer_presets() const;
 
 	List<String> get_input_presets() const { return input_presets; }
 
 	void set_disable_feature_overrides(bool p_disable);
-	Object *get_singleton_object(const String &p_name) const;
 
 	void register_global_defaults();
 

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -34,6 +34,7 @@
 #include "compressed_translation.h"
 #include "core/io/xml_parser.h"
 #include "core_string_names.h"
+#include "engine.h"
 #include "func_ref.h"
 #include "geometry.h"
 #include "input_map.h"
@@ -203,19 +204,19 @@ void register_core_singletons() {
 	ClassDB::register_class<InputMap>();
 	ClassDB::register_class<_JSON>();
 
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("ProjectSettings", ProjectSettings::get_singleton()));
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("IP", IP::get_singleton()));
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("Geometry", _Geometry::get_singleton()));
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("ResourceLoader", _ResourceLoader::get_singleton()));
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("ResourceSaver", _ResourceSaver::get_singleton()));
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("OS", _OS::get_singleton()));
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("Engine", _Engine::get_singleton()));
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("ClassDB", _classdb));
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("Marshalls", _Marshalls::get_singleton()));
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("TranslationServer", TranslationServer::get_singleton()));
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("Input", Input::get_singleton()));
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("InputMap", InputMap::get_singleton()));
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("JSON", _JSON::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("ProjectSettings", ProjectSettings::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("IP", IP::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("Geometry", _Geometry::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("ResourceLoader", _ResourceLoader::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("ResourceSaver", _ResourceSaver::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("OS", _OS::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("Engine", _Engine::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("ClassDB", _classdb));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("Marshalls", _Marshalls::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("TranslationServer", TranslationServer::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("Input", Input::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("InputMap", InputMap::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("JSON", _JSON::get_singleton()));
 }
 
 void unregister_core_types() {

--- a/core/script_debugger_remote.cpp
+++ b/core/script_debugger_remote.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 #include "script_debugger_remote.h"
 
+#include "engine.h"
 #include "io/ip.h"
 #include "io/marshalls.h"
 #include "os/input.h"
@@ -939,7 +940,7 @@ ScriptDebuggerRemote::ScriptDebuggerRemote()
 	  tcp_client(StreamPeerTCP::create_ref()),
 	  packet_peer_stream(Ref<PacketPeerStream>(memnew(PacketPeerStream))),
 	  last_perf_time(0),
-	  performance(ProjectSettings::get_singleton()->get_singleton_object("Performance")),
+	  performance(Engine::get_singleton()->get_singleton_object("Performance")),
 	  requested_quit(false),
 	  mutex(Mutex::create()),
 	  max_cps(GLOBAL_GET("network/limits/debugger_stdout/max_chars_per_second")),

--- a/editor/doc/doc_data.cpp
+++ b/editor/doc/doc_data.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 #include "doc_data.h"
 
+#include "engine.h"
 #include "global_constants.h"
 #include "io/compression.h"
 #include "io/marshalls.h"
@@ -543,14 +544,14 @@ void DocData::generate(bool p_basic_types) {
 			c.constants.push_back(cd);
 		}
 
-		List<ProjectSettings::Singleton> singletons;
-		ProjectSettings::get_singleton()->get_singletons(&singletons);
+		List<Engine::Singleton> singletons;
+		Engine::get_singleton()->get_singletons(&singletons);
 
 		//servers (this is kind of hackish)
-		for (List<ProjectSettings::Singleton>::Element *E = singletons.front(); E; E = E->next()) {
+		for (List<Engine::Singleton>::Element *E = singletons.front(); E; E = E->next()) {
 
 			PropertyDoc pd;
-			ProjectSettings::Singleton &s = E->get();
+			Engine::Singleton &s = E->get();
 			pd.name = s.name;
 			pd.type = s.ptr->get_class();
 			while (String(ClassDB::get_parent_class(pd.type)) != "Object")

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -284,7 +284,6 @@ private:
 			}
 
 			ProjectSettings *current = memnew(ProjectSettings);
-			current->add_singleton(ProjectSettings::Singleton("Current"));
 
 			if (current->setup(dir, "")) {
 				set_message(TTR("Couldn't get project.godot in project path."), MESSAGE_ERROR);
@@ -503,7 +502,6 @@ public:
 			name_container->show();
 
 			ProjectSettings *current = memnew(ProjectSettings);
-			current->add_singleton(ProjectSettings::Singleton("Current"));
 
 			if (current->setup(project_path->get_text(), "")) {
 				set_message(TTR("Couldn't get project.godot in the project path."), MESSAGE_ERROR);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -294,7 +294,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	translation_server = memnew(TranslationServer);
 	performance = memnew(Performance);
 	ClassDB::register_class<Performance>();
-	globals->add_singleton(ProjectSettings::Singleton("Performance", performance));
+	engine->add_singleton(Engine::Singleton("Performance", performance));
 
 	GLOBAL_DEF("debug/settings/crash_handler/message", String("Please include this when reporting the bug on https://github.com/godotengine/godot/issues"));
 

--- a/modules/gdnative/gdnative/gdnative.cpp
+++ b/modules/gdnative/gdnative/gdnative.cpp
@@ -30,10 +30,10 @@
 #include "gdnative/gdnative.h"
 
 #include "class_db.h"
+#include "engine.h"
 #include "error_macros.h"
 #include "global_constants.h"
 #include "os/os.h"
-#include "project_settings.h"
 #include "variant.h"
 
 #ifdef __cplusplus
@@ -88,7 +88,7 @@ void GDAPI godot_object_destroy(godot_object *p_o) {
 // Singleton API
 
 godot_object GDAPI *godot_global_get_singleton(char *p_name) {
-	return (godot_object *)ProjectSettings::get_singleton()->get_singleton_object(String(p_name));
+	return (godot_object *)Engine::get_singleton()->get_singleton_object(String(p_name));
 } // result shouldn't be freed
 
 void GDAPI *godot_get_stack_bottom() {

--- a/modules/gdnative/nativescript/api_generator.cpp
+++ b/modules/gdnative/nativescript/api_generator.cpp
@@ -32,9 +32,9 @@
 #ifdef TOOLS_ENABLED
 
 #include "core/class_db.h"
+#include "core/engine.h"
 #include "core/global_constants.h"
 #include "core/pair.h"
-#include "core/project_settings.h"
 #include "os/file_access.h"
 
 // helper stuff
@@ -177,7 +177,7 @@ List<ClassAPI> generate_c_api_classes() {
 			if (name.begins_with("_")) {
 				name.remove(0);
 			}
-			class_api.is_singleton = ProjectSettings::get_singleton()->has_singleton(name);
+			class_api.is_singleton = Engine::get_singleton()->has_singleton(name);
 		}
 		class_api.is_instanciable = !class_api.is_singleton && ClassDB::can_instance(class_name);
 

--- a/modules/gdscript/gd_script.cpp
+++ b/modules/gdscript/gd_script.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 #include "gd_script.h"
 
+#include "engine.h"
 #include "gd_compiler.h"
 #include "global_constants.h"
 #include "io/file_access_encrypted.h"
@@ -1347,9 +1348,9 @@ void GDScriptLanguage::init() {
 
 	//populate singletons
 
-	List<ProjectSettings::Singleton> singletons;
-	ProjectSettings::get_singleton()->get_singletons(&singletons);
-	for (List<ProjectSettings::Singleton>::Element *E = singletons.front(); E; E = E->next()) {
+	List<Engine::Singleton> singletons;
+	Engine::get_singleton()->get_singletons(&singletons);
+	for (List<Engine::Singleton>::Element *E = singletons.front(); E; E = E->next()) {
 
 		_add_global(E->get().name, E->get().ptr);
 	}

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -31,12 +31,12 @@
 
 #ifdef DEBUG_METHODS_ENABLED
 
+#include "engine.h"
 #include "global_constants.h"
 #include "io/compression.h"
 #include "os/dir_access.h"
 #include "os/file_access.h"
 #include "os/os.h"
-#include "project_settings.h"
 #include "ucaps.h"
 
 #include "../glue/cs_compressed.gen.h"
@@ -1169,7 +1169,7 @@ Error BindingsGenerator::generate_glue(const String &p_output_dir) {
 
 			output.push_back("Object* ");
 			output.push_back(singleton_icall_name);
-			output.push_back("() " OPEN_BLOCK "\treturn ProjectSettings::get_singleton()->get_singleton_object(\"");
+			output.push_back("() " OPEN_BLOCK "\treturn Engine::get_singleton()->get_singleton_object(\"");
 			output.push_back(itype.proxy_name);
 			output.push_back("\");\n" CLOSE_BLOCK "\n");
 		}
@@ -1505,7 +1505,7 @@ void BindingsGenerator::_populate_object_type_interfaces() {
 		TypeInterface itype = TypeInterface::create_object_type(type_cname, api_type);
 
 		itype.base_name = ClassDB::get_parent_class(type_cname);
-		itype.is_singleton = ProjectSettings::get_singleton()->has_singleton(itype.proxy_name);
+		itype.is_singleton = Engine::get_singleton()->has_singleton(itype.proxy_name);
 		itype.is_instantiable = ClassDB::can_instance(type_cname) && !itype.is_singleton;
 		itype.is_reference = ClassDB::is_parent_class(type_cname, refclass_name);
 		itype.memory_own = itype.is_reference;

--- a/modules/mono/glue/glue_header.h
+++ b/modules/mono/glue/glue_header.h
@@ -35,10 +35,10 @@
 
 #include "bind/core_bind.h"
 #include "class_db.h"
+#include "engine.h"
 #include "io/marshalls.h"
 #include "object.h"
 #include "os/os.h"
-#include "project_settings.h"
 #include "reference.h"
 #include "variant_parser.h"
 

--- a/modules/mono/register_types.cpp
+++ b/modules/mono/register_types.cpp
@@ -29,7 +29,7 @@
 /*************************************************************************/
 #include "register_types.h"
 
-#include "project_settings.h"
+#include "engine.h"
 
 #include "csharp_script.h"
 
@@ -45,7 +45,7 @@ void register_mono_types() {
 	_godotsharp = memnew(_GodotSharp);
 
 	ClassDB::register_class<_GodotSharp>();
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("GodotSharp", _GodotSharp::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("GodotSharp", _GodotSharp::get_singleton()));
 
 	script_language_cs = memnew(CSharpLanguage);
 	script_language_cs->set_language_index(ScriptServer::get_language_count());

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -29,9 +29,9 @@
 /*************************************************************************/
 #include "visual_script_func_nodes.h"
 
+#include "engine.h"
 #include "io/resource_loader.h"
 #include "os/os.h"
-#include "project_settings.h"
 #include "scene/main/node.h"
 #include "scene/main/scene_tree.h"
 #include "visual_script_nodes.h"
@@ -344,7 +344,7 @@ void VisualScriptFunctionCall::set_singleton(const StringName &p_type) {
 		return;
 
 	singleton = p_type;
-	Object *obj = ProjectSettings::get_singleton()->get_singleton_object(singleton);
+	Object *obj = Engine::get_singleton()->get_singleton_object(singleton);
 	if (obj) {
 		base_type = obj->get_class();
 	}
@@ -380,7 +380,7 @@ void VisualScriptFunctionCall::_update_method_cache() {
 
 	} else if (call_mode == CALL_MODE_SINGLETON) {
 
-		Object *obj = ProjectSettings::get_singleton()->get_singleton_object(singleton);
+		Object *obj = Engine::get_singleton()->get_singleton_object(singleton);
 		if (obj) {
 			type = obj->get_class();
 			script = obj->get_script();
@@ -565,11 +565,11 @@ void VisualScriptFunctionCall::_validate_property(PropertyInfo &property) const 
 		if (call_mode != CALL_MODE_SINGLETON) {
 			property.usage = 0;
 		} else {
-			List<ProjectSettings::Singleton> names;
-			ProjectSettings::get_singleton()->get_singletons(&names);
+			List<Engine::Singleton> names;
+			Engine::get_singleton()->get_singletons(&names);
 			property.hint = PROPERTY_HINT_ENUM;
 			String sl;
-			for (List<ProjectSettings::Singleton>::Element *E = names.front(); E; E = E->next()) {
+			for (List<Engine::Singleton>::Element *E = names.front(); E; E = E->next()) {
 				if (sl != String())
 					sl += ",";
 				sl += E->get().name;
@@ -603,7 +603,7 @@ void VisualScriptFunctionCall::_validate_property(PropertyInfo &property) const 
 			property.hint_string = itos(get_visual_script()->get_instance_id());
 		} else if (call_mode == CALL_MODE_SINGLETON) {
 
-			Object *obj = ProjectSettings::get_singleton()->get_singleton_object(singleton);
+			Object *obj = Engine::get_singleton()->get_singleton_object(singleton);
 			if (obj) {
 				property.hint = PROPERTY_HINT_METHOD_OF_INSTANCE;
 				property.hint_string = itos(obj->get_instance_id());
@@ -879,7 +879,7 @@ public:
 			} break;
 			case VisualScriptFunctionCall::CALL_MODE_SINGLETON: {
 
-				Object *object = ProjectSettings::get_singleton()->get_singleton_object(singleton);
+				Object *object = Engine::get_singleton()->get_singleton_object(singleton);
 				if (!object) {
 					r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD;
 					r_error_str = "Invalid singleton name: '" + String(singleton) + "'";

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 #include "visual_script_nodes.h"
 
+#include "engine.h"
 #include "global_constants.h"
 #include "os/input.h"
 #include "os/os.h"
@@ -1976,13 +1977,13 @@ public:
 VisualScriptNodeInstance *VisualScriptEngineSingleton::instance(VisualScriptInstance *p_instance) {
 
 	VisualScriptNodeInstanceEngineSingleton *instance = memnew(VisualScriptNodeInstanceEngineSingleton);
-	instance->singleton = ProjectSettings::get_singleton()->get_singleton_object(singleton);
+	instance->singleton = Engine::get_singleton()->get_singleton_object(singleton);
 	return instance;
 }
 
 VisualScriptEngineSingleton::TypeGuess VisualScriptEngineSingleton::guess_output_type(TypeGuess *p_inputs, int p_output) const {
 
-	Object *obj = ProjectSettings::get_singleton()->get_singleton_object(singleton);
+	Object *obj = Engine::get_singleton()->get_singleton_object(singleton);
 	TypeGuess tg;
 	tg.type = Variant::OBJECT;
 	if (obj) {
@@ -2000,11 +2001,11 @@ void VisualScriptEngineSingleton::_bind_methods() {
 
 	String cc;
 
-	List<ProjectSettings::Singleton> singletons;
+	List<Engine::Singleton> singletons;
 
-	ProjectSettings::get_singleton()->get_singletons(&singletons);
+	Engine::get_singleton()->get_singletons(&singletons);
 
-	for (List<ProjectSettings::Singleton>::Element *E = singletons.front(); E; E = E->next()) {
+	for (List<Engine::Singleton>::Element *E = singletons.front(); E; E = E->next()) {
 		if (E->get().name == "VS" || E->get().name == "PS" || E->get().name == "PS2D" || E->get().name == "AS" || E->get().name == "TS" || E->get().name == "SS" || E->get().name == "SS2D")
 			continue; //skip these, too simple named
 

--- a/platform/android/godot_android.cpp
+++ b/platform/android/godot_android.cpp
@@ -35,6 +35,7 @@
 #include <EGL/egl.h>
 #include <GLES2/gl2.h>
 
+#include "engine.h"
 #include "file_access_android.h"
 #include "main/main.h"
 #include "os_android.h"
@@ -842,7 +843,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_Godot_registerSingleton(JNIEnv
 	s->set_instance(env->NewGlobalRef(p_object));
 	jni_singletons[singname] = s;
 
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton(singname, s));
+	Engine::get_singleton()->add_singleton(Engine::Singleton(singname, s));
 }
 
 static Variant::Type get_jni_type(const String &p_type) {

--- a/platform/android/java_glue.cpp
+++ b/platform/android/java_glue.cpp
@@ -34,6 +34,7 @@
 #include "audio_driver_jandroid.h"
 #include "core/os/keyboard.h"
 #include "dir_access_jandroid.h"
+#include "engine.h"
 #include "file_access_android.h"
 #include "file_access_jandroid.h"
 #include "java_class_wrapper.h"
@@ -953,7 +954,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_setup(JNIEnv *env, jo
 	__android_log_print(ANDROID_LOG_INFO, "godot", "*****SETUP OK");
 
 	java_class_wrapper = memnew(JavaClassWrapper(_godot_instance));
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("JavaClassWrapper", java_class_wrapper));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("JavaClassWrapper", java_class_wrapper));
 	_initialize_java_modules();
 }
 
@@ -1426,7 +1427,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_singleton(JNIEnv *env
 	s->set_instance(env->NewGlobalRef(p_object));
 	jni_singletons[singname] = s;
 
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton(singname, s));
+	Engine::get_singleton()->add_singleton(Engine::Singleton(singname, s));
 	ProjectSettings::get_singleton()->set(singname, s);
 }
 

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -641,7 +641,7 @@ String OS_Android::get_data_dir() const {
 	}
 
 	return ".";
-	//return ProjectSettings::get_singleton()->get_singleton_object("GodotOS")->call("get_data_dir");
+	//return Engine::get_singleton()->get_singleton_object("GodotOS")->call("get_data_dir");
 }
 
 void OS_Android::set_screen_orientation(ScreenOrientation p_orientation) {

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -138,28 +138,28 @@ void OSIPhone::initialize(const VideoMode &p_desired, int p_video_driver, int p_
 /*
 #ifdef IOS_SCORELOOP_ENABLED
 	scoreloop = memnew(ScoreloopIOS);
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("Scoreloop", scoreloop));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("Scoreloop", scoreloop));
 	scoreloop->connect();
 #endif
 	*/
 
 #ifdef GAME_CENTER_ENABLED
 	game_center = memnew(GameCenter);
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("GameCenter", game_center));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("GameCenter", game_center));
 	game_center->connect();
 #endif
 
 #ifdef STOREKIT_ENABLED
 	store_kit = memnew(InAppStore);
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("InAppStore", store_kit));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("InAppStore", store_kit));
 #endif
 
 #ifdef ICLOUD_ENABLED
 	icloud = memnew(ICloud);
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("ICloud", icloud));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("ICloud", icloud));
 //icloud->connect();
 #endif
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("iOS", memnew(iOS)));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("iOS", memnew(iOS)));
 };
 
 MainLoop *OSIPhone::get_main_loop() const {

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -29,8 +29,8 @@
 /*************************************************************************/
 #include "os_javascript.h"
 
+#include "core/engine.h"
 #include "core/io/file_access_buffered_fa.h"
-#include "core/project_settings.h"
 #include "dom_keys.h"
 #include "drivers/gles3/rasterizer_gles3.h"
 #include "drivers/unix/dir_access_unix.h"
@@ -514,7 +514,7 @@ void OS_JavaScript::initialize(const VideoMode &p_desired, int p_video_driver, i
 
 #ifdef JAVASCRIPT_EVAL_ENABLED
 	javascript_eval = memnew(JavaScript);
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("JavaScript", javascript_eval));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("JavaScript", javascript_eval));
 #endif
 
 	visual_server->init();
@@ -896,7 +896,6 @@ String OS_JavaScript::get_data_dir() const {
 		return get_data_dir_func();
 	*/
 	return "/userfs";
-	//return ProjectSettings::get_singleton()->get_singleton_object("GodotOS")->call("get_data_dir");
 };
 
 String OS_JavaScript::get_executable_path() const {

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -28,6 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include "register_server_types.h"
+#include "engine.h"
 #include "project_settings.h"
 
 #include "arvr/arvr_interface.h"
@@ -171,9 +172,9 @@ void unregister_server_types() {
 }
 
 void register_server_singletons() {
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("VisualServer", VisualServer::get_singleton()));
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("AudioServer", AudioServer::get_singleton()));
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("PhysicsServer", PhysicsServer::get_singleton()));
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("Physics2DServer", Physics2DServer::get_singleton()));
-	ProjectSettings::get_singleton()->add_singleton(ProjectSettings::Singleton("ARVRServer", ARVRServer::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("VisualServer", VisualServer::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("AudioServer", AudioServer::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("PhysicsServer", PhysicsServer::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("Physics2DServer", Physics2DServer::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("ARVRServer", ARVRServer::get_singleton()));
 }


### PR DESCRIPTION
 - Change `get_singleton_object()` to fail when called with a non-existent singleton name
-  Move singleton management from `ProjectSettings` to `Engine`