### PR TITLE
Set SO_BROADCAST socket option for UDP sockets.

### DIFF
--- a/drivers/unix/socket_helpers.h
+++ b/drivers/unix/socket_helpers.h
@@ -124,6 +124,13 @@ static int _socket_create(IP::Type &p_type, int type, int protocol) {
 			WARN_PRINT("Unable to set/unset IPv4 address mapping over IPv6");
 		}
 	}
+	if (protocol == IPPROTO_UDP && p_type != IP::TYPE_IPV6) {
+		// Enable broadcasting for UDP sockets if it's not IPv6 only (IPv6 has no broadcast option).
+		int broadcast = 1;
+		if (setsockopt(sockfd, SOL_SOCKET, SO_BROADCAST, (char *)&broadcast, sizeof(broadcast)) != 0) {
+			WARN_PRINT("Error when enabling broadcasting");
+		}
+	}
 
 	return sockfd;
 }


### PR DESCRIPTION
UDP broadcasting was not working because `SO_BROADCAST` option was not set for the socket.
With this PR broacasting will be enabled on all UDP and IPv4-enabled sockets (IPv6 has no broadcast).

The option has to be set because:
> Socket semantics require that an application set the SO_BROADCAST option on before attempting to send a datagram to a base or broadcast address. This protects the application from accidentally sending a datagram to many systems.

So I'm wonder if we should make this optional, but I guess for now it's fine.

Fixes #18736