### PR TITLE
rand/seed: always ensure an appropriate seed value

### DIFF
--- a/core/math/math_funcs.cpp
+++ b/core/math/math_funcs.cpp
@@ -39,6 +39,8 @@ pcg32_random_t Math::default_pcg = { 12047754176567800795ULL, PCG_DEFAULT_INC_64
 // TODO: we should eventually expose pcg.inc too
 uint32_t Math::rand_from_seed(uint64_t *seed) {
 	pcg32_random_t pcg = { *seed, PCG_DEFAULT_INC_64 };
+	// the next state ensures a proper seed value
+	pcg32_random_r(&pcg);
 	uint32_t r = pcg32_random_r(&pcg);
 	*seed = pcg.state;
 	return r;
@@ -46,6 +48,8 @@ uint32_t Math::rand_from_seed(uint64_t *seed) {
 
 void Math::seed(uint64_t x) {
 	default_pcg.state = x;
+	// the next state ensures a proper seed value
+	pcg32_random_r(&default_pcg);
 }
 
 void Math::randomize() {


### PR DESCRIPTION
Fixes #17664 

CC @tagcup

```
	print("--i--")
	seed(0)
	print(randi())
	print(randi())
	seed(42)
	print(randi())
	print(randi())
	print("--i--")
	seed(0)
	print(randi())
	print(randi())
	seed(42)
	print(randi())
	print(randi())
	print("--f--")
	seed(0)
	print(randf())
	print(randf())
	seed(42)
	print(randf())
	print(randf())
	print("--f--")
	seed(0)
	print(randf())
	print(randf())
	seed(42)
	print(randf())
	print(randf())

	print("--rs--")
	var ar = rand_seed(42)
	print(ar)
	var ar2 = rand_seed(ar[1])
	print(ar2)
	var ar3 = rand_seed(ar2[1])
	print(ar3)
	print("--rs--")
	ar = rand_seed(42)
	print(ar)
	ar2 = rand_seed(ar[1])
	print(ar2)
	ar3 = rand_seed(ar2[1])
	print(ar3)

	seed(42)
	prints(rand_range(0, 1), rand_range(0, 1))
	seed(42)
	prints(rand_range(0, 1), rand_range(0, 1))
```

```
--i--
1613493245
3894649422
1971522493
242089394
--i--
1613493245
3894649422
1971522493
242089394
--f--
0.375671
0.906794
0.459031
0.056366
--f--
0.375671
0.906794
0.459031
0.056366
--rs--
[1971522493, 4159066171780167020]
[-837177377, -6817952583752890242]
[19596830, 483838003013946848]
--rs--
[1971522493, 4159066171780167020]
[-837177377, -6817952583752890242]
[19596830, 483838003013946848]
0.459031 0.056366
0.459031 0.056366
```
