### PR TITLE
Changed periods in the script templates

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -61,7 +61,7 @@ Ref<Script> GDScriptLanguage::get_template(const String &p_class_name, const Str
 					   "# var b = \"textvar\"\n\n" +
 					   "func _ready():\n" +
 					   "%TS%# Called when the node is added to the scene for the first time.\n" +
-					   "%TS%# Initialization here\n" +
+					   "%TS%# Initialization here.\n" +
 					   "%TS%pass\n\n" +
 					   "#func _process(delta):\n" +
 					   "#%TS%# Called every frame. Delta is time since last frame.\n" +

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -305,7 +305,7 @@ Ref<Script> CSharpLanguage::get_template(const String &p_class_name, const Strin
 							 "    public override void _Ready()\n"
 							 "    {\n"
 							 "        // Called every time the node is added to the scene.\n"
-							 "        // Initialization here\n"
+							 "        // Initialization here.\n"
 							 "        \n"
 							 "    }\n"
 							 "\n"


### PR DESCRIPTION
Comments in the docs don't end with a period, unless it's to start another phrase. Made so that the script templates follow suit, which also makes them consistent with the comments right above them.

Also, clang-format requested to add a tab to a comment in the script.

**EDIT**: Nevermind, I guess something is up to the clang-format in my end then.