### PR TITLE
Added more invalid characters removed by set_name.

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -981,7 +981,7 @@ void Node::_set_name_nocheck(const StringName &p_name) {
 
 void Node::set_name(const String &p_name) {
 
-	String name = p_name.replace(":", "").replace("/", "").replace("@", "");
+	String name = p_name.replace(":", "").replace("/", "").replace("@", "").replace("\"", "").replace(".", "");
 
 	ERR_FAIL_COND(name == "");
 	data.name = name;


### PR DESCRIPTION
Certain characters which cause problems are taken care of when renamed
in the editor and this commit adds the validation into the set_node
method itself. The referred PR also needs to be merged along with this.

Partially Fixes: #18448
See also: #18451