### PR TITLE
Build HTML5 release_debug with -Os

### DIFF
--- a/platform/javascript/SCsub
+++ b/platform/javascript/SCsub
@@ -30,8 +30,8 @@ zip_files = env.InstallAs([
     zip_dir.File('godot.wasm'),
     zip_dir.File('godot.html')
 ], [
-	js_wrapped,
-	wasm,
-	'#misc/dist/html/default.html'
+    js_wrapped,
+    wasm,
+    '#misc/dist/html/default.html'
 ])
 env.Zip('#bin/godot', zip_files, ZIPROOT=zip_dir, ZIPSUFFIX='${PROGSUFFIX}${ZIPSUFFIX}', ZIPCOMSTR='Archving $SOURCES as $TARGET')

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -1,5 +1,4 @@
 import os
-import string
 import sys
 
 
@@ -48,8 +47,6 @@ def configure(env):
         # run-time performance.
         env.Append(CCFLAGS=['-Os'])
         env.Append(LINKFLAGS=['-Os'])
-        if env['target'] == 'profile':
-            env.Append(LINKFLAGS=['--profiling-funcs'])
 
     elif env['target'] == 'release_debug':
         env.Append(CPPDEFINES=['DEBUG_ENABLED'])

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -38,7 +38,7 @@ def configure(env):
 
     ## Build type
 
-    if env['target'] == 'release' or env['target'] == 'profile':
+    if env['target'] != 'debug':
         # Use -Os to prioritize optimizing for reduced file size. This is
         # particularly valuable for the web platform because it directly
         # decreases download time.
@@ -47,15 +47,11 @@ def configure(env):
         # run-time performance.
         env.Append(CCFLAGS=['-Os'])
         env.Append(LINKFLAGS=['-Os'])
-
-    elif env['target'] == 'release_debug':
-        env.Append(CPPDEFINES=['DEBUG_ENABLED'])
-        env.Append(CCFLAGS=['-O2'])
-        env.Append(LINKFLAGS=['-O2'])
-        # Retain function names for backtraces at the cost of file size.
-        env.Append(LINKFLAGS=['--profiling-funcs'])
-
-    elif env['target'] == 'debug':
+        if env['target'] == 'release_debug':
+            env.Append(CPPDEFINES=['DEBUG_ENABLED'])
+            # Retain function names for backtraces at the cost of file size.
+            env.Append(LINKFLAGS=['--profiling-funcs'])
+    else:
         env.Append(CPPDEFINES=['DEBUG_ENABLED'])
         env.Append(CCFLAGS=['-O1', '-g'])
         env.Append(LINKFLAGS=['-O1', '-g'])


### PR DESCRIPTION
For `release_debug`, there's little reason to prefer `-O2` over `-Os`. For faster, iterative builds during development, `debug` is available.
Decreases binary size from 19.1 to 12.5 MB.

Also includes a whitespace fix and drops some useless lines.