### PR TITLE
Small visual changes for some filter bars

### DIFF
--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -286,6 +286,9 @@ void GroupDialog::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			add_button->set_icon(get_icon("Forward", "EditorIcons"));
 			remove_button->set_icon(get_icon("Back", "EditorIcons"));
+
+			add_filter->add_icon_override("right_icon", get_icon("Search", "EditorIcons"));
+			remove_filter->add_icon_override("right_icon", get_icon("Search", "EditorIcons"));
 		} break;
 	}
 }

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -523,6 +523,8 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 
 	search = memnew(LineEdit);
 	search->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	search->set_placeholder(TTR("Filter properties"));
+	search->add_icon_override("right_icon", get_icon("Search", "EditorIcons"));
 	add_child(search);
 
 	warning = memnew(Button);
@@ -560,12 +562,3 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 
 InspectorDock::~InspectorDock() {
 }
-
-// void InspectorDock::_clear_search_box() {
-
-// 	if (search_box->get_text() == "")
-// 		return;
-
-// 	search_box->clear();
-// 	inspector->update_tree();
-// }


### PR DESCRIPTION
Made the property filter match the one in the scene dock:
![screenshot1](https://user-images.githubusercontent.com/30739239/40210658-b62fa23a-5a35-11e8-87bb-d073a0411836.png)

Also gave these two the icons for consistency:
![screenshot2](https://user-images.githubusercontent.com/30739239/40210659-b772219a-5a35-11e8-91de-d2e823949277.png)