### PR TITLE
Extended node rename function to also support renaming  node path script instance property

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -933,7 +933,13 @@ void SceneTreeDock::perform_node_renames(Node *p_base, List<Pair<NodePath, NodeP
 						NodePath root_path = p_base->get_path();
 
 						NodePath rel_path_old = root_path.rel_path_to(E->get().first);
-						NodePath rel_path_new = root_path.rel_path_to(E->get().second);
+
+						NodePath rel_path_new = E->get().second;
+
+						// if not empty, get new relative path
+						if (E->get().second != NodePath()) {
+							rel_path_new = root_path.rel_path_to(E->get().second);
+						}
 
 						// if old path detected, then it needs to be replaced with the new one
 						if (p == rel_path_old) {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -903,9 +903,6 @@ void SceneTreeDock::perform_node_renames(Node *p_base, List<Pair<NodePath, NodeP
 	if (!r_rem_anims)
 		r_rem_anims = &rem_anims;
 
-	if (!bool(EDITOR_DEF("editors/animation/autorename_animation_tracks", true)))
-		return;
-
 	if (!p_base) {
 
 		p_base = edited_scene;
@@ -914,7 +911,48 @@ void SceneTreeDock::perform_node_renames(Node *p_base, List<Pair<NodePath, NodeP
 	if (!p_base)
 		return;
 
-	if (Object::cast_to<AnimationPlayer>(p_base)) {
+	// Renaming node paths used in script instances
+	if (p_base->get_script_instance()) {
+
+		ScriptInstance *si = p_base->get_script_instance();
+
+		if (si) {
+
+			List<PropertyInfo> properties;
+			si->get_property_list(&properties);
+
+			for (List<PropertyInfo>::Element *E = properties.front(); E; E = E->next()) {
+
+				String propertyname = E->get().name;
+				Variant p = p_base->get(propertyname);
+				if (p.get_type() == Variant::NODE_PATH) {
+
+					// Goes through all paths to check if its matching
+					for (List<Pair<NodePath, NodePath> >::Element *E = p_renames->front(); E; E = E->next()) {
+
+						NodePath root_path = p_base->get_path();
+
+						NodePath rel_path_old = root_path.rel_path_to(E->get().first);
+						NodePath rel_path_new = root_path.rel_path_to(E->get().second);
+
+						// if old path detected, then it needs to be replaced with the new one
+						if (p == rel_path_old) {
+
+							editor_data->get_undo_redo().add_do_property(p_base, propertyname, rel_path_new);
+							editor_data->get_undo_redo().add_undo_property(p_base, propertyname, rel_path_old);
+
+							p_base->set(propertyname, rel_path_new);
+							break;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	bool autorename_animation_tracks = bool(EDITOR_DEF("editors/animation/autorename_animation_tracks", true));
+
+	if (autorename_animation_tracks && Object::cast_to<AnimationPlayer>(p_base)) {
 
 		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_base);
 		List<StringName> anims;
@@ -1145,7 +1183,30 @@ void SceneTreeDock::_do_reparent(Node *p_new_parent, int p_position_in_parent, V
 			editor_data->get_undo_redo().add_do_method(new_parent, "move_child", node, p_position_in_parent + inc);
 
 		ScriptEditorDebugger *sed = ScriptEditor::get_singleton()->get_debugger();
+		String old_name = former_names[ni];
 		String new_name = new_parent->validate_child_name(node);
+
+		// name was modified, fix the path renames
+		if (old_name.casecmp_to(new_name) != 0) {
+
+			// Fix the to name to have the new name
+			NodePath old_new_name = path_renames[ni].second;
+			NodePath new_path;
+
+			Vector<StringName> unfixed_new_names = old_new_name.get_names();
+			Vector<StringName> fixed_new_names;
+
+			// Get last name and replace with fixed new name
+			for (int a = 0; a < (unfixed_new_names.size() - 1); a++) {
+				fixed_new_names.push_back(unfixed_new_names[a]);
+			}
+			fixed_new_names.push_back(new_name);
+
+			NodePath fixed_node_path = NodePath(fixed_new_names, true);
+
+			path_renames[ni].second = fixed_node_path;
+		}
+
 		editor_data->get_undo_redo().add_do_method(sed, "live_debug_reparent_node", edited_scene->get_path_to(node), edited_scene->get_path_to(new_parent), new_name, -1);
 		editor_data->get_undo_redo().add_undo_method(sed, "live_debug_reparent_node", NodePath(String(edited_scene->get_path_to(new_parent)) + "/" + new_name), edited_scene->get_path_to(node->get_parent()), node->get_name(), node->get_index());
 


### PR DESCRIPTION
Node paths set in script instance now get renamed properly so that they point to the new node location and potential new node name.

I also updated the rename list after the validate_child_name function gets called.
This fixes a bug in animation rename functionality which could occur when you reparent a node to a parent which already contains a node with the same name.