### PR TITLE
Fix .pck exporting via PCKPacker

### DIFF
--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -29,8 +29,8 @@
 /*************************************************************************/
 
 #include "pck_packer.h"
-
 #include "core/os/file_access.h"
+#include "version.h"
 
 static uint64_t _align(uint64_t p_n, int p_alignment) {
 
@@ -70,9 +70,9 @@ Error PCKPacker::pck_start(const String &p_file, int p_alignment) {
 	alignment = p_alignment;
 
 	file->store_32(0x43504447); // MAGIC
-	file->store_32(0); // # version
-	file->store_32(0); // # major
-	file->store_32(0); // # minor
+	file->store_32(1); // # version
+	file->store_32(VERSION_MAJOR); // # major
+	file->store_32(VERSION_MINOR); // # minor
 	file->store_32(0); // # revision
 
 	for (int i = 0; i < 16; i++) {


### PR DESCRIPTION
Currently, if you try to export a `.pck` via code like this ([inspired by **neikeq**'s example in the original issue](https://github.com/godotengine/godot-docs/issues/154#issuecomment-221551632)):
```
var packer = PCKPacker.new()
packer.pck_start("Test.pck", 0)
packer.add_file("file1.txt",path)
packer.flush(true)
print("Packed")
ProjectSettings.load_resource_pack("Test.pck")
```

...you get the following error when trying to import it:
![pckversion](https://user-images.githubusercontent.com/1654763/38960395-9f0d7f38-4364-11e8-99f3-d13789ddae02.png)

This is because [PackedSourcePCK::try_open_pack()](https://github.com/godotengine/godot/blob/9ce8d8ddda35cda781364e9b648325a2953d3f63/core/io/file_access_pack.cpp#L173) checks if the `version` contained in the `.pck` is [1](https://github.com/godotengine/godot/blob/9ce8d8ddda35cda781364e9b648325a2953d3f63/core/io/file_access_pack.cpp#L36).

That version seems to be correctly set to `1` when [exporting via the editor](https://github.com/godotengine/godot/blob/18d543d7ab2a362e39cf45d7d4c44c188b60dac9/editor/editor_export.cpp#L818).

However, `PCKPacker::pck_start()` still seems to [set it to 0](https://github.com/godotengine/godot/blob/9ce8d8ddda35cda781364e9b648325a2953d3f63/core/io/pck_packer.cpp#L73).

This PR updates `PCKPacker::pck_start()` to set the same values as exporting a `.pck` via the editor.