### PR TITLE
Correctly label vertical scroll position in tooltip as "vertical"

### DIFF
--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -22,7 +22,7 @@
 			If [code]true[/code], enables horizontal scrolling.
 		</member>
 		<member name="scroll_vertical" type="int" setter="set_v_scroll" getter="get_v_scroll">
-			The current horizontal scroll value.
+			The current vertical scroll value.
 		</member>
 		<member name="scroll_vertical_enabled" type="bool" setter="set_enable_v_scroll" getter="is_v_scroll_enabled">
 			If [code]true[/code], enables vertical scrolling.


### PR DESCRIPTION
Easy problem, easy fix: The tooltip for the `Vertical` value on the `ScrollContainer` node incorrectly state that it represents the current *horizontal* scroll value. Change the word to "vertical" and the problem is solved.