### PR TITLE
Inspector folding fix

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -374,6 +374,11 @@ void EditorNode::_notification(int p_what) {
 		dock_tab_move_left->set_icon(theme->get_icon("Back", "EditorIcons"));
 		dock_tab_move_right->set_icon(theme->get_icon("Forward", "EditorIcons"));
 		update_menu->set_icon(gui_base->get_icon("Progress1", "EditorIcons"));
+
+		PopupMenu *p = object_menu->get_popup();
+		bool code_folding = EDITOR_GET("interface/editor/disable_inspector_folding");
+		p->set_item_disabled(p->get_item_index(EXPAND_ALL), code_folding);
+		p->set_item_disabled(p->get_item_index(COLLAPSE_ALL), code_folding);
 	}
 
 	if (p_what == Control::NOTIFICATION_RESIZED) {
@@ -1618,6 +1623,9 @@ void EditorNode::_edit_current() {
 	p->clear();
 	p->add_shortcut(ED_SHORTCUT("property_editor/expand_all", TTR("Expand all properties")), EXPAND_ALL);
 	p->add_shortcut(ED_SHORTCUT("property_editor/collapse_all", TTR("Collapse all properties")), COLLAPSE_ALL);
+	bool code_folding = EDITOR_GET("interface/editor/disable_inspector_folding");
+	p->set_item_disabled(p->get_item_index(EXPAND_ALL), code_folding);
+	p->set_item_disabled(p->get_item_index(COLLAPSE_ALL), code_folding);
 	p->add_separator();
 	p->add_shortcut(ED_SHORTCUT("property_editor/copy_params", TTR("Copy Params")), OBJECT_COPY_PARAMS);
 	p->add_shortcut(ED_SHORTCUT("property_editor/paste_params", TTR("Paste Params")), OBJECT_PASTE_PARAMS);

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -2661,6 +2661,7 @@ void PropertyEditor::_notification(int p_what) {
 	}
 
 	if (p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
+		set_use_folding(!bool(EDITOR_GET("interface/editor/disable_inspector_folding")));
 		update_tree();
 	}
 }
@@ -4238,7 +4239,7 @@ void PropertyEditor::set_subsection_selectable(bool p_selectable) {
 void PropertyEditor::set_use_folding(bool p_enable) {
 
 	use_folding = p_enable;
-	tree->set_hide_folding(false);
+	tree->set_hide_folding(!p_enable);
 }
 
 void PropertyEditor::collapse_all_folding() {


### PR DESCRIPTION
I've fixed inspector folding property(EditorSettings->Interface->Editor->Disable Inspector Folding)
1. It will now can be apply, without editor restart
2. It will actually hide the property folding controls(as it intended to be)

when disabled
![image](https://user-images.githubusercontent.com/3036176/35767146-7e4dddee-08f7-11e8-80ef-7072300a6b76.png)
when enabled
![image](https://user-images.githubusercontent.com/3036176/35767151-a361fe44-08f7-11e8-9b07-9b8086e52ae3.png)

3. Also, when Folding is disabled
The Collapse and Expand labels should also be disabled, and I maked it..
![image](https://user-images.githubusercontent.com/3036176/35767487-234a8a26-08fe-11e8-9143-9e3e05c6803c.png)
