### PR TITLE
Clean and expose get_audio/video_driver_* funcs on OS class

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -205,6 +205,22 @@ String _OS::get_clipboard() const {
 	return OS::get_singleton()->get_clipboard();
 }
 
+int _OS::get_video_driver_count() const {
+	return OS::get_singleton()->get_video_driver_count();
+}
+
+String _OS::get_video_driver_name(int p_driver) const {
+	return OS::get_singleton()->get_video_driver_name(p_driver);
+}
+
+int _OS::get_audio_driver_count() const {
+	return OS::get_singleton()->get_audio_driver_count();
+}
+
+String _OS::get_audio_driver_name(int p_driver) const {
+	return OS::get_singleton()->get_audio_driver_name(p_driver);
+}
+
 void _OS::set_video_mode(const Size2 &p_size, bool p_fullscreen, bool p_resizeable, int p_screen) {
 
 	OS::VideoMode vm;
@@ -1014,6 +1030,11 @@ void _OS::_bind_methods() {
 	//ClassDB::bind_method(D_METHOD("is_video_mode_fullscreen","screen"),&_OS::is_video_mode_fullscreen,DEFVAL(0));
 	//ClassDB::bind_method(D_METHOD("is_video_mode_resizable","screen"),&_OS::is_video_mode_resizable,DEFVAL(0));
 	//ClassDB::bind_method(D_METHOD("get_fullscreen_mode_list","screen"),&_OS::get_fullscreen_mode_list,DEFVAL(0));
+
+	ClassDB::bind_method(D_METHOD("get_video_driver_count"), &_OS::get_video_driver_count);
+	ClassDB::bind_method(D_METHOD("get_video_driver_name"), &_OS::get_video_driver_name);
+	ClassDB::bind_method(D_METHOD("get_audio_driver_count"), &_OS::get_audio_driver_count);
+	ClassDB::bind_method(D_METHOD("get_audio_driver_name"), &_OS::get_audio_driver_name);
 
 	ClassDB::bind_method(D_METHOD("get_screen_count"), &_OS::get_screen_count);
 	ClassDB::bind_method(D_METHOD("get_current_screen"), &_OS::get_current_screen);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -146,6 +146,12 @@ public:
 	bool is_video_mode_resizable(int p_screen = 0) const;
 	Array get_fullscreen_mode_list(int p_screen = 0) const;
 
+	virtual int get_video_driver_count() const;
+	virtual String get_video_driver_name(int p_driver) const;
+
+	virtual int get_audio_driver_count() const;
+	virtual String get_audio_driver_name(int p_driver) const;
+
 	virtual int get_screen_count() const;
 	virtual int get_current_screen() const;
 	virtual void set_current_screen(int p_screen);

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -34,6 +34,7 @@
 #include "input.h"
 #include "os/file_access.h"
 #include "project_settings.h"
+#include "servers/audio_server.h"
 #include "version_generated.gen.h"
 
 #include <stdarg.h>
@@ -625,6 +626,34 @@ void OS::center_window() {
 	int x = scr.width / 2 - wnd.width / 2;
 	int y = scr.height / 2 - wnd.height / 2;
 	set_window_position(Vector2(x, y));
+}
+
+int OS::get_video_driver_count() const {
+
+	return 2;
+}
+
+const char *OS::get_video_driver_name(int p_driver) const {
+
+	switch (p_driver) {
+		case VIDEO_DRIVER_GLES2:
+			return "GLES2";
+		case VIDEO_DRIVER_GLES3:
+		default:
+			return "GLES3";
+	}
+}
+
+int OS::get_audio_driver_count() const {
+
+	return AudioDriverManager::get_driver_count();
+}
+
+const char *OS::get_audio_driver_name(int p_driver) const {
+
+	AudioDriver *driver = AudioDriverManager::get_driver(p_driver);
+	ERR_FAIL_COND_V(!driver, "");
+	return AudioDriverManager::get_driver(p_driver)->get_name();
 }
 
 OS::OS() {

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -44,6 +44,11 @@
 	@author Juan Linietsky <reduzio@gmail.com>
 */
 
+enum VideoDriver {
+	VIDEO_DRIVER_GLES3,
+	VIDEO_DRIVER_GLES2
+};
+
 class OS {
 
 	static OS *singleton;
@@ -115,12 +120,6 @@ protected:
 	RenderThreadMode _render_thread_mode;
 
 	// functions used by main to initialize/deintialize the OS
-	virtual int get_video_driver_count() const = 0;
-	virtual const char *get_video_driver_name(int p_driver) const = 0;
-
-	virtual int get_audio_driver_count() const = 0;
-	virtual const char *get_audio_driver_name(int p_driver) const = 0;
-
 	void add_logger(Logger *p_logger);
 
 	virtual void initialize_core() = 0;
@@ -174,6 +173,12 @@ public:
 	virtual void set_video_mode(const VideoMode &p_video_mode, int p_screen = 0) = 0;
 	virtual VideoMode get_video_mode(int p_screen = 0) const = 0;
 	virtual void get_fullscreen_mode_list(List<VideoMode> *p_list, int p_screen = 0) const = 0;
+
+	virtual int get_video_driver_count() const;
+	virtual const char *get_video_driver_name(int p_driver) const;
+
+	virtual int get_audio_driver_count() const;
+	virtual const char *get_audio_driver_name(int p_driver) const;
 
 	virtual int get_screen_count() const { return 1; }
 	virtual int get_current_screen() const { return 0; }

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -73,15 +73,6 @@ void OS_Unix::debug_break() {
 	assert(false);
 };
 
-int OS_Unix::get_audio_driver_count() const {
-
-	return 1;
-}
-const char *OS_Unix::get_audio_driver_name(int p_driver) const {
-
-	return "dummy";
-}
-
 int OS_Unix::unix_initialize_audio(int p_audio_driver) {
 
 	return 0;

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -48,12 +48,6 @@ protected:
 	// UNIX only handles the core functions.
 	// inheriting platforms under unix (eg. X11) should handle the rest
 
-	//virtual int get_video_driver_count() const;
-	//virtual const char * get_video_driver_name(int p_driver) const;
-
-	virtual int get_audio_driver_count() const;
-	virtual const char *get_audio_driver_name(int p_driver) const;
-
 	virtual void initialize_core();
 	virtual int unix_initialize_audio(int p_audio_driver);
 	//virtual Error initialize(int p_video_driver,int p_audio_driver);

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -130,8 +130,6 @@ Error OS_Android::initialize(const VideoMode &p_desired, int p_video_driver, int
 	if (gfx_init_func)
 		gfx_init_func(gfx_init_ud, use_gl2);
 
-	AudioDriverManager::add_driver(&audio_driver_android);
-
 	RasterizerGLES3::register_config();
 	RasterizerGLES3::make_current();
 
@@ -775,6 +773,8 @@ OS_Android::OS_Android(GFXInitFunc p_gfx_init_func, void *p_gfx_init_ud, OpenURI
 	Vector<Logger *> loggers;
 	loggers.push_back(memnew(AndroidLogger));
 	_set_logger(memnew(CompositeLogger(loggers)));
+
+	AudioDriverManager::add_driver(&audio_driver_android);
 }
 
 OS_Android::~OS_Android() {

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -123,7 +123,6 @@ Error OSIPhone::initialize(const VideoMode &p_desired, int p_video_driver, int p
 	// reset this to what it should be, it will have been set to 0 after visual_server->init() is called
 	RasterizerStorageGLES3::system_fbo = gl_view_base_fb;
 
-	AudioDriverManager::add_driver(&audio_driver);
 	AudioDriverManager::initialize(p_audio_driver);
 
 	input = memnew(InputDefault);
@@ -632,6 +631,8 @@ OSIPhone::OSIPhone(int width, int height, String p_data_dir) {
 	loggers.push_back(memnew(StdLogger));
 #endif
 	_set_logger(memnew(CompositeLogger(loggers)));
+
+	AudioDriverManager::add_driver(&audio_driver);
 };
 
 OSIPhone::~OSIPhone() {

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -447,7 +447,6 @@ Error OS_JavaScript::initialize(const VideoMode &p_desired, int p_video_driver, 
 
 	print_line("Init Audio");
 
-	AudioDriverManager::add_driver(&audio_driver_javascript);
 	AudioDriverManager::initialize(p_audio_driver);
 
 	RasterizerGLES3::register_config();
@@ -1012,6 +1011,8 @@ OS_JavaScript::OS_JavaScript(const char *p_execpath, GetUserDataDirFunc p_get_us
 	Vector<Logger *> loggers;
 	loggers.push_back(memnew(StdLogger));
 	_set_logger(memnew(CompositeLogger(loggers)));
+
+	AudioDriverManager::add_driver(&audio_driver_javascript);
 }
 
 OS_JavaScript::~OS_JavaScript() {

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -50,11 +50,6 @@
 	@author Juan Linietsky <reduzio@gmail.com>
 */
 
-enum VideoDriver {
-	VIDEO_DRIVER_GLES3,
-	VIDEO_DRIVER_GLES2
-};
-
 class OS_OSX : public OS_Unix {
 public:
 	struct KeyEvent {
@@ -139,9 +134,6 @@ public:
 	void _update_window();
 
 protected:
-	virtual int get_video_driver_count() const;
-	virtual const char *get_video_driver_name(int p_driver) const;
-
 	virtual void initialize_core();
 	virtual Error initialize(const VideoMode &p_desired, int p_video_driver, int p_audio_driver);
 	virtual void finalize();

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1026,22 +1026,6 @@ void OS_OSX::set_ime_position(const Point2 &p_pos) {
 	im_position = p_pos;
 }
 
-int OS_OSX::get_video_driver_count() const {
-
-	return 2;
-}
-
-const char *OS_OSX::get_video_driver_name(int p_driver) const {
-
-	switch (p_driver) {
-		case VIDEO_DRIVER_GLES2:
-			return "GLES2";
-		case VIDEO_DRIVER_GLES3:
-		default:
-			return "GLES3";
-	}
-}
-
 void OS_OSX::initialize_core() {
 
 	crash_handler.initialize();
@@ -1214,8 +1198,6 @@ Error OS_OSX::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 		zoomed = true;
 
 	/*** END OSX INITIALIZATION ***/
-
-	AudioDriverManager::add_driver(&audio_driver);
 
 	// only opengl support here...
 	if (p_video_driver == VIDEO_DRIVER_GLES2) {
@@ -2445,6 +2427,8 @@ OS_OSX::OS_OSX() {
 
 		[NSApp sendEvent:event];
 	}
+
+	AudioDriverManager::add_driver(&audio_driver);
 }
 
 bool OS_OSX::_check_internal_feature_support(const String &p_feature) {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -151,26 +151,6 @@ void RedirectIOToConsole() {
 	// point to console as well
 }
 
-int OS_Windows::get_video_driver_count() const {
-
-	return 1;
-}
-const char *OS_Windows::get_video_driver_name(int p_driver) const {
-
-	return "GLES3";
-}
-
-int OS_Windows::get_audio_driver_count() const {
-
-	return AudioDriverManager::get_driver_count();
-}
-const char *OS_Windows::get_audio_driver_name(int p_driver) const {
-
-	AudioDriver *driver = AudioDriverManager::get_driver(p_driver);
-	ERR_FAIL_COND_V(!driver, "");
-	return AudioDriverManager::get_driver(p_driver)->get_name();
-}
-
 void OS_Windows::initialize_core() {
 
 	crash_handler.initialize();

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -142,12 +142,6 @@ class OS_Windows : public OS {
 
 	// functions used by main to initialize/deintialize the OS
 protected:
-	virtual int get_video_driver_count() const;
-	virtual const char *get_video_driver_name(int p_driver) const;
-
-	virtual int get_audio_driver_count() const;
-	virtual const char *get_audio_driver_name(int p_driver) const;
-
 	virtual void initialize_core();
 	virtual Error initialize(const VideoMode &p_desired, int p_video_driver, int p_audio_driver);
 

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -77,34 +77,6 @@
 
 #include <X11/XKBlib.h>
 
-int OS_X11::get_video_driver_count() const {
-
-	return 2;
-}
-
-const char *OS_X11::get_video_driver_name(int p_driver) const {
-
-	switch (p_driver) {
-		case VIDEO_DRIVER_GLES2:
-			return "GLES2";
-		case VIDEO_DRIVER_GLES3:
-		default:
-			return "GLES3";
-	}
-}
-
-int OS_X11::get_audio_driver_count() const {
-
-	return AudioDriverManager::get_driver_count();
-}
-
-const char *OS_X11::get_audio_driver_name(int p_driver) const {
-
-	AudioDriver *driver = AudioDriverManager::get_driver(p_driver);
-	ERR_FAIL_COND_V(!driver, "");
-	return AudioDriverManager::get_driver(p_driver)->get_name();
-}
-
 void OS_X11::initialize_core() {
 
 	crash_handler.initialize();

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -53,11 +53,6 @@
 #include <X11/extensions/XInput2.h>
 #endif
 
-enum VideoDriver {
-	VIDEO_DRIVER_GLES3,
-	VIDEO_DRIVER_GLES2
-};
-
 // Hints for X11 fullscreen
 typedef struct {
 	unsigned long flags;
@@ -193,12 +188,6 @@ class OS_X11 : public OS_Unix {
 	Bool xrandr_ext_ok;
 
 protected:
-	virtual int get_video_driver_count() const;
-	virtual const char *get_video_driver_name(int p_driver) const;
-
-	virtual int get_audio_driver_count() const;
-	virtual const char *get_audio_driver_name(int p_driver) const;
-
 	virtual void initialize_core();
 	virtual Error initialize(const VideoMode &p_desired, int p_video_driver, int p_audio_driver);
 	virtual void finalize();


### PR DESCRIPTION
With this PR get_video_driver_count, get_video_driver_name, get_audio_driver_count, get_audio_driver_name are now usable from gdscripts.