### PR TITLE
Increases settings apply speed and added deferred color setting to ColorPicker

### DIFF
--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -31,6 +31,9 @@
 		<member name="raw_mode" type="bool" setter="set_raw_mode" getter="is_raw_mode">
 			If [code]true[/code], allows the color R, G, B component values to go beyond 1.0, which can be used for certain special operations that require it (like tinting without darkening or rendering sprites in HDR).
 		</member>
+		<member name="deferred_mode" type="bool" setter="set_deferred_mode" getter="is_deferred_mode">
+			If [code]true[/code], the color will apply only after user releases mouse button, otherwise it will apply immediatly even in mouse motion event (which can cause performance issues).
+		</member>
 	</members>
 	<signals>
 		<signal name="color_changed">

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -1979,7 +1979,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	tab_container->add_child(plugin_settings);
 
 	timer = memnew(Timer);
-	timer->set_wait_time(1.5);
+	timer->set_wait_time(0.1);
 	timer->connect("timeout", ProjectSettings::get_singleton(), "save");
 	timer->set_one_shot(true);
 	add_child(timer);

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -847,6 +847,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 			if (!color_picker) {
 				//late init for performance
 				color_picker = memnew(ColorPicker);
+				color_picker->set_deferred_mode(true);
 				add_child(color_picker);
 				color_picker->hide();
 				color_picker->connect("color_changed", this, "_color_changed");

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -493,7 +493,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	//get_cancel()->set_text("Close");
 
 	timer = memnew(Timer);
-	timer->set_wait_time(1.5);
+	timer->set_wait_time(0.1);
 	timer->connect("timeout", this, "_settings_save");
 	timer->set_one_shot(true);
 	add_child(timer);

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -242,6 +242,14 @@ bool ColorPicker::is_raw_mode() const {
 	return raw_mode_enabled;
 }
 
+void ColorPicker::set_deferred_mode(bool p_enabled) {
+	deferred_mode_enabled = p_enabled;
+}
+
+bool ColorPicker::is_deferred_mode() const {
+	return deferred_mode_enabled;
+}
+
 void ColorPicker::_update_text_value() {
 	bool visible = true;
 	if (text_is_constructor) {
@@ -328,7 +336,11 @@ void ColorPicker::_uv_input(const Ref<InputEvent> &p_event) {
 			last_hsv = color;
 			set_pick_color(color);
 			_update_color();
+			if (!deferred_mode_enabled)
+				emit_signal("color_changed", color);
+		} else if (deferred_mode_enabled && !bev->is_pressed() && bev->get_button_index() == BUTTON_LEFT) {
 			emit_signal("color_changed", color);
+			changing_color = false;
 		} else {
 			changing_color = false;
 		}
@@ -347,7 +359,8 @@ void ColorPicker::_uv_input(const Ref<InputEvent> &p_event) {
 		last_hsv = color;
 		set_pick_color(color);
 		_update_color();
-		emit_signal("color_changed", color);
+		if (!deferred_mode_enabled)
+			emit_signal("color_changed", color);
 	}
 }
 
@@ -368,7 +381,10 @@ void ColorPicker::_w_input(const Ref<InputEvent> &p_event) {
 		last_hsv = color;
 		set_pick_color(color);
 		_update_color();
-		emit_signal("color_changed", color);
+		if (!deferred_mode_enabled)
+			emit_signal("color_changed", color);
+		else if (!bev->is_pressed() && bev->get_button_index() == BUTTON_LEFT)
+			emit_signal("color_changed", color);
 	}
 
 	Ref<InputEventMouseMotion> mev = p_event;
@@ -383,7 +399,8 @@ void ColorPicker::_w_input(const Ref<InputEvent> &p_event) {
 		last_hsv = color;
 		set_pick_color(color);
 		_update_color();
-		emit_signal("color_changed", color);
+		if (!deferred_mode_enabled)
+			emit_signal("color_changed", color);
 	}
 }
 
@@ -500,6 +517,8 @@ void ColorPicker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_pick_color"), &ColorPicker::get_pick_color);
 	ClassDB::bind_method(D_METHOD("set_raw_mode", "mode"), &ColorPicker::set_raw_mode);
 	ClassDB::bind_method(D_METHOD("is_raw_mode"), &ColorPicker::is_raw_mode);
+	ClassDB::bind_method(D_METHOD("set_deferred_mode", "mode"), &ColorPicker::set_deferred_mode);
+	ClassDB::bind_method(D_METHOD("is_deferred_mode"), &ColorPicker::is_deferred_mode);
 	ClassDB::bind_method(D_METHOD("set_edit_alpha", "show"), &ColorPicker::set_edit_alpha);
 	ClassDB::bind_method(D_METHOD("is_editing_alpha"), &ColorPicker::is_editing_alpha);
 	ClassDB::bind_method(D_METHOD("add_preset", "color"), &ColorPicker::add_preset);
@@ -522,6 +541,7 @@ void ColorPicker::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "set_pick_color", "get_pick_color");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "edit_alpha"), "set_edit_alpha", "is_editing_alpha");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "raw_mode"), "set_raw_mode", "is_raw_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deferred_mode"), "set_deferred_mode", "is_deferred_mode");
 
 	ADD_SIGNAL(MethodInfo("color_changed", PropertyInfo(Variant::COLOR, "color")));
 }
@@ -533,6 +553,7 @@ ColorPicker::ColorPicker() :
 	edit_alpha = true;
 	text_is_constructor = false;
 	raw_mode_enabled = false;
+	deferred_mode_enabled = false;
 	changing_color = false;
 	screen = NULL;
 

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -67,6 +67,7 @@ private:
 
 	Color color;
 	bool raw_mode_enabled;
+	bool deferred_mode_enabled;
 	bool updating;
 	bool changing_color;
 	float h, s, v;
@@ -106,6 +107,9 @@ public:
 	void add_preset(const Color &p_color);
 	void set_raw_mode(bool p_enabled);
 	bool is_raw_mode() const;
+
+	void set_deferred_mode(bool p_enabled);
+	bool is_deferred_mode() const;
 
 	void set_focus_on_line_edit();
 


### PR DESCRIPTION
The project and editor settings apply time is 1.5 second which is not huge but irritating, I decreased it to 0.1, the only problem with this approach is ColorPicker - which is extremly laggy when you drag mouse on its UV surface(in theme Color at least) because it emit signal about color changing every mouse motion event. I solved this problem by introducing new property called **deferred_mode** - this property is just a hint for ColorPicker to not send signal about color changing until user not released mouse button, it is default true for editor, but for user apps it should be false by default(for not breaking compatibility). Discuss..