### PR TITLE
fix get_char_width for non-latin characters

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -302,7 +302,7 @@ void TextEdit::Text::remove(int p_at) {
 	text.remove(p_at);
 }
 
-int TextEdit::Text::get_char_width(char c, char next_c, int px) const {
+int TextEdit::Text::get_char_width(CharType c, CharType next_c, int px) const {
 
 	int tab_w = font->get_char_size(' ').width * indent_size;
 	int w = 0;
@@ -3620,7 +3620,7 @@ void TextEdit::adjust_viewport_to_cursor() {
 		visible_width -= v_scroll->get_combined_minimum_size().width;
 	visible_width -= 20; // give it a little more space
 
-	if (is_wrap_enabled()) {
+	if (!is_wrap_enabled()) {
 		// adjust x offset
 		int cursor_x = get_column_x_offset(cursor.column, text[cursor.line]);
 

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -95,7 +95,7 @@ public:
 		void set_color_regions(const Vector<ColorRegion> *p_regions) { color_regions = p_regions; }
 		int get_line_width(int p_line) const;
 		int get_max_width(bool p_exclude_hidden = false) const;
-		int get_char_width(char c, char next_c, int px) const;
+		int get_char_width(CharType c, CharType next_c, int px) const;
 		void set_line_wrap_amount(int p_line, int p_wrap_amount) const;
 		int get_line_wrap_amount(int p_line) const;
 		const Map<int, ColorRegionInfo> &get_color_region_info(int p_line) const;


### PR DESCRIPTION
Fixes #18906 
Non-Latin characters now render properly.
Note: wrapping Non-Latin characters still does not work as it should, I will look into this later
also contains a minor fix when adjusting window