### PR TITLE
Small corrections to Inspector collapse/expand feature

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1475,7 +1475,6 @@ void EditorNode::_edit_current() {
 	object_menu->set_disabled(true);
 
 	bool capitalize = bool(EDITOR_DEF("interface/editor/capitalize_properties", true));
-	bool expandall = bool(EDITOR_DEF("interface/editor/expand_all_properties", true));
 	bool is_resource = current_obj->is_class("Resource");
 	bool is_node = current_obj->is_class("Node");
 	resource_save_button->set_disabled(!is_resource);
@@ -1545,10 +1544,6 @@ void EditorNode::_edit_current() {
 
 	if (property_editor->is_capitalize_paths_enabled() != capitalize) {
 		property_editor->set_enable_capitalize_paths(capitalize);
-	}
-
-	if (property_editor->is_expand_all_properties_enabled() != expandall) {
-		property_editor->set_use_folding(expandall == false);
 	}
 
 	/* Take care of PLUGIN EDITOR */

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -2665,12 +2665,12 @@ TreeItem *PropertyEditor::get_parent_node(String p_path, HashMap<String, TreeIte
 		item->set_editable(1, false);
 		item->set_selectable(1, subsection_selectable);
 
-		if (use_folding) {
+		if (use_folding || folding_behaviour != FB_UNDEFINED) { // Even if you disabled folding (expand all by default), you still can collapse all manually.
 			if (!obj->editor_is_section_unfolded(p_path)) {
 				updating_folding = true;
 				if (folding_behaviour == FB_COLLAPSEALL)
 					item->set_collapsed(true);
-				else if (folding_behaviour == FB_EXPANDALL)
+				else if (folding_behaviour == FB_EXPANDALL || is_expandall_enabled)
 					item->set_collapsed(false);
 				else
 					item->set_collapsed(true);
@@ -4310,6 +4310,7 @@ PropertyEditor::PropertyEditor() {
 	property_selectable = false;
 	show_type_icons = false; // maybe one day will return.
 	folding_behaviour = FB_UNDEFINED;
+	is_expandall_enabled = bool(EDITOR_DEF("interface/editor/expand_all_properties", true));
 }
 
 PropertyEditor::~PropertyEditor() {

--- a/editor/property_editor.h
+++ b/editor/property_editor.h
@@ -203,6 +203,7 @@ class PropertyEditor : public Control {
 	bool hide_script;
 	bool use_folding;
 	bool property_selectable;
+	bool is_expandall_enabled;
 
 	bool updating_folding;
 


### PR DESCRIPTION
Small fixes to #13233:
a) Manual "Collapse all" command was ignored if "expand all" was enabled in editor settings by default.
b) Collapse/expand state was manually resetted on field change in property editor.