### PR TITLE
[WIP] Introduce `OS.set_drag_mode()` - Tell the window manager to move / resize the window.

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -188,6 +188,16 @@ int _OS::get_mouse_button_state() const {
 	return OS::get_singleton()->get_mouse_button_state();
 }
 
+void _OS::set_drag_mode(DragMode p_drag_mode) {
+
+	OS::get_singleton()->set_drag_mode(OS::DragMode(p_drag_mode));
+}
+
+_OS::DragMode _OS::get_drag_mode() const {
+
+	return DragMode(OS::get_singleton()->get_drag_mode());
+}
+
 String _OS::get_unique_id() const {
 	return OS::get_singleton()->get_unique_id();
 }
@@ -1032,6 +1042,8 @@ void _OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_touchscreen_ui_hint"), &_OS::has_touchscreen_ui_hint);
 
 	ClassDB::bind_method(D_METHOD("set_window_title", "title"), &_OS::set_window_title);
+	ClassDB::bind_method(D_METHOD("set_drag_mode", "drag_mode"), &_OS::set_drag_mode);
+	ClassDB::bind_method(D_METHOD("get_drag_mode"), &_OS::get_drag_mode);
 
 	ClassDB::bind_method(D_METHOD("set_low_processor_usage_mode", "enable"), &_OS::set_low_processor_usage_mode);
 	ClassDB::bind_method(D_METHOD("is_in_low_processor_usage_mode"), &_OS::is_in_low_processor_usage_mode);
@@ -1137,6 +1149,7 @@ void _OS::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keep_screen_on"), "set_keep_screen_on", "is_keep_screen_on");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "screen_orientation", PROPERTY_HINT_ENUM, "Landscape,Portrait,Reverse Landscape,Reverse Portrait,Sensor Landscape,Sensor Portrait,Sensor"), "set_screen_orientation", "get_screen_orientation");
 	ADD_GROUP("Window", "window_");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "drag_mode", PROPERTY_HINT_ENUM, "None,Move,Resize Top,Resize Left,Resize Bottom,Resize Right,Resize Top Left,Resize Top Right,Resize Bottom Right,Resize Bottom Left"), "set_drag_mode", "get_drag_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "window_borderless"), "set_borderless_window", "get_borderless_window");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "window_fullscreen"), "set_window_fullscreen", "is_window_fullscreen");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "window_maximized"), "set_window_maximized", "is_window_maximized");
