### PR TITLE
Set current SynchronizationContext before the game loop starts

### DIFF
--- a/modules/mono/glue/cs_files/GodotTaskScheduler.cs
+++ b/modules/mono/glue/cs_files/GodotTaskScheduler.cs
@@ -14,6 +14,7 @@ namespace Godot
 		public GodotTaskScheduler()
 		{
 			Context = new GodotSynchronizationContext();
+			SynchronizationContext.SetSynchronizationContext(Context);
 		}
 
 		protected sealed override void QueueTask(Task task)
@@ -57,7 +58,6 @@ namespace Godot
 
 		public void Activate()
 		{
-			SynchronizationContext.SetSynchronizationContext(Context);
 			ExecuteQueuedTasks();
 			Context.ExecutePendingContinuations();
 		}


### PR DESCRIPTION
This Fixes the problem that `SynchronizationContext.Current` would be null during the call to `_EnterTree`, `_Ready` and the first call to `_Process` thus the task continuations would be scheduled outside the main thread, which is unexpected and might lead to crashes.

With this change, task continuations are scheduled always on the main thread and so async/await can be used without any explicit synchronization, which is what is expected.

Fixes #18849