### PR TITLE
Fix a rendering bug with screen_texture

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -993,13 +993,11 @@ void RasterizerCanvasGLES3::_copy_texscreen(const Rect2 &p_rect) {
 	glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->fbo); //back to front
 	glViewport(0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height);
 
-	state.canvas_shader.bind(); //back to canvas
-	_bind_canvas_texture(state.current_tex, state.current_normal);
+	// back to canvas, force rebind
+	state.using_texture_rect = true;
+	_set_texture_rect_mode(false);
 
-	if (state.using_texture_rect) {
-		state.using_texture_rect = false;
-		_set_texture_rect_mode(state.using_texture_rect, state.using_ninepatch);
-	}
+	_bind_canvas_texture(state.current_tex, state.current_normal);
 
 	glEnable(GL_BLEND);
 }


### PR DESCRIPTION
Fixes a strange bug with rendering, which caused StyleBoxFlat-s with a screen-reading shader to disappear based on what was drawn before them.

Before:
![peek 2018-02-19 22-11](https://user-images.githubusercontent.com/5276727/36395468-f6a2ea56-15c1-11e8-8d16-c99e50fb2b47.gif)

After:
![peek 2018-02-19 22-13](https://user-images.githubusercontent.com/5276727/36395488-131a47ec-15c2-11e8-9d89-5cf076f238c0.gif)

Tree (node with script just hides itself on "space"):
![image](https://user-images.githubusercontent.com/5276727/36395539-4a80204e-15c2-11e8-8dba-db7590df132f.png)


Sample project: [x-render-screen-texture.zip](https://github.com/godotengine/godot/files/1738061/x-render-screen-texture.zip)
