### PR TITLE
Extended shader functions

### DIFF
--- a/drivers/gles3/shader_compiler_gles3.h
+++ b/drivers/gles3/shader_compiler_gles3.h
@@ -90,8 +90,10 @@ private:
 	Set<StringName> used_flag_pointers;
 	Set<StringName> used_rmode_defines;
 	Set<StringName> internal_functions;
+	Set<StringName> internal_functions_ex;
 
 	DefaultIdentifierActions actions[VS::SHADER_MAX];
+	bool used_funcs_ex;
 
 public:
 	Error compile(VS::ShaderMode p_mode, const String &p_code, IdentifierActions *p_actions, const String &p_path, GeneratedCode &r_gen_code);

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -1,5 +1,40 @@
 [vertex]
 
+#ifdef GODOT_ENABLE_EXTRA_BUILTIN
+
+float saturate(in float value) {
+	return clamp(value, 0.0, 1.0);
+}
+
+vec2 saturate(in vec2 value) {
+	return clamp(value, vec2(0.0, 0.0), vec2(1.0, 1.0));
+}
+
+vec3 saturate(in vec3 value) {
+	return clamp(value, vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0));
+}
+
+vec4 saturate(in vec4 value) {
+	return clamp(value, vec4(0.0, 0.0, 0.0, 0.0), vec4(1.0, 1.0, 1.0, 1.0));
+}
+
+vec3 rgb2hsv(in vec3 c) {
+	vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+    vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
+    vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
+
+    float d = q.x - min(q.w, q.y);
+    float e = 1.0e-10;
+    return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+}
+
+vec3 hsv2rgb(in vec3 c) {
+	vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+	vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+	return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
+}
+
+#endif
 
 layout(location=0) in highp vec2 vertex;
 layout(location=3) in vec4 color_attrib;
@@ -201,7 +236,41 @@ VERTEX_SHADER_CODE
 
 [fragment]
 
+#ifdef GODOT_ENABLE_EXTRA_BUILTIN
 
+float saturate(in float value) {
+	return clamp(value, 0.0, 1.0);
+}
+
+vec2 saturate(in vec2 value) {
+	return clamp(value, vec2(0.0, 0.0), vec2(1.0, 1.0));
+}
+
+vec3 saturate(in vec3 value) {
+	return clamp(value, vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0));
+}
+
+vec4 saturate(in vec4 value) {
+	return clamp(value, vec4(0.0, 0.0, 0.0, 0.0), vec4(1.0, 1.0, 1.0, 1.0));
+}
+
+vec3 rgb2hsv(in vec3 c) {
+	vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+    vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
+    vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
+
+    float d = q.x - min(q.w, q.y);
+    float e = 1.0e-10;
+    return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+}
+
+vec3 hsv2rgb(in vec3 c) {
+	vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+	vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+	return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
+}
+
+#endif
 
 uniform mediump sampler2D color_texture; // texunit:0
 uniform highp vec2 color_texpixel_size;

--- a/drivers/gles3/shaders/particles.glsl
+++ b/drivers/gles3/shaders/particles.glsl
@@ -1,6 +1,40 @@
 [vertex]
 
+#ifdef GODOT_ENABLE_EXTRA_BUILTIN
 
+float saturate(in float value) {
+	return clamp(value, 0.0, 1.0);
+}
+
+vec2 saturate(in vec2 value) {
+	return clamp(value, vec2(0.0, 0.0), vec2(1.0, 1.0));
+}
+
+vec3 saturate(in vec3 value) {
+	return clamp(value, vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0));
+}
+
+vec4 saturate(in vec4 value) {
+	return clamp(value, vec4(0.0, 0.0, 0.0, 0.0), vec4(1.0, 1.0, 1.0, 1.0));
+}
+
+vec3 rgb2hsv(in vec3 c) {
+	vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+    vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
+    vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
+
+    float d = q.x - min(q.w, q.y);
+    float e = 1.0e-10;
+    return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+}
+
+vec3 hsv2rgb(in vec3 c) {
+	vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+	vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+	return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
+}
+
+#endif
 
 layout(location=0) in highp vec4 color;
 layout(location=1) in highp vec4 velocity_active;

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -2,6 +2,42 @@
 
 #define M_PI 3.14159265359
 
