### PR TITLE
Fix setting vsync from GDScript being ignored

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -433,15 +433,6 @@ Error _OS::set_thread_name(const String &p_name) {
 	return Thread::set_name(p_name);
 };
 
-void _OS::set_use_vsync(bool p_enable) {
-	OS::get_singleton()->set_use_vsync(p_enable);
-}
-
-bool _OS::is_vsync_enabled() const {
-
-	return OS::get_singleton()->is_vsync_enabled();
-}
-
 _OS::PowerState _OS::get_power_state() {
 	return _OS::PowerState(OS::get_singleton()->get_power_state());
 }
@@ -1112,9 +1103,6 @@ void _OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("alert", "text", "title"), &_OS::alert, DEFVAL("Alert!"));
 
 	ClassDB::bind_method(D_METHOD("set_thread_name", "name"), &_OS::set_thread_name);
-
-	ClassDB::bind_method(D_METHOD("set_use_vsync", "enable"), &_OS::set_use_vsync);
-	ClassDB::bind_method(D_METHOD("is_vsync_enabled"), &_OS::is_vsync_enabled);
 
 	ClassDB::bind_method(D_METHOD("has_feature", "tag_name"), &_OS::has_feature);
 

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -311,9 +311,6 @@ public:
 
 	Error set_thread_name(const String &p_name);
 
-	void set_use_vsync(bool p_enable);
-	bool is_vsync_enabled() const;
-
 	PowerState get_power_state();
 	int get_power_seconds_left();
 	int get_power_percent_left();

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -565,6 +565,11 @@ public:
 	virtual bool has_feature(Features p_feature) const { return visual_server->has_feature(p_feature); }
 	virtual bool has_os_feature(const String &p_feature) const { return visual_server->has_os_feature(p_feature); }
 
+	/* VSYNC */
+
+	FUNC1(set_use_vsync, bool);
+	FUNC0RC(bool, is_vsync_enabled);
+
 	VisualServerWrapMT(VisualServer *p_contained, bool p_create_thread);
 	~VisualServerWrapMT();
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -30,6 +30,7 @@
 #include "visual_server.h"
 
 #include "method_bind_ext.gen.inc"
+#include "os/os.h"
 #include "project_settings.h"
 
 VisualServer *VisualServer::singleton = NULL;
@@ -1678,6 +1679,9 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_os_feature", "feature"), &VisualServer::has_os_feature);
 	ClassDB::bind_method(D_METHOD("set_debug_generate_wireframes", "generate"), &VisualServer::set_debug_generate_wireframes);
 
+	ClassDB::bind_method(D_METHOD("set_use_vsync", "enable"), &VisualServer::set_use_vsync);
+	ClassDB::bind_method(D_METHOD("is_vsync_enabled"), &VisualServer::is_vsync_enabled);
+
 	BIND_CONSTANT(NO_INDEX_ARRAY);
 	BIND_CONSTANT(ARRAY_WEIGHTS_SIZE);
 	BIND_CONSTANT(CANVAS_ITEM_Z_MIN);
@@ -1915,6 +1919,15 @@ RID VisualServer::instance_create2(RID p_base, RID p_scenario) {
 	instance_set_base(instance, p_base);
 	instance_set_scenario(instance, p_scenario);
 	return instance;
+}
+
+void VisualServer::set_use_vsync(bool p_enable) {
+	OS::get_singleton()->set_use_vsync(p_enable);
+}
+
+bool VisualServer::is_vsync_enabled() const {
+
+	return OS::get_singleton()->is_vsync_enabled();
 }
 
 VisualServer::VisualServer() {

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -963,6 +963,11 @@ public:
 
 	virtual void set_debug_generate_wireframes(bool p_generate) = 0;
 
+	/* VSYNC */
+
+	virtual void set_use_vsync(bool p_enable);
+	virtual bool is_vsync_enabled() const;
+
 	VisualServer();
 	virtual ~VisualServer();
 };


### PR DESCRIPTION
The API call to set_use_vsync has been moved from OS to VisualServer.
This permits to internally use the rendering thread to set the vsync.

is_vsync_enabled has been moved too for consistency.

Related to #13447