### PR TITLE
Fix anoying crash when closing the Editor

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1830,6 +1830,9 @@ void Main::cleanup() {
 		memdelete(script_debugger);
 	}
 
+	message_queue->flush();
+	memdelete(message_queue);
+
 	OS::get_singleton()->delete_main_loop();
 
 	OS::get_singleton()->_cmdline.clear();
@@ -1878,9 +1881,6 @@ void Main::cleanup() {
 		memdelete(globals);
 	if (engine)
 		memdelete(engine);
-
-	message_queue->flush();
-	memdelete(message_queue);
 
 	unregister_core_driver_types();
 	unregister_core_types();


### PR DESCRIPTION
The reason of the crash was that flushing messages was trying to call get_icon from default them, but this was previously freed.
This PR needs review from core programmers because this change may cause unexpected and undesired execution order, in that case the solution should be prevent the call to be queued in the message queue which would take some more work.