### PR TITLE
Adjusted Control.set_size so that it can respect anchors

### DIFF
--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -160,6 +160,8 @@ private:
 		GrowDirection h_grow;
 		GrowDirection v_grow;
 
+		bool use_new_resize;
+
 		float rotation;
 		Vector2 scale;
 		Vector2 pivot_offset;
@@ -476,6 +478,9 @@ public:
 
 	void set_clip_contents(bool p_clip);
 	bool is_clipping_contents();
+
+	void set_use_new_resize(bool p_new_resize);
+	bool get_use_new_resize();
 
 	void set_block_minimum_size_adjust(bool p_block);
 	bool is_minimum_size_adjust_blocked() const;


### PR DESCRIPTION
This is an experimental example for making `Control.set_size` respect the control's anchors. I added a `use_new_resize` property to enable/disable the new behavior for testing.

I think it is pretty nice and makes the anchors more powerful and useful, allowing to save time during ui design in the editor and convenience when controls need to be dynamically resized at runtime. However the ui behavior for dragging to resize might need to be adjusted.

Implements idea in #19329