### PR TITLE
Godot now allows built-in irrespective of the filepath.

### DIFF
--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -535,15 +535,19 @@ void ScriptCreateDialog::_update_dialog() {
 
 	/* Is Script created or loaded from existing file */
 
-	if (is_new_script_created) {
+	if (is_built_in) {
+		get_ok()->set_text(TTR("Create"));
+		parent_name->set_editable(true);
+		parent_browse_button->set_disabled(false);
+		internal->set_disabled(!supports_built_in);
+		_msg_path_valid(true, TTR("Built-in script (into scene file)"));
+	} else if (is_new_script_created) {
 		// New Script Created
 		get_ok()->set_text(TTR("Create"));
 		parent_name->set_editable(true);
 		parent_browse_button->set_disabled(false);
 		internal->set_disabled(!supports_built_in);
-		if (is_built_in) {
-			_msg_path_valid(true, TTR("Built-in script (into scene file)"));
-		} else if (is_path_valid) {
+		if (is_path_valid) {
 			_msg_path_valid(true, TTR("Create new script file"));
 		}
 	} else {
@@ -551,7 +555,7 @@ void ScriptCreateDialog::_update_dialog() {
 		get_ok()->set_text(TTR("Load"));
 		parent_name->set_editable(false);
 		parent_browse_button->set_disabled(true);
-		internal->set_disabled(true);
+		internal->set_disabled(!supports_built_in);
 		if (is_path_valid) {
 			_msg_path_valid(true, TTR("Load existing script file"));
 		}


### PR DESCRIPTION
Since the file in the filepath is irrelevant when setting the file
as built-in, changes have been made to allow setting to built-in
even if the file in the path exists.

Fixes #16425