### PR TITLE
Added --quit and --build-solutions cmd line options to make CI pipelines possible

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1784,7 +1784,7 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 		editor_data.save_editor_external_data();
 	}
 
-	if (!_call_build())
+	if (!call_build())
 		return;
 
 	if (bool(EDITOR_DEF("run/output/always_clear_output_on_play", true))) {
@@ -2321,7 +2321,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			if (run_native->is_deploy_debug_remote_enabled()) {
 				_menu_option_confirm(RUN_STOP, true);
 
-				if (!_call_build())
+				if (!call_build())
 					break; // build failed
 
 				emit_signal("play_pressed");
@@ -4525,7 +4525,7 @@ void EditorNode::add_build_callback(EditorBuildCallback p_callback) {
 
 EditorBuildCallback EditorNode::build_callbacks[EditorNode::MAX_BUILD_CALLBACKS];
 
-bool EditorNode::_call_build() {
+bool EditorNode::call_build() {
 
 	for (int i = 0; i < build_callback_count; i++) {
 		if (!build_callbacks[i]())

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -596,7 +596,6 @@ private:
 	static EditorPluginInitializeCallback plugin_init_callbacks[MAX_INIT_CALLBACKS];
 	void _save_default_environment();
 
-	bool _call_build();
 	static int build_callback_count;
 	static EditorBuildCallback build_callbacks[MAX_BUILD_CALLBACKS];
 
@@ -634,6 +633,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	bool call_build();
+
 	static void add_plugin_init_callback(EditorPluginInitializeCallback p_callback);
 
 	enum EditorTable {


### PR DESCRIPTION
This adds the ability to use the following command line arguments:

    -q/--quit
    --build-solutions

-q/--quit auto quits the editor after one iteration through the main loop. This allows for assets to be imported and any other command line arguments to be run without hackish solutions such as @brainsick  and I were discussing on this thread: https://github.com/godotengine/godot/issues/15957

The --build-solutions flag allows for C# to be built (and any other language someone might implement).

Both of these combined make it very easy to integrate and create a CI solution for game projects.

An example of how this looks in bash is:

    $GODOT=/path/to/godot
    $GODOT -e -q --build-solutions
    $GODOT TestRunner.tscn