### PR TITLE
Rich Text Label: fixed deselection issue

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -793,6 +793,17 @@ void RichTextLabel::_gui_input(Ref<InputEvent> p_event) {
 
 							selection.click = item;
 							selection.click_char = line;
+
+							// Erase previous selection.
+							if (selection.active) {
+								selection.from = NULL;
+								selection.from_char = NULL;
+								selection.to = NULL;
+								selection.to_char = NULL;
+								selection.active = false;
+
+								update();
+							}
 						}
 					}
 


### PR DESCRIPTION
Before: https://i.imgur.com/HKF4rKW.gifv (you click anywhere - but selection do not disappear)
After: https://i.imgur.com/iZkaLxA.gifv (click anywhere, old selection will disappear)