### PR TITLE
Improve TileMap undo operations

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.h
+++ b/editor/plugins/tile_map_editor_plugin.h
@@ -174,6 +174,7 @@ class TileMapEditor : public VBoxContainer {
 	void _update_palette();
 	void _menu_option(int p_option);
 
+	void _create_set_cell_undo(const Point2i &p_pos, int p_value, bool p_flip_h, bool p_flip_v, bool p_transpose);
 	void _set_cell(const Point2i &p_pos, int p_value, bool p_flip_h = false, bool p_flip_v = false, bool p_transpose = false);
 
 	void _canvas_mouse_enter();


### PR DESCRIPTION
Fixes #18996
This changes the way the TileMap works with undo operations, before the whole tile_data was used to undo/redo which can freeze the engine a lot with big tilemaps, after this PR only the changed cells are used to undo/redo.