### PR TITLE
Disable stop button if the scene is not running (2.1)

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1604,7 +1604,7 @@ void EditorNode::_edit_current() {
 	if (main_plugin) {
 
 		// special case if use of external editor is true
-		if (main_plugin->get_name() == "Script" && bool(EditorSettings::get_singleton()->get("external_editor/use_external_editor"))){
+		if (main_plugin->get_name() == "Script" && bool(EditorSettings::get_singleton()->get("external_editor/use_external_editor"))) {
 			main_plugin->edit(current_obj);
 		}
 
@@ -1876,6 +1876,7 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 		play_button->set_pressed(true);
 		play_button->set_icon(gui_base->get_icon("Reload", "EditorIcons"));
 	}
+	stop_button->set_disabled(false);
 
 	_playing_edited = p_current;
 }
@@ -2571,6 +2572,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			play_scene_button->set_icon(gui_base->get_icon("PlayScene", "EditorIcons"));
 			play_custom_scene_button->set_pressed(false);
 			play_custom_scene_button->set_icon(gui_base->get_icon("PlayCustom", "EditorIcons"));
+			stop_button->set_disabled(true);
 			//pause_button->set_pressed(false);
 			if (bool(EDITOR_DEF("run/always_close_output_on_stop", false))) {
 				for (int i = 0; i < bottom_panel_items.size(); i++) {
@@ -5596,6 +5598,7 @@ EditorNode::EditorNode() {
 	stop_button->set_icon(gui_base->get_icon("MainStop", "EditorIcons"));
 	stop_button->connect("pressed", this, "_menu_option", make_binds(RUN_STOP));
 	stop_button->set_tooltip(TTR("Stop the scene."));
+	stop_button->set_disabled(true);
 	stop_button->set_shortcut(ED_SHORTCUT("editor/stop", TTR("Stop"), KEY_F8));
 
 	run_native = memnew(EditorRunNative);


### PR DESCRIPTION
This is a port to Godot 2.1 of @waldson's PR ['Fix stop button always enabled'](https://github.com/godotengine/godot/pull/13977). I've tested it and it works as expected. Thanks waldson ;)