### PR TITLE
SCons: Pass env to modules can_build method

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -396,7 +396,17 @@ if selected_platform in platform_list:
         sys.path.append(tmppath)
         env.current_module = x
         import config
-        if (config.can_build(selected_platform)):
+        # can_build changed number of arguments between 3.0 (1) and 3.1 (2),
+        # so try both to preserve compatibility for 3.0 modules
+        can_build = False
+        try:
+            can_build = config.can_build(env, selected_platform)
+        except TypeError:
+            print("Warning: module '%s' uses a deprecated `can_build` "
+                  "signature in its config.py file, it should be "
+                  "`can_build(env, platform)`." % x)
+            can_build = config.can_build(selected_platform)
+        if (can_build):
             config.configure(env)
             env.module_list.append(x)
             try:

--- a/modules/bmp/config.py
+++ b/modules/bmp/config.py
@@ -1,7 +1,5 @@
-
-def can_build(platform):
+def can_build(env, platform):
     return True
-
 
 def configure(env):
     pass

--- a/modules/bullet/config.py
+++ b/modules/bullet/config.py
@@ -1,4 +1,4 @@
-def can_build(platform):
+def can_build(env, platform):
     return True
 
 def configure(env):

--- a/modules/csg/config.py
+++ b/modules/csg/config.py
@@ -1,4 +1,4 @@
-def can_build(platform):
+def can_build(env, platform):
     return True
 
 def configure(env):

--- a/modules/dds/config.py
+++ b/modules/dds/config.py
@@ -1,4 +1,4 @@
-def can_build(platform):
+def can_build(env, platform):
     return True
 
 def configure(env):

--- a/modules/enet/config.py
+++ b/modules/enet/config.py
@@ -1,4 +1,4 @@
-def can_build(platform):
+def can_build(env, platform):
     return True
 
 def configure(env):

--- a/modules/etc/config.py
+++ b/modules/etc/config.py
@@ -1,9 +1,5 @@
-def can_build(platform):
-    return True
+def can_build(env, platform):
+    return env['tools']
 
 def configure(env):
-    # Tools only, disabled for non-tools
-    # TODO: Find a cleaner way to achieve that
-    if not env['tools']:
-        env['module_etc_enabled'] = False
-        env.disabled_modules.append("etc")
+    pass

--- a/modules/freetype/config.py
+++ b/modules/freetype/config.py
@@ -1,4 +1,4 @@
-def can_build(platform):
+def can_build(env, platform):
     return True
 
 def configure(env):

--- a/modules/gdnative/config.py
+++ b/modules/gdnative/config.py
@@ -1,4 +1,4 @@
-def can_build(platform):
+def can_build(env, platform):
     return True
 
 def configure(env):

--- a/modules/gdscript/config.py
+++ b/modules/gdscript/config.py
@@ -1,4 +1,4 @@
-def can_build(platform):
+def can_build(env, platform):
     return True
 
 def configure(env):

--- a/modules/gridmap/config.py
+++ b/modules/gridmap/config.py
@@ -1,4 +1,4 @@
-def can_build(platform):
+def can_build(env, platform):
     return True
 
 def configure(env):

--- a/modules/hdr/config.py
+++ b/modules/hdr/config.py
@@ -1,4 +1,4 @@
-def can_build(platform):
+def can_build(env, platform):
     return True
 
 def configure(env):

--- a/modules/jpg/config.py
+++ b/modules/jpg/config.py
@@ -1,4 +1,4 @@
-def can_build(platform):
+def can_build(env, platform):
     return True
 
 def configure(env):

--- a/modules/mbedtls/config.py
+++ b/modules/mbedtls/config.py
@@ -1,4 +1,4 @@
-def can_build(platform):
+def can_build(env, platform):
     return True
 
 def configure(env):

--- a/modules/mobile_vr/config.py
+++ b/modules/mobile_vr/config.py
@@ -1,4 +1,4 @@
-def can_build(platform):
+def can_build(env, platform):
     # should probably change this to only be true on iOS and Android
     return False
 

--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -19,7 +19,7 @@ def find_file_in_dir(directory, files, prefix='', extension=''):
     return ''
 
 
-def can_build(platform):
+def can_build(env, platform):
     if platform in ["javascript"]:
         return False # Not yet supported
     return True

--- a/modules/ogg/config.py
+++ b/modules/ogg/config.py
@@ -1,4 +1,4 @@
-def can_build(platform):
+def can_build(env, platform):
     return True
 
 def configure(env):

