### PR TITLE
Fix mbedTLS compilation with mingw 4.x

### DIFF
--- a/thirdparty/mbedtls/include/mbedtls/mingwhack.h
+++ b/thirdparty/mbedtls/include/mbedtls/mingwhack.h
@@ -1,0 +1,71 @@
+/**
+ * This file has no copyright assigned and is placed in the Public Domain.
+ * This file is part of the mingw-w64 runtime package.
+ */
+
+#ifndef _INTSAFE_H_INCLUDED_
+#define _INTSAFE_H_INCLUDED_
+
+#include <winapifamily.h>
+
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP)
+
+#include <wtypesbase.h>
+#include <specstrings.h>
+
+#define INTSAFE_E_ARITHMETIC_OVERFLOW ((HRESULT)0x80070216)
+
+#ifndef S_OK
+#define S_OK ((HRESULT)0)
+#endif
+
+#ifdef __clang__
+#if __has_builtin(__builtin_add_overflow)
+#define __MINGW_INTSAFE_WORKS
+#endif
+#elif __GNUC__ >= 5
+#define __MINGW_INTSAFE_WORKS
+#endif
+
+#ifdef __MINGW_INTSAFE_WORKS
+
+#ifndef __MINGW_INTSAFE_API
+#define __MINGW_INTSAFE_API FORCEINLINE
+#endif
+
+/** If CHAR is unsigned, use static inline for functions that operate
+on chars.  This avoids the risk of linking to the wrong function when
+different translation units with different types of chars are linked
+together, and code using signed chars will not be affected. */
+#ifndef __MINGW_INTSAFE_CHAR_API
+#ifdef __CHAR_UNSIGNED__
+#define __MINGW_INTSAFE_CHAR_API static inline
+#else
+#define __MINGW_INTSAFE_CHAR_API __MINGW_INTSAFE_API
+#endif
+#endif
+
+#define __MINGW_INTSAFE_BODY(operation, x, y) \
+{ \
+  if (__builtin_##operation##_overflow(x, y, result)) \
+  { \
+      *result = 0; \
+      return INTSAFE_E_ARITHMETIC_OVERFLOW; \
+  } \
+  return S_OK; \
+}
+
+#define __MINGW_INTSAFE_CONV(name, type_src, type_dest) \
+    HRESULT name(type_src operand, type_dest * result) \
+    __MINGW_INTSAFE_BODY(add, operand, 0)
+
+#define __MINGW_INTSAFE_MATH(name, type, operation) \
+    HRESULT name(type x, type y, type * result) \
+    __MINGW_INTSAFE_BODY(operation, x, y)
+
+__MINGW_INTSAFE_API __MINGW_INTSAFE_CONV(SizeTToULong, size_t, ULONG)
+__MINGW_INTSAFE_API __MINGW_INTSAFE_CONV(SizeTToInt, size_t, INT)
+
+#endif /* __GNUC__ >= 5 */
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) */
+#endif /* _INTSAFE_H_INCLUDED_ */

--- a/thirdparty/mbedtls/library/entropy_poll.c
+++ b/thirdparty/mbedtls/library/entropy_poll.c
@@ -63,7 +63,13 @@
 #pragma warning( push )
 #pragma warning( disable : 4005 )
 #endif
+
+#if defined(__MINGW32__) && (!defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 5)
+#include "mbedtls/mingwhack.h"
+#else
 #include <intsafe.h>
+#endif
+
 #if _MSC_VER <= 1600
 #pragma warning( pop )
 #endif

--- a/thirdparty/mbedtls/library/x509_crt.c
+++ b/thirdparty/mbedtls/library/x509_crt.c
@@ -70,7 +70,11 @@
 #pragma warning( push )
 #pragma warning( disable : 4005 )
 #endif
+#if defined(__MINGW32__) && (!defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 5)
+#include "mbedtls/mingwhack.h"
+#else
 #include <intsafe.h>
