### PR TITLE
Updated Linux template extensions to match architecture.

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1288,8 +1288,18 @@ bool EditorExportPlatformPC::can_export(const Ref<EditorExportPreset> &p_preset,
 	return valid;
 }
 
-String EditorExportPlatformPC::get_binary_extension() const {
-	return extension;
+String EditorExportPlatformPC::get_binary_extension(const Ref<EditorExportPreset> &p_preset) const {
+	for (Map<String, String>::Element *E = extensions.front(); E; E = E->next()) {
+		if (p_preset->get(E->key())) {
+			return extensions[E->key()];
+		}
+	}
+
+	if (extensions.has("default")) {
+		return extensions["default"];
+	}
+
+	return "";
 }
 
 Error EditorExportPlatformPC::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {
@@ -1337,8 +1347,8 @@ Error EditorExportPlatformPC::export_project(const Ref<EditorExportPreset> &p_pr
 	return save_pack(p_preset, pck_path);
 }
 
-void EditorExportPlatformPC::set_extension(const String &p_extension) {
-	extension = p_extension;
+void EditorExportPlatformPC::set_extension(const String &p_extension, const String &p_feature_key) {
+	extensions[p_feature_key] = p_extension;
 }
 
 void EditorExportPlatformPC::set_name(const String &p_name) {

--- a/editor/editor_export.h
+++ b/editor/editor_export.h
@@ -240,7 +240,7 @@ public:
 
 	virtual bool can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const = 0;
 
-	virtual String get_binary_extension() const = 0;
+	virtual String get_binary_extension(const Ref<EditorExportPreset> &p_preset) const = 0;
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) = 0;
 	virtual void get_platform_features(List<String> *r_features) = 0;
 
@@ -363,7 +363,7 @@ class EditorExportPlatformPC : public EditorExportPlatform {
 	Ref<ImageTexture> logo;
 	String name;
 	String os_name;
-	String extension;
+	Map<String, String> extensions;
 
 	String release_file_32;
 	String release_file_64;
@@ -385,10 +385,10 @@ public:
 	virtual Ref<Texture> get_logo() const;
 
 	virtual bool can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const;
-	virtual String get_binary_extension() const;
+	virtual String get_binary_extension(const Ref<EditorExportPreset> &p_preset) const;
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0);
 
-	void set_extension(const String &p_extension);
+	void set_extension(const String &p_extension, const String &p_feature_key = "default");
 	void set_name(const String &p_name);
 	void set_os_name(const String &p_name);
 

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -718,7 +718,9 @@ void ProjectExportDialog::_export_project() {
 	export_project->set_access(FileDialog::ACCESS_FILESYSTEM);
 	export_project->clear_filters();
 	export_project->set_current_file(default_filename);
-	String extension = platform->get_binary_extension();
+
+	String extension = platform->get_binary_extension(current);
+
 	if (extension != String()) {
 		export_project->add_filter("*." + extension + " ; " + platform->get_name() + " Export");
 	}

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1305,7 +1305,7 @@ public:
 		return valid;
 	}
 
-	virtual String get_binary_extension() const {
+	virtual String get_binary_extension(const Ref<EditorExportPreset> &p_preset) const {
 		return "apk";
 	}
 

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -108,7 +108,7 @@ public:
 	virtual String get_os_name() const { return "iOS"; }
 	virtual Ref<Texture> get_logo() const { return logo; }
 
-	virtual String get_binary_extension() const { return "ipa"; }
+	virtual String get_binary_extension(const Ref<EditorExportPreset> &p_preset) const { return "ipa"; }
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0);
 
 	virtual bool can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const;

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -57,7 +57,7 @@ public:
 	virtual Ref<Texture> get_logo() const;
 
 	virtual bool can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const;
-	virtual String get_binary_extension() const;
+	virtual String get_binary_extension(const Ref<EditorExportPreset> &p_preset) const;
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0);
 
 	virtual bool poll_devices();
@@ -149,7 +149,7 @@ bool EditorExportPlatformJavaScript::can_export(const Ref<EditorExportPreset> &p
 	return !r_missing_templates;
 }
 
-String EditorExportPlatformJavaScript::get_binary_extension() const {
+String EditorExportPlatformJavaScript::get_binary_extension(const Ref<EditorExportPreset> &p_preset) const {
 
 	return "html";
 }

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -74,7 +74,7 @@ public:
 	virtual String get_os_name() const { return "OSX"; }
 	virtual Ref<Texture> get_logo() const { return logo; }
 
-	virtual String get_binary_extension() const { return use_dmg() ? "dmg" : "zip"; }
+	virtual String get_binary_extension(const Ref<EditorExportPreset> &p_preset) const { return use_dmg() ? "dmg" : "zip"; }
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0);
 
 	virtual bool can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const;

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -1013,7 +1013,7 @@ public:
 		return "UWP";
 	}
 
-	virtual String get_binary_extension() const {
+	virtual String get_binary_extension(const Ref<EditorExportPreset> &p_preset) const {
 		return "appx";
 	}
 

--- a/platform/x11/export/export.cpp
+++ b/platform/x11/export/export.cpp
@@ -44,7 +44,8 @@ void register_x11_exporter() {
 	logo->create_from_image(img);
 	platform->set_logo(logo);
 	platform->set_name("Linux/X11");
-	platform->set_extension("bin");
+	platform->set_extension("x86");
+	platform->set_extension("x86_64", "binary_format/64_bits");
 	platform->set_release_32("linux_x11_32_release");
 	platform->set_debug_32("linux_x11_32_debug");
 	platform->set_release_64("linux_x11_64_release");


### PR DESCRIPTION
This is a revised version of: https://github.com/godotengine/godot/pull/14574
This fixes: https://github.com/godotengine/godot/issues/14470

This changes the Linux export extension of .bin to .x86 and .x86_64 for each respective architecture.

This PR is a work in progress.

People previously involved in the conversation were @insomniacUNDERSCORElemon @akien-mga @groud @Hinsbart @Calinou 