### PR TITLE
Fix use of execvp for freebsd

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -53,6 +53,7 @@
 
 #if defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <sys/param.h>
+#include <sys/sysctl.h>
 #endif
 #include "project_settings.h"
 #include <assert.h>
@@ -298,17 +299,7 @@ Error OS_Unix::execute(const String &p_path, const List<String> &p_arguments, bo
 			args.push_back((char *)cs[i].get_data()); // shitty C cast
 		args.push_back(0);
 
-#ifdef __FreeBSD__
-		if (p_path.find("/") != -1) {
-			// exec name contains path so use it
-			execv(p_path.utf8().get_data(), &args[0]);
-		} else {
-			// use program name and search through PATH to find it
-			execvp(getprogname(), &args[0]);
-		}
-#else
 		execvp(p_path.utf8().get_data(), &args[0]);
-#endif
 		// still alive? something failed..
 		fprintf(stderr, "**ERROR** OS_Unix::execute - Could not create child process while executing: %s\n", p_path.utf8().get_data());
 		abort();
@@ -462,12 +453,23 @@ String OS_Unix::get_executable_path() const {
 		return OS::get_executable_path();
 	}
 	return b;
-#elif defined(__FreeBSD__) || defined(__OpenBSD__)
+#elif defined(__OpenBSD__)
 	char resolved_path[MAXPATHLEN];
 
 	realpath(OS::get_executable_path().utf8().get_data(), resolved_path);
 
 	return String(resolved_path);
+#elif defined(__FreeBSD__)
+	int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
+	char buf[MAXPATHLEN];
+	size_t len = sizeof(buf);
+	if (sysctl(mib, 4, buf, &len, NULL, 0) != 0) {
+		WARN_PRINT("Couldn't get executable path from sysctl");
+		return OS::get_executable_path();
+	}
+	String b;
+	b.parse_utf8(buf);
+	return b;
 #elif defined(__APPLE__)
 	char temp_path[1];
 	uint32_t buff_size = 1;


### PR DESCRIPTION
When I first got godot running on freebsd I had a [change commited](https://github.com/godotengine/godot/commit/73ca870c81145865d5a73c7aa95431c6792d5ec1) that used execvp to relaunch godot. This only worked when godot could be found in $PATH.

I later found that this broke other uses of `OS_Unix::execute()` as it was used in other areas, such as calling xdg-open to start external processes.

The correct fix is to use sysctl to get the executable path for godot and to use the earlier call to execv. This allows godot to be started from any path and fixes the use of `OS_Unix::execute()` for other uses, like xdg-open.

I am not 100% sure, but expect the same or similar change in OS_Unix::get_executable_path to also work with openBSD.

This should resolve issue #15361
