### PR TITLE
Added force_process_input function to viewport

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2381,6 +2381,16 @@ void Viewport::input(const Ref<InputEvent> &p_event) {
 	//get_tree()->call_group(SceneTree::GROUP_CALL_REVERSE|SceneTree::GROUP_CALL_REALTIME|SceneTree::GROUP_CALL_MULIILEVEL,gui_input_group,"_gui_input",p_event); //special one for GUI, as controls use their own process check
 }
 
+void Viewport::force_process_input(const Ref<InputEvent> &p_event) {
+
+	ERR_FAIL_COND(!is_inside_tree());
+
+	if (!get_tree()->is_input_handled()) {
+		get_tree()->_call_input_pause(input_group, "_input", p_event); //not a bug, must happen before GUI, order is _input -> gui input -> _unhandled input
+	}
+	_gui_input_event(p_event);
+}
+
 void Viewport::unhandled_input(const Ref<InputEvent> &p_event) {
 
 	ERR_FAIL_COND(!is_inside_tree());
@@ -2662,6 +2672,7 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_viewport_rid"), &Viewport::get_viewport_rid);
 	ClassDB::bind_method(D_METHOD("input", "local_event"), &Viewport::input);
 	ClassDB::bind_method(D_METHOD("unhandled_input", "local_event"), &Viewport::unhandled_input);
+	ClassDB::bind_method(D_METHOD("force_process_input", "local_event"), &Viewport::force_process_input);
 
 	ClassDB::bind_method(D_METHOD("update_worlds"), &Viewport::update_worlds);
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -432,6 +432,7 @@ public:
 
 	void input(const Ref<InputEvent> &p_event);
 	void unhandled_input(const Ref<InputEvent> &p_event);
+	void force_process_input(const Ref<InputEvent> &p_event);
 
 	void set_disable_input(bool p_disable);
 	bool is_input_disabled() const;


### PR DESCRIPTION
Closes #12991 

Events can be force processed if required, which makes passing input events from GDScript possible.