### PR TITLE
Fix RichTextLabel bug which clears its content when theme changed

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -784,15 +784,6 @@ void RichTextLabel::_notification(int p_what) {
 			update();
 
 		} break;
-		case NOTIFICATION_THEME_CHANGED: {
-
-			if (is_inside_tree() && use_bbcode) {
-				parse_bbcode(bbcode);
-				//first_invalid_line=0; //invalidate ALL
-				//update();
-			}
-
-		} break;
 		case NOTIFICATION_DRAW: {
 
 			_validate_line_caches(main);


### PR DESCRIPTION
I found this bug when working with RichTextLabel for chat in my game, it clears its content every time theme or style changed, I dont wanna touch the work logic of `parse_bbcode` so instead removing `clear` from it, I just remove this unnecessary notification, which called it and breaks a chat logic