### PR TITLE
cppcheck - defensive programming on i index check order

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -500,7 +500,7 @@ public:
 
 	virtual String get_tooltip(const Point2 &p_pos) const {
 		for (int i = 0; i < flag_rects.size(); i++) {
-			if (flag_rects[i].has_point(p_pos) && i < names.size()) {
+			if (i < names.size() && flag_rects[i].has_point(p_pos)) {
 				return names[i];
 			}
 		}


### PR DESCRIPTION
Found via [cppcheck](https://github.com/danmar/cppcheck).

_Defensive programming: The variable 'i' is used as an array index before it is checked that it is within limits. This can mean that the array might be accessed out of bounds. Reorder conditions such as '(a[i] && i < 10)' to '(i < 10 && a[i])'. That way the array will not be accessed if the index is out of limits._
