### PR TITLE
Fix IPhone and OSX cross compilation

### DIFF
--- a/modules/webm/libvpx/SCsub
+++ b/modules/webm/libvpx/SCsub
@@ -340,7 +340,7 @@ if webm_simd_optimizations == False:
 
 env_libvpx.add_source_files(env.modules_sources, libvpx_sources)
 if webm_cpu_x86:
-    is_clang_or_gcc = ('gcc' in env["CC"]) or ('clang' in env["CC"])
+    is_clang_or_gcc = ('gcc' in env["CC"]) or ('clang' in env["CC"]) or ("OSXCROSS_ROOT" in os.environ)
 
     env_libvpx_mmx = env_libvpx.Clone()
     if cpu_bits == '32' and is_clang_or_gcc:

--- a/platform/iphone/SCsub
+++ b/platform/iphone/SCsub
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import os
 
 Import('env')
 
@@ -21,6 +22,10 @@ ios_lib = env_ios.add_library('iphone', iphone_lib)
 
 def combine_libs(target=None, source=None, env=None):
     lib_path = target[0].srcnode().abspath
-    env.Execute('$IPHONEPATH/usr/bin/libtool -static -o "' + lib_path + '" ' + ' '.join([('"' + lib.srcnode().abspath + '"') for lib in source]))
+    if ("OSXCROSS_IOS" in os.environ):
+        libtool = '$IPHONEPATH/usr/bin/${ios_triple}libtool'
+    else:
+        libtool = "$IPHONEPATH/usr/bin/libtool"
+    env.Execute(libtool + ' -static -o "' + lib_path + '" ' + ' '.join([('"' + lib.srcnode().abspath + '"') for lib in source]))
 
 combine_command = env_ios.Command('#bin/libgodot' + env_ios['LIBSUFFIX'], [ios_lib] + env_ios['LIBS'], combine_libs)

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -93,6 +93,7 @@ def configure(env):
         env['AR'] = basecmd + "ar"
         env['RANLIB'] = basecmd + "ranlib"
         env['AS'] = basecmd + "as"
+        env.Append(CCFLAGS=['-D__MACPORTS__']) #hack to fix libvpx MM256_BROADCASTSI128_SI256 define
 
     if (env["CXX"] == "clang++"):
         env.Append(CPPFLAGS=['-DTYPED_METHOD_BIND'])


### PR DESCRIPTION
- WebM was not correctly recognizing `clang` when using `OSXCROSS`
- `OSXCROSS` compilation needs the same hack of `macports`
- Use correct prefixing for `libtool` when cross compiling for IPhone.