### PR TITLE
Remove contrived JavaScript.eval() return types 

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -68,7 +68,7 @@ name is available.
     Juan Linietsky (reduz)
     Julian Murgia (StraToN)
     Kostadin Damyanov (Max-Might)
-    L. Krause (eska014)
+    Leon Krause (eska014)
     Marc Gilleron (Zylann)
     Marcelo Fernandez (marcelofg55)
     Mariano Javier Suligoy (MarianoGnu)


### PR DESCRIPTION
Specifically, remove the `Vector2`, `Vector3`, `Rect2` and `Color` return types, I haven't found any valid use case for these.

Also update `AUTHORS.md` to contain my full name.