### PR TITLE
Prop editor input improvements

### DIFF
--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -211,7 +211,7 @@ void EditorSpinSlider::_notification(int p_what) {
 			Rect2 grabber_rect = Rect2(ofs + gofs, svofs + 1, grabber_w, 2 * EDSCALE);
 			draw_rect(grabber_rect, c);
 
-			bool display_grabber = (mouse_over_spin || mouse_over_grabber) && !grabbing_spinner;
+			bool display_grabber = (mouse_over_spin || mouse_over_grabber) && !grabbing_spinner && !value_input->is_visible();
 			if (grabber->is_visible() != display_grabber) {
 				if (display_grabber) {
 					grabber->show();

--- a/editor/editor_spin_slider.h
+++ b/editor/editor_spin_slider.h
@@ -57,6 +57,7 @@ class EditorSpinSlider : public Range {
 	bool grabbing_spinner;
 
 	bool read_only;
+	float grabbing_spinner_dist_cache;
 	Vector2 grabbing_spinner_mouse_pos;
 
 	LineEdit *value_input;

--- a/editor/editor_spin_slider.h
+++ b/editor/editor_spin_slider.h
@@ -61,11 +61,12 @@ class EditorSpinSlider : public Range {
 	Vector2 grabbing_spinner_mouse_pos;
 
 	LineEdit *value_input;
+	bool value_input_just_closed;
 
 	void _grabber_gui_input(const Ref<InputEvent> &p_event);
 	void _value_input_closed();
 	void _value_input_entered(const String &);
-
+	void _value_focus_exited();
 	bool hide_slider;
 
 protected:
@@ -74,6 +75,7 @@ protected:
 	static void _bind_methods();
 	void _grabber_mouse_entered();
 	void _grabber_mouse_exited();
+	void _focus_entered();
 
 public:
 	String get_text_value() const;


### PR DESCRIPTION
there are actually three things in this pr. (I can separate them if desired)

### Shortcuts for spin_slider
the spin slider had an exp(), speed dependant, behaviour (which was hard to control)
now it is easy to control it's behaviour by shortcuts (ctrl = int steps, shift = factor 0.1)
![ctrl_shift_showcase](https://user-images.githubusercontent.com/16718859/40326583-0dbe9af8-5d40-11e8-9ea6-b9afee3642f6.gif)

Also the step per int is now always consistent (6 pixels per int) and slow enough to actually make small steps.
also pressing control during spinning rounds the value to the next int immediately.

There is an issue on OS X, that control click is changed to right click... This prohibits you from holding control and than start to drag (with int steps), instead you first have to drag, and than (when the mouse button is hold down) press ctrl. It works fine but if someone has a better solution would be great.
### Better tab control
this was hard to implement there might be an easier solution (took me a long time to figure out what signals I should use) so any help/feedback is desired.

![godot_showcase_tab_prop_editor](https://user-images.githubusercontent.com/16718859/40326653-5a3dc1f6-5d40-11e8-9adc-65a79842ce3e.gif)

 - tab now also enters the text and you go to the next input AND activated the value_input (the modal popup with the textfield) (as seen in the gif, before you had to: enter, down arrow, enter, text input, enter....)
 - enter closes the modal value_input
 - esc closes the modal value_input
 - click outside the input, closes the modal value_input

### fixed showing grabber
The grabber was still shown when editing the number with the value_input.
which looked buggy

## Deprecated (commit removed)
### Removed the grey highlighting on the left of the inspector
Since the one on the items themselves is more than enough Imo. (looks better I think, it's just an aesthetic thing)
Can be seen in the gifs too.
@djrm you told me I should not add sneaky changes (which you are right!) I made it a separate commit. so we can easily remove it. 