### PR TITLE
Fixes to the new inspector

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -245,7 +245,7 @@ class EditorInspector : public ScrollContainer {
 	bool read_only;
 	bool keying;
 
-	int refresh_countdown;
+	float refresh_countdown;
 	bool update_tree_pending;
 	StringName _prop_edited;
 	StringName property_selected;
@@ -256,7 +256,7 @@ class EditorInspector : public ScrollContainer {
 
 	void _edit_set(const String &p_name, const Variant &p_value, bool p_refresh_all, const String &p_changed_field);
 
-	void _property_changed(const String &p_path, const Variant &p_value);
+	void _property_changed(const String &p_path, const Variant &p_value, bool changing = false);
 	void _property_changed_update_all(const String &p_path, const Variant &p_value);
 	void _multiple_properties_changed(Vector<String> p_paths, Array p_values);
 	void _property_keyed(const String &p_path);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -50,7 +50,7 @@ void EditorPropertyText::_text_changed(const String &p_string) {
 	if (updating)
 		return;
 
-	emit_signal("property_changed", get_edited_property(), p_string);
+	emit_signal("property_changed", get_edited_property(), p_string, true);
 }
 
 void EditorPropertyText::update_property() {
@@ -78,12 +78,12 @@ EditorPropertyText::EditorPropertyText() {
 
 void EditorPropertyMultilineText::_big_text_changed() {
 	text->set_text(big_text->get_text());
-	emit_signal("property_changed", get_edited_property(), big_text->get_text());
+	emit_signal("property_changed", get_edited_property(), big_text->get_text(), true);
 }
 
 void EditorPropertyMultilineText::_text_changed() {
 
-	emit_signal("property_changed", get_edited_property(), text->get_text());
+	emit_signal("property_changed", get_edited_property(), text->get_text(), true);
 }
 
 void EditorPropertyMultilineText::_open_big_text() {

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1411,7 +1411,7 @@ void Control::set_anchor(Margin p_margin, float p_anchor, bool p_keep_margin, bo
 	}
 
 	update();
-	_change_notify();
+	_change_notify("anchor");
 }
 
 void Control::_set_anchor(Margin p_margin, float p_anchor) {


### PR DESCRIPTION
Fix #19008, Fix  #19072.
- Fix inspector dock not updating tree for main resource;
- Also fix "docks/property_editor/auto_refresh_interval" used by MultiNodeEdit, it wasn't working.

## Update:
Fix https://github.com/godotengine/godot/issues/9890#issuecomment-394844248.
Before:
![out mp4](https://user-images.githubusercontent.com/1387165/41000087-3ec76676-68e3-11e8-8884-ccd20be770f9.gif)
After:
![out mp4](https://user-images.githubusercontent.com/1387165/41182469-3357f43e-6b4c-11e8-9b6a-006713435ca7.gif)
This happens when you try to slide to a value that the property doesn't allow (because of the minimum size of the children is "dynamic"), in this case the `margin_left` can't go above 15, but here it's set that can range from -4096 to 4096.
https://github.com/godotengine/godot/blob/66871322b99436990daec5a70c09620619430b8d/scene/gui/control.cpp#L2868
and the fix was just pass "anchor" on `_change_notify`.