### PR TITLE
Exposed set/get_project_metadata in EditorSettings

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -4,7 +4,7 @@
 		Editor interface and main components.
 	</brief_description>
 	<description>
-		Editor interface. Allows saving and (re-)loading scenes, rendering mesh previews, inspecting and editing resources and objects and provides access to [EditorSettings], [EditorFileSystem], [EditorResourcePreview]\ er, [ScriptEditor], the editor viewport, as well as information about scenes. Also see [EditorPlugin] and [EditorScript].
+		Editor interface. Allows saving and (re-)loading scenes, rendering mesh previews, inspecting and editing resources and objects and provides access to [EditorSettings], [EditorFileSystem], [EditorResourcePreview], [ScriptEditor], the editor viewport, as well as information about scenes. Also see [EditorPlugin] and [EditorScript].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -55,7 +55,19 @@
 				Get the list of favorite directories for this project.
 			</description>
 		</method>
-		<method name="get_project_settings_dir" qualifiers="const">
+		<method name="get_project_metadata" qualifiers="const">
+			<return type="Variant">
+			</return>
+			<argument index="0" name="section" type="String">
+			</argument>
+			<argument index="1" name="key" type="String">
+			</argument>
+			<argument index="2" name="default" type="Variant" default="null">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_project_settings_dir">
 			<return type="String">
 			</return>
 			<description>
@@ -127,6 +139,16 @@
 			<argument index="1" name="value" type="Variant">
 			</argument>
 			<argument index="2" name="update_current" type="bool">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_project_metadata">
+			<argument index="0" name="section" type="String">
+			</argument>
+			<argument index="1" name="key" type="String">
+			</argument>
+			<argument index="2" name="data" type="Variant">
 			</argument>
 			<description>
 			</description>

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1151,7 +1151,7 @@ void EditorSettings::set_project_metadata(const String &p_section, const String 
 	cf->save(path);
 }
 
-Variant EditorSettings::get_project_metadata(const String &p_section, const String &p_key, Variant p_default) {
+Variant EditorSettings::get_project_metadata(const String &p_section, const String &p_key, Variant p_default) const {
 	Ref<ConfigFile> cf = memnew(ConfigFile);
 	String path = get_project_settings_dir().plus_file("project_metadata.cfg");
 	Error err = cf->load(path);
@@ -1492,6 +1492,9 @@ void EditorSettings::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_settings_dir"), &EditorSettings::get_settings_dir);
 	ClassDB::bind_method(D_METHOD("get_project_settings_dir"), &EditorSettings::get_project_settings_dir);
+
+	ClassDB::bind_method(D_METHOD("set_project_metadata", "section", "key", "data"), &EditorSettings::set_project_metadata);
+	ClassDB::bind_method(D_METHOD("get_project_metadata", "section", "key", "default"), &EditorSettings::get_project_metadata, DEFVAL(Variant()));
 
 	ClassDB::bind_method(D_METHOD("set_favorite_dirs", "dirs"), &EditorSettings::set_favorite_dirs);
 	ClassDB::bind_method(D_METHOD("get_favorite_dirs"), &EditorSettings::get_favorite_dirs);

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -167,7 +167,7 @@ public:
 	String get_cache_dir() const;
 
 	void set_project_metadata(const String &p_section, const String &p_key, Variant p_data);
-	Variant get_project_metadata(const String &p_section, const String &p_key, Variant p_default);
+	Variant get_project_metadata(const String &p_section, const String &p_key, Variant p_default) const;
 
 	void set_favorite_dirs(const Vector<String> &p_favorites_dirs);
 	Vector<String> get_favorite_dirs() const;


### PR DESCRIPTION
Some plugins may want to store some information about the project they're in, but without having to add files to the project itself, that's where being able to access the project's metadata is very useful, which is made to store info about the project specifically.

It's going to help a lot in a notes plugin that I'm making.