### PR TITLE
[2.1] - Fix TextureRegionEditor's snap mode is not initial bug.

### DIFF
--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -777,6 +777,7 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	edited_margin = -1;
 	drag_index = -1;
 	drag = false;
+	snap_mode = SNAP_NONE;
 
 	VBoxContainer *main_vb = memnew(VBoxContainer);
 	add_child(main_vb);


### PR DESCRIPTION
Fix this bug:
![capture](https://user-images.githubusercontent.com/24988459/32998493-7587805e-cdd6-11e7-8f58-f2044b6f53cf.png)

It caused by TextureRegionEditor's snap mode is not initial.
![capture2](https://user-images.githubusercontent.com/24988459/32998494-75faccee-cdd6-11e7-84c4-51ff397efd06.png)