### PR TITLE
Fix premature declaration of shader variables created with assignment

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -3209,8 +3209,6 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const Map<StringName, Bui
 				var.precision = precision;
 				var.line = tk_line;
 
-				p_block->variables[name] = var;
-
 				VariableDeclarationNode::Declaration decl;
 
 				decl.name = name;
@@ -3219,7 +3217,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const Map<StringName, Bui
 				tk = _get_token();
 
 				if (tk.type == TK_OP_ASSIGN) {
-					//variable creted with assignment! must parse an expression
+					//variable created with assignment! must parse an expression
 					Node *n = _parse_and_reduce_expression(p_block, p_builtin_types);
 					if (!n)
 						return ERR_PARSE_ERROR;
@@ -3232,6 +3230,8 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const Map<StringName, Bui
 					}
 					tk = _get_token();
 				}
+
+				p_block->variables[name] = var;
 
 				vardecl->declarations.push_back(decl);
 


### PR DESCRIPTION
This pr fixes cases where variables could reference themselves in their initialization without giving an error in godot.

Example:
`float x = x;`
will now give an unknown identifier error.