### PR TITLE
Needed a broader search path flag

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1597,7 +1597,7 @@ Error OS_Windows::open_dynamic_library(const String p_path, void *&p_library_han
 		cookie = AddDllDirectory(p_path.get_base_dir().c_str());
 	}
 
-	p_library_handle = (void *)LoadLibraryExW(p_path.c_str(),NULL,p_also_set_library_path ? LOAD_LIBRARY_SEARCH_USER_DIRS : 0);
+	p_library_handle = (void *)LoadLibraryExW(p_path.c_str(), NULL, p_also_set_library_path ? LOAD_LIBRARY_SEARCH_DEFAULT_DIRS : 0);
 
 	if (p_also_set_library_path) {
 		RemoveDllDirectory(cookie);


### PR DESCRIPTION
This seems to work slightly better, tested with godot_openvr.dll, now loads the dependent openvr_api.dll from the same folder as godot_openvr.dll