### PR TITLE
Mono: Pending exceptions and cleanup

### DIFF
--- a/modules/mono/SCsub
+++ b/modules/mono/SCsub
@@ -5,9 +5,11 @@ Import('env_modules')
 
 env_mono = env_modules.Clone()
 
-from compat import byte_to_str
+# TODO move functions to their own modules
 
 def make_cs_files_header(src, dst):
+    from compat import byte_to_str
+
     with open(dst, 'w') as header:
         header.write('/* This is an automatically generated file; DO NOT EDIT! OK THX */\n')
         header.write('#ifndef _CS_FILES_DATA_H\n')
@@ -75,6 +77,13 @@ else:
 if ARGUMENTS.get('yolo_copy', False):
     env_mono.Append(CPPDEFINES=['YOLO_COPY'])
 
+# Configure TLS checks
+
+import tls_configure
+conf = Configure(env_mono)
+tls_configure.configure(conf)
+env_mono = conf.Finish()
+
 
 # Build GodotSharpTools solution
 
@@ -128,12 +137,13 @@ def find_msbuild_windows():
         raise RuntimeError('Cannot find mono root directory')
 
     framework_path = os.path.join(mono_root, 'lib', 'mono', '4.5')
-
     mono_bin_dir = os.path.join(mono_root, 'bin')
-
     msbuild_mono = os.path.join(mono_bin_dir, 'msbuild.bat')
 
     if os.path.isfile(msbuild_mono):
