### PR TITLE
fixed scrolling in new ispector when using trackpad pan gesture

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1380,6 +1380,8 @@ void Viewport::_gui_call_input(Control *p_control, const Ref<InputEvent> &p_inpu
 									 mb->get_button_index() == BUTTON_WHEEL_UP ||
 									 mb->get_button_index() == BUTTON_WHEEL_LEFT ||
 									 mb->get_button_index() == BUTTON_WHEEL_RIGHT));
+	Ref<InputEventPanGesture> pn = p_input;
+	cant_stop_me_now = pn.is_valid() || cant_stop_me_now;
 
 	bool ismouse = ev.is_valid() || Object::cast_to<InputEventMouseMotion>(*p_input) != NULL;
 


### PR DESCRIPTION
The scroll event did not activate set 'cant_stop_me_now' variable to true so it could not get passed to the scroll container... it was stuck in the child controls...

Now it is passed to the root parent the same as MOUS_BUTTON_UP/DOWN/LEFT/RIGHT.

