### PR TITLE
Remove unused Variant._data.RefPtr

### DIFF
--- a/core/variant.h
+++ b/core/variant.h
@@ -140,7 +140,6 @@ private:
 		::AABB *_aabb;
 		Basis *_basis;
 		Transform *_transform;
-		RefPtr *_resource;
 		void *_ptr; //generic pointer
 		uint8_t _mem[sizeof(ObjData) > (sizeof(real_t) * 4) ? sizeof(ObjData) : (sizeof(real_t) * 4)];
 	} _data;


### PR DESCRIPTION
I've realized this union item is never used. Beside it can puzzle people given `Variant` already has the `ObjData` structure which deal with `RefPtr`&`Object*`.