### PR TITLE
Track render time in profiling/monitors

### DIFF
--- a/editor/editor_profiler.h
+++ b/editor/editor_profiler.h
@@ -52,6 +52,7 @@ public:
 		int frame_number;
 		float frame_time;
 		float idle_time;
+		float render_time;
 		float physics_time;
 		float physics_frame_time;
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1712,6 +1712,7 @@ bool Main::force_redraw_requested = false;
 //for performance metrics
 static uint64_t physics_process_max = 0;
 static uint64_t idle_process_max = 0;
+static uint64_t render_process_max = 0;
 
 bool Main::iteration() {
 
@@ -1735,6 +1736,7 @@ bool Main::iteration() {
 
 	uint64_t physics_process_ticks = 0;
 	uint64_t idle_process_ticks = 0;
+	uint64_t render_process_ticks = 0;
 
 	frame += ticks_elapsed;
 
@@ -1786,7 +1788,7 @@ bool Main::iteration() {
 
 	Engine::get_singleton()->_in_physics = false;
 
-	uint64_t idle_begin = OS::get_singleton()->get_ticks_usec();
+	uint64_t render_begin = OS::get_singleton()->get_ticks_usec();
 
 	OS::get_singleton()->get_main_loop()->idle(step * time_scale);
 	message_queue->flush();
@@ -1806,6 +1808,11 @@ bool Main::iteration() {
 			force_redraw_requested = false;
 		}
 	}
+
+	render_process_ticks = OS::get_singleton()->get_ticks_usec() - render_begin;
+	render_process_max = MAX(render_process_ticks, render_process_max);
+
+	uint64_t idle_begin = OS::get_singleton()->get_ticks_usec();
 
 	if (AudioServer::get_singleton())
 		AudioServer::get_singleton()->update();
@@ -1841,8 +1848,10 @@ bool Main::iteration() {
 		Engine::get_singleton()->_fps = frames;
 		performance->set_process_time(USEC_TO_SEC(idle_process_max));
 		performance->set_physics_process_time(USEC_TO_SEC(physics_process_max));
+		performance->set_render_process_time(USEC_TO_SEC(render_process_max));
 		idle_process_max = 0;
 		physics_process_max = 0;
+		render_process_max = 0;
 
 		frame %= 1000000;
 		frames = 0;

--- a/main/performance.cpp
+++ b/main/performance.cpp
@@ -44,6 +44,7 @@ void Performance::_bind_methods() {
 	BIND_ENUM_CONSTANT(TIME_FPS);
 	BIND_ENUM_CONSTANT(TIME_PROCESS);
 	BIND_ENUM_CONSTANT(TIME_PHYSICS_PROCESS);
+	BIND_ENUM_CONSTANT(TIME_RENDER_PROCESS);
 	BIND_ENUM_CONSTANT(MEMORY_STATIC);
 	BIND_ENUM_CONSTANT(MEMORY_DYNAMIC);
 	BIND_ENUM_CONSTANT(MEMORY_STATIC_MAX);
@@ -80,6 +81,7 @@ String Performance::get_monitor_name(Monitor p_monitor) const {
 		"time/fps",
 		"time/process",
 		"time/physics_process",
+		"time/render_process",
 		"memory/static",
 		"memory/dynamic",
 		"memory/static_max",
@@ -116,6 +118,7 @@ float Performance::get_monitor(Monitor p_monitor) const {
 		case TIME_FPS: return Engine::get_singleton()->get_frames_per_second();
 		case TIME_PROCESS: return _process_time;
 		case TIME_PHYSICS_PROCESS: return _physics_process_time;
+		case TIME_RENDER_PROCESS: return _render_process_time;
 		case MEMORY_STATIC: return Memory::get_mem_usage();
 		case MEMORY_DYNAMIC: return MemoryPool::total_memory;
 		case MEMORY_STATIC_MAX: return Memory::get_mem_max_usage();
@@ -162,6 +165,7 @@ Performance::MonitorType Performance::get_monitor_type(Monitor p_monitor) const 
 		MONITOR_TYPE_QUANTITY,
 		MONITOR_TYPE_TIME,
 		MONITOR_TYPE_TIME,
+		MONITOR_TYPE_TIME,
 		MONITOR_TYPE_MEMORY,
 		MONITOR_TYPE_MEMORY,
 		MONITOR_TYPE_MEMORY,
@@ -202,9 +206,14 @@ void Performance::set_physics_process_time(float p_pt) {
 	_physics_process_time = p_pt;
 }
 
+void Performance::set_render_process_time(float p_pt) {
+	_render_process_time = p_pt;
+}
+
 Performance::Performance() {
 
 	_process_time = 0;
 	_physics_process_time = 0;
+	_render_process_time = 0;
 	singleton = this;
 }

--- a/main/performance.h
+++ b/main/performance.h
@@ -45,6 +45,7 @@ class Performance : public Object {
 
 	float _process_time;
 	float _physics_process_time;
+	float _render_process_time;
 
 public:
 	enum Monitor {
@@ -52,6 +53,7 @@ public:
 		TIME_FPS,
 		TIME_PROCESS,
 		TIME_PHYSICS_PROCESS,
+		TIME_RENDER_PROCESS,
 		MEMORY_STATIC,
 		MEMORY_DYNAMIC,
 		MEMORY_STATIC_MAX,
@@ -93,6 +95,7 @@ public:
 
 	void set_process_time(float p_pt);
 	void set_physics_process_time(float p_pt);
+	void set_render_process_time(float p_pt);
 
 	static Performance *get_singleton() { return singleton; }
 


### PR DESCRIPTION
So here's a feature that I wanted a couple days back and took the time to code. 

Monitors now show the time it takes for the engine to render (as opposed to having a blob of 'idle time' that covers both rendering and audio and who knows what). 'Idle time' is still a thing, but no longer includes rendering.

:eyes: wanted because it works in monitors but not in profiler (and I mostly wanted it for the profiler)