### PR TITLE
Fix skybox generation imprecision with Clang

### DIFF
--- a/scene/resources/sky_box.cpp
+++ b/scene/resources/sky_box.cpp
@@ -180,7 +180,7 @@ Ref<Image> ProceduralSky::_generate_sky() {
 
 				normal.normalize();
 
-				float v_angle = Math::acos(normal.y);
+				float v_angle = Math::acos(CLAMP(normal.y, -1.0, 1.0));
 
 				Color color;
 
@@ -193,7 +193,7 @@ Ref<Image> ProceduralSky::_generate_sky() {
 					float c = v_angle / (Math_PI * 0.5);
 					color = sky_horizon_linear.linear_interpolate(sky_top_linear, Math::ease(1.0 - c, sky_curve));
 
-					float sun_angle = Math::rad2deg(Math::acos(sun.dot(normal)));
+					float sun_angle = Math::rad2deg(Math::acos(CLAMP(sun.dot(normal), -1.0, 1.0)));
 
 					if (sun_angle < sun_angle_min) {
 						color = color.blend(sun_color);


### PR DESCRIPTION
The bug generated a "blue circle" at the bottom end of the y axis,
and probably one too at the other end.
This is caused by a normalization of a vector which results in its y component
to be sometimes > 1.0 or < -1.0 in Clang.
This value is then used with acos(), which returns NaN.

Fixes #11247