### PR TITLE
Fix bad operator check in `ShaderLanguage::_validate_assign`

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -2300,7 +2300,7 @@ bool ShaderLanguage::_validate_assign(Node *p_node, const Map<StringName, BuiltI
 	if (p_node->type == Node::TYPE_OPERATOR) {
 
 		OperatorNode *op = static_cast<OperatorNode *>(p_node);
-		if (op->type == OP_INDEX) {
+		if (op->op == OP_INDEX) {
 			return _validate_assign(op->arguments[0], p_builtin_types);
 		}
 	}


### PR DESCRIPTION
I'm not familiar with godot's codebase to tell if that influenced anything critical, but it might've prevented proper checking assigns in index operators ?