### PR TITLE
Animation Tree: Prevent cycle_test from being altered by past-test.

### DIFF
--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -1140,6 +1140,9 @@ void AnimationTreePlayer::transition_node_set_input_count(const StringName &p_no
 
 	n->inputs.resize(p_inputs);
 	n->input_data.resize(p_inputs);
+
+	_clear_cycle_test();
+
 	last_error = _cycle_test(out_name);
 }
 void AnimationTreePlayer::transition_node_set_input_auto_advance(const StringName &p_node, int p_input, bool p_auto_advance) {
@@ -1360,6 +1363,8 @@ void AnimationTreePlayer::remove_node(const StringName &p_node) {
 
 	node_map.erase(p_node);
 
+	_clear_cycle_test();
+
 	// compute last error again, just in case
 	last_error = _cycle_test(out_name);
 	dirty_caches = true;
@@ -1387,6 +1392,14 @@ AnimationTreePlayer::ConnectError AnimationTreePlayer::_cycle_test(const StringN
 	return CONNECT_OK;
 }
 
+// Use this function to not alter next complete _cycle_test().
+void AnimationTreePlayer::_clear_cycle_test() {
+	for (Map<StringName, NodeBase *>::Element *E = node_map.front(); E; E = E->next()) {
+		NodeBase *nb = E->get();
+		nb->cycletest = false;
+	}
+}
+
 Error AnimationTreePlayer::connect_nodes(const StringName &p_src_node, const StringName &p_dst_node, int p_dst_input) {
 
 	ERR_FAIL_COND_V(!node_map.has(p_src_node), ERR_INVALID_PARAMETER);
@@ -1411,11 +1424,7 @@ Error AnimationTreePlayer::connect_nodes(const StringName &p_src_node, const Str
 
 	dst->inputs[p_dst_input].node = p_src_node;
 
-	for (Map<StringName, NodeBase *>::Element *E = node_map.front(); E; E = E->next()) {
-
-		NodeBase *nb = E->get();
-		nb->cycletest = false;
-	}
+	_clear_cycle_test();
 
 	last_error = _cycle_test(out_name);
 	if (last_error) {

--- a/scene/animation/animation_tree_player.h
+++ b/scene/animation/animation_tree_player.h
@@ -317,6 +317,7 @@ private:
 	bool reset_request;
 
 	ConnectError _cycle_test(const StringName &p_at_node);
+	void _clear_cycle_test();
 
 	Track *_find_track(const NodePath &p_path);
 	void _recompute_caches();


### PR DESCRIPTION
`_cycle_test()` were altered because we set NodeBase's `cycletest` on **true** without ever bringing them back to **false**.

Fixes #15000.