### PR TITLE
Fix infinite loop on splash screen on tiling windows managers

### DIFF
--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -200,6 +200,8 @@ protected:
 
 	void _window_changed(XEvent *xevent);
 
+	bool is_window_maximize_allowed();
+
 public:
 	virtual String get_name();
 


### PR DESCRIPTION
Fix #15068
Related PR #15085

Tested on Gnome (3.26.2), KDE (5.11.4) and I3WM (4.14.1).

The original fix #14993 for splash screen problem, from what I tested, only works for KDE. Gnome still have this problem.

@groud I think it's a good ideia merge #15085 as a fallback for the loop problem.
I can rebase if that pr goes first to preserve @oisincar's credits.

### Update:
As reported here #14336, my changes may cause a regression in KDE because the error doesn't always occur, **in my tests, I didn't see any problem**. This bug will need more exhaustive tests and if necessary we can revert this pr.
