### PR TITLE
Fix OrderedDict in json load

### DIFF
--- a/modules/gdnative/SCsub
+++ b/modules/gdnative/SCsub
@@ -181,7 +181,7 @@ def build_gdnative_api_struct(target, source, env):
     from collections import OrderedDict
 
     with open(source[0].path, 'r') as fd:
-        api = json.load(fd)
+        api = json.load(fd, object_pairs_hook=OrderedDict)
 
     header, source = target
     with open(header.path, 'w') as fd:


### PR DESCRIPTION
Not using ordered dict causes the extensions to be loaded in random order.
Windows will load in the reverse order of linux causing the ARVR extension to be first.

This was broken after moving to arrays for the API definition:
 [in this commit](https://github.com/godotengine/godot/commit/39584f33123eaf537d559b4f2340044b3fc90b87)