### PR TITLE
fixed 'A' input not registered in osx script editor

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2851,7 +2851,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 				}
 				select_all();
 #else
-				if (k->get_alt()) {
+				if (k->get_alt() || (!k->get_shift() && !k->get_command() && !k->get_control())) {
 					scancode_handled = false;
 					break;
 				}


### PR DESCRIPTION
on OS X the input of the a key was only registered when alt is pressed...

*Bugsquad edit:* Fixes #18808.