### PR TITLE
Added "Cinema Mode" so that the spatial editor can actively track the...

### DIFF
--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -95,7 +95,8 @@ class SpatialEditorViewport : public Control {
 		VIEW_DISPLAY_WIREFRAME,
 		VIEW_DISPLAY_OVERDRAW,
 		VIEW_DISPLAY_SHADELESS,
-		VIEW_LOCK_ROTATION
+		VIEW_LOCK_ROTATION,
+		VIEW_CINEMATIC_PREVIEW
 	};
 
 public:
@@ -141,6 +142,7 @@ private:
 
 	Label *info_label;
 	Label *fps_label;
+	Label *cinema_label;
 
 	struct _RayResult {
 
@@ -289,8 +291,11 @@ private:
 	Camera *previewing;
 	Camera *preview;
 
+	bool previewing_cinema;
+
 	void _preview_exited_scene();
 	void _toggle_camera_preview(bool);
+	void _toggle_cinema_preview(bool);
 	void _init_gizmo_instance(int p_idx);
 	void _finish_gizmo_instances();
 	void _selection_result_pressed(int);


### PR DESCRIPTION
… most recently selected camera when previewing.  Simplifies the approach to creating cut scenes by allowing you preview an entire cut scene without the need to manually change cameras.

See the video of its use right here:
https://youtu.be/DLrPziNY528
  