### PR TITLE
NativeScript don't require a class name while attach to  node

### DIFF
--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -904,7 +904,7 @@ Script *NativeScriptLanguage::create_script() const {
 	return script;
 }
 bool NativeScriptLanguage::has_named_classes() const {
-	return true;
+	return false;
 }
 bool NativeScriptLanguage::supports_builtin_mode() const {
 	return true;


### PR DESCRIPTION
Fix #14643