### PR TITLE
Fixes scrollbars in Canvas Item Editor

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -201,7 +201,6 @@ class CanvasItemEditor : public VBoxContainer {
 	bool selection_menu_additive_selection;
 
 	Tool tool;
-	bool first_update;
 	Control *viewport;
 	Control *viewport_scrollable;
 
@@ -221,6 +220,8 @@ class CanvasItemEditor : public VBoxContainer {
 	bool show_viewport;
 	bool show_helpers;
 	float zoom;
+	Point2 view_offset;
+	Point2 previous_update_view_offset;
 
 	Point2 grid_offset;
 	Point2 grid_step;


### PR DESCRIPTION
The 2D editor had few problems with the scrollbars:
- The default offset was not taken into account.
- It had a weird behaviour when a node is moved to the left then brought back to the center (with a low zoom level). The scrollable area was updated while dragging the node, which is not really convinient.