### PR TITLE
Trigger rename_error's close_fail_notify only after exhausting attempts on Windows

### DIFF
--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -139,19 +139,22 @@ void FileAccessWindows::close() {
 				//atomic replace for existing file
 				rename_error = !ReplaceFileW(save_path.c_str(), (save_path + ".tmp").c_str(), NULL, 2 | 4, NULL, NULL);
 			}
-			if (rename_error && close_fail_notify) {
-				close_fail_notify(save_path);
-			}
 			if (rename_error) {
 				attempts--;
 				OS::get_singleton()->delay_usec(1000000); //wait 100msec and try again
 			}
 		}
 
-		save_path = "";
 		if (rename_error) {
+			if (close_fail_notify) {
+				close_fail_notify(save_path);
+			}
+
 			ERR_EXPLAIN("Safe save failed. This may be a permissions problem, but also may happen because you are running a paranoid antivirus. If this is the case, please switch to Windows Defender or disable the 'safe save' option in editor settings. This makes it work, but increases the risk of file corruption in a crash.");
 		}
+
+		save_path = "";
+
 		ERR_FAIL_COND(rename_error);
 	}
 }


### PR DESCRIPTION
See #16274

On Windows it seems to be necessary to attempt renaming multiple times, and while this strategy seems succesful, it still throws errors to the error log -before- all attempts are exhausted.

This leads to Godot being very unusable on Windows, as someone has to close the error log after any save where more than 1 attempt was necessary to rename a file. Keep in mind that Godot autosaves sometimes too like when closing the project settings. So: very annoying.

Since it's likely for renaming to need re-attempts on Windows, it doesn't make sense to throw errors to the error logs until -after- all attempts were exhausted. Please see my commit to understand the change.

Built and tested on x64 release_debug