### PR TITLE
Fix editor freezing when inserting key frames

### DIFF
--- a/editor/animation_editor.h
+++ b/editor/animation_editor.h
@@ -283,6 +283,7 @@ class AnimationKeyEditor : public VBoxContainer {
 	void _query_insert(const InsertData &p_id);
 	void _update_menu();
 	bool insert_queue;
+	void _show_insert_confirm();
 	void _insert_delay();
 	void _scale();
 


### PR DESCRIPTION
The issue was caused by the confirmation dialog for inserting new tracks
getting shown multiple times.

This is fixed by deferring the dialog until after all new tracks have
been added.

Fixes #18614 