### PR TITLE
Adjust decimal precision

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -945,8 +945,8 @@ String String::num(double p_num, int p_decimals) {
 
 #ifndef NO_USE_STDLIB
 
-	if (p_decimals > 12)
-		p_decimals = 12;
+	if (p_decimals > 16)
+		p_decimals = 16;
 
 	char fmt[7];
 	fmt[0] = '%';


### PR DESCRIPTION
Increase the possible number of significant digits when converting from double to string.

Fixes #17312