### PR TITLE
Use generic joystick define (Linux platforms) (2.1)

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -593,7 +593,7 @@ static const char *s_ControllerMappings[] = {
 	"d814000000000000cecf000000000000,MC Cthulhu,leftx:,lefty:,rightx:,righty:,lefttrigger:b6,a:b1,b:b2,y:b3,x:b0,start:b9,back:b8,leftshoulder:b4,rightshoulder:b5,dpup:h0.1,dpleft:h0.8,dpdown:h0.4,dpright:h0.2,righttrigger:b7,",
 #endif
 
-#if X11_ENABLED
+#if JOYDEV_ENABLED
 	"0000000058626f782047616d65706100,Xbox Gamepad (userspace driver),a:b0,b:b1,x:b2,y:b3,start:b7,back:b6,guide:b8,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,leftshoulder:b4,rightshoulder:b5,lefttrigger:a5,righttrigger:a4,leftstick:b9,rightstick:b10,leftx:a0,lefty:a1,rightx:a2,righty:a3,",
 	"0300000000f000000300000000010000,RetroUSB.com RetroPad,a:b1,b:b5,x:b0,y:b4,back:b2,start:b3,leftshoulder:b6,rightshoulder:b7,leftx:a0,lefty:a1,",
 	"0300000000f00000f100000000010000,RetroUSB.com Super RetroPort,a:b1,b:b5,x:b0,y:b4,back:b2,start:b3,leftshoulder:b6,rightshoulder:b7,leftx:a0,lefty:a1,",


### PR DESCRIPTION
When adding joystick support in a custom platform, I've noticed (actually, @Faless did) that the linux joystick support (x11 platform) has its controller mappings in main/input_default.cpp guarded by X11_ENABLED.

Since the linux joystick support is generic and it's already guarded by its own define (if you look at platform/x11/joystick_linux.cpp, you'll see that the whole source is conditionally compiled based on JOYDEV_ENABLED), I was wondering if you could change `main/input_default.cpp` to make the linux controller mappings useable in other platforms too.