### PR TITLE
Make same child index as edited scene when using live edit

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1248,7 +1248,7 @@ void SceneTreeDock::_do_reparent(Node *p_new_parent, int p_position_in_parent, V
 			path_renames[ni].second = fixed_node_path;
 		}
 
-		editor_data->get_undo_redo().add_do_method(sed, "live_debug_reparent_node", edited_scene->get_path_to(node), edited_scene->get_path_to(new_parent), new_name, -1);
+		editor_data->get_undo_redo().add_do_method(sed, "live_debug_reparent_node", edited_scene->get_path_to(node), edited_scene->get_path_to(new_parent), new_name, p_position_in_parent + inc);
 		editor_data->get_undo_redo().add_undo_method(sed, "live_debug_reparent_node", NodePath(String(edited_scene->get_path_to(new_parent)) + "/" + new_name), edited_scene->get_path_to(node->get_parent()), node->get_name(), node->get_index());
 
 		if (p_keep_global_xform) {


### PR DESCRIPTION
current behavior, note that running game on right is different with edited scene on left
![reparent_child](https://user-images.githubusercontent.com/8281454/41130009-b70e00dc-6aef-11e8-9974-2ce5693f6116.gif)

with this PR, it's same on both editor and running game.
![reparent_child_fix](https://user-images.githubusercontent.com/8281454/41130012-b8eaca34-6aef-11e8-981a-2d4f8ef344ed.gif)
