### PR TITLE
"Up" Vector for Curve3D and new PathFollow Algorithm.

### DIFF
--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -232,6 +232,7 @@ class Curve3D : public Resource {
 	mutable bool baked_cache_dirty;
 	mutable PoolVector3Array baked_point_cache;
 	mutable PoolRealArray baked_tilt_cache;
+	mutable PoolVector3Array baked_up_vector_cache;
 	mutable float baked_max_ofs;
 
 	void _bake() const;
@@ -268,8 +269,10 @@ public:
 	float get_baked_length() const;
 	Vector3 interpolate_baked(float p_offset, bool p_cubic = false) const;
 	float interpolate_baked_tilt(float p_offset) const;
+	Vector3 interpolate_baked_up_vector(float p_offset, bool p_apply_tilt = false) const;
 	PoolVector3Array get_baked_points() const; //useful for going through
 	PoolRealArray get_baked_tilts() const; //useful for going through
+	PoolVector3Array get_baked_up_vectors() const;
 	Vector3 get_closest_point(const Vector3 &p_to_point) const;
 	float get_closest_offset(const Vector3 &p_to_point) const;
 


### PR DESCRIPTION

**Suggested Features**

- A baked "up vector" property added to Curve3D.
- Improved rollercoaster-like PathFollow algorithm using the previous feature.

**Why?**

The Baked Up Vector

- Sampling an up vector from an arbitrary offset in a 3D curve following a  rollercoaster fashion requires previous orientation information since the beginning of the curve to obtain the correct orientation on that specific offset, which is not desirable to do in realtime.
- Can be used for camera orientation (perhaps in a rollercoaster? xD).
- Tilt information is properly interpolated and used IF the user wishes to do so (ie: the apply_tilt argument).

The Rollercoaster-like PathFollow Algorithm

- It explains itself.
- Supports all axis constraints.
- Depends on the previous feature.

**Added Methods**

Curve3D

`Vector3 interpolate_baked_up_vector(float p_offset, bool p_apply_tilt = false) `

Samples an interpolated up vector.

**p_offset** - The offset.
**p_apply_tilt** - Applies an interpolated tilt sampled from **p_offset**.

Returns the (maybe tilted) up vector.

`PoolVector3Array Curve3D::get_baked_up_vectors()`

Returns the baked up vectors.

**Showcase**

https://cdn.discordapp.com/attachments/279004126795268106/441382904145248278/output.gif
https://cdn.discordapp.com/attachments/279004126795268106/441381983021432839/output.gif
https://cdn.discordapp.com/attachments/279004126795268106/442355995101102081/output.gif
