### PR TITLE
[NativeScript] added global type tag system

### DIFF
--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -5822,6 +5822,23 @@
             ]
           },
           {
+            "name": "godot_nativescript_set_global_type_tag",
+            "return_type": "void",
+            "arguments": [
+              ["int", "p_idx"],
+              ["const char *", "p_name"],
+              ["const void *", "p_type_tag"]
+            ]
+          },
+          {
+            "name": "godot_nativescript_get_global_type_tag",
+            "return_type": "const void *",
+            "arguments": [
+              ["int", "p_idx"],
+              ["const char *", "p_name"]
+            ]
+          },
+          {
             "name": "godot_nativescript_set_type_tag",
             "return_type": "void",
             "arguments": [

--- a/modules/gdnative/include/nativescript/godot_nativescript.h
+++ b/modules/gdnative/include/nativescript/godot_nativescript.h
@@ -214,13 +214,16 @@ void GDAPI godot_nativescript_set_signal_documentation(void *p_gdnative_handle, 
 
 // type tag API
 
+void GDAPI godot_nativescript_set_global_type_tag(int p_idx, const char *p_name, const void *p_type_tag);
+const void GDAPI *godot_nativescript_get_global_type_tag(int p_idx, const char *p_name);
+
 void GDAPI godot_nativescript_set_type_tag(void *p_gdnative_handle, const char *p_name, const void *p_type_tag);
 const void GDAPI *godot_nativescript_get_type_tag(const godot_object *p_object);
 
 // instance binding API
 
 typedef struct {
-	GDCALLINGCONV void *(*alloc_instance_binding_data)(void *, godot_object *);
+	GDCALLINGCONV void *(*alloc_instance_binding_data)(void *, const void *, godot_object *);
 	GDCALLINGCONV void (*free_instance_binding_data)(void *, void *);
 	void *data;
 	GDCALLINGCONV void (*free_func)(void *);

--- a/modules/gdnative/nativescript/godot_nativescript.cpp
+++ b/modules/gdnative/nativescript/godot_nativescript.cpp
@@ -313,6 +313,14 @@ void GDAPI godot_nativescript_set_signal_documentation(void *p_gdnative_handle, 
 	signal->get().documentation = *(String *)&p_documentation;
 }
 
+void GDAPI godot_nativescript_set_global_type_tag(int p_idx, const char *p_name, const void *p_type_tag) {
+	NativeScriptLanguage::get_singleton()->set_global_type_tag(p_idx, StringName(p_name), p_type_tag);
+}
+
+const void GDAPI *godot_nativescript_get_global_type_tag(int p_idx, const char *p_name) {
+	return NativeScriptLanguage::get_singleton()->get_global_type_tag(p_idx, StringName(p_name));
+}
+
 void GDAPI godot_nativescript_set_type_tag(void *p_gdnative_handle, const char *p_name, const void *p_type_tag) {
 	String *s = (String *)p_gdnative_handle;
 
@@ -347,10 +355,6 @@ const void GDAPI *godot_nativescript_get_type_tag(const godot_object *p_object) 
 	return NULL;
 }
 
-#ifdef __cplusplus
-}
-#endif
-
 int GDAPI godot_nativescript_register_instance_binding_data_functions(godot_instance_binding_functions p_binding_functions) {
 	return NativeScriptLanguage::get_singleton()->register_binding_functions(p_binding_functions);
 }
@@ -362,3 +366,7 @@ void GDAPI godot_nativescript_unregister_instance_binding_data_functions(int p_i
 void GDAPI *godot_nativescript_get_instance_binding_data(int p_idx, godot_object *p_object) {
 	return NativeScriptLanguage::get_singleton()->get_instance_binding_data(p_idx, (Object *)p_object);
 }
+
+#ifdef __cplusplus
+}
+#endif

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -36,6 +36,7 @@
 #include "core/self_list.h"
 #include "io/resource_loader.h"
 #include "io/resource_saver.h"
+#include "oa_hash_map.h"
 #include "ordered_hash_map.h"
 #include "os/thread_safe.h"
 #include "scene/main/node.h"
@@ -240,6 +241,8 @@ private:
 	Vector<Pair<bool, godot_instance_binding_functions> > binding_functions;
 	Set<Vector<void *> *> binding_instances;
 
+	Map<int, HashMap<StringName, const void *> > global_type_tags;
+
 public:
 	// These two maps must only be touched on the main thread
 	Map<String, Map<StringName, NativeScriptDesc> > library_classes;
@@ -323,6 +326,9 @@ public:
 
 	virtual void *alloc_instance_binding_data(Object *p_object);
 	virtual void free_instance_binding_data(void *p_data);
+
+	void set_global_type_tag(int p_idx, StringName p_class_name, const void *p_type_tag);
+	const void *get_global_type_tag(int p_idx, StringName p_class_name) const;
 };
 
 inline NativeScriptDesc *NativeScript::get_script_desc() const {


### PR DESCRIPTION
This adds a map for library-defined global type tags. This is useful for safe casting and type checking on the library side.