### PR TITLE
Move Project Manager favorite icon back to center.

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1039,9 +1039,9 @@ void ProjectManager::_load_recent_projects() {
 		favorite->set_normal_texture(favorite_icon);
 		if (!is_favorite)
 			favorite->set_modulate(Color(1, 1, 1, 0.2));
-		favorite->set_v_size_flags(SIZE_EXPAND);
 		favorite->connect("pressed", this, "_favorite_pressed", varray(hb));
 		favorite_box->add_child(favorite);
+		favorite_box->set_alignment(BoxContainer::ALIGN_CENTER);
 		hb->add_child(favorite_box);
 
 		TextureRect *tf = memnew(TextureRect);


### PR DESCRIPTION
This patch solves #14989. The `SIZE_EXPAND` flag appeared to have been making the icon expand through the `favorite_box`, preventing any possible centering since it already occupied the entire box's available space, even if not visually. There was no center alignment flag set on the `favorite_box`, either.
