### PR TITLE
Revert "Fix mbedTLS and websocket module for UWP"

### DIFF
--- a/modules/websocket/SCsub
+++ b/modules/websocket/SCsub
@@ -54,7 +54,7 @@ thirdparty_sources = [
 if env_lws["platform"] == "android": # Builtin getifaddrs
     thirdparty_sources += ["misc/getifaddrs.c"]
 
-if env_lws["platform"] == "windows" or env_lws["platform"] == "uwp": # Winsock
+if env_lws["platform"] == "windows": # Winsock
     thirdparty_sources += ["plat/lws-plat-win.c", helper_dir + "getopt.c", helper_dir + "getopt_long.c", helper_dir + "gettimeofday.c"]
 else: # Unix socket
     thirdparty_sources += ["plat/lws-plat-unix.c"]
@@ -75,10 +75,7 @@ else:
         mbedtls_includes = "#thirdparty/mbedtls/include"
         env_lws.Append(CPPPATH=[mbedtls_includes])
 
-    if env_lws["platform"] == "windows" or env_lws["platform"] == "uwp":
+    if env_lws["platform"] == "windows":
         env_lws.Append(CPPPATH=[thirdparty_dir + helper_dir])
-
-    if env_lws["platform"] == "uwp":
-        env_lws.Append(CCFLAGS=["/DLWS_MINGW_SUPPORT"])
 
 env_lws.add_source_files(env.modules_sources, "*.cpp")

--- a/platform/uwp/detect.py
+++ b/platform/uwp/detect.py
@@ -160,7 +160,6 @@ def configure(env):
         'libANGLE',
         'libEGL',
         'libGLESv2',
-        'bcrypt',
     ]
     env.Append(LINKFLAGS=[p + ".lib" for p in LIBS])
 

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -179,7 +179,7 @@ def configure(env):
         if env["bits"] == "64":
             env.Append(CCFLAGS=['/D_WIN64'])
 
-        LIBS = ['winmm', 'opengl32', 'dsound', 'kernel32', 'ole32', 'oleaut32', 'user32', 'gdi32', 'IPHLPAPI', 'Shlwapi', 'wsock32', 'Ws2_32', 'shell32', 'advapi32', 'dinput8', 'dxguid', 'imm32', 'bcrypt']
+        LIBS = ['winmm', 'opengl32', 'dsound', 'kernel32', 'ole32', 'oleaut32', 'user32', 'gdi32', 'IPHLPAPI', 'Shlwapi', 'wsock32', 'Ws2_32', 'shell32', 'advapi32', 'dinput8', 'dxguid', 'imm32']
         env.Append(LINKFLAGS=[p + env["LIBSUFFIX"] for p in LIBS])
 
         env.Append(LIBPATH=[os.getenv("WindowsSdkDir") + "/Lib"])
@@ -281,7 +281,7 @@ def configure(env):
         env.Append(CCFLAGS=['-DRTAUDIO_ENABLED'])
         env.Append(CCFLAGS=['-DWASAPI_ENABLED'])
         env.Append(CCFLAGS=['-DWINVER=%s' % env['target_win_version'], '-D_WIN32_WINNT=%s' % env['target_win_version']])
-        env.Append(LIBS=['mingw32', 'opengl32', 'dsound', 'ole32', 'd3d9', 'winmm', 'gdi32', 'iphlpapi', 'shlwapi', 'wsock32', 'ws2_32', 'kernel32', 'oleaut32', 'dinput8', 'dxguid', 'ksuser', 'imm32', 'bcrypt'])
+        env.Append(LIBS=['mingw32', 'opengl32', 'dsound', 'ole32', 'd3d9', 'winmm', 'gdi32', 'iphlpapi', 'shlwapi', 'wsock32', 'ws2_32', 'kernel32', 'oleaut32', 'dinput8', 'dxguid', 'ksuser', 'imm32'])
 
         env.Append(CPPFLAGS=['-DMINGW_ENABLED'])
 

--- a/thirdparty/mbedtls/library/entropy_poll.c
+++ b/thirdparty/mbedtls/library/entropy_poll.c
@@ -54,41 +54,28 @@
 #define _WIN32_WINNT 0x0400
 #endif
 #include <windows.h>
