### PR TITLE
Add placement deletes to avoid warnings on VC++

### DIFF
--- a/core/os/memory.cpp
+++ b/core/os/memory.cpp
@@ -44,6 +44,26 @@ void *operator new(size_t p_size, void *(*p_allocfunc)(size_t p_size)) {
 	return p_allocfunc(p_size);
 }
 
+#ifdef _MSC_VER
+void operator delete(void *p_mem, const char *p_description) {
+
+	ERR_EXPLAINC("Call to placement delete should not happen.");
+	CRASH_NOW();
+}
+
+void operator delete(void *p_mem, void *(*p_allocfunc)(size_t p_size)) {
+
+	ERR_EXPLAINC("Call to placement delete should not happen.");
+	CRASH_NOW();
+}
+
+void operator delete(void *p_mem, void *p_pointer, size_t check, const char *p_description) {
+
+	ERR_EXPLAINC("Call to placement delete should not happen.");
+	CRASH_NOW();
+}
+#endif
+
 #ifdef DEBUG_ENABLED
 uint64_t Memory::mem_usage = 0;
 uint64_t Memory::max_usage = 0;

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -72,6 +72,14 @@ void *operator new(size_t p_size, void *(*p_allocfunc)(size_t p_size)); ///< ope
 
 void *operator new(size_t p_size, void *p_pointer, size_t check, const char *p_description); ///< operator new that takes a description and uses a pointer to the preallocated memory
 
+#ifdef _MSC_VER
+// When compiling with VC++ 2017, the above declarations of placement new generate many irrelevant warnings (C4291).
+// The purpose of the following definitions is to muffle these warnings, not to provide a usable implementation of placement delete.
+void operator delete(void *p_mem, const char *p_description);
+void operator delete(void *p_mem, void *(*p_allocfunc)(size_t p_size));
+void operator delete(void *p_mem, void *p_pointer, size_t check, const char *p_description);
+#endif
+
 #define memalloc(m_size) Memory::alloc_static(m_size)
 #define memrealloc(m_mem, m_size) Memory::realloc_static(m_mem, m_size)
 #define memfree(m_size) Memory::free_static(m_size)


### PR DESCRIPTION
When compiling with VC++ 2017, Godot generates huge nubmers of C4291 warnings about missing placement delete.

I have not found a way to disable these warnings using compiler options: AFAICT there is no equivalent to `-f-no-exceptions` for VC++ (there is only /EH to change the exception-handling model,
/GX is deprecated) and adding /wd4291  to the `disable_nonessential_warnings` list in the `SConstruct` file or even compiling with `warnings=no` does not disable the messages.

Placement delete is only called when placement new throws an exception, since Godot doesn't use exceptions this change should have no runtime effect.

Fixes #12654 (probably, difficult to say without log)