### PR TITLE
Fixed scene tree updating when undo/redo root node creation, issue 6125

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1415,6 +1415,7 @@ void SceneTreeDock::_create() {
 		} else {
 
 			editor_data->get_undo_redo().add_do_method(editor, "set_edited_scene", child);
+			editor_data->get_undo_redo().add_do_method(scene_tree, "update_tree");
 			editor_data->get_undo_redo().add_do_reference(child);
 			editor_data->get_undo_redo().add_undo_method(editor, "set_edited_scene", (Object *)NULL);
 		}


### PR DESCRIPTION
Fixed scene tree not updating when undoing then redoing root node creation.

closes #6125