### PR TITLE
Reduce allocations when converting mono arrays to pool arrays

### DIFF
--- a/modules/mono/mono_gd/gd_mono_marshal.cpp
+++ b/modules/mono/mono_gd/gd_mono_marshal.cpp
@@ -607,10 +607,11 @@ MonoArray *Array_to_mono_array(const Array &p_array) {
 Array mono_array_to_Array(MonoArray *p_array) {
 	Array ret;
 	int length = mono_array_length(p_array);
+	ret.resize(length);
 
 	for (int i = 0; i < length; i++) {
 		MonoObject *elem = mono_array_get(p_array, MonoObject *, i);
-		ret.push_back(mono_object_to_variant(elem));
+		ret[i] = mono_object_to_variant(elem);
 	}
 
 	return ret;
@@ -631,10 +632,10 @@ MonoArray *PoolIntArray_to_mono_array(const PoolIntArray &p_array) {
 PoolIntArray mono_array_to_PoolIntArray(MonoArray *p_array) {
 	PoolIntArray ret;
 	int length = mono_array_length(p_array);
-
+	ret.resize(length);
 	for (int i = 0; i < length; i++) {
 		int32_t elem = mono_array_get(p_array, int32_t, i);
-		ret.push_back(elem);
+		ret.set(i, elem);
 	}
 
 	return ret;
@@ -653,10 +654,11 @@ MonoArray *PoolByteArray_to_mono_array(const PoolByteArray &p_array) {
 PoolByteArray mono_array_to_PoolByteArray(MonoArray *p_array) {
 	PoolByteArray ret;
 	int length = mono_array_length(p_array);
+	ret.resize(length);
 
 	for (int i = 0; i < length; i++) {
 		uint8_t elem = mono_array_get(p_array, uint8_t, i);
-		ret.push_back(elem);
+		ret.set(i, elem);
 	}
 
 	return ret;
@@ -675,10 +677,11 @@ MonoArray *PoolRealArray_to_mono_array(const PoolRealArray &p_array) {
 PoolRealArray mono_array_to_PoolRealArray(MonoArray *p_array) {
 	PoolRealArray ret;
 	int length = mono_array_length(p_array);
+	ret.resize(length);
 
 	for (int i = 0; i < length; i++) {
 		real_t elem = mono_array_get(p_array, real_t, i);
-		ret.push_back(elem);
+		ret.set(i, elem);
 	}
 
 	return ret;
@@ -698,10 +701,11 @@ MonoArray *PoolStringArray_to_mono_array(const PoolStringArray &p_array) {
 PoolStringArray mono_array_to_PoolStringArray(MonoArray *p_array) {
 	PoolStringArray ret;
 	int length = mono_array_length(p_array);
+	ret.resize(length);
 
 	for (int i = 0; i < length; i++) {
 		MonoString *elem = mono_array_get(p_array, MonoString *, i);
-		ret.push_back(mono_string_to_godot(elem));
+		ret.set(i, mono_string_to_godot(elem));
 	}
 
 	return ret;
@@ -729,11 +733,12 @@ MonoArray *PoolColorArray_to_mono_array(const PoolColorArray &p_array) {
 PoolColorArray mono_array_to_PoolColorArray(MonoArray *p_array) {
 	PoolColorArray ret;
 	int length = mono_array_length(p_array);
+	ret.resize(length);
 
 	for (int i = 0; i < length; i++) {
 		real_t *raw_elem = (real_t *)mono_array_addr_with_size(p_array, sizeof(real_t) * 4, i);
 		MARSHALLED_IN(Color, raw_elem, elem);
-		ret.push_back(elem);
+		ret.set(i, elem);
 	}
 
 	return ret;
@@ -759,11 +764,12 @@ MonoArray *PoolVector2Array_to_mono_array(const PoolVector2Array &p_array) {
 PoolVector2Array mono_array_to_PoolVector2Array(MonoArray *p_array) {
 	PoolVector2Array ret;
 	int length = mono_array_length(p_array);
+	ret.resize(length);
 
 	for (int i = 0; i < length; i++) {
 		real_t *raw_elem = (real_t *)mono_array_addr_with_size(p_array, sizeof(real_t) * 2, i);
 		MARSHALLED_IN(Vector2, raw_elem, elem);
-		ret.push_back(elem);
+		ret.set(i, elem);
 	}
 
 	return ret;
@@ -790,11 +796,12 @@ MonoArray *PoolVector3Array_to_mono_array(const PoolVector3Array &p_array) {
 PoolVector3Array mono_array_to_PoolVector3Array(MonoArray *p_array) {
 	PoolVector3Array ret;
 	int length = mono_array_length(p_array);
+	ret.resize(length);
 
 	for (int i = 0; i < length; i++) {
 		real_t *raw_elem = (real_t *)mono_array_addr_with_size(p_array, sizeof(real_t) * 3, i);
 		MARSHALLED_IN(Vector3, raw_elem, elem);
-		ret.push_back(elem);
+		ret.set(i, elem);
 	}
 
 	return ret;


### PR DESCRIPTION
Converting MonoArrays to PoolArrays currently involves starting with an empty PoolArray and pushing one item at a time into the array.  This means if there are N items in the mono array, there are N calls to ```PoolArray.resize()```.

This changes that to call ```resize()``` once at the beginning, then call ```set(i, elem)``` instead of ```push_back(elem)```