-#include <bcrypt.h>
-#if _MSC_VER <= 1600
-/* Visual Studio 2010 and earlier issue a warning when both <stdint.h> and <intsafe.h> are included, as they
- * redefine a number of <TYPE>_MAX constants. These constants are guaranteed to be the same, though, so
- * we suppress the warning when including intsafe.h.
- */
-#pragma warning( push )
-#pragma warning( disable : 4005 )
-#endif
-#include <intsafe.h>
-#if _MSC_VER <= 1600
-#pragma warning( pop )
-#endif
+#include <wincrypt.h>
 
 int mbedtls_platform_entropy_poll( void *data, unsigned char *output, size_t len,
                            size_t *olen )
 {
-    ULONG len_as_ulong = 0;
+    HCRYPTPROV provider;
     ((void) data);
     *olen = 0;
 
-    /*
-     * BCryptGenRandom takes ULONG for size, which is smaller than size_t on 64-bit platforms.
-     * Ensure len's value can be safely converted into a ULONG.
-     */
-    if ( FAILED( SizeTToULong( len, &len_as_ulong ) ) )
+    if( CryptAcquireContext( &provider, NULL, NULL,
+                              PROV_RSA_FULL, CRYPT_VERIFYCONTEXT ) == FALSE )
     {
         return( MBEDTLS_ERR_ENTROPY_SOURCE_FAILED );
     }
 
-    if ( !BCRYPT_SUCCESS( BCryptGenRandom( NULL, output, len_as_ulong, BCRYPT_USE_SYSTEM_PREFERRED_RNG ) ) )
+    if( CryptGenRandom( provider, (DWORD) len, output ) == FALSE )
     {
+        CryptReleaseContext( provider, 0 );
         return( MBEDTLS_ERR_ENTROPY_SOURCE_FAILED );
     }
 
+    CryptReleaseContext( provider, 0 );
     *olen = len;
 
     return( 0 );

--- a/thirdparty/mbedtls/library/net_sockets.c
+++ b/thirdparty/mbedtls/library/net_sockets.c
@@ -49,7 +49,7 @@
 #undef _WIN32_WINNT
 #endif
 /* Enables getaddrinfo() & Co */
-#define _WIN32_WINNT 0x0601
+#define _WIN32_WINNT 0x0501
 #include <ws2tcpip.h>
 
 #include <winsock2.h>

--- a/thirdparty/mbedtls/library/x509_crt.c
+++ b/thirdparty/mbedtls/library/x509_crt.c
@@ -62,18 +62,6 @@
 
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
 #include <windows.h>
-#if _MSC_VER <= 1600
-/* Visual Studio 2010 and earlier issue a warning when both <stdint.h> and <intsafe.h> are included, as they
- * redefine a number of <TYPE>_MAX constants. These constants are guaranteed to be the same, though, so
- * we suppress the warning when including intsafe.h.
- */
-#pragma warning( push )
-#pragma warning( disable : 4005 )
-#endif
-#include <intsafe.h>
-#if _MSC_VER <= 1600
-#pragma warning( pop )
-#endif
 #else
 #include <time.h>
 #endif
@@ -1122,7 +1110,6 @@ int mbedtls_x509_crt_parse_path( mbedtls_x509_crt *chain, const char *path )
     char filename[MAX_PATH];
     char *p;
     size_t len = strlen( path );
-    int lengthAsInt = 0;
 
     WIN32_FIND_DATAW file_data;
     HANDLE hFind;
@@ -1137,10 +1124,7 @@ int mbedtls_x509_crt_parse_path( mbedtls_x509_crt *chain, const char *path )
     p = filename + len;
     filename[len++] = '*';
 
-    if ( FAILED ( SizeTToInt( len, &lengthAsInt ) ) )
-        return( MBEDTLS_ERR_X509_FILE_IO_ERROR );
-
-    w_ret = MultiByteToWideChar( CP_ACP, 0, filename, lengthAsInt, szDir,
+    w_ret = MultiByteToWideChar( CP_ACP, 0, filename, (int)len, szDir,
                                  MAX_PATH - 3 );
     if( w_ret == 0 )
         return( MBEDTLS_ERR_X509_BAD_INPUT_DATA );
@@ -1157,11 +1141,8 @@ int mbedtls_x509_crt_parse_path( mbedtls_x509_crt *chain, const char *path )
         if( file_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY )
             continue;
 
-        if ( FAILED( SizeTToInt( wcslen( file_data.cFileName ), &lengthAsInt ) ) )
-            return( MBEDTLS_ERR_X509_FILE_IO_ERROR );
-
         w_ret = WideCharToMultiByte( CP_ACP, 0, file_data.cFileName,
-                                     lengthAsInt,
+                                     lstrlenW( file_data.cFileName ),
                                      p, (int) len - 1,
                                      NULL, NULL );
         if( w_ret == 0 )


### PR DESCRIPTION
Reverts godotengine/godot#16865

Breaks mingw build on centos 7.4.

```
[go] Task: /bin/bash -c "scons platform=windows target=release_debug -j`nproc --all` use_lto=no gdnative_wrapper=yes deprecated=no"took: 11.138sexited: 2
scons: Reading SConscript files ...
YASM is necessary for WebM SIMD optimizations.
WebM SIMD optimizations are disabled. Check if your CPU architecture, CPU bits or platform are supported!
Checking for C header file mntent.h... (cached) no
scons: done reading SConscript files.
scons: Building targets ...
Compiling ==> main/main.cpp
Compiling ==> thirdparty/mbedtls/library/entropy_poll.c
thirdparty/mbedtls/library/entropy_poll.c:66:21: fatal error: intsafe.h: No such file or directory
 #include <intsafe.h>
                     ^
compilation terminated.
scons: *** [thirdparty/mbedtls/library/entropy_poll.windows.opt.tools.64.o] Error 1
```
