### PR TITLE
Draw the Camera gizmo more accurately

### DIFF
--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -1130,7 +1130,7 @@ void CameraSpatialGizmo::set_handle(int p_idx, Camera *p_camera, const Point2 &p
 	if (camera->get_projection() == Camera::PROJECTION_PERSPECTIVE) {
 		Transform gt = camera->get_global_transform();
 		float a = _find_closest_angle_to_half_pi_arc(s[0], s[1], 1.0, gt);
-		camera->set("fov", a);
+		camera->set("fov", a * 2.0);
 	} else {
 
 		Vector3 ra, rb;
@@ -1187,7 +1187,8 @@ void CameraSpatialGizmo::redraw() {
 
 		case Camera::PROJECTION_PERSPECTIVE: {
 
-			float fov = camera->get_fov();
+			// The real FOV is halved for accurate representation
+			float fov = camera->get_fov() / 2.0;
 
 			Vector3 side = Vector3(Math::sin(Math::deg2rad(fov)), 0, -Math::cos(Math::deg2rad(fov)));
 			Vector3 nside = side;


### PR DESCRIPTION
The Camera gizmo no longer looks twice as wide as it actually is.
This fixes #16399.