### PR TITLE
Fix command line II

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -337,7 +337,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	String video_driver = "";
 	String audio_driver = "";
-	String game_path;
+	String game_path = ".";
 	bool upwards = false;
 	String debug_mode;
 	String debug_host;
@@ -693,9 +693,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		I = N;
 	}
 
-	if (game_path.empty()) {
-		game_path = ".";
-	}
 	if (globals->setup(game_path, main_pack, upwards) == OK) {
 		found_project = true;
 	} else {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -337,7 +337,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	String video_driver = "";
 	String audio_driver = "";
-	String game_path = ".";
+	String project_path = ".";
 	bool upwards = false;
 	String debug_mode;
 	String debug_host;
@@ -553,7 +553,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				if (OS::get_singleton()->set_cwd(p) == OK) {
 					//nothing
 				} else {
-					game_path = I->next()->get(); //use game_path instead
+					project_path = I->next()->get(); //use project_path instead
 				}
 				N = I->next()->next();
 			} else {
@@ -576,7 +576,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			if (OS::get_singleton()->set_cwd(path) == OK) {
 				// path already specified, don't override
 			} else {
-				game_path = path;
+				project_path = path;
 			}
 #ifdef TOOLS_ENABLED
 			editor = true;
@@ -678,14 +678,14 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		I = N;
 	}
 
-	if (globals->setup(game_path, main_pack, upwards) == OK) {
+	if (globals->setup(project_path, main_pack, upwards) == OK) {
 		found_project = true;
 	} else {
 
 #ifdef TOOLS_ENABLED
 		editor = false;
 #else
-		OS::get_singleton()->print("Error: Could not load game path '%s'.\n", game_path.ascii().get_data());
+		OS::get_singleton()->print("Error: Could not load game path '%s'.\n", project_path.ascii().get_data());
 
 		goto error;
 #endif
@@ -976,7 +976,7 @@ error:
 
 	video_driver = "";
 	audio_driver = "";
-	game_path = "";
+	project_path = "";
 
 	args.clear();
 	main_args.clear();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -672,22 +672,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (I->get() == "--disable-crash-handler") {
 			OS::get_singleton()->disable_crash_handler();
 		} else {
-
-			//test for game path
-			bool gpfound = false;
-
-			if (!I->get().begins_with("-") && game_path == "") {
-				DirAccess *da = DirAccess::open(I->get());
-				if (da != NULL) {
-					game_path = I->get();
-					gpfound = true;
-					memdelete(da);
-				}
-			}
-
-			if (!gpfound) {
-				main_args.push_back(I->get());
-			}
+			main_args.push_back(I->get());
 		}
 
 		I = N;


### PR DESCRIPTION
Hindsight says it's better to remove this dead branch rather than revive it. Fixes #18805

The purpose seems to have been to reference a project just by its directory path, without prefixing `--path` or handing the path to the `project.godot` file. But it could also be a `--doctool`/`--generate-mono-bindings` target path, which would be parsed later.

There seems to be a larger issue here, but I don't feel like taking a deep dive into command line parsing logic.

I changed a variable identifier `game_path` to `project_path`, since it confusingly occurred with different purposes in both `start()` and `setup()`

mention @PJB3005 @neikeq since you encountered this