### PR TITLE
Improve the 3D editor grid

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -400,8 +400,17 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	_initial_set("editors/grid_map/pick_distance", 5000.0);
 
-	_initial_set("editors/3d/grid_color", Color::html("808080"));
-	hints["editors/3d/grid_color"] = PropertyInfo(Variant::COLOR, "editors/3d/grid_color", PROPERTY_HINT_COLOR_NO_ALPHA, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
+	_initial_set("editors/3d/primary_grid_color", Color::html("909090"));
+	hints["editors/3d/primary_grid_color"] = PropertyInfo(Variant::COLOR, "editors/3d/primary_grid_color", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
+
+	_initial_set("editors/3d/secondary_grid_color", Color::html("606060"));
+	hints["editors/3d/secondary_grid_color"] = PropertyInfo(Variant::COLOR, "editors/3d/secondary_grid_color", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
+
+	_initial_set("editors/3d/grid_size", 50);
+	hints["editors/3d/grid_size"] = PropertyInfo(Variant::INT, "editors/3d/grid_size", PROPERTY_HINT_RANGE, "1,500,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
+
+	_initial_set("editors/3d/primary_grid_steps", 10);
+	hints["editors/3d/primary_grid_steps"] = PropertyInfo(Variant::INT, "editors/3d/primary_grid_steps", PROPERTY_HINT_RANGE, "1,100,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 
 	_initial_set("editors/3d/default_fov", 70.0);
 	_initial_set("editors/3d/default_z_near", 0.05);

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -4598,7 +4598,10 @@ void SpatialEditor::_init_grid() {
 	PoolVector<Color> grid_colors[3];
 	PoolVector<Vector3> grid_points[3];
 
-	Color grid_color = EditorSettings::get_singleton()->get("editors/3d/grid_color");
+	Color primary_grid_color = EditorSettings::get_singleton()->get("editors/3d/primary_grid_color");
+	Color secondary_grid_color = EditorSettings::get_singleton()->get("editors/3d/secondary_grid_color");
+	int grid_size = EditorSettings::get_singleton()->get("editors/3d/grid_size");
+	int primary_grid_steps = EditorSettings::get_singleton()->get("editors/3d/primary_grid_steps");
 
 	for (int i = 0; i < 3; i++) {
 		Vector3 axis;
@@ -4608,19 +4611,17 @@ void SpatialEditor::_init_grid() {
 		Vector3 axis_n2;
 		axis_n2[(i + 2) % 3] = 1;
 
-#define ORIGIN_GRID_SIZE 50
-
-		for (int j = -ORIGIN_GRID_SIZE; j <= ORIGIN_GRID_SIZE; j++) {
-			Vector3 p1 = axis_n1 * j + axis_n2 * -ORIGIN_GRID_SIZE;
+		for (int j = -grid_size; j <= grid_size; j++) {
+			Vector3 p1 = axis_n1 * j + axis_n2 * -grid_size;
 			Vector3 p1_dest = p1 * (-axis_n2 + axis_n1);
-			Vector3 p2 = axis_n2 * j + axis_n1 * -ORIGIN_GRID_SIZE;
+			Vector3 p2 = axis_n2 * j + axis_n1 * -grid_size;
 			Vector3 p2_dest = p2 * (-axis_n1 + axis_n2);
 
-			Color line_color = grid_color;
+			Color line_color = secondary_grid_color;
 			if (j == 0) {
 				continue;
-			} else if (j % 10 == 0) {
-				line_color *= 1.5;
+			} else if (j % primary_grid_steps == 0) {
+				line_color = primary_grid_color;
 			}
 
 			grid_points[i].push_back(p1);


### PR DESCRIPTION
- The grid's primary and secondary colors can now be changed
- The number of grid steps (subdivisions) can now be changed
- The grid size can now be changed
- The grid is now darker by default

**New default grid settings:**

![improved_3d_grid_default](https://user-images.githubusercontent.com/180032/39427533-573d2cb6-4c84-11e8-8d50-aa6757299274.png)

**Example grid settings tweak:**

![improved_3d_grid_tweaked](https://user-images.githubusercontent.com/180032/39427534-576362c8-4c84-11e8-9ade-a6206314e847.png)
