### PR TITLE
Hide button tree when file system dock isn't in split mode

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -154,6 +154,7 @@ void FileSystemDock::_notification(int p_what) {
 				} else {
 
 					tree->set_v_size_flags(SIZE_FILL);
+					button_tree->hide();
 					if (!tree->is_visible()) {
 						tree->show();
 						button_favorite->show();
@@ -163,7 +164,6 @@ void FileSystemDock::_notification(int p_what) {
 
 					if (!file_list_vb->is_visible()) {
 						file_list_vb->show();
-						button_tree->hide();
 						_update_files(true);
 					}
 				}


### PR DESCRIPTION
Partially fixes this #16230

Missing the enhancement about repositioning the button. This need to be discussed I think.