### PR TITLE
SpriteFrames: expose method to get array containing animation names

### DIFF
--- a/doc/classes/SpriteFrames.xml
+++ b/doc/classes/SpriteFrames.xml
@@ -127,6 +127,13 @@
 				Changes the animation's name to [code]newname[/code].
 			</description>
 		</method>
+		<method name="get_animation_names">
+			<return type="PoolStringArray">
+			</return>
+			<description>
+				Returns an array containing the names associated to each animation. Values are placed in alphabetical order.
+			</description>
+		</method>
 		<method name="set_animation_loop">
 			<return type="void">
 			</return>

--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -175,6 +175,16 @@ void SpriteFrames::get_animation_list(List<StringName> *r_animations) const {
 	}
 }
 
+Vector<String> SpriteFrames::get_animation_names() const {
+
+	Vector<String> names;
+	for (const Map<StringName, Anim>::Element *E = animations.front(); E; E = E->next()) {
+		names.push_back(E->key());
+	}
+	names.sort();
+	return names;
+}
+
 void SpriteFrames::set_animation_speed(const StringName &p_anim, float p_fps) {
 
 	ERR_FAIL_COND(p_fps < 0);
@@ -265,6 +275,8 @@ void SpriteFrames::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_animation", "anim"), &SpriteFrames::has_animation);
 	ClassDB::bind_method(D_METHOD("remove_animation", "anim"), &SpriteFrames::remove_animation);
 	ClassDB::bind_method(D_METHOD("rename_animation", "anim", "newname"), &SpriteFrames::rename_animation);
+
+	ClassDB::bind_method(D_METHOD("get_animation_names"), &SpriteFrames::get_animation_names);
 
 	ClassDB::bind_method(D_METHOD("set_animation_speed", "anim", "speed"), &SpriteFrames::set_animation_speed);
 	ClassDB::bind_method(D_METHOD("get_animation_speed", "anim"), &SpriteFrames::get_animation_speed);

--- a/scene/2d/animated_sprite.h
+++ b/scene/2d/animated_sprite.h
@@ -72,6 +72,7 @@ public:
 	void rename_animation(const StringName &p_prev, const StringName &p_next);
 
 	void get_animation_list(List<StringName> *r_animations) const;
+	Vector<String> get_animation_names() const;
 
 	void set_animation_speed(const StringName &p_anim, float p_fps);
 	float get_animation_speed(const StringName &p_anim) const;


### PR DESCRIPTION
Adds method `get_animation_names` to expose `SpriteFrames`' animation names at script level.
This is useful when a script needs to handle or make some logic out of the current list of animations.

Solution for #16708