### PR TITLE
Proposed change to close issue "#6382 - Properties in the inspector lacking tooltips"

### DIFF
--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -2952,14 +2952,19 @@ void PropertyEditor::update_tree() {
 			if (!found) {
 				DocData *dd = EditorHelp::get_doc_data();
 				Map<String, DocData::ClassDoc>::Element *E = dd->class_list.find(classname);
-				if (E) {
+				while (E && descr == String()) {
 					for (int i = 0; i < E->get().properties.size(); i++) {
 						if (E->get().properties[i].name == propname.operator String()) {
 							descr = E->get().properties[i].description.strip_edges().word_wrap(80);
+							break;
 						}
 					}
+					if (!E->get().inherits.empty()) {
+						E = dd->class_list.find(E->get().inherits);
+					} else {
+						break;
+					}
 				}
-
 				descr_cache[classname][propname] = descr;
 			}
 


### PR DESCRIPTION
This is a proposed change to close godotengine/godot#6382 issue

Basically, the change does this: traverse classes docs so that all properties from inherited classes have tooltips accordingly

If we are seeing the properties of a Node2D, not only it's properties will have tooltips (like it was before), but also CanvasItem (from where Node2D inherits from) properties will have their tooltips.

![godot_6382](https://user-images.githubusercontent.com/8830610/34037929-704fd360-e182-11e7-9f0c-8d6970974cba.gif)
