### PR TITLE
Change a color of the node emitting the signal in Connecting…

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -204,14 +204,14 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 	} else if (marked.has(p_node)) {
 
 		item->set_selectable(0, marked_selectable);
-		item->set_custom_color(0, get_color("error_color", "Editor"));
+		item->set_custom_color(0, get_color("success_color", "Editor"));
 	} else if (!marked_selectable && !marked_children_selectable) {
 
 		Node *node = p_node;
 		while (node) {
 			if (marked.has(node)) {
 				item->set_selectable(0, false);
-				item->set_custom_color(0, get_color("error_color", "Editor"));
+				item->set_custom_color(0, get_color("success_color", "Editor"));
 				break;
 			}
 			node = node->get_parent();


### PR DESCRIPTION
… Signal dialog.

Color of node changed to standard "success_color" of default editor theme.

![godot2](https://user-images.githubusercontent.com/2286710/39094920-643c0a8a-4640-11e8-879f-c80ba974700e.png)
