### PR TITLE
Fixed deleting an animation marked to autoplay in the editor affecting the creation of one with the same name

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -459,6 +459,12 @@ void AnimationPlayerEditor::_animation_remove_confirmed() {
 	Ref<Animation> anim = player->get_animation(current);
 
 	undo_redo->create_action(TTR("Remove Animation"));
+	if (player->get_autoplay() == current) {
+		undo_redo->add_do_method(player, "set_autoplay", "");
+		undo_redo->add_undo_method(player, "set_autoplay", current);
+		// Avoid having the autoplay icon linger around if there is only one animation in the player
+		undo_redo->add_do_method(this, "_animation_player_changed", player);
+	}
 	undo_redo->add_do_method(player, "remove_animation", current);
 	undo_redo->add_undo_method(player, "add_animation", current, anim);
 	undo_redo->add_do_method(this, "_animation_player_changed", player);

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -828,6 +828,7 @@ void AnimationPlayerEditor::_update_player() {
 	save_anim->set_disabled(animlist.size() == 0);
 	tool_anim->set_disabled(player == NULL);
 	onion_skinning->set_disabled(player == NULL);
+	pin->set_disabled(player == NULL);
 
 	int active_idx = -1;
 	for (List<StringName>::Element *E = animlist.front(); E; E = E->next()) {


### PR DESCRIPTION
Fixes #18064.

Also, removing an animation marked to autoplay via script still leaves it as it is. As I don't know if this is intended behavior or not.

One small addition; made the pin button be disabled when no AnimationPlayer is selected. Forgot to change that in my other commit.