### PR TITLE
Cleanup old references to GLES2 renderer

### DIFF
--- a/drivers/gl_context/context_gl.cpp
+++ b/drivers/gl_context/context_gl.cpp
@@ -29,7 +29,7 @@
 /*************************************************************************/
 #include "context_gl.h"
 
-#if defined(OPENGL_ENABLED) || defined(GLES2_ENABLED)
+#if defined(OPENGL_ENABLED) || defined(GLES_ENABLED)
 
 ContextGL *ContextGL::singleton = NULL;
 

--- a/drivers/gl_context/context_gl.h
+++ b/drivers/gl_context/context_gl.h
@@ -30,7 +30,7 @@
 #ifndef CONTEXT_GL_H
 #define CONTEXT_GL_H
 
-#if defined(OPENGL_ENABLED) || defined(GLES2_ENABLED)
+#if defined(OPENGL_ENABLED) || defined(GLES_ENABLED)
 
 #include "typedefs.h"
 

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -149,13 +149,6 @@ void RasterizerCanvasGLES3::canvas_begin() {
 		storage->frame.clear_request = false;
 	}
 
-	/*canvas_shader.unbind();
-	canvas_shader.set_custom_shader(0);
-	canvas_shader.set_conditional(CanvasShaderGLES2::USE_MODULATE,false);
-	canvas_shader.bind();
-	canvas_shader.set_uniform(CanvasShaderGLES2::TEXTURE, 0);
-	canvas_use_modulate=false;*/
-
 	reset_canvas();
 
 	state.canvas_shader.set_conditional(CanvasShaderGLES3::USE_TEXTURE_RECT, true);
@@ -910,61 +903,6 @@ void RasterizerCanvasGLES3::_canvas_item_render_commands(Item *p_item, Item *cur
 		}
 	}
 }
-
-#if 0
-void RasterizerGLES2::_canvas_item_setup_shader_params(ShaderMaterial *material,Shader* shader) {
-
-	if (canvas_shader.bind())
-		rebind_texpixel_size=true;
-
-	if (material->shader_version!=shader->version) {
-		//todo optimize uniforms
-		material->shader_version=shader->version;
-	}
-
-	if (shader->has_texscreen && framebuffer.active) {
-
-		int x = viewport.x;
-		int y = window_size.height-(viewport.height+viewport.y);
-
-		canvas_shader.set_uniform(CanvasShaderGLES2::TEXSCREEN_SCREEN_MULT,Vector2(float(viewport.width)/framebuffer.width,float(viewport.height)/framebuffer.height));
-		canvas_shader.set_uniform(CanvasShaderGLES2::TEXSCREEN_SCREEN_CLAMP,Color(float(x)/framebuffer.width,float(y)/framebuffer.height,float(x+viewport.width)/framebuffer.width,float(y+viewport.height)/framebuffer.height));
-		canvas_shader.set_uniform(CanvasShaderGLES2::TEXSCREEN_TEX,max_texture_units-1);
-		glActiveTexture(GL_TEXTURE0+max_texture_units-1);
-		glBindTexture(GL_TEXTURE_2D,framebuffer.sample_color);
-		if (framebuffer.scale==1 && !canvas_texscreen_used) {
-#ifdef GLEW_ENABLED
-			if (current_rt) {
-				glReadBuffer(GL_COLOR_ATTACHMENT0);
-			} else {
-				glReadBuffer(GL_BACK);
-			}
-#endif
-			if (current_rt) {
-				glCopyTexSubImage2D(GL_TEXTURE_2D,0,viewport.x,viewport.y,viewport.x,viewport.y,viewport.width,viewport.height);
-				canvas_shader.set_uniform(CanvasShaderGLES2::TEXSCREEN_SCREEN_CLAMP,Color(float(x)/framebuffer.width,float(viewport.y)/framebuffer.height,float(x+viewport.width)/framebuffer.width,float(y+viewport.height)/framebuffer.height));
-				//window_size.height-(viewport.height+viewport.y)
-			} else {
-				glCopyTexSubImage2D(GL_TEXTURE_2D,0,x,y,x,y,viewport.width,viewport.height);
-			}
-
-			canvas_texscreen_used=true;
-		}
-
-		glActiveTexture(GL_TEXTURE0);
-
-	}
-
-	if (shader->has_screen_uv) {
-		canvas_shader.set_uniform(CanvasShaderGLES2::SCREEN_UV_MULT,Vector2(1.0/viewport.width,1.0/viewport.height));
-	}
-
-
-	uses_texpixel_size=shader->uses_texpixel_size;
-
-}
-
-#endif
 
 void RasterizerCanvasGLES3::_copy_texscreen(const Rect2 &p_rect) {
 

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -205,7 +205,7 @@ def configure(env):
         env.Append(CPPFLAGS=["-isystem", lib_sysroot + "/usr/include"])
 
     env.Append(CPPFLAGS='-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -fvisibility=hidden -fno-strict-aliasing'.split())
-    env.Append(CPPFLAGS='-DNO_STATVFS -DGLES2_ENABLED'.split())
+    env.Append(CPPFLAGS='-DNO_STATVFS -DGLES_ENABLED'.split())
 
     env['neon_enabled'] = False
     if env['android_arch'] == 'x86':

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -945,16 +945,17 @@ public:
 public:
 	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) {
 
-		int api = p_preset->get("graphics/api");
+		// Reenable when a GLES 2.0 backend is readded
+		/*int api = p_preset->get("graphics/api");
 		if (api == 0)
 			r_features->push_back("etc");
-		else
-			r_features->push_back("etc2");
+		else*/
+		r_features->push_back("etc2");
 	}
 
 	virtual void get_export_options(List<ExportOption> *r_options) {
 
-		r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "graphics/api", PROPERTY_HINT_ENUM, "OpenGL ES 2.0,OpenGL ES 3.0"), 1));
+		/*r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "graphics/api", PROPERTY_HINT_ENUM, "OpenGL ES 2.0,OpenGL ES 3.0"), 1));*/
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "graphics/32_bits_framebuffer"), true));
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "one_click_deploy/clear_previous_install"), true));
 		r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "custom_package/debug", PROPERTY_HINT_GLOBAL_FILE, "apk"), ""));

