### PR TITLE
Removed unneeded sort from SpriteFramesEditor plugin

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -458,8 +458,6 @@ void SpriteFramesEditor::_update_library(bool p_skip_selector) {
 
 		List<StringName> anim_names;
 
-		anim_names.sort_custom<StringName::AlphCompare>();
-
 		frames->get_animation_list(&anim_names);
 
 		anim_names.sort_custom<StringName::AlphCompare>();


### PR DESCRIPTION
The `anim_names` list was just created and is empty.