### PR TITLE
Add Script.get_base_script()/get_instance_base_type() to API

### DIFF
--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -54,6 +54,8 @@ void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_source_code"), &Script::get_source_code);
 	ClassDB::bind_method(D_METHOD("set_source_code", "source"), &Script::set_source_code);
 	ClassDB::bind_method(D_METHOD("reload", "keep_state"), &Script::reload, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_base_script"), &Script::get_base_script);
+	ClassDB::bind_method(D_METHOD("get_instance_base_type"), &Script::get_instance_base_type);
 
 	ClassDB::bind_method(D_METHOD("has_script_signal", "signal_name"), &Script::has_script_signal);
 


### PR DESCRIPTION
Tested this in my own project and it worked just fine.

    extends "res://uber_controlled_button.gd"
    
    func _ready():
        print(get_script().get_base_script().resource_path)

Prints:
res://uber_controlled_button.gd

When doing it from something that extends an in-engine type, it prints [Object:null] as expected.