### PR TITLE
Add popup_closed signal for ColorPickerButton

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -660,6 +660,11 @@ void ColorPickerButton::_color_changed(const Color &p_color) {
 	emit_signal("color_changed", p_color);
 }
 
+void ColorPickerButton::_modal_closed() {
+
+	emit_signal("popup_closed");
+}
+
 void ColorPickerButton::pressed() {
 
 	popup->set_position(get_global_position() - picker->get_combined_minimum_size());
@@ -722,8 +727,10 @@ void ColorPickerButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_edit_alpha", "show"), &ColorPickerButton::set_edit_alpha);
 	ClassDB::bind_method(D_METHOD("is_editing_alpha"), &ColorPickerButton::is_editing_alpha);
 	ClassDB::bind_method(D_METHOD("_color_changed"), &ColorPickerButton::_color_changed);
+	ClassDB::bind_method(D_METHOD("_modal_closed"), &ColorPickerButton::_modal_closed);
 
 	ADD_SIGNAL(MethodInfo("color_changed", PropertyInfo(Variant::COLOR, "color")));
+	ADD_SIGNAL(MethodInfo("popup_closed"));
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "set_pick_color", "get_pick_color");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "edit_alpha"), "set_edit_alpha", "is_editing_alpha");
 }
@@ -735,5 +742,7 @@ ColorPickerButton::ColorPickerButton() {
 	popup->add_child(picker);
 
 	picker->connect("color_changed", this, "_color_changed");
+	popup->connect("modal_closed", this, "_modal_closed");
+
 	add_child(popup);
 }

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -120,6 +120,8 @@ class ColorPickerButton : public Button {
 	ColorPicker *picker;
 
 	void _color_changed(const Color &p_color);
+	void _modal_closed();
+
 	virtual void pressed();
 
 protected:


### PR DESCRIPTION
These changes correct the desired behavior as I understand the problem. They add a new signal
within ColorPickerButton that fires when the modal closes. The new signal is reflected in the Editor UI.

![screen shot 2018-04-12 at 5 20 09 pm](https://user-images.githubusercontent.com/18668880/38707171-d2ab5c6e-3e75-11e8-8e84-6cd589d66b19.png)

I haven't been working with this project for long, so there may be a better solution. Mine piggybacks
on the `modal_closed` signal to emit the new `popup_closed` signal. 

Feel free to let me know if I'm off-base or causing unintended side effects.

Thanks for your help!

**Bugsquad edit: Closes #17688**