### PR TITLE
Destroy AudioServer after other non-core types are unregistered

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1845,11 +1845,6 @@ void Main::cleanup() {
 	EditorNode::unregister_editor_types();
 #endif
 
-	if (audio_server) {
-		audio_server->finish();
-		memdelete(audio_server);
-	}
-
 	if (arvr_server) {
 		// cleanup now before we pull the rug from underneath...
 		memdelete(arvr_server);
@@ -1860,6 +1855,11 @@ void Main::cleanup() {
 	unregister_platform_apis();
 	unregister_scene_types();
 	unregister_server_types();
+
+	if (audio_server) {
+		audio_server->finish();
+		memdelete(audio_server);
+	}
 
 	OS::get_singleton()->finalize();
 	finalize_physics();


### PR DESCRIPTION
This is important for some GDNative bindings and probably for Mono. They
may keep references to audio objects which are freed when they are
unregistered. If AudioServer is already deleted at that point, it causes
segfaults.