### PR TITLE
Highlight Editor Settings categories

### DIFF
--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -4532,6 +4532,7 @@ void SectionedPropertyEditor::update_category_list() {
 		for (int i = 0; i < sc; i++) {
 
 			TreeItem *parent = section_map[metasection];
+			parent->set_custom_bg_color(0, get_color("prop_subsection", "Editor"));
 
 			if (i > 0) {
 				metasection += "/" + sectionarr[i];
@@ -4585,7 +4586,7 @@ SectionedPropertyEditor::SectionedPropertyEditor() {
 	search_box = NULL;
 
 	VBoxContainer *left_vb = memnew(VBoxContainer);
-	left_vb->set_custom_minimum_size(Size2(160, 0) * EDSCALE);
+	left_vb->set_custom_minimum_size(Size2(170, 0) * EDSCALE);
 	add_child(left_vb);
 
 	sections = memnew(Tree);


### PR DESCRIPTION
Originating from https://github.com/godotengine/godot/issues/14380, but reusing already established design "standards" of other parts in the editor rather than new font style stuff.

- Highlights Editor Settings category / parent items.
- Made category tree a little wider to fully fit the "Window Placement" item into it.
- ~~Also hides the "interface/dialogs" category as manually configuring it doesn't make sense and is more irritating than useful (joke's on me, I introduced it some time ago).~~ s. below

![image](https://user-images.githubusercontent.com/9631152/33830633-345076ea-de75-11e7-9da8-cf05c1770075.png)

