### PR TITLE
Fix Tween follow not working [2.1]

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -557,56 +557,50 @@ void Tween::_tween_process(float p_delta) {
 			data.finish = true;
 		}
 
-		switch (data.type) {
-			case INTER_PROPERTY:
-			case INTER_METHOD: {
-				Variant result = _run_equation(data);
-				emit_signal("tween_step", object, data.key, data.elapsed, result);
-				_apply_tween_value(data, result);
-				if (data.finish)
-					_apply_tween_value(data, data.final_val);
-			} break;
+		if (data.type == INTER_CALLBACK) {
+			if (data.finish) {
+				if (data.call_deferred) {
 
-			case INTER_CALLBACK:
-				if (data.finish) {
-					if (data.call_deferred) {
-
-						switch (data.args) {
-							case 0:
-								object->call_deferred(data.key);
-								break;
-							case 1:
-								object->call_deferred(data.key, data.arg[0]);
-								break;
-							case 2:
-								object->call_deferred(data.key, data.arg[0], data.arg[1]);
-								break;
-							case 3:
-								object->call_deferred(data.key, data.arg[0], data.arg[1], data.arg[2]);
-								break;
-							case 4:
-								object->call_deferred(data.key, data.arg[0], data.arg[1], data.arg[2], data.arg[3]);
-								break;
-							case 5:
-								object->call_deferred(data.key, data.arg[0], data.arg[1], data.arg[2], data.arg[3], data.arg[4]);
-								break;
-						}
-					} else {
-						Variant::CallError error;
-						Variant *arg[5] = {
-							&data.arg[0],
-							&data.arg[1],
-							&data.arg[2],
-							&data.arg[3],
-							&data.arg[4],
-						};
-						object->call(data.key, (const Variant **)arg, data.args, error);
+					switch (data.args) {
+						case 0:
+							object->call_deferred(data.key);
+							break;
+						case 1:
+							object->call_deferred(data.key, data.arg[0]);
+							break;
+						case 2:
+							object->call_deferred(data.key, data.arg[0], data.arg[1]);
+							break;
+						case 3:
+							object->call_deferred(data.key, data.arg[0], data.arg[1], data.arg[2]);
+							break;
+						case 4:
+							object->call_deferred(data.key, data.arg[0], data.arg[1], data.arg[2], data.arg[3]);
+							break;
+						case 5:
+							object->call_deferred(data.key, data.arg[0], data.arg[1], data.arg[2], data.arg[3], data.arg[4]);
+							break;
 					}
+				} else {
+					Variant::CallError error;
+					Variant *arg[5] = {
+						&data.arg[0],
+						&data.arg[1],
+						&data.arg[2],
+						&data.arg[3],
+						&data.arg[4],
+					};
+					object->call(data.key, (const Variant **)arg, data.args, error);
 				}
-				break;
+			}
+		} else {
+			Variant result = _run_equation(data);
+			emit_signal("tween_step", object, data.key, data.elapsed, result);
+			_apply_tween_value(data, result);
 		}
 
 		if (data.finish) {
+			_apply_tween_value(data, data.final_val);
 			emit_signal("tween_complete", object, data.key);
 			// not repeat mode, remove completed action
 			if (!repeat)


### PR DESCRIPTION
Fix regression from 01ef7a73de46236c4b0cd0e7853f9d3c91768111

original code looks a little bit weird, but anyway
```cpp
Variant result = _run_equation(data);
emit_signal("tween_step", object, data.key, data.elapsed, result);
_apply_tween_value(data, result);
```
this codes run on all kind of `data.type` but except `INTER_CALLBACK`

```cpp
enum InterpolateType {
		INTER_PROPERTY,
		INTER_METHOD,
		FOLLOW_PROPERTY,
		FOLLOW_METHOD,
		TARGETING_PROPERTY,
		TARGETING_METHOD,
		INTER_CALLBACK,
	};
```

but after 01ef7a73de46236c4b0cd0e7853f9d3c91768111,
only `_apply_tween_value` is called only `INTER_PROPERTY`, `INTER_METHOD` cases

This PR make following works again, and call callback successfully.
here is test code.

```gdscript
func _ready():
	test_tween()

func test_tween():
	var tween = Tween.new()
	tween.interpolate_callback(self, 1, "dummy")
	add_child(tween)
	tween.start()
	tween.connect("tween_complete", self, "_on_tween_complete", [tween])

func dummy():
	print("called dummy")

func _on_tween_complete(obj, key, tween):
	print("_on_tween_complete", obj, key)
	tween.queue_free()
```

possibly fix what https://github.com/godotengine/godot/issues/8752#issuecomment-348679007 said