### PR TITLE
Up android 'compileSdkVersion' to 24

### DIFF
--- a/platform/android/build.gradle.template
+++ b/platform/android/build.gradle.template
@@ -31,7 +31,7 @@ android {
 		disable 'MissingTranslation'
 	}
 
-	compileSdkVersion 23
+	compileSdkVersion 24
 	buildToolsVersion "26.0.1"
 	useLibrary 'org.apache.http.legacy'
 


### PR DESCRIPTION
This PR increase compileSdkVersion to 24, because the most latest third party SDK like Facebook required at least 24 version. This changes dont affect on lower device version but allows use the latest android features in third party SDKs