### PR TITLE
Fixed loop mode values when importing a wav file.

### DIFF
--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -268,9 +268,15 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 			for (int i = 0; i < 10; i++)
 				file->get_32(); // i wish to know why should i do this... no doc!
 
-			loop = file->get_32() ? AudioStreamSample::LOOP_PING_PONG : AudioStreamSample::LOOP_FORWARD;
-			loop_begin = file->get_32();
-			loop_end = file->get_32();
+			// only read 0x00 (loop forward) and 0x01 (loop ping-pong) and skip anything else because
+			// it's not supported (loop backward), reserved for future uses or sampler specific
+			// from https://sites.google.com/site/musicgapi/technical-documents/wav-file-format#smpl (loop type values table)
+			int loop_type = file->get_32();
+			if (loop_type == 0x00 || loop_type == 0x01) {
+				loop = loop_type ? AudioStreamSample::LOOP_PING_PONG : AudioStreamSample::LOOP_FORWARD;
+				loop_begin = file->get_32();
+				loop_end = file->get_32();
+			}
 		}
 		file->seek(file_pos + chunksize);
 	}


### PR DESCRIPTION
Importing a wav file that was exported with a custom loop type was causing it being imported with loop mode ping-pong.

From the loop type values from this https://sites.google.com/site/musicgapi/technical-documents/wav-file-format#smpl anything bigger than 0x01 is a different loop type. Because some audio authoring software record a custom loop type in that field godot was importing them as ping-pong loops.

Fixes https://github.com/godotengine/godot/issues/15247
  