### PR TITLE
A few adjustments to file/dir open dialogs

### DIFF
--- a/editor/editor_file_dialog.h
+++ b/editor/editor_file_dialog.h
@@ -143,6 +143,7 @@ private:
 	void _recent_selected(int p_idx);
 
 	void _item_selected(int p_item);
+	void _items_clear_selection();
 	void _item_dc_selected(int p_item);
 
 	void _select_drive(int p_idx);
@@ -171,6 +172,8 @@ private:
 	void _request_single_thumbnail(const String &p_path);
 
 	void _unhandled_input(const Ref<InputEvent> &p_event);
+
+	bool _is_open_should_be_disabled();
 
 protected:
 	void _notification(int p_what);

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -85,6 +85,10 @@ void FileDialog::_unhandled_input(const Ref<InputEvent> &p_event) {
 
 					invalidate();
 				} break;
+				case KEY_BACKSPACE: {
+
+					_dir_entered("..");
+				} break;
 				default: { handled = false; }
 			}
 
@@ -189,7 +193,7 @@ void FileDialog::_action_pressed() {
 		TreeItem *item = tree->get_selected();
 		if (item) {
 			Dictionary d = item->get_metadata(0);
-			if (d["dir"]) {
+			if (d["dir"] && d["name"] != "..") {
 				path = path.plus_file(d["name"]);
 			}
 		}
@@ -272,6 +276,26 @@ void FileDialog::_cancel_pressed() {
 	hide();
 }
 
+bool FileDialog::_is_open_should_be_disabled() {
+
+	if (mode == MODE_OPEN_ANY || mode == MODE_SAVE_FILE)
+		return false;
+
+	TreeItem *ti = tree->get_selected();
+	// We have something that we can't select?
+	if (!ti)
+		return true;
+
+	Dictionary d = ti->get_metadata(0);
+
+	// Opening a file, but selected a folder? Forbidden.
+	if (((mode == MODE_OPEN_FILE || mode == MODE_OPEN_FILES) && d["dir"]) || // Flipped case, also forbidden.
+			(mode == MODE_OPEN_DIR && !d["dir"]))
+		return true;
+
+	return false;
+}
+
 void FileDialog::_tree_selected() {
 
 	TreeItem *ti = tree->get_selected();
@@ -283,6 +307,8 @@ void FileDialog::_tree_selected() {
 
 		file->set_text(d["name"]);
 	}
+
+	get_ok()->set_disabled(_is_open_should_be_disabled());
 }
 
 void FileDialog::_tree_dc_selected() {
@@ -563,7 +589,7 @@ void FileDialog::set_mode(Mode p_mode) {
 			makedir->hide();
 			break;
 		case MODE_OPEN_DIR:
-			get_ok()->set_text(RTR("Open"));
+			get_ok()->set_text(RTR("Select Current Folder"));
 			set_title(RTR("Open a Directory"));
 			makedir->show();
 			break;

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -33,7 +33,6 @@
 #include "box_container.h"
 #include "os/dir_access.h"
 #include "scene/gui/dialogs.h"
-#include "scene/gui/dialogs.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/tool_button.h"
@@ -116,6 +115,8 @@ private:
 	void _update_drives();
 
 	void _unhandled_input(const Ref<InputEvent> &p_event);
+
+	bool _is_open_should_be_disabled();
 
 	virtual void _post_popup();
 


### PR DESCRIPTION
a) Added Backspace key support for Tree-based file dialog.
b) Fixed issue inability to select a folder in project manager (always previous folder was selected instead). Video: https://i.imgur.com/iQe8XAN.gifv (#13242, #13203)
c) Open Directory mode: changed "Open" to "Select Current Folder"
d) Block "Open" button when inappropriate content is selected (for example, file when in open folder mode, or folder when in open files mode)
e) List-based file dialog now support item deselecting (when you click on empty space). Video: https://i.imgur.com/i90oId9.gifv

P.S. Require PR #13245 to function/compile - for d) & e)

Fixes #13203.