### PR TITLE
Build polygon clipper only in tools builds

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -68,7 +68,6 @@ thirdparty_sources = [
 	"md5.cpp",
 	"pcg.cpp",
 	"triangulator.cpp",
-	"clipper.cpp",
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 env.add_source_files(env.core_sources, thirdparty_sources)

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -466,6 +466,7 @@ if env['tools']:
 
 
     env.add_source_files(env.editor_sources, "*.cpp")
+    env.add_source_files(env.editor_sources, ["#thirdparty/misc/clipper.cpp"])
 
     SConscript('collada/SCsub')
     SConscript('doc/SCsub')


### PR DESCRIPTION
`thirdparty/misc/clipper.cpp` uses exceptions, which are disabled in the HTML5 platform.

Fixes #16960 