### PR TITLE
TextEdit scaled selection

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -415,7 +415,7 @@ void TextEdit::_click_selection_held() {
 }
 
 void TextEdit::_update_selection_mode_pointer() {
-	Point2 mp = Input::get_singleton()->get_mouse_position() - get_global_position();
+	Point2 mp = get_local_mouse_position();
 
 	int row, col;
 	_get_mouse_pos(Point2i(mp.x, mp.y), row, col);
@@ -430,7 +430,7 @@ void TextEdit::_update_selection_mode_pointer() {
 }
 
 void TextEdit::_update_selection_mode_word() {
-	Point2 mp = Input::get_singleton()->get_mouse_position() - get_global_position();
+	Point2 mp = get_local_mouse_position();
 
 	int row, col;
 	_get_mouse_pos(Point2i(mp.x, mp.y), row, col);
@@ -483,7 +483,7 @@ void TextEdit::_update_selection_mode_word() {
 }
 
 void TextEdit::_update_selection_mode_line() {
-	Point2 mp = Input::get_singleton()->get_mouse_position() - get_global_position();
+	Point2 mp = get_local_mouse_position();
 
 	int row, col;
 	_get_mouse_pos(Point2i(mp.x, mp.y), row, col);


### PR DESCRIPTION
Fixes #15245

I ended up using get_viewport_transform().get_scale() *  get_global_transform().get_scale()  to manually scale mouse_position, for some reason the transform's xfrom didn't give the desired result.

It also fixes word selection and line selection, which also appeared with an offset when resized. 
And fixes a similar bug that happened when the TextEdit itself had a scale applied.