### PR TITLE
Fixes for parameter names of builtin functions in visual scripts/core

### DIFF
--- a/doc/classes/@GDScript.xml
+++ b/doc/classes/@GDScript.xml
@@ -182,7 +182,7 @@
 		<method name="clamp">
 			<return type="float">
 			</return>
-			<argument index="0" name="val" type="float">
+			<argument index="0" name="value" type="float">
 			</argument>
 			<argument index="1" name="min" type="float">
 			</argument>
@@ -589,7 +589,7 @@
 		<method name="nearest_po2">
 			<return type="int">
 			</return>
-			<argument index="0" name="val" type="int">
+			<argument index="0" name="value" type="int">
 			</argument>
 			<description>
 				Returns the nearest larger power of 2 for integer [code]val[/code].

--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -1483,7 +1483,7 @@ MethodInfo GDScriptFunctions::get_info(Function p_func) {
 			return mi;
 		} break;
 		case MATH_INVERSE_LERP: {
-			MethodInfo mi("inverse_lerp", PropertyInfo(Variant::REAL, "from"), PropertyInfo(Variant::REAL, "to"), PropertyInfo(Variant::REAL, "value"));
+			MethodInfo mi("inverse_lerp", PropertyInfo(Variant::REAL, "from"), PropertyInfo(Variant::REAL, "to"), PropertyInfo(Variant::REAL, "weight"));
 			mi.return_val.type = Variant::REAL;
 			return mi;
 		} break;
@@ -1579,12 +1579,12 @@ MethodInfo GDScriptFunctions::get_info(Function p_func) {
 			return mi;
 		} break;
 		case LOGIC_CLAMP: {
-			MethodInfo mi("clamp", PropertyInfo(Variant::REAL, "val"), PropertyInfo(Variant::REAL, "min"), PropertyInfo(Variant::REAL, "max"));
+			MethodInfo mi("clamp", PropertyInfo(Variant::REAL, "value"), PropertyInfo(Variant::REAL, "min"), PropertyInfo(Variant::REAL, "max"));
 			mi.return_val.type = Variant::REAL;
 			return mi;
 		} break;
 		case LOGIC_NEAREST_PO2: {
-			MethodInfo mi("nearest_po2", PropertyInfo(Variant::INT, "val"));
+			MethodInfo mi("nearest_po2", PropertyInfo(Variant::INT, "value"));
 			mi.return_val.type = Variant::INT;
 			return mi;
 		} break;

--- a/modules/visual_script/visual_script_builtin_funcs.cpp
+++ b/modules/visual_script/visual_script_builtin_funcs.cpp
@@ -257,10 +257,10 @@ PropertyInfo VisualScriptBuiltinFunc::get_input_value_port_info(int p_idx) const
 		case MATH_ASIN:
 		case MATH_ACOS:
 		case MATH_ATAN:
-		case MATH_ATAN2:
 		case MATH_SQRT: {
-			return PropertyInfo(Variant::REAL, "num");
+			return PropertyInfo(Variant::REAL, "s");
 		} break;
+		case MATH_ATAN2:
 		case MATH_FMOD:
 		case MATH_FPOSMOD: {
 			if (p_idx == 0)
@@ -273,7 +273,7 @@ PropertyInfo VisualScriptBuiltinFunc::get_input_value_port_info(int p_idx) const
 		case MATH_ROUND:
 		case MATH_ABS:
 		case MATH_SIGN: {
-			return PropertyInfo(Variant::REAL, "num");
+			return PropertyInfo(Variant::REAL, "s");
 
 		} break;
 
@@ -287,7 +287,7 @@ PropertyInfo VisualScriptBuiltinFunc::get_input_value_port_info(int p_idx) const
 		case MATH_EXP:
 		case MATH_ISNAN:
 		case MATH_ISINF: {
-			return PropertyInfo(Variant::REAL, "num");
+			return PropertyInfo(Variant::REAL, "s");
 		} break;
 		case MATH_EASE: {
 			if (p_idx == 0)
@@ -318,7 +318,7 @@ PropertyInfo VisualScriptBuiltinFunc::get_input_value_port_info(int p_idx) const
 			else if (p_idx == 1)
 				return PropertyInfo(Variant::REAL, "to");
 			else
-				return PropertyInfo(Variant::REAL, "value");
+				return PropertyInfo(Variant::REAL, "weight");
 		} break;
 		case MATH_RANGE_LERP: {
 			if (p_idx == 0)
@@ -415,14 +415,14 @@ PropertyInfo VisualScriptBuiltinFunc::get_input_value_port_info(int p_idx) const
 		} break;
 		case LOGIC_CLAMP: {
 			if (p_idx == 0)
-				return PropertyInfo(Variant::REAL, "a");
-			else if (p_idx == 0) // FIXME: is it ok to test p_idx == 0 twice?
+				return PropertyInfo(Variant::REAL, "value");
+			else if (p_idx == 1)
 				return PropertyInfo(Variant::REAL, "min");
 			else
 				return PropertyInfo(Variant::REAL, "max");
 		} break;
 		case LOGIC_NEAREST_PO2: {
-			return PropertyInfo(Variant::INT, "num");
+			return PropertyInfo(Variant::INT, "value");
 		} break;
 		case OBJ_WEAKREF: {
 


### PR DESCRIPTION
This PR fixes the difference between visual script and gdscript in parameter names of built-in functions. 
I renamed "val" to "value" in core gd_functions for better unification..
I also fixes some bugs:

![image](https://user-images.githubusercontent.com/3036176/35000103-8a0d0512-faf4-11e7-901d-b76db0453152.png)
become
![image](https://user-images.githubusercontent.com/3036176/35000188-c9b39e10-faf4-11e7-8016-f502d23ee2e0.png)

![image](https://user-images.githubusercontent.com/3036176/35000275-05e99e20-faf5-11e7-95dd-6a826301e668.png)
become
![image](https://user-images.githubusercontent.com/3036176/35000236-f139b776-faf4-11e7-9e03-c63a3523bfc5.png)

Also inverse lerp should have "weight" instead "value"
![image](https://user-images.githubusercontent.com/3036176/35000356-4019f644-faf5-11e7-8a5e-458e7a65343b.png)
so I changed it
![image](https://user-images.githubusercontent.com/3036176/35000432-75d230b2-faf5-11e7-920b-e3b08159b222.png)

The common functions like sin,cos,abs etc will accept "s" instead "num" in visual scripts, but if its not desired I could revert this change...
