### PR TITLE
Small tooltip changes

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -383,11 +383,11 @@ void FileSystemDock::_update_file_display_toggle_button() {
 	if (button_display_mode->is_pressed()) {
 		display_mode = DISPLAY_LIST;
 		button_display_mode->set_icon(get_icon("FileThumbnail", "EditorIcons"));
-		button_display_mode->set_tooltip(TTR("View items as a grid of thumbnails"));
+		button_display_mode->set_tooltip(TTR("View items as a grid of thumbnails."));
 	} else {
 		display_mode = DISPLAY_THUMBNAILS;
 		button_display_mode->set_icon(get_icon("FileList", "EditorIcons"));
-		button_display_mode->set_tooltip(TTR("View items as a list"));
+		button_display_mode->set_tooltip(TTR("View items as a list."));
 	}
 }
 
@@ -1860,7 +1860,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	button_favorite->set_flat(true);
 	button_favorite->set_toggle_mode(true);
 	button_favorite->connect("pressed", this, "_favorites_pressed");
-	button_favorite->set_tooltip(TTR("Toggle folder status as Favorite"));
+	button_favorite->set_tooltip(TTR("Toggle folder status as Favorite."));
 	button_favorite->set_focus_mode(FOCUS_NONE);
 	toolbar_hbc->add_child(button_favorite);
 
@@ -1916,11 +1916,13 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	file_list_vb->add_child(path_hb);
 
 	button_tree = memnew(ToolButton);
+	button_tree->set_tooltip(TTR("Enter tree-view."));
 	button_tree->hide();
 	path_hb->add_child(button_tree);
 
 	search_box = memnew(LineEdit);
 	search_box->set_h_size_flags(SIZE_EXPAND_FILL);
+	search_box->set_placeholder(TTR("Search files"));
 	search_box->connect("text_changed", this, "_search_changed");
 	path_hb->add_child(search_box);
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1404,6 +1404,7 @@ void ScriptEditor::_update_members_overview_visibility() {
 
 	ScriptEditorBase *se = _get_current_editor();
 	if (!se) {
+		members_overview_buttons_hbox->set_visible(false);
 		members_overview->set_visible(false);
 		return;
 	}
@@ -2681,7 +2682,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	members_overview_vbox->add_child(members_overview_buttons_hbox);
 
 	members_overview_alphabeta_sort_button = memnew(ToolButton);
-	members_overview_alphabeta_sort_button->set_tooltip(TTR("Sort alphabetically"));
+	members_overview_alphabeta_sort_button->set_tooltip(TTR("Toggle alphabetical sorting of the method list."));
 	members_overview_alphabeta_sort_button->set_toggle_mode(true);
 	members_overview_alphabeta_sort_button->set_pressed(EditorSettings::get_singleton()->get("text_editor/tools/sort_members_outline_alphabetically"));
 	members_overview_alphabeta_sort_button->connect("toggled", this, "_toggle_members_overview_alpha_sort");


### PR DESCRIPTION
- Changed the tooltip of the alphabetical sorting of the method list to be a little more descriptive.
- Added periods to the tooltips in the Filesystem dock, as well as giving its search bar a placeholder.