### PR TITLE
Properly closing all files in Python build code

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -18,9 +18,8 @@ gd_cpp = '#include "project_settings.h"\n'
 gd_cpp += gd_inc
 gd_cpp += "void ProjectSettings::register_global_defaults() {\n" + gd_call + "\n}\n"
 
-f = open("global_defaults.gen.cpp", "w")
-f.write(gd_cpp)
-f.close()
+with open("global_defaults.gen.cpp", "w") as f:
+	f.write(gd_cpp)
 
 
 # Generate AES256 script encryption key
@@ -47,9 +46,8 @@ if ("SCRIPT_AES256_ENCRYPTION_KEY" in os.environ):
         txt = "0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0"
         print("Invalid AES256 encryption key, not 64 bits hex: " + e)
 
-f = open("script_encryption_key.gen.cpp", "w")
-f.write("#include \"project_settings.h\"\nuint8_t script_encryption_key[32]={" + txt + "};\n")
-f.close()
+with open("script_encryption_key.gen.cpp", "w") as f:
+	f.write("#include \"project_settings.h\"\nuint8_t script_encryption_key[32]={" + txt + "};\n")
 
 
 # Add required thirdparty code. Header paths are hardcoded, we don't need to append

--- a/core/make_binders.py
+++ b/core/make_binders.py
@@ -265,10 +265,8 @@ def run(target, source, env):
         else:
             text += t
 
-    f = open(target[0].path, "w")
-    f.write(text)
-    f.close()
+    with open(target[0].path, "w") as f:
+        f.write(text)
 
-    f = open(target[1].path, "w")
-    f.write(text_ext)
-    f.close()
+    with open(target[1].path, "w") as f:
+        f.write(text_ext)

--- a/doc/tools/makemd.py
+++ b/doc/tools/makemd.py
@@ -93,6 +93,8 @@ def make_class_list(class_list, columns):
         s += '\n'
         f.write(s)
 
+    f.close()
+
 
 def dokuize_text(txt):
 
@@ -330,6 +332,8 @@ def make_doku_class(node):
             f.write('\n')
             f.write(dokuize_text(d.text.strip()))
             f.write('\n')
+   
+    f.close()
 
 
 for file in input_list:

--- a/doc/tools/makerst.py
+++ b/doc/tools/makerst.py
@@ -104,6 +104,7 @@ def make_class_list(class_list, columns):
         f.write("--+-------+")
     f.write("\n")
 
+    f.close()
 
 def rstize_text(text, cclass):
     # Linebreak + tabs in the XML should become two line breaks unless in a "codeblock"
@@ -571,6 +572,8 @@ def make_rst_class(node):
             f.write(rstize_text(d.text.strip(), name))
             f.write("\n\n")
         f.write('\n')
+
+    f.close()
 
 
 file_list = []

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -4,6 +4,7 @@ Import('env')
 env.editor_sources = []
 
 import os
+import os.path
 from compat import encode_utf8, byte_to_str, open_utf8, escape_string
 
 
@@ -29,6 +30,9 @@ def make_certs_header(target, source, env):
     g.write("};\n")
     g.write("#endif")
 
+    g.close()
+    f.close()
+
 
 def make_doc_header(target, source, env):
 
@@ -41,8 +45,8 @@ def make_doc_header(target, source, env):
         src = s.srcnode().abspath
         if not src.endswith(".xml"):
             continue
-        f = open_utf8(src, "r")
-        content = f.read()
+        with open_utf8(src, "r") as f:
+            content = f.read()
         buf += content
 
     buf = encode_utf8(docbegin + buf + docend)
@@ -62,6 +66,8 @@ def make_doc_header(target, source, env):
 
     g.write("#endif")
 
+    g.close()
+
 
 def make_fonts_header(target, source, env):
 
@@ -76,9 +82,8 @@ def make_fonts_header(target, source, env):
     # saving uncompressed, since freetype will reference from memory pointer
     xl_names = []
     for i in range(len(source)):
