### PR TITLE
Tile randomizer for tilemap editor.

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.h
+++ b/editor/plugins/tile_map_editor_plugin.h
@@ -157,6 +157,7 @@ class TileMapEditor : public VBoxContainer {
 	List<TileData> copydata;
 
 	Map<Point2i, CellOp> undo_data;
+	Vector<int> invalid_cell;
 
 	void _pick_tile(const Point2 &p_pos);
 
@@ -173,8 +174,8 @@ class TileMapEditor : public VBoxContainer {
 
 	void _update_copydata();
 
-	int get_selected_tile() const;
-	void set_selected_tile(int p_tile);
+	Vector<int> get_selected_tiles() const;
+	void set_selected_tiles(Vector<int> p_tile);
 
 	void _manual_toggled(bool p_enabled);
 	void _text_entered(const String &p_text);
@@ -187,7 +188,7 @@ class TileMapEditor : public VBoxContainer {
 	void _start_undo(const String &p_action);
 	void _finish_undo();
 	void _create_set_cell_undo(const Vector2 &p_vec, const CellOp &p_cell_old, const CellOp &p_cell_new);
-	void _set_cell(const Point2i &p_pos, int p_value, bool p_flip_h = false, bool p_flip_v = false, bool p_transpose = false);
+	void _set_cell(const Point2i &p_pos, Vector<int> p_values, bool p_flip_h = false, bool p_flip_v = false, bool p_transpose = false);
 
 	void _canvas_mouse_enter();
 	void _canvas_mouse_exit();


### PR DESCRIPTION
The tile palette on the tilemap editor now accepts a multi-tile selection. One of these tiles will be randomly selected at drawing time.
This random selection affects all drawing operations except (naturally) erasing, but does not affect previews, nor tile flipping and rotation.