### PR TITLE
Use run-time dynamic linking for AddDllDirectory and RemoveDllDirectory

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -73,21 +73,16 @@ static String format_error_message(DWORD id) {
 
 	LPWSTR messageBuffer = NULL;
 	size_t size = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-				       NULL, id, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&messageBuffer, 0, NULL);
+			NULL, id, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&messageBuffer, 0, NULL);
 
-	String msg = "Error "+itos(id)+": "+String(messageBuffer,size);
+	String msg = "Error " + itos(id) + ": " + String(messageBuffer, size);
 
 	LocalFree(messageBuffer);
 
 	return msg;
-
 }
 
-
-
 extern HINSTANCE godot_hinstance;
-
-
 
 void RedirectIOToConsole() {
 
@@ -1608,17 +1603,23 @@ void OS_Windows::_update_window_style(bool repaint) {
 
 Error OS_Windows::open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path) {
 
+	typedef DLL_DIRECTORY_COOKIE(WINAPI * PAddDllDirectory)(PCWSTR);
+	typedef BOOL(WINAPI * PRemoveDllDirectory)(DLL_DIRECTORY_COOKIE);
 
+	PAddDllDirectory add_dll_directory = (PAddDllDirectory)GetProcAddress(GetModuleHandle("kernel32.dll"), "AddDllDirectory");
+	PRemoveDllDirectory remove_dll_directory = (PRemoveDllDirectory)GetProcAddress(GetModuleHandle("kernel32.dll"), "RemoveDllDirectory");
+
+	bool has_dll_directory_api = ((add_dll_directory != NULL) && (remove_dll_directory != NULL));
 	DLL_DIRECTORY_COOKIE cookie;
 
-	if (p_also_set_library_path) {
-		cookie = AddDllDirectory(p_path.get_base_dir().c_str());
+	if (p_also_set_library_path && has_dll_directory_api) {
+		cookie = add_dll_directory(p_path.get_base_dir().c_str());
 	}
 
-	p_library_handle = (void *)LoadLibraryExW(p_path.c_str(), NULL, p_also_set_library_path ? LOAD_LIBRARY_SEARCH_DEFAULT_DIRS : 0);
+	p_library_handle = (void *)LoadLibraryExW(p_path.c_str(), NULL, (p_also_set_library_path && has_dll_directory_api) ? LOAD_LIBRARY_SEARCH_DEFAULT_DIRS : 0);
 
-	if (p_also_set_library_path) {
-		RemoveDllDirectory(cookie);
+	if (p_also_set_library_path && has_dll_directory_api) {
+		remove_dll_directory(cookie);
 	}
 
 	if (!p_library_handle) {


### PR DESCRIPTION
Use run-time dynamic linking for AddDllDirectory and RemoveDllDirectory to support mingw-w64 build and Windows 7 with KB2533623.

Please test this PR on Windows 7 before merging.

Fixes #13949.