### PR TITLE
Add target helper functions and refactor (2.1)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -115,6 +115,10 @@ env_base.__class__.add_source_files = methods.add_source_files
 env_base.__class__.use_windows_spawn_fix = methods.use_windows_spawn_fix
 env_base.__class__.split_lib = methods.split_lib
 
+env_base.__class__.add_shared_library = methods.add_shared_library
+env_base.__class__.add_library = methods.add_library
+env_base.__class__.add_program = methods.add_program
+
 env_base["x86_libtheora_opt_gcc"] = False
 env_base["x86_libtheora_opt_vc"] = False
 

--- a/core/SCsub
+++ b/core/SCsub
@@ -101,8 +101,7 @@ SConscript('helper/SCsub')
 
 
 # Build it all as a library
-lib = env.Library("core", env.core_sources)
-env.NoCache(lib)
+lib = env.add_library("core", env.core_sources)
 env.Prepend(LIBS=[lib])
 
 Export('env')

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -38,6 +38,5 @@ if env.split_drivers:
     env.split_lib("drivers")
 else:
     env.add_source_files(env.drivers_sources, "*.cpp")
-    lib = env.Library("drivers", env.drivers_sources)
-    env.NoCache(lib)
+    lib = env.add_library("drivers", env.drivers_sources)
     env.Prepend(LIBS=[lib])

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -211,8 +211,7 @@ if (env["tools"] == "yes"):
     SConscript('io_plugins/SCsub')
     SConscript('plugins/SCsub')
 
-    lib = env.Library("editor", env.editor_sources)
-    env.NoCache(lib)
+    lib = env.add_library("editor", env.editor_sources)
     env.Prepend(LIBS=[lib])
 
     Export('env')

--- a/main/SCsub
+++ b/main/SCsub
@@ -9,7 +9,6 @@ Export('env')
 
 SConscript('tests/SCsub')
 
-lib = env.Library("main", env.main_sources)
-env.NoCache(lib)
+lib = env.add_library("main", env.main_sources)
 
 env.Prepend(LIBS=[lib])

--- a/main/tests/SCsub
+++ b/main/tests/SCsub
@@ -9,7 +9,6 @@ Export('env')
 
 # SConscript('math/SCsub');
 
-lib = env.Library("tests", env.tests_sources)
-env.NoCache(lib)
+lib = env.add_library("tests", env.tests_sources)
 
 env.Prepend(LIBS=[lib])

--- a/methods.py
+++ b/methods.py
@@ -1417,30 +1417,26 @@ def split_lib(self, libname):
         base = string.join(fname.split("/")[:2], "/")
         if base != cur_base and len(list) > max_src:
             if num > 0:
-                lib = env.Library(libname + str(num), list)
-                env.NoCache(lib)
+                lib = env.add_library(libname + str(num), list)
                 lib_list.append(lib)
                 list = []
             num = num + 1
         cur_base = base
         list.append(f)
 
-    lib = env.Library(libname + str(num), list)
-    env.NoCache(lib)
+    lib = env.add_library(libname + str(num), list)
     lib_list.append(lib)
 
     if len(lib_list) > 0:
         import os, sys
         if os.name == 'posix' and sys.platform == 'msys':
             env.Replace(ARFLAGS=['rcsT'])
-            lib = env.Library(libname + "_collated", lib_list)
-            env.NoCache(lib)
+            lib = env.add_library(libname + "_collated", lib_list)
             lib_list = [lib]
 
     lib_base = []
     env.add_source_files(lib_base, "*.cpp")
-    lib = env.Library(libname, lib_base)
-    env.NoCache(lib)
+    lib = env.add_library(libname, lib_base)
     lib_list.insert(0, lib)
 
     env.Prepend(LIBS=lib_list)
@@ -1659,3 +1655,18 @@ def precious_program(env, program, sources, **args):
     program = env.ProgramOriginal(program, sources, **args)
     env.Precious(program)
     return program
