### PR TITLE
Adds some missing shader built-in functions

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -1374,6 +1374,17 @@ const ShaderLanguage::BuiltinFuncDef ShaderLanguage::builtin_func_defs[] = {
 	{ "bvec4", TYPE_BVEC4, { TYPE_VEC4, TYPE_VOID } },
 
 	//builtins - trigonometry
+
+	{ "radians", TYPE_FLOAT, { TYPE_FLOAT, TYPE_VOID } },
+	{ "radians", TYPE_VEC2, { TYPE_VEC2, TYPE_VOID } },
+	{ "radians", TYPE_VEC3, { TYPE_VEC3, TYPE_VOID } },
+	{ "radians", TYPE_VEC4, { TYPE_VEC4, TYPE_VOID } },
+
+	{ "degrees", TYPE_FLOAT, { TYPE_FLOAT, TYPE_VOID } },
+	{ "degrees", TYPE_VEC2, { TYPE_VEC2, TYPE_VOID } },
+	{ "degrees", TYPE_VEC3, { TYPE_VEC3, TYPE_VOID } },
+	{ "degrees", TYPE_VEC4, { TYPE_VEC4, TYPE_VOID } },
+
 	{ "sin", TYPE_FLOAT, { TYPE_FLOAT, TYPE_VOID } },
 	{ "sin", TYPE_VEC2, { TYPE_VEC2, TYPE_VOID } },
 	{ "sin", TYPE_VEC3, { TYPE_VEC3, TYPE_VOID } },
@@ -1423,6 +1434,21 @@ const ShaderLanguage::BuiltinFuncDef ShaderLanguage::builtin_func_defs[] = {
 	{ "tanh", TYPE_VEC3, { TYPE_VEC3, TYPE_VOID } },
 	{ "tanh", TYPE_VEC4, { TYPE_VEC4, TYPE_VOID } },
 
+	{ "asinh", TYPE_FLOAT, { TYPE_FLOAT, TYPE_VOID } },
+	{ "asinh", TYPE_VEC2, { TYPE_VEC2, TYPE_VOID } },
+	{ "asinh", TYPE_VEC3, { TYPE_VEC3, TYPE_VOID } },
+	{ "asinh", TYPE_VEC4, { TYPE_VEC4, TYPE_VOID } },
+
+	{ "acosh", TYPE_FLOAT, { TYPE_FLOAT, TYPE_VOID } },
+	{ "acosh", TYPE_VEC2, { TYPE_VEC2, TYPE_VOID } },
+	{ "acosh", TYPE_VEC3, { TYPE_VEC3, TYPE_VOID } },
+	{ "acosh", TYPE_VEC4, { TYPE_VEC4, TYPE_VOID } },
+
+	{ "atanh", TYPE_FLOAT, { TYPE_FLOAT, TYPE_VOID } },
+	{ "atanh", TYPE_VEC2, { TYPE_VEC2, TYPE_VOID } },
+	{ "atanh", TYPE_VEC3, { TYPE_VEC3, TYPE_VOID } },
+	{ "atanh", TYPE_VEC4, { TYPE_VEC4, TYPE_VOID } },
+
 	//builtins - exponential
 	{ "pow", TYPE_FLOAT, { TYPE_FLOAT, TYPE_FLOAT, TYPE_VOID } },
 	{ "pow", TYPE_VEC2, { TYPE_VEC2, TYPE_VEC2, TYPE_VOID } },
@@ -1436,6 +1462,14 @@ const ShaderLanguage::BuiltinFuncDef ShaderLanguage::builtin_func_defs[] = {
 	{ "log", TYPE_VEC2, { TYPE_VEC2, TYPE_VOID } },
 	{ "log", TYPE_VEC3, { TYPE_VEC3, TYPE_VOID } },
 	{ "log", TYPE_VEC4, { TYPE_VEC4, TYPE_VOID } },
+	{ "exp2", TYPE_FLOAT, { TYPE_FLOAT, TYPE_VOID } },
+	{ "exp2", TYPE_VEC2, { TYPE_VEC2, TYPE_VOID } },
+	{ "exp2", TYPE_VEC3, { TYPE_VEC3, TYPE_VOID } },
+	{ "exp2", TYPE_VEC4, { TYPE_VEC4, TYPE_VOID } },
+	{ "log2", TYPE_FLOAT, { TYPE_FLOAT, TYPE_VOID } },
+	{ "log2", TYPE_VEC2, { TYPE_VEC2, TYPE_VOID } },
+	{ "log2", TYPE_VEC3, { TYPE_VEC3, TYPE_VOID } },
+	{ "log2", TYPE_VEC4, { TYPE_VEC4, TYPE_VOID } },
 	{ "sqrt", TYPE_FLOAT, { TYPE_FLOAT, TYPE_VOID } },
 	{ "sqrt", TYPE_VEC2, { TYPE_VEC2, TYPE_VOID } },
 	{ "sqrt", TYPE_VEC3, { TYPE_VEC3, TYPE_VOID } },
@@ -1482,6 +1516,10 @@ const ShaderLanguage::BuiltinFuncDef ShaderLanguage::builtin_func_defs[] = {
 	{ "round", TYPE_VEC2, { TYPE_VEC2, TYPE_VOID } },
 	{ "round", TYPE_VEC3, { TYPE_VEC3, TYPE_VOID } },
 	{ "round", TYPE_VEC4, { TYPE_VEC4, TYPE_VOID } },
+	{ "roundEven", TYPE_FLOAT, { TYPE_FLOAT, TYPE_VOID } },
+	{ "roundEven", TYPE_VEC2, { TYPE_VEC2, TYPE_VOID } },
+	{ "roundEven", TYPE_VEC3, { TYPE_VEC3, TYPE_VOID } },
+	{ "roundEven", TYPE_VEC4, { TYPE_VEC4, TYPE_VOID } },
 	{ "ceil", TYPE_FLOAT, { TYPE_FLOAT, TYPE_VOID } },
 	{ "ceil", TYPE_VEC2, { TYPE_VEC2, TYPE_VOID } },
 	{ "ceil", TYPE_VEC3, { TYPE_VEC3, TYPE_VOID } },


### PR DESCRIPTION
I found several built-in functions in GLSL which looks interesting but missed in Godot.
**radians** and **degrees** - both can be useful in future Shader Visual editor to convert angles
**asinh**,**acosh**,**atanh** -  these arc-hyperbolic trigonometric functions can do various graphical effects like their fellows
**roundEven** - I think is also can be useful for achive some effects
**exp2** and **log2** -  I dont know how to use them yet.. but why not ?
All these functions exist both in GLSL3.3 and GLES3.