### PR TITLE
Fix errors with custom theme and custom font in project settings.

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -65,7 +65,9 @@ void EditorLog::_notification(int p_what) {
 		Ref<DynamicFont> df_output_code = get_font("output_source", "EditorFonts");
 		if (df_output_code.is_valid()) {
 			df_output_code->set_size(int(EDITOR_DEF("run/output/font_size", 13)) * EDSCALE);
-			log->add_font_override("normal_font", get_font("output_source", "EditorFonts"));
+			if (log != NULL) {
+				log->add_font_override("normal_font", get_font("output_source", "EditorFonts"));
+			}
 		}
 	}
 

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -332,6 +332,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Color font_color = mono_color.linear_interpolate(base_color, 0.25);
 	const Color font_color_hl = mono_color.linear_interpolate(base_color, 0.15);
 	const Color font_color_disabled = Color(mono_color.r, mono_color.g, mono_color.b, 0.3);
+	const Color font_color_selection = Color::html("#7d7d7d");
 	const Color color_disabled = mono_color.inverted().linear_interpolate(base_color, 0.7);
 	const Color color_disabled_bg = mono_color.inverted().linear_interpolate(base_color, 0.9);
 
@@ -790,6 +791,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("read_only", "LineEdit", font_color_disabled);
 	theme->set_color("font_color", "LineEdit", font_color);
 	theme->set_color("cursor_color", "LineEdit", font_color);
+	theme->set_color("selection_color", "LineEdit", font_color_selection);
 
 	// TextEdit
 	theme->set_stylebox("normal", "TextEdit", style_widget);
@@ -799,6 +801,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("tab", "TextEdit", theme->get_icon("GuiTab", "EditorIcons"));
 	theme->set_color("font_color", "TextEdit", font_color);
 	theme->set_color("caret_color", "TextEdit", highlight_color);