-        f = open(source[i].srcnode().abspath, "rb")
-        buf = f.read()
-        import os.path
+        with open(source[i].srcnode().abspath, "rb")as f:
+            buf = f.read()
 
         name = os.path.splitext(os.path.basename(source[i].srcnode().abspath))[0]
 
@@ -90,6 +95,8 @@ def make_fonts_header(target, source, env):
         g.write("};\n")
 
     g.write("#endif")
+
+    g.close()
 
 
 def make_translations_header(target, source, env):
@@ -110,8 +117,8 @@ def make_translations_header(target, source, env):
 
     xl_names = []
     for i in range(len(sorted_paths)):
-        f = open(sorted_paths[i], "rb")
-        buf = f.read()
+        with open(sorted_paths[i], "rb") as f:
+            buf = f.read()
         decomp_size = len(buf)
         buf = zlib.compress(buf)
         name = os.path.splitext(os.path.basename(sorted_paths[i]))[0]
@@ -137,6 +144,9 @@ def make_translations_header(target, source, env):
     g.write("};\n")
 
     g.write("#endif")
+
+    g.close()
+
 
 def make_authors_header(target, source, env):
 
@@ -180,6 +190,9 @@ def make_authors_header(target, source, env):
 
     g.write("#endif\n")
 
+    g.close()
+    f.close()
+
 def make_donors_header(target, source, env):
 
     sections = ["Platinum sponsors", "Gold sponsors", "Mini sponsors", "Gold donors", "Silver donors", "Bronze donors"]
@@ -221,6 +234,10 @@ def make_donors_header(target, source, env):
         close_section()
 
     g.write("#endif\n")
+
+    g.close()
+    f.close()
+
 
 def make_license_header(target, source, env):
 
@@ -387,17 +404,23 @@ def make_license_header(target, source, env):
 
     g.write("#endif\n")
 
+    g.close()
+    fc.close()
+    f.close()
+
 
 def _make_doc_data_class_path(to_path):
-      g = open_utf8(os.path.join(to_path,"doc_data_class_path.gen.h"), "w")
-      g.write("static const int _doc_data_class_path_count = " + str(len(env.doc_class_path)) + ";\n")
-      g.write("struct _DocDataClassPath { const char* name; const char* path; };\n")
+    g = open_utf8(os.path.join(to_path,"doc_data_class_path.gen.h"), "w")
+    g.write("static const int _doc_data_class_path_count = " + str(len(env.doc_class_path)) + ";\n")
+    g.write("struct _DocDataClassPath { const char* name; const char* path; };\n")
 
-      g.write("static const _DocDataClassPath _doc_data_class_paths[" + str(len(env.doc_class_path) + 1) + "] = {\n");
-      for c in sorted(env.doc_class_path):
-          g.write("\t{\"" + c + "\", \"" + env.doc_class_path[c] + "\"},\n")
-      g.write("\t{NULL, NULL}\n")
-      g.write("};\n")
+    g.write("static const _DocDataClassPath _doc_data_class_paths[" + str(len(env.doc_class_path) + 1) + "] = {\n");
+    for c in sorted(env.doc_class_path):
+        g.write("\t{\"" + c + "\", \"" + env.doc_class_path[c] + "\"},\n")
+    g.write("\t{NULL, NULL}\n")
+    g.write("};\n")
+
+    g.close()
 
 
 if env['tools']:
@@ -409,10 +432,9 @@ if env['tools']:
         reg_exporters += '\tregister_' + e + '_exporter();\n'
         reg_exporters_inc += '#include "platform/' + e + '/export/export.h"\n'
     reg_exporters += '}\n'
-    f = open_utf8("register_exporters.gen.cpp", "w")
-    f.write(reg_exporters_inc)
-    f.write(reg_exporters)
-    f.close()
+    with open_utf8("register_exporters.gen.cpp", "w") as f:
+        f.write(reg_exporters_inc)
+        f.write(reg_exporters)
 
     # API documentation
     docs = []

--- a/editor/icons/SCsub
+++ b/editor/icons/SCsub
@@ -82,10 +82,9 @@ def make_editor_icons_action(target, source, env):
 
     s.write("#endif\n")
 
