### PR TITLE
Enable snapping in 3D when control key pressed

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -4691,6 +4691,8 @@ void SpatialEditor::_unhandled_key_input(Ref<InputEvent> p_event) {
 	if (!is_visible_in_tree() || get_viewport()->gui_has_modal_stack())
 		return;
 
+	snap_key_enabled = Input::get_singleton()->is_key_pressed(KEY_CONTROL);
+
 	Ref<InputEventKey> k = p_event;
 
 	if (k.is_valid()) {
@@ -4962,6 +4964,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	editor_selection->add_editor_plugin(this);
 
 	snap_enabled = false;
+	snap_key_enabled = false;
 	tool_mode = TOOL_MODE_SELECT;
 
 	hbc_menu = memnew(HBoxContainer);

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -505,6 +505,7 @@ private:
 	ConfirmationDialog *settings_dialog;
 
 	bool snap_enabled;
+	bool snap_key_enabled;
 	LineEdit *snap_translate;
 	LineEdit *snap_rotate;
 	LineEdit *snap_scale;
@@ -579,7 +580,7 @@ public:
 
 	ToolMode get_tool_mode() const { return tool_mode; }
 	bool are_local_coords_enabled() const { return tool_option_button[SpatialEditor::TOOL_OPT_LOCAL_COORDS]->is_pressed(); }
-	bool is_snap_enabled() const { return snap_enabled; }
+	bool is_snap_enabled() const { return snap_enabled ^ snap_key_enabled; }
 	float get_translate_snap() const { return snap_translate->get_text().to_double(); }
 	float get_rotate_snap() const { return snap_rotate->get_text().to_double(); }
 	float get_scale_snap() const { return snap_scale->get_text().to_double(); }


### PR DESCRIPTION
I think the control key can be used simular to Blender, Unity and other 3D editor / engines for temporary toggle snapping when its pressed.