### PR TITLE
Expose colour channel masking to spatial material shaders.

### DIFF
--- a/doc/classes/SpatialMaterial.xml
+++ b/doc/classes/SpatialMaterial.xml
@@ -40,6 +40,14 @@
 		</member>
 		<member name="clearcoat_texture" type="Texture" setter="set_texture" getter="get_texture">
 		</member>
+		<member name="color_channels_a" type="bool" setter="set_color_channel" getter="get_color_channel">
+		</member>
+		<member name="color_channels_b" type="bool" setter="set_color_channel" getter="get_color_channel">
+		</member>
+		<member name="color_channels_g" type="bool" setter="set_color_channel" getter="get_color_channel">
+		</member>
+		<member name="color_channels_r" type="bool" setter="set_color_channel" getter="get_color_channel">
+		</member>
 		<member name="depth_deep_parallax" type="bool" setter="set_depth_deep_parallax" getter="is_depth_deep_parallax_enabled">
 		</member>
 		<member name="depth_enabled" type="bool" setter="set_feature" getter="get_feature">
@@ -317,6 +325,16 @@
 		<constant name="FLAG_ALBEDO_TEXTURE_FORCE_SRGB" value="13" enum="Flags">
 		</constant>
 		<constant name="FLAG_MAX" value="14" enum="Flags">
+		</constant>
+		<constant name="COLOR_CHANNEL_RED" value="0" enum="ColorChannel">
+		</constant>
+		<constant name="COLOR_CHANNEL_GREEN" value="1" enum="ColorChannel">
+		</constant>
+		<constant name="COLOR_CHANNEL_BLUE" value="2" enum="ColorChannel">
+		</constant>
+		<constant name="COLOR_CHANNEL_ALPHA" value="3" enum="ColorChannel">
+		</constant>
+		<constant name="COLOR_CHANNEL_MAX" value="4" enum="ColorChannel">
 		</constant>
 		<constant name="DIFFUSE_BURLEY" value="0" enum="DiffuseMode">
 		</constant>

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1584,7 +1584,8 @@ void RasterizerCanvasGLES3::reset_canvas() {
 
 	if (storage->frame.current_rt) {
 		glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->fbo);
-		glColorMask(1, 1, 1, 1); //don't touch alpha
+		scene_render->state.color_write_disabled = false;
+		scene_render->_set_color_mask(true, true, true, true); //don't touch alpha
 	}
 
 	glBindVertexArray(0);

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -197,9 +197,14 @@ public:
 
 		bool cull_front;
 		bool cull_disabled;
+		bool color_mask_red;
+		bool color_mask_green;
+		bool color_mask_blue;
+		bool color_mask_alpha;
 		bool used_sss;
 		bool used_screen_texture;
 		bool using_contact_shadows;
+		bool color_write_disabled;
 
 		VS::ViewportDebugDraw debug_draw;
 	} state;
@@ -812,6 +817,7 @@ public:
 	RenderList render_list;
 
 	_FORCE_INLINE_ void _set_cull(bool p_front, bool p_disabled, bool p_reverse_cull);
