### PR TITLE
Fix horizontal scroll for windows platform [2.1]

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -589,7 +589,7 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 					mb.y = old_y;
 				}
 
-				if (uMsg != WM_MOUSEWHEEL) {
+				if (uMsg != WM_MOUSEWHEEL && uMsg != WM_MOUSEHWHEEL) {
 					if (mb.pressed) {
 
 						if (++pressrc > 0)


### PR DESCRIPTION
See #15833

Edit:
Potential fix for #9116

Edit2:
Potential fix for #6424 as well.

Some mice have horizontal tilt on the scroll wheel which can be **_really_** easy to unknowingly trigger.