### PR TITLE
Syntax coloring for auto completion result

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -164,6 +164,7 @@ void ScriptTextEditor::_load_theme_settings() {
 	text_edit->add_color_override("search_result_color", search_result_color);
 	text_edit->add_color_override("search_result_border_color", search_result_border_color);
 	text_edit->add_color_override("symbol_color", symbol_color);
+	text_edit->add_color_override("basetype_color", basetype_color);
 
 	text_edit->add_constant_override("line_spacing", EDITOR_DEF("text_editor/theme/line_spacing", 4));
 

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -117,6 +117,7 @@ void ShaderTextEditor::_load_theme_settings() {
 	get_text_edit()->add_color_override("search_result_color", search_result_color);
 	get_text_edit()->add_color_override("search_result_border_color", search_result_border_color);
 	get_text_edit()->add_color_override("symbol_color", symbol_color);
+	get_text_edit()->add_color_override("basetype_color", basetype_color);
 
 	List<String> keywords;
 	ShaderLanguage::get_keyword_list(&keywords);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -29,7 +29,6 @@
 /*************************************************************************/
 
 #include "text_edit.h"
-
 #include "message_queue.h"
 #include "os/input.h"
 #include "os/keyboard.h"
@@ -1418,11 +1417,49 @@ void TextEdit::_notification(int p_what) {
 					int l = line_from + i;
 					ERR_CONTINUE(l < 0 || l >= completion_options.size());
 					Color text_color = cache.completion_font_color;
+
+					if (syntax_coloring) {
+						String upper = completion_options[l].to_upper();
+
+						if (keywords.has(completion_options[l])) {
+							if (completion_options[l].get(0) == L'_' || completion_options[l].get(0) != upper[0]) {
+								// colorize functions name
+								text_color = cache.function_color;
+							} else {
+
+								if (completion_options[l] == upper &&
+										completion_options[l] != "IP" &&
+										completion_options[l] != "RID" &&
+										completion_options[l] != "AABB" &&
+										completion_options[l] != "JSON" &&
+										completion_options[l] != "OS") {
+									// colorize constants
+									//text_color = cache.member_variable_color;
+								} else
+									// colorize engine class names
+									text_color = cache.basetype_color;
+							}
+						} else if (completion_options[l] == upper) {
+							// colorize constants
+							// text_color = cache.member_variable_color;
+						} else if (completion_options[l].get(0) != L'_' && completion_options[l].get(0) == upper[0]) {
+							// colorize non-engine class names
+							// text_color = cache.member_variable_color;
+						} else if (completion_options[l].get(completion_options[l].length() - 1) == ')' || completion_options[l].get(completion_options[l].length() - 1) == '(') {
+							// colorize functions names
+							text_color = cache.function_color;
+						} else {
+							// colorize variables/properties names
+							// text_color = cache.member_variable_color;
+						}
+					}
+
 					for (int j = 0; j < color_regions.size(); j++) {
 						if (completion_options[l].begins_with(color_regions[j].begin_key)) {
 							text_color = color_regions[j].color;
 						}
 					}
+
 					draw_string(cache.font, Point2(completion_rect.position.x, completion_rect.position.y + i * get_row_height() + cache.font->get_ascent()), completion_options[l], text_color, completion_rect.size.width);
 				}
 
@@ -4122,6 +4159,7 @@ void TextEdit::_update_caches() {
 	cache.line_number_color = get_color("line_number_color");
 	cache.font_color = get_color("font_color");
 	cache.font_selected_color = get_color("font_selected_color");
+	cache.basetype_color = get_color("basetype_color");
 	cache.keyword_color = get_color("keyword_color");
 	cache.function_color = get_color("function_color");
 	cache.member_variable_color = get_color("member_variable_color");

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -90,6 +90,7 @@ class TextEdit : public Control {
 		Color line_number_color;
 		Color font_color;
 		Color font_selected_color;
+		Color basetype_color;
 		Color keyword_color;
 		Color number_color;
 		Color function_color;


### PR DESCRIPTION
I've added basic auto completion coloring for constants and class names for help developer eyes. After this change, constants and class names will be marked with specific colors, all other remains same. I also added an option which enable this coloring in Editor Settings -> Text Editor -> Completion -> Syntax Highlighting. This option is enabled by default.

How it is looks 
![image](https://user-images.githubusercontent.com/3036176/35184051-7a049d50-fe01-11e7-8025-d9c5748684aa.png)
