### PR TITLE
[Build] Fix WebM (libvpx) SIMD optimizations on macOS.

### DIFF
--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -59,7 +59,7 @@ def configure(env):
 
     # Mac OS X no longer runs on 32-bit since 10.7 which is unsupported since 2014
     # As such, we only support 64-bit
-    env["bits"] = 64
+    env["bits"] = "64"
 
     ## Compiler configuration
 


### PR DESCRIPTION
Fix regression form f04958c, 42c5af5 and 3e6f2b7.

`env["bits"]` should be string to enable optimization - [modules/webm/libvpx/SCsub#L271](https://github.com/godotengine/godot/blob/master/modules/webm/libvpx/SCsub#L271).