### PR TITLE
Disable Emscripten assertions in release_debug builds

### DIFF
--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -65,13 +65,14 @@ def configure(env):
 
     elif (env["target"] == "release_debug"):
         env.Append(CCFLAGS=['-O2', '-DDEBUG_ENABLED'])
-        env.Append(LINKFLAGS=['-O2', '-s', 'ASSERTIONS=1'])
+        env.Append(LINKFLAGS=['-O2'])
         # retain function names at the cost of file size, for backtraces and profiling
         env.Append(LINKFLAGS=['--profiling-funcs'])
 
     elif (env["target"] == "debug"):
         env.Append(CCFLAGS=['-O1', '-D_DEBUG', '-g', '-DDEBUG_ENABLED'])
         env.Append(LINKFLAGS=['-O1', '-g'])
+        env.Append(LINKFLAGS=['-s', 'ASSERTIONS=1'])
 
     ## Compiler configuration
 


### PR DESCRIPTION
The messages generated by some of these assertions can be confusing to users and are mostly useful when working on the engine code. The assertions are enabled in `target=debug` builds