### PR TITLE
3.0 - Fix context menu of first node in a new scene

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1358,7 +1358,7 @@ void SceneTreeDock::_create() {
 
 		editor_data->get_undo_redo().commit_action();
 		editor->push_item(c);
-
+		editor_selection->clear();
 		if (Object::cast_to<Control>(c)) {
 			//make editor more comfortable, so some controls don't appear super shrunk
 			Control *ct = Object::cast_to<Control>(c);


### PR DESCRIPTION
Fix #13198 
