### PR TITLE
[GDNative] disable -fPIC flag with msvc compiler

### DIFF
--- a/modules/gdnative/SCsub
+++ b/modules/gdnative/SCsub
@@ -245,7 +245,7 @@ if ARGUMENTS.get('gdnative_wrapper', False):
     gd_wrapper_env = env.Clone()
     gd_wrapper_env.Append(CPPPATH=['#modules/gdnative/include/'])
 
-    # I think this doesn't work on MSVC yet...
-    gd_wrapper_env.Append(CCFLAGS=['-fPIC'])
+    if not env.msvc:
+        gd_wrapper_env.Append(CCFLAGS=['-fPIC'])
 
     gd_wrapper_env.Library("#bin/gdnative_wrapper_code", [gensource])


### PR DESCRIPTION
Compilation with msvc seems to work [without this](https://ci.appveyor.com/project/GodotBuilder/godot-builds/build/1.0.230/job/tl2rfhaj5wgiypsu#L63), but warning are not nice