### PR TITLE
Add several unlikely() macros

### DIFF
--- a/core/hash_map.h
+++ b/core/hash_map.h
@@ -313,7 +313,7 @@ public:
 
 	_FORCE_INLINE_ TData *getptr(const TKey &p_key) {
 
-		if (!hash_table)
+		if (unlikely(!hash_table))
 			return NULL;
 
 		Element *e = const_cast<Element *>(get_element(p_key));
@@ -326,7 +326,7 @@ public:
 
 	_FORCE_INLINE_ const TData *getptr(const TKey &p_key) const {
 
-		if (!hash_table)
+		if (unlikely(!hash_table))
 			return NULL;
 
 		const Element *e = const_cast<Element *>(get_element(p_key));
@@ -345,7 +345,7 @@ public:
 	template <class C>
 	_FORCE_INLINE_ TData *custom_getptr(C p_custom_key, uint32_t p_custom_hash) {
 
-		if (!hash_table)
+		if (unlikely(!hash_table))
 			return NULL;
 
 		uint32_t hash = p_custom_hash;
@@ -371,7 +371,7 @@ public:
 	template <class C>
 	_FORCE_INLINE_ const TData *custom_getptr(C p_custom_key, uint32_t p_custom_hash) const {
 
-		if (!hash_table)
+		if (unlikely(!hash_table))
 			return NULL;
 
 		uint32_t hash = p_custom_hash;
@@ -400,7 +400,7 @@ public:
 
 	bool erase(const TKey &p_key) {
 
-		if (!hash_table)
+		if (unlikely(!hash_table))
 			return false;
 
 		uint32_t hash = Hasher::hash(p_key);
@@ -478,7 +478,8 @@ public:
 	*/
 	const TKey *next(const TKey *p_key) const {
 
-		if (!hash_table) return NULL;
+		if (unlikely(!hash_table))
+			return NULL;
 
 		if (!p_key) { /* get the first key */
 
@@ -559,7 +560,7 @@ public:
 	}
 
 	void get_key_value_ptr_array(const Pair **p_pairs) const {
-		if (!hash_table)
+		if (unlikely(!hash_table))
 			return;
 		for (int i = 0; i < (1 << hash_table_power); i++) {
 
@@ -573,7 +574,7 @@ public:
 	}
 
 	void get_key_list(List<TKey> *p_keys) const {
-		if (!hash_table)
+		if (unlikely(!hash_table))
 			return;
 		for (int i = 0; i < (1 << hash_table_power); i++) {
 

--- a/scene/3d/voxel_light_baker.cpp
+++ b/scene/3d/voxel_light_baker.cpp
@@ -1692,7 +1692,7 @@ Vector3 VoxelLightBaker::_compute_ray_trace_at_pos(const Vector3 &p_pos, const V
 				}
 
 				cell = bc->childs[child];
-				if (cell == CHILD_EMPTY)
+				if (unlikely(cell == CHILD_EMPTY))
 					break;
 
 				half >>= 1;
@@ -1701,12 +1701,12 @@ Vector3 VoxelLightBaker::_compute_ray_trace_at_pos(const Vector3 &p_pos, const V
 			pos += advance;
 		}
 
-		if (cell != CHILD_EMPTY) {
+		if (unlikely(cell != CHILD_EMPTY)) {
 			for (int i = 0; i < 6; i++) {
 				//anisotropic read light
 				float amount = direction.dot(aniso_normal[i]);
-				if (amount < 0)
-					amount = 0;
+				if (amount <= 0)
+					continue;
 				accum.x += light[cell].accum[i][0] * amount;
 				accum.y += light[cell].accum[i][1] * amount;
 				accum.z += light[cell].accum[i][2] * amount;


### PR DESCRIPTION
Based off of perf-based prediction misses these seem to be the
lowest-hanging fruit for quick (albeit small) improvements. These are
based on:

* baking a complex lightmap
* running platformer 3d
* running goltorus