### PR TITLE
Implement multitouch on X11 and improve it on Windows (2.1)

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -176,6 +176,8 @@ def get_opts():
     return [
         ('mingw_prefix', 'Mingw Prefix', mingw32),
         ('mingw_prefix_64', 'Mingw Prefix 64 bits', mingw64),
+        # Targeted Windows version: Vista (and later)
+        ('target_win_version', 'Targeted Windows version, >= 0x0600 (Vista)', '0x0600'),
     ]
 
 
@@ -210,16 +212,13 @@ def configure(env):
 
     env.Append(CPPPATH=['#platform/windows'])
 
-    # Targeted Windows version: Vista (and later)
-    winver = "0x0600" # Windows Vista is the minimum target for windows builds
-
     env['is_mingw'] = False
     if (os.name == "nt" and os.getenv("VCINSTALLDIR")):
         # build using visual studio
         env['ENV']['TMP'] = os.environ['TMP']
         env.Append(CPPPATH=['#platform/windows/include'])
         env.Append(LIBPATH=['#platform/windows/lib'])
-        env.Append(CCFLAGS=['/DWINVER=%s' % winver, '/D_WIN32_WINNT=%s' % winver])
+        env.Append(CCFLAGS=['/DWINVER=%s' % env['target_win_version'], '/D_WIN32_WINNT=%s' % env['target_win_version']])
 
         if (env["target"] == "release"):
 

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -98,17 +98,7 @@ def is_active():
 
 def get_name():
     return "Windows"
-    if (os.getenv("MINGW32_PREFIX")):
-        mingw32=os.getenv("MINGW32_PREFIX")
-        mingw = mingw32
-    if (os.getenv("MINGW64_PREFIX")):
-        mingw64=os.getenv("MINGW64_PREFIX")
 
-
-    return [
-        ('mingw_prefix','Mingw Prefix',mingw32),
-        ('mingw_prefix_64','Mingw Prefix 64 bits',mingw64),
-    ]
 
 def can_build():
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -130,6 +130,9 @@ class OS_Windows : public OS {
 
 	InputDefault *input;
 	joystick_windows *joystick;
+#if WINVER >= 0x0601 // for windows 7
+	Map<int, Point2i> touch_state;
+#endif
 
 #ifdef WASAPI_ENABLED
 	AudioDriverWASAPI driver_wasapi;

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -59,6 +59,7 @@ def get_opts():
         ('pulseaudio', 'Detect & Use pulseaudio', 'yes'),
         ('udev', 'Use udev for gamepad connection callbacks', 'no'),
         ('debug_release', 'Add debug symbols to release version', 'no'),
+        ('touch', 'Enable touch events', 'yes'),
     ]
 
 
@@ -144,6 +145,14 @@ def configure(env):
     env.ParseConfig('pkg-config xinerama --cflags --libs')
     env.ParseConfig('pkg-config xcursor --cflags --libs')
     env.ParseConfig('pkg-config xrandr --cflags --libs')
+
+    if (env['touch'] == 'yes'):
+        x11_error = os.system("pkg-config xi --modversion > /dev/null ")
+        if (x11_error):
+            print("xi not found.. cannot build with touch. Aborting.")
+            sys.exit(255)
+        env.ParseConfig('pkg-config xi --cflags --libs')
+        env.Append(CPPFLAGS=['-DTOUCH_ENABLED'])
 
     if (env['builtin_openssl'] == 'no'):
         env.ParseConfig('pkg-config openssl --cflags --libs')

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -55,6 +55,9 @@
 #include <X11/Xlib.h>
 #include <X11/extensions/Xrandr.h>
 #include <X11/keysym.h>
+#ifdef TOUCH_ENABLED
+#include <X11/extensions/XInput2.h>
+#endif
 
 // Hints for X11 fullscreen
 typedef struct {
@@ -122,6 +125,14 @@ class OS_X11 : public OS_Unix {
 	uint64_t last_click_ms;
 	unsigned int event_id;
 	uint32_t last_button_state;
+#ifdef TOUCH_ENABLED
+	struct {
+		int opcode;
+		Vector<int> devices;
+		XIEventMask event_mask;
+		Map<int, Point2i> state;
+	} touch;
+#endif
 
 	PhysicsServer *physics_server;
 	unsigned int get_mouse_button_state(unsigned int p_x11_state);


### PR DESCRIPTION
Plus add a compile option to target different versions of Windows. Needed because for touch events the lowest release is Windows 7, but for 2.1 we are targeting Vista.

This code is donated to Godot by [AdPodnet](https://www.adpodnet.com/). (More on this on an upcoming blog post.)