### PR TITLE
Fix internal Emscripten JS API calls

### DIFF
--- a/misc/dist/html/default.html
+++ b/misc/dist/html/default.html
@@ -350,7 +350,7 @@ $GODOT_HEAD_INCLUDE
 				};
 
 				function printError(text) {
-					if (!text.startsWith('**ERROR**: ')) {
+					if (!String.prototype.trim.call(text).startsWith('**ERROR**: ')) {
 						text = '**ERROR**: ' + text;
 					}
 					print(text);

--- a/platform/javascript/javascript_main.cpp
+++ b/platform/javascript/javascript_main.cpp
@@ -65,7 +65,7 @@ int main(int argc, char *argv[]) {
 		FS.mkdir('/userfs');
 		FS.mount(IDBFS, {}, '/userfs');
 		FS.syncfs(true, function(err) {
-			Module['ccall']('main_after_fs_sync', null, ['string'], [err ? err.message : ""])
+			ccall('main_after_fs_sync', null, ['string'], [err ? err.message : ""])
 		});
 	);
 	/* clang-format on */

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -566,7 +566,7 @@ void OS_JavaScript::set_css_cursor(const char *p_cursor) {
 
 	/* clang-format off */
 	EM_ASM_({
-		Module.canvas.style.cursor = Module.UTF8ToString($0);
+		Module.canvas.style.cursor = UTF8ToString($0);
 	}, p_cursor);
 	/* clang-format on */
 }
@@ -576,7 +576,7 @@ const char *OS_JavaScript::get_css_cursor() const {
 	char cursor[16];
 	/* clang-format off */
 	EM_ASM_INT({
-		Module.stringToUTF8(Module.canvas.style.cursor ? Module.canvas.style.cursor : 'auto', $0, 16);
+		stringToUTF8(Module.canvas.style.cursor ? Module.canvas.style.cursor : 'auto', $0, 16);
 	}, cursor);
 	/* clang-format on */
 	return cursor;
@@ -792,7 +792,7 @@ void OS_JavaScript::main_loop_begin() {
 
 	/* clang-format off */
 	EM_ASM_ARGS({
-		const send_notification = Module.cwrap('send_notification', null, ['number']);
+		const send_notification = cwrap('send_notification', null, ['number']);
 		const notifs = arguments;
 		(['mouseover', 'mouseleave', 'focus', 'blur']).forEach(function(event, i) {
 			Module.canvas.addEventListener(event, send_notification.bind(null, notifs[i]));


### PR DESCRIPTION
Emscripten 1.37.24 no longer exports these functions by default, but we can just call them internally

Fixes #15015 