### PR TITLE
Drop HTML5 asm.js support

### DIFF
--- a/misc/dist/html/default.html
+++ b/misc/dist/html/default.html
@@ -230,7 +230,6 @@ $GODOT_HEAD_INCLUDE
 		(function() {
 
 			const BASENAME = '$GODOT_BASENAME';
-			const MEMORY_SIZE = $GODOT_TOTAL_MEMORY;
 			const DEBUG_ENABLED = $GODOT_DEBUG_ENABLED;
 			const INDETERMINATE_STATUS_STEP_MS = 100;
 
@@ -247,7 +246,6 @@ $GODOT_HEAD_INCLUDE
 
 			setStatusMode('indeterminate');
 			game.setCanvas(canvas);
-			game.setAsmjsMemorySize(MEMORY_SIZE);
 
 			function setStatusMode(mode) {
 

--- a/platform/javascript/SCsub
+++ b/platform/javascript/SCsub
@@ -21,37 +21,21 @@ for x in javascript_files:
 
 env.Append(LINKFLAGS=["-s", "EXPORTED_FUNCTIONS=\"['_main','_main_after_fs_sync','_send_notification']\""])
 
-# output file name without file extension
-basename = "godot" + env["PROGSUFFIX"]
 target_dir = env.Dir("#bin")
-
-zip_dir = target_dir.Dir('.javascript_zip')
-zip_files = env.InstallAs(zip_dir.File('godot.html'), '#misc/dist/html/default.html')
-
-implicit_targets = []
-if env['wasm']:
-    wasm = target_dir.File(basename + '.wasm')
-    implicit_targets.append(wasm)
-    zip_files.append(InstallAs(zip_dir.File('godot.wasm'), wasm))
-    prejs = env.File('pre_wasm.js')
-else:
-    asmjs_files = [target_dir.File(basename + '.asm.js'), target_dir.File(basename + '.js.mem')]
-    implicit_targets.extend(asmjs_files)
-    zip_files.append(InstallAs([zip_dir.File('godot.asm.js'), zip_dir.File('godot.mem')], asmjs_files))
-    prejs = env.File('pre_asmjs.js')
-
-js = env.Program(['#bin/godot'] + implicit_targets, javascript_objects, PROGSUFFIX=env['PROGSUFFIX'] + '.js')[0];
-zip_files.append(InstallAs(zip_dir.File('godot.js'), js))
+build = env.Program(['#bin/godot', target_dir.File('godot' + env['PROGSUFFIX'] + '.wasm')], javascript_objects, PROGSUFFIX=env['PROGSUFFIX'] + '.js');
 
 js_libraries = []
 js_libraries.append(env.File('http_request.js'))
 for lib in js_libraries:
     env.Append(LINKFLAGS=['--js-library', lib.path])
-env.Depends(js, js_libraries)
+env.Depends(build, js_libraries)
 
+prejs = env.File('pre.js')
 postjs = env.File('engine.js')
-env.Depends(js, [prejs, postjs])
 env.Append(LINKFLAGS=['--pre-js', prejs.path])
 env.Append(LINKFLAGS=['--post-js', postjs.path])
+env.Depends(build, [prejs, postjs])
 
+zip_dir = target_dir.Dir('.javascript_zip')
+zip_files = env.InstallAs([zip_dir.File('godot.js'), zip_dir.File('godot.wasm'), zip_dir.File('godot.html')], build + ['#misc/dist/html/default.html'])
 Zip('#bin/godot', zip_files, ZIPSUFFIX=env['PROGSUFFIX'] + env['ZIPSUFFIX'], ZIPROOT=zip_dir, ZIPCOMSTR="Archving $SOURCES as $TARGET")

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -19,7 +19,6 @@ def can_build():
 def get_opts():
     from SCons.Variables import BoolVariable
     return [
-        BoolVariable('wasm', 'Compile to WebAssembly', False),
         BoolVariable('javascript_eval', 'Enable JavaScript eval interface', True),
     ]
 
@@ -106,17 +105,11 @@ def configure(env):
     env.Append(LINKFLAGS=['-s', 'EXTRA_EXPORTED_RUNTIME_METHODS="[\'FS\']"'])
     env.Append(LINKFLAGS=['-s', 'USE_WEBGL2=1'])
 
-    if env['wasm']:
-        env.Append(LINKFLAGS=['-s', 'BINARYEN=1'])
-        # In contrast to asm.js, enabling memory growth on WebAssembly has no
-        # major performance impact, and causes only a negligible increase in
-        # memory size.
-        env.Append(LINKFLAGS=['-s', 'ALLOW_MEMORY_GROWTH=1'])
-        env.extra_suffix = '.webassembly' + env.extra_suffix
-    else:
-        env.Append(LINKFLAGS=['-s', 'ASM_JS=1'])
-        env.Append(LINKFLAGS=['--separate-asm'])
-        env.Append(LINKFLAGS=['--memory-init-file', '1'])
+    env.Append(LINKFLAGS=['-s', 'BINARYEN=1'])
+    # In contrast to asm.js, enabling memory growth on WebAssembly has no
+    # major performance impact, and causes only a negligible increase in
+    # memory size.
+    env.Append(LINKFLAGS=['-s', 'ALLOW_MEMORY_GROWTH=1'])
 
     # TODO: Move that to opus module's config
     if 'module_opus_enabled' in env and env['module_opus_enabled']:

--- a/platform/javascript/pre.js
+++ b/platform/javascript/pre.js
@@ -1,3 +1,2 @@
 var Engine = {
-	USING_WASM: false,
 	RuntimeEnvironment: function(Module) {

--- a/platform/javascript/pre_wasm.js
+++ b/platform/javascript/pre_wasm.js
@@ -1,3 +1,0 @@
-var Engine = {
-	USING_WASM: true,
-	RuntimeEnvironment: function(Module) {


### PR DESCRIPTION
Godot 3 requires WebGL 2.0, which is only supported in Firefox and Chromium, so maintaining asm.js is more effort more than it's worth.