### PR TITLE
Added Image.rotation_left/right 90 deg.

### DIFF
--- a/core/image.h
+++ b/core/image.h
@@ -108,6 +108,7 @@ public:
 		INTERPOLATE_BILINEAR,
 		INTERPOLATE_CUBIC,
 		/* INTERPOLATE GAUSS */
+		INTERPOLATE_NONE,
 	};
 
 	enum CompressSource {
@@ -213,6 +214,9 @@ public:
 
 	void flip_x();
 	void flip_y();
+
+	void rotate_right();
+	void rotate_left();
 
 	/**
 	 * Generate a mipmap to an image (creates an image 1/4 the size, with averaging of 4->1)


### PR DESCRIPTION
It will handle any Image size as square so that no informations get lost.

Examples 4 Times rotate_right then 4 times rotate_left

![peek 2018-05-29 00-24](https://user-images.githubusercontent.com/4741886/40630858-b9c2d058-62d6-11e8-9e17-aeadc27ef102.gif)

![peek 2018-05-29 00-26](https://user-images.githubusercontent.com/4741886/40630888-08ad61c4-62d7-11e8-8220-6abbcdf49fe1.gif)

![peek 2018-05-29 00-29](https://user-images.githubusercontent.com/4741886/40630922-6188e502-62d7-11e8-80b8-7578b135589e.gif)

![peek 2018-05-29 00-30](https://user-images.githubusercontent.com/4741886/40630923-63171baa-62d7-11e8-88f6-0480a9d0679d.gif)


The new version with resize

![peek 2018-05-29 23-43](https://user-images.githubusercontent.com/4741886/40688184-75943d14-639d-11e8-93dd-f2635cc9efb0.gif)
