### PR TITLE
Restore the behavior of Spatial rotations recently changed in c1153f5.

### DIFF
--- a/core/math/matrix3.cpp
+++ b/core/math/matrix3.cpp
@@ -228,10 +228,22 @@ void Basis::scale(const Vector3 &p_scale) {
 }
 
 Basis Basis::scaled(const Vector3 &p_scale) const {
-
 	Basis m = *this;
 	m.scale(p_scale);
 	return m;
+}
+
+void Basis::scale_local(const Vector3 &p_scale) {
+	// performs a scaling in object-local coordinate system:
+	// M -> (M.S.Minv).M = M.S.
+	*this = scaled_local(p_scale);
+}
+
+Basis Basis::scaled_local(const Vector3 &p_scale) const {
+	Basis b;
+	b.set_scale(p_scale);
+
+	return (*this) * b;
 }
 
 void Basis::set_scale(const Vector3 &p_scale) {
@@ -312,7 +324,8 @@ void Basis::rotate(const Vector3 &p_axis, real_t p_phi) {
 }
 
 void Basis::rotate_local(const Vector3 &p_axis, real_t p_phi) {
-
+	// performs a rotation in object-local coordinate system:
+	// M -> (M.R.Minv).M = M.R.
 	*this = rotated_local(p_axis, p_phi);
 }
 Basis Basis::rotated_local(const Vector3 &p_axis, real_t p_phi) const {

--- a/core/math/matrix3.h
+++ b/core/math/matrix3.h
@@ -103,6 +103,9 @@ public:
 	void scale(const Vector3 &p_scale);
 	Basis scaled(const Vector3 &p_scale) const;
 
+	void scale_local(const Vector3 &p_scale);
+	Basis scaled_local(const Vector3 &p_scale) const;
+
 	void set_scale(const Vector3 &p_scale);
 	Vector3 get_scale() const;
 	Vector3 get_signed_scale() const;

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -38,7 +38,7 @@
 			<argument index="1" name="phi" type="float">
 			</argument>
 			<description>
-				Create a rotation matrix which rotates around the given axis by the specified angle. The axis must be a normalized vector.
+				Create a rotation matrix which rotates around the given axis by the specified angle, in radians. The axis must be a normalized vector.
 			</description>
 		</method>
 		<method name="Basis">

--- a/doc/classes/Spatial.xml
+++ b/doc/classes/Spatial.xml
@@ -5,6 +5,8 @@
 	</brief_description>
 	<description>
 		Most basic 3D game object, with a 3D [Transform] and visibility settings. All other 3D game objects inherit from Spatial. Use Spatial as a parent node to move, scale, rotate and show/hide children in a 3D project.
+
+		Affine operations (rotate, scale, translate) happen in parent's local coordinate system, unless the Spatial object is set as top level. Affine operations in this coordinate system correspond to direct affine operations on the Spatial's transform. The word local below refers to this coordinate system. The coordinate system that is attached to the Spatial object itself is referred to as object-local coordinate system.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -32,15 +34,35 @@
 				Returns the current [World] resource this Spatial node is registered to.
 			</description>
 		</method>
+		<method name="rotate_object_local">
+			<return type="void">
+			</return>
+			<argument index="0" name="axis" type="Vector3">
+			</argument>
+			<argument index="1" name="angle" type="float">
+			</argument>
+			<description>
+				Rotates the local transformation around axis, a unit [Vector3], by specified angle in radians. The rotation axis is in object-local coordinate system.
+			</description>
+		</method>
+		<method name="scale_object_local">
+			<return type="void">
+			</return>
+			<argument index="0" name="scale" type="Vector3">
+			</argument>
+			<description>
+				Scales the local transformation by given 3D scale factors in object-local coordinate system.
+			</description>
+		</method>
 		<method name="global_rotate">
 			<return type="void">
 			</return>
-			<argument index="0" name="normal" type="Vector3">
+			<argument index="0" name="axis" type="Vector3">
 			</argument>
-			<argument index="1" name="radians" type="float">
+			<argument index="1" name="angle" type="float">
 			</argument>
 			<description>
-				Rotates the current node along normal [Vector3] by angle in radians in Global space.
+				Rotates the global (world) transformation around axis, a unit [Vector3], by specified angle in radians. The rotation axis is in global coordinate system.
 			</description>
 		</method>
 		<method name="global_translate">
@@ -49,7 +71,7 @@
 			<argument index="0" name="offset" type="Vector3">
 			</argument>
 			<description>
-				Moves the node by [Vector3] offset in Global space.
+				Moves the global (world) transformation by [Vector3] offset. The offset is in global coordinate system.
 			</description>
 		</method>
 		<method name="hide">
@@ -115,45 +137,45 @@
 			<return type="void">
 			</return>
 			<description>
-				Resets this node's transformations (like scale, skew and taper) preserving its rotation and translation. Performs orthonormalization on this node [Transform3D].
+				Resets this node's transformations (like scale, skew and taper) preserving its rotation and translation by performing Gram-Schmidt orthonormalization on this node's [Transform3D].
 			</description>
 		</method>
 		<method name="rotate">
 			<return type="void">
 			</return>
-			<argument index="0" name="normal" type="Vector3">
+			<argument index="0" name="axis" type="Vector3">
 			</argument>
-			<argument index="1" name="radians" type="float">
+			<argument index="1" name="angle" type="float">
 			</argument>
 			<description>
-				Rotates the node in local space on given normal [Vector3] by angle in radians.
+				Rotates the local transformation around axis, a unit [Vector3], by specified angle in radians.
 			</description>
 		</method>
 		<method name="rotate_x">
 			<return type="void">
 			</return>
-			<argument index="0" name="radians" type="float">
+			<argument index="0" name="angle" type="float">
 			</argument>
 			<description>
-				Rotates the node in local space on X axis by angle in radians.
+				Rotates the local transformation around the X axis by angle in radians
 			</description>
 		</method>
 		<method name="rotate_y">
 			<return type="void">
 			</return>
-			<argument index="0" name="radians" type="float">
+			<argument index="0" name="angle" type="float">
 			</argument>
 			<description>
-				Rotates the node in local space on Y axis by angle in radians.
+				Rotates the local transformation around the Y axis by angle in radians.
 			</description>
 		</method>
 		<method name="rotate_z">
 			<return type="void">
 			</return>
-			<argument index="0" name="radians" type="float">
+			<argument index="0" name="angle" type="float">
 			</argument>
 			<description>
-				Rotates the node in local space on Z axis by angle in radians.
+				Rotates the local transformation around the Z axis by angle in radians.
 			</description>
 		</method>
 		<method name="set_as_toplevel">
@@ -255,16 +277,18 @@
 			World space (global) [Transform] of this node.
 		</member>
 		<member name="rotation" type="Vector3" setter="set_rotation" getter="get_rotation">
-			Local euler rotation in radians of this node.
+			Rotation part of the local transformation, specified in terms of YXZ-Euler angles in the format (X-angle, Y-angle, Z-angle), in radians.
+
+			Note that in the mathematical sense, rotation is a matrix and not a vector. The three Euler angles, which are the three indepdent parameters of the Euler-angle parametrization of the rotation matrix, are stored in a [Vector3] data structure not because the rotation is a vector, but only because [Vector3] exists as a convenient data-structure to store 3 floating point numbers. Therefore, applying affine operations on the rotation "vector" is not meaningful.
 		</member>
 		<member name="rotation_degrees" type="Vector3" setter="set_rotation_degrees" getter="get_rotation_degrees">
-			Local euler rotation in degrees of this node.
+			Rotation part of the local transformation, specified in terms of YXZ-Euler angles in the format (X-angle, Y-angle, Z-angle), in degrees.
 		</member>
 		<member name="scale" type="Vector3" setter="set_scale" getter="get_scale">
-			Local scale of this node.
+			Scale part of the local transformation.
 		</member>
 		<member name="transform" type="Transform" setter="set_transform" getter="get_transform">
-			Local space [Transform] of this node.
+			Local space [Transform] of this node, with respect to the parent node.
 		</member>
 		<member name="translation" type="Vector3" setter="set_translation" getter="get_translation">
 			Local translation of this node.

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -555,30 +555,36 @@ bool Spatial::is_visible() const {
 	return data.visible;
 }
 
-void Spatial::rotate(const Vector3 &p_normal, float p_radians) {
-
+void Spatial::rotate_object_local(const Vector3 &p_axis, float p_angle) {
 	Transform t = get_transform();
-	t.basis.rotate_local(p_normal, p_radians); //use local rotation here, as it makes more sense here in tree hierarchy
+	t.basis.rotate_local(p_axis, p_angle);
 	set_transform(t);
 }
 
-void Spatial::rotate_x(float p_radians) {
+void Spatial::rotate(const Vector3 &p_axis, float p_angle) {
 
 	Transform t = get_transform();
-	t.basis.rotate_local(Vector3(1, 0, 0), p_radians);
+	t.basis.rotate(p_axis, p_angle);
 	set_transform(t);
 }
 
-void Spatial::rotate_y(float p_radians) {
+void Spatial::rotate_x(float p_angle) {
 
 	Transform t = get_transform();
-	t.basis.rotate_local(Vector3(0, 1, 0), p_radians);
+	t.basis.rotate(Vector3(1, 0, 0), p_angle);
 	set_transform(t);
 }
-void Spatial::rotate_z(float p_radians) {
+
+void Spatial::rotate_y(float p_angle) {
 
 	Transform t = get_transform();
-	t.basis.rotate_local(Vector3(0, 0, 1), p_radians);
+	t.basis.rotate(Vector3(0, 1, 0), p_angle);
+	set_transform(t);
+}
+void Spatial::rotate_z(float p_angle) {
+
+	Transform t = get_transform();
+	t.basis.rotate(Vector3(0, 0, 1), p_angle);
 	set_transform(t);
 }
 
@@ -589,19 +595,45 @@ void Spatial::translate(const Vector3 &p_offset) {
 	set_transform(t);
 }
 
+void Spatial::translate_object_local(const Vector3 &p_offset) {
+	Transform t = get_transform();
+
+	Transform s;
+	s.translate(p_offset);
+	set_transform(t * s);
+}
+
 void Spatial::scale(const Vector3 &p_ratio) {
 
 	Transform t = get_transform();
 	t.basis.scale(p_ratio);
 	set_transform(t);
 }
-void Spatial::global_rotate(const Vector3 &p_normal, float p_radians) {
 
-	Basis rotation(p_normal, p_radians);
+void Spatial::scale_object_local(const Vector3 &p_scale) {
+	Transform t = get_transform();
+	t.basis.scale_local(p_scale);
+	set_transform(t);
+}
+
+void Spatial::global_rotate(const Vector3 &p_axis, float p_angle) {
+
+	Basis rotation(p_axis, p_angle);
 	Transform t = get_global_transform();
 	t.basis = rotation * t.basis;
 	set_global_transform(t);
 }
+
+void Spatial::global_scale(const Vector3 &p_scale) {
+
+	Basis s;
+	s.set_scale(p_scale);
+
+	Transform t = get_global_transform();
+	t.basis = s * t.basis;
+	set_global_transform(t);
+}
+
 void Spatial::global_translate(const Vector3 &p_offset) {
 	Transform t = get_global_transform();
 	t.origin += p_offset;
@@ -620,7 +652,7 @@ void Spatial::set_identity() {
 	set_transform(Transform());
 }
 
-void Spatial::look_at(const Vector3 &p_target, const Vector3 &p_up_normal) {
+void Spatial::look_at(const Vector3 &p_target, const Vector3 &p_up) {
 
 	Transform lookat;
 	lookat.origin = get_global_transform().origin;
@@ -629,19 +661,19 @@ void Spatial::look_at(const Vector3 &p_target, const Vector3 &p_up_normal) {
 		ERR_FAIL();
 	}
 
-	if (p_up_normal.cross(p_target - lookat.origin) == Vector3()) {
+	if (p_up.cross(p_target - lookat.origin) == Vector3()) {
 		ERR_EXPLAIN("Up vector and direction between node origin and target are aligned, look_at() failed");
 		ERR_FAIL();
 	}
-	lookat = lookat.looking_at(p_target, p_up_normal);
+	lookat = lookat.looking_at(p_target, p_up);
 	set_global_transform(lookat);
 }
 
-void Spatial::look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up_normal) {
+void Spatial::look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up) {
 
 	Transform lookat;
 	lookat.origin = p_pos;
-	lookat = lookat.looking_at(p_target, p_up_normal);
+	lookat = lookat.looking_at(p_target, p_up);
 	set_global_transform(lookat);
 }
 
@@ -677,9 +709,9 @@ void Spatial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_transform"), &Spatial::get_transform);
 	ClassDB::bind_method(D_METHOD("set_translation", "translation"), &Spatial::set_translation);
 	ClassDB::bind_method(D_METHOD("get_translation"), &Spatial::get_translation);
-	ClassDB::bind_method(D_METHOD("set_rotation", "radians"), &Spatial::set_rotation);
+	ClassDB::bind_method(D_METHOD("set_rotation", "euler"), &Spatial::set_rotation);
 	ClassDB::bind_method(D_METHOD("get_rotation"), &Spatial::get_rotation);
-	ClassDB::bind_method(D_METHOD("set_rotation_degrees", "degrees"), &Spatial::set_rotation_degrees);
+	ClassDB::bind_method(D_METHOD("set_rotation_degrees", "euler_degrees"), &Spatial::set_rotation_degrees);
 	ClassDB::bind_method(D_METHOD("get_rotation_degrees"), &Spatial::get_rotation_degrees);
 	ClassDB::bind_method(D_METHOD("set_scale", "scale"), &Spatial::set_scale);
 	ClassDB::bind_method(D_METHOD("get_scale"), &Spatial::get_scale);
@@ -711,22 +743,26 @@ void Spatial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_notify_transform", "enable"), &Spatial::set_notify_transform);
 	ClassDB::bind_method(D_METHOD("is_transform_notification_enabled"), &Spatial::is_transform_notification_enabled);
 
-	void rotate(const Vector3 &p_normal, float p_radians);
-	void rotate_x(float p_radians);
-	void rotate_y(float p_radians);
-	void rotate_z(float p_radians);
+	void rotate(const Vector3 &p_axis, float p_angle);
+	void rotate_x(float p_angle);
+	void rotate_y(float p_angle);
+	void rotate_z(float p_angle);
 	void translate(const Vector3 &p_offset);
 	void scale(const Vector3 &p_ratio);
-	void global_rotate(const Vector3 &p_normal, float p_radians);
+	void global_rotate(const Vector3 &p_axis, float p_angle);
 	void global_translate(const Vector3 &p_offset);
 
-	ClassDB::bind_method(D_METHOD("rotate", "normal", "radians"), &Spatial::rotate);
-	ClassDB::bind_method(D_METHOD("global_rotate", "normal", "radians"), &Spatial::global_rotate);
-	ClassDB::bind_method(D_METHOD("rotate_x", "radians"), &Spatial::rotate_x);
-	ClassDB::bind_method(D_METHOD("rotate_y", "radians"), &Spatial::rotate_y);
-	ClassDB::bind_method(D_METHOD("rotate_z", "radians"), &Spatial::rotate_z);
-	ClassDB::bind_method(D_METHOD("translate", "offset"), &Spatial::translate);
+	ClassDB::bind_method(D_METHOD("rotate", "axis", "angle"), &Spatial::rotate);
+	ClassDB::bind_method(D_METHOD("global_rotate", "axis", "angle"), &Spatial::global_rotate);
+	ClassDB::bind_method(D_METHOD("global_scale", "scale"), &Spatial::global_scale);
 	ClassDB::bind_method(D_METHOD("global_translate", "offset"), &Spatial::global_translate);
+	ClassDB::bind_method(D_METHOD("rotate_object_local", "axis", "angle"), &Spatial::rotate_object_local);
+	ClassDB::bind_method(D_METHOD("scale_object_local", "scale"), &Spatial::scale_object_local);
+	ClassDB::bind_method(D_METHOD("translate_object_local", "offset"), &Spatial::translate_object_local);
+	ClassDB::bind_method(D_METHOD("rotate_x", "angle"), &Spatial::rotate_x);
+	ClassDB::bind_method(D_METHOD("rotate_y", "angle"), &Spatial::rotate_y);
+	ClassDB::bind_method(D_METHOD("rotate_z", "angle"), &Spatial::rotate_z);
+	ClassDB::bind_method(D_METHOD("translate", "offset"), &Spatial::translate);
 	ClassDB::bind_method(D_METHOD("orthonormalize"), &Spatial::orthonormalize);
 	ClassDB::bind_method(D_METHOD("set_identity"), &Spatial::set_identity);
 

--- a/scene/3d/spatial.h
+++ b/scene/3d/spatial.h
@@ -158,17 +158,23 @@ public:
 
 	Transform get_relative_transform(const Node *p_parent) const;
 
-	void rotate(const Vector3 &p_normal, float p_radians);
-	void rotate_x(float p_radians);
-	void rotate_y(float p_radians);
-	void rotate_z(float p_radians);
+	void rotate(const Vector3 &p_axis, float p_angle);
+	void rotate_x(float p_angle);
+	void rotate_y(float p_angle);
+	void rotate_z(float p_angle);
 	void translate(const Vector3 &p_offset);
 	void scale(const Vector3 &p_ratio);
-	void global_rotate(const Vector3 &p_normal, float p_radians);
+
+	void rotate_object_local(const Vector3 &p_axis, float p_angle);
+	void scale_object_local(const Vector3 &p_scale);
+	void translate_object_local(const Vector3 &p_offset);
+
+	void global_rotate(const Vector3 &p_axis, float p_angle);
+	void global_scale(const Vector3 &p_scale);
 	void global_translate(const Vector3 &p_offset);
 
-	void look_at(const Vector3 &p_target, const Vector3 &p_up_normal);
-	void look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up_normal);
+	void look_at(const Vector3 &p_target, const Vector3 &p_up);
+	void look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up);
 
 	Vector3 to_local(Vector3 p_global) const;
 	Vector3 to_global(Vector3 p_local) const;


### PR DESCRIPTION
That change was borne out of a confusion regarding the meaning of "local" in #14569.

Affine transformations in Spatial simply correspond to affine operations its Transform.
Such operations take plane in a coordinate system that is defined by the parent Spatial.
When there is no parent, they correspond to operations in the global coordinate system.
This coordinate system, which is relative to the parent, has been referred to as the local coordinate system in the docs,
but this sloppy language has apparently confused some users,
making them think that the local coordinate system refers to the one whose axes are "painted" on the Spatial node itself.

To avoid such conceptual conflations and misunderstandings in the future, the parent-relative local system is now referred to as "parent-local", and the object-relative local system is called "object-local" in the docs.

This commit add the functionality "requested" in #14569, not by changing how rotate/scale/translate works, but adding new rotate_local, scale_local and translate_local functions. Also, for completeness, there is now global_scale.

This commit also updates another part of the docs regarding the rotation property of Spatial, which also leads to confusion among some users.