### PR TITLE
Move things into the title bars of Visual Script nodes.

### DIFF
--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -121,6 +121,10 @@ Array VisualScriptNode::_get_default_input_values() const {
 	return default_input_values;
 }
 
+String VisualScriptNode::get_text() const {
+	return "";
+}
+
 void VisualScriptNode::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_visual_script"), &VisualScriptNode::get_visual_script);

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -78,7 +78,7 @@ public:
 	Variant get_default_input_value(int p_port) const;
 
 	virtual String get_caption() const = 0;
-	virtual String get_text() const = 0;
+	virtual String get_text() const;
 	virtual String get_category() const = 0;
 
 	//used by editor, this is not really saved

--- a/modules/visual_script/visual_script_builtin_funcs.cpp
+++ b/modules/visual_script/visual_script_builtin_funcs.cpp
@@ -666,12 +666,14 @@ PropertyInfo VisualScriptBuiltinFunc::get_output_value_port_info(int p_idx) cons
 	return PropertyInfo(t, "");
 }
 
+/*
 String VisualScriptBuiltinFunc::get_caption() const {
 
 	return "BuiltinFunc";
 }
+*/
 
-String VisualScriptBuiltinFunc::get_text() const {
+String VisualScriptBuiltinFunc::get_caption() const {
 
 	return func_name[func];
 }

--- a/modules/visual_script/visual_script_builtin_funcs.h
+++ b/modules/visual_script/visual_script_builtin_funcs.h
@@ -129,7 +129,7 @@ public:
 	virtual PropertyInfo get_output_value_port_info(int p_idx) const;
 
 	virtual String get_caption() const;
-	virtual String get_text() const;
+	//virtual String get_text() const;
 	virtual String get_category() const { return "functions"; }
 
 	void set_func(BuiltinFunc p_which);

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -527,6 +527,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 
 		GraphNode *gnode = memnew(GraphNode);
 		gnode->set_title(node->get_caption());
+		gnode->set_offset(pos * EDSCALE);
 		if (error_line == E->get()) {
 			gnode->set_overlay(GraphNode::OVERLAY_POSITION);
 		} else if (node->is_breakpoint()) {
@@ -543,8 +544,10 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 			gnode->set_show_close_button(true);
 		}
 
-		if (Object::cast_to<VisualScriptExpression>(node.ptr())) {
+		bool has_gnode_text = false;
 
+		if (Object::cast_to<VisualScriptExpression>(node.ptr())) {
+			has_gnode_text = true;
 			LineEdit *line_edit = memnew(LineEdit);
 			line_edit->set_text(node->get_text());
 			line_edit->set_expand_to_text_length(true);
@@ -552,9 +555,13 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 			gnode->add_child(line_edit);
 			line_edit->connect("text_changed", this, "_expression_text_changed", varray(E->get()));
 		} else {
-			Label *text = memnew(Label);
-			text->set_text(node->get_text());
-			gnode->add_child(text);
+			String text = node->get_text();
+			if (!text.empty()) {
+				has_gnode_text = true;
+				Label *label = memnew(Label);
+				label->set_text(text);
+				gnode->add_child(label);
+			}
 		}
 
 		if (Object::cast_to<VisualScriptComment>(node.ptr())) {
@@ -589,9 +596,21 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 		int slot_idx = 0;
 
 		bool single_seq_output = node->get_output_sequence_port_count() == 1 && node->get_output_sequence_port_text(0) == String();
-		gnode->set_slot(0, node->has_input_sequence_port(), TYPE_SEQUENCE, mono_color, single_seq_output, TYPE_SEQUENCE, mono_color, seq_port, seq_port);
-		gnode->set_offset(pos * EDSCALE);
-		slot_idx++;
+		if ((node->has_input_sequence_port() || single_seq_output) || has_gnode_text) {
+			// IF has_gnode_text is true BUT we have no sequence ports to draw (in here),
+			// we still draw the disabled default ones to shift up the slots by one,
+			// so the slots DON'T start with the content text.
+
+			// IF has_gnode_text is false, but we DO want to draw default sequence ports,
+			// we draw a dummy text to take up the position of the sequence nodes, so all the other ports are still aligned correctly.
+			if (!has_gnode_text) {
+				Label *dummy = memnew(Label);
+				dummy->set_text(" ");
+				gnode->add_child(dummy);
+			}
+			gnode->set_slot(0, node->has_input_sequence_port(), TYPE_SEQUENCE, mono_color, single_seq_output, TYPE_SEQUENCE, mono_color, seq_port, seq_port);
+			slot_idx++;
+		}
 
 		int mixed_seq_ports = 0;
 

--- a/modules/visual_script/visual_script_flow_control.cpp
+++ b/modules/visual_script/visual_script_flow_control.cpp
@@ -772,7 +772,7 @@ PropertyInfo VisualScriptTypeCast::get_output_value_port_info(int p_idx) const {
 
 String VisualScriptTypeCast::get_caption() const {
 
-	return "TypeCast";
+	return "Type Cast";
 }
 
 String VisualScriptTypeCast::get_text() const {

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -1063,36 +1063,31 @@ PropertyInfo VisualScriptPropertySet::get_output_value_port_info(int p_idx) cons
 
 String VisualScriptPropertySet::get_caption() const {
 
-	static const char *cname[4] = {
-		"Self",
-		"Node",
-		"Instance",
-		"Basic"
+	static const char *opname[ASSIGN_OP_MAX] = {
+		"Set", "Add", "Subtract", "Multiply", "Divide", "Mod", "ShiftLeft", "ShiftRight", "BitAnd", "BitOr", "BitXor"
 	};
 
-	static const char *opname[ASSIGN_OP_MAX] = {
-		"Set", "Add", "Sub", "Mul", "Div", "Mod", "ShiftLeft", "ShiftRight", "BitAnd", "BitOr", "BitXor"
-	};
-	return String(cname[call_mode]) + opname[assign_op];
+	String prop = String(opname[assign_op]) + " " + property;
+	if (index != StringName()) {
+		prop += "." + String(index);
+	}
+
+	return prop;
 }
 
 String VisualScriptPropertySet::get_text() const {
 
-	String prop;
-
-	if (call_mode == CALL_MODE_BASIC_TYPE)
-		prop = Variant::get_type_name(basic_type) + "." + property;
-	else if (call_mode == CALL_MODE_NODE_PATH)
-		prop = String(base_path) + ":" + property;
-	else if (call_mode == CALL_MODE_SELF)
-		prop = property;
-	else if (call_mode == CALL_MODE_INSTANCE)
-		prop = String(base_type) + ":" + property;
-
-	if (index != StringName()) {
-		prop += "." + String(index);
+	if (call_mode == CALL_MODE_BASIC_TYPE) {
+		return String("On ") + Variant::get_type_name(basic_type);
 	}
-	return prop;
+
+	static const char *cname[3] = {
+		"Self",
+		"Scene Node",
+		"Instance"
+	};
+
+	return String("On ") + cname[call_mode];
 }
 
 void VisualScriptPropertySet::_update_base_type() {
@@ -1826,30 +1821,22 @@ PropertyInfo VisualScriptPropertyGet::get_output_value_port_info(int p_idx) cons
 
 String VisualScriptPropertyGet::get_caption() const {
 
-	static const char *cname[4] = {
-		"SelfGet",
-		"NodeGet",
-		"InstanceGet",
-		"BasicGet"
-	};
-
-	return cname[call_mode];
+	return String("Get ") + property;
 }
 
 String VisualScriptPropertyGet::get_text() const {
 
-	String prop;
+	if (call_mode == CALL_MODE_BASIC_TYPE) {
+		return String("On ") + Variant::get_type_name(basic_type);
+	}
 
-	if (call_mode == CALL_MODE_BASIC_TYPE)
-		prop = Variant::get_type_name(basic_type) + "." + property;
-	else if (call_mode == CALL_MODE_NODE_PATH)
-		prop = String(base_path) + ":" + property;
-	else if (call_mode == CALL_MODE_SELF)
-		prop = property;
-	else if (call_mode == CALL_MODE_INSTANCE)
-		prop = String(base_type) + ":" + property;
+	static const char *cname[3] = {
+		"Self",
+		"Scene Node",
+		"Instance"
+	};
 
-	return prop;
+	return String("On ") + cname[call_mode];
 }
 
 void VisualScriptPropertyGet::set_base_type(const StringName &p_type) {
@@ -2385,16 +2372,9 @@ PropertyInfo VisualScriptEmitSignal::get_output_value_port_info(int p_idx) const
 	return PropertyInfo();
 }
 
-/*
 String VisualScriptEmitSignal::get_caption() const {
 
-	return "EmitSignal";
-}
-*/
-
-String VisualScriptEmitSignal::get_caption() const {
-
-	return "emit " + String(name);
+	return "Emit " + String(name);
 }
 
 void VisualScriptEmitSignal::set_signal(const StringName &p_type) {

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -262,26 +262,6 @@ PropertyInfo VisualScriptFunctionCall::get_output_value_port_info(int p_idx) con
 }
 
 String VisualScriptFunctionCall::get_caption() const {
-
-	static const char *cname[5] = {
-		"CallSelf",
-		"CallNode",
-		"CallInstance",
-		"CallBasic",
-		"CallSingleton"
-	};
-
-	String caption = cname[call_mode];
-
-	if (rpc_call_mode) {
-		caption += " (RPC)";
-	}
-
-	return caption;
-}
-
-String VisualScriptFunctionCall::get_text() const {
-
 	if (call_mode == CALL_MODE_SELF)
 		return "  " + String(function) + "()";
 	if (call_mode == CALL_MODE_SINGLETON)
@@ -292,6 +272,14 @@ String VisualScriptFunctionCall::get_text() const {
 		return " [" + String(base_path.simplified()) + "]." + String(function) + "()";
 	else
 		return "  " + base_type + "." + String(function) + "()";
+}
+
+String VisualScriptFunctionCall::get_text() const {
+
+	if (rpc_call_mode) {
+		return "RPC";
+	}
+	return "";
 }
 
 void VisualScriptFunctionCall::set_basic_type(Variant::Type p_type) {
@@ -2397,12 +2385,14 @@ PropertyInfo VisualScriptEmitSignal::get_output_value_port_info(int p_idx) const
 	return PropertyInfo();
 }
 
+/*
 String VisualScriptEmitSignal::get_caption() const {
 
 	return "EmitSignal";
 }
+*/
 
-String VisualScriptEmitSignal::get_text() const {
+String VisualScriptEmitSignal::get_caption() const {
 
 	return "emit " + String(name);
 }

--- a/modules/visual_script/visual_script_func_nodes.h
+++ b/modules/visual_script/visual_script_func_nodes.h
@@ -346,7 +346,7 @@ public:
 	virtual PropertyInfo get_output_value_port_info(int p_idx) const;
 
 	virtual String get_caption() const;
-	virtual String get_text() const;
+	//virtual String get_text() const;
 	virtual String get_category() const { return "functions"; }
 
 	void set_signal(const StringName &p_type);

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -1291,12 +1291,7 @@ PropertyInfo VisualScriptIndexGet::get_output_value_port_info(int p_idx) const {
 
 String VisualScriptIndexGet::get_caption() const {
 
-	return "IndexGet";
-}
-
-String VisualScriptIndexGet::get_text() const {
-
-	return String("get");
+	return "Get Index";
 }
 
 class VisualScriptNodeInstanceIndexGet : public VisualScriptNodeInstance {
@@ -1371,12 +1366,7 @@ PropertyInfo VisualScriptIndexSet::get_output_value_port_info(int p_idx) const {
 
 String VisualScriptIndexSet::get_caption() const {
 
-	return "IndexSet";
-}
-
-String VisualScriptIndexSet::get_text() const {
-
-	return String("set");
+	return "Set Index";
 }
 
 class VisualScriptNodeInstanceIndexSet : public VisualScriptNodeInstance {
@@ -3032,12 +3022,7 @@ PropertyInfo VisualScriptConstructor::get_output_value_port_info(int p_idx) cons
 
 String VisualScriptConstructor::get_caption() const {
 
-	return "Construct";
-}
-
-String VisualScriptConstructor::get_text() const {
-
-	return "new " + Variant::get_type_name(type) + "()";
+	return "Construct " + Variant::get_type_name(type);
 }
 
 String VisualScriptConstructor::get_category() const {
@@ -3600,12 +3585,7 @@ PropertyInfo VisualScriptDeconstruct::get_output_value_port_info(int p_idx) cons
 
 String VisualScriptDeconstruct::get_caption() const {
 
-	return "Deconstruct";
-}
-
-String VisualScriptDeconstruct::get_text() const {
-
-	return "from " + Variant::get_type_name(type) + ":";
+	return "Deconstruct " + Variant::get_type_name(type);
 }
 
 String VisualScriptDeconstruct::get_category() const {

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -467,12 +467,12 @@ PropertyInfo VisualScriptOperator::get_output_value_port_info(int p_idx) const {
 
 static const char *op_names[] = {
 	//comparison
-	"Equal", //OP_EQUAL,
-	"NotEqual", //OP_NOT_EQUAL,
-	"Less", //OP_LESS,
-	"LessEqual", //OP_LESS_EQUAL,
-	"Greater", //OP_GREATER,
-	"GreaterEq", //OP_GREATER_EQUAL,
+	"Are Equal", //OP_EQUAL,
+	"Are Not Equal", //OP_NOT_EQUAL,
+	"Less Than", //OP_LESS,
+	"Less Than or Equal", //OP_LESS_EQUAL,
+	"Greater Than", //OP_GREATER,
+	"Greater Than or Equal", //OP_GREATER_EQUAL,
 	//mathematic
 	"Add", //OP_ADD,
 	"Subtract", //OP_SUBTRACT,
@@ -481,14 +481,14 @@ static const char *op_names[] = {
 	"Negate", //OP_NEGATE,
 	"Positive", //OP_POSITIVE,
 	"Remainder", //OP_MODULE,
-	"Concat", //OP_STRING_CONCAT,
+	"Concatenate", //OP_STRING_CONCAT,
 	//bitwise
-	"ShiftLeft", //OP_SHIFT_LEFT,
-	"ShiftRight", //OP_SHIFT_RIGHT,
-	"BitAnd", //OP_BIT_AND,
-	"BitOr", //OP_BIT_OR,
-	"BitXor", //OP_BIT_XOR,
-	"BitNeg", //OP_BIT_NEGATE,
+	"Bit Shift Left", //OP_SHIFT_LEFT,
+	"Bit Shift Right", //OP_SHIFT_RIGHT,
+	"Bit And", //OP_BIT_AND,
+	"Bit Or", //OP_BIT_OR,
+	"Bit Xor", //OP_BIT_XOR,
+	"Bit Negate", //OP_BIT_NEGATE,
 	//logic
 	"And", //OP_AND,
 	"Or", //OP_OR,
@@ -499,11 +499,6 @@ static const char *op_names[] = {
 };
 
 String VisualScriptOperator::get_caption() const {
-
-	return op_names[op];
-}
-
-String VisualScriptOperator::get_text() const {
 
 	static const wchar_t *op_names[] = {
 		//comparison
@@ -803,14 +798,8 @@ PropertyInfo VisualScriptVariableGet::get_output_value_port_info(int p_idx) cons
 
 String VisualScriptVariableGet::get_caption() const {
 
-	return "Variable";
+	return "Get " + variable;
 }
-
-String VisualScriptVariableGet::get_text() const {
-
-	return variable;
-}
-
 void VisualScriptVariableGet::set_variable(StringName p_variable) {
 
 	if (variable == p_variable)
@@ -928,12 +917,7 @@ PropertyInfo VisualScriptVariableSet::get_output_value_port_info(int p_idx) cons
 
 String VisualScriptVariableSet::get_caption() const {
 
-	return "VariableSet";
-}
-
-String VisualScriptVariableSet::get_text() const {
-
-	return variable;
+	return "Set " + variable;
 }
 
 void VisualScriptVariableSet::set_variable(StringName p_variable) {
@@ -1044,7 +1028,7 @@ PropertyInfo VisualScriptConstant::get_input_value_port_info(int p_idx) const {
 PropertyInfo VisualScriptConstant::get_output_value_port_info(int p_idx) const {
 
 	PropertyInfo pinfo;
-	pinfo.name = "get";
+	pinfo.name = String(value);
 	pinfo.type = type;
 	return pinfo;
 }
@@ -1052,11 +1036,6 @@ PropertyInfo VisualScriptConstant::get_output_value_port_info(int p_idx) const {
 String VisualScriptConstant::get_caption() const {
 
 	return "Constant";
-}
-
-String VisualScriptConstant::get_text() const {
-
-	return String(value);
 }
 
 void VisualScriptConstant::set_constant_type(Variant::Type p_type) {
@@ -1174,10 +1153,20 @@ PropertyInfo VisualScriptPreload::get_input_value_port_info(int p_idx) const {
 
 PropertyInfo VisualScriptPreload::get_output_value_port_info(int p_idx) const {
 
-	PropertyInfo pinfo = PropertyInfo(Variant::OBJECT, "res");
+	PropertyInfo pinfo;
+	pinfo.type = Variant::OBJECT;
 	if (preload.is_valid()) {
 		pinfo.hint = PROPERTY_HINT_RESOURCE_TYPE;
 		pinfo.hint_string = preload->get_class();
+		if (preload->get_path().is_resource_file()) {
+			pinfo.name = preload->get_path();
+		} else if (preload->get_name() != String()) {
+			pinfo.name = preload->get_name();
+		} else {
+			pinfo.name = preload->get_class();
+		}
+	} else {
+		pinfo.name = "<empty>";
 	}
 
 	return pinfo;
@@ -1186,21 +1175,6 @@ PropertyInfo VisualScriptPreload::get_output_value_port_info(int p_idx) const {
 String VisualScriptPreload::get_caption() const {
 
 	return "Preload";
-}
-
-String VisualScriptPreload::get_text() const {
-
-	if (preload.is_valid()) {
-		if (preload->get_path().is_resource_file()) {
-			return preload->get_path();
-		} else if (preload->get_name() != String()) {
-			return preload->get_name();
-		} else {
-			return preload->get_class();
-		}
-	} else {
-		return "<empty>";
-	}
 }
 
 void VisualScriptPreload::set_preload(const Ref<Resource> &p_preload) {
@@ -1429,18 +1403,13 @@ PropertyInfo VisualScriptGlobalConstant::get_input_value_port_info(int p_idx) co
 }
 
 PropertyInfo VisualScriptGlobalConstant::get_output_value_port_info(int p_idx) const {
-
-	return PropertyInfo(Variant::REAL, "value");
+	String name = GlobalConstants::get_global_constant_name(index);
+	return PropertyInfo(Variant::REAL, name);
 }
 
 String VisualScriptGlobalConstant::get_caption() const {
 
-	return "GlobalConst";
-}
-
-String VisualScriptGlobalConstant::get_text() const {
-
-	return GlobalConstants::get_global_constant_name(index);
+	return "Global Constant";
 }
 
 void VisualScriptGlobalConstant::set_global_constant(int p_which) {
@@ -1529,17 +1498,12 @@ PropertyInfo VisualScriptClassConstant::get_input_value_port_info(int p_idx) con
 
 PropertyInfo VisualScriptClassConstant::get_output_value_port_info(int p_idx) const {
 
-	return PropertyInfo(Variant::INT, "value");
+	return PropertyInfo(Variant::INT, String(base_type) + "." + String(name));
 }
 
 String VisualScriptClassConstant::get_caption() const {
 
-	return "ClassConst";
-}
-
-String VisualScriptClassConstant::get_text() const {
-
-	return String(base_type) + "." + String(name);
+	return "Class Constant";
 }
 
 void VisualScriptClassConstant::set_class_constant(const StringName &p_which) {
@@ -1663,7 +1627,7 @@ PropertyInfo VisualScriptBasicTypeConstant::get_output_value_port_info(int p_idx
 
 String VisualScriptBasicTypeConstant::get_caption() const {
 
-	return "BasicConst";
+	return "Basic Constant";
 }
 
 String VisualScriptBasicTypeConstant::get_text() const {
@@ -1818,17 +1782,12 @@ PropertyInfo VisualScriptMathConstant::get_input_value_port_info(int p_idx) cons
 
 PropertyInfo VisualScriptMathConstant::get_output_value_port_info(int p_idx) const {
 
-	return PropertyInfo(Variant::REAL, "value");
+	return PropertyInfo(Variant::REAL, const_name[constant]);
 }
 
 String VisualScriptMathConstant::get_caption() const {
 
-	return "MathConst";
-}
-
-String VisualScriptMathConstant::get_text() const {
-
-	return const_name[constant];
+	return "Math Constant";
 }
 
 void VisualScriptMathConstant::set_math_constant(MathConstant p_which) {
@@ -1893,7 +1852,7 @@ VisualScriptMathConstant::VisualScriptMathConstant() {
 }
 
 //////////////////////////////////////////
-////////////////GLOBALSINGLETON///////////
+////////////////ENGINESINGLETON///////////
 //////////////////////////////////////////
 
 int VisualScriptEngineSingleton::get_output_sequence_port_count() const {
@@ -1927,17 +1886,12 @@ PropertyInfo VisualScriptEngineSingleton::get_input_value_port_info(int p_idx) c
 
 PropertyInfo VisualScriptEngineSingleton::get_output_value_port_info(int p_idx) const {
 
-	return PropertyInfo(Variant::OBJECT, "instance");
+	return PropertyInfo(Variant::OBJECT, singleton);
 }
 
 String VisualScriptEngineSingleton::get_caption() const {
 
-	return "EngineSingleton";
-}
-
-String VisualScriptEngineSingleton::get_text() const {
-
-	return singleton;
+	return "Get Engine Singleton";
 }
 
 void VisualScriptEngineSingleton::set_singleton(const String &p_string) {
@@ -2048,17 +2002,12 @@ PropertyInfo VisualScriptSceneNode::get_input_value_port_info(int p_idx) const {
 
 PropertyInfo VisualScriptSceneNode::get_output_value_port_info(int p_idx) const {
 
-	return PropertyInfo(Variant::OBJECT, "node");
+	return PropertyInfo(Variant::OBJECT, path.simplified());
 }
 
 String VisualScriptSceneNode::get_caption() const {
 
-	return "SceneNode";
-}
-
-String VisualScriptSceneNode::get_text() const {
-
-	return path.simplified();
+	return "Get Scene Node";
 }
 
 void VisualScriptSceneNode::set_node_path(const NodePath &p_path) {
@@ -2249,17 +2198,12 @@ PropertyInfo VisualScriptSceneTree::get_input_value_port_info(int p_idx) const {
 
 PropertyInfo VisualScriptSceneTree::get_output_value_port_info(int p_idx) const {
 
-	return PropertyInfo(Variant::OBJECT, "instance");
+	return PropertyInfo(Variant::OBJECT, "Scene Tree");
 }
 
 String VisualScriptSceneTree::get_caption() const {
 
-	return "SceneTree";
-}
-
-String VisualScriptSceneTree::get_text() const {
-
-	return "";
+	return "Get Scene Tree";
 }
 
 class VisualScriptNodeInstanceSceneTree : public VisualScriptNodeInstance {
@@ -2351,17 +2295,12 @@ PropertyInfo VisualScriptResourcePath::get_input_value_port_info(int p_idx) cons
 
 PropertyInfo VisualScriptResourcePath::get_output_value_port_info(int p_idx) const {
 
-	return PropertyInfo(Variant::STRING, "path");
+	return PropertyInfo(Variant::STRING, path);
 }
 
 String VisualScriptResourcePath::get_caption() const {
 
-	return "ResourcePath";
-}
-
-String VisualScriptResourcePath::get_text() const {
-
-	return path;
+	return "Resource Path";
 }
 
 void VisualScriptResourcePath::set_resource_path(const String &p_path) {
@@ -2443,20 +2382,18 @@ PropertyInfo VisualScriptSelf::get_input_value_port_info(int p_idx) const {
 
 PropertyInfo VisualScriptSelf::get_output_value_port_info(int p_idx) const {
 
-	return PropertyInfo(Variant::OBJECT, "instance");
+	String type_name;
+	if (get_visual_script().is_valid())
+		type_name = get_visual_script()->get_instance_base_type();
+	else
+		type_name = "instance";
+
+	return PropertyInfo(Variant::OBJECT, type_name);
 }
 
 String VisualScriptSelf::get_caption() const {
 
-	return "Self";
-}
-
-String VisualScriptSelf::get_text() const {
-
-	if (get_visual_script().is_valid())
-		return get_visual_script()->get_instance_base_type();
-	else
-		return "";
+	return "Get Self";
 }
 
 class VisualScriptNodeInstanceSelf : public VisualScriptNodeInstance {
@@ -3148,17 +3085,12 @@ PropertyInfo VisualScriptLocalVar::get_input_value_port_info(int p_idx) const {
 }
 PropertyInfo VisualScriptLocalVar::get_output_value_port_info(int p_idx) const {
 
-	return PropertyInfo(type, "get");
+	return PropertyInfo(type, name);
 }
 
 String VisualScriptLocalVar::get_caption() const {
 
-	return "LocalVarGet";
-}
-
-String VisualScriptLocalVar::get_text() const {
-
-	return name;
+	return "Get Local Var";
 }
 
 String VisualScriptLocalVar::get_category() const {
@@ -3274,7 +3206,7 @@ PropertyInfo VisualScriptLocalVarSet::get_output_value_port_info(int p_idx) cons
 
 String VisualScriptLocalVarSet::get_caption() const {
 
-	return "LocalVarSet";
+	return "Set Local Var";
 }
 
 String VisualScriptLocalVarSet::get_text() const {
@@ -3412,12 +3344,7 @@ PropertyInfo VisualScriptInputAction::get_output_value_port_info(int p_idx) cons
 
 String VisualScriptInputAction::get_caption() const {
 
-	return "Action";
-}
-
-String VisualScriptInputAction::get_text() const {
-
-	return name;
+	return "Action " + name;
 }
 
 String VisualScriptInputAction::get_category() const {

--- a/modules/visual_script/visual_script_nodes.h
+++ b/modules/visual_script/visual_script_nodes.h
@@ -327,7 +327,6 @@ public:
 	virtual PropertyInfo get_output_value_port_info(int p_idx) const;
 
 	virtual String get_caption() const;
-	virtual String get_text() const;
 	virtual String get_category() const { return "operators"; }
 
 	virtual VisualScriptNodeInstance *instance(VisualScriptInstance *p_instance);
@@ -352,7 +351,6 @@ public:
 	virtual PropertyInfo get_output_value_port_info(int p_idx) const;
 
 	virtual String get_caption() const;
-	virtual String get_text() const;
 	virtual String get_category() const { return "operators"; }
 
 	virtual VisualScriptNodeInstance *instance(VisualScriptInstance *p_instance);
@@ -822,7 +820,6 @@ public:
 	virtual PropertyInfo get_output_value_port_info(int p_idx) const;
 
 	virtual String get_caption() const;
-	virtual String get_text() const;
 	virtual String get_category() const;
 
 	void set_constructor_type(Variant::Type p_type);
@@ -993,7 +990,6 @@ public:
 	virtual PropertyInfo get_output_value_port_info(int p_idx) const;
 
 	virtual String get_caption() const;
-	virtual String get_text() const;
 	virtual String get_category() const;
 
 	void set_deconstruct_type(Variant::Type p_type);

--- a/modules/visual_script/visual_script_nodes.h
+++ b/modules/visual_script/visual_script_nodes.h
@@ -124,7 +124,6 @@ public:
 	virtual PropertyInfo get_output_value_port_info(int p_idx) const;
 
 	virtual String get_caption() const;
-	virtual String get_text() const;
 	virtual String get_category() const { return "operators"; }
 
 	void set_operator(Variant::Operator p_op);
@@ -194,7 +193,6 @@ public:
 	virtual PropertyInfo get_output_value_port_info(int p_idx) const;
 
 	virtual String get_caption() const;
-	virtual String get_text() const;
 	virtual String get_category() const { return "data"; }
 
 	void set_variable(StringName p_variable);
@@ -228,7 +226,6 @@ public:
 	virtual PropertyInfo get_output_value_port_info(int p_idx) const;
 
 	virtual String get_caption() const;
-	virtual String get_text() const;
 	virtual String get_category() const { return "data"; }
 
 	void set_variable(StringName p_variable);
@@ -263,7 +260,6 @@ public:
 	virtual PropertyInfo get_output_value_port_info(int p_idx) const;
 
 	virtual String get_caption() const;
-	virtual String get_text() const;
 	virtual String get_category() const { return "constants"; }
 
 	void set_constant_type(Variant::Type p_type);
@@ -299,7 +295,6 @@ public:
 	virtual PropertyInfo get_output_value_port_info(int p_idx) const;
 
 	virtual String get_caption() const;
-	virtual String get_text() const;
 	virtual String get_category() const { return "data"; }
 
 	void set_preload(const Ref<Resource> &p_preload);
@@ -379,7 +374,6 @@ public:
 	virtual PropertyInfo get_output_value_port_info(int p_idx) const;
 
 	virtual String get_caption() const;
-	virtual String get_text() const;
 	virtual String get_category() const { return "constants"; }
 
 	void set_global_constant(int p_which);
@@ -414,7 +408,6 @@ public:
 	virtual PropertyInfo get_output_value_port_info(int p_idx) const;
 
 	virtual String get_caption() const;
-	virtual String get_text() const;
 	virtual String get_category() const { return "constants"; }
 
 	void set_class_constant(const StringName &p_which);
@@ -503,7 +496,6 @@ public:
 	virtual PropertyInfo get_output_value_port_info(int p_idx) const;
 
 	virtual String get_caption() const;
-	virtual String get_text() const;
 	virtual String get_category() const { return "constants"; }
 
 	void set_math_constant(MathConstant p_which);
@@ -537,7 +529,6 @@ public:
 	virtual PropertyInfo get_output_value_port_info(int p_idx) const;
 
 	virtual String get_caption() const;
-	virtual String get_text() const;
 	virtual String get_category() const { return "data"; }
 
 	void set_singleton(const String &p_string);
@@ -573,7 +564,6 @@ public:
 	virtual PropertyInfo get_output_value_port_info(int p_idx) const;
 
 	virtual String get_caption() const;
-	virtual String get_text() const;
 	virtual String get_category() const { return "data"; }
 
 	void set_node_path(const NodePath &p_path);
@@ -607,7 +597,6 @@ public:
 	virtual PropertyInfo get_output_value_port_info(int p_idx) const;
 
 	virtual String get_caption() const;
-	virtual String get_text() const;
 	virtual String get_category() const { return "data"; }
 
 	virtual VisualScriptNodeInstance *instance(VisualScriptInstance *p_instance);
@@ -639,7 +628,6 @@ public:
 	virtual PropertyInfo get_output_value_port_info(int p_idx) const;
 
 	virtual String get_caption() const;
-	virtual String get_text() const;
 	virtual String get_category() const { return "data"; }
 
 	void set_resource_path(const String &p_path);
@@ -670,7 +658,6 @@ public:
 	virtual PropertyInfo get_output_value_port_info(int p_idx) const;
 
 	virtual String get_caption() const;
-	virtual String get_text() const;
 	virtual String get_category() const { return "data"; }
 
 	virtual VisualScriptNodeInstance *instance(VisualScriptInstance *p_instance);
@@ -856,7 +843,6 @@ public:
 	virtual PropertyInfo get_output_value_port_info(int p_idx) const;
 
 	virtual String get_caption() const;
-	virtual String get_text() const;
 	virtual String get_category() const;
 
 	void set_var_name(const StringName &p_name);
@@ -939,7 +925,6 @@ public:
 	virtual PropertyInfo get_output_value_port_info(int p_idx) const;
 
 	virtual String get_caption() const;
-	virtual String get_text() const;
 	virtual String get_category() const;
 
 	void set_action_name(const StringName &p_name);


### PR DESCRIPTION
Previously, EVERY NODE would have a label of text on the row of the primary sequence nodes, which was in a lot of cases ugly and wasted vertical space. Also do we really need half in-code names in the title bars? Waste of space.
