### PR TITLE
Add SolidShape2D class

### DIFF
--- a/doc/classes/SolidShape2D.xml
+++ b/doc/classes/SolidShape2D.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SolidShape2D" inherits="Node2D" category="Core" version="3.0-stable">
+	<brief_description>
+		A 2D shape.
+	</brief_description>
+	<description>
+		A SolidShape2D is defined by a Shape2D and can be filled with color. Use Node2D's transform to change the size. The shape will be drawn to the screen.
+	</description>
+	<tutorials>
+	</tutorials>
+	<demos>
+	</demos>
+	<methods>
+	</methods>
+	<members>
+		<member name="shape" type="Shape2D" setter="set_shape" getter="get_shape">
+			This is the shape that will be drawn. Default value: [code]None[/code].
+		</member>
+		<member name="color" type="Color" setter="set_color" getter="get_color">
+			The shape's fill color. Default value: [code]White[/code].
+		</member>
+	</members>
+	<constants>
+	</constants>
+</class>

--- a/editor/icons/icon_solid_shape_2d.svg
+++ b/editor/icons/icon_solid_shape_2d.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<g transform="translate(0 -1036.4)">
+<path d="m14 1050.4h-12v-12h12z" fill="#a5b7f3" stroke="#a5b7f3" stroke-linejoin="round" stroke-width="2"/>
+</g>
+</svg>

--- a/scene/2d/solid_shape_2d.cpp
+++ b/scene/2d/solid_shape_2d.cpp
@@ -1,0 +1,103 @@
+/*************************************************************************/
+/*  solid_shape_2d.cpp                                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "solid_shape_2d.h"
+
+void SolidShape2D::_shape_changed() {
+
+	update();
+}
+
+void SolidShape2D::_notification(int p_what) {
+
+	switch (p_what) {
+		case NOTIFICATION_DRAW:
+			if (!shape.is_valid())
+				return;
+			shape->draw(get_canvas_item(), color);
+			break;
+	}
+}
+
+void SolidShape2D::set_shape(const Ref<Shape2D> &p_shape) {
+
+	if (shape.is_valid())
+		shape->disconnect("changed", this, "_shape_changed");
+	shape = p_shape;
+	update();
+	if (shape.is_valid())
+		shape->connect("changed", this, "_shape_changed");
+
+	update_configuration_warning();
+}
+
+String SolidShape2D::get_configuration_warning() const {
+
+	if (!shape.is_valid()) {
+		return TTR("A shape must be provided for SolidShape2D to function. Please create a shape resource for it!");
+	}
+
+	return String();
+}
+
+Ref<Shape2D> SolidShape2D::get_shape() const {
+
+	return shape;
+}
+
+void SolidShape2D::set_color(const Color &p_color) {
+
+	color = p_color;
+	update();
+}
+
+Color SolidShape2D::get_color() const {
+
+	return color;
+}
+
+void SolidShape2D::_bind_methods() {
+
+	ClassDB::bind_method(D_METHOD("set_shape", "shape"), &SolidShape2D::set_shape);
+	ClassDB::bind_method(D_METHOD("get_shape"), &SolidShape2D::get_shape);
+
+	ClassDB::bind_method(D_METHOD("set_color", "color"), &SolidShape2D::set_color);
+	ClassDB::bind_method(D_METHOD("get_color"), &SolidShape2D::get_color);
+
+	ClassDB::bind_method(D_METHOD("_shape_changed"), &SolidShape2D::_shape_changed);
+
+	ADD_PROPERTYNZ(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape2D"), "set_shape", "get_shape");
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "set_color", "get_color");
+}
+
+SolidShape2D::SolidShape2D() {
+
+	color = Color(1, 1, 1);
+}

--- a/scene/2d/solid_shape_2d.h
+++ b/scene/2d/solid_shape_2d.h
@@ -1,0 +1,61 @@
+/*************************************************************************/
+/*  solid_shape_2d.h                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef SOLID_SHAPE_2D_H
+#define SOLID_SHAPE_2D_H
+
+#include "scene/2d/node_2d.h"
+#include "scene/resources/shape_2d.h"
+
+class SolidShape2D : public Node2D {
+
+	GDCLASS(SolidShape2D, Node2D);
+
+	Ref<Shape2D> shape;
+	Color color;
+	void _shape_changed();
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	void set_shape(const Ref<Shape2D> &p_shape);
+	Ref<Shape2D> get_shape() const;
+
+	void set_color(const Color &p_color);
+	Color get_color() const;
+
+	virtual String get_configuration_warning() const;
+
+	SolidShape2D();
+};
+
+#endif // SOLID_SHAPE_2D_H

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -57,6 +57,7 @@
 #include "scene/2d/ray_cast_2d.h"
 #include "scene/2d/remote_transform_2d.h"
 #include "scene/2d/screen_button.h"
+#include "scene/2d/solid_shape_2d.h"
 #include "scene/2d/sprite.h"
 #include "scene/2d/tile_map.h"
 #include "scene/2d/visibility_notifier_2d.h"
@@ -447,6 +448,7 @@ void register_scene_types() {
 	ClassDB::register_class<VisibilityNotifier2D>();
 	ClassDB::register_class<VisibilityEnabler2D>();
 	ClassDB::register_class<Polygon2D>();
+	ClassDB::register_class<SolidShape2D>();
 	ClassDB::register_class<Light2D>();
 	ClassDB::register_class<LightOccluder2D>();
 	ClassDB::register_class<OccluderPolygon2D>();


### PR DESCRIPTION
SolidShape2D
Fixes #6750
![solidshapes](https://user-images.githubusercontent.com/10054226/35952803-c094d120-0c4f-11e8-815b-aeb51c24fce7.png)
Adds a new class SolidShape2D that draws a Shape2D to the screen.
Similar to Polygon2D but it draws a selected shape in a color.
