### PR TITLE
Remove size restriction for mouse cursor

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1507,9 +1507,7 @@ void OS_OSX::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, c
 		Ref<Texture> texture = p_cursor;
 		Ref<Image> image = texture->get_data();
 
-		int image_size = 32 * 32;
-
-		ERR_FAIL_COND(texture->get_width() != 32 || texture->get_height() != 32);
+		ERR_FAIL_COND(texture->get_width() > 256 || texture->get_height() > 256);
 
 		NSBitmapImageRep *imgrep = [[[NSBitmapImageRep alloc]
 				initWithBitmapDataPlanes:NULL

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1896,26 +1896,25 @@ void OS_Windows::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shap
 		Ref<Texture> texture = p_cursor;
 		Ref<Image> image = texture->get_data();
 
-		UINT image_size = 32 * 32;
+		UINT image_size = texture->get_width() * texture->get_height();
 		UINT size = sizeof(UINT) * image_size;
 
-		ERR_FAIL_COND(texture->get_width() != 32 || texture->get_height() != 32);
+		ERR_FAIL_COND(texture->get_width() > 256 || texture->get_height() > 256);
 
 		// Create the BITMAP with alpha channel
 		COLORREF *buffer = (COLORREF *)malloc(sizeof(COLORREF) * image_size);
 
 		image->lock();
 		for (UINT index = 0; index < image_size; index++) {
-			int column_index = floor(index / 32);
-			int row_index = index % 32;
+			int row_index = floor(index / texture->get_width());
+			int column_index = index % texture->get_width();
 
-			Color pcColor = image->get_pixel(row_index, column_index);
-			*(buffer + index) = image->get_pixel(row_index, column_index).to_argb32();
+			*(buffer + index) = image->get_pixel(column_index, row_index).to_argb32();
 		}
 		image->unlock();
 
 		// Using 4 channels, so 4 * 8 bits
-		HBITMAP bitmap = CreateBitmap(32, 32, 1, 4 * 8, buffer);
+		HBITMAP bitmap = CreateBitmap(texture->get_width(), texture->get_height(), 1, 4 * 8, buffer);
 		COLORREF clrTransparent = -1;
 
 		// Create the AND and XOR masks for the bitmap

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -2375,11 +2375,11 @@ void OS_X11::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, c
 		Ref<Texture> texture = p_cursor;
 		Ref<Image> image = texture->get_data();
 
-		ERR_FAIL_COND(texture->get_width() != 32 || texture->get_height() != 32);
+		ERR_FAIL_COND(texture->get_width() > 256 || texture->get_height() > 256);
 
 		// Create the cursor structure
 		XcursorImage *cursor_image = XcursorImageCreate(texture->get_width(), texture->get_height());
-		XcursorUInt image_size = 32 * 32;
+		XcursorUInt image_size = texture->get_width() * texture->get_height();
 		XcursorDim size = sizeof(XcursorPixel) * image_size;
 
 		cursor_image->version = 1;
@@ -2393,10 +2393,10 @@ void OS_X11::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, c
 		image->lock();
 
 		for (XcursorPixel index = 0; index < image_size; index++) {
-			int column_index = floor(index / 32);
-			int row_index = index % 32;
+			int row_index = floor(index / texture->get_width());
+			int column_index = index % texture->get_width();
 
-			*(cursor_image->pixels + index) = image->get_pixel(row_index, column_index).to_argb32();
+			*(cursor_image->pixels + index) = image->get_pixel(column_index, row_index).to_argb32();
 		}
 
 		image->unlock();


### PR DESCRIPTION
Fix #17992

I put a limit of 256x256 because on my linux machine any size bigger than this starts to flicker.

I think 256px is it enough for a cursor, right?

Tested on Win10 and Linux, dunno what will happen in other windows versions.
Mac is probably working, I'm without a virtual machine to test right now.