### PR TITLE
Remov. doc/non-exist. member x,y,z in Plane class

### DIFF
--- a/doc/classes/Plane.xml
+++ b/doc/classes/Plane.xml
@@ -149,12 +149,6 @@
 		</member>
 		<member name="normal" type="Vector3" setter="" getter="">
 		</member>
-		<member name="x" type="float" setter="" getter="">
-		</member>
-		<member name="y" type="float" setter="" getter="">
-		</member>
-		<member name="z" type="float" setter="" getter="">
-		</member>
 	</members>
 	<constants>
 	</constants>


### PR DESCRIPTION
There aren't such x,y,z members in Plane class.
See https://github.com/godotengine/godot/blob/34c988cfa92f19c232b65990704816ba1c7d2622/core/math/plane.h