### PR TITLE
Implemented better way to map inputs in godot

### DIFF
--- a/core/input_map.cpp
+++ b/core/input_map.cpp
@@ -208,7 +208,7 @@ void InputMap::load_from_globals() {
 		if (!pi.name.begins_with("input/"))
 			continue;
 
-		String name = pi.name.substr(pi.name.find("/") + 1, pi.name.length());
+		String name = pi.name.get_slice("/", 1);
 
 		add_action(name);
 

--- a/core/input_map.cpp
+++ b/core/input_map.cpp
@@ -165,20 +165,30 @@ const List<Ref<InputEvent> > *InputMap::get_action_list(const StringName &p_acti
 	return &E->get().inputs;
 }
 
-bool InputMap::event_is_action(const Ref<InputEvent> &p_event, const StringName &p_action) const {
+Ref<InputEvent> InputMap::event_get_input_event_if_action(const Ref<InputEvent> &p_event, const StringName &p_action) const {
 
 	Map<StringName, Action>::Element *E = input_map.find(p_action);
 	if (!E) {
 		ERR_EXPLAIN("Request for nonexistent InputMap action: " + String(p_action));
-		ERR_FAIL_COND_V(!E, false);
+		ERR_FAIL_COND_V(!E, Ref<InputEvent>());
 	}
 
 	Ref<InputEventAction> iea = p_event;
 	if (iea.is_valid()) {
-		return iea->get_action() == p_action;
+		if (iea->get_action() == p_action)
+			return iea;
 	}
 
-	return _find_event(E->get().inputs, p_event, true) != NULL;
+	List<Ref<InputEvent> >::Element *E_ie = _find_event(E->get().inputs, p_event, true);
+	if (E_ie)
+		return E_ie->get();
+	else
+		return Ref<InputEvent>();
+}
+
+bool InputMap::event_is_action(const Ref<InputEvent> &p_event, const StringName &p_action) const {
+
+	return event_get_input_event_if_action(p_event, p_action).is_valid();
 }
 
 const Map<StringName, InputMap::Action> &InputMap::get_action_map() const {

--- a/core/input_map.h
+++ b/core/input_map.h
@@ -70,6 +70,7 @@ public:
 	void action_erase_event(const StringName &p_action, const Ref<InputEvent> &p_event);
 
 	const List<Ref<InputEvent> > *get_action_list(const StringName &p_action);
+	Ref<InputEvent> event_get_input_event_if_action(const Ref<InputEvent> &p_event, const StringName &p_action) const;
 	bool event_is_action(const Ref<InputEvent> &p_event, const StringName &p_action) const;
 
 	const Map<StringName, Action> &get_action_map() const;

--- a/core/input_map.h
+++ b/core/input_map.h
@@ -51,7 +51,7 @@ private:
 
 	List<Ref<InputEvent> >::Element *_find_event(List<Ref<InputEvent> > &p_list, const Ref<InputEvent> &p_event, bool p_action_test = false) const;
 
-	Array _get_action_list(const StringName &p_action);
+	Array _get_action_list(const StringName &p_controller_action);
 	Array _get_actions();
 
 protected:
@@ -60,18 +60,19 @@ protected:
 public:
 	static _FORCE_INLINE_ InputMap *get_singleton() { return singleton; }
 
-	bool has_action(const StringName &p_action) const;
+	bool has_action(const StringName &p_controller_action) const;
 	List<StringName> get_actions() const;
-	void add_action(const StringName &p_action);
-	void erase_action(const StringName &p_action);
+	void add_action(const StringName &p_controller_action);
+	void erase_action(const StringName &p_controller_action);
 
 	void action_add_event(const StringName &p_action, const Ref<InputEvent> &p_event);
+	void add_action_with_event(const StringName &p_action, const Ref<InputEvent> &p_event);
 	bool action_has_event(const StringName &p_action, const Ref<InputEvent> &p_event);
 	void action_erase_event(const StringName &p_action, const Ref<InputEvent> &p_event);
 
-	const List<Ref<InputEvent> > *get_action_list(const StringName &p_action);
-	Ref<InputEvent> event_get_input_event_if_action(const Ref<InputEvent> &p_event, const StringName &p_action) const;
-	bool event_is_action(const Ref<InputEvent> &p_event, const StringName &p_action) const;
+	const List<Ref<InputEvent> > *get_action_list(const StringName &p_controller_action);
+	Ref<InputEvent> event_get_input_event_if_action(const Ref<InputEvent> &p_event, const StringName &p_controller_action) const;
+	bool event_is_action(const Ref<InputEvent> &p_event, const StringName &p_controller_action) const;
 
 	const Map<StringName, Action> &get_action_map() const;
 	void load_from_globals();

--- a/core/os/input.cpp
+++ b/core/os/input.cpp
@@ -57,6 +57,8 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_action_pressed", "action"), &Input::is_action_pressed);
 	ClassDB::bind_method(D_METHOD("is_action_just_pressed", "action"), &Input::is_action_just_pressed);
 	ClassDB::bind_method(D_METHOD("is_action_just_released", "action"), &Input::is_action_just_released);
+	ClassDB::bind_method(D_METHOD("is_action_just_changed", "action"), &Input::is_action_just_changed);
+	ClassDB::bind_method(D_METHOD("get_action_axis_value", "action"), &Input::get_action_axis_value);
 	ClassDB::bind_method(D_METHOD("add_joy_mapping", "mapping", "update_existing"), &Input::add_joy_mapping, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_joy_mapping", "guid"), &Input::remove_joy_mapping);
 	ClassDB::bind_method(D_METHOD("joy_connection_changed", "device", "connected", "name", "guid"), &Input::joy_connection_changed);

--- a/core/os/input.cpp
+++ b/core/os/input.cpp
@@ -54,11 +54,11 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_key_pressed", "scancode"), &Input::is_key_pressed);
 	ClassDB::bind_method(D_METHOD("is_mouse_button_pressed", "button"), &Input::is_mouse_button_pressed);
 	ClassDB::bind_method(D_METHOD("is_joy_button_pressed", "device", "button"), &Input::is_joy_button_pressed);
-	ClassDB::bind_method(D_METHOD("is_action_pressed", "action"), &Input::is_action_pressed);
-	ClassDB::bind_method(D_METHOD("is_action_just_pressed", "action"), &Input::is_action_just_pressed);
-	ClassDB::bind_method(D_METHOD("is_action_just_released", "action"), &Input::is_action_just_released);
-	ClassDB::bind_method(D_METHOD("is_action_just_changed", "action"), &Input::is_action_just_changed);
-	ClassDB::bind_method(D_METHOD("get_action_axis_value", "action"), &Input::get_action_axis_value);
+	ClassDB::bind_method(D_METHOD("is_action_pressed", "action", "device"), &Input::is_action_pressed, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("is_action_just_pressed", "action", "controller"), &Input::is_action_just_pressed, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("is_action_just_released", "action", "controller"), &Input::is_action_just_released, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("is_action_just_changed", "action", "controller"), &Input::is_action_just_changed, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_action_axis_value", "action", "controller"), &Input::get_action_axis_value, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("add_joy_mapping", "mapping", "update_existing"), &Input::add_joy_mapping, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_joy_mapping", "guid"), &Input::remove_joy_mapping);
 	ClassDB::bind_method(D_METHOD("joy_connection_changed", "device", "connected", "name", "guid"), &Input::joy_connection_changed);
@@ -85,8 +85,8 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_mouse_mode", "mode"), &Input::set_mouse_mode);
 	ClassDB::bind_method(D_METHOD("get_mouse_mode"), &Input::get_mouse_mode);
 	ClassDB::bind_method(D_METHOD("warp_mouse_position", "to"), &Input::warp_mouse_position);
-	ClassDB::bind_method(D_METHOD("action_press", "action"), &Input::action_press);
-	ClassDB::bind_method(D_METHOD("action_release", "action"), &Input::action_release);
+	ClassDB::bind_method(D_METHOD("action_press", "action", "controller"), &Input::action_press, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("action_release", "action", "controller"), &Input::action_release, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("set_custom_mouse_cursor", "image", "shape", "hotspot"), &Input::set_custom_mouse_cursor, DEFVAL(CURSOR_ARROW), DEFVAL(Vector2()));
 	ClassDB::bind_method(D_METHOD("parse_input_event", "event"), &Input::parse_input_event);
 

--- a/core/os/input.cpp
+++ b/core/os/input.cpp
@@ -120,7 +120,12 @@ void Input::get_argument_options(const StringName &p_function, int p_idx, List<S
 #ifdef TOOLS_ENABLED
 
 	String pf = p_function;
-	if (p_idx == 0 && (pf == "is_action_pressed" || pf == "action_press" || pf == "action_release" || pf == "is_action_just_pressed" || pf == "is_action_just_released")) {
+
+	bool search_actions = true;
+	if (pf == "is_action_just_changed" || pf == "get_action_axis_value")
+		search_actions = false;
+
+	if (p_idx == 0 && (pf == "is_action_pressed" || pf == "action_press" || pf == "action_release" || pf == "is_action_just_pressed" || pf == "is_action_just_released" || pf == "is_action_just_changed" || pf == "get_action_axis_value")) {
 
 		List<PropertyInfo> pinfo;
 		ProjectSettings::get_singleton()->get_property_list(&pinfo);
@@ -131,7 +136,10 @@ void Input::get_argument_options(const StringName &p_function, int p_idx, List<S
 			if (!pi.name.begins_with("input/"))
 				continue;
 
-			String name = pi.name.substr(pi.name.find("/") + 1, pi.name.length());
+			if (!search_actions && !pi.name.ends_with("/axis"))
+				continue;
+
+			String name = pi.name.get_slice("/", 1);
 			r_options->push_back("\"" + name + "\"");
 		}
 	}

--- a/core/os/input.h
+++ b/core/os/input.h
@@ -82,11 +82,12 @@ public:
 	virtual bool is_key_pressed(int p_scancode) const = 0;
 	virtual bool is_mouse_button_pressed(int p_button) const = 0;
 	virtual bool is_joy_button_pressed(int p_device, int p_button) const = 0;
-	virtual bool is_action_pressed(const StringName &p_action) const = 0;
-	virtual bool is_action_just_pressed(const StringName &p_action) const = 0;
-	virtual bool is_action_just_released(const StringName &p_action) const = 0;
-	virtual bool is_action_just_changed(const StringName &p_action) const = 0;
-	virtual float get_action_axis_value(const StringName &p_name) const = 0;
+
+	virtual bool is_action_pressed(const StringName &p_action, int p_device = 0) const = 0;
+	virtual bool is_action_just_pressed(const StringName &p_action, int p_device = 0) const = 0;
+	virtual bool is_action_just_released(const StringName &p_action, int p_device = 0) const = 0;
+	virtual bool is_action_just_changed(const StringName &p_action, int p_device = 0) const = 0;
+	virtual float get_action_axis_value(const StringName &p_name, int p_device = 0) const = 0;
 
 	virtual float get_joy_axis(int p_device, int p_axis) const = 0;
 	virtual String get_joy_name(int p_idx) = 0;
@@ -114,8 +115,8 @@ public:
 	virtual Vector3 get_magnetometer() const = 0;
 	virtual Vector3 get_gyroscope() const = 0;
 
-	virtual void action_press(const StringName &p_action) = 0;
-	virtual void action_release(const StringName &p_action) = 0;
+	virtual void action_press(const StringName &p_action, int p_device = 0) = 0;
+	virtual void action_release(const StringName &p_action, int p_device = 0) = 0;
 
 	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const;
 

--- a/core/os/input.h
+++ b/core/os/input.h
@@ -85,6 +85,8 @@ public:
 	virtual bool is_action_pressed(const StringName &p_action) const = 0;
 	virtual bool is_action_just_pressed(const StringName &p_action) const = 0;
 	virtual bool is_action_just_released(const StringName &p_action) const = 0;
+	virtual bool is_action_just_changed(const StringName &p_action) const = 0;
+	virtual float get_action_axis_value(const StringName &p_name) const = 0;
 
 	virtual float get_joy_axis(int p_device, int p_axis) const = 0;
 	virtual String get_joy_name(int p_idx) = 0;

--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -54,13 +54,17 @@ bool InputEvent::is_simulating_axis() {
 	return ABS(axis_factor) > 0;
 }
 
+void InputEvent::set_data(const String &p_data) {
+	data = p_data;
+}
+
 float InputEvent::get_axis_value() const {
 	return pressed;
 }
 
 bool InputEvent::is_action(const StringName &p_action) const {
 
-	return InputMap::get_singleton()->event_is_action(Ref<InputEvent>((InputEvent *)this), p_action);
+	return InputMap::get_singleton()->event_is_action(Ref<InputEvent>((InputEvent *)this), (get_data() == "" ? "0" : get_data()) + ":" + p_action);
 }
 
 bool InputEvent::is_action_pressed(const StringName &p_action) const {
@@ -113,6 +117,9 @@ void InputEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_axis_factor", "factor"), &InputEvent::set_axis_factor);
 	ClassDB::bind_method(D_METHOD("get_axis_factor"), &InputEvent::get_axis_factor);
 
+	ClassDB::bind_method(D_METHOD("set_data", "data"), &InputEvent::set_data);
+	ClassDB::bind_method(D_METHOD("get_data"), &InputEvent::get_data);
+
 	ClassDB::bind_method(D_METHOD("is_simulating_axis"), &InputEvent::is_simulating_axis);
 	ClassDB::bind_method(D_METHOD("get_axis_value"), &InputEvent::get_axis_value);
 
@@ -133,6 +140,7 @@ void InputEvent::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "device"), "set_device", "get_device");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pressed"), "set_pressed", "is_pressed");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "axis_factor"), "set_axis_factor", "get_axis_factor");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "data"), "set_data", "get_data");
 }
 
 InputEvent::InputEvent() {

--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -41,9 +41,21 @@ int InputEvent::get_device() const {
 	return device;
 }
 
-bool InputEvent::is_pressed() const {
+void InputEvent::set_pressed(bool p_pressed) {
 
-	return false;
+	pressed = p_pressed;
+}
+
+void InputEvent::set_axis_factor(float p_axis_factor) {
+	axis_factor = p_axis_factor;
+}
+
+bool InputEvent::is_simulating_axis() {
+	return ABS(axis_factor) > 0;
+}
+
+float InputEvent::get_axis_value() const {
+	return pressed;
 }
 
 bool InputEvent::is_action(const StringName &p_action) const {
@@ -95,7 +107,15 @@ void InputEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_device", "device"), &InputEvent::set_device);
 	ClassDB::bind_method(D_METHOD("get_device"), &InputEvent::get_device);
 
+	ClassDB::bind_method(D_METHOD("set_pressed", "pressed"), &InputEvent::set_pressed);
 	ClassDB::bind_method(D_METHOD("is_pressed"), &InputEvent::is_pressed);
+
+	ClassDB::bind_method(D_METHOD("set_axis_factor", "factor"), &InputEvent::set_axis_factor);
+	ClassDB::bind_method(D_METHOD("get_axis_factor"), &InputEvent::get_axis_factor);
+
+	ClassDB::bind_method(D_METHOD("is_simulating_axis"), &InputEventJoypadMotion::is_simulating_axis);
+	ClassDB::bind_method(D_METHOD("get_axis_value"), &InputEventJoypadMotion::get_axis_value);
+
 	ClassDB::bind_method(D_METHOD("is_action", "action"), &InputEvent::is_action);
 	ClassDB::bind_method(D_METHOD("is_action_pressed", "action"), &InputEvent::is_action_pressed);
 	ClassDB::bind_method(D_METHOD("is_action_released", "action"), &InputEvent::is_action_released);
@@ -111,11 +131,14 @@ void InputEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("xformed_by", "xform", "local_ofs"), &InputEvent::xformed_by, DEFVAL(Vector2()));
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "device"), "set_device", "get_device");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pressed"), "set_pressed", "is_pressed");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "axis_factor"), "set_axis_factor", "get_axis_factor");
 }
 
 InputEvent::InputEvent() {
 
 	device = 0;
+	axis_factor = 0;
 }
 
 //////////////////
@@ -208,16 +231,6 @@ InputEventWithModifiers::InputEventWithModifiers() {
 
 //////////////////////////////////
 
-void InputEventKey::set_pressed(bool p_pressed) {
-
-	pressed = p_pressed;
-}
-
-bool InputEventKey::is_pressed() const {
-
-	return pressed;
-}
-
 void InputEventKey::set_scancode(uint32_t p_scancode) {
 
 	scancode = p_scancode;
@@ -307,8 +320,6 @@ bool InputEventKey::shortcut_match(const Ref<InputEvent> &p_event) const {
 
 void InputEventKey::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("set_pressed", "pressed"), &InputEventKey::set_pressed);
-
 	ClassDB::bind_method(D_METHOD("set_scancode", "scancode"), &InputEventKey::set_scancode);
 	ClassDB::bind_method(D_METHOD("get_scancode"), &InputEventKey::get_scancode);
 
@@ -319,7 +330,6 @@ void InputEventKey::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_scancode_with_modifiers"), &InputEventKey::get_scancode_with_modifiers);
 
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pressed"), "set_pressed", "is_pressed");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "scancode"), "set_scancode", "get_scancode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "unicode"), "set_unicode", "get_unicode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "echo"), "set_echo", "is_echo");
@@ -404,15 +414,6 @@ int InputEventMouseButton::get_button_index() const {
 	return button_index;
 }
 
-void InputEventMouseButton::set_pressed(bool p_pressed) {
-
-	pressed = p_pressed;
-}
-bool InputEventMouseButton::is_pressed() const {
-
-	return pressed;
-}
-
 void InputEventMouseButton::set_doubleclick(bool p_doubleclick) {
 
 	doubleclick = p_doubleclick;
@@ -438,7 +439,7 @@ Ref<InputEvent> InputEventMouseButton::xformed_by(const Transform2D &p_xform, co
 	mb->set_global_position(g);
 
 	mb->set_button_mask(get_button_mask());
-	mb->set_pressed(pressed);
+	mb->set_pressed(is_pressed());
 	mb->set_doubleclick(doubleclick);
 	mb->set_factor(factor);
 	mb->set_button_index(button_index);
@@ -484,7 +485,7 @@ String InputEventMouseButton::as_text() const {
 			button_index_string = itos(get_button_index());
 			break;
 	}
-	return "InputEventMouseButton : button_index=" + button_index_string + ", pressed=" + (pressed ? "true" : "false") + ", position=(" + String(get_position()) + "), button_mask=" + itos(get_button_mask()) + ", doubleclick=" + (doubleclick ? "true" : "false");
+	return "InputEventMouseButton : button_index=" + button_index_string + ", pressed=" + (is_pressed() ? "true" : "false") + ", position=(" + String(get_position()) + "), button_mask=" + itos(get_button_mask()) + ", doubleclick=" + (doubleclick ? "true" : "false");
 }
 
 void InputEventMouseButton::_bind_methods() {
@@ -495,15 +496,11 @@ void InputEventMouseButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_button_index", "button_index"), &InputEventMouseButton::set_button_index);
 	ClassDB::bind_method(D_METHOD("get_button_index"), &InputEventMouseButton::get_button_index);
 
-	ClassDB::bind_method(D_METHOD("set_pressed", "pressed"), &InputEventMouseButton::set_pressed);
-	//	ClassDB::bind_method(D_METHOD("is_pressed"), &InputEventMouseButton::is_pressed);
-
 	ClassDB::bind_method(D_METHOD("set_doubleclick", "doubleclick"), &InputEventMouseButton::set_doubleclick);
 	ClassDB::bind_method(D_METHOD("is_doubleclick"), &InputEventMouseButton::is_doubleclick);
 
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "factor"), "set_factor", "get_factor");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "button_index"), "set_button_index", "get_button_index");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pressed"), "set_pressed", "is_pressed");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "doubleclick"), "set_doubleclick", "is_doubleclick");
 }
 
