### PR TITLE
Add additional macos shortcuts for going to start/end of line

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2845,13 +2845,64 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			} break;
 			case KEY_A: {
 
+#ifndef APPLE_STYLE_KEYS
 				if (!k->get_command() || k->get_shift() || k->get_alt()) {
 					scancode_handled = false;
 					break;
 				}
-
 				select_all();
+#else
+				if (k->get_alt()) {
+					scancode_handled = false;
+					break;
+				}
+				if (!k->get_shift() && k->get_command())
+					select_all();
+				else if (k->get_control()) {
+					if (k->get_shift())
+						_pre_shift_selection();
 
+					int current_line_whitespace_len = 0;
+					while (current_line_whitespace_len < text[cursor.line].length()) {
+						CharType c = text[cursor.line][current_line_whitespace_len];
+						if (c != '\t' && c != ' ')
+							break;
+						current_line_whitespace_len++;
+					}
+
+					if (cursor_get_column() == current_line_whitespace_len)
+						cursor_set_column(0);
+					else
+						cursor_set_column(current_line_whitespace_len);
+
+					if (k->get_shift())
+						_post_shift_selection();
+					else if (k->get_command() || k->get_control())
+						deselect();
+				}
+			} break;
+			case KEY_E: {
+
+				if (!k->get_control() || k->get_command() || k->get_alt()) {
+					scancode_handled = false;
+					break;
+				}
+
+				if (k->get_shift())
+					_pre_shift_selection();
+
+				if (k->get_command())
+					cursor_set_line(text.size() - 1, true, false);
+				cursor_set_column(text[cursor.line].length());
+
+				if (k->get_shift())
+					_post_shift_selection();
+				else if (k->get_command() || k->get_control())
+					deselect();
+
+				_cancel_completion();
+				completion_hint = "";
+#endif
 			} break;
 			case KEY_X: {
 				if (readonly) {


### PR DESCRIPTION
This adds `control-a` and `control-e` as shortcuts for going to start and end of line respectively. This is a common OS-level shortcut in macos, and should be part of text editors.

Fixes Issue #17981 