### PR TITLE
Enable enet client to setup a local port; fixes #15877

### DIFF
--- a/modules/enet/networked_multiplayer_enet.cpp
+++ b/modules/enet/networked_multiplayer_enet.cpp
@@ -92,15 +92,41 @@ Error NetworkedMultiplayerENet::create_server(int p_port, int p_max_clients, int
 	connection_status = CONNECTION_CONNECTED;
 	return OK;
 }
-Error NetworkedMultiplayerENet::create_client(const IP_Address &p_ip, int p_port, int p_in_bandwidth, int p_out_bandwidth) {
+Error NetworkedMultiplayerENet::create_client(const IP_Address &p_ip, int p_port, int c_port, int p_in_bandwidth, int p_out_bandwidth) {
 
 	ERR_FAIL_COND_V(active, ERR_ALREADY_IN_USE);
 
-	host = enet_host_create(NULL /* create a client host */,
-			1 /* only allow 1 outgoing connection */,
-			SYSCH_MAX /* allow up to SYSCH_MAX channels to be used */,
-			p_in_bandwidth /* 56K modem with 56 Kbps downstream bandwidth */,
-			p_out_bandwidth /* 56K modem with 14 Kbps upstream bandwidth */);
+	if (c_port != 0) {
+		ENetAddress c_client;
+
+#ifdef GODOT_ENET
+		if (bind_ip.is_wildcard()) {
+			c_client.wildcard = 1;
+		} else {
+			enet_address_set_ip(&c_client, bind_ip.get_ipv6(), 16);
+		}
+#else
+		if (bind_ip.is_wildcard()) {
+			c_client.host = 0;
+		} else {
+			ERR_FAIL_COND_V(!bind_ip.is_ipv4(), ERR_INVALID_PARAMETER);
+			c_client.host = *(uint32_t *)bind_ip.get_ipv4();
+		}
+#endif
+		c_client.port = c_port;
+
+		host = enet_host_create(&c_client /* create a client host */,
+				1 /* only allow 1 outgoing connection */,
+				SYSCH_MAX /* allow up to SYSCH_MAX channels to be used */,
+				p_in_bandwidth /* 56K modem with 56 Kbps downstream bandwidth */,
+				p_out_bandwidth /* 56K modem with 14 Kbps upstream bandwidth */);
+	} else {
+		host = enet_host_create(NULL /* create a client host */,
+				1 /* only allow 1 outgoing connection */,
+				SYSCH_MAX /* allow up to SYSCH_MAX channels to be used */,
+				p_in_bandwidth /* 56K modem with 56 Kbps downstream bandwidth */,
+				p_out_bandwidth /* 56K modem with 14 Kbps upstream bandwidth */);
+	}
 
 	ERR_FAIL_COND_V(!host, ERR_CANT_CREATE);
 
@@ -657,7 +683,7 @@ void NetworkedMultiplayerENet::enet_compressor_destroy(void *context) {
 void NetworkedMultiplayerENet::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("create_server", "port", "max_clients", "in_bandwidth", "out_bandwidth"), &NetworkedMultiplayerENet::create_server, DEFVAL(32), DEFVAL(0), DEFVAL(0));
-	ClassDB::bind_method(D_METHOD("create_client", "ip", "port", "in_bandwidth", "out_bandwidth"), &NetworkedMultiplayerENet::create_client, DEFVAL(0), DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("create_client", "ip", "port", "client_port", "in_bandwidth", "out_bandwidth"), &NetworkedMultiplayerENet::create_client, DEFVAL(0), DEFVAL(0), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("close_connection"), &NetworkedMultiplayerENet::close_connection);
 	ClassDB::bind_method(D_METHOD("set_compression_mode", "mode"), &NetworkedMultiplayerENet::set_compression_mode);
 	ClassDB::bind_method(D_METHOD("get_compression_mode"), &NetworkedMultiplayerENet::get_compression_mode);

--- a/modules/enet/networked_multiplayer_enet.h
+++ b/modules/enet/networked_multiplayer_enet.h
@@ -116,7 +116,7 @@ public:
 	virtual int get_packet_peer() const;
 
 	Error create_server(int p_port, int p_max_clients = 32, int p_in_bandwidth = 0, int p_out_bandwidth = 0);
-	Error create_client(const IP_Address &p_ip, int p_port, int p_in_bandwidth = 0, int p_out_bandwidth = 0);
+	Error create_client(const IP_Address &p_ip, int p_port, int c_port = 0, int p_in_bandwidth = 0, int p_out_bandwidth = 0);
 
 	void close_connection();
 


### PR DESCRIPTION
I tested it using my Bomber demo matchmaking server (https://github.com/henriquelalves/Godot-Bomber-matchmaking-server); I set up the server on an Azure VM and 'played' an online game using my smartphone 4G connection and my PC lan connection, which means NAT punching is effectively working. Without setting up the client port, online gaming (not LAN) is only possible by using Godot more low-level network api's (UDP packet or TCP stream).

It's kind of a hassle to test since you'd have to setup the node server on a not-local machine and compile the engine+android exports, but I'd love to know if this fix does work on other machines, or if there is some OS related issues I'm not accounting for here.

Used Android and Fedora 27.