### PR TITLE
Several TileMap Fixes

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -4753,9 +4753,9 @@ VSplitContainer *SpatialEditor::get_shader_split() {
 	return shader_split;
 }
 
-HBoxContainer *SpatialEditor::get_palette_split() {
+HSplitContainer *SpatialEditor::get_palette_split() {
 
-	return palette_split_container;
+	return palette_split;
 }
 
 void SpatialEditor::_request_gizmo(Object *p_obj) {
@@ -5045,10 +5045,6 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	palette_split = memnew(HSplitContainer);
 	palette_split->set_v_size_flags(SIZE_EXPAND_FILL);
 	vbc->add_child(palette_split);
-
-	palette_split_container = memnew(HBoxContainer);
-	palette_split_container->set_v_size_flags(SIZE_EXPAND_FILL);
-	palette_split->add_child(palette_split_container);
 
 	shader_split = memnew(VSplitContainer);
 	shader_split->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -413,7 +413,6 @@ private:
 	SpatialEditorViewport *viewports[VIEWPORTS_COUNT];
 	VSplitContainer *shader_split;
 	HSplitContainer *palette_split;
-	HBoxContainer *palette_split_container;
 
 	/////
 
@@ -608,7 +607,7 @@ public:
 	void add_control_to_menu_panel(Control *p_control);
 
 	VSplitContainer *get_shader_split();
-	HBoxContainer *get_palette_split();
+	HSplitContainer *get_palette_split();
 
 	Spatial *get_selected() { return selected; }
 

--- a/editor/plugins/tile_map_editor_plugin.h
+++ b/editor/plugins/tile_map_editor_plugin.h
@@ -167,7 +167,7 @@ class TileMapEditor : public VBoxContainer {
 	void _update_palette();
 	void _menu_option(int p_option);
 
-	void _set_cell(const Point2i &p_pos, int p_value, bool p_flip_h = false, bool p_flip_v = false, bool p_transpose = false, bool p_with_undo = false);
+	void _set_cell(const Point2i &p_pos, int p_value, bool p_flip_h = false, bool p_flip_v = false, bool p_transpose = false);
 
 	void _canvas_mouse_enter();
 	void _canvas_mouse_exit();

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -1015,21 +1015,47 @@ void AutotileEditor::_on_tool_clicked(int p_tool) {
 		tile_set->autotile_clear_bitmask_map(get_current_tile());
 		workspace->update();
 	} else if (p_tool == SHAPE_DELETE) {
-		if (!edited_collision_shape.is_null()) {
-			Vector<TileSet::ShapeData> sd = tile_set->tile_get_shapes(get_current_tile());
-			int index;
-			for (int i = 0; i < sd.size(); i++) {
-				if (sd[i].shape == edited_collision_shape) {
-					index = i;
-					break;
-				}
-			}
-			if (index >= 0) {
-				sd.remove(index);
-				tile_set->tile_set_shapes(get_current_tile(), sd);
-				edited_collision_shape.unref();
-				current_shape.resize(0);
-				workspace->update();
+		if (creating_shape) {
+			creating_shape = false;
+			current_shape.resize(0);
+			workspace->update();
+		} else {
+			switch (edit_mode) {
+				case EDITMODE_COLLISION: {
+					if (!edited_collision_shape.is_null()) {
+						Vector<TileSet::ShapeData> sd = tile_set->tile_get_shapes(get_current_tile());
+						int index;
+						for (int i = 0; i < sd.size(); i++) {
+							if (sd[i].shape == edited_collision_shape) {
+								index = i;
+								break;
+							}
+						}
+						if (index >= 0) {
+							sd.remove(index);
+							tile_set->tile_set_shapes(get_current_tile(), sd);
+							edited_collision_shape = Ref<ConcavePolygonShape2D>();
+							current_shape.resize(0);
+							workspace->update();
+						}
+					}
+				} break;
+				case EDITMODE_NAVIGATION: {
+					if (!edited_navigation_shape.is_null()) {
+						tile_set->autotile_set_navigation_polygon(get_current_tile(), Ref<NavigationPolygon>(), edited_shape_coord);
+						edited_navigation_shape = Ref<NavigationPolygon>();
+						current_shape.resize(0);
+						workspace->update();
+					}
+				} break;
+				case EDITMODE_OCCLUSION: {
+					if (!edited_occlusion_shape.is_null()) {
+						tile_set->autotile_set_light_occluder(get_current_tile(), Ref<OccluderPolygon2D>(), edited_shape_coord);
+						edited_occlusion_shape = Ref<OccluderPolygon2D>();
+						current_shape.resize(0);
+						workspace->update();
+					}
+				} break;
 			}
 		}
 	} else if (p_tool == ZOOM_OUT) {

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -241,8 +241,8 @@ public:
 	bool is_cell_x_flipped(int p_x, int p_y) const;
 	bool is_cell_y_flipped(int p_x, int p_y) const;
 	bool is_cell_transposed(int p_x, int p_y) const;
-	int get_cell_autotile_coord_x(int p_x, int p_y) const;
-	int get_cell_autotile_coord_y(int p_x, int p_y) const;
+	void set_cell_autotile_coord(int p_x, int p_y, const Vector2 &p_coord);
+	Vector2 get_cell_autotile_coord(int p_x, int p_y) const;
 
 	void set_cellv(const Vector2 &p_pos, int p_tile, bool p_flip_x = false, bool p_flip_y = false, bool p_transpose = false);
 	int get_cellv(const Vector2 &p_pos) const;


### PR DESCRIPTION
- Reimplementing Undo/Redo to take auto-tiling in account
- Fix autotiling for Rect Line and Fill tools. Fixes #13224
- Prevent crash when pressing "Delete" Button while editing a collision shape. Fixes #13291 
- Allow to delete Navigation and Occlusion shapes with the "Delete" Button. Fixes #13411 
- Revert changes done to Spatial Editor side panel (how could i mistake spatial with canvas editor? :cry: ). Fixes #13197 