### PR TITLE
Remove RoundToInt from Mathf

### DIFF
--- a/modules/mono/glue/cs_files/Mathf.cs
+++ b/modules/mono/glue/cs_files/Mathf.cs
@@ -227,11 +227,6 @@ namespace Godot
             return (real_t)Math.Round(s);
         }
 
-        public static int RoundToInt(real_t s)
-        {
-            return (int)Math.Round(s);
-        }
-
         public static int Sign(int s)
         {
             return (s < 0) ? -1 : 1;


### PR DESCRIPTION
RoundToInt is currently declared in both Mathf.cs and MathfEx.cs, which causes errors when attempting to build a C# project's solution.  I assumed that removing it from Mathf was the right choice as the other functions in MathfEx follow the same format.