### PR TITLE
Fix of a possible memory leak in ConcavePolygonShapeBullet::setup

### DIFF
--- a/modules/bullet/shape_bullet.cpp
+++ b/modules/bullet/shape_bullet.cpp
@@ -337,10 +337,10 @@ void ConcavePolygonShapeBullet::setup(PoolVector<Vector3> p_faces) {
 	int src_face_count = faces.size();
 	if (0 < src_face_count) {
 
-		btTriangleMesh *shapeInterface = bulletnew(btTriangleMesh);
-
 		// It counts the faces and assert the array contains the correct number of vertices.
 		ERR_FAIL_COND(src_face_count % 3);
+
+		btTriangleMesh *shapeInterface = bulletnew(btTriangleMesh);
 		src_face_count /= 3;
 		PoolVector<Vector3>::Read r = p_faces.read();
 		const Vector3 *facesr = r.ptr();


### PR DESCRIPTION
This code block could cause memory leak:
https://github.com/godotengine/godot/blob/098c7ba4f9c49b472b9417819144378081996874/modules/bullet/shape_bullet.cpp#L340-L343
Let's assume that `src_face_count % 3` not equal to 0, then error will be printed and `ConcavePolygonShapeBullet::setup` will exit, but created `shapeInterface` won't be released.