### PR TITLE
Fix some Coverity warnings in String API

### DIFF
--- a/core/string_db.cpp
+++ b/core/string_db.cpp
@@ -164,21 +164,14 @@ void StringName::operator=(const StringName &p_name) {
 		_data = p_name._data;
 	}
 }
-/* was inlined
-StringName::operator String() const {
 
-	if (_data)
-		return _data->get_name();
-
-	return "";
-}
-*/
 StringName::StringName(const StringName &p_name) {
 
-	ERR_FAIL_COND(!configured);
 	_data = NULL;
-	if (p_name._data && p_name._data->refcount.ref()) {
 
+	ERR_FAIL_COND(!configured);
+
+	if (p_name._data && p_name._data->refcount.ref()) {
 		_data = p_name._data;
 	}
 }

--- a/core/string_db.h
+++ b/core/string_db.h
@@ -67,6 +67,7 @@ class StringName {
 		_Data() {
 			cname = NULL;
 			next = prev = NULL;
+			idx = 0;
 			hash = 0;
 		}
 	};

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -1151,7 +1151,7 @@ String String::num_uint64(uint64_t p_num, int base, bool capitalize_hex) {
 	c[chars] = 0;
 	n = p_num;
 	do {
-		int mod = ABS(n % base);
+		int mod = n % base;
 		if (mod >= 10) {
 			char a = (capitalize_hex ? 'A' : 'a');
 			c[--chars] = a + (mod - 10);
@@ -1550,8 +1550,7 @@ String::String(const StrRange &p_range) {
 
 int String::hex_to_int(bool p_with_prefix) const {
 
-	int l = length();
-	if (p_with_prefix && l < 3)
+	if (p_with_prefix && length() < 3)
 		return 0;
 
 	const CharType *s = ptr();
@@ -1560,17 +1559,13 @@ int String::hex_to_int(bool p_with_prefix) const {
 
 	if (sign < 0) {
 		s++;
-		l--;
-		if (p_with_prefix && l < 2)
-			return 0;
 	}
 
 	if (p_with_prefix) {
 		if (s[0] != '0' || s[1] != 'x')
 			return 0;
 		s += 2;
-		l -= 2;
-	};
+	}
 
 	int hex = 0;
 
@@ -1596,8 +1591,7 @@ int String::hex_to_int(bool p_with_prefix) const {
 
 int64_t String::hex_to_int64(bool p_with_prefix) const {
 
-	int l = length();
-	if (p_with_prefix && l < 3)
+	if (p_with_prefix && length() < 3)
 		return 0;
 
 	const CharType *s = ptr();
@@ -1606,17 +1600,13 @@ int64_t String::hex_to_int64(bool p_with_prefix) const {
 
 	if (sign < 0) {
 		s++;
-		l--;
-		if (p_with_prefix && l < 2)
-			return 0;
 	}
 
 	if (p_with_prefix) {
 		if (s[0] != '0' || s[1] != 'x')
 			return 0;
 		s += 2;
-		l -= 2;
-	};
+	}
 
 	int64_t hex = 0;
 
@@ -3478,13 +3468,13 @@ bool String::is_valid_hex_number(bool p_with_prefix) const {
 
 	if (p_with_prefix) {
 
-		if (len < 2)
+		if (len < 3)
 			return false;
 		if (operator[](from) != '0' || operator[](from + 1) != 'x') {
 			return false;
-		};
+		}
 		from += 2;
-	};
+	}
 
 	for (int i = from; i < len; i++) {
 
@@ -3492,7 +3482,7 @@ bool String::is_valid_hex_number(bool p_with_prefix) const {
 		if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))
 			continue;
 		return false;
-	};
+	}
 
 	return true;
 };


### PR DESCRIPTION
- StringName::StringName(const StringName &p_name)
  Non-static class member _data is not initialized in this constructor nor in any functions that it calls.

- StringName::_Data()
  Non-static class member idx is not initialized in this constructor nor in any functions that it calls.

- String::num_uint64(...)
  This less-than-zero comparison of an unsigned value is never true. n % base < 0UL.

- String::hex_to_int(...) and String::hex_to_int64(...)
  Execution cannot reach this statement (deadcode)