### PR TITLE
Improve popup menus usability

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1671,8 +1671,6 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 				selection_menu_additive_selection = b->get_shift();
 				selection_menu->set_global_position(b->get_global_position());
 				selection_menu->popup();
-				selection_menu->call_deferred("grab_click_focus");
-				selection_menu->set_invalidate_click_until_motion();
 				return true;
 			}
 		}

--- a/editor/plugins/shader_graph_editor_plugin.cpp
+++ b/editor/plugins/shader_graph_editor_plugin.cpp
@@ -2769,8 +2769,6 @@ void ShaderGraphEditor::_popup_requested(const Vector2 &p_position)
 	popup->set_global_position(p_position);
 	popup->set_size( Size2( 200, 0) );
 	popup->popup();
-	popup->call_deferred("grab_click_focus");
-	popup->set_invalidate_click_until_motion();
 }
 
 void ShaderGraphEditor::_notification(int p_what) {

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -886,8 +886,6 @@ void SpatialEditorViewport::_list_select(Ref<InputEventMouseButton> b) {
 
 		selection_menu->set_global_position(b->get_global_position());
 		selection_menu->popup();
-		selection_menu->call_deferred("grab_click_focus");
-		selection_menu->set_invalidate_click_until_motion();
 	}
 }
 

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -59,7 +59,6 @@ void MenuButton::pressed() {
 	popup->set_size(Size2(size.width, 0));
 	popup->set_parent_rect(Rect2(Point2(gp - popup->get_global_position()), get_size()));
 	popup->popup();
-	popup->set_invalidate_click_until_motion();
 }
 
 void MenuButton::_gui_input(Ref<InputEvent> p_event) {
@@ -109,7 +108,6 @@ MenuButton::MenuButton() {
 	add_child(popup);
 	popup->set_as_toplevel(true);
 	popup->set_pass_on_modal_close_click(false);
-	connect("button_up", popup, "call_deferred", make_binds("grab_click_focus"));
 	set_process_unhandled_key_input(true);
 	set_action_mode(ACTION_MODE_BUTTON_PRESS);
 }

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -78,6 +78,8 @@ class PopupMenu : public Popup {
 	Timer *submenu_timer;
 	List<Rect2> autohide_areas;
 	Vector<Item> items;
+	int initial_button_mask;
+	bool during_grabbed_click;
 	int mouse_over;
 	int submenu_over;
 	Rect2 parent_rect;
@@ -178,7 +180,6 @@ public:
 	void add_autohide_area(const Rect2 &p_area);
 	void clear_autohide_areas();
 
-	void set_invalidate_click_until_motion();
 	void set_hide_on_item_selection(bool p_enabled);
 	bool is_hide_on_item_selection() const;
 
@@ -187,6 +188,8 @@ public:
 
 	void set_hide_on_multistate_item_selection(bool p_enabled);
 	bool is_hide_on_multistate_item_selection() const;
+
+	virtual void popup(const Rect2 &p_bounds = Rect2());
 
 	PopupMenu();
 	~PopupMenu();

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -248,6 +248,7 @@ private:
 
 		bool key_event_accepted;
 		Control *mouse_focus;
+		Control *mouse_click_grabber;
 		int mouse_focus_button;
 		Control *key_focus;
 		Control *mouse_over;
@@ -323,6 +324,7 @@ private:
 	bool _gui_control_has_focus(const Control *p_control);
 	void _gui_control_grab_focus(Control *p_control);
 	void _gui_grab_click_focus(Control *p_control);
+	void _post_gui_grab_click_focus();
 	void _gui_accept_event();
 
 	Control *_gui_get_focus_owner();


### PR DESCRIPTION
It seems that popups were intended to "grab" the mouse click that triggered them, but their intent was being lost. This commit does the necessary changes to let it happen and updates items that were trying to get advantage of it, because the semantics of `Control::grab_click_focus()` have changed a bit. Namely, it must be called **before** showing the modal.

**This allows to popup a menu and activate an item in it in a single click-point-release cycle, instead of having to click once to open the menu and once more to pick an item.**

This ability is extended even to context menus activated with the RMB (or any other mouse button, for that matter). The editor benefits from this in the context menu of the tree dock, which has been patched to opt-in for this feature.

This improves UX a bit by saving unnecessary clicks.

~**NOTE:** This changes a bit how `Control::grab_click_focus()` has to be used. Thereby, not sure if this can be safely cherry-picked for 3.0. I don't think it will break many projects, though. Furthermore, `grab_click_focus()` wasn't documented yet so we may afford this little change of behavior.~

**UPDATE:**
- Note:
_Please note this does not change how menu bars work. You still have to dismiss current pop-up and click to open another menu. I'll try to address that as well in a future PR._

- Change in code:
From now on, `PopupMenu` always grabs the click and also invalidates the first button release unless the mouse has moved (that's what `set_invalidate_click_until_motion()` was doing and now it's removed), so there is no longer the need of doing both things at every point a pop-up menu is shown.