### PR TITLE
Increase versionCode range

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -441,7 +441,7 @@ void EditorExportPlatformAndroid::_get_property_list(List<PropertyInfo> *p_list)
 	p_list->push_back(PropertyInfo(Variant::STRING, "custom_package/debug", PROPERTY_HINT_GLOBAL_FILE, "apk"));
 	p_list->push_back(PropertyInfo(Variant::STRING, "custom_package/release", PROPERTY_HINT_GLOBAL_FILE, "apk"));
 	p_list->push_back(PropertyInfo(Variant::STRING, "command_line/extra_args"));
-	p_list->push_back(PropertyInfo(Variant::INT, "version/code", PROPERTY_HINT_RANGE, "1,65535,1"));
+	p_list->push_back(PropertyInfo(Variant::INT, "version/code", PROPERTY_HINT_RANGE, "1,2147483647,1"));
 	p_list->push_back(PropertyInfo(Variant::STRING, "version/name"));
 	p_list->push_back(PropertyInfo(Variant::STRING, "package/unique_name"));
 	p_list->push_back(PropertyInfo(Variant::STRING, "package/name"));


### PR DESCRIPTION
Version code range too small and it gets me an headache. Some build tool make it automatically and use next formula: 2.1.4 goes to 201042 where last digit used for different architectures (as you can see it bigger than 65535).
I have rewrited my app on Godot and have a big problem to increase version that I already have.