### PR TITLE
Implement settings dialog UI ideas

### DIFF
--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -548,34 +548,28 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	HBoxContainer *hbc = memnew(HBoxContainer);
 	add_child(hbc);
 
-	VBoxContainer *vbc_path = memnew(VBoxContainer);
-	vbc_path->set_h_size_flags(SIZE_EXPAND_FILL);
+	Label *l = memnew(Label);
+	l->set_text(TTR("Path:"));
+	hbc->add_child(l);
 
 	autoload_add_path = memnew(EditorLineEditFileChooser);
 	autoload_add_path->set_h_size_flags(SIZE_EXPAND_FILL);
-
 	autoload_add_path->get_file_dialog()->set_mode(EditorFileDialog::MODE_OPEN_FILE);
 	autoload_add_path->get_file_dialog()->connect("file_selected", this, "_autoload_file_callback");
+	hbc->add_child(autoload_add_path);
 
-	vbc_path->add_margin_child(TTR("Path:"), autoload_add_path);
-	hbc->add_child(vbc_path);
-
-	VBoxContainer *vbc_name = memnew(VBoxContainer);
-	vbc_name->set_h_size_flags(SIZE_EXPAND_FILL);
-
-	HBoxContainer *hbc_name = memnew(HBoxContainer);
+	l = memnew(Label);
+	l->set_text(TTR("Node Name:"));
+	hbc->add_child(l);
 
 	autoload_add_name = memnew(LineEdit);
 	autoload_add_name->set_h_size_flags(SIZE_EXPAND_FILL);
-	hbc_name->add_child(autoload_add_name);
+	hbc->add_child(autoload_add_name);
 
 	Button *add_autoload = memnew(Button);
 	add_autoload->set_text(TTR("Add"));
-	hbc_name->add_child(add_autoload);
 	add_autoload->connect("pressed", this, "_autoload_add");
-
-	vbc_name->add_margin_child(TTR("Node Name:"), hbc_name);
-	hbc->add_child(vbc_name);
+	hbc->add_child(add_autoload);
 
 	tree = memnew(Tree);
 	tree->set_hide_root(true);
@@ -606,5 +600,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	tree->connect("item_edited", this, "_autoload_edited");
 	tree->connect("button_pressed", this, "_autoload_button_pressed");
 
-	add_margin_child(TTR("List:"), tree, true);
+	tree->set_v_size_flags(SIZE_EXPAND_FILL);
+
+	add_child(tree, true);
 }

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -1690,12 +1690,12 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	vbc->set_anchor_and_margin(MARGIN_LEFT, ANCHOR_BEGIN, 0);
 	vbc->set_anchor_and_margin(MARGIN_RIGHT, ANCHOR_END, 0);
 
-	l = memnew(Label);
-	vbc->add_child(l);
-	l->set_text(TTR("Action:"));
-
 	hbc = memnew(HBoxContainer);
 	vbc->add_child(hbc);
