### PR TITLE
Fix delay in rename_error windows save loop, should be 100msec, not 1sec

### DIFF
--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -162,7 +162,7 @@ void FileAccessWindows::close() {
 			}
 			if (rename_error) {
 				attempts--;
-				OS::get_singleton()->delay_usec(1000000); //wait 100msec and try again
+				OS::get_singleton()->delay_usec(100000); // wait 100msec and try again
 			}
 		}
 


### PR DESCRIPTION
Found this when I was rooting through all the uses of ``delay_usec`` in the codebase when doing the other PR, if this new behaviour breaks things somehow, at least now it does what it says it should be doing. (and waiting 1 second between each iteration seems like a long time)

related to #14339 