### PR TITLE
Use different x11 WM_CLASS for the editor

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -2332,7 +2332,7 @@ void OS_X11::set_context(int p_context) {
 			classHint->res_name = (char *)"Godot_Editor";
 		if (p_context == CONTEXT_PROJECTMAN)
 			classHint->res_name = (char *)"Godot_ProjectList";
-		classHint->res_class = (char *)"Godot";
+		classHint->res_class = (char *)"Godot_Editor";
 		XSetClassHint(x11_display, x11_window, classHint);
 		XFree(classHint);
 	}


### PR DESCRIPTION
Brings 2 separate icons for the editor and the 'played' project
in the OS Launcher. 

Fixes #15130 ??
Please review, I don't have this problem myself.

