### PR TITLE
Added curve in/out (tangent) handle mirroring

### DIFF
--- a/core/image.h
+++ b/core/image.h
@@ -217,7 +217,7 @@ public:
 	/**
 	 * Generate a mipmap to an image (creates an image 1/4 the size, with averaging of 4->1)
 	 */
-	Error generate_mipmaps();
+	Error generate_mipmaps(bool p_renormalize = false);
 
 	void clear_mipmaps();
 

--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -29,8 +29,8 @@
 /*************************************************************************/
 
 #include "pck_packer.h"
-
 #include "core/os/file_access.h"
+#include "version.h"
 
 static uint64_t _align(uint64_t p_n, int p_alignment) {
 
@@ -70,9 +70,9 @@ Error PCKPacker::pck_start(const String &p_file, int p_alignment) {
 	alignment = p_alignment;
 
 	file->store_32(0x43504447); // MAGIC
-	file->store_32(0); // # version
-	file->store_32(0); // # major
-	file->store_32(0); // # minor
+	file->store_32(1); // # version
+	file->store_32(VERSION_MAJOR); // # major
+	file->store_32(VERSION_MINOR); // # minor
 	file->store_32(0); // # revision
 
 	for (int i = 0; i < 16; i++) {

--- a/doc/classes/Spatial.xml
+++ b/doc/classes/Spatial.xml
@@ -99,7 +99,9 @@
 			<argument index="1" name="up" type="Vector3">
 			</argument>
 			<description>
-				Rotates itself to point into direction of target position. Operations take place in global space.
+				Rotates itself so that the local -Z axis points towards the [code]target[/code] position.
+				The transform will first be rotated around the given [code]up[/code] vector, and then fully aligned to the target by a further rotation around an axis perpendicular to both the [code]target[/code] and [code]up[/code] vectors.
+				Operations take place in global space.
 			</description>
 		</method>
 		<method name="look_at_from_position">
@@ -112,7 +114,7 @@
 			<argument index="2" name="up" type="Vector3">
 			</argument>
 			<description>
-				Moves the node to specified position and then rotates itself to point into direction of target position. Operations take place in global space.
+				Moves the node to the specified [code]position[/code], and then rotates itself to point toward the [code]target[/code] as per [method look_at]. Operations take place in global space.
 			</description>
 		</method>
 		<method name="orthonormalize">

--- a/doc/classes/Transform.xml
+++ b/doc/classes/Transform.xml
@@ -99,7 +99,9 @@
 			<argument index="1" name="up" type="Vector3">
 			</argument>
 			<description>
-				Rotate the transform around the up vector to face the target.
+				Returns a copy of the transform rotated such that its -Z axis points towards the [code]target[/code] position.
+				The transform will first be rotated around the given [code]up[/code] vector, and then fully aligned to the target by a further rotation around an axis perpendicular to both the [code]target[/code] and [code]up[/code] vectors.
+				Operations take place in global space.
 			</description>
 		</method>
 		<method name="orthonormalized">

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -911,6 +911,16 @@ Error EditorExportPlatform::save_zip(const Ref<EditorExportPreset> &p_preset, co
 	return OK;
 }
 
+Error EditorExportPlatform::export_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {
+	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
+	return save_pack(p_preset, p_path);
+}
+
+Error EditorExportPlatform::export_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {
+	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
+	return save_zip(p_preset, p_path);
+}
+
 void EditorExportPlatform::gen_export_flags(Vector<String> &r_flags, int p_flags) {
 
 	String host = EditorSettings::get_singleton()->get("network/debug/remote_host");

--- a/editor/editor_export.h
+++ b/editor/editor_export.h
@@ -243,6 +243,8 @@ public:
 
 	virtual String get_binary_extension(const Ref<EditorExportPreset> &p_preset) const = 0;
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) = 0;
+	virtual Error export_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0);
+	virtual Error export_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0);
 	virtual void get_platform_features(List<String> *r_features) = 0;
 
 	EditorExportPlatform();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -483,12 +483,12 @@ void EditorNode::_fs_changed() {
 				Error err;
 				if (!preset->is_runnable() && (export_defer.path.ends_with(".pck") || export_defer.path.ends_with(".zip"))) {
 					if (export_defer.path.ends_with(".zip")) {
-						err = platform->save_zip(preset, export_defer.path);
+						err = platform->export_zip(preset, export_defer.debug, export_defer.path);
 					} else if (export_defer.path.ends_with(".pck")) {
-						err = platform->save_pack(preset, export_defer.path);
+						err = platform->export_pack(preset, export_defer.debug, export_defer.path);
 					}
 				} else {
-					err = platform->export_project(preset, export_defer.debug, export_defer.path, /*p_flags*/ 0);
+					err = platform->export_project(preset, export_defer.debug, export_defer.path);
 				}
 				if (err != OK) {
 					ERR_PRINTS(vformat(TTR("Project export failed with error code %d."), (int)err));

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -295,7 +295,7 @@ void ResourceImporterTexture::_save_stex(const Ref<Image> &p_image, const String
 		case COMPRESS_VIDEO_RAM: {
 
 			Ref<Image> image = p_image->duplicate();
-			image->generate_mipmaps();
+			image->generate_mipmaps(p_force_normal);
 
 			if (p_force_rgbe && image->get_format() >= Image::FORMAT_R8 && image->get_format() <= Image::FORMAT_RGBE9995) {
 				image->convert(Image::FORMAT_RGBE9995);

--- a/editor/plugins/collision_polygon_editor_plugin.h
+++ b/editor/plugins/collision_polygon_editor_plugin.h
@@ -78,6 +78,7 @@ class Polygon3DEditor : public HBoxContainer {
 	Vector<Vector2> pre_move_edit;
 	Vector<Vector2> wip;
 	bool wip_active;
+	bool snap_ignore;
 
 	float prev_depth;
 

--- a/editor/plugins/path_editor_plugin.cpp
+++ b/editor/plugins/path_editor_plugin.cpp
@@ -547,6 +547,7 @@ PathEditorPlugin::PathEditorPlugin(EditorNode *p_node) {
 	curve_edit = memnew(ToolButton);
 	curve_edit->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("CurveEdit", "EditorIcons"));
 	curve_edit->set_toggle_mode(true);
+	curve_edit->set_pressed(true);
 	curve_edit->hide();
 	curve_edit->set_focus_mode(Control::FOCUS_NONE);
 	curve_edit->set_tooltip(TTR("Select Points") + "\n" + TTR("Shift+Drag: Select Control Points") + "\n" + keycode_get_string(KEY_MASK_CMD) + TTR("Click: Add Point") + "\n" + TTR("Right Click: Delete Point"));
@@ -572,7 +573,6 @@ PathEditorPlugin::PathEditorPlugin(EditorNode *p_node) {
 	curve_close->set_tooltip(TTR("Close Curve"));
 	SpatialEditor::get_singleton()->add_control_to_menu_panel(curve_close);
 
-	curve_edit->set_pressed(true);
 	/*
 	collision_polygon_editor = memnew( PathEditor(p_node) );
 	editor->get_viewport()->add_child(collision_polygon_editor);

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -691,11 +691,11 @@ ThemeEditor::ThemeEditor() {
 	test_menu_button->get_popup()->add_separator();
 	test_menu_button->get_popup()->add_check_item(TTR("Check Item"));
 	test_menu_button->get_popup()->add_check_item(TTR("Checked Item"));
-	test_menu_button->get_popup()->set_item_checked(2, true);
+	test_menu_button->get_popup()->set_item_checked(3, true);
 	test_menu_button->get_popup()->add_separator();
-	test_menu_button->get_popup()->add_check_item(TTR("Radio Item"));
+	test_menu_button->get_popup()->add_radio_check_item(TTR("Radio Item"));
 	test_menu_button->get_popup()->add_radio_check_item(TTR("Checked Radio Item"));
-	test_menu_button->get_popup()->set_item_checked(5, true);
+	test_menu_button->get_popup()->set_item_checked(6, true);
 	first_vb->add_child(test_menu_button);
 
 	OptionButton *test_option_button = memnew(OptionButton);

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -703,9 +703,9 @@ void ProjectExportDialog::_export_pck_zip_selected(const String &p_path) {
 	ERR_FAIL_COND(platform.is_null());
 
 	if (p_path.ends_with(".zip")) {
-		platform->save_zip(current, p_path);
+		platform->export_zip(current, export_pck_zip_debug->is_pressed(), p_path);
 	} else if (p_path.ends_with(".pck")) {
-		platform->save_pack(current, p_path);
+		platform->export_pack(current, export_pck_zip_debug->is_pressed(), p_path);
 	}
 }
 
@@ -980,6 +980,11 @@ ProjectExportDialog::ProjectExportDialog() {
 	export_debug->set_text(TTR("Export With Debug"));
 	export_debug->set_pressed(true);
 	export_project->get_vbox()->add_child(export_debug);
+
+	export_pck_zip_debug = memnew(CheckButton);
+	export_pck_zip_debug->set_text(TTR("Export With Debug"));
+	export_pck_zip_debug->set_pressed(true);
+	export_pck_zip->get_vbox()->add_child(export_pck_zip_debug);
 
 	set_hide_on_ok(false);
 

--- a/editor/project_export.h
+++ b/editor/project_export.h
@@ -131,6 +131,7 @@ private:
 	FileDialog *export_pck_zip;
 	FileDialog *export_project;
 	CheckButton *export_debug;
+	CheckButton *export_pck_zip_debug;
 
 	void _open_export_template_manager();
 

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -27,6 +27,7 @@ private:
 	AABB node_aabb;
 
 	bool dirty;
+	float snap;
 
 	bool use_collision;
 	Ref<ConcavePolygonShape> root_collision_shape;
@@ -59,7 +60,7 @@ private:
 
 protected:
 	void _notification(int p_what);
-	virtual CSGBrush *_build_brush(AABB *r_aabb) = 0;
+	virtual CSGBrush *_build_brush() = 0;
 	void _make_dirty();
 
 	static void _bind_methods();
@@ -81,6 +82,9 @@ public:
 	void set_use_collision(bool p_enable);
 	bool is_using_collision() const;
 
+	void set_snap(float p_snap);
+	float get_snap() const;
+
 	bool is_root_shape() const;
 	CSGShape();
 	~CSGShape();
@@ -91,16 +95,9 @@ VARIANT_ENUM_CAST(CSGShape::Operation)
 class CSGCombiner : public CSGShape {
 	GDCLASS(CSGCombiner, CSGShape)
 private:
-	float snap;
-	virtual CSGBrush *_build_brush(AABB *r_aabb);
-
-protected:
-	static void _bind_methods();
+	virtual CSGBrush *_build_brush();
 
 public:
-	void set_snap(float p_snap);
-	float get_snap() const;
-
 	CSGCombiner();
 };
 
@@ -124,7 +121,7 @@ public:
 class CSGMesh : public CSGPrimitive {
 	GDCLASS(CSGMesh, CSGPrimitive)
 
-	virtual CSGBrush *_build_brush(AABB *r_aabb);
+	virtual CSGBrush *_build_brush();
 
 	Ref<Mesh> mesh;
 
@@ -141,7 +138,7 @@ public:
 class CSGSphere : public CSGPrimitive {
 
 	GDCLASS(CSGSphere, CSGPrimitive)
-	virtual CSGBrush *_build_brush(AABB *r_aabb);
+	virtual CSGBrush *_build_brush();
 
 	Ref<Material> material;
 	bool smooth_faces;
@@ -174,7 +171,7 @@ public:
 class CSGBox : public CSGPrimitive {
 
 	GDCLASS(CSGBox, CSGPrimitive)
-	virtual CSGBrush *_build_brush(AABB *r_aabb);
+	virtual CSGBrush *_build_brush();
 
 	Ref<Material> material;
 	float width;
@@ -203,7 +200,7 @@ public:
 class CSGCylinder : public CSGPrimitive {
 
 	GDCLASS(CSGCylinder, CSGPrimitive)
-	virtual CSGBrush *_build_brush(AABB *r_aabb);
+	virtual CSGBrush *_build_brush();
 
 	Ref<Material> material;
 	float radius;
@@ -240,7 +237,7 @@ public:
 class CSGTorus : public CSGPrimitive {
 
 	GDCLASS(CSGTorus, CSGPrimitive)
-	virtual CSGBrush *_build_brush(AABB *r_aabb);
+	virtual CSGBrush *_build_brush();
 
 	Ref<Material> material;
 	float inner_radius;
@@ -292,7 +289,7 @@ public:
 	};
 
 private:
-	virtual CSGBrush *_build_brush(AABB *r_aabb);
+	virtual CSGBrush *_build_brush();
 
 	Vector<Vector2> polygon;
 	Ref<Material> material;

--- a/modules/gdnative/SCsub
+++ b/modules/gdnative/SCsub
@@ -275,8 +275,8 @@ if ARGUMENTS.get('gdnative_wrapper', False):
 
     if gd_wrapper_env['use_lto']:
         if not env.msvc:
-            gd_wrapper_env.Append(CCFLAGS=['--no-lto'])
-            gd_wrapper_env.Append(LINKFLAGS=['--no-lto'])
+            gd_wrapper_env.Append(CCFLAGS=['-fno-lto'])
+            gd_wrapper_env.Append(LINKFLAGS=['-fno-lto'])
         else:
             gd_wrapper_env.Append(CCFLAGS=['/GL-'])
             gd_wrapper_env.Append(LINKFLAGS=['/LTCG:OFF'])

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -248,14 +248,14 @@ void BindingsGenerator::_generate_method_icalls(const TypeInterface &p_itype) {
 		if (imethod.is_virtual)
 			continue;
 
-		const TypeInterface *return_type = _get_type_by_name_or_placeholder(imethod.return_type);
+		const TypeInterface *return_type = _get_type_or_placeholder(imethod.return_type);
 
 		String im_sig;
 		String im_unique_sig;
 
 		if (p_itype.is_object_type) {
 			im_sig += "IntPtr " CS_PARAM_METHODBIND ", ";
-			im_unique_sig += imethod.return_type.operator String() + ",IntPtr,IntPtr";
+			im_unique_sig += imethod.return_type.cname.operator String() + ",IntPtr,IntPtr";
 		}
 
 		im_sig += "IntPtr " CS_PARAM_INSTANCE;
@@ -263,7 +263,7 @@ void BindingsGenerator::_generate_method_icalls(const TypeInterface &p_itype) {
 		// Get arguments information
 		int i = 0;
 		for (const List<ArgumentInterface>::Element *F = imethod.arguments.front(); F; F = F->next()) {
-			const TypeInterface *arg_type = _get_type_by_name_or_placeholder(F->get().type);
+			const TypeInterface *arg_type = _get_type_or_placeholder(F->get().type);
 
 			im_sig += ", ";
 			im_sig += arg_type->im_type_in;
@@ -1069,12 +1069,12 @@ Error BindingsGenerator::_generate_cs_property(const BindingsGenerator::TypeInte
 	}
 
 	if (getter && setter) {
-		ERR_FAIL_COND_V(getter->return_type != setter->arguments.back()->get().type, ERR_BUG);
+		ERR_FAIL_COND_V(getter->return_type.cname != setter->arguments.back()->get().type.cname, ERR_BUG);
 	}
 
-	StringName proptype_name = getter ? getter->return_type : setter->arguments.back()->get().type;
+	const TypeReference &proptype_name = getter ? getter->return_type : setter->arguments.back()->get().type;
 
-	const TypeInterface *prop_itype = _get_type_by_name_or_null(proptype_name);
+	const TypeInterface *prop_itype = _get_type_or_null(proptype_name);
 	ERR_FAIL_NULL_V(prop_itype, ERR_BUG); // Property type not found
 
 	String prop_proxy_name = escape_csharp_keyword(snake_to_pascal_case(p_iprop.cname));
@@ -1122,9 +1122,9 @@ Error BindingsGenerator::_generate_cs_property(const BindingsGenerator::TypeInte
 		p_output.push_back(getter->proxy_name + "(");
 		if (p_iprop.index != -1) {
 			const ArgumentInterface &idx_arg = getter->arguments.front()->get();
-			if (idx_arg.type != name_cache.type_int) {
+			if (idx_arg.type.cname != name_cache.type_int) {
 				// Assume the index parameter is an enum
-				const TypeInterface *idx_arg_type = _get_type_by_name_or_null(idx_arg.type);
+				const TypeInterface *idx_arg_type = _get_type_or_null(idx_arg.type);
 				CRASH_COND(idx_arg_type == NULL);
 				p_output.push_back("(" + idx_arg_type->proxy_name + ")" + itos(p_iprop.index));
 			} else {
@@ -1139,9 +1139,9 @@ Error BindingsGenerator::_generate_cs_property(const BindingsGenerator::TypeInte
 		p_output.push_back(setter->proxy_name + "(");
 		if (p_iprop.index != -1) {
 			const ArgumentInterface &idx_arg = setter->arguments.front()->get();
-			if (idx_arg.type != name_cache.type_int) {
+			if (idx_arg.type.cname != name_cache.type_int) {
 				// Assume the index parameter is an enum
-				const TypeInterface *idx_arg_type = _get_type_by_name_or_null(idx_arg.type);
+				const TypeInterface *idx_arg_type = _get_type_or_null(idx_arg.type);
 				CRASH_COND(idx_arg_type == NULL);
 				p_output.push_back("(" + idx_arg_type->proxy_name + ")" + itos(p_iprop.index) + ", ");
 			} else {
@@ -1158,7 +1158,7 @@ Error BindingsGenerator::_generate_cs_property(const BindingsGenerator::TypeInte
 
 Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterface &p_itype, const BindingsGenerator::MethodInterface &p_imethod, int &p_method_bind_count, List<String> &p_output) {
 
-	const TypeInterface *return_type = _get_type_by_name_or_placeholder(p_imethod.return_type);
+	const TypeInterface *return_type = _get_type_or_placeholder(p_imethod.return_type);
 
 	String method_bind_field = "method_bind_" + itos(p_method_bind_count);
 
@@ -1175,7 +1175,7 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 	// Retrieve information from the arguments
 	for (const List<ArgumentInterface>::Element *F = p_imethod.arguments.front(); F; F = F->next()) {
 		const ArgumentInterface &iarg = F->get();
-		const TypeInterface *arg_type = _get_type_by_name_or_placeholder(iarg.type);
+		const TypeInterface *arg_type = _get_type_or_placeholder(iarg.type);
 
 		// Add the current arguments to the signature
 		// If the argument has a default value which is not a constant, we will make it Nullable
@@ -1328,21 +1328,19 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 		const InternalCall *im_icall = match->value();
 
 		String im_call = im_icall->editor_only ? BINDINGS_CLASS_NATIVECALLS_EDITOR : BINDINGS_CLASS_NATIVECALLS;
-		im_call += "." + im_icall->name + "(" + icall_params + ");\n";
+		im_call += "." + im_icall->name + "(" + icall_params + ")";
 
 		if (p_imethod.arguments.size())
 			p_output.push_back(cs_in_statements);
 
 		if (return_type->cname == name_cache.type_void) {
-			p_output.push_back(im_call);
+			p_output.push_back(im_call + ";\n");
 		} else if (return_type->cs_out.empty()) {
-			p_output.push_back("return " + im_call);
+			p_output.push_back("return " + im_call + ";\n");
 		} else {
-			p_output.push_back(return_type->im_type_out);
-			p_output.push_back(" " LOCAL_RET " = ");
-			p_output.push_back(im_call);
 			p_output.push_back(INDENT3);
-			p_output.push_back(sformat(return_type->cs_out, LOCAL_RET) + "\n");
+			p_output.push_back(sformat(return_type->cs_out, im_call, return_type->cs_type, return_type->im_type_out));
+			p_output.push_back("\n");
 		}
 
 		p_output.push_back(CLOSE_BLOCK_L2);
@@ -1540,9 +1538,9 @@ Error BindingsGenerator::_generate_glue_method(const BindingsGenerator::TypeInte
 	if (p_imethod.is_virtual)
 		return OK; // Ignore
 
-	bool ret_void = p_imethod.return_type == name_cache.type_void;
+	bool ret_void = p_imethod.return_type.cname == name_cache.type_void;
 
-	const TypeInterface *return_type = _get_type_by_name_or_placeholder(p_imethod.return_type);
+	const TypeInterface *return_type = _get_type_or_placeholder(p_imethod.return_type);
 
 	String argc_str = itos(p_imethod.arguments.size());
 
@@ -1554,7 +1552,7 @@ Error BindingsGenerator::_generate_glue_method(const BindingsGenerator::TypeInte
 	int i = 0;
 	for (const List<ArgumentInterface>::Element *F = p_imethod.arguments.front(); F; F = F->next()) {
 		const ArgumentInterface &iarg = F->get();
-		const TypeInterface *arg_type = _get_type_by_name_or_placeholder(iarg.type);
+		const TypeInterface *arg_type = _get_type_or_placeholder(iarg.type);
 
 		String c_param_name = "arg" + itos(i + 1);
 
@@ -1695,42 +1693,49 @@ Error BindingsGenerator::_generate_glue_method(const BindingsGenerator::TypeInte
 	return OK;
 }
 
-const BindingsGenerator::TypeInterface *BindingsGenerator::_get_type_by_name_or_null(const StringName &p_cname) {
+const BindingsGenerator::TypeInterface *BindingsGenerator::_get_type_or_null(const TypeReference &p_typeref) {
 
-	const Map<StringName, TypeInterface>::Element *builtin_type_match = builtin_types.find(p_cname);
+	const Map<StringName, TypeInterface>::Element *builtin_type_match = builtin_types.find(p_typeref.cname);
 
 	if (builtin_type_match)
 		return &builtin_type_match->get();
 
-	const OrderedHashMap<StringName, TypeInterface>::Element obj_type_match = obj_types.find(p_cname);
+	const OrderedHashMap<StringName, TypeInterface>::Element obj_type_match = obj_types.find(p_typeref.cname);
 
 	if (obj_type_match)
 		return &obj_type_match.get();
 
-	const Map<StringName, TypeInterface>::Element *enum_match = enum_types.find(p_cname);
+	if (p_typeref.is_enum) {
+		const Map<StringName, TypeInterface>::Element *enum_match = enum_types.find(p_typeref.cname);
 
-	if (enum_match)
-		return &enum_match->get();
+		if (enum_match)
+			return &enum_match->get();
+
+		// Enum not found. Most likely because none of its constants were bound, so it's empty. That's fine. Use int instead.
+		const Map<StringName, TypeInterface>::Element *int_match = builtin_types.find(name_cache.type_int);
+		ERR_FAIL_NULL_V(int_match, NULL);
+		return &int_match->get();
+	}
 
 	return NULL;
 }
 
-const BindingsGenerator::TypeInterface *BindingsGenerator::_get_type_by_name_or_placeholder(const StringName &p_cname) {
+const BindingsGenerator::TypeInterface *BindingsGenerator::_get_type_or_placeholder(const TypeReference &p_typeref) {
 
-	const TypeInterface *found = _get_type_by_name_or_null(p_cname);
+	const TypeInterface *found = _get_type_or_null(p_typeref);
 
 	if (found)
 		return found;
 
-	ERR_PRINTS(String() + "Type not found. Creating placeholder: " + p_cname.operator String());
+	ERR_PRINTS(String() + "Type not found. Creating placeholder: " + p_typeref.cname.operator String());
 
-	const Map<StringName, TypeInterface>::Element *match = placeholder_types.find(p_cname);
+	const Map<StringName, TypeInterface>::Element *match = placeholder_types.find(p_typeref.cname);
 
 	if (match)
 		return &match->get();
 
 	TypeInterface placeholder;
-	TypeInterface::create_placeholder_type(placeholder, p_cname);
+	TypeInterface::create_placeholder_type(placeholder, p_typeref.cname);
 
 	return &placeholder_types.insert(placeholder.cname, placeholder)->get();
 }
@@ -1874,7 +1879,7 @@ void BindingsGenerator::_populate_object_type_interfaces() {
 					// The method Object.free is registered as a virtual method, but without the virtual flag.
 					// This is because this method is not supposed to be overridden, but called.
 					// We assume the return type is void.
-					imethod.return_type = name_cache.type_void;
+					imethod.return_type.cname = name_cache.type_void;
 
 					// Actually, more methods like this may be added in the future,
 					// which could actually will return something different.
@@ -1889,21 +1894,22 @@ void BindingsGenerator::_populate_object_type_interfaces() {
 				} else {
 					ERR_PRINTS("Missing MethodBind for non-virtual method: " + itype.name + "." + imethod.name);
 				}
-			} else if (return_info.type == Variant::INT && return_info.usage & PROPERTY_USAGE_CLASS_IS_ENUM) { // TODO redundant?
-				imethod.return_type = return_info.class_name;
+			} else if (return_info.type == Variant::INT && return_info.usage & PROPERTY_USAGE_CLASS_IS_ENUM) {
+				imethod.return_type.cname = return_info.class_name;
+				imethod.return_type.is_enum = true;
 			} else if (return_info.class_name != StringName()) {
-				imethod.return_type = return_info.class_name;
+				imethod.return_type.cname = return_info.class_name;
 			} else if (return_info.hint == PROPERTY_HINT_RESOURCE_TYPE) {
-				imethod.return_type = return_info.hint_string;
+				imethod.return_type.cname = return_info.hint_string;
 			} else if (return_info.type == Variant::NIL && return_info.usage & PROPERTY_USAGE_NIL_IS_VARIANT) {
-				imethod.return_type = name_cache.type_Variant;
+				imethod.return_type.cname = name_cache.type_Variant;
 			} else if (return_info.type == Variant::NIL) {
-				imethod.return_type = name_cache.type_void;
+				imethod.return_type.cname = name_cache.type_void;
 			} else {
-				imethod.return_type = Variant::get_type_name(return_info.type);
+				imethod.return_type.cname = Variant::get_type_name(return_info.type);
 			}
 
-			if (!itype.requires_collections && imethod.return_type == name_cache.type_Dictionary)
+			if (!itype.requires_collections && imethod.return_type.cname == name_cache.type_Dictionary)
 				itype.requires_collections = true;
 
 			for (int i = 0; i < argc; i++) {
@@ -1912,21 +1918,22 @@ void BindingsGenerator::_populate_object_type_interfaces() {
 				ArgumentInterface iarg;
 				iarg.name = arginfo.name;
 
-				if (arginfo.type == Variant::INT && arginfo.usage & PROPERTY_USAGE_CLASS_IS_ENUM) { // TODO redundant?
-					iarg.type = arginfo.class_name;
+				if (arginfo.type == Variant::INT && arginfo.usage & PROPERTY_USAGE_CLASS_IS_ENUM) {
+					iarg.type.cname = arginfo.class_name;
+					iarg.type.is_enum = true;
 				} else if (arginfo.class_name != StringName()) {
-					iarg.type = arginfo.class_name;
+					iarg.type.cname = arginfo.class_name;
 				} else if (arginfo.hint == PROPERTY_HINT_RESOURCE_TYPE) {
-					iarg.type = arginfo.hint_string;
+					iarg.type.cname = arginfo.hint_string;
 				} else if (arginfo.type == Variant::NIL) {
-					iarg.type = name_cache.type_Variant;
+					iarg.type.cname = name_cache.type_Variant;
 				} else {
-					iarg.type = Variant::get_type_name(arginfo.type);
+					iarg.type.cname = Variant::get_type_name(arginfo.type);
 				}
 
 				iarg.name = escape_csharp_keyword(snake_to_camel_case(iarg.name));
 
-				if (!itype.requires_collections && iarg.type == name_cache.type_Dictionary)
+				if (!itype.requires_collections && iarg.type.cname == name_cache.type_Dictionary)
 					itype.requires_collections = true;
 
 				if (m && m->has_default_argument(i)) {
@@ -1938,7 +1945,7 @@ void BindingsGenerator::_populate_object_type_interfaces() {
 
 			if (imethod.is_vararg) {
 				ArgumentInterface ivararg;
-				ivararg.type = name_cache.type_VarArg;
+				ivararg.type.cname = name_cache.type_VarArg;
 				ivararg.name = "@args";
 				imethod.add_argument(ivararg);
 			}
@@ -2023,17 +2030,11 @@ void BindingsGenerator::_populate_object_type_interfaces() {
 			itype.enums.push_back(ienum);
 
 			TypeInterface enum_itype;
+			enum_itype.is_enum = true;
 			enum_itype.name = itype.name + "." + String(*k);
 			enum_itype.cname = StringName(enum_itype.name);
 			enum_itype.proxy_name = itype.proxy_name + "." + enum_proxy_name;
-			enum_itype.c_arg_in = "&%s";
-			enum_itype.c_type = "int";
-			enum_itype.c_type_in = "int";
-			enum_itype.c_type_out = "int";
-			enum_itype.cs_type = enum_itype.proxy_name;
-			enum_itype.im_type_in = enum_itype.proxy_name;
-			enum_itype.im_type_out = enum_itype.proxy_name;
-			enum_itype.class_doc = &EditorHelp::get_doc_data()->class_list[enum_itype.proxy_name];
+			TypeInterface::postsetup_enum_type(enum_itype);
 			enum_types.insert(enum_itype.cname, enum_itype);
 		}
 
@@ -2068,7 +2069,7 @@ void BindingsGenerator::_default_argument_from_variant(const Variant &p_val, Arg
 
 	switch (p_val.get_type()) {
 		case Variant::NIL:
-			if (ClassDB::class_exists(r_iarg.type)) {
+			if (ClassDB::class_exists(r_iarg.type.cname)) {
 				// Object type
 				r_iarg.default_argument = "null";
 			} else {
@@ -2081,7 +2082,7 @@ void BindingsGenerator::_default_argument_from_variant(const Variant &p_val, Arg
 			r_iarg.default_argument = bool(p_val) ? "true" : "false";
 			break;
 		case Variant::INT:
-			if (r_iarg.type != name_cache.type_int) {
+			if (r_iarg.type.cname != name_cache.type_int) {
 				r_iarg.default_argument = "(%s)" + r_iarg.default_argument;
 			}
 			break;
@@ -2142,7 +2143,7 @@ void BindingsGenerator::_default_argument_from_variant(const Variant &p_val, Arg
 		default: {}
 	}
 
-	if (r_iarg.def_param_mode == ArgumentInterface::CONSTANT && r_iarg.type == name_cache.type_Variant && r_iarg.default_argument != "null")
+	if (r_iarg.def_param_mode == ArgumentInterface::CONSTANT && r_iarg.type.cname == name_cache.type_Variant && r_iarg.default_argument != "null")
 		r_iarg.def_param_mode = ArgumentInterface::NULLABLE_REF;
 }
 
@@ -2161,7 +2162,7 @@ void BindingsGenerator::_populate_builtin_type_interfaces() {
 		itype.c_arg_in = "&%s_in";                                                                    \
 		itype.c_type_in = m_type_in;                                                                  \
 		itype.cs_in = "ref %s";                                                                       \
-		itype.cs_out = "return (" #m_type ")%0;";                                                     \
+		itype.cs_out = "return (%1)%0;";                                                              \
 		itype.im_type_out = "object";                                                                 \
 		builtin_types.insert(itype.cname, itype);                                                     \
 	}
@@ -2256,7 +2257,7 @@ void BindingsGenerator::_populate_builtin_type_interfaces() {
 	itype.c_type_out = itype.c_type + "*";
 	itype.cs_type = itype.proxy_name;
 	itype.cs_in = "NodePath." CS_SMETHOD_GETINSTANCE "(%0)";
-	itype.cs_out = "return new NodePath(%0);";
+	itype.cs_out = "return new %1(%0);";
 	itype.im_type_in = "IntPtr";
 	itype.im_type_out = "IntPtr";
 	_populate_builtin_type(itype, Variant::NODE_PATH);
@@ -2279,7 +2280,7 @@ void BindingsGenerator::_populate_builtin_type_interfaces() {
 	itype.c_type_out = itype.c_type + "*";
 	itype.cs_type = itype.proxy_name;
 	itype.cs_in = "RID." CS_SMETHOD_GETINSTANCE "(%0)";
-	itype.cs_out = "return new RID(%0);";
+	itype.cs_out = "return new %1(%0);";
 	itype.im_type_in = "IntPtr";
 	itype.im_type_out = "IntPtr";
 	_populate_builtin_type(itype, Variant::_RID);
@@ -2408,11 +2409,11 @@ void BindingsGenerator::_populate_builtin_type(TypeInterface &r_itype, Variant::
 			iarg.name = pi.name;
 
 			if (pi.type == Variant::NIL)
-				iarg.type = name_cache.type_Variant;
+				iarg.type.cname = name_cache.type_Variant;
 			else
-				iarg.type = Variant::get_type_name(pi.type);
+				iarg.type.cname = Variant::get_type_name(pi.type);
 
-			if (!r_itype.requires_collections && iarg.type == name_cache.type_Dictionary)
+			if (!r_itype.requires_collections && iarg.type.cname == name_cache.type_Dictionary)
 				r_itype.requires_collections = true;
 
 			if ((mi.default_arguments.size() - mi.arguments.size() + i) >= 0)
@@ -2423,12 +2424,12 @@ void BindingsGenerator::_populate_builtin_type(TypeInterface &r_itype, Variant::
 
 		if (mi.return_val.type == Variant::NIL) {
 			if (mi.return_val.name != "")
-				imethod.return_type = name_cache.type_Variant;
+				imethod.return_type.cname = name_cache.type_Variant;
 		} else {
-			imethod.return_type = Variant::get_type_name(mi.return_val.type);
+			imethod.return_type.cname = Variant::get_type_name(mi.return_val.type);
 		}
 
-		if (!r_itype.requires_collections && imethod.return_type == name_cache.type_Dictionary)
+		if (!r_itype.requires_collections && imethod.return_type.cname == name_cache.type_Dictionary)
 			r_itype.requires_collections = true;
 
 		if (r_itype.class_doc) {
@@ -2494,13 +2495,11 @@ void BindingsGenerator::_populate_global_constants() {
 			EnumInterface &ienum = E->get();
 
 			TypeInterface enum_itype;
-			enum_itype = TypeInterface::create_value_type(ienum.cname);
-			enum_itype.c_arg_in = "&%s";
-			enum_itype.c_type = "int";
-			enum_itype.c_type_in = "int";
-			enum_itype.c_type_out = "int";
-			enum_itype.im_type_in = enum_itype.name;
-			enum_itype.im_type_out = enum_itype.name;
+			enum_itype.is_enum = true;
+			enum_itype.name = ienum.cname.operator String();
+			enum_itype.cname = ienum.cname;
+			enum_itype.proxy_name = enum_itype.name;
+			TypeInterface::postsetup_enum_type(enum_itype);
 			enum_types.insert(enum_itype.cname, enum_itype);
 
 			ienum.prefix = _determine_enum_prefix(ienum);
@@ -2521,15 +2520,13 @@ void BindingsGenerator::_populate_global_constants() {
 	hardcoded_enums.push_back("Vector3.Axis");
 	for (List<StringName>::Element *E = hardcoded_enums.front(); E; E = E->next()) {
 		// These enums are not generated and must be written manually (e.g.: Vector3.Axis)
-		// Here, we are assuming core types do not begin with underscore
+		// Here, we assume core types do not begin with underscore
 		TypeInterface enum_itype;
-		enum_itype = TypeInterface::create_value_type(E->get());
-		enum_itype.c_arg_in = "&%s";
-		enum_itype.c_type = "int";
-		enum_itype.c_type_in = "int";
-		enum_itype.c_type_out = "int";
-		enum_itype.im_type_in = enum_itype.name;
-		enum_itype.im_type_out = enum_itype.name;
+		enum_itype.is_enum = true;
+		enum_itype.name = E->get().operator String();
+		enum_itype.cname = E->get();
+		enum_itype.proxy_name = enum_itype.name;
+		TypeInterface::postsetup_enum_type(enum_itype);
 		enum_types.insert(enum_itype.cname, enum_itype);
 	}
 }

--- a/modules/mono/mono_reg_utils.py
+++ b/modules/mono/mono_reg_utils.py
@@ -75,7 +75,7 @@ def find_msbuild_tools_path_reg():
         vswhere = os.getenv('PROGRAMFILES')
     vswhere += r'\Microsoft Visual Studio\Installer\vswhere.exe'
 
-    vswhere_args = ['-latest', '-requires', 'Microsoft.Component.MSBuild']
+    vswhere_args = ['-latest', '-products', '*', '-requires', 'Microsoft.Component.MSBuild']
 
     try:
         lines = subprocess.check_output([vswhere] + vswhere_args).splitlines()

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1323,6 +1323,8 @@ public:
 
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) {
 
+		ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
+
 		String src_apk;
 
 		EditorProgress ep("export", "Exporting for Android", 105);


### PR DESCRIPTION
Added a mirroring option to the path editing tool bar for manipulating curve in/out handles (also known as tangent handles), which makes creating curved paths a lot easier. I've added this functionality for both 2D and 3D curves. If you feel the way I've implemented is wrong or could be improved, please let me know :)

![handles](https://user-images.githubusercontent.com/10464013/39424005-8eb148ca-4c6c-11e8-8751-687a75753bdb.gif)
