### PR TITLE
Integrate all Debugger error information into a convenient Tree widget.

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -678,47 +678,47 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		String time = String("%d:%02d:%02d:%04d").sprintf(vals, &e);
 		String txt = err[8].is_zero() ? String(err[7]) : String(err[8]);
 
-        TreeItem *r = error_tree->get_root();
-        if (r == nullptr) {
-            r = error_tree->create_item();
-        }
-        TreeItem *error = error_tree->create_item(r);
-        error->set_collapsed(true);
+		TreeItem *r = error_tree->get_root();
+		if (r == nullptr) {
+			r = error_tree->create_item();
+		}
+		TreeItem *error = error_tree->create_item(r);
+		error->set_collapsed(true);
 
-        error->set_icon(0, get_icon(warning ? "Warning" : "Error", "EditorIcons"));
-        error->set_text(0, time);
-        error->set_text_align(0, TreeItem::ALIGN_LEFT);
+		error->set_icon(0, get_icon(warning ? "Warning" : "Error", "EditorIcons"));
+		error->set_text(0, time);
+		error->set_text_align(0, TreeItem::ALIGN_LEFT);
 
-        error->set_text(1, txt);
+		error->set_text(1, txt);
 
-        TreeItem *c_info = error_tree->create_item(error);
-        c_info->set_text(0, "<" + TTR("C Source") + ">");
-        c_info->set_text(1, String(err[5]) + ":" + String(err[6]) + " @ " + String(err[4]) + "()");
-        c_info->set_text_align(0, TreeItem::ALIGN_LEFT);
+		TreeItem *c_info = error_tree->create_item(error);
+		c_info->set_text(0, "<" + TTR("C Source") + ">");
+		c_info->set_text(1, String(err[5]) + ":" + String(err[6]) + " @ " + String(err[4]) + "()");
+		c_info->set_text_align(0, TreeItem::ALIGN_LEFT);
 
 		int scc = p_data[1];
 
-        for (int i = 0; i < scc; i += 2) {
-            String script = p_data[2 + i];
-            int line = p_data[3 + i];
+		for (int i = 0; i < scc; i += 2) {
+			String script = p_data[2 + i];
+			int line = p_data[3 + i];
 
-            TreeItem *stack_trace = error_tree->create_item(error);
-            Array meta;
-            meta.push_back(script);
-            meta.push_back(line);
-            stack_trace->set_metadata(0, meta);
+			TreeItem *stack_trace = error_tree->create_item(error);
+			Array meta;
+			meta.push_back(script);
+			meta.push_back(line);
+			stack_trace->set_metadata(0, meta);
 
-            if (i == 0) {
-                stack_trace->set_text(0, "<" + TTR("Stack Trace") + ">");
-                stack_trace->set_text_align(0, TreeItem::ALIGN_LEFT);
-            }
+			if (i == 0) {
+				stack_trace->set_text(0, "<" + TTR("Stack Trace") + ">");
+				stack_trace->set_text_align(0, TreeItem::ALIGN_LEFT);
+			}
 
-            stack_trace->set_text(1, script.get_file() + ":" + itos(line));
-        }
+			stack_trace->set_text(1, script.get_file() + ":" + itos(line));
+		}
 
