### PR TITLE
Renamed navmesh_create to navmesh_add since no navmesh is created.

### DIFF
--- a/doc/classes/Navigation.xml
+++ b/doc/classes/Navigation.xml
@@ -57,7 +57,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="navmesh_create">
+		<method name="navmesh_add">
 			<return type="int">
 			</return>
 			<argument index="0" name="mesh" type="NavigationMesh">

--- a/doc/classes/Navigation2D.xml
+++ b/doc/classes/Navigation2D.xml
@@ -37,7 +37,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="navpoly_create">
+		<method name="navpoly_add">
 			<return type="int">
 			</return>
 			<argument index="0" name="mesh" type="NavigationPolygon">

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -469,7 +469,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 			nm.xform = xform;
 
 			if (navigation) {
-				nm.id = navigation->navmesh_create(navmesh, xform, this);
+				nm.id = navigation->navmesh_add(navmesh, xform, this);
 			} else {
 				nm.id = -1;
 			}
@@ -556,7 +556,7 @@ void GridMap::_octant_enter_world(const OctantKey &p_key) {
 			if (cell_map.has(F->key()) && F->get().id < 0) {
 				Ref<NavigationMesh> nm = theme->get_item_navmesh(cell_map[F->key()].item);
 				if (nm.is_valid()) {
-					F->get().id = navigation->navmesh_create(nm, F->get().xform, this);
+					F->get().id = navigation->navmesh_add(nm, F->get().xform, this);
 				}
 			}
 		}

--- a/scene/2d/navigation2d.cpp
+++ b/scene/2d/navigation2d.cpp
@@ -205,7 +205,7 @@ void Navigation2D::_navpoly_unlink(int p_id) {
 	nm.linked = false;
 }
 
