### PR TITLE
Fix Godot-2.1 build error on VS2013, use integer as argument for set_input_buffer_max_size()

### DIFF
--- a/core/script_debugger_remote.cpp
+++ b/core/script_debugger_remote.cpp
@@ -1150,7 +1150,7 @@ ScriptDebuggerRemote::ScriptDebuggerRemote() {
 	tcp_client = StreamPeerTCP::create_ref();
 	packet_peer_stream = Ref<PacketPeerStream>(memnew(PacketPeerStream));
 	packet_peer_stream->set_stream_peer(tcp_client);
-	packet_peer_stream->set_input_buffer_max_size(pow(2, 20));
+	packet_peer_stream->set_input_buffer_max_size(1024 * 1024 * 1);
 	mutex = Mutex::create();
 	locking = false;
 

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1720,7 +1720,7 @@ void ScriptEditorDebugger::_bind_methods() {
 ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 
 	ppeer = Ref<PacketPeerStream>(memnew(PacketPeerStream));
-	ppeer->set_input_buffer_max_size(pow(2, 20));
+	ppeer->set_input_buffer_max_size(1024 * 1024 * 1);
 
 	editor = p_editor;
 	editor->get_property_editor()->connect("object_id_selected", this, "_scene_tree_property_select_object");


### PR DESCRIPTION
Fix Godot-2.1 branch build error on VS2013 
Fixes this issue: https://github.com/godotengine/godot/issues/18556

https://github.com/godotengine/godot/blob/2.1/editor/script_editor_debugger.cpp
https://github.com/godotengine/godot/blob/2.1/core/script_debugger_remote.cpp

------------------

**Issue description:**
Build failure on Visual Studio 2013 because of calling pow() with integer (without type casting).

**Steps to reproduce:**
1. Build "**Godot-2.1 (branch)** or **Godot-2.1.4 (stable)**" with Visual Studio 2013 + Python 2.7 + scons
2. scons platform=windows vsproj=yes
3. This will throw error:
```
editor\script_editor_debugger.cpp(1736) : error C2668: 'pow' : ambiguous call to overloaded function
        D:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\INCLUDE\math.h(1233): could be 'long double pow(long double,int) throw()'
        D:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\INCLUDE\math.h(1231): or       'long double pow(long double,long double) throw()'
        D:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\INCLUDE\math.h(1117): or       'float pow(float,int) throw()'
        D:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\INCLUDE\math.h(1115): or       'float pow(float,float) throw()'
        D:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\INCLUDE\math.h(1027): or       'double pow(double,int) throw()'
        D:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\INCLUDE\math.h(512): or       'double pow(double,double)'
        while trying to match the argument list '(int, int)'
editor\script_editor_debugger.cpp(1736) : error C2143: syntax error : missing ')' before ';'
scons: *** [editor\script_editor_debugger.windows.tools.32.obj] Error 2
scons: building terminated because of errors.

```