+        # The (Csc/Vbc/Fsc)ToolExe environment variables are required when
+        # building with Mono's MSBuild. They must point to the batch files
+        # in Mono's bin directory to make sure they are executed with Mono.
         mono_msbuild_env = {
             'CscToolExe': os.path.join(mono_bin_dir, 'csc.bat'),
             'VbcToolExe': os.path.join(mono_bin_dir, 'vbc.bat'),

--- a/modules/mono/editor/csharp_project.cpp
+++ b/modules/mono/editor/csharp_project.cpp
@@ -47,11 +47,11 @@ String generate_core_api_project(const String &p_dir, const Vector<String> &p_fi
 	Variant dir = p_dir;
 	Variant compile_items = p_files;
 	const Variant *args[2] = { &dir, &compile_items };
-	MonoObject *ex = NULL;
-	MonoObject *ret = klass->get_method("GenCoreApiProject", 2)->invoke(NULL, args, &ex);
+	MonoException *exc = NULL;
+	MonoObject *ret = klass->get_method("GenCoreApiProject", 2)->invoke(NULL, args, &exc);
 
-	if (ex) {
-		mono_print_unhandled_exception(ex);
+	if (exc) {
+		GDMonoUtils::debug_unhandled_exception(exc);
 		ERR_FAIL_V(String());
 	}
 
@@ -68,11 +68,11 @@ String generate_editor_api_project(const String &p_dir, const String &p_core_dll
 	Variant core_dll_path = p_core_dll_path;
 	Variant compile_items = p_files;
 	const Variant *args[3] = { &dir, &core_dll_path, &compile_items };
-	MonoObject *ex = NULL;
-	MonoObject *ret = klass->get_method("GenEditorApiProject", 3)->invoke(NULL, args, &ex);
+	MonoException *exc = NULL;
+	MonoObject *ret = klass->get_method("GenEditorApiProject", 3)->invoke(NULL, args, &exc);
 
-	if (ex) {
-		mono_print_unhandled_exception(ex);
+	if (exc) {
+		GDMonoUtils::debug_unhandled_exception(exc);
 		ERR_FAIL_V(String());
 	}
 
@@ -89,11 +89,11 @@ String generate_game_project(const String &p_dir, const String &p_name, const Ve
 	Variant name = p_name;
 	Variant compile_items = p_files;
 	const Variant *args[3] = { &dir, &name, &compile_items };
-	MonoObject *ex = NULL;
-	MonoObject *ret = klass->get_method("GenGameProject", 3)->invoke(NULL, args, &ex);
+	MonoException *exc = NULL;
+	MonoObject *ret = klass->get_method("GenGameProject", 3)->invoke(NULL, args, &exc);
 
-	if (ex) {
-		mono_print_unhandled_exception(ex);
+	if (exc) {
+		GDMonoUtils::debug_unhandled_exception(exc);
 		ERR_FAIL_V(String());
 	}
 
@@ -110,11 +110,11 @@ void add_item(const String &p_project_path, const String &p_item_type, const Str
 	Variant item_type = p_item_type;
 	Variant include = p_include;
 	const Variant *args[3] = { &project_path, &item_type, &include };
-	MonoObject *ex = NULL;
-	klass->get_method("AddItemToProjectChecked", 3)->invoke(NULL, args, &ex);
+	MonoException *exc = NULL;
+	klass->get_method("AddItemToProjectChecked", 3)->invoke(NULL, args, &exc);
 
-	if (ex) {
-		mono_print_unhandled_exception(ex);
+	if (exc) {
+		GDMonoUtils::debug_unhandled_exception(exc);
 		ERR_FAIL();
 	}
 }

--- a/modules/mono/editor/godotsharp_builds.cpp
+++ b/modules/mono/editor/godotsharp_builds.cpp
@@ -512,14 +512,14 @@ void GodotSharpBuilds::BuildProcess::start(bool p_blocking) {
 
 	const Variant *ctor_args[2] = { &solution, &config };
 
-	MonoObject *ex = NULL;
+	MonoException *exc = NULL;
 	GDMonoMethod *ctor = klass->get_method(".ctor", 2);
-	ctor->invoke(mono_object, ctor_args, &ex);
+	ctor->invoke(mono_object, ctor_args, &exc);
 
-	if (ex) {
+	if (exc) {
 		exited = true;
-		GDMonoUtils::print_unhandled_exception(ex);
-		String message = "The build constructor threw an exception.\n" + GDMonoUtils::get_exception_name_and_message(ex);
+		GDMonoUtils::debug_unhandled_exception(exc);
+		String message = "The build constructor threw an exception.\n" + GDMonoUtils::get_exception_name_and_message(exc);
 		build_tab->on_build_exec_failed(message);
 		ERR_EXPLAIN(message);
 		ERR_FAIL();
@@ -534,14 +534,14 @@ void GodotSharpBuilds::BuildProcess::start(bool p_blocking) {
 
 	const Variant *args[3] = { &logger_assembly, &logger_output_dir, &custom_props };
 
-	ex = NULL;
+	exc = NULL;
 	GDMonoMethod *build_method = klass->get_method(p_blocking ? "Build" : "BuildAsync", 3);
-	build_method->invoke(mono_object, args, &ex);
+	build_method->invoke(mono_object, args, &exc);
 
-	if (ex) {
+	if (exc) {
 		exited = true;
-		GDMonoUtils::print_unhandled_exception(ex);
-		String message = "The build method threw an exception.\n" + GDMonoUtils::get_exception_name_and_message(ex);
+		GDMonoUtils::debug_unhandled_exception(exc);
+		String message = "The build method threw an exception.\n" + GDMonoUtils::get_exception_name_and_message(exc);
 		build_tab->on_build_exec_failed(message);
 		ERR_EXPLAIN(message);
 		ERR_FAIL();

--- a/modules/mono/editor/monodevelop_instance.cpp
+++ b/modules/mono/editor/monodevelop_instance.cpp
@@ -40,14 +40,14 @@ void MonoDevelopInstance::execute(const Vector<String> &p_files) {
 	ERR_FAIL_NULL(execute_method);
 	ERR_FAIL_COND(gc_handle.is_null());
 
-	MonoObject *ex = NULL;
+	MonoException *exc = NULL;
 
 	Variant files = p_files;
 	const Variant *args[1] = { &files };
-	execute_method->invoke(gc_handle->get_target(), args, &ex);
+	execute_method->invoke(gc_handle->get_target(), args, &exc);
 
-	if (ex) {
-		mono_print_unhandled_exception(ex);
+	if (exc) {
+		GDMonoUtils::debug_unhandled_exception(exc);
 		ERR_FAIL();
 	}
 }
@@ -68,14 +68,14 @@ MonoDevelopInstance::MonoDevelopInstance(const String &p_solution) {
 	MonoObject *obj = mono_object_new(TOOLS_DOMAIN, klass->get_mono_ptr());
 
 	GDMonoMethod *ctor = klass->get_method(".ctor", 1);
-	MonoObject *ex = NULL;
+	MonoException *exc = NULL;
 
 	Variant solution = p_solution;
 	const Variant *args[1] = { &solution };
-	ctor->invoke(obj, args, &ex);
+	ctor->invoke(obj, args, &exc);
 
-	if (ex) {
-		mono_print_unhandled_exception(ex);
+	if (exc) {
+		GDMonoUtils::debug_unhandled_exception(exc);
 		ERR_FAIL();
 	}
 

--- a/modules/mono/mono_gd/gd_mono.h
+++ b/modules/mono/mono_gd/gd_mono.h
@@ -164,6 +164,8 @@ public:
 
 	static GDMono *get_singleton() { return singleton; }
 
+	static void unhandled_exception_hook(MonoObject *p_exc, void *p_user_data);
+
 	// Do not use these, unless you know what you're doing
 	void add_assembly(uint32_t p_domain_id, GDMonoAssembly *p_assembly);
 	GDMonoAssembly **get_loaded_assembly(const String &p_name);

--- a/modules/mono/mono_gd/gd_mono_internals.cpp
+++ b/modules/mono/mono_gd/gd_mono_internals.cpp
@@ -32,7 +32,11 @@
 
 #include "../csharp_script.h"
 #include "../mono_gc_handle.h"
+#include "../utils/macros.h"
+#include "../utils/thread_local.h"
 #include "gd_mono_utils.h"
+
+#include <mono/metadata/exception.h>
 
 namespace GDMonoInternals {
 
@@ -64,4 +68,11 @@ void tie_managed_to_unmanaged(MonoObject *managed, Object *unmanaged) {
 
 	return;
 }
+
+void unhandled_exception(MonoException *p_exc) {
+	mono_unhandled_exception((MonoObject *)p_exc); // prints the exception as well
+	abort();
+	_UNREACHABLE_();
+}
+
 } // namespace GDMonoInternals

--- a/modules/mono/mono_gd/gd_mono_internals.h
+++ b/modules/mono/mono_gd/gd_mono_internals.h
@@ -33,11 +33,20 @@
 
 #include <mono/jit/jit.h>
 
+#include "../utils/macros.h"
+
 #include "core/object.h"
 
 namespace GDMonoInternals {
 
 void tie_managed_to_unmanaged(MonoObject *managed, Object *unmanaged);
-}
+
+/**
+ * Do not call this function directly.
+ * Use GDMonoUtils::debug_unhandled_exception(MonoException *) instead.
+ */
+_NO_RETURN_ void unhandled_exception(MonoException *p_exc);
+
+} // namespace GDMonoInternals
 
 #endif // GD_MONO_INTERNALS_H

--- a/modules/mono/mono_gd/gd_mono_marshal.cpp
+++ b/modules/mono/mono_gd/gd_mono_marshal.cpp
@@ -837,11 +837,13 @@ MonoObject *Dictionary_to_mono_object(const Dictionary &p_dict) {
 
 	GDMonoUtils::MarshalUtils_ArraysToDict arrays_to_dict = CACHED_METHOD_THUNK(MarshalUtils, ArraysToDictionary);
 
-	MonoObject *ex = NULL;
-	MonoObject *ret = arrays_to_dict(keys, values, &ex);
+	MonoException *exc = NULL;
+	GD_MONO_BEGIN_RUNTIME_INVOKE;
+	MonoObject *ret = arrays_to_dict(keys, values, (MonoObject **)&exc);
+	GD_MONO_END_RUNTIME_INVOKE;
 
-	if (ex) {
-		mono_print_unhandled_exception(ex);
+	if (exc) {
+		GDMonoUtils::set_pending_exception(exc);
 		ERR_FAIL_V(NULL);
 	}
 
@@ -858,11 +860,13 @@ Dictionary mono_object_to_Dictionary(MonoObject *p_dict) {
 
 	MonoArray *keys = NULL;
 	MonoArray *values = NULL;
-	MonoObject *ex = NULL;
-	dict_to_arrays(p_dict, &keys, &values, &ex);
+	MonoException *exc = NULL;
+	GD_MONO_BEGIN_RUNTIME_INVOKE;
+	dict_to_arrays(p_dict, &keys, &values, (MonoObject **)&exc);
+	GD_MONO_END_RUNTIME_INVOKE;
 
-	if (ex) {
-		mono_print_unhandled_exception(ex);
+	if (exc) {
+		GDMonoUtils::set_pending_exception(exc);
 		ERR_FAIL_V(Dictionary());
 	}
 

--- a/modules/mono/mono_gd/gd_mono_method.h
+++ b/modules/mono/mono_gd/gd_mono_method.h
@@ -71,9 +71,9 @@ public:
 
 	void *get_thunk();
 
-	MonoObject *invoke(MonoObject *p_object, const Variant **p_params, MonoObject **r_exc = NULL);
-	MonoObject *invoke(MonoObject *p_object, MonoObject **r_exc = NULL);
-	MonoObject *invoke_raw(MonoObject *p_object, void **p_params, MonoObject **r_exc = NULL);
+	MonoObject *invoke(MonoObject *p_object, const Variant **p_params, MonoException **r_exc = NULL);
+	MonoObject *invoke(MonoObject *p_object, MonoException **r_exc = NULL);
+	MonoObject *invoke_raw(MonoObject *p_object, void **p_params, MonoException **r_exc = NULL);
 
 	String get_full_name(bool p_signature = false) const;
 	String get_full_name_no_class() const;

--- a/modules/mono/mono_gd/gd_mono_property.cpp
+++ b/modules/mono/mono_gd/gd_mono_property.cpp
@@ -138,47 +138,53 @@ bool GDMonoProperty::has_setter() {
 	return mono_property_get_set_method(mono_property) != NULL;
 }
 
-void GDMonoProperty::set_value(MonoObject *p_object, MonoObject *p_value, MonoObject **r_exc) {
+void GDMonoProperty::set_value(MonoObject *p_object, MonoObject *p_value, MonoException **r_exc) {
 	MonoMethod *prop_method = mono_property_get_set_method(mono_property);
 
 	MonoArray *params = mono_array_new(mono_domain_get(), CACHED_CLASS_RAW(MonoObject), 1);
 	mono_array_set(params, MonoObject *, 0, p_value);
 
-	MonoObject *exc = NULL;
-	mono_runtime_invoke_array(prop_method, p_object, params, &exc);
+	MonoException *exc = NULL;
+	GD_MONO_BEGIN_RUNTIME_INVOKE;
+	mono_runtime_invoke_array(prop_method, p_object, params, (MonoObject **)&exc);
+	GD_MONO_END_RUNTIME_INVOKE;
 
 	if (exc) {
 		if (r_exc) {
 			*r_exc = exc;
 		} else {
-			GDMonoUtils::print_unhandled_exception(exc);
+			GDMonoUtils::set_pending_exception(exc);
 		}
 	}
 }
 
-void GDMonoProperty::set_value(MonoObject *p_object, void **p_params, MonoObject **r_exc) {
-	MonoObject *exc = NULL;
-	mono_property_set_value(mono_property, p_object, p_params, &exc);
+void GDMonoProperty::set_value(MonoObject *p_object, void **p_params, MonoException **r_exc) {
+	MonoException *exc = NULL;
+	GD_MONO_BEGIN_RUNTIME_INVOKE;
+	mono_property_set_value(mono_property, p_object, p_params, (MonoObject **)&exc);
+	GD_MONO_END_RUNTIME_INVOKE;
 
 	if (exc) {
 		if (r_exc) {
 			*r_exc = exc;
 		} else {
-			GDMonoUtils::print_unhandled_exception(exc);
+			GDMonoUtils::set_pending_exception(exc);
 		}
 	}
 }
 
-MonoObject *GDMonoProperty::get_value(MonoObject *p_object, MonoObject **r_exc) {
-	MonoObject *exc = NULL;
-	MonoObject *ret = mono_property_get_value(mono_property, p_object, NULL, &exc);
+MonoObject *GDMonoProperty::get_value(MonoObject *p_object, MonoException **r_exc) {
+	MonoException *exc = NULL;
+	GD_MONO_BEGIN_RUNTIME_INVOKE;
+	MonoObject *ret = mono_property_get_value(mono_property, p_object, NULL, (MonoObject **)&exc);
+	GD_MONO_END_RUNTIME_INVOKE;
 
 	if (exc) {
 		ret = NULL;
 		if (r_exc) {
 			*r_exc = exc;
 		} else {
-			GDMonoUtils::print_unhandled_exception(exc);
+			GDMonoUtils::set_pending_exception(exc);
 		}
 	}
 

--- a/modules/mono/mono_gd/gd_mono_property.h
+++ b/modules/mono/mono_gd/gd_mono_property.h
@@ -62,9 +62,9 @@ public:
 
 	_FORCE_INLINE_ ManagedType get_type() const { return type; }
 
-	void set_value(MonoObject *p_object, MonoObject *p_value, MonoObject **r_exc = NULL);
-	void set_value(MonoObject *p_object, void **p_params, MonoObject **r_exc = NULL);
-	MonoObject *get_value(MonoObject *p_object, MonoObject **r_exc = NULL);
+	void set_value(MonoObject *p_object, MonoObject *p_value, MonoException **r_exc = NULL);
+	void set_value(MonoObject *p_object, void **p_params, MonoException **r_exc = NULL);
+	MonoObject *get_value(MonoObject *p_object, MonoException **r_exc = NULL);
 
 	bool get_bool_value(MonoObject *p_object);
 	int get_int_value(MonoObject *p_object);

--- a/modules/mono/mono_gd/gd_mono_utils.cpp
+++ b/modules/mono/mono_gd/gd_mono_utils.cpp
@@ -30,12 +30,15 @@
 
 #include "gd_mono_utils.h"
 
+#include <mono/metadata/exception.h>
+
 #include "os/dir_access.h"
 #include "os/os.h"
 #include "project_settings.h"
 #include "reference.h"
 
 #include "../csharp_script.h"
+#include "../utils/macros.h"
 #include "gd_mono.h"
 #include "gd_mono_class.h"
 #include "gd_mono_marshal.h"
@@ -397,10 +400,10 @@ MonoDomain *create_domain(const String &p_friendly_name) {
 	return domain;
 }
 
-String get_exception_name_and_message(MonoObject *p_ex) {
+String get_exception_name_and_message(MonoException *p_ex) {
 	String res;
 
-	MonoClass *klass = mono_object_get_class(p_ex);
+	MonoClass *klass = mono_object_get_class((MonoObject *)p_ex);
 	MonoType *type = mono_class_get_type(klass);
 
 	char *full_name = mono_type_full_name(type);
@@ -410,29 +413,31 @@ String get_exception_name_and_message(MonoObject *p_ex) {
 	res += ": ";
 
 	MonoProperty *prop = mono_class_get_property_from_name(klass, "Message");
-	MonoString *msg = (MonoString *)mono_property_get_value(prop, p_ex, NULL, NULL);
+	MonoString *msg = (MonoString *)mono_property_get_value(prop, (MonoObject *)p_ex, NULL, NULL);
 	res += GDMonoMarshal::mono_string_to_godot(msg);
 
 	return res;
 }
 
-void print_unhandled_exception(MonoObject *p_exc) {
-	print_unhandled_exception(p_exc, false);
+void debug_print_unhandled_exception(MonoException *p_exc) {
+	print_unhandled_exception(p_exc);
+	debug_send_unhandled_exception_error(p_exc);
 }
 
-void print_unhandled_exception(MonoObject *p_exc, bool p_recursion_caution) {
-	mono_print_unhandled_exception(p_exc);
+void debug_send_unhandled_exception_error(MonoException *p_exc) {
 #ifdef DEBUG_ENABLED
 	if (!ScriptDebugger::get_singleton())
 		return;
 
+	_TLS_RECURSION_GUARD_;
+
 	ScriptLanguage::StackInfo separator;
-	separator.file = "";
+	separator.file = String();
 	separator.func = "--- " + RTR("End of inner exception stack trace") + " ---";
 	separator.line = 0;
 
 	Vector<ScriptLanguage::StackInfo> si;
-	String exc_msg = "";
+	String exc_msg;
 
 	while (p_exc != NULL) {
 		GDMonoClass *st_klass = CACHED_CLASS(System_Diagnostics_StackTrace);
@@ -441,24 +446,16 @@ void print_unhandled_exception(MonoObject *p_exc, bool p_recursion_caution) {
 		MonoBoolean need_file_info = true;
 		void *ctor_args[2] = { p_exc, &need_file_info };
 
-		MonoObject *unexpected_exc = NULL;
+		MonoException *unexpected_exc = NULL;
 		CACHED_METHOD(System_Diagnostics_StackTrace, ctor_Exception_bool)->invoke_raw(stack_trace, ctor_args, &unexpected_exc);
 
-		if (unexpected_exc != NULL) {
-			mono_print_unhandled_exception(unexpected_exc);
-
-			if (p_recursion_caution) {
-				// Called from CSharpLanguage::get_current_stack_info,
-				// so printing an error here could result in endless recursion
-				OS::get_singleton()->printerr("Mono: Method GDMonoUtils::print_unhandled_exception failed");
-				return;
-			} else {
-				ERR_FAIL();
-			}
+		if (unexpected_exc) {
+			GDMonoInternals::unhandled_exception(unexpected_exc);
+			_UNREACHABLE_();
 		}
 
 		Vector<ScriptLanguage::StackInfo> _si;
-		if (stack_trace != NULL && !p_recursion_caution) {
+		if (stack_trace != NULL) {
 			_si = CSharpLanguage::get_singleton()->stack_trace_get_info(stack_trace);
 			for (int i = _si.size() - 1; i >= 0; i--)
 				si.insert(0, _si[i]);
@@ -466,10 +463,15 @@ void print_unhandled_exception(MonoObject *p_exc, bool p_recursion_caution) {
 
 		exc_msg += (exc_msg.length() > 0 ? " ---> " : "") + GDMonoUtils::get_exception_name_and_message(p_exc);
 
-		GDMonoProperty *p_prop = GDMono::get_singleton()->get_class(mono_object_get_class(p_exc))->get_property("InnerException");
-		p_exc = p_prop != NULL ? p_prop->get_value(p_exc) : NULL;
-		if (p_exc != NULL)
+		GDMonoClass *exc_class = GDMono::get_singleton()->get_class(mono_get_exception_class());
+		GDMonoProperty *inner_exc_prop = exc_class->get_property("InnerException");
+		CRASH_COND(inner_exc_prop == NULL);
+
+		MonoObject *inner_exc = inner_exc_prop->get_value((MonoObject *)p_exc);
+		if (inner_exc != NULL)
 			si.insert(0, separator);
+
+		p_exc = (MonoException *)inner_exc;
 	}
 
 	String file = si.size() ? si[0].file : __FILE__;
@@ -480,5 +482,39 @@ void print_unhandled_exception(MonoObject *p_exc, bool p_recursion_caution) {
 	ScriptDebugger::get_singleton()->send_error(func, file, line, error_msg, exc_msg, ERR_HANDLER_ERROR, si);
 #endif
 }
+
+void debug_unhandled_exception(MonoException *p_exc) {
+#ifdef DEBUG_ENABLED
+	GDMonoUtils::debug_send_unhandled_exception_error(p_exc);
+	if (ScriptDebugger::get_singleton())
+		ScriptDebugger::get_singleton()->idle_poll();
+#endif
+	GDMonoInternals::unhandled_exception(p_exc); // prints the exception as well
+	_UNREACHABLE_();
+}
+
+void print_unhandled_exception(MonoException *p_exc) {
+	mono_print_unhandled_exception((MonoObject *)p_exc);
+}
+
+void set_pending_exception(MonoException *p_exc) {
+#ifdef HAS_PENDING_EXCEPTIONS
+	if (get_runtime_invoke_count() == 0) {
+		debug_unhandled_exception(p_exc);
+		_UNREACHABLE_();
+	}
+
+	if (!mono_runtime_set_pending_exception(p_exc, false)) {
+		ERR_PRINTS("Exception thrown from managed code, but it could not be set as pending:");
+		GDMonoUtils::debug_print_unhandled_exception(p_exc);
+	}
+#else
+	debug_unhandled_exception(p_exc);
+	_UNREACHABLE_();
+#endif
+}
+
+_THREAD_LOCAL_(int)
+current_invoke_count = 0;
 
 } // namespace GDMonoUtils

--- a/modules/mono/mono_gd/gd_mono_utils.h
+++ b/modules/mono/mono_gd/gd_mono_utils.h
@@ -34,6 +34,8 @@
 #include <mono/metadata/threads.h>
 
 #include "../mono_gc_handle.h"
+#include "../utils/macros.h"
+#include "../utils/thread_local.h"
 #include "gd_mono_header.h"
 
 #include "object.h"
@@ -184,10 +186,28 @@ MonoObject *create_managed_from(const RID &p_from);
 
 MonoDomain *create_domain(const String &p_friendly_name);
 
-String get_exception_name_and_message(MonoObject *p_ex);
+String get_exception_name_and_message(MonoException *p_ex);
 
-void print_unhandled_exception(MonoObject *p_exc);
-void print_unhandled_exception(MonoObject *p_exc, bool p_recursion_caution);
+void debug_print_unhandled_exception(MonoException *p_exc);
+void debug_send_unhandled_exception_error(MonoException *p_exc);
+_NO_RETURN_ void debug_unhandled_exception(MonoException *p_exc);
+void print_unhandled_exception(MonoException *p_exc);
+
+/**
+ * Sets the exception as pending. The exception will be thrown when returning to managed code.
+ * If no managed method is being invoked by the runtime, the exception will be treated as
+ * an unhandled exception and the method will not return.
+ */
+void set_pending_exception(MonoException *p_exc);
+
+extern _THREAD_LOCAL_(int) current_invoke_count;
+
+_FORCE_INLINE_ int get_runtime_invoke_count() {
+	return current_invoke_count;
+}
+_FORCE_INLINE_ int &get_runtime_invoke_count_ref() {
+	return current_invoke_count;
+}
 
 } // namespace GDMonoUtils
 
@@ -205,5 +225,12 @@ void print_unhandled_exception(MonoObject *p_exc, bool p_recursion_caution);
 #else
 #define REAL_T_MONOCLASS CACHED_CLASS_RAW(float)
 #endif
+
+#define GD_MONO_BEGIN_RUNTIME_INVOKE                                              \
+	int &_runtime_invoke_count_ref = GDMonoUtils::get_runtime_invoke_count_ref(); \
+	_runtime_invoke_count_ref += 1;
+
+#define GD_MONO_END_RUNTIME_INVOKE \
+	_runtime_invoke_count_ref -= 1;
 
 #endif // GD_MONOUTILS_H

--- a/modules/mono/signal_awaiter_utils.cpp
+++ b/modules/mono/signal_awaiter_utils.cpp
@@ -101,11 +101,13 @@ Variant SignalAwaiterHandle::_signal_callback(const Variant **p_args, int p_argc
 
 	GDMonoUtils::SignalAwaiter_SignalCallback thunk = CACHED_METHOD_THUNK(SignalAwaiter, SignalCallback);
 
-	MonoObject *ex = NULL;
-	thunk(get_target(), signal_args, &ex);
+	MonoException *exc = NULL;
+	GD_MONO_BEGIN_RUNTIME_INVOKE;
+	thunk(get_target(), signal_args, (MonoObject **)&exc);
+	GD_MONO_END_RUNTIME_INVOKE;
 
-	if (ex) {
-		mono_print_unhandled_exception(ex);
+	if (exc) {
+		GDMonoUtils::set_pending_exception(exc);
 		ERR_FAIL_V(Variant());
 	}
 
@@ -133,11 +135,13 @@ SignalAwaiterHandle::~SignalAwaiterHandle() {
 		MonoObject *awaiter = get_target();
 
 		if (awaiter) {
-			MonoObject *ex = NULL;
-			thunk(awaiter, &ex);
+			MonoException *exc = NULL;
+			GD_MONO_BEGIN_RUNTIME_INVOKE;
+			thunk(awaiter, (MonoObject **)&exc);
+			GD_MONO_END_RUNTIME_INVOKE;
 
-			if (ex) {
-				mono_print_unhandled_exception(ex);
+			if (exc) {
+				GDMonoUtils::set_pending_exception(exc);
 				ERR_FAIL_V();
 			}
 		}

--- a/modules/mono/tls_configure.py
+++ b/modules/mono/tls_configure.py
@@ -1,0 +1,36 @@
+from __future__ import print_function
+
+def supported(result):
+    return 'supported' if result else 'not supported'
+
+
+def check_cxx11_thread_local(conf):
+    print('Checking for `thread_local` support...', end=" ")
+    result = conf.TryCompile('thread_local int foo = 0; int main() { return foo; }', '.cpp')
+    print(supported(result))
+    return bool(result)
+
+
+def check_declspec_thread(conf):
+    print('Checking for `__declspec(thread)` support...', end=" ")
+    result = conf.TryCompile('__declspec(thread) int foo = 0; int main() { return foo; }', '.cpp')
+    print(supported(result))
+    return bool(result)
+
+
+def check_gcc___thread(conf):
+    print('Checking for `__thread` support...', end=" ")
+    result = conf.TryCompile('__thread int foo = 0; int main() { return foo; }', '.cpp')
+    print(supported(result))
+    return bool(result)
+
+
+def configure(conf):
+    if check_cxx11_thread_local(conf):
+        conf.env.Append(CPPDEFINES=['HAVE_CXX11_THREAD_LOCAL'])
+    else:
+        if conf.env.msvc:
+            if check_declspec_thread(conf):
+                conf.env.Append(CPPDEFINES=['HAVE_DECLSPEC_THREAD'])
+        elif check_gcc___thread(conf):
+            conf.env.Append(CPPDEFINES=['HAVE_GCC___THREAD'])

--- a/modules/mono/utils/thread_local.h
+++ b/modules/mono/utils/thread_local.h
@@ -1,0 +1,171 @@
+/*************************************************************************/
+/*  thread_local.h                                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef THREAD_LOCAL_H
+#define THREAD_LOCAL_H
+
+#ifdef HAVE_CXX11_THREAD_LOCAL
+#define _THREAD_LOCAL_(m_t) thread_local m_t
+#else
+
+#if !defined(__GNUC__) && !defined(_MSC_VER)
+#error Platform or compiler not supported
+#endif
+
+#ifdef __GNUC__
+
+#ifdef HAVE_GCC___THREAD
+#define _THREAD_LOCAL_(m_t) __thread m_t
+#else
+#define USE_CUSTOM_THREAD_LOCAL
+#endif
+
+#elif _MSC_VER
+
+#ifdef HAVE_DECLSPEC_THREAD
+#define _THREAD_LOCAL_(m_t) __declspec(thread) m_t
+#else
+#define USE_CUSTOM_THREAD_LOCAL
+#endif
+
+#endif // __GNUC__ _MSC_VER
+
+#endif // HAVE_CXX11_THREAD_LOCAL
+
+#ifdef USE_CUSTOM_THREAD_LOCAL
+#define _THREAD_LOCAL_(m_t) ThreadLocal<m_t>
+#endif
+
+#include "core/typedefs.h"
+
+struct ThreadLocalStorage {
+
+	void *get_value() const;
+	void set_value(void *p_value) const;
+
+	void alloc(void (*p_dest_callback)(void *));
+	void free();
+
+private:
+	struct Impl;
+	Impl *pimpl;
+};
+
+template <typename T>
+class ThreadLocal {
+
+	ThreadLocalStorage storage;
+
+	T init_val;
+
+#ifdef WINDOWS_ENABLED
+#define _CALLBACK_FUNC_ __stdcall
+#else
+#define _CALLBACK_FUNC_
+#endif
+
+	static void _CALLBACK_FUNC_ destr_callback(void *tls_data) {
+		memdelete(static_cast<T *>(tls_data));
+	}
+
+#undef _CALLBACK_FUNC_
+
+	T *_tls_get_value() const {
+		void *tls_data = storage.get_value();
+
+		if (tls_data)
+			return static_cast<T *>(tls_data);
+
+		T *data = memnew(T(init_val));
+
+		storage.set_value(data);
+
+		return data;
+	}
+
+public:
+	ThreadLocal() :
+			ThreadLocal(T()) {}
+
+	ThreadLocal(const T &p_init_val) :
+			init_val(p_init_val) {
+		storage.alloc(&destr_callback);
+	}
+
+	ThreadLocal(const ThreadLocal &other) :
+			ThreadLocal(*other._tls_get_value()) {}
+
+	~ThreadLocal() {
+		storage.free();
+	}
+
+	_FORCE_INLINE_ T *operator&() const {
+		return _tls_get_value();
+	}
+
+	_FORCE_INLINE_ operator T &() const {
+		return *_tls_get_value();
+	}
+
+	_FORCE_INLINE_ ThreadLocal &operator=(const T &val) {
+		T *ptr = _tls_get_value();
+		*ptr = val;
+		return *this;
+	}
+};
+
+struct FlagScopeGuard {
+
+	FlagScopeGuard(bool &p_flag) :
+			flag(p_flag) {
+		flag = !flag;
+	}
+
+	~FlagScopeGuard() {
+		flag = !flag;
+	}
+
+private:
+	bool &flag;
+};
+
+#define _TLS_RECURSION_GUARD_V_(m_ret)                    \
+	static _THREAD_LOCAL_(bool) _recursion_flag_ = false; \
+	if (_recursion_flag_)                                 \
+		return m_ret;                                     \
+	FlagScopeGuard _recursion_guard_(_recursion_flag_);
+
+#define _TLS_RECURSION_GUARD_                             \
+	static _THREAD_LOCAL_(bool) _recursion_flag_ = false; \
+	if (_recursion_flag_)                                 \
+		return;                                           \
+	FlagScopeGuard _recursion_guard_(_recursion_flag_);
+
+#endif // THREAD_LOCAL_H


### PR DESCRIPTION
Recently, the function `mono_runtime_set_pending_exception` was exposed to embedders. This allows Godot, which does not allow exceptions, to pass exceptions from native to managed code instead of treating them as unhandled exceptions.

**Important:** This raises the minimum Mono version for compiling the module to 5.12.
