### PR TITLE
obsolete UndoRedo max_steps; no users identified

### DIFF
--- a/core/undo_redo.cpp
+++ b/core/undo_redo.cpp
@@ -246,13 +246,6 @@ void UndoRedo::commit_action() {
 
 	redo(); // perform action
 
-	if (max_steps > 0 && actions.size() > max_steps) {
-		//clear early steps
-
-		while (actions.size() > max_steps)
-			_pop_history_tail();
-	}
-
 	if (callback && actions.size() > 0) {
 		callback(callback_ud, actions[actions.size() - 1].name);
 	}
@@ -347,16 +340,6 @@ String UndoRedo::get_current_action_name() const {
 	return actions[current_action].name;
 }
 
-void UndoRedo::set_max_steps(int p_max_steps) {
-
-	max_steps = p_max_steps;
-}
-
-int UndoRedo::get_max_steps() const {
-
-	return max_steps;
-}
-
 uint64_t UndoRedo::get_version() const {
 
 	return version;
@@ -385,7 +368,6 @@ UndoRedo::UndoRedo() {
 	version = 1;
 	action_level = 0;
 	current_action = -1;
-	max_steps = -1;
 	merge_mode = MERGE_DISABLE;
 	callback = NULL;
 	callback_ud = NULL;
@@ -510,8 +492,6 @@ void UndoRedo::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear_history"), &UndoRedo::clear_history);
 	ClassDB::bind_method(D_METHOD("get_current_action_name"), &UndoRedo::get_current_action_name);
 	ClassDB::bind_method(D_METHOD("get_version"), &UndoRedo::get_version);
-	ClassDB::bind_method(D_METHOD("set_max_steps", "max_steps"), &UndoRedo::set_max_steps);
-	ClassDB::bind_method(D_METHOD("get_max_steps"), &UndoRedo::get_max_steps);
 	ClassDB::bind_method(D_METHOD("redo"), &UndoRedo::redo);
 	ClassDB::bind_method(D_METHOD("undo"), &UndoRedo::undo);
 

--- a/core/undo_redo.h
+++ b/core/undo_redo.h
@@ -79,7 +79,6 @@ private:
 	Vector<Action> actions;
 	int current_action;
 	int action_level;
-	int max_steps;
 	MergeMode merge_mode;
 	uint64_t version;
 
@@ -114,9 +113,6 @@ public:
 	void undo();
 	String get_current_action_name() const;
 	void clear_history();
-
-	void set_max_steps(int p_max_steps);
-	int get_max_steps() const;
 
 	uint64_t get_version() const;
 

--- a/doc/classes/UndoRedo.xml
+++ b/doc/classes/UndoRedo.xml
@@ -108,12 +108,6 @@
 				Get the name of the current action.
 			</description>
 		</method>
-		<method name="get_max_steps" qualifiers="const">
-			<return type="int">
-			</return>
-			<description>
-			</description>
-		</method>
 		<method name="get_version" qualifiers="const">
 			<return type="int">
 			</return>
@@ -125,14 +119,6 @@
 		<method name="redo">
 			<return type="void">
 			</return>
-			<description>
-			</description>
-		</method>
-		<method name="set_max_steps">
-			<return type="void">
-			</return>
-			<argument index="0" name="max_steps" type="int">
-			</argument>
 			<description>
 			</description>
 		</method>


### PR DESCRIPTION
Addresses #15460.

Test:

```
todd@todd-ab28d3:~/repos/remote/brainsick-godot$ cat ../brainsick-godot-tests/tests/qa/classes/UndoRedoTest.gd
extends MainLoop

var testobject1
var undoredo

func _initialize():
	testobject1 = TestClass.new()
	testobject1.set_prop(1)
	
	undoredo = UndoRedo.new()

# main test body
func _iteration(delta):
	test_create_method()
	test_create_property()
	test_undo()
	test_redo()
	
	return true # exit MainLoop

func _finalize():
	undoredo.free()

func test_create_method():
	undoredo.create_action('first action - method')
	undoredo.add_do_method(testobject1, 'set_prop', 2)
	undoredo.add_undo_method(testobject1, 'set_prop', testobject1.get_prop())
	undoredo.commit_action()
	
	assert(testobject1.prop == 2)

func test_create_property():
	undoredo.create_action('second action - property')
	undoredo.add_do_property(testobject1, 'prop', 3)
	undoredo.add_undo_property(testobject1, 'prop', testobject1.prop)
	undoredo.commit_action()
	
	assert(testobject1.prop == 3)

func test_undo():
	undoredo.undo()
	
	assert(testobject1.prop == 2)

func test_redo():
	undoredo.redo()
	
	assert(testobject1.prop == 3)

class TestClass:
	var prop
	
	func get_prop():
		return prop
	
	func set_prop(prop):
		self.prop = prop
todd@todd-ab28d3:~/repos/remote/brainsick-godot$ cat ../brainsick-godot-tests/tests/qa/classes/UndoRedoTest-max_steps.gd 
extends MainLoop

var testobject1
var undoredo

func _initialize():
	testobject1 = TestClass.new()
	testobject1.set_prop(1)
	
	undoredo = UndoRedo.new()
	undoredo.set_max_steps(1)

# main test body
func _iteration(delta):
	test_max_steps()
	
	return true # exit MainLoop

func _finalize():
	undoredo.free()

func test_max_steps():
	undoredo.create_action('first action - method')
	undoredo.add_do_method(testobject1, 'set_prop', 2)
	undoredo.add_undo_method(testobject1, 'set_prop', testobject1.get_prop())
	undoredo.commit_action()
	
	undoredo.create_action('second action - property')
	undoredo.add_do_property(testobject1, 'prop', 3)
	undoredo.add_undo_property(testobject1, 'prop', testobject1.prop)
	undoredo.commit_action()
	
	undoredo.undo()
	undoredo.undo()
	
	assert(testobject1.prop == 1)

class TestClass:
	var prop
	
	func get_prop():
		return prop
	
	func set_prop(prop):
		self.prop = prop
```

Before:

```
todd@todd-ab28d3:~/repos/remote/brainsick-godot$ ./bin/godot.x11.tools.64 -s ../brainsick-godot-tests/tests/qa/classes/UndoRedoTest.gd
No touch devices found
OpenGL ES 3.0 Renderer: AMD Radeon (TM) R9 Fury Series (AMD FIJI / DRM 3.18.0 / 4.13.0-21-generic, LLVM 5.0.0)
GLES3: max ubo light: 409
GLES3: max ubo reflections: 455, ubo size: 144
ARVR: Registered interface: Native mobile
todd@todd-ab28d3:~/repos/remote/brainsick-godot$ ./bin/godot.x11.tools.64 -s ../brainsick-godot-tests/tests/qa/classes/UndoRedoTest-max_steps.gd
No touch devices found
OpenGL ES 3.0 Renderer: AMD Radeon (TM) R9 Fury Series (AMD FIJI / DRM 3.18.0 / 4.13.0-21-generic, LLVM 5.0.0)
GLES3: max ubo light: 409
GLES3: max ubo reflections: 455, ubo size: 144
ARVR: Registered interface: Native mobile
SCRIPT ERROR: test_max_steps: Assertion failed.
   At: res://../brainsick-godot-tests/tests/qa/classes/UndoRedoTest-max_steps.gd:36.
```

After:

```
todd@todd-ab28d3:~/repos/remote/brainsick-godot$ ./bin/godot.x11.tools.64 -s ../brainsick-godot-tests/tests/qa/classes/UndoRedoTest.gd
No touch devices found
OpenGL ES 3.0 Renderer: AMD Radeon (TM) R9 Fury Series (AMD FIJI / DRM 3.18.0 / 4.13.0-21-generic, LLVM 5.0.0)
GLES3: max ubo light: 409
GLES3: max ubo reflections: 455, ubo size: 144
ARVR: Registered interface: Native mobile
todd@todd-ab28d3:~/repos/remote/brainsick-godot$ ./bin/godot.x11.tools.64 -s ../brainsick-godot-tests/tests/qa/classes/UndoRedoTest-max_steps.gd
No touch devices found
OpenGL ES 3.0 Renderer: AMD Radeon (TM) R9 Fury Series (AMD FIJI / DRM 3.18.0 / 4.13.0-21-generic, LLVM 5.0.0)
GLES3: max ubo light: 409
GLES3: max ubo reflections: 455, ubo size: 144
ARVR: Registered interface: Native mobile
SCRIPT ERROR: _initialize: Invalid call. Nonexistent function 'set_max_steps' in base 'UndoRedo'.
   At: res://../brainsick-godot-tests/tests/qa/classes/UndoRedoTest-max_steps.gd:11.

```

I also fooled around in the Editor some, doing and undoing stuff.  It did and undid successfully.  :)
  