### PR TITLE
Add comfortable methods for checking mouse wheel input

### DIFF
--- a/core/os/input.cpp
+++ b/core/os/input.cpp
@@ -53,6 +53,11 @@ void Input::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("is_key_pressed", "scancode"), &Input::is_key_pressed);
 	ClassDB::bind_method(D_METHOD("is_mouse_button_pressed", "button"), &Input::is_mouse_button_pressed);
+	ClassDB::bind_method(D_METHOD("is_mouse_wheel_up"), &Input::is_mouse_wheel_up);
+	ClassDB::bind_method(D_METHOD("is_mouse_wheel_down"), &Input::is_mouse_wheel_down);
+	ClassDB::bind_method(D_METHOD("is_mouse_wheel_left"), &Input::is_mouse_wheel_left);
+	ClassDB::bind_method(D_METHOD("is_mouse_wheel_right"), &Input::is_mouse_wheel_right);
+	ClassDB::bind_method(D_METHOD("clear_mouse_wheel_mask"), &Input::clear_mouse_wheel_mask);
 	ClassDB::bind_method(D_METHOD("is_joy_button_pressed", "device", "button"), &Input::is_joy_button_pressed);
 	ClassDB::bind_method(D_METHOD("is_action_pressed", "action"), &Input::is_action_pressed);
 	ClassDB::bind_method(D_METHOD("is_action_just_pressed", "action"), &Input::is_action_just_pressed);

--- a/core/os/input.h
+++ b/core/os/input.h
@@ -81,11 +81,16 @@ public:
 
 	virtual bool is_key_pressed(int p_scancode) const = 0;
 	virtual bool is_mouse_button_pressed(int p_button) const = 0;
+	virtual bool is_mouse_wheel_up() const = 0;
+	virtual bool is_mouse_wheel_down() const = 0;
+	virtual bool is_mouse_wheel_left() const = 0;
+	virtual bool is_mouse_wheel_right() const = 0;
 	virtual bool is_joy_button_pressed(int p_device, int p_button) const = 0;
 	virtual bool is_action_pressed(const StringName &p_action) const = 0;
 	virtual bool is_action_just_pressed(const StringName &p_action) const = 0;
 	virtual bool is_action_just_released(const StringName &p_action) const = 0;
 
+	virtual void clear_mouse_wheel_mask() = 0;
 	virtual float get_joy_axis(int p_device, int p_axis) const = 0;
 	virtual String get_joy_name(int p_idx) = 0;
 	virtual Array get_connected_joypads() = 0;

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -176,6 +176,13 @@
 				Return the mouse mode. See the constants for more information.
 			</description>
 		</method>
+		<method name="clear_mouse_wheel_mask">
+			<return type="bool">
+			</return>
+			<description>
+				Clear wheel mask. Call it after usage of [code]is_mouse_wheel_[/code] methods.
+			</description>
+		</method>
 		<method name="is_action_just_pressed" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -240,6 +247,34 @@
 			</argument>
 			<description>
 				Returns [code]true[/code] if you are pressing the mouse button. You can pass [code]BUTTON_*[/code], which are pre-defined constants listed in [@GlobalScope].
+			</description>
+		</method>
+		<method name="is_mouse_wheel_up" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+				Returns [code]true[/code] if you scroll wheel up.
+			</description>
+		</method>
+		<method name="is_mouse_wheel_down" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+				Returns [code]true[/code] if you scroll wheel down.
+			</description>
+		</method>
+		<method name="is_mouse_wheel_left" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+				Returns [code]true[/code] if you scroll wheel left.
+			</description>
+		</method>
+		<method name="is_mouse_wheel_right" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+				Returns [code]true[/code] if you scroll wheel right.
 			</description>
 		</method>
 		<method name="joy_connection_changed">

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -39,6 +39,7 @@ class InputDefault : public Input {
 	_THREAD_SAFE_CLASS_
 
 	int mouse_button_mask;
+	int mouse_wheel_mask;
 
 	Set<int> keys_pressed;
 	Set<int> joy_buttons_pressed;
@@ -178,11 +179,16 @@ private:
 public:
 	virtual bool is_key_pressed(int p_scancode) const;
 	virtual bool is_mouse_button_pressed(int p_button) const;
+	virtual bool is_mouse_wheel_up() const;
+	virtual bool is_mouse_wheel_down() const;
+	virtual bool is_mouse_wheel_left() const;
+	virtual bool is_mouse_wheel_right() const;
 	virtual bool is_joy_button_pressed(int p_device, int p_button) const;
 	virtual bool is_action_pressed(const StringName &p_action) const;
 	virtual bool is_action_just_pressed(const StringName &p_action) const;
 	virtual bool is_action_just_released(const StringName &p_action) const;
 
+	virtual void clear_mouse_wheel_mask();
 	virtual float get_joy_axis(int p_device, int p_axis) const;
 	String get_joy_name(int p_idx);
 	virtual Array get_connected_joypads();


### PR DESCRIPTION
This PR brings five new methods to Input class. Now its possible to use wheel more comfortable, instead overriding the \_input method. Note : is_mouse_button_pressed(BUTTON_WHEEL_) is not working correctly, because wheel reacts on release and not pressed event. 

**is_mouse_wheel_up**,**is_mouse_wheel_down**,**is_mouse_wheel_left**,**is_mouse_wheel_right** - is boolean checks for mouse wheel, for correct usage push **clear_mouse_wheel_mask** after them

Example of usage:
```
	if Input.is_mouse_wheel_up():
		camera.zoom = Vector2(clamp(camera.zoom.x - zoom_speed, 0.25, 1.0), clamp(camera.zoom.y - 0.05, 0.25, 1.0))
	if Input.is_mouse_wheel_down():
		camera.zoom = Vector2(clamp(camera.zoom.x + zoom_speed, 0.25, 1.0), clamp(camera.zoom.y + 0.05, 0.25, 1.0))

	Input.clear_mouse_wheel_mask()
```