+
+def add_shared_library(env, name, sources, **args):
+	library = env.SharedLibrary(name, sources, **args)
+	env.NoCache(library)
+	return library
+
+def add_library(env, name, sources, **args):
+	library = env.Library(name, sources, **args)
+	env.NoCache(library)
+	return library
+
+def add_program(env, name, sources, **args):
+	program = env.Program(name, sources, **args)
+	env.NoCache(program)
+	return program

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -18,7 +18,6 @@ for x in env.module_list:
     env_modules.Append(CPPFLAGS=["-DMODULE_" + x.upper() + "_ENABLED"])
     SConscript(x + "/SCsub")
 
-lib = env_modules.Library("modules", env.modules_sources)
-env.NoCache(lib)
+lib = env_modules.add_library("modules", env.modules_sources)
 
 env.Prepend(LIBS=[lib])

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -68,8 +68,7 @@ if (env['builtin_freetype'] != 'no'):
     if (env['builtin_libpng'] != 'no'):
         env.Append(CPPPATH=["#thirdparty/libpng"])
 
-    lib = env.Library("freetype_builtin", thirdparty_sources)
-    env.NoCache(lib)
+    lib = env.add_library("freetype_builtin", thirdparty_sources)
     # Needs to be appended to arrive after libscene in the linker call,
     # but we don't want it to arrive *after* system libs, so manual hack
     # LIBS contains first SCons Library objects ("SCons.Node.FS.File object")

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -143,8 +143,7 @@ manifest = manifest.replace("$$ADD_APPATTRIBUTE_CHUNKS$$", env.android_appattrib
 pp_baseout.write(manifest)
 
 
-lib = env_android.SharedLibrary("#bin/libgodot", [android_objects], SHLIBSUFFIX=env["SHLIBSUFFIX"])
-env_android.NoCache(lib)
+lib = env_android.add_shared_library("#bin/libgodot", [android_objects], SHLIBSUFFIX=env["SHLIBSUFFIX"])
 
 lib_arch_dir = ''
 if env['android_arch'] == 'armv6':

--- a/platform/bb10/SCsub
+++ b/platform/bb10/SCsub
@@ -20,5 +20,4 @@ if env['bb10_lgles_override'] == "yes":
 
 
 prog = None
-prog = env_bps.Program('#bin/godot', bb10_lib)
-env_bps.NoCache(prog)
+prog = env_bps.add_program('#bin/godot', bb10_lib)

--- a/platform/haiku/SCsub
+++ b/platform/haiku/SCsub
@@ -12,7 +12,7 @@ common_haiku = [
     'audio_driver_media_kit.cpp'
 ]
 
-target = env.Program(
+target = env.add_program(
     '#bin/godot',
     ['godot_haiku.cpp'] + common_haiku
 )

--- a/platform/iphone/SCsub
+++ b/platform/iphone/SCsub
@@ -20,8 +20,7 @@ iphone_lib = [
 
 # env.Depends('#core/math/vector3.h', 'vector3_psp.h')
 
-#iphone_lib = env.Library('iphone', iphone_lib)
-#env.NoCache(iphone_lib)
+#iphone_lib = env.add_library('iphone', iphone_lib)
 
 env_ios = env.Clone()
 
@@ -33,7 +32,6 @@ if env['ios_gles22_override'] == "yes":
 obj = env_ios.Object('godot_iphone.cpp')
 
 prog = None
-prog = env_ios.Program('#bin/godot', [obj] + iphone_lib)
-env_ios.NoCache(prog)
+prog = env_ios.add_program('#bin/godot', [obj] + iphone_lib)
 action = "$IPHONEPATH/usr/bin/dsymutil " + File(prog)[0].path + " -o " + File(prog)[0].path + ".dSYM"
 env.AddPostAction(prog, action)

--- a/platform/javascript/SCsub
+++ b/platform/javascript/SCsub
@@ -23,7 +23,6 @@ env.Append(LINKFLAGS=["-s", "EXPORTED_FUNCTIONS=\"['_main','_audio_server_mix_fu
 
 prog = None
 
-# env_javascript.SharedLibrary("#platform/javascript/libgodot_javascript.so",[javascript_objects])
+# env_javascript.add_shared_library("#platform/javascript/libgodot_javascript.so",[javascript_objects])
 
-prog = env.Program('#bin/godot', javascript_objects, PROGSUFFIX=env["PROGSUFFIX"] + ".html")
-env.NoCache(prog)
+prog = env.add_program('#bin/godot', javascript_objects, PROGSUFFIX=env["PROGSUFFIX"] + ".html")

--- a/platform/osx/SCsub
+++ b/platform/osx/SCsub
@@ -13,8 +13,7 @@ files = [
     'joystick_osx.cpp',
 ]
 
-prog = env.Program('#bin/godot', files)
-env.NoCache(prog)
+prog = env.add_program('#bin/godot', files)
 
 if (env['target'] == "debug" or env['target'] == "release_debug"):
     # Build the .dSYM file for atos

--- a/platform/server/SCsub
+++ b/platform/server/SCsub
@@ -7,5 +7,4 @@ common_server = [\
     "os_server.cpp",\
 ]
 
-prog = env.Program('#bin/godot_server', ['godot_server.cpp'] + common_server)
-env.NoCache(prog)
+prog = env.add_program('#bin/godot_server', ['godot_server.cpp'] + common_server)

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -21,8 +21,7 @@ obj = env.RES(restarget, 'godot_res.rc')
 
 common_win.append(obj)
 
-prog = env.Program('#bin/godot', ['godot_win.cpp'] + common_win, PROGSUFFIX=env["PROGSUFFIX"])
-env.NoCache(prog)
+prog = env.add_program('#bin/godot', ['godot_win.cpp'] + common_win, PROGSUFFIX=env["PROGSUFFIX"])
 
 # Microsoft Visual Studio Project Generation
 if (env['vsproj']) == "yes":

--- a/platform/winrt/SCsub
+++ b/platform/winrt/SCsub
@@ -18,8 +18,7 @@ files = [
 if "build_angle" in env and env["build_angle"]:
 	cmd = env.AlwaysBuild(env.ANGLE('libANGLE.lib', None))
 
-prog = env.Program('#bin/godot', files)
-env.NoCache(prog)
+prog = env.add_program('#bin/godot', files)
 
 if "build_angle" in env and env["build_angle"]:
 	env.Depends(prog, [cmd])

--- a/platform/x11/SCsub
+++ b/platform/x11/SCsub
@@ -11,5 +11,4 @@ common_x11 = [
     "joystick_linux.cpp",
 ]
 
-prog = env.Program('#bin/godot', ['godot_x11.cpp'] + common_x11)
-env.NoCache(prog)
+prog = env.add_program('#bin/godot', ['godot_x11.cpp'] + common_x11)

--- a/scene/SCsub
+++ b/scene/SCsub
@@ -31,8 +31,7 @@ SConscript('io/SCsub')
 
 
 # Build it all as a library
-lib = env.Library("scene", env.scene_sources)
-env.NoCache(lib)
+lib = env.add_library("scene", env.scene_sources)
 env.Prepend(LIBS=[lib])
 
 Export('env')

--- a/servers/SCsub
+++ b/servers/SCsub
@@ -14,7 +14,6 @@ SConscript('audio/SCsub')
 SConscript('spatial_sound/SCsub')
 SConscript('spatial_sound_2d/SCsub')
 
-lib = env.Library("servers", env.servers_sources)
-env.NoCache(lib)
+lib = env.add_library("servers", env.servers_sources)
 
 env.Prepend(LIBS=[lib])


### PR DESCRIPTION
Called instead of `env.Program()`, `env.Library()` and `env.SharedLibrary()` to tell **SCons** not to cache those targets.