--- a/platform/android/globals/global_defaults.cpp
+++ b/platform/android/globals/global_defaults.cpp
@@ -31,12 +31,4 @@
 #include "project_settings.h"
 
 void register_android_global_defaults() {
-
-	/*	GLOBAL_DEF("rasterizer.Android/use_fragment_lighting",false);
-	GLOBAL_DEF("rasterizer.Android/fp16_framebuffer",false);
-	GLOBAL_DEF("display.Android/driver","GLES2");
-	//GLOBAL_DEF("rasterizer.Android/trilinear_mipmap_filter",false);
-
-	ProjectSettings::get_singleton()->set_custom_property_info("display.Android/driver",PropertyInfo(Variant::STRING,"display.Android/driver",PROPERTY_HINT_ENUM,"GLES2"));
-	*/
 }

--- a/platform/android/godot_android.cpp
+++ b/platform/android/godot_android.cpp
@@ -29,24 +29,23 @@
 /*************************************************************************/
 #ifdef ANDROID_NATIVE_ACTIVITY
 
-#include <errno.h>
-#include <jni.h>
-
-#include <EGL/egl.h>
-#include <GLES2/gl2.h>
-
 #include "engine.h"
 #include "file_access_android.h"
 #include "main/main.h"
 #include "os_android.h"
 #include "project_settings.h"
+
+#include <EGL/egl.h>
 #include <android/log.h>
 #include <android/sensor.h>
 #include <android/window.h>
 #include <android_native_app_glue.h>
+#include <errno.h>
+#include <jni.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+
 #define LOGI(...) ((void)__android_log_print(ANDROID_LOG_INFO, "godot", __VA_ARGS__))
 #define LOGW(...) ((void)__android_log_print(ANDROID_LOG_WARN, "godot", __VA_ARGS__))
 

--- a/platform/haiku/detect.py
+++ b/platform/haiku/detect.py
@@ -67,7 +67,7 @@ def configure(env):
     ## Flags
 
     env.Append(CPPPATH=['#platform/haiku'])
-    env.Append(CPPFLAGS=['-DUNIX_ENABLED', '-DOPENGL_ENABLED', '-DGLES2_ENABLED', '-DGLES_OVER_GL'])
+    env.Append(CPPFLAGS=['-DUNIX_ENABLED', '-DOPENGL_ENABLED', '-DGLES_ENABLED', '-DGLES_OVER_GL'])
     env.Append(CPPFLAGS=['-DMEDIA_KIT_ENABLED'])
     # env.Append(CCFLAGS=['-DFREETYPE_ENABLED'])
     env.Append(CPPFLAGS=['-DPTHREAD_NO_RENAME'])  # TODO: enable when we have pthread_setname_np

