### PR TITLE
Add flip switch to SurfaceTool.generate_normals

### DIFF
--- a/doc/classes/SurfaceTool.xml
+++ b/doc/classes/SurfaceTool.xml
@@ -196,8 +196,11 @@
 		<method name="generate_normals">
 			<return type="void">
 			</return>
+			<argument index="0" name="flip" type="bool" default="false">
+			</argument>
 			<description>
 				Generates normals from Vertices so you do not have to do it manually.
+				Setting "flip" [code]true[/code] inverts resulting normals.
 			</description>
 		</method>
 		<method name="generate_tangents">

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -861,7 +861,7 @@ void SurfaceTool::generate_tangents() {
 	}
 }
 
-void SurfaceTool::generate_normals() {
+void SurfaceTool::generate_normals(bool p_flip) {
 
 	ERR_FAIL_COND(primitive != Mesh::PRIMITIVE_TRIANGLES);
 
@@ -887,7 +887,11 @@ void SurfaceTool::generate_normals() {
 		ERR_FAIL_COND(!v[2]);
 		E = v[2]->next();
 
-		Vector3 normal = Plane(v[0]->get().vertex, v[1]->get().vertex, v[2]->get().vertex).normal;
+		Vector3 normal;
+		if (!p_flip)
+			normal = Plane(v[0]->get().vertex, v[1]->get().vertex, v[2]->get().vertex).normal;
+		else
+			normal = Plane(v[2]->get().vertex, v[1]->get().vertex, v[0]->get().vertex).normal;
 
 		if (smooth) {
 
@@ -980,7 +984,7 @@ void SurfaceTool::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("index"), &SurfaceTool::index);
 	ClassDB::bind_method(D_METHOD("deindex"), &SurfaceTool::deindex);
-	ClassDB::bind_method(D_METHOD("generate_normals"), &SurfaceTool::generate_normals);
+	ClassDB::bind_method(D_METHOD("generate_normals", "flip"), &SurfaceTool::generate_normals, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("generate_tangents"), &SurfaceTool::generate_tangents);
 
 	ClassDB::bind_method(D_METHOD("add_to_format", "flags"), &SurfaceTool::add_to_format);

--- a/scene/resources/surface_tool.h
+++ b/scene/resources/surface_tool.h
@@ -116,7 +116,7 @@ public:
 
 	void index();
 	void deindex();
-	void generate_normals();
+	void generate_normals(bool p_flip = false);
 	void generate_tangents();
 
 	void add_to_format(int p_flags) { format |= p_flags; }


### PR DESCRIPTION
The SurfaceTool.generate_normals definitly must have a flip switch, of course it's false by default, so it does not break existing code. Closes #16528