### PR TITLE
TileMap Navigation Fixes

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -61,6 +61,7 @@ void TileMap::_notification(int p_what) {
 			}
 
 			pending_update = true;
+			_recreate_quadrants();
 			_update_dirty_quadrants();
 			RID space = get_world_2d()->get_space();
 			_update_quadrant_transform();
@@ -653,7 +654,7 @@ void TileMap::_make_quadrant_dirty(Map<PosKey, Quadrant>::Element *Q) {
 	pending_update = true;
 	if (!is_inside_tree())
 		return;
-	call_deferred("_update_dirty_quadrants");
+	_update_dirty_quadrants();
 }
 
 void TileMap::set_cellv(const Vector2 &p_pos, int p_tile, bool p_flip_x, bool p_flip_y, bool p_transpose) {


### PR DESCRIPTION
Hello,

This pull requests fixes two issues:

https://github.com/godotengine/godot/issues/15767
https://github.com/godotengine/godot/issues/11077

While these changes do fix the above issues, I was wondering if the "call_deferred" was affecting and/or doing something special that I do not know about.  I don't know if changing it would cause other regressions.  Or maybe it was an optimization?  I could see a case where, when iterating over a TileMap, I would not want to update until after iterating over all the tiles; instead of after each tile.

Anyways, let me know if there are any questions or concerns.

Thanks.