### PR TITLE
Adds keywords to autocomplete predictions.

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1521,6 +1521,13 @@ static void _find_identifiers(GDScriptCompletionContext &context, int p_line, bo
 		result.insert(_type_names[i]);
 	}
 
+	List<String> reserved_words;
+	GDScriptLanguage::get_singleton()->get_reserved_words(&reserved_words);
+
+	for (List<String>::Element *E = reserved_words.front(); E; E = E->next()) {
+		result.insert(E->get());
+	}
+
 	//autoload singletons
 	List<PropertyInfo> props;
 	ProjectSettings::get_singleton()->get_property_list(&props);


### PR DESCRIPTION
Adds keywords to the autocomplete prediction in GDScript so
they are not replaced by irrelevant predictions.

Fixes: #5972