### PR TITLE
KinematiceBody::move_and_collide returns multiple collision

### DIFF
--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -926,17 +926,20 @@ bool SpaceBullet::test_body_motion(RigidBodyBullet *p_body, const Transform &p_f
 			B_TO_G(recovered_motion + recover_initial_position, r_result->motion);
 
 			if (hasPenetration) {
-				const btRigidBody *btRigid = static_cast<const btRigidBody *>(r_recover_result.other_collision_object);
-				CollisionObjectBullet *collisionObject = static_cast<CollisionObjectBullet *>(btRigid->getUserPointer());
+				for (int i = 0; i < r_recover_result.recovered_collisions.size(); ++i) {
+					RecoveredCollision recoveredCollision = r_recover_result.recovered_collisions[i];
+					const btRigidBody *btRigid = static_cast<const btRigidBody *>(recoveredCollision.other_collision_object);
+					CollisionObjectBullet *collisionObject = static_cast<CollisionObjectBullet *>(btRigid->getUserPointer());
 
-				r_result->remainder = p_motion - r_result->motion; // is the remaining movements
-				B_TO_G(r_recover_result.pointWorld, r_result->collision_point);
-				B_TO_G(r_recover_result.pointNormalWorld, r_result->collision_normal);
-				B_TO_G(btRigid->getVelocityInLocalPoint(r_recover_result.pointWorld - btRigid->getWorldTransform().getOrigin()), r_result->collider_velocity); // It calculates velocity at point and assign it using special function Bullet_to_Godot
-				r_result->collider = collisionObject->get_self();
-				r_result->collider_id = collisionObject->get_instance_id();
-				r_result->collider_shape = r_recover_result.other_compound_shape_index;
-				r_result->collision_local_shape = r_recover_result.local_shape_most_recovered;
+					r_result->collisions.push_back(PhysicsServer::Collision());
+					r_result->remainder = p_motion - r_result->motion; // is the remaining movements
+					B_TO_G(recoveredCollision.pointWorld, r_result->collisions[i].collision_point);
+					B_TO_G(recoveredCollision.pointNormalWorld, r_result->collisions[i].collision_normal);
+					B_TO_G(btRigid->getVelocityInLocalPoint(recoveredCollision.pointWorld - btRigid->getWorldTransform().getOrigin()), r_result->collisions[i].collider_velocity); // It calculates velocity at point and assign it using special function Bullet_to_Godot
+					r_result->collisions[i].collider = collisionObject->get_self();
+					r_result->collisions[i].collider_id = collisionObject->get_instance_id();
+					r_result->collisions[i].collider_shape = recoveredCollision.other_compound_shape_index;
+					r_result->collisions[i].collision_local_shape = r_recover_result.local_shape_most_recovered;
 
 //{ /// Add manifold point to manage collisions
 //    btPersistentManifold* manifold = dynamicsWorld->getDispatcher()->getNewManifold(p_body->getBtBody(), btRigid);
@@ -948,17 +951,17 @@ bool SpaceBullet::test_body_motion(RigidBodyBullet *p_body, const Transform &p_f
 //}
 
 #if debug_test_motion
-				Vector3 sup_line2;
-				B_TO_G(recovered_motion, sup_line2);
-				//Vector3 sup_pos;
-				//B_TO_G( pt.getPositionWorldOnB(), sup_pos);
-				normalLine->clear();
-				normalLine->begin(Mesh::PRIMITIVE_LINES, NULL);
-				normalLine->add_vertex(r_result->collision_point);
-				normalLine->add_vertex(r_result->collision_point + r_result->collision_normal * 10);
-				normalLine->end();
+					Vector3 sup_line2;
+					B_TO_G(recovered_motion, sup_line2);
+					//Vector3 sup_pos;
+					//B_TO_G( pt.getPositionWorldOnB(), sup_pos);
+					normalLine->clear();
+					normalLine->begin(Mesh::PRIMITIVE_LINES, NULL);
+					normalLine->add_vertex(r_result->collisions[i].collision_point);
+					normalLine->add_vertex(r_result->collisions[i].collision_point + r_result->collisions[i].collision_normal * 10);
+					normalLine->end();
 #endif
-
+				}
 			} else {
 				r_result->remainder = Vector3();
 			}
@@ -1088,13 +1091,15 @@ bool SpaceBullet::RFP_convex_convex_test(const btConvexShape *p_shapeA, const bt
 		r_recover_position += result.m_normalOnBInWorld * (result.m_distance * -1);
 
 		if (r_recover_result) {
+			RecoveredCollision rec_col;
 
 			r_recover_result->hasPenetration = true;
-			r_recover_result->other_collision_object = p_objectB;
-			r_recover_result->other_compound_shape_index = p_shapeId_B;
-			r_recover_result->penetration_distance = result.m_distance;
-			r_recover_result->pointNormalWorld = result.m_normalOnBInWorld;
-			r_recover_result->pointWorld = result.m_pointInWorld;
+			rec_col.other_collision_object = p_objectB;
+			rec_col.other_compound_shape_index = p_shapeId_B;
+			rec_col.penetration_distance = result.m_distance;
+			rec_col.pointNormalWorld = result.m_normalOnBInWorld;
+			rec_col.pointWorld = result.m_pointInWorld;
+			r_recover_result->recovered_collisions.push_back(rec_col);
 		}
 		return true;
 	}
@@ -1124,13 +1129,15 @@ bool SpaceBullet::RFP_convex_world_test(const btConvexShape *p_shapeA, const btC
 			r_recover_position += contactPointResult.m_pointNormalWorld * (contactPointResult.m_penetration_distance * -1);
 
 			if (r_recover_result) {
+				RecoveredCollision rec_col;
 
 				r_recover_result->hasPenetration = true;
-				r_recover_result->other_collision_object = p_objectB;
-				r_recover_result->other_compound_shape_index = p_shapeId_B;
-				r_recover_result->penetration_distance = contactPointResult.m_penetration_distance;
-				r_recover_result->pointNormalWorld = contactPointResult.m_pointNormalWorld;
-				r_recover_result->pointWorld = contactPointResult.m_pointWorld;
+				rec_col.other_collision_object = p_objectB;
+				rec_col.other_compound_shape_index = p_shapeId_B;
+				rec_col.penetration_distance = contactPointResult.m_penetration_distance;
+				rec_col.pointNormalWorld = contactPointResult.m_pointNormalWorld;
+				rec_col.pointWorld = contactPointResult.m_pointWorld;
+				r_recover_result->recovered_collisions.push_back(rec_col);
 			}
 			return true;
 		}

--- a/modules/bullet/space_bullet.h
+++ b/modules/bullet/space_bullet.h
@@ -176,15 +176,18 @@ private:
 	void check_ghost_overlaps();
 	void check_body_collision();
 
-	struct RecoverResult {
-		bool hasPenetration;
+	struct RecoveredCollision {
 		btVector3 pointNormalWorld;
 		btVector3 pointWorld;
 		btScalar penetration_distance; // Negative is penetration
 		int other_compound_shape_index;
 		const btCollisionObject *other_collision_object;
-		int local_shape_most_recovered;
+	};
 
+	struct RecoverResult {
+		bool hasPenetration;
+		int local_shape_most_recovered;
+		Vector<RecoveredCollision> recovered_collisions;
 		RecoverResult()
 			: hasPenetration(false) {}
 	};

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -919,14 +919,14 @@ RigidBody::~RigidBody() {
 
 Ref<KinematicCollision> KinematicBody::_move(const Vector3 &p_motion) {
 
-	Collision col;
-	if (move_and_collide(p_motion, col)) {
+	Vector<Collision> cols;
+	if (move_and_collide(p_motion, cols)) {
 		if (motion_cache.is_null()) {
 			motion_cache.instance();
 			motion_cache->owner = this;
 		}
 
-		motion_cache->collision = col;
+		motion_cache->collision = cols[0]; // fix
 
 		return motion_cache;
 	}
@@ -934,22 +934,27 @@ Ref<KinematicCollision> KinematicBody::_move(const Vector3 &p_motion) {
 	return Ref<KinematicCollision>();
 }
 
-bool KinematicBody::move_and_collide(const Vector3 &p_motion, Collision &r_collision) {
+bool KinematicBody::move_and_collide(const Vector3 &p_motion, Vector<Collision> &r_collisions) {
 
 	Transform gt = get_global_transform();
 	PhysicsServer::MotionResult result;
 	bool colliding = PhysicsServer::get_singleton()->body_test_motion(get_rid(), gt, p_motion, &result);
 
 	if (colliding) {
-		r_collision.collider_metadata = result.collider_metadata;
-		r_collision.collider_shape = result.collider_shape;
-		r_collision.collider_vel = result.collider_velocity;
-		r_collision.collision = result.collision_point;
-		r_collision.normal = result.collision_normal;
-		r_collision.collider = result.collider_id;
-		r_collision.travel = result.motion;
-		r_collision.remainder = result.remainder;
-		r_collision.local_shape = result.collision_local_shape;
+		for (int i = 0; i < result.collisions.size(); ++i) {
+			Collision col;
+			col.collider_metadata = result.collisions[i].collider_metadata;
+			col.collider_shape = result.collisions[i].collider_shape;
+			col.collider_vel = result.collisions[i].collider_velocity;
+			col.collision = result.collisions[i].collision_point;
+			col.normal = result.collisions[i].collision_normal;
+			col.collider = result.collisions[i].collider_id;
+			col.travel = result.motion;
+			col.remainder = result.remainder;
+			col.local_shape = result.collisions[i].collision_local_shape;
+
+			r_collisions.push_back(col);
+		}
 	}
 
 	gt.origin += result.motion;
@@ -971,45 +976,45 @@ Vector3 KinematicBody::move_and_slide(const Vector3 &p_linear_velocity, const Ve
 
 	while (p_max_slides) {
 
-		Collision collision;
+		Vector<Collision> collisions; // multiple collisions
 
-		bool collided = move_and_collide(motion, collision);
+		bool collided = move_and_collide(motion, collisions);
 
 		if (collided) {
+			for (int i = 0; i < collisions.size(); ++i) {
+				motion = collisions[i].remainder;
 
-			motion = collision.remainder;
-
-			if (p_floor_direction == Vector3()) {
-				//all is a wall
-				on_wall = true;
-			} else {
-				if (collision.normal.dot(p_floor_direction) >= Math::cos(p_floor_max_angle)) { //floor
-
-					on_floor = true;
-					floor_velocity = collision.collider_vel;
-
-					Vector3 rel_v = lv - floor_velocity;
-					Vector3 hv = rel_v - p_floor_direction * p_floor_direction.dot(rel_v);
-
-					if (collision.travel.length() < 0.05 && hv.length() < p_slope_stop_min_velocity) {
-						Transform gt = get_global_transform();
-						gt.origin -= collision.travel;
-						set_global_transform(gt);
-						return floor_velocity - p_floor_direction * p_floor_direction.dot(floor_velocity);
-					}
-				} else if (collision.normal.dot(-p_floor_direction) >= Math::cos(p_floor_max_angle)) { //ceiling
-					on_ceiling = true;
-				} else {
+				if (p_floor_direction == Vector3()) {
+					//all is a wall
 					on_wall = true;
+				} else {
+					if (collisions[i].normal.dot(p_floor_direction) >= Math::cos(p_floor_max_angle)) { //floor
+
+						on_floor = true;
+						floor_velocity = collisions[i].collider_vel;
+
+						Vector3 rel_v = lv - floor_velocity;
+						Vector3 hv = rel_v - p_floor_direction * p_floor_direction.dot(rel_v);
+
+						if (collisions[i].travel.length() < 0.05 && hv.length() < p_slope_stop_min_velocity) {
+							Transform gt = get_global_transform();
+							gt.origin -= collisions[i].travel;
+							set_global_transform(gt);
+							return floor_velocity - p_floor_direction * p_floor_direction.dot(floor_velocity);
+						}
+					} else if (collisions[i].normal.dot(-p_floor_direction) >= Math::cos(p_floor_max_angle)) { //ceiling
+						on_ceiling = true;
+					} else {
+						on_wall = true;
+					}
 				}
+
+				Vector3 n = collisions[i].normal;
+				motion = motion.slide(n);
+				lv = lv.slide(n);
+
+				colliders.push_back(collisions[i]);
 			}
-
-			Vector3 n = collision.normal;
-			motion = motion.slide(n);
-			lv = lv.slide(n);
-
-			colliders.push_back(collision);
-
 		} else {
 			break;
 		}

--- a/scene/3d/physics_body.h
+++ b/scene/3d/physics_body.h
@@ -300,7 +300,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	bool move_and_collide(const Vector3 &p_motion, Collision &r_collision);
+	bool move_and_collide(const Vector3 &p_motion, Vector<Collision> &r_collisions);
 	bool test_move(const Transform &p_from, const Vector3 &p_motion);
 
 	void set_safe_margin(float p_margin);

--- a/servers/physics/space_sw.cpp
+++ b/servers/physics/space_sw.cpp
@@ -557,10 +557,6 @@ bool SpaceSW::test_body_motion(BodySW *p_body, const Transform &p_from, const Ve
 	//this took about a week to get right..
 	//but is it right? who knows at this point..
 
-	if (r_result) {
-		r_result->collider_id = 0;
-		r_result->collider_shape = 0;
-	}
 	AABB body_aabb;
 
 	for (int i = 0; i < p_body->get_shape_count(); i++) {
@@ -793,18 +789,22 @@ bool SpaceSW::test_body_motion(BodySW *p_body, const Transform &p_from, const Ve
 		if (rcd.best_len != 0) {
 
 			if (r_result) {
-				r_result->collider = rcd.best_object->get_self();
-				r_result->collider_id = rcd.best_object->get_instance_id();
-				r_result->collider_shape = rcd.best_shape;
-				r_result->collision_local_shape = best_shape;
-				r_result->collision_normal = rcd.best_normal;
-				r_result->collision_point = rcd.best_contact;
+				PhysicsServer::Collision col;
+
+				col.collider = rcd.best_object->get_self();
+				col.collider_id = rcd.best_object->get_instance_id();
+				col.collider_shape = rcd.best_shape;
+				col.collision_local_shape = best_shape;
+				col.collision_normal = rcd.best_normal;
+				col.collision_point = rcd.best_contact;
 				//r_result->collider_metadata = rcd.best_object->get_shape_metadata(rcd.best_shape);
 
 				const BodySW *body = static_cast<const BodySW *>(rcd.best_object);
 				//Vector3 rel_vec = r_result->collision_point - body->get_transform().get_origin();
 				//				r_result->collider_velocity = Vector3(-body->get_angular_velocity() * rel_vec.y, body->get_angular_velocity() * rel_vec.x) + body->get_linear_velocity();
-				r_result->collider_velocity = body->get_linear_velocity() + (body->get_angular_velocity()).cross(body->get_transform().origin - rcd.best_contact); // * mPos);
+				col.collider_velocity = body->get_linear_velocity() + (body->get_angular_velocity()).cross(body->get_transform().origin - rcd.best_contact); // * mPos);
+
+				r_result->collisions.push_back(col);
 
 				r_result->motion = safe * p_motion;
 				r_result->remainder = p_motion - safe * p_motion;

--- a/servers/physics_server.h
+++ b/servers/physics_server.h
@@ -470,11 +470,7 @@ public:
 	// this function only works on physics process, errors and returns null otherwise
 	virtual PhysicsDirectBodyState *body_get_direct_state(RID p_body) = 0;
 
-	struct MotionResult {
-
-		Vector3 motion;
-		Vector3 remainder;
-
+	struct Collision {
 		Vector3 collision_point;
 		Vector3 collision_normal;
 		Vector3 collider_velocity;
@@ -483,6 +479,14 @@ public:
 		RID collider;
 		int collider_shape;
 		Variant collider_metadata;
+	};
+
+	struct MotionResult {
+
+		Vector3 motion;
+		Vector3 remainder;
+
+		Vector<Collision> collisions;
 	};
 
 	virtual bool body_test_motion(RID p_body, const Transform &p_from, const Vector3 &p_motion, MotionResult *r_result = NULL) = 0;


### PR DESCRIPTION
_fixes #13210_

-----------------
Problem:
Because of move_and_collide return only one collision, KinematicBody
omits other collision informations. This cause, for example,
sometimes KinematicBody stucks near wall.

Fix:
Change move_and_collide to return multiple collisions.
Now returns all collisions. So, we can know KinematicBody
is on_wall and also on_floor.