### PR TITLE
Expose animation pos to user for AnimationNodes in AnimationTree

### DIFF
--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -1216,6 +1216,12 @@ String AnimationTreePlayer::animation_node_get_master_animation(const StringName
 	return n->from;
 }
 
+float AnimationTreePlayer::animation_node_get_position(const StringName &p_node) const {
+
+	GET_NODE_V(NODE_ANIMATION, AnimationNode, 0);
+	return n->time;
+}
+
 bool AnimationTreePlayer::animation_node_is_path_filtered(const StringName &p_node, const NodePath &p_path) const {
 
 	GET_NODE_V(NODE_ANIMATION, AnimationNode, 0);
@@ -1724,6 +1730,7 @@ void AnimationTreePlayer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("animation_node_set_master_animation", "id", "source"), &AnimationTreePlayer::animation_node_set_master_animation);
 	ClassDB::bind_method(D_METHOD("animation_node_get_master_animation", "id"), &AnimationTreePlayer::animation_node_get_master_animation);
+	ClassDB::bind_method(D_METHOD("animation_node_get_position", "id"), &AnimationTreePlayer::animation_node_get_position);
 	ClassDB::bind_method(D_METHOD("animation_node_set_filter_path", "id", "path", "enable"), &AnimationTreePlayer::animation_node_set_filter_path);
 
 	ClassDB::bind_method(D_METHOD("oneshot_node_set_fadein_time", "id", "time_sec"), &AnimationTreePlayer::oneshot_node_set_fadein_time);

--- a/scene/animation/animation_tree_player.h
+++ b/scene/animation/animation_tree_player.h
@@ -348,6 +348,7 @@ public:
 	Ref<Animation> animation_node_get_animation(const StringName &p_node) const;
 	void animation_node_set_master_animation(const StringName &p_node, const String &p_master_animation);
 	String animation_node_get_master_animation(const StringName &p_node) const;
+	float animation_node_get_position(const StringName &p_node) const;
 
 	void animation_node_set_filter_path(const StringName &p_node, const NodePath &p_track_path, bool p_filter);
 	void animation_node_set_get_filtered_paths(const StringName &p_node, List<NodePath> *r_paths) const;


### PR DESCRIPTION
Small change that allows a user to get the current position in an animation, running in an animation tree, via script.

Useful if the game logic needs to poll for how much an animation have progressed (for example to trigger additional logic or update UI)

Feel free to suggest improvements, especially a better name for the method