### PR TITLE
Better Tileset Editor

### DIFF
--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -54,6 +54,9 @@ void TextureRegionEditor::_region_draw() {
 		base_tex = obj_styleBox->get_texture();
 	else if (atlas_tex.is_valid())
 		base_tex = atlas_tex->get_atlas();
+	else if (tile_set.is_valid() && ts_editor->get_current_tile() != -1)
+		base_tex = tile_set->tile_get_texture(ts_editor->get_current_tile());
+
 	if (base_tex.is_null())
 		return;
 
@@ -278,6 +281,9 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 									r = obj_styleBox->get_region_rect();
 								else if (atlas_tex.is_valid())
 									r = atlas_tex->get_region();
+								else if (tile_set.is_valid() && ts_editor->get_current_tile() != -1)
+									r = tile_set->tile_get_region(ts_editor->get_current_tile());
+
 								rect.expand_to(r.position);
 								rect.expand_to(r.position + r.size);
 							}
@@ -294,6 +300,9 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 							} else if (atlas_tex.is_valid()) {
 								undo_redo->add_do_method(atlas_tex.ptr(), "set_region", rect);
 								undo_redo->add_undo_method(atlas_tex.ptr(), "set_region", atlas_tex->get_region());
+							} else if (tile_set.is_valid() && ts_editor->get_current_tile() != -1) {
+								undo_redo->add_do_method(tile_set.ptr(), "tile_set_region", rect);
+								undo_redo->add_undo_method(tile_set.ptr(), "tile_set_region", tile_set->tile_get_region(ts_editor->get_current_tile()));
 							}
 							undo_redo->add_do_method(edit_draw, "update");
 							undo_redo->add_undo_method(edit_draw, "update");
@@ -316,6 +325,8 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 						rect_prev = obj_styleBox->get_region_rect();
 					else if (atlas_tex.is_valid())
 						rect_prev = atlas_tex->get_region();
+					else if (tile_set.is_valid() && ts_editor->get_current_tile() != -1)
+						rect_prev = tile_set->tile_get_region(ts_editor->get_current_tile());
 
 					for (int i = 0; i < 8; i++) {
 						Vector2 tuv = endpoints[i];
@@ -359,6 +370,9 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 					} else if (obj_styleBox.is_valid()) {
 						undo_redo->add_do_method(obj_styleBox.ptr(), "set_region_rect", obj_styleBox->get_region_rect());
 						undo_redo->add_undo_method(obj_styleBox.ptr(), "set_region_rect", rect_prev);
+					} else if (tile_set.is_valid() && ts_editor->get_current_tile() != -1) {
+						undo_redo->add_do_method(tile_set.ptr(), "tile_set_region", tile_set->tile_get_region(ts_editor->get_current_tile()));
+						undo_redo->add_undo_method(tile_set.ptr(), "tile_set_region", rect_prev);
 					}
 					drag_index = -1;
 				}
@@ -579,6 +593,13 @@ void TextureRegionEditor::apply_rect(const Rect2 &rect) {
 		obj_styleBox->set_region_rect(rect);
 	else if (atlas_tex.is_valid())
 		atlas_tex->set_region(rect);
+	else if (tile_set.is_valid() && ts_editor->get_current_tile() != -1) {
+		tile_set->tile_set_region(ts_editor->get_current_tile(), rect);
+		tile_set->_change_notify("");
+		ts_editor->preview->set_texture(tile_set->tile_get_texture(ts_editor->get_current_tile()));
+		ts_editor->preview->set_region_rect(tile_set->tile_get_region(ts_editor->get_current_tile()));
+		ts_editor->workspace->set_custom_minimum_size(tile_set->tile_get_region(ts_editor->get_current_tile()).size);
+	}
 }
 
 void TextureRegionEditor::_notification(int p_what) {
@@ -598,6 +619,7 @@ void TextureRegionEditor::_node_removed(Object *p_obj) {
 		node_sprite = NULL;
 		obj_styleBox = Ref<StyleBox>(NULL);
 		atlas_tex = Ref<AtlasTexture>(NULL);
+		tile_set = Ref<TileSet>(NULL);
 		hide();
 	}
 }
