### PR TITLE
Fix crash in `canvas_item_add_polyline` when passing more points than colors

### DIFF
--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -440,13 +440,17 @@ void VisualServerCanvas::canvas_item_add_polyline(RID p_item, const Vector<Point
 			if (p_antialiased) {
 				pline->line_colors.push_back(Color(1, 1, 1, 1));
 			}
-		}
-		if (p_colors.size() == 1) {
+		} else if (p_colors.size() == 1) {
 			pline->triangle_colors = p_colors;
 			pline->line_colors = p_colors;
 		} else {
-			pline->triangle_colors.resize(pline->triangles.size());
-			pline->line_colors.resize(pline->lines.size());
+			if (p_colors.size() != p_points.size()) {
+				pline->triangle_colors.push_back(p_colors[0]);
+				pline->line_colors.push_back(p_colors[0]);
+			} else {
+				pline->triangle_colors.resize(pline->triangles.size());
+				pline->line_colors.resize(pline->lines.size());
+			}
 		}
 
 		for (int i = 0; i < p_points.size(); i++) {


### PR DESCRIPTION
Fix crash in `canvas_item_add_polyline` when passing more points than colors

When `p_points.size() > p_colors.size()`, it crashed with invalid
array access to `p_colors`. Also, when `p_colors` was an empty
`Vector` it crashed due a missing `else` checking the `size`
condition, as the code handling that special case exists.

This PR fixes the missing `else` for `p_colors.size == 0` and,
following the `canvas_item_add_multiline` spirit, it only uses the
first color for the whole polyline if points and colors differ in
size.

Fix #17621.