### PR TITLE
The inspector will show the custom resources added via plugin

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -433,26 +433,7 @@ Object *CreateDialog::instance_selected() {
 			custom = md;
 
 		if (custom != String()) {
-			if (EditorNode::get_editor_data().get_custom_types().has(custom)) {
-
-				for (int i = 0; i < EditorNode::get_editor_data().get_custom_types()[custom].size(); i++) {
-					if (EditorNode::get_editor_data().get_custom_types()[custom][i].name == selected->get_text(0)) {
-						Ref<Texture> icon = EditorNode::get_editor_data().get_custom_types()[custom][i].icon;
-						Ref<Script> script = EditorNode::get_editor_data().get_custom_types()[custom][i].script;
-						String name = selected->get_text(0);
-
-						Object *ob = ClassDB::instance(custom);
-						ERR_FAIL_COND_V(!ob, NULL);
-						if (ob->is_class("Node")) {
-							ob->call("set_name", name);
-						}
-						ob->set_script(script.get_ref_ptr());
-						if (icon.is_valid())
-							ob->set_meta("_editor_icon", icon);
-						return ob;
-					}
-				}
-			}
+			return EditorNode::get_editor_data().instance_custom_type(selected->get_text(0), custom);
 		} else {
 			return ClassDB::instance(selected->get_text(0));
 		}

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -452,6 +452,31 @@ void EditorData::add_custom_type(const String &p_type, const String &p_inherits,
 	custom_types[p_inherits].push_back(ct);
 }
 
+Object *EditorData::instance_custom_type(const String &p_type, const String &p_inherits) {
+
+	if (get_custom_types().has(p_inherits)) {
+
+		for (int i = 0; i < get_custom_types()[p_inherits].size(); i++) {
+			if (get_custom_types()[p_inherits][i].name == p_type) {
+				Ref<Texture> icon = get_custom_types()[p_inherits][i].icon;
+				Ref<Script> script = get_custom_types()[p_inherits][i].script;
+
+				Object *ob = ClassDB::instance(p_inherits);
+				ERR_FAIL_COND_V(!ob, NULL);
+				if (ob->is_class("Node")) {
+					ob->call("set_name", p_type);
+				}
+				ob->set_script(script.get_ref_ptr());
+				if (icon.is_valid())
+					ob->set_meta("_editor_icon", icon);
+				return ob;
+			}
+		}
+	}
+
+	return NULL;
+}
+
 void EditorData::remove_custom_type(const String &p_type) {
 
 	for (Map<String, Vector<CustomType> >::Element *E = custom_types.front(); E; E = E->next()) {

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -171,6 +171,7 @@ public:
 	void restore_editor_global_states();
 
 	void add_custom_type(const String &p_type, const String &p_inherits, const Ref<Script> &p_script, const Ref<Texture> &p_icon);
+	Object *instance_custom_type(const String &p_type, const String &p_inherits);
 	void remove_custom_type(const String &p_type);
 	const Map<String, Vector<CustomType> > &get_custom_types() const { return custom_types; }
 


### PR DESCRIPTION
Before this, the custom resources added via a plugin weren't being shown in the inspector dropdown with hint `PROPERTY_HINT_RESOURCE_TYPE`. This PR fixes this.

If you filter them with `hint_string` in the `_get_property_list()` function:
![https://i.imgur.com/lhMVQ2L.png](https://i.imgur.com/lhMVQ2L.png)

If you export a var with `export (Resource) var test`:
![https://i.imgur.com/4ROwnRL.png](https://i.imgur.com/4ROwnRL.png)

*Bugsquad edit:* fixes #17395.