### PR TITLE
Fix #10798: Fixes Change Type does not change icon

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1459,6 +1459,8 @@ void SceneTreeDock::_create() {
 		for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
 			if (!(E->get().usage & PROPERTY_USAGE_STORAGE))
 				continue;
+			if (E->get().name == "__meta__")
+				continue;
 			newnode->set(E->get().name, n->get(E->get().name));
 		}
 


### PR DESCRIPTION
Problem : While replacing old node properties with new ones, we
also copy meta data of old node's icon

Solve: don't copy meta so don't override _editor_icon