### PR TITLE
[macOS] Return exit code specified by `OS.exit_code` parameter.

### DIFF
--- a/platform/osx/godot_main_osx.mm
+++ b/platform/osx/godot_main_osx.mm
@@ -101,5 +101,5 @@ int main(int argc, char **argv) {
 
 	Main::cleanup();
 
-	return 0;
+	return os.get_exit_code();
 };


### PR DESCRIPTION
Changes macOS behaviour to match Windows and Linux.