### PR TITLE
Introduce inline comments to GDScript

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -46,6 +46,7 @@ void GDScriptLanguage::get_comment_delimiters(List<String> *p_delimiters) const 
 
 	p_delimiters->push_back("#");
 	p_delimiters->push_back("\"\"\" \"\"\"");
+	p_delimiters->push_back("/* */");
 }
 void GDScriptLanguage::get_string_delimiters(List<String> *p_delimiters) const {
 

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -539,6 +539,36 @@ void GDScriptTokenizerText::_advance() {
 						INCPOS(1);
 
 					} break;
+					case '*': { // multiline comment
+
+						INCPOS(1);
+						bool is_in_comment = true;
+						while (is_in_comment) {
+							INCPOS(1);
+
+							switch (GETCHAR(0)) {
+								case 0: { // end of file
+									_make_error("Unterminated Comment");
+									_make_token(TK_EOF);
+									return;
+								} break;
+								case '\n': { // newline
+									INCPOS(1);
+									column = 1;
+									line++;
+								} break;
+								case '*': { // candidate for end of comment
+									if (GETCHAR(1) == '/') { // end of comment
+										INCPOS(1);
+										is_in_comment = false;
+									}
+								} break;
+							}
+						}
+						INCPOS(1)
+						continue; // get the token after this comment
+
+					} break;
 					default:
 						_make_token(TK_OP_DIV);
 				}


### PR DESCRIPTION
Introduces C-Style /* */ comments to GDScript like proposed in godotengine/godot#18228.

To the tokenizer the comments and its contents are invisible so for example they can be placed inside of function calls.

This pull request has been created to serve as a playground to get a feeling on how C-Style comments would look and work in GDScript. Feel free to reject and close the pull request, if the decision is made against C-Style comments or a different / better implementation is desired. :sweat_smile: 

Closes godotengine/godot#18228

**Example project:**
[MidComment.zip](https://github.com/godotengine/godot/files/1921088/MidComment.zip)

**Screenshot:**
![inline_comment](https://user-images.githubusercontent.com/1138805/38888900-48350272-427d-11e8-8d63-41302594e99b.png)
