### PR TITLE
Fix get_edited_scene_root error at starting editor

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3990,6 +3990,7 @@ void CanvasItemEditor::_bind_methods() {
 	ClassDB::bind_method("_snap_changed", &CanvasItemEditor::_snap_changed);
 	ClassDB::bind_method(D_METHOD("_selection_result_pressed"), &CanvasItemEditor::_selection_result_pressed);
 	ClassDB::bind_method(D_METHOD("_selection_menu_hide"), &CanvasItemEditor::_selection_menu_hide);
+	ClassDB::bind_method(D_METHOD("set_state"), &CanvasItemEditor::set_state);
 
 	ADD_SIGNAL(MethodInfo("item_lock_status_changed"));
 	ADD_SIGNAL(MethodInfo("item_group_status_changed"));
@@ -4348,7 +4349,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	additive_selection = false;
 
 	// Update the menus checkboxes
-	set_state(get_state());
+	call_deferred("set_state", get_state());
 }
 
 CanvasItemEditor *CanvasItemEditor::singleton = NULL;

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -342,7 +342,7 @@ AutotileEditor::AutotileEditor(EditorNode *p_editor) {
 	split->add_child(property_editor);
 
 	helper = memnew(AutotileEditorHelper(this));
-	property_editor->edit(helper);
+	property_editor->call_deferred("edit", helper);
 
 	//Editor
 

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -4135,6 +4135,7 @@ void PropertyEditor::_bind_methods() {
 	ClassDB::bind_method("_resource_preview_done", &PropertyEditor::_resource_preview_done);
 	ClassDB::bind_method("refresh", &PropertyEditor::refresh);
 	ClassDB::bind_method("_draw_transparency", &PropertyEditor::_draw_transparency);
+	ClassDB::bind_method("edit", &PropertyEditor::edit);
 
 	ClassDB::bind_method(D_METHOD("get_drag_data_fw"), &PropertyEditor::get_drag_data_fw);
 	ClassDB::bind_method(D_METHOD("can_drop_data_fw"), &PropertyEditor::can_drop_data_fw);


### PR DESCRIPTION
Fix #15300

there are 2 same error at starting editor.
one comes from `editor/plugins/canvas_item_editor_plugin.cpp`
and the other one from `editor/plugins/tile_set_editor_plugin.cpp`

I thought I fixed in #14480
but the problem was that the method is not bound by `ClassDB::bind_method`
so `call_deferred` couldn't call it.
after all, `set_state()` from `canvas_item_editor_plugin.cpp` and `edit()` from `property_editor.cpp` are not called.

it made two problems of course.
The one from CanvasItemEditor made b8c849205c18c632e34c66c294bd5b38b11687f3 issue.
The other one form TileSetEditor made #14890 issue and it's reverted #15117

it's now properly called and works as expected.