### PR TITLE
OSX: Remove support for 32-bit and fat binaries

### DIFF
--- a/platform/osx/crash_handler_osx.mm
+++ b/platform/osx/crash_handler_osx.mm
@@ -35,8 +35,7 @@
 #include <string.h>
 #include <unistd.h>
 
-// Note: Dump backtrace in 32bit mode is getting a bus error on the fgets by the ->execute, so enable only on 64bit
-#if defined(DEBUG_ENABLED) && defined(__x86_64__)
+#if defined(DEBUG_ENABLED)
 #define CRASH_HANDLER_ENABLED 1
 #endif
 
@@ -50,13 +49,8 @@
 #include <mach-o/dyld.h>
 #include <mach-o/getsect.h>
 
-#ifdef __x86_64__
 static uint64_t load_address() {
 	const struct segment_command_64 *cmd = getsegbyname("__TEXT");
-#else
-static uint32_t load_address() {
-	const struct segment_command *cmd = getsegbyname("__TEXT");
-#endif
 	char full_path[1024];
 	uint32_t size = sizeof(full_path);
 
@@ -120,11 +114,7 @@ static void handle_crash(int sig) {
 				args.push_back("-o");
 				args.push_back(_execpath);
 				args.push_back("-arch");
-#ifdef __x86_64__
 				args.push_back("x86_64");
-#else
-				args.push_back("i386");
-#endif
 				args.push_back("-l");
 				snprintf(str, 1024, "%p", load_addr);
 				args.push_back(str);

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -57,22 +57,15 @@ def configure(env):
 
     ## Architecture
 
-    is64 = sys.maxsize > 2**32
-    if (env["bits"] == "default"):
-        env["bits"] = "64" if is64 else "32"
+    # Mac OS X no longer runs on 32-bit since 10.7 which is unsupported since 2014
+    # As such, we only support 64-bit
+    env["bits"] == "64"
 
     ## Compiler configuration
 
     if "OSXCROSS_ROOT" not in os.environ: # regular native build
-        if (env["bits"] == "fat"):
-            env.Append(CCFLAGS=['-arch', 'i386', '-arch', 'x86_64'])
-            env.Append(LINKFLAGS=['-arch', 'i386', '-arch', 'x86_64'])
-        elif (env["bits"] == "32"):
-            env.Append(CCFLAGS=['-arch', 'i386'])
-            env.Append(LINKFLAGS=['-arch', 'i386'])
-        else: # 64-bit, default
-            env.Append(CCFLAGS=['-arch', 'x86_64'])
-            env.Append(LINKFLAGS=['-arch', 'x86_64'])
+        env.Append(CCFLAGS=['-arch', 'x86_64'])
+        env.Append(LINKFLAGS=['-arch', 'x86_64'])
         if (env["macports_clang"] != 'no'):
             mpprefix = os.environ.get("MACPORTS_PREFIX", "/opt/local")
             mpclangver = env["macports_clang"]
@@ -86,14 +79,7 @@ def configure(env):
 
     else: # osxcross build
         root = os.environ.get("OSXCROSS_ROOT", 0)
-        if env["bits"] == "fat":
-            basecmd = root + "/target/bin/x86_64-apple-" + env["osxcross_sdk"] + "-"
-            env.Append(CCFLAGS=['-arch', 'i386', '-arch', 'x86_64'])
-            env.Append(LINKFLAGS=['-arch', 'i386', '-arch', 'x86_64'])
-        elif env["bits"] == "32":
-            basecmd = root + "/target/bin/i386-apple-" + env["osxcross_sdk"] + "-"
-        else: # 64-bit, default
-            basecmd = root + "/target/bin/x86_64-apple-" + env["osxcross_sdk"] + "-"
+        basecmd = root + "/target/bin/x86_64-apple-" + env["osxcross_sdk"] + "-"
 
         ccache_path = os.environ.get("CCACHE")
         if ccache_path == None:

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -101,15 +101,7 @@ void EditorExportPlatformOSX::get_preset_features(const Ref<EditorExportPreset> 
 		r_features->push_back("etc2");
 	}
 
-	int bits = p_preset->get("application/bits_mode");
-
-	if (bits == 0 || bits == 1) {
-		r_features->push_back("64");
-	}
-
-	if (bits == 0 || bits == 2) {
-		r_features->push_back("32");
-	}
+	r_features->push_back("64");
 }
 
 void EditorExportPlatformOSX::get_export_options(List<ExportOption> *r_options) {
@@ -125,7 +117,6 @@ void EditorExportPlatformOSX::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/short_version"), "1.0"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/version"), "1.0"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/copyright"), ""));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "application/bits_mode", PROPERTY_HINT_ENUM, "Fat (32 & 64 bits),64 bits,32 bits"), 0));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "display/high_res"), false));
 
 #ifdef OSX_ENABLED
@@ -323,11 +314,8 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 	ERR_FAIL_COND_V(!src_pkg_zip, ERR_CANT_OPEN);
 	int ret = unzGoToFirstFile(src_pkg_zip);
 
-	String binary_to_use = "godot_osx_" + String(p_debug ? "debug" : "release") + ".";
-	int bits_mode = p_preset->get("application/bits_mode");
-	binary_to_use += String(bits_mode == 0 ? "fat" : bits_mode == 1 ? "64" : "32");
+	String binary_to_use = "godot_osx_" + String(p_debug ? "debug" : "release") + ".64";
 
-	print_line("binary: " + binary_to_use);
 	String pkg_name;
 	if (p_preset->get("application/name") != "")
 		pkg_name = p_preset->get("application/name"); // app_name


### PR DESCRIPTION
Mac OS X is 64-bit only since 10.7 (Lion), which has reached End-Of-Life in October 2014.
On top of that, Apple is also now refusing 32-bit only apps from its App Store, and will remove the existing ones by mid 2018.

Therefore it no longer makes sense to support exporting 32-bit binaries for Mac OS X,
and we can now default to 64-bit instead of bigger "fat" binaries.

Fixes #12704.