### PR TITLE
Make InstancePlaceholder more flexible by allowing to instance without removing it.

### DIFF
--- a/scene/main/instance_placeholder.cpp
+++ b/scene/main/instance_placeholder.cpp
@@ -52,6 +52,7 @@ bool InstancePlaceholder::_get(const StringName &p_name, Variant &r_ret) const {
 	}
 	return false;
 }
+
 void InstancePlaceholder::_get_property_list(List<PropertyInfo> *p_list) const {
 
 	for (const List<PropSet>::Element *E = stored_values.front(); E; E = E->next()) {
@@ -73,13 +74,14 @@ String InstancePlaceholder::get_instance_path() const {
 
 	return path;
 }
-void InstancePlaceholder::replace_by_instance(const Ref<PackedScene> &p_custom_scene) {
 
-	ERR_FAIL_COND(!is_inside_tree());
+Node *InstancePlaceholder::create_instance(bool p_replace, const Ref<PackedScene> &p_custom_scene) {
+
+	ERR_FAIL_COND_V(!is_inside_tree(), NULL);
 
 	Node *base = get_parent();
 	if (!base)
-		return;
+		return NULL;
 
 	Ref<PackedScene> ps;
 	if (p_custom_scene.is_valid())
@@ -88,7 +90,7 @@ void InstancePlaceholder::replace_by_instance(const Ref<PackedScene> &p_custom_s
 		ps = ResourceLoader::load(path, "PackedScene");
 
 	if (!ps.is_valid())
-		return;
+		return NULL;
 	Node *scene = ps->instance();
 	scene->set_name(get_name());
 	int pos = get_position_in_parent();
@@ -97,11 +99,20 @@ void InstancePlaceholder::replace_by_instance(const Ref<PackedScene> &p_custom_s
 		scene->set(E->get().name, E->get().value);
 	}
 
-	queue_delete();
+	if (p_replace) {
+		queue_delete();
+		base->remove_child(this);
+	}
 
-	base->remove_child(this);
 	base->add_child(scene);
 	base->move_child(scene, pos);
+
+	return scene;
+}
+
+void InstancePlaceholder::replace_by_instance(const Ref<PackedScene> &p_custom_scene) {
+	//Deprecated by
+	create_instance(true, p_custom_scene);
 }
 
 Dictionary InstancePlaceholder::get_stored_values(bool p_with_order) {
@@ -124,6 +135,7 @@ Dictionary InstancePlaceholder::get_stored_values(bool p_with_order) {
 void InstancePlaceholder::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_stored_values", "with_order"), &InstancePlaceholder::get_stored_values, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("create_instance", "replace", "custom_scene"), &InstancePlaceholder::create_instance, DEFVAL(false), DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("replace_by_instance", "custom_scene"), &InstancePlaceholder::replace_by_instance, DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("get_instance_path"), &InstancePlaceholder::get_instance_path);
 }

--- a/scene/main/instance_placeholder.h
+++ b/scene/main/instance_placeholder.h
@@ -60,6 +60,7 @@ public:
 
 	Dictionary get_stored_values(bool p_with_order = false);
 
+	Node *create_instance(bool p_replace = false, const Ref<PackedScene> &p_custom_scene = Ref<PackedScene>());
 	void replace_by_instance(const Ref<PackedScene> &p_custom_scene = Ref<PackedScene>());
 
 	InstancePlaceholder();


### PR DESCRIPTION
`create_instance` allows to create an instance from an `InstancePlaceholder` without removing the placeholder node.

This option is useful for designing levels in blocks, placing subscenes to instance and remove when needed by code, also for creating recyclable "spawners" that can be triggered without having to rely on helper nodes while at the same time are visible when editing scenes, among other uses.

Deprecates `InstancePlaceholder.replace_by_instance()` but was kept for compatibility.

Closes #8428.
