### PR TITLE
only draw panorama sky when fully configured

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2361,7 +2361,9 @@ void RasterizerSceneGLES3::_draw_sky(RasterizerStorageGLES3::Sky *p_sky, const C
 
 	RasterizerStorageGLES3::Texture *tex = storage->texture_owner.getornull(p_sky->panorama);
 
-	ERR_FAIL_COND(!tex);
+	if (!tex)
+		return;
+
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(tex->target, tex->tex_id);
 


### PR DESCRIPTION
Fixes the bug part of #10541.

Makes no attempt to address the usability issue of a default or warning.