### PR TITLE
Add target helper functions and refactor (master)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -121,6 +121,10 @@ env_base.__class__.add_source_files = methods.add_source_files
 env_base.__class__.use_windows_spawn_fix = methods.use_windows_spawn_fix
 env_base.__class__.split_lib = methods.split_lib
 
+env_base.__class__.add_shared_library = methods.add_shared_library
+env_base.__class__.add_library = methods.add_library
+env_base.__class__.add_program = methods.add_program
+
 env_base["x86_libtheora_opt_gcc"] = False
 env_base["x86_libtheora_opt_vc"] = False
 

--- a/core/SCsub
+++ b/core/SCsub
@@ -105,7 +105,6 @@ SConscript('helper/SCsub')
 
 
 # Build it all as a library
-lib = env.Library("core", env.core_sources)
-env.NoCache(lib)
+lib = env.add_library("core", env.core_sources)
 env.Prepend(LIBS=[lib])
 Export('env')

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -45,6 +45,5 @@ if env.split_drivers:
     env.split_lib("drivers")
 else:
     env.add_source_files(env.drivers_sources, "*.cpp")
-    lib = env.Library("drivers", env.drivers_sources)
-    env.NoCache(lib)
+    lib = env.add_library("drivers", env.drivers_sources)
     env.Prepend(LIBS=[lib])

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -474,8 +474,7 @@ if env['tools']:
     SConscript('import/SCsub')
     SConscript('plugins/SCsub')
 
-    lib = env.Library("editor", env.editor_sources)
-    env.NoCache(lib)
+    lib = env.add_library("editor", env.editor_sources)
     env.Prepend(LIBS=[lib])
 
     Export('env')

--- a/main/SCsub
+++ b/main/SCsub
@@ -56,6 +56,5 @@ env.Command("#main/app_icon.gen.h", "#main/app_icon.png", make_app_icon)
 
 SConscript('tests/SCsub')
 
-lib = env.Library("main", env.main_sources)
-env.NoCache(lib)
+lib = env.add_library("main", env.main_sources)
 env.Prepend(LIBS=[lib])

--- a/main/tests/SCsub
+++ b/main/tests/SCsub
@@ -9,6 +9,5 @@ Export('env')
 
 # SConscript('math/SCsub');
 
-lib = env.Library("tests", env.tests_sources)
-env.NoCache(lib)
+lib = env.add_library("tests", env.tests_sources)
 env.Prepend(LIBS=[lib])

--- a/methods.py
+++ b/methods.py
@@ -1495,30 +1495,26 @@ def split_lib(self, libname):
         base = string.join(fname.split("/")[:2], "/")
         if base != cur_base and len(list) > max_src:
             if num > 0:
-                lib = env.Library(libname + str(num), list)
-                env.NoCache(lib)
+                lib = env.add_library(libname + str(num), list)
                 lib_list.append(lib)
                 list = []
             num = num + 1
         cur_base = base
         list.append(f)
 
-    lib = env.Library(libname + str(num), list)
-    env.NoCache(lib)
+    lib = env.add_library(libname + str(num), list)
     lib_list.append(lib)
 
     if len(lib_list) > 0:
         import os, sys
         if os.name == 'posix' and sys.platform == 'msys':
             env.Replace(ARFLAGS=['rcsT'])
-            lib = env.Library(libname + "_collated", lib_list)
-            env.NoCache(lib)
+            lib = env.add_library(libname + "_collated", lib_list)
             lib_list = [lib]
 
     lib_base = []
     env.add_source_files(lib_base, "*.cpp")
-    lib = env.Library(libname, lib_base)
-    env.NoCache(lib)
+    lib = env.add_library(libname, lib_base)
     lib_list.insert(0, lib)
 
     env.Prepend(LIBS=lib_list)
@@ -1757,3 +1753,18 @@ def precious_program(env, program, sources, **args):
     program = env.ProgramOriginal(program, sources, **args)
     env.Precious(program)
     return program
+
+def add_shared_library(env, name, sources, **args):
+	library = env.SharedLibrary(name, sources, **args)
+	env.NoCache(library)
+	return library
+
+def add_library(env, name, sources, **args):
+	library = env.Library(name, sources, **args)
+	env.NoCache(library)
+	return library
+
+def add_program(env, name, sources, **args):
+	program = env.Program(name, sources, **args)
+	env.NoCache(program)
+	return program

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -17,7 +17,6 @@ for x in env.module_list:
     env_modules.Append(CPPFLAGS=["-DMODULE_" + x.upper() + "_ENABLED"])
     SConscript(x + "/SCsub")
 
