### PR TITLE
Fix the revert button issue with instanced nodes

### DIFF
--- a/editor/property_editor.h
+++ b/editor/property_editor.h
@@ -253,6 +253,7 @@ class PropertyEditor : public Control {
 	bool _might_be_in_instance();
 	bool _get_instanced_node_original_property(const StringName &p_prop, Variant &value);
 	bool _is_property_different(const Variant &p_current, const Variant &p_orig, int p_usage = 0);
+	bool _is_instanced_node_with_original_property_different(const String &p_name, TreeItem *item);
 
 	void _refresh_item(TreeItem *p_item);
 	void _set_range_def(Object *p_item, String prop, float p_frame);


### PR DESCRIPTION
The method "check_reload_status" on the file "property_editor.cpp" didn't take into account if the field is a property of an instanced node just like the "update_tree" does. The code that checks this in "update_tree" has been extracted into the method "_is_instanced_node_with_original_property_different" to be also used in "check_reload_status".

Fixes #13415