### PR TITLE
Basis accepts Vector3 as constructor argument.

### DIFF
--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -267,6 +267,7 @@ bool Variant::can_convert(Variant::Type p_type_from, Variant::Type p_type_to) {
 
 			static const Type valid[] = {
 				QUAT,
+				VECTOR3,
 				NIL
 			};
 


### PR DESCRIPTION
I believe this is all that's needed to close #10721 

If not, I'm happy to plod along here and sort it out.