### PR TITLE
Separate zoom focus for script editor and shader editor

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -594,6 +594,22 @@ FindReplaceBar::FindReplaceBar() {
 
 /*** CODE EDITOR ****/
 
+void CodeTextEditor::set_font_name(String p_font_name) {
+	font_name = p_font_name;
+}
+
+String CodeTextEditor::get_font_name() const {
+	return font_name;
+}
+
+void CodeTextEditor::set_font_size_name(String p_font_size_name) {
+	font_size_name = p_font_size_name;
+}
+
+String CodeTextEditor::get_font_size_name() const {
+	return font_size_name;
+}
+
 void CodeTextEditor::_text_editor_gui_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventMouseButton> mb = p_event;
@@ -664,7 +680,7 @@ void CodeTextEditor::_reset_zoom() {
 	Ref<DynamicFont> font = text_editor->get_font("font"); // reset source font size to default
 
 	if (font.is_valid()) {
-		EditorSettings::get_singleton()->set("interface/editor/code_font_size", 14);
+		EditorSettings::get_singleton()->set(font_size_name, 14);
 		font->set_size(14);
 		zoom_nb->set_text("100%");
 	}
@@ -732,7 +748,7 @@ bool CodeTextEditor::_add_font_size(int p_delta) {
 		zoom_nb->set_text(itos(100 * new_size / 14) + "%");
 
 		if (new_size != font->get_size()) {
-			EditorSettings::get_singleton()->set("interface/editor/code_font_size", new_size / EDSCALE);
+			EditorSettings::get_singleton()->set(font_size_name, new_size / EDSCALE);
 			font->set_size(new_size);
 		}
 
@@ -774,7 +790,7 @@ void CodeTextEditor::set_error(const String &p_error) {
 
 void CodeTextEditor::_update_font() {
 
-	text_editor->add_font_override("font", get_font("source", "EditorFonts"));
+	text_editor->add_font_override("font", get_font(font_name, "EditorFonts"));
 
 	Ref<Font> status_bar_font = get_font("status_source", "EditorFonts");
 	int count = status_bar->get_child_count();

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -150,6 +150,8 @@ class CodeTextEditor : public VBoxContainer {
 	Timer *idle;
 	Timer *code_complete_timer;
 	bool enable_complete_timer;
+	String font_name;
+	String font_size_name;
 
 	Timer *font_resize_timer;
 	int font_resize_val;
@@ -162,18 +164,18 @@ class CodeTextEditor : public VBoxContainer {
 	void _update_font();
 	void _complete_request();
 	void _font_resize_timeout();
-	bool _add_font_size(int p_delta);
 
 	void _text_editor_gui_input(const Ref<InputEvent> &p_event);
-	void _zoom_in();
-	void _zoom_out();
-	void _zoom_changed();
+	virtual void _zoom_in();
+	virtual void _zoom_out();
+	virtual void _zoom_changed();
 	void _reset_zoom();
 
 	CodeTextEditorCodeCompleteFunc code_complete_func;
 	void *code_complete_ud;
 
 protected:
+	bool _add_font_size(int p_delta);
 	virtual void _load_theme_settings() {}
 	virtual void _validate_script() {}
 	virtual void _code_complete_script(const String &p_code, List<String> *r_options) {}
@@ -186,6 +188,11 @@ protected:
 	static void _bind_methods();
 
 public:
+	void set_font_name(String p_font_name);
+	String get_font_name() const;
+	void set_font_size_name(String p_font_size_name);
+	String get_font_size_name() const;
+
 	void update_editor_settings();
 	void set_error(const String &p_error);
 	void update_line_and_column() { _line_col_changed(); }

--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -179,6 +179,9 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	MAKE_SOURCE_FONT(df_code, int(EditorSettings::get_singleton()->get("interface/editor/code_font_size")) * EDSCALE);
 	p_theme->set_font("source", "EditorFonts", df_code);
 
+	MAKE_SOURCE_FONT(df_shader_code, int(EditorSettings::get_singleton()->get("interface/editor/shader_code_font_size")) * EDSCALE);
+	p_theme->set_font("shader_source", "EditorFonts", df_shader_code);
+
 	MAKE_SOURCE_FONT(df_doc_code, int(EDITOR_DEF("text_editor/help/help_source_font_size", 14)) * EDSCALE);
 	p_theme->set_font("doc_source", "EditorFonts", df_doc_code);
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -290,6 +290,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["interface/editor/main_font_size"] = PropertyInfo(Variant::INT, "interface/editor/main_font_size", PROPERTY_HINT_RANGE, "10,40,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/code_font_size", 14);
 	hints["interface/editor/code_font_size"] = PropertyInfo(Variant::INT, "interface/editor/code_font_size", PROPERTY_HINT_RANGE, "8,96,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
+	_initial_set("interface/editor/shader_code_font_size", 14);
+	hints["interface/editor/shader_code_font_size"] = PropertyInfo(Variant::INT, "interface/editor/shader_code_font_size", PROPERTY_HINT_RANGE, "8,96,1", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL);
 	_initial_set("interface/editor/main_font", "");
 	hints["interface/editor/main_font"] = PropertyInfo(Variant::STRING, "interface/editor/main_font", PROPERTY_HINT_GLOBAL_FILE, "*.ttf,*.otf", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/code_font", "");

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1540,6 +1540,8 @@ ScriptTextEditor::ScriptTextEditor() {
 
 	code_editor = memnew(CodeTextEditor);
 	add_child(code_editor);
+	code_editor->set_font_name("source");
+	code_editor->set_font_size_name("interface/editor/code_font_size");
 	code_editor->add_constant_override("separation", 0);
 	code_editor->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	code_editor->connect("validate_script", this, "_validate_script");

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -57,6 +57,28 @@ void ShaderTextEditor::set_edited_shader(const Ref<Shader> &p_shader) {
 	_line_col_changed();
 }
 
+void ShaderTextEditor::_zoom_in() {
+	shader_font_resize_val += EDSCALE;
+	_zoom_changed();
+}
+
+void ShaderTextEditor::_zoom_out() {
+	shader_font_resize_val -= EDSCALE;
+	_zoom_changed();
+}
+
+void ShaderTextEditor::_zoom_changed() {
+	if (shader_font_resize_timer->get_time_left() == 0)
+		shader_font_resize_timer->start();
+}
+
+void ShaderTextEditor::_shader_font_resize_timeout() {
+
+	if (_add_font_size(shader_font_resize_val)) {
+		shader_font_resize_val = 0;
+	}
+}
+
 void ShaderTextEditor::_load_theme_settings() {
 
 	get_text_edit()->clear_colors();
@@ -229,9 +251,19 @@ void ShaderTextEditor::_validate_script() {
 }
 
 void ShaderTextEditor::_bind_methods() {
+	ClassDB::bind_method("_shader_font_resize_timeout", &ShaderTextEditor::_shader_font_resize_timeout);
 }
 
 ShaderTextEditor::ShaderTextEditor() {
+	set_font_name("shader_source");
+	set_font_size_name("interface/editor/shader_code_font_size");
+
+	shader_font_resize_val = 0;
+	shader_font_resize_timer = memnew(Timer);
+	add_child(shader_font_resize_timer);
+	shader_font_resize_timer->set_one_shot(true);
+	shader_font_resize_timer->set_wait_time(0.07);
+	shader_font_resize_timer->connect("timeout", this, "_shader_font_resize_timeout");
 }
 
 /*** SCRIPT EDITOR ******/

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -46,8 +46,14 @@ class ShaderTextEditor : public CodeTextEditor {
 	GDCLASS(ShaderTextEditor, CodeTextEditor);
 
 	Ref<Shader> shader;
+	int shader_font_resize_val;
+	Timer *shader_font_resize_timer;
 
 	void _check_shader_mode();
+	void _zoom_in(); // override
+	void _zoom_out(); // override
+	void _zoom_changed(); // override
+	void _shader_font_resize_timeout();
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
This commit adds Font settings for Shader Editor, allows zooming and setup fonts in script editor and shaders editor separately(its impossible to do previously)

You can look at this video and compare with the current behavior
https://youtu.be/NakXF48C6JM
