### PR TITLE
Made multiline property editor deselect text when opening

### DIFF
--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -551,6 +551,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 
 				text_edit->show();
 				text_edit->set_text(v);
+				text_edit->deselect();
 
 				int button_margin = get_constant("button_margin", "Dialogs");
 				int margin = get_constant("margin", "Dialogs");


### PR DESCRIPTION
Before, the multiline editor kept the previous selection, even between different texts. My idea at first was to simply remove all selection, but as the single-line properties select all text when clicked, I thought it would be better to do this for consistency.

![screenshot at 2017-12-15 11-51-38](https://user-images.githubusercontent.com/30739239/34044996-624c093a-e18e-11e7-8f9c-edaff2c24752.png)

**EDIT:** See below.