### PR TITLE
Fix wrong SSL handshake

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -298,7 +298,7 @@ Error HTTPClient::poll() {
 				case StreamPeerTCP::STATUS_CONNECTED: {
 					if (ssl) {
 						Ref<StreamPeerSSL> ssl = StreamPeerSSL::create();
-						Error err = ssl->connect_to_stream(tcp_connection, ssl_verify_host, ssl_verify_host ? conn_host : String());
+						Error err = ssl->connect_to_stream(tcp_connection, ssl_verify_host, conn_host);
 						if (err != OK) {
 							close();
 							status = STATUS_SSL_HANDSHAKE_ERROR;


### PR DESCRIPTION
The name of the remote host is passed to mbed TLS in all cases so the client hello message is correctly formed.

Connecting to AWS hosts was impossible for me before this. The server wasn't sending anything in reply to the client hello.

@akien-mga, I'm a bit confused about milestones. You told me currently we should pick 3.1, but this PR is relevant for 3.0.x, so how to proceed?