### PR TITLE
Fixes vsync setting ignored when using a separate thread for rendering

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -92,14 +92,16 @@ public:
 		bool resizable;
 		bool borderless_window;
 		bool maximized;
+		bool use_vsync;
 		float get_aspect() const { return (float)width / (float)height; }
-		VideoMode(int p_width = 1024, int p_height = 600, bool p_fullscreen = false, bool p_resizable = true, bool p_borderless_window = false, bool p_maximized = false) {
+		VideoMode(int p_width = 1024, int p_height = 600, bool p_fullscreen = false, bool p_resizable = true, bool p_borderless_window = false, bool p_maximized = false, bool p_use_vsync = false) {
 			width = p_width;
 			height = p_height;
 			fullscreen = p_fullscreen;
 			resizable = p_resizable;
 			borderless_window = p_borderless_window;
 			maximized = p_maximized;
+			use_vsync = p_use_vsync;
 		}
 	};
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -819,7 +819,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		OS::get_singleton()->_allow_hidpi = GLOBAL_DEF("display/window/dpi/allow_hidpi", false);
 	}
 
-	use_vsync = GLOBAL_DEF("display/window/vsync/use_vsync", true);
+	video_mode.use_vsync = GLOBAL_DEF("display/window/vsync/use_vsync", true);
 
 	GLOBAL_DEF("rendering/quality/intended_usage/framebuffer_allocation", 2);
 	GLOBAL_DEF("rendering/quality/intended_usage/framebuffer_allocation.mobile", 3);
@@ -992,8 +992,6 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	// also init our arvr_server from here
 	arvr_server = memnew(ARVRServer);
-
-	OS::get_singleton()->set_use_vsync(use_vsync);
 
 	register_core_singletons();
 

--- a/platform/haiku/os_haiku.cpp
+++ b/platform/haiku/os_haiku.cpp
@@ -105,6 +105,7 @@ void OS_Haiku::initialize(const VideoMode &p_desired, int p_video_driver, int p_
 	context_gl = memnew(ContextGL_Haiku(window));
 	context_gl->initialize();
 	context_gl->make_current();
+	context_gl->set_use_vsync(current_video_mode.use_vsync);
 
 	/* Port to GLES 3 rasterizer */
 	//rasterizer = memnew(RasterizerGLES2);

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1089,6 +1089,8 @@ void OS_OSX::initialize(const VideoMode &p_desired, int p_video_driver, int p_au
 
 	[context makeCurrentContext];
 
+	set_use_vsync(p_desired.use_vsync);
+
 	[NSApp activateIgnoringOtherApps:YES];
 
 	_update_window();

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -241,6 +241,7 @@ void OSUWP::initialize(const VideoMode &p_desired, int p_video_driver, int p_aud
 
 	RasterizerGLES3::register_config();
 	RasterizerGLES3::make_current();
+	gl_context->set_use_vsync(vm.use_vsync);
 
 	visual_server = memnew(VisualServerRaster);
 	// FIXME: Reimplement threaded rendering? Or remove?

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1074,6 +1074,8 @@ void OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int 
 	RasterizerGLES3::register_config();
 
 	RasterizerGLES3::make_current();
+
+	gl_context->set_use_vsync(video_mode.use_vsync);
 #endif
 
 	visual_server = memnew(VisualServerRaster);

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -286,6 +286,8 @@ void OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_au
 
 	RasterizerGLES3::make_current();
 
+	context_gl->set_use_vsync(current_videomode.use_vsync);
+
 #endif
 	visual_server = memnew(VisualServerRaster);
 


### PR DESCRIPTION
Setting the vsync in the main thread, after the rendering thread starts
and takes the OpenGL context fails, so we need to do that before.
Also, for some reason, the main thread cannot make current the context
anymore.

Fixes #13447