### PR TITLE
More fixes to set_borderless_window

### DIFF
--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -109,6 +109,7 @@ public:
 	bool minimized;
 	bool maximized;
 	bool zoomed;
+	bool resizable;
 
 	Size2 window_size;
 	Rect2 restore_rect;

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1184,6 +1184,7 @@ Error OS_OSX::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 	if (p_desired.borderless_window) {
 		styleMask = NSWindowStyleMaskBorderless;
 	} else {
+		resizable = p_desired.resizable;
 		styleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | (p_desired.resizable ? NSWindowStyleMaskResizable : 0);
 	}
 
@@ -2114,6 +2115,8 @@ void OS_OSX::set_window_resizable(bool p_enabled) {
 		[window_object setStyleMask:[window_object styleMask] | NSWindowStyleMaskResizable];
 	else
 		[window_object setStyleMask:[window_object styleMask] & ~NSWindowStyleMaskResizable];
+
+	resizable = p_enabled;
 };
 
 bool OS_OSX::is_window_resizable() const {
@@ -2223,7 +2226,7 @@ void OS_OSX::set_borderless_window(bool p_borderless) {
 		if (layered_window)
 			set_window_per_pixel_transparency_enabled(false);
 
-		[window_object setStyleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable];
+		[window_object setStyleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | (resizable ? NSWindowStyleMaskResizable : 0)];
 
 		// Force update of the window styles
 		NSRect frameRect = [window_object frame];
@@ -2619,6 +2622,7 @@ OS_OSX::OS_OSX() {
 	minimized = false;
 	window_size = Vector2(1024, 600);
 	zoomed = false;
+	resizable = false;
 
 	Vector<Logger *> loggers;
 	loggers.push_back(memnew(OSXTerminalLogger));

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -628,21 +628,7 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 				video_mode.height = window_h;
 			} else {
 				preserve_window_size = false;
-				int w = video_mode.width;
-				int h = video_mode.height;
-
-				RECT rect;
-				GetWindowRect(hWnd, &rect);
-
-				if (video_mode.borderless_window == false) {
-					RECT crect;
-					GetClientRect(hWnd, &crect);
-
-					w += (rect.right - rect.left) - (crect.right - crect.left);
-					h += (rect.bottom - rect.top) - (crect.bottom - crect.top);
-				}
-
-				MoveWindow(hWnd, rect.left, rect.top, w, h, TRUE);
+				set_window_size(Size2(video_mode.width, video_mode.height));
 			}
 			if (wParam == SIZE_MAXIMIZED) {
 				maximized = true;

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -1292,6 +1292,9 @@ void OS_X11::set_borderless_window(bool p_borderless) {
 	hints.decorations = current_videomode.borderless_window ? 0 : 1;
 	property = XInternAtom(x11_display, "_MOTIF_WM_HINTS", True);
 	XChangeProperty(x11_display, x11_window, property, property, 32, PropModeReplace, (unsigned char *)&hints, 5);
+
+	// Preserve window size
+	set_window_size(Size2(current_videomode.width, current_videomode.height));
 }
 
 bool OS_X11::get_borderless_window() {


### PR DESCRIPTION
- [x11] Preserve window size when calling this method. (Same as #19070, but only happens when resizable is true, so I only noticed now)
- [osx] Make sure it don't make the window resizable if it's not needed.
- [windows] clean up the code.