### PR TITLE
Fix combatibility with older .scn files

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -84,8 +84,10 @@ enum {
 	OBJECT_INTERNAL_RESOURCE = 2,
 	OBJECT_EXTERNAL_RESOURCE_INDEX = 3,
 	//version 2: added 64 bits support for float and int
-	FORMAT_VERSION = 2,
-	FORMAT_VERSION_CAN_RENAME_DEPS = 1
+	//version 3: changed nodepath encoding
+	FORMAT_VERSION = 3,
+	FORMAT_VERSION_CAN_RENAME_DEPS = 1,
+	FORMAT_VERSION_NO_NODEPATH_PROPERTY = 3,
 
 };
 
@@ -273,6 +275,9 @@ Error ResourceInteractiveLoaderBinary::parse_variant(Variant &r_v) {
 			uint32_t subname_count = f->get_16();
 			absolute = subname_count & 0x8000;
 			subname_count &= 0x7FFF;
+			if (ver_format < FORMAT_VERSION_NO_NODEPATH_PROPERTY) {
+				subname_count += 1; // has a property field, so we should count it as well
+			}
 
 			for (int i = 0; i < name_count; i++)
 				names.push_back(_get_string());
@@ -854,7 +859,7 @@ void ResourceInteractiveLoaderBinary::open(FileAccess *p_f) {
 
 	uint32_t ver_major = f->get_32();
 	uint32_t ver_minor = f->get_32();
-	uint32_t ver_format = f->get_32();
+	ver_format = f->get_32();
 
 	print_bl("big endian: " + itos(big_endian));
 #ifdef BIG_ENDIAN_ENABLED

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -41,6 +41,7 @@ class ResourceInteractiveLoaderBinary : public ResourceInteractiveLoader {
 	String res_path;
 	String type;
 	Ref<Resource> resource;
+	uint32_t ver_format;
 
 	FileAccess *f;
 


### PR DESCRIPTION
Fixes #13162. There might be some problems opening .scn files created after 613d374bc571929d601af1eab17079a639fe576f, because the format was changed without changing the version number.