### PR TITLE
Fixes moving files causes scene corruption

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1162,9 +1162,11 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 		ERR_FAIL_V(ERR_FILE_UNRECOGNIZED);
 	}
 
-	fw->store_32(VERSION_MAJOR); //current version
-	fw->store_32(VERSION_MINOR);
-	fw->store_32(FORMAT_VERSION);
+	// Since we're not actually converting the file contents, leave the version
+	// numbers in the file untouched.
+	fw->store_32(ver_major);
+	fw->store_32(ver_minor);
+	fw->store_32(ver_format);
 
 	save_ustring(fw, get_ustring(f)); //type
 


### PR DESCRIPTION
This commit fixes issue #17585: renaming/moving resources can corrupt
scene files.  The corruption was caused by
'ResourceFormatLoaderBinary::rename_dependencies' updating the file
format version field of the affected scene file to the latest version
without actually updating the content of the file to that version,
resulting in a file whose content does not match its file format version
field.  The fix preserves the file format version field and the engine
version fields when renaming dependencies.