### PR TITLE
Fix UpdatePowerInfo method implementation in PowerIphone class

### DIFF
--- a/platform/iphone/power_iphone.cpp
+++ b/platform/iphone/power_iphone.cpp
@@ -30,7 +30,7 @@
 
 #include "power_iphone.h"
 
-bool OS::PowerState::UpdatePowerInfo() {
+bool PowerIphone::UpdatePowerInfo() {
 	return false;
 }
 


### PR DESCRIPTION
Well trying to implement method for OS::PowerState enum doesn't sound like good idea. Just a Mistype fix.