### PR TITLE
Renamed "mode_overrides_title" to "mode_overrides_text" and changed its functionality

### DIFF
--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -103,8 +103,8 @@
 		</member>
 		<member name="mode" type="int" setter="set_mode" getter="get_mode" enum="FileDialog.Mode">
 		</member>
-		<member name="mode_overrides_title" type="bool" setter="set_mode_overrides_title" getter="is_mode_overriding_title">
-			If [code]true[/code], changing the [code]mode[/code] property will set the window title accordingly (e. g. setting mode to [code]MODE_OPEN_FILE[/code] will change the window title to "Open a File").
+		<member name="mode_overrides_text" type="bool" setter="set_mode_overrides_text" getter="is_mode_overriding_text">
+			If [code]true[/code], changing the [code]mode[/code] property will set the window text accordingly (e. g. setting mode to [code]MODE_OPEN_FILE[/code] will change the window title to "Open a File" and its OK button to "Open").
 		</member>
 		<member name="show_hidden_files" type="bool" setter="set_show_hidden_files" getter="is_showing_hidden_files">
 		</member>

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -604,12 +604,12 @@ void FileDialog::set_current_path(const String &p_path) {
 	}
 }
 
-void FileDialog::set_mode_overrides_title(bool p_override) {
-	mode_overrides_title = p_override;
+void FileDialog::set_mode_overrides_text(bool p_override) {
+	mode_overrides_text = p_override;
 }
 
-bool FileDialog::is_mode_overriding_title() const {
-	return mode_overrides_title;
+bool FileDialog::is_mode_overriding_text() const {
+	return mode_overrides_text;
 }
 
 void FileDialog::set_mode(Mode p_mode) {
@@ -618,33 +618,38 @@ void FileDialog::set_mode(Mode p_mode) {
 	switch (mode) {
 
 		case MODE_OPEN_FILE:
-			get_ok()->set_text(RTR("Open"));
-			if (mode_overrides_title)
+			if (mode_overrides_text) {
+				get_ok()->set_text(RTR("Open"));
 				set_title(RTR("Open a File"));
+			}
 			makedir->hide();
 			break;
 		case MODE_OPEN_FILES:
-			get_ok()->set_text(RTR("Open"));
-			if (mode_overrides_title)
+			if (mode_overrides_text) {
+				get_ok()->set_text(RTR("Open"));
 				set_title(RTR("Open File(s)"));
+			}
 			makedir->hide();
 			break;
 		case MODE_OPEN_DIR:
-			get_ok()->set_text(RTR("Select Current Folder"));
-			if (mode_overrides_title)
+			if (mode_overrides_text) {
+				get_ok()->set_text(RTR("Select Current Folder"));
 				set_title(RTR("Open a Directory"));
+			}
 			makedir->show();
 			break;
 		case MODE_OPEN_ANY:
-			get_ok()->set_text(RTR("Open"));
-			if (mode_overrides_title)
+			if (mode_overrides_text) {
+				get_ok()->set_text(RTR("Open"));
 				set_title(RTR("Open a File or Directory"));
+			}
 			makedir->show();
 			break;
 		case MODE_SAVE_FILE:
-			get_ok()->set_text(RTR("Save"));
-			if (mode_overrides_title)
+			if (mode_overrides_text) {
+				get_ok()->set_text(RTR("Save"));
 				set_title(RTR("Save a File"));
+			}
 			makedir->show();
 			break;
 	}
@@ -774,8 +779,8 @@ void FileDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_current_dir", "dir"), &FileDialog::set_current_dir);
 	ClassDB::bind_method(D_METHOD("set_current_file", "file"), &FileDialog::set_current_file);
 	ClassDB::bind_method(D_METHOD("set_current_path", "path"), &FileDialog::set_current_path);
-	ClassDB::bind_method(D_METHOD("set_mode_overrides_title", "override"), &FileDialog::set_mode_overrides_title);
-	ClassDB::bind_method(D_METHOD("is_mode_overriding_title"), &FileDialog::is_mode_overriding_title);
+	ClassDB::bind_method(D_METHOD("set_mode_overrides_text", "override"), &FileDialog::set_mode_overrides_text);
+	ClassDB::bind_method(D_METHOD("is_mode_overriding_text"), &FileDialog::is_mode_overriding_text);
 	ClassDB::bind_method(D_METHOD("set_mode", "mode"), &FileDialog::set_mode);
 	ClassDB::bind_method(D_METHOD("get_mode"), &FileDialog::get_mode);
 	ClassDB::bind_method(D_METHOD("get_vbox"), &FileDialog::get_vbox);
@@ -807,7 +812,7 @@ void FileDialog::_bind_methods() {
 	BIND_ENUM_CONSTANT(ACCESS_USERDATA);
 	BIND_ENUM_CONSTANT(ACCESS_FILESYSTEM);
 
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "mode_overrides_title"), "set_mode_overrides_title", "is_mode_overriding_title");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "mode_overrides_text"), "set_mode_overrides_text", "is_mode_overriding_text");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mode", PROPERTY_HINT_ENUM, "Open one,Open many,Open folder,Open any,Save"), "set_mode", "get_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "access", PROPERTY_HINT_ENUM, "Resources,User data,File system"), "set_access", "get_access");
 	ADD_PROPERTY(PropertyInfo(Variant::POOL_STRING_ARRAY, "filters"), "set_filters", "get_filters");
@@ -831,7 +836,7 @@ FileDialog::FileDialog() {
 
 	show_hidden_files = default_show_hidden_files;
 
-	mode_overrides_title = true;
+	mode_overrides_text = true;
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	add_child(vbc);

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -93,7 +93,7 @@ private:
 
 	Vector<String> filters;
 
-	bool mode_overrides_title;
+	bool mode_overrides_text;
 
 	static bool default_show_hidden_files;
 	bool show_hidden_files;
@@ -146,8 +146,8 @@ public:
 	void set_current_file(const String &p_file);
 	void set_current_path(const String &p_path);
 
-	void set_mode_overrides_title(bool p_override);
-	bool is_mode_overriding_title() const;
+	void set_mode_overrides_text(bool p_override);
+	bool is_mode_overriding_text() const;
 
 	void set_mode(Mode p_mode);
 	Mode get_mode() const;


### PR DESCRIPTION
Sorry, but another one for the 3.1 pile.

Renamed `mode_overrides_title` to `mode_overrides_text` and, as the new name suggests, made it affect not just the title but all the text in it(which basically means the title and the OK button).