### PR TITLE
Autotile Enhancement

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -343,12 +343,13 @@ AutotileEditor::AutotileEditor(EditorNode *p_editor) {
 	split->add_child(property_editor);
 
 	helper = memnew(AutotileEditorHelper(this));
-	property_editor->call_deferred("edit", helper);
+	property_editor->edit(helper);
 
 	// Editor
 
 	dragging_point = -1;
 	creating_shape = false;
+	snap_step = Vector2(32, 32);
 
 	set_custom_minimum_size(Size2(0, 150));
 
@@ -426,10 +427,78 @@ AutotileEditor::AutotileEditor(EditorNode *p_editor) {
 	tools[SHAPE_KEEP_INSIDE_TILE]->set_toggle_mode(true);
 	tools[SHAPE_KEEP_INSIDE_TILE]->set_pressed(true);
 	tool_containers[TOOLBAR_SHAPE]->add_child(tools[SHAPE_KEEP_INSIDE_TILE]);
-	tools[SHAPE_SNAP_TO_BITMASK_GRID] = memnew(ToolButton);
-	tools[SHAPE_SNAP_TO_BITMASK_GRID]->set_toggle_mode(true);
-	tools[SHAPE_SNAP_TO_BITMASK_GRID]->set_pressed(true);
-	tool_containers[TOOLBAR_SHAPE]->add_child(tools[SHAPE_SNAP_TO_BITMASK_GRID]);
+	tools[SHAPE_GRID_SNAP] = memnew(ToolButton);
+	tools[SHAPE_GRID_SNAP]->set_toggle_mode(true);
+	tools[SHAPE_GRID_SNAP]->connect("toggled", this, "_on_grid_snap_toggled");
+	tool_containers[TOOLBAR_SHAPE]->add_child(tools[SHAPE_GRID_SNAP]);
+
+	hb_grid = memnew(HBoxContainer);
+	tool_containers[TOOLBAR_SHAPE]->add_child(hb_grid);
+
+	hb_grid->add_child(memnew(VSeparator));
+	hb_grid->add_child(memnew(Label(TTR("Offset:"))));
+
+	sb_off_x = memnew(SpinBox);
+	sb_off_x->set_min(-256);
+	sb_off_x->set_max(256);
+	sb_off_x->set_step(1);
+	sb_off_x->set_value(snap_offset.x);
+	sb_off_x->set_suffix("px");
+	sb_off_x->connect("value_changed", this, "_set_snap_off_x");
+	hb_grid->add_child(sb_off_x);
+
+	sb_off_y = memnew(SpinBox);
+	sb_off_y->set_min(-256);
+	sb_off_y->set_max(256);
+	sb_off_y->set_step(1);
+	sb_off_y->set_value(snap_offset.y);
+	sb_off_y->set_suffix("px");
+	sb_off_y->connect("value_changed", this, "_set_snap_off_y");
+	hb_grid->add_child(sb_off_y);
+
+	hb_grid->add_child(memnew(VSeparator));
+	hb_grid->add_child(memnew(Label(TTR("Step:"))));
+
+	sb_step_x = memnew(SpinBox);
+	sb_step_x->set_min(-256);
+	sb_step_x->set_max(256);
+	sb_step_x->set_step(1);
+	sb_step_x->set_value(snap_step.x);
+	sb_step_x->set_suffix("px");
+	sb_step_x->connect("value_changed", this, "_set_snap_step_x");
+	hb_grid->add_child(sb_step_x);
+
+	sb_step_y = memnew(SpinBox);
+	sb_step_y->set_min(-256);
+	sb_step_y->set_max(256);
+	sb_step_y->set_step(1);
+	sb_step_y->set_value(snap_step.y);
+	sb_step_y->set_suffix("px");
+	sb_step_y->connect("value_changed", this, "_set_snap_step_y");
+	hb_grid->add_child(sb_step_y);
+
+	hb_grid->add_child(memnew(VSeparator));
+	hb_grid->add_child(memnew(Label(TTR("Separation:"))));
+
+	sb_sep_x = memnew(SpinBox);
+	sb_sep_x->set_min(0);
+	sb_sep_x->set_max(256);
+	sb_sep_x->set_step(1);
+	sb_sep_x->set_value(snap_separation.x);
+	sb_sep_x->set_suffix("px");
+	sb_sep_x->connect("value_changed", this, "_set_snap_sep_x");
+	hb_grid->add_child(sb_sep_x);
+
+	sb_sep_y = memnew(SpinBox);
+	sb_sep_y->set_min(0);
+	sb_sep_y->set_max(256);
+	sb_sep_y->set_step(1);
+	sb_sep_y->set_value(snap_separation.y);
+	sb_sep_y->set_suffix("px");
+	sb_sep_y->connect("value_changed", this, "_set_snap_sep_y");
+	hb_grid->add_child(sb_sep_y);
+
+	hb_grid->hide();
 
 	spin_priority = memnew(SpinBox);
 	spin_priority->set_min(1);
@@ -489,6 +558,13 @@ void AutotileEditor::_bind_methods() {
 	ClassDB::bind_method("_on_workspace_input", &AutotileEditor::_on_workspace_input);
 	ClassDB::bind_method("_on_tool_clicked", &AutotileEditor::_on_tool_clicked);
 	ClassDB::bind_method("_on_priority_changed", &AutotileEditor::_on_priority_changed);
+	ClassDB::bind_method("_on_grid_snap_toggled", &AutotileEditor::_on_grid_snap_toggled);
+	ClassDB::bind_method("_set_snap_step_x", &AutotileEditor::_set_snap_step_x);
+	ClassDB::bind_method("_set_snap_step_y", &AutotileEditor::_set_snap_step_y);
+	ClassDB::bind_method("_set_snap_off_x", &AutotileEditor::_set_snap_off_x);
+	ClassDB::bind_method("_set_snap_off_y", &AutotileEditor::_set_snap_off_y);
+	ClassDB::bind_method("_set_snap_sep_x", &AutotileEditor::_set_snap_sep_x);
+	ClassDB::bind_method("_set_snap_sep_y", &AutotileEditor::_set_snap_sep_y);
 }
 
 void AutotileEditor::_notification(int p_what) {
@@ -501,7 +577,7 @@ void AutotileEditor::_notification(int p_what) {
 		tools[SHAPE_NEW_POLYGON]->set_icon(get_icon("CollisionPolygon2D", "EditorIcons"));
 		tools[SHAPE_DELETE]->set_icon(get_icon("Remove", "EditorIcons"));
 		tools[SHAPE_KEEP_INSIDE_TILE]->set_icon(get_icon("Snap", "EditorIcons"));
-		tools[SHAPE_SNAP_TO_BITMASK_GRID]->set_icon(get_icon("SnapGrid", "EditorIcons"));
+		tools[SHAPE_GRID_SNAP]->set_icon(get_icon("SnapGrid", "EditorIcons"));
 		tools[ZOOM_OUT]->set_icon(get_icon("ZoomLess", "EditorIcons"));
 		tools[ZOOM_1]->set_icon(get_icon("ZoomReset", "EditorIcons"));
 		tools[ZOOM_IN]->set_icon(get_icon("ZoomMore", "EditorIcons"));
@@ -632,6 +708,7 @@ void AutotileEditor::_on_workspace_draw() {
 				Vector2 coord = edited_shape_coord;
 				draw_highlight_tile(coord);
 				draw_polygon_shapes();
+				draw_grid_snap();
 			} break;
 			case EDITMODE_PRIORITY: {
 				spin_priority->set_value(tile_set->autotile_get_subtile_priority(get_current_tile(), edited_shape_coord));
@@ -880,15 +957,15 @@ void AutotileEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 									Vector<TileSet::ShapeData> sd = tile_set->tile_get_shapes(get_current_tile());
 									for (int i = 0; i < sd.size(); i++) {
 										if (sd[i].autotile_coord == coord) {
-											Ref<ConcavePolygonShape2D> shape = sd[i].shape;
+											Ref<ConvexPolygonShape2D> shape = sd[i].shape;
 											if (shape.is_valid()) {
-												//FIXME: i need a way to know if the point is countained on the polygon instead of the rect
+
 												Rect2 bounding_rect;
 												PoolVector2Array polygon;
-												bounding_rect.position = shape->get_segments()[0];
-												for (int j = 0; j < shape->get_segments().size(); j += 2) {
-													polygon.push_back(shape->get_segments()[j] + shape_anchor);
-													bounding_rect.expand_to(shape->get_segments()[j] + shape_anchor);
+												bounding_rect.position = shape->get_points()[0];
+												for (int j = 0; j < shape->get_points().size(); j++) {
+													polygon.push_back(shape->get_points()[j] + shape_anchor);
+													bounding_rect.expand_to(shape->get_points()[j] + shape_anchor);
 												}
 												if (bounding_rect.has_point(mb->get_position())) {
 													current_shape = polygon;
@@ -905,17 +982,17 @@ void AutotileEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 								if (dragging_point >= 0) {
 									dragging_point = -1;
 
-									PoolVector<Vector2> segments;
-									segments.resize(current_shape.size() * 2);
-									PoolVector<Vector2>::Write w = segments.write();
+									Vector<Vector2> points;
 
 									for (int i = 0; i < current_shape.size(); i++) {
-										w[(i << 1) + 0] = current_shape[i] - shape_anchor;
-										w[(i << 1) + 1] = current_shape[(i + 1) % current_shape.size()] - shape_anchor;
+										Vector2 p = current_shape[i];
+										if (tools[SHAPE_GRID_SNAP]->is_pressed() || tools[SHAPE_KEEP_INSIDE_TILE]->is_pressed()) {
+											p = snap_point(p);
+										}
+										points.push_back(p - shape_anchor);
 									}
 
-									w = PoolVector<Vector2>::Write();
-									edited_collision_shape->set_segments(segments);
+									edited_collision_shape->set_points(points);
 
 									workspace->update();
 								}
@@ -982,11 +1059,30 @@ void AutotileEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 								current_shape.push_back(pos);
 								workspace->update();
 							} else {
+								int t_id = get_current_tile();
+								if (t_id >= 0) {
+									Vector<TileSet::ShapeData> sd = tile_set->tile_get_shapes(t_id);
+									for (int i = 0; i < sd.size(); i++) {
+										if (sd[i].autotile_coord == edited_shape_coord) {
+											Ref<ConvexPolygonShape2D> shape = sd[i].shape;
+
+											if (!shape.is_null()) {
+												sd.remove(i);
+												tile_set->tile_set_shapes(get_current_tile(), sd);
+												edited_collision_shape = Ref<Shape2D>();
+												current_shape.resize(0);
+												workspace->update();
+											}
+											break;
+										}
+									}
+								}
+
 								creating_shape = true;
 								current_shape.resize(0);
 								current_shape.push_back(snap_point(pos));
 							}
-						} else if (mb->is_pressed() && mb->get_button_index() == BUTTON_RIGHT) {
+						} else if (mb->is_pressed() && mb->get_button_index() == BUTTON_RIGHT && current_shape.size() > 2) {
 							if (creating_shape) {
 								close_shape(shape_anchor);
 							}
@@ -1034,7 +1130,7 @@ void AutotileEditor::_on_tool_clicked(int p_tool) {
 						if (index >= 0) {
 							sd.remove(index);
 							tile_set->tile_set_shapes(get_current_tile(), sd);
-							edited_collision_shape = Ref<ConcavePolygonShape2D>();
+							edited_collision_shape = Ref<Shape2D>();
 							current_shape.resize(0);
 							workspace->update();
 						}
@@ -1081,6 +1177,43 @@ void AutotileEditor::_on_priority_changed(float val) {
 	workspace->update();
 }
 
+void AutotileEditor::_on_grid_snap_toggled(bool p_val) {
+	if (p_val)
+		hb_grid->show();
+	else
+		hb_grid->hide();
+	workspace->update();
+}
+
+void AutotileEditor::_set_snap_step_x(float p_val) {
+	snap_step.x = p_val;
+	workspace->update();
+}
+
+void AutotileEditor::_set_snap_step_y(float p_val) {
+	snap_step.y = p_val;
+	workspace->update();
+}
+
+void AutotileEditor::_set_snap_off_x(float p_val) {
+	snap_offset.x = p_val;
+	workspace->update();
+}
+
+void AutotileEditor::_set_snap_off_y(float p_val) {
+	snap_offset.y = p_val;
+	workspace->update();
+}
+void AutotileEditor::_set_snap_sep_x(float p_val) {
+	snap_separation.x = p_val;
+	workspace->update();
+}
+
+void AutotileEditor::_set_snap_sep_y(float p_val) {
+	snap_separation.y = p_val;
+	workspace->update();
+}
+
 void AutotileEditor::draw_highlight_tile(Vector2 coord, const Vector<Vector2> &other_highlighted) {
 
 	Vector2 size = tile_set->autotile_get_size(get_current_tile());
@@ -1103,6 +1236,49 @@ void AutotileEditor::draw_highlight_tile(Vector2 coord, const Vector<Vector2> &o
 	}
 }
 
+void AutotileEditor::draw_grid_snap() {
+	if (tools[SHAPE_GRID_SNAP]->is_pressed()) {
+		Color grid_color = Color(0.39, 0, 1, 0.2f);
+		Size2 s = workspace->get_size();
+
+		Vector2 size = tile_set->autotile_get_size(get_current_tile());
+
+		int width_count = (int)(s.width / (snap_step.x + snap_separation.x));
+		int height_count = (int)(s.height / (snap_step.y + snap_separation.y));
+
+		if (snap_step.x != 0) {
+			int last_p = 0;
+			for (int i = 0; i <= width_count; i++) {
+				if (i == 0 && snap_offset.x != 0) {
+					last_p = snap_offset.x;
+				}
+				if (snap_separation.x != 0 && i != 0) {
+					workspace->draw_rect(Rect2(last_p, 0, snap_separation.x, s.height), grid_color);
+					last_p += snap_separation.x;
+				} else
+					workspace->draw_line(Point2(last_p, 0), Point2(last_p, s.height), grid_color);
+
+				last_p += snap_step.x;
+			}
+		}
+
+		if (snap_step.y != 0) {
+			int last_p = 0;
+			for (int i = 0; i <= height_count; i++) {
+				if (i == 0 && snap_offset.y != 0) {
+					last_p = snap_offset.y;
+				}
+				if (snap_separation.x != 0 && i != 0) {
+					workspace->draw_rect(Rect2(0, last_p, s.width, snap_separation.y), grid_color);
+					last_p += snap_separation.y;
+				} else
+					workspace->draw_line(Point2(0, last_p), Point2(s.width, last_p), grid_color);
+				last_p += snap_step.y;
+			}
+		}
+	}
+}
+
 void AutotileEditor::draw_polygon_shapes() {
 
 	int t_id = get_current_tile();
@@ -1119,7 +1295,7 @@ void AutotileEditor::draw_polygon_shapes() {
 				anchor.y += tile_set->autotile_get_spacing(t_id);
 				anchor.x *= coord.x;
 				anchor.y *= coord.y;
-				Ref<ConcavePolygonShape2D> shape = sd[i].shape;
+				Ref<ConvexPolygonShape2D> shape = sd[i].shape;
 				if (shape.is_valid()) {
 					Color c_bg;
 					Color c_border;
@@ -1138,19 +1314,22 @@ void AutotileEditor::draw_polygon_shapes() {
 							colors.push_back(c_bg);
 						}
 					} else {
-						for (int j = 0; j < shape->get_segments().size(); j += 2) {
-							polygon.push_back(shape->get_segments()[j] + anchor);
+						for (int j = 0; j < shape->get_points().size(); j++) {
+							polygon.push_back(shape->get_points()[j] + anchor);
 							colors.push_back(c_bg);
 						}
 					}
-					workspace->draw_polygon(polygon, colors);
+					if (polygon.size() > 2) {
+						workspace->draw_polygon(polygon, colors);
+					}
 					if (coord == edited_shape_coord) {
-						for (int j = 0; j < shape->get_segments().size(); j += 2) {
-							workspace->draw_line(shape->get_segments()[j] + anchor, shape->get_segments()[j + 1] + anchor, c_border, 1, true);
+						for (int j = 0; j < shape->get_points().size() - 1; j++) {
+							workspace->draw_line(shape->get_points()[j] + anchor, shape->get_points()[j + 1] + anchor, c_border, 1, true);
 						}
+
 						if (shape == edited_collision_shape) {
 							for (int j = 0; j < current_shape.size(); j++) {
-								workspace->draw_circle(current_shape[j], 5, Color(1, 0, 0));
+								workspace->draw_circle(current_shape[j], 8 / workspace->get_scale().x, Color(1, 0, 0, 0.7f));
 							}
 						}
 					}
@@ -1198,7 +1377,7 @@ void AutotileEditor::draw_polygon_shapes() {
 						workspace->draw_line(shape->get_polygon()[shape->get_polygon().size() - 1] + anchor, shape->get_polygon()[0] + anchor, c_border, 1, true);
 						if (shape == edited_occlusion_shape) {
 							for (int j = 0; j < current_shape.size(); j++) {
-								workspace->draw_circle(current_shape[j], 5, Color(1, 0, 0));
+								workspace->draw_circle(current_shape[j], 8 / workspace->get_scale().x, Color(1, 0, 0));
 							}
 						}
 					}
@@ -1248,7 +1427,7 @@ void AutotileEditor::draw_polygon_shapes() {
 							}
 							if (shape == edited_navigation_shape) {
 								for (int j = 0; j < current_shape.size(); j++) {
-									workspace->draw_circle(current_shape[j], 5, Color(1, 0, 0));
+									workspace->draw_circle(current_shape[j], 8 / workspace->get_scale().x, Color(1, 0, 0));
 								}
 							}
 						}
@@ -1270,22 +1449,21 @@ void AutotileEditor::close_shape(const Vector2 &shape_anchor) {
 	creating_shape = false;
 
 	if (edit_mode == EDITMODE_COLLISION) {
-		Ref<ConcavePolygonShape2D> shape = memnew(ConcavePolygonShape2D);
+		if (current_shape.size() >= 3) {
+			Ref<ConvexPolygonShape2D> shape = memnew(ConvexPolygonShape2D);
 
-		PoolVector<Vector2> segments;
-		segments.resize(current_shape.size() * 2);
-		PoolVector<Vector2>::Write w = segments.write();
+			Vector<Vector2> segments;
 
-		for (int i = 0; i < current_shape.size(); i++) {
-			w[(i << 1) + 0] = current_shape[i] - shape_anchor;
-			w[(i << 1) + 1] = current_shape[(i + 1) % current_shape.size()] - shape_anchor;
+			for (int i = 0; i < current_shape.size(); i++) {
+				segments.push_back(current_shape[i] - shape_anchor);
+			}
+
+			shape->set_points(segments);
+
+			tile_set->tile_add_shape(get_current_tile(), shape, Transform2D(), false, edited_shape_coord);
+			edited_collision_shape = shape;
 		}
 
-		w = PoolVector<Vector2>::Write();
-		shape->set_segments(segments);
-
-		tile_set->tile_add_shape(get_current_tile(), shape, Transform2D(), false, edited_shape_coord);
-		edited_collision_shape = shape;
 		tools[TOOL_SELECT]->set_pressed(true);
 		workspace->update();
 	} else if (edit_mode == EDITMODE_OCCLUSION) {
@@ -1338,6 +1516,10 @@ Vector2 AutotileEditor::snap_point(const Vector2 &point) {
 	anchor.x *= (tile_size.x + spacing);
 	anchor.y *= (tile_size.y + spacing);
 	Rect2 region(anchor, tile_size);
+	if (tools[SHAPE_GRID_SNAP]->is_pressed()) {
+		p.x = Math::snap_scalar_seperation(snap_offset.x, snap_step.x, p.x, snap_separation.x);
+		p.y = Math::snap_scalar_seperation(snap_offset.y, snap_step.y, p.y, snap_separation.y);
+	}
 	if (tools[SHAPE_KEEP_INSIDE_TILE]->is_pressed()) {
 		if (p.x < region.position.x)
 			p.x = region.position.x;
@@ -1348,23 +1530,6 @@ Vector2 AutotileEditor::snap_point(const Vector2 &point) {
 		if (p.y > region.position.y + region.size.y)
 			p.y = region.position.y + region.size.y;
 	}
-	if (tools[SHAPE_SNAP_TO_BITMASK_GRID]->is_pressed()) {
-		Vector2 p2 = p;
-		if (tile_set->autotile_get_bitmask_mode(get_current_tile()) == TileSet::BITMASK_2X2) {
-			p2.x = Math::stepify(p2.x, tile_size.x / 2);
-			p2.y = Math::stepify(p2.y, tile_size.y / 2);
-			if ((p2 - p).length_squared() <= MAX(tile_size.y / 4, MIN_DISTANCE_SQUARED)) {
-				p = p2;
-			}
-		} else if (tile_set->autotile_get_bitmask_mode(get_current_tile()) == TileSet::BITMASK_3X3) {
-			p2.x = Math::stepify(p2.x, tile_size.x / 3);
-			p2.y = Math::stepify(p2.y, tile_size.y / 3);
-			if ((p2 - p).length_squared() <= MAX(tile_size.y / 6, MIN_DISTANCE_SQUARED)) {
-				p = p2;
-			}
-		}
-	}
-	p.floor();
 	return p;
 }
 

--- a/editor/plugins/tile_set_editor_plugin.h
+++ b/editor/plugins/tile_set_editor_plugin.h
@@ -33,7 +33,7 @@
 #include "editor/editor_name_dialog.h"
 #include "editor/editor_node.h"
 #include "scene/2d/sprite.h"
-#include "scene/resources/concave_polygon_shape_2d.h"
+#include "scene/resources/convex_polygon_shape_2d.h"
 #include "scene/resources/tile_set.h"
 
 class AutotileEditorHelper;
@@ -70,7 +70,7 @@ class AutotileEditor : public Control {
 		SHAPE_CREATE_FROM_BITMASK,
 		SHAPE_CREATE_FROM_NOT_BITMASK,
 		SHAPE_KEEP_INSIDE_TILE,
-		SHAPE_SNAP_TO_BITMASK_GRID,
+		SHAPE_GRID_SNAP,
 		ZOOM_OUT,
 		ZOOM_1,
 		ZOOM_IN,
@@ -78,7 +78,7 @@ class AutotileEditor : public Control {
 	};
 
 	Ref<TileSet> tile_set;
-	Ref<ConcavePolygonShape2D> edited_collision_shape;
+	Ref<ConvexPolygonShape2D> edited_collision_shape;
 	Ref<OccluderPolygon2D> edited_occlusion_shape;
 	Ref<NavigationPolygon> edited_navigation_shape;
 
@@ -91,9 +91,20 @@ class AutotileEditor : public Control {
 	Button *tool_editmode[EDITMODE_MAX];
 	HBoxContainer *tool_containers[TOOLBAR_MAX];
 	HBoxContainer *toolbar;
+	HBoxContainer *hb_grid;
 	ToolButton *tools[TOOL_MAX];
 	SpinBox *spin_priority;
+	SpinBox *sb_step_y;
+	SpinBox *sb_step_x;
+	SpinBox *sb_off_y;
+	SpinBox *sb_off_x;
+	SpinBox *sb_sep_y;
+	SpinBox *sb_sep_x;
 	EditMode edit_mode;
+
+	Vector2 snap_step;
+	Vector2 snap_offset;
+	Vector2 snap_separation;
 
 	bool creating_shape;
 	int dragging_point;
@@ -119,9 +130,16 @@ private:
 	void _on_workspace_input(const Ref<InputEvent> &p_ie);
 	void _on_tool_clicked(int p_tool);
 	void _on_priority_changed(float val);
+	void _on_grid_snap_toggled(bool p_val);
+	void _set_snap_step_x(float p_val);
+	void _set_snap_step_y(float p_val);
+	void _set_snap_off_x(float p_val);
+	void _set_snap_off_y(float p_val);
+	void _set_snap_sep_x(float p_val);
+	void _set_snap_sep_y(float p_val);
 
 	void draw_highlight_tile(Vector2 coord, const Vector<Vector2> &other_highlighted = Vector<Vector2>());
-	void draw_grid(const Vector2 &size, int spacing);
+	void draw_grid_snap();
 	void draw_polygon_shapes();
 	void close_shape(const Vector2 &shape_anchor);
 	Vector2 snap_point(const Vector2 &point);


### PR DESCRIPTION
Changes :
- [x] Fix : https://github.com/godotengine/godot/issues/14890
- [x] Collision now using ConvexPolygonShape2D
- [x] Grid Snapping

Next :
- [ ] Sprite Region Visual Editor for regular tile (?)
- [ ] Collision Editor for regular tile (?)
- [ ] Navigation Editor for regular tile (?)
- [ ] Occlusion Editor for regular tile (?)
- [ ] Tile Animation (?)

About ConvexPolygonShape2D
1. When creating collision shape, make sure the direction is clockwise. Counter-clockwise makes collider not working
2. Must be more than equal (>=) 3 points.

<b>Important</b>
According to change of collision type, remove your old tile (which is contains concave collider) to avoid any crashes.

![preview](https://user-images.githubusercontent.com/8519218/34401787-06be239a-ebd0-11e7-9c0c-41c86eb961a2.gif)

![grid_snap](https://user-images.githubusercontent.com/8519218/34417388-d2100748-ec2a-11e7-9d40-c79d9d0f94fe.gif)
