### PR TITLE
Fix class docs, improve error handling of the rst generator.

### DIFF
--- a/doc/tools/makerst.py
+++ b/doc/tools/makerst.py
@@ -7,6 +7,7 @@ import os
 import xml.etree.ElementTree as ET
 
 input_list = []
+cur_file = ""
 
 for arg in sys.argv[1:]:
     if arg.endswith(os.sep):
@@ -217,7 +218,10 @@ def rstize_text(text, cclass):
                 param = tag_text[space_pos + 1:]
 
                 if param.find('.') != -1:
-                    (class_param, method_param) = param.split('.')
+                    ss = param.split('.')
+                    if len(ss) > 2:
+                        sys.exit("Bad reference: '" + param + "' in file: " + cur_file)
+                    (class_param, method_param) = ss
                     tag_text = ':ref:`' + class_param + '.' + method_param + '<class_' + class_param + '_' + method_param + '>`'
                 else:
                     tag_text = ':ref:`' + param + '<class_' + cclass + "_" + param + '>`'
@@ -519,8 +523,8 @@ for path in input_list:
     elif os.path.isfile(path) and path.endswith('.xml'):
         file_list.append(path)
 
-for file in file_list:
-    tree = ET.parse(file)
+for cur_file in file_list:
+    tree = ET.parse(cur_file)
     doc = tree.getroot()
 
     if 'version' not in doc.attrib:

--- a/modules/regex/doc_classes/RegExMatch.xml
+++ b/modules/regex/doc_classes/RegExMatch.xml
@@ -4,7 +4,7 @@
 		Contains the results of a regex search.
 	</brief_description>
 	<description>
-		Contains the results of a single regex match returned by [method RegEx.search] and [method.RegEx.search_all]. It can be used to find the position and range of the match and its capturing groups, and it can extract its sub-string for you.
+		Contains the results of a single regex match returned by [method RegEx.search] and [method RegEx.search_all]. It can be used to find the position and range of the match and its capturing groups, and it can extract its sub-string for you.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
The rst-generator gives you now a hint what's going on:
Bad reference: 'method.RegEx.search_all' in file: ../modules/regex/doc_classes/RegExMatch.xml

grep 'method.RegEx.search_all' ../modules/regex/doc_classes/RegExMatch.xml
	Contains the results of a single regex match returned by [method RegEx.search]
	and [method.RegEx.search_all]. It can be used to find the position and range of the match
	and its capturing groups, and it can extract its sub-string for you.