### PR TITLE
Fix StyleBox ignoring region rect and ProgressBar using center size

### DIFF
--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -33,13 +33,16 @@
 Size2 ProgressBar::get_minimum_size() const {
 
 	Ref<StyleBox> bg = get_stylebox("bg");
+	Ref<StyleBox> fg = get_stylebox("fg");
 	Ref<Font> font = get_font("font");
 
-	Size2 ms = bg->get_minimum_size() + bg->get_center_size();
+	Size2 minimum_size = bg->get_minimum_size();
+	minimum_size.height = MAX(minimum_size.height, fg->get_minimum_size().height);
+	minimum_size.width = MAX(minimum_size.width, fg->get_minimum_size().width);
 	if (percent_visible) {
-		ms.height = MAX(ms.height, bg->get_minimum_size().height + font->get_height());
+		minimum_size.height = MAX(minimum_size.height, bg->get_minimum_size().height + font->get_height());
 	}
-	return ms;
+	return minimum_size;
 }
 
 void ProgressBar::_notification(int p_what) {

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -182,7 +182,7 @@ Size2 StyleBoxTexture::get_center_size() const {
 	if (texture.is_null())
 		return Size2();
 
-	return texture->get_size() - get_minimum_size();
+	return region_rect.size - get_minimum_size();
 }
 
 void StyleBoxTexture::set_expand_margin_size(Margin p_expand_margin, float p_size) {


### PR DESCRIPTION
ProgressBar used the center size of the stylebox to calculate its minimum size, thus disallowing certain setups. Note that this is likely a **breaking** change, and perhaps unintended.
If the old behaviour is wanted, it can be forced by providing a custom minimum size, or by giving proper margins to the stylebox.

Fixes #17779.