### PR TITLE
Optimize PopupMenu rendering

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1696,6 +1696,7 @@ void SceneTreeDock::_add_children_to_popup(Object *p_obj, int p_depth) {
 
 		if (menu->get_item_count() == 0) {
 			menu->add_item(TTR("Sub-Resources:"));
+			menu->set_item_h_offset(0, -20 * EDSCALE);
 			menu->set_item_disabled(0, true);
 		}
 		int index = menu->get_item_count();

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -70,6 +70,30 @@ class PopupMenu : public Popup {
 		}
 	};
 
+	struct MeasureInfo {
+		float width; // Total width of menu items
+		float height; // Total height of menu items
+		int left_col_count; // Number of image columns on the left
+		float width_offset; // Widest offset of a menu item
+		float width_check; // Width of checkbox column in menu items (ignore if only 1 column)
+		float width_icon; // Width of icon column in menu items
+		float width_text; // Width of widest text in menu items
+		float width_accel; // Width of widest accelerator or submenu arrow in menu items
+		Vector<int> item_heights; // Height of each menu item (without vseparation)
+
+		MeasureInfo() {
+			width = 0;
+			height = 0;
+			left_col_count = 0;
+			width_offset = 0;
+			width_check = 0;
+			width_icon = 0;
+			width_text = 0;
+			width_accel = 0;
+			item_heights = Vector<int>();
+		}
+	};
+
 	Timer *submenu_timer;
 	List<Rect2> autohide_areas;
 	Vector<Item> items;
@@ -90,6 +114,8 @@ class PopupMenu : public Popup {
 
 	Array _get_items() const;
 	void _set_items(const Array &p_items);
+
+	MeasureInfo _measure() const;
 
 	Map<Ref<ShortCut>, int> shortcut_refcount;
 


### PR DESCRIPTION
As proposed by me in https://github.com/godotengine/godot/issues/13962 . Results look exactly as in the "after" images there (right side). Also "fixed" the node context-menu to still display "Sub-Resources:" on the very left with a negative horizontal offset.

- Moved and rewrote measurement related code to a private method which returns a `MeasureInfo` instance.
- Rewrote rendering completely using this info.
- Simplified mouse hover item detection using this info.

Some example imagery:
![image](https://user-images.githubusercontent.com/9631152/33580417-6a2c0608-d94d-11e7-91c8-869b68d2624a.png) ![image](https://user-images.githubusercontent.com/9631152/33580388-509d4e54-d94d-11e7-961b-9bcacb8ae69c.png)
![image](https://user-images.githubusercontent.com/9631152/33580372-3db17d24-d94d-11e7-8bd2-5bce8f992d3c.png)
![image](https://user-images.githubusercontent.com/9631152/33580995-7bbe22e6-d94f-11e7-8189-3b7f5d26535d.png)

Time to slowly add (new) icons to existing menues without ruining their look when some are still missing... 😎 