### PR TITLE
Fix broken APK expansion due to missed option renames

### DIFF
--- a/platform/android/java/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/src/org/godotengine/godot/Godot.java
@@ -404,7 +404,7 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 				new_cmdline = new String[2];
 			}
 
-			new_cmdline[cll] = "--main_pack";
+			new_cmdline[cll] = "--main-pack";
 			new_cmdline[cll + 1] = expansion_pack_path;
 			command_line = new_cmdline;
 		}

--- a/platform/android/java_glue.cpp
+++ b/platform/android/java_glue.cpp
@@ -926,7 +926,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_setup(JNIEnv *env, jo
 				} else {
 					//__android_log_print(ANDROID_LOG_INFO,"godot","cmdline arg %i is: %s\n",i,rawString);
 
-					if (strcmp(rawString, "-main_pack") == 0)
+					if (strcmp(rawString, "--main-pack") == 0)
 						use_apk_expansion = true;
 				}
 


### PR DESCRIPTION
Command line options were refactored for 3.0 to follow the common usage
of double-dashed long options, but `--main-pack` went through the cracks.

Fixes #16533.