### PR TITLE
Added new audio device functions to set/get the audio device

### DIFF
--- a/drivers/alsa/audio_driver_alsa.h
+++ b/drivers/alsa/audio_driver_alsa.h
@@ -44,8 +44,14 @@ class AudioDriverALSA : public AudioDriver {
 
 	snd_pcm_t *pcm_handle;
 
-	int32_t *samples_in;
-	int16_t *samples_out;
+	String device_name;
+	String new_device;
+
+	Vector<int32_t> samples_in;
+	Vector<int16_t> samples_out;
+
+	Error init_device();
+	void finish_device();
 
 	static void thread_func(void *p_udata);
 
@@ -71,6 +77,9 @@ public:
 	virtual void start();
 	virtual int get_mix_rate() const;
 	virtual SpeakerMode get_speaker_mode() const;
+	virtual Array get_device_list();
+	virtual String get_device();
+	virtual void set_device(String device);
 	virtual void lock();
 	virtual void unlock();
 	virtual void finish();

--- a/drivers/coreaudio/audio_driver_coreaudio.h
+++ b/drivers/coreaudio/audio_driver_coreaudio.h
@@ -43,11 +43,11 @@
 class AudioDriverCoreAudio : public AudioDriver {
 
 	AudioComponentInstance audio_unit;
-#ifdef OSX_ENABLED
-	AudioObjectPropertyAddress outputDeviceAddress;
-#endif
+
 	bool active;
 	Mutex *mutex;
+
+	String device_name;
 
 	int mix_rate;
 	unsigned int channels;
@@ -56,14 +56,18 @@ class AudioDriverCoreAudio : public AudioDriver {
 
 	Vector<int32_t> samples_in;
 
+	static OSStatus output_device_address_cb(AudioObjectID inObjectID,
+			UInt32 inNumberAddresses, const AudioObjectPropertyAddress *inAddresses,
+			void *inClientData);
+
 	static OSStatus output_callback(void *inRefCon,
 			AudioUnitRenderActionFlags *ioActionFlags,
 			const AudioTimeStamp *inTimeStamp,
 			UInt32 inBusNumber, UInt32 inNumberFrames,
 			AudioBufferList *ioData);
 
-	Error initDevice();
-	Error finishDevice();
+	Error init_device();
+	Error finish_device();
 
 public:
 	const char *get_name() const {
@@ -74,12 +78,16 @@ public:
 	virtual void start();
 	virtual int get_mix_rate() const;
 	virtual SpeakerMode get_speaker_mode() const;
+#ifdef OSX_ENABLED
+	virtual Array get_device_list();
+	virtual String get_device();
+	virtual void set_device(String device);
+#endif
 	virtual void lock();
 	virtual void unlock();
 	virtual void finish();
 
 	bool try_lock();
-	Error reopen();
 
 	AudioDriverCoreAudio();
 	~AudioDriverCoreAudio();

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -35,6 +35,8 @@
 #include "os/os.h"
 #include "project_settings.h"
 
+#include <functiondiscoverykeys.h>
+
 const CLSID CLSID_MMDeviceEnumerator = __uuidof(MMDeviceEnumerator);
 const IID IID_IMMDeviceEnumerator = __uuidof(IMMDeviceEnumerator);
 const IID IID_IAudioClient = __uuidof(IAudioClient);
@@ -121,7 +123,61 @@ Error AudioDriverWASAPI::init_device(bool reinit) {
 	HRESULT hr = CoCreateInstance(CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL, IID_IMMDeviceEnumerator, (void **)&enumerator);
 	ERR_FAIL_COND_V(hr != S_OK, ERR_CANT_OPEN);
 
-	hr = enumerator->GetDefaultAudioEndpoint(eRender, eConsole, &device);
+	if (device_name == "Default") {
+		hr = enumerator->GetDefaultAudioEndpoint(eRender, eConsole, &device);
+	} else {
+		IMMDeviceCollection *devices = NULL;
+
+		hr = enumerator->EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE, &devices);
+		ERR_FAIL_COND_V(hr != S_OK, ERR_CANT_OPEN);
+
+		LPWSTR strId = NULL;
+		bool found = false;
+
+		UINT count = 0;
+		hr = devices->GetCount(&count);
+		ERR_FAIL_COND_V(hr != S_OK, ERR_CANT_OPEN);
+
+		for (ULONG i = 0; i < count && !found; i++) {
+			IMMDevice *device = NULL;
+
+			hr = devices->Item(i, &device);
+			ERR_BREAK(hr != S_OK);
+
+			IPropertyStore *props = NULL;
+			hr = device->OpenPropertyStore(STGM_READ, &props);
+			ERR_BREAK(hr != S_OK);
+
+			PROPVARIANT propvar;
+			PropVariantInit(&propvar);
+
+			hr = props->GetValue(PKEY_Device_FriendlyName, &propvar);
+			ERR_BREAK(hr != S_OK);
+
+			if (device_name == String(propvar.pwszVal)) {
+				hr = device->GetId(&strId);
+				ERR_BREAK(hr != S_OK);
+
+				found = true;
+			}
+
+			PropVariantClear(&propvar);
+			props->Release();
+			device->Release();
+		}
+
+		if (found) {
+			hr = enumerator->GetDevice(strId, &device);
+		}
+
+		if (strId) {
+			CoTaskMemFree(strId);
+		}
+
+		if (device == NULL) {
+			hr = enumerator->GetDefaultAudioEndpoint(eRender, eConsole, &device);
+		}
+	}
 	if (reinit) {
 		// In case we're trying to re-initialize the device prevent throwing this error on the console,
 		// otherwise if there is currently no device available this will spam the console.
@@ -285,6 +341,64 @@ AudioDriver::SpeakerMode AudioDriverWASAPI::get_speaker_mode() const {
 	return get_speaker_mode_by_total_channels(channels);
 }
 
+Array AudioDriverWASAPI::get_device_list() {
+
+	Array list;
+	IMMDeviceCollection *devices = NULL;
+	IMMDeviceEnumerator *enumerator = NULL;
+
+	list.push_back(String("Default"));
+
+	CoInitialize(NULL);
+
+	HRESULT hr = CoCreateInstance(CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL, IID_IMMDeviceEnumerator, (void **)&enumerator);
+	ERR_FAIL_COND_V(hr != S_OK, Array());
+
+	hr = enumerator->EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE, &devices);
+	ERR_FAIL_COND_V(hr != S_OK, Array());
+
+	UINT count = 0;
+	hr = devices->GetCount(&count);
+	ERR_FAIL_COND_V(hr != S_OK, Array());
+
+	for (ULONG i = 0; i < count; i++) {
+		IMMDevice *device = NULL;
+
+		hr = devices->Item(i, &device);
+		ERR_BREAK(hr != S_OK);
+
+		IPropertyStore *props = NULL;
+		hr = device->OpenPropertyStore(STGM_READ, &props);
+		ERR_BREAK(hr != S_OK);
+
+		PROPVARIANT propvar;
+		PropVariantInit(&propvar);
+
+		hr = props->GetValue(PKEY_Device_FriendlyName, &propvar);
+		ERR_BREAK(hr != S_OK);
+
+		list.push_back(String(propvar.pwszVal));
+
+		PropVariantClear(&propvar);
+		props->Release();
+		device->Release();
+	}
+
+	devices->Release();
+	enumerator->Release();
+	return list;
+}
+
+String AudioDriverWASAPI::get_device() {
+
+	return device_name;
+}
+
+void AudioDriverWASAPI::set_device(String device) {
+
+	new_device = device;
+}
+
 void AudioDriverWASAPI::write_sample(AudioDriverWASAPI *ad, BYTE *buffer, int i, int32_t sample) {
 	if (ad->format_tag == WAVE_FORMAT_PCM) {
 		switch (ad->bits_per_sample) {
@@ -400,13 +514,23 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 			}
 		}
 
-		if (default_device_changed) {
+		// If we're using the Default device and it changed finish it so we'll re-init the device
+		if (ad->device_name == "Default" && default_device_changed) {
 			Error err = ad->finish_device();
 			if (err != OK) {
 				ERR_PRINT("WASAPI: finish_device error");
 			}
 
 			default_device_changed = false;
+		}
+
+		// User selected a new device, finish the current one so we'll init the new device
+		if (ad->device_name != ad->new_device) {
+			ad->device_name = ad->new_device;
+			Error err = ad->finish_device();
+			if (err != OK) {
+				ERR_PRINT("WASAPI: finish_device error");
+			}
 		}
 
 		if (!ad->audio_client) {
@@ -483,6 +607,9 @@ AudioDriverWASAPI::AudioDriverWASAPI() {
 	thread_exited = false;
 	exit_thread = false;
 	active = false;
+
+	device_name = "Default";
+	new_device = "Default";
 }
 
 #endif

--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -49,6 +49,9 @@ class AudioDriverWASAPI : public AudioDriver {
 	Mutex *mutex;
 	Thread *thread;
 
+	String device_name;
+	String new_device;
+
 	WORD format_tag;
 	WORD bits_per_sample;
 
@@ -80,6 +83,9 @@ public:
 	virtual void start();
 	virtual int get_mix_rate() const;
 	virtual SpeakerMode get_speaker_mode() const;
+	virtual Array get_device_list();
+	virtual String get_device();
+	virtual void set_device(String device);
 	virtual void lock();
 	virtual void unlock();
 	virtual void finish();

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -234,10 +234,10 @@ def configure(env):
         print("ALSA libraries not found, disabling driver")
 
     if env['pulseaudio']:
-        if (os.system("pkg-config --exists libpulse-simple") == 0): # 0 means found
+        if (os.system("pkg-config --exists libpulse") == 0): # 0 means found
             print("Enabling PulseAudio")
             env.Append(CPPFLAGS=["-DPULSEAUDIO_ENABLED"])
-            env.ParseConfig('pkg-config --cflags --libs libpulse-simple')
+            env.ParseConfig('pkg-config --cflags --libs libpulse')
         else:
             print("PulseAudio development libraries not found, disabling driver")
 

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -101,6 +101,18 @@ int AudioDriver::get_total_channels_by_speaker_mode(AudioDriver::SpeakerMode p_m
 	ERR_FAIL_V(2);
 }
 
+Array AudioDriver::get_device_list() {
+	Array list;
+
+	list.push_back("Default");
+
+	return list;
+}
+
+String AudioDriver::get_device() {
+	return "Default";
+}
+
 AudioDriver::AudioDriver() {
 
 	_last_mix_time = 0;
@@ -1108,6 +1120,21 @@ Ref<AudioBusLayout> AudioServer::generate_bus_layout() const {
 	return state;
 }
 
+Array AudioServer::get_device_list() {
+
+	return AudioDriver::get_singleton()->get_device_list();
+}
+
+String AudioServer::get_device() {
+
+	return AudioDriver::get_singleton()->get_device();
+}
+
+void AudioServer::set_device(String device) {
+
+	AudioDriver::get_singleton()->set_device(device);
+}
+
 void AudioServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_bus_count", "amount"), &AudioServer::set_bus_count);
@@ -1154,6 +1181,9 @@ void AudioServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_speaker_mode"), &AudioServer::get_speaker_mode);
 	ClassDB::bind_method(D_METHOD("get_mix_rate"), &AudioServer::get_mix_rate);
+	ClassDB::bind_method(D_METHOD("get_device_list"), &AudioServer::get_device_list);
+	ClassDB::bind_method(D_METHOD("get_device"), &AudioServer::get_device);
+	ClassDB::bind_method(D_METHOD("set_device"), &AudioServer::set_device);
 
 	ClassDB::bind_method(D_METHOD("set_bus_layout", "bus_layout"), &AudioServer::set_bus_layout);
 	ClassDB::bind_method(D_METHOD("generate_bus_layout"), &AudioServer::generate_bus_layout);

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -70,6 +70,9 @@ public:
 	virtual void start() = 0;
 	virtual int get_mix_rate() const = 0;
 	virtual SpeakerMode get_speaker_mode() const = 0;
+	virtual Array get_device_list();
+	virtual String get_device();
+	virtual void set_device(String device) {}
 	virtual void lock() = 0;
 	virtual void unlock() = 0;
 	virtual void finish() = 0;
@@ -299,6 +302,10 @@ public:
 
 	void set_bus_layout(const Ref<AudioBusLayout> &p_bus_layout);
 	Ref<AudioBusLayout> generate_bus_layout() const;
+
+	Array get_device_list();
+	String get_device();
+	void set_device(String device);
 
 	AudioServer();
 	virtual ~AudioServer();


### PR DESCRIPTION
This PR adds new functions for audio device handling:
```
	Array get_device_list();
	String get_device();
	void set_device(String device);
```
These can be called from GDscript using for example: `AudioServer.get_device_list()`

This simple project can be used to test this new functionality: [Device Changer.zip](https://github.com/godotengine/godot/files/1845675/Device.Changer.zip)

Implemented and tested: WASAPI, CoreAudio, PulseAudio and ALSA.