### PR TITLE
[DOCS] Add note that PoolByteArray is passed by value

### DIFF
--- a/doc/classes/PoolByteArray.xml
+++ b/doc/classes/PoolByteArray.xml
@@ -4,7 +4,7 @@
 		Raw byte array.
 	</brief_description>
 	<description>
-		Raw byte array. Contains bytes. Optimized for memory usage, can't fragment the memory. Note that this type is passed by value and not by reference, the reason being it is used for data being sent to servers which shouldn't be modifiable once sent (this may change in the future).
+		Raw byte array. Contains bytes. Optimized for memory usage, can't fragment the memory. Note that this type is passed by value and not by reference.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PoolByteArray.xml
+++ b/doc/classes/PoolByteArray.xml
@@ -4,7 +4,7 @@
 		Raw byte array.
 	</brief_description>
 	<description>
-		Raw byte array. Contains bytes. Optimized for memory usage, can't fragment the memory.
+		Raw byte array. Contains bytes. Optimized for memory usage, can't fragment the memory. Note that this type is passed by value and not by reference, the reason being it is used for data being sent to servers which shouldn't be modifiable once sent (this may change in the future).
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PoolColorArray.xml
+++ b/doc/classes/PoolColorArray.xml
@@ -4,7 +4,7 @@
 		Array of Colors
 	</brief_description>
 	<description>
-		Array of Color, Contains colors. Optimized for memory usage, can't fragment the memory.
+		Array of Color, Contains colors. Optimized for memory usage, can't fragment the memory. Note that this type is passed by value and not by reference.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PoolIntArray.xml
+++ b/doc/classes/PoolIntArray.xml
@@ -4,7 +4,7 @@
 		Integer Array.
 	</brief_description>
 	<description>
-		Integer Array. Contains integers. Optimized for memory usage, can't fragment the memory.
+		Integer Array. Contains integers. Optimized for memory usage, can't fragment the memory. Note that this type is passed by value and not by reference.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PoolRealArray.xml
+++ b/doc/classes/PoolRealArray.xml
@@ -4,7 +4,7 @@
 		Real Array.
 	</brief_description>
 	<description>
-		Real Array. Array of floating point values. Can only contain floats. Optimized for memory usage, can't fragment the memory.
+		Real Array. Array of floating point values. Can only contain floats. Optimized for memory usage, can't fragment the memory. Note that this type is passed by value and not by reference.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PoolStringArray.xml
+++ b/doc/classes/PoolStringArray.xml
@@ -4,7 +4,7 @@
 		String Array.
 	</brief_description>
 	<description>
-		String Array. Array of strings. Can only contain strings. Optimized for memory usage, can't fragment the memory.
+		String Array. Array of strings. Can only contain strings. Optimized for memory usage, can't fragment the memory. Note that this type is passed by value and not by reference.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PoolVector2Array.xml
+++ b/doc/classes/PoolVector2Array.xml
@@ -4,7 +4,7 @@
 		An Array of Vector2.
 	</brief_description>
 	<description>
-		An Array specifically designed to hold Vector2.
+		An Array specifically designed to hold Vector2. Note that this type is passed by value and not by reference.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PoolVector3Array.xml
+++ b/doc/classes/PoolVector3Array.xml
@@ -4,7 +4,7 @@
 		An Array of Vector3.
 	</brief_description>
 	<description>
-		An Array specifically designed to hold Vector3.
+		An Array specifically designed to hold Vector3. Note that this type is passed by value and not by reference.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
This should be mentioned to avoid confusion, as it is not passed by reference like a normal array type. This confused me and was not mentioned in the docs. I had to go into the #godotengine-devel IRC to learn this fact.