### PR TITLE
Fix duplication of signals

### DIFF
--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -169,6 +169,7 @@ private:
 
 	void _duplicate_signals(const Node *p_original, Node *p_copy) const;
 	void _duplicate_and_reown(Node *p_new_parent, const Map<Node *, Node *> &p_reown_map) const;
+	Node *_duplicate(int p_flags) const;
 
 	Array _get_children() const;
 	Array _get_groups() const;


### PR DESCRIPTION
- Partially revert 6496b53549aca7b1be57c3be55815f32a4842201, adding a comment about why duplications of signals must happen as a second phase.
- Add fallback logic for connections to nodes not in the duplicated hierarchy.
- Remove redundant call to `Node::_duplicate_signals()`.

Fixes #12951.