### PR TITLE
Fix compilation errors with FreeBSD and libwebsocket

### DIFF
--- a/thirdparty/lws/lws_config_private.h
+++ b/thirdparty/lws/lws_config_private.h
@@ -81,7 +81,7 @@
 
 /* Define to 1 if you have the <sys/prctl.h> header file. */
 #define LWS_HAVE_SYS_PRCTL_H
-#if defined(OSX_ENABLED) || defined(IPHONE_ENABLED)
+#if defined(OSX_ENABLED) || defined(IPHONE_ENABLED) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #undef LWS_HAVE_SYS_PRCTL_H
 #endif
 


### PR DESCRIPTION
Add a simple way to detect FreeBSD and skip LWS_HAVE_SYS_PRCTL_H compiling libwebsocket, as it would fail otherwise. Fix #16472.