+	_FORCE_INLINE_ void _set_color_mask(bool p_color_mask_red, bool p_color_mask_green, bool p_color_mask_blue, bool p_color_mask_alpha);
 
 	_FORCE_INLINE_ bool _setup_material(RasterizerStorageGLES3::Material *p_material, bool p_alpha_pass);
 	_FORCE_INLINE_ void _setup_geometry(RenderList::Element *e, const Transform &p_view_transform);

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -1646,6 +1646,10 @@ void RasterizerStorageGLES3::_update_shader(Shader *p_shader) const {
 			p_shader->spatial.uses_vertex = false;
 			p_shader->spatial.writes_modelview_or_projection = false;
 			p_shader->spatial.uses_world_coordinates = false;
+			p_shader->spatial.disable_channel_r = false;
+			p_shader->spatial.disable_channel_g = false;
+			p_shader->spatial.disable_channel_b = false;
+			p_shader->spatial.disable_channel_a = false;
 
 			shaders.actions_scene.render_mode_values["blend_add"] = Pair<int *, int>(&p_shader->spatial.blend_mode, Shader::Spatial::BLEND_MODE_ADD);
 			shaders.actions_scene.render_mode_values["blend_mix"] = Pair<int *, int>(&p_shader->spatial.blend_mode, Shader::Spatial::BLEND_MODE_MIX);
@@ -1656,6 +1660,11 @@ void RasterizerStorageGLES3::_update_shader(Shader *p_shader) const {
 			shaders.actions_scene.render_mode_values["depth_draw_always"] = Pair<int *, int>(&p_shader->spatial.depth_draw_mode, Shader::Spatial::DEPTH_DRAW_ALWAYS);
 			shaders.actions_scene.render_mode_values["depth_draw_never"] = Pair<int *, int>(&p_shader->spatial.depth_draw_mode, Shader::Spatial::DEPTH_DRAW_NEVER);
 			shaders.actions_scene.render_mode_values["depth_draw_alpha_prepass"] = Pair<int *, int>(&p_shader->spatial.depth_draw_mode, Shader::Spatial::DEPTH_DRAW_ALPHA_PREPASS);
+
+			shaders.actions_scene.render_mode_flags["disable_channel_r"] = &p_shader->spatial.disable_channel_r;
+			shaders.actions_scene.render_mode_flags["disable_channel_g"] = &p_shader->spatial.disable_channel_g;
+			shaders.actions_scene.render_mode_flags["disable_channel_b"] = &p_shader->spatial.disable_channel_b;
+			shaders.actions_scene.render_mode_flags["disable_channel_a"] = &p_shader->spatial.disable_channel_a;
 
 			shaders.actions_scene.render_mode_values["cull_front"] = Pair<int *, int>(&p_shader->spatial.cull_mode, Shader::Spatial::CULL_MODE_FRONT);
 			shaders.actions_scene.render_mode_values["cull_back"] = Pair<int *, int>(&p_shader->spatial.cull_mode, Shader::Spatial::CULL_MODE_BACK);

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -478,6 +478,10 @@ public:
 			bool writes_modelview_or_projection;
 			bool uses_vertex_lighting;
 			bool uses_world_coordinates;
+			bool disable_channel_r;
+			bool disable_channel_g;
+			bool disable_channel_b;
+			bool disable_channel_a;
 
 		} spatial;
 

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -391,6 +391,20 @@ void SpatialMaterial::_update_shader() {
 	if (flags[FLAG_TRIPLANAR_USE_WORLD] && (flags[FLAG_UV1_USE_TRIPLANAR] || flags[FLAG_UV2_USE_TRIPLANAR])) {
 		code += ",world_vertex_coords";
 	}
+
+	if (!color_channels[COLOR_CHANNEL_RED]) {
+		code += ",disable_channel_r";
+	}
+	if (!color_channels[COLOR_CHANNEL_GREEN]) {
+		code += ",disable_channel_g";
+	}
+	if (!color_channels[COLOR_CHANNEL_BLUE]) {
+		code += ",disable_channel_b";
+	}
+	if (!color_channels[COLOR_CHANNEL_ALPHA]) {
+		code += ",disable_channel_a";
+	}
+
 	code += ";\n";
 
 	code += "uniform vec4 albedo : hint_color;\n";
@@ -1242,6 +1256,23 @@ bool SpatialMaterial::get_feature(Feature p_feature) const {
 	return features[p_feature];
 }
 
+void SpatialMaterial::set_color_channel(ColorChannel p_color_channel, bool p_enabled) {
+
+	ERR_FAIL_INDEX(p_color_channel, COLOR_CHANNEL_MAX);
+	if (color_channels[p_color_channel] == p_enabled)
+		return;
+
+	color_channels[p_color_channel] = p_enabled;
+	_change_notify();
+	_queue_shader_change();
+}
+
+bool SpatialMaterial::get_color_channel(ColorChannel p_color_channel) const {
+
+	ERR_FAIL_INDEX_V(p_color_channel, COLOR_CHANNEL_MAX, false);
+	return color_channels[p_color_channel];
+}
+
 void SpatialMaterial::set_texture(TextureParam p_param, const Ref<Texture> &p_texture) {
 
 	ERR_FAIL_INDEX(p_param, TEXTURE_MAX);
@@ -1753,6 +1784,9 @@ void SpatialMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_feature", "feature", "enable"), &SpatialMaterial::set_feature);
 	ClassDB::bind_method(D_METHOD("get_feature", "feature"), &SpatialMaterial::get_feature);
 
+	ClassDB::bind_method(D_METHOD("set_color_channel", "color_channel", "enable"), &SpatialMaterial::set_color_channel);
+	ClassDB::bind_method(D_METHOD("get_color_channel", "color_channel"), &SpatialMaterial::get_color_channel);
+
 	ClassDB::bind_method(D_METHOD("set_texture", "param", "texture"), &SpatialMaterial::set_texture);
 	ClassDB::bind_method(D_METHOD("get_texture", "param"), &SpatialMaterial::get_texture);
 
@@ -1852,6 +1886,12 @@ void SpatialMaterial::_bind_methods() {
 	ADD_GROUP("Vertex Color", "vertex_color");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "vertex_color_use_as_albedo"), "set_flag", "get_flag", FLAG_ALBEDO_FROM_VERTEX_COLOR);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "vertex_color_is_srgb"), "set_flag", "get_flag", FLAG_SRGB_VERTEX_COLOR);
