### PR TITLE
GUI elements ui_action usage, improvements

### DIFF
--- a/core/input_map.cpp
+++ b/core/input_map.cpp
@@ -282,6 +282,16 @@ void InputMap::load_default() {
 	key->set_scancode(KEY_PAGEDOWN);
 	action_add_event("ui_page_down", key);
 
+	add_action("ui_home");
+	key.instance();
+	key->set_scancode(KEY_HOME);
+	action_add_event("ui_home", key);
+
+	add_action("ui_end");
+	key.instance();
+	key->set_scancode(KEY_END);
+	action_add_event("ui_end", key);
+
 	//set("display/window/handheld/orientation", "landscape");
 }
 

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -1027,6 +1027,20 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("input/ui_page_down", va);
 	input_presets.push_back("input/ui_page_down");
 
+	va = Array();
+	key.instance();
+	key->set_scancode(KEY_HOME);
+	va.push_back(key);
+	GLOBAL_DEF("input/ui_home", va);
+	input_presets.push_back("input/ui_home");
+
+	va = Array();
+	key.instance();
+	key->set_scancode(KEY_END);
+	va.push_back(key);
+	GLOBAL_DEF("input/ui_end", va);
+	input_presets.push_back("input/ui_end");
+
 	//GLOBAL_DEF("display/window/handheld/orientation", "landscape");
 
 	custom_prop_info["display/window/handheld/orientation"] = PropertyInfo(Variant::STRING, "display/window/handheld/orientation", PROPERTY_HINT_ENUM, "landscape,portrait,reverse_landscape,reverse_portrait,sensor_landscape,sensor_portrait,sensor");

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -373,12 +373,14 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 				case KEY_UP: {
 
 					shift_selection_check_pre(k->get_shift());
+					if (get_cursor_position() == 0) handled = false;
 					set_cursor_position(0);
 					shift_selection_check_post(k->get_shift());
 				} break;
 				case KEY_DOWN: {
 
 					shift_selection_check_pre(k->get_shift());
+					if (get_cursor_position() == text.length()) handled = false;
 					set_cursor_position(text.length());
 					shift_selection_check_post(k->get_shift());
 				} break;

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -75,6 +75,10 @@ void OptionButton::_notification(int p_what) {
 	}
 }
 
