### PR TITLE
Fix align=center info is not saved with CheckBox & CheckButton

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -253,7 +253,7 @@ void Button::_bind_methods() {
 	ADD_PROPERTYNZ(PropertyInfo(Variant::OBJECT, "icon", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_button_icon", "get_button_icon");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flat"), "set_flat", "is_flat");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::BOOL, "clip_text"), "set_clip_text", "get_clip_text");
-	ADD_PROPERTYNO(PropertyInfo(Variant::INT, "align", PROPERTY_HINT_ENUM, "Left,Center,Right"), "set_text_align", "get_text_align");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "align", PROPERTY_HINT_ENUM, "Left,Center,Right"), "set_text_align", "get_text_align");
 }
 
 Button::Button(const String &p_text) {


### PR DESCRIPTION
Reproduce steps
- add CheckBox or CheckButton node to scene
- change text align mode to Center
- save it
- close scene
- open scene again
- see it's set to Left again