### PR TITLE
windows: ensure minimum possible timer resolution for sleep

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -188,6 +188,10 @@ void OS_Windows::initialize_core() {
 	ticks_start = 0;
 	ticks_start = get_ticks_usec();
 
+	// set minimum resolution for periodic timers, otherwise Sleep(n) may wait at least as
+	//  long as the windows scheduler resolution (~16-30ms) even for calls like Sleep(1)
+	timeBeginPeriod(1);
+
 	process_map = memnew((Map<ProcessID, ProcessInfo>));
 
 	IP_Unix::make_default();
@@ -1260,6 +1264,8 @@ void OS_Windows::finalize() {
 }
 
 void OS_Windows::finalize_core() {
+
+	timeEndPeriod(1);
 
 	memdelete(process_map);
 


### PR DESCRIPTION
Right now, `OS_Windows::delay_usec` calls windows `Sleep` function.

A problem being that the windows timer resolution is somewhere between 15-30ms normally, so even a call to `Sleep(1)` could potentially end up waiting for 15-30ms, which is far from optimal.

Luckily windows provides [timeBeginPeriod](https://msdn.microsoft.com/en-us/library/dd757624(v=vs.85).aspx) to set the minimum desired resolution (down to a millisecond).

So this is a simple and harmless fix, might get rid of some odd hitches if we're lucky (if for some reason the resolution isn't already 1ms set by another process on the system).

But generally it shouldn't cause any havoc at least.

(in most cases, the timer res might already be 1ms due to another program setting it system wide, your browser.. some audio utility or something else, but ensuring it actually is can't hurt)