### PR TITLE
Add --print-fps option to output FPS to stdout

### DIFF
--- a/misc/dist/linux/godot.6
+++ b/misc/dist/linux/godot.6
@@ -119,6 +119,9 @@ Disable crash handler when supported by the platform code.
 .TP
 \fB\-\-fixed\-fps\fR <fps>
 Force a fixed number of frames per second. This setting disables real\-time synchronization.
+.TP
+\fB\-\-print\-fps\fR
+Print the frames per second to the stdout.
 .SS "Standalone tools:"
 .TP
 \fB\-s\fR, \fB\-\-script\fR <script>


### PR DESCRIPTION
Works both for the editor and games.

Projects can still use "debug/settings/stdout/print_fps" to enable it
permanently. The --print-fps option takes precedence (so works even if
the project setting is disabled). That setting is also no longer redefined
on the fly based on the verbose flag, that was a mess.

----

Another take on #16005 since there are use cases for printing the editor FPS (see https://github.com/godotengine/godot/issues/17584#issuecomment-374649215).

I initially went for an editor setting, but redefining it based on the verbose flag as done for "debug/settings/stdout/print_fps" turns out to be a mess (e.g. if you run `godot -v`, it will be turned on - if you then quit Godot and run `godot` (non verbose), it's still on due to the previous definition, albeit shown as revertable). So I moved to a command line option instead, and removed the "verbose dependent" logic for "debug/settings/stdout/print_fps".