### PR TITLE
Makes the tilemap editor aware of tile modulate.

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -166,6 +166,20 @@ Color ItemList::get_item_custom_fg_color(int p_idx) const {
 	return items[p_idx].custom_fg;
 }
 
+void ItemList::set_item_icon_modulate(int p_idx, const Color &p_icon_modulate) {
+
+	ERR_FAIL_INDEX(p_idx, items.size());
+
+	items[p_idx].icon_modulate = p_icon_modulate;
+}
+
+Color ItemList::get_item_icon_modulate(int p_idx) const {
+
+	ERR_FAIL_INDEX_V(p_idx, items.size(), Color());
+
+	return items[p_idx].icon_modulate;
+}
+
 void ItemList::set_item_tag_icon(int p_idx, const Ref<Texture> &p_tag_icon) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
@@ -1035,7 +1049,7 @@ void ItemList::_notification(int p_what) {
 					draw_rect.size = adj.size;
 				}
 
-				Color modulate = Color(1, 1, 1, 1);
+				Color modulate = items[i].icon_modulate != Color() ? items[i].icon_modulate : Color(1, 1, 1, 1);
 				if (items[i].disabled)
 					modulate.a *= 0.5;
 
@@ -1370,6 +1384,9 @@ void ItemList::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_item_custom_bg_color", "idx", "custom_bg_color"), &ItemList::set_item_custom_bg_color);
 	ClassDB::bind_method(D_METHOD("get_item_custom_bg_color", "idx"), &ItemList::get_item_custom_bg_color);
+
+	ClassDB::bind_method(D_METHOD("set_item_icon_modulate", "idx", "icon_modulate"), &ItemList::set_item_icon_modulate);
+	ClassDB::bind_method(D_METHOD("get_item_icon_modulate", "idx"), &ItemList::get_item_icon_modulate);
 
 	ClassDB::bind_method(D_METHOD("set_item_tooltip_enabled", "idx", "enable"), &ItemList::set_item_tooltip_enabled);
 	ClassDB::bind_method(D_METHOD("is_item_tooltip_enabled", "idx"), &ItemList::is_item_tooltip_enabled);

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -64,6 +64,7 @@ private:
 		String tooltip;
 		Color custom_fg;
 		Color custom_bg;
+		Color icon_modulate;
 
 		Rect2 rect_cache;
 		Rect2 min_rect_cache;
@@ -158,6 +159,9 @@ public:
 
 	void set_item_custom_fg_color(int p_idx, const Color &p_custom_fg_color);
 	Color get_item_custom_fg_color(int p_idx) const;
+
+	void set_item_icon_modulate(int p_idx, const Color &p_icon_modulate);
+	Color get_item_icon_modulate(int p_idx) const;
 
 	void select(int p_idx, bool p_single = true);
 	void unselect(int p_idx);


### PR DESCRIPTION
So now the previews won't render without modulate applied.

![image](https://user-images.githubusercontent.com/8107459/36341283-1ee37558-13ec-11e8-9016-e892dc36b765.png)
