### PR TITLE
Added 'fill selection' command to grid map editor

### DIFF
--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -231,6 +231,13 @@ void GridMapEditor::_menu_option(int p_option) {
 			_delete_selection();
 
 		} break;
+		case MENU_OPTION_SELECTION_FILL: {
+			if (!selection.active)
+				return;
+
+			_fill_selection();
+
+		} break;
 		case MENU_OPTION_GRIDMAP_SETTINGS: {
 			settings_dialog->popup_centered(settings_vbc->get_combined_minimum_size() + Size2(50, 50) * EDSCALE);
 		} break;
@@ -445,6 +452,29 @@ void GridMapEditor::_delete_selection() {
 			for (int k = selection.begin.z; k <= selection.end.z; k++) {
 
 				undo_redo->add_do_method(node, "set_cell_item", i, j, k, GridMap::INVALID_CELL_ITEM);
+				undo_redo->add_undo_method(node, "set_cell_item", i, j, k, node->get_cell_item(i, j, k), node->get_cell_item_orientation(i, j, k));
+			}
+		}
+	}
+	undo_redo->commit_action();
+
+	selection.active = false;
+	_validate_selection();
+}
+
+void GridMapEditor::_fill_selection() {
+
+	if (!selection.active)
+		return;
+
+	undo_redo->create_action(TTR("GridMap Fill Selection"));
+	for (int i = selection.begin.x; i <= selection.end.x; i++) {
+
+		for (int j = selection.begin.y; j <= selection.end.y; j++) {
+
+			for (int k = selection.begin.z; k <= selection.end.z; k++) {
+
+				undo_redo->add_do_method(node, "set_cell_item", i, j, k, selected_pallete, cursor_rot);
 				undo_redo->add_undo_method(node, "set_cell_item", i, j, k, node->get_cell_item(i, j, k), node->get_cell_item_orientation(i, j, k));
 			}
 		}
@@ -1063,6 +1093,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	options->get_popup()->add_separator();
 	options->get_popup()->add_item(TTR("Duplicate Selection"), MENU_OPTION_SELECTION_DUPLICATE, KEY_MASK_SHIFT + KEY_C);
 	options->get_popup()->add_item(TTR("Clear Selection"), MENU_OPTION_SELECTION_CLEAR, KEY_MASK_SHIFT + KEY_X);
+	options->get_popup()->add_item(TTR("Fill Selection"), MENU_OPTION_SELECTION_FILL, KEY_MASK_SHIFT + KEY_F);
 
 	options->get_popup()->add_separator();
 	options->get_popup()->add_item(TTR("Settings"), MENU_OPTION_GRIDMAP_SETTINGS);

--- a/modules/gridmap/grid_map_editor_plugin.h
+++ b/modules/gridmap/grid_map_editor_plugin.h
@@ -167,6 +167,7 @@ class GridMapEditor : public VBoxContainer {
 		MENU_OPTION_SELECTION_MAKE_EXTERIOR_CONNECTOR,
 		MENU_OPTION_SELECTION_DUPLICATE,
 		MENU_OPTION_SELECTION_CLEAR,
+		MENU_OPTION_SELECTION_FILL,
 		MENU_OPTION_REMOVE_AREA,
 		MENU_OPTION_GRIDMAP_SETTINGS
 
@@ -199,6 +200,7 @@ class GridMapEditor : public VBoxContainer {
 	void _floor_changed(float p_value);
 
 	void _delete_selection();
+	void _fill_selection();
 
 	EditorNode *editor;
 	bool do_input_action(Camera *p_camera, const Point2 &p_point, bool p_click);


### PR DESCRIPTION
This commit adds a 'fill selection' command (shortcut: shift+f) to the
grid map editor, making it easier to block out large parts of grid maps.
The new command is equivalent to the existing 'clear selection' command
except that it fills the selection with the currently selected block
instead of the empty grid cell.