### PR TITLE
Fix clone down newline bug

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1007,6 +1007,10 @@ void ScriptTextEditor::_edit_option(int p_op) {
 			}
 			int next_line = to_line + 1;
 
+			if (to_line >= tx->get_line_count() - 1) {
+				tx->set_line(to_line, tx->get_line(to_line) + "\n");
+			}
+
 			tx->begin_complex_operation();
 			for (int i = from_line; i <= to_line; i++) {
 


### PR DESCRIPTION
Previously cloning down at the end of a script was broken if there was
not an additional empty line.

This fix ensures there is an empty line before attempting to clone
downwards.

Fixes #18206, cheers!