### PR TITLE
fix AudioStreamPlayer2D not working when inside CanvasLayer

### DIFF
--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -157,9 +157,12 @@ void CanvasLayer::_notification(int p_what) {
 			VisualServer::get_singleton()->viewport_set_canvas_layer(viewport, canvas->get_canvas(), layer);
 			VisualServer::get_singleton()->viewport_set_canvas_transform(viewport, canvas->get_canvas(), transform);
 
+			canvas->_register_viewport(vp, Rect2());
+
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 
+			canvas->_remove_viewport(vp);
 			VisualServer::get_singleton()->viewport_remove_canvas(viewport, canvas->get_canvas());
 			viewport = RID();
 
@@ -184,6 +187,7 @@ RID CanvasLayer::get_viewport() const {
 void CanvasLayer::set_custom_viewport(Node *p_viewport) {
 	ERR_FAIL_NULL(p_viewport);
 	if (is_inside_tree()) {
+		canvas->_remove_viewport(vp);
 		VisualServer::get_singleton()->viewport_remove_canvas(viewport, canvas->get_canvas());
 		viewport = RID();
 	}
@@ -208,6 +212,8 @@ void CanvasLayer::set_custom_viewport(Node *p_viewport) {
 		VisualServer::get_singleton()->viewport_attach_canvas(viewport, canvas->get_canvas());
 		VisualServer::get_singleton()->viewport_set_canvas_layer(viewport, canvas->get_canvas(), layer);
 		VisualServer::get_singleton()->viewport_set_canvas_transform(viewport, canvas->get_canvas(), transform);
+
+		canvas->_register_viewport(vp, Rect2());
 	}
 }
 

--- a/scene/resources/world_2d.h
+++ b/scene/resources/world_2d.h
@@ -38,6 +38,7 @@
 class SpatialIndexer2D;
 class VisibilityNotifier2D;
 class Viewport;
+class CanvasLayer;
 
 class World2D : public Resource {
 
@@ -52,6 +53,7 @@ protected:
 	static void _bind_methods();
 	friend class Viewport;
 	friend class VisibilityNotifier2D;
+	friend class CanvasLayer;
 
 	void _register_viewport(Viewport *p_viewport, const Rect2 &p_rect);
 	void _update_viewport(Viewport *p_viewport, const Rect2 &p_rect);


### PR DESCRIPTION
Fixes #17523. I believe this is the cleanest fix possible. 

`World2D` needs to get `CanvasLayer` added as a friend since `CanvasLayer` needs to be able to call `_register_viewport` on its `world_2d.`

I also made sure to add corresponding calls to `_remove_viewport`.