### PR TITLE
Use relative node path when assigning a node on inspector

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1522,7 +1522,8 @@ EditorPropertyColor::EditorPropertyColor() {
 
 void EditorPropertyNodePath::_node_selected(const NodePath &p_path) {
 
-	emit_signal("property_changed", get_edited_property(), p_path);
+	Node *base_node = Object::cast_to<Node>(get_edited_object());
+	emit_signal("property_changed", get_edited_property(), base_node->get_path().rel_path_to(p_path));
 	update_property();
 }
 


### PR DESCRIPTION
Absolute node path is saved when assigning a node on inspector now.
so `.tscn` has like this.

```
[node name="PinJoint2D" type="PinJoint2D" parent="." index="6"]
node_a = NodePath("/root/EditorNode/@@5/@@6/@@14/@@16/@@20/@@24/@@25/@@26/@@42/@@43/@@50/@@51/@@6631/@@6498/@@6499/@@6500/@@6501/@@6502/Node123/RigidBody2D")
node_b = NodePath("/root/EditorNode/@@5/@@6/@@14/@@16/@@20/@@24/@@25/@@26/@@42/@@43/@@50/@@51/@@6631/@@6498/@@6499/@@6500/@@6501/@@6502/Node123/RigidBody2D2")

[node name="Polygon2D" type="Polygon2D" parent="." index="4"]
skeleton = NodePath("/root/EditorNode/@@5/@@6/@@14/@@16/@@20/@@24/@@25/@@26/@@42/@@43/@@50/@@51/@@6631/@@6498/@@6499/@@6500/@@6501/@@6502/Node123/Skeleton2D")
```

with this PR

```
[node name="PinJoint2D" type="PinJoint2D" parent="." index="6"]
node_a = NodePath("../RigidBody2D")
node_b = NodePath("../RigidBody2D2")

[node name="Polygon2D" type="Polygon2D" parent="." index="4"]
skeleton = NodePath("../Skeleton2D")
```