### PR TITLE
Fix getting Android device information (2.1)

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1505,8 +1505,7 @@ void EditorExportPlatformAndroid::_device_poll_thread(void *ud) {
 						args.push_back("-s");
 						args.push_back(d.id);
 						args.push_back("shell");
-						args.push_back("cat");
-						args.push_back("/system/build.prop");
+						args.push_back("getprop");
 						int ec;
 						String dp;
 
@@ -1519,7 +1518,14 @@ void EditorExportPlatformAndroid::_device_poll_thread(void *ud) {
 						d.api_level = 0;
 						for (int j = 0; j < props.size(); j++) {
 
+							// got information by `shell cat /system/build.prop` before and its format is "property=value"
+							// it's now changed to use `shell getporp` because of permission issue with Android 8.0 and above
+							// its format is "[property]: [value]" so changed it as like build.prop
 							String p = props[j];
+							p = p.replace("]: ", "=");
+							p = p.replace("[", "");
+							p = p.replace("]", "");
+
 							if (p.begins_with("ro.product.model=")) {
 								device = p.get_slice("=", 1).strip_edges();
 							} else if (p.begins_with("ro.product.brand=")) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8281454/37637250-f2eaa61c-2c49-11e8-8e99-36aa7ac640fb.png)

This PR fixes showing empty item on device list if Android >= 8.0