### PR TITLE
Mono: Exported variables now show in the correct order.

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1332,7 +1332,7 @@ bool CSharpScript::_update_exports() {
 		while (top && top != native) {
 			const Vector<GDMonoField *> &fields = top->get_all_fields();
 
-			for (int i = 0; i < fields.size(); i++) {
+			for (int i = fields.size() - 1; i >= 0; i--) {
 				GDMonoField *field = fields[i];
 
 				if (field->is_static()) {
@@ -1382,7 +1382,7 @@ bool CSharpScript::_update_exports() {
 					PropertyInfo prop_info = PropertyInfo(type, name, hint, hint_string, PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_SCRIPT_VARIABLE);
 
 					member_info[cname] = prop_info;
-					exported_members_cache.push_back(prop_info);
+					exported_members_cache.push_front(prop_info);
 
 					if (tmp_object) {
 						exported_members_defval_cache[cname] = GDMonoMarshal::mono_object_to_variant(field->get_value(tmp_object));


### PR DESCRIPTION
Exported variables now come in the same order as GDScript, from base class to sub class 1 to sub class 3 etc.

Fixes https://github.com/godotengine/godot/issues/13493