### PR TITLE
remove usage of C#7 in DebuggingUtils.cs for compatibility with 2015 Build Tools

### DIFF
--- a/modules/mono/glue/cs_files/DebuggingUtils.cs
+++ b/modules/mono/glue/cs_files/DebuggingUtils.cs
@@ -34,8 +34,8 @@ namespace Godot
 
             StringBuilder sb = new StringBuilder();
 
-            if (methodBase is MethodInfo methodInfo)
-                sb.AppendTypeName(methodInfo.ReturnType);
+            if (methodBase is MethodInfo)
+                sb.AppendTypeName(((MethodInfo)methodBase).ReturnType);
 
             sb.Append(methodBase.DeclaringType.FullName);
             sb.Append(".");


### PR DESCRIPTION
*Bugsquad edit:* Fixes #15742