### PR TITLE
Fix mbedTLS and Websocket on FreeBSD

### DIFF
--- a/modules/mbedtls/SCsub
+++ b/modules/mbedtls/SCsub
@@ -85,7 +85,7 @@ if env['builtin_mbedtls']:
     thirdparty_dir = "#thirdparty/mbedtls/library/"
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
     env_mbed_tls.add_source_files(env.modules_sources, thirdparty_sources)
-    env_mbed_tls.Append(CPPPATH=["#thirdparty/mbedtls/include/"])
+    env_mbed_tls.Prepend(CPPPATH=["#thirdparty/mbedtls/include/"])
 
 # Module sources
 env_mbed_tls.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/websocket/SCsub
+++ b/modules/websocket/SCsub
@@ -69,11 +69,11 @@ else:
     env_lws.Append(CPPPATH=[thirdparty_dir])
 
     wrapper_includes = ["#thirdparty/lws/mbedtls_wrapper/include/" + inc for inc in ["internal", "openssl", "platform", ""]]
-    env_lws.Append(CPPPATH=wrapper_includes)
+    env_lws.Prepend(CPPPATH=wrapper_includes)
 
     if env['builtin_mbedtls']:
         mbedtls_includes = "#thirdparty/mbedtls/include"
-        env_lws.Append(CPPPATH=[mbedtls_includes])
+        env_lws.Prepend(CPPPATH=[mbedtls_includes])
 
     if env_lws["platform"] == "windows" or env_lws["platform"] == "uwp":
         env_lws.Append(CPPPATH=[thirdparty_dir + helper_dir])

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -235,7 +235,7 @@ File extracted from upstream source:
   - From `server/` exclude `access-log.c`, `cgi.c`, `daemonize.c`, `lws-spa.c`, 
 `peer-limits.c`, `rewrite.c`
 - Also copy `win32helpers/` from `win32port/`
-- `mbedtls_wrapper/include/platform/ssl_port.h` has a small change to check for OSX (missing `malloc.h`).
+- `mbedtls_wrapper/include/platform/ssl_port.h` has a small change to check for OSX and FreeBSD (missing `malloc.h`).
   The bug is fixed in upstream master via `LWS_HAVE_MALLOC_H`, but not in the 2.4.1 branch (as the file structure has changed).
 
 Important: `lws_config.h` and `lws_config_private.h` contains custom 

--- a/thirdparty/lws/mbedtls_wrapper/include/platform/ssl_port.h
+++ b/thirdparty/lws/mbedtls_wrapper/include/platform/ssl_port.h
@@ -25,7 +25,7 @@
 */
 #include "string.h"
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__FreeBSD__)
 #include <stdlib.h>
 #else
 #include "malloc.h"


### PR DESCRIPTION
Fix `libwebsockets` compilation on FreeBSD, same as OSX (this error is actually fixed upstream, waiting for a new release)


Use Prepend instead of Append for mbedTLS includes (fixes build on FreeBSD when system-wide mbedTLS and/or OpenSSL is installed)
Closes #16991 