### PR TITLE
Rename a node on change type if it has the default name

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1547,6 +1547,9 @@ void SceneTreeDock::replace_node(Node *p_node, Node *p_by_node) {
 
 	String newname = n->get_name();
 
+	if (newname == String(n->get_class_name()))
+		newname = newnode->get_class_name();
+
 	List<Node *> to_erase;
 	for (int i = 0; i < n->get_child_count(); i++) {
 		if (n->get_child(i)->get_owner() == NULL && n->is_owned_by_parent()) {


### PR DESCRIPTION
Ahoy.

I always found it a little confusing that if i change the type of a node in the scene tree, the name of the node will remain the same.
i would end up with a node named "StaticBody2D" with a type of a RigidBody2D.

This commit would add that feature. But it will not rename the node when it has been renamed already.
Meaning that a Node2D called "Player" will still have that name when it type changes to eg. a KinematicBody.
