### PR TITLE
Revert "Use fake audio playing property in editor"

### DIFF
--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -233,6 +233,7 @@ void AudioStreamPlayer2D::_notification(int p_what) {
 		//stop playing if no longer active
 		if (!active) {
 			set_physics_process_internal(false);
+			//do not update, this makes it easier to animate (will shut off otherwise)
 			//_change_notify("playing"); //update property in editor
 			emit_signal("finished");
 		}
@@ -312,11 +313,6 @@ void AudioStreamPlayer2D::stop() {
 
 bool AudioStreamPlayer2D::is_playing() const {
 
-#ifdef TOOLS_ENABLED
-	if (Engine::get_singleton()->is_editor_hint())
-		return fake_active;
-#endif
-
 	if (stream_playback.is_valid()) {
 		return active; // && stream_playback->is_playing();
 	}
@@ -361,16 +357,11 @@ bool AudioStreamPlayer2D::is_autoplay_enabled() {
 
 void AudioStreamPlayer2D::_set_playing(bool p_enable) {
 
-#ifdef TOOLS_ENABLED
-	fake_active = p_enable;
-#endif
-
 	if (p_enable)
 		play();
 	else
 		stop();
 }
-
 bool AudioStreamPlayer2D::_is_active() const {
 
 	return active;

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -69,10 +69,6 @@ private:
 	volatile bool active;
 	volatile float setplay;
 
-#ifdef TOOLS_ENABLED
-	volatile bool fake_active;
-#endif
-
 	float volume_db;
 	float pitch_scale;
 	bool autoplay;

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -543,6 +543,7 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 		//stop playing if no longer active
 		if (!active) {
 			set_physics_process_internal(false);
+			//do not update, this makes it easier to animate (will shut off otherwise)
 			//_change_notify("playing"); //update property in editor
 			emit_signal("finished");
 		}
@@ -640,11 +641,6 @@ void AudioStreamPlayer3D::stop() {
 
 bool AudioStreamPlayer3D::is_playing() const {
 
-#ifdef TOOLS_ENABLED
-	if (Engine::get_singleton()->is_editor_hint())
-		return fake_active;
-#endif
-
 	if (stream_playback.is_valid()) {
 		return active; // && stream_playback->is_playing();
 	}
@@ -689,16 +685,11 @@ bool AudioStreamPlayer3D::is_autoplay_enabled() {
 
 void AudioStreamPlayer3D::_set_playing(bool p_enable) {
 
-#ifdef TOOLS_ENABLED
-	fake_active = p_enable;
-#endif
-
 	if (p_enable)
 		play();
 	else
 		stop();
 }
-
 bool AudioStreamPlayer3D::_is_active() const {
 
 	return active;

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -102,10 +102,6 @@ private:
 	volatile bool active;
 	volatile float setplay;
 
-#ifdef TOOLS_ENABLED
-	volatile bool fake_active;
-#endif
-
 	AttenuationModel attenuation_model;
 	float unit_db;
 	float unit_size;

--- a/scene/audio/audio_player.cpp
+++ b/scene/audio/audio_player.cpp
@@ -127,7 +127,6 @@ void AudioStreamPlayer::_notification(int p_what) {
 		if (!active || (setseek < 0 && !stream_playback->is_playing())) {
 			active = false;
 			set_process_internal(false);
-			//_change_notify("playing"); //update property in editor
 			emit_signal("finished");
 		}
 	}
@@ -212,13 +211,8 @@ void AudioStreamPlayer::stop() {
 
 bool AudioStreamPlayer::is_playing() const {
 
-#ifdef TOOLS_ENABLED
-	if (Engine::get_singleton()->is_editor_hint())
-		return fake_active;
-#endif
-
 	if (stream_playback.is_valid()) {
-		return active; // && stream_playback->is_playing();
+		return active; //&& stream_playback->is_playing();
 	}
 
 	return false;
@@ -271,16 +265,11 @@ AudioStreamPlayer::MixTarget AudioStreamPlayer::get_mix_target() const {
 
 void AudioStreamPlayer::_set_playing(bool p_enable) {
 
-#ifdef TOOLS_ENABLED
-	fake_active = p_enable;
-#endif
-
 	if (p_enable)
 		play();
 	else
 		stop();
 }
-
 bool AudioStreamPlayer::_is_active() const {
 
 	return active;

--- a/scene/audio/audio_player.h
+++ b/scene/audio/audio_player.h
@@ -53,10 +53,6 @@ private:
 	volatile float setseek;
 	volatile bool active;
 
-#ifdef TOOLS_ENABLED
-	volatile bool fake_active;
-#endif
-
 	float mix_volume_db;
 	float pitch_scale;
 	float volume_db;


### PR DESCRIPTION
Reverts godotengine/godot#17367

Sorry, this should've gone into 3.0 not master.