### PR TITLE
Filesystem and Visual Script Members delete key fix

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 #include "filesystem_dock.h"
 
+#include "core/os/keyboard.h"
 #include "editor_node.h"
 #include "editor_settings.h"
 #include "io/resource_loader.h"
@@ -1636,6 +1637,23 @@ void FileSystemDock::_file_multi_selected(int p_index, bool p_selected) {
 	call_deferred("_update_import_dock");
 }
 
+void FileSystemDock::_files_gui_input(Ref<InputEvent> p_event) {
+
+	if (get_viewport()->get_modal_stack_top())
+		return; //ignore because of modal window
+
+	Ref<InputEventKey> key = p_event;
+	if (key.is_valid() && key->is_pressed() && !key->is_echo()) {
+		if (ED_IS_SHORTCUT("filesystem_dock/duplicate", p_event)) {
+			_file_option(FILE_DUPLICATE);
+		} else if (ED_IS_SHORTCUT("filesystem_dock/copy_path", p_event)) {
+			_file_option(FILE_COPY_PATH);
+		} else if (ED_IS_SHORTCUT("filesystem_dock/delete", p_event)) {
+			_file_option(FILE_REMOVE);
+		}
+	}
+}
+
 void FileSystemDock::_file_selected() {
 
 	import_dock_needs_update = true;
@@ -1692,6 +1710,7 @@ void FileSystemDock::_update_import_dock() {
 
 void FileSystemDock::_bind_methods() {
 
+	ClassDB::bind_method(D_METHOD("_files_gui_input"), &FileSystemDock::_files_gui_input);
 	ClassDB::bind_method(D_METHOD("_update_tree"), &FileSystemDock::_update_tree);
 	ClassDB::bind_method(D_METHOD("_rescan"), &FileSystemDock::_rescan);
 	ClassDB::bind_method(D_METHOD("_favorites_pressed"), &FileSystemDock::_favorites_pressed);
@@ -1737,6 +1756,10 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	set_name("FileSystem");
 	editor = p_editor;
 	path = "res://";
+
+	ED_SHORTCUT("filesystem_dock/copy_path", TTR("Copy Path"), KEY_MASK_CMD | KEY_C);
+	ED_SHORTCUT("filesystem_dock/duplicate", TTR("Duplicate..."), KEY_MASK_CMD | KEY_D);
+	ED_SHORTCUT("filesystem_dock/delete", TTR("Delete"), KEY_DELETE);
 
 	HBoxContainer *toolbar_hbc = memnew(HBoxContainer);
 	add_child(toolbar_hbc);
@@ -1844,6 +1867,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	files->set_select_mode(ItemList::SELECT_MULTI);
 	files->set_drag_forwarding(this);
 	files->connect("item_rmb_selected", this, "_files_list_rmb_select");
+	files->connect("gui_input", this, "_files_gui_input");
 	files->connect("item_selected", this, "_file_selected");
 	files->connect("multi_selected", this, "_file_multi_selected");
 	files->connect("rmb_clicked", this, "_rmb_pressed");

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -158,6 +158,8 @@ private:
 	bool _create_tree(TreeItem *p_parent, EditorFileSystemDirectory *p_dir, Vector<String> &uncollapsed_paths);
 	void _update_tree(bool keep_collapse_state);
 
+	void _files_gui_input(Ref<InputEvent> p_event);
+
 	void _update_files(bool p_keep_selection);
 	void _update_file_display_toggle_button();
 	void _change_file_display();

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -1306,6 +1306,35 @@ void VisualScriptEditor::_input(const Ref<InputEvent> &p_event) {
 	}
 }
 
+void VisualScriptEditor::_members_gui_input(const Ref<InputEvent> &p_event) {
+
+	Ref<InputEventKey> key = p_event;
+	if (key.is_valid() && key->is_pressed() && !key->is_echo()) {
+		if (members->has_focus()) {
+			TreeItem *ti = members->get_selected();
+			if (ti) {
+				TreeItem *root = members->get_root();
+				if (ti->get_parent() == root->get_children()) {
+					member_type = MEMBER_FUNCTION;
+				}
+				if (ti->get_parent() == root->get_children()->get_next()) {
+					member_type = MEMBER_VARIABLE;
+				}
+				if (ti->get_parent() == root->get_children()->get_next()->get_next()) {
+					member_type = MEMBER_SIGNAL;
+				}
+				member_name = ti->get_text(0);
+			}
+			if (ED_IS_SHORTCUT("visual_script_editor/delete_selected", p_event)) {
+				_member_option(MEMBER_REMOVE);
+			}
+			if (ED_IS_SHORTCUT("visual_script_editor/edit_member", p_event)) {
+				_member_option(MEMBER_EDIT);
+			}
+		}
+	}
+}
+
 Variant VisualScriptEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
 
 	if (p_from == nodes) {
@@ -3088,7 +3117,7 @@ void VisualScriptEditor::_member_rmb_selected(const Vector2 &p_pos) {
 
 		member_type = MEMBER_FUNCTION;
 		member_name = ti->get_text(0);
-		member_popup->add_icon_item(del_icon, TTR("Remove Function"), MEMBER_REMOVE);
+		member_popup->add_icon_shortcut(del_icon, ED_GET_SHORTCUT("visual_script_editor/delete_selected"), MEMBER_REMOVE);
 		member_popup->popup();
 		return;
 	}
@@ -3097,9 +3126,9 @@ void VisualScriptEditor::_member_rmb_selected(const Vector2 &p_pos) {
 
 		member_type = MEMBER_VARIABLE;
 		member_name = ti->get_text(0);
-		member_popup->add_icon_item(edit_icon, TTR("Edit Variable"), MEMBER_EDIT);
+		member_popup->add_icon_shortcut(edit_icon, ED_GET_SHORTCUT("visual_script_editor/edit_member"), MEMBER_EDIT);
 		member_popup->add_separator();
-		member_popup->add_icon_item(del_icon, TTR("Remove Variable"), MEMBER_REMOVE);
+		member_popup->add_icon_shortcut(del_icon, ED_GET_SHORTCUT("visual_script_editor/delete_selected"), MEMBER_REMOVE);
 		member_popup->popup();
 		return;
 	}
@@ -3108,9 +3137,9 @@ void VisualScriptEditor::_member_rmb_selected(const Vector2 &p_pos) {
 
 		member_type = MEMBER_SIGNAL;
 		member_name = ti->get_text(0);
-		member_popup->add_icon_item(edit_icon, TTR("Edit Signal"), MEMBER_EDIT);
+		member_popup->add_icon_shortcut(edit_icon, ED_GET_SHORTCUT("visual_script_editor/edit_member"), MEMBER_EDIT);
 		member_popup->add_separator();
-		member_popup->add_icon_item(del_icon, TTR("Remove Signal"), MEMBER_REMOVE);
+		member_popup->add_icon_shortcut(del_icon, ED_GET_SHORTCUT("visual_script_editor/delete_selected"), MEMBER_REMOVE);
 		member_popup->popup();
 		return;
 	}
@@ -3241,6 +3270,7 @@ void VisualScriptEditor::_bind_methods() {
 	ClassDB::bind_method("drop_data_fw", &VisualScriptEditor::drop_data_fw);
 
 	ClassDB::bind_method("_input", &VisualScriptEditor::_input);
+	ClassDB::bind_method("_members_gui_input", &VisualScriptEditor::_members_gui_input);
 	ClassDB::bind_method("_on_nodes_delete", &VisualScriptEditor::_on_nodes_delete);
 	ClassDB::bind_method("_on_nodes_duplicate", &VisualScriptEditor::_on_nodes_duplicate);
 
@@ -3303,6 +3333,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	members->connect("button_pressed", this, "_member_button");
 	members->connect("item_edited", this, "_member_edited");
 	members->connect("cell_selected", this, "_member_selected", varray(), CONNECT_DEFERRED);
+	members->connect("gui_input", this, "_members_gui_input");
 	members->set_allow_reselect(true);
 	members->set_hide_folding(true);
 	members->set_drag_forwarding(this);
@@ -3476,12 +3507,13 @@ static void register_editor_callback() {
 
 	ScriptEditor::register_create_script_editor_function(create_editor);
 
-	ED_SHORTCUT("visual_script_editor/delete_selected", TTR("Delete Selected"));
+	ED_SHORTCUT("visual_script_editor/delete_selected", TTR("Delete Selected"), KEY_DELETE);
 	ED_SHORTCUT("visual_script_editor/toggle_breakpoint", TTR("Toggle Breakpoint"), KEY_F9);
 	ED_SHORTCUT("visual_script_editor/find_node_type", TTR("Find Node Type"), KEY_MASK_CMD + KEY_F);
 	ED_SHORTCUT("visual_script_editor/copy_nodes", TTR("Copy Nodes"), KEY_MASK_CMD + KEY_C);
 	ED_SHORTCUT("visual_script_editor/cut_nodes", TTR("Cut Nodes"), KEY_MASK_CMD + KEY_X);
 	ED_SHORTCUT("visual_script_editor/paste_nodes", TTR("Paste Nodes"), KEY_MASK_CMD + KEY_V);
+	ED_SHORTCUT("visual_script_editor/edit_member", TTR("Edit Member"), KEY_MASK_CMD + KEY_E);
 }
 
 void VisualScriptEditor::register_editor() {

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -210,6 +210,7 @@ class VisualScriptEditor : public ScriptEditorBase {
 	String revert_on_drag;
 
 	void _input(const Ref<InputEvent> &p_event);
+	void _members_gui_input(const Ref<InputEvent> &p_event);
 	void _on_nodes_delete();
 	void _on_nodes_duplicate();
 


### PR DESCRIPTION
Fixes #14568
Adds Keyboard shortcuts.
In the Filesystem allows Delete (Delete), Duplicate (Cmd+D), and Copy Node Path (Cmd+C) on files 
In the Visual Script Editor's Members area allows Delete (Delete) and Edit (Cmd+E) on variables, functions, and signals
  