### PR TITLE
Fix option run/output/always_open_output_on_play

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -612,7 +612,9 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 
 			if (!EditorNode::get_log()->is_visible()) {
 				if (EditorNode::get_singleton()->are_bottom_panels_hidden()) {
-					EditorNode::get_singleton()->make_bottom_panel_item_visible(EditorNode::get_log());
+					if (EDITOR_GET("run/output/always_open_output_on_play")) {
+						EditorNode::get_singleton()->make_bottom_panel_item_visible(EditorNode::get_log());
+					}
 				}
 			}
 			EditorNode::get_log()->add_message(t);


### PR DESCRIPTION
Option ```run/output/always_open_output_on_play``` was not working