### PR TITLE
2D Editor GUI input rework

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -50,9 +50,6 @@ class CanvasItemEditorSelectedItem : public Object {
 	GDCLASS(CanvasItemEditorSelectedItem, Object);
 
 public:
-	Variant undo_state;
-	Vector2 undo_pivot;
-
 	Transform2D prev_xform;
 	float prev_rot;
 	Rect2 prev_rect;
@@ -61,6 +58,11 @@ public:
 
 	Transform2D pre_drag_xform;
 	Rect2 pre_drag_rect;
+
+	List<float> pre_drag_bones_length;
+	List<Dictionary> pre_drag_bones_undo_state;
+
+	Dictionary undo_state;
 
 	CanvasItemEditorSelectedItem() { prev_rot = 0; }
 };
@@ -86,6 +88,7 @@ class CanvasItemEditor : public VBoxContainer {
 		SNAP_USE_NODE_PARENT,
 		SNAP_USE_NODE_ANCHORS,
 		SNAP_USE_NODE_SIDES,
+		SNAP_USE_NODE_CENTER,
 		SNAP_USE_OTHER_NODES,
 		SNAP_USE_GRID,
 		SNAP_USE_GUIDES,
@@ -169,6 +172,7 @@ class CanvasItemEditor : public VBoxContainer {
 
 	enum DragType {
 		DRAG_NONE,
+		DRAG_BOX_SELECTION,
 		DRAG_LEFT,
 		DRAG_TOP_LEFT,
 		DRAG_TOP,
@@ -185,28 +189,19 @@ class CanvasItemEditor : public VBoxContainer {
 		DRAG_ALL,
 		DRAG_ROTATE,
 		DRAG_PIVOT,
-		DRAG_NODE_2D,
 		DRAG_V_GUIDE,
 		DRAG_H_GUIDE,
 		DRAG_DOUBLE_GUIDE,
-	};
-
-	enum KeyMoveMODE {
-		MOVE_VIEW_BASE,
-		MOVE_LOCAL_BASE,
-		MOVE_LOCAL_WITH_ROT
+		DRAG_KEY_MOVE
 	};
 
 	EditorSelection *editor_selection;
-	bool additive_selection;
+	bool selection_menu_additive_selection;
 
 	Tool tool;
 	bool first_update;
 	Control *viewport;
-	Control *viewport_base;
 	Control *viewport_scrollable;
-
-	bool can_move_pivot;
 
 	HScrollBar *h_scroll;
 	VScrollBar *v_scroll;
@@ -233,6 +228,7 @@ class CanvasItemEditor : public VBoxContainer {
 	bool snap_node_parent;
 	bool snap_node_anchors;
 	bool snap_node_sides;
+	bool snap_node_center;
 	bool snap_other_nodes;
 	bool snap_grid;
 	bool snap_guides;
@@ -240,13 +236,9 @@ class CanvasItemEditor : public VBoxContainer {
 	bool snap_relative;
 	bool snap_pixel;
 	bool skeleton_show_bones;
-	bool box_selecting;
-	Point2 box_selecting_to;
 	bool key_pos;
 	bool key_rot;
 	bool key_scale;
-
-	void _tool_select(int p_index);
 
 	MenuOption last_option;
 
@@ -267,33 +259,17 @@ class CanvasItemEditor : public VBoxContainer {
 		Transform2D xform;
 		Vector2 from;
 		Vector2 to;
-		ObjectID bone;
 		uint64_t last_pass;
 	};
-
 	uint64_t bone_last_frame;
 	Map<ObjectID, BoneList> bone_list;
 
-	Transform2D bone_orig_xform;
-
-	struct BoneIK {
-
-		Variant orig_state;
-		Vector2 pos;
-		float len;
-		Node2D *node;
-	};
-
-	List<BoneIK> bone_ik_list;
-
 	struct PoseClipboard {
-
 		Vector2 pos;
 		Vector2 scale;
 		float rot;
 		ObjectID id;
 	};
-
 	List<PoseClipboard> pose_clipboard;
 
 	ToolButton *select_button;
@@ -333,16 +309,17 @@ class CanvasItemEditor : public VBoxContainer {
 	Control *top_ruler;
 	Control *left_ruler;
 
-	//PopupMenu *popup;
-	DragType drag;
+	DragType drag_type;
 	Point2 drag_from;
-	Point2 drag_point_from;
-	bool updating_value_dialog;
-	Point2 display_rotate_from;
-	Point2 display_rotate_to;
+	Point2 drag_to;
+	Point2 drag_rotation_center;
+	List<CanvasItem *> drag_selection;
+	int dragged_guide_index;
+	Point2 dragged_guide_pos;
 
-	int edited_guide_index;
-	Point2 edited_guide_pos;
+	bool updating_value_dialog;
+
+	Point2 box_selecting_to;
 
 	Ref<StyleBoxTexture> select_sb;
 	Ref<Texture> select_handle;
@@ -353,28 +330,19 @@ class CanvasItemEditor : public VBoxContainer {
 	Ref<ShortCut> multiply_grid_step_shortcut;
 	Ref<ShortCut> divide_grid_step_shortcut;
 
-	int handle_len;
-	bool _is_part_of_subscene(CanvasItem *p_item);
-	void _find_canvas_items_at_pos(const Point2 &p_pos, Node *p_node, const Transform2D &p_parent_xform, const Transform2D &p_canvas_xform, Vector<_SelectResult> &r_items, int limit = 0);
-	void _find_canvas_items_at_rect(const Rect2 &p_rect, Node *p_node, const Transform2D &p_parent_xform, const Transform2D &p_canvas_xform, List<CanvasItem *> *r_items);
-
-	void _select_click_on_empty_area(Point2 p_click_pos, bool p_append, bool p_box_selection);
-	bool _select_click_on_item(CanvasItem *item, Point2 p_click_pos, bool p_append, bool p_drag);
+	void _find_canvas_items_at_pos(const Point2 &p_pos, Node *p_node, Vector<_SelectResult> &r_items, int limit = 0, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D());
+	void _find_canvas_items_at_rect(const Rect2 &p_rect, Node *p_node, List<CanvasItem *> *r_items, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D());
+	bool _select_click_on_item(CanvasItem *item, Point2 p_click_pos, bool p_append);
 
 	ConfirmationDialog *snap_dialog;
 
 	CanvasItem *ref_item;
 
-	void _edit_set_pivot(const Vector2 &mouse_pos);
 	void _add_canvas_item(CanvasItem *p_canvas_item);
-	void _remove_canvas_item(CanvasItem *p_canvas_item);
-	void _clear_canvas_items();
-	void _key_move(const Vector2 &p_dir, bool p_snap, KeyMoveMODE p_move_mode);
-	void _list_select(const Ref<InputEventMouseButton> &b);
 
-	DragType _get_resize_handle_drag_type(const Point2 &p_click, Vector2 &r_point);
-	void _prepare_drag(const Point2 &p_click_pos);
-	DragType _get_anchor_handle_drag_type(const Point2 &p_click, Vector2 &r_point);
+	void _save_canvas_item_state(List<CanvasItem *> p_canvas_items, bool save_bones = false);
+	void _restore_canvas_item_state(List<CanvasItem *> p_canvas_items, bool restore_bones = false);
+	void _commit_canvas_item_state(List<CanvasItem *> p_canvas_items, String action_name, bool commit_bones = false);
 
 	Vector2 _anchor_to_position(const Control *p_control, Vector2 anchor);
 	Vector2 _position_to_anchor(const Control *p_control, Vector2 position);
@@ -383,27 +351,21 @@ class CanvasItemEditor : public VBoxContainer {
 	bool updating_scroll;
 	void _update_scroll(float);
 	void _update_scrollbars();
-	void _update_cursor();
-	void incbeg(float &beg, float &end, float inc, float minsize, bool p_symmetric);
-	void incend(float &beg, float &end, float inc, float minsize, bool p_symmetric);
-
 	void _append_canvas_item(CanvasItem *p_item);
 	void _snap_changed();
 	void _selection_result_pressed(int);
 	void _selection_menu_hide();
 
 	UndoRedo *undo_redo;
-
-	Point2 _find_topleftmost_point();
-
 	void _build_bones_list(Node *p_node);
 
-	void _get_encompassing_rect(Node *p_node, Rect2 &r_rect, const Transform2D &p_xform);
+	List<CanvasItem *> _get_edited_canvas_items(bool retreive_locked = false, bool remove_canvas_item_if_parent_in_selection = true);
+	Rect2 _get_encompassing_rect_from_list(List<CanvasItem *> p_list);
+	void _expand_encompassing_rect_using_children(Rect2 &p_rect, Node *p_node, bool &r_first, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D());
+	Rect2 _get_scene_encompassing_rect();
 
 	Object *_get_editor_data(Object *p_what);
 
-	CanvasItem *_get_single_item();
-	int get_item_count();
 	void _keying_changed();
 
 	void _unhandled_key_input(const Ref<InputEvent> &p_ev);
@@ -411,6 +373,7 @@ class CanvasItemEditor : public VBoxContainer {
 	void _draw_text_at_position(Point2 p_position, String p_string, Margin p_side);
 	void _draw_margin_at_position(int p_value, Point2 p_position, Margin p_side);
 	void _draw_percentage_at_position(float p_value, Point2 p_position, Margin p_side);
+	void _draw_straight_line(Point2 p_from, Point2 p_to, Color p_color);
 
 	void _draw_rulers();
 	void _draw_guides();
@@ -422,12 +385,22 @@ class CanvasItemEditor : public VBoxContainer {
 	void _draw_locks_and_groups(Node *p_node, const Transform2D &p_xform);
 
 	void _draw_viewport();
-	void _draw_viewport_base();
+
+	bool _gui_input_anchors(const Ref<InputEvent> &p_event);
+	bool _gui_input_move(const Ref<InputEvent> &p_event);
+	bool _gui_input_open_scene_on_double_click(const Ref<InputEvent> &p_event);
+	bool _gui_input_pivot(const Ref<InputEvent> &p_event);
+	bool _gui_input_resize(const Ref<InputEvent> &p_event);
+	bool _gui_input_rotate(const Ref<InputEvent> &p_event);
+	bool _gui_input_select(const Ref<InputEvent> &p_event);
+	bool _gui_input_zoom_or_pan(const Ref<InputEvent> &p_event);
+	bool _gui_input_rulers_and_guides(const Ref<InputEvent> &p_event);
 
 	void _gui_input_viewport(const Ref<InputEvent> &p_event);
-	void _gui_input_viewport_base(const Ref<InputEvent> &p_event);
 
 	void _focus_selection(int p_op);
+
+	void _solve_IK(Node2D *leaf_node, Point2 target_position);
 
 	void _snap_if_closer_float(float p_value, float p_target_snap, float &r_current_snap, bool &r_snapped, float p_radius = 10.0);
 	void _snap_if_closer_point(Point2 p_value, Point2 p_target_snap, Point2 &r_current_snap, bool (&r_snapped)[2], real_t rotation = 0.0, float p_radius = 10.0);
@@ -437,12 +410,13 @@ class CanvasItemEditor : public VBoxContainer {
 	void _set_margins_preset(Control::LayoutPreset p_preset);
 	void _set_anchors_and_margins_preset(Control::LayoutPreset p_preset);
 
+	HBoxContainer *zoom_hb;
 	void _zoom_on_position(float p_zoom, Point2 p_position = Point2());
-	void _zoom_minus();
-	void _zoom_reset();
-	void _zoom_plus();
-
-	void _toggle_snap(bool p_status);
+	void _button_zoom_minus();
+	void _button_zoom_reset();
+	void _button_zoom_plus();
+	void _button_toggle_snap(bool p_status);
+	void _button_tool_select(int p_index);
 
 	HSplitContainer *palette_split;
 	VSplitContainer *bottom_split;
@@ -494,9 +468,10 @@ public:
 		SNAP_NODE_PARENT = 1 << 3,
 		SNAP_NODE_ANCHORS = 1 << 4,
 		SNAP_NODE_SIDES = 1 << 5,
-		SNAP_OTHER_NODES = 1 << 6,
+		SNAP_NODE_CENTER = 1 << 6,
+		SNAP_OTHER_NODES = 1 << 7,
 
-		SNAP_DEFAULT = 0x07,
+		SNAP_DEFAULT = SNAP_GRID | SNAP_GUIDES | SNAP_PIXEL,
 	};
 
 	Point2 snap_point(Point2 p_target, unsigned int p_modes = SNAP_DEFAULT, const CanvasItem *p_canvas_item = NULL, unsigned int p_forced_modes = 0);

--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -34,7 +34,51 @@
 
 #define NORMAL_SUFFIX "_normal"
 
-////////////////////////////
+Dictionary AnimatedSprite::_edit_get_state() const {
+	Dictionary state = Node2D::_edit_get_state();
+	state["offset"] = offset;
+	return state;
+}
+
+void AnimatedSprite::_edit_set_state(const Dictionary &p_state) {
+	Node2D::_edit_set_state(p_state);
+	set_offset(p_state["offset"]);
+}
+
+void AnimatedSprite::_edit_set_pivot(const Point2 &p_pivot) {
+	set_offset(get_offset() - p_pivot);
+	set_position(get_transform().xform(p_pivot));
+}
+
+Point2 AnimatedSprite::_edit_get_pivot() const {
+	return Vector2();
+}
+
+bool AnimatedSprite::_edit_use_pivot() const {
+	return true;
+}
+
+Rect2 AnimatedSprite::_edit_get_rect() const {
+	if (!frames.is_valid() || !frames->has_animation(animation) || frame < 0 || frame >= frames->get_frame_count(animation)) {
+		return Node2D::_edit_get_rect();
+	}
+
+	Ref<Texture> t;
+	if (animation)
+		t = frames->get_frame(animation, frame);
+	if (t.is_null())
+		return Node2D::_edit_get_rect();
+	Size2 s = t->get_size();
+
+	Point2 ofs = offset;
+	if (centered)
+		ofs -= s / 2;
+
+	if (s == Size2(0, 0))
+		s = Size2(1, 1);
+
+	return Rect2(ofs, s);
+}
 
 void SpriteFrames::add_frame(const StringName &p_anim, const Ref<Texture> &p_frame, int p_at_pos) {
 
@@ -246,20 +290,6 @@ void SpriteFrames::_bind_methods() {
 SpriteFrames::SpriteFrames() {
 
 	add_animation(SceneStringNames::get_singleton()->_default);
-}
-
-void AnimatedSprite::_edit_set_pivot(const Point2 &p_pivot) {
-
-	set_offset(p_pivot);
-}
-
-Point2 AnimatedSprite::_edit_get_pivot() const {
-
-	return get_offset();
-}
-bool AnimatedSprite::_edit_use_pivot() const {
-
-	return true;
 }
 
 void AnimatedSprite::_validate_property(PropertyInfo &property) const {
@@ -489,29 +519,6 @@ void AnimatedSprite::set_flip_v(bool p_flip) {
 bool AnimatedSprite::is_flipped_v() const {
 
 	return vflip;
-}
-
-Rect2 AnimatedSprite::_edit_get_rect() const {
-
-	if (!frames.is_valid() || !frames->has_animation(animation) || frame < 0 || frame >= frames->get_frame_count(animation)) {
-		return Node2D::_edit_get_rect();
-	}
-
-	Ref<Texture> t;
-	if (animation)
-		t = frames->get_frame(animation, frame);
-	if (t.is_null())
-		return Node2D::_edit_get_rect();
-	Size2i s = t->get_size();
-
-	Point2 ofs = offset;
-	if (centered)
-		ofs -= s / 2;
-
-	if (s == Size2(0, 0))
-		s = Size2(1, 1);
-
-	return Rect2(ofs, s);
 }
 
 void AnimatedSprite::_res_changed() {

--- a/scene/2d/animated_sprite.h
+++ b/scene/2d/animated_sprite.h
@@ -150,9 +150,13 @@ protected:
 	virtual void _validate_property(PropertyInfo &property) const;
 
 public:
+	virtual Dictionary _edit_get_state() const;
+	virtual void _edit_set_state(const Dictionary &p_state);
+
 	virtual void _edit_set_pivot(const Point2 &p_pivot);
 	virtual Point2 _edit_get_pivot() const;
 	virtual bool _edit_use_pivot() const;
+	virtual Rect2 _edit_get_rect() const;
 
 	void set_sprite_frames(const Ref<SpriteFrames> &p_frames);
 	Ref<SpriteFrames> get_sprite_frames() const;
@@ -181,8 +185,6 @@ public:
 
 	void set_modulate(const Color &p_color);
 	Color get_modulate() const;
-
-	virtual Rect2 _edit_get_rect() const;
 
 	virtual String get_configuration_warning() const;
 	AnimatedSprite();

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -230,7 +230,7 @@ public:
 	// Used to resize/move/select the node
 	virtual void _edit_set_rect(const Rect2 &p_rect){};
 	virtual Rect2 _edit_get_rect() const { return Rect2(-32, -32, 64, 64); };
-	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const { return true; }
+	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const { return _edit_get_rect().has_point(p_point); }
 	Rect2 _edit_get_item_and_children_rect() const;
 	virtual bool _edit_use_rect() const { return false; };
 

--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -33,35 +33,36 @@
 #include "engine.h"
 #include "servers/visual_server.h"
 
-void Light2D::_edit_set_pivot(const Point2 &p_pivot) {
+Dictionary Light2D::_edit_get_state() const {
+	Dictionary state = Node2D::_edit_get_state();
+	state["offset"] = get_texture_offset();
+	return state;
+}
 
-	set_texture_offset(p_pivot);
+void Light2D::_edit_set_state(const Dictionary &p_state) {
+	Node2D::_edit_set_state(p_state);
+	set_texture_offset(p_state["offset"]);
+}
+
+void Light2D::_edit_set_pivot(const Point2 &p_pivot) {
+	set_position(get_transform().xform(p_pivot));
+	set_texture_offset(get_texture_offset() - p_pivot);
 }
 
 Point2 Light2D::_edit_get_pivot() const {
-
-	return get_texture_offset();
+	return Vector2();
 }
-bool Light2D::_edit_use_pivot() const {
 
+bool Light2D::_edit_use_pivot() const {
 	return true;
 }
 
 Rect2 Light2D::_edit_get_rect() const {
-
 	if (texture.is_null())
-		return Rect2(0, 0, 1, 1);
+		return Node2D::_edit_get_rect();
 
-	Size2i s;
-
-	s = texture->get_size() * _scale;
-	Point2i ofs = texture_offset;
-	ofs -= s / 2;
-
-	if (s == Size2(0, 0))
-		s = Size2(1, 1);
-
-	return Rect2(ofs, s);
+	Size2 s = texture->get_size() * _scale;
+	return Rect2(texture_offset - s / 2.0, s);
 }
 
 void Light2D::_update_light_visibility() {
@@ -131,6 +132,7 @@ void Light2D::set_texture_offset(const Vector2 &p_offset) {
 	texture_offset = p_offset;
 	VS::get_singleton()->canvas_light_set_texture_offset(canvas_light, texture_offset);
 	item_rect_changed();
+	_change_notify("offset");
 }
 
 Vector2 Light2D::get_texture_offset() const {

--- a/scene/2d/light_2d.h
+++ b/scene/2d/light_2d.h
@@ -85,6 +85,9 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual Dictionary _edit_get_state() const;
+	virtual void _edit_set_state(const Dictionary &p_state);
+
 	virtual void _edit_set_pivot(const Point2 &p_pivot);
 	virtual Point2 _edit_get_pivot() const;
 	virtual bool _edit_use_pivot() const;

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -46,10 +46,9 @@ Dictionary Node2D::_edit_get_state() const {
 }
 void Node2D::_edit_set_state(const Dictionary &p_state) {
 
-	Dictionary state = p_state;
-	pos = state["position"];
-	angle = state["rotation"];
-	_scale = state["scale"];
+	pos = p_state["position"];
+	angle = p_state["rotation"];
+	_scale = p_state["scale"];
 
 	_update_transform();
 	_change_notify("rotation");
@@ -60,6 +59,8 @@ void Node2D::_edit_set_state(const Dictionary &p_state) {
 
 void Node2D::_edit_set_position(const Point2 &p_position) {
 	pos = p_position;
+	_update_transform();
+	_change_notify("position");
 }
 
 Point2 Node2D::_edit_get_position() const {

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -31,8 +31,31 @@
 #include "polygon_2d.h"
 #include "core/math/geometry.h"
 
-Rect2 Polygon2D::_edit_get_rect() const {
+Dictionary Polygon2D::_edit_get_state() const {
+	Dictionary state = Node2D::_edit_get_state();
+	state["offset"] = offset;
+	return state;
+}
 
+void Polygon2D::_edit_set_state(const Dictionary &p_state) {
+	Node2D::_edit_set_state(p_state);
+	set_offset(p_state["offset"]);
+}
+
+void Polygon2D::_edit_set_pivot(const Point2 &p_pivot) {
+	set_position(get_transform().xform(p_pivot));
+	set_offset(get_offset() - p_pivot);
+}
+
+Point2 Polygon2D::_edit_get_pivot() const {
+	return Vector2();
+}
+
+bool Polygon2D::_edit_use_pivot() const {
+	return true;
+}
+
+Rect2 Polygon2D::_edit_get_rect() const {
 	if (rect_cache_dirty) {
 		int l = polygon.size();
 		PoolVector<Vector2>::Read r = polygon.read();
@@ -52,21 +75,7 @@ Rect2 Polygon2D::_edit_get_rect() const {
 
 bool Polygon2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
 
-	return Geometry::is_point_in_polygon(p_point, Variant(polygon));
-}
-
-void Polygon2D::_edit_set_pivot(const Point2 &p_pivot) {
-
-	set_offset(p_pivot);
-}
-
-Point2 Polygon2D::_edit_get_pivot() const {
-
-	return get_offset();
-}
-bool Polygon2D::_edit_use_pivot() const {
-
-	return true;
+	return Geometry::is_point_in_polygon(p_point - get_offset(), Variant(polygon));
 }
 
 void Polygon2D::_notification(int p_what) {
@@ -324,6 +333,7 @@ void Polygon2D::set_offset(const Vector2 &p_offset) {
 	offset = p_offset;
 	rect_cache_dirty = true;
 	update();
+	_change_notify("offset");
 }
 
 Vector2 Polygon2D::get_offset() const {

--- a/scene/2d/polygon_2d.h
+++ b/scene/2d/polygon_2d.h
@@ -59,6 +59,16 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual Dictionary _edit_get_state() const;
+	virtual void _edit_set_state(const Dictionary &p_state);
+
+	virtual void _edit_set_pivot(const Point2 &p_pivot);
+	virtual Point2 _edit_get_pivot() const;
+	virtual bool _edit_use_pivot() const;
+	virtual Rect2 _edit_get_rect() const;
+
+	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
+
 	void set_polygon(const PoolVector<Vector2> &p_polygon);
 	PoolVector<Vector2> get_polygon() const;
 
@@ -97,15 +107,6 @@ public:
 
 	void set_offset(const Vector2 &p_offset);
 	Vector2 get_offset() const;
-
-	//editor stuff
-
-	virtual void _edit_set_pivot(const Point2 &p_pivot);
-	virtual Point2 _edit_get_pivot() const;
-	virtual bool _edit_use_pivot() const;
-
-	virtual Rect2 _edit_get_rect() const;
-	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
 
 	Polygon2D();
 };

--- a/scene/2d/sprite.cpp
+++ b/scene/2d/sprite.cpp
@@ -34,17 +34,27 @@
 #include "scene/main/viewport.h"
 #include "scene/scene_string_names.h"
 
-void Sprite::_edit_set_pivot(const Point2 &p_pivot) {
+Dictionary Sprite::_edit_get_state() const {
+	Dictionary state = Node2D::_edit_get_state();
+	state["offset"] = offset;
+	return state;
+}
 
-	set_offset(p_pivot);
+void Sprite::_edit_set_state(const Dictionary &p_state) {
+	Node2D::_edit_set_state(p_state);
+	set_offset(p_state["offset"]);
+}
+
+void Sprite::_edit_set_pivot(const Point2 &p_pivot) {
+	set_offset(get_offset() - p_pivot);
+	set_position(get_transform().xform(p_pivot));
 }
 
 Point2 Sprite::_edit_get_pivot() const {
-
-	return get_offset();
+	return Vector2();
 }
-bool Sprite::_edit_use_pivot() const {
 
+bool Sprite::_edit_use_pivot() const {
 	return true;
 }
 

--- a/scene/2d/sprite.h
+++ b/scene/2d/sprite.h
@@ -65,6 +65,9 @@ protected:
 	virtual void _validate_property(PropertyInfo &property) const;
 
 public:
+	virtual Dictionary _edit_get_state() const;
+	virtual void _edit_set_state(const Dictionary &p_state);
+
 	virtual void _edit_set_pivot(const Point2 &p_pivot);
 	virtual Point2 _edit_get_pivot() const;
 	virtual bool _edit_use_pivot() const;

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -307,6 +307,8 @@ void BaseButton::toggled(bool p_pressed) {
 }
 
 void BaseButton::set_disabled(bool p_disabled) {
+	if (status.disabled == p_disabled)
+		return;
 
 	status.disabled = p_disabled;
 	update();

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -49,31 +49,41 @@
 Dictionary Control::_edit_get_state() const {
 
 	Dictionary s;
-	s["rect"] = get_rect();
 	s["rotation"] = get_rotation();
 	s["scale"] = get_scale();
+	s["pivot"] = get_pivot_offset();
 	Array anchors;
 	anchors.push_back(get_anchor(MARGIN_LEFT));
 	anchors.push_back(get_anchor(MARGIN_TOP));
 	anchors.push_back(get_anchor(MARGIN_RIGHT));
 	anchors.push_back(get_anchor(MARGIN_BOTTOM));
 	s["anchors"] = anchors;
+	Array margins;
+	margins.push_back(get_margin(MARGIN_LEFT));
+	margins.push_back(get_margin(MARGIN_TOP));
+	margins.push_back(get_margin(MARGIN_RIGHT));
+	margins.push_back(get_margin(MARGIN_BOTTOM));
+	s["margins"] = margins;
 	return s;
 }
 void Control::_edit_set_state(const Dictionary &p_state) {
 
 	Dictionary state = p_state;
 
-	Rect2 rect = state["rect"];
-	set_position(rect.position);
-	set_size(rect.size);
 	set_rotation(state["rotation"]);
 	set_scale(state["scale"]);
+	set_pivot_offset(state["pivot"]);
 	Array anchors = state["anchors"];
-	set_anchor(MARGIN_LEFT, anchors[0]);
-	set_anchor(MARGIN_TOP, anchors[1]);
-	set_anchor(MARGIN_RIGHT, anchors[2]);
-	set_anchor(MARGIN_BOTTOM, anchors[3]);
+	data.anchor[MARGIN_LEFT] = anchors[0];
+	data.anchor[MARGIN_TOP] = anchors[1];
+	data.anchor[MARGIN_RIGHT] = anchors[2];
+	data.anchor[MARGIN_BOTTOM] = anchors[3];
+	Array margins = state["margins"];
+	data.margin[MARGIN_LEFT] = margins[0];
+	data.margin[MARGIN_TOP] = margins[1];
+	data.margin[MARGIN_RIGHT] = margins[2];
+	data.margin[MARGIN_BOTTOM] = margins[3];
+	_size_changed();
 }
 
 void Control::_edit_set_position(const Point2 &p_position) {
@@ -85,19 +95,8 @@ Point2 Control::_edit_get_position() const {
 };
 
 void Control::_edit_set_rect(const Rect2 &p_edit_rect) {
-
-	Transform2D xform = _get_internal_transform();
-
-	Vector2 new_pos = xform.basis_xform(p_edit_rect.position);
-
-	Vector2 pos = get_position() + new_pos;
-
-	Rect2 new_rect = get_rect();
-	new_rect.position = pos.snapped(Vector2(1, 1));
-	new_rect.size = p_edit_rect.size.snapped(Vector2(1, 1));
-
-	set_position(new_rect.position);
-	set_size(new_rect.size);
+	set_position((get_position() + get_transform().basis_xform(p_edit_rect.position)).snapped(Vector2(1, 1)));
+	set_size(p_edit_rect.size.snapped(Vector2(1, 1)));
 }
 
 Rect2 Control::_edit_get_rect() const {
@@ -121,6 +120,9 @@ bool Control::_edit_use_rotation() const {
 }
 
 void Control::_edit_set_pivot(const Point2 &p_pivot) {
+	Vector2 delta_pivot = p_pivot - get_pivot_offset();
+	Vector2 move = Vector2((cos(data.rotation) - 1.0) * delta_pivot.x - sin(data.rotation) * delta_pivot.y, sin(data.rotation) * delta_pivot.x + (cos(data.rotation) - 1.0) * delta_pivot.y);
+	set_position(get_position() + move);
 	set_pivot_offset(p_pivot);
 }
 
@@ -1297,7 +1299,8 @@ void Control::_size_changed() {
 		new_size_cache.height = MAX(minimum_size.height, new_size_cache.height);
 	}
 
-	if (get_viewport()->is_snap_controls_to_pixels_enabled()) {
+	// We use a little workaround to avoid flickering when moving the pivot with _edit_set_pivot()
+	if (Math::abs(Math::sin(data.rotation * 4.0f)) < 0.00001f && get_viewport()->is_snap_controls_to_pixels_enabled()) {
 		new_size_cache = new_size_cache.floor();
 		new_pos_cache = new_pos_cache.floor();
 	}
@@ -1378,7 +1381,6 @@ void Control::set_anchor(Margin p_margin, float p_anchor, bool p_keep_margin, bo
 			data.margin[(p_margin + 2) % 4] = _s2a(previous_opposite_margin_pos, data.anchor[(p_margin + 2) % 4], parent_range);
 		}
 	}
-
 	if (is_inside_tree()) {
 		_size_changed();
 	}


### PR DESCRIPTION
A huge (sorry) rework of the 2D editor. It should now be a lot easier to maintain in the future.
What changes:
- The input handling is now split into several function, allowing an easier debugging and displays more information in the console (instead of "Edited CanvasItem"):
![2018-02-11-193317_209x85_scrot](https://user-images.githubusercontent.com/6093119/36076859-73a5af0e-0f62-11e8-9636-0d4d1041a3fe.png)
- Probably fixes #12505
- The way we deal with bone is a little bit different, as by default moving a node which is a bone now follows the IK. The node can be normally moved if the alt key is pressed:
![output](https://user-images.githubusercontent.com/6093119/36076940-9a1b23ac-0f63-11e8-920a-6d81ce58c952.gif)



- Probably fixes other bugs (and introduce new ones ^^)
