### PR TITLE
Enhance FileSystem dock

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -129,6 +129,7 @@ void FileSystemDock::_update_tree(bool keep_collapse_state) {
 	}
 
 	_create_tree(root, EditorFileSystem::get_singleton()->get_filesystem(), uncollapsed_paths);
+	tree->ensure_cursor_is_visible();
 	updating_tree = false;
 }
 
@@ -592,8 +593,7 @@ void FileSystemDock::_select_file(int p_idx) {
 		}
 		path = fpath;
 		_update_files(false);
-		current_path->set_text(path);
-		_push_to_history();
+		navigate_to_path(path);
 	} else {
 		if (ResourceLoader::get_resource_type(fpath) == "PackedScene") {
 			editor->open_request(fpath);
@@ -1219,6 +1219,9 @@ void FileSystemDock::_go_to_file_list() {
 		tree->hide();
 		file_list_vb->show();
 		button_favorite->hide();
+	} else {
+		bool collapsed = tree->get_selected()->is_collapsed();
+		tree->get_selected()->set_collapsed(!collapsed);
 	}
 
 	//file_options->show();


### PR DESCRIPTION
* Collapse / Uncollapse folder with double click
* Sync with tree and bottom panel
* Show selected folder in tree when changed

![filesystem_dock](https://user-images.githubusercontent.com/8281454/34071325-2f1a14b4-e2b8-11e7-8c08-71e68c395d9c.gif)