+    with open(dst, "w") as f:
+        f.write(s.getvalue())
 
-    f = open(dst, "w")
-    f.write(s.getvalue())
-    f.close()
     s.close()
     icons_string.close()
 

--- a/editor/translations/extract.py
+++ b/editor/translations/extract.py
@@ -52,11 +52,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8-bit\\n"
 """
 
-print("Updating the editor.pot template...")
-
-for fname in matches:
-
-    f = open(fname, "rb")
+def process_file(f, fname):
 
     l = f.readline()
     lc = 1
@@ -100,12 +96,14 @@ for fname in matches:
         l = f.readline()
         lc += 1
 
-    f.close()
+print("Updating the editor.pot template...")
 
+for fname in matches:
+    with open(fname, "rb") as f:
+        process_file(f, fname)
 
-f = open("editor.pot", "wb")
-f.write(main_po)
-f.close()
+with open("editor.pot", "wb") as f:
+    f.write(main_po)
 
 if (os.name == "posix"):
     print("Wrapping template at 79 characters for compatibility with Weblate.")

--- a/main/SCsub
+++ b/main/SCsub
@@ -8,60 +8,59 @@ def make_splash(target, source, env):
 
     src = source[0].srcnode().abspath
     dst = target[0].srcnode().abspath
-    f = open(src, "rb")
-    g = open(dst, "w")
 
-    buf = f.read()
+    with open(src, "rb") as f:
+        buf = f.read()
 
-    g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
-    g.write("#ifndef BOOT_SPLASH_H\n")
-    g.write("#define BOOT_SPLASH_H\n")
-    g.write('static const Color boot_splash_bg_color = Color::html("#232323");\n')
-    g.write("static const unsigned char boot_splash_png[] = {\n")
-    for i in range(len(buf)):
-        g.write(byte_to_str(buf[i]) + ",\n")
-    g.write("};\n")
-    g.write("#endif")
+    with open(dst, "w") as g:
+        g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
+        g.write("#ifndef BOOT_SPLASH_H\n")
+        g.write("#define BOOT_SPLASH_H\n")
+        g.write('static const Color boot_splash_bg_color = Color::html("#232323");\n')
+        g.write("static const unsigned char boot_splash_png[] = {\n")
+        for i in range(len(buf)):
+            g.write(byte_to_str(buf[i]) + ",\n")
+        g.write("};\n")
+        g.write("#endif")
 
 
 def make_splash_editor(target, source, env):
 
     src = source[0].srcnode().abspath
     dst = target[0].srcnode().abspath
-    f = open(src, "rb")
-    g = open(dst, "w")
 
-    buf = f.read()
+    with open(src, "rb") as f:
+        buf = f.read()
 
-    g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
-    g.write("#ifndef BOOT_SPLASH_EDITOR_H\n")
-    g.write("#define BOOT_SPLASH_EDITOR_H\n")
-    g.write('static const Color boot_splash_editor_bg_color = Color::html("#232323");\n')
-    g.write("static const unsigned char boot_splash_editor_png[] = {\n")
-    for i in range(len(buf)):
-        g.write(byte_to_str(buf[i]) + ",\n")
-    g.write("};\n")
-    g.write("#endif")
-
+    with open(dst, "w") as g:
+        g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
+        g.write("#ifndef BOOT_SPLASH_EDITOR_H\n")
+        g.write("#define BOOT_SPLASH_EDITOR_H\n")
+        g.write('static const Color boot_splash_editor_bg_color = Color::html("#232323");\n')
+        g.write("static const unsigned char boot_splash_editor_png[] = {\n")
+        for i in range(len(buf)):
+            g.write(byte_to_str(buf[i]) + ",\n")
+        g.write("};\n")
+        g.write("#endif")
 
 
 def make_app_icon(target, source, env):
 
     src = source[0].srcnode().abspath
     dst = target[0].srcnode().abspath
-    f = open(src, "rb")
-    g = open(dst, "w")
 
-    buf = f.read()
+    with open(src, "rb") as f:
+        buf = f.read()
 
-    g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
-    g.write("#ifndef APP_ICON_H\n")
-    g.write("#define APP_ICON_H\n")
-    g.write("static const unsigned char app_icon_png[] = {\n")
-    for i in range(len(buf)):
-        g.write(byte_to_str(buf[i]) + ",\n")
-    g.write("};\n")
-    g.write("#endif")
+    with open(dst, "w") as g:
+        g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
+        g.write("#ifndef APP_ICON_H\n")
+        g.write("#define APP_ICON_H\n")
+        g.write("static const unsigned char app_icon_png[] = {\n")
+        for i in range(len(buf)):
+            g.write(byte_to_str(buf[i]) + ",\n")
+        g.write("};\n")
+        g.write("#endif")
 
 
 env.main_sources = []

--- a/methods.py
+++ b/methods.py
@@ -597,6 +597,9 @@ def parse_cg_file(fname, uniforms, sizes, conditionals):
 
         line = fs.readline()
 
+    fs.close()
+
+
 import glob
 
 
@@ -644,8 +647,8 @@ void unregister_module_types() {
 }
 """
 
