### PR TITLE
Add standardised color names to doc and Color constructor accepting t…

### DIFF
--- a/core/color.cpp
+++ b/core/color.cpp
@@ -346,7 +346,7 @@ bool Color::html_is_valid(const String &p_color) {
 	return true;
 }
 
-Color Color::named(const String &p_name) {
+Color Color::named(const String &p_name, float alpha) {
 	if (_named_colors.empty()) _populate_named_colors(); // from color_names.inc
 	String name = p_name;
 	// Normalize name
@@ -359,7 +359,9 @@ Color Color::named(const String &p_name) {
 
 	const Map<String, Color>::Element *color = _named_colors.find(name);
 	if (color) {
-		return color->value();
+		Color col = color->value();
+		col.a = alpha;
+		return col;
 	} else {
 		ERR_EXPLAIN("Invalid Color Name: " + p_name);
 		ERR_FAIL_V(Color());

--- a/core/color.h
+++ b/core/color.h
@@ -188,7 +188,7 @@ struct Color {
 	static Color hex(uint32_t p_hex);
 	static Color html(const String &p_color);
 	static bool html_is_valid(const String &p_color);
-	static Color named(const String &p_name);
+	static Color named(const String &p_name, float alpha);
 	String to_html(bool p_alpha = true) const;
 
 	_FORCE_INLINE_ bool operator<(const Color &p_color) const; //used in set keys

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -887,6 +887,10 @@ struct _VariantCall {
 		r_ret = Color::hex(*p_args[0]);
 	}
 
+	static void Color_init5(Variant &r_ret, const Variant **p_args) {
+		r_ret = Color::named(*p_args[0], *p_args[1]);
+	}
+	
 	static void AABB_init1(Variant &r_ret, const Variant **p_args) {
 
 		r_ret = ::AABB(*p_args[0], *p_args[1]);
@@ -1801,6 +1805,7 @@ void register_variant_methods() {
 
 	_VariantCall::add_constructor(_VariantCall::Color_init1, Variant::COLOR, "r", Variant::REAL, "g", Variant::REAL, "b", Variant::REAL, "a", Variant::REAL);
 	_VariantCall::add_constructor(_VariantCall::Color_init2, Variant::COLOR, "r", Variant::REAL, "g", Variant::REAL, "b", Variant::REAL);
+	_VariantCall::add_constructor(_VariantCall::Color_init5, Variant::COLOR, "name", Variant::STRING, "alpha", Variant::REAL);
 
 	_VariantCall::add_constructor(_VariantCall::AABB_init1, Variant::AABB, "position", Variant::VECTOR3, "size", Variant::VECTOR3);
 

--- a/doc/classes/@GDScript.xml
+++ b/doc/classes/@GDScript.xml
@@ -41,10 +41,12 @@
 			<argument index="1" name="alpha" type="float">
 			</argument>
 			<description>
-				Returns color [code]name[/code] with [code]alpha[/code] ranging from 0 to 1. Note: [code]name[/code] is defined in color_names.inc.
+				Returns a color according to the standardised [code]name[/code] with [code]alpha[/code] ranging from 0 to 1. Same as [method Color.Color].
 				[codeblock]
-				red = ColorN('red')
+				red = ColorN("red", 1)
 				[/codeblock]
+				Supported color name :
+				"aliceblue", "antiquewhite", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanchedalmond", "blue", "blueviolet", "brown", "burlywood", "cadetblue", "chartreuse", "chocolate", "coral", "cornflower", "cornsilk", "crimson", "cyan", "darkblue", "darkcyan", "darkgoldenrod", "darkgray", "darkgreen", "darkkhaki", "darkmagenta", "darkolivegreen", "darkorange", "darkorchid", "darkred", "darksalmon", "darkseagreen", "darkslateblue", "darkslategray", "darkturquoise", "darkviolet", "deeppink", "deepskyblue", "dimgray", "dodgerblue", "firebrick", "floralwhite", "forestgreen", "fuchsia", "gainsboro", "ghostwhite", "gold", "goldenrod", "gray", "webgray", "green", "webgreen", "greenyellow", "honeydew", "hotpink", "indianred", "indigo", "ivory", "khaki", "lavender", "lavenderblush", "lawngreen", "lemonchiffon", "lightblue", "lightcoral", "lightcyan", "lightgoldenrod", "lightgray", "lightgreen", "lightpink", "lightsalmon", "lightseagreen", "lightskyblue", "lightslategray", "lightsteelblue", "lightyellow", "lime", "limegreen", "linen", "magenta", "maroon", "webmaroon", "mediumaquamarine", "mediumblue", "mediumorchid", "mediumpurple", "mediumseagreen", "mediumslateblue", "mediumspringgreen", "mediumturquoise", "mediumvioletred", "midnightblue", "mintcream", "mistyrose", "moccasin", "navajowhite", "navyblue", "oldlace", "olive", "olivedrab", "orange", "orangered", "orchid", "palegoldenrod", "palegreen", "paleturquoise", "palevioletred", "papayawhip", "peachpuff", "peru", "pink", "plum", "powderblue", "purple", "webpurple", "rebeccapurple", "red", "rosybrown", "royalblue", "saddlebrown", "salmon", "sandybrown", "seagreen", "seashell", "sienna", "silver", "skyblue", "slateblue", "slategray", "snow", "springgreen", "steelblue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "whitesmoke", "yellow", "yellowgreen".
 			</description>
 		</method>
 		<method name="abs">

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -48,6 +48,22 @@
 		<method name="Color">
 			<return type="Color">
 			</return>
+			<argument index="0" name="name" type="String">
+			</argument>
+			<argument index="1" name="alpha" type="float">
+			</argument>
+			<description>
+				Constructs a color according to the standardised [code]name[/code] with [code]alpha[/code] ranging from 0 to 1.
+				[codeblock]
+				var c = Color("red", 1)
+				[/codeblock]
+				Supported color name :
+				"aliceblue", "antiquewhite", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanchedalmond", "blue", "blueviolet", "brown", "burlywood", "cadetblue", "chartreuse", "chocolate", "coral", "cornflower", "cornsilk", "crimson", "cyan", "darkblue", "darkcyan", "darkgoldenrod", "darkgray", "darkgreen", "darkkhaki", "darkmagenta", "darkolivegreen", "darkorange", "darkorchid", "darkred", "darksalmon", "darkseagreen", "darkslateblue", "darkslategray", "darkturquoise", "darkviolet", "deeppink", "deepskyblue", "dimgray", "dodgerblue", "firebrick", "floralwhite", "forestgreen", "fuchsia", "gainsboro", "ghostwhite", "gold", "goldenrod", "gray", "webgray", "green", "webgreen", "greenyellow", "honeydew", "hotpink", "indianred", "indigo", "ivory", "khaki", "lavender", "lavenderblush", "lawngreen", "lemonchiffon", "lightblue", "lightcoral", "lightcyan", "lightgoldenrod", "lightgray", "lightgreen", "lightpink", "lightsalmon", "lightseagreen", "lightskyblue", "lightslategray", "lightsteelblue", "lightyellow", "lime", "limegreen", "linen", "magenta", "maroon", "webmaroon", "mediumaquamarine", "mediumblue", "mediumorchid", "mediumpurple", "mediumseagreen", "mediumslateblue", "mediumspringgreen", "mediumturquoise", "mediumvioletred", "midnightblue", "mintcream", "mistyrose", "moccasin", "navajowhite", "navyblue", "oldlace", "olive", "olivedrab", "orange", "orangered", "orchid", "palegoldenrod", "palegreen", "paleturquoise", "palevioletred", "papayawhip", "peachpuff", "peru", "pink", "plum", "powderblue", "purple", "webpurple", "rebeccapurple", "red", "rosybrown", "royalblue", "saddlebrown", "salmon", "sandybrown", "seagreen", "seashell", "sienna", "silver", "skyblue", "slateblue", "slategray", "snow", "springgreen", "steelblue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "whitesmoke", "yellow", "yellowgreen".
+			</description>
+		</method>
+		<method name="Color">
+			<return type="Color">
+			</return>
 			<argument index="0" name="from" type="int">
 			</argument>
 			<description>

--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -1169,11 +1169,7 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 				r_error.argument = 0;
 				r_ret = Variant();
 			} else {
-				Color color = Color::named(*p_args[0]);
-				if (p_arg_count == 2) {
-					VALIDATE_ARG_NUM(1);
-					color.a = *p_args[1];
-				}
+				Color color = Color::named(*p_args[0], *p_args[1]);
 				r_ret = color;
 			}
 

--- a/modules/visual_script/visual_script_builtin_funcs.cpp
+++ b/modules/visual_script/visual_script_builtin_funcs.cpp
@@ -1237,8 +1237,7 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 
 			VALIDATE_ARG_NUM(1);
 
-			Color color = Color::named(*p_inputs[0]);
-			color.a = *p_inputs[1];
+			Color color = Color::named(*p_inputs[0], *p_inputs[1]);
 
 			*r_return = String(color);
 


### PR DESCRIPTION
For #11164, added color names to the doc.

I discovered the `@GDScript.ColorN()` with this issue (but thinked many times : why Color hasn't a constructor with named color ?), so I added a constructor to do this, same as `@GDScript.ColorN()`.