### PR TITLE
[WIP] Added tabs with short and full descriptions to node creation dialog.

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -231,6 +231,8 @@ void CreateDialog::_update_search() {
 	favorite->set_disabled(true);
 
 	help_bit->set_text("");
+	help_full_bit->set_text("");
+
 	/*
 	TreeItem *root = search_options->create_item();
 	_parse_fs(EditorFileSystem::get_singleton()->get_filesystem());
@@ -457,6 +459,7 @@ void CreateDialog::_item_selected() {
 		return;
 
 	help_bit->set_text(EditorHelp::get_doc_data()->class_list[name].brief_description);
+	help_full_bit->set_text(EditorHelp::get_doc_data()->class_list[name].description);
 
 	get_ok()->set_disabled(false);
 }
@@ -696,7 +699,23 @@ CreateDialog::CreateDialog() {
 	base_type = "Object";
 	preferred_search_result_type = "";
 
+	TabContainer *tbc = memnew(TabContainer);
+	tbc->set_h_size_flags(SIZE_EXPAND_FILL);
+	tbc->set_tab_align(TabContainer::TabAlign::ALIGN_LEFT);
+	tbc->set_custom_minimum_size(Size2(0, 150 * EDSCALE));
+	vbc->add_child(tbc);
+
+	Tabs *desc_tab = memnew(Tabs);
+	desc_tab->set_name(TTR("Brief Description:"));
 	help_bit = memnew(EditorHelpBit);
-	vbc->add_margin_child(TTR("Description:"), help_bit);
+	desc_tab->add_child(help_bit);
 	help_bit->connect("request_hide", this, "_closed");
+	tbc->add_child(desc_tab);
+
+	Tabs *full_desc_tab = memnew(Tabs);
+	full_desc_tab->set_name(TTR("Description:"));
+	help_full_bit = memnew(EditorHelpBit);
+	full_desc_tab->add_child(help_full_bit);
+	help_full_bit->connect("request_hide", this, "_closed");
+	tbc->add_child(full_desc_tab);
 }

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -57,6 +57,7 @@ class CreateDialog : public ConfirmationDialog {
 	String base_type;
 	String preferred_search_result_type;
 	EditorHelpBit *help_bit;
+	EditorHelpBit *help_full_bit;
 	List<StringName> type_list;
 
 	void _item_selected();

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1958,9 +1958,9 @@ EditorHelpBit::EditorHelpBit() {
 
 	rich_text = memnew(RichTextLabel);
 	add_child(rich_text);
+	set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	rich_text->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	rich_text->connect("meta_clicked", this, "_meta_clicked");
 	rich_text->add_color_override("selection_color", get_color("text_editor/theme/selection_color", "Editor"));
 	rich_text->set_override_selected_font_color(false);
-	set_custom_minimum_size(Size2(0, 70 * EDSCALE));
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3036176/39300558-c749220e-4954-11e8-9ce1-e341166b935c.png)

Watch video demo here -
https://www.youtube.com/watch?v=EoVYMmHxT3o

(I used clang-format but for some reason travis failed to build)