### PR TITLE
Clean up \n from end of translation strings

### DIFF
--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -514,7 +514,7 @@ void DependencyRemoveDialog::ok_pressed() {
 		print_line("Moving to trash: " + path);
 		Error err = OS::get_singleton()->move_to_trash(path);
 		if (err != OK) {
-			EditorNode::get_singleton()->add_io_error(TTR("Cannot remove:\n") + to_delete[i] + "\n");
+			EditorNode::get_singleton()->add_io_error(TTR("Cannot remove:") + "\n" + to_delete[i] + "\n");
 		}
 	}
 

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1347,7 +1347,7 @@ Error EditorExportPlatformPC::export_project(const Ref<EditorExportPreset> &p_pr
 	}
 
 	if (template_path != String() && !FileAccess::exists(template_path)) {
-		EditorNode::get_singleton()->show_warning(TTR("Template file not found:\n") + template_path);
+		EditorNode::get_singleton()->show_warning(TTR("Template file not found:") + "\n" + template_path);
 		return ERR_FILE_NOT_FOUND;
 	}
 

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -250,7 +250,7 @@ void ExportTemplateManager::_install_from_file(const String &p_file, bool p_use_
 	DirAccess *d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	Error err = d->make_dir_recursive(template_path);
 	if (err != OK) {
-		EditorNode::get_singleton()->show_warning(TTR("Error creating path for templates:\n") + template_path);
+		EditorNode::get_singleton()->show_warning(TTR("Error creating path for templates:") + "\n" + template_path);
 		unzClose(pkg);
 		return;
 	}

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -752,7 +752,7 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 		return;
 	} else if (!p_item.is_file && new_path.begins_with(old_path)) {
 		//This check doesn't erroneously catch renaming to a longer name as folder paths always end with "/"
-		EditorNode::get_singleton()->add_io_error(TTR("Cannot move a folder into itself.\n") + old_path + "\n");
+		EditorNode::get_singleton()->add_io_error(TTR("Cannot move a folder into itself.") + "\n" + old_path + "\n");
 		return;
 	}
 
@@ -772,7 +772,7 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 		if (p_item.is_file && FileAccess::exists(old_path + ".import")) {
 			err = da->rename(old_path + ".import", new_path + ".import");
 			if (err != OK) {
-				EditorNode::get_singleton()->add_io_error(TTR("Error moving:\n") + old_path + ".import\n");
+				EditorNode::get_singleton()->add_io_error(TTR("Error moving:") + "\n" + old_path + ".import\n");
 			}
 		}
 
@@ -796,7 +796,7 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 			print_line("  Remap: " + changed_paths[i] + " -> " + p_renames[changed_paths[i]]);
 		}
 	} else {
-		EditorNode::get_singleton()->add_io_error(TTR("Error moving:\n") + old_path + "\n");
+		EditorNode::get_singleton()->add_io_error(TTR("Error moving:") + "\n" + old_path + "\n");
 	}
 	memdelete(da);
 }
@@ -813,7 +813,7 @@ void FileSystemDock::_try_duplicate_item(const FileOrFolder &p_item, const Strin
 		return;
 	} else if (!p_item.is_file && new_path.begins_with(old_path)) {
 		//This check doesn't erroneously catch renaming to a longer name as folder paths always end with "/"
-		EditorNode::get_singleton()->add_io_error(TTR("Cannot move a folder into itself.\n") + old_path + "\n");
+		EditorNode::get_singleton()->add_io_error(TTR("Cannot move a folder into itself.") + "\n" + old_path + "\n");
 		return;
 	}
 
@@ -825,11 +825,11 @@ void FileSystemDock::_try_duplicate_item(const FileOrFolder &p_item, const Strin
 		if (p_item.is_file && FileAccess::exists(old_path + ".import")) {
 			err = da->copy(old_path + ".import", new_path + ".import");
 			if (err != OK) {
-				EditorNode::get_singleton()->add_io_error(TTR("Error duplicating:\n") + old_path + ".import\n");
+				EditorNode::get_singleton()->add_io_error(TTR("Error duplicating:") + "\n" + old_path + ".import\n");
 			}
 		}
 	} else {
-		EditorNode::get_singleton()->add_io_error(TTR("Error duplicating:\n") + old_path + "\n");
+		EditorNode::get_singleton()->add_io_error(TTR("Error duplicating:") + "\n" + old_path + "\n");
 	}
 	memdelete(da);
 }
@@ -901,7 +901,7 @@ void FileSystemDock::_update_dependencies_after_move(const Map<String, String> &
 			if (ResourceLoader::get_resource_type(file) == "PackedScene")
 				editor->reload_scene(file);
 		} else {
-			EditorNode::get_singleton()->add_io_error(TTR("Unable to update dependencies:\n") + remaps[i] + "\n");
+			EditorNode::get_singleton()->add_io_error(TTR("Unable to update dependencies:") + "\n" + remaps[i] + "\n");
 		}
 	}
 }

--- a/editor/plugins/navigation_mesh_editor_plugin.cpp
+++ b/editor/plugins/navigation_mesh_editor_plugin.cpp
@@ -107,7 +107,7 @@ NavigationMeshEditor::NavigationMeshEditor() {
 	button_bake->set_text(TTR("Bake!"));
 	button_bake->set_toggle_mode(true);
 	button_reset = memnew(Button);
-	button_bake->set_tooltip(TTR("Bake the navigation mesh.\n"));
+	button_bake->set_tooltip(TTR("Bake the navigation mesh.") + "\n");
 
 	bake_info = memnew(Label);
 	bake_hbox->add_child(button_bake);

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -4947,7 +4947,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	tool_button[TOOL_MODE_SELECT]->set_pressed(true);
 	button_binds[0] = MENU_TOOL_SELECT;
 	tool_button[TOOL_MODE_SELECT]->connect("pressed", this, "_menu_item_pressed", button_binds);
-	tool_button[TOOL_MODE_SELECT]->set_tooltip(TTR("Select Mode (Q)\n") + keycode_get_string(KEY_MASK_CMD) + TTR("Drag: Rotate\nAlt+Drag: Move\nAlt+RMB: Depth list selection"));
+	tool_button[TOOL_MODE_SELECT]->set_tooltip(TTR("Select Mode (Q)") + "\n" + keycode_get_string(KEY_MASK_CMD) + TTR("Drag: Rotate\nAlt+Drag: Move\nAlt+RMB: Depth list selection"));
 
 	tool_button[TOOL_MODE_MOVE] = memnew(ToolButton);
 	hbc_menu->add_child(tool_button[TOOL_MODE_MOVE]);


### PR DESCRIPTION
This removes `\n`s from ends of translation strings (replaces `TTR("`**...**`\n")` with `TTR("`**...**`")+"\n"`).