### PR TITLE
Fix open_dynamic_library override in OSIPhone

### DIFF
--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -394,12 +394,12 @@ void OSIPhone::alert(const String &p_alert, const String &p_title) {
 	iOS::alert(utf8_alert.get_data(), utf8_title.get_data());
 }
 
-Error OSIPhone::open_dynamic_library(const String p_path, void *&p_library_handle) {
+Error OSIPhone::open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path) {
 	if (p_path.length() == 0) {
 		p_library_handle = RTLD_SELF;
 		return OK;
 	}
-	return OS_Unix::open_dynamic_library(p_path, p_library_handle);
+	return OS_Unix::open_dynamic_library(p_path, p_library_handle, p_also_set_library_path);
 }
 
 Error OSIPhone::close_dynamic_library(void *p_library_handle) {

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -155,7 +155,7 @@ public:
 
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
 
-	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle);
+	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path = false);
 	virtual Error close_dynamic_library(void *p_library_handle);
 	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle, bool p_optional = false);
 


### PR DESCRIPTION
Was broken at 9678231b109c333a5273325c8758241310cd27f4. Yet another good reason to start using C++11 features - compiler would detect this :-P