### PR TITLE
Fixed some warnings found with Cppcheck

### DIFF
--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -120,7 +120,6 @@ void ParallaxLayer::set_base_offset_and_scale(const Point2 &p_offset, float p_sc
 
 	if (mirroring.x) {
 		double den = mirroring.x * p_scale;
-		double before = new_ofs.x;
 		new_ofs.x -= den * ceil(new_ofs.x / den);
 	}
 

--- a/scene/3d/vehicle_body.cpp
+++ b/scene/3d/vehicle_body.cpp
@@ -672,13 +672,8 @@ void VehicleBody::_update_friction(PhysicsDirectBodyState *s) {
 	m_forwardImpulse.resize(numWheel);
 	m_sideImpulse.resize(numWheel);
 
-	int numWheelsOnGround = 0;
-
 	//collapse all those loops into one!
 	for (int i = 0; i < wheels.size(); i++) {
-		VehicleWheel &wheelInfo = *wheels[i];
-		if (wheelInfo.m_raycastInfo.m_isInContact)
-			numWheelsOnGround++;
 		m_sideImpulse[i] = real_t(0.);
 		m_forwardImpulse[i] = real_t(0.);
 	}

--- a/scene/3d/voxel_light_baker.cpp
+++ b/scene/3d/voxel_light_baker.cpp
@@ -2316,13 +2316,10 @@ Ref<MultiMesh> VoxelLightBaker::create_debug_multimesh(DebugMode p_mode) {
 
 		PoolVector<Vector3> vertices;
 		PoolVector<Color> colors;
-
-		int vtx_idx = 0;
 #define ADD_VTX(m_idx)                      \
 	;                                       \
 	vertices.push_back(face_points[m_idx]); \
-	colors.push_back(Color(1, 1, 1, 1));    \
-	vtx_idx++;
+	colors.push_back(Color(1, 1, 1, 1));
 
 		for (int i = 0; i < 6; i++) {
 

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -507,7 +507,6 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, float 
 void AnimationPlayer::_animation_process_data(PlaybackData &cd, float p_delta, float p_blend) {
 
 	float delta = p_delta * speed_scale * cd.speed_scale;
-	bool backwards = delta < 0;
 	float next_pos = cd.pos + delta;
 
 	float len = cd.from->animation->get_length();
@@ -524,6 +523,8 @@ void AnimationPlayer::_animation_process_data(PlaybackData &cd, float p_delta, f
 		delta = next_pos - cd.pos;
 
 		if (&cd == &playback.current) {
+
+			bool backwards = delta < 0;
 
 			if (!backwards && cd.pos <= len && next_pos == len /*&& playback.blend.empty()*/) {
 				//playback finished

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -190,7 +190,6 @@ private:
 
 	struct ItemNewline : public Item {
 
-		int line; // FIXME: Overriding base's line ?
 		ItemNewline() { type = ITEM_NEWLINE; }
 	};
 

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -33,13 +33,6 @@
 #include "label.h"
 #include "margin_container.h"
 
-struct _MinSizeCache {
-
-	int min_size;
-	bool will_stretch;
-	int final_size;
-};
-
 Control *SplitContainer::_getch(int p_idx) const {
 
 	int idx = 0;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -302,7 +302,6 @@ void TextEdit::_update_scrollbars() {
 
 	int hscroll_rows = ((hmin.height - 1) / get_row_height()) + 1;
 	int visible_rows = get_visible_rows();
-	int num_rows = MAX(visible_rows, num_lines_from(CLAMP(cursor.line_ofs, 0, text.size() - 1), MIN(visible_rows, text.size() - 1 - cursor.line_ofs)));
 
 	int total_rows = (is_hiding_enabled() ? get_total_unhidden_rows() : text.size());
 	if (scroll_past_end_of_file_enabled) {
@@ -2453,13 +2452,14 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					break;
 				} else if (k->get_command()) {
 #endif
-					bool prev_char = false;
 					int cc = cursor.column;
 
 					if (cc == 0 && cursor.line > 0) {
 						cursor_set_line(cursor.line - 1);
 						cursor_set_column(text[cursor.line].length());
 					} else {
+						bool prev_char = false;
+
 						while (cc > 0) {
 							bool ischar = _is_text_char(text[cursor.line][cc - 1]);
 
@@ -2514,13 +2514,14 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					break;
 				} else if (k->get_command()) {
 #endif
-					bool prev_char = false;
 					int cc = cursor.column;
 
 					if (cc == text[cursor.line].length() && cursor.line < text.size() - 1) {
 						cursor_set_line(cursor.line + 1);
 						cursor_set_column(0);
 					} else {
+						bool prev_char = false;
+
 						while (cc < text[cursor.line].length()) {
 							bool ischar = _is_text_char(text[cursor.line][cc]);
 

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -222,7 +222,6 @@ Ref<Mesh> Mesh::create_outline(float p_margin) const {
 			continue;
 
 		Array a = surface_get_arrays(i);
-		int vcount = 0;
 
 		if (i == 0) {
 			arrays = a;
@@ -230,6 +229,7 @@ Ref<Mesh> Mesh::create_outline(float p_margin) const {
 			index_accum += v.size();
 		} else {
 
+			int vcount = 0;
 			for (int j = 0; j < arrays.size(); j++) {
 
 				if (arrays[j].get_type() == Variant::NIL || a[j].get_type() == Variant::NIL) {
@@ -1193,8 +1193,6 @@ Error ArrayMesh::lightmap_unwrap(const Transform &p_base_transform, float p_texe
 		int surface = uv_index[gen_vertices[gen_indices[i + 0]]].first;
 
 		for (int j = 0; j < 3; j++) {
-
-			int vertex_idx = gen_vertices[gen_indices[i + j]];
 
 			SurfaceTool::Vertex v = surfaces[surface].vertices[uv_index[gen_vertices[gen_indices[i + j]]].second];
 


### PR DESCRIPTION
These are by no means all of them, there where a lot of other type of warns about no explicit constructors, uninitialized variables in the constructor, and C-style casts. But I don't know which are intentional or not, so I chose to fix the ones that were clearly mistakes:

- Removed a overriding variable that doesn't seem to have any purpose in rich_text_label.
- Removed a unused struct in split_container.
- Removed various pointless variable assignments.
- Reduced various scopes.