### PR TITLE
Command line fixes

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -483,7 +483,7 @@ void EditorNode::_fs_changed() {
 				// come during the export
 				export_defer.preset = "";
 				Error err = OK;
-				if (!preset->is_runnable() && (export_defer.path.ends_with(".pck") || export_defer.path.ends_with(".zip"))) {
+				if (export_defer.path.ends_with(".pck") || export_defer.path.ends_with(".zip")) {
 					if (export_defer.path.ends_with(".zip")) {
 						err = platform->export_zip(preset, export_defer.debug, export_defer.path);
 					} else if (export_defer.path.ends_with(".pck")) {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -337,7 +337,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	String video_driver = "";
 	String audio_driver = "";
-	String game_path = ".";
+	String game_path;
 	bool upwards = false;
 	String debug_mode;
 	String debug_host;
@@ -693,6 +693,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		I = N;
 	}
 
+	if (game_path.empty()) {
+		game_path = ".";
+	}
 	if (globals->setup(game_path, main_pack, upwards) == OK) {
 		found_project = true;
 	} else {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -262,8 +262,8 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("Standalone tools:\n");
 	OS::get_singleton()->print("  -s, --script <script>            Run a script.\n");
 #ifdef TOOLS_ENABLED
-	OS::get_singleton()->print("  --export <target>                Export the project using the given export target.\n");
-	OS::get_singleton()->print("  --export-debug                   Use together with --export, enables debug mode for the template.\n");
+	OS::get_singleton()->print("  --export <target>                Export the project using the given export target. Export only main pack if path ends with .pck or .zip'.\n");
+	OS::get_singleton()->print("  --export-debug <target>          Like --export, but use debug template.\n");
 	OS::get_singleton()->print("  --doctool <path>                 Dump the engine API reference to the given <path> in XML format, merging if existing files are found.\n");
 	OS::get_singleton()->print("  --no-docbase                     Disallow dumping the base types (used with --doctool).\n");
 	OS::get_singleton()->print("  --build-solutions                Build the scripting solutions (e.g. for C# projects).\n");

--- a/misc/dist/linux/godot.6
+++ b/misc/dist/linux/godot.6
@@ -128,10 +128,10 @@ Print the frames per second to the stdout.
 Run a script.
 .TP
 \fB\-\-export\fR <target>
-Export the project using the given export target.
+Export the project using the given export target. Export only main pack if path ends with .pck or .zip.
 .TP
 \fB\-\-export\-debug\fR
-Use together with \fB\-\-export\fR, enables debug mode for the template.
+Like \-\-export, but use debug template.
 .TP
 \fB\-\-doctool\fR <path>
 Dump the engine API reference to the given <path> in XML format, merging if existing files are found.


### PR DESCRIPTION
Fixes a bug when passing the resource directory path per command line, closes #18068
Also fixes help text and removes an unnecessary restriction on runnable presets.