### PR TITLE
Fixed documentation errors

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -498,7 +498,7 @@
 			<return type="void">
 			</return>
 			<description>
-				Removes a node and set all its children as children of the parent node (if exists). All even subscriptions that pass by the removed node will be unsubscribed.
+				Removes a node and set all its children as children of the parent node (if exists). All event subscriptions that pass by the removed node will be unsubscribed.
 			</description>
 		</method>
 		<method name="remove_child">

--- a/doc/classes/Transform.xml
+++ b/doc/classes/Transform.xml
@@ -137,18 +137,18 @@
 			</description>
 		</method>
 		<method name="xform">
-			<return type="var">
+			<return type="Vector3">
 			</return>
-			<argument index="0" name="v" type="var">
+			<argument index="0" name="v" type="Vector3">
 			</argument>
 			<description>
 				Transforms the given vector "v" by this transform.
 			</description>
 		</method>
 		<method name="xform_inv">
-			<return type="var">
+			<return type="Vector3">
 			</return>
-			<argument index="0" name="v" type="var">
+			<argument index="0" name="v" type="Vector3">
 			</argument>
 			<description>
 				Inverse-transforms the given vector "v" by this transform.


### PR DESCRIPTION
Fixed some documentation errors for Node and Transform

Node had a typo for `remove_and_skip()`
Transform had the incorrect return type for `xform()` and `xform_inv()`