### PR TITLE
[Mono] Improvements for Mathf

### DIFF
--- a/modules/mono/glue/cs_files/Basis.cs
+++ b/modules/mono/glue/cs_files/Basis.cs
@@ -206,13 +206,13 @@ namespace Godot
                 }
                 else
                 {
-                    euler.x = Mathf.PI * 0.5f;
+                    euler.x = Mathf.Pi * 0.5f;
                     euler.y = -Mathf.Atan2(-m[0, 1], m[0, 0]);
                 }
             }
             else
             {
-                euler.x = -Mathf.PI * 0.5f;
+                euler.x = -Mathf.Pi * 0.5f;
                 euler.y = -Mathf.Atan2(-m[0, 1], m[0, 0]);
             }
 

--- a/modules/mono/glue/cs_files/Mathf.cs
+++ b/modules/mono/glue/cs_files/Mathf.cs
@@ -8,21 +8,24 @@ using real_t = System.Single;
 
 namespace Godot
 {
-    public static class Mathf
+    public static partial class Mathf
     {
-        // Define constants with Decimal precision and cast down to double or float. 
-        public const real_t PI = (real_t) 3.1415926535897932384626433833M; // 3.1415927f and 3.14159265358979
+        // Define constants with Decimal precision and cast down to double or float.
 
-        #if REAL_T_IS_DOUBLE
-        public const real_t Epsilon = 1e-14; // Epsilon size should depend on the precision used.
-        #else
-        public const real_t Epsilon = 1e-06f;
-        #endif
+        public const real_t Tau = (real_t) 6.2831853071795864769252867666M; // 6.2831855f and 6.28318530717959
+        public const real_t Pi = (real_t) 3.1415926535897932384626433833M; // 3.1415927f and 3.14159265358979
+        public const real_t Inf = real_t.PositiveInfinity;
+        public const real_t NaN = real_t.NaN;
 
         private const real_t Deg2RadConst = (real_t) 0.0174532925199432957692369077M; // 0.0174532924f and 0.0174532925199433
         private const real_t Rad2DegConst = (real_t) 57.295779513082320876798154814M; // 57.29578f and 57.2957795130823
 
         public static real_t Abs(real_t s)
+        {
+            return Math.Abs(s);
+        }
+
+        public static int Abs(int s)
         {
             return Math.Abs(s);
         }
@@ -57,18 +60,14 @@ namespace Godot
             return (real_t)Math.Ceiling(s);
         }
 
-        public static real_t Clamp(real_t val, real_t min, real_t max)
+        public static int Clamp(int value, int min, int max)
         {
-            if (val < min)
-            {
-                return min;
-            }
-            else if (val > max)
-            {
-                return max;
-            }
+            return value < min ? min : value > max ? max : value;
+        }
 
-            return val;
+        public static real_t Clamp(real_t value, real_t min, real_t max)
+        {
+            return value < min ? min : value > max ? max : value;
         }
 
         public static real_t Cos(real_t s)
@@ -151,6 +150,21 @@ namespace Godot
             }
         }
 
+        public static real_t InverseLerp(real_t from, real_t to, real_t weight)
+        {
+           return (Clamp(weight, 0f, 1f) - from) / (to - from);
+        }
+
+        public static bool IsInf(real_t s)
+        {
+           return real_t.IsInfinity(s);
+        }
+
+        public static bool IsNaN(real_t s)
+        {
+           return real_t.IsNaN(s);
+        }
+
         public static real_t Lerp(real_t from, real_t to, real_t weight)
         {
             return from + (to - from) * Clamp(weight, 0f, 1f);
@@ -181,16 +195,16 @@ namespace Godot
             return (a < b) ? a : b;
         }
 
-        public static int NearestPo2(int val)
+        public static int NearestPo2(int value)
         {
-            val--;
-            val |= val >> 1;
-            val |= val >> 2;
-            val |= val >> 4;
-            val |= val >> 8;
-            val |= val >> 16;
-            val++;
-            return val;
+            value--;
+            value |= value >> 1;
+            value |= value >> 2;
+            value |= value >> 4;
+            value |= value >> 8;
+            value |= value >> 16;
+            value++;
+            return value;
         }
 
         public static Vector2 Polar2Cartesian(real_t r, real_t th)
@@ -216,6 +230,11 @@ namespace Godot
         public static int RoundToInt(real_t s)
         {
             return (int)Math.Round(s);
+        }
+
+        public static int Sign(int s)
+        {
+            return (s < 0) ? -1 : 1;
         }
 
         public static real_t Sign(real_t s)
@@ -258,16 +277,16 @@ namespace Godot
             return (real_t)Math.Tanh(s);
         }
 
-        public static int Wrap(int val, int min, int max)
+        public static int Wrap(int value, int min, int max)
         {
             int rng = max - min;
-            return min + ((((val - min) % rng) + rng) % rng);
+            return min + ((((value - min) % rng) + rng) % rng);
         }
 
-        public static real_t Wrap(real_t val, real_t min, real_t max)
+        public static real_t Wrap(real_t value, real_t min, real_t max)
         {
             real_t rng = max - min;
-            return min + (val - min) - (rng * Floor((val - min) / rng));
+            return min + ((((value - min) % rng) + rng) % rng);
         }
     }
 }

--- a/modules/mono/glue/cs_files/MathfEx.cs
+++ b/modules/mono/glue/cs_files/MathfEx.cs
@@ -1,0 +1,39 @@
+using System;
+
+#if REAL_T_IS_DOUBLE
+using real_t = System.Double;
+#else
+using real_t = System.Single;
+#endif
+
+namespace Godot
+{
+    public static partial class Mathf
+    {
+        // Define constants with Decimal precision and cast down to double or float.
+
+        public const real_t E = (real_t) 2.7182818284590452353602874714M; // 2.7182817f and 2.718281828459045
+        public const real_t Sqrt2 = (real_t) 1.4142135623730950488016887242M; // 1.4142136f and 1.414213562373095
+
+#if REAL_T_IS_DOUBLE
+        public const real_t Epsilon = 1e-14; // Epsilon size should depend on the precision used.
+#else
+        public const real_t Epsilon = 1e-06f;
+#endif
+
+        public static int CeilToInt(real_t s)
+        {
+            return (int)Math.Ceiling(s);
+        }
+
+        public static int FloorToInt(real_t s)
+        {
+            return (int)Math.Floor(s);
+        }    
+
+        public static int RoundToInt(real_t s)
+        {
+            return (int)Math.Round(s);
+        }
+    }
+}


### PR DESCRIPTION
Changes:

- Added Tau, Inf, NaN - constants from GDscript,
- Added Rt2 - Square root of 2
- Added E constant(for compatibility with System.Math class)
- Added InverseLerp, IsInf, IsNaN 
- Changed "val" to "value" in parameter names, yes value is keyword but its fine and no problem to use it(same as "from" which also a keyword and already existed in some functions)
- Added int versions of Abs, Clamp and Sign
- Clamp looks much simpler now(single line of code)
- Added CeilToInt, FloorToInt
- Renamed PI to Pi for compatibility with PascalCase
- Changed Wrap for float to more compact version(thanks @aaronfranke)
- Maked Mathf a partial class and placed all extensions and new constants to new MathfEx.cs