### PR TITLE
Fix visibility of gizmos on scene load

### DIFF
--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -188,7 +188,9 @@ void Spatial::_notification(int p_what) {
 					if (data.gizmo.is_valid()) {
 						data.gizmo->create();
 						if (data.gizmo->can_draw()) {
-							data.gizmo->redraw();
+							if (is_visible_in_tree()) {
+								data.gizmo->redraw();
+							}
 						}
 						data.gizmo->transform();
 					}
@@ -409,7 +411,9 @@ void Spatial::set_gizmo(const Ref<SpatialGizmo> &p_gizmo) {
 
 		data.gizmo->create();
 		if (data.gizmo->can_draw()) {
-			data.gizmo->redraw();
+			if (is_visible_in_tree()) {
+				data.gizmo->redraw();
+			}
 		}
 		data.gizmo->transform();
 	}


### PR DESCRIPTION
When loading a scene, hidden nodes were correctly hidden but their gizmos were drawn anyway. This PR fixes that.

![image](https://user-images.githubusercontent.com/4402304/36629857-bfe4ffd8-195c-11e8-9372-5679a42b913c.png)