--- a/modules/opus/config.py
+++ b/modules/opus/config.py
@@ -1,4 +1,4 @@
-def can_build(platform):
+def can_build(env, platform):
     return True
 
 def configure(env):

--- a/modules/pvr/config.py
+++ b/modules/pvr/config.py
@@ -1,4 +1,4 @@
-def can_build(platform):
+def can_build(env, platform):
     return True
 
 def configure(env):

--- a/modules/recast/config.py
+++ b/modules/recast/config.py
@@ -1,5 +1,5 @@
-def can_build(platform):
-    return platform != "android"
+def can_build(env, platform):
+    return env['tools']
 
 def configure(env):
     pass

--- a/modules/regex/config.py
+++ b/modules/regex/config.py
@@ -1,4 +1,4 @@
-def can_build(platform):
+def can_build(env, platform):
     return True
 
 def configure(env):

--- a/modules/squish/config.py
+++ b/modules/squish/config.py
@@ -1,9 +1,5 @@
-def can_build(platform):
-    return True
+def can_build(env, platform):
+    return env['tools']
 
 def configure(env):
-    # Tools only, disabled for non-tools
-    # TODO: Find a cleaner way to achieve that
-    if not env['tools']:
-        env['module_squish_enabled'] = False
-        env.disabled_modules.append("squish")
+    pass

--- a/modules/stb_vorbis/config.py
+++ b/modules/stb_vorbis/config.py
@@ -1,4 +1,4 @@
-def can_build(platform):
+def can_build(env, platform):
     return True
 
 def configure(env):

--- a/modules/svg/config.py
+++ b/modules/svg/config.py
@@ -1,4 +1,4 @@
-def can_build(platform):
+def can_build(env, platform):
     return True
 
 def configure(env):

--- a/modules/tga/config.py
+++ b/modules/tga/config.py
@@ -1,4 +1,4 @@
-def can_build(platform):
+def can_build(env, platform):
     return True
 
 def configure(env):

--- a/modules/thekla_unwrap/config.py
+++ b/modules/thekla_unwrap/config.py
@@ -1,7 +1,5 @@
-def can_build(platform):
-    return platform != "android" and platform != "ios"
+def can_build(env, platform):
+    return (env['tools'] and platform not in ["android", "ios"])
 
 def configure(env):
-    if not env['tools']:
-        env['builtin_thekla_atlas'] = False
-        env.disabled_modules.append("thekla_unwrap")
+    pass

--- a/modules/theora/config.py
+++ b/modules/theora/config.py
@@ -1,4 +1,4 @@
-def can_build(platform):
+def can_build(env, platform):
     return True
 
 def configure(env):

--- a/modules/tinyexr/config.py
+++ b/modules/tinyexr/config.py
@@ -1,9 +1,5 @@
-def can_build(platform):
-    return True
+def can_build(env, platform):
+    return env['tools']
 
 def configure(env):
-    # Tools only, disabled for non-tools
-    # TODO: Find a cleaner way to achieve that
-    if not env['tools']:
-        env['module_tinyexr_enabled'] = False
-        env.disabled_modules.append("tinyexr")
+    pass

--- a/modules/visual_script/config.py
+++ b/modules/visual_script/config.py
@@ -1,4 +1,4 @@
-def can_build(platform):
+def can_build(env, platform):
     return True
 
 def configure(env):

--- a/modules/vorbis/config.py
+++ b/modules/vorbis/config.py
@@ -1,4 +1,4 @@
-def can_build(platform):
+def can_build(env, platform):
     return True
 
 def configure(env):

--- a/modules/webm/config.py
+++ b/modules/webm/config.py
@@ -1,5 +1,5 @@
-def can_build(platform):
-    return platform != 'iphone'
+def can_build(env, platform):
+    return platform not in ['iphone']
 
 def configure(env):
     pass

--- a/modules/webp/config.py
+++ b/modules/webp/config.py
@@ -1,4 +1,4 @@
-def can_build(platform):
+def can_build(env, platform):
     return True
 
 def configure(env):

--- a/modules/websocket/config.py
+++ b/modules/websocket/config.py
@@ -1,7 +1,5 @@
-
-def can_build(platform):
+def can_build(env, platform):
     return True
-
 
 def configure(env):
     pass


### PR DESCRIPTION
This allows to disable modules based on the environment, in particular `env[tools]` which tells us if we are building the editor or not.

I've added some `try... except` logic to `SConstruct` to preserve compatibility with existing 3.0 modules.