### PR TITLE
Prevent users from moving instanced children

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -774,9 +774,11 @@ Variant SceneTreeEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from
 
 		Node *n = get_node(np);
 		if (n) {
-
-			selected.push_back(n);
-			icons.push_back(next->get_icon(0));
+			// Only allow selection if not part of an instanced scene.
+			if (!n->get_owner() || n->get_owner() == get_scene_node() || n->get_owner()->get_filename() == String()) {
+				selected.push_back(n);
+				icons.push_back(next->get_icon(0));
+			}
 		}
 		next = tree->get_next_selected(next);
 	}


### PR DESCRIPTION
This implements one possible fix for #14648 (the <del>second</del> first alternative discussed in the issue).

Fixes #14648