### PR TITLE
Fix listing files inside directory in pack file

### DIFF
--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -88,7 +88,11 @@ void PackedData::add_path(const String &pkg_path, const String &path, uint64_t o
 				}
 			}
 		}
-		cd->files.insert(path.get_file());
+		String filename = path.get_file();
+		// Don't add as a file if the path points to a directoryy
+		if (!filename.empty()) {
+			cd->files.insert(filename);
+		}
 	}
 }
 


### PR DESCRIPTION
When adding a directory path to the inventory of the pack, an empty file name was being added to the file list. That made `Directory.get_next()` signal end-of-list too early so that files in a subdirectory were missed.

Fixes #15801.
Helps with #16798.