### PR TITLE
Make tween able to be used as before (without the need for ":...")

### DIFF
--- a/core/node_path.cpp
+++ b/core/node_path.cpp
@@ -207,7 +207,7 @@ StringName NodePath::get_concatenated_subnames() const {
 		String concatenated;
 		const StringName *ssn = data->subpath.ptr();
 		for (int i = 0; i < spc; i++) {
-			concatenated += i == 0 ? ssn[i].operator String() : "." + ssn[i];
+			concatenated += i == 0 ? ssn[i].operator String() : ":" + ssn[i];
 		}
 		data->concatenated_subpath = concatenated;
 	}
@@ -257,13 +257,17 @@ NodePath NodePath::rel_path_to(const NodePath &p_np) const {
 
 NodePath NodePath::get_as_property_path() const {
 
-	if (data->has_slashes || !data->path.size()) {
-		return NodePath(Vector<StringName>(), data->subpath, false);
+	if (!data->path.size()) {
+		return *this;
 	} else {
-		ERR_FAIL_COND_V(data->path.size() != 1, NodePath());
-
 		Vector<StringName> new_path = data->subpath;
-		new_path.insert(0, data->path[0]);
+
+		String initial_subname = data->path[0];
+		for (size_t i = 1; i < data->path.size(); i++) {
+			initial_subname += i == 0 ? data->path[i].operator String() : "/" + data->path[i];
+		}
+		new_path.insert(0, initial_subname);
+
 		return NodePath(Vector<StringName>(), new_path, false);
 	}
 }
@@ -335,7 +339,6 @@ NodePath::NodePath(const String &p_path) {
 		return;
 
 	String path = p_path;
-	StringName property;
 	Vector<StringName> subpath;
 
 	int absolute = (path[0] == '/') ? 1 : 0;

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -449,6 +449,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM0R(NodePath, get_subname_count);
 	VCALL_LOCALMEM1R(NodePath, get_subname);
 	VCALL_LOCALMEM0R(NodePath, get_concatenated_subnames);
+	VCALL_LOCALMEM0R(NodePath, get_as_property_path);
 	VCALL_LOCALMEM0R(NodePath, is_empty);
 
 	VCALL_LOCALMEM0R(Dictionary, size);
@@ -1592,6 +1593,7 @@ void register_variant_methods() {
 	ADDFUNC0R(NODE_PATH, INT, NodePath, get_subname_count, varray());
 	ADDFUNC1R(NODE_PATH, STRING, NodePath, get_subname, INT, "idx", varray());
 	ADDFUNC0R(NODE_PATH, STRING, NodePath, get_concatenated_subnames, varray());
+	ADDFUNC0R(NODE_PATH, NODE_PATH, NodePath, get_as_property_path, varray());
 	ADDFUNC0R(NODE_PATH, BOOL, NodePath, is_empty, varray());
 
 	ADDFUNC0R(DICTIONARY, INT, Dictionary, size, varray());


### PR DESCRIPTION
Should fixes #13174.

Now this things work again:
```gdscript
tween.interpolate_property($"2d/Label", "custom_colors/font_color", null, Color(1,1,1,1), 2, Tween.TRANS_LINEAR, Tween.EASE_OUT, 0)
tween.remove($"2d/Label", "custom_colors/font_color")
# --
tween.interpolate_property($"2d/Label", "custom_colors/font_color:r", null, 1, 2, Tween.TRANS_LINEAR, Tween.EASE_OUT, 0)
tween.remove($"2d/Label", "custom_colors/font_color:r")
```