### PR TITLE
Windows detect.py: Detect missing WindowsSdkDir

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -193,7 +193,10 @@ def configure_msvc(env, manual_msvc_config):
     env.AppendUnique(CCFLAGS=['/MT', '/Gd', '/GR', '/nologo'])
     env.AppendUnique(CXXFLAGS=['/TP']) # assume all sources are C++
     if manual_msvc_config: # should be automatic if SCons found it
-        env.Append(CPPPATH=[os.getenv("WindowsSdkDir") + "/Include"])
+        if os.getenv("WindowsSdkDir") is not None:
+            env.Append(CPPPATH=[os.getenv("WindowsSdkDir") + "/Include"])
+        else:
+            print("Missing environment variable: WindowsSdkDir")
 
     env.AppendUnique(CPPDEFINES = ['WINDOWS_ENABLED', 'OPENGL_ENABLED',
                                    'RTAUDIO_ENABLED', 'WASAPI_ENABLED',
@@ -211,7 +214,10 @@ def configure_msvc(env, manual_msvc_config):
     env.Append(LINKFLAGS=[p + env["LIBSUFFIX"] for p in LIBS])
 
     if manual_msvc_config:
-        env.Append(LIBPATH=[os.getenv("WindowsSdkDir") + "/Lib"])
+        if os.getenv("WindowsSdkDir") is not None:
+            env.Append(LIBPATH=[os.getenv("WindowsSdkDir") + "/Lib"])
+        else:
+            print("Missing environment variable: WindowsSdkDir")
 
     ## LTO
 


### PR DESCRIPTION
Currently, if the WindowsSdkDir env var is missing on manual MSVC configuration you get a stack trace.

This instead prints an error. Should this be an exception instead?