### PR TITLE
TextEdit code folding with comments

### DIFF
--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -430,7 +430,7 @@ public:
 	void fold_all_lines();
 	void unhide_all_lines();
 	int num_lines_from(int p_line_from, int unhidden_amount) const;
-	int get_whitespace_level(int p_line) const;
+	int get_indent_level(int p_line, bool p_ignore_comments = true) const;
 	bool can_fold(int p_line) const;
 	bool is_folded(int p_line) const;
 	void fold_line(int p_line);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -158,7 +158,7 @@ class TextEdit : public Control {
 		void set_font(const Ref<Font> &p_font);
 		void set_color_regions(const Vector<ColorRegion> *p_regions) { color_regions = p_regions; }
 		int get_line_width(int p_line) const;
-		int get_max_width() const;
+		int get_max_width(bool p_exclude_hidden = false) const;
 		const Map<int, ColorRegionInfo> &get_color_region_info(int p_line);
 		void set(int p_line, const String &p_text);
 		void set_marked(int p_line, bool p_marked) { text[p_line].marked = p_marked; }


### PR DESCRIPTION
Fixes #13107
allows folding comment regions (non-indented only)
can fold over lines that start with # or //, as long there is still an indentation
also fixes horizontal scrolling over hidden lines

