### PR TITLE
Travis: Use separate SCons caches for each build job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ sudo: false
 
 env:
   global:
-    - SCONS_CACHE=$HOME/.scons_cache
+    - SCONS_CACHE_ROOT=$HOME/.scons_cache
 
 cache:
   directories:
-    - $SCONS_CACHE
+    - $SCONS_CACHE_ROOT
 
 matrix:
   include:
@@ -88,5 +88,6 @@ script:
   - if [ "$STATIC_CHECKS" = "yes" ]; then
       sh ./misc/travis/clang-format.sh;
     else
+      export SCONS_CACHE=$SCONS_CACHE_ROOT/${GODOT_TARGET}-${CXX}-tools_${TOOLS}/;
       scons -j2 CC=$CC CXX=$CXX platform=$GODOT_TARGET TOOLS=$TOOLS verbose=yes progress=no;
     fi


### PR DESCRIPTION
We've started to have some Android builds failing today, which I think might be related to #13301.
https://travis-ci.org/godotengine/godot/jobs/307581286

Let's try to keep the cache for each platform/tools combination separate to avoid issues between compiled and generated files.