### PR TITLE
Fix polyline rendering when width <= 1.

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -566,7 +566,7 @@ void RasterizerCanvasGLES3::_canvas_item_render_commands(Item *p_item, Item *cur
 
 					} else {
 
-						_draw_generic(GL_LINES, pline->lines.size(), pline->lines.ptr(), NULL, pline->line_colors.ptr(), pline->line_colors.size() == 1);
+						_draw_generic(GL_LINE_STRIP, pline->lines.size(), pline->lines.ptr(), NULL, pline->line_colors.ptr(), pline->line_colors.size() == 1);
 					}
 
 #ifdef GLES_OVER_GL


### PR DESCRIPTION
GL_LINES connects pairs of points, for example `A----B    C----D`, but we want a continuous polyline `A---B---C---D`, which is achieved with GL_LINE_STRIP.

I don't know what multiline is. Depending on its meaning, the same change might need to be applied there as well.

Fixes #17050.