### PR TITLE
Tweak some help texts in the build system

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2,16 +2,12 @@
 
 EnsureSConsVersion(0, 98, 1)
 
-
 import string
 import os
 import os.path
 import glob
 import sys
 import methods
-
-# moved below to compensate with module version string
-# methods.update_version()
 
 # scan possible build platforms
 
@@ -52,9 +48,6 @@ for x in glob.glob("platform/*"):
     sys.modules.pop('detect')
 
 module_list = methods.detect_modules()
-
-
-# print "Detected Platforms: "+str(platform_list)
 
 methods.save_active_platforms(active_platforms, active_platform_ids)
 
@@ -101,7 +94,6 @@ env_base.Decider('MD5-timestamp')
 # http://scons.org/doc/production/HTML/scons-user/ch06s04.html
 env_base.SetOption('implicit_cache', 1)
 
-
 env_base.__class__.android_add_maven_repository = methods.android_add_maven_repository
 env_base.__class__.android_add_flat_dir = methods.android_add_flat_dir
 env_base.__class__.android_add_dependency = methods.android_add_dependency
@@ -145,54 +137,53 @@ if profile:
 opts = Variables(customs, ARGUMENTS)
 
 # Target build options
-opts.Add('arch', "Platform-dependent architecture (arm/arm64/x86/x64/mips/etc)", '')
+opts.Add('arch', "Platform-dependent architecture (arm/arm64/x86/x64/mips/...)", '')
 opts.Add(EnumVariable('bits', "Target platform bits", 'default', ('default', '32', '64')))
 opts.Add('p', "Platform (alias for 'platform')", '')
 opts.Add('platform', "Target platform (%s)" % ('|'.join(platform_list), ), '')
 opts.Add(EnumVariable('target', "Compilation target", 'debug', ('debug', 'release_debug', 'release')))
-opts.Add(BoolVariable('tools', "Build the tools a.k.a. the Godot editor", True))
-opts.Add(BoolVariable('use_lto', 'Use linking time optimization', False))
+opts.Add(BoolVariable('tools', "Build the tools (a.k.a. the Godot editor)", True))
+opts.Add(BoolVariable('use_lto', 'Use link-time optimization', False))
 
 # Components
 opts.Add(BoolVariable('deprecated', "Enable deprecated features", True))
-opts.Add(BoolVariable('gdscript', "Build GDSCript support", True))
-opts.Add(BoolVariable('minizip', "Build minizip archive support", True))
-opts.Add(BoolVariable('xaudio2', "XAudio2 audio driver", False))
-opts.Add(BoolVariable('xml', "XML format support for resources", True))
+opts.Add(BoolVariable('gdscript', "Enable GDScript support", True))
+opts.Add(BoolVariable('minizip', "Enable ZIP archive support using minizip", True))
+opts.Add(BoolVariable('xaudio2', "Enable the XAudio2 audio driver", False))
+opts.Add(BoolVariable('xml', "Enable XML format support for resources", True))
 
 # Advanced options
-opts.Add(BoolVariable('disable_3d', "Disable 3D nodes for smaller executable", False))
-opts.Add(BoolVariable('disable_advanced_gui', "Disable advanced 3D gui nodes and behaviors", False))
+opts.Add(BoolVariable('disable_3d', "Disable 3D nodes for a smaller executable", False))
+opts.Add(BoolVariable('disable_advanced_gui', "Disable advanced 3D GUI nodes and behaviors", False))
 opts.Add('extra_suffix', "Custom extra suffix added to the base filename of all generated binary files", '')
-opts.Add('unix_global_settings_path', "UNIX-specific path to system-wide settings. Currently only used for templates", '')
 opts.Add(BoolVariable('verbose', "Enable verbose output for the compilation", False))
-opts.Add(BoolVariable('vsproj', "Generate Visual Studio Project", False))
+opts.Add(BoolVariable('vsproj', "Generate a Visual Studio solution", False))
 opts.Add(EnumVariable('warnings', "Set the level of warnings emitted during compilation", 'no', ('extra', 'all', 'moderate', 'no')))
