### PR TITLE
Fix clicking on sub-resources in a node's right-click menu

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2066,6 +2066,7 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	menu->connect("id_pressed", this, "_tool_selected");
 	menu_subresources = memnew(PopupMenu);
 	menu_subresources->set_name("Sub-Resources");
+	menu_subresources->connect("id_pressed", this, "_tool_selected");
 	menu->add_child(menu_subresources);
 	first_enter = true;
 	restore_script_editor_on_drag = false;


### PR DESCRIPTION
Fixes #15649