### PR TITLE
[mono] show whole trace of nested exceptions

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1646,12 +1646,20 @@ void ScriptEditorDebugger::_error_selected(int p_idx) {
 		md.push_back(st[i + 1]);
 		md.push_back(st[i + 2]);
 
-		String str = func + " in " + script.get_file() + ":line " + itos(line);
+		String str = func;
+		String tooltip_str = TTR("Function:") + " " + func;
+		if (script.length() > 0) {
+			str += " in " + script.get_file();
+			tooltip_str = TTR("File:") + " " + script + "\n" + tooltip_str;
+			if (line > 0) {
+				str += ":line " + itos(line);
+				tooltip_str += "\n" + TTR("Line:") + " " + itos(line);
+			}
+		}
 
 		error_stack->add_item(str);
 		error_stack->set_item_metadata(error_stack->get_item_count() - 1, md);
-		error_stack->set_item_tooltip(error_stack->get_item_count() - 1,
-				TTR("File:") + " " + script + "\n" + TTR("Function:") + " " + func + "\n" + TTR("Line:") + " " + itos(line));
+		error_stack->set_item_tooltip(error_stack->get_item_count() - 1, tooltip_str);
 	}
 }
 


### PR DESCRIPTION
Issue #15886

The debugger now shows the whole trace of nested exception (it was only showing the top level for now).
![capture du 2018-02-24 17-02-48](https://user-images.githubusercontent.com/437025/36632656-32c5d992-1989-11e8-8155-70aeae279c20.png)

I'm not sure 0c63b15 should be included as it feels a bit hacky, is not really mandatory and could feel like module specific code outside of the module itself. Feel free to tell me to delete it.
