### PR TITLE
Allow underscores in GDScript numeric literals

### DIFF
--- a/modules/gdscript/gd_tokenizer.cpp
+++ b/modules/gdscript/gd_tokenizer.cpp
@@ -885,6 +885,9 @@ void GDTokenizerText::_advance() {
 								return;
 							}
 							sign_found = true;
+						} else if (GETCHAR(i) == '_') {
+							i++;
+							continue; // Included for readability, shouldn't be a part of the string
 						} else
 							break;
 
@@ -897,7 +900,7 @@ void GDTokenizerText::_advance() {
 						return;
 					}
 
-					INCPOS(str.length());
+					INCPOS(i);
 					if (hexa_found) {
 						int64_t val = str.hex_to_int64();
 						_make_constant(val);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -894,17 +894,18 @@ void TextEdit::_notification(int p_what) {
 							is_hex_notation = false;
 						}
 
-						// check for dot or 'x' for hex notation in floating point number
-						if ((str[j] == '.' || str[j] == 'x') && !in_word && prev_is_number && !is_number) {
+						// check for dot or underscore or 'x' for hex notation in floating point number
+						if ((str[j] == '.' || str[j] == 'x' || str[j] == '_') && !in_word && prev_is_number && !is_number) {
 							is_number = true;
 							is_symbol = false;
+							is_char = false;
 
 							if (str[j] == 'x' && str[j - 1] == '0') {
 								is_hex_notation = true;
 							}
 						}
 
-						if (!in_word && _is_char(str[j])) {
+						if (!in_word && _is_char(str[j]) && !is_number) {
 							in_word = true;
 						}
 


### PR DESCRIPTION
Closes #12928
Allows doing things like:
```gdscript
var x = 1_000_000
var y = 1_00_00_00
var z = 100_000_0
```