### PR TITLE
Visual glitch when dragging keyframes #15285

### DIFF
--- a/editor/animation_editor.cpp
+++ b/editor/animation_editor.cpp
@@ -1533,7 +1533,7 @@ void AnimationKeyEditor::_track_editor_draw() {
 			for (Map<SelectedKey, KeyInfo>::Element *E = selection.front(); E; E = E->next()) {
 
 				int idx = E->key().track;
-				int i = idx - v_scroll->get_value();
+				int i = idx - Math::floor(v_scroll->get_value());
 				if (i < 0 || i >= fit)
 					continue;
 				int y = h + i * h + sep;

--- a/editor/animation_editor.cpp
+++ b/editor/animation_editor.cpp
@@ -1533,7 +1533,7 @@ void AnimationKeyEditor::_track_editor_draw() {
 			for (Map<SelectedKey, KeyInfo>::Element *E = selection.front(); E; E = E->next()) {
 
 				int idx = E->key().track;
-				int i = idx - Math::floor(v_scroll->get_value());
+				int i = idx - (int)v_scroll->get_value();
 				if (i < 0 || i >= fit)
 					continue;
 				int y = h + i * h + sep;


### PR DESCRIPTION
The drag key glitch in the animation editor should be fixed with this pr.

*Bugsquad edit:* Closes #15285.
  