### PR TITLE
Fixed bug #17929. Inconsistent sort in file manager.

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -533,6 +533,7 @@ void FileSystemDock::_update_files(bool p_keep_selection) {
 
 			filelist.push_back(fi);
 		}
+		filelist.sort();
 	}
 
 	String oi = "Object";


### PR DESCRIPTION
This commit fix a bug #17929 in file manager. 
I just added sorting of files list in method FileSystemDock::_update_files.