### PR TITLE
Fix CurveTexture format being incompatible with GLES3.0

### DIFF
--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1467,7 +1467,7 @@ void CurveTexture::_update() {
 
 	Ref<Image> image = memnew(Image(_width, 1, false, Image::FORMAT_RF, data));
 
-	VS::get_singleton()->texture_allocate(_texture, _width, 1, Image::FORMAT_RF, VS::TEXTURE_FLAG_FILTER);
+	VS::get_singleton()->texture_allocate(_texture, _width, 1, Image::FORMAT_RF, 0);
 	VS::get_singleton()->texture_set_data(_texture, image);
 
 	emit_changed();


### PR DESCRIPTION
CurveTexture uses format GL_R32F with filter GL_LINEAR, but according to GLES3.0 specification, GL_R32F is not filterable. Thus, CurveTexture didn't work on some mobile GPUs.  I removed TEXTURE_FLAG_FILTER flag to disable linear filter.

Tested on Sony F3311 (Mali-T720) and ASUS Z010D (Adreno 306); both had this issue and on both it was resolved with my fix.

Filterable/non-filterable texture formats are listed here: https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf paragraph 3.8.3.2 page 130-132 

Also found a related discussion at arm.com: https://community.arm.com/graphics/f/discussions/5266/is-it-somehow-possible-to-sample-a-texture-with-gl_r32f-format-with-a-sampler2d-on-mali-t-760
