### PR TITLE
Added error checks for fscache saving

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -274,9 +274,13 @@ void EditorFileSystem::_scan_filesystem() {
 	memdelete(d);
 
 	f = FileAccess::open(fscache, FileAccess::WRITE);
-	_save_filesystem_cache(new_filesystem, f);
-	f->close();
-	memdelete(f);
+	if (f == NULL) {
+		ERR_PRINTS("Error writing fscache: " + fscache);
+	} else {
+		_save_filesystem_cache(new_filesystem, f);
+		f->close();
+		memdelete(f);
+	}
 
 	scanning = false;
 }
@@ -285,9 +289,13 @@ void EditorFileSystem::_save_filesystem_cache() {
 	String fscache = EditorSettings::get_singleton()->get_project_settings_path().plus_file("filesystem_cache3");
 
 	FileAccess *f = FileAccess::open(fscache, FileAccess::WRITE);
-	_save_filesystem_cache(filesystem, f);
-	f->close();
-	memdelete(f);
+	if (f == NULL) {
+		ERR_PRINTS("Error writing fscache: " + fscache);
+	} else {
+		_save_filesystem_cache(filesystem, f);
+		f->close();
+		memdelete(f);
+	}
 }
 
 void EditorFileSystem::_thread_func(void *_userdata) {

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -856,11 +856,8 @@ void EditorSettings::save() {
 	Error err = ResourceSaver::save(singleton->config_file_path, singleton);
 
 	if (err != OK) {
-		ERR_PRINT("Can't Save!");
-		return;
-	}
-
-	if (OS::get_singleton()->is_stdout_verbose()) {
+		ERR_PRINTS("Error saving editor settings to " + singleton->config_file_path);
+	} else if (OS::get_singleton()->is_stdout_verbose()) {
 		print_line("EditorSettings Save OK!");
 	}
 }


### PR DESCRIPTION
I found out about these after I started godot on a new OS install with root user by mistake and the .godot config dir got root permissions, so then when I started godot with my regular user it was crashing while trying to write the fscache.