### PR TITLE
Implement OS::get_processor_count() for Windows

### DIFF
--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -253,6 +253,9 @@ public:
 	virtual String get_executable_path() const;
 
 	virtual String get_locale() const;
+
+	virtual int get_processor_count() const;
+
 	virtual LatinKeyboardVariant get_latin_keyboard_variant() const;
 
 	virtual void enable_for_stealing_focus(ProcessID pid);


### PR DESCRIPTION
Current this is hardcoded as '1' for any platform except Unix. The
little is_wow64() dance is required to get correct output on a 32bit
compiled godot running on 64bit Windows according to MSDN.

This code should be UWP safe but I have no way to test that so it's not
implemented for UWP yet.