### PR TITLE
Fix garbage in string padding.

### DIFF
--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -813,7 +813,7 @@ static void _encode_string(const String &p_string, uint8_t *&buf, int &r_len) {
 	while (r_len % 4) {
 		r_len++; //pad
 		if (buf) {
-			buf++;
+			*(buf++) = 0;
 		}
 	}
 }


### PR DESCRIPTION
I found this bug when decoding strings in Python that were previously marshalled by Godot.

Problem: string paddings were not filled with zeroes and thus contained original "dirty" memory parts. For example, code `net.put_var('asd')` yielded the following binary data:

`\x0c\x00\x00\x00\x04\x00\x00\x00\x03\x00\x00\x00asd\xae`

The padding byte (`\xae`) changes randomly each time I send data from Godot.
This made my Python `GodotSerializer` class tests fail because `unmarshal(marshal(obj)) == obj`, but `marshal(unmarshal(raw)) != raw`.

This PR fixes it so that each padded byte is nullified and thus marshalling/unmarshalling process is consistent.