### PR TITLE
PackedScene Instance Thread Safety

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -1741,8 +1741,10 @@ void PackedScene::_bind_methods() {
 	BIND_ENUM_CONSTANT(GEN_EDIT_STATE_MAIN);
 }
 
-PackedScene::PackedScene() {
-
+PackedScene::PackedScene() : mtx(Mutex::create()) {
 	state = Ref<SceneState>(memnew(SceneState));
-	mtx = Mutex::create();
+}
+
+PackedScene::~PackedScene() {
+	memdelete(mtx);
 }

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -1671,6 +1671,7 @@ bool PackedScene::can_instance() const {
 }
 
 Node *PackedScene::instance(GenEditState p_edit_state) const {
+	MutexLock lck(mtx);
 
 #ifndef TOOLS_ENABLED
 	if (p_edit_state != GEN_EDIT_STATE_DISABLED) {
@@ -1743,4 +1744,5 @@ void PackedScene::_bind_methods() {
 PackedScene::PackedScene() {
 
 	state = Ref<SceneState>(memnew(SceneState));
+	mtx = Mutex::create();
 }

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -33,6 +33,7 @@
 
 #include "resource.h"
 #include "scene/main/node.h"
+//#include "core/os/mutex.h"
 
 class SceneState : public Reference {
 
@@ -203,6 +204,7 @@ class PackedScene : public Resource {
 
 	void _set_bundled_scene(const Dictionary &p_scene);
 	Dictionary _get_bundled_scene() const;
+	mutable Mutex *mtx;
 
 protected:
 	virtual bool editor_can_reload_from_file() { return false; } // this is handled by editor better

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -234,6 +234,7 @@ public:
 	Ref<SceneState> get_state();
 
 	PackedScene();
+	~PackedScene();
 };
 
 VARIANT_ENUM_CAST(PackedScene::GenEditState)

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -33,7 +33,6 @@
 
 #include "resource.h"
 #include "scene/main/node.h"
-//#include "core/os/mutex.h"
 
 class SceneState : public Reference {
 


### PR DESCRIPTION
#15687 

Makes PackedScene.instance() threadsafe so that scenes can be instanced in background threads.

Aids in dynamic construction of large scenes, etc...