### PR TITLE
Allows setting the Timer wait_time in start method.

### DIFF
--- a/doc/classes/Timer.xml
+++ b/doc/classes/Timer.xml
@@ -21,8 +21,10 @@
 		<method name="start">
 			<return type="void">
 			</return>
+			<argument index="0" name="time_sec" type="float" default="-1">
+			</argument>
 			<description>
-				Starts the timer. This also resets the remaining time to [code]wait_time[/code].
+				Starts the timer. Sets [code]wait_time[/code] to [code]time_sec[/code] if [code]time_sec[/code] > 0. This also resets the remaining time to [code]wait_time[/code].
 				Note: this method will not resume a paused timer. See [method set_paused].
 			</description>
 		</method>

--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -107,7 +107,10 @@ bool Timer::has_autostart() const {
 	return autostart;
 }
 
-void Timer::start() {
+void Timer::start(float p_time) {
+	if (p_time > 0) {
+		set_wait_time(p_time);
+	}
 	time_left = wait_time;
 	_set_process(true);
 }
@@ -185,7 +188,7 @@ void Timer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_autostart", "enable"), &Timer::set_autostart);
 	ClassDB::bind_method(D_METHOD("has_autostart"), &Timer::has_autostart);
 
-	ClassDB::bind_method(D_METHOD("start"), &Timer::start);
+	ClassDB::bind_method(D_METHOD("start", "time_sec"), &Timer::start, DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("stop"), &Timer::stop);
 
 	ClassDB::bind_method(D_METHOD("set_paused", "paused"), &Timer::set_paused);

--- a/scene/main/timer.h
+++ b/scene/main/timer.h
@@ -64,7 +64,7 @@ public:
 	void set_autostart(bool p_start);
 	bool has_autostart() const;
 
-	void start();
+	void start(float p_time = -1);
 	void stop();
 
 	void set_paused(bool p_paused);


### PR DESCRIPTION
Allows shortening the two line method of Timer.set_wait_time
followed by Timer.start set wait_time as a parameter to
Timer.start. Also modifies the class documentation.

Fixes: #18107