### PR TITLE
Fixed PopupMenu's submenus not showing up in certain situations

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -202,10 +202,10 @@ void PopupMenu::_activate_submenu(int over) {
 
 void PopupMenu::_submenu_timeout() {
 
-	if (mouse_over == submenu_over) {
+	if (mouse_over == submenu_over)
 		_activate_submenu(mouse_over);
-		submenu_over = -1;
-	}
+
+	submenu_over = -1;
 }
 
 void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {


### PR DESCRIPTION
This was annoying me to no end. The reason was that if you removed the mouse before the timer could finish, the `submenu_over` variable would remain stuck with the value `over`.

I could swear that there was a issue report about this, but I can't seem to find it...

**EDIT:** Found it! Fixes https://github.com/godotengine/godot/issues/10911.