### PR TITLE
Updated Seed Documentation in Class Reference

### DIFF
--- a/doc/classes/@GDScript.xml
+++ b/doc/classes/@GDScript.xml
@@ -870,6 +870,7 @@
 				my_seed = "Godot Rocks"
 				seed(my_seed.hash())
 				[/codeblock]
+				Note: The first call to a function such as [code]randf()[/code] or [code]randi()[/code] after setting the seed will usually return a number close to or equal to 0. This is due to the specific implementation. To avoid this behavior call [code]randf()[/code] or [code]randi()[/code] once after setting the seed.
 			</description>
 		</method>
 		<method name="sign">


### PR DESCRIPTION
Addresses Issue #17664 and acknowledges that the first call to `randf()` or `randi()` after a call to `seed()` will result in less than useful numbers.

For now I have just documented the behavior, however in the future we should look into changing the implementation itself.
