### PR TITLE
Add uppercase and lowercase to rightclickmenu in scripteditor

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1509,6 +1509,8 @@ void ScriptTextEditor::_make_context_menu(bool p_selection, bool p_color, bool p
 
 	if (p_selection) {
 		context_menu->add_separator();
+		context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_to_uppercase"), EDIT_TO_UPPERCASE);
+		context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_to_lowercase"), EDIT_TO_LOWERCASE);
 		context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/indent_left"), EDIT_INDENT_LEFT);
 		context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/indent_right"), EDIT_INDENT_RIGHT);
 		context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_comment"), EDIT_TOGGLE_COMMENT);


### PR DESCRIPTION
Easy to convert case.
![e](https://user-images.githubusercontent.com/24988459/33704899-362fe540-db69-11e7-8722-4e77c8e1a234.gif)
