### PR TITLE
Allow configuration of which mouse buttons the BaseButton responds to

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -15,7 +15,7 @@
 			<return type="void">
 			</return>
 			<description>
-				Called when button is pressed.
+				Called when the button is pressed.
 			</description>
 		</method>
 		<method name="_toggled" qualifiers="virtual">
@@ -24,7 +24,7 @@
 			<argument index="0" name="button_pressed" type="bool">
 			</argument>
 			<description>
-				Called when button is toggled (only if toggle_mode is active).
+				Called when the button is toggled (only if toggle_mode is active).
 			</description>
 		</method>
 		<method name="get_draw_mode" qualifiers="const">
@@ -38,13 +38,17 @@
 			<return type="bool">
 			</return>
 			<description>
-				Return true if mouse entered the button before it exit.
+				Return true if the mouse has entered the button and has not left it yet.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="action_mode" type="int" setter="set_action_mode" getter="get_action_mode" enum="BaseButton.ActionMode">
 			Determines when the button is considered clicked, one of the ACTION_MODE_* constants.
+		</member>
+		<member name="button_mask" type="int" setter="set_button_mask" getter="get_button_mask">
+			Binary mask to choose which mouse buttons this button will respond to.
+			To allow both left-click and right-click, set this to 3, because it's BUTTON_MASK_LEFT | BUTTON_MASK_RIGHT.
 		</member>
 		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled">
 			If [code]true[/code] the button is in disabled state and can't be clicked or toggled.

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -60,7 +60,7 @@ void BaseButton::_gui_input(Ref<InputEvent> p_event) {
 	Ref<InputEventMouseButton> b = p_event;
 
 	if (b.is_valid()) {
-		if (status.disabled || b->get_button_index() != 1)
+		if (status.disabled || ((1 << (b->get_button_index() - 1)) & button_mask) == 0)
 			return;
 
 		if (status.pressing_button)
@@ -403,6 +403,16 @@ BaseButton::ActionMode BaseButton::get_action_mode() const {
 	return action_mode;
 }
 
+void BaseButton::set_button_mask(int p_mask) {
+
+	button_mask = p_mask;
+}
+
+int BaseButton::get_button_mask() const {
+
+	return button_mask;
+}
+
 void BaseButton::set_enabled_focus_mode(FocusMode p_mode) {
 
 	enabled_focus_mode = p_mode;
@@ -491,6 +501,8 @@ void BaseButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_disabled"), &BaseButton::is_disabled);
 	ClassDB::bind_method(D_METHOD("set_action_mode", "mode"), &BaseButton::set_action_mode);
 	ClassDB::bind_method(D_METHOD("get_action_mode"), &BaseButton::get_action_mode);
+	ClassDB::bind_method(D_METHOD("set_button_mask", "mask"), &BaseButton::set_button_mask);
+	ClassDB::bind_method(D_METHOD("get_button_mask"), &BaseButton::get_button_mask);
 	ClassDB::bind_method(D_METHOD("get_draw_mode"), &BaseButton::get_draw_mode);
 	ClassDB::bind_method(D_METHOD("set_enabled_focus_mode", "mode"), &BaseButton::set_enabled_focus_mode);
 	ClassDB::bind_method(D_METHOD("get_enabled_focus_mode"), &BaseButton::get_enabled_focus_mode);
@@ -512,6 +524,7 @@ void BaseButton::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "toggle_mode"), "set_toggle_mode", "is_toggle_mode");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::BOOL, "pressed"), "set_pressed", "is_pressed");
 	ADD_PROPERTYNO(PropertyInfo(Variant::INT, "action_mode", PROPERTY_HINT_ENUM, "Button Press,Button Release"), "set_action_mode", "get_action_mode");
+	ADD_PROPERTYNO(PropertyInfo(Variant::INT, "button_mask", PROPERTY_HINT_FLAGS, "Mouse Left, Mouse Right, Mouse Middle"), "set_button_mask", "get_button_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "enabled_focus_mode", PROPERTY_HINT_ENUM, "None,Click,All"), "set_enabled_focus_mode", "get_enabled_focus_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shortcut", PROPERTY_HINT_RESOURCE_TYPE, "ShortCut"), "set_shortcut", "get_shortcut");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "group", PROPERTY_HINT_RESOURCE_TYPE, "ButtonGroup"), "set_button_group", "get_button_group");
@@ -537,6 +550,7 @@ BaseButton::BaseButton() {
 	set_focus_mode(FOCUS_ALL);
 	enabled_focus_mode = FOCUS_ALL;
 	action_mode = ACTION_MODE_BUTTON_RELEASE;
+	button_mask = BUTTON_MASK_LEFT;
 }
 
 BaseButton::~BaseButton() {

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -49,6 +49,7 @@ public:
 	};
 
 private:
+	int button_mask;
 	bool toggle_mode;
 	FocusMode enabled_focus_mode;
 	Ref<ShortCut> shortcut;
@@ -103,6 +104,9 @@ public:
 
 	void set_action_mode(ActionMode p_mode);
 	ActionMode get_action_mode() const;
+
+	void set_button_mask(int p_mask);
+	int get_button_mask() const;
 
 	void set_enabled_focus_mode(FocusMode p_mode);
 	FocusMode get_enabled_focus_mode() const;


### PR DESCRIPTION
Not sure if I'm doing this right, but this was the only easy way I found to get right-click and middle-click support on the buttons of my game, with theme change, signals and all the other goodies.

The button responsible for the trigger should probably also be provided to `_pressed` or even `_toggled`, and to signals as well, but that would break compatibility. For now, there are other ways to get which mouse button has been pressed in the `_pressed` callback, because `_gui_input` is always triggered first and knows it in its `event`.

This commit also leverages the existing `BUTTON_MASK_*` constants, which fitted quite nicely.