### PR TITLE
Make tool scripts print on the editor Output panel

### DIFF
--- a/core/print_string.cpp
+++ b/core/print_string.cpp
@@ -82,7 +82,25 @@ void print_line(String p_string) {
 	PrintHandlerList *l = print_handler_list;
 	while (l) {
 
-		l->printfunc(l->userdata, p_string);
+		l->printfunc(l->userdata, p_string, false);
+		l = l->next;
+	}
+
+	_global_unlock();
+}
+
+void print_error(String p_string) {
+
+	if (!_print_error_enabled)
+		return;
+
+	OS::get_singleton()->printerr("%s\n", p_string.utf8().get_data());
+
+	_global_lock();
+	PrintHandlerList *l = print_handler_list;
+	while (l) {
+
+		l->printfunc(l->userdata, p_string, true);
 		l = l->next;
 	}
 

--- a/core/print_string.h
+++ b/core/print_string.h
@@ -34,7 +34,7 @@
 
 extern void (*_print_func)(String);
 
-typedef void (*PrintHandlerFunc)(void *, const String &p_string);
+typedef void (*PrintHandlerFunc)(void *, const String &p_string, bool p_error);
 
 struct PrintHandlerList {
 
@@ -56,5 +56,6 @@ void remove_print_handler(PrintHandlerList *p_handler);
 extern bool _print_line_enabled;
 extern bool _print_error_enabled;
 extern void print_line(String p_string);
+extern void print_error(String p_string);
 
 #endif

--- a/core/script_debugger_remote.cpp
+++ b/core/script_debugger_remote.cpp
@@ -832,7 +832,7 @@ void ScriptDebuggerRemote::send_message(const String &p_message, const Array &p_
 	mutex->unlock();
 }
 
-void ScriptDebuggerRemote::_print_handler(void *p_this, const String &p_string) {
+void ScriptDebuggerRemote::_print_handler(void *p_this, const String &p_string, bool p_error) {
 
 	ScriptDebuggerRemote *sdr = (ScriptDebuggerRemote *)p_this;
 

--- a/core/script_debugger_remote.h
+++ b/core/script_debugger_remote.h
@@ -94,7 +94,7 @@ class ScriptDebuggerRemote : public ScriptDebugger {
 	uint64_t msec_count;
 
 	bool locking; //hack to avoid a deadloop
-	static void _print_handler(void *p_this, const String &p_string);
+	static void _print_handler(void *p_this, const String &p_string, bool p_error);
 
 	PrintHandlerList phl;
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4552,6 +4552,11 @@ static Node *_resource_get_edited_scene() {
 	return EditorNode::get_singleton()->get_edited_scene();
 }
 
+void EditorNode::_print_handler(void *p_this, const String &p_string, bool p_error) {
+	EditorNode *en = (EditorNode *)p_this;
+	en->log->add_message(p_string, p_error);
+}
+
 EditorNode::EditorNode() {
 
 	Resource::_get_local_scene_func = _resource_get_edited_scene;
@@ -5652,6 +5657,10 @@ EditorNode::EditorNode() {
 	_dim_timer->connect("timeout", this, "_dim_timeout");
 	add_child(_dim_timer);
 
+	print_handler.printfunc = _print_handler;
+	print_handler.userdata = this;
+	add_print_handler(&print_handler);
+
 	ED_SHORTCUT("editor/editor_2d", TTR("Open 2D Editor"), KEY_F1);
 	ED_SHORTCUT("editor/editor_3d", TTR("Open 3D Editor"), KEY_F2);
 	ED_SHORTCUT("editor/editor_script", TTR("Open Script Editor"), KEY_F3); //hack neded for script editor F3 search to work :) Assign like this or don't use F3
@@ -5663,6 +5672,7 @@ EditorNode::EditorNode() {
 
 EditorNode::~EditorNode() {
 
+	remove_print_handler(&print_handler);
 	memdelete(EditorHelp::get_doc_data());
 	memdelete(editor_selection);
 	memdelete(editor_plugins_over);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -30,6 +30,7 @@
 #ifndef EDITOR_NODE_H
 #define EDITOR_NODE_H
 
+#include "core/print_string.h"
 #include "editor/connections_dialog.h"
 #include "editor/create_dialog.h"
 #include "editor/editor_about.h"
@@ -609,6 +610,9 @@ private:
 	void _license_tree_selected();
 
 	Vector<Ref<EditorResourceConversionPlugin> > resource_conversion_plugins;
+
+	PrintHandlerList print_handler;
+	static void _print_handler(void *p_this, const String &p_string, bool p_error);
 
 protected:
 	void _notification(int p_what);

--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -642,7 +642,7 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 			}
 
 			//str+="\n";
-			OS::get_singleton()->printerr("%s\n", str.utf8().get_data());
+			print_error(str);
 			r_ret = Variant();
 
 		} break;

--- a/modules/visual_script/visual_script_builtin_funcs.cpp
+++ b/modules/visual_script/visual_script_builtin_funcs.cpp
@@ -1109,7 +1109,7 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 			String str = *p_inputs[0];
 
 			//str+="\n";
-			OS::get_singleton()->printerr("%s\n", str.utf8().get_data());
+			print_error(str);
 
 		} break;
 		case VisualScriptBuiltinFunc::TEXT_PRINTRAW: {


### PR DESCRIPTION
~~This makes the GDScript module include an editor header, and I'm not sure if that's okay, but I couldn't think of another way to do this.~~

Fix #8748.