### PR TITLE
Add explicit exception model flag for Visual C++

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -326,6 +326,8 @@ if selected_platform in platform_list:
             env.Append(CCFLAGS=['/W2'] + disable_nonessential_warnings)
         else: # 'no'
             env.Append(CCFLAGS=['/w'])
+        # Set exception handling model to avoid warnings caused by Windows system headers.
+        env.Append(CCFLAGS=['/EHsc'])
     else: # Rest of the world
         if (env["warnings"] == 'extra'):
             env.Append(CCFLAGS=['-Wall', '-Wextra'])


### PR DESCRIPTION
VC++ warns about exceptions being thrown by certain system headers and the use of the `noexcept` keyword in the Godot sources if no explicit exception handling model is specified. Option `EHsc` catches C++ exceptions only and seems to be the preferable option:

https://docs.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model

I am not sure whether this change has any noticeable performance impact. Since VC++ catches both synchronous structured exceptions and C++ exceptions by default, this is unlikely to have a major negative impact and might actually be beneficial.