### PR TITLE
Improve : ease of use TileSet Editor

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.h
+++ b/editor/plugins/tile_set_editor_plugin.h
@@ -86,6 +86,7 @@ class AutotileEditor : public Control {
 
 	int current_item_index;
 	Sprite *preview;
+	ScrollContainer *scroll;
 	Control *workspace_container;
 	Control *workspace;
 	Button *tool_editmode[EDITMODE_MAX];


### PR DESCRIPTION
Changes :
1. Revert collision points when the direction is counter-clockwise.
2. Dragging middle mouse will scrolling workspace.
3. Fix bug deleting shape while editing another type shape