### PR TITLE
Fixes TileMap occluder offsets.

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -513,16 +513,13 @@ void TileMap::_update_dirty_quadrants() {
 			}
 
 			Ref<OccluderPolygon2D> occluder;
-			Vector2 occluder_ofs;
 			if (tile_set->tile_get_is_autotile(c.id)) {
 				occluder = tile_set->autotile_get_light_occluder(c.id, Vector2(c.autotile_coord_x, c.autotile_coord_y));
-				occluder_ofs = tile_set->tile_get_occluder_offset(c.id);
 			} else {
 				occluder = tile_set->tile_get_light_occluder(c.id);
-				occluder_ofs = Vector2();
 			}
 			if (occluder.is_valid()) {
-
+				Vector2 occluder_ofs = tile_set->tile_get_occluder_offset(c.id);
 				Transform2D xform;
 				xform.set_origin(offset.floor() + q.pos);
 				_fix_cell_transform(xform, c, occluder_ofs + center_ofs, s);


### PR DESCRIPTION
This is NOT related to #14388! (couldn't find an issue about this)

This fixes a graphical bug where the light occluders used by tilemaps weren't getting offset anymore, thus they'd be positioned incorrectly.

I tried on all 3 tilemap positioning modes and it seemed to work on every single one with this.