### PR TITLE
Fixed right dock dragger not disappearing when there is no docks there

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3805,7 +3805,11 @@ void EditorNode::_update_dock_slots_visibility() {
 			}
 		}
 		bottom_panel->show();
-		right_hsplit->show();
+
+		if (right_l_vsplit->is_visible() || right_r_vsplit->is_visible())
+			right_hsplit->show();
+		else
+			right_hsplit->hide();
 	}
 }
 


### PR DESCRIPTION
Fixes #14849

**EDIT:** Made a mistake and closed it, and now I learned that a force-push makes you unable to reopen it, good to know.