### PR TITLE
Simplify detection of Sprite clicks

### DIFF
--- a/scene/2d/sprite.cpp
+++ b/scene/2d/sprite.cpp
@@ -287,7 +287,7 @@ bool Sprite::_edit_is_selected_on_click(const Point2 &p_point, double p_toleranc
 	return c.a > 0.01;
 }
 
-Rect2 Sprite::_edit_get_rect() const {
+Rect2 Sprite::get_rect() const {
 
 	if (texture.is_null())
 		return Rect2(0, 0, 1, 1);
@@ -363,6 +363,8 @@ void Sprite::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_hframes", "hframes"), &Sprite::set_hframes);
 	ClassDB::bind_method(D_METHOD("get_hframes"), &Sprite::get_hframes);
+
+	ClassDB::bind_method(D_METHOD("get_rect"), &Sprite::get_rect);
 
 	ADD_SIGNAL(MethodInfo("frame_changed"));
 	ADD_SIGNAL(MethodInfo("texture_changed"));

--- a/scene/2d/sprite.h
+++ b/scene/2d/sprite.h
@@ -69,7 +69,7 @@ public:
 	virtual Point2 _edit_get_pivot() const;
 	virtual bool _edit_use_pivot() const;
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
-	virtual Rect2 _edit_get_rect() const;
+	virtual Rect2 _edit_get_rect() const { return get_rect(); }
 
 	void set_texture(const Ref<Texture> &p_texture);
 	Ref<Texture> get_texture() const;
@@ -106,6 +106,8 @@ public:
 
 	void set_hframes(int p_amount);
 	int get_hframes() const;
+
+	Rect2 get_rect() const;
 
 	Sprite();
 };


### PR DESCRIPTION
People were inventing [far more complicated ways](https://www.reddit.com/r/godot/comments/7xwr22/guide_how_to_click_a_sprite/) of trying to get the clickable area of a Sprite (a very common operation), and this should help to simplify that process.