### PR TITLE
Exposed apply_torque_impulse to gdscript

### DIFF
--- a/doc/classes/RigidBody.xml
+++ b/doc/classes/RigidBody.xml
@@ -36,6 +36,15 @@
 				Apply a positioned impulse (which will be affected by the body mass and shape). This is the equivalent of hitting a billiard ball with a cue: a force that is applied once, and only once. Both the impulse and the position are in global coordinates, and the position is relative to the object's origin.
 			</description>
 		</method>
+		<method name="apply_torque_impulse">
+			<return type="void">
+			</return>
+			<argument index="1" name="impulse" type="Vector3">
+			</argument>
+			<description>
+				Apply a torque impulse (which will be affected by the body mass and shape). This will rotate the body around the passed in vector.
+			</description>
+		</method>
 		<method name="get_colliding_bodies" qualifiers="const">
 			<return type="Array">
 			</return>

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -696,6 +696,10 @@ void RigidBody::apply_impulse(const Vector3 &p_pos, const Vector3 &p_impulse) {
 	PhysicsServer::get_singleton()->body_apply_impulse(get_rid(), p_pos, p_impulse);
 }
 
+void RigidBody::apply_torque_impulse(const Vector3 &p_impulse) {
+	PhysicsServer::get_singleton()->body_apply_torque_impulse(get_rid(), p_impulse);
+}
+
 void RigidBody::set_use_continuous_collision_detection(bool p_enable) {
 
 	ccd = p_enable;
@@ -835,6 +839,7 @@ void RigidBody::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_axis_velocity", "axis_velocity"), &RigidBody::set_axis_velocity);
 	ClassDB::bind_method(D_METHOD("apply_impulse", "position", "impulse"), &RigidBody::apply_impulse);
+	ClassDB::bind_method(D_METHOD("apply_torque_impulse", "impulse"), &RigidBody::apply_torque_impulse);
 
 	ClassDB::bind_method(D_METHOD("set_sleeping", "sleeping"), &RigidBody::set_sleeping);
 	ClassDB::bind_method(D_METHOD("is_sleeping"), &RigidBody::is_sleeping);

--- a/scene/3d/physics_body.h
+++ b/scene/3d/physics_body.h
@@ -242,6 +242,7 @@ public:
 	Array get_colliding_bodies() const;
 
 	void apply_impulse(const Vector3 &p_pos, const Vector3 &p_impulse);
+	void apply_torque_impulse(const Vector3 &p_impulse);
 
 	virtual String get_configuration_warning() const;
 


### PR DESCRIPTION
To avoid the "apply two impulses in opposite direction" hacks suggested in a few places around the forums, and solves the 3d equivalent of issue #1058