### PR TITLE
Fix bugs related to bad handling of rotated/translated shapes in tilemap

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -123,10 +123,10 @@ void TileSetEditor::_import_node(Node *p_node, Ref<TileSet> p_library) {
 			for (List<uint32_t>::Element *E = shapes.front(); E; E = E->next()) {
 				if (sb->is_shape_owner_disabled(E->get())) continue;
 
-				Transform2D shape_transform = sb->shape_owner_get_transform(E->get());
+				Transform2D shape_transform = sb->get_transform() * sb->shape_owner_get_transform(E->get());
 				bool one_way = sb->is_shape_owner_one_way_collision_enabled(E->get());
 
-				shape_transform[2] -= phys_offset - sb->get_transform().xform(shape_transform[2]);
+				shape_transform[2] -= phys_offset;
 
 				for (int k = 0; k < sb->shape_owner_get_shape_count(E->get()); k++) {
 

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -466,9 +466,11 @@ void TileMap::_update_dirty_quadrants() {
 						Transform2D xform;
 						xform.set_origin(offset.floor());
 
-						Vector2 shape_ofs = tile_set->tile_get_shape_offset(c.id, i);
+						Vector2 shape_ofs = shapes[i].shape_transform.get_origin();
 
 						_fix_cell_transform(xform, c, shape_ofs + center_ofs, s);
+
+						xform *= shapes[i].shape_transform.untranslated();
 
 						if (debug_canvas_item.is_valid()) {
 							vs->canvas_item_add_set_transform(debug_canvas_item, xform);


### PR DESCRIPTION
Fixup #18529 and #12870. CC @swarnimarun and @Nibodhika if they want to check.

Handling of "Tile Origin" != "Top-Left" is still weird, but it isn't coming from this PR.

Edit, fixes part of #18493.