### PR TITLE
Added antialias setting to DynamicFont

### DIFF
--- a/doc/classes/DynamicFont.xml
+++ b/doc/classes/DynamicFont.xml
@@ -86,6 +86,9 @@
 		<member name="use_mipmaps" type="bool" setter="set_use_mipmaps" getter="get_use_mipmaps">
 			If [code]true[/code] mipmapping is used.
 		</member>
+		<member name="use_antialias" type="bool" setter="set_use_antialias" getter="get_use_antialias">
+			If [code]true[/code] antialias is used.
+		</member>
 	</members>
 	<constants>
 		<constant name="SPACING_TOP" value="0" enum="SpacingType">

--- a/doc/classes/DynamicFontData.xml
+++ b/doc/classes/DynamicFontData.xml
@@ -19,6 +19,9 @@
 		<member name="hinting" type="int" setter="set_hinting" getter="get_hinting" enum="DynamicFontData.Hinting">
 			The font hinting mode used by FreeType.
 		</member>
+		<member name="use_antialias" type="bool" setter="set_use_antialias" getter="get_use_antialias">
+			If the font is using antialias or not.
+		</member>
 	</members>
 	<constants>
 		<constant name="HINTING_NONE" value="0" enum="Hinting">

--- a/doc/classes/DynamicFontData.xml
+++ b/doc/classes/DynamicFontData.xml
@@ -19,9 +19,6 @@
 		<member name="hinting" type="int" setter="set_hinting" getter="get_hinting" enum="DynamicFontData.Hinting">
 			The font hinting mode used by FreeType.
 		</member>
-		<member name="use_antialias" type="bool" setter="set_use_antialias" getter="get_use_antialias">
-			If the font is using antialias or not.
-		</member>
 	</members>
 	<constants>
 		<constant name="HINTING_NONE" value="0" enum="Hinting">

--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -205,10 +205,11 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	FontThai->set_force_autohinter(true); //just looks better..i think?
 
 	/* Hack */
-
+	bool font_source_antialias = EditorSettings::get_singleton()->get("interface/editor/code_font_antialias");
 	Ref<DynamicFontData> dfmono;
 	dfmono.instance();
 	dfmono->set_hinting(font_source_hinting);
+	dfmono->set_use_antialias(font_source_antialias);
 	dfmono->set_font_ptr(_font_Hack_Regular, _font_Hack_Regular_size);
 	//dfd->set_force_autohinter(true); //just looks better..i think?
 

