### PR TITLE
Allow exporting arrays of resources in GDScript

### DIFF
--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -3228,22 +3228,34 @@ void PropertyEditor::update_tree() {
 				while (hint.begins_with(itos(Variant::ARRAY) + ":")) {
 					type_name += "<Array";
 					type_name_suffix += ">";
-					hint = hint.substr(2, hint.size() - 2);
+					hint = hint.right(2);
 				}
 				if (hint.find(":") >= 0) {
-					hint = hint.substr(0, hint.find(":"));
+					int colon_pos = hint.find(":");
+					String hint_string = hint.right(colon_pos + 1);
+					hint = hint.left(colon_pos);
+
+					PropertyHint property_hint = PROPERTY_HINT_NONE;
+
 					if (hint.find("/") >= 0) {
-						hint = hint.substr(0, hint.find("/"));
+						int slash_pos = hint.find("/");
+						property_hint = PropertyHint(hint.right(slash_pos + 1).to_int());
+						hint = hint.left(slash_pos);
 					}
-					type_name += "<" + Variant::get_type_name(Variant::Type(hint.to_int()));
+
+					if (property_hint == PROPERTY_HINT_RESOURCE_TYPE) {
+						type_name += "<" + hint_string;
+					} else {
+						type_name += "<" + Variant::get_type_name(Variant::Type(hint.to_int()));
+					}
 					type_name_suffix += ">";
 				}
 				type_name += type_name_suffix;
 
 				if (v.is_array())
-					item->set_text(1, type_name + "[" + itos(v.call("size")) + "]");
+					item->set_text(1, type_name + "(" + itos(v.call("size")) + ")");
 				else
-					item->set_text(1, type_name + "[]");
+					item->set_text(1, type_name + "()");
 
 				if (show_type_icons)
 					item->set_icon(0, get_icon("ArrayData", "EditorIcons"));

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3408,6 +3408,22 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 				if (tokenizer->get_token() == GDScriptTokenizer::TK_PARENTHESIS_OPEN) {
 
 					tokenizer->advance();
+
+					String hint_prefix = "";
+					bool is_arrayed = false;
+
+					while (tokenizer->get_token() == GDScriptTokenizer::TK_BUILT_IN_TYPE &&
+							tokenizer->get_token_type() == Variant::ARRAY &&
+							tokenizer->get_token(1) == GDScriptTokenizer::TK_COMMA) {
+						tokenizer->advance(); // Array
+						tokenizer->advance(); // Comma
+						if (is_arrayed) {
+							hint_prefix += itos(Variant::ARRAY) + ":";
+						} else {
+							is_arrayed = true;
+						}
+					}
+
 					if (tokenizer->get_token() == GDScriptTokenizer::TK_BUILT_IN_TYPE) {
 
 						Variant::Type type = tokenizer->get_token_type();
@@ -3422,28 +3438,6 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 						current_export.type = type;
 						current_export.usage |= PROPERTY_USAGE_SCRIPT_VARIABLE;
 						tokenizer->advance();
-
-						String hint_prefix = "";
-
-						if (type == Variant::ARRAY && tokenizer->get_token() == GDScriptTokenizer::TK_COMMA) {
-							tokenizer->advance();
-
-							while (tokenizer->get_token() == GDScriptTokenizer::TK_BUILT_IN_TYPE) {
-								type = tokenizer->get_token_type();
-
-								tokenizer->advance();
-
-								if (type == Variant::ARRAY) {
-									hint_prefix += itos(Variant::ARRAY) + ":";
-									if (tokenizer->get_token() == GDScriptTokenizer::TK_COMMA) {
-										tokenizer->advance();
-									}
-								} else {
-									hint_prefix += itos(type);
-									break;
-								}
-							}
-						}
 
 						if (tokenizer->get_token() == GDScriptTokenizer::TK_COMMA) {
 							// hint expected next!
@@ -3798,13 +3792,6 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 								} break;
 							}
 						}
-						if (current_export.type == Variant::ARRAY && !hint_prefix.empty()) {
-							if (current_export.hint) {
-								hint_prefix += "/" + itos(current_export.hint);
-							}
-							current_export.hint_string = hint_prefix + ":" + current_export.hint_string;
-							current_export.hint = PROPERTY_HINT_NONE;
-						}
 
 					} else {
 
@@ -3889,6 +3876,16 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 						current_export = PropertyInfo();
 						_set_error("Expected ')' or ',' after export hint.");
 						return;
+					}
+
+					if (is_arrayed) {
+						hint_prefix += itos(current_export.type);
+						if (current_export.hint) {
+							hint_prefix += "/" + itos(current_export.hint);
+						}
+						current_export.hint_string = hint_prefix + ":" + current_export.hint_string;
+						current_export.hint = PROPERTY_HINT_TYPE_STRING;
+						current_export.type = Variant::ARRAY;
 					}
 
 					tokenizer->advance();
@@ -4058,7 +4055,8 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 
 							member._export.type=Variant::DICTIONARY;
 
-						} else*/ {
+						} else*/
+						{
 
 							if (subexpr->type != Node::TYPE_CONSTANT) {
 


### PR DESCRIPTION
Fixes #15961.

Also, changed the display in the property list from `Array<X>[5]` to `Array<X>(5)`.
Also, made it display the resource type correctly.