### PR TITLE
Hiding a Control now fires NOTIFICATION_FOCUS_EXIT.

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2302,7 +2302,7 @@ void Viewport::_gui_hid_control(Control *p_control) {
 	*/
 
 	if (gui.key_focus == p_control)
-		gui.key_focus = NULL;
+		_gui_remove_focus();
 	if (gui.mouse_over == p_control)
 		gui.mouse_over = NULL;
 	if (gui.tooltip == p_control)


### PR DESCRIPTION
It always removed the focus from the control, but this happened without firing the relevant notification.