-lib = env_modules.Library("modules", env.modules_sources)
-env_modules.NoCache(lib)
+lib = env_modules.add_library("modules", env.modules_sources)
 
 env.Prepend(LIBS=[lib])

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -68,8 +68,7 @@ if env['builtin_freetype']:
     if env['builtin_libpng']:
         env.Append(CPPPATH=["#thirdparty/libpng"])
 
-    lib = env.Library("freetype_builtin", thirdparty_sources)
-    env.NoCache(lib)
+    lib = env.add_library("freetype_builtin", thirdparty_sources)
     # Needs to be appended to arrive after libscene in the linker call,
     # but we don't want it to arrive *after* system libs, so manual hack
     # LIBS contains first SCons Library objects ("SCons.Node.FS.File object")

--- a/modules/gdnative/SCsub
+++ b/modules/gdnative/SCsub
@@ -248,5 +248,4 @@ if ARGUMENTS.get('gdnative_wrapper', False):
     if not env.msvc:
         gd_wrapper_env.Append(CCFLAGS=['-fPIC'])
 
-    lib = gd_wrapper_env.Library("#bin/gdnative_wrapper_code", [gensource])
-    gd_wrapper_env.NoCache(lib)
+    lib = gd_wrapper_env.add_library("#bin/gdnative_wrapper_code", [gensource])

--- a/modules/recast/SCsub
+++ b/modules/recast/SCsub
@@ -24,8 +24,7 @@ if env['builtin_recast']:
 
     env.Append(CPPPATH=[thirdparty_dir, thirdparty_dir + "/Include"])
 
-    lib = env.Library("recast_builtin", thirdparty_sources)
-    env.NoCache(lib)
+    lib = env.add_library("recast_builtin", thirdparty_sources)
     env.Append(LIBS=[lib])
 
 # Godot source files

--- a/modules/svg/SCsub
+++ b/modules/svg/SCsub
@@ -12,8 +12,7 @@ thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
 # env.add_source_files(env.modules_sources, thirdparty_sources)
 
-lib = env.Library("svg_builtin", thirdparty_sources)
-env.NoCache(lib)
+lib = env.add_library("svg_builtin", thirdparty_sources)
 
 # Needs to be appended to arrive after libscene in the linker call,
 # but we don't want it to arrive *after* system libs, so manual hack

--- a/platform/SCsub
+++ b/platform/SCsub
@@ -25,8 +25,7 @@ f.write(unreg_apis)
 f.close()
 platform_sources.append('register_platform_apis.gen.cpp')
 
