### PR TITLE
Fix find/replace bar

### DIFF
--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -63,12 +63,12 @@ class FindReplaceBar : public HBoxContainer {
 
 	GDCLASS(FindReplaceBar, HBoxContainer);
 
+	Control *container;
 	LineEdit *search_text;
 	ToolButton *find_prev;
 	ToolButton *find_next;
 	CheckBox *case_sensitive;
 	CheckBox *whole_words;
-	Label *error_label;
 	TextureButton *hide_button;
 
 	LineEdit *replace_text;
@@ -76,9 +76,10 @@ class FindReplaceBar : public HBoxContainer {
 	Button *replace_all;
 	CheckBox *selection_only;
 
-	VBoxContainer *text_vbc;
-	HBoxContainer *replace_hbc;
-	HBoxContainer *replace_options_hbc;
+	HBoxContainer *hbc;
+	VBoxContainer *vbc_lineedit;
+	HBoxContainer *hbc_button_replace;
+	HBoxContainer *hbc_option_replace;
 
 	TextEdit *text_edit;
 
@@ -98,6 +99,7 @@ class FindReplaceBar : public HBoxContainer {
 	void _search_text_changed(const String &p_text);
 	void _search_text_entered(const String &p_text);
 	void _replace_text_entered(const String &p_text);
+	void _update_size();
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
- make LineEdit resizable for find/replace
- move replaced count/no match message to status bar
- fix replaced n occuurence message is not displayed when n > 0

Fixes #15394 

![find](https://user-images.githubusercontent.com/8281454/35073695-7e74879a-fc2d-11e7-8df7-a4f561ec3615.gif)
