### PR TITLE
Fix issue #15895, audio streams don't signalling finished after the first one

### DIFF
--- a/scene/audio/audio_player.cpp
+++ b/scene/audio/audio_player.cpp
@@ -126,8 +126,8 @@ void AudioStreamPlayer::_notification(int p_what) {
 
 		if (!active || (setseek < 0 && !stream_playback->is_playing())) {
 			active = false;
-			emit_signal("finished");
 			set_process_internal(false);
+			emit_signal("finished");
 		}
 	}
 


### PR DESCRIPTION
Fix issue #15895, audio streams don't signalling finished after the first one
if the audio player is set to play again, due to the order of calls in
_notification. First it emits the signal, and later it disable the internal
processing regardless what the callback did.

Changed to emit the signal at the end to ensure the changes done at callback
remains.