### PR TITLE
Add standardised color names to doc

### DIFF
--- a/doc/classes/@GDScript.xml
+++ b/doc/classes/@GDScript.xml
@@ -41,10 +41,12 @@
 			<argument index="1" name="alpha" type="float">
 			</argument>
 			<description>
-				Returns color [code]name[/code] with [code]alpha[/code] ranging from 0 to 1. Note: [code]name[/code] is defined in color_names.inc.
+				Returns a color according to the standardised [code]name[/code] with [code]alpha[/code] ranging from 0 to 1.
 				[codeblock]
-				red = ColorN('red')
+				red = ColorN("red", 1)
 				[/codeblock]
+				Supported color names:
+				"aliceblue", "antiquewhite", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanchedalmond", "blue", "blueviolet", "brown", "burlywood", "cadetblue", "chartreuse", "chocolate", "coral", "cornflower", "cornsilk", "crimson", "cyan", "darkblue", "darkcyan", "darkgoldenrod", "darkgray", "darkgreen", "darkkhaki", "darkmagenta", "darkolivegreen", "darkorange", "darkorchid", "darkred", "darksalmon", "darkseagreen", "darkslateblue", "darkslategray", "darkturquoise", "darkviolet", "deeppink", "deepskyblue", "dimgray", "dodgerblue", "firebrick", "floralwhite", "forestgreen", "fuchsia", "gainsboro", "ghostwhite", "gold", "goldenrod", "gray", "webgray", "green", "webgreen", "greenyellow", "honeydew", "hotpink", "indianred", "indigo", "ivory", "khaki", "lavender", "lavenderblush", "lawngreen", "lemonchiffon", "lightblue", "lightcoral", "lightcyan", "lightgoldenrod", "lightgray", "lightgreen", "lightpink", "lightsalmon", "lightseagreen", "lightskyblue", "lightslategray", "lightsteelblue", "lightyellow", "lime", "limegreen", "linen", "magenta", "maroon", "webmaroon", "mediumaquamarine", "mediumblue", "mediumorchid", "mediumpurple", "mediumseagreen", "mediumslateblue", "mediumspringgreen", "mediumturquoise", "mediumvioletred", "midnightblue", "mintcream", "mistyrose", "moccasin", "navajowhite", "navyblue", "oldlace", "olive", "olivedrab", "orange", "orangered", "orchid", "palegoldenrod", "palegreen", "paleturquoise", "palevioletred", "papayawhip", "peachpuff", "peru", "pink", "plum", "powderblue", "purple", "webpurple", "rebeccapurple", "red", "rosybrown", "royalblue", "saddlebrown", "salmon", "sandybrown", "seagreen", "seashell", "sienna", "silver", "skyblue", "slateblue", "slategray", "snow", "springgreen", "steelblue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "whitesmoke", "yellow", "yellowgreen".
 			</description>
 		</method>
 		<method name="abs">

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A color is represented as red, green and blue (r,g,b) components. Additionally, "a" represents the alpha component, often used for transparency. Values are in floating point and usually range from 0 to 1.  Some methods (such as set_modulate(color)) may accept values &gt; 1.
+		You can also create a color from standardised color names with [method @GDScript.ColorN].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -63,7 +64,7 @@
 			<argument index="0" name="from" type="String">
 			</argument>
 			<description>
-				Constructs a color from an HTML hexadecimal color string in ARGB or RGB format.
+				Constructs a color from an HTML hexadecimal color string in ARGB or RGB format. See also [method @GDScript.ColorN].
 				The following string formats are supported:
 					[code]"#ff00ff00"[/code] - ARGB format with '#'
 					[code]"ff00ff00"[/code] - ARGB format


### PR DESCRIPTION
For #11164, added color names to the doc. Also added a reference to `@GDScript.ColorN()` from the `Color`
 class, because, well, it's the first place you search for creating Color from standardised names.

According to #14704 and #15435, this PR is a temporary solution, Godot 3.1 will handle standardised color in a more clean way : moving `@GDScript.ColorN()` to the Color class with autocompletion or something else like color constant...