### PR TITLE
Avoid confusing traceback on attempting build without platform option (failed)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2,7 +2,6 @@
 
 EnsureSConsVersion(0, 98, 1)
 
-
 import string
 import os
 import os.path
@@ -492,6 +491,7 @@ else:
     for x in platform_list:
         print("\t" + x)
     print("\nPlease run scons again with argument: platform=<string>")
+	sys.exit(255)
 
 
 screen = sys.stdout

--- a/SConstruct
+++ b/SConstruct
@@ -2,6 +2,7 @@
 
 EnsureSConsVersion(0, 98, 1)
 
+
 import string
 import os
 import os.path
@@ -491,7 +492,7 @@ else:
     for x in platform_list:
         print("\t" + x)
     print("\nPlease run scons again with argument: platform=<string>")
-	sys.exit(255)
+    sys.exit(255)
 
 
 screen = sys.stdout


### PR DESCRIPTION
A traceback is printed on invoking scons without the compulsory
platform option. This is confusing, since the problem is not in
the code. Fix is to explicitly exit from the build right after
printing the error message, so the missing env variable cannot
cause the traceback later.

Fixes #17414