### PR TITLE
Update Android compileSdkVersion to 26

### DIFF
--- a/platform/android/build.gradle.template
+++ b/platform/android/build.gradle.template
@@ -31,7 +31,7 @@ android {
 		disable 'MissingTranslation'
 	}
 
-	compileSdkVersion 24
+	compileSdkVersion 26
 	buildToolsVersion "26.0.1"
 	useLibrary 'org.apache.http.legacy'
 


### PR DESCRIPTION
The version should be kept up to date so that some dependencies (such as Facebook SDK) keep compiling.