### PR TITLE
Fix _signals variable should be outside TOOLS_ENABLED

### DIFF
--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -90,13 +90,14 @@ class CSharpScript : public Script {
 		Variant::Type type;
 	};
 
+	Map<StringName, Vector<Argument> > _signals;
+
 #ifdef TOOLS_ENABLED
 	List<PropertyInfo> exported_members_cache; // members_cache
 	Map<StringName, Variant> exported_members_defval_cache; // member_default_values_cache
 	Set<PlaceHolderScriptInstance *> placeholders;
 	bool source_changed_cache;
 	bool exports_invalidated;
-	Map<StringName, Vector<Argument> > _signals;
 	bool signals_invalidated;
 
 	void _update_exports_values(Map<StringName, Variant> &values, List<PropertyInfo> &propnames);


### PR DESCRIPTION
Variable is used outside the macro in csharp_script.cpp
thereby conflicting with tools=no builds.