### PR TITLE
Timer class clarification

### DIFF
--- a/doc/classes/Timer.xml
+++ b/doc/classes/Timer.xml
@@ -4,7 +4,7 @@
 		A countdown timer.
 	</brief_description>
 	<description>
-		Counts down a specified interval and emits a signal on reaching 0. Can be set to repeat or "one shot" mode.
+		Emit a signal at specified interval either once or repeatedly.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -59,14 +59,14 @@
 		<member name="autostart" type="bool" setter="set_autostart" getter="has_autostart">
 			If [code]true[/code], Timer will automatically start when entering the scene tree. Default value: [code]false[/code].
 		</member>
-		<member name="one_shot" type="bool" setter="set_one_shot" getter="is_one_shot">
-			If [code]true[/code], Timer will stop when reaching 0. If [code]false[/code], it will restart. Default value: [code]false[/code].
+		<member name="repeat" type="bool" setter="set_repeat" getter="is_repeat">
+			If [code]true[/code], Timer will restart when reaching 0. If [code]false[/code], Timer will stop. Default value: [code]true[/code].
 		</member>
 		<member name="process_mode" type="int" setter="set_timer_process_mode" getter="get_timer_process_mode" enum="Timer.TimerProcessMode">
 			Processing mode. Uses TIMER_PROCESS_* constants as value.
 		</member>
