### PR TITLE
Fix TreeItem cell text alignment

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1009,10 +1009,10 @@ void Tree::draw_item_rect(const TreeItem::Cell &p_cell, const Rect2i &p_rect, co
 		case TreeItem::ALIGN_LEFT:
 			break; //do none
 		case TreeItem::ALIGN_CENTER:
-			rect.position.x = MAX(0, (rect.size.width - w) / 2);
+			rect.position.x += MAX(0, (rect.size.width - w) / 2);
 			break; //do none
 		case TreeItem::ALIGN_RIGHT:
-			rect.position.x = MAX(0, (rect.size.width - w));
+			rect.position.x += MAX(0, (rect.size.width - w));
 			break; //do none
 	}
 


### PR DESCRIPTION
Fix TreeItem cell set_text_align using ALIGN_CENTER and ALIGN_RIGHT.

![table](https://user-images.githubusercontent.com/25857669/34409407-c5b02562-ec1d-11e7-9128-38848cf88639.png)
