### PR TITLE
Added autotile override

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.h
+++ b/editor/plugins/tile_map_editor_plugin.h
@@ -35,6 +35,7 @@
 #include "editor/editor_plugin.h"
 
 #include "scene/2d/tile_map.h"
+#include "scene/gui/check_box.h"
 #include "scene/gui/label.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/menu_button.h"
@@ -77,6 +78,8 @@ class TileMapEditor : public VBoxContainer {
 	};
 
 	TileMap *node;
+	bool manual_autotile;
+	Vector2 manual_position;
 
 	EditorNode *editor;
 	UndoRedo *undo_redo;
@@ -85,6 +88,7 @@ class TileMapEditor : public VBoxContainer {
 	LineEdit *search_box;
 	HSlider *size_slider;
 	ItemList *palette;
+	ItemList *manual_palette;
 
 	HBoxContainer *toolbar;
 
@@ -97,6 +101,7 @@ class TileMapEditor : public VBoxContainer {
 	ToolButton *rotate_90;
 	ToolButton *rotate_180;
 	ToolButton *rotate_270;
+	CheckBox *manual_button;
 
 	Tool tool;
 
@@ -168,11 +173,13 @@ class TileMapEditor : public VBoxContainer {
 	int get_selected_tile() const;
 	void set_selected_tile(int p_tile);
 
+	void _manual_toggled(bool p_enabled);
 	void _text_entered(const String &p_text);
 	void _text_changed(const String &p_text);
 	void _sbox_input(const Ref<InputEvent> &p_ie);
 	void _update_palette();
 	void _menu_option(int p_option);
+	void _palette_selected(int index);
 
 	void _set_cell(const Point2i &p_pos, int p_value, bool p_flip_h = false, bool p_flip_v = false, bool p_transpose = false);
 

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -977,6 +977,14 @@ void TileMap::set_cell_autotile_coord(int p_x, int p_y, const Vector2 &p_coord) 
 	c.autotile_coord_x = p_coord.x;
 	c.autotile_coord_y = p_coord.y;
 	tile_map[pk] = c;
+
+	PosKey qk(p_x / _get_quadrant_size(), p_y / _get_quadrant_size());
+	Map<PosKey, Quadrant>::Element *Q = quadrant_map.find(qk);
+
+	if (!Q)
+		return;
+
+	_make_quadrant_dirty(Q);
 }
 
 Vector2 TileMap::get_cell_autotile_coord(int p_x, int p_y) const {


### PR DESCRIPTION
This pull request implements the feature discussed in #19295.

A new checkbox is added to the tilemap editor that allows for overriding Godot's autotiling. This is useful if specific details are required for specific positions in a tilemap, like so:
![screenshot_2018-05-31_16-51-22-v2](https://user-images.githubusercontent.com/1700153/40807898-936153c0-64f3-11e8-8832-6146b62723f4.png)

The intended workflow from this is the creation of general shapes using autotiling, then adding specific details without autotiling later.

The new GUI looks like this in the editor:
![autotiling enabled](https://user-images.githubusercontent.com/1700153/40865581-f8b3669a-65c6-11e8-8ca7-409ad39a123c.png)

With the "Disable Autotile" switch enabled, the GUI changes to this:
![autotiling disabled with auto selected](https://user-images.githubusercontent.com/1700153/40865595-08c82b42-65c7-11e8-9357-ec9442d93db3.png)
This portion added to the bottom is to allow for specific potions of an autotile to be placed.

A basic non-autotiling tile can also be selected and autotiling will not be triggered on nearby tiles (the autotile select will not show for non-autotiling tiles):
![autotiling disabled with simple selected](https://user-images.githubusercontent.com/1700153/40865619-3cfce740-65c7-11e8-9b1a-ab731a7bdc74.png)

Placing any tile with autotiling disabled will not affect any adjacent tiles whatsoever, even if those tiles are autotiling.

Please let me know if there's anything I need to change. I'm new to contributing to open source projects, so I'm open to criticism and suggestions! :)