### PR TITLE
Shader Language: Add in-for declared variables within for-block scope.

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -3426,7 +3426,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const Map<StringName, Bui
 			}
 
 			BlockNode *block = alloc_node<BlockNode>();
-			block->parent_block = p_block;
+			block->parent_block = init_block;
 			cf->blocks.push_back(block);
 			p_block->statements.push_back(cf);
 


### PR DESCRIPTION
Before this commit, in-for declared variables were unavailable within for-block scope.

Fix #14456.