### PR TITLE
Added class to store extra information of input mapping

### DIFF
--- a/core/input_map.cpp
+++ b/core/input_map.cpp
@@ -208,10 +208,17 @@ void InputMap::load_from_globals() {
 
 		for (int i = 0; i < va.size(); i++) {
 
-			Ref<InputEvent> ie = va[i];
-			if (ie.is_null())
-				continue;
-			action_add_event(name, ie);
+			Ref<StoredInputEvent> sie = va[i];
+			if (sie.is_null()) {
+				Ref<InputEvent> ie = va[i];
+				if (ie.is_null())
+					continue;
+				action_add_event(name, ie);
+			} else {
+				if (sie->event.is_null())
+					continue;
+				action_add_event(name, sie->event);
+			}
 		}
 	}
 }

--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -1021,3 +1021,15 @@ InputEventPanGesture::InputEventPanGesture() {
 
 	delta = Vector2(0, 0);
 }
+
+void StoredInputEvent::_bind_methods() {
+
+	ClassDB::bind_method(D_METHOD("set_event", "event"), &StoredInputEvent::set_event);
+	ClassDB::bind_method(D_METHOD("get_event"), &StoredInputEvent::get_event);
+
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "event"), "set_event", "get_event");
+}
+
+void StoredInputEvent::set_event(Ref<InputEvent> p_event) {
+	event = p_event;
+}

--- a/core/os/input_event.h
+++ b/core/os/input_event.h
@@ -516,4 +516,19 @@ public:
 
 	InputEventPanGesture();
 };
+
+class StoredInputEvent : public Resource {
+
+	GDCLASS(StoredInputEvent, Resource)
+
+protected:
+	static void _bind_methods();
+
+public:
+	Ref<InputEvent> event;
+
+	void set_event(Ref<InputEvent> p_event);
+	Ref<InputEvent> get_event() const { return event; }
+};
+
 #endif


### PR DESCRIPTION
This new class `StoredInputEvent` is very useful when you need to add extra information in the input settings that are not directly related to the event state.