### PR TITLE
allow undefined GODOT_DEBUG_MSBUILD environment  variable

### DIFF
--- a/modules/mono/editor/GodotSharpTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotSharpTools/Build/BuildSystem.cs
@@ -234,7 +234,7 @@ namespace GodotSharpTools.Build
 
         private static bool IsDebugMSBuildRequested()
         {
-            return Environment.GetEnvironmentVariable("GODOT_DEBUG_MSBUILD").Trim() == "1";
+            return Environment.GetEnvironmentVariable("GODOT_DEBUG_MSBUILD")?.Trim() == "1";
         }
 
         public void Dispose()


### PR DESCRIPTION
Fixes null reference error in https://github.com/godotengine/godot/issues/19394