### PR TITLE
PropertyEditor: Fix display of property doc in tooltip

### DIFF
--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -1036,7 +1036,6 @@ bool ClassDB::get_property(Object *p_object, const StringName &p_property, Varia
 			r_value = *c;
 			return true;
 		}
-		//if (check->constant_map.fin)
 
 		check = check->inherits_ptr;
 	}
@@ -1157,24 +1156,6 @@ bool ClassDB::has_method(StringName p_class, StringName p_method, bool p_no_inhe
 			return true;
 		if (p_no_inheritance)
 			return false;
-		check = check->inherits_ptr;
-	}
-
-	return false;
-}
-
-bool ClassDB::get_setter_and_type_for_property(const StringName &p_class, const StringName &p_prop, StringName &r_class, StringName &r_setter) {
-
-	ClassInfo *type = classes.getptr(p_class);
-	ClassInfo *check = type;
-	while (check) {
-
-		if (check->property_setget.has(p_prop)) {
-			r_class = check->name;
-			r_setter = check->property_setget[p_prop].setter;
-			return true;
-		}
-
 		check = check->inherits_ptr;
 	}
 

--- a/core/class_db.h
+++ b/core/class_db.h
@@ -349,8 +349,6 @@ public:
 
 	static StringName get_category(const StringName &p_node);
 
-	static bool get_setter_and_type_for_property(const StringName &p_class, const StringName &p_prop, StringName &r_class, StringName &r_setter);
-
 	static void set_class_enabled(StringName p_class, bool p_enable);
 	static bool is_class_enabled(StringName p_class);
 

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -647,7 +647,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 					}
 				}
 
-				if (type)
+				if (type != Variant::NIL)
 					property_select->select_property_from_basic_type(type, v);
 
 				updating = false;
@@ -2802,13 +2802,12 @@ void PropertyEditor::update_tree() {
 			TreeItem *sep = tree->create_item(root);
 			current_category = sep;
 			String type = p.name;
-			//*
+
 			if (has_icon(type, "EditorIcons"))
 				sep->set_icon(0, get_icon(type, "EditorIcons"));
 			else
 				sep->set_icon(0, get_icon("Object", "EditorIcons"));
 
-			//*/
 			sep->set_text(0, type);
 			sep->set_expand_right(0, true);
 			sep->set_selectable(0, false);
@@ -2934,38 +2933,36 @@ void PropertyEditor::update_tree() {
 		}
 
 		if (use_doc_hints) {
-			StringName setter;
-			StringName type;
-			if (ClassDB::get_setter_and_type_for_property(obj->get_class_name(), p.name, type, setter)) {
 
-				String descr;
-				bool found = false;
-				Map<StringName, Map<StringName, String> >::Element *E = descr_cache.find(type);
-				if (E) {
+			StringName classname = obj->get_class_name();
+			StringName propname = p.name;
+			String descr;
+			bool found = false;
 
-					Map<StringName, String>::Element *F = E->get().find(setter);
-					if (F) {
-						found = true;
-						descr = F->get();
-					}
+			Map<StringName, Map<StringName, String> >::Element *E = descr_cache.find(classname);
+			if (E) {
+				Map<StringName, String>::Element *F = E->get().find(propname);
+				if (F) {
+					found = true;
+					descr = F->get();
 				}
-				if (!found) {
+			}
 
-					DocData *dd = EditorHelp::get_doc_data();
-					Map<String, DocData::ClassDoc>::Element *E = dd->class_list.find(type);
-					if (E) {
-						for (int i = 0; i < E->get().methods.size(); i++) {
-							if (E->get().methods[i].name == setter.operator String()) {
-								descr = E->get().methods[i].description.strip_edges().word_wrap(80);
-							}
+			if (!found) {
+				DocData *dd = EditorHelp::get_doc_data();
+				Map<String, DocData::ClassDoc>::Element *E = dd->class_list.find(classname);
+				if (E) {
+					for (int i = 0; i < E->get().properties.size(); i++) {
+						if (E->get().properties[i].name == propname.operator String()) {
+							descr = E->get().properties[i].description.strip_edges().word_wrap(80);
 						}
 					}
-
-					descr_cache[type][setter] = descr;
 				}
 
-				item->set_tooltip(0, TTR("Property:") + " " + p.name + "\n\n" + descr);
+				descr_cache[classname][propname] = descr;
 			}
+
+			item->set_tooltip(0, TTR("Property:") + " " + p.name + "\n\n" + descr);
 		}
 
 		Dictionary d;

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -363,23 +363,6 @@ void PropertySelector::_item_selected() {
 
 			at_class = ClassDB::get_parent_class(at_class);
 		}
-
-		if (text == String()) {
-
-			StringName setter;
-			StringName type;
-			if (ClassDB::get_setter_and_type_for_property(class_type, name, type, setter)) {
-				Map<String, DocData::ClassDoc>::Element *E = dd->class_list.find(type);
-				if (E) {
-					for (int i = 0; i < E->get().methods.size(); i++) {
-						if (E->get().methods[i].name == setter.operator String()) {
-							text = E->get().methods[i].description;
-						}
-					}
-				}
-			}
-		}
-
 	} else {
 
 		String at_class = class_type;
@@ -516,6 +499,7 @@ void PropertySelector::select_property_from_script(const Ref<Script> &p_script, 
 	search_box->grab_focus();
 	_update_search();
 }
+
 void PropertySelector::select_property_from_basic_type(Variant::Type p_type, const String &p_current) {
 
 	ERR_FAIL_COND(p_type == Variant::NIL);


### PR DESCRIPTION
Since properties were changed to be documented directly instead of via their setter (now hidden in the docs), the tooltips in the Inspector were missing their descriptions. It's now even easier to get the proper description from DocData, so I removed the useless `ClassDB::get_setter_and_type_for_property`.

Also fixed a bug where `PropertySelector::select_property_from_basic_type` was called on `Variant::Nil`.