### PR TITLE
Fix of RigidBody's configuration warning for Z axis

### DIFF
--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -781,7 +781,7 @@ String RigidBody::get_configuration_warning() const {
 
 	String warning = CollisionObject::get_configuration_warning();
 
-	if ((get_mode() == MODE_RIGID || get_mode() == MODE_CHARACTER) && (ABS(t.basis.get_axis(0).length() - 1.0) > 0.05 || ABS(t.basis.get_axis(1).length() - 1.0) > 0.05 || ABS(t.basis.get_axis(0).length() - 1.0) > 0.05)) {
+	if ((get_mode() == MODE_RIGID || get_mode() == MODE_CHARACTER) && (ABS(t.basis.get_axis(0).length() - 1.0) > 0.05 || ABS(t.basis.get_axis(1).length() - 1.0) > 0.05 || ABS(t.basis.get_axis(2).length() - 1.0) > 0.05)) {
 		if (warning != String()) {
 			warning += "\n";
 		}


### PR DESCRIPTION
Fix of RigidBody's configuration warning for Z axis. There were identical sub-expressions in || operator (copy-paste mistake probably).

**Godot version:**  0ee72fb
**OS:** any
**Steps to reproduce:**

1. Create RigidBody.
2. Create CollisionShape as a child node. Assign new Shape (BoxShape for example).
3. RigidBody: set Mode to Rigid or Character.
4. RidigBody: Spatial -> Trasform -> Transform, set xx = 1, yy = 1, zz = 1.06.
Expected result: warning
Actual result before fix: no warning
Actual result after fix: warning


**Minimal reproduction project:**
[RigidBodyNoConfigWarnZAxis.zip](https://github.com/godotengine/godot/files/1888654/RigidBodyNoConfigWarnZAxis.zip)

