### PR TITLE
Fix overwriting all common properties when using `Change Type` tool

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1411,6 +1411,7 @@ void SceneTreeDock::replace_node(Node *p_node, Node *p_by_node) {
 
 	Node *n = p_node;
 	Node *newnode = p_by_node;
+	Node *default_oldnode = Object::cast_to<Node>(ClassDB::instance(n->get_class()));
 	List<PropertyInfo> pinfo;
 	n->get_property_list(&pinfo);
 
@@ -1419,8 +1420,11 @@ void SceneTreeDock::replace_node(Node *p_node, Node *p_by_node) {
 			continue;
 		if (E->get().name == "__meta__")
 			continue;
-		newnode->set(E->get().name, n->get(E->get().name));
+		if (default_oldnode->get(E->get().name) != n->get(E->get().name)) {
+			newnode->set(E->get().name, n->get(E->get().name));
+		}
 	}
+	memdelete(default_oldnode);
 
 	editor->push_item(NULL);
 


### PR DESCRIPTION
Fix overwriting all common properties when using `Change Type` tool

If you change the type of an existing node, it checks if you have
modified the initial value of their properties before overwriting
their values in the new node.

For example, if you created a `Label` and changed it to
`LineEdit`, the `mouse_filter` property was created as `Ignore`
for the original `Label` node, and was maintained after changing
it to `LineEdit` causing not to work as expected. Now it checks if
`Ignore` is the default value for `Label` nodes, and as it is, the
property value is left unchanged, maintaining the default value
for `LineEdit`, which is `Stop`.

Fix #13955 and alike.