### PR TITLE
fix iOS build - error due to GLES2 missing include

### DIFF
--- a/platform/iphone/platform_config.h
+++ b/platform/iphone/platform_config.h
@@ -30,6 +30,7 @@
 
 #include <alloca.h>
 
+#define GLES2_INCLUDE_H <ES2/gl.h>
 #define GLES3_INCLUDE_H <ES3/gl.h>
 
 #define PLATFORM_REFCOUNT


### PR DESCRIPTION
(with the advice from bruvzg[m] on irc)