### PR TITLE
Use exact positioning for the ItemList::get_tooltip method.

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1192,7 +1192,7 @@ bool ItemList::is_pos_at_end_of_items(const Point2 &p_pos) const {
 
 String ItemList::get_tooltip(const Point2 &p_pos) const {
 
-	int closest = get_item_at_position(p_pos);
+	int closest = get_item_at_position(p_pos, true);
 
 	if (closest != -1) {
 		if (!items[closest].tooltip_enabled) {


### PR DESCRIPTION
This is a potential resolution for #15241, which makes all `ItemList`s use the exact position flag on `get_item_at_position()` for use within `get_tooltip()`, solving any potential issue with widely inaccurate, technically "closest" items being returned.

Note that this affects **all** `ItemList`s, not just the `FileSystemDock` class which uses it. I imagine the ramifications of this are not too terrible, but it has to be said.