### PR TITLE
Removed the .bin extension on Linux.

### DIFF
--- a/platform/x11/export/export.cpp
+++ b/platform/x11/export/export.cpp
@@ -44,7 +44,6 @@ void register_x11_exporter() {
 	logo->create_from_image(img);
 	platform->set_logo(logo);
 	platform->set_name("Linux/X11");
-	platform->set_extension("bin");
 	platform->set_release_32("linux_x11_32_release");
 	platform->set_debug_32("linux_x11_32_debug");
 	platform->set_release_64("linux_x11_64_release");


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/14470

This **removes** the extension from Linux exports entirely. So it will no longer export **MyGame.bin** and will simply export **MyGame** instead.

Also, I made a version with .x86 and .x86_64 extensions here depending on which architecture you choose, but I believe the consensus is to just remove all extensions from Linux since the end user can add those manually. The code is already written though just in case: https://github.com/NathanWarden/godot/tree/linux_extensions

Thanks :)