### PR TITLE
Add customizable clips_input property to Control

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -629,10 +629,17 @@ void Control::_notification(int p_notification) {
 	}
 }
 
-bool Control::clips_input() const {
+void Control::set_clips_input(bool p_clip) {
 
-	return false;
+	data.clips_input = p_clip;
+	update();
 }
+
+bool Control::clips_input() {
+
+	return data.clips_input;
+}
+
 bool Control::has_point(const Point2 &p_point) const {
 
 	if (get_script_instance()) {
@@ -2643,6 +2650,7 @@ void Control::get_argument_options(const StringName &p_function, int p_idx, List
 		}
 	}
 }
+
 void Control::set_clip_contents(bool p_clip) {
 
 	data.clip_contents = p_clip;
@@ -2791,6 +2799,9 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_mouse_filter", "filter"), &Control::set_mouse_filter);
 	ClassDB::bind_method(D_METHOD("get_mouse_filter"), &Control::get_mouse_filter);
 
+	ClassDB::bind_method(D_METHOD("set_clips_input", "enable"), &Control::set_clips_input);
+	ClassDB::bind_method(D_METHOD("clips_input"), &Control::clips_input);
+
 	ClassDB::bind_method(D_METHOD("set_clip_contents", "enable"), &Control::set_clip_contents);
 	ClassDB::bind_method(D_METHOD("is_clipping_contents"), &Control::is_clipping_contents);
 
@@ -2836,6 +2847,7 @@ void Control::_bind_methods() {
 	ADD_PROPERTYNZ(PropertyInfo(Variant::REAL, "rect_rotation", PROPERTY_HINT_RANGE, "-1080,1080,0.01"), "set_rotation_degrees", "get_rotation_degrees");
 	ADD_PROPERTYNO(PropertyInfo(Variant::VECTOR2, "rect_scale"), "set_scale", "get_scale");
 	ADD_PROPERTYNO(PropertyInfo(Variant::VECTOR2, "rect_pivot_offset"), "set_pivot_offset", "get_pivot_offset");
+	ADD_PROPERTYNZ(PropertyInfo(Variant::BOOL, "rect_clips_input"), "set_clips_input", "clips_input");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::BOOL, "rect_clip_content"), "set_clip_contents", "is_clipping_contents");
 
 	ADD_GROUP("Hint", "hint_");
@@ -2968,6 +2980,7 @@ Control::Control() {
 	data.h_grow = GROW_DIRECTION_END;
 	data.v_grow = GROW_DIRECTION_END;
 
+	data.clips_input = false;
 	data.clip_contents = false;
 	for (int i = 0; i < 4; i++) {
 		data.anchor[i] = ANCHOR_BEGIN;

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -170,6 +170,7 @@ private:
 
 		MouseFilter mouse_filter;
 
+		bool clips_input;
 		bool clip_contents;
 
 		bool block_minimum_size_adjust;
@@ -299,7 +300,6 @@ public:
 	virtual Size2 get_minimum_size() const;
 	virtual Size2 get_combined_minimum_size() const;
 	virtual bool has_point(const Point2 &p_point) const;
-	virtual bool clips_input() const;
 	virtual void set_drag_forwarding(Control *p_target);
 	virtual Variant get_drag_data(const Point2 &p_point);
 	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const;
@@ -461,6 +461,9 @@ public:
 	virtual bool is_text_field() const;
 
 	Control *get_root_parent_control() const;
+
+	void set_clips_input(bool p_clip);
+	bool clips_input();
 
 	void set_clip_contents(bool p_clip);
 	bool is_clipping_contents();

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -92,11 +92,6 @@ void GraphEdit::disconnect_node(const StringName &p_from, int p_from_port, const
 	}
 }
 
-bool GraphEdit::clips_input() const {
-
-	return true;
-}
-
 void GraphEdit::get_connection_list(List<Connection> *r_connections) const {
 
 	*r_connections = connections;
@@ -1274,5 +1269,6 @@ GraphEdit::GraphEdit() {
 
 	setting_scroll_ofs = false;
 	just_disconected = false;
+	set_clips_input(true);
 	set_clip_contents(true);
 }

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -167,7 +167,6 @@ protected:
 	virtual void add_child_notify(Node *p_child);
 	virtual void remove_child_notify(Node *p_child);
 	void _notification(int p_what);
-	virtual bool clips_input() const;
 
 public:
 	Error connect_node(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port);

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -30,10 +30,6 @@
 
 #include "scroll_container.h"
 #include "os/os.h"
-bool ScrollContainer::clips_input() const {
-
-	return true;
-}
 
 Size2 ScrollContainer::get_minimum_size() const {
 
@@ -491,5 +487,6 @@ ScrollContainer::ScrollContainer() {
 	scroll_h = true;
 	scroll_v = true;
 
+	set_clips_input(true);
 	set_clip_contents(true);
 };

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -86,8 +86,6 @@ public:
 	void set_enable_v_scroll(bool p_enable);
 	bool is_v_scroll_enabled() const;
 
-	virtual bool clips_input() const;
-
 	virtual String get_configuration_warning() const;
 
 	ScrollContainer();


### PR DESCRIPTION
Enables `clips_input` as a modifiable property to complement `clip_contents`. See https://github.com/Cryszon/godot-clips-input-example for an example project.

This allows overriding `clips_input` for `GraphEdit` and `ScrollContainer`, but I think the `clip_ contents` already does the same thing. I used the original `clips_input` as the name, but was wondering if it should be renamed to `clip_input` to be more consistent with the existing `clip_contents`.

This is my first time contributing to Godot so hopefully I'm doing it right. Feedback and guidance is appreciated. I posted this on Discord yesterday but didn't get a reply so I thought I'd go ahead and make the pull request.