### PR TITLE
Fix HTML5 JS API setResizeCanvasOnStart

### DIFF
--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -430,16 +430,11 @@ Error OS_JavaScript::initialize(const VideoMode &p_desired, int p_video_driver, 
 	// can't fulfil fullscreen request due to browser security
 	video_mode.fullscreen = false;
 	/* clang-format off */
-	bool resize_canvas_on_start = EM_ASM_INT_V(
-		return Module.resizeCanvasOnStart;
-	);
-	/* clang-format on */
-	if (resize_canvas_on_start) {
+	if (EM_ASM_INT_V({ return Module.resizeCanvasOnStart })) {
+		/* clang-format on */
 		set_window_size(Size2(video_mode.width, video_mode.height));
 	} else {
-		Size2 canvas_size = get_window_size();
-		video_mode.width = canvas_size.width;
-		video_mode.height = canvas_size.height;
+		set_window_size(get_window_size());
 	}
 
 	char locale_ptr[16];


### PR DESCRIPTION
Setting `video_mode` isn't enough, canvas size needs to be adjusted as well. `set_window_size()` knows what to do