### PR TITLE
Focus on sprite animation list after adding a new one to allow renaming with f2

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -394,6 +394,7 @@ void SpriteFramesEditor::_animation_add() {
 	edited_anim = name;
 
 	undo_redo->commit_action();
+	animations->grab_focus();
 }
 void SpriteFramesEditor::_animation_remove() {
 


### PR DESCRIPTION
After adding a new sprite animation, focus on the sprite animation list
to allow renaming the animation by pressing f2 instead of having to click on
the sprite name again.