### PR TITLE
Make status bar label fonts updateable

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -771,6 +771,14 @@ void CodeTextEditor::set_error(const String &p_error) {
 void CodeTextEditor::_update_font() {
 
 	text_editor->add_font_override("font", get_font("source", "EditorFonts"));
+
+	Ref<Font> status_bar_font = get_font("status_source", "EditorFonts");
+	int count = status_bar->get_child_count();
+	for (int i = 0; i < count; i++) {
+		Control *n = Object::cast_to<Control>(status_bar->get_child(i));
+		if (n)
+			n->add_font_override("font", status_bar_font);
+	}
 }
 
 void CodeTextEditor::_on_settings_change() {
@@ -851,7 +859,7 @@ CodeTextEditor::CodeTextEditor() {
 	text_editor->set_brace_matching(true);
 	text_editor->set_auto_indent(true);
 
-	HBoxContainer *status_bar = memnew(HBoxContainer);
+	status_bar = memnew(HBoxContainer);
 	add_child(status_bar);
 	status_bar->set_h_size_flags(SIZE_EXPAND_FILL);
 

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -141,6 +141,7 @@ class CodeTextEditor : public VBoxContainer {
 
 	TextEdit *text_editor;
 	FindReplaceBar *find_replace_bar;
+	HBoxContainer *status_bar;
 
 	Label *line_nb;
 	Label *col_nb;


### PR DESCRIPTION
The labels of bottom status bar(of code editor) cannot be updated(when editor fonts changed via Editor settings), without editor restarts, this commit fix it.

It affects these labels in bottom toolbar
![image](https://user-images.githubusercontent.com/3036176/36364994-738f9916-1558-11e8-9940-137cdc39e339.png)
