### PR TITLE
Fix _ClassDB::get_method_list when instrospection is disabled

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2459,7 +2459,13 @@ Array _ClassDB::get_method_list(StringName p_class, bool p_no_inheritance) const
 	Array ret;
 
 	for (List<MethodInfo>::Element *E = methods.front(); E; E = E->next()) {
+#ifdef DEBUG_METHODS_ENABLED
 		ret.push_back(E->get().operator Dictionary());
+#else
+		Dictionary dict;
+		dict["name"] = E->get().name;
+		ret.push_back(dict);
+#endif
 	}
 
 	return ret;


### PR DESCRIPTION
Addressing #15065 

This fix removes the fields that cannot be provided when introspection is disabled (i.e. only `name` field is stays available)
example:
```python
{
	'name': 'set_texture',
	'args': [
		{'name': 'texture', 'class_name': 'Texture', 'type': 17, 'hint': 17, 'hint_string': 'Texture', 'usage': 7}
	],
	'default_args': [],
	'flags': 1,
	'id': 3726,
	'return': {
		'name': '',
		'class_name': '',
		'type': 0,
		'hint': 0,
		'hint_string': '',
		'usage': 7
	}
}
```

becomes 
```python
{'name': 'set_texture'}
```

instead of
```python
{
	'name': 'set_texture',
	'args': [],
	'default_args': [],
	'flags': 1,
	'id': 0,
	'return': {
		'name': '',
		'class_name': '',
		'type': 0,
		'hint': 0,
		'hint_string': '',
		'usage': 7
	}
}
```
(note `default_args`, `flags` and `return` fields have the same values in this example only because it is the default ones)
  