### PR TITLE
[WIP] Add graph node roundness option

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -260,6 +260,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	int border_size = EDITOR_DEF("interface/theme/border_size", 1);
 
 	bool use_gn_headers = EDITOR_DEF("interface/theme/use_graph_node_headers", false);
+	int gn_roundness = EDITOR_DEF("interface/theme/graph_node_roundness", 0);
 
 	Color script_bg_color = EDITOR_DEF("text_editor/highlighting/background_color", Color(0, 0, 0, 0));
 

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -527,6 +527,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 
 		GraphNode *gnode = memnew(GraphNode);
 		gnode->set_title(node->get_caption());
+		gnode->set_roundness((int)EDITOR_GET("interface/theme/graph_node_roundness"));
 		if (error_line == E->get()) {
 			gnode->set_overlay(GraphNode::OVERLAY_POSITION);
 		} else if (node->is_breakpoint()) {

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -202,6 +202,9 @@ void GraphNode::_notification(int p_what) {
 
 			sb = get_stylebox(selected ? "selectedframe" : "frame");
 		}
+		if (use_roundness) {
+			((Ref<StyleBoxFlat>)sb)->set_corner_radius_all(roundness);
+		}
 
 		//sb=sb->duplicate();
 		//sb->call("set_modulate",modulate);
@@ -660,6 +663,15 @@ bool GraphNode::is_resizable() const {
 	return resizable;
 }
 
+void GraphNode::set_roundness(int p_roundness) {
+	roundness = p_roundness;
+	use_roundness = true;
+}
+
+int GraphNode::get_roundness() const {
+	return roundness;
+}
+
 void GraphNode::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_title", "title"), &GraphNode::set_title);
@@ -733,4 +745,6 @@ GraphNode::GraphNode() {
 	resizable = false;
 	resizing = false;
 	selected = false;
+	roundness = 0;
+	use_roundness = false;
 }

--- a/scene/gui/graph_node.h
+++ b/scene/gui/graph_node.h
@@ -37,6 +37,8 @@ class GraphNode : public Container {
 
 	GDCLASS(GraphNode, Container);
 
+	friend class VisualScriptEditor;
+
 public:
 	enum Overlay {
 		OVERLAY_DISABLED,
@@ -99,6 +101,13 @@ private:
 	bool selected;
 
 	Overlay overlay;
+
+	int roundness;
+	bool use_roundness;
+
+	// private(for now)
+	void set_roundness(int p_roundness);
+	int get_roundness() const;
 
 protected:
 	void _gui_input(const Ref<InputEvent> &p_ev);


### PR DESCRIPTION
 Its cool if user can control roundness of visual script nodes, so I've added possibility for this. I bring a new option interface->theme->Graph Node Roundness, Its off by default - "0" .

![image](https://user-images.githubusercontent.com/3036176/38235000-4d738804-3728-11e8-9864-b0ca225e7c29.png)

For example, If you change it to "10" - (changes will apply immediatly)

![image](https://user-images.githubusercontent.com/3036176/38203242-45166220-36a7-11e8-8c52-d657ca50d5b8.png) - with header
![image](https://user-images.githubusercontent.com/3036176/38203397-d4c263ec-36a7-11e8-8194-c44691beeb1f.png) - without header

IRC summarize:

22:41:56IssueBot#17926: Add graph node roundness option | https://git.io/vximk 
22:42:17AkienIt looks nice, but I wonder why the added methods are private? 
22:42:18reduzto me this is pointless, if you guys like it go ahead, i see no reason to merge this 
22:42:46groud_Well i kind of agree 
22:42:59chaosus89because if they public the custom GraphNode could crash inside editor 
22:43:11groud_I mean, the style is nice, but i don't get why people want to add everything as an option 
22:43:19chaosus89its works only in VisualScriptEditor 
22:43:21chaosus89for now 
22:43:39groud_If people like I would just make it default 
22:43:51reduzalso exposing it in GraphNode makes no sense, we have a theme system for a reason 
22:43:52groud_And don't provide an option to change that 
22:44:22groud_Oh i did not think about that 
22:44:43groud_Making it part of editor theme makes more sense 
22:44:53reduzit already is part of the editor theme 
22:45:05falesyeah, fix it in theme in case. I agree roundness is nice (though title should not be rounded as in comment) but should really be done via theme 
22:45:05groud_So the option makes no sense then 
22:45:05reduzjust not esily exposed in editor settings 
22:45:54falesI don't really think it's should be an option in editor settings, we should go for a nice look by default and that's it 
22:46:05falesit should* 
22:46:27chaosus89oh, I can remove it and change to just a constant ? nice 
22:47:11reduzwho made the editor theme? was it not toger5 and djrm[m]? 
22:47:20groud_Probably yes 
22:47:43groud_Maybe we can tag them and if they agree to make it default 
22:48:19faleschaosus89, no, the stylebox for GraphNode in the editor theme should be changed in case. 
22:48:21AkienOk I'll quickly summarize our points and ping djrm, let's move to the next PR in the meantime, time flies 