### PR TITLE
Instance scene at root node by default

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -113,7 +113,7 @@ void SceneTreeDock::instance(const String &p_file) {
 	Node *parent = scene_tree->get_selected();
 
 	if (!parent) {
-		Node *parent = edited_scene;
+		parent = edited_scene;
 	};
 
 	if (!edited_scene) {


### PR DESCRIPTION
Fix bug in cdcfb9582e6e9f18df1475619f2ebe62b7f0bdce leading to the
root node not being selected by default.

Fix #18557.