### PR TITLE
Fix OSXCROSS build with clang-6.0

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -913,7 +913,7 @@ static int remapKey(unsigned int key) {
 
 	CFDataRef layoutData = (CFDataRef)TISGetInputSourceProperty(currentKeyboard, kTISPropertyUnicodeKeyLayoutData);
 	if (!layoutData)
-		return nil;
+		return 0;
 
 	const UCKeyboardLayout *keyboardLayout = (const UCKeyboardLayout *)CFDataGetBytePtr(layoutData);
 
@@ -1740,7 +1740,8 @@ String OS_OSX::get_godot_dir_name() const {
 
 String OS_OSX::get_system_dir(SystemDir p_dir) const {
 
-	NSSearchPathDirectory id = 0;
+	NSSearchPathDirectory id;
+	bool found = true;
 
 	switch (p_dir) {
 		case SYSTEM_DIR_DESKTOP: {
@@ -1761,10 +1762,13 @@ String OS_OSX::get_system_dir(SystemDir p_dir) const {
 		case SYSTEM_DIR_PICTURES: {
 			id = NSPicturesDirectory;
 		} break;
+		default: {
+			found = false;
+		}
 	}
 
 	String ret;
-	if (id) {
+	if (found) {
 
 		NSArray *paths = NSSearchPathForDirectoriesInDomains(id, NSUserDomainMask, YES);
 		if (paths && [paths count] >= 1) {


### PR DESCRIPTION
I was getting the following error:
```
platform/osx/os_osx.mm:916:10: error: cannot initialize return object of type 'int' with an rvalue of type 'nullptr_t'
                return nil;
                       ^~~
../SDK/MacOSX10.11.sdk/usr/include/MacTypes.h:92:19: note: expanded from macro 'nil'
      #define nil nullptr
                  ^~~~~~~
platform/osx/os_osx.mm:1743:24: error: cannot initialize a variable of type 'NSSearchPathDirectory' with an rvalue of type 'int'
        NSSearchPathDirectory id = 0;
```
Which makes sense, `0` is not even a valid `NSSearchPathDirectory` value, the return type of `remapKey` is `int` so returning `0` instead of `nil` should be fine.