### PR TITLE
Fix AnimationPlayer edited scene bug

### DIFF
--- a/editor/animation_editor.cpp
+++ b/editor/animation_editor.cpp
@@ -3130,7 +3130,6 @@ void AnimationKeyEditor::set_animation(const Ref<Animation> &p_anim) {
 
 	timeline_pos = 0;
 	_clear_selection();
-	_update_paths();
 
 	_update_menu();
 	selected_track = -1;


### PR DESCRIPTION
Fixes #18112.

It turns out that `_update_menu()` has all of the same code as `_update_paths()`. Removing the duplicate code stopped the editor from thinking it had been modified.

![animationplayersolved](https://user-images.githubusercontent.com/18668880/39148025-e0e8f05a-4700-11e8-9e76-f85de76f4fe4.gif)
