### PR TITLE
Script hierarchies for Inspector

### DIFF
--- a/core/object.h
+++ b/core/object.h
@@ -637,6 +637,7 @@ public:
 	void set_indexed(const Vector<StringName> &p_names, const Variant &p_value, bool *r_valid = NULL);
 	Variant get_indexed(const Vector<StringName> &p_names, bool *r_valid = NULL) const;
 
+	void get_property_list_script_categories(List<PropertyInfo> *p_list) const;
 	void get_property_list(List<PropertyInfo> *p_list, bool p_reversed = false) const;
 
 	bool has_method(const StringName &p_method) const;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2179,8 +2179,7 @@ void CSharpScript::update_signals() {
 
 Ref<Script> CSharpScript::get_base_script() const {
 
-	// TODO search in metadata file once we have it, not important any way?
-	return Ref<Script>();
+	return base_cache;
 }
 
 void CSharpScript::get_script_property_list(List<PropertyInfo> *p_list) const {


### PR DESCRIPTION
Fixes #10799 

Demonstration:

Here are some various screenshots. These are from an environment in which I have the following structure:

    # class_c.gd
    extends "res://class_b.gd"
    export(bool) var c = true
    export(bool) var c2 = false
    
    # class_b.gd
    extends "res://class_a.gd"
    var b = true
    
    # class_a.gd
    extends "res://class_2.gd"
    export var a = "a"
    export var a2 = "a2"
    
    # class_2.gd
    extends "res://class_1.gd"
    export var three = 3
    export var four = 4
    
    # class_1.gd
    extends Node
    export var one = 1
    export var two = 2

The only variable/class we should NOT see show up is `class_b.gd` with the single, un-exported `b` property with value `true`.

If I attach `class_c.gd` to a Node, I see this before/after:

![class_c_before](https://user-images.githubusercontent.com/16217563/34071983-f3f6c350-e244-11e7-803c-85046580828a.PNG)
![class_c_after](https://user-images.githubusercontent.com/16217563/34071939-464641cc-e244-11e7-808c-4bc14bff6155.PNG)

If I have a builtin script with exported `builtin1` and non-exported `builtin2`, then I get this before/after (`script_test.tscn` is the name of the scene and the built-in script extends a `Node` type):

![builtin_script_before](https://user-images.githubusercontent.com/16217563/34071953-5a8c3182-e244-11e7-9194-b969c4976b17.PNG)
![builtin_script_after](https://user-images.githubusercontent.com/16217563/34071955-60a4e1fe-e244-11e7-8c16-cfe749116b81.PNG)

If I have `class_c` open, and I change it to extend from `class_2` instead of `class_b`, but I HAVEN'T saved it yet, then I will see this before/after (looks the same as the saved version, which was the goal):

![derive_2_not_b_unsaved_c_before](https://user-images.githubusercontent.com/16217563/34071961-7f72b336-e244-11e7-9e45-b2f5a74a13a7.PNG)
![derive_2_not_b_unsaved_c_after](https://user-images.githubusercontent.com/16217563/34071963-83ce9044-e244-11e7-93df-885e61020f3d.PNG)

~~In the course of doing this, I did find another small bug for the unsaved scripts (going from less derived to more derived base class in an unsaved script. In this case, I went from `class_1` to `class_a`, so `class_2` and `class_a's variables are showing up under `class_1`'s), so it seems it still needs some more work.~~

Edit: Oh wait! No, that's a purposeful "bug". If you ADD scripts and properties to the inheritance hierarchy, but the script hasn't been saved, the `p_list` ends up with all of these extra properties and doesn't yet know about the new scripts, so it just bundles them all underneath the most relevant script it can find. It gets revised when you actually save the script.

![derive_a_not_1_unsaved_c_after](https://user-images.githubusercontent.com/16217563/34072091-d5a3f3d0-e246-11e7-96e0-07fefc8d23c0.PNG)
(after saving:)
![class_c_after](https://user-images.githubusercontent.com/16217563/34072148-8ede8266-e247-11e7-9a86-cd2fa65a506b.PNG)

Incidentally, if you add a script to a node that has nothing else in the script hierarchy, and the script is not yet saved (so it doesn't have a name yet), AND if it has export variables that show up in the Inspector, then it starts autonaming the category blocks with "Class 0", "Class 1", etc. for every script that isn't yet saved. If anywhere in the script hierarchy there is a saved script, then all of the unsaved scripts' properties are assumed to belong to the saved script, until those other scripts are saved. This is why we see the "buggy" behavior above. Here's what this algorithm results in for the objects with no saved scripts:

![unsaved_new_script_export](https://user-images.githubusercontent.com/16217563/34072268-c8464fd2-e249-11e7-8569-1ecf3283d0ad.PNG)

Regardless of whether this ends up as part of the 3.0 release or not, I might actually start extending this out into a full on overhaul of custom types in general, targeting a 3.1 release. This would be a critical change to have for a full custom type simulation across the engine.

Edit:

Here are some various screenshots. These are from an environment in which I have the following structure:

    # class_c.gd
    extends "res://class_b.gd"
    export(bool) var c = true
    export(bool) var c2 = false
    
    # class_b.gd
    extends "res://class_a.gd"
    var b = true
    
    # class_a.gd
    extends "res://class_2.gd"
    export var a = "a"
    export var a2 = "a2"
    
    # class_2.gd
    extends "res://class_1.gd"
    export var three = 3
    export var four = 4
    
    # class_1.gd
    extends Node
    export var one = 1
    export var two = 2

The only variable/class we should NOT see show up is `class_b.gd` with the single, un-exported `b` property with value `true`.

If I attach `class_c.gd` to a Node, I see this before/after:

![class_c_before](https://user-images.githubusercontent.com/16217563/34071983-f3f6c350-e244-11e7-803c-85046580828a.PNG)
![class_c_after](https://user-images.githubusercontent.com/16217563/34071939-464641cc-e244-11e7-808c-4bc14bff6155.PNG)

If I have a builtin script with exported `builtin1` and non-exported `builtin2`, then I get this before/after (`script_test.tscn` is the name of the scene and the built-in script extends a `Node` type):

![builtin_script_before](https://user-images.githubusercontent.com/16217563/34071953-5a8c3182-e244-11e7-9194-b969c4976b17.PNG)
![builtin_script_after](https://user-images.githubusercontent.com/16217563/34071955-60a4e1fe-e244-11e7-8c16-cfe749116b81.PNG)

If I have `class_c` open, and I change it to extend from `class_2` instead of `class_b`, but I HAVEN'T saved it yet, then I will see this before/after (looks the same as the saved version, which was the goal):

![derive_2_not_b_unsaved_c_before](https://user-images.githubusercontent.com/16217563/34071961-7f72b336-e244-11e7-9e45-b2f5a74a13a7.PNG)
![derive_2_not_b_unsaved_c_after](https://user-images.githubusercontent.com/16217563/34071963-83ce9044-e244-11e7-93df-885e61020f3d.PNG)

~~In the course of doing this, I did find another small bug for the unsaved scripts (going from less derived to more derived base class in an unsaved script. In this case, I went from `class_1` to `class_a`, so `class_2` and `class_a's variables are showing up under `class_1`'s), so it seems it still needs some more work.~~

Edit: Oh wait! No, that's a purposeful "bug". If you ADD scripts and properties to the inheritance hierarchy, but the script hasn't been saved, the `p_list` ends up with all of these extra properties and doesn't yet know about the new scripts, so it just bundles them all underneath the most relevant script it can find. It gets revised when you actually save the script.

![derive_a_not_1_unsaved_c_after](https://user-images.githubusercontent.com/16217563/34072091-d5a3f3d0-e246-11e7-96e0-07fefc8d23c0.PNG)
(after saving:)
![class_c_after](https://user-images.githubusercontent.com/16217563/34072148-8ede8266-e247-11e7-9a86-cd2fa65a506b.PNG)

Incidentally, if you add a script to a node that has nothing else in the script hierarchy, and the script is not yet saved (so it doesn't have a name yet), AND if it has export variables that show up in the Inspector, then it starts autonaming the category blocks with "Class 0", "Class 1", etc. for every script that isn't yet saved. If anywhere in the script hierarchy there is a saved script, then all of the unsaved scripts' properties are assumed to belong to the saved script, until those other scripts are saved. This is why we see the "buggy" behavior above. Here's what this algorithm results in for the objects with no saved scripts:

![unsaved_new_script_export](https://user-images.githubusercontent.com/16217563/34072268-c8464fd2-e249-11e7-8569-1ecf3283d0ad.PNG)

Regardless of whether this ends up as part of the 3.0 release or not, I might actually start extending this out into a full on overhaul of custom types in general, targeting a 3.1 release. This would be a critical change to have for a full custom type simulation across the engine.


