### PR TITLE
Pluginscript fix add global constant mandatory

### DIFF
--- a/modules/gdnative/pluginscript/register_types.cpp
+++ b/modules/gdnative/pluginscript/register_types.cpp
@@ -78,7 +78,7 @@ static Error _check_language_desc(const godot_pluginscript_language_desc *desc) 
 	// desc->profiling_stop is not mandatory
 	// desc->profiling_get_accumulated_data is not mandatory
 	// desc->profiling_get_frame_data is not mandatory
-	// desc->frame is not mandatory
+	// desc->profiling_frame is not mandatory
 
 	ERR_FAIL_COND_V(!desc->script_desc.init, ERR_BUG);
 	ERR_FAIL_COND_V(!desc->script_desc.finish, ERR_BUG);

--- a/modules/gdnative/pluginscript/register_types.cpp
+++ b/modules/gdnative/pluginscript/register_types.cpp
@@ -64,7 +64,7 @@ static Error _check_language_desc(const godot_pluginscript_language_desc *desc) 
 	// desc->make_function is not mandatory
 	// desc->complete_code is not mandatory
 	// desc->auto_indent_code is not mandatory
-	// desc->add_global_constant is not mandatory
+	ERR_FAIL_COND_V(!desc->add_global_constant, ERR_BUG);
 	// desc->debug_get_error is not mandatory
 	// desc->debug_get_stack_level_count is not mandatory
 	// desc->debug_get_stack_level_line is not mandatory


### PR DESCRIPTION
See here https://github.com/touilleMan/godot-python/issues/64

`add_global_constant` is a mandatory callback (given it is used to implement autoloaded script), it should be checked accordingly.