--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -76,6 +76,7 @@ static Ref<BitmapFont> make_font(int p_height, int p_ascent, int p_valign, int p
 	Ref<DynamicFont> m_name;                                    \
 	m_name.instance();                                          \
 	m_name->set_size(m_size);                                   \
+	m_name->set_use_antialias(true);                            \
 	if (CustomFont.is_valid()) {                                \
 		m_name->set_font_data(CustomFont);                      \
 		m_name->add_fallback(DefaultFont);                      \
@@ -90,6 +91,7 @@ static Ref<BitmapFont> make_font(int p_height, int p_ascent, int p_valign, int p
 	Ref<DynamicFont> m_name;                                    \
 	m_name.instance();                                          \
 	m_name->set_size(m_size);                                   \
+	m_name->set_use_antialias(true);                            \
 	if (CustomFont.is_valid()) {                                \
 		m_name->set_font_data(CustomFontBold);                  \
 		m_name->add_fallback(DefaultFontBold);                  \
@@ -100,10 +102,11 @@ static Ref<BitmapFont> make_font(int p_height, int p_ascent, int p_valign, int p
 	m_name->set_spacing(DynamicFont::SPACING_BOTTOM, -EDSCALE); \
 	MAKE_FALLBACKS(m_name);
 
-#define MAKE_SOURCE_FONT(m_name, m_size)                        \
+#define MAKE_SOURCE_FONT(m_name, m_size, m_antialias)           \
 	Ref<DynamicFont> m_name;                                    \
 	m_name.instance();                                          \
 	m_name->set_size(m_size);                                   \
+	m_name->set_use_antialias(m_antialias);                     \
 	if (CustomFontSource.is_valid()) {                          \
 		m_name->set_font_data(CustomFontSource);                \
 		m_name->add_fallback(dfmono);                           \
@@ -205,11 +208,9 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	FontThai->set_force_autohinter(true); //just looks better..i think?
 
 	/* Hack */
-	bool font_source_antialias = EditorSettings::get_singleton()->get("interface/editor/code_font_antialias");
 	Ref<DynamicFontData> dfmono;
 	dfmono.instance();
 	dfmono->set_hinting(font_source_hinting);
-	dfmono->set_use_antialias(font_source_antialias);
 	dfmono->set_font_ptr(_font_Hack_Regular, _font_Hack_Regular_size);
 	//dfd->set_force_autohinter(true); //just looks better..i think?
 
@@ -235,7 +236,7 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	p_theme->set_font("doc", "EditorFonts", df_doc);
 	p_theme->set_font("doc_title", "EditorFonts", df_doc_title);
 
-	MAKE_SOURCE_FONT(df_doc_code, int(EDITOR_DEF("text_editor/help/help_source_font_size", 14)) * EDSCALE);
+	MAKE_SOURCE_FONT(df_doc_code, int(EDITOR_DEF("text_editor/help/help_source_font_size", 14)) * EDSCALE, true);
 	p_theme->set_font("doc_source", "EditorFonts", df_doc_code);
 
 	// Ruler font
@@ -243,12 +244,13 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	p_theme->set_font("rulers", "EditorFonts", df_rulers);
 
 	// Code font
-	MAKE_SOURCE_FONT(df_code, int(EditorSettings::get_singleton()->get("interface/editor/code_font_size")) * EDSCALE);
+	bool font_source_antialias = EditorSettings::get_singleton()->get("interface/editor/code_font_antialias");
+	MAKE_SOURCE_FONT(df_code, int(EditorSettings::get_singleton()->get("interface/editor/code_font_size")) * EDSCALE, font_source_antialias);
 	p_theme->set_font("source", "EditorFonts", df_code);
 
-	MAKE_SOURCE_FONT(df_output_code, int(EDITOR_DEF("run/output/font_size", 13)) * EDSCALE);
+	MAKE_SOURCE_FONT(df_output_code, int(EDITOR_DEF("run/output/font_size", 13)) * EDSCALE, true);
 	p_theme->set_font("output_source", "EditorFonts", df_output_code);
 
-	MAKE_SOURCE_FONT(df_text_editor_status_code, 14 * EDSCALE);
+	MAKE_SOURCE_FONT(df_text_editor_status_code, 14 * EDSCALE, true);
 	p_theme->set_font("status_source", "EditorFonts", df_text_editor_status_code);
 }

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -298,6 +298,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("interface/editor/main_font_size", 14);
 	hints["interface/editor/main_font_size"] = PropertyInfo(Variant::INT, "interface/editor/main_font_size", PROPERTY_HINT_RANGE, "10,40,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/code_font_size", 14);
+	_initial_set("interface/editor/code_font_antialias", true);
 	hints["interface/editor/code_font_size"] = PropertyInfo(Variant::INT, "interface/editor/code_font_size", PROPERTY_HINT_RANGE, "8,96,1", PROPERTY_USAGE_DEFAULT);
 	_initial_set("interface/editor/main_font_hinting", 2);
 	hints["interface/editor/main_font_hinting"] = PropertyInfo(Variant::INT, "interface/editor/main_font_hinting", PROPERTY_HINT_ENUM, "None,Light,Normal", PROPERTY_USAGE_DEFAULT);

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -81,11 +81,21 @@ void DynamicFontData::set_force_autohinter(bool p_force) {
 	force_autohinter = p_force;
 }
 
+void DynamicFontData::set_use_antialias(bool p_use) {
+	use_antialias = p_use;
+}
+
+bool DynamicFontData::get_use_antialias() const {
+	return use_antialias;
+}
+
 void DynamicFontData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_font_path", "path"), &DynamicFontData::set_font_path);
 	ClassDB::bind_method(D_METHOD("get_font_path"), &DynamicFontData::get_font_path);
 	ClassDB::bind_method(D_METHOD("set_hinting", "mode"), &DynamicFontData::set_hinting);
 	ClassDB::bind_method(D_METHOD("get_hinting"), &DynamicFontData::get_hinting);
+	ClassDB::bind_method(D_METHOD("set_use_antialias", "enabled"), &DynamicFontData::set_use_antialias);
+	ClassDB::bind_method(D_METHOD("is_using_antialias"), &DynamicFontData::get_use_antialias);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "hinting", PROPERTY_HINT_ENUM, "None,Light,Normal"), "set_hinting", "get_hinting");
 
@@ -94,12 +104,14 @@ void DynamicFontData::_bind_methods() {
 	BIND_ENUM_CONSTANT(HINTING_NORMAL);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "font_path", PROPERTY_HINT_FILE, "*.ttf,*.otf"), "set_font_path", "get_font_path");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "antialias"), "set_use_antialias", "is_using_antialias");
 }
 
 DynamicFontData::DynamicFontData() {
 
 	force_autohinter = false;
 	hinting = DynamicFontData::HINTING_NORMAL;
+	use_antialias = true;
 	font_mem = NULL;
 	font_mem_size = 0;
 }
