### PR TITLE
Abstracted the syntax highlighter from text edit.

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1778,6 +1778,20 @@ bool ScriptEditor::edit(const Ref<Script> &p_script, int p_line, int p_col, bool
 	}
 	ERR_FAIL_COND_V(!se, false);
 
+	bool highlighter_set = false;
+	for (int i = 0; i < syntax_highlighters_func_count; i++) {
+		SyntaxHighlighter *highlighter = syntax_highlighters_funcs[i]();
+		se->add_syntax_highlighter(highlighter);
+
+		if (!highlighter_set) {
+			List<String> languages = highlighter->get_supported_languages();
+			if (languages.find(p_script->get_language()->get_name())) {
+				se->set_syntax_highlighter(highlighter);
+				highlighter_set = true;
+			}
+		}
+	}
+
 	tab_container->add_child(se);
 	se->set_edited_script(p_script);
 	se->set_tooltip_request_func("_get_debug_tooltip", this);
@@ -2492,6 +2506,14 @@ void ScriptEditor::_open_script_request(const String &p_path) {
 	if (script.is_valid()) {
 		script_editor->edit(script, false);
 	}
+}
+
+int ScriptEditor::syntax_highlighters_func_count = 0;
+CreateSyntaxHighlighterFunc ScriptEditor::syntax_highlighters_funcs[ScriptEditor::SYNTAX_HIGHLIGHTER_FUNC_MAX];
+
+void ScriptEditor::register_create_syntax_highlighter_function(CreateSyntaxHighlighterFunc p_func) {
+	ERR_FAIL_COND(syntax_highlighters_func_count == SYNTAX_HIGHLIGHTER_FUNC_MAX);
+	syntax_highlighters_funcs[syntax_highlighters_func_count++] = p_func;
 }
 
 int ScriptEditor::script_editor_func_count = 0;

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -80,6 +80,9 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual void add_syntax_highlighter(SyntaxHighlighter *p_highlighter) = 0;
+	virtual void set_syntax_highlighter(SyntaxHighlighter *p_highlighter) = 0;
+
 	virtual void apply_code() = 0;
 	virtual Ref<Script> get_edited_script() const = 0;
 	virtual Vector<String> get_functions() = 0;
@@ -112,6 +115,7 @@ public:
 	ScriptEditorBase() {}
 };
 
+typedef SyntaxHighlighter *(*CreateSyntaxHighlighterFunc)();
 typedef ScriptEditorBase *(*CreateScriptEditorFunc)(const Ref<Script> &p_script);
 
 class EditorScriptCodeCompletionCache;
