### PR TITLE
Made possible to reselect the same member/help section in the script overview lists

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1323,6 +1323,7 @@ void ScriptEditor::ensure_focus_current() {
 }
 
 void ScriptEditor::_members_overview_selected(int p_idx) {
+	members_overview->unselect(p_idx);
 	Node *current = tab_container->get_child(tab_container->get_current_tab());
 	ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(current);
 	if (!se) {
@@ -1337,6 +1338,7 @@ void ScriptEditor::_members_overview_selected(int p_idx) {
 }
 
 void ScriptEditor::_help_overview_selected(int p_idx) {
+	help_overview->unselect(p_idx);
 	Node *current = tab_container->get_child(tab_container->get_current_tab());
 	EditorHelp *se = Object::cast_to<EditorHelp>(current);
 	if (!se) {


### PR DESCRIPTION
Before you had to click in another member/section, and then click back into it. The side effect is that now it doesn't highlight it anymore, but I think it's a worthy trade-off for the benefit:
![peek 2018-01-17 18-49](https://user-images.githubusercontent.com/30739239/35066283-3ac70cc8-fbb7-11e7-90c8-79afca046685.gif)