### PR TITLE
Make filename clipped on Import dock

### DIFF
--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -407,6 +407,7 @@ ImportDock::ImportDock() {
 	set_name("Import");
 	imported = memnew(Label);
 	imported->add_style_override("normal", EditorNode::get_singleton()->get_gui_base()->get_stylebox("normal", "LineEdit"));
+	imported->set_clip_text(true);
 	add_child(imported);
 	HBoxContainer *hb = memnew(HBoxContainer);
 	add_margin_child(TTR("Import As:"), hb);


### PR DESCRIPTION
Fix #19096

![screenshot_20180522_165425](https://user-images.githubusercontent.com/8281454/40349316-439fd53c-5de1-11e8-9b5e-631ff6b07fc8.png)
