### PR TITLE
Initialize sensors to default values for Android platform

### DIFF
--- a/platform/android/java/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/src/org/godotengine/godot/Godot.java
@@ -379,6 +379,13 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 		mGyroscope = mSensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE);
 		mSensorManager.registerListener(this, mGyroscope, SensorManager.SENSOR_DELAY_GAME);
 
+		// Since there is no way to poll sensors themselves to get actual values
+		// we initialize them to 0
+		GodotLib.accelerometer(0, 0, 0);
+		GodotLib.gravity(0, 0, 0);
+		GodotLib.magnetometer(0, 0, 0);
+		GodotLib.gyroscope(0, 0, 0);
+
 		result_callback = null;
 
 		mPaymentsManager = PaymentsManager.createManager(this).initService();


### PR DESCRIPTION
Should fix https://github.com/godotengine/godot/issues/17988

Tested on Samsung S4 Android 4.4 and on Samsung S4 Android 5.1