### PR TITLE
Avoid call pressed signal for button when drag performed

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -75,7 +75,7 @@ void BaseButton::_gui_input(Ref<InputEvent> p_event) {
 
 					status.press_attempt = true;
 					status.pressing_inside = true;
-
+					status.pressing_pos = b->get_position();
 					pressed();
 					if (get_script_instance()) {
 						Variant::CallError ce;
@@ -119,13 +119,16 @@ void BaseButton::_gui_input(Ref<InputEvent> p_event) {
 
 			status.press_attempt = true;
 			status.pressing_inside = true;
+			status.pressing_pos = b->get_position();
 			emit_signal("button_down");
 
 		} else {
 
 			emit_signal("button_up");
+			const float drag_detect_threshold_squared = 4000;
 
-			if (status.press_attempt && status.pressing_inside) {
+			if (status.press_attempt && status.pressing_inside &&
+				(status.pressing_pos - b->get_position()).length_squared() < drag_detect_threshold_squared) {
 
 				if (!toggle_mode) { //mouse press attempt
 
@@ -192,6 +195,7 @@ void BaseButton::_gui_input(Ref<InputEvent> p_event) {
 				status.pressing_button++;
 				status.press_attempt = true;
 				status.pressing_inside = true;
+				status.pressing_pos = b->get_position();
 				emit_signal("button_down");
 
 			} else if (status.press_attempt) {

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -62,6 +62,7 @@ private:
 
 		bool disabled;
 		int pressing_button;
+		Vector2 pressing_pos;
 
 	} status;
 


### PR DESCRIPTION
These changes solve problem when we have button in scroll container and try to scroll this by touch.
In this case mouse position stay on button during scroll and after mouse up it fired `pressed` signal