### PR TITLE
Fix bad autocomplete of partially written node paths when using syntactic sugar notation ($)

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5232,7 +5232,7 @@ void TextEdit::_update_completion_candidates() {
 
 	} else {
 
-		while (cofs > 0 && l[cofs - 1] > 32 && _is_completable(l[cofs - 1])) {
+		while (cofs > 0 && l[cofs - 1] > 32 && (l[cofs - 1] == '/' || _is_completable(l[cofs - 1]))) {
 			s = String::chr(l[cofs - 1]) + s;
 			if (l[cofs - 1] == '\'' || l[cofs - 1] == '"' || l[cofs - 1] == '$')
 				break;


### PR DESCRIPTION
Fix bad autocomplete of partially written node paths when using syntactic sugar notation ($)

If you had a tree like Node2D->Sprite->Camera2D and you write a
code like $Node2D/Spr and chose the autocompletion sugested
Node2D/Sprite, the resulting string was $Node2D/Node2D/Sprite
instead $Node2D/Sprite. If you chose Node2D/Sprite/Camera2D, then
you ended with $Node2D/Node2D/Sprite/Camera2D.

Fix #15813.