### PR TITLE
Added the ability for RemoteTransform and RemoteTransform2D to follow the remote node

### DIFF
--- a/doc/classes/RemoteTransform.xml
+++ b/doc/classes/RemoteTransform.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RemoteTransform" inherits="Spatial" category="Core" version="3.0-alpha">
 	<brief_description>
-		RemoteTransform mirrors the [Transform] of another [Spatial] derived Node in the scene.
+		RemoteTransform leads or follows the [Transform] of another [Spatial] derived Node in the scene.
 	</brief_description>
 	<description>
-		RemoteTransform mirrors the [Transform] of another [Spatial] derived Node (called the remote node) in the scene.
-		It can be set to track another Node's position, rotation and/or scale and update its own accordingly, using either global or local coordinates.
+		RemoteTransform leads or follows the [Transform] of another [Spatial] derived Node (called the remote node) in the scene.
+		It can be set to track another Node's position, rotation and/or and update its own accordingly, using either global or local coordinates.
+
+		It can either follow the [Transform] of the remote node, or it can make the remote node's [Transform] follow the RemoteTransform's [Transform].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -16,30 +18,42 @@
 			<return type="NodePath">
 			</return>
 			<description>
+				Returns the nodepath to the remote node, relative to the RemoteTransform's position in the node scene
 			</description>
 		</method>
 		<method name="get_update_position" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
+				Returns if the RemoteTransform is tracking position.
 			</description>
 		</method>
 		<method name="get_update_rotation" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
+				Returns if the RemoteTransform is tracking rotation.
 			</description>
 		</method>
 		<method name="get_update_scale" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
+				Returns if the RemoteTransform is tracking scale.
 			</description>
 		</method>
 		<method name="get_use_global_coordinates" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
+				Returns if the RemoteTransform is tracking using global coordinates.
+			</description>
+		</method>
+		<method name="get_remote_mode" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the current remote mode.
 			</description>
 		</method>
 		<method name="set_remote_node">
@@ -48,6 +62,7 @@
 			<argument index="0" name="path" type="NodePath">
 			</argument>
 			<description>
+				Sets the path to the remote node, relative to the RemoteTransform's position in the node scene.
 			</description>
 		</method>
 		<method name="set_update_position">
@@ -56,6 +71,7 @@
 			<argument index="0" name="update_remote_position" type="bool">
 			</argument>
 			<description>
+				Sets whether or not the position will be tracked.
 			</description>
 		</method>
 		<method name="set_update_rotation">
@@ -64,6 +80,7 @@
 			<argument index="0" name="update_remote_rotation" type="bool">
 			</argument>
 			<description>
+				Sets whether or not the rotation will be tracked.
 			</description>
 		</method>
 		<method name="set_update_scale">
@@ -72,6 +89,7 @@
 			<argument index="0" name="update_remote_scale" type="bool">
 			</argument>
 			<description>
+				Sets whether or not the scale will be tracked.
 			</description>
 		</method>
 		<method name="set_use_global_coordinates">
@@ -80,26 +98,51 @@
 			<argument index="0" name="use_global_coordinates" type="bool">
 			</argument>
 			<description>
+				Set whether or not to use global coordinates for node updates.
+
+				If [code]true[/code], RemoteTransform will track using global coordinates, while if it's [code]false[/code] it will track using local coordinates.
+			</description>
+		</method>
+		<method name="set_remote_mode">
+			<return type="void">
+			</return>
+			<argument index="0" name="remote_mode" type="int">
+			</argument>
+			<description>
+				Sets the remote mode. There are currently two possible modes: Follow and Lead.
+
+				Lead will make the remote node follow RemoteTransform's [Transform].
+				Follow will make the RemoteTransform follow the remote node's [Transform].
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="remote_path" type="NodePath" setter="set_remote_node" getter="get_remote_node">
-			The remote node's [NodePath].
+			The remote node's [NodePath], relative to Transform's position in the node scene.
+		</member>
+		<member name="mode" type="int" setter="get_remote_mode" getter="set_remote_mode">
+			The mode we're using. If set to lead the remote node will follow the RemoteTransform's [Transform], while setting it to follow will
+			make the RemoteTransform follow the [Transform] of the remote node. Default value: [code]0[/code]
 		</member>
 		<member name="update_position" type="bool" setter="set_update_position" getter="get_update_position">
-			If [code]true[/code] the remote node's position is mirrored.
+			If [code]true[/code] the remote node's position is tracked. Default value: [code]true[/code]
 		</member>
 		<member name="update_rotation" type="bool" setter="set_update_rotation" getter="get_update_rotation">
