### PR TITLE
Fix unable to remove split on Polygon 2D editor after restarting editor

### DIFF
--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -563,6 +563,7 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 
 				if (uv_move_current == UV_MODE_REMOVE_SPLIT) {
 
+					splits_prev = node->get_splits();
 					for (int i = 0; i < splits_prev.size(); i += 2) {
 						if (splits_prev[i] < 0 || splits_prev[i] >= points_prev.size())
 							continue;


### PR DESCRIPTION
reproduce steps

1. create Polygon2D
2. assign texture
3. create polygon and splits on UV editor
4. restart editor
5. try to remove split on UV editor which added a previous session.