### PR TITLE
fix typo in switch statement

### DIFF
--- a/modules/bullet/bullet_physics_server.cpp
+++ b/modules/bullet/bullet_physics_server.cpp
@@ -121,7 +121,7 @@ RID BulletPhysicsServer::shape_create(ShapeType p_shape) {
 			shape = bulletnew(RayShapeBullet);
 		} break;
 		case SHAPE_CUSTOM:
-		defaul:
+		default:
 			ERR_FAIL_V(RID());
 			break;
 	}


### PR DESCRIPTION
Found via [cppcheck](http://cppcheck.sourceforge.net/).  Typo in switch statement.