### PR TITLE
Account for folded code blocks when navigating via members list

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1329,12 +1329,12 @@ void ScriptEditor::_members_overview_selected(int p_idx) {
 	if (!se) {
 		return;
 	}
-	Dictionary state;
-	state["scroll_position"] = members_overview->get_item_metadata(p_idx);
+	// Go to the member's line and reset the cursor column. We can't just change scroll_position
+	// directly, since code might be folded.
+	se->goto_line(members_overview->get_item_metadata(p_idx));
+	Dictionary state = se->get_edit_state();
 	state["column"] = 0;
-	state["row"] = members_overview->get_item_metadata(p_idx);
 	se->set_edit_state(state);
-	se->ensure_focus();
 }
 
 void ScriptEditor::_help_overview_selected(int p_idx) {

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -537,10 +537,6 @@ void ScriptTextEditor::set_edit_state(const Variant &p_state) {
 	code_editor->get_text_edit()->cursor_set_line(state["row"]);
 	code_editor->get_text_edit()->set_v_scroll(state["scroll_position"]);
 	code_editor->get_text_edit()->grab_focus();
-
-	//int scroll_pos;
-	//int cursor_column;
-	//int cursor_row;
 }
 
 String ScriptTextEditor::get_name() {


### PR DESCRIPTION
Previously, the editor would attempt to set the scroll position to the
function's line number, but this would result in an invalid scroll
whenever functions above the target were folded.

This changes callback to use a combination of `goto_line` and
`set_edit_state` to navigate to the target line and reset the cursor to
column 0.

Using `goto_line` also has the side effect of automatically unfolding
the target function, which seems like useful behavior.

Fixes #14572.