### PR TITLE
[Mono] Allow loading assemblies (including mscorlib) from resources.

### DIFF
--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -479,6 +479,9 @@ void FileAccess::store_double(double p_dest) {
 
 uint64_t FileAccess::get_modified_time(const String &p_file) {
 
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && PackedData::get_singleton()->has_path(p_file))
+		return 0;
+
 	FileAccess *fa = create_for_path(p_file);
 	ERR_FAIL_COND_V(!fa, 0);
 


### PR DESCRIPTION
Allow loading assemblies (including `mscorlib`) from resources (tested with project folder and ZIP loaded with `--main-pack` on macOS and Linux).

This PR is not fixing export (#15615) or editor not finding Mono SDK (#13355).