### PR TITLE
Improved API to active / deactive ragdoll

### DIFF
--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -1825,6 +1825,7 @@ void PhysicalBone::_notification(int p_what) {
 			parent_skeleton = find_skeleton_parent(get_parent());
 			update_bone_id();
 			reset_to_rest_position();
+			_reset_physics_simulation_state();
 			break;
 		case NOTIFICATION_EXIT_TREE:
 			if (parent_skeleton) {
@@ -1886,10 +1887,8 @@ void PhysicalBone::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_body_offset", "offset"), &PhysicalBone::set_body_offset);
 	ClassDB::bind_method(D_METHOD("get_body_offset"), &PhysicalBone::get_body_offset);
 
-	ClassDB::bind_method(D_METHOD("set_static_body", "simulate"), &PhysicalBone::set_static_body);
 	ClassDB::bind_method(D_METHOD("is_static_body"), &PhysicalBone::is_static_body);
 
-	ClassDB::bind_method(D_METHOD("set_simulate_physics", "simulate"), &PhysicalBone::set_simulate_physics);
 	ClassDB::bind_method(D_METHOD("get_simulate_physics"), &PhysicalBone::get_simulate_physics);
 
 	ClassDB::bind_method(D_METHOD("is_simulating_physics"), &PhysicalBone::is_simulating_physics);
@@ -1913,9 +1912,7 @@ void PhysicalBone::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "joint_type", PROPERTY_HINT_ENUM, "None,PinJoint,ConeJoint,HingeJoint,SliderJoint,6DOFJoint"), "set_joint_type", "get_joint_type");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM, "joint_offset"), "set_joint_offset", "get_joint_offset");
 
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "simulate_physics"), "set_simulate_physics", "get_simulate_physics");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM, "body_offset"), "set_body_offset", "get_body_offset");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "static_body"), "set_static_body", "is_static_body");
 
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "mass", PROPERTY_HINT_EXP_RANGE, "0.01,65535,0.01"), "set_mass", "get_mass");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "weight", PROPERTY_HINT_EXP_RANGE, "0.01,65535,0.01"), "set_weight", "get_weight");
@@ -2255,8 +2252,8 @@ PhysicalBone::PhysicalBone() :
 		joint_data(NULL),
 		static_body(false),
 		simulate_physics(false),
-		_internal_static_body(!static_body),
-		_internal_simulate_physics(simulate_physics),
+		_internal_static_body(false),
+		_internal_simulate_physics(false),
 		bone_id(-1),
 		parent_skeleton(NULL),
 		bone_name(""),

--- a/scene/3d/skeleton.h
+++ b/scene/3d/skeleton.h
@@ -120,8 +120,10 @@ public:
 
 	// skeleton creation api
 	void add_bone(const String &p_name);
-	int find_bone(String p_name) const;
+	int find_bone(const String &p_name) const;
 	String get_bone_name(int p_bone) const;
+
+	bool is_bone_parent_of(int p_bone_id, int p_parent_bone_id) const;
 
 	void set_bone_parent(int p_bone, int p_parent);
 	int get_bone_parent(int p_bone) const;
@@ -176,7 +178,8 @@ private:
 	void _rebuild_physical_bones_cache();
 
 public:
-	void physical_bones_simulation(bool start);
+	void physical_bones_stop_simulation();
+	void physical_bones_start_simulation_on(const Array &p_bones);
 	void physical_bones_add_collision_exception(RID p_exception);
 	void physical_bones_remove_collision_exception(RID p_exception);
 


### PR DESCRIPTION
In order to make easy activation and deactivation of ragdoll I've improved the API of skeleton by adding this functions:

**physical_bones_start_simulation**
**physical_bones_stop_simulation**

The function physical_bones_start_simulation accept a list of bone names in order to active the simulation on partial skeleton bones (like this: https://youtu.be/mn_59vVYot8)

Closes: #18704