### PR TITLE
Local debugging fix & extensions

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -320,6 +320,7 @@ public:
 
 	virtual void disable_crash_handler() {}
 	virtual bool is_disable_crash_handler() const { return false; }
+	virtual void initialize_debugging() {}
 
 	enum CursorShape {
 		CURSOR_ARROW,

--- a/core/script_debugger_local.cpp
+++ b/core/script_debugger_local.cpp
@@ -29,12 +29,23 @@
 /*************************************************************************/
 
 #include "script_debugger_local.h"
+#include "scene/main/scene_tree.h"
 
 #include "os/os.h"
 
 void ScriptDebuggerLocal::debug(ScriptLanguage *p_script, bool p_can_continue) {
 
-	print_line("Debugger Break, Reason: '" + p_script->debug_get_error() + "'");
+	if (!target_function.empty()) {
+		String current_function = p_script->debug_get_stack_level_function(0);
+		if (current_function != target_function) {
+			set_depth(0);
+			set_lines_left(1);
+			return;
+		}
+		target_function = "";
+	}
+
+	print_line("\nDebugger Break, Reason: '" + p_script->debug_get_error() + "'");
 	print_line("*Frame " + itos(0) + " - " + p_script->debug_get_stack_level_source(0) + ":" + itos(p_script->debug_get_stack_level_line(0)) + " in function '" + p_script->debug_get_stack_level_function(0) + "'");
 	print_line("Enter \"help\" for assistance.");
 	int current_frame = 0;
@@ -44,8 +55,11 @@ void ScriptDebuggerLocal::debug(ScriptLanguage *p_script, bool p_can_continue) {
 		OS::get_singleton()->print("debug> ");
 		String line = OS::get_singleton()->get_stdin_string().strip_edges();
 
+		// Cache options
+		String variable_prefix = options["variable_prefix"];
+
 		if (line == "") {
-			print_line("Debugger Break, Reason: '" + p_script->debug_get_error() + "'");
+			print_line("\nDebugger Break, Reason: '" + p_script->debug_get_error() + "'");
 			print_line("*Frame " + itos(current_frame) + " - " + p_script->debug_get_stack_level_source(current_frame) + ":" + itos(p_script->debug_get_stack_level_line(current_frame)) + " in function '" + p_script->debug_get_stack_level_function(current_frame) + "'");
 			print_line("Enter \"help\" for assistance.");
 		} else if (line == "c" || line == "continue")
@@ -72,38 +86,56 @@ void ScriptDebuggerLocal::debug(ScriptLanguage *p_script, bool p_can_continue) {
 				}
 			}
 
+		} else if (line.begins_with("set")) {
+
+			if (line.get_slice_count(" ") == 1) {
+
+				for (Map<String, String>::Element *E = options.front(); E; E = E->next()) {
+					print_line("\t" + E->key() + "=" + E->value());
+				}
+
+			} else {
+				String key_value = line.get_slicec(' ', 1);
+				int value_pos = key_value.find("=");
+
+				if (value_pos < 0) {
+					print_line("Error: Invalid set format. Use: set key=value");
+				} else {
+
+					String key = key_value.left(value_pos);
+
+					if (!options.has(key)) {
+						print_line("Error: Unknown option " + key);
+					} else {
+
+						// Allow explicit tab character
+						String value = key_value.right(value_pos + 1).replace("\\t", "\t");
+
+						options[key] = value;
+					}
+				}
+			}
+
 		} else if (line == "lv" || line == "locals") {
 
 			List<String> locals;
 			List<Variant> values;
 			p_script->debug_get_stack_level_locals(current_frame, &locals, &values);
-			List<Variant>::Element *V = values.front();
-			for (List<String>::Element *E = locals.front(); E; E = E->next()) {
-				print_line(E->get() + ": " + String(V->get()));
-				V = V->next();
-			}
+			print_variables(locals, values, variable_prefix);
 
 		} else if (line == "gv" || line == "globals") {
 
-			List<String> locals;
+			List<String> globals;
 			List<Variant> values;
-			p_script->debug_get_globals(&locals, &values);
-			List<Variant>::Element *V = values.front();
-			for (List<String>::Element *E = locals.front(); E; E = E->next()) {
-				print_line(E->get() + ": " + String(V->get()));
-				V = V->next();
-			}
+			p_script->debug_get_globals(&globals, &values);
+			print_variables(globals, values, variable_prefix);
 
 		} else if (line == "mv" || line == "members") {
 
-			List<String> locals;
+			List<String> members;
 			List<Variant> values;
-			p_script->debug_get_stack_level_members(current_frame, &locals, &values);
-			List<Variant>::Element *V = values.front();
-			for (List<String>::Element *E = locals.front(); E; E = E->next()) {
-				print_line(E->get() + ": " + String(V->get()));
-				V = V->next();
-			}
+			p_script->debug_get_stack_level_members(current_frame, &members, &values);
+			print_variables(members, values, variable_prefix);
 
 		} else if (line.begins_with("p") || line.begins_with("print")) {
 
@@ -121,63 +153,147 @@ void ScriptDebuggerLocal::debug(ScriptLanguage *p_script, bool p_can_continue) {
 			set_depth(-1);
 			set_lines_left(1);
 			break;
-		} else if (line.begins_with("n") || line.begins_with("next")) {
+		} else if (line == "n" || line == "next") {
 
 			set_depth(0);
 			set_lines_left(1);
 			break;
+		} else if (line == "fin" || line == "finish") {
+
+			String current_function = p_script->debug_get_stack_level_function(0);
+
+			for (int i = 0; i < total_frames; i++) {
+				target_function = p_script->debug_get_stack_level_function(i);
+				if (target_function != current_function) {
+					set_depth(0);
+					set_lines_left(1);
+					return;
+				}
+			}
+
+			print_line("Error: Reached last frame.");
+			target_function = "";
+
 		} else if (line.begins_with("br") || line.begins_with("break")) {
 
 			if (line.get_slice_count(" ") <= 1) {
-				//show breakpoints
+
+				const Map<int, Set<StringName> > &breakpoints = get_breakpoints();
+				if (breakpoints.size() == 0) {
+					print_line("No Breakpoints.");
+					continue;
+				}
+
+				print_line("Breakpoint(s): " + itos(breakpoints.size()));
+				for (Map<int, Set<StringName> >::Element *E = breakpoints.front(); E; E = E->next()) {
+					print_line("\t" + String(E->value().front()->get()) + ":" + itos(E->key()));
+				}
+
 			} else {
 
-				String bppos = line.get_slicec(' ', 1);
-				String source = bppos.get_slicec(':', 0).strip_edges();
-				int line = bppos.get_slicec(':', 1).strip_edges().to_int();
+				Pair<String, int> breakpoint = to_breakpoint(line);
 
-				source = breakpoint_find_source(source);
+				String source = breakpoint.first;
+				int linenr = breakpoint.second;
 
-				insert_breakpoint(line, source);
+				if (source.empty())
+					continue;
 
-				print_line("BreakPoint at " + source + ":" + itos(line));
+				insert_breakpoint(linenr, source);
+
+				print_line("Added breakpoint at " + source + ":" + itos(linenr));
 			}
 
+		} else if (line == "q" || line == "quit") {
+
+			// Do not stop again on quit
+			clear_breakpoints();
+			ScriptDebugger::get_singleton()->set_depth(-1);
+			ScriptDebugger::get_singleton()->set_lines_left(-1);
+
+			SceneTree::get_singleton()->quit();
+			break;
 		} else if (line.begins_with("delete")) {
 
 			if (line.get_slice_count(" ") <= 1) {
 				clear_breakpoints();
 			} else {
 
-				String bppos = line.get_slicec(' ', 1);
-				String source = bppos.get_slicec(':', 0).strip_edges();
-				int line = bppos.get_slicec(':', 1).strip_edges().to_int();
+				Pair<String, int> breakpoint = to_breakpoint(line);
 
-				source = breakpoint_find_source(source);
+				String source = breakpoint.first;
+				int linenr = breakpoint.second;
 
-				remove_breakpoint(line, source);
+				if (source.empty())
+					continue;
 
-				print_line("Removed BreakPoint at " + source + ":" + itos(line));
+				remove_breakpoint(linenr, source);
+
+				print_line("Removed breakpoint at " + source + ":" + itos(linenr));
 			}
 
 		} else if (line == "h" || line == "help") {
 
 			print_line("Built-In Debugger command list:\n");
-			print_line("\tc,continue :\t\t Continue execution.");
-			print_line("\tbt,backtrace :\t\t Show stack trace (frames).");
+			print_line("\tc,continue\t\t Continue execution.");
+			print_line("\tbt,backtrace\t\t Show stack trace (frames).");
 			print_line("\tfr,frame <frame>:\t Change current frame.");
-			print_line("\tlv,locals :\t\t Show local variables for current frame.");
-			print_line("\tmv,members :\t\t Show member variables for \"this\" in frame.");
-			print_line("\tgv,globals :\t\t Show global variables.");
-			print_line("\tp,print <expr> :\t Execute and print variable in expression.");
-			print_line("\ts,step :\t\t Step to next line.");
-			print_line("\tn,next :\t\t Next line.");
-			print_line("\tbr,break source:line :\t Place a breakpoint.");
-			print_line("\tdelete [source:line]:\t\t Delete one/all breakpoints.");
+			print_line("\tlv,locals\t\t Show local variables for current frame.");
+			print_line("\tmv,members\t\t Show member variables for \"this\" in frame.");
+			print_line("\tgv,globals\t\t Show global variables.");
+			print_line("\tp,print <expr>\t\t Execute and print variable in expression.");
+			print_line("\ts,step\t\t\t Step to next line.");
+			print_line("\tn,next\t\t\t Next line.");
+			print_line("\tfin,finish\t\t Step out of current frame.");
+			print_line("\tbr,break [source:line]\t List all breakpoints or place a breakpoint.");
+			print_line("\tdelete [source:line]:\t Delete one/all breakpoints.");
+			print_line("\tset [key=value]:\t List all options, or set one.");
+			print_line("\tq,quit\t\t\t Quit application.");
 		} else {
 			print_line("Error: Invalid command, enter \"help\" for assistance.");
 		}
 	}
+}
+
+void ScriptDebuggerLocal::print_variables(const List<String> &names, const List<Variant> &values, const String &variable_prefix) {
+
+	String value;
+	Vector<String> value_lines;
+	const List<Variant>::Element *V = values.front();
+	for (const List<String>::Element *E = names.front(); E; E = E->next()) {
+
+		value = String(V->get());
+
+		if (variable_prefix.empty()) {
+			print_line(E->get() + ": " + String(V->get()));
+		} else {
+
+			print_line(E->get() + ":");
+			value_lines = value.split("\n");
+			for (int i = 0; i < value_lines.size(); ++i) {
+				print_line(variable_prefix + value_lines[i]);
+			}
+		}
+
+		V = V->next();
+	}
+}
+
+Pair<String, int> ScriptDebuggerLocal::to_breakpoint(const String &p_line) {
+
+	String breakpoint_part = p_line.get_slicec(' ', 1);
+	Pair<String, int> breakpoint;
+
+	int last_colon = breakpoint_part.rfind(":");
+	if (last_colon < 0) {
+		print_line("Error: Invalid breakpoint format. Expected [source:line]");
+		return breakpoint;
+	}
+
+	breakpoint.first = breakpoint_find_source(breakpoint_part.left(last_colon).strip_edges());
+	breakpoint.second = breakpoint_part.right(last_colon).strip_edges().to_int();
+
+	return breakpoint;
 }
 
 struct _ScriptDebuggerLocalProfileInfoSort {
@@ -304,4 +420,5 @@ ScriptDebuggerLocal::ScriptDebuggerLocal() {
 
 	profiling = false;
 	idle_accum = OS::get_singleton()->get_ticks_usec();
+	options["variable_prefix"] = "";
 }

--- a/core/script_debugger_local.h
+++ b/core/script_debugger_local.h
@@ -31,6 +31,7 @@
 #ifndef SCRIPT_DEBUGGER_LOCAL_H
 #define SCRIPT_DEBUGGER_LOCAL_H
 
+#include "list.h"
 #include "script_language.h"
 
 class ScriptDebuggerLocal : public ScriptDebugger {
@@ -38,8 +39,13 @@ class ScriptDebuggerLocal : public ScriptDebugger {
 	bool profiling;
 	float frame_time, idle_time, physics_time, physics_frame_time;
 	uint64_t idle_accum;
+	String target_function;
+	Map<String, String> options;
 
 	Vector<ScriptLanguage::ProfilingInfo> pinfo;
+
+	Pair<String, int> to_breakpoint(const String &p_line);
+	void print_variables(const List<String> &names, const List<Variant> &values, const String &variable_prefix);
 
 public:
 	void debug(ScriptLanguage *p_script, bool p_can_continue);

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -386,6 +386,7 @@ public:
 	bool is_breakpoint(int p_line, const StringName &p_source) const;
 	bool is_breakpoint_line(int p_line) const;
 	void clear_breakpoints();
+	const Map<int, Set<StringName> > &get_breakpoints() const { return breakpoints; }
 
 	virtual void debug(ScriptLanguage *p_script, bool p_can_continue = true) = 0;
 	virtual void idle_poll();

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -73,6 +73,23 @@ void OS_Unix::debug_break() {
 	assert(false);
 };
 
+static void handle_interrupt(int sig) {
+	if (ScriptDebugger::get_singleton() == NULL)
+		return;
+
+	ScriptDebugger::get_singleton()->set_depth(-1);
+	ScriptDebugger::get_singleton()->set_lines_left(1);
+}
+
+void OS_Unix::initialize_debugging() {
+
+	if (ScriptDebugger::get_singleton() != NULL) {
+		struct sigaction action;
+		action.sa_handler = handle_interrupt;
+		sigaction(SIGINT, &action, NULL);
+	}
+}
+
 int OS_Unix::unix_initialize_audio(int p_audio_driver) {
 
 	return 0;

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -101,6 +101,7 @@ public:
 	virtual int get_processor_count() const;
 
 	virtual void debug_break();
+	virtual void initialize_debugging();
 
 	virtual String get_executable_path() const;
 	virtual String get_user_data_dir() const;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -730,6 +730,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	} else if (debug_mode == "local") {
 
 		script_debugger = memnew(ScriptDebuggerLocal);
+		OS::get_singleton()->initialize_debugging();
 	}
 
 	FileAccessNetwork::configure();

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -152,6 +152,25 @@ void RedirectIOToConsole() {
 	// point to console as well
 }
 
+BOOL WINAPI HandlerRoutine(_In_ DWORD dwCtrlType) {
+	if (ScriptDebugger::get_singleton() == NULL)
+		return FALSE;
+
+	switch (dwCtrlType) {
+		case CTRL_C_EVENT:
+			ScriptDebugger::get_singleton()->set_depth(-1);
+			ScriptDebugger::get_singleton()->set_lines_left(1);
+			return TRUE;
+		default:
+			return FALSE;
+	}
+}
+
+void OS_Windows::initialize_debugging() {
+
+	SetConsoleCtrlHandler(HandlerRoutine, TRUE);
+}
+
 void OS_Windows::initialize_core() {
 
 	crash_handler.initialize();

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -294,6 +294,7 @@ public:
 
 	void disable_crash_handler();
 	bool is_disable_crash_handler() const;
+	virtual void initialize_debugging();
 
 	void force_process_input();
 


### PR DESCRIPTION
- Adds q/quit option to console debugging
- Adds options (variable_prefix) 
- Breaks into debugger with Ctrl-C in local debug mode (Unix/Windows)
- Adds list of breakpoints (when br without arguments)
- Adds fin/finish to step out of current function
- Fixes add/remove breakpoint bug (invalid path parsing)
- Minor cleanup

**I need testers for windows** (if it builds at all :) ):
Run in command prompt:
```godot```
Hit Ctrl-C in command prompt. Should kill godot (as usual)

Run in command prompt: 
```godot -d```
Hit Ctrl-C in command prompt. Break into debugger. Type:
```quit```
Should quit it.

Note: I could not add the handler setup to OS initialization, as the ScriptDebugger does not exist at this point and there is no way to tell if I'm in debug mode.
If that bugs you I can rearrange the argument parsing in main to make it work. The proposed method had less implications.