### PR TITLE
AudioServer emit bus_layout_changed signal when adding, moving or del…

### DIFF
--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -518,6 +518,8 @@ void AudioServer::remove_bus(int p_index) {
 	memdelete(buses[p_index]);
 	buses.remove(p_index);
 	unlock();
+
+	emit_signal("bus_layout_changed");
 }
 
 void AudioServer::add_bus(int p_at_pos) {
@@ -571,6 +573,8 @@ void AudioServer::add_bus(int p_at_pos) {
 		buses.push_back(bus);
 	else
 		buses.insert(p_at_pos, bus);
+
+	emit_signal("bus_layout_changed");
 }
 
 void AudioServer::move_bus(int p_bus, int p_to_pos) {
@@ -593,6 +597,8 @@ void AudioServer::move_bus(int p_bus, int p_to_pos) {
 	} else {
 		buses.insert(p_to_pos - 1, bus);
 	}
+
+	emit_signal("bus_layout_changed");
 }
 
 int AudioServer::get_bus_count() const {


### PR DESCRIPTION
…eting a bus

It was only emitting when changing the bus count or changing a bus name.