### PR TITLE
Fix gradient texture preview

### DIFF
--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -75,6 +75,9 @@ void TextureEditor::_notification(int p_what) {
 			// In the case of CurveTextures we know they are 1 in height, so fill the preview to see the gradient
 			ofs_y = 0;
 			tex_height = size.height;
+		} else if (Object::cast_to<GradientTexture>(*texture)) {
+			ofs_y = size.height / 4.0;
+			tex_height = size.height / 2.0;
 		}
 
 		draw_texture_rect(texture, Rect2(ofs_x, ofs_y, tex_width, tex_height));


### PR DESCRIPTION
This is simple fix, which makes it more visible for human eyes. Closes #16316
Before
![image](https://user-images.githubusercontent.com/3036176/35765775-f1618860-08db-11e8-813b-0a3194815390.png)
After
![image](https://user-images.githubusercontent.com/3036176/35765769-cc6815b0-08db-11e8-87f5-2d1cb05b61c9.png)
