### PR TITLE
Fix "selection_changed" called twice

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -871,6 +871,7 @@ void EditorSelection::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_node", "node"), &EditorSelection::remove_node);
 	ClassDB::bind_method(D_METHOD("get_selected_nodes"), &EditorSelection::_get_selected_nodes);
 	ClassDB::bind_method(D_METHOD("get_transformable_selected_nodes"), &EditorSelection::_get_transformable_selected_nodes);
+	ClassDB::bind_method(D_METHOD("_emit_change"), &EditorSelection::_emit_change);
 	ADD_SIGNAL(MethodInfo("selection_changed"));
 }
 
@@ -914,7 +915,15 @@ void EditorSelection::update() {
 	if (!changed)
 		return;
 	changed = false;
+	if (!emitted) {
+		emitted = true;
+		call_deferred("_emit_change");
+	}
+}
+
+void EditorSelection::_emit_change() {
 	emit_signal("selection_changed");
+	emitted = false;
 }
 
 List<Node *> &EditorSelection::get_selected_node_list() {
@@ -938,6 +947,7 @@ void EditorSelection::clear() {
 }
 EditorSelection::EditorSelection() {
 
+	emitted = false;
 	changed = false;
 	nl_changed = false;
 }

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -209,9 +209,10 @@ class EditorSelection : public Object {
 
 	GDCLASS(EditorSelection, Object);
 
-public:
+private:
 	Map<Node *, Object *> selection;
 
+	bool emitted;
 	bool changed;
 	bool nl_changed;
 
@@ -223,6 +224,7 @@ public:
 	void _update_nl();
 	Array _get_selected_nodes();
 	Array _get_transformable_selected_nodes();
+	void _emit_change();
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
Currently, `"selection_changed"` signal is called twice everytime selection is changed.
because it's called many places in the different state in one frame.

the first emit is in `NOTIFICATION_PHYSICS_PROCESS` state.
and it's cleared in `void CanvasItemEditor::edit(CanvasItem *p_canvas_item)`

then second emit is in `NOTIFICATION_DRAW` state.

so every function is called twice if it's connected with `"selection_changed"`
