### PR TITLE
Revert "Fix mouse button release not sent to gui_input if it's different from the button that gave focus"

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1811,8 +1811,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 				_gui_call_input(gui.mouse_focus, mb);
 			}
 
-			if (mb->get_button_mask() == 0) {
-				// Last mouse button was released
+			if (mb->get_button_index() == gui.mouse_focus_button) {
 				gui.mouse_focus = NULL;
 				gui.mouse_focus_button = -1;
 			}


### PR DESCRIPTION
Reverts godotengine/godot#14484