### PR TITLE
Fixes popup_centered_* methods, dialogs with wrong sizes and visual script editor

### DIFF
--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -188,6 +188,7 @@ EditorAbout::EditorAbout() {
 	tpl_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	tpl_label->set_autowrap(true);
 	tpl_label->set_text(TTR("Godot Engine relies on a number of thirdparty free and open source libraries, all compatible with the terms of its MIT license. The following is an exhaustive list of all such thirdparty components with their respective copyright statements and license terms."));
+	tpl_label->set_size(Size2(630, 1) * EDSCALE);
 	license_thirdparty->add_child(tpl_label);
 
 	HSplitContainer *tpl_hbc = memnew(HSplitContainer);

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -234,6 +234,7 @@ void EditorAssetLibraryItemDescription::_preview_click(int p_id) {
 			if (!preview_images[i].is_video) {
 				if (preview_images[i].image.is_valid()) {
 					preview->set_texture(preview_images[i].image);
+					minimum_size_changed();
 				}
 			} else {
 				_link_click(preview_images[i].video_link);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1406,15 +1406,18 @@ void ScriptEditor::_update_members_overview_visibility() {
 	if (!se) {
 		members_overview_alphabeta_sort_button->set_visible(false);
 		members_overview->set_visible(false);
+		overview_vbox->set_visible(false);
 		return;
 	}
 
 	if (members_overview_enabled && se->show_members_overview()) {
 		members_overview_alphabeta_sort_button->set_visible(true);
 		members_overview->set_visible(true);
+		overview_vbox->set_visible(true);
 	} else {
 		members_overview_alphabeta_sort_button->set_visible(false);
 		members_overview->set_visible(false);
+		overview_vbox->set_visible(false);
 	}
 }
 
@@ -1465,9 +1468,11 @@ void ScriptEditor::_update_help_overview_visibility() {
 	if (help_overview_enabled) {
 		members_overview_alphabeta_sort_button->set_visible(false);
 		help_overview->set_visible(true);
+		overview_vbox->set_visible(true);
 		filename->set_text(se->get_name());
 	} else {
 		help_overview->set_visible(false);
+		overview_vbox->set_visible(false);
 	}
 }
 
@@ -2679,19 +2684,19 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	add_child(context_menu);
 	context_menu->connect("id_pressed", this, "_menu_option");
 
-	members_overview_vbox = memnew(VBoxContainer);
-	members_overview_vbox->set_custom_minimum_size(Size2(0, 90));
-	members_overview_vbox->set_v_size_flags(SIZE_EXPAND_FILL);
+	overview_vbox = memnew(VBoxContainer);
+	overview_vbox->set_custom_minimum_size(Size2(0, 90));
+	overview_vbox->set_v_size_flags(SIZE_EXPAND_FILL);
 
-	list_split->add_child(members_overview_vbox);
-	members_overview_buttons_hbox = memnew(HBoxContainer);
-	members_overview_vbox->add_child(members_overview_buttons_hbox);
+	list_split->add_child(overview_vbox);
+	buttons_hbox = memnew(HBoxContainer);
+	overview_vbox->add_child(buttons_hbox);
 
 	filename = memnew(Label);
 	filename->set_clip_text(true);
 	filename->set_h_size_flags(SIZE_EXPAND_FILL);
 	filename->add_style_override("normal", EditorNode::get_singleton()->get_gui_base()->get_stylebox("normal", "LineEdit"));
-	members_overview_buttons_hbox->add_child(filename);
+	buttons_hbox->add_child(filename);
 
 	members_overview_alphabeta_sort_button = memnew(ToolButton);
 	members_overview_alphabeta_sort_button->set_tooltip(TTR("Toggle alphabetical sorting of the method list."));
@@ -2699,10 +2704,10 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	members_overview_alphabeta_sort_button->set_pressed(EditorSettings::get_singleton()->get("text_editor/tools/sort_members_outline_alphabetically"));
 	members_overview_alphabeta_sort_button->connect("toggled", this, "_toggle_members_overview_alpha_sort");
 
-	members_overview_buttons_hbox->add_child(members_overview_alphabeta_sort_button);
+	buttons_hbox->add_child(members_overview_alphabeta_sort_button);
 
 	members_overview = memnew(ItemList);
-	members_overview_vbox->add_child(members_overview);
+	overview_vbox->add_child(members_overview);
 
 	members_overview->set_allow_reselect(true);
 	members_overview->set_custom_minimum_size(Size2(0, 90)); //need to give a bit of limit to avoid it from disappearing
@@ -2711,7 +2716,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	members_overview->set_drag_forwarding(this);
 
 	help_overview = memnew(ItemList);
-	members_overview_vbox->add_child(help_overview);
+	overview_vbox->add_child(help_overview);
 	help_overview->set_allow_reselect(true);
 	help_overview->set_custom_minimum_size(Size2(0, 90)); //need to give a bit of limit to avoid it from disappearing
 	help_overview->set_v_size_flags(SIZE_EXPAND_FILL);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -199,8 +199,8 @@ class ScriptEditor : public PanelContainer {
 	ItemList *script_list;
 	HSplitContainer *script_split;
 	ItemList *members_overview;
-	VBoxContainer *members_overview_vbox;
-	HBoxContainer *members_overview_buttons_hbox;
+	VBoxContainer *overview_vbox;
+	HBoxContainer *buttons_hbox;
 	Label *filename;
 	ToolButton *members_overview_alphabeta_sort_button;
 	bool members_overview_enabled;

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -162,6 +162,7 @@ void Control::_update_minimum_size_cache() {
 	minsize.y = MAX(minsize.y, data.custom_minimum_size.y);
 	data.minimum_size_cache = minsize;
 	data.minimum_size_valid = true;
+	minimum_size_changed();
 }
 
 Size2 Control::get_combined_minimum_size() const {
@@ -452,10 +453,8 @@ void Control::_notification(int p_notification) {
 
 		} break;
 		case NOTIFICATION_POST_ENTER_TREE: {
-			if (is_visible_in_tree()) {
-				data.minimum_size_valid = false;
-				_size_changed();
-			}
+			data.minimum_size_valid = false;
+			_size_changed();
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -113,37 +113,9 @@ void Popup::set_as_minsize() {
 
 void Popup::popup_centered_minsize(const Size2 &p_minsize) {
 
-	Size2 total_minsize = p_minsize;
-
-	for (int i = 0; i < get_child_count(); i++) {
-
-		Control *c = Object::cast_to<Control>(get_child(i));
-		if (!c)
-			continue;
-		if (!c->is_visible())
-			continue;
-
-		Size2 minsize = c->get_combined_minimum_size();
-
-		for (int j = 0; j < 2; j++) {
-
-			Margin m_beg = Margin(0 + j);
-			Margin m_end = Margin(2 + j);
-
-			float margin_begin = c->get_margin(m_beg);
-			float margin_end = c->get_margin(m_end);
-			float anchor_begin = c->get_anchor(m_beg);
-			float anchor_end = c->get_anchor(m_end);
-
-			minsize[j] += margin_begin * (ANCHOR_END - anchor_begin) + margin_end * anchor_end;
-		}
-
-		total_minsize.width = MAX(total_minsize.width, minsize.width);
-		total_minsize.height = MAX(total_minsize.height, minsize.height);
-	}
-
-	popup_centered(total_minsize);
-	popped_up = true;
+	set_custom_minimum_size(p_minsize);
+	_fix_size();
+	popup_centered();
 }
 
 void Popup::popup_centered(const Size2 &p_size) {


### PR DESCRIPTION
Fix #16069, Fix #19292, Fix #19267, Fix #18940.

- Fix slider in the project settings; 
- Fix all tabs in about dialog ~**except for the licence thirdparty**~ (Fixed now, the problem was caused by label autowrap with zero width. fix [here](https://github.com/godotengine/godot/pull/19334/files#diff-406898b6f6403046f6e22a8aba832784R191));
- Fix `popup_centered` incorrectly positioned the first time.
- Fix assetlib dialogs not resizing when preview texture is updated (https://github.com/godotengine/godot/issues/18940#issuecomment-389638767)]

This pr also fix batch rename dialog with wrong size in the first time it appears.

Edit:
Fix this https://github.com/godotengine/godot/pull/19188#issuecomment-394847634 too.

Edit2:
Fix #19441.