### PR TITLE
Update collision shapes data on tree entered (2.1)

### DIFF
--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -94,6 +94,16 @@ void CollisionPolygon2D::_add_to_collision_object(Object *p_obj) {
 	//co->add_shape(shape,get_transform());
 }
 
+void CollisionPolygon2D::_update_xform_in_parent() {
+
+	if (shape_from >= 0 && shape_to >= 0) {
+		CollisionObject2D *co = get_parent()->cast_to<CollisionObject2D>();
+		for (int i = shape_from; i <= shape_to; i++) {
+			co->set_shape_transform(i, get_transform());
+		}
+	}
+}
+
 void CollisionPolygon2D::_update_parent() {
 
 	if (!can_update_body)
@@ -159,6 +169,7 @@ void CollisionPolygon2D::_notification(int p_what) {
 			unparenting = false;
 			can_update_body = get_tree()->is_editor_hint();
 			if (!get_tree()->is_editor_hint()) {
+				_update_xform_in_parent();
 				//display above all else
 				set_z_as_relative(false);
 				set_z(VS::CANVAS_ITEM_Z_MAX - 1);
@@ -174,11 +185,8 @@ void CollisionPolygon2D::_notification(int p_what) {
 				break;
 			if (can_update_body) {
 				_update_parent();
-			} else if (shape_from >= 0 && shape_to >= 0) {
-				CollisionObject2D *co = get_parent()->cast_to<CollisionObject2D>();
-				for (int i = shape_from; i <= shape_to; i++) {
-					co->set_shape_transform(i, get_transform());
-				}
+			} else {
+				_update_xform_in_parent();
 			}
 
 		} break;

--- a/scene/2d/collision_polygon_2d.h
+++ b/scene/2d/collision_polygon_2d.h
@@ -51,6 +51,7 @@ protected:
 	bool unparenting;
 
 	void _add_to_collision_object(Object *p_obj);
+	void _update_xform_in_parent();
 	void _update_parent();
 
 	bool can_update_body;

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -56,6 +56,17 @@ void CollisionShape2D::_shape_changed() {
 	_update_parent();
 }
 
+void CollisionShape2D::_update_xform_in_parent() {
+
+	if (update_shape_index >= 0) {
+
+		CollisionObject2D *co = get_parent()->cast_to<CollisionObject2D>();
+		if (co) {
+			co->set_shape_transform(update_shape_index, get_transform());
+		}
+	}
+}
+
 void CollisionShape2D::_update_parent() {
 
 	Node *parent = get_parent();
@@ -75,6 +86,7 @@ void CollisionShape2D::_notification(int p_what) {
 			unparenting = false;
 			can_update_body = get_tree()->is_editor_hint();
 			if (!get_tree()->is_editor_hint()) {
+				_update_xform_in_parent();
 				//display above all else
 				set_z_as_relative(false);
 				set_z(VS::CANVAS_ITEM_Z_MAX - 1);
@@ -87,12 +99,8 @@ void CollisionShape2D::_notification(int p_what) {
 				break;
 			if (can_update_body) {
 				_update_parent();
-			} else if (update_shape_index >= 0) {
-
-				CollisionObject2D *co = get_parent()->cast_to<CollisionObject2D>();
-				if (co) {
-					co->set_shape_transform(update_shape_index, get_transform());
-				}
+			} else {
+				_update_xform_in_parent();
 			}
 
 		} break;

--- a/scene/2d/collision_shape_2d.h
+++ b/scene/2d/collision_shape_2d.h
@@ -47,6 +47,8 @@ class CollisionShape2D : public Node2D {
 	void _set_update_shape_index(int p_index);
 	int _get_update_shape_index() const;
 
+	void _update_xform_in_parent();
+
 protected:
 	void _update_parent();
 	void _notification(int p_what);

--- a/scene/3d/collision_polygon.cpp
+++ b/scene/3d/collision_polygon.cpp
@@ -103,6 +103,19 @@ void CollisionPolygon::_add_to_collision_object(Object *p_obj) {
 	//co->add_shape(shape,get_transform());
 }
 
+void CollisionPolygon::_update_xform_in_parent() {
+
+	if (shape_from >= 0 && shape_to >= 0) {
+
+		CollisionObject *co = get_parent()->cast_to<CollisionObject>();
+		if (co) {
+			for (int i = shape_from; i <= shape_to; i++) {
+				co->set_shape_transform(i, get_transform());
+			}
+		}
+	}
+}
+
 void CollisionPolygon::_update_parent() {
 
 	if (!can_update_body)
@@ -135,6 +148,10 @@ void CollisionPolygon::_notification(int p_what) {
 			can_update_body = get_tree()->is_editor_hint();
 			set_notify_local_transform(!can_update_body);
 
+			if (!can_update_body) {
+				_update_xform_in_parent();
+			}
+
 			//indicator_instance = VisualServer::get_singleton()->instance_create2(indicator,get_world()->get_scenario());
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
@@ -151,14 +168,8 @@ void CollisionPolygon::_notification(int p_what) {
 
 		} break;
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
-			if (!can_update_body && shape_from >= 0 && shape_to >= 0) {
-
-				CollisionObject *co = get_parent()->cast_to<CollisionObject>();
-				if (co) {
-					for (int i = shape_from; i <= shape_to; i++) {
-						co->set_shape_transform(i, get_transform());
-					}
-				}
+			if (!can_update_body) {
+				_update_xform_in_parent();
 			}
 
 		} break;

--- a/scene/3d/collision_polygon.h
+++ b/scene/3d/collision_polygon.h
@@ -50,6 +50,7 @@ protected:
 	Vector<Point2> polygon;
 
 	void _add_to_collision_object(Object *p_obj);
+	void _update_xform_in_parent();
 	void _update_parent();
 
 	bool can_update_body;


### PR DESCRIPTION
This is needed because the final startup values for shapes may change between parenting and entering the scene tree. For instance, if the collision shape belongs to a inherited scene.

Fixes #8896.