### PR TITLE
Update TileMap when its TileSet changes

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -142,16 +142,20 @@ void TileMap::_update_quadrant_transform() {
 
 void TileMap::set_tileset(const Ref<TileSet> &p_tileset) {
 
-	if (tile_set.is_valid())
+	if (tile_set.is_valid()) {
 		tile_set->disconnect("changed", this, "_recreate_quadrants");
+		tile_set->remove_change_receptor(this);
+	}
 
 	_clear_quadrants();
 	tile_set = p_tileset;
 
-	if (tile_set.is_valid())
+	if (tile_set.is_valid()) {
 		tile_set->connect("changed", this, "_recreate_quadrants");
-	else
+		tile_set->add_change_receptor(this);
+	} else {
 		clear();
+	}
 
 	_recreate_quadrants();
 	emit_signal("settings_changed");
@@ -1573,6 +1577,12 @@ void TileMap::_bind_methods() {
 	BIND_ENUM_CONSTANT(TILE_ORIGIN_BOTTOM_LEFT);
 }
 
+void TileMap::_changed_callback(Object *p_changed, const char *p_prop) {
+	if (tile_set.is_valid() && tile_set.ptr() == p_changed) {
+		emit_signal("settings_changed");
+	}
+}
+
 TileMap::TileMap() {
 
 	rect_cache_dirty = true;
@@ -1600,6 +1610,9 @@ TileMap::TileMap() {
 }
 
 TileMap::~TileMap() {
+
+	if (tile_set.is_valid())
+		tile_set->remove_change_receptor(this);
 
 	clear();
 }

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -217,6 +217,8 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+	virtual void _changed_callback(Object *p_changed, const char *p_prop);
+
 public:
 	enum {
 		INVALID_CELL = -1


### PR DESCRIPTION
Make TileMap monitor its TileSet for changes and emit a signal when the TileSet changes. This makes the editor update and show the updated version of the TileSet.

Can be tested using the demo project in #17274 and following the steps described there.

Fixes #17274