### PR TITLE
Revert "Prevent visibility notification from being called twice in object creation"

### DIFF
--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -272,8 +272,7 @@ bool CanvasItem::is_visible_in_tree() const {
 
 void CanvasItem::_propagate_visibility_changed(bool p_visible) {
 
-	if (!first_draw)
-		notification(NOTIFICATION_VISIBILITY_CHANGED);
+	notification(NOTIFICATION_VISIBILITY_CHANGED);
 
 	if (p_visible)
 		update(); //todo optimize


### PR DESCRIPTION
Reverts godotengine/godot#18172.

This caused a regression (#18614), and potentially other unintended regressions.

Fixes #18614.