### PR TITLE
Prevent PulseAudio driver to lock its mutex for too long

### DIFF
--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -340,13 +340,22 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 						bytes = byte_size;
 					}
 
-					int ret = pa_stream_write(ad->pa_str, ptr, bytes, NULL, 0LL, PA_SEEK_RELATIVE);
+					ret = pa_stream_write(ad->pa_str, ptr, bytes, NULL, 0LL, PA_SEEK_RELATIVE);
 					if (ret >= 0) {
 						byte_size -= bytes;
 						ptr = (const char *)ptr + bytes;
 					}
 				} else {
-					pa_mainloop_iterate(ad->pa_ml, 1, NULL);
+					ret = pa_mainloop_iterate(ad->pa_ml, 0, NULL);
+					if (ret == 0) {
+						// If pa_mainloop_iterate returns 0 sleep for 1 msec to wait
+						// for the stream to be able to process more bytes
+						ad->unlock();
+
+						OS::get_singleton()->delay_usec(1000);
+
+						ad->lock();
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #18366