### PR TITLE
Added video thumbnail overlay in asset description

### DIFF
--- a/editor/icons/icon_play_overlay.svg
+++ b/editor/icons/icon_play_overlay.svg
@@ -1,0 +1,4 @@
+<svg width="64" height="64" version="1.1" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="64" height="64" rx="5" ry="5" fill="#044B94" fill-opacity="0.6"/>
+  <path d="M16 16 L48 32 L16 48" fill="#f2f2f2"/>
+</svg>

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -170,7 +170,23 @@ void EditorAssetLibraryItemDescription::set_image(int p_type, int p_index, const
 
 			for (int i = 0; i < preview_images.size(); i++) {
 				if (preview_images[i].id == p_index) {
-					preview_images[i].button->set_icon(p_image);
+					if (preview_images[i].is_video) {
+						Ref<Image> overlay = get_icon("PlayOverlay", "EditorIcons")->get_data();
+						Ref<Image> thumbnail = p_image->get_data();
+						Point2 overlay_pos = Point2((thumbnail->get_width() - overlay->get_width()) / 2, (thumbnail->get_height() - overlay->get_height()) / 2);
+
+						thumbnail->lock();
+						thumbnail->blend_rect(overlay, overlay->get_used_rect(), overlay_pos);
+						thumbnail->unlock();
+
+						Ref<ImageTexture> tex;
+						tex.instance();
+						tex->create_from_image(thumbnail);
+
+						preview_images[i].button->set_icon(tex);
+					} else {
+						preview_images[i].button->set_icon(p_image);
+					}
 					break;
 				}
 			}


### PR DESCRIPTION
Related issue: https://github.com/godotengine/godot/issues/6068

![image](https://user-images.githubusercontent.com/27275873/39938612-2e9c9806-555c-11e8-9998-ba43c5ba9c2d.png)
