### PR TITLE
Fix crash on startup when external editor cannot be found.

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -520,6 +520,8 @@ void ScriptEditor::_update_modified_scripts_for_external_editor(Ref<Script> p_fo
 	if (!bool(EditorSettings::get_singleton()->get("external_editor/use_external_editor")))
 		return;
 
+	ERR_FAIL_COND(!get_tree());
+
 	Set<Ref<Script> > scripts;
 
 	Node *base = get_tree()->get_edited_scene_root();


### PR DESCRIPTION
Fixes #10965
Is already fixed for 6687484958412ff0f3bd6d97cbc1fcebc7ae64d2