### PR TITLE
Minor improvements for #14658 (MacPorts clang support)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -169,7 +169,7 @@ opts.Add(EnumVariable('warnings', "Set the level of warnings emitted during comp
 opts.Add(BoolVariable('progress', "Show a progress indicator during build", True))
 opts.Add(BoolVariable('dev', "If yes, alias for verbose=yes warnings=all", False))
 opts.Add(BoolVariable('openmp', "If yes, enable OpenMP", True))
-opts.Add(BoolVariable('macports_clang', "Build using clang-5.0 from MacPorts", False))
+opts.Add(EnumVariable('macports_clang', "Build using clang from MacPorts", 'no', ('no', '5.0', 'devel')))
 
 # Thirdparty libraries
 opts.Add(BoolVariable('builtin_enet', "Use the builtin enet library", True))

--- a/platform/osx/SCsub
+++ b/platform/osx/SCsub
@@ -4,9 +4,10 @@ import os
 Import('env')
 
 def make_debug(target, source, env):
-    if (env["macports_clang"]):
+    if (env["macports_clang"] != 'no'):
         mpprefix = os.environ.get("MACPORTS_PREFIX", "/opt/local")
-        os.system(mpprefix + '/libexec/llvm-5.0/bin/llvm-dsymutil %s -o %s.dSYM' % (target[0], target[0]))
+        mpclangver = env["macports_clang"]
+        os.system(mpprefix + '/libexec/llvm-' + mpclangver + '/bin/llvm-dsymutil %s -o %s.dSYM' % (target[0], target[0]))
     else:
         os.system('dsymutil %s -o %s.dSYM' % (target[0], target[0]))
 

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -72,19 +72,19 @@ def configure(env):
         else: # 64-bit, default
             env.Append(CCFLAGS=['-arch', 'x86_64'])
             env.Append(LINKFLAGS=['-arch', 'x86_64'])
-        if (env["macports_clang"]):
+        if (env["macports_clang"] != 'no'):
             mpprefix = os.environ.get("MACPORTS_PREFIX", "/opt/local")
-            env["CC"] = mpprefix + "/libexec/llvm-5.0/bin/clang"
-            env["LD"] = mpprefix + "/libexec/llvm-5.0/bin/clang++"
-            env["CXX"] = mpprefix + "/libexec/llvm-5.0/bin/clang++"
-            env['AR'] = mpprefix + "/libexec/llvm-5.0/bin/llvm-ar"
-            env['RANLIB'] = mpprefix + "/libexec/llvm-5.0/bin/llvm-ranlib"
-            env['AS'] = mpprefix + "/libexec/llvm-5.0/bin/llvm-as"
+            mpclangver = env["macports_clang"]
+            env["CC"] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/clang"
+            env["LD"] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/clang++"
+            env["CXX"] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/clang++"
+            env['AR'] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/llvm-ar"
+            env['RANLIB'] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/llvm-ranlib"
+            env['AS'] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/llvm-as"
             env.Append(CCFLAGS=['-D__MACPORTS__']) #hack to fix libvpx MM256_BROADCASTSI128_SI256 define
             if (env["openmp"]):
                 env.Append(CPPFLAGS=['-fopenmp'])
-                env.Append(LINKFLAGS=['-L' + mpprefix + '/lib/libomp/'])
-                env.Append(LIBS=['gomp'])
+                env.Append(LINKFLAGS=['-fopenmp'])
 
     else: # osxcross build
         root = os.environ.get("OSXCROSS_ROOT", 0)


### PR DESCRIPTION
Added ability to select clang version: 5.0 / devel(6.0).
Fixed OpenMP linking: now linked against libomp instead of libgomp (currently both are symlinks to same file, but `-fopenmp` linking flag is correct way to do it).