-			If [code]true[/code] the remote node's rotation is mirrored.
+			If [code]true[/code] the remote node's rotation is tracked. Default value: [code]true[/code]
 		</member>
 		<member name="update_scale" type="bool" setter="set_update_scale" getter="get_update_scale">
-			If [code]true[/code] the remote node's scale is mirrored.
+			If [code]true[/code] the remote node's scale is tracked. Default value: [code]true[/code]
 		</member>
 		<member name="use_global_coordinates" type="bool" setter="set_use_global_coordinates" getter="get_use_global_coordinates">
 			If [code]true[/code] global coordinates are used. If [code]false[/code] local coordinates are used. Default value: [code]true[/code].
 		</member>
 	</members>
 	<constants>
+		<constant name="REMOTE_MODE_LEAD" value="0">
+			Lead mode will make the remote node follow RemoteTransform's [Transform].
+		</constant>
+		<constant name="REMOTE_MODE_FOLLOW" value="1">
+			Follow mode will make the RemoteTransform follow the remote node's [Transform].
+		</constant>
 	</constants>
 </class>

--- a/doc/classes/RemoteTransform2D.xml
+++ b/doc/classes/RemoteTransform2D.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RemoteTransform2D" inherits="Node2D" category="Core" version="3.0-alpha">
 	<brief_description>
-		RemoteTransform2D mirrors the [Transform2D] of another [CanvasItem] derived Node in the scene.
+		RemoteTransform2D leads or follows the [Transform2D] of another [CanvasItem] derived Node in the scene.
 	</brief_description>
 	<description>
-		RemoteTransform2D mirrors the [Transform2D] of another [CanvasItem] derived Node (called the remote node) in the scene.
+		RemoteTransform2D leads or follows the [Transform2D] of another [CanvasItem] derived Node (called the remote node) in the scene.
 		It can be set to track another Node's position, rotation and/or and update its own accordingly, using either global or local coordinates.
+
+		It can either follow the [Transform2D] of the remote node, or it can make the remote node's [Transform2D] follow the RemoteTransform2D's [Transform2D].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -16,30 +18,42 @@
 			<return type="NodePath">
 			</return>
 			<description>
+				Returns the nodepath to the remote node, relative to the RemoteTransform2D's position in the node scene.
 			</description>
 		</method>
 		<method name="get_update_position" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
+				Returns if the RemoteTransform2D is tracking position.
 			</description>
 		</method>
 		<method name="get_update_rotation" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
+				Returns if the RemoteTransform2D is tracking rotation.
 			</description>
 		</method>
 		<method name="get_update_scale" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
+				Returns if the RemoteTransform2D is tracking scale.
 			</description>
 		</method>
 		<method name="get_use_global_coordinates" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
+				Returns if the RemoteTransform2D is tracking using global coordinates.
+			</description>
+		</method>
+		<method name="get_remote_mode" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the current remote mode.
 			</description>
 		</method>
 		<method name="set_remote_node">
@@ -48,6 +62,7 @@
 			<argument index="0" name="path" type="NodePath">
 			</argument>
 			<description>
+				Sets the path to the remote node, relative to the RemoteTransform2D's position in the node scene.
 			</description>
 		</method>
 		<method name="set_update_position">
@@ -56,6 +71,7 @@
 			<argument index="0" name="update_remote_position" type="bool">
 			</argument>
 			<description>
+				Sets whether or not the position will be tracked.
 			</description>
 		</method>
 		<method name="set_update_rotation">
@@ -64,6 +80,7 @@
 			<argument index="0" name="update_remote_rotation" type="bool">
 			</argument>
 			<description>
+				Sets whether or not the rotation will be tracked.
 			</description>
 		</method>
 		<method name="set_update_scale">
@@ -72,6 +89,7 @@
 			<argument index="0" name="update_remote_scale" type="bool">
 			</argument>
 			<description>
+				Sets whether or not the scale will be tracked.
 			</description>
 		</method>
 		<method name="set_use_global_coordinates">
@@ -80,26 +98,51 @@
 			<argument index="0" name="use_global_coordinates" type="bool">
 			</argument>
 			<description>
