### PR TITLE
Add cli paramerter --check-only for script parsing

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -263,6 +263,7 @@ void Main::print_help(const char *p_binary) {
 
 	OS::get_singleton()->print("Standalone tools:\n");
 	OS::get_singleton()->print("  -s, --script <script>            Run a script.\n");
+	OS::get_singleton()->print("  --check-only                     Only parse for errors and quit (use with --script).\n");
 #ifdef TOOLS_ENABLED
 	OS::get_singleton()->print("  --export <target>                Export the project using the given export target. Export only main pack if path ends with .pck or .zip'.\n");
 	OS::get_singleton()->print("  --export-debug <target>          Like --export, but use debug template.\n");
@@ -1239,6 +1240,7 @@ bool Main::start() {
 	String test;
 	String _export_preset;
 	bool export_debug = false;
+	bool check_only = false;
 
 	main_timer_sync.init(OS::get_singleton()->get_ticks_usec());
 
@@ -1261,6 +1263,8 @@ bool Main::start() {
 			bool parsed_pair = true;
 			if (args[i] == "-s" || args[i] == "--script") {
 				script = args[i + 1];
+			} else if (args[i] == "--check-only") {
+				check_only = true;
 			} else if (args[i] == "--test") {
 				test = args[i + 1];
 #ifdef TOOLS_ENABLED
@@ -1382,6 +1386,10 @@ bool Main::start() {
 		Ref<Script> script_res = ResourceLoader::load(script);
 		ERR_EXPLAIN("Can't load script: " + script);
 		ERR_FAIL_COND_V(script_res.is_null(), false);
+
+		if (check_only) {
+			return false;
+		}
 
 		if (script_res->can_instance() /*&& script_res->inherits_from("SceneTreeScripted")*/) {
 


### PR DESCRIPTION
This allows basic error checking for GDScript files to be used in Continuous Integration and/or in external editors. For example, the following errorformat can be used in vim to get an error parsed: '%E%.%#SCRIPT\ ERROR:\ GDScript::reload:\ %.%#1m%m,%Z%>%.%#res://%f:%l%.%#'

Actually I was thinking about creating a basic toolchain for GDScript, which would simply be a set of CLI tools around the gdscript module. Besides error checking, code completion and symbol/doc lookup could be provided. This is also an alternative solution to the proposed server in #2245 

I haven't found time yet and would be happy hearing your thoughts on this. Is there any interest in this?