### PR TITLE
Fix bug when launching a game with no main scene

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -744,6 +744,15 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 		goto error;
 #endif
+	} else if (String(GLOBAL_DEF("application/run/main_scene", "")) == "") {
+#ifdef TOOLS_ENABLED
+		if (!editor) {
+#endif
+			OS::get_singleton()->print("Error: Can't run project: no main scene defined.\n");
+			goto error;
+#ifdef TOOLS_ENABLED
+		}
+#endif
 	}
 
 	GLOBAL_DEF("logging/file_logging/enable_file_logging", false);


### PR DESCRIPTION
Issue #15704 

At first I wanted to do this in `Main::start` but could not find a way to isolate a launch next to a `project.godot` file. So in the end, the fix is in `Main::setup`.

Check for a main scene after loading project settings and exit if there's none (except if launching in editor mode).