### PR TITLE
Fix overwrite of file/folder of same name without warning

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1044,7 +1044,40 @@ void FileSystemDock::_duplicate_operation_confirm() {
 	_rescan();
 }
 
-void FileSystemDock::_move_operation_confirm(const String &p_to_path) {
+void FileSystemDock::_move_with_overwrite() {
+	_move_operation_confirm(to_move_path, true);
+}
+
+bool FileSystemDock::_check_existing() {
+	String &p_to_path = to_move_path;
+	for (int i = 0; i < to_move.size(); i++) {
+		String ol_pth = to_move[i].path.ends_with("/") ? to_move[i].path.substr(0, to_move[i].path.length() - 1) : to_move[i].path;
+		String p_new_path = p_to_path.plus_file(ol_pth.get_file());
+		FileOrFolder p_item = to_move[i];
+
+		String old_path = (p_item.is_file || p_item.path.ends_with("/")) ? p_item.path : (p_item.path + "/");
+		String new_path = (p_item.is_file || p_new_path.ends_with("/")) ? p_new_path : (p_new_path + "/");
+
+		if (p_item.is_file && FileAccess::exists(new_path)) {
+			return false;
+		} else if (!p_item.is_file && DirAccess::exists(new_path)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool overwrite) {
+	if (!overwrite) {
+		to_move_path = p_to_path;
+		bool can_move = _check_existing();
+		if (!can_move) {
+			//ask to do something
+			overwrite_dialog->popup_centered_minsize();
+			overwrite_dialog->grab_focus();
+			return;
+		}
+	}
 
 	Map<String, String> file_renames;
 	Map<String, String> folder_renames;
@@ -1796,6 +1829,7 @@ void FileSystemDock::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_folder_option"), &FileSystemDock::_folder_option);
 	ClassDB::bind_method(D_METHOD("_make_dir_confirm"), &FileSystemDock::_make_dir_confirm);
 	ClassDB::bind_method(D_METHOD("_move_operation_confirm"), &FileSystemDock::_move_operation_confirm);
+	ClassDB::bind_method(D_METHOD("_move_with_overwrite"), &FileSystemDock::_move_with_overwrite);
 	ClassDB::bind_method(D_METHOD("_rename_operation_confirm"), &FileSystemDock::_rename_operation_confirm);
 	ClassDB::bind_method(D_METHOD("_duplicate_operation_confirm"), &FileSystemDock::_duplicate_operation_confirm);
 
@@ -1978,6 +2012,12 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	add_child(rename_dialog);
 	rename_dialog->register_text_enter(rename_dialog_text);
 	rename_dialog->connect("confirmed", this, "_rename_operation_confirm");
+
+	overwrite_dialog = memnew(ConfirmationDialog);
+	overwrite_dialog->set_text(TTR("There is already file or folder with the same name in this location."));
+	overwrite_dialog->get_ok()->set_text(TTR("Overwrite"));
+	add_child(overwrite_dialog);
+	overwrite_dialog->connect("confirmed", this, "_move_with_overwrite");
 
 	duplicate_dialog = memnew(ConfirmationDialog);
 	VBoxContainer *duplicate_dialog_vb = memnew(VBoxContainer);

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -128,6 +128,7 @@ private:
 	LineEdit *duplicate_dialog_text;
 	ConfirmationDialog *make_dir_dialog;
 	LineEdit *make_dir_dialog_text;
+	ConfirmationDialog *overwrite_dialog;
 	ScriptCreateDialog *make_script_dialog_text;
 
 	class FileOrFolder {
@@ -145,6 +146,7 @@ private:
 	FileOrFolder to_rename;
 	FileOrFolder to_duplicate;
 	Vector<FileOrFolder> to_move;
+	String to_move_path;
 
 	Vector<String> history;
 	int history_pos;
@@ -190,7 +192,9 @@ private:
 	void _make_dir_confirm();
 	void _rename_operation_confirm();
 	void _duplicate_operation_confirm();
-	void _move_operation_confirm(const String &p_to_path);
+	void _move_with_overwrite();
+	bool _check_existing();
+	void _move_operation_confirm(const String &p_to_path, bool overwrite = false);
 
 	void _file_option(int p_option);
 	void _folder_option(int p_option);


### PR DESCRIPTION
 #18622, is the issue.

I also wanted to ask if should I change the return type of the, [_try_move_item()](https://github.com/godotengine/godot/blob/46bab3abc71156cd2da95312368f2c72abe7b151/editor/filesystem_dock.cpp#L751) to boolean.
Cause I currently don't see a way for creating a dialog box to ask to cancel operation and reverse all the previous move action of files/folders, in the current selection.

But if it's not supposed to be implemented that way then I think this commit is fine too.