### PR TITLE
Make 'Export PCK/ZIP' work well with EditorExportPlugin

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -911,6 +911,16 @@ Error EditorExportPlatform::save_zip(const Ref<EditorExportPreset> &p_preset, co
 	return OK;
 }
 
+Error EditorExportPlatform::export_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {
+	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
+	return save_pack(p_preset, p_path);
+}
+
+Error EditorExportPlatform::export_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {
+	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
+	return save_zip(p_preset, p_path);
+}
+
 void EditorExportPlatform::gen_export_flags(Vector<String> &r_flags, int p_flags) {
 
 	String host = EditorSettings::get_singleton()->get("network/debug/remote_host");

--- a/editor/editor_export.h
+++ b/editor/editor_export.h
@@ -243,6 +243,8 @@ public:
 
 	virtual String get_binary_extension(const Ref<EditorExportPreset> &p_preset) const = 0;
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) = 0;
+	virtual Error export_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0);
+	virtual Error export_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0);
 	virtual void get_platform_features(List<String> *r_features) = 0;
 
 	EditorExportPlatform();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -483,12 +483,12 @@ void EditorNode::_fs_changed() {
 				Error err;
 				if (!preset->is_runnable() && (export_defer.path.ends_with(".pck") || export_defer.path.ends_with(".zip"))) {
 					if (export_defer.path.ends_with(".zip")) {
-						err = platform->save_zip(preset, export_defer.path);
+						err = platform->export_zip(preset, export_defer.debug, export_defer.path);
 					} else if (export_defer.path.ends_with(".pck")) {
-						err = platform->save_pack(preset, export_defer.path);
+						err = platform->export_pack(preset, export_defer.debug, export_defer.path);
 					}
 				} else {
-					err = platform->export_project(preset, export_defer.debug, export_defer.path, /*p_flags*/ 0);
+					err = platform->export_project(preset, export_defer.debug, export_defer.path);
 				}
 				if (err != OK) {
 					ERR_PRINTS(vformat(TTR("Project export failed with error code %d."), (int)err));

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -703,9 +703,9 @@ void ProjectExportDialog::_export_pck_zip_selected(const String &p_path) {
 	ERR_FAIL_COND(platform.is_null());
 
 	if (p_path.ends_with(".zip")) {
-		platform->save_zip(current, p_path);
+		platform->export_zip(current, export_pck_zip_debug->is_pressed(), p_path);
 	} else if (p_path.ends_with(".pck")) {
-		platform->save_pack(current, p_path);
+		platform->export_pack(current, export_pck_zip_debug->is_pressed(), p_path);
 	}
 }
 
@@ -980,6 +980,11 @@ ProjectExportDialog::ProjectExportDialog() {
 	export_debug->set_text(TTR("Export With Debug"));
 	export_debug->set_pressed(true);
 	export_project->get_vbox()->add_child(export_debug);
+
+	export_pck_zip_debug = memnew(CheckButton);
+	export_pck_zip_debug->set_text(TTR("Export With Debug"));
+	export_pck_zip_debug->set_pressed(true);
+	export_pck_zip->get_vbox()->add_child(export_pck_zip_debug);
 
 	set_hide_on_ok(false);
 

--- a/editor/project_export.h
+++ b/editor/project_export.h
@@ -131,6 +131,7 @@ private:
 	FileDialog *export_pck_zip;
 	FileDialog *export_project;
 	CheckButton *export_debug;
+	CheckButton *export_pck_zip_debug;
 
 	void _open_export_template_manager();
 

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1323,6 +1323,8 @@ public:
 
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) {
 
+		ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
+
 		String src_apk;
 
 		EditorProgress ep("export", "Exporting for Android", 105);


### PR DESCRIPTION
Fixed `EditorExportPlugin::_export_begin` notification not being called when exporting to android.

Made '_Export PCK/ZIP_' notify when the export process begins, which is needed to receive the `EditorExportPlugin::_export_begin` callback.

Added a debug flag to the '_Export PCK/ZIP_' option. It's the same checkbox as in the '_Export Project_' dialog.

![screenshot](https://user-images.githubusercontent.com/7718100/39332478-d677d0e2-49a7-11e8-9da5-b64f9ab88085.png)

This feature is needed for the mono module to determine the _Configuration_ to build the project with. It may be useful for other languages as well.
