### PR TITLE
[WIP] Fix constant assignment in shaders, fixes #15168, fixes #10589

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -2226,24 +2226,54 @@ bool ShaderLanguage::_is_operator_assign(Operator p_op) const {
 	return false;
 }
 
-bool ShaderLanguage::_validate_assign(Node *p_node, const Map<StringName, BuiltInInfo> &p_builtin_types) {
+bool ShaderLanguage::_validate_assign(Node *p_node, const Map<StringName, BuiltInInfo> &p_builtin_types, String *r_message) {
 
 	if (p_node->type == Node::TYPE_OPERATOR) {
 
 		OperatorNode *op = static_cast<OperatorNode *>(p_node);
-		if (op->type == OP_INDEX) {
-			return _validate_assign(op->arguments[0], p_builtin_types);
-		}
-	}
 
-	if (p_node->type == Node::TYPE_VARIABLE) {
+		if (op->op == OP_INDEX) {
+			return _validate_assign(op->arguments[0], p_builtin_types, r_message);
+
+		} else if (_is_operator_assign(op->op)) {
+			//chained assignment
+			return _validate_assign(op->arguments[1], p_builtin_types, r_message);
+
+		} else if (op->op == OP_CALL) {
+			if (r_message)
+				*r_message = "Assignment to function.";
+			return false;
+		}
+
+	} else if (p_node->type == Node::TYPE_MEMBER) {
+
+		MemberNode *member = static_cast<MemberNode *>(p_node);
+		return _validate_assign(member->owner, p_builtin_types, r_message);
+
+	} else if (p_node->type == Node::TYPE_VARIABLE) {
 
 		VariableNode *var = static_cast<VariableNode *>(p_node);
-		if (p_builtin_types.has(var->name) && p_builtin_types[var->name].constant) {
-			return false; //ops not valid
+
+		if (shader->uniforms.has(var->name)) {
+			if (r_message)
+				*r_message = "Assignment to uniform.";
+			return false;
+		}
+
+		if (shader->varyings.has(var->name) && current_function != String("vertex")) {
+			if (r_message)
+				*r_message = "Varyings can only be assigned in vertex function.";
+			return false;
+		}
+
+		if (!(p_builtin_types.has(var->name) && p_builtin_types[var->name].constant)) {
+			return true;
 		}
 	}
-	return true;
+
+	if (r_message)
+		*r_message = "Assignment to constant expression.";
+	return false;
 }
 
 ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, const Map<StringName, BuiltInInfo> &p_builtin_types) {
@@ -3014,10 +3044,14 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 				ERR_FAIL_V(NULL);
 			}
 
-			if (_is_operator_assign(op->op) && !_validate_assign(expression[next_op - 1].node, p_builtin_types)) {
+			if (_is_operator_assign(op->op)) {
 
-				_set_error("Assignment to constant expression.");
-				return NULL;
+				String assign_message;
+				if (!_validate_assign(expression[next_op - 1].node, p_builtin_types, &assign_message)) {
+
+					_set_error(assign_message);
+					return NULL;
+				}
 			}
 
 			if (expression[next_op + 1].is_op) {

--- a/servers/visual/shader_language.h
+++ b/servers/visual/shader_language.h
@@ -614,7 +614,7 @@ private:
 	bool _find_identifier(const BlockNode *p_block, const Map<StringName, BuiltInInfo> &p_builtin_types, const StringName &p_identifier, DataType *r_data_type = NULL, IdentifierType *r_type = NULL);
 
 	bool _is_operator_assign(Operator p_op) const;
-	bool _validate_assign(Node *p_node, const Map<StringName, BuiltInInfo> &p_builtin_types);
+	bool _validate_assign(Node *p_node, const Map<StringName, BuiltInInfo> &p_builtin_types, String *r_message = NULL);
 
 	bool _validate_operator(OperatorNode *p_op, DataType *r_ret_type = NULL);
 


### PR DESCRIPTION
Changes:
- Members of builtin-type constants cannot be assigned.
E.g. `PROJECTION_MATRIX[3].xyz = vec3(0.0);` will error.
- Varyings can only be assigned in the vertex function.
- Uniforms cannot be assigned in shader code (except for default values)
- Functions cannot be assigned to.
- Literals cannot be assigned to.

Needs more testing. Feedback is appreciated :smiley:
