### PR TITLE
Fixes importing hdr files with extra header info

### DIFF
--- a/modules/hdr/image_loader_hdr.cpp
+++ b/modules/hdr/image_loader_hdr.cpp
@@ -42,14 +42,18 @@ Error ImageLoaderHDR::load_image(Ref<Image> p_image, FileAccess *f, bool p_force
 	ERR_FAIL_COND_V(header != "#?RADIANCE" && header != "#?RGBE", ERR_FILE_UNRECOGNIZED);
 
 	while (true) {
-		String format = f->get_token();
+		String line = f->get_line();
 		ERR_FAIL_COND_V(f->eof_reached(), ERR_FILE_UNRECOGNIZED);
-		if (format.begins_with("FORMAT=") && format != "FORMAT=32-bit_rle_rgbe") {
-			ERR_EXPLAIN("Only 32-bit_rle_rgbe is supported for .hdr files.");
-			return ERR_FILE_UNRECOGNIZED;
-		}
-		if (format == "FORMAT=32-bit_rle_rgbe")
+		if (line == "") // empty line indicates end of header
 			break;
+		if (line.begins_with("FORMAT=")) { // leave option to implement other commands
+			if (line != "FORMAT=32-bit_rle_rgbe") {
+				ERR_EXPLAIN("Only 32-bit_rle_rgbe is supported for HDR files.");
+				return ERR_FILE_UNRECOGNIZED;
+			}
+		} else if (!line.begins_with("#")) { // not comment
+			WARN_PRINTS("Ignoring unsupported header information in HDR : " + line);
+		}
 	}
 
 	String token = f->get_token();


### PR DESCRIPTION
When importing a .hdr file (Radiance HDR file format) that has more commands/variables in the header information, such as EXPOSURE= or GAMMA=, the process failed and the texture could not be used even though it's perfectly fine:
```
modules\hdr\image_loader_hdr.cpp:57 - Condition ' token != "-Y" ' is true. returned: ERR_FILE_CORRUPT
```
After inspecting the code, it was clear it doesn't allow any other commands in the header apart from the FORMAT. It then expects the resolution. It should read all header information until an empty line is found (end of header) and then look for the resolution.

References:
http://paulbourke.net/dataformats/pic/
https://en.wikipedia.org/wiki/Radiance_(software)#HDR_image_format
http://radsite.lbl.gov/radiance/refer/Notes/picture_format.html
Mirror of Radiance source code: https://github.com/NREL/Radiance

Fixes #17447