### PR TITLE
Fix NEQ operation for Arrays and Pool*Arrays

### DIFF
--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -339,7 +339,7 @@ bool Variant::booleanize() const {
 	CASE_TYPE(m_prefix, m_op_name, m_name) {                                                     \
 		if (p_b.type == NIL)                                                                     \
 			_RETURN(true)                                                                        \
-		DEFAULT_OP_ARRAY_OP_BODY(m_prefix, m_op_name, m_name, m_type, !=, ==, true, true, false) \
+		DEFAULT_OP_ARRAY_OP_BODY(m_prefix, m_op_name, m_name, m_type, !=, !=, false, true, true) \
 	}
 
 #define DEFAULT_OP_ARRAY_LT(m_prefix, m_op_name, m_name, m_type) \
@@ -539,12 +539,12 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 				if (arr_b->size() != l)
 					_RETURN(true);
 				for (int i = 0; i < l; i++) {
-					if (((*arr_a)[i] == (*arr_b)[i])) {
-						_RETURN(false);
+					if (((*arr_a)[i] != (*arr_b)[i])) {
+						_RETURN(true);
 					}
 				}
 
-				_RETURN(true);
+				_RETURN(false);
 			}
 
 			DEFAULT_OP_NUM_NULL(math, OP_NOT_EQUAL, INT, !=, _int);


### PR DESCRIPTION
If we have 2 arrays like:
```
a1 = [1, 2, 3]
a2 = [1, 3, 3]
```

and compare them:

```
print(a1 != a2)
```

Before it was returning `false` because `a1[0] == a2[0]` when it should return `true` (they aren't the same)
Now it returns `true` because `a1[1] != a2[1]`

Fixes https://github.com/godotengine/godot/issues/15378
  