### PR TITLE
Revert this change, we need to export symbols on the library side

### DIFF
--- a/modules/gdnative/include/gdnative/gdnative.h
+++ b/modules/gdnative/include/gdnative/gdnative.h
@@ -53,7 +53,7 @@ extern "C" {
 
 // This is for libraries *using* the header, NOT GODOT EXPOSING STUFF!!
 #ifdef _WIN32
-#define GDN_EXPORT
+#define GDN_EXPORT __declspec(dllexport)
 #else
 #define GDN_EXPORT
 #endif


### PR DESCRIPTION
This was removed because on the Godot side we no longer have a need to export symbols thanks to our api_structs.

On the library side of life however, we still need to export our entry points!