### PR TITLE
Fix #14429 GIProbe does not work with SpotLights

### DIFF
--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -2283,7 +2283,7 @@ void VisualServerScene::_bake_gi_probe_light(const GIProbeDataHeader *header, co
 					if (angle > light_cache.spot_angle)
 						continue;
 
-					float d = CLAMP(angle / light_cache.spot_angle, 1, 0);
+					float d = CLAMP(angle / light_cache.spot_angle, 0, 1);
 					att *= powf(1.0 - d, light_cache.spot_attenuation);
 				}
 


### PR DESCRIPTION
Looks like a little mistake. 
This change seems to fix the problem

The result:
![image](https://user-images.githubusercontent.com/1430971/33799033-f090aa76-dd23-11e7-93fb-01a5921b8760.png)
