### PR TITLE
Add menu option to hide/show visibility_aabb in ParticlesGizmo

### DIFF
--- a/editor/plugins/particles_editor_plugin.cpp
+++ b/editor/plugins/particles_editor_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "particles_editor_plugin.h"
 #include "editor/plugins/spatial_editor_plugin.h"
+#include "editor/spatial_editor_gizmos.h"
 #include "io/resource_loader.h"
 
 void ParticlesEditor::_node_removed(Node *p_node) {
@@ -93,6 +94,9 @@ void ParticlesEditor::_menu_option(int p_option) {
 		case MENU_OPTION_GENERATE_AABB: {
 			generate_aabb->popup_centered_minsize();
 		} break;
+		case MENU_OPTION_TOGGLE_AABB: {
+			_toggle_aabb_display();
+		} break;
 		case MENU_OPTION_CREATE_EMISSION_VOLUME_FROM_MESH: {
 
 			Ref<ParticlesMaterial> material = node->get_process_material();
@@ -142,6 +146,13 @@ void ParticlesEditor::_generate_aabb() {
 	}
 
 	node->set_visibility_aabb(rect);
+}
+
+void ParticlesEditor::_toggle_aabb_display() {
+
+	Ref<ParticlesGizmo> gizmo = node->get_gizmo();
+	gizmo->set_aabb_display(!gizmo->get_aabb_display());
+	node->update_gizmo();
 }
 
 void ParticlesEditor::edit(Particles *p_particles) {
@@ -345,6 +356,7 @@ void ParticlesEditor::_bind_methods() {
 	ClassDB::bind_method("_node_selected", &ParticlesEditor::_node_selected);
 	ClassDB::bind_method("_generate_emission_points", &ParticlesEditor::_generate_emission_points);
 	ClassDB::bind_method("_generate_aabb", &ParticlesEditor::_generate_aabb);
+	ClassDB::bind_method("_toggle_aabb_display", &ParticlesEditor::_toggle_aabb_display);
 }
 
 ParticlesEditor::ParticlesEditor() {
@@ -357,6 +369,7 @@ ParticlesEditor::ParticlesEditor() {
 
 	options->set_text(TTR("Particles"));
 	options->get_popup()->add_item(TTR("Generate AABB"), MENU_OPTION_GENERATE_AABB);
+	options->get_popup()->add_item(TTR("Toggle AABB display"), MENU_OPTION_TOGGLE_AABB);
 	options->get_popup()->add_separator();
 	options->get_popup()->add_item(TTR("Create Emission Points From Mesh"), MENU_OPTION_CREATE_EMISSION_VOLUME_FROM_MESH);
 	options->get_popup()->add_item(TTR("Create Emission Points From Node"), MENU_OPTION_CREATE_EMISSION_VOLUME_FROM_NODE);

--- a/editor/plugins/particles_editor_plugin.h
+++ b/editor/plugins/particles_editor_plugin.h
@@ -64,6 +64,7 @@ class ParticlesEditor : public Control {
 	enum Menu {
 
 		MENU_OPTION_GENERATE_AABB,
+		MENU_OPTION_TOGGLE_AABB,
 		MENU_OPTION_CREATE_EMISSION_VOLUME_FROM_NODE,
 		MENU_OPTION_CREATE_EMISSION_VOLUME_FROM_MESH,
 		MENU_OPTION_CLEAR_EMISSION_VOLUME,
@@ -73,6 +74,7 @@ class ParticlesEditor : public Control {
 	PoolVector<Face3> geometry;
 
 	void _generate_aabb();
+	void _toggle_aabb_display();
 	void _generate_emission_points();
 	void _node_selected(const NodePath &p_path);
 

--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -2373,14 +2373,35 @@ void ParticlesGizmo::commit_handle(int p_idx, const Variant &p_restore, bool p_c
 	ur->commit_action();
 }
 
+void ParticlesGizmo::_changed_callback(Object *p_changed, const char *p_property) {
+
+	set_aabb_display(true);
+}
+
+void ParticlesGizmo::set_aabb_display(bool p_display) {
+
+	display_aabb = p_display;
+}
+
+bool ParticlesGizmo::get_aabb_display() {
+
+	return display_aabb;
+}
+
 void ParticlesGizmo::redraw() {
 
 	clear();
+
+	Ref<Material> icon = create_icon_material("particles_icon", SpatialEditor::get_singleton()->get_icon("GizmoParticles", "EditorIcons"));
+	add_unscaled_billboard(icon, 0.05);
+
+	if (!display_aabb) return;
 
 	Vector<Vector3> lines;
 	AABB aabb = particles->get_visibility_aabb();
 
 	for (int i = 0; i < 12; i++) {
+
 		Vector3 a, b;
 		aabb.get_edge(i, a, b);
 		lines.push_back(a);
@@ -2410,7 +2431,6 @@ void ParticlesGizmo::redraw() {
 
 	Color gizmo_color = EDITOR_GET("editors/3d_gizmos/gizmo_colors/particles");
 	Ref<Material> material = create_material("particles_material", gizmo_color);
-	Ref<Material> icon = create_icon_material("particles_icon", SpatialEditor::get_singleton()->get_icon("GizmoParticles", "EditorIcons"));
 
 	add_lines(lines, material);
 	add_collision_segments(lines);
@@ -2422,14 +2442,14 @@ void ParticlesGizmo::redraw() {
 		add_solid_box(solid_material, aabb.get_size());
 	}
 
-	//add_unscaled_billboard(SpatialEditorGizmos::singleton->visi,0.05);
-	add_unscaled_billboard(icon, 0.05);
 	add_handles(handles);
 }
 ParticlesGizmo::ParticlesGizmo(Particles *p_particles) {
 
 	particles = p_particles;
+	display_aabb = true;
 	set_spatial_node(p_particles);
+	particles->add_change_receptor(this);
 }
 
 ////////

--- a/editor/spatial_editor_gizmos.h
+++ b/editor/spatial_editor_gizmos.h
@@ -248,12 +248,17 @@ class ParticlesGizmo : public EditorSpatialGizmo {
 	GDCLASS(ParticlesGizmo, EditorSpatialGizmo);
 
 	Particles *particles;
+	bool display_aabb;
 
 public:
 	virtual String get_handle_name(int p_idx) const;
 	virtual Variant get_handle_value(int p_idx) const;
 	virtual void set_handle(int p_idx, Camera *p_camera, const Point2 &p_point);
 	virtual void commit_handle(int p_idx, const Variant &p_restore, bool p_cancel = false);
+	virtual void _changed_callback(Object *p_changed, const char *p_property);
+
+	void set_aabb_display(bool p_display);
+	bool get_aabb_display();
 
 	void redraw();
 	ParticlesGizmo(Particles *p_particles = NULL);


### PR DESCRIPTION
When working on a particle system it can be bothering to have the visibility AABB getting in your way and changing the color of the particles, so I added the option to toggle its display. If you edit the visibility box from the inspector (or by generating a new AABB) it automatically displays again so you get visual feedback.