### PR TITLE
Fully expose the data variable in AudioStreamSample and AudioStreamOGGVorbis

### DIFF
--- a/doc/classes/AudioStreamSample.xml
+++ b/doc/classes/AudioStreamSample.xml
@@ -13,6 +13,9 @@
 	<methods>
 	</methods>
 	<members>
+		<member name="data" type="PoolByteArray" setter="set_data" getter="get_data">
+			Contains the audio data in bytes.
+		</member>
 		<member name="format" type="int" setter="set_format" getter="get_format" enum="AudioStreamSample.Format">
 			Audio format. See FORMAT_* constants for values.
 		</member>

--- a/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
@@ -263,8 +263,8 @@ float AudioStreamOGGVorbis::get_length() const {
 
 void AudioStreamOGGVorbis::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("_set_data", "data"), &AudioStreamOGGVorbis::set_data);
-	ClassDB::bind_method(D_METHOD("_get_data"), &AudioStreamOGGVorbis::get_data);
+	ClassDB::bind_method(D_METHOD("set_data", "data"), &AudioStreamOGGVorbis::set_data);
+	ClassDB::bind_method(D_METHOD("get_data"), &AudioStreamOGGVorbis::get_data);
 
 	ClassDB::bind_method(D_METHOD("set_loop", "enable"), &AudioStreamOGGVorbis::set_loop);
 	ClassDB::bind_method(D_METHOD("has_loop"), &AudioStreamOGGVorbis::has_loop);
@@ -272,7 +272,7 @@ void AudioStreamOGGVorbis::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_loop_offset", "seconds"), &AudioStreamOGGVorbis::set_loop_offset);
 	ClassDB::bind_method(D_METHOD("get_loop_offset"), &AudioStreamOGGVorbis::get_loop_offset);
 
-	ADD_PROPERTY(PropertyInfo(Variant::POOL_BYTE_ARRAY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_set_data", "_get_data");
+	ADD_PROPERTY(PropertyInfo(Variant::POOL_BYTE_ARRAY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_data", "get_data");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "loop", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_loop", "has_loop");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "loop_offset", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_loop_offset", "get_loop_offset");
 }

--- a/modules/stb_vorbis/doc_classes/AudioStreamOGGVorbis.xml
+++ b/modules/stb_vorbis/doc_classes/AudioStreamOGGVorbis.xml
@@ -13,6 +13,9 @@
 	<methods>
 	</methods>
 	<members>
+		<member name="data" type="PoolByteArray" setter="set_data" getter="get_data">
+			Contains the audio data in bytes.
+		</member>
 		<member name="loop" type="bool" setter="set_loop" getter="has_loop">
 		</member>
 		<member name="loop_offset" type="float" setter="set_loop_offset" getter="get_loop_offset">

--- a/scene/resources/audio_stream_sample.cpp
+++ b/scene/resources/audio_stream_sample.cpp
@@ -524,6 +524,9 @@ String AudioStreamSample::get_stream_name() const {
 
 void AudioStreamSample::_bind_methods() {
 
+	ClassDB::bind_method(D_METHOD("set_data", "data"), &AudioStreamSample::set_data);
+	ClassDB::bind_method(D_METHOD("get_data"), &AudioStreamSample::get_data);
+
 	ClassDB::bind_method(D_METHOD("set_format", "format"), &AudioStreamSample::set_format);
 	ClassDB::bind_method(D_METHOD("get_format"), &AudioStreamSample::get_format);
 
@@ -542,16 +545,13 @@ void AudioStreamSample::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_stereo", "stereo"), &AudioStreamSample::set_stereo);
 	ClassDB::bind_method(D_METHOD("is_stereo"), &AudioStreamSample::is_stereo);
 
-	ClassDB::bind_method(D_METHOD("_set_data", "data"), &AudioStreamSample::set_data);
-	ClassDB::bind_method(D_METHOD("_get_data"), &AudioStreamSample::get_data);
-
+	ADD_PROPERTY(PropertyInfo(Variant::POOL_BYTE_ARRAY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_data", "get_data");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "format", PROPERTY_HINT_ENUM, "8-Bit,16-Bit,IMA-ADPCM"), "set_format", "get_format");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "loop_mode", PROPERTY_HINT_ENUM, "Disabled,Forward,Ping-Pong"), "set_loop_mode", "get_loop_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "loop_begin"), "set_loop_begin", "get_loop_begin");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "loop_end"), "set_loop_end", "get_loop_end");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mix_rate"), "set_mix_rate", "get_mix_rate");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "stereo"), "set_stereo", "is_stereo");
-	ADD_PROPERTY(PropertyInfo(Variant::POOL_BYTE_ARRAY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_set_data", "_get_data");
 
 	BIND_ENUM_CONSTANT(FORMAT_8_BITS);
 	BIND_ENUM_CONSTANT(FORMAT_16_BITS);


### PR DESCRIPTION
The "data" variable on AudioStreamSample and AudioStreamOGGVorbis seemed to be missing from the docs.

This if my first PR, so please tell me if there's anything I can improve!