### PR TITLE
Fix binding of ViewportTexture to Sky

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2362,7 +2362,11 @@ void RasterizerSceneGLES3::_draw_sky(RasterizerStorageGLES3::Sky *p_sky, const C
 
 	ERR_FAIL_COND(!tex);
 	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(tex->target, tex->tex_id);
+
+	if (tex->proxy && tex->proxy->tex_id)
+		glBindTexture(tex->target, tex->proxy->tex_id);
+	else
+		glBindTexture(tex->target, tex->tex_id);
 
 	if (storage->config.srgb_decode_supported && tex->srgb && !tex->using_srgb) {
 


### PR DESCRIPTION
In order to the get the actual rendered image from a ViewportTexture the sky needs to access the proxy texture.

For ViewportTextures to work with Environments _timing is very important_. The ViewportTexture only functions if it has access to the specified Viewport. Depending on how you build your scene it may happen that the ViewportTexture is referenced before the actual Viewport is available. This results in error message spam and a black texture being displayed.

Fixes #17510 

The example given in #17510 had to be modified in order to work since the Environment was being build before the Viewport is available.

Working example (with this pull request):
[viewportskybug.zip](https://github.com/godotengine/godot/files/1904954/viewportskybug.zip)

**Note:** I'm not sure how one would go and build a fix that would work no matter what the order of node creation is. The ViewportTexture somehow needs to be notified of a scene being "ready" / the Viewport becoming available and then again notifying everything else that depends on the ViewportTexture, so they can get the correct width / height etc. from the ViewportTexture.

Might look into this. For now, this pull requests at least allows ViewportTexture usage as long as you make sure the build order is ok.