### PR TITLE
Fix Line2D tile mode for non-square textures

### DIFF
--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -252,11 +252,14 @@ void Line2D::_draw() {
 	lb.sharp_limit = _sharp_limit;
 	lb.width = _width;
 
-	lb.build();
-
 	RID texture_rid;
-	if (_texture.is_valid())
+	if (_texture.is_valid()) {
 		texture_rid = (**_texture).get_rid();
+
+		lb.tile_aspect = _texture->get_size().aspect();
+	}
+
+	lb.build();
 
 	VS::get_singleton()->canvas_item_add_triangle_array(
 			get_canvas_item(),

--- a/scene/2d/line_builder.cpp
+++ b/scene/2d/line_builder.cpp
@@ -101,6 +101,7 @@ LineBuilder::LineBuilder() {
 	round_precision = 8;
 	begin_cap_mode = Line2D::LINE_CAP_NONE;
 	end_cap_mode = Line2D::LINE_CAP_NONE;
+	tile_aspect = 1.f;
 
 	_interpolate_color = false;
 	_last_index[0] = 0;
@@ -111,6 +112,7 @@ void LineBuilder::clear_output() {
 	vertices.clear();
 	colors.clear();
 	indices.clear();
+	uvs.clear();
 }
 
 void LineBuilder::build() {
@@ -120,6 +122,8 @@ void LineBuilder::build() {
 		clear_output();
 		return;
 	}
+
+	ERR_FAIL_COND(tile_aspect <= 0.f);
 
 	const float hw = width / 2.f;
 	const float hw_sq = hw * hw;
@@ -164,7 +168,7 @@ void LineBuilder::build() {
 		current_distance1 = current_distance0;
 	} else if (begin_cap_mode == Line2D::LINE_CAP_ROUND) {
 		if (texture_mode == Line2D::LINE_TEXTURE_TILE) {
-			uvx0 = 0.5f;
+			uvx0 = 0.5f / tile_aspect;
 		}
 		new_arc(pos0, pos_up0 - pos0, -Math_PI, color0, Rect2(0.f, 0.f, 1.f, 1.f));
 		total_distance += width;
@@ -286,8 +290,8 @@ void LineBuilder::build() {
 			color1 = gradient->get_color_at_offset(current_distance1 / total_distance);
 		}
 		if (texture_mode == Line2D::LINE_TEXTURE_TILE) {
-			uvx0 = current_distance0 / width;
-			uvx1 = current_distance1 / width;
+			uvx0 = current_distance0 / (width * tile_aspect);
+			uvx1 = current_distance1 / (width * tile_aspect);
 		}
 
 		strip_add_quad(pos_up1, pos_down1, color1, uvx1);
@@ -373,7 +377,7 @@ void LineBuilder::build() {
 		color1 = gradient->get_color(gradient->get_points_count() - 1);
 	}
 	if (texture_mode == Line2D::LINE_TEXTURE_TILE) {
-		uvx1 = current_distance1 / width;
+		uvx1 = current_distance1 / (width * tile_aspect);
 	}
 
 	strip_add_quad(pos_up1, pos_down1, color1, uvx1);

--- a/scene/2d/line_builder.h
+++ b/scene/2d/line_builder.h
@@ -50,6 +50,7 @@ public:
 	Line2D::LineTextureMode texture_mode;
 	float sharp_limit;
 	int round_precision;
+	float tile_aspect; // w/h
 	// TODO offset_joints option (offers alternative implementation of round joints)
 
 	// TODO Move in a struct and reference it


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/16950

Note: I also found https://github.com/godotengine/godot/issues/16961, which was in Godot for a while (at least for months). It's not due directly to Line2D's code, it's rather happening due to a corner case, which could be fixed in `Vector<T>` as discussed with @hpvb.
it causes the black glitches in the following screenshot in debug mode with MSVC. other than that, the feature works (but I would strongly recommend Vector to be fixed, there is an uncontrolled memory access going on):

![image](https://user-images.githubusercontent.com/1311555/36636843-8a5e2368-19ce-11e8-8070-efa6194ffc8a.png)


