### PR TITLE
Fix gizmo solid box mesh being added twice

### DIFF
--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -308,15 +308,6 @@ void EditorSpatialGizmo::add_solid_box(Ref<Material> &p_material, Vector3 p_size
 	m->add_surface_from_arrays(cubem.surface_get_primitive_type(0), cubem.surface_get_arrays(0));
 	m->surface_set_material(0, p_material);
 	add_mesh(m);
-
-	Instance ins;
-	ins.mesh = m;
-	if (valid) {
-		ins.create_instance(spatial_node);
-		VS::get_singleton()->instance_set_transform(ins.instance, spatial_node->get_global_transform());
-	}
-
-	instances.push_back(ins);
 }
 
 void EditorSpatialGizmo::set_spatial_node(Spatial *p_node) {


### PR DESCRIPTION
The removed piece of code is the same as the one in add_mesh(), this meant the mesh was being added twice.