### PR TITLE
Properly implement Basis constructor using Vector3 of Euler angles

### DIFF
--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -66,7 +66,7 @@ String Variant::get_type_name(Variant::Type p_type) {
 			return "String";
 		} break;
 
-			// math types
+		// math types
 
 		case VECTOR2: {
 
@@ -513,6 +513,7 @@ bool Variant::can_convert_strict(Variant::Type p_type_from, Variant::Type p_type
 
 			static const Type valid[] = {
 				QUAT,
+				VECTOR3,
 				NIL
 			};
 
@@ -723,7 +724,7 @@ bool Variant::is_zero() const {
 
 		} break;
 
-			// math types
+		// math types
 
 		case VECTOR2: {
 
@@ -932,7 +933,7 @@ void Variant::reference(const Variant &p_variant) {
 			memnew_placement(_data._mem, String(*reinterpret_cast<const String *>(p_variant._data._mem)));
 		} break;
 
-			// math types
+		// math types
 
 		case VECTOR2: {
 
@@ -1632,7 +1633,9 @@ Variant::operator Basis() const {
 		return *_data._basis;
 	else if (type == QUAT)
 		return *reinterpret_cast<const Quat *>(_data._mem);
-	else if (type == TRANSFORM)
+	else if (type == VECTOR3) {
+		return Basis(*reinterpret_cast<const Vector3 *>(_data._mem));
+	} else if (type == TRANSFORM) // unexposed in Variant::can_convert?
 		return _data._transform->basis;
 	else
 		return Basis();
@@ -2502,7 +2505,7 @@ void Variant::operator=(const Variant &p_variant) {
 			*reinterpret_cast<String *>(_data._mem) = *reinterpret_cast<const String *>(p_variant._data._mem);
 		} break;
 
-			// math types
+		// math types
 
 		case VECTOR2: {
 
@@ -2642,7 +2645,7 @@ uint32_t Variant::hash() const {
 
 			return reinterpret_cast<const String *>(_data._mem)->hash();
 		} break;
-			// math types
+		// math types
 
 		case VECTOR2: {
 

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -899,11 +899,6 @@ struct _VariantCall {
 		r_ret = Basis(p_args[0]->operator Vector3(), p_args[1]->operator real_t());
 	}
 
-	static void Basis_init3(Variant &r_ret, const Variant **p_args) {
-
-		r_ret = Basis(p_args[0]->operator Vector3());
-	}
-
 	static void Transform_init1(Variant &r_ret, const Variant **p_args) {
 
 		Transform t;
@@ -1799,7 +1794,6 @@ void register_variant_methods() {
 
 	_VariantCall::add_constructor(_VariantCall::Basis_init1, Variant::BASIS, "x_axis", Variant::VECTOR3, "y_axis", Variant::VECTOR3, "z_axis", Variant::VECTOR3);
 	_VariantCall::add_constructor(_VariantCall::Basis_init2, Variant::BASIS, "axis", Variant::VECTOR3, "phi", Variant::REAL);
-	_VariantCall::add_constructor(_VariantCall::Basis_init3, Variant::BASIS, "euler", Variant::VECTOR3);
 
 	_VariantCall::add_constructor(_VariantCall::Transform_init1, Variant::TRANSFORM, "x_axis", Variant::VECTOR3, "y_axis", Variant::VECTOR3, "z_axis", Variant::VECTOR3, "origin", Variant::VECTOR3);
 	_VariantCall::add_constructor(_VariantCall::Transform_init2, Variant::TRANSFORM, "basis", Variant::BASIS, "origin", Variant::VECTOR3);


### PR DESCRIPTION
Fixes #13104.

Regarding binding such constructors: take note that `can_convert` must also be changed, it was already done for this constructor in #13080 but that was incomplete.