### PR TITLE
Fixed 2D intersect_shape limiting broadphase results 

### DIFF
--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -180,11 +180,14 @@ int Physics2DDirectSpaceStateSW::intersect_shape(const RID &p_shape, const Trans
 	Rect2 aabb = p_xform.xform(shape->get_aabb());
 	aabb = aabb.grow(p_margin);
 
-	int amount = space->broadphase->cull_aabb(aabb, space->intersection_query_results, p_result_max, space->intersection_query_subindex_results);
+	int amount = space->broadphase->cull_aabb(aabb, space->intersection_query_results, Space2DSW::INTERSECTION_QUERY_MAX, space->intersection_query_subindex_results);
 
 	int cc = 0;
 
 	for (int i = 0; i < amount; i++) {
+
+		if (cc >= p_result_max)
+			break;
 
 		if (!_can_collide_with(space->intersection_query_results[i], p_collision_mask))
 			continue;


### PR DESCRIPTION
Physics2DDirectSpaceStateSW was applying the result limit to broadphase
collision detection instead of narrow. This is inconsistent with its 3D
variant, as well as the rest of the 2D direct space state functions.

Broadphase is now limited by INTERSECTION_QUERY_MAX like everything else,
and narrow phase is exited early when the result limit has been reached. 
Same logic as the 3D version.

I found this after using intersect_shape with a large shape. It worked fine with small shapes, but large shapes resulted in an empty array. Turns out it was because it was grabbing 130 surrounding tiles and returning early, even though their layer wasn't in the query's mask. 

Looks like this was introduced by #4287