### PR TITLE
[WIP] Seeing if I can improve lag in mobile_vr

### DIFF
--- a/modules/mobile_vr/config.py
+++ b/modules/mobile_vr/config.py
@@ -1,6 +1,6 @@
 def can_build(env, platform):
     # should probably change this to only be true on iOS and Android
-    return False
+    return True
 
 def configure(env):
     pass

--- a/modules/mobile_vr/mobile_interface.h
+++ b/modules/mobile_vr/mobile_interface.h
@@ -49,6 +49,8 @@
 	more advanced interfaces.
 */
 
+#define MOBILEVR_AVG_FRAMES 5
+
 class MobileVRInterface : public ARVRInterface {
 	GDCLASS(MobileVRInterface, ARVRInterface);
 
@@ -57,6 +59,10 @@ private:
 	Basis orientation;
 	float eye_height;
 	uint64_t last_ticks;
+
+	Basis predicted_orientation;
+	uint64_t frame_timing[MOBILEVR_AVG_FRAMES];
+	float avg_frame_time;
 
 	LensDistortedShaderGLES3 lens_shader;
 	GLuint half_screen_quad;


### PR DESCRIPTION
My first attempt at doing some very simple predictive logic to ensure the image rendered better matches up with where the players head is at when the image becomes visible. Simply taking the average frame timing (time between process and submit) over the last 5 frames and using the last gyro reading to make a guestimate how much further the headset will have rotated by the time the rendered image is made visible.

I have not fully tested this yet because I'm currently at a place where i can't try out my headset. 