### PR TITLE
Fix server build on FreeBSD

### DIFF
--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import sys
 
 
@@ -132,7 +133,12 @@ def configure(env):
     env.Append(CPPPATH=['#platform/server'])
     env.Append(CPPFLAGS=['-DSERVER_ENABLED', '-DUNIX_ENABLED'])
     env.Append(LIBS=['pthread'])
-    env.Append(LIBS=['dl'])
+
+    if (platform.system() == "Linux"):
+        env.Append(LIBS=['dl'])
+
+    if (platform.system().find("BSD") >= 0):
+        env.Append(LIBS=['execinfo'])
 
     # Link those statically for portability
     if env['use_static_cpp']:

--- a/platform/server/platform_config.h
+++ b/platform/server/platform_config.h
@@ -28,4 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifdef __linux__
 #include <alloca.h>
+#endif
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
+#include <stdlib.h>
+#define PTHREAD_BSD_SET_NAME
+#endif

--- a/platform/x11/crash_handler_x11.cpp
+++ b/platform/x11/crash_handler_x11.cpp
@@ -32,8 +32,9 @@
 #define CRASH_HANDLER_ENABLED 1
 #endif
 
+#include "crash_handler_x11.h"
 #include "main/main.h"
-#include "os_x11.h"
+#include "os/os.h"
 #include "project_settings.h"
 
 #ifdef CRASH_HANDLER_ENABLED


### PR DESCRIPTION
Took `platform_config.h` from `x11`, include proper library on BSD, let `crash_handler_x11.cpp` include `os/os.h` instead of `os_x11.h` (as the handler is currently shared with the server platform, and `os_x11.h` requires xcursor and other X11 stuff)

Closes #6238