### PR TITLE
[GLES2] Renderer selection improvement

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -829,8 +829,11 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	OS::get_singleton()->set_cmdline(execpath, main_args);
 
-	//if (video_driver == "") // useless for now, so removing
-	//	video_driver = GLOBAL_DEF("display/driver/name", Variant((const char *)OS::get_singleton()->get_video_driver_name(0)));
+	GLOBAL_DEF("rendering/quality/driver/driver_name", "GLES3");
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/driver/driver_name", PropertyInfo(Variant::STRING, "rendering/quality/driver/driver_name", PROPERTY_HINT_ENUM, "GLES3,GLES2"));
+	if (video_driver == "") {
+		video_driver = GLOBAL_GET("rendering/quality/driver/driver_name");
+	}
 
 	GLOBAL_DEF("display/window/size/width", 1024);
 	GLOBAL_DEF("display/window/size/height", 600);

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1169,8 +1169,6 @@ Error OS_OSX::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 
 	/*** END OSX INITIALIZATION ***/
 
-	bool use_gl2 = p_video_driver != 1;
-
 	AudioDriverManager::add_driver(&audio_driver);
 
 	// only opengl support here...

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -78,19 +78,23 @@
 #include <X11/XKBlib.h>
 
 int OS_X11::get_video_driver_count() const {
-	return 1;
+
+	return 2;
 }
 
 const char *OS_X11::get_video_driver_name(int p_driver) const {
-	String driver_name = GLOBAL_GET("rendering/quality/driver/driver_name");
 
-	if (driver_name == "GLES2") {
-		return "GLES2";
+	switch (p_driver) {
+		case VIDEO_DRIVER_GLES2:
+			return "GLES2";
+		case VIDEO_DRIVER_GLES3:
+		default:
+			return "GLES3";
 	}
-	return "GLES3";
 }
 
 int OS_X11::get_audio_driver_count() const {
+
 	return AudioDriverManager::get_driver_count();
 }
 
@@ -289,13 +293,9 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 //print_line("def videomode "+itos(current_videomode.width)+","+itos(current_videomode.height));
 #if defined(OPENGL_ENABLED)
 
-	String setting_name = "rendering/quality/driver/driver_name";
-	ProjectSettings::get_singleton()->set_custom_property_info(setting_name, PropertyInfo(Variant::STRING, setting_name, PROPERTY_HINT_ENUM, "GLES3,GLES2"));
-	String video_driver_name = GLOBAL_DEF("rendering/quality/driver/driver_name", "GLES3");
-
 	ContextGL_X11::ContextType opengl_api_type = ContextGL_X11::GLES_3_0_COMPATIBLE;
 
-	if (video_driver_name == "GLES2") {
+	if (p_video_driver == VIDEO_DRIVER_GLES2) {
 		opengl_api_type = ContextGL_X11::GLES_2_0_COMPATIBLE;
 	}
 

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -53,6 +53,11 @@
 #include <X11/extensions/XInput2.h>
 #endif
 
+enum VideoDriver {
+	VIDEO_DRIVER_GLES3,
+	VIDEO_DRIVER_GLES2
+};
+
 // Hints for X11 fullscreen
 typedef struct {
 	unsigned long flags;


### PR DESCRIPTION
* Fix `--help` command line argument output:

Before:
```
  --audio-driver <driver>          Audio driver ('PulseAudio', 'ALSA').
  --video-driver <driver>          Video driver (WARNING: not found: rendering/quality/driver/driver_name
'GLES3').
```
After:
```
  --audio-driver <driver>          Audio driver ('PulseAudio', 'ALSA').
  --video-driver <driver>          Video driver ('GLES3', 'GLES2').
```

* Allow renderer override with `--video-driver <driver>` command line argument.


