### PR TITLE
Check only for WebGL 1.0 before starting downloads, move test to HTML file

### DIFF
--- a/misc/dist/html/default.html
+++ b/misc/dist/html/default.html
@@ -244,9 +244,6 @@ $GODOT_HEAD_INCLUDE
 			var statusMode = 'hidden';
 			var indeterminiateStatusAnimationId = 0;
 
-			setStatusMode('indeterminate');
-			engine.setCanvas(canvas);
-
 			function setStatusMode(mode) {
 
 				if (statusMode === mode || !initializing)
@@ -367,18 +364,27 @@ $GODOT_HEAD_INCLUDE
 				});
 			}
 
-			engine.startGame(BASENAME + '.pck').then(() => {
-				setStatusMode('hidden');
-				initializing = false;
-			}, err => {
+			function displayFailureNotice(err) {
+				var msg = err.message || err;
 				if (DEBUG_ENABLED) {
-					printError(err.message);
-					console.warn(err);
+					printError(msg);
 				}
-				setStatusNotice(err.message);
+				console.error(msg);
+				setStatusNotice(msg);
 				setStatusMode('notice');
 				initializing = false;
-			});
+			};
+
+			if (!Engine.isWebGLAvailable()) {
+				displayFailureNotice("WebGL not available");
+			} else {
+				setStatusMode('indeterminate');
+				engine.setCanvas(canvas);
+				engine.startGame(BASENAME + '.pck').then(() => {
+					setStatusMode('hidden');
+					initializing = false;
+				}, displayFailureNotice);
+			}
 		})();
 	//]]></script>
 </body>

--- a/platform/javascript/engine.js
+++ b/platform/javascript/engine.js
@@ -138,18 +138,6 @@
 			}
 
 			var actualCanvas = this.rtenv.canvas;
-			var testContext = false;
-			var testCanvas;
-			try {
-				testCanvas = document.createElement('canvas');
-				testContext = testCanvas.getContext('webgl2') || testCanvas.getContext('experimental-webgl2');
-			} catch (e) {}
-			if (!testContext) {
-				throw new Error("WebGL 2 not available");
-			}
-			testCanvas = null;
-			testContext = null;
-
 			// canvas can grab focus on click
 			if (actualCanvas.tabIndex < 0) {
 				actualCanvas.tabIndex = 0;
@@ -272,6 +260,20 @@
 	}; // Engine()
 
 	Engine.RuntimeEnvironment = engine.RuntimeEnvironment;
+
+	Engine.isWebGLAvailable = function(majorVersion = 1) {
+
+		var testContext = false;
+		try {
+			var testCanvas = document.createElement('canvas');
+			if (majorVersion === 1) {
+				testContext = testCanvas.getContext('webgl') || testCanvas.getContet('experimental-webgl');
+			} else if (majorVersion === 2) {
+				testContext = testCanvas.getContext('webgl2') || testCanvas.getContet('experimental-webgl2');
+			}
+		} catch (e) {}
+		return !!testContext;
+	};
 
 	Engine.load = function(newBasePath) {
 

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -444,6 +444,7 @@ Error OS_JavaScript::initialize(const VideoMode &p_desired, int p_video_driver, 
 			break;
 	}
 	EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx = emscripten_webgl_create_context(NULL, &attributes);
+	ERR_EXPLAIN("WebGL " + itos(attributes.majorVersion) + ".0 not available");
 	ERR_FAIL_COND_V(emscripten_webgl_make_context_current(ctx) != EMSCRIPTEN_RESULT_SUCCESS, ERR_UNAVAILABLE);
 
 	video_mode = p_desired;


### PR DESCRIPTION
Whether to use WebGL 1.0 or 2.0 can only be determined at runtime after reading project settings, so check for the lower version.

The test is now in the HTML file, so if desired WebGL 2.0 can be checked for instead by changing the behaviour there.
This is also necessary to allow skipping the check outright, once we want headless HTML5 builds.