### PR TITLE
Facilitate using non-default filename extensions in HTML5 platform

### DIFF
--- a/misc/dist/html/default.html
+++ b/misc/dist/html/default.html
@@ -229,7 +229,7 @@ $GODOT_HEAD_INCLUDE
 
 		(function() {
 
-			const BASENAME = '$GODOT_BASENAME';
+			const MAIN_PACK = '$GODOT_BASENAME.pck';
 			const DEBUG_ENABLED = $GODOT_DEBUG_ENABLED;
 			const INDETERMINATE_STATUS_STEP_MS = 100;
 
@@ -380,7 +380,7 @@ $GODOT_HEAD_INCLUDE
 			} else {
 				setStatusMode('indeterminate');
 				engine.setCanvas(canvas);
-				engine.startGame(BASENAME + '.pck').then(() => {
+				engine.startGame(MAIN_PACK).then(() => {
 					setStatusMode('hidden');
 					initializing = false;
 				}, displayFailureNotice);

--- a/platform/javascript/engine.js
+++ b/platform/javascript/engine.js
@@ -130,13 +130,17 @@
 		this.startGame = function(mainPack) {
 
 			executableName = getBaseName(mainPack);
+			var mainArgs = [];
+			if (!getPathLeaf(mainPack).endsWith('.pck')) {
+				mainArgs = ['--main-pack', getPathLeaf(mainPack)];
+			}
 			return Promise.all([
 				// Load from directory,
 				this.init(getBasePath(mainPack)),
 				// ...but write to root where the engine expects it.
 				this.preloadFile(mainPack, getPathLeaf(mainPack))
 			]).then(
-				Function.prototype.apply.bind(synchronousStart, this, [])
+				Function.prototype.apply.bind(synchronousStart, this, mainArgs)
 			);
 		};
 

--- a/platform/javascript/engine.js
+++ b/platform/javascript/engine.js
@@ -10,6 +10,7 @@
 	var DOWNLOAD_ATTEMPTS_MAX = 4;
 
 	var basePath = null;
+	var wasmFilenameExtensionOverride = null;
 	var engineLoadPromise = null;
 
 	var loadingFiles = {};
@@ -299,6 +300,14 @@
 		return !!testContext;
 	};
 
+	Engine.setWebAssemblyFilenameExtension = function(override) {
+
+		if (String(override).length === 0) {
+			throw new Error('Invalid WebAssembly filename extension override');
+		}
+		wasmFilenameExtensionOverride = String(override);
+	}
+
 	Engine.load = function(newBasePath) {
 
 		if (newBasePath !== undefined) basePath = getBasePath(newBasePath);
@@ -306,7 +315,7 @@
 			if (typeof WebAssembly !== 'object')
 				return Promise.reject(new Error("Browser doesn't support WebAssembly"));
 			// TODO cache/retrieve module to/from idb
-			engineLoadPromise = loadPromise(basePath + '.wasm').then(function(xhr) {
+			engineLoadPromise = loadPromise(basePath + '.' + (wasmFilenameExtensionOverride || 'wasm')).then(function(xhr) {
 				return xhr.response;
 			});
 			engineLoadPromise = engineLoadPromise.catch(function(err) {


### PR DESCRIPTION
Adds a new function `Engine.setWebAssemblyFilenameExtension()` that causes the WebAssembly module to be loaded with the passed filename extension rather than the standardized `.wasm`.

Also allows passing main packs with any filename extension to `startGame()`, for example `.dat` or `.zip` instead of `.pck`.

Fixes #17687