### PR TITLE
handle shift space

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3133,7 +3133,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 
 		if (!scancode_handled && !k->get_command()) { //for German kbds
 
-			if (k->get_unicode() >= 32) {
+			if (k->get_unicode() >= 32 && !(k->get_scancode() == KEY_SPACE && k->get_shift())) {
 
 				if (readonly)
 					return;


### PR DESCRIPTION
Fixes #16264.

This seems to be more like a workaround. Shortcuts are handles in PopupMenu and kb input in TextEdit. The problem is that TextEdit handles input event BEFORE PopupMenu. I didn't find a way to fix this, someone more experienced may do it.