### PR TITLE
Fix crash on clicking classes/search or editor/project settings

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2377,11 +2377,7 @@ List<Control *>::Element *Viewport::_gui_show_modal(Control *p_control) {
 		mb->set_global_position(gui.mouse_focus->get_local_mouse_position());
 		mb->set_button_index(gui.mouse_focus_button);
 		mb->set_pressed(false);
-		gui.mouse_focus->call_multilevel(SceneStringNames::get_singleton()->_gui_input, mb);
-
-		//if (gui.mouse_over == gui.mouse_focus) {
-		//	gui.mouse_focus->notification(Control::NOTIFICATION_MOUSE_EXIT);
-		//}
+		gui.mouse_focus->call_deferred(SceneStringNames::get_singleton()->_gui_input, mb);
 		gui.mouse_focus = NULL;
 	}
 


### PR DESCRIPTION
As a result of a bugfix for menu items not releasing the "selected" state
after initial mouse clicks (#14854), the logic was inadvertently causing
gui mouse events to recurse infinitely as a result of a multi-level call.

The solution is to switch it to a deferred call for the mouse input.

This fixes #14886.