### PR TITLE
Add an hinting mode setting to DynamicFonts

### DIFF
--- a/doc/classes/DynamicFontData.xml
+++ b/doc/classes/DynamicFontData.xml
@@ -16,7 +16,19 @@
 		<member name="font_path" type="String" setter="set_font_path" getter="get_font_path">
 			The path to the vector font file.
 		</member>
+		<member name="hinting" type="int" setter="set_hinting" getter="get_hinting" enum="DynamicFontData.Hinting">
+			The font hinting mode used by FreeType.
+		</member>
 	</members>
 	<constants>
+		<constant name="HINTING_NONE" value="0" enum="Hinting">
+			Disable font hinting (smoother but less crisp).
+		</constant>
+		<constant name="HINTING_LIGHT" value="1" enum="Hinting">
+			Use the light font hinting mode.
+		</constant>
+		<constant name="HINTING_NORMAL" value="2" enum="Hinting">
+			Use the default font hinting mode (crisper but less smooth).
+		</constant>
 	</constants>
 </class>

--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -103,9 +103,11 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	/* Custom font */
 
 	String custom_font = EditorSettings::get_singleton()->get("interface/editor/main_font");
+	DynamicFontData::Hinting font_hinting = (DynamicFontData::Hinting)(int)EditorSettings::get_singleton()->get("interface/editor/main_font_hinting");
 	Ref<DynamicFontData> CustomFont;
 	if (custom_font.length() > 0) {
 		CustomFont.instance();
+		CustomFont->set_hinting(font_hinting);
 		CustomFont->set_font_path(custom_font);
 		CustomFont->set_force_autohinter(true); //just looks better..i think?
 	}
@@ -113,9 +115,11 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	/* Custom source code font */
 
 	String custom_font_source = EditorSettings::get_singleton()->get("interface/editor/code_font");
+	DynamicFontData::Hinting font_source_hinting = (DynamicFontData::Hinting)(int)EditorSettings::get_singleton()->get("interface/editor/code_font_hinting");
 	Ref<DynamicFontData> CustomFontSource;
 	if (custom_font_source.length() > 0) {
 		CustomFontSource.instance();
+		CustomFontSource->set_hinting(font_source_hinting);
 		CustomFontSource->set_font_path(custom_font_source);
 	}
 
@@ -123,38 +127,45 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 
 	Ref<DynamicFontData> DefaultFont;
 	DefaultFont.instance();
+	DefaultFont->set_hinting(font_hinting);
 	DefaultFont->set_font_ptr(_font_NotoSansUI_Regular, _font_NotoSansUI_Regular_size);
 	DefaultFont->set_force_autohinter(true); //just looks better..i think?
 
 	Ref<DynamicFontData> FontFallback;
 	FontFallback.instance();
+	FontFallback->set_hinting(font_hinting);
 	FontFallback->set_font_ptr(_font_DroidSansFallback, _font_DroidSansFallback_size);
 	FontFallback->set_force_autohinter(true); //just looks better..i think?
 
 	Ref<DynamicFontData> FontJapanese;
 	FontJapanese.instance();
+	FontJapanese->set_hinting(font_hinting);
 	FontJapanese->set_font_ptr(_font_DroidSansJapanese, _font_DroidSansJapanese_size);
 	FontJapanese->set_force_autohinter(true); //just looks better..i think?
 
 	Ref<DynamicFontData> FontArabic;
 	FontArabic.instance();
+	FontArabic->set_hinting(font_hinting);
 	FontArabic->set_font_ptr(_font_NotoNaskhArabicUI_Regular, _font_NotoNaskhArabicUI_Regular_size);
 	FontArabic->set_force_autohinter(true); //just looks better..i think?
 
 	Ref<DynamicFontData> FontHebrew;
 	FontHebrew.instance();
+	FontHebrew->set_hinting(font_hinting);
 	FontHebrew->set_font_ptr(_font_NotoSansHebrew_Regular, _font_NotoSansHebrew_Regular_size);
 	FontHebrew->set_force_autohinter(true); //just looks better..i think?
 
 	Ref<DynamicFontData> FontThai;
 	FontThai.instance();
+	FontThai->set_hinting(font_hinting);
 	FontThai->set_font_ptr(_font_NotoSansThaiUI_Regular, _font_NotoSansThaiUI_Regular_size);
 	FontThai->set_force_autohinter(true); //just looks better..i think?
 
-	/* Source Code Pro */
+	/* Hack */
 
 	Ref<DynamicFontData> dfmono;
 	dfmono.instance();
+	dfmono->set_hinting(font_source_hinting);
 	dfmono->set_font_ptr(_font_Hack_Regular, _font_Hack_Regular_size);
 	//dfd->set_force_autohinter(true); //just looks better..i think?
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -290,6 +290,10 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["interface/editor/main_font_size"] = PropertyInfo(Variant::INT, "interface/editor/main_font_size", PROPERTY_HINT_RANGE, "10,40,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/code_font_size", 14);
 	hints["interface/editor/code_font_size"] = PropertyInfo(Variant::INT, "interface/editor/code_font_size", PROPERTY_HINT_RANGE, "8,96,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
+	_initial_set("interface/editor/main_font_hinting", 2);
+	hints["interface/editor/main_font_hinting"] = PropertyInfo(Variant::INT, "interface/editor/main_font_hinting", PROPERTY_HINT_ENUM, "None,Light,Normal", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
+	_initial_set("interface/editor/code_font_hinting", 2);
+	hints["interface/editor/code_font_hinting"] = PropertyInfo(Variant::INT, "interface/editor/code_font_hinting", PROPERTY_HINT_ENUM, "None,Light,Normal", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/main_font", "");
 	hints["interface/editor/main_font"] = PropertyInfo(Variant::STRING, "interface/editor/main_font", PROPERTY_HINT_GLOBAL_FILE, "*.ttf,*.otf", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/code_font", "");

--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -64,10 +64,20 @@ public:
 		}
 	};
 
+	enum Hinting {
+		HINTING_NONE,
+		HINTING_LIGHT,
+		HINTING_NORMAL
+	};
+
+	Hinting get_hinting() const;
+	void set_hinting(Hinting p_hinting);
+
 private:
 	const uint8_t *font_mem;
 	int font_mem_size;
 	bool force_autohinter;
+	Hinting hinting;
 
 	String font_path;
 	Map<CacheID, DynamicFontAtSize *> size_cache;
@@ -90,6 +100,8 @@ public:
 	DynamicFontData();
 	~DynamicFontData();
 };
+
+VARIANT_ENUM_CAST(DynamicFontData::Hinting);
 
 class DynamicFontAtSize : public Reference {
 


### PR DESCRIPTION
- Editor font hinting can now be tweaked in the Editor Settings.
- DynamicFonts used in projects now have tweakable hinting settings in their DynamicFontData child. Changes will be visible upon reloading the scene in the editor.

### Preview

**Normal font hinting** (the default setting, which was the former hardcoded setting):

![editor_font_hinting_normal](https://user-images.githubusercontent.com/180032/36760910-002d5046-1c1d-11e8-9443-ae91b18152cf.png)

**No font hinting** (smoother but less crisp):

![editor_font_hinting_none](https://user-images.githubusercontent.com/180032/36760909-ffe1920a-1c1c-11e8-934c-6b7c4bdd42d6.png)

**Light font hinting** (compromise between **Normal** and **None** modes):

![editor_font_hinting_light](https://user-images.githubusercontent.com/180032/36761010-6dfcd8e4-1c1d-11e8-92e0-3c955ab6d3c4.png)


