### PR TITLE
Use a more naive RNG for the lightmapper

### DIFF
--- a/scene/3d/voxel_light_baker.cpp
+++ b/scene/3d/voxel_light_baker.cpp
@@ -1614,6 +1614,18 @@ Vector3 VoxelLightBaker::_compute_pixel_light_at_pos(const Vector3 &p_pos, const
 	return accum;
 }
 
+uint32_t xorshiftstate[] = { 123 }; // anything non-zero will do here
+
+_ALWAYS_INLINE_ uint32_t xorshift32() {
+	/* Algorithm "xor" from p. 4 of Marsaglia, "Xorshift RNGs" */
+	uint32_t x = xorshiftstate[0];
+	x ^= x << 13;
+	x ^= x >> 17;
+	x ^= x << 5;
+	xorshiftstate[0] = x;
+	return x;
+}
+
 Vector3 VoxelLightBaker::_compute_ray_trace_at_pos(const Vector3 &p_pos, const Vector3 &p_normal) {
 
 	int samples_per_quality[3] = { 48, 128, 512 };
@@ -1638,9 +1650,9 @@ Vector3 VoxelLightBaker::_compute_ray_trace_at_pos(const Vector3 &p_pos, const V
 
 	for (int i = 0; i < samples; i++) {
 
-		float random_angle1 = (((Math::rand() % 65535) / 65535.0) * 2.0 - 1.0) * spread;
+		float random_angle1 = (((xorshift32() % 65535) / 65535.0) * 2.0 - 1.0) * spread;
 		Vector3 axis(0, sin(random_angle1), cos(random_angle1));
-		float random_angle2 = ((Math::rand() % 65535) / 65535.0) * Math_PI * 2.0;
+		float random_angle2 = ((xorshift32() % 65535) / 65535.0) * Math_PI * 2.0;
 		Basis rot(Vector3(0, 0, 1), random_angle2);
 		axis = rot.xform(axis);
 


### PR DESCRIPTION
This speeds up the lightmapper by about 10% with no visible impact. A
comparison is up here:

https://tmm.cx/nextcloud/s/Log1eAXen1dJzBz

AMD Ryzen 7 1700 Eight-Core Processor
Sponza scene

pcg32
256/256/high   00:10:13
256/256/medium 00:02:50
256/256/low    00:01:11

xorshift
256/256/high   00:09:32
256/256/medium 00:02:34
256/256/low    00:01:05