### PR TITLE
Store flags so it isn't lost when viewport isn't setup yet

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -72,6 +72,9 @@ void ViewportTexture::setup_local_to_scene() {
 	vp->viewport_textures.insert(this);
 
 	VS::get_singleton()->texture_set_proxy(proxy, vp->texture_rid);
+
+	vp->texture_flags = flags;
+	VS::get_singleton()->texture_set_flags(vp->texture_rid, flags);
 }
 
 void ViewportTexture::set_viewport_path_in_scene(const NodePath &p_path) {
@@ -122,20 +125,18 @@ Ref<Image> ViewportTexture::get_data() const {
 	return VS::get_singleton()->texture_get_data(vp->texture_rid);
 }
 void ViewportTexture::set_flags(uint32_t p_flags) {
+	flags = p_flags;
 
 	if (!vp)
 		return;
 
-	vp->texture_flags = p_flags;
-	VS::get_singleton()->texture_set_flags(vp->texture_rid, p_flags);
+	vp->texture_flags = flags;
+	VS::get_singleton()->texture_set_flags(vp->texture_rid, flags);
 }
 
 uint32_t ViewportTexture::get_flags() const {
 
-	if (!vp)
-		return 0;
-
-	return vp->texture_flags;
+	return flags;
 }
 
 void ViewportTexture::_bind_methods() {
@@ -149,6 +150,7 @@ void ViewportTexture::_bind_methods() {
 ViewportTexture::ViewportTexture() {
 
 	vp = NULL;
+	flags = 0;
 	set_local_to_scene(true);
 	proxy = VS::get_singleton()->texture_create();
 }

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -58,6 +58,7 @@ class ViewportTexture : public Texture {
 
 	friend class Viewport;
 	Viewport *vp;
+	uint32_t flags;
 
 	RID proxy;
 


### PR DESCRIPTION
When a scene is loaded, and as a result our ViewportTexture is loaded, it sets the flags before it has a chance to setup the viewport. Because the flags were stored in the viewport, the setting was lost.

I've added a flags variable to the ViewportTexture so the value isn't lost but set later.
Obviously if you have multiple ViewportTextures all using the same viewport, the last one that is constructed wins.

Fixes #18926 