### PR TITLE
Small fix for Control bindings

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -96,7 +96,7 @@
 				Overrides the [code]name[/code] shader in the [theme] resource the node uses. If [code]shader[/code] is empty, Godot clears the override.
 			</description>
 		</method>
-		<method name="add_style_override">
+		<method name="add_stylebox_override">
 			<return type="void">
 			</return>
 			<argument index="0" name="name" type="String">
@@ -375,6 +375,14 @@
 			<return type="bool">
 			</return>
 			<argument index="0" name="point" type="Vector2">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="has_shader_override" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="name" type="String">
 			</argument>
 			<description>
 			</description>

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2747,7 +2747,7 @@ void Control::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("add_icon_override", "name", "texture"), &Control::add_icon_override);
 	ClassDB::bind_method(D_METHOD("add_shader_override", "name", "shader"), &Control::add_shader_override);
-	ClassDB::bind_method(D_METHOD("add_style_override", "name", "stylebox"), &Control::add_style_override);
+	ClassDB::bind_method(D_METHOD("add_stylebox_override", "name", "stylebox"), &Control::add_style_override);
 	ClassDB::bind_method(D_METHOD("add_font_override", "name", "font"), &Control::add_font_override);
 	ClassDB::bind_method(D_METHOD("add_color_override", "name", "color"), &Control::add_color_override);
 	ClassDB::bind_method(D_METHOD("add_constant_override", "name", "constant"), &Control::add_constant_override);
@@ -2759,6 +2759,7 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_constant", "name", "type"), &Control::get_constant, DEFVAL(""));
 
 	ClassDB::bind_method(D_METHOD("has_icon_override", "name"), &Control::has_icon_override);
+	ClassDB::bind_method(D_METHOD("has_shader_override", "name"), &Control::has_shader_override);
 	ClassDB::bind_method(D_METHOD("has_stylebox_override", "name"), &Control::has_stylebox_override);
 	ClassDB::bind_method(D_METHOD("has_font_override", "name"), &Control::has_font_override);
 	ClassDB::bind_method(D_METHOD("has_color_override", "name"), &Control::has_color_override);


### PR DESCRIPTION
* Bindings were missing for `has_shader_override`.
* Renamed `add_style_override` to `add_stylebox_override` since it's the only one using "style" over "stylebox" in GDScript. I couldn't find at first when I looked for it.