### PR TITLE
Update collision shapes data on tree entered

### DIFF
--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -115,6 +115,15 @@ Vector<Vector<Vector2> > CollisionPolygon2D::_decompose_in_convex() {
 	return decomp;
 }
 
+void CollisionPolygon2D::_update_in_shape_owner(bool p_xform_only) {
+
+	parent->shape_owner_set_transform(owner_id, get_transform());
+	if (p_xform_only)
+		return;
+	parent->shape_owner_set_disabled(owner_id, disabled);
+	parent->shape_owner_set_one_way_collision(owner_id, one_way_collision);
+}
+
 void CollisionPolygon2D::_notification(int p_what) {
 
 	switch (p_what) {
@@ -124,9 +133,7 @@ void CollisionPolygon2D::_notification(int p_what) {
 			if (parent) {
 				owner_id = parent->create_shape_owner(this);
 				_build_polygon();
-				parent->shape_owner_set_transform(owner_id, get_transform());
-				parent->shape_owner_set_disabled(owner_id, disabled);
-				parent->shape_owner_set_one_way_collision(owner_id, one_way_collision);
+				_update_in_shape_owner();
 			}
 
 			/*if (Engine::get_singleton()->is_editor_hint()) {
@@ -136,10 +143,17 @@ void CollisionPolygon2D::_notification(int p_what) {
 			}*/
 
 		} break;
+		case NOTIFICATION_ENTER_TREE: {
+
+			if (parent) {
+				_update_in_shape_owner();
+			}
+
+		} break;
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
 
 			if (parent) {
-				parent->shape_owner_set_transform(owner_id, get_transform());
+				_update_in_shape_owner(true);
 			}
 
 		} break;

--- a/scene/2d/collision_polygon_2d.h
+++ b/scene/2d/collision_polygon_2d.h
@@ -59,6 +59,8 @@ protected:
 
 	void _build_polygon();
 
+	void _update_in_shape_owner(bool p_xform_only = false);
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -45,6 +45,15 @@ void CollisionShape2D::_shape_changed() {
 	update();
 }
 
+void CollisionShape2D::_update_in_shape_owner(bool p_xform_only) {
+
+	parent->shape_owner_set_transform(owner_id, get_transform());
+	if (p_xform_only)
+		return;
+	parent->shape_owner_set_disabled(owner_id, disabled);
+	parent->shape_owner_set_one_way_collision(owner_id, one_way_collision);
+}
+
 void CollisionShape2D::_notification(int p_what) {
 
 	switch (p_what) {
@@ -57,9 +66,7 @@ void CollisionShape2D::_notification(int p_what) {
 				if (shape.is_valid()) {
 					parent->shape_owner_add_shape(owner_id, shape);
 				}
-				parent->shape_owner_set_transform(owner_id, get_transform());
-				parent->shape_owner_set_disabled(owner_id, disabled);
-				parent->shape_owner_set_one_way_collision(owner_id, one_way_collision);
+				_update_in_shape_owner();
 			}
 
 			/*if (Engine::get_singleton()->is_editor_hint()) {
@@ -69,10 +76,17 @@ void CollisionShape2D::_notification(int p_what) {
 			}*/
 
 		} break;
+		case NOTIFICATION_ENTER_TREE: {
+
+			if (parent) {
+				_update_in_shape_owner();
+			}
+
+		} break;
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
 
 			if (parent) {
-				parent->shape_owner_set_transform(owner_id, get_transform());
+				_update_in_shape_owner(true);
 			}
 
 		} break;

--- a/scene/2d/collision_shape_2d.h
+++ b/scene/2d/collision_shape_2d.h
@@ -47,6 +47,8 @@ class CollisionShape2D : public Node2D {
 	bool disabled;
 	bool one_way_collision;
 
+	void _update_in_shape_owner(bool p_xform_only = false);
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/scene/3d/collision_polygon.cpp
+++ b/scene/3d/collision_polygon.cpp
@@ -73,6 +73,14 @@ void CollisionPolygon::_build_polygon() {
 	}
 }
 
+void CollisionPolygon::_update_in_shape_owner(bool p_xform_only) {
+
+	parent->shape_owner_set_transform(owner_id, get_transform());
+	if (p_xform_only)
+		return;
+	parent->shape_owner_set_disabled(owner_id, disabled);
+}
+
 void CollisionPolygon::_notification(int p_what) {
 
 	switch (p_what) {
@@ -82,14 +90,20 @@ void CollisionPolygon::_notification(int p_what) {
 			if (parent) {
 				owner_id = parent->create_shape_owner(this);
 				_build_polygon();
-				parent->shape_owner_set_transform(owner_id, get_transform());
-				parent->shape_owner_set_disabled(owner_id, disabled);
+				_update_in_shape_owner();
 			}
+		} break;
+		case NOTIFICATION_ENTER_TREE: {
+
+			if (parent) {
+				_update_in_shape_owner();
+			}
+
 		} break;
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
 
 			if (parent) {
-				parent->shape_owner_set_transform(owner_id, get_transform());
+				_update_in_shape_owner(true);
 			}
 
 		} break;

--- a/scene/3d/collision_polygon.h
+++ b/scene/3d/collision_polygon.h
@@ -51,6 +51,8 @@ protected:
 
 	void _build_polygon();
 
+	void _update_in_shape_owner(bool p_xform_only = false);
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/scene/3d/collision_shape.cpp
+++ b/scene/3d/collision_shape.cpp
@@ -64,6 +64,14 @@ void CollisionShape::make_convex_from_brothers() {
 	}
 }
 
+void CollisionShape::_update_in_shape_owner(bool p_xform_only) {
+
+	parent->shape_owner_set_transform(owner_id, get_transform());
+	if (p_xform_only)
+		return;
+	parent->shape_owner_set_disabled(owner_id, disabled);
+}
+
 void CollisionShape::_notification(int p_what) {
 
 	switch (p_what) {
@@ -75,19 +83,20 @@ void CollisionShape::_notification(int p_what) {
 				if (shape.is_valid()) {
 					parent->shape_owner_add_shape(owner_id, shape);
 				}
-				parent->shape_owner_set_transform(owner_id, get_transform());
-				parent->shape_owner_set_disabled(owner_id, disabled);
+				_update_in_shape_owner();
 			}
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
+			if (parent) {
+				_update_in_shape_owner();
+			}
 			if (get_tree()->is_debugging_collisions_hint()) {
 				_create_debug_shape();
 			}
-
 		} break;
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
 			if (parent) {
-				parent->shape_owner_set_transform(owner_id, get_transform());
+				_update_in_shape_owner(true);
 			}
 		} break;
 		case NOTIFICATION_UNPARENTED: {

--- a/scene/3d/collision_shape.h
+++ b/scene/3d/collision_shape.h
@@ -51,6 +51,8 @@ class CollisionShape : public Spatial {
 
 	void _create_debug_shape();
 
+	void _update_in_shape_owner(bool p_xform_only = false);
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();


### PR DESCRIPTION
This is needed because the final startup values for shapes may change between parenting and entering the scene tree. For instance, if the collision shape belongs to a inherited scene.

Fixes #13835.