### PR TITLE
RichTextLabel: Adding ability for single meta hovering

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -374,6 +374,20 @@
 			<description>
 			</description>
 		</signal>
+		<signal name="meta_hover_started">
+			<argument index="0" name="meta" type="Nil">
+			</argument>
+			<description>
+				Triggers when the mouse enters a meta tag. 
+			</description>
+		</signal>
+		<signal name="meta_hover_ended">
+			<argument index="0" name="meta" type="Nil">
+			</argument>
+			<description>
+				Triggers when the mouse exits a meta tag. 
+			</description>
+		</signal>
 	</signals>
 	<constants>
 		<constant name="ALIGN_LEFT" value="0">

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -877,11 +877,13 @@ void RichTextLabel::_gui_input(Ref<InputEvent> p_event) {
 		if (main->first_invalid_line < main->lines.size())
 			return;
 
+		int line = 0;
+		Item *item = NULL;
+		bool outside;
+		_find_click(main, m->get_position(), &item, &line, &outside);
+
 		if (selection.click) {
 
-			int line = 0;
-			Item *item = NULL;
-			_find_click(main, m->get_position(), &item, &line);
 			if (!item)
 				return; // do not update
 
@@ -911,6 +913,22 @@ void RichTextLabel::_gui_input(Ref<InputEvent> p_event) {
 
 			selection.active = true;
 			update();
+		}
+
+		Variant meta;
+		if (item && !outside && _find_meta(item, &meta)) {
+			if (meta_hovering != item) {
+				if (meta_hovering) {
+					emit_signal("meta_hover_ended", current_meta);
+				}
+				meta_hovering = static_cast<ItemMeta *>(item);
+				current_meta = meta;
+				emit_signal("meta_hover_started", meta);
+			}
+		} else if (meta_hovering) {
+			emit_signal("meta_hover_ended", current_meta);
+			meta_hovering = NULL;
+			current_meta = false;
 		}
 	}
 }
@@ -1968,6 +1986,8 @@ void RichTextLabel::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "override_selected_font_color"), "set_override_selected_font_color", "is_overriding_selected_font_color");
 
 	ADD_SIGNAL(MethodInfo("meta_clicked", PropertyInfo(Variant::NIL, "meta", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT)));
+	ADD_SIGNAL(MethodInfo("meta_hover_started", PropertyInfo(Variant::NIL, "meta", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT)));
+	ADD_SIGNAL(MethodInfo("meta_hover_ended", PropertyInfo(Variant::NIL, "meta", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT)));
 
 	BIND_ENUM_CONSTANT(ALIGN_LEFT);
 	BIND_ENUM_CONSTANT(ALIGN_CENTER);

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -225,6 +225,9 @@ private:
 
 	Align default_align;
 
+	ItemMeta *meta_hovering;
+	Variant current_meta;
+
 	void _invalidate_current_line(ItemFrame *p_frame);
 	void _validate_line_caches(ItemFrame *p_frame);
 


### PR DESCRIPTION
This will enable `meta_hover_start` and `meta_hover_end` events which also have the meta attached as a parameter. It supports only a single meta tag.

![richtextlabel_hoversignals](https://user-images.githubusercontent.com/16217563/32931338-4b8f6528-cb29-11e7-9f98-8c74e0b1d388.gif)

Note that the use of `current_meta` for line 930 of the .cpp was only needed because the attached meta kept on printing as an empty array on the scripting side when I tried just using `meta_hovering->meta`. Not quite sure why. If there is a way to remove the use of `current_meta` though, I'd be all for it.