### PR TITLE
Allow keep show local scene tree while debugger start

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1827,14 +1827,22 @@ void SceneTreeDock::add_remote_tree_editor(Control *p_remote) {
 
 void SceneTreeDock::show_remote_tree() {
 
-	button_hb->show();
 	_remote_tree_selected();
 }
 
 void SceneTreeDock::hide_remote_tree() {
 
-	button_hb->hide();
 	_local_tree_selected();
+}
+
+void SceneTreeDock::show_tab_buttons() {
+
+	button_hb->show();
+}
+
+void SceneTreeDock::hide_tab_buttons() {
+
+	button_hb->hide();
 }
 
 void SceneTreeDock::_remote_tree_selected() {

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -202,6 +202,8 @@ public:
 	void add_remote_tree_editor(Control *p_remote);
 	void show_remote_tree();
 	void hide_remote_tree();
+	void show_tab_buttons();
+	void hide_tab_buttons();
 
 	void open_script_dialog(Node *p_for_node);
 	SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSelection *p_editor_selection, EditorData &p_editor_data);

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -957,7 +957,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 			if (connection.is_valid()) {
 				inspect_scene_tree_timeout -= get_process_delta_time();
 				if (inspect_scene_tree_timeout < 0) {
-					inspect_scene_tree_timeout = EditorSettings::get_singleton()->get("debugger/scene_tree_refresh_interval");
+					inspect_scene_tree_timeout = EditorSettings::get_singleton()->get("debugger/remote_scene_tree_refresh_interval");
 					if (inspect_scene_tree->is_visible_in_tree()) {
 						_scene_tree_request();
 
@@ -1160,7 +1160,12 @@ void ScriptEditorDebugger::start() {
 		return;
 	}
 
-	EditorNode::get_singleton()->get_scene_tree_dock()->show_remote_tree();
+	EditorNode::get_singleton()->get_scene_tree_dock()->show_tab_buttons();
+	auto_switch_remote_scene_tree = (bool)EditorSettings::get_singleton()->get("debugger/auto_switch_to_remote_scene_tree");
+	if (auto_switch_remote_scene_tree) {
+		EditorNode::get_singleton()->get_scene_tree_dock()->show_remote_tree();
+	}
+
 	set_process(true);
 }
 
@@ -1198,6 +1203,7 @@ void ScriptEditorDebugger::stop() {
 	EditorNode::get_singleton()->get_pause_button()->set_pressed(false);
 	EditorNode::get_singleton()->get_pause_button()->set_disabled(true);
 	EditorNode::get_singleton()->get_scene_tree_dock()->hide_remote_tree();
+	EditorNode::get_singleton()->get_scene_tree_dock()->hide_tab_buttons();
 
 	if (hide_on_stop) {
 		if (is_visible_in_tree())
@@ -1848,7 +1854,8 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		inspect_scene_tree->connect("cell_selected", this, "_scene_tree_selected");
 		inspect_scene_tree->connect("item_collapsed", this, "_scene_tree_folded");
 
-		inspect_scene_tree_timeout = EDITOR_DEF("debugger/scene_tree_refresh_interval", 1.0);
+		auto_switch_remote_scene_tree = EDITOR_DEF("debugger/auto_switch_to_remote_scene_tree", true);
+		inspect_scene_tree_timeout = EDITOR_DEF("debugger/remote_scene_tree_refresh_interval", 1.0);
 		inspect_edited_object_timeout = EDITOR_DEF("debugger/remote_inspect_refresh_interval", 0.2);
 		inspected_object_id = 0;
 		updating_scene_tree = false;

--- a/editor/script_editor_debugger.h
+++ b/editor/script_editor_debugger.h
@@ -75,6 +75,7 @@ class ScriptEditorDebugger : public Control {
 	bool updating_scene_tree;
 	float inspect_scene_tree_timeout;
 	float inspect_edited_object_timeout;
+	bool auto_switch_remote_scene_tree;
 	ObjectID inspected_object_id;
 	ScriptEditorDebuggerVariables *variables;
 	Map<ObjectID, ScriptEditorDebuggerInspectedObject *> remote_objects;


### PR DESCRIPTION
* Add editor setting `auto_switch_to_remote_scene_tree`
* Rename editor setting `scene_tree_refresh_interval` to `remote_scene_tree_refresh_interval`.