### PR TITLE
Remove get_stack_bottom

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -606,10 +606,6 @@ bool OS::has_feature(const String &p_feature) {
 	return false;
 }
 
-void *OS::get_stack_bottom() const {
-	return _stack_bottom;
-}
-
 OS::OS() {
 	void *volatile stack_bottom;
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -445,13 +445,6 @@ public:
 	virtual void force_process_input(){};
 	bool has_feature(const String &p_feature);
 
-	/**
-	 * Returns the stack bottom of the main thread of the application.
-	 * This may be of use when integrating languages with garbage collectors that
-	 * need to check whether a pointer is on the stack.
-	 */
-	virtual void *get_stack_bottom() const;
-
 	bool is_hidpi_allowed() const { return _allow_hidpi; }
 	OS();
 	virtual ~OS();

--- a/modules/gdnative/gdnative/gdnative.cpp
+++ b/modules/gdnative/gdnative/gdnative.cpp
@@ -52,10 +52,6 @@ godot_object GDAPI *godot_global_get_singleton(char *p_name) {
 	return (godot_object *)Engine::get_singleton()->get_singleton_object(String(p_name));
 } // result shouldn't be freed
 
-void GDAPI *godot_get_stack_bottom() {
-	return OS::get_singleton()->get_stack_bottom();
-}
-
 // MethodBind API
 
 godot_method_bind GDAPI *godot_method_bind_get_method(const char *p_classname, const char *p_methodname) {

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -5533,12 +5533,6 @@
         ]
       },
       {
-        "name": "godot_get_stack_bottom",
-        "return_type": "void *",
-        "arguments": [
-        ]
-      },
-      {
         "name": "godot_method_bind_get_method",
         "return_type": "godot_method_bind *",
         "arguments": [

--- a/modules/gdnative/include/gdnative/gdnative.h
+++ b/modules/gdnative/include/gdnative/gdnative.h
@@ -212,10 +212,6 @@ void GDAPI godot_object_destroy(godot_object *p_o);
 
 godot_object GDAPI *godot_global_get_singleton(char *p_name); // result shouldn't be freed
 
-////// OS API
-
-void GDAPI *godot_get_stack_bottom(); //  returns stack bottom of the main thread
-
 ////// MethodBind API
 
 typedef struct {


### PR DESCRIPTION
It's not used in godot-nim any longer and there were no other uses for
it.