### PR TITLE
Fix index out of size error of image.cpp

### DIFF
--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -97,6 +97,7 @@ Ref<Texture> EditorTexturePreviewPlugin::generate(const RES &p_from) {
 	if (img.is_null() || img->empty())
 		return Ref<Texture>();
 
+	img = img->duplicate();
 	img->clear_mipmaps();
 
 	int thumbnail_size = EditorSettings::get_singleton()->get("filesystem/file_dialog/thumbnail_size");


### PR DESCRIPTION
Fix #19235

https://github.com/volzhs/godot/blob/224ca96c57284ffd2a58fcc9803c8d3f1b5424f6/editor/plugins/editor_preview_plugins.cpp#L94
get `Image` ref from here, and...
https://github.com/volzhs/godot/blob/224ca96c57284ffd2a58fcc9803c8d3f1b5424f6/editor/plugins/editor_preview_plugins.cpp#L127
it resizes referenced `Image` to `filesystem/file_dialog/thumbnail_size`

so, need to duplicate `Image` for generating thumbnail for editor.