-    f = open("modules/register_module_types.gen.cpp", "w")
-    f.write(modules_cpp)
+    with open("modules/register_module_types.gen.cpp", "w") as f:
+        f.write(modules_cpp)
 
     return module_list
 
@@ -744,18 +747,18 @@ def android_add_default_config(self, config):
 
 def android_add_to_manifest(self, file):
     base_path = self.Dir(".").abspath + "/modules/" + self.current_module + "/" + file
-    f = open(base_path, "r")
-    self.android_manifest_chunk += f.read()
+    with open(base_path, "r") as f:
+        self.android_manifest_chunk += f.read()
 
 def android_add_to_permissions(self, file):
     base_path = self.Dir(".").abspath + "/modules/" + self.current_module + "/" + file
-    f = open(base_path, "r")
-    self.android_permission_chunk += f.read()
+    with open(base_path, "r") as f:
+        self.android_permission_chunk += f.read()
 
 def android_add_to_attributes(self, file):
     base_path = self.Dir(".").abspath + "/modules/" + self.current_module + "/" + file
-    f = open(base_path, "r")
-    self.android_appattributes_chunk += f.read()
+    with open(base_path, "r") as f:
+        self.android_appattributes_chunk += f.read()
 
 def disable_module(self):
     self.disabled_modules.append(self.current_module)
@@ -886,9 +889,11 @@ def save_active_platforms(apnames, ap):
 
             str += "};\n"
 
+            pngf.close()
+
             wf = x + "/" + name + ".gen.h"
-            pngw = open(wf, "w")
-            pngw.write(str)
+            with open(wf, "w") as pngw:
+                pngw.write(str)
 
 
 def no_verbose(sys, env):
@@ -1048,8 +1053,8 @@ def generate_cpp_hint_file(filename):
         pass
     else:
         try:
-            fd = open(filename, "w")
-            fd.write("#define GDCLASS(m_class, m_inherits)\n")
+            with open(filename, "w") as fd:
+                fd.write("#define GDCLASS(m_class, m_inherits)\n")
         except IOError:
             print("Could not write cpp.hint file.")
 

--- a/misc/scripts/fix_headers.py
+++ b/misc/scripts/fix_headers.py
@@ -92,9 +92,11 @@ while (fname != ""):
     fileread.close()
 
     # Write
-    fileread = open(fname.strip(), "wb")
-    fileread.write(text)
-    fileread.close()
+    filewrite = open(fname.strip(), "wb")
+    filewrite.write(text)
+    filewrite.close()
 
     # Next file
     fname = files.readline()
+
+files.close()

--- a/misc/scripts/make_glwrapper.py
+++ b/misc/scripts/make_glwrapper.py
@@ -16,9 +16,7 @@ READ_CONSTANTS = 2
 
 read_what = READ_TYPES
 
