### PR TITLE
Fixed graphic artifact caused by anisotropic filter

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -904,7 +904,7 @@ float G_GGX_anisotropic_2cos(float cos_theta_m, float alpha_x, float alpha_y, fl
 	float sin2 = (1.0-cos2);
 	float s_x = alpha_x * cos_phi;
 	float s_y = alpha_y * sin_phi;
-	return 1.0  / (cos_theta_m + sqrt(cos2 + (s_x*s_x + s_y*s_y)*sin2 ));
+	return 1.0  / max(cos_theta_m + sqrt(cos2 + (s_x*s_x + s_y*s_y)*sin2 ), 0.001);
 }
 
 float D_GGX_anisotropic(float cos_theta_m, float alpha_x, float alpha_y, float cos_phi, float sin_phi) {
@@ -913,7 +913,7 @@ float D_GGX_anisotropic(float cos_theta_m, float alpha_x, float alpha_y, float c
 	float r_x = cos_phi/alpha_x;
 	float r_y = sin_phi/alpha_y;
 	float d = cos2 + sin2*(r_x * r_x + r_y * r_y);
-	return 1.0 / (M_PI * alpha_x * alpha_y * d * d );
+	return 1.0 / max(M_PI * alpha_x * alpha_y * d * d, 0.001);
 }
 
 


### PR DESCRIPTION
Fixes: #15557

The artifact was caused by division by 0