### PR TITLE
Added `get_playing_speed` method to AnimationPlayer, returning the actual playing speed of the animation being played

### DIFF
--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -103,6 +103,14 @@
 				Get the blend time (in seconds) between two animations, referenced by their names.
 			</description>
 		</method>
+		<method name="get_playing_speed" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+				Get the actual playing speed of current animation or 0 if not playing. This speed is the [code]playback_speed[/code] property multiplied by [code]custom_speed[/code] argument specified when calling the [code]play[/code] method.
+			</description>
+		</method>
+
 		<method name="has_animation" qualifiers="const">
 			<return type="bool">
 			</return>

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1024,6 +1024,13 @@ float AnimationPlayer::get_speed_scale() const {
 
 	return speed_scale;
 }
+float AnimationPlayer::get_playing_speed() const {
+
+	if (!playing) {
+		return 0;
+	}
+	return speed_scale * playback.current.speed_scale;
+}
 
 void AnimationPlayer::seek(float p_time, bool p_update) {
 
@@ -1315,6 +1322,7 @@ void AnimationPlayer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_speed_scale", "speed"), &AnimationPlayer::set_speed_scale);
 	ClassDB::bind_method(D_METHOD("get_speed_scale"), &AnimationPlayer::get_speed_scale);
+	ClassDB::bind_method(D_METHOD("get_playing_speed"), &AnimationPlayer::get_playing_speed);
 
 	ClassDB::bind_method(D_METHOD("set_autoplay", "name"), &AnimationPlayer::set_autoplay);
 	ClassDB::bind_method(D_METHOD("get_autoplay"), &AnimationPlayer::get_autoplay);

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -293,6 +293,7 @@ public:
 
 	void set_speed_scale(float p_speed);
 	float get_speed_scale() const;
+	float get_playing_speed() const;
 
 	void set_autoplay(const String &p_name);
 	String get_autoplay() const;


### PR DESCRIPTION
AnimationPlayer now sets `playback_speed` property correctly when calling `play` method in any variant.

Fix #16550.