### PR TITLE
Fix crash when using Image.resize() without calling Image.create() first

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -447,8 +447,6 @@ void Image::convert(Format p_new_format) {
 
 	Image new_img(width, height, 0, p_new_format);
 
-	//int len=data.size();
-
 	PoolVector<uint8_t>::Read r = data.read();
 	PoolVector<uint8_t>::Write w = new_img.data.write();
 
@@ -695,6 +693,11 @@ void Image::resize_to_po2(bool p_square) {
 }
 
 void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
+
+	if (data.size() == 0) {
+		ERR_EXPLAIN("Cannot resize image before creating it, use create() or create_from_data() first.");
+		ERR_FAIL();
+	}
 
 	if (!_can_modify(format)) {
 		ERR_EXPLAIN("Cannot resize in indexed, compressed or custom image formats.");

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -395,6 +395,7 @@
 				Sets the [Color] of the pixel at [code](x, y)[/code] if the image is locked. Example:
 				[codeblock]
 				var img = Image.new()
+				img.create(img_width, img_height, false, Image.FORMAT_RGBA8)
 				img.lock()
 				img.set_pixel(x, y, color) # Works
 				img.unlock()


### PR DESCRIPTION
Fix #15374.