### PR TITLE
Fix Mono builds with Python 3.

### DIFF
--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -161,7 +161,7 @@ def configure(env):
 
             mono_lib_path = ''
             mono_so_name = ''
-            mono_prefix = subprocess.check_output(["pkg-config", "mono-2", "--variable=prefix"]).strip()
+            mono_prefix = subprocess.check_output(["pkg-config", "mono-2", "--variable=prefix"], encoding="utf8").strip()
 
             tmpenv = Environment()
             tmpenv.AppendENVPath('PKG_CONFIG_PATH', os.getenv('PKG_CONFIG_PATH'))


### PR DESCRIPTION
A subprocess call wasn't specifying an encoding, so this gave a TypeError in Python 3.