### PR TITLE
Fix signal arguments shadowing member variables

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -21,7 +21,7 @@
 		<method name="_toggled" qualifiers="virtual">
 			<return type="void">
 			</return>
-			<argument index="0" name="pressed" type="bool">
+			<argument index="0" name="button_pressed" type="bool">
 			</argument>
 			<description>
 				Called when button is toggled (only if toggle_mode is active).
@@ -82,7 +82,7 @@
 			</description>
 		</signal>
 		<signal name="toggled">
-			<argument index="0" name="pressed" type="bool">
+			<argument index="0" name="button_pressed" type="bool">
 			</argument>
 			<description>
 				This signal is emitted when the button was just toggled between pressed and normal states (only if toggle_mode is active). The new state is contained in the [i]pressed[/i] argument.

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -131,14 +131,14 @@
 	</members>
 	<signals>
 		<signal name="text_changed">
-			<argument index="0" name="text" type="String">
+			<argument index="0" name="new_text" type="String">
 			</argument>
 			<description>
 				Emitted when the text changes.
 			</description>
 		</signal>
 		<signal name="text_entered">
-			<argument index="0" name="text" type="String">
+			<argument index="0" name="new_text" type="String">
 			</argument>
 			<description>
 				Emitted when the user presses KEY_ENTER on the [code]LineEdit[/code].

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -504,12 +504,12 @@ void BaseButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_button_group"), &BaseButton::get_button_group);
 
 	BIND_VMETHOD(MethodInfo("_pressed"));
-	BIND_VMETHOD(MethodInfo("_toggled", PropertyInfo(Variant::BOOL, "pressed")));
+	BIND_VMETHOD(MethodInfo("_toggled", PropertyInfo(Variant::BOOL, "button_pressed")));
 
 	ADD_SIGNAL(MethodInfo("pressed"));
 	ADD_SIGNAL(MethodInfo("button_up"));
 	ADD_SIGNAL(MethodInfo("button_down"));
-	ADD_SIGNAL(MethodInfo("toggled", PropertyInfo(Variant::BOOL, "pressed")));
+	ADD_SIGNAL(MethodInfo("toggled", PropertyInfo(Variant::BOOL, "button_pressed")));
 	ADD_PROPERTYNZ(PropertyInfo(Variant::BOOL, "disabled"), "set_disabled", "is_disabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "toggle_mode"), "set_toggle_mode", "is_toggle_mode");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::BOOL, "pressed"), "set_pressed", "is_pressed");

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1413,8 +1413,8 @@ void LineEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_context_menu_enabled", "enable"), &LineEdit::set_context_menu_enabled);
 	ClassDB::bind_method(D_METHOD("is_context_menu_enabled"), &LineEdit::is_context_menu_enabled);
 
-	ADD_SIGNAL(MethodInfo("text_changed", PropertyInfo(Variant::STRING, "text")));
-	ADD_SIGNAL(MethodInfo("text_entered", PropertyInfo(Variant::STRING, "text")));
+	ADD_SIGNAL(MethodInfo("text_changed", PropertyInfo(Variant::STRING, "new_text")));
+	ADD_SIGNAL(MethodInfo("text_entered", PropertyInfo(Variant::STRING, "new_text")));
 
 	BIND_ENUM_CONSTANT(ALIGN_LEFT);
 	BIND_ENUM_CONSTANT(ALIGN_CENTER);


### PR DESCRIPTION
Fixes #10212. Comments welcome on the new names I used, if you have better ideas.. :)

There might be other cases of signal argument names conflicting properties, so it would be great if someone wants to review all `ADD_SIGNAL` calls for other potential issues.