### PR TITLE
Correct next-line calculation for RichTextEdit

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -177,7 +177,7 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 			l.descent_caches.push_back(line_descent);                                                                                                           \
 			l.space_caches.push_back(spaces);                                                                                                                   \
 		}                                                                                                                                                       \
-		y += line_height + get_constant(SceneStringNames::get_singleton()->line_separation);                                                                    \
+		y += line_height - line_descent + get_constant(SceneStringNames::get_singleton()->line_separation);                                                     \
 		line_height = 0;                                                                                                                                        \
 		line_ascent = 0;                                                                                                                                        \
 		line_descent = 0;                                                                                                                                       \
@@ -2132,6 +2132,7 @@ RichTextLabel::RichTextLabel() {
 	default_align = ALIGN_LEFT;
 	underline_meta = true;
 	override_selected_font_color = false;
+	meta_hovering = NULL;
 
 	scroll_visible = false;
 	scroll_follow = false;


### PR DESCRIPTION
It appears that after 77b1320fb the line height of the first line in a
RichTextEdit is no longer correctly calculated compared to the following
lines. By subtracting the line_descent from the next y base coordinate
of the next line we get the correct result.

Comparisons:
3.0-stable
![screenshot from 2018-03-01 17-55-36](https://user-images.githubusercontent.com/2591099/36857805-c4aec0be-1d79-11e8-9986-202826392cdd.png)
3.0.1-stable
![screenshot from 2018-03-01 17-56-01](https://user-images.githubusercontent.com/2591099/36857829-d20509da-1d79-11e8-9805-e205ed12fbc7.png)
This pr:
![screenshot from 2018-03-01 17-56-24](https://user-images.githubusercontent.com/2591099/36857849-df890bf6-1d79-11e8-9290-f4be8f7d1fe9.png)

And with multiple font sizes:
3.0-stable
![screenshot from 2018-03-01 17-57-19](https://user-images.githubusercontent.com/2591099/36857916-03dd92b0-1d7a-11e8-86f1-88d5f9680d55.png)
3.0.1-stable
![screenshot from 2018-03-01 17-57-46](https://user-images.githubusercontent.com/2591099/36857935-11fe97ae-1d7a-11e8-941a-1540e6c71d14.png)
This pr:
![screenshot from 2018-03-01 17-58-07](https://user-images.githubusercontent.com/2591099/36857946-1d1ef174-1d7a-11e8-9a1c-f76b1936f726.png)

I believe this fixes #17139