### PR TITLE
assembly_load_hook fallback for registering GDMonoAssemblies.

### DIFF
--- a/modules/mono/mono_gd/gd_mono_assembly.h
+++ b/modules/mono/mono_gd/gd_mono_assembly.h
@@ -91,6 +91,7 @@ class GDMonoAssembly {
 	static bool no_search;
 	static Vector<String> search_dirs;
 
+	static void assembly_load_hook(MonoAssembly *assembly, void *user_data);
 	static MonoAssembly *assembly_search_hook(MonoAssemblyName *aname, void *user_data);
 	static MonoAssembly *assembly_refonly_search_hook(MonoAssemblyName *aname, void *user_data);
 	static MonoAssembly *assembly_preload_hook(MonoAssemblyName *aname, char **assemblies_path, void *user_data);
@@ -100,6 +101,7 @@ class GDMonoAssembly {
 	static MonoAssembly *_preload_hook(MonoAssemblyName *aname, char **assemblies_path, void *user_data, bool refonly);
 
 	static GDMonoAssembly *_load_assembly_from(const String &p_name, const String &p_path, bool p_refonly);
+	static void _wrap_mono_assembly(MonoAssembly *assembly);
 
 	friend class GDMono;
 	static void initialize();


### PR DESCRIPTION
Fixes #18029.

There are ways to load assemblies that the search hook has no way of intercepting and handling itself. Such as loading from a `byte[]` in C# code.

We now handle these cases with a fallback assembly_load_hook, to avoid crashes when this is indeed done.

Current Problem:
* Neikeq hit a freeze he'll investigate.
* ~~There seems to be a crash when shutting the engine down~~ fixed:

<details/>
  <summary>The crash</summary>

```
Native stacktrace:

        0   libmonosgen-2.0.1.dylib             0x000000010f81f27a mono_handle_native_crash + 242
        1   libmonosgen-2.0.1.dylib             0x000000010f87e3b7 altstack_handle_and_restore + 70
        2   libmonosgen-2.0.1.dylib             0x000000010f9c0a61 monoeg_g_str_hash + 4
        3   libmonosgen-2.0.1.dylib             0x000000010f9c01c2 monoeg_g_hash_table_lookup_extended + 47
        4   libmonosgen-2.0.1.dylib             0x000000010f9c0181 monoeg_g_hash_table_lookup + 25
        5   libmonosgen-2.0.1.dylib             0x000000010f8c9d8e mono_image_close_except_pools + 296
        6   libmonosgen-2.0.1.dylib             0x000000010f89805e mono_assembly_close_except_image_pools + 239
        7   libmonosgen-2.0.1.dylib             0x000000010f93a3ac mono_domain_free + 579
        8   libmonosgen-2.0.1.dylib             0x000000010f9381e9 unload_thread_main + 768
        9   libmonosgen-2.0.1.dylib             0x000000010f917fe4 start_wrapper + 605
        10  libsystem_pthread.dylib             0x00007fff7fb2b661 _pthread_body + 340
        11  libsystem_pthread.dylib             0x00007fff7fb2b50d _pthread_body + 0
        12  libsystem_pthread.dylib             0x00007fff7fb2abf9 thread_start + 13
```
I was able to find a similar issue: #12142.
</details>


cc @neikeq 

