### PR TITLE
API hash fixes

### DIFF
--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -355,7 +355,7 @@ uint64_t ClassDB::get_api_hash(APIType p_api) {
 
 		ClassInfo *t = classes.getptr(E->get());
 		ERR_FAIL_COND_V(!t, 0);
-		if (t->api != p_api)
+		if (t->api != p_api || !t->exposed)
 			continue;
 		hash = hash_djb2_one_64(t->name.hash(), hash);
 		hash = hash_djb2_one_64(t->inherits.hash(), hash);

--- a/modules/visual_script/register_types.cpp
+++ b/modules/visual_script/register_types.cpp
@@ -112,7 +112,9 @@ void register_visual_script_types() {
 	register_visual_script_expression_node();
 
 #ifdef TOOLS_ENABLED
+	ClassDB::set_current_api(ClassDB::API_EDITOR);
 	ClassDB::register_class<_VisualScriptEditor>();
+	ClassDB::set_current_api(ClassDB::API_CORE);
 	vs_editor_singleton = memnew(_VisualScriptEditor);
 	Engine::get_singleton()->add_singleton(Engine::Singleton("VisualScriptEditor", _VisualScriptEditor::get_singleton()));
 

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -107,12 +107,12 @@ OccluderPolygon2D::~OccluderPolygon2D() {
 	VS::get_singleton()->free(occ_polygon);
 }
 
-#ifdef DEBUG_ENABLED
 void LightOccluder2D::_poly_changed() {
 
+#ifdef DEBUG_ENABLED
 	update();
-}
 #endif
+}
 
 void LightOccluder2D::_notification(int p_what) {
 
@@ -221,9 +221,7 @@ void LightOccluder2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_occluder_light_mask", "mask"), &LightOccluder2D::set_occluder_light_mask);
 	ClassDB::bind_method(D_METHOD("get_occluder_light_mask"), &LightOccluder2D::get_occluder_light_mask);
 
-#ifdef DEBUG_ENABLED
 	ClassDB::bind_method("_poly_changed", &LightOccluder2D::_poly_changed);
-#endif
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "occluder", PROPERTY_HINT_RESOURCE_TYPE, "OccluderPolygon2D"), "set_occluder_polygon", "get_occluder_polygon");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "light_mask", PROPERTY_HINT_LAYERS_2D_RENDER), "set_occluder_light_mask", "get_occluder_light_mask");

--- a/scene/2d/light_occluder_2d.h
+++ b/scene/2d/light_occluder_2d.h
@@ -78,9 +78,7 @@ class LightOccluder2D : public Node2D {
 	int mask;
 	Ref<OccluderPolygon2D> occluder_polygon;
 
-#ifdef DEBUG_ENABLED
 	void _poly_changed();
-#endif
 
 protected:
 	void _notification(int p_what);

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -430,10 +430,9 @@ Ref<SpatialGizmo> Spatial::get_gizmo() const {
 #endif
 }
 
-#ifdef TOOLS_ENABLED
-
 void Spatial::_update_gizmo() {
 
+#ifdef TOOLS_ENABLED
 	if (!is_inside_world())
 		return;
 	data.gizmo_dirty = false;
@@ -445,8 +444,10 @@ void Spatial::_update_gizmo() {
 				data.gizmo->clear();
 		}
 	}
+#endif
 }
 
+#ifdef TOOLS_ENABLED
 void Spatial::set_disable_gizmo(bool p_enabled) {
 
 	data.gizmo_disabled = p_enabled;
@@ -726,9 +727,7 @@ void Spatial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_set_as_toplevel"), &Spatial::is_set_as_toplevel);
 	ClassDB::bind_method(D_METHOD("get_world"), &Spatial::get_world);
 
-#ifdef TOOLS_ENABLED
 	ClassDB::bind_method(D_METHOD("_update_gizmo"), &Spatial::_update_gizmo);
-#endif
 
 	ClassDB::bind_method(D_METHOD("update_gizmo"), &Spatial::update_gizmo);
 	ClassDB::bind_method(D_METHOD("set_gizmo", "gizmo"), &Spatial::set_gizmo);
@@ -790,9 +789,7 @@ void Spatial::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "scale", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_scale", "get_scale");
 	ADD_GROUP("Visibility", "");
 	ADD_PROPERTYNO(PropertyInfo(Variant::BOOL, "visible"), "set_visible", "is_visible");
-#ifdef TOOLS_ENABLED
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "gizmo", PROPERTY_HINT_RESOURCE_TYPE, "SpatialGizmo", 0), "set_gizmo", "get_gizmo");
-#endif
 
 	ADD_SIGNAL(MethodInfo("visibility_changed"));
 }

--- a/scene/3d/spatial.h
+++ b/scene/3d/spatial.h
@@ -100,10 +100,8 @@ class Spatial : public Node {
 #endif
 
 	} data;
-#ifdef TOOLS_ENABLED
 
 	void _update_gizmo();
-#endif
 	void _notify_dirty();
 	void _propagate_transform_changed(Spatial *p_origin);
 

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1327,12 +1327,12 @@ PopupMenu *LineEdit::get_menu() const {
 	return menu;
 }
 
-#ifdef TOOLS_ENABLED
 void LineEdit::_editor_settings_changed() {
+#ifdef TOOLS_ENABLED
 	cursor_set_blink_enabled(EDITOR_DEF("text_editor/cursor/caret_blink", false));
 	cursor_set_blink_speed(EDITOR_DEF("text_editor/cursor/caret_blink_speed", 0.65));
-}
 #endif
