### PR TITLE
Allow users to add items to Tool menu

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -141,6 +141,7 @@ private:
 		EDIT_REDO,
 		EDIT_REVERT,
 		TOOLS_ORPHAN_RESOURCES,
+		TOOLS_CUSTOM,
 		RESOURCE_NEW,
 		RESOURCE_LOAD,
 		RESOURCE_SAVE,
@@ -426,6 +427,7 @@ private:
 	void _menu_option(int p_option);
 	void _menu_confirm_current();
 	void _menu_option_confirm(int p_option, bool p_confirmed);
+	void _tool_menu_option(int p_idx);
 	void _update_debug_options();
 
 	void _property_editor_forward();
@@ -599,21 +601,6 @@ private:
 	bool _call_build();
 	static int build_callback_count;
 	static EditorBuildCallback build_callbacks[MAX_BUILD_CALLBACKS];
-
-	bool _initializing_tool_menu;
-
-	struct ToolMenuItem {
-		String name;
-		String submenu;
-		Variant ud;
-		ObjectID handler;
-		String callback;
-	};
-
-	Vector<ToolMenuItem> tool_menu_items;
-
-	void _tool_menu_insert_item(const ToolMenuItem &p_item);
-	void _rebuild_tool_menu() const;
 
 	bool _dimming;
 	float _dim_time;

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -421,21 +421,18 @@ void EditorPlugin::remove_control_from_container(CustomControlContainer p_locati
 }
 
 void EditorPlugin::add_tool_menu_item(const String &p_name, Object *p_handler, const String &p_callback, const Variant &p_ud) {
-
-	//EditorNode::get_singleton()->add_tool_menu_item(p_name, p_handler, p_callback, p_ud);
+	EditorNode::get_singleton()->add_tool_menu_item(p_name, p_handler, p_callback, p_ud);
 }
 
 void EditorPlugin::add_tool_submenu_item(const String &p_name, Object *p_submenu) {
-
 	ERR_FAIL_NULL(p_submenu);
 	PopupMenu *submenu = Object::cast_to<PopupMenu>(p_submenu);
 	ERR_FAIL_NULL(submenu);
-	//EditorNode::get_singleton()->add_tool_submenu_item(p_name, submenu);
+	EditorNode::get_singleton()->add_tool_submenu_item(p_name, submenu);
 }
 
 void EditorPlugin::remove_tool_menu_item(const String &p_name) {
-
-	//EditorNode::get_singleton()->remove_tool_menu_item(p_name);
+	EditorNode::get_singleton()->remove_tool_menu_item(p_name);
 }
 
 void EditorPlugin::set_input_event_forwarding_always_enabled() {
@@ -699,9 +696,9 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_control_from_docks", "control"), &EditorPlugin::remove_control_from_docks);
 	ClassDB::bind_method(D_METHOD("remove_control_from_bottom_panel", "control"), &EditorPlugin::remove_control_from_bottom_panel);
 	ClassDB::bind_method(D_METHOD("remove_control_from_container", "container", "control"), &EditorPlugin::remove_control_from_container);
-	//ClassDB::bind_method(D_METHOD("add_tool_menu_item", "name", "handler", "callback", "ud"),&EditorPlugin::add_tool_menu_item,DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("add_tool_menu_item", "name", "handler", "callback", "ud"), &EditorPlugin::add_tool_menu_item, DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("add_tool_submenu_item", "name", "submenu"), &EditorPlugin::add_tool_submenu_item);
-	//ClassDB::bind_method(D_METHOD("remove_tool_menu_item", "name"),&EditorPlugin::remove_tool_menu_item);
+	ClassDB::bind_method(D_METHOD("remove_tool_menu_item", "name"), &EditorPlugin::remove_tool_menu_item);
 	ClassDB::bind_method(D_METHOD("add_custom_type", "type", "base", "script", "icon"), &EditorPlugin::add_custom_type);
 	ClassDB::bind_method(D_METHOD("remove_custom_type", "type"), &EditorPlugin::remove_custom_type);
 


### PR DESCRIPTION
Added functions `add_tool_menu_item` and `remove_tool_menu_item` which were commented out and added logic to them. Also added logic to `add_tool_submenu_item`.

This allows users to create plugins that add items or submenus to the tools menu under Projects.

Fixes #9969