### PR TITLE
Fix Manage Export Templates link

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1261,6 +1261,7 @@ bool EditorExportPlatformPC::can_export(const Ref<EditorExportPreset> &p_preset,
 	if (custom_debug_binary == "" && custom_release_binary == "") {
 		if (!err.empty())
 			r_error = err;
+		r_missing_templates = !valid;
 		return valid;
 	}
 

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -974,6 +974,7 @@ bool EditorExportPlatformIOS::can_export(const Ref<EditorExportPreset> &p_preset
 	if (!err.empty())
 		r_error = err;
 
+	r_missing_templates = !valid;
 	return valid;
 }
 

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -605,6 +605,7 @@ bool EditorExportPlatformOSX::can_export(const Ref<EditorExportPreset> &p_preset
 	if (!err.empty())
 		r_error = err;
 
+	r_missing_templates = !valid;
 	return valid;
 }
 


### PR DESCRIPTION
In some cases, the link to download export templates was missing.
Fixes #14391 

Please, be aware I am a beginner in C++ and this is only the second time I try to fix godot's code. I hope I din't break anything.