### PR TITLE
Allow focus on disabled buttons

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -311,10 +311,6 @@ void BaseButton::set_disabled(bool p_disabled) {
 	status.disabled = p_disabled;
 	update();
 	_change_notify("disabled");
-	if (p_disabled)
-		set_focus_mode(FOCUS_NONE);
-	else
-		set_focus_mode(enabled_focus_mode);
 }
 
 bool BaseButton::is_disabled() const {


### PR DESCRIPTION
This behavior better matches other gui toolkits. A selected disabled
button still can't be interacted with but it can now be selected. This
seems to be what QT and GTK do also.

This fixes #16131