### PR TITLE
Fix installing export templates from file

### DIFF
--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -555,7 +555,7 @@ ExportTemplateManager::ExportTemplateManager() {
 	template_open->add_filter("*.tpz ; Godot Export Templates");
 	template_open->set_access(FileDialog::ACCESS_FILESYSTEM);
 	template_open->set_mode(FileDialog::MODE_OPEN_FILE);
-	template_open->connect("file_selected", this, "_install_from_file");
+	template_open->connect("file_selected", this, "_install_from_file", varray(true));
 	add_child(template_open);
 
 	set_title(TTR("Export Template Manager"));


### PR DESCRIPTION
3de20641f5690aba7551da5c592a79d44af54fef did break installing export templates from file, godot is giving this error message when I try to install export templates from file: ` core/object.cpp:1201 - Error calling method from signal 'file_selected': 'ExportTemplateManager::_install_from_file': Method expected 2 arguments, but called with 1.`

This patch is fixing this issue.