### PR TITLE
Fix missing stylebox for LinkButton's hover states

### DIFF
--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -257,6 +257,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	// LinkButton
 
+	theme->set_stylebox("focus", "LinkButton", focus);
+
 	theme->set_font("font", "LinkButton", default_font);
 
 	theme->set_color("font_color", "LinkButton", control_font_color);


### PR DESCRIPTION
The 'hover' stylebox was missing in LinkButton style definition on default_theme.cpp. This PR adds it. This closes #12959.