### PR TITLE
Fix a corner-case bug in _copy_texscreen in the gles3 renderer

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -193,11 +193,11 @@ void RasterizerCanvasGLES3::canvas_end() {
 	state.using_ninepatch = false;
 }
 
-RasterizerStorageGLES3::Texture *RasterizerCanvasGLES3::_bind_canvas_texture(const RID &p_texture, const RID &p_normal_map) {
+RasterizerStorageGLES3::Texture *RasterizerCanvasGLES3::_bind_canvas_texture(const RID &p_texture, const RID &p_normal_map, bool p_force) {
 
 	RasterizerStorageGLES3::Texture *tex_return = NULL;
 
-	if (p_texture == state.current_tex) {
+	if (p_texture == state.current_tex && !p_force) {
 		tex_return = state.current_tex_ptr;
 	} else if (p_texture.is_valid()) {
 
@@ -232,7 +232,7 @@ RasterizerStorageGLES3::Texture *RasterizerCanvasGLES3::_bind_canvas_texture(con
 		state.current_tex_ptr = NULL;
 	}
 
-	if (p_normal_map == state.current_normal) {
+	if (p_normal_map == state.current_normal && !p_force) {
 		//do none
 		state.canvas_shader.set_uniform(CanvasShaderGLES3::USE_DEFAULT_NORMAL, state.current_normal.is_valid());
 
@@ -1086,7 +1086,7 @@ void RasterizerCanvasGLES3::_copy_texscreen(const Rect2 &p_rect) {
 	state.using_texture_rect = true;
 	_set_texture_rect_mode(false);
 
-	_bind_canvas_texture(state.current_tex, state.current_normal);
+	_bind_canvas_texture(state.current_tex, state.current_normal, true);
 
 	glEnable(GL_BLEND);
 }

--- a/drivers/gles3/rasterizer_canvas_gles3.h
+++ b/drivers/gles3/rasterizer_canvas_gles3.h
@@ -123,7 +123,7 @@ public:
 	virtual void canvas_end();
 
 	_FORCE_INLINE_ void _set_texture_rect_mode(bool p_enable, bool p_ninepatch = false);
-	_FORCE_INLINE_ RasterizerStorageGLES3::Texture *_bind_canvas_texture(const RID &p_texture, const RID &p_normal_map);
+	_FORCE_INLINE_ RasterizerStorageGLES3::Texture *_bind_canvas_texture(const RID &p_texture, const RID &p_normal_map, bool p_force = false);
 
 	_FORCE_INLINE_ void _draw_gui_primitive(int p_points, const Vector2 *p_vertices, const Color *p_colors, const Vector2 *p_uvs);
 	_FORCE_INLINE_ void _draw_polygon(const int *p_indices, int p_index_count, int p_vertex_count, const Vector2 *p_vertices, const Vector2 *p_uvs, const Color *p_colors, bool p_singlecolor, const int *p_bones, const float *p_weights);


### PR DESCRIPTION
Fixes #17698, obsoletes #18363.

The issue was that `_copy_texscreen` messed up when rebinding to the previous texture.