### PR TITLE
Set Caret Blinking Enabled by Default

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -348,7 +348,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/files/autosave_interval_secs", 0);
 
 	_initial_set("text_editor/cursor/block_caret", false);
-	_initial_set("text_editor/cursor/caret_blink", false);
+	_initial_set("text_editor/cursor/caret_blink", true);
 	_initial_set("text_editor/cursor/caret_blink_speed", 0.65);
 	hints["text_editor/cursor/caret_blink_speed"] = PropertyInfo(Variant::REAL, "text_editor/cursor/caret_blink_speed", PROPERTY_HINT_RANGE, "0.1, 10, 0.1");
 


### PR DESCRIPTION

- I usually set caret blink to be enabled by default, before compiling Godot, .
- To address any concern as follow

![caret_blinking](https://user-images.githubusercontent.com/20697655/33600091-d0a5cab2-d9da-11e7-948e-1ab0b449bd09.png)
