### PR TITLE
Editor:   update favorite dirs when dir got deleted

### DIFF
--- a/editor/dependency_editor.h
+++ b/editor/dependency_editor.h
@@ -102,7 +102,8 @@ class DependencyRemoveDialog : public ConfirmationDialog {
 	Tree *owners;
 
 	Map<String, String> all_remove_files;
-	Vector<String> to_delete;
+	Vector<String> dirs_to_delete;
+	Vector<String> files_to_delete;
 
 	struct RemovedDependency {
 		String file;

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -1027,6 +1027,7 @@ void EditorFileDialog::invalidate() {
 
 	if (is_visible_in_tree()) {
 		update_file_list();
+		_update_favorites();
 		invalidated = false;
 	} else {
 		invalidated = true;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/16921 

adds some procedure to update favorite dirs list after a DependencyRemoveDialog being confirmed. 