### PR TITLE
Move NavigationMeshEditorPlugin to Recast module as should be

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -88,7 +88,6 @@
 #include "editor/plugins/mesh_editor_plugin.h"
 #include "editor/plugins/mesh_instance_editor_plugin.h"
 #include "editor/plugins/multimesh_editor_plugin.h"
-#include "editor/plugins/navigation_mesh_editor_plugin.h"
 #include "editor/plugins/navigation_polygon_editor_plugin.h"
 #include "editor/plugins/particles_2d_editor_plugin.h"
 #include "editor/plugins/particles_editor_plugin.h"
@@ -5365,7 +5364,6 @@ EditorNode::EditorNode() {
 	add_editor_plugin(memnew(TextureEditorPlugin(this)));
 	add_editor_plugin(memnew(AudioBusesEditorPlugin(audio_bus_editor)));
 	add_editor_plugin(memnew(AudioBusesEditorPlugin(audio_bus_editor)));
-	add_editor_plugin(memnew(NavigationMeshEditorPlugin(this)));
 	add_editor_plugin(memnew(SkeletonEditorPlugin(this)));
 	add_editor_plugin(memnew(PhysicalBonePlugin(this)));
 

--- a/modules/recast/SCsub
+++ b/modules/recast/SCsub
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 Import('env')
+Import('env_modules')
 
-# Not building in a separate env as core needs it
+env_recast = env_modules.Clone()
 
 # Thirdparty source files
 if env['builtin_recast']:
@@ -22,13 +23,10 @@ if env['builtin_recast']:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env.Append(CPPPATH=[thirdparty_dir, thirdparty_dir + "/Include"])
-
-    lib = env.add_library("recast_builtin", thirdparty_sources)
-    env.Append(LIBS=[lib])
+    env_recast.add_source_files(env.modules_sources, thirdparty_sources)
+    env_recast.Append(CPPPATH=[thirdparty_dir + "/Include"])
 
 # Godot source files
-env.add_source_files(env.modules_sources, "*.cpp")
-env.Append(CCFLAGS=['-DRECAST_ENABLED'])
+env_recast.add_source_files(env.modules_sources, "*.cpp")
 
 Export('env')

--- a/modules/recast/navigation_mesh_editor_plugin.cpp
+++ b/modules/recast/navigation_mesh_editor_plugin.cpp
@@ -29,12 +29,11 @@
 /*************************************************************************/
 
 #include "navigation_mesh_editor_plugin.h"
+
 #include "io/marshalls.h"
 #include "io/resource_saver.h"
 #include "scene/3d/mesh_instance.h"
 #include "scene/gui/box_container.h"
-
-#ifdef RECAST_ENABLED
 
 void NavigationMeshEditor::_node_removed(Node *p_node) {
 
@@ -162,5 +161,3 @@ NavigationMeshEditorPlugin::NavigationMeshEditorPlugin(EditorNode *p_node) {
 
 NavigationMeshEditorPlugin::~NavigationMeshEditorPlugin() {
 }
-
-#endif // RECAST_ENABLED

--- a/modules/recast/navigation_mesh_editor_plugin.h
+++ b/modules/recast/navigation_mesh_editor_plugin.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  navigation_mesh_generator.h                                          */
+/*  navigation_mesh_editor_plugin.h                                      */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,39 +28,57 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef NAVIGATION_MESH_GENERATOR_H
-#define NAVIGATION_MESH_GENERATOR_H
-
-#ifdef RECAST_ENABLED
+#ifndef NAVIGATION_MESH_GENERATOR_PLUGIN_H
+#define NAVIGATION_MESH_GENERATOR_PLUGIN_H
 
 #include "editor/editor_node.h"
-#include "editor/editor_settings.h"
+#include "editor/editor_plugin.h"
+#include "navigation_mesh_generator.h"
 
-#include "scene/3d/mesh_instance.h"
+class NavigationMeshEditor : public Control {
+	friend class NavigationMeshEditorPlugin;
 
-#include "scene/3d/navigation_mesh.h"
+	GDCLASS(NavigationMeshEditor, Control);
 
-#include "os/thread.h"
-#include "scene/resources/shape.h"
+	AcceptDialog *err_dialog;
 
-#include <Recast.h>
+	HBoxContainer *bake_hbox;
+	Button *button_bake;
+	Button *button_reset;
+	Label *bake_info;
 
-class NavigationMeshGenerator {
+	NavigationMeshInstance *node;
+
+	void _bake_pressed();
+	void _clear_pressed();
+
 protected:
-	static void _add_vertex(const Vector3 &p_vec3, Vector<float> &p_verticies);
-	static void _add_mesh(const Ref<Mesh> &p_mesh, const Transform &p_xform, Vector<float> &p_verticies, Vector<int> &p_indices);
-	static void _parse_geometry(const Transform &p_base_inverse, Node *p_node, Vector<float> &p_verticies, Vector<int> &p_indices);
-
-	static void _convert_detail_mesh_to_native_navigation_mesh(const rcPolyMeshDetail *p_detail_mesh, Ref<NavigationMesh> p_nav_mesh);
-	static void _build_recast_navigation_mesh(Ref<NavigationMesh> p_nav_mesh, EditorProgress *ep,
-			rcHeightfield *hf, rcCompactHeightfield *chf, rcContourSet *cset, rcPolyMesh *poly_mesh,
-			rcPolyMeshDetail *detail_mesh, Vector<float> &vertices, Vector<int> &indices);
+	void _node_removed(Node *p_node);
+	static void _bind_methods();
+	void _notification(int p_option);
 
 public:
-	static void bake(Ref<NavigationMesh> p_nav_mesh, Node *p_node);
-	static void clear(Ref<NavigationMesh> p_nav_mesh);
+	void edit(NavigationMeshInstance *p_nav_mesh_instance);
+	NavigationMeshEditor();
+	~NavigationMeshEditor();
 };
 
-#endif // RECAST_ENABLED
+class NavigationMeshEditorPlugin : public EditorPlugin {
 
-#endif // NAVIGATION_MESH_GENERATOR_H
+	GDCLASS(NavigationMeshEditorPlugin, EditorPlugin);
+
+	NavigationMeshEditor *navigation_mesh_editor;
+	EditorNode *editor;
+
+public:
+	virtual String get_name() const { return "NavigationMesh"; }
+	bool has_main_screen() const { return false; }
+	virtual void edit(Object *p_object);
+	virtual bool handles(Object *p_object) const;
+	virtual void make_visible(bool p_visible);
+
+	NavigationMeshEditorPlugin(EditorNode *p_node);
+	~NavigationMeshEditorPlugin();
+};
+
+#endif // NAVIGATION_MESH_GENERATOR_PLUGIN_H

--- a/modules/recast/navigation_mesh_generator.cpp
+++ b/modules/recast/navigation_mesh_generator.cpp
@@ -30,8 +30,6 @@
 
 #include "navigation_mesh_generator.h"
 
-#ifdef RECAST_ENABLED
-
 void NavigationMeshGenerator::_add_vertex(const Vector3 &p_vec3, Vector<float> &p_verticies) {
 	p_verticies.push_back(p_vec3.x);
 	p_verticies.push_back(p_vec3.y);
@@ -304,5 +302,3 @@ void NavigationMeshGenerator::clear(Ref<NavigationMesh> p_nav_mesh) {
 		p_nav_mesh->set_vertices(PoolVector<Vector3>());
 	}
 }
-
-#endif //RECAST_ENABLED

--- a/modules/recast/navigation_mesh_generator.h
+++ b/modules/recast/navigation_mesh_generator.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  navigation_mesh_editor_plugin.h                                      */
+/*  navigation_mesh_generator.h                                          */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,60 +28,32 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef NAVIGATION_MESH_GENERATOR_PLUGIN_H
-#define NAVIGATION_MESH_GENERATOR_PLUGIN_H
-
-#ifdef RECAST_ENABLED
+#ifndef NAVIGATION_MESH_GENERATOR_H
+#define NAVIGATION_MESH_GENERATOR_H
 
 #include "editor/editor_node.h"
-#include "editor/editor_plugin.h"
-#include "navigation_mesh_generator.h"
+#include "editor/editor_settings.h"
+#include "os/thread.h"
+#include "scene/3d/mesh_instance.h"
+#include "scene/3d/navigation_mesh.h"
+#include "scene/resources/shape.h"
 
-class NavigationMeshEditor : public Control {
-	friend class NavigationMeshEditorPlugin;
+#include <Recast.h>
 
-	GDCLASS(NavigationMeshEditor, Control);
-
-	AcceptDialog *err_dialog;
-
-	HBoxContainer *bake_hbox;
-	Button *button_bake;
-	Button *button_reset;
-	Label *bake_info;
-
-	NavigationMeshInstance *node;
-
-	void _bake_pressed();
-	void _clear_pressed();
-
+class NavigationMeshGenerator {
 protected:
-	void _node_removed(Node *p_node);
-	static void _bind_methods();
-	void _notification(int p_option);
+	static void _add_vertex(const Vector3 &p_vec3, Vector<float> &p_verticies);
+	static void _add_mesh(const Ref<Mesh> &p_mesh, const Transform &p_xform, Vector<float> &p_verticies, Vector<int> &p_indices);
+	static void _parse_geometry(const Transform &p_base_inverse, Node *p_node, Vector<float> &p_verticies, Vector<int> &p_indices);
+
+	static void _convert_detail_mesh_to_native_navigation_mesh(const rcPolyMeshDetail *p_detail_mesh, Ref<NavigationMesh> p_nav_mesh);
+	static void _build_recast_navigation_mesh(Ref<NavigationMesh> p_nav_mesh, EditorProgress *ep,
+			rcHeightfield *hf, rcCompactHeightfield *chf, rcContourSet *cset, rcPolyMesh *poly_mesh,
+			rcPolyMeshDetail *detail_mesh, Vector<float> &vertices, Vector<int> &indices);
 
 public:
-	void edit(NavigationMeshInstance *p_nav_mesh_instance);
-	NavigationMeshEditor();
-	~NavigationMeshEditor();
+	static void bake(Ref<NavigationMesh> p_nav_mesh, Node *p_node);
+	static void clear(Ref<NavigationMesh> p_nav_mesh);
 };
 
-class NavigationMeshEditorPlugin : public EditorPlugin {
-
-	GDCLASS(NavigationMeshEditorPlugin, EditorPlugin);
-
-	NavigationMeshEditor *navigation_mesh_editor;
-	EditorNode *editor;
-
-public:
-	virtual String get_name() const { return "NavigationMesh"; }
-	bool has_main_screen() const { return false; }
-	virtual void edit(Object *p_object);
-	virtual bool handles(Object *p_object) const;
-	virtual void make_visible(bool p_visible);
-
-	NavigationMeshEditorPlugin(EditorNode *p_node);
-	~NavigationMeshEditorPlugin();
-};
-
-#endif // RECAST_ENABLED
-#endif // NAVIGATION_MESH_GENERATOR_PLUGIN_H
+#endif // NAVIGATION_MESH_GENERATOR_H

--- a/modules/recast/register_types.cpp
+++ b/modules/recast/register_types.cpp
@@ -30,5 +30,10 @@
 
 #include "register_types.h"
 
-void register_recast_types() {}
+#include "navigation_mesh_editor_plugin.h"
+
+void register_recast_types() {
+	EditorPlugins::add_by_type<NavigationMeshEditorPlugin>();
+}
+
 void unregister_recast_types() {}


### PR DESCRIPTION
Modules can register their own editor plugins (like GridMap does), so there is no need to put module-specific classes in the `editor/` folder.

Also cleans up the previous SCons env pollution from the Recast module, integrating its code into libmodules as other modules.

@SaracenOne I guess you based your initial `SCsub` on the `freetype` one, but it's a bad example as FreeType is needed by the core stuff, while recast is only needed for the editor and can be registered in its `register_types.cpp` file as other modules do. As such it can be built isolated in its own environment without impacting the rest of the build.

This needs testing to make sure it still works as it used to before merging, I've just tested the build so far.