### PR TITLE
Revert "Fix color-picker sliders"

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -158,14 +158,15 @@ void ColorPicker::_update_color() {
 	updating = true;
 
 	for (int i = 0; i < 4; i++) {
+		scroll[i]->set_step(0.01);
 		if (raw_mode_enabled) {
-			scroll[i]->set_step(0.01);
-			scroll[i]->set_max(1);
+			scroll[i]->set_max(100);
+			if (i == 3)
+				scroll[i]->set_max(1);
 			scroll[i]->set_value(color.components[i]);
 		} else {
-			scroll[i]->set_step(1);
-			scroll[i]->set_max(255);
 			const int byte_value = color.components[i] * 255;
+			scroll[i]->set_max(next_power_of_2(MAX(255, byte_value)) - 1);
 			scroll[i]->set_value(byte_value);
 		}
 	}


### PR DESCRIPTION
Reverts godotengine/godot#18981, as discussed with @MarianoGnu in the PR.