### PR TITLE
Mono: Added implicit vector conversions between Vector2 and Vector3

### DIFF
--- a/modules/mono/glue/cs_files/Vector2.cs
+++ b/modules/mono/glue/cs_files/Vector2.cs
@@ -336,6 +336,16 @@ namespace Godot
             return x == other.x && y == other.y;
         }
 
+        public static implicit operator Vector2 (Vector3 vec)
+        {
+            return new Vector2(vec.x, vec.y);
+        }
+
+        public static implicit operator Vector3 (Vector2 vec)
+        {
+            return new Vector3(vec.x, vec.y, 0.0f);
+        }
+
         public override int GetHashCode()
         {
             return y.GetHashCode() ^ x.GetHashCode();


### PR DESCRIPTION
@neikeq This is a very basic addition. It simply makes it so you can directly assign a Vector2 to a Vector3 and vice versa, in C#.