@@ -511,7 +508,6 @@ InputEventMouseButton::InputEventMouseButton() {
 
 	factor = 1;
 	button_index = 0;
-	pressed = false;
 	doubleclick = false;
 }
 
@@ -610,13 +606,13 @@ void InputEventJoypadMotion::set_axis_value(float p_value) {
 
 	axis_value = p_value;
 }
+
 float InputEventJoypadMotion::get_axis_value() const {
 
 	return axis_value;
 }
 
 bool InputEventJoypadMotion::is_pressed() const {
-
 	return Math::abs(axis_value) > 0.5f;
 }
 
@@ -626,7 +622,7 @@ bool InputEventJoypadMotion::action_match(const Ref<InputEvent> &p_event) const 
 	if (jm.is_null())
 		return false;
 
-	return (axis == jm->axis && ((axis_value < 0) == (jm->axis_value < 0) || jm->axis_value == 0));
+	return axis == jm->axis;
 }
 
 String InputEventJoypadMotion::as_text() const {
@@ -663,15 +659,6 @@ int InputEventJoypadButton::get_button_index() const {
 	return button_index;
 }
 
-void InputEventJoypadButton::set_pressed(bool p_pressed) {
-
-	pressed = p_pressed;
-}
-bool InputEventJoypadButton::is_pressed() const {
-
-	return pressed;
-}
-
 void InputEventJoypadButton::set_pressure(float p_pressure) {
 
 	pressure = p_pressure;
@@ -692,7 +679,7 @@ bool InputEventJoypadButton::action_match(const Ref<InputEvent> &p_event) const 
 
 String InputEventJoypadButton::as_text() const {
 
-	return "InputEventJoypadButton : button_index=" + itos(button_index) + ", pressed=" + (pressed ? "true" : "false") + ", pressure=" + String(Variant(pressure));
+	return "InputEventJoypadButton : button_index=" + itos(button_index) + ", pressed=" + (is_pressed() ? "true" : "false") + ", pressure=" + String(Variant(pressure));
 }
 
 void InputEventJoypadButton::_bind_methods() {
@@ -703,19 +690,14 @@ void InputEventJoypadButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_pressure", "pressure"), &InputEventJoypadButton::set_pressure);
 	ClassDB::bind_method(D_METHOD("get_pressure"), &InputEventJoypadButton::get_pressure);
 
-	ClassDB::bind_method(D_METHOD("set_pressed", "pressed"), &InputEventJoypadButton::set_pressed);
-	//	ClassDB::bind_method(D_METHOD("is_pressed"), &InputEventJoypadButton::is_pressed);
-
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "button_index"), "set_button_index", "get_button_index");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "pressure"), "set_pressure", "get_pressure");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pressed"), "set_pressed", "is_pressed");
 }
 
 InputEventJoypadButton::InputEventJoypadButton() {
 
 	button_index = 0;
 	pressure = 0;
-	pressed = false;
 }
 
 //////////////////////////////////////////////
