### PR TITLE
Added custom aabb to primitives

### DIFF
--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -166,7 +166,11 @@ void PrimitiveMesh::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_mesh_arrays"), &PrimitiveMesh::get_mesh_arrays);
 
+	ClassDB::bind_method(D_METHOD("set_custom_aabb", "aabb"), &PrimitiveMesh::set_custom_aabb);
+	ClassDB::bind_method(D_METHOD("get_custom_aabb"), &PrimitiveMesh::get_custom_aabb);
+
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "SpatialMaterial,ShaderMaterial"), "set_material", "get_material");
+	ADD_PROPERTY(PropertyInfo(Variant::AABB, "custom_aabb", PROPERTY_HINT_NONE, ""), "set_custom_aabb", "get_custom_aabb");
 }
 
 void PrimitiveMesh::set_material(const Ref<Material> &p_material) {
@@ -185,6 +189,18 @@ Ref<Material> PrimitiveMesh::get_material() const {
 
 Array PrimitiveMesh::get_mesh_arrays() const {
 	return surface_get_arrays(0);
+}
+
+void PrimitiveMesh::set_custom_aabb(const AABB &p_custom) {
+
+	custom_aabb = p_custom;
+	VS::get_singleton()->mesh_set_custom_aabb(mesh, custom_aabb);
+	emit_changed();
+}
+
+AABB PrimitiveMesh::get_custom_aabb() const {
+
+	return custom_aabb;
 }
 
 PrimitiveMesh::PrimitiveMesh() {

--- a/scene/resources/primitive_meshes.h
+++ b/scene/resources/primitive_meshes.h
@@ -48,6 +48,7 @@ class PrimitiveMesh : public Mesh {
 private:
 	RID mesh;
 	mutable AABB aabb;
+	AABB custom_aabb;
 
 	Ref<Material> material;
 
@@ -80,6 +81,9 @@ public:
 	Ref<Material> get_material() const;
 
 	Array get_mesh_arrays() const;
+
+	void set_custom_aabb(const AABB &p_custom);
+	AABB get_custom_aabb() const;
 
 	PrimitiveMesh();
 	~PrimitiveMesh();


### PR DESCRIPTION
Ran into this when building my terrain editor. 

When you modify the vertices in a vertex shader its likely the mesh extends out of the default bounding box that is created by the primitive shape. That can result in the mesh being culled. 

Adding a custom aabb property similar to that found on the array mesh allows you to override the default aabb to something more suitable.

(would be nice if this gets cherry picked for 3.0.3)