### PR TITLE
fix billboard on win10 with some amd card. issue-17771

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -378,6 +378,13 @@ void SpatialMaterial::_update_shader() {
 		case SPECULAR_DISABLED: code += ",specular_disabled"; break;
 	}
 
+	switch (billboard_mode) {
+		case BILLBOARD_DISABLED: break;
+		case BILLBOARD_ENABLED: code += ",skip_vertex_transform"; break;
+		case BILLBOARD_FIXED_Y: code += ",skip_vertex_transform"; break;
+		case BILLBOARD_PARTICLES: code += ",skip_vertex_transform"; break;
+	}
+
 	if (flags[FLAG_UNSHADED]) {
 		code += ",unshaded";
 	}
@@ -535,9 +542,13 @@ void SpatialMaterial::_update_shader() {
 		case BILLBOARD_ENABLED: {
 
 			code += "\tMODELVIEW_MATRIX = INV_CAMERA_MATRIX * mat4(CAMERA_MATRIX[0],CAMERA_MATRIX[1],CAMERA_MATRIX[2],WORLD_MATRIX[3]);\n";
+			code += "\tVERTEX = (MODELVIEW_MATRIX * vec4(VERTEX, 1.0)).xyz;\n";
+			code += "\tNORMAL = (MODELVIEW_MATRIX * vec4(VERTEX, 0.0)).xyz;\n";
 		} break;
 		case BILLBOARD_FIXED_Y: {
 			code += "\tMODELVIEW_MATRIX = INV_CAMERA_MATRIX * mat4(CAMERA_MATRIX[0],WORLD_MATRIX[1],vec4(normalize(cross(CAMERA_MATRIX[0].xyz,WORLD_MATRIX[1].xyz)),0.0),WORLD_MATRIX[3]);\n";
+			code += "\tVERTEX = (MODELVIEW_MATRIX * vec4(VERTEX, 1.0)).xyz;\n";
+			code += "\tNORMAL = (MODELVIEW_MATRIX * vec4(VERTEX, 0.0)).xyz;\n";
 		} break;
 		case BILLBOARD_PARTICLES: {
 
@@ -547,7 +558,8 @@ void SpatialMaterial::_update_shader() {
 			code += "\tmat_world = mat_world * mat4( vec4(cos(INSTANCE_CUSTOM.x),-sin(INSTANCE_CUSTOM.x),0.0,0.0), vec4(sin(INSTANCE_CUSTOM.x),cos(INSTANCE_CUSTOM.x),0.0,0.0),vec4(0.0,0.0,1.0,0.0),vec4(0.0,0.0,0.0,1.0));\n";
 			//set modelview
 			code += "\tMODELVIEW_MATRIX = INV_CAMERA_MATRIX * mat_world;\n";
-
+			code += "\tVERTEX = (MODELVIEW_MATRIX * vec4(VERTEX, 1.0)).xyz;\n";
+			code += "\tNORMAL = (MODELVIEW_MATRIX * vec4(VERTEX, 0.0)).xyz;\n";
 			//handle animation
 			code += "\tint particle_total_frames = particles_anim_h_frames * particles_anim_v_frames;\n";
 			code += "\tint particle_frame = int(INSTANCE_CUSTOM.y * float(particle_total_frames));\n";


### PR DESCRIPTION
**BEFORE**:
![](https://raw.githubusercontent.com/aron3097/issueImg/master/Pics_Godot_3.1dev_Win_BillboardNotWork_Mar37/1.gif)

**AFTER**:
![](https://raw.githubusercontent.com/aron3097/issueImg/master/Pics_Godot_3.1dev_Win_BillboardNotWork_Mar37/4f0cf278-ffe0-4cdf-a0f4-c9737fcb0b4b.gif)

Billboard works for me now.
but not sure if it is the correct way. It seems more cpu will use when particle use particle-billboard.

*Bugsquad edit:* Fixes #17771.