### PR TITLE
Rename collision_friction to friction in TileMap

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -245,7 +245,7 @@
 		<member name="collision_bounce" type="float" setter="set_collision_bounce" getter="get_collision_bounce">
 			Bounce value for static body collisions (see [code]collision_use_kinematic[/code]). Default value: 0.
 		</member>
-		<member name="collision_friction" type="float" setter="set_collision_friction" getter="get_collision_friction">
+		<member name="friction" type="float" setter="set_friction" getter="get_friction">
 			Friction value for static body collisions (see [code]collision_use_kinematic[/code]). Default value: 1.
 		</member>
 		<member name="collision_layer" type="int" setter="set_collision_layer" getter="get_collision_layer">

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1171,7 +1171,7 @@ void TileMap::set_collision_use_kinematic(bool p_use_kinematic) {
 	_recreate_quadrants();
 }
 
-void TileMap::set_collision_friction(float p_friction) {
+void TileMap::set_friction(float p_friction) {
 
 	friction = p_friction;
 	for (Map<PosKey, Quadrant>::Element *E = quadrant_map.front(); E; E = E->next()) {
@@ -1181,9 +1181,19 @@ void TileMap::set_collision_friction(float p_friction) {
 	}
 }
 
-float TileMap::get_collision_friction() const {
+float TileMap::get_friction() const {
 
 	return friction;
+}
+
+void TileMap::set_collision_friction(float p_friction) {
+
+	set_friction(p_friction);
+}
+
+float TileMap::get_collision_friction() const {
+
+	return get_friction();
 }
 
 void TileMap::set_collision_bounce(float p_bounce) {
@@ -1567,8 +1577,11 @@ void TileMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_collision_mask_bit", "bit", "value"), &TileMap::set_collision_mask_bit);
 	ClassDB::bind_method(D_METHOD("get_collision_mask_bit", "bit"), &TileMap::get_collision_mask_bit);
 
-	ClassDB::bind_method(D_METHOD("set_collision_friction", "value"), &TileMap::set_collision_friction);
-	ClassDB::bind_method(D_METHOD("get_collision_friction"), &TileMap::get_collision_friction);
+	ClassDB::bind_method(D_METHOD("set_collision_friction", "value"), &TileMap::set_friction);
+	ClassDB::bind_method(D_METHOD("get_collision_friction"), &TileMap::get_friction);
+
+	ClassDB::bind_method(D_METHOD("set_friction", "value"), &TileMap::set_friction);
+	ClassDB::bind_method(D_METHOD("get_friction"), &TileMap::get_friction);
 
 	ClassDB::bind_method(D_METHOD("set_collision_bounce", "value"), &TileMap::set_collision_bounce);
 	ClassDB::bind_method(D_METHOD("get_collision_bounce"), &TileMap::get_collision_bounce);
@@ -1618,6 +1631,7 @@ void TileMap::_bind_methods() {
 
 	ADD_GROUP("Collision", "collision_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collision_use_kinematic", PROPERTY_HINT_NONE, ""), "set_collision_use_kinematic", "get_collision_use_kinematic");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "friction", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_friction", "get_friction");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "collision_friction", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_collision_friction", "get_collision_friction");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "collision_bounce", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_collision_bounce", "get_collision_bounce");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_layer", PROPERTY_HINT_LAYERS_2D_PHYSICS), "set_collision_layer", "get_collision_layer");

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -267,6 +267,9 @@ public:
 	void set_collision_use_kinematic(bool p_use_kinematic);
 	bool get_collision_use_kinematic() const;
 
+	void set_friction(float p_friction);
+	float get_friction() const;
+
 	void set_collision_friction(float p_friction);
 	float get_collision_friction() const;
 


### PR DESCRIPTION
Renames the collision_friction property to friction in the TileMap class
to conform with the naming in other classes.
The documentation is updated accordingly.
Fixes #18190