@@ -629,6 +651,8 @@ void TextureRegionEditor::edit(Object *p_obj) {
 		obj_styleBox->remove_change_receptor(this);
 	if (atlas_tex.is_valid())
 		atlas_tex->remove_change_receptor(this);
+	if (tile_set.is_valid())
+		tile_set->remove_change_receptor(this);
 	if (p_obj) {
 		node_sprite = Object::cast_to<Sprite>(p_obj);
 		node_ninepatch = Object::cast_to<NinePatchRect>(p_obj);
@@ -636,6 +660,8 @@ void TextureRegionEditor::edit(Object *p_obj) {
 			obj_styleBox = Ref<StyleBoxTexture>(Object::cast_to<StyleBoxTexture>(p_obj));
 		if (Object::cast_to<AtlasTexture>(p_obj))
 			atlas_tex = Ref<AtlasTexture>(Object::cast_to<AtlasTexture>(p_obj));
+		if (Object::cast_to<TileSet>(p_obj))
+			tile_set = Ref<TileSet>(Object::cast_to<TileSet>(p_obj));
 		p_obj->add_change_receptor(this);
 		_edit_region();
 	} else {
@@ -643,6 +669,7 @@ void TextureRegionEditor::edit(Object *p_obj) {
 		node_ninepatch = NULL;
 		obj_styleBox = Ref<StyleBoxTexture>(NULL);
 		atlas_tex = Ref<AtlasTexture>(NULL);
+		tile_set = Ref<TileSet>(NULL);
 	}
 	edit_draw->update();
 }
@@ -665,6 +692,8 @@ void TextureRegionEditor::_edit_region() {
 		texture = obj_styleBox->get_texture();
 	else if (atlas_tex.is_valid())
 		texture = atlas_tex->get_atlas();
+	else if (tile_set.is_valid() && ts_editor->get_current_tile() != -1)
+		texture = tile_set->tile_get_texture(ts_editor->get_current_tile());
 
 	if (texture.is_null()) {
 		return;
@@ -732,6 +761,8 @@ void TextureRegionEditor::_edit_region() {
 		rect = obj_styleBox->get_region_rect();
 	else if (atlas_tex.is_valid())
 		rect = atlas_tex->get_region();
+	else if (tile_set.is_valid() && ts_editor->get_current_tile() != -1)
+		rect = tile_set->tile_get_region(ts_editor->get_current_tile());
 
 	edit_draw->update();
 }
@@ -750,6 +781,7 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	node_ninepatch = NULL;
 	obj_styleBox = Ref<StyleBoxTexture>(NULL);
 	atlas_tex = Ref<AtlasTexture>(NULL);
+	tile_set = Ref<TileSet>(NULL);
 	editor = p_editor;
 	undo_redo = editor->get_undo_redo();
 

--- a/editor/plugins/texture_region_editor_plugin.h
+++ b/editor/plugins/texture_region_editor_plugin.h
@@ -36,10 +36,12 @@
 #include "canvas_item_editor_plugin.h"
 #include "editor/editor_node.h"
 #include "editor/editor_plugin.h"
+#include "editor/plugins/tile_set_editor_plugin.h"
 #include "scene/2d/sprite.h"
 #include "scene/gui/nine_patch_rect.h"
 #include "scene/resources/style_box.h"
 #include "scene/resources/texture.h"
+#include "scene/resources/tile_set.h"
 
 class TextureRegionEditor : public Control {
 
@@ -53,6 +55,8 @@ class TextureRegionEditor : public Control {
 	};
 
 	friend class TextureRegionEditorPlugin;
+	friend class TileSetEditorPlugin;
+	friend class TileSetEditor;
 	MenuButton *snap_mode_button;
 	TextureRect *icon_zoom;
 	ToolButton *zoom_in;
@@ -71,6 +75,7 @@ class TextureRegionEditor : public Control {
 	HScrollBar *hscroll;
 
 	EditorNode *editor;
+	TileSetEditor *ts_editor;
 	UndoRedo *undo_redo;
 
 	Vector2 draw_ofs;
@@ -86,6 +91,7 @@ class TextureRegionEditor : public Control {
 	Sprite *node_sprite;
 	Ref<StyleBoxTexture> obj_styleBox;
 	Ref<AtlasTexture> atlas_tex;
+	Ref<TileSet> tile_set;
 
 	Rect2 rect;
 	Rect2 rect_prev;

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -333,7 +333,7 @@ AutotileEditor::AutotileEditor(EditorNode *p_editor) {
 	autotile_list = memnew(ItemList);
 	autotile_list->set_v_size_flags(SIZE_EXPAND_FILL);
 	autotile_list->set_h_size_flags(SIZE_EXPAND_FILL);
-	autotile_list->set_custom_minimum_size(Size2(02, 200));
+	autotile_list->set_custom_minimum_size(Size2(10, 200));
 	autotile_list->connect("item_selected", this, "_on_autotile_selected");
 	split->add_child(autotile_list);
 
@@ -531,7 +531,7 @@ AutotileEditor::AutotileEditor(EditorNode *p_editor) {
 
 	main_vb->add_child(toolbar);
 
-	ScrollContainer *scroll = memnew(ScrollContainer);
+	scroll = memnew(ScrollContainer);
 	main_vb->add_child(scroll);
 	scroll->set_v_size_flags(SIZE_EXPAND_FILL);
 
@@ -1095,6 +1095,16 @@ void AutotileEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 				}
 			} break;
 		}
+
+		//Drag Middle Mouse
+		if (mm.is_valid()) {
+			if (mm->get_button_mask() & BUTTON_MASK_MIDDLE) {
+
+				Vector2 dragged(mm->get_relative().x, mm->get_relative().y);
+				scroll->set_h_scroll(scroll->get_h_scroll() - dragged.x * workspace->get_scale().x);
+				scroll->set_v_scroll(scroll->get_v_scroll() - dragged.y * workspace->get_scale().x);
+			}
+		}
 	}
 }
 
@@ -1453,10 +1463,19 @@ void AutotileEditor::close_shape(const Vector2 &shape_anchor) {
 			Ref<ConvexPolygonShape2D> shape = memnew(ConvexPolygonShape2D);
 
 			Vector<Vector2> segments;
+			float p_total = 0;
 
 			for (int i = 0; i < current_shape.size(); i++) {
 				segments.push_back(current_shape[i] - shape_anchor);
+
+				if (i != current_shape.size() - 1)
+					p_total += ((current_shape[i + 1].x - current_shape[i].x) * (-current_shape[i + 1].y + (-current_shape[i].y)));
+				else
+					p_total += ((current_shape[0].x - current_shape[i].x) * (-current_shape[0].y + (-current_shape[i].y)));
 			}
+
+			if (p_total < 0)
+				segments.invert();
 
 			shape->set_points(segments);
 

--- a/editor/plugins/tile_set_editor_plugin.h
+++ b/editor/plugins/tile_set_editor_plugin.h
@@ -86,6 +86,7 @@ class AutotileEditor : public Control {
 
 	int current_item_index;
 	Sprite *preview;
+	ScrollContainer *scroll;
 	Control *workspace_container;
 	Control *workspace;
 	Button *tool_editmode[EDITMODE_MAX];

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -307,6 +307,7 @@ void TileSet::tile_set_texture(int p_id, const Ref<Texture> &p_texture) {
 
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	tile_map[p_id].texture = p_texture;
+	_change_notify("texture");
 	emit_changed();
 }
 
@@ -684,7 +685,7 @@ Ref<NavigationPolygon> TileSet::tile_get_navigation_polygon(int p_id) const {
 	return tile_map[p_id].navigation_polygon;
 }
 
-const Map<Vector2, Ref<OccluderPolygon2D> > &TileSet::autotile_get_light_oclusion_map(int p_id) const {
+const Map<Vector2, Ref<OccluderPolygon2D> > &TileSet::autotile_get_light_occluder_map(int p_id) const {
 
 	static Map<Vector2, Ref<OccluderPolygon2D> > dummy;
 	ERR_FAIL_COND_V(!tile_map.has(p_id), dummy);

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -200,7 +200,7 @@ public:
 
 	void autotile_set_light_occluder(int p_id, const Ref<OccluderPolygon2D> &p_light_occluder, const Vector2 &p_coord);
 	Ref<OccluderPolygon2D> autotile_get_light_occluder(int p_id, const Vector2 &p_coord) const;
-	const Map<Vector2, Ref<OccluderPolygon2D> > &autotile_get_light_oclusion_map(int p_id) const;
+	const Map<Vector2, Ref<OccluderPolygon2D> > &autotile_get_light_occluder_map(int p_id) const;
 
 	void tile_set_navigation_polygon_offset(int p_id, const Vector2 &p_offset);
 	Vector2 tile_get_navigation_polygon_offset(int p_id) const;


### PR DESCRIPTION
This is still in progress. Place it here to track issues.
This might be available for 3.1, since feature freeze. But I need a confirmation tho if this rejected to go for 3.0.

Changes :
- [x] Fixes lot of bug I found 🤣 
- [x] Tileset now have editor for collision, occluder, navigation
- [x] Tileset can access Texture Region Editor to edit texture from tileset

Issues :
- [ ] First time selecting tileset.res not draw the collision shapes
- [ ] Assign new Texture to tileset not updating tileset-list (sidepanel)
- [ ] ??

SS :
![image](https://user-images.githubusercontent.com/8519218/34477975-970f50be-efd0-11e7-9c8c-67ec83d922c4.png)
![image](https://user-images.githubusercontent.com/8519218/34477989-b9ae9576-efd0-11e7-8ae5-b2be029b180f.png)
