### PR TITLE
Remove the "." and "/" (at the end of folders name) from file manage dialog (open scene, open file, ...)

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -541,6 +541,9 @@ void EditorFileDialog::update_file_list() {
 
 	while ((item = dir_access->get_next(&isdir)) != "") {
 
+		if (item == ".")
+			continue;
+
 		ishidden = dir_access->current_is_hidden();
 
 		if (show_hidden || !ishidden) {
@@ -562,7 +565,7 @@ void EditorFileDialog::update_file_list() {
 	while (!dirs.empty()) {
 		const String &dir_name = dirs.front()->get();
 
-		item_list->add_item(dir_name + "/");
+		item_list->add_item(dir_name);
 
 		if (display_mode == DISPLAY_THUMBNAILS) {
 

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -323,6 +323,9 @@ void FileDialog::update_file_list() {
 
 	while ((item = dir_access->get_next(&isdir)) != "") {
 
+		if (item == ".")
+			continue;
+
 		ishidden = dir_access->current_is_hidden();
 
 		if (show_hidden || !ishidden) {
@@ -344,7 +347,7 @@ void FileDialog::update_file_list() {
 	while (!dirs.empty()) {
 		String &dir_name = dirs.front()->get();
 		TreeItem *ti = tree->create_item(root);
-		ti->set_text(0, dir_name + "/");
+		ti->set_text(0, dir_name);
 		ti->set_icon(0, folder);
 
 		Dictionary d;


### PR DESCRIPTION
Nothing harmful, just small change - remove the "." from file manager dialog.
It is not a bug, but undesired to be there: its not clickable anyway, you can't anyhow interact with it, just received from filesystem besides files/directories and not sorted out initially, and since it do nothing when you click it - no point to display it and confuse newbies. 
Godot 2.1 also doesn't have it.

Same done for the "/" at end of folders name. Also useless addition, not making any useful  functional/cosmetic use.

Screenshot of Open Scene file manager: https://i.imgur.com/3oNMJN5.png
![image](https://user-images.githubusercontent.com/8281454/33076444-159c2efc-cf10-11e7-8bbe-7f7bed7e17c9.png)

Screenshot of in-game filedialog control: https://i.imgur.com/k4lC2eq.png
![image](https://user-images.githubusercontent.com/8281454/33076453-1c19b344-cf10-11e7-8d35-be200bbb24e5.png)
