### PR TITLE
Inspector: Implemented a collapse/expand all (v2)

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1392,6 +1392,14 @@ void EditorNode::_property_editor_back() {
 		_edit_current();
 }
 
+void EditorNode::_menu_collapseall() {
+	property_editor->collapse_all_parent_nodes();
+}
+
+void EditorNode::_menu_expandall() {
+	property_editor->expand_all_parent_nodes();
+}
+
 void EditorNode::_save_default_environment() {
 
 	Ref<Environment> fallback = get_tree()->get_root()->get_world()->get_fallback_environment();
@@ -1466,6 +1474,7 @@ void EditorNode::_edit_current() {
 	object_menu->set_disabled(true);
 
 	bool capitalize = bool(EDITOR_DEF("interface/editor/capitalize_properties", true));
+	bool expandall = bool(EDITOR_DEF("interface/editor/expand_all_properties", true));
 	bool is_resource = current_obj->is_class("Resource");
 	bool is_node = current_obj->is_class("Node");
 	resource_save_button->set_disabled(!is_resource);
@@ -1537,6 +1546,10 @@ void EditorNode::_edit_current() {
 		property_editor->set_enable_capitalize_paths(capitalize);
 	}
 
+	if (property_editor->is_expand_all_properties_enabled() != expandall) {
+		property_editor->set_use_folding(expandall == false);
+	}
+
 	/* Take care of PLUGIN EDITOR */
 
 	EditorPlugin *main_plugin = editor_data.get_editor(current_obj);
@@ -1596,6 +1609,9 @@ void EditorNode::_edit_current() {
 	PopupMenu *p = object_menu->get_popup();
 
 	p->clear();
+	p->add_shortcut(ED_SHORTCUT("property_editor/expand_all", TTR("Expand all properties")), EXPAND_ALL);
+	p->add_shortcut(ED_SHORTCUT("property_editor/collapse_all", TTR("Collapse all properties")), COLLAPSE_ALL);
+	p->add_separator();
 	p->add_shortcut(ED_SHORTCUT("property_editor/copy_params", TTR("Copy Params")), OBJECT_COPY_PARAMS);
 	p->add_shortcut(ED_SHORTCUT("property_editor/paste_params", TTR("Paste Params")), OBJECT_PASTE_PARAMS);
 	p->add_separator();
@@ -2224,6 +2240,14 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 			_set_editing_top_editors(NULL);
 			_set_editing_top_editors(current);
+
+		} break;
+		case COLLAPSE_ALL: {
+			_menu_collapseall();
+
+		} break;
+		case EXPAND_ALL: {
+			_menu_expandall();
 
 		} break;
 		case RUN_PLAY: {
@@ -5376,11 +5400,11 @@ EditorNode::EditorNode() {
 	property_editor = memnew(PropertyEditor);
 	property_editor->set_autoclear(true);
 	property_editor->set_show_categories(true);
-	property_editor->set_use_folding(true);
 	property_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	property_editor->set_use_doc_hints(true);
 	property_editor->set_hide_script(false);
 	property_editor->set_enable_capitalize_paths(bool(EDITOR_DEF("interface/editor/capitalize_properties", true)));
+	property_editor->set_use_folding(bool(EDITOR_DEF("interface/editor/expand_all_properties", false)) == false);
 
 	property_editor->hide_top_label();
 	property_editor->register_text_enter(search_box);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -153,6 +153,9 @@ private:
 		OBJECT_REQUEST_HELP,
 		RUN_PLAY,
 
+		COLLAPSE_ALL,
+		EXPAND_ALL,
+
 		RUN_STOP,
 		RUN_PLAY_SCENE,
 		RUN_PLAY_NATIVE,
@@ -425,6 +428,9 @@ private:
 
 	void _property_editor_forward();
 	void _property_editor_back();
+
+	void _menu_collapseall();
+	void _menu_expandall();
 
 	void _select_history(int p_idx);
 	void _prepare_history();

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -2668,7 +2668,12 @@ TreeItem *PropertyEditor::get_parent_node(String p_path, HashMap<String, TreeIte
 		if (use_folding) {
 			if (!obj->editor_is_section_unfolded(p_path)) {
 				updating_folding = true;
-				item->set_collapsed(true);
+				if (folding_behaviour == FB_COLLAPSEALL)
+					item->set_collapsed(true);
+				else if (folding_behaviour == FB_EXPANDALL)
+					item->set_collapsed(false);
+				else
+					item->set_collapsed(true);
 				updating_folding = false;
 			}
 			item->set_metadata(0, p_path);
@@ -4207,10 +4212,29 @@ void PropertyEditor::set_subsection_selectable(bool p_selectable) {
 	update_tree();
 }
 
+bool PropertyEditor::is_expand_all_properties_enabled() const {
+
+	return (use_folding == false);
+}
+
 void PropertyEditor::set_use_folding(bool p_enable) {
 
 	use_folding = p_enable;
 	tree->set_hide_folding(false);
+}
+
+void PropertyEditor::collapse_all_parent_nodes() {
+
+	folding_behaviour = FB_COLLAPSEALL;
+	update_tree();
+	folding_behaviour = FB_UNDEFINED;
+}
+
+void PropertyEditor::expand_all_parent_nodes() {
+
+	folding_behaviour = FB_EXPANDALL;
+	update_tree();
+	folding_behaviour = FB_UNDEFINED;
 }
 
 PropertyEditor::PropertyEditor() {
@@ -4285,6 +4309,7 @@ PropertyEditor::PropertyEditor() {
 	subsection_selectable = false;
 	property_selectable = false;
 	show_type_icons = false; // maybe one day will return.
+	folding_behaviour = FB_UNDEFINED;
 }
 
 PropertyEditor::~PropertyEditor() {

--- a/editor/property_editor.h
+++ b/editor/property_editor.h
@@ -1,4 +1,4 @@
-﻿/*************************************************************************/
+/*************************************************************************/
 /*  property_editor.h                                                    */
 /*************************************************************************/
 /*                       This file is part of:                           */
@@ -206,6 +206,14 @@ class PropertyEditor : public Control {
 
 	bool updating_folding;
 
+	enum FOLDING_BEHAVIOUR {
+		FB_UNDEFINED,
+		FB_COLLAPSEALL,
+		FB_EXPANDALL,
+		FB_EXPANDALL_FORCE
+	};
+	FOLDING_BEHAVIOUR folding_behaviour;
+
 	HashMap<String, String> pending;
 	String selected_property;
 
@@ -304,6 +312,11 @@ public:
 	void set_property_selectable(bool p_selectable);
 
 	void set_use_folding(bool p_enable);
+
+	bool is_expand_all_properties_enabled() const;
+
+	void collapse_all_parent_nodes();
+	void expand_all_parent_nodes();
 	PropertyEditor();
 	~PropertyEditor();
 };


### PR DESCRIPTION
Implemented a collapse all / expand all feature request (fixes #9427) via "object properties" button popup menu + added option in Editor Settings, taking into account notes from Reduz discussed in #13158 .

This is how it works in action: https://i.imgur.com/8LO302l.gifv