### PR TITLE
Add EditorPlugin.build() build callbacks

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -412,6 +412,18 @@ void EditorData::paste_object_params(Object *p_object) {
 	}
 }
 
+bool EditorData::call_build() {
+
+	bool result = true;
+
+	for (int i = 0; i < editor_plugins.size() && result; i++) {
+
+		result &= editor_plugins[i]->build();
+	}
+
+	return result;
+}
+
 UndoRedo &EditorData::get_undo_redo() {
 
 	return undo_redo;

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -196,6 +196,7 @@ public:
 	NodePath get_edited_scene_live_edit_root();
 	bool check_and_update_scene(int p_idx);
 	void move_edited_scene_to_index(int p_idx);
+	bool call_build();
 
 	void set_plugin_window_layout(Ref<ConfigFile> p_layout);
 	void get_plugin_window_layout(Ref<ConfigFile> p_layout);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4527,12 +4527,21 @@ EditorBuildCallback EditorNode::build_callbacks[EditorNode::MAX_BUILD_CALLBACKS]
 
 bool EditorNode::_call_build() {
 
-	for (int i = 0; i < build_callback_count; i++) {
-		if (!build_callbacks[i]())
-			return false;
+	bool builds_successful = true;
+
+	for (int i = 0; i < build_callback_count && builds_successful; i++) {
+		if (!build_callbacks[i]()) {
+			ERR_PRINT("A Godot Engine build callback failed.");
+			builds_successful = false;
+		}
 	}
 
-	return true;
+	if (builds_successful && !editor_data.call_build()) {
+		ERR_PRINT("An EditorPlugin build callback failed.");
+		builds_successful = false;
+	}
+
+	return builds_successful;
 }
 
 void EditorNode::_inherit_imported(const String &p_action) {

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -614,6 +614,15 @@ void EditorPlugin::get_window_layout(Ref<ConfigFile> p_layout) {
 	}
 }
 
+bool EditorPlugin::build() {
+
+	if (get_script_instance() && get_script_instance()->has_method("build")) {
+		return get_script_instance()->call("build");
+	}
+
+	return true;
+}
+
 void EditorPlugin::queue_save_layout() const {
 
 	EditorNode::get_singleton()->save_layout();
@@ -686,6 +695,7 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::POOL_STRING_ARRAY, "get_breakpoints"));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo("set_window_layout", PropertyInfo(Variant::OBJECT, "layout", PROPERTY_HINT_RESOURCE_TYPE, "ConfigFile")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo("get_window_layout", PropertyInfo(Variant::OBJECT, "layout", PROPERTY_HINT_RESOURCE_TYPE, "ConfigFile")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "build"));
 
 	ADD_SIGNAL(MethodInfo("scene_changed", PropertyInfo(Variant::OBJECT, "scene_root", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
 	ADD_SIGNAL(MethodInfo("scene_closed", PropertyInfo(Variant::STRING, "filepath")));

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -186,6 +186,7 @@ public:
 	virtual void set_window_layout(Ref<ConfigFile> p_layout);
 	virtual void get_window_layout(Ref<ConfigFile> p_layout);
 	virtual void edited_scene_changed() {} // if changes are pending in editor, apply them
+	virtual bool build(); // builds with external tools. Returns true if safe to continue running scene.
 
 	EditorInterface *get_editor_interface();
 


### PR DESCRIPTION
This will enable users to create custom build callbacks from EditorPlugin scripts. People will therefore be able to create build tools for GDNative or other post-scene-save, pre-scene-run operations.