### PR TITLE
Editor: Makes dragdrop instantiation behavior consistent with the instance scene button

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -3121,7 +3121,7 @@ bool SpatialEditorViewport::_create_instance(Node *parent, String &path, const P
 			if (!scene.is_valid()) { // invalid scene
 				return false;
 			} else {
-				instanced_scene = scene->instance();
+				instanced_scene = scene->instance(PackedScene::GEN_EDIT_STATE_INSTANCE);
 			}
 		}
 	}


### PR DESCRIPTION
should fix #18660 except the other potential problem i mentioned, but that's a different issue

btw also the preview node instantiation in SpatialEditorViewport::_create_preview is missing GEN_EDIT_STATE_INSTANCE but that looks irrelevant
