### PR TITLE
Fix mouse button release not sent to gui_input if it's different from the button that gave focus

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1800,7 +1800,8 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 				_gui_call_input(gui.mouse_focus, mb);
 			}
 
-			if (mb->get_button_index() == gui.mouse_focus_button) {
+			if (mb->get_button_mask() == 0) {
+				// Last mouse button was released
 				gui.mouse_focus = NULL;
 				gui.mouse_focus_button = -1;
 			}


### PR DESCRIPTION
Fixes #14373
See comment https://github.com/godotengine/godot/issues/14373#issuecomment-350515100