### PR TITLE
prevent strings from being evaluated to just "true"

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -3213,7 +3213,7 @@ bool SpatialEditorViewport::can_drop_data_fw(const Point2 &p_point, const Varian
 							continue;
 						}
 						memdelete(instanced_scene);
-					} else if (type == "Mesh" || "ArrayMesh" || "PrimitiveMesh") {
+					} else if (type == "Mesh" || type == "ArrayMesh" || type == "PrimitiveMesh") {
 						Ref<Mesh> mesh = ResourceLoader::load(files[i]);
 						if (!mesh.is_valid()) {
 							continue;


### PR DESCRIPTION
Found via [cppcheck](http://cppcheck.sourceforge.net/).  Just a straight string will evaluate to "true", thus this conditional check was always true.