### PR TITLE
Updates frame timeout when changing speed scale

### DIFF
--- a/scene/2d/animated_sprite.h
+++ b/scene/2d/animated_sprite.h
@@ -141,6 +141,7 @@ class AnimatedSprite : public Node2D {
 
 	void _res_changed();
 
+	float _get_frame_duration();
 	void _reset_timeout();
 	void _set_playing(bool p_playing);
 	bool _is_playing() const;


### PR DESCRIPTION
The problem was the following: if we change the speed scale from a very low value to a higher one, the animation waited for the last frame to timeout according to the low speed scale.
This resulted in an animation speed looking non responsive.

This PR fixes the problem by updating the timeout value according to the new speed scale set.