### PR TITLE
Explicitly print an error when --export fails.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -470,24 +470,28 @@ void EditorNode::_fs_changed() {
 		}
 		if (preset.is_null()) {
 			String err = "Unknown export preset: " + export_defer.preset;
-			ERR_PRINT(err.utf8().get_data());
+			ERR_PRINTS(err);
 		} else {
 			Ref<EditorExportPlatform> platform = preset->get_platform();
 			if (platform.is_null()) {
 				String err = "Preset \"" + export_defer.preset + "\" doesn't have a platform.";
-				ERR_PRINT(err.utf8().get_data());
+				ERR_PRINTS(err);
 			} else {
 				// ensures export_project does not loop infinitely, because notifications may
 				// come during the export
 				export_defer.preset = "";
+				Error err;
 				if (!preset->is_runnable() && (export_defer.path.ends_with(".pck") || export_defer.path.ends_with(".zip"))) {
 					if (export_defer.path.ends_with(".zip")) {
-						platform->save_zip(preset, export_defer.path);
+						err = platform->save_zip(preset, export_defer.path);
 					} else if (export_defer.path.ends_with(".pck")) {
-						platform->save_pack(preset, export_defer.path);
+						err = platform->save_pack(preset, export_defer.path);
 					}
 				} else {
-					platform->export_project(preset, export_defer.debug, export_defer.path, /*p_flags*/ 0);
+					err = platform->export_project(preset, export_defer.debug, export_defer.path, /*p_flags*/ 0);
+				}
+				if (err != OK) {
+					ERR_PRINTS(vformat(TTR("Project export failed with error code %d."), (int)err));
 				}
 			}
 		}


### PR DESCRIPTION
Previously this would not explicitly say the export failed.
Sure you might see another error somewhere, but that's not very reliable/obvious.