### PR TITLE
Allow shortcuts with "tab" keys - Fix #8799

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -180,7 +180,7 @@ void EditorNode::_update_title() {
 	OS::get_singleton()->set_window_title(title);
 }
 
-void EditorNode::_unhandled_input(const Ref<InputEvent> &p_event) {
+void EditorNode::_input(const Ref<InputEvent> &p_event) {
 
 	if (Node::get_viewport()->get_modal_stack_top())
 		return; //ignore because of modal window
@@ -188,34 +188,49 @@ void EditorNode::_unhandled_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventKey> k = p_event;
 	if (k.is_valid() && k->is_pressed() && !k->is_echo() && !gui_base->get_viewport()->gui_has_modal_stack()) {
 
+		bool shortcut_triggered = false;
 		if (ED_IS_SHORTCUT("editor/next_tab", p_event)) {
 			int next_tab = editor_data.get_edited_scene() + 1;
 			next_tab %= editor_data.get_edited_scene_count();
 			_scene_tab_changed(next_tab);
+			shortcut_triggered = true;
 		}
 		if (ED_IS_SHORTCUT("editor/prev_tab", p_event)) {
 			int next_tab = editor_data.get_edited_scene() - 1;
 			next_tab = next_tab >= 0 ? next_tab : editor_data.get_edited_scene_count() - 1;
 			_scene_tab_changed(next_tab);
+			shortcut_triggered = true;
 		}
 		if (ED_IS_SHORTCUT("editor/filter_files", p_event)) {
 			filesystem_dock->focus_on_filter();
+			shortcut_triggered = true;
 		}
 
 		if (ED_IS_SHORTCUT("editor/editor_2d", p_event)) {
 			_editor_select(EDITOR_2D);
+			shortcut_triggered = true;
 		} else if (ED_IS_SHORTCUT("editor/editor_3d", p_event)) {
 			_editor_select(EDITOR_3D);
+			shortcut_triggered = true;
 		} else if (ED_IS_SHORTCUT("editor/editor_script", p_event)) {
 			_editor_select(EDITOR_SCRIPT);
+			shortcut_triggered = true;
 		} else if (ED_IS_SHORTCUT("editor/editor_help", p_event)) {
 			emit_signal("request_help_search", "");
+			shortcut_triggered = true;
 		} else if (ED_IS_SHORTCUT("editor/editor_assetlib", p_event)) {
 			_editor_select(EDITOR_ASSETLIB);
+			shortcut_triggered = true;
 		} else if (ED_IS_SHORTCUT("editor/editor_next", p_event)) {
 			_editor_select_next();
+			shortcut_triggered = true;
 		} else if (ED_IS_SHORTCUT("editor/editor_prev", p_event)) {
 			_editor_select_prev();
+			shortcut_triggered = true;
+		}
+
+		if (shortcut_triggered) {
+			get_tree()->set_input_as_handled();
 		}
 	}
 }
@@ -4627,7 +4642,7 @@ void EditorNode::_bind_methods() {
 	ClassDB::bind_method("_editor_select", &EditorNode::_editor_select);
 	ClassDB::bind_method("_node_renamed", &EditorNode::_node_renamed);
 	ClassDB::bind_method("edit_node", &EditorNode::edit_node);
-	ClassDB::bind_method("_unhandled_input", &EditorNode::_unhandled_input);
+	ClassDB::bind_method("_input", &EditorNode::_input);
 
 	ClassDB::bind_method("_get_scene_metadata", &EditorNode::_get_scene_metadata);
 	ClassDB::bind_method("set_edited_scene", &EditorNode::set_edited_scene);
@@ -5779,7 +5794,7 @@ EditorNode::EditorNode() {
 	editor_data.restore_editor_global_states();
 	convert_old = false;
 	opening_prev = false;
-	set_process_unhandled_input(true);
+	set_process_input(true);
 	_playing_edited = false;
 
 	load_errors = memnew(RichTextLabel);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -484,7 +484,7 @@ private:
 
 	bool convert_old;
 
-	void _unhandled_input(const Ref<InputEvent> &p_event);
+	void _input(const Ref<InputEvent> &p_event);
 
 	static void _load_error_notify(void *p_ud, const String &p_text);
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2019,54 +2019,6 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 				top->hide();
 			}
 		}
-
-		Control *from = gui.key_focus ? gui.key_focus : NULL; //hmm
-
-		//keyboard focus
-		//if (from && p_event->is_pressed() && !p_event->get_alt() && !p_event->get_metakey() && !p_event->key->get_command()) {
-
-		Ref<InputEventKey> k = p_event;
-		//need to check for mods, otherwise any combination of alt/ctrl/shift+<up/down/left/righ/etc> is handled here when it shouldn't be.
-		bool mods = k.is_valid() && (k->get_control() || k->get_alt() || k->get_shift() || k->get_metakey());
-
-		if (from && p_event->is_pressed()) {
-			Control *next = NULL;
-
-			if (p_event->is_action("ui_focus_next")) {
-
-				next = from->find_next_valid_focus();
-			}
-
-			if (p_event->is_action("ui_focus_prev")) {
-
-				next = from->find_prev_valid_focus();
-			}
-
-			if (!mods && p_event->is_action("ui_up")) {
-
-				next = from->_get_focus_neighbour(MARGIN_TOP);
-			}
-
-			if (!mods && p_event->is_action("ui_left")) {
-
-				next = from->_get_focus_neighbour(MARGIN_LEFT);
-			}
-
-			if (!mods && p_event->is_action("ui_right")) {
-
-				next = from->_get_focus_neighbour(MARGIN_RIGHT);
-			}
-
-			if (!mods && p_event->is_action("ui_down")) {
-
-				next = from->_get_focus_neighbour(MARGIN_BOTTOM);
-			}
-
-			if (next) {
-				next->grab_focus();
-				get_tree()->set_input_as_handled();
-			}
-		}
 	}
 }
 
