### PR TITLE
Fix Windows-to-Linux export error (2.1)

### DIFF
--- a/core/os/file_access.h
+++ b/core/os/file_access.h
@@ -139,7 +139,7 @@ public:
 
 	virtual Error reopen(const String &p_path, int p_mode_flags); ///< does not change the AccessType
 
-	virtual Error _chmod(const String &p_path, int p_mod) { return FAILED; }
+	virtual Error _chmod(const String &p_path, int p_mod) { return ERR_UNAVAILABLE; }
 
 	static FileAccess *create(AccessType p_access); /// Create a file access (for the current platform) this is the only portable way of accessing files.
 	static FileAccess *create_for_path(const String &p_path);

--- a/editor/editor_import_export.cpp
+++ b/editor/editor_import_export.cpp
@@ -1350,6 +1350,9 @@ Error EditorExportPlatformPC::export_project(const String &p_path, bool p_debug,
 		int flags = get_chmod_flags();
 		if (flags) {
 			err = dst->_chmod(p_path, flags);
+			// If exporting from a platform with no chmod support (i.e., Windows), don't fail
+			if (err == ERR_UNAVAILABLE)
+				err = OK;
 		}
 	}
 


### PR DESCRIPTION
Now chmod() returns ERR_UNAVAILABLE by default, to signal the caller the problem is lack of support instead of a failed operation.