### PR TITLE
Add 'uppercase' and 'lowercase' to script editor

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1168,6 +1168,16 @@ void ScriptEditor::_menu_option(int p_option) {
 				current->get_text_edit()->cut();
 				current->get_text_edit()->call_deferred("grab_focus");
 			} break;
+			case EDIT_UPPERCASE: {
+
+				current->get_text_edit()->convert_case(current->get_text_edit()->UPPERCASE);
+				current->get_text_edit()->call_deferred("grab_focus");
+			} break;
+			case EDIT_LOWERCASE: {
+
+				current->get_text_edit()->convert_case(current->get_text_edit()->LOWERCASE);
+				current->get_text_edit()->call_deferred("grab_focus");
+			} break;
 			case EDIT_COPY: {
 				current->get_text_edit()->copy();
 				current->get_text_edit()->call_deferred("grab_focus");
@@ -2768,6 +2778,9 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	edit_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/paste", TTR("Paste"), KEY_MASK_CMD | KEY_V), EDIT_PASTE);
 	edit_menu->get_popup()->add_separator();
 	edit_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/select_all", TTR("Select All"), KEY_MASK_CMD | KEY_A), EDIT_SELECT_ALL);
+	edit_menu->get_popup()->add_separator();
+	edit_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/convert_to_uppercase", TTR("Convert to UpperCase")), EDIT_UPPERCASE);
+	edit_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/convert_to_lowercase", TTR("Convert to LowerCase")), EDIT_LOWERCASE);
 	edit_menu->get_popup()->add_separator();
 	edit_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/move_up", TTR("Move Up"), KEY_MASK_ALT | KEY_UP), EDIT_MOVE_LINE_UP);
 	edit_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/move_down", TTR("Move Down"), KEY_MASK_ALT | KEY_DOWN), EDIT_MOVE_LINE_DOWN);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -125,6 +125,8 @@ class ScriptEditor : public VBoxContainer {
 		EDIT_COPY,
 		EDIT_PASTE,
 		EDIT_SELECT_ALL,
+		EDIT_UPPERCASE,
+		EDIT_LOWERCASE,
 		EDIT_COMPLETE,
 		EDIT_AUTO_INDENT,
 		EDIT_TRIM_TRAILING_WHITESAPCE,
@@ -288,7 +290,7 @@ class ScriptEditor : public VBoxContainer {
 
 	void _script_selected(int p_idx);
 
-	void _script_rmb_selected(int p_idx, const Vector2 & p_pos);
+	void _script_rmb_selected(int p_idx, const Vector2 &p_pos);
 
 	void _find_scripts(Node *p_base, Node *p_current, Set<Ref<Script> > &used);
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3370,6 +3370,21 @@ void TextEdit::cut() {
 	}
 }
 
+void TextEdit::convert_case(int p_case) {
+	if (selection.active) {
+		String text = _base_get_text(selection.from_line, selection.from_column, selection.to_line, selection.to_column);
+		selection.active = false;
+		_remove_text(selection.from_line, selection.from_column, selection.to_line, selection.to_column);
+		cursor_set_line(selection.from_line);
+		cursor_set_column(selection.from_column);
+		if (p_case == UPPERCASE) {
+			_insert_text_at_cursor(text.to_upper());
+		} else if (p_case == LOWERCASE) {
+			_insert_text_at_cursor(text.to_lower());
+		}
+	}
+}
+
 void TextEdit::copy() {
 
 	if (!selection.active) {
@@ -4312,6 +4327,16 @@ void TextEdit::menu_option(int p_option) {
 				clear();
 			}
 		} break;
+		case MENU_UPPERCASE: {
+			if (!readonly) {
+				convert_case(UPPERCASE);
+			}
+		} break;
+		case MENU_LOWERCASE: {
+			if (!readonly) {
+				convert_case(LOWERCASE);
+			}
+		} break;
 		case MENU_SELECT_ALL: {
 			select_all();
 		} break;
@@ -4372,6 +4397,7 @@ void TextEdit::_bind_methods() {
 	ObjectTypeDB::bind_method(_MD("paste"), &TextEdit::paste);
 	ObjectTypeDB::bind_method(_MD("select_all"), &TextEdit::select_all);
 	ObjectTypeDB::bind_method(_MD("select", "from_line", "from_column", "to_line", "to_column"), &TextEdit::select);
+	ObjectTypeDB::bind_method(_MD("convert_case", "case"), &TextEdit::convert_case);
 
 	ObjectTypeDB::bind_method(_MD("is_selection_active"), &TextEdit::is_selection_active);
 	ObjectTypeDB::bind_method(_MD("get_selection_from_line"), &TextEdit::get_selection_from_line);
@@ -4547,6 +4573,9 @@ TextEdit::TextEdit() {
 	menu->add_separator();
 	menu->add_item(TTR("Select All"), MENU_SELECT_ALL, KEY_MASK_CMD | KEY_A);
 	menu->add_item(TTR("Clear"), MENU_CLEAR);
+	menu->add_separator();
+	menu->add_item(TTR("UpperCase"), MENU_UPPERCASE);
+	menu->add_item(TTR("LowerCase"), MENU_LOWERCASE);
 	menu->add_separator();
 	menu->add_item(TTR("Undo"), MENU_UNDO, KEY_MASK_CMD | KEY_Z);
 	menu->connect("item_pressed", this, "menu_option");

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -346,12 +346,16 @@ public:
 		MENU_COPY,
 		MENU_PASTE,
 		MENU_CLEAR,
+		MENU_UPPERCASE,
+		MENU_LOWERCASE,
 		MENU_SELECT_ALL,
 		MENU_UNDO,
 		MENU_MAX
-
 	};
-
+	enum Case {
+		UPPERCASE,
+		LOWERCASE
+	};
 	enum SearchFlags {
 
 		SEARCH_MATCH_CASE = 1,
@@ -428,6 +432,7 @@ public:
 	bool is_syntax_coloring_enabled() const;
 
 	void cut();
+	void convert_case(int p_case);
 	void copy();
 	void paste();
 	void select_all();


### PR DESCRIPTION
Easy to convert case in 2.1.
like 3.0.
![test](https://user-images.githubusercontent.com/24988459/33749716-41e3ca7c-dc0a-11e7-9a31-19c93fb2a5f0.gif)
