### PR TITLE
[GDnative] macOS `dylib` export fixes

### DIFF
--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -138,6 +138,8 @@ public:
 
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
 
+	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path = false);
+
 	virtual void set_cursor_shape(CursorShape p_shape);
 	virtual void set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot);
 


### PR DESCRIPTION
Some additions to 6e2ed15ff14efe3063f66c182218f56e557bb468:

Fixes `.dylib` export for `.dmg` export mode in addition to `.zip` export.
Change `.dylib` export and lookup path to `/Contents/Frameworks` standard for macOS.

Fixes #15183
  