### PR TITLE
Handle directories in engine.js preloadFile()

### DIFF
--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -129,13 +129,6 @@ def configure(env):
     # This setting just makes WebGL 2 APIs available, it does NOT disable WebGL 1.
     env.Append(LINKFLAGS=['-s', 'USE_WEBGL2=1'])
 
-    # engine.js uses FS but is not currently evaluated by Emscripten, so export FS.
-    # TODO: Getting rid of this export is desirable.
-    extra_exports = [
-        'FS',
-    ]
-    env.Append(LINKFLAGS=['-s', 'EXTRA_EXPORTED_RUNTIME_METHODS="%s"' % repr(extra_exports)])
-
     env.Append(LINKFLAGS=['-s', 'INVOKE_RUN=0'])
 
     # TODO: Reevaluate usage of this setting now that engine.js manages engine runtime.

--- a/platform/javascript/engine.js
+++ b/platform/javascript/engine.js
@@ -14,6 +14,13 @@
 
 	var loadingFiles = {};
 
+	function getPathLeaf(path) {
+
+		while (path.endsWith('/'))
+			path = path.slice(0, -1);
+		return path.slice(path.lastIndexOf('/') + 1);
+	}
+
 	function getBasePath(path) {
 
 		if (path.endsWith('/'))
@@ -25,8 +32,7 @@
 
 	function getBaseName(path) {
 
-		path = getBasePath(path);
-		return path.slice(path.lastIndexOf('/') + 1);
+		return getPathLeaf(getBasePath(path));
 	}
 
 	Engine = function Engine() {
@@ -123,7 +129,12 @@
 		this.startGame = function(mainPack) {
 
 			executableName = getBaseName(mainPack);
-			return Promise.all([this.init(getBasePath(mainPack)), this.preloadFile(mainPack)]).then(
+			return Promise.all([
+				// Load from directory,
+				this.init(getBasePath(mainPack)),
+				// ...but write to root where the engine expects it.
+				this.preloadFile(mainPack, getPathLeaf(mainPack))
+			]).then(
 				Function.prototype.apply.bind(synchronousStart, this, [])
 			);
 		};

--- a/platform/javascript/engine.js
+++ b/platform/javascript/engine.js
@@ -88,7 +88,7 @@
 			});
 		}
 
-		this.preloadFile = function(pathOrBuffer, bufferFilename) {
+		this.preloadFile = function(pathOrBuffer, destPath) {
 
 			if (pathOrBuffer instanceof ArrayBuffer) {
 				pathOrBuffer = new Uint8Array(pathOrBuffer);
@@ -97,14 +97,14 @@
 			}
 			if (pathOrBuffer instanceof Uint8Array) {
 				preloadedFiles.push({
-					path: bufferFilename,
+					path: destPath,
 					buffer: pathOrBuffer
 				});
 				return Promise.resolve();
 			} else if (typeof pathOrBuffer === 'string') {
 				return loadPromise(pathOrBuffer, preloadProgressTracker).then(function(xhr) {
 					preloadedFiles.push({
-						path: pathOrBuffer,
+						path: destPath || pathOrBuffer,
 						buffer: xhr.response
 					});
 				});

--- a/platform/javascript/engine.js
+++ b/platform/javascript/engine.js
@@ -1,3 +1,4 @@
+		exposedLibs['FS'] = FS;
 		return Module;
 	},
 };
@@ -30,6 +31,8 @@
 	Engine = function Engine() {
 
 		this.rtenv = null;
+
+		var LIBS = {};
 
 		var initPromise = null;
 		var unloadAfterInit = true;
@@ -80,7 +83,7 @@
 			return new Promise(function(resolve, reject) {
 				rtenvProps.onRuntimeInitialized = resolve;
 				rtenvProps.onAbort = reject;
-				rtenvProps.engine.rtenv = Engine.RuntimeEnvironment(rtenvProps);
+				rtenvProps.engine.rtenv = Engine.RuntimeEnvironment(rtenvProps, LIBS);
 			});
 		}
 
@@ -163,7 +166,7 @@
 			this.rtenv.thisProgram = executableName || getBaseName(basePath);
 
 			preloadedFiles.forEach(function(file) {
-				this.rtenv.FS.createDataFile('/', file.name, new Uint8Array(file.buffer), true, true, true);
+				LIBS.FS.createDataFile('/', file.name, new Uint8Array(file.buffer), true, true, true);
 			}, this);
 
 			preloadedFiles = null;

--- a/platform/javascript/pre.js
+++ b/platform/javascript/pre.js
@@ -1,2 +1,2 @@
 var Engine = {
-	RuntimeEnvironment: function(Module) {
+	RuntimeEnvironment: function(Module, exposedLibs) {


### PR DESCRIPTION
Fixes preloading files from directories.
That fix is used to also fix calling `startGame()` with a directory, resolves #17788
Also eliminate unnecessary export of `FS` library.