### PR TITLE
Fix serialization of identifiers with non printable ASCII characters

### DIFF
--- a/scene/resources/scene_format_text.cpp
+++ b/scene/resources/scene_format_text.cpp
@@ -1445,8 +1445,15 @@ void ResourceFormatSaverTextInstance::_find_resources(const Variant &p_variant, 
 
 static String _valprop(const String &p_name) {
 
-	if (p_name.find("\"") != -1 || p_name.find("=") != -1 || p_name.find(" ") != -1)
-		return "\"" + p_name.c_escape_multiline() + "\"";
+	// Escape and quote strings with extended ASCII or further Unicode characters
+	// as well as '"', '=' or ' ' (32)
+	const CharType *cstr = p_name.c_str();
+	for (int i = 0; cstr[i]; i++) {
+		if (cstr[i] == '=' || cstr[i] == '"' || cstr[i] < 33 || cstr[i] > 126) {
+			return "\"" + p_name.c_escape_multiline() + "\"";
+		}
+	}
+	// Keep as is
 	return p_name;
 }
 


### PR DESCRIPTION
Fixes #6888.

Same as #17177 but for the master branch. Should also be cherry-picked for 3.0.x, as this bug causes corruption of tscn and tres files (and eventually config files growing to hundreds of MBs as in #6888).