-opts.Add(BoolVariable('progress', "Show a progress indicator during build", True))
+opts.Add(BoolVariable('progress', "Show a progress indicator during compilation", True))
 opts.Add(BoolVariable('dev', "If yes, alias for verbose=yes warnings=all", False))
-opts.Add(EnumVariable('macports_clang', "Build using clang from MacPorts", 'no', ('no', '5.0', 'devel')))
+opts.Add(EnumVariable('macports_clang', "Build using Clang from MacPorts", 'no', ('no', '5.0', 'devel')))
 opts.Add(BoolVariable('no_editor_splash', "Don't use the custom splash screen for the editor", False))
 
 # Thirdparty libraries
-opts.Add(BoolVariable('builtin_bullet', "Use the builtin bullet library", True))
-opts.Add(BoolVariable('builtin_enet', "Use the builtin enet library", True))
-opts.Add(BoolVariable('builtin_freetype', "Use the builtin freetype library", True))
-opts.Add(BoolVariable('builtin_libogg', "Use the builtin libogg library", True))
-opts.Add(BoolVariable('builtin_libpng', "Use the builtin libpng library", True))
-opts.Add(BoolVariable('builtin_libtheora', "Use the builtin libtheora library", True))
-opts.Add(BoolVariable('builtin_libvorbis', "Use the builtin libvorbis library", True))
-opts.Add(BoolVariable('builtin_libvpx', "Use the builtin libvpx library", True))
-opts.Add(BoolVariable('builtin_libwebp', "Use the builtin libwebp library", True))
-opts.Add(BoolVariable('builtin_libwebsockets', "Use the builtin libwebsockets library", True))
-opts.Add(BoolVariable('builtin_mbedtls', "Use the builtin mbedTLS library", True))
-opts.Add(BoolVariable('builtin_miniupnpc', "Use the builtin miniupnpc library", True))
-opts.Add(BoolVariable('builtin_opus', "Use the builtin opus library", True))
-opts.Add(BoolVariable('builtin_pcre2', "Use the builtin pcre2 library)", True))
-opts.Add(BoolVariable('builtin_recast', "Use the builtin recast library", True))
-opts.Add(BoolVariable('builtin_squish', "Use the builtin squish library", True))
-opts.Add(BoolVariable('builtin_thekla_atlas', "Use the builtin thekla_altas library", True))
-opts.Add(BoolVariable('builtin_zlib', "Use the builtin zlib library", True))
-opts.Add(BoolVariable('builtin_zstd', "Use the builtin zstd library", True))
+opts.Add(BoolVariable('builtin_bullet', "Use the built-in Bullet library", True))
+opts.Add(BoolVariable('builtin_enet', "Use the built-in ENet library", True))
+opts.Add(BoolVariable('builtin_freetype', "Use the built-in FreeType library", True))
+opts.Add(BoolVariable('builtin_libogg', "Use the built-in libogg library", True))
+opts.Add(BoolVariable('builtin_libpng', "Use the built-in libpng library", True))
+opts.Add(BoolVariable('builtin_libtheora', "Use the built-in libtheora library", True))
+opts.Add(BoolVariable('builtin_libvorbis', "Use the built-in libvorbis library", True))
+opts.Add(BoolVariable('builtin_libvpx', "Use the built-in libvpx library", True))
+opts.Add(BoolVariable('builtin_libwebp', "Use the built-in libwebp library", True))
+opts.Add(BoolVariable('builtin_libwebsockets', "Use the built-in libwebsockets library", True))
+opts.Add(BoolVariable('builtin_mbedtls', "Use the built-in mbedTLS library", True))
+opts.Add(BoolVariable('builtin_miniupnpc', "Use the built-in miniupnpc library", True))
+opts.Add(BoolVariable('builtin_opus', "Use the built-in Opus library", True))
+opts.Add(BoolVariable('builtin_pcre2', "Use the built-in PCRE2 library)", True))
+opts.Add(BoolVariable('builtin_recast', "Use the built-in Recast library", True))
+opts.Add(BoolVariable('builtin_squish', "Use the built-in squish library", True))
+opts.Add(BoolVariable('builtin_thekla_atlas', "Use the built-in thekla_altas library", True))
+opts.Add(BoolVariable('builtin_zlib', "Use the built-in zlib library", True))
+opts.Add(BoolVariable('builtin_zstd', "Use the built-in Zstd library", True))
 
 # Compilation environment setup
 opts.Add("CXX", "C++ compiler")
