### PR TITLE
Focus path field after seleting file browser on Attach script window

### DIFF
--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -331,6 +331,12 @@ void ScriptCreateDialog::_file_selected(const String &p_file) {
 	} else {
 		file_path->set_text(p);
 		_path_changed(p);
+
+		String filename = p.get_file().get_basename();
+		int select_start = p.find_last(filename);
+		file_path->select(select_start, select_start + filename.length());
+		file_path->set_cursor_position(select_start + filename.length());
+		file_path->grab_focus();
 	}
 }
 


### PR DESCRIPTION
* focus path field
* select filename
* cursor located at end of filename

![focus](https://user-images.githubusercontent.com/8281454/33972544-a4b7df56-e0c1-11e7-9ecd-68e47293871e.gif)

this will be better with #14551