### PR TITLE
Small usability improvements to Input Map editor

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -945,84 +945,31 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("application/config/custom_user_dir_name", "");
 
 	key.instance();
-	key->set_scancode(KEY_ENTER);
+	key->set_scancode(KEY_END);
 	va.push_back(key);
-	key.instance();
-	key->set_scancode(KEY_KP_ENTER);
-	va.push_back(key);
-	key.instance();
-	key->set_scancode(KEY_SPACE);
-	va.push_back(key);
-	joyb.instance();
-	joyb->set_button_index(JOY_BUTTON_0);
-	va.push_back(joyb);
-	GLOBAL_DEF("input/ui_accept", va);
-	input_presets.push_back("input/ui_accept");
+	GLOBAL_DEF("input/ui_end", va);
+	input_presets.push_back("input/ui_end");
 
 	va = Array();
 	key.instance();
-	key->set_scancode(KEY_SPACE);
+	key->set_scancode(KEY_HOME);
 	va.push_back(key);
-	joyb.instance();
-	joyb->set_button_index(JOY_BUTTON_3);
-	va.push_back(joyb);
-	GLOBAL_DEF("input/ui_select", va);
-	input_presets.push_back("input/ui_select");
+	GLOBAL_DEF("input/ui_home", va);
+	input_presets.push_back("input/ui_home");
 
 	va = Array();
 	key.instance();
-	key->set_scancode(KEY_ESCAPE);
+	key->set_scancode(KEY_PAGEDOWN);
 	va.push_back(key);
-	joyb.instance();
-	joyb->set_button_index(JOY_BUTTON_1);
-	va.push_back(joyb);
-	GLOBAL_DEF("input/ui_cancel", va);
-	input_presets.push_back("input/ui_cancel");
+	GLOBAL_DEF("input/ui_page_down", va);
+	input_presets.push_back("input/ui_page_down");
 
 	va = Array();
 	key.instance();
-	key->set_scancode(KEY_TAB);
+	key->set_scancode(KEY_PAGEUP);
 	va.push_back(key);
-	GLOBAL_DEF("input/ui_focus_next", va);
-	input_presets.push_back("input/ui_focus_next");
-
-	va = Array();
-	key.instance();
-	key->set_scancode(KEY_TAB);
-	key->set_shift(true);
-	va.push_back(key);
-	GLOBAL_DEF("input/ui_focus_prev", va);
-	input_presets.push_back("input/ui_focus_prev");
-
-	va = Array();
-	key.instance();
-	key->set_scancode(KEY_LEFT);
-	va.push_back(key);
-	joyb.instance();
-	joyb->set_button_index(JOY_DPAD_LEFT);
-	va.push_back(joyb);
-	GLOBAL_DEF("input/ui_left", va);
-	input_presets.push_back("input/ui_left");
-
-	va = Array();
-	key.instance();
-	key->set_scancode(KEY_RIGHT);
-	va.push_back(key);
-	joyb.instance();
-	joyb->set_button_index(JOY_DPAD_RIGHT);
-	va.push_back(joyb);
-	GLOBAL_DEF("input/ui_right", va);
-	input_presets.push_back("input/ui_right");
-
-	va = Array();
-	key.instance();
-	key->set_scancode(KEY_UP);
-	va.push_back(key);
-	joyb.instance();
-	joyb->set_button_index(JOY_DPAD_UP);
-	va.push_back(joyb);
-	GLOBAL_DEF("input/ui_up", va);
-	input_presets.push_back("input/ui_up");
+	GLOBAL_DEF("input/ui_page_up", va);
+	input_presets.push_back("input/ui_page_up");
 
 	va = Array();
 	key.instance();