+#ifdef GODOT_ENABLE_EXTRA_BUILTIN
+
+float saturate(in float value) {
+	return clamp(value, 0.0, 1.0);
+}
+
+vec2 saturate(in vec2 value) {
+	return clamp(value, vec2(0.0, 0.0), vec2(1.0, 1.0));
+}
+
+vec3 saturate(in vec3 value) {
+	return clamp(value, vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0));
+}
+
+vec4 saturate(in vec4 value) {
+	return clamp(value, vec4(0.0, 0.0, 0.0, 0.0), vec4(1.0, 1.0, 1.0, 1.0));
+}
+
+vec3 rgb2hsv(in vec3 c) {
+	vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+    vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
+    vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
+
+    float d = q.x - min(q.w, q.y);
+    float e = 1.0e-10;
+    return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+}
+
+vec3 hsv2rgb(in vec3 c) {
+	vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+	vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+	return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
+}
+
+#endif
+
 /*
 from VisualServer:
 
@@ -532,6 +568,42 @@ VERTEX_SHADER_CODE
 uniform highp mat4 world_transform;
 
 #define M_PI 3.14159265359
+
+#ifdef GODOT_ENABLE_EXTRA_BUILTIN
+
+float saturate(in float value) {
+	return clamp(value, 0.0, 1.0);
+}
+
+vec2 saturate(in vec2 value) {
+	return clamp(value, vec2(0.0, 0.0), vec2(1.0, 1.0));
+}
+
+vec3 saturate(in vec3 value) {
+	return clamp(value, vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0));
+}
+
+vec4 saturate(in vec4 value) {
+	return clamp(value, vec4(0.0, 0.0, 0.0, 0.0), vec4(1.0, 1.0, 1.0, 1.0));
+}
+
+vec3 rgb2hsv(in vec3 c) {
+	vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+    vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
+    vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
+
+    float d = q.x - min(q.w, q.y);
+    float e = 1.0e-10;
+    return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+}
+
+vec3 hsv2rgb(in vec3 c) {
+	vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+	vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+	return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
+}
+
+#endif
 
 /* Varyings */
 

--- a/servers/visual/shader_language.h
+++ b/servers/visual/shader_language.h
@@ -536,7 +536,7 @@ public:
 	static bool is_sampler_type(DataType p_type);
 
 	static void get_keyword_list(List<String> *r_keywords);
-	static void get_builtin_funcs(List<String> *r_keywords);
+	static void get_builtin_funcs(List<String> *r_keywords, bool p_extended);
 
 	struct BuiltInInfo {
 		DataType type;
@@ -637,6 +637,7 @@ private:
 	bool _get_completable_identifier(BlockNode *p_block, CompletionType p_type, StringName &identifier);
 
 	static const BuiltinFuncDef builtin_func_defs[];
+	static const BuiltinFuncDef builtin_func_ex_defs[];
 	bool _validate_function_call(BlockNode *p_block, OperatorNode *p_func, DataType *r_ret_type);
 
 	bool _parse_function_arguments(BlockNode *p_block, const Map<StringName, BuiltInInfo> &p_builtin_types, OperatorNode *p_func, int *r_complete_arg = NULL);

--- a/servers/visual/shader_types.cpp
+++ b/servers/visual/shader_types.cpp
@@ -140,6 +140,8 @@ ShaderTypes::ShaderTypes() {
 
 	shader_modes[VS::SHADER_SPATIAL].functions["light"].can_discard = true;
 
+	shader_modes[VS::SHADER_SPATIAL].modes.insert("ext_funcs");
+
 	shader_modes[VS::SHADER_SPATIAL].modes.insert("blend_mix");
 	shader_modes[VS::SHADER_SPATIAL].modes.insert("blend_add");
 	shader_modes[VS::SHADER_SPATIAL].modes.insert("blend_sub");
@@ -225,6 +227,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["light"].built_ins["TIME"] = constt(ShaderLanguage::TYPE_FLOAT);
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["light"].can_discard = true;
 
+	shader_modes[VS::SHADER_CANVAS_ITEM].modes.insert("ext_funcs");
 	shader_modes[VS::SHADER_CANVAS_ITEM].modes.insert("skip_vertex_transform");
 
 	shader_modes[VS::SHADER_CANVAS_ITEM].modes.insert("blend_mix");
@@ -254,6 +257,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[VS::SHADER_PARTICLES].functions["vertex"].built_ins["RANDOM_SEED"] = constt(ShaderLanguage::TYPE_UINT);
 	shader_modes[VS::SHADER_PARTICLES].functions["vertex"].can_discard = false;
 
+	shader_modes[VS::SHADER_PARTICLES].modes.insert("ext_funcs");
 	shader_modes[VS::SHADER_PARTICLES].modes.insert("billboard");
 	shader_modes[VS::SHADER_PARTICLES].modes.insert("disable_force");
 	shader_modes[VS::SHADER_PARTICLES].modes.insert("disable_velocity");


### PR DESCRIPTION
I know UE4 have a lot of complex functions included from box for materials. So, I think its not bad idea for Godot to add a possibility to extend shader language with useful complex operations. These functions injects into shader code only when new **render_type ext_funcs** flag used and be available for all shader types, both in fragment and vertex functions. It does not break existed code and dont expand the user shaders size when it does not needed. I checked all carefully, it does not break backward compatibility and these functions added to intellisense list only when "ext_funcs" included. 

For now I've added 3 functions
**saturate** - shortcut for clamp(value, 0.0, 1.0), can be used on vectors
**hsv2rgb** - converts HSV color to RGB, accept and return vec3
**rgb2hsv** - converts RGB color to HSV, accept and return vec3

![image](https://user-images.githubusercontent.com/3036176/36645291-79fd77d6-1a77-11e8-9e88-2badd5c61b5b.png)
