### PR TITLE
Changed "Syntax Menu" into radio Menu

### DIFF
--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -49,8 +49,8 @@ class ScriptTextEditor : public ScriptEditorBase {
 	HBoxContainer *edit_hb;
 
 	MenuButton *edit_menu;
-	MenuButton *highlighter_menu;
 	MenuButton *search_menu;
+	PopupMenu *highlighter_menu;
 	PopupMenu *context_menu;
 
 	GotoLineDialog *goto_line_dialog;


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/12082976/40563011-89aa5faa-6063-11e8-855c-aa6e62a26e63.png)
After:
![after](https://user-images.githubusercontent.com/12082976/40563578-8db76d48-6065-11e8-8a06-cd92a9a56748.jpg)

Issue:
https://github.com/godotengine/godot/issues/18779
