### PR TITLE
Fix #17019 : overrides with unknown base setting

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -794,12 +794,11 @@ Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_cust
 Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default) {
 
 	Variant ret;
-	if (ProjectSettings::get_singleton()->has_setting(p_var)) {
-		ret = ProjectSettings::get_singleton()->get(p_var);
-	} else {
+	if (!ProjectSettings::get_singleton()->has_setting(p_var)) {
 		ProjectSettings::get_singleton()->set(p_var, p_default);
-		ret = p_default;
 	}
+	ret = ProjectSettings::get_singleton()->get(p_var);
+
 	ProjectSettings::get_singleton()->set_initial_value(p_var, p_default);
 	ProjectSettings::get_singleton()->set_builtin_order(p_var);
 	return ret;


### PR DESCRIPTION
If at the time of the _GLOBAL_DEF call a setting itself was unknown,
the function would always return the supplied default value instead of
checking for overrides. This commit changes that, lookup now always
happens which correctly takes overrides into account.

It would be more efficient to check whether overrides exist; _GLOBAL_DEF does
not have the required information and it would feel wrong to me to just
make a has_override function available.