### PR TITLE
Fix weird editor crash when switching from editing one gradient to another keeps 'grabbing' variable to true

### DIFF
--- a/scene/gui/gradient_edit.cpp
+++ b/scene/gui/gradient_edit.cpp
@@ -367,6 +367,13 @@ void GradientEdit::_notification(int p_what) {
 			draw_line(Vector2(-1, -1), Vector2(-1, h + 1), Color(1, 1, 1, 0.6));
 		}
 	}
+
+	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
+
+		if (!is_visible()) {
+			grabbing = false;
+		}
+	}
 }
 
 void GradientEdit::_draw_checker(int x, int y, int w, int h) {


### PR DESCRIPTION
Fix weird editor crash when switching from editing one gradient to another keeps 'grabbing' variable to true.