+void OptionButton::_focused(int p_which) {
+	emit_signal("item_focused", p_which);
+}
+
 void OptionButton::_selected(int p_which) {
 
 	int selid = -1;
@@ -290,6 +294,7 @@ void OptionButton::get_translatable_strings(List<String> *p_strings) const {
 void OptionButton::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_selected"), &OptionButton::_selected);
+	ClassDB::bind_method(D_METHOD("_focused"), &OptionButton::_focused);
 
 	ClassDB::bind_method(D_METHOD("add_item", "label", "id"), &OptionButton::add_item, DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("add_icon_item", "texture", "label", "id"), &OptionButton::add_icon_item);
@@ -322,6 +327,7 @@ void OptionButton::_bind_methods() {
 	// "selected" property must come after "items", otherwise GH-10213 occurs
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "selected"), "_select_int", "get_selected");
 	ADD_SIGNAL(MethodInfo("item_selected", PropertyInfo(Variant::INT, "ID")));
+	ADD_SIGNAL(MethodInfo("item_focused", PropertyInfo(Variant::INT, "ID")));
 }
 
 OptionButton::OptionButton() {
@@ -336,6 +342,7 @@ OptionButton::OptionButton() {
 	popup->set_as_toplevel(true);
 	popup->set_pass_on_modal_close_click(false);
 	popup->connect("id_pressed", this, "_selected");
+	popup->connect("id_focused", this, "_focused");
 }
 
 OptionButton::~OptionButton() {

--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -43,6 +43,7 @@ class OptionButton : public Button {
 	PopupMenu *popup;
 	int current;
 
+	void _focused(int p_which);
 	void _selected(int p_which);
 	void _select(int p_which, bool p_emit = false);
 	void _select_int(int p_which);

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -211,86 +211,67 @@ void PopupMenu::_scroll(float p_factor, const Point2 &p_over) {
 
 void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 
-	Ref<InputEventKey> k = p_event;
+	if (p_event->is_action("ui_down") && p_event->is_pressed()) {
 
-	if (k.is_valid()) {
+		int search_from = mouse_over + 1;
+		if (search_from >= items.size())
+			search_from = 0;
 
-		if (!k->is_pressed())
-			return;
+		for (int i = search_from; i < items.size(); i++) {
 
-		switch (k->get_scancode()) {
+			if (i < 0 || i >= items.size())
+				continue;
 
-			case KEY_DOWN: {
+			if (!items[i].separator && !items[i].disabled) {
 
-				int search_from = mouse_over + 1;
-				if (search_from >= items.size())
-					search_from = 0;
+				mouse_over = i;
+				update();
+				accept_event();
+				break;
+			}
+		}
+	} else if (p_event->is_action("ui_up") && p_event->is_pressed()) {
 
-				for (int i = search_from; i < items.size(); i++) {
+		int search_from = mouse_over - 1;
+		if (search_from < 0)
+			search_from = items.size() - 1;
 
-					if (i < 0 || i >= items.size())
-						continue;
+		for (int i = search_from; i >= 0; i--) {
 
-					if (!items[i].separator && !items[i].disabled) {
+			if (i < 0 || i >= items.size())
+				continue;
 
-						mouse_over = i;
-						update();
-						break;
-					}
-				}
-			} break;
-			case KEY_UP: {
+			if (!items[i].separator && !items[i].disabled) {
 
-				int search_from = mouse_over - 1;
-				if (search_from < 0)
-					search_from = items.size() - 1;
+				mouse_over = i;
+				update();
+				accept_event();
+				break;
+			}
+		}
+	} else if (p_event->is_action("ui_left") && p_event->is_pressed()) {
 
-				for (int i = search_from; i >= 0; i--) {
+		Node *n = get_parent();
+		if (n && Object::cast_to<PopupMenu>(n)) {
+			hide();
+			accept_event();
+		}
+	} else if (p_event->is_action("ui_right") && p_event->is_pressed()) {
 
-					if (i < 0 || i >= items.size())
-						continue;
+		if (mouse_over >= 0 && mouse_over < items.size() && !items[mouse_over].separator && items[mouse_over].submenu != "" && submenu_over != mouse_over) {
+			_activate_submenu(mouse_over);
+			accept_event();
+		}
+	} else if (p_event->is_action("ui_accept") && p_event->is_pressed()) {
 
-					if (!items[i].separator && !items[i].disabled) {
+		if (mouse_over >= 0 && mouse_over < items.size() && !items[mouse_over].separator) {
 
-						mouse_over = i;
-						update();
-						break;
-					}
-				}
-			} break;
-
-			case KEY_LEFT: {
-
-				Node *n = get_parent();
-				if (!n)
-					break;
-
-				PopupMenu *pm = Object::cast_to<PopupMenu>(n);
-				if (!pm)
-					break;
-
-				hide();
-			} break;
-
-			case KEY_RIGHT: {
-
-				if (mouse_over >= 0 && mouse_over < items.size() && !items[mouse_over].separator && items[mouse_over].submenu != "" && submenu_over != mouse_over)
-					_activate_submenu(mouse_over);
-			} break;
-
-			case KEY_ENTER:
-			case KEY_KP_ENTER: {
-
-				if (mouse_over >= 0 && mouse_over < items.size() && !items[mouse_over].separator) {
-
-					if (items[mouse_over].submenu != "" && submenu_over != mouse_over) {
-						_activate_submenu(mouse_over);
-						break;
-					}
-
-					activate_item(mouse_over);
-				}
-			} break;
+			if (items[mouse_over].submenu != "" && submenu_over != mouse_over) {
+				_activate_submenu(mouse_over);
+			} else {
+				activate_item(mouse_over);
+			}
+			accept_event();
 		}
 	}
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -225,6 +225,7 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 			if (!items[i].separator && !items[i].disabled) {
 
 				mouse_over = i;
+				emit_signal("id_focused", i);
 				update();
 				accept_event();
 				break;
@@ -244,6 +245,7 @@ void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 			if (!items[i].separator && !items[i].disabled) {
 
 				mouse_over = i;
+				emit_signal("id_focused", i);
 				update();
 				accept_event();
 				break;
@@ -1210,6 +1212,7 @@ void PopupMenu::_bind_methods() {
 	ADD_PROPERTYNO(PropertyInfo(Variant::BOOL, "hide_on_state_item_selection"), "set_hide_on_state_item_selection", "is_hide_on_state_item_selection");
 
 	ADD_SIGNAL(MethodInfo("id_pressed", PropertyInfo(Variant::INT, "ID")));
+	ADD_SIGNAL(MethodInfo("id_focused", PropertyInfo(Variant::INT, "ID")));
 	ADD_SIGNAL(MethodInfo("index_pressed", PropertyInfo(Variant::INT, "index")));
 }
 

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -199,8 +199,6 @@ void ScrollBar::_gui_input(Ref<InputEvent> p_event) {
 		}
 	}
 
-	Ref<InputEventKey> k = p_event;
-
 	if (p_event->is_pressed()) {
 
 		if (p_event->is_action("ui_left")) {
@@ -228,20 +226,13 @@ void ScrollBar::_gui_input(Ref<InputEvent> p_event) {
 				return;
 			set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
 
-		} else if (k.is_valid()) {
+		} else if (p_event->is_action("ui_home")) {
 
-			switch (k->get_scancode()) {
-				case KEY_HOME: {
+			set_value(get_min());
 
-					set_value(get_min());
+		} else if (p_event->is_action("ui_end")) {
 
-				} break;
-				case KEY_END: {
-
-					set_value(get_max());
-
-				} break;
-			}
+			set_value(get_max());
 		}
 	}
 }

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -201,52 +201,47 @@ void ScrollBar::_gui_input(Ref<InputEvent> p_event) {
 
 	Ref<InputEventKey> k = p_event;
 
-	if (k.is_valid()) {
+	if (p_event->is_pressed()) {
 
-		if (!k->is_pressed())
-			return;
+		if (p_event->is_action("ui_left")) {
 
-		switch (k->get_scancode()) {
+			if (orientation != HORIZONTAL)
+				return;
+			set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
 
-			case KEY_LEFT: {
+		} else if (p_event->is_action("ui_right")) {
 
-				if (orientation != HORIZONTAL)
-					return;
-				set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
+			if (orientation != HORIZONTAL)
+				return;
+			set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
 
-			} break;
-			case KEY_RIGHT: {
+		} else if (p_event->is_action("ui_up")) {
 
-				if (orientation != HORIZONTAL)
-					return;
-				set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
+			if (orientation != VERTICAL)
+				return;
 
-			} break;
-			case KEY_UP: {
+			set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
 
-				if (orientation != VERTICAL)
-					return;
+		} else if (p_event->is_action("ui_down")) {
 
-				set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
+			if (orientation != VERTICAL)
+				return;
+			set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
 
-			} break;
-			case KEY_DOWN: {
+		} else if (k.is_valid()) {
 
-				if (orientation != VERTICAL)
-					return;
-				set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
+			switch (k->get_scancode()) {
+				case KEY_HOME: {
 
-			} break;
-			case KEY_HOME: {
+					set_value(get_min());
 
-				set_value(get_min());
+				} break;
+				case KEY_END: {
 
-			} break;
-			case KEY_END: {
+					set_value(get_max());
 
-				set_value(get_max());
-
-			} break;
+				} break;
+			}
 		}
 	}
 }

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -118,28 +118,14 @@ void Slider::_gui_input(Ref<InputEvent> p_event) {
 				return;
 			set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
 			accept_event();
+		} else if (p_event->is_action("ui_home") && p_event->is_pressed()) {
 
-		} else {
+			set_value(get_min());
+			accept_event();
+		} else if (p_event->is_action("ui_end") && p_event->is_pressed()) {
 
-			Ref<InputEventKey> k = p_event;
-
-			if (!k.is_valid() || !k->is_pressed())
-				return;
-
-			switch (k->get_scancode()) {
-
-				case KEY_HOME: {
-
-					set_value(get_min());
-					accept_event();
-				} break;
-				case KEY_END: {
-
-					set_value(get_max());
-					accept_event();
-
-				} break;
-			}
+			set_value(get_max());
+			accept_event();
 		}
 	}
 }

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -507,6 +507,10 @@ private:
 	ValueEvaluator *evaluator;
 
 	int _count_selected_items(TreeItem *p_from) const;
+	void _go_left();
+	void _go_right();
+	void _go_down();
+	void _go_up();
 
 protected:
 	static void _bind_methods();

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2017,6 +2017,9 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 				top->notification(Control::NOTIFICATION_MODAL_CLOSE);
 				top->_modal_stack_remove();
 				top->hide();
+				// Close modal, set input as handled
+				get_tree()->set_input_as_handled();
+				return;
 			}
 		}
 


### PR DESCRIPTION
- Popupmenu now uses UI actions instead of key presses
- Tree now uses UI actions instead of key presses
- Line edit up/down focus pass through
  When line edit receive a up/down and the cursor is at beginning/end it will not set the input as handled
- Properly sets input as handled when closing modal
- Scrollbar now uses UI actions instead of key presses
- Add two new default actions `ui_end`, `ui_home`, used by Slider and Scrollbar (I can remove this if found useless)
- Add item_focused signal to OptionButton (and id_focused to PopupMenu)
  This is useful if for example you want to add UI sounds to your game.

Closes #16946 
Closes #17159