### PR TITLE
Add option to sign UWP exports with signtool

### DIFF
--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -1041,6 +1041,10 @@ public:
 		r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "identity/product_guid"), "00000000-0000-0000-0000-000000000000"));
 		r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "identity/publisher_guid"), "00000000-0000-0000-0000-000000000000"));
 
+		r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "signing/certificate", PROPERTY_HINT_GLOBAL_FILE, "*.pfx"), ""));
+		r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "signing/password"), ""));
+		r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "signing/algorithm", PROPERTY_HINT_ENUM, "MD5,SHA1,SHA256"), 2));
+
 		r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "version/major"), 1));
 		r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "version/minor"), 0));
 		r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "version/build"), 0));
@@ -1370,6 +1374,58 @@ public:
 
 		packager.finish();
 
+#ifdef WINDOWS_ENABLED
+		// Sign with signtool
+		String signtool_path = EditorSettings::get_singleton()->get("export/uwp/signtool");
+		if (signtool_path == String()) {
+			return OK;
+		}
+
+		if (!FileAccess::exists(signtool_path)) {
+			ERR_PRINTS("Could not find signtool executable at " + signtool_path + ", aborting.");
+			return ERR_FILE_NOT_FOUND;
+		}
+
+		static String algs[] = { "MD5", "SHA1", "SHA256" };
+
+		String cert_path = EditorSettings::get_singleton()->get("export/uwp/debug_certificate");
+		String cert_pass = EditorSettings::get_singleton()->get("export/uwp/debug_password");
+		int cert_alg = EditorSettings::get_singleton()->get("export/uwp/debug_algorithm");
+
+		if (!p_debug) {
+			cert_path = p_preset->get("signing/certificate");
+			cert_pass = p_preset->get("signing/password");
+			cert_alg = p_preset->get("signing/algorithm");
+		}
+
+		if (cert_path == String()) {
+			return OK; // Certificate missing, don't try to sign
+		}
+
+		if (!FileAccess::exists(cert_path)) {
+			ERR_PRINTS("Could not find certificate file at " + cert_path + ", aborting.");
+			return ERR_FILE_NOT_FOUND;
+		}
+
+		if (cert_alg < 0 || cert_alg > 2) {
+			ERR_PRINTS("Invalid certificate algorithm " + itos(cert_alg) + ", aborting.");
+			return ERR_INVALID_DATA;
+		}
+
+		List<String> args;
+		args.push_back("sign");
+		args.push_back("/fd");
+		args.push_back(algs[cert_alg]);
+		args.push_back("/a");
+		args.push_back("/f");
+		args.push_back(cert_path);
+		args.push_back("/p");
+		args.push_back(cert_pass);
+		args.push_back(p_path);
+
+		OS::get_singleton()->execute(signtool_path, args, true);
+#endif // WINDOWS_ENABLED
+
 		return OK;
 	}
 
@@ -1387,6 +1443,18 @@ public:
 };
 
 void register_uwp_exporter() {
-	Ref<EditorExportUWP> exporter = Ref<EditorExportUWP>(memnew(EditorExportUWP));
+
+#ifdef WINDOWS_ENABLED
+	EDITOR_DEF("export/uwp/signtool", "");
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/uwp/signtool", PROPERTY_HINT_GLOBAL_FILE, "*.exe"));
+	EDITOR_DEF("export/uwp/debug_certificate", "");
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/uwp/debug_certificate", PROPERTY_HINT_GLOBAL_FILE, "*.pfx"));
+	EDITOR_DEF("export/uwp/debug_password", "");
+	EDITOR_DEF("export/uwp/debug_algorithm", 2); // SHA256 is the default
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "export/uwp/debug_algorithm", PROPERTY_HINT_ENUM, "MD5,SHA1,SHA256"));
+#endif // WINDOWS_ENABLED
+
+	Ref<EditorExportUWP> exporter;
+	exporter.instance();
 	EditorExport::get_singleton()->add_export_platform(exporter);
 }


### PR DESCRIPTION
This options is Windows only, because SignTool isn't available on other platforms IINM.