@@ -214,11 +218,15 @@ class ScriptEditor : public PanelContainer {
 	ToolButton *script_forward;
 
 	enum {
-		SCRIPT_EDITOR_FUNC_MAX = 32
+		SCRIPT_EDITOR_FUNC_MAX = 32,
+		SYNTAX_HIGHLIGHTER_FUNC_MAX = 32
 	};
 
 	static int script_editor_func_count;
 	static CreateScriptEditorFunc script_editor_funcs[SCRIPT_EDITOR_FUNC_MAX];
+
+	static int syntax_highlighters_func_count;
+	static CreateSyntaxHighlighterFunc syntax_highlighters_funcs[SYNTAX_HIGHLIGHTER_FUNC_MAX];
 
 	struct ScriptHistory {
 
@@ -399,7 +407,9 @@ public:
 	ScriptEditorDebugger *get_debugger() { return debugger; }
 	void set_live_auto_reload_running_scripts(bool p_enabled);
 
+	static void register_create_syntax_highlighter_function(CreateSyntaxHighlighterFunc p_func);
 	static void register_create_script_editor_function(CreateScriptEditorFunc p_func);
+
 	ScriptEditor(EditorNode *p_editor);
 	~ScriptEditor();
 };

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -573,6 +573,7 @@ void ScriptTextEditor::set_edited_script(const Ref<Script> &p_script) {
 	ERR_FAIL_COND(!script.is_null());
 
 	script = p_script;
+	_set_theme_for_script();
 
 	code_editor->get_text_edit()->set_text(script->get_source_code());
 	code_editor->get_text_edit()->clear_undo_history();
@@ -580,8 +581,6 @@ void ScriptTextEditor::set_edited_script(const Ref<Script> &p_script) {
 
 	emit_signal("name_changed");
 	code_editor->update_line_and_column();
-
-	_set_theme_for_script();
 }
 
 void ScriptTextEditor::_validate_script() {
@@ -1245,11 +1244,26 @@ void ScriptTextEditor::_edit_option(int p_op) {
 	}
 }
 
+void ScriptTextEditor::add_syntax_highlighter(SyntaxHighlighter *p_highlighter) {
+	highlighters[p_highlighter->get_name()] = p_highlighter;
+	highlighter_menu->get_popup()->add_item(p_highlighter->get_name());
+}
+
+void ScriptTextEditor::set_syntax_highlighter(SyntaxHighlighter *p_highlighter) {
+	TextEdit *te = code_editor->get_text_edit();
+	te->_set_syntax_highlighting(p_highlighter);
+}
+
+void ScriptTextEditor::_change_syntax_highlighter(int p_idx) {
+	set_syntax_highlighter(highlighters[highlighter_menu->get_popup()->get_item_text(p_idx)]);
+}
+
 void ScriptTextEditor::_bind_methods() {
 
 	ClassDB::bind_method("_validate_script", &ScriptTextEditor::_validate_script);
 	ClassDB::bind_method("_load_theme_settings", &ScriptTextEditor::_load_theme_settings);
 	ClassDB::bind_method("_breakpoint_toggled", &ScriptTextEditor::_breakpoint_toggled);
+	ClassDB::bind_method("_change_syntax_highlighter", &ScriptTextEditor::_change_syntax_highlighter);
 	ClassDB::bind_method("_edit_option", &ScriptTextEditor::_edit_option);
 	ClassDB::bind_method("_goto_line", &ScriptTextEditor::_goto_line);
 	ClassDB::bind_method("_lookup_symbol", &ScriptTextEditor::_lookup_symbol);
@@ -1634,6 +1648,14 @@ ScriptTextEditor::ScriptTextEditor() {
 	search_menu->get_popup()->connect("id_pressed", this, "_edit_option");
 
 	edit_hb->add_child(edit_menu);
+
+	highlighters["Standard"] = NULL;
+
+	highlighter_menu = memnew(MenuButton);
+	highlighter_menu->set_text(TTR("Syntax Highlighter"));
+	highlighter_menu->get_popup()->add_item("Standard");
+	highlighter_menu->get_popup()->connect("id_pressed", this, "_change_syntax_highlighter");
+	edit_hb->add_child(highlighter_menu);
 
 	quick_open = memnew(ScriptEditorQuickOpen);
 	add_child(quick_open);

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -49,6 +49,7 @@ class ScriptTextEditor : public ScriptEditorBase {
 	HBoxContainer *edit_hb;
 
 	MenuButton *edit_menu;
+	MenuButton *highlighter_menu;
 	MenuButton *search_menu;
 	PopupMenu *context_menu;
 
@@ -125,6 +126,9 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+	Map<String, SyntaxHighlighter *> highlighters;
+	void _change_syntax_highlighter(int p_idx);
+
 	void _edit_option(int p_op);
 	void _make_context_menu(bool p_selection, bool p_color, bool p_can_fold, bool p_is_folded);
 	void _text_edit_gui_input(const Ref<InputEvent> &ev);
@@ -145,6 +149,9 @@ protected:
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
 
 public:
+	virtual void add_syntax_highlighter(SyntaxHighlighter *p_highlighter);
+	virtual void set_syntax_highlighter(SyntaxHighlighter *p_highlighter);
+
 	virtual void apply_code();
 	virtual Ref<Script> get_edited_script() const;
 	virtual Vector<String> get_functions();

--- a/modules/gdscript/gdscript_highlighter.cpp
+++ b/modules/gdscript/gdscript_highlighter.cpp
@@ -1,0 +1,278 @@
+/*************************************************************************/
+/*  gdscript_highlighter.cpp                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "gdscript_highlighter.h"
+#include "scene/gui/text_edit.h"
+
+inline bool _is_symbol(CharType c) {
+
+	return is_symbol(c);
+}
+
+static bool _is_text_char(CharType c) {
+
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_';
+}
+
+static bool _is_whitespace(CharType c) {
+	return c == '\t' || c == ' ';
+}
+
+static bool _is_char(CharType c) {
+
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_';
+}
+
+static bool _is_number(CharType c) {
+	return (c >= '0' && c <= '9');
+}
+
+static bool _is_hex_symbol(CharType c) {
+	return ((c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'));
+}
+
+Map<int, TextEdit::HighlighterInfo> GDSyntaxHighlighter::_get_line_syntax_highlighting(int p_line) {
+	Map<int, TextEdit::HighlighterInfo> color_map;
+
+	bool prev_is_char = false;
+	bool prev_is_number = false;
+	bool in_keyword = false;
+	bool in_word = false;
+	bool in_function_name = false;
+	bool in_member_variable = false;
+	bool is_hex_notation = false;
+	Color keyword_color;
+	Color color;
+
+	int in_region = -1;
+	int deregion = 0;
+	for (int i = 0; i < p_line; i++) {
+		int ending_color_region = text_editor->_get_line_ending_color_region(i);
+		if (in_region == -1) {
+			in_region = ending_color_region;
+		} else if (in_region == ending_color_region) {
+			in_region = -1;
+		} else {
+			const Map<int, TextEdit::Text::ColorRegionInfo> &cri_map = text_editor->_get_line_color_region_info(i);
+			for (const Map<int, TextEdit::Text::ColorRegionInfo>::Element *E = cri_map.front(); E; E = E->next()) {
+				const TextEdit::Text::ColorRegionInfo &cri = E->get();
+				if (cri.region == in_region) {
+					in_region = -1;
+				}
+			}
+		}
+	}
+
+	const Map<int, TextEdit::Text::ColorRegionInfo> cri_map = text_editor->_get_line_color_region_info(p_line);
+	const String &str = text_editor->get_line(p_line);
+	Color prev_color;
+	for (int j = 0; j < str.length(); j++) {
+		TextEdit::HighlighterInfo highlighter_info;
+
+		if (deregion > 0) {
+			deregion--;
+			if (deregion == 0) {
+				in_region = -1;
+			}
+		}
+
+		if (deregion != 0) {
+			if (color != prev_color) {
+				prev_color = color;
+				highlighter_info.color = color;
+				color_map[j] = highlighter_info;
+			}
+			continue;
+		}
+
+		color = font_color;
+
+		bool is_char = _is_text_char(str[j]);
+		bool is_symbol = _is_symbol(str[j]);
+		bool is_number = _is_number(str[j]);
+
+		// allow ABCDEF in hex notation
+		if (is_hex_notation && (_is_hex_symbol(str[j]) || is_number)) {
+			is_number = true;
+		} else {
+			is_hex_notation = false;
+		}
+
+		// check for dot or underscore or 'x' for hex notation in floating point number
+		if ((str[j] == '.' || str[j] == 'x' || str[j] == '_') && !in_word && prev_is_number && !is_number) {
+			is_number = true;
+			is_symbol = false;
+			is_char = false;
+
+			if (str[j] == 'x' && str[j - 1] == '0') {
+				is_hex_notation = true;
+			}
+		}
+
+		if (!in_word && _is_char(str[j]) && !is_number) {
+			in_word = true;
+		}
+
+		if ((in_keyword || in_word) && !is_hex_notation) {
+			is_number = false;
+		}
+
+		if (is_symbol && str[j] != '.' && in_word) {
+			in_word = false;
+		}
+
+		if (is_symbol && cri_map.has(j)) {
+			const TextEdit::Text::ColorRegionInfo &cri = cri_map[j];
+
+			if (in_region == -1) {
+				if (!cri.end) {
+					in_region = cri.region;
+				}
+			} else {
+				TextEdit::ColorRegion cr = text_editor->_get_color_region(cri.region);
+				if (in_region == cri.region && !cr.line_only) { //ignore otherwise
+					if (cri.end || cr.eq) {
+						deregion = cr.eq ? cr.begin_key.length() : cr.end_key.length();
+					}
+				}
+			}
+		}
+
+		if (!is_char) {
+			in_keyword = false;
+		}
+
+		if (in_region == -1 && !in_keyword && is_char && !prev_is_char) {
+
+			int to = j;
+			while (to < str.length() && _is_text_char(str[to]))
+				to++;
+
+			String word = str.substr(j, to - j);
+			Color col = Color();
+			if (text_editor->has_keyword_color(word)) {
+				col = text_editor->get_keyword_color(word);
+			} else if (text_editor->has_member_color(word)) {
+				col = text_editor->get_member_color(word);
+				for (int k = j - 1; k >= 0; k--) {
+					if (str[k] == '.') {
+						col = Color(); //member indexing not allowed
+						break;
+					} else if (str[k] > 32) {
+						break;
+					}
+				}
+			}
+
+			if (col != Color()) {
+				in_keyword = true;
+				keyword_color = col;
+			}
+		}
+
+		if (!in_function_name && in_word && !in_keyword) {
+
+			int k = j;
+			while (k < str.length() && !_is_symbol(str[k]) && str[k] != '\t' && str[k] != ' ') {
+				k++;
+			}
+
+			// check for space between name and bracket
+			while (k < str.length() && (str[k] == '\t' || str[k] == ' ')) {
+				k++;
+			}
+
+			if (str[k] == '(') {
+				in_function_name = true;
+			}
+		}
+
+		if (!in_function_name && !in_member_variable && !in_keyword && !is_number && in_word) {
+			int k = j;
+			while (k > 0 && !_is_symbol(str[k]) && str[k] != '\t' && str[k] != ' ') {
+				k--;
+			}
+
+			if (str[k] == '.') {
+				in_member_variable = true;
+			}
+		}
+
+		if (is_symbol) {
+			in_function_name = false;
+			in_member_variable = false;
+		}
+
+		if (in_region >= 0)
+			color = text_editor->_get_color_region(in_region).color;
+		else if (in_keyword)
+			color = keyword_color;
+		else if (in_member_variable)
+			color = member_color;
+		else if (in_function_name)
+			color = function_color;
+		else if (is_symbol)
+			color = symbol_color;
+		else if (is_number)
+			color = number_color;
+
+		prev_is_char = is_char;
+		prev_is_number = is_number;
+
+		if (color != prev_color) {
+			prev_color = color;
+			highlighter_info.color = color;
+			color_map[j] = highlighter_info;
+		}
+	}
+	return color_map;
+}
+
+String GDSyntaxHighlighter::get_name() {
+	return "GDScript";
+}
+
+List<String> GDSyntaxHighlighter::get_supported_languages() {
+	List<String> languages;
+	languages.push_back("GDScript");
+	return languages;
+}
+
+void GDSyntaxHighlighter::_update_cache() {
+	font_color = text_editor->get_color("font_color");
+	symbol_color = text_editor->get_color("symbol_color");
+	function_color = text_editor->get_color("function_color");
+	number_color = text_editor->get_color("number_color");
+	member_color = text_editor->get_color("member_variable_color");
+}
+
+SyntaxHighlighter *GDSyntaxHighlighter::create() {
+	return memnew(GDSyntaxHighlighter);
+}

--- a/modules/gdscript/gdscript_highlighter.h
+++ b/modules/gdscript/gdscript_highlighter.h
@@ -1,0 +1,56 @@
+/*************************************************************************/
+/*  gdscript_highlighter.h                                               */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef GDSCRIPT_HIGHLIGHTER_H
+#define GDSCRIPT_HIGHLIGHTER_H
+
+#include "scene/gui/text_edit.h"
+
+class GDSyntaxHighlighter : public SyntaxHighlighter {
+private:
+	// colours
+	Color font_color;
+	Color symbol_color;
+	Color function_color;
+	Color built_in_type_color;
+	Color number_color;
+	Color member_color;
+
+public:
+	static SyntaxHighlighter *create();
+
+	virtual void _update_cache();
+	virtual Map<int, TextEdit::HighlighterInfo> _get_line_syntax_highlighting(int p_line);
+
+	virtual String get_name();
+	virtual List<String> get_supported_languages();
+};
+
+#endif // GDSCRIPT_HIGHLIGHTER_H

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -31,6 +31,7 @@
 #include "register_types.h"
 
 #include "gdscript.h"
+#include "gdscript_highlighter.h"
 #include "gdscript_tokenizer.h"
 #include "io/file_access_encrypted.h"
 #include "io/resource_loader.h"
@@ -92,6 +93,7 @@ void register_gdscript_types() {
 	ResourceSaver::add_resource_format_saver(resource_saver_gd);
 
 #ifdef TOOLS_ENABLED
+	ScriptEditor::register_create_syntax_highlighter_function(GDSyntaxHighlighter::create);
 	EditorNode::add_init_callback(_editor_init);
 #endif
 }

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -3236,6 +3236,12 @@ void VisualScriptEditor::_member_option(int p_option) {
 	}
 }
 
+void VisualScriptEditor::add_syntax_highlighter(SyntaxHighlighter *p_highlighter) {
+}
+
+void VisualScriptEditor::set_syntax_highlighter(SyntaxHighlighter *p_highlighter) {
+}
+
 void VisualScriptEditor::_bind_methods() {
 
 	ClassDB::bind_method("_member_button", &VisualScriptEditor::_member_button);

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -246,6 +246,9 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual void add_syntax_highlighter(SyntaxHighlighter *p_highlighter);
+	virtual void set_syntax_highlighter(SyntaxHighlighter *p_highlighter);
+
 	virtual void apply_code();
 	virtual Ref<Script> get_edited_script() const;
 	virtual Vector<String> get_functions();


### PR DESCRIPTION
This PR abstracts out the syntax highlighting from the draw section of `TextEdit` allowing custom highlighters to be used.

There is a new class called `SyntaxHighlighter` of which all syntax highlighters must extend. All `TextEdits` and `SyntaxHighlighters` have a 1 to 1 relationship, so a `SyntaxHighlighter` cannot serve multiple `TextEdits` and vice versa.

If the `TextEdit` is not given a `SyntaxHighlighter` or is set to `NULL` it will go ahead a use a modified version of the current system.

The `SyntaxHighlighter::_get_line_syntax_highlighting` will get called for every line that we are drawing. Returning  `Map<int, HighlighterInfo>` where the key is the column start of the section and `HighlighterInfo` a new struct directing how this section should be drawn. Currently it can only change the colour. The section ends when the end of line is reached or a new section is found.

There is also a new function in `ScriptEditorPlugin` to register `SyntaxHighlighter` creation functions. Now when a new `ScriptEditor` is created the `SyntaxHighlighters` will also be created and added. 

When adding `SyntaxHighlighters` it will check if it supports the scripts language, if a match is found that highlighter will be automatically selected.

The `ScriptTextEditor` has gained a new drop down menu item `Syntax Highlighter` listing all the added  `SyntaxHighlighters` giving you the ability to change the current highlighter on the fly.

I've also included a `GDSyntaxHighlighter` that is currently identical to the default one, ready for adding GDScript specific use cases.

Lastly, in the process I've had to remove the encapsulation around some of the internal `TextEdit` implementation and hopefully made calculating `ColorRegion(s)` slightly more performance friendly. 

closes #15691