### PR TITLE
A few small Debugger->Errors tab enhancements:

### DIFF
--- a/editor/script_editor_debugger.h
+++ b/editor/script_editor_debugger.h
@@ -62,6 +62,10 @@ class ScriptEditorDebugger : public Control {
 		MESSAGE_SUCCESS,
 	};
 
+	enum ItemMenu {
+		ITEM_MENU_COPY_ERROR,
+	};
+
 	AcceptDialog *msgdialog;
 
 	Button *debugger_button;
@@ -85,6 +89,8 @@ class ScriptEditorDebugger : public Control {
 	ItemList *error_list;
 	ItemList *error_stack;
 	Tree *inspect_scene_tree;
+	Button *clearbutton;
+	PopupMenu *item_menu;
 
 	int error_count;
 	int last_error_count;
@@ -175,6 +181,10 @@ class ScriptEditorDebugger : public Control {
 
 	void _set_remote_object(ObjectID p_id, ScriptEditorDebuggerInspectedObject *p_obj);
 	void _clear_remote_objects();
+	void _clear_errors_list();
+
+	void _error_list_item_rmb_selected(int p_item, const Vector2 &p_pos);
+	void _item_menu_id_pressed(int p_option);
 
 protected:
 	void _notification(int p_what);

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -930,6 +930,9 @@ void ItemList::_notification(int p_what) {
 						scroll_bar->hide();
 					} else {
 						scroll_bar->show();
+
+						if (do_autoscroll_to_bottom)
+							scroll_bar->set_value(max);
 					}
 					break;
 				}
@@ -1313,6 +1316,11 @@ Size2 ItemList::get_minimum_size() const {
 	return Size2();
 }
 
+void ItemList::set_autoscroll_to_bottom(const bool p_enable) {
+
+	do_autoscroll_to_bottom = p_enable;
+}
+
 void ItemList::set_auto_height(bool p_enable) {
 
 	auto_height = p_enable;
@@ -1466,6 +1474,7 @@ ItemList::ItemList() {
 	ensure_selected_visible = false;
 	defer_select_single = -1;
 	allow_rmb_select = false;
+	do_autoscroll_to_bottom = false;
 
 	icon_scale = 1.0f;
 	set_clip_contents(true);

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -107,6 +107,8 @@ private:
 
 	real_t icon_scale;
 
+	bool do_autoscroll_to_bottom;
+
 	Array _get_items() const;
 	void _set_items(const Array &p_items);
 
@@ -211,6 +213,8 @@ public:
 	bool has_auto_height() const;
 
 	Size2 get_minimum_size() const;
+
+	void set_autoscroll_to_bottom(const bool p_enable);
 
 	VScrollBar *get_v_scroll() { return scroll_bar; }
 


### PR DESCRIPTION
1. Added "Clear" button to clear list.
2. Errors list is now autoscrolled to bottom to see newest errors, without need manually scrolling
3. Added PopupMenu to errors list with ability to quickly Copy error text & details.

This is how all of it looks in action:
https://i.imgur.com/lyC6zhZ.gifv