### PR TITLE
Implement settings dialog UI ideas - Clang fix

### DIFF
--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -352,7 +352,7 @@ void EditorSettingsDialog::_tabs_tab_changed(int p_tab) {
 void EditorSettingsDialog::_focus_current_search_box() {
 
 	Control *tab = tabs->get_current_tab_control();
-	LineEdit* current_search_box;
+	LineEdit *current_search_box;
 	if (tab == tab_general)
 		current_search_box = search_box;
 	else if (tab == tab_shortcuts)


### PR DESCRIPTION
https://github.com/godotengine/godot/pull/14779 got merged so fast D: and I had a formatting error in it before I could see it. Set my clang format extension to format on save now (didn't before to compare manually and learn project standards from it) - missed a tiny spot in one file.

Actually I wanted to wait on feedback on [Krakean's idea]( https://github.com/godotengine/godot/pull/14779#issuecomment-352276937), but I just quickly tested it and decided not to implement it:
- The current logic of adding an AutoLoad node would override an already entered name if a path is picked
- and the name can be automatically suggested by picking the path first