### PR TITLE
Fix AnimationPlayer redundantly signaling finish

### DIFF
--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -205,6 +205,7 @@ private:
 
 	List<StringName> queued;
 
+	bool end_reached;
 	bool end_notify;
 
 	String autoplay;


### PR DESCRIPTION
Now it will emit only when actually going from not-finished-yet to finished, as has always been the case.

The bug was a side effect of 2d2467c0ff8ba05f492cefef3adbcd5513bbd8dd.