### PR TITLE
Tileset Editor Improvement

### DIFF
--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -57,6 +57,8 @@ void TextureRegionEditor::_region_draw() {
 		base_tex = obj_styleBox->get_texture();
 	else if (atlas_tex.is_valid())
 		base_tex = atlas_tex->get_atlas();
+	else if (tile_set.is_valid() && selected_tile != -1)
+		base_tex = tile_set->tile_get_texture(selected_tile);
 	if (base_tex.is_null())
 		return;
 
@@ -281,6 +283,8 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 									r = obj_styleBox->get_region_rect();
 								else if (atlas_tex.is_valid())
 									r = atlas_tex->get_region();
+								else if (tile_set.is_valid() && selected_tile != -1)
+									r = tile_set->tile_get_region(selected_tile);
 								rect.expand_to(r.position);
 								rect.expand_to(r.position + r.size);
 							}
@@ -297,6 +301,9 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 							} else if (atlas_tex.is_valid()) {
 								undo_redo->add_do_method(atlas_tex.ptr(), "set_region", rect);
 								undo_redo->add_undo_method(atlas_tex.ptr(), "set_region", atlas_tex->get_region());
+							} else if (tile_set.is_valid() && selected_tile != -1) {
+								undo_redo->add_do_method(tile_set.ptr(), "tile_set_region", selected_tile, rect);
+								undo_redo->add_undo_method(tile_set.ptr(), "tile_set_region", selected_tile, tile_set->tile_get_region(selected_tile));
 							}
 							undo_redo->add_do_method(edit_draw, "update");
 							undo_redo->add_undo_method(edit_draw, "update");
@@ -319,6 +326,8 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 						rect_prev = obj_styleBox->get_region_rect();
 					else if (atlas_tex.is_valid())
 						rect_prev = atlas_tex->get_region();
+					else if (tile_set.is_valid() && selected_tile != -1)
+						rect_prev = tile_set->tile_get_region(selected_tile);
 
 					for (int i = 0; i < 8; i++) {
 						Vector2 tuv = endpoints[i];
@@ -362,6 +371,9 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 					} else if (obj_styleBox.is_valid()) {
 						undo_redo->add_do_method(obj_styleBox.ptr(), "set_region_rect", obj_styleBox->get_region_rect());
 						undo_redo->add_undo_method(obj_styleBox.ptr(), "set_region_rect", rect_prev);
+					} else if (tile_set.is_valid()) {
+						undo_redo->add_do_method(tile_set.ptr(), "tile_set_region", selected_tile, tile_set->tile_get_region(selected_tile));
+						undo_redo->add_undo_method(tile_set.ptr(), "tile_set_region", selected_tile, rect_prev);
 					}
 					drag_index = -1;
 				}
