### PR TITLE
Make separate debug symbols opt-in

### DIFF
--- a/platform/osx/SCsub
+++ b/platform/osx/SCsub
@@ -23,6 +23,6 @@ files = [
 
 prog = env.add_program('#bin/godot', files)
 
-if env["debug_symbols"] == "full" or env["debug_symbols"] == "yes":
+if (env["debug_symbols"] == "full" or env["debug_symbols"] == "yes") and env["separate_debug_symbols"]:
     env.AddPostAction(prog, make_debug)
 

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -24,6 +24,7 @@ def get_opts():
     return [
         ('osxcross_sdk', 'OSXCross SDK version', 'darwin14'),
         EnumVariable('debug_symbols', 'Add debug symbols to release version', 'yes', ('yes', 'no', 'full')),
+        BoolVariable('separate_debug_symbols', 'Create a separate file with the debug symbols', False),
     ]
 
 

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -39,5 +39,5 @@ if env['vsproj']:
         env.vs_srcs = env.vs_srcs + ["platform/windows/" + str(x)]
 
 if not os.getenv("VCINSTALLDIR"):
-    if env["debug_symbols"] == "full" or env["debug_symbols"] == "yes":
+    if (env["debug_symbols"] == "full" or env["debug_symbols"] == "yes") and env["separate_debug_symbols"]:
         env.AddPostAction(prog, make_debug_mingw)

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -69,6 +69,7 @@ def get_opts():
         # Vista support dropped after EOL due to GH-10243
         ('target_win_version', 'Targeted Windows version, >= 0x0601 (Windows 7)', '0x0601'),
         EnumVariable('debug_symbols', 'Add debug symbols to release version', 'yes', ('yes', 'no', 'full')),
+        BoolVariable('separate_debug_symbols', 'Create a separate file with the debug symbols', False),
     ]
 
 

--- a/platform/x11/SCsub
+++ b/platform/x11/SCsub
@@ -19,5 +19,5 @@ common_x11 = [
 
 prog = env.add_program('#bin/godot', ['godot_x11.cpp'] + common_x11)
 
-if env["debug_symbols"] == "full" or env["debug_symbols"] == "yes":
+if (env["debug_symbols"] == "full" or env["debug_symbols"] == "yes") and env["separate_debug_symbols"]:
     env.AddPostAction(prog, make_debug)

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -55,6 +55,7 @@ def get_opts():
         BoolVariable('pulseaudio', 'Detect & use pulseaudio', True),
         BoolVariable('udev', 'Use udev for gamepad connection callbacks', False),
         EnumVariable('debug_symbols', 'Add debug symbols to release version', 'yes', ('yes', 'no', 'full')),
+        BoolVariable('separate_debug_symbols', 'Create a separate file with the debug symbols', False),
         BoolVariable('touch', 'Enable touch events', True),
     ]
 


### PR DESCRIPTION
This adds a separate_debug_symbols option to the x11, windows, and osx
targets. This will default to adding normal debugging symbols to the
artifacts and only splits them when separate_debug_symbols=yes on the
Scons command line.