### PR TITLE
Check invalid node name

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -644,11 +644,12 @@ void SceneTreeEditor::_renamed() {
 	ERR_FAIL_COND(!n);
 
 	String new_name = which->get_text(0);
-	if (new_name.find(".") != -1 || new_name.find("/") != -1) {
+	if (!Node::_validate_node_name(new_name)) {
 
-		error->set_text(TTR("Invalid node name, the following characters are not allowed:") + "\n  \".\", \"/\"");
+		error->set_text(TTR("Invalid node name, the following characters are not allowed:") + "\n" + Node::invalid_character);
 		error->popup_centered_minsize();
-		new_name = n->get_name();
+
+		which->set_text(0, new_name);
 	}
 
 	if (new_name == n->get_name())

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -979,9 +979,23 @@ void Node::_set_name_nocheck(const StringName &p_name) {
 	data.name = p_name;
 }
 
+String Node::invalid_character = ". : @ / \"";
+
+bool Node::_validate_node_name(String &p_name) {
+	String name = p_name;
+	Vector<String> chars = Node::invalid_character.split(" ");
+	for (int i = 0; i < chars.size(); i++) {
+		name = name.replace(chars[i], "");
+	}
+	bool is_valid = name == p_name;
+	p_name = name;
+	return is_valid;
+}
+
 void Node::set_name(const String &p_name) {
 
-	String name = p_name.replace(":", "").replace("/", "").replace("@", "");
+	String name = p_name;
+	_validate_node_name(name);
 
 	ERR_FAIL_COND(name == "");
 	data.name = name;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -190,6 +190,12 @@ private:
 
 	void _set_tree(SceneTree *p_tree);
 
+#ifdef TOOLS_ENABLED
+	friend class SceneTreeEditor;
+#endif
+	static String invalid_character;
+	static bool _validate_node_name(String &p_name);
+
 protected:
 	void _block() { data.blocked++; }
 	void _unblock() { data.blocked--; }


### PR DESCRIPTION
Fix #18448

if we don't strip out the invalid letter after renaming node,
we can still save a scene with the invalid letter for a node name.