@@ -634,7 +646,7 @@ void DynamicFontAtSize::_update_char(CharType p_char) {
 	if (id.outline_size > 0) {
 		character = _make_outline_char(p_char);
 	} else {
-		error = FT_Render_Glyph(face->glyph, FT_RENDER_MODE_NORMAL);
+		error = FT_Render_Glyph(face->glyph, (font->use_antialias) ? FT_RENDER_MODE_NORMAL : FT_RENDER_MODE_MONO);
 		if (!error)
 			character = _bitmap_to_character(slot->bitmap, slot->bitmap_top, slot->bitmap_left, slot->advance.x / 64.0);
 	}

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -81,21 +81,11 @@ void DynamicFontData::set_force_autohinter(bool p_force) {
 	force_autohinter = p_force;
 }
 
-void DynamicFontData::set_use_antialias(bool p_use) {
-	use_antialias = p_use;
-}
-
-bool DynamicFontData::get_use_antialias() const {
-	return use_antialias;
-}
-
 void DynamicFontData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_font_path", "path"), &DynamicFontData::set_font_path);
 	ClassDB::bind_method(D_METHOD("get_font_path"), &DynamicFontData::get_font_path);
 	ClassDB::bind_method(D_METHOD("set_hinting", "mode"), &DynamicFontData::set_hinting);
 	ClassDB::bind_method(D_METHOD("get_hinting"), &DynamicFontData::get_hinting);
-	ClassDB::bind_method(D_METHOD("set_use_antialias", "enabled"), &DynamicFontData::set_use_antialias);
-	ClassDB::bind_method(D_METHOD("is_using_antialias"), &DynamicFontData::get_use_antialias);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "hinting", PROPERTY_HINT_ENUM, "None,Light,Normal"), "set_hinting", "get_hinting");
 
@@ -104,14 +94,12 @@ void DynamicFontData::_bind_methods() {
 	BIND_ENUM_CONSTANT(HINTING_NORMAL);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "font_path", PROPERTY_HINT_FILE, "*.ttf,*.otf"), "set_font_path", "get_font_path");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "antialias"), "set_use_antialias", "is_using_antialias");
 }
 
 DynamicFontData::DynamicFontData() {
 
 	force_autohinter = false;
 	hinting = DynamicFontData::HINTING_NORMAL;
-	use_antialias = true;
 	font_mem = NULL;
 	font_mem_size = 0;
 }
