### PR TITLE
Fix two issues preventing model import from working properly when platform=server

### DIFF
--- a/editor/doc/doc_data.cpp
+++ b/editor/doc/doc_data.cpp
@@ -567,6 +567,9 @@ void DocData::generate(bool p_basic_types) {
 
 			PropertyDoc pd;
 			Engine::Singleton &s = E->get();
+			if (!s.ptr) {
+				continue;
+			}
 			pd.name = s.name;
 			pd.type = s.ptr->get_class();
 			while (String(ClassDB::get_parent_class(pd.type)) != "Object")


### PR DESCRIPTION
Happy to split this review if requested, but the first change is small enough that it didn't feel worth it.

1. `DocData::generate` was crashing for us with a null-pointer dereference, because I guess not all the singletons get instantiated when `platform=server`.
2. Fixes #17308 by storing mesh data in `RasterizerStorageDummy`. Without this, the mesh data that is imported by any of the scene importers was immediately thrown away before being written to disk.
