### PR TITLE
bullet cast_motion: reordered null check

### DIFF
--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -175,13 +175,13 @@ bool BulletPhysicsDirectSpaceState::cast_motion(const RID &p_shape, const Transf
 
 	space->dynamicsWorld->convexSweepTest(bt_convex_shape, bt_xform_from, bt_xform_to, btResult, 0.002);
 
-	if (r_info) {
-		if (btResult.hasHit()) {
+	if (btResult.hasHit()) {
+		p_closest_safe = p_closest_unsafe = btResult.m_closestHitFraction;
+		if (r_info) {
 			if (btCollisionObject::CO_RIGID_BODY == btResult.m_hitCollisionObject->getInternalType()) {
 				B_TO_G(static_cast<const btRigidBody *>(btResult.m_hitCollisionObject)->getVelocityInLocalPoint(btResult.m_hitPointWorld), r_info->linear_velocity);
 			}
 			CollisionObjectBullet *collision_object = static_cast<CollisionObjectBullet *>(btResult.m_hitCollisionObject->getUserPointer());
-			p_closest_safe = p_closest_unsafe = btResult.m_closestHitFraction;
 			B_TO_G(btResult.m_hitPointWorld, r_info->point);
 			B_TO_G(btResult.m_hitNormalWorld, r_info->normal);
 			r_info->rid = collision_object->get_self();


### PR DESCRIPTION
#13046 fixed the crash, but, if there is an hit, p_closest_safe and p_closest_unsafe should be written to even when r_info is null.