### PR TITLE
Disable colored output and progress bar when building outside of a TTY

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -8,6 +8,9 @@ Bastiaan Olij <mux213@gmail.com>
 Bernhard Liebl <poke1024@gmx.de>
 Bernhard Liebl <poke1024@gmx.org>
 Geequlim <geequlim@gmail.com>
+Hugo Locurcio <hugo.locurcio@hugo.pro>
+Hugo Locurcio <hugo.locurcio@hugo.pro> <hugo.l@openmailbox.org>
+Hugo Locurcio <hugo.locurcio@hugo.pro> <Calinou@users.noreply.github.com>
 Ignacio Etcheverry <ignalfonsore@gmail.com>
 Indah Sylvia <ISylvox@yahoo.com>
 Jakub Grzesik <kubecz3k@gmail.com>

--- a/SConstruct
+++ b/SConstruct
@@ -498,7 +498,12 @@ node_count_interval = 1
 node_pruning = 8 # Number of nodes to process before prunning the cache
 if ('env' in locals()):
     node_count_fname = str(env.Dir('#')) + '/.scons_node_count'
-show_progress = env['progress']
+# Progress reporting is not available in non-TTY environments since it
+# messes with the output (for example, when writing to a file)
+if sys.stdout.isatty():
+    show_progress = env['progress']
+else:
+    show_progress = False
 
 import time, math
 

--- a/methods.py
+++ b/methods.py
@@ -1549,18 +1549,26 @@ def save_active_platforms(apnames, ap):
 
 def no_verbose(sys, env):
 
-    # If the output is not a terminal, do nothing
-    if not sys.stdout.isatty():
-        return
-
     colors = {}
-    colors['cyan'] = '\033[96m'
-    colors['purple'] = '\033[95m'
-    colors['blue'] = '\033[94m'
-    colors['green'] = '\033[92m'
-    colors['yellow'] = '\033[93m'
-    colors['red'] = '\033[91m'
-    colors['end'] = '\033[0m'
+
+    # Colors are disabled in non-TTY environments such as pipes. This means
+    # that if output is redirected to a file, it will not contain color codes
+    if sys.stdout.isatty():
+        colors['cyan'] = '\033[96m'
+        colors['purple'] = '\033[95m'
+        colors['blue'] = '\033[94m'
+        colors['green'] = '\033[92m'
+        colors['yellow'] = '\033[93m'
+        colors['red'] = '\033[91m'
+        colors['end'] = '\033[0m'
+    else:
+        colors['cyan'] = ''
+        colors['purple'] = ''
+        colors['blue'] = ''
+        colors['green'] = ''
+        colors['yellow'] = ''
+        colors['red'] = ''
+        colors['end'] = ''
 
     compile_source_message = '%sCompiling %s==> %s$SOURCE%s' % (colors['blue'], colors['purple'], colors['yellow'], colors['end'])
     java_compile_source_message = '%sCompiling %s==> %s$SOURCE%s' % (colors['blue'], colors['purple'], colors['yellow'], colors['end'])


### PR DESCRIPTION
This makes the output more readable if it is written to a file, and more compact in continuous integration environments, keeping the log sizes low.

This commit also adds myself to .mailmap.