### PR TITLE
Fixes thekla atlas mingw-w64 build.

### DIFF
--- a/modules/thekla_unwrap/SCsub
+++ b/modules/thekla_unwrap/SCsub
@@ -67,7 +67,7 @@ if env['builtin_thekla_atlas']:
         if env.msvc:
             env_thekla_unwrap.Append(CCFLAGS=["-DNV_OS_WIN32", "-DNV_CC_MSVC", "-DPOSH_COMPILER_MSVC" ])
         else:
-            env_thekla_unwrap.Append(CCFLAGS=["-DNV_OS_MINGW", "-DNV_CC_GNUC", "-DPOSH_COMPILER_GCC"])
+            env_thekla_unwrap.Append(CCFLAGS=["-DNV_OS_MINGW", "-DNV_CC_GNUC", "-DPOSH_COMPILER_GCC", "-U__STRICT_ANSI__"])
             env.Append(LIBS=["dbghelp"])
         
 # Godot source files

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -308,6 +308,10 @@ Files extracted from the upstream source:
 - Relevant sources from src/
 - License.txt
 
+Important: Some files have Godot-made changes, those
+changes are marked with `// -- GODOT --` comments.
+
+
 ## nanosvg
 
 - Upstream: https://github.com/memononen/nanosvg

--- a/thirdparty/thekla_atlas/nvcore/Debug.cpp
+++ b/thirdparty/thekla_atlas/nvcore/Debug.cpp
@@ -14,6 +14,7 @@
 #   define VC_EXTRALEAN
 #   include <windows.h>
 #   include <direct.h>
+// -- GODOT start -
 #   include <crtdbg.h>
 #   if _MSC_VER < 1300
 #       define DECLSPEC_DEPRECATED
@@ -24,6 +25,7 @@
 // VC7: ships with updated headers
 #       include <dbghelp.h>
 #   endif
+// -- GODOT end -
 #   pragma comment(lib,"dbghelp.lib")
 #endif
 
@@ -107,8 +109,9 @@ namespace
 
 #endif
 
-
+// -- GODOT start -
 #if NV_OS_WIN32 || NV_OS_DURANGO
+// -- GODOT end -
 
     // We should try to simplify the top level filter as much as possible.
     // http://www.nynaeve.net/?p=128

--- a/thirdparty/thekla_atlas/nvcore/DefsGnucWin32.h
+++ b/thirdparty/thekla_atlas/nvcore/DefsGnucWin32.h
@@ -19,7 +19,9 @@
 #endif
 
 #define NV_FASTCALL		__attribute__((fastcall))
+// -- GODOT start -
 #define NV_FORCEINLINE	__attribute__((always_inline)) inline
+// -- GODOT end -
 #define NV_DEPRECATED   __attribute__((deprecated))
 
 #if __GNUC__ > 2


### PR DESCRIPTION
Fixes #14669

Fixes thekla atlas mingw-w64 build.
Tested on macOS 10.13.2, mingw-w64 5.0.3 and Debian 9, mingw-w64 5.0.1.

Upstream changes made in #14595 marked with `// -- GODOT --` comments.