### PR TITLE
Make resources edited by plugins be sent as reference (2.1)

### DIFF
--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -176,7 +176,11 @@ void EditorPlugin::make_visible(bool p_visible) {
 void EditorPlugin::edit(Object *p_object) {
 
 	if (get_script_instance() && get_script_instance()->has_method("edit")) {
-		get_script_instance()->call("edit", p_object);
+		if (p_object->is_class("Resource")) {
+			get_script_instance()->call("edit", Ref<Resource>(Object::cast_to<Resource>(p_object)));
+		} else {
+			get_script_instance()->call("edit", p_object);
+		}
 	}
 }
 


### PR DESCRIPTION
This ensures that a plugin can save a resource using the `ResourceSaver`.

Same as #12987 but for the 2.1 branch.