### PR TITLE
Added editor theme contrast and tint settings.

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -286,6 +286,10 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["interface/theme/base_color"] = PropertyInfo(Variant::COLOR, "interface/theme/base_color", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/theme/contrast", 0.25);
 	hints["interface/theme/contrast"] = PropertyInfo(Variant::REAL, "interface/theme/contrast", PROPERTY_HINT_RANGE, "0.01, 1, 0.01");
+	_initial_set("interface/theme/panel_brightness", 1);
+	hints["interface/theme/panel_brightness"] = PropertyInfo(Variant::REAL, "interface/theme/panel_brightness", PROPERTY_HINT_RANGE, "0.5, 1.5, 0.01");
+	_initial_set("interface/theme/font_brightness", 1);
+	hints["interface/theme/font_brightness"] = PropertyInfo(Variant::REAL, "interface/theme/font_brightness", PROPERTY_HINT_RANGE, "0.5, 1.5, 0.01");
 	_initial_set("interface/theme/highlight_tabs", false);
 	_initial_set("interface/theme/border_size", 1);
 	_initial_set("interface/theme/use_graph_node_headers", false);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -248,6 +248,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	Color accent_color = EDITOR_DEF("interface/theme/accent_color", Color::html("#699ce8"));
 	Color base_color = EDITOR_DEF("interface/theme/base_color", Color::html("#323b4f"));
 	float contrast = EDITOR_DEF("interface/theme/contrast", default_contrast);
+	float panel_brightness = EDITOR_DEF("interface/theme/panel_brightness", 1);
+	float font_brightness = EDITOR_DEF("interface/theme/font_brightness", 1);
 
 	int preset = EDITOR_DEF("interface/theme/preset", 0);
 	int icon_font_color_setting = EDITOR_DEF("interface/theme/icon_and_font_color", 0);
@@ -329,8 +331,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Color contrast_color_1 = base_color.linear_interpolate(mono_color, MAX(contrast, default_contrast));
 	const Color contrast_color_2 = base_color.linear_interpolate(mono_color, MAX(contrast * 1.5, default_contrast * 1.5));
 
-	const Color font_color = mono_color.linear_interpolate(base_color, 0.25);
-	const Color font_color_hl = mono_color.linear_interpolate(base_color, 0.15);
+	const Color font_color = mono_color.linear_interpolate(base_color, 0.25 * font_brightness);
+	const Color font_color_hl = mono_color.linear_interpolate(base_color, 0.15 * font_brightness);
 	const Color font_color_disabled = Color(mono_color.r, mono_color.g, mono_color.b, 0.3);
 	const Color color_disabled = mono_color.inverted().linear_interpolate(base_color, 0.7);
 	const Color color_disabled_bg = mono_color.inverted().linear_interpolate(base_color, 0.9);
@@ -338,6 +340,12 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Color separator_color = Color(mono_color.r, mono_color.g, mono_color.b, 0.1);
 
 	const Color highlight_color = Color(mono_color.r, mono_color.g, mono_color.b, 0.2);
+
+	// Panel Colors
+	const Color panel_dark_color_1 = dark_color_1 * panel_brightness;
+	const Color panel_dark_color_2 = dark_color_2 * panel_brightness;
+	const Color panel_dark_color_3 = dark_color_3 * panel_brightness;
+	const Color panel_contrast_color_1 = contrast_color_1 * panel_brightness;
 
 	theme->set_color("accent_color", "Editor", accent_color);
 	theme->set_color("highlight_color", "Editor", highlight_color);
@@ -419,8 +427,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_widget->set_default_margin(MARGIN_TOP, (extra_spacing + default_margin_size) * EDSCALE);
 	style_widget->set_default_margin(MARGIN_RIGHT, (extra_spacing + 6) * EDSCALE);
 	style_widget->set_default_margin(MARGIN_BOTTOM, (extra_spacing + default_margin_size) * EDSCALE);
-	style_widget->set_bg_color(dark_color_1);
-	style_widget->set_border_color_all(dark_color_2);
+	style_widget->set_bg_color(panel_dark_color_1);
+	style_widget->set_border_color_all(panel_dark_color_2);
 
 	Ref<StyleBoxFlat> style_widget_disabled = style_widget->duplicate();
 	style_widget_disabled->set_border_color_all(color_disabled);
@@ -630,8 +638,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	// Tree & ItemList background
 	Ref<StyleBoxFlat> style_tree_bg = style_default->duplicate();
-	style_tree_bg->set_bg_color(dark_color_1);
-	style_tree_bg->set_border_color_all(dark_color_3);
+	style_tree_bg->set_bg_color(panel_dark_color_1);
+	style_tree_bg->set_border_color_all(panel_dark_color_3);
 	theme->set_stylebox("bg", "Tree", style_tree_bg);
 
 	const Color guide_color = Color(mono_color.r, mono_color.g, mono_color.b, 0.05);
@@ -663,7 +671,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_constant("scroll_speed", "Tree", 12);
 
 	Ref<StyleBoxFlat> style_tree_btn = style_default->duplicate();
-	style_tree_btn->set_bg_color(contrast_color_1);
+	style_tree_btn->set_bg_color(panel_contrast_color_1);
 	style_tree_btn->set_border_width_all(0);
 	theme->set_stylebox("button_pressed", "Tree", style_tree_btn);
 
@@ -699,9 +707,9 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	// ItemList
 	Ref<StyleBoxFlat> style_itemlist_bg = style_default->duplicate();
-	style_itemlist_bg->set_bg_color(dark_color_1);
+	style_itemlist_bg->set_bg_color(panel_dark_color_1);
 	style_itemlist_bg->set_border_width_all(border_width);
-	style_itemlist_bg->set_border_color_all(dark_color_3);
+	style_itemlist_bg->set_border_color_all(panel_dark_color_3);
 
 	Ref<StyleBoxFlat> style_itemlist_cursor = style_default->duplicate();
 	style_itemlist_cursor->set_draw_center(false);
@@ -792,6 +800,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("cursor_color", "LineEdit", font_color);
 
 	// TextEdit
+	Ref<StyleBoxFlat> style_textedit_widget = style_widget->duplicate();
+	style_textedit_widget->set_bg_color(panel_dark_color_1);
 	theme->set_stylebox("normal", "TextEdit", style_widget);
 	theme->set_stylebox("focus", "TextEdit", style_widget_hover);
 	theme->set_stylebox("read_only", "TextEdit", style_widget_disabled);
@@ -837,7 +847,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	// complex window, for now only Editor settings and Project settings
 	Ref<StyleBoxFlat> style_complex_window = style_window->duplicate();
-	style_complex_window->set_bg_color(dark_color_2);
+	style_complex_window->set_bg_color(panel_dark_color_2);
 	style_complex_window->set_border_color_all(highlight_tabs ? tab_color : dark_color_2);
 	theme->set_stylebox("panel", "EditorSettingsDialog", style_complex_window);
 	theme->set_stylebox("panel", "ProjectSettingsEditor", style_complex_window);
@@ -889,7 +899,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("headline_color", "EditorHelp", mono_color);
 
 	// Panel
-	theme->set_stylebox("panel", "Panel", make_flat_stylebox(dark_color_1, 6, 4, 6, 4));
+	theme->set_stylebox("panel", "Panel", make_flat_stylebox(panel_dark_color_1, 6, 4, 6, 4));
 
 	// Label
 	theme->set_stylebox("normal", "Label", style_empty);


### PR DESCRIPTION
While the theme contrast functionality is very nice, I would like to be able to apply more contrast especially with light themes. I am not sure if this is desired functionality by others, but it would greatly improve my work with a fantastic game engine.
  