### PR TITLE
Restore non-WebAssembly (asm.js) support in HTML5 export

### DIFF
--- a/misc/dist/html/default.html
+++ b/misc/dist/html/default.html
@@ -230,6 +230,7 @@ $GODOT_HEAD_INCLUDE
 		(function() {
 
 			const MAIN_PACK = '$GODOT_BASENAME.pck';
+			const MEMORY_SIZE = $GODOT_TOTAL_MEMORY;
 			const DEBUG_ENABLED = $GODOT_DEBUG_ENABLED;
 			const INDETERMINATE_STATUS_STEP_MS = 100;
 
@@ -243,6 +244,8 @@ $GODOT_HEAD_INCLUDE
 			var initializing = true;
 			var statusMode = 'hidden';
 			var indeterminiateStatusAnimationId = 0;
+
+			engine.setAsmjsMemorySize(MEMORY_SIZE);
 
 			function setStatusMode(mode) {
 
@@ -327,6 +330,10 @@ $GODOT_HEAD_INCLUDE
 				outputRoot.style.display = 'block';
 
 				function print(text) {
+					if (arguments.length > 1) {
+						text = Array.prototype.slice.call(arguments).join(" ");
+					}
+					if (text.length <= 0) return;
 					while (outputScroll.childElementCount >= OUTPUT_MSG_COUNT_MAX) {
 						outputScroll.firstChild.remove();
 					}

--- a/platform/javascript/SCsub
+++ b/platform/javascript/SCsub
@@ -10,28 +10,48 @@ javascript_files = [
     'os_javascript.cpp',
 ]
 
-build = env.add_program(['#bin/godot${PROGSUFFIX}.js', '#bin/godot${PROGSUFFIX}.wasm'], javascript_files);
-js, wasm = build
+if env['wasm']:
+	build = env.add_program(['#bin/godot${PROGSUFFIX}.js', '#bin/godot${PROGSUFFIX}.wasm'], javascript_files);
+	js, wasm = build
+	wrapper_start = env.File('pre_wasm.js')
+else:
+	build = env.add_program(['#bin/godot${PROGSUFFIX}.js', '#bin/godot${PROGSUFFIX}.asm.js', '#bin/godot${PROGSUFFIX}.js.mem'], javascript_files);
+	js, asm, mem = build
+	wrapper_start = env.File('pre_asmjs.js')
 
 js_libraries = [
     'http_request.js',
 ]
 for lib in js_libraries:
     env.Append(LINKFLAGS=['--js-library', env.File(lib).path])
+
 env.Depends(build, js_libraries)
 
-wrapper_start = env.File('pre.js')
 wrapper_end = env.File('engine.js')
 js_wrapped = env.Textfile('#bin/godot', [wrapper_start, js, wrapper_end], TEXTFILESUFFIX='${PROGSUFFIX}.wrapped.js')
 
 zip_dir = env.Dir('#bin/.javascript_zip')
-zip_files = env.InstallAs([
-    zip_dir.File('godot.js'),
-    zip_dir.File('godot.wasm'),
-    zip_dir.File('godot.html')
-], [
-	js_wrapped,
-	wasm,
-	'#misc/dist/html/default.html'
-])
-env.Zip('#bin/godot', zip_files, ZIPROOT=zip_dir, ZIPSUFFIX='${PROGSUFFIX}${ZIPSUFFIX}', ZIPCOMSTR='Archving $SOURCES as $TARGET')
+if env['wasm']:
+	zip_files = env.InstallAs([
+	    zip_dir.File('godot.js'),
+	    zip_dir.File('godot.wasm'),
+	    zip_dir.File('godot.html')
+	], [
+		js_wrapped,
+		wasm,
+		'#misc/dist/html/default.html'
+	])
+else:
+	zip_files = env.InstallAs([
+	    zip_dir.File('godot.js'),
+	    zip_dir.File('godot.asm.js'),
+	    zip_dir.File('godot.mem'),
+            zip_dir.File('godot.html')
+	], [
+		js_wrapped,
+		asm,
+		mem,
+		'#misc/dist/html/default.html'
+	])
+
+env.Zip('#bin/godot', zip_files, ZIPROOT=zip_dir, ZIPSUFFIX='${PROGSUFFIX}${ZIPSUFFIX}', ZIPCOMSTR='Archiving $SOURCES as $TARGET')

--- a/platform/javascript/pre_asmjs.js
+++ b/platform/javascript/pre_asmjs.js
@@ -1,0 +1,3 @@
+var Engine = {
+	USING_WASM: false,
+	RuntimeEnvironment: function(Module, exposedLibs) {

--- a/platform/javascript/pre_wasm.js
+++ b/platform/javascript/pre_wasm.js
@@ -1,2 +1,3 @@
 var Engine = {
+	USING_WASM: true,
 	RuntimeEnvironment: function(Module, exposedLibs) {


### PR DESCRIPTION
This reverts commit 9107357c8dfda98c5adb33d3c5f4a7be1996fa07, reversing
changes made to 0aa4765904b0aea28ccf485b2428b027a5960df4.

Basically what the title of the commit says, plus modifications to make it work against latest master again.

When building the javascript export template you can say: 

wasm=yes for WebAssembly or
wasm=no for asm.js support.
 
Tested with a 2D Example scene, both variants exported, working in Firefox. 
Chromium has some OpenGL related issues though, but those happen in master too and should be unrelated to the exporter itself.

Furthermore, you can export to HTML5 now if you ONLY have specified atleast a debug or a release template (means this is enough already, in case you dont have "regular" templates installed.