### PR TITLE
Fix silent failure of importing OGG Vorbis files

### DIFF
--- a/modules/stb_vorbis/resource_importer_ogg_vorbis.cpp
+++ b/modules/stb_vorbis/resource_importer_ogg_vorbis.cpp
@@ -100,6 +100,7 @@ Error ResourceImporterOGGVorbis::import(const String &p_source_file, const Strin
 	ogg_stream.instance();
 
 	ogg_stream->set_data(data);
+	ERR_FAIL_COND_V(!ogg_stream->get_data().size(), ERR_FILE_CORRUPT);
 	ogg_stream->set_loop(loop);
 	ogg_stream->set_loop_offset(loop_offset);
 


### PR DESCRIPTION
Fix silent failure of importing OGG Vorbis files

When importing non-valid OGG Vorbis audio files, now the filesystem
navigation tree shows the correct sad red-face icon, as it does with
non-valid PNG, JPG or WAV files.

Fix #9793.