### PR TITLE
Fix Windows-to-Linux export error

### DIFF
--- a/core/os/dir_access.cpp
+++ b/core/os/dir_access.cpp
@@ -333,6 +333,9 @@ Error DirAccess::copy(String p_from, String p_to, int chmod_flags) {
 	if (err == OK && chmod_flags != -1) {
 		fdst->close();
 		err = fdst->_chmod(p_to, chmod_flags);
+		// If running on a platform with no chmod support (i.e., Windows), don't fail
+		if (err == ERR_UNAVAILABLE)
+			err = OK;
 	}
 
 	memdelete(fsrc);

--- a/core/os/file_access.h
+++ b/core/os/file_access.h
@@ -141,7 +141,7 @@ public:
 
 	virtual Error reopen(const String &p_path, int p_mode_flags); ///< does not change the AccessType
 
-	virtual Error _chmod(const String &p_path, int p_mod) { return FAILED; }
+	virtual Error _chmod(const String &p_path, int p_mod) { return ERR_UNAVAILABLE; }
 
 	static FileAccess *create(AccessType p_access); /// Create a file access (for the current platform) this is the only portable way of accessing files.
 	static FileAccess *create_for_path(const String &p_path);


### PR DESCRIPTION
Now chmod() returns ERR_UNAVAILABLE by default, to signal the caller the problem is lack of support instead of a failed operation.