### PR TITLE
Shader Language: Fix Vertex Lighting artifacts.

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -174,7 +174,7 @@ void light_compute(vec3 N, vec3 L,vec3 V, vec3 light_color, float roughness, ino
 
 		vec3 H = normalize(V + L);
 		float dotNH = max(dot(N,H), 0.0 );
-		float intensity = pow( dotNH, (1.0-roughness) * 256.0);
+		float intensity = (roughness >= 1.0 ? 1.0 : pow( dotNH, (1.0-roughness) * 256.0));
 		specular += light_color * intensity;
 
 	}


### PR DESCRIPTION
- When using Direction Lighting along with Vertex Lighting,
  putting a SpatialMaterial Roughness to 1.0 causes artifacts to appear.
  (#14552)

When we shade a Mesh through the Vertex Shader along with a Directional Light,
we compute the dot product of surfaces normal and the (V(viewer) + L(light)) normalized vector.
In doing so, *hidden* surfaces produce a negative (< 0.0) `dotNH`. But we'll keep `dotNH = 0.0` as result.
Providing we use a `roughness = 1.0`, the effective call to `pow( dotNH, (1.0-roughness) * 256.0)` is `pow(0.0, 0.0)`.

Nevertheless, according to the *OpenGL ES Shading Language* **pow(x, y)** docs :
> Results are undefined if x = 0 and y <= 0.

Which is our case...
So we may check when **y** (`(1.0-roughness)*256.0` in our case) is null, and return `1.0`, providing `x^0.0` will *always* return `1.0`.

Fixes #14552.