### PR TITLE
Mono: Don't defer call to dispose queue objects when finalizing domain

### DIFF
--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -696,11 +696,13 @@ bool _GodotSharp::is_domain_loaded() {
 	return GDMono::get_singleton()->get_scripts_domain() != NULL;
 }
 
-#define ENQUEUE_FOR_DISPOSAL(m_queue, m_inst) \
-	m_queue.push_back(m_inst);                \
-	if (queue_empty) {                        \
-		queue_empty = false;                  \
-		call_deferred("_dispose_callback");   \
+#define ENQUEUE_FOR_DISPOSAL(m_queue, m_inst)                                   \
+	m_queue.push_back(m_inst);                                                  \
+	if (queue_empty) {                                                          \
+		queue_empty = false;                                                    \
+		if (!is_finalizing_domain()) { /* call_deferred may not be safe here */ \
+			call_deferred("_dispose_callback");                                 \
+		}                                                                       \
 	}
 
 void _GodotSharp::queue_dispose(MonoObject *p_mono_object, Object *p_object) {


### PR DESCRIPTION
It's going to be called anyway after `mono_domain_finalize`.
This also prevents crashes, since the MessageQueue singleton could already be freed at this point (see: #15702).
