### PR TITLE
Don't pass -std=gnu++11 to MSVC

### DIFF
--- a/modules/etc/SCsub
+++ b/modules/etc/SCsub
@@ -34,7 +34,8 @@ env_etc.Append(CPPPATH=[thirdparty_dir])
 env_etc.add_source_files(env.modules_sources, "*.cpp")
 
 # upstream uses c++11
-env_etc.Append(CCFLAGS="-std=gnu++11")
+if (not env_etc.msvc):
+	env_etc.Append(CCFLAGS="-std=c++11")
 # -ffast-math seems to be incompatible with ec2comp on recent versions of
 # GCC and Clang
 if '-ffast-math' in env_etc['CCFLAGS']:

--- a/modules/thekla_unwrap/SCsub
+++ b/modules/thekla_unwrap/SCsub
@@ -56,7 +56,8 @@ if env['builtin_thekla_atlas']:
     env_thekla_unwrap.Append(CPPPATH=[thirdparty_dir, thirdparty_dir + "/poshlib", thirdparty_dir + "/nvcore", thirdparty_dir + "/nvmesh"])
 
     # upstream uses c++11
-    env_thekla_unwrap.Append(CXXFLAGS="-std=gnu++11")
+    if (not env_thekla_unwrap.msvc):
+        env_thekla_unwrap.Append(CXXFLAGS="-std=c++11")
 
     if env["platform"] == 'x11':
         env_thekla_unwrap.Append(CCFLAGS=["-DNV_OS_LINUX"])


### PR DESCRIPTION
This gets rid of some compilation warnings with Visual Studio.