### PR TITLE
Numerous changes to the Animation Editor

### DIFF
--- a/editor/animation_editor.cpp
+++ b/editor/animation_editor.cpp
@@ -1076,6 +1076,9 @@ void AnimationKeyEditor::_track_editor_draw() {
 	if (!animation.is_valid()) {
 		v_scroll->hide();
 		h_scroll->hide();
+		length->set_editable(false);
+		step->set_editable(false);
+		loop->set_disabled(true);
 		menu_add_track->set_disabled(true);
 		menu_track->set_disabled(true);
 		edit_button->set_disabled(true);
@@ -1087,6 +1090,9 @@ void AnimationKeyEditor::_track_editor_draw() {
 		return;
 	}
 
+	length->set_editable(true);
+	step->set_editable(true);
+	loop->set_disabled(false);
 	menu_add_track->set_disabled(false);
 	menu_track->set_disabled(false);
 	edit_button->set_disabled(false);
@@ -3856,6 +3862,7 @@ AnimationKeyEditor::AnimationKeyEditor() {
 	length->set_h_size_flags(SIZE_EXPAND_FILL);
 	length->set_stretch_ratio(1);
 	length->set_tooltip(TTR("Animation length (in seconds)."));
+	length->set_editable(false);
 
 	hb->add_child(length);
 	length->connect("value_changed", this, "_animation_len_changed");
@@ -3872,6 +3879,7 @@ AnimationKeyEditor::AnimationKeyEditor() {
 	step->set_h_size_flags(SIZE_EXPAND_FILL);
 	step->set_stretch_ratio(1);
 	step->set_tooltip(TTR("Cursor step snap (in seconds)."));
+	step->set_editable(false);
 
 	hb->add_child(step);
 	step->connect("value_changed", this, "_step_changed");
@@ -3881,6 +3889,7 @@ AnimationKeyEditor::AnimationKeyEditor() {
 	loop->connect("pressed", this, "_animation_loop_changed");
 	hb->add_child(loop);
 	loop->set_tooltip(TTR("Enable/Disable looping in animation."));
+	loop->set_disabled(true);
 
 	hb->add_child(memnew(VSeparator));
 
@@ -3918,7 +3927,7 @@ AnimationKeyEditor::AnimationKeyEditor() {
 	menu_track = memnew(MenuButton);
 	hb->add_child(menu_track);
 	menu_track->get_popup()->connect("id_pressed", this, "_menu_track");
-	menu_track->set_tooltip(TTR("Track tools"));
+	menu_track->set_tooltip(TTR("Track Tools"));
 
 	edit_button = memnew(ToolButton);
 	edit_button->set_toggle_mode(true);

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -491,7 +491,7 @@ void AnimationPlayerEditor::_animation_name_edited() {
 
 	String new_name = name->get_text();
 	if (new_name == "" || new_name.find(":") != -1 || new_name.find("/") != -1) {
-		error_dialog->set_text(TTR("ERROR: Invalid animation name!"));
+		error_dialog->set_text(TTR("Invalid animation name!"));
 		error_dialog->popup_centered_minsize();
 		return;
 	}
@@ -502,7 +502,7 @@ void AnimationPlayerEditor::_animation_name_edited() {
 	}
 
 	if (player->has_animation(new_name)) {
-		error_dialog->set_text(TTR("ERROR: Animation name already exists!"));
+		error_dialog->set_text(TTR("Animation name already exists!"));
 		error_dialog->popup_centered_minsize();
 		return;
 	}
@@ -811,6 +811,8 @@ void AnimationPlayerEditor::_update_player() {
 	play_bw->set_disabled(animlist.size() == 0);
 	play_bw_from->set_disabled(animlist.size() == 0);
 	play_from->set_disabled(animlist.size() == 0);
+	frame->set_editable(animlist.size() != 0);
+	animation->set_disabled(animlist.size() == 0);
 	autoplay->set_disabled(animlist.size() == 0);
 	duplicate_anim->set_disabled(animlist.size() == 0);
 	rename_anim->set_disabled(animlist.size() == 0);
@@ -1088,7 +1090,7 @@ void AnimationPlayerEditor::_animation_tool_menu(int p_option) {
 		case TOOL_COPY_ANIM: {
 
 			if (!animation->get_item_count()) {
-				error_dialog->set_text(TTR("ERROR: No animation to copy!"));
+				error_dialog->set_text(TTR("No animation to copy!"));
 				error_dialog->popup_centered_minsize();
 				return;
 			}
@@ -1103,7 +1105,7 @@ void AnimationPlayerEditor::_animation_tool_menu(int p_option) {
 
 			Ref<Animation> anim = EditorSettings::get_singleton()->get_resource_clipboard();
 			if (!anim.is_valid()) {
-				error_dialog->set_text(TTR("ERROR: No animation resource on clipboard!"));
+				error_dialog->set_text(TTR("No animation resource on clipboard!"));
 				error_dialog->popup_centered_minsize();
 				return;
 			}
@@ -1134,7 +1136,7 @@ void AnimationPlayerEditor::_animation_tool_menu(int p_option) {
 		case TOOL_EDIT_RESOURCE: {
 
 			if (!animation->get_item_count()) {
-				error_dialog->set_text(TTR("ERROR: No animation to edit!"));
+				error_dialog->set_text(TTR("No animation to edit!"));
 				error_dialog->popup_centered_minsize();
 				return;
 			}
@@ -1611,7 +1613,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 	hb->add_child(load_anim);
 
 	save_anim = memnew(MenuButton);
-	save_anim->set_tooltip(TTR("Save the current animation"));
+	save_anim->set_tooltip(TTR("Save the current animation."));
 	save_anim->get_popup()->add_shortcut(ED_SHORTCUT("animation_player_editor/save", TTR("Save")), ANIM_SAVE);
 	save_anim->get_popup()->add_shortcut(ED_SHORTCUT("animation_player_editor/save_as", TTR("Save As")), ANIM_SAVE_AS);
 	save_anim->set_focus_mode(Control::FOCUS_NONE);
@@ -1691,6 +1693,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 
 	pin = memnew(ToolButton);
 	pin->set_toggle_mode(true);
+	pin->set_tooltip(TTR("Pin AnimationPlayer"));
 	hb->add_child(pin);
 
 	resource_edit_anim = memnew(Button);
@@ -1718,7 +1721,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 
 	error_dialog = memnew(ConfirmationDialog);
 	error_dialog->get_ok()->set_text(TTR("Close"));
-	error_dialog->set_text(TTR("Error!"));
+	error_dialog->set_title(TTR("Error!"));
 	add_child(error_dialog);
 
 	name_dialog->connect("confirmed", this, "_animation_name_edited");


### PR DESCRIPTION
- Made more components that where useless when no animation was present to be disabled as well.
- Made the error dialog have "Error!" in its title, and removed the "ERROR:" from the texts.
- Gave the pin button a tooltip.