### PR TITLE
Refactor version macros and fix related bugs

### DIFF
--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -347,7 +347,7 @@ uint64_t ClassDB::get_api_hash(APIType p_api) {
 	OBJTYPE_RLOCK;
 #ifdef DEBUG_METHODS_ENABLED
 
-	uint64_t hash = hash_djb2_one_64(HashMapHasherDefault::hash(VERSION_FULL_NAME));
+	uint64_t hash = hash_djb2_one_64(HashMapHasherDefault::hash(VERSION_FULL_CONFIG));
 
 	List<StringName> names;
 

--- a/core/version.h
+++ b/core/version.h
@@ -30,9 +30,32 @@
 
 #include "version_generated.gen.h"
 
+// Godot versions are of the form <major>.<minor> for the initial release,
+// and then <major>.<minor>.<patch> for subsequent bugfix releases where <patch> != 0
+// That's arbitrary, but we find it pretty and it's the current policy.
+
+// Defines the main "branch" version. Patch versions in this branch should be
+// forward-compatible.
+// Example: "3.1"
+#define VERSION_BRANCH "" _MKSTR(VERSION_MAJOR) "." _MKSTR(VERSION_MINOR)
 #ifdef VERSION_PATCH
-#define VERSION_MKSTRING "" _MKSTR(VERSION_MAJOR) "." _MKSTR(VERSION_MINOR) "." _MKSTR(VERSION_PATCH) "." VERSION_STATUS "." VERSION_BUILD VERSION_MODULE_CONFIG
+// Example: "3.1.4"
+#define VERSION_NUMBER "" VERSION_BRANCH "." _MKSTR(VERSION_PATCH)
 #else
-#define VERSION_MKSTRING "" _MKSTR(VERSION_MAJOR) "." _MKSTR(VERSION_MINOR) "." VERSION_STATUS "." VERSION_BUILD VERSION_MODULE_CONFIG
+// Example: "3.1"
+#define VERSION_NUMBER "" VERSION_BRANCH
 #endif // VERSION_PATCH
-#define VERSION_FULL_NAME "" VERSION_NAME " v" VERSION_MKSTRING
+
+// Describes the full configuration of that Godot version, including the version number,
+// the status (beta, stable, etc.) and potential module-specific features (e.g. mono).
+// Example: "3.1.4.stable.mono"
+#define VERSION_FULL_CONFIG "" VERSION_NUMBER "." VERSION_STATUS VERSION_MODULE_CONFIG
+
+// Similar to VERSION_FULL_CONFIG, but also includes the (potentially custom) VERSION_BUILD
+// description (e.g. official, custom_build, etc.).
+// Example: "3.1.4.stable.mono.official"
+#define VERSION_FULL_BUILD "" VERSION_FULL_CONFIG "." VERSION_BUILD
+
+// Same as above, but prepended with Godot's name and a cosmetic "v" for "version".
+// Example: "Godot v3.1.4.stable.official.mono"
+#define VERSION_FULL_NAME "" VERSION_NAME " v" VERSION_FULL_BUILD

--- a/editor/doc/doc_data.cpp
+++ b/editor/doc/doc_data.cpp
@@ -974,7 +974,7 @@ Error DocData::save_classes(const String &p_default_path, const Map<String, Stri
 		if (c.category == "")
 			category = "Core";
 		header += " category=\"" + category + "\"";
-		header += String(" version=\"") + itos(VERSION_MAJOR) + "." + itos(VERSION_MINOR) + "-" + VERSION_STATUS + "\"";
+		header += String(" version=\"") + VERSION_NUMBER + "\"";
 		header += ">";
 		_write_string(f, 0, header);
 		_write_string(f, 1, "<brief_description>");

--- a/editor/doc/doc_dump.cpp
+++ b/editor/doc/doc_dump.cpp
@@ -83,7 +83,7 @@ void DocDump::dump(const String &p_file) {
 	FileAccess *f = FileAccess::open(p_file, FileAccess::WRITE);
 
 	_write_string(f, 0, "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>");
-	_write_string(f, 0, String("<doc version=\"") + itos(VERSION_MAJOR) + "." + itos(VERSION_MINOR) + "-" + VERSION_STATUS + "\" name=\"Engine Types\">");
+	_write_string(f, 0, String("<doc version=\"") + VERSION_NUMBER + "\" name=\"Engine Types\">");
 
 	while (class_list.size()) {
 

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -337,7 +337,7 @@ Error EditorExportPlatform::_save_zip_file(void *p_userdata, const String &p_pat
 
 String EditorExportPlatform::find_export_template(String template_file_name, String *err) const {
 
-	String current_version = itos(VERSION_MAJOR) + "." + itos(VERSION_MINOR) + "-" + VERSION_STATUS + VERSION_MODULE_CONFIG;
+	String current_version = VERSION_FULL_CONFIG;
 	String template_path = EditorSettings::get_singleton()->get_templates_dir().plus_file(current_version).plus_file(template_file_name);
 
 	if (FileAccess::exists(template_path)) {

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -70,7 +70,7 @@ void ExportTemplateManager::_update_template_list() {
 
 	memdelete(d);
 
-	String current_version = itos(VERSION_MAJOR) + "." + itos(VERSION_MINOR) + "-" + VERSION_STATUS + VERSION_MODULE_CONFIG;
+	String current_version = VERSION_FULL_CONFIG;
 
 	Label *current = memnew(Label);
 	current->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -30,11 +30,10 @@
 
 #include "asset_library_editor_plugin.h"
 
+#include "core/io/json.h"
+#include "core/version.h"
 #include "editor_node.h"
 #include "editor_settings.h"
-#include "io/json.h"
-
-#include "version_generated.gen.h"
 
 void EditorAssetLibraryItem::configure(const String &p_title, int p_asset_id, const String &p_category, int p_category_id, const String &p_author, int p_author_id, int p_rating, const String &p_cost) {
 
@@ -877,7 +876,8 @@ void EditorAssetLibrary::_search(int p_page) {
 	}
 	args += String() + "sort=" + sort_key[sort->get_selected()];
 
-	args += "&godot_version=" + itos(VERSION_MAJOR) + "." + itos(VERSION_MINOR);
+	// We use the "branch" version, i.e. major.minor, as patch releases should be compatible
+	args += "&godot_version=" + String(VERSION_BRANCH);
 
 	String support_list;
 	for (int i = 0; i < SUPPORT_MAX; i++) {

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -244,7 +244,7 @@ void ThemeEditor::_save_template_cbk(String fname) {
 	file->store_line("; ");
 	file->store_line("; ******************* ");
 	file->store_line("; ");
-	file->store_line("; Template Generated Using: " + String(VERSION_MKSTRING));
+	file->store_line("; Template Generated Using: " + String(VERSION_FULL_BUILD));
 	file->store_line(";    ");
 	file->store_line("; ");
 	file->store_line("");

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1570,7 +1570,7 @@ ProjectManager::ProjectManager() {
 	String hash = String(VERSION_HASH);
 	if (hash.length() != 0)
 		hash = "." + hash.left(7);
-	l->set_text("v" VERSION_MKSTRING "" + hash);
+	l->set_text("v" VERSION_FULL_BUILD "" + hash);
 	l->set_align(Label::ALIGN_CENTER);
 	top_hb->add_child(l);
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -175,7 +175,7 @@ static String get_full_version_string() {
 	String hash = String(VERSION_HASH);
 	if (hash.length() != 0)
 		hash = "." + hash.left(7);
-	return String(VERSION_MKSTRING) + hash;
+	return String(VERSION_FULL_BUILD) + hash;
 }
 
 //#define DEBUG_INIT

--- a/platform/windows/godot_res.rc
+++ b/platform/windows/godot_res.rc
@@ -3,11 +3,9 @@
 #define _STR(m_x) #m_x
 #define _MKSTR(m_x) _STR(m_x)
 #endif
+
 #ifndef VERSION_PATCH
 #define VERSION_PATCH 0
-#define PATCH_STRING
-#else
-#define PATCH_STRING "." _MKSTR(VERSION_PATCH)
 #endif
 
 GODOT_ICON ICON platform/windows/godot.ico
@@ -24,12 +22,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName",            "Godot Engine"
             VALUE "FileDescription",        VERSION_NAME " Editor"
-            VALUE "FileVersion",            _MKSTR(VERSION_MAJOR) "." _MKSTR(VERSION_MINOR) "." _MKSTR(VERSION_PATCH)
+            VALUE "FileVersion",            VERSION_NUMBER
             VALUE "ProductName",            VERSION_NAME
             VALUE "Licence",                "MIT"
-            VALUE "LegalCopyright",         "Copyright (c) 2007-" _MKSTR(VERSION_YEAR) " Juan Linietsky, Ariel Manzur"
+            VALUE "LegalCopyright",         "Copyright (c) 2007-" _MKSTR(VERSION_YEAR) " Juan Linietsky, Ariel Manzur and contributors"
             VALUE "Info",                   "https://godotengine.org"
-            VALUE "ProductVersion",         _MKSTR(VERSION_MAJOR) "." _MKSTR(VERSION_MINOR) PATCH_STRING "." VERSION_BUILD
+            VALUE "ProductVersion",         VERSION_FULL_BUILD
         END
     END
     BLOCK "VarFileInfo"

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -121,7 +121,7 @@ Error HTTPRequest::request(const String &p_url, const Vector<String> &p_custom_h
 	}
 
 	if (!has_user_agent) {
-		headers.push_back("User-Agent: GodotEngine/" + String(VERSION_MKSTRING) + " (" + OS::get_singleton()->get_name() + ")");
+		headers.push_back("User-Agent: GodotEngine/" + String(VERSION_FULL_BUILD) + " (" + OS::get_singleton()->get_name() + ")");
 	}
 
 	if (!has_accept) {

--- a/scene/resources/scene_format_text.cpp
+++ b/scene/resources/scene_format_text.cpp
@@ -1506,7 +1506,6 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_r
 			title += "load_steps=" + itos(load_steps) + " ";
 		}
 		title += "format=" + itos(FORMAT_VERSION) + "";
-		//title+="engine_version=\""+itos(VERSION_MAJOR)+"."+itos(VERSION_MINOR)+"\"";
 
 		f->store_string(title);
 		f->store_line("]\n"); //one empty line


### PR DESCRIPTION
The previous logic with VERSION_MKSTRING was a bit unwieldy, so there were
several places hardcoding their own variant of the version string, potentially
with bugs (e.g. forgetting the patch number when defined).

The new logic defines:

- VERSION_BRANCH, the main 'major.minor' version (e.g. 3.1)
- VERSION_NUMBER, which can be 'major.minor' or 'major.minor.patch',
  depending on whether the latter is defined (e.g. 3.1.4)
- VERSION_FULL_CONFIG, which contains the version status (e.g. stable)
  and the module-specific suffix (e.g. mono)
- VERSION_FULL_BUILD, same as above but with build/reference name
  (e.g. official, custom_build, mageia, etc.)
  Note: Slight change here, as the previous format had the build name
  *before* the module-specific suffix; now it's after
- VERSION_FULL_NAME, same as before, so VERSION_FULL_BUILD prefixed
  with "Godot v" for readability

Bugs fixed thanks to that:

- Export templates version matching now properly takes VERSION_PATCH
  into account by relying on VERSION_FULL_CONFIG (currently we can't
release 3.0.1-stable because of that).
- ClassDB hash no longer takes the build name into account, but limits
  itself to VERSION_FULL_CONFIG (build name is cosmetic, not relevant
  for the API hash).
- Docs XML no longer hardcode the VERSION_STATUS, this was annoying.
- Small cleanup in Windows .rc file thanks to new macros.