### PR TITLE
Add RWLockDummy for NO_THREADS builds

### DIFF
--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -33,17 +33,8 @@
 #include "os/mutex.h"
 #include "version.h"
 
-#ifdef NO_THREADS
-
-#define OBJTYPE_RLOCK
-#define OBJTYPE_WLOCK
-
-#else
-
 #define OBJTYPE_RLOCK RWLockRead _rw_lockr_(lock);
 #define OBJTYPE_WLOCK RWLockWrite _rw_lockw_(lock);
-
-#endif
 
 #ifdef DEBUG_METHODS_ENABLED
 
@@ -895,15 +886,9 @@ void ClassDB::add_property_group(StringName p_class, const String &p_name, const
 
 void ClassDB::add_property(StringName p_class, const PropertyInfo &p_pinfo, const StringName &p_setter, const StringName &p_getter, int p_index) {
 
-#ifndef NO_THREADS
 	lock->read_lock();
-#endif
-
 	ClassInfo *type = classes.getptr(p_class);
-
-#ifndef NO_THREADS
 	lock->read_unlock();
-#endif
 
 	ERR_FAIL_COND(!type);
 
@@ -1380,10 +1365,7 @@ RWLock *ClassDB::lock = NULL;
 
 void ClassDB::init() {
 
-#ifndef NO_THREADS
-
 	lock = RWLock::create();
-#endif
 }
 
 void ClassDB::cleanup() {
@@ -1406,10 +1388,7 @@ void ClassDB::cleanup() {
 	resource_base_extensions.clear();
 	compat_classes.clear();
 
-#ifndef NO_THREADS
-
 	memdelete(lock);
-#endif
 }
 
 //

--- a/core/os/thread_dummy.cpp
+++ b/core/os/thread_dummy.cpp
@@ -55,3 +55,11 @@ Semaphore *SemaphoreDummy::create() {
 void SemaphoreDummy::make_default() {
 	Semaphore::create_func = &SemaphoreDummy::create;
 };
+
+RWLock *RWLockDummy::create() {
+	return memnew(RWLockDummy);
+};
+
+void RWLockDummy::make_default() {
+	RWLock::create_func = &RWLockDummy::create;
+};

--- a/core/os/thread_dummy.h
+++ b/core/os/thread_dummy.h
@@ -32,6 +32,7 @@
 #define THREAD_DUMMY_H
 
 #include "mutex.h"
+#include "rw_lock.h"
 #include "semaphore.h"
 #include "thread.h"
 
@@ -65,6 +66,22 @@ public:
 	virtual Error wait() { return OK; };
 	virtual Error post() { return OK; };
 	virtual int get() const { return 0; }; ///< get semaphore value
+
+	static void make_default();
+};
+
+class RWLockDummy : public RWLock {
+
+	static RWLock *create();
+
+public:
+	virtual void read_lock() {}
+	virtual void read_unlock() {}
+	virtual Error read_try_lock() { return OK; }
+
+	virtual void write_lock() {}
+	virtual void write_unlock() {}
+	virtual Error write_try_lock() { return OK; }
 
 	static void make_default();
 };

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -89,10 +89,11 @@ void handle_sigchld(int sig) {
 
 void OS_Unix::initialize_core() {
 
-#ifdef NO_PTHREADS
+#ifdef NO_THREADS
 	ThreadDummy::make_default();
 	SemaphoreDummy::make_default();
 	MutexDummy::make_default();
+	RWLockDummy::make_default();
 #else
 	ThreadPosix::make_default();
 	SemaphorePosix::make_default();

--- a/drivers/unix/thread_posix.cpp
+++ b/drivers/unix/thread_posix.cpp
@@ -31,7 +31,7 @@
 #include "thread_posix.h"
 #include "script_language.h"
 
-#if defined(UNIX_ENABLED) || defined(PTHREAD_ENABLED)
+#if (defined(UNIX_ENABLED) || defined(PTHREAD_ENABLED)) && !defined(NO_THREADS)
 
 #ifdef PTHREAD_BSD_SET_NAME
 #include <pthread_np.h>

--- a/drivers/unix/thread_posix.h
+++ b/drivers/unix/thread_posix.h
@@ -35,7 +35,7 @@
 	@author Juan Linietsky <reduzio@gmail.com>
 */
 
-#if defined(UNIX_ENABLED) || defined(PTHREAD_ENABLED)
+#if (defined(UNIX_ENABLED) || defined(PTHREAD_ENABLED)) && !defined(NO_THREADS)
 
 #include "os/thread.h"
 #include <pthread.h>

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -103,7 +103,7 @@ def configure(env):
     ## Compile flags
 
     env.Append(CPPPATH=['#platform/javascript'])
-    env.Append(CPPFLAGS=['-DJAVASCRIPT_ENABLED', '-DUNIX_ENABLED', '-DPTHREAD_NO_RENAME', '-DTYPED_METHOD_BIND', '-DNO_THREADS'])
+    env.Append(CPPFLAGS=['-DJAVASCRIPT_ENABLED', '-DUNIX_ENABLED', '-DTYPED_METHOD_BIND', '-DNO_THREADS'])
     env.Append(CPPFLAGS=['-DGLES3_ENABLED'])
 
     # These flags help keep the file size down


### PR DESCRIPTION
This lets OS_Unix build with `-DNO_THREADS` without any pthread calls. With RWLockDummy we avoid adding several `#ifdef`s to core classes.
Also lets us remove a confusing `PTHREAD_` flag from javascript builds.