### PR TITLE
Drop path text at mouse pos

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1283,12 +1283,9 @@ Variant ScriptTextEditor::get_drag_data_fw(const Point2 &p_point, Control *p_fro
 bool ScriptTextEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
 
 	Dictionary d = p_data;
-	if (d.has("type") &&
-			(
-
-					String(d["type"]) == "resource" ||
-					String(d["type"]) == "files" ||
-					String(d["type"]) == "nodes")) {
+	if (d.has("type") && (String(d["type"]) == "resource" ||
+								 String(d["type"]) == "files" ||
+								 String(d["type"]) == "nodes")) {
 
 		return true;
 	}
@@ -1329,6 +1326,10 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 
 	Dictionary d = p_data;
 
+	TextEdit *te = code_editor->get_text_edit();
+	int row, col;
+	te->_get_mouse_pos(p_point, row, col);
+
 	if (d.has("type") && String(d["type"]) == "resource") {
 
 		Ref<Resource> res = d["resource"];
@@ -1341,7 +1342,9 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 			return;
 		}
 
-		code_editor->get_text_edit()->insert_text_at_cursor(res->get_path());
+		te->cursor_set_line(row);
+		te->cursor_set_column(col);
+		te->insert_text_at_cursor(res->get_path());
 	}
 
 	if (d.has("type") && String(d["type"]) == "files") {
@@ -1356,7 +1359,9 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 			text_to_drop += "\"" + String(files[i]).c_escape() + "\"";
 		}
 
-		code_editor->get_text_edit()->insert_text_at_cursor(text_to_drop);
+		te->cursor_set_line(row);
+		te->cursor_set_column(col);
+		te->insert_text_at_cursor(text_to_drop);
 	}
 
 	if (d.has("type") && String(d["type"]) == "nodes") {
@@ -1385,7 +1390,9 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 			text_to_drop += "\"" + path.c_escape() + "\"";
 		}
 
-		code_editor->get_text_edit()->insert_text_at_cursor(text_to_drop);
+		te->cursor_set_line(row);
+		te->cursor_set_column(col);
+		te->insert_text_at_cursor(text_to_drop);
 	}
 }
 


### PR DESCRIPTION
When dragging and dropping a resource, node, or files into the script text editor, the path is inserted at the current mouse position instead of where the cursor was last, unless there is selected text.