### PR TITLE
Fix GridMap Bug#16524 -unable to delete MeshTile on MacBook using TouchPad

### DIFF
--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -638,6 +638,7 @@ bool GridMapEditor::forward_spatial_input_event(Camera *p_camera, const Ref<Inpu
 		return do_input_action(p_camera, mm->get_position(), false);
 	}
 
+	/* REMOVED - Code breaks ability to delete a MeshTile on a Macbook Touchpad (Bug #16524)
 	Ref<InputEventPanGesture> pan_gesture = p_event;
 	if (pan_gesture.is_valid()) {
 
@@ -646,7 +647,7 @@ bool GridMapEditor::forward_spatial_input_event(Camera *p_camera, const Ref<Inpu
 			floor->set_value(floor->get_value() + SGN(delta));
 			return true;
 		}
-	}
+	} */
 
 	return false;
 }


### PR DESCRIPTION
Fixes #16524 