### PR TITLE
[WIP] Experimental in-editor playback

### DIFF
--- a/core/script_language.h
+++ b/core/script_language.h
@@ -232,6 +232,7 @@ public:
 
 	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const = 0;
 	virtual void add_global_constant(const StringName &p_variable, const Variant &p_value) = 0;
+	virtual void remove_global_constant(const StringName &p_variable) = 0;
 
 	/* MULTITHREAD FUNCTIONS */
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -74,6 +74,7 @@
 #include "editor/plugins/collision_shape_2d_editor_plugin.h"
 #include "editor/plugins/cube_grid_theme_editor_plugin.h"
 #include "editor/plugins/curve_editor_plugin.h"
+#include "editor/plugins/editor_playback_plugin.h"
 #include "editor/plugins/editor_preview_plugins.h"
 #include "editor/plugins/gi_probe_editor_plugin.h"
 #include "editor/plugins/gradient_editor_plugin.h"
@@ -261,7 +262,8 @@ void EditorNode::_notification(int p_what) {
 		}
 		editor_selection->update();
 
-		scene_root->set_size_override(true, Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height")));
+		if (use_fixed_window_size_override == true)
+			scene_root->set_size_override(true, Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height")));
 
 		ResourceImporterTexture::get_singleton()->update_imports();
 	}
@@ -1121,7 +1123,11 @@ void EditorNode::_dialog_action(String p_file) {
 			ProjectSettings::get_singleton()->set("application/run/main_scene", p_file);
 			ProjectSettings::get_singleton()->save();
 			//would be nice to show the project manager opened with the highlighted field..
-			_run(false, ""); // automatically run the project
+			if (run_native->is_run_in_editor_enabled()) {
+				_editor_playback_run(false, ""); // automatically run the project
+			} else {
+				_run(false, ""); // automatically run the project
+			}
 		} break;
 		case FILE_CLOSE:
 		case FILE_CLOSE_ALL_AND_QUIT:
@@ -1676,6 +1682,239 @@ void EditorNode::_resource_selected(const RES &p_res, const String &p_property) 
 	push_item(r.operator->(), p_property);
 }
 
