### PR TITLE
renames "z" Node2D property to "z_index"

### DIFF
--- a/doc/classes/Node2D.xml
+++ b/doc/classes/Node2D.xml
@@ -157,7 +157,7 @@
 		<member name="transform" type="Transform2D" setter="set_transform" getter="get_transform">
 			Local [Transform2D].
 		</member>
-		<member name="z" type="int" setter="set_z" getter="get_z">
+		<member name="z_index" type="int" setter="set_z_index" getter="get_z_index">
 			Z-index. Controls the order in which the nodes render. A node with a higher Z-index will display in front of others.
 		</member>
 		<member name="z_as_relative" type="bool" setter="set_z_as_relative" getter="is_z_relative">

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -637,7 +637,7 @@ void CanvasItemEditor::_find_canvas_items_at_pos(const Point2 &p_pos, Node *p_no
 
 			_SelectResult res;
 			res.item = c;
-			res.z = node ? node->get_z() : 0;
+			res.z_index = node ? node->get_z_index() : 0;
 			res.has_z = node;
 			r_items.push_back(res);
 		}

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -252,10 +252,10 @@ class CanvasItemEditor : public VBoxContainer {
 	struct _SelectResult {
 
 		CanvasItem *item;
-		float z;
+		float z_index;
 		bool has_z;
 		_FORCE_INLINE_ bool operator<(const _SelectResult &p_rr) const {
-			return has_z && p_rr.has_z ? p_rr.z < z : p_rr.has_z;
+			return has_z && p_rr.has_z ? p_rr.z_index < z_index : p_rr.has_z;
 		}
 	};
 

--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -131,7 +131,7 @@ void CollisionPolygon2D::_notification(int p_what) {
 			/*if (Engine::get_singleton()->is_editor_hint()) {
 				//display above all else
 				set_z_as_relative(false);
-				set_z(VS::CANVAS_ITEM_Z_MAX - 1);
+				set_z_index(VS::CANVAS_ITEM_Z_MAX - 1);
 			}*/
 
 		} break;

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -64,7 +64,7 @@ void CollisionShape2D::_notification(int p_what) {
 			/*if (Engine::get_singleton()->is_editor_hint()) {
 				//display above all else
 				set_z_as_relative(false);
-				set_z(VS::CANVAS_ITEM_Z_MAX - 1);
+				set_z_index(VS::CANVAS_ITEM_Z_MAX - 1);
 			}*/
 
 		} break;

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -329,13 +329,13 @@ void Node2D::set_global_transform(const Transform2D &p_transform) {
 		set_transform(p_transform);
 }
 
-void Node2D::set_z(int p_z) {
+void Node2D::set_z_index(int p_z) {
 
 	ERR_FAIL_COND(p_z < VS::CANVAS_ITEM_Z_MIN);
 	ERR_FAIL_COND(p_z > VS::CANVAS_ITEM_Z_MAX);
-	z = p_z;
-	VS::get_singleton()->canvas_item_set_z(get_canvas_item(), z);
-	_change_notify("z");
+	z_index = p_z;
+	VS::get_singleton()->canvas_item_set_z_index(get_canvas_item(), z_index);
+	_change_notify("z_index");
 }
 
 void Node2D::set_z_as_relative(bool p_enabled) {
@@ -351,9 +351,9 @@ bool Node2D::is_z_relative() const {
 	return z_relative;
 }
 
-int Node2D::get_z() const {
+int Node2D::get_z_index() const {
 
-	return z;
+	return z_index;
 }
 
 Transform2D Node2D::get_relative_transform_to_parent(const Node *p_parent) const {
@@ -427,8 +427,8 @@ void Node2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("to_local", "global_point"), &Node2D::to_local);
 	ClassDB::bind_method(D_METHOD("to_global", "local_point"), &Node2D::to_global);
 
-	ClassDB::bind_method(D_METHOD("set_z", "z"), &Node2D::set_z);
-	ClassDB::bind_method(D_METHOD("get_z"), &Node2D::get_z);
+	ClassDB::bind_method(D_METHOD("set_z_index", "z_index"), &Node2D::set_z_index);
+	ClassDB::bind_method(D_METHOD("get_z_index"), &Node2D::get_z_index);
 
 	ClassDB::bind_method(D_METHOD("set_z_as_relative", "enable"), &Node2D::set_z_as_relative);
 	ClassDB::bind_method(D_METHOD("is_z_relative"), &Node2D::is_z_relative);
@@ -448,8 +448,8 @@ void Node2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "global_scale", PROPERTY_HINT_NONE, "", 0), "set_global_scale", "get_global_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM2D, "global_transform", PROPERTY_HINT_NONE, "", 0), "set_global_transform", "get_global_transform");
 
-	ADD_GROUP("Z", "");
-	ADD_PROPERTYNZ(PropertyInfo(Variant::INT, "z", PROPERTY_HINT_RANGE, itos(VS::CANVAS_ITEM_Z_MIN) + "," + itos(VS::CANVAS_ITEM_Z_MAX) + ",1"), "set_z", "get_z");
+	ADD_GROUP("Z Index", "");
+	ADD_PROPERTYNZ(PropertyInfo(Variant::INT, "z_index", PROPERTY_HINT_RANGE, itos(VS::CANVAS_ITEM_Z_MIN) + "," + itos(VS::CANVAS_ITEM_Z_MAX) + ",1"), "set_z_index", "get_z_index");
 	ADD_PROPERTYNO(PropertyInfo(Variant::BOOL, "z_as_relative"), "set_z_as_relative", "is_z_relative");
 }
 
@@ -458,6 +458,6 @@ Node2D::Node2D() {
 	angle = 0;
 	_scale = Vector2(1, 1);
 	_xform_dirty = false;
-	z = 0;
+	z_index = 0;
 	z_relative = true;
 }

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -39,7 +39,7 @@ class Node2D : public CanvasItem {
 	Point2 pos;
 	float angle;
 	Size2 _scale;
-	int z;
+	int z_index;
 	bool z_relative;
 
 	Transform2D _mat;
@@ -96,8 +96,8 @@ public:
 	void set_global_rotation_degrees(float p_degrees);
 	void set_global_scale(const Size2 &p_scale);
 
-	void set_z(int p_z);
-	int get_z() const;
+	void set_z_index(int p_z);
+	int get_z_index() const;
 
 	void look_at(const Vector2 &p_pos);
 	float get_angle_to(const Vector2 &p_pos) const;

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -336,7 +336,7 @@ void TileMap::_update_dirty_quadrants() {
 					debug_canvas_item = vs->canvas_item_create();
 					vs->canvas_item_set_parent(debug_canvas_item, canvas_item);
 					vs->canvas_item_set_z_as_relative_to_parent(debug_canvas_item, false);
-					vs->canvas_item_set_z(debug_canvas_item, VS::CANVAS_ITEM_Z_MAX - 1);
+					vs->canvas_item_set_z_index(debug_canvas_item, VS::CANVAS_ITEM_Z_MAX - 1);
 					q.canvas_items.push_back(debug_canvas_item);
 					prev_debug_canvas_item = debug_canvas_item;
 				}

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1498,7 +1498,7 @@ void TextEdit::_notification(int p_what) {
 			if (OS::get_singleton()->has_virtual_keyboard())
 				OS::get_singleton()->show_virtual_keyboard(get_text(), get_global_rect());
 			if (raised_from_completion) {
-				VisualServer::get_singleton()->canvas_item_set_z(get_canvas_item(), 1);
+				VisualServer::get_singleton()->canvas_item_set_z_index(get_canvas_item(), 1);
 			}
 
 		} break;
@@ -1512,7 +1512,7 @@ void TextEdit::_notification(int p_what) {
 			if (OS::get_singleton()->has_virtual_keyboard())
 				OS::get_singleton()->hide_virtual_keyboard();
 			if (raised_from_completion) {
-				VisualServer::get_singleton()->canvas_item_set_z(get_canvas_item(), 0);
+				VisualServer::get_singleton()->canvas_item_set_z_index(get_canvas_item(), 0);
 			}
 		} break;
 	}
@@ -5001,7 +5001,7 @@ void TextEdit::_confirm_completion() {
 
 void TextEdit::_cancel_code_hint() {
 
-	VisualServer::get_singleton()->canvas_item_set_z(get_canvas_item(), 0);
+	VisualServer::get_singleton()->canvas_item_set_z_index(get_canvas_item(), 0);
 	raised_from_completion = false;
 	completion_hint = "";
 	update();
@@ -5009,7 +5009,7 @@ void TextEdit::_cancel_code_hint() {
 
 void TextEdit::_cancel_completion() {
 
-	VisualServer::get_singleton()->canvas_item_set_z(get_canvas_item(), 0);
+	VisualServer::get_singleton()->canvas_item_set_z_index(get_canvas_item(), 0);
 	raised_from_completion = false;
 	if (!completion_active)
 		return;
@@ -5184,7 +5184,7 @@ void TextEdit::query_code_comple() {
 
 void TextEdit::set_code_hint(const String &p_hint) {
 
-	VisualServer::get_singleton()->canvas_item_set_z(get_canvas_item(), 1);
+	VisualServer::get_singleton()->canvas_item_set_z_index(get_canvas_item(), 1);
 	raised_from_completion = true;
 	completion_hint = p_hint;
 	completion_hint_offset = -0xFFFF;
@@ -5193,7 +5193,7 @@ void TextEdit::set_code_hint(const String &p_hint) {
 
 void TextEdit::code_complete(const Vector<String> &p_strings, bool p_forced) {
 
-	VisualServer::get_singleton()->canvas_item_set_z(get_canvas_item(), 1);
+	VisualServer::get_singleton()->canvas_item_set_z_index(get_canvas_item(), 1);
 	raised_from_completion = true;
 	completion_strings = p_strings;
 	completion_active = true;

--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -102,9 +102,9 @@ void VisualServerCanvas::_render_canvas_item(Item *p_canvas_item, const Transfor
 	}
 
 	if (ci->z_relative)
-		p_z = CLAMP(p_z + ci->z, VS::CANVAS_ITEM_Z_MIN, VS::CANVAS_ITEM_Z_MAX);
+		p_z = CLAMP(p_z + ci->z_index, VS::CANVAS_ITEM_Z_MIN, VS::CANVAS_ITEM_Z_MAX);
 	else
-		p_z = ci->z;
+		p_z = ci->z_index;
 
 	for (int i = 0; i < child_item_count; i++) {
 
@@ -805,14 +805,14 @@ void VisualServerCanvas::canvas_item_set_sort_children_by_y(RID p_item, bool p_e
 
 	canvas_item->sort_y = p_enable;
 }
-void VisualServerCanvas::canvas_item_set_z(RID p_item, int p_z) {
+void VisualServerCanvas::canvas_item_set_z_index(RID p_item, int p_z) {
 
 	ERR_FAIL_COND(p_z < VS::CANVAS_ITEM_Z_MIN || p_z > VS::CANVAS_ITEM_Z_MAX);
 
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
 	ERR_FAIL_COND(!canvas_item);
 
-	canvas_item->z = p_z;
+	canvas_item->z_index = p_z;
 }
 void VisualServerCanvas::canvas_item_set_z_as_relative_to_parent(RID p_item, bool p_enable) {
 

--- a/servers/visual/visual_server_canvas.h
+++ b/servers/visual/visual_server_canvas.h
@@ -39,7 +39,7 @@ public:
 
 		RID parent; // canvas it belongs to
 		List<Item *>::Element *E;
-		int z;
+		int z_index;
 		bool z_relative;
 		bool sort_y;
 		Color modulate;
@@ -53,7 +53,7 @@ public:
 		Item() {
 			children_order_dirty = true;
 			E = NULL;
-			z = 0;
+			z_index = 0;
 			modulate = Color(1, 1, 1, 1);
 			self_modulate = Color(1, 1, 1, 1);
 			sort_y = false;
@@ -187,7 +187,7 @@ public:
 	void canvas_item_add_set_transform(RID p_item, const Transform2D &p_transform);
 	void canvas_item_add_clip_ignore(RID p_item, bool p_ignore);
 	void canvas_item_set_sort_children_by_y(RID p_item, bool p_enable);
-	void canvas_item_set_z(RID p_item, int p_z);
+	void canvas_item_set_z_index(RID p_item, int p_z);
 	void canvas_item_set_z_as_relative_to_parent(RID p_item, bool p_enable);
 	void canvas_item_set_copy_to_backbuffer(RID p_item, bool p_enable, const Rect2 &p_rect);
 

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -586,7 +586,7 @@ public:
 	BIND2(canvas_item_add_set_transform, RID, const Transform2D &)
 	BIND2(canvas_item_add_clip_ignore, RID, bool)
 	BIND2(canvas_item_set_sort_children_by_y, RID, bool)
-	BIND2(canvas_item_set_z, RID, int)
+	BIND2(canvas_item_set_z_index, RID, int)
 	BIND2(canvas_item_set_z_as_relative_to_parent, RID, bool)
 	BIND3(canvas_item_set_copy_to_backbuffer, RID, bool, const Rect2 &)
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -503,7 +503,7 @@ public:
 	FUNC2(canvas_item_add_set_transform, RID, const Transform2D &)
 	FUNC2(canvas_item_add_clip_ignore, RID, bool)
 	FUNC2(canvas_item_set_sort_children_by_y, RID, bool)
-	FUNC2(canvas_item_set_z, RID, int)
+	FUNC2(canvas_item_set_z_index, RID, int)
 	FUNC2(canvas_item_set_z_as_relative_to_parent, RID, bool)
 	FUNC3(canvas_item_set_copy_to_backbuffer, RID, bool, const Rect2 &)
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1611,7 +1611,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("canvas_item_add_set_transform", "item", "transform"), &VisualServer::canvas_item_add_set_transform);
 	ClassDB::bind_method(D_METHOD("canvas_item_add_clip_ignore", "item", "ignore"), &VisualServer::canvas_item_add_clip_ignore);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_sort_children_by_y", "item", "enabled"), &VisualServer::canvas_item_set_sort_children_by_y);
-	ClassDB::bind_method(D_METHOD("canvas_item_set_z", "item", "z"), &VisualServer::canvas_item_set_z);
+	ClassDB::bind_method(D_METHOD("canvas_item_set_z_index", "item", "z_index"), &VisualServer::canvas_item_set_z_index);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_z_as_relative_to_parent", "item", "enabled"), &VisualServer::canvas_item_set_z_as_relative_to_parent);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_copy_to_backbuffer", "item", "enabled", "rect"), &VisualServer::canvas_item_set_copy_to_backbuffer);
 	ClassDB::bind_method(D_METHOD("canvas_item_clear", "item"), &VisualServer::canvas_item_clear);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -847,7 +847,7 @@ public:
 	virtual void canvas_item_add_set_transform(RID p_item, const Transform2D &p_transform) = 0;
 	virtual void canvas_item_add_clip_ignore(RID p_item, bool p_ignore) = 0;
 	virtual void canvas_item_set_sort_children_by_y(RID p_item, bool p_enable) = 0;
-	virtual void canvas_item_set_z(RID p_item, int p_z) = 0;
+	virtual void canvas_item_set_z_index(RID p_item, int p_z) = 0;
 	virtual void canvas_item_set_z_as_relative_to_parent(RID p_item, bool p_enable) = 0;
 	virtual void canvas_item_set_copy_to_backbuffer(RID p_item, bool p_enable, const Rect2 &p_rect) = 0;
 


### PR DESCRIPTION
For #15078, renames `z` Node2D property to `z_index`, making possible to use a `z` variable in scripts.

To check : 

- [x] there is a breaking changes list where I can add this ?
- [ ] must be added an auto correction to change  `z` to `z_index` for current 3.0 projects ? (I tested opening a project with `z` property with the `z_index` build, no crash, only `z` values are lost.
- [x] add it to the 2.1.4 -> 3.0 migration tool (added to the todo list of migration tool)
- [x] update the doc