### PR TITLE
Set source code font with ttf, otf

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1034,7 +1034,7 @@ void CodeTextEditor::_reset_zoom() {
 	Ref<DynamicFont> font = text_editor->get_font("font"); // reset source font size to default
 
 	if (font.is_valid()) {
-		EditorSettings::get_singleton()->set("interface/editor/source_font_size", 14);
+		EditorSettings::get_singleton()->set("interface/editor/code_font_size", 14);
 		font->set_size(14);
 	}
 }
@@ -1098,7 +1098,7 @@ bool CodeTextEditor::_add_font_size(int p_delta) {
 	if (font.is_valid()) {
 		int new_size = CLAMP(font->get_size() + p_delta, 8 * EDSCALE, 96 * EDSCALE);
 		if (new_size != font->get_size()) {
-			EditorSettings::get_singleton()->set("interface/editor/source_font_size", new_size / EDSCALE);
+			EditorSettings::get_singleton()->set("interface/editor/code_font_size", new_size / EDSCALE);
 			font->set_size(new_size);
 		}
 
@@ -1140,20 +1140,7 @@ void CodeTextEditor::set_error(const String &p_error) {
 
 void CodeTextEditor::_update_font() {
 
-	// FONTS
-	String editor_font = EDITOR_DEF("text_editor/theme/font", "");
-	bool font_overridden = false;
-	if (editor_font != "") {
-		Ref<Font> fnt = ResourceLoader::load(editor_font);
-		if (fnt.is_valid()) {
-			text_editor->add_font_override("font", fnt);
-			font_overridden = true;
-		}
-	}
-	if (!font_overridden) {
-
-		text_editor->add_font_override("font", get_font("source", "EditorFonts"));
-	}
+	text_editor->add_font_override("font", get_font("source", "EditorFonts"));
 }
 
 void CodeTextEditor::_on_settings_change() {

--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -85,15 +85,38 @@ static Ref<BitmapFont> make_font(int p_height, int p_ascent, int p_valign, int p
 	m_name->set_spacing(DynamicFont::SPACING_BOTTOM, -EDSCALE); \
 	MAKE_FALLBACKS(m_name);
 
+#define MAKE_SOURCE_FONT(m_name, m_size)                        \
+	Ref<DynamicFont> m_name;                                    \
+	m_name.instance();                                          \
+	m_name->set_size(m_size);                                   \
+	if (CustomFontSource.is_valid()) {                          \
+		m_name->set_font_data(CustomFontSource);                \
+		m_name->add_fallback(dfmono);                           \
+	} else {                                                    \
+		m_name->set_font_data(dfmono);                          \
+	}                                                           \
+	m_name->set_spacing(DynamicFont::SPACING_TOP, -EDSCALE);    \
+	m_name->set_spacing(DynamicFont::SPACING_BOTTOM, -EDSCALE); \
+	MAKE_FALLBACKS(m_name);
+
 void editor_register_fonts(Ref<Theme> p_theme) {
 	/* Custom font */
 
-	String custom_font = EditorSettings::get_singleton()->get("interface/editor/custom_font");
+	String custom_font = EditorSettings::get_singleton()->get("interface/editor/main_font");
 	Ref<DynamicFontData> CustomFont;
 	if (custom_font.length() > 0) {
 		CustomFont.instance();
 		CustomFont->set_font_path(custom_font);
 		CustomFont->set_force_autohinter(true); //just looks better..i think?
+	}
+
+	/* Custom source code font */
+
+	String custom_font_source = EditorSettings::get_singleton()->get("interface/editor/code_font");
+	Ref<DynamicFontData> CustomFontSource;
+	if (custom_font_source.length() > 0) {
+		CustomFontSource.instance();
+		CustomFontSource->set_font_path(custom_font_source);
 	}
 
 	/* Droid Sans */
@@ -135,7 +158,7 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	dfmono->set_font_ptr(_font_Hack_Regular, _font_Hack_Regular_size);
 	//dfd->set_force_autohinter(true); //just looks better..i think?
 
-	int default_font_size = int(EditorSettings::get_singleton()->get("interface/editor/font_size")) * EDSCALE;
+	int default_font_size = int(EditorSettings::get_singleton()->get("interface/editor/main_font_size")) * EDSCALE;
 	MAKE_DEFAULT_FONT(df, default_font_size);
 
 	p_theme->set_default_theme_font(df);
@@ -153,41 +176,15 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	MAKE_DEFAULT_FONT(df_rulers, 8 * EDSCALE);
 	p_theme->set_font("rulers", "EditorFonts", df_rulers);
 
-	Ref<DynamicFont> df_code;
-	df_code.instance();
-	df_code->set_size(int(EditorSettings::get_singleton()->get("interface/editor/source_font_size")) * EDSCALE);
-	df_code->set_font_data(dfmono);
-	MAKE_FALLBACKS(df_code);
-
+	MAKE_SOURCE_FONT(df_code, int(EditorSettings::get_singleton()->get("interface/editor/code_font_size")) * EDSCALE);
 	p_theme->set_font("source", "EditorFonts", df_code);
 
-	Ref<DynamicFont> df_doc_code;
-	df_doc_code.instance();
-	df_doc_code->set_size(int(EDITOR_DEF("text_editor/help/help_source_font_size", 14)) * EDSCALE);
-	df_doc_code->set_spacing(DynamicFont::SPACING_TOP, -EDSCALE);
-	df_doc_code->set_spacing(DynamicFont::SPACING_BOTTOM, -EDSCALE);
-	df_doc_code->set_font_data(dfmono);
-	MAKE_FALLBACKS(df_doc_code);
-
+	MAKE_SOURCE_FONT(df_doc_code, int(EDITOR_DEF("text_editor/help/help_source_font_size", 14)) * EDSCALE);
 	p_theme->set_font("doc_source", "EditorFonts", df_doc_code);
 
-	Ref<DynamicFont> df_output_code;
-	df_output_code.instance();
-	df_output_code->set_size(int(EDITOR_DEF("run/output/font_size", 13)) * EDSCALE);
-	df_output_code->set_spacing(DynamicFont::SPACING_TOP, -EDSCALE);
-	df_output_code->set_spacing(DynamicFont::SPACING_BOTTOM, -EDSCALE);
-	df_output_code->set_font_data(dfmono);
-	MAKE_FALLBACKS(df_output_code);
-
+	MAKE_SOURCE_FONT(df_output_code, int(EDITOR_DEF("run/output/font_size", 13)) * EDSCALE);
 	p_theme->set_font("output_source", "EditorFonts", df_output_code);
 
-	Ref<DynamicFont> df_text_editor_status_code;
-	df_text_editor_status_code.instance();
-	df_text_editor_status_code->set_size(14 * EDSCALE);
-	df_text_editor_status_code->set_spacing(DynamicFont::SPACING_TOP, -EDSCALE);
-	df_text_editor_status_code->set_spacing(DynamicFont::SPACING_BOTTOM, -EDSCALE);
-	df_text_editor_status_code->set_font_data(dfmono);
-	MAKE_FALLBACKS(df_text_editor_status_code);
-
+	MAKE_SOURCE_FONT(df_text_editor_status_code, 14 * EDSCALE);
 	p_theme->set_font("status_source", "EditorFonts", df_text_editor_status_code);
 }

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -273,12 +273,14 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("interface/editor/hidpi_mode", 0);
 	hints["interface/editor/hidpi_mode"] = PropertyInfo(Variant::INT, "interface/editor/hidpi_mode", PROPERTY_HINT_ENUM, "Auto,VeryLoDPI,LoDPI,MidDPI,HiDPI", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/scene_tabs/show_script_button", false);
-	_initial_set("interface/editor/font_size", 14);
-	hints["interface/editor/font_size"] = PropertyInfo(Variant::INT, "interface/editor/font_size", PROPERTY_HINT_RANGE, "10,40,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
-	_initial_set("interface/editor/source_font_size", 14);
-	hints["interface/editor/source_font_size"] = PropertyInfo(Variant::INT, "interface/editor/source_font_size", PROPERTY_HINT_RANGE, "8,96,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
-	_initial_set("interface/editor/custom_font", "");
-	hints["interface/editor/custom_font"] = PropertyInfo(Variant::STRING, "interface/editor/custom_font", PROPERTY_HINT_GLOBAL_FILE, "*.ttf,*.otf", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
+	_initial_set("interface/editor/main_font_size", 14);
+	hints["interface/editor/main_font_size"] = PropertyInfo(Variant::INT, "interface/editor/main_font_size", PROPERTY_HINT_RANGE, "10,40,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
+	_initial_set("interface/editor/code_font_size", 14);
+	hints["interface/editor/code_font_size"] = PropertyInfo(Variant::INT, "interface/editor/code_font_size", PROPERTY_HINT_RANGE, "8,96,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
+	_initial_set("interface/editor/main_font", "");
+	hints["interface/editor/main_font"] = PropertyInfo(Variant::STRING, "interface/editor/main_font", PROPERTY_HINT_GLOBAL_FILE, "*.ttf,*.otf", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
+	_initial_set("interface/editor/code_font", "");
+	hints["interface/editor/code_font"] = PropertyInfo(Variant::STRING, "interface/editor/code_font", PROPERTY_HINT_GLOBAL_FILE, "*.ttf,*.otf", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/dim_editor_on_dialog_popup", true);
 	_initial_set("interface/editor/dim_amount", 0.6f);
 	hints["interface/editor/dim_amount"] = PropertyInfo(Variant::REAL, "interface/editor/dim_amount", PROPERTY_HINT_RANGE, "0,1,0.01", PROPERTY_USAGE_DEFAULT);
@@ -367,8 +369,6 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["text_editor/cursor/caret_blink_speed"] = PropertyInfo(Variant::REAL, "text_editor/cursor/caret_blink_speed", PROPERTY_HINT_RANGE, "0.1, 10, 0.1");
 	_initial_set("text_editor/cursor/right_click_moves_caret", true);
 
-	_initial_set("text_editor/theme/font", "");
-	hints["text_editor/theme/font"] = PropertyInfo(Variant::STRING, "text_editor/theme/font", PROPERTY_HINT_GLOBAL_FILE, "*.font,*.tres,*.res");
 	_initial_set("text_editor/completion/auto_brace_complete", false);
 	_initial_set("text_editor/files/restore_scripts_on_load", true);
 	_initial_set("text_editor/completion/complete_file_paths", true);


### PR DESCRIPTION
renamed `interface/editor/`**custom_font** to `interface/editor/`**main_font**
moved `text_editor/theme/`**font** to `interface/editor/`**code_font**
renamed `interface/editor/`**font_size** to `interface/editor/`**main_font_size**
renamed `interface/editor/`**source_code_size** to `interface/editor/`**code_font_size**

![screenshot from 2018-01-08 05-12-25](https://user-images.githubusercontent.com/8281454/34653680-cbb4bfd2-f432-11e7-971f-d722346b49ba.png)

  
  