### PR TITLE
Ignore Visual Studio '*.natvis' files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,9 @@ bld/
 # Hints for improving IntelliSense, created together with VS project
 cpp.hint
 
+# Visualizers for the VS debugger
+*.natvis
+
 #NUNIT
 *.VisualState.xml
 TestResult.xml


### PR DESCRIPTION
`*.natvis` files are used to define custom visualizations for the VS debugger. If more developers used VS it might make sense to include visualizations for the most common Godot types (or to generate them when building the VS project, similar to `cpp.hint`) but for now it seems simpler to just ignore them.