### PR TITLE
Mono: Buildsystem improvements

### DIFF
--- a/modules/mono/SCsub
+++ b/modules/mono/SCsub
@@ -202,10 +202,16 @@ def mono_build_solution(source, target, env):
 
     copyfile(os.path.join(src_dir, asm_file), os.path.join(dst_dir, asm_file))
 
+output_dir = Dir('#bin').abspath
+assemblies_output_dir = Dir(env['mono_assemblies_output_dir']).abspath
 
-mono_sln_builder = Builder(action = mono_build_solution)
+mono_sln_builder = Builder(action=mono_build_solution)
 env_mono.Append(BUILDERS={'MonoBuildSolution': mono_sln_builder})
 env_mono.MonoBuildSolution(
-    os.path.join(Dir('#bin').abspath, 'GodotSharpTools.dll'),
+    os.path.join(assemblies_output_dir, 'GodotSharpTools.dll'),
     'editor/GodotSharpTools/GodotSharpTools.sln'
 )
+
+if os.path.normpath(output_dir) != os.path.normpath(assemblies_output_dir):
+    rel_assemblies_output_dir = os.path.relpath(assemblies_output_dir, output_dir)
+    env_mono.Append(CPPDEFINES={'GD_MONO_EDITOR_ASSEMBLIES_DIR': rel_assemblies_output_dir})

--- a/modules/mono/mono_gd/gd_mono_assembly.cpp
+++ b/modules/mono/mono_gd/gd_mono_assembly.cpp
@@ -102,6 +102,9 @@ MonoAssembly *GDMonoAssembly::_preload_hook(MonoAssemblyName *aname, char **asse
 		search_dirs.push_back(GodotSharpDirs::get_res_assemblies_dir());
 		search_dirs.push_back(OS::get_singleton()->get_resource_dir());
 		search_dirs.push_back(OS::get_singleton()->get_executable_path().get_base_dir());
+#ifdef GD_MONO_EDITOR_ASSEMBLIES_DIR
+		search_dirs.push_back(OS::get_singleton()->get_executable_path().get_base_dir().plus_file(_MKSTR(GD_MONO_EDITOR_ASSEMBLIES_DIR)).simplify_path());
+#endif
 
 		const char *rootdir = mono_assembly_getrootdir();
 		if (rootdir) {


### PR DESCRIPTION

- Bundle with mscorlib.dll to avoid compatibilities issues
- Add build option 'mono_assemblies_output_dir' to specify the output directory where the assemblies will be copied to. '#bin' by default.
