### PR TITLE
Add stretch mode to VideoPlayer control

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1971,7 +1971,6 @@ FindBar::FindBar() {
 	hide_button = memnew(TextureButton);
 	add_child(hide_button);
 	hide_button->set_focus_mode(FOCUS_NONE);
-	hide_button->set_expand(true);
 	hide_button->set_stretch_mode(TextureButton::STRETCH_KEEP_CENTERED);
 	hide_button->connect("pressed", this, "_hide_pressed");
 }

--- a/editor/editor_profiler.cpp
+++ b/editor/editor_profiler.cpp
@@ -694,7 +694,6 @@ EditorProfiler::EditorProfiler() {
 	variables->connect("item_edited", this, "_item_edited");
 
 	graph = memnew(TextureRect);
-	graph->set_expand(true);
 	graph->set_mouse_filter(MOUSE_FILTER_STOP);
 	//graph->set_ignore_mouse(false);
 	graph->connect("draw", this, "_graph_tex_draw");

--- a/scene/gui/texture_button.h
+++ b/scene/gui/texture_button.h
@@ -55,7 +55,6 @@ private:
 	Ref<Texture> disabled;
 	Ref<Texture> focused;
 	Ref<BitMap> click_mask;
-	bool expand;
 	StretchMode stretch_mode;
 
 	Rect2 _texture_region;
@@ -63,7 +62,6 @@ private:
 	bool _tile;
 
 protected:
-	virtual Size2 get_minimum_size() const;
 	virtual bool has_point(const Point2 &p_point) const;
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -82,9 +80,6 @@ public:
 	Ref<Texture> get_disabled_texture() const;
 	Ref<Texture> get_focused_texture() const;
 	Ref<BitMap> get_click_mask() const;
-
-	bool get_expand() const;
-	void set_expand(bool p_expand);
 
 	void set_stretch_mode(StretchMode p_stretch_mode);
 	StretchMode get_stretch_mode() const;

--- a/scene/gui/texture_rect.cpp
+++ b/scene/gui/texture_rect.cpp
@@ -39,10 +39,6 @@ void TextureRect::_notification(int p_what) {
 			return;
 
 		switch (stretch_mode) {
-			case STRETCH_SCALE_ON_EXPAND: {
-				Size2 s = expand ? get_size() : texture->get_size();
-				draw_texture_rect(texture, Rect2(Point2(), s), false);
-			} break;
 			case STRETCH_SCALE: {
 				draw_texture_rect(texture, Rect2(Point2(), get_size()), false);
 			} break;
@@ -93,27 +89,16 @@ void TextureRect::_notification(int p_what) {
 	}
 }
 
-Size2 TextureRect::get_minimum_size() const {
-
-	if (!expand && !texture.is_null())
-		return texture->get_size();
-	else
-		return Size2();
-}
 void TextureRect::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_texture", "texture"), &TextureRect::set_texture);
 	ClassDB::bind_method(D_METHOD("get_texture"), &TextureRect::get_texture);
-	ClassDB::bind_method(D_METHOD("set_expand", "enable"), &TextureRect::set_expand);
-	ClassDB::bind_method(D_METHOD("has_expand"), &TextureRect::has_expand);
 	ClassDB::bind_method(D_METHOD("set_stretch_mode", "stretch_mode"), &TextureRect::set_stretch_mode);
 	ClassDB::bind_method(D_METHOD("get_stretch_mode"), &TextureRect::get_stretch_mode);
 
 	ADD_PROPERTYNZ(PropertyInfo(Variant::OBJECT, "texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_texture", "get_texture");
-	ADD_PROPERTYNZ(PropertyInfo(Variant::BOOL, "expand"), "set_expand", "has_expand");
-	ADD_PROPERTYNO(PropertyInfo(Variant::INT, "stretch_mode", PROPERTY_HINT_ENUM, "Scale On Expand (Compat),Scale,Tile,Keep,Keep Centered,Keep Aspect,Keep Aspect Centered,Keep Aspect Covered"), "set_stretch_mode", "get_stretch_mode");
+	ADD_PROPERTYNO(PropertyInfo(Variant::INT, "stretch_mode", PROPERTY_HINT_ENUM, "Scale,Tile,Keep,Keep Centered,Keep Aspect,Keep Aspect Centered,Keep Aspect Covered"), "set_stretch_mode", "get_stretch_mode");
 
-	BIND_ENUM_CONSTANT(STRETCH_SCALE_ON_EXPAND);
 	BIND_ENUM_CONSTANT(STRETCH_SCALE);
 	BIND_ENUM_CONSTANT(STRETCH_TILE);
 	BIND_ENUM_CONSTANT(STRETCH_KEEP);
@@ -139,17 +124,6 @@ Ref<Texture> TextureRect::get_texture() const {
 	return texture;
 }
 
-void TextureRect::set_expand(bool p_expand) {
-
-	expand = p_expand;
-	update();
-	minimum_size_changed();
-}
-bool TextureRect::has_expand() const {
-
-	return expand;
-}
-
 void TextureRect::set_stretch_mode(StretchMode p_mode) {
 
 	stretch_mode = p_mode;
@@ -163,9 +137,8 @@ TextureRect::StretchMode TextureRect::get_stretch_mode() const {
 
 TextureRect::TextureRect() {
 
-	expand = false;
 	set_mouse_filter(MOUSE_FILTER_PASS);
-	stretch_mode = STRETCH_SCALE_ON_EXPAND;
+	stretch_mode = STRETCH_SCALE;
 }
 
 TextureRect::~TextureRect() {

--- a/scene/gui/texture_rect.h
+++ b/scene/gui/texture_rect.h
@@ -41,7 +41,6 @@ class TextureRect : public Control {
 
 public:
 	enum StretchMode {
-		STRETCH_SCALE_ON_EXPAND, //default, for backwards compatibility
 		STRETCH_SCALE,
 		STRETCH_TILE,
 		STRETCH_KEEP,
@@ -52,21 +51,16 @@ public:
 	};
 
 private:
-	bool expand;
 	Ref<Texture> texture;
 	StretchMode stretch_mode;
 
 protected:
 	void _notification(int p_what);
-	virtual Size2 get_minimum_size() const;
 	static void _bind_methods();
 
 public:
 	void set_texture(const Ref<Texture> &p_tex);
 	Ref<Texture> get_texture() const;
-
-	void set_expand(bool p_expand);
-	bool has_expand() const;
 
 	void set_stretch_mode(StretchMode p_mode);
 	StretchMode get_stretch_mode() const;

--- a/scene/gui/video_player.h
+++ b/scene/gui/video_player.h
@@ -40,6 +40,18 @@ class VideoPlayer : public Control {
 
 	GDCLASS(VideoPlayer, Control);
 
+public:
+	enum StretchMode {
+		STRETCH_SCALE,
+		STRETCH_TILE,
+		STRETCH_KEEP,
+		STRETCH_KEEP_CENTERED,
+		STRETCH_KEEP_ASPECT,
+		STRETCH_KEEP_ASPECT_CENTERED,
+		STRETCH_KEEP_ASPECT_COVERED,
+	};
+
+private:
 	struct Output {
 
 		AudioFrame vol;
@@ -65,11 +77,11 @@ class VideoPlayer : public Control {
 	bool autoplay;
 	float volume;
 	double last_audio_time;
-	bool expand;
 	bool loops;
 	int buffering_ms;
 	int audio_track;
 	int bus_index;
+	StretchMode stretch_mode;
 
 	StringName bus;
 
@@ -83,10 +95,6 @@ protected:
 	void _validate_property(PropertyInfo &property) const;
 
 public:
-	Size2 get_minimum_size() const;
-	void set_expand(bool p_expand);
-	bool has_expand() const;
-
 	Ref<Texture> get_video_texture();
 
 	void set_stream(const Ref<VideoStream> &p_stream);
@@ -121,8 +129,12 @@ public:
 	void set_bus(const StringName &p_bus);
 	StringName get_bus() const;
 
+	void set_stretch_mode(StretchMode p_mode);
+	StretchMode get_stretch_mode() const;
+
 	VideoPlayer();
 	~VideoPlayer();
 };
 
+VARIANT_ENUM_CAST(VideoPlayer::StretchMode);
 #endif // VIDEO_PLAYER_H


### PR DESCRIPTION
Adds stretch mode functionality to the VideoPlayer control.  This is a direct copy from TextureRect, with the exception that I removed STRETCH_SCALE_ON_EXPAND, which appears to be deprecated (but kept around for backward compatibility).