+				Set whether or not to use global coordinates for node updates.
+
+				If [code]true[/code], RemoteTransform2D will track using global coordinates, while if it's [code]false[/code] it will track using local coordinates.
+			</description>
+		</method>
+		<method name="set_remote_mode">
+			<return type="void">
+			</return>
+			<argument index="0" name="remote_mode" type="int">
+			</argument>
+			<description>
+				Sets the remote mode. There are currently two possible modes: Follow and Lead.
+
+				Lead will make the remote node follow RemoteTransform2D's [Transform2D].
+				Follow will make the RemoteTransform2D follow the remote node's [Transform2D].
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="remote_path" type="NodePath" setter="set_remote_node" getter="get_remote_node">
-			The remote node's [NodePath].
+			The remote node's [NodePath], relative to Transform2D's position in the node scene.
+		</member>
+		<member name="mode" type="int" setter="get_remote_mode" getter="set_remote_mode">
+			The mode we're using. If set to lead the remote node will follow the RemoteTransform2D's [Transform2D], while setting it to follow will
+			make the RemoteTransform2D follow the [Transform2D] of the remote node. Default value: [code]0[/code]
 		</member>
 		<member name="update_position" type="bool" setter="set_update_position" getter="get_update_position">
-			If [code]true[/code] the remote node's position is mirrored.
+			If [code]true[/code] the remote node's position is tracked. Default value: [code]true[/code]
 		</member>
 		<member name="update_rotation" type="bool" setter="set_update_rotation" getter="get_update_rotation">
-			If [code]true[/code] the remote node's rotation is mirrored.
+			If [code]true[/code] the remote node's rotation is tracked. Default value: [code]true[/code]
 		</member>
 		<member name="update_scale" type="bool" setter="set_update_scale" getter="get_update_scale">
-			If [code]true[/code] the remote node's scale is mirrored.
+			If [code]true[/code] the remote node's scale is tracked. Default value: [code]true[/code]
 		</member>
 		<member name="use_global_coordinates" type="bool" setter="set_use_global_coordinates" getter="get_use_global_coordinates">
 			If [code]true[/code] global coordinates are used. If [code]false[/code] local coordinates are used. Default value: [code]true[/code].
 		</member>
 	</members>
 	<constants>
+		<constant name="REMOTE_MODE_LEAD" value="0">
+			Lead mode will make the remote node follow RemoteTransform2D's [Transform2D].
+		</constant>
+		<constant name="REMOTE_MODE_FOLLOW" value="1">
+			Follow mode will make the RemoteTransform2D follow the remote node's [Transform2D].
+		</constant>
 	</constants>
 </class>

--- a/scene/2d/remote_transform_2d.h
+++ b/scene/2d/remote_transform_2d.h
@@ -50,6 +50,13 @@ protected:
 	void _notification(int p_what);
 
 public:
+	enum RemoteMode {
+		REMOTE_MODE_LEAD,
+		REMOTE_MODE_FOLLOW
+	};
+
+	RemoteMode remote_mode;
+
 	void set_remote_node(const NodePath &p_remote_node);
 	NodePath get_remote_node() const;
 
@@ -65,7 +72,12 @@ public:
 	void set_update_scale(const bool p_update);
 	bool get_update_scale() const;
 
+	void set_remote_mode(const RemoteMode p_mode);
+	RemoteMode get_remote_mode() const;
+
 	virtual String get_configuration_warning() const;
 
 	RemoteTransform2D();
 };
+
+VARIANT_ENUM_CAST(RemoteTransform2D::RemoteMode);

--- a/scene/3d/remote_transform.h
+++ b/scene/3d/remote_transform.h
@@ -52,6 +52,11 @@ protected:
 	void _notification(int p_what);
 
 public:
+	enum RemoteMode { REMOTE_MODE_LEAD,
+		REMOTE_MODE_FOLLOW };
+
+	RemoteMode remote_mode;
+
 	void set_remote_node(const NodePath &p_remote_node);
 	NodePath get_remote_node() const;
 
@@ -67,9 +72,14 @@ public:
 	void set_update_scale(const bool p_update);
 	bool get_update_scale() const;
 
+	void set_remote_mode(const RemoteMode p_mode);
+	RemoteMode get_remote_mode() const;
+
 	virtual String get_configuration_warning() const;
 
 	RemoteTransform();
 };
+
+VARIANT_ENUM_CAST(RemoteTransform::RemoteMode);
 
 #endif // REMOTETRANSFORM_H


### PR DESCRIPTION
Added the ability for RemoteTransform and RemoteTransform2D to follow the remote node. Now RemoteTransform and RemoteTransform2D can both lead and follow the remote node, based on a new enumerator called remote_mode.

The default mode is lead so functionality is the same as Godot 2 (so migrating from Godot 2 to 3 doesn't need any changes for either node).

In order to follow the remote node, I'm doing checks every physics process, which works but may not be the most efficient, but I couldn't find any great way to tell if the remote node's transform had changed.
I also refactored the code a bit, so it's a little cleaner.

Also made changes to the documentation for both nodes, fixing #13066 and adding the documentation for the new additions and changes.

EDIT: Fixed formatting issues
EDIT 2: Formatting still had issues, hopefully they're fixed now...