### PR TITLE
Makes 3D editor grid color update without restart.

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -4259,67 +4259,26 @@ void SpatialEditor::_init_indicators() {
 		indicator_mat->set_flag(SpatialMaterial::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
 		indicator_mat->set_flag(SpatialMaterial::FLAG_SRGB_VERTEX_COLOR, true);
 
-		PoolVector<Color> grid_colors[3];
-		PoolVector<Vector3> grid_points[3];
 		Vector<Color> origin_colors;
 		Vector<Vector3> origin_points;
-
-		Color grid_color = EditorSettings::get_singleton()->get("editors/3d/grid_color");
 
 		for (int i = 0; i < 3; i++) {
 			Vector3 axis;
 			axis[i] = 1;
-			Vector3 axis_n1;
-			axis_n1[(i + 1) % 3] = 1;
-			Vector3 axis_n2;
-			axis_n2[(i + 2) % 3] = 1;
+
+			grid_enable[i] = false;
+			grid_visible[i] = false;
 
 			origin_colors.push_back(Color(axis.x, axis.y, axis.z));
 			origin_colors.push_back(Color(axis.x, axis.y, axis.z));
 			origin_points.push_back(axis * 4096);
 			origin_points.push_back(axis * -4096);
-#define ORIGIN_GRID_SIZE 50
-
-			for (int j = -ORIGIN_GRID_SIZE; j <= ORIGIN_GRID_SIZE; j++) {
-
-				Vector3 p1 = axis_n1 * j + axis_n2 * -ORIGIN_GRID_SIZE;
-				Vector3 p1_dest = p1 * (-axis_n2 + axis_n1);
-				Vector3 p2 = axis_n2 * j + axis_n1 * -ORIGIN_GRID_SIZE;
-				Vector3 p2_dest = p2 * (-axis_n1 + axis_n2);
-
-				Color line_color = grid_color;
-				if (j == 0) {
-					continue;
-				} else if (j % 10 == 0) {
-					line_color *= 1.5;
-				}
-
-				grid_points[i].push_back(p1);
-				grid_points[i].push_back(p1_dest);
-				grid_colors[i].push_back(line_color);
-				grid_colors[i].push_back(line_color);
-
-				grid_points[i].push_back(p2);
-				grid_points[i].push_back(p2_dest);
-				grid_colors[i].push_back(line_color);
-				grid_colors[i].push_back(line_color);
-			}
-
-			grid[i] = VisualServer::get_singleton()->mesh_create();
-			Array d;
-			d.resize(VS::ARRAY_MAX);
-			d[VisualServer::ARRAY_VERTEX] = grid_points[i];
-			d[VisualServer::ARRAY_COLOR] = grid_colors[i];
-			VisualServer::get_singleton()->mesh_add_surface_from_arrays(grid[i], VisualServer::PRIMITIVE_LINES, d);
-			VisualServer::get_singleton()->mesh_surface_set_material(grid[i], 0, indicator_mat->get_rid());
-			grid_instance[i] = VisualServer::get_singleton()->instance_create2(grid[i], get_tree()->get_root()->get_world()->get_scenario());
-
-			grid_visible[i] = false;
-			grid_enable[i] = false;
-			VisualServer::get_singleton()->instance_set_visible(grid_instance[i], false);
-			VisualServer::get_singleton()->instance_geometry_set_cast_shadows_setting(grid_instance[i], VS::SHADOW_CASTING_SETTING_OFF);
-			VS::get_singleton()->instance_set_layer_mask(grid_instance[i], 1 << SpatialEditorViewport::GIZMO_GRID_LAYER);
 		}
+
+		grid_enable[1] = true;
+		grid_visible[1] = true;
+
+		_init_grid();
 
 		origin = VisualServer::get_singleton()->mesh_create();
 		Array d;
@@ -4338,9 +4297,6 @@ void SpatialEditor::_init_indicators() {
 
 		VisualServer::get_singleton()->instance_geometry_set_cast_shadows_setting(origin_instance, VS::SHADOW_CASTING_SETTING_OFF);
 
-		VisualServer::get_singleton()->instance_set_visible(grid_instance[1], true);
-		grid_enable[1] = true;
-		grid_visible[1] = true;
 		grid_enabled = true;
 		last_grid_snap = 1;
 	}
@@ -4609,17 +4565,75 @@ void SpatialEditor::_init_indicators() {
 	_generate_selection_box();
 }
 
+void SpatialEditor::_init_grid() {
+
+	PoolVector<Color> grid_colors[3];
+	PoolVector<Vector3> grid_points[3];
+
+	Color grid_color = EditorSettings::get_singleton()->get("editors/3d/grid_color");
+
+	for (int i = 0; i < 3; i++) {
+		Vector3 axis;
+		axis[i] = 1;
+		Vector3 axis_n1;
+		axis_n1[(i + 1) % 3] = 1;
+		Vector3 axis_n2;
+		axis_n2[(i + 2) % 3] = 1;
+
+#define ORIGIN_GRID_SIZE 50
+
+		for (int j = -ORIGIN_GRID_SIZE; j <= ORIGIN_GRID_SIZE; j++) {
+			Vector3 p1 = axis_n1 * j + axis_n2 * -ORIGIN_GRID_SIZE;
+			Vector3 p1_dest = p1 * (-axis_n2 + axis_n1);
+			Vector3 p2 = axis_n2 * j + axis_n1 * -ORIGIN_GRID_SIZE;
+			Vector3 p2_dest = p2 * (-axis_n1 + axis_n2);
+
+			Color line_color = grid_color;
+			if (j == 0) {
+				continue;
+			} else if (j % 10 == 0) {
+				line_color *= 1.5;
+			}
+
+			grid_points[i].push_back(p1);
+			grid_points[i].push_back(p1_dest);
+			grid_colors[i].push_back(line_color);
+			grid_colors[i].push_back(line_color);
+
+			grid_points[i].push_back(p2);
+			grid_points[i].push_back(p2_dest);
+			grid_colors[i].push_back(line_color);
+			grid_colors[i].push_back(line_color);
+		}
+
+		grid[i] = VisualServer::get_singleton()->mesh_create();
+		Array d;
+		d.resize(VS::ARRAY_MAX);
+		d[VisualServer::ARRAY_VERTEX] = grid_points[i];
+		d[VisualServer::ARRAY_COLOR] = grid_colors[i];
+		VisualServer::get_singleton()->mesh_add_surface_from_arrays(grid[i], VisualServer::PRIMITIVE_LINES, d);
+		VisualServer::get_singleton()->mesh_surface_set_material(grid[i], 0, indicator_mat->get_rid());
+		grid_instance[i] = VisualServer::get_singleton()->instance_create2(grid[i], get_tree()->get_root()->get_world()->get_scenario());
+
+		VisualServer::get_singleton()->instance_set_visible(grid_instance[i], grid_visible[i]);
+		VisualServer::get_singleton()->instance_geometry_set_cast_shadows_setting(grid_instance[i], VS::SHADOW_CASTING_SETTING_OFF);
+		VS::get_singleton()->instance_set_layer_mask(grid_instance[i], 1 << SpatialEditorViewport::GIZMO_GRID_LAYER);
+	}
+}
+
 void SpatialEditor::_finish_indicators() {
 
 	VisualServer::get_singleton()->free(origin_instance);
 	VisualServer::get_singleton()->free(origin);
+
+	_finish_grid();
+}
+
+void SpatialEditor::_finish_grid() {
 	for (int i = 0; i < 3; i++) {
 		VisualServer::get_singleton()->free(grid_instance[i]);
 		VisualServer::get_singleton()->free(grid[i]);
 	}
-	//VisualServer::get_singleton()->free(poly);
-	//VisualServer::get_singleton()->free(indicators_instance);
-	//VisualServer::get_singleton()->free(indicators);
 }
 
 bool SpatialEditor::is_any_freelook_active() const {
@@ -4733,6 +4747,10 @@ void SpatialEditor::_notification(int p_what) {
 		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_3_VIEWPORTS), get_icon("Panels3", "EditorIcons"));
 		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_3_VIEWPORTS_ALT), get_icon("Panels3Alt", "EditorIcons"));
 		view_menu->get_popup()->set_item_icon(view_menu->get_popup()->get_item_index(MENU_VIEW_USE_4_VIEWPORTS), get_icon("Panels4", "EditorIcons"));
+
+		// Update grid color by rebuilding grid.
+		_finish_grid();
+		_init_grid();
 	}
 }
 

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -533,7 +533,9 @@ private:
 
 	void _instance_scene();
 	void _init_indicators();
+	void _init_grid();
 	void _finish_indicators();
+	void _finish_grid();
 
 	void _toggle_maximize_view(Object *p_viewport);
 


### PR DESCRIPTION
Fixes #14415 

I didn't know if there is a better way to change the grid's color than to simply re-generate it, so that's what I did. If there's a better way I'll happily optimize it.