### PR TITLE
sync rasterizers with engine

### DIFF
--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -772,7 +772,7 @@ public:
 	void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale) {}
 
 	void initialize() {}
-	void begin_frame() {}
+	void begin_frame(double frame_step) {}
 	void set_current_render_target(RID p_render_target) {}
 	void restore_render_target() {}
 	void clear_render_target(const Color &p_color) {}

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -227,20 +227,13 @@ void RasterizerGLES2::initialize() {
 	scene->initialize();
 }
 
-void RasterizerGLES2::begin_frame() {
-	uint64_t tick = OS::get_singleton()->get_ticks_usec();
+void RasterizerGLES2::begin_frame(double frame_step) {
+	time_total += frame_step;
 
-	double delta = double(tick - prev_ticks) / 1000000.0;
-	delta *= Engine::get_singleton()->get_time_scale();
-
-	time_total += delta;
-
-	if (delta == 0) {
+	if (frame_step == 0) {
 		//to avoid hiccups
-		delta = 0.001;
+		frame_step = 0.001;
 	}
-
-	prev_ticks = tick;
 
 	// double time_roll_over = GLOBAL_GET("rendering/limits/time/time_rollover_secs");
 	// if (time_total > time_roll_over)
@@ -251,9 +244,7 @@ void RasterizerGLES2::begin_frame() {
 	storage->frame.time[2] = Math::fmod(time_total, 900);
 	storage->frame.time[3] = Math::fmod(time_total, 60);
 	storage->frame.count++;
-	storage->frame.delta = delta;
-
-	storage->frame.prev_tick = tick;
+	storage->frame.delta = frame_step;
 
 	storage->update_dirty_resources();
 
@@ -452,7 +443,6 @@ RasterizerGLES2::RasterizerGLES2() {
 	scene->storage = storage;
 	storage->scene = scene;
 
-	prev_ticks = 0;
 	time_total = 0;
 }
 

--- a/drivers/gles2/rasterizer_gles2.h
+++ b/drivers/gles2/rasterizer_gles2.h
@@ -43,7 +43,6 @@ class RasterizerGLES2 : public Rasterizer {
 	RasterizerCanvasGLES2 *canvas;
 	RasterizerSceneGLES2 *scene;
 
-	uint64_t prev_ticks;
 	double time_total;
 
 public:
@@ -54,7 +53,7 @@ public:
 	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale);
 
 	virtual void initialize();
-	virtual void begin_frame();
+	virtual void begin_frame(double frame_step);
 	virtual void set_current_render_target(RID p_render_target);
 	virtual void restore_render_target();
 	virtual void clear_render_target(const Color &p_color);

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -1988,7 +1988,6 @@ void RasterizerStorageGLES2::initialize() {
 	}
 
 	frame.count = 0;
-	frame.prev_tick = 0;
 	frame.delta = 0;
 	frame.current_rt = NULL;
 	frame.clear_request = false;

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -814,7 +814,6 @@ public:
 		int canvas_draw_commands;
 		float time[4];
 		float delta;
-		uint64_t prev_tick;
 		uint64_t count;
 
 	} frame;

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -192,21 +192,14 @@ void RasterizerGLES3::initialize() {
 	scene->initialize();
 }
 
-void RasterizerGLES3::begin_frame() {
+void RasterizerGLES3::begin_frame(double frame_step) {
 
-	uint64_t tick = OS::get_singleton()->get_ticks_usec();
+	time_total += frame_step;
 
-	double delta = double(tick - prev_ticks) / 1000000.0;
-	delta *= Engine::get_singleton()->get_time_scale();
-
-	time_total += delta;
-
-	if (delta == 0) {
+	if (frame_step == 0) {
 		//to avoid hiccups
-		delta = 0.001;
+		frame_step = 0.001;
 	}
-
-	prev_ticks = tick;
 
 	double time_roll_over = GLOBAL_GET("rendering/limits/time/time_rollover_secs");
 	if (time_total > time_roll_over)
@@ -217,9 +210,7 @@ void RasterizerGLES3::begin_frame() {
 	storage->frame.time[2] = Math::fmod(time_total, 900);
 	storage->frame.time[3] = Math::fmod(time_total, 60);
 	storage->frame.count++;
-	storage->frame.delta = delta;
-
-	storage->frame.prev_tick = tick;
+	storage->frame.delta = frame_step;
 
 	storage->update_dirty_resources();
 
@@ -281,7 +272,7 @@ void RasterizerGLES3::set_boot_image(const Ref<Image> &p_image, const Color &p_c
 	if (p_image.is_null() || p_image->empty())
 		return;
 
-	begin_frame();
+	begin_frame(0.0);
 
 	int window_w = OS::get_singleton()->get_video_mode(0).width;
 	int window_h = OS::get_singleton()->get_video_mode(0).height;
@@ -451,7 +442,6 @@ RasterizerGLES3::RasterizerGLES3() {
 	scene->storage = storage;
 	storage->scene = scene;
 
-	prev_ticks = 0;
 	time_total = 0;
 }
 

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -44,7 +44,6 @@ class RasterizerGLES3 : public Rasterizer {
 	RasterizerCanvasGLES3 *canvas;
 	RasterizerSceneGLES3 *scene;
 
-	uint64_t prev_ticks;
 	double time_total;
 
 public:
@@ -55,7 +54,7 @@ public:
 	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale);
 
 	virtual void initialize();
-	virtual void begin_frame();
+	virtual void begin_frame(double frame_step);
 	virtual void set_current_render_target(RID p_render_target);
 	virtual void restore_render_target();
 	virtual void clear_render_target(const Color &p_color);

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -7359,7 +7359,6 @@ void RasterizerStorageGLES3::initialize() {
 #endif
 
 	frame.count = 0;
-	frame.prev_tick = 0;
 	frame.delta = 0;
 	frame.current_rt = NULL;
 	config.keep_original_textures = false;

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1417,7 +1417,6 @@ public:
 		int canvas_draw_commands;
 		float time[4];
 		float delta;
-		uint64_t prev_tick;
 		uint64_t count;
 
 	} frame;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1734,8 +1734,11 @@ bool Main::iteration() {
 	int physics_fps = Engine::get_singleton()->get_iterations_per_second();
 	float frame_slice = 1.0 / physics_fps;
 
+	float time_scale = Engine::get_singleton()->get_time_scale();
+
 	MainFrameTime advance = main_timer_sync.advance(frame_slice, physics_fps);
 	double step = advance.idle_step;
+	double scaled_step = step * time_scale;
 
 	Engine::get_singleton()->_frame_step = step;
 
@@ -1756,8 +1759,6 @@ bool Main::iteration() {
 		step -= (advance.physics_steps - max_physics_steps) * frame_slice;
 		advance.physics_steps = max_physics_steps;
 	}
-
-	float time_scale = Engine::get_singleton()->get_time_scale();
 
 	bool exit = false;
 
@@ -1805,11 +1806,11 @@ bool Main::iteration() {
 
 		if ((!force_redraw_requested) && OS::get_singleton()->is_in_low_processor_usage_mode()) {
 			if (VisualServer::get_singleton()->has_changed()) {
-				VisualServer::get_singleton()->draw(); // flush visual commands
+				VisualServer::get_singleton()->draw(true, scaled_step); // flush visual commands
 				Engine::get_singleton()->frames_drawn++;
 			}
 		} else {
-			VisualServer::get_singleton()->draw(); // flush visual commands
+			VisualServer::get_singleton()->draw(true, scaled_step); // flush visual commands
 			Engine::get_singleton()->frames_drawn++;
 			force_redraw_requested = false;
 		}

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -1069,7 +1069,7 @@ public:
 	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale) = 0;
 
 	virtual void initialize() = 0;
-	virtual void begin_frame() = 0;
+	virtual void begin_frame(double frame_step) = 0;
 	virtual void set_current_render_target(RID p_render_target) = 0;
 	virtual void restore_render_target() = 0;
 	virtual void clear_render_target(const Color &p_color) = 0;

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -93,11 +93,11 @@ void VisualServerRaster::request_frame_drawn_callback(Object *p_where, const Str
 	frame_drawn_callbacks.push_back(fdc);
 }
 
-void VisualServerRaster::draw(bool p_swap_buffers) {
+void VisualServerRaster::draw(bool p_swap_buffers, double frame_step) {
 
 	changes = 0;
 
-	VSG::rasterizer->begin_frame();
+	VSG::rasterizer->begin_frame(frame_step);
 
 	VSG::scene->update_dirty_instances(); //update scene stuff
 

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -652,7 +652,7 @@ public:
 
 	virtual void request_frame_drawn_callback(Object *p_where, const StringName &p_method, const Variant &p_userdata);
 
-	virtual void draw(bool p_swap_buffers);
+	virtual void draw(bool p_swap_buffers, double frame_step);
 	virtual void sync();
 	virtual bool has_changed() const;
 	virtual void init();

--- a/servers/visual/visual_server_wrap_mt.cpp
+++ b/servers/visual/visual_server_wrap_mt.cpp
@@ -37,11 +37,11 @@ void VisualServerWrapMT::thread_exit() {
 	exit = true;
 }
 
-void VisualServerWrapMT::thread_draw() {
+void VisualServerWrapMT::thread_draw(bool p_swap_buffers, double frame_step) {
 
 	if (!atomic_decrement(&draw_pending)) {
 
-		visual_server->draw();
+		visual_server->draw(p_swap_buffers, frame_step);
 	}
 }
 
@@ -91,15 +91,15 @@ void VisualServerWrapMT::sync() {
 	}
 }
 
-void VisualServerWrapMT::draw(bool p_swap_buffers) {
+void VisualServerWrapMT::draw(bool p_swap_buffers, double frame_step) {
 
 	if (create_thread) {
 
 		atomic_increment(&draw_pending);
-		command_queue.push(this, &VisualServerWrapMT::thread_draw);
+		command_queue.push(this, &VisualServerWrapMT::thread_draw, p_swap_buffers, frame_step);
 	} else {
 
-		visual_server->draw(p_swap_buffers);
+		visual_server->draw(p_swap_buffers, frame_step);
 	}
 }
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -55,7 +55,7 @@ class VisualServerWrapMT : public VisualServer {
 	bool create_thread;
 
 	uint64_t draw_pending;
-	void thread_draw();
+	void thread_draw(bool p_swap_buffers, double frame_step);
 	void thread_flush();
 
 	void thread_exit();
@@ -572,7 +572,7 @@ public:
 
 	virtual void init();
 	virtual void finish();
-	virtual void draw(bool p_swap_buffers);
+	virtual void draw(bool p_swap_buffers, double frame_step);
 	virtual void sync();
 	FUNC0RC(bool, has_changed)
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1516,13 +1516,13 @@ Array VisualServer::_mesh_surface_get_skeleton_aabb_bind(RID p_mesh, int p_surfa
 void VisualServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("force_sync"), &VisualServer::sync);
-	ClassDB::bind_method(D_METHOD("force_draw", "swap_buffers"), &VisualServer::draw, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("force_draw", "swap_buffers", "frame_step"), &VisualServer::draw, DEFVAL(true), DEFVAL(0.0));
 
 	// "draw" and "sync" are deprecated duplicates of "force_draw" and "force_sync"
 	// FIXME: Add deprecation messages using GH-4397 once available, and retire
 	// once the warnings have been enabled for a full release cycle
 	ClassDB::bind_method(D_METHOD("sync"), &VisualServer::sync);
-	ClassDB::bind_method(D_METHOD("draw", "swap_buffers"), &VisualServer::draw, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("draw", "swap_buffers", "frame_step"), &VisualServer::draw, DEFVAL(true), DEFVAL(0.0));
 
 	ClassDB::bind_method(D_METHOD("texture_create"), &VisualServer::texture_create);
 	ClassDB::bind_method(D_METHOD("texture_create_from_image", "image", "flags"), &VisualServer::texture_create_from_image, DEFVAL(TEXTURE_FLAGS_DEFAULT));

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -939,7 +939,7 @@ public:
 
 	/* EVENT QUEUING */
 
-	virtual void draw(bool p_swap_buffers = true) = 0;
+	virtual void draw(bool p_swap_buffers = true, double frame_step = 0.0) = 0;
 	virtual void sync() = 0;
 	virtual bool has_changed() const = 0;
 	virtual void init() = 0;


### PR DESCRIPTION
The GLES3 rasterizer were calculating its own frame delta time. 
Apart from being a repetition of a calculation we are doing in the main script anyways, this meant that the frame_slice limit that is set in the main script were being ignored, leading to de-synchronization. This was visible when using particle systems since they need the frame delta time ().

This fix lets the rasterizer get the frame delta from the Engine singleton
That way any regulations to the frame step from the main script will not cause particle systems to process at a different step than the rest of the Engine.