### PR TITLE
Fix placeholders position in `LineEdit` when editing inside the Editor

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1143,7 +1143,6 @@ void LineEdit::clear_internal() {
 
 	_clear_undo_stack();
 	cached_width = 0;
-	cached_placeholder_width = 0;
 	cursor_pos = 0;
 	window_pos = 0;
 	undo_text = "";


### PR DESCRIPTION
Fix placeholders position in `LineEdit` when editing inside the Editor

Editing the `Text` property through the editor causes a wrong
placement of the placeholder, as it calls `LineEdit::clear_internal`,
which was wrongly reseting the cached placeholder width.

Fix #18184.