### PR TITLE
Allow exporting enums from GDScript

### DIFF
--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -415,7 +415,11 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 				menu->clear();
 				Vector<String> options = hint_text.split(",");
 				for (int i = 0; i < options.size(); i++) {
-					menu->add_item(options[i], i);
+					if (options[i].find(":") != -1) {
+						menu->add_item(options[i].get_slicec(':', 0), options[i].get_slicec(':', 1).to_int());
+					} else {
+						menu->add_item(options[i], i);
+					}
 				}
 				menu->set_position(get_position());
 				menu->popup();


### PR DESCRIPTION
Examples:
```gdscript
enum Tile {TILE_AIR = 0, TILE_BLOCK, TILE_ICE}
export(Tile) var tile_type = TILE_AIR

export({user = 0, moderator = 50, admin = 100}) var role = 100
export({"user": 0, "moderator": 50, "admin": 100}) var role_alt = 100

const Utils = {"Util 1": 0, "Util 2": 1, "Util 3": 10}
export(Utils) var util
```
Closes #12392