### PR TITLE
More threading in AssetLib

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -514,6 +514,7 @@ EditorAssetLibraryItemDownload::EditorAssetLibraryItemDownload() {
 	download = memnew(HTTPRequest);
 	add_child(download);
 	download->connect("request_completed", this, "_http_download_completed");
+	download->set_use_threads(EDITOR_DEF("asset_library/use_threads", true));
 
 	download_error = memnew(AcceptDialog);
 	add_child(download_error);
@@ -832,6 +833,7 @@ void EditorAssetLibrary::_request_image(ObjectID p_for, String p_image_url, Imag
 	iq.image_index = p_image_index;
 	iq.image_type = p_type;
 	iq.request = memnew(HTTPRequest);
+	iq.request->set_use_threads(EDITOR_DEF("asset_library/use_threads", true));
 
 	iq.target = p_for;
 	iq.queue_id = ++last_queue_id;


### PR DESCRIPTION
AssetLib now uses thread as requested to download previews and ItemDownload