### PR TITLE
Fix AnimationPlayer redundantly signaling finish (2.1)

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -527,12 +527,14 @@ void AnimationPlayer::_animation_process_data(PlaybackData &cd, float p_delta, f
 
 			if (!backwards && cd.pos <= len && next_pos == len /*&& playback.blend.empty()*/) {
 				//playback finished
-				end_notify = true;
+				end_reached = true;
+				end_notify = cd.pos < len; // Notify only if not already at the end
 			}
 
 			if (backwards && cd.pos >= 0 && next_pos == 0 /*&& playback.blend.empty()*/) {
 				//playback finished
-				end_notify = true;
+				end_reached = true;
+				end_notify = cd.pos > 0; // Notify only if not already at the beginning
 			}
 		}
 
@@ -676,24 +678,26 @@ void AnimationPlayer::_animation_process(float p_delta) {
 
 	if (playback.current.from) {
 
+		end_reached = false;
 		end_notify = false;
 		_animation_process2(p_delta);
 		_animation_update_transforms();
-		if (end_notify) {
+		if (end_reached) {
 			if (queued.size()) {
 				String old = playback.assigned;
 				play(queued.front()->get());
 				String new_name = playback.assigned;
 				queued.pop_front();
-				end_notify = false;
-				emit_signal(SceneStringNames::get_singleton()->animation_changed, old, new_name);
+				if (end_notify)
+					emit_signal(SceneStringNames::get_singleton()->animation_changed, old, new_name);
 			} else {
 				//stop();
 				playing = false;
 				_set_process(false);
-				end_notify = false;
-				emit_signal(SceneStringNames::get_singleton()->finished);
+				if (end_notify)
+					emit_signal(SceneStringNames::get_singleton()->finished);
 			}
+			end_reached = false;
 		}
 
 	} else {
@@ -953,7 +957,7 @@ void AnimationPlayer::play(const StringName &p_name, float p_custom_blend, float
 	c.current.speed_scale = p_custom_scale;
 	c.assigned = p_name;
 
-	if (!end_notify)
+	if (!end_reached)
 		queued.clear();
 	_set_process(true); // always process when starting an animation
 	playing = true;
@@ -1291,7 +1295,7 @@ AnimationPlayer::AnimationPlayer() {
 	cache_update_size = 0;
 	cache_update_prop_size = 0;
 	speed_scale = 1;
-	end_notify = false;
+	end_reached = false;
 	animation_process_mode = ANIMATION_PROCESS_IDLE;
 	processing = false;
 	default_blend_time = 0;

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -187,6 +187,7 @@ private:
 
 	List<StringName> queued;
 
+	bool end_reached;
 	bool end_notify;
 
 	String autoplay;


### PR DESCRIPTION
Now it will emit only when actually going from not-finished-yet to finished, as has always been the case.

The bug was a side effect of a0a9363b7a2d4bd70477857beaed96e9c20e9cfc.