### PR TITLE
Clear function made godot crashing because line_number is below 0 (2.1.5-beta)

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3212,7 +3212,7 @@ void TextEdit::_clear() {
 		op.type = TextOperation::TYPE_CLEAR;
 		op.from_line = 0;
 		op.from_column = 0;
-		op.to_line = get_line_count() - 1;
+		op.to_line = MAX(0, get_line_count() - 1);
 		op.to_column = get_line(op.to_line).length();
 		op.text = undo_text;
 		op.version = ++version;


### PR DESCRIPTION
Clear function made godot crashing because line_number is below 0

- Adding a MAX(0, index) in order to have at least 0 inserted in the history