### PR TITLE
Implement Input.set_default_cursor_shape to change the default shape

### DIFF
--- a/core/os/input.cpp
+++ b/core/os/input.cpp
@@ -85,6 +85,7 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("warp_mouse_position", "to"), &Input::warp_mouse_position);
 	ClassDB::bind_method(D_METHOD("action_press", "action"), &Input::action_press);
 	ClassDB::bind_method(D_METHOD("action_release", "action"), &Input::action_release);
+	ClassDB::bind_method(D_METHOD("set_default_cursor_shape", "shape"), &Input::set_default_cursor_shape, DEFVAL(CURSOR_ARROW));
 	ClassDB::bind_method(D_METHOD("set_custom_mouse_cursor", "image", "shape", "hotspot"), &Input::set_custom_mouse_cursor, DEFVAL(CURSOR_ARROW), DEFVAL(Vector2()));
 	ClassDB::bind_method(D_METHOD("parse_input_event", "event"), &Input::parse_input_event);
 

--- a/core/os/input.h
+++ b/core/os/input.h
@@ -119,6 +119,8 @@ public:
 
 	virtual bool is_emulating_touchscreen() const = 0;
 
+	virtual CursorShape get_default_cursor_shape() = 0;
+	virtual void set_default_cursor_shape(CursorShape p_shape) = 0;
 	virtual void set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape = CURSOR_ARROW, const Vector2 &p_hotspot = Vector2()) = 0;
 	virtual void set_mouse_in_window(bool p_in_window) = 0;
 

--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -495,6 +495,15 @@ bool InputDefault::is_emulating_touchscreen() const {
 	return emulate_touch;
 }
 
+Input::CursorShape InputDefault::get_default_cursor_shape() {
+	return default_shape;
+}
+
+void InputDefault::set_default_cursor_shape(CursorShape p_shape) {
+	default_shape = p_shape;
+	OS::get_singleton()->set_cursor_shape((OS::CursorShape)p_shape);
+}
+
 void InputDefault::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot) {
 	if (Engine::get_singleton()->is_editor_hint())
 		return;

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -115,6 +115,7 @@ class InputDefault : public Input {
 	SpeedTrack mouse_speed_track;
 	Map<int, Joypad> joy_names;
 	int fallback_mapping;
+	CursorShape default_shape = CURSOR_ARROW;
 
 public:
 	enum HatMask {
@@ -225,6 +226,8 @@ public:
 	void set_emulate_touch(bool p_emulate);
 	virtual bool is_emulating_touchscreen() const;
 
+	virtual CursorShape get_default_cursor_shape();
+	virtual void set_default_cursor_shape(CursorShape p_shape);
 	virtual void set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape = Input::CURSOR_ARROW, const Vector2 &p_hotspot = Vector2());
 	virtual void set_mouse_in_window(bool p_in_window);
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1814,7 +1814,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 		}
 
 		if (!over) {
-			OS::get_singleton()->set_cursor_shape(OS::CURSOR_ARROW);
+			OS::get_singleton()->set_cursor_shape((OS::CursorShape)Input::get_singleton()->get_default_cursor_shape());
 			return;
 		}
 


### PR DESCRIPTION
Closes #18043 

Now we can call ```Input.set_default_cursor_shape(Input.CURSOR_IBEAM)``` and this cursor shape will be the default in the viewport.