### PR TITLE
using TIME in light shader enables uses_fragment_time

### DIFF
--- a/drivers/gles3/shader_compiler_gles3.cpp
+++ b/drivers/gles3/shader_compiler_gles3.cpp
@@ -477,22 +477,22 @@ String ShaderCompilerGLES3::_dump_node_code(SL::Node *p_node, int p_level, Gener
 
 				current_func_name = fnode->name;
 
-				if (fnode->name == "vertex") {
+				if (fnode->name == vertex_name) {
 
 					_dump_function_deps(pnode, fnode->name, function_code, r_gen_code.vertex_global, added_vtx);
-					r_gen_code.vertex = function_code["vertex"];
+					r_gen_code.vertex = function_code[vertex_name];
 				}
 
-				if (fnode->name == "fragment") {
+				if (fnode->name == fragment_name) {
 
 					_dump_function_deps(pnode, fnode->name, function_code, r_gen_code.fragment_global, added_fragment);
-					r_gen_code.fragment = function_code["fragment"];
+					r_gen_code.fragment = function_code[fragment_name];
 				}
 
-				if (fnode->name == "light") {
+				if (fnode->name == light_name) {
 
 					_dump_function_deps(pnode, fnode->name, function_code, r_gen_code.fragment_global, added_fragment);
-					r_gen_code.light = function_code["light"];
+					r_gen_code.light = function_code[light_name];
 				}
 			}
 
@@ -573,7 +573,7 @@ String ShaderCompilerGLES3::_dump_node_code(SL::Node *p_node, int p_level, Gener
 				if (current_func_name == vertex_name) {
 					r_gen_code.uses_vertex_time = true;
 				}
-				if (current_func_name == fragment_name) {
+				if (current_func_name == fragment_name || current_func_name == light_name) {
 					r_gen_code.uses_fragment_time = true;
 				}
 			}
@@ -939,6 +939,7 @@ ShaderCompilerGLES3::ShaderCompilerGLES3() {
 
 	vertex_name = "vertex";
 	fragment_name = "fragment";
+	light_name = "light";
 	time_name = "TIME";
 
 	List<String> func_list;

--- a/drivers/gles3/shader_compiler_gles3.h
+++ b/drivers/gles3/shader_compiler_gles3.h
@@ -83,6 +83,7 @@ private:
 	StringName current_func_name;
 	StringName vertex_name;
 	StringName fragment_name;
+	StringName light_name;
 	StringName time_name;
 
 	Set<StringName> used_name_defines;


### PR DESCRIPTION
The GLES3 shader compiler performs certain checks to enable or disable
the usage of certain uniform variables (and with that the set-up of UBOs).

If the `TIME` variable gets used inside the `vertex` function then the
renderer knows that it has to insert that value into the UBO.
The same applies to the `fragment` function.

The `light` function gets executed inside the fragment shader for every
light source that is relevant to the current pixel. If the `TIME` variable
gets used in that function then it needs to be present in the fragment-UBO.
The check for this was missing, so if a shader uses `TIME` inside `light`
but not inside `fragment` then the uniform will not actually be set up.

-----------------

This commit also makes use of the `fragment_name`, `vertex_name` and `light_name` members instead of hardcoded strings.