### PR TITLE
Fixed project name line edit lost input focus in project rename dialog.

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -508,7 +508,8 @@ public:
 			} else if (current->has_setting("application/config/name")) {
 				project_name->set_text(current->get("application/config/name"));
 			}
-			project_name->grab_focus();
+			
+			project_name->call_deferred("grab_focus");
 
 			create_dir->hide();
 			status_btn->hide();


### PR DESCRIPTION
In project manager dialog,  select a project from project list, then click rename button, project name line edit lost input focus. 

This is caused by "get_ok()->call_deferred("grab_focus");" in function _path_selected