### PR TITLE
Fixed issues with clicking animation keys that are on frame 0

### DIFF
--- a/editor/animation_editor.cpp
+++ b/editor/animation_editor.cpp
@@ -2079,7 +2079,7 @@ void AnimationKeyEditor::_track_editor_gui_input(const Ref<InputEvent> &p_input)
 					return;
 				}
 
-				if (mpos.x < name_limit) {
+				if (mpos.x < name_limit - (type_icon[0]->get_width() / 2.0)) {
 					//name column
 
 					// area


### PR DESCRIPTION
Keys on frame 0 overlap the name/node path part of the animation editor, this meant only half of the animation key was clickable, the other half was blocked by the clickable area of the name/path column. I've reduced the name/path column's clickable area by half the width of the key icon to fix this.