### PR TITLE
Avoid converting Quat to Euler angles when not necessary.

### DIFF
--- a/core/math/matrix3.h
+++ b/core/math/matrix3.h
@@ -81,8 +81,12 @@ public:
 	void rotate(const Vector3 &p_euler);
 	Basis rotated(const Vector3 &p_euler) const;
 
+	void rotate(const Quat &p_quat);
+	Basis rotated(const Quat &p_quat) const;
+
 	Vector3 get_rotation() const;
 	void get_rotation_axis_angle(Vector3 &p_axis, real_t &p_angle) const;
+	void get_rotation_axis_angle_local(Vector3 &p_axis, real_t &p_angle) const;
 
 	Vector3 rotref_posscale_decomposition(Basis &rotref) const;
 
@@ -108,7 +112,12 @@ public:
 
 	void set_scale(const Vector3 &p_scale);
 	Vector3 get_scale() const;
-	Vector3 get_signed_scale() const;
+	Vector3 get_scale_abs() const;
+	Vector3 get_scale_local() const;
+
+	void set_axis_angle_scale(const Vector3 &p_axis, real_t p_phi, const Vector3 &p_scale);
+	void set_euler_scale(const Vector3 &p_euler, const Vector3 &p_scale);
+	void set_quat_scale(const Quat &p_quat, const Vector3 &p_scale);
 
 	// transposed dot products
 	_FORCE_INLINE_ real_t tdotx(const Vector3 &v) const {
@@ -139,6 +148,8 @@ public:
 
 	int get_orthogonal_index() const;
 	void set_orthogonal_index(int p_index);
+
+	void set_diagonal(const Vector3 p_diag);
 
 	bool is_orthogonal() const;
 	bool is_diagonal() const;
@@ -219,6 +230,8 @@ public:
 	Basis(const Quat &p_quat) { set_quat(p_quat); };
 	Basis(const Vector3 &p_euler) { set_euler(p_euler); }
 	Basis(const Vector3 &p_axis, real_t p_phi) { set_axis_angle(p_axis, p_phi); }
+	Basis(const Vector3 &p_axis, real_t p_phi, const Vector3 &p_scale) { set_axis_angle_scale(p_axis, p_phi, p_scale); }
+	Basis(const Quat &p_quat, const Vector3 &p_scale) { set_quat_scale(p_quat, p_scale); }
 
 	_FORCE_INLINE_ Basis(const Vector3 &row0, const Vector3 &row1, const Vector3 &row2) {
 		elements[0] = row0;

--- a/core/math/transform.cpp
+++ b/core/math/transform.cpp
@@ -119,11 +119,11 @@ Transform Transform::interpolate_with(const Transform &p_transform, real_t p_c) 
 
 	/* not sure if very "efficient" but good enough? */
 
-	Vector3 src_scale = basis.get_signed_scale();
+	Vector3 src_scale = basis.get_scale();
 	Quat src_rot = basis.orthonormalized();
 	Vector3 src_loc = origin;
 
-	Vector3 dst_scale = p_transform.basis.get_signed_scale();
+	Vector3 dst_scale = p_transform.basis.get_scale();
 	Quat dst_rot = p_transform.basis;
 	Vector3 dst_loc = p_transform.origin;
 

--- a/modules/bullet/collision_object_bullet.cpp
+++ b/modules/bullet/collision_object_bullet.cpp
@@ -49,7 +49,7 @@
 CollisionObjectBullet::ShapeWrapper::~ShapeWrapper() {}
 
 void CollisionObjectBullet::ShapeWrapper::set_transform(const Transform &p_transform) {
-	G_TO_B(p_transform.get_basis().get_scale(), scale);
+	G_TO_B(p_transform.get_basis().get_scale_abs(), scale);
 	G_TO_B(p_transform, transform);
 	UNSCALE_BT_BASIS(transform);
 }
@@ -158,7 +158,7 @@ int CollisionObjectBullet::get_godot_object_flags() const {
 
 void CollisionObjectBullet::set_transform(const Transform &p_global_transform) {
 
-	set_body_scale(p_global_transform.basis.get_scale());
+	set_body_scale(p_global_transform.basis.get_scale_abs());
 
 	btTransform bt_transform;
 	G_TO_B(p_global_transform, bt_transform);

--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -122,7 +122,7 @@ int BulletPhysicsDirectSpaceState::intersect_shape(const RID &p_shape, const Tra
 
 	ShapeBullet *shape = space->get_physics_server()->get_shape_owner()->get(p_shape);
 
-	btCollisionShape *btShape = shape->create_bt_shape(p_xform.basis.get_scale(), p_margin);
+	btCollisionShape *btShape = shape->create_bt_shape(p_xform.basis.get_scale_abs(), p_margin);
 	if (!btShape->isConvex()) {
 		bulletdelete(btShape);
 		ERR_PRINTS("The shape is not a convex shape, then is not supported: shape type: " + itos(shape->get_type()));
@@ -202,7 +202,7 @@ bool BulletPhysicsDirectSpaceState::collide_shape(RID p_shape, const Transform &
 
 	ShapeBullet *shape = space->get_physics_server()->get_shape_owner()->get(p_shape);
 
-	btCollisionShape *btShape = shape->create_bt_shape(p_shape_xform.basis.get_scale(), p_margin);
+	btCollisionShape *btShape = shape->create_bt_shape(p_shape_xform.basis.get_scale_abs(), p_margin);
 	if (!btShape->isConvex()) {
 		bulletdelete(btShape);
 		ERR_PRINTS("The shape is not a convex shape, then is not supported: shape type: " + itos(shape->get_type()));
@@ -234,7 +234,7 @@ bool BulletPhysicsDirectSpaceState::rest_info(RID p_shape, const Transform &p_sh
 
 	ShapeBullet *shape = space->get_physics_server()->get_shape_owner()->get(p_shape);
 
-	btCollisionShape *btShape = shape->create_bt_shape(p_shape_xform.basis.get_scale(), p_margin);
+	btCollisionShape *btShape = shape->create_bt_shape(p_shape_xform.basis.get_scale_abs(), p_margin);
 	if (!btShape->isConvex()) {
 		bulletdelete(btShape);
 		ERR_PRINTS("The shape is not a convex shape, then is not supported: shape type: " + itos(shape->get_type()));

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -85,9 +85,7 @@ void Spatial::_notify_dirty() {
 }
 
 void Spatial::_update_local_transform() const {
-	data.local_transform.basis = Basis();
-	data.local_transform.basis.scale(data.scale);
-	data.local_transform.basis.rotate(data.rotation);
+	data.local_transform.basis.set_euler_scale(data.rotation, data.scale);
 
 	data.dirty &= ~DIRTY_LOCAL;
 }

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -590,9 +590,7 @@ void AnimationPlayer::_animation_update_transforms() {
 
 			Transform t;
 			t.origin = nc->loc_accum;
-			t.basis.scale(nc->scale_accum);
-			t.basis.rotate(nc->rot_accum.get_euler());
-
+			t.basis.set_quat_scale(nc->rot_accum, nc->scale_accum);
 			if (nc->skeleton && nc->bone_idx >= 0) {
 
 				nc->skeleton->set_bone_pose(nc->bone_idx, t);

--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -900,8 +900,7 @@ void AnimationTreePlayer::_process_animation(float p_delta) {
 		t.scale.x += 1.0;
 		t.scale.y += 1.0;
 		t.scale.z += 1.0;
-		xform.basis.scale(t.scale);
-		xform.basis.rotate(t.rot.get_euler());
+		xform.basis.set_quat_scale(t.rot, t.scale);
 
 		if (t.bone_idx >= 0) {
 			if (t.skeleton)


### PR DESCRIPTION
Also ensure that get_scale doesn't arbitrarlity change the signs of scales, ensuring that the combination of get_rotation and get_scale gives the correct basis.

Added various missing functions and constructors.

Should close #17968.