### PR TITLE
Fix scroll enabled in case of content fit in scroll container

### DIFF
--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -354,6 +354,7 @@ void ScrollContainer::update_scrollbars() {
 	if (!scroll_v || min.height <= size.height - hmin.height) {
 
 		v_scroll->hide();
+		v_scroll->set_max(0);
 		scroll.y = 0;
 	} else {
 
@@ -366,6 +367,7 @@ void ScrollContainer::update_scrollbars() {
 	if (!scroll_h || min.width <= size.width - vmin.width) {
 
 		h_scroll->hide();
+		h_scroll->set_max(0);
 		scroll.x = 0;
 	} else {
 


### PR DESCRIPTION
These changes are solved a problem when it is possible scroll content of scroll container by touch in spite of content  fit in scroll container
Example:
![2017-12-05_23-44-49](https://user-images.githubusercontent.com/3992195/33643991-da3dbf0e-da74-11e7-85e8-42a425d4bdac.gif)
