### PR TITLE
Make rulers on by default

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4314,7 +4314,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 
 	show_grid = false;
 	show_helpers = false;
-	show_rulers = false;
+	show_rulers = true;
 	show_guides = true;
 	zoom = 1;
 	grid_offset = Point2();


### PR DESCRIPTION
As a suggestion from @reduz, so that people understand faster that the units are pixels.