### PR TITLE
RichTextLabel, doc: Added new method to get total content height

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -75,6 +75,13 @@
 				Returns the number of visible lines.
 			</description>
 		</method>
+		<method name="get_content_height">
+			<return type="int">
+			</return>
+			<description>
+				Returns the height of the content.
+			</description>
+		</method>
 		<method name="newline">
 			<return type="void">
 			</return>

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -676,9 +676,7 @@ void RichTextLabel::_scroll_changed(double) {
 
 void RichTextLabel::_update_scroll() {
 
-	int total_height = 0;
-	if (main->lines.size())
-		total_height = main->lines[main->lines.size() - 1].height_accum_cache + get_stylebox("normal")->get_minimum_size().height;
+	int total_height = get_content_height();
 
 	bool exceeds = total_height > get_size().height && scroll_active;
 
@@ -2030,6 +2028,13 @@ float RichTextLabel::get_percent_visible() const {
 	return percent_visible;
 }
 
+int RichTextLabel::get_content_height() {
+	int total_height = 0;
+	if (main->lines.size())
+		total_height = main->lines[main->lines.size() - 1].height_accum_cache + get_stylebox("normal")->get_minimum_size().height;
+	return total_height;
+}
+
 void RichTextLabel::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_gui_input"), &RichTextLabel::_gui_input);
@@ -2095,6 +2100,8 @@ void RichTextLabel::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_line_count"), &RichTextLabel::get_line_count);
 	ClassDB::bind_method(D_METHOD("get_visible_line_count"), &RichTextLabel::get_visible_line_count);
+
+	ClassDB::bind_method(D_METHOD("get_content_height"), &RichTextLabel::get_content_height);
 
 	ADD_GROUP("BBCode", "bbcode_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "bbcode_enabled"), "set_use_bbcode", "is_using_bbcode");

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -340,6 +340,8 @@ public:
 	int get_line_count() const;
 	int get_visible_line_count() const;
 
+	int get_content_height();
+
 	VScrollBar *get_v_scroll() { return vscroll; }
 
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const;


### PR DESCRIPTION
Added a get_content_height() method to be able to know the total height of the contents. This will allow anyone to resize the RichTextLabel vertically to avoid need of scrolling.

Use case: Adding several rich text labels dinamically to a VBoxContainer making sure you will not have any of that labels with an scrollbar and be able to resize them to its contents size.