### PR TITLE
Fix shader compile error on Android

### DIFF
--- a/drivers/gles3/shaders/effect_blur.glsl
+++ b/drivers/gles3/shaders/effect_blur.glsl
@@ -214,7 +214,7 @@ void main() {
 
 	vec4 color_accum = vec4(0.0);
 
-	float max_accum=0;
+	float max_accum=0.0;
 
 	for(int i=0;i<dof_kernel_size;i++) {
 


### PR DESCRIPTION
```
**ERROR**: EffectBlurShaderGLES3: Fragment Program Compilation Failed:
23:191: S0001: Type mismatch, cannot convert from 'int' to 'float'
   At: drivers/gles3/shader_gles3.cpp:168:_display_error_with_code() - EffectBlurShaderGLES3: Fragment Program Compilation Failed:
```