### PR TITLE
Expand project root directory on editor start

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -77,7 +77,7 @@ bool FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 	return true;
 }
 
-void FileSystemDock::_update_tree(bool keep_collapse_state) {
+void FileSystemDock::_update_tree(bool keep_collapse_state, bool p_uncollapse_root) {
 
 	Vector<String> uncollapsed_paths;
 	if (keep_collapse_state) {
@@ -127,6 +127,10 @@ void FileSystemDock::_update_tree(bool keep_collapse_state) {
 		ti->set_icon(0, folder_icon);
 		ti->set_selectable(0, true);
 		ti->set_metadata(0, fave);
+	}
+
+	if (p_uncollapse_root) {
+		uncollapsed_paths.push_back("res://");
 	}
 
 	_create_tree(root, EditorFileSystem::get_singleton()->get_filesystem(), uncollapsed_paths);
@@ -204,7 +208,7 @@ void FileSystemDock::_notification(int p_what) {
 			if (EditorFileSystem::get_singleton()->is_scanning()) {
 				_set_scanning_mode();
 			} else {
-				_update_tree(false);
+				_update_tree(false, true);
 			}
 
 		} break;

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -157,7 +157,7 @@ private:
 	bool import_dock_needs_update;
 
 	bool _create_tree(TreeItem *p_parent, EditorFileSystemDirectory *p_dir, Vector<String> &uncollapsed_paths);
-	void _update_tree(bool keep_collapse_state);
+	void _update_tree(bool keep_collapse_state, bool p_uncollapse_root = false);
 
 	void _update_files(bool p_keep_selection);
 	void _update_file_display_toggle_button();


### PR DESCRIPTION
close #16232

I added and tested editor option for expanding all directories.
but, this option is a bit tricky and buggy.