### PR TITLE
openmp: Don't try to link GCC's implementation on Clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,14 +48,14 @@ addons:
       - pkg-config
       - libx11-dev
       - libxcursor-dev
-      - libasound2-dev
-      - libfreetype6-dev
-      - libgl1-mesa-dev
-      - libglu1-mesa-dev
-      - libssl-dev
+      - libxi-dev
       - libxinerama-dev
       - libxrandr-dev
-      - libxi-dev
+      - libgl1-mesa-dev
+      - libglu1-mesa-dev
+      - libasound2-dev
+      - libfreetype6-dev
+      - libssl-dev
 
       # For cross-compiling to Windows.
       #- binutils-mingw-w64-i686
@@ -90,5 +90,5 @@ script:
   - if [ "$STATIC_CHECKS" = "yes" ]; then
       sh ./misc/travis/clang-format.sh;
     else
-      scons -j2 CC=$CC CXX=$CXX platform=$GODOT_TARGET TOOLS=$TOOLS verbose=yes progress=no;
+      scons -j2 CC=$CC CXX=$CXX platform=$GODOT_TARGET TOOLS=$TOOLS verbose=yes progress=no openmp=no;
     fi

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -265,9 +265,10 @@ def configure(env):
         env.Append(LINKFLAGS=['-m64', '-L/usr/lib/i686-linux-gnu'])
 
 
-    if (env["openmp"]):
+    if env["openmp"]:
         env.Append(CPPFLAGS=['-fopenmp'])
-        env.Append(LIBS=['gomp'])
+        if not env['use_llvm']:
+            env.Append(LIBS=['gomp'])
 
     if env['use_static_cpp']:
         env.Append(LINKFLAGS=['-static-libstdc++'])


### PR DESCRIPTION
Also disable openmp build on Travis, breaks on Trusty's Clang.
Group deps more naturally.