### PR TITLE
Show opened script or help name

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1404,16 +1404,16 @@ void ScriptEditor::_update_members_overview_visibility() {
 
 	ScriptEditorBase *se = _get_current_editor();
 	if (!se) {
-		members_overview_buttons_hbox->set_visible(false);
+		members_overview_alphabeta_sort_button->set_visible(false);
 		members_overview->set_visible(false);
 		return;
 	}
 
 	if (members_overview_enabled && se->show_members_overview()) {
-		members_overview_buttons_hbox->set_visible(true);
+		members_overview_alphabeta_sort_button->set_visible(true);
 		members_overview->set_visible(true);
 	} else {
-		members_overview_buttons_hbox->set_visible(false);
+		members_overview_alphabeta_sort_button->set_visible(false);
 		members_overview->set_visible(false);
 	}
 }
@@ -1440,6 +1440,11 @@ void ScriptEditor::_update_members_overview() {
 		members_overview->add_item(functions[i].get_slice(":", 0));
 		members_overview->set_item_metadata(i, functions[i].get_slice(":", 1).to_int() - 1);
 	}
+
+	String path = se->get_edited_script()->get_path();
+	bool built_in = !path.is_resource_file();
+	String name = built_in ? path.get_file() : se->get_name();
+	filename->set_text(name);
 }
 
 void ScriptEditor::_update_help_overview_visibility() {
@@ -1458,8 +1463,9 @@ void ScriptEditor::_update_help_overview_visibility() {
 	}
 
 	if (help_overview_enabled) {
-		members_overview_buttons_hbox->set_visible(false);
+		members_overview_alphabeta_sort_button->set_visible(false);
 		help_overview->set_visible(true);
+		filename->set_text(se->get_name());
 	} else {
 		help_overview->set_visible(false);
 	}
@@ -2680,6 +2686,12 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	list_split->add_child(members_overview_vbox);
 	members_overview_buttons_hbox = memnew(HBoxContainer);
 	members_overview_vbox->add_child(members_overview_buttons_hbox);
+
+	filename = memnew(Label);
+	filename->set_clip_text(true);
+	filename->set_h_size_flags(SIZE_EXPAND_FILL);
+	filename->add_style_override("normal", EditorNode::get_singleton()->get_gui_base()->get_stylebox("normal", "LineEdit"));
+	members_overview_buttons_hbox->add_child(filename);
 
 	members_overview_alphabeta_sort_button = memnew(ToolButton);
 	members_overview_alphabeta_sort_button->set_tooltip(TTR("Toggle alphabetical sorting of the method list."));

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -201,6 +201,7 @@ class ScriptEditor : public PanelContainer {
 	ItemList *members_overview;
 	VBoxContainer *members_overview_vbox;
 	HBoxContainer *members_overview_buttons_hbox;
+	Label *filename;
 	ToolButton *members_overview_alphabeta_sort_button;
 	bool members_overview_enabled;
 	ItemList *help_overview;


### PR DESCRIPTION
Fix #18864

![filename](https://user-images.githubusercontent.com/8281454/41003386-9a5b704a-6951-11e8-9368-6feab96b23ff.gif)

We got enough room to show name after #18442
and show class name for help for visual consistency