### PR TITLE
Apply culling margin (fixes issue #16115)

### DIFF
--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -730,6 +730,11 @@ void VisualServerScene::instance_set_exterior(RID p_instance, bool p_enabled) {
 }
 
 void VisualServerScene::instance_set_extra_visibility_margin(RID p_instance, real_t p_margin) {
+	Instance *instance = instance_owner.get(p_instance);
+	ERR_FAIL_COND(!instance);
+
+	instance->extra_margin = p_margin;
+	_instance_queue_update(instance, true, false);
 }
 
 Vector<ObjectID> VisualServerScene::instances_cull_aabb(const AABB &p_aabb, RID p_scenario) const {


### PR DESCRIPTION
Fixes issue #16115 - Extra Cull Margin has no effect:

![extra-cull-margin-option](https://user-images.githubusercontent.com/3613175/36946117-178063de-1fb8-11e8-9683-d5c37c3a5e88.png)

The extra margin field is already used: https://github.com/godotengine/godot/blob/e619727e999ecd8e6883330f2c6950cd0624de99/servers/visual/visual_server_scene.cpp#L1014

...but one tiny part, namely the `VisualServerScene::instance_set_extra_visibility_margin()` did not actually apply the new margin.

_This is my first commit and I'm not familiar with Godot's renderer architecture yet, please check thoroughly_ :)