### PR TITLE
Export icon and splash images directly to final package

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -743,6 +743,18 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		custom_map["path_remap/remapped_paths"] = path_remaps;
 	}
 
+	// Store icon and splash images directly, they need to bypass the import system and be loaded as images
+	String icon = ProjectSettings::get_singleton()->get("application/config/icon");
+	String splash = ProjectSettings::get_singleton()->get("application/boot_splash/image");
+	if (icon != String() && FileAccess::exists(icon)) {
+		Vector<uint8_t> array = FileAccess::get_file_as_array(icon);
+		p_func(p_udata, icon, array, idx, total);
+	}
+	if (splash != String() && FileAccess::exists(splash)) {
+		Vector<uint8_t> array = FileAccess::get_file_as_array(splash);
+		p_func(p_udata, splash, array, idx, total);
+	}
+
 	String config_file = "project.binary";
 	String engine_cfb = EditorSettings::get_singleton()->get_cache_dir().plus_file("tmp" + config_file);
 	ProjectSettings::get_singleton()->save_custom(engine_cfb, custom_map, custom_list);


### PR DESCRIPTION
They need to bypass the path remapping to be loaded as images during the start routine.

Fix #13321.