### PR TITLE
Fix inconsistencies and typos in argument names

### DIFF
--- a/core/safe_refcount.cpp
+++ b/core/safe_refcount.cpp
@@ -119,8 +119,8 @@ _ALWAYS_INLINE_ uint64_t _atomic_exchange_if_greater_impl(register uint64_t *pw,
 
 // The actual advertised functions; they'll call the right implementation
 
-uint32_t atomic_conditional_increment(register uint32_t *counter) {
-	return _atomic_conditional_increment_impl(counter);
+uint32_t atomic_conditional_increment(register uint32_t *pw) {
+	return _atomic_conditional_increment_impl(pw);
 }
 
 uint32_t atomic_decrement(register uint32_t *pw) {
@@ -143,8 +143,8 @@ uint32_t atomic_exchange_if_greater(register uint32_t *pw, register uint32_t val
 	return _atomic_exchange_if_greater_impl(pw, val);
 }
 
-uint64_t atomic_conditional_increment(register uint64_t *counter) {
-	return _atomic_conditional_increment_impl(counter);
+uint64_t atomic_conditional_increment(register uint64_t *pw) {
+	return _atomic_conditional_increment_impl(pw);
 }
 
 uint64_t atomic_decrement(register uint64_t *pw) {

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -145,7 +145,7 @@ public:
 	bool has_setting(const String &p_setting) const;
 	void erase(const String &p_setting);
 	void raise_order(const String &p_setting);
-	void set_initial_value(const StringName &p_setting, const Variant &p_value, bool update_current = false);
+	void set_initial_value(const StringName &p_setting, const Variant &p_value, bool p_update_current = false);
 	void set_manually(const StringName &p_setting, const Variant &p_value, bool p_emit_signal = false) {
 		if (p_emit_signal)
 			_set(p_setting, p_value);

--- a/editor/editor_sub_scene.cpp
+++ b/editor/editor_sub_scene.cpp
@@ -121,10 +121,10 @@ void EditorSubScene::_item_multi_selected(Object *p_object, int p_cell, bool p_s
 	}
 }
 
-void EditorSubScene::_remove_selection_child(Node *n) {
-	if (n->get_child_count() > 0) {
-		for (int i = 0; i < n->get_child_count(); i++) {
-			Node *c = n->get_child(i);
+void EditorSubScene::_remove_selection_child(Node *p_node) {
+	if (p_node->get_child_count() > 0) {
+		for (int i = 0; i < p_node->get_child_count(); i++) {
+			Node *c = p_node->get_child(i);
 			List<Node *>::Element *E = selection.find(c);
 			if (E) {
 				selection.move_to_back(E);

--- a/editor/editor_sub_scene.h
+++ b/editor/editor_sub_scene.h
@@ -50,7 +50,7 @@ class EditorSubScene : public ConfirmationDialog {
 	void _fill_tree(Node *p_node, TreeItem *p_parent);
 	void _selected_changed();
 	void _item_multi_selected(Object *p_object, int p_cell, bool p_selected);
-	void _remove_selection_child(Node *c);
+	void _remove_selection_child(Node *p_node);
 	void _reown(Node *p_node, List<Node *> *p_to_reown);
 
 	void ok_pressed();

--- a/editor/spatial_editor_gizmos.h
+++ b/editor/spatial_editor_gizmos.h
@@ -105,7 +105,7 @@ protected:
 	void add_collision_triangles(const Ref<TriangleMesh> &p_tmesh, const AABB &p_bounds = AABB());
 	void add_unscaled_billboard(const Ref<Material> &p_material, float p_scale = 1);
 	void add_handles(const Vector<Vector3> &p_handles, bool p_billboard = false, bool p_secondary = false);
-	void add_solid_box(Ref<Material> &p_material, Vector3 size);
+	void add_solid_box(Ref<Material> &p_material, Vector3 p_size);
 
 	void set_spatial_node(Spatial *p_node);
 	const Spatial *get_spatial_node() const { return spatial_node; }
@@ -376,13 +376,13 @@ public:
 
 class JointGizmosDrawer {
 public:
-	static Basis look_body(const Transform &joint_transform, const Transform &body_transform);
+	static Basis look_body(const Transform &p_joint_transform, const Transform &p_body_transform);
 	static Basis look_body_toward(Vector3::Axis p_axis, const Transform &joint_transform, const Transform &body_transform);
-	static Basis look_body_toward_x(const Transform &joint_transform, const Transform &body_transform);
-	static Basis look_body_toward_y(const Transform &joint_transform, const Transform &body_transform);
+	static Basis look_body_toward_x(const Transform &p_joint_transform, const Transform &p_body_transform);
+	static Basis look_body_toward_y(const Transform &p_joint_transform, const Transform &p_body_transform);
 	/// Special function just used for physics joints, it that returns a basis constrained toward Joint Z axis
 	/// with axis X and Y that are looking toward the body and oriented toward up
-	static Basis look_body_toward_z(const Transform &joint_transform, const Transform &body_transform);
+	static Basis look_body_toward_z(const Transform &p_joint_transform, const Transform &p_body_transform);
 
 	// Draw circle around p_axis
 	static void draw_circle(Vector3::Axis p_axis, real_t p_radius, const Transform &p_offset, const Basis &p_base, real_t p_limit_lower, real_t p_limit_upper, Vector<Vector3> &r_points, bool p_inverse = false);

--- a/modules/bullet/bullet_physics_server.h
+++ b/modules/bullet/bullet_physics_server.h
@@ -154,7 +154,7 @@ public:
 	/// AREA_PARAM_GRAVITY_VECTOR
 	/// Otherwise you can set area parameters
 	virtual void area_set_param(RID p_area, AreaParameter p_param, const Variant &p_value);
-	virtual Variant area_get_param(RID p_parea, AreaParameter p_param) const;
+	virtual Variant area_get_param(RID p_area, AreaParameter p_param) const;
 
 	virtual void area_set_transform(RID p_area, const Transform &p_transform);
 	virtual Transform area_get_transform(RID p_area) const;
@@ -301,7 +301,7 @@ public:
 	virtual void pin_joint_set_local_b(RID p_joint, const Vector3 &p_B);
 	virtual Vector3 pin_joint_get_local_b(RID p_joint) const;
 
-	virtual RID joint_create_hinge(RID p_body_A, const Transform &p_frame_A, RID p_body_B, const Transform &p_frame_B);
+	virtual RID joint_create_hinge(RID p_body_A, const Transform &p_hinge_A, RID p_body_B, const Transform &p_hinge_B);
 	virtual RID joint_create_hinge_simple(RID p_body_A, const Vector3 &p_pivot_A, const Vector3 &p_axis_A, RID p_body_B, const Vector3 &p_pivot_B, const Vector3 &p_axis_B);
 
 	virtual void hinge_joint_set_param(RID p_joint, HingeJointParam p_param, float p_value);

--- a/modules/bullet/godot_ray_world_algorithm.h
+++ b/modules/bullet/godot_ray_world_algorithm.h
@@ -49,7 +49,7 @@ class GodotRayWorldAlgorithm : public btActivatingCollisionAlgorithm {
 	bool m_isSwapped;
 
 public:
-	GodotRayWorldAlgorithm(const btDiscreteDynamicsWorld *m_world, btPersistentManifold *mf, const btCollisionAlgorithmConstructionInfo &ci, const btCollisionObjectWrapper *body0Wrap, const btCollisionObjectWrapper *body1Wrap, bool isSwapped);
+	GodotRayWorldAlgorithm(const btDiscreteDynamicsWorld *world, btPersistentManifold *mf, const btCollisionAlgorithmConstructionInfo &ci, const btCollisionObjectWrapper *body0Wrap, const btCollisionObjectWrapper *body1Wrap, bool isSwapped);
 	virtual ~GodotRayWorldAlgorithm();
 
 	virtual void processCollision(const btCollisionObjectWrapper *body0Wrap, const btCollisionObjectWrapper *body1Wrap, const btDispatcherInfo &dispatchInfo, btManifoldResult *resultOut);

--- a/modules/bullet/godot_result_callbacks.h
+++ b/modules/bullet/godot_result_callbacks.h
@@ -205,6 +205,6 @@ struct GodotDeepPenetrationContactResultCallback : public btManifoldResult {
 		return m_pointCollisionObject;
 	}
 
-	virtual void addContactPoint(const btVector3 &normalOnBInWorld, const btVector3 &pointInWorld, btScalar depth);
+	virtual void addContactPoint(const btVector3 &normalOnBInWorld, const btVector3 &pointInWorldOnB, btScalar depth);
 };
 #endif // GODOT_RESULT_CALLBACKS_H

--- a/modules/bullet/rigid_body_bullet.h
+++ b/modules/bullet/rigid_body_bullet.h
@@ -262,12 +262,12 @@ public:
 	Variant get_state(PhysicsServer::BodyState p_state) const;
 
 	void apply_impulse(const Vector3 &p_pos, const Vector3 &p_impulse);
-	void apply_central_impulse(const Vector3 &p_force);
+	void apply_central_impulse(const Vector3 &p_impulse);
 	void apply_torque_impulse(const Vector3 &p_impulse);
 
 	void apply_force(const Vector3 &p_force, const Vector3 &p_pos);
 	void apply_central_force(const Vector3 &p_force);
-	void apply_torque(const Vector3 &p_force);
+	void apply_torque(const Vector3 &p_torque);
 
 	void set_applied_force(const Vector3 &p_force);
 	Vector3 get_applied_force() const;

--- a/modules/bullet/shape_bullet.h
+++ b/modules/bullet/shape_bullet.h
@@ -99,7 +99,7 @@ public:
 	virtual void set_data(const Variant &p_data);
 	virtual Variant get_data() const;
 	virtual PhysicsServer::ShapeType get_type() const;
-	virtual btCollisionShape *create_bt_shape(const btVector3 &p_scale, real_t p_margin = 0);
+	virtual btCollisionShape *create_bt_shape(const btVector3 &p_implicit_scale, real_t p_margin = 0);
 
 private:
 	void setup(const Plane &p_plane);
@@ -116,7 +116,7 @@ public:
 	virtual void set_data(const Variant &p_data);
 	virtual Variant get_data() const;
 	virtual PhysicsServer::ShapeType get_type() const;
-	virtual btCollisionShape *create_bt_shape(const btVector3 &p_scale, real_t p_margin = 0);
+	virtual btCollisionShape *create_bt_shape(const btVector3 &p_implicit_scale, real_t p_margin = 0);
 
 private:
 	void setup(real_t p_radius);
@@ -133,7 +133,7 @@ public:
 	virtual void set_data(const Variant &p_data);
 	virtual Variant get_data() const;
 	virtual PhysicsServer::ShapeType get_type() const;
-	virtual btCollisionShape *create_bt_shape(const btVector3 &p_scale, real_t p_margin = 0);
+	virtual btCollisionShape *create_bt_shape(const btVector3 &p_implicit_scale, real_t p_margin = 0);
 
 private:
 	void setup(const Vector3 &p_half_extents);
@@ -152,7 +152,7 @@ public:
 	virtual void set_data(const Variant &p_data);
 	virtual Variant get_data() const;
 	virtual PhysicsServer::ShapeType get_type() const;
-	virtual btCollisionShape *create_bt_shape(const btVector3 &p_scale, real_t p_margin = 0);
+	virtual btCollisionShape *create_bt_shape(const btVector3 &p_implicit_scale, real_t p_margin = 0);
 
 private:
 	void setup(real_t p_height, real_t p_radius);
@@ -169,7 +169,7 @@ public:
 	void get_vertices(Vector<Vector3> &out_vertices);
 	virtual Variant get_data() const;
 	virtual PhysicsServer::ShapeType get_type() const;
-	virtual btCollisionShape *create_bt_shape(const btVector3 &p_scale, real_t p_margin = 0);
+	virtual btCollisionShape *create_bt_shape(const btVector3 &p_implicit_scale, real_t p_margin = 0);
 
 private:
 	void setup(const Vector<Vector3> &p_vertices);
@@ -187,7 +187,7 @@ public:
 	virtual void set_data(const Variant &p_data);
 	virtual Variant get_data() const;
 	virtual PhysicsServer::ShapeType get_type() const;
-	virtual btCollisionShape *create_bt_shape(const btVector3 &p_scale, real_t p_margin = 0);
+	virtual btCollisionShape *create_bt_shape(const btVector3 &p_implicit_scale, real_t p_margin = 0);
 
 private:
 	void setup(PoolVector<Vector3> p_faces);
@@ -206,7 +206,7 @@ public:
 	virtual void set_data(const Variant &p_data);
 	virtual Variant get_data() const;
 	virtual PhysicsServer::ShapeType get_type() const;
-	virtual btCollisionShape *create_bt_shape(const btVector3 &p_scale, real_t p_margin = 0);
+	virtual btCollisionShape *create_bt_shape(const btVector3 &p_implicit_scale, real_t p_margin = 0);
 
 private:
 	void setup(PoolVector<real_t> &p_heights, int p_width, int p_depth, real_t p_cell_size);
@@ -222,7 +222,7 @@ public:
 	virtual void set_data(const Variant &p_data);
 	virtual Variant get_data() const;
 	virtual PhysicsServer::ShapeType get_type() const;
-	virtual btCollisionShape *create_bt_shape(const btVector3 &p_scale, real_t p_margin = 0);
+	virtual btCollisionShape *create_bt_shape(const btVector3 &p_implicit_scale, real_t p_margin = 0);
 
 private:
 	void setup(real_t p_length);

--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -116,7 +116,7 @@ bool BulletPhysicsDirectSpaceState::intersect_ray(const Vector3 &p_from, const V
 	}
 }
 
-int BulletPhysicsDirectSpaceState::intersect_shape(const RID &p_shape, const Transform &p_xform, float p_margin, ShapeResult *p_results, int p_result_max, const Set<RID> &p_exclude, uint32_t p_collision_mask) {
+int BulletPhysicsDirectSpaceState::intersect_shape(const RID &p_shape, const Transform &p_xform, float p_margin, ShapeResult *r_results, int p_result_max, const Set<RID> &p_exclude, uint32_t p_collision_mask) {
 	if (p_result_max <= 0)
 		return 0;
 
@@ -138,7 +138,7 @@ int BulletPhysicsDirectSpaceState::intersect_shape(const RID &p_shape, const Tra
 	collision_object.setCollisionShape(btConvex);
 	collision_object.setWorldTransform(bt_xform);
 
-	GodotAllContactResultCallback btQuery(&collision_object, p_results, p_result_max, &p_exclude);
+	GodotAllContactResultCallback btQuery(&collision_object, r_results, p_result_max, &p_exclude);
 	btQuery.m_collisionFilterGroup = 0;
 	btQuery.m_collisionFilterMask = p_collision_mask;
 	btQuery.m_closestDistanceThreshold = 0;

--- a/modules/bullet/space_bullet.h
+++ b/modules/bullet/space_bullet.h
@@ -199,12 +199,12 @@ private:
 				local_shape_most_recovered(0) {}
 	};
 
-	bool recover_from_penetration(RigidBodyBullet *p_body, const btTransform &p_from, btScalar p_recover_movement_scale, btVector3 &r_delta_recover_movement, RecoverResult *r_recover_result = NULL);
+	bool recover_from_penetration(RigidBodyBullet *p_body, const btTransform &p_body_position, btScalar p_recover_movement_scale, btVector3 &r_delta_recover_movement, RecoverResult *r_recover_result = NULL);
 	/// This is an API that recover a kinematic object from penetration
 	/// This allow only Convex Convex test and it always use GJK algorithm, With this API we don't benefit of Bullet special accelerated functions
-	bool RFP_convex_convex_test(const btConvexShape *p_shapeA, const btConvexShape *p_shapeB, btCollisionObject *p_objectB, int p_shapeId_B, const btTransform &p_transformA, const btTransform &p_transformB, btScalar p_movement_scale, btVector3 &r_delta_recover_movement, RecoverResult *r_recover_result = NULL);
+	bool RFP_convex_convex_test(const btConvexShape *p_shapeA, const btConvexShape *p_shapeB, btCollisionObject *p_objectB, int p_shapeId_B, const btTransform &p_transformA, const btTransform &p_transformB, btScalar p_recover_movement_scale, btVector3 &r_delta_recover_movement, RecoverResult *r_recover_result = NULL);
 	/// This is an API that recover a kinematic object from penetration
 	/// Using this we leave Bullet to select the best algorithm, For example GJK in case we have Convex Convex, or a Bullet accelerated algorithm
-	bool RFP_convex_world_test(const btConvexShape *p_shapeA, const btCollisionShape *p_shapeB, btCollisionObject *p_objectA, btCollisionObject *p_objectB, int p_shapeId_A, int p_shapeId_B, const btTransform &p_transformA, const btTransform &p_transformB, btScalar p_movement_scale, btVector3 &r_delta_recover_movement, RecoverResult *r_recover_result = NULL);
+	bool RFP_convex_world_test(const btConvexShape *p_shapeA, const btCollisionShape *p_shapeB, btCollisionObject *p_objectA, btCollisionObject *p_objectB, int p_shapeId_A, int p_shapeId_B, const btTransform &p_transformA, const btTransform &p_transformB, btScalar p_recover_movement_scale, btVector3 &r_delta_recover_movement, RecoverResult *r_recover_result = NULL);
 };
 #endif

--- a/modules/gdnative/gdnative_library_editor_plugin.h
+++ b/modules/gdnative/gdnative_library_editor_plugin.h
@@ -79,7 +79,7 @@ protected:
 	void _on_library_selected(const String &file);
 	void _on_dependencies_selected(const PoolStringArray &files);
 	void _on_filter_selected(int id);
-	void _on_item_collapsed(Object *item);
+	void _on_item_collapsed(Object *p_item);
 	void _on_item_activated();
 	void _on_create_new_entry();
 	void _set_target_value(const String &section, const String &target, Variant file);

--- a/modules/gdnative/pluginscript/pluginscript_script.h
+++ b/modules/gdnative/pluginscript/pluginscript_script.h
@@ -112,7 +112,7 @@ public:
 
 	virtual void update_exports();
 	virtual void get_script_method_list(List<MethodInfo> *r_methods) const;
-	virtual void get_script_property_list(List<PropertyInfo> *r_propertieslist) const;
+	virtual void get_script_property_list(List<PropertyInfo> *r_properties) const;
 
 	virtual int get_member_line(const StringName &p_member) const;
 

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -247,7 +247,7 @@ public:
 	int get_cell_item(int p_x, int p_y, int p_z) const;
 	int get_cell_item_orientation(int p_x, int p_y, int p_z) const;
 
-	Vector3 world_to_map(const Vector3 &p_pos) const;
+	Vector3 world_to_map(const Vector3 &p_world_pos) const;
 	Vector3 map_to_world(int p_x, int p_y, int p_z) const;
 
 	void set_clip(bool p_enabled, bool p_clip_above = true, int p_floor = 0, Vector3::Axis p_axis = Vector3::AXIS_X);

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -504,8 +504,8 @@ class BindingsGenerator {
 	const TypeInterface *_get_type_by_name_or_null(const StringName &p_cname);
 	const TypeInterface *_get_type_by_name_or_placeholder(const StringName &p_cname);
 
-	void _default_argument_from_variant(const Variant &p_var, ArgumentInterface &r_iarg);
-	void _populate_builtin_type(TypeInterface &r_type, Variant::Type vtype);
+	void _default_argument_from_variant(const Variant &p_val, ArgumentInterface &r_iarg);
+	void _populate_builtin_type(TypeInterface &r_itype, Variant::Type vtype);
 
 	void _populate_object_type_interfaces();
 	void _populate_builtin_type_interfaces();
@@ -514,14 +514,14 @@ class BindingsGenerator {
 
 	Error _generate_cs_type(const TypeInterface &itype, const String &p_output_file);
 
-	Error _generate_cs_property(const TypeInterface &p_itype, const PropertyInterface &p_prop_doc, List<String> &p_output);
+	Error _generate_cs_property(const TypeInterface &p_itype, const PropertyInterface &p_iprop, List<String> &p_output);
 	Error _generate_cs_method(const TypeInterface &p_itype, const MethodInterface &p_imethod, int &p_method_bind_count, List<String> &p_output);
 
 	void _generate_global_constants(List<String> &p_output);
 
 	Error _generate_glue_method(const TypeInterface &p_itype, const MethodInterface &p_imethod, List<String> &p_output);
 
-	Error _save_file(const String &path, const List<String> &content);
+	Error _save_file(const String &p_path, const List<String> &p_content);
 
 	BindingsGenerator() {}
 

--- a/modules/mono/editor/monodevelop_instance.h
+++ b/modules/mono/editor/monodevelop_instance.h
@@ -43,7 +43,7 @@ class MonoDevelopInstance {
 
 public:
 	void execute(const Vector<String> &p_files);
-	void execute(const String &p_files);
+	void execute(const String &p_file);
 
 	MonoDevelopInstance(const String &p_solution);
 };

--- a/modules/mono/mono_gd/gd_mono_assembly.h
+++ b/modules/mono/mono_gd/gd_mono_assembly.h
@@ -110,7 +110,7 @@ public:
 	_FORCE_INLINE_ String get_path() const { return path; }
 	_FORCE_INLINE_ uint64_t get_modified_time() const { return modified_time; }
 
-	GDMonoClass *get_class(const StringName &p_namespace, const StringName &p_class);
+	GDMonoClass *get_class(const StringName &p_namespace, const StringName &p_name);
 	GDMonoClass *get_class(MonoClass *p_mono_class);
 
 	GDMonoClass *get_object_derived_class(const StringName &p_class);

--- a/modules/mono/mono_gd/gd_mono_class.h
+++ b/modules/mono/mono_gd/gd_mono_class.h
@@ -125,7 +125,7 @@ public:
 	GDMonoMethod *get_method(MonoMethod *p_raw_method);
 	GDMonoMethod *get_method(MonoMethod *p_raw_method, const StringName &p_name);
 	GDMonoMethod *get_method(MonoMethod *p_raw_method, const StringName &p_name, int p_params_count);
-	GDMonoMethod *get_method_with_desc(const String &p_description, bool p_includes_namespace);
+	GDMonoMethod *get_method_with_desc(const String &p_description, bool p_include_namespace);
 
 	GDMonoField *get_field(const StringName &p_name);
 	const Vector<GDMonoField *> &get_all_fields();

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -199,7 +199,7 @@ protected:
 
 	virtual void set_main_loop(MainLoop *p_main_loop);
 
-	void _window_changed(XEvent *xevent);
+	void _window_changed(XEvent *event);
 
 	bool is_window_maximize_allowed();
 

--- a/scene/3d/camera.h
+++ b/scene/3d/camera.h
@@ -97,7 +97,7 @@ protected:
 	void _update_camera_mode();
 
 	void _notification(int p_what);
-	virtual void _validate_property(PropertyInfo &property) const;
+	virtual void _validate_property(PropertyInfo &p_property) const;
 
 	static void _bind_methods();
 

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -1603,19 +1603,19 @@ float Animation::get_step() const {
 	return step;
 }
 
-void Animation::copy_track(int src_track, Ref<Animation> p_to_animation) {
+void Animation::copy_track(int p_track, Ref<Animation> p_to_animation) {
 	ERR_FAIL_COND(p_to_animation.is_null());
-	ERR_FAIL_INDEX(src_track, get_track_count());
+	ERR_FAIL_INDEX(p_track, get_track_count());
 	int dst_track = p_to_animation->get_track_count();
-	p_to_animation->add_track(track_get_type(src_track));
+	p_to_animation->add_track(track_get_type(p_track));
 
-	p_to_animation->track_set_path(dst_track, track_get_path(src_track));
-	p_to_animation->track_set_imported(dst_track, track_is_imported(src_track));
-	p_to_animation->track_set_enabled(dst_track, track_is_enabled(src_track));
-	p_to_animation->track_set_interpolation_type(dst_track, track_get_interpolation_type(src_track));
-	p_to_animation->track_set_interpolation_loop_wrap(dst_track, track_get_interpolation_loop_wrap(src_track));
-	for (int i = 0; i < track_get_key_count(src_track); i++) {
-		p_to_animation->track_insert_key(dst_track, track_get_key_time(src_track, i), track_get_key_value(src_track, i), track_get_key_transition(src_track, i));
+	p_to_animation->track_set_path(dst_track, track_get_path(p_track));
+	p_to_animation->track_set_imported(dst_track, track_is_imported(p_track));
+	p_to_animation->track_set_enabled(dst_track, track_is_enabled(p_track));
+	p_to_animation->track_set_interpolation_type(dst_track, track_get_interpolation_type(p_track));
+	p_to_animation->track_set_interpolation_loop_wrap(dst_track, track_get_interpolation_loop_wrap(p_track));
+	for (int i = 0; i < track_get_key_count(p_track); i++) {
+		p_to_animation->track_insert_key(dst_track, track_get_key_time(p_track, i), track_get_key_value(p_track, i), track_get_key_transition(p_track, i));
 	}
 }
 

--- a/servers/physics/physics_server_sw.cpp
+++ b/servers/physics/physics_server_sw.cpp
@@ -795,12 +795,12 @@ void PhysicsServerSW::body_set_axis_velocity(RID p_body, const Vector3 &p_axis_v
 	body->wakeup();
 };
 
-void PhysicsServerSW::body_set_axis_lock(RID p_body, BodyAxis p_axis, bool lock) {
+void PhysicsServerSW::body_set_axis_lock(RID p_body, BodyAxis p_axis, bool p_lock) {
 
 	BodySW *body = body_owner.get(p_body);
 	ERR_FAIL_COND(!body);
 
-	body->set_axis_lock(p_axis, lock);
+	body->set_axis_lock(p_axis, p_lock);
 	body->wakeup();
 }
 

--- a/servers/physics_2d_server.cpp
+++ b/servers/physics_2d_server.cpp
@@ -168,9 +168,9 @@ float Physics2DShapeQueryParameters::get_margin() const {
 	return margin;
 }
 
-void Physics2DShapeQueryParameters::set_collision_mask(int p_collision_layer) {
+void Physics2DShapeQueryParameters::set_collision_mask(int p_collision_mask) {
 
-	collision_mask = p_collision_layer;
+	collision_mask = p_collision_mask;
 }
 int Physics2DShapeQueryParameters::get_collision_mask() const {
 

--- a/servers/physics_server.h
+++ b/servers/physics_server.h
@@ -118,7 +118,7 @@ public:
 	void set_margin(float p_margin);
 	float get_margin() const;
 
-	void set_collision_mask(int p_collision_layer);
+	void set_collision_mask(int p_collision_mask);
 	int get_collision_mask() const;
 
 	void set_exclude(const Vector<RID> &p_exclude);

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -457,7 +457,7 @@ public:
 	virtual void instance_set_visible(RID p_instance, bool p_visible);
 	virtual void instance_set_use_lightmap(RID p_instance, RID p_lightmap_instance, RID p_lightmap);
 
-	virtual void instance_set_custom_aabb(RID p_insatnce, AABB aabb);
+	virtual void instance_set_custom_aabb(RID p_instance, AABB p_aabb);
 
 	virtual void instance_attach_skeleton(RID p_instance, RID p_skeleton);
 	virtual void instance_set_exterior(RID p_instance, bool p_enabled);


### PR DESCRIPTION
This PR should fix issue #15668 .

**Note**: I mostly changed argument names in header files to match those found in their definition (.cpp), but in some cases I changed them in their definition as well to keep naming consistent across respective files.

I am however not sure how to approach the changes in `gdnative_library_editor_plugin.h` . I changed `*item` to `*p_item` to mirror the naming found in the definition file but this breaks consistency because argument names in the header file (in other functions) do not follow the `p_[argument_name]` naming convention. I could change the argument name to `item` in definition but there is a local scope variable with the same name in the function.