### PR TITLE
Closing the app might lead to a crash due to an IllegalArgumentException

### DIFF
--- a/platform/android/java/src/org/godotengine/godot/payments/PaymentsManager.java
+++ b/platform/android/java/src/org/godotengine/godot/payments/PaymentsManager.java
@@ -193,7 +193,13 @@ public class PaymentsManager {
 
 	public void destroy() {
 		if (mService != null) {
-			activity.unbindService(mServiceConn);
+			try {
+				activity.unbindService(mServiceConn);
+			} catch (IllegalArgumentException e) {
+				// Somehow we've already been unbound. This is a non-fatal
+				// error.
+				Log.e(TAG, "Unable to unbind from payment service (already unbound)");
+			}
 		}
 
 		mSetupDone = false;


### PR DESCRIPTION
Since closing the app on android might lead to a crash of PaymentManager service, I added a `try` `catch` on the `unbind` service method to catch it. If the service is already unbound when we are trying to close the app, we should not let it crash. Instead the exception is caught and logged as an error.

Crash report:
```
java.lang.RuntimeException: 
   at android.app.ActivityThread.performDestroyActivity (ActivityThread.java:4244)
   at android.app.ActivityThread.handleDestroyActivity (ActivityThread.java:4262)
   at android.app.ActivityThread.-wrap6 (ActivityThread.java)
   at android.app.ActivityThread$H.handleMessage (ActivityThread.java:1551)
   at android.os.Handler.dispatchMessage (Handler.java:102)
   at android.os.Looper.loop (Looper.java:154)
   at android.app.ActivityThread.main (ActivityThread.java:6165)
   at java.lang.reflect.Method.invoke (Native Method)
   at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run (ZygoteInit.java:888)
   at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:778)
Caused by: java.lang.IllegalArgumentException: 
   at android.app.LoadedApk.forgetServiceDispatcher (LoadedApk.java:1298)
   at android.app.ContextImpl.unbindService (ContextImpl.java:1483)
   at android.content.ContextWrapper.unbindService (ContextWrapper.java:648)
   at org.godotengine.godot.payments.PaymentsManager.destroy (Unknown Source)
   at org.godotengine.godot.Godot.onDestroy (Unknown Source)
   at android.app.Activity.performDestroy (Activity.java:6889)
   at android.app.Instrumentation.callActivityOnDestroy (Instrumentation.java:1175)
   at android.app.ActivityThread.performDestroyActivity (ActivityThread.java:4231)
```