### PR TITLE
Fix NativeScript property list order

### DIFF
--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -357,14 +357,13 @@ void NativeScript::get_script_property_list(List<PropertyInfo> *p_list) const {
 	NativeScriptDesc *script_data = get_script_desc();
 
 	Set<StringName> existing_properties;
+	List<PropertyInfo>::Element *original_back = p_list->back();
 	while (script_data) {
-		List<PropertyInfo>::Element *insert_position = p_list->front();
-		bool insert_before = true;
+		List<PropertyInfo>::Element *insert_position = original_back;
 
 		for (OrderedHashMap<StringName, NativeScriptDesc::Property>::Element E = script_data->properties.front(); E; E = E.next()) {
 			if (!existing_properties.has(E.key())) {
-				insert_position = insert_before ? p_list->insert_before(insert_position, E.get().info) : p_list->insert_after(insert_position, E.get().info);
-				insert_before = false;
+				insert_position = p_list->insert_after(insert_position, E.get().info);
 				existing_properties.insert(E.key());
 			}
 		}


### PR DESCRIPTION
`NativeScript::get_script_property_list` previously inserted PropertyInfos at the front of the (already partially filled) list passed to it.

It should append them to the back instead, like GDScript does. Placing them in front of `script` causes them to never be loaded when instancing scenes, because the NativeScript is not yet attached when they're set.

Fixes #17672 and #18088.

CC @karroffel 