### PR TITLE
Enhancements and fixes for PopupMenu's submenus

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -42,24 +42,6 @@ String PopupMenu::_get_accel_text(int p_item) const {
 	else if (items[p_item].accel)
 		return keycode_get_string(items[p_item].accel);
 	return String();
-
-	/*
-	String atxt;
-	if (p_accel&KEY_MASK_SHIFT)
-		atxt+="Shift+";
-	if (p_accel&KEY_MASK_ALT)
-		atxt+="Alt+";
-	if (p_accel&KEY_MASK_CTRL)
-		atxt+="Ctrl+";
-	if (p_accel&KEY_MASK_META)
-		atxt+="Meta+";
-
-	p_accel&=KEY_CODE_MASK;
-
-	atxt+=String::chr(p_accel).to_upper();
-
-	return atxt;
-*/
 }
 
 Size2 PopupMenu::get_minimum_size() const {
@@ -136,7 +118,6 @@ int PopupMenu::_get_mouse_over(const Point2 &p_over) const {
 
 	Ref<Font> font = get_font("font");
 	int vseparation = get_constant("vseparation");
-	//int hseparation = get_constant("hseparation");
 	float font_h = font->get_height();
 
 	for (int i = 0; i < items.size(); i++) {
@@ -230,6 +211,11 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 
 						mouse_over = i;
 						update();
+
+						if (items[i].submenu != "" && submenu_over != i) {
+							submenu_over = i;
+							submenu_timer->start();
+						}
 						break;
 					}
 				}
@@ -245,6 +231,11 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 
 						mouse_over = i;
 						update();
+
+						if (items[i].submenu != "" && submenu_over != i) {
+							submenu_over = i;
+							submenu_timer->start();
+						}
 						break;
 					}
 				}
@@ -499,6 +490,13 @@ void PopupMenu::_notification(int p_what) {
 			grab_focus();
 		} break;
 		case NOTIFICATION_MOUSE_EXIT: {
+
+			if (mouse_over >= 0 && (items[mouse_over].submenu == "" || submenu_over != -1)) {
+				mouse_over = -1;
+				update();
+			}
+		} break;
+		case NOTIFICATION_POPUP_HIDE: {
 
 			if (mouse_over >= 0) {
 				mouse_over = -1;
@@ -1217,6 +1215,7 @@ void PopupMenu::set_invalidate_click_until_motion() {
 PopupMenu::PopupMenu() {
 
 	mouse_over = -1;
+	submenu_over = -1;
 
 	set_focus_mode(FOCUS_ALL);
 	set_as_toplevel(true);


### PR DESCRIPTION
- Fixed submenu's PopupMenu not opening if the submenu index was 0.
- Using the keyboard to highlight a submenu now opens its PopupMenu.
- Submenus stay highlighted after their PopupMenu opens:
![submenu](https://user-images.githubusercontent.com/30739239/34053692-e8b9dbf8-e1ae-11e7-9d3d-d05ea2ba36a2.png)
- Removed some commented code. Warn me if it was something that shouldn't have been removed.