### PR TITLE
Make GDNative DLLs work on UWP

### DIFF
--- a/modules/gdnative/gdnative.cpp
+++ b/modules/gdnative/gdnative.cpp
@@ -130,6 +130,9 @@ bool GDNative::initialize() {
 	// we should pass library name to dlopen(). The library name is flattened
 	// during export.
 	String path = lib_path.get_file();
+#elif defined(UWP_ENABLED)
+	// On UWP we use a relative path from the app
+	String path = lib_path.replace("res://", "");
 #else
 	String path = ProjectSettings::get_singleton()->globalize_path(lib_path);
 #endif

--- a/modules/gdnative/gdnative_library_editor_plugin.cpp
+++ b/modules/gdnative/gdnative_library_editor_plugin.cpp
@@ -299,8 +299,8 @@ GDNativeLibraryEditor::GDNativeLibraryEditor() {
 		NativePlatformConfig platform_uwp;
 		platform_uwp.name = "Windows Universal";
 		platform_uwp.entries.push_back("arm");
-		platform_uwp.entries.push_back("x86");
-		platform_uwp.entries.push_back("x64");
+		platform_uwp.entries.push_back("32");
+		platform_uwp.entries.push_back("64");
 		platform_uwp.library_extension = "*.dll";
 		platforms["UWP"] = platform_uwp;
 

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -1024,6 +1024,17 @@ public:
 	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) {
 		r_features->push_back("s3tc");
 		r_features->push_back("etc");
+		switch ((int)p_preset->get("architecture/target")) {
+			case EditorExportUWP::ARM: {
+				r_features->push_back("arm");
+			} break;
+			case EditorExportUWP::X86: {
+				r_features->push_back("32");
+			} break;
+			case EditorExportUWP::X64: {
+				r_features->push_back("64");
+			} break;
+		}
 	}
 
 	virtual void get_export_options(List<ExportOption> *r_options) {

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -242,6 +242,10 @@ public:
 	virtual void show_virtual_keyboard(const String &p_existing_text, const Rect2 &p_screen_rect = Rect2());
 	virtual void hide_virtual_keyboard();
 
+	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path = false);
+	virtual Error close_dynamic_library(void *p_library_handle);
+	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle, bool p_optional = false);
+
 	virtual Error shell_open(String p_uri);
 
 	void run();


### PR DESCRIPTION
The DLL file isn't included in the export for some reason, but apparently this is broken for all platforms.