### PR TITLE
Fix new Node dialog Create button behavior

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -476,6 +476,8 @@ void CreateDialog::_item_selected() {
 		return;
 
 	help_bit->set_text(EditorHelp::get_doc_data()->class_list[name].brief_description);
+
+	get_ok()->set_disabled(false);
 }
 
 void CreateDialog::_favorite_toggled() {


### PR DESCRIPTION
Added a one-liner to update the Create button disabled state when
selecting an item from the search results list.

Fixes #17265, long live the Realm!