### PR TITLE
Generate mouse events from touch on X11 (2.1)

### DIFF
--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -132,6 +132,9 @@ class OS_X11 : public OS_Unix {
 		XIEventMask event_mask;
 		Map<int, Point2i> state;
 	} touch;
+	// For touch-to-mouse
+	int num_touches;
+	int touch_mouse_index;
 #endif
 
 	PhysicsServer *physics_server;


### PR DESCRIPTION
To match behavior on other platforms.

This code is donated by [AdPodnet](https://www.adpodnet.com/).