+	theme->set_color("selection_color", "TextEdit", font_color_selection);
 
 	// H/VSplitContainer
 	theme->set_stylebox("bg", "VSplitContainer", make_stylebox(theme->get_icon("GuiVsplitBg", "EditorIcons"), 1, 1, 1, 1));

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -220,31 +220,17 @@ void register_scene_types() {
 	resource_loader_theme = memnew(ResourceFormatLoaderTheme);
 	ResourceLoader::add_resource_format_loader(resource_loader_theme);
 
-	bool default_theme_hidpi = GLOBAL_DEF("gui/theme/use_hidpi", false);
-	ProjectSettings::get_singleton()->set_custom_property_info("gui/theme/use_hidpi", PropertyInfo(Variant::BOOL, "gui/theme/use_hidpi", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED));
-	String theme_path = GLOBAL_DEF("gui/theme/custom", "");
-	ProjectSettings::get_singleton()->set_custom_property_info("gui/theme/custom", PropertyInfo(Variant::STRING, "gui/theme/custom", PROPERTY_HINT_FILE, "*.tres,*.res", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED));
-	String font_path = GLOBAL_DEF("gui/theme/custom_font", "");
-	ProjectSettings::get_singleton()->set_custom_property_info("gui/theme/custom_font", PropertyInfo(Variant::STRING, "gui/theme/custom_font", PROPERTY_HINT_FILE, "*.tres,*.res,*.font", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED));
+	resource_saver_text = memnew(ResourceFormatSaverText);
+	ResourceSaver::add_resource_format_saver(resource_saver_text, true);
 
-	bool has_theme = false;
-	if (theme_path != String()) {
-		Ref<Theme> theme = ResourceLoader::load(theme_path);
-		if (theme.is_valid()) {
-			Theme::set_default(theme);
-			has_theme = true;
-		} else {
-			ERR_PRINTS("Error loading custom theme '" + theme_path + "'");
-		}
-	}
+	resource_loader_text = memnew(ResourceFormatLoaderText);
+	ResourceLoader::add_resource_format_loader(resource_loader_text, true);
 
-	if (!has_theme) {
-		Ref<Font> font;
-		if (font_path != String()) {
-			font = ResourceLoader::load(font_path);
-		}
-		make_default_theme(default_theme_hidpi, font);
-	}
+	resource_saver_shader = memnew(ResourceFormatSaverShader);
+	ResourceSaver::add_resource_format_saver(resource_saver_shader, true);
+
+	resource_loader_shader = memnew(ResourceFormatLoaderShader);
+	ResourceLoader::add_resource_format_loader(resource_loader_shader, true);
 
 	OS::get_singleton()->yield(); //may take time to init
 
@@ -604,23 +590,41 @@ void register_scene_types() {
 
 	OS::get_singleton()->yield(); //may take time to init
 
-	resource_saver_text = memnew(ResourceFormatSaverText);
-	ResourceSaver::add_resource_format_saver(resource_saver_text, true);
-
-	resource_loader_text = memnew(ResourceFormatLoaderText);
-	ResourceLoader::add_resource_format_loader(resource_loader_text, true);
-
-	resource_saver_shader = memnew(ResourceFormatSaverShader);
-	ResourceSaver::add_resource_format_saver(resource_saver_shader, true);
-
-	resource_loader_shader = memnew(ResourceFormatLoaderShader);
-	ResourceLoader::add_resource_format_loader(resource_loader_shader, true);
-
 	for (int i = 0; i < 20; i++) {
 		GLOBAL_DEF("layer_names/2d_render/layer_" + itos(i + 1), "");
 		GLOBAL_DEF("layer_names/2d_physics/layer_" + itos(i + 1), "");
 		GLOBAL_DEF("layer_names/3d_render/layer_" + itos(i + 1), "");
 		GLOBAL_DEF("layer_names/3d_physics/layer_" + itos(i + 1), "");
+	}
+
+	bool default_theme_hidpi = GLOBAL_DEF("gui/theme/use_hidpi", false);
+	ProjectSettings::get_singleton()->set_custom_property_info("gui/theme/use_hidpi", PropertyInfo(Variant::BOOL, "gui/theme/use_hidpi", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED));
+	String theme_path = GLOBAL_DEF("gui/theme/custom", "");
+	ProjectSettings::get_singleton()->set_custom_property_info("gui/theme/custom", PropertyInfo(Variant::STRING, "gui/theme/custom", PROPERTY_HINT_FILE, "*.tres,*.res,*.theme", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED));
+	String font_path = GLOBAL_DEF("gui/theme/custom_font", "");
+	ProjectSettings::get_singleton()->set_custom_property_info("gui/theme/custom_font", PropertyInfo(Variant::STRING, "gui/theme/custom_font", PROPERTY_HINT_FILE, "*.tres,*.res,*.font", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED));
+
+	Ref<Font> font;
+	if (font_path != String()) {
+		font = ResourceLoader::load(font_path);
+		if (!font.is_valid()) {
+			ERR_PRINTS("Error loading custom font '" + font_path + "'");
+		}
+	}
+
+	// Always make the default theme to avoid invalid default font/icon/style in the given theme
+	make_default_theme(default_theme_hidpi, font);
+
+	if (theme_path != String()) {
+		Ref<Theme> theme = ResourceLoader::load(theme_path);
+		if (theme.is_valid()) {
+			Theme::set_default(theme);
+			if (font.is_valid()) {
+				Theme::set_default_font(font);
+			}
+		} else {
+			ERR_PRINTS("Error loading custom theme '" + theme_path + "'");
+		}
 	}
 }
 

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -880,7 +880,7 @@ void make_default_theme(bool p_hidpi, Ref<Font> p_font) {
 
 	Ref<StyleBox> default_style;
 	Ref<Texture> default_icon;
-	Ref<BitmapFont> default_font;
+	Ref<Font> default_font;
 	if (p_font.is_valid()) {
 		default_font = p_font;
 	} else if (p_hidpi) {
@@ -888,7 +888,7 @@ void make_default_theme(bool p_hidpi, Ref<Font> p_font) {
 	} else {
 		default_font = make_font2(_lodpi_font_height, _lodpi_font_ascent, _lodpi_font_charcount, &_lodpi_font_charrects[0][0], _lodpi_font_kerning_pair_count, &_lodpi_font_kerning_pairs[0][0], _lodpi_font_img_width, _lodpi_font_img_height, _lodpi_font_img_data);
 	}
-	Ref<BitmapFont> large_font = default_font;
+	Ref<Font> large_font = default_font;
 	fill_default_theme(t, default_font, large_font, default_icon, default_style, p_hidpi ? 2.0 : 1.0);
 
 	Theme::set_default(t);


### PR DESCRIPTION
* Load custom theme after required classes are registered to make the custom theme works again.
* Fix crash with dynamic custom font.
* Define text selection color for editor theme so this color don't relys on the default color any more.