### PR TITLE
Prevent visibility notification from being called twice in object creation

### DIFF
--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -263,7 +263,8 @@ bool CanvasItem::is_visible_in_tree() const {
 
 void CanvasItem::_propagate_visibility_changed(bool p_visible) {
 
-	notification(NOTIFICATION_VISIBILITY_CHANGED);
+	if (!first_draw)
+		notification(NOTIFICATION_VISIBILITY_CHANGED);
 
 	if (p_visible)
 		update(); //todo optimize


### PR DESCRIPTION
this notification already called in https://github.com/godotengine/godot/blob/3a5b25d5b489ad88c2861c9c37b56469580fbf03/scene/2d/canvas_item.cpp#L330-L332
Closes #18160