### PR TITLE
Tweak editor help font sizes for better readability

### DIFF
--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -134,9 +134,9 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	//Ref<BitmapFont> doc_title_font = make_font(_bi_font_doc_title_font_height,_bi_font_doc_title_font_ascent,0,_bi_font_doc_title_font_charcount,_bi_font_doc_title_font_characters,p_theme->get_icon("DocTitleFont","EditorIcons"));
 	//Ref<BitmapFont> doc_code_font = make_font(_bi_font_doc_code_font_height,_bi_font_doc_code_font_ascent,0,_bi_font_doc_code_font_charcount,_bi_font_doc_code_font_characters,p_theme->get_icon("DocCodeFont","EditorIcons"));
 
-	MAKE_DEFAULT_FONT(df_doc_title, int(EDITOR_DEF("text_editor/help/help_title_font_size", 16)) * EDSCALE);
+	MAKE_DEFAULT_FONT(df_doc_title, int(EDITOR_DEF("text_editor/help/help_title_font_size", 23)) * EDSCALE);
 
-	MAKE_DEFAULT_FONT(df_doc, int(EDITOR_DEF("text_editor/help/help_font_size", 14)) * EDSCALE);
+	MAKE_DEFAULT_FONT(df_doc, int(EDITOR_DEF("text_editor/help/help_font_size", 15)) * EDSCALE);
 
 	p_theme->set_font("doc", "EditorFonts", df_doc);
 	p_theme->set_font("doc_title", "EditorFonts", df_doc_title);
@@ -154,7 +154,7 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 
 	Ref<DynamicFont> df_doc_code;
 	df_doc_code.instance();
-	df_doc_code->set_size(int(EDITOR_DEF("text_editor/help/help_source_font_size", 16)) * EDSCALE);
+	df_doc_code->set_size(int(EDITOR_DEF("text_editor/help/help_source_font_size", 14)) * EDSCALE);
 	df_doc_code->set_spacing(DynamicFont::SPACING_TOP, -EDSCALE);
 	df_doc_code->set_spacing(DynamicFont::SPACING_BOTTOM, -EDSCALE);
 	df_doc_code->set_font_data(dfmono);


### PR DESCRIPTION
The "normal" font size is now consistent with the source font size. Titles are also larger now.

See the screenshots below for examples of how it looks:

![tweaked_editor_help_1](https://user-images.githubusercontent.com/180032/33189874-63e32780-d0a7-11e7-985c-966899e9fa3f.png)

![tweaked_editor_help_2](https://user-images.githubusercontent.com/180032/33189873-63c72094-d0a7-11e7-9ec1-a330f30d778a.png)

**Edit:** The source font size has been made slightly smaller, see [here](https://github.com/godotengine/godot/pull/13222#issuecomment-346883440) for an updated screenshot.
