### PR TITLE
Allows to map an action to all devices.

### DIFF
--- a/core/input_map.cpp
+++ b/core/input_map.cpp
@@ -35,6 +35,8 @@
 
 InputMap *InputMap::singleton = NULL;
 
+int InputMap::ALL_DEVICES = -1;
+
 void InputMap::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("has_action", "action"), &InputMap::has_action);
@@ -103,10 +105,10 @@ List<Ref<InputEvent> >::Element *InputMap::_find_event(List<Ref<InputEvent> > &p
 		//if (e.type != Ref<InputEvent>::KEY && e.device != p_event.device) -- unsure about the KEY comparison, why is this here?
 		//	continue;
 
-		if (e->get_device() != p_event->get_device())
-			continue;
-		if (e->action_match(p_event))
-			return E;
+		int device = e->get_device();
+		if (device == ALL_DEVICES || device == p_event->get_device())
+			if (e->action_match(p_event))
+				return E;
 	}
 
 	return NULL;

--- a/core/input_map.h
+++ b/core/input_map.h
@@ -39,6 +39,11 @@ class InputMap : public Object {
 	GDCLASS(InputMap, Object);
 
 public:
+	/**
+	* A special value used to signify that a given Action can be triggered by any device
+	*/
+	static int ALL_DEVICES;
+
 	struct Action {
 		int id;
 		List<Ref<InputEvent> > inputs;

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -80,7 +80,7 @@ class ProjectSettingsEditor : public AcceptDialog {
 	ConfirmationDialog *press_a_key;
 	Label *press_a_key_label;
 	ConfirmationDialog *device_input;
-	SpinBox *device_id;
+	OptionButton *device_id;
 	OptionButton *device_index;
 	Label *device_index_label;
 	MenuButton *popup_copy_to_feature;
@@ -169,6 +169,10 @@ class ProjectSettingsEditor : public AcceptDialog {
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+
+	int _get_current_device();
+	void _set_current_device(int i_device);
+	String _get_device_string(int i_device);
 
 public:
 	void add_translation(const String &p_translation);


### PR DESCRIPTION
This is accomplished by setting a special value (-1) to the device variable
in the InputEvent that's being used to compare with the one received from the OS.

This special value is invalid for a regular input, so it should be safe.
Implements #17942