+void EditorNode::_editor_playback_destroy_autoloads() {
+	for (int i = 0; i < editor_singletons.size(); i++) {
+		editor_singletons[i];
+	}
+
+	editor_singletons.clear();
+}
+
+void EditorNode::_editor_playback_init_autoloads(Node *p_root) {
+	//autoload
+	List<PropertyInfo> props;
+	ProjectSettings::get_singleton()->get_property_list(&props);
+
+	//first pass, add the constants so they exist before any script is loaded
+	for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
+
+		String s = E->get().name;
+		if (!s.begins_with("autoload/"))
+			continue;
+		String name = s.get_slicec('/', 1);
+		String path = ProjectSettings::get_singleton()->get(s);
+		bool global_var = false;
+		if (path.begins_with("*")) {
+			global_var = true;
+		}
+
+		if (global_var) {
+			for (int i = 0; i < ScriptServer::get_language_count(); i++) {
+				editor_singletons.push_back(name);
+				ScriptServer::get_language(i)->add_global_constant(name, Variant());
+			}
+		}
+	}
+
+	//second pass, load into global constants
+	List<Node *> to_add;
+	for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
+
+		String s = E->get().name;
+		if (!s.begins_with("autoload/"))
+			continue;
+		String name = s.get_slicec('/', 1);
+		String path = ProjectSettings::get_singleton()->get(s);
+		bool global_var = false;
+		if (path.begins_with("*")) {
+			global_var = true;
+			path = path.substr(1, path.length() - 1);
+		}
+
+		RES res = ResourceLoader::load(path);
+		ERR_EXPLAIN("Can't autoload: " + path);
+		ERR_CONTINUE(res.is_null());
+		Node *n = NULL;
+		if (res->is_class("PackedScene")) {
+			Ref<PackedScene> ps = res;
+			n = ps->instance();
+		} else if (res->is_class("Script")) {
+			Ref<Script> s = res;
+			StringName ibt = s->get_instance_base_type();
+			bool valid_type = ClassDB::is_parent_class(ibt, "Node");
+			ERR_EXPLAIN("Script does not inherit a Node: " + path);
+			ERR_CONTINUE(!valid_type);
+
+			Object *obj = ClassDB::instance(ibt);
+
+			ERR_EXPLAIN("Cannot instance script for autoload, expected 'Node' inheritance, got: " + String(ibt));
+			ERR_CONTINUE(obj == NULL);
+
+			n = Object::cast_to<Node>(obj);
+			n->set_script(s.get_ref_ptr());
+		}
+
+		ERR_EXPLAIN("Path in autoload not a node or script: " + path);
+		ERR_CONTINUE(!n);
+		n->set_name(name);
+
+		//defer so references are all valid on _ready()
+		to_add.push_back(n);
+
+		if (global_var) {
+			for (int i = 0; i < ScriptServer::get_language_count(); i++) {
+				ScriptServer::get_language(i)->add_global_constant(name, n);
+			}
+		}
+	}
+
+	for (List<Node *>::Element *E = to_add.front(); E; E = E->next()) {
+
+		p_root->add_child(E->get());
+	}
+}
+
+void EditorNode::_editor_playback_stop(const bool p_reload_scene) {
+	if (is_editor_playback_running()) {
+		if (editor_data.get_edited_scene_root()) {
+
+			Node *scene = editor_data.get_edited_scene_root();
+			String run_filename = scene->get_filename();
+
+			PhysicsServer::get_singleton()->set_active(false);
+			Physics2DServer::get_singleton()->set_active(false);
+			ScriptServer::set_scripting_enabled(false);
+
+			editor_playback_running = false;
+
+			_editor_playback_destroy_autoloads();
+
+			// TODO: why is this limited to debugging?
+			for (int i = 0; i < ScriptServer::get_language_count(); i++) {
+				ScriptServer::get_language(i)->reload_all_scripts();
+			}
+
+			print_line("_editor_playback_run stop...");
+
+			if (p_reload_scene) {
+				reload_scene(run_filename);
+			}
+		}
+	}
+}
+
+void EditorNode::_editor_playback_run(bool p_current, const String &p_custom) {
+	if (!is_editor_playback_running()) {
+
+		String playback_scene_filename;
+
+		if (p_current || (editor_data.get_edited_scene_root() && p_custom == editor_data.get_edited_scene_root()->get_filename())) {
+
+			Node *scene = editor_data.get_edited_scene_root();
+
+			if (!scene) {
+				current_option = -1;
+				accept->get_ok()->set_text(TTR("I see.."));
+				accept->set_text(TTR("There is no defined scene to run."));
+				accept->popup_centered_minsize();
+				return;
+			}
+
+			if (scene->get_filename() == "") {
+				current_option = -1;
+				_menu_option_confirm(FILE_SAVE_BEFORE_RUN, false);
+				return;
+			}
+
+			playback_scene_filename = scene->get_filename();
+		} else if (p_custom != "") {
+			playback_scene_filename = p_custom;
+		} else {
+
+			//evidently, run the scene
+			String main_scene = GLOBAL_DEF("application/run/main_scene", "");
+			if (main_scene == "") {
+
+				current_option = -1;
+				pick_main_scene->set_text(TTR("No main scene has ever been defined, select one?\nYou can change it later in \"Project Settings\" under the 'application' category."));
+				pick_main_scene->popup_centered_minsize();
+				return;
+			}
+
+			if (!FileAccess::exists(main_scene)) {
+
+				current_option = -1;
+				pick_main_scene->set_text(vformat(TTR("Selected scene '%s' does not exist, select a valid one?\nYou can change it later in \"Project Settings\" under the 'application' category."), main_scene));
+				pick_main_scene->popup_centered_minsize();
+				return;
+			}
+
+			if (ResourceLoader::get_resource_type(main_scene) != "PackedScene") {
+
+				current_option = -1;
+				pick_main_scene->set_text(vformat(TTR("Selected scene '%s' is not a scene file, select a valid one?\nYou can change it later in \"Project Settings\" under the 'application' category."), main_scene));
+				pick_main_scene->popup_centered_minsize();
+				return;
+			}
+
+			playback_scene_filename = main_scene;
+		}
+
+		if (bool(EDITOR_DEF("run/auto_save/save_before_running", true))) {
+
+			if (unsaved_cache) {
+
+				Node *scene = editor_data.get_edited_scene_root();
+
+				if (scene) { //only autosave if there is a scene obviously
+
+					if (scene->get_filename() == "") {
+
+						current_option = -1;
+						accept->get_ok()->set_text(TTR("I see.."));
+						accept->set_text(TTR("Current scene was never saved, please save it prior to running."));
+						accept->popup_centered_minsize();
+						return;
+					}
+
+					_save_scene_with_preview(scene->get_filename());
+				}
+			}
+			_menu_option(FILE_SAVE_ALL_SCENES);
+			editor_data.save_editor_external_data();
+		}
+
+		if (!_call_build())
+			return;
+
+		if (bool(EDITOR_DEF("run/output/always_clear_output_on_play", true))) {
+			log->clear();
+		}
+
+		if (bool(EDITOR_DEF("run/output/always_open_output_on_play", true))) {
+			make_bottom_panel_item_visible(log);
+		}
+
+		PhysicsServer::get_singleton()->set_active(true);
+		Physics2DServer::get_singleton()->set_active(true);
+		ScriptServer::set_scripting_enabled(true);
+
+		print_line("_editor_playback_run begin...");
+
+		if (load_scene(playback_scene_filename, false, false, true, false, true) != OK) {
+			PhysicsServer::get_singleton()->set_active(false);
+			Physics2DServer::get_singleton()->set_active(false);
+			ScriptServer::set_scripting_enabled(false);
+
+			for (int i = 0; i < ScriptServer::get_language_count(); i++) {
+				ScriptServer::get_language(i)->reload_all_scripts();
+			}
+		} else {
+			//_editor_select(EDITOR_PLAY);
+		}
+	}
+}
+
 void EditorNode::_run(bool p_current, const String &p_custom) {
 
 	if (editor_run.get_status() == EditorRun::STATUS_PLAY) {
@@ -1885,6 +2124,13 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		case SCENE_TAB_CLOSE:
 		case FILE_SAVE_SCENE: {
 
+			if (editor_playback_running) {
+				accept->get_ok()->set_text(TTR("I see.."));
+				accept->set_text(TTR("This operation can't be done during playback mode."));
+				accept->popup_centered_minsize();
+				break;
+			}
+
 			int scene_idx = (p_option == FILE_SAVE_SCENE) ? -1 : tab_closing;
 
 			Node *scene = editor_data.get_edited_scene_root(scene_idx);
@@ -1903,6 +2149,14 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			// fallthrough to save_as
 		};
 		case FILE_SAVE_AS_SCENE: {
+
+			if (editor_playback_running) {
+				accept->get_ok()->set_text(TTR("I see.."));
+				accept->set_text(TTR("This operation can't be done during playback mode."));
+				accept->popup_centered_minsize();
+				break;
+			}
+
 			int scene_idx = (p_option == FILE_SAVE_SCENE || p_option == FILE_SAVE_AS_SCENE) ? -1 : tab_closing;
 
 			Node *scene = editor_data.get_edited_scene_root(scene_idx);
@@ -1952,6 +2206,13 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		} break;
 
 		case FILE_SAVE_ALL_SCENES: {
+
+			if (editor_playback_running) {
+				accept->get_ok()->set_text(TTR("I see.."));
+				accept->set_text(TTR("This operation can't be done during playback mode."));
+				accept->popup_centered_minsize();
+				break;
+			}
 
 			_save_all_scenes();
 		} break;
@@ -2253,11 +2514,15 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		} break;
 		case RUN_PLAY: {
 			_menu_option_confirm(RUN_STOP, true);
-			_run(false);
+			if (run_native->is_run_in_editor_enabled()) {
+				_editor_playback_run(false);
+			} else {
+				_run(false);
+			}
 
 		} break;
 		case RUN_PLAY_CUSTOM_SCENE: {
-			if (run_custom_filename.empty() || editor_run.get_status() == EditorRun::STATUS_STOP) {
+			if (run_custom_filename.empty() || (editor_run.get_status() == EditorRun::STATUS_STOP && !is_editor_playback_running())) {
 				_menu_option_confirm(RUN_STOP, true);
 				quick_run->popup("PackedScene", true);
 				quick_run->set_title(TTR("Quick Run Scene.."));
@@ -2265,16 +2530,22 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			} else {
 				String last_custom_scene = run_custom_filename;
 				_menu_option_confirm(RUN_STOP, true);
-				_run(false, last_custom_scene);
+				if (run_native->is_run_in_editor_enabled()) {
+					_editor_playback_run(false, last_custom_scene);
+				} else {
+					_run(false, last_custom_scene);
+				}
 			}
 
 		} break;
 		case RUN_STOP: {
 
-			if (editor_run.get_status() == EditorRun::STATUS_STOP)
+			if (editor_run.get_status() == EditorRun::STATUS_STOP && !is_editor_playback_running())
 				break;
 
 			editor_run.stop();
+			_editor_playback_stop(true);
+
 			run_custom_filename.clear();
 			play_button->set_pressed(false);
 			play_button->set_icon(gui_base->get_icon("MainPlay", "EditorIcons"));
@@ -2297,7 +2568,11 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 			_save_default_environment();
 			_menu_option_confirm(RUN_STOP, true);
-			_run(true);
+			if (run_native->is_run_in_editor_enabled()) {
+				_editor_playback_run(true);
+			} else {
+				_run(true);
+			}
 
 		} break;
 		case RUN_PLAY_NATIVE: {
@@ -2384,6 +2659,14 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_FILE_SERVER), !ischecked);
 			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_file_server", !ischecked);
+		} break;
+		case RUN_IN_EDITOR: {
+
+			bool ischecked = debug_menu->get_popup()->is_item_checked(debug_menu->get_popup()->get_item_index(RUN_IN_EDITOR));
+			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_IN_EDITOR), !ischecked);
+			run_native->set_run_in_editor(!ischecked);
+			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_in_editor", !ischecked);
+
 		} break;
 		case RUN_LIVE_DEBUG: {
 
@@ -2601,6 +2884,7 @@ void EditorNode::_discard_changes(const String &p_str) {
 
 void EditorNode::_update_debug_options() {
 
+	bool check_run_in_editor = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_in_editor", false);
 	bool check_deploy_remote = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_deploy_remote_debug", false);
 	bool check_file_server = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_file_server", false);
 	bool check_debug_collisons = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_collisons", false);
@@ -2608,6 +2892,7 @@ void EditorNode::_update_debug_options() {
 	bool check_live_debug = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_live_debug", false);
 	bool check_reload_scripts = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_reload_scripts", false);
 
+	if (check_run_in_editor) _menu_option_confirm(RUN_IN_EDITOR, true);
 	if (check_deploy_remote) _menu_option_confirm(RUN_DEPLOY_REMOTE_DEBUG, true);
 	if (check_file_server) _menu_option_confirm(RUN_FILE_SERVER, true);
 	if (check_debug_collisons) _menu_option_confirm(RUN_DEBUG_COLLISONS, true);
@@ -2830,7 +3115,7 @@ void EditorNode::_remove_scene(int index) {
 	}
 }
 
-void EditorNode::set_edited_scene(Node *p_scene) {
+void EditorNode::set_edited_scene(Node *p_scene, bool p_autoloads) {
 
 	if (get_editor_data().get_edited_scene_root()) {
 		if (get_editor_data().get_edited_scene_root()->get_parent() == scene_root)
@@ -2843,6 +3128,15 @@ void EditorNode::set_edited_scene(Node *p_scene) {
 	scene_tree_dock->set_edited_scene(p_scene);
 	if (get_tree())
 		get_tree()->set_edited_scene_root(p_scene);
+
+	if (p_autoloads) {
+		// TODO: why is this limited to debugging?
+		for (int i = 0; i < ScriptServer::get_language_count(); i++) {
+			ScriptServer::get_language(i)->reload_all_scripts();
+		}
+
+		_editor_playback_init_autoloads(scene_root);
+	}
 
 	if (p_scene) {
 		if (p_scene->get_parent() != scene_root)
@@ -2944,6 +3238,8 @@ void EditorNode::set_current_scene(int p_idx) {
 		call_deferred("_clear_undo_history");
 	}
 
+	_editor_playback_stop(false); // CRASH
+
 	changing_scene = true;
 	editor_data.save_edited_scene_state(editor_selection, &editor_history, _get_main_scene_state());
 
@@ -2989,7 +3285,7 @@ void EditorNode::fix_dependencies(const String &p_for_file) {
 	dependency_fixer->edit(p_for_file);
 }
 
-Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, bool p_set_inherited, bool p_clear_errors, bool p_force_open_imported) {
+Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, bool p_set_inherited, bool p_clear_errors, bool p_force_open_imported, bool p_runtime_scene) {
 
 	if (!is_inside_tree()) {
 		defer_load_scene = p_scene;
@@ -2998,11 +3294,13 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 
 	if (!p_set_inherited) {
 
-		for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
+		if (!p_runtime_scene) {
+			for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
 
-			if (editor_data.get_scene_path(i) == p_scene) {
-				_scene_tab_changed(i);
-				return OK;
+				if (editor_data.get_scene_path(i) == p_scene) {
+					_scene_tab_changed(i);
+					return OK;
+				}
 			}
 		}
 
@@ -3097,6 +3395,9 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 		sdata->set_path(lpath, true); //take over path
 	}
 
+	if (p_runtime_scene)
+		editor_playback_running = true;
+
 	Node *new_scene = sdata->instance(PackedScene::GEN_EDIT_STATE_MAIN);
 
 	if (!new_scene) {
@@ -3108,6 +3409,9 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 			set_current_scene(prev);
 			editor_data.remove_scene(idx);
 		}
+
+		editor_playback_running = false;
+
 		return ERR_FILE_NOT_FOUND;
 	}
 
@@ -3120,7 +3424,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 
 	new_scene->set_scene_instance_state(Ref<SceneState>());
 
-	set_edited_scene(new_scene);
+	set_edited_scene(new_scene, editor_playback_running);
 	_get_scene_metadata(p_scene);
 
 	saved_version = editor_data.get_undo_redo().get_version();
@@ -3288,7 +3592,11 @@ void EditorNode::_quick_opened() {
 
 void EditorNode::_quick_run() {
 
-	_run(false, quick_run->get_selected());
+	if (run_native->is_run_in_editor_enabled()) {
+		_editor_playback_run(false, quick_run->get_selected());
+	} else {
+		_run(false, quick_run->get_selected());
+	}
 }
 
 void EditorNode::notify_child_process_exited() {
@@ -4680,6 +4988,13 @@ void EditorNode::_print_handler(void *p_this, const String &p_string, bool p_err
 	en->log->add_message(p_string, p_error);
 }
 
+void EditorNode::set_use_fixed_window_size_override(bool p_override) {
+	use_fixed_window_size_override = p_override;
+	if (use_fixed_window_size_override) {
+		scene_root->set_size_override(true, Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height")));
+	}
+}
+
 EditorNode::EditorNode() {
 
 	Resource::_get_local_scene_func = _resource_get_edited_scene;
@@ -4704,6 +5019,8 @@ EditorNode::EditorNode() {
 	}
 
 	singleton = this;
+	use_fixed_window_size_override = true;
+	editor_playback_running = false;
 	exiting = false;
 	last_checked_version = 0;
 	changing_scene = false;
@@ -5179,6 +5496,8 @@ EditorNode::EditorNode() {
 
 	p = debug_menu->get_popup();
 	p->set_hide_on_item_selection(false);
+	p->add_check_item(TTR("Run In-Editor (EXPERIMENTAL!)"), RUN_IN_EDITOR);
+	p->set_item_tooltip(p->get_item_count() - 1, TTR("When running the project, it will be run from within the editor rather than as a seperate application instance."));
 	p->add_check_item(TTR("Deploy with Remote Debug"), RUN_DEPLOY_REMOTE_DEBUG);
 	p->set_item_tooltip(p->get_item_count() - 1, TTR("When exporting or deploying, the resulting executable will attempt to connect to the IP of this computer in order to be debugged."));
 	p->add_check_item(TTR("Small Deploy with Network FS"), RUN_FILE_SERVER);
@@ -5609,6 +5928,8 @@ EditorNode::EditorNode() {
 	} else {
 		WARN_PRINT("Asset Library not available, as it requires SSL to work.");
 	}
+
+	add_editor_plugin(memnew(EditorPlaybackPlugin(this)));
 
 	//add interface before adding plugins
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -167,6 +167,7 @@ private:
 		RUN_LIVE_DEBUG,
 		RUN_DEBUG_COLLISONS,
 		RUN_DEBUG_NAVIGATION,
+		RUN_IN_EDITOR,
 		RUN_DEPLOY_REMOTE_DEBUG,
 		RUN_RELOAD_SCRIPTS,
 		SETTINGS_UPDATE_ALWAYS,
@@ -226,6 +227,8 @@ private:
 	TextureRect *tab_preview;
 	int tab_closing;
 
+	bool use_fixed_window_size_override;
+	bool editor_playback_running;
 	bool exiting;
 
 	int old_split_ofs;
@@ -470,6 +473,16 @@ private:
 	void _quick_opened();
 	void _quick_run();
 
+	void _reset_play_button_state();
+
+	// Editor Playback
+	List<String> editor_singletons;
+	void _editor_playback_init_autoloads(Node *p_root);
+	void _editor_playback_destroy_autoloads();
+
+	void _editor_playback_stop(const bool p_reload_scene);
+	void _editor_playback_run(bool p_current = false, const String &p_custom = "");
+
 	void _run(bool p_current = false, const String &p_custom = "");
 
 	void _save_optimized();
@@ -639,7 +652,8 @@ public:
 		EDITOR_2D = 0,
 		EDITOR_3D,
 		EDITOR_SCRIPT,
-		EDITOR_ASSETLIB
+		EDITOR_ASSETLIB,
+		EDITOR_PLAY
 	};
 
 	void set_visible_editor(EditorTable p_table) { _editor_select(p_table); }
@@ -694,7 +708,7 @@ public:
 	static EditorLog *get_log() { return singleton->log; }
 	Control *get_viewport();
 
-	void set_edited_scene(Node *p_scene);
+	void set_edited_scene(Node *p_scene, bool p_autoloads);
 
 	Node *get_edited_scene() { return editor_data.get_edited_scene_root(); }
 
@@ -702,7 +716,7 @@ public:
 
 	void fix_dependencies(const String &p_for_file);
 	void clear_scene() { _cleanup_scene(); }
-	Error load_scene(const String &p_scene, bool p_ignore_broken_deps = false, bool p_set_inherited = false, bool p_clear_errors = true, bool p_force_open_imported = false);
+	Error load_scene(const String &p_scene, bool p_ignore_broken_deps = false, bool p_set_inherited = false, bool p_clear_errors = true, bool p_force_open_imported = false, bool p_runtime_scene = false);
 	Error load_resource(const String &p_scene);
 
 	bool is_scene_open(const String &p_path);
@@ -772,6 +786,7 @@ public:
 
 	void reload_scene(const String &p_path);
 
+	bool is_editor_playback_running() const { return editor_playback_running; }
 	bool is_exiting() const { return exiting; }
 
 	ToolButton *get_pause_button() { return pause_button; }
@@ -791,6 +806,8 @@ public:
 	void remove_tool_menu_item(const String &p_name);
 
 	void dim_editor(bool p_dimming);
+
+	void set_use_fixed_window_size_override(bool p_override);
 
 	EditorNode();
 	~EditorNode();

--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -154,6 +154,16 @@ bool EditorRunNative::is_deploy_dumb_enabled() const {
 	return deploy_dumb;
 }
 
+void EditorRunNative::set_run_in_editor(bool p_enabled) {
+
+	run_in_editor = p_enabled;
+}
+
+bool EditorRunNative::is_run_in_editor_enabled() const {
+
+	return run_in_editor;
+}
+
 void EditorRunNative::set_deploy_debug_remote(bool p_enabled) {
 
 	deploy_debug_remote = p_enabled;

--- a/editor/editor_run_native.h
+++ b/editor/editor_run_native.h
@@ -40,6 +40,7 @@ class EditorRunNative : public HBoxContainer {
 	Map<int, MenuButton *> menus;
 	bool first;
 	bool deploy_dumb;
+	bool run_in_editor;
 	bool deploy_debug_remote;
 	bool debug_collisions;
 	bool debug_navigation;
@@ -53,6 +54,9 @@ protected:
 public:
 	void set_deploy_dumb(bool p_enabled);
 	bool is_deploy_dumb_enabled() const;
+
+	void set_run_in_editor(bool p_enabled);
+	bool is_run_in_editor_enabled() const;
 
 	void set_deploy_debug_remote(bool p_enabled);
 	bool is_deploy_debug_remote_enabled() const;

--- a/editor/icons/icon_game.svg
+++ b/editor/icons/icon_game.svg
@@ -1,0 +1,7 @@
+<svg width="16" height="16" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<g transform="translate(0 -1036.4)">
+<g>
+<path d="m4.9883 1039.4c-0.5469 0.01-0.98717 0.4511-0.98828 0.998v8c1.163e-4 0.7986 0.89011 1.275 1.5547 0.8321l6-4c0.59362-0.3959 0.59362-1.2682 0-1.6641l-6-4c-0.1678-0.1111-0.3652-0.1689-0.56641-0.166z" color="#000000" color-rendering="auto" dominant-baseline="auto" fill="#e0e0e0" fill-rule="evenodd" image-rendering="auto" shape-rendering="auto" solid-color="#000000" style="font-feature-settings:normal;font-variant-alternates:normal;font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal;font-variant-position:normal;isolation:auto;mix-blend-mode:normal;shape-padding:0;text-decoration-color:#000000;text-decoration-line:none;text-decoration-style:solid;text-indent:0;text-orientation:mixed;text-transform:none;white-space:normal"/>
+</g>
+</g>
+</svg>

--- a/editor/plugins/editor_playback_plugin.cpp
+++ b/editor/plugins/editor_playback_plugin.cpp
@@ -1,0 +1,553 @@
+/*************************************************************************/
+/*  editor_playback_plugin.cpp                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#include "editor_playback_plugin.h"
+
+#include "camera_matrix.h"
+#include "core/os/input.h"
+#include "editor/animation_editor.h"
+#include "editor/editor_node.h"
+#include "editor/editor_settings.h"
+#include "editor/plugins/script_editor_plugin.h"
+#include "editor/script_editor_debugger.h"
+#include "os/keyboard.h"
+#include "print_string.h"
+#include "project_settings.h"
+#include "scene/3d/camera.h"
+#include "scene/3d/visual_instance.h"
+#include "scene/resources/packed_scene.h"
+#include "sort.h"
+
+static int _get_key_modifier_setting(const String &p_property) {
+
+	switch (EditorSettings::get_singleton()->get(p_property).operator int()) {
+
+		case 0: return 0;
+		case 1: return KEY_SHIFT;
+		case 2: return KEY_ALT;
+		case 3: return KEY_META;
+		case 4: return KEY_CONTROL;
+	}
+	return 0;
+}
+
+static int _get_key_modifier(Ref<InputEventWithModifiers> e) {
+	if (e->get_shift())
+		return KEY_SHIFT;
+	if (e->get_alt())
+		return KEY_ALT;
+	if (e->get_control())
+		return KEY_CONTROL;
+	if (e->get_metakey())
+		return KEY_META;
+	return 0;
+}
+
+void EditorPlaybackViewport::_smouseenter() {
+
+	if (!surface->has_focus() && (!get_focus_owner() || !get_focus_owner()->is_text_field()))
+		surface->grab_focus();
+}
+
+void EditorPlaybackViewport::_smouseexit() {
+}
+
+void EditorPlaybackViewport::_sinput(const Ref<InputEvent> &p_event) {
+
+	{
+		EditorNode *en = editor;
+		EditorPluginList *force_input_forwarding_list = en->get_editor_plugins_force_input_forwarding();
+		if (!force_input_forwarding_list->empty()) {
+		}
+	}
+	{
+		EditorNode *en = editor;
+		EditorPluginList *over_plugin_list = en->get_editor_plugins_over();
+		if (!over_plugin_list->empty()) {
+		}
+	}
+
+	Ref<InputEventMouseButton> b = p_event;
+
+	if (b.is_valid()) {
+	}
+
+	Ref<InputEventMouseMotion> m = p_event;
+
+	if (m.is_valid()) {
+	}
+
+	Ref<InputEventKey> k = p_event;
+
+	if (k.is_valid()) {
+	}
+}
+
+void EditorPlaybackViewport::set_message(String p_message, float p_time) {
+
+	message = p_message;
+	message_time = p_time;
+}
+
+void EditorPlaybackViewport::_notification(int p_what) {
+
+	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
+
+		bool visible = is_visible_in_tree();
+
+		set_process(visible);
+	}
+
+	if (p_what == NOTIFICATION_RESIZED) {
+	}
+
+	if (p_what == NOTIFICATION_PROCESS) {
+
+		real_t delta = get_process_delta_time();
+
+		bool changed = false;
+		bool exist = false;
+
+		if (message_time > 0) {
+
+			if (message != last_message) {
+				surface->update();
+				last_message = message;
+			}
+
+			message_time -= get_physics_process_delta_time();
+			if (message_time < 0)
+				surface->update();
+		}
+
+		//update shadow atlas if changed
+
+		int shadowmap_size = ProjectSettings::get_singleton()->get("rendering/quality/shadow_atlas/size");
+		int atlas_q0 = ProjectSettings::get_singleton()->get("rendering/quality/shadow_atlas/quadrant_0_subdiv");
+		int atlas_q1 = ProjectSettings::get_singleton()->get("rendering/quality/shadow_atlas/quadrant_1_subdiv");
+		int atlas_q2 = ProjectSettings::get_singleton()->get("rendering/quality/shadow_atlas/quadrant_2_subdiv");
+		int atlas_q3 = ProjectSettings::get_singleton()->get("rendering/quality/shadow_atlas/quadrant_3_subdiv");
+
+		viewport->set_shadow_atlas_size(shadowmap_size);
+		viewport->set_shadow_atlas_quadrant_subdiv(0, Viewport::ShadowAtlasQuadrantSubdiv(atlas_q0));
+		viewport->set_shadow_atlas_quadrant_subdiv(1, Viewport::ShadowAtlasQuadrantSubdiv(atlas_q1));
+		viewport->set_shadow_atlas_quadrant_subdiv(2, Viewport::ShadowAtlasQuadrantSubdiv(atlas_q2));
+		viewport->set_shadow_atlas_quadrant_subdiv(3, Viewport::ShadowAtlasQuadrantSubdiv(atlas_q3));
+
+		//update msaa if changed
+
+		int msaa_mode = ProjectSettings::get_singleton()->get("rendering/quality/filters/msaa");
+		viewport->set_msaa(Viewport::MSAA(msaa_mode));
+
+		bool hdr = ProjectSettings::get_singleton()->get("rendering/quality/depth/hdr");
+		viewport->set_hdr(hdr);
+
+		editor->get_scene_root()->set_size_override(true, get_size());
+
+		prev_size = surface->get_size();
+
+		_update_camera_state();
+	}
+
+	if (p_what == NOTIFICATION_ENTER_TREE) {
+
+		surface->connect("draw", this, "_draw");
+		surface->connect("gui_input", this, "_sinput");
+		surface->connect("mouse_entered", this, "_smouseenter");
+		surface->connect("mouse_exited", this, "_smouseexit");
+	}
+	if (p_what == NOTIFICATION_EXIT_TREE) {
+	}
+
+	if (p_what == NOTIFICATION_MOUSE_ENTER) {
+	}
+
+	if (p_what == NOTIFICATION_DRAW) {
+	}
+}
+
+void EditorPlaybackViewport::_current_camera_changed(Object *p_camera) {
+	camera_pointer = Object::cast_to<Camera>(p_camera);
+}
+
+void EditorPlaybackViewport::_update_camera_state() {
+	if (camera_pointer) {
+		camera->show();
+
+		camera->set_global_transform(camera_pointer->get_global_transform());
+		if (camera_pointer->get_projection() == Camera::PROJECTION_PERSPECTIVE) {
+			camera->set_perspective(camera_pointer->get_fov(), camera_pointer->get_znear(), camera_pointer->get_zfar());
+		} else {
+			camera->set_orthogonal(camera_pointer->get_size(), camera_pointer->get_znear(), camera_pointer->get_zfar());
+		}
+		camera->set_environment(camera_pointer->get_environment());
+		camera->set_cull_mask(camera_pointer->get_cull_mask());
+
+		;
+	} else {
+		camera->hide();
+	}
+}
+
+void EditorPlaybackViewport::_draw() {
+
+	if (surface->has_focus()) {
+		Size2 size = surface->get_size();
+		Rect2 r = Rect2(Point2(), size);
+		get_stylebox("Focus", "EditorStyles")->draw(surface->get_canvas_item(), r);
+	}
+
+	RID ci = surface->get_canvas_item();
+
+	if (message_time > 0) {
+		Ref<Font> font = get_font("font", "Label");
+		Point2 msgpos = Point2(5, get_size().y - 20);
+		font->draw(ci, msgpos + Point2(1, 1), message, Color(0, 0, 0, 0.8));
+		font->draw(ci, msgpos + Point2(-1, -1), message, Color(0, 0, 0, 0.8));
+		font->draw(ci, msgpos, message, Color(1, 1, 1, 1));
+	}
+
+	/*if (previewing) {
+
+		Size2 ss = Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height"));
+		float aspect = ss.aspect();
+		Size2 s = get_size();
+
+		Rect2 draw_rect;
+
+		switch (previewing->get_keep_aspect_mode()) {
+			case Camera::KEEP_WIDTH: {
+
+				draw_rect.size = Size2(s.width, s.width / aspect);
+				draw_rect.position.x = 0;
+				draw_rect.position.y = (s.height - draw_rect.size.y) * 0.5;
+
+			} break;
+			case Camera::KEEP_HEIGHT: {
+
+				draw_rect.size = Size2(s.height * aspect, s.height);
+				draw_rect.position.y = 0;
+				draw_rect.position.x = (s.width - draw_rect.size.x) * 0.5;
+
+			} break;
+		}
+
+		draw_rect = Rect2(Vector2(), s).clip(draw_rect);
+
+		stroke_rect(*surface, draw_rect, Color(0.6, 0.6, 0.1, 0.5), 2.0);
+
+	} else {
+	}*/
+}
+
+void EditorPlaybackViewport::_bind_methods() {
+
+	ClassDB::bind_method(D_METHOD("_draw"), &EditorPlaybackViewport::_draw);
+	ClassDB::bind_method(D_METHOD("_smouseenter"), &EditorPlaybackViewport::_smouseenter);
+	ClassDB::bind_method(D_METHOD("_smouseexit"), &EditorPlaybackViewport::_smouseexit);
+	ClassDB::bind_method(D_METHOD("_sinput"), &EditorPlaybackViewport::_sinput);
+	ClassDB::bind_method(D_METHOD("_current_camera_changed"), &EditorPlaybackViewport::_current_camera_changed);
+
+	ADD_SIGNAL(MethodInfo("toggle_maximize_view", PropertyInfo(Variant::OBJECT, "viewport")));
+}
+
+void EditorPlaybackViewport::reset() {
+
+	message_time = 0;
+	message = "";
+	last_message = "";
+	name = "";
+}
+
+void EditorPlaybackViewport::focus_selection() {
+	Vector3 center;
+	int count = 0;
+
+	if (count != 0) {
+		center /= float(count);
+	}
+}
+
+EditorPlaybackViewport::EditorPlaybackViewport(EditorPlayback *p_editor_playback, EditorNode *p_editor) {
+
+	editor = p_editor;
+	editor_data = editor->get_scene_tree_dock()->get_editor_data();
+	message_time = 0;
+
+	editor_playback = p_editor_playback;
+
+	ViewportContainer *c = memnew(ViewportContainer);
+	viewport_container = c;
+	c->set_stretch(true);
+	add_child(c);
+	c->set_anchors_and_margins_preset(Control::PRESET_WIDE);
+	c->show();
+	viewport = memnew(Viewport);
+	viewport->set_disable_input(false);
+	viewport->set_world_2d(editor->get_scene_root()->get_world_2d());
+	c->add_child(viewport);
+
+	camera = memnew(Camera);
+	camera->set_disable_gizmo(true);
+	viewport->add_child(camera);
+	camera->make_current();
+	camera->hide();
+
+	surface = memnew(Control);
+	surface->set_drag_forwarding(this);
+	add_child(surface);
+	surface->set_anchors_and_margins_preset(Control::PRESET_WIDE);
+	surface->set_clip_contents(true);
+	surface->set_focus_mode(FOCUS_ALL);
+
+	camera_pointer = NULL;
+
+	// Setup camera
+	Viewport *vp = editor->get_scene_root();
+	if (vp) {
+		_current_camera_changed(vp->get_camera());
+		vp->connect("current_camera_changed", this, "_current_camera_changed");
+	}
+
+	name = "";
+}
+
+EditorPlaybackViewport::~EditorPlaybackViewport() {
+	Viewport *vp = editor->get_scene_root();
+	if (vp) {
+		vp->disconnect("current_camera_changed", this, "_current_camera_changed");
+	}
+}
+
+//////////////////////////////////////////////////////////////
+
+void EditorPlaybackViewportContainer::_gui_input(const Ref<InputEvent> &p_event) {
+}
+
+void EditorPlaybackViewportContainer::_notification(int p_what) {
+
+	if (p_what == NOTIFICATION_MOUSE_ENTER || p_what == NOTIFICATION_MOUSE_EXIT) {
+
+		mouseover = (p_what == NOTIFICATION_MOUSE_ENTER);
+		update();
+	}
+
+	if (p_what == NOTIFICATION_DRAW && mouseover) {
+	}
+
+	if (p_what == NOTIFICATION_SORT_CHILDREN) {
+
+		EditorPlaybackViewport *viewport;
+		viewport = Object::cast_to<EditorPlaybackViewport>(get_child(0));
+
+		Size2 size = get_size();
+
+		if (size.x < 10 || size.y < 10) {
+			viewport->hide();
+			return;
+		} else {
+			viewport->show();
+		}
+
+		fit_child_in_rect(viewport, Rect2(Vector2(), size));
+	}
+}
+
+void EditorPlaybackViewportContainer::_bind_methods() {
+
+	ClassDB::bind_method("_gui_input", &EditorPlaybackViewportContainer::_gui_input);
+}
+
+EditorPlaybackViewportContainer::EditorPlaybackViewportContainer() {
+
+	mouseover = false;
+	ratio_h = 0.5;
+	ratio_v = 0.5;
+}
+
+///////////////////////////////////////////////////////////////////
+
+EditorPlayback *EditorPlayback::singleton = NULL;
+
+Dictionary EditorPlayback::get_state() const {
+
+	Dictionary d;
+
+	int vc = 1;
+
+	d["viewport_mode"] = vc;
+	Array vpdata;
+
+	d["viewports"] = vpdata;
+
+	return d;
+}
+void EditorPlayback::set_state(const Dictionary &p_state) {
+
+	Dictionary d = p_state;
+
+	if (d.has("viewports")) {
+		Array vp = d["viewports"];
+		ERR_FAIL_COND(vp.size() > VIEWPORTS_COUNT);
+	}
+}
+
+void EditorPlayback::_unhandled_key_input(Ref<InputEvent> p_event) {
+
+	if (!is_visible_in_tree() || get_viewport()->gui_has_modal_stack())
+		return;
+}
+void EditorPlayback::_notification(int p_what) {
+
+	if (p_what == NOTIFICATION_READY) {
+
+		get_tree()->connect("node_removed", this, "_node_removed");
+		EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor()->connect("node_changed", this, "_refresh_menu_icons");
+	}
+
+	if (p_what == NOTIFICATION_ENTER_TREE) {
+	}
+
+	if (p_what == NOTIFICATION_EXIT_TREE) {
+	}
+}
+
+void EditorPlayback::_toggle_maximize_view(Object *p_viewport) {
+	if (!p_viewport)
+		return;
+
+	EditorPlaybackViewport *current_viewport = Object::cast_to<EditorPlaybackViewport>(p_viewport);
+	if (!current_viewport)
+		return;
+
+	bool maximized = false;
+
+	if (current_viewport->get_global_rect() == viewport_base->get_global_rect())
+		maximized = true;
+
+	if (!maximized) {
+		viewport->set_anchors_and_margins_preset(Control::PRESET_WIDE);
+	} else {
+		viewport->show();
+	}
+}
+
+void EditorPlayback::_node_removed(Node *p_node) {
+}
+
+void EditorPlayback::_bind_methods() {
+
+	//ClassDB::bind_method("_gui_input",&EditorPlayback::_gui_input);
+	ClassDB::bind_method("_unhandled_key_input", &EditorPlayback::_unhandled_key_input);
+	ClassDB::bind_method("_node_removed", &EditorPlayback::_node_removed);
+	ClassDB::bind_method("_toggle_maximize_view", &EditorPlayback::_toggle_maximize_view);
+}
+
+void EditorPlayback::clear() {
+
+	viewport->reset();
+}
+
+EditorPlayback::EditorPlayback(EditorNode *p_editor) {
+
+	singleton = this;
+	editor = p_editor;
+	editor_selection = editor->get_editor_selection();
+	editor_selection->add_editor_plugin(this);
+
+	VBoxContainer *vbc = this;
+
+	hbc_menu = memnew(HBoxContainer);
+	vbc->add_child(hbc_menu);
+
+	viewport_base = memnew(EditorPlaybackViewportContainer);
+	viewport_base->set_v_size_flags(SIZE_EXPAND_FILL);
+	vbc->add_child(viewport_base);
+
+	viewport = memnew(EditorPlaybackViewport(this, editor));
+	viewport->connect("toggle_maximize_view", this, "_toggle_maximize_view");
+	viewport_base->add_child(viewport);
+
+	set_process_unhandled_key_input(true);
+	add_to_group("_editor_playback_group");
+}
+
+EditorPlayback::~EditorPlayback() {
+}
+
+void EditorPlaybackPlugin::make_visible(bool p_visible) {
+
+	if (p_visible) {
+
+		editor_playback->show();
+		VisualServer::get_singleton()->viewport_set_hide_canvas(editor->get_scene_root()->get_viewport_rid(), false);
+		editor->set_use_fixed_window_size_override(false);
+		editor_playback->set_process(true);
+		editor_playback->grab_focus();
+
+	} else {
+
+		editor_playback->hide();
+		VisualServer::get_singleton()->viewport_set_hide_canvas(editor->get_scene_root()->get_viewport_rid(), true);
+		editor->set_use_fixed_window_size_override(true);
+		editor_playback->set_process(false);
+	}
+}
+void EditorPlaybackPlugin::edit(Object *p_object) {
+}
+
+bool EditorPlaybackPlugin::handles(Object *p_object) const {
+
+	return false;
+}
+
+Dictionary EditorPlaybackPlugin::get_state() const {
+	return editor_playback->get_state();
+}
+
+void EditorPlaybackPlugin::set_state(const Dictionary &p_state) {
+
+	editor_playback->set_state(p_state);
+}
+
+void EditorPlaybackPlugin::_bind_methods() {
+}
+
+EditorPlaybackPlugin::EditorPlaybackPlugin(EditorNode *p_node) {
+
+	editor = p_node;
+	editor_playback = memnew(EditorPlayback(p_node));
+	editor_playback->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	editor->get_viewport()->add_child(editor_playback);
+
+	editor_playback->hide();
+}
+
+EditorPlaybackPlugin::~EditorPlaybackPlugin() {
+}

--- a/editor/plugins/editor_playback_plugin.h
+++ b/editor/plugins/editor_playback_plugin.h
@@ -1,0 +1,185 @@
+/*************************************************************************/
+/*  editor_playback_plugin.h                                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2017 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2017 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#ifndef EDITOR_PREVIEW_PLUGIN_H
+#define EDITOR_PREVIEW_PLUGIN_H
+
+#include "editor/editor_node.h"
+#include "editor/editor_plugin.h"
+#include "scene/3d/immediate_geometry.h"
+#include "scene/3d/light.h"
+#include "scene/3d/visual_instance.h"
+#include "scene/gui/panel_container.h"
+
+class Camera;
+
+class EditorPlaybackViewport : public Control {
+
+	GDCLASS(EditorPlaybackViewport, Control);
+	friend class EditorPlayback;
+
+private:
+	String name;
+	Size2 prev_size;
+
+	EditorNode *editor;
+	EditorData *editor_data;
+
+	ViewportContainer *viewport_container;
+
+	Control *surface;
+	Viewport *viewport;
+	Camera *camera;
+	Camera *camera_pointer;
+
+	String last_message;
+	String message;
+	float message_time;
+
+	void set_message(String p_message, float p_time = 5);
+
+	//
+	void _draw();
+
+	void _smouseenter();
+	void _smouseexit();
+	void _sinput(const Ref<InputEvent> &p_event);
+	EditorPlayback *editor_playback;
+
+protected:
+	void _current_camera_changed(Object *p_camera);
+	void _update_camera_state();
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	void reset();
+
+	void focus_selection();
+
+	Viewport *get_viewport_node() { return viewport; }
+
+	EditorPlaybackViewport(EditorPlayback *p_editor_playback, EditorNode *p_editor);
+	~EditorPlaybackViewport();
+};
+
+class EditorPlaybackViewportContainer : public Container {
+
+	GDCLASS(EditorPlaybackViewportContainer, Container)
+private:
+	bool mouseover;
+	float ratio_h;
+	float ratio_v;
+
+	void _gui_input(const Ref<InputEvent> &p_event);
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	EditorPlaybackViewportContainer();
+};
+
+class EditorPlayback : public VBoxContainer {
+
+	GDCLASS(EditorPlayback, VBoxContainer);
+
+private:
+	static const unsigned int VIEWPORTS_COUNT = 1;
+
+	EditorNode *editor;
+	EditorSelection *editor_selection;
+
+	EditorPlaybackViewportContainer *viewport_base;
+	EditorPlaybackViewport *viewport;
+
+	//
+	//
+
+	HBoxContainer *hbc_menu;
+
+	void _toggle_maximize_view(Object *p_viewport);
+
+	static EditorPlayback *singleton;
+
+	void _node_removed(Node *p_node);
+	EditorPlayback();
+
+protected:
+	void _notification(int p_what);
+	//void _gui_input(InputEvent p_event);
+	void _unhandled_key_input(Ref<InputEvent> p_event);
+
+	static void _bind_methods();
+
+public:
+	static EditorPlayback *get_singleton() { return singleton; }
+
+	Dictionary get_state() const;
+	void set_state(const Dictionary &p_state);
+
+	EditorPlaybackViewport *get_editor_viewport() {
+		return viewport;
+	}
+
+	Camera *get_camera() { return NULL; }
+	void clear();
+
+	EditorPlayback(EditorNode *p_editor);
+	~EditorPlayback();
+};
+
+class EditorPlaybackPlugin : public EditorPlugin {
+
+	GDCLASS(EditorPlaybackPlugin, EditorPlugin);
+
+	EditorPlayback *editor_playback;
+	EditorNode *editor;
+
+protected:
+	static void _bind_methods();
+
+public:
+	EditorPlayback *get_editor_playback() { return editor_playback; }
+	virtual String get_name() const { return "Game"; }
+	bool has_main_screen() const { return true; }
+	virtual void make_visible(bool p_visible);
+	virtual void edit(Object *p_object);
+	virtual bool handles(Object *p_object) const;
+
+	virtual Dictionary get_state() const;
+	virtual void set_state(const Dictionary &p_state);
+	virtual void clear() { editor_playback->clear(); }
+
+	EditorPlaybackPlugin(EditorNode *p_node);
+	~EditorPlaybackPlugin();
+};
+
+#endif

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1230,8 +1230,8 @@ void SceneTreeDock::_delete_confirm() {
 
 	if (entire_scene) {
 
-		editor_data->get_undo_redo().add_do_method(editor, "set_edited_scene", (Object *)NULL);
-		editor_data->get_undo_redo().add_undo_method(editor, "set_edited_scene", edited_scene);
+		editor_data->get_undo_redo().add_do_method(editor, "set_edited_scene", (Object *)NULL, false);
+		editor_data->get_undo_redo().add_undo_method(editor, "set_edited_scene", edited_scene, false);
 		editor_data->get_undo_redo().add_undo_method(edited_scene, "set_owner", edited_scene->get_owner());
 		editor_data->get_undo_redo().add_undo_method(scene_tree, "update_tree");
 		editor_data->get_undo_redo().add_undo_reference(edited_scene);
@@ -1351,10 +1351,10 @@ void SceneTreeDock::_create() {
 
 		} else {
 
-			editor_data->get_undo_redo().add_do_method(editor, "set_edited_scene", child);
+			editor_data->get_undo_redo().add_do_method(editor, "set_edited_scene", child, false);
 			editor_data->get_undo_redo().add_do_method(scene_tree, "update_tree");
 			editor_data->get_undo_redo().add_do_reference(child);
-			editor_data->get_undo_redo().add_undo_method(editor, "set_edited_scene", (Object *)NULL);
+			editor_data->get_undo_redo().add_undo_method(editor, "set_edited_scene", (Object *)NULL, false);
 		}
 
 		editor_data->get_undo_redo().commit_action();
@@ -1425,7 +1425,7 @@ void SceneTreeDock::_create() {
 
 		if (n == edited_scene) {
 			edited_scene = newnode;
-			editor->set_edited_scene(newnode);
+			editor->set_edited_scene(newnode, false);
 			newnode->set_editable_instances(n->get_editable_instances());
 		}
 

--- a/modules/gdnative/include/pluginscript/godot_pluginscript.h
+++ b/modules/gdnative/include/pluginscript/godot_pluginscript.h
@@ -139,6 +139,7 @@ typedef struct {
 	void (*auto_indent_code)(godot_pluginscript_language_data *p_data, godot_string *p_code, int p_from_line, int p_to_line);
 
 	void (*add_global_constant)(godot_pluginscript_language_data *p_data, const godot_string *p_variable, const godot_variant *p_value);
+	void (*remove_global_constant)(godot_pluginscript_language_data *p_data, const godot_string *p_variable);
 	godot_string (*debug_get_error)(godot_pluginscript_language_data *p_data);
 	int (*debug_get_stack_level_count)(godot_pluginscript_language_data *p_data);
 	int (*debug_get_stack_level_line)(godot_pluginscript_language_data *p_data, int p_level);

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -920,6 +920,9 @@ void NativeScriptLanguage::auto_indent_code(String &p_code, int p_from_line, int
 void NativeScriptLanguage::add_global_constant(const StringName &p_variable, const Variant &p_value) {
 }
 
+void NativeScriptLanguage::remove_global_constant(const StringName &p_variable) {
+}
+
 // Debugging stuff here. Not used for now.
 String NativeScriptLanguage::debug_get_error() const {
 	return "";

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -274,6 +274,7 @@ public:
 	virtual String make_function(const String &p_class, const String &p_name, const PoolStringArray &p_args) const;
 	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const;
 	virtual void add_global_constant(const StringName &p_variable, const Variant &p_value);
+	virtual void remove_global_constant(const StringName &p_variable);
 	virtual String debug_get_error() const;
 	virtual int debug_get_stack_level_count() const;
 	virtual int debug_get_stack_level_line(int p_level) const;

--- a/modules/gdnative/pluginscript/pluginscript_language.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_language.cpp
@@ -186,6 +186,11 @@ void PluginScriptLanguage::add_global_constant(const StringName &p_variable, con
 	_desc.add_global_constant(_data, (godot_string *)&variable, (godot_variant *)&p_value);
 }
 
+void PluginScriptLanguage::remove_global_constant(const StringName &p_variable) {
+	const String variable = String(p_variable);
+	_desc.remove_global_constant(_data, (godot_string *)&variable);
+}
+
 /* LOADER FUNCTIONS */
 
 void PluginScriptLanguage::get_recognized_extensions(List<String> *p_extensions) const {

--- a/modules/gdnative/pluginscript/pluginscript_language.h
+++ b/modules/gdnative/pluginscript/pluginscript_language.h
@@ -84,6 +84,7 @@ public:
 	virtual Error complete_code(const String &p_code, const String &p_base_path, Object *p_owner, List<String> *r_options, bool &r_force, String &r_call_hint);
 	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const;
 	virtual void add_global_constant(const StringName &p_variable, const Variant &p_value);
+	virtual void remove_global_constant(const StringName &p_variable);
 
 	/* MULTITHREAD FUNCTIONS */
 

--- a/modules/gdnative/pluginscript/register_types.cpp
+++ b/modules/gdnative/pluginscript/register_types.cpp
@@ -64,6 +64,7 @@ static Error _check_language_desc(const godot_pluginscript_language_desc *desc) 
 	// desc->complete_code is not mandatory
 	// desc->auto_indent_code is not mandatory
 	// desc->add_global_constant is not mandatory
+	// desc->remove_global_constant is not mandatory
 	// desc->debug_get_error is not mandatory
 	// desc->debug_get_stack_level_count is not mandatory
 	// desc->debug_get_stack_level_line is not mandatory

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1327,9 +1327,25 @@ void GDScriptLanguage::_add_global(const StringName &p_name, const Variant &p_va
 	_global_array = global_array.ptrw();
 }
 
+void GDScriptLanguage::_remove_global(const StringName &p_name) {
+
+	// TODO: Fix indexes!
+	if (globals.has(p_name)) {
+		int index = globals[p_name];
+		global_array.remove(index);
+		globals.erase(p_name);
+		for (int i = index; i < globals.size(); i++) {
+		}
+	}
+}
+
 void GDScriptLanguage::add_global_constant(const StringName &p_variable, const Variant &p_value) {
 
 	_add_global(p_variable, p_value);
+}
+
+void GDScriptLanguage::remove_global_constant(const StringName &p_variable) {
+	_remove_global(p_variable);
 }
 
 void GDScriptLanguage::init() {
@@ -1518,7 +1534,7 @@ struct GDScriptDepSort {
 
 void GDScriptLanguage::reload_all_scripts() {
 
-#ifdef DEBUG_ENABLED
+#if 1
 	print_line("RELOAD ALL SCRIPTS");
 	if (lock) {
 		lock->lock();
@@ -1554,7 +1570,7 @@ void GDScriptLanguage::reload_all_scripts() {
 
 void GDScriptLanguage::reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload) {
 
-#ifdef DEBUG_ENABLED
+#if 1
 
 	if (lock) {
 		lock->lock();

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -279,6 +279,7 @@ class GDScriptLanguage : public ScriptLanguage {
 	CallLevel *_call_stack;
 
 	void _add_global(const StringName &p_name, const Variant &p_value);
+	void _remove_global(const StringName &p_name);
 
 	friend class GDScriptInstance;
 
@@ -400,6 +401,7 @@ public:
 	virtual String _get_indentation() const;
 	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const;
 	virtual void add_global_constant(const StringName &p_variable, const Variant &p_value);
+	virtual void remove_global_constant(const StringName &p_variable);
 
 	/* DEBUGGER FUNCTIONS */
 

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -2422,7 +2422,11 @@ String VisualScriptLanguage::make_function(const String &p_class, const String &
 
 void VisualScriptLanguage::auto_indent_code(String &p_code, int p_from_line, int p_to_line) const {
 }
+
 void VisualScriptLanguage::add_global_constant(const StringName &p_variable, const Variant &p_value) {
+}
+
+void VisualScriptLanguage::remove_global_constant(const StringName &p_variable) {
 }
 
 /* DEBUGGER FUNCTIONS */

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -572,6 +572,7 @@ public:
 	virtual String make_function(const String &p_class, const String &p_name, const PoolStringArray &p_args) const;
 	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const;
 	virtual void add_global_constant(const StringName &p_variable, const Variant &p_value);
+	virtual void remove_global_constant(const StringName &p_variable);
 
 	/* DEBUGGER FUNCTIONS */
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -916,6 +916,8 @@ void Viewport::_camera_set(Camera *p_camera) {
 		camera->notification(Camera::NOTIFICATION_BECAME_CURRENT);
 	}
 
+	emit_signal("current_camera_changed", camera);
+
 	_update_listener();
 	_camera_transform_changed_notify();
 #endif
@@ -2758,6 +2760,7 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "shadow_atlas_quad_3", PROPERTY_HINT_ENUM, "Disabled,1 Shadow,4 Shadows,16 Shadows,64 Shadows,256 Shadows,1024 Shadows"), "set_shadow_atlas_quadrant_subdiv", "get_shadow_atlas_quadrant_subdiv", 3);
 
 	ADD_SIGNAL(MethodInfo("size_changed"));
+	ADD_SIGNAL(MethodInfo("current_camera_changed", PropertyInfo(Variant::OBJECT, "camera")));
 
 	BIND_ENUM_CONSTANT(UPDATE_DISABLED);
 	BIND_ENUM_CONSTANT(UPDATE_ONCE);


### PR DESCRIPTION
WIP branch, do not merge.

Merely putting this up for advice and feedback. What this PR is intended to do is essentially provide a secondary playback functionality allowing you to play your game from within the editor itself, as well as pause it an fly around the scene while it's playing. I experimented with this a while back to feel out the feasibility of such a feature, but now I made the first effort to actually try bringing this into a usable feature. Since the editor is built onto of the same node tree, there is no real architectural reason why this is not possible; it just requires various hooks to be addressed in order for it to work accurately and stable. At the moment, the thing which is giving me the most trouble is an issue opened here #13353 where the GDScriptDepSort operator does not work as intended, which is required for a safe global script reload on playback. Since this problem is particularly hard to debug, I may return to the branch later, but if anyone has any solutions, please let me know.

These are a list of currently known tasks, but I will add others as needed:
- [x] In-editor playback mode added to the editor node with physics and non-tool script simulation
- [x] Game plugin which views the scene from the current camera perspective
- [x] Singleton/autoload support for in-editor playback
- [ ] Inheritance-dependent script reloading #13353
- [ ] Game plugin input support with sandboxing.
- [ ] Seperate method from 'is_editor_hint' detecting specifically whether the game is in playback mode.
- [ ] Script breakpoint support
- [ ] Cleanup and polish.