### PR TITLE
Add functionality to move selected tiles in tile map editor

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.h
+++ b/editor/plugins/tile_map_editor_plugin.h
@@ -61,6 +61,7 @@ class TileMapEditor : public VBoxContainer {
 		TOOL_BUCKET,
 		TOOL_PICKING,
 		TOOL_DUPLICATING,
+		TOOL_MOVING
 	};
 
 	enum Options {
@@ -72,6 +73,7 @@ class TileMapEditor : public VBoxContainer {
 		OPTION_ERASE_SELECTION,
 		OPTION_PAINTING,
 		OPTION_FIX_INVALID,
+		OPTION_MOVE
 	};
 
 	TileMap *node;


### PR DESCRIPTION
This change adds a new entry "Move Selection" to the "Tile Map"
menu in the tile map editor. It allows the user to easily move
as set of selected tiles.

Implements #17862 