### PR TITLE
Update android build tool to latest

### DIFF
--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -104,7 +104,7 @@ gradle_asset_dirs_text = ""
 gradle_default_config_text = ""
 
 minSdk = 18
-targetSdk = 23
+targetSdk = 27
 
 for x in env.android_default_config:
     if x.startswith("minSdkVersion") and int(x.split(" ")[-1]) < minSdk:

--- a/platform/android/build.gradle.template
+++ b/platform/android/build.gradle.template
@@ -31,8 +31,8 @@ android {
 		disable 'MissingTranslation'
 	}
 
-	compileSdkVersion 26
-	buildToolsVersion "26.0.1"
+	compileSdkVersion 27
+	buildToolsVersion "27.0.3"
 	useLibrary 'org.apache.http.legacy'
 
 	packagingOptions {

--- a/platform/android/java/gradle/wrapper/gradle-wrapper.properties
+++ b/platform/android/java/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
this will fix target sdk of #15273
and AFAIK, in godot 3.0, we already support 64bit option at export settings.