### PR TITLE
GDScript: Refactor "GD" class prefix to "GDScript"

### DIFF
--- a/doc/classes/@GDScript.xml
+++ b/doc/classes/@GDScript.xml
@@ -1103,14 +1103,14 @@
 			</description>
 		</method>
 		<method name="yield">
-			<return type="GDFunctionState">
+			<return type="GDScriptFunctionState">
 			</return>
 			<argument index="0" name="object" type="Object">
 			</argument>
 			<argument index="1" name="signal" type="String">
 			</argument>
 			<description>
-				Stops the function execution and returns the current state. Call [method GDFunctionState.resume] on the state to resume execution. This invalidates the state.
+				Stops the function execution and returns the current state. Call [method GDScriptFunctionState.resume] on the state to resume execution. This invalidates the state.
 				Returns anything that was passed to the resume function call. If passed an object and a signal, the execution is resumed when the object's signal is emitted.
 			</description>
 		</method>

--- a/main/tests/test_gdscript.cpp
+++ b/main/tests/test_gdscript.cpp
@@ -35,10 +35,10 @@
 
 #ifdef GDSCRIPT_ENABLED
 
-#include "modules/gdscript/gd_compiler.h"
-#include "modules/gdscript/gd_parser.h"
-#include "modules/gdscript/gd_script.h"
-#include "modules/gdscript/gd_tokenizer.h"
+#include "modules/gdscript/gdscript.h"
+#include "modules/gdscript/gdscript_compiler.h"
+#include "modules/gdscript/gdscript_parser.h"
+#include "modules/gdscript/gdscript_tokenizer.h"
 
 namespace TestGDScript {
 
@@ -52,7 +52,7 @@ static void _print_indent(int p_ident, const String &p_text) {
 	print_line(txt + p_text);
 }
 
-static String _parser_extends(const GDParser::ClassNode *p_class) {
+static String _parser_extends(const GDScriptParser::ClassNode *p_class) {
 
 	String txt = "extends ";
 	if (String(p_class->extends_file) != "") {
@@ -72,29 +72,29 @@ static String _parser_extends(const GDParser::ClassNode *p_class) {
 	return txt;
 }
 
-static String _parser_expr(const GDParser::Node *p_expr) {
+static String _parser_expr(const GDScriptParser::Node *p_expr) {
 
 	String txt;
 	switch (p_expr->type) {
 
-		case GDParser::Node::TYPE_IDENTIFIER: {
+		case GDScriptParser::Node::TYPE_IDENTIFIER: {
 
-			const GDParser::IdentifierNode *id_node = static_cast<const GDParser::IdentifierNode *>(p_expr);
+			const GDScriptParser::IdentifierNode *id_node = static_cast<const GDScriptParser::IdentifierNode *>(p_expr);
 			txt = id_node->name;
 		} break;
-		case GDParser::Node::TYPE_CONSTANT: {
-			const GDParser::ConstantNode *c_node = static_cast<const GDParser::ConstantNode *>(p_expr);
+		case GDScriptParser::Node::TYPE_CONSTANT: {
+			const GDScriptParser::ConstantNode *c_node = static_cast<const GDScriptParser::ConstantNode *>(p_expr);
 			if (c_node->value.get_type() == Variant::STRING)
 				txt = "\"" + String(c_node->value) + "\"";
 			else
 				txt = c_node->value;
 
 		} break;
-		case GDParser::Node::TYPE_SELF: {
+		case GDScriptParser::Node::TYPE_SELF: {
 			txt = "self";
 		} break;
-		case GDParser::Node::TYPE_ARRAY: {
-			const GDParser::ArrayNode *arr_node = static_cast<const GDParser::ArrayNode *>(p_expr);
+		case GDScriptParser::Node::TYPE_ARRAY: {
+			const GDScriptParser::ArrayNode *arr_node = static_cast<const GDScriptParser::ArrayNode *>(p_expr);
 			txt += "[";
 			for (int i = 0; i < arr_node->elements.size(); i++) {
 
@@ -104,51 +104,51 @@ static String _parser_expr(const GDParser::Node *p_expr) {
 			}
 			txt += "]";
 		} break;
-		case GDParser::Node::TYPE_DICTIONARY: {
-			const GDParser::DictionaryNode *dict_node = static_cast<const GDParser::DictionaryNode *>(p_expr);
+		case GDScriptParser::Node::TYPE_DICTIONARY: {
+			const GDScriptParser::DictionaryNode *dict_node = static_cast<const GDScriptParser::DictionaryNode *>(p_expr);
 			txt += "{";
 			for (int i = 0; i < dict_node->elements.size(); i++) {
 
 				if (i > 0)
 					txt += ", ";
 
-				const GDParser::DictionaryNode::Pair &p = dict_node->elements[i];
+				const GDScriptParser::DictionaryNode::Pair &p = dict_node->elements[i];
 				txt += _parser_expr(p.key);
 				txt += ":";
 				txt += _parser_expr(p.value);
 			}
 			txt += "}";
 		} break;
-		case GDParser::Node::TYPE_OPERATOR: {
+		case GDScriptParser::Node::TYPE_OPERATOR: {
 
-			const GDParser::OperatorNode *c_node = static_cast<const GDParser::OperatorNode *>(p_expr);
+			const GDScriptParser::OperatorNode *c_node = static_cast<const GDScriptParser::OperatorNode *>(p_expr);
 			switch (c_node->op) {
 
-				case GDParser::OperatorNode::OP_PARENT_CALL:
+				case GDScriptParser::OperatorNode::OP_PARENT_CALL:
 					txt += ".";
-				case GDParser::OperatorNode::OP_CALL: {
+				case GDScriptParser::OperatorNode::OP_CALL: {
 
 					ERR_FAIL_COND_V(c_node->arguments.size() < 1, "");
 					String func_name;
-					const GDParser::Node *nfunc = c_node->arguments[0];
+					const GDScriptParser::Node *nfunc = c_node->arguments[0];
 					int arg_ofs = 0;
-					if (nfunc->type == GDParser::Node::TYPE_BUILT_IN_FUNCTION) {
+					if (nfunc->type == GDScriptParser::Node::TYPE_BUILT_IN_FUNCTION) {
 
-						const GDParser::BuiltInFunctionNode *bif_node = static_cast<const GDParser::BuiltInFunctionNode *>(nfunc);
-						func_name = GDFunctions::get_func_name(bif_node->function);
+						const GDScriptParser::BuiltInFunctionNode *bif_node = static_cast<const GDScriptParser::BuiltInFunctionNode *>(nfunc);
+						func_name = GDScriptFunctions::get_func_name(bif_node->function);
 						arg_ofs = 1;
-					} else if (nfunc->type == GDParser::Node::TYPE_TYPE) {
+					} else if (nfunc->type == GDScriptParser::Node::TYPE_TYPE) {
 
-						const GDParser::TypeNode *t_node = static_cast<const GDParser::TypeNode *>(nfunc);
+						const GDScriptParser::TypeNode *t_node = static_cast<const GDScriptParser::TypeNode *>(nfunc);
 						func_name = Variant::get_type_name(t_node->vtype);
 						arg_ofs = 1;
 					} else {
 
 						ERR_FAIL_COND_V(c_node->arguments.size() < 2, "");
 						nfunc = c_node->arguments[1];
-						ERR_FAIL_COND_V(nfunc->type != GDParser::Node::TYPE_IDENTIFIER, "");
+						ERR_FAIL_COND_V(nfunc->type != GDScriptParser::Node::TYPE_IDENTIFIER, "");
 
-						if (c_node->arguments[0]->type != GDParser::Node::TYPE_SELF)
+						if (c_node->arguments[0]->type != GDScriptParser::Node::TYPE_SELF)
 							func_name = _parser_expr(c_node->arguments[0]) + ".";
 
 						func_name += _parser_expr(nfunc);
@@ -159,7 +159,7 @@ static String _parser_expr(const GDParser::Node *p_expr) {
 
 					for (int i = arg_ofs; i < c_node->arguments.size(); i++) {
 
-						const GDParser::Node *arg = c_node->arguments[i];
+						const GDScriptParser::Node *arg = c_node->arguments[i];
 						if (i > arg_ofs)
 							txt += ", ";
 						txt += _parser_expr(arg);
@@ -168,7 +168,7 @@ static String _parser_expr(const GDParser::Node *p_expr) {
 					txt += ")";
 
 				} break;
-				case GDParser::OperatorNode::OP_INDEX: {
+				case GDScriptParser::OperatorNode::OP_INDEX: {
 
 					ERR_FAIL_COND_V(c_node->arguments.size() != 2, "");
 
@@ -176,125 +176,125 @@ static String _parser_expr(const GDParser::Node *p_expr) {
 					txt = _parser_expr(c_node->arguments[0]) + "[" + _parser_expr(c_node->arguments[1]) + "]";
 
 				} break;
-				case GDParser::OperatorNode::OP_INDEX_NAMED: {
+				case GDScriptParser::OperatorNode::OP_INDEX_NAMED: {
 
 					ERR_FAIL_COND_V(c_node->arguments.size() != 2, "");
 
 					txt = _parser_expr(c_node->arguments[0]) + "." + _parser_expr(c_node->arguments[1]);
 
 				} break;
-				case GDParser::OperatorNode::OP_NEG: {
+				case GDScriptParser::OperatorNode::OP_NEG: {
 					txt = "-" + _parser_expr(c_node->arguments[0]);
 				} break;
-				case GDParser::OperatorNode::OP_NOT: {
+				case GDScriptParser::OperatorNode::OP_NOT: {
 					txt = "not " + _parser_expr(c_node->arguments[0]);
 				} break;
-				case GDParser::OperatorNode::OP_BIT_INVERT: {
+				case GDScriptParser::OperatorNode::OP_BIT_INVERT: {
 					txt = "~" + _parser_expr(c_node->arguments[0]);
 				} break;
-				case GDParser::OperatorNode::OP_PREINC: {
+				case GDScriptParser::OperatorNode::OP_PREINC: {
 				} break;
-				case GDParser::OperatorNode::OP_PREDEC: {
+				case GDScriptParser::OperatorNode::OP_PREDEC: {
 				} break;
-				case GDParser::OperatorNode::OP_INC: {
+				case GDScriptParser::OperatorNode::OP_INC: {
 				} break;
-				case GDParser::OperatorNode::OP_DEC: {
+				case GDScriptParser::OperatorNode::OP_DEC: {
 				} break;
-				case GDParser::OperatorNode::OP_IN: {
+				case GDScriptParser::OperatorNode::OP_IN: {
 					txt = _parser_expr(c_node->arguments[0]) + " in " + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_EQUAL: {
+				case GDScriptParser::OperatorNode::OP_EQUAL: {
 					txt = _parser_expr(c_node->arguments[0]) + "==" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_NOT_EQUAL: {
+				case GDScriptParser::OperatorNode::OP_NOT_EQUAL: {
 					txt = _parser_expr(c_node->arguments[0]) + "!=" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_LESS: {
+				case GDScriptParser::OperatorNode::OP_LESS: {
 					txt = _parser_expr(c_node->arguments[0]) + "<" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_LESS_EQUAL: {
+				case GDScriptParser::OperatorNode::OP_LESS_EQUAL: {
 					txt = _parser_expr(c_node->arguments[0]) + "<=" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_GREATER: {
+				case GDScriptParser::OperatorNode::OP_GREATER: {
 					txt = _parser_expr(c_node->arguments[0]) + ">" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_GREATER_EQUAL: {
+				case GDScriptParser::OperatorNode::OP_GREATER_EQUAL: {
 					txt = _parser_expr(c_node->arguments[0]) + ">=" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_AND: {
+				case GDScriptParser::OperatorNode::OP_AND: {
 					txt = _parser_expr(c_node->arguments[0]) + " and " + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_OR: {
+				case GDScriptParser::OperatorNode::OP_OR: {
 					txt = _parser_expr(c_node->arguments[0]) + " or " + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_ADD: {
+				case GDScriptParser::OperatorNode::OP_ADD: {
 					txt = _parser_expr(c_node->arguments[0]) + "+" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_SUB: {
+				case GDScriptParser::OperatorNode::OP_SUB: {
 					txt = _parser_expr(c_node->arguments[0]) + "-" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_MUL: {
+				case GDScriptParser::OperatorNode::OP_MUL: {
 					txt = _parser_expr(c_node->arguments[0]) + "*" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_DIV: {
+				case GDScriptParser::OperatorNode::OP_DIV: {
 					txt = _parser_expr(c_node->arguments[0]) + "/" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_MOD: {
+				case GDScriptParser::OperatorNode::OP_MOD: {
 					txt = _parser_expr(c_node->arguments[0]) + "%" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_SHIFT_LEFT: {
+				case GDScriptParser::OperatorNode::OP_SHIFT_LEFT: {
 					txt = _parser_expr(c_node->arguments[0]) + "<<" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_SHIFT_RIGHT: {
+				case GDScriptParser::OperatorNode::OP_SHIFT_RIGHT: {
 					txt = _parser_expr(c_node->arguments[0]) + ">>" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_ASSIGN: {
+				case GDScriptParser::OperatorNode::OP_ASSIGN: {
 					txt = _parser_expr(c_node->arguments[0]) + "=" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_ASSIGN_ADD: {
+				case GDScriptParser::OperatorNode::OP_ASSIGN_ADD: {
 					txt = _parser_expr(c_node->arguments[0]) + "+=" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_ASSIGN_SUB: {
+				case GDScriptParser::OperatorNode::OP_ASSIGN_SUB: {
 					txt = _parser_expr(c_node->arguments[0]) + "-=" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_ASSIGN_MUL: {
+				case GDScriptParser::OperatorNode::OP_ASSIGN_MUL: {
 					txt = _parser_expr(c_node->arguments[0]) + "*=" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_ASSIGN_DIV: {
+				case GDScriptParser::OperatorNode::OP_ASSIGN_DIV: {
 					txt = _parser_expr(c_node->arguments[0]) + "/=" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_ASSIGN_MOD: {
+				case GDScriptParser::OperatorNode::OP_ASSIGN_MOD: {
 					txt = _parser_expr(c_node->arguments[0]) + "%=" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_ASSIGN_SHIFT_LEFT: {
+				case GDScriptParser::OperatorNode::OP_ASSIGN_SHIFT_LEFT: {
 					txt = _parser_expr(c_node->arguments[0]) + "<<=" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_ASSIGN_SHIFT_RIGHT: {
+				case GDScriptParser::OperatorNode::OP_ASSIGN_SHIFT_RIGHT: {
 					txt = _parser_expr(c_node->arguments[0]) + ">>=" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_ASSIGN_BIT_AND: {
+				case GDScriptParser::OperatorNode::OP_ASSIGN_BIT_AND: {
 					txt = _parser_expr(c_node->arguments[0]) + "&=" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_ASSIGN_BIT_OR: {
+				case GDScriptParser::OperatorNode::OP_ASSIGN_BIT_OR: {
 					txt = _parser_expr(c_node->arguments[0]) + "|=" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_ASSIGN_BIT_XOR: {
+				case GDScriptParser::OperatorNode::OP_ASSIGN_BIT_XOR: {
 					txt = _parser_expr(c_node->arguments[0]) + "^=" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_BIT_AND: {
+				case GDScriptParser::OperatorNode::OP_BIT_AND: {
 					txt = _parser_expr(c_node->arguments[0]) + "&" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_BIT_OR: {
+				case GDScriptParser::OperatorNode::OP_BIT_OR: {
 					txt = _parser_expr(c_node->arguments[0]) + "|" + _parser_expr(c_node->arguments[1]);
 				} break;
-				case GDParser::OperatorNode::OP_BIT_XOR: {
+				case GDScriptParser::OperatorNode::OP_BIT_XOR: {
 					txt = _parser_expr(c_node->arguments[0]) + "^" + _parser_expr(c_node->arguments[1]);
 				} break;
 				default: {}
 			}
 
 		} break;
-		case GDParser::Node::TYPE_NEWLINE: {
+		case GDScriptParser::Node::TYPE_NEWLINE: {
 
 			//skippie
 		} break;
@@ -310,20 +310,20 @@ static String _parser_expr(const GDParser::Node *p_expr) {
 	//return "("+txt+")";
 }
 
-static void _parser_show_block(const GDParser::BlockNode *p_block, int p_indent) {
+static void _parser_show_block(const GDScriptParser::BlockNode *p_block, int p_indent) {
 
 	for (int i = 0; i < p_block->statements.size(); i++) {
 
-		const GDParser::Node *statement = p_block->statements[i];
+		const GDScriptParser::Node *statement = p_block->statements[i];
 
 		switch (statement->type) {
 
-			case GDParser::Node::TYPE_CONTROL_FLOW: {
+			case GDScriptParser::Node::TYPE_CONTROL_FLOW: {
 
-				const GDParser::ControlFlowNode *cf_node = static_cast<const GDParser::ControlFlowNode *>(statement);
+				const GDScriptParser::ControlFlowNode *cf_node = static_cast<const GDScriptParser::ControlFlowNode *>(statement);
 				switch (cf_node->cf_type) {
 
-					case GDParser::ControlFlowNode::CF_IF: {
+					case GDScriptParser::ControlFlowNode::CF_IF: {
 
 						ERR_FAIL_COND(cf_node->arguments.size() != 1);
 						String txt;
@@ -339,7 +339,7 @@ static void _parser_show_block(const GDParser::BlockNode *p_block, int p_indent)
 						}
 
 					} break;
-					case GDParser::ControlFlowNode::CF_FOR: {
+					case GDScriptParser::ControlFlowNode::CF_FOR: {
 						ERR_FAIL_COND(cf_node->arguments.size() != 2);
 						String txt;
 						txt += "for ";
@@ -352,7 +352,7 @@ static void _parser_show_block(const GDParser::BlockNode *p_block, int p_indent)
 						_parser_show_block(cf_node->body, p_indent + 1);
 
 					} break;
-					case GDParser::ControlFlowNode::CF_WHILE: {
+					case GDScriptParser::ControlFlowNode::CF_WHILE: {
 
 						ERR_FAIL_COND(cf_node->arguments.size() != 1);
 						String txt;
@@ -364,18 +364,18 @@ static void _parser_show_block(const GDParser::BlockNode *p_block, int p_indent)
 						_parser_show_block(cf_node->body, p_indent + 1);
 
 					} break;
-					case GDParser::ControlFlowNode::CF_SWITCH: {
+					case GDScriptParser::ControlFlowNode::CF_SWITCH: {
 
 					} break;
-					case GDParser::ControlFlowNode::CF_CONTINUE: {
+					case GDScriptParser::ControlFlowNode::CF_CONTINUE: {
 
 						_print_indent(p_indent, "continue");
 					} break;
-					case GDParser::ControlFlowNode::CF_BREAK: {
+					case GDScriptParser::ControlFlowNode::CF_BREAK: {
 
 						_print_indent(p_indent, "break");
 					} break;
-					case GDParser::ControlFlowNode::CF_RETURN: {
+					case GDScriptParser::ControlFlowNode::CF_RETURN: {
 
 						if (cf_node->arguments.size())
 							_print_indent(p_indent, "return " + _parser_expr(cf_node->arguments[0]));
@@ -385,9 +385,9 @@ static void _parser_show_block(const GDParser::BlockNode *p_block, int p_indent)
 				}
 
 			} break;
-			case GDParser::Node::TYPE_LOCAL_VAR: {
+			case GDScriptParser::Node::TYPE_LOCAL_VAR: {
 
-				const GDParser::LocalVarNode *lv_node = static_cast<const GDParser::LocalVarNode *>(statement);
+				const GDScriptParser::LocalVarNode *lv_node = static_cast<const GDScriptParser::LocalVarNode *>(statement);
 				_print_indent(p_indent, "var " + String(lv_node->name));
 			} break;
 			default: {
@@ -398,7 +398,7 @@ static void _parser_show_block(const GDParser::BlockNode *p_block, int p_indent)
 	}
 }
 
-static void _parser_show_function(const GDParser::FunctionNode *p_func, int p_indent, GDParser::BlockNode *p_initializer = NULL) {
+static void _parser_show_function(const GDScriptParser::FunctionNode *p_func, int p_indent, GDScriptParser::BlockNode *p_initializer = NULL) {
 
 	String txt;
 	if (p_func->_static)
@@ -434,7 +434,7 @@ static void _parser_show_function(const GDParser::FunctionNode *p_func, int p_in
 	_parser_show_block(p_func->body, p_indent + 1);
 }
 
-static void _parser_show_class(const GDParser::ClassNode *p_class, int p_indent, const Vector<String> &p_code) {
+static void _parser_show_class(const GDScriptParser::ClassNode *p_class, int p_indent, const Vector<String> &p_code) {
 
 	if (p_indent == 0 && (String(p_class->extends_file) != "" || p_class->extends_class.size())) {
 
@@ -444,7 +444,7 @@ static void _parser_show_class(const GDParser::ClassNode *p_class, int p_indent,
 
 	for (int i = 0; i < p_class->subclasses.size(); i++) {
 
-		const GDParser::ClassNode *subclass = p_class->subclasses[i];
+		const GDScriptParser::ClassNode *subclass = p_class->subclasses[i];
 		String line = "class " + subclass->name;
 		if (String(subclass->extends_file) != "" || subclass->extends_class.size())
 			line += " " + _parser_extends(subclass);
@@ -456,13 +456,13 @@ static void _parser_show_class(const GDParser::ClassNode *p_class, int p_indent,
 
 	for (int i = 0; i < p_class->constant_expressions.size(); i++) {
 
-		const GDParser::ClassNode::Constant &constant = p_class->constant_expressions[i];
+		const GDScriptParser::ClassNode::Constant &constant = p_class->constant_expressions[i];
 		_print_indent(p_indent, "const " + String(constant.identifier) + "=" + _parser_expr(constant.expression));
 	}
 
 	for (int i = 0; i < p_class->variables.size(); i++) {
 
-		const GDParser::ClassNode::Member &m = p_class->variables[i];
+		const GDScriptParser::ClassNode::Member &m = p_class->variables[i];
 
 		_print_indent(p_indent, "var " + String(m.identifier));
 	}
@@ -487,27 +487,27 @@ static void _parser_show_class(const GDParser::ClassNode *p_class, int p_indent,
 	print_line("\n");
 }
 
-static String _disassemble_addr(const Ref<GDScript> &p_script, const GDFunction &func, int p_addr) {
+static String _disassemble_addr(const Ref<GDScript> &p_script, const GDScriptFunction &func, int p_addr) {
 
-	int addr = p_addr & GDFunction::ADDR_MASK;
+	int addr = p_addr & GDScriptFunction::ADDR_MASK;
 
-	switch (p_addr >> GDFunction::ADDR_BITS) {
+	switch (p_addr >> GDScriptFunction::ADDR_BITS) {
 
-		case GDFunction::ADDR_TYPE_SELF: {
+		case GDScriptFunction::ADDR_TYPE_SELF: {
 			return "self";
 		} break;
-		case GDFunction::ADDR_TYPE_CLASS: {
+		case GDScriptFunction::ADDR_TYPE_CLASS: {
 			return "class";
 		} break;
-		case GDFunction::ADDR_TYPE_MEMBER: {
+		case GDScriptFunction::ADDR_TYPE_MEMBER: {
 
 			return "member(" + p_script->debug_get_member_by_index(addr) + ")";
 		} break;
-		case GDFunction::ADDR_TYPE_CLASS_CONSTANT: {
+		case GDScriptFunction::ADDR_TYPE_CLASS_CONSTANT: {
 
 			return "class_const(" + func.get_global_name(addr) + ")";
 		} break;
-		case GDFunction::ADDR_TYPE_LOCAL_CONSTANT: {
+		case GDScriptFunction::ADDR_TYPE_LOCAL_CONSTANT: {
 
 			Variant v = func.get_constant(addr);
 			String txt;
@@ -517,19 +517,19 @@ static String _disassemble_addr(const Ref<GDScript> &p_script, const GDFunction 
 				txt = v;
 			return "const(" + txt + ")";
 		} break;
-		case GDFunction::ADDR_TYPE_STACK: {
+		case GDScriptFunction::ADDR_TYPE_STACK: {
 
 			return "stack(" + itos(addr) + ")";
 		} break;
-		case GDFunction::ADDR_TYPE_STACK_VARIABLE: {
+		case GDScriptFunction::ADDR_TYPE_STACK_VARIABLE: {
 
 			return "var_stack(" + itos(addr) + ")";
 		} break;
-		case GDFunction::ADDR_TYPE_GLOBAL: {
+		case GDScriptFunction::ADDR_TYPE_GLOBAL: {
 
 			return "global(" + func.get_global_name(addr) + ")";
 		} break;
-		case GDFunction::ADDR_TYPE_NIL: {
+		case GDScriptFunction::ADDR_TYPE_NIL: {
 			return "nil";
 		} break;
 	}
@@ -539,11 +539,11 @@ static String _disassemble_addr(const Ref<GDScript> &p_script, const GDFunction 
 
 static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String> &p_code) {
 
-	const Map<StringName, GDFunction *> &mf = p_class->debug_get_member_functions();
+	const Map<StringName, GDScriptFunction *> &mf = p_class->debug_get_member_functions();
 
-	for (const Map<StringName, GDFunction *>::Element *E = mf.front(); E; E = E->next()) {
+	for (const Map<StringName, GDScriptFunction *>::Element *E = mf.front(); E; E = E->next()) {
 
-		const GDFunction &func = *E->get();
+		const GDScriptFunction &func = *E->get();
 		const int *code = func.get_code();
 		int codelen = func.get_code_size();
 		String defargs;
@@ -568,7 +568,7 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 
 			switch (code[ip]) {
 
-				case GDFunction::OPCODE_OPERATOR: {
+				case GDScriptFunction::OPCODE_OPERATOR: {
 
 					int op = code[ip + 1];
 					txt += "op ";
@@ -583,7 +583,7 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 					incr += 5;
 
 				} break;
-				case GDFunction::OPCODE_SET: {
+				case GDScriptFunction::OPCODE_SET: {
 
 					txt += "set ";
 					txt += DADDR(1);
@@ -594,7 +594,7 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 					incr += 4;
 
 				} break;
-				case GDFunction::OPCODE_GET: {
+				case GDScriptFunction::OPCODE_GET: {
 
 					txt += " get ";
 					txt += DADDR(3);
@@ -606,7 +606,7 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 					incr += 4;
 
 				} break;
-				case GDFunction::OPCODE_SET_NAMED: {
+				case GDScriptFunction::OPCODE_SET_NAMED: {
 
 					txt += " set_named ";
 					txt += DADDR(1);
@@ -617,7 +617,7 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 					incr += 4;
 
 				} break;
-				case GDFunction::OPCODE_GET_NAMED: {
+				case GDScriptFunction::OPCODE_GET_NAMED: {
 
 					txt += " get_named ";
 					txt += DADDR(3);
@@ -629,7 +629,7 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 					incr += 4;
 
 				} break;
-				case GDFunction::OPCODE_SET_MEMBER: {
+				case GDScriptFunction::OPCODE_SET_MEMBER: {
 
 					txt += " set_member ";
 					txt += "[\"";
@@ -639,7 +639,7 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 					incr += 3;
 
 				} break;
-				case GDFunction::OPCODE_GET_MEMBER: {
+				case GDScriptFunction::OPCODE_GET_MEMBER: {
 
 					txt += " get_member ";
 					txt += DADDR(2);
@@ -650,7 +650,7 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 					incr += 3;
 
 				} break;
-				case GDFunction::OPCODE_ASSIGN: {
+				case GDScriptFunction::OPCODE_ASSIGN: {
 
 					txt += " assign ";
 					txt += DADDR(1);
@@ -659,7 +659,7 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 					incr += 3;
 
 				} break;
-				case GDFunction::OPCODE_ASSIGN_TRUE: {
+				case GDScriptFunction::OPCODE_ASSIGN_TRUE: {
 
 					txt += " assign ";
 					txt += DADDR(1);
@@ -667,7 +667,7 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 					incr += 2;
 
 				} break;
-				case GDFunction::OPCODE_ASSIGN_FALSE: {
+				case GDScriptFunction::OPCODE_ASSIGN_FALSE: {
 
 					txt += " assign ";
 					txt += DADDR(1);
@@ -675,7 +675,7 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 					incr += 2;
 
 				} break;
-				case GDFunction::OPCODE_CONSTRUCT: {
+				case GDScriptFunction::OPCODE_CONSTRUCT: {
 
 					Variant::Type t = Variant::Type(code[ip + 1]);
 					int argc = code[ip + 2];
@@ -696,7 +696,7 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 					incr = 4 + argc;
 
 				} break;
-				case GDFunction::OPCODE_CONSTRUCT_ARRAY: {
+				case GDScriptFunction::OPCODE_CONSTRUCT_ARRAY: {
 
 					int argc = code[ip + 1];
 					txt += " make_array ";
@@ -714,7 +714,7 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 					incr += 3 + argc;
 
 				} break;
-				case GDFunction::OPCODE_CONSTRUCT_DICTIONARY: {
+				case GDScriptFunction::OPCODE_CONSTRUCT_DICTIONARY: {
 
 					int argc = code[ip + 1];
 					txt += " make_dict ";
@@ -735,10 +735,10 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 
 				} break;
 
-				case GDFunction::OPCODE_CALL:
-				case GDFunction::OPCODE_CALL_RETURN: {
+				case GDScriptFunction::OPCODE_CALL:
+				case GDScriptFunction::OPCODE_CALL_RETURN: {
 
-					bool ret = code[ip] == GDFunction::OPCODE_CALL_RETURN;
+					bool ret = code[ip] == GDScriptFunction::OPCODE_CALL_RETURN;
 
 					if (ret)
 						txt += " call-ret ";
@@ -764,14 +764,14 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 					incr = 5 + argc;
 
 				} break;
-				case GDFunction::OPCODE_CALL_BUILT_IN: {
+				case GDScriptFunction::OPCODE_CALL_BUILT_IN: {
 
 					txt += " call-built-in ";
 
 					int argc = code[ip + 2];
 					txt += DADDR(3 + argc) + "=";
 
-					txt += GDFunctions::get_func_name(GDFunctions::Function(code[ip + 1]));
+					txt += GDScriptFunctions::get_func_name(GDScriptFunctions::Function(code[ip + 1]));
 					txt += "(";
 
 					for (int i = 0; i < argc; i++) {
@@ -784,7 +784,7 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 					incr = 4 + argc;
 
 				} break;
-				case GDFunction::OPCODE_CALL_SELF_BASE: {
+				case GDScriptFunction::OPCODE_CALL_SELF_BASE: {
 
 					txt += " call-self-base ";
 
@@ -804,13 +804,13 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 					incr = 4 + argc;
 
 				} break;
-				case GDFunction::OPCODE_YIELD: {
+				case GDScriptFunction::OPCODE_YIELD: {
 
 					txt += " yield ";
 					incr = 1;
 
 				} break;
-				case GDFunction::OPCODE_YIELD_SIGNAL: {
+				case GDScriptFunction::OPCODE_YIELD_SIGNAL: {
 
 					txt += " yield_signal ";
 					txt += DADDR(1);
@@ -818,13 +818,13 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 					txt += DADDR(2);
 					incr = 3;
 				} break;
-				case GDFunction::OPCODE_YIELD_RESUME: {
+				case GDScriptFunction::OPCODE_YIELD_RESUME: {
 
 					txt += " yield resume: ";
 					txt += DADDR(1);
 					incr = 2;
 				} break;
-				case GDFunction::OPCODE_JUMP: {
+				case GDScriptFunction::OPCODE_JUMP: {
 
 					txt += " jump ";
 					txt += itos(code[ip + 1]);
@@ -832,7 +832,7 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 					incr = 2;
 
 				} break;
-				case GDFunction::OPCODE_JUMP_IF: {
+				case GDScriptFunction::OPCODE_JUMP_IF: {
 
 					txt += " jump-if ";
 					txt += DADDR(1);
@@ -841,7 +841,7 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 
 					incr = 3;
 				} break;
-				case GDFunction::OPCODE_JUMP_IF_NOT: {
+				case GDScriptFunction::OPCODE_JUMP_IF_NOT: {
 
 					txt += " jump-if-not ";
 					txt += DADDR(1);
@@ -850,12 +850,12 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 
 					incr = 3;
 				} break;
-				case GDFunction::OPCODE_JUMP_TO_DEF_ARGUMENT: {
+				case GDScriptFunction::OPCODE_JUMP_TO_DEF_ARGUMENT: {
 
 					txt += " jump-to-default-argument ";
 					incr = 1;
 				} break;
-				case GDFunction::OPCODE_RETURN: {
+				case GDScriptFunction::OPCODE_RETURN: {
 
 					txt += " return ";
 					txt += DADDR(1);
@@ -863,19 +863,19 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 					incr = 2;
 
 				} break;
-				case GDFunction::OPCODE_ITERATE_BEGIN: {
+				case GDScriptFunction::OPCODE_ITERATE_BEGIN: {
 
 					txt += " for-init " + DADDR(4) + " in " + DADDR(2) + " counter " + DADDR(1) + " end " + itos(code[ip + 3]);
 					incr += 5;
 
 				} break;
-				case GDFunction::OPCODE_ITERATE: {
+				case GDScriptFunction::OPCODE_ITERATE: {
 
 					txt += " for-loop " + DADDR(4) + " in " + DADDR(2) + " counter " + DADDR(1) + " end " + itos(code[ip + 3]);
 					incr += 5;
 
 				} break;
-				case GDFunction::OPCODE_LINE: {
+				case GDScriptFunction::OPCODE_LINE: {
 
 					int line = code[ip + 1] - 1;
 					if (line >= 0 && line < p_code.size())
@@ -884,12 +884,12 @@ static void _disassemble_class(const Ref<GDScript> &p_class, const Vector<String
 						txt = "";
 					incr += 2;
 				} break;
-				case GDFunction::OPCODE_END: {
+				case GDScriptFunction::OPCODE_END: {
 
 					txt += " end";
 					incr += 1;
 				} break;
-				case GDFunction::OPCODE_ASSERT: {
+				case GDScriptFunction::OPCODE_ASSERT: {
 
 					txt += " assert ";
 					txt += DADDR(1);
@@ -952,15 +952,15 @@ MainLoop *test(TestType p_type) {
 
 	if (p_type == TEST_TOKENIZER) {
 
-		GDTokenizerText tk;
+		GDScriptTokenizerText tk;
 		tk.set_code(code);
 		int line = -1;
-		while (tk.get_token() != GDTokenizer::TK_EOF) {
+		while (tk.get_token() != GDScriptTokenizer::TK_EOF) {
 
 			String text;
-			if (tk.get_token() == GDTokenizer::TK_IDENTIFIER)
+			if (tk.get_token() == GDScriptTokenizer::TK_IDENTIFIER)
 				text = "'" + tk.get_token_identifier() + "' (identifier)";
-			else if (tk.get_token() == GDTokenizer::TK_CONSTANT) {
+			else if (tk.get_token() == GDScriptTokenizer::TK_CONSTANT) {
 				Variant c = tk.get_token_constant();
 				if (c.get_type() == Variant::STRING)
 					text = "\"" + String(c) + "\"";
@@ -968,12 +968,12 @@ MainLoop *test(TestType p_type) {
 					text = c;
 
 				text = text + " (" + Variant::get_type_name(c.get_type()) + " constant)";
-			} else if (tk.get_token() == GDTokenizer::TK_ERROR)
+			} else if (tk.get_token() == GDScriptTokenizer::TK_ERROR)
 				text = "ERROR: " + tk.get_token_error();
-			else if (tk.get_token() == GDTokenizer::TK_NEWLINE)
+			else if (tk.get_token() == GDScriptTokenizer::TK_NEWLINE)
 				text = "newline (" + itos(tk.get_token_line()) + ") + indent: " + itos(tk.get_token_line_indent());
-			else if (tk.get_token() == GDTokenizer::TK_BUILT_IN_FUNC)
-				text = "'" + String(GDFunctions::get_func_name(tk.get_token_built_in_func())) + "' (built-in function)";
+			else if (tk.get_token() == GDScriptTokenizer::TK_BUILT_IN_FUNC)
+				text = "'" + String(GDScriptFunctions::get_func_name(tk.get_token_built_in_func())) + "' (built-in function)";
 			else
 				text = tk.get_token_name(tk.get_token());
 
@@ -995,7 +995,7 @@ MainLoop *test(TestType p_type) {
 
 	if (p_type == TEST_PARSER) {
 
-		GDParser parser;
+		GDScriptParser parser;
 		Error err = parser.parse(code);
 		if (err) {
 			print_line("Parse Error:\n" + itos(parser.get_error_line()) + ":" + itos(parser.get_error_column()) + ":" + parser.get_error());
@@ -1003,16 +1003,16 @@ MainLoop *test(TestType p_type) {
 			return NULL;
 		}
 
-		const GDParser::Node *root = parser.get_parse_tree();
-		ERR_FAIL_COND_V(root->type != GDParser::Node::TYPE_CLASS, NULL);
-		const GDParser::ClassNode *cnode = static_cast<const GDParser::ClassNode *>(root);
+		const GDScriptParser::Node *root = parser.get_parse_tree();
+		ERR_FAIL_COND_V(root->type != GDScriptParser::Node::TYPE_CLASS, NULL);
+		const GDScriptParser::ClassNode *cnode = static_cast<const GDScriptParser::ClassNode *>(root);
 
 		_parser_show_class(cnode, 0, lines);
 	}
 
 	if (p_type == TEST_COMPILER) {
 
-		GDParser parser;
+		GDScriptParser parser;
 
 		Error err = parser.parse(code);
 		if (err) {
@@ -1023,7 +1023,7 @@ MainLoop *test(TestType p_type) {
 
 		GDScript *script = memnew(GDScript);
 
-		GDCompiler gdc;
+		GDScriptCompiler gdc;
 		err = gdc.compile(&parser, script);
 		if (err) {
 
@@ -1046,7 +1046,7 @@ MainLoop *test(TestType p_type) {
 
 	} else if (p_type == TEST_BYTECODE) {
 
-		Vector<uint8_t> buf = GDTokenizerBuffer::parse_code_string(code);
+		Vector<uint8_t> buf = GDScriptTokenizerBuffer::parse_code_string(code);
 		String dst = test.get_basename() + ".gdc";
 		FileAccess *fw = FileAccess::open(dst, FileAccess::WRITE);
 		fw->store_buffer(buf.ptr(), buf.size());

--- a/modules/gdscript/config.py
+++ b/modules/gdscript/config.py
@@ -6,9 +6,9 @@ def configure(env):
 
 def get_doc_classes():
     return [
-        "GDFunctionState",
-        "GDNativeClass",
         "GDScript",
+        "GDScriptFunctionState",
+        "GDScriptNativeClass",
     ]
 
 def get_doc_path():

--- a/modules/gdscript/doc_classes/GDScriptFunctionState.xml
+++ b/modules/gdscript/doc_classes/GDScriptFunctionState.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="GDFunctionState" inherits="Reference" category="Core" version="3.0-alpha">
+<class name="GDScriptFunctionState" inherits="Reference" category="Core" version="3.0-alpha">
 	<brief_description>
 		State of a function call after yielding.
 	</brief_description>
@@ -18,7 +18,7 @@
 			</argument>
 			<description>
 				Check whether the function call may be resumed. This is not the case if the function state was already resumed.
-				If [code]extended_check[/code] is enabled, it also checks if the associated script and object still exist. The extended check is done in debug mode as part of [method GDFunctionState.resume], but you can use this if you know you may be trying to resume without knowing for sure the object and/or script have survived up to that point.
+				If [code]extended_check[/code] is enabled, it also checks if the associated script and object still exist. The extended check is done in debug mode as part of [method GDScriptFunctionState.resume], but you can use this if you know you may be trying to resume without knowing for sure the object and/or script have survived up to that point.
 			</description>
 		</method>
 		<method name="resume">

--- a/modules/gdscript/doc_classes/GDScriptNativeClass.xml
+++ b/modules/gdscript/doc_classes/GDScriptNativeClass.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="GDNativeClass" inherits="Reference" category="Core" version="3.0-alpha">
+<class name="GDScriptNativeClass" inherits="Reference" category="Core" version="3.0-alpha">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  gd_script.h                                                          */
+/*  gdscript.h                                                           */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -27,16 +27,17 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#ifndef GD_SCRIPT_H
-#define GD_SCRIPT_H
+#ifndef GDSCRIPT_H
+#define GDSCRIPT_H
 
-#include "gd_function.h"
+#include "gdscript_function.h"
 #include "io/resource_loader.h"
 #include "io/resource_saver.h"
 #include "script_language.h"
-class GDNativeClass : public Reference {
 
-	GDCLASS(GDNativeClass, Reference);
+class GDScriptNativeClass : public Reference {
+
+	GDCLASS(GDScriptNativeClass, Reference);
 
 	StringName name;
 
@@ -48,7 +49,7 @@ public:
 	_FORCE_INLINE_ const StringName &get_name() const { return name; }
 	Variant _new();
 	Object *instance();
-	GDNativeClass(const StringName &p_name);
+	GDScriptNativeClass(const StringName &p_name);
 };
 
 class GDScript : public Script {
@@ -64,21 +65,21 @@ class GDScript : public Script {
 		ScriptInstance::RPCMode rpc_mode;
 	};
 
-	friend class GDInstance;
-	friend class GDFunction;
-	friend class GDCompiler;
-	friend class GDFunctions;
+	friend class GDScriptInstance;
+	friend class GDScriptFunction;
+	friend class GDScriptCompiler;
+	friend class GDScriptFunctions;
 	friend class GDScriptLanguage;
 
 	Variant _static_ref; //used for static call
-	Ref<GDNativeClass> native;
+	Ref<GDScriptNativeClass> native;
 	Ref<GDScript> base;
 	GDScript *_base; //fast pointer access
 	GDScript *_owner; //for subclasses
 
 	Set<StringName> members; //members are just indices to the instanced script.
 	Map<StringName, Variant> constants;
-	Map<StringName, GDFunction *> member_functions;
+	Map<StringName, GDScriptFunction *> member_functions;
 	Map<StringName, MemberInfo> member_indices; //members are just indices to the instanced script.
 	Map<StringName, Ref<GDScript> > subclasses;
 	Map<StringName, Vector<StringName> > _signals;
@@ -99,7 +100,7 @@ class GDScript : public Script {
 #endif
 	Map<StringName, PropertyInfo> member_info;
 
-	GDFunction *initializer; //direct pointer to _init , faster to locate
+	GDScriptFunction *initializer; //direct pointer to _init , faster to locate
 
 	int subclass_count;
 	Set<Object *> instances;
@@ -109,7 +110,7 @@ class GDScript : public Script {
 	String name;
 	SelfList<GDScript> script_list;
 
-	GDInstance *_create_instance(const Variant **p_args, int p_argcount, Object *p_owner, bool p_isref, Variant::CallError &r_error);
+	GDScriptInstance *_create_instance(const Variant **p_args, int p_argcount, Object *p_owner, bool p_isref, Variant::CallError &r_error);
 
 	void _set_subclass_path(Ref<GDScript> &p_sc, const String &p_path);
 
@@ -143,8 +144,8 @@ public:
 	const Map<StringName, Ref<GDScript> > &get_subclasses() const { return subclasses; }
 	const Map<StringName, Variant> &get_constants() const { return constants; }
 	const Set<StringName> &get_members() const { return members; }
-	const Map<StringName, GDFunction *> &get_member_functions() const { return member_functions; }
-	const Ref<GDNativeClass> &get_native() const { return native; }
+	const Map<StringName, GDScriptFunction *> &get_member_functions() const { return member_functions; }
+	const Ref<GDScriptNativeClass> &get_native() const { return native; }
 
 	virtual bool has_script_signal(const StringName &p_signal) const;
 	virtual void get_script_signal_list(List<MethodInfo> *r_signals) const;
@@ -153,7 +154,7 @@ public:
 	Ref<GDScript> get_base() const;
 
 	const Map<StringName, MemberInfo> &debug_get_member_indices() const { return member_indices; }
-	const Map<StringName, GDFunction *> &debug_get_member_functions() const; //this is debug only
+	const Map<StringName, GDScriptFunction *> &debug_get_member_functions() const; //this is debug only
 	StringName debug_get_member_by_index(int p_idx) const;
 
 	Variant _new(const Variant **p_args, int p_argcount, Variant::CallError &r_error);
@@ -201,11 +202,11 @@ public:
 	~GDScript();
 };
 
-class GDInstance : public ScriptInstance {
+class GDScriptInstance : public ScriptInstance {
 	friend class GDScript;
-	friend class GDFunction;
-	friend class GDFunctions;
-	friend class GDCompiler;
+	friend class GDScriptFunction;
+	friend class GDScriptFunctions;
+	friend class GDScriptCompiler;
 
 	Object *owner;
 	Ref<GDScript> script;
@@ -246,8 +247,8 @@ public:
 	virtual RPCMode get_rpc_mode(const StringName &p_method) const;
 	virtual RPCMode get_rset_mode(const StringName &p_variable) const;
 
-	GDInstance();
-	~GDInstance();
+	GDScriptInstance();
+	~GDScriptInstance();
 };
 
 class GDScriptLanguage : public ScriptLanguage {
@@ -261,8 +262,8 @@ class GDScriptLanguage : public ScriptLanguage {
 	struct CallLevel {
 
 		Variant *stack;
-		GDFunction *function;
-		GDInstance *instance;
+		GDScriptFunction *function;
+		GDScriptInstance *instance;
 		int *ip;
 		int *line;
 	};
@@ -276,16 +277,16 @@ class GDScriptLanguage : public ScriptLanguage {
 
 	void _add_global(const StringName &p_name, const Variant &p_value);
 
-	friend class GDInstance;
+	friend class GDScriptInstance;
 
 	Mutex *lock;
 
 	friend class GDScript;
 
 	SelfList<GDScript>::List script_list;
-	friend class GDFunction;
+	friend class GDScriptFunction;
 
-	SelfList<GDFunction>::List function_list;
+	SelfList<GDScriptFunction>::List function_list;
 	bool profiling;
 	uint64_t script_frame_time;
 
@@ -295,7 +296,7 @@ public:
 	bool debug_break(const String &p_error, bool p_allow_continue = true);
 	bool debug_break_parse(const String &p_file, int p_line, const String &p_error);
 
-	_FORCE_INLINE_ void enter_function(GDInstance *p_instance, GDFunction *p_function, Variant *p_stack, int *p_ip, int *p_line) {
+	_FORCE_INLINE_ void enter_function(GDScriptInstance *p_instance, GDScriptFunction *p_function, Variant *p_stack, int *p_ip, int *p_line) {
 
 		if (Thread::get_main_id() != Thread::get_caller_id())
 			return; //no support for other threads than main for now
@@ -446,4 +447,4 @@ public:
 	virtual bool recognize(const RES &p_resource) const;
 };
 
-#endif // GD_SCRIPT_H
+#endif // GDSCRIPT_H

--- a/modules/gdscript/gdscript_compiler.h
+++ b/modules/gdscript/gdscript_compiler.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  gd_compiler.h                                                        */
+/*  gdscript_compiler.h                                                  */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -27,26 +27,26 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#ifndef GD_COMPILER_H
-#define GD_COMPILER_H
+#ifndef GDSCRIPT_COMPILER_H
+#define GDSCRIPT_COMPILER_H
 
-#include "gd_parser.h"
-#include "gd_script.h"
+#include "gdscript.h"
+#include "gdscript_parser.h"
 
-class GDCompiler {
+class GDScriptCompiler {
 
-	const GDParser *parser;
+	const GDScriptParser *parser;
 	struct CodeGen {
 
 		GDScript *script;
-		const GDParser::ClassNode *class_node;
-		const GDParser::FunctionNode *function_node;
+		const GDScriptParser::ClassNode *class_node;
+		const GDScriptParser::FunctionNode *function_node;
 		bool debug_stack;
 
 		List<Map<StringName, int> > stack_id_stack;
 		Map<StringName, int> stack_identifiers;
 
-		List<GDFunction::StackDebug> stack_debug;
+		List<GDScriptFunction::StackDebug> stack_debug;
 		List<Map<StringName, int> > block_identifier_stack;
 		Map<StringName, int> block_identifiers;
 
@@ -54,7 +54,7 @@ class GDCompiler {
 			stack_identifiers[p_id] = p_stackpos;
 			if (debug_stack) {
 				block_identifiers[p_id] = p_stackpos;
-				GDFunction::StackDebug sd;
+				GDScriptFunction::StackDebug sd;
 				sd.added = true;
 				sd.line = current_line;
 				sd.identifier = p_id;
@@ -79,7 +79,7 @@ class GDCompiler {
 			if (debug_stack) {
 				for (Map<StringName, int>::Element *E = block_identifiers.front(); E; E = E->next()) {
 
-					GDFunction::StackDebug sd;
+					GDScriptFunction::StackDebug sd;
 					sd.added = false;
 					sd.identifier = E->key();
 					sd.line = current_line;
@@ -129,29 +129,29 @@ class GDCompiler {
 	bool _is_class_member_property(CodeGen &codegen, const StringName &p_name);
 	bool _is_class_member_property(GDScript *owner, const StringName &p_name);
 
-	void _set_error(const String &p_error, const GDParser::Node *p_node);
+	void _set_error(const String &p_error, const GDScriptParser::Node *p_node);
 
-	bool _create_unary_operator(CodeGen &codegen, const GDParser::OperatorNode *on, Variant::Operator op, int p_stack_level);
-	bool _create_binary_operator(CodeGen &codegen, const GDParser::OperatorNode *on, Variant::Operator op, int p_stack_level, bool p_initializer = false);
+	bool _create_unary_operator(CodeGen &codegen, const GDScriptParser::OperatorNode *on, Variant::Operator op, int p_stack_level);
+	bool _create_binary_operator(CodeGen &codegen, const GDScriptParser::OperatorNode *on, Variant::Operator op, int p_stack_level, bool p_initializer = false);
 
-	int _parse_assign_right_expression(CodeGen &codegen, const GDParser::OperatorNode *p_expression, int p_stack_level);
-	int _parse_expression(CodeGen &codegen, const GDParser::Node *p_expression, int p_stack_level, bool p_root = false, bool p_initializer = false);
-	Error _parse_block(CodeGen &codegen, const GDParser::BlockNode *p_block, int p_stack_level = 0, int p_break_addr = -1, int p_continue_addr = -1);
-	Error _parse_function(GDScript *p_script, const GDParser::ClassNode *p_class, const GDParser::FunctionNode *p_func, bool p_for_ready = false);
-	Error _parse_class(GDScript *p_script, GDScript *p_owner, const GDParser::ClassNode *p_class, bool p_keep_state);
+	int _parse_assign_right_expression(CodeGen &codegen, const GDScriptParser::OperatorNode *p_expression, int p_stack_level);
+	int _parse_expression(CodeGen &codegen, const GDScriptParser::Node *p_expression, int p_stack_level, bool p_root = false, bool p_initializer = false);
+	Error _parse_block(CodeGen &codegen, const GDScriptParser::BlockNode *p_block, int p_stack_level = 0, int p_break_addr = -1, int p_continue_addr = -1);
+	Error _parse_function(GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::FunctionNode *p_func, bool p_for_ready = false);
+	Error _parse_class(GDScript *p_script, GDScript *p_owner, const GDScriptParser::ClassNode *p_class, bool p_keep_state);
 	int err_line;
 	int err_column;
 	StringName source;
 	String error;
 
 public:
-	Error compile(const GDParser *p_parser, GDScript *p_script, bool p_keep_state = false);
+	Error compile(const GDScriptParser *p_parser, GDScript *p_script, bool p_keep_state = false);
 
 	String get_error() const;
 	int get_error_line() const;
 	int get_error_column() const;
 
-	GDCompiler();
+	GDScriptCompiler();
 };
 
-#endif // COMPILER_H
+#endif // GDSCRIPT_COMPILER_H

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  gd_function.h                                                        */
+/*  gdscript_function.h                                                  */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -27,8 +27,8 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#ifndef GD_FUNCTION_H
-#define GD_FUNCTION_H
+#ifndef GDSCRIPT_FUNCTION_H
+#define GDSCRIPT_FUNCTION_H
 
 #include "os/thread.h"
 #include "pair.h"
@@ -38,10 +38,10 @@
 #include "string_db.h"
 #include "variant.h"
 
-class GDInstance;
+class GDScriptInstance;
 class GDScript;
 
-class GDFunction {
+class GDScriptFunction {
 public:
 	enum Opcode {
 		OPCODE_OPERATOR,
@@ -111,7 +111,7 @@ public:
 	};
 
 private:
-	friend class GDCompiler;
+	friend class GDScriptCompiler;
 
 	StringName source;
 
@@ -145,12 +145,12 @@ private:
 
 	List<StackDebug> stack_debug;
 
-	_FORCE_INLINE_ Variant *_get_variant(int p_address, GDInstance *p_instance, GDScript *p_script, Variant &self, Variant *p_stack, String &r_error) const;
+	_FORCE_INLINE_ Variant *_get_variant(int p_address, GDScriptInstance *p_instance, GDScript *p_script, Variant &self, Variant *p_stack, String &r_error) const;
 	_FORCE_INLINE_ String _get_call_error(const Variant::CallError &p_err, const String &p_where, const Variant **argptrs) const;
 
 	friend class GDScriptLanguage;
 
-	SelfList<GDFunction> function_list;
+	SelfList<GDScriptFunction> function_list;
 #ifdef DEBUG_ENABLED
 	CharString func_cname;
 	const char *_func_cname;
@@ -176,7 +176,7 @@ public:
 		ObjectID instance_id; //by debug only
 		ObjectID script_id;
 
-		GDInstance *instance;
+		GDScriptInstance *instance;
 		Vector<uint8_t> stack;
 		int stack_size;
 		Variant self;
@@ -219,19 +219,19 @@ public:
 		return default_arguments[p_idx];
 	}
 
-	Variant call(GDInstance *p_instance, const Variant **p_args, int p_argcount, Variant::CallError &r_err, CallState *p_state = NULL);
+	Variant call(GDScriptInstance *p_instance, const Variant **p_args, int p_argcount, Variant::CallError &r_err, CallState *p_state = NULL);
 
 	_FORCE_INLINE_ ScriptInstance::RPCMode get_rpc_mode() const { return rpc_mode; }
-	GDFunction();
-	~GDFunction();
+	GDScriptFunction();
+	~GDScriptFunction();
 };
 
-class GDFunctionState : public Reference {
+class GDScriptFunctionState : public Reference {
 
-	GDCLASS(GDFunctionState, Reference);
-	friend class GDFunction;
-	GDFunction *function;
-	GDFunction::CallState state;
+	GDCLASS(GDScriptFunctionState, Reference);
+	friend class GDScriptFunction;
+	GDScriptFunction *function;
+	GDScriptFunction::CallState state;
 	Variant _signal_callback(const Variant **p_args, int p_argcount, Variant::CallError &r_error);
 
 protected:
@@ -240,8 +240,8 @@ protected:
 public:
 	bool is_valid(bool p_extended_check = false) const;
 	Variant resume(const Variant &p_arg = Variant());
-	GDFunctionState();
-	~GDFunctionState();
+	GDScriptFunctionState();
+	~GDScriptFunctionState();
 };
 
-#endif // GD_FUNCTION_H
+#endif // GDSCRIPT_FUNCTION_H

--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  gd_functions.cpp                                                     */
+/*  gdscript_functions.cpp                                               */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -27,10 +27,11 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#include "gd_functions.h"
+#include "gdscript_functions.h"
+
 #include "class_db.h"
 #include "func_ref.h"
-#include "gd_script.h"
+#include "gdscript.h"
 #include "io/json.h"
 #include "io/marshalls.h"
 #include "math_funcs.h"
@@ -38,7 +39,7 @@
 #include "reference.h"
 #include "variant_parser.h"
 
-const char *GDFunctions::get_func_name(Function p_func) {
+const char *GDScriptFunctions::get_func_name(Function p_func) {
 
 	ERR_FAIL_INDEX_V(p_func, FUNC_MAX, "");
 
@@ -123,7 +124,7 @@ const char *GDFunctions::get_func_name(Function p_func) {
 	return _names[p_func];
 }
 
-void GDFunctions::call(Function p_func, const Variant **p_args, int p_arg_count, Variant &r_ret, Variant::CallError &r_error) {
+void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_count, Variant &r_ret, Variant::CallError &r_error) {
 
 	r_error.error = Variant::CallError::CALL_OK;
 #ifdef DEBUG_ENABLED
@@ -899,7 +900,7 @@ void GDFunctions::call(Function p_func, const Variant **p_args, int p_arg_count,
 					return;
 				} else {
 
-					GDInstance *ins = static_cast<GDInstance *>(obj->get_script_instance());
+					GDScriptInstance *ins = static_cast<GDScriptInstance *>(obj->get_script_instance());
 					Ref<GDScript> base = ins->get_script();
 					if (base.is_null()) {
 
@@ -1030,7 +1031,7 @@ void GDFunctions::call(Function p_func, const Variant **p_args, int p_arg_count,
 
 			r_ret = gdscr->_new(NULL, 0, r_error);
 
-			GDInstance *ins = static_cast<GDInstance *>(static_cast<Object *>(r_ret)->get_script_instance());
+			GDScriptInstance *ins = static_cast<GDScriptInstance *>(static_cast<Object *>(r_ret)->get_script_instance());
 			Ref<GDScript> gd_ref = ins->get_script();
 
 			for (Map<StringName, GDScript::MemberInfo>::Element *E = gd_ref->member_indices.front(); E; E = E->next()) {
@@ -1254,7 +1255,7 @@ void GDFunctions::call(Function p_func, const Variant **p_args, int p_arg_count,
 	}
 }
 
-bool GDFunctions::is_deterministic(Function p_func) {
+bool GDScriptFunctions::is_deterministic(Function p_func) {
 
 	//man i couldn't have chosen a worse function name,
 	//way too controversial..
@@ -1317,7 +1318,7 @@ bool GDFunctions::is_deterministic(Function p_func) {
 	return false;
 }
 
-MethodInfo GDFunctions::get_info(Function p_func) {
+MethodInfo GDScriptFunctions::get_info(Function p_func) {
 
 #ifdef TOOLS_ENABLED
 	//using a switch, so the compiler generates a jumptable

--- a/modules/gdscript/gdscript_functions.h
+++ b/modules/gdscript/gdscript_functions.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  gd_functions.h                                                       */
+/*  gdscript_functions.h                                                 */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -27,12 +27,12 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#ifndef GD_FUNCTIONS_H
-#define GD_FUNCTIONS_H
+#ifndef GDSCRIPT_FUNCTIONS_H
+#define GDSCRIPT_FUNCTIONS_H
 
 #include "variant.h"
 
-class GDFunctions {
+class GDScriptFunctions {
 public:
 	enum Function {
 		MATH_SIN,
@@ -120,4 +120,4 @@ public:
 	static MethodInfo get_info(Function p_func);
 };
 
-#endif // GD_FUNCTIONS_H
+#endif // GDSCRIPT_FUNCTIONS_H

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  gd_parser.h                                                          */
+/*  gdscript_parser.h                                                    */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -27,16 +27,16 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#ifndef GD_PARSER_H
-#define GD_PARSER_H
+#ifndef GDSCRIPT_PARSER_H
+#define GDSCRIPT_PARSER_H
 
-#include "gd_functions.h"
-#include "gd_tokenizer.h"
+#include "gdscript_functions.h"
+#include "gdscript_tokenizer.h"
 #include "map.h"
 #include "object.h"
 #include "script_language.h"
 
-class GDParser {
+class GDScriptParser {
 public:
 	struct Node {
 
@@ -166,7 +166,7 @@ public:
 		TypeNode() { type = TYPE_TYPE; }
 	};
 	struct BuiltInFunctionNode : public Node {
-		GDFunctions::Function function;
+		GDScriptFunctions::Function function;
 		BuiltInFunctionNode() { type = TYPE_BUILT_IN_FUNCTION; }
 	};
 
@@ -448,7 +448,7 @@ public:
 	};
 
 private:
-	GDTokenizer *tokenizer;
+	GDScriptTokenizer *tokenizer;
 
 	Node *head;
 	Node *list;
@@ -540,8 +540,8 @@ public:
 	int get_completion_identifier_is_function();
 
 	void clear();
-	GDParser();
-	~GDParser();
+	GDScriptParser();
+	~GDScriptParser();
 };
 
-#endif // PARSER_H
+#endif // GDSCRIPT_PARSER_H

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  gd_tokenizer.cpp                                                     */
+/*  gdscript_tokenizer.cpp                                               */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -27,14 +27,14 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#include "gd_tokenizer.h"
+#include "gdscript_tokenizer.h"
 
-#include "gd_functions.h"
+#include "gdscript_functions.h"
 #include "io/marshalls.h"
 #include "map.h"
 #include "print_string.h"
 
-const char *GDTokenizer::token_names[TK_MAX] = {
+const char *GDScriptTokenizer::token_names[TK_MAX] = {
 	"Empty",
 	"Identifier",
 	"Constant",
@@ -170,68 +170,68 @@ static const _bit _type_list[] = {
 };
 
 struct _kws {
-	GDTokenizer::Token token;
+	GDScriptTokenizer::Token token;
 	const char *text;
 };
 
 static const _kws _keyword_list[] = {
 	//ops
-	{ GDTokenizer::TK_OP_IN, "in" },
-	{ GDTokenizer::TK_OP_NOT, "not" },
-	{ GDTokenizer::TK_OP_OR, "or" },
-	{ GDTokenizer::TK_OP_AND, "and" },
+	{ GDScriptTokenizer::TK_OP_IN, "in" },
+	{ GDScriptTokenizer::TK_OP_NOT, "not" },
+	{ GDScriptTokenizer::TK_OP_OR, "or" },
+	{ GDScriptTokenizer::TK_OP_AND, "and" },
 	//func
-	{ GDTokenizer::TK_PR_FUNCTION, "func" },
-	{ GDTokenizer::TK_PR_CLASS, "class" },
-	{ GDTokenizer::TK_PR_EXTENDS, "extends" },
-	{ GDTokenizer::TK_PR_IS, "is" },
-	{ GDTokenizer::TK_PR_ONREADY, "onready" },
-	{ GDTokenizer::TK_PR_TOOL, "tool" },
-	{ GDTokenizer::TK_PR_STATIC, "static" },
-	{ GDTokenizer::TK_PR_EXPORT, "export" },
-	{ GDTokenizer::TK_PR_SETGET, "setget" },
-	{ GDTokenizer::TK_PR_VAR, "var" },
-	{ GDTokenizer::TK_PR_PRELOAD, "preload" },
-	{ GDTokenizer::TK_PR_ASSERT, "assert" },
-	{ GDTokenizer::TK_PR_YIELD, "yield" },
-	{ GDTokenizer::TK_PR_SIGNAL, "signal" },
-	{ GDTokenizer::TK_PR_BREAKPOINT, "breakpoint" },
-	{ GDTokenizer::TK_PR_REMOTE, "remote" },
-	{ GDTokenizer::TK_PR_MASTER, "master" },
-	{ GDTokenizer::TK_PR_SLAVE, "slave" },
-	{ GDTokenizer::TK_PR_SYNC, "sync" },
-	{ GDTokenizer::TK_PR_CONST, "const" },
-	{ GDTokenizer::TK_PR_ENUM, "enum" },
+	{ GDScriptTokenizer::TK_PR_FUNCTION, "func" },
+	{ GDScriptTokenizer::TK_PR_CLASS, "class" },
+	{ GDScriptTokenizer::TK_PR_EXTENDS, "extends" },
+	{ GDScriptTokenizer::TK_PR_IS, "is" },
+	{ GDScriptTokenizer::TK_PR_ONREADY, "onready" },
+	{ GDScriptTokenizer::TK_PR_TOOL, "tool" },
+	{ GDScriptTokenizer::TK_PR_STATIC, "static" },
+	{ GDScriptTokenizer::TK_PR_EXPORT, "export" },
+	{ GDScriptTokenizer::TK_PR_SETGET, "setget" },
+	{ GDScriptTokenizer::TK_PR_VAR, "var" },
+	{ GDScriptTokenizer::TK_PR_PRELOAD, "preload" },
+	{ GDScriptTokenizer::TK_PR_ASSERT, "assert" },
+	{ GDScriptTokenizer::TK_PR_YIELD, "yield" },
+	{ GDScriptTokenizer::TK_PR_SIGNAL, "signal" },
+	{ GDScriptTokenizer::TK_PR_BREAKPOINT, "breakpoint" },
+	{ GDScriptTokenizer::TK_PR_REMOTE, "remote" },
+	{ GDScriptTokenizer::TK_PR_MASTER, "master" },
+	{ GDScriptTokenizer::TK_PR_SLAVE, "slave" },
+	{ GDScriptTokenizer::TK_PR_SYNC, "sync" },
+	{ GDScriptTokenizer::TK_PR_CONST, "const" },
+	{ GDScriptTokenizer::TK_PR_ENUM, "enum" },
 	//controlflow
-	{ GDTokenizer::TK_CF_IF, "if" },
-	{ GDTokenizer::TK_CF_ELIF, "elif" },
-	{ GDTokenizer::TK_CF_ELSE, "else" },
-	{ GDTokenizer::TK_CF_FOR, "for" },
-	{ GDTokenizer::TK_CF_WHILE, "while" },
-	{ GDTokenizer::TK_CF_DO, "do" },
-	{ GDTokenizer::TK_CF_SWITCH, "switch" },
-	{ GDTokenizer::TK_CF_CASE, "case" },
-	{ GDTokenizer::TK_CF_BREAK, "break" },
-	{ GDTokenizer::TK_CF_CONTINUE, "continue" },
-	{ GDTokenizer::TK_CF_RETURN, "return" },
-	{ GDTokenizer::TK_CF_MATCH, "match" },
-	{ GDTokenizer::TK_CF_PASS, "pass" },
-	{ GDTokenizer::TK_SELF, "self" },
-	{ GDTokenizer::TK_CONST_PI, "PI" },
-	{ GDTokenizer::TK_CONST_TAU, "TAU" },
-	{ GDTokenizer::TK_WILDCARD, "_" },
-	{ GDTokenizer::TK_CONST_INF, "INF" },
-	{ GDTokenizer::TK_CONST_NAN, "NAN" },
-	{ GDTokenizer::TK_ERROR, NULL }
+	{ GDScriptTokenizer::TK_CF_IF, "if" },
+	{ GDScriptTokenizer::TK_CF_ELIF, "elif" },
+	{ GDScriptTokenizer::TK_CF_ELSE, "else" },
+	{ GDScriptTokenizer::TK_CF_FOR, "for" },
+	{ GDScriptTokenizer::TK_CF_WHILE, "while" },
+	{ GDScriptTokenizer::TK_CF_DO, "do" },
+	{ GDScriptTokenizer::TK_CF_SWITCH, "switch" },
+	{ GDScriptTokenizer::TK_CF_CASE, "case" },
+	{ GDScriptTokenizer::TK_CF_BREAK, "break" },
+	{ GDScriptTokenizer::TK_CF_CONTINUE, "continue" },
+	{ GDScriptTokenizer::TK_CF_RETURN, "return" },
+	{ GDScriptTokenizer::TK_CF_MATCH, "match" },
+	{ GDScriptTokenizer::TK_CF_PASS, "pass" },
+	{ GDScriptTokenizer::TK_SELF, "self" },
+	{ GDScriptTokenizer::TK_CONST_PI, "PI" },
+	{ GDScriptTokenizer::TK_CONST_TAU, "TAU" },
+	{ GDScriptTokenizer::TK_WILDCARD, "_" },
+	{ GDScriptTokenizer::TK_CONST_INF, "INF" },
+	{ GDScriptTokenizer::TK_CONST_NAN, "NAN" },
+	{ GDScriptTokenizer::TK_ERROR, NULL }
 };
 
-const char *GDTokenizer::get_token_name(Token p_token) {
+const char *GDScriptTokenizer::get_token_name(Token p_token) {
 
 	ERR_FAIL_INDEX_V(p_token, TK_MAX, "<error>");
 	return token_names[p_token];
 }
 
-bool GDTokenizer::is_token_literal(int p_offset, bool variable_safe) const {
+bool GDScriptTokenizer::is_token_literal(int p_offset, bool variable_safe) const {
 	switch (get_token(p_offset)) {
 		// Can always be literal:
 		case TK_IDENTIFIER:
@@ -303,7 +303,7 @@ bool GDTokenizer::is_token_literal(int p_offset, bool variable_safe) const {
 	}
 }
 
-StringName GDTokenizer::get_token_literal(int p_offset) const {
+StringName GDScriptTokenizer::get_token_literal(int p_offset) const {
 	Token token = get_token(p_offset);
 	switch (token) {
 		case TK_IDENTIFIER:
@@ -320,7 +320,7 @@ StringName GDTokenizer::get_token_literal(int p_offset) const {
 			}
 		} break; // Shouldn't get here, stuff happens
 		case TK_BUILT_IN_FUNC:
-			return GDFunctions::get_func_name(get_token_built_in_func(p_offset));
+			return GDScriptFunctions::get_func_name(get_token_built_in_func(p_offset));
 		case TK_CONSTANT: {
 			const Variant value = get_token_constant(p_offset);
 
@@ -365,7 +365,7 @@ static bool _is_hex(CharType c) {
 	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
 }
 
-void GDTokenizerText::_make_token(Token p_type) {
+void GDScriptTokenizerText::_make_token(Token p_type) {
 
 	TokenData &tk = tk_rb[tk_rb_pos];
 
@@ -375,7 +375,7 @@ void GDTokenizerText::_make_token(Token p_type) {
 
 	tk_rb_pos = (tk_rb_pos + 1) % TK_RB_SIZE;
 }
-void GDTokenizerText::_make_identifier(const StringName &p_identifier) {
+void GDScriptTokenizerText::_make_identifier(const StringName &p_identifier) {
 
 	TokenData &tk = tk_rb[tk_rb_pos];
 
@@ -387,7 +387,7 @@ void GDTokenizerText::_make_identifier(const StringName &p_identifier) {
 	tk_rb_pos = (tk_rb_pos + 1) % TK_RB_SIZE;
 }
 
-void GDTokenizerText::_make_built_in_func(GDFunctions::Function p_func) {
+void GDScriptTokenizerText::_make_built_in_func(GDScriptFunctions::Function p_func) {
 
 	TokenData &tk = tk_rb[tk_rb_pos];
 
@@ -398,7 +398,7 @@ void GDTokenizerText::_make_built_in_func(GDFunctions::Function p_func) {
 
 	tk_rb_pos = (tk_rb_pos + 1) % TK_RB_SIZE;
 }
-void GDTokenizerText::_make_constant(const Variant &p_constant) {
+void GDScriptTokenizerText::_make_constant(const Variant &p_constant) {
 
 	TokenData &tk = tk_rb[tk_rb_pos];
 
@@ -410,7 +410,7 @@ void GDTokenizerText::_make_constant(const Variant &p_constant) {
 	tk_rb_pos = (tk_rb_pos + 1) % TK_RB_SIZE;
 }
 
-void GDTokenizerText::_make_type(const Variant::Type &p_type) {
+void GDScriptTokenizerText::_make_type(const Variant::Type &p_type) {
 
 	TokenData &tk = tk_rb[tk_rb_pos];
 
@@ -422,7 +422,7 @@ void GDTokenizerText::_make_type(const Variant::Type &p_type) {
 	tk_rb_pos = (tk_rb_pos + 1) % TK_RB_SIZE;
 }
 
-void GDTokenizerText::_make_error(const String &p_error) {
+void GDScriptTokenizerText::_make_error(const String &p_error) {
 
 	error_flag = true;
 	last_error = p_error;
@@ -435,7 +435,7 @@ void GDTokenizerText::_make_error(const String &p_error) {
 	tk_rb_pos = (tk_rb_pos + 1) % TK_RB_SIZE;
 }
 
-void GDTokenizerText::_make_newline(int p_spaces) {
+void GDScriptTokenizerText::_make_newline(int p_spaces) {
 
 	TokenData &tk = tk_rb[tk_rb_pos];
 	tk.type = TK_NEWLINE;
@@ -445,7 +445,7 @@ void GDTokenizerText::_make_newline(int p_spaces) {
 	tk_rb_pos = (tk_rb_pos + 1) % TK_RB_SIZE;
 }
 
-void GDTokenizerText::_advance() {
+void GDScriptTokenizerText::_advance() {
 
 	if (error_flag) {
 		//parser broke
@@ -966,11 +966,11 @@ void GDTokenizerText::_advance() {
 
 							//built in func?
 
-							for (int i = 0; i < GDFunctions::FUNC_MAX; i++) {
+							for (int i = 0; i < GDScriptFunctions::FUNC_MAX; i++) {
 
-								if (str == GDFunctions::get_func_name(GDFunctions::Function(i))) {
+								if (str == GDScriptFunctions::get_func_name(GDScriptFunctions::Function(i))) {
 
-									_make_built_in_func(GDFunctions::Function(i));
+									_make_built_in_func(GDScriptFunctions::Function(i));
 									found = true;
 									break;
 								}
@@ -1016,7 +1016,7 @@ void GDTokenizerText::_advance() {
 	}
 }
 
-void GDTokenizerText::set_code(const String &p_code) {
+void GDScriptTokenizerText::set_code(const String &p_code) {
 
 	code = p_code;
 	len = p_code.length();
@@ -1035,7 +1035,7 @@ void GDTokenizerText::set_code(const String &p_code) {
 		_advance();
 }
 
-GDTokenizerText::Token GDTokenizerText::get_token(int p_offset) const {
+GDScriptTokenizerText::Token GDScriptTokenizerText::get_token(int p_offset) const {
 	ERR_FAIL_COND_V(p_offset <= -MAX_LOOKAHEAD, TK_ERROR);
 	ERR_FAIL_COND_V(p_offset >= MAX_LOOKAHEAD, TK_ERROR);
 
@@ -1043,7 +1043,7 @@ GDTokenizerText::Token GDTokenizerText::get_token(int p_offset) const {
 	return tk_rb[ofs].type;
 }
 
-int GDTokenizerText::get_token_line(int p_offset) const {
+int GDScriptTokenizerText::get_token_line(int p_offset) const {
 	ERR_FAIL_COND_V(p_offset <= -MAX_LOOKAHEAD, -1);
 	ERR_FAIL_COND_V(p_offset >= MAX_LOOKAHEAD, -1);
 
@@ -1051,7 +1051,7 @@ int GDTokenizerText::get_token_line(int p_offset) const {
 	return tk_rb[ofs].line;
 }
 
-int GDTokenizerText::get_token_column(int p_offset) const {
+int GDScriptTokenizerText::get_token_column(int p_offset) const {
 	ERR_FAIL_COND_V(p_offset <= -MAX_LOOKAHEAD, -1);
 	ERR_FAIL_COND_V(p_offset >= MAX_LOOKAHEAD, -1);
 
@@ -1059,7 +1059,7 @@ int GDTokenizerText::get_token_column(int p_offset) const {
 	return tk_rb[ofs].col;
 }
 
-const Variant &GDTokenizerText::get_token_constant(int p_offset) const {
+const Variant &GDScriptTokenizerText::get_token_constant(int p_offset) const {
 	ERR_FAIL_COND_V(p_offset <= -MAX_LOOKAHEAD, tk_rb[0].constant);
 	ERR_FAIL_COND_V(p_offset >= MAX_LOOKAHEAD, tk_rb[0].constant);
 
@@ -1068,7 +1068,7 @@ const Variant &GDTokenizerText::get_token_constant(int p_offset) const {
 	return tk_rb[ofs].constant;
 }
 
-StringName GDTokenizerText::get_token_identifier(int p_offset) const {
+StringName GDScriptTokenizerText::get_token_identifier(int p_offset) const {
 
 	ERR_FAIL_COND_V(p_offset <= -MAX_LOOKAHEAD, StringName());
 	ERR_FAIL_COND_V(p_offset >= MAX_LOOKAHEAD, StringName());
@@ -1078,17 +1078,17 @@ StringName GDTokenizerText::get_token_identifier(int p_offset) const {
 	return tk_rb[ofs].identifier;
 }
 
-GDFunctions::Function GDTokenizerText::get_token_built_in_func(int p_offset) const {
+GDScriptFunctions::Function GDScriptTokenizerText::get_token_built_in_func(int p_offset) const {
 
-	ERR_FAIL_COND_V(p_offset <= -MAX_LOOKAHEAD, GDFunctions::FUNC_MAX);
-	ERR_FAIL_COND_V(p_offset >= MAX_LOOKAHEAD, GDFunctions::FUNC_MAX);
+	ERR_FAIL_COND_V(p_offset <= -MAX_LOOKAHEAD, GDScriptFunctions::FUNC_MAX);
+	ERR_FAIL_COND_V(p_offset >= MAX_LOOKAHEAD, GDScriptFunctions::FUNC_MAX);
 
 	int ofs = (TK_RB_SIZE + tk_rb_pos + p_offset - MAX_LOOKAHEAD - 1) % TK_RB_SIZE;
-	ERR_FAIL_COND_V(tk_rb[ofs].type != TK_BUILT_IN_FUNC, GDFunctions::FUNC_MAX);
+	ERR_FAIL_COND_V(tk_rb[ofs].type != TK_BUILT_IN_FUNC, GDScriptFunctions::FUNC_MAX);
 	return tk_rb[ofs].func;
 }
 
-Variant::Type GDTokenizerText::get_token_type(int p_offset) const {
+Variant::Type GDScriptTokenizerText::get_token_type(int p_offset) const {
 
 	ERR_FAIL_COND_V(p_offset <= -MAX_LOOKAHEAD, Variant::NIL);
 	ERR_FAIL_COND_V(p_offset >= MAX_LOOKAHEAD, Variant::NIL);
@@ -1098,7 +1098,7 @@ Variant::Type GDTokenizerText::get_token_type(int p_offset) const {
 	return tk_rb[ofs].vtype;
 }
 
-int GDTokenizerText::get_token_line_indent(int p_offset) const {
+int GDScriptTokenizerText::get_token_line_indent(int p_offset) const {
 
 	ERR_FAIL_COND_V(p_offset <= -MAX_LOOKAHEAD, 0);
 	ERR_FAIL_COND_V(p_offset >= MAX_LOOKAHEAD, 0);
@@ -1108,7 +1108,7 @@ int GDTokenizerText::get_token_line_indent(int p_offset) const {
 	return tk_rb[ofs].constant;
 }
 
-String GDTokenizerText::get_token_error(int p_offset) const {
+String GDScriptTokenizerText::get_token_error(int p_offset) const {
 
 	ERR_FAIL_COND_V(p_offset <= -MAX_LOOKAHEAD, String());
 	ERR_FAIL_COND_V(p_offset >= MAX_LOOKAHEAD, String());
@@ -1118,7 +1118,7 @@ String GDTokenizerText::get_token_error(int p_offset) const {
 	return tk_rb[ofs].constant;
 }
 
-void GDTokenizerText::advance(int p_amount) {
+void GDScriptTokenizerText::advance(int p_amount) {
 
 	ERR_FAIL_COND(p_amount <= 0);
 	for (int i = 0; i < p_amount; i++)
@@ -1129,7 +1129,7 @@ void GDTokenizerText::advance(int p_amount) {
 
 #define BYTECODE_VERSION 12
 
-Error GDTokenizerBuffer::set_code_buffer(const Vector<uint8_t> &p_buffer) {
+Error GDScriptTokenizerBuffer::set_code_buffer(const Vector<uint8_t> &p_buffer) {
 
 	const uint8_t *buf = p_buffer.ptr();
 	int total_len = p_buffer.size();
@@ -1217,7 +1217,7 @@ Error GDTokenizerBuffer::set_code_buffer(const Vector<uint8_t> &p_buffer) {
 	return OK;
 }
 
-Vector<uint8_t> GDTokenizerBuffer::parse_code_string(const String &p_code) {
+Vector<uint8_t> GDScriptTokenizerBuffer::parse_code_string(const String &p_code) {
 
 	Vector<uint8_t> buf;
 
@@ -1226,7 +1226,7 @@ Vector<uint8_t> GDTokenizerBuffer::parse_code_string(const String &p_code) {
 	Map<uint32_t, int> line_map;
 	Vector<uint32_t> token_array;
 
-	GDTokenizerText tt;
+	GDScriptTokenizerText tt;
 	tt.set_code(p_code);
 	int line = -1;
 
@@ -1375,17 +1375,17 @@ Vector<uint8_t> GDTokenizerBuffer::parse_code_string(const String &p_code) {
 	return buf;
 }
 
-GDTokenizerBuffer::Token GDTokenizerBuffer::get_token(int p_offset) const {
+GDScriptTokenizerBuffer::Token GDScriptTokenizerBuffer::get_token(int p_offset) const {
 
 	int offset = token + p_offset;
 
 	if (offset < 0 || offset >= tokens.size())
 		return TK_EOF;
 
-	return GDTokenizerBuffer::Token(tokens[offset] & TOKEN_MASK);
+	return GDScriptTokenizerBuffer::Token(tokens[offset] & TOKEN_MASK);
 }
 
-StringName GDTokenizerBuffer::get_token_identifier(int p_offset) const {
+StringName GDScriptTokenizerBuffer::get_token_identifier(int p_offset) const {
 
 	int offset = token + p_offset;
 
@@ -1396,14 +1396,14 @@ StringName GDTokenizerBuffer::get_token_identifier(int p_offset) const {
 	return identifiers[identifier];
 }
 
-GDFunctions::Function GDTokenizerBuffer::get_token_built_in_func(int p_offset) const {
+GDScriptFunctions::Function GDScriptTokenizerBuffer::get_token_built_in_func(int p_offset) const {
 
 	int offset = token + p_offset;
-	ERR_FAIL_INDEX_V(offset, tokens.size(), GDFunctions::FUNC_MAX);
-	return GDFunctions::Function(tokens[offset] >> TOKEN_BITS);
+	ERR_FAIL_INDEX_V(offset, tokens.size(), GDScriptFunctions::FUNC_MAX);
+	return GDScriptFunctions::Function(tokens[offset] >> TOKEN_BITS);
 }
 
-Variant::Type GDTokenizerBuffer::get_token_type(int p_offset) const {
+Variant::Type GDScriptTokenizerBuffer::get_token_type(int p_offset) const {
 
 	int offset = token + p_offset;
 	ERR_FAIL_INDEX_V(offset, tokens.size(), Variant::NIL);
@@ -1411,7 +1411,7 @@ Variant::Type GDTokenizerBuffer::get_token_type(int p_offset) const {
 	return Variant::Type(tokens[offset] >> TOKEN_BITS);
 }
 
-int GDTokenizerBuffer::get_token_line(int p_offset) const {
+int GDScriptTokenizerBuffer::get_token_line(int p_offset) const {
 
 	int offset = token + p_offset;
 	int pos = lines.find_nearest(offset);
@@ -1424,7 +1424,7 @@ int GDTokenizerBuffer::get_token_line(int p_offset) const {
 	uint32_t l = lines.getv(pos);
 	return l & TOKEN_LINE_MASK;
 }
-int GDTokenizerBuffer::get_token_column(int p_offset) const {
+int GDScriptTokenizerBuffer::get_token_column(int p_offset) const {
 
 	int offset = token + p_offset;
 	int pos = lines.find_nearest(offset);
@@ -1436,13 +1436,13 @@ int GDTokenizerBuffer::get_token_column(int p_offset) const {
 	uint32_t l = lines.getv(pos);
 	return l >> TOKEN_LINE_BITS;
 }
-int GDTokenizerBuffer::get_token_line_indent(int p_offset) const {
+int GDScriptTokenizerBuffer::get_token_line_indent(int p_offset) const {
 
 	int offset = token + p_offset;
 	ERR_FAIL_INDEX_V(offset, tokens.size(), 0);
 	return tokens[offset] >> TOKEN_BITS;
 }
-const Variant &GDTokenizerBuffer::get_token_constant(int p_offset) const {
+const Variant &GDScriptTokenizerBuffer::get_token_constant(int p_offset) const {
 
 	int offset = token + p_offset;
 	ERR_FAIL_INDEX_V(offset, tokens.size(), nil);
@@ -1450,17 +1450,17 @@ const Variant &GDTokenizerBuffer::get_token_constant(int p_offset) const {
 	ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), nil);
 	return constants[constant];
 }
-String GDTokenizerBuffer::get_token_error(int p_offset) const {
+String GDScriptTokenizerBuffer::get_token_error(int p_offset) const {
 
 	ERR_FAIL_V(String());
 }
 
-void GDTokenizerBuffer::advance(int p_amount) {
+void GDScriptTokenizerBuffer::advance(int p_amount) {
 
 	ERR_FAIL_INDEX(p_amount + token, tokens.size());
 	token += p_amount;
 }
-GDTokenizerBuffer::GDTokenizerBuffer() {
+GDScriptTokenizerBuffer::GDScriptTokenizerBuffer() {
 
 	token = 0;
 }

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  gd_tokenizer.h                                                       */
+/*  gdscript_tokenizer.h                                                 */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -27,16 +27,16 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#ifndef GD_TOKENIZER_H
-#define GD_TOKENIZER_H
+#ifndef GDSCRIPT_TOKENIZER_H
+#define GDSCRIPT_TOKENIZER_H
 
-#include "gd_functions.h"
+#include "gdscript_functions.h"
 #include "string_db.h"
 #include "ustring.h"
 #include "variant.h"
 #include "vmap.h"
 
-class GDTokenizer {
+class GDScriptTokenizer {
 public:
 	enum Token {
 
@@ -156,7 +156,7 @@ public:
 	virtual const Variant &get_token_constant(int p_offset = 0) const = 0;
 	virtual Token get_token(int p_offset = 0) const = 0;
 	virtual StringName get_token_identifier(int p_offset = 0) const = 0;
-	virtual GDFunctions::Function get_token_built_in_func(int p_offset = 0) const = 0;
+	virtual GDScriptFunctions::Function get_token_built_in_func(int p_offset = 0) const = 0;
 	virtual Variant::Type get_token_type(int p_offset = 0) const = 0;
 	virtual int get_token_line(int p_offset = 0) const = 0;
 	virtual int get_token_column(int p_offset = 0) const = 0;
@@ -164,10 +164,10 @@ public:
 	virtual String get_token_error(int p_offset = 0) const = 0;
 	virtual void advance(int p_amount = 1) = 0;
 
-	virtual ~GDTokenizer(){};
+	virtual ~GDScriptTokenizer(){};
 };
 
-class GDTokenizerText : public GDTokenizer {
+class GDScriptTokenizerText : public GDScriptTokenizer {
 
 	enum {
 		MAX_LOOKAHEAD = 4,
@@ -181,7 +181,7 @@ class GDTokenizerText : public GDTokenizer {
 		Variant constant; //for constant types
 		union {
 			Variant::Type vtype; //for type types
-			GDFunctions::Function func; //function for built in functions
+			GDScriptFunctions::Function func; //function for built in functions
 		};
 		int line, col;
 		TokenData() {
@@ -194,7 +194,7 @@ class GDTokenizerText : public GDTokenizer {
 	void _make_token(Token p_type);
 	void _make_newline(int p_spaces = 0);
 	void _make_identifier(const StringName &p_identifier);
-	void _make_built_in_func(GDFunctions::Function p_func);
+	void _make_built_in_func(GDScriptFunctions::Function p_func);
 	void _make_constant(const Variant &p_constant);
 	void _make_type(const Variant::Type &p_type);
 	void _make_error(const String &p_error);
@@ -216,7 +216,7 @@ public:
 	void set_code(const String &p_code);
 	virtual Token get_token(int p_offset = 0) const;
 	virtual StringName get_token_identifier(int p_offset = 0) const;
-	virtual GDFunctions::Function get_token_built_in_func(int p_offset = 0) const;
+	virtual GDScriptFunctions::Function get_token_built_in_func(int p_offset = 0) const;
 	virtual Variant::Type get_token_type(int p_offset = 0) const;
 	virtual int get_token_line(int p_offset = 0) const;
 	virtual int get_token_column(int p_offset = 0) const;
@@ -226,7 +226,7 @@ public:
 	virtual void advance(int p_amount = 1);
 };
 
-class GDTokenizerBuffer : public GDTokenizer {
+class GDScriptTokenizerBuffer : public GDScriptTokenizer {
 
 	enum {
 
@@ -249,7 +249,7 @@ public:
 	static Vector<uint8_t> parse_code_string(const String &p_code);
 	virtual Token get_token(int p_offset = 0) const;
 	virtual StringName get_token_identifier(int p_offset = 0) const;
-	virtual GDFunctions::Function get_token_built_in_func(int p_offset = 0) const;
+	virtual GDScriptFunctions::Function get_token_built_in_func(int p_offset = 0) const;
 	virtual Variant::Type get_token_type(int p_offset = 0) const;
 	virtual int get_token_line(int p_offset = 0) const;
 	virtual int get_token_column(int p_offset = 0) const;
@@ -257,7 +257,7 @@ public:
 	virtual const Variant &get_token_constant(int p_offset = 0) const;
 	virtual String get_token_error(int p_offset = 0) const;
 	virtual void advance(int p_amount = 1);
-	GDTokenizerBuffer();
+	GDScriptTokenizerBuffer();
 };
 
-#endif // TOKENIZER_H
+#endif // GDSCRIPT_TOKENIZER_H

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -29,7 +29,7 @@
 /*************************************************************************/
 #include "register_types.h"
 
-#include "gd_script.h"
+#include "gdscript.h"
 #include "io/file_access_encrypted.h"
 #include "io/resource_loader.h"
 #include "os/file_access.h"
@@ -41,10 +41,9 @@ ResourceFormatSaverGDScript *resource_saver_gd = NULL;
 void register_gdscript_types() {
 
 	ClassDB::register_class<GDScript>();
-	ClassDB::register_virtual_class<GDFunctionState>();
+	ClassDB::register_virtual_class<GDScriptFunctionState>();
 
 	script_language_gd = memnew(GDScriptLanguage);
-	//script_language_gd->init();
 	ScriptServer::register_language(script_language_gd);
 	resource_loader_gd = memnew(ResourceFormatLoaderGDScript);
 	ResourceLoader::add_resource_format_loader(resource_loader_gd);


### PR DESCRIPTION
All this to remove the confusion between GDScript's former `GDNativeClass` and the actual GDNative classes... but I think it's for the best, GDScript is but a module and should not have the monopoly over the `GD` prefix.