### PR TITLE
Fix enums without class name not opening docs page

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2641,6 +2641,18 @@ Error GDScriptLanguage::lookup_code(const String &p_code, const String &p_symbol
 	context.function = p.get_completion_function();
 	context.base = p_owner;
 	context.base_path = p_base_path;
+
+	if (context._class && context._class->extends_class.size() > 0) {
+		bool success = false;
+		ClassDB::get_integer_constant(context._class->extends_class[0], p_symbol, &success);
+		if (success) {
+			r_result.type = ScriptLanguage::LookupResult::RESULT_CLASS_CONSTANT;
+			r_result.class_name = context._class->extends_class[0];
+			r_result.class_member = p_symbol;
+			return OK;
+		}
+	}
+
 	bool isfunction = false;
 
 	switch (p.get_completion_type()) {


### PR DESCRIPTION
Fixes #17957

Ctrl+Click on an Enum in the script editor without a class name now opens the appropriate documentation, as opposed to ignoring the click.

Feedback welcome!