### PR TITLE
Fix wrong signal emission (2.1)

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -374,7 +374,8 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		breaked = true;
 		dobreak->set_disabled(true);
 		docontinue->set_disabled(false);
-		emit_signal("breaked", true, can_continue);
+		// Variant() needed to call the right overload
+		emit_signal("breaked", Variant(true), Variant(can_continue));
 		OS::get_singleton()->move_window_to_foreground();
 		if (error != "") {
 			tabs->set_current_tab(0);
@@ -399,7 +400,8 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		forward->set_disabled(true);
 		dobreak->set_disabled(false);
 		docontinue->set_disabled(true);
-		emit_signal("breaked", false, false);
+		// Variant() needed to call the right overload
+		emit_signal("breaked", Variant(false), Variant(false));
 		//tabs->set_current_tab(0);
 		profiler->set_enabled(true);
 		profiler->disable_seeking();


### PR DESCRIPTION
Breakpoint hits were complaining about parameter mismatch.