### PR TITLE
Add support for radio-looking items with icon

### DIFF
--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -77,6 +77,21 @@
 				created from the index. Note that checkable items just display a checkmark, but don't have any built-in checking behavior and must be checked/unchecked manually.
 			</description>
 		</method>
+		<method name="add_icon_radio_check_item">
+			<return type="void">
+			</return>
+			<argument index="0" name="texture" type="Texture">
+			</argument>
+			<argument index="1" name="label" type="String">
+			</argument>
+			<argument index="2" name="id" type="int" default="-1">
+			</argument>
+			<argument index="3" name="accel" type="int" default="0">
+			</argument>
+			<description>
+				The same as [method add_icon_check_item] but the inserted item will look as a radio button. Remember this is just cosmetic and you have to add the logic for checking/unchecking items in radio groups.
+			</description>
+		</method>
 		<method name="add_icon_check_shortcut">
 			<return type="void">
 			</return>

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -112,7 +112,7 @@ void OptionButton::pressed() {
 
 void OptionButton::add_icon_item(const Ref<Texture> &p_icon, const String &p_label, int p_ID) {
 
-	popup->add_icon_check_item(p_icon, p_label, p_ID);
+	popup->add_icon_radio_check_item(p_icon, p_label, p_ID);
 	if (popup->get_item_count() == 1)
 		select(0);
 }

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -588,6 +588,13 @@ void PopupMenu::add_radio_check_item(const String &p_label, int p_ID, uint32_t p
 	update();
 }
 
+void PopupMenu::add_icon_radio_check_item(const Ref<Texture> &p_icon, const String &p_label, int p_ID, uint32_t p_accel) {
+
+	add_icon_check_item(p_icon, p_label, p_ID, p_accel);
+	items[items.size() - 1].checkable_type = Item::CHECKABLE_TYPE_RADIO_BUTTON;
+	update();
+}
+
 void PopupMenu::add_icon_shortcut(const Ref<Texture> &p_icon, const Ref<ShortCut> &p_shortcut, int p_ID, bool p_global) {
 
 	ERR_FAIL_COND(p_shortcut.is_null());

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -122,6 +122,7 @@ public:
 	void add_icon_check_item(const Ref<Texture> &p_icon, const String &p_label, int p_ID = -1, uint32_t p_accel = 0);
 	void add_check_item(const String &p_label, int p_ID = -1, uint32_t p_accel = 0);
 	void add_radio_check_item(const String &p_label, int p_ID = -1, uint32_t p_accel = 0);
+	void add_icon_radio_check_item(const Ref<Texture> &p_icon, const String &p_label, int p_ID = -1, uint32_t p_accel = 0);
 	void add_submenu_item(const String &p_label, const String &p_submenu, int p_ID = -1);
 
 	void add_icon_shortcut(const Ref<Texture> &p_icon, const Ref<ShortCut> &p_shortcut, int p_ID = -1, bool p_global = false);


### PR DESCRIPTION
Letting users of `PopupMenu` use them. `OptionButton` was one of those interested and is updated in this commit.

Fixes #18063.