-        TreeItem *copy = error_tree->create_item(error);
-        copy->add_button(0, get_icon("CopyNodePath", "EditorIcons"), -1, false, TTR("Copy to clipboard."));
-        copy->set_text(1, TTR("Copy to clipboard."));
+		TreeItem *copy = error_tree->create_item(error);
+		copy->add_button(0, get_icon("CopyNodePath", "EditorIcons"), -1, false, TTR("Copy to clipboard."));
+		copy->set_text(1, TTR("Copy to clipboard."));
 
 		error_count++;
 		/*
@@ -1045,7 +1045,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 					inspect_scene_tree->clear();
 					le_set->set_disabled(true);
 					le_clear->set_disabled(false);
-                    error_tree->clear();
+					error_tree->clear();
 					error_count = 0;
 					profiler_signature.clear();
 					//live_edit_root->set_text("/root");
@@ -1627,50 +1627,50 @@ void ScriptEditorDebugger::reload_scripts() {
 }
 
 void ScriptEditorDebugger::_error_activated() {
-    TreeItem *selected = error_tree->get_selected();
+	TreeItem *selected = error_tree->get_selected();
 
-    TreeItem *ci = selected->get_children();
-    if (ci != nullptr) {
-        selected->set_collapsed( !selected->is_collapsed() );
-    }
+	TreeItem *ci = selected->get_children();
+	if (ci != nullptr) {
+		selected->set_collapsed( !selected->is_collapsed() );
+	}
 }
 
 void ScriptEditorDebugger::_error_selected() {
-    TreeItem *selected = error_tree->get_selected();
+	TreeItem *selected = error_tree->get_selected();
 
-    Array meta = selected->get_metadata(0);
+	Array meta = selected->get_metadata(0);
 
-    if (meta.size() == 0) {
-        return;
-    }
+	if (meta.size() == 0) {
+		return;
+	}
 
-    Ref<Script> s = ResourceLoader::load(meta[0]);
-    emit_signal("goto_script_line", s, int(meta[1]) - 1);
+	Ref<Script> s = ResourceLoader::load(meta[0]);
+	emit_signal("goto_script_line", s, int(meta[1]) - 1);
 }
 
 void ScriptEditorDebugger::_error_button_pressed(Object* p_item, int p_column, int p_id) {
-    TreeItem *ti = Object::cast_to<TreeItem>(p_item)->get_parent();
+	TreeItem *ti = Object::cast_to<TreeItem>(p_item)->get_parent();
 
-    String type;
+	String type;
 
-    if (ti->get_icon(0) == get_icon("Warning", "EditorIcons")) {
-        type = "W ";
-    } else if(ti->get_icon(0) == get_icon("Error", "EditorIcons")) {
-        type = "E ";
-    }
+	if (ti->get_icon(0) == get_icon("Warning", "EditorIcons")) {
+		type = "W ";
+	} else if(ti->get_icon(0) == get_icon("Error", "EditorIcons")) {
+		type = "E ";
+	}
 
-    String text = ti->get_text(0) + "        ";
-    int rpad_len = text.length();
+	String text = ti->get_text(0) + "        ";
+	int rpad_len = text.length();
 
-    text = type + text + ti->get_text(1) + "\n";
+	text = type + text + ti->get_text(1) + "\n";
 
-    TreeItem *ci = ti->get_children();
-    while (ci && ci->get_next()) {
-        text += "  " + ci->get_text(0).rpad(rpad_len) + ci->get_text(1) + "\n";
-        ci = ci->get_next();
-    }
+	TreeItem *ci = ti->get_children();
+	while (ci && ci->get_next()) {
+		text += "  " + ci->get_text(0).rpad(rpad_len) + ci->get_text(1) + "\n";
+		ci = ci->get_next();
+	}
 
-    OS::get_singleton()->set_clipboard(text);
+	OS::get_singleton()->set_clipboard(text);
 }
 
 void ScriptEditorDebugger::set_hide_on_stop(bool p_hide) {
@@ -1866,18 +1866,18 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 	}
 
 	{ //errors
-        error_tree = memnew(Tree);
-        error_tree->set_columns(2);
+		error_tree = memnew(Tree);
+		error_tree->set_columns(2);
 
-        error_tree->set_column_expand(0, false);
-        error_tree->set_column_min_width(0, 140);
+		error_tree->set_column_expand(0, false);
+		error_tree->set_column_min_width(0, 140);
 
-        error_tree->set_column_expand(1, true);
+		error_tree->set_column_expand(1, true);
 
-        error_tree->set_select_mode(Tree::SELECT_ROW);
-        error_tree->set_hide_root(true);
-        error_tree->set_h_size_flags(SIZE_EXPAND_FILL);
-        error_tree->set_name(TTR("Errors"));
+		error_tree->set_select_mode(Tree::SELECT_ROW);
+		error_tree->set_hide_root(true);
+		error_tree->set_h_size_flags(SIZE_EXPAND_FILL);
+		error_tree->set_name(TTR("Errors"));
 		tabs->add_child(error_tree);
 	}
 

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -678,7 +678,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		String time = String("%d:%02d:%02d:%04d").sprintf(vals, &e);
 		String txt = time + " - " + (err[8].is_zero() ? String(err[7]) : String(err[8]));
 
-		String tooltip = TTR("Type:") + String(warning ? TTR("Warning") : TTR("Error"));
+		String tooltip = TTR("Type:") + " " + String(warning ? TTR("Warning") : TTR("Error"));
 		tooltip += "\n" + TTR("Description:") + " " + String(err[8]);
 		tooltip += "\n" + TTR("Time:") + " " + time;
 		tooltip += "\nC " + TTR("Error:") + " " + String(err[7]);
@@ -1622,6 +1622,8 @@ void ScriptEditorDebugger::_error_selected(int p_idx) {
 		error_stack->set_item_metadata(error_stack->get_item_count() - 1, md);
 		error_stack->set_item_tooltip(error_stack->get_item_count() - 1, TTR("File:") + " " + String(st[i]) + "\n" + TTR("Line:") + " " + itos(line));
 	}
+
+	error_details->set_text(error_list->get_item_tooltip(p_idx));
 }
 
 void ScriptEditorDebugger::_error_stack_selected(int p_idx) {
@@ -1828,11 +1830,25 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 	{ //errors
 
 		error_split = memnew(HSplitContainer);
+
+		VSplitContainer *error_vsplit = memnew(VSplitContainer);
+		error_vsplit->set_h_size_flags(SIZE_EXPAND_FILL);
+		error_vsplit->set_stretch_ratio(3);
+		error_split->add_child(error_vsplit);
+
 		VBoxContainer *errvb = memnew(VBoxContainer);
-		errvb->set_h_size_flags(SIZE_EXPAND_FILL);
+		errvb->set_v_size_flags(SIZE_EXPAND_FILL);
 		error_list = memnew(ItemList);
 		errvb->add_margin_child(TTR("Errors:"), error_list, true);
-		error_split->add_child(errvb);
+		error_vsplit->add_child(errvb);
+
+		errvb = memnew(VBoxContainer);
+		errvb->set_v_size_flags(SIZE_EXPAND_FILL);
+		errvb->set_stretch_ratio(2);
+		error_details = memnew(TextEdit);
+		error_details->set_readonly(true);
+		errvb->add_margin_child(TTR("Details:"), error_details, true);
+		error_vsplit->add_child(errvb);
 
 		errvb = memnew(VBoxContainer);
 		errvb->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/editor/script_editor_debugger.h
+++ b/editor/script_editor_debugger.h
@@ -84,6 +84,7 @@ class ScriptEditorDebugger : public Control {
 	HSplitContainer *error_split;
 	ItemList *error_list;
 	ItemList *error_stack;
+	TextEdit *error_details;
 	Tree *inspect_scene_tree;
 
 	int error_count;

--- a/editor/script_editor_debugger.h
+++ b/editor/script_editor_debugger.h
@@ -81,7 +81,7 @@ class ScriptEditorDebugger : public Control {
 	Map<ObjectID, ScriptEditorDebuggerInspectedObject *> remote_objects;
 	Set<ObjectID> unfold_cache;
 
-    Tree *error_tree;
+	Tree *error_tree;
 	Tree *inspect_scene_tree;
 
 	int error_count;

--- a/editor/script_editor_debugger.h
+++ b/editor/script_editor_debugger.h
@@ -81,10 +81,7 @@ class ScriptEditorDebugger : public Control {
 	Map<ObjectID, ScriptEditorDebuggerInspectedObject *> remote_objects;
 	Set<ObjectID> unfold_cache;
 
-	HSplitContainer *error_split;
-	ItemList *error_list;
-	ItemList *error_stack;
-	TextEdit *error_details;
+    Tree *error_tree;
 	Tree *inspect_scene_tree;
 
 	int error_count;
@@ -166,8 +163,9 @@ class ScriptEditorDebugger : public Control {
 	void _method_changed(Object *p_base, const StringName &p_name, VARIANT_ARG_DECLARE);
 	void _property_changed(Object *p_base, const StringName &p_property, const Variant &p_value);
 
-	void _error_selected(int p_idx);
-	void _error_stack_selected(int p_idx);
+	void _error_selected();
+	void _error_activated();
+	void _error_button_pressed(Object* p_item, int p_column, int p_id);
 
 	void _profiler_activate(bool p_enable);
 	void _profiler_seeked();


### PR DESCRIPTION
Fixes #15234 by vertically splitting the Errors box and introducing a read-only `TextEdit` to display the information which was previously only available through the tooltip in the errors `ItemList`.

Also inserts missing `" "` after `"Type:"` in the detailed information, and sets `stretch_ratio` on a couple of the boxes to give more space to the Errors and the Details by default, but since everything is contained in a `SplitContainer`, the user is free to resize them as needed.