### PR TITLE
Fix for ARVRCamera::project_local_ray_normal not getting called.

### DIFF
--- a/scene/3d/camera.h
+++ b/scene/3d/camera.h
@@ -132,9 +132,9 @@ public:
 
 	virtual Transform get_camera_transform() const;
 
-	Vector3 project_ray_normal(const Point2 &p_pos) const;
+	virtual Vector3 project_ray_normal(const Point2 &p_pos) const;
 	virtual Vector3 project_ray_origin(const Point2 &p_pos) const;
-	Vector3 project_local_ray_normal(const Point2 &p_pos) const;
+	virtual Vector3 project_local_ray_normal(const Point2 &p_pos) const;
 	virtual Point2 unproject_position(const Vector3 &p_pos) const;
 	bool is_position_behind(const Vector3 &p_pos) const;
 	virtual Vector3 project_position(const Point2 &p_point) const;


### PR DESCRIPTION
Camera::project_local_ray_normal needs to be virtual so that ARVRCamera::project_local_ray_normal gets called.