### PR TITLE
Fixes for SCons shared cache for Travis-CI and AppVeyor-CI (master)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,8 +3,8 @@ os: Visual Studio 2015
 environment:
   HOME: "%HOMEDRIVE%%HOMEPATH%"
   PYTHON: C:\Python27
-  SCONS_CACHE: "%HOME%\\scons_cache"
-  SCONS_CACHE_LIMIT: 128
+  SCONS_CACHE_ROOT: "%HOME%\\scons_cache"
+  SCONS_CACHE_LIMIT: 512
   matrix:
     - VS: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
       GD_PLATFORM: windows
@@ -13,7 +13,7 @@ environment:
       ARCH: amd64
 
 cache:
-  - "%SCONS_CACHE%"
+  - "%SCONS_CACHE_ROOT%"
 
 install:
   - SET "PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
@@ -25,6 +25,7 @@ before_build:
   - python --version
   - scons --version
   - cl.exe
+  - SET "SCONS_CACHE=%SCONS_CACHE_ROOT%\master"
 
 build_script:
-- scons platform=%GD_PLATFORM% target=%TARGET% tools=%TOOLS% progress=no
+- scons platform=%GD_PLATFORM% target=%TARGET% tools=%TOOLS% verbose=yes progress=no

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ sudo: false
 env:
   global:
     - SCONS_CACHE=$HOME/.scons_cache
-    - SCONS_CACHE_LIMIT=128
+    - SCONS_CACHE_LIMIT=1024
 
 cache:
   directories:
@@ -18,22 +18,22 @@ matrix:
     - env: STATIC_CHECKS=yes
       os: linux
       compiler: clang
-    - env: GODOT_TARGET=x11 TOOLS=yes
+    - env: GODOT_TARGET=x11 TOOLS=yes CACHE_NAME=${GODOT_TARGET}-gcc-tools
       os: linux
       compiler: gcc
-    - env: GODOT_TARGET=x11 TOOLS=no
+    - env: GODOT_TARGET=x11 TOOLS=no CACHE_NAME=${GODOT_TARGET}-clang
       os: linux
       compiler: clang
-    #- env: GODOT_TARGET=windows TOOLS=yes
+    #- env: GODOT_TARGET=windows TOOLS=yes CACHE_NAME=${GODOT_TARGET}-gcc-tools
     #  os: linux
     #  compiler: gcc
-    - env: GODOT_TARGET=android TOOLS=no
+    - env: GODOT_TARGET=android TOOLS=no CACHE_NAME=${GODOT_TARGET}-gcc
       os: linux
       compiler: gcc
-    - env: GODOT_TARGET=osx TOOLS=yes
+    - env: GODOT_TARGET=osx TOOLS=yes CACHE_NAME=${GODOT_TARGET}-clang-tools
       os: osx
       compiler: clang
-    #- env: GODOT_TARGET=iphone TOOLS=no
+    #- env: GODOT_TARGET=iphone TOOLS=no CACHE_NAME=${GODOT_TARGET}-clang
     #  os: osx
     #  compiler: clang
 

--- a/core/SCsub
+++ b/core/SCsub
@@ -106,5 +106,6 @@ SConscript('helper/SCsub')
 
 # Build it all as a library
 lib = env.Library("core", env.core_sources)
+env.NoCache(lib)
 env.Prepend(LIBS=[lib])
 Export('env')

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -46,4 +46,5 @@ if env.split_drivers:
 else:
     env.add_source_files(env.drivers_sources, "*.cpp")
     lib = env.Library("drivers", env.drivers_sources)
+    env.NoCache(lib)
     env.Prepend(LIBS=[lib])

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -475,6 +475,7 @@ if env['tools']:
     SConscript('plugins/SCsub')
 
     lib = env.Library("editor", env.editor_sources)
+    env.NoCache(lib)
     env.Prepend(LIBS=[lib])
 
     Export('env')

--- a/main/SCsub
+++ b/main/SCsub
@@ -57,5 +57,5 @@ env.Command("#main/app_icon.gen.h", "#main/app_icon.png", make_app_icon)
 SConscript('tests/SCsub')
 
 lib = env.Library("main", env.main_sources)
-
+env.NoCache(lib)
 env.Prepend(LIBS=[lib])

--- a/main/tests/SCsub
+++ b/main/tests/SCsub
@@ -10,5 +10,5 @@ Export('env')
 # SConscript('math/SCsub');
 
 lib = env.Library("tests", env.tests_sources)
