### PR TITLE
NetworkedMultiplayerEnet: Add disconnecting/kicking peers

### DIFF
--- a/modules/enet/networked_multiplayer_enet.h
+++ b/modules/enet/networked_multiplayer_enet.h
@@ -120,6 +120,8 @@ public:
 
 	void close_connection();
 
+	void disconnect_peer(int p_peer, bool now = false);
+
 	virtual void poll();
 
 	virtual bool is_server() const;


### PR DESCRIPTION
Adds the ability to disconnect/kick peers from servers in NetworkedMultiplayerEnet.

Also some comment/code cleanup in the surrounding code.

Tested, seems to work fine. Closes #16452.

Not sure if this should be cherry-picked? It shouldn't break compability, only adds a new method.