### PR TITLE
Use internal physics processing for Nodes' internal logic

### DIFF
--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -101,7 +101,7 @@ void RayCast2D::set_enabled(bool p_enabled) {
 
 	enabled = p_enabled;
 	if (is_inside_tree() && !Engine::get_singleton()->is_editor_hint())
-		set_physics_process(p_enabled);
+		set_physics_process_internal(p_enabled);
 	if (!p_enabled)
 		collided = false;
 }
@@ -141,9 +141,9 @@ void RayCast2D::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 
 			if (enabled && !Engine::get_singleton()->is_editor_hint())
-				set_physics_process(true);
+				set_physics_process_internal(true);
 			else
-				set_physics_process(false);
+				set_physics_process_internal(false);
 
 			if (Object::cast_to<CollisionObject2D>(get_parent())) {
 				if (exclude_parent_body)
@@ -155,7 +155,7 @@ void RayCast2D::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 
 			if (enabled)
-				set_physics_process(false);
+				set_physics_process_internal(false);
 
 		} break;
 
@@ -183,7 +183,7 @@ void RayCast2D::_notification(int p_what) {
 
 		} break;
 
-		case NOTIFICATION_PHYSICS_PROCESS: {
+		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 
 			if (!enabled)
 				break;

--- a/scene/3d/ray_cast.cpp
+++ b/scene/3d/ray_cast.cpp
@@ -103,7 +103,7 @@ void RayCast::set_enabled(bool p_enabled) {
 
 	enabled = p_enabled;
 	if (is_inside_tree() && !Engine::get_singleton()->is_editor_hint())
-		set_physics_process(p_enabled);
+		set_physics_process_internal(p_enabled);
 	if (!p_enabled)
 		collided = false;
 
@@ -150,12 +150,12 @@ void RayCast::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 
 			if (enabled && !Engine::get_singleton()->is_editor_hint()) {
-				set_physics_process(true);
+				set_physics_process_internal(true);
 
 				if (get_tree()->is_debugging_collisions_hint())
 					_update_debug_shape();
 			} else
-				set_physics_process(false);
+				set_physics_process_internal(false);
 
 			if (Object::cast_to<CollisionObject>(get_parent())) {
 				if (exclude_parent_body)
@@ -168,14 +168,14 @@ void RayCast::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 
 			if (enabled) {
-				set_physics_process(false);
+				set_physics_process_internal(false);
 			}
 
 			if (debug_shape)
 				_clear_debug_shape();
 
 		} break;
-		case NOTIFICATION_PHYSICS_PROCESS: {
+		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 
 			if (!enabled)
 				break;

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -182,8 +182,8 @@ void AnimationPlayer::_notification(int p_what) {
 			if (!processing) {
 				//make sure that a previous process state was not saved
 				//only process if "processing" is set
-				set_physics_process(false);
-				set_process(false);
+				set_physics_process_internal(false);
+				set_process_internal(false);
 			}
 			//_set_process(false);
 			clear_caches();

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -114,7 +114,7 @@ void ScrollBar::_gui_input(Ref<InputEvent> p_event) {
 
 				if (smooth_scroll_enabled) {
 					scrolling = true;
-					set_physics_process(true);
+					set_physics_process_internal(true);
 				} else {
 					set_value(target_scroll);
 				}
@@ -138,7 +138,7 @@ void ScrollBar::_gui_input(Ref<InputEvent> p_event) {
 
 				if (smooth_scroll_enabled) {
 					scrolling = true;
-					set_physics_process(true);
+					set_physics_process_internal(true);
 				} else {
 					set_value(target_scroll);
 				}
@@ -322,7 +322,7 @@ void ScrollBar::_notification(int p_what) {
 		drag_slave = NULL;
 	}
 
-	if (p_what == NOTIFICATION_PHYSICS_PROCESS) {
+	if (p_what == NOTIFICATION_INTERNAL_PHYSICS_PROCESS) {
 
 		if (scrolling) {
 			if (get_value() != target_scroll) {
@@ -337,7 +337,7 @@ void ScrollBar::_notification(int p_what) {
 				}
 			} else {
 				scrolling = false;
-				set_physics_process(false);
+				set_physics_process_internal(false);
 			}
 		} else if (drag_slave_touching) {
 
@@ -397,7 +397,7 @@ void ScrollBar::_notification(int p_what) {
 				}
 
 				if (turnoff) {
-					set_physics_process(false);
+					set_physics_process_internal(false);
 					drag_slave_touching = false;
 					drag_slave_touching_deaccel = false;
 				}
@@ -566,7 +566,7 @@ void ScrollBar::_drag_slave_input(const Ref<InputEvent> &p_input) {
 		if (mb->is_pressed()) {
 
 			if (drag_slave_touching) {
-				set_physics_process(false);
+				set_physics_process_internal(false);
 				drag_slave_touching_deaccel = false;
 				drag_slave_touching = false;
 				drag_slave_speed = Vector2();
@@ -586,7 +586,7 @@ void ScrollBar::_drag_slave_input(const Ref<InputEvent> &p_input) {
 				drag_slave_touching_deaccel = false;
 				time_since_motion = 0;
 				if (drag_slave_touching) {
-					set_physics_process(true);
+					set_physics_process_internal(true);
 					time_since_motion = 0;
 				}
 			}
@@ -598,7 +598,7 @@ void ScrollBar::_drag_slave_input(const Ref<InputEvent> &p_input) {
 				if (drag_slave_speed == Vector2()) {
 					drag_slave_touching_deaccel = false;
 					drag_slave_touching = false;
-					set_physics_process(false);
+					set_physics_process_internal(false);
 				} else {
 
 					drag_slave_touching_deaccel = true;

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -68,7 +68,7 @@ Size2 ScrollContainer::get_minimum_size() const {
 };
 
 void ScrollContainer::_cancel_drag() {
-	set_physics_process(false);
+	set_physics_process_internal(false);
 	drag_touching_deaccel = false;
 	drag_touching = false;
 	drag_speed = Vector2();
@@ -141,7 +141,7 @@ void ScrollContainer::_gui_input(const Ref<InputEvent> &p_gui_input) {
 				beyond_deadzone = false;
 				time_since_motion = 0;
 				if (drag_touching) {
-					set_physics_process(true);
+					set_physics_process_internal(true);
 					time_since_motion = 0;
 				}
 			}
@@ -278,7 +278,7 @@ void ScrollContainer::_notification(int p_what) {
 		update_scrollbars();
 	}
 
-	if (p_what == NOTIFICATION_PHYSICS_PROCESS) {
+	if (p_what == NOTIFICATION_INTERNAL_PHYSICS_PROCESS) {
 
 		if (drag_touching) {
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -539,7 +539,7 @@ void TextEdit::_notification(int p_what) {
 			draw_caret = false;
 			update();
 		} break;
-		case NOTIFICATION_PHYSICS_PROCESS: {
+		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (scrolling && v_scroll->get_value() != target_v_scroll) {
 				double target_y = target_v_scroll - v_scroll->get_value();
 				double dist = sqrt(target_y * target_y);
@@ -548,13 +548,13 @@ void TextEdit::_notification(int p_what) {
 				if (Math::abs(vel) >= dist) {
 					v_scroll->set_value(target_v_scroll);
 					scrolling = false;
-					set_physics_process(false);
+					set_physics_process_internal(false);
 				} else {
 					v_scroll->set_value(v_scroll->get_value() + vel);
 				}
 			} else {
 				scrolling = false;
-				set_physics_process(false);
+				set_physics_process_internal(false);
 			}
 		} break;
 		case NOTIFICATION_DRAW: {
@@ -3027,7 +3027,7 @@ void TextEdit::_scroll_up(real_t p_delta) {
 			v_scroll->set_value(target_v_scroll);
 		} else {
 			scrolling = true;
-			set_physics_process(true);
+			set_physics_process_internal(true);
 		}
 	} else {
 		v_scroll->set_value(target_v_scroll);
@@ -3060,7 +3060,7 @@ void TextEdit::_scroll_down(real_t p_delta) {
 			v_scroll->set_value(target_v_scroll);
 		} else {
 			scrolling = true;
-			set_physics_process(true);
+			set_physics_process_internal(true);
 		}
 	} else {
 		v_scroll->set_value(target_v_scroll);

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2545,7 +2545,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 					if (drag_speed == 0) {
 						drag_touching_deaccel = false;
 						drag_touching = false;
-						set_physics_process(false);
+						set_physics_process_internal(false);
 					} else {
 
 						drag_touching_deaccel = true;
@@ -2611,7 +2611,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 					break;
 
 				if (drag_touching) {
-					set_physics_process(false);
+					set_physics_process_internal(false);
 					drag_touching_deaccel = false;
 					drag_touching = false;
 					drag_speed = 0;
@@ -2626,7 +2626,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 					drag_touching = OS::get_singleton()->has_touchscreen_ui_hint();
 					drag_touching_deaccel = false;
 					if (drag_touching) {
-						set_physics_process(true);
+						set_physics_process_internal(true);
 					}
 
 					if (b->get_button_index() == BUTTON_LEFT) {
@@ -2829,7 +2829,7 @@ void Tree::_notification(int p_what) {
 
 		drop_mode_flags = 0;
 		scrolling = false;
-		set_physics_process(false);
+		set_physics_process_internal(false);
 		update();
 	}
 	if (p_what == NOTIFICATION_DRAG_BEGIN) {
@@ -2837,10 +2837,10 @@ void Tree::_notification(int p_what) {
 		single_select_defer = NULL;
 		if (cache.scroll_speed > 0 && get_rect().has_point(get_viewport()->get_mouse_position() - get_global_position())) {
 			scrolling = true;
-			set_physics_process(true);
+			set_physics_process_internal(true);
 		}
 	}
-	if (p_what == NOTIFICATION_PHYSICS_PROCESS) {
+	if (p_what == NOTIFICATION_INTERNAL_PHYSICS_PROCESS) {
 
 		if (drag_touching) {
 
@@ -2853,7 +2853,7 @@ void Tree::_notification(int p_what) {
 				if (pos < 0) {
 					pos = 0;
 					turnoff = true;
-					set_physics_process(false);
+					set_physics_process_internal(false);
 					drag_touching = false;
 					drag_touching_deaccel = false;
 				}
@@ -2873,7 +2873,7 @@ void Tree::_notification(int p_what) {
 				drag_speed = sgn * val;
 
 				if (turnoff) {
-					set_physics_process(false);
+					set_physics_process_internal(false);
 					drag_touching = false;
 					drag_touching_deaccel = false;
 				}


### PR DESCRIPTION
Follow-up to #17537.

AFAIK all cases are now handled, the only objects that still use `NOTIFICATION_PROCESS` or `NOTIFICATION_FIXED_PROCESS` are editor plugins (and the base `Node` for obvious reasons).

```
$ rg NOTIFICATION_PROCESS -l | sort
doc/classes/Node.xml
editor/editor_audio_buses.cpp
editor/editor_file_dialog.cpp
editor/editor_file_system.cpp
editor/editor_help.cpp
editor/editor_node.cpp
editor/editor_run_native.cpp
editor/export_template_manager.cpp
editor/filesystem_dock.cpp
editor/find_in_files.cpp
editor/plugins/animation_player_editor_plugin.cpp
editor/plugins/asset_library_editor_plugin.cpp
editor/plugins/camera_editor_plugin.cpp
editor/plugins/collision_polygon_editor_plugin.cpp
editor/plugins/spatial_editor_plugin.cpp
editor/plugins/theme_editor_plugin.cpp
editor/plugins/tile_map_editor_plugin.cpp
editor/script_editor_debugger.cpp
modules/gridmap/grid_map_editor_plugin.cpp
scene/main/node.cpp
scene/main/node.h
scene/main/scene_tree.cpp

$ rg NOTIFICATION_PHYSICS_PROCESS -l | sort
doc/classes/Node.xml
editor/plugins/abstract_polygon_2d_editor.cpp
editor/plugins/canvas_item_editor_plugin.cpp
editor/plugins/light_occluder_2d_editor_plugin.cpp
editor/plugins/material_editor_plugin.cpp
editor/plugins/mesh_editor_plugin.cpp
editor/plugins/path_2d_editor_plugin.cpp
editor/plugins/polygon_2d_editor_plugin.cpp
editor/plugins/resource_preloader_editor_plugin.cpp
editor/plugins/sprite_frames_editor_plugin.cpp
editor/plugins/texture_editor_plugin.cpp
editor/property_editor.cpp
scene/main/node.cpp
scene/main/node.h
scene/main/scene_tree.cpp

$ rg [^_]set_process\\\( -l | sort
editor/editor_audio_buses.cpp
editor/editor_file_dialog.cpp
editor/editor_file_system.cpp
editor/editor_help.cpp
editor/editor_node.cpp
editor/editor_run_native.cpp
editor/export_template_manager.cpp
editor/filesystem_dock.cpp
editor/find_in_files.cpp
editor/plugins/animation_player_editor_plugin.cpp
editor/plugins/asset_library_editor_plugin.cpp
editor/plugins/collision_polygon_editor_plugin.cpp
editor/plugins/material_editor_plugin.cpp
editor/plugins/mesh_editor_plugin.cpp
editor/plugins/resource_preloader_editor_plugin.cpp
editor/plugins/script_editor_plugin.cpp
editor/plugins/spatial_editor_plugin.cpp
editor/plugins/sprite_frames_editor_plugin.cpp
editor/plugins/texture_editor_plugin.cpp
editor/plugins/theme_editor_plugin.cpp
editor/plugins/tile_map_editor_plugin.cpp
editor/script_editor_debugger.cpp
modules/gridmap/grid_map_editor_plugin.cpp
modules/visual_script/visual_script.cpp
scene/2d/visibility_notifier_2d.cpp   ///< used to enabling processing of parent node, part of its functionality
scene/main/node.cpp
scene/main/node.h

$ rg set_physics_process\\\( -l | sort
editor/plugins/animation_tree_editor_plugin.cpp
editor/plugins/canvas_item_editor_plugin.cpp
editor/plugins/resource_preloader_editor_plugin.cpp
editor/plugins/sprite_frames_editor_plugin.cpp
editor/property_editor.cpp
modules/visual_script/visual_script.cpp
scene/2d/visibility_notifier_2d.cpp   ///< used to enabling processing of parent node, part of its functionality
scene/main/node.cpp
scene/main/node.h
```