### PR TITLE
Insert proper copy icon to debugger

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -948,7 +948,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 
 			inspector->edit(variables);
 
-			copy->set_icon(get_icon("Duplicate", "EditorIcons"));
+			copy->set_icon(get_icon("ActionCopy", "EditorIcons"));
 
 			step->set_icon(get_icon("DebugStep", "EditorIcons"));
 			next->set_icon(get_icon("DebugNext", "EditorIcons"));


### PR DESCRIPTION
Thanks to #16909 :tada:, we now have a proper copy icon.
This PR inserts the `ActionCopy` icon to debugger `Copy Error` button.

![Screenshot](https://user-images.githubusercontent.com/19972511/36527074-a384fb5a-17c1-11e8-8d33-d4e366e80e17.png)
