### PR TITLE
Fix the class docs for the rst-syntax errors.

### DIFF
--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -287,7 +287,7 @@
 			<argument index="1" name="send" type="String">
 			</argument>
 			<description>
-				Connects the output of the bus at [code]bus_idx[/code] to the bus named [code]send[/send].
+				Connects the output of the bus at [code]bus_idx[/code] to the bus named [code]send[/code].
 			</description>
 		</method>
 		<method name="set_bus_solo">

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -60,7 +60,7 @@
 			<argument index="1" name="constant" type="int">
 			</argument>
 			<description>
-				Overrides an integer constant in the [theme] resource the node uses. If the [code]constant[code] is invalid, Godot clears the override. See [member Theme.INVALID_CONSTANT] for more information.
+				Overrides an integer constant in the [Theme] resource the node uses. If the [code]constant[/code] is invalid, Godot clears the override. See [member Theme.INVALID_CONSTANT] for more information.
 			</description>
 		</method>
 		<method name="add_font_override">

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -377,13 +377,13 @@
 			</argument>
 			<description>
 				Sets the [Color] of the pixel at [code](x, y)[/code] if the image is unlocked. Example:
-				[code]
+				[codeblock]
 				var img = Image.new()
 				img.lock()
 				img.set_pixel(x, y, color) # Does not have an effect
 				img.unlock()
 				img.set_pixel(x, y, color) # Works
-				[/code].
+				[/codeblock]
 			</description>
 		</method>
 		<method name="shrink_x2">

--- a/doc/classes/InputEvent.xml
+++ b/doc/classes/InputEvent.xml
@@ -18,7 +18,7 @@
 			<argument index="0" name="event" type="InputEvent">
 			</argument>
 			<description>
-				Returns [code]true[/code] if this event matches [code]event[event].
+				Returns [code]true[/code] if this event matches [code]event[/code].
 			</description>
 		</method>
 		<method name="as_text" qualifiers="const">

--- a/doc/classes/InputEventAction.xml
+++ b/doc/classes/InputEventAction.xml
@@ -4,7 +4,7 @@
 		Input event type for actions.
 	</brief_description>
 	<description>
-		Contains a generic action which can be targeted from several type of inputs. Actions can be created from the project settings menu [code]Project &gt; Project Settings &gt; Input Map[/Code]. See [method Node._input].
+		Contains a generic action which can be targeted from several type of inputs. Actions can be created from the project settings menu [code]Project &gt; Project Settings &gt; Input Map[/code]. See [method Node._input].
 	</description>
 	<tutorials>
 		http://docs.godotengine.org/en/stable/learning/features/inputs/inputevent.html#actions

--- a/doc/classes/InputMap.xml
+++ b/doc/classes/InputMap.xml
@@ -4,7 +4,7 @@
 		Singleton that manages [InputEventAction].
 	</brief_description>
 	<description>
-		Manages all [InputEventAction] which can be created/modified from the project settings menu [code]Project &gt; Project Settings &gt; Input Map[/Code] or in code with [method add_action] and [method action_add_event]. See [method Node._input].
+		Manages all [InputEventAction] which can be created/modified from the project settings menu [code]Project &gt; Project Settings &gt; Input Map[/code] or in code with [method add_action] and [method action_add_event]. See [method Node._input].
 	</description>
 	<tutorials>
 		http://docs.godotengine.org/en/stable/learning/features/inputs/inputevent.html#inputmap

--- a/doc/classes/KinematicBody.xml
+++ b/doc/classes/KinematicBody.xml
@@ -32,7 +32,7 @@
 			<argument index="0" name="slide_idx" type="int">
 			</argument>
 			<description>
-				Returns a [KinematicCollision], which contains information about a collision that occured during the last [method move_and_slide] call. Since the body can collide several times in a single call to [method move_and_slide], you must specify the index of the collision in the range 0 to ([method get_slide_count]()-1).
+				Returns a [KinematicCollision], which contains information about a collision that occured during the last [method move_and_slide] call. Since the body can collide several times in a single call to [method move_and_slide], you must specify the index of the collision in the range 0 to ([method get_slide_count] - 1).
 			</description>
 		</method>
 		<method name="get_slide_count" qualifiers="const">

--- a/doc/classes/KinematicBody2D.xml
+++ b/doc/classes/KinematicBody2D.xml
@@ -32,7 +32,7 @@
 			<argument index="0" name="slide_idx" type="int">
 			</argument>
 			<description>
-				Returns a [KinematicCollision2D], which contains information about a collision that occured during the last [method move_and_slide] call. Since the body can collide several times in a single call to [method move_and_slide], you must specify the index of the collision in the range 0 to ([method get_slide_count]()-1).
+				Returns a [KinematicCollision2D], which contains information about a collision that occured during the last [method move_and_slide] call. Since the body can collide several times in a single call to [method move_and_slide], you must specify the index of the collision in the range 0 to ([method get_slide_count] - 1).
 			</description>
 		</method>
 		<method name="get_slide_count" qualifiers="const">

--- a/doc/classes/Line2D.xml
+++ b/doc/classes/Line2D.xml
@@ -63,7 +63,7 @@
 			<argument index="0" name="i" type="int">
 			</argument>
 			<description>
-				Returns point [code]i[code]'s position.
+				Returns point [code]i[/code]'s position.
 			</description>
 		</method>
 		<method name="get_points" qualifiers="const">

--- a/doc/tools/makerst.py
+++ b/doc/tools/makerst.py
@@ -207,6 +207,7 @@ def rstize_text(text, cclass):
             elif cmd == '/code':
                 tag_text = '``'
                 inside_code = False
+                escape_post = True
             elif inside_code:
                 tag_text = '[' + tag_text + ']'
             elif cmd.find('html') == 0:


### PR DESCRIPTION
Fix [/code] surrounding text inline markup and xml souce bugs
for the sphinx's rst syntax werrors:

class_area.rst:319: WARNING: Inline literal start-string without end-string.
class_area2d.rst:287: WARNING: Inline literal start-string without end-string.
class_audioserver.rst:287: WARNING: Inline literal start-string without end-string.
class_control.rst:509: WARNING: Inline literal start-string without end-string.
class_image.rst:422: WARNING: Inline literal start-string without end-string.
class_image.rst:434: WARNING: Inline literal start-string without end-string.
class_inputevent.rst:74: WARNING: Inline literal start-string without end-string.
class_inputeventaction.rst:45: WARNING: Inline literal start-string without end-string.
class_inputmap.rst:47: WARNING: Inline literal start-string without end-string.
class_kinematicbody.rst:80: WARNING: Inline interpreted text or phrase reference start-string without end-string.
class_kinematicbody2d.rst:80: WARNING: Inline interpreted text or phrase reference start-string without end-string.
class_line2d.rst:182: WARNING: Inline literal start-string without end-string.
class_thread.rst:51: WARNING: Inline literal start-string without end-string.
class_treeitem.rst:160: WARNING: Inline literal start-string without end-string.