### PR TITLE
add InputActionListener type

### DIFF
--- a/core/os/input.cpp
+++ b/core/os/input.cpp
@@ -32,6 +32,22 @@
 #include "input_map.h"
 #include "os/os.h"
 #include "project_settings.h"
+
+void InputActionListener::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_action_name"), &InputActionListener::get_action_name);
+
+	ADD_SIGNAL(MethodInfo("pressed"));
+	ADD_SIGNAL(MethodInfo("released"));
+}
+
+void InputActionListener::set_action_name(const StringName &p_action_name) {
+	action_name = p_action_name;
+}
+
+StringName InputActionListener::get_action_name() const {
+	return action_name;
+}
+
 Input *Input::singleton = NULL;
 
 Input *Input::get_singleton() {
@@ -57,6 +73,7 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_action_pressed", "action"), &Input::is_action_pressed);
 	ClassDB::bind_method(D_METHOD("is_action_just_pressed", "action"), &Input::is_action_just_pressed);
 	ClassDB::bind_method(D_METHOD("is_action_just_released", "action"), &Input::is_action_just_released);
+	ClassDB::bind_method(D_METHOD("get_action_listener", "action"), &Input::get_action_listener);
 	ClassDB::bind_method(D_METHOD("add_joy_mapping", "mapping", "update_existing"), &Input::add_joy_mapping, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_joy_mapping", "guid"), &Input::remove_joy_mapping);
 	ClassDB::bind_method(D_METHOD("joy_connection_changed", "device", "connected", "name", "guid"), &Input::joy_connection_changed);

--- a/core/os/input.h
+++ b/core/os/input.h
@@ -34,6 +34,22 @@
 #include "object.h"
 #include "os/main_loop.h"
 #include "os/thread_safe.h"
+class Input;
+
+class InputActionListener : public Reference {
+	GDCLASS(InputActionListener, Reference)
+
+	friend class Input;
+
+	StringName action_name;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_action_name(const StringName &p_action_name);
+	StringName get_action_name() const;
+};
 
 class Input : public Object {
 
@@ -85,6 +101,9 @@ public:
 	virtual bool is_action_pressed(const StringName &p_action) const = 0;
 	virtual bool is_action_just_pressed(const StringName &p_action) const = 0;
 	virtual bool is_action_just_released(const StringName &p_action) const = 0;
+
+	virtual Ref<InputActionListener> get_action_listener(const StringName &p_action) = 0;
+	virtual void remove_action_listener(const StringName &p_action) = 0;
 
 	virtual float get_joy_axis(int p_device, int p_axis) const = 0;
 	virtual String get_joy_name(int p_idx) = 0;

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -133,6 +133,7 @@ void register_core_types() {
 	ClassDB::register_virtual_class<InputEventGesture>();
 	ClassDB::register_class<InputEventMagnifyGesture>();
 	ClassDB::register_class<InputEventPanGesture>();
+	ClassDB::register_class<InputActionListener>();
 
 	ClassDB::register_class<FuncRef>();
 	ClassDB::register_virtual_class<StreamPeer>();

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -59,6 +59,8 @@ class InputDefault : public Input {
 
 	Map<StringName, Action> action_state;
 
+	Map<StringName, Ref<InputActionListener> > action_listeners;
+
 	bool emulate_touch;
 
 	struct VibrationInfo {
@@ -182,6 +184,9 @@ public:
 	virtual bool is_action_pressed(const StringName &p_action) const;
 	virtual bool is_action_just_pressed(const StringName &p_action) const;
 	virtual bool is_action_just_released(const StringName &p_action) const;
+
+	virtual Ref<InputActionListener> get_action_listener(const StringName &p_action);
+	virtual void remove_action_listener(const StringName &p_action);
 
 	virtual float get_joy_axis(int p_device, int p_axis) const;
 	String get_joy_name(int p_idx);


### PR DESCRIPTION
This commit adds a new Reference type, called `InputActionListener`,
which can be used to listen for action-pressed and action-released
events using signals.

To create a value of that type, the `Input.get_action_listener`
method should be used.