### PR TITLE
Fix being able to create folder name with ending '.' on Windows

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -918,7 +918,7 @@ void FileSystemDock::_make_dir_confirm() {
 	if (dir_name.length() == 0) {
 		EditorNode::get_singleton()->show_warning(TTR("No name provided"));
 		return;
-	} else if (dir_name.find("/") != -1 || dir_name.find("\\") != -1 || dir_name.find(":") != -1) {
+	} else if (dir_name.find("/") != -1 || dir_name.find("\\") != -1 || dir_name.find(":") != -1 || dir_name.ends_with(".")) {
 		EditorNode::get_singleton()->show_warning(TTR("Provided name contains invalid characters"));
 		return;
 	}


### PR DESCRIPTION
Original [Issue #16735](https://github.com/godotengine/godot/issues/16735)

Added an additional check when creating a folder so that if the folder name ends with a dot and the current OS is on windows, gives an error and do not create such a folder.