### PR TITLE
File Dialogs adjustments (v2)

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -586,7 +586,7 @@ void EditorFileDialog::update_file_list() {
 
 	while ((item = dir_access->get_next(&isdir)) != "") {
 
-		if (item == ".")
+		if (item == "." || item == "..")
 			continue;
 
 		ishidden = dir_access->current_is_hidden();
@@ -597,11 +597,6 @@ void EditorFileDialog::update_file_list() {
 			else if (item != ".." || !skip_pp)
 				dirs.push_back(item);
 		}
-	}
-
-	if (dirs.find("..") == NULL) {
-		//may happen if lacking permissions
-		dirs.push_back("..");
 	}
 
 	dirs.sort_custom<NaturalNoCaseComparator>();

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -723,6 +723,7 @@ void ProjectExportDialog::_export_project() {
 		export_project->add_filter("*." + extension + " ; " + platform->get_name() + " Export");
 	}
 
+	export_project->set_mode(FileDialog::MODE_SAVE_FILE);
 	export_project->popup_centered_ratio();
 }
 

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -86,6 +86,8 @@ private:
 	DirAccess *dir_access;
 	ConfirmationDialog *confirm_save;
 
+	ToolButton *dir_up;
+
 	ToolButton *refresh;
 
 	Vector<String> filters;
@@ -111,6 +113,7 @@ private:
 	void _filter_selected(int);
 	void _make_dir();
 	void _make_dir_confirm();
+	void _go_up();
 
 	void _update_drives();
 
@@ -155,6 +158,8 @@ public:
 	static void set_default_show_hidden_files(bool p_show);
 
 	void invalidate();
+
+	void deselect_items();
 
 	FileDialog();
 	~FileDialog();

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1923,9 +1923,6 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool
 				c = c->next;
 				item_h += child_h;
 			}
-
-			if (!c && !p_mod->get_shift() && !p_mod->get_control() && !p_mod->get_command() && !click_handled && p_button != BUTTON_RIGHT)
-				emit_signal("nothing_selected");
 		}
 	}
 
@@ -2602,6 +2599,12 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 					if (drag_touching) {
 						set_physics_process(true);
 					}
+
+					if (b->get_button_index() == BUTTON_LEFT)
+					{
+						if (get_item_at_position(b->get_position()) == NULL && !b->get_shift() && !b->get_control() && !b->get_command())
+							emit_signal("nothing_selected");
+					}
 				}
 
 			} break;
@@ -3044,6 +3047,25 @@ void Tree::item_deselected(int p_column, TreeItem *p_item) {
 void Tree::set_select_mode(SelectMode p_mode) {
 
 	select_mode = p_mode;
+}
+
+void Tree::deselect_all() {
+
+	TreeItem* item = get_next_selected(get_root());
+	while (item) {
+		item->deselect(selected_col);
+		item = get_next_selected(get_root());
+	}
+
+	selected_item = NULL;
+	selected_col  = -1;
+	
+	update();
+}
+
+bool Tree::is_anything_selected() {
+
+	return (selected_item != NULL);	
 }
 
 void Tree::clear() {

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -546,6 +546,8 @@ public:
 	int get_selected_column() const;
 	int get_pressed_button() const;
 	void set_select_mode(SelectMode p_mode);
+	void deselect_all();
+	bool is_anything_selected();
 
 	void set_columns(int p_columns);
 	int get_columns() const;


### PR DESCRIPTION
Made adjustments to open/save file dialogs according to notes from Akien (see comment https://github.com/godotengine/godot/pull/13252#issuecomment-347045849), plus a bit more:
1. Added "go to parent folder" (^) button to Save a File dialog.
2. Tree.cpp: "nothing_selected" signal has been re-made
3. Fixed issue in Project Export dialog: MODE_SAVE_FILE wasn't set when you click "Export".

See commit message for all details.