### PR TITLE
SCons: Remove extraneous lib for SVG module

### DIFF
--- a/modules/svg/SCsub
+++ b/modules/svg/SCsub
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 Import('env')
-from compat import isbasestring
 
 # Thirdparty source files
 thirdparty_dir = "#thirdparty/nanosvg/"
@@ -10,23 +9,7 @@ thirdparty_sources = [
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-# env.add_source_files(env.modules_sources, thirdparty_sources)
-
-lib = env.add_library("svg_builtin", thirdparty_sources)
-
-# Needs to be appended to arrive after libscene in the linker call,
-# but we don't want it to arrive *after* system libs, so manual hack
-# LIBS contains first SCons Library objects ("SCons.Node.FS.File object")
-# and then plain strings for system library. We insert between the two.
-inserted = False
-for idx, linklib in enumerate(env["LIBS"]):
-    if isbasestring(linklib): # first system lib such as "X11", otherwise SCons lib object
-        env["LIBS"].insert(idx, lib)
-        inserted = True
-        break
-if not inserted:
-    env.Append(LIBS=[lib])
-
+env.add_source_files(env.modules_sources, thirdparty_sources)
 env.Append(CPPPATH=[thirdparty_dir])
 env.Append(CCFLAGS=["-DSVG_ENABLED"])
 


### PR DESCRIPTION
It was likely copy pasted by mistake from the freetype module, which is more complex due to its usage in the core of the engine.
The SVG module does not seem to need any special treatment, apart from linking in the main env so that editor can access it.

CC @djrm in case I missed the reason why it would need this custom lib.