### PR TITLE
Adds support for CMD+Left and CMD+Right on MacOS

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -215,6 +215,12 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 				case (KEY_A): { //Select All
 					select();
 				} break;
+				case (KEY_LEFT): { // Go to start of text - like HOME key
+					set_cursor_position(0);
+				} break;
+				case (KEY_RIGHT): { // Go to end of text - like END key
+					set_cursor_position(text.length());
+				} break;
 				default: { handled = false; }
 			}
 


### PR DESCRIPTION
CMD+Left and CMD+Right are hotkeys used on MacOS for
moving cursor to start and end of the text, respectively.
They are now supported, alongside ALT+key.

Fixes: #17631