### PR TITLE
Connect signal for VisualScript "Yield Signal" using oneshot mode

### DIFF
--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -2289,7 +2289,7 @@ void VisualScriptFunctionState::connect_to_signal(Object *p_obj, const String &p
 		binds.push_back(p_binds[i]);
 	}
 	binds.push_back(Ref<VisualScriptFunctionState>(this)); //add myself on the back to avoid dying from unreferencing
-	p_obj->connect(p_signal, this, "_signal_callback", binds);
+	p_obj->connect(p_signal, this, "_signal_callback", binds, CONNECT_ONESHOT);
 }
 
 bool VisualScriptFunctionState::is_valid() const {


### PR DESCRIPTION
Since the first call to a `VisualScriptFunctionState` invalidates the state, any further call results in errors.
Currently, emitting a signal multiple times results in warnings starting with the second invocation if a "Yield Signal" node makes use of the signal.

This can be seen in the attached example project:  [VsYieldErrors.zip](https://github.com/godotengine/godot/files/1520350/VsYieldErrors.zip)

To reproduce, run the `main.tscn` scene, press the `Start` button and then the `Inc!` button several times. Starting with the second click, the debugger shows an error message "Condition 'function == StringName()' is true. returned Variant()". This error is caused by the "pressed" signal of the `Inc!` button being called on the invalid `VisualScriptFunctionState` objects from previous yields.
