### PR TITLE
Fix "ui_accept" action not calling _pressed() function in GDScript Button

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -211,6 +211,11 @@ void BaseButton::_gui_input(Ref<InputEvent> p_event) {
 				if (!toggle_mode) { //mouse press attempt
 
 					pressed();
+					if (get_script_instance()) {
+						Variant::CallError ce;
+						get_script_instance()->call(SceneStringNames::get_singleton()->_pressed, NULL, 0, ce);
+					}
+
 					emit_signal("pressed");
 				} else {
 


### PR DESCRIPTION
Fixed "ui_accept" action in BaseButton.cpp not calling _pressed() function in GDScript

GDScript _pressed() function isn't getting called when the "ui_accept" action is fired. This prevents deriving  from the Button type in GDScript and getting the _pressed() function called when "ui_accept" action is seen.