### PR TITLE
Fix for large .pck files

### DIFF
--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -184,7 +184,7 @@ size_t FileAccessUnix::get_position() const {
 
 	ERR_FAIL_COND_V(!f, 0);
 
-	int pos = ftell(f);
+	long pos = ftell(f);
 	if (pos < 0) {
 		check_errors();
 		ERR_FAIL_V(0);
@@ -196,10 +196,10 @@ size_t FileAccessUnix::get_len() const {
 
 	ERR_FAIL_COND_V(!f, 0);
 
-	int pos = ftell(f);
+	long pos = ftell(f);
 	ERR_FAIL_COND_V(pos < 0, 0);
 	ERR_FAIL_COND_V(fseek(f, 0, SEEK_END), 0);
-	int size = ftell(f);
+	long size = ftell(f);
 	ERR_FAIL_COND_V(size < 0, 0);
 	ERR_FAIL_COND_V(fseek(f, pos, SEEK_SET), 0);
 


### PR DESCRIPTION
An error in unix file IO was causing crashes when getting the size of a file larger than max integer size
As ftell returns a long the fix is trivial

fixes [#18147](https://github.com/godotengine/godot/issues/18147)