### PR TITLE
Fix custom cursor when it's hidden

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1474,6 +1474,11 @@ void OS_OSX::set_cursor_shape(CursorShape p_shape) {
 	if (cursor_shape == p_shape)
 		return;
 
+	if (mouse_mode != MOUSE_MODE_VISIBLE) {
+		cursor_shape = p_shape;
+		return;
+	}
+
 	if (cursors[p_shape] != NULL) {
 		[cursors[p_shape] set];
 	} else {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1299,7 +1299,9 @@ void OS_Windows::set_mouse_mode(MouseMode p_mode) {
 	if (p_mode == MOUSE_MODE_CAPTURED || p_mode == MOUSE_MODE_HIDDEN) {
 		hCursor = SetCursor(NULL);
 	} else {
-		SetCursor(hCursor);
+		CursorShape c = cursor_shape;
+		cursor_shape = CURSOR_MAX;
+		set_cursor_shape(c);
 	}
 }
 
@@ -1863,6 +1865,11 @@ void OS_Windows::set_cursor_shape(CursorShape p_shape) {
 	if (cursor_shape == p_shape)
 		return;
 
+	if (mouse_mode != MOUSE_MODE_VISIBLE) {
+		cursor_shape = p_shape;
+		return;
+	}
+
 	static const LPCTSTR win_cursors[CURSOR_MAX] = {
 		IDC_ARROW,
 		IDC_IBEAM,
@@ -1888,6 +1895,7 @@ void OS_Windows::set_cursor_shape(CursorShape p_shape) {
 	} else {
 		SetCursor(LoadCursor(hInstance, win_cursors[p_shape]));
 	}
+
 	cursor_shape = p_shape;
 }
 

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -634,7 +634,7 @@ void OS_X11::set_mouse_mode(MouseMode p_mode) {
 	bool showCursor = (p_mode == MOUSE_MODE_VISIBLE || p_mode == MOUSE_MODE_CONFINED);
 
 	if (showCursor) {
-		XUndefineCursor(x11_display, x11_window); // show cursor
+		XDefineCursor(x11_display, x11_window, cursors[current_cursor]); // show cursor
 	} else {
 		XDefineCursor(x11_display, x11_window, null_cursor); // hide cursor
 	}


### PR DESCRIPTION
[Linux] Ensures that the custom cursor will be used when changing to
MOUSE_MODE_VISIBLE. Fix #3086

[Windows] Fix cursor flickering when MOUSE_MODE_HIDDEN.

[Mac] Fix possible cursor flicker when MOUSE_MODE_HIDDEN.