### PR TITLE
Use mimeType according to glTF spec.

### DIFF
--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -1163,7 +1163,7 @@ Error EditorSceneImporterGLTF::_parse_images(GLTFState &state, const String &p_b
 			continue;
 		}
 
-		if (mimetype.findn("jpg") != -1) {
+		if (mimetype.findn("jpeg") != -1) {
 			//is a jpg
 			Ref<Image> img = Image::_jpg_mem_loader_func(data_ptr, data_size);
 


### PR DESCRIPTION
Hi Godot Team,

Not sure if the Godot version of the glTF importer is 2.0 or not. If 2.0 the mimeType must be image/jpeg. If not feel free to ignore this PR. (According to your docu: http://docs.godotengine.org/en/3.0/getting_started/workflow/assets/importing_scenes.html it is.)

Here the glTF 2.0 spec:
https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#imagemimetype

I couldn't load some of the sample files provided by Khronos.

Yaakuro