### PR TITLE
Add open feature to editor autoload settings

### DIFF
--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -245,7 +245,9 @@ void EditorAutoloadSettings::_autoload_button_pressed(Object *p_item, int p_colu
 	UndoRedo *undo_redo = EditorNode::get_undo_redo();
 
 	switch (p_button) {
-
+		case BUTTON_OPEN: {
+			_autoload_open(ti->get_text(1));
+		} break;
 		case BUTTON_MOVE_UP:
 		case BUTTON_MOVE_DOWN: {
 
@@ -304,6 +306,21 @@ void EditorAutoloadSettings::_autoload_button_pressed(Object *p_item, int p_colu
 	}
 }
 
+void EditorAutoloadSettings::_autoload_activated() {
+	TreeItem *ti = tree->get_selected();
+	if (!ti)
+		return;
+	_autoload_open(ti->get_text(1));
+}
+
+void EditorAutoloadSettings::_autoload_open(const String &fpath) {
+	if (ResourceLoader::get_resource_type(fpath) == "PackedScene") {
+		EditorNode::get_singleton()->open_request(fpath);
+	} else {
+		EditorNode::get_singleton()->load_resource(fpath);
+	}
+	ProjectSettingsEditor::get_singleton()->hide();
+}
 void EditorAutoloadSettings::_autoload_file_callback(const String &p_path) {
 
 	autoload_add_name->set_text(p_path.get_file().get_basename());
@@ -355,13 +372,13 @@ void EditorAutoloadSettings::update_autoload() {
 		item->set_editable(0, true);
 
 		item->set_text(1, path);
-		item->set_selectable(1, false);
+		item->set_selectable(1, true);
 
 		item->set_cell_mode(2, TreeItem::CELL_MODE_CHECK);
 		item->set_editable(2, true);
 		item->set_text(2, TTR("Enable"));
 		item->set_checked(2, global);
-
+		item->add_button(3, get_icon("FileList", "EditorIcons"), BUTTON_OPEN);
 		item->add_button(3, get_icon("MoveUp", "EditorIcons"), BUTTON_MOVE_UP);
 		item->add_button(3, get_icon("MoveDown", "EditorIcons"), BUTTON_MOVE_DOWN);
 		item->add_button(3, get_icon("Remove", "EditorIcons"), BUTTON_DELETE);
@@ -528,6 +545,8 @@ void EditorAutoloadSettings::_bind_methods() {
 	ClassDB::bind_method("_autoload_edited", &EditorAutoloadSettings::_autoload_edited);
 	ClassDB::bind_method("_autoload_button_pressed", &EditorAutoloadSettings::_autoload_button_pressed);
 	ClassDB::bind_method("_autoload_file_callback", &EditorAutoloadSettings::_autoload_file_callback);
+	ClassDB::bind_method("_autoload_activated", &EditorAutoloadSettings::_autoload_activated);
+	ClassDB::bind_method("_autoload_open", &EditorAutoloadSettings::_autoload_open);
 
 	ClassDB::bind_method("get_drag_data_fw", &EditorAutoloadSettings::get_drag_data_fw);
 	ClassDB::bind_method("can_drop_data_fw", &EditorAutoloadSettings::can_drop_data_fw);
@@ -594,12 +613,12 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	tree->set_column_min_width(2, 80);
 
 	tree->set_column_expand(3, false);
-	tree->set_column_min_width(3, 80);
+	tree->set_column_min_width(3, 120);
 
 	tree->connect("cell_selected", this, "_autoload_selected");
 	tree->connect("item_edited", this, "_autoload_edited");
 	tree->connect("button_pressed", this, "_autoload_button_pressed");
-
+	tree->connect("item_activated", this, "_autoload_activated");
 	tree->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	add_child(tree, true);

--- a/editor/editor_autoload_settings.h
+++ b/editor/editor_autoload_settings.h
@@ -40,6 +40,7 @@ class EditorAutoloadSettings : public VBoxContainer {
 	GDCLASS(EditorAutoloadSettings, VBoxContainer);
 
 	enum {
+		BUTTON_OPEN,
 		BUTTON_MOVE_UP,
 		BUTTON_MOVE_DOWN,
 		BUTTON_DELETE
@@ -72,6 +73,8 @@ class EditorAutoloadSettings : public VBoxContainer {
 	void _autoload_selected();
 	void _autoload_edited();
 	void _autoload_button_pressed(Object *p_item, int p_column, int p_button);
+	void _autoload_activated();
+	void _autoload_open(const String &fpath);
 	void _autoload_file_callback(const String &p_path);
 
 	Variant get_drag_data_fw(const Point2 &p_point, Control *p_control);


### PR DESCRIPTION
Easy to **open and manager** autoload scripts or scene.
**Double click** can open autoload scripts now.
Or **click the small button** on the right.
![test](https://user-images.githubusercontent.com/24988459/34476101-0ba0541c-efc9-11e7-91e3-6f3c9aeea0ac.gif)

