### PR TITLE
Some Editor UI patchwork

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2613,8 +2613,8 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 
 	tab_container = memnew(TabContainer);
 	tab_container->set_tabs_visible(false);
+	tab_container->set_custom_minimum_size(Size2(200 * EDSCALE, 0));
 	script_split->add_child(tab_container);
-
 	tab_container->set_h_size_flags(SIZE_EXPAND_FILL);
 
 	ED_SHORTCUT("script_editor/window_sort", TTR("Sort"));

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1699,7 +1699,7 @@ void SceneTreeDock::_add_children_to_popup(Object *p_obj, int p_depth) {
 			icon = get_icon("Object", "EditorIcons");
 
 		if (menu->get_item_count() == 0) {
-			menu->add_submenu_item(TTR("Sub-Resources:"), "Sub-Resources");
+			menu->add_submenu_item(TTR("Sub-Resources"), "Sub-Resources");
 		}
 		int index = menu_subresources->get_item_count();
 		menu_subresources->add_icon_item(icon, E->get().name.capitalize(), EDIT_SUBRESOURCE_BASE + subresources.size());
@@ -1733,6 +1733,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 	if (selection.size() == 1) {
 
 		subresources.clear();
+		menu_subresources->clear();
 		_add_children_to_popup(selection.front()->get(), 0);
 		if (menu->get_item_count() > 0)
 			menu->add_separator();


### PR DESCRIPTION
Fixing some bugs I quickly squashed while having the time for it

- Fixes 2 issues with https://github.com/godotengine/godot/pull/14770: The submenu wasn't cleared when popping up and the label had an unnecessary semicolon
![animation](https://user-images.githubusercontent.com/9631152/34163583-5e9ffeb2-e4d7-11e7-89da-1cc541cca890.gif)
- Fixes https://github.com/godotengine/godot/issues/14812 code editor getting smaller than useful, limited to min. 200 pixels now (everything below squashes it to nonsense).
![animation](https://user-images.githubusercontent.com/9631152/34163622-85547e3e-e4d7-11e7-8eb1-1852874dfa64.gif)

Did you know the word "pitch" comes from patch + bitch? I guess I'm a pitch :(
