### PR TITLE
Really, really disable pulseaudio when pulseaudio=false.

### DIFF
--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -14,7 +14,8 @@ SConscript('windows/SCsub')
 # Sounds drivers
 SConscript('alsa/SCsub')
 SConscript('coreaudio/SCsub')
-SConscript('pulseaudio/SCsub')
+if env['pulseaudio']:
+    SConscript('pulseaudio/SCsub')
 if (env["platform"] == "windows"):
     SConscript("rtaudio/SCsub")
     SConscript("wasapi/SCsub")


### PR DESCRIPTION
Without this my app would write an error to stdout. Somethin like `"Pulseaudio: Cannot connect."`