### PR TITLE
Tree: Insert new item, fix behavior when no parent given

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2950,43 +2950,51 @@ Size2 Tree::get_minimum_size() const {
 	return Size2(1, 1);
 }
 
-TreeItem *Tree::create_item(TreeItem *p_parent) {
+TreeItem *Tree::create_item(TreeItem *p_parent, int p_idx) {
 
 	ERR_FAIL_COND_V(blocked > 0, NULL);
 
-	TreeItem *ti = memnew(TreeItem(this));
-
-	ERR_FAIL_COND_V(!ti, NULL);
-	ti->cells.resize(columns.size());
+	TreeItem *ti = NULL;
 
 	if (p_parent) {
 
-		/* Always append at the end */
+		// Append or insert a new item to the given parent.
+		ti = memnew(TreeItem(this));
+		ERR_FAIL_COND_V(!ti, NULL);
+		ti->cells.resize(columns.size());
 
-		TreeItem *last = 0;
+		TreeItem *prev = NULL;
 		TreeItem *c = p_parent->childs;
+		int idx = 0;
 
 		while (c) {
-
-			last = c;
+			if (idx++ == p_idx) {
+				ti->next = c;
+				break;
+			}
+			prev = c;
 			c = c->next;
 		}
 
-		if (last) {
-
-			last->next = ti;
-		} else {
-
+		if (prev)
+			prev->next = ti;
+		else
 			p_parent->childs = ti;
-		}
 		ti->parent = p_parent;
 
 	} else {
 
-		if (root)
-			ti->childs = root;
+		if (!root) {
+			// No root exists, make the given item the new root.
+			ti = memnew(TreeItem(this));
+			ERR_FAIL_COND_V(!ti, NULL);
+			ti->cells.resize(columns.size());
 
-		root = ti;
+			root = ti;
+		} else {
+			// Root exists, append or insert to root.
+			ti = create_item(root, p_idx);
+		}
 	}
 
 	return ti;
@@ -3723,7 +3731,7 @@ void Tree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_scroll_moved"), &Tree::_scroll_moved);
 
 	ClassDB::bind_method(D_METHOD("clear"), &Tree::clear);
-	ClassDB::bind_method(D_METHOD("create_item", "parent"), &Tree::_create_item, DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("create_item", "parent", "idx"), &Tree::_create_item, DEFVAL(Variant()), DEFVAL(-1));
 
 	ClassDB::bind_method(D_METHOD("get_root"), &Tree::get_root);
 	ClassDB::bind_method(D_METHOD("set_column_min_width", "column", "min_width"), &Tree::set_column_min_width);

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -511,8 +511,8 @@ protected:
 	static void _bind_methods();
 
 	//bind helpers
-	Object *_create_item(Object *p_parent) {
-		return create_item(Object::cast_to<TreeItem>(p_parent));
+	Object *_create_item(Object *p_parent, int p_idx = -1) {
+		return create_item(Object::cast_to<TreeItem>(p_parent), p_idx);
 	}
 
 	TreeItem *_get_next_selected(Object *p_item) {
@@ -532,7 +532,7 @@ public:
 
 	void clear();
 
-	TreeItem *create_item(TreeItem *p_parent = 0);
+	TreeItem *create_item(TreeItem *p_parent = 0, int p_idx = -1);
 	TreeItem *get_root();
 	TreeItem *get_last_item();
 


### PR DESCRIPTION
- Added new optional parameter `int p_idx = -1` to `Tree::create_item`. Results in `Tree::create_item(TreeItem* p_parent = NULL, int p_idx = -1)`
- If `p_parent` is not given, and no root exists, the created item becomes the root (`p_idx` is ignored).
- If `p_parent` is not given, and a root exists, the created item is added or inserted to the root item (according to `p_idx`). This is the behavior as stated in the documentation, not the one suggested by [reduz here](https://github.com/godotengine/godot/issues/14660#issuecomment-352185335) (don't kill me D:).
- If `p_idx` is smaller than 0 or bigger than the number of children in `p_parent`, it is always appended to the end of that parent.

Finishes https://github.com/godotengine/godot/pull/13725
Fixes https://github.com/godotengine/godot/issues/14660 https://github.com/godotengine/godot/issues/12118
