### PR TITLE
Fix Ctrl+click on @GDScript constants

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2628,6 +2628,13 @@ Error GDScriptLanguage::lookup_code(const String &p_code, const String &p_symbol
 		}
 	}
 
+	if ("PI" == p_symbol || "TAU" == p_symbol || "INF" == p_symbol || "NAN" == p_symbol) {
+		r_result.type = ScriptLanguage::LookupResult::RESULT_CLASS_CONSTANT;
+		r_result.class_name = "@GDScript";
+		r_result.class_member = p_symbol;
+		return OK;
+	}
+
 	GDScriptParser p;
 	p.parse(p_code, p_base_path, false, "", true);
 


### PR DESCRIPTION
Fixes #17958

It feels a little sloppy to hardcode the four constants, but I haven't found a more elegant way to get these names yet. In `modules/gdscript/gdscript.cpp` they are added as globals, but seem to be lumped in with all the other global values. Maybe I can add a list to GDScriptLanguage that keeps track of these constants?

![gdscript-constant-help](https://user-images.githubusercontent.com/18668880/39221341-04149f1a-47fc-11e8-83af-12be4e95c84b.gif)


