### PR TITLE
Add support for XDG Base Directory spec

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -888,9 +888,9 @@ void _OS::dump_resources_to_file(const String &p_file) {
 	OS::get_singleton()->dump_resources_to_file(p_file.utf8().get_data());
 }
 
-String _OS::get_data_dir() const {
+String _OS::get_user_data_dir() const {
 
-	return OS::get_singleton()->get_data_dir();
+	return OS::get_singleton()->get_user_data_dir();
 };
 
 Error _OS::native_video_play(String p_path, float p_volume, String p_audio_track, String p_subtitle_track) {
@@ -1088,7 +1088,7 @@ void _OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_static_memory_peak_usage"), &_OS::get_static_memory_peak_usage);
 	ClassDB::bind_method(D_METHOD("get_dynamic_memory_usage"), &_OS::get_dynamic_memory_usage);
 
-	ClassDB::bind_method(D_METHOD("get_data_dir"), &_OS::get_data_dir);
+	ClassDB::bind_method(D_METHOD("get_user_data_dir"), &_OS::get_user_data_dir);
 	ClassDB::bind_method(D_METHOD("get_system_dir", "dir"), &_OS::get_system_dir);
 	ClassDB::bind_method(D_METHOD("get_unique_id"), &_OS::get_unique_id);
 

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -297,7 +297,7 @@ public:
 
 	String get_system_dir(SystemDir p_dir) const;
 
-	String get_data_dir() const;
+	String get_user_data_dir() const;
 
 	void alert(const String &p_alert, const String &p_title = "ALERT!");
 

--- a/core/os/dir_access.cpp
+++ b/core/os/dir_access.cpp
@@ -38,7 +38,7 @@ String DirAccess::_get_root_path() const {
 	switch (_access_type) {
 
 		case ACCESS_RESOURCES: return ProjectSettings::get_singleton()->get_resource_path();
-		case ACCESS_USERDATA: return OS::get_singleton()->get_data_dir();
+		case ACCESS_USERDATA: return OS::get_singleton()->get_user_data_dir();
 		default: return "";
 	}
 
@@ -217,7 +217,7 @@ String DirAccess::fix_path(String p_path) const {
 
 			if (p_path.begins_with("user://")) {
 
-				String data_dir = OS::get_singleton()->get_data_dir();
+				String data_dir = OS::get_singleton()->get_user_data_dir();
 				if (data_dir != "") {
 
 					return p_path.replace_first("user:/", data_dir);

--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -152,7 +152,7 @@ String FileAccess::fix_path(const String &p_path) const {
 
 			if (r_path.begins_with("user://")) {
 
-				String data_dir = OS::get_singleton()->get_data_dir();
+				String data_dir = OS::get_singleton()->get_user_data_dir();
 				if (data_dir != "") {
 
 					return r_path.replace("user:/", data_dir);

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -281,7 +281,7 @@ String OS::get_safe_application_name() const {
 	return an;
 }
 
-String OS::get_data_dir() const {
+String OS::get_user_data_dir() const {
 
 	return ".";
 };
@@ -374,9 +374,9 @@ OS::ScreenOrientation OS::get_screen_orientation() const {
 	return (OS::ScreenOrientation)_orientation;
 }
 
-void OS::_ensure_data_dir() {
+void OS::_ensure_user_data_dir() {
 
-	String dd = get_data_dir();
+	String dd = get_user_data_dir();
 	DirAccess *da = DirAccess::open(dd);
 	if (da) {
 		memdelete(da);

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -33,6 +33,7 @@
 #include "input.h"
 #include "os/file_access.h"
 #include "project_settings.h"
+#include "version_generated.gen.h"
 
 #include <stdarg.h>
 
@@ -262,16 +263,7 @@ String OS::get_locale() const {
 	return "en";
 }
 
-String OS::get_resource_dir() const {
-
-	return ProjectSettings::get_singleton()->get_resource_path();
-}
-
-String OS::get_system_dir(SystemDir p_dir) const {
-
-	return ".";
-}
-
+// Helper function used by OS_Unix and OS_Windows
 String OS::get_safe_application_name() const {
 	String an = ProjectSettings::get_singleton()->get("application/config/name");
 	Vector<String> invalid_char = String("\\ / : * ? \" < > |").split(" ");
@@ -281,10 +273,50 @@ String OS::get_safe_application_name() const {
 	return an;
 }
 
+// Path to data, config, cache, etc. OS-specific folders
+
+// Get properly capitalized engine name for system paths
+String OS::get_godot_dir_name() const {
+
+	// Default to lowercase, so only override when different case is needed
+	return String(_MKSTR(VERSION_SHORT_NAME)).to_lower();
+}
+
+// OS equivalent of XDG_DATA_HOME
+String OS::get_data_path() const {
+
+	return ".";
+}
+
+// OS equivalent of XDG_CONFIG_HOME
+String OS::get_config_path() const {
+
+	return ".";
+}
+
+// OS equivalent of XDG_CACHE_HOME
+String OS::get_cache_path() const {
+
+	return ".";
+}
+
+// OS specific path for user://
 String OS::get_user_data_dir() const {
 
 	return ".";
 };
+
+// Absolute path to res://
+String OS::get_resource_dir() const {
+
+	return ProjectSettings::get_singleton()->get_resource_path();
+}
+
+// Access system-specific dirs like Documents, Downloads, etc.
+String OS::get_system_dir(SystemDir p_dir) const {
+
+	return ".";
+}
 
 Error OS::shell_open(String p_uri) {
 	return ERR_UNAVAILABLE;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -124,7 +124,7 @@ protected:
 
 	virtual void set_cmdline(const char *p_execpath, const List<String> &p_args);
 
-	void _ensure_data_dir();
+	void _ensure_user_data_dir();
 	virtual bool _check_internal_feature_support(const String &p_feature) = 0;
 
 public:
@@ -334,7 +334,7 @@ public:
 	virtual String get_locale() const;
 
 	String get_safe_application_name() const;
-	virtual String get_data_dir() const;
+	virtual String get_user_data_dir() const;
 	virtual String get_resource_dir() const;
 
 	virtual Error move_to_trash(const String &p_path) { return FAILED; }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -200,7 +200,6 @@ public:
 	virtual void set_low_processor_usage_mode(bool p_enabled);
 	virtual bool is_in_low_processor_usage_mode() const;
 
-	virtual String get_installed_templates_path() const { return ""; }
 	virtual String get_executable_path() const;
 	virtual Error execute(const String &p_path, const List<String> &p_arguments, bool p_blocking, ProcessID *r_child_id = NULL, String *r_pipe = NULL, int *r_exitcode = NULL, bool read_stderr = false) = 0;
 	virtual Error kill(const ProcessID &p_pid) = 0;
@@ -334,10 +333,14 @@ public:
 	virtual String get_locale() const;
 
 	String get_safe_application_name() const;
+	virtual String get_godot_dir_name() const;
+
+	virtual String get_data_path() const;
+	virtual String get_config_path() const;
+	virtual String get_cache_path() const;
+
 	virtual String get_user_data_dir() const;
 	virtual String get_resource_dir() const;
-
-	virtual Error move_to_trash(const String &p_path) { return FAILED; }
 
 	enum SystemDir {
 		SYSTEM_DIR_DESKTOP,
@@ -351,6 +354,8 @@ public:
 	};
 
 	virtual String get_system_dir(SystemDir p_dir) const;
+
+	virtual Error move_to_trash(const String &p_path) { return FAILED; }
 
 	virtual void set_no_window_mode(bool p_enable);
 	virtual bool is_no_window_mode_enabled() const;

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -116,7 +116,7 @@ String ProjectSettings::globalize_path(const String &p_path) const {
 		return p_path.replace("res://", "");
 	} else if (p_path.begins_with("user://")) {
 
-		String data_dir = OS::get_singleton()->get_data_dir();
+		String data_dir = OS::get_singleton()->get_user_data_dir();
 		if (data_dir != "") {
 
 			return p_path.replace("user:/", data_dir);

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -55,7 +55,7 @@
 				Get the list of favorite directories for this project.
 			</description>
 		</method>
-		<method name="get_project_settings_path" qualifiers="const">
+		<method name="get_project_settings_dir" qualifiers="const">
 			<return type="String">
 			</return>
 			<description>
@@ -77,7 +77,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_settings_path" qualifiers="const">
+		<method name="get_settings_dir" qualifiers="const">
 			<return type="String">
 			</return>
 			<description>

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -127,11 +127,11 @@
 				Returns the current screen index (0 padded).
 			</description>
 		</method>
-		<method name="get_data_dir" qualifiers="const">
+		<method name="get_user_data_dir" qualifiers="const">
 			<return type="String">
 			</return>
 			<description>
-				Returns the absolute directory path of user data path([user://]).
+				Returns the absolute directory path where user data is written ([code]user://[/code]).
 			</description>
 		</method>
 		<method name="get_date" qualifiers="const">

--- a/drivers/unix/SCsub
+++ b/drivers/unix/SCsub
@@ -2,16 +2,6 @@
 
 Import('env')
 
-g_set_p = '#ifdef UNIX_ENABLED\n'
-g_set_p += '#include "os_unix.h"\n'
-g_set_p += 'String OS_Unix::get_global_settings_path() const {\n'
-g_set_p += '\treturn "' + env["unix_global_settings_path"] + '";\n'
-g_set_p += '}\n'
-g_set_p += '#endif'
-f = open("os_unix_global_settings_path.gen.cpp", "w")
-f.write(g_set_p)
-f.close()
-
 env.add_source_files(env.drivers_sources, "*.cpp")
 
 env["check_c_headers"] = [ [ "mntent.h", "HAVE_MNTENT" ] ]

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -454,7 +454,7 @@ int OS_Unix::get_processor_count() const {
 	return sysconf(_SC_NPROCESSORS_CONF);
 }
 
-String OS_Unix::get_data_dir() const {
+String OS_Unix::get_user_data_dir() const {
 
 	String an = get_safe_application_name();
 	if (an != "") {

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -456,28 +456,17 @@ int OS_Unix::get_processor_count() const {
 
 String OS_Unix::get_user_data_dir() const {
 
-	String an = get_safe_application_name();
-	if (an != "") {
-
-		if (has_environment("HOME")) {
-
-			bool use_godot = ProjectSettings::get_singleton()->get("application/config/use_shared_user_dir");
-			if (use_godot)
-				return get_environment("HOME") + "/.godot/app_userdata/" + an;
-			else
-				return get_environment("HOME") + "/." + an;
+	String appname = get_safe_application_name();
+	if (appname != "") {
+		bool use_godot_dir = ProjectSettings::get_singleton()->get("application/config/use_shared_user_dir");
+		if (use_godot_dir) {
+			return get_data_path().plus_file(get_godot_dir_name()).plus_file("app_userdata").plus_file(appname);
+		} else {
+			return get_data_path().plus_file(appname);
 		}
 	}
 
 	return ProjectSettings::get_singleton()->get_resource_path();
-}
-
-String OS_Unix::get_installed_templates_path() const {
-	String p = get_global_settings_path();
-	if (p != "")
-		return p + "/templates/";
-	else
-		return "";
 }
 
 String OS_Unix::get_executable_path() const {

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -110,7 +110,7 @@ public:
 
 	virtual String get_installed_templates_path() const;
 	virtual String get_executable_path() const;
-	virtual String get_data_dir() const;
+	virtual String get_user_data_dir() const;
 
 	//virtual void run( MainLoop * p_main_loop );
 };

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -62,8 +62,6 @@ protected:
 
 	String stdin_buf;
 
-	String get_global_settings_path() const;
-
 public:
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
 	virtual String get_stdin_string(bool p_block);
@@ -108,11 +106,8 @@ public:
 
 	virtual void debug_break();
 
-	virtual String get_installed_templates_path() const;
 	virtual String get_executable_path() const;
 	virtual String get_user_data_dir() const;
-
-	//virtual void run( MainLoop * p_main_loop );
 };
 
 class UnixTerminalLogger : public StdLogger {

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -41,7 +41,7 @@ void CreateDialog::popup_create(bool p_dontclear) {
 
 	recent->clear();
 
-	FileAccess *f = FileAccess::open(EditorSettings::get_singleton()->get_project_settings_path().plus_file("create_recent." + base_type), FileAccess::READ);
+	FileAccess *f = FileAccess::open(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("create_recent." + base_type), FileAccess::READ);
 
 	if (f) {
 
@@ -63,7 +63,7 @@ void CreateDialog::popup_create(bool p_dontclear) {
 
 	favorites->clear();
 
-	f = FileAccess::open(EditorSettings::get_singleton()->get_project_settings_path().plus_file("favorites." + base_type), FileAccess::READ);
+	f = FileAccess::open(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("favorites." + base_type), FileAccess::READ);
 
 	favorite_list.clear();
 
@@ -316,7 +316,7 @@ void CreateDialog::_confirmed() {
 	if (!ti)
 		return;
 
-	FileAccess *f = FileAccess::open(EditorSettings::get_singleton()->get_project_settings_path().plus_file("create_recent." + base_type), FileAccess::WRITE);
+	FileAccess *f = FileAccess::open(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("create_recent." + base_type), FileAccess::WRITE);
 
 	if (f) {
 		f->store_line(get_selected_type());
@@ -476,7 +476,7 @@ void CreateDialog::_favorite_toggled() {
 
 void CreateDialog::_save_favorite_list() {
 
-	FileAccess *f = FileAccess::open(EditorSettings::get_singleton()->get_project_settings_path().plus_file("favorites." + base_type), FileAccess::WRITE);
+	FileAccess *f = FileAccess::open(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("favorites." + base_type), FileAccess::WRITE);
 
 	if (f) {
 

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -337,7 +337,7 @@ Error EditorExportPlatform::_save_zip_file(void *p_userdata, const String &p_pat
 String EditorExportPlatform::find_export_template(String template_file_name, String *err) const {
 
 	String base_name = itos(VERSION_MAJOR) + "." + itos(VERSION_MINOR) + "-" + _MKSTR(VERSION_STATUS) + "/" + template_file_name;
-	String user_file = EditorSettings::get_singleton()->get_settings_path() + "/templates/" + base_name;
+	String user_file = EditorSettings::get_singleton()->get_settings_dir() + "/templates/" + base_name;
 	String system_file = OS::get_singleton()->get_installed_templates_path();
 	bool has_system_path = (system_file != "");
 	system_file = system_file.plus_file(base_name);
@@ -692,7 +692,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 	}
 
 	String config_file = "project.binary";
-	String engine_cfb = EditorSettings::get_singleton()->get_settings_path() + "/tmp/tmp" + config_file;
+	String engine_cfb = EditorSettings::get_singleton()->get_settings_dir() + "/tmp/tmp" + config_file;
 	ProjectSettings::get_singleton()->save_custom(engine_cfb, custom_map, custom_list);
 	Vector<uint8_t> data = FileAccess::get_file_as_array(engine_cfb);
 
@@ -705,7 +705,7 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, c
 
 	EditorProgress ep("savepack", TTR("Packing"), 102);
 
-	String tmppath = EditorSettings::get_singleton()->get_settings_path() + "/tmp/packtmp";
+	String tmppath = EditorSettings::get_singleton()->get_settings_dir() + "/tmp/packtmp";
 	FileAccess *ftmp = FileAccess::open(tmppath, FileAccess::WRITE);
 	ERR_FAIL_COND_V(!ftmp, ERR_CANT_CREATE)
 

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -336,33 +336,18 @@ Error EditorExportPlatform::_save_zip_file(void *p_userdata, const String &p_pat
 
 String EditorExportPlatform::find_export_template(String template_file_name, String *err) const {
 
-	String base_name = itos(VERSION_MAJOR) + "." + itos(VERSION_MINOR) + "-" + _MKSTR(VERSION_STATUS) + "/" + template_file_name;
-	String user_file = EditorSettings::get_singleton()->get_settings_dir() + "/templates/" + base_name;
-	String system_file = OS::get_singleton()->get_installed_templates_path();
-	bool has_system_path = (system_file != "");
-	system_file = system_file.plus_file(base_name);
+	String current_version = itos(VERSION_MAJOR) + "." + itos(VERSION_MINOR) + "-" + _MKSTR(VERSION_STATUS) + VERSION_MODULE_CONFIG;
+	String template_path = EditorSettings::get_singleton()->get_templates_dir().plus_file(current_version).plus_file(template_file_name);
 
-	// Prefer user file
-	if (FileAccess::exists(user_file)) {
-		return user_file;
-	}
-
-	// Now check system file
-	if (has_system_path) {
-		if (FileAccess::exists(system_file)) {
-			return system_file;
-		}
+	if (FileAccess::exists(template_path)) {
+		return template_path;
 	}
 
 	// Not found
 	if (err) {
-		*err += "No export template found at \"" + user_file + "\"";
-		if (has_system_path)
-			*err += "\n or \"" + system_file + "\".";
-		else
-			*err += ".";
+		*err += "No export template found at \"" + template_path + "\".";
 	}
-	return String(); // not found
+	return String();
 }
 
 bool EditorExportPlatform::exists_export_template(String template_file_name, String *err) const {

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -677,7 +677,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 	}
 
 	String config_file = "project.binary";
-	String engine_cfb = EditorSettings::get_singleton()->get_settings_dir() + "/tmp/tmp" + config_file;
+	String engine_cfb = EditorSettings::get_singleton()->get_cache_dir().plus_file("tmp" + config_file);
 	ProjectSettings::get_singleton()->save_custom(engine_cfb, custom_map, custom_list);
 	Vector<uint8_t> data = FileAccess::get_file_as_array(engine_cfb);
 
@@ -690,7 +690,7 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, c
 
 	EditorProgress ep("savepack", TTR("Packing"), 102);
 
-	String tmppath = EditorSettings::get_singleton()->get_settings_dir() + "/tmp/packtmp";
+	String tmppath = EditorSettings::get_singleton()->get_cache_dir().plus_file("packtmp");
 	FileAccess *ftmp = FileAccess::open(tmppath, FileAccess::WRITE);
 	ERR_FAIL_COND_V(!ftmp, ERR_CANT_CREATE)
 

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -188,7 +188,7 @@ void EditorFileSystem::_scan_filesystem() {
 
 	String project = ProjectSettings::get_singleton()->get_resource_path();
 
-	String fscache = EditorSettings::get_singleton()->get_project_settings_path().plus_file("filesystem_cache3");
+	String fscache = EditorSettings::get_singleton()->get_project_settings_dir().plus_file("filesystem_cache3");
 	FileAccess *f = FileAccess::open(fscache, FileAccess::READ);
 
 	if (f) {
@@ -238,7 +238,7 @@ void EditorFileSystem::_scan_filesystem() {
 		memdelete(f);
 	}
 
-	String update_cache = EditorSettings::get_singleton()->get_project_settings_path().plus_file("filesystem_update3");
+	String update_cache = EditorSettings::get_singleton()->get_project_settings_dir().plus_file("filesystem_update3");
 
 	if (FileAccess::exists(update_cache)) {
 		{
@@ -282,7 +282,7 @@ void EditorFileSystem::_scan_filesystem() {
 }
 
 void EditorFileSystem::_save_filesystem_cache() {
-	String fscache = EditorSettings::get_singleton()->get_project_settings_path().plus_file("filesystem_cache3");
+	String fscache = EditorSettings::get_singleton()->get_project_settings_dir().plus_file("filesystem_cache3");
 
 	FileAccess *f = FileAccess::open(fscache, FileAccess::WRITE);
 	_save_filesystem_cache(filesystem, f);
@@ -1180,7 +1180,7 @@ EditorFileSystemDirectory *EditorFileSystem::get_filesystem_path(const String &p
 
 void EditorFileSystem::_save_late_updated_files() {
 	//files that already existed, and were modified, need re-scanning for dependencies upon project restart. This is done via saving this special file
-	String fscache = EditorSettings::get_singleton()->get_project_settings_path().plus_file("filesystem_update3");
+	String fscache = EditorSettings::get_singleton()->get_project_settings_dir().plus_file("filesystem_update3");
 	FileAccessRef f = FileAccess::open(fscache, FileAccess::WRITE);
 	for (Set<String>::Element *E = late_update_files.front(); E; E = E->next()) {
 		f->store_line(E->get());

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -705,7 +705,7 @@ void EditorNode::_get_scene_metadata(const String &p_file) {
 	if (!scene)
 		return;
 
-	String path = EditorSettings::get_singleton()->get_project_settings_path().plus_file(p_file.get_file() + "-editstate-" + p_file.md5_text() + ".cfg");
+	String path = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(p_file.get_file() + "-editstate-" + p_file.md5_text() + ".cfg");
 
 	Ref<ConfigFile> cf;
 	cf.instance();
@@ -739,7 +739,7 @@ void EditorNode::_set_scene_metadata(const String &p_file, int p_idx) {
 	scene->set_meta("__editor_run_settings__", Variant()); //clear it (no point in keeping it)
 	scene->set_meta("__editor_plugin_states__", Variant());
 
-	String path = EditorSettings::get_singleton()->get_project_settings_path().plus_file(p_file.get_file() + "-editstate-" + p_file.md5_text() + ".cfg");
+	String path = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(p_file.get_file() + "-editstate-" + p_file.md5_text() + ".cfg");
 
 	Ref<ConfigFile> cf;
 	cf.instance();
@@ -926,7 +926,7 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 		img->flip_y();
 
 		//save thumbnail directly, as thumbnailer may not update due to actual scene not changing md5
-		String temp_path = EditorSettings::get_singleton()->get_settings_path().plus_file("tmp");
+		String temp_path = EditorSettings::get_singleton()->get_settings_dir().plus_file("tmp");
 		String cache_base = ProjectSettings::get_singleton()->globalize_path(p_file).md5_text();
 		cache_base = temp_path.plus_file("resthumb-" + cache_base);
 
@@ -1198,7 +1198,7 @@ void EditorNode::_dialog_action(String p_file) {
 
 			Ref<ConfigFile> config;
 			config.instance();
-			Error err = config->load(EditorSettings::get_singleton()->get_settings_path().plus_file("editor_layouts-3.cfg"));
+			Error err = config->load(EditorSettings::get_singleton()->get_settings_dir().plus_file("editor_layouts-3.cfg"));
 
 			if (err == ERR_CANT_OPEN) {
 				config.instance(); // new config
@@ -1209,7 +1209,7 @@ void EditorNode::_dialog_action(String p_file) {
 
 			_save_docks_to_config(config, p_file);
 
-			config->save(EditorSettings::get_singleton()->get_settings_path().plus_file("editor_layouts-3.cfg"));
+			config->save(EditorSettings::get_singleton()->get_settings_dir().plus_file("editor_layouts-3.cfg"));
 
 			layout_dialog->hide();
 			_update_layouts_menu();
@@ -1226,7 +1226,7 @@ void EditorNode::_dialog_action(String p_file) {
 
 			Ref<ConfigFile> config;
 			config.instance();
-			Error err = config->load(EditorSettings::get_singleton()->get_settings_path().plus_file("editor_layouts-3.cfg"));
+			Error err = config->load(EditorSettings::get_singleton()->get_settings_dir().plus_file("editor_layouts-3.cfg"));
 
 			if (err != OK || !config->has_section(p_file)) {
 				show_warning(TTR("Layout name not found!"));
@@ -1240,7 +1240,7 @@ void EditorNode::_dialog_action(String p_file) {
 				config->set_value(p_file, E->get(), Variant());
 			}
 
-			config->save(EditorSettings::get_singleton()->get_settings_path().plus_file("editor_layouts-3.cfg"));
+			config->save(EditorSettings::get_singleton()->get_settings_dir().plus_file("editor_layouts-3.cfg"));
 
 			layout_dialog->hide();
 			_update_layouts_menu();
@@ -3581,7 +3581,7 @@ void EditorNode::_save_docks() {
 	_save_docks_to_config(config, "docks");
 	editor_data.get_plugin_window_layout(config);
 
-	config->save(EditorSettings::get_singleton()->get_project_settings_path().plus_file("editor_layout.cfg"));
+	config->save(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
 }
 
 void EditorNode::_save_docks_to_config(Ref<ConfigFile> p_layout, const String &p_section) {
@@ -3643,7 +3643,7 @@ void EditorNode::_load_docks() {
 
 	Ref<ConfigFile> config;
 	config.instance();
-	Error err = config->load(EditorSettings::get_singleton()->get_project_settings_path().plus_file("editor_layout.cfg"));
+	Error err = config->load(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
 	if (err != OK) {
 		//no config
 		if (overridden_default_layout >= 0) {
@@ -3812,7 +3812,7 @@ void EditorNode::_update_layouts_menu() {
 
 	Ref<ConfigFile> config;
 	config.instance();
-	Error err = config->load(EditorSettings::get_singleton()->get_settings_path().plus_file("editor_layouts-3.cfg"));
+	Error err = config->load(EditorSettings::get_singleton()->get_settings_dir().plus_file("editor_layouts-3.cfg"));
 	if (err != OK) {
 		return; //no config
 	}
@@ -3860,7 +3860,7 @@ void EditorNode::_layout_menu_option(int p_id) {
 
 			Ref<ConfigFile> config;
 			config.instance();
-			Error err = config->load(EditorSettings::get_singleton()->get_settings_path().plus_file("editor_layouts-3.cfg"));
+			Error err = config->load(EditorSettings::get_singleton()->get_settings_dir().plus_file("editor_layouts-3.cfg"));
 			if (err != OK) {
 				return; //no config
 			}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -926,7 +926,7 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 		img->flip_y();
 
 		//save thumbnail directly, as thumbnailer may not update due to actual scene not changing md5
-		String temp_path = EditorSettings::get_singleton()->get_settings_dir().plus_file("tmp");
+		String temp_path = EditorSettings::get_singleton()->get_cache_dir();
 		String cache_base = ProjectSettings::get_singleton()->globalize_path(p_file).md5_text();
 		cache_base = temp_path.plus_file("resthumb-" + cache_base);
 
@@ -1198,7 +1198,7 @@ void EditorNode::_dialog_action(String p_file) {
 
 			Ref<ConfigFile> config;
 			config.instance();
-			Error err = config->load(EditorSettings::get_singleton()->get_settings_dir().plus_file("editor_layouts-3.cfg"));
+			Error err = config->load(EditorSettings::get_singleton()->get_editor_layouts_config());
 
 			if (err == ERR_CANT_OPEN) {
 				config.instance(); // new config
@@ -1209,7 +1209,7 @@ void EditorNode::_dialog_action(String p_file) {
 
 			_save_docks_to_config(config, p_file);
 
-			config->save(EditorSettings::get_singleton()->get_settings_dir().plus_file("editor_layouts-3.cfg"));
+			config->save(EditorSettings::get_singleton()->get_editor_layouts_config());
 
 			layout_dialog->hide();
 			_update_layouts_menu();
@@ -1226,7 +1226,7 @@ void EditorNode::_dialog_action(String p_file) {
 
 			Ref<ConfigFile> config;
 			config.instance();
-			Error err = config->load(EditorSettings::get_singleton()->get_settings_dir().plus_file("editor_layouts-3.cfg"));
+			Error err = config->load(EditorSettings::get_singleton()->get_editor_layouts_config());
 
 			if (err != OK || !config->has_section(p_file)) {
 				show_warning(TTR("Layout name not found!"));
@@ -1240,7 +1240,7 @@ void EditorNode::_dialog_action(String p_file) {
 				config->set_value(p_file, E->get(), Variant());
 			}
 
-			config->save(EditorSettings::get_singleton()->get_settings_dir().plus_file("editor_layouts-3.cfg"));
+			config->save(EditorSettings::get_singleton()->get_editor_layouts_config());
 
 			layout_dialog->hide();
 			_update_layouts_menu();
@@ -3812,7 +3812,7 @@ void EditorNode::_update_layouts_menu() {
 
 	Ref<ConfigFile> config;
 	config.instance();
-	Error err = config->load(EditorSettings::get_singleton()->get_settings_dir().plus_file("editor_layouts-3.cfg"));
+	Error err = config->load(EditorSettings::get_singleton()->get_editor_layouts_config());
 	if (err != OK) {
 		return; //no config
 	}
@@ -3860,7 +3860,7 @@ void EditorNode::_layout_menu_option(int p_id) {
 
 			Ref<ConfigFile> config;
 			config.instance();
-			Error err = config->load(EditorSettings::get_singleton()->get_settings_dir().plus_file("editor_layouts-3.cfg"));
+			Error err = config->load(EditorSettings::get_singleton()->get_editor_layouts_config());
 			if (err != OK) {
 				return; //no config
 			}

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -198,7 +198,7 @@ void EditorResourcePreview::_thread() {
 
 				} else {
 
-					String temp_path = EditorSettings::get_singleton()->get_settings_path().plus_file("tmp");
+					String temp_path = EditorSettings::get_singleton()->get_settings_dir().plus_file("tmp");
 					String cache_base = ProjectSettings::get_singleton()->globalize_path(item.path).md5_text();
 					cache_base = temp_path.plus_file("resthumb-" + cache_base);
 

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -198,7 +198,7 @@ void EditorResourcePreview::_thread() {
 
 				} else {
 
-					String temp_path = EditorSettings::get_singleton()->get_settings_dir().plus_file("tmp");
+					String temp_path = EditorSettings::get_singleton()->get_cache_dir();
 					String cache_base = ProjectSettings::get_singleton()->globalize_path(item.path).md5_text();
 					cache_base = temp_path.plus_file("resthumb-" + cache_base);
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -712,6 +712,12 @@ void EditorSettings::create() {
 			}
 		}
 
+		if (dir->change_dir("templates") != OK) {
+			dir->make_dir("templates");
+		} else {
+			dir->change_dir("..");
+		}
+
 		// Validate/create cache dir
 
 		if (dir->change_dir(cache_path) != OK) {
@@ -746,20 +752,6 @@ void EditorSettings::create() {
 			}
 		}
 
-		// FIXME: Move to data dir
-		if (dir->change_dir("templates") != OK) {
-			dir->make_dir("templates");
-		} else {
-			dir->change_dir("..");
-		}
-
-		// FIXME: Move to cache dir
-		if (dir->change_dir("tmp") != OK) {
-			dir->make_dir("tmp");
-		} else {
-			dir->change_dir("..");
-		}
-
 		if (dir->change_dir("text_editor_themes") != OK) {
 			dir->make_dir("text_editor_themes");
 		} else {
@@ -771,18 +763,17 @@ void EditorSettings::create() {
 		} else {
 			dir->change_dir("..");
 		}
-		_create_script_templates(dir->get_current_dir() + "/script_templates");
+		_create_script_templates(dir->get_current_dir().plus_file("script_templates"));
 
-		// FIXME: Rename to "projects"
-		if (dir->change_dir("config") != OK) {
-			dir->make_dir("config");
+		if (dir->change_dir("projects") != OK) {
+			dir->make_dir("projects");
 		} else {
 			dir->change_dir("..");
 		}
 
 		// Validate/create project-specific config dir
 
-		dir->change_dir("config");
+		dir->change_dir("projects");
 		String project_config_dir = ProjectSettings::get_singleton()->get_resource_path();
 		if (project_config_dir.ends_with("/"))
 			project_config_dir = config_path.substr(0, project_config_dir.size() - 1);
@@ -1040,8 +1031,7 @@ String EditorSettings::get_settings_dir() const {
 
 String EditorSettings::get_project_settings_dir() const {
 
-	// FIXME: Rename to "projects"
-	return get_settings_dir().plus_file("config").plus_file(project_config_dir);
+	return get_settings_dir().plus_file("projects").plus_file(project_config_dir);
 }
 
 String EditorSettings::get_text_editor_themes_dir() const {
@@ -1138,7 +1128,7 @@ void EditorSettings::load_favorites() {
 
 void EditorSettings::list_text_editor_themes() {
 	String themes = "Adaptive,Default";
-	DirAccess *d = DirAccess::open(get_settings_dir().plus_file("text_editor_themes"));
+	DirAccess *d = DirAccess::open(get_text_editor_themes_dir());
 	if (d) {
 		d->list_dir_begin();
 		String file = d->get_next();
@@ -1160,7 +1150,7 @@ void EditorSettings::load_text_editor_theme() {
 		return;
 	}
 
-	String theme_path = get_settings_dir().plus_file("text_editor_themes").plus_file((String)get("text_editor/theme/color_theme") + ".tet");
+	String theme_path = get_text_editor_themes_dir().plus_file((String)get("text_editor/theme/color_theme") + ".tet");
 
 	Ref<ConfigFile> cf = memnew(ConfigFile);
 	Error err = cf->load(theme_path);
@@ -1198,9 +1188,9 @@ bool EditorSettings::import_text_editor_theme(String p_file) {
 			return false;
 		}
 
-		DirAccess *d = DirAccess::open(get_settings_dir().plus_file("text_editor_themes"));
+		DirAccess *d = DirAccess::open(get_text_editor_themes_dir());
 		if (d) {
-			d->copy(p_file, get_settings_dir().plus_file("text_editor_themes").plus_file(p_file.get_file()));
+			d->copy(p_file, get_text_editor_themes_dir().plus_file(p_file.get_file()));
 			memdelete(d);
 			return true;
 		}
@@ -1215,7 +1205,7 @@ bool EditorSettings::save_text_editor_theme() {
 	if (p_file.get_file().to_lower() == "default" || p_file.get_file().to_lower() == "adaptive") {
 		return false;
 	}
-	String theme_path = get_settings_dir().plus_file("text_editor_themes").plus_file(p_file + ".tet");
+	String theme_path = get_text_editor_themes_dir().plus_file(p_file + ".tet");
 	return _save_text_editor_theme(theme_path);
 }
 
@@ -1233,7 +1223,7 @@ bool EditorSettings::save_text_editor_theme_as(String p_file) {
 		list_text_editor_themes();
 		String theme_name = p_file.substr(0, p_file.length() - 4).get_file();
 
-		if (p_file.get_base_dir() == get_settings_dir().plus_file("text_editor_themes")) {
+		if (p_file.get_base_dir() == get_text_editor_themes_dir()) {
 			_initial_set("text_editor/theme/color_theme", theme_name);
 			load_text_editor_theme();
 		}
@@ -1245,7 +1235,7 @@ bool EditorSettings::save_text_editor_theme_as(String p_file) {
 Vector<String> EditorSettings::get_script_templates(const String &p_extension) {
 
 	Vector<String> templates;
-	DirAccess *d = DirAccess::open(get_settings_dir().plus_file("script_templates"));
+	DirAccess *d = DirAccess::open(get_script_templates_dir());
 	if (d) {
 		d->list_dir_begin();
 		String file = d->get_next();
@@ -1259,6 +1249,11 @@ Vector<String> EditorSettings::get_script_templates(const String &p_extension) {
 		memdelete(d);
 	}
 	return templates;
+}
+
+String EditorSettings::get_editor_layouts_config() const {
+
+	return get_settings_dir().plus_file("editor_layouts.cfg");
 }
 
 // Shortcuts

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -147,8 +147,8 @@ public:
 	void set_resource_clipboard(const Ref<Resource> &p_resource) { clipboard = p_resource; }
 	Ref<Resource> get_resource_clipboard() const { return clipboard; }
 
-	String get_settings_path() const;
-	String get_project_settings_path() const;
+	String get_settings_dir() const;
+	String get_project_settings_dir() const;
 
 	void set_project_metadata(const String &p_section, const String &p_key, Variant p_data);
 	Variant get_project_metadata(const String &p_section, const String &p_key, Variant p_default);

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -173,6 +173,7 @@ public:
 	bool save_text_editor_theme_as(String p_file);
 
 	Vector<String> get_script_templates(const String &p_extension);
+	String get_editor_layouts_config() const;
 
 	void add_shortcut(const String &p_name, Ref<ShortCut> &p_shortcut);
 	bool is_shortcut(const String &p_name, const Ref<InputEvent> &p_event) const;

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -93,9 +93,11 @@ private:
 	Map<String, Ref<ShortCut> > shortcuts;
 
 	String resource_path;
+	String settings_dir;
+	String data_dir;
+	String cache_dir;
 	String config_file_path;
-	String settings_path;
-	String project_config_path;
+	String project_config_dir;
 
 	Vector<String> favorite_dirs;
 	Vector<String> recent_dirs;
@@ -147,8 +149,13 @@ public:
 	void set_resource_clipboard(const Ref<Resource> &p_resource) { clipboard = p_resource; }
 	Ref<Resource> get_resource_clipboard() const { return clipboard; }
 
+	String get_data_dir() const;
+	String get_templates_dir() const;
 	String get_settings_dir() const;
 	String get_project_settings_dir() const;
+	String get_text_editor_themes_dir() const;
+	String get_script_templates_dir() const;
+	String get_cache_dir() const;
 
 	void set_project_metadata(const String &p_section, const String &p_key, Variant p_data);
 	Variant get_project_metadata(const String &p_section, const String &p_key, Variant p_default);

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -46,7 +46,7 @@ void ExportTemplateManager::_update_template_list() {
 	}
 
 	DirAccess *d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	Error err = d->change_dir(EditorSettings::get_singleton()->get_settings_path().plus_file("templates"));
+	Error err = d->change_dir(EditorSettings::get_singleton()->get_settings_dir().plus_file("templates"));
 
 	d->list_dir_begin();
 	Set<String> templates;
@@ -142,7 +142,7 @@ void ExportTemplateManager::_uninstall_template(const String &p_version) {
 void ExportTemplateManager::_uninstall_template_confirm() {
 
 	DirAccess *d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	Error err = d->change_dir(EditorSettings::get_singleton()->get_settings_path().plus_file("templates"));
+	Error err = d->change_dir(EditorSettings::get_singleton()->get_settings_dir().plus_file("templates"));
 
 	ERR_FAIL_COND(err != OK);
 
@@ -244,7 +244,7 @@ void ExportTemplateManager::_install_from_file(const String &p_file) {
 		return;
 	}
 
-	String template_path = EditorSettings::get_singleton()->get_settings_path().plus_file("templates").plus_file(version);
+	String template_path = EditorSettings::get_singleton()->get_settings_dir().plus_file("templates").plus_file(version);
 
 	DirAccess *d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	Error err = d->make_dir_recursive(template_path);
@@ -393,7 +393,7 @@ void ExportTemplateManager::_http_download_templates_completed(int p_status, int
 			if (p_code != 200) {
 				template_list_state->set_text(TTR("Failed:") + " " + itos(p_code));
 			} else {
-				String path = EditorSettings::get_singleton()->get_settings_path().plus_file("tmp").plus_file("tmp_templates.tpz");
+				String path = EditorSettings::get_singleton()->get_settings_dir().plus_file("tmp").plus_file("tmp_templates.tpz");
 				FileAccess *f = FileAccess::open(path, FileAccess::WRITE);
 				if (!f) {
 					template_list_state->set_text(TTR("Can't write file."));

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -35,6 +35,7 @@
 #include "io/zip_io.h"
 #include "os/dir_access.h"
 #include "version.h"
+
 void ExportTemplateManager::_update_template_list() {
 
 	while (current_hb->get_child_count()) {
@@ -46,7 +47,7 @@ void ExportTemplateManager::_update_template_list() {
 	}
 
 	DirAccess *d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	Error err = d->change_dir(EditorSettings::get_singleton()->get_settings_dir().plus_file("templates"));
+	Error err = d->change_dir(EditorSettings::get_singleton()->get_templates_dir());
 
 	d->list_dir_begin();
 	Set<String> templates;
@@ -142,7 +143,7 @@ void ExportTemplateManager::_uninstall_template(const String &p_version) {
 void ExportTemplateManager::_uninstall_template_confirm() {
 
 	DirAccess *d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	Error err = d->change_dir(EditorSettings::get_singleton()->get_settings_dir().plus_file("templates"));
+	Error err = d->change_dir(EditorSettings::get_singleton()->get_templates_dir());
 
 	ERR_FAIL_COND(err != OK);
 
@@ -244,7 +245,7 @@ void ExportTemplateManager::_install_from_file(const String &p_file) {
 		return;
 	}
 
-	String template_path = EditorSettings::get_singleton()->get_settings_dir().plus_file("templates").plus_file(version);
+	String template_path = EditorSettings::get_singleton()->get_templates_dir().plus_file(version);
 
 	DirAccess *d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	Error err = d->make_dir_recursive(template_path);
@@ -393,7 +394,7 @@ void ExportTemplateManager::_http_download_templates_completed(int p_status, int
 			if (p_code != 200) {
 				template_list_state->set_text(TTR("Failed:") + " " + itos(p_code));
 			} else {
-				String path = EditorSettings::get_singleton()->get_settings_dir().plus_file("tmp").plus_file("tmp_templates.tpz");
+				String path = EditorSettings::get_singleton()->get_cache_dir().plus_file("tmp_templates.tpz");
 				FileAccess *f = FileAccess::open(path, FileAccess::WRITE);
 				if (!f) {
 					template_list_state->set_text(TTR("Can't write file."));

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -445,7 +445,7 @@ void EditorAssetLibraryItemDownload::_install() {
 
 void EditorAssetLibraryItemDownload::_make_request() {
 	download->cancel_request();
-	download->set_download_file(EditorSettings::get_singleton()->get_settings_path().plus_file("tmp").plus_file("tmp_asset_" + itos(asset_id)) + ".zip");
+	download->set_download_file(EditorSettings::get_singleton()->get_settings_dir().plus_file("tmp").plus_file("tmp_asset_" + itos(asset_id)) + ".zip");
 
 	Error err = download->request(host);
 	if (err != OK) {
@@ -680,7 +680,7 @@ void EditorAssetLibrary::_image_update(bool use_cache, bool final, const PoolByt
 		PoolByteArray image_data = p_data;
 
 		if (use_cache) {
-			String cache_filename_base = EditorSettings::get_singleton()->get_settings_path().plus_file("tmp").plus_file("assetimage_" + image_queue[p_queue_id].image_url.md5_text());
+			String cache_filename_base = EditorSettings::get_singleton()->get_settings_dir().plus_file("tmp").plus_file("assetimage_" + image_queue[p_queue_id].image_url.md5_text());
 
 			FileAccess *file = FileAccess::open(cache_filename_base + ".data", FileAccess::READ);
 
@@ -738,7 +738,7 @@ void EditorAssetLibrary::_image_request_completed(int p_status, int p_code, cons
 		if (p_code != HTTPClient::RESPONSE_NOT_MODIFIED) {
 			for (int i = 0; i < headers.size(); i++) {
 				if (headers[i].findn("ETag:") == 0) { // Save etag
-					String cache_filename_base = EditorSettings::get_singleton()->get_settings_path().plus_file("tmp").plus_file("assetimage_" + image_queue[p_queue_id].image_url.md5_text());
+					String cache_filename_base = EditorSettings::get_singleton()->get_settings_dir().plus_file("tmp").plus_file("assetimage_" + image_queue[p_queue_id].image_url.md5_text());
 					String new_etag = headers[i].substr(headers[i].find(":") + 1, headers[i].length()).strip_edges();
 					FileAccess *file;
 
@@ -786,7 +786,7 @@ void EditorAssetLibrary::_update_image_queue() {
 	for (Map<int, ImageQueue>::Element *E = image_queue.front(); E; E = E->next()) {
 		if (!E->get().active && current_images < max_images) {
 
-			String cache_filename_base = EditorSettings::get_singleton()->get_settings_path().plus_file("tmp").plus_file("assetimage_" + E->get().image_url.md5_text());
+			String cache_filename_base = EditorSettings::get_singleton()->get_settings_dir().plus_file("tmp").plus_file("assetimage_" + E->get().image_url.md5_text());
 			Vector<String> headers;
 
 			if (FileAccess::exists(cache_filename_base + ".etag") && FileAccess::exists(cache_filename_base + ".data")) {

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -445,7 +445,7 @@ void EditorAssetLibraryItemDownload::_install() {
 
 void EditorAssetLibraryItemDownload::_make_request() {
 	download->cancel_request();
-	download->set_download_file(EditorSettings::get_singleton()->get_settings_dir().plus_file("tmp").plus_file("tmp_asset_" + itos(asset_id)) + ".zip");
+	download->set_download_file(EditorSettings::get_singleton()->get_cache_dir().plus_file("tmp_asset_" + itos(asset_id)) + ".zip");
 
 	Error err = download->request(host);
 	if (err != OK) {
@@ -680,7 +680,7 @@ void EditorAssetLibrary::_image_update(bool use_cache, bool final, const PoolByt
 		PoolByteArray image_data = p_data;
 
 		if (use_cache) {
-			String cache_filename_base = EditorSettings::get_singleton()->get_settings_dir().plus_file("tmp").plus_file("assetimage_" + image_queue[p_queue_id].image_url.md5_text());
+			String cache_filename_base = EditorSettings::get_singleton()->get_cache_dir().plus_file("assetimage_" + image_queue[p_queue_id].image_url.md5_text());
 
 			FileAccess *file = FileAccess::open(cache_filename_base + ".data", FileAccess::READ);
 
@@ -738,7 +738,7 @@ void EditorAssetLibrary::_image_request_completed(int p_status, int p_code, cons
 		if (p_code != HTTPClient::RESPONSE_NOT_MODIFIED) {
 			for (int i = 0; i < headers.size(); i++) {
 				if (headers[i].findn("ETag:") == 0) { // Save etag
-					String cache_filename_base = EditorSettings::get_singleton()->get_settings_dir().plus_file("tmp").plus_file("assetimage_" + image_queue[p_queue_id].image_url.md5_text());
+					String cache_filename_base = EditorSettings::get_singleton()->get_cache_dir().plus_file("assetimage_" + image_queue[p_queue_id].image_url.md5_text());
 					String new_etag = headers[i].substr(headers[i].find(":") + 1, headers[i].length()).strip_edges();
 					FileAccess *file;
 
@@ -786,7 +786,7 @@ void EditorAssetLibrary::_update_image_queue() {
 	for (Map<int, ImageQueue>::Element *E = image_queue.front(); E; E = E->next()) {
 		if (!E->get().active && current_images < max_images) {
 
-			String cache_filename_base = EditorSettings::get_singleton()->get_settings_dir().plus_file("tmp").plus_file("assetimage_" + E->get().image_url.md5_text());
+			String cache_filename_base = EditorSettings::get_singleton()->get_cache_dir().plus_file("assetimage_" + E->get().image_url.md5_text());
 			Vector<String> headers;
 
 			if (FileAccess::exists(cache_filename_base + ".etag") && FileAccess::exists(cache_filename_base + ".data")) {

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -184,7 +184,7 @@ Ref<Texture> EditorPackedScenePreviewPlugin::generate(const RES &p_from) {
 
 Ref<Texture> EditorPackedScenePreviewPlugin::generate_from_path(const String &p_path) {
 
-	String temp_path = EditorSettings::get_singleton()->get_settings_path().plus_file("tmp");
+	String temp_path = EditorSettings::get_singleton()->get_settings_dir().plus_file("tmp");
 	String cache_base = ProjectSettings::get_singleton()->globalize_path(p_path).md5_text();
 	cache_base = temp_path.plus_file("resthumb-" + cache_base);
 

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -184,7 +184,7 @@ Ref<Texture> EditorPackedScenePreviewPlugin::generate(const RES &p_from) {
 
 Ref<Texture> EditorPackedScenePreviewPlugin::generate_from_path(const String &p_path) {
 
-	String temp_path = EditorSettings::get_singleton()->get_settings_dir().plus_file("tmp");
+	String temp_path = EditorSettings::get_singleton()->get_cache_dir();
 	String cache_base = ProjectSettings::get_singleton()->globalize_path(p_path).md5_text();
 	cache_base = temp_path.plus_file("resthumb-" + cache_base);
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -855,7 +855,7 @@ void ScriptEditor::_menu_option(int p_option) {
 			file_dialog_option = FILE_SAVE_THEME_AS;
 			file_dialog->clear_filters();
 			file_dialog->add_filter("*.tet");
-			file_dialog->set_current_path(EditorSettings::get_singleton()->get_settings_path() + "/text_editor_themes/" + EditorSettings::get_singleton()->get("text_editor/theme/color_theme"));
+			file_dialog->set_current_path(EditorSettings::get_singleton()->get_settings_dir() + "/text_editor_themes/" + EditorSettings::get_singleton()->get("text_editor/theme/color_theme"));
 			file_dialog->popup_centered_ratio();
 			file_dialog->set_title(TTR("Save Theme As.."));
 		} break;

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -855,7 +855,7 @@ void ScriptEditor::_menu_option(int p_option) {
 			file_dialog_option = FILE_SAVE_THEME_AS;
 			file_dialog->clear_filters();
 			file_dialog->add_filter("*.tet");
-			file_dialog->set_current_path(EditorSettings::get_singleton()->get_settings_dir() + "/text_editor_themes/" + EditorSettings::get_singleton()->get("text_editor/theme/color_theme"));
+			file_dialog->set_current_path(EditorSettings::get_singleton()->get_text_editor_themes_dir().plus_file(EditorSettings::get_singleton()->get("text_editor/theme/color_theme")));
 			file_dialog->popup_centered_ratio();
 			file_dialog->set_title(TTR("Save Theme As.."));
 		} break;

--- a/editor/pvrtc_compress.cpp
+++ b/editor/pvrtc_compress.cpp
@@ -62,7 +62,7 @@ static void _compress_image(Image::CompressMode p_mode, Image *p_image) {
 		}
 		return;
 	}
-	String spath = EditorSettings::get_singleton()->get_settings_path();
+	String spath = EditorSettings::get_singleton()->get_settings_dir();
 
 	List<String> args;
 

--- a/editor/pvrtc_compress.cpp
+++ b/editor/pvrtc_compress.cpp
@@ -62,12 +62,12 @@ static void _compress_image(Image::CompressMode p_mode, Image *p_image) {
 		}
 		return;
 	}
-	String spath = EditorSettings::get_singleton()->get_settings_dir();
+	String tmppath = EditorSettings::get_singleton()->get_cache_dir();
 
 	List<String> args;
 
-	String src_img = spath + "/" + "_tmp_src_img.png";
-	String dst_img = spath + "/" + "_tmp_dst_img.pvr";
+	String src_img = tmppath.plus_file("_tmp_src_img.png");
+	String dst_img = tmppath.plus_file("_tmp_dst_img.pvr");
 
 	args.push_back("-i");
 	args.push_back(src_img);

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -128,7 +128,7 @@ void ScriptCreateDialog::_template_changed(int p_template) {
 	}
 	String ext = ScriptServer::get_language(language_menu->get_selected())->get_extension();
 	String name = template_list[p_template - 1] + "." + ext;
-	script_template = EditorSettings::get_singleton()->get_settings_path() + "/script_templates/" + name;
+	script_template = EditorSettings::get_singleton()->get_settings_dir() + "/script_templates/" + name;
 }
 
 void ScriptCreateDialog::ok_pressed() {

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -128,7 +128,7 @@ void ScriptCreateDialog::_template_changed(int p_template) {
 	}
 	String ext = ScriptServer::get_language(language_menu->get_selected())->get_extension();
 	String name = template_list[p_template - 1] + "." + ext;
-	script_template = EditorSettings::get_singleton()->get_settings_dir() + "/script_templates/" + name;
+	script_template = EditorSettings::get_singleton()->get_script_templates_dir().plus_file(name);
 }
 
 void ScriptCreateDialog::ok_pressed() {

--- a/modules/enet/networked_multiplayer_enet.cpp
+++ b/modules/enet/networked_multiplayer_enet.cpp
@@ -505,7 +505,7 @@ uint32_t NetworkedMultiplayerENet::_gen_unique_id() const {
 		hash = hash_djb2_one_32(
 				(uint32_t)OS::get_singleton()->get_unix_time(), hash);
 		hash = hash_djb2_one_32(
-				(uint32_t)OS::get_singleton()->get_data_dir().hash64(), hash);
+				(uint32_t)OS::get_singleton()->get_user_data_dir().hash64(), hash);
 		/*
 		hash = hash_djb2_one_32(
 					(uint32_t)OS::get_singleton()->get_unique_id().hash64(), hash );

--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -80,7 +80,7 @@ String _get_mono_user_dir() {
 		return settings_path.plus_file("mono");
 	}
 #else
-	return OS::get_singleton()->get_data_dir().plus_file("mono");
+	return OS::get_singleton()->get_user_data_dir().plus_file("mono");
 #endif
 }
 

--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -57,7 +57,7 @@ String _get_expected_build_config() {
 String _get_mono_user_dir() {
 #ifdef TOOLS_ENABLED
 	if (EditorSettings::get_singleton()) {
-		return EditorSettings::get_singleton()->get_settings_path().plus_file("mono");
+		return EditorSettings::get_singleton()->get_settings_dir().plus_file("mono");
 	} else {
 		String settings_path;
 

--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -57,7 +57,7 @@ String _get_expected_build_config() {
 String _get_mono_user_dir() {
 #ifdef TOOLS_ENABLED
 	if (EditorSettings::get_singleton()) {
-		return EditorSettings::get_singleton()->get_settings_dir().plus_file("mono");
+		return EditorSettings::get_singleton()->get_data_dir().plus_file("mono");
 	} else {
 		String settings_path;
 
@@ -68,13 +68,7 @@ String _get_mono_user_dir() {
 			// contain yourself
 			settings_path = exe_dir.plus_file("editor_data");
 		} else {
-			if (OS::get_singleton()->has_environment("APPDATA")) {
-				String app_data = OS::get_singleton()->get_environment("APPDATA").replace("\\", "/");
-				settings_path = app_data.plus_file(String(_MKSTR(VERSION_SHORT_NAME)).capitalize());
-			} else if (OS::get_singleton()->has_environment("HOME")) {
-				String home = OS::get_singleton()->get_environment("HOME");
-				settings_path = home.plus_file("." + String(_MKSTR(VERSION_SHORT_NAME)).to_lower());
-			}
+			settings_path = OS::get_singleton()->get_data_path().plus_file(OS::get_singleton()->get_godot_dir_name());
 		}
 
 		return settings_path.plus_file("mono");

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1066,7 +1066,7 @@ public:
 		if (use_reverse)
 			p_debug_flags |= DEBUG_FLAG_REMOTE_DEBUG_LOCALHOST;
 
-		String export_to = EditorSettings::get_singleton()->get_settings_path() + "/tmp/tmpexport.apk";
+		String export_to = EditorSettings::get_singleton()->get_settings_dir() + "/tmp/tmpexport.apk";
 		Error err = export_project(p_preset, true, export_to, p_debug_flags);
 		if (err) {
 			device_lock->unlock();
@@ -1291,7 +1291,7 @@ public:
 		zlib_filefunc_def io2 = io;
 		FileAccess *dst_f = NULL;
 		io2.opaque = &dst_f;
-		String unaligned_path = EditorSettings::get_singleton()->get_settings_path() + "/tmp/tmpexport-unaligned.apk";
+		String unaligned_path = EditorSettings::get_singleton()->get_settings_dir() + "/tmp/tmpexport-unaligned.apk";
 		zipFile unaligned_apk = zipOpen2(unaligned_path.utf8().get_data(), APPEND_STATUS_CREATE, NULL, &io2);
 
 		bool export_x86 = p_preset->get("architecture/x86");

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1066,7 +1066,7 @@ public:
 		if (use_reverse)
 			p_debug_flags |= DEBUG_FLAG_REMOTE_DEBUG_LOCALHOST;
 
-		String export_to = EditorSettings::get_singleton()->get_settings_dir() + "/tmp/tmpexport.apk";
+		String export_to = EditorSettings::get_singleton()->get_cache_dir().plus_file("tmpexport.apk");
 		Error err = export_project(p_preset, true, export_to, p_debug_flags);
 		if (err) {
 			device_lock->unlock();
@@ -1291,7 +1291,7 @@ public:
 		zlib_filefunc_def io2 = io;
 		FileAccess *dst_f = NULL;
 		io2.opaque = &dst_f;
-		String unaligned_path = EditorSettings::get_singleton()->get_settings_dir() + "/tmp/tmpexport-unaligned.apk";
+		String unaligned_path = EditorSettings::get_singleton()->get_cache_dir().plus_file("tmpexport-unaligned.apk");
 		zipFile unaligned_apk = zipOpen2(unaligned_path.utf8().get_data(), APPEND_STATUS_CREATE, NULL, &io2);
 
 		bool export_x86 = p_preset->get("architecture/x86");

--- a/platform/android/java_glue.cpp
+++ b/platform/android/java_glue.cpp
@@ -647,7 +647,7 @@ static int _open_uri(const String &p_uri) {
 	return env->CallIntMethod(godot_io, _openURI, jStr);
 }
 
-static String _get_data_dir() {
+static String _get_user_data_dir() {
 
 	JNIEnv *env = ThreadAndroid::get_env();
 	jstring s = (jstring)env->CallObjectMethod(godot_io, _getDataDir);
@@ -825,7 +825,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_initialize(JNIEnv *en
 		AudioDriverAndroid::setup(gob);
 	}
 
-	os_android = new OS_Android(_gfx_init_func, env, _open_uri, _get_data_dir, _get_locale, _get_model, _get_screen_dpi, _show_vk, _hide_vk, _get_vk_height, _set_screen_orient, _get_unique_id, _get_system_dir, _play_video, _is_video_playing, _pause_video, _stop_video, _set_keep_screen_on, _alert, p_use_apk_expansion);
+	os_android = new OS_Android(_gfx_init_func, env, _open_uri, _get_user_data_dir, _get_locale, _get_model, _get_screen_dpi, _show_vk, _hide_vk, _get_vk_height, _set_screen_orient, _get_unique_id, _get_system_dir, _play_video, _is_video_playing, _pause_video, _stop_video, _set_keep_screen_on, _alert, p_use_apk_expansion);
 	os_android->set_need_reload_hooks(p_need_reload_hook);
 
 	char wd[500];

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -612,13 +612,13 @@ void OS_Android::set_need_reload_hooks(bool p_needs_them) {
 	use_reload_hooks = p_needs_them;
 }
 
-String OS_Android::get_data_dir() const {
+String OS_Android::get_user_data_dir() const {
 
 	if (data_dir_cache != String())
 		return data_dir_cache;
 
-	if (get_data_dir_func) {
-		String data_dir = get_data_dir_func();
+	if (get_user_data_dir_func) {
+		String data_dir = get_user_data_dir_func();
 
 		//store current dir
 		char real_current_dir_name[2048];
@@ -641,7 +641,6 @@ String OS_Android::get_data_dir() const {
 	}
 
 	return ".";
-	//return Engine::get_singleton()->get_singleton_object("GodotOS")->call("get_data_dir");
 }
 
 void OS_Android::set_screen_orientation(ScreenOrientation p_orientation) {
@@ -709,7 +708,7 @@ bool OS_Android::_check_internal_feature_support(const String &p_feature) {
 	return p_feature == "mobile" || p_feature == "etc" || p_feature == "etc2"; //TODO support etc2 only if GLES3 driver is selected
 }
 
-OS_Android::OS_Android(GFXInitFunc p_gfx_init_func, void *p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetDataDirFunc p_get_data_dir_func, GetLocaleFunc p_get_locale_func, GetModelFunc p_get_model_func, GetScreenDPIFunc p_get_screen_dpi_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk, VirtualKeyboardHeightFunc p_vk_height_func, SetScreenOrientationFunc p_screen_orient, GetUniqueIDFunc p_get_unique_id, GetSystemDirFunc p_get_sdir_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func, SetKeepScreenOnFunc p_set_keep_screen_on_func, AlertFunc p_alert_func, bool p_use_apk_expansion) {
+OS_Android::OS_Android(GFXInitFunc p_gfx_init_func, void *p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetUserDataDirFunc p_get_user_data_dir_func, GetLocaleFunc p_get_locale_func, GetModelFunc p_get_model_func, GetScreenDPIFunc p_get_screen_dpi_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk, VirtualKeyboardHeightFunc p_vk_height_func, SetScreenOrientationFunc p_screen_orient, GetUniqueIDFunc p_get_unique_id, GetSystemDirFunc p_get_sdir_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func, SetKeepScreenOnFunc p_set_keep_screen_on_func, AlertFunc p_alert_func, bool p_use_apk_expansion) {
 
 	use_apk_expansion = p_use_apk_expansion;
 	default_videomode.width = 800;
@@ -725,7 +724,7 @@ OS_Android::OS_Android(GFXInitFunc p_gfx_init_func, void *p_gfx_init_ud, OpenURI
 	use_gl2 = false;
 
 	open_uri_func = p_open_uri_func;
-	get_data_dir_func = p_get_data_dir_func;
+	get_user_data_dir_func = p_get_user_data_dir_func;
 	get_locale_func = p_get_locale_func;
 	get_model_func = p_get_model_func;
 	get_screen_dpi_func = p_get_screen_dpi_func;

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -48,7 +48,7 @@
 
 typedef void (*GFXInitFunc)(void *ud, bool gl2);
 typedef int (*OpenURIFunc)(const String &);
-typedef String (*GetDataDirFunc)();
+typedef String (*GetUserDataDirFunc)();
 typedef String (*GetLocaleFunc)();
 typedef String (*GetModelFunc)();
 typedef int (*GetScreenDPIFunc)();
@@ -116,7 +116,7 @@ private:
 	MainLoop *main_loop;
 
 	OpenURIFunc open_uri_func;
-	GetDataDirFunc get_data_dir_func;
+	GetUserDataDirFunc get_user_data_dir_func;
 	GetLocaleFunc get_locale_func;
 	GetModelFunc get_model_func;
 	GetScreenDPIFunc get_screen_dpi_func;
@@ -208,7 +208,7 @@ public:
 	virtual void set_screen_orientation(ScreenOrientation p_orientation);
 
 	virtual Error shell_open(String p_uri);
-	virtual String get_data_dir() const;
+	virtual String get_user_data_dir() const;
 	virtual String get_resource_dir() const;
 	virtual String get_locale() const;
 	virtual String get_model_name() const;
@@ -237,7 +237,7 @@ public:
 	void joy_connection_changed(int p_device, bool p_connected, String p_name);
 
 	virtual bool _check_internal_feature_support(const String &p_feature);
-	OS_Android(GFXInitFunc p_gfx_init_func, void *p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetDataDirFunc p_get_data_dir_func, GetLocaleFunc p_get_locale_func, GetModelFunc p_get_model_func, GetScreenDPIFunc p_get_screen_dpi_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk, VirtualKeyboardHeightFunc p_vk_height_func, SetScreenOrientationFunc p_screen_orient, GetUniqueIDFunc p_get_unique_id, GetSystemDirFunc p_get_sdir_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func, SetKeepScreenOnFunc p_set_keep_screen_on_func, AlertFunc p_alert_func, bool p_use_apk_expansion);
+	OS_Android(GFXInitFunc p_gfx_init_func, void *p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetUserDataDirFunc p_get_user_data_dir_func, GetLocaleFunc p_get_locale_func, GetModelFunc p_get_model_func, GetScreenDPIFunc p_get_screen_dpi_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk, VirtualKeyboardHeightFunc p_vk_height_func, SetScreenOrientationFunc p_screen_orient, GetUniqueIDFunc p_get_unique_id, GetSystemDirFunc p_get_sdir_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func, SetKeepScreenOnFunc p_set_keep_screen_on_func, AlertFunc p_alert_func, bool p_use_apk_expansion);
 	~OS_Android();
 };
 

--- a/platform/haiku/os_haiku.cpp
+++ b/platform/haiku/os_haiku.cpp
@@ -314,3 +314,36 @@ bool OS_Haiku::_check_internal_feature_support(const String &p_feature) {
 
 	return p_feature == "pc" || p_feature == "s3tc";
 }
+
+String OS_Haiku::get_config_path() const {
+
+	if (has_environment("XDG_CONFIG_HOME")) {
+		return get_environment("XDG_CONFIG_HOME");
+	} else if (has_environment("HOME")) {
+		return get_environment("HOME").plus_file(".config");
+	} else {
+		return ".";
+	}
+}
+
+String OS_Haiku::get_data_path() const {
+
+	if (has_environment("XDG_DATA_HOME")) {
+		return get_environment("XDG_DATA_HOME");
+	} else if (has_environment("HOME")) {
+		return get_environment("HOME").plus_file(".local/share");
+	} else {
+		return get_config_path();
+	}
+}
+
+String OS_Haiku::get_cache_path() const {
+
+	if (has_environment("XDG_CACHE_HOME")) {
+		return get_environment("XDG_CACHE_HOME");
+	} else if (has_environment("HOME")) {
+		return get_environment("HOME").plus_file(".cache");
+	} else {
+		return get_config_path();
+	}
+}

--- a/platform/haiku/os_haiku.h
+++ b/platform/haiku/os_haiku.h
@@ -117,6 +117,10 @@ public:
 	virtual int get_power_percent_left();
 
 	virtual bool _check_internal_feature_support(const String &p_feature);
+
+	virtual String get_config_path() const;
+	virtual String get_data_path() const;
+	virtual String get_cache_path() const;
 };
 
 #endif

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -470,7 +470,7 @@ void OSIPhone::set_cursor_shape(CursorShape p_shape){
 
 };
 
-String OSIPhone::get_data_dir() const {
+String OSIPhone::get_user_data_dir() const {
 
 	return data_dir;
 };
@@ -509,7 +509,7 @@ Error OSIPhone::native_video_play(String p_path, float p_volume, String p_audio_
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ);
 	bool exists = f && f->is_open();
 
-	String tempFile = get_data_dir();
+	String tempFile = get_user_data_dir();
 	if (!exists)
 		return FAILED;
 
@@ -521,7 +521,7 @@ Error OSIPhone::native_video_play(String p_path, float p_volume, String p_audio_
 			p_path = p_path.replace("res:/", ProjectSettings::get_singleton()->get_resource_path());
 		}
 	} else if (p_path.begins_with("user://"))
-		p_path = p_path.replace("user:/", get_data_dir());
+		p_path = p_path.replace("user:/", get_user_data_dir());
 
 	memdelete(f);
 

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -178,7 +178,7 @@ public:
 
 	Error shell_open(String p_uri);
 
-	String get_data_dir() const;
+	String get_user_data_dir() const;
 
 	void set_locale(String p_locale);
 	String get_locale() const;

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -319,7 +319,7 @@ int EditorExportPlatformJavaScript::get_device_count() const {
 
 Error EditorExportPlatformJavaScript::run(const Ref<EditorExportPreset> &p_preset, int p_device, int p_debug_flags) {
 
-	String path = EditorSettings::get_singleton()->get_settings_path() + "/tmp/tmp_export.html";
+	String path = EditorSettings::get_singleton()->get_settings_dir() + "/tmp/tmp_export.html";
 	Error err = export_project(p_preset, true, path, p_debug_flags);
 	if (err) {
 		return err;

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -319,7 +319,7 @@ int EditorExportPlatformJavaScript::get_device_count() const {
 
 Error EditorExportPlatformJavaScript::run(const Ref<EditorExportPreset> &p_preset, int p_device, int p_debug_flags) {
 
-	String path = EditorSettings::get_singleton()->get_settings_dir() + "/tmp/tmp_export.html";
+	String path = EditorSettings::get_singleton()->get_cache_dir().plus_file("tmp_export.html");
 	Error err = export_project(p_preset, true, path, p_debug_flags);
 	if (err) {
 		return err;

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -889,11 +889,11 @@ String OS_JavaScript::get_resource_dir() const {
 	return "/"; //javascript has it's own filesystem for resources inside the APK
 }
 
-String OS_JavaScript::get_data_dir() const {
+String OS_JavaScript::get_user_data_dir() const {
 
 	/*
-	if (get_data_dir_func)
-		return get_data_dir_func();
+	if (get_user_data_dir_func)
+		return get_user_data_dir_func();
 	*/
 	return "/userfs";
 };
@@ -993,7 +993,7 @@ bool OS_JavaScript::is_userfs_persistent() const {
 	return idbfs_available;
 }
 
-OS_JavaScript::OS_JavaScript(const char *p_execpath, GetDataDirFunc p_get_data_dir_func) {
+OS_JavaScript::OS_JavaScript(const char *p_execpath, GetUserDataDirFunc p_get_user_data_dir_func) {
 	set_cmdline(p_execpath, get_cmdline_args());
 	main_loop = NULL;
 	gl_extensions = NULL;
@@ -1001,7 +1001,7 @@ OS_JavaScript::OS_JavaScript(const char *p_execpath, GetDataDirFunc p_get_data_d
 	soft_fs_enabled = false;
 	canvas_size_adjustment_requested = false;
 
-	get_data_dir_func = p_get_data_dir_func;
+	get_user_data_dir_func = p_get_user_data_dir_func;
 	FileAccessUnix::close_notification_func = _close_notification_funcs;
 
 	idbfs_available = false;

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -42,7 +42,7 @@
 
 #include <emscripten/html5.h>
 
-typedef String (*GetDataDirFunc)();
+typedef String (*GetUserDataDirFunc)();
 
 class OS_JavaScript : public OS_Unix {
 
@@ -63,7 +63,7 @@ class OS_JavaScript : public OS_Unix {
 	CursorShape cursor_shape;
 	MainLoop *main_loop;
 
-	GetDataDirFunc get_data_dir_func;
+	GetUserDataDirFunc get_user_data_dir_func;
 
 	PowerJavascript *power_manager;
 
@@ -146,7 +146,7 @@ public:
 	void set_opengl_extensions(const char *p_gl_extensions);
 
 	virtual Error shell_open(String p_uri);
-	virtual String get_data_dir() const;
+	virtual String get_user_data_dir() const;
 	String get_executable_path() const;
 	virtual String get_resource_dir() const;
 
@@ -165,7 +165,7 @@ public:
 
 	void set_idbfs_available(bool p_idbfs_available);
 
-	OS_JavaScript(const char *p_execpath, GetDataDirFunc p_get_data_dir_func);
+	OS_JavaScript(const char *p_execpath, GetUserDataDirFunc p_get_user_data_dir_func);
 	~OS_JavaScript();
 };
 

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -160,7 +160,7 @@ void EditorExportPlatformOSX::_make_icon(const Ref<Image> &p_icon, Vector<uint8_
 		copy->convert(Image::FORMAT_RGBA8);
 		copy->resize(size, size);
 		it->create_from_image(copy);
-		String path = EditorSettings::get_singleton()->get_settings_path() + "/tmp/icon.png";
+		String path = EditorSettings::get_singleton()->get_settings_dir() + "/tmp/icon.png";
 		ResourceSaver::save(path, it);
 
 		FileAccess *f = FileAccess::open(path, FileAccess::READ);
@@ -344,7 +344,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 
 	if (use_dmg()) {
 		// We're on OSX so we can export to DMG, but first we create our application bundle
-		tmp_app_path_name = EditorSettings::get_singleton()->get_settings_path() + "/tmp/" + pkg_name + ".app";
+		tmp_app_path_name = EditorSettings::get_singleton()->get_settings_dir() + "/tmp/" + pkg_name + ".app";
 		print_line("Exporting to " + tmp_app_path_name);
 		DirAccess *tmp_app_path = DirAccess::create_for_path(tmp_app_path_name);
 		if (!tmp_app_path) {
@@ -539,7 +539,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 			OS::get_singleton()->move_to_trash(tmp_app_path_name);
 		} else {
 
-			String pack_path = EditorSettings::get_singleton()->get_settings_path() + "/tmp/" + pkg_name + ".pck";
+			String pack_path = EditorSettings::get_singleton()->get_settings_dir() + "/tmp/" + pkg_name + ".pck";
 			Error err = save_pack(p_preset, pack_path);
 
 			if (err == OK) {

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -160,7 +160,7 @@ void EditorExportPlatformOSX::_make_icon(const Ref<Image> &p_icon, Vector<uint8_
 		copy->convert(Image::FORMAT_RGBA8);
 		copy->resize(size, size);
 		it->create_from_image(copy);
-		String path = EditorSettings::get_singleton()->get_settings_dir() + "/tmp/icon.png";
+		String path = EditorSettings::get_singleton()->get_cache_dir().plus_file("icon.png");
 		ResourceSaver::save(path, it);
 
 		FileAccess *f = FileAccess::open(path, FileAccess::READ);
@@ -344,7 +344,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 
 	if (use_dmg()) {
 		// We're on OSX so we can export to DMG, but first we create our application bundle
-		tmp_app_path_name = EditorSettings::get_singleton()->get_settings_dir() + "/tmp/" + pkg_name + ".app";
+		tmp_app_path_name = EditorSettings::get_singleton()->get_cache_dir().plus_file(pkg_name + ".app");
 		print_line("Exporting to " + tmp_app_path_name);
 		DirAccess *tmp_app_path = DirAccess::create_for_path(tmp_app_path_name);
 		if (!tmp_app_path) {
@@ -539,7 +539,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 			OS::get_singleton()->move_to_trash(tmp_app_path_name);
 		} else {
 
-			String pack_path = EditorSettings::get_singleton()->get_settings_dir() + "/tmp/" + pkg_name + ".pck";
+			String pack_path = EditorSettings::get_singleton()->get_cache_dir().plus_file(pkg_name + ".pck");
 			Error err = save_pack(p_preset, pack_path);
 
 			if (err == OK) {

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -154,6 +154,11 @@ public:
 
 	virtual MainLoop *get_main_loop() const;
 
+	virtual String get_config_path() const;
+	virtual String get_data_path() const;
+	virtual String get_cache_path() const;
+	virtual String get_godot_dir_name() const;
+
 	virtual String get_system_dir(SystemDir p_dir) const;
 
 	virtual bool can_draw() const;

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1095,7 +1095,7 @@ void OS_OSX::initialize(const VideoMode &p_desired, int p_video_driver, int p_au
 
 	power_manager = memnew(power_osx);
 
-	_ensure_data_dir();
+	_ensure_user_data_dir();
 
 	restore_rect = Rect2(get_window_position(), get_window_size());
 }

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -36,6 +36,7 @@
 #include "print_string.h"
 #include "sem_osx.h"
 #include "servers/visual/visual_server_raster.h"
+#include "version_generated.gen.h"
 
 #include <Carbon/Carbon.h>
 #import <Cocoa/Cocoa.h>
@@ -1338,6 +1339,43 @@ void OS_OSX::set_icon(const Ref<Image> &p_icon) {
 MainLoop *OS_OSX::get_main_loop() const {
 
 	return main_loop;
+}
+
+String OS_OSX::get_config_path() const {
+
+	if (has_environment("XDG_CONFIG_HOME")) {
+		return get_environment("XDG_CONFIG_HOME");
+	} else if (has_environment("HOME")) {
+		return get_environment("HOME").plus_file("Library/Application Support");
+	} else {
+		return ".";
+	}
+}
+
+String OS_OSX::get_data_path() const {
+
+	if (has_environment("XDG_DATA_HOME")) {
+		return get_environment("XDG_DATA_HOME");
+	} else {
+		return get_config_path();
+	}
+}
+
+String OS_OSX::get_cache_path() const {
+
+	if (has_environment("XDG_CACHE_HOME")) {
+		return get_environment("XDG_CACHE_HOME");
+	} else if (has_environment("HOME")) {
+		return get_environment("HOME").plus_file("Library/Caches");
+	} else {
+		return get_config_path();
+	}
+}
+
+// Get properly capitalized engine name for system paths
+String OS_OSX::get_godot_dir_name() const {
+
+	return String(_MKSTR(VERSION_SHORT_NAME)).capitalize();
 }
 
 String OS_OSX::get_system_dir(SystemDir p_dir) const {

--- a/platform/server/os_server.cpp
+++ b/platform/server/os_server.cpp
@@ -73,7 +73,7 @@ void OS_Server::initialize(const VideoMode &p_desired, int p_video_driver, int p
 
 	input = memnew(InputDefault);
 
-	_ensure_data_dir();
+	_ensure_user_data_dir();
 }
 void OS_Server::finalize() {
 

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -456,8 +456,8 @@ void AppxPackager::init(FileAccess *p_fa) {
 	package = p_fa;
 	central_dir_offset = 0;
 	end_of_central_dir_offset = 0;
-	tmp_blockmap_file_path = EditorSettings::get_singleton()->get_settings_path() + "/tmp/tmpblockmap.xml";
-	tmp_content_types_file_path = EditorSettings::get_singleton()->get_settings_path() + "/tmp/tmpcontenttypes.xml";
+	tmp_blockmap_file_path = EditorSettings::get_singleton()->get_settings_dir() + "/tmp/tmpblockmap.xml";
+	tmp_content_types_file_path = EditorSettings::get_singleton()->get_settings_dir() + "/tmp/tmpcontenttypes.xml";
 }
 
 void AppxPackager::add_file(String p_file_name, const uint8_t *p_buffer, size_t p_len, int p_file_no, int p_total_files, bool p_compress) {
@@ -886,7 +886,7 @@ class EditorExportUWP : public EditorExportPlatform {
 
 		if (!image) return data;
 
-		String tmp_path = EditorSettings::get_singleton()->get_settings_path().plus_file("tmp/uwp_tmp_logo.png");
+		String tmp_path = EditorSettings::get_singleton()->get_settings_dir().plus_file("tmp/uwp_tmp_logo.png");
 
 		Error err = image->get_data()->save_png(tmp_path);
 

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -456,8 +456,8 @@ void AppxPackager::init(FileAccess *p_fa) {
 	package = p_fa;
 	central_dir_offset = 0;
 	end_of_central_dir_offset = 0;
-	tmp_blockmap_file_path = EditorSettings::get_singleton()->get_settings_dir() + "/tmp/tmpblockmap.xml";
-	tmp_content_types_file_path = EditorSettings::get_singleton()->get_settings_dir() + "/tmp/tmpcontenttypes.xml";
+	tmp_blockmap_file_path = EditorSettings::get_singleton()->get_cache_dir().plus_file("tmpblockmap.xml");
+	tmp_content_types_file_path = EditorSettings::get_singleton()->get_cache_dir().plus_file("tmpcontenttypes.xml");
 }
 
 void AppxPackager::add_file(String p_file_name, const uint8_t *p_buffer, size_t p_len, int p_file_no, int p_total_files, bool p_compress) {
@@ -886,7 +886,7 @@ class EditorExportUWP : public EditorExportPlatform {
 
 		if (!image) return data;
 
-		String tmp_path = EditorSettings::get_singleton()->get_settings_dir().plus_file("tmp/uwp_tmp_logo.png");
+		String tmp_path = EditorSettings::get_singleton()->get_cache_dir().plus_file("uwp_tmp_logo.png");
 
 		Error err = image->get_data()->save_png(tmp_path);
 

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -28,6 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include "os_uwp.h"
+
 #include "drivers/gles3/rasterizer_gles3.h"
 #include "drivers/unix/ip_unix.h"
 #include "drivers/windows/dir_access_windows.h"
@@ -298,7 +299,7 @@ void OSUWP::initialize(const VideoMode &p_desired, int p_video_driver, int p_aud
 				ref new TypedEventHandler<Gyrometer ^, GyrometerReadingChangedEventArgs ^>(managed_object, &ManagedType::on_gyroscope_reading_changed);
 	}
 
-	_ensure_data_dir();
+	_ensure_user_data_dir();
 
 	if (is_keep_screen_on())
 		display_request->RequestActive();
@@ -781,7 +782,7 @@ MainLoop *OSUWP::get_main_loop() const {
 	return main_loop;
 }
 
-String OSUWP::get_data_dir() const {
+String OSUWP::get_user_data_dir() const {
 
 	Windows::Storage::StorageFolder ^ data_folder = Windows::Storage::ApplicationData::Current->LocalFolder;
 

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -226,7 +226,7 @@ public:
 	virtual String get_locale() const;
 
 	virtual void move_window_to_foreground();
-	virtual String get_data_dir() const;
+	virtual String get_user_data_dir() const;
 
 	virtual bool _check_internal_feature_support(const String &p_feature);
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1090,7 +1090,7 @@ void OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int 
 
 	//RegisterTouchWindow(hWnd, 0); // Windows 7
 
-	_ensure_data_dir();
+	_ensure_user_data_dir();
 
 	DragAcceptFiles(hWnd, true);
 
@@ -2167,7 +2167,7 @@ String OS_Windows::get_system_dir(SystemDir p_dir) const {
 	ERR_FAIL_COND_V(res != S_OK, String());
 	return String(szPath);
 }
-String OS_Windows::get_data_dir() const {
+String OS_Windows::get_user_data_dir() const {
 
 	String an = get_safe_application_name();
 	if (an != "") {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -47,6 +47,7 @@
 #include "servers/visual/visual_server_wrap_mt.h"
 #include "stream_peer_winsock.h"
 #include "tcp_server_winsock.h"
+#include "version_generated.gen.h"
 #include "windows_terminal_logger.h"
 
 #include <process.h>
@@ -2131,6 +2132,43 @@ MainLoop *OS_Windows::get_main_loop() const {
 	return main_loop;
 }
 
+String OS_Windows::get_config_path() const {
+
+	if (has_environment("XDG_CONFIG_HOME")) { // unlikely, but after all why not?
+		return get_environment("XDG_CONFIG_HOME");
+	} else if (has_environment("APPDATA")) {
+		return get_environment("APPDATA");
+	} else {
+		return ".";
+	}
+}
+
+String OS_Windows::get_data_path() const {
+
+	if (has_environment("XDG_DATA_HOME")) {
+		return get_environment("XDG_DATA_HOME");
+	} else {
+		return get_config_path();
+	}
+}
+
+String OS_Windows::get_cache_path() const {
+
+	if (has_environment("XDG_CACHE_HOME")) {
+		return get_environment("XDG_CACHE_HOME");
+	} else if (has_environment("TEMP")) {
+		return get_environment("TEMP");
+	} else {
+		return get_config_path();
+	}
+}
+
+// Get properly capitalized engine name for system paths
+String OS_Windows::get_godot_dir_name() const {
+
+	return String(_MKSTR(VERSION_SHORT_NAME)).capitalize();
+}
+
 String OS_Windows::get_system_dir(SystemDir p_dir) const {
 
 	int id;
@@ -2167,18 +2205,17 @@ String OS_Windows::get_system_dir(SystemDir p_dir) const {
 	ERR_FAIL_COND_V(res != S_OK, String());
 	return String(szPath);
 }
+
 String OS_Windows::get_user_data_dir() const {
 
-	String an = get_safe_application_name();
-	if (an != "") {
+	String appname = get_safe_application_name();
+	if (appname != "") {
 
-		if (has_environment("APPDATA")) {
-
-			bool use_godot = ProjectSettings::get_singleton()->get("application/config/use_shared_user_dir");
-			if (!use_godot)
-				return (OS::get_singleton()->get_environment("APPDATA") + "/" + an).replace("\\", "/");
-			else
-				return (OS::get_singleton()->get_environment("APPDATA") + "/Godot/app_userdata/" + an).replace("\\", "/");
+		bool use_godot_dir = ProjectSettings::get_singleton()->get("application/config/use_shared_user_dir");
+		if (use_godot_dir) {
+			return get_data_path().plus_file(get_godot_dir_name()).plus_file("app_userdata").plus_file(appname).replace("\\", "/");
+		} else {
+			return get_data_path().plus_file(appname).replace("\\", "/");
 		}
 	}
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -253,7 +253,7 @@ public:
 
 	virtual void enable_for_stealing_focus(ProcessID pid);
 	virtual void move_window_to_foreground();
-	virtual String get_data_dir() const;
+	virtual String get_user_data_dir() const;
 	virtual String get_system_dir(SystemDir p_dir) const;
 
 	virtual void release_rendering_thread();

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -253,8 +253,14 @@ public:
 
 	virtual void enable_for_stealing_focus(ProcessID pid);
 	virtual void move_window_to_foreground();
-	virtual String get_user_data_dir() const;
+
+	virtual String get_config_path() const;
+	virtual String get_data_path() const;
+	virtual String get_cache_path() const;
+	virtual String get_godot_dir_name() const;
+
 	virtual String get_system_dir(SystemDir p_dir) const;
+	virtual String get_user_data_dir() const;
 
 	virtual void release_rendering_thread();
 	virtual void make_rendering_thread();

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -464,7 +464,7 @@ void OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_au
 #ifdef JOYDEV_ENABLED
 	joypad = memnew(JoypadLinux(input));
 #endif
-	_ensure_data_dir();
+	_ensure_user_data_dir();
 
 	power_manager = memnew(PowerX11);
 }

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -1941,6 +1941,39 @@ bool OS_X11::_check_internal_feature_support(const String &p_feature) {
 	return p_feature == "pc" || p_feature == "s3tc";
 }
 
+String OS_X11::get_config_path() const {
+
+	if (has_environment("XDG_CONFIG_HOME")) {
+		return get_environment("XDG_CONFIG_HOME");
+	} else if (has_environment("HOME")) {
+		return get_environment("HOME").plus_file(".config");
+	} else {
+		return ".";
+	}
+}
+
+String OS_X11::get_data_path() const {
+
+	if (has_environment("XDG_DATA_HOME")) {
+		return get_environment("XDG_DATA_HOME");
+	} else if (has_environment("HOME")) {
+		return get_environment("HOME").plus_file(".local/share");
+	} else {
+		return get_config_path();
+	}
+}
+
+String OS_X11::get_cache_path() const {
+
+	if (has_environment("XDG_CACHE_HOME")) {
+		return get_environment("XDG_CACHE_HOME");
+	} else if (has_environment("HOME")) {
+		return get_environment("HOME").plus_file(".cache");
+	} else {
+		return get_config_path();
+	}
+}
+
 String OS_X11::get_system_dir(SystemDir p_dir) const {
 
 	String xdgparam;

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -213,6 +213,10 @@ public:
 	virtual void make_rendering_thread();
 	virtual void swap_buffers();
 
+	virtual String get_config_path() const;
+	virtual String get_data_path() const;
+	virtual String get_cache_path() const;
+
 	virtual String get_system_dir(SystemDir p_dir) const;
 
 	virtual Error shell_open(String p_uri);


### PR DESCRIPTION
Three virtual methods are added to OS for the various XDG paths we will use:
- OS::get_data_path gives XDG_DATA_HOME, or if missing:
  ~/.local/share on X11, ~/Library/Application Support/ on macOS and %APPDATA% on Windows
- OS::get_config_path gives XDG_CONFIG_HOME, or if missing:
  ~/.config on X11, ~/Library/Application Support/ on macOS and %APPDATA% on Windows
- OS::get_cache_path gives XDG_CACHE_HOME, or if missing:
  ~/.cache on X11, ~/Library/Caches on macOS and %TEMP% on Windows

So for Windows there are no changes, for Linux we follow the full split spec
and for macOS stuff will move from ~/.godot to ~/Library/Application Support/Godot.

Support for system-wide installation of templates on Unix was removed for now,
as it's a bit hackish and I don't think anyone uses it.

user:// will still be OS::get_data_path() + "/godot/app_userdata/$name" by
default, but when using the application/config/use_shared_user_dir option
it will now use XDG_DATA_HOME/$name, e.g. ~/.local/share/MyGame.

Fixes #3513.