@@ -738,15 +720,6 @@ Vector2 InputEventScreenTouch::get_position() const {
 	return pos;
 }
 
-void InputEventScreenTouch::set_pressed(bool p_pressed) {
-
-	pressed = p_pressed;
-}
-bool InputEventScreenTouch::is_pressed() const {
-
-	return pressed;
-}
-
 Ref<InputEvent> InputEventScreenTouch::xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs) const {
 
 	Ref<InputEventScreenTouch> st;
@@ -754,14 +727,14 @@ Ref<InputEvent> InputEventScreenTouch::xformed_by(const Transform2D &p_xform, co
 	st->set_device(get_device());
 	st->set_index(index);
 	st->set_position(p_xform.xform(pos + p_local_ofs));
-	st->set_pressed(pressed);
+	st->set_pressed(is_pressed());
 
 	return st;
 }
 
 String InputEventScreenTouch::as_text() const {
 
-	return "InputEventScreenTouch : index=" + itos(index) + ", pressed=" + (pressed ? "true" : "false") + ", position=(" + String(get_position()) + ")";
+	return "InputEventScreenTouch : index=" + itos(index) + ", pressed=" + (is_pressed() ? "true" : "false") + ", position=(" + String(get_position()) + ")";
 }
 
 void InputEventScreenTouch::_bind_methods() {
@@ -772,18 +745,13 @@ void InputEventScreenTouch::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_position", "position"), &InputEventScreenTouch::set_position);
 	ClassDB::bind_method(D_METHOD("get_position"), &InputEventScreenTouch::get_position);
 
-	ClassDB::bind_method(D_METHOD("set_pressed", "pressed"), &InputEventScreenTouch::set_pressed);
-	//ClassDB::bind_method(D_METHOD("is_pressed"),&InputEventScreenTouch::is_pressed);
-
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "index"), "set_index", "get_index");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "position"), "set_position", "get_position");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pressed"), "set_pressed", "is_pressed");
 }
 
 InputEventScreenTouch::InputEventScreenTouch() {
 
 	index = 0;
-	pressed = false;
 }
 
 /////////////////////////////
