### PR TITLE
use application:didFinishLaunchingWithOptions: instead of application…

### DIFF
--- a/platform/iphone/app_delegate.mm
+++ b/platform/iphone/app_delegate.mm
@@ -568,7 +568,7 @@ static int frame_count = 0;
 			MainLoop::NOTIFICATION_OS_MEMORY_WARNING);
 };
 
-- (void)applicationDidFinishLaunching:(UIApplication *)application {
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 
 	printf("**************** app delegate init\n");
 	CGRect rect = [[UIScreen mainScreen] bounds];
@@ -665,6 +665,7 @@ static int frame_count = 0;
 												  isAdvertisingTrackingEnabled]];
 
 #endif
+	return TRUE;
 };
 
 - (void)applicationWillTerminate:(UIApplication *)application {


### PR DESCRIPTION
…DidFinishLaunching: for iOS

https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623053-applicationdidfinishlaunching?language=objc

> Tells the delegate when the app has finished launching. Don’t use. Instead, use application:didFinishLaunchingWithOptions:.

and other SDK, like FacebookSDK requires this.