### PR TITLE
Ceil dynamic font glyph size

### DIFF
--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -308,6 +308,9 @@ Size2 DynamicFontAtSize::get_char_size(CharType p_char, CharType p_next, const V
 			ret.x += (delta.x >> 6) / oversampling;
 		}
 	}
+
+	// ensures oversampled glyphs will have enough space when this value is used by clipping/wrapping algorithms
+	ret.x = Math::ceil(ret.x);
 	return ret;
 }
 


### PR DESCRIPTION
Fixes #15459. When oversampling is enabled, glyphs may have fractional
size, but they are still rendered into integral pixels, which results in
them taking more space than was anticiped by autowrapping algorithm. The
solution here is to return ceiled width, which makes autowrapper
consider characters a bit larger than they are, but it doesn't hurt the
actual rendering and ensures there is enough space for the characters.

Still not entirely sure this is the best way to handle the problem, would appreciate input from @reduz.