### PR TITLE
Tweak the default editor camera settings

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -370,8 +370,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("editors/3d/grid_color", Color::html("808080"));
 	hints["editors/3d/grid_color"] = PropertyInfo(Variant::COLOR, "editors/3d/grid_color", PROPERTY_HINT_COLOR_NO_ALPHA, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 
-	_initial_set("editors/3d/default_fov", 55.0);
-	_initial_set("editors/3d/default_z_near", 0.1);
+	_initial_set("editors/3d/default_fov", 70.0);
+	_initial_set("editors/3d/default_z_near", 0.05);
 	_initial_set("editors/3d/default_z_far", 500.0);
 
 	// navigation

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -4828,8 +4828,8 @@ void SpatialEditor::_bind_methods() {
 
 void SpatialEditor::clear() {
 
-	settings_fov->set_value(EDITOR_DEF("editors/3d/default_fov", 55.0));
-	settings_znear->set_value(EDITOR_DEF("editors/3d/default_z_near", 0.1));
+	settings_fov->set_value(EDITOR_DEF("editors/3d/default_fov", 70.0));
+	settings_znear->set_value(EDITOR_DEF("editors/3d/default_z_near", 0.05));
 	settings_zfar->set_value(EDITOR_DEF("editors/3d/default_z_far", 1500.0));
 
 	for (uint32_t i = 0; i < VIEWPORTS_COUNT; i++) {
@@ -5072,14 +5072,14 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	settings_fov->set_max(MAX_FOV);
 	settings_fov->set_min(MIN_FOV);
 	settings_fov->set_step(0.01);
-	settings_fov->set_value(EDITOR_DEF("editors/3d/default_fov", 55.0));
+	settings_fov->set_value(EDITOR_DEF("editors/3d/default_fov", 70.0));
 	settings_vbc->add_margin_child(TTR("Perspective FOV (deg.):"), settings_fov);
 
 	settings_znear = memnew(SpinBox);
 	settings_znear->set_max(MAX_Z);
 	settings_znear->set_min(MIN_Z);
 	settings_znear->set_step(0.01);
-	settings_znear->set_value(EDITOR_DEF("editors/3d/default_z_near", 0.1));
+	settings_znear->set_value(EDITOR_DEF("editors/3d/default_z_near", 0.05));
 	settings_vbc->add_margin_child(TTR("View Z-Near:"), settings_znear);
 
 	settings_zfar = memnew(SpinBox);


### PR DESCRIPTION
- The default FOV is now 70 (instead of 55).
- The default Z-near plane is now at 0.05 meters (from 0.1 meters).

Preview:

![higher_fov_distraction_free](https://user-images.githubusercontent.com/180032/33235275-22411000-d235-11e7-9ede-8a9480360d6f.png)
![higher_fov_normal](https://user-images.githubusercontent.com/180032/33235276-2268c762-d235-11e7-84fc-dccdf6a99dd4.png)

I hope I changed all the required values this time, I missed some of them last time 😄