### PR TITLE
More precise description for is_visible_in_tree() in CanvasItem

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -415,7 +415,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Returns [code]true[/code] if the node is present in the [SceneTree], its [code]visible[/code] property is [code]true[/code] and its inherited visibility is also [code]true[/code].
+				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code] and its inherited visibility is also [code]true[/code].
 			</description>
 		</method>
 		<method name="make_canvas_position_local" qualifiers="const">

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -415,7 +415,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Returns [code]true[/code] if the node is in the [SceneTree] and is visible on-screen.
+				Returns [code]true[/code] if the node is present in the [SceneTree], its [code]visible[/code] property is [code]true[/code] and its inherited visibility is also [code]true[/code].
 			</description>
 		</method>
 		<method name="make_canvas_position_local" qualifiers="const">


### PR DESCRIPTION
The method's previous description was ambiguous and could be mistaken for "visibility of a CanvasItem in the current camera's view" when it only returns the "visible" property including inheritance.