### PR TITLE
Allow actions to provide an analog value

### DIFF
--- a/core/input_map.h
+++ b/core/input_map.h
@@ -46,6 +46,7 @@ public:
 
 	struct Action {
 		int id;
+		float deadzone;
 		List<Ref<InputEvent> > inputs;
 	};
 
@@ -54,7 +55,7 @@ private:
 
 	mutable Map<StringName, Action> input_map;
 
-	List<Ref<InputEvent> >::Element *_find_event(List<Ref<InputEvent> > &p_list, const Ref<InputEvent> &p_event, bool p_action_test = false) const;
+	List<Ref<InputEvent> >::Element *_find_event(Action p_action, const Ref<InputEvent> &p_event, bool *p_pressed = NULL, float *p_strength = NULL) const;
 
 	Array _get_action_list(const StringName &p_action);
 	Array _get_actions();
@@ -67,15 +68,17 @@ public:
 
 	bool has_action(const StringName &p_action) const;
 	List<StringName> get_actions() const;
-	void add_action(const StringName &p_action);
+	void add_action(const StringName &p_action, float p_deadzone = 0.5);
 	void erase_action(const StringName &p_action);
 
+	void action_set_deadzone(const StringName &p_action, float p_deadzone);
 	void action_add_event(const StringName &p_action, const Ref<InputEvent> &p_event);
 	bool action_has_event(const StringName &p_action, const Ref<InputEvent> &p_event);
 	void action_erase_event(const StringName &p_action, const Ref<InputEvent> &p_event);
 
 	const List<Ref<InputEvent> > *get_action_list(const StringName &p_action);
 	bool event_is_action(const Ref<InputEvent> &p_event, const StringName &p_action) const;
+	bool event_get_action_status(const Ref<InputEvent> &p_event, const StringName &p_action, bool *p_pressed = NULL, float *p_strength = NULL) const;
 
 	const Map<StringName, Action> &get_action_map() const;
 	void load_from_globals();

--- a/core/os/input.cpp
+++ b/core/os/input.cpp
@@ -57,6 +57,7 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_action_pressed", "action"), &Input::is_action_pressed);
 	ClassDB::bind_method(D_METHOD("is_action_just_pressed", "action"), &Input::is_action_just_pressed);
 	ClassDB::bind_method(D_METHOD("is_action_just_released", "action"), &Input::is_action_just_released);
+	ClassDB::bind_method(D_METHOD("get_action_strength", "action"), &Input::get_action_strength);
 	ClassDB::bind_method(D_METHOD("add_joy_mapping", "mapping", "update_existing"), &Input::add_joy_mapping, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_joy_mapping", "guid"), &Input::remove_joy_mapping);
 	ClassDB::bind_method(D_METHOD("joy_connection_changed", "device", "connected", "name", "guid"), &Input::joy_connection_changed);
@@ -118,7 +119,7 @@ void Input::get_argument_options(const StringName &p_function, int p_idx, List<S
 #ifdef TOOLS_ENABLED
 
 	String pf = p_function;
-	if (p_idx == 0 && (pf == "is_action_pressed" || pf == "action_press" || pf == "action_release" || pf == "is_action_just_pressed" || pf == "is_action_just_released")) {
+	if (p_idx == 0 && (pf == "is_action_pressed" || pf == "action_press" || pf == "action_release" || pf == "is_action_just_pressed" || pf == "is_action_just_released" || pf == "get_action_strength")) {
 
 		List<PropertyInfo> pinfo;
 		ProjectSettings::get_singleton()->get_property_list(&pinfo);

--- a/core/os/input.h
+++ b/core/os/input.h
@@ -85,6 +85,7 @@ public:
 	virtual bool is_action_pressed(const StringName &p_action) const = 0;
 	virtual bool is_action_just_pressed(const StringName &p_action) const = 0;
 	virtual bool is_action_just_released(const StringName &p_action) const = 0;
+	virtual float get_action_strength(const StringName &p_action) const = 0;
 
 	virtual float get_joy_axis(int p_device, int p_axis) const = 0;
 	virtual String get_joy_name(int p_idx) = 0;

--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -41,11 +41,6 @@ int InputEvent::get_device() const {
 	return device;
 }
 
-bool InputEvent::is_pressed() const {
-
-	return false;
-}
-
 bool InputEvent::is_action(const StringName &p_action) const {
 
 	return InputMap::get_singleton()->event_is_action(Ref<InputEvent>((InputEvent *)this), p_action);
@@ -53,11 +48,29 @@ bool InputEvent::is_action(const StringName &p_action) const {
 
 bool InputEvent::is_action_pressed(const StringName &p_action) const {
 
-	return (is_pressed() && !is_echo() && is_action(p_action));
+	bool pressed;
+	bool valid = InputMap::get_singleton()->event_get_action_status(Ref<InputEvent>((InputEvent *)this), p_action, &pressed);
+	return valid && pressed && !is_echo();
 }
+
 bool InputEvent::is_action_released(const StringName &p_action) const {
 
-	return (!is_pressed() && is_action(p_action));
+	bool pressed;
+	bool valid = InputMap::get_singleton()->event_get_action_status(Ref<InputEvent>((InputEvent *)this), p_action, &pressed);
+	return valid && !pressed;
+}
+
+float InputEvent::get_action_strength(const StringName &p_action) const {
+
+	bool pressed;
+	float strength;
+	bool valid = InputMap::get_singleton()->event_get_action_status(Ref<InputEvent>((InputEvent *)this), p_action, &pressed, &strength);
+	return valid ? strength : 0.0f;
+}
+
+bool InputEvent::is_pressed() const {
+
+	return false;
 }
 
 bool InputEvent::is_echo() const {
@@ -75,7 +88,7 @@ String InputEvent::as_text() const {
 	return String();
 }
 
-bool InputEvent::action_match(const Ref<InputEvent> &p_event) const {
+bool InputEvent::action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float p_deadzone) const {
 
 	return false;
 }
@@ -95,15 +108,16 @@ void InputEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_device", "device"), &InputEvent::set_device);
 	ClassDB::bind_method(D_METHOD("get_device"), &InputEvent::get_device);
 
-	ClassDB::bind_method(D_METHOD("is_pressed"), &InputEvent::is_pressed);
 	ClassDB::bind_method(D_METHOD("is_action", "action"), &InputEvent::is_action);
 	ClassDB::bind_method(D_METHOD("is_action_pressed", "action"), &InputEvent::is_action_pressed);
 	ClassDB::bind_method(D_METHOD("is_action_released", "action"), &InputEvent::is_action_released);
+	ClassDB::bind_method(D_METHOD("get_action_strength", "action"), &InputEvent::get_action_strength);
+
+	ClassDB::bind_method(D_METHOD("is_pressed"), &InputEvent::is_pressed);
 	ClassDB::bind_method(D_METHOD("is_echo"), &InputEvent::is_echo);
 
 	ClassDB::bind_method(D_METHOD("as_text"), &InputEvent::as_text);
 
-	ClassDB::bind_method(D_METHOD("action_match", "event"), &InputEvent::action_match);
 	ClassDB::bind_method(D_METHOD("shortcut_match", "event"), &InputEvent::shortcut_match);
 
 	ClassDB::bind_method(D_METHOD("is_action_type"), &InputEvent::is_action_type);
@@ -281,7 +295,7 @@ String InputEventKey::as_text() const {
 	return kc;
 }
 
-bool InputEventKey::action_match(const Ref<InputEvent> &p_event) const {
+bool InputEventKey::action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float p_deadzone) const {
 
 	Ref<InputEventKey> key = p_event;
 	if (key.is_null())
@@ -290,7 +304,14 @@ bool InputEventKey::action_match(const Ref<InputEvent> &p_event) const {
 	uint32_t code = get_scancode_with_modifiers();
 	uint32_t event_code = key->get_scancode_with_modifiers();
 
-	return get_scancode() == key->get_scancode() && (!key->is_pressed() || (code & event_code) == code);
+	bool match = get_scancode() == key->get_scancode() && (!key->is_pressed() || (code & event_code) == code);
+	if (match) {
+		if (p_pressed != NULL)
+			*p_pressed = key->is_pressed();
+		if (p_strength != NULL)
+			*p_strength = (*p_pressed) ? 1.0f : 0.0f;
+	}
+	return match;
 }
 
 bool InputEventKey::shortcut_match(const Ref<InputEvent> &p_event) const {
@@ -446,13 +467,21 @@ Ref<InputEvent> InputEventMouseButton::xformed_by(const Transform2D &p_xform, co
 	return mb;
 }
 
-bool InputEventMouseButton::action_match(const Ref<InputEvent> &p_event) const {
+bool InputEventMouseButton::action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float p_deadzone) const {
 
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_null())
 		return false;
 
-	return mb->button_index == button_index;
+	bool match = mb->button_index == button_index;
+	if (match) {
+		if (p_pressed != NULL)
+			*p_pressed = mb->is_pressed();
+		if (p_strength != NULL)
+			*p_strength = (*p_pressed) ? 1.0f : 0.0f;
+	}
+
+	return match;
 }
 
 String InputEventMouseButton::as_text() const {
@@ -610,6 +639,7 @@ void InputEventJoypadMotion::set_axis_value(float p_value) {
 
 	axis_value = p_value;
 }
+
 float InputEventJoypadMotion::get_axis_value() const {
 
 	return axis_value;
@@ -617,16 +647,23 @@ float InputEventJoypadMotion::get_axis_value() const {
 
 bool InputEventJoypadMotion::is_pressed() const {
 
-	return Math::abs(axis_value) > 0.5f;
+	return Math::abs(axis_value) >= 0.5f;
 }
 
-bool InputEventJoypadMotion::action_match(const Ref<InputEvent> &p_event) const {
+bool InputEventJoypadMotion::action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float p_deadzone) const {
 
 	Ref<InputEventJoypadMotion> jm = p_event;
 	if (jm.is_null())
 		return false;
 
-	return (axis == jm->axis && ((axis_value < 0) == (jm->axis_value < 0) || jm->axis_value == 0));
+	bool match = (axis == jm->axis && ((axis_value < 0) == (jm->axis_value < 0) || jm->axis_value == 0));
+	if (match) {
+		if (p_pressed != NULL)
+			*p_pressed = Math::abs(jm->get_axis_value() >= p_deadzone);
+		if (p_strength != NULL)
+			*p_strength = (*p_pressed) ? Math::inverse_lerp(p_deadzone, 1.0f, Math::abs(jm->get_axis_value())) : 0.0f;
+	}
+	return match;
 }
 
 String InputEventJoypadMotion::as_text() const {
@@ -681,13 +718,21 @@ float InputEventJoypadButton::get_pressure() const {
 	return pressure;
 }
 
-bool InputEventJoypadButton::action_match(const Ref<InputEvent> &p_event) const {
+bool InputEventJoypadButton::action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float p_deadzone) const {
 
 	Ref<InputEventJoypadButton> jb = p_event;
 	if (jb.is_null())
 		return false;
 
-	return button_index == jb->button_index;
+	bool match = button_index == jb->button_index;
+	if (match) {
+		if (p_pressed != NULL)
+			*p_pressed = jb->is_pressed();
+		if (p_strength != NULL)
+			*p_strength = (*p_pressed) ? 1.0f : 0.0f;
+	}
+
+	return match;
 }
 
 String InputEventJoypadButton::as_text() const {

--- a/core/os/input_event.h
+++ b/core/os/input_event.h
@@ -154,16 +154,21 @@ public:
 	void set_device(int p_device);
 	int get_device() const;
 
+	bool is_action(const StringName &p_action) const;
+	bool is_action_pressed(const StringName &p_action) const;
+	bool is_action_released(const StringName &p_action) const;
+	float get_action_strength(const StringName &p_action) const;
+
+	// To be removed someday, since they do not make sense for all events
 	virtual bool is_pressed() const;
-	virtual bool is_action(const StringName &p_action) const;
-	virtual bool is_action_pressed(const StringName &p_action) const;
-	virtual bool is_action_released(const StringName &p_action) const;
 	virtual bool is_echo() const;
+	// ...-.
+
 	virtual String as_text() const;
 
 	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const;
 
-	virtual bool action_match(const Ref<InputEvent> &p_event) const;
+	virtual bool action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float p_deadzone) const;
 	virtual bool shortcut_match(const Ref<InputEvent> &p_event) const;
 	virtual bool is_action_type() const;
 
@@ -244,7 +249,7 @@ public:
 
 	uint32_t get_scancode_with_modifiers() const;
 
-	virtual bool action_match(const Ref<InputEvent> &p_event) const;
+	virtual bool action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float p_deadzone) const;
 	virtual bool shortcut_match(const Ref<InputEvent> &p_event) const;
 
 	virtual bool is_action_type() const { return true; }
@@ -305,7 +310,7 @@ public:
 	bool is_doubleclick() const;
 
 	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const;
-	virtual bool action_match(const Ref<InputEvent> &p_event) const;
+	virtual bool action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float p_deadzone) const;
 
 	virtual bool is_action_type() const { return true; }
 	virtual String as_text() const;
@@ -352,7 +357,8 @@ public:
 	float get_axis_value() const;
 
 	virtual bool is_pressed() const;
-	virtual bool action_match(const Ref<InputEvent> &p_event) const;
+
+	virtual bool action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float p_deadzone) const;
 
 	virtual bool is_action_type() const { return true; }
 	virtual String as_text() const;
@@ -379,7 +385,7 @@ public:
 	void set_pressure(float p_pressure);
 	float get_pressure() const;
 
-	virtual bool action_match(const Ref<InputEvent> &p_event) const;
+	virtual bool action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float p_deadzone) const;
 
 	virtual bool is_action_type() const { return true; }
 	virtual String as_text() const;

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -42,7 +42,7 @@
 #include "variant_parser.h"
 #include <zlib.h>
 
-#define FORMAT_VERSION 3
+#define FORMAT_VERSION 4
 
 ProjectSettings *ProjectSettings::singleton = NULL;
 
@@ -262,6 +262,23 @@ bool ProjectSettings::_load_resource_pack(const String &p_pack) {
 	return true;
 }
 
+void ProjectSettings::_convert_to_last_version() {
+	if (!has_setting("config_version") || (int)get_setting("config_version") <= 3) {
+
+		// Converts the actions from array to dictionary (array of events to dictionary with deadzone + events)
+		for (Map<StringName, ProjectSettings::VariantContainer>::Element *E = props.front(); E; E = E->next()) {
+			Variant value = E->get().variant;
+			if (String(E->key()).begins_with("input/") && value.get_type() == Variant::ARRAY) {
+				Array array = value;
+				Dictionary action;
+				action["deadzone"] = Variant(0.5f);
+				action["events"] = array;
+				E->get().variant = action;
+			}
+		}
+	}
+}
+
 Error ProjectSettings::setup(const String &p_path, const String &p_main_pack, bool p_upwards) {
 
 	//If looking for files in network, just use network!
@@ -389,6 +406,8 @@ Error ProjectSettings::setup(const String &p_path, const String &p_main_pack, bo
 
 	if (resource_path.length() && resource_path[resource_path.length() - 1] == '/')
 		resource_path = resource_path.substr(0, resource_path.length() - 1); // chop end
+
+	_convert_to_last_version();
 
 	return OK;
 }

--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -102,6 +102,8 @@ protected:
 
 	Error _save_custom_bnd(const String &p_file);
 
+	void _convert_to_last_version();
+
 	bool _load_resource_pack(const String &p_pack);
 
 	void _add_property_info_bind(const Dictionary &p_info);

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -83,6 +83,8 @@ class ProjectSettingsEditor : public AcceptDialog {
 	OptionButton *device_id;
 	OptionButton *device_index;
 	Label *device_index_label;
+	SpinBox *device_special_value;
+	Label *device_special_value_label;
 	MenuButton *popup_copy_to_feature;
 
 	LineEdit *action_name;

--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -127,6 +127,14 @@ bool InputDefault::is_action_just_released(const StringName &p_action) const {
 	}
 }
 
+float InputDefault::get_action_strength(const StringName &p_action) const {
+	const Map<StringName, Action>::Element *E = action_state.find(p_action);
+	if (!E)
+		return 0.0f;
+
+	return E->get().strength;
+}
+
 float InputDefault::get_joy_axis(int p_device, int p_axis) const {
 
 	_THREAD_SAFE_METHOD_
@@ -330,16 +338,18 @@ void InputDefault::parse_input_event(const Ref<InputEvent> &p_event) {
 		}
 	}
 
-	if (!p_event->is_echo()) {
-		for (const Map<StringName, InputMap::Action>::Element *E = InputMap::get_singleton()->get_action_map().front(); E; E = E->next()) {
+	for (const Map<StringName, InputMap::Action>::Element *E = InputMap::get_singleton()->get_action_map().front(); E; E = E->next()) {
+		if (InputMap::get_singleton()->event_is_action(p_event, E->key())) {
 
-			if (InputMap::get_singleton()->event_is_action(p_event, E->key()) && is_action_pressed(E->key()) != p_event->is_pressed()) {
+			// Save the action's state
+			if (!p_event->is_echo() && is_action_pressed(E->key()) != p_event->is_action_pressed(E->key())) {
 				Action action;
 				action.physics_frame = Engine::get_singleton()->get_physics_frames();
 				action.idle_frame = Engine::get_singleton()->get_idle_frames();
-				action.pressed = p_event->is_pressed();
+				action.pressed = p_event->is_action_pressed(E->key());
 				action_state[E->key()] = action;
 			}
+			action_state[E->key()].strength = p_event->get_action_strength(E->key());
 		}
 	}
 

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -55,6 +55,7 @@ class InputDefault : public Input {
 		uint64_t physics_frame;
 		uint64_t idle_frame;
 		bool pressed;
+		float strength;
 	};
 
 	Map<StringName, Action> action_state;
@@ -182,6 +183,7 @@ public:
 	virtual bool is_action_pressed(const StringName &p_action) const;
 	virtual bool is_action_just_pressed(const StringName &p_action) const;
 	virtual bool is_action_just_released(const StringName &p_action) const;
+	virtual float get_action_strength(const StringName &p_action) const;
 
 	virtual float get_joy_axis(int p_device, int p_axis) const;
 	String get_joy_name(int p_idx);


### PR DESCRIPTION
This is an alternative PR for #16797.

While it does not allow to define named axis, this PR instead assigns a "strength" value to pressed actions. To simulate an axis you can write:
```
var move_x = Input.get_action_value("ui_right") - Input.get_action_value("ui_left")
```
Or, for a single event, `Input.get_action_value("ui_right")`
Thus an action can now be used as a binary or an analog value. Nothing changes in the way you map inputs, and if you use the default actions it works out of the box .

However, to provide more control on how Joystick axis should be considered, this PR also allows to define a "deadzone". This value between 0 and 1 defines the threshold value when a JoystickMotionEvent is considered as pressed or not (an thus how far you have to push the joystick before `get_action_value` returns something else than 0). Here is the single UI change:
![2018-02-21-230248_345x207_scrot](https://user-images.githubusercontent.com/6093119/36508022-bb09d54a-175b-11e8-9119-399c0bf801d6.png)


