### PR TITLE
Fix the prevention for sliding on slopes in the 2d version of move_and_slide

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1028,7 +1028,10 @@ Vector2 KinematicBody2D::move_and_slide(const Vector2 &p_linear_velocity, const 
 					on_floor = true;
 					floor_velocity = collision.collider_vel;
 
-					if (collision.travel.length() < 1 && ABS((lv.x - floor_velocity.x)) < p_slope_stop_min_velocity) {
+					Vector2 rel_v = lv - floor_velocity;
+					Vector2 hv = rel_v - p_floor_direction * p_floor_direction.dot(rel_v);
+
+					if (collision.travel.length() < 1 && hv.length() < p_slope_stop_min_velocity) {
 						Transform2D gt = get_global_transform();
 						gt.elements[2] -= collision.travel;
 						set_global_transform(gt);


### PR DESCRIPTION
Done by using the same method the 3d counterpart uses.

Fixes #13063.