### PR TITLE
Implement font shadows for RichTextLabel

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -319,6 +319,14 @@
 		</theme_item>
 		<theme_item name="font_color_selected" type="Color">
 		</theme_item>
+		<theme_item name="font_color_shadow" type="Color">
+		</theme_item>
+		<theme_item name="shadow_as_outline" type="int">
+		</theme_item>
+		<theme_item name="shadow_offset_x" type="int">
+		</theme_item>
+		<theme_item name="shadow_offset_y" type="int">
+		</theme_item>
 		<theme_item name="italics_font" type="Font">
 		</theme_item>
 		<theme_item name="line_separation" type="int">

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -891,6 +891,10 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	//RichTextLabel
 	theme->set_color("default_color", "RichTextLabel", font_color);
+	theme->set_color("font_color_shadow", "RichTextLabel", Color(0, 0, 0, 0));
+	theme->set_constant("shadow_offset_x", "RichTextLabel", 1 * EDSCALE);
+	theme->set_constant("shadow_offset_y", "RichTextLabel", 1 * EDSCALE);
+	theme->set_constant("shadow_as_outline", "RichTextLabel", 0 * EDSCALE);
 	theme->set_stylebox("focus", "RichTextLabel", make_empty_stylebox());
 	theme->set_stylebox("normal", "RichTextLabel", style_tree_bg);
 

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -270,7 +270,7 @@ private:
 	int visible_characters;
 	float percent_visible;
 
-	int _process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &y, int p_width, int p_line, ProcessMode p_mode, const Ref<Font> &p_base_font, const Color &p_base_color, const Point2i &p_click_pos = Point2i(), Item **r_click_item = NULL, int *r_click_char = NULL, bool *r_outside = NULL, int p_char_count = 0);
+	int _process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &y, int p_width, int p_line, ProcessMode p_mode, const Ref<Font> &p_base_font, const Color &p_base_color, const Color &p_font_color_shadow, bool p_shadow_as_outline, const Point2 &shadow_ofs, const Point2i &p_click_pos = Point2i(), Item **r_click_item = NULL, int *r_click_char = NULL, bool *r_outside = NULL, int p_char_count = 0);
 	void _find_click(ItemFrame *p_frame, const Point2i &p_click, Item **r_click_item = NULL, int *r_click_char = NULL, bool *r_outside = NULL);
 
 	Ref<Font> _find_font(Item *p_item);

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -818,6 +818,12 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_color_selected", "RichTextLabel", font_color_selection);
 	theme->set_color("selection_color", "RichTextLabel", Color(0.1, 0.1, 1, 0.8));
 
+	theme->set_color("font_color_shadow", "RichTextLabel", Color(0, 0, 0, 0));
+
+	theme->set_constant("shadow_offset_x", "RichTextLabel", 1 * scale);
+	theme->set_constant("shadow_offset_y", "RichTextLabel", 1 * scale);
+	theme->set_constant("shadow_as_outline", "RichTextLabel", 0 * scale);
+
 	theme->set_constant("line_separation", "RichTextLabel", 1 * scale);
 	theme->set_constant("table_hseparation", "RichTextLabel", 3 * scale);
 	theme->set_constant("table_vseparation", "RichTextLabel", 3 * scale);


### PR DESCRIPTION
`Label` implements shadowing of the fonts, which is useful for 2D games, eg. point 'n click adventure games.

`RichTextLabel`s are more useful, though, for supporting bold and italic through fonts, but used to be less readable.

This implements shadows for `RichTextLabel`s. I've tested it as extensively as my imagination allows now, and haven't got it to break.

One major change is how selection is handled, because the drawing order matters for preserving the rectangle and the shadow, but I find the code more readable in its current form.

What do you think?

Thanks!