### PR TITLE
Ceil char width within Label instead of Font

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -103,7 +103,8 @@ void Label::_notification(int p_what) {
 
 		int lines_visible = (size.y + line_spacing) / font_h;
 
-		int space_w = font->get_char_size(' ').width;
+		// ceiling to ensure autowrapping does not cut text
+		int space_w = Math::ceil(font->get_char_size(' ').width);
 		int chars_total = 0;
 
 		int vbegin = 0, vsep = 0;
@@ -331,7 +332,8 @@ int Label::get_longest_line_width() const {
 			}
 		} else {
 
-			int char_width = font->get_char_size(current, xl_text[i + 1]).width;
+			// ceiling to ensure autowrapping does not cut text
+			int char_width = Math::ceil(font->get_char_size(current, xl_text[i + 1]).width);
 			line_width += char_width;
 		}
 	}
@@ -384,7 +386,8 @@ void Label::regenerate_word_cache() {
 	int word_pos = 0;
 	int line_width = 0;
 	int space_count = 0;
-	int space_width = font->get_char_size(' ').width;
+	// ceiling to ensure autowrapping does not cut text
+	int space_width = Math::ceil(font->get_char_size(' ').width);
 	int line_spacing = get_constant("line_spacing");
 	line_count = 1;
 	total_char_cache = 0;
@@ -446,8 +449,8 @@ void Label::regenerate_word_cache() {
 			if (current_word_size == 0) {
 				word_pos = i;
 			}
-
-			char_width = font->get_char_size(current, xl_text[i + 1]).width;
+			// ceiling to ensure autowrapping does not cut text
+			char_width = Math::ceil(font->get_char_size(current, xl_text[i + 1]).width);
 			current_word_size += char_width;
 			line_width += char_width;
 			total_char_cache++;

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -307,8 +307,6 @@ Size2 DynamicFontAtSize::get_char_size(CharType p_char, CharType p_next, const V
 	}
 	ret.x += _get_kerning_advance(font, p_char, p_next);
 
-	// ensures oversampled glyphs will have enough space when this value is used by clipping/wrapping algorithms
-	ret.x = Math::ceil(ret.x);
 	return ret;
 }
 


### PR DESCRIPTION
Some classes use Font::get_char_size directly and not only for
autowrapping. RichTextLabel is one such example. So this commit
reverts aa8561d (PR #17504) and instead ceils character width within
Label. This makes sure Label autowraps correctly while not affecting
other Font clients.

Fixes #18835.