### PR TITLE
2 to 3 exporter: Add Color and Reference Frame/Rect to type renames

### DIFF
--- a/editor/editor_export_godot3.cpp
+++ b/editor/editor_export_godot3.cpp
@@ -476,6 +476,8 @@ static const char *type_renames[][2] = {
 	{ "SamplePlayer2D", "AudioStreamPlayer2D" },
 	{ "SoundPlayer2D", "Node2D" },
 	{ "SampleLibrary", "Resource" },
+	{ "ColorFrame", "ColorRect" },
+	{ "ReferenceFrame", "ReferenceRect" },
 	{ "TextureFrame", "TextureRect" },
 	{ "Patch9Frame", "NinePatchRect" },
 	{ "FixedMaterial", "SpatialMaterial" },


### PR DESCRIPTION
More `Frame` to `Rect` renames.