### PR TITLE
Make VisualScriptFunctionState instantiable

### DIFF
--- a/modules/visual_script/register_types.cpp
+++ b/modules/visual_script/register_types.cpp
@@ -53,7 +53,7 @@ void register_visual_script_types() {
 
 	ClassDB::register_class<VisualScript>();
 	ClassDB::register_virtual_class<VisualScriptNode>();
-	ClassDB::register_virtual_class<VisualScriptFunctionState>();
+	ClassDB::register_class<VisualScriptFunctionState>();
 	ClassDB::register_class<VisualScriptFunction>();
 	ClassDB::register_class<VisualScriptOperator>();
 	ClassDB::register_class<VisualScriptVariableSet>();


### PR DESCRIPTION
As far as I can tell, right now it is impossible to define VisualScript custom nodes that yield, since there is no way to create the required function state from plugins. 

All other required methods and enumerations are already exported, so it seems sensible to make `VisualScriptFunctionState` available as well.
