### PR TITLE
Disable OpenSSL module in HTML5 platform by default

### DIFF
--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -28,6 +28,11 @@ def get_flags():
     return [
         ('tools', False),
         ('module_theora_enabled', False),
+        # Disabling the OpenSSL module noticeably reduces file size.
+        # The module has little use due to the limited networking functionality
+        # in this platform. For the available networking methods, the browser
+        # manages TLS.
+        ('module_openssl_enabled', False),
     ]
 
 


### PR DESCRIPTION
Building without the OpenSSL module reduces the WebAssembly module file size by ~1MiB. `StreamPeerSSL` has a very limited use case in the HTML5 platform with most of the networking classes non-functional. `HTTPClient` leaves TLS to the browser.