### PR TITLE
Mono: Avoid invalid class names.

### DIFF
--- a/core/script_language.h
+++ b/core/script_language.h
@@ -203,6 +203,7 @@ public:
 	virtual void make_template(const String &p_class_name, const String &p_base_class_name, Ref<Script> &p_script) {}
 	virtual bool is_using_templates() { return false; }
 	virtual bool validate(const String &p_script, int &r_line_error, int &r_col_error, String &r_test_error, const String &p_path = "", List<String> *r_functions = NULL) const = 0;
+	virtual String validate_path(const String &p_path) const { return ""; }
 	virtual Script *create_script() const = 0;
 	virtual bool has_named_classes() const = 0;
 	virtual bool supports_builtin_mode() const = 0;

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -434,6 +434,13 @@ void ScriptCreateDialog::_path_changed(const String &p_path) {
 		return;
 	}
 
+	String path_error = ScriptServer::get_language(language_menu->get_selected())->validate_path(p);
+	if (path_error != "") {
+		_msg_path_valid(false, path_error);
+		_update_dialog();
+		return;
+	}
+
 	/* All checks passed */
 
 	is_path_valid = true;

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -294,6 +294,7 @@ public:
 	virtual bool is_using_templates();
 	virtual void make_template(const String &p_class_name, const String &p_base_class_name, Ref<Script> &p_script);
 	/* TODO */ virtual bool validate(const String &p_script, int &r_line_error, int &r_col_error, String &r_test_error, const String &p_path, List<String> *r_functions) const { return true; }
+	virtual String validate_path(const String &p_path) const;
 	virtual Script *create_script() const;
 	virtual bool has_named_classes() const;
 	virtual bool supports_builtin_mode() const;


### PR DESCRIPTION
Disallow reserved keywords as class names and prefix base class with the Godot
namespace if it's the same as the class name.

Fixes #12483