### PR TITLE
Windows MSVC intellisense - sourcetrail fix.

### DIFF
--- a/modules/bullet/SCsub
+++ b/modules/bullet/SCsub
@@ -192,4 +192,9 @@ env_bullet.add_source_files(env.modules_sources, bullet_sources)
 # Godot source files
 env_bullet.add_source_files(env.modules_sources, "*.cpp")
 
+# Msvc Intellisense needs to know bullet is available, pass to main env
+if "platform" in env and env["platform"] == "windows":
+    env.Append(CPPPATH=env_bullet['CPPPATH'])
+    env.Append(CPPFLAGS=env_bullet['CPPFLAGS'])
+
 Export('env')

--- a/modules/enet/SCsub
+++ b/modules/enet/SCsub
@@ -25,4 +25,11 @@ if env['builtin_enet']:
     env_enet.Append(CPPPATH=[thirdparty_dir])
     env_enet.Append(CPPFLAGS=["-DGODOT_ENET"])
 
+    # Msvc Intellisense needs to know enet is available, pass to main env
+    if "platform" in env and env["platform"] == "windows":
+        env.Append(CPPPATH=env_enet['CPPPATH'])
+        env.Append(CPPFLAGS=env_enet['CPPFLAGS'])
+
 env_enet.add_source_files(env.modules_sources, "*.cpp")
+
+Export('env')

--- a/modules/etc/SCsub
+++ b/modules/etc/SCsub
@@ -40,3 +40,10 @@ if (not env_etc.msvc):
 # GCC and Clang
 if '-ffast-math' in env_etc['CCFLAGS']:
 	env_etc['CCFLAGS'].remove('-ffast-math')
+
+# Msvc Intellisense needs to know etc is available, pass to main env
+if "platform" in env and env["platform"] == "windows":
+    env.Append(CPPPATH=env_etc['CPPPATH'])
+    env.Append(CPPFLAGS=env_etc['CPPFLAGS'])
+
+Export('env')

