### PR TITLE
Fix UWP build after #17194

### DIFF
--- a/platform/uwp/detect.py
+++ b/platform/uwp/detect.py
@@ -43,6 +43,8 @@ def get_flags():
 
 def configure(env):
 
+    env.msvc = True
+
     if (env["bits"] != "default"):
         print("Error: bits argument is disabled for MSVC")
         print("""


### PR DESCRIPTION
After #17194 `uwp/detect.py` was not setting the `env.msvc` variable to true causing scons to pass wrong arguments to `msvc` (using `clang/gcc` options) which in turn break the build due to  `Werror=return-type` not being recognized by ms compiler.