### PR TITLE
Mono: Display opt-out warning in editor about WIP status

### DIFF
--- a/modules/mono/editor/godotsharp_editor.h
+++ b/modules/mono/editor/godotsharp_editor.h
@@ -44,6 +44,8 @@ class GodotSharpEditor : public Node {
 	PopupMenu *menu_popup;
 
 	AcceptDialog *error_dialog;
+	AcceptDialog *about_dialog;
+	CheckBox *about_dialog_checkbox;
 
 	ToolButton *bottom_panel_btn;
 
@@ -54,17 +56,21 @@ class GodotSharpEditor : public Node {
 	bool _create_project_solution();
 
 	void _remove_create_sln_menu_option();
+	void _show_about_dialog();
+	void _toggle_about_dialog_on_start(bool p_enabled);
 
 	void _menu_option_pressed(int p_id);
 
 	static GodotSharpEditor *singleton;
 
 protected:
+	void _notification(int p_notification);
 	static void _bind_methods();
 
 public:
 	enum MenuOptions {
-		MENU_CREATE_SLN
+		MENU_CREATE_SLN,
+		MENU_ABOUT_CSHARP,
 	};
 
 	enum ExternalEditor {


### PR DESCRIPTION
This ensures that all users of the Mono flavour of Godot 3.0 are aware
of its current shortcomings (no export, crashes and usability issues).
The dialog is shown each time the editor is started, until the checkbox
is disabled (i.e. until users will have actually read it).

![spectacle b13937](https://user-images.githubusercontent.com/4701338/35224483-67b02040-ff85-11e7-8825-3bed58ef42af.png)

Fixes #15956.

@djrm @volzhs Help welcome to get a bigger warning sign :)