### PR TITLE
Changes for the "Recent Scripts" menu

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -382,8 +382,6 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/completion/callhint_tooltip_offset", Vector2());
 	_initial_set("text_editor/files/restore_scripts_on_load", true);
 	_initial_set("text_editor/completion/complete_file_paths", true);
-	_initial_set("text_editor/files/maximum_recent_files", 20);
-	hints["text_editor/files/maximum_recent_files"] = PropertyInfo(Variant::INT, "text_editor/files/maximum_recent_files", PROPERTY_HINT_RANGE, "1, 200, 1");
 
 	_initial_set("docks/scene_tree/start_create_dialog_fully_expanded", false);
 	_initial_set("docks/scene_tree/draw_relationship_lines", false);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -198,6 +198,7 @@ class ScriptEditor : public PanelContainer {
 	VSplitContainer *list_split;
 	TabContainer *tab_container;
 	EditorFileDialog *file_dialog;
+	AcceptDialog *error_dialog;
 	ConfirmationDialog *erase_tab_confirm;
 	ScriptCreateDialog *script_create_dialog;
 	ScriptEditorDebugger *debugger;
@@ -227,8 +228,6 @@ class ScriptEditor : public PanelContainer {
 	Vector<ScriptHistory> history;
 	int history_pos;
 
-	Vector<String> previous_scripts;
-
 	EditorHelpIndex *help_index;
 
 	void _tab_changed(int p_which);
@@ -249,6 +248,8 @@ class ScriptEditor : public PanelContainer {
 	void _add_recent_script(String p_path);
 	void _update_recent_scripts();
 	void _open_recent_script(int p_idx);
+
+	void _show_error_dialog(String p_path);
 
 	void _close_tab(int p_idx, bool p_save = true);
 


### PR DESCRIPTION
- Scripts now are added to the list when opened, not closed.
- Scripts aren't removed from the list when selecting them.
- Removed "/" at the beginning of each item in the list, for consistency with the scene's recent list.
- Added a error dialog that opens when trying to open a nonexistent script, and made the script be removed from the list.
- Removed "Maximum Recent Files" options, as the list works differently now.

There are some bugs that I found(that happened **before** this commit) which were a little beyond the scope of this commit, and may need a little more digging. I will open issue reports about them shortly after.

- Selecting build-in scripts in the recent list opens empty docs.

Partially addresses #15240.

**UPDATE:** Fixed #15508.