@@ -202,7 +193,6 @@ opts.Add("CCFLAGS", "Custom flags for both the C and C++ compilers")
 opts.Add("CXXFLAGS", "Custom flags for the C++ compiler")
 opts.Add("CFLAGS", "Custom flags for the C compiler")
 opts.Add("LINKFLAGS", "Custom flags for the linker")
-
 
 # add platform specific options
 
@@ -234,14 +224,6 @@ env_base.Append(CPPPATH=['#core', '#core/math', '#editor', '#drivers', '#'])
 env_base.platform_exporters = platform_exporters
 env_base.platform_apis = platform_apis
 
-"""
-sys.path.append("./platform/"+env_base["platform"])
-import detect
-detect.configure(env_base)
-sys.path.remove("./platform/"+env_base["platform"])
-sys.modules.pop('detect')
-"""
-
 if (env_base['target'] == 'debug'):
     env_base.Append(CPPDEFINES=['DEBUG_MEMORY_ALLOC', 'SCI_NAMESPACE'])
 
@@ -253,7 +235,6 @@ if not env_base['deprecated']:
 
 env_base.platforms = {}
 
-
 selected_platform = ""
 
 if env_base['platform'] != "":
@@ -261,7 +242,6 @@ if env_base['platform'] != "":
 elif env_base['p'] != "":
     selected_platform = env_base['p']
     env_base["platform"] = selected_platform
-
 
 if selected_platform in platform_list:
 
@@ -354,7 +334,6 @@ if selected_platform in platform_list:
         else: # 'no'
             env.Append(CCFLAGS=['-w'])
         env.Append(CCFLAGS=['-Werror=return-type'])
-    #env['platform_libsuffix'] = env['LIBSUFFIX']
 
     suffix = "." + selected_platform
 
@@ -431,10 +410,6 @@ if selected_platform in platform_list:
 
     if (env.use_ptrcall):
         env.Append(CPPDEFINES=['PTRCALL_ENABLED'])
-
-    # to test 64 bits compiltion
-    # env.Append(CPPFLAGS=['-m64'])
-
     if env['tools']:
         env.Append(CPPDEFINES=['TOOLS_ENABLED'])
     if env['disable_3d']:
@@ -443,10 +418,8 @@ if selected_platform in platform_list:
         env.Append(CPPDEFINES=['GDSCRIPT_ENABLED'])
     if env['disable_advanced_gui']:
         env.Append(CPPDEFINES=['ADVANCED_GUI_DISABLED'])
-
     if env['minizip']:
         env.Append(CPPDEFINES=['MINIZIP_ENABLED'])
-
     if env['xml']:
         env.Append(CPPDEFINES=['XML_ENABLED'])
 
@@ -494,11 +467,10 @@ if selected_platform in platform_list:
 else:
 
     print("No valid target platform selected.")
-    print("The following were detected:")
+    print("The following platforms were detected:")
     for x in platform_list:
         print("\t" + x)
-    print("\nPlease run scons again with argument: platform=<string>")
-
+    print("\nPlease run SCons again with the argument: platform=<string>")
 
 # The following only makes sense when the env is defined, and assumes it is
 if 'env' in locals():

