### PR TITLE
Rotate Control node with respecting pivot offset

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1953,9 +1953,9 @@ void CanvasItemEditor::_gui_input_viewport(const Ref<InputEvent> &p_event) {
 
 					if (node) {
 						real_t angle = node->get_rotation();
-						node->set_rotation(snap_angle(angle + (dfrom - center).angle_to(dto - center), angle));
 						display_rotate_to = dto;
-						display_rotate_from = center;
+						display_rotate_from = center + node->get_pivot_offset().rotated(angle);
+						node->set_rotation(snap_angle(angle + (dfrom - display_rotate_from).angle_to(display_rotate_to - display_rotate_from), angle));
 						viewport->update();
 					}
 				}


### PR DESCRIPTION
current behavior
![pivot1](https://user-images.githubusercontent.com/8281454/35318291-fe3a79ae-011d-11e8-8796-4d142bb019ec.gif)

with this PR
![pivot2](https://user-images.githubusercontent.com/8281454/35318297-03f6dc48-011e-11e8-9b1f-f1dcce32b6a4.gif)

Updated demonstration GIFs.