### PR TITLE
Removed unnecessary newlines from tscn

### DIFF
--- a/scene/resources/scene_format_text.cpp
+++ b/scene/resources/scene_format_text.cpp
@@ -1672,7 +1672,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_r
 				f->store_string(vars);
 			}
 
-			f->store_line("]\n");
+			f->store_line("]");
 
 			for (int j = 0; j < state->get_node_property_count(i); j++) {
 
@@ -1682,10 +1682,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_r
 				f->store_string(_valprop(String(state->get_node_property_name(i, j))) + " = " + vars + "\n");
 			}
 
-			if (state->get_node_property_count(i)) {
-				//add space
-				f->store_line(String());
-			}
+			f->store_line(String());
 		}
 
 		for (int i = 0; i < state->get_connection_count(); i++) {
@@ -1708,14 +1705,12 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_r
 				f->store_string(" binds= " + vars);
 			}
 
-			f->store_line("]\n");
+			f->store_line("]");
 		}
-
-		f->store_line(String());
 
 		Vector<NodePath> editable_instances = state->get_editable_instances();
 		for (int i = 0; i < editable_instances.size(); i++) {
-			f->store_line("[editable path=\"" + editable_instances[i].operator String() + "\"]");
+			f->store_line("\n[editable path=\"" + editable_instances[i].operator String() + "\"]");
 		}
 	}
 


### PR DESCRIPTION
References #6025. Made small changes to avoid adding newlines for no reason. I was working on fixing the whole bug, but I saw #17589 which I like more than my own fix.