### PR TITLE
Show Options Dialog for NodePath and File in clicked button position.

### DIFF
--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -1764,24 +1764,40 @@ void CustomPropertyEditor::_focus_exit() {
 
 void CustomPropertyEditor::config_action_buttons(const List<String> &p_strings) {
 
-	int cell_width = 60;
-	int cell_height = 25;
-	int cell_margin = 5;
+	Ref<StyleBox> sb = get_stylebox("panel");
+	int margin_top = sb->get_margin(MARGIN_TOP);
+	int margin_left = sb->get_margin(MARGIN_LEFT);
+	int margin_bottom = sb->get_margin(MARGIN_BOTTOM);
+	int margin_right = sb->get_margin(MARGIN_RIGHT);
 
-	set_size(Size2(cell_margin + (cell_width + cell_margin) * p_strings.size(), (cell_margin * 2) + cell_height) * EDSCALE);
+	int max_width = 0;
+	int height = 0;
 
 	for (int i = 0; i < MAX_ACTION_BUTTONS; i++) {
 
 		if (i < p_strings.size()) {
+
 			action_buttons[i]->show();
 			action_buttons[i]->set_text(p_strings[i]);
-			action_buttons[i]->set_position(Point2(cell_margin + (cell_width + cell_margin) * i, cell_margin) * EDSCALE);
-			action_buttons[i]->set_size(Size2(cell_width, cell_height - cell_margin * 2) * EDSCALE);
-			action_buttons[i]->set_flat(true);
+
+			Size2 btn_m_size = action_buttons[i]->get_minimum_size();
+			if (btn_m_size.width > max_width)
+				max_width = btn_m_size.width;
+
 		} else {
 			action_buttons[i]->hide();
 		}
 	}
+
+	for (int i = 0; i < p_strings.size(); i++) {
+
+		Size2 btn_m_size = action_buttons[i]->get_size();
+		action_buttons[i]->set_position(Point2(0, height) + Point2(margin_left, margin_top));
+		action_buttons[i]->set_size(Size2(max_width, btn_m_size.height));
+
+		height += btn_m_size.height;
+	}
+	set_size(Size2(max_width, height) + Size2(margin_left + margin_right, margin_top + margin_bottom));
 }
 
 void CustomPropertyEditor::config_value_editors(int p_amount, int p_columns, int p_label_w, const List<String> &p_strings) {
@@ -1902,6 +1918,7 @@ CustomPropertyEditor::CustomPropertyEditor() {
 		Vector<Variant> binds;
 		binds.push_back(i);
 		action_buttons[i]->connect("pressed", this, "_action_pressed", binds);
+		action_buttons[i]->set_flat(true);
 	}
 
 	color_picker = NULL;
@@ -3956,11 +3973,13 @@ void PropertyEditor::_edit_button(Object *p_item, int p_column, int p_button) {
 		if (t == Variant::NODE_PATH) {
 
 			Variant v = obj->get(n);
-			custom_editor->edit(obj, n, (Variant::Type)t, v, h, ht);
 			Rect2 where = tree->get_item_rect(ti, 1);
 			where.position -= tree->get_scroll();
-			where.position += tree->get_global_position();
+			where.position += tree->get_global_position() + Point2(where.size.width, 0);
+			for (int i = ti->get_button_count(p_column) - 1; i >= p_button; i--)
+				where.position.x -= ti->get_button(p_column, i)->get_width();
 			custom_editor->set_position(where.position);
+			custom_editor->edit(obj, n, (Variant::Type)t, v, h, ht);
 			custom_editor->popup();
 
 		} else if (t == Variant::STRING) {
@@ -3971,7 +3990,9 @@ void PropertyEditor::_edit_button(Object *p_item, int p_column, int p_button) {
 
 				Rect2 where = tree->get_item_rect(ti, 1);
 				where.position -= tree->get_scroll();
-				where.position += tree->get_global_position();
+				where.position += tree->get_global_position() + Point2(where.size.width, 0);
+				for (int i = ti->get_button_count(p_column) - 1; i >= p_button; i--)
+					where.position.x -= ti->get_button(p_column, i)->get_width();
 				custom_editor->set_position(where.position);
 				custom_editor->popup();
 			} else {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1360,6 +1360,7 @@ void SceneTreeDock::_create() {
 		editor_data->get_undo_redo().commit_action();
 		editor->push_item(c);
 		editor_selection->clear();
+		editor_selection->add_node(child);
 		if (Object::cast_to<Control>(c)) {
 			//make editor more comfortable, so some controls don't appear super shrunk
 			Control *ct = Object::cast_to<Control>(c);

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -56,13 +56,14 @@ private:
 	float _internal_margin[4];
 
 protected:
-	virtual Size2 get_minimum_size() const;
 	void _set_internal_margin(Margin p_margin, float p_value);
 	void _notification(int p_what);
 	static void _bind_methods();
 
 public:
 	//
+
+	virtual Size2 get_minimum_size() const;
 
 	void set_text(const String &p_text);
 	String get_text() const;


### PR DESCRIPTION
Auto select newly created nodes.


Now you can easily click the options without having to move the mouse too much.
Also autoselect the new created node, this is very useful for inserting more nodes or move nodes after their creating, currently you need to create then select the node just to move it.


this:
![screenshot from 2017-12-23 14-38-56](https://user-images.githubusercontent.com/1103897/34322613-a335201c-e7f1-11e7-8635-bfa0ef957af9.png)

instead of this
![screenshot from 2017-12-23 14-58-22](https://user-images.githubusercontent.com/1103897/34322619-d72993b2-e7f1-11e7-9739-020d3b5f8a4b.png)

or worse this.

![screenshot from 2017-12-23 14-58-45](https://user-images.githubusercontent.com/1103897/34322620-dd34d410-e7f1-11e7-8a8e-356a2f8414a3.png)
