### PR TITLE
Add cpp.hint file to improve IntelliSense

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,9 @@ bld/
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*
 
+# Hints for improving IntelliSense, created together with VS project
+cpp.hint
+
 #NUNIT
 *.VisualState.xml
 TestResult.xml

--- a/SConstruct
+++ b/SConstruct
@@ -452,6 +452,7 @@ if selected_platform in platform_list:
     if env['vsproj']:
         env['CPPPATH'] = [Dir(path) for path in env['CPPPATH']]
         methods.generate_vs_project(env, GetOption("num_jobs"))
+        methods.generate_cpp_hint_file("cpp.hint")
 
     # Check for the existence of headers
     conf = Configure(env)

--- a/methods.py
+++ b/methods.py
@@ -1686,6 +1686,17 @@ def find_visual_c_batch_file(env):
     (host_platform, target_platform,req_target_platform) = get_host_target(env)
     return find_batch_file(env, version, host_platform, target_platform)[0]
 
+def generate_cpp_hint_file(filename):
+    import os.path
+    if os.path.isfile(filename):
+        # Don't overwrite an existing hint file since the user may have customized it.
+        pass
+    else:
+        try:
+            fd = open(filename, "w")
+            fd.write("#define GDCLASS(m_class, m_inherits)\n")
+        except IOError:
+            print("Could not write cpp.hint file.")
 
 def generate_vs_project(env, num_jobs):
     batch_file = find_visual_c_batch_file(env)


### PR DESCRIPTION
I'm not really sure about this PR.

Visual Studio sometimes gets confused about macro definitions and marks them as undefined functions. Adding the macro signature to a `cpp.hint` file in the same directory as the solution fixes this, so this PR is a minor quality of life improvement for VS users. (I've only added `GDCLASS` for now, since it's the macro I first encountered, but this is a fairly common problem in VS, so there are likely to be more instances of macros it doesn't understand.) On the other hand, it adds clutter to the root directory of the project.

Another solution that I can think of is

- Add an entry `cpp.hint` to .`gitignore`
- Generate `cpp.hint` when flag `vsproj=yes` is true, since the file is only relevant for users who generate a VS project.

This would avoid some clutter, but slightly increase the complexity of the build files. Not sure which solution is better (or whether this is worth addressing at all).

Note that if you add the `cpp.hint` file and the solution was already opened in VS, you need to remove the `.vs` directory for it to have any effect.