--- a/platform/haiku/os_haiku.cpp
+++ b/platform/haiku/os_haiku.cpp
@@ -76,7 +76,7 @@ int OS_Haiku::get_video_driver_count() const {
 }
 
 const char *OS_Haiku::get_video_driver_name(int p_driver) const {
-	return "GLES2";
+	return "GLES3";
 }
 
 void OS_Haiku::initialize(const VideoMode &p_desired, int p_video_driver, int p_audio_driver) {
@@ -106,7 +106,9 @@ void OS_Haiku::initialize(const VideoMode &p_desired, int p_video_driver, int p_
 	context_gl->initialize();
 	context_gl->make_current();
 
-	rasterizer = memnew(RasterizerGLES2);
+	/* Port to GLES 3 rasterizer */
+	//rasterizer = memnew(RasterizerGLES2);
+
 #endif
 
 	visual_server = memnew(VisualServerRaster(rasterizer));

--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -163,7 +163,7 @@ def configure(env):
     env['ENV']['CODESIGN_ALLOCATE'] = '/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/codesign_allocate'
 
     env.Append(CPPPATH=['#platform/iphone'])
-    env.Append(CPPFLAGS=['-DIPHONE_ENABLED', '-DUNIX_ENABLED', '-DGLES2_ENABLED', '-DMPC_FIXED_POINT', '-DCOREAUDIO_ENABLED'])
+    env.Append(CPPFLAGS=['-DIPHONE_ENABLED', '-DUNIX_ENABLED', '-DGLES_ENABLED', '-DMPC_FIXED_POINT', '-DCOREAUDIO_ENABLED'])
 
     # TODO: Move that to opus module's config
     if 'module_opus_enabled' in env and env['module_opus_enabled']:

--- a/platform/iphone/globals/global_defaults.cpp
+++ b/platform/iphone/globals/global_defaults.cpp
@@ -31,11 +31,4 @@
 #include "project_settings.h"
 
 void register_iphone_global_defaults() {
-
-	/*GLOBAL_DEF("rasterizer.iOS/use_fragment_lighting",false);
-	GLOBAL_DEF("rasterizer.iOS/fp16_framebuffer",false);
-	GLOBAL_DEF("display.iOS/driver","GLES2");
-	ProjectSettings::get_singleton()->set_custom_property_info("display.iOS/driver",PropertyInfo(Variant::STRING,"display.iOS/driver",PROPERTY_HINT_ENUM,"GLES1,GLES2"));
-	GLOBAL_DEF("display.iOS/use_cadisplaylink",true);
-	*/
 }

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -54,7 +54,7 @@ int OSIPhone::get_video_driver_count() const {
 
 const char *OSIPhone::get_video_driver_name(int p_driver) const {
 
-	return "GLES2";
+	return "GLES3";
 };
 
 OSIPhone *OSIPhone::get_singleton() {

--- a/platform/iphone/platform_config.h
+++ b/platform/iphone/platform_config.h
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include <alloca.h>
-// #define GLES2_INCLUDE_H <ES2/gl.h>
+
 #define GLES3_INCLUDE_H <ES3/gl.h>
 
 #define PLATFORM_REFCOUNT

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -110,7 +110,7 @@ def configure(env):
     ## Flags
 
     env.Append(CPPPATH=['#platform/osx'])
-    env.Append(CPPFLAGS=['-DOSX_ENABLED', '-DUNIX_ENABLED', '-DGLES2_ENABLED', '-DAPPLE_STYLE_KEYS', '-DCOREAUDIO_ENABLED'])
+    env.Append(CPPFLAGS=['-DOSX_ENABLED', '-DUNIX_ENABLED', '-DGLES_ENABLED', '-DAPPLE_STYLE_KEYS', '-DCOREAUDIO_ENABLED'])
     env.Append(LINKFLAGS=['-framework', 'Cocoa', '-framework', 'Carbon', '-framework', 'OpenGL', '-framework', 'AGL', '-framework', 'AudioUnit', '-framework', 'CoreAudio', '-lz', '-framework', 'IOKit', '-framework', 'ForceFeedback'])
     env.Append(LIBS=['pthread'])
 

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -896,7 +896,7 @@ int OS_OSX::get_video_driver_count() const {
 
 const char *OS_OSX::get_video_driver_name(int p_driver) const {
 
-	return "GLES2";
+	return "GLES3";
 }
 
 void OS_OSX::initialize_core() {
@@ -1066,8 +1066,6 @@ void OS_OSX::initialize(const VideoMode &p_desired, int p_video_driver, int p_au
 		zoomed = true;
 
 	/*** END OSX INITIALIZATION ***/
-	/*** END OSX INITIALIZATION ***/
-	/*** END OSX INITIALIZATION ***/
 
 	bool use_gl2 = p_video_driver != 1;
 
@@ -1077,16 +1075,12 @@ void OS_OSX::initialize(const VideoMode &p_desired, int p_video_driver, int p_au
 	RasterizerGLES3::register_config();
 	RasterizerGLES3::make_current();
 
-	//rasterizer = instance_RasterizerGLES2();
-	//visual_server = memnew( VisualServerRaster(rasterizer) );
-
 	visual_server = memnew(VisualServerRaster);
 	if (get_render_thread_mode() != RENDER_THREAD_UNSAFE) {
 
 		visual_server = memnew(VisualServerWrapMT(visual_server, get_render_thread_mode() == RENDER_SEPARATE_THREAD));
 	}
 	visual_server->init();
-	//	visual_server->cursor_set_visible(false, 0);
 
 	AudioDriverManager::initialize(p_audio_driver);
 

--- a/platform/uwp/app.h
+++ b/platform/uwp/app.h
@@ -33,6 +33,7 @@
 
 #include <wrl.h>
 
+// ANGLE doesn't provide a specific lib for GLES3, so we keep using GLES2
 #include "GLES2/gl2.h"
 #include "os_uwp.h"
 

--- a/platform/uwp/detect.py
+++ b/platform/uwp/detect.py
@@ -136,7 +136,7 @@ def configure(env):
 
     env.Append(CPPPATH=['#platform/uwp', '#drivers/windows'])
     env.Append(CCFLAGS=['/DUWP_ENABLED', '/DWINDOWS_ENABLED', '/DTYPED_METHOD_BIND'])
-    env.Append(CCFLAGS=['/DGLES2_ENABLED', '/DGL_GLEXT_PROTOTYPES', '/DEGL_EGLEXT_PROTOTYPES', '/DANGLE_ENABLED'])
+    env.Append(CCFLAGS=['/DGLES_ENABLED', '/DGL_GLEXT_PROTOTYPES', '/DEGL_EGLEXT_PROTOTYPES', '/DANGLE_ENABLED'])
     winver = "0x0602" # Windows 8 is the minimum target for UWP build
     env.Append(CCFLAGS=['/DWINVER=%s' % winver, '/D_WIN32_WINNT=%s' % winver])
 

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -69,7 +69,7 @@ int OSUWP::get_video_driver_count() const {
 }
 const char *OSUWP::get_video_driver_name(int p_driver) const {
 
-	return "GLES2";
+	return "GLES3";
 }
 
 Size2 OSUWP::get_window_size() const {

--- a/platform/windows/context_gl_win.cpp
+++ b/platform/windows/context_gl_win.cpp
@@ -27,24 +27,11 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#if defined(OPENGL_ENABLED) || defined(GLES2_ENABLED)
+#if defined(OPENGL_ENABLED) || defined(GLES_ENABLED)
 
-//
-// C++ Implementation: context_gl_x11
-//
-// Description:
-//
-//
 // Author: Juan Linietsky <reduzio@gmail.com>, (C) 2008
-//
-// Copyright: See COPYING file that comes with this distribution
-//
-//
 
 #include "context_gl_win.h"
-
-//#include "drivers/opengl/glwrapper.h"
-//#include "ctxgl_procaddr.h"
 
 #define WGL_CONTEXT_MAJOR_VERSION_ARB 0x2091
 #define WGL_CONTEXT_MINOR_VERSION_ARB 0x2092

--- a/platform/windows/context_gl_win.h
+++ b/platform/windows/context_gl_win.h
@@ -27,18 +27,9 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#if defined(OPENGL_ENABLED) || defined(GLES2_ENABLED)
-//
-// C++ Interface: context_gl_x11
-//
-// Description:
-//
-//
+#if defined(OPENGL_ENABLED) || defined(GLES_ENABLED)
+
 // Author: Juan Linietsky <reduzio@gmail.com>, (C) 2008
-//
-// Copyright: See COPYING file that comes with this distribution
-//
-//
 
 #ifndef CONTEXT_GL_WIN_H
 #define CONTEXT_GL_WIN_H

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -143,7 +143,7 @@ int OS_Windows::get_video_driver_count() const {
 }
 const char *OS_Windows::get_video_driver_name(int p_driver) const {
 
-	return "GLES2";
+	return "GLES3";
 }
 
 int OS_Windows::get_audio_driver_count() const {

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -236,7 +236,7 @@ def configure(env):
         env.ParseConfig('pkg-config zlib --cflags --libs')
 
     env.Append(CPPPATH=['#platform/x11'])
-    env.Append(CPPFLAGS=['-DX11_ENABLED', '-DUNIX_ENABLED', '-DOPENGL_ENABLED', '-DGLES2_ENABLED', '-DGLES_OVER_GL'])
+    env.Append(CPPFLAGS=['-DX11_ENABLED', '-DUNIX_ENABLED', '-DOPENGL_ENABLED', '-DGLES_ENABLED', '-DGLES_OVER_GL'])
     env.Append(LIBS=['GL', 'pthread'])
 
     if (platform.system() == "Linux"):


### PR DESCRIPTION
There are still some left in the Android Java code, even stuff to swap between
GLES1 and GLES2 support from early Godot days... would be good to see some cleanup
there too one day.

The "graphics/api" option for Android exports is removed, as only GLES 3.0 is supported.
It can be readded when GLES 2.0 support comes back. Fixes #13004.