### PR TITLE
Fix marshalling when a function is returning an object from c#

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1044,7 +1044,7 @@ bool CSharpInstance::get(const StringName &p_name, Variant &r_ret) const {
 
 		if (field) {
 			MonoObject *value = field->get_value(mono_object);
-			r_ret = GDMonoMarshal::mono_object_to_variant(value, field->get_type());
+			r_ret = GDMonoMarshal::mono_object_to_variant(value);
 			return true;
 		}
 
@@ -1057,7 +1057,7 @@ bool CSharpInstance::get(const StringName &p_name, Variant &r_ret) const {
 				r_ret = Variant();
 				GDMonoUtils::print_unhandled_exception(exc);
 			} else {
-				r_ret = GDMonoMarshal::mono_object_to_variant(value, property->get_type());
+				r_ret = GDMonoMarshal::mono_object_to_variant(value);
 			}
 			return true;
 		}
@@ -1147,7 +1147,7 @@ Variant CSharpInstance::call(const StringName &p_method, const Variant **p_args,
 			MonoObject *return_value = method->invoke(mono_object, p_args);
 
 			if (return_value) {
-				return GDMonoMarshal::mono_object_to_variant(return_value, method->get_return_type());
+				return GDMonoMarshal::mono_object_to_variant(return_value);
 			} else {
 				return Variant();
 			}
@@ -1633,7 +1633,7 @@ Variant CSharpScript::call(const StringName &p_method, const Variant **p_args, i
 			MonoObject *result = method->invoke(NULL, p_args);
 
 			if (result) {
-				return GDMonoMarshal::mono_object_to_variant(result, method->get_return_type());
+				return GDMonoMarshal::mono_object_to_variant(result);
 			} else {
 				return Variant();
 			}

--- a/modules/mono/mono_gd/gd_mono_marshal.cpp
+++ b/modules/mono/mono_gd/gd_mono_marshal.cpp
@@ -459,11 +459,7 @@ Variant mono_object_to_variant(MonoObject *p_obj) {
 	type.type_encoding = mono_type_get_type(raw_type);
 	type.type_class = tclass;
 
-	return mono_object_to_variant(p_obj, type);
-}
-
-Variant mono_object_to_variant(MonoObject *p_obj, const ManagedType &p_type) {
-	switch (p_type.type_encoding) {
+	switch (type.type_encoding) {
 		case MONO_TYPE_BOOLEAN:
 			return (bool)unbox<MonoBoolean>(p_obj);
 
@@ -497,7 +493,7 @@ Variant mono_object_to_variant(MonoObject *p_obj, const ManagedType &p_type) {
 		} break;
 
 		case MONO_TYPE_VALUETYPE: {
-			GDMonoClass *tclass = p_type.type_class;
+			GDMonoClass *tclass = type.type_class;
 
 			if (tclass == CACHED_CLASS(Vector2))
 				RETURN_UNBOXED_STRUCT(Vector2, p_obj);
@@ -535,7 +531,7 @@ Variant mono_object_to_variant(MonoObject *p_obj, const ManagedType &p_type) {
 
 		case MONO_TYPE_ARRAY:
 		case MONO_TYPE_SZARRAY: {
-			MonoArrayType *array_type = mono_type_get_array_type(GDMonoClass::get_raw_type(p_type.type_class));
+			MonoArrayType *array_type = mono_type_get_array_type(GDMonoClass::get_raw_type(type.type_class));
 
 			if (array_type->eklass == CACHED_CLASS_RAW(MonoObject))
 				return mono_array_to_Array((MonoArray *)p_obj);
@@ -566,7 +562,7 @@ Variant mono_object_to_variant(MonoObject *p_obj, const ManagedType &p_type) {
 		} break;
 
 		case MONO_TYPE_CLASS: {
-			GDMonoClass *type_class = p_type.type_class;
+			GDMonoClass *type_class = type.type_class;
 
 			// GodotObject
 			if (CACHED_CLASS(GodotObject)->is_assignable_from(type_class)) {
@@ -586,14 +582,14 @@ Variant mono_object_to_variant(MonoObject *p_obj, const ManagedType &p_type) {
 		} break;
 
 		case MONO_TYPE_GENERICINST: {
-			if (CACHED_RAW_MONO_CLASS(Dictionary) == p_type.type_class->get_mono_ptr()) {
+			if (CACHED_RAW_MONO_CLASS(Dictionary) == type.type_class->get_mono_ptr()) {
 				return mono_object_to_Dictionary(p_obj);
 			}
 		} break;
 	}
 
 	ERR_EXPLAIN(String() + "Attempted to convert an unmarshallable managed type to Variant. Name: \'" +
-				p_type.type_class->get_name() + "\' Encoding: " + itos(p_type.type_encoding));
+				type.type_class->get_name() + "\' Encoding: " + itos(type.type_encoding));
 	ERR_FAIL_V(Variant());
 }
 

--- a/modules/mono/mono_gd/gd_mono_marshal.h
+++ b/modules/mono/mono_gd/gd_mono_marshal.h
@@ -102,7 +102,6 @@ _FORCE_INLINE_ MonoObject *variant_to_mono_object(Variant p_var) {
 }
 
 Variant mono_object_to_variant(MonoObject *p_obj);
-Variant mono_object_to_variant(MonoObject *p_obj, const ManagedType &p_type);
 
 // Array
 


### PR DESCRIPTION
Here's the situation now: if you setup those two nodes in a project, the behavior is inconsistent.

```c#
public class Foo : Node
{
    public object[] GetVar() { return new object[] { "foo"; } }
    public object GetVar2() { return "foo"; }
}
```
```gdscript
extends Node

export (NodePath) var fooPath
onready var foo = get_node(fooPath)

func _ready():
    print(foo.call("GetVar"))
    print(foo.call("GetVar2"))
```

It prints:
```
[foo]
Null
```
And raise a marshalling error when calling `GetVar2`.

To fix this, I removed the hint we're getting from the function return type. I'm not sure we should always do this or only when the return type is actually `object`.