### PR TITLE
Remove unused duplicate wireframe shortcut

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -5082,8 +5082,6 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	ED_SHORTCUT("spatial_editor/tool_rotate", TTR("Tool Rotate"), KEY_E);
 	ED_SHORTCUT("spatial_editor/tool_scale", TTR("Tool Scale"), KEY_R);
 
-	ED_SHORTCUT("spatial_editor/display_wireframe", TTR("Display Wireframe"), KEY_Z);
-
 	ED_SHORTCUT("spatial_editor/freelook_toggle", TTR("Toggle Freelook"), KEY_MASK_SHIFT + KEY_F);
 
 	PopupMenu *p;


### PR DESCRIPTION
So there was this duplicate shortcut that seems to have been left behind when the new viewport shading bindings were also added, this just removes it as it does nothing and isn't referenced anywhere.

Something to consider usability-wise may be a binding to switch between the viewport shading modes (bound to Z?) instead of a separate keybind for every single mode (and right now, none of them are bound).