-lib = env.Library('platform', platform_sources)
-env.NoCache(lib)
+lib = env.add_library('platform', platform_sources)
 env.Prepend(LIBS=lib)
 
 Export('env')

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -144,8 +144,7 @@ manifest = manifest.replace("$$ADD_APPATTRIBUTE_CHUNKS$$", env.android_appattrib
 pp_baseout.write(manifest)
 
 
-lib = env_android.SharedLibrary("#bin/libgodot", [android_objects], SHLIBSUFFIX=env["SHLIBSUFFIX"])
-env_android.NoCache(lib)
+lib = env_android.add_shared_library("#bin/libgodot", [android_objects], SHLIBSUFFIX=env["SHLIBSUFFIX"])
 
 lib_arch_dir = ''
 if env['android_arch'] == 'armv6':

--- a/platform/haiku/SCsub
+++ b/platform/haiku/SCsub
@@ -12,7 +12,7 @@ common_haiku = [
     'audio_driver_media_kit.cpp'
 ]
 
-target = env.Program(
+target = env.add_program(
     '#bin/godot',
     ['godot_haiku.cpp'] + common_haiku
 )

--- a/platform/iphone/SCsub
+++ b/platform/iphone/SCsub
@@ -17,8 +17,7 @@ iphone_lib = [
 ]
 
 env_ios = env.Clone()
-ios_lib = env_ios.Library('iphone', iphone_lib)
-env_ios.NoCache(ios_lib)
+ios_lib = env_ios.add_library('iphone', iphone_lib)
 
 def combine_libs(target=None, source=None, env=None):
     lib_path = target[0].srcnode().abspath

--- a/platform/javascript/SCsub
+++ b/platform/javascript/SCsub
@@ -22,7 +22,7 @@ for x in javascript_files:
 env.Append(LINKFLAGS=["-s", "EXPORTED_FUNCTIONS=\"['_main','_main_after_fs_sync','_send_notification']\""])
 
 target_dir = env.Dir("#bin")
-build = env.Program(['#bin/godot', target_dir.File('godot' + env['PROGSUFFIX'] + '.wasm')], javascript_objects, PROGSUFFIX=env['PROGSUFFIX'] + '.js');
+build = env.add_program(['#bin/godot', target_dir.File('godot' + env['PROGSUFFIX'] + '.wasm')], javascript_objects, PROGSUFFIX=env['PROGSUFFIX'] + '.js');
 
 js_libraries = []
 js_libraries.append(env.File('http_request.js'))

--- a/platform/osx/SCsub
+++ b/platform/osx/SCsub
@@ -16,8 +16,7 @@ files = [
     'power_osx.cpp',
 ]
 
-prog = env.Program('#bin/godot', files)
-env.NoCache(prog)
+prog = env.add_program('#bin/godot', files)
 
 if env["debug_symbols"] == "full" or env["debug_symbols"] == "yes":
     env.AddPostAction(prog, make_debug)

--- a/platform/server/SCsub
+++ b/platform/server/SCsub
@@ -7,5 +7,4 @@ common_server = [\
     "os_server.cpp",\
 ]
 
-prog = env.Program('#bin/godot_server', ['godot_server.cpp'] + common_server)
-env.NoCache(prog)
+prog = env.add_program('#bin/godot_server', ['godot_server.cpp'] + common_server)

--- a/platform/uwp/SCsub
+++ b/platform/uwp/SCsub
@@ -19,8 +19,7 @@ files = [
 if "build_angle" in env and env["build_angle"]:
     cmd = env.AlwaysBuild(env.ANGLE('libANGLE.lib', None))
 
-prog = env.Program('#bin/godot', files)
-env.NoCache(prog)
+prog = env.add_program('#bin/godot', files)
 
 if "build_angle" in env and env["build_angle"]:
     env.Depends(prog, [cmd])

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -28,8 +28,7 @@ obj = env.RES(restarget, 'godot_res.rc')
 
 common_win.append(obj)
 
-prog = env.Program('#bin/godot', ['godot_win.cpp'] + common_win, PROGSUFFIX=env["PROGSUFFIX"])
-env.NoCache(prog)
+prog = env.add_program('#bin/godot', ['godot_win.cpp'] + common_win, PROGSUFFIX=env["PROGSUFFIX"])
 
 # Microsoft Visual Studio Project Generation
 if env['vsproj']:

--- a/platform/x11/SCsub
+++ b/platform/x11/SCsub
@@ -17,8 +17,7 @@ common_x11 = [
     "power_x11.cpp",
 ]
 
-prog = env.Program('#bin/godot', ['godot_x11.cpp'] + common_x11)
-env.NoCache(prog)
+prog = env.add_program('#bin/godot', ['godot_x11.cpp'] + common_x11)
 
 if env["debug_symbols"] == "full" or env["debug_symbols"] == "yes":
     env.AddPostAction(prog, make_debug)

--- a/scene/SCsub
+++ b/scene/SCsub
@@ -30,8 +30,7 @@ SConscript('resources/SCsub')
 
 
 # Build it all as a library
-lib = env.Library("scene", env.scene_sources)
-env.NoCache(lib)
+lib = env.add_library("scene", env.scene_sources)
 env.Prepend(LIBS=[lib])
 
 Export('env')

--- a/servers/SCsub
+++ b/servers/SCsub
@@ -13,7 +13,6 @@ SConscript('physics_2d/SCsub')
 SConscript('visual/SCsub')
 SConscript('audio/SCsub')
 
-lib = env.Library("servers", env.servers_sources)
-env.NoCache(lib)
+lib = env.add_library("servers", env.servers_sources)
 
 env.Prepend(LIBS=[lib])


### PR DESCRIPTION
Called instead of `env.Program()`, `env.Library()` and `env.SharedLibrary()` to tell **SCons** not to cache those targets.