### PR TITLE
Added RigidBody functionality to VehicleBody

### DIFF
--- a/scene/3d/physics_body.h
+++ b/scene/3d/physics_body.h
@@ -114,7 +114,7 @@ public:
 		MODE_KINEMATIC,
 	};
 
-private:
+protected:
 	bool can_sleep;
 	PhysicsDirectBodyState *state;
 	Mode mode;
@@ -177,9 +177,8 @@ private:
 	void _body_exit_tree(ObjectID p_id);
 
 	void _body_inout(int p_status, ObjectID p_instance, int p_body_shape, int p_local_shape);
-	void _direct_state_changed(Object *p_state);
+	virtual void _direct_state_changed(Object *p_state);
 
-protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 

--- a/scene/3d/vehicle_body.cpp
+++ b/scene/3d/vehicle_body.cpp
@@ -374,7 +374,7 @@ void VehicleBody::_update_wheel(int p_idx, PhysicsDirectBodyState *s) {
 
 	Basis steeringMat(up, steering);
 
-	Basis rotatingMat(right, -wheel.m_rotation);
+	Basis rotatingMat(right, wheel.m_rotation);
 
 	/*
 	if (p_idx==1)
@@ -815,26 +815,24 @@ void VehicleBody::_update_friction(PhysicsDirectBodyState *s) {
 
 void VehicleBody::_direct_state_changed(Object *p_state) {
 
-	PhysicsDirectBodyState *s = Object::cast_to<PhysicsDirectBodyState>(p_state);
+	RigidBody::_direct_state_changed(p_state);
 
-	set_ignore_transform_notification(true);
-	set_global_transform(s->get_transform());
-	set_ignore_transform_notification(false);
+	state = Object::cast_to<PhysicsDirectBodyState>(p_state);
 
-	float step = s->get_step();
+	float step = state->get_step();
 
 	for (int i = 0; i < wheels.size(); i++) {
 
-		_update_wheel(i, s);
+		_update_wheel(i, state);
 	}
 
 	for (int i = 0; i < wheels.size(); i++) {
 
-		_ray_cast(i, s);
-		wheels[i]->set_transform(s->get_transform().inverse() * wheels[i]->m_worldTransform);
+		_ray_cast(i, state);
+		wheels[i]->set_transform(state->get_transform().inverse() * wheels[i]->m_worldTransform);
 	}
 
-	_update_suspension(s);
+	_update_suspension(state);
 
 	for (int i = 0; i < wheels.size(); i++) {
 
@@ -847,21 +845,21 @@ void VehicleBody::_direct_state_changed(Object *p_state) {
 			suspensionForce = wheel.m_maxSuspensionForce;
 		}
 		Vector3 impulse = wheel.m_raycastInfo.m_contactNormalWS * suspensionForce * step;
-		Vector3 relpos = wheel.m_raycastInfo.m_contactPointWS - s->get_transform().origin;
+		Vector3 relpos = wheel.m_raycastInfo.m_contactPointWS - state->get_transform().origin;
 
-		s->apply_impulse(relpos, impulse);
+		state->apply_impulse(relpos, impulse);
 		//getRigidBody()->applyImpulse(impulse, relpos);
 	}
 
-	_update_friction(s);
+	_update_friction(state);
 
 	for (int i = 0; i < wheels.size(); i++) {
 		VehicleWheel &wheel = *wheels[i];
-		Vector3 relpos = wheel.m_raycastInfo.m_hardPointWS - s->get_transform().origin;
-		Vector3 vel = s->get_linear_velocity() + (s->get_angular_velocity()).cross(relpos); // * mPos);
+		Vector3 relpos = wheel.m_raycastInfo.m_hardPointWS - state->get_transform().origin;
+		Vector3 vel = state->get_linear_velocity() + (state->get_angular_velocity()).cross(relpos); // * mPos);
 
 		if (wheel.m_raycastInfo.m_isInContact) {
-			const Transform &chassisWorldTransform = s->get_transform();
+			const Transform &chassisWorldTransform = state->get_transform();
 
 			Vector3 fwd(
 					chassisWorldTransform.basis[0][Vector3::AXIS_Z],
@@ -882,29 +880,8 @@ void VehicleBody::_direct_state_changed(Object *p_state) {
 
 		wheel.m_deltaRotation *= real_t(0.99); //damping of rotation when not in contact
 	}
-	linear_velocity = s->get_linear_velocity();
-}
 
-void VehicleBody::set_mass(real_t p_mass) {
-
-	mass = p_mass;
-	PhysicsServer::get_singleton()->body_set_param(get_rid(), PhysicsServer::BODY_PARAM_MASS, mass);
-}
-
-real_t VehicleBody::get_mass() const {
-
-	return mass;
-}
-
-void VehicleBody::set_friction(real_t p_friction) {
-
-	friction = p_friction;
-	PhysicsServer::get_singleton()->body_set_param(get_rid(), PhysicsServer::BODY_PARAM_FRICTION, friction);
-}
-
-real_t VehicleBody::get_friction() const {
-
-	return friction;
+	state = NULL;
 }
 
 void VehicleBody::set_engine_force(float p_engine_force) {
@@ -935,17 +912,7 @@ float VehicleBody::get_steering() const {
 	return m_steeringValue;
 }
 
-Vector3 VehicleBody::get_linear_velocity() const {
-	return linear_velocity;
-}
-
 void VehicleBody::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("set_mass", "mass"), &VehicleBody::set_mass);
-	ClassDB::bind_method(D_METHOD("get_mass"), &VehicleBody::get_mass);
-
-	ClassDB::bind_method(D_METHOD("set_friction", "friction"), &VehicleBody::set_friction);
-	ClassDB::bind_method(D_METHOD("get_friction"), &VehicleBody::get_friction);
 
 	ClassDB::bind_method(D_METHOD("set_engine_force", "engine_force"), &VehicleBody::set_engine_force);
 	ClassDB::bind_method(D_METHOD("get_engine_force"), &VehicleBody::get_engine_force);
@@ -956,21 +923,14 @@ void VehicleBody::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_steering", "steering"), &VehicleBody::set_steering);
 	ClassDB::bind_method(D_METHOD("get_steering"), &VehicleBody::get_steering);
 
-	ClassDB::bind_method(D_METHOD("get_linear_velocity"), &VehicleBody::get_linear_velocity);
-
-	ClassDB::bind_method(D_METHOD("_direct_state_changed"), &VehicleBody::_direct_state_changed);
-
 	ADD_GROUP("Motion", "");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "engine_force", PROPERTY_HINT_RANGE, "0.00,1024.0,0.01"), "set_engine_force", "get_engine_force");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "brake", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), "set_brake", "get_brake");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "steering", PROPERTY_HINT_RANGE, "-180,180.0,0.01"), "set_steering", "get_steering");
-	ADD_GROUP("Mass", "");
-	ADD_PROPERTY(PropertyInfo(Variant::REAL, "mass", PROPERTY_HINT_RANGE, "0.01,65536,0.01"), "set_mass", "get_mass");
-	ADD_PROPERTY(PropertyInfo(Variant::REAL, "friction", PROPERTY_HINT_RANGE, "0.01,1,0.01"), "set_friction", "get_friction");
 }
 
 VehicleBody::VehicleBody() :
-		PhysicsBody(PhysicsServer::BODY_MODE_RIGID) {
+		RigidBody() {
 
 	m_pitchControl = 0;
 	m_currentVehicleSpeedKmHour = real_t(0.);
@@ -981,10 +941,11 @@ VehicleBody::VehicleBody() :
 
 	friction = 1;
 
+	state = NULL;
 	ccd = false;
 
 	exclude.insert(get_rid());
-	PhysicsServer::get_singleton()->body_set_force_integration_callback(get_rid(), this, "_direct_state_changed");
+	//PhysicsServer::get_singleton()->body_set_force_integration_callback(get_rid(), this, "_direct_state_changed");
 
 	set_mass(40);
 }

--- a/scene/3d/vehicle_body.h
+++ b/scene/3d/vehicle_body.h
@@ -138,19 +138,12 @@ public:
 	VehicleWheel();
 };
 
-class VehicleBody : public PhysicsBody {
+class VehicleBody : public RigidBody {
 
-	GDCLASS(VehicleBody, PhysicsBody);
-
-	real_t mass;
-	real_t friction;
+	GDCLASS(VehicleBody, RigidBody);
 
 	float engine_force;
 	float brake;
-
-	Vector3 linear_velocity;
-	Vector3 angular_velocity;
-	bool ccd;
 
 	real_t m_pitchControl;
 	real_t m_steeringValue;
@@ -191,12 +184,6 @@ class VehicleBody : public PhysicsBody {
 	void _direct_state_changed(Object *p_state);
 
 public:
-	void set_mass(real_t p_mass);
-	real_t get_mass() const;
-
-	void set_friction(real_t p_friction);
-	real_t get_friction() const;
-
 	void set_engine_force(float p_engine_force);
 	float get_engine_force() const;
 
@@ -205,8 +192,6 @@ public:
 
 	void set_steering(float p_steering);
 	float get_steering() const;
-
-	Vector3 get_linear_velocity() const;
 
 	VehicleBody();
 };


### PR DESCRIPTION
Ahoy!
Made VehicleBody inherit from RigidBody instead of PhysicsBody, so that methods like apply_impulse and _integrate_forces are properly exposed.

I Tested it quite a bit and i havent found any bugs/unexpected behaviour.
The changes should probably still be looked over since i have'nt worked with this part of the engine before.

fixes #13405, fixes #12694, fixes #10663
  