### PR TITLE
Add snapping support for Camera2D

### DIFF
--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -133,6 +133,15 @@
 		<member name="smoothing_speed" type="float" setter="set_follow_smoothing" getter="get_follow_smoothing">
 			Speed in pixels per second of the camera's smoothing effect when [member smoothing_enabled] is [code]true[/code]
 		</member>
+		<member name="snapping_value" type="Vector2" setter="set_snapping_value" getter="get_snapping_value">
+			The camera's snapping, useful for restricting camera's position to a grid, suitable for tile-based games.
+		</member>
+		<member name="snapping_enabled" type="bool" setter="set_snapping_enabled" getter="is_snapping_enabled">
+			If [code]true[/code] the camera's position is snapped to a grid. If [member smoothing_enabled] is [code]true[/code], this creates smooth transitions between grid cells. Default value: [code]false[/code]
+		</member>
+		<member name="snapping_offset" type="Vector2" setter="set_snapping_offset" getter="get_snapping_offset">
+			The camera's snapping offset used for shifting the snapping grid. Each component's value can range from -0.5 to 0.5. Default value: [code]Vector(0, 0)[/code].
+		</member>
 		<member name="zoom" type="Vector2" setter="set_zoom" getter="get_zoom">
 			The camera's zoom relative to the viewport. Values larger than [code]Vector2(1, 1)[/code] zoom out and smaller values zoom in. For an example, use [code]Vector2(0.5, 0.5)[/code] for a 2x zoom in, and [code]Vector2(4, 4)[/code] for a 4x zoom out.
 		</member>

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -141,6 +141,14 @@ Transform2D Camera2D::get_camera_transform() {
 				camera_pos.y -= screen_rect.position.y - limit[MARGIN_TOP];
 		}
 