+}
 
 void LineEdit::set_expand_to_text_length(bool p_enabled) {
 
@@ -1401,9 +1401,7 @@ void LineEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_text_changed"), &LineEdit::_text_changed);
 	ClassDB::bind_method(D_METHOD("_toggle_draw_caret"), &LineEdit::_toggle_draw_caret);
 
-#ifdef TOOLS_ENABLED
 	ClassDB::bind_method("_editor_settings_changed", &LineEdit::_editor_settings_changed);
-#endif
 
 	ClassDB::bind_method(D_METHOD("set_align", "align"), &LineEdit::set_align);
 	ClassDB::bind_method(D_METHOD("get_align"), &LineEdit::get_align);

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -134,9 +134,7 @@ private:
 	void clear_internal();
 	void changed_internal();
 
-#ifdef TOOLS_ENABLED
 	void _editor_settings_changed();
-#endif
 
 	void _gui_input(Ref<InputEvent> p_event);
 	void _notification(int p_what);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2567,18 +2567,21 @@ Array Node::_get_children() const {
 	return arr;
 }
 
-#ifdef TOOLS_ENABLED
 void Node::set_import_path(const NodePath &p_import_path) {
 
+#ifdef TOOLS_ENABLED
 	data.import_path = p_import_path;
+#endif
 }
 
 NodePath Node::get_import_path() const {
 
+#ifdef TOOLS_ENABLED
 	return data.import_path;
-}
-
+#else
+	return NodePath();
 #endif
+}
 
 static void _add_nodes_to_options(const Node *p_base, const Node *p_node, List<String> *r_options) {
 
@@ -2737,12 +2740,9 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("rpc_config", "method", "mode"), &Node::rpc_config);
 	ClassDB::bind_method(D_METHOD("rset_config", "property", "mode"), &Node::rset_config);
 
-#ifdef TOOLS_ENABLED
 	ClassDB::bind_method(D_METHOD("_set_import_path", "import_path"), &Node::set_import_path);
 	ClassDB::bind_method(D_METHOD("_get_import_path"), &Node::get_import_path);
 	ADD_PROPERTYNZ(PropertyInfo(Variant::NODE_PATH, "_import_path", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_set_import_path", "_get_import_path");
-
-#endif
 
 	{
 		MethodInfo mi;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -374,10 +374,8 @@ public:
 
 	void force_parent_owned() { data.parent_owned = true; } //hack to avoid duplicate nodes
 
-#ifdef TOOLS_ENABLED
 	void set_import_path(const NodePath &p_import_path); //path used when imported, used by scene editors to keep tracking
 	NodePath get_import_path() const;
-#endif
 
 	bool is_owned_by_parent() const;
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1197,16 +1197,20 @@ void SceneTree::set_screen_stretch(StretchMode p_mode, StretchAspect p_aspect, c
 	_update_root_rect();
 }
 
-#ifdef TOOLS_ENABLED
 void SceneTree::set_edited_scene_root(Node *p_node) {
+#ifdef TOOLS_ENABLED
 	edited_scene_root = p_node;
+#endif
 }
 
 Node *SceneTree::get_edited_scene_root() const {
 
+#ifdef TOOLS_ENABLED
 	return edited_scene_root;
-}
+#else
+	return NULL;
 #endif
+}
 
 void SceneTree::set_current_scene(Node *p_scene) {
 
@@ -1737,10 +1741,8 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_debug_navigation_hint", "enable"), &SceneTree::set_debug_navigation_hint);
 	ClassDB::bind_method(D_METHOD("is_debugging_navigation_hint"), &SceneTree::is_debugging_navigation_hint);
 
-#ifdef TOOLS_ENABLED
 	ClassDB::bind_method(D_METHOD("set_edited_scene_root", "scene"), &SceneTree::set_edited_scene_root);
 	ClassDB::bind_method(D_METHOD("get_edited_scene_root"), &SceneTree::get_edited_scene_root);
-#endif
 
 	ClassDB::bind_method(D_METHOD("set_pause", "enable"), &SceneTree::set_pause);
 	ClassDB::bind_method(D_METHOD("is_paused"), &SceneTree::is_paused);
@@ -1815,9 +1817,7 @@ void SceneTree::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "paused"), "set_pause", "is_paused");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "refuse_new_network_connections"), "set_refuse_new_network_connections", "is_refusing_new_network_connections");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_font_oversampling"), "set_use_font_oversampling", "is_using_font_oversampling");
-#ifdef TOOLS_ENABLED
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "edited_scene_root", PROPERTY_HINT_RESOURCE_TYPE, "Node", 0), "set_edited_scene_root", "get_edited_scene_root");
-#endif
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "current_scene", PROPERTY_HINT_RESOURCE_TYPE, "Node", 0), "set_current_scene", "get_current_scene");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "network_peer", PROPERTY_HINT_RESOURCE_TYPE, "NetworkedMultiplayerPeer", 0), "set_network_peer", "get_network_peer");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "root", PROPERTY_HINT_RESOURCE_TYPE, "Node", 0), "", "get_root");

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -390,10 +390,8 @@ public:
 	//void change_scene(const String& p_path);
 	//Node *get_loaded_scene();
 
-#ifdef TOOLS_ENABLED
 	void set_edited_scene_root(Node *p_node);
 	Node *get_edited_scene_root() const;
-#endif
 
 	void set_current_scene(Node *p_scene);
 	Node *get_current_scene() const;


### PR DESCRIPTION
Methods inside the core API must not be bound only with TOOLS_ENABLED. That breaks the API between the editor player and the exported player.
