### PR TITLE
Fix non working action names containing whitespaces

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -692,7 +692,10 @@ Error ProjectSettings::_save_settings_text(const String &p_file, const Map<Strin
 
 			String vstr;
 			VariantWriter::write_to_string(value, vstr);
-			file->store_string(F->get() + "=" + vstr + "\n");
+			if (F->get().find(" ") != -1)
+				file->store_string(F->get().quote() + "=" + vstr + "\n");
+			else
+				file->store_string(F->get() + "=" + vstr + "\n");
 		}
 	}
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -137,12 +137,12 @@ void ProjectSettingsEditor::_action_edited() {
 	if (new_name == old_name)
 		return;
 
-	if (new_name.find("/") != -1 || new_name.find(":") != -1 || new_name == "") {
+	if (new_name.find("/") != -1 || new_name.find(":") != -1 || new_name.find("\"") != -1 || new_name == "") {
 
 		ti->set_text(0, old_name);
 		add_at = "input/" + old_name;
 
-		message->set_text(TTR("Invalid action (anything goes but '/' or ':')."));
+		message->set_text(TTR("Invalid action (anything goes but '/', ':' or '\"')."));
 		message->popup_centered(Size2(300, 100) * EDSCALE);
 		return;
 	}
@@ -830,9 +830,9 @@ void ProjectSettingsEditor::_action_check(String p_action) {
 		action_add->set_disabled(true);
 	} else {
 
-		if (p_action.find("/") != -1 || p_action.find(":") != -1) {
+		if (p_action.find("/") != -1 || p_action.find(":") != -1 || p_action.find("\"") != -1) {
 
-			action_add_error->set_text(TTR("Can't contain '/' or ':'"));
+			action_add_error->set_text(TTR("Can't contain '/', ':' or '\"'"));
 			action_add_error->show();
 			action_add->set_disabled(true);
 			return;


### PR DESCRIPTION
Fix non working action names containing whitespaces

Now the action name is quoted if it contains spaces. Also, quotation
mark (") is added to the forbidden character list for action names, as
it was also a bug.

Fix #17322