### PR TITLE
Fix intermittent audio driver crash during startup on Android

### DIFF
--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -271,4 +271,5 @@ AudioDriverOpenSL::AudioDriverOpenSL() {
 	s_ad = this;
 	mutex = Mutex::create(); //NULL;
 	pause = false;
+	active = false;
 }


### PR DESCRIPTION
set_pause can be called before the driver is initialized, and there
already is a check for that. The problem is that the 'active' field
was not initialied in the constructor, which lead to it having an
undefined value.