+#endif
 #if _MSC_VER <= 1600
 #pragma warning( pop )
 #endif


### PR DESCRIPTION
Users reported the mbedtls library spitting error when compiling with mingw < 5 (after #16865, see #16939).

This PR makes a workaround by importing bits of `intsafe.h` from mingw 5.x to be included when older versions are detected in place of `intsafe.h`

The cross compilation seems to be broken anyway by the `etc` module at least on Ubuntu 16.04 (mingw 4.0.4 with GCC 5.3.1).

**I would prefer not to merge this, and instead stop supporting mingw versions < 5** (keep your toolchains updated!).

I'm still making the PR as requested, we can discuss the keep/drop behavior below, or simply merge it if you are satisfied with it.

----

The ETC error on Ubuntu 16.04
```
    thirdparty/etc2comp/EtcImage.cpp: In member function 'Etc::Image::EncodingStatus Etc::Image::Encode(Etc::Image::Format, Etc::ErrorMetric, float, unsigned int, unsigned int)':
    thirdparty/etc2comp/EtcImage.cpp:259:64: error: invalid use of incomplete type 'class std::future<void>'
       std::future<void> *handle = new std::future<void>[a_uiMaxJobs];
                                                                    ^
    In file included from thirdparty/etc2comp/EtcImage.cpp:40:0:
    /usr/lib/gcc/x86_64-w64-mingw32/5.3-win32/include/c++/future:115:11: note: declaration of 'class std::future<void>'
         class future;
               ^
    thirdparty/etc2comp/EtcImage.cpp:268:12: error: invalid use of incomplete type 'class std::future<void>'
        handle[i] = async(std::launch::async, &Image::RunFirstPass, this, i, uiNumTh
                ^
    In file included from thirdparty/etc2comp/EtcImage.cpp:40:0:
    /usr/lib/gcc/x86_64-w64-mingw32/5.3-win32/include/c++/future:115:11: note: declaration of 'class std::future<void>'
         class future;
               ^
    thirdparty/etc2comp/EtcImage.cpp:268:91: error: invalid use of incomplete type 'class std::future<void>'
     = async(std::launch::async, &Image::RunFirstPass, this, i, uiNumThreadsNeeded);
                                                                                  ^
    In file included from thirdparty/etc2comp/EtcImage.cpp:40:0:
    /usr/lib/gcc/x86_64-w64-mingw32/5.3-win32/include/c++/future:115:11: note: declaration of 'class std::future<void>'
         class future;
               ^
    thirdparty/etc2comp/EtcImage.cpp:275:12: error: invalid use of incomplete type 'class std::future<void>'
        handle[i].get();
                ^
    In file included from thirdparty/etc2comp/EtcImage.cpp:40:0:
    /usr/lib/gcc/x86_64-w64-mingw32/5.3-win32/include/c++/future:115:11: note: declaration of 'class std::future<void>'
         class future;
               ^
    thirdparty/etc2comp/EtcImage.cpp:275:13: error: invalid use of incomplete type 'class std::future<void>'
        handle[i].get();
                 ^
    In file included from thirdparty/etc2comp/EtcImage.cpp:40:0:
    /usr/lib/gcc/x86_64-w64-mingw32/5.3-win32/include/c++/future:115:11: note: declaration of 'class std::future<void>'
         class future;
               ^
    thirdparty/etc2comp/EtcImage.cpp:330:107: error: invalid use of incomplete type 'class std::future<unsigned int>'
     > *handleToBlockEncoders = new std::future<unsigned int>[uiNumThreadsNeeded-1];
                                                                                  ^
    In file included from thirdparty/etc2comp/EtcImage.cpp:40:0:
    /usr/lib/gcc/x86_64-w64-mingw32/5.3-win32/include/c++/future:115:11: note: declaration of 'class std::future<unsigned int>'
         class future;
               ^
    thirdparty/etc2comp/EtcImage.cpp:334:30: error: invalid use of incomplete type 'class std::future<unsigned int>'
           handleToBlockEncoders[i] = async(std::launch::async, &Image::IterateThrou
                                  ^
    In file included from thirdparty/etc2comp/EtcImage.cpp:40:0:
    /usr/lib/gcc/x86_64-w64-mingw32/5.3-win32/include/c++/future:115:11: note: declaration of 'class std::future<unsigned int>'
         class future;
               ^
    thirdparty/etc2comp/EtcImage.cpp:334:147: error: invalid use of incomplete type 'class std::future<unsigned int>'
     erateThroughWorstBlocks, this, blocksToIterateThisPass, i, uiNumThreadsNeeded);
                                                                                  ^
    In file included from thirdparty/etc2comp/EtcImage.cpp:40:0:
    /usr/lib/gcc/x86_64-w64-mingw32/5.3-win32/include/c++/future:115:11: note: declaration of 'class std::future<unsigned int>'
         class future;
               ^
    thirdparty/etc2comp/EtcImage.cpp:340:50: error: invalid use of incomplete type 'class std::future<unsigned int>'
           uiIteratedBlocks += handleToBlockEncoders[i].get();
                                                      ^
    In file included from thirdparty/etc2comp/EtcImage.cpp:40:0:
    /usr/lib/gcc/x86_64-w64-mingw32/5.3-win32/include/c++/future:115:11: note: declaration of 'class std::future<unsigned int>'
         class future;
               ^
    thirdparty/etc2comp/EtcImage.cpp:340:51: error: invalid use of incomplete type 'class std::future<unsigned int>'
           uiIteratedBlocks += handleToBlockEncoders[i].get();
                                                       ^
    In file included from thirdparty/etc2comp/EtcImage.cpp:40:0:
    /usr/lib/gcc/x86_64-w64-mingw32/5.3-win32/include/c++/future:115:11: note: declaration of 'class std::future<unsigned int>'
         class future;
               ^
    thirdparty/etc2comp/EtcImage.cpp:356:12: error: invalid use of incomplete type 'class std::future<void>'
        handle[i] = async(std::launch::async, &Image::SetEncodingBits, this, i, a_ui
                ^
    In file included from thirdparty/etc2comp/EtcImage.cpp:40:0:
    /usr/lib/gcc/x86_64-w64-mingw32/5.3-win32/include/c++/future:115:11: note: declaration of 'class std::future<void>'
         class future;
               ^
    thirdparty/etc2comp/EtcImage.cpp:356:84: error: invalid use of incomplete type 'class std::future<void>'
     dle[i] = async(std::launch::async, &Image::SetEncodingBits, this, i, a_uiJobs);
                                                                                  ^
    In file included from thirdparty/etc2comp/EtcImage.cpp:40:0:
    /usr/lib/gcc/x86_64-w64-mingw32/5.3-win32/include/c++/future:115:11: note: declaration of 'class std::future<void>'
         class future;
               ^
    thirdparty/etc2comp/EtcImage.cpp:362:12: error: invalid use of incomplete type 'class std::future<void>'
        handle[i].get();
                ^
    In file included from thirdparty/etc2comp/EtcImage.cpp:40:0:
    /usr/lib/gcc/x86_64-w64-mingw32/5.3-win32/include/c++/future:115:11: note: declaration of 'class std::future<void>'
         class future;
               ^
    thirdparty/etc2comp/EtcImage.cpp:362:13: error: invalid use of incomplete type 'class std::future<void>'
        handle[i].get();
                 ^
    In file included from thirdparty/etc2comp/EtcImage.cpp:40:0:
    /usr/lib/gcc/x86_64-w64-mingw32/5.3-win32/include/c++/future:115:11: note: declaration of 'class std::future<void>'
         class future;
               ^
    scons: *** [thirdparty/etc2comp/EtcImage.windows.tools.64.o] Error 1
    scons: building terminated because of errors.
```