### PR TITLE
Pause AudioStreamPlayer when SceneTree pauses

### DIFF
--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -36,11 +36,8 @@
 
 void AudioStreamPlayer2D::_mix_audio() {
 
-	if (!stream_playback.is_valid()) {
-		return;
-	}
-
-	if (!active) {
+	if (!stream_playback.is_valid() || !active ||
+			(stream_paused && stream_paused_fade <= 0.f)) {
 		return;
 	}
 
@@ -53,8 +50,10 @@ void AudioStreamPlayer2D::_mix_audio() {
 	AudioFrame *buffer = mix_buffer.ptrw();
 	int buffer_size = mix_buffer.size();
 
-	//mix
-	stream_playback->mix(buffer, pitch_scale, buffer_size);
+	// Mix if we're not paused or we're fading out
+	if (!stream_paused || stream_paused_fade > 0.f) {
+		stream_playback->mix(buffer, pitch_scale, buffer_size);
+	}
 
 	//write all outputs
 	for (int i = 0; i < output_count; i++) {
@@ -85,6 +84,13 @@ void AudioStreamPlayer2D::_mix_audio() {
 		//mix!
 		AudioFrame vol_inc = (current.vol - prev_outputs[i].vol) / float(buffer_size);
 		AudioFrame vol = current.vol;
+
+		if (stream_paused) {
+			vol = vol * stream_paused_fade;
+			if (stream_paused_fade > 0.f) {
+				stream_paused_fade -= 0.1f;
+			}
+		}
 
 		int cc = AudioServer::get_singleton()->get_channel_count();
 
@@ -140,6 +146,17 @@ void AudioStreamPlayer2D::_notification(int p_what) {
 	if (p_what == NOTIFICATION_EXIT_TREE) {
 
 		AudioServer::get_singleton()->remove_callback(_mix_audios, this);
+	}
+
+	if (p_what == NOTIFICATION_PAUSED) {
+		if (!can_process()) {
+			// Node can't process so we start fading out to silence
+			set_stream_paused(true);
+		}
+	}
+
+	if (p_what == NOTIFICATION_UNPAUSED) {
+		set_stream_paused(false);
 	}
 
 	if (p_what == NOTIFICATION_INTERNAL_PHYSICS_PROCESS) {
@@ -418,6 +435,19 @@ uint32_t AudioStreamPlayer2D::get_area_mask() const {
 	return area_mask;
 }
 
+void AudioStreamPlayer2D::set_stream_paused(bool p_pause) {
+
+	if (p_pause != stream_paused) {
+		stream_paused = p_pause;
+		stream_paused_fade = stream_paused ? 1.f : 0.f;
+	}
+}
+
+bool AudioStreamPlayer2D::get_stream_paused() const {
+
+	return stream_paused;
+}
+
 void AudioStreamPlayer2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_stream", "stream"), &AudioStreamPlayer2D::set_stream);
@@ -454,6 +484,9 @@ void AudioStreamPlayer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_area_mask", "mask"), &AudioStreamPlayer2D::set_area_mask);
 	ClassDB::bind_method(D_METHOD("get_area_mask"), &AudioStreamPlayer2D::get_area_mask);
 
+	ClassDB::bind_method(D_METHOD("set_stream_paused", "pause"), &AudioStreamPlayer2D::set_stream_paused);
+	ClassDB::bind_method(D_METHOD("get_stream_paused"), &AudioStreamPlayer2D::get_stream_paused);
+
 	ClassDB::bind_method(D_METHOD("_bus_layout_changed"), &AudioStreamPlayer2D::_bus_layout_changed);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "stream", PROPERTY_HINT_RESOURCE_TYPE, "AudioStream"), "set_stream", "get_stream");
@@ -461,6 +494,7 @@ void AudioStreamPlayer2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "pitch_scale", PROPERTY_HINT_RANGE, "0.01,32,0.01"), "set_pitch_scale", "get_pitch_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playing", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "_set_playing", "is_playing");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autoplay"), "set_autoplay", "is_autoplay_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "stream_paused", PROPERTY_HINT_NONE, ""), "set_stream_paused", "get_stream_paused");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "max_distance", PROPERTY_HINT_EXP_RANGE, "1,4096,1,or_greater"), "set_max_distance", "get_max_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "attenuation", PROPERTY_HINT_EXP_EASING, "attenuation"), "set_attenuation", "get_attenuation");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "bus", PROPERTY_HINT_ENUM, ""), "set_bus", "get_bus");
@@ -483,6 +517,8 @@ AudioStreamPlayer2D::AudioStreamPlayer2D() {
 	setplay = -1;
 	output_ready = false;
 	area_mask = 1;
+	stream_paused = false;
+	stream_paused_fade = 0.f;
 	AudioServer::get_singleton()->connect("bus_layout_changed", this, "_bus_layout_changed");
 }
 

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -71,7 +71,9 @@ private:
 
 	float volume_db;
 	float pitch_scale;
+	float stream_paused_fade;
 	bool autoplay;
+	bool stream_paused;
 	StringName bus;
 
 	void _mix_audio();
@@ -122,6 +124,9 @@ public:
 
 	void set_area_mask(uint32_t p_mask);
 	uint32_t get_area_mask() const;
+
+	void set_stream_paused(bool p_pause);
+	bool get_stream_paused() const;
 
 	AudioStreamPlayer2D();
 	~AudioStreamPlayer2D();

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -35,11 +35,8 @@
 #include "scene/main/viewport.h"
 void AudioStreamPlayer3D::_mix_audio() {
 
-	if (!stream_playback.is_valid()) {
-		return;
-	}
-
-	if (!active) {
+	if (!stream_playback.is_valid() || !active ||
+			(stream_paused && stream_paused_fade <= 0.f)) {
 		return;
 	}
 
@@ -54,8 +51,9 @@ void AudioStreamPlayer3D::_mix_audio() {
 	AudioFrame *buffer = mix_buffer.ptrw();
 	int buffer_size = mix_buffer.size();
 
-	//mix
-	if (output_count > 0 || out_of_range_mode == OUT_OF_RANGE_MIX) {
+	// Mix if we're not paused or we're fading out
+	if ((output_count > 0 || out_of_range_mode == OUT_OF_RANGE_MIX) &&
+			(!stream_paused || stream_paused_fade > 0.f)) {
 
 		float output_pitch_scale = 0.0;
 		if (output_count) {
@@ -107,6 +105,13 @@ void AudioStreamPlayer3D::_mix_audio() {
 		for (int k = 0; k < buffers; k++) {
 			AudioFrame vol_inc = (current.vol[k] - prev_outputs[i].vol[k]) / float(buffer_size);
 			AudioFrame vol = current.vol[k];
+
+			if (stream_paused) {
+				vol = vol * stream_paused_fade;
+				if (stream_paused_fade > 0.f) {
+					stream_paused_fade -= 0.1f;
+				}
+			}
 
 			AudioFrame *target = AudioServer::get_singleton()->thread_get_channel_mix_buffer(current.bus_index, k);
 
@@ -237,6 +242,18 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 
 		AudioServer::get_singleton()->remove_callback(_mix_audios, this);
 	}
+
+	if (p_what == NOTIFICATION_PAUSED) {
+		if (!can_process()) {
+			// Node can't process so we start fading out to silence
+			set_stream_paused(true);
+		}
+	}
+
+	if (p_what == NOTIFICATION_UNPAUSED) {
+		set_stream_paused(false);
+	}
+
 	if (p_what == NOTIFICATION_TRANSFORM_CHANGED) {
 
 		if (doppler_tracking != DOPPLER_TRACKING_DISABLED) {
@@ -825,6 +842,19 @@ AudioStreamPlayer3D::DopplerTracking AudioStreamPlayer3D::get_doppler_tracking()
 	return doppler_tracking;
 }
 
+void AudioStreamPlayer3D::set_stream_paused(bool p_pause) {
+
+	if (p_pause != stream_paused) {
+		stream_paused = p_pause;
+		stream_paused_fade = stream_paused ? 1.f : 0.f;
+	}
+}
+
+bool AudioStreamPlayer3D::get_stream_paused() const {
+
+	return stream_paused;
+}
+
 void AudioStreamPlayer3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_stream", "stream"), &AudioStreamPlayer3D::set_stream);
@@ -888,6 +918,9 @@ void AudioStreamPlayer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_doppler_tracking", "mode"), &AudioStreamPlayer3D::set_doppler_tracking);
 	ClassDB::bind_method(D_METHOD("get_doppler_tracking"), &AudioStreamPlayer3D::get_doppler_tracking);
 
+	ClassDB::bind_method(D_METHOD("set_stream_paused", "pause"), &AudioStreamPlayer3D::set_stream_paused);
+	ClassDB::bind_method(D_METHOD("get_stream_paused"), &AudioStreamPlayer3D::get_stream_paused);
+
 	ClassDB::bind_method(D_METHOD("_bus_layout_changed"), &AudioStreamPlayer3D::_bus_layout_changed);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "stream", PROPERTY_HINT_RESOURCE_TYPE, "AudioStream"), "set_stream", "get_stream");
@@ -898,6 +931,7 @@ void AudioStreamPlayer3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "pitch_scale", PROPERTY_HINT_RANGE, "0.01,32,0.01"), "set_pitch_scale", "get_pitch_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playing", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "_set_playing", "is_playing");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autoplay"), "set_autoplay", "is_autoplay_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "stream_paused", PROPERTY_HINT_NONE, ""), "set_stream_paused", "get_stream_paused");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "max_distance", PROPERTY_HINT_EXP_RANGE, "0,4096,1,or_greater"), "set_max_distance", "get_max_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "out_of_range_mode", PROPERTY_HINT_ENUM, "Mix,Pause"), "set_out_of_range_mode", "get_out_of_range_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "bus", PROPERTY_HINT_ENUM, ""), "set_bus", "get_bus");
@@ -949,6 +983,8 @@ AudioStreamPlayer3D::AudioStreamPlayer3D() {
 	attenuation_filter_db = -24;
 	out_of_range_mode = OUT_OF_RANGE_MIX;
 	doppler_tracking = DOPPLER_TRACKING_DISABLED;
+	stream_paused = false;
+	stream_paused_fade = 0.f;
 
 	velocity_tracker.instance();
 	AudioServer::get_singleton()->connect("bus_layout_changed", this, "_bus_layout_changed");

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -107,7 +107,9 @@ private:
 	float unit_size;
 	float max_db;
 	float pitch_scale;
+	float stream_paused_fade;
 	bool autoplay;
+	bool stream_paused;
 	StringName bus;
 
 	void _mix_audio();
@@ -198,6 +200,9 @@ public:
 
 	void set_doppler_tracking(DopplerTracking p_tracking);
 	DopplerTracking get_doppler_tracking() const;
+
+	void set_stream_paused(bool p_pause);
+	bool get_stream_paused() const;
 
 	AudioStreamPlayer3D();
 	~AudioStreamPlayer3D();

--- a/scene/audio/audio_player.h
+++ b/scene/audio/audio_player.h
@@ -56,7 +56,9 @@ private:
 	float mix_volume_db;
 	float pitch_scale;
 	float volume_db;
+	float stream_paused_fade;
 	bool autoplay;
+	bool stream_paused;
 	StringName bus;
 
 	MixTarget mix_target;
@@ -99,6 +101,9 @@ public:
 
 	void set_mix_target(MixTarget p_target);
 	MixTarget get_mix_target() const;
+
+	void set_stream_paused(bool p_pause);
+	bool get_stream_paused() const;
 
 	AudioStreamPlayer();
 	~AudioStreamPlayer();


### PR DESCRIPTION
Fixes #14009.
Also implemented the suggestion by @mrcdk and exposed the `stream_pause` state, can be toggled on scripts to pause/resume the stream.