### PR TITLE
Mono: StackFrame and MonoDevelop crash fixes

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -449,7 +449,7 @@ Vector<ScriptLanguage::StackInfo> CSharpLanguage::debug_get_current_stack_info()
 
 	// Printing an error here will result in endless recursion, so we must be careful
 
-	if (!gdmono->is_runtime_initialized() && GDMono::get_singleton()->get_api_assembly())
+	if (!gdmono->is_runtime_initialized() || !GDMono::get_singleton()->get_api_assembly() || !GDMonoUtils::mono_cache.corlib_cache_updated)
 		return Vector<StackInfo>();
 
 	MonoObject *stack_trace = mono_object_new(mono_domain_get(), CACHED_CLASS(System_Diagnostics_StackTrace)->get_mono_ptr());
@@ -502,6 +502,10 @@ Vector<ScriptLanguage::StackInfo> CSharpLanguage::stack_trace_get_info(MonoObjec
 			GDMonoUtils::print_unhandled_exception(exc, true /* fail silently to avoid endless recursion */);
 			return Vector<StackInfo>();
 		}
+
+		// TODO
+		// what if the StackFrame method is null (method_decl is empty). should we skip this frame?
+		// can reproduce with a MissingMethodException on internal calls
 
 		sif.file = GDMonoMarshal::mono_string_to_godot(file_name);
 		sif.line = file_line_num;

--- a/modules/mono/editor/monodevelop_instance.cpp
+++ b/modules/mono/editor/monodevelop_instance.cpp
@@ -35,6 +35,8 @@
 
 void MonoDevelopInstance::execute(const Vector<String> &p_files) {
 
+	_GDMONO_SCOPE_DOMAIN_(TOOLS_DOMAIN)
+
 	ERR_FAIL_NULL(execute_method);
 	ERR_FAIL_COND(gc_handle.is_null());
 

--- a/modules/mono/glue/cs_files/DebuggingUtils.cs
+++ b/modules/mono/glue/cs_files/DebuggingUtils.cs
@@ -26,6 +26,12 @@ namespace Godot
 
             MethodBase methodBase = frame.GetMethod();
 
+            if (methodBase == null)
+            {
+                methodDecl = string.Empty;
+                return;
+            }
+
             StringBuilder sb = new StringBuilder();
 
             if (methodBase is MethodInfo methodInfo)

--- a/modules/mono/mono_gd/gd_mono_utils.h
+++ b/modules/mono/mono_gd/gd_mono_utils.h
@@ -129,10 +129,16 @@ struct MonoCache {
 
 	Ref<MonoGCHandle> task_scheduler_handle;
 
+	bool corlib_cache_updated;
+	bool godot_api_cache_updated;
+
 	void clear_members();
-	void cleanup() {}
+	void cleanup();
 
 	MonoCache() {
+		corlib_cache_updated = false;
+		godot_api_cache_updated = false;
+
 		clear_members();
 	}
 };


### PR DESCRIPTION
- Execute MonoDevelop from the right appdomain. Closes #15454
- Sometimes `StackFrame.GetMethod()` returns null (e.g.: latest frame of a `MissingMethodException`). Still not sure what to do with that frame (maybe skip it), but at least it no longer fails.
- Skip `CSharpLanguage::debug_get_current_stack_info()` if an error is printed from `GDMonoUtils::update_corlib_cache()`.
- Fix crash when calling `GDMonoUtils::print_unhandled_exception(exc)` if there is no ScriptDebugger attached.
