### PR TITLE
Fix script editor CTRL+CLICK on singleton functions

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -746,6 +746,8 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 
 		_goto_line(p_row);
 
+		result.class_name = result.class_name.trim_prefix("_");
+
 		switch (result.type) {
 			case ScriptLanguage::LookupResult::RESULT_SCRIPT_LOCATION: {
 


### PR DESCRIPTION
Fixes #18604

It turns out the editor was looking up the `_Engine` class instead of `Engine`. Does anyone know of a situation where we would keep the "_" prefix? I don't want to overreach with this change.