### PR TITLE
Fixed bullet kinematic char sliding

### DIFF
--- a/modules/bullet/godot_result_callbacks.cpp
+++ b/modules/bullet/godot_result_callbacks.cpp
@@ -257,18 +257,15 @@ btScalar GodotRestInfoContactResultCallback::addSingleResult(btManifoldPoint &cp
 
 void GodotDeepPenetrationContactResultCallback::addContactPoint(const btVector3 &normalOnBInWorld, const btVector3 &pointInWorldOnB, btScalar depth) {
 
-	if (depth < 0) {
-		// Has penetration
-		if (m_most_penetrated_distance > depth) {
+	// Has penetration
+	if (m_penetration_distance < ABS(depth)) {
 
-			bool isSwapped = m_manifoldPtr->getBody0() != m_body0Wrap->getCollisionObject();
+		bool isSwapped = m_manifoldPtr->getBody0() != m_body0Wrap->getCollisionObject();
 
-			m_most_penetrated_distance = depth;
-			m_pointCollisionObject = (isSwapped ? m_body0Wrap : m_body1Wrap)->getCollisionObject();
-			m_other_compound_shape_index = isSwapped ? m_index1 : m_index0;
-			m_pointNormalWorld = isSwapped ? normalOnBInWorld * -1 : normalOnBInWorld;
-			m_pointWorld = isSwapped ? (pointInWorldOnB + normalOnBInWorld * depth) : pointInWorldOnB;
-			m_penetration_distance = depth;
-		}
+		m_penetration_distance = depth;
+		m_pointCollisionObject = (isSwapped ? m_body0Wrap : m_body1Wrap)->getCollisionObject();
+		m_other_compound_shape_index = isSwapped ? m_index1 : m_index0;
+		m_pointNormalWorld = isSwapped ? normalOnBInWorld * -1 : normalOnBInWorld;
+		m_pointWorld = isSwapped ? (pointInWorldOnB + normalOnBInWorld * depth) : pointInWorldOnB;
 	}
 }

--- a/modules/bullet/godot_result_callbacks.h
+++ b/modules/bullet/godot_result_callbacks.h
@@ -187,18 +187,15 @@ struct GodotDeepPenetrationContactResultCallback : public btManifoldResult {
 	int m_other_compound_shape_index;
 	const btCollisionObject *m_pointCollisionObject;
 
-	btScalar m_most_penetrated_distance;
-
 	GodotDeepPenetrationContactResultCallback(const btCollisionObjectWrapper *body0Wrap, const btCollisionObjectWrapper *body1Wrap) :
 			btManifoldResult(body0Wrap, body1Wrap),
 			m_pointCollisionObject(NULL),
 			m_penetration_distance(0),
-			m_other_compound_shape_index(0),
-			m_most_penetrated_distance(1e20) {}
+			m_other_compound_shape_index(0) {}
 
 	void reset() {
 		m_pointCollisionObject = NULL;
-		m_most_penetrated_distance = 1e20;
+		m_penetration_distance = 0;
 	}
 
 	bool hasHit() {


### PR DESCRIPTION
Fixed sliding of kinematic character in bullet.

The problem was caused by threshold that Bullet use by default and also the reported penetration in particular cases are positive but valid.