### PR TITLE
Made the Create Dialog be clearer when it's changing a type of something

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -37,7 +37,7 @@
 #include "print_string.h"
 #include "scene/gui/box_container.h"
 
-void CreateDialog::popup_create(bool p_dontclear) {
+void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode) {
 
 	recent->clear();
 
@@ -89,11 +89,12 @@ void CreateDialog::popup_create(bool p_dontclear) {
 		popup_centered_ratio();
 	}
 
-	if (p_dontclear)
+	if (p_dont_clear) {
 		search_box->select_all();
-	else {
+	} else {
 		search_box->clear();
 	}
+
 	search_box->grab_focus();
 
 	_update_search();
@@ -104,8 +105,19 @@ void CreateDialog::popup_create(bool p_dontclear) {
 	if (enable_rl) {
 		search_options->add_constant_override("draw_relationship_lines", 1);
 		search_options->add_color_override("relationship_line_color", rl_color);
-	} else
+	} else {
 		search_options->add_constant_override("draw_relationship_lines", 0);
+	}
+
+	is_replace_mode = p_replace_mode;
+
+	if (p_replace_mode) {
+		set_title(vformat(TTR("Change %s Type"), base_type));
+		get_ok()->set_text(TTR("Change"));
+	} else {
+		set_title(vformat(TTR("Create New %s"), base_type));
+		get_ok()->set_text(TTR("Create"));
+	}
 }
 
 void CreateDialog::_text_changed(const String &p_newtext) {
@@ -369,7 +381,11 @@ void CreateDialog::_notification(int p_what) {
 void CreateDialog::set_base_type(const String &p_base) {
 
 	base_type = p_base;
-	set_title(vformat(TTR("Create New %s"), p_base));
+	if (is_replace_mode)
+		set_title(vformat(TTR("Change %s Type"), p_base));
+	else
+		set_title(vformat(TTR("Create New %s"), p_base));
+
 	_update_search();
 }
 
@@ -624,6 +640,8 @@ void CreateDialog::_bind_methods() {
 
 CreateDialog::CreateDialog() {
 
+	is_replace_mode = false;
+
 	ClassDB::get_class_list(&type_list);
 	type_list.sort_custom<StringName::AlphCompare>();
 
@@ -678,7 +696,6 @@ CreateDialog::CreateDialog() {
 	search_box->connect("gui_input", this, "_sbox_input");
 	search_options = memnew(Tree);
 	vbc->add_margin_child(TTR("Matches:"), search_options, true);
-	get_ok()->set_text(TTR("Create"));
 	get_ok()->set_disabled(true);
 	register_text_enter(search_box);
 	set_hide_on_ok(false);

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -52,6 +52,7 @@ class CreateDialog : public ConfirmationDialog {
 	Button *favorite;
 	LineEdit *search_box;
 	Tree *search_options;
+	bool is_replace_mode;
 	String base_type;
 	String preferred_search_result_type;
 	EditorHelpBit *help_bit;
@@ -97,7 +98,7 @@ public:
 	void set_preferred_search_result_type(const String &p_preferred_type);
 	String get_preferred_search_result_type();
 
-	void popup_create(bool p_dontclear);
+	void popup_create(bool p_dont_clear, bool p_replace_mode = false);
 
 	CreateDialog();
 };

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -307,7 +307,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 		} break;
 		case TOOL_REPLACE: {
 
-			create_dialog->popup_create(false);
+			create_dialog->popup_create(false, true);
 		} break;
 		case TOOL_ATTACH_SCRIPT: {
 
@@ -417,7 +417,6 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			if (editor_selection->is_selected(edited_scene)) {
 
 				current_option = -1;
-				//accept->get_cancel()->hide();
 				accept->get_ok()->set_text(TTR("I see.."));
 				accept->set_text(TTR("This operation can't be done on the tree root."));
 				accept->popup_centered_minsize();


### PR DESCRIPTION
Basically only used for Node changing, as is the only place I'm aware that you can do that.

![screenshot at 2017-12-28 22-50-15](https://user-images.githubusercontent.com/30739239/34426813-8f0e9f12-ec21-11e7-8055-a17821c619a5.png)
![screenshot at 2017-12-28 22-50-26](https://user-images.githubusercontent.com/30739239/34426814-8f352f88-ec21-11e7-95f2-80cc88504c80.png)