### PR TITLE
Fixed some popups not shrinking their size back when losing items

### DIFF
--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -756,6 +756,7 @@ void AnimationTreeEditor::_gui_input(Ref<InputEvent> p_event) {
 					if (rclick_type == CLICK_INPUT_SLOT || rclick_type == CLICK_OUTPUT_SLOT) {
 
 						node_popup->clear();
+						node_popup->set_size(Size2(1, 1));
 						node_popup->add_item(TTR("Disconnect"), NODE_DISCONNECT);
 						if (anim_tree->node_get_type(rclick_node) == AnimationTreePlayer::NODE_TRANSITION) {
 							node_popup->add_item(TTR("Add Input"), NODE_ADD_INPUT);
@@ -774,6 +775,7 @@ void AnimationTreeEditor::_gui_input(Ref<InputEvent> p_event) {
 
 					if (rclick_type == CLICK_NODE) {
 						node_popup->clear();
+						node_popup->set_size(Size2(1, 1));
 						node_popup->add_item(TTR("Rename"), NODE_RENAME);
 						node_popup->add_item(TTR("Remove"), NODE_ERASE);
 						if (anim_tree->node_get_type(rclick_node) == AnimationTreePlayer::NODE_TRANSITION)

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1794,6 +1794,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 
 		subresources.clear();
 		menu_subresources->clear();
+		menu_subresources->set_size(Size2(1, 1));
 		_add_children_to_popup(selection.front()->get(), 0);
 		if (menu->get_item_count() > 0)
 			menu->add_separator();


### PR DESCRIPTION
The scene tree's right-click "sub-resources" menu and in the AnimationTreePlayer.