### PR TITLE
Implement multitouch on X11 and improve it on Windows

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -64,6 +64,10 @@ def get_opts():
     return [
         ('mingw_prefix_32', 'MinGW prefix (Win32)', mingw32),
         ('mingw_prefix_64', 'MinGW prefix (Win64)', mingw64),
+        # Targeted Windows version: 7 (and later), minimum supported version
+        # XP support dropped after EOL due to missing API for IPv6 and other issues
+        # Vista support dropped after EOL due to GH-10243
+        ('target_win_version', 'Targeted Windows version, >= 0x0601 (Windows 7)', '0x0601'),
         EnumVariable('debug_symbols', 'Add debug symbols to release version', 'yes', ('yes', 'no', 'full')),
     ]
 
@@ -96,11 +100,6 @@ def build_res_file(target, source, env):
 def configure(env):
 
     env.Append(CPPPATH=['#platform/windows'])
-
-    # Targeted Windows version: 7 (and later), minimum supported version
-    # XP support dropped after EOL due to missing API for IPv6 and other issues
-    # Vista support dropped after EOL due to GH-10243
-    winver = "0x0601"
 
     if (os.name == "nt" and os.getenv("VCINSTALLDIR")): # MSVC
 
@@ -175,7 +174,7 @@ def configure(env):
         env.Append(CCFLAGS=['/DWASAPI_ENABLED'])
         env.Append(CCFLAGS=['/DTYPED_METHOD_BIND'])
         env.Append(CCFLAGS=['/DWIN32'])
-        env.Append(CCFLAGS=['/DWINVER=%s' % winver, '/D_WIN32_WINNT=%s' % winver])
+        env.Append(CCFLAGS=['/DWINVER=%s' % env['target_win_version'], '/D_WIN32_WINNT=%s' % env['target_win_version']])
         if env["bits"] == "64":
             env.Append(CCFLAGS=['/D_WIN64'])
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -73,21 +73,16 @@ static String format_error_message(DWORD id) {
 
 	LPWSTR messageBuffer = NULL;
 	size_t size = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-				       NULL, id, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&messageBuffer, 0, NULL);
+			NULL, id, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&messageBuffer, 0, NULL);
 
-	String msg = "Error "+itos(id)+": "+String(messageBuffer,size);
+	String msg = "Error " + itos(id) + ": " + String(messageBuffer, size);
 
 	LocalFree(messageBuffer);
 
 	return msg;
-
 }
 
-
-
 extern HINSTANCE godot_hinstance;
-
-
 
 void RedirectIOToConsole() {
 
@@ -228,7 +223,19 @@ bool OS_Windows::can_draw() const {
 #define SIGNATURE_MASK 0xFFFFFF00
 #define IsPenEvent(dw) (((dw)&SIGNATURE_MASK) == MI_WP_SIGNATURE)
 
-void OS_Windows::_touch_event(bool p_pressed, int p_x, int p_y, int idx) {
+void OS_Windows::_touch_event(bool p_pressed, float p_x, float p_y, int idx) {
+
+#if WINVER >= 0x0601 // for windows 7
+	// Defensive
+	if (touch_state.has(idx) == p_pressed)
+		return;
+
+	if (p_pressed) {
+		touch_state.insert(idx, Vector2(p_x, p_y));
+	} else {
+		touch_state.erase(idx);
+	}
+#endif
 
 	Ref<InputEventScreenTouch> event;
 	event.instance();
@@ -241,7 +248,19 @@ void OS_Windows::_touch_event(bool p_pressed, int p_x, int p_y, int idx) {
 	}
 };
 
-void OS_Windows::_drag_event(int p_x, int p_y, int idx) {
+void OS_Windows::_drag_event(float p_x, float p_y, int idx) {
+
+#if WINVER >= 0x0601 // for windows 7
+	Map<int, Vector2>::Element *curr = touch_state.find(idx);
+	// Defensive
+	if (!curr)
+		return;
+
+	if (curr->get() == Vector2(p_x, p_y))
+		return;
+
+	curr->get() = Vector2(p_x, p_y);
+#endif
 
 	Ref<InputEventScreenDrag> event;
 	event.instance();
@@ -271,6 +290,13 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 			if (mouse_mode == MOUSE_MODE_CAPTURED || mouse_mode == MOUSE_MODE_CONFINED) {
 				ReleaseCapture();
 			}
+#if WINVER >= 0x0601 // for windows 7
+			// Release every touch to avoid sticky points
+			for (Map<int, Vector2>::Element *E = touch_state.front(); E; E = E->next()) {
+				_touch_event(false, E->get().x, E->get().y, E->key());
+			}
+			touch_state.clear();
+#endif
 			break;
 		}
 		case WM_ACTIVATE: // Watch For Window Activate Message
@@ -687,10 +713,10 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 						//do something with each touch input entry
 						if (ti.dwFlags & TOUCHEVENTF_MOVE) {
 
-							_drag_event(ti.x / 100, ti.y / 100, ti.dwID);
+							_drag_event(ti.x / 100.0f, ti.y / 100.0f, ti.dwID);
 						} else if (ti.dwFlags & (TOUCHEVENTF_UP | TOUCHEVENTF_DOWN)) {
 
-							_touch_event(ti.dwFlags & TOUCHEVENTF_DOWN != 0, ti.x / 100, ti.y / 100, ti.dwID);
+							_touch_event(ti.dwFlags & TOUCHEVENTF_DOWN, ti.x / 100.0f, ti.y / 100.0f, ti.dwID);
 						};
 					}
 					bHandled = TRUE;
@@ -1092,7 +1118,9 @@ void OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int 
 	tme.dwHoverTime = HOVER_DEFAULT;
 	TrackMouseEvent(&tme);
 
-	//RegisterTouchWindow(hWnd, 0); // Windows 7
+#if WINVER >= 0x0601 // for windows 7
+	RegisterTouchWindow(hWnd, 0); // Windows 7
+#endif
 
 	_ensure_user_data_dir();
 
@@ -1206,6 +1234,9 @@ void OS_Windows::finalize() {
 
 	memdelete(joypad);
 	memdelete(input);
+#if WINVER >= 0x0601 // for windows 7
+	touch_state.clear();
+#endif
 
 	visual_server->finish();
 	memdelete(visual_server);
@@ -1607,7 +1638,6 @@ void OS_Windows::_update_window_style(bool repaint) {
 }
 
 Error OS_Windows::open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path) {
-
 
 	DLL_DIRECTORY_COOKIE cookie;
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -225,7 +225,6 @@ bool OS_Windows::can_draw() const {
 
 void OS_Windows::_touch_event(bool p_pressed, float p_x, float p_y, int idx) {
 
-#if WINVER >= 0x0601 // for windows 7
 	// Defensive
 	if (touch_state.has(idx) == p_pressed)
 		return;
@@ -235,7 +234,6 @@ void OS_Windows::_touch_event(bool p_pressed, float p_x, float p_y, int idx) {
 	} else {
 		touch_state.erase(idx);
 	}
-#endif
 
 	Ref<InputEventScreenTouch> event;
 	event.instance();
@@ -250,7 +248,6 @@ void OS_Windows::_touch_event(bool p_pressed, float p_x, float p_y, int idx) {
 
 void OS_Windows::_drag_event(float p_x, float p_y, int idx) {
 
-#if WINVER >= 0x0601 // for windows 7
 	Map<int, Vector2>::Element *curr = touch_state.find(idx);
 	// Defensive
 	if (!curr)
@@ -260,7 +257,6 @@ void OS_Windows::_drag_event(float p_x, float p_y, int idx) {
 		return;
 
 	curr->get() = Vector2(p_x, p_y);
-#endif
 
 	Ref<InputEventScreenDrag> event;
 	event.instance();
@@ -290,13 +286,13 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 			if (mouse_mode == MOUSE_MODE_CAPTURED || mouse_mode == MOUSE_MODE_CONFINED) {
 				ReleaseCapture();
 			}
-#if WINVER >= 0x0601 // for windows 7
+
 			// Release every touch to avoid sticky points
 			for (Map<int, Vector2>::Element *E = touch_state.front(); E; E = E->next()) {
 				_touch_event(false, E->get().x, E->get().y, E->key());
 			}
 			touch_state.clear();
-#endif
+
 			break;
 		}
 		case WM_ACTIVATE: // Watch For Window Activate Message
@@ -700,7 +696,6 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 			print_line("input lang change");
 		} break;
 
-#if WINVER >= 0x0601 // for windows 7
 		case WM_TOUCH: {
 
 			BOOL bHandled = FALSE;
@@ -734,7 +729,6 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 
 		} break;
 
-#endif
 		case WM_DEVICECHANGE: {
 
 			joypad->probe_joypads();
@@ -1118,9 +1112,7 @@ void OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int 
 	tme.dwHoverTime = HOVER_DEFAULT;
 	TrackMouseEvent(&tme);
 
-#if WINVER >= 0x0601 // for windows 7
-	RegisterTouchWindow(hWnd, 0); // Windows 7
-#endif
+	RegisterTouchWindow(hWnd, 0);
 
 	_ensure_user_data_dir();
 
@@ -1234,9 +1226,7 @@ void OS_Windows::finalize() {
 
 	memdelete(joypad);
 	memdelete(input);
-#if WINVER >= 0x0601 // for windows 7
 	touch_state.clear();
-#endif
 
 	visual_server->finish();
 	memdelete(visual_server);

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -117,9 +117,7 @@ class OS_Windows : public OS {
 
 	InputDefault *input;
 	JoypadWindows *joypad;
-#if WINVER >= 0x0601 // for windows 7
 	Map<int, Vector2> touch_state;
-#endif
 
 	PowerWindows *power_manager;
 
@@ -215,7 +213,7 @@ public:
 	virtual void set_borderless_window(int p_borderless);
 	virtual bool get_borderless_window();
 
-	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle,bool p_also_set_library_path=false);
+	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path = false);
 	virtual Error close_dynamic_library(void *p_library_handle);
 	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle, bool p_optional = false);
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -117,6 +117,9 @@ class OS_Windows : public OS {
 
 	InputDefault *input;
 	JoypadWindows *joypad;
+#if WINVER >= 0x0601 // for windows 7
+	Map<int, Vector2> touch_state;
+#endif
 
 	PowerWindows *power_manager;
 
@@ -132,8 +135,8 @@ class OS_Windows : public OS {
 
 	CrashHandler crash_handler;
 
-	void _drag_event(int p_x, int p_y, int idx);
-	void _touch_event(bool p_pressed, int p_x, int p_y, int idx);
+	void _drag_event(float p_x, float p_y, int idx);
+	void _touch_event(bool p_pressed, float p_x, float p_y, int idx);
 
 	void _update_window_style(bool repaint = true);
 

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -55,6 +55,7 @@ def get_opts():
         BoolVariable('pulseaudio', 'Detect & use pulseaudio', True),
         BoolVariable('udev', 'Use udev for gamepad connection callbacks', False),
         EnumVariable('debug_symbols', 'Add debug symbols to release version', 'yes', ('yes', 'no', 'full')),
+        BoolVariable('touch', 'Enable touch events', True),
     ]
 
 
@@ -140,6 +141,14 @@ def configure(env):
     env.ParseConfig('pkg-config xcursor --cflags --libs')
     env.ParseConfig('pkg-config xinerama --cflags --libs')
     env.ParseConfig('pkg-config xrandr --cflags --libs')
+
+    if (env['touch']):
+        x11_error = os.system("pkg-config xi --modversion > /dev/null ")
+        if (x11_error):
+            print("xi not found.. cannot build with touch. Aborting.")
+            sys.exit(255)
+        env.ParseConfig('pkg-config xi --cflags --libs')
+        env.Append(CPPFLAGS=['-DTOUCH_ENABLED'])
 
     # FIXME: Check for existence of the libs before parsing their flags with pkg-config
 

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -48,6 +48,9 @@
 #include <X11/Xlib.h>
 #include <X11/extensions/Xrandr.h>
 #include <X11/keysym.h>
+#ifdef TOUCH_ENABLED
+#include <X11/extensions/XInput2.h>
+#endif
 
 // Hints for X11 fullscreen
 typedef struct {
@@ -117,6 +120,14 @@ class OS_X11 : public OS_Unix {
 	Point2i last_click_pos;
 	uint64_t last_click_ms;
 	uint32_t last_button_state;
+#ifdef TOUCH_ENABLED
+	struct {
+		int opcode;
+		Vector<int> devices;
+		XIEventMask event_mask;
+		Map<int, Vector2> state;
+	} touch;
+#endif
 
 	unsigned int get_mouse_button_state(unsigned int p_x11_state);
 	void get_key_modifier_state(unsigned int p_x11_state, Ref<InputEventWithModifiers> state);


### PR DESCRIPTION
Plus add a compile option to target different versions of Windows. This was added since it was added to 2.1 as well as part of the version of this PR for it, to keep the build systems homogeneous.

This code is donated to Godot by [AdPodnet](https://www.adpodnet.com/). (More on this on an upcoming blog post.)