### PR TITLE
fix bone scale/rotation in AnimationPlayers

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -590,8 +590,8 @@ void AnimationPlayer::_animation_update_transforms() {
 
 			Transform t;
 			t.origin = nc->loc_accum;
-			t.basis = nc->rot_accum;
 			t.basis.scale(nc->scale_accum);
+			t.basis.rotate(nc->rot_accum.get_euler());
 
 			if (nc->skeleton && nc->bone_idx >= 0) {
 

--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -895,13 +895,13 @@ void AnimationTreePlayer::_process_animation(float p_delta) {
 		}
 
 		Transform xform;
-		xform.basis = t.rot;
 		xform.origin = t.loc;
 
 		t.scale.x += 1.0;
 		t.scale.y += 1.0;
 		t.scale.z += 1.0;
 		xform.basis.scale(t.scale);
+		xform.basis.rotate(t.rot.get_euler());
 
 		if (t.bone_idx >= 0) {
 			if (t.skeleton)


### PR DESCRIPTION
fixes #17325.

The bone pose transform was created by setting the rotation and
**then** scaling the transform. This leads to object "deformation"
that's not intended.