### PR TITLE
Don't crash when trying to add an invalid navmesh

### DIFF
--- a/scene/3d/navigation.cpp
+++ b/scene/3d/navigation.cpp
@@ -35,6 +35,7 @@ void Navigation::_navmesh_link(int p_id) {
 	ERR_FAIL_COND(!navmesh_map.has(p_id));
 	NavMesh &nm = navmesh_map[p_id];
 	ERR_FAIL_COND(nm.linked);
+	ERR_FAIL_COND(nm.navmesh.is_null());
 
 	PoolVector<Vector3> vertices = nm.navmesh->get_vertices();
 	int len = vertices.size();


### PR DESCRIPTION
It is possible to try to add an invalid object as a navmesh through
GDScript which results in an engine crash. This creates a debug message
that should help the user figure out what's wrong.

This fixes #17153 