### PR TITLE
Mono: Improve 'script class not found' error

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1954,11 +1954,6 @@ Variant CSharpScript::_new(const Variant **p_args, int p_argcount, Variant::Call
 
 ScriptInstance *CSharpScript::instance_create(Object *p_this) {
 
-	if (!script_class) {
-		ERR_EXPLAIN("Cannot find class " + name + " for script " + get_path());
-		ERR_FAIL_V(NULL);
-	}
-
 	ERR_FAIL_COND_V(!valid, NULL);
 
 	if (!tool && !ScriptServer::is_scripting_enabled()) {
@@ -1971,6 +1966,18 @@ ScriptInstance *CSharpScript::instance_create(Object *p_this) {
 #else
 		return NULL;
 #endif
+	}
+	
+	if (!script_class) {
+		if (GDMono::get_singleton()->get_project_assembly() == NULL) {
+			// The project assembly is not loaded
+			ERR_EXPLAIN("Cannot instance script because the project assembly is not loaded. Script: " + get_path());
+			ERR_FAIL_V(NULL);
+		}
+		
+			// The project assembly is loaded, but the class could not found
+		ERR_EXPLAIN("Cannot instance script because the class '" + name + "' could not be found. Script: " + get_path());
+		ERR_FAIL_V(NULL);
 	}
 
 	update_signals();


### PR DESCRIPTION
No longer printed when using using placeholder script instances (for non-tool scripts in the editor).
Print different error if the project assembly is not loaded