### PR TITLE
Fix oversampled font artifacts after resize

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -498,13 +498,13 @@ bool SceneTree::idle(float p_time) {
 	Size2 win_size = Size2(OS::get_singleton()->get_video_mode().width, OS::get_singleton()->get_video_mode().height);
 	if (win_size != last_screen_size) {
 
+		last_screen_size = win_size;
+		_update_root_rect();
+
 		if (use_font_oversampling) {
 			DynamicFontAtSize::font_oversampling = OS::get_singleton()->get_window_size().width / root->get_visible_rect().size.width;
 			DynamicFont::update_oversampling();
 		}
-
-		last_screen_size = win_size;
-		_update_root_rect();
 
 		emit_signal("screen_resized");
 	}


### PR DESCRIPTION
Font update after resize relies on the viewport size which was updated
after the font was already refreshed, which resulted in artifacts when
it was rendered into the actual/new viewport size.

Fixes #15173.