### PR TITLE
Remove physics / render layer flyout label.

### DIFF
--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -430,24 +430,19 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 
 			} else if (hint == PROPERTY_HINT_LAYERS_2D_PHYSICS || hint == PROPERTY_HINT_LAYERS_2D_RENDER || hint == PROPERTY_HINT_LAYERS_3D_PHYSICS || hint == PROPERTY_HINT_LAYERS_3D_RENDER) {
 
-				String title;
 				String basename;
 				switch (hint) {
 					case PROPERTY_HINT_LAYERS_2D_RENDER:
 						basename = "layer_names/2d_render";
-						title = "2D Render Layers";
 						break;
 					case PROPERTY_HINT_LAYERS_2D_PHYSICS:
 						basename = "layer_names/2d_physics";
-						title = "2D Physics Layers";
 						break;
 					case PROPERTY_HINT_LAYERS_3D_RENDER:
 						basename = "layer_names/3d_render";
-						title = "3D Render Layers";
 						break;
 					case PROPERTY_HINT_LAYERS_3D_PHYSICS:
 						basename = "layer_names/3d_physics";
-						title = "3D Physics Layers";
 						break;
 				}
 
@@ -469,11 +464,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 
 				show();
 
-				value_label[0]->set_text(title);
-				value_label[0]->show();
-				value_label[0]->set_position(Vector2(4, 4) * EDSCALE);
-
-				checks20gc->set_position(Vector2(4, 4) * EDSCALE + Vector2(0, value_label[0]->get_size().height + 4 * EDSCALE));
+				checks20gc->set_position(Vector2(4, 4) * EDSCALE);
 				checks20gc->set_size(checks20gc->get_minimum_size());
 
 				set_size(Vector2(4, 4) * EDSCALE + checks20gc->get_position() + checks20gc->get_size());


### PR DESCRIPTION
As discussed in https://github.com/godotengine/godot/issues/14363 and https://github.com/godotengine/godot/pull/14374 as it does more damage than being helpful.
![image](https://user-images.githubusercontent.com/9631152/33797482-f1c75edc-dd08-11e7-8c96-c5342c7327e5.png)

The checkboxes are not really centered because they have an unnecessary margin to the right (which they shouldn't have if there is no text). Didn't quickly understand how that minimum size is calculated so I ignored it for this PR; tell me if you can't live without that additional checkbox "fix".

On another note, why don't we make the squares editable directly in the property editor? With the flyout only opening when clicking the drop down arrow (which might get removed in that turn), possibly allowing menu features like "Invert" or "Select All / Clear All".