### PR TITLE
Makes project manager never initialize mono debug.

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -122,12 +122,17 @@ static bool force_lowdpi = false;
 static int init_screen = -1;
 static bool use_vsync = true;
 static bool editor = false;
-static bool project_manager = false;
 static bool show_help = false;
 static bool disable_render_loop = false;
 static int fixed_fps = -1;
 
 static OS::ProcessID allow_focus_steal_pid = 0;
+
+static bool project_manager = false;
+
+bool Main::is_project_manager() {
+	return project_manager;
+}
 
 void initialize_physics() {
 

--- a/main/main.h
+++ b/main/main.h
@@ -56,6 +56,7 @@ public:
 	static bool iteration();
 	static void cleanup();
 	static void force_redraw();
+	static bool is_project_manager();
 };
 
 #endif

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -47,6 +47,7 @@
 
 #ifdef TOOLS_ENABLED
 #include "../editor/godotsharp_editor.h"
+#include "main/main.h"
 #endif
 
 void gdmono_unhandled_exception_hook(MonoObject *exc, void *user_data) {
@@ -94,21 +95,6 @@ static bool _wait_for_debugger_msecs(uint32_t p_msecs) {
 }
 #endif
 
-#ifdef TOOLS_ENABLED
-// temporary workaround. should be provided from Main::setup/setup2 instead
-bool _is_project_manager_requested() {
-
-	List<String> cmdline_args = OS::get_singleton()->get_cmdline_args();
-	for (List<String>::Element *E = cmdline_args.front(); E; E = E->next()) {
-		const String &arg = E->get();
-		if (arg == "-p" || arg == "--project-manager")
-			return true;
-	}
-
-	return false;
-}
-#endif
-
 #ifdef DEBUG_ENABLED
 void gdmono_debug_init() {
 
@@ -121,7 +107,7 @@ void gdmono_debug_init() {
 #ifdef TOOLS_ENABLED
 	if (Engine::get_singleton()->is_editor_hint() ||
 			ProjectSettings::get_singleton()->get_resource_path().empty() ||
-			_is_project_manager_requested()) {
+			Main::is_project_manager()) {
 		return;
 	}
 #endif


### PR DESCRIPTION
The heuristic whether we're in the project manager inside `GDMono` didn't work if the project manager was launched by not having any path to run.

This is fixed now by making a `Main::is_project_manager()`.