@@ -881,15 +849,6 @@ StringName InputEventAction::get_action() const {
 	return action;
 }
 
-void InputEventAction::set_pressed(bool p_pressed) {
-
-	pressed = p_pressed;
-}
-bool InputEventAction::is_pressed() const {
-
-	return pressed;
-}
-
 bool InputEventAction::is_action(const StringName &p_action) const {
 
 	return action == p_action;
@@ -897,7 +856,7 @@ bool InputEventAction::is_action(const StringName &p_action) const {
 
 String InputEventAction::as_text() const {
 
-	return "InputEventAction : action=" + action + ", pressed=(" + (pressed ? "true" : "false");
+	return "InputEventAction : action=" + action + ", pressed=(" + (is_pressed() ? "true" : "false");
 }
 
 void InputEventAction::_bind_methods() {
@@ -905,18 +864,12 @@ void InputEventAction::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_action", "action"), &InputEventAction::set_action);
 	ClassDB::bind_method(D_METHOD("get_action"), &InputEventAction::get_action);
 
-	ClassDB::bind_method(D_METHOD("set_pressed", "pressed"), &InputEventAction::set_pressed);
-	//ClassDB::bind_method(D_METHOD("is_pressed"), &InputEventAction::is_pressed);
-
 	//	ClassDB::bind_method(D_METHOD("is_action", "name"), &InputEventAction::is_action);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "action"), "set_action", "get_action");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pressed"), "set_pressed", "is_pressed");
 }
 
-InputEventAction::InputEventAction() {
-	pressed = false;
-}
+InputEventAction::InputEventAction() {}
 /////////////////////////////
 
 void InputEventGesture::set_position(const Vector2 &p_pos) {

--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -113,8 +113,8 @@ void InputEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_axis_factor", "factor"), &InputEvent::set_axis_factor);
 	ClassDB::bind_method(D_METHOD("get_axis_factor"), &InputEvent::get_axis_factor);
 
-	ClassDB::bind_method(D_METHOD("is_simulating_axis"), &InputEventJoypadMotion::is_simulating_axis);
-	ClassDB::bind_method(D_METHOD("get_axis_value"), &InputEventJoypadMotion::get_axis_value);
+	ClassDB::bind_method(D_METHOD("is_simulating_axis"), &InputEvent::is_simulating_axis);
+	ClassDB::bind_method(D_METHOD("get_axis_value"), &InputEvent::get_axis_value);
 
 	ClassDB::bind_method(D_METHOD("is_action", "action"), &InputEvent::is_action);
 	ClassDB::bind_method(D_METHOD("is_action_pressed", "action"), &InputEvent::is_action_pressed);
@@ -636,7 +636,6 @@ void InputEventJoypadMotion::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_axis"), &InputEventJoypadMotion::get_axis);
 
 	ClassDB::bind_method(D_METHOD("set_axis_value", "axis_value"), &InputEventJoypadMotion::set_axis_value);
-	ClassDB::bind_method(D_METHOD("get_axis_value"), &InputEventJoypadMotion::get_axis_value);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "axis"), "set_axis", "get_axis");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "axis_value"), "set_axis_value", "get_axis_value");

