### PR TITLE
Mono: Add properties support in scripts

### DIFF
--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -104,6 +104,8 @@ class CSharpScript : public Script {
 	void _clear();
 
 	bool _update_exports();
+	bool _get_member_export(GDMonoClass *p_class, GDMonoClassMember *p_member, PropertyInfo &r_prop_info, bool &r_exported);
+
 	CSharpInstance *_create_instance(const Variant **p_args, int p_argcount, Object *p_owner, bool p_isref, Variant::CallError &r_error);
 	Variant _new(const Variant **p_args, int p_argcount, Variant::CallError &r_error);
 
@@ -177,6 +179,8 @@ class CSharpInstance : public ScriptInstance {
 	static CSharpInstance *create_for_managed_type(Object *p_owner, CSharpScript *p_script, const Ref<MonoGCHandle> &p_gchandle);
 
 	void _call_multilevel(MonoObject *p_mono_object, const StringName &p_method, const Variant **p_args, int p_argcount);
+
+	RPCMode _member_get_rpc_mode(GDMonoClassMember *p_member) const;
 
 public:
 	MonoObject *get_mono_object() const;

--- a/modules/mono/editor/godotsharp_builds.cpp
+++ b/modules/mono/editor/godotsharp_builds.cpp
@@ -446,7 +446,7 @@ void GodotSharpBuilds::BuildProcess::start(bool p_blocking) {
 
 	GDMonoClass *klass = GDMono::get_singleton()->get_editor_tools_assembly()->get_class("GodotSharpTools.Build", "BuildInstance");
 
-	MonoObject *mono_object = mono_object_new(mono_domain_get(), klass->get_raw());
+	MonoObject *mono_object = mono_object_new(mono_domain_get(), klass->get_mono_ptr());
 
 	// Construct
 

--- a/modules/mono/editor/monodevelop_instance.cpp
+++ b/modules/mono/editor/monodevelop_instance.cpp
@@ -62,7 +62,7 @@ MonoDevelopInstance::MonoDevelopInstance(const String &p_solution) {
 
 	GDMonoClass *klass = GDMono::get_singleton()->get_editor_tools_assembly()->get_class("GodotSharpTools.Editor", "MonoDevelopInstance");
 
-	MonoObject *obj = mono_object_new(TOOLS_DOMAIN, klass->get_raw());
+	MonoObject *obj = mono_object_new(TOOLS_DOMAIN, klass->get_mono_ptr());
 
 	GDMonoMethod *ctor = klass->get_method(".ctor", 1);
 	MonoObject *ex = NULL;

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -52,8 +52,7 @@ void gdmono_unhandled_exception_hook(MonoObject *exc, void *user_data) {
 
 	(void)user_data; // UNUSED
 
-	ERR_PRINT(GDMonoUtils::get_exception_name_and_message(exc).utf8());
-	mono_print_unhandled_exception(exc);
+	GDMonoUtils::print_unhandled_exception(exc);
 	abort();
 }
 

--- a/modules/mono/mono_gd/gd_mono.h
+++ b/modules/mono/mono_gd/gd_mono.h
@@ -112,14 +112,6 @@ public:
 #endif
 #endif
 
-	enum MemberVisibility {
-		PRIVATE,
-		PROTECTED_AND_INTERNAL, // FAM_AND_ASSEM
-		INTERNAL, // ASSEMBLY
-		PROTECTED, // FAMILY
-		PUBLIC
-	};
-
 	static GDMono *get_singleton() { return singleton; }
 
 	// Do not use these, unless you know what you're doing

--- a/modules/mono/mono_gd/gd_mono_assembly.cpp
+++ b/modules/mono/mono_gd/gd_mono_assembly.cpp
@@ -318,7 +318,7 @@ GDMonoClass *GDMonoAssembly::get_object_derived_class(const StringName &p_class)
 				void *iter = NULL;
 
 				while (true) {
-					MonoClass *raw_nested = mono_class_get_nested_types(current_nested->get_raw(), &iter);
+					MonoClass *raw_nested = mono_class_get_nested_types(current_nested->get_mono_ptr(), &iter);
 
 					if (!raw_nested)
 						break;

--- a/modules/mono/mono_gd/gd_mono_class.h
+++ b/modules/mono/mono_gd/gd_mono_class.h
@@ -38,6 +38,7 @@
 #include "gd_mono_field.h"
 #include "gd_mono_header.h"
 #include "gd_mono_method.h"
+#include "gd_mono_property.h"
 #include "gd_mono_utils.h"
 
 class GDMonoClass {
@@ -84,6 +85,10 @@ class GDMonoClass {
 	Map<StringName, GDMonoField *> fields;
 	Vector<GDMonoField *> fields_list;
 
+	bool properties_fetched;
+	Map<StringName, GDMonoProperty *> properties;
+	Vector<GDMonoProperty *> properties_list;
+
 	friend class GDMonoAssembly;
 	GDMonoClass(const StringName &p_namespace, const StringName &p_name, MonoClass *p_class, GDMonoAssembly *p_assembly);
 
@@ -95,7 +100,7 @@ public:
 	_FORCE_INLINE_ StringName get_namespace() const { return namespace_name; }
 	_FORCE_INLINE_ StringName get_name() const { return class_name; }
 
-	_FORCE_INLINE_ MonoClass *get_raw() const { return mono_class; }
+	_FORCE_INLINE_ MonoClass *get_mono_ptr() const { return mono_class; }
 	_FORCE_INLINE_ const GDMonoAssembly *get_assembly() const { return assembly; }
 
 	String get_full_name() const;
@@ -123,6 +128,9 @@ public:
 
 	GDMonoField *get_field(const StringName &p_name);
 	const Vector<GDMonoField *> &get_all_fields();
+
+	GDMonoProperty *get_property(const StringName &p_name);
+	const Vector<GDMonoProperty *> &get_all_properties();
 
 	~GDMonoClass();
 };

--- a/modules/mono/mono_gd/gd_mono_class_member.h
+++ b/modules/mono/mono_gd/gd_mono_class_member.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  gd_mono_field.h                                                      */
+/*  gd_mono_class_member.h                                               */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -27,49 +27,41 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#ifndef GDMONOFIELD_H
-#define GDMONOFIELD_H
+#ifndef GD_MONO_CLASS_MEMBER_H
+#define GD_MONO_CLASS_MEMBER_H
 
-#include "gd_mono.h"
-#include "gd_mono_class_member.h"
 #include "gd_mono_header.h"
 
-class GDMonoField : public GDMonoClassMember {
+#include <mono/metadata/object.h>
 
-	GDMonoClass *owner;
-	MonoClassField *mono_field;
-
-	StringName name;
-	ManagedType type;
-
-	bool attrs_fetched;
-	MonoCustomAttrInfo *attributes;
-
+class GDMonoClassMember {
 public:
-	virtual MemberType get_member_type() { return MEMBER_TYPE_FIELD; }
+	enum Visibility {
+		PRIVATE,
+		PROTECTED_AND_INTERNAL, // FAM_AND_ASSEM
+		INTERNAL, // ASSEMBLY
+		PROTECTED, // FAMILY
+		PUBLIC
+	};
 
-	virtual StringName get_name() { return name; }
+	enum MemberType {
+		MEMBER_TYPE_FIELD,
+		MEMBER_TYPE_PROPERTY,
+		MEMBER_TYPE_METHOD
+	};
 
-	virtual bool is_static();
-	virtual Visibility get_visibility();
+	virtual ~GDMonoClassMember() {}
 
-	virtual bool has_attribute(GDMonoClass *p_attr_class);
-	virtual MonoObject *get_attribute(GDMonoClass *p_attr_class);
-	void fetch_attributes();
+	virtual MemberType get_member_type() = 0;
 
-	_FORCE_INLINE_ ManagedType get_type() const { return type; }
+	virtual StringName get_name() = 0;
 
-	void set_value_raw(MonoObject *p_object, void *p_ptr);
-	void set_value_from_variant(MonoObject *p_object, const Variant &p_value);
+	virtual bool is_static() = 0;
 
-	_FORCE_INLINE_ MonoObject *get_value(MonoObject *p_object);
+	virtual Visibility get_visibility() = 0;
 
-	bool get_bool_value(MonoObject *p_object);
-	int get_int_value(MonoObject *p_object);
-	String get_string_value(MonoObject *p_object);
-
-	GDMonoField(MonoClassField *p_mono_field, GDMonoClass *p_owner);
-	~GDMonoField();
+	virtual bool has_attribute(GDMonoClass *p_attr_class) = 0;
+	virtual MonoObject *get_attribute(GDMonoClass *p_attr_class) = 0;
 };
 
-#endif // GDMONOFIELD_H
+#endif // GD_MONO_CLASS_MEMBER_H

--- a/modules/mono/mono_gd/gd_mono_header.h
+++ b/modules/mono/mono_gd/gd_mono_header.h
@@ -34,8 +34,10 @@
 
 class GDMonoAssembly;
 class GDMonoClass;
-class GDMonoMethod;
+class GDMonoClassMember;
 class GDMonoField;
+class GDMonoProperty;
+class GDMonoMethod;
 
 struct ManagedType {
 	int type_encoding;

--- a/modules/mono/mono_gd/gd_mono_marshal.cpp
+++ b/modules/mono/mono_gd/gd_mono_marshal.cpp
@@ -113,7 +113,7 @@ Variant::Type managed_to_variant_type(const ManagedType &p_type) {
 			if (tclass == CACHED_CLASS(Plane))
 				return Variant::PLANE;
 
-			if (mono_class_is_enum(tclass->get_raw()))
+			if (mono_class_is_enum(tclass->get_mono_ptr()))
 				return Variant::INT;
 		} break;
 
@@ -164,7 +164,7 @@ Variant::Type managed_to_variant_type(const ManagedType &p_type) {
 		} break;
 
 		case MONO_TYPE_GENERICINST: {
-			if (CACHED_RAW_MONO_CLASS(Dictionary) == p_type.type_class->get_raw()) {
+			if (CACHED_RAW_MONO_CLASS(Dictionary) == p_type.type_class->get_mono_ptr()) {
 				return Variant::DICTIONARY;
 			}
 		} break;
@@ -306,9 +306,9 @@ MonoObject *variant_to_mono_object(const Variant *p_var, const ManagedType &p_ty
 			if (tclass == CACHED_CLASS(Plane))
 				RETURN_BOXED_STRUCT(Plane, p_var);
 
-			if (mono_class_is_enum(tclass->get_raw())) {
+			if (mono_class_is_enum(tclass->get_mono_ptr())) {
 				int val = p_var->operator signed int();
-				return BOX_ENUM(tclass->get_raw(), val);
+				return BOX_ENUM(tclass->get_mono_ptr(), val);
 			}
 		} break;
 
@@ -432,7 +432,7 @@ MonoObject *variant_to_mono_object(const Variant *p_var, const ManagedType &p_ty
 			}
 			break;
 			case MONO_TYPE_GENERICINST: {
-				if (CACHED_RAW_MONO_CLASS(Dictionary) == p_type.type_class->get_raw()) {
+				if (CACHED_RAW_MONO_CLASS(Dictionary) == p_type.type_class->get_mono_ptr()) {
 					return Dictionary_to_mono_object(p_var->operator Dictionary());
 				}
 			} break;
@@ -528,7 +528,7 @@ Variant mono_object_to_variant(MonoObject *p_obj, const ManagedType &p_type) {
 			if (tclass == CACHED_CLASS(Plane))
 				RETURN_UNBOXED_STRUCT(Plane, p_obj);
 
-			if (mono_class_is_enum(tclass->get_raw()))
+			if (mono_class_is_enum(tclass->get_mono_ptr()))
 				return unbox<int32_t>(p_obj);
 		} break;
 
@@ -585,7 +585,7 @@ Variant mono_object_to_variant(MonoObject *p_obj, const ManagedType &p_type) {
 		} break;
 
 		case MONO_TYPE_GENERICINST: {
-			if (CACHED_RAW_MONO_CLASS(Dictionary) == p_type.type_class->get_raw()) {
+			if (CACHED_RAW_MONO_CLASS(Dictionary) == p_type.type_class->get_mono_ptr()) {
 				return mono_object_to_Dictionary(p_obj);
 			}
 		} break;

--- a/modules/mono/mono_gd/gd_mono_method.cpp
+++ b/modules/mono/mono_gd/gd_mono_method.cpp
@@ -32,6 +32,8 @@
 #include "gd_mono_class.h"
 #include "gd_mono_marshal.h"
 
+#include <mono/metadata/attrdefs.h>
+
 void GDMonoMethod::_update_signature() {
 	// Apparently MonoMethodSignature needs not to be freed.
 	// mono_method_signature caches the result, we don't need to cache it ourselves.
@@ -41,7 +43,6 @@ void GDMonoMethod::_update_signature() {
 }
 
 void GDMonoMethod::_update_signature(MonoMethodSignature *p_method_sig) {
-	is_instance = mono_signature_is_instance(p_method_sig);
 	params_count = mono_signature_get_param_count(p_method_sig);
 
 	MonoType *ret_type = mono_signature_get_return_type(p_method_sig);
@@ -61,12 +62,31 @@ void GDMonoMethod::_update_signature(MonoMethodSignature *p_method_sig) {
 
 		param_type.type_encoding = mono_type_get_type(param_raw_type);
 
-		if (param_type.type_encoding != MONO_TYPE_VOID) {
-			MonoClass *param_type_class = mono_class_from_mono_type(param_raw_type);
-			param_type.type_class = GDMono::get_singleton()->get_class(param_type_class);
-		}
+		MonoClass *param_type_class = mono_class_from_mono_type(param_raw_type);
+		param_type.type_class = GDMono::get_singleton()->get_class(param_type_class);
 
 		param_types.push_back(param_type);
+	}
+}
+
+bool GDMonoMethod::is_static() {
+	return mono_method_get_flags(mono_method, NULL) & MONO_METHOD_ATTR_STATIC;
+}
+
+GDMonoClassMember::Visibility GDMonoMethod::get_visibility() {
+	switch (mono_method_get_flags(mono_method, NULL) & MONO_METHOD_ATTR_ACCESS_MASK) {
+		case MONO_METHOD_ATTR_PRIVATE:
+			return GDMonoClassMember::PRIVATE;
+		case MONO_METHOD_ATTR_FAM_AND_ASSEM:
+			return GDMonoClassMember::PROTECTED_AND_INTERNAL;
+		case MONO_METHOD_ATTR_ASSEM:
+			return GDMonoClassMember::INTERNAL;
+		case MONO_METHOD_ATTR_FAMILY:
+			return GDMonoClassMember::PROTECTED;
+		case MONO_METHOD_ATTR_PUBLIC:
+			return GDMonoClassMember::PUBLIC;
+		default:
+			ERR_FAIL_V(GDMonoClassMember::PRIVATE);
 	}
 }
 
@@ -87,11 +107,11 @@ MonoObject *GDMonoMethod::invoke(MonoObject *p_object, const Variant **p_params,
 		MonoObject *ret = mono_runtime_invoke_array(mono_method, p_object, params, &exc);
 
 		if (exc) {
+			ret = NULL;
 			if (r_exc) {
 				*r_exc = exc;
 			} else {
-				ERR_PRINT(GDMonoUtils::get_exception_name_and_message(exc).utf8());
-				mono_print_unhandled_exception(exc);
+				GDMonoUtils::print_unhandled_exception(exc);
 			}
 		}
 
@@ -104,8 +124,7 @@ MonoObject *GDMonoMethod::invoke(MonoObject *p_object, const Variant **p_params,
 			if (r_exc) {
 				*r_exc = exc;
 			} else {
-				ERR_PRINT(GDMonoUtils::get_exception_name_and_message(exc).utf8());
-				mono_print_unhandled_exception(exc);
+				GDMonoUtils::print_unhandled_exception(exc);
 			}
 		}
 
@@ -123,11 +142,11 @@ MonoObject *GDMonoMethod::invoke_raw(MonoObject *p_object, void **p_params, Mono
 	MonoObject *ret = mono_runtime_invoke(mono_method, p_object, p_params, &exc);
 
 	if (exc) {
+		ret = NULL;
 		if (r_exc) {
 			*r_exc = exc;
 		} else {
-			ERR_PRINT(GDMonoUtils::get_exception_name_and_message(exc).utf8());
-			mono_print_unhandled_exception(exc);
+			GDMonoUtils::print_unhandled_exception(exc);
 		}
 	}
 
@@ -143,7 +162,7 @@ bool GDMonoMethod::has_attribute(GDMonoClass *p_attr_class) {
 	if (!attributes)
 		return false;
 
-	return mono_custom_attrs_has_attr(attributes, p_attr_class->get_raw());
+	return mono_custom_attrs_has_attr(attributes, p_attr_class->get_mono_ptr());
 }
 
 MonoObject *GDMonoMethod::get_attribute(GDMonoClass *p_attr_class) {
@@ -155,7 +174,7 @@ MonoObject *GDMonoMethod::get_attribute(GDMonoClass *p_attr_class) {
 	if (!attributes)
 		return NULL;
 
-	return mono_custom_attrs_get_attr(attributes, p_attr_class->get_raw());
+	return mono_custom_attrs_get_attr(attributes, p_attr_class->get_mono_ptr());
 }
 
 void GDMonoMethod::fetch_attributes() {

--- a/modules/mono/mono_gd/gd_mono_method.h
+++ b/modules/mono/mono_gd/gd_mono_method.h
@@ -31,13 +31,13 @@
 #define GD_MONO_METHOD_H
 
 #include "gd_mono.h"
+#include "gd_mono_class_member.h"
 #include "gd_mono_header.h"
 
-class GDMonoMethod {
+class GDMonoMethod : public GDMonoClassMember {
 
 	StringName name;
 
-	bool is_instance;
 	int params_count;
 	ManagedType return_type;
 	Vector<ManagedType> param_types;
@@ -53,9 +53,18 @@ class GDMonoMethod {
 	MonoMethod *mono_method;
 
 public:
-	_FORCE_INLINE_ StringName get_name() { return name; }
+	virtual MemberType get_member_type() { return MEMBER_TYPE_METHOD; }
 
-	_FORCE_INLINE_ bool is_static() { return !is_instance; }
+	virtual StringName get_name() { return name; }
+
+	virtual bool is_static();
+
+	virtual Visibility get_visibility();
+
+	virtual bool has_attribute(GDMonoClass *p_attr_class);
+	virtual MonoObject *get_attribute(GDMonoClass *p_attr_class);
+	virtual void fetch_attributes();
+
 	_FORCE_INLINE_ int get_parameters_count() { return params_count; }
 	_FORCE_INLINE_ ManagedType get_return_type() { return return_type; }
 
@@ -64,10 +73,6 @@ public:
 	MonoObject *invoke(MonoObject *p_object, const Variant **p_params, MonoObject **r_exc = NULL);
 	MonoObject *invoke(MonoObject *p_object, MonoObject **r_exc = NULL);
 	MonoObject *invoke_raw(MonoObject *p_object, void **p_params, MonoObject **r_exc = NULL);
-
-	bool has_attribute(GDMonoClass *p_attr_class);
-	MonoObject *get_attribute(GDMonoClass *p_attr_class);
-	void fetch_attributes();
 
 	String get_full_name(bool p_signature = false) const;
 	String get_full_name_no_class() const;

--- a/modules/mono/mono_gd/gd_mono_property.cpp
+++ b/modules/mono/mono_gd/gd_mono_property.cpp
@@ -1,0 +1,199 @@
+/*************************************************************************/
+/*  gd_mono_property.cpp                                                 */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+#include "gd_mono_property.h"
+
+#include "gd_mono_class.h"
+#include "gd_mono_marshal.h"
+
+#include <mono/metadata/attrdefs.h>
+
+GDMonoProperty::GDMonoProperty(MonoProperty *p_mono_property, GDMonoClass *p_owner) {
+	owner = p_owner;
+	mono_property = p_mono_property;
+	name = mono_property_get_name(mono_property);
+
+	MonoMethod *prop_method = mono_property_get_get_method(mono_property);
+
+	if (prop_method) {
+		MonoMethodSignature *getter_sig = mono_method_signature(prop_method);
+
+		MonoType *ret_type = mono_signature_get_return_type(getter_sig);
+
+		type.type_encoding = mono_type_get_type(ret_type);
+		MonoClass *ret_type_class = mono_class_from_mono_type(ret_type);
+		type.type_class = GDMono::get_singleton()->get_class(ret_type_class);
+	} else {
+		prop_method = mono_property_get_set_method(mono_property);
+
+		MonoMethodSignature *setter_sig = mono_method_signature(prop_method);
+
+		void *iter = NULL;
+		MonoType *param_raw_type = mono_signature_get_params(setter_sig, &iter);
+
+		type.type_encoding = mono_type_get_type(param_raw_type);
+		MonoClass *param_type_class = mono_class_from_mono_type(param_raw_type);
+		type.type_class = GDMono::get_singleton()->get_class(param_type_class);
+	}
+
+	attrs_fetched = false;
+	attributes = NULL;
+}
+
+GDMonoProperty::~GDMonoProperty() {
+	if (attributes) {
+		mono_custom_attrs_free(attributes);
+	}
+}
+
+bool GDMonoProperty::is_static() {
+	MonoMethod *prop_method = mono_property_get_get_method(mono_property);
+	if (prop_method == NULL)
+		prop_method = mono_property_get_set_method(mono_property);
+	return mono_method_get_flags(prop_method, NULL) & MONO_METHOD_ATTR_STATIC;
+}
+
+GDMonoClassMember::Visibility GDMonoProperty::get_visibility() {
+	MonoMethod *prop_method = mono_property_get_get_method(mono_property);
+	if (prop_method == NULL)
+		prop_method = mono_property_get_set_method(mono_property);
+
+	switch (mono_method_get_flags(prop_method, NULL) & MONO_METHOD_ATTR_ACCESS_MASK) {
+		case MONO_METHOD_ATTR_PRIVATE:
+			return GDMonoClassMember::PRIVATE;
+		case MONO_METHOD_ATTR_FAM_AND_ASSEM:
+			return GDMonoClassMember::PROTECTED_AND_INTERNAL;
+		case MONO_METHOD_ATTR_ASSEM:
+			return GDMonoClassMember::INTERNAL;
+		case MONO_METHOD_ATTR_FAMILY:
+			return GDMonoClassMember::PROTECTED;
+		case MONO_METHOD_ATTR_PUBLIC:
+			return GDMonoClassMember::PUBLIC;
+		default:
+			ERR_FAIL_V(GDMonoClassMember::PRIVATE);
+	}
+}
+
+bool GDMonoProperty::has_attribute(GDMonoClass *p_attr_class) {
+	ERR_FAIL_NULL_V(p_attr_class, false);
+
+	if (!attrs_fetched)
+		fetch_attributes();
+
+	if (!attributes)
+		return false;
+
+	return mono_custom_attrs_has_attr(attributes, p_attr_class->get_mono_ptr());
+}
+
+MonoObject *GDMonoProperty::get_attribute(GDMonoClass *p_attr_class) {
+	ERR_FAIL_NULL_V(p_attr_class, NULL);
+
+	if (!attrs_fetched)
+		fetch_attributes();
+
+	if (!attributes)
+		return NULL;
+
+	return mono_custom_attrs_get_attr(attributes, p_attr_class->get_mono_ptr());
+}
+
+void GDMonoProperty::fetch_attributes() {
+	ERR_FAIL_COND(attributes != NULL);
+	attributes = mono_custom_attrs_from_property(owner->get_mono_ptr(), mono_property);
+	attrs_fetched = true;
+}
+
+bool GDMonoProperty::has_getter() {
+	return mono_property_get_get_method(mono_property) != NULL;
+}
+
+bool GDMonoProperty::has_setter() {
+	return mono_property_get_set_method(mono_property) != NULL;
+}
+
+void GDMonoProperty::set_value(MonoObject *p_object, MonoObject *p_value, MonoObject **r_exc) {
+	MonoMethod *prop_method = mono_property_get_get_method(mono_property);
+
+	MonoArray *params = mono_array_new(mono_domain_get(), CACHED_CLASS_RAW(MonoObject), 1);
+	mono_array_set(params, MonoObject *, 0, p_value);
+
+	MonoObject *exc = NULL;
+	mono_runtime_invoke_array(prop_method, p_object, params, &exc);
+
+	if (exc) {
+		if (r_exc) {
+			*r_exc = exc;
+		} else {
+			GDMonoUtils::print_unhandled_exception(exc);
+		}
+	}
+}
+
+void GDMonoProperty::set_value(MonoObject *p_object, void **p_params, MonoObject **r_exc) {
+	MonoObject *exc = NULL;
+	mono_property_set_value(mono_property, p_object, p_params, &exc);
+
+	if (exc) {
+		if (r_exc) {
+			*r_exc = exc;
+		} else {
+			GDMonoUtils::print_unhandled_exception(exc);
+		}
+	}
+}
+
+MonoObject *GDMonoProperty::get_value(MonoObject *p_object, MonoObject **r_exc) {
+	MonoObject *exc = NULL;
+	MonoObject *ret = mono_property_get_value(mono_property, p_object, NULL, &exc);
+
+	if (exc) {
+		ret = NULL;
+		if (r_exc) {
+			*r_exc = exc;
+		} else {
+			GDMonoUtils::print_unhandled_exception(exc);
+		}
+	}
+
+	return ret;
+}
+
+bool GDMonoProperty::get_bool_value(MonoObject *p_object) {
+	return (bool)GDMonoMarshal::unbox<MonoBoolean>(get_value(p_object));
+}
+
+int GDMonoProperty::get_int_value(MonoObject *p_object) {
+	return GDMonoMarshal::unbox<int32_t>(get_value(p_object));
+}
+
+String GDMonoProperty::get_string_value(MonoObject *p_object) {
+	MonoObject *val = get_value(p_object);
+	return GDMonoMarshal::mono_string_to_godot((MonoString *)val);
+}

--- a/modules/mono/mono_gd/gd_mono_property.h
+++ b/modules/mono/mono_gd/gd_mono_property.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  gd_mono_field.h                                                      */
+/*  gd_mono_property.h                                                   */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -27,17 +27,17 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
-#ifndef GDMONOFIELD_H
-#define GDMONOFIELD_H
+#ifndef GD_MONO_PROPERTY_H
+#define GD_MONO_PROPERTY_H
 
 #include "gd_mono.h"
 #include "gd_mono_class_member.h"
 #include "gd_mono_header.h"
 
-class GDMonoField : public GDMonoClassMember {
+class GDMonoProperty : public GDMonoClassMember {
 
 	GDMonoClass *owner;
-	MonoClassField *mono_field;
+	MonoProperty *mono_property;
 
 	StringName name;
 	ManagedType type;
@@ -46,7 +46,7 @@ class GDMonoField : public GDMonoClassMember {
 	MonoCustomAttrInfo *attributes;
 
 public:
-	virtual MemberType get_member_type() { return MEMBER_TYPE_FIELD; }
+	virtual MemberType get_member_type() { return MEMBER_TYPE_PROPERTY; }
 
 	virtual StringName get_name() { return name; }
 
@@ -57,19 +57,21 @@ public:
 	virtual MonoObject *get_attribute(GDMonoClass *p_attr_class);
 	void fetch_attributes();
 
+	bool has_getter();
+	bool has_setter();
+
 	_FORCE_INLINE_ ManagedType get_type() const { return type; }
 
-	void set_value_raw(MonoObject *p_object, void *p_ptr);
-	void set_value_from_variant(MonoObject *p_object, const Variant &p_value);
-
-	_FORCE_INLINE_ MonoObject *get_value(MonoObject *p_object);
+	void set_value(MonoObject *p_object, MonoObject *p_value, MonoObject **r_exc = NULL);
+	void set_value(MonoObject *p_object, void **p_params, MonoObject **r_exc = NULL);
+	MonoObject *get_value(MonoObject *p_object, MonoObject **r_exc = NULL);
 
 	bool get_bool_value(MonoObject *p_object);
 	int get_int_value(MonoObject *p_object);
 	String get_string_value(MonoObject *p_object);
 
-	GDMonoField(MonoClassField *p_mono_field, GDMonoClass *p_owner);
-	~GDMonoField();
+	GDMonoProperty(MonoProperty *p_mono_property, GDMonoClass *p_owner);
+	~GDMonoProperty();
 };
 
-#endif // GDMONOFIELD_H
+#endif // GD_MONO_PROPERTY_H

--- a/modules/mono/mono_gd/gd_mono_utils.cpp
+++ b/modules/mono/mono_gd/gd_mono_utils.cpp
@@ -198,7 +198,7 @@ void update_godot_api_cache() {
 		CACHE_RAW_MONO_CLASS_AND_CHECK(Dictionary, mono_class_from_mono_type(dict_type));
 	}
 
-	MonoObject *task_scheduler = mono_object_new(SCRIPTS_DOMAIN, GODOT_API_CLASS(GodotTaskScheduler)->get_raw());
+	MonoObject *task_scheduler = mono_object_new(SCRIPTS_DOMAIN, GODOT_API_CLASS(GodotTaskScheduler)->get_mono_ptr());
 	mono_runtime_object_init(task_scheduler);
 	mono_cache.task_scheduler_handle = MonoGCHandle::create_strong(task_scheduler);
 }
@@ -298,7 +298,7 @@ MonoObject *create_managed_for_godot_object(GDMonoClass *p_class, const StringNa
 		ERR_FAIL_V(NULL);
 	}
 
-	MonoObject *mono_object = mono_object_new(SCRIPTS_DOMAIN, p_class->get_raw());
+	MonoObject *mono_object = mono_object_new(SCRIPTS_DOMAIN, p_class->get_mono_ptr());
 	ERR_FAIL_NULL_V(mono_object, NULL);
 
 	CACHED_FIELD(GodotObject, ptr)->set_value_raw(mono_object, p_object);
@@ -364,4 +364,10 @@ String get_exception_name_and_message(MonoObject *p_ex) {
 
 	return res;
 }
+
+void print_unhandled_exception(MonoObject *p_ex) {
+	ERR_PRINT(GDMonoUtils::get_exception_name_and_message(p_ex).utf8());
+	mono_print_unhandled_exception(p_ex);
+}
+
 } // namespace GDMonoUtils

--- a/modules/mono/mono_gd/gd_mono_utils.h
+++ b/modules/mono/mono_gd/gd_mono_utils.h
@@ -166,12 +166,14 @@ MonoDomain *create_domain(const String &p_friendly_name);
 
 String get_exception_name_and_message(MonoObject *p_ex);
 
+void print_unhandled_exception(MonoObject *p_ex);
+
 } // namespace GDMonoUtils
 
 #define NATIVE_GDMONOCLASS_NAME(m_class) (GDMonoMarshal::mono_string_to_godot((MonoString *)m_class->get_field(BINDINGS_NATIVE_NAME_FIELD)->get_value(NULL)))
 
 #define CACHED_CLASS(m_class) (GDMonoUtils::mono_cache.class_##m_class)
-#define CACHED_CLASS_RAW(m_class) (GDMonoUtils::mono_cache.class_##m_class->get_raw())
+#define CACHED_CLASS_RAW(m_class) (GDMonoUtils::mono_cache.class_##m_class->get_mono_ptr())
 #define CACHED_NS_CLASS(m_ns, m_class) (GDMonoUtils::mono_cache.class_##m_ns##_##m_class)
 #define CACHED_RAW_MONO_CLASS(m_class) (GDMonoUtils::mono_cache.rawclass_##m_class)
 #define CACHED_FIELD(m_class, m_field) (GDMonoUtils::mono_cache.field_##m_class##_##m_field)


### PR DESCRIPTION
`set` and `get` now supports properties and properties can be exported.

Closes #15030
