### PR TITLE
Added curve in/out (tangent) handle mirroring

### DIFF
--- a/editor/plugins/path_2d_editor_plugin.h
+++ b/editor/plugins/path_2d_editor_plugin.h
@@ -69,6 +69,15 @@ class Path2DEditor : public HBoxContainer {
 	ToolButton *curve_edit_curve;
 	ToolButton *curve_del;
 	ToolButton *curve_close;
+	MenuButton *handle_menu;
+
+	bool mirror_handle_angle;
+	bool mirror_handle_length;
+
+	enum HandleOption {
+		HANDLE_OPTION_ANGLE,
+		HANDLE_OPTION_LENGTH
+	};
 
 	enum Action {
 
@@ -82,8 +91,11 @@ class Path2DEditor : public HBoxContainer {
 	int action_point;
 	Point2 moving_from;
 	Point2 moving_screen_from;
+	float orig_in_length;
+	float orig_out_length;
 
 	void _mode_selected(int p_mode);
+	void _handle_option_pressed(int p_option);
 
 	void _node_visibility_changed();
 	friend class Path2DEditorPlugin;

--- a/editor/plugins/path_editor_plugin.h
+++ b/editor/plugins/path_editor_plugin.h
@@ -1,4 +1,4 @@
-/*************************************************************************/
+﻿/*************************************************************************/
 /*  path_editor_plugin.h                                                 */
 /*************************************************************************/
 /*                       This file is part of:                           */
@@ -40,6 +40,8 @@ class PathSpatialGizmo : public EditorSpatialGizmo {
 
 	Path *path;
 	mutable Vector3 original;
+	mutable float orig_in_length;
+	mutable float orig_out_length;
 
 public:
 	virtual String get_handle_name(int p_idx) const;
@@ -60,6 +62,7 @@ class PathEditorPlugin : public EditorPlugin {
 	ToolButton *curve_edit;
 	ToolButton *curve_del;
 	ToolButton *curve_close;
+	MenuButton *handle_menu;
 
 	EditorNode *editor;
 
@@ -67,6 +70,15 @@ class PathEditorPlugin : public EditorPlugin {
 
 	void _mode_changed(int p_idx);
 	void _close_curve();
+	void _handle_option_pressed(int p_option);
+	bool handle_clicked;
+	bool mirror_handle_angle;
+	bool mirror_handle_length;
+
+	enum HandleOption {
+		HANDLE_OPTION_ANGLE,
+		HANDLE_OPTION_LENGTH
+	};
 
 protected:
 	void _notification(int p_what);
@@ -87,6 +99,11 @@ public:
 	virtual void edit(Object *p_object);
 	virtual bool handles(Object *p_object) const;
 	virtual void make_visible(bool p_visible);
+
+	bool mirror_angle_enabled() { return mirror_handle_angle; }
+	bool mirror_length_enabled() { return mirror_handle_length; }
+	bool is_handle_clicked() { return handle_clicked; }
+	void set_handle_clicked(bool clicked) { handle_clicked = clicked; }
 
 	PathEditorPlugin(EditorNode *p_node);
 	~PathEditorPlugin();


### PR DESCRIPTION
(Sorry, re-created this pull request because I well and truly destroyed my last branch trying to squash commits...)

Added a mirroring option to the path editing tool bar for manipulating curve in/out handles (also known as tangent handles), which makes creating curved paths a lot easier. I've added this functionality for both 2D and 3D curves. If you feel the way I've implemented is wrong or could be improved, please let me know :)

![2d](https://user-images.githubusercontent.com/10464013/39452710-1bc70d5e-4ccb-11e8-85a5-c43fe99db6cd.gif)

![3d](https://user-images.githubusercontent.com/10464013/39452715-205a7144-4ccb-11e8-8bf3-9b5fadd0e950.gif)
