### PR TITLE
Fix theme inheritance

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -861,6 +861,8 @@ Ref<StyleBox> Control::get_stylebox(const StringName &p_name, const StringName &
 			class_name = ClassDB::get_parent_class_nocheck(class_name);
 		}
 
+		class_name = type;
+
 		Control *parent = Object::cast_to<Control>(theme_owner->get_parent());
 
 		if (parent)
@@ -868,8 +870,6 @@ Ref<StyleBox> Control::get_stylebox(const StringName &p_name, const StringName &
 		else
 			theme_owner = NULL;
 	}
-
-	class_name = type;
 
 	while (class_name != StringName()) {
 		if (Theme::get_default()->has_stylebox(p_name, class_name))
@@ -2155,6 +2155,7 @@ void Control::set_theme(const Ref<Theme> &p_theme) {
 	data.theme = p_theme;
 	if (!p_theme.is_null()) {
 
+		data.theme_owner = this;
 		_propagate_theme_changed(this, this);
 	} else {
 


### PR DESCRIPTION
Theme inheritance was broken (`Parent (Theme 1) -> Child (Theme 2, partial) -> SubChild (looking for stylebox missing in theme 2 but present in Theme 1 and returning the default editor theme value)` ).

You can try with this demo:

[theme_test.zip](https://github.com/godotengine/godot/files/1607357/theme_test.zip)
