### PR TITLE
Fix SceneTreeEditor crashing when calling _deselect_items

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -484,7 +484,8 @@ void SceneTreeEditor::_selected_changed() {
 void SceneTreeEditor::_deselect_items() {
 
 	// Clear currently elected items in scene tree dock.
-	editor_selection->clear();
+	if (editor_selection)
+		editor_selection->clear();
 }
 
 void SceneTreeEditor::_cell_multi_selected(Object *p_object, int p_cell, bool p_selected) {


### PR DESCRIPTION
The crash can be triggered for instance by trying to reparent a node
and clicking on the background of the Reparent Node window.