### PR TITLE
EditorScenePostImport: added get_source_folder() and get_source_file(…

### DIFF
--- a/doc/classes/EditorScenePostImport.xml
+++ b/doc/classes/EditorScenePostImport.xml
@@ -1,20 +1,56 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="EditorScenePostImport" inherits="Reference" category="Core" version="3.1">
 	<brief_description>
+		Post process scenes after import
 	</brief_description>
 	<description>
+		The imported scene can be automatically modified right after import by specifying a 'custom script' that inherits from this class. The [method post_import]-method receives the imported scene's root-node and returns the modified version of the scene
 	</description>
 	<tutorials>
+		http://docs.godotengine.org/en/latest/learning/workflow/assets/importing_scenes.html?highlight=post%20import
 	</tutorials>
 	<demos>
+		[codeblock]
+tool # needed so it runs in editor
+extends EditorScenePostImport
+
+# This sample changes all node names
+
+# get called right after the scene is imported and gets the root-node
+func post_import(scene):
+	# change all node names to "modified_[oldnodename]"
+    iterate(scene)
+    return scene # remember to return the imported scene
+
+func iterate(node):
+    if node!=null:
+        node.name = "modified_"+node.name
+        for child in node.get_children():
+            iterate(child)	
+[/codeblock]
 	</demos>
 	<methods>
+		<method name="get_source_file" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+				Returns the source-file-path which got imported (e.g. [code]res://scene.dae[/code] )
+			</description>
+		</method>
+		<method name="get_source_folder" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+				Returns the resource-folder the imported scene-file is located in
+			</description>
+		</method>
 		<method name="post_import" qualifiers="virtual">
-			<return type="void">
+			<return type="Object">
 			</return>
 			<argument index="0" name="scene" type="Object">
 			</argument>
 			<description>
+				Gets called after the scene got imported and has to return the modified version of the scene
 			</description>
 		</method>
 	</methods>

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -130,7 +130,9 @@ void EditorSceneImporter::_bind_methods() {
 /////////////////////////////////
 void EditorScenePostImport::_bind_methods() {
 
-	BIND_VMETHOD(MethodInfo("post_import", PropertyInfo(Variant::OBJECT, "scene")));
+	BIND_VMETHOD(MethodInfo(Variant::OBJECT, "post_import", PropertyInfo(Variant::OBJECT, "scene")));
+	ClassDB::bind_method(D_METHOD("get_source_folder"), &EditorScenePostImport::get_source_folder);
+	ClassDB::bind_method(D_METHOD("get_source_file"), &EditorScenePostImport::get_source_file);
 }
 
 Node *EditorScenePostImport::post_import(Node *p_scene) {
@@ -139,6 +141,21 @@ Node *EditorScenePostImport::post_import(Node *p_scene) {
 		return get_script_instance()->call("post_import", p_scene);
 
 	return p_scene;
+}
+
+String EditorScenePostImport::get_source_folder() const {
+
+	return source_folder;
+}
+
+String EditorScenePostImport::get_source_file() const {
+
+	return source_file;
+}
+
+void EditorScenePostImport::init(const String &p_source_folder, const String &p_source_file) {
+	source_folder = p_source_folder;
+	source_file = p_source_file;
 }
 
 EditorScenePostImport::EditorScenePostImport() {
@@ -1346,6 +1363,7 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 	}
 
 	if (post_import_script.is_valid()) {
+		post_import_script->init(base_path, p_source_file);
 		scene = post_import_script->post_import(scene);
 		if (!scene) {
 			EditorNode::add_io_error(TTR("Error running post-import script:") + " " + post_import_script_path);

--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -75,11 +75,17 @@ class EditorScenePostImport : public Reference {
 
 	GDCLASS(EditorScenePostImport, Reference);
 
+	String source_folder;
+	String source_file;
+
 protected:
 	static void _bind_methods();
 
 public:
+	String get_source_folder() const;
+	String get_source_file() const;
 	virtual Node *post_import(Node *p_scene);
+	virtual void init(const String &p_scene_folder, const String &p_scene_path);
 	EditorScenePostImport();
 };
 


### PR DESCRIPTION
…) methods

When creating a custom script(gdscript) to be used with the editor's import-panel to alter a newly imported scene you might need to import resources that got written with the imported file. e.g. a dae got exported and has some references in it where to find other resources. To be able to find those you need at least the folder where the source-scene is located in.
This PR adds two methods:
String get_source_folder() // returns the folder path the imported file is located in (in "res://"-notation)
String get_source_file() // returns the file-path the (folder + filename) of the loaded scene-resource

Additionally I provided the corresponding API-Reference