### PR TITLE
Fix shared lib loading for Unix, dlopen expects leading ./ for relative paths.

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -349,6 +349,12 @@ Error OS_Unix::open_dynamic_library(const String p_path, void *&p_library_handle
 
 	String path = p_path;
 
+	if (FileAccess::exists(path) && path.is_rel_path()) {
+		// dlopen expects a slash, in this case a leading ./ for it to be interpreted as a relative path,
+		//  otherwise it will end up searching various system directories for the lib instead and finally failing.
+		path = "./" + path;
+	}
+
 	if (!FileAccess::exists(path)) {
 		//this code exists so gdnative can load .so files from within the executable path
 		path = get_executable_path().get_base_dir().plus_file(p_path.get_file());


### PR DESCRIPTION
So exporting projects with GDNative libs on Unix systems wasn't working so well (if the current working directory was alongside the actual binary, `dlopen` was given just the filename)

With some confusion as to why `dlopen` wasn't loading the lib when given just the name, quickly reading the manpage gave me this snippet:
```
If filename is NULL, then the returned handle is for the main program. 
If filename contains a slash ("/"), then it is interpreted as a (relative or absolute) pathname.
Otherwise, the dynamic linker searches for the object as follows (see ld.so(8)  for  further details):
```

So since the filename in this case was just `some_library.so`, `dlopen` happily searched everywhere but alongside the actual binary.

Which gave me some clarity in why GDNative wasn't loading shared libs that definitely sat alongside the binary when exported, so this is the fix.

I've tested it on a rudimentary project of my own, but there shouldn't be anything strange here.