@@ -646,7 +634,7 @@ void DynamicFontAtSize::_update_char(CharType p_char) {
 	if (id.outline_size > 0) {
 		character = _make_outline_char(p_char);
 	} else {
-		error = FT_Render_Glyph(face->glyph, (font->use_antialias) ? FT_RENDER_MODE_NORMAL : FT_RENDER_MODE_MONO);
+		error = FT_Render_Glyph(face->glyph, (id.antialias) ? FT_RENDER_MODE_NORMAL : FT_RENDER_MODE_MONO);
 		if (!error)
 			character = _bitmap_to_character(slot->bitmap, slot->bitmap_top, slot->bitmap_left, slot->advance.x / 64.0);
 	}
@@ -796,6 +784,18 @@ void DynamicFont::set_use_filter(bool p_enable) {
 		return;
 	cache_id.filter = p_enable;
 	outline_cache_id.filter = p_enable;
+	_reload_cache();
+}
+
+bool DynamicFont::get_use_antialias() const {
+	return cache_id.antialias;
+}
+
+void DynamicFont::set_use_antialias(bool p_enable) {
+	if (cache_id.antialias == p_enable)
+		return;
+	cache_id.antialias = p_enable;
+	outline_cache_id.antialias = p_enable;
 	_reload_cache();
 }
 
@@ -1012,6 +1012,8 @@ void DynamicFont::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_use_mipmaps"), &DynamicFont::get_use_mipmaps);
 	ClassDB::bind_method(D_METHOD("set_use_filter", "enable"), &DynamicFont::set_use_filter);
 	ClassDB::bind_method(D_METHOD("get_use_filter"), &DynamicFont::get_use_filter);
+	ClassDB::bind_method(D_METHOD("set_use_antialias", "enabled"), &DynamicFont::set_use_antialias);
+	ClassDB::bind_method(D_METHOD("get_use_antialias"), &DynamicFont::get_use_antialias);
 	ClassDB::bind_method(D_METHOD("set_spacing", "type", "value"), &DynamicFont::set_spacing);
 	ClassDB::bind_method(D_METHOD("get_spacing", "type"), &DynamicFont::get_spacing);
 
@@ -1027,6 +1029,7 @@ void DynamicFont::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "outline_color"), "set_outline_color", "get_outline_color");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_mipmaps"), "set_use_mipmaps", "get_use_mipmaps");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_filter"), "set_use_filter", "get_use_filter");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_antialias"), "set_use_antialias", "get_use_antialias");
 	ADD_GROUP("Extra Spacing", "extra_spacing");
 	ADD_PROPERTYINZ(PropertyInfo(Variant::INT, "extra_spacing_top"), "set_spacing", "get_spacing", SPACING_TOP);
 	ADD_PROPERTYINZ(PropertyInfo(Variant::INT, "extra_spacing_bottom"), "set_spacing", "get_spacing", SPACING_BOTTOM);

--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -56,6 +56,7 @@ public:
 				uint32_t outline_size : 8;
 				bool mipmaps : 1;
 				bool filter : 1;
+				bool antialias : 1;
 			};
 			uint32_t key;
 		};
@@ -78,6 +79,7 @@ private:
 	const uint8_t *font_mem;
 	int font_mem_size;
 	bool force_autohinter;
+	bool use_antialias;
 	Hinting hinting;
 
 	String font_path;
@@ -97,6 +99,8 @@ public:
 	void set_font_path(const String &p_path);
 	String get_font_path() const;
 	void set_force_autohinter(bool p_force);
+	void set_use_antialias(bool p_use);
+	bool get_use_antialias() const;
 
 	DynamicFontData();
 	~DynamicFontData();

--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -79,7 +79,6 @@ private:
 	const uint8_t *font_mem;
 	int font_mem_size;
 	bool force_autohinter;
-	bool use_antialias;
 	Hinting hinting;
 
 	String font_path;
@@ -99,8 +98,6 @@ public:
 	void set_font_path(const String &p_path);
 	String get_font_path() const;
 	void set_force_autohinter(bool p_force);
-	void set_use_antialias(bool p_use);
-	bool get_use_antialias() const;
 
 	DynamicFontData();
 	~DynamicFontData();
@@ -263,6 +260,9 @@ public:
 
 	bool get_use_filter() const;
 	void set_use_filter(bool p_enable);
+
+	bool get_use_antialias() const;
+	void set_use_antialias(bool p_enable);
 
 	int get_spacing(int p_type) const;
 	void set_spacing(int p_type, int p_value);


### PR DESCRIPTION
And added editor settings for the code editor while at it. Maybe GIF wasn't the best idea to showcase it.

![capture](https://user-images.githubusercontent.com/250464/37002535-53cf0846-20ca-11e8-81b5-473bd54bfd1b.gif)

To be honest this is more of a request for comments than a PR: 

* I'm not happy with the category of the setting. It makes sense in the gui, but it's not really a theme setting. I'm also unsure how the Font setting on that same section works, it looks nothing like the editor fonts part. The lack of size setting also tells me this isn't the right place.

* I'm not sure if the antialias setting should be bound. #17094 seems to do it for hinting so I guess the answer is yes?

Other than that, it does what the original issue reporter wanted, so with the necessary adjustments it's pretty much done. 