### PR TITLE
Rename the debug symbol files to .debugsymbols

### DIFF
--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -9,9 +9,9 @@ def make_debug_mingw(target, source, env):
         mingw_prefix = env["mingw_prefix_32"]
     else:
         mingw_prefix = env["mingw_prefix_64"]
-    os.system(mingw_prefix + 'objcopy --only-keep-debug %s %s.debug' % (target[0], target[0]))
+    os.system(mingw_prefix + 'objcopy --only-keep-debug %s %s.debugsymbols' % (target[0], target[0]))
     os.system(mingw_prefix + 'strip --strip-debug --strip-unneeded %s' % (target[0]))
-    os.system(mingw_prefix + 'objcopy --add-gnu-debuglink=%s.debug %s' % (target[0], target[0]))
+    os.system(mingw_prefix + 'objcopy --add-gnu-debuglink=%s.debugsymbols %s' % (target[0], target[0]))
 
 common_win = [
     "context_gl_win.cpp",

--- a/platform/x11/SCsub
+++ b/platform/x11/SCsub
@@ -4,9 +4,9 @@ import os
 Import('env')
 
 def make_debug(target, source, env):
-    os.system('objcopy --only-keep-debug %s %s.debug' % (target[0], target[0]))
+    os.system('objcopy --only-keep-debug %s %s.debugsymbols' % (target[0], target[0]))
     os.system('strip --strip-debug --strip-unneeded %s' % (target[0]))
-    os.system('objcopy --add-gnu-debuglink=%s.debug %s' % (target[0], target[0]))
+    os.system('objcopy --add-gnu-debuglink=%s.debugsymbols %s' % (target[0], target[0]))
 
 common_x11 = [
     "context_gl_x11.cpp",


### PR DESCRIPTION
Some users were confused by the '.debug' suffix for the symbols.