### PR TITLE
Enhanced 'open' menu in filesystemdock

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -909,10 +909,21 @@ void FileSystemDock::_file_option(int p_option) {
 			OS::get_singleton()->shell_open(String("file://") + dir);
 		} break;
 		case FILE_OPEN: {
-			int idx = files->get_current();
-			if (idx < 0 || idx >= files->get_item_count())
-				break;
-			_select_file(idx);
+			if (files->get_selected_items().size() > 1) {
+				for (int i = 0; i < files->get_item_count(); i++) {
+					if (files->is_selected(i)) {
+						String path = files->get_item_metadata(i);
+						if (ResourceLoader::get_resource_type(path) == "PackedScene") {
+							editor->open_request(path);
+						}
+					}
+				}
+			} else {
+				int idx = files->get_current();
+				if (idx < 0 || idx >= files->get_item_count())
+					break;
+				_select_file(idx);
+			}
 		} break;
 		case FILE_INSTANCE: {
 


### PR DESCRIPTION
Increase the capability to open the scene in batch.
![test](https://user-images.githubusercontent.com/24988459/33509387-1cacca24-d73c-11e7-9bc7-bc81854474ec.gif)

I make a mistake.Can't reopen this:#13438
![c](https://user-images.githubusercontent.com/24988459/33509403-3cb46520-d73c-11e7-8c1b-08225bf5906b.png)