### PR TITLE
[mono] fix build error when compiling with mono, tools=no, target=debug

### DIFF
--- a/modules/mono/mono_gd/gd_mono_utils.cpp
+++ b/modules/mono/mono_gd/gd_mono_utils.cpp
@@ -422,7 +422,7 @@ void print_unhandled_exception(MonoObject *p_exc, bool p_recursion_caution) {
 
 	ScriptLanguage::StackInfo separator;
 	separator.file = "";
-	separator.func = "--- " + TTR("End of inner exception stack trace") + " ---";
+	separator.func = "--- " + RTR("End of inner exception stack trace") + " ---";
 	separator.line = 0;
 
 	Vector<ScriptLanguage::StackInfo> si;


### PR DESCRIPTION
This build error was introduced by #16981.  
I'm deeply sorry, I have somewhat of a hard time getting used to the build options and their impact on the code :cold_sweat: 