### PR TITLE
Use fake audio playing property in editor

### DIFF
--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -233,7 +233,6 @@ void AudioStreamPlayer2D::_notification(int p_what) {
 		//stop playing if no longer active
 		if (!active) {
 			set_physics_process_internal(false);
-			//do not update, this makes it easier to animate (will shut off otherwise)
 			//_change_notify("playing"); //update property in editor
 			emit_signal("finished");
 		}
@@ -313,6 +312,11 @@ void AudioStreamPlayer2D::stop() {
 
 bool AudioStreamPlayer2D::is_playing() const {
 
+#ifdef TOOLS_ENABLED
+	if (Engine::get_singleton()->is_editor_hint())
+		return fake_active;
+#endif
+
 	if (stream_playback.is_valid()) {
 		return active; // && stream_playback->is_playing();
 	}
@@ -357,11 +361,16 @@ bool AudioStreamPlayer2D::is_autoplay_enabled() {
 
 void AudioStreamPlayer2D::_set_playing(bool p_enable) {
 
+#ifdef TOOLS_ENABLED
+	fake_active = p_enable;
+#endif
+
 	if (p_enable)
 		play();
 	else
 		stop();
 }
+
 bool AudioStreamPlayer2D::_is_active() const {
 
 	return active;

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -69,6 +69,10 @@ private:
 	volatile bool active;
 	volatile float setplay;
 
+#ifdef TOOLS_ENABLED
+	volatile bool fake_active;
+#endif
+
 	float volume_db;
 	float pitch_scale;
 	bool autoplay;

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -543,7 +543,6 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 		//stop playing if no longer active
 		if (!active) {
 			set_physics_process_internal(false);
-			//do not update, this makes it easier to animate (will shut off otherwise)
 			//_change_notify("playing"); //update property in editor
 			emit_signal("finished");
 		}
@@ -641,6 +640,11 @@ void AudioStreamPlayer3D::stop() {
 
 bool AudioStreamPlayer3D::is_playing() const {
 
+#ifdef TOOLS_ENABLED
+	if (Engine::get_singleton()->is_editor_hint())
+		return fake_active;
+#endif
+
 	if (stream_playback.is_valid()) {
 		return active; // && stream_playback->is_playing();
 	}
@@ -685,11 +689,16 @@ bool AudioStreamPlayer3D::is_autoplay_enabled() {
 
 void AudioStreamPlayer3D::_set_playing(bool p_enable) {
 
+#ifdef TOOLS_ENABLED
+	fake_active = p_enable;
+#endif
+
 	if (p_enable)
 		play();
 	else
 		stop();
 }
+
 bool AudioStreamPlayer3D::_is_active() const {
 
 	return active;

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -102,6 +102,10 @@ private:
 	volatile bool active;
 	volatile float setplay;
 
+#ifdef TOOLS_ENABLED
+	volatile bool fake_active;
+#endif
+
 	AttenuationModel attenuation_model;
 	float unit_db;
 	float unit_size;

--- a/scene/audio/audio_player.cpp
+++ b/scene/audio/audio_player.cpp
@@ -127,6 +127,7 @@ void AudioStreamPlayer::_notification(int p_what) {
 		if (!active || (setseek < 0 && !stream_playback->is_playing())) {
 			active = false;
 			set_process_internal(false);
+			//_change_notify("playing"); //update property in editor
 			emit_signal("finished");
 		}
 	}
@@ -211,8 +212,13 @@ void AudioStreamPlayer::stop() {
 
 bool AudioStreamPlayer::is_playing() const {
 
+#ifdef TOOLS_ENABLED
+	if (Engine::get_singleton()->is_editor_hint())
+		return fake_active;
+#endif
+
 	if (stream_playback.is_valid()) {
-		return active; //&& stream_playback->is_playing();
+		return active; // && stream_playback->is_playing();
 	}
 
 	return false;
@@ -265,11 +271,16 @@ AudioStreamPlayer::MixTarget AudioStreamPlayer::get_mix_target() const {
 
 void AudioStreamPlayer::_set_playing(bool p_enable) {
 
+#ifdef TOOLS_ENABLED
+	fake_active = p_enable;
+#endif
+
 	if (p_enable)
 		play();
 	else
 		stop();
 }
+
 bool AudioStreamPlayer::_is_active() const {
 
 	return active;

--- a/scene/audio/audio_player.h
+++ b/scene/audio/audio_player.h
@@ -53,6 +53,10 @@ private:
 	volatile float setseek;
 	volatile bool active;
 
+#ifdef TOOLS_ENABLED
+	volatile bool fake_active;
+#endif
+
 	float mix_volume_db;
 	float pitch_scale;
 	float volume_db;


### PR DESCRIPTION
It appears that some time ago users were supposed to be able to include the playback of sound effects in their animations by placing keys on the "playing" property. Back then the key frame editor took the value of the checkbox in the property_editor.

Somewhere / Sometime this behaviour changed and the key frame editor is now reading the actual value from the object instead of relying on the property editor.

This commit introduces a fake active field that is returned when reading the playing property in the editor. While the actual active flag is changed when playback is finished the fake one will stay the same thus allowing the user to take their time with setting the key in the animation editor.

Fixes #17309

**Demo project showing off different ways to "animate" sounds:**
[audioanim.zip](https://github.com/godotengine/godot/files/1794499/audioanim.zip)
