### PR TITLE
Fix msbuild with a msvc 'tools only' install

### DIFF
--- a/modules/mono/mono_reg_utils.py
+++ b/modules/mono/mono_reg_utils.py
@@ -75,7 +75,7 @@ def find_msbuild_tools_path_reg():
         vswhere = os.getenv('PROGRAMFILES')
     vswhere += r'\Microsoft Visual Studio\Installer\vswhere.exe'
 
-    vswhere_args = ['-latest', '-requires', 'Microsoft.Component.MSBuild']
+    vswhere_args = ['-latest', '-products', '*', '-requires', 'Microsoft.Component.MSBuild']
 
     try:
         lines = subprocess.check_output([vswhere] + vswhere_args).splitlines()


### PR DESCRIPTION
Taken from https://github.com/Microsoft/vswhere/wiki/Find-MSBuild
without '-products *' vswhere does not locate msbuild when installing a
tools-only (no IDE) version of the microsoft compilers.