### PR TITLE
Bugfix/mutex error android

### DIFF
--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -265,6 +265,5 @@ void AudioDriverOpenSL::set_pause(bool p_pause) {
 
 AudioDriverOpenSL::AudioDriverOpenSL() {
 	s_ad = this;
-	mutex = Mutex::create();
 	pause = false;
 }


### PR DESCRIPTION
Fix: https://github.com/godotengine/godot/issues/18193

Mutex is created on line 115 during the thread creation. We should not create it in the constructor.