+
+	ADD_GROUP("Color Channels", "color_channels_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "color_channels_r"), "set_color_channel", "get_color_channel", COLOR_CHANNEL_RED);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "color_channels_g"), "set_color_channel", "get_color_channel", COLOR_CHANNEL_GREEN);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "color_channels_b"), "set_color_channel", "get_color_channel", COLOR_CHANNEL_BLUE);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "color_channels_a"), "set_color_channel", "get_color_channel", COLOR_CHANNEL_ALPHA);
 
 	ADD_GROUP("Parameters", "params_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_diffuse_mode", PROPERTY_HINT_ENUM, "Burley,Lambert,Lambert Wrap,Oren Nayar,Toon"), "set_diffuse_mode", "get_diffuse_mode");
@@ -2040,6 +2080,12 @@ void SpatialMaterial::_bind_methods() {
 	BIND_ENUM_CONSTANT(FLAG_ALBEDO_TEXTURE_FORCE_SRGB);
 	BIND_ENUM_CONSTANT(FLAG_MAX);
 
+	BIND_ENUM_CONSTANT(COLOR_CHANNEL_RED);
+	BIND_ENUM_CONSTANT(COLOR_CHANNEL_GREEN);
+	BIND_ENUM_CONSTANT(COLOR_CHANNEL_BLUE);
+	BIND_ENUM_CONSTANT(COLOR_CHANNEL_ALPHA);
+	BIND_ENUM_CONSTANT(COLOR_CHANNEL_MAX);
+
 	BIND_ENUM_CONSTANT(DIFFUSE_BURLEY);
 	BIND_ENUM_CONSTANT(DIFFUSE_LAMBERT);
 	BIND_ENUM_CONSTANT(DIFFUSE_LAMBERT_WRAP);
@@ -2127,6 +2173,11 @@ SpatialMaterial::SpatialMaterial() :
 	detail_blend_mode = BLEND_MODE_MIX;
 	depth_draw_mode = DEPTH_DRAW_OPAQUE_ONLY;
 	cull_mode = CULL_BACK;
+
+	for (int i = 0; i < COLOR_CHANNEL_MAX; i++) {
+		color_channels[i] = true;
+	}
+
 	for (int i = 0; i < FLAG_MAX; i++) {
 		flags[i] = 0;
 	}

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -191,6 +191,14 @@ public:
 		FLAG_MAX
 	};
 
