### PR TITLE
Fix/Remove potentially confusing references to Euler

### DIFF
--- a/doc/classes/@GDScript.xml
+++ b/doc/classes/@GDScript.xml
@@ -326,7 +326,8 @@
 			<argument index="0" name="s" type="float">
 			</argument>
 			<description>
-				Raises the Euler's constant [b]e[/b] to the power of [code]s[/code] and returns it. [b]e[/b] has an approximate value of 2.71828.
+				The natural exponential function. It raises the mathematical constant [b]e[/b] to the power of [code]s[/code] and returns it.
+				[b]e[/b] has an approximate value of 2.71828.
 				[codeblock]
 				a = exp(2) # approximately 7.39
 				[/codeblock]

--- a/modules/visual_script/doc_classes/VisualScriptBuiltinFunc.xml
+++ b/modules/visual_script/doc_classes/VisualScriptBuiltinFunc.xml
@@ -80,7 +80,7 @@
 			Return the natural logarithm of the input. Note that this is not the typical base-10 logarithm function calculators use.
 		</constant>
 		<constant name="MATH_EXP" value="20" enum="BuiltinFunc">
-			Return [b]e[/b] raised to the power of the input. [b]e[/b] sometimes called "Euler's number" is a mathematical constant whose value is approximately 2.71828.
+			Return the mathematical constant [b]e[/b] raised to the specified power of the input. [b]e[/b] has an approximate value of 2.71828.
 		</constant>
 		<constant name="MATH_ISNAN" value="21" enum="BuiltinFunc">
 			Return whether the input is NaN (Not a Number) or not. NaN is usually produced by dividing 0 by 0, though other ways exist.

--- a/modules/visual_script/doc_classes/VisualScriptMathConstant.xml
+++ b/modules/visual_script/doc_classes/VisualScriptMathConstant.xml
@@ -4,7 +4,7 @@
 		Commonly used mathematical constants.
 	</brief_description>
 	<description>
-		Provides common math constants, such as Pi or Euler's constant, on an output Data port.
+		Provides common math constants, such as Pi, on an output Data port.
 		[b]Input Ports:[/b]
 		none
 		[b]Output Ports:[/b]
@@ -35,7 +35,7 @@
 			Tau: [code]6.283185[/code]
 		</constant>
 		<constant name="MATH_CONSTANT_E" value="4" enum="MathConstant">
-			Natural log: [code]2.718282[/code]
+			Mathematical constant [code]e[/code], the natural log base: [code]2.718282[/code]
 		</constant>
 		<constant name="MATH_CONSTANT_SQRT2" value="5" enum="MathConstant">
 			Square root of two: [code]1.414214[/code]


### PR DESCRIPTION
e is referred to as Euler’s number, so technically the MATH_EXP description in VisualScript doc was not incorrect, though could potentially lead to confusion.

e is different from Euler’s constant however, making the existing GDScript exp description invalid.

Fixed #18179