### PR TITLE
Fix: JAR files signed with the MD5 algorithm as unsigned (godot 3)

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1643,9 +1643,9 @@ public:
 
 			List<String> args;
 			args.push_back("-digestalg");
-			args.push_back("SHA1");
+			args.push_back("SHA-256");
 			args.push_back("-sigalg");
-			args.push_back("MD5withRSA");
+			args.push_back("SHA256withRSA");
 			String tsa_url = EditorSettings::get_singleton()->get("export/android/timestamping_authority_url");
 			if (tsa_url != "") {
 				args.push_back("-tsa");


### PR DESCRIPTION
**Bugsquad edit**: Fixes https://github.com/godotengine/godot/issues/8758