### PR TITLE
Fix polygon triangulation failure.

### DIFF
--- a/core/math/triangulate.cpp
+++ b/core/math/triangulate.cpp
@@ -74,7 +74,7 @@ bool Triangulate::is_inside_triangle(real_t Ax, real_t Ay,
 	cCROSSap = cx * apy - cy * apx;
 	bCROSScp = bx * cpy - by * cpx;
 
-	return ((aCROSSbp >= 0.0) && (bCROSScp >= 0.0) && (cCROSSap >= 0.0));
+	return ((aCROSSbp > 0.0) && (bCROSScp > 0.0) && (cCROSSap > 0.0));
 };
 
 bool Triangulate::snip(const Vector<Vector2> &p_contour, int u, int v, int w, int n, const Vector<int> &V) {


### PR DESCRIPTION
The ear clipping algorithm used to triangulate polygons has a slightly too conservative point-in-triangle test which can, in some configurations prevent it from finding a possible tessellation. Relaxing the test by considering that points exactly on edges don't belong the triangle fixes the issue. Changing the semantic of the test is safe because no other code makes use of it. A more detailed explanation can be found in issue #16395.

Fixes #16395.