### PR TITLE
Only add autoloads in editor if they have tool scripts

### DIFF
--- a/editor/editor_autoload_settings.h
+++ b/editor/editor_autoload_settings.h
@@ -52,10 +52,18 @@ class EditorAutoloadSettings : public VBoxContainer {
 		String name;
 		String path;
 		bool is_singleton;
+		bool in_editor;
 		int order;
+		Node *node;
 
 		bool operator==(const AutoLoadInfo &p_info) {
 			return order == p_info.order;
+		}
+
+		AutoLoadInfo() {
+			is_singleton = false;
+			in_editor = false;
+			node = NULL;
 		}
 	};
 
@@ -78,6 +86,7 @@ class EditorAutoloadSettings : public VBoxContainer {
 	void _autoload_activated();
 	void _autoload_open(const String &fpath);
 	void _autoload_file_callback(const String &p_path);
+	Node *_create_autoload(const String &p_path);
 
 	Variant get_drag_data_fw(const Point2 &p_point, Control *p_control);
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_control) const;
@@ -93,6 +102,7 @@ public:
 	void autoload_remove(const String &p_name);
 
 	EditorAutoloadSettings();
+	~EditorAutoloadSettings();
 };
 
 #endif

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1444,7 +1444,7 @@ bool Main::start() {
 		}
 #endif
 
-		if (!project_manager) { // game or editor
+		if (!project_manager && !editor) { // game
 			if (game_path != "" || script != "") {
 				//autoload
 				List<PropertyInfo> props;
@@ -1465,24 +1465,13 @@ bool Main::start() {
 
 					if (global_var) {
 						for (int i = 0; i < ScriptServer::get_language_count(); i++) {
-#ifdef TOOLS_ENABLED
-							if (editor) {
-								ScriptServer::get_language(i)->add_named_global_constant(name, Variant());
-							} else {
-								ScriptServer::get_language(i)->add_global_constant(name, Variant());
-							}
-#else
 							ScriptServer::get_language(i)->add_global_constant(name, Variant());
-#endif
 						}
 					}
 				}
 
 				//second pass, load into global constants
 				List<Node *> to_add;
-#ifdef TOOLS_ENABLED
-				ResourceLoader::set_timestamp_on_load(editor); // Avoid problems when editing
-#endif
 				for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
 
 					String s = E->get().name;
@@ -1528,22 +1517,10 @@ bool Main::start() {
 
 					if (global_var) {
 						for (int i = 0; i < ScriptServer::get_language_count(); i++) {
-#ifdef TOOLS_ENABLED
-							if (editor) {
-								ScriptServer::get_language(i)->add_named_global_constant(name, n);
-							} else {
-								ScriptServer::get_language(i)->add_global_constant(name, n);
-							}
-#else
 							ScriptServer::get_language(i)->add_global_constant(name, n);
-#endif
 						}
 					}
 				}
-
-#ifdef TOOLS_ENABLED
-				ResourceLoader::set_timestamp_on_load(false);
-#endif
 
 				for (List<Node *>::Element *E = to_add.front(); E; E = E->next()) {
 


### PR DESCRIPTION
Since nodes might not be in the tree anymore, I needed to add a reference to them in the autoload cache, so they can be properly freed. The update logic is a bit less clever as well, any change in status will cause the node to be reloaded (this is to guarantee they are not leaked nor double-freed).

If you add or remove the tool keyword from an autoloaded script, you need to open the Project Settings to trigger the update.

Fix #18956