### PR TITLE
Fix Coverity reports of uninitialized scalar variable

### DIFF
--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -254,11 +254,13 @@ HashMap<StringName, StringName, StringNameHasher> ClassDB::compat_classes;
 
 ClassDB::ClassInfo::ClassInfo() {
 
+	api = API_NONE;
 	creation_func = NULL;
 	inherits_ptr = NULL;
 	disabled = false;
 	exposed = false;
 }
+
 ClassDB::ClassInfo::~ClassInfo() {
 }
 

--- a/core/math/quick_hull.cpp
+++ b/core/math/quick_hull.cpp
@@ -74,7 +74,7 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry::MeshData &r_me
 	int longest_axis = aabb.get_longest_axis_index();
 
 	//first two vertices are the most distant
-	int simplex[4];
+	int simplex[4] = { 0 };
 
 	{
 		real_t max = 0, min = 0;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -469,18 +469,18 @@ void EditorNode::_fs_changed() {
 			preset.unref();
 		}
 		if (preset.is_null()) {
-			String err = "Unknown export preset: " + export_defer.preset;
-			ERR_PRINTS(err);
+			String errstr = "Unknown export preset: " + export_defer.preset;
+			ERR_PRINTS(errstr);
 		} else {
 			Ref<EditorExportPlatform> platform = preset->get_platform();
 			if (platform.is_null()) {
-				String err = "Preset \"" + export_defer.preset + "\" doesn't have a platform.";
-				ERR_PRINTS(err);
+				String errstr = "Preset \"" + export_defer.preset + "\" doesn't have a platform.";
+				ERR_PRINTS(errstr);
 			} else {
 				// ensures export_project does not loop infinitely, because notifications may
 				// come during the export
 				export_defer.preset = "";
-				Error err;
+				Error err = OK;
 				if (!preset->is_runnable() && (export_defer.path.ends_with(".pck") || export_defer.path.ends_with(".zip"))) {
 					if (export_defer.path.ends_with(".zip")) {
 						err = platform->save_zip(preset, export_defer.path);

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -639,7 +639,7 @@ const char *EditorAssetLibrary::support_key[SUPPORT_MAX] = {
 
 void EditorAssetLibrary::_select_author(int p_id) {
 
-	//opemn author window
+	// Open author window
 }
 
 void EditorAssetLibrary::_select_category(int p_id) {
@@ -659,16 +659,6 @@ void EditorAssetLibrary::_select_category(int p_id) {
 void EditorAssetLibrary::_select_asset(int p_id) {
 
 	_api_request("asset/" + itos(p_id), REQUESTING_ASSET);
-
-	/*
-	if (description) {
-		memdelete(description);
-	}
-
-
-	description = memnew( EditorAssetLibraryItemDescription );
-	add_child(description);
-	description->popup_centered_minsize();*/
 }
 
 void EditorAssetLibrary::_image_update(bool use_cache, bool final, const PoolByteArray &p_data, int p_queue_id) {
@@ -774,7 +764,7 @@ void EditorAssetLibrary::_image_request_completed(int p_status, int p_code, cons
 		_image_update(p_code == HTTPClient::RESPONSE_NOT_MODIFIED, true, p_data, p_queue_id);
 
 	} else {
-		WARN_PRINTS("Error getting PNG file for asset id " + itos(image_queue[p_queue_id].asset_id));
+		WARN_PRINTS("Error getting PNG file from URL: " + image_queue[p_queue_id].image_url);
 		Object *obj = ObjectDB::get_instance(image_queue[p_queue_id].target);
 		if (obj) {
 			obj->call("set_image", image_queue[p_queue_id].image_type, image_queue[p_queue_id].image_index, get_icon("ErrorSign", "EditorIcons"));

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -241,7 +241,6 @@ class EditorAssetLibrary : public PanelContainer {
 
 		bool active;
 		int queue_id;
-		int asset_id;
 		ImageType image_type;
 		int image_index;
 		String image_url;

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -628,7 +628,7 @@ void CanvasItemEditor::_save_canvas_item_state(List<CanvasItem *> p_canvas_items
 			if (bone && bone->has_meta("_edit_bone_")) {
 				// Check if we have an IK chain
 				List<Node2D *> bone_ik_list;
-				bool ik_found;
+				bool ik_found = false;
 				bone = Object::cast_to<Node2D>(bone->get_parent());
 				while (bone) {
 					bone_ik_list.push_back(bone);

--- a/editor/plugins/tile_map_editor_plugin.h
+++ b/editor/plugins/tile_map_editor_plugin.h
@@ -125,12 +125,11 @@ class TileMapEditor : public VBoxContainer {
 		bool yf;
 		bool tr;
 
-		CellOp() {
-			idx = -1;
-			xf = false;
-			yf = false;
-			tr = false;
-		}
+		CellOp() :
+				idx(TileMap::INVALID_CELL),
+				xf(false),
+				yf(false),
+				tr(false) {}
 	};
 
 	Map<Point2i, CellOp> paint_undo;
@@ -141,8 +140,12 @@ class TileMapEditor : public VBoxContainer {
 		bool flip_h;
 		bool flip_v;
 		bool transpose;
-		int auto_x;
-		int auto_y;
+
+		TileData() :
+				cell(TileMap::INVALID_CELL),
+				flip_h(false),
+				flip_v(false),
+				transpose(false) {}
 	};
 
 	List<TileData> copydata;

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -805,7 +805,7 @@ void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 							Vector2 coord((int)(mb->get_position().x / (spacing + size.x)), (int)(mb->get_position().y / (spacing + size.y)));
 							Vector2 pos(coord.x * (spacing + size.x), coord.y * (spacing + size.y));
 							pos = mb->get_position() - pos;
-							uint16_t bit;
+							uint16_t bit = 0;
 							if (tileset->autotile_get_bitmask_mode(get_current_tile()) == TileSet::BITMASK_2X2) {
 								if (pos.x < size.x / 2) {
 									if (pos.y < size.y / 2) {
@@ -868,7 +868,7 @@ void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 						Vector2 coord((int)(mm->get_position().x / (spacing + size.x)), (int)(mm->get_position().y / (spacing + size.y)));
 						Vector2 pos(coord.x * (spacing + size.x), coord.y * (spacing + size.y));
 						pos = mm->get_position() - pos;
-						uint16_t bit;
+						uint16_t bit = 0;
 						if (tileset->autotile_get_bitmask_mode(get_current_tile()) == TileSet::BITMASK_2X2) {
 							if (pos.x < size.x / 2) {
 								if (pos.y < size.y / 2) {
@@ -1146,7 +1146,7 @@ void TileSetEditor::_on_tool_clicked(int p_tool) {
 				case EDITMODE_COLLISION: {
 					if (!edited_collision_shape.is_null()) {
 						Vector<TileSet::ShapeData> sd = tileset->tile_get_shapes(get_current_tile());
-						int index;
+						int index = -1;
 						for (int i = 0; i < sd.size(); i++) {
 							if (sd[i].shape == edited_collision_shape) {
 								index = i;

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -710,25 +710,6 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		error_list->set_item_metadata(error_list->get_item_count() - 1, stack);
 
 		error_count++;
-		/*
-		int count = p_data[1];
-
-		Array cstack;
-
-		OutputError oe = errors.front()->get();
-
-		packet_peer_stream->put_var(oe.hr);
-		packet_peer_stream->put_var(oe.min);
-		packet_peer_stream->put_var(oe.sec);
-		packet_peer_stream->put_var(oe.msec);
-		packet_peer_stream->put_var(oe.source_func);
-		packet_peer_stream->put_var(oe.source_file);
-		packet_peer_stream->put_var(oe.source_line);
-		packet_peer_stream->put_var(oe.error);
-		packet_peer_stream->put_var(oe.error_descr);
-		packet_peer_stream->put_var(oe.warning);
-		packet_peer_stream->put_var(oe.callstack);
-		*/
 
 	} else if (p_msg == "profile_sig") {
 		//cache a signature
@@ -755,6 +736,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 			EditorProfiler::Metric::Category::Item item;
 			item.calls = 1;
 			item.line = 0;
+
 			item.name = "Physics Time";
 			item.total = metric.physics_time;
 			item.self = item.total;
@@ -792,8 +774,9 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 			for (int i = 0; i < values.size(); i += 2) {
 
 				EditorProfiler::Metric::Category::Item item;
-				item.name = values[i];
 				item.calls = 1;
+				item.line = 0;
+				item.name = values[i];
 				item.self = values[i + 1];
 				item.total = item.self;
 				item.signature = "categ::" + name + "::" + item.name;

--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -194,8 +194,6 @@ void InputDefault::joy_connection_changed(int p_idx, bool p_connected, String p_
 	Joypad js;
 	js.name = p_connected ? p_name : "";
 	js.uid = p_connected ? p_guid : "";
-	js.mapping = -1;
-	js.hat_current = 0;
 
 	if (p_connected) {
 
@@ -797,12 +795,12 @@ InputDefault::JoyEvent InputDefault::_find_to_event(String p_to) {
 
 	JoyEvent ret;
 	ret.type = -1;
+	ret.index = 0;
 
 	int i = 0;
 	while (buttons[i]) {
 
 		if (p_to == buttons[i]) {
-			//printf("mapping button %s\n", buttons[i]);
 			ret.type = TYPE_BUTTON;
 			ret.index = i;
 			ret.value = 0;

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -97,7 +97,6 @@ class InputDefault : public Input {
 		int hat_current;
 
 		Joypad() {
-
 			for (int i = 0; i < JOY_AXIS_MAX; i++) {
 
 				last_axis[i] = 0.0f;
@@ -110,6 +109,7 @@ class InputDefault : public Input {
 			last_hat = HAT_MASK_CENTER;
 			filter = 0.01f;
 			mapping = -1;
+			hat_current = 0;
 		}
 	};
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -430,6 +430,9 @@ struct GDScriptCompletionIdentifier {
 	Ref<GDScript> script;
 	Variant::Type type;
 	Variant value; //im case there is a value, also return it
+
+	GDScriptCompletionIdentifier() :
+			type(Variant::NIL) {}
 };
 
 static GDScriptCompletionIdentifier _get_type_from_variant(const Variant &p_variant, bool p_allow_gdnative_class = false) {
@@ -551,9 +554,7 @@ static Ref<Reference> _get_parent_class(GDScriptCompletionContext &context) {
 
 static GDScriptCompletionIdentifier _get_native_class(GDScriptCompletionContext &context) {
 
-	//eeh...
 	GDScriptCompletionIdentifier id;
-	id.type = Variant::NIL;
 
 	REF pc = _get_parent_class(context);
 	if (!pc.is_valid()) {

--- a/modules/pvr/texture_loader_pvr.cpp
+++ b/modules/pvr/texture_loader_pvr.cpp
@@ -536,8 +536,8 @@ static void decompress_pvrtc(PVRTCBlock *p_comp_img, const int p_2bit, const int
 
 	int p_x, p_y;
 
-	int p_modulation[8][16];
-	int p_modulation_modes[8][16];
+	int p_modulation[8][16] = { { 0 } };
+	int p_modulation_modes[8][16] = { { 0 } };
 
 	int Mod, DoPT;
 

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -2028,6 +2028,7 @@ void VisualScriptInstance::create(const Ref<VisualScript> &p_script, Object *p_o
 		function.flow_stack_size = 0;
 		function.pass_stack_size = 0;
 		function.node_count = 0;
+
 		Map<StringName, int> local_var_indices;
 
 		if (function.node < 0) {

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -374,12 +374,10 @@ class VisualScriptInstance : public ScriptInstance {
 		int node;
 		int max_stack;
 		int trash_pos;
-		int return_pos;
 		int flow_stack_size;
 		int pass_stack_size;
 		int node_count;
 		int argument_count;
-		bool valid;
 	};
 
 	Map<StringName, Function> functions;

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -122,6 +122,14 @@ class AppxPackager {
 		Vector<BlockHash> hashes;
 		uLong file_crc32;
 		ZPOS64_T zip_offset;
+
+		FileMeta() :
+				lfh_size(0),
+				compressed(false),
+				compressed_size(0),
+				uncompressed_size(0),
+				file_crc32(0),
+				zip_offset(0) {}
 	};
 
 	String progress_task;

--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -812,8 +812,6 @@ void AnimationTreePlayer::_process_animation(float p_delta) {
 
 		t.value = t.object->get_indexed(t.subpath);
 		t.value.zero();
-
-		t.skip = false;
 	}
 
 	/* STEP 2 PROCESS ANIMATIONS */
@@ -886,7 +884,7 @@ void AnimationTreePlayer::_process_animation(float p_delta) {
 
 		Track &t = E->get();
 
-		if (t.skip || !t.object)
+		if (!t.object)
 			continue;
 
 		if (t.subpath.size()) { // value track

--- a/scene/animation/animation_tree_player.h
+++ b/scene/animation/animation_tree_player.h
@@ -107,8 +107,6 @@ private:
 		Vector3 scale;
 
 		Variant value;
-
-		bool skip;
 	};
 
 	typedef Map<TrackKey, Track> TrackMap;

--- a/servers/physics/body_pair_sw.cpp
+++ b/servers/physics/body_pair_sw.cpp
@@ -78,6 +78,7 @@ void BodyPairSW::contact_added_callback(const Vector3 &p_point_A, const Vector3 
 	contact.local_A = local_A;
 	contact.local_B = local_B;
 	contact.normal = (p_point_A - p_point_B).normalized();
+	contact.mass_normal = 0; // will be computed in setup()
 
 	// attempt to determine if the contact will be reused
 	real_t contact_recycle_radius = space->get_contact_recycle_radius();

--- a/servers/physics_2d/body_pair_2d_sw.cpp
+++ b/servers/physics_2d/body_pair_2d_sw.cpp
@@ -62,6 +62,7 @@ void BodyPair2DSW::_contact_added_callback(const Vector2 &p_point_A, const Vecto
 	contact.local_B = local_B;
 	contact.reused = true;
 	contact.normal = (p_point_A - p_point_B).normalized();
+	contact.mass_normal = 0; // will be computed in setup()
 
 	// attempt to determine if the contact will be reused
 

--- a/servers/visual/shader_language.h
+++ b/servers/visual/shader_language.h
@@ -425,6 +425,7 @@ public:
 
 		FunctionNode() {
 			type = TYPE_FUNCTION;
+			return_type = TYPE_VOID;
 			return_precision = PRECISION_DEFAULT;
 			can_discard = false;
 		}


### PR DESCRIPTION
Fixes most current reports on [Coverity Scan](https://scan.coverity.com/projects/godotengine-godot/) of uninitialized scalar variable
(CWE-457): https://cwe.mitre.org/data/definitions/457.html

These happen most of the time (in our code) when instanciating structs
without a constructor, and later returning the instance.
I've added constructors with (as far as I could tell) meaningful default
values to mitigate that.