### PR TITLE
add option to invert y-axis

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -403,6 +403,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// navigation
 	_initial_set("editors/3d/navigation/navigation_scheme", 0);
+	_initial_set("editors/3d/navigation/invert_y-axis", false);
 	hints["editors/3d/navigation/navigation_scheme"] = PropertyInfo(Variant::INT, "editors/3d/navigation/navigation_scheme", PROPERTY_HINT_ENUM, "Godot,Maya,Modo");
 	_initial_set("editors/3d/navigation/zoom_style", 0);
 	hints["editors/3d/navigation/zoom_style"] = PropertyInfo(Variant::INT, "editors/3d/navigation/zoom_style", PROPERTY_HINT_ENUM, "Vertical, Horizontal");

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -1907,8 +1907,13 @@ void SpatialEditorViewport::_nav_orbit(Ref<InputEventWithModifiers> p_event, con
 
 	real_t degrees_per_pixel = EditorSettings::get_singleton()->get("editors/3d/navigation_feel/orbit_sensitivity");
 	real_t radians_per_pixel = Math::deg2rad(degrees_per_pixel);
+	bool invert_y_axis = EditorSettings::get_singleton()->get("editors/3d/navigation/invert_y-axis");
 
-	cursor.x_rot += p_relative.y * radians_per_pixel;
+	if (invert_y_axis) {
+		cursor.x_rot -= p_relative.y * radians_per_pixel;
+	} else {
+		cursor.x_rot += p_relative.y * radians_per_pixel;
+	}
 	cursor.y_rot += p_relative.x * radians_per_pixel;
 	if (cursor.x_rot > Math_PI / 2.0)
 		cursor.x_rot = Math_PI / 2.0;
@@ -1925,11 +1930,16 @@ void SpatialEditorViewport::_nav_look(Ref<InputEventWithModifiers> p_event, cons
 	if (!orthogonal) {
 		real_t degrees_per_pixel = EditorSettings::get_singleton()->get("editors/3d/navigation_feel/orbit_sensitivity");
 		real_t radians_per_pixel = Math::deg2rad(degrees_per_pixel);
+		bool invert_y_axis = EditorSettings::get_singleton()->get("editors/3d/navigation/invert_y-axis");
 
 		// Note: do NOT assume the camera has the "current" transform, because it is interpolated and may have "lag".
 		Transform prev_camera_transform = to_camera_transform(cursor);
 
-		cursor.x_rot += p_relative.y * radians_per_pixel;
+		if (invert_y_axis) {
+			cursor.x_rot -= p_relative.y * radians_per_pixel;
+		} else {
+			cursor.x_rot += p_relative.y * radians_per_pixel;
+		}
 		cursor.y_rot += p_relative.x * radians_per_pixel;
 		if (cursor.x_rot > Math_PI / 2.0)
 			cursor.x_rot = Math_PI / 2.0;


### PR DESCRIPTION
This was suggested in issue #16926.

I'm new to Godot and I'm trying my hand at some issues to get familiar with the engine.
That one seemed simple so there should not be unforeseen side-effects.

I added the two options in editor settings.
Then I modified nav_look and nav_orbit so that cursor.x_rot moves in the opposite direction if the corresponding option is activated.

