### PR TITLE
Fix Collada material roughness import function

### DIFF
--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -480,7 +480,7 @@ Error ColladaImport::_create_material(const String &p_target) {
 		}
 	}
 
-	float roughness = Math::sqrt(1.0 - ((Math::log(effect.shininess) / Math::log(2.0)) / 8.0)); //not very right..
+	float roughness = - Math::sqrt(1.0 - ((Math::log(effect.shininess) / Math::log(2.0)) / 9.0)) + 1;
 	material->set_roughness(roughness);
 
 	if (effect.double_sided) {

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -480,7 +480,7 @@ Error ColladaImport::_create_material(const String &p_target) {
 		}
 	}
 
-	float roughness = -Math::sqrt(1.0 - ((Math::log(effect.shininess) / Math::log(2.0)) / 9.0)) + 1;
+	float roughness = (512.0 * (1.0 - Math::sqrt(1.0 - ((Math::log(effect.shininess) / Math::log(2.0)) / 9.0)))) / 503.0;
 	material->set_roughness(roughness);
 
 	if (effect.double_sided) {

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -480,7 +480,7 @@ Error ColladaImport::_create_material(const String &p_target) {
 		}
 	}
 
-	float roughness = - Math::sqrt(1.0 - ((Math::log(effect.shininess) / Math::log(2.0)) / 9.0)) + 1;
+	float roughness = -Math::sqrt(1.0 - ((Math::log(effect.shininess) / Math::log(2.0)) / 9.0)) + 1;
 	material->set_roughness(roughness);
 
 	if (effect.double_sided) {

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -480,7 +480,7 @@ Error ColladaImport::_create_material(const String &p_target) {
 		}
 	}
 
-	float roughness = (512.0 * (1.0 - Math::sqrt(1.0 - ((Math::log(effect.shininess) / Math::log(2.0)) / 9.0)))) / 503.0;
+	float roughness = (effect.shininess - 1.0) / 510;
 	material->set_roughness(roughness);
 
 	if (effect.double_sided) {


### PR DESCRIPTION
Fixes NaN roughness in Godot when importing .dae with material hardness more than 255 (set in Blender, for example).
Also corrects dependency: more hardness = more roughness (it says shininess, but it actually is hardness).

This Fixes #17822, please look inside the issue for details.