### PR TITLE
Use MinGW specific binutils for debug symbols separation.

### DIFF
--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -4,9 +4,14 @@ import os
 Import('env')
 
 def make_debug_mingw(target, source, env):
-    os.system('objcopy --only-keep-debug %s %s.debug' % (target[0], target[0]))
-    os.system('strip --strip-debug --strip-unneeded %s' % (target[0]))
-    os.system('objcopy --add-gnu-debuglink=%s.debug %s' % (target[0], target[0]))
+    mingw_prefix = ""
+    if (env["bits"] == "32"):
+        mingw_prefix = env["mingw_prefix_32"]
+    else:
+        mingw_prefix = env["mingw_prefix_64"]
+    os.system(mingw_prefix + 'objcopy --only-keep-debug %s %s.debug' % (target[0], target[0]))
+    os.system(mingw_prefix + 'strip --strip-debug --strip-unneeded %s' % (target[0]))
+    os.system(mingw_prefix + 'objcopy --add-gnu-debuglink=%s.debug %s' % (target[0], target[0]))
 
 common_win = [
     "context_gl_win.cpp",


### PR DESCRIPTION
Without MinGW prefix creating separate debug info files fails on macOS.
Tested on macOS and Debian 9.