### PR TITLE
fix for segfault when using CallBasic in visual script on release build

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -153,9 +153,9 @@ struct _VariantCall {
 		funcdata.func = p_func;
 		funcdata.default_args = p_defaultarg;
 		funcdata._const = p_const;
+		funcdata.returns = p_has_return;
 #ifdef DEBUG_ENABLED
 		funcdata.return_type = p_return;
-		funcdata.returns = p_has_return;
 #endif
 
 		if (p_argtype1.name) {


### PR DESCRIPTION
_VariantCall::FuncData.returns now initialized in release builds,
as it is required for visual script.
fixes #16465