### PR TITLE
Improve side impulse calculation

### DIFF
--- a/scene/3d/vehicle_body.h
+++ b/scene/3d/vehicle_body.h
@@ -168,7 +168,7 @@ class VehicleBody : public RigidBody {
 		btVehicleWheelContactPoint(PhysicsDirectBodyState *s, PhysicsBody *body1, const Vector3 &frictionPosWorld, const Vector3 &frictionDirectionWorld, real_t maxImpulse);
 	};
 
-	void _resolve_single_bilateral(PhysicsDirectBodyState *s, const Vector3 &pos1, PhysicsBody *body2, const Vector3 &pos2, const Vector3 &normal, real_t &impulse);
+	void _resolve_single_bilateral(PhysicsDirectBodyState *s, const Vector3 &pos1, PhysicsBody *body2, const Vector3 &pos2, const Vector3 &normal, real_t &impulse, real_t p_rollInfluence);
 	real_t _calc_rolling_friction(btVehicleWheelContactPoint &contactPoint);
 
 	void _update_friction(PhysicsDirectBodyState *s);


### PR DESCRIPTION
Did a bunch of experimentation using my vehicle demo to figure out what was causing all the jittery and stuff.

This fix resolves what I believe is one of the core issues here. While the forward impulse is nicely adjusted by our timing our side impulse is not. Instead it is simply multiplied by a constant, one that interestingly is double what it is in bullets original code :)

The result however is that we have a rather large impulse applied each and every frame, as we're dealing with a counter force it's over compensating and we get a constant back and forth of ever increasing strength. Once the car gets moving the forward motion overtakes the sideways motion and stabilizes the simulation. Slow down again and the problems reappear. 

With the 0.2 setting bullet uses the simulation improves but is still shaky.

The solution I came up with is by scaling the impulse by the time lapsed, over time the same total impulse is still given. 

Note the division by roll influence. Roll influence is a bit of a fluke value to combat roll. What it does is scale the point the impulse is applied to. The smaller the roll influence, the closer to the center of mass our impulse is applied, but as a result, the larger this impulse needs to be to have the desired effect. 
I had expected it to counter the roll influence but it actually seems to do the job. It still prevents access body roll but prevents to car from sliding sideways when it shouldn't.

This is only one piece of the puzzle but it seems to do the trick.

One other thing of note is that the wheels need to be spaced apart properly, we should probably put this into our documentation. I had the left front wheel slightly out of alignment with the right front wheel and that is enough to get a difference in impulse between the two wheels. This was what was causing the car to spin around its axis.

You can try out my demo here: https://github.com/BastiaanOlij/vehicle-demo