### PR TITLE
Fix PulseAudio driver for audio devices that report unknown number of channels

### DIFF
--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -149,8 +149,9 @@ Error AudioDriverPulseAudio::init_device() {
 			break;
 
 		default:
-			ERR_PRINTS("PulseAudio: Unsupported number of channels: " + itos(pa_channels));
-			ERR_FAIL_V(ERR_CANT_OPEN);
+			WARN_PRINTS("PulseAudio: Unsupported number of channels: " + itos(pa_channels));
+			pa_channels = 2;
+			channels = 2;
 			break;
 	}
 


### PR DESCRIPTION
For example PulseAudio reports 12 channels for my Focusrite Scarlett 6i6 device, this PR forces to use stereo for this kind of audio devices.