### PR TITLE
Fix mono build properly!

### DIFF
--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -161,7 +161,7 @@ def configure(env):
 
             mono_lib_path = ''
             mono_so_name = ''
-            mono_prefix = subprocess.check_output(["pkg-config", "mono-2", "--variable=prefix"], encoding="utf8").strip()
+            mono_prefix = subprocess.check_output(["pkg-config", "mono-2", "--variable=prefix"]).decode("utf8").strip()
 
             tmpenv = Environment()
             tmpenv.AppendENVPath('PKG_CONFIG_PATH', os.getenv('PKG_CONFIG_PATH'))


### PR DESCRIPTION
Fixes the mistake I made in #17603 to make it require Python >= 3.6.