### PR TITLE
AndroidModule GodotPaymentsV3 - emit signal when connected (2.1)

### DIFF
--- a/platform/android/java/src/org/godotengine/godot/GodotPaymentV3.java
+++ b/platform/android/java/src/org/godotengine/godot/GodotPaymentV3.java
@@ -67,7 +67,7 @@ public class GodotPaymentV3 extends Godot.SingletonBase {
 
 	public GodotPaymentV3(Activity p_activity) {
 
-		registerClass("GodotPayments", new String[]{"purchase", "setPurchaseCallbackId", "setPurchaseValidationUrlPrefix", "setTransactionId", "getSignature", "consumeUnconsumedPurchases", "requestPurchased", "setAutoConsume", "consume", "querySkuDetails"});
+		registerClass("GodotPayments", new String[]{"purchase", "setPurchaseCallbackId", "setPurchaseValidationUrlPrefix", "setTransactionId", "getSignature", "consumeUnconsumedPurchases", "requestPurchased", "setAutoConsume", "consume", "querySkuDetails", "isConnected"});
 		activity = (Godot) p_activity;
 		mPaymentManager = activity.getPaymentsManager();
 		mPaymentManager.setBaseSingleton(this);
@@ -162,6 +162,19 @@ public class GodotPaymentV3 extends Godot.SingletonBase {
 	// callback for requestPurchased()
 	public void callbackPurchased(String receipt, String signature, String sku) {
 		GodotLib.calldeferred(purchaseCallbackId, "has_purchased", new Object[]{receipt, signature, sku});
+	}
+
+	public void callbackDisconnected() {
+		GodotLib.calldeferred(purchaseCallbackId, "iap_disconnected", new Object[]{});
+	}
+
+	public void callbackConnected() {
+		GodotLib.calldeferred(purchaseCallbackId, "iap_connected", new Object[]{});
+	}
+
+	// true if connected, false otherwise
+	public boolean isConnected() {
+		return mPaymentManager.isConnected();
 	}
 
 	// consume item automatically after purchase. default is true.

--- a/platform/android/java/src/org/godotengine/godot/payments/PaymentsManager.java
+++ b/platform/android/java/src/org/godotengine/godot/payments/PaymentsManager.java
@@ -92,11 +92,21 @@ public class PaymentsManager {
 		@Override
 		public void onServiceDisconnected(ComponentName name) {
 			mService = null;
+
+			// At this stage, godotPaymentV3 might not have been initialized yet.
+			if (godotPaymentV3 != null) {
+				godotPaymentV3.callbackDisconnected();
+			}
 		}
 
 		@Override
 		public void onServiceConnected(ComponentName name, IBinder service) {
 			mService = IInAppBillingService.Stub.asInterface(service);
+
+			// At this stage, godotPaymentV3 might not have been initialized yet.
+			if (godotPaymentV3 != null) {
+				godotPaymentV3.callbackConnected();
+			}
 		}
 	};
 
@@ -121,6 +131,10 @@ public class PaymentsManager {
 
 		}.purchase(sku, transactionId);
 
+	}
+
+	public boolean isConnected() {
+		return mService != null;
 	}
 
 	public void consumeUnconsumedPurchases() {


### PR DESCRIPTION
I put a timer of 10 secondes to get the sku details when godot starts, but on low-end device it is not enough. I'd rather have a way to check if android service is connected than put a timer without behind 100% sure. So this PR fixes this issue:
```
java.lang.NullPointerException: Attempt to invoke interface method
'android.os.Bundle com.android.vending.billing.IInAppBillingService.getSkuDetails(int, java.lang.String, java.lang.String, android.os.Bundle)' on a null object reference
```

When GodotPaymentsV3 is connected to the android service, it emits 'iap_connect' signal. And if it has been disconnected, it emits 'iap_disconnected' signal. This could happen time to time and is useful when using GodotPayments module to perform IAP on Android.

Added a function 'isConnected' returning a boolean. It is possible to miss the 'iap_connected' signal, so users should use the 'isConnected' function to check if it has been already connected, and also to listen to connections events.

Tested and working on Android 4.4 (samsung), 7.1 (nokia) and 8.0 (nokia).

To properly use this PR, here an example of `iap.gd` file:

```gdscript

extends Node

signal purchase_success(item_name)
signal purchase_fail
signal purchase_cancel
signal purchase_owned(item_name)

signal has_purchased(item_name)

signal consume_success(item_name)
signal consume_fail
signal consume_not_required

signal sku_details_complete
signal sku_details_error

signal iap_disconnected
signal iap_connected

onready var payment = Globals.get_singleton('GodotPayments')

func _ready():
  if payment:
    # set callback with this script instance
    payment.setPurchaseCallbackId(get_instance_ID())

# set consume purchased item automatically after purchase, defulat value is true
func set_auto_consume(auto):
  if payment:
    payment.setAutoConsume(auto)

# request user owned item, callback : has_purchased
func request_purchased():
  if payment:
    payment.requestPurchased()

func has_purchased(receipt, signature, sku):
  if sku == '':
    print('has_purchased : nothing')
    emit_signal('has_purchased', null)
  else:
    print('has_purchased : ', sku)
    emit_signal('has_purchased', sku)


# purchase item
# callback : purchase_success, purchase_fail, purchase_cancel, purchase_owned
func purchase(item_name):
  if payment:
    # transaction_id could be any string that used for validation internally in java
    payment.purchase(item_name, 'transaction_id')
  elif OS.is_debug_build():
    call_deferred('purchase_success', null, null, item_name)

func purchase_success(receipt, signature, sku):
  print('purchase_success : ', sku)
  emit_signal('purchase_success', sku)

func purchase_fail():
  print('purchase_fail')
  emit_signal('purchase_fail')

func purchase_cancel():
  print('purchase_cancel')
  emit_signal('purchase_cancel')

func purchase_owned(sku):
  print('purchase_owned : ', sku)
  emit_signal('purchase_owned', sku)


# consume purchased item
# callback : consume_success, consume_fail
func consume(item_name):
  if payment:
    payment.consume(item_name)

# consume all purchased items
func consume_all():
  if payment:
    payment.consumeUnconsumedPurchases()

func consume_success(receipt, signature, sku):
  print('consume_success : ', sku)
  emit_signal('consume_success', sku)

# if consume fail, need to call request_purchased() to get purchase token from google
# then try to consume again
func consume_fail():
  emit_signal('consume_fail')

# no purchased item to consume
func consume_not_required():
  emit_signal('consume_not_required')


# detail info of IAP items
# sku_details = {
#     product_id (String) : {
#         type (String),
#         product_id (String),
#         title (String),
#         description (String),
#         price (String),  # this can be used to display price for each country with their own currency
#         price_currency_code (String),
#         price_amount (float)
#     },
#     ...
# }
var sku_details = {}

# query for details of IAP items
# callback : sku_details_complete
func sku_details_query(list):
  if payment:
    var sku_list = StringArray(list)

    payment.querySkuDetails(sku_list)

func sku_details_complete(result):
  print('sku_details_complete : ', result)
  for key in result.keys():
    sku_details[key] = result[key]
  emit_signal('sku_details_complete')

func sku_details_error(error_message):
  print('error_sku_details = ', error_message)
  emit_signal('sku_details_error')

func iap_disconnected():
  print('iap_disconnected')

  emit_signal('iap_disconnected')

func iap_connected():
  print('iap_connected')

  emit_signal('iap_connected')

 
func is_connected():
  var connected = false

  if payment:
    connected = payment.isConnected()

  return connected
```