--- a/core/os/input_event.h
+++ b/core/os/input_event.h
@@ -148,7 +148,8 @@ class InputEvent : public Resource {
 protected:
 	int device;
 	bool pressed;
-	float axis_factor; // Used to simulate axis on normal buttons or to scale the real value of axis_value
+	float axis_factor; // Used to simulate axis on buttons event or to scale the axis value in case of axis event
+	String data; // Used to store extra information
 
 protected:
 	static void _bind_methods();
@@ -161,9 +162,12 @@ public:
 	_FORCE_INLINE_ virtual bool is_pressed() const { return pressed; }
 
 	void set_axis_factor(float p_axis_factor);
-	float get_axis_factor() const { return axis_factor; }
+	_FORCE_INLINE_ float get_axis_factor() const { return axis_factor; }
 
 	bool is_simulating_axis();
+
+	void set_data(const String &p_data);
+	_FORCE_INLINE_ const String &get_data() const { return data; }
 
 	virtual float get_axis_value() const;
 

--- a/core/os/input_event.h
+++ b/core/os/input_event.h
@@ -145,7 +145,10 @@ enum JoystickList {
 class InputEvent : public Resource {
 	GDCLASS(InputEvent, Resource)
 
+protected:
 	int device;
+	bool pressed;
+	float axis_factor; // Used to simulate axis on normal buttons or to scale the real value of axis_value
 
 protected:
 	static void _bind_methods();
@@ -154,7 +157,16 @@ public:
 	void set_device(int p_device);
 	int get_device() const;
 
-	virtual bool is_pressed() const;
+	void set_pressed(bool p_pressed);
+	_FORCE_INLINE_ virtual bool is_pressed() const { return pressed; }
+
+	void set_axis_factor(float p_axis_factor);
+	float get_axis_factor() const { return axis_factor; }
+
+	bool is_simulating_axis();
+
+	virtual float get_axis_value() const;
+
 	virtual bool is_action(const StringName &p_action) const;
 	virtual bool is_action_pressed(const StringName &p_action) const;
 	virtual bool is_action_released(const StringName &p_action) const;
@@ -230,9 +242,6 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_pressed(bool p_pressed);
-	virtual bool is_pressed() const;
-
 	void set_scancode(uint32_t p_scancode);
 	uint32_t get_scancode() const;
 
@@ -285,7 +294,6 @@ class InputEventMouseButton : public InputEventMouse {
 
 	float factor;
 	int button_index;
-	bool pressed; //otherwise released
 	bool doubleclick; //last even less than doubleclick time
 
 protected:
@@ -297,9 +305,6 @@ public:
 
 	void set_button_index(int p_index);
 	int get_button_index() const;
-
-	void set_pressed(bool p_pressed);
-	virtual bool is_pressed() const;
 
 	void set_doubleclick(bool p_doubleclick);
 	bool is_doubleclick() const;
@@ -349,9 +354,10 @@ public:
 	int get_axis() const;
 
 	void set_axis_value(float p_value);
-	float get_axis_value() const;
+	virtual float get_axis_value() const; // return value -1 to 1
 
 	virtual bool is_pressed() const;
+
 	virtual bool action_match(const Ref<InputEvent> &p_event) const;
 
 	virtual bool is_action_type() const { return true; }
@@ -364,7 +370,6 @@ class InputEventJoypadButton : public InputEvent {
 	GDCLASS(InputEventJoypadButton, InputEvent)
 
 	int button_index;
-	bool pressed;
 	float pressure; //0 to 1
 protected:
 	static void _bind_methods();
@@ -372,9 +377,6 @@ protected:
 public:
 	void set_button_index(int p_index);
 	int get_button_index() const;
-
-	void set_pressed(bool p_pressed);
-	virtual bool is_pressed() const;
 
 	void set_pressure(float p_pressure);
 	float get_pressure() const;
@@ -391,7 +393,6 @@ class InputEventScreenTouch : public InputEvent {
 	GDCLASS(InputEventScreenTouch, InputEvent)
 	int index;
 	Vector2 pos;
-	bool pressed;
 
 protected:
 	static void _bind_methods();
@@ -402,9 +403,6 @@ public:
 
 	void set_position(const Vector2 &p_pos);
 	Vector2 get_position() const;
-
-	void set_pressed(bool p_pressed);
-	virtual bool is_pressed() const;
 
 	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const;
 	virtual String as_text() const;
@@ -447,7 +445,6 @@ class InputEventAction : public InputEvent {
 	GDCLASS(InputEventAction, InputEvent)
 
 	StringName action;
-	bool pressed;
 
 protected:
 	static void _bind_methods();
@@ -455,9 +452,6 @@ protected:
 public:
 	void set_action(const StringName &p_action);
 	StringName get_action() const;
-
-	void set_pressed(bool p_pressed);
-	virtual bool is_pressed() const;
 
 	virtual bool is_action(const StringName &p_action) const;
 

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -96,6 +96,7 @@ class ProjectSettingsEditor : public AcceptDialog {
 	LineEdit *action_name;
 	Button *action_add;
 	Label *action_add_error;
+	SpinBox *controller_id_sb;
 	Tree *input_editor;
 	bool updating_actions;
 	bool setting;
@@ -134,6 +135,8 @@ class ProjectSettingsEditor : public AcceptDialog {
 	void _action_adds(String);
 	void _action_add();
 	void _device_input_add();
+
+	void _controller_changed(double p_value);
 
 	void _tab_container_changed(int p_tab);
 	void _item_checked(const String &p_item, bool p_check);

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -77,9 +77,14 @@ class ProjectSettingsEditor : public AcceptDialog {
 	LineEdit *property;
 	OptionButton *type;
 	PopupMenu *popup_add;
+	VBoxContainer *sim_axis_vbc;
+	CheckBox *sim_axis_cb;
+	SpinBox *sim_axis_sb;
 	ConfirmationDialog *press_a_key;
+	VBoxContainer *press_a_key_vbc;
 	Label *press_a_key_label;
 	ConfirmationDialog *device_input;
+	VBoxContainer *device_input_vbc;
 	SpinBox *device_id;
 	OptionButton *device_index;
 	Label *device_index_label;
@@ -134,6 +139,7 @@ class ProjectSettingsEditor : public AcceptDialog {
 	void _wait_for_key(const Ref<InputEvent> &p_event);
 	void _press_a_key_confirm();
 	void _show_last_added(const Ref<InputEvent> &p_event, const String &p_name);
+	void _toggle_sim_axis(bool p_button_pressed);
 
 	void _settings_prop_edited(const String &p_name);
 	void _settings_changed();

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -78,7 +78,6 @@ class ProjectSettingsEditor : public AcceptDialog {
 	OptionButton *type;
 	PopupMenu *popup_add;
 	VBoxContainer *sim_axis_vbc;
-	CheckBox *sim_axis_cb;
 	SpinBox *sim_axis_sb;
 	ConfirmationDialog *press_a_key;
 	VBoxContainer *press_a_key_vbc;
@@ -90,10 +89,15 @@ class ProjectSettingsEditor : public AcceptDialog {
 	Label *device_index_label;
 	MenuButton *popup_copy_to_feature;
 
+	Control *input_base_actions;
+	Control *input_base_axis;
+	VBoxContainer *input_map_vbc;
+	Label *action_label;
 	LineEdit *action_name;
 	Button *action_add;
 	Label *action_add_error;
 	Tree *input_editor;
+	bool updating_actions;
 	bool setting;
 	bool updating_translations;
 
@@ -131,6 +135,7 @@ class ProjectSettingsEditor : public AcceptDialog {
 	void _action_add();
 	void _device_input_add();
 
+	void _tab_container_changed(int p_tab);
 	void _item_checked(const String &p_item, bool p_check);
 	void _action_selected();
 	void _action_edited();
@@ -139,7 +144,6 @@ class ProjectSettingsEditor : public AcceptDialog {
 	void _wait_for_key(const Ref<InputEvent> &p_event);
 	void _press_a_key_confirm();
 	void _show_last_added(const Ref<InputEvent> &p_event, const String &p_name);
-	void _toggle_sim_axis(bool p_button_pressed);
 
 	void _settings_prop_edited(const String &p_name);
 	void _settings_changed();

--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -353,7 +353,7 @@ void InputDefault::parse_input_event(const Ref<InputEvent> &p_event) {
 			if (action_ie.is_valid()) {
 				ActionState &a = action_state[E->key()];
 				const float new_axis_value = action_ie->get_axis_factor() * p_event->get_axis_value();
-				if (a.idle_frame == -1 || a.axis_value != new_axis_value) {
+				if (a.idle_frame == -1 || a.axis_value != new_axis_value || a.pressed != p_event->is_pressed()) {
 					a.physics_frame = Engine::get_singleton()->get_physics_frames();
 					a.idle_frame = Engine::get_singleton()->get_idle_frames();
 					a.pressed = p_event->is_pressed();

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -186,11 +186,12 @@ public:
 	virtual bool is_key_pressed(int p_scancode) const;
 	virtual bool is_mouse_button_pressed(int p_button) const;
 	virtual bool is_joy_button_pressed(int p_device, int p_button) const;
-	virtual bool is_action_pressed(const StringName &p_action) const;
-	virtual bool is_action_just_pressed(const StringName &p_action) const;
-	virtual bool is_action_just_released(const StringName &p_action) const;
-	virtual bool is_action_just_changed(const StringName &p_action) const;
-	virtual float get_action_axis_value(const StringName &p_action) const;
+
+	virtual bool is_action_pressed(const StringName &p_action, int p_controller = 0) const;
+	virtual bool is_action_just_pressed(const StringName &p_action, int p_controller = 0) const;
+	virtual bool is_action_just_released(const StringName &p_action, int p_controller = 0) const;
+	virtual bool is_action_just_changed(const StringName &p_action, int p_controller = 0) const;
+	virtual float get_action_axis_value(const StringName &p_action, int p_controller = 0) const;
 
 	virtual float get_joy_axis(int p_device, int p_axis) const;
 	String get_joy_name(int p_idx);
@@ -227,8 +228,8 @@ public:
 	void set_main_loop(MainLoop *p_main_loop);
 	void set_mouse_position(const Point2 &p_posf);
 
-	void action_press(const StringName &p_action);
-	void action_release(const StringName &p_action);
+	void action_press(const StringName &p_action, int p_controller = 0);
+	void action_release(const StringName &p_action, int p_controller = 0);
 
 	void iteration(float p_step);
 
@@ -259,6 +260,9 @@ public:
 	String get_joy_guid_remapped(int p_device) const;
 	void set_fallback_mapping(String p_guid);
 	InputDefault();
+
+private:
+	const StringName combine_controller_action(int p_controller, const StringName &p_action) const;
 };
 
 #endif // INPUT_DEFAULT_H

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -51,13 +51,20 @@ class InputDefault : public Input {
 	Vector2 mouse_pos;
 	MainLoop *main_loop;
 
-	struct Action {
+	struct ActionState {
 		uint64_t physics_frame;
 		uint64_t idle_frame;
 		bool pressed;
+		float axis_value;
+
+		ActionState() :
+				physics_frame(-1),
+				idle_frame(-1),
+				pressed(false),
+				axis_value(0.) {}
 	};
 
-	Map<StringName, Action> action_state;
+	Map<StringName, ActionState> action_state;
 
 	bool emulate_touch;
 
@@ -182,6 +189,8 @@ public:
 	virtual bool is_action_pressed(const StringName &p_action) const;
 	virtual bool is_action_just_pressed(const StringName &p_action) const;
 	virtual bool is_action_just_released(const StringName &p_action) const;
+	virtual bool is_action_just_changed(const StringName &p_action) const;
+	virtual float get_action_axis_value(const StringName &p_action) const;
 
 	virtual float get_joy_axis(int p_device, int p_axis) const;
 	String get_joy_name(int p_idx);

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -3521,7 +3521,7 @@ void VisualScriptInputAction::_validate_property(PropertyInfo &property) const {
 			if (!pi.name.begins_with("input/"))
 				continue;
 
-			String name = pi.name.substr(pi.name.find("/") + 1, pi.name.length());
+			String name = pi.name.get_slice("/", 1);
 
 			al.push_back(name);
 		}


### PR DESCRIPTION
With this commit I've added a way to map stick (axis) input inside Godot actions.

Basically now is possible to map together axis and buttons in order to simplify the life of developer and allow to change bindings at runtime easily.

Please check this video to see it in action: https://youtu.be/tKd7rEfwpIo