### PR TITLE
[Doc] Fixes in find bar

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1978,8 +1978,27 @@ FindBar::FindBar() {
 }
 
 void FindBar::popup_search() {
+
 	show();
-	search_text->grab_focus();
+	bool grabbed_focus = false;
+	if (!search_text->has_focus()) {
+		search_text->grab_focus();
+		grabbed_focus = true;
+	}
+
+	if (!search_text->get_text().empty()) {
+		search_text->select_all();
+		search_text->set_cursor_position(search_text->get_text().length());
+		if (grabbed_focus) {
+			_search();
+		}
+	}
+
+	call_deferred("_update_size");
+}
+
+void FindBar::_update_size() {
+
 	container->set_custom_minimum_size(Size2(0, hbc->get_size().height));
 }
 
@@ -2016,6 +2035,7 @@ void FindBar::_bind_methods() {
 	ClassDB::bind_method("_search_next", &FindBar::search_next);
 	ClassDB::bind_method("_search_prev", &FindBar::search_prev);
 	ClassDB::bind_method("_hide_pressed", &FindBar::_hide_bar);
+	ClassDB::bind_method("_update_size", &FindBar::_update_size);
 
 	ADD_SIGNAL(MethodInfo("search"));
 }

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -148,6 +148,8 @@ class FindBar : public HBoxContainer {
 	void _search_text_changed(const String &p_text);
 	void _search_text_entered(const String &p_text);
 
+	void _update_size();
+
 protected:
 	void _notification(int p_what);
 	void _unhandled_input(const Ref<InputEvent> &p_event);


### PR DESCRIPTION
Fix #19152.

- Automatically select all text when find bar called.
- Adjust the size height when first displayed.