### PR TITLE
Fix editor crash on "save and exit" bug

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1871,6 +1871,7 @@ void Main::cleanup() {
 	if (engine)
 		memdelete(engine);
 
+	message_queue->flush();
 	memdelete(message_queue);
 
 	unregister_core_driver_types();


### PR DESCRIPTION
If a scene is modified and a user closes the editor and selects the "Save
and exit" option in the modal dialog -- the editor crashes. This appears
to be a result of the message queue being memdeleted AFTER visual servers
have been destroyed. Remnant textures handled by the message queue throw a
NRE when their own ~Texture destructors reference the visual servers.

The proposed solution is to perform a flush on the message queue prior to any
memdeletions.

This fixes bugs: #12946 and #12813.