### PR TITLE
Add encrypt_text/decrypt_text function using aes256 algorithm (2.1.5)

### DIFF
--- a/core/ustring.h
+++ b/core/ustring.h
@@ -191,6 +191,10 @@ public:
 	uint64_t hash64() const; /* hash the string */
 	String md5_text() const;
 	String sha256_text() const;
+
+	String encrypt_text(const String &p_key) const;
+	String decrypt_text(const String &p_key) const;
+
 	Vector<uint8_t> md5_buffer() const;
 	Vector<uint8_t> sha256_buffer() const;
 

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -261,6 +261,8 @@ struct _VariantCall {
 	VCALL_LOCALMEM0R(String, hash);
 	VCALL_LOCALMEM0R(String, md5_text);
 	VCALL_LOCALMEM0R(String, sha256_text);
+	VCALL_LOCALMEM1R(String, encrypt_text);
+	VCALL_LOCALMEM1R(String, decrypt_text);
 	VCALL_LOCALMEM0R(String, md5_buffer);
 	VCALL_LOCALMEM0R(String, sha256_buffer);
 	VCALL_LOCALMEM0R(String, empty);
@@ -1345,6 +1347,8 @@ void register_variant_methods() {
 	ADDFUNC0(STRING, INT, String, hash, varray());
 	ADDFUNC0(STRING, STRING, String, md5_text, varray());
 	ADDFUNC0(STRING, STRING, String, sha256_text, varray());
+	ADDFUNC1(STRING, STRING, String, encrypt_text, STRING, "key", varray());
+	ADDFUNC1(STRING, STRING, String, decrypt_text, STRING, "key", varray());
 	ADDFUNC0(STRING, RAW_ARRAY, String, md5_buffer, varray());
 	ADDFUNC0(STRING, RAW_ARRAY, String, sha256_buffer, varray());
 	ADDFUNC0(STRING, BOOL, String, empty, varray());

--- a/doc/base/classes.xml
+++ b/doc/base/classes.xml
@@ -39294,11 +39294,29 @@
 				Perform a case-sensitive comparison to another string, return -1 if less, 0 if equal and +1 if greater.
 			</description>
 		</method>
+		<method name="decrypt_text">
+			<return type="String">
+			</return>
+			<argument index="0" name="key" type="String">
+			</argument>
+			<description>
+				Copy the String and return it decrypted.
+			</description>
+		</method>
 		<method name="empty">
 			<return type="bool">
 			</return>
 			<description>
 				Return true if the string is empty.
+			</description>
+		</method>
+		<method name="encrypt_text">
+			<return type="String">
+			</return>
+			<argument index="0" name="key" type="String">
+			</argument>
+			<description>
+				Copy the String and return it encrypted.
 			</description>
 		</method>
 		<method name="ends_with">


### PR DESCRIPTION
This merge request should fix this issue https://github.com/godotengine/godot/issues/1969

- [x] Tested using the following gdscript

```python
  var encrypt_key = 'supersecretkey'
  var original_string = {
    test = 'aAáäç,©./:\'[p',
    test2 = 156,
    as56 = '©ç9865321898#@!$%6&'
  }

  var encrypted_string = original_string.to_json().encrypt_text(encrypt_key)
  var decrypted_string = encrypted_string.decrypt_text(encrypt_key)

  print('original_string: %s' % [original_string])
  print('encrypted_string: %s' % [encrypted_string])
  print('decrypted_string: %s' % [decrypted_string])
```

I'm using it for large amount of json, and it works flawlessly