### PR TITLE
Fix return type of _get() virtual method

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1677,6 +1677,7 @@ void Object::_bind_methods() {
 #ifdef TOOLS_ENABLED
 	MethodInfo miget("_get", PropertyInfo(Variant::STRING, "property"));
 	miget.return_val.name = "Variant";
+	miget.return_val.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
 	BIND_VMETHOD(miget);
 
 	MethodInfo plget("_get_property_list");


### PR DESCRIPTION
This is important when using type hints (probably affects C# as well, cc @neikeq).

I'm not sure if this breaks compatibility though.

*Bugsquad edit:* Fixes #17209.