### PR TITLE
Fixed not be able to unfold the last line

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4536,7 +4536,7 @@ bool TextEdit::can_fold(int p_line) const {
 bool TextEdit::is_folded(int p_line) const {
 
 	ERR_FAIL_INDEX_V(p_line, text.size(), false);
-	if (p_line + 1 >= text.size() - 1)
+	if (p_line + 1 >= text.size())
 		return false;
 	if (!is_line_hidden(p_line) && is_line_hidden(p_line + 1))
 		return true;


### PR DESCRIPTION
Fixed not be able to unfold the last line.

Given the following script, it would be possible to fold but not unfold.

```
func i_cant_be_unfolded():
    pass
```