### PR TITLE
Set default file name for exported projects

### DIFF
--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -986,6 +986,10 @@ ProjectExportDialog::ProjectExportDialog() {
 	editor_icons = "EditorIcons";
 
 	default_filename = EditorSettings::get_singleton()->get_project_metadata("export_options", "default_filename", String());
+
+	if (default_filename == "") {
+		default_filename = ProjectSettings::get_singleton()->get("application/config/name");
+	}
 }
 
 ProjectExportDialog::~ProjectExportDialog() {


### PR DESCRIPTION
Fixes #17976. 

It looks like the editor doesn't check for a valid file name before exporting a project. This pull request sets the project name as the default value for an exported file if a default name hasn't already been set. 

I imagine it would be better to test for an empty filename and alert the user. Do you think I should implement the alert in addition to this fix?

![apr-17-2018 16-28-08](https://user-images.githubusercontent.com/18668880/38899051-5aa88eae-425c-11e8-9c81-ef860214891a.gif)
