### PR TITLE
Fix for a possible compile error under OS X

### DIFF
--- a/drivers/coreaudio/audio_driver_coreaudio.cpp
+++ b/drivers/coreaudio/audio_driver_coreaudio.cpp
@@ -37,7 +37,7 @@
 #define kOutputBus 0
 
 #ifdef OSX_ENABLED
-static OSStatus outputDeviceAddressCB(AudioObjectID inObjectID, UInt32 inNumberAddresses, const AudioObjectPropertyAddress *inAddresses, void *__nullable inClientData) {
+static OSStatus outputDeviceAddressCB(AudioObjectID inObjectID, UInt32 inNumberAddresses, const AudioObjectPropertyAddress *inAddresses, void *inClientData) {
 	AudioDriverCoreAudio *driver = (AudioDriverCoreAudio *)inClientData;
 
 	driver->reopen();

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -54,7 +54,30 @@ class EditorHelpSearch : public ConfirmationDialog {
 	Tree *search_options;
 	String base_type;
 
-	class IncrementalSearch;
+	class IncrementalSearch : public Reference {
+		String term;
+		TreeItem *root;
+
+		EditorHelpSearch *search;
+		Tree *search_options;
+
+		DocData *doc;
+		Ref<Texture> def_icon;
+
+		int phase;
+		Map<String, DocData::ClassDoc>::Element *iterator;
+
+		void phase1(Map<String, DocData::ClassDoc>::Element *E);
+		void phase2(Map<String, DocData::ClassDoc>::Element *E);
+		bool slice();
+
+	public:
+		IncrementalSearch(EditorHelpSearch *p_search, Tree *p_search_options, const String &p_term);
+
+		bool empty() const;
+		bool work(uint64_t slot = 1000000 / 10);
+	};
+
 	Ref<IncrementalSearch> search;
 
 	void _update_search();


### PR DESCRIPTION
This fixes this error I'm getting on OS X Yosemite:
```
In file included from main/main.cpp:38:
In file included from core/os/os.h:34:
In file included from core/engine.h:35:
In file included from core/os/main_loop.h:34:
In file included from core/os/input_event.h:36:
In file included from core/resource.h:37:
core/reference.h:261:29: error: member access into incomplete type 'EditorHelpSearch::IncrementalSearch'
                if (reference && reference->unreference()) {
                                          ^
core/reference.h:279:3: note: in instantiation of member function 'Ref<EditorHelpSearch::IncrementalSearch>::unref' requested here
                unref();
                ^
editor/editor_help.h:49:7: note: in instantiation of member function 'Ref<EditorHelpSearch::IncrementalSearch>::~Ref' requested here
class EditorHelpSearch : public ConfirmationDialog {
      ^
editor/editor_help.h:57:8: note: forward declaration of 'EditorHelpSearch::IncrementalSearch'
        class IncrementalSearch;
              ^
8 warnings and 1 error generated.
```