### PR TITLE
Set particles emitting to false when particles finish emitting with one-shot enabled

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -5334,6 +5334,14 @@ void RasterizerStorageGLES3::particles_set_emitting(RID p_particles, bool p_emit
 	}
 	particles->emitting = p_emitting;
 }
+
+bool RasterizerStorageGLES3::particles_get_emitting(RID p_particles) {
+	Particles *particles = particles_owner.getornull(p_particles);
+	ERR_FAIL_COND_V(!particles, false);
+
+	return particles->emitting;
+}
+
 void RasterizerStorageGLES3::particles_set_amount(RID p_particles, int p_amount) {
 
 	Particles *particles = particles_owner.getornull(p_particles);

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1206,6 +1206,7 @@ public:
 	virtual RID particles_create();
 
 	virtual void particles_set_emitting(RID p_particles, bool p_emitting);
+	virtual bool particles_get_emitting(RID p_particles);
 	virtual void particles_set_amount(RID p_particles, int p_amount);
 	virtual void particles_set_lifetime(RID p_particles, float p_lifetime);
 	virtual void particles_set_one_shot(RID p_particles, bool p_one_shot);

--- a/scene/2d/particles_2d.cpp
+++ b/scene/2d/particles_2d.cpp
@@ -35,8 +35,7 @@
 
 void Particles2D::set_emitting(bool p_emitting) {
 
-	emitting = p_emitting;
-	VS::get_singleton()->particles_set_emitting(particles, emitting);
+	VS::get_singleton()->particles_set_emitting(particles, p_emitting);
 }
 
 void Particles2D::set_amount(int p_amount) {
@@ -56,7 +55,7 @@ void Particles2D::set_one_shot(bool p_enable) {
 
 	one_shot = p_enable;
 	VS::get_singleton()->particles_set_one_shot(particles, one_shot);
-	if (!one_shot && emitting)
+	if (!one_shot && is_emitting())
 		VisualServer::get_singleton()->particles_restart(particles);
 }
 void Particles2D::set_pre_process_time(float p_time) {
@@ -134,7 +133,7 @@ void Particles2D::set_speed_scale(float p_scale) {
 
 bool Particles2D::is_emitting() const {
 
-	return emitting;
+	return VS::get_singleton()->particles_get_emitting(particles);
 }
 int Particles2D::get_amount() const {
 

--- a/scene/2d/particles_2d.h
+++ b/scene/2d/particles_2d.h
@@ -47,7 +47,6 @@ public:
 private:
 	RID particles;
 
-	bool emitting;
 	bool one_shot;
 	int amount;
 	float lifetime;

--- a/scene/3d/particles.cpp
+++ b/scene/3d/particles.cpp
@@ -42,8 +42,7 @@ PoolVector<Face3> Particles::get_faces(uint32_t p_usage_flags) const {
 
 void Particles::set_emitting(bool p_emitting) {
 
-	emitting = p_emitting;
-	VS::get_singleton()->particles_set_emitting(particles, emitting);
+	VS::get_singleton()->particles_set_emitting(particles, p_emitting);
 }
 
 void Particles::set_amount(int p_amount) {
@@ -63,7 +62,7 @@ void Particles::set_one_shot(bool p_one_shot) {
 
 	one_shot = p_one_shot;
 	VS::get_singleton()->particles_set_one_shot(particles, one_shot);
-	if (!one_shot && emitting)
+	if (!one_shot && is_emitting())
 		VisualServer::get_singleton()->particles_restart(particles);
 }
 
@@ -113,7 +112,7 @@ void Particles::set_speed_scale(float p_scale) {
 
 bool Particles::is_emitting() const {
 
-	return emitting;
+	return VS::get_singleton()->particles_get_emitting(particles);
 }
 int Particles::get_amount() const {
 

--- a/scene/3d/particles.h
+++ b/scene/3d/particles.h
@@ -57,7 +57,6 @@ public:
 private:
 	RID particles;
 
-	bool emitting;
 	bool one_shot;
 	int amount;
 	float lifetime;

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -473,6 +473,8 @@ public:
 	virtual RID particles_create() = 0;
 
 	virtual void particles_set_emitting(RID p_particles, bool p_emitting) = 0;
+	virtual bool particles_get_emitting(RID p_particles) = 0;
+
 	virtual void particles_set_amount(RID p_particles, int p_amount) = 0;
 	virtual void particles_set_lifetime(RID p_particles, float p_lifetime) = 0;
 	virtual void particles_set_one_shot(RID p_particles, bool p_one_shot) = 0;

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -384,6 +384,7 @@ public:
 	BIND0R(RID, particles_create)
 
 	BIND2(particles_set_emitting, RID, bool)
+	BIND1R(bool, particles_get_emitting, RID)
 	BIND2(particles_set_amount, RID, int)
 	BIND2(particles_set_lifetime, RID, float)
 	BIND2(particles_set_one_shot, RID, bool)

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -317,6 +317,7 @@ public:
 	FUNCRID(particles)
 
 	FUNC2(particles_set_emitting, RID, bool)
+	FUNC1R(bool, particles_get_emitting, RID)
 	FUNC2(particles_set_amount, RID, int)
 	FUNC2(particles_set_lifetime, RID, float)
 	FUNC2(particles_set_one_shot, RID, bool)

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -504,6 +504,7 @@ public:
 	virtual RID particles_create() = 0;
 
 	virtual void particles_set_emitting(RID p_particles, bool p_emitting) = 0;
+	virtual bool particles_get_emitting(RID p_particles) = 0;
 	virtual void particles_set_amount(RID p_particles, int p_amount) = 0;
 	virtual void particles_set_lifetime(RID p_particles, float p_lifetime) = 0;
 	virtual void particles_set_one_shot(RID p_particles, bool p_one_shot) = 0;


### PR DESCRIPTION
Particles nodes couldn't know if they were emitting or not https://github.com/godotengine/godot/issues/12218

With this change, whenever the user checks `emitting` on the node it will query the visual server to get if the emitter is emitting or not.

I've removed the internal `emitting` variables from `scene/2d/particles_2d` and `scene/3d/particles` because they use the visual server to know the state of it.

Fixes https://github.com/godotengine/godot/issues/12218