### PR TITLE
allow comments and whitespace before shader_type declaration

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -3990,13 +3990,56 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 	return OK;
 }
 
+// skips over whitespace and /* */ and // comments
+static int _get_first_ident_pos(const String &p_code) {
+
+	int idx = 0;
+
+#define GETCHAR(m_idx) (((idx + m_idx) < p_code.length()) ? p_code[idx + m_idx] : CharType(0))
+
+	while (true) {
+		if (GETCHAR(0) == '/' && GETCHAR(1) == '/') {
+			idx += 2;
+			while (true) {
+				if (GETCHAR(0) == 0) return 0;
+				if (GETCHAR(0) == '\n') {
+					idx++;
+					break; // loop
+				}
+				idx++;
+			}
+		} else if (GETCHAR(0) == '/' && GETCHAR(1) == '*') {
+			idx += 2;
+			while (true) {
+				if (GETCHAR(0) == 0) return 0;
+				if (GETCHAR(0) == '*' && GETCHAR(1) == '/') {
+					idx += 2;
+					break; // loop
+				}
+				idx++;
+			}
+		} else {
+			switch (GETCHAR(0)) {
+				case ' ':
+				case '\t':
+				case '\r':
+				case '\n': {
+					idx++;
+				} break; // switch
+				default:
+					return idx;
+			}
+		}
+	}
+}
+
 String ShaderLanguage::get_shader_type(const String &p_code) {
 
 	bool reading_type = false;
 
 	String cur_identifier;
 
-	for (int i = 0; i < p_code.length(); i++) {
+	for (int i = _get_first_ident_pos(p_code); i < p_code.length(); i++) {
 
 		if (p_code[i] == ';') {
 			break;


### PR DESCRIPTION
Needs review.

I re-define a GETCHAR macro in this file.  Should I use another name?  Both uses are local to their respective functions.

Fixes #16032.