-int Navigation2D::navpoly_create(const Ref<NavigationPolygon> &p_mesh, const Transform2D &p_xform, Object *p_owner) {
+int Navigation2D::navpoly_add(const Ref<NavigationPolygon> &p_mesh, const Transform2D &p_xform, Object *p_owner) {
 
 	int id = last_id++;
 	NavMesh nm;
@@ -708,7 +708,7 @@ Object *Navigation2D::get_closest_point_owner(const Vector2 &p_point) {
 
 void Navigation2D::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("navpoly_create", "mesh", "xform", "owner"), &Navigation2D::navpoly_create, DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("navpoly_add", "mesh", "xform", "owner"), &Navigation2D::navpoly_add, DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("navpoly_set_transform", "id", "xform"), &Navigation2D::navpoly_set_transform);
 	ClassDB::bind_method(D_METHOD("navpoly_remove", "id"), &Navigation2D::navpoly_remove);
 

--- a/scene/2d/navigation2d.h
+++ b/scene/2d/navigation2d.h
@@ -159,7 +159,7 @@ protected:
 
 public:
 	//API should be as dynamic as possible
-	int navpoly_create(const Ref<NavigationPolygon> &p_mesh, const Transform2D &p_xform, Object *p_owner = NULL);
+	int navpoly_add(const Ref<NavigationPolygon> &p_mesh, const Transform2D &p_xform, Object *p_owner = NULL);
 	void navpoly_set_transform(int p_id, const Transform2D &p_xform);
 	void navpoly_remove(int p_id);
 

--- a/scene/2d/navigation_polygon.cpp
+++ b/scene/2d/navigation_polygon.cpp
@@ -293,7 +293,7 @@ void NavigationPolygonInstance::set_enabled(bool p_enabled) {
 
 			if (navpoly.is_valid()) {
 
-				nav_id = navigation->navpoly_create(navpoly, get_relative_transform_to_parent(navigation), this);
+				nav_id = navigation->navpoly_add(navpoly, get_relative_transform_to_parent(navigation), this);
 			}
 		}
 	}
@@ -324,7 +324,7 @@ void NavigationPolygonInstance::_notification(int p_what) {
 
 					if (enabled && navpoly.is_valid()) {
 
-						nav_id = navigation->navpoly_create(navpoly, get_relative_transform_to_parent(navigation), this);
+						nav_id = navigation->navpoly_add(navpoly, get_relative_transform_to_parent(navigation), this);
 					}
 					break;
 				}
@@ -419,7 +419,7 @@ void NavigationPolygonInstance::set_navigation_polygon(const Ref<NavigationPolyg
 	}
 
 	if (navigation && navpoly.is_valid() && enabled) {
-		nav_id = navigation->navpoly_create(navpoly, get_relative_transform_to_parent(navigation), this);
+		nav_id = navigation->navpoly_add(navpoly, get_relative_transform_to_parent(navigation), this);
 	}
 	//update_gizmo();
 	_change_notify("navpoly");

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -486,7 +486,7 @@ void TileMap::_update_dirty_quadrants() {
 					xform.set_origin(offset.floor() + q.pos);
 					_fix_cell_transform(xform, c, npoly_ofs + center_ofs, s);
 
-					int pid = navigation->navpoly_create(navpoly, nav_rel * xform);
+					int pid = navigation->navpoly_add(navpoly, nav_rel * xform);
 
 					Quadrant::NavPoly np;
 					np.id = pid;

--- a/scene/3d/navigation.cpp
+++ b/scene/3d/navigation.cpp
@@ -202,7 +202,7 @@ void Navigation::_navmesh_unlink(int p_id) {
 	nm.linked = false;
 }
 
-int Navigation::navmesh_create(const Ref<NavigationMesh> &p_mesh, const Transform &p_xform, Object *p_owner) {
+int Navigation::navmesh_add(const Ref<NavigationMesh> &p_mesh, const Transform &p_xform, Object *p_owner) {
 
 	int id = last_id++;
 	NavMesh nm;
@@ -686,7 +686,7 @@ Vector3 Navigation::get_up_vector() const {
 
 void Navigation::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("navmesh_create", "mesh", "xform", "owner"), &Navigation::navmesh_create, DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("navmesh_add", "mesh", "xform", "owner"), &Navigation::navmesh_add, DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("navmesh_set_transform", "id", "xform"), &Navigation::navmesh_set_transform);
 	ClassDB::bind_method(D_METHOD("navmesh_remove", "id"), &Navigation::navmesh_remove);
 

--- a/scene/3d/navigation.h
+++ b/scene/3d/navigation.h
@@ -166,7 +166,7 @@ public:
 	Vector3 get_up_vector() const;
 
 	//API should be as dynamic as possible
-	int navmesh_create(const Ref<NavigationMesh> &p_mesh, const Transform &p_xform, Object *p_owner = NULL);
+	int navmesh_add(const Ref<NavigationMesh> &p_mesh, const Transform &p_xform, Object *p_owner = NULL);
 	void navmesh_set_transform(int p_id, const Transform &p_xform);
 	void navmesh_remove(int p_id);
 

--- a/scene/3d/navigation_mesh.cpp
+++ b/scene/3d/navigation_mesh.cpp
@@ -471,7 +471,7 @@ void NavigationMeshInstance::set_enabled(bool p_enabled) {
 
 			if (navmesh.is_valid()) {
 
-				nav_id = navigation->navmesh_create(navmesh, get_relative_transform(navigation), this);
+				nav_id = navigation->navmesh_add(navmesh, get_relative_transform(navigation), this);
 			}
 		}
 	}
@@ -508,7 +508,7 @@ void NavigationMeshInstance::_notification(int p_what) {
 
 					if (enabled && navmesh.is_valid()) {
 
-						nav_id = navigation->navmesh_create(navmesh, get_relative_transform(navigation), this);
+						nav_id = navigation->navmesh_add(navmesh, get_relative_transform(navigation), this);
 					}
 					break;
 				}
@@ -568,7 +568,7 @@ void NavigationMeshInstance::set_navigation_mesh(const Ref<NavigationMesh> &p_na
 	navmesh = p_navmesh;
 
 	if (navigation && navmesh.is_valid() && enabled) {
-		nav_id = navigation->navmesh_create(navmesh, get_relative_transform(navigation), this);
+		nav_id = navigation->navmesh_add(navmesh, get_relative_transform(navigation), this);
 	}
 
 	if (debug_view && navmesh.is_valid()) {


### PR DESCRIPTION
While documenting Navigation I noticed there's navmesh_create, but then there's navmesh_remove. Looking closer at the code, navmesh_create requires an already created navmesh but instead simply adds it to a Map, therefore navmesh_add is an accurate name and navmesh_create is not. It also is more consistent with navmesh_remove.. IE. 'add' and 'remove'.