### PR TITLE
fix template builds with mono 

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1550,7 +1550,6 @@ bool CSharpScript::_update_exports() {
 }
 
 bool CSharpScript::_update_signals() {
-#ifdef TOOLS_ENABLED
 	if (!valid)
 		return false;
 
@@ -1581,8 +1580,6 @@ bool CSharpScript::_update_signals() {
 	}
 
 	return changed;
-#endif
-	return false;
 }
 
 bool CSharpScript::_get_signal(GDMonoClass *p_class, GDMonoClass *p_delegate, Vector<Argument> &params) {
@@ -2135,9 +2132,7 @@ void CSharpScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
 }
 
 void CSharpScript::update_signals() {
-#ifdef TOOLS_ENABLED
 	_update_signals();
-#endif
 }
 
 Ref<Script> CSharpScript::get_base_script() const {

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -90,15 +90,15 @@ class CSharpScript : public Script {
 		Variant::Type type;
 	};
 
+	Map<StringName, Vector<Argument> > _signals;
+	bool signals_invalidated;
+
 #ifdef TOOLS_ENABLED
 	List<PropertyInfo> exported_members_cache; // members_cache
 	Map<StringName, Variant> exported_members_defval_cache; // member_default_values_cache
 	Set<PlaceHolderScriptInstance *> placeholders;
 	bool source_changed_cache;
 	bool exports_invalidated;
-	Map<StringName, Vector<Argument> > _signals;
-	bool signals_invalidated;
-
 	void _update_exports_values(Map<StringName, Variant> &values, List<PropertyInfo> &propnames);
 	virtual void _placeholder_erased(PlaceHolderScriptInstance *p_placeholder);
 #endif


### PR DESCRIPTION
_signals was moved out of "#ifdef TOOLS_ENABLED" the same like for
GDScript.