### PR TITLE
Fix alpha dithering in viewports with TransparentBg=false and Usage=2D, issue #11416

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1570,6 +1570,7 @@ void RasterizerCanvasGLES3::reset_canvas() {
 	glDisable(GL_CULL_FACE);
 	glDisable(GL_DEPTH_TEST);
 	glDisable(GL_SCISSOR_TEST);
+	glDisable(GL_DITHER);
 	glEnable(GL_BLEND);
 	glBlendEquation(GL_FUNC_ADD);
 	if (storage->frame.current_rt && storage->frame.current_rt->flags[RasterizerStorage::RENDER_TARGET_TRANSPARENT]) {


### PR DESCRIPTION
There are no usages of glEnable(GL_DITHER) in drivers/gles3 but according to [this](https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glEnable.xml) GL_DITHER is set by default. Adding glDisable(GL_DITHER) to reset_canvas() method fixed this issue for me.

*Bugsquad edit:* Fixes #11416.