### PR TITLE
C# Signal attribute

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1566,13 +1566,13 @@ bool CSharpScript::_update_signals() {
 
 		while (top && top != native) {
 			const Vector<GDMonoClass *> &delegates = top->get_all_delegates();
-			for (int i = delegates.size() - 1; i >= 0; i--) {
+			for (int i = delegates.size() - 1; i >= 0; --i) {
+				Vector<Argument> parameters;
+
 				GDMonoClass *delegate = delegates[i];
 
-				if (delegate->has_attribute(CACHED_CLASS(SignalAttribute))) {
-					StringName name = delegate->get_name();
-
-					_signals[name] = Vector<StringName>(); // TODO Retrieve arguments
+				if (_get_signal(top, delegate, parameters)) {
+					_signals[delegate->get_name()] = parameters;
 				}
 			}
 
@@ -1582,6 +1582,41 @@ bool CSharpScript::_update_signals() {
 
 	return changed;
 #endif
+	return false;
+}
+
+bool CSharpScript::_get_signal(GDMonoClass *p_class, GDMonoClass *p_delegate, Vector<Argument> &params) {
+	if (p_delegate->has_attribute(CACHED_CLASS(SignalAttribute))) {
+		MonoType *raw_type = GDMonoClass::get_raw_type(p_delegate);
+
+		if (mono_type_get_type(raw_type) == MONO_TYPE_CLASS) {
+			// Arguments are accessibles as arguments of .Invoke method
+			GDMonoMethod *invoke = p_delegate->get_method("Invoke", -1);
+
+			Vector<StringName> names;
+			Vector<ManagedType> types;
+			invoke->get_parameter_names(names);
+			invoke->get_parameter_types(types);
+
+			if (names.size() == types.size()) {
+				for (int i = 0; i < names.size(); ++i) {
+					Argument arg;
+					arg.name = names[i];
+					arg.type = GDMonoMarshal::managed_to_variant_type(types[i]);
+
+					if (arg.type == Variant::NIL) {
+						ERR_PRINTS("Unknown type of signal parameter: " + arg.name + " in " + p_class->get_full_name());
+						return false;
+					}
+
+					params.push_back(arg);
+				}
+
+				return true;
+			}
+		}
+	}
+
 	return false;
 }
 
@@ -1913,6 +1948,8 @@ ScriptInstance *CSharpScript::instance_create(Object *p_this) {
 #endif
 	}
 
+	update_signals();
+
 	if (native) {
 		String native_name = native->get_name();
 		if (!ClassDB::is_parent_class(p_this->get_class_name(), native_name)) {
@@ -2074,6 +2111,27 @@ void CSharpScript::update_exports() {
 #ifdef TOOLS_ENABLED
 	_update_exports();
 #endif
+}
+
+bool CSharpScript::has_script_signal(const StringName &p_signal) const {
+	if (_signals.has(p_signal))
+		return true;
+
+	return false;
+}
+
+void CSharpScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
+	for (const Map<StringName, Vector<Argument> >::Element *E = _signals.front(); E; E = E->next()) {
+		MethodInfo mi;
+
+		mi.name = E->key();
+		for (int i = 0; i < E->get().size(); i++) {
+			PropertyInfo arg;
+			arg.name = E->get()[i].name;
+			mi.arguments.push_back(arg);
+		}
+		r_signals->push_back(mi);
+	}
 }
 
 void CSharpScript::update_signals() {

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -91,6 +91,8 @@ class CSharpScript : public Script {
 	Set<PlaceHolderScriptInstance *> placeholders;
 	bool source_changed_cache;
 	bool exports_invalidated;
+	Map<StringName, Vector<StringName> > _signals;
+	bool signals_invalidated;
 
 	void _update_exports_values(Map<StringName, Variant> &values, List<PropertyInfo> &propnames);
 	virtual void _placeholder_erased(PlaceHolderScriptInstance *p_placeholder);
@@ -103,6 +105,8 @@ class CSharpScript : public Script {
 	Map<StringName, PropertyInfo> member_info;
 
 	void _clear();
+
+	bool _update_signals();
 
 	bool _update_exports();
 #ifdef TOOLS_ENABLED
@@ -139,6 +143,7 @@ public:
 
 	/* TODO */ virtual bool has_script_signal(const StringName &p_signal) const { return false; }
 	/* TODO */ virtual void get_script_signal_list(List<MethodInfo> *r_signals) const {}
+	virtual void update_signals();
 
 	/* TODO */ virtual bool get_property_default_value(const StringName &p_property, Variant &r_value) const;
 	virtual void get_script_property_list(List<PropertyInfo> *p_list) const;

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -85,13 +85,18 @@ class CSharpScript : public Script {
 
 	SelfList<CSharpScript> script_list;
 
+	struct Argument {
+		String name;
+		Variant::Type type;
+	};
+
 #ifdef TOOLS_ENABLED
 	List<PropertyInfo> exported_members_cache; // members_cache
 	Map<StringName, Variant> exported_members_defval_cache; // member_default_values_cache
 	Set<PlaceHolderScriptInstance *> placeholders;
 	bool source_changed_cache;
 	bool exports_invalidated;
-	Map<StringName, Vector<StringName> > _signals;
+	Map<StringName, Vector<Argument> > _signals;
 	bool signals_invalidated;
 
 	void _update_exports_values(Map<StringName, Variant> &values, List<PropertyInfo> &propnames);
@@ -107,6 +112,7 @@ class CSharpScript : public Script {
 	void _clear();
 
 	bool _update_signals();
+	bool _get_signal(GDMonoClass *p_class, GDMonoClass *p_delegate, Vector<Argument> &params);
 
 	bool _update_exports();
 #ifdef TOOLS_ENABLED
@@ -141,8 +147,8 @@ public:
 
 	virtual Error reload(bool p_keep_state = false);
 
-	/* TODO */ virtual bool has_script_signal(const StringName &p_signal) const { return false; }
-	/* TODO */ virtual void get_script_signal_list(List<MethodInfo> *r_signals) const {}
+	virtual bool has_script_signal(const StringName &p_signal) const;
+	virtual void get_script_signal_list(List<MethodInfo> *r_signals) const;
 	virtual void update_signals();
 
 	/* TODO */ virtual bool get_property_default_value(const StringName &p_property, Variant &r_value) const;

--- a/modules/mono/glue/cs_files/SignalAttribute.cs
+++ b/modules/mono/glue/cs_files/SignalAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Godot
+{
+    [AttributeUsage(AttributeTargets.Delegate)]
+    public class SignalAttribute : Attribute
+    {
+        public SignalAttribute()
+        {
+        }
+    }
+}

--- a/modules/mono/mono_gd/gd_mono_class.h
+++ b/modules/mono/mono_gd/gd_mono_class.h
@@ -90,6 +90,10 @@ class GDMonoClass {
 	Map<StringName, GDMonoProperty *> properties;
 	Vector<GDMonoProperty *> properties_list;
 
+	bool delegates_fetched;
+	Map<StringName, GDMonoClass *> delegates;
+	Vector<GDMonoClass *> delegates_list;
+
 	friend class GDMonoAssembly;
 	GDMonoClass(const StringName &p_namespace, const StringName &p_name, MonoClass *p_class, GDMonoAssembly *p_assembly);
 
@@ -132,6 +136,8 @@ public:
 
 	GDMonoProperty *get_property(const StringName &p_name);
 	const Vector<GDMonoProperty *> &get_all_properties();
+
+	const Vector<GDMonoClass *> &get_all_delegates();
 
 	~GDMonoClass();
 };

--- a/modules/mono/mono_gd/gd_mono_method.cpp
+++ b/modules/mono/mono_gd/gd_mono_method.cpp
@@ -229,6 +229,20 @@ String GDMonoMethod::get_signature_desc(bool p_namespaces) const {
 	return res;
 }
 
+void GDMonoMethod::get_parameter_names(Vector<StringName> &names) const {
+	const char *_names[params_count];
+	mono_method_get_param_names(mono_method, _names);
+	for (int i = 0; i < params_count; ++i) {
+		names.push_back(StringName(_names[i]));
+	}
+}
+
+void GDMonoMethod::get_parameter_types(Vector<ManagedType> &types) const {
+	for (int i = 0; i < param_types.size(); ++i) {
+		types.push_back(param_types[i]);
+	}
+}
+
 GDMonoMethod::GDMonoMethod(StringName p_name, MonoMethod *p_method) {
 	name = p_name;
 

--- a/modules/mono/mono_gd/gd_mono_method.h
+++ b/modules/mono/mono_gd/gd_mono_method.h
@@ -80,6 +80,9 @@ public:
 	String get_ret_type_full_name() const;
 	String get_signature_desc(bool p_namespaces = false) const;
 
+	void get_parameter_names(Vector<StringName> &names) const;
+	void get_parameter_types(Vector<ManagedType> &types) const;
+
 	GDMonoMethod(StringName p_name, MonoMethod *p_method);
 	~GDMonoMethod();
 };

--- a/modules/mono/mono_gd/gd_mono_utils.cpp
+++ b/modules/mono/mono_gd/gd_mono_utils.cpp
@@ -114,6 +114,7 @@ void MonoCache::clear_members() {
 	class_ExportAttribute = NULL;
 	field_ExportAttribute_hint = NULL;
 	field_ExportAttribute_hintString = NULL;
+	class_SignalAttribute = NULL;
 	class_ToolAttribute = NULL;
 	class_RemoteAttribute = NULL;
 	class_SyncAttribute = NULL;
@@ -201,6 +202,7 @@ void update_godot_api_cache() {
 	CACHE_CLASS_AND_CHECK(ExportAttribute, GODOT_API_CLASS(ExportAttribute));
 	CACHE_FIELD_AND_CHECK(ExportAttribute, hint, CACHED_CLASS(ExportAttribute)->get_field("hint"));
 	CACHE_FIELD_AND_CHECK(ExportAttribute, hintString, CACHED_CLASS(ExportAttribute)->get_field("hintString"));
+	CACHE_CLASS_AND_CHECK(SignalAttribute, GODOT_API_CLASS(SignalAttribute));
 	CACHE_CLASS_AND_CHECK(ToolAttribute, GODOT_API_CLASS(ToolAttribute));
 	CACHE_CLASS_AND_CHECK(RemoteAttribute, GODOT_API_CLASS(RemoteAttribute));
 	CACHE_CLASS_AND_CHECK(SyncAttribute, GODOT_API_CLASS(SyncAttribute));

--- a/modules/mono/mono_gd/gd_mono_utils.h
+++ b/modules/mono/mono_gd/gd_mono_utils.h
@@ -108,6 +108,7 @@ struct MonoCache {
 	GDMonoClass *class_ExportAttribute;
 	GDMonoField *field_ExportAttribute_hint;
 	GDMonoField *field_ExportAttribute_hintString;
+	GDMonoClass *class_SignalAttribute;
 	GDMonoClass *class_ToolAttribute;
 	GDMonoClass *class_RemoteAttribute;
 	GDMonoClass *class_SyncAttribute;


### PR DESCRIPTION
This is about #15004.  
Introduces a `[Signal]` attribute available for delegates. Use it like `signal` in GDScript.