### PR TITLE
Prevented external editor from running multiple times

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1599,7 +1599,8 @@ void EditorNode::_edit_current() {
 
 		// special case if use of external editor is true
 		if (main_plugin->get_name() == "Script" && (bool(EditorSettings::get_singleton()->get("text_editor/external/use_external_editor")) || overrides_external_editor(current_obj))) {
-			main_plugin->edit(current_obj);
+			if (!changing_scene)
+				main_plugin->edit(current_obj);
 		}
 
 		else if (main_plugin != editor_plugin_screen && (!ScriptEditor::get_singleton() || !ScriptEditor::get_singleton()->is_visible_in_tree() || ScriptEditor::get_singleton()->can_take_away_focus())) {


### PR DESCRIPTION
Fixes #16923 I think. I'm not a fan of the special case for scripts in editor_node.cpp, but in any case,
I made it so it wouldn't make the external editor to re-open just because we switched scenes.