### PR TITLE
Files list: Add "New Folder.." popup when nothing under mouse cursor

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -157,7 +157,9 @@ void EditorNode::_update_scene_tabs() {
 			tabbar_container->remove_child(scene_tab_add);
 			scene_tabs->add_child(scene_tab_add);
 		}
-		Rect2 last_tab = scene_tabs->get_tab_rect(scene_tabs->get_tab_count() - 1);
+		Rect2 last_tab = Rect2();
+		if (scene_tabs->get_tab_count() != 0)
+			last_tab = scene_tabs->get_tab_rect(scene_tabs->get_tab_count() - 1);
 		scene_tab_add->set_position(Point2(last_tab.get_position().x + last_tab.get_size().x + 3, last_tab.get_position().y));
 	}
 }

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1447,6 +1447,15 @@ void FileSystemDock::_files_list_rmb_select(int p_item, const Vector2 &p_pos) {
 	file_options->popup();
 }
 
+void FileSystemDock::_rmb_pressed(const Vector2 &p_pos) {
+	folder_options->clear();
+	folder_options->set_size(Size2(1, 1));
+
+	folder_options->add_item(TTR("New Folder.."), FOLDER_NEW_FOLDER);
+	folder_options->set_position(files->get_global_position() + p_pos);
+	folder_options->popup();
+}
+
 void FileSystemDock::select_file(const String &p_file) {
 
 	navigate_to_path(p_file);
@@ -1547,6 +1556,7 @@ void FileSystemDock::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_file_selected"), &FileSystemDock::_file_selected);
 	ClassDB::bind_method(D_METHOD("_file_multi_selected"), &FileSystemDock::_file_multi_selected);
 	ClassDB::bind_method(D_METHOD("_update_import_dock"), &FileSystemDock::_update_import_dock);
+	ClassDB::bind_method(D_METHOD("_rmb_pressed"), &FileSystemDock::_rmb_pressed);
 
 	ADD_SIGNAL(MethodInfo("instance", PropertyInfo(Variant::POOL_STRING_ARRAY, "files")));
 	ADD_SIGNAL(MethodInfo("open"));
@@ -1665,6 +1675,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	files->connect("item_rmb_selected", this, "_files_list_rmb_select");
 	files->connect("item_selected", this, "_file_selected");
 	files->connect("multi_selected", this, "_file_multi_selected");
+	files->connect("rmb_clicked", this, "_rmb_pressed");
 	files->set_allow_rmb_select(true);
 	file_list_vb->add_child(files);
 

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -192,6 +192,7 @@ private:
 
 	void _dir_rmb_pressed(const Vector2 &p_pos);
 	void _files_list_rmb_select(int p_item, const Vector2 &p_pos);
+	void _rmb_pressed(const Vector2 &p_pos);
 
 	struct FileInfo {
 		String name;

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -525,6 +525,11 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 
 			return;
 		}
+		if (mb->get_button_index() == BUTTON_RIGHT) {
+			emit_signal("rmb_clicked", mb->get_position());
+
+			return;
+		}
 	}
 	if (mb.is_valid() && mb->get_button_index() == BUTTON_WHEEL_UP && mb->is_pressed()) {
 
@@ -1397,6 +1402,7 @@ void ItemList::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("item_rmb_selected", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::VECTOR2, "at_position")));
 	ADD_SIGNAL(MethodInfo("multi_selected", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::BOOL, "selected")));
 	ADD_SIGNAL(MethodInfo("item_activated", PropertyInfo(Variant::INT, "index")));
+	ADD_SIGNAL(MethodInfo("rmb_clicked", PropertyInfo(Variant::VECTOR2, "at_position")));
 
 	GLOBAL_DEF("gui/timers/incremental_search_max_interval_msec", 2000);
 }

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -525,6 +525,11 @@ void ItemList::_gui_input(const Ref<InputEvent> &p_event) {
 
 			return;
 		}
+		if (mb->get_button_index() == BUTTON_RIGHT) {
+			emit_signal("rmb_clicked", mb->get_position());
+
+			return;
+		}
 	}
 	if (mb.is_valid() && mb->get_button_index() == BUTTON_WHEEL_UP && mb->is_pressed()) {
 
@@ -1397,6 +1402,7 @@ void ItemList::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("item_rmb_selected", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::VECTOR2, "at_position")));
 	ADD_SIGNAL(MethodInfo("multi_selected", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::BOOL, "selected")));
 	ADD_SIGNAL(MethodInfo("item_activated", PropertyInfo(Variant::INT, "index")));
+	ADD_SIGNAL(MethodInfo("rmb_clicked"), PropertyInfo(Variant::VECTOR2, "at_position"));
 
 	GLOBAL_DEF("gui/timers/incremental_search_max_interval_msec", 2000);
 }

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1402,7 +1402,7 @@ void ItemList::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("item_rmb_selected", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::VECTOR2, "at_position")));
 	ADD_SIGNAL(MethodInfo("multi_selected", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::BOOL, "selected")));
 	ADD_SIGNAL(MethodInfo("item_activated", PropertyInfo(Variant::INT, "index")));
-	ADD_SIGNAL(MethodInfo("rmb_clicked"), PropertyInfo(Variant::VECTOR2, "at_position"));
+	ADD_SIGNAL(MethodInfo("rmb_clicked", PropertyInfo(Variant::VECTOR2, "at_position")));
 
 	GLOBAL_DEF("gui/timers/incremental_search_max_interval_msec", 2000);
 }


### PR DESCRIPTION
Small issue: currently, if there is nothing under mouse cursor in project's file list panel, when you try to right mouse button click - nothing happens.

After this patch, when you RMB on empty space in files list panel, you will see a popup with "New Folder.." item.
Screenshot: https://i.imgur.com/xvvNpbh.png