### PR TITLE
Fix for clang warning at distance_to

### DIFF
--- a/core/math/math_2d.h
+++ b/core/math/math_2d.h
@@ -303,7 +303,7 @@ struct Rect2 {
 
 	inline real_t distance_to(const Vector2 &p_point) const {
 
-		real_t dist;
+		real_t dist = 0.0;
 		bool inside = true;
 
 		if (p_point.x < position.x) {


### PR DESCRIPTION
Fixes this warning: `warning: variable 'dist' is uninitialized when used here [-Wuninitialized]`
I know that it's not really used uninitialized but that warning is everywhere when compiling with clang, this makes it easier to find other useful warnings.