### PR TITLE
Mono: Fix compiler error with Variant::operator AABB()

### DIFF
--- a/modules/mono/mono_gd/gd_mono_field.cpp
+++ b/modules/mono/mono_gd/gd_mono_field.cpp
@@ -41,7 +41,7 @@ void GDMonoField::set_value_raw(MonoObject *p_object, void *p_ptr) {
 void GDMonoField::set_value(MonoObject *p_object, const Variant &p_value) {
 #define SET_FROM_STRUCT_AND_BREAK(m_type)                \
 	{                                                    \
-		const m_type &val = p_value.operator m_type();   \
+		const m_type &val = p_value.operator ::m_type(); \
 		MARSHALLED_OUT(m_type, val, raw);                \
 		mono_field_set_value(p_object, mono_field, raw); \
 		break;                                           \

--- a/modules/mono/mono_gd/gd_mono_marshal.cpp
+++ b/modules/mono/mono_gd/gd_mono_marshal.cpp
@@ -36,7 +36,7 @@ namespace GDMonoMarshal {
 
 #define RETURN_BOXED_STRUCT(m_t, m_var_in)                                    \
 	{                                                                         \
-		const m_t &m_in = m_var_in->operator m_t();                           \
+		const m_t &m_in = m_var_in->operator ::m_t();                         \
 		MARSHALLED_OUT(m_t, m_in, raw);                                       \
 		return mono_value_box(mono_domain_get(), CACHED_CLASS_RAW(m_t), raw); \
 	}


### PR DESCRIPTION
Fixes #13011

**Note:** Variant implements `operator ::AABB()` with `::` to avoid collision with `Variant::Type::AABB`. This constant **should be to renamed** to `_AABB` like it's done with `Variant::Type::_RID`. I made this PR anyway, since it does no harm.
