### PR TITLE
Fix CheckButton & CheckBox minimum size

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -587,9 +587,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	// Checkbox
 	Ref<StyleBoxFlat> sb_checkbox = style_menu->duplicate();
-	// HACK, in reality, the checkbox draws the text over the icon by default, so the margin compensates that.
-	const int cb_w = theme->get_icon("GuiChecked", "EditorIcons")->get_width() + default_margin_size;
-	sb_checkbox->set_default_margin(MARGIN_LEFT, cb_w * EDSCALE);
+	sb_checkbox->set_default_margin(MARGIN_LEFT, default_margin_size * EDSCALE);
 	sb_checkbox->set_default_margin(MARGIN_RIGHT, default_margin_size * EDSCALE);
 	sb_checkbox->set_default_margin(MARGIN_TOP, default_margin_size * EDSCALE);
 	sb_checkbox->set_default_margin(MARGIN_BOTTOM, default_margin_size * EDSCALE);

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -55,6 +55,10 @@ Size2 Button::get_minimum_size() const {
 	return get_stylebox("normal")->get_minimum_size() + minsize;
 }
 
+void Button::_set_internal_margin(Margin p_margin, float p_value) {
+	_internal_margin[p_margin] = p_value;
+}
+
 void Button::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_TRANSLATION_CHANGED) {
@@ -136,7 +140,7 @@ void Button::_notification(int p_what) {
 
 		Point2 icon_ofs = (!_icon.is_null()) ? Point2(_icon->get_width() + get_constant("hseparation"), 0) : Point2();
 		int text_clip = size.width - style->get_minimum_size().width - icon_ofs.width;
-		Point2 text_ofs = (size - style->get_minimum_size() - icon_ofs - font->get_string_size(xl_text)) / 2.0;
+		Point2 text_ofs = (size - style->get_minimum_size() - icon_ofs - font->get_string_size(xl_text) - Point2(_internal_margin[MARGIN_RIGHT], 0)) / 2.0;
 
 		switch (align) {
 			case ALIGN_LEFT: {
@@ -150,7 +154,7 @@ void Button::_notification(int p_what) {
 				text_ofs += style->get_offset();
 			} break;
 			case ALIGN_RIGHT: {
-				text_ofs.x = size.x - style->get_margin(MARGIN_RIGHT) - font->get_string_size(xl_text).x;
+				text_ofs.x = size.x - style->get_margin(MARGIN_RIGHT) - font->get_string_size(xl_text).x - _internal_margin[MARGIN_RIGHT];
 				text_ofs.y += style->get_offset().y;
 			} break;
 		}
@@ -263,6 +267,10 @@ Button::Button(const String &p_text) {
 	set_mouse_filter(MOUSE_FILTER_STOP);
 	set_text(p_text);
 	align = ALIGN_CENTER;
+
+	for (int i = 0; i < 4; i++) {
+		_internal_margin[i] = 0;
+	}
 }
 
 Button::~Button() {

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -140,11 +140,11 @@ void Button::_notification(int p_what) {
 
 		Point2 icon_ofs = (!_icon.is_null()) ? Point2(_icon->get_width() + get_constant("hseparation"), 0) : Point2();
 		int text_clip = size.width - style->get_minimum_size().width - icon_ofs.width;
-		Point2 text_ofs = (size - style->get_minimum_size() - icon_ofs - font->get_string_size(xl_text) - Point2(_internal_margin[MARGIN_RIGHT], 0)) / 2.0;
+		Point2 text_ofs = (size - style->get_minimum_size() - icon_ofs - font->get_string_size(xl_text) - Point2(_internal_margin[MARGIN_RIGHT] - _internal_margin[MARGIN_LEFT], 0)) / 2.0;
 
 		switch (align) {
 			case ALIGN_LEFT: {
-				text_ofs.x = style->get_margin(MARGIN_LEFT) + icon_ofs.x;
+				text_ofs.x = style->get_margin(MARGIN_LEFT) + icon_ofs.x + _internal_margin[MARGIN_LEFT] + get_constant("hseparation");
 				text_ofs.y += style->get_offset().y;
 			} break;
 			case ALIGN_CENTER: {
@@ -154,7 +154,11 @@ void Button::_notification(int p_what) {
 				text_ofs += style->get_offset();
 			} break;
 			case ALIGN_RIGHT: {
-				text_ofs.x = size.x - style->get_margin(MARGIN_RIGHT) - font->get_string_size(xl_text).x - _internal_margin[MARGIN_RIGHT];
+				if (_internal_margin[MARGIN_RIGHT] > 0) {
+					text_ofs.x = size.x - style->get_margin(MARGIN_RIGHT) - font->get_string_size(xl_text).x - _internal_margin[MARGIN_RIGHT] - get_constant("hseparation");
+				} else {
+					text_ofs.x = size.x - style->get_margin(MARGIN_RIGHT) - font->get_string_size(xl_text).x;
+				}
 				text_ofs.y += style->get_offset().y;
 			} break;
 		}
@@ -166,7 +170,11 @@ void Button::_notification(int p_what) {
 			int valign = size.height - style->get_minimum_size().y;
 			if (is_disabled())
 				color_icon.a = 0.4;
-			_icon->draw(ci, style->get_offset() + Point2(0, Math::floor((valign - _icon->get_height()) / 2.0)), color_icon);
+			if (_internal_margin[MARGIN_LEFT] > 0) {
+				_icon->draw(ci, style->get_offset() + Point2(_internal_margin[MARGIN_LEFT] + get_constant("hseparation"), Math::floor((valign - _icon->get_height()) / 2.0)), color_icon);
+			} else {
+				_icon->draw(ci, style->get_offset() + Point2(0, Math::floor((valign - _icon->get_height()) / 2.0)), color_icon);
+			}
 		}
 	}
 }

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -53,9 +53,11 @@ private:
 	Ref<Texture> icon;
 	bool clip_text;
 	TextAlign align;
+	float _internal_margin[4];
 
 protected:
 	virtual Size2 get_minimum_size() const;
+	void _set_internal_margin(Margin p_margin, float p_value);
 	void _notification(int p_what);
 	static void _bind_methods();
 

--- a/scene/gui/check_box.cpp
+++ b/scene/gui/check_box.cpp
@@ -31,18 +31,54 @@
 
 #include "servers/visual_server.h"
 
+Size2 CheckBox::get_icon_size() const {
+	Ref<Texture> checked = Control::get_icon("checked");
+	Ref<Texture> unchecked = Control::get_icon("unchecked");
+	Ref<Texture> radio_checked = Control::get_icon("radio_checked");
+	Ref<Texture> radio_unchecked = Control::get_icon("radio_unchecked");
+
+	Size2 tex_size = Size2(0, 0);
+	if (!checked.is_null())
+		tex_size = Size2(checked->get_width(), checked->get_height());
+	if (!unchecked.is_null())
+		tex_size = Size2(MAX(tex_size.width, unchecked->get_width()), MAX(tex_size.height, unchecked->get_height()));
+	if (!radio_checked.is_null())
+		tex_size = Size2(MAX(tex_size.width, radio_checked->get_width()), MAX(tex_size.height, radio_checked->get_height()));
+	if (!radio_unchecked.is_null())
+		tex_size = Size2(MAX(tex_size.width, radio_unchecked->get_width()), MAX(tex_size.height, radio_unchecked->get_height()));
+	return tex_size;
+}
+
+Size2 CheckBox::get_minimum_size() const {
+
+	Size2 minsize = Button::get_minimum_size();
+	Size2 tex_size = get_icon_size();
+	minsize.width += tex_size.width;
+	if (get_text().length() > 0) {
+		minsize.width += get_constant("hseparation");
+	}
+	Ref<StyleBox> sb = get_stylebox("normal");
+	minsize.height = MAX(minsize.height, tex_size.height + sb->get_margin(MARGIN_TOP) + sb->get_margin(MARGIN_BOTTOM));
+
+	return minsize;
+}
+
 void CheckBox::_notification(int p_what) {
 
-	if (p_what == NOTIFICATION_DRAW) {
+	if (p_what == NOTIFICATION_THEME_CHANGED) {
+
+		_set_internal_margin(MARGIN_LEFT, get_icon_size().width);
+	} else if (p_what == NOTIFICATION_DRAW) {
 
 		RID ci = get_canvas_item();
 
 		Ref<Texture> on = Control::get_icon(is_radio() ? "radio_checked" : "checked");
 		Ref<Texture> off = Control::get_icon(is_radio() ? "radio_unchecked" : "unchecked");
+		Ref<StyleBox> sb = get_stylebox("normal");
 
 		Vector2 ofs;
-		ofs.x = 0;
-		ofs.y = int((get_size().height - on->get_height()) / 2);
+		ofs.x = sb->get_margin(MARGIN_LEFT);
+		ofs.y = int((get_size().height - get_icon_size().height) / 2);
 
 		if (is_pressed())
 			on->draw(ci, ofs);
@@ -60,6 +96,7 @@ CheckBox::CheckBox(const String &p_text) :
 		Button(p_text) {
 	set_toggle_mode(true);
 	set_text_align(ALIGN_LEFT);
+	_set_internal_margin(MARGIN_LEFT, get_icon_size().width);
 }
 
 CheckBox::~CheckBox() {

--- a/scene/gui/check_box.h
+++ b/scene/gui/check_box.h
@@ -39,6 +39,8 @@ class CheckBox : public Button {
 	GDCLASS(CheckBox, Button);
 
 protected:
+	Size2 get_icon_size() const;
+	Size2 get_minimum_size() const;
 	void _notification(int p_what);
 
 	bool is_radio();

--- a/scene/gui/check_button.cpp
+++ b/scene/gui/check_button.cpp
@@ -32,10 +32,7 @@
 #include "print_string.h"
 #include "servers/visual_server.h"
 
-Size2 CheckButton::get_minimum_size() const {
-
-	Size2 minsize = Button::get_minimum_size();
-
+Size2 CheckButton::get_icon_size() const {
 	Ref<Texture> on = Control::get_icon("on");
 	Ref<Texture> off = Control::get_icon("off");
 	Size2 tex_size = Size2(0, 0);
@@ -43,15 +40,29 @@ Size2 CheckButton::get_minimum_size() const {
 		tex_size = Size2(on->get_width(), on->get_height());
 	if (!off.is_null())
 		tex_size = Size2(MAX(tex_size.width, off->get_width()), MAX(tex_size.height, off->get_height()));
-	minsize += Size2(tex_size.width + get_constant("hseparation"), 0);
-	minsize.height = MAX(minsize.height, tex_size.height);
+	return tex_size;
+}
 
-	return get_stylebox("normal")->get_minimum_size() + minsize;
+Size2 CheckButton::get_minimum_size() const {
+
+	Size2 minsize = Button::get_minimum_size();
+	Size2 tex_size = get_icon_size();
+	minsize.width += tex_size.width;
+	if (get_text().length() > 0) {
+		minsize.width += get_constant("hseparation");
+	}
+	Ref<StyleBox> sb = get_stylebox("normal");
+	minsize.height = MAX(minsize.height, tex_size.height + sb->get_margin(MARGIN_TOP) + sb->get_margin(MARGIN_BOTTOM));
+
+	return minsize;
 }
 
 void CheckButton::_notification(int p_what) {
 
-	if (p_what == NOTIFICATION_DRAW) {
+	if (p_what == NOTIFICATION_THEME_CHANGED) {
+
+		_set_internal_margin(MARGIN_RIGHT, get_icon_size().width);
+	} else if (p_what == NOTIFICATION_DRAW) {
 
 		RID ci = get_canvas_item();
 
@@ -59,10 +70,11 @@ void CheckButton::_notification(int p_what) {
 		Ref<Texture> off = Control::get_icon("off");
 
 		Ref<StyleBox> sb = get_stylebox("normal");
-		Size2 sb_ofs = Size2(sb->get_margin(MARGIN_RIGHT), sb->get_margin(MARGIN_TOP));
 		Vector2 ofs;
-		ofs.x = get_minimum_size().width - (on->get_width() + sb_ofs.width);
-		ofs.y = sb_ofs.height;
+		Size2 tex_size = get_icon_size();
+
+		ofs.x = get_size().width - (tex_size.width + sb->get_margin(MARGIN_RIGHT));
+		ofs.y = (get_size().height - tex_size.height) / 2;
 
 		if (is_pressed())
 			on->draw(ci, ofs);
@@ -75,6 +87,8 @@ CheckButton::CheckButton() {
 
 	set_toggle_mode(true);
 	set_text_align(ALIGN_LEFT);
+
+	_set_internal_margin(MARGIN_RIGHT, get_icon_size().width);
 }
 
 CheckButton::~CheckButton() {

--- a/scene/gui/check_button.h
+++ b/scene/gui/check_button.h
@@ -39,6 +39,7 @@ class CheckButton : public Button {
 	GDCLASS(CheckButton, Button);
 
 protected:
+	Size2 get_icon_size() const;
 	virtual Size2 get_minimum_size() const;
 	void _notification(int p_what);
 

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -385,7 +385,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	Ref<StyleBox> cb_empty = memnew(StyleBoxEmpty);
 	cb_empty->set_default_margin(MARGIN_LEFT, 6 * scale);
-	cb_empty->set_default_margin(MARGIN_RIGHT, 70 * scale);
+	cb_empty->set_default_margin(MARGIN_RIGHT, 6 * scale);
 	cb_empty->set_default_margin(MARGIN_TOP, 4 * scale);
 	cb_empty->set_default_margin(MARGIN_BOTTOM, 4 * scale);
 

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -350,15 +350,15 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	// CheckBox
 
 	Ref<StyleBox> cbx_empty = memnew(StyleBoxEmpty);
-	cbx_empty->set_default_margin(MARGIN_LEFT, 22 * scale);
+	cbx_empty->set_default_margin(MARGIN_LEFT, 4 * scale);
 	cbx_empty->set_default_margin(MARGIN_RIGHT, 4 * scale);
 	cbx_empty->set_default_margin(MARGIN_TOP, 4 * scale);
-	cbx_empty->set_default_margin(MARGIN_BOTTOM, 5 * scale);
+	cbx_empty->set_default_margin(MARGIN_BOTTOM, 4 * scale);
 	Ref<StyleBox> cbx_focus = focus;
 	cbx_focus->set_default_margin(MARGIN_LEFT, 4 * scale);
-	cbx_focus->set_default_margin(MARGIN_RIGHT, 22 * scale);
+	cbx_focus->set_default_margin(MARGIN_RIGHT, 4 * scale);
 	cbx_focus->set_default_margin(MARGIN_TOP, 4 * scale);
-	cbx_focus->set_default_margin(MARGIN_BOTTOM, 5 * scale);
+	cbx_focus->set_default_margin(MARGIN_BOTTOM, 4 * scale);
 
 	theme->set_stylebox("normal", "CheckBox", cbx_empty);
 	theme->set_stylebox("pressed", "CheckBox", cbx_empty);


### PR DESCRIPTION
Fix #14510

# CheckButton

![2 1](https://user-images.githubusercontent.com/8281454/33816448-52407bda-de7c-11e7-9a12-21feaf677a32.png)
This is a test scene with 2.1

![current](https://user-images.githubusercontent.com/8281454/33816489-9265e1f0-de7c-11e7-9581-c6d219bed8d9.png)
This is same test scene with 3.0 beta c05c66ee01bcf285d5b4d952fb24c15af281803d

![fixed](https://user-images.githubusercontent.com/8281454/33816493-9bad8204-de7c-11e7-8363-1e32e9127c44.png)
This is same test scene with this PR
**Now it respects on/off icon size of CheckButton.**
previous style for checkbutton was kind of hack.
```cpp
cb_empty->set_default_margin(MARGIN_RIGHT, 70 * scale);
```

![current1](https://user-images.githubusercontent.com/8281454/33816518-c25e8d08-de7c-11e7-8653-32ff2f3fcfec.png)
Here is current "Attach script window"

![fixed1](https://user-images.githubusercontent.com/8281454/33816525-cfd3a1e4-de7c-11e7-8487-8acab79b3ca8.png)
And here is how it look with this PR


# CheckBox
![image](https://user-images.githubusercontent.com/8281454/33818657-7a9bf66a-de89-11e7-9fda-19b369e4f7ca.png)
current

![image](https://user-images.githubusercontent.com/8281454/33818641-6641e2ba-de89-11e7-85b1-77d5aaab201b.png)
![image](https://user-images.githubusercontent.com/8281454/33818707-c4b62ffe-de89-11e7-8847-9530ef812a0b.png)
with this PR
**Now it respects checked/unchecked icon size of CheckBox.**