### PR TITLE
Fix mbedTLS and websocket module for UWP

### DIFF
--- a/modules/websocket/SCsub
+++ b/modules/websocket/SCsub
@@ -54,7 +54,7 @@ thirdparty_sources = [
 if env_lws["platform"] == "android": # Builtin getifaddrs
     thirdparty_sources += ["misc/getifaddrs.c"]
 
-if env_lws["platform"] == "windows": # Winsock
+if env_lws["platform"] == "windows" or env_lws["platform"] == "uwp": # Winsock
     thirdparty_sources += ["plat/lws-plat-win.c", helper_dir + "getopt.c", helper_dir + "getopt_long.c", helper_dir + "gettimeofday.c"]
 else: # Unix socket
     thirdparty_sources += ["plat/lws-plat-unix.c"]
@@ -75,7 +75,10 @@ else:
         mbedtls_includes = "#thirdparty/mbedtls/include"
         env_lws.Append(CPPPATH=[mbedtls_includes])
 
-    if env_lws["platform"] == "windows":
+    if env_lws["platform"] == "windows" or env_lws["platform"] == "uwp":
         env_lws.Append(CPPPATH=[thirdparty_dir + helper_dir])
+
+    if env_lws["platform"] == "uwp":
+        env_lws.Append(CCFLAGS=["/DLWS_MINGW_SUPPORT"])
 
 env_lws.add_source_files(env.modules_sources, "*.cpp")

--- a/platform/uwp/detect.py
+++ b/platform/uwp/detect.py
@@ -160,6 +160,7 @@ def configure(env):
         'libANGLE',
         'libEGL',
         'libGLESv2',
+        'bcrypt',
     ]
     env.Append(LINKFLAGS=[p + ".lib" for p in LIBS])
 

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -179,7 +179,7 @@ def configure(env):
         if env["bits"] == "64":
             env.Append(CCFLAGS=['/D_WIN64'])
 
-        LIBS = ['winmm', 'opengl32', 'dsound', 'kernel32', 'ole32', 'oleaut32', 'user32', 'gdi32', 'IPHLPAPI', 'Shlwapi', 'wsock32', 'Ws2_32', 'shell32', 'advapi32', 'dinput8', 'dxguid', 'imm32']
+        LIBS = ['winmm', 'opengl32', 'dsound', 'kernel32', 'ole32', 'oleaut32', 'user32', 'gdi32', 'IPHLPAPI', 'Shlwapi', 'wsock32', 'Ws2_32', 'shell32', 'advapi32', 'dinput8', 'dxguid', 'imm32', 'bcrypt']
         env.Append(LINKFLAGS=[p + env["LIBSUFFIX"] for p in LIBS])
 
         env.Append(LIBPATH=[os.getenv("WindowsSdkDir") + "/Lib"])
@@ -281,7 +281,7 @@ def configure(env):
         env.Append(CCFLAGS=['-DRTAUDIO_ENABLED'])
         env.Append(CCFLAGS=['-DWASAPI_ENABLED'])
         env.Append(CCFLAGS=['-DWINVER=%s' % env['target_win_version'], '-D_WIN32_WINNT=%s' % env['target_win_version']])
-        env.Append(LIBS=['mingw32', 'opengl32', 'dsound', 'ole32', 'd3d9', 'winmm', 'gdi32', 'iphlpapi', 'shlwapi', 'wsock32', 'ws2_32', 'kernel32', 'oleaut32', 'dinput8', 'dxguid', 'ksuser', 'imm32'])
+        env.Append(LIBS=['mingw32', 'opengl32', 'dsound', 'ole32', 'd3d9', 'winmm', 'gdi32', 'iphlpapi', 'shlwapi', 'wsock32', 'ws2_32', 'kernel32', 'oleaut32', 'dinput8', 'dxguid', 'ksuser', 'imm32', 'bcrypt'])
 
         env.Append(CPPFLAGS=['-DMINGW_ENABLED'])
 

--- a/thirdparty/mbedtls/library/entropy_poll.c
+++ b/thirdparty/mbedtls/library/entropy_poll.c
@@ -54,28 +54,41 @@
 #define _WIN32_WINNT 0x0400
 #endif
 #include <windows.h>