+
+	l = memnew(Label);
+	hbc->add_child(l);
+	l->set_text(TTR("Action:"));
 
 	action_name = memnew(LineEdit);
 	action_name->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -4599,7 +4599,7 @@ SectionedPropertyEditor::SectionedPropertyEditor() {
 	sections->set_v_size_flags(SIZE_EXPAND_FILL);
 	sections->set_hide_root(true);
 
-	left_vb->add_margin_child(TTR("Sections:"), sections, true);
+	left_vb->add_child(sections, true);
 
 	VBoxContainer *right_vb = memnew(VBoxContainer);
 	right_vb->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -4608,7 +4608,7 @@ SectionedPropertyEditor::SectionedPropertyEditor() {
 	filter = memnew(SectionedPropertyEditorFilter);
 	editor = memnew(PropertyEditor);
 	editor->set_v_size_flags(SIZE_EXPAND_FILL);
-	right_vb->add_margin_child(TTR("Properties:"), editor, true);
+	right_vb->add_child(editor, true);
 
 	editor->get_scene_tree()->set_column_titles_visible(false);
 

--- a/editor/property_editor.h
+++ b/editor/property_editor.h
@@ -314,9 +314,9 @@ public:
 
 class SectionedPropertyEditorFilter;
 
-class SectionedPropertyEditor : public HBoxContainer {
+class SectionedPropertyEditor : public HSplitContainer {
 
-	GDCLASS(SectionedPropertyEditor, HBoxContainer);
+	GDCLASS(SectionedPropertyEditor, HSplitContainer);
 
 	ObjectID obj;
 

--- a/editor/settings_config_dialog.h
+++ b/editor/settings_config_dialog.h
@@ -41,6 +41,8 @@ class EditorSettingsDialog : public AcceptDialog {
 	bool updating;
 
 	TabContainer *tabs;
+	Control *tab_general;
+	Control *tab_shortcuts;
 
 	LineEdit *search_box;
 	LineEdit *shortcut_search_box;
@@ -68,9 +70,13 @@ class EditorSettingsDialog : public AcceptDialog {
 
 	void _unhandled_input(const Ref<InputEvent> &p_event);
 	void _notification(int p_what);
+	void _update_icons();
 
 	void _press_a_key_confirm();
 	void _wait_for_key(const Ref<InputEvent> &p_event);
+
+	void _tabs_tab_changed(int p_tab);
+	void _focus_current_search_box();
 
 	void _clear_shortcut_search_box();
 	void _clear_search_box();


### PR DESCRIPTION
I implemented several UI ideas which popped up recently (partly from https://github.com/godotengine/godot/issues/14380). I've changed the windows as follows (with before / after images). Feedback and discussion welcome.

**Editor Settings**
- General tab: Removed search and section labels.
![image](https://user-images.githubusercontent.com/9631152/34082229-b8f8b6e8-e35a-11e7-8367-ea2bff7ed023.png) ![image](https://user-images.githubusercontent.com/9631152/34082236-c7b88820-e35a-11e7-8104-5509a39c9b82.png)
- Shortcuts tab: Removed search and section labels.
![image](https://user-images.githubusercontent.com/9631152/34082258-19bbb02a-e35b-11e7-9a04-f61f073e8df5.png) ![image](https://user-images.githubusercontent.com/9631152/34082261-25e26e3e-e35b-11e7-911f-b5427ed2325c.png)
- Search box of each tab is automatically focussed and all text selected.
- Bugfix: Changing the theme did not update the icon and tree colors.

Indifferent about removal of Search label. Fact is that the "Search Help" dialogues never had something like it, and I made it similar to them. On the other hand, the Project Settings dialog always has something like a label or button in front of the actual input box.

**Property Editor**
- Made splitter between tree and properties draggable (`HBoxContainer` -> `HSplitContainer`). I just recently manually increased the width of the tree to fit some new section texts, but in other languages, this might not have been enough.

**Project Settings**
- General tab: Remove section labels.
![image](https://user-images.githubusercontent.com/9631152/34082276-5c92bec0-e35b-11e7-9479-eb902d5948ec.png) ![image](https://user-images.githubusercontent.com/9631152/34082282-6c7dccc6-e35b-11e7-9e07-b12dae15e264.png)
- Input Map: Remove section labels and inline "toolbar" controls.
![image](https://user-images.githubusercontent.com/9631152/34082297-99256248-e35b-11e7-84ed-da2a7cb138ca.png) ![image](https://user-images.githubusercontent.com/9631152/34082300-a1748988-e35b-11e7-9c77-307e8b856268.png)
- AutoLoad tab: Remove section labels and inline "toolbar" controls.
![image](https://user-images.githubusercontent.com/9631152/34082309-b87cc794-e35b-11e7-996d-7dd211372615.png) ![image](https://user-images.githubusercontent.com/9631152/34082307-b5da11a4-e35b-11e7-9e6f-5b0c3ff2bf46.png)

