### PR TITLE
Expose channels and ordered mode in NetworkedMultiplayerENet

### DIFF
--- a/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
+++ b/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
@@ -65,6 +65,20 @@
 				Disconnect the given peer. If "now" is set to true, the connection will be closed immediately without flushing queued messages.
 			</description>
 		</method>
+		<method name="get_last_packet_channel" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the channel of the last packet fetched via [method PacketPeer.get_packet]
+			</description>
+		</method>
+		<method name="get_packet_channel" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the channel of the next packet that will be retrieved via [method PacketPeer.get_packet_peer]
+			</description>
+		</method>
 		<method name="get_peer_address" qualifiers="const">
 			<return type="String">
 			</return>
@@ -94,8 +108,17 @@
 		</method>
 	</methods>
 	<members>
+		<member name="always_ordered" type="bool" setter="set_always_ordered" getter="is_always_ordered">
+			Always use [code]TRANSFER_MODE_ORDERED[/code] in place of [code]TRANSFER_MODE_UNRELIABLE[/code]. This is the only way to use ordering with the RPC system.
+		</member>
+		<member name="channel_count" type="int" setter="set_channel_count" getter="get_channel_count">
+			The number of channels to be used by ENet. Default: [code]3[/code]. Channels are used to separate different kinds of data. In realiable or ordered mode, for example, the packet delivery order is ensured on a per channel basis.
+		</member>
 		<member name="compression_mode" type="int" setter="set_compression_mode" getter="get_compression_mode" enum="NetworkedMultiplayerENet.CompressionMode">
 			The compression method used for network packets. Default is no compression. These have different tradeoffs of compression speed versus bandwidth, you may need to test which one works best for your use case if you use compression at all.
+		</member>
+		<member name="transfer_channel" type="int" setter="set_transfer_channel" getter="get_transfer_channel">
+			Set the default channel to be used to transfer data. By default this value is [code]-1[/code] which means that ENet will only use 2 channels, one for reliable and one for unreliable packets. Channel [code]0[/code] is reserved, and cannot be used. Setting this member to any value between [code]0[/code] and [member channel_count] (excluded) will force ENet to use that channel for sending data.
 		</member>
 	</members>
 	<constants>

--- a/modules/enet/networked_multiplayer_enet.h
+++ b/modules/enet/networked_multiplayer_enet.h
@@ -68,6 +68,9 @@ private:
 
 	int target_peer;
 	TransferMode transfer_mode;
+	int transfer_channel;
+	int channel_count;
+	bool always_ordered;
 
 	ENetEvent event;
 	ENetPeer *peer;
@@ -83,6 +86,7 @@ private:
 
 		ENetPacket *packet;
 		int from;
+		int channel;
 	};
 
 	CompressionMode compression_mode;
@@ -144,6 +148,15 @@ public:
 
 	void set_compression_mode(CompressionMode p_mode);
 	CompressionMode get_compression_mode() const;
+
+	int get_packet_channel() const;
+	int get_last_packet_channel() const;
+	void set_transfer_channel(int p_channel);
+	int get_transfer_channel() const;
+	void set_channel_count(int p_channel);
+	int get_channel_count() const;
+	void set_always_ordered(bool p_ordered);
+	bool is_always_ordered() const;
 
 	NetworkedMultiplayerENet();
 	~NetworkedMultiplayerENet();


### PR DESCRIPTION
This PR exposes ENet channels in a way that can be used by the RPC system without changing the API.

A new property `channel_count` allows the selection of the desired number of channels to be allocated when `create_client` or `create_server` is used. A new property `transfer_channel` allows the selection of the channel to be used during `put_packet`. If the `transfer_channel` is `-1` Godot will autoselect the channel (2 different channels for reliable and unreliable data). The property `always_ordered` will instead force any unreliable data to be sent in ordered mode instead.

For example
```
multiplayer.network_peer.transfer_channel = 3
multiplayer.network_peer.always_ordered = true
rpc_unreliable("my_func")
# Restore state for other RPCs
multiplayer.network_peer.transfer_channel = -1
multiplayer.network_peer.always_ordered = false
```

Will call `my_func` in an unreliable way, but preserving order (like with `TRANSFER_MODE_UNRELIABLE_ORDERED`), and using channel `3`.

Closes #6642 .