### PR TITLE
Expose audio streams get_length()

### DIFF
--- a/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
@@ -115,17 +115,12 @@ void AudioStreamPlaybackOGGVorbis::seek(float p_time) {
 	if (!active)
 		return;
 
-	if (p_time >= get_length()) {
+	if (p_time >= vorbis_stream->get_length()) {
 		p_time = 0;
 	}
 	frames_mixed = uint32_t(vorbis_stream->sample_rate * p_time);
 
 	stb_vorbis_seek(ogg_stream, frames_mixed);
-}
-
-float AudioStreamPlaybackOGGVorbis::get_length() const {
-
-	return vorbis_stream->length;
 }
 
 AudioStreamPlaybackOGGVorbis::~AudioStreamPlaybackOGGVorbis() {
@@ -259,6 +254,11 @@ void AudioStreamOGGVorbis::set_loop_offset(float p_seconds) {
 
 float AudioStreamOGGVorbis::get_loop_offset() const {
 	return loop_offset;
+}
+
+float AudioStreamOGGVorbis::get_length() const {
+
+	return length;
 }
 
 void AudioStreamOGGVorbis::_bind_methods() {

--- a/modules/stb_vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/stb_vorbis/audio_stream_ogg_vorbis.h
@@ -71,8 +71,6 @@ public:
 	virtual float get_playback_position() const;
 	virtual void seek(float p_time);
 
-	virtual float get_length() const; //if supported, otherwise return 0
-
 	AudioStreamPlaybackOGGVorbis() {}
 	~AudioStreamPlaybackOGGVorbis();
 };
@@ -111,6 +109,8 @@ public:
 
 	void set_data(const PoolVector<uint8_t> &p_data);
 	PoolVector<uint8_t> get_data() const;
+
+	virtual float get_length() const; //if supported, otherwise return 0
 
 	AudioStreamOGGVorbis();
 	virtual ~AudioStreamOGGVorbis();

--- a/scene/resources/audio_stream_sample.cpp
+++ b/scene/resources/audio_stream_sample.cpp
@@ -77,7 +77,7 @@ void AudioStreamPlaybackSample::seek(float p_time) {
 	if (base->format == AudioStreamSample::FORMAT_IMA_ADPCM)
 		return; //no seeking in ima-adpcm
 
-	float max = get_length();
+	float max = base->get_length();
 	if (p_time < 0) {
 		p_time = 0;
 	} else if (p_time >= max) {
@@ -390,22 +390,6 @@ void AudioStreamPlaybackSample::mix(AudioFrame *p_buffer, float p_rate_scale, in
 	}
 }
 
-float AudioStreamPlaybackSample::get_length() const {
-
-	int len = base->data_bytes;
-	switch (base->format) {
-		case AudioStreamSample::FORMAT_8_BITS: len /= 1; break;
-		case AudioStreamSample::FORMAT_16_BITS: len /= 2; break;
-		case AudioStreamSample::FORMAT_IMA_ADPCM: len *= 2; break;
-	}
-
-	if (base->stereo) {
-		len /= 2;
-	}
-
-	return float(len) / base->mix_rate;
-}
-
 AudioStreamPlaybackSample::AudioStreamPlaybackSample() {
 
 	active = false;
@@ -467,6 +451,22 @@ void AudioStreamSample::set_stereo(bool p_enable) {
 bool AudioStreamSample::is_stereo() const {
 
 	return stereo;
+}
+
+float AudioStreamSample::get_length() const {
+
+	int len = data_bytes;
+	switch (format) {
+		case AudioStreamSample::FORMAT_8_BITS: len /= 1; break;
+		case AudioStreamSample::FORMAT_16_BITS: len /= 2; break;
+		case AudioStreamSample::FORMAT_IMA_ADPCM: len *= 2; break;
+	}
+
+	if (stereo) {
+		len /= 2;
+	}
+
+	return float(len) / mix_rate;
 }
 
 void AudioStreamSample::set_data(const PoolVector<uint8_t> &p_data) {

--- a/scene/resources/audio_stream_sample.h
+++ b/scene/resources/audio_stream_sample.h
@@ -77,8 +77,6 @@ public:
 
 	virtual void mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames);
 
-	virtual float get_length() const; //if supported, otherwise return 0
-
 	AudioStreamPlaybackSample();
 };
 
@@ -136,6 +134,8 @@ public:
 
 	void set_stereo(bool p_enable);
 	bool is_stereo() const;
+
+	virtual float get_length() const; //if supported, otherwise return 0
 
 	void set_data(const PoolVector<uint8_t> &p_data);
 	PoolVector<uint8_t> get_data() const;

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -91,6 +91,13 @@ void AudioStreamPlaybackResampled::mix(AudioFrame *p_buffer, float p_rate_scale,
 }
 ////////////////////////////////
 
+void AudioStream::_bind_methods() {
+
+	ClassDB::bind_method(D_METHOD("get_length"), &AudioStream::get_length);
+}
+
+////////////////////////////////
+
 void AudioStreamRandomPitch::set_audio_stream(const Ref<AudioStream> &p_audio_stream) {
 
 	audio_stream = p_audio_stream;
@@ -134,6 +141,14 @@ String AudioStreamRandomPitch::get_stream_name() const {
 		return "Random: " + audio_stream->get_name();
 	}
 	return "RandomPitch";
+}
+
+float AudioStreamRandomPitch::get_length() const {
+	if (audio_stream.is_valid()) {
+		return audio_stream->get_length();
+	}
+
+	return 0;
 }
 
 void AudioStreamRandomPitch::_bind_methods() {
@@ -207,14 +222,6 @@ void AudioStreamPlaybackRandomPitch::mix(AudioFrame *p_buffer, float p_rate_scal
 			p_buffer[i] = AudioFrame(0, 0);
 		}
 	}
-}
-
-float AudioStreamPlaybackRandomPitch::get_length() const {
-	if (playing.is_valid()) {
-		return playing->get_length();
-	}
-
-	return 0;
 }
 
 AudioStreamPlaybackRandomPitch::~AudioStreamPlaybackRandomPitch() {

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -50,8 +50,6 @@ public:
 	virtual void seek(float p_time) = 0;
 
 	virtual void mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) = 0;
-
-	virtual float get_length() const = 0; //if supported, otherwise return 0
 };
 
 class AudioStreamPlaybackResampled : public AudioStreamPlayback {
@@ -85,9 +83,14 @@ class AudioStream : public Resource {
 	GDCLASS(AudioStream, Resource)
 	OBJ_SAVE_TYPE(AudioStream) //children are all saved as AudioStream, so they can be exchanged
 
+protected:
+	static void _bind_methods();
+
 public:
 	virtual Ref<AudioStreamPlayback> instance_playback() = 0;
 	virtual String get_stream_name() const = 0;
+
+	virtual float get_length() const = 0; //if supported, otherwise return 0
 };
 
 class AudioStreamPlaybackRandomPitch;
@@ -114,6 +117,8 @@ public:
 	virtual Ref<AudioStreamPlayback> instance_playback();
 	virtual String get_stream_name() const;
 
+	virtual float get_length() const; //if supported, otherwise return 0
+
 	AudioStreamRandomPitch();
 };
 
@@ -138,8 +143,6 @@ public:
 	virtual void seek(float p_time);
 
 	virtual void mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames);
-
-	virtual float get_length() const; //if supported, otherwise return 0
 
 	~AudioStreamPlaybackRandomPitch();
 };


### PR DESCRIPTION
The code was there but it wasn't being registered in ClassDB

AudioStreamRandomPitch will return the stream length without the random pitch applied.

Closes https://github.com/godotengine/godot/issues/15964