### PR TITLE
Fix pressing `F3` do both changing to script editor AND find next text

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -190,6 +190,8 @@ void EditorNode::_unhandled_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventKey> k = p_event;
 	if (k.is_valid() && k->is_pressed() && !k->is_echo() && !gui_base->get_viewport()->gui_has_modal_stack()) {
 
+		EditorPlugin *old_editor = editor_plugin_screen;
+
 		if (ED_IS_SHORTCUT("editor/next_tab", p_event)) {
 			int next_tab = editor_data.get_edited_scene() + 1;
 			next_tab %= editor_data.get_edited_scene_count();
@@ -224,6 +226,10 @@ void EditorNode::_unhandled_input(const Ref<InputEvent> &p_event) {
 			for (int i = 0; i < bottom_panel_items.size(); i++) {
 				_bottom_panel_switch(false, i);
 			}
+		}
+
+		if (old_editor != editor_plugin_screen) {
+			get_tree()->set_input_as_handled();
 		}
 	}
 }


### PR DESCRIPTION
Fix pressing `F3` do both changing to script editor AND find next text

As `KEY_F3` was used both for changing to script editor window and, in
the script editor, for finding the next result in the last search, and
the key event is **not** consumed, the resulting behaviour was similar
to press `F3` twice, first to change to script editor and second to
find the next result of a previous search.

This PR sets the `key_pressed` status of `InputEvent` to `false` if
this event is responsible of an editor change, simulating the
consumption of the event.

Fix #17334