### PR TITLE
Fix mouse confined and set_borderless_window

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1480,7 +1480,7 @@ void OS_OSX::set_cursor_shape(CursorShape p_shape) {
 	if (cursor_shape == p_shape)
 		return;
 
-	if (mouse_mode != MOUSE_MODE_VISIBLE) {
+	if (mouse_mode != MOUSE_MODE_VISIBLE && mouse_mode != MOUSE_MODE_CONFINED) {
 		cursor_shape = p_shape;
 		return;
 	}

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -105,6 +105,7 @@ class OS_Windows : public OS {
 
 	Size2 window_rect;
 	VideoMode video_mode;
+	bool preserve_window_size = false;
 
 	MainLoop *main_loop;
 

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -2407,7 +2407,7 @@ void OS_X11::set_cursor_shape(CursorShape p_shape) {
 
 	if (p_shape == current_cursor)
 		return;
-	if (mouse_mode == MOUSE_MODE_VISIBLE) {
+	if (mouse_mode == MOUSE_MODE_VISIBLE && mouse_mode != MOUSE_MODE_CONFINED) {
 		if (cursors[p_shape] != None)
 			XDefineCursor(x11_display, x11_window, cursors[p_shape]);
 		else if (cursors[CURSOR_ARROW] != None)


### PR DESCRIPTION
Fix #19033.

- Fix a bug when mouse is confined don't update the cursor shape.
- Don't let the mouse leave the window when resizing to a smaller resolution when `MOUSE_MODE_CONFINED`.
- Fix set_borderless_window to preserve the actual video_mode.widht/height (client rect).