@@ -2346,6 +2298,54 @@ void Viewport::unhandled_input(const Ref<InputEvent> &p_event) {
 						Object::cast_to<InputEventScreenDrag>(*p_event) ||
 						Object::cast_to<InputEventScreenTouch>(*p_event))) {
 			physics_picking_events.push_back(p_event);
+		}
+	}
+
+	Control *from = gui.key_focus ? gui.key_focus : NULL; //hmm
+
+	//keyboard focus
+	//if (from && p_event->is_pressed() && !p_event->get_alt() && !p_event->get_metakey() && !p_event->key->get_command()) {
+
+	Ref<InputEventKey> k = p_event;
+	//need to check for mods, otherwise any combination of alt/ctrl/shift+<up/down/left/righ/etc> is handled here when it shouldn't be.
+	bool mods = k.is_valid() && (k->get_control() || k->get_alt() || k->get_shift() || k->get_metakey());
+
+	if (from && p_event->is_pressed()) {
+		Control *next = NULL;
+
+		if (p_event->is_action("ui_focus_next")) {
+
+			next = from->find_next_valid_focus();
+		}
+
+		if (p_event->is_action("ui_focus_prev")) {
+
+			next = from->find_prev_valid_focus();
+		}
+
+		if (!mods && p_event->is_action("ui_up")) {
+
+			next = from->_get_focus_neighbour(MARGIN_TOP);
+		}
+
+		if (!mods && p_event->is_action("ui_left")) {
+
+			next = from->_get_focus_neighbour(MARGIN_LEFT);
+		}
+
+		if (!mods && p_event->is_action("ui_right")) {
+
+			next = from->_get_focus_neighbour(MARGIN_RIGHT);
+		}
+
+		if (!mods && p_event->is_action("ui_down")) {
+
+			next = from->_get_focus_neighbour(MARGIN_BOTTOM);
+		}
+
+		if (next) {
+			next->grab_focus();
+			get_tree()->set_input_as_handled();
 		}
 	}
 }


### PR DESCRIPTION
Fixes: [#8799](https://github.com/godotengine/godot/issues/8799)

Based on the default editor input mappings, the `Viewport` will consume tab keys before they can be processed for shortcuts.  By moving this logic to `Viewport::_unhandled_input`, other `Node`s may consume the keys used in the `InputMap` for shortcuts (assuming the handle it in `_input` and not `_unhandled_input`, per the [`InputEvent` documentation](http://docs.godotengine.org/en/latest/tutorials/inputs/inputevent.html)).