### PR TITLE
Fix WorldEnvironment missing camera warning bug

### DIFF
--- a/scene/3d/camera.cpp
+++ b/scene/3d/camera.cpp
@@ -102,7 +102,7 @@ void Camera::_notification(int p_what) {
 		case NOTIFICATION_ENTER_WORLD: {
 
 			bool first_camera = get_viewport()->_camera_add(this);
-			if (!get_tree()->is_node_being_edited(this) && (current || first_camera))
+			if (current || first_camera)
 				make_current();
 
 		} break;


### PR DESCRIPTION
Fixes #17943

Does anyone understand why this code is checking to make sure the node isn't being edited? 

It seems to be preventing the camera from assigning itself to the viewport, which causes a warning to be displayed (with no other side effects) as reported in #17943. 

The configuration warning is in `scene/3d/scenario_fx.cpp`, where `get_viewport()->get_camera()` fails to return a camera.

Seeing as how `make_current()` calls `get_viewport()->_camera_set(this)`, removing the failing check silences the warning.