### PR TITLE
Fix read bug in compressed bone weights

### DIFF
--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1347,7 +1347,7 @@ Array VisualServer::_get_array_from_surface(uint32_t p_format, PoolVector<uint8_
 
 						const uint16_t *v = (const uint16_t *)&r[j * total_elem_size + offsets[i]];
 						for (int k = 0; k < 4; k++) {
-							w[j * 4 + k] = float(v[k] / 65535.0) * 2.0 - 1.0;
+							w[j * 4 + k] = float(v[k] / 65535.0);
 						}
 					}
 				} else {


### PR DESCRIPTION
Fixes #13081 (thank you @gad-o and @bojidar-bg) when reading compressed bone weights. 

Tested using the example from issue and `platformer` demo. 