### PR TITLE
Fix for wrong preview generated when saving scene with script editor opened

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -895,9 +895,13 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 
 	Ref<Image> img;
 	if (is2d) {
-		img = scene_root->get_texture()->get_data();
+		if (_get_current_main_editor() == EDITOR_2D) {
+			img = scene_root->get_texture()->get_data();
+		}
 	} else {
-		img = SpatialEditor::get_singleton()->get_editor_viewport(0)->get_viewport_node()->get_texture()->get_data();
+		if (_get_current_main_editor() == EDITOR_3D) {
+			img = SpatialEditor::get_singleton()->get_editor_viewport(0)->get_viewport_node()->get_texture()->get_data();
+		}
 	}
 
 	if (img.is_valid()) {


### PR DESCRIPTION
This works around #12686 by saving the scene preview only if the relevant editor is opened (i.e. EDITOR_2D in case of a 2D scene and EDITOR_3D in case of a 3D scene).