### PR TITLE
Remove the rect surrounding 2D nodes in 2D editor when it's not pertinent

### DIFF
--- a/editor/icons/icon_editor_position.svg
+++ b/editor/icons/icon_editor_position.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   viewBox="0 0 16 16"
+   id="svg919"
+   sodipodi:docname="icon_editor_position.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <metadata
+     id="metadata925">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs923" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2550"
+     inkscape:window-height="1414"
+     id="namedview921"
+     showgrid="false"
+     inkscape:zoom="64"
+     inkscape:cx="13.492036"
+     inkscape:cy="5.8518769"
+     inkscape:window-x="1370"
+     inkscape:window-y="20"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg919"
+     inkscape:snap-page="true" />
+  <g
+     id="g6479">
+    <path
+       id="path913"
+       d="M 6 0 L 6 4.4199219 A 4.2661548 4.0576186 0 0 0 4.2910156 6 L 0 6 L 0 10 L 4.2949219 10 A 4.2661548 4.0576186 0 0 0 6 11.582031 L 6 16 L 10 16 L 10 11.580078 A 4.2661548 4.0576186 0 0 0 11.708984 10 L 16 10 L 16 6 L 11.705078 6 A 4.2661548 4.0576186 0 0 0 10 4.4179688 L 10 0 L 6 0 z "
+       style="fill:#ffffff;fill-opacity:0.70588237" />
+    <path
+       id="path915"
+       d="M 7 1 L 7 4.0605469 A 4.2661548 4.0576186 0 0 1 8 3.9414062 A 4.2661548 4.0576186 0 0 1 9 4.0605469 L 9 1 L 7 1 z M 1 7 L 1 9 L 3.8691406 9 A 4.2661548 4.0576186 0 0 1 3.734375 8 A 4.2661548 4.0576186 0 0 1 3.8710938 7 L 1 7 z M 12.130859 7 A 4.2661548 4.0576186 0 0 1 12.265625 8 A 4.2661548 4.0576186 0 0 1 12.128906 9 L 15 9 L 15 7 L 12.130859 7 z M 7 11.939453 L 7 15 L 9 15 L 9 11.939453 A 4.2661548 4.0576186 0 0 1 8 12.058594 A 4.2661548 4.0576186 0 0 1 7 11.939453 z "
+       style="fill:#ff8484;stroke:none;fill-opacity:1" />
+    <circle
+       id="circle1517"
+       r="2.9201488"
+       cy="8"
+       cx="8"
+       style="fill:#ff8484;fill-opacity:1;stroke-width:0.97338283" />
+  </g>
+</svg>

--- a/editor/icons/icon_editor_position_previous.svg
+++ b/editor/icons/icon_editor_position_previous.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   viewBox="0 0 16 16"
+   id="svg919"
+   sodipodi:docname="icon_editor_position_previous.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <metadata
+     id="metadata925">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs923" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1356"
+     inkscape:window-height="742"
+     id="namedview921"
+     showgrid="false"
+     inkscape:zoom="11.313709"
+     inkscape:cx="14.523034"
+     inkscape:cy="-5.7323703"
+     inkscape:window-x="4"
+     inkscape:window-y="20"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg919"
+     inkscape:snap-page="true" />
+  <path
+     style="fill:#6699ff;stroke:none;fill-opacity:0.69803923"
+     d="M 7 1 L 7 4.0605469 A 4.2661548 4.0576186 0 0 1 8 3.9414062 A 4.2661548 4.0576186 0 0 1 9 4.0605469 L 9 1 L 7 1 z M 1 7 L 1 9 L 3.8691406 9 A 4.2661548 4.0576186 0 0 1 3.734375 8 A 4.2661548 4.0576186 0 0 1 3.8710938 7 L 1 7 z M 12.130859 7 A 4.2661548 4.0576186 0 0 1 12.265625 8 A 4.2661548 4.0576186 0 0 1 12.128906 9 L 15 9 L 15 7 L 12.130859 7 z M 7 11.939453 L 7 15 L 9 15 L 9 11.939453 A 4.2661548 4.0576186 0 0 1 8 12.058594 A 4.2661548 4.0576186 0 0 1 7 11.939453 z "
+     id="path915" />
+  <circle
+     style="fill:#6699ff;fill-opacity:0.69803923;stroke-width:0.97338283"
+     cx="8"
+     cy="8"
+     r="2.9201488"
+     id="circle1517" />
+</svg>