-		<member name="wait_time" type="float" setter="set_wait_time" getter="get_wait_time">
-			Wait time in seconds.
+		<member name="time_interval" type="float" setter="set_time_interval" getter="get_time_interval">
+			Timer interval in seconds.
 		</member>
 	</members>
 	<signals>

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1163,7 +1163,7 @@ void CodeTextEditor::_on_settings_change() {
 	text_editor->set_auto_brace_completion(
 			EDITOR_DEF("text_editor/completion/auto_brace_complete", true));
 
-	code_complete_timer->set_wait_time(
+	code_complete_timer->set_time_interval(
 			EDITOR_DEF("text_editor/completion/code_complete_delay", .3f));
 
 	enable_complete_timer = EDITOR_DEF("text_editor/completion/enable_code_completion_delay", true);
@@ -1239,15 +1239,15 @@ CodeTextEditor::CodeTextEditor() {
 
 	idle = memnew(Timer);
 	add_child(idle);
-	idle->set_one_shot(true);
-	idle->set_wait_time(EDITOR_DEF("text_editor/completion/idle_parse_delay", 2));
+	idle->set_repeat(false);
+	idle->set_time_interval(EDITOR_DEF("text_editor/completion/idle_parse_delay", 2));
 
 	code_complete_timer = memnew(Timer);
 	add_child(code_complete_timer);
-	code_complete_timer->set_one_shot(true);
+	code_complete_timer->set_repeat(false);
 	enable_complete_timer = EDITOR_DEF("text_editor/completion/enable_code_completion_delay", true);
 
-	code_complete_timer->set_wait_time(EDITOR_DEF("text_editor/completion/code_complete_delay", .3f));
+	code_complete_timer->set_time_interval(EDITOR_DEF("text_editor/completion/code_complete_delay", .3f));
 
 	error = memnew(Label);
 	status_bar->add_child(error);
@@ -1315,8 +1315,8 @@ CodeTextEditor::CodeTextEditor() {
 	font_size = -1;
 	font_resize_timer = memnew(Timer);
 	add_child(font_resize_timer);
-	font_resize_timer->set_one_shot(true);
-	font_resize_timer->set_wait_time(0.07);
+	font_resize_timer->set_repeat(false);
+	font_resize_timer->set_time_interval(0.07);
 	font_resize_timer->connect("timeout", this, "_font_resize_timeout");
 
 	EditorSettings::get_singleton()->connect("settings_changed", this, "_on_settings_change");

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1150,8 +1150,8 @@ EditorAudioBuses::EditorAudioBuses() {
 	bus_scroll->add_child(bus_hb);
 
 	save_timer = memnew(Timer);
-	save_timer->set_wait_time(0.8);
-	save_timer->set_one_shot(true);
+	save_timer->set_time_interval(0.8);
+	save_timer->set_repeat(false);
 	add_child(save_timer);
 	save_timer->connect("timeout", this, "_server_save");
 

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1186,8 +1186,8 @@ EditorExport::EditorExport() {
 
 	save_timer = memnew(Timer);
 	add_child(save_timer);
-	save_timer->set_wait_time(0.8);
-	save_timer->set_one_shot(true);
+	save_timer->set_time_interval(0.8);
+	save_timer->set_repeat(false);
 	save_timer->connect("timeout", this, "_save");
 	block_save = false;
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4557,19 +4557,19 @@ void EditorNode::_start_dimming(bool p_dimming) {
 
 void EditorNode::_dim_timeout() {
 
-	_dim_time += _dim_timer->get_wait_time();
-	float wait_time = EditorSettings::get_singleton()->get("interface/editor/dim_transition_time");
+	_dim_time += _dim_timer->get_time_interval();
+	float time_interval = EditorSettings::get_singleton()->get("interface/editor/dim_transition_time");
 
 	float c = 1.0f - (float)EditorSettings::get_singleton()->get("interface/editor/dim_amount");
 
 	Color base = _dimming ? Color(1, 1, 1) : Color(c, c, c);
 	Color final = _dimming ? Color(c, c, c) : Color(1, 1, 1);
 
-	if (_dim_time + _dim_timer->get_wait_time() >= wait_time) {
+	if (_dim_time + _dim_timer->get_time_interval() >= time_interval) {
 		gui_base->set_modulate(final);
 		_dim_timer->stop();
 	} else {
-		gui_base->set_modulate(base.linear_interpolate(final, _dim_time / wait_time));
+		gui_base->set_modulate(base.linear_interpolate(final, _dim_time / time_interval));
 	}
 }
 
@@ -4969,8 +4969,8 @@ EditorNode::EditorNode() {
 
 	dock_drag_timer = memnew(Timer);
 	add_child(dock_drag_timer);
-	dock_drag_timer->set_wait_time(0.5);
-	dock_drag_timer->set_one_shot(true);
+	dock_drag_timer->set_time_interval(0.5);
+	dock_drag_timer->set_repeat(false);
 	dock_drag_timer->connect("timeout", this, "_save_docks");
 
 	top_split = memnew(VSplitContainer);
@@ -5812,7 +5812,7 @@ EditorNode::EditorNode() {
 	_dimming = false;
 	_dim_time = 0.0f;
 	_dim_timer = memnew(Timer);
-	_dim_timer->set_wait_time(0.01666f);
+	_dim_timer->set_time_interval(0.01666f);
 	_dim_timer->connect("timeout", this, "_dim_timeout");
 	add_child(_dim_timer);
 

--- a/editor/editor_profiler.cpp
+++ b/editor/editor_profiler.cpp
@@ -69,12 +69,12 @@ void EditorProfiler::add_frame_metric(const Metric &p_metric, bool p_final) {
 
 	if (!frame_delay->is_processing()) {
 
-		frame_delay->set_wait_time(p_final ? 0.1 : 1);
+		frame_delay->set_time_interval(p_final ? 0.1 : 1);
 		frame_delay->start();
 	}
 
 	if (!plot_delay->is_processing()) {
-		plot_delay->set_wait_time(0.1);
+		plot_delay->set_time_interval(0.1);
 		plot_delay->start();
 	}
 }
@@ -154,7 +154,7 @@ void EditorProfiler::_item_edited() {
 		plot_sigs.erase(signature);
 
 	if (!frame_delay->is_processing()) {
-		frame_delay->set_wait_time(0.1);
+		frame_delay->set_time_interval(0.1);
 		frame_delay->start();
 	}
 
@@ -555,7 +555,7 @@ void EditorProfiler::_graph_tex_input(const Ref<InputEvent> &p_ev) {
 			seeking = true;
 
 			if (!frame_delay->is_processing()) {
-				frame_delay->set_wait_time(0.1);
+				frame_delay->set_time_interval(0.1);
 				frame_delay->start();
 			}
 		}
@@ -703,14 +703,14 @@ EditorProfiler::EditorProfiler() {
 	//display_mode=DISPLAY_FRAME_TIME;
 
 	frame_delay = memnew(Timer);
-	frame_delay->set_wait_time(0.1);
-	frame_delay->set_one_shot(true);
+	frame_delay->set_time_interval(0.1);
+	frame_delay->set_repeat(false);
 	add_child(frame_delay);
 	frame_delay->connect("timeout", this, "_update_frame");
 
 	plot_delay = memnew(Timer);
-	plot_delay->set_wait_time(0.1);
-	plot_delay->set_one_shot(true);
+	plot_delay->set_time_interval(0.1);
+	plot_delay->set_repeat(false);
 	add_child(plot_delay);
 	plot_delay->connect("timeout", this, "_update_plot");
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1168,7 +1168,7 @@ void ScriptEditor::_notification(int p_what) {
 			{
 				float autosave_time = EditorSettings::get_singleton()->get("text_editor/files/autosave_interval_secs");
 				if (autosave_time > 0) {
-					autosave_timer->set_wait_time(autosave_time);
+					autosave_timer->set_time_interval(autosave_time);
 					autosave_timer->start();
 				} else {
 					autosave_timer->stop();
@@ -1928,7 +1928,7 @@ void ScriptEditor::_editor_settings_changed() {
 
 	float autosave_time = EditorSettings::get_singleton()->get("text_editor/files/autosave_interval_secs");
 	if (autosave_time > 0) {
-		autosave_timer->set_wait_time(autosave_time);
+		autosave_timer->set_time_interval(autosave_time);
 		autosave_timer->start();
 	} else {
 		autosave_timer->stop();
@@ -2783,7 +2783,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	debugger->connect("breaked", this, "_breaked");
 
 	autosave_timer = memnew(Timer);
-	autosave_timer->set_one_shot(false);
+	autosave_timer->set_repeat(true);
 	add_child(autosave_timer);
 
 	grab_focus_block = false;

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -1897,9 +1897,9 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	tab_container->add_child(plugin_settings);
 
 	timer = memnew(Timer);
-	timer->set_wait_time(1.5);
+	timer->set_time_interval(1.5);
 	timer->connect("timeout", ProjectSettings::get_singleton(), "save");
-	timer->set_one_shot(true);
+	timer->set_repeat(false);
 	add_child(timer);
 
 	updating_translations = false;

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -1032,8 +1032,8 @@ SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_ope
 
 	update_timer = memnew(Timer);
 	update_timer->connect("timeout", this, "_update_tree");
-	update_timer->set_one_shot(true);
-	update_timer->set_wait_time(0.5);
+	update_timer->set_repeat(false);
+	update_timer->set_time_interval(0.5);
 	add_child(update_timer);
 
 	script_types = memnew(List<StringName>);

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -435,9 +435,9 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	//get_cancel()->set_text("Close");
 
 	timer = memnew(Timer);
-	timer->set_wait_time(1.5);
+	timer->set_time_interval(1.5);
 	timer->connect("timeout", this, "_settings_save");
-	timer->set_one_shot(true);
+	timer->set_repeat(false);
 	add_child(timer);
 	EditorSettings::get_singleton()->connect("settings_changed", this, "_settings_changed");
 	get_ok()->set_text(TTR("Close"));

--- a/modules/mono/editor/godotsharp_editor.cpp
+++ b/modules/mono/editor/godotsharp_editor.cpp
@@ -272,8 +272,8 @@ MonoReloadNode::MonoReloadNode() {
 
 	reload_timer = memnew(Timer);
 	add_child(reload_timer);
-	reload_timer->set_one_shot(false);
-	reload_timer->set_wait_time(EDITOR_DEF("mono/assembly_watch_interval_sec", 0.5));
+	reload_timer->set_repeat(true);
+	reload_timer->set_time_interval(EDITOR_DEF("mono/assembly_watch_interval_sec", 0.5));
 	reload_timer->connect("timeout", this, "_reload_timer_timeout");
 	reload_timer->start();
 }

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -3357,7 +3357,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	graph->add_child(hint_text);
 
 	hint_text_timer = memnew(Timer);
-	hint_text_timer->set_wait_time(4);
+	hint_text_timer->set_time_interval(4);
 	hint_text_timer->connect("timeout", this, "_hide_timer");
 	add_child(hint_text_timer);
 

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -904,12 +904,12 @@ void LineEdit::cursor_set_blink_enabled(const bool p_enabled) {
 }
 
 float LineEdit::cursor_get_blink_speed() const {
-	return caret_blink_timer->get_wait_time();
+	return caret_blink_timer->get_time_interval();
 }
 
 void LineEdit::cursor_set_blink_speed(const float p_speed) {
 	ERR_FAIL_COND(p_speed <= 0);
-	caret_blink_timer->set_wait_time(p_speed);
+	caret_blink_timer->set_time_interval(p_speed);
 }
 
 void LineEdit::_reset_caret_blink_timer() {
@@ -1467,7 +1467,7 @@ LineEdit::LineEdit() {
 	caret_blink_enabled = false;
 	caret_blink_timer = memnew(Timer);
 	add_child(caret_blink_timer);
-	caret_blink_timer->set_wait_time(0.65);
+	caret_blink_timer->set_time_interval(0.65);
 	caret_blink_timer->connect("timeout", this, "_toggle_draw_caret");
 	cursor_set_blink_enabled(false);
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1225,8 +1225,8 @@ PopupMenu::PopupMenu() {
 	set_hide_on_multistate_item_selection(false);
 
 	submenu_timer = memnew(Timer);
-	submenu_timer->set_wait_time(0.3);
-	submenu_timer->set_one_shot(true);
+	submenu_timer->set_time_interval(0.3);
+	submenu_timer->set_repeat(false);
 	submenu_timer->connect("timeout", this, "_submenu_timeout");
 	add_child(submenu_timer);
 }

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -75,9 +75,9 @@ void SpinBox::_range_click_timeout() {
 		bool up = get_local_mouse_position().y < (get_size().height / 2);
 		set_value(get_value() + (up ? get_step() : -get_step()));
 
-		if (range_click_timer->is_one_shot()) {
-			range_click_timer->set_wait_time(0.075);
-			range_click_timer->set_one_shot(false);
+		if (!(range_click_timer->is_repeat())) {
+			range_click_timer->set_time_interval(0.075);
+			range_click_timer->set_repeat(true);
 			range_click_timer->start();
 		}
 
@@ -104,8 +104,8 @@ void SpinBox::_gui_input(const Ref<InputEvent> &p_event) {
 
 				set_value(get_value() + (up ? get_step() : -get_step()));
 
-				range_click_timer->set_wait_time(0.6);
-				range_click_timer->set_one_shot(true);
+				range_click_timer->set_time_interval(0.6);
+				range_click_timer->set_repeat(false);
 				range_click_timer->start();
 
 				line_edit->grab_focus();

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3667,12 +3667,12 @@ void TextEdit::cursor_set_blink_enabled(const bool p_enabled) {
 }
 
 float TextEdit::cursor_get_blink_speed() const {
-	return caret_blink_timer->get_wait_time();
+	return caret_blink_timer->get_time_interval();
 }
 
 void TextEdit::cursor_set_blink_speed(const float p_speed) {
 	ERR_FAIL_COND(p_speed <= 0);
-	caret_blink_timer->set_wait_time(p_speed);
+	caret_blink_timer->set_time_interval(p_speed);
 }
 
 void TextEdit::cursor_set_block_mode(const bool p_enable) {
@@ -5588,19 +5588,19 @@ TextEdit::TextEdit() {
 	caret_blink_enabled = false;
 	caret_blink_timer = memnew(Timer);
 	add_child(caret_blink_timer);
-	caret_blink_timer->set_wait_time(0.65);
+	caret_blink_timer->set_time_interval(0.65);
 	caret_blink_timer->connect("timeout", this, "_toggle_draw_caret");
 	cursor_set_blink_enabled(false);
 
 	idle_detect = memnew(Timer);
 	add_child(idle_detect);
-	idle_detect->set_one_shot(true);
-	idle_detect->set_wait_time(GLOBAL_GET("gui/timers/text_edit_idle_detect_sec"));
+	idle_detect->set_repeat(false);
+	idle_detect->set_time_interval(GLOBAL_GET("gui/timers/text_edit_idle_detect_sec"));
 	idle_detect->connect("timeout", this, "_push_current_op");
 
 	click_select_held = memnew(Timer);
 	add_child(click_select_held);
-	click_select_held->set_wait_time(0.05);
+	click_select_held->set_time_interval(0.05);
 	click_select_held->connect("timeout", this, "_click_selection_held");
 
 	current_op.type = TextOperation::TYPE_NONE;

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1571,9 +1571,9 @@ void Tree::_range_click_timeout() {
 		propagate_mouse_event(pos + cache.offset, 0, 0, false, root, BUTTON_LEFT, mb);
 		blocked--;
 
-		if (range_click_timer->is_one_shot()) {
-			range_click_timer->set_wait_time(0.05);
-			range_click_timer->set_one_shot(false);
+		if (!(range_click_timer->is_repeat())) {
+			range_click_timer->set_time_interval(0.05);
+			range_click_timer->set_repeat(true);
 			range_click_timer->start();
 		}
 
@@ -1820,8 +1820,8 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool
 								range_item_last = p_item;
 								range_up_last = up;
 
-								range_click_timer->set_wait_time(0.6);
-								range_click_timer->set_one_shot(true);
+								range_click_timer->set_time_interval(0.6);
+								range_click_timer->set_repeat(false);
 								range_click_timer->start();
 
 							} else if (up != range_up_last) {

--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -52,8 +52,8 @@ void Timer::_notification(int p_what) {
 			time_left -= get_process_delta_time();
 
 			if (time_left < 0) {
-				if (!one_shot)
-					time_left += wait_time;
+				if (repeat)
+					time_left += time_interval;
 				else
 					stop();
 
@@ -67,8 +67,8 @@ void Timer::_notification(int p_what) {
 			time_left -= get_physics_process_delta_time();
 
 			if (time_left < 0) {
-				if (!one_shot)
-					time_left += wait_time;
+				if (repeat)
+					time_left += time_interval;
 				else
 					stop();
 				emit_signal("timeout");
@@ -78,23 +78,23 @@ void Timer::_notification(int p_what) {
 	}
 }
 
-void Timer::set_wait_time(float p_time) {
+void Timer::set_time_interval(float p_time) {
 	ERR_EXPLAIN("time should be greater than zero.");
 	ERR_FAIL_COND(p_time <= 0);
-	wait_time = p_time;
+	time_interval = p_time;
 }
-float Timer::get_wait_time() const {
+float Timer::get_time_interval() const {
 
-	return wait_time;
+	return time_interval;
 }
 
-void Timer::set_one_shot(bool p_one_shot) {
+void Timer::set_repeat(bool p_repeat) {
 
-	one_shot = p_one_shot;
+	repeat = p_repeat;
 }
-bool Timer::is_one_shot() const {
+bool Timer::is_repeat() const {
 
-	return one_shot;
+	return repeat;
 }
 
 void Timer::set_autostart(bool p_start) {
@@ -107,7 +107,7 @@ bool Timer::has_autostart() const {
 }
 
 void Timer::start() {
-	time_left = wait_time;
+	time_left = time_interval;
 	_set_process(true);
 }
 
@@ -175,11 +175,11 @@ void Timer::_set_process(bool p_process, bool p_force) {
 
 void Timer::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("set_wait_time", "time_sec"), &Timer::set_wait_time);
-	ClassDB::bind_method(D_METHOD("get_wait_time"), &Timer::get_wait_time);
+	ClassDB::bind_method(D_METHOD("set_time_interval", "time_sec"), &Timer::set_time_interval);
+	ClassDB::bind_method(D_METHOD("get_time_interval"), &Timer::get_time_interval);
 
-	ClassDB::bind_method(D_METHOD("set_one_shot", "enable"), &Timer::set_one_shot);
-	ClassDB::bind_method(D_METHOD("is_one_shot"), &Timer::is_one_shot);
+	ClassDB::bind_method(D_METHOD("set_repeat", "enable"), &Timer::set_repeat);
+	ClassDB::bind_method(D_METHOD("is_repeat"), &Timer::is_repeat);
 
 	ClassDB::bind_method(D_METHOD("set_autostart", "enable"), &Timer::set_autostart);
 	ClassDB::bind_method(D_METHOD("has_autostart"), &Timer::has_autostart);
@@ -200,8 +200,8 @@ void Timer::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("timeout"));
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "process_mode", PROPERTY_HINT_ENUM, "Physics,Idle"), "set_timer_process_mode", "get_timer_process_mode");
-	ADD_PROPERTY(PropertyInfo(Variant::REAL, "wait_time", PROPERTY_HINT_EXP_RANGE, "0.01,4096,0.01"), "set_wait_time", "get_wait_time");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "one_shot"), "set_one_shot", "is_one_shot");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "time_interval", PROPERTY_HINT_EXP_RANGE, "0.01,4096,0.01"), "set_time_interval", "get_time_interval");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "repeat"), "set_repeat", "is_repeat");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autostart"), "set_autostart", "has_autostart");
 
 	BIND_ENUM_CONSTANT(TIMER_PROCESS_PHYSICS);
@@ -211,8 +211,8 @@ void Timer::_bind_methods() {
 Timer::Timer() {
 	timer_process_mode = TIMER_PROCESS_IDLE;
 	autostart = false;
-	wait_time = 1;
-	one_shot = false;
+	time_interval = 1;
+	repeat = true;
 	time_left = -1;
 	processing = false;
 	paused = false;

--- a/scene/main/timer.h
+++ b/scene/main/timer.h
@@ -36,8 +36,8 @@ class Timer : public Node {
 
 	GDCLASS(Timer, Node);
 
-	float wait_time;
-	bool one_shot;
+	float time_interval;
+	bool repeat;
 	bool autostart;
 	bool processing;
 	bool paused;
@@ -54,11 +54,11 @@ public:
 		TIMER_PROCESS_IDLE,
 	};
 
-	void set_wait_time(float p_time);
-	float get_wait_time() const;
+	void set_time_interval(float p_time);
+	float get_time_interval() const;
 
-	void set_one_shot(bool p_one_shot);
-	bool is_one_shot() const;
+	void set_repeat(bool p_repeat);
+	bool is_repeat() const;
 
 	void set_autostart(bool p_start);
 	bool has_autostart() const;


### PR DESCRIPTION
The current [Timer](http://docs.godotengine.org/en/latest/classes/class_timer.html#member-variables) variable naming is not very clear. Specifically:
- "one_shot" is not immediately intuitive. This has been renamed to "repeat".
- "wait_time" has been updated to "time_interval", to be more consistent with it's function.

Logic, class doc, and code using Timer class have been updated accordingly. 

Pros: Class is now more intuitive to work with
Downside: This changes the API. Docs and tutorials would need to be updated. 


