### PR TITLE
Fix switching WindowDialog types leaves garbage buttons

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2502,7 +2502,10 @@ void Node::replace_by(Node *p_node, bool p_keep_data) {
 
 		Node *child = get_child(0);
 		remove_child(child);
-		p_node->add_child(child);
+		if (!child->is_owned_by_parent()) {
+			// add the custom children to the p_node
+			p_node->add_child(child);
+		}
 	}
 
 	p_node->set_owner(owner);


### PR DESCRIPTION
We can distinguish between node-specific children and custom children by `child->is_owned_by_parent()`.

Fixes: #16350