### PR TITLE
3.0 - add open feture to dependency_editor.cpp(View Owner..)

### DIFF
--- a/editor/dependency_editor.h
+++ b/editor/dependency_editor.h
@@ -36,6 +36,7 @@
 #include "scene/gui/tree.h"
 
 class EditorFileSystemDirectory;
+class EditorNode;
 
 class DependencyEditor : public AcceptDialog {
 	GDCLASS(DependencyEditor, AcceptDialog);
@@ -71,12 +72,25 @@ class DependencyEditorOwners : public AcceptDialog {
 	GDCLASS(DependencyEditorOwners, AcceptDialog);
 
 	ItemList *owners;
+	PopupMenu *file_options;
+	EditorNode *editor;
 	String editing;
+
 	void _fill_owners(EditorFileSystemDirectory *efsd);
+
+	static void _bind_methods();
+	void _list_rmb_select(int p_item, const Vector2 &p_pos);
+	void _select_file(int p_idx);
+	void _file_option(int p_option);
+
+private:
+	enum FileMenu {
+		FILE_OPEN
+	};
 
 public:
 	void show(const String &p_path);
-	DependencyEditorOwners();
+	DependencyEditorOwners(EditorNode *p_editor);
 };
 
 class DependencyRemoveDialog : public ConfirmationDialog {

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1670,7 +1670,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	deps_editor = memnew(DependencyEditor);
 	add_child(deps_editor);
 
-	owners_editor = memnew(DependencyEditorOwners);
+	owners_editor = memnew(DependencyEditorOwners(editor));
 	add_child(owners_editor);
 
 	remove_dialog = memnew(DependencyRemoveDialog);


### PR DESCRIPTION
Easy to open Scene in dependency owner editor.
Including double click and right click menu.
![capture](https://user-images.githubusercontent.com/24988459/32818563-f8e35dd2-c9fe-11e7-8cda-879b1071e37d.png)
