### PR TITLE
"Save Scene As" And "Save branch as Scene" fixes

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -516,6 +516,7 @@ private:
 	bool _find_and_save_edited_subresources(Object *obj, Map<RES, bool> &processed, int32_t flags);
 	void _save_edited_subresources(Node *scene, Map<RES, bool> &processed, int32_t flags);
 	void _mark_unsaved_scenes();
+	void _prevent_duplicate_edited_scenes(const String &p_scene_name);
 
 	void _find_node_types(Node *p_node, int &count_2d, int &count_3d);
 	void _save_scene_with_preview(String p_file, int p_idx = -1);


### PR DESCRIPTION
"Save Scene As" code now checks and closes duplicate scenes in the editor to fix the issue where you can have two instances of the same scene with different data open at the same time.

"Save branch as Scene" when overwriting an existing scene the code now reloads the scene from disk so that all open tabs and child scenes get reloaded in editor.

Fixes issue:
 https://github.com/godotengine/godot/issues/17628