-for x in (range(len(sys.argv) - 1)):
-    f = open(sys.argv[x + 1], "r")
-
+def read_file(f):
     while(True):
 
         line = f.readline()
@@ -86,6 +84,9 @@ for x in (range(len(sys.argv) - 1)):
             functions.append(funcdata)
             print(funcdata)
 
+for path in sys.argv[1:]:
+    with open(path, "r") as f:
+        read_file(f)
 
 # print(types)
 # print(constants)
@@ -156,6 +157,7 @@ f.write("void glWrapperInit( GLWrapperFuncPtr (*wrapperFunc)(const char*) );\n")
 f.write("#ifdef __cplusplus\n}\n#endif\n")
 
 f.write("#endif\n\n")
+f.close()
 
 f = open("glwrapper.c", "w")
 
@@ -176,3 +178,4 @@ for x in functions:
 f.write("\n\n")
 f.write("}\n")
 f.write("\n\n")
+f.close()

--- a/platform/SCsub
+++ b/platform/SCsub
@@ -18,11 +18,10 @@ for platform in env.platform_apis:
 reg_apis_inc += '\n'
 reg_apis += '}\n\n'
 unreg_apis += '}\n'
-f = open_utf8('register_platform_apis.gen.cpp', 'w')
-f.write(reg_apis_inc)
-f.write(reg_apis)
-f.write(unreg_apis)
-f.close()
+with open_utf8('register_platform_apis.gen.cpp', 'w') as f:
+	f.write(reg_apis_inc)
+	f.write(reg_apis)
+	f.write(unreg_apis)
 platform_sources.append('register_platform_apis.gen.cpp')
 
 lib = env.add_library('platform', platform_sources)

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -41,10 +41,8 @@ prog = None
 abspath = env.Dir(".").abspath
 
 
-gradle_basein = open_utf8(abspath + "/build.gradle.template", "r")
-gradle_baseout = open_utf8(abspath + "/java/build.gradle", "w")
-
-gradle_text = gradle_basein.read()
+with open_utf8(abspath + "/build.gradle.template", "r") as gradle_basein:
+	gradle_text = gradle_basein.read()
 
 gradle_maven_flat_text = ""
 if len(env.android_flat_dirs) > 0:
@@ -131,17 +129,19 @@ gradle_text = gradle_text.replace("$$GRADLE_DEFAULT_CONFIG$$", gradle_default_co
 gradle_text = gradle_text.replace("$$GRADLE_PLUGINS$$", gradle_plugins)
 gradle_text = gradle_text.replace("$$GRADLE_CLASSPATH$$", gradle_classpath)
 
-gradle_baseout.write(gradle_text)
-gradle_baseout.close()
+with open_utf8(abspath + "/java/build.gradle", "w") as gradle_baseout:
+	gradle_baseout.write(gradle_text)
 
 
-pp_basein = open_utf8(abspath + "/AndroidManifest.xml.template", "r")
-pp_baseout = open_utf8(abspath + "/java/AndroidManifest.xml", "w")
-manifest = pp_basein.read()
+with open_utf8(abspath + "/AndroidManifest.xml.template", "r") as pp_basein:
+	manifest = pp_basein.read()
+
 manifest = manifest.replace("$$ADD_APPLICATION_CHUNKS$$", env.android_manifest_chunk)
 manifest = manifest.replace("$$ADD_PERMISSION_CHUNKS$$", env.android_permission_chunk)
 manifest = manifest.replace("$$ADD_APPATTRIBUTE_CHUNKS$$", env.android_appattributes_chunk)
-pp_baseout.write(manifest)
+
+with open_utf8(abspath + "/java/AndroidManifest.xml", "w") as pp_baseout:
+	pp_baseout.write(manifest)
 
 
 lib = env_android.add_shared_library("#bin/libgodot", [android_objects], SHLIBSUFFIX=env["SHLIBSUFFIX"])


### PR DESCRIPTION
Properly close all files everywhere in Python build code. Using the Python **with** statement for file context wherever it did not need too much refactoring. Explicit close calls are added in all other cases.

Related to #5042