### PR TITLE
Fix HTML5 feature tags

### DIFF
--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -71,7 +71,7 @@ public:
 	virtual void get_platform_features(List<String> *r_features) {
 
 		r_features->push_back("web");
-		r_features->push_back("JavaScript");
+		r_features->push_back(get_os_name());
 	}
 
 	EditorExportPlatformJavaScript();
@@ -130,7 +130,7 @@ String EditorExportPlatformJavaScript::get_name() const {
 
 String EditorExportPlatformJavaScript::get_os_name() const {
 
-	return "JavaScript";
+	return "HTML5";
 }
 
 Ref<Texture> EditorExportPlatformJavaScript::get_logo() const {

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -52,7 +52,6 @@ class OS_JavaScript : public OS_Unix {
 
 	VisualServer *visual_server;
 	AudioDriverJavaScript audio_driver_javascript;
-	const char *gl_extensions;
 
 	InputDefault *input;
 	Vector2 windowed_size;
@@ -138,8 +137,6 @@ public:
 	void main_loop_focusin();
 
 	virtual bool has_touchscreen_ui_hint() const;
-
-	void set_opengl_extensions(const char *p_gl_extensions);
 
 	virtual Error shell_open(String p_uri);
 	virtual String get_user_data_dir() const;


### PR DESCRIPTION
Set the tags for available texture compression formats.

Also use `HTML5` as platform tag, `JavaScript` tag indicates availability of the `JavaScript.eval()` singleton.

