### PR TITLE
Editor canvas item api rework

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -346,14 +346,14 @@
 				Get the global transform matrix of this item in relation to the canvas.
 			</description>
 		</method>
-		<method name="get_item_and_children_rect" qualifiers="const">
+		<method name="edit_get_item_and_children_rect" qualifiers="const">
 			<return type="Rect2">
 			</return>
 			<description>
 				Get a [Rect2] with the boundaries of this item and its children.
 			</description>
 		</method>
-		<method name="get_item_rect" qualifiers="const">
+		<method name="edit_get_rect" qualifiers="const">
 			<return type="Rect2">
 			</return>
 			<description>

--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -363,7 +363,7 @@ PoolVector<Vector2> TileMapEditor::_bucket_fill(const Point2i &p_start, bool era
 		return PoolVector<Vector2>();
 	}
 
-	Rect2i r = node->get_item_rect();
+	Rect2i r = node->_edit_get_rect();
 	r.position = r.position / node->get_cell_size();
 	r.size = r.size / node->get_cell_size();
 

--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -247,16 +247,16 @@ SpriteFrames::SpriteFrames() {
 	add_animation(SceneStringNames::get_singleton()->_default);
 }
 
-void AnimatedSprite::edit_set_pivot(const Point2 &p_pivot) {
+void AnimatedSprite::_edit_set_pivot(const Point2 &p_pivot) {
 
 	set_offset(p_pivot);
 }
 
-Point2 AnimatedSprite::edit_get_pivot() const {
+Point2 AnimatedSprite::_edit_get_pivot() const {
 
 	return get_offset();
 }
-bool AnimatedSprite::edit_has_pivot() const {
+bool AnimatedSprite::_edit_use_pivot() const {
 
 	return true;
 }
@@ -509,17 +509,17 @@ bool AnimatedSprite::is_flipped_v() const {
 	return vflip;
 }
 
-Rect2 AnimatedSprite::get_item_rect() const {
+Rect2 AnimatedSprite::_edit_get_rect() const {
 
 	if (!frames.is_valid() || !frames->has_animation(animation) || frame < 0 || frame >= frames->get_frame_count(animation)) {
-		return Node2D::get_item_rect();
+		return Node2D::_edit_get_rect();
 	}
 
 	Ref<Texture> t;
 	if (animation)
 		t = frames->get_frame(animation, frame);
 	if (t.is_null())
-		return Node2D::get_item_rect();
+		return Node2D::_edit_get_rect();
 	Size2i s = t->get_size();
 
 	Point2 ofs = offset;

--- a/scene/2d/animated_sprite.h
+++ b/scene/2d/animated_sprite.h
@@ -149,9 +149,9 @@ protected:
 	virtual void _validate_property(PropertyInfo &property) const;
 
 public:
-	virtual void edit_set_pivot(const Point2 &p_pivot);
-	virtual Point2 edit_get_pivot() const;
-	virtual bool edit_has_pivot() const;
+	virtual void _edit_set_pivot(const Point2 &p_pivot);
+	virtual Point2 _edit_get_pivot() const;
+	virtual bool _edit_use_pivot() const;
 
 	void set_sprite_frames(const Ref<SpriteFrames> &p_frames);
 	Ref<SpriteFrames> get_sprite_frames() const;
@@ -181,7 +181,7 @@ public:
 	void set_modulate(const Color &p_color);
 	Color get_modulate() const;
 
-	virtual Rect2 get_item_rect() const;
+	virtual Rect2 _edit_get_rect() const;
 
 	virtual String get_configuration_warning() const;
 	AnimatedSprite();

--- a/scene/2d/back_buffer_copy.cpp
+++ b/scene/2d/back_buffer_copy.cpp
@@ -49,7 +49,7 @@ void BackBufferCopy::_update_copy_mode() {
 	}
 }
 
-Rect2 BackBufferCopy::get_item_rect() const {
+Rect2 BackBufferCopy::_edit_get_rect() const {
 
 	return rect;
 }

--- a/scene/2d/back_buffer_copy.h
+++ b/scene/2d/back_buffer_copy.h
@@ -52,13 +52,13 @@ protected:
 	static void _bind_methods();
 
 public:
+	Rect2 _edit_get_rect() const;
+
 	void set_rect(const Rect2 &p_rect);
 	Rect2 get_rect() const;
 
 	void set_copy_mode(CopyMode p_mode);
 	CopyMode get_copy_mode() const;
-
-	Rect2 get_item_rect() const;
 
 	BackBufferCopy();
 	~BackBufferCopy();

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -306,22 +306,7 @@ void CanvasItem::hide() {
 	_change_notify("visible");
 }
 
-Variant CanvasItem::edit_get_state() const {
-
-	return Variant();
-}
-void CanvasItem::edit_set_state(const Variant &p_state) {
-}
-
-void CanvasItem::edit_set_rect(const Rect2 &p_edit_rect) {
-
-	//used by editors, implement at will
-}
-
-void CanvasItem::edit_rotate(float p_rot) {
-}
-
-Size2 CanvasItem::edit_get_minimum_size() const {
+Size2 CanvasItem::_edit_get_minimum_size() const {
 
 	return Size2(-1, -1); //no limit
 }
@@ -941,15 +926,22 @@ void CanvasItem::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_toplevel_raise_self"), &CanvasItem::_toplevel_raise_self);
 	ClassDB::bind_method(D_METHOD("_update_callback"), &CanvasItem::_update_callback);
+	ClassDB::bind_method(D_METHOD("_edit_set_state", "state"), &CanvasItem::_edit_set_state);
+	ClassDB::bind_method(D_METHOD("_edit_get_state"), &CanvasItem::_edit_get_state);
 
-	ClassDB::bind_method(D_METHOD("edit_set_state", "state"), &CanvasItem::edit_set_state);
-	ClassDB::bind_method(D_METHOD("edit_get_state"), &CanvasItem::edit_get_state);
-	ClassDB::bind_method(D_METHOD("edit_set_rect", "rect"), &CanvasItem::edit_set_rect);
-	ClassDB::bind_method(D_METHOD("edit_rotate", "degrees"), &CanvasItem::edit_rotate);
-
-	ClassDB::bind_method(D_METHOD("get_item_rect"), &CanvasItem::get_item_rect);
-	ClassDB::bind_method(D_METHOD("get_item_and_children_rect"), &CanvasItem::get_item_and_children_rect);
-	//ClassDB::bind_method(D_METHOD("get_transform"),&CanvasItem::get_transform);
+	ClassDB::bind_method(D_METHOD("_edit_set_position", "position"), &CanvasItem::_edit_set_position);
+	ClassDB::bind_method(D_METHOD("_edit_get_position"), &CanvasItem::_edit_get_position);
+	ClassDB::bind_method(D_METHOD("_edit_use_position"), &CanvasItem::_edit_use_position);
+	ClassDB::bind_method(D_METHOD("_edit_set_rect", "rect"), &CanvasItem::_edit_set_rect);
+	ClassDB::bind_method(D_METHOD("_edit_get_rect"), &CanvasItem::_edit_get_rect);
+	ClassDB::bind_method(D_METHOD("_edit_use_rect"), &CanvasItem::_edit_use_rect);
+	ClassDB::bind_method(D_METHOD("_edit_get_item_and_children_rect"), &CanvasItem::_edit_get_item_and_children_rect);
+	ClassDB::bind_method(D_METHOD("_edit_set_rotation", "degrees"), &CanvasItem::_edit_set_rotation);
+	ClassDB::bind_method(D_METHOD("_edit_get_rotation"), &CanvasItem::_edit_get_rotation);
+	ClassDB::bind_method(D_METHOD("_edit_use_rotation"), &CanvasItem::_edit_use_rotation);
+	ClassDB::bind_method(D_METHOD("_edit_set_pivot", "pivot"), &CanvasItem::_edit_set_pivot);
+	ClassDB::bind_method(D_METHOD("_edit_get_pivot"), &CanvasItem::_edit_get_pivot);
+	ClassDB::bind_method(D_METHOD("_edit_use_pivot"), &CanvasItem::_edit_use_pivot);
 
 	ClassDB::bind_method(D_METHOD("get_canvas_item"), &CanvasItem::get_canvas_item);
 
@@ -1119,14 +1111,14 @@ int CanvasItem::get_canvas_layer() const {
 		return 0;
 }
 
-Rect2 CanvasItem::get_item_and_children_rect() const {
+Rect2 CanvasItem::_edit_get_item_and_children_rect() const {
 
-	Rect2 rect = get_item_rect();
+	Rect2 rect = _edit_get_rect();
 
 	for (int i = 0; i < get_child_count(); i++) {
 		CanvasItem *c = Object::cast_to<CanvasItem>(get_child(i));
 		if (c) {
-			Rect2 sir = c->get_transform().xform(c->get_item_and_children_rect());
+			Rect2 sir = c->get_transform().xform(c->_edit_get_item_and_children_rect());
 			rect = rect.merge(sir);
 		}
 	}

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -216,11 +216,31 @@ public:
 
 	/* EDITOR */
 
-	virtual Variant edit_get_state() const;
-	virtual void edit_set_state(const Variant &p_state);
-	virtual void edit_set_rect(const Rect2 &p_edit_rect);
-	virtual void edit_rotate(float p_rot);
-	virtual Size2 edit_get_minimum_size() const;
+	virtual void _edit_set_state(const Dictionary &p_state){};
+	virtual Dictionary _edit_get_state() const { return Dictionary(); };
+
+	// Used to move/select the node
+	virtual void _edit_set_position(const Point2 &p_position){};
+	virtual Point2 _edit_get_position() const { return Point2(); };
+	virtual bool _edit_use_position() const { return false; };
+
+	// Used to resize/move/select the node
+	virtual void _edit_set_rect(const Rect2 &p_rect){};
+	virtual Rect2 _edit_get_rect() const { return Rect2(-32, -32, 64, 64); };
+	Rect2 _edit_get_item_and_children_rect() const;
+	virtual bool _edit_use_rect() const { return false; };
+
+	// Used to rotate the node
+	virtual void _edit_set_rotation(float p_rotation){};
+	virtual float _edit_get_rotation() const { return 0.0; };
+	virtual bool _edit_use_rotation() const { return false; };
+
+	// Used to set a pivot
+	virtual void _edit_set_pivot(const Point2 &p_pivot){};
+	virtual Point2 _edit_get_pivot() const { return Point2(); };
+	virtual bool _edit_use_pivot() const { return false; };
+
+	virtual Size2 _edit_get_minimum_size() const;
 
 	/* VISIBILITY */
 
@@ -272,13 +292,10 @@ public:
 
 	CanvasItem *get_parent_item() const;
 
-	virtual Rect2 get_item_rect() const = 0;
 	virtual Transform2D get_transform() const = 0;
 
 	virtual Transform2D get_global_transform() const;
 	virtual Transform2D get_global_transform_with_canvas() const;
-
-	Rect2 get_item_and_children_rect() const;
 
 	CanvasItem *get_toplevel() const;
 	_FORCE_INLINE_ RID get_canvas_item() const { return canvas_item; }

--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -243,7 +243,7 @@ CollisionPolygon2D::BuildMode CollisionPolygon2D::get_build_mode() const {
 	return build_mode;
 }
 
-Rect2 CollisionPolygon2D::get_item_rect() const {
+Rect2 CollisionPolygon2D::_edit_get_rect() const {
 
 	return aabb;
 }

--- a/scene/2d/collision_polygon_2d.h
+++ b/scene/2d/collision_polygon_2d.h
@@ -69,7 +69,7 @@ public:
 	void set_polygon(const Vector<Point2> &p_polygon);
 	Vector<Point2> get_polygon() const;
 
-	virtual Rect2 get_item_rect() const;
+	virtual Rect2 _edit_get_rect() const;
 
 	virtual String get_configuration_warning() const;
 

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -158,7 +158,7 @@ Ref<Shape2D> CollisionShape2D::get_shape() const {
 	return shape;
 }
 
-Rect2 CollisionShape2D::get_item_rect() const {
+Rect2 CollisionShape2D::_edit_get_rect() const {
 
 	return rect;
 }

--- a/scene/2d/collision_shape_2d.h
+++ b/scene/2d/collision_shape_2d.h
@@ -51,9 +51,10 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual Rect2 _edit_get_rect() const;
+
 	void set_shape(const Ref<Shape2D> &p_shape);
 	Ref<Shape2D> get_shape() const;
-	virtual Rect2 get_item_rect() const;
 
 	void set_disabled(bool p_disabled);
 	bool is_disabled() const;

--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -32,21 +32,21 @@
 #include "engine.h"
 #include "servers/visual_server.h"
 
-void Light2D::edit_set_pivot(const Point2 &p_pivot) {
+void Light2D::_edit_set_pivot(const Point2 &p_pivot) {
 
 	set_texture_offset(p_pivot);
 }
 
-Point2 Light2D::edit_get_pivot() const {
+Point2 Light2D::_edit_get_pivot() const {
 
 	return get_texture_offset();
 }
-bool Light2D::edit_has_pivot() const {
+bool Light2D::_edit_use_pivot() const {
 
 	return true;
 }
 
-Rect2 Light2D::get_item_rect() const {
+Rect2 Light2D::_edit_get_rect() const {
 
 	if (texture.is_null())
 		return Rect2(0, 0, 1, 1);

--- a/scene/2d/light_2d.h
+++ b/scene/2d/light_2d.h
@@ -84,9 +84,10 @@ protected:
 	static void _bind_methods();
 
 public:
-	virtual void edit_set_pivot(const Point2 &p_pivot);
-	virtual Point2 edit_get_pivot() const;
-	virtual bool edit_has_pivot() const;
+	virtual void _edit_set_pivot(const Point2 &p_pivot);
+	virtual Point2 _edit_get_pivot() const;
+	virtual bool _edit_use_pivot() const;
+	virtual Rect2 _edit_get_rect() const;
 
 	void set_enabled(bool p_enabled);
 	bool is_enabled() const;
@@ -150,8 +151,6 @@ public:
 
 	void set_shadow_smooth(float p_amount);
 	float get_shadow_smooth() const;
-
-	virtual Rect2 get_item_rect() const;
 
 	String get_configuration_warning() const;
 

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -34,35 +34,22 @@
 #include "scene/main/viewport.h"
 #include "servers/visual_server.h"
 
-void Node2D::edit_set_pivot(const Point2 &p_pivot) {
-}
+Dictionary Node2D::_edit_get_state() const {
 
-Point2 Node2D::edit_get_pivot() const {
-
-	return Point2();
-}
-bool Node2D::edit_has_pivot() const {
-
-	return false;
-}
-
-Variant Node2D::edit_get_state() const {
-
-	Array state;
-	state.push_back(get_position());
-	state.push_back(get_rotation());
-	state.push_back(get_scale());
+	Dictionary state;
+	state["position"] = get_position();
+	state["rotation"] = get_rotation();
+	state["scale"] = get_scale();
 
 	return state;
 }
-void Node2D::edit_set_state(const Variant &p_state) {
+void Node2D::_edit_set_state(const Dictionary &p_state) {
 
-	Array state = p_state;
-	ERR_FAIL_COND(state.size() != 3);
+	Dictionary state = p_state;
+	pos = state["position"];
+	angle = state["rotation"];
+	_scale = state["scale"];
 
-	pos = state[0];
-	angle = state[1];
-	_scale = state[2];
 	_update_transform();
 	_change_notify("rotation");
 	_change_notify("rotation_degrees");
@@ -70,9 +57,16 @@ void Node2D::edit_set_state(const Variant &p_state) {
 	_change_notify("position");
 }
 
-void Node2D::edit_set_rect(const Rect2 &p_edit_rect) {
+void Node2D::_edit_set_position(const Point2 &p_position) {
+	pos = p_position;
+}
 
-	Rect2 r = get_item_rect();
+Point2 Node2D::_edit_get_position() const {
+	return pos;
+}
+
+void Node2D::_edit_set_rect(const Rect2 &p_edit_rect) {
+	Rect2 r = _edit_get_rect();
 
 	Vector2 zero_offset;
 	if (r.size.x != 0)
@@ -101,12 +95,23 @@ void Node2D::edit_set_rect(const Rect2 &p_edit_rect) {
 	_change_notify("position");
 }
 
-void Node2D::edit_rotate(float p_rot) {
+bool Node2D::_edit_use_rect() const {
+	return true;
+}
 
-	angle += p_rot;
+void Node2D::_edit_set_rotation(float p_rotation) {
+	angle = p_rotation;
 	_update_transform();
 	_change_notify("rotation");
 	_change_notify("rotation_degrees");
+}
+
+float Node2D::_edit_get_rotation() const {
+	return angle;
+}
+
+bool Node2D::_edit_use_rotation() const {
+	return true;
 }
 
 void Node2D::_update_xform_values() {
@@ -203,17 +208,6 @@ void Node2D::_notification(int p_what) {
 Transform2D Node2D::get_transform() const {
 
 	return _mat;
-}
-
-Rect2 Node2D::get_item_rect() const {
-
-	if (get_script_instance()) {
-		Variant::CallError err;
-		Rect2 r = get_script_instance()->call("_get_item_rect", NULL, 0, err);
-		if (err.error == Variant::CallError::CALL_OK)
-			return r;
-	}
-	return Rect2(Point2(-32, -32), Size2(64, 64));
 }
 
 void Node2D::rotate(float p_radians) {
@@ -439,7 +433,7 @@ void Node2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_z_as_relative", "enable"), &Node2D::set_z_as_relative);
 	ClassDB::bind_method(D_METHOD("is_z_relative"), &Node2D::is_z_relative);
 
-	ClassDB::bind_method(D_METHOD("edit_set_pivot", "pivot"), &Node2D::edit_set_pivot);
+	ClassDB::bind_method(D_METHOD("_edit_set_pivot", "pivot"), &Node2D::_edit_set_pivot);
 
 	ClassDB::bind_method(D_METHOD("get_relative_transform_to_parent", "parent"), &Node2D::get_relative_transform_to_parent);
 

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -56,13 +56,16 @@ protected:
 	static void _bind_methods();
 
 public:
-	virtual Variant edit_get_state() const;
-	virtual void edit_set_state(const Variant &p_state);
-	virtual void edit_set_rect(const Rect2 &p_edit_rect);
-	virtual void edit_rotate(float p_rot);
-	virtual void edit_set_pivot(const Point2 &p_pivot);
-	virtual Point2 edit_get_pivot() const;
-	virtual bool edit_has_pivot() const;
+	virtual Dictionary _edit_get_state() const;
+	virtual void _edit_set_state(const Dictionary &p_state);
+
+	virtual void _edit_set_position(const Point2 &p_position);
+	virtual Point2 _edit_get_position() const;
+	virtual void _edit_set_rect(const Rect2 &p_edit_rect);
+	virtual bool _edit_use_rect() const;
+	virtual void _edit_set_rotation(float p_rotation);
+	virtual float _edit_get_rotation() const;
+	virtual bool _edit_use_rotation() const;
 
 	void set_position(const Point2 &p_pos);
 	void set_rotation(float p_radians);
@@ -85,7 +88,6 @@ public:
 	float get_global_rotation() const;
 	float get_global_rotation_degrees() const;
 	Size2 get_global_scale() const;
-	virtual Rect2 get_item_rect() const;
 
 	void set_transform(const Transform2D &p_transform);
 	void set_global_transform(const Transform2D &p_transform);

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -29,7 +29,7 @@
 /*************************************************************************/
 #include "polygon_2d.h"
 
-Rect2 Polygon2D::get_item_rect() const {
+Rect2 Polygon2D::_edit_get_rect() const {
 
 	if (rect_cache_dirty) {
 		int l = polygon.size();
@@ -49,16 +49,16 @@ Rect2 Polygon2D::get_item_rect() const {
 	return item_rect;
 }
 
-void Polygon2D::edit_set_pivot(const Point2 &p_pivot) {
+void Polygon2D::_edit_set_pivot(const Point2 &p_pivot) {
 
 	set_offset(p_pivot);
 }
 
-Point2 Polygon2D::edit_get_pivot() const {
+Point2 Polygon2D::_edit_get_pivot() const {
 
 	return get_offset();
 }
-bool Polygon2D::edit_has_pivot() const {
+bool Polygon2D::_edit_use_pivot() const {
 
 	return true;
 }

--- a/scene/2d/polygon_2d.h
+++ b/scene/2d/polygon_2d.h
@@ -99,11 +99,11 @@ public:
 
 	//editor stuff
 
-	virtual void edit_set_pivot(const Point2 &p_pivot);
-	virtual Point2 edit_get_pivot() const;
-	virtual bool edit_has_pivot() const;
+	virtual void _edit_set_pivot(const Point2 &p_pivot);
+	virtual Point2 _edit_get_pivot() const;
+	virtual bool _edit_use_pivot() const;
 
-	virtual Rect2 get_item_rect() const;
+	virtual Rect2 _edit_get_rect() const;
 
 	Polygon2D();
 };

--- a/scene/2d/position_2d.cpp
+++ b/scene/2d/position_2d.cpp
@@ -38,7 +38,7 @@ void Position2D::_draw_cross() {
 	draw_line(Point2(0, -10), Point2(0, +10), Color(0.5, 1, 0.5));
 }
 
-Rect2 Position2D::get_item_rect() const {
+Rect2 Position2D::_edit_get_rect() const {
 
 	return Rect2(Point2(-10, -10), Size2(20, 20));
 }

--- a/scene/2d/position_2d.h
+++ b/scene/2d/position_2d.h
@@ -42,7 +42,7 @@ protected:
 	void _notification(int p_what);
 
 public:
-	virtual Rect2 get_item_rect() const;
+	virtual Rect2 _edit_get_rect() const;
 	Position2D();
 };
 

--- a/scene/2d/screen_button.cpp
+++ b/scene/2d/screen_button.cpp
@@ -133,7 +133,7 @@ void TouchScreenButton::_notification(int p_what) {
 				return;
 			if (shape.is_valid()) {
 				Color draw_col = get_tree()->get_debug_collisions_color();
-				Vector2 pos = shape_centered ? get_item_rect().size * 0.5f : Vector2();
+				Vector2 pos = shape_centered ? _edit_get_rect().size * 0.5f : Vector2();
 				draw_set_transform_matrix(get_canvas_transform().translated(pos));
 				shape->draw(get_canvas_item(), draw_col);
 			}
@@ -251,7 +251,7 @@ void TouchScreenButton::_input(const Ref<InputEvent> &p_event) {
 bool TouchScreenButton::_is_point_inside(const Point2 &p_point) {
 
 	Point2 coord = (get_global_transform_with_canvas()).affine_inverse().xform(p_point);
-	Rect2 item_rect = get_item_rect();
+	Rect2 item_rect = _edit_get_rect();
 
 	bool touched = false;
 	bool check_rect = true;
@@ -322,13 +322,13 @@ void TouchScreenButton::_release(bool p_exiting_tree) {
 	}
 }
 
-Rect2 TouchScreenButton::get_item_rect() const {
+Rect2 TouchScreenButton::_edit_get_rect() const {
 
 	if (texture.is_null())
 		return Rect2(0, 0, 1, 1);
 	/*
 	if (texture.is_null())
-		return CanvasItem::get_item_rect();
+		return CanvasItem::_edit_get_rect();
 	*/
 
 	return Rect2(Size2(), texture->get_size());

--- a/scene/2d/screen_button.h
+++ b/scene/2d/screen_button.h
@@ -102,7 +102,7 @@ public:
 
 	bool is_pressed() const;
 
-	Rect2 get_item_rect() const;
+	Rect2 _edit_get_rect() const;
 
 	TouchScreenButton();
 };

--- a/scene/2d/sprite.cpp
+++ b/scene/2d/sprite.cpp
@@ -33,16 +33,16 @@
 #include "scene/main/viewport.h"
 #include "scene/scene_string_names.h"
 
-void Sprite::edit_set_pivot(const Point2 &p_pivot) {
+void Sprite::_edit_set_pivot(const Point2 &p_pivot) {
 
 	set_offset(p_pivot);
 }
 
-Point2 Sprite::edit_get_pivot() const {
+Point2 Sprite::_edit_get_pivot() const {
 
 	return get_offset();
 }
-bool Sprite::edit_has_pivot() const {
+bool Sprite::_edit_use_pivot() const {
 
 	return true;
 }
@@ -257,13 +257,13 @@ int Sprite::get_hframes() const {
 	return hframes;
 }
 
-Rect2 Sprite::get_item_rect() const {
+Rect2 Sprite::_edit_get_rect() const {
 
 	if (texture.is_null())
 		return Rect2(0, 0, 1, 1);
 	/*
 	if (texture.is_null())
-		return CanvasItem::get_item_rect();
+		return CanvasItem::_edit_get_rect();
 	*/
 
 	Size2i s;
@@ -368,224 +368,3 @@ Sprite::Sprite() {
 	vframes = 1;
 	hframes = 1;
 }
-
-//////////////////////////// VPSPRITE
-///
-///
-///
-
-#if 0
-void ViewportSprite::edit_set_pivot(const Point2& p_pivot) {
-
-	set_offset(p_pivot);
-}
-
-Point2 ViewportSprite::edit_get_pivot() const {
-
-	return get_offset();
-}
-bool ViewportSprite::edit_has_pivot() const {
-
-	return true;
-}
-
-void ViewportSprite::_notification(int p_what) {
-
-	switch(p_what) {
-
-		case NOTIFICATION_ENTER_TREE: {
-
-			if (!viewport_path.is_empty()) {
-
-				Node *n = get_node(viewport_path);
-				ERR_FAIL_COND(!n);
-				Viewport *vp=Object::cast_to<Viewport>(n);
-				ERR_FAIL_COND(!vp);
-
-				Ref<RenderTargetTexture> rtt = vp->get_render_target_texture();
-				texture=rtt;
-				texture->connect("changed",this,"update");
-				item_rect_changed();
-			}
-		} break;
-		case NOTIFICATION_EXIT_TREE: {
-
-			if (texture.is_valid()) {
-
-				texture->disconnect("changed",this,"update");
-				texture=Ref<Texture>();
-			}
-		} break;
-		case NOTIFICATION_DRAW: {
-
-			if (texture.is_null())
-				return;
-
-			RID ci = get_canvas_item();
-
-			/*
-			texture->draw(ci,Point2());
-			break;
-			*/
-
-			Size2i s;
-			Rect2i src_rect;
-
-			s = texture->get_size();
-
-			src_rect.size=s;
-
-			Point2 ofs=offset;
-			if (centered)
-				ofs-=s/2;
-
-			if (OS::get_singleton()->get_use_pixel_snap()) {
-				ofs=ofs.floor();
-			}
-			Rect2 dst_rect(ofs,s);
-			texture->draw_rect_region(ci,dst_rect,src_rect,modulate);
-
-		} break;
-	}
-}
-
-void ViewportSprite::set_viewport_path(const NodePath& p_viewport) {
-
-	viewport_path=p_viewport;
-	update();
-	if (!is_inside_tree())
-		return;
-
-	if (texture.is_valid()) {
-		texture->disconnect("changed",this,"update");
-		texture=Ref<Texture>();
-	}
-
-	if (viewport_path.is_empty())
-		return;
-
-
-	Node *n = get_node(viewport_path);
-	ERR_FAIL_COND(!n);
-	Viewport *vp=Object::cast_to<Viewport>(n);
-	ERR_FAIL_COND(!vp);
-
-	Ref<RenderTargetTexture> rtt = vp->get_render_target_texture();
-	texture=rtt;
-
-	if (texture.is_valid()) {
-		texture->connect("changed",this,"update");
-	}
-
-	item_rect_changed();
-
-}
-
-NodePath ViewportSprite::get_viewport_path() const {
-
-	return viewport_path;
-}
-
-void ViewportSprite::set_centered(bool p_center) {
-
-	centered=p_center;
-	update();
-	item_rect_changed();
-}
-
-bool ViewportSprite::is_centered() const {
-
-	return centered;
-}
-
-void ViewportSprite::set_offset(const Point2& p_offset) {
-
-	offset=p_offset;
-	update();
-	item_rect_changed();
-}
-Point2 ViewportSprite::get_offset() const {
-
-	return offset;
-}
-void ViewportSprite::set_modulate(const Color& p_color) {
-
-	modulate=p_color;
-	update();
-}
-
-Color ViewportSprite::get_modulate() const{
-
-	return modulate;
-}
-
-
-Rect2 ViewportSprite::get_item_rect() const {
-
-	if (texture.is_null())
-		return Rect2(0,0,1,1);
-	/*
-	if (texture.is_null())
-		return CanvasItem::get_item_rect();
-	*/
-
-	Size2i s;
-
-	s = texture->get_size();
-	Point2 ofs=offset;
-	if (centered)
-		ofs-=s/2;
-
-	if (s==Size2(0,0))
-		s=Size2(1,1);
-
-	return Rect2(ofs,s);
-}
-
-String ViewportSprite::get_configuration_warning() const {
-
-	if (!has_node(viewport_path) || !Object::cast_to<Viewport>(get_node(viewport_path))) {
-		return TTR("Path property must point to a valid Viewport node to work. Such Viewport must be set to 'render target' mode.");
-	} else {
-
-		Node *n = get_node(viewport_path);
-		if (n) {
-			Viewport *vp = Object::cast_to<Viewport>(n);
-			if (!vp->is_set_as_render_target()) {
-
-				return TTR("The Viewport set in the path property must be set as 'render target' in order for this sprite to work.");
-			}
-		}
-	}
-
-	return String();
-
-}
-
-void ViewportSprite::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("set_viewport_path","path"),&ViewportSprite::set_viewport_path);
-	ClassDB::bind_method(D_METHOD("get_viewport_path"),&ViewportSprite::get_viewport_path);
-
-	ClassDB::bind_method(D_METHOD("set_centered","centered"),&ViewportSprite::set_centered);
-	ClassDB::bind_method(D_METHOD("is_centered"),&ViewportSprite::is_centered);
-
-	ClassDB::bind_method(D_METHOD("set_offset","offset"),&ViewportSprite::set_offset);
-	ClassDB::bind_method(D_METHOD("get_offset"),&ViewportSprite::get_offset);
-
-	ClassDB::bind_method(D_METHOD("set_modulate","modulate"),&ViewportSprite::set_modulate);
-	ClassDB::bind_method(D_METHOD("get_modulate"),&ViewportSprite::get_modulate);
-
-	ADD_PROPERTYNZ( PropertyInfo( Variant::NODE_PATH, "viewport"), "set_viewport_path","get_viewport_path");
-	ADD_PROPERTYNO( PropertyInfo( Variant::BOOL, "centered"), "set_centered","is_centered");
-	ADD_PROPERTYNZ( PropertyInfo( Variant::VECTOR2, "offset"), "set_offset","get_offset");
-	ADD_PROPERTYNO( PropertyInfo( Variant::COLOR, "modulate"), "set_modulate","get_modulate");
-
-}
-
-ViewportSprite::ViewportSprite() {
-
-	centered=true;
-	modulate=Color(1,1,1,1);
-}
-#endif

--- a/scene/2d/sprite.h
+++ b/scene/2d/sprite.h
@@ -62,9 +62,10 @@ protected:
 	virtual void _validate_property(PropertyInfo &property) const;
 
 public:
-	virtual void edit_set_pivot(const Point2 &p_pivot);
-	virtual Point2 edit_get_pivot() const;
-	virtual bool edit_has_pivot() const;
+	virtual void _edit_set_pivot(const Point2 &p_pivot);
+	virtual Point2 _edit_get_pivot() const;
+	virtual bool _edit_use_pivot() const;
+	virtual Rect2 _edit_get_rect() const;
 
 	void set_texture(const Ref<Texture> &p_texture);
 	Ref<Texture> get_texture() const;
@@ -102,53 +103,7 @@ public:
 	void set_hframes(int p_amount);
 	int get_hframes() const;
 
-	virtual Rect2 get_item_rect() const;
-
 	Sprite();
 };
 
-#if 0
-class ViewportSprite : public Node2D {
-
-	GDCLASS( ViewportSprite, Node2D );
-
-	Ref<Texture> texture;
-	NodePath viewport_path;
-
-	bool centered;
-	Point2 offset;
-	Color modulate;
-
-protected:
-
-	void _notification(int p_what);
-
-	static void _bind_methods();
-
-public:
-
-	virtual void edit_set_pivot(const Point2& p_pivot);
-	virtual Point2 edit_get_pivot() const;
-	virtual bool edit_has_pivot() const;
-
-	void set_viewport_path(const NodePath& p_viewport);
-	NodePath get_viewport_path() const;
-
-	void set_centered(bool p_center);
-	bool is_centered() const;
-
-	void set_offset(const Point2& p_offset);
-	Point2 get_offset() const;
-
-	void set_modulate(const Color& p_color);
-	Color get_modulate() const;
-
-	virtual Rect2 get_item_rect() const;
-
-	virtual String get_configuration_warning() const;
-
-	ViewportSprite();
-};
-
-#endif
 #endif // SPRITE_H

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -883,7 +883,7 @@ PoolVector<int> TileMap::_get_tile_data() const {
 	return data;
 }
 
-Rect2 TileMap::get_item_rect() const {
+Rect2 TileMap::_edit_get_rect() const {
 
 	const_cast<TileMap *>(this)->_update_dirty_quadrants();
 	return rect_cache;

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -229,7 +229,7 @@ public:
 	void set_cellv(const Vector2 &p_pos, int p_tile, bool p_flip_x = false, bool p_flip_y = false, bool p_transpose = false);
 	int get_cellv(const Vector2 &p_pos) const;
 
-	Rect2 get_item_rect() const;
+	Rect2 _edit_get_rect() const;
 
 	void set_collision_layer(uint32_t p_layer);
 	uint32_t get_collision_layer() const;

--- a/scene/2d/visibility_notifier_2d.cpp
+++ b/scene/2d/visibility_notifier_2d.cpp
@@ -83,7 +83,7 @@ void VisibilityNotifier2D::set_rect(const Rect2 &p_rect) {
 	_change_notify("rect");
 }
 
-Rect2 VisibilityNotifier2D::get_item_rect() const {
+Rect2 VisibilityNotifier2D::_edit_get_rect() const {
 
 	return rect;
 }

--- a/scene/2d/visibility_notifier_2d.h
+++ b/scene/2d/visibility_notifier_2d.h
@@ -54,12 +54,12 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual Rect2 _edit_get_rect() const;
+
 	void set_rect(const Rect2 &p_rect);
 	Rect2 get_rect() const;
 
 	bool is_on_screen() const;
-
-	virtual Rect2 get_item_rect() const;
 
 	VisibilityNotifier2D();
 };

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -271,10 +271,25 @@ public:
 
 	};
 
-	virtual Variant edit_get_state() const;
-	virtual void edit_set_state(const Variant &p_state);
-	virtual void edit_set_rect(const Rect2 &p_edit_rect);
-	virtual Size2 edit_get_minimum_size() const;
+	virtual Dictionary _edit_get_state() const;
+	virtual void _edit_set_state(const Dictionary &p_state);
+
+	virtual void _edit_set_position(const Point2 &p_position);
+	virtual Point2 _edit_get_position() const;
+
+	virtual void _edit_set_rect(const Rect2 &p_edit_rect);
+	virtual Rect2 _edit_get_rect() const;
+	virtual bool _edit_use_rect() const;
+
+	virtual void _edit_set_rotation(float p_rotation);
+	virtual float _edit_get_rotation() const;
+	virtual bool _edit_use_rotation() const;
+
+	virtual void _edit_set_pivot(const Point2 &p_pivot);
+	virtual Point2 _edit_get_pivot() const;
+	virtual bool _edit_use_pivot() const;
+
+	virtual Size2 _edit_get_minimum_size() const;
 
 	void accept_event();
 
@@ -427,7 +442,6 @@ public:
 	CursorShape get_default_cursor_shape() const;
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const;
 
-	virtual Rect2 get_item_rect() const;
 	virtual Transform2D get_transform() const;
 
 	bool is_toplevel_control() const;


### PR DESCRIPTION
Rework of the Editor/CanvasItem API, this is a first step before a refactoring of the canvas item editor code. That should allow a customization of the way the editor "Gizmos" impact each node.
For example, it could disable the rect drawn it for nodes that do not need to be scaled, disable the rotation, etc...