### PR TITLE
HTML5 HTTPClient fixes

### DIFF
--- a/platform/javascript/http_client.h.inc
+++ b/platform/javascript/http_client.h.inc
@@ -46,3 +46,8 @@ String password;
 int polled_response_code;
 String polled_response_header;
 PoolByteArray polled_response;
+
+#ifdef DEBUG_ENABLED
+bool has_polled;
+uint64_t last_polling_frame;
+#endif

--- a/platform/javascript/http_client_javascript.cpp
+++ b/platform/javascript/http_client_javascript.cpp
@@ -193,8 +193,6 @@ PoolByteArray HTTPClient::read_response_body_chunk() {
 	if (response_read_offset == polled_response.size()) {
 		status = STATUS_CONNECTED;
 		polled_response.resize(0);
-		polled_response_code = 0;
-		polled_response_header = String();
 		godot_xhr_reset(xhr_id);
 	}
 

--- a/platform/javascript/http_client_javascript.cpp
+++ b/platform/javascript/http_client_javascript.cpp
@@ -81,6 +81,8 @@ Ref<StreamPeer> HTTPClient::get_connection() const {
 Error HTTPClient::prepare_request(Method p_method, const String &p_url, const Vector<String> &p_headers) {
 
 	ERR_FAIL_INDEX_V(p_method, METHOD_MAX, ERR_INVALID_PARAMETER);
+	ERR_EXPLAIN("HTTP methods TRACE and CONNECT are not supported for the HTML5 platform");
+	ERR_FAIL_COND_V(p_method == METHOD_TRACE || p_method == METHOD_CONNECT, ERR_UNAVAILABLE);
 	ERR_FAIL_COND_V(status != STATUS_CONNECTED, ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(host.empty(), ERR_UNCONFIGURED);
 	ERR_FAIL_COND_V(port < 0, ERR_UNCONFIGURED);

--- a/platform/javascript/http_client_javascript.cpp
+++ b/platform/javascript/http_client_javascript.cpp
@@ -158,7 +158,7 @@ int HTTPClient::get_response_code() const {
 
 Error HTTPClient::get_response_headers(List<String> *r_response) {
 
-	if (!polled_response_header.size())
+	if (polled_response_header.empty())
 		return ERR_INVALID_PARAMETER;
 
 	Vector<String> header_lines = polled_response_header.split("\r\n", false);
@@ -250,9 +250,11 @@ Error HTTPClient::poll() {
 
 			PoolByteArray bytes;
 			int len = godot_xhr_get_response_headers_length(xhr_id);
-			bytes.resize(len);
+			bytes.resize(len + 1);
+
 			PoolByteArray::Write write = bytes.write();
 			godot_xhr_get_response_headers(xhr_id, reinterpret_cast<char *>(write.ptr()), len);
+			write[len] = 0;
 			write = PoolByteArray::Write();
 
 			PoolByteArray::Read read = bytes.read();

--- a/platform/javascript/http_client_javascript.cpp
+++ b/platform/javascript/http_client_javascript.cpp
@@ -240,6 +240,21 @@ Error HTTPClient::poll() {
 			return ERR_CONNECTION_ERROR;
 
 		case STATUS_REQUESTING:
+
+#ifdef DEBUG_ENABLED
+			if (!has_polled) {
+				has_polled = true;
+			} else {
+				// forcing synchronous requests is not possible on the web
+				if (last_polling_frame == Engine::get_singleton()->get_idle_frames()) {
+					WARN_PRINT("HTTPClient polled multiple times in one frame, "
+							   "but request cannot progress more than once per "
+							   "frame on the HTML5 platform.");
+				}
+			}
+			last_polling_frame = Engine::get_singleton()->get_idle_frames();
+#endif
+
 			polled_response_code = godot_xhr_get_status(xhr_id);
 			if (godot_xhr_get_ready_state(xhr_id) != XHR_READY_STATE_DONE) {
 				return OK;
@@ -280,6 +295,10 @@ HTTPClient::HTTPClient() {
 	port = -1;
 	use_tls = false;
 	polled_response_code = 0;
+#ifdef DEBUG_ENABLED
+	has_polled = false;
+	last_polling_frame = 0;
+#endif
 }
 
 HTTPClient::~HTTPClient() {


### PR DESCRIPTION
- Fixed a bug causing invalid connection errors
- Fixed occasionally missing response headers 
- HTTP methods `CONNECT` and `TRACE` are disabled in HTML5
- Print a warning when polling multiple times in one frame. This is usually done with `OS.delay_msec`, which can't work in HTML5 export
- Response headers are no longer flushed after retrieving the response body