### PR TITLE
Made Node.print_tree() print prettily

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -453,7 +453,30 @@
 			<return type="void">
 			</return>
 			<description>
-				Prints the scene hierarchy of this node and all it's children to stdout. Used mainly for debugging purposes.
+				Prints the tree to stdout. Used mainly for debugging purposes. This version displays the path relative to the current node, and is good for copy/pasting into the [method get_node] function. Example output:
+				[codeblock]
+				TheGame
+				TheGame/Menu
+				TheGame/Menu/Label
+				TheGame/Menu/Camera2D
+				TheGame/SplashScreen
+				TheGame/SplashScreen/Camera2D
+				[/codeblock]
+			</description>
+		</method>
+		<method name="print_tree_pretty">
+			<return type="void">
+			</return>
+			<description>
+				Similar to [method print_tree], this prints the tree to stdout. This version displays a more graphical representation similar to what is displayed in the scene inspector. It is useful for inspecting larger trees. Example output:
+				[codeblock]
+				 ┖╴TheGame
+				    ┠╴Menu
+				    ┃  ┠╴Label
+				    ┃  ┖╴Camera2D
+				    ┖-SplashScreen
+				       ┖╴Camera2D
+				[/codeblock]
 			</description>
 		</method>
 		<method name="propagate_call">

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1708,16 +1708,29 @@ bool Node::has_persistent_groups() const {
 
 	return false;
 }
-void Node::_print_tree(const Node *p_node) {
+void Node::_print_tree_pretty(const String prefix, const bool last) {
 
-	print_line(String(p_node->get_path_to(this)));
-	for (int i = 0; i < data.children.size(); i++)
-		data.children[i]->_print_tree(p_node);
+	String new_prefix = last ? String::utf8(" ┖╴") : String::utf8(" ┠╴");
+	print_line(prefix + new_prefix + String(get_name()));
+	for (int i = 0; i < data.children.size(); i++) {
+		new_prefix = last ? String::utf8("   ") : String::utf8(" ┃ ");
+		data.children[i]->_print_tree_pretty(prefix + new_prefix, i == data.children.size() - 1);
+	}
+}
+
+void Node::print_tree_pretty() {
+	_print_tree_pretty("", true);
 }
 
 void Node::print_tree() {
 
 	_print_tree(this);
+}
+
+void Node::_print_tree(const Node *p_node) {
+	print_line(String(p_node->get_path_to(this)));
+	for (int i = 0; i < data.children.size(); i++)
+		data.children[i]->_print_tree(p_node);
 }
 
 void Node::_propagate_reverse_notification(int p_notification) {
@@ -2668,6 +2681,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_and_skip"), &Node::remove_and_skip);
 	ClassDB::bind_method(D_METHOD("get_index"), &Node::get_index);
 	ClassDB::bind_method(D_METHOD("print_tree"), &Node::print_tree);
+	ClassDB::bind_method(D_METHOD("print_tree_pretty"), &Node::print_tree_pretty);
 	ClassDB::bind_method(D_METHOD("set_filename", "filename"), &Node::set_filename);
 	ClassDB::bind_method(D_METHOD("get_filename"), &Node::get_filename);
 	ClassDB::bind_method(D_METHOD("propagate_notification", "what"), &Node::propagate_notification);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -153,6 +153,7 @@ private:
 
 	Ref<MultiplayerAPI> multiplayer_api;
 
+	void _print_tree_pretty(const String prefix, const bool last);
 	void _print_tree(const Node *p_node);
 
 	Node *_get_node(const NodePath &p_path) const;
@@ -289,6 +290,7 @@ public:
 	int get_index() const;
 
 	void print_tree();
+	void print_tree_pretty();
 
 	void set_filename(const String &p_filename);
 	String get_filename() const;


### PR DESCRIPTION
I found the output of print_tree() to be slightly obstuse to read for more than a few nodes. So I tweaked print_tree() to give a nicer output. This is extremely useful where objects are loaded dynamically and you need to see the whole project structure.

Example tree:
```
 '-root
    |-game
    |  |-LevelManager
    |  '-CharacterManager
    |     '-Player
    |        |-PlayerPhysics
    |        |  |-HeadCollision
    |        |  |-TorsoCollision
    |        |  '-PlayerGeometry
    |        |     |-Cylinder
    |        |     |-Cylinder_001
    |        |     |-Cylinder_002
    |        |     |-AnimationPlayer
    |        |     '-CameraTilt
    |        |        |-SpotLight
    |        |        '-Camera
    |        '-PreviewLight
    '-HUD
       |-Menu
       |  |-Label
       |  '-Camera2D
       '-SplashScreen
          '-Camera2D
```

I did want to use the box drawing characters, but for some reason they weren't printing.

Reasons why you may not want to include this pull request:
 - You can no longer copy/paste from print_tree() to the get_node() function.