### PR TITLE
Add encrypt_text/decrypt_text function using aes256 EBC algorithm

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -37,6 +37,8 @@
 #include "ucaps.h"
 #include "variant.h"
 
+#include "thirdparty/misc/aes256.h"
+#include "thirdparty/misc/base64.h"
 #include "thirdparty/misc/md5.h"
 #include "thirdparty/misc/sha256.h"
 
@@ -2153,6 +2155,107 @@ String String::sha256_text() const {
 	return String::hex_encode_buffer(hash, 32);
 }
 
+String String::encrypt_text(const String &p_key) const {
+
+	// Validate key
+	String cs = p_key.md5_text();
+
+	ERR_FAIL_COND_V(cs.length() != 32, String());
+
+	Vector<uint8_t> key;
+	key.resize(32);
+	for (int i = 0; i < 32; i++) {
+
+		key[i] = cs[i];
+	}
+
+	// Prepare buffer
+	const CharType *clear_str = c_str();
+	Vector<uint8_t> encrypted_buf;
+
+	// Note:
+	// Converting extended ascii to char, 4 bytes to 1 (due to unsigned/signed types).
+	// This has to be done only in the encryption part.
+	size_t len = length() * 4;
+	if (len % 16) {
+		len += 16 - (len % 16);
+	}
+
+	encrypted_buf.resize(len);
+	zeromem(encrypted_buf.ptrw(), len);
+	for (int i = 0; i < length() * 4; i++) {
+		encrypted_buf[i] = ((uint8_t *)clear_str)[i];
+	}
+
+	aes256_context ctx;
+	aes256_init(&ctx, key.ptrw());
+
+	for (size_t i = 0; i < len; i += 16) {
+
+		aes256_encrypt_ecb(&ctx, &encrypted_buf[i]);
+	}
+
+	aes256_done(&ctx);
+
+	// Preparing encrypted buffer encoded in base64
+	len = encrypted_buf.size();
+	size_t b64len = len / 3 * 4 + 4 + 1;
+
+	Vector<uint8_t> encrypted_buf_base64;
+	encrypted_buf_base64.resize(b64len);
+	zeromem((char *)(&encrypted_buf_base64[0]), len);
+
+	size_t strlen = base64_encode((char *)(&encrypted_buf_base64[0]), (char *)(&encrypted_buf[0]), len);
+	encrypted_buf_base64[strlen] = 0;
+	String encrypted_str = (char *)&encrypted_buf_base64[0];
+
+	return encrypted_str;
+}
+
+String String::decrypt_text(const String &p_key) const {
+
+	// Validate key
+	String cs = p_key.md5_text();
+
+	ERR_FAIL_COND_V(cs.length() != 32, String());
+
+	Vector<uint8_t> key;
+	key.resize(32);
+	for (int i = 0; i < 32; i++) {
+
+		key[i] = cs[i];
+	}
+
+	// Prepare buffer, base64 to raw array
+	size_t strlen = length();
+	CharString cstr = utf8();
+
+	size_t len;
+	Vector<uint8_t> decrypted_buf;
+	{
+		decrypted_buf.resize(strlen / 4 * 3 + 1);
+
+		len = base64_decode((char *)(&decrypted_buf[0]), (char *)cstr.get_data(), strlen);
+	};
+	decrypted_buf.resize(len);
+
+	aes256_context ctx;
+	aes256_init(&ctx, key.ptrw());
+
+	for (size_t i = 0; i < len; i += 16) {
+
+		aes256_decrypt_ecb(&ctx, &decrypted_buf[i]);
+	}
+
+	aes256_done(&ctx);
+
+	// decrypted_buf is originally stored using unsigned short, this is
+	// why we are casting it to CharType
+	String decrypted_str = (CharType *)&decrypted_buf[0];
+
+	return decrypted_str;
+}
+
 Vector<uint8_t> String::md5_buffer() const {
 
 	CharString cs = utf8();
@@ -3097,6 +3200,7 @@ String String::humanize_size(size_t p_size) {
 
 	return String::num(p_size / divisor, digits) + prefix[prefix_idx];
 }
+
 bool String::is_abs_path() const {
 
 	if (length() > 1)

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -208,6 +208,10 @@ public:
 	uint64_t hash64() const; /* hash the string */
 	String md5_text() const;
 	String sha256_text() const;
+
+	String encrypt_text(const String &p_key) const;
+	String decrypt_text(const String &p_key) const;
+
 	Vector<uint8_t> md5_buffer() const;
 	Vector<uint8_t> sha256_buffer() const;
 

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -272,6 +272,8 @@ struct _VariantCall {
 	VCALL_LOCALMEM0R(String, hash);
 	VCALL_LOCALMEM0R(String, md5_text);
 	VCALL_LOCALMEM0R(String, sha256_text);
+	VCALL_LOCALMEM1R(String, encrypt_text);
+	VCALL_LOCALMEM1R(String, decrypt_text);
 	VCALL_LOCALMEM0R(String, md5_buffer);
 	VCALL_LOCALMEM0R(String, sha256_buffer);
 	VCALL_LOCALMEM0R(String, empty);
@@ -1469,6 +1471,8 @@ void register_variant_methods() {
 	ADDFUNC0R(STRING, INT, String, hash, varray());
 	ADDFUNC0R(STRING, STRING, String, md5_text, varray());
 	ADDFUNC0R(STRING, STRING, String, sha256_text, varray());
+	ADDFUNC1R(STRING, STRING, String, encrypt_text, STRING, "key", varray());
+	ADDFUNC1R(STRING, STRING, String, decrypt_text, STRING, "key", varray());
 	ADDFUNC0R(STRING, POOL_BYTE_ARRAY, String, md5_buffer, varray());
 	ADDFUNC0R(STRING, POOL_BYTE_ARRAY, String, sha256_buffer, varray());
 	ADDFUNC0R(STRING, BOOL, String, empty, varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -273,6 +273,15 @@
 				Performs a case-sensitive comparison to another string. Returns [code]-1[/code] if less than, [code]+1[/code] if greater than, or [code]0[/code] if equal.
 			</description>
 		</method>
+		<method name="decrypt_text">
+			<return type="String">
+			</return>
+			<argument index="0" name="key" type="String">
+			</argument>
+			<description>
+				Copy the String and return it decrypted.
+			</description>
+		</method>
 		<method name="dedent">
 			<return type="String">
 			</return>
@@ -285,6 +294,15 @@
 			</return>
 			<description>
 				Returns [code]true[/code] if the string is empty.
+			</description>
+		</method>
+		<method name="encrypt_text">
+			<return type="String">
+			</return>
+			<argument index="0" name="key" type="String">
+			</argument>
+			<description>
+				Copy the String and return it encrypted.
 			</description>
 		</method>
 		<method name="ends_with">


### PR DESCRIPTION
Porting https://github.com/godotengine/godot/pull/17366 to master branch. Fix this issue: https://github.com/godotengine/godot/issues/1969

Warning it uses [AES EBC encryption and CBC would be a better alternative](https://datalocker.com/what-is-the-difference-between-ecb-mode-versus-cbc-mode-aes-encryption/).