### PR TITLE
Add string trim_prefix, trim_suffix, lstrip and rstrip methods

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -2997,6 +2997,40 @@ String String::strip_escapes() const {
 	return substr(beg, end - beg);
 }
 
+String String::lstrip(const Vector<CharType> &p_chars) const {
+
+	int len = length();
+	int beg;
+
+	for (beg = 0; beg < len; beg++) {
+
+		if (p_chars.find(operator[](beg)) == -1)
+			break;
+	}
+
+	if (beg == 0)
+		return *this;
+
+	return substr(beg, len - beg);
+}
+
+String String::rstrip(const Vector<CharType> &p_chars) const {
+
+	int len = length();
+	int end;
+
+	for (end = len - 1; end >= 0; end--) {
+
+		if (p_chars.find(operator[](end)) == -1)
+			break;
+	}
+
+	if (end == len - 1)
+		return *this;
+
+	return substr(0, end + 1);
+}
+
 String String::simplify_path() const {
 
 	String s = *this;
@@ -3445,6 +3479,24 @@ String String::pad_zeros(int p_digits) const {
 		end++;
 	}
 
+	return s;
+}
+
+String String::trim_prefix(const String &p_prefix) const {
+
+	String s = *this;
+	if (s.begins_with(p_prefix)) {
+		return s.substr(p_prefix.length(), s.length() - p_prefix.length());
+	}
+	return s;
+}
+
+String String::trim_suffix(const String &p_suffix) const {
+
+	String s = *this;
+	if (s.ends_with(p_suffix)) {
+		return s.substr(0, s.length() - p_suffix.length());
+	}
 	return s;
 }
 

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -137,6 +137,8 @@ public:
 	String insert(int p_at_pos, const String &p_string) const;
 	String pad_decimals(int p_digits) const;
 	String pad_zeros(int p_digits) const;
+	String trim_prefix(const String &p_prefix) const;
+	String trim_suffix(const String &p_suffix) const;
 	String lpad(int min_length, const String &character = " ") const;
 	String rpad(int min_length, const String &character = " ") const;
 	String sprintf(const Array &values, bool *error) const;
@@ -188,6 +190,8 @@ public:
 	String dedent() const;
 	String strip_edges(bool left = true, bool right = true) const;
 	String strip_escapes() const;
+	String lstrip(const Vector<CharType> &p_chars) const;
+	String rstrip(const Vector<CharType> &p_chars) const;
 	String get_extension() const;
 	String get_basename() const;
 	String plus_file(const String &p_file) const;

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -264,6 +264,8 @@ struct _VariantCall {
 	VCALL_LOCALMEM1R(String, right);
 	VCALL_LOCALMEM0R(String, dedent);
 	VCALL_LOCALMEM2R(String, strip_edges);
+	VCALL_LOCALMEM1R(String, lstrip);
+	VCALL_LOCALMEM1R(String, rstrip);
 	VCALL_LOCALMEM0R(String, get_extension);
 	VCALL_LOCALMEM0R(String, get_basename);
 	VCALL_LOCALMEM1R(String, plus_file);
@@ -296,6 +298,8 @@ struct _VariantCall {
 	VCALL_LOCALMEM0R(String, hex_to_int);
 	VCALL_LOCALMEM1R(String, pad_decimals);
 	VCALL_LOCALMEM1R(String, pad_zeros);
+	VCALL_LOCALMEM1R(String, trim_prefix);
+	VCALL_LOCALMEM1R(String, trim_suffix);
 
 	static void _call_String_to_ascii(Variant &r_ret, Variant &p_self, const Variant **p_args) {
 
@@ -1460,6 +1464,8 @@ void register_variant_methods() {
 	ADDFUNC1R(STRING, STRING, String, left, INT, "position", varray());
 	ADDFUNC1R(STRING, STRING, String, right, INT, "position", varray());
 	ADDFUNC2R(STRING, STRING, String, strip_edges, BOOL, "left", BOOL, "right", varray(true, true));
+	ADDFUNC1R(STRING, STRING, String, lstrip, STRING, "chars", varray());
+	ADDFUNC1R(STRING, STRING, String, rstrip, STRING, "chars", varray());
 	ADDFUNC0R(STRING, STRING, String, get_extension, varray());
 	ADDFUNC0R(STRING, STRING, String, get_basename, varray());
 	ADDFUNC1R(STRING, STRING, String, plus_file, STRING, "file", varray());
@@ -1493,6 +1499,8 @@ void register_variant_methods() {
 	ADDFUNC0R(STRING, INT, String, hex_to_int, varray());
 	ADDFUNC1R(STRING, STRING, String, pad_decimals, INT, "digits", varray());
 	ADDFUNC1R(STRING, STRING, String, pad_zeros, INT, "digits", varray());
+	ADDFUNC1R(STRING, STRING, String, trim_prefix, STRING, "prefix", varray());
+	ADDFUNC1R(STRING, STRING, String, trim_suffix, STRING, "suffix", varray());
 
 	ADDFUNC0R(STRING, POOL_BYTE_ARRAY, String, to_ascii, varray());
 	ADDFUNC0R(STRING, POOL_BYTE_ARRAY, String, to_utf8, varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -490,6 +490,15 @@
 				Returns the string's amount of characters.
 			</description>
 		</method>
+		<method name="lstrip">
+			<return type="String">
+			</return>
+			<argument index="0" name="chars" type="String">
+			</argument>
+			<description>
+				Returns a copy of the string with characters removed from the left.
+			</description>
+		</method>
 		<method name="match">
 			<return type="bool">
 			</return>
@@ -634,6 +643,15 @@
 				Returns the right side of the string from a given position.
 			</description>
 		</method>
+		<method name="rstrip">
+			<return type="String">
+			</return>
+			<argument index="0" name="chars" type="String">
+			</argument>
+			<description>
+				Returns a copy of the string with characters removed from the right.
+			</description>
+		</method>
 		<method name="sha256_buffer">
 			<return type="PoolByteArray">
 			</return>
@@ -743,6 +761,24 @@
 			</return>
 			<description>
 				Converts the String (which is an array of characters) to [PoolByteArray] (which is an array of bytes). The conversion is a bit slower than to_ascii(), but supports all UTF-8 characters. Therefore, you should prefer this function over to_ascii().
+			</description>
+		</method>
+		<method name="trim_prefix">
+			<return type="String">
+			</return>
+			<argument index="0" name="prefix" type="String">
+			</argument>
+			<description>
+				Removes a given string from the start if it starts with it or leaves the string unchanged.
+			</description>
+		</method>
+		<method name="trim_suffix">
+			<return type="String">
+			</return>
+			<argument index="0" name="suffix" type="String">
+			</argument>
+			<description>
+				Removes a given string from the end if it ends with it or leaves the string unchanged.
 			</description>
 		</method>
 		<method name="xml_escape">


### PR DESCRIPTION
~~`trim_start`/`trim_end`~~ `trim_prefix`/`trim_suffix` - removes a given string from the start/end if it starts/ends with it or leaves the string unchanged

Also adds `lstrip` and `rstrip` that remove any of the chars from the left/right of the string.