### PR TITLE
Fix several in-class initialization clang warning

### DIFF
--- a/core/command_queue_mt.cpp
+++ b/core/command_queue_mt.cpp
@@ -105,6 +105,7 @@ CommandQueueMT::CommandQueueMT(bool p_sync) {
 
 	read_ptr = 0;
 	write_ptr = 0;
+	dealloc_ptr = 0;
 	mutex = Mutex::create();
 
 	for (int i = 0; i < SYNC_SEMAPHORES; i++) {

--- a/core/command_queue_mt.h
+++ b/core/command_queue_mt.h
@@ -309,9 +309,9 @@ class CommandQueueMT {
 	};
 
 	uint8_t command_mem[COMMAND_MEM_SIZE];
-	uint32_t read_ptr = 0;
-	uint32_t write_ptr = 0;
-	uint32_t dealloc_ptr = 0;
+	uint32_t read_ptr;
+	uint32_t write_ptr;
+	uint32_t dealloc_ptr;
 	SyncSemaphore sync_sems[SYNC_SEMAPHORES];
 	Mutex *mutex;
 	Semaphore *sync;

--- a/core/reference.h
+++ b/core/reference.h
@@ -63,7 +63,7 @@ public:
 template <class T>
 class Ref {
 
-	T *reference = NULL;
+	T *reference;
 
 	void ref(const Ref &p_from) {
 
@@ -213,10 +213,9 @@ public:
 
 	Ref(T *p_reference) {
 
+		reference = NULL;
 		if (p_reference)
 			ref_pointer(p_reference);
-		else
-			reference = NULL;
 	}
 
 	Ref(const Variant &p_variant) {

--- a/core/string_buffer.h
+++ b/core/string_buffer.h
@@ -39,7 +39,7 @@ class StringBuffer {
 
 	CharType short_buffer[SHORT_BUFFER_SIZE];
 	String buffer;
-	int string_length = 0;
+	int string_length;
 
 	_FORCE_INLINE_ CharType *current_buffer_ptr() {
 		return static_cast<Vector<CharType> &>(buffer).empty() ? short_buffer : buffer.ptrw();
@@ -78,6 +78,10 @@ public:
 
 	_FORCE_INLINE_ operator String() {
 		return as_string();
+	}
+
+	StringBuffer() {
+		string_length = 0;
 	}
 };
 

--- a/core/string_builder.h
+++ b/core/string_builder.h
@@ -37,7 +37,7 @@
 
 class StringBuilder {
 
-	uint32_t string_length = 0;
+	uint32_t string_length;
 
 	Vector<String> strings;
 	Vector<const char *> c_strings;
@@ -74,6 +74,10 @@ public:
 
 	_FORCE_INLINE_ operator String() const {
 		return as_string();
+	}
+
+	StringBuilder() {
+		string_length = 0;
 	}
 };
 

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -100,7 +100,7 @@ public:
 	id context;
 
 	CursorShape cursor_shape;
-	NSCursor *cursors[CURSOR_MAX] = { NULL };
+	NSCursor *cursors[CURSOR_MAX];
 	MouseMode mouse_mode;
 
 	String title;

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -2369,6 +2369,7 @@ OS_OSX *OS_OSX::singleton = NULL;
 
 OS_OSX::OS_OSX() {
 
+	memset(cursors, 0, sizeof(cursors));
 	key_event_pos = 0;
 	mouse_mode = OS::MOUSE_MODE_VISIBLE;
 	main_loop = NULL;


### PR DESCRIPTION
This fixes most of this clang warnings: `warning: in-class initialization of non-static data member is a C++11 extension`