### PR TITLE
Improved error checking at EditorExportPlatformPC::export_project

### DIFF
--- a/core/os/dir_access.cpp
+++ b/core/os/dir_access.cpp
@@ -301,8 +301,8 @@ Error DirAccess::copy(String p_from, String p_to, int p_chmod_flags) {
 	FileAccess *fsrc = FileAccess::open(p_from, FileAccess::READ, &err);
 
 	if (err) {
-
-		ERR_FAIL_COND_V(err, err);
+		ERR_PRINTS("Failed to open " + p_from);
+		return err;
 	}
 
 	FileAccess *fdst = FileAccess::open(p_to, FileAccess::WRITE, &err);
@@ -310,7 +310,8 @@ Error DirAccess::copy(String p_from, String p_to, int p_chmod_flags) {
 
 		fsrc->close();
 		memdelete(fsrc);
-		ERR_FAIL_COND_V(err, err);
+		ERR_PRINTS("Failed to open " + p_to);
+		return err;
 	}
 
 	fsrc->seek_end(0);

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1352,27 +1352,24 @@ Error EditorExportPlatformPC::export_project(const Ref<EditorExportPreset> &p_pr
 
 	DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	Error err = da->copy(template_path, p_path, get_chmod_flags());
-	memdelete(da);
+	if (err == OK) {
+		String pck_path = p_path.get_basename() + ".pck";
 
-	if (err != OK) {
-		return err;
+		Vector<SharedObject> so_files;
+
+		err = save_pack(p_preset, pck_path, &so_files);
+
+		if (err == OK && !so_files.empty()) {
+			//if shared object files, copy them
+			da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+			for (int i = 0; i < so_files.size() && err == OK; i++) {
+				err = da->copy(so_files[i].path, p_path.get_base_dir().plus_file(so_files[i].path.get_file()));
+			}
+		}
 	}
 
-	String pck_path = p_path.get_basename() + ".pck";
-
-	Vector<SharedObject> so_files;
-
-	err = save_pack(p_preset, pck_path, &so_files);
-
-	if (err != OK || so_files.empty())
-		return err;
-	//if shared object files, copy them
-	da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	for (int i = 0; i < so_files.size(); i++) {
-		da->copy(so_files[i].path, p_path.get_base_dir().plus_file(so_files[i].path.get_file()));
-	}
 	memdelete(da);
-	return OK;
+	return err;
 }
 
 void EditorExportPlatformPC::set_extension(const String &p_extension, const String &p_feature_key) {

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -496,7 +496,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 		if (use_dmg()) {
 			String pack_path = tmp_app_path_name + "/Contents/Resources/" + pkg_name + ".pck";
 			Vector<SharedObject> shared_objects;
-			Error err = save_pack(p_preset, pack_path, &shared_objects);
+			err = save_pack(p_preset, pack_path, &shared_objects);
 
 			// see if we can code sign our new package
 			String identity = p_preset->get("codesign/identity");
@@ -504,7 +504,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 			if (err == OK) {
 				DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 				for (int i = 0; i < shared_objects.size(); i++) {
-					da->copy(shared_objects[i].path, tmp_app_path_name + "/Contents/Frameworks/" + shared_objects[i].path.get_file());
+					err = da->copy(shared_objects[i].path, tmp_app_path_name + "/Contents/Frameworks/" + shared_objects[i].path.get_file());
 					if (err == OK && identity != "") {
 						err = _code_sign(p_preset, tmp_app_path_name + "/Contents/Frameworks/" + shared_objects[i].path.get_file());
 					}
@@ -549,7 +549,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 			String pack_path = EditorSettings::get_singleton()->get_cache_dir().plus_file(pkg_name + ".pck");
 
 			Vector<SharedObject> shared_objects;
-			Error err = save_pack(p_preset, pack_path, &shared_objects);
+			err = save_pack(p_preset, pack_path, &shared_objects);
 
 			if (err == OK) {
 				zipOpenNewFileInZip(dst_pkg_zip,
@@ -581,7 +581,9 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 				} else {
 					err = ERR_CANT_OPEN;
 				}
+			}
 
+			if (err == OK) {
 				//add shared objects
 				for (int i = 0; i < shared_objects.size(); i++) {
 					Vector<uint8_t> file = FileAccess::get_file_as_array(shared_objects[i].path);
@@ -609,7 +611,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 		zipClose(dst_pkg_zip, NULL);
 	}
 
-	return OK;
+	return err;
 }
 
 bool EditorExportPlatformOSX::can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const {


### PR DESCRIPTION
Also improve the error checking at the OS X exporter in the same way.
With this PR if there is a missing shared library DirAccess::copy will show the missing file on the console and the export will fail.