### PR TITLE
Facilitate documenting platform-exclusive classes

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -22,6 +22,7 @@ platform_flags = {}  # flags for each platform
 active_platforms = []
 active_platform_ids = []
 platform_exporters = []
+platform_apis = []
 global_defaults = []
 
 for x in glob.glob("platform/*"):
@@ -34,6 +35,8 @@ for x in glob.glob("platform/*"):
 
     if (os.path.exists(x + "/export/export.cpp")):
         platform_exporters.append(x[9:])
+    if (os.path.exists(x + "/api/api.cpp")):
+        platform_apis.append(x[9:])
     if (os.path.exists(x + "/globals/global_defaults.cpp")):
         global_defaults.append(x[9:])
     if (detect.is_active()):
@@ -215,6 +218,7 @@ env_base.Append(CPPPATH=['#core', '#core/math', '#editor', '#drivers', '#'])
 
 # configure ENV for platform
 env_base.platform_exporters = platform_exporters
+env_base.platform_apis = platform_apis
 
 """
 sys.path.append("./platform/"+env_base["platform"])
@@ -435,6 +439,7 @@ if selected_platform in platform_list:
     SConscript("editor/SCsub")
     SConscript("drivers/SCsub")
 
+    SConscript("platform/SCsub")
     SConscript("modules/SCsub")
     SConscript("main/SCsub")
 

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -44,6 +44,8 @@
 		<member name="JSON" type="JSON" setter="" getter="">
 			[JSON] singleton
 		</member>
+		<member name="JavaScript" type="JavaScript" setter="" getter="">
+		</member>
 		<member name="Marshalls" type="Reference" setter="" getter="">
 			[Marshalls] singleton
 		</member>

--- a/doc/classes/JavaScript.xml
+++ b/doc/classes/JavaScript.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="JavaScript" inherits="Object" category="Core" version="3.0-alpha">
+	<brief_description>
+		Singleton that connects the engine with the browser's JavaScript context in HTML5 export.
+	</brief_description>
+	<description>
+		The JavaScript singleton is implemented only in HTML5 export. It's used to access the browser's JavaScript context. This allows interaction with embedding pages or calling third-party JavaScript APIs.
+	</description>
+	<tutorials>
+		http://docs.godotengine.org/en/stable/learning/workflow/export/exporting_for_web.html#calling-javascript-from-script
+	</tutorials>
+	<demos>
+	</demos>
+	<methods>
+		<method name="eval">
+			<return type="Variant">
+			</return>
+			<argument index="0" name="code" type="String">
+			</argument>
+			<argument index="1" name="use_global_execution_context" type="bool" default="false">
+			</argument>
+			<description>
+				Execute the string [code]code[/code] as JavaScript code within the browser window. This is a call to the actual global JavaScript function [code]eval()[/code].
+				If [code]use_global_execution_context[/code] is [code]true[/code], the code will be evaluated in the global execution context. Otherwise, it is evaluated in the execution context of a function within the engine's runtime environment.
+			</description>
+		</method>
+	</methods>
+	<constants>
+	</constants>
+</class>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -35,6 +35,7 @@
 #include "message_queue.h"
 #include "modules/register_module_types.h"
 #include "os/os.h"
+#include "platform/register_platform_apis.h"
 #include "project_settings.h"
 #include "scene/register_scene_types.h"
 #include "script_debugger_local.h"
@@ -1108,6 +1109,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	MAIN_PRINT("Main: Load Modules, Physics, Drivers, Scripts");
 
+	register_platform_apis();
 	register_module_types();
 
 	initialize_physics();
@@ -1825,6 +1827,7 @@ void Main::cleanup() {
 
 	unregister_driver_types();
 	unregister_module_types();
+	unregister_platform_apis();
 	unregister_scene_types();
 	unregister_server_types();
 

--- a/platform/SCsub
+++ b/platform/SCsub
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+from compat import open_utf8
+
+Import('env')
+platform_sources = []
+
+# Register platform-exclusive APIs
+reg_apis_inc = '#include "register_platform_apis.h"\n'
+reg_apis = 'void register_platform_apis() {\n'
+unreg_apis = 'void unregister_platform_apis() {\n'
+for platform in env.platform_apis:
+    platform_dir = env.Dir(platform)
+    platform_sources.append(platform_dir.File('api/api.cpp'))
+    reg_apis += '\tregister_' + platform + '_api();\n'
+    unreg_apis += '\tunregister_' + platform + '_api();\n'
+    reg_apis_inc += '#include "' + platform + '/api/api.h"\n'
+reg_apis_inc += '\n'
+reg_apis += '}\n\n'
+unreg_apis += '}\n'
+f = open_utf8('register_platform_apis.gen.cpp', 'w')
+f.write(reg_apis_inc)
+f.write(reg_apis)
+f.write(unreg_apis)
+f.close()
+platform_sources.append('register_platform_apis.gen.cpp')
+
+env.Prepend(LIBS=env.Library('platform', platform_sources))
+
+Export('env')

--- a/platform/javascript/api/api.cpp
+++ b/platform/javascript/api/api.cpp
@@ -1,0 +1,73 @@
+/*************************************************************************/
+/*  api.cpp                                                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#include "api.h"
+#include "engine.h"
+#include "javascript_eval.h"
+
+static JavaScript *javascript_eval;
+
+void register_javascript_api() {
+
+	ClassDB::register_virtual_class<JavaScript>();
+	javascript_eval = memnew(JavaScript);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("JavaScript", javascript_eval));
+}
+
+void unregister_javascript_api() {
+
+	memdelete(javascript_eval);
+}
+
+JavaScript *JavaScript::singleton = NULL;
+
+JavaScript *JavaScript::get_singleton() {
+
+	return singleton;
+}
+
+JavaScript::JavaScript() {
+
+	ERR_FAIL_COND(singleton != NULL);
+	singleton = this;
+}
+
+JavaScript::~JavaScript() {}
+
+void JavaScript::_bind_methods() {
+
+	ClassDB::bind_method(D_METHOD("eval", "code", "use_global_execution_context"), &JavaScript::eval, DEFVAL(false));
+}
+
+#if !defined(JAVASCRIPT_ENABLED) || !defined(JAVASCRIPT_EVAL_ENABLED)
+Variant JavaScript::eval(const String &p_code, bool p_use_global_exec_context) {
+
+	return Variant();
+}
+#endif

--- a/platform/javascript/api/api.h
+++ b/platform/javascript/api/api.h
@@ -1,0 +1,31 @@
+/*************************************************************************/
+/*  api.h                                                                */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+void register_javascript_api();
+void unregister_javascript_api();

--- a/platform/javascript/api/javascript_eval.h
+++ b/platform/javascript/api/javascript_eval.h
@@ -1,0 +1,52 @@
+/*************************************************************************/
+/*  javascript_eval.h                                                    */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#ifndef JAVASCRIPT_EVAL_H
+#define JAVASCRIPT_EVAL_H
+
+#include "object.h"
+
+class JavaScript : public Object {
+private:
+	GDCLASS(JavaScript, Object);
+
+	static JavaScript *singleton;
+
+protected:
+	static void _bind_methods();
+
+public:
+	Variant eval(const String &p_code, bool p_use_global_exec_context = false);
+
+	static JavaScript *get_singleton();
+	JavaScript();
+	~JavaScript();
+};
+
+#endif // JAVASCRIPT_EVAL_H

--- a/platform/javascript/javascript_eval.cpp
+++ b/platform/javascript/javascript_eval.cpp
@@ -29,15 +29,8 @@
 /*************************************************************************/
 #ifdef JAVASCRIPT_EVAL_ENABLED
 
-#include "javascript_eval.h"
+#include "api/javascript_eval.h"
 #include "emscripten.h"
-
-JavaScript *JavaScript::singleton = NULL;
-
-JavaScript *JavaScript::get_singleton() {
-
-	return singleton;
-}
 
 extern "C" EMSCRIPTEN_KEEPALIVE uint8_t *resize_poolbytearray_and_open_write(PoolByteArray *p_arr, PoolByteArray::Write *r_write, int p_len) {
 
@@ -180,20 +173,6 @@ Variant JavaScript::eval(const String &p_code, bool p_use_global_exec_context) {
 			return arr;
 	}
 	return Variant();
-}
-
-void JavaScript::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("eval", "code", "use_global_execution_context"), &JavaScript::eval, false);
-}
-
-JavaScript::JavaScript() {
-
-	ERR_FAIL_COND(singleton != NULL);
-	singleton = this;
-}
-
-JavaScript::~JavaScript() {
 }
 
 #endif // JAVASCRIPT_EVAL_ENABLED

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -512,11 +512,6 @@ void OS_JavaScript::initialize(const VideoMode &p_desired, int p_video_driver, i
 #undef SET_EM_CALLBACK
 #undef EM_CHECK
 
-#ifdef JAVASCRIPT_EVAL_ENABLED
-	javascript_eval = memnew(JavaScript);
-	Engine::get_singleton()->add_singleton(Engine::Singleton("JavaScript", javascript_eval));
-#endif
-
 	visual_server->init();
 }
 

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -32,7 +32,6 @@
 
 #include "audio_driver_javascript.h"
 #include "drivers/unix/os_unix.h"
-#include "javascript_eval.h"
 #include "main/input_default.h"
 #include "os/input.h"
 #include "os/main_loop.h"
@@ -66,10 +65,6 @@ class OS_JavaScript : public OS_Unix {
 	GetDataDirFunc get_data_dir_func;
 
 	PowerJavascript *power_manager;
-
-#ifdef JAVASCRIPT_EVAL_ENABLED
-	JavaScript *javascript_eval;
-#endif
 
 	static void _close_notification_funcs(const String &p_file, int p_flags);
 

--- a/platform/register_platform_apis.h
+++ b/platform/register_platform_apis.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  javascript_eval.h                                                    */
+/*  register_platform_apis.h                                             */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -27,29 +27,10 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#ifdef JAVASCRIPT_EVAL_ENABLED
+#ifndef REGISTER_APIS_H
+#define REGISTER_APIS_H
 
-#ifndef JAVASCRIPT_EVAL_H
-#define JAVASCRIPT_EVAL_H
+void register_platform_apis();
+void unregister_platform_apis();
 
-#include "object.h"
-
-class JavaScript : public Object {
-private:
-	GDCLASS(JavaScript, Object);
-
-	static JavaScript *singleton;
-
-protected:
-	static void _bind_methods();
-
-public:
-	Variant eval(const String &p_code, bool p_use_global_exec_context = false);
-
-	static JavaScript *get_singleton();
-	JavaScript();
-	~JavaScript();
-};
-
-#endif // JAVASCRIPT_EVAL_H
-#endif // JAVASCRIPT_EVAL_ENABLED
+#endif


### PR DESCRIPTION
This allows generating documentation templates for plaform-exclusive APIs based on duplicate noop-definitions in an `api` directory per platform.

Definitions of platform-exclusive classes must be duplicated in `platform/<platform>/api/api.h` without implementation. This makes the classes available in the editor, which then allows dumping the doc templates per doctool.

Documentation for the `JavaScript` singleton in the HTML5 platform is included.


