### PR TITLE
Changed EditorAbout's TextEdits to RichTextLabels

### DIFF
--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -44,8 +44,8 @@ void EditorAbout::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 
 			Ref<Font> font = EditorNode::get_singleton()->get_gui_base()->get_font("source", "EditorFonts");
-			_tpl_text->add_font_override("font", font);
-			_license_text->add_font_override("font", font);
+			_tpl_text->add_font_override("normal_font", font);
+			_license_text->add_font_override("normal_font", font);
 		} break;
 	}
 }
@@ -53,7 +53,6 @@ void EditorAbout::_notification(int p_what) {
 void EditorAbout::_license_tree_selected() {
 
 	TreeItem *selected = _tpl_tree->get_selected();
-	_tpl_text->select(0, 0, 0, 0);
 	_tpl_text->set_text(selected->get_metadata(0));
 }
 
@@ -165,12 +164,10 @@ EditorAbout::EditorAbout() {
 
 	// License
 
-	_license_text = memnew(TextEdit);
+	_license_text = memnew(RichTextLabel);
 	_license_text->set_name(TTR("License"));
 	_license_text->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	_license_text->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	_license_text->set_wrap(true);
-	_license_text->set_readonly(true);
 	_license_text->set_text(String::utf8(about_license));
 	tc->add_child(_license_text);
 
@@ -239,11 +236,9 @@ EditorAbout::EditorAbout() {
 	tpl_ti_all->set_metadata(0, long_text);
 	tpl_hbc->add_child(_tpl_tree);
 
-	_tpl_text = memnew(TextEdit);
+	_tpl_text = memnew(RichTextLabel);
 	_tpl_text->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	_tpl_text->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	_tpl_text->set_wrap(true);
-	_tpl_text->set_readonly(true);
 	tpl_hbc->add_child(_tpl_text);
 
 	_tpl_tree->connect("item_selected", this, "_license_tree_selected");

--- a/editor/editor_about.h
+++ b/editor/editor_about.h
@@ -33,11 +33,11 @@
 #include "scene/gui/control.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/item_list.h"
+#include "scene/gui/rich_text_label.h"
 #include "scene/gui/scroll_container.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/split_container.h"
 #include "scene/gui/tab_container.h"
-#include "scene/gui/text_edit.h"
 #include "scene/gui/texture_rect.h"
 #include "scene/gui/tree.h"
 
@@ -55,8 +55,8 @@ private:
 	ScrollContainer *_populate_list(const String &p_name, const List<String> &p_sections, const char **p_src[], const int p_flag_single_column = 0);
 
 	Tree *_tpl_tree;
-	TextEdit *_license_text;
-	TextEdit *_tpl_text;
+	RichTextLabel *_license_text;
+	RichTextLabel *_tpl_text;
 	TextureRect *_logo;
 
 protected:


### PR DESCRIPTION
As discussed [here](https://github.com/godotengine/godot/pull/13409#issuecomment-348374473), RichTextLabels seems more fit for the purpose of simply showing text than TextEdits.