### PR TITLE
Add DNS resolution in NetworkedMultiplayerEnet::create_client()

### DIFF
--- a/modules/enet/networked_multiplayer_enet.h
+++ b/modules/enet/networked_multiplayer_enet.h
@@ -119,7 +119,7 @@ public:
 	virtual int get_peer_port(int p_peer_id) const;
 
 	Error create_server(int p_port, int p_max_clients = 32, int p_in_bandwidth = 0, int p_out_bandwidth = 0);
-	Error create_client(const IP_Address &p_ip, int p_port, int p_in_bandwidth = 0, int p_out_bandwidth = 0);
+	Error create_client(const String &p_address, int p_port, int p_in_bandwidth = 0, int p_out_bandwidth = 0);
 
 	void close_connection();
 


### PR DESCRIPTION
Closes #12512.

Tested & works locally. Now you can actually use domains for your server with enet! (Or "localhost" instead of "127.0.0.1", I guess)