### PR TITLE
Allow set_custom_mouse_cursor to use same cursor(image) with different shapes

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -413,10 +413,6 @@ void InputDefault::set_mouse_position(const Point2 &p_posf) {
 
 	mouse_speed_track.update(p_posf - mouse_pos);
 	mouse_pos = p_posf;
-	if (custom_cursor.is_valid()) {
-		//removed, please insist that we implement hardware cursors
-		//		VisualServer::get_singleton()->cursor_set_pos(get_mouse_position());
-	}
 }
 
 Point2 InputDefault::get_mouse_position() const {
@@ -502,11 +498,6 @@ bool InputDefault::is_emulating_touchscreen() const {
 void InputDefault::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot) {
 	if (Engine::get_singleton()->is_editor_hint())
 		return;
-
-	if (custom_cursor == p_cursor)
-		return;
-
-	custom_cursor = p_cursor;
 
 	OS::get_singleton()->set_custom_mouse_cursor(p_cursor, (OS::CursorShape)p_shape, p_hotspot);
 }

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -115,7 +115,6 @@ class InputDefault : public Input {
 	SpeedTrack mouse_speed_track;
 	Map<int, Joypad> joy_names;
 	int fallback_mapping;
-	RES custom_cursor;
 
 public:
 	enum HatMask {


### PR DESCRIPTION
before:
```
Input.set_custom_mouse_cursor(arrow, Input.CURSOR_ARROW)
Input.set_custom_mouse_cursor(null, Input.CURSOR_IBEAM) # Hack
Input.set_custom_mouse_cursor(arrow, Input.CURSOR_IBEAM)
```
after:
```
Input.set_custom_mouse_cursor(arrow, Input.CURSOR_ARROW)
Input.set_custom_mouse_cursor(arrow, Input.CURSOR_IBEAM)
```