### PR TITLE
Fixed high cpu usage with PulseAudio

### DIFF
--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -177,7 +177,11 @@ Error AudioDriverPulseAudio::init_device() {
 
 	pa_buffer_attr attr;
 	// set to appropriate buffer length (in bytes) from global settings
-	attr.tlength = pa_buffer_size * sizeof(int16_t);
+	// Note: PulseAudio defaults to 4 fragments, which means that the actual
+	// latency is tlength / fragments. It seems that the PulseAudio has no way
+	// to get the fragments number so we're hardcoding this to the default of 4
+	const int fragments = 4;
+	attr.tlength = pa_buffer_size * sizeof(int16_t) * fragments;
 	// set them to be automatically chosen
 	attr.prebuf = (uint32_t)-1;
 	attr.maxlength = (uint32_t)-1;


### PR DESCRIPTION
Fixes #15266
I finally found why PulseAudio eats more cpu than it should with Godot, the buffer inside PulseAudio is divided into fragments (by default 4) which lowers the latency to the fragment size (tlength / fragments).

PulseAudio latency before this PR:
![screenshot from 2018-04-15 12-11-21](https://user-images.githubusercontent.com/10578225/38779962-271e6ee4-40a6-11e8-81f5-be1827a6386b.png)

PulseAudio latency after this PR:
![screenshot1](https://user-images.githubusercontent.com/10578225/38779961-271daf0e-40a6-11e8-8bea-06c8a96851b2.png)
