### PR TITLE
Fix Issue#15303 FreeBSD compilation error in thekla_atlas

### DIFF
--- a/modules/thekla_unwrap/SCsub
+++ b/modules/thekla_unwrap/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import platform
+
 Import('env')
 Import('env_modules')
 
@@ -60,7 +62,13 @@ if env['builtin_thekla_atlas']:
         env_thekla_unwrap.Append(CXXFLAGS="-std=c++11")
 
     if env["platform"] == 'x11':
-        env_thekla_unwrap.Append(CCFLAGS=["-DNV_OS_LINUX", "-DPOSH_COMPILER_GCC"])
+        # if not specifically one of the *BSD, then use LINUX as default
+        if platform.system() == "FreeBSD":
+            env_thekla_unwrap.Append(CCFLAGS=["-DNV_OS_FREEBSD", "-DPOSH_COMPILER_GCC"])
+        elif platform.system() == "OpenBSD":
+            env_thekla_unwrap.Append(CCFLAGS=["-DNV_OS_OPENBSD", "-DPOSH_COMPILER_GCC"])
+        else:
+            env_thekla_unwrap.Append(CCFLAGS=["-DNV_OS_LINUX", "-DPOSH_COMPILER_GCC"])
     elif env["platform"] == 'osx':
         env_thekla_unwrap.Append(CCFLAGS=["-DNV_OS_DARWIN", "-DPOSH_COMPILER_GCC"])
     elif env["platform"] == 'windows':
@@ -69,6 +77,6 @@ if env['builtin_thekla_atlas']:
         else:
             env_thekla_unwrap.Append(CCFLAGS=["-DNV_OS_MINGW", "-DNV_CC_GNUC", "-DPOSH_COMPILER_GCC", "-U__STRICT_ANSI__"])
             env.Append(LIBS=["dbghelp"])
-        
+
 # Godot source files
 env_thekla_unwrap.add_source_files(env.modules_sources, "*.cpp")


### PR DESCRIPTION
Fix #15303 FreeBSD compilation error in thekla_atlas due to wrong definition of NV_OS_LINUX instead NV_OS_FREEBSD.

When Godot add preprocessor defined constants for thekla_atlas, it only uses platform (x11/osx/haiku...) to set them, and x11 is set as NV_OS_LINUX. But Linux, FreeBSD and OpenBSD have their own peculiarities in the thekla_atlas code, carefully crafted with differents NV_OS_ defines.

Now it checks first in x11 for FreeBSD, then for OpenBSD, and if it is neither of this two, it defaults directly to the original Linux defines.
  