### PR TITLE
Clicking outside a modal window should terminate the model, and that'…

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1663,6 +1663,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 						top->notification(Control::NOTIFICATION_MODAL_CLOSE);
 						top->_modal_stack_remove();
 						top->hide();
+						return; // exiting modal mode should be the only effect
 					} else {
 						break;
 					}


### PR DESCRIPTION
…s it - the click itself should have no effect. This is currently other windowing systems' default behavior. Fixes #12451