-#include <wincrypt.h>
+#include <bcrypt.h>
+#if _MSC_VER <= 1600
+/* Visual Studio 2010 and earlier issue a warning when both <stdint.h> and <intsafe.h> are included, as they
+ * redefine a number of <TYPE>_MAX constants. These constants are guaranteed to be the same, though, so
+ * we suppress the warning when including intsafe.h.
+ */
+#pragma warning( push )
+#pragma warning( disable : 4005 )
+#endif
+#include <intsafe.h>
+#if _MSC_VER <= 1600
+#pragma warning( pop )
+#endif
 
 int mbedtls_platform_entropy_poll( void *data, unsigned char *output, size_t len,
                            size_t *olen )
 {
-    HCRYPTPROV provider;
+    ULONG len_as_ulong = 0;
     ((void) data);
     *olen = 0;
 
-    if( CryptAcquireContext( &provider, NULL, NULL,
-                              PROV_RSA_FULL, CRYPT_VERIFYCONTEXT ) == FALSE )
+    /*
+     * BCryptGenRandom takes ULONG for size, which is smaller than size_t on 64-bit platforms.
+     * Ensure len's value can be safely converted into a ULONG.
+     */
+    if ( FAILED( SizeTToULong( len, &len_as_ulong ) ) )
     {
         return( MBEDTLS_ERR_ENTROPY_SOURCE_FAILED );
     }
 
-    if( CryptGenRandom( provider, (DWORD) len, output ) == FALSE )
+    if ( !BCRYPT_SUCCESS( BCryptGenRandom( NULL, output, len_as_ulong, BCRYPT_USE_SYSTEM_PREFERRED_RNG ) ) )
     {
-        CryptReleaseContext( provider, 0 );
         return( MBEDTLS_ERR_ENTROPY_SOURCE_FAILED );
     }
 
-    CryptReleaseContext( provider, 0 );
     *olen = len;
 
     return( 0 );

--- a/thirdparty/mbedtls/library/net_sockets.c
+++ b/thirdparty/mbedtls/library/net_sockets.c
@@ -49,7 +49,7 @@
 #undef _WIN32_WINNT
 #endif
 /* Enables getaddrinfo() & Co */
-#define _WIN32_WINNT 0x0501
+#define _WIN32_WINNT 0x0601
 #include <ws2tcpip.h>
 
 #include <winsock2.h>

--- a/thirdparty/mbedtls/library/x509_crt.c
+++ b/thirdparty/mbedtls/library/x509_crt.c
@@ -62,6 +62,18 @@
 
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
 #include <windows.h>
+#if _MSC_VER <= 1600
+/* Visual Studio 2010 and earlier issue a warning when both <stdint.h> and <intsafe.h> are included, as they
+ * redefine a number of <TYPE>_MAX constants. These constants are guaranteed to be the same, though, so
+ * we suppress the warning when including intsafe.h.
+ */
+#pragma warning( push )
+#pragma warning( disable : 4005 )
+#endif
+#include <intsafe.h>
+#if _MSC_VER <= 1600
+#pragma warning( pop )
+#endif
 #else
 #include <time.h>
 #endif
@@ -1110,6 +1122,7 @@ int mbedtls_x509_crt_parse_path( mbedtls_x509_crt *chain, const char *path )
     char filename[MAX_PATH];
     char *p;
     size_t len = strlen( path );
+    int lengthAsInt = 0;
 
     WIN32_FIND_DATAW file_data;
     HANDLE hFind;
@@ -1124,7 +1137,10 @@ int mbedtls_x509_crt_parse_path( mbedtls_x509_crt *chain, const char *path )
     p = filename + len;
     filename[len++] = '*';
 
-    w_ret = MultiByteToWideChar( CP_ACP, 0, filename, (int)len, szDir,
+    if ( FAILED ( SizeTToInt( len, &lengthAsInt ) ) )
+        return( MBEDTLS_ERR_X509_FILE_IO_ERROR );
+
+    w_ret = MultiByteToWideChar( CP_ACP, 0, filename, lengthAsInt, szDir,
                                  MAX_PATH - 3 );
     if( w_ret == 0 )
         return( MBEDTLS_ERR_X509_BAD_INPUT_DATA );
@@ -1141,8 +1157,11 @@ int mbedtls_x509_crt_parse_path( mbedtls_x509_crt *chain, const char *path )
         if( file_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY )
             continue;
 
+        if ( FAILED( SizeTToInt( wcslen( file_data.cFileName ), &lengthAsInt ) ) )
+            return( MBEDTLS_ERR_X509_FILE_IO_ERROR );
+
         w_ret = WideCharToMultiByte( CP_ACP, 0, file_data.cFileName,
-                                     lstrlenW( file_data.cFileName ),
+                                     lengthAsInt,
                                      p, (int) len - 1,
                                      NULL, NULL );
         if( w_ret == 0 )


### PR DESCRIPTION
In this PR:

- Add correct includes in UWP builds (thanks @vnen)
- Import PR 730 from mbedTLS repo (seems ready to be approved)
- Add new linked library bcrypt (used by mbedTLS with that patch). Should I squash the commit? Can I add the library in the module `SCsub`?)
- Force _WIN32_WINNT to `0x0601` in `mbedtls/library/net_sockets.c` (maybe worth reporting this upstream relative to issue 1228).

I suppose I should also update the README for the mbedTLS module... or maybe not, if they gets upstreamed.