### PR TITLE
Enable SCons shared cache for AppVeyor CI (2.1)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,13 +1,18 @@
 os: Visual Studio 2015
 
 environment:
+  HOME: "%HOMEDRIVE%%HOMEPATH%"
   PYTHON: C:\Python27
+  SCONS_CACHE: "%HOME%\\scons_cache"
   matrix:
     - VS: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
       GD_PLATFORM: windows
       TOOLS: yes
       TARGET: release_debug
       ARCH: amd64
+
+cache:
+  - "%SCONS_CACHE%"
 
 install:
   - SET "PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"

--- a/SConstruct
+++ b/SConstruct
@@ -394,6 +394,11 @@ if selected_platform in platform_list:
     if (env['verbose'] == 'no'):
         methods.no_verbose(sys, env)
 
+    scons_cache_path = os.environ.get("SCONS_CACHE")
+    if scons_cache_path != None:
+        CacheDir(scons_cache_path)
+        print("Scons cache enabled... (path: '" + scons_cache_path + "')")
+
     Export('env')
 
     # build subdirs, the build order is dependent on link order.


### PR DESCRIPTION
Enable [SCons shared cache](http://scons.org/doc/2.0.1/HTML/scons-user/c4213.html) for Appveyor CI
