### PR TITLE
gdnative_api.json: Change argument name to r_dest

### DIFF
--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -3964,7 +3964,7 @@
         "name": "godot_variant_new_bool",
         "return_type": "void",
         "arguments": [
-          ["godot_variant *", "p_v"],
+          ["godot_variant *", "r_dest"],
           ["const godot_bool", "p_b"]
         ]
       },

--- a/modules/gdnative/include/gdnative/variant.h
+++ b/modules/gdnative/include/gdnative/variant.h
@@ -135,7 +135,7 @@ void GDAPI godot_variant_new_copy(godot_variant *r_dest, const godot_variant *p_
 
 void GDAPI godot_variant_new_nil(godot_variant *r_dest);
 
-void GDAPI godot_variant_new_bool(godot_variant *p_v, const godot_bool p_b);
+void GDAPI godot_variant_new_bool(godot_variant *r_dest, const godot_bool p_b);
 void GDAPI godot_variant_new_uint(godot_variant *r_dest, const uint64_t p_i);
 void GDAPI godot_variant_new_int(godot_variant *r_dest, const int64_t p_i);
 void GDAPI godot_variant_new_real(godot_variant *r_dest, const double p_r);


### PR DESCRIPTION
This reflects its usage as an output argument, consistent with the other godot_variant_new functions