### PR TITLE
Fixed 3D box/region select

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -506,27 +506,26 @@ void SpatialEditorViewport::_select_region() {
 
 	Vector<Plane> frustum;
 
-	Vector3 cam_pos = _get_camera_position();
+	Vector3 cursor_pos = to_camera_transform(cursor).origin;
 
 	for (int i = 0; i < 4; i++) {
 
 		Vector3 a = _get_screen_to_space(box[i]);
 		Vector3 b = _get_screen_to_space(box[(i + 1) % 4]);
-		frustum.push_back(Plane(a, b, cam_pos));
+		frustum.push_back(Plane(a, b, cursor_pos));
 	}
 
-	Plane near(cam_pos, -_get_camera_normal());
+	Plane near(cursor_pos, -_get_camera_normal());
 	near.d -= get_znear();
 
 	frustum.push_back(near);
 
 	Plane far = -near;
-	far.d += 500.0;
+	far.d += 10000.0;
 
 	frustum.push_back(far);
 
 	Vector<ObjectID> instances = VisualServer::get_singleton()->instances_cull_convex(frustum, get_tree()->get_root()->get_world()->get_scenario());
-	Vector<Spatial *> selected;
 
 	Node *edited_scene = get_tree()->get_edited_scene_root();
 
@@ -545,10 +544,8 @@ void SpatialEditorViewport::_select_region() {
 		while (root_sp && root_sp != edited_scene && root_sp->get_owner() != edited_scene && !edited_scene->is_editable_instance(root_sp->get_owner())) {
 			root_sp = Object::cast_to<Spatial>(root_sp->get_owner());
 		}
-
-		if (selected.find(root_sp) == -1)
-			if (seg->intersect_frustum(camera, frustum))
-				_select(root_sp, true, false);
+		if (root_sp->is_visible())
+			_select(root_sp, true, false);
 	}
 }
 


### PR DESCRIPTION
Sorry, meant to do this back in December, but got sidetracked with other things! This is the fix to make the box/region select work in the 3D view. I've been using it for the past 4 months on my own custom build and I haven't really had any issues. The only problem that still persists is using this kind of selection in orthographic view, as it doesn't seem to work at all, but this wasn't introduced by my changes. Futher investigation will need to be done on that area later.

There are still objects that won't be selected when using this selection method, i.e objects that have no gizmo/collision info, such as physics bodies (the collision shape children will be selected instead if they exist).

This fixes #11187