### PR TITLE
Mono project export

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -274,8 +274,6 @@ void EditorExportPlatform::gen_debug_flags(Vector<String> &r_flags, int p_flags)
 }
 
 Error EditorExportPlatform::_save_pack_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total) {
-	if (p_path.ends_with(".so") || p_path.ends_with(".dylib") || p_path.ends_with(".dll"))
-		return OK;
 
 	PackData *pd = (PackData *)p_userdata;
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -118,6 +118,8 @@ void CSharpLanguage::init() {
 
 #ifdef TOOLS_ENABLED
 	EditorNode::add_init_callback(&gdsharp_editor_init_callback);
+
+	GLOBAL_DEF("mono/export/include_scripts_content", true);
 #endif
 }
 

--- a/modules/mono/editor/godotsharp_builds.cpp
+++ b/modules/mono/editor/godotsharp_builds.cpp
@@ -200,7 +200,7 @@ bool GodotSharpBuilds::copy_api_assembly(const String &p_src_dir, const String &
 		memdelete(da);
 
 		if (err != OK) {
-			show_build_error_dialog("Failed to copy " API_ASSEMBLY_NAME ".dll");
+			show_build_error_dialog("Failed to copy " + assembly_file);
 			return false;
 		}
 	}
@@ -283,7 +283,7 @@ bool GodotSharpBuilds::make_api_sln(GodotSharpBuilds::APIType p_api_type) {
 	return true;
 }
 
-bool GodotSharpBuilds::build_project_blocking() {
+bool GodotSharpBuilds::build_project_blocking(const String &p_config) {
 
 	if (!FileAccess::exists(GodotSharpDirs::get_project_sln_path()))
 		return true; // No solution to build
@@ -298,7 +298,7 @@ bool GodotSharpBuilds::build_project_blocking() {
 
 	pr.step("Building project solution");
 
-	MonoBuildInfo build_info(GodotSharpDirs::get_project_sln_path(), "Tools");
+	MonoBuildInfo build_info(GodotSharpDirs::get_project_sln_path(), p_config);
 	if (!GodotSharpBuilds::get_singleton()->build(build_info)) {
 		GodotSharpBuilds::show_build_error_dialog("Failed to build project solution");
 		return false;
@@ -307,6 +307,11 @@ bool GodotSharpBuilds::build_project_blocking() {
 	pr.step("Done");
 
 	return true;
+}
+
+bool GodotSharpBuilds::editor_build_callback() {
+
+	return build_project_blocking("Tools");
 }
 
 GodotSharpBuilds *GodotSharpBuilds::singleton = NULL;
@@ -362,7 +367,7 @@ GodotSharpBuilds::GodotSharpBuilds() {
 
 	singleton = this;
 
-	EditorNode::get_singleton()->add_build_callback(&GodotSharpBuilds::build_project_blocking);
+	EditorNode::get_singleton()->add_build_callback(&GodotSharpBuilds::editor_build_callback);
 
 	// Build tool settings
 	EditorSettings *ed_settings = EditorSettings::get_singleton();
@@ -462,6 +467,7 @@ void GodotSharpBuilds::BuildProcess::start(bool p_blocking) {
 
 	if (ex) {
 		exited = true;
+		GDMonoUtils::print_unhandled_exception(ex);
 		String message = "The build constructor threw an exception.\n" + GDMonoUtils::get_exception_name_and_message(ex);
 		build_tab->on_build_exec_failed(message);
 		ERR_EXPLAIN(message);
@@ -482,6 +488,7 @@ void GodotSharpBuilds::BuildProcess::start(bool p_blocking) {
 
 	if (ex) {
 		exited = true;
+		GDMonoUtils::print_unhandled_exception(ex);
 		String message = "The build method threw an exception.\n" + GDMonoUtils::get_exception_name_and_message(ex);
 		build_tab->on_build_exec_failed(message);
 		ERR_EXPLAIN(message);

--- a/modules/mono/editor/godotsharp_editor.cpp
+++ b/modules/mono/editor/godotsharp_editor.cpp
@@ -41,6 +41,7 @@
 #include "../utils/path_utils.h"
 #include "bindings_generator.h"
 #include "csharp_project.h"
+#include "godotsharp_export.h"
 #include "net_solution.h"
 
 #ifdef WINDOWS_ENABLED
@@ -316,6 +317,11 @@ GodotSharpEditor::GodotSharpEditor(EditorNode *p_editor) {
 	EditorSettings *ed_settings = EditorSettings::get_singleton();
 	EDITOR_DEF("mono/editor/external_editor", EDITOR_NONE);
 	ed_settings->add_property_hint(PropertyInfo(Variant::INT, "mono/editor/external_editor", PROPERTY_HINT_ENUM, "None,MonoDevelop,Visual Studio Code"));
+
+	// Export plugin
+	Ref<GodotSharpExport> godotsharp_export;
+	godotsharp_export.instance();
+	EditorExport::get_singleton()->add_export_plugin(godotsharp_export);
 }
 
 GodotSharpEditor::~GodotSharpEditor() {

--- a/modules/mono/editor/godotsharp_editor.h
+++ b/modules/mono/editor/godotsharp_editor.h
@@ -32,7 +32,6 @@
 #define GODOTSHARP_EDITOR_H
 
 #include "godotsharp_builds.h"
-
 #include "monodevelop_instance.h"
 
 class GodotSharpEditor : public Node {

--- a/modules/mono/editor/godotsharp_export.cpp
+++ b/modules/mono/editor/godotsharp_export.cpp
@@ -1,0 +1,163 @@
+/*************************************************************************/
+/*  godotsharp_export.cpp                                                */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "godotsharp_export.h"
+
+#include "../csharp_script.h"
+#include "../godotsharp_defs.h"
+#include "../godotsharp_dirs.h"
+#include "godotsharp_builds.h"
+
+void GodotSharpExport::_export_file(const String &p_path, const String &p_type, const Set<String> &p_features) {
+
+	if (p_type != CSharpLanguage::get_singleton()->get_type())
+		return;
+
+	ERR_FAIL_COND(p_path.get_extension() != CSharpLanguage::get_singleton()->get_extension());
+
+	// TODO what if the source file is not part of the game's C# project
+
+	if (!GLOBAL_GET("mono/export/include_scripts_content")) {
+		// We don't want to include the source code on exported games
+		add_file(p_path, Vector<uint8_t>(), false);
+		skip();
+	}
+}
+
+void GodotSharpExport::_export_begin(const Set<String> &p_features, bool p_debug, const String &p_path, int p_flags) {
+
+	// TODO right now there is no way to stop the export process with an error
+
+	String build_config = p_debug ? "Debug" : "Release";
+
+	ERR_FAIL_COND(!GodotSharpBuilds::build_project_blocking(build_config));
+
+	// Add API assemblies
+
+	String core_api_dll_path = GodotSharpDirs::get_res_assemblies_dir().plus_file(API_ASSEMBLY_NAME ".dll");
+	ERR_FAIL_COND(!_add_assembly(core_api_dll_path, core_api_dll_path));
+
+	String editor_api_dll_path = GodotSharpDirs::get_res_assemblies_dir().plus_file(EDITOR_API_ASSEMBLY_NAME ".dll");
+	ERR_FAIL_COND(!_add_assembly(editor_api_dll_path, editor_api_dll_path));
+
+	// Add project assembly
+
+	String project_dll_name = ProjectSettings::get_singleton()->get("application/config/name");
+	if (project_dll_name.empty()) {
+		project_dll_name = "UnnamedProject";
+	}
+
+	String project_dll_src_path = GodotSharpDirs::get_res_temp_assemblies_base_dir().plus_file(build_config).plus_file(project_dll_name + ".dll");
+	String project_dll_dst_path = GodotSharpDirs::get_res_assemblies_dir().plus_file(project_dll_name + ".dll");
+	ERR_FAIL_COND(!_add_assembly(project_dll_src_path, project_dll_dst_path));
+
+	// Add dependencies
+
+	MonoDomain *prev_domain = mono_domain_get();
+	MonoDomain *export_domain = GDMonoUtils::create_domain("GodotEngine.ProjectExportDomain");
+
+	ERR_FAIL_COND(!export_domain);
+	ERR_FAIL_COND(!mono_domain_set(export_domain, false));
+
+	Map<String, String> dependencies;
+	dependencies.insert("mscorlib", GDMono::get_singleton()->get_corlib_assembly()->get_path());
+
+	GDMonoAssembly *scripts_assembly = GDMonoAssembly::load_from(project_dll_name, project_dll_src_path, /* refonly: */ true);
+
+	ERR_EXPLAIN("Cannot load refonly assembly: " + project_dll_name);
+	ERR_FAIL_COND(!scripts_assembly);
+
+	Error depend_error = _get_assembly_dependencies(scripts_assembly, dependencies);
+
+	GDMono::get_singleton()->finalize_and_unload_domain(export_domain);
+	mono_domain_set(prev_domain, false);
+
+	ERR_FAIL_COND(depend_error != OK);
+
+	for (Map<String, String>::Element *E = dependencies.front(); E; E = E->next()) {
+		String depend_src_path = E->value();
+		String depend_dst_path = GodotSharpDirs::get_res_assemblies_dir().plus_file(depend_src_path.get_file());
+		ERR_FAIL_COND(!_add_assembly(depend_src_path, depend_dst_path));
+	}
+}
+
+bool GodotSharpExport::_add_assembly(const String &p_src_path, const String &p_dst_path) {
+
+	FileAccessRef f = FileAccess::open(p_src_path, FileAccess::READ);
+	ERR_FAIL_COND_V(!f, false);
+
+	Vector<uint8_t> data;
+	data.resize(f->get_len());
+	f->get_buffer(data.ptrw(), data.size());
+
+	add_file(p_dst_path, data, false);
+
+	return true;
+}
+
+Error GodotSharpExport::_get_assembly_dependencies(GDMonoAssembly *p_assembly, Map<String, String> &r_dependencies) {
+
+	MonoImage *image = p_assembly->get_image();
+
+	for (int i = 0; i < mono_image_get_table_rows(image, MONO_TABLE_ASSEMBLYREF); i++) {
+		MonoAssemblyName *ref_aname = aname_prealloc;
+		mono_assembly_get_assemblyref(image, i, ref_aname);
+		String ref_name = mono_assembly_name_get_name(ref_aname);
+
+		if (ref_name == "mscorlib" || r_dependencies.find(ref_name))
+			continue;
+
+		GDMonoAssembly *ref_assembly = NULL;
+		if (!GDMono::get_singleton()->load_assembly(ref_name, ref_aname, &ref_assembly, /* refonly: */ true)) {
+			ERR_EXPLAIN("Cannot load refonly assembly: " + ref_name);
+			ERR_FAIL_V(ERR_CANT_RESOLVE);
+		}
+
+		r_dependencies.insert(ref_name, ref_assembly->get_path());
+
+		Error err = _get_assembly_dependencies(ref_assembly, r_dependencies);
+		if (err != OK)
+			return err;
+	}
+
+	return OK;
+}
+
+GodotSharpExport::GodotSharpExport() {
+	// MonoAssemblyName is an incomplete type (internal to mono), so we can't allocate it ourselves.
+	// There isn't any api to allocate an empty one either, so we need to do it this way.
+	aname_prealloc = mono_assembly_name_new("whatever");
+	mono_assembly_name_free(aname_prealloc); // "it does not frees the object itself, only the name members" (typo included)
+}
+
+GodotSharpExport::~GodotSharpExport() {
+	if (aname_prealloc)
+		mono_free(aname_prealloc);
+}

--- a/modules/mono/editor/godotsharp_export.h
+++ b/modules/mono/editor/godotsharp_export.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  godotsharp_builds.h                                                  */
+/*  godotsharp_export.h                                                  */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,77 +28,30 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOTSHARP_BUILDS_H
-#define GODOTSHARP_BUILDS_H
+#ifndef GODOTSHARP_EXPORT_H
+#define GODOTSHARP_EXPORT_H
 
-#include "mono_bottom_panel.h"
-#include "mono_build_info.h"
+#include <mono/metadata/image.h>
 
-typedef void (*GodotSharpBuild_ExitCallback)(int);
+#include "editor/editor_export.h"
 
-class GodotSharpBuilds {
+#include "../mono_gd/gd_mono_header.h"
 
-private:
-	struct BuildProcess {
-		Ref<MonoGCHandle> build_instance;
-		MonoBuildInfo build_info;
-		MonoBuildTab *build_tab;
-		GodotSharpBuild_ExitCallback exit_callback;
-		bool exited;
-		int exit_code;
+class GodotSharpExport : public EditorExportPlugin {
 
-		void on_exit(int p_exit_code);
-		void start(bool p_blocking = false);
+	MonoAssemblyName *aname_prealloc;
 
-		BuildProcess() {}
-		BuildProcess(const MonoBuildInfo &p_build_info, GodotSharpBuild_ExitCallback p_callback = NULL);
-	};
+	bool _add_assembly(const String &p_src_path, const String &p_dst_path);
 
-	HashMap<MonoBuildInfo, BuildProcess, MonoBuildInfo::Hasher> builds;
+	Error _get_assembly_dependencies(GDMonoAssembly *p_assembly, Map<String, String> &r_dependencies);
 
-	static GodotSharpBuilds *singleton;
-
-	friend class GDMono;
-	static void _register_internal_calls();
+protected:
+	virtual void _export_file(const String &p_path, const String &p_type, const Set<String> &p_features);
+	virtual void _export_begin(const Set<String> &p_features, bool p_debug, const String &p_path, int p_flags);
 
 public:
-	enum APIType {
-		API_CORE,
-		API_EDITOR
-	};
-
-	enum BuildTool {
-		MSBUILD_MONO,
-#ifdef WINDOWS_ENABLED
-		MSBUILD
-#else
-		XBUILD // Deprecated
-#endif
-	};
-
-	_FORCE_INLINE_ static GodotSharpBuilds *get_singleton() { return singleton; }
-
-	static void show_build_error_dialog(const String &p_message);
-
-	void build_exit_callback(const MonoBuildInfo &p_build_info, int p_exit_code);
-
-	void restart_build(MonoBuildTab *p_build_tab);
-	void stop_build(MonoBuildTab *p_build_tab);
-
-	bool build(const MonoBuildInfo &p_build_info);
-	bool build_async(const MonoBuildInfo &p_build_info, GodotSharpBuild_ExitCallback p_callback = NULL);
-
-	static bool build_api_sln(const String &p_name, const String &p_api_sln_dir, const String &p_config);
-	static bool copy_api_assembly(const String &p_src_dir, const String &p_dst_dir, const String &p_assembly_name);
-
-	static bool make_api_sln(APIType p_api_type);
-
-	static bool build_project_blocking(const String &p_config);
-
-	static bool editor_build_callback();
-
-	GodotSharpBuilds();
-	~GodotSharpBuilds();
+	GodotSharpExport();
+	~GodotSharpExport();
 };
 
-#endif // GODOTSHARP_BUILDS_H
+#endif // GODOTSHARP_EXPORT_H

--- a/modules/mono/editor/mono_bottom_panel.cpp
+++ b/modules/mono/editor/mono_bottom_panel.cpp
@@ -142,7 +142,7 @@ void MonoBottomPanel::_errors_toggled(bool p_pressed) {
 
 void MonoBottomPanel::_build_project_pressed() {
 
-	GodotSharpBuilds::get_singleton()->build_project_blocking();
+	GodotSharpBuilds::get_singleton()->build_project_blocking("Tools");
 
 	MonoReloadNode::get_singleton()->restart_reload_timer();
 	CSharpLanguage::get_singleton()->reload_assemblies_if_needed(true);

--- a/modules/mono/mono_gd/gd_mono.h
+++ b/modules/mono/mono_gd/gd_mono.h
@@ -94,8 +94,6 @@ class GDMono {
 	void _initialize_and_check_api_hashes();
 #endif
 
-	bool _load_assembly(const String &p_name, GDMonoAssembly **r_assembly);
-
 	GDMonoLog *gdmono_log;
 
 #ifdef WINDOWS_ENABLED
@@ -144,6 +142,10 @@ public:
 #ifdef TOOLS_ENABLED
 	Error reload_scripts_domain();
 #endif
+
+	bool load_assembly(const String &p_name, GDMonoAssembly **r_assembly, bool p_refonly = false);
+	bool load_assembly(const String &p_name, MonoAssemblyName *p_aname, GDMonoAssembly **r_assembly, bool p_refonly = false);
+	Error finalize_and_unload_domain(MonoDomain *p_domain);
 
 	void initialize();
 

--- a/modules/mono/mono_gd/gd_mono_assembly.h
+++ b/modules/mono/mono_gd/gd_mono_assembly.h
@@ -71,6 +71,7 @@ class GDMonoAssembly {
 	MonoAssembly *assembly;
 	MonoImage *image;
 
+	bool refonly;
 	bool loaded;
 
 	String name;
@@ -90,19 +91,25 @@ class GDMonoAssembly {
 	static bool no_search;
 	static Vector<String> search_dirs;
 
-	static MonoAssembly *_search_hook(MonoAssemblyName *aname, void *user_data);
-	static MonoAssembly *_preload_hook(MonoAssemblyName *aname, char **assemblies_path, void *user_data);
+	static MonoAssembly *assembly_search_hook(MonoAssemblyName *aname, void *user_data);
+	static MonoAssembly *assembly_refonly_search_hook(MonoAssemblyName *aname, void *user_data);
+	static MonoAssembly *assembly_preload_hook(MonoAssemblyName *aname, char **assemblies_path, void *user_data);
+	static MonoAssembly *assembly_refonly_preload_hook(MonoAssemblyName *aname, char **assemblies_path, void *user_data);
 
-	static MonoAssembly *_load_assembly_from(const String &p_name, const String &p_path);
+	static MonoAssembly *_search_hook(MonoAssemblyName *aname, void *user_data, bool refonly);
+	static MonoAssembly *_preload_hook(MonoAssemblyName *aname, char **assemblies_path, void *user_data, bool refonly);
+
+	static GDMonoAssembly *_load_assembly_from(const String &p_name, const String &p_path, bool p_refonly);
 
 	friend class GDMono;
 	static void initialize();
 
 public:
-	Error load(MonoDomain *p_domain);
+	Error load(bool p_refonly);
 	Error wrapper_for_image(MonoImage *p_image);
 	void unload();
 
+	_FORCE_INLINE_ bool is_refonly() const { return refonly; }
 	_FORCE_INLINE_ bool is_loaded() const { return loaded; }
 	_FORCE_INLINE_ MonoImage *get_image() const { return image; }
 	_FORCE_INLINE_ MonoAssembly *get_assembly() const { return assembly; }
@@ -114,6 +121,8 @@ public:
 	GDMonoClass *get_class(MonoClass *p_mono_class);
 
 	GDMonoClass *get_object_derived_class(const StringName &p_class);
+
+	static GDMonoAssembly *load_from(const String &p_name, const String &p_path, bool p_refonly);
 
 	GDMonoAssembly(const String &p_name, const String &p_path = String());
 	~GDMonoAssembly();


### PR DESCRIPTION
Just a WIP, but worth being merged at this point.

**TODO** (not in this PR):
- Make it use the export templates compiled with mono, somehow.
- Fix `_export_begin` not being called with the _"Export PCK"_ option. I used this patch for testing purposes but, as you can see, it doesn't take Debug/Release and the output path into account:
  ``` diff
  @@ -596,6 +596,7 @@ EditorExportPlatform::ExportNotifier::~ExportNotifier() {
   }
   
   Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &p_preset, EditorExportSaveFunction p_func, void *p_udata, EditorExportSaveSharedObject p_so_func) {
  +	ExportNotifier notifier(*this, p_preset, false, "", 0);
   	//figure out paths of files that will be exported
   	Set<String> paths;
   	Vector<String> path_remaps;
  ```

