### PR TITLE
Added interpolation qualifiers to shaderlang

### DIFF
--- a/drivers/gles3/shader_compiler_gles3.cpp
+++ b/drivers/gles3/shader_compiler_gles3.cpp
@@ -81,6 +81,16 @@ static int _get_datatype_size(SL::DataType p_type) {
 	ERR_FAIL_V(0);
 }
 
+static String _interpstr(SL::DataInterpolation p_interp) {
+
+	switch (p_interp) {
+		case SL::INTERPOLATION_FLAT: return "flat ";
+		case SL::INTERPOLATION_NO_PERSPECTIVE: return "noperspective ";
+		case SL::INTERPOLATION_SMOOTH: return "smooth ";
+	}
+	return "";
+}
+
 static String _prestr(SL::DataPrecision p_pres) {
 
 	switch (p_pres) {
@@ -383,12 +393,13 @@ String ShaderCompilerGLES3::_dump_node_code(SL::Node *p_node, int p_level, Gener
 			for (Map<StringName, SL::ShaderNode::Varying>::Element *E = pnode->varyings.front(); E; E = E->next()) {
 
 				String vcode;
+				String interp_mode = _interpstr(E->get().interpolation);
 				vcode += _prestr(E->get().precission);
 				vcode += _typestr(E->get().type);
 				vcode += " " + _mkid(E->key());
 				vcode += ";\n";
-				r_gen_code.vertex_global += "out " + vcode;
-				r_gen_code.fragment_global += "in " + vcode;
+				r_gen_code.vertex_global += interp_mode + "out " + vcode;
+				r_gen_code.fragment_global += interp_mode + "in " + vcode;
 			}
 
 			Map<StringName, String> function_code;

--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -254,6 +254,9 @@ const ShaderLanguage::KeyWord ShaderLanguage::keyword_list[] = {
 	{ TK_TYPE_ISAMPLER2D, "isampler2D" },
 	{ TK_TYPE_USAMPLER2D, "usampler2D" },
 	{ TK_TYPE_SAMPLERCUBE, "samplerCube" },
+	{ TK_INTERPOLATION_FLAT, "flat" },
+	{ TK_INTERPOLATION_NO_PERSPECTIVE, "noperspective" },
+	{ TK_INTERPOLATION_SMOOTH, "smooth" },
 	{ TK_PRECISION_LOW, "lowp" },
 	{ TK_PRECISION_MID, "mediump" },
 	{ TK_PRECISION_HIGH, "highp" },
@@ -656,6 +659,24 @@ bool ShaderLanguage::is_token_datatype(TokenType p_type) {
 ShaderLanguage::DataType ShaderLanguage::get_token_datatype(TokenType p_type) {
 
 	return DataType(p_type - TK_TYPE_VOID);
+}
+
+bool ShaderLanguage::is_token_interpolation(TokenType p_type) {
+
+	return (
+			p_type == TK_INTERPOLATION_FLAT ||
+			p_type == TK_INTERPOLATION_NO_PERSPECTIVE ||
+			p_type == TK_INTERPOLATION_SMOOTH);
+}
+
+ShaderLanguage::DataInterpolation ShaderLanguage::get_token_interpolation(TokenType p_type) {
+
+	if (p_type == TK_INTERPOLATION_FLAT)
+		return INTERPOLATION_FLAT;
+	else if (p_type == TK_INTERPOLATION_NO_PERSPECTIVE)
+		return INTERPOLATION_NO_PERSPECTIVE;
+	else
+		return INTERPOLATION_SMOOTH;
 }
 
 bool ShaderLanguage::is_token_precision(TokenType p_type) {
@@ -3576,10 +3597,16 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 
 				bool uniform = tk.type == TK_UNIFORM;
 				DataPrecision precision = PRECISION_DEFAULT;
+				DataInterpolation interpolation = INTERPOLATION_SMOOTH;
 				DataType type;
 				StringName name;
 
 				tk = _get_token();
+				if (is_token_interpolation(tk.type)) {
+					interpolation = get_token_interpolation(tk.type);
+					tk = _get_token();
+				}
+
 				if (is_token_precision(tk.type)) {
 					precision = get_token_precision(tk.type);
 					tk = _get_token();
@@ -3777,6 +3804,7 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 					ShaderNode::Varying varying;
 					varying.type = type;
 					varying.precission = precision;
+					varying.interpolation = interpolation;
 					shader->varyings[name] = varying;
 
 					tk = _get_token();

--- a/servers/visual/shader_language.h
+++ b/servers/visual/shader_language.h
@@ -72,6 +72,9 @@ public:
 		TK_TYPE_ISAMPLER2D,
 		TK_TYPE_USAMPLER2D,
 		TK_TYPE_SAMPLERCUBE,
+		TK_INTERPOLATION_FLAT,
+		TK_INTERPOLATION_NO_PERSPECTIVE,
+		TK_INTERPOLATION_SMOOTH,
 		TK_PRECISION_LOW,
 		TK_PRECISION_MID,
 		TK_PRECISION_HIGH,
@@ -190,6 +193,12 @@ public:
 		PRECISION_MEDIUMP,
 		PRECISION_HIGHP,
 		PRECISION_DEFAULT,
+	};
+
+	enum DataInterpolation {
+		INTERPOLATION_FLAT,
+		INTERPOLATION_NO_PERSPECTIVE,
+		INTERPOLATION_SMOOTH,
 	};
 
 	enum Operator {
@@ -431,6 +440,7 @@ public:
 
 		struct Varying {
 			DataType type;
+			DataInterpolation interpolation;
 			DataPrecision precission;
 		};
 
@@ -511,6 +521,8 @@ public:
 
 	static bool is_token_datatype(TokenType p_type);
 	static DataType get_token_datatype(TokenType p_type);
+	static bool is_token_interpolation(TokenType p_type);
+	static DataInterpolation get_token_interpolation(TokenType p_type);
 	static bool is_token_precision(TokenType p_type);
 	static DataPrecision get_token_precision(TokenType p_type);
 	static String get_datatype_name(DataType p_type);


### PR DESCRIPTION
Another take on #12503, without bloating the shader code as requested.
Adds an option for  [interpolation qualifiers](https://www.khronos.org/opengl/wiki/Type_Qualifier_(GLSL)#Interpolation_qualifiers) to varyings in the shaderlang.

in action:
![pic](https://i.imgur.com/8wPObXY.png)
