### PR TITLE
set_auto_accept_quit was not working properly when Godot editor is open (debug mode)

### DIFF
--- a/scene/main/scene_main_loop.cpp
+++ b/scene/main/scene_main_loop.cpp
@@ -560,10 +560,7 @@ void SceneTree::_notification(int p_notification) {
 
 			get_root()->propagate_notification(p_notification);
 
-			if (accept_quit) {
-				_quit = true;
-				break;
-			}
+			_quit = accept_quit;
 		} break;
 		case NOTIFICATION_OS_MEMORY_WARNING:
 		case NOTIFICATION_WM_FOCUS_IN:


### PR DESCRIPTION
Currently the `set_auto_accept_quit` function does not work when the godot engine editor is open (debug mode).

This issue is present since 2.1.4 at least (tested manually on android/linux). I tried an _exhausting_ git bisect but I did not want to dig further than 2.1.4.

For debug purpose I needed to be able to set the `set_auto_accept_quit` flag to false without creating and deploying a fresh new apk. 

**Note:**
The fix has been tested on Linux, Android and Windows 10.