### PR TITLE
FIX: FILE_SHOW_IN_EXPLORER now correctly shows the file's directory

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1034,8 +1034,19 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path) {
 void FileSystemDock::_file_option(int p_option) {
 	switch (p_option) {
 		case FILE_SHOW_IN_EXPLORER: {
-			String dir = ProjectSettings::get_singleton()->globalize_path(this->path);
-			OS::get_singleton()->shell_open(String("file://") + dir);
+
+			String path = this->path;
+
+			// first try to grab directory from selected file, so that it works for searched files
+			int idx = files->get_current();
+
+			if (idx >= 0 && idx < files->get_item_count()) {
+				path = files->get_item_metadata(idx);
+				path = path.get_base_dir();
+			}
+
+			path = ProjectSettings::get_singleton()->globalize_path(path);
+			OS::get_singleton()->shell_open(String("file://") + path);
 		} break;
 		case FILE_OPEN: {
 			for (int i = 0; i < files->get_item_count(); i++) {


### PR DESCRIPTION
From the filesystem dock you can search for files but when you right clicked and used show in file manager it would show you the folder that you were in before searching for files.

So now if there is any file selected, it will show the selected file folder. If no file is selected it works as before.