### PR TITLE
Fixes #15416 - "The deleted nodes are hanging in the inspector."

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -38,7 +38,7 @@
 #include "project_settings.h"
 #include "scene/resources/packed_scene.h"
 
-void EditorHistory::_cleanup_history() {
+void EditorHistory::cleanup_history() {
 
 	for (int i = 0; i < history.size(); i++) {
 
@@ -48,8 +48,14 @@ void EditorHistory::_cleanup_history() {
 			if (!history[i].path[j].ref.is_null())
 				continue;
 
-			if (ObjectDB::get_instance(history[i].path[j].object))
-				continue; //has isntance, try next
+			Object *obj = ObjectDB::get_instance(history[i].path[j].object);
+			if (obj) {
+				Node *n = Object::cast_to<Node>(obj);
+				if (n && n->is_inside_tree())
+					continue;
+				if (!n) // Possibly still alive
+					continue;
+			}
 
 			if (j <= history[i].level) {
 				//before or equal level, complete fail
@@ -152,7 +158,7 @@ bool EditorHistory::is_at_end() const {
 
 bool EditorHistory::next() {
 
-	_cleanup_history();
+	cleanup_history();
 
 	if ((current + 1) < history.size())
 		current++;
@@ -164,7 +170,7 @@ bool EditorHistory::next() {
 
 bool EditorHistory::previous() {
 
-	_cleanup_history();
+	cleanup_history();
 
 	if (current > 0)
 		current--;

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -70,11 +70,11 @@ class EditorHistory {
 		Variant value;
 	};
 
-	void _cleanup_history();
-
 	void _add_object(ObjectID p_object, const String &p_property, int p_level_change);
 
 public:
+	void cleanup_history();
+
 	bool is_at_beginning() const;
 	bool is_at_end() const;
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1398,7 +1398,7 @@ void EditorNode::_property_editor_forward() {
 }
 void EditorNode::_property_editor_back() {
 
-	if (editor_history.previous())
+	if (editor_history.previous() || editor_history.get_path_size() == 1)
 		_edit_current();
 }
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1285,6 +1285,11 @@ void SceneTreeDock::_delete_confirm() {
 		editor->get_viewport_control()->update();
 
 	editor->push_item(NULL);
+
+	// Fixes the EditorHistory from still offering deleted notes
+	EditorHistory *editor_history = EditorNode::get_singleton()->get_editor_history();
+	editor_history->cleanup_history();
+	EditorNode::get_singleton()->call("_prepare_history");
 }
 
 void SceneTreeDock::_selection_changed() {


### PR DESCRIPTION
Problem was the history in #15416 
Exposed the cleanup and also called  a slightly modified _prepare_history which solves an issue where the history would not be correct after cleanup.

I am curious to know if there is a better way do determine if a node was deleted.

I am using is_inside_tree because from the look of it delete nodes never get freed in the editor. Possibly another issue, I thought it is the reference inside the history but it seems to hold references elsewhere.
  