@@ -1036,31 +983,84 @@ ProjectSettings::ProjectSettings() {
 
 	va = Array();
 	key.instance();
-	key->set_scancode(KEY_PAGEUP);
+	key->set_scancode(KEY_UP);
 	va.push_back(key);
-	GLOBAL_DEF("input/ui_page_up", va);
-	input_presets.push_back("input/ui_page_up");
+	joyb.instance();
+	joyb->set_button_index(JOY_DPAD_UP);
+	va.push_back(joyb);
+	GLOBAL_DEF("input/ui_up", va);
+	input_presets.push_back("input/ui_up");
 
 	va = Array();
 	key.instance();
-	key->set_scancode(KEY_PAGEDOWN);
+	key->set_scancode(KEY_RIGHT);
 	va.push_back(key);
-	GLOBAL_DEF("input/ui_page_down", va);
-	input_presets.push_back("input/ui_page_down");
+	joyb.instance();
+	joyb->set_button_index(JOY_DPAD_RIGHT);
+	va.push_back(joyb);
+	GLOBAL_DEF("input/ui_right", va);
+	input_presets.push_back("input/ui_right");
 
 	va = Array();
 	key.instance();
-	key->set_scancode(KEY_HOME);
+	key->set_scancode(KEY_LEFT);
 	va.push_back(key);
-	GLOBAL_DEF("input/ui_home", va);
-	input_presets.push_back("input/ui_home");
+	joyb.instance();
+	joyb->set_button_index(JOY_DPAD_LEFT);
+	va.push_back(joyb);
+	GLOBAL_DEF("input/ui_left", va);
+	input_presets.push_back("input/ui_left");
 
 	va = Array();
 	key.instance();
-	key->set_scancode(KEY_END);
+	key->set_scancode(KEY_TAB);
+	key->set_shift(true);
 	va.push_back(key);
-	GLOBAL_DEF("input/ui_end", va);
-	input_presets.push_back("input/ui_end");
+	GLOBAL_DEF("input/ui_focus_prev", va);
+	input_presets.push_back("input/ui_focus_prev");
+
+	va = Array();
+	key.instance();
+	key->set_scancode(KEY_TAB);
+	va.push_back(key);
+	GLOBAL_DEF("input/ui_focus_next", va);
+	input_presets.push_back("input/ui_focus_next");
+
+	va = Array();
+	key.instance();
+	key->set_scancode(KEY_ESCAPE);
+	va.push_back(key);
+	joyb.instance();
+	joyb->set_button_index(JOY_BUTTON_1);
+	va.push_back(joyb);
+	GLOBAL_DEF("input/ui_cancel", va);
+	input_presets.push_back("input/ui_cancel");
+
+	va = Array();
+	key.instance();
+	key->set_scancode(KEY_SPACE);
+	va.push_back(key);
+	joyb.instance();
+	joyb->set_button_index(JOY_BUTTON_3);
+	va.push_back(joyb);
+	GLOBAL_DEF("input/ui_select", va);
+	input_presets.push_back("input/ui_select");
+
+	va = Array();
+	key.instance();
+	key->set_scancode(KEY_ENTER);
+	va.push_back(key);
+	key.instance();
+	key->set_scancode(KEY_KP_ENTER);
+	va.push_back(key);
+	key.instance();
+	key->set_scancode(KEY_SPACE);
+	va.push_back(key);
+	joyb.instance();
+	joyb->set_button_index(JOY_BUTTON_0);
+	va.push_back(joyb);
+	GLOBAL_DEF("input/ui_accept", va);
+	input_presets.push_back("input/ui_accept");
 
 	//GLOBAL_DEF("display/window/handheld/orientation", "landscape");
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -401,8 +401,7 @@ void ProjectSettingsEditor::_wait_for_key(const Ref<InputEvent> &p_event) {
 
 	if (k.is_valid() && k->get_scancode() != 0) {
 
-		if (k->is_pressed())
-		{
+		if (k->is_pressed()) {
 			last_wait_for_key = p_event;
 			String str = keycode_get_string(k->get_scancode()).capitalize();
 			if (k->get_metakey())
@@ -416,9 +415,7 @@ void ProjectSettingsEditor::_wait_for_key(const Ref<InputEvent> &p_event) {
 
 			press_a_key_label->set_text(str);
 			press_a_key->accept_event();
-		}
-		else
-		{
+		} else {
 			press_a_key->hide();
 			_press_a_key_confirm();
 		}
@@ -671,7 +668,7 @@ void ProjectSettingsEditor::_update_actions() {
 	List<PropertyInfo> props;
 	ProjectSettings::get_singleton()->get_property_list(&props);
 
-	for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
+	for (List<PropertyInfo>::Element *E = props.back(); E; E = E->prev()) {
 
 		const PropertyInfo &pi = E->get();
 		if (!pi.name.begins_with("input/"))
@@ -956,7 +953,7 @@ void ProjectSettingsEditor::_action_add() {
 	if (!r)
 		return;
 	r->select(0);
-	input_editor->ensure_cursor_is_visible();
+	input_editor->scroll_to_item(input_editor->get_root());
 	action_add_error->hide();
 	action_name->clear();
 }

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -399,21 +399,29 @@ void ProjectSettingsEditor::_wait_for_key(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventKey> k = p_event;
 
-	if (k.is_valid() && k->is_pressed() && k->get_scancode() != 0) {
+	if (k.is_valid() && k->get_scancode() != 0) {
 
-		last_wait_for_key = p_event;
-		String str = keycode_get_string(k->get_scancode()).capitalize();
-		if (k->get_metakey())
-			str = vformat("%s+", find_keycode_name(KEY_META)) + str;
-		if (k->get_shift())
-			str = TTR("Shift+") + str;
-		if (k->get_alt())
-			str = TTR("Alt+") + str;
-		if (k->get_control())
-			str = TTR("Control+") + str;
+		if (k->is_pressed())
+		{
+			last_wait_for_key = p_event;
+			String str = keycode_get_string(k->get_scancode()).capitalize();
+			if (k->get_metakey())
+				str = vformat("%s+", find_keycode_name(KEY_META)) + str;
+			if (k->get_shift())
+				str = TTR("Shift+") + str;
+			if (k->get_alt())
+				str = TTR("Alt+") + str;
+			if (k->get_control())
+				str = TTR("Control+") + str;
 
-		press_a_key_label->set_text(str);
-		press_a_key->accept_event();
+			press_a_key_label->set_text(str);
+			press_a_key->accept_event();
+		}
+		else
+		{
+			press_a_key->hide();
+			_press_a_key_confirm();
+		}
 	}
 }
 


### PR DESCRIPTION
1) Automatically close the _Press a key_ dialog when releasing the key. This makes adding many key events more streamlined, as you don't need to move the cursor back and forth between the OK button and the add button all the time.
2) Sort actions in reverse order (newest first). This is partly because of the same reason as above; the controls to add new actions are at the top of the window, so putting the new actions near the top too means less superfluous mouse movement (especially when adding many actions and their events at the same time). Additionally, you're generally more interested in editing your newly added actions than the oldest ones or the default ui_* actions, so it makes sense to allow that without having to scroll down.