### PR TITLE
Avoid confusing traceback on attempting build without platform option

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -491,6 +491,7 @@ else:
     for x in platform_list:
         print("\t" + x)
     print("\nPlease run scons again with argument: platform=<string>")
+    sys.exit(255)
 
 
 screen = sys.stdout


### PR DESCRIPTION
A traceback is printed on invoking scons without the compulsory
platform option. This is confusing, since the problem is not in
the code. Fix is to explicitly exit from the build right after
printing the error message, so the missing env variable cannot
cause the traceback later.

Fixes #17414