### PR TITLE
Visual Studio project creation bug fix

### DIFF
--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -34,7 +34,12 @@ if env['tools']:
     SConscript("convex_decomp/SCsub")
 
 if env['vsproj']:
+    import os
+    path = os.getcwd()
+    # Change directory so the path resolves correctly in the function call.
+    os.chdir("..")
     env.AddToVSProject(env.drivers_sources)
+    os.chdir(path)
 
 if env.split_drivers:
     env.split_lib("drivers")


### PR DESCRIPTION
A bug in the /drivers SCons script was preventing files in the /drivers and some in the /thirdparty directories from being added to the VS project.

This will only affect builds that use the 'vsproj=yes' option.