### PR TITLE
Allow degenerate triangles in polygon triangulation when necessary.

### DIFF
--- a/core/math/triangulate.h
+++ b/core/math/triangulate.h
@@ -51,10 +51,11 @@ public:
 	static bool is_inside_triangle(real_t Ax, real_t Ay,
 			real_t Bx, real_t By,
 			real_t Cx, real_t Cy,
-			real_t Px, real_t Py);
+			real_t Px, real_t Py,
+			bool include_edges);
 
 private:
-	static bool snip(const Vector<Vector2> &p_contour, int u, int v, int w, int n, const Vector<int> &V);
+	static bool snip(const Vector<Vector2> &p_contour, int u, int v, int w, int n, const Vector<int> &V, bool relaxed);
 };
 
 #endif


### PR DESCRIPTION
Fixes #17102.

This modifies the ear-clipping implementation so that it first tries to avoid completely flat triangles, but falls back to allowing them as a last resort when triangulation would otherwise fail.
I explained this with a few more details on the issue.

This adds a bit of unfortunate branchiness that hurts code aesthetics more than actual performance, because these branches are very predictable and ear clipping is already pretty inefficient anyway.

If we don't care about degenerate triangles at all, we can replace this change by simply turning the first check in `Triangulate::snip` into:

```C++
	if (-CMP_EPSILON > (((Bx - Ax) * (Cy - Ay)) - ((By - Ay) * (Cx - Ax)))) return false;
```

Using a negative epsilon instead of zero conservatively avoids potential floating point precision issues.