### PR TITLE
Fix: JAR files signed with the MD5 algorithm as unsigned (godot 2)

### DIFF
--- a/platform/android/AndroidManifest.xml.template
+++ b/platform/android/AndroidManifest.xml.template
@@ -201,6 +201,6 @@ $$ADD_PERMISSION_CHUNKS$$
 <uses-permission android:name="godot.custom.18"/>
 <uses-permission android:name="godot.custom.19"/>
 
-<uses-sdk android:minSdkVersion="10" android:targetSdkVersion="23"/>
+<uses-sdk android:minSdkVersion="18" android:targetSdkVersion="27"/>
          
 </manifest> 

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1282,9 +1282,9 @@ Error EditorExportPlatformAndroid::export_project(const String &p_path, bool p_d
 
 		List<String> args;
 		args.push_back("-digestalg");
-		args.push_back("SHA1");
+		args.push_back("SHA-256");
 		args.push_back("-sigalg");
-		args.push_back("MD5withRSA");
+		args.push_back("SHA256withRSA");
 		String tsa_url = EditorSettings::get_singleton()->get("android/timestamping_authority_url");
 		if (tsa_url != "") {
 			args.push_back("-tsa");


### PR DESCRIPTION
Fix: JAR files signed with the MD5 algorithm as unsigned