### PR TITLE
Resume audio on iOS after phone call or alarm

### DIFF
--- a/drivers/coreaudio/audio_driver_coreaudio.cpp
+++ b/drivers/coreaudio/audio_driver_coreaudio.cpp
@@ -217,12 +217,23 @@ void AudioDriverCoreAudio::start() {
 	if (!active) {
 		OSStatus result = AudioOutputUnitStart(audio_unit);
 		if (result != noErr) {
-			ERR_PRINT("AudioOutputUnitStart failed");
+			ERR_PRINT(("AudioOutputUnitStart failed, code: " + itos(result)).utf8().get_data());
 		} else {
 			active = true;
 		}
 	}
 };
+
+void AudioDriverCoreAudio::stop() {
+	if (active) {
+		OSStatus result = AudioOutputUnitStop(audio_unit);
+		if (result != noErr) {
+			ERR_PRINT(("AudioOutputUnitStop failed, code: " + itos(result)).utf8().get_data());
+		} else {
+			active = false;
+		}
+	}
+}
 
 int AudioDriverCoreAudio::get_mix_rate() const {
 	return mix_rate;

--- a/drivers/coreaudio/audio_driver_coreaudio.h
+++ b/drivers/coreaudio/audio_driver_coreaudio.h
@@ -90,6 +90,7 @@ public:
 	virtual void finish();
 
 	bool try_lock();
+	void stop();
 
 	AudioDriverCoreAudio();
 	~AudioDriverCoreAudio();

--- a/platform/iphone/app_delegate.h
+++ b/platform/iphone/app_delegate.h
@@ -37,6 +37,7 @@
 @interface AppDelegate : NSObject <UIApplicationDelegate, GLViewDelegate> {
 	//@property (strong, nonatomic) UIWindow *window;
 	ViewController *view_controller;
+	bool is_focus_out;
 };
 
 @property(strong, nonatomic) UIWindow *window;


### PR DESCRIPTION
When a phone call or an alarm triggers on iOS, the application receives
an "audio interruption" and it's up to the application to resume
playback when the interruption ends. I added handling for audio
interruptions same as if the game is focused out and then back in.