### PR TITLE
Enable pruning for SCons shared cache (master)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,6 +4,7 @@ environment:
   HOME: "%HOMEDRIVE%%HOMEPATH%"
   PYTHON: C:\Python27
   SCONS_CACHE: "%HOME%\\scons_cache"
+  SCONS_CACHE_LIMIT: 128
   matrix:
     - VS: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
       GD_PLATFORM: windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,12 @@ sudo: false
 
 env:
   global:
-    - SCONS_CACHE_ROOT=$HOME/.scons_cache
+    - SCONS_CACHE=$HOME/.scons_cache
+    - SCONS_CACHE_LIMIT=128
 
 cache:
   directories:
-    - $SCONS_CACHE_ROOT
+    - $SCONS_CACHE
 
 matrix:
   include:
@@ -88,6 +89,5 @@ script:
   - if [ "$STATIC_CHECKS" = "yes" ]; then
       sh ./misc/travis/clang-format.sh;
     else
-      export SCONS_CACHE=$SCONS_CACHE_ROOT/${GODOT_TARGET}-${CXX}-tools_${TOOLS}/;
       scons -j2 CC=$CC CXX=$CXX platform=$GODOT_TARGET TOOLS=$TOOLS verbose=yes progress=no;
     fi


### PR DESCRIPTION
This will prune SCons shared cache to the value specified by **SCONS_CACHE_LIMIT** in the environment variables, the default maximum size is 1024MB if **SCONS_CACHE_LIMIT** is not specified. Its current value is 512MB as set in **.travis.yml** and **.appveyor.yml**

Travis already uses separate caches for each job as specified [here](https://docs.travis-ci.com/user/caching/#Caches-and-build-matrices), the problem was that the cache will grow indefinitely if not prune as specified [here](https://github.com/garyo/scons-wiki/wiki/LimitCacheSizeWithProgress).

I still haven't reached the disk quote limit in my fork, so I've been testing the changes locally to see if the size surpasses the limit, and it does it by a few MBs before it's pruned back to the cap limit.

Cheers!
