### PR TITLE
fixed crash with StringBuilder

### DIFF
--- a/core/string_builder.cpp
+++ b/core/string_builder.cpp
@@ -56,6 +56,9 @@ StringBuilder &StringBuilder::append(const char *p_cstring) {
 
 String StringBuilder::as_string() const {
 
+	if (string_length == 0)
+		return "";
+
 	CharType *buffer = memnew_arr(CharType, string_length);
 
 	int current_position = 0;


### PR DESCRIPTION
When using a newly created StringBuilder then the as_string() method
will crash when trying to free an allocated 0-sized chunk of memory.

When 0 bytes get allocated with memnew_arr then a NULL pointer gets
returned. When trying to free that pointer the programm will crash.