### PR TITLE
Add reserved words to GDScript auto-completions

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1497,11 +1497,15 @@ static void _find_identifiers(GDScriptCompletionContext &context, int p_line, bo
 		clss = clss->owner;
 	}
 
-	for (int i = 0; i < GDScriptFunctions::FUNC_MAX; i++) {
+	// language reserved words such as if, while, func, pass and built-in functions
+	List<String> reserved_words;
+	GDScriptLanguage::get_singleton()->get_reserved_words(&reserved_words);
 
-		result.insert(GDScriptFunctions::get_func_name(GDScriptFunctions::Function(i)));
+	for (const List<String>::Element *E = reserved_words.front(); E; E = E->next()) {
+		result.insert(E->get());
 	}
 
+	// other built-in types
 	static const char *_type_names[Variant::VARIANT_MAX] = {
 		"null", "bool", "int", "float", "String", "Vector2", "Rect2", "Vector3", "Transform2D", "Plane", "Quat", "AABB", "Basis", "Transform",
 		"Color", "NodePath", "RID", "Object", "Dictionary", "Array", "PoolByteArray", "PoolIntArray", "PoolRealArray", "PoolStringArray",
@@ -1516,7 +1520,7 @@ static void _find_identifiers(GDScriptCompletionContext &context, int p_line, bo
 	List<PropertyInfo> props;
 	ProjectSettings::get_singleton()->get_property_list(&props);
 
-	for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
+	for (const List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
 
 		String s = E->get().name;
 		if (!s.begins_with("autoload/"))


### PR DESCRIPTION
This commit fixes issue #6445 as proposed, but there are still changes that can be discussed. Quoting myself from the issue thread:

> I'm not sure if I should keep it like this, as it's already functional, or if I should improve ranking (to prefer similar letter casing so that constants don't pop up when typing a keyword or identifier), and only add specific keywords into the completion code (which I'm afraid may cause the completion engine to go out of sync with the language if any keywords are added or removed).