### PR TITLE
Some fixes for the Script Editor and dead code cleaning.

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -324,23 +324,14 @@ EditorHelpSearch::EditorHelpSearch() {
 	set_hide_on_ok(false);
 	search_options->connect("item_activated", this, "_confirmed");
 	set_title(TTR("Search Help"));
-
-	//search_options->set_hide_root(true);
 }
 
 /////////////////////////////////
-
-////////////////////////////////////
-/// /////////////////////////////////
 
 void EditorHelpIndex::add_type(const String &p_type, HashMap<String, TreeItem *> &p_types, TreeItem *p_root) {
 
 	if (p_types.has(p_type))
 		return;
-	/*
-	if (!ClassDB::is_type(p_type,base) || p_type==base)
-		return;
-	*/
 
 	String inherits = EditorHelp::get_doc_data()->class_list[p_type].inherits;
 
@@ -379,8 +370,6 @@ void EditorHelpIndex::_tree_item_selected() {
 	EditorNode::get_singleton()->set_visible_editor(EditorNode::EDITOR_SCRIPT);
 	emit_signal("open_class", s->get_text(0));
 	hide();
-
-	//_goto_desc(s->get_text(0));
 }
 
 void EditorHelpIndex::select_class(const String &p_class) {
@@ -518,8 +507,6 @@ EditorHelpIndex::EditorHelpIndex() {
 
 /////////////////////////////////
 
-////////////////////////////////////
-/// /////////////////////////////////
 DocData *EditorHelp::doc = NULL;
 
 void EditorHelp::_init_colors() {
@@ -572,9 +559,7 @@ void EditorHelp::_class_list_select(const String &p_select) {
 
 void EditorHelp::_class_desc_select(const String &p_select) {
 
-	//print_line("LINK: "+p_select);
 	if (p_select.begins_with("$")) { //enum
-		//_goto_desc(p_select.substr(1,p_select.length()));
 		String select = p_select.substr(1, p_select.length());
 		String class_name;
 		if (select.find(".") != -1) {
@@ -585,7 +570,6 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 		emit_signal("go_to_help", "class_enum:" + class_name + ":" + select);
 		return;
 	} else if (p_select.begins_with("#")) {
-		//_goto_desc(p_select.substr(1,p_select.length()));
 		emit_signal("go_to_help", "class_name:" + p_select.substr(1, p_select.length()));
 		return;
 	} else if (p_select.begins_with("@")) {
@@ -612,7 +596,6 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 		}
 
 		if (link.find(".") != -1) {
-			//must go somewhere else
 
 			emit_signal("go_to_help", topic + ":" + link.get_slice(".", 0) + ":" + link.get_slice(".", 1));
 		} else {
@@ -749,16 +732,13 @@ void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview
 
 Error EditorHelp::_goto_desc(const String &p_class, int p_vscr) {
 
-	//ERR_FAIL_COND(!doc->class_list.has(p_class));
 	if (!doc->class_list.has(p_class))
 		return ERR_DOES_NOT_EXIST;
 
-	//if (tree_item_map.has(p_class)) {
 	select_locked = true;
-	//}
 
 	class_desc->show();
-	//tabs->set_current_tab(PAGE_CLASS_DESC);
+
 	description_line = 0;
 
 	if (p_class == edited_class)
@@ -770,7 +750,6 @@ Error EditorHelp::_goto_desc(const String &p_class, int p_vscr) {
 	method_line.clear();
 	section_line.clear();
 	edited_class = p_class;
-	//edited_class->show();
 
 	_init_colors();
 
@@ -866,7 +845,6 @@ Error EditorHelp::_goto_desc(const String &p_class, int p_vscr) {
 		class_desc->pop();
 		class_desc->pop();
 
-		//class_desc->add_newline();
 		class_desc->add_newline();
 		class_desc->push_color(text_color);
 		class_desc->push_font(doc_font);
@@ -891,7 +869,6 @@ Error EditorHelp::_goto_desc(const String &p_class, int p_vscr) {
 		class_desc->add_text(TTR("Members:"));
 		class_desc->pop();
 		class_desc->pop();
-		//class_desc->add_newline();
 
 		class_desc->push_indent(1);
 		class_desc->push_table(2);
@@ -969,9 +946,6 @@ Error EditorHelp::_goto_desc(const String &p_class, int p_vscr) {
 		class_desc->add_text(TTR("Public Methods:"));
 		class_desc->pop();
 		class_desc->pop();
-
-		//class_desc->add_newline();
-		//class_desc->add_newline();
 
 		class_desc->push_indent(1);
 		class_desc->push_table(2);
@@ -1094,7 +1068,6 @@ Error EditorHelp::_goto_desc(const String &p_class, int p_vscr) {
 		class_desc->pop();
 
 		class_desc->add_newline();
-		//class_desc->add_newline();
 
 		class_desc->push_indent(1);
 
@@ -1102,8 +1075,6 @@ Error EditorHelp::_goto_desc(const String &p_class, int p_vscr) {
 
 			signal_line[cd.signals[i].name] = class_desc->get_line_count() - 2; //gets overridden if description
 			class_desc->push_font(doc_code_font); // monofont
-			//_add_type("void");
-			//class_desc->add_text(" ");
 			class_desc->push_color(headline_color);
 			_add_text(cd.signals[i].name);
 			class_desc->pop();
@@ -1137,7 +1108,6 @@ Error EditorHelp::_goto_desc(const String &p_class, int p_vscr) {
 				class_desc->push_font(doc_font);
 				class_desc->push_color(comment_color);
 				class_desc->push_indent(1);
-				// class_desc->add_text(" ");
 				_add_text(cd.signals[i].description);
 				class_desc->pop(); // indent
 				class_desc->pop();
@@ -1181,7 +1151,6 @@ Error EditorHelp::_goto_desc(const String &p_class, int p_vscr) {
 			class_desc->push_indent(1);
 
 			class_desc->add_newline();
-			//class_desc->add_newline();
 
 			for (Map<String, Vector<DocData::ConstantDoc> >::Element *E = enums.front(); E; E = E->next()) {
 
@@ -1256,7 +1225,6 @@ Error EditorHelp::_goto_desc(const String &p_class, int p_vscr) {
 			class_desc->push_indent(1);
 
 			class_desc->add_newline();
-			//class_desc->add_newline();
 
 			for (int i = 0; i < constants.size(); i++) {
 
@@ -1275,7 +1243,6 @@ Error EditorHelp::_goto_desc(const String &p_class, int p_vscr) {
 				if (constants[i].description != "") {
 					class_desc->push_font(doc_font);
 					class_desc->push_indent(1);
-					//class_desc->add_text("  ");
 					class_desc->push_color(comment_color);
 					_add_text(constants[i].description);
 					class_desc->pop();
@@ -1348,8 +1315,6 @@ Error EditorHelp::_goto_desc(const String &p_class, int p_vscr) {
 			class_desc->pop(); // color
 			class_desc->pop(); // font
 			class_desc->pop(); // cell
-
-			//class_desc->add_text(" ");
 
 			if (cd.properties[i].setter != "") {
 
@@ -1534,7 +1499,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 		}
 
 		if (brk_pos == bbcode.length())
-			break; //nothing else o add
+			break; //nothing else to add
 
 		int brk_end = bbcode.find("]", brk_pos + 1);
 
@@ -1730,10 +1695,6 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 			pos = brk_pos + 1;
 		}
 	}
-
-	/*p_rt->pop();
-	p_rt->pop();
-	p_rt->pop();*/
 }
 
 void EditorHelp::_add_text(const String &p_bbcode) {
@@ -1758,8 +1719,7 @@ void EditorHelp::_notification(int p_what) {
 	switch (p_what) {
 
 		case NOTIFICATION_READY: {
-			//forward->set_icon(get_icon("Forward","EditorIcons"));
-			//back->set_icon(get_icon("Back","EditorIcons"));
+
 			_update_doc();
 
 		} break;
@@ -1832,7 +1792,6 @@ void EditorHelp::_bind_methods() {
 	ClassDB::bind_method("_class_list_select", &EditorHelp::_class_list_select);
 	ClassDB::bind_method("_class_desc_select", &EditorHelp::_class_desc_select);
 	ClassDB::bind_method("_class_desc_input", &EditorHelp::_class_desc_input);
-	//ClassDB::bind_method("_button_pressed",&EditorHelp::_button_pressed);
 	ClassDB::bind_method("_request_help", &EditorHelp::_request_help);
 	ClassDB::bind_method("_unhandled_key_input", &EditorHelp::_unhandled_key_input);
 	ClassDB::bind_method("_search", &EditorHelp::_search);
@@ -1844,21 +1803,16 @@ void EditorHelp::_bind_methods() {
 
 EditorHelp::EditorHelp() {
 
-	VBoxContainer *vbc = this;
+	set_custom_minimum_size(Size2(150 * EDSCALE, 0));
 
 	EDITOR_DEF("text_editor/help/sort_functions_alphabetically", true);
 
-	//class_list->connect("meta_clicked",this,"_class_list_select");
-	//class_list->set_selection_enabled(true);
-
-	{
-		class_desc = memnew(RichTextLabel);
-		vbc->add_child(class_desc);
-		class_desc->set_v_size_flags(SIZE_EXPAND_FILL);
-		class_desc->add_color_override("selection_color", get_color("text_editor/theme/selection_color", "Editor"));
-		class_desc->connect("meta_clicked", this, "_class_desc_select");
-		class_desc->connect("gui_input", this, "_class_desc_input");
-	}
+	class_desc = memnew(RichTextLabel);
+	add_child(class_desc);
+	class_desc->set_v_size_flags(SIZE_EXPAND_FILL);
+	class_desc->add_color_override("selection_color", get_color("text_editor/theme/selection_color", "Editor"));
+	class_desc->connect("meta_clicked", this, "_class_desc_select");
+	class_desc->connect("gui_input", this, "_class_desc_input");
 
 	class_desc->set_selection_enabled(true);
 
@@ -1878,12 +1832,6 @@ EditorHelp::EditorHelp() {
 	search_dialog->get_ok()->set_text(TTR("Find"));
 	search_dialog->connect("confirmed", this, "_search_cbk");
 	search_dialog->set_hide_on_ok(false);
-
-	/*class_search = memnew( EditorHelpSearch(editor) );
-	editor->get_gui_base()->add_child(class_search);
-	class_search->connect("go_to_help",this,"_help_callback");*/
-
-	//prev_search_page=-1;
 }
 
 EditorHelp::~EditorHelp() {
@@ -1901,9 +1849,9 @@ void EditorHelpBit::_go_to_help(String p_what) {
 void EditorHelpBit::_meta_clicked(String p_select) {
 
 	print_line("got meta " + p_select);
-	//print_line("LINK: "+p_select);
+
 	if (p_select.begins_with("$")) { //enum
-		//_goto_desc(p_select.substr(1,p_select.length()));
+
 		String select = p_select.substr(1, p_select.length());
 		String class_name;
 		if (select.find(".") != -1) {
@@ -1914,24 +1862,15 @@ void EditorHelpBit::_meta_clicked(String p_select) {
 		_go_to_help("class_enum:" + class_name + ":" + select);
 		return;
 	} else if (p_select.begins_with("#")) {
-		//_goto_desc(p_select.substr(1,p_select.length()));
+
 		_go_to_help("class_name:" + p_select.substr(1, p_select.length()));
 		return;
 	} else if (p_select.begins_with("@")) {
 
 		String m = p_select.substr(1, p_select.length());
 
-		if (m.find(".") != -1) {
-			//must go somewhere else
-
-			_go_to_help("class_method:" + m.get_slice(".", 0) + ":" + m.get_slice(".", 0));
-		} else {
-			/*
-			if (!method_line.has(m))
-				return;
-			class_desc->scroll_to_line(method_line[m]);
-			*/
-		}
+		if (m.find(".") != -1)
+			_go_to_help("class_method:" + m.get_slice(".", 0) + ":" + m.get_slice(".", 0)); //must go somewhere else
 	}
 }
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -132,7 +132,7 @@ public:
 				I = I->next();
 			}
 
-			if (O != E) { //should never heppane..
+			if (O != E) { //should never happen..
 				cached.erase(O);
 			}
 		}
@@ -234,7 +234,6 @@ ScriptEditorQuickOpen::ScriptEditorQuickOpen() {
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	add_child(vbc);
-	//set_child_rect(vbc);
 	search_box = memnew(LineEdit);
 	vbc->add_margin_child(TTR("Search:"), search_box);
 	search_box->connect("text_changed", this, "_text_changed");
@@ -256,8 +255,6 @@ ScriptEditor *ScriptEditor::script_editor = NULL;
 /*** SCRIPT EDITOR ******/
 
 String ScriptEditor::_get_debug_tooltip(const String &p_text, Node *_se) {
-
-	//ScriptEditorBase *se=Object::cast_to<ScriptEditorBase>(_se);
 
 	String val = debugger->get_var_value(p_text);
 	if (val != String()) {
@@ -551,8 +548,6 @@ void ScriptEditor::_close_tab(int p_idx, bool p_save) {
 			idx = history[history_pos].control->get_index();
 		}
 		tab_container->set_current_tab(idx);
-
-		//script_list->select(idx);
 	}
 
 	_update_history_arrows();
@@ -698,7 +693,6 @@ void ScriptEditor::_reload_scripts() {
 		uint64_t last_date = script->get_last_modified_time();
 		uint64_t date = FileAccess::get_modified_time(script->get_path());
 
-		//printf("last date: %lli vs date: %lli\n",last_date,date);
 		if (last_date == date) {
 			continue;
 		}
@@ -776,7 +770,6 @@ bool ScriptEditor::_test_script_times_on_disk(Ref<Script> p_for_script) {
 			uint64_t last_date = script->get_last_modified_time();
 			uint64_t date = FileAccess::get_modified_time(script->get_path());
 
-			//printf("last date: %lli vs date: %lli\n",last_date,date);
 			if (last_date != date) {
 
 				TreeItem *ti = disk_changed_list->create_item(r);
@@ -786,7 +779,6 @@ bool ScriptEditor::_test_script_times_on_disk(Ref<Script> p_for_script) {
 					need_ask = true;
 				}
 				need_reload = true;
-				//r->set_metadata(0,);
 			}
 		}
 	}
@@ -1205,9 +1197,6 @@ void ScriptEditor::_notification(int p_what) {
 			_update_modified_scripts_for_external_editor();
 		} break;
 
-		case NOTIFICATION_PROCESS: {
-		} break;
-
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 
 			help_search->set_icon(get_icon("HelpSearch", "EditorIcons"));
@@ -1367,18 +1356,9 @@ void ScriptEditor::ensure_select_current() {
 
 			if (!grab_focus_block && is_visible_in_tree())
 				se->ensure_focus();
-
-			//edit_menu->show();
-			//search_menu->show();
 		}
 
 		EditorHelp *eh = Object::cast_to<EditorHelp>(current);
-
-		if (eh) {
-			//edit_menu->hide();
-			//search_menu->hide();
-			//script_search_menu->show();
-		}
 	}
 
 	_update_selected_editor_menu();
@@ -1823,12 +1803,8 @@ void ScriptEditor::save_all_scripts() {
 		if (script.is_valid())
 			se->apply_code();
 
-		if (script->get_path() != "" && script->get_path().find("local://") == -1 && script->get_path().find("::") == -1) {
-			//external script, save it
-
-			editor->save_resource(script);
-			//ResourceSaver::save(script->get_path(),script);
-		}
+		if (script->get_path() != "" && script->get_path().find("local://") == -1 && script->get_path().find("::") == -1)
+			editor->save_resource(script); //external script, save it
 	}
 
 	_update_script_names();
@@ -1886,7 +1862,6 @@ void ScriptEditor::_editor_stop() {
 
 void ScriptEditor::_add_callback(Object *p_obj, const String &p_function, const PoolStringArray &p_args) {
 
-	//print_line("add callback! hohoho"); kinda sad to remove this
 	ERR_FAIL_COND(!p_obj);
 	Ref<Script> script = p_obj->get_script();
 	ERR_FAIL_COND(!script.is_valid());
@@ -1980,8 +1955,6 @@ void ScriptEditor::_script_split_dragged(float) {
 }
 
 Variant ScriptEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
-
-	// return Variant(); // return this if drag disabled
 
 	Node *cur_node = tab_container->get_child(tab_container->get_current_tab());
 
@@ -2202,9 +2175,6 @@ void ScriptEditor::_make_script_list_context_menu() {
 	}
 
 	EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_child(selected));
-	if (eh) {
-		// nothing
-	}
 
 	context_menu->add_separator();
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/window_move_up"), WINDOW_MOVE_UP);
@@ -2588,10 +2558,9 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 
 	script_list = memnew(ItemList);
 	list_split->add_child(script_list);
-	script_list->set_custom_minimum_size(Size2(150 * EDSCALE, 100)); //need to give a bit of limit to avoid it from disappearing
+	script_list->set_custom_minimum_size(Size2(150 * EDSCALE, 90)); //need to give a bit of limit to avoid it from disappearing
 	script_list->set_v_size_flags(SIZE_EXPAND_FILL);
 	script_split->set_split_offset(140);
-	//list_split->set_split_offset(500);
 	_sort_list_on_update = true;
 	script_list->connect("gui_input", this, "_script_list_gui_input");
 	script_list->set_allow_rmb_select(true);
@@ -2603,12 +2572,12 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 
 	members_overview = memnew(ItemList);
 	list_split->add_child(members_overview);
-	members_overview->set_custom_minimum_size(Size2(0, 100)); //need to give a bit of limit to avoid it from disappearing
+	members_overview->set_custom_minimum_size(Size2(0, 90)); //need to give a bit of limit to avoid it from disappearing
 	members_overview->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	help_overview = memnew(ItemList);
 	list_split->add_child(help_overview);
-	help_overview->set_custom_minimum_size(Size2(0, 100)); //need to give a bit of limit to avoid it from disappearing
+	help_overview->set_custom_minimum_size(Size2(0, 90)); //need to give a bit of limit to avoid it from disappearing
 	help_overview->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	tab_container = memnew(TabContainer);
@@ -2762,7 +2731,6 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	{
 		VBoxContainer *vbc = memnew(VBoxContainer);
 		disk_changed->add_child(vbc);
-		//disk_changed->set_child_rect(vbc);
 
 		Label *dl = memnew(Label);
 		dl->set_text(TTR("The following files are newer on disk.\nWhat action should be taken?:"));


### PR DESCRIPTION
- Made minimal size for the script list and member/help overview slightly smaller. Fixes https://github.com/godotengine/godot/issues/10875.
- Added minimal size for the EditorHelp, so it can no longer be resized into nothing.

Some things that should be reviewed carefully:

- Removed a lot of what seemed to be dead code, with the exception of the things related to the debugger menu, as it has some live code tied to it.
- Removed what appeared to be redundant code in the EditorHelp constructor. Correct me if it was necessary for some reason.