### PR TITLE
Added the "GLES2" option for the video-driver in the terminal help

### DIFF
--- a/misc/dist/linux/godot.6
+++ b/misc/dist/linux/godot.6
@@ -59,7 +59,7 @@ Password for remote filesystem.
 Audio driver ('PulseAudio', 'ALSA').
 .TP
 \fB\-\-video\-driver\fR <driver>
-Video driver ('GLES3').
+Video driver ('GLES3', 'GLES2').
 .SS "Display options:"
 .TP
 \fB\-f\fR, \fB\-\-fullscreen\fR


### PR DESCRIPTION
A.K.A. `godot --help`.