-
+env.NoCache(lib)
 env.Prepend(LIBS=[lib])

--- a/methods.py
+++ b/methods.py
@@ -1496,6 +1496,7 @@ def split_lib(self, libname):
         if base != cur_base and len(list) > max_src:
             if num > 0:
                 lib = env.Library(libname + str(num), list)
+                env.NoCache(lib)
                 lib_list.append(lib)
                 list = []
             num = num + 1
@@ -1503,6 +1504,7 @@ def split_lib(self, libname):
         list.append(f)
 
     lib = env.Library(libname + str(num), list)
+    env.NoCache(lib)
     lib_list.append(lib)
 
     if len(lib_list) > 0:
@@ -1510,11 +1512,14 @@ def split_lib(self, libname):
         if os.name == 'posix' and sys.platform == 'msys':
             env.Replace(ARFLAGS=['rcsT'])
             lib = env.Library(libname + "_collated", lib_list)
+            env.NoCache(lib)
             lib_list = [lib]
 
     lib_base = []
     env.add_source_files(lib_base, "*.cpp")
-    lib_list.insert(0, env.Library(libname, lib_base))
+    lib = env.Library(libname, lib_base)
+    env.NoCache(lib)
+    lib_list.insert(0, lib)
 
     env.Prepend(LIBS=lib_list)
 

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -18,5 +18,6 @@ for x in env.module_list:
     SConscript(x + "/SCsub")
 
 lib = env_modules.Library("modules", env.modules_sources)
+env_modules.NoCache(lib)
 
 env.Prepend(LIBS=[lib])

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -69,6 +69,7 @@ if env['builtin_freetype']:
         env.Append(CPPPATH=["#thirdparty/libpng"])
 
     lib = env.Library("freetype_builtin", thirdparty_sources)
+    env.NoCache(lib)
     # Needs to be appended to arrive after libscene in the linker call,
     # but we don't want it to arrive *after* system libs, so manual hack
     # LIBS contains first SCons Library objects ("SCons.Node.FS.File object")

--- a/modules/gdnative/SCsub
+++ b/modules/gdnative/SCsub
@@ -248,4 +248,5 @@ if ARGUMENTS.get('gdnative_wrapper', False):
     if not env.msvc:
         gd_wrapper_env.Append(CCFLAGS=['-fPIC'])
 
-    gd_wrapper_env.Library("#bin/gdnative_wrapper_code", [gensource])
+    lib = gd_wrapper_env.Library("#bin/gdnative_wrapper_code", [gensource])
+    gd_wrapper_env.NoCache(lib)

--- a/modules/recast/SCsub
+++ b/modules/recast/SCsub
@@ -25,6 +25,7 @@ if env['builtin_recast']:
     env.Append(CPPPATH=[thirdparty_dir, thirdparty_dir + "/Include"])
 
     lib = env.Library("recast_builtin", thirdparty_sources)
+    env.NoCache(lib)
     env.Append(LIBS=[lib])
 
 # Godot source files

--- a/modules/svg/SCsub
+++ b/modules/svg/SCsub
@@ -13,6 +13,8 @@ thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 # env.add_source_files(env.modules_sources, thirdparty_sources)
 
 lib = env.Library("svg_builtin", thirdparty_sources)
+env.NoCache(lib)
+
 # Needs to be appended to arrive after libscene in the linker call,
 # but we don't want it to arrive *after* system libs, so manual hack
 # LIBS contains first SCons Library objects ("SCons.Node.FS.File object")

--- a/platform/SCsub
+++ b/platform/SCsub
@@ -25,6 +25,8 @@ f.write(unreg_apis)
 f.close()
 platform_sources.append('register_platform_apis.gen.cpp')
 
