### PR TITLE
completed-signal for coroutines with more than one yield

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -1535,15 +1535,21 @@ Variant GDScriptFunctionState::_signal_callback(const Variant **p_args, int p_ar
 	// then the function did yield again after resuming.
 	if (ret.is_ref()) {
 		GDScriptFunctionState *gdfs = Object::cast_to<GDScriptFunctionState>(ret);
-		if (gdfs && gdfs->function == function)
+		if (gdfs && gdfs->function == function) {
 			completed = false;
+			gdfs->previous_state = Ref<GDScriptFunctionState>(this);
+		}
 	}
 
 	function = NULL; //cleaned up;
 	state.result = Variant();
 
 	if (completed) {
-		emit_signal("completed", ret);
+		GDScriptFunctionState *state = this;
+		while (state != NULL) {
+			state->emit_signal("completed", ret);
+			state = *(state->previous_state);
+		}
 	}
 
 	return ret;
@@ -1591,15 +1597,21 @@ Variant GDScriptFunctionState::resume(const Variant &p_arg) {
 	// then the function did yield again after resuming.
 	if (ret.is_ref()) {
 		GDScriptFunctionState *gdfs = Object::cast_to<GDScriptFunctionState>(ret);
-		if (gdfs && gdfs->function == function)
+		if (gdfs && gdfs->function == function) {
 			completed = false;
+			gdfs->previous_state = Ref<GDScriptFunctionState>(this);
+		}
 	}
 
 	function = NULL; //cleaned up;
 	state.result = Variant();
 
 	if (completed) {
-		emit_signal("completed", ret);
+		GDScriptFunctionState *state = this;
+		while (state != NULL) {
+			state->emit_signal("completed", ret);
+			state = *(state->previous_state);
+		}
 	}
 
 	return ret;

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -234,6 +234,7 @@ class GDScriptFunctionState : public Reference {
 	GDScriptFunction *function;
 	GDScriptFunction::CallState state;
 	Variant _signal_callback(const Variant **p_args, int p_argcount, Variant::CallError &r_error);
+	Ref<GDScriptFunctionState> previous_state;
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
This is a proposal in response to issue #17280. 
You can yield for completion of a coroutine like this: `yield(coroutine(), "completed")`
but without this PR that only works for coroutines with one yield inside, since every yield keyword returns a GDScriptFunctionState and the completed-signal was only emitted for the last one.

NOTE: there's probably something missing yet - it causes an error that I don't quite understand (Object::disconnect warns that the signal "completed" didn't exist) and I assume that referencing the previous GDScriptFunctionStates with raw pointers may not be a good idea since it probably won't make sure that the previous states aren't freed before their completed-signal is emitted.