### PR TITLE
Change shebang of pre-commit-clang-format hook to make it portable

### DIFF
--- a/misc/hooks/pre-commit-clang-format
+++ b/misc/hooks/pre-commit-clang-format
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # git pre-commit hook that runs a clang-format stylecheck.
 # Features:


### PR DESCRIPTION
Change shebang of `pre-commit-clang-format` hook to make it portable

The default one is `#!/bin/bash`, but BSD systems doesn't have bash
in that path. For portability reasons, it should be changed to
`#!/usr/bin/env bash`.

More info: [https://en.wikipedia.org/wiki/Shebang_%28Unix%29#Portability](https://en.wikipedia.org/wiki/Shebang_%28Unix%29#Portability)