### PR TITLE
iOS: Drop obsolete code from never-public modules

### DIFF
--- a/platform/iphone/in_app_store.mm
+++ b/platform/iphone/in_app_store.mm
@@ -31,10 +31,6 @@
 
 #include "in_app_store.h"
 
-#ifdef MODULE_FUSEBOXX_ENABLED
-#import "modules/fuseboxx/ios/FuseSDK.h"
-#endif
-
 extern "C" {
 #import <Foundation/Foundation.h>
 #import <StoreKit/StoreKit.h>
@@ -224,10 +220,6 @@ Error InAppStore::request_product_info(Variant p_params) {
 					[pending_transactions setObject:transaction forKey:transaction.payment.productIdentifier];
 				}
 
-#ifdef MODULE_FUSEBOXX_ENABLED
-				printf("Registering transaction on Fuseboxx!\n");
-				[FuseSDK registerInAppPurchase:transaction];
-#endif
 			}; break;
 			case SKPaymentTransactionStateFailed: {
 				printf("status transaction failed!\n");


### PR DESCRIPTION
Those modules likely date from old Okam days, I've never seen any of them in the open source repo.

If they're still in use by @punto-, I think we should find a better way to plugin OS functionality from within a module so that we don't need to clutter the official platform support.

Note: I haven't tested the changes as I don't have any iThing. Especially, it would be good to check that the now-useless callbacks are removed are not problematic (they could be kept with `return false;` otherwise).

iOS code still needs a real cleanup from someone knowing what they're doing though, e.g.:
```
#ifdef ADD_MICRO_GAMEPAD // disabling this for now, only available on iOS 9+,
		// while we are setting that as the minimum, seems our
		// build environment doesn't like it
```
(cc @volzhs @endragor @BastiaanOlij)