### PR TITLE
Fix a crash when trying to run Godot debugger on a release build.

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -1311,9 +1311,9 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		GDScriptLanguage::get_singleton()->script_frame_time += time_taken - function_call_time;
 	}
 
-#endif
 	if (ScriptDebugger::get_singleton())
 		GDScriptLanguage::get_singleton()->exit_function();
+#endif
 
 	if (_stack_size) {
 		//free stack


### PR DESCRIPTION
The GDScriptLanguage::enter_function is wrapped in #ifdef DEBUG but the exit_function is not, resulting in a stack underflow error.