@@ -582,6 +594,8 @@ void TextureRegionEditor::apply_rect(const Rect2 &rect) {
 		obj_styleBox->set_region_rect(rect);
 	else if (atlas_tex.is_valid())
 		atlas_tex->set_region(rect);
+	else if (tile_set.is_valid() && selected_tile != -1)
+		tile_set->tile_set_region(selected_tile, rect);
 }
 
 void TextureRegionEditor::_notification(int p_what) {
@@ -596,11 +610,12 @@ void TextureRegionEditor::_notification(int p_what) {
 }
 
 void TextureRegionEditor::_node_removed(Object *p_obj) {
-	if (p_obj == node_sprite || p_obj == node_ninepatch || p_obj == obj_styleBox.ptr() || p_obj == atlas_tex.ptr()) {
+	if (p_obj == node_sprite || p_obj == node_ninepatch || p_obj == obj_styleBox.ptr() || p_obj == atlas_tex.ptr() || p_obj == tile_set.ptr()) {
 		node_ninepatch = NULL;
 		node_sprite = NULL;
 		obj_styleBox = Ref<StyleBox>(NULL);
 		atlas_tex = Ref<AtlasTexture>(NULL);
+		tile_set = Ref<TileSet>(NULL);
 		hide();
 	}
 }
@@ -632,6 +647,8 @@ void TextureRegionEditor::edit(Object *p_obj) {
 		obj_styleBox->remove_change_receptor(this);
 	if (atlas_tex.is_valid())
 		atlas_tex->remove_change_receptor(this);
+	if (tile_set.is_valid())
+		tile_set->remove_change_receptor(this);
 	if (p_obj) {
 		node_sprite = Object::cast_to<Sprite>(p_obj);
 		node_ninepatch = Object::cast_to<NinePatchRect>(p_obj);
@@ -639,6 +656,8 @@ void TextureRegionEditor::edit(Object *p_obj) {
 			obj_styleBox = Ref<StyleBoxTexture>(Object::cast_to<StyleBoxTexture>(p_obj));
 		if (Object::cast_to<AtlasTexture>(p_obj))
 			atlas_tex = Ref<AtlasTexture>(Object::cast_to<AtlasTexture>(p_obj));
+		if (Object::cast_to<TileSet>(p_obj))
+			tile_set = Ref<TileSet>(Object::cast_to<TileSet>(p_obj));
 		p_obj->add_change_receptor(this);
 		_edit_region();
 	} else {
@@ -646,6 +665,7 @@ void TextureRegionEditor::edit(Object *p_obj) {
 		node_ninepatch = NULL;
 		obj_styleBox = Ref<StyleBoxTexture>(NULL);
 		atlas_tex = Ref<AtlasTexture>(NULL);
+		tile_set = Ref<TileSet>(NULL);
 	}
 	edit_draw->update();
 }
@@ -668,6 +688,8 @@ void TextureRegionEditor::_edit_region() {
 		texture = obj_styleBox->get_texture();
 	else if (atlas_tex.is_valid())
 		texture = atlas_tex->get_atlas();
+	else if (tile_set.is_valid() && selected_tile != -1)
+		texture = tile_set->tile_get_texture(selected_tile);
 
 	if (texture.is_null()) {
 		return;
@@ -735,6 +757,8 @@ void TextureRegionEditor::_edit_region() {
 		rect = obj_styleBox->get_region_rect();
 	else if (atlas_tex.is_valid())
 		rect = atlas_tex->get_region();
+	else if (tile_set.is_valid() && selected_tile != -1)
+		rect = tile_set->tile_get_region(selected_tile);
 
 	edit_draw->update();
 }
@@ -753,6 +777,7 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	node_ninepatch = NULL;
 	obj_styleBox = Ref<StyleBoxTexture>(NULL);
 	atlas_tex = Ref<AtlasTexture>(NULL);
+	tile_set = Ref<TileSet>(NULL);
 	editor = p_editor;
 	undo_redo = editor->get_undo_redo();
 
@@ -903,11 +928,11 @@ bool TextureRegionEditorPlugin::handles(Object *p_object) const {
 
 void TextureRegionEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
-		region_button->show();
-		if (region_button->is_pressed())
+		texture_region_button->show();
+		if (texture_region_button->is_pressed())
 			region_editor->show();
 	} else {
-		region_button->hide();
+		texture_region_button->hide();
 		region_editor->edit(NULL);
 		region_editor->hide();
 	}
@@ -961,10 +986,10 @@ TextureRegionEditorPlugin::TextureRegionEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
 	region_editor = memnew(TextureRegionEditor(p_node));
 
-	region_button = p_node->add_bottom_panel_item(TTR("Texture Region"), region_editor);
-	region_button->set_tooltip(TTR("Texture Region Editor"));
+	texture_region_button = p_node->add_bottom_panel_item(TTR("Texture Region"), region_editor);
+	texture_region_button->set_tooltip(TTR("Texture Region Editor"));
 
 	region_editor->set_custom_minimum_size(Size2(0, 200));
 	region_editor->hide();
-	region_button->hide();
+	texture_region_button->hide();
 }

--- a/editor/plugins/texture_region_editor_plugin.h
+++ b/editor/plugins/texture_region_editor_plugin.h
@@ -38,6 +38,7 @@
 #include "scene/gui/nine_patch_rect.h"
 #include "scene/resources/style_box.h"
 #include "scene/resources/texture.h"
+#include "scene/resources/tile_set.h"
 
 /**
 	@author Mariano Suligoy
@@ -55,6 +56,8 @@ class TextureRegionEditor : public Control {
 	};
 
 	friend class TextureRegionEditorPlugin;
+	friend class TileSetEditor;
+	friend class TileSetEditorPlugin;
 	MenuButton *snap_mode_button;
 	TextureRect *icon_zoom;
 	ToolButton *zoom_in;
@@ -88,12 +91,14 @@ class TextureRegionEditor : public Control {
 	Sprite *node_sprite;
 	Ref<StyleBoxTexture> obj_styleBox;
 	Ref<AtlasTexture> atlas_tex;
+	Ref<TileSet> tile_set;
 
 	Rect2 rect;
 	Rect2 rect_prev;
 	float prev_margin;
 	int edited_margin;
 	List<Rect2> autoslice_cache;
+	int selected_tile;
 
 	bool drag;
 	bool creating;
@@ -134,7 +139,7 @@ public:
 class TextureRegionEditorPlugin : public EditorPlugin {
 	GDCLASS(TextureRegionEditorPlugin, EditorPlugin);
 
-	Button *region_button;
+	Button *texture_region_button;
 	TextureRegionEditor *region_editor;
 	EditorNode *editor;
 

--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -303,7 +303,7 @@ void TileMapEditor::_update_palette() {
 		if (tex.is_valid()) {
 			Rect2 region = tileset->tile_get_region(entries[i].id);
 
-			if (tileset->tile_get_is_autotile(entries[i].id)) {
+			if (tileset->tile_get_tile_mode(entries[i].id) == TileSet::AUTO_TILE) {
 				int spacing = tileset->autotile_get_spacing(entries[i].id);
 				region.size = tileset->autotile_get_size(entries[i].id);
 				region.position += (region.size + Vector2(spacing, spacing)) * tileset->autotile_get_icon_coordinate(entries[i].id);
@@ -506,7 +506,7 @@ void TileMapEditor::_draw_cell(int p_cell, const Point2i &p_point, bool p_flip_h
 	Vector2 tile_ofs = node->get_tileset()->tile_get_texture_offset(p_cell);
 
 	Rect2 r = node->get_tileset()->tile_get_region(p_cell);
-	if (node->get_tileset()->tile_get_is_autotile(p_cell)) {
+	if (node->get_tileset()->tile_get_tile_mode(p_cell) == TileSet::AUTO_TILE) {
 		int spacing = node->get_tileset()->autotile_get_spacing(p_cell);
 		r.size = node->get_tileset()->autotile_get_size(p_cell);
 		r.position += (r.size + Vector2(spacing, spacing)) * node->get_tileset()->autotile_get_icon_coordinate(p_cell);

--- a/editor/plugins/tile_set_editor_plugin.h
+++ b/editor/plugins/tile_set_editor_plugin.h
@@ -33,35 +33,38 @@
 
 #include "editor/editor_name_dialog.h"
 #include "editor/editor_node.h"
+#include "editor/plugins/texture_region_editor_plugin.h"
 #include "scene/2d/sprite.h"
 #include "scene/resources/convex_polygon_shape_2d.h"
 #include "scene/resources/tile_set.h"
 
-class AutotileEditorHelper;
-class AutotileEditor : public Control {
+class TileSetEditorHelper;
+
+class TileSetEditor : public Control {
 
 	friend class TileSetEditorPlugin;
-	friend class AutotileEditorHelper;
-	GDCLASS(AutotileEditor, Control);
+	friend class TextureRegionEditor;
+
+	GDCLASS(TileSetEditor, Control);
 
 	enum EditMode {
-		EDITMODE_ICON,
-		EDITMODE_BITMASK,
 		EDITMODE_COLLISION,
 		EDITMODE_OCCLUSION,
 		EDITMODE_NAVIGATION,
+		EDITMODE_BITMASK,
 		EDITMODE_PRIORITY,
+		EDITMODE_ICON,
 		EDITMODE_MAX
 	};
 
-	enum AutotileToolbars {
+	enum TileSetToolbar {
 		TOOLBAR_DUMMY,
 		TOOLBAR_BITMASK,
 		TOOLBAR_SHAPE,
 		TOOLBAR_MAX
 	};
 
-	enum AutotileTools {
+	enum TileSetTools {
 		TOOL_SELECT,
 		BITMASK_COPY,
 		BITMASK_PASTE,
@@ -78,12 +81,11 @@ class AutotileEditor : public Control {
 		TOOL_MAX
 	};
 
-	Ref<TileSet> tile_set;
+	Ref<TileSet> tileset;
+
 	Ref<ConvexPolygonShape2D> edited_collision_shape;
 	Ref<OccluderPolygon2D> edited_occlusion_shape;
 	Ref<NavigationPolygon> edited_navigation_shape;
-
-	EditorNode *editor;
 
 	int current_item_index;
 	Sprite *preview;
@@ -114,72 +116,14 @@ class AutotileEditor : public Control {
 	PoolVector2Array current_shape;
 	Map<Vector2, uint16_t> bitmask_map_copy;
 
-	Control *side_panel;
-	ItemList *autotile_list;
-	PropertyEditor *property_editor;
-	AutotileEditorHelper *helper;
-
-	AutotileEditor(EditorNode *p_editor);
-	~AutotileEditor();
-
-protected:
-	static void _bind_methods();
-	void _notification(int p_what);
-	virtual void _changed_callback(Object *p_changed, const char *p_prop);
-
-private:
-	void _on_autotile_selected(int p_index);
-	void _on_edit_mode_changed(int p_edit_mode);
-	void _on_workspace_draw();
-	void _on_workspace_input(const Ref<InputEvent> &p_ie);
-	void _on_tool_clicked(int p_tool);
-	void _on_priority_changed(float val);
-	void _on_grid_snap_toggled(bool p_val);
-	void _set_snap_step_x(float p_val);
-	void _set_snap_step_y(float p_val);
-	void _set_snap_off_x(float p_val);
-	void _set_snap_off_y(float p_val);
-	void _set_snap_sep_x(float p_val);
-	void _set_snap_sep_y(float p_val);
-
-	void draw_highlight_tile(Vector2 coord, const Vector<Vector2> &other_highlighted = Vector<Vector2>());
-	void draw_grid_snap();
-	void draw_polygon_shapes();
-	void close_shape(const Vector2 &shape_anchor);
-	void select_coord(const Vector2 &coord);
-	Vector2 snap_point(const Vector2 &point);
-
-	void edit(Object *p_node);
-	int get_current_tile();
-};
-
-class AutotileEditorHelper : public Object {
-
-	friend class AutotileEditor;
-	GDCLASS(AutotileEditorHelper, Object);
-
-	Ref<TileSet> tile_set;
-	AutotileEditor *autotile_editor;
-
-public:
-	void set_tileset(const Ref<TileSet> &p_tileset);
-
-protected:
-	bool _set(const StringName &p_name, const Variant &p_value);
-	bool _get(const StringName &p_name, Variant &r_ret) const;
-	void _get_property_list(List<PropertyInfo> *p_list) const;
-
-	AutotileEditorHelper(AutotileEditor *p_autotile_editor);
-};
-
-class TileSetEditor : public Control {
-
-	friend class TileSetEditorPlugin;
-	GDCLASS(TileSetEditor, Control);
-
-	Ref<TileSet> tileset;
-
 	EditorNode *editor;
+	TextureRegionEditor *texture_region_editor;
+	Control *bottom_panel;
+	Control *side_panel;
+	ItemList *tile_list;
+	PropertyEditor *property_editor;
+	TileSetEditorHelper *helper;
+
 	MenuButton *menu;
 	ConfirmationDialog *cd;
 	EditorNameDialog *nd;
@@ -203,12 +147,62 @@ class TileSetEditor : public Control {
 
 protected:
 	static void _bind_methods();
+	void _notification(int p_what);
+	virtual void _changed_callback(Object *p_changed, const char *p_prop);
 
 public:
 	void edit(const Ref<TileSet> &p_tileset);
 	static Error update_library_file(Node *p_base_scene, Ref<TileSet> ml, bool p_merge = true);
 
 	TileSetEditor(EditorNode *p_editor);
+
+private:
+	void _on_tile_list_selected(int p_index);
+	void _on_edit_mode_changed(int p_edit_mode);
+	void _on_workspace_draw();
+	void _on_workspace_input(const Ref<InputEvent> &p_ie);
+	void _on_tool_clicked(int p_tool);
+	void _on_priority_changed(float val);
+	void _on_grid_snap_toggled(bool p_val);
+	void _set_snap_step_x(float p_val);
+	void _set_snap_step_y(float p_val);
+	void _set_snap_off_x(float p_val);
+	void _set_snap_off_y(float p_val);
+	void _set_snap_sep_x(float p_val);
+	void _set_snap_sep_y(float p_val);
+
+	void initialize_bottom_editor();
+	void draw_highlight_tile(Vector2 coord, const Vector<Vector2> &other_highlighted = Vector<Vector2>());
+	void draw_grid_snap();
+	void draw_polygon_shapes();
+	void close_shape(const Vector2 &shape_anchor);
+	void select_coord(const Vector2 &coord);
+	Vector2 snap_point(const Vector2 &point);
+	void update_tile_list();
+	void update_tile_list_icon();
+	void update_workspace_tile_mode();
+
+	int get_current_tile();
+};
+
+class TileSetEditorHelper : public Object {
+
+	friend class TileSetEditor;
+	GDCLASS(TileSetEditorHelper, Object);
+
+	Ref<TileSet> tileset;
+	TileSetEditor *tileset_editor;
+	int selected_tile;
+
+public:
+	void set_tileset(const Ref<TileSet> &p_tileset);
+
+protected:
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
+
+	TileSetEditorHelper(TileSetEditor *p_tileset_editor);
 };
 
 class TileSetEditorPlugin : public EditorPlugin {
@@ -216,10 +210,10 @@ class TileSetEditorPlugin : public EditorPlugin {
 	GDCLASS(TileSetEditorPlugin, EditorPlugin);
 
 	TileSetEditor *tileset_editor;
-	AutotileEditor *autotile_editor;
 	EditorNode *editor;
 
-	ToolButton *autotile_button;
+	ToolButton *tileset_editor_button;
+	ToolButton *texture_region_button;
 
 public:
 	virtual String get_name() const { return "TileSet"; }

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -353,7 +353,7 @@ void TileMap::_update_dirty_quadrants() {
 			}
 
 			Rect2 r = tile_set->tile_get_region(c.id);
-			if (tile_set->tile_get_is_autotile(c.id)) {
+			if (tile_set->tile_get_tile_mode(c.id) == TileSet::AUTO_TILE) {
 				int spacing = tile_set->autotile_get_spacing(c.id);
 				r.size = tile_set->autotile_get_size(c.id);
 				r.position += (r.size + Vector2(spacing, spacing)) * Vector2(c.autotile_coord_x, c.autotile_coord_y);
@@ -447,7 +447,7 @@ void TileMap::_update_dirty_quadrants() {
 			for (int i = 0; i < shapes.size(); i++) {
 				Ref<Shape2D> shape = shapes[i].shape;
 				if (shape.is_valid()) {
-					if (!tile_set->tile_get_is_autotile(c.id) || (shapes[i].autotile_coord.x == c.autotile_coord_x && shapes[i].autotile_coord.y == c.autotile_coord_y)) {
+					if (tile_set->tile_get_tile_mode(c.id) == TileSet::SINGLE_TILE || (shapes[i].autotile_coord.x == c.autotile_coord_x && shapes[i].autotile_coord.y == c.autotile_coord_y)) {
 						Transform2D xform;
 						xform.set_origin(offset.floor());
 
@@ -474,7 +474,7 @@ void TileMap::_update_dirty_quadrants() {
 			if (navigation) {
 				Ref<NavigationPolygon> navpoly;
 				Vector2 npoly_ofs;
-				if (tile_set->tile_get_is_autotile(c.id)) {
+				if (tile_set->tile_get_tile_mode(c.id) == TileSet::AUTO_TILE) {
 					navpoly = tile_set->autotile_get_navigation_polygon(c.id, Vector2(c.autotile_coord_x, c.autotile_coord_y));
 					npoly_ofs = Vector2();
 				} else {
@@ -497,7 +497,7 @@ void TileMap::_update_dirty_quadrants() {
 			}
 
 			Ref<OccluderPolygon2D> occluder;
-			if (tile_set->tile_get_is_autotile(c.id)) {
+			if (tile_set->tile_get_tile_mode(c.id) == TileSet::AUTO_TILE) {
 				occluder = tile_set->autotile_get_light_occluder(c.id, Vector2(c.autotile_coord_x, c.autotile_coord_y));
 			} else {
 				occluder = tile_set->tile_get_light_occluder(c.id);
@@ -766,7 +766,7 @@ void TileMap::update_cell_bitmask(int p_x, int p_y) {
 	Map<PosKey, Cell>::Element *E = tile_map.find(p);
 	if (E != NULL) {
 		int id = get_cell(p_x, p_y);
-		if (tile_set->tile_get_is_autotile(id)) {
+		if (tile_set->tile_get_tile_mode(id) == TileSet::AUTO_TILE) {
 			uint16_t mask = 0;
 			if (tile_set->autotile_get_bitmask_mode(id) == TileSet::BITMASK_2X2) {
 				if (tile_set->is_tile_bound(id, get_cell(p_x - 1, p_y - 1)) && tile_set->is_tile_bound(id, get_cell(p_x, p_y - 1)) && tile_set->is_tile_bound(id, get_cell(p_x - 1, p_y))) {

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -57,8 +57,8 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 		tile_set_modulate(id, p_value);
 	else if (what == "region")
 		tile_set_region(id, p_value);
-	else if (what == "is_autotile")
-		tile_set_is_autotile(id, p_value);
+	else if (what == "tile_mode")
+		tile_set_tile_mode(id, (TileMode)((int)p_value));
 	else if (what.left(9) == "autotile/") {
 		what = what.right(9);
 		if (what == "bitmask_mode")
@@ -174,8 +174,8 @@ bool TileSet::_get(const StringName &p_name, Variant &r_ret) const {
 		r_ret = tile_get_modulate(id);
 	else if (what == "region")
 		r_ret = tile_get_region(id);
-	else if (what == "is_autotile")
-		r_ret = tile_get_is_autotile(id);
+	else if (what == "tile_mode")
+		r_ret = tile_get_tile_mode(id);
 	else if (what.left(9) == "autotile/") {
 		what = what.right(9);
 		if (what == "bitmask_mode")
@@ -258,13 +258,13 @@ void TileSet::_get_property_list(List<PropertyInfo> *p_list) const {
 		p_list->push_back(PropertyInfo(Variant::OBJECT, pre + "material", PROPERTY_HINT_RESOURCE_TYPE, "ShaderMaterial"));
 		p_list->push_back(PropertyInfo(Variant::COLOR, pre + "modulate"));
 		p_list->push_back(PropertyInfo(Variant::RECT2, pre + "region"));
-		p_list->push_back(PropertyInfo(Variant::BOOL, pre + "is_autotile", PROPERTY_HINT_NONE, ""));
-		if (tile_get_is_autotile(id)) {
+		p_list->push_back(PropertyInfo(Variant::INT, pre + "tile_mode", PROPERTY_HINT_ENUM, "SINGLE_TILE,AUTO_TILE"));
+		if (tile_get_tile_mode(id) == AUTO_TILE) {
 			p_list->push_back(PropertyInfo(Variant::INT, pre + "autotile/bitmask_mode", PROPERTY_HINT_ENUM, "2X2,3X3", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
+			p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "autotile/bitmask_flags", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
 			p_list->push_back(PropertyInfo(Variant::VECTOR2, pre + "autotile/icon_coordinate", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
 			p_list->push_back(PropertyInfo(Variant::VECTOR2, pre + "autotile/tile_size", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
 			p_list->push_back(PropertyInfo(Variant::INT, pre + "autotile/spacing", PROPERTY_HINT_RANGE, "0,256,1", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
-			p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "autotile/bitmask_flags", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
 			p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "autotile/occluder_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
 			p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "autotile/navpoly_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
 			p_list->push_back(PropertyInfo(Variant::ARRAY, pre + "autotile/priority_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
@@ -282,7 +282,6 @@ void TileSet::_get_property_list(List<PropertyInfo> *p_list) const {
 }
 
 void TileSet::create_tile(int p_id) {
-
 	ERR_FAIL_COND(tile_map.has(p_id));
 	tile_map[p_id] = TileData();
 	tile_map[p_id].autotile_data = AutotileData();
@@ -291,7 +290,6 @@ void TileSet::create_tile(int p_id) {
 }
 
 void TileSet::autotile_set_bitmask_mode(int p_id, BitmaskMode p_mode) {
-
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	tile_map[p_id].autotile_data.bitmask_mode = p_mode;
 	_change_notify("");
@@ -375,6 +373,7 @@ void TileSet::tile_set_region(int p_id, const Rect2 &p_region) {
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	tile_map[p_id].region = p_region;
 	emit_changed();
+	_change_notify("region");
 }
 
 Rect2 TileSet::tile_get_region(int p_id) const {
@@ -383,18 +382,17 @@ Rect2 TileSet::tile_get_region(int p_id) const {
 	return tile_map[p_id].region;
 }
 
-void TileSet::tile_set_is_autotile(int p_id, bool p_is_autotile) {
-
+void TileSet::tile_set_tile_mode(int p_id, TileMode p_tile_mode) {
 	ERR_FAIL_COND(!tile_map.has(p_id));
-	tile_map[p_id].is_autotile = p_is_autotile;
+	tile_map[p_id].tile_mode = p_tile_mode;
 	emit_changed();
-	_change_notify("is_autotile");
+	_change_notify("tile_mode");
 }
 
-bool TileSet::tile_get_is_autotile(int p_id) const {
+TileSet::TileMode TileSet::tile_get_tile_mode(int p_id) const {
 
-	ERR_FAIL_COND_V(!tile_map.has(p_id), false);
-	return tile_map[p_id].is_autotile;
+	ERR_FAIL_COND_V(!tile_map.has(p_id), SINGLE_TILE);
+	return tile_map[p_id].tile_mode;
 }
 
 void TileSet::autotile_set_icon_coordinate(int p_id, Vector2 coord) {
@@ -534,6 +532,7 @@ void TileSet::tile_set_name(int p_id, const String &p_name) {
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	tile_map[p_id].name = p_name;
 	emit_changed();
+	_change_notify("name");
 }
 
 String TileSet::tile_get_name(int p_id) const {

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -71,6 +71,12 @@ public:
 		BIND_BOTTOMRIGHT = 256
 	};
 
+	enum TileMode {
+		SINGLE_TILE,
+		AUTO_TILE,
+		ANIMATED_TILE
+	};
+
 	struct AutotileData {
 		BitmaskMode bitmask_mode;
 		int spacing;
@@ -84,6 +90,7 @@ public:
 		// Default size to prevent invalid value
 		explicit AutotileData() :
 				size(64, 64),
+				spacing(0),
 				icon_coord(0, 0) {
 			bitmask_mode = BITMASK_2X2;
 		}
@@ -104,13 +111,13 @@ private:
 		Ref<NavigationPolygon> navigation_polygon;
 		Ref<ShaderMaterial> material;
 		Color modulate;
-		bool is_autotile;
+		TileMode tile_mode;
 		AutotileData autotile_data;
 
 		// Default modulate for back-compat
 		explicit TileData() :
-				modulate(1, 1, 1),
-				is_autotile(false) {}
+				tile_mode(SINGLE_TILE),
+				modulate(1, 1, 1) {}
 	};
 
 	Map<int, TileData> tile_map;
@@ -146,8 +153,8 @@ public:
 	void tile_set_region(int p_id, const Rect2 &p_region);
 	Rect2 tile_get_region(int p_id) const;
 
-	void tile_set_is_autotile(int p_id, bool p_is_autotile);
-	bool tile_get_is_autotile(int p_id) const;
+	void tile_set_tile_mode(int p_id, TileMode p_tile_mode);
+	TileMode tile_get_tile_mode(int p_id) const;
 
 	void autotile_set_icon_coordinate(int p_id, Vector2 coord);
 	Vector2 autotile_get_icon_coordinate(int p_id) const;


### PR DESCRIPTION
![texture_region_editor](https://user-images.githubusercontent.com/8519218/36340367-0eb32e9a-140e-11e8-8007-02aadee0f8f0.gif)
![single_tile](https://user-images.githubusercontent.com/8519218/36340368-11f527a2-140e-11e8-842a-2a4e9e49e612.gif)
Changes :
- Allow to access Texture Region Editor
- Allow editing singletile collision, occlusion, and navigation
- Refactoring the AutoTile

Minor :
- Change order editmode to make consistency between autotile and singletile
![image](https://user-images.githubusercontent.com/8519218/36340389-692b87aa-140e-11e8-9c4c-ef2ce833e513.png)
- Update tile list when adding and removing tile
- Better handling switching new shape polygon to select tool
- Adding tile automatically set the name as last_unused_id

