### PR TITLE
Fix bad rendering of BBCode tables in `RichTextLabel`

### DIFF
--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -87,6 +87,7 @@ private:
 		int height_accum_cache;
 		int char_count;
 		int minimum_width;
+		int maximum_width;
 
 		Line() {
 			from = NULL;
@@ -199,6 +200,7 @@ private:
 			bool expand;
 			int expand_ratio;
 			int min_width;
+			int max_width;
 			int width;
 		};
 


### PR DESCRIPTION
Fix bad rendering of BBCode tables in `RichTextLabel`

Text overflowed canvas as tables didn't calculate correctly the width
of their columns. They used the whole table width available for each
column. Also, the `cell` parameter was wrongly parsed if used with its
optional argument (expand ratio).

This PR fixs the parsing of `cell` parameter (i.e. `cell=e`) and the
distribution of the full table width between columns, but it overrides
automatically the `expand` flag if the column is smaller than it could
be, to allow a better UX out-of-the-box. It keeps the `expand_ratio`
flag to let the user customize how every column grows in relation to
the rest.

Partially fix #6289.