### PR TITLE
Tweak the default camera node settings

### DIFF
--- a/scene/3d/camera.cpp
+++ b/scene/3d/camera.cpp
@@ -649,7 +649,7 @@ Camera::Camera() {
 	current = false;
 	force_change = false;
 	mode = PROJECTION_PERSPECTIVE;
-	set_perspective(65.0, 0.1, 100.0);
+	set_perspective(70.0, 0.05, 100.0);
 	keep_aspect = KEEP_HEIGHT;
 	layers = 0xfffff;
 	v_offset = 0;

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -120,9 +120,9 @@ public:
 		Camera() {
 
 			visible_layers = 0xFFFFFFFF;
-			fov = 65;
+			fov = 70;
 			type = PERSPECTIVE;
-			znear = 0.1;
+			znear = 0.05;
 			zfar = 100;
 			size = 1.0;
 			vaspect = false;


### PR DESCRIPTION
This is like https://github.com/godotengine/godot/pull/13293, but for Camera nodes (which are used in games). Existing Camera nodes are probably not affected by this change.

- Increase FOV to 70
- Put the Z-near plane at 0.05 meters