### PR TITLE
Provide error details when in-app purchase fails

### DIFF
--- a/platform/android/java/src/org/godotengine/godot/GodotPaymentV3.java
+++ b/platform/android/java/src/org/godotengine/godot/GodotPaymentV3.java
@@ -101,12 +101,12 @@ public class GodotPaymentV3 extends Godot.SingletonBase {
 		GodotLib.calldeferred(purchaseCallbackId, "consume_not_required", new Object[] {});
 	}
 
-	public void callbackFailConsume() {
-		GodotLib.calldeferred(purchaseCallbackId, "consume_fail", new Object[] {});
+	public void callbackFailConsume(String message) {
+		GodotLib.calldeferred(purchaseCallbackId, "consume_fail", new Object[] { message });
 	}
 
-	public void callbackFail() {
-		GodotLib.calldeferred(purchaseCallbackId, "purchase_fail", new Object[] {});
+	public void callbackFail(String message) {
+		GodotLib.calldeferred(purchaseCallbackId, "purchase_fail", new Object[] { message });
 	}
 
 	public void callbackCancel() {
@@ -165,11 +165,11 @@ public class GodotPaymentV3 extends Godot.SingletonBase {
 	}
 
 	public void callbackDisconnected() {
-		GodotLib.calldeferred(purchaseCallbackId, "iap_disconnected", new Object[]{});
+		GodotLib.calldeferred(purchaseCallbackId, "iap_disconnected", new Object[] {});
 	}
 
 	public void callbackConnected() {
-		GodotLib.calldeferred(purchaseCallbackId, "iap_connected", new Object[]{});
+		GodotLib.calldeferred(purchaseCallbackId, "iap_connected", new Object[] {});
 	}
 
 	// true if connected, false otherwise

--- a/platform/android/java/src/org/godotengine/godot/payments/PaymentsManager.java
+++ b/platform/android/java/src/org/godotengine/godot/payments/PaymentsManager.java
@@ -116,7 +116,7 @@ public class PaymentsManager {
 
 			@Override
 			protected void error(String message) {
-				godotPaymentV3.callbackFail();
+				godotPaymentV3.callbackFail(message);
 			}
 
 			@Override
@@ -148,7 +148,7 @@ public class PaymentsManager {
 			@Override
 			protected void error(String message) {
 				Log.d("godot", "consumeUnconsumedPurchases :" + message);
-				godotPaymentV3.callbackFailConsume();
+				godotPaymentV3.callbackFailConsume(message);
 			}
 
 			@Override
@@ -222,7 +222,7 @@ public class PaymentsManager {
 
 						@Override
 						protected void error(String message) {
-							godotPaymentV3.callbackFail();
+							godotPaymentV3.callbackFail(message);
 						}
 					}
 							.consume(sku);
@@ -231,7 +231,7 @@ public class PaymentsManager {
 
 			@Override
 			protected void error(String message) {
-				godotPaymentV3.callbackFail();
+				godotPaymentV3.callbackFail(message);
 			}
 
 			@Override
@@ -258,7 +258,7 @@ public class PaymentsManager {
 
 					@Override
 					protected void error(String message) {
-						godotPaymentV3.callbackFail();
+						godotPaymentV3.callbackFail(message);
 					}
 				}
 						.consume(sku);
@@ -266,7 +266,7 @@ public class PaymentsManager {
 
 			@Override
 			protected void error(String message) {
-				godotPaymentV3.callbackFail();
+				godotPaymentV3.callbackFail(message);
 			}
 
 			@Override
@@ -291,7 +291,7 @@ public class PaymentsManager {
 
 			@Override
 			protected void error(String message) {
-				godotPaymentV3.callbackFailConsume();
+				godotPaymentV3.callbackFailConsume(message);
 			}
 		}
 				.consume(sku);

--- a/platform/iphone/in_app_store.mm
+++ b/platform/iphone/in_app_store.mm
@@ -238,6 +238,7 @@ Error InAppStore::restore_purchases() {
 				ret["type"] = "purchase";
 				ret["result"] = "error";
 				ret["product_id"] = pid;
+				ret["error"] = String::utf8([transaction.error.localizedDescription UTF8String]);
 				InAppStore::get_singleton()->_post_event(ret);
 				[[SKPaymentQueue defaultQueue] finishTransaction:transaction];
 			} break;


### PR DESCRIPTION
This breaks backward-compatibility for Android purchases, but I think it should be fine for 3.1, and the change is useful - you always want to at least log the error, and perhaps also display it to the player so that they have an idea of what could've went wrong.