### PR TITLE
Fixed members overview not scrolling to correct line

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1328,11 +1328,12 @@ void ScriptEditor::_members_overview_selected(int p_idx) {
 	if (!se) {
 		return;
 	}
-	// Go to the member's line and reset the cursor column. We can't just change scroll_position
-	// directly, since code might be folded.
+	// Go to the member's line and reset the cursor column. We can't change scroll_position
+	// directly until we have gone to the line first, since code might be folded.
 	se->goto_line(members_overview->get_item_metadata(p_idx));
 	Dictionary state = se->get_edit_state();
 	state["column"] = 0;
+	state["scroll_position"] = members_overview->get_item_metadata(p_idx);
 	se->set_edit_state(state);
 }
 


### PR DESCRIPTION
Fixed members overview not scrolling to correct line.

As mentioned in #11648