### PR TITLE
Add a ToggleButton for alphabetic sorting in methods overview

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -382,6 +382,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/files/trim_trailing_whitespace_on_save", false);
 	_initial_set("text_editor/completion/idle_parse_delay", 2);
 	_initial_set("text_editor/tools/create_signal_callbacks", true);
+	_initial_set("text_editor/tools/sort_members_outline_alphabetically", false);
 	_initial_set("text_editor/files/autosave_interval_secs", 0);
 
 	_initial_set("text_editor/cursor/block_caret", false);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -199,6 +199,9 @@ class ScriptEditor : public PanelContainer {
 	ItemList *script_list;
 	HSplitContainer *script_split;
 	ItemList *members_overview;
+	VBoxContainer *members_overview_vbox;
+	HBoxContainer *members_overview_buttons_hbox;
+	ToolButton *members_overview_alphabeta_sort_button;
 	bool members_overview_enabled;
 	ItemList *help_overview;
 	bool help_overview_enabled;
@@ -318,6 +321,7 @@ class ScriptEditor : public PanelContainer {
 
 	void _update_members_overview_visibility();
 	void _update_members_overview();
+	void _toggle_members_overview_alpha_sort(bool p_alphabetic_sort);
 	void _update_script_names();
 	bool _sort_list_on_update;
 


### PR DESCRIPTION
This commit adds an HBox above methods overview in Script editor. In it, I added a ToolButton that toggles alphabetic sorting on the methods list.

Some precisions: I used Vector's default sort() that sorts functions this way:

```
_bar()
_bbar()
_ffoo()
_foo()
_ready()
bar()
bbar()
ffoo()
foo()
```

One can probably improve this with a custom sort that doesn't take leading '_' into account, or even better create another button for this purpose. I personally like it this way.

_Bugsquad edit: closes #18461_