### PR TITLE
Bake navigation meshes by groups as alternative to NavigationMeshInstance-Children

### DIFF
--- a/doc/classes/NavigationMeshInstance.xml
+++ b/doc/classes/NavigationMeshInstance.xml
@@ -15,6 +15,10 @@
 		</member>
 		<member name="navmesh" type="NavigationMesh" setter="set_navigation_mesh" getter="get_navigation_mesh">
 		</member>
+		<member name="bakemode_type" type="int" setter="set_bake_mode_type" getter="get_bake_mode_type">
+		</member>
+		<member name="groupname" type="StringName" setter="set_navmesh_groupname" getter="get_navmesh_groupname">
+		</member>
 	</members>
 	<constants>
 	</constants>

--- a/modules/recast/navigation_mesh_generator.h
+++ b/modules/recast/navigation_mesh_generator.h
@@ -44,7 +44,7 @@ class NavigationMeshGenerator {
 protected:
 	static void _add_vertex(const Vector3 &p_vec3, Vector<float> &p_verticies);
 	static void _add_mesh(const Ref<Mesh> &p_mesh, const Transform &p_xform, Vector<float> &p_verticies, Vector<int> &p_indices);
-	static void _parse_geometry(const Transform &p_base_inverse, Node *p_node, Vector<float> &p_verticies, Vector<int> &p_indices);
+	static void _parse_geometry(const Transform &p_base_inverse, Node *p_node, Vector<float> &p_verticies, Vector<int> &p_indices, int bake_selection_mode = NavigationMeshInstance::BAKE_SELECTION_MODE_NAVMESH_CHILDREN, Set<Node *> *_processedList = 0, const StringName &navmesh_groupname = "navmesh");
 
 	static void _convert_detail_mesh_to_native_navigation_mesh(const rcPolyMeshDetail *p_detail_mesh, Ref<NavigationMesh> p_nav_mesh);
 	static void _build_recast_navigation_mesh(Ref<NavigationMesh> p_nav_mesh, EditorProgress *ep,

--- a/scene/3d/navigation_mesh.cpp
+++ b/scene/3d/navigation_mesh.cpp
@@ -494,6 +494,23 @@ bool NavigationMeshInstance::is_enabled() const {
 	return enabled;
 }
 
+void NavigationMeshInstance::set_bake_selection_mode(int p_value) {
+	ERR_FAIL_COND(p_value > BAKE_SELECTION_MODE_GROUPS_EXPLICIT);
+	bake_selection_mode = static_cast<BakeSelectionMode>(p_value);
+}
+
+int NavigationMeshInstance::get_bake_selection_mode() const {
+	return static_cast<int>(bake_selection_mode);
+}
+
+void NavigationMeshInstance::set_navmesh_groupname(const StringName &name) {
+	navmesh_groupname = name;
+}
+
+StringName NavigationMeshInstance::get_navmesh_groupname() {
+	return navmesh_groupname;
+}
+
 /////////////////////////////
 
 void NavigationMeshInstance::_notification(int p_what) {
@@ -606,15 +623,27 @@ String NavigationMeshInstance::get_configuration_warning() const {
 }
 
 void NavigationMeshInstance::_bind_methods() {
-
 	ClassDB::bind_method(D_METHOD("set_navigation_mesh", "navmesh"), &NavigationMeshInstance::set_navigation_mesh);
 	ClassDB::bind_method(D_METHOD("get_navigation_mesh"), &NavigationMeshInstance::get_navigation_mesh);
 
 	ClassDB::bind_method(D_METHOD("set_enabled", "enabled"), &NavigationMeshInstance::set_enabled);
 	ClassDB::bind_method(D_METHOD("is_enabled"), &NavigationMeshInstance::is_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_bake_selection_mode", "bake_mode_type"), &NavigationMeshInstance::set_bake_selection_mode);
+	ClassDB::bind_method(D_METHOD("get_bake_selection_mode"), &NavigationMeshInstance::get_bake_selection_mode);
+
+	ClassDB::bind_method(D_METHOD("set_navmesh_groupname", "navmesh_groupname"), &NavigationMeshInstance::set_navmesh_groupname);
+	ClassDB::bind_method(D_METHOD("get_navmesh_groupname"), &NavigationMeshInstance::get_navmesh_groupname);
+
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "navmesh", PROPERTY_HINT_RESOURCE_TYPE, "NavigationMesh"), "set_navigation_mesh", "get_navigation_mesh");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "enabled"), "set_enabled", "is_enabled");
+
+	BIND_CONSTANT(BAKE_SELECTION_MODE_NAVMESH_CHILDREN);
+	BIND_CONSTANT(BAKE_SELECTION_MODE_GROUPS_WITH_CHILDREN);
+	BIND_CONSTANT(BAKE_SELECTION_MODE_GROUPS_EXPLICIT);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "selection_mode", PROPERTY_HINT_ENUM, "navmesh children,group with children,group explicit"), "set_bake_selection_mode", "get_bake_selection_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "navmesh_groupname"), "set_navmesh_groupname", "get_navmesh_groupname");
 }
 
 NavigationMeshInstance::NavigationMeshInstance() {
@@ -623,5 +652,7 @@ NavigationMeshInstance::NavigationMeshInstance() {
 	navigation = NULL;
 	nav_id = -1;
 	enabled = true;
+	bake_selection_mode = BAKE_SELECTION_MODE_NAVMESH_CHILDREN;
+	navmesh_groupname = "navmesh";
 	set_notify_transform(true);
 }

--- a/scene/3d/navigation_mesh.h
+++ b/scene/3d/navigation_mesh.h
@@ -164,7 +164,21 @@ class NavigationMeshInstance : public Spatial {
 
 	GDCLASS(NavigationMeshInstance, Spatial);
 
+public:
+	enum BakeSelectionMode {
+		// select meshes for baking that are child of the NavigationMeshInstnace
+		BAKE_SELECTION_MODE_NAVMESH_CHILDREN = 0,
+		// select meshes and their children(recusive) for baking that have the are in the specified group
+		BAKE_SELECTION_MODE_GROUPS_WITH_CHILDREN,
+		// select only those meshes that are in the specified group (and not their children automatically)
+		BAKE_SELECTION_MODE_GROUPS_EXPLICIT
+	};
+
+private:
 	bool enabled;
+	BakeSelectionMode bake_selection_mode;
+	StringName navmesh_groupname;
+
 	int nav_id;
 	Navigation *navigation;
 	Ref<NavigationMesh> navmesh;
@@ -178,6 +192,12 @@ protected:
 public:
 	void set_enabled(bool p_enabled);
 	bool is_enabled() const;
+
+	void set_bake_selection_mode(int p_value);
+	int get_bake_selection_mode() const;
+
+	void set_navmesh_groupname(const StringName &name);
+	StringName get_navmesh_groupname();
 
 	void set_navigation_mesh(const Ref<NavigationMesh> &p_navmesh);
 	Ref<NavigationMesh> get_navigation_mesh() const;


### PR DESCRIPTION
Atm to create a navigation-mesh you have two options:
a) create it manually i.e. in blender (or let blender create it...) and export it with "-navmesh" postfix
b) create Navigation-Node with an NavigationMeshInstance as child, and add all mesh-nodes that should be taken into account to the NavigationMeshInstance.

a) works as intended. (actually I just [fixed blender to create navigation-meshes from multiple objects](https://developer.blender.org/D2976). not sure when this will make it's way into master, but this is another story ;) )
b) also works as intended (but the gizmo mesh is upside down)

Using one mesh in multiple navigation-meshes is not possible. E.g. you would want to create a navmesh for other Navmesh-settings (Agent is taller/thicker...) or you want one navmesh e.g. with a small scope(one tile with ground and obstacles) and another one with a bigger scope e.g. multiple tiles...

I created two more options (beside "navmesh-children" which is still the default):
1) "group with children": Use all nodes that are in a group specified in the "Navmesh Groupname"-Property and its children
2) "group explicit": only take the nodes that are in the specified group. children will be ignored

You can access the options on the NavigationMeshInstance using the "Bake Mode Type"-Property and the Navmesh Groupname and can also be activated using the "Bake"-button

This Pullrequest also fixes the gizmo for editor-created navmeshes.

Oh,I just read(in the contributing-txt) that I should have asked beforehand if this feature is wanted....Next time I will do this,..the feature just happend... ;)

Also look at the attached project that shows the changes in action
[TestNavmeshGroups.zip](https://github.com/godotengine/godot/files/1589845/TestNavmeshGroups.zip)


    