### PR TITLE
Fix autotiles properties

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -343,7 +343,7 @@ AutotileEditor::AutotileEditor(EditorNode *p_editor) {
 	split->add_child(property_editor);
 
 	helper = memnew(AutotileEditorHelper(this));
-	property_editor->call_deferred("edit", helper);
+	property_editor->edit(helper);
 
 	// Editor
 


### PR DESCRIPTION
https://github.com/godotengine/godot/issues/14890

Question : when is `call_deferred` called? 
When I change it to directly call the `edit` function, the properties option back normal. But back to the beta 1 still using `call_deferred` and it's fine too.