### PR TITLE
TileMap: Drop unused center_x/center_y booleans

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -38,20 +38,6 @@
 				Return the tile index of the cell referenced by a Vector2.
 			</description>
 		</method>
-		<method name="get_center_x" qualifiers="const">
-			<return type="bool">
-			</return>
-			<description>
-				Return true if tiles are to be centered in x coordinate (by default this is false and they are drawn from upper left cell corner).
-			</description>
-		</method>
-		<method name="get_center_y" qualifiers="const">
-			<return type="bool">
-			</return>
-			<description>
-				Return true if tiles are to be centered in y coordinate (by default this is false and they are drawn from upper left cell corner).
-			</description>
-		</method>
 		<method name="get_collision_layer_bit" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -174,24 +160,6 @@
 				Set the tile index for the cell referenced by a Vector2 of grid-based coordinates.
 				A tile index of -1 clears the cell.
 				Optionally, the tile can also be flipped over the X and Y axes or transposed.
-			</description>
-		</method>
-		<method name="set_center_x">
-			<return type="void">
-			</return>
-			<argument index="0" name="enable" type="bool">
-			</argument>
-			<description>
-				Set tiles to be centered in x coordinate. (by default this is false and they are drawn from upper left cell corner).
-			</description>
-		</method>
-		<method name="set_center_y">
-			<return type="void">
-			</return>
-			<argument index="0" name="enable" type="bool">
-			</argument>
-			<description>
-				Set tiles to be centered in y coordinate. (by default this is false and they are drawn from upper left cell corner).
 			</description>
 		</method>
 		<method name="set_collision_layer_bit">

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -28,6 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 #include "tile_map.h"
+
 #include "io/marshalls.h"
 #include "method_bind_ext.gen.inc"
 #include "os/os.h"
@@ -169,10 +170,12 @@ void TileMap::set_cell_size(Size2 p_size) {
 	_recreate_quadrants();
 	emit_signal("settings_changed");
 }
+
 Size2 TileMap::get_cell_size() const {
 
 	return cell_size;
 }
+
 void TileMap::set_quadrant_size(int p_size) {
 
 	ERR_FAIL_COND(p_size < 1);
@@ -182,30 +185,10 @@ void TileMap::set_quadrant_size(int p_size) {
 	_recreate_quadrants();
 	emit_signal("settings_changed");
 }
+
 int TileMap::get_quadrant_size() const {
 
 	return quadrant_size;
-}
-
-void TileMap::set_center_x(bool p_enable) {
-
-	center_x = p_enable;
-	_recreate_quadrants();
-	emit_signal("settings_changed");
-}
-bool TileMap::get_center_x() const {
-
-	return center_x;
-}
-void TileMap::set_center_y(bool p_enable) {
-
-	center_y = p_enable;
-	_recreate_quadrants();
-	emit_signal("settings_changed");
-}
-bool TileMap::get_center_y() const {
-
-	return center_y;
 }
 
 void TileMap::_fix_cell_transform(Transform2D &xform, const Cell &p_cell, const Vector2 &p_offset, const Size2 &p_sc) {
@@ -1473,12 +1456,6 @@ void TileMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_tile_origin", "origin"), &TileMap::set_tile_origin);
 	ClassDB::bind_method(D_METHOD("get_tile_origin"), &TileMap::get_tile_origin);
 
-	ClassDB::bind_method(D_METHOD("set_center_x", "enable"), &TileMap::set_center_x);
-	ClassDB::bind_method(D_METHOD("get_center_x"), &TileMap::get_center_x);
-
-	ClassDB::bind_method(D_METHOD("set_center_y", "enable"), &TileMap::set_center_y);
-	ClassDB::bind_method(D_METHOD("get_center_y"), &TileMap::get_center_y);
-
 	ClassDB::bind_method(D_METHOD("set_clip_uv", "enable"), &TileMap::set_clip_uv);
 	ClassDB::bind_method(D_METHOD("get_clip_uv"), &TileMap::get_clip_uv);
 
@@ -1580,8 +1557,6 @@ TileMap::TileMap() {
 	quadrant_order_dirty = false;
 	quadrant_size = 16;
 	cell_size = Size2(64, 64);
-	center_x = false;
-	center_y = false;
 	collision_layer = 1;
 	collision_mask = 1;
 	friction = 1;

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -68,7 +68,6 @@ private:
 	Ref<TileSet> tile_set;
 	Size2i cell_size;
 	int quadrant_size;
-	bool center_x, center_y;
 	Mode mode;
 	Transform2D custom_transform;
 	HalfOffset half_offset;
@@ -230,11 +229,6 @@ public:
 
 	void set_quadrant_size(int p_size);
 	int get_quadrant_size() const;
-
-	void set_center_x(bool p_enable);
-	bool get_center_x() const;
-	void set_center_y(bool p_enable);
-	bool get_center_y() const;
 
 	void set_cell(int p_x, int p_y, int p_tile, bool p_flip_x = false, bool p_flip_y = false, bool p_transpose = false, Vector2 p_autotile_coord = Vector2());
 	int get_cell(int p_x, int p_y) const;


### PR DESCRIPTION
Two years later they are still unused and we do not know their intend use case, so tschüss.
Closes #2513.