### PR TITLE
ViewportContainer passes input down to children viewports

### DIFF
--- a/scene/gui/viewport_container.h
+++ b/scene/gui/viewport_container.h
@@ -48,6 +48,7 @@ public:
 	void set_stretch(bool p_enable);
 	bool is_stretch_enabled() const;
 
+	void _input(const Ref<InputEvent> &p_event);
 	void set_stretch_shrink(int p_shrink);
 	int get_stretch_shrink() const;
 


### PR DESCRIPTION
`ViewportContainer` now listens for `_input` events and funnel them down to child viewports (unless `Viewport.disable_input` is set).

Fixes #15488.
Merger please have a look at #9950 (fixed, but latest docs should be updated to use `ViewportContainer` instead of `Control`) and #8419 (which still applies to `3.0` unless we agree it's by design, and I personally do).

You can test with: [viewport_input_test.zip](https://github.com/godotengine/godot/files/1629591/viewport_input_test.zip)
