### PR TITLE
fix clang6 assignment error

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -867,9 +867,9 @@ void RichTextLabel::_gui_input(Ref<InputEvent> p_event) {
 							// Erase previous selection.
 							if (selection.active) {
 								selection.from = NULL;
-								selection.from_char = NULL;
+								selection.from_char = '\0';
 								selection.to = NULL;
-								selection.to_char = NULL;
+								selection.to_char = '\0';
 								selection.active = false;
 
 								update();


### PR DESCRIPTION
With the switch to clang version 6, the compiler doesn't allow assigning a char to NULL anymore. This patch changes it to the null character `'\0'` and fixes the build with clang version 6.

I have used godot 3.0.2 built with this for many hours without any problems.