### PR TITLE
fix for TextEdit::set_text firing signals it shouldn't.

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1005,7 +1005,6 @@ void LineEdit::set_text(String p_text) {
 	update();
 	cursor_pos = 0;
 	window_pos = 0;
-	_text_changed();
 }
 
 void LineEdit::clear() {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4110,7 +4110,7 @@ Control::CursorShape TextEdit::get_cursor_shape(const Point2 &p_pos) const {
 void TextEdit::set_text(String p_text) {
 
 	setting_text = true;
-	clear();
+	_clear();
 	_insert_text_at_cursor(p_text);
 	clear_undo_history();
 	cursor.column = 0;
@@ -4123,7 +4123,7 @@ void TextEdit::set_text(String p_text) {
 	cursor_set_column(0);
 	update();
 	setting_text = false;
-	_text_changed_emit();
+
 	//get_range()->set(0);
 };
 


### PR DESCRIPTION
Removing some "_changed" signals in "set_" functions.
Includes revert of commit 384625aa31a3627c25246e06c1fbc3019866765c

fixes #18937