### PR TITLE
Fixed several leaks

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -415,4 +415,5 @@ RasterizerGLES3::~RasterizerGLES3() {
 
 	memdelete(storage);
 	memdelete(canvas);
+	memdelete(scene);
 }

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -5118,3 +5118,23 @@ void RasterizerSceneGLES3::finalize() {
 
 RasterizerSceneGLES3::RasterizerSceneGLES3() {
 }
+
+RasterizerSceneGLES3::~RasterizerSceneGLES3() {
+
+	memdelete(default_material.get_data());
+	memdelete(default_material_twosided.get_data());
+	memdelete(default_shader.get_data());
+	memdelete(default_shader_twosided.get_data());
+
+	memdelete(default_worldcoord_material.get_data());
+	memdelete(default_worldcoord_material_twosided.get_data());
+	memdelete(default_worldcoord_shader.get_data());
+	memdelete(default_worldcoord_shader_twosided.get_data());
+
+	memdelete(default_overdraw_material.get_data());
+	memdelete(default_overdraw_shader.get_data());
+
+	memfree(state.spot_array_tmp);
+	memfree(state.omni_array_tmp);
+	memfree(state.reflection_array_tmp);
+}

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -852,6 +852,7 @@ public:
 	void initialize();
 	void finalize();
 	RasterizerSceneGLES3();
+	~RasterizerSceneGLES3();
 };
 
 #endif // RASTERIZERSCENEGLES3_H

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -205,4 +205,5 @@ VisualServerRaster::~VisualServerRaster() {
 	memdelete(VSG::canvas);
 	memdelete(VSG::viewport);
 	memdelete(VSG::rasterizer);
+	memdelete(VSG::scene);
 }

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -3333,6 +3333,7 @@ VisualServerScene::~VisualServerScene() {
 
 #ifndef NO_THREADS
 	probe_bake_thread_exit = true;
+	probe_bake_sem->post();
 	Thread::wait_to_finish(probe_bake_thread);
 	memdelete(probe_bake_thread);
 	memdelete(probe_bake_sem);


### PR DESCRIPTION
The following memory allocation is currently leaking:
https://github.com/godotengine/godot/blob/eceba5aa6a36521c878cf976845123e820d27161/drivers/gles3/rasterizer_gles3.cpp#L403

This pull request attempts to fix this.

Focus on the `possibly lost` line of the `valgrind` summary before this patch:
```
==10494== LEAK SUMMARY:
==10494==    definitely lost: 0 bytes in 0 blocks
==10494==    indirectly lost: 0 bytes in 0 blocks
==10494==      possibly lost: 4,651,783 bytes in 78 blocks
==10494==    still reachable: 140,096 bytes in 1,257 blocks
==10494==         suppressed: 0 bytes in 0 blocks
```

And after this patch:
```
==10268== LEAK SUMMARY:
==10268==    definitely lost: 197,688 bytes in 8 blocks
==10268==    indirectly lost: 2,904 bytes in 10 blocks
==10268==      possibly lost: 1,147,783 bytes in 6 blocks
==10268==    still reachable: 140,000 bytes in 1,256 blocks
==10268==         suppressed: 0 bytes in 0 blocks
```

I tested this patch with some of the 2D and 3D demos and everything seems alright to me.