### PR TITLE
Fixed #13167. Restored ParallaxLayer mirroring that was broken by pull request #12421

### DIFF
--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -73,7 +73,8 @@ void ParallaxLayer::_update_mirroring() {
 
 		RID c = pb->get_world_2d()->get_canvas();
 		RID ci = get_canvas_item();
-		VisualServer::get_singleton()->canvas_set_item_mirroring(c, ci, mirroring);
+		Point2 mirrorScale = mirroring * get_scale();
+		VisualServer::get_singleton()->canvas_set_item_mirroring(c, ci, mirrorScale);
 	}
 }
 
@@ -116,18 +117,21 @@ void ParallaxLayer::set_base_offset_and_scale(const Point2 &p_offset, float p_sc
 
 	Point2 new_ofs = (screen_offset + (p_offset - screen_offset) * motion_scale) + motion_offset * p_scale + orig_offset * p_scale;
 
-	Vector2 mirror = Vector2(1, 1);
-
 	if (mirroring.x) {
-		mirror.x = -1;
+		double den = mirroring.x * p_scale;
+		double before = new_ofs.x;
+		new_ofs.x -= den * ceil(new_ofs.x / den);
 	}
 
 	if (mirroring.y) {
-		mirror.y = -1;
+		double den = mirroring.y * p_scale;
+		new_ofs.y -= den * ceil(new_ofs.y / den);
 	}
 
 	set_position(new_ofs);
-	set_scale(mirror * p_scale * orig_scale);
+	set_scale(Vector2(1, 1) * p_scale * orig_scale);
+
+	_update_mirroring();
 }
 
 String ParallaxLayer::get_configuration_warning() const {


### PR DESCRIPTION
This fixes #13167, a regression caused by pull request #12421. Essentially it was for repeating scrolling parallax backgrounds, such as used in the Platform demo. I restored the original code, and made some tweaks to it so that it could better handle zoom (which it couldn't initially).

The Platform demo works fine now.