### PR TITLE
Fix displacement for centered tilemaps

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -565,20 +565,19 @@ void TileMapEditor::_draw_cell(int p_cell, const Point2i &p_point, bool p_flip_h
 		}
 
 	} else if (node->get_tile_origin() == TileMap::TILE_ORIGIN_CENTER) {
-		rect.position += node->get_cell_size() / 2;
-		Vector2 s = r.size;
+		Size2 cell_size = node->get_cell_size();
 
-		Vector2 center = (s / 2) - tile_ofs;
+		rect.position += tile_ofs;
 
 		if (p_flip_h)
-			rect.position.x -= s.x - center.x;
+			rect.position.x -= cell_size.x / 2;
 		else
-			rect.position.x -= center.x;
+			rect.position.x += cell_size.x / 2;
 
 		if (p_flip_v)
-			rect.position.y -= s.y - center.y;
+			rect.position.y -= cell_size.y / 2;
 		else
-			rect.position.y -= center.y;
+			rect.position.y += cell_size.y / 2;
 	}
 
 	rect.position = p_xform.xform(rect.position);

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -215,6 +215,9 @@ void TileMap::_fix_cell_transform(Transform2D &xform, const Cell &p_cell, const 
 
 	if (tile_origin == TILE_ORIGIN_BOTTOM_LEFT)
 		offset.y += cell_size.y;
+	else if (tile_origin == TILE_ORIGIN_CENTER) {
+		offset += cell_size / 2;
+	}
 
 	if (s.y > s.x) {
 		if ((p_cell.flip_h && (p_cell.flip_v || p_cell.transpose)) || (p_cell.flip_v && !p_cell.transpose))
@@ -235,6 +238,8 @@ void TileMap::_fix_cell_transform(Transform2D &xform, const Cell &p_cell, const 
 		xform.elements[1].x = -xform.elements[1].x;
 		if (tile_origin == TILE_ORIGIN_TOP_LEFT || tile_origin == TILE_ORIGIN_BOTTOM_LEFT)
 			offset.x = s.x - offset.x;
+		else if (tile_origin == TILE_ORIGIN_CENTER)
+			offset.x = s.x - offset.x / 2;
 	}
 	if (p_cell.flip_v) {
 		xform.elements[0].y = -xform.elements[0].y;
@@ -242,10 +247,9 @@ void TileMap::_fix_cell_transform(Transform2D &xform, const Cell &p_cell, const 
 		if (tile_origin == TILE_ORIGIN_TOP_LEFT)
 			offset.y = s.y - offset.y;
 		else if (tile_origin == TILE_ORIGIN_BOTTOM_LEFT) {
-			if (p_cell.transpose)
-				offset.y += s.y;
-			else
-				offset.y -= s.y;
+			offset.y += s.y;
+		} else if (tile_origin == TILE_ORIGIN_CENTER) {
+			offset.y += s.y;
 		}
 	}
 	xform.elements[2].x += offset.x;
@@ -429,20 +433,18 @@ void TileMap::_update_dirty_quadrants() {
 				}
 
 			} else if (tile_origin == TILE_ORIGIN_CENTER) {
-				rect.position += tcenter;
 
-				Vector2 center = (s / 2) - tile_ofs;
-				center_ofs = tcenter - (s / 2);
+				rect.position += tile_ofs;
 
 				if (c.flip_h)
-					rect.position.x -= s.x - center.x;
+					rect.position.x -= cell_size.x / 2;
 				else
-					rect.position.x -= center.x;
+					rect.position.x += cell_size.x / 2;
 
 				if (c.flip_v)
-					rect.position.y -= s.y - center.y;
+					rect.position.y -= cell_size.y / 2;
 				else
-					rect.position.y -= center.y;
+					rect.position.y += cell_size.y / 2;
 			}
 
 			Ref<Texture> normal_map = tile_set->tile_get_normal_map(c.id);


### PR DESCRIPTION
This PR fixes the issue mentioned in #3209, if I understand the problem correctly. I'd be glad to get feedback from people who have more experience with 2D editors whether the behavior with this PR is as intended.

Square cells seem to work the same for all three origin settings, including collision and navigation, no matter how they are transformed or flipped. The test project below contains a number of examples.

Non-square cells don't really work for anything but top-left origin when they are transformed or flipped, but neither do they in the current master. It's not even clear to me what the desired behavior for transformations of non-square cells should be. One way would be to emulate the current "top-left behavior" for all origins, although this does not seem desirable to me: Right now, if you flip a non-square cell horizontally, it does not stay within its bounds but is displaced to the left. I suppose this is done so that the "rotation" buttons (which just select a combination of transposition and h/v flipping) rotate tiles around the center point of the leftmost square (when the origin is top-left, obviously).

Centered isometric tiles also work if they are not transformed. How transforms affect them depends on their size relative to the cell size, and whether they use a region. Since isometric tiles generally don't look right when transformed I don't think this is a problem.

Like I said in IRC, this PR is just trying to fix the most prominent inconsistencies in the current tile map implementation with a minimal amount of changes. To address more of the issues with the tilemap editor, e.g., those mentioned in the discussion of #13062, it would make sense to clarify what the actual use cases are and how the individual features *should* interact. (And to refactor the code to implement them in a cleaner way).

Test project is at <https://gitlab.com/mhoelzl/TilemapTest>.

Fixes #3209