### PR TITLE
Adding version info to GDNative ARVR interfaces

### DIFF
--- a/modules/gdnative/arvr/arvr_interface_gdnative.cpp
+++ b/modules/gdnative/arvr/arvr_interface_gdnative.cpp
@@ -217,6 +217,10 @@ void ARVRInterfaceGDNative::process() {
 extern "C" {
 
 void GDAPI godot_arvr_register_interface(const godot_arvr_interface_gdnative *p_interface) {
+	// If our major version is 0 or bigger then 10, we're likely looking at our constructor pointer from an older plugin
+	ERR_EXPLAINC("GDNative ARVR interfaces build for Godot 3.0 are not supported");
+	ERR_FAIL_COND((p_interface->version.major == 0) || (p_interface->version.major > 10));
+
 	Ref<ARVRInterfaceGDNative> new_interface;
 	new_interface.instance();
 	new_interface->set_interface((godot_arvr_interface_gdnative *const)p_interface);

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -5966,7 +5966,7 @@
       "type": "ARVR",
       "version": {
         "major": 1,
-        "minor": 0
+        "minor": 1
       },
       "next": null,
       "api": [

--- a/modules/gdnative/include/arvr/godot_arvr.h
+++ b/modules/gdnative/include/arvr/godot_arvr.h
@@ -37,7 +37,15 @@
 extern "C" {
 #endif
 
+// For future versions of the API we should only add new functions at the end of the structure and use the
+// version info to detect whether a call is available
+
+// Use these to populate version in your plugin
+#define GODOTVR_API_MAJOR 1
+#define GODOTVR_API_MINOR 0
+
 typedef struct {
+	godot_gdnative_api_version version; /* version of our API */
 	void *(*constructor)(godot_object *);
 	void (*destructor)(void *);
 	godot_string (*get_name)(const void *);


### PR DESCRIPTION
I've been holding off adding new calls to the ARVR interface because we had no sure way to test if the plugin had support for any new calls. Because we hadn't added this for the 3.0 release it would always mean a breaking change.

I've added a type field and a version field at the top of the structure. The type field just makes it easier to detect when we have a pointer to an interface written for Godot 3.0 as the pointer of the constructor is unlikely to ever spell ARVR, the version will allow us to detect whether new features are supported by the plugin.

For testing and seeing what changes are required I have updated the ARVRSimple reference implementation to perform all the required version checks:
https://github.com/BastiaanOlij/ARVRSimple/pull/4