### PR TITLE
Make the performance reporting update frequency customizable

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -1071,6 +1071,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("rendering/quality/intended_usage/framebuffer_mode", 2);
 
 	GLOBAL_DEF("debug/settings/profiler/max_functions", 16384);
+	GLOBAL_DEF("debug/settings/performance/update_frequency_msec", 250);
 
 	//assigning here, because using GLOBAL_GET on every block for compressing can be slow
 	Compression::zstd_long_distance_matching = GLOBAL_DEF("compression/formats/zstd/long_distance_matching", false);

--- a/core/script_debugger_remote.cpp
+++ b/core/script_debugger_remote.cpp
@@ -854,7 +854,7 @@ void ScriptDebuggerRemote::idle_poll() {
 	if (performance) {
 
 		uint64_t pt = OS::get_singleton()->get_ticks_msec();
-		if (pt - last_perf_time > 1000) {
+		if (pt - last_perf_time > update_frequency) {
 
 			last_perf_time = pt;
 			int max = performance->get("MONITOR_MAX");
@@ -1081,7 +1081,7 @@ ScriptDebuggerRemote::ScriptDebuggerRemote() :
 	eh.userdata = this;
 	add_error_handler(&eh);
 
-	profile_info.resize(CLAMP(int(ProjectSettings::get_singleton()->get("debug/settings/profiler/max_functions")), 128, 65535));
+	profile_info.resize(CLAMP(int(GLOBAL_GET("debug/settings/profiler/max_functions")), 128, 65535));
 	profile_info_ptrs.resize(profile_info.size());
 }
 

--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "script_language.h"
+#include "project_settings.h"
 
 ScriptLanguage *ScriptServer::_languages[MAX_LANGUAGES];
 int ScriptServer::_language_count = 0;
@@ -283,6 +284,7 @@ ScriptDebugger::ScriptDebugger() {
 	lines_left = -1;
 	depth = -1;
 	break_lang = NULL;
+	update_frequency = GLOBAL_GET("debug/settings/performance/update_frequency_msec");
 }
 
 bool PlaceHolderScriptInstance::set(const StringName &p_name, const Variant &p_value) {

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -352,6 +352,8 @@ class ScriptDebugger {
 public:
 	typedef void (*RequestSceneTreeMessageFunc)(void *);
 
+	int update_frequency;
+
 	struct LiveEditFuncs {
 
 		void *udata;

--- a/main/main.h
+++ b/main/main.h
@@ -44,7 +44,7 @@ class Main {
 	static void print_help(const char *p_binary);
 	static uint64_t last_ticks;
 	static uint64_t target_ticks;
-	static uint32_t frames;
+	static Array frame_times;
 	static uint32_t frame;
 	static bool force_redraw_requested;
 


### PR DESCRIPTION
The default update frequency has been changed from 1000ms to 250ms. This makes FPS counter and monitor updates smoother and more reactive. I couldn't notice any significant performance decreases by lowering the default reporting rate to 250ms, even on a nearly empty project which ran at over 4,000 FPS on my machine.

I had to redesign the FPS counting algorithm after [this one](http://www.growingwiththeweb.com/2017/12/fast-simple-js-fps-counter.html) so that FPS counting no longer relies on an update frequency of 1000ms.

This implements https://github.com/godotengine/godot/issues/2794.