### PR TITLE
Fix pixel snap not being used in 3.0

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1784,6 +1784,8 @@ void RasterizerCanvasGLES3::initialize() {
 
 	state.canvas_shader.set_conditional(CanvasShaderGLES3::USE_RGBA_SHADOWS, storage->config.use_rgba_2d_shadows);
 	state.canvas_shadow_shader.set_conditional(CanvasShadowShaderGLES3::USE_RGBA_SHADOWS, storage->config.use_rgba_2d_shadows);
+
+	state.canvas_shader.set_conditional(CanvasShaderGLES3::USE_PIXEL_SNAP, GLOBAL_DEF("rendering/quality/2d/use_pixel_snap", false));
 }
 
 void RasterizerCanvasGLES3::finalize() {

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -171,7 +171,7 @@ VERTEX_SHADER_CODE
 
 #ifdef USE_PIXEL_SNAP
 
-	outvec.xy=floor(outvec+0.5);
+	outvec.xy=floor(outvec+0.5).xy;
 #endif
 
 


### PR DESCRIPTION
Fix #14644 and maybe this #13273, I don't tested the last one.
Apparently pixel snap was disabled in 3.0