### PR TITLE
Fixed generating radiance texture when using viewport texture for sky

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2363,10 +2363,9 @@ void RasterizerSceneGLES3::_draw_sky(RasterizerStorageGLES3::Sky *p_sky, const C
 	ERR_FAIL_COND(!tex);
 	glActiveTexture(GL_TEXTURE0);
 
-	if (tex->proxy && tex->proxy->tex_id)
-		glBindTexture(tex->target, tex->proxy->tex_id);
-	else
-		glBindTexture(tex->target, tex->tex_id);
+	tex = tex->get_ptr(); //resolve for proxies
+
+	glBindTexture(tex->target, tex->tex_id);
 
 	if (storage->config.srgb_decode_supported && tex->srgb && !tex->using_srgb) {
 

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -1356,6 +1356,8 @@ void RasterizerStorageGLES3::sky_set_texture(RID p_sky, RID p_panorama, int p_ra
 		ERR_FAIL_COND(!texture);
 	}
 
+	texture = texture->get_ptr(); //resolve for proxies
+
 	glBindVertexArray(0);
 	glDisable(GL_CULL_FACE);
 	glDisable(GL_DEPTH_TEST);
@@ -5895,12 +5897,9 @@ void RasterizerStorageGLES3::update_particles() {
 							tex = resources.white_tex;
 						} break;
 					}
-				} else if (t->proxy && t->proxy->tex_id) {
-
-					target = t->proxy->target;
-					tex = t->proxy->tex_id;
 				} else {
 
+					t = t->get_ptr(); //resolve for proxies
 					target = t->target;
 					tex = t->tex_id;
 				}


### PR DESCRIPTION
As per @karroffel suggestion changed the code to properly used get_ptr() and also applied the fix to calculating the radiance texture when assigning the sky (I'm going to raise a new issue for this however suggesting some improvements but need some feedback first).

Fixes #19028