### PR TITLE
Fix error precision in move_and_slide when the angle is virtually the floor limit

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1039,7 +1039,7 @@ Vector2 KinematicBody2D::move_and_slide(const Vector2 &p_linear_velocity, const 
 				//all is a wall
 				on_wall = true;
 			} else {
-				if (collision.normal.dot(p_floor_direction) >= Math::cos(p_floor_max_angle)) { //floor
+				if (collision.normal.dot(p_floor_direction) >= Math::cos(p_floor_max_angle * 1.001)) { //floor
 
 					on_floor = true;
 					floor_velocity = collision.collider_vel;
@@ -1053,7 +1053,7 @@ Vector2 KinematicBody2D::move_and_slide(const Vector2 &p_linear_velocity, const 
 						set_global_transform(gt);
 						return Vector2();
 					}
-				} else if (collision.normal.dot(-p_floor_direction) >= Math::cos(p_floor_max_angle)) { //ceiling
+				} else if (collision.normal.dot(-p_floor_direction) >= Math::cos(p_floor_max_angle * 1.001)) { //ceiling
 					on_ceiling = true;
 				} else {
 					on_wall = true;


### PR DESCRIPTION
Fix error precision in move_and_slide when the angle is virtually the limit
angle to consider it a wall, a floor or a ceiling making a workaround, adding
a 1/1000 of the limit angle to provie a "safety margin" to compare with.

Try to fix #15632.