### PR TITLE
Dummy texture importer

### DIFF
--- a/drivers/dummy/texture_loader_dummy.cpp
+++ b/drivers/dummy/texture_loader_dummy.cpp
@@ -1,0 +1,87 @@
+/*************************************************************************/
+/*  texture_loader_dummy.cpp                                               */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "texture_loader_dummy.h"
+#include "core/os/file_access.h"
+#include "print_string.h"
+#include <string.h>
+
+RES ResourceFormatDummyTexture::load(const String &p_path, const String &p_original_path, Error *r_error) {
+	unsigned int width = 8;
+	unsigned int height = 8;
+
+	//We just use some format
+	Image::Format fmt = Image::FORMAT_RGB8;
+	int rowsize = 3 * width;
+
+	PoolVector<uint8_t> dstbuff;
+
+	dstbuff.resize(rowsize * height);
+
+	PoolVector<uint8_t>::Write dstbuff_write = dstbuff.write();
+
+	uint8_t *data = dstbuff_write.ptr();
+
+	uint8_t **row_p = memnew_arr(uint8_t *, height);
+
+	for (unsigned int i = 0; i < height; i++) {
+		row_p[i] = 0; //No colors any more, I want them to turn black
+	}
+
+	memdelete_arr(row_p);
+
+	Ref<Image> img = memnew(Image(width, height, 0, fmt, dstbuff));
+
+	Ref<ImageTexture> texture = memnew(ImageTexture);
+	texture->create_from_image(img);
+
+	if (r_error)
+		*r_error = OK;
+
+	return texture;
+}
+
+void ResourceFormatDummyTexture::get_recognized_extensions(List<String> *p_extensions) const {
+	p_extensions->push_back("png");
+	p_extensions->push_back("hdr");
+	p_extensions->push_back("jpg");
+	p_extensions->push_back("tga");
+}
+
+bool ResourceFormatDummyTexture::handles_type(const String &p_type) const {
+	return ClassDB::is_parent_class(p_type, "Texture");
+}
+
+String ResourceFormatDummyTexture::get_resource_type(const String &p_path) const {
+	String extension = p_path.get_extension().to_lower();
+	if (extension == "png" || extension == "hdr" || extension == "jpg" || extension == "tga")
+		return "ImageTexture";
+	return "";
+}

--- a/drivers/dummy/texture_loader_dummy.h
+++ b/drivers/dummy/texture_loader_dummy.h
@@ -1,0 +1,47 @@
+/*************************************************************************/
+/*  texture_loader_dummy.h                                                 */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TEXTURE_LOADER_DUMMY_H
+#define TEXTURE_LOADER_DUMMY_H
+
+#include "core/io/resource_loader.h"
+#include "scene/resources/texture.h"
+
+class ResourceFormatDummyTexture : public ResourceFormatLoader {
+public:
+	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = NULL);
+	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual bool handles_type(const String &p_type) const;
+	virtual String get_resource_type(const String &p_path) const;
+
+	virtual ~ResourceFormatDummyTexture() {}
+};
+
+#endif // TEXTURE_LOADER_DUMMY_H

--- a/platform/server/os_server.cpp
+++ b/platform/server/os_server.cpp
@@ -30,6 +30,7 @@
 #include "os_server.h"
 #include "drivers/dummy/audio_driver_dummy.h"
 #include "drivers/dummy/rasterizer_dummy.h"
+#include "drivers/dummy/texture_loader_dummy.h"
 #include "print_string.h"
 #include "servers/visual/visual_server_raster.h"
 #include <stdio.h>
@@ -83,6 +84,9 @@ Error OS_Server::initialize(const VideoMode &p_desired, int p_video_driver, int 
 
 	_ensure_user_data_dir();
 
+	resource_loader_dummy = memnew(ResourceFormatDummyTexture);
+	ResourceLoader::add_resource_format_loader(resource_loader_dummy);
+
 	return OK;
 }
 
@@ -98,6 +102,8 @@ void OS_Server::finalize() {
 	memdelete(input);
 
 	memdelete(power_manager);
+
+	memdelete(resource_loader_dummy);
 
 	args.clear();
 }

--- a/platform/server/os_server.h
+++ b/platform/server/os_server.h
@@ -32,6 +32,7 @@
 
 #include "../x11/crash_handler_x11.h"
 #include "../x11/power_x11.h"
+#include "drivers/dummy/texture_loader_dummy.h"
 #include "drivers/rtaudio/audio_driver_rtaudio.h"
 #include "drivers/unix/os_unix.h"
 #include "main/input_default.h"
@@ -64,6 +65,8 @@ class OS_Server : public OS_Unix {
 	PowerX11 *power_manager;
 
 	CrashHandler crash_handler;
+
+	ResourceFormatDummyTexture *resource_loader_dummy;
 
 protected:
 	virtual int get_video_driver_count() const;


### PR DESCRIPTION
Currently running a project in headless mode (binary built with p=server) causes a crash since the server platform does not have support for any kind of texture (which makes sense really).

This PR implements a dummy importer for textures in the server platform and allows for running a project in headless mode without crashing when loading scenes containing textured objects.

Also as a result decreases load time as no image files have to be loaded.