### PR TITLE
ParticlesGizmo solid box now follows actual visibility_aabb position.

### DIFF
--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -299,13 +299,24 @@ void EditorSpatialGizmo::add_handles(const Vector<Vector3> &p_handles, bool p_bi
 	}
 }
 
-void EditorSpatialGizmo::add_solid_box(Ref<Material> &p_material, Vector3 p_size) {
+void EditorSpatialGizmo::add_solid_box(Ref<Material> &p_material, Vector3 p_size, Vector3 p_position) {
 	ERR_FAIL_COND(!spatial_node);
 
 	CubeMesh cubem;
 	cubem.set_size(p_size);
+
+	Array arrays = cubem.surface_get_arrays(0);
+	PoolVector3Array vertex = arrays[VS::ARRAY_VERTEX];
+	PoolVector3Array::Write w = vertex.write();
+
+	for (int i = 0; i < vertex.size(); ++i) {
+		w[i] += p_position;
+	}
+
+	arrays[VS::ARRAY_VERTEX] = vertex;
+
 	Ref<ArrayMesh> m = memnew(ArrayMesh);
-	m->add_surface_from_arrays(cubem.surface_get_primitive_type(0), cubem.surface_get_arrays(0));
+	m->add_surface_from_arrays(cubem.surface_get_primitive_type(0), arrays);
 	m->surface_set_material(0, p_material);
 	add_mesh(m);
 
@@ -2419,7 +2430,7 @@ void ParticlesGizmo::redraw() {
 
 		gizmo_color.a = 0.1;
 		Ref<Material> solid_material = create_material("particles_solid_material", gizmo_color);
-		add_solid_box(solid_material, aabb.get_size());
+		add_solid_box(solid_material, aabb.get_size(), aabb.get_position() + aabb.get_size() / 2.0);
 	}
 
 	//add_unscaled_billboard(SpatialEditorGizmos::singleton->visi,0.05);

--- a/editor/spatial_editor_gizmos.h
+++ b/editor/spatial_editor_gizmos.h
@@ -105,7 +105,7 @@ protected:
 	void add_collision_triangles(const Ref<TriangleMesh> &p_tmesh, const AABB &p_bounds = AABB());
 	void add_unscaled_billboard(const Ref<Material> &p_material, float p_scale = 1);
 	void add_handles(const Vector<Vector3> &p_handles, bool p_billboard = false, bool p_secondary = false);
-	void add_solid_box(Ref<Material> &p_material, Vector3 p_size);
+	void add_solid_box(Ref<Material> &p_material, Vector3 p_size, Vector3 p_position = Vector3());
 
 	void set_spatial_node(Spatial *p_node);
 	const Spatial *get_spatial_node() const { return spatial_node; }


### PR DESCRIPTION
ParticlesGizmo had a solid mesh but it didn't move along with the actual visibility AABB, it just stayed centered on the node. I'm not sure this is the best way to modify the vertexes of a mesh, if anyone knows a better one please let me know.

_Bugsquad edit: fixes #16768_