### PR TITLE
Fixed leak in BulletPhysicsServer

### DIFF
--- a/modules/bullet/bullet_physics_server.cpp
+++ b/modules/bullet/bullet_physics_server.cpp
@@ -89,7 +89,9 @@ BulletPhysicsServer::BulletPhysicsServer() :
 		active(true),
 		active_spaces_count(0) {}
 
-BulletPhysicsServer::~BulletPhysicsServer() {}
+BulletPhysicsServer::~BulletPhysicsServer() {
+	bulletdelete(emptyShape);
+}
 
 RID BulletPhysicsServer::shape_create(ShapeType p_shape) {
 	ShapeBullet *shape = NULL;


### PR DESCRIPTION
This allocation was leaking:

https://github.com/godotengine/godot/blob/fe93459ef9ded290277dff0d29747b9336077238/modules/bullet/bullet_physics_server.cpp#L77

The `valgrind` report before this commit:
```
==27789== LEAK SUMMARY:
==27789==    definitely lost: 0 bytes in 0 blocks
==27789==    indirectly lost: 0 bytes in 0 blocks
==27789==      possibly lost: 71 bytes in 1 blocks
==27789==    still reachable: 139,832 bytes in 1,254 blocks
==27789==         suppressed: 0 bytes in 0 blocks
```

Here's the `valgrind` report after applying this commit:
```
==25117== LEAK SUMMARY:
==25117==    definitely lost: 0 bytes in 0 blocks
==25117==    indirectly lost: 0 bytes in 0 blocks
==25117==      possibly lost: 0 bytes in 0 blocks
==25117==    still reachable: 139,832 bytes in 1,254 blocks
==25117==         suppressed: 0 bytes in 0 blocks
```