@@ -1165,6 +1178,17 @@ void _OS::_bind_methods() {
 	BIND_ENUM_CONSTANT(MONTH_OCTOBER);
 	BIND_ENUM_CONSTANT(MONTH_NOVEMBER);
 	BIND_ENUM_CONSTANT(MONTH_DECEMBER);
+
+	BIND_ENUM_CONSTANT(DRAG_MODE_NONE);
+	BIND_ENUM_CONSTANT(DRAG_MODE_MOVE);
+	BIND_ENUM_CONSTANT(DRAG_MODE_RESIZE_TOP);
+	BIND_ENUM_CONSTANT(DRAG_MODE_RESIZE_RIGHT);
+	BIND_ENUM_CONSTANT(DRAG_MODE_RESIZE_BOTTOM);
+	BIND_ENUM_CONSTANT(DRAG_MODE_RESIZE_LEFT);
+	BIND_ENUM_CONSTANT(DRAG_MODE_RESIZE_TOPLEFT);
+	BIND_ENUM_CONSTANT(DRAG_MODE_RESIZE_TOPRIGHT);
+	BIND_ENUM_CONSTANT(DRAG_MODE_RESIZE_BOTTOMRIGHT);
+	BIND_ENUM_CONSTANT(DRAG_MODE_RESIZE_BOTTOMLEFT);
 
 	BIND_ENUM_CONSTANT(SCREEN_ORIENTATION_LANDSCAPE);
 	BIND_ENUM_CONSTANT(SCREEN_ORIENTATION_PORTRAIT);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -137,6 +137,23 @@ public:
 	void set_window_title(const String &p_title);
 	int get_mouse_button_state() const;
 
+  enum DragMode {
+
+    DRAG_MODE_NONE,
+    DRAG_MODE_MOVE,
+    DRAG_MODE_RESIZE_TOP,
+    DRAG_MODE_RESIZE_RIGHT,
+    DRAG_MODE_RESIZE_BOTTOM,
+    DRAG_MODE_RESIZE_LEFT,
+    DRAG_MODE_RESIZE_TOPLEFT,
+    DRAG_MODE_RESIZE_TOPRIGHT,
+    DRAG_MODE_RESIZE_BOTTOMRIGHT,
+    DRAG_MODE_RESIZE_BOTTOMLEFT
+  };
+
+  void set_drag_mode(DragMode p_drag_mode);
+  DragMode get_drag_mode() const;
+
 	void set_clipboard(const String &p_text);
 	String get_clipboard() const;
 
@@ -331,6 +348,7 @@ VARIANT_ENUM_CAST(_OS::Weekday);
 VARIANT_ENUM_CAST(_OS::Month);
 VARIANT_ENUM_CAST(_OS::SystemDir);
 VARIANT_ENUM_CAST(_OS::ScreenOrientation);
+VARIANT_ENUM_CAST(_OS::DragMode);
 
 class _Geometry : public Object {
 

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -508,6 +508,9 @@ void OS::native_video_stop(){
 void OS::set_mouse_mode(MouseMode p_mode) {
 }
 
+void OS::set_drag_mode(DragMode p_drag_mode) {
+}
+
 bool OS::can_use_threads() const {
 
 #ifdef NO_THREADS
@@ -521,6 +524,8 @@ OS::MouseMode OS::get_mouse_mode() const {
 
 	return MOUSE_MODE_VISIBLE;
 }
+
+OS::DragMode OS::get_drag_mode() const { return DRAG_MODE_NONE; }
 
 OS::LatinKeyboardVariant OS::get_latin_keyboard_variant() const {
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -161,6 +161,22 @@ public:
 	virtual void set_mouse_mode(MouseMode p_mode);
 	virtual MouseMode get_mouse_mode() const;
 
+	enum DragMode {
+		DRAG_MODE_NONE,
+		DRAG_MODE_MOVE,
+		DRAG_MODE_RESIZE_TOP,
+		DRAG_MODE_RESIZE_RIGHT,
+		DRAG_MODE_RESIZE_BOTTOM,
+		DRAG_MODE_RESIZE_LEFT,
+		DRAG_MODE_RESIZE_TOPLEFT,
+		DRAG_MODE_RESIZE_TOPRIGHT,
+		DRAG_MODE_RESIZE_BOTTOMRIGHT,
+		DRAG_MODE_RESIZE_BOTTOMLEFT
+	};
+
+	virtual void set_drag_mode(DragMode p_drag_mode);
+	virtual DragMode get_drag_mode() const;
+
 	virtual void warp_mouse_position(const Point2 &p_to) {}
 	virtual Point2 get_mouse_position() const = 0;
 	virtual int get_mouse_button_state() const = 0;

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -222,7 +222,7 @@
 			<return type="int" enum="OS.DragMode">
 			</return>
 			<description>
-				Returns the current window manager drag mode. (What action the window manager will take when the left mouse button is pressed and dragged in the window. Only valid on the [code]X11[/code] paltform at the moment. See [code]DRAG_MODE_*[/code] constants.
+				Returns the current window manager drag mode. (What action the window manager will take when the left mouse button is pressed and dragged in the window. Only valid on the [code]X11[/code] and [code]OSX[/code] platforms at the moment. See [code]DRAG_MODE_*[/code] constants.
 			</description>
 		</method>
 		<method name="get_process_id" qualifiers="const">
@@ -572,7 +572,7 @@
 			<argument index="0" name="drag_mode" type="int" enum="OS.DragMode">
 			</argument>
 			<description>
-				Sets the window manager drag mode. (What action the window manager will take when the left mouse button is pressed and dragged in the window.) Useful for implementing custom window dragging and resize handles. Only valid on the [code]X11[/code] paltform at the moment. Valid arguments are the [code]DRAG_MODE_*[/code] constants.
+				Sets the window manager drag mode. (What action the window manager will take when the left mouse button is pressed and dragged in the window.) Useful for implementing custom window dragging and resize handles. Only valid on the [code]X11[/code] and [code]OSX[/code] platforms at the moment. Valid arguments are the [code]DRAG_MODE_*[/code] constants.
 			</description>
 		</method>
 		<method name="set_ime_position">
@@ -671,7 +671,7 @@
 			The size of the window (without counting window manager decorations).
 		</member>
 		<member name="drag_mode" type="int" enum="OS.DragMode" setter="set_drag_mode" getter="get_drag_mode">
-			The window manager drag mode. (What action the window manager will take when the left mouse button is pressed and dragged in the window.) Used for implementing custom window dragging and resize handles. Only valid on the [code]X11[/code] paltform at the moment. Valid arguments are the [code]DRAG_MODE_*[/code] constants.
+			The window manager drag mode. (What action the window manager will take when the left mouse button is pressed and dragged in the window.) Used for implementing custom window dragging and resize handles. Only valid on the [code]X11[/code] and [code]OSX[/code] platforms at the moment. Valid arguments are the [code]DRAG_MODE_*[/code] constants.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -218,6 +218,13 @@
 				Returns the current state of the device regarding battery and power. See [code]POWERSTATE_*[/code] constants.
 			</description>
 		</method>
+		<method name="get_drag_mode">
+			<return type="int" enum="OS.DragMode">
+			</return>
+			<description>
+				Returns the current window manager drag mode. (What action the window manager will take when the left mouse button is pressed and dragged in the window. Only valid on the [code]X11[/code] paltform at the moment. See [code]DRAG_MODE_*[/code] constants.
+			</description>
+		</method>
 		<method name="get_process_id" qualifiers="const">
 			<return type="int">
 			</return>
@@ -559,6 +566,15 @@
 				Sets the game's icon.
 			</description>
 		</method>
+		<method name="set_drag_mode">
+			<return type="void">
+			</return>
+			<argument index="0" name="drag_mode" type="int" enum="OS.DragMode">
+			</argument>
+			<description>
+				Sets the window manager drag mode. (What action the window manager will take when the left mouse button is pressed and dragged in the window.) Useful for implementing custom window dragging and resize handles. Only valid on the [code]X11[/code] paltform at the moment. Valid arguments are the [code]DRAG_MODE_*[/code] constants.
+			</description>
+		</method>
 		<method name="set_ime_position">
 			<return type="void">
 			</return>
@@ -654,6 +670,9 @@
 		<member name="window_size" type="Vector2" setter="set_window_size" getter="get_window_size">
 			The size of the window (without counting window manager decorations).
 		</member>
+		<member name="drag_mode" type="int" enum="OS.DragMode" setter="set_drag_mode" getter="get_drag_mode">
+			The window manager drag mode. (What action the window manager will take when the left mouse button is pressed and dragged in the window.) Used for implementing custom window dragging and resize handles. Only valid on the [code]X11[/code] paltform at the moment. Valid arguments are the [code]DRAG_MODE_*[/code] constants.
+		</member>
 	</members>
 	<constants>
 		<constant name="DAY_SUNDAY" value="0" enum="Weekday">
@@ -733,6 +752,39 @@
 		<constant name="POWERSTATE_CHARGING" value="3" enum="PowerState">
 		</constant>
 		<constant name="POWERSTATE_CHARGED" value="4" enum="PowerState">
+		</constant>
+		<constant name="DRAG_MODE_NONE" value="0" enum="DragMode">
+			Tells the window manager to ignore the click / drag and passes it to your game (default).
+			While any state other than [code]DRAG_MODE_NONE[/code] is active, mouse events will not be passed to your game.
+			[code]DRAG_MODE_NONE[/code] is the only valid mode when the mouse is constrained or grabbed by your window.
+			Once the window manager has completed an action other than [code]DRAG_MODE_NONE[/code] the mode will be automatically reset to [code]DRAG_MODE_NONE[/code].
+		</constant>
+		<constant name="DRAG_MODE_MOVE" value="1" enum="DragMode">
+			Tells the window manger to start moving your window.
+		</constant>
+		<constant name="DRAG_MODE_RESIZE_TOP" value="2" enum="DragMode">
+			Tells the window manger to resize your window from the top.
+		</constant>
+		<constant name="DRAG_MODE_RESIZE_RIGHT" value="3" enum="DragMode">
+			Tells the window manger to resize your window from the right.
+		</constant>
+		<constant name="DRAG_MODE_RESIZE_BOTTOM" value="4" enum="DragMode">
+			Tells the window manger to resize your window from the bottom.
+		</constant>
+		<constant name="DRAG_MODE_RESIZE_LEFT" value="5" enum="DragMode">
+			Tells the window manger to resize your window from the left.
+		</constant>
+		<constant name="DRAG_MODE_RESIZE_TOPLEFT" value="6" enum="DragMode">
+			Tells the window manger to resize your window from the top-left corner.
+		</constant>
+		<constant name="DRAG_MODE_RESIZE_TOPRIGHT" value="7" enum="DragMode">
+			Tells the window manger to resize your window from the top-right corner.
+		</constant>
+		<constant name="DRAG_MODE_RESIZE_BOTTOMRIGHT" value="8" enum="DragMode">
+			Tells the window manger to resize your window from the bottom-right corner.
+		</constant>
+		<constant name="DRAG_MODE_RESIZE_BOTTOMLEFT" value="9" enum="DragMode">
+			Tells the window manger to resize your window from the bottom-left corner.
 		</constant>
 	</constants>
 </class>

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -102,6 +102,7 @@ public:
 	CursorShape cursor_shape;
 	NSCursor *cursors[CURSOR_MAX] = { NULL };
 	MouseMode mouse_mode;
+	DragMode drag_mode;
 
 	String title;
 	bool minimized;
@@ -242,6 +243,10 @@ public:
 
 	void set_mouse_mode(MouseMode p_mode);
 	MouseMode get_mouse_mode() const;
+
+	void set_drag_mode(DragMode p_drag_mode);
+	OS::DragMode get_drag_mode() const;
+	bool process_drag_mode(NSEvent *event);
 
 	void disable_crash_handler();
 	bool is_disable_crash_handler() const;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -510,7 +510,6 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 						mb->set_button_index(2);
 					} break;
 					case WM_LBUTTONDBLCLK: {
-
 						mb->set_pressed(true);
 						mb->set_button_index(1);
 						mb->set_doubleclick(true);
@@ -780,7 +779,25 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 			}
 
 		} break;
+		case WM_NCHITTEST: {
+			// Only handle the hit test if the left mouse button is pressed.
+			bool buttons_swapped = GetSystemMetrics(SM_SWAPBUTTON);
+			if (!GetAsyncKeyState(VK_LBUTTON) && !buttons_swapped || !GetAsyncKeyState(VK_RBUTTON) && buttons_swapped) break;
 
+			switch (drag_mode) {
+				case DRAG_MODE_MOVE: return HTCAPTION;
+				case DRAG_MODE_RESIZE_TOP: return HTTOP;
+				case DRAG_MODE_RESIZE_RIGHT: return HTRIGHT;
+				case DRAG_MODE_RESIZE_BOTTOM: return HTBOTTOM;
+				case DRAG_MODE_RESIZE_LEFT: return HTLEFT;
+				case DRAG_MODE_RESIZE_TOPLEFT: return HTTOPLEFT;
+				case DRAG_MODE_RESIZE_TOPRIGHT: return HTTOPRIGHT;
+				case DRAG_MODE_RESIZE_BOTTOMRIGHT: return HTBOTTOMRIGHT;
+				case DRAG_MODE_RESIZE_BOTTOMLEFT: return HTBOTTOMLEFT;
+				case DRAG_MODE_NONE: return HTCLIENT;
+				default: return HTCLIENT;
+			}
+		} break;
 		default: {
 
 			if (user_proc) {
@@ -1332,6 +1349,16 @@ Point2 OS_Windows::get_mouse_position() const {
 int OS_Windows::get_mouse_button_state() const {
 
 	return last_button_state;
+}
+
+void OS_Windows::set_drag_mode(DragMode p_drag_mode) {
+
+	drag_mode = p_drag_mode;
+}
+
+OS::DragMode OS_Windows::get_drag_mode() const {
+
+	return drag_mode;
 }
 
 void OS_Windows::set_window_title(const String &p_title) {

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -105,6 +105,8 @@ class OS_Windows : public OS {
 	WNDPROC user_proc;
 
 	MouseMode mouse_mode;
+	DragMode drag_mode;
+
 	bool alt_mem;
 	bool gr_mem;
 	bool shift_mem;
@@ -181,6 +183,8 @@ public:
 
 	void set_mouse_mode(MouseMode p_mode);
 	MouseMode get_mouse_mode() const;
+	virtual void set_drag_mode(DragMode p_drag_mode);
+	virtual OS::DragMode get_drag_mode() const;
 
 	virtual void warp_mouse_position(const Point2 &p_to);
 	virtual Point2 get_mouse_position() const;

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -134,6 +134,7 @@ class OS_X11 : public OS_Unix {
 	void get_key_modifier_state(unsigned int p_x11_state, Ref<InputEventWithModifiers> state);
 
 	MouseMode mouse_mode;
+	DragMode drag_mode;
 	Point2i center;
 
 	void handle_key_event(XKeyEvent *p_event, bool p_echo = false);
@@ -211,6 +212,10 @@ public:
 
 	void set_mouse_mode(MouseMode p_mode);
 	MouseMode get_mouse_mode() const;
+
+	virtual void set_drag_mode(DragMode p_drag_mode);
+	virtual OS::DragMode get_drag_mode() const;
+	bool process_drag_mode(XEvent *event);
 
 	virtual void warp_mouse_position(const Point2 &p_to);
 	virtual Point2 get_mouse_position() const;


### PR DESCRIPTION
Borderless windows have a big disadvantage compared to normal windows — they can't be dragged (drug?) or resized without implementing a significant amount of custom logic. And even if you do implement said logic, you'll still lose features such as window snapping. This PR introduces `OS.set_drag_mode(DragMode drag_mode)` and related getters and accessors.

The available drag modes are:

```
DRAG_MODE_NONE, // Current / default behavior.
DRAG_MODE_MOVE, // Tell the window manager to move the window when the mouse is dragged.
DRAG_MODE_RESIZE_TOP, // Tells the window manager to resize the window from the top when the mouse is dragged.
DRAG_MODE_RESIZE_RIGHT, // etc.
DRAG_MODE_RESIZE_BOTTOM,
DRAG_MODE_RESIZE_LEFT,
DRAG_MODE_RESIZE_TOPLEFT,
DRAG_MODE_RESIZE_TOPRIGHT,
DRAG_MODE_RESIZE_BOTTOMRIGHT,
DRAG_MODE_RESIZE_BOTTOMLEFT
```

The drag modes may be set at any time. They will only take effect when the mouse is held down and starts moving in the window.

Example Usage:

To make a panel draggable, add this to the panel's script:
```gdscript
func _on_Panel_mouse_entered():
	OS.set_drag_mode(OS.DRAG_MODE_MOVE);

func _on_Panel_mouse_exited():
	OS.set_drag_mode(OS.DRAG_MODE_NONE);
```
This will treat the panel as a titlebar. Buttons or other interactable controls inside the panel will still be usable as normal without triggering a window move.

Enabling window resize on a background panel is a bit trickier. Say you have a root panel with 5 pixels of internal margin. Here's how you'd make it control window resize:

```gdscript
func _on_Root_Panel_gui_input( ev ):
	if ev is InputEventMouseMotion:
		var horizontal = -1;
		var vertical = -1;
		var mode = OS.DRAG_MODE_NONE;
		var cursor = Control.CURSOR_ARROW;

		if ev.position.x > OS.window_size.x - 5:
			horizontal = OS.DRAG_MODE_RESIZE_RIGHT;
			cursor = Control.CURSOR_HSIZE;
			mode = horizontal;

		if ev.position.x < 5:
			cursor = Control.CURSOR_HSIZE;
			horizontal = OS.DRAG_MODE_RESIZE_LEFT;
			mode = horizontal;

		if ev.position.y < 5:
			cursor = Control.CURSOR_VSIZE;
			vertical = OS.DRAG_MODE_RESIZE_TOP;
			mode = vertical;

		if ev.position.y > OS.window_size.y - 5:
			cursor = Control.CURSOR_VSIZE;
			vertical = OS.DRAG_MODE_RESIZE_BOTTOM;
			mode = vertical;

		if vertical == OS.DRAG_MODE_RESIZE_TOP && horizontal == OS.DRAG_MODE_RESIZE_RIGHT:
			mode = OS.DRAG_MODE_RESIZE_TOPRIGHT;
			cursor = Control.CURSOR_BDIAGSIZE;

		elif vertical == OS.DRAG_MODE_RESIZE_TOP && horizontal == OS.DRAG_MODE_RESIZE_LEFT:
			mode = OS.DRAG_MODE_RESIZE_TOPLEFT;
			cursor = Control.CURSOR_FDIAGSIZE;

		elif vertical == OS.DRAG_MODE_RESIZE_BOTTOM && horizontal == OS.DRAG_MODE_RESIZE_RIGHT:
			mode = OS.DRAG_MODE_RESIZE_BOTTOMRIGHT;
			cursor = Control.CURSOR_FDIAGSIZE;

		elif vertical == OS.DRAG_MODE_RESIZE_BOTTOM && horizontal == OS.DRAG_MODE_RESIZE_LEFT:
			mode = OS.DRAG_MODE_RESIZE_BOTTOMLEFT;
			cursor = Control.CURSOR_BDIAGSIZE;

		if OS.drag_mode != mode:
			self.mouse_default_cursor_shape = cursor;
			OS.set_drag_mode(mode);
```

Together, those scripts are sufficient to allow native window movement and resize support as shown in the GIF below (Pardon the recording quality, the jittering when moving isn't present in actual usage.)

![ezgif com-optimize](https://user-images.githubusercontent.com/5861371/36016154-9fccc106-0dac-11e8-9d05-423e6ce130dd.gif)

## Status:
- [x] X11 Implementation
- [x] macOS Implementation
- [x] Windows Implementation **Doesn't support Aero Snap yet.**
- [ ] Haiku Implementation?
- ~~UWP Implementation?~~ Doesn't appear to be possible.

Android, iPhone, and Web support shouldn't be necessary since they don't have a floating window manager system. (At least for the time being.)

*I know I should really discuss the features for these PRs beforehand on IRC or Discord or something, but unfortunately, my timezone appears to be the opposite of pretty much everyone else, so it's faster for me to just write the code and PR it for discussion.*