### PR TITLE
Revert #14753, as it is buggy and no longer necessary.

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1562,7 +1562,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 		if (mb->is_pressed()) {
 
 			Size2 pos = mpos;
-			if (gui.mouse_focus && mb->get_button_index() != gui.mouse_focus_button && mb->get_button_index() == BUTTON_LEFT) {
+			if (gui.mouse_focus && mb->get_button_index() != gui.mouse_focus_button) {
 
 				//do not steal mouse focus and stuff
 


### PR DESCRIPTION
Fixes #14373, fixes #18598, fixes #17891.

Now, when a mouse button is pressed while another button has focus, focus is not stolen. This was causing an issue in freelook mode where the scroll wheel was causing focus to be lost on the Spatial editor.

I would appreciate it if this was tested heavily before merging, as I don't have any projects using the more esoteric features where this could go wrong (modals, etc.)