### PR TITLE
Fix targetSdk not update for Android

### DIFF
--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -109,7 +109,7 @@ targetSdk = 23
 for x in env.android_default_config:
     if x.startswith("minSdkVersion") and int(x.split(" ")[-1]) < minSdk:
         x = "minSdkVersion " + str(minSdk)
-    if x.startswith("targetSdkVersion") and int(x.split(" ")[-1]) > targetSdk:
+    if x.startswith("targetSdkVersion") and int(x.split(" ")[-1]) < targetSdk:
         x = "targetSdkVersion " + str(targetSdk)
 
     gradle_default_config_text += x + "\n\t\t"


### PR DESCRIPTION
targetSdk should be updated if custom module defines greater version than godot official
```
env.android_add_default_config("targetSdkVersion 26")
```