### PR TITLE
Fix spatial editor plugin issues on multi viewport view menu shortcuts (only those that are bound to keys)

### DIFF
--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -273,8 +273,11 @@ private:
 	Transform to_camera_transform(const Cursor &p_cursor) const;
 	void _draw();
 
-	void _smouseenter();
-	void _smouseexit();
+	void _surface_mouse_enter();
+	void _surface_mouse_exit();
+	void _surface_focus_enter();
+	void _surface_focus_exit();
+
 	void _sinput(const Ref<InputEvent> &p_event);
 	void _update_freelook(real_t delta);
 	SpatialEditor *spatial_editor;

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -33,6 +33,9 @@
 
 void MenuButton::_unhandled_key_input(Ref<InputEvent> p_event) {
 
+	if (disable_shortcuts)
+		return;
+
 	if (p_event->is_pressed() && !p_event->is_echo() && (Object::cast_to<InputEventKey>(p_event.ptr()) || Object::cast_to<InputEventJoypadButton>(p_event.ptr()) || Object::cast_to<InputEventAction>(*p_event))) {
 
 		if (!get_parent() || !is_visible_in_tree() || is_disabled())
@@ -98,14 +101,22 @@ void MenuButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_unhandled_key_input"), &MenuButton::_unhandled_key_input);
 	ClassDB::bind_method(D_METHOD("_set_items"), &MenuButton::_set_items);
 	ClassDB::bind_method(D_METHOD("_get_items"), &MenuButton::_get_items);
+	ClassDB::bind_method(D_METHOD("set_disable_shortcuts", "disabled"), &MenuButton::set_disable_shortcuts);
 
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "items", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "_set_items", "_get_items");
 
 	ADD_SIGNAL(MethodInfo("about_to_show"));
 }
+
+void MenuButton::set_disable_shortcuts(bool p_disabled) {
+
+	disable_shortcuts = p_disabled;
+}
+
 MenuButton::MenuButton() {
 
 	set_flat(true);
+	set_disable_shortcuts(false);
 	set_enabled_focus_mode(FOCUS_NONE);
 	popup = memnew(PopupMenu);
 	popup->hide();

--- a/scene/gui/menu_button.h
+++ b/scene/gui/menu_button.h
@@ -40,6 +40,7 @@ class MenuButton : public Button {
 	GDCLASS(MenuButton, Button);
 
 	bool clicked;
+	bool disable_shortcuts;
 	PopupMenu *popup;
 	virtual void pressed();
 
@@ -54,6 +55,8 @@ protected:
 
 public:
 	PopupMenu *get_popup();
+	void set_disable_shortcuts(bool p_disabled);
+
 	MenuButton();
 	~MenuButton();
 };


### PR DESCRIPTION
These are proposed changes that closes #14371 and closes #12409

**Problem:**

All view menu items, that are also shortcuts activated by a Key, had issues with the viewport that was being updated...
In the case of multiple viewports, instead of the action to be applied to the viewport in focus, it was being applied always and only to the last viewport.

The affected key shortcuts were these ones:
- Top View
- Bottom View
- Left View
- Right View
- Front View
- Rear View
- Focus Origin
- Focus Selection
- Align Selection With View

Also, for the top/bottom/left/view/front/rear view shortcuts, there was duplicated code being ran, which caused updates to the focused viewport, and the last viewport.

**Proposed solution:**
- When a viewport looses focus, the view menu is hidden avoiding the menu action being called, when a key shortcut was used
- When a viewport gains focus, the view menu is set to visible -> either a click the menu item, or a key shortcut is used, the correct focused viewport will be updated, since it is the only viewport that has the view menu active, and so, it's the only menu/shortcut action that will trigger the event action
- All of those key shortcuts are now being handled by the `_sinput(...)` method, which call then the `_menu_option(...)` method, where the logic code related to the action is, in fact:
  - when shortcut is used -> `_sinput(...)`
  - when menu item is used -> `_menu_option(...)`

I've tested this fix with success... now the key shortcut actions listed above, updates only the focused viewport, as it should be.