--- a/platform/haiku/detect.py
+++ b/platform/haiku/detect.py
@@ -22,7 +22,7 @@ def get_opts():
     from SCons.Variables import EnumVariable
 
     return [
-        EnumVariable('debug_symbols', 'Add debug symbols to release version', 'yes', ('yes', 'no', 'full')),
+        EnumVariable('debug_symbols', 'Add debugging symbols to release builds', 'yes', ('yes', 'no', 'full')),
     ]
 
 

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -23,8 +23,8 @@ def get_opts():
 
     return [
         ('osxcross_sdk', 'OSXCross SDK version', 'darwin14'),
-        EnumVariable('debug_symbols', 'Add debug symbols to release version', 'yes', ('yes', 'no', 'full')),
-        BoolVariable('separate_debug_symbols', 'Create a separate file with the debug symbols', False),
+        EnumVariable('debug_symbols', 'Add debugging symbols to release builds', 'yes', ('yes', 'no', 'full')),
+        BoolVariable('separate_debug_symbols', 'Create a separate file containing debugging symbols', False),
     ]
 
 

--- a/platform/uwp/detect.py
+++ b/platform/uwp/detect.py
@@ -28,8 +28,8 @@ def get_opts():
     from SCons.Variables import BoolVariable
 
     return [
-        ('msvc_version', 'MSVC version to use. Ignored if VCINSTALLDIR is set in shell env.', None),
-        BoolVariable('use_mingw', 'Use the Mingw compiler, even if MSVC is installed. Only used on Windows.', False),
+        ('msvc_version', 'MSVC version to use (ignored if the VCINSTALLDIR environment variable is set)', None),
+        BoolVariable('use_mingw', 'Use the MinGW compiler even if MSVC is installed (only used on Windows)', False),
     ]
 
 
@@ -112,7 +112,7 @@ def configure(env):
             env["bits"] = "32"
             print("Compiled program architecture will be a x86 executable. (forcing bits=32).")
         else:
-            print("Failed to detect MSVC compiler architecture version... Defaulting to 32bit executable settings (forcing bits=32). Compilation attempt will continue, but SCons can not detect for what architecture this build is compiled for. You should check your settings/compilation setup.")
+            print("Failed to detect MSVC compiler architecture version... Defaulting to 32-bit executable settings (forcing bits=32). Compilation attempt will continue, but SCons can not detect for what architecture this build is compiled for. You should check your settings/compilation setup.")
             env["bits"] = "32"
 
         if (env["bits"] == "32"):

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -62,8 +62,8 @@ def get_opts():
         # XP support dropped after EOL due to missing API for IPv6 and other issues
         # Vista support dropped after EOL due to GH-10243
         ('target_win_version', 'Targeted Windows version, >= 0x0601 (Windows 7)', '0x0601'),
-        EnumVariable('debug_symbols', 'Add debug symbols to release version', 'yes', ('yes', 'no', 'full')),
-        BoolVariable('separate_debug_symbols', 'Create a separate file with the debug symbols', False),
+        EnumVariable('debug_symbols', 'Add debugging symbols to release builds', 'yes', ('yes', 'no', 'full')),
+        BoolVariable('separate_debug_symbols', 'Create a separate file containing debugging symbols', False),
         ('msvc_version', 'MSVC version to use. Ignored if VCINSTALLDIR is set in shell env.', None),
         BoolVariable('use_mingw', 'Use the Mingw compiler, even if MSVC is installed. Only used on Windows.', False),
     ]

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -59,8 +59,8 @@ def get_opts():
         BoolVariable('use_leak_sanitizer', 'Use LLVM compiler memory leaks sanitizer (implies use_sanitizer)', False),
         BoolVariable('pulseaudio', 'Detect & use pulseaudio', True),
         BoolVariable('udev', 'Use udev for gamepad connection callbacks', False),
-        EnumVariable('debug_symbols', 'Add debug symbols to release version', 'yes', ('yes', 'no', 'full')),
-        BoolVariable('separate_debug_symbols', 'Create a separate file with the debug symbols', False),
+        EnumVariable('debug_symbols', 'Add debugging symbols to release builds', 'yes', ('yes', 'no', 'full')),
+        BoolVariable('separate_debug_symbols', 'Create a separate file containing debugging symbols', False),
         BoolVariable('touch', 'Enable touch events', True),
     ]
 


### PR DESCRIPTION
This fixes a few typos, improves grammar and uses correct casing in all help texts. This also removes some bits of commented-out code.