### PR TITLE
Add a check to the PurchaseTask.purchase method to prevent NullPointe…

### DIFF
--- a/platform/android/java/src/org/godotengine/godot/payments/PaymentsManager.java
+++ b/platform/android/java/src/org/godotengine/godot/payments/PaymentsManager.java
@@ -211,7 +211,7 @@ public class PaymentsManager {
 	}
 
 	public void requestPurchase(final String sku, String transactionId) {
-		if (!mSetupDone) return;
+		if (!isConnected()) return;
 
 		PurchaseTask purchaseTask = new PurchaseTask(mService, Godot.getInstance()) {
 			@Override


### PR DESCRIPTION
purchase method has to check if the service is connected before making any purchase.
The service might be null when:
1. it has not been initialized yet
2. the service has been disconnected (this case was not properly checked)