### PR TITLE
X11: Fixes maximized splash-boot screen bug.

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -1050,6 +1050,10 @@ void OS_X11::set_window_maximized(bool p_enabled) {
 
 	XSendEvent(x11_display, DefaultRootWindow(x11_display), False, SubstructureRedirectMask | SubstructureNotifyMask, &xev);
 
+	while (p_enabled && !is_window_maximized()) {
+		// Wait for effective resizing (so the GLX context is too).
+	}
+
 	maximized = p_enabled;
 }
 


### PR DESCRIPTION
We need to wait the GLX Context to be resized before beginning to render with it.

![godotfix14336](https://user-images.githubusercontent.com/32960642/34323370-598c7d34-e846-11e7-9f9c-8ff784df0b36.jpg)


Fixes #14336 