### PR TITLE
[X11] Improving error detection in move_to_trash

### DIFF
--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -361,6 +361,7 @@ Error DirAccessUnix::rename(String p_path, String p_new_path) {
 
 	return ::rename(p_path.utf8().get_data(), p_new_path.utf8().get_data()) == 0 ? OK : FAILED;
 }
+
 Error DirAccessUnix::remove(String p_path) {
 
 	if (p_path.is_rel_path())


### PR DESCRIPTION
Hi, this is my first PR here, so I would appreciate any advice or criticism.
Beside correctness of the code, that includes the coding guidelines, branch naming, commit message and pretty much anything you think I could've done better :D

OS: Arch Linux
(Other info about the system isn't necessary for this issue)

I have noticed a small issue in x11's implementation of **move_to_trash** function.

When deleting the asset from the editor, I have noticed that the asset wasn't actually deleted but just moved to some other directory which should represent the "Trash can". In my case, that happened to be "${HOME}/.local/share/Trash/files". This behavior was undesirable to me and I wanted to actually delete the asset. My idea was to create symbolic(soft) link to /dev/null that will be named "Trash", so that when Godot tries to move the asset to the "Trash" directory, it will actually be deleted. After creation of that symbolic link, I've noticed that Godot now couldn't delete the assets anymore. In this case, the engine acted like it did the job well, no errors were reported, but the asset remained untouched. After that I've analyzed the code and noticed that in the **move_to_trash** function, execution of both **mkdir** and **mv** are succeeding, but their return values were never checked to see if they did the job well.
My PR will include the checking of returned values from **mkdir** and **mv** in order to give the user correct error report in similar cases. Beside that, I have added a few comments in the function, mainly for myself but I think it can be useful for others.