### PR TITLE
Build WebAssembly release module with -Os to decrease file size

### DIFF
--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -49,8 +49,14 @@ def configure(env):
     ## Build type
 
     if (env["target"] == "release"):
-        env.Append(CCFLAGS=['-O3'])
-        env.Append(LINKFLAGS=['-O3'])
+        # Use -Os to prioritize optimizing for reduced file size. This is
+        # particularly valuable for the web platform because it directly
+        # decreases download time.
+        # -Os reduces file size by around 5 MiB over -O3. -Oz only saves about
+        # 100 KiB over -Os, which does not justify the negative impact on
+        # run-time performance.
+        env.Append(CCFLAGS=['-Os'])
+        env.Append(LINKFLAGS=['-Os'])
 
     elif (env["target"] == "release_debug"):
         env.Append(CCFLAGS=['-O2', '-DDEBUG_ENABLED'])


### PR DESCRIPTION
WebAssembly in release mode is currently built with `-O3` for performance. Since file size (= download time) is important for the web more than other platforms, I suggest we use `-Os`.

Optimization mode | `.wasm` file size
-|-
`-O3` | 16594 KiB
`-Os` | 11087 KiB
`-Oz` | 10979 KiB

I don't think using `-Oz` over `-Os` is worth the possible decrease in run-time performance.