### PR TITLE
Fix keyboard focus lock-out with HTML5 canvas in iframe

### DIFF
--- a/misc/dist/html/default.html
+++ b/misc/dist/html/default.html
@@ -195,7 +195,7 @@ $GODOT_HEAD_INCLUDE
 </head>
 <body>
 	<div id="container">
-		<canvas id="canvas" oncontextmenu="event.preventDefault();" width="640" height="480">
+		<canvas id="canvas" width="640" height="480">
 			HTML5 canvas appears to be unsupported in the current browser.<br />
 			Please try updating or use a different browser.
 		</canvas>

--- a/platform/javascript/engine.js
+++ b/platform/javascript/engine.js
@@ -161,6 +161,10 @@
 			actualCanvas.style.padding = 0;
 			actualCanvas.style.borderWidth = 0;
 			actualCanvas.style.borderStyle = 'none';
+			// disable right-click context menu
+			actualCanvas.addEventListener('contextmenu', function(ev) {
+				ev.preventDefault();
+			}, false);
 			// until context restoration is implemented
 			actualCanvas.addEventListener('webglcontextlost', function(ev) {
 				alert("WebGL context lost, please reload the page");

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -167,10 +167,9 @@ static EM_BOOL _mousebutton_callback(int event_type, const EmscriptenMouseEvent 
 	int mask = _input->get_mouse_button_mask();
 	int button_flag = 1 << (ev->get_button_index() - 1);
 	if (ev->is_pressed()) {
-		// since the event is consumed, focus manually
-		if (!is_canvas_focused()) {
-			focus_canvas();
-		}
+		// Since the event is consumed, focus manually. The containing iframe,
+		// if used, may not have focus yet, so focus even if already focused.
+		focus_canvas();
 		mask |= button_flag;
 	} else if (mask & button_flag) {
 		mask &= ~button_flag;
@@ -181,7 +180,8 @@ static EM_BOOL _mousebutton_callback(int event_type, const EmscriptenMouseEvent 
 	ev->set_button_mask(mask);
 
 	_input->parse_input_event(ev);
-	// prevent selection dragging
+	// Prevent multi-click text selection and wheel-click scrolling anchor.
+	// Context menu is prevented through contextmenu event.
 	return true;
 }
 


### PR DESCRIPTION
Currently, clicking the game canvas, then outside the iframe, then back inside the canvas does not grant keyboard focus, making it impossible to receive key events.
Noticed this on itch.io, but this should affect just about every web game host.