### PR TITLE
skip demo download prompt if ssl is unavailable

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -689,7 +689,7 @@ void ProjectManager::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_READY: {
 
-			if (scroll_children->get_child_count() == 0)
+			if (scroll_children->get_child_count() == 0 && StreamPeerSSL::is_available())
 				open_templates->popup_centered_minsize();
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {


### PR DESCRIPTION
If you compile the editor without SSL support and you first start it without projects, you get the prompt to download the demos. If you then go ahead, the editor crashes.

I didn't follow through with investigating the crash itself, but I reckon if there is no SSL support it is best to skip the prompt anyway.