--- a/editor/icons/icon_editor_position_unselected.svg
+++ b/editor/icons/icon_editor_position_unselected.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   viewBox="0 0 16 16"
+   id="svg919"
+   sodipodi:docname="icon_editor_position_unselected.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <metadata
+     id="metadata925">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs923" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2550"
+     inkscape:window-height="1414"
+     id="namedview921"
+     showgrid="false"
+     inkscape:zoom="64"
+     inkscape:cx="13.492036"
+     inkscape:cy="8.3518769"
+     inkscape:window-x="1370"
+     inkscape:window-y="20"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg919"
+     inkscape:snap-page="true" />
+  <path
+     style="fill:#000000;fill-opacity:0.41077441"
+     d="M 6 0 L 6 4.4199219 A 4.2661548 4.0576186 0 0 0 4.2910156 6 L 0 6 L 0 10 L 4.2949219 10 A 4.2661548 4.0576186 0 0 0 6 11.582031 L 6 16 L 10 16 L 10 11.580078 A 4.2661548 4.0576186 0 0 0 11.708984 10 L 16 10 L 16 6 L 11.705078 6 A 4.2661548 4.0576186 0 0 0 10 4.4179688 L 10 0 L 6 0 z "
+     id="path913" />
+  <path
+     style="fill:#d9d9d9;stroke:none;fill-opacity:1"
+     d="M 7 1 L 7 4.0605469 A 4.2661548 4.0576186 0 0 1 8 3.9414062 A 4.2661548 4.0576186 0 0 1 9 4.0605469 L 9 1 L 7 1 z M 1 7 L 1 9 L 3.8691406 9 A 4.2661548 4.0576186 0 0 1 3.734375 8 A 4.2661548 4.0576186 0 0 1 3.8710938 7 L 1 7 z M 12.130859 7 A 4.2661548 4.0576186 0 0 1 12.265625 8 A 4.2661548 4.0576186 0 0 1 12.128906 9 L 15 9 L 15 7 L 12.130859 7 z M 7 11.939453 L 7 15 L 9 15 L 9 11.939453 A 4.2661548 4.0576186 0 0 1 8 12.058594 A 4.2661548 4.0576186 0 0 1 7 11.939453 z "
+     id="path915" />
+  <circle
+     style="fill:#d9d9d9;fill-opacity:1;stroke-width:0.97338283"
+     cx="8"
+     cy="8"
+     r="2.9201488"
+     id="circle1517" />
+</svg>

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -433,22 +433,22 @@ void CanvasItemEditor::_find_canvas_items_at_pos(const Point2 &p_pos, Node *p_no
 	const real_t grab_distance = EDITOR_DEF("editors/poly_editor/point_grab_radius", 8);
 	CanvasItem *canvas_item = Object::cast_to<CanvasItem>(p_node);
 
-	for (int i = p_node->get_child_count() - 1; i >= 0; i--) {
-		if (canvas_item && !canvas_item->is_set_as_toplevel())
-			_find_canvas_items_at_pos(p_pos, p_node->get_child(i), r_items, 0, p_parent_xform * canvas_item->get_transform(), p_canvas_xform);
-		else {
-			CanvasLayer *cl = Object::cast_to<CanvasLayer>(p_node);
-			_find_canvas_items_at_pos(p_pos, p_node->get_child(i), r_items, 0, Transform2D(), cl ? cl->get_transform() : p_canvas_xform); //use base transform
+	if (p_node->get_owner() != editor->get_edited_scene() || !p_node->has_meta("_edit_lock_")) {
+		for (int i = p_node->get_child_count() - 1; i >= 0; i--) {
+			if (canvas_item && !canvas_item->is_set_as_toplevel()) {
+				_find_canvas_items_at_pos(p_pos, p_node->get_child(i), r_items, 0, p_parent_xform * canvas_item->get_transform(), p_canvas_xform);
+			} else {
+				CanvasLayer *cl = Object::cast_to<CanvasLayer>(p_node);
+				_find_canvas_items_at_pos(p_pos, p_node->get_child(i), r_items, 0, Transform2D(), cl ? cl->get_transform() : p_canvas_xform);
+			}
+			if (limit != 0 && r_items.size() >= limit)
+				return;
 		}
-		if (limit != 0 && r_items.size() >= limit)
-			return;
 	}
 
-	if (canvas_item && canvas_item->is_visible_in_tree() && !canvas_item->has_meta("_edit_lock_")) {
-
+	if (canvas_item && canvas_item->is_visible_in_tree() && (canvas_item->get_owner() != editor->get_edited_scene() || !canvas_item->has_meta("_edit_lock_"))) {
 		Transform2D xform = (p_parent_xform * p_canvas_xform * canvas_item->get_transform()).affine_inverse();
 		const real_t local_grab_distance = xform.basis_xform(Vector2(grab_distance, 0)).length();
-
 		if (canvas_item->_edit_is_selected_on_click(xform.xform(p_pos), local_grab_distance)) {
 			Node2D *node = Object::cast_to<Node2D>(canvas_item);
 
@@ -2508,32 +2508,45 @@ void CanvasItemEditor::_draw_bones() {
 	}
 }
 
-void CanvasItemEditor::_draw_locks_and_groups(Node *p_node, const Transform2D &p_xform) {
+void CanvasItemEditor::_draw_locks_and_groups(Node *p_node, const Transform2D &p_parent_xform, const Transform2D &p_canvas_xform) {
 	ERR_FAIL_COND(!p_node);
 
-	RID viewport_ci = viewport->get_canvas_item();
+	Node *scene = editor->get_edited_scene();
+	if (p_node != scene && p_node->get_owner() != scene && !scene->is_editable_instance(p_node->get_owner()))
+		return;
+	CanvasItem *canvas_item = Object::cast_to<CanvasItem>(p_node);
+	if (canvas_item && !canvas_item->is_visible())
+		return;
 
-	Transform2D transform_ci = p_xform;
-	CanvasItem *ci = Object::cast_to<CanvasItem>(p_node);
-	if (ci)
-		transform_ci = transform_ci * ci->get_transform();
+	Transform2D parent_xform = p_parent_xform;
+	Transform2D canvas_xform = p_canvas_xform;
 
-	for (int i = p_node->get_child_count() - 1; i >= 0; i--) {
-		_draw_locks_and_groups(p_node->get_child(i), transform_ci);
+	if (canvas_item && !canvas_item->is_set_as_toplevel()) {
+		parent_xform = parent_xform * canvas_item->get_transform();
+	} else {
+		CanvasLayer *cl = Object::cast_to<CanvasLayer>(p_node);
+		parent_xform = Transform2D();
+		canvas_xform = cl ? cl->get_transform() : p_canvas_xform;
 	}
 
-	if (ci) {
+	for (int i = p_node->get_child_count() - 1; i >= 0; i--) {
+		_draw_locks_and_groups(p_node->get_child(i), parent_xform, canvas_xform);
+	}
+
+	RID viewport_canvas_item = viewport->get_canvas_item();
+	if (canvas_item) {
+		float offset = 0;
+
 		Ref<Texture> lock = get_icon("LockViewport", "EditorIcons");
 		if (p_node->has_meta("_edit_lock_")) {
-			lock->draw(viewport_ci, transform_ci.xform(Point2(0, 0)));
+			lock->draw(viewport_canvas_item, (transform * canvas_xform * parent_xform).xform(Point2(0, 0)) + Point2(offset, 0));
+			offset += lock->get_size().x;
 		}
 
 		Ref<Texture> group = get_icon("GroupViewport", "EditorIcons");
-		if (ci->has_meta("_edit_group_")) {
-			Vector2 ofs = transform_ci.xform(Point2(0, 0));
-			if (ci->has_meta("_edit_lock_"))
-				ofs = Point2(ofs.x + lock->get_size().x, ofs.y);
-			group->draw(viewport_ci, ofs);
+		if (canvas_item->has_meta("_edit_group_")) {
+			group->draw(viewport_canvas_item, (transform * canvas_xform * parent_xform).xform(Point2(0, 0)) + Point2(offset, 0));
+			//offset += group->get_size().x;
 		}
 	}
 }
@@ -2600,7 +2613,7 @@ void CanvasItemEditor::_draw_viewport() {
 	_draw_selection();
 	_draw_axis();
 	if (editor->get_edited_scene())
-		_draw_locks_and_groups(editor->get_edited_scene(), transform);
+		_draw_locks_and_groups(editor->get_edited_scene());
 
 	RID ci = viewport->get_canvas_item();
 	VisualServer::get_singleton()->canvas_item_add_set_transform(ci, Transform2D());

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -336,7 +336,7 @@ class CanvasItemEditor : public VBoxContainer {
 	Ref<ShortCut> divide_grid_step_shortcut;
 
 	void _find_canvas_items_at_pos(const Point2 &p_pos, Node *p_node, Vector<_SelectResult> &r_items, int limit = 0, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D());
-	void _find_canvas_items_at_rect(const Rect2 &p_rect, Node *p_node, List<CanvasItem *> *r_items, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D());
+	void _find_canvas_items_in_rect(const Rect2 &p_rect, Node *p_node, List<CanvasItem *> *r_items, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D());
 	bool _select_click_on_item(CanvasItem *item, Point2 p_click_pos, bool p_append);
 
 	ConfirmationDialog *snap_dialog;
@@ -366,8 +366,8 @@ class CanvasItemEditor : public VBoxContainer {
 
 	List<CanvasItem *> _get_edited_canvas_items(bool retreive_locked = false, bool remove_canvas_item_if_parent_in_selection = true);
 	Rect2 _get_encompassing_rect_from_list(List<CanvasItem *> p_list);
-	void _expand_encompassing_rect_using_children(Rect2 &p_rect, Node *p_node, bool &r_first, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D());
-	Rect2 _get_scene_encompassing_rect();
+	void _expand_encompassing_rect_using_children(Rect2 &p_rect, const Node *p_node, bool &r_first, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D());
+	Rect2 _get_encompassing_rect(const Node *p_node);
 
 	Object *_get_editor_data(Object *p_what);
 

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -387,6 +387,7 @@ class CanvasItemEditor : public VBoxContainer {
 	void _draw_selection();
 	void _draw_axis();
 	void _draw_bones();
+	void _draw_invisible_nodes_positions(Node *p_node, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D());
 	void _draw_locks_and_groups(Node *p_node, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D());
 
 	void _draw_viewport();

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -387,7 +387,7 @@ class CanvasItemEditor : public VBoxContainer {
 	void _draw_selection();
 	void _draw_axis();
 	void _draw_bones();
-	void _draw_locks_and_groups(Node *p_node, const Transform2D &p_xform);
+	void _draw_locks_and_groups(Node *p_node, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D());
 
 	void _draw_viewport();
 

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -258,6 +258,7 @@ class CanvasItemEditor : public VBoxContainer {
 	};
 
 	Vector<_SelectResult> selection_results;
+	Vector<_SelectResult> hovering_results;
 
 	struct BoneList {
 
@@ -389,6 +390,7 @@ class CanvasItemEditor : public VBoxContainer {
 	void _draw_bones();
 	void _draw_invisible_nodes_positions(Node *p_node, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D());
 	void _draw_locks_and_groups(Node *p_node, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D());
+	void _draw_hover();
 
 	void _draw_viewport();
 
@@ -401,6 +403,7 @@ class CanvasItemEditor : public VBoxContainer {
 	bool _gui_input_select(const Ref<InputEvent> &p_event);
 	bool _gui_input_zoom_or_pan(const Ref<InputEvent> &p_event);
 	bool _gui_input_rulers_and_guides(const Ref<InputEvent> &p_event);
+	bool _gui_input_hover(const Ref<InputEvent> &p_event);
 
 	void _gui_input_viewport(const Ref<InputEvent> &p_event);
 

--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -80,6 +80,10 @@ Rect2 AnimatedSprite::_edit_get_rect() const {
 	return Rect2(ofs, s);
 }
 
+bool AnimatedSprite::_edit_use_rect() const {
+	return true;
+}
+
 void SpriteFrames::add_frame(const StringName &p_anim, const Ref<Texture> &p_frame, int p_at_pos) {
 
 	Map<StringName, Anim>::Element *E = animations.find(p_anim);

--- a/scene/2d/animated_sprite.h
+++ b/scene/2d/animated_sprite.h
@@ -157,6 +157,7 @@ public:
 	virtual Point2 _edit_get_pivot() const;
 	virtual bool _edit_use_pivot() const;
 	virtual Rect2 _edit_get_rect() const;
+	virtual bool _edit_use_rect() const;
 
 	void set_sprite_frames(const Ref<SpriteFrames> &p_frames);
 	Ref<SpriteFrames> get_sprite_frames() const;

--- a/scene/2d/back_buffer_copy.cpp
+++ b/scene/2d/back_buffer_copy.cpp
@@ -55,6 +55,10 @@ Rect2 BackBufferCopy::_edit_get_rect() const {
 	return rect;
 }
 
+bool BackBufferCopy::_edit_use_rect() const {
+	return true;
+}
+
 void BackBufferCopy::set_rect(const Rect2 &p_rect) {
 
 	rect = p_rect;

--- a/scene/2d/back_buffer_copy.h
+++ b/scene/2d/back_buffer_copy.h
@@ -54,6 +54,7 @@ protected:
 
 public:
 	Rect2 _edit_get_rect() const;
+	virtual bool _edit_use_rect() const;
 
 	void set_rect(const Rect2 &p_rect);
 	Rect2 get_rect() const;

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -245,6 +245,14 @@ CanvasItemMaterial::~CanvasItemMaterial() {
 
 ///////////////////////////////////////////////////////////////////
 
+bool CanvasItem::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
+	if (_edit_use_rect()) {
+		return _edit_get_rect().has_point(p_point);
+	} else {
+		return p_point.length() < p_tolerance;
+	}
+}
+
 bool CanvasItem::is_visible_in_tree() const {
 
 	if (!is_inside_tree())
@@ -976,7 +984,8 @@ void CanvasItem::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_edit_set_position", "position"), &CanvasItem::_edit_set_position);
 	ClassDB::bind_method(D_METHOD("_edit_get_position"), &CanvasItem::_edit_get_position);
-	ClassDB::bind_method(D_METHOD("_edit_use_position"), &CanvasItem::_edit_use_position);
+	ClassDB::bind_method(D_METHOD("_edit_set_scale", "scale"), &CanvasItem::_edit_set_scale);
+	ClassDB::bind_method(D_METHOD("_edit_get_scale"), &CanvasItem::_edit_get_scale);
 	ClassDB::bind_method(D_METHOD("_edit_set_rect", "rect"), &CanvasItem::_edit_set_rect);
 	ClassDB::bind_method(D_METHOD("_edit_get_rect"), &CanvasItem::_edit_get_rect);
 	ClassDB::bind_method(D_METHOD("_edit_use_rect"), &CanvasItem::_edit_use_rect);

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -220,30 +220,46 @@ public:
 
 	/* EDITOR */
 
+	// Save and restore a CanvasItem state
 	virtual void _edit_set_state(const Dictionary &p_state){};
 	virtual Dictionary _edit_get_state() const { return Dictionary(); };
 
-	// Used to move/select the node
-	virtual void _edit_set_position(const Point2 &p_position){};
-	virtual Point2 _edit_get_position() const { return Point2(); };
-	virtual bool _edit_use_position() const { return false; };
+	// Used to move the node
+	virtual void _edit_set_position(const Point2 &p_position) = 0;
+	virtual Point2 _edit_get_position() const = 0;
 
-	// Used to resize/move/select the node
+	// Used to scale the node
+	virtual void _edit_set_scale(const Size2 &p_scale) = 0;
+	virtual Size2 _edit_get_scale() const = 0;
+
+	// Used to resize/move the node
 	virtual void _edit_set_rect(const Rect2 &p_rect){};
-	virtual Rect2 _edit_get_rect() const { return Rect2(-32, -32, 64, 64); };
-	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const { return _edit_get_rect().has_point(p_point); }
-	Rect2 _edit_get_item_and_children_rect() const;
+	virtual Rect2 _edit_get_rect() const { return Rect2(0, 0, 0, 0); };
 	virtual bool _edit_use_rect() const { return false; };
 
+	Rect2 _edit_get_item_and_children_rect() const;
+
+	// used to select the node
+	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
+
 	// Used to rotate the node
-	virtual void _edit_set_rotation(float p_rotation){};
-	virtual float _edit_get_rotation() const { return 0.0; };
-	virtual bool _edit_use_rotation() const { return false; };
+	virtual void
+	_edit_set_rotation(float p_rotation){};
+	virtual float _edit_get_rotation() const {
+		return 0.0;
+	};
+	virtual bool _edit_use_rotation() const {
+		return false;
+	};
 
 	// Used to set a pivot
 	virtual void _edit_set_pivot(const Point2 &p_pivot){};
-	virtual Point2 _edit_get_pivot() const { return Point2(); };
-	virtual bool _edit_use_pivot() const { return false; };
+	virtual Point2 _edit_get_pivot() const {
+		return Point2();
+	};
+	virtual bool _edit_use_pivot() const {
+		return false;
+	};
 
 	virtual Size2 _edit_get_minimum_size() const;
 
@@ -308,7 +324,9 @@ public:
 	virtual Transform2D get_global_transform_with_canvas() const;
 
 	CanvasItem *get_toplevel() const;
-	_FORCE_INLINE_ RID get_canvas_item() const { return canvas_item; }
+	_FORCE_INLINE_ RID get_canvas_item() const {
+		return canvas_item;
+	}
 
 	void set_block_transform_notify(bool p_enable);
 	bool is_block_transform_notify_enabled() const;

--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -264,6 +264,10 @@ Rect2 CollisionPolygon2D::_edit_get_rect() const {
 	return aabb;
 }
 
+bool CollisionPolygon2D::_edit_use_rect() const {
+	return true;
+}
+
 bool CollisionPolygon2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
 
 	return Geometry::is_point_in_polygon(p_point, Variant(polygon));

--- a/scene/2d/collision_polygon_2d.h
+++ b/scene/2d/collision_polygon_2d.h
@@ -73,6 +73,7 @@ public:
 	Vector<Point2> get_polygon() const;
 
 	virtual Rect2 _edit_get_rect() const;
+	virtual bool _edit_use_rect() const;
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
 
 	virtual String get_configuration_warning() const;

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -173,11 +173,6 @@ Ref<Shape2D> CollisionShape2D::get_shape() const {
 	return shape;
 }
 
-Rect2 CollisionShape2D::_edit_get_rect() const {
-
-	return rect;
-}
-
 bool CollisionShape2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
 
 	if (!shape.is_valid())

--- a/scene/2d/collision_shape_2d.h
+++ b/scene/2d/collision_shape_2d.h
@@ -54,7 +54,6 @@ protected:
 	static void _bind_methods();
 
 public:
-	virtual Rect2 _edit_get_rect() const;
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
 
 	void set_shape(const Ref<Shape2D> &p_shape);

--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -65,6 +65,10 @@ Rect2 Light2D::_edit_get_rect() const {
 	return Rect2(texture_offset - s / 2.0, s);
 }
 
+bool Light2D::_edit_use_rect() const {
+	return true;
+}
+
 void Light2D::_update_light_visibility() {
 
 	if (!is_inside_tree())

--- a/scene/2d/light_2d.h
+++ b/scene/2d/light_2d.h
@@ -92,6 +92,7 @@ public:
 	virtual Point2 _edit_get_pivot() const;
 	virtual bool _edit_use_pivot() const;
 	virtual Rect2 _edit_get_rect() const;
+	virtual bool _edit_use_rect() const;
 
 	void set_enabled(bool p_enabled);
 	bool is_enabled() const;

--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -62,6 +62,10 @@ Rect2 Line2D::_edit_get_rect() const {
 	return aabb;
 }
 
+bool Line2D::_edit_use_rect() const {
+	return true;
+}
+
 bool Line2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
 
 	const real_t d = _width / 2 + p_tolerance;

--- a/scene/2d/line_2d.h
+++ b/scene/2d/line_2d.h
@@ -59,6 +59,7 @@ public:
 	Line2D();
 
 	virtual Rect2 _edit_get_rect() const;
+	virtual bool _edit_use_rect() const;
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
 
 	void set_points(const PoolVector<Vector2> &p_points);

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -58,47 +58,19 @@ void Node2D::_edit_set_state(const Dictionary &p_state) {
 }
 
 void Node2D::_edit_set_position(const Point2 &p_position) {
-	pos = p_position;
-	_update_transform();
-	_change_notify("position");
+	set_position(p_position);
 }
 
 Point2 Node2D::_edit_get_position() const {
 	return pos;
 }
 
-void Node2D::_edit_set_rect(const Rect2 &p_edit_rect) {
-	Rect2 r = _edit_get_rect();
-
-	Vector2 zero_offset;
-	if (r.size.x != 0)
-		zero_offset.x = -r.position.x / r.size.x;
-	if (r.size.y != 0)
-		zero_offset.y = -r.position.y / r.size.y;
-
-	Size2 new_scale(1, 1);
-
-	if (r.size.x != 0)
-		new_scale.x = p_edit_rect.size.x / r.size.x;
-	if (r.size.y != 0)
-		new_scale.y = p_edit_rect.size.y / r.size.y;
-
-	Point2 new_pos = p_edit_rect.position + p_edit_rect.size * zero_offset; //p_edit_rect.pos - r.pos;
-
-	Transform2D postxf;
-	postxf.set_rotation_and_scale(angle, _scale);
-	new_pos = postxf.xform(new_pos);
-
-	pos += new_pos;
-	_scale *= new_scale;
-
-	_update_transform();
-	_change_notify("scale");
-	_change_notify("position");
+void Node2D::_edit_set_scale(const Size2 &p_scale) {
+	set_scale(p_scale);
 }
 
-bool Node2D::_edit_use_rect() const {
-	return true;
+Size2 Node2D::_edit_get_scale() const {
+	return _scale;
 }
 
 void Node2D::_edit_set_rotation(float p_rotation) {
@@ -114,6 +86,38 @@ float Node2D::_edit_get_rotation() const {
 
 bool Node2D::_edit_use_rotation() const {
 	return true;
+}
+
+void Node2D::_edit_set_rect(const Rect2 &p_edit_rect) {
+	ERR_FAIL_COND(!_edit_use_rect());
+
+	Rect2 r = _edit_get_rect();
+
+	Vector2 zero_offset;
+	if (r.size.x != 0)
+		zero_offset.x = -r.position.x / r.size.x;
+	if (r.size.y != 0)
+		zero_offset.y = -r.position.y / r.size.y;
+
+	Size2 new_scale(1, 1);
+
+	if (r.size.x != 0)
+		new_scale.x = p_edit_rect.size.x / r.size.x;
+	if (r.size.y != 0)
+		new_scale.y = p_edit_rect.size.y / r.size.y;
+
+	Point2 new_pos = p_edit_rect.position + p_edit_rect.size * zero_offset;
+
+	Transform2D postxf;
+	postxf.set_rotation_and_scale(angle, _scale);
+	new_pos = postxf.xform(new_pos);
+
+	pos += new_pos;
+	_scale *= new_scale;
+
+	_update_transform();
+	_change_notify("scale");
+	_change_notify("position");
 }
 
 void Node2D::_update_xform_values() {

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -62,11 +62,15 @@ public:
 
 	virtual void _edit_set_position(const Point2 &p_position);
 	virtual Point2 _edit_get_position() const;
-	virtual void _edit_set_rect(const Rect2 &p_edit_rect);
-	virtual bool _edit_use_rect() const;
+
+	virtual void _edit_set_scale(const Size2 &p_scale);
+	virtual Size2 _edit_get_scale() const;
+
 	virtual void _edit_set_rotation(float p_rotation);
 	virtual float _edit_get_rotation() const;
 	virtual bool _edit_use_rotation() const;
+
+	virtual void _edit_set_rect(const Rect2 &p_edit_rect);
 
 	void set_position(const Point2 &p_pos);
 	void set_rotation(float p_radians);

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -57,6 +57,10 @@ Rect2 Path2D::_edit_get_rect() const {
 	return aabb;
 }
 
+bool Path2D::_edit_use_rect() const {
+	return true;
+}
+
 bool Path2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
 
 	for (int i = 0; i < curve->get_point_count(); i++) {

--- a/scene/2d/path_2d.h
+++ b/scene/2d/path_2d.h
@@ -48,6 +48,7 @@ protected:
 
 public:
 	virtual Rect2 _edit_get_rect() const;
+	virtual bool _edit_use_rect() const;
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
 
 	void set_curve(const Ref<Curve2D> &p_curve);

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -73,6 +73,10 @@ Rect2 Polygon2D::_edit_get_rect() const {
 	return item_rect;
 }
 
+bool Polygon2D::_edit_use_rect() const {
+	return true;
+}
+
 bool Polygon2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
 
 	return Geometry::is_point_in_polygon(p_point - get_offset(), Variant(polygon));

--- a/scene/2d/polygon_2d.h
+++ b/scene/2d/polygon_2d.h
@@ -68,6 +68,7 @@ public:
 	virtual Point2 _edit_get_pivot() const;
 	virtual bool _edit_use_pivot() const;
 	virtual Rect2 _edit_get_rect() const;
+	virtual bool _edit_use_rect() const;
 
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
 

--- a/scene/2d/position_2d.cpp
+++ b/scene/2d/position_2d.cpp
@@ -44,6 +44,10 @@ Rect2 Position2D::_edit_get_rect() const {
 	return Rect2(Point2(-10, -10), Size2(20, 20));
 }
 
+bool Position2D::_edit_use_rect() const {
+	return false;
+}
+
 void Position2D::_notification(int p_what) {
 
 	switch (p_what) {

--- a/scene/2d/position_2d.h
+++ b/scene/2d/position_2d.h
@@ -44,6 +44,7 @@ protected:
 
 public:
 	virtual Rect2 _edit_get_rect() const;
+	virtual bool _edit_use_rect() const;
 	Position2D();
 };
 

--- a/scene/2d/screen_button.cpp
+++ b/scene/2d/screen_button.cpp
@@ -335,6 +335,10 @@ Rect2 TouchScreenButton::_edit_get_rect() const {
 	return Rect2(Size2(), texture->get_size());
 }
 
+bool TouchScreenButton::_edit_use_rect() const {
+	return true;
+}
+
 void TouchScreenButton::set_visibility_mode(VisibilityMode p_mode) {
 	visibility = p_mode;
 	update();

--- a/scene/2d/screen_button.h
+++ b/scene/2d/screen_button.h
@@ -104,6 +104,7 @@ public:
 	bool is_pressed() const;
 
 	Rect2 _edit_get_rect() const;
+	virtual bool _edit_use_rect() const;
 
 	TouchScreenButton();
 };

--- a/scene/2d/sprite.cpp
+++ b/scene/2d/sprite.cpp
@@ -58,6 +58,14 @@ bool Sprite::_edit_use_pivot() const {
 	return true;
 }
 
+Rect2 Sprite::_edit_get_rect() const {
+	return get_rect();
+}
+
+bool Sprite::_edit_use_rect() const {
+	return true;
+}
+
 void Sprite::_get_rects(Rect2 &r_src_rect, Rect2 &r_dst_rect, bool &r_filter_clip) const {
 
 	Size2 s;

--- a/scene/2d/sprite.h
+++ b/scene/2d/sprite.h
@@ -74,7 +74,9 @@ public:
 	virtual Point2 _edit_get_pivot() const;
 	virtual bool _edit_use_pivot() const;
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
-	virtual Rect2 _edit_get_rect() const { return get_rect(); }
+
+	virtual Rect2 _edit_get_rect() const;
+	virtual bool _edit_use_rect() const;
 
 	void set_texture(const Ref<Texture> &p_texture);
 	Ref<Texture> get_texture() const;

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1119,6 +1119,10 @@ Rect2 TileMap::_edit_get_rect() const {
 	return rect_cache;
 }
 
+bool TileMap::_edit_use_rect() const {
+	return true;
+}
+
 void TileMap::set_collision_layer(uint32_t p_layer) {
 
 	collision_layer = p_layer;

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -245,6 +245,7 @@ public:
 	int get_cellv(const Vector2 &p_pos) const;
 
 	Rect2 _edit_get_rect() const;
+	virtual bool _edit_use_rect() const;
 
 	void make_bitmask_area_dirty(const Vector2 &p_pos);
 	void update_bitmask_area(const Vector2 &p_pos);

--- a/scene/2d/visibility_notifier_2d.cpp
+++ b/scene/2d/visibility_notifier_2d.cpp
@@ -89,6 +89,10 @@ Rect2 VisibilityNotifier2D::_edit_get_rect() const {
 	return rect;
 }
 
+bool VisibilityNotifier2D::_edit_use_rect() const {
+	return true;
+}
+
 Rect2 VisibilityNotifier2D::get_rect() const {
 
 	return rect;

--- a/scene/2d/visibility_notifier_2d.h
+++ b/scene/2d/visibility_notifier_2d.h
@@ -56,6 +56,7 @@ protected:
 
 public:
 	virtual Rect2 _edit_get_rect() const;
+	virtual bool _edit_use_rect() const;
 
 	void set_rect(const Rect2 &p_rect);
 	Rect2 get_rect() const;

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -94,6 +94,14 @@ Point2 Control::_edit_get_position() const {
 	return get_position();
 };
 
+void Control::_edit_set_scale(const Size2 &p_scale) {
+	set_scale(p_scale);
+}
+
+Size2 Control::_edit_get_scale() const {
+	return data.scale;
+}
+
 void Control::_edit_set_rect(const Rect2 &p_edit_rect) {
 	set_position((get_position() + get_transform().basis_xform(p_edit_rect.position)).snapped(Vector2(1, 1)));
 	set_size(p_edit_rect.size.snapped(Vector2(1, 1)));

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -280,6 +280,9 @@ public:
 	virtual void _edit_set_position(const Point2 &p_position);
 	virtual Point2 _edit_get_position() const;
 
+	virtual void _edit_set_scale(const Size2 &p_scale);
+	virtual Size2 _edit_get_scale() const;
+
 	virtual void _edit_set_rect(const Rect2 &p_edit_rect);
 	virtual Rect2 _edit_get_rect() const;
 	virtual bool _edit_use_rect() const;


### PR DESCRIPTION
In most cases, the rectangle surrounding a node in the 2D editor is not really pertinent, especially when it modifies the scale of a node. Indeed, it's pretty rare having to modify the scale of a Node, thus in most cases the rectangle is more annoying than useful. When necessary, this PR replaces the rect by a position marker that can still be moved an rotated.

Also, to know where to click to select the node, I added the display of the node icon+name when hovering hover the position point.

![output](https://user-images.githubusercontent.com/6093119/37389615-52e6f4c4-2765-11e8-888d-5c04bf8b913d.gif)

And one more thing, no more annoying rect for collision shapes. ;)
![output](https://user-images.githubusercontent.com/6093119/37389897-569b4e7a-2766-11e8-9ff9-85c9ca46c0fd.gif)

Also, fixes #17148, fixes #17101 and fixes #16454.
Fixes #4255.
Probably closes #13967 too.

