### PR TITLE
Mono: Remove automatic script multilevel calls

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -947,19 +947,6 @@ void CSharpLanguage::free_instance_binding_data(void *p_data) {
 #endif
 }
 
-void CSharpInstance::_ml_call_reversed(MonoObject *p_mono_object, GDMonoClass *p_klass, const StringName &p_method, const Variant **p_args, int p_argcount) {
-
-	GDMonoClass *base = p_klass->get_parent_class();
-	if (base && base != script->native)
-		_ml_call_reversed(p_mono_object, base, p_method, p_args, p_argcount);
-
-	GDMonoMethod *method = p_klass->get_method(p_method, p_argcount);
-
-	if (method) {
-		method->invoke(p_mono_object, p_args);
-	}
-}
-
 CSharpInstance *CSharpInstance::create_for_managed_type(Object *p_owner, CSharpScript *p_script, const Ref<MonoGCHandle> &p_gchandle) {
 
 	CSharpInstance *instance = memnew(CSharpInstance);
@@ -1028,6 +1015,8 @@ bool CSharpInstance::set(const StringName &p_name, const Variant &p_value) {
 
 			if (ret && GDMonoMarshal::unbox<MonoBoolean>(ret) == true)
 				return true;
+
+			break;
 		}
 
 		top = top->get_parent_class();
@@ -1088,6 +1077,8 @@ bool CSharpInstance::get(const StringName &p_name, Variant &r_ret) const {
 				r_ret = GDMonoMarshal::mono_object_to_variant(ret);
 				return true;
 			}
+
+			break;
 		}
 
 		top = top->get_parent_class();
@@ -1190,8 +1181,10 @@ void CSharpInstance::_call_multilevel(MonoObject *p_mono_object, const StringNam
 	while (top && top != script->native) {
 		GDMonoMethod *method = top->get_method(p_method, p_argcount);
 
-		if (method)
+		if (method) {
 			method->invoke(p_mono_object, p_args);
+			return;
+		}
 
 		top = top->get_parent_class();
 	}
@@ -1199,13 +1192,9 @@ void CSharpInstance::_call_multilevel(MonoObject *p_mono_object, const StringNam
 
 void CSharpInstance::call_multilevel_reversed(const StringName &p_method, const Variant **p_args, int p_argcount) {
 
-	if (script.is_valid()) {
-		MonoObject *mono_object = get_mono_object();
+	// Sorry, the method is the one that controls the call order
 
-		ERR_FAIL_NULL(mono_object);
-
-		_ml_call_reversed(mono_object, script->script_class, p_method, p_args, p_argcount);
-	}
+	call_multilevel(p_method, p_args, p_argcount);
 }
 
 void CSharpInstance::_reference_owner_unsafe() {

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -172,8 +172,6 @@ class CSharpInstance : public ScriptInstance {
 	bool base_ref;
 	bool ref_dying;
 
-	void _ml_call_reversed(MonoObject *p_mono_object, GDMonoClass *klass, const StringName &p_method, const Variant **p_args, int p_argcount);
-
 	void _reference_owner_unsafe();
 	void _unreference_owner_unsafe();
 


### PR DESCRIPTION
This is the same as calling the method on a derived type, not the base class that declared the virtual method, so keywords like `new` make no sense unless you want to call these from C# as well.

The problem with the other way is that we need to call methods that are not declared in Godot's built-in types, like a signal callback. We could use `((Node)obj)._Ready()` for `call_multilevel` only and `((DerivedNode)obj)._Ready()` for `call`, but the different behavior may cause confusion.

Opinions?

Closes #15053
