### PR TITLE
Bugfix: Add "undo" mechanism to the "Clear" action

### DIFF
--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -169,7 +169,8 @@ class TextEdit : public Control {
 		enum Type {
 			TYPE_NONE,
 			TYPE_INSERT,
-			TYPE_REMOVE
+			TYPE_REMOVE,
+			TYPE_CLEAR
 		};
 
 		Type type;


### PR DESCRIPTION
*Clear* action is now *UNDOABLE*

![clear-undo](https://user-images.githubusercontent.com/6616005/35687704-66f78f16-073d-11e8-9894-542e3bcd9564.gif)

It has been tested on a TextEdit box and also in the Godot Engine Editor. It works flawlessly.

This should fix the issue https://github.com/godotengine/godot/issues/8533