### PR TITLE
Fix 2d filter shader rendering bug

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1190,6 +1190,8 @@ void RasterizerCanvasGLES3::canvas_render_items(Item *p_item_list, int p_z, cons
 				}
 
 			} else {
+				glBindTexture(GL_TEXTURE_2D, storage->resources.white_tex);
+
 				state.canvas_shader.set_custom_shader(0);
 				state.canvas_shader.bind();
 			}


### PR DESCRIPTION
Fixes #17698

My experience with OpenGL is limited, so I'm very open to feedback! This tweak fixes an issue where having two ColorRects inside a CanvasLayer (where the first ColorRect has a shader and is the first child of the CanvasLayer) would cause the second ColorRect to show an inverted image of the scene instead of the solid color expected.

Before:
![colorrect-before](https://user-images.githubusercontent.com/18668880/39097807-42621774-4627-11e8-9b7a-8825b3062002.gif)

After:
![colorrect-after](https://user-images.githubusercontent.com/18668880/39098088-1663abfc-462b-11e8-9db7-a31da64fe344.gif)