### PR TITLE
added command line options

### DIFF
--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -160,6 +160,14 @@ Error EditorRun::run(const String &p_scene, const String p_custom_args, const Li
 		}
 	}
 
+	String debug_options = ProjectSettings::get_singleton()->get("debug/settings/command_line/options");
+	if (debug_options != "") {
+		Vector<String> options = debug_options.split(",");
+		for (int i = 0; i < options.size(); i++) {
+			args.push_back(options[i]);
+		}
+	}
+
 	String exec = OS::get_singleton()->get_executable_path();
 
 	printf("Running: %ls", exec.c_str());

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -300,6 +300,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	engine->add_singleton(Engine::Singleton("Performance", performance));
 
 	GLOBAL_DEF("debug/settings/crash_handler/message", String("Please include this when reporting the bug on https://github.com/godotengine/godot/issues"));
+	GLOBAL_DEF("debug/settings/command_line/options", "");
 
 	MAIN_PRINT("Main: Parse CMDLine");
 


### PR DESCRIPTION
closes #2577

Is "," okay for separation?
Tested with `-port=9001,-arg2=100`
They will only be passed when run in Editor.
