### PR TITLE
Fix PopupMenu to show & detect properly hover area

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -122,8 +122,7 @@ int PopupMenu::_get_mouse_over(const Point2 &p_over) const {
 
 	for (int i = 0; i < items.size(); i++) {
 
-		if (i > 0)
-			ofs.y += vseparation;
+		ofs.y += vseparation;
 		float h;
 
 		if (!items[i].icon.is_null()) {
@@ -459,7 +458,7 @@ void PopupMenu::_notification(int p_what) {
 
 				if (i == mouse_over) {
 
-					hover->draw(ci, Rect2(item_ofs + Point2(-hseparation, -vseparation), Size2(get_size().width - style->get_minimum_size().width + hseparation * 2, h + vseparation * 2)));
+					hover->draw(ci, Rect2(item_ofs + Point2(-hseparation, -vseparation / 2), Size2(get_size().width - style->get_minimum_size().width + hseparation * 2, h + vseparation)));
 				}
 
 				if (items[i].separator) {


### PR DESCRIPTION
Fix #15275

I changed `Additional Spacing` to `5` at Editor Settings > Interface > Theme to show this bug more clear.

![popup_menu_before](https://user-images.githubusercontent.com/8281454/34576578-ae9751a8-f1c1-11e7-9aff-5f3198fe2a95.gif)

note that hover style box is drawn very large than expected.
see that the hover style box is overlapped each other with `New inherited scene..` and `Open scene..` menu.
and this makes users to be confused.

![popup_menu_after](https://user-images.githubusercontent.com/8281454/34576698-1c14c904-f1c2-11e7-9819-7390e6fbeb94.gif)

NOTE : I don't know what's wrong with my screen recoder, but the mouse pointer location in this GIF is shown as about +2 or +3 px off of y. :(