### PR TITLE
Resolves crash on shape2D culling for empty Concave shapes

### DIFF
--- a/servers/physics_2d/shape_2d_sw.cpp
+++ b/servers/physics_2d/shape_2d_sw.cpp
@@ -1011,6 +1011,10 @@ void ConcavePolygonShape2DSW::cull(const Rect2 &p_local_aabb, Callback p_callbac
 		stack[i]=0;
 	*/
 
+	if (segments.size() == 0 || points.size() == 0 || bvh.size() == 0) {
+		return;
+	}
+
 	int level = 0;
 
 	const Segment *segmentptr = &segments[0];

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -33,6 +33,7 @@
 #include "collision_solver_2d_sw.h"
 #include "pair.h"
 #include "physics_2d_server_sw.h"
+
 _FORCE_INLINE_ static bool _can_collide_with(CollisionObject2DSW *p_object, uint32_t p_collision_mask) {
 
 	return p_object->get_collision_layer() & p_collision_mask;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/17789