### PR TITLE
Fix #16773 (Rename "Install" to "Download" in AssetLib)

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -308,7 +308,7 @@ EditorAssetLibraryItemDescription::EditorAssetLibraryItemDescription() {
 	preview_hb->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	previews->add_child(preview_hb);
-	get_ok()->set_text(TTR("Install"));
+	get_ok()->set_text(TTR("Download"));
 	get_cancel()->set_text(TTR("Close"));
 }
 ///////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #16773.
Renames "Install" to "Download" in Asset Library.

![Screenshot after rename](https://user-images.githubusercontent.com/19972511/36341184-6096b6ea-13fb-11e8-94da-183336c9bf91.png)