+		if (snapping_enabled && !Engine::get_singleton()->is_editor_hint()) {
+
+			real_t x = Math::floor(camera_pos.x / snapping.x + snapping_offset.x) * snapping.x;
+			real_t y = Math::floor(camera_pos.y / snapping.y + snapping_offset.y) * snapping.y;
+
+			camera_pos = Vector2(x, y);
+		}
+
 		if (smoothing_enabled && !Engine::get_singleton()->is_editor_hint()) {
 
 			float c = smoothing * get_process_delta_time();
@@ -513,6 +521,46 @@ float Camera2D::get_follow_smoothing() const {
 	return smoothing;
 }
 
+void Camera2D::set_snapping_enabled(bool p_enabled) {
+
+	snapping_enabled = p_enabled;
+}
+
+bool Camera2D::is_snapping_enabled() const {
+
+	return snapping_enabled;
+}
+
+void Camera2D::set_snapping_offset(const Vector2 &p_snapping_offset) {
+
+	real_t x = CLAMP(p_snapping_offset.x, -0.5, 0.5);
+	real_t y = CLAMP(p_snapping_offset.y, -0.5, 0.5);
+
+	snapping_offset = Vector2(x, y);
+}
+
+Vector2 Camera2D::get_snapping_offset() const {
+
+	return snapping_offset;
+}
+
+void Camera2D::set_snapping_value(const Vector2 &p_snapping) {
+
+	snapping = p_snapping;
+
+	if (snapping.x <= 0.0) {
+		snapping.x = 0.01;
+	}
+	if (snapping.y <= 0.0) {
+		snapping.y = 0.01;
+	}
+}
+
+Vector2 Camera2D::get_snapping_value() const {
+
+	return snapping;
+}
+
 Point2 Camera2D::get_camera_screen_center() const {
 
 	return camera_screen_center;
@@ -695,6 +743,15 @@ void Camera2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_enable_follow_smoothing", "follow_smoothing"), &Camera2D::set_enable_follow_smoothing);
 	ClassDB::bind_method(D_METHOD("is_follow_smoothing_enabled"), &Camera2D::is_follow_smoothing_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_snapping_enabled", "enabled"), &Camera2D::set_snapping_enabled);
+	ClassDB::bind_method(D_METHOD("is_snapping_enabled"), &Camera2D::is_snapping_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_snapping_offset", "offset"), &Camera2D::set_snapping_offset);
+	ClassDB::bind_method(D_METHOD("get_snapping_offset"), &Camera2D::get_snapping_offset);
+
+	ClassDB::bind_method(D_METHOD("set_snapping_value", "value"), &Camera2D::set_snapping_value);
+	ClassDB::bind_method(D_METHOD("get_snapping_value"), &Camera2D::get_snapping_value);
+
 	ClassDB::bind_method(D_METHOD("force_update_scroll"), &Camera2D::force_update_scroll);
 	ClassDB::bind_method(D_METHOD("reset_smoothing"), &Camera2D::reset_smoothing);
 	ClassDB::bind_method(D_METHOD("align"), &Camera2D::align);
@@ -731,6 +788,11 @@ void Camera2D::_bind_methods() {
 	ADD_GROUP("Smoothing", "smoothing_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "smoothing_enabled"), "set_enable_follow_smoothing", "is_follow_smoothing_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "smoothing_speed"), "set_follow_smoothing", "get_follow_smoothing");
+
+	ADD_GROUP("Snapping", "snapping_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "snapping_enabled"), "set_snapping_enabled", "is_snapping_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "snapping_offset", PROPERTY_HINT_RANGE, "-0.5,0.5,0.01"), "set_snapping_offset", "get_snapping_offset");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "snapping_value"), "set_snapping_value", "get_snapping_value");
 
 	ADD_GROUP("Offset", "offset_");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "offset_v", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_v_offset", "get_v_offset");
@@ -774,6 +836,10 @@ Camera2D::Camera2D() {
 
 	smoothing = 5.0;
 	zoom = Vector2(1, 1);
+
+	snapping_enabled = false;
+	snapping = Vector2();
+	snapping_offset = Vector2();
 
 	screen_drawing_enabled = true;
 	limit_drawing_enabled = false;

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -56,17 +56,25 @@ protected:
 	StringName group_name;
 	StringName canvas_group_name;
 	RID canvas;
+
 	Vector2 offset;
 	Vector2 zoom;
+
+	bool snapping_enabled;
+	Vector2 snapping;
+	Vector2 snapping_offset;
+
 	AnchorMode anchor_mode;
 	bool rotating;
 	bool current;
+
 	float smoothing;
 	bool smoothing_enabled;
+
 	int limit[4];
 	bool limit_smoothing_enabled;
-	float drag_margin[4];
 
+	float drag_margin[4];
 	bool h_drag_enabled;
 	bool v_drag_enabled;
 	float h_ofs;
@@ -125,6 +133,15 @@ public:
 
 	void set_follow_smoothing(float p_speed);
 	float get_follow_smoothing() const;
+
+	void set_snapping_enabled(bool p_enabled);
+	bool is_snapping_enabled() const;
+
+	void set_snapping_offset(const Vector2 &p_snapping_offset);
+	Vector2 get_snapping_offset() const;
+
+	void set_snapping_value(const Vector2 &p_snapping);
+	Vector2 get_snapping_value() const;
 
 	void make_current();
 	void clear_current();


### PR DESCRIPTION
This allows to snap camera's position transform to a grid, will be useful for tile-map based games.
When combined with smoothing, this creates cool transitions between grid cells.

This is not limited to grid snapping and can also be used to snap to a particular slice using either horizontal or vertical snapping (separate sky and land for instance).

The snapping offset property could be used to dynamically shift the snapping grid, making it easy to adapt to whatever "tile origin" you use in your game (top-left origin, centered, half-centered, 1/4 centered etc).

Refer to this [video](https://www.youtube.com/watch?v=CqU6w164AbU) by @NathanLovato (GDQuest).

This definitely needs review and testing considering that this my first attempt at modifying somewhat significant portion of the codebase. If this feature is too specific to be added to the core, I hope it'll be useful for creating more sophisticated camera system.
