### PR TITLE
Fix non-valid characters for `input_action`

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -123,6 +123,15 @@ void ProjectSettingsEditor::_notification(int p_what) {
 	}
 }
 
+static bool _validate_action_name(const String &p_name) {
+	const CharType *cstr = p_name.c_str();
+	for (int i = 0; cstr[i]; i++)
+		if (cstr[i] == '/' || cstr[i] == ':' || cstr[i] == '"' ||
+				cstr[i] == '=' || cstr[i] == '\\' || cstr[i] < 32)
+			return false;
+	return true;
+}
+
 void ProjectSettingsEditor::_action_selected() {
 
 	TreeItem *ti = input_editor->get_selected();
@@ -145,12 +154,12 @@ void ProjectSettingsEditor::_action_edited() {
 	if (new_name == old_name)
 		return;
 
-	if (new_name.find("/") != -1 || new_name.find(":") != -1 || new_name.find("\"") != -1 || new_name == "") {
+	if (new_name == "" || !_validate_action_name(new_name)) {
 
 		ti->set_text(0, old_name);
 		add_at = "input/" + old_name;
 
-		message->set_text(TTR("Invalid action (anything goes but '/', ':' or '\"')."));
+		message->set_text(TTR("Invalid action name. it cannot be empty nor contain '/', ':', '=', '\\' or '\"'"));
 		message->popup_centered(Size2(300, 100) * EDSCALE);
 		return;
 	}
@@ -838,9 +847,9 @@ void ProjectSettingsEditor::_action_check(String p_action) {
 		action_add->set_disabled(true);
 	} else {
 
-		if (p_action.find("/") != -1 || p_action.find(":") != -1 || p_action.find("\"") != -1) {
+		if (!_validate_action_name(p_action)) {
 
-			action_add_error->set_text(TTR("Can't contain '/', ':' or '\"'"));
+			action_add_error->set_text(TTR("Invalid action name. it cannot be empty nor contain '/', ':', '=', '\\' or '\"'"));
 			action_add_error->show();
 			action_add->set_disabled(true);
 			return;


### PR DESCRIPTION
Fix non-valid characters for `input_action`

Add a new function to check action names, `_validate_action_name`, in
the spirit of `_valprop`. Offending characters include non-printable
ascii, and `\/=:"`.