### PR TITLE
Fixed "Open" button being enabled when nothing is selected in a FileDialog while in "Open folder" mode

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -210,7 +210,7 @@ void FileDialog::_action_pressed() {
 		bool valid = false;
 
 		if (filter->get_selected() == filter->get_item_count() - 1) {
-			valid = true; //match none
+			valid = true; // match none
 		} else if (filters.size() > 1 && filter->get_selected() == 0) {
 			// match all filters
 			for (int i = 0; i < filters.size(); i++) {
@@ -287,7 +287,7 @@ bool FileDialog::_is_open_should_be_disabled() {
 	TreeItem *ti = tree->get_selected();
 	// We have something that we can't select?
 	if (!ti)
-		return true;
+		return mode != MODE_OPEN_DIR; // In "Open folder" mode, having nothing selected picks the current folder.
 
 	Dictionary d = ti->get_metadata(0);
 
@@ -320,16 +320,14 @@ void FileDialog::deselect_items() {
 			case MODE_OPEN_FILE:
 			case MODE_OPEN_FILES:
 				get_ok()->set_text(TTR("Open"));
-				get_ok()->set_disabled(false);
 				break;
-
 			case MODE_OPEN_DIR:
 				get_ok()->set_text(TTR("Select Current Folder"));
-				get_ok()->set_disabled(false);
 				break;
 		}
 	}
 }
+
 void FileDialog::_tree_selected() {
 
 	TreeItem *ti = tree->get_selected();
@@ -347,7 +345,7 @@ void FileDialog::_tree_selected() {
 	get_ok()->set_disabled(_is_open_should_be_disabled());
 }
 
-void FileDialog::_tree_dc_selected() {
+void FileDialog::_tree_item_activated() {
 
 	TreeItem *ti = tree->get_selected();
 	if (!ti)
@@ -756,7 +754,7 @@ void FileDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_unhandled_input"), &FileDialog::_unhandled_input);
 
 	ClassDB::bind_method(D_METHOD("_tree_selected"), &FileDialog::_tree_selected);
-	ClassDB::bind_method(D_METHOD("_tree_db_selected"), &FileDialog::_tree_dc_selected);
+	ClassDB::bind_method(D_METHOD("_tree_item_activated"), &FileDialog::_tree_item_activated);
 	ClassDB::bind_method(D_METHOD("_dir_entered"), &FileDialog::_dir_entered);
 	ClassDB::bind_method(D_METHOD("_file_entered"), &FileDialog::_file_entered);
 	ClassDB::bind_method(D_METHOD("_action_pressed"), &FileDialog::_action_pressed);
@@ -881,7 +879,7 @@ FileDialog::FileDialog() {
 	filter = memnew(OptionButton);
 	filter->set_stretch_ratio(3);
 	filter->set_h_size_flags(SIZE_EXPAND_FILL);
-	filter->set_clip_text(true); //too many extensions overflow it
+	filter->set_clip_text(true); // too many extensions overflows it
 	hbc->add_child(filter);
 	vbc->add_child(hbc);
 
@@ -890,9 +888,8 @@ FileDialog::FileDialog() {
 	_update_drives();
 
 	connect("confirmed", this, "_action_pressed");
-	//cancel->connect("pressed", this,"_cancel_pressed");
 	tree->connect("cell_selected", this, "_tree_selected", varray(), CONNECT_DEFERRED);
-	tree->connect("item_activated", this, "_tree_db_selected", varray());
+	tree->connect("item_activated", this, "_tree_item_activated", varray());
 	tree->connect("nothing_selected", this, "deselect_items");
 	dir->connect("text_entered", this, "_dir_entered");
 	file->connect("text_entered", this, "_file_entered");
@@ -922,7 +919,6 @@ FileDialog::FileDialog() {
 	exterr->set_text(RTR("Must use a valid extension."));
 	add_child(exterr);
 
-	//update_file_list();
 	update_filters();
 	update_dir();
 

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -107,7 +107,7 @@ private:
 	void _tree_selected();
 
 	void _select_drive(int p_idx);
-	void _tree_dc_selected();
+	void _tree_item_activated();
 	void _dir_entered(String p_dir);
 	void _file_entered(const String &p_file);
 	void _action_pressed();


### PR DESCRIPTION
Also changed the `_tree_dc_selected` binding to match the function's name.