### PR TITLE
Removed incorrect Basis::set_scale().

### DIFF
--- a/core/math/matrix3.cpp
+++ b/core/math/matrix3.cpp
@@ -242,16 +242,9 @@ void Basis::scale_local(const Vector3 &p_scale) {
 
 Basis Basis::scaled_local(const Vector3 &p_scale) const {
 	Basis b;
-	b.set_scale(p_scale);
+	b.set_diagonal(p_scale);
 
 	return (*this) * b;
-}
-
-void Basis::set_scale(const Vector3 &p_scale) {
-
-	set_axis(0, get_axis(0).normalized() * p_scale.x);
-	set_axis(1, get_axis(1).normalized() * p_scale.y);
-	set_axis(2, get_axis(2).normalized() * p_scale.z);
 }
 
 Vector3 Basis::get_scale_abs() const {

--- a/core/math/matrix3.h
+++ b/core/math/matrix3.h
@@ -110,7 +110,6 @@ public:
 	void scale_local(const Vector3 &p_scale);
 	Basis scaled_local(const Vector3 &p_scale) const;
 
-	void set_scale(const Vector3 &p_scale);
 	Vector3 get_scale() const;
 	Vector3 get_scale_abs() const;
 	Vector3 get_scale_local() const;
@@ -230,10 +229,13 @@ public:
 	operator Quat() const { return get_quat(); }
 
 	Basis(const Quat &p_quat) { set_quat(p_quat); };
+	Basis(const Quat &p_quat, const Vector3 &p_scale) { set_quat_scale(p_quat, p_scale); }
+
 	Basis(const Vector3 &p_euler) { set_euler(p_euler); }
+	Basis(const Vector3 &p_euler, const Vector3 &p_scale) { set_euler_scale(p_euler, p_scale); }
+
 	Basis(const Vector3 &p_axis, real_t p_phi) { set_axis_angle(p_axis, p_phi); }
 	Basis(const Vector3 &p_axis, real_t p_phi, const Vector3 &p_scale) { set_axis_angle_scale(p_axis, p_phi, p_scale); }
-	Basis(const Quat &p_quat, const Vector3 &p_scale) { set_quat_scale(p_quat, p_scale); }
 
 	_FORCE_INLINE_ Basis(const Vector3 &row0, const Vector3 &row1, const Vector3 &row2) {
 		elements[0] = row0;

--- a/core/math/transform.cpp
+++ b/core/math/transform.cpp
@@ -127,12 +127,11 @@ Transform Transform::interpolate_with(const Transform &p_transform, real_t p_c) 
 	Quat dst_rot = p_transform.basis;
 	Vector3 dst_loc = p_transform.origin;
 
-	Transform dst; //this could be made faster by using a single function in Basis..
-	dst.basis = src_rot.slerp(dst_rot, p_c).normalized();
-	dst.basis.set_scale(src_scale.linear_interpolate(dst_scale, p_c));
-	dst.origin = src_loc.linear_interpolate(dst_loc, p_c);
+	Transform interp;
+	interp.basis.set_quat_scale(src_rot.slerp(dst_rot, p_c).normalized(), src_scale.linear_interpolate(dst_scale, p_c));
+	interp.origin = src_loc.linear_interpolate(dst_loc, p_c);
 
-	return dst;
+	return interp;
 }
 
 void Transform::scale(const Vector3 &p_scale) {

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -632,19 +632,15 @@ void Spatial::scale_object_local(const Vector3 &p_scale) {
 
 void Spatial::global_rotate(const Vector3 &p_axis, float p_angle) {
 
-	Basis rotation(p_axis, p_angle);
 	Transform t = get_global_transform();
-	t.basis = rotation * t.basis;
+	t.basis.rotate(p_axis, p_angle);
 	set_global_transform(t);
 }
 
 void Spatial::global_scale(const Vector3 &p_scale) {
 
-	Basis s;
-	s.set_scale(p_scale);
-
 	Transform t = get_global_transform();
-	t.basis = s * t.basis;
+	t.basis.scale(p_scale);
 	set_global_transform(t);
 }
 


### PR DESCRIPTION
Also added a missing constructor in Basis.

Removed some unnecessary temporaries in Spatial.

~~`set_scale` set the scaling in the object-local frame rather than parent/global-frame~~ (nope, it is in the parent/global frame), but it doesn't work correctly with negative scales.

A correct set_scale was introduced in 9a37ff1 but was removed in a0bbf5c  for reasons specified in the commit log.

It was added back in 6d233c6 in the aforementioned manner.