### PR TITLE
When drag'n'drop, automatically create dragged resource as a root node if you haven't any yet (v2)

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -578,6 +578,7 @@ class CanvasItemEditorViewport : public Control {
 	void _create_nodes(Node *parent, Node *child, String &path, const Point2 &p_point);
 	bool _create_instance(Node *parent, String &path, const Point2 &p_point);
 	void _perform_drop_data();
+	void _show_resource_type_selector();
 
 	static void _bind_methods();
 


### PR DESCRIPTION
Alternative implementation to PR #13164, closes #12325.

This is how it looks in action: https://i.imgur.com/gE39CZS.gifv

Main difference: initial PR was about to create Node as root node and place there as a child a resource that you trying drag'n'drop.
This new PR create a resource that you drag'n'drop as root node itself, without "Node" as root.