### PR TITLE
Add method on EditorPlugin to set main screen plugins icons

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -337,7 +337,13 @@ void EditorNode::_notification(int p_what) {
 
 		//_update_icons
 		for (int i = 0; i < singleton->main_editor_buttons.size(); i++) {
-			main_editor_buttons[i]->set_icon(gui_base->get_icon(singleton->main_editor_buttons[i]->get_name(), "EditorIcons"));
+			Ref<Texture> icon = singleton->main_editor_buttons[i]->get_icon();
+
+			if (icon.is_valid()) {
+				main_editor_buttons[i]->set_icon(icon);
+			} else if (singleton->gui_base->has_icon(singleton->main_editor_buttons[i]->get_name(), "EditorIcons")) {
+				main_editor_buttons[i]->set_icon(gui_base->get_icon(singleton->main_editor_buttons[i]->get_name(), "EditorIcons"));
+			}
 		}
 		play_button->set_icon(gui_base->get_icon("MainPlay", "EditorIcons"));
 		play_scene_button->set_icon(gui_base->get_icon("PlayScene", "EditorIcons"));
@@ -2670,7 +2676,14 @@ void EditorNode::add_editor_plugin(EditorPlugin *p_editor) {
 		tb->set_toggle_mode(true);
 		tb->connect("pressed", singleton, "_editor_select", varray(singleton->main_editor_buttons.size()));
 		tb->set_text(p_editor->get_name());
-		tb->set_icon(singleton->gui_base->get_icon(p_editor->get_name(), "EditorIcons"));
+		Ref<Texture> icon = p_editor->get_icon();
+
+		if (icon.is_valid()) {
+			tb->set_icon(icon);
+		} else if (singleton->gui_base->has_icon(p_editor->get_name(), "EditorIcons")) {
+			tb->set_icon(singleton->gui_base->get_icon(p_editor->get_name(), "EditorIcons"));
+		}
+
 		tb->set_name(p_editor->get_name());
 		singleton->main_editor_buttons.push_back(tb);
 		singleton->main_editor_button_vb->add_child(tb);

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -466,6 +466,14 @@ String EditorPlugin::get_name() const {
 
 	return String();
 }
+const Ref<Texture> EditorPlugin::get_icon() const {
+
+	if (get_script_instance() && get_script_instance()->has_method("get_plugin_icon")) {
+		return get_script_instance()->call("get_plugin_icon");
+	}
+
+	return Ref<Texture>();
+}
 bool EditorPlugin::has_main_screen() const {
 
 	if (get_script_instance() && get_script_instance()->has_method("has_main_screen")) {
@@ -644,6 +652,7 @@ void EditorPlugin::_bind_methods() {
 	gizmo.return_val.hint_string = "EditorSpatialGizmo";
 	ClassDB::add_virtual_method(get_class_static(), gizmo);
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "get_plugin_name"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::OBJECT, "get_plugin_icon"));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "has_main_screen"));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo("make_visible", PropertyInfo(Variant::BOOL, "visible")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo("edit", PropertyInfo(Variant::OBJECT, "object")));

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -165,6 +165,7 @@ public:
 	virtual void forward_force_draw_over_viewport(Control *p_overlay);
 	virtual bool forward_spatial_gui_input(Camera *p_camera, const Ref<InputEvent> &p_event);
 	virtual String get_name() const;
+	virtual const Ref<Texture> get_icon() const;
 	virtual bool has_main_screen() const;
 	virtual void make_visible(bool p_visible);
 	virtual void selected_notify() {} //notify that it was raised by the user, not the editor


### PR DESCRIPTION
This PR adds a new method to EditorPlugin (`get_icon`). 
This method is intended to be used by main screen plugins in order to set their icons.
A GDScript bind was also created (`get_plugin_icon`).

To keep compability with current main screen plugins, it does the following:


1. Check if `get_plugin_icon` function is implemeneted in plugin's script and returns a valid `Ref<Texture>`, if so, sets its icon to it;
2. If the texture is not set, it tries to load the icon from Godot's internal icons by searching for its name  (this is the current behavior);
3. If the internal icon doesn't exist, the icon is not displayed.

Step 2 was kept for compatibility reasons. The best way to do it is to override `get_icon` in every main scene plugin.

This could close #13028.

![godot_script](https://user-images.githubusercontent.com/160668/33689848-ba5499ec-dabf-11e7-9d75-998dec27ab05.png)

![godot_plugin2](https://user-images.githubusercontent.com/160668/33690103-c0e99a68-dac0-11e7-8c41-8623a4f0328f.png)

![godot_plugin](https://user-images.githubusercontent.com/160668/33689850-baec1aec-dabf-11e7-8076-fa31549ee90d.png)












 
