### PR TITLE
Fix PoolAllocator::resize for too large p_new_size

### DIFF
--- a/core/pool_allocator.cpp
+++ b/core/pool_allocator.cpp
@@ -359,7 +359,7 @@ Error PoolAllocator::resize(ID p_mem, int p_new_size) {
 	//p_new_size = align(p_new_size)
 	int _free = free_mem; // - static_area_size;
 
-	if ((_free + aligned(e->len)) - alloc_size < 0) {
+	if (uint32_t(_free + aligned(e->len)) < alloc_size) {
 		mt_unlock();
 		ERR_FAIL_V(ERR_OUT_OF_MEMORY);
 	};


### PR DESCRIPTION
The code had a subtle signed/unsigned bug -
```cpp
if( signed - unsigned < 0)
// signed - unsigned is unsigned in c++, so the code becomes
if( unsigned < 0)
// and thus the if block will never be executed
```

Thus all the following code would be ran, including unnecessary retries
of compacting the pool.