### PR TITLE
[3.0] - Change editor_settings.tres to editor_settings-3.tres

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -789,7 +789,7 @@ void EditorSettings::create() {
 
 		// Validate editor config file
 
-		String config_file_name = "editor_settings.tres";
+		String config_file_name = "editor_settings-3.tres";
 		config_file_path = config_dir.plus_file(config_file_name);
 		if (!dir->file_exists(config_file_name)) {
 			goto fail;


### PR DESCRIPTION
A change causes my 2.1 project list to be covered.
Why 3.0 must use "**editor_settings.tres**" name?
You have to think about the coexistence of 2.1 and 3.0
This is what happened to me with 2.1 version:
![capture](https://user-images.githubusercontent.com/24988459/33000476-49d6089c-cde3-11e7-8045-e1fe4c3306df.png)