+	enum ColorChannel {
+		COLOR_CHANNEL_RED,
+		COLOR_CHANNEL_GREEN,
+		COLOR_CHANNEL_BLUE,
+		COLOR_CHANNEL_ALPHA,
+		COLOR_CHANNEL_MAX
+	};
+
 	enum DiffuseMode {
 		DIFFUSE_BURLEY,
 		DIFFUSE_LAMBERT,
@@ -237,6 +245,7 @@ private:
 			uint64_t depth_draw_mode : 2;
 			uint64_t cull_mode : 2;
 			uint64_t flags : 14;
+			uint64_t color_channels : 4;
 			uint64_t detail_blend_mode : 2;
 			uint64_t diffuse_mode : 3;
 			uint64_t specular_mode : 2;
@@ -281,6 +290,11 @@ private:
 		for (int i = 0; i < FLAG_MAX; i++) {
 			if (flags[i]) {
 				mk.flags |= (1 << i);
+			}
+		}
+		for (int i = 0; i < COLOR_CHANNEL_MAX; i++) {
+			if (color_channels[i]) {
+				mk.color_channels |= (1 << i);
 			}
 		}
 		mk.detail_blend_mode = detail_blend_mode;
@@ -405,6 +419,7 @@ private:
 	DepthDrawMode depth_draw_mode;
 	CullMode cull_mode;
 	bool flags[FLAG_MAX];
+	bool color_channels[COLOR_CHANNEL_MAX];
 	SpecularMode specular_mode;
 	DiffuseMode diffuse_mode;
 	BillboardMode billboard_mode;
@@ -531,6 +546,9 @@ public:
 	void set_feature(Feature p_feature, bool p_enabled);
 	bool get_feature(Feature p_feature) const;
 
+	void set_color_channel(ColorChannel p_color_channel, bool p_enabled);
+	bool get_color_channel(ColorChannel p_color_channel) const;
+
 	void set_uv1_scale(const Vector3 &p_scale);
 	Vector3 get_uv1_scale() const;
 
@@ -619,6 +637,7 @@ VARIANT_ENUM_CAST(SpatialMaterial::BlendMode)
 VARIANT_ENUM_CAST(SpatialMaterial::DepthDrawMode)
 VARIANT_ENUM_CAST(SpatialMaterial::CullMode)
 VARIANT_ENUM_CAST(SpatialMaterial::Flags)
+VARIANT_ENUM_CAST(SpatialMaterial::ColorChannel)
 VARIANT_ENUM_CAST(SpatialMaterial::DiffuseMode)
 VARIANT_ENUM_CAST(SpatialMaterial::SpecularMode)
 VARIANT_ENUM_CAST(SpatialMaterial::BillboardMode)

--- a/servers/visual/shader_types.cpp
+++ b/servers/visual/shader_types.cpp
@@ -152,6 +152,11 @@ ShaderTypes::ShaderTypes() {
 
 	shader_modes[VS::SHADER_SPATIAL].modes.insert("depth_test_disable");
 
+	shader_modes[VS::SHADER_SPATIAL].modes.insert("disable_channel_r");
+	shader_modes[VS::SHADER_SPATIAL].modes.insert("disable_channel_g");
+	shader_modes[VS::SHADER_SPATIAL].modes.insert("disable_channel_b");
+	shader_modes[VS::SHADER_SPATIAL].modes.insert("disable_channel_a");
+
 	shader_modes[VS::SHADER_SPATIAL].modes.insert("cull_front");
 	shader_modes[VS::SHADER_SPATIAL].modes.insert("cull_back");
 	shader_modes[VS::SHADER_SPATIAL].modes.insert("cull_disabled");


### PR DESCRIPTION
This PR exposes the color mask state machine to shaders as a parameter and also includes it as part of the SpatialMaterial shader generation process. In the interest of moduralizing my integration of full stencil buffer support gradually, I wanted to first expose this particular interface since it's an almost crucial part of a stencil buffer render pass. It's the easiest way to write only to the depth buffer while ignoring the colour buffer, and this is particularly relevant given the stencil buffer is merely an extension of the depth buffer. The color channel writes are of course still always disabled during a shadow pass or depth prepass, but this gives an extra level of fine-grained control in other passes which will be crucial for many of the effects made possible with access to the stencil buffer.