### PR TITLE
Editor autocomplete won't insert unnecessary quotes

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5535,7 +5535,17 @@ void TextEdit::_confirm_completion() {
 	cursor_set_column(cursor.column - completion_base.length(), false);
 	insert_text_at_cursor(completion_current);
 
-	if (completion_current.ends_with("(") && auto_brace_completion_enabled) {
+	// When inserted into the middle of an existing string, don't add an unnecessary quote
+	String line = text[cursor.line];
+	CharType next_char = line[cursor.column];
+	CharType last_completion_char = completion_current[completion_current.length() - 1];
+
+	if ((last_completion_char == '"' || last_completion_char == '\'') &&
+			last_completion_char == next_char) {
+		_base_remove_text(cursor.line, cursor.column, cursor.line, cursor.column + 1);
+	}
+
+	if (last_completion_char == '(' && auto_brace_completion_enabled) {
 		insert_text_at_cursor(")");
 		cursor.column--;
 	}


### PR DESCRIPTION
When autocompleting a string (e.g. emit_signal or connect), e.g.

    emit_signal('visibility_c')
                            ^

where "^" is the cursor, hitting `<tab>` would insert an unnecessary
quote, breaking the string:

    emit_signal('visibility_changed'')

This commit adds a small lookahead, so the end result will be as the
user probably expected:

    emit_signal('visibility_changed')

There's probably a more efficient way of doing this check than this PR, maybe someone more versed in the core godot library could minify it to a few simple ops.