### PR TITLE
Script Editor now displays positional column

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -677,7 +677,20 @@ void CodeTextEditor::_reset_zoom() {
 void CodeTextEditor::_line_col_changed() {
 
 	line_nb->set_text(itos(text_editor->cursor_get_line() + 1));
-	col_nb->set_text(itos(text_editor->cursor_get_column() + 1));
+
+	String line = text_editor->get_line(text_editor->cursor_get_line());
+
+	int positional_column = 0;
+
+	for (int i = 0; i < text_editor->cursor_get_column(); i++) {
+		if (line[i] == '\t') {
+			positional_column += text_editor->get_indent_size(); //tab size
+		} else {
+			positional_column += 1;
+		}
+	}
+
+	col_nb->set_text(itos(positional_column + 1));
 }
 
 void CodeTextEditor::_text_changed() {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4978,6 +4978,11 @@ void TextEdit::set_indent_size(const int p_size) {
 	update();
 }
 
+int TextEdit::get_indent_size() {
+
+	return indent_size;
+}
+
 void TextEdit::set_draw_tabs(bool p_draw) {
 
 	draw_tabs = p_draw;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -557,6 +557,7 @@ public:
 	void set_indent_using_spaces(const bool p_use_spaces);
 	bool is_indent_using_spaces() const;
 	void set_indent_size(const int p_size);
+	int get_indent_size();
 	void set_draw_tabs(bool p_draw);
 	bool is_drawing_tabs() const;
 	void set_override_selected_font_color(bool p_override_selected_font_color);


### PR DESCRIPTION
This solves #17931 and makes the script editor consistent with other text editors(Sublime, Gedit, Vim) in displaying the position rather than the raw number of characters.
Basically, this makes tabs counted as multiple columns(based on indent size) rather than just one.