### PR TITLE
Remove default non-zero left margin

### DIFF
--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -844,7 +844,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	theme->set_constant("separation", "HBoxContainer", 4 * scale);
 	theme->set_constant("separation", "VBoxContainer", 4 * scale);
-	theme->set_constant("margin_left", "MarginContainer", 8 * scale);
+	theme->set_constant("margin_left", "MarginContainer", 0 * scale);
 	theme->set_constant("margin_top", "MarginContainer", 0 * scale);
 	theme->set_constant("margin_right", "MarginContainer", 0 * scale);
 	theme->set_constant("margin_bottom", "MarginContainer", 0 * scale);


### PR DESCRIPTION
While creating UIs, I wondered why those "strange offets".

I noticed that I had to override the left margin property of containers to set it to 0 explicitly, though 0 was shown in the inspector as the default.

The default theme has no need for a predefined left margin, does it?

Sadly, this breaks compatibility for UIs already designed so it'll have to wait for 3.1.

@akien-mga , @hpvb , please check if these observations and tagging are right.