### PR TITLE
Fix an issue with the animation editor not seeking to the target time

### DIFF
--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -208,6 +208,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="assigned_animation" type="String" setter="set_assigned_animation" getter="get_assigned_animation">
+			If playing, the current animation; otherwise, the animation last played. When set, would change the animation, but would not play it unless currently playing. See also [member current_animation].
+		</member>
 		<member name="autoplay" type="String" setter="set_autoplay" getter="get_autoplay">
 			The name of the animation to play when the scene loads. Default value: [code]""[/code].
 		</member>

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -73,7 +73,7 @@ void AnimationPlayerEditor::_notification(int p_what) {
 			if (player->is_playing()) {
 
 				{
-					String animname = player->get_current_animation();
+					String animname = player->get_assigned_animation();
 
 					if (player->has_animation(animname)) {
 						Ref<Animation> anim = player->get_animation(animname);
@@ -186,7 +186,7 @@ void AnimationPlayerEditor::_play_pressed() {
 
 	if (current != "") {
 
-		if (current == player->get_current_animation())
+		if (current == player->get_assigned_animation())
 			player->stop(); //so it wont blend with itself
 		player->play(current);
 	}
@@ -209,7 +209,7 @@ void AnimationPlayerEditor::_play_from_pressed() {
 
 		float time = player->get_current_animation_position();
 
-		if (current == player->get_current_animation() && player->is_playing()) {
+		if (current == player->get_assigned_animation() && player->is_playing()) {
 
 			player->stop(); //so it wont blend with itself
 		}
@@ -234,7 +234,7 @@ void AnimationPlayerEditor::_play_bw_pressed() {
 
 	if (current != "") {
 
-		if (current == player->get_current_animation())
+		if (current == player->get_assigned_animation())
 			player->stop(); //so it wont blend with itself
 		player->play(current, -1, -1, true);
 	}
@@ -256,7 +256,7 @@ void AnimationPlayerEditor::_play_bw_from_pressed() {
 	if (current != "") {
 
 		float time = player->get_current_animation_position();
-		if (current == player->get_current_animation())
+		if (current == player->get_assigned_animation())
 			player->stop(); //so it wont blend with itself
 
 		player->play(current, -1, -1, true);
@@ -299,7 +299,7 @@ void AnimationPlayerEditor::_animation_selected(int p_which) {
 
 	if (current != "") {
 
-		// player->set_current_animation(current, false);
+		player->set_assigned_animation(current);
 
 		Ref<Animation> anim = player->get_animation(current);
 		{
@@ -654,9 +654,7 @@ Dictionary AnimationPlayerEditor::get_state() const {
 	d["visible"] = is_visible_in_tree();
 	if (EditorNode::get_singleton()->get_edited_scene() && is_visible_in_tree() && player) {
 		d["player"] = EditorNode::get_singleton()->get_edited_scene()->get_path_to(player);
-	}
-	if (animation->get_selected() >= 0 && animation->get_selected() < animation->get_item_count()) {
-		d["animation"] = animation->get_item_text(animation->get_selected());
+		d["animation"] = player->get_assigned_animation();
 	}
 
 	return d;
@@ -784,7 +782,7 @@ void AnimationPlayerEditor::_update_animation() {
 	}
 
 	scale->set_text(String::num(player->get_speed_scale(), 2));
-	String current = player->get_current_animation();
+	String current = player->get_assigned_animation();
 
 	for (int i = 0; i < animation->get_item_count(); i++) {
 
@@ -831,7 +829,7 @@ void AnimationPlayerEditor::_update_player() {
 		else
 			animation->add_item(E->get());
 
-		if (player->get_current_animation() == E->get())
+		if (player->get_assigned_animation() == E->get())
 			active_idx = animation->get_item_count() - 1;
 	}
 
@@ -988,7 +986,7 @@ void AnimationPlayerEditor::_seek_value_changed(float p_value, bool p_set) {
 	};
 
 	updating = true;
-	String current = player->get_current_animation(); //animation->get_item_text( animation->get_selected() );
+	String current = player->get_assigned_animation(); //animation->get_item_text( animation->get_selected() );
 	if (current == "" || !player->has_animation(current)) {
 		updating = false;
 		current = "";
@@ -1338,7 +1336,7 @@ void AnimationPlayerEditor::_prepare_onion_layers_1() {
 
 void AnimationPlayerEditor::_prepare_onion_layers_2() {
 
-	Ref<Animation> anim = player->get_animation(player->get_current_animation());
+	Ref<Animation> anim = player->get_animation(player->get_assigned_animation());
 	if (!anim.is_valid())
 		return;
 

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -977,6 +977,7 @@ bool AnimationPlayer::is_playing() const {
 	return true;
 	*/
 }
+
 void AnimationPlayer::set_current_animation(const String &p_anim) {
 
 	if (p_anim == "[stop]" || p_anim == "") {
@@ -986,18 +987,28 @@ void AnimationPlayer::set_current_animation(const String &p_anim) {
 	} else {
 		// Same animation, do not replay from start
 	}
-
-	/*
-	ERR_FAIL_COND(!animation_set.has(p_anim));
-	playback.current.pos = 0;
-	playback.current.from = &animation_set[p_anim];
-	playback.assigned = p_anim;
-	*/
 }
 
 String AnimationPlayer::get_current_animation() const {
 
 	return (is_playing() ? playback.assigned : "");
+}
+
+void AnimationPlayer::set_assigned_animation(const String &p_anim) {
+
+	if (is_playing()) {
+		play(p_anim);
+	} else {
+		ERR_FAIL_COND(!animation_set.has(p_anim));
+		playback.current.pos = 0;
+		playback.current.from = &animation_set[p_anim];
+		playback.assigned = p_anim;
+	}
+}
+
+String AnimationPlayer::get_assigned_animation() const {
+
+	return playback.assigned;
 }
 
 void AnimationPlayer::stop(bool p_reset) {
@@ -1301,6 +1312,8 @@ void AnimationPlayer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_current_animation", "anim"), &AnimationPlayer::set_current_animation);
 	ClassDB::bind_method(D_METHOD("get_current_animation"), &AnimationPlayer::get_current_animation);
+	ClassDB::bind_method(D_METHOD("set_assigned_animation", "anim"), &AnimationPlayer::set_assigned_animation);
+	ClassDB::bind_method(D_METHOD("get_assigned_animation"), &AnimationPlayer::get_assigned_animation);
 	ClassDB::bind_method(D_METHOD("queue", "name"), &AnimationPlayer::queue);
 	ClassDB::bind_method(D_METHOD("clear_queue"), &AnimationPlayer::clear_queue);
 
@@ -1331,6 +1344,7 @@ void AnimationPlayer::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "root_node"), "set_root", "get_root");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "current_animation", PROPERTY_HINT_ENUM, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_ANIMATE_AS_TRIGGER), "set_current_animation", "get_current_animation");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "assigned_animation", PROPERTY_HINT_NONE, "", 0), "set_assigned_animation", "get_assigned_animation");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "autoplay", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_autoplay", "get_autoplay");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "current_animation_length", PROPERTY_HINT_NONE, "", 0), "", "get_current_animation_length");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "current_animation_position", PROPERTY_HINT_NONE, "", 0), "", "get_current_animation_position");

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -284,6 +284,8 @@ public:
 	bool is_playing() const;
 	String get_current_animation() const;
 	void set_current_animation(const String &p_anim);
+	String get_assigned_animation() const;
+	void set_assigned_animation(const String &p_anim);
 	void stop_all();
 	void set_active(bool p_active);
 	bool is_active() const;


### PR DESCRIPTION
Also, exposes `AnimationPlayer.assigned_animation`.

Fixes #15646.