### PR TITLE
Errata fix on Image get_format() description

### DIFF
--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -217,7 +217,7 @@
 			<return type="int" enum="Image.Format">
 			</return>
 			<description>
-				Returns the image's raw data.
+				Returns the image’s format. See [code]FORMAT_*[/code] constants.
 			</description>
 		</method>
 		<method name="get_height" qualifiers="const">


### PR DESCRIPTION
The description of this function seems to be duplicated from the preceding description.