### PR TITLE
Use .ttf or .otf file for editor custom font

### DIFF
--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -77,12 +77,27 @@ static Ref<BitmapFont> make_font(int p_height, int p_ascent, int p_valign, int p
 	Ref<DynamicFont> m_name;                                    \
 	m_name.instance();                                          \
 	m_name->set_size(m_size);                                   \
-	m_name->set_font_data(DefaultFont);                         \
+	if (CustomFont.is_valid()) {                                \
+		m_name->set_font_data(CustomFont);                      \
+		m_name->add_fallback(DefaultFont);                      \
+	} else {                                                    \
+		m_name->set_font_data(DefaultFont);                     \
+	}                                                           \
 	m_name->set_spacing(DynamicFont::SPACING_TOP, -EDSCALE);    \
 	m_name->set_spacing(DynamicFont::SPACING_BOTTOM, -EDSCALE); \
 	MAKE_FALLBACKS(m_name);
 
 void editor_register_fonts(Ref<Theme> p_theme) {
+	/* Custom font */
+
+	String custom_font = EditorSettings::get_singleton()->get("interface/editor/custom_font");
+	Ref<DynamicFontData> CustomFont;
+	if (custom_font.length() > 0) {
+		CustomFont.instance();
+		CustomFont->set_font_path(custom_font);
+		CustomFont->set_force_autohinter(true); //just looks better..i think?
+	}
+
 	/* Droid Sans */
 
 	Ref<DynamicFontData> DefaultFont;

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -264,7 +264,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("interface/editor/source_font_size", 14);
 	hints["interface/editor/source_font_size"] = PropertyInfo(Variant::INT, "interface/editor/source_font_size", PROPERTY_HINT_RANGE, "8,96,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/custom_font", "");
-	hints["interface/editor/custom_font"] = PropertyInfo(Variant::STRING, "interface/editor/custom_font", PROPERTY_HINT_GLOBAL_FILE, "*.font,*.tres,*.res", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
+	hints["interface/editor/custom_font"] = PropertyInfo(Variant::STRING, "interface/editor/custom_font", PROPERTY_HINT_GLOBAL_FILE, "*.ttf,*.otf", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/dim_editor_on_dialog_popup", true);
 	_initial_set("interface/editor/dim_amount", 0.6f);
 	hints["interface/editor/dim_amount"] = PropertyInfo(Variant::REAL, "interface/editor/dim_amount", PROPERTY_HINT_RANGE, "0,1,0.01", PROPERTY_USAGE_DEFAULT);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1100,16 +1100,5 @@ Ref<Theme> create_custom_theme(const Ref<Theme> p_theme) {
 		theme = create_editor_theme(p_theme);
 	}
 
-	String global_font = EditorSettings::get_singleton()->get("interface/editor/custom_font");
-	if (global_font != "") {
-		Ref<Font> fnt = ResourceLoader::load(global_font);
-		if (fnt.is_valid()) {
-			if (!theme.is_valid()) {
-				theme.instance();
-			}
-			theme->set_default_theme_font(fnt);
-		}
-	}
-
 	return theme;
 }


### PR DESCRIPTION
![editor-font](https://user-images.githubusercontent.com/8281454/34362132-41dc0072-eab4-11e7-82cb-0120b8b779cb.gif)

Fix #11589
Fix #10806

This PR uses `editor/custom_font` first for editor font, and add fallbacks with embeded fonts.