### PR TITLE
Remove button from button_group when free

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -539,13 +539,13 @@ BaseButton::BaseButton() {
 	set_focus_mode(FOCUS_ALL);
 	enabled_focus_mode = FOCUS_ALL;
 	action_mode = ACTION_MODE_BUTTON_RELEASE;
+}
+
+BaseButton::~BaseButton() {
 
 	if (button_group.is_valid()) {
 		button_group->buttons.erase(this);
 	}
-}
-
-BaseButton::~BaseButton() {
 }
 
 void ButtonGroup::get_buttons(List<BaseButton *> *r_buttons) {


### PR DESCRIPTION
Button pointer still remain in `button_group->buttons`
so this causes crash after the button is freed.