-env.Prepend(LIBS=env.Library('platform', platform_sources))
+lib = env.Library('platform', platform_sources)
+env.NoCache(lib)
+env.Prepend(LIBS=lib)
 
 Export('env')

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -144,8 +144,8 @@ manifest = manifest.replace("$$ADD_APPATTRIBUTE_CHUNKS$$", env.android_appattrib
 pp_baseout.write(manifest)
 
 
-env_android.SharedLibrary("#bin/libgodot", [android_objects], SHLIBSUFFIX=env["SHLIBSUFFIX"])
-
+lib = env_android.SharedLibrary("#bin/libgodot", [android_objects], SHLIBSUFFIX=env["SHLIBSUFFIX"])
+env_android.NoCache(lib)
 
 lib_arch_dir = ''
 if env['android_arch'] == 'armv6':

--- a/platform/iphone/SCsub
+++ b/platform/iphone/SCsub
@@ -18,6 +18,7 @@ iphone_lib = [
 
 env_ios = env.Clone()
 ios_lib = env_ios.Library('iphone', iphone_lib)
+env_ios.NoCache(ios_lib)
 
 def combine_libs(target=None, source=None, env=None):
     lib_path = target[0].srcnode().abspath

--- a/platform/osx/SCsub
+++ b/platform/osx/SCsub
@@ -16,7 +16,9 @@ files = [
     'power_osx.cpp',
 ]
 
-binary = env.Program('#bin/godot', files)
+prog = env.Program('#bin/godot', files)
+env.NoCache(prog)
+
 if env["debug_symbols"] == "full" or env["debug_symbols"] == "yes":
-    env.AddPostAction(binary, make_debug)
+    env.AddPostAction(prog, make_debug)
 

--- a/platform/server/SCsub
+++ b/platform/server/SCsub
@@ -7,4 +7,5 @@ common_server = [\
     "os_server.cpp",\
 ]
 
-env.Program('#bin/godot_server', ['godot_server.cpp'] + common_server)
+prog = env.Program('#bin/godot_server', ['godot_server.cpp'] + common_server)
+env.NoCache(prog)

--- a/platform/uwp/SCsub
+++ b/platform/uwp/SCsub
@@ -20,6 +20,7 @@ if "build_angle" in env and env["build_angle"]:
     cmd = env.AlwaysBuild(env.ANGLE('libANGLE.lib', None))
 
 prog = env.Program('#bin/godot', files)
+env.NoCache(prog)
 
 if "build_angle" in env and env["build_angle"]:
     env.Depends(prog, [cmd])

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -28,7 +28,8 @@ obj = env.RES(restarget, 'godot_res.rc')
 
 common_win.append(obj)
 
-binary = env.Program('#bin/godot', ['godot_win.cpp'] + common_win, PROGSUFFIX=env["PROGSUFFIX"])
+prog = env.Program('#bin/godot', ['godot_win.cpp'] + common_win, PROGSUFFIX=env["PROGSUFFIX"])
+env.NoCache(prog)
 
 # Microsoft Visual Studio Project Generation
 if env['vsproj']:
@@ -38,4 +39,4 @@ if env['vsproj']:
 
 if not os.getenv("VCINSTALLDIR"):
     if env["debug_symbols"] == "full" or env["debug_symbols"] == "yes":
-        env.AddPostAction(binary, make_debug_mingw)
+        env.AddPostAction(prog, make_debug_mingw)

--- a/platform/x11/SCsub
+++ b/platform/x11/SCsub
@@ -17,6 +17,8 @@ common_x11 = [
     "power_x11.cpp",
 ]
 
-binary = env.Program('#bin/godot', ['godot_x11.cpp'] + common_x11)
+prog = env.Program('#bin/godot', ['godot_x11.cpp'] + common_x11)
+env.NoCache(prog)
+
 if env["debug_symbols"] == "full" or env["debug_symbols"] == "yes":
-    env.AddPostAction(binary, make_debug)
+    env.AddPostAction(prog, make_debug)

--- a/scene/SCsub
+++ b/scene/SCsub
@@ -31,6 +31,7 @@ SConscript('resources/SCsub')
 
 # Build it all as a library
 lib = env.Library("scene", env.scene_sources)
+env.NoCache(lib)
 env.Prepend(LIBS=[lib])
 
 Export('env')

--- a/servers/SCsub
+++ b/servers/SCsub
@@ -14,5 +14,6 @@ SConscript('visual/SCsub')
 SConscript('audio/SCsub')
 
 lib = env.Library("servers", env.servers_sources)
+env.NoCache(lib)
 
 env.Prepend(LIBS=[lib])


### PR DESCRIPTION
- Fix pruning when the option `progress` is set to 'no'
- Use separate caches for each job (Travis)
- Use separate folders for each brach (AppVeyor)
- Limit the [cache size](https://www.appveyor.com/docs/build-cache/#cache-size-beta) to 1024 MB for AppVeyor (512 MB per branch) which functions as a single cache, because AppVeyor still doesn't support [a separate cache per branch](https://github.com/appveyor/ci/issues/1623).
- Limit the cache size to 1024 MB per job for Travis, giving a total of 9GB (5GB for master branch + 4GB for branch 2.1) that function independently of each other.
- Programs and libraries are not added to the cache, because those are too big and change too often, only intermediate build artifacts are added.
