### PR TITLE
Clean up some bad words from code comments

### DIFF
--- a/core/io/file_access_network.cpp
+++ b/core/io/file_access_network.cpp
@@ -418,8 +418,6 @@ int FileAccessNetwork::get_buffer(uint8_t *p_dst, int p_length) const {
 		if (page != last_page) {
 			buffer_mutex->lock();
 			if (pages[page].buffer.empty()) {
-				//fuck
-
 				waiting_on_page = page;
 				for (int j = 0; j < read_ahead; j++) {
 

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1124,7 +1124,7 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 		DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 		da->remove(p_path + ".depren");
 		memdelete(da);
-		//fuck it, use the old approach;
+		//use the old approach
 
 		WARN_PRINT(("This file is old, so it can't refactor dependencies, opening and resaving: " + p_path).utf8().get_data());
 

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -296,7 +296,7 @@ Error OS_Unix::execute(const String &p_path, const List<String> &p_arguments, bo
 
 		Vector<char *> args;
 		for (int i = 0; i < cs.size(); i++)
-			args.push_back((char *)cs[i].get_data()); // shitty C cast
+			args.push_back((char *)cs[i].get_data());
 		args.push_back(0);
 
 		execvp(p_path.utf8().get_data(), &args[0]);

--- a/editor/animation_editor.cpp
+++ b/editor/animation_editor.cpp
@@ -3362,7 +3362,7 @@ int AnimationKeyEditor::_confirm_insert(InsertData p_id, int p_last_track) {
 			//wants a new tack
 
 			{
-				//shitty hack
+				//hack
 				NodePath np;
 				animation->add_track(p_id.type);
 				animation->track_set_path(animation->get_track_count() - 1, p_id.path);

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -253,7 +253,6 @@ void EditorResourcePreview::_thread() {
 							img.instance();
 
 							if (img->load(cache_base + ".png") != OK) {
-								//well fuck
 								cache_valid = false;
 							} else {
 

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -398,8 +398,6 @@ void SpriteFramesEditor::_animation_add() {
 	animations->grab_focus();
 }
 void SpriteFramesEditor::_animation_remove() {
-
-	//fuck everything
 	if (updating)
 		return;
 

--- a/scene/2d/line_builder.cpp
+++ b/scene/2d/line_builder.cpp
@@ -347,7 +347,7 @@ void LineBuilder::build() {
 			}
 
 			if (intersection_result != SEGMENT_INTERSECT)
-				// In this case the joint is too fucked up to be re-used,
+				// In this case the joint is too corrputed to be re-used,
 				// start again the strip with fallback points
 				strip_begin(pos_up0, pos_down0, color1, uvx1);
 		}

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -372,9 +372,7 @@ bool RigidBody2D::_test_motion(const Vector2 &p_motion, float p_margin, const Re
 
 void RigidBody2D::_direct_state_changed(Object *p_state) {
 
-//eh.. fuck
 #ifdef DEBUG_ENABLED
-
 	state = Object::cast_to<Physics2DDirectBodyState>(p_state);
 #else
 	state = (Physics2DDirectBodyState *)p_state; //trust it

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -370,9 +370,7 @@ struct _RigidBodyInOut {
 
 void RigidBody::_direct_state_changed(Object *p_state) {
 
-//eh.. fuck
 #ifdef DEBUG_ENABLED
-
 	state = Object::cast_to<PhysicsDirectBodyState>(p_state);
 #else
 	state = (PhysicsDirectBodyState *)p_state; //trust it

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2384,7 +2384,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 
 	if (mm.is_valid()) {
 
-		if (cache.font.is_null()) // avoid a strange case that may fuckup stuff
+		if (cache.font.is_null()) // avoid a strange case that may corrupt stuff
 			update_cache();
 
 		Ref<StyleBox> bg = cache.bg;
@@ -2483,7 +2483,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 	Ref<InputEventMouseButton> b = p_event;
 
 	if (b.is_valid()) {
-		if (cache.font.is_null()) // avoid a strange case that may fuckup stuff
+		if (cache.font.is_null()) // avoid a strange case that may corrupt stuff
 			update_cache();
 
 		if (!b->is_pressed()) {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -364,7 +364,7 @@ public:
 
 	void queue_delete();
 
-	//shitty hacks for speed
+	//hacks for speed
 	static void set_human_readable_collision_renaming(bool p_enabled);
 	static void init_node_hrcr();
 

--- a/servers/audio/audio_filter_sw.cpp
+++ b/servers/audio/audio_filter_sw.cpp
@@ -58,8 +58,7 @@ void AudioFilterSW::prepare_coefficients(Coeffs *p_coeffs) {
 	int sr_limit = (sampling_rate / 2) + 512;
 
 	double final_cutoff = (cutoff > sr_limit) ? sr_limit : cutoff;
-	if (final_cutoff < 1) //avoid crapness
-		final_cutoff = 1; //don't allow less than this
+	if (final_cutoff < 1) final_cutoff = 1; //don't allow less than this
 
 	double omega = 2.0 * Math_PI * final_cutoff / sampling_rate;
 

--- a/servers/physics/shape_sw.cpp
+++ b/servers/physics/shape_sw.cpp
@@ -672,7 +672,7 @@ Vector3 CapsuleShapeSW::get_closest_point_to(const Vector3 &p_point) const {
 
 Vector3 CapsuleShapeSW::get_moment_of_inertia(real_t p_mass) const {
 
-	// use crappy AABB approximation
+	// use bad AABB approximation
 	Vector3 extents = get_aabb().size * 0.5;
 
 	return Vector3(
@@ -943,7 +943,7 @@ Vector3 ConvexPolygonShapeSW::get_closest_point_to(const Vector3 &p_point) const
 
 Vector3 ConvexPolygonShapeSW::get_moment_of_inertia(real_t p_mass) const {
 
-	// use crappy AABB approximation
+	// use bad AABB approximation
 	Vector3 extents = get_aabb().size * 0.5;
 
 	return Vector3(
@@ -1331,7 +1331,7 @@ void ConcavePolygonShapeSW::cull(const AABB &p_local_aabb, Callback p_callback, 
 
 Vector3 ConcavePolygonShapeSW::get_moment_of_inertia(real_t p_mass) const {
 
-	// use crappy AABB approximation
+	// use bad AABB approximation
 	Vector3 extents = get_aabb().size * 0.5;
 
 	return Vector3(
@@ -1594,7 +1594,7 @@ void HeightMapShapeSW::cull(const AABB &p_local_aabb, Callback p_callback, void 
 
 Vector3 HeightMapShapeSW::get_moment_of_inertia(real_t p_mass) const {
 
-	// use crappy AABB approximation
+	// use bad AABB approximation
 	Vector3 extents = get_aabb().size * 0.5;
 
 	return Vector3(

--- a/servers/physics_2d/shape_2d_sw.cpp
+++ b/servers/physics_2d/shape_2d_sw.cpp
@@ -589,7 +589,7 @@ bool ConvexPolygonShape2DSW::intersect_segment(const Vector2 &p_begin, const Vec
 
 	for (int i = 0; i < point_count; i++) {
 
-		//hmm crap.. no can do..
+		//hmm.. no can do..
 		/*
 		if (d.dot(points[i].normal)>=0)
 			continue;


### PR DESCRIPTION
This cleans up some bad words from code comments.
Stuff in `thirdparty` was not touched.