### PR TITLE
Remove disabled shapes from physics 2D calculations

### DIFF
--- a/servers/physics_2d/collision_object_2d_sw.h
+++ b/servers/physics_2d/collision_object_2d_sw.h
@@ -136,10 +136,7 @@ public:
 	_FORCE_INLINE_ Transform2D get_inv_transform() const { return inv_transform; }
 	_FORCE_INLINE_ Space2DSW *get_space() const { return space; }
 
-	_FORCE_INLINE_ void set_shape_as_disabled(int p_idx, bool p_disabled) {
-		ERR_FAIL_INDEX(p_idx, shapes.size());
-		shapes[p_idx].disabled = p_disabled;
-	}
+	void set_shape_as_disabled(int p_idx, bool p_disabled);
 	_FORCE_INLINE_ bool is_shape_set_as_disabled(int p_idx) const {
 		ERR_FAIL_INDEX_V(p_idx, shapes.size(), false);
 		return shapes[p_idx].disabled;


### PR DESCRIPTION
Disabling a shape removes it from physics calculations. Enabling a shape adds it back to the physics calculations.

This speeds up the physics system (tested with example project from #17099 ) and prevents disabled shapes from being detected by raycasts ( see #17015 ).

Fixes #17015 and speeds up #17099 