### PR TITLE
Fix editor detecting msbuild with a msvc 'tools only' install

### DIFF
--- a/modules/mono/utils/mono_reg_utils.cpp
+++ b/modules/mono/utils/mono_reg_utils.cpp
@@ -174,6 +174,8 @@ String find_msbuild_tools_path() {
 
 	List<String> vswhere_args;
 	vswhere_args.push_back("-latest");
+	vswhere_args.push_back("-products");
+	vswhere_args.push_back("*");
 	vswhere_args.push_back("-requires");
 	vswhere_args.push_back("Microsoft.Component.MSBuild");
 


### PR DESCRIPTION
Applied the same changes in #18522 to the editor.
