### PR TITLE
Add compatibility hacks for Adreno 3xx

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2692,7 +2692,7 @@ void RasterizerSceneGLES3::_setup_lights(RID *p_light_cull_result, int p_light_c
 
 	for (int i = 0; i < p_light_cull_count; i++) {
 
-		ERR_BREAK(i >= RenderList::MAX_LIGHTS);
+		ERR_BREAK(i >= render_list.max_lights);
 
 		LightInstance *li = light_instance_owner.getptr(p_light_cull_result[i]);
 
@@ -4804,6 +4804,8 @@ void RasterizerSceneGLES3::initialize() {
 	glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
 	render_list.max_elements = GLOBAL_DEF("rendering/limits/rendering/max_renderable_elements", (int)RenderList::DEFAULT_MAX_ELEMENTS);
+	render_list.max_lights = GLOBAL_DEF("rendering/limits/rendering/max_lights", (int)RenderList::DEFAULT_MAX_LIGHTS);
+	render_list.max_reflections = GLOBAL_DEF("rendering/limits/rendering/max_reflections", (int)RenderList::DEFAULT_MAX_REFLECTIONS);
 	if (render_list.max_elements > 1000000)
 		render_list.max_elements = 1000000;
 	if (render_list.max_elements < 1024)
@@ -4902,7 +4904,7 @@ void RasterizerSceneGLES3::initialize() {
 		glGetIntegerv(GL_MAX_UNIFORM_BLOCK_SIZE, &max_ubo_size);
 		const int ubo_light_size = 160;
 		state.ubo_light_size = ubo_light_size;
-		state.max_ubo_lights = MIN(RenderList::MAX_LIGHTS, max_ubo_size / ubo_light_size);
+		state.max_ubo_lights = MIN(render_list.max_lights, max_ubo_size / ubo_light_size);
 		print_line("GLES3: max ubo light: " + itos(state.max_ubo_lights));
 
 		state.spot_array_tmp = (uint8_t *)memalloc(ubo_light_size * state.max_ubo_lights);
@@ -4928,7 +4930,7 @@ void RasterizerSceneGLES3::initialize() {
 		state.scene_shader.add_custom_define("#define MAX_LIGHT_DATA_STRUCTS " + itos(state.max_ubo_lights) + "\n");
 		state.scene_shader.add_custom_define("#define MAX_FORWARD_LIGHTS " + itos(state.max_forward_lights_per_object) + "\n");
 
-		state.max_ubo_reflections = MIN(RenderList::MAX_REFLECTIONS, max_ubo_size / sizeof(ReflectionProbeDataUBO));
+		state.max_ubo_reflections = MIN(render_list.max_reflections, max_ubo_size / sizeof(ReflectionProbeDataUBO));
 		print_line("GLES3: max ubo reflections: " + itos(state.max_ubo_reflections) + ", ubo size: " + itos(sizeof(ReflectionProbeDataUBO)));
 
 		state.reflection_array_tmp = (uint8_t *)memalloc(sizeof(ReflectionProbeDataUBO) * state.max_ubo_reflections);

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -653,8 +653,8 @@ public:
 			SORT_FLAG_SKELETON = 1,
 			SORT_FLAG_INSTANCING = 2,
 			MAX_DIRECTIONAL_LIGHTS = 16,
-			MAX_LIGHTS = 4096,
-			MAX_REFLECTIONS = 1024,
+			DEFAULT_MAX_LIGHTS = 4096,
+			DEFAULT_MAX_REFLECTIONS = 1024,
 
 			SORT_KEY_PRIORITY_SHIFT = 56,
 			SORT_KEY_PRIORITY_MASK = 0xFF,
@@ -685,6 +685,8 @@ public:
 		};
 
 		int max_elements;
+		int max_lights;
+		int max_reflections;
 
 		struct Element {
 
@@ -797,6 +799,8 @@ public:
 		RenderList() {
 
 			max_elements = DEFAULT_MAX_ELEMENTS;
+			max_lights = DEFAULT_MAX_LIGHTS;
+			max_reflections = DEFAULT_MAX_REFLECTIONS;
 		}
 
 		~RenderList() {

--- a/drivers/gles3/shader_compiler_gles3.cpp
+++ b/drivers/gles3/shader_compiler_gles3.cpp
@@ -505,6 +505,11 @@ String ShaderCompilerGLES3::_dump_node_code(SL::Node *p_node, int p_level, Gener
 
 			if (p_default_actions.renames.has(vnode->name))
 				code = p_default_actions.renames[vnode->name];
+#ifdef ANDROID_ENABLED
+			else if (vnode->get_datatype() == ShaderLanguage::TYPE_BOOL)
+				// Hack for Adreno 3xx GPUs, see comments in ShaderGLES3::get_current_version
+				code = "UNWRAP_BOOL(" + _mkid(vnode->name) + ")";
+#endif
 			else
 				code = _mkid(vnode->name);
 

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -167,6 +167,25 @@ static void _display_error_with_code(const String &p_error, const Vector<const c
 	ERR_PRINTS(p_error);
 }
 
+static void _insert_shader_adreno_hacks(Vector<const char *> &p_strings) {
+	// Hacks for Adreno 3xx GPUs
+
+	// Hack 1 - sometimes shader compiler crashes when parsing code like `if (some_bool) { ... }`
+	// if `some_bool` was declared within `UniformData` struct
+	// Replacting `some_bool` with `int(some_bool) != 0` fixes the crash
+	p_strings.push_back("#define UNWRAP_BOOL(b) (int(b) != 0)\n");
+
+	// Hack 2 - compiler may hang on code with `pow` calls
+	// Seems like it's because shader compiler tries to inline `pow` but somehow fails
+	// Wrapping `pow` into another function forces the compiler never inline `pow`
+	p_strings.push_back("float pow_no_inline(float x, float y) {\n\treturn pow(x, y);\n}\n");
+	p_strings.push_back("vec2 pow_no_inline(vec2 x, vec2 y) {\n\treturn pow(x, y);\n}\n");
+	p_strings.push_back("vec3 pow_no_inline(vec3 x, vec3 y) {\n\treturn pow(x, y);\n}\n");
+	p_strings.push_back("vec4 pow_no_inline(vec4 x, vec4 y) {\n\treturn pow(x, y);\n}\n");
+	// According to GLES specification (paragraph 8.2) `pow` accepts float, vec2, vec3 and vec4 arguments
+	p_strings.push_back("#define pow(x, y) pow_no_inline(x, y)\n");
+}
+
 ShaderGLES3::Version *ShaderGLES3::get_current_version() {
 
 	Version *_v = version_map.getptr(conditional_version);
@@ -279,6 +298,10 @@ ShaderGLES3::Version *ShaderGLES3::get_current_version() {
 	strings.push_back("precision highp sampler2DArray;\n");
 #endif
 
+#ifdef ANDROID_ENABLED
+	_insert_shader_adreno_hacks(strings);
+#endif
+
 	strings.push_back(vertex_code0.get_data());
 
 	if (cc) {
@@ -365,6 +388,10 @@ ShaderGLES3::Version *ShaderGLES3::get_current_version() {
 	strings.push_back("precision highp sampler2D;\n");
 	strings.push_back("precision highp samplerCube;\n");
 	strings.push_back("precision highp sampler2DArray;\n");
+#endif
+
+#ifdef ANDROID_ENABLED
+	_insert_shader_adreno_hacks(strings);
 #endif
 
 	strings.push_back(fragment_code0.get_data());


### PR DESCRIPTION
As mentioned in many issues (https://github.com/godotengine/godot/issues/12816 https://github.com/godotengine/godot/issues/14771 https://github.com/godotengine/godot/issues/11693, maybe some more), Godot doesn't run on devices with Adreno 3xx GPU.
I tried to fix this... and found many strange bugs. For some of these bugs I wrote hacks and finally I managed to launch my game on ASUS Z010D (with Adreno 306). Also tested on Sony G8441 with Adreno 540, but the later one doesn't have any issues to begin with.
So, here is what I found out:
**Issue 1**
Shader compiler hangs on compilation of `pow` function (yes, I'm 100% sure, I checked, double-checked and triple-checked this). That's mostly why 3D scenes hang. My guess, the compiler tries to inline `pow`, but something goes wrong and it fails. Surprising fix for this bug is to make a custom function which calls `pow` and call that function instead. Pretty much, like this:
```
float pow_no_inline(float x, float y) {
	return pow(x, y);
}
#define pow(x, y) pow_no_inline(x, y)
```

**Issue 2**
Now shaders compile, but it takes ~3.5 sec to compile one shader. Woops.
And that's because of `OmniLightData`, `SpotLightData` amd `ReflectionProbeData` structures. They contain arrays with length of max possible count of lights/reflections and that's about 400 for Adreno 306. Probably, compiler tries to unfold `for` cycles with hypothetically 400+ iterations and it takes quite a lot of time. After setting max lights and max reflections to smaller value, shader compiler starts working really fast.
In the PR I just moved `max_lights` and `max_reflections` to the project settings.


**Issue 3**
Next bug I found was crashing on shader compilation. For example, this shader produces 100% crash:
```
shader_type canvas_item;

uniform sampler2D mask_texture: hint_white;
uniform bool grayscale;

void fragment() {
	vec4 tex_color = texture(TEXTURE, UV);
	COLOR = vec4(tex_color.rgb, texture(mask_texture, UV).r * tex_color.a);
	
	if (grayscale)
	{
		COLOR.rgb = vec3(dot(COLOR.rgb, vec3(0.3, 0.59, 0.11)));
	}
	
}
```
And the line that actually causes crash is `if (grayscale)`.
Adreno 306 doesn't like uniform bool variables. Strangely enough it only happens to variables from the user code. And simply replacing condition with `if (int(grayscale) != 0)` eliminates the crash.
My final solution is to wrap all user-defined boolean variables into a macro defined like this:
```
#define UNWRAP_BOOL(b) (int(b) != 0)
```
And no more crash with this.

**Now the issues I found, but didn't solve:**
**Issue 4**
Vertex lighting doesn't work. Meshes are rendered distorted or not rendered at all. No errors in logcat. I don't use vertex lighting in my project, so I didn't research, why this happens and how to fix it.
I found out that after commenting out this line:
https://github.com/godotengine/godot/blob/1fa9aac3e415f53a095e955c8a37000629d56dde/drivers/gles3/shaders/scene.glsl#L171
meshes are rendered normally (but unlit) and that's where I stopped.

**Issue 5**
Using `SCREEN_TEXTURE` in the shader leads to a 100% GPU deadlock. The logcat message is like this:
`<gsl_ldd_control:427>: ioctl fd XX code 0x400c0907 (IOCTL_KGSL_DEVICE_WAITTIMESTAMP_CTXTID) failed: errno 35 Resource deadlock would occur`
I don't have a fix for this one too.
Looks like deadlock occur on calls of `scene_render->state.effect_blur_shader.bind();` in `RasterizerCanvasGLES3::_copy_texscreen`. At least, no deadlock after commenting out these calls.

**Issue 6**
Showing over 3D scene some UI with `ViewportContainer` (which contains another 3D scene) screws up the render of the main 3D scene. Even after deleting `ViewportContainer`, the main scene doesn't recover. Scene inside container is rendered just fine.
No fix for this, ~but I'm still working on it, maybe I can find one.~ UPD: won't fix this bug, screw it.

That's all I found so far.
TL;DR:
1. You can launch on Adreno 3xx now
2. Do not use vertex lighting
3. Do not use SCREEN_TEXTURE
4. Do not use ViewportContainer
5. Or better wait for GLES 2.0 renderer
5. F.. you, Qualcomm