### PR TITLE
Change position of validation in set_custom_mouse_cursor

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1543,9 +1543,10 @@ void OS_OSX::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, c
 
 		ERR_FAIL_COND(!texture.is_valid());
 		ERR_FAIL_COND(texture_size.width > 256 || texture_size.height > 256);
-		ERR_FAIL_COND(!image.is_valid());
 
 		image = texture->get_data();
+
+		ERR_FAIL_COND(!image.is_valid());
 
 		NSBitmapImageRep *imgrep = [[NSBitmapImageRep alloc]
 				initWithBitmapDataPlanes:NULL

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2074,9 +2074,10 @@ void OS_Windows::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shap
 
 		ERR_FAIL_COND(!texture.is_valid());
 		ERR_FAIL_COND(texture_size.width > 256 || texture_size.height > 256);
-		ERR_FAIL_COND(!image.is_valid());
 
 		image = texture->get_data();
+
+		ERR_FAIL_COND(!image.is_valid());
 
 		UINT image_size = texture_size.width * texture_size.height;
 		UINT size = sizeof(UINT) * image_size;

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -2449,9 +2449,10 @@ void OS_X11::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, c
 
 		ERR_FAIL_COND(!texture.is_valid());
 		ERR_FAIL_COND(texture_size.width > 256 || texture_size.height > 256);
-		ERR_FAIL_COND(!image.is_valid());
 
 		image = texture->get_data();
+
+		ERR_FAIL_COND(!image.is_valid());
 
 		// Create the cursor structure
 		XcursorImage *cursor_image = XcursorImageCreate(texture_size.width, texture_size.height);


### PR DESCRIPTION
@mhilbrunner Sry, moving the validation because I placed in the wrong position in this pr #19210.

This way the validation will work for Texture and AtlasTexture.