--- a/modules/gdnative/SCsub
+++ b/modules/gdnative/SCsub
@@ -12,6 +12,13 @@ gdn_env.add_source_files(env.modules_sources, "gdnative_library_editor_plugin.cp
 
 gdn_env.Append(CPPPATH=['#modules/gdnative/include/'])
 
+# Msvc Intellisense needs to know gdn is available, pass to main env
+if "platform" in env and env["platform"] == "windows":
+    env.Append(CPPPATH=gdn_env['CPPPATH'])
+    env.Append(CPPFLAGS=gdn_env['CPPFLAGS'])
+
+Export('env')
+
 SConscript("arvr/SCsub")
 SConscript("pluginscript/SCsub")
 

--- a/modules/jpg/SCsub
+++ b/modules/jpg/SCsub
@@ -18,3 +18,11 @@ env_jpg.Append(CPPPATH=[thirdparty_dir])
 
 # Godot's own source files
 env_jpg.add_source_files(env.modules_sources, "*.cpp")
+
+# Msvc Intellisense needs to know jpg is available, pass to main env
+if "platform" in env and env["platform"] == "windows":
+    env.Append(CPPPATH=env_jpg['CPPPATH'])
+    env.Append(CPPFLAGS=env_jpg['CPPFLAGS'])
+
+Export('env')
+

--- a/modules/openssl/SCsub
+++ b/modules/openssl/SCsub
@@ -693,4 +693,9 @@ if "platform" in env and env["platform"] == "uwp":
     env.Append(CPPPATH=[thirdparty_dir])
     env.Append(CPPFLAGS=['-DOPENSSL_ENABLED'])
 
+# Msvc Intellisense needs to know openssl is available, pass to main env
+if "platform" in env and env["platform"] == "windows":
+    env.Append(CPPPATH=env_openssl['CPPPATH'])
+    env.Append(CPPFLAGS=env_openssl['CPPFLAGS'])
+
 Export('env')

--- a/modules/opus/SCsub
+++ b/modules/opus/SCsub
@@ -221,3 +221,10 @@ if not stub:
 else:
     # Module files
     env_opus.add_source_files(env.modules_sources, "stub/register_types.cpp")
+
+# Msvc Intellisense needs to know opus is available, pass to main env
+if "platform" in env and env["platform"] == "windows":
+    env.Append(CPPPATH=env_opus['CPPPATH'])
+    env.Append(CPPFLAGS=env_opus['CPPFLAGS'])
+
+Export('env')

--- a/modules/pvr/SCsub
+++ b/modules/pvr/SCsub
@@ -22,3 +22,10 @@ env_pvr.Append(CPPPATH=[thirdparty_dir])
 
 # Godot source files
 env_pvr.add_source_files(env.modules_sources, "*.cpp")
+
+# Msvc Intellisense needs to know pvr is available, pass to main env
+if "platform" in env and env["platform"] == "windows":
+    env.Append(CPPPATH=env_pvr['CPPPATH'])
+    env.Append(CPPFLAGS=env_pvr['CPPFLAGS'])
+
+Export('env')

--- a/modules/regex/SCsub
+++ b/modules/regex/SCsub
@@ -51,3 +51,10 @@ if env['builtin_pcre2']:
         env_pcre2.Append(CPPFLAGS=["-DPCRE2_CODE_UNIT_WIDTH=" + width])
     pcre2_builtin("16")
     pcre2_builtin("32")
+
+    # Msvc Intellisense needs to know regex is available, pass to main env
+    if "platform" in env and env["platform"] == "windows":
+        env.Append(CPPPATH=env_regex['CPPPATH'])
+        env.Append(CPPFLAGS=env_regex['CPPFLAGS'])
+
+    Export('env')

--- a/modules/squish/SCsub
+++ b/modules/squish/SCsub
@@ -27,3 +27,10 @@ if env['builtin_squish']:
 
 # Godot source files
 env_squish.add_source_files(env.modules_sources, "*.cpp")
+
+# Msvc Intellisense needs to know squish is available, pass to main env
+if "platform" in env and env["platform"] == "windows":
+    env.Append(CPPPATH=env_squish['CPPPATH'])
+    env.Append(CPPFLAGS=env_squish['CPPFLAGS'])
+
+Export('env')

--- a/modules/thekla_unwrap/SCsub
+++ b/modules/thekla_unwrap/SCsub
@@ -69,6 +69,12 @@ if env['builtin_thekla_atlas']:
         else:
             env_thekla_unwrap.Append(CCFLAGS=["-DNV_OS_MINGW", "-DNV_CC_GNUC", "-DPOSH_COMPILER_GCC", "-U__STRICT_ANSI__"])
             env.Append(LIBS=["dbghelp"])
+    # Msvc Intellisense needs to know thekla_unwrap is available, pass to main env
+    if "platform" in env and env["platform"] == "windows":
+        env.Append(CPPPATH=env_thekla_unwrap['CPPPATH'])
+        env.Append(CPPFLAGS=env_thekla_unwrap['CPPFLAGS'])
         
 # Godot source files
 env_thekla_unwrap.add_source_files(env.modules_sources, "*.cpp")
+
+Export('env')

--- a/modules/theora/SCsub
+++ b/modules/theora/SCsub
@@ -78,6 +78,14 @@ if env['builtin_libtheora']:
         env_theora.Append(CPPPATH=["#thirdparty/libogg"])
     if env['builtin_libvorbis']:
         env_theora.Append(CPPPATH=["#thirdparty/libvorbis"])
+    
+    # Msvc Intellisense needs to know theora is available, pass to main env
+    if "platform" in env and env["platform"] == "windows":
+        env.Append(CPPPATH=env_theora['CPPPATH'])
+        env.Append(CPPFLAGS=env_theora['CPPFLAGS'])
+    
+    Export('env')
 
 # Godot source files
 env_theora.add_source_files(env.modules_sources, "*.cpp")
+

--- a/modules/vorbis/SCsub
+++ b/modules/vorbis/SCsub
@@ -53,3 +53,10 @@ if not stub:
 else:
     # Module files
     env_vorbis.add_source_files(env.modules_sources, "stub/register_types.cpp")
+
+# Msvc Intellisense needs to know vorbis is available, pass to main env
+if "platform" in env and env["platform"] == "windows":
+    env.Append(CPPPATH=env_vorbis['CPPPATH'])
+    env.Append(CPPFLAGS=env_vorbis['CPPFLAGS'])
+
+Export('env')

--- a/modules/webm/SCsub
+++ b/modules/webm/SCsub
@@ -30,5 +30,10 @@ if env['builtin_libvpx']:
     Export('env_webm')
     SConscript("libvpx/SCsub")
 
+# Msvc Intellisense needs to know webm is available, pass to main env
+if "platform" in env and env["platform"] == "windows":
+    env.Append(CPPPATH=env_webm['CPPPATH'])
+    env.Append(CPPFLAGS=env_webm['CPPFLAGS'])
+
 # Godot source files
 env_webm.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/webp/SCsub
+++ b/modules/webp/SCsub
@@ -128,5 +128,12 @@ if env['builtin_libwebp']:
     env_webp.add_source_files(env.modules_sources, thirdparty_sources)
     env_webp.Append(CPPPATH=[thirdparty_dir, thirdparty_dir + "src/"])
 
+    # Msvc Intellisense needs to know webp is available, pass to main env
+    if "platform" in env and env["platform"] == "windows":
+        env.Append(CPPPATH=env_webp['CPPPATH'])
+        env.Append(CPPFLAGS=env_webp['CPPFLAGS'])
+    
+    Export('env')
+
 # Godot source files
 env_webp.add_source_files(env.modules_sources, "*.cpp")


### PR DESCRIPTION
Fix scons scripts so that sourcetrail / intellisense has the paths of the includes for compiling. This is required for proper scanning of godot source code.

https://www.sourcetrail.com/

@Listwon Can you review this?

![sourcetrail_2017-12-29_10-33-17](https://user-images.githubusercontent.com/32321/34444546-b6df8b34-ec83-11e7-80a9-3fbeddff00fb.png)

