### PR TITLE
[Build] Abort compilation on missing return values (CGG/clang)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -353,6 +353,7 @@ if selected_platform in platform_list:
             env.Append(CCFLAGS=['-Wall', '-Wno-unused'])
         else: # 'no'
             env.Append(CCFLAGS=['-w'])
+        env.Append(CCFLAGS=['-Werror=return-type'])
 
     #env['platform_libsuffix'] = env['LIBSUFFIX']
 


### PR DESCRIPTION
Adds `-Werror=return-type` flag to match MSVC behaviour and prevent missing returns like in 7cd867c3fe48187dced1060dedb22cc82f5aa094 and #15299.

Building 7cd867c3fe48187dced1060dedb22cc82f5aa094 on Linux/macOS will produce:
```
In file included from editor/editor_node.cpp:102:
In file included from ./editor/plugins/skeleton_2d_editor_plugin.h:6:
./scene/2d/skeleton_2d.h:38:3: error: control reaches end of non-void function [-Werror,-Wreturn-type]
                }
                ^
```