### PR TITLE
Fixing unconsistent behaviour on autotile editor

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.h
+++ b/editor/plugins/tile_set_editor_plugin.h
@@ -144,6 +144,7 @@ private:
 	void draw_grid_snap();
 	void draw_polygon_shapes();
 	void close_shape(const Vector2 &shape_anchor);
+	void select_coord(const Vector2 &coord);
 	Vector2 snap_point(const Vector2 &point);
 
 	void edit(Object *p_node);


### PR DESCRIPTION
This basically bug fix I found when creating https://github.com/godotengine/godot/pull/15262
The bug is :
- Behaviour between collision with navigation / occlusion is different. Collision need to select the tile, and select again the collision to select the collision. Navigation and occlusion only need to select the tile to select the shape. IMO, this not quite good UX. So, I change the collision behavior same as navigation / occlusion.
- When changing mode between collision, navigation and occlusion, the selected tile will not draw the shape.