### PR TITLE
Few fixes for asset store browser

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -47,9 +47,9 @@ void EditorAssetLibraryItem::configure(const String &p_title, int p_asset_id, co
 
 	for (int i = 0; i < 5; i++) {
 		if (i < p_rating)
-			stars[i]->set_texture(get_icon("RatingStar", "EditorIcons"));
+			stars[i]->set_texture(get_icon("Favorites", "EditorIcons"));
 		else
-			stars[i]->set_texture(get_icon("RatingNoStar", "EditorIcons"));
+			stars[i]->set_texture(get_icon("NonFavorite", "EditorIcons"));
 	}
 }
 
@@ -273,15 +273,15 @@ EditorAssetLibraryItemDescription::EditorAssetLibraryItemDescription() {
 
 	HBoxContainer *hbox = memnew(HBoxContainer);
 	vbox->add_child(hbox);
-	vbox->add_constant_override("separation", 15);
+	vbox->add_constant_override("separation", 15 * EDSCALE);
 	VBoxContainer *desc_vbox = memnew(VBoxContainer);
 	hbox->add_child(desc_vbox);
-	hbox->add_constant_override("separation", 15);
+	hbox->add_constant_override("separation", 15 * EDSCALE);
 
 	item = memnew(EditorAssetLibraryItem);
 
 	desc_vbox->add_child(item);
-	desc_vbox->set_custom_minimum_size(Size2(300, 0));
+	desc_vbox->set_custom_minimum_size(Size2(300 * EDSCALE, 0));
 
 	desc_bg = memnew(PanelContainer);
 	desc_vbox->add_child(desc_bg);
@@ -292,12 +292,12 @@ EditorAssetLibraryItemDescription::EditorAssetLibraryItemDescription() {
 	desc_bg->add_child(description);
 
 	preview = memnew(TextureRect);
-	preview->set_custom_minimum_size(Size2(640, 345));
+	preview->set_custom_minimum_size(Size2(640 * EDSCALE, 345 * EDSCALE));
 	hbox->add_child(preview);
 
 	previews_bg = memnew(PanelContainer);
 	vbox->add_child(previews_bg);
-	previews_bg->set_custom_minimum_size(Size2(0, 85));
+	previews_bg->set_custom_minimum_size(Size2(0, 101 * EDSCALE));
 
 	previews = memnew(ScrollContainer);
 	previews_bg->add_child(previews);
@@ -702,15 +702,28 @@ void EditorAssetLibrary::_image_update(bool use_cache, bool final, const PoolByt
 		Ref<Image> image = Ref<Image>(memnew(Image(r.ptr(), len)));
 
 		if (!image->empty()) {
-			float max_height = 10000;
 			switch (image_queue[p_queue_id].image_type) {
-				case IMAGE_QUEUE_ICON: max_height = 80; break;
-				case IMAGE_QUEUE_THUMBNAIL: max_height = 80; break;
-				case IMAGE_QUEUE_SCREENSHOT: max_height = 345; break;
-			}
-			float scale_ratio = max_height / image->get_height();
-			if (scale_ratio < 1) {
-				image->resize(image->get_width() * scale_ratio, image->get_height() * scale_ratio, Image::INTERPOLATE_CUBIC);
+				case IMAGE_QUEUE_ICON:
+
+					image->resize(80 * EDSCALE, 80 * EDSCALE, Image::INTERPOLATE_CUBIC);
+
+					break;
+				case IMAGE_QUEUE_THUMBNAIL: {
+					float max_height = 85 * EDSCALE;
+
+					float scale_ratio = max_height / (image->get_height() * EDSCALE);
+					if (scale_ratio < 1) {
+						image->resize(image->get_width() * EDSCALE * scale_ratio, image->get_height() * EDSCALE * scale_ratio, Image::INTERPOLATE_CUBIC);
+					}
+				} break;
+				case IMAGE_QUEUE_SCREENSHOT: {
+					float max_height = 397 * EDSCALE;
+
+					float scale_ratio = max_height / (image->get_height() * EDSCALE);
+					if (scale_ratio < 1) {
+						image->resize(image->get_width() * EDSCALE * scale_ratio, image->get_height() * EDSCALE * scale_ratio, Image::INTERPOLATE_CUBIC);
+					}
+				} break;
 			}
 
 			Ref<ImageTexture> tex;


### PR DESCRIPTION
1) Set an icon size to constant 80x80, assets will be stretched to this size. I think its better be constant for all assets, cuz different sizes of different assets looks ugly

2) Added missed icons for rating stars(used python script for generate header)
 
So the result looks like
![image](https://user-images.githubusercontent.com/3036176/32979766-890748be-cc6c-11e7-978c-4ede809e29ed.png)
yes I fill star with gray color, cuz transparent looks very hard for eyes(on dark themes)
and(if stars is active)
![image](https://user-images.githubusercontent.com/3036176/32979979-b7509e98-cc6f-11e7-95d0-21dd2c17b555.png)
