### PR TITLE
Implement Random class

### DIFF
--- a/core/math/math_funcs.cpp
+++ b/core/math/math_funcs.cpp
@@ -30,14 +30,13 @@
 
 #include "math_funcs.h"
 
-#include "core/os/os.h"
-
-pcg32_random_t Math::default_pcg = { 12047754176567800795ULL, PCG_DEFAULT_INC_64 };
+RandomBase Math::default_rand(RandomBase::DEFAULT_SEED, RandomBase::DEFAULT_INC);
 
 #define PHI 0x9e3779b9
 
 // TODO: we should eventually expose pcg.inc too
 uint32_t Math::rand_from_seed(uint64_t *seed) {
+	// TODO: create a RandomBase instance
 	pcg32_random_t pcg = { *seed, PCG_DEFAULT_INC_64 };
 	uint32_t r = pcg32_random_r(&pcg);
 	*seed = pcg.state;
@@ -45,15 +44,15 @@ uint32_t Math::rand_from_seed(uint64_t *seed) {
 }
 
 void Math::seed(uint64_t x) {
-	default_pcg.state = x;
+	default_rand.seed(x);
 }
 
 void Math::randomize() {
-	seed(OS::get_singleton()->get_ticks_usec() * default_pcg.state + PCG_DEFAULT_INC_64);
+	default_rand.randomize();
 }
 
 uint32_t Math::rand() {
-	return pcg32_random_r(&default_pcg);
+	return default_rand.rand();
 }
 
 int Math::step_decimals(double p_step) {
@@ -167,13 +166,9 @@ uint32_t Math::larger_prime(uint32_t p_val) {
 }
 
 double Math::random(double from, double to) {
-	unsigned int r = Math::rand();
-	double ret = (double)r / (double)RANDOM_MAX;
-	return (ret) * (to - from) + from;
+	return default_rand.random(from, to);
 }
 
 float Math::random(float from, float to) {
-	unsigned int r = Math::rand();
-	float ret = (float)r / (float)RANDOM_MAX;
-	return (ret) * (to - from) + from;
+	return default_rand.random(from, to);
 }

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -34,6 +34,7 @@
 #include "math_defs.h"
 #include "typedefs.h"
 
+#include "randombase.h"
 #include "thirdparty/misc/pcg.h"
 
 #include <float.h>
@@ -48,7 +49,7 @@
 
 class Math {
 
-	static pcg32_random_t default_pcg;
+	static RandomBase default_rand;
 
 public:
 	Math() {} // useless to instance

--- a/core/math/random.cpp
+++ b/core/math/random.cpp
@@ -1,0 +1,40 @@
+#include "random.h"
+
+Random::Random() :
+		randbase() {}
+
+void Random::seed(uint64_t seed) {
+	return randbase.seed(seed);
+}
+
+void Random::randomize() {
+	return randbase.randomize();
+}
+
+uint32_t Random::randi() {
+	return randbase.rand();
+}
+
+double Random::randd(double from, double to) {
+	if (isnan(to)) {
+		if (isnan(from)) {
+			// randd()
+			from = (double)0;
+			to = (double)1;
+		} else {
+			// randd(to)
+			to = from;
+			from = (double)0;
+		}
+	}
+
+	return randbase.random(from, to);
+}
+
+void Random::_bind_methods() {
+
+	ClassDB::bind_method(D_METHOD("seed", "seed"), &Random::seed);
+	ClassDB::bind_method(D_METHOD("randi"), &Random::randi);
+	ClassDB::bind_method(D_METHOD("randd", "from", "to"), &Random::randd, DEFVAL(NAN), DEFVAL(NAN));
+	ClassDB::bind_method(D_METHOD("randomize"), &Random::randomize);
+}

--- a/core/math/random.h
+++ b/core/math/random.h
@@ -1,0 +1,25 @@
+#ifndef RAND_CORE_H
+#define RAND_CORE_H
+
+#include "randombase.h"
+#include "reference.h"
+
+class Random : public Reference {
+	GDCLASS(Random, Reference);
+
+	RandomBase randbase;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void seed(uint64_t seed);
+	void randomize();
+
+	uint32_t randi();
+	double randd(double from = NAN, double to = NAN);
+
+	Random();
+};
+
+#endif // RAND_CORE_H

--- a/core/math/randombase.cpp
+++ b/core/math/randombase.cpp
@@ -1,0 +1,33 @@
+#include "randombase.h"
+
+#include "core/os/os.h"
+
+RandomBase::RandomBase(uint64_t seed, uint64_t inc) :
+		pcg() {
+	pcg.state = seed;
+	pcg.inc = inc;
+}
+
+void RandomBase::seed(uint64_t seed) {
+	pcg.state = seed;
+}
+
+void RandomBase::randomize() {
+	seed(OS::get_singleton()->get_ticks_usec() * pcg.state + PCG_DEFAULT_INC_64);
+}
+
+uint32_t RandomBase::rand() {
+	return pcg32_random_r(&pcg);
+}
+
+double RandomBase::random(double from, double to) {
+	unsigned int r = rand();
+	double ret = (double)r / (double)RANDOM_MAX;
+	return (ret) * (to - from) + from;
+}
+
+float RandomBase::random(float from, float to) {
+	unsigned int r = rand();
+	float ret = (float)r / (float)RANDOM_MAX;
+	return (ret) * (to - from) + from;
+}

--- a/core/math/randombase.h
+++ b/core/math/randombase.h
@@ -1,0 +1,29 @@
+#ifndef RANDBASE_CORE_H
+#define RANDBASE_CORE_H
+
+#include "math.h"
+#include "math_defs.h"
+#include "thirdparty/misc/pcg.h"
+
+class RandomBase {
+	pcg32_random_t pcg;
+
+public:
+	static const uint64_t DEFAULT_SEED = 12047754176567800795ULL;
+	static const uint64_t DEFAULT_INC = PCG_DEFAULT_INC_64;
+	static const uint64_t RANDOM_MAX = 4294967295;
+
+	RandomBase(uint64_t seed = DEFAULT_SEED, uint64_t inc = PCG_DEFAULT_INC_64);
+
+	void seed(uint64_t x);
+	void randomize();
+	uint32_t rand();
+	_ALWAYS_INLINE_ double randf() { return (double)rand() / (double)RANDOM_MAX; }
+	_ALWAYS_INLINE_ float randd() { return (float)rand() / (float)RANDOM_MAX; }
+
+	double random(double from, double to);
+	float random(float from, float to);
+	real_t random(int from, int to) { return (real_t)random((real_t)from, (real_t)to); }
+};
+
+#endif // RANDBASE_CORE_H

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -53,6 +53,7 @@
 #include "io/tcp_server.h"
 #include "io/translation_loader_po.h"
 #include "math/a_star.h"
+#include "math/random.h"
 #include "math/triangle_mesh.h"
 #include "os/input.h"
 #include "os/main_loop.h"
@@ -173,6 +174,7 @@ void register_core_types() {
 	ClassDB::register_virtual_class<PackedDataContainerRef>();
 	ClassDB::register_class<AStar>();
 	ClassDB::register_class<EncodedObjectAsID>();
+	ClassDB::register_class<Random>();
 
 	ClassDB::register_class<JSONParseResult>();
 


### PR DESCRIPTION
Begin to address #7199 and #7989, among others. Add a Random class implementing
the existing interface for random number generation, acting as a thin wrapper
around the current functionality.

The random functions in the Math namespace operate on a global instance of this
class, keeping backwards-compatibility and simple use cases.

The code had to be split into two classes, RandomBase and Random, as it seems
like reference.h relies on math_funcs.h, and thus math_funcs cannot itself
instance a reference.

In essence, this patch keeps the interface we currently use for RNG as-is, without introducing a slew of concepts. This is my first time touching c++ in quite some time, so the code may not be the best, and there are a few of questions which might be worth answering before merging:

* Is this all the API we want? The one method I think is missing is getting an array of random numbers (doable in a `for` loop though)
  * Do we want `randi` to also accept `from, to`?
* Is there a way to reduce code reuse? All the main functions in `Math::randomX` are basically calls to `RandomBase::X`, and likewise all calls in `Random::X` are basically proxies to `RandomBase::X`. Is there perhaps a better way?
* Is what I said above true, that we can't easily `#include "reference.h"` in math_funcs because of a dependency conflict?
* How do we pass arguments to the `Random` constructor from GDScript? i.e. `Random.new(initial_seed)` ? I tried adding another constructor with arguments, but it seemed like `Random.new` only calls the 0-arguments constructor, and additionally cannot be compiled without one.

Again, I tried to keep this as small a change as possible, so that perhaps we can pave the way to a better, more diverse RNG interface later, but right now provide the already established interface.

Edit: Noticed I haven't even talked about the API:

```gdscript
var r = Random.new()
# grab an int
r.randi()
# since they both the same initial seed, the global `rand()` function will return the same result as the above

# seed our random
r.seed(1)
r.randi()

# create another random
var r2 = Random.new()
r2.randi()
# again, same as the initial r.randi()

r.randomize()
r.randd(low, high)
```