### PR TITLE
Consistently save index for less VCS noise

### DIFF
--- a/scene/resources/scene_format_text.cpp
+++ b/scene/resources/scene_format_text.cpp
@@ -1643,8 +1643,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_r
 			}
 			if (index >= 0) {
 				header += " index=\"" + itos(index) + "\"";
-			}
-			else {
+			} else {
 				header += " index=\"0\"";
 			}
 

--- a/scene/resources/scene_format_text.cpp
+++ b/scene/resources/scene_format_text.cpp
@@ -1644,6 +1644,9 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_r
 			if (index >= 0) {
 				header += " index=\"" + itos(index) + "\"";
 			}
+			else {
+				header += " index=\"0\"";
+			}
 
 			if (groups.size()) {
 				String sgroups = " groups=[\n";


### PR DESCRIPTION
Kinda-solves the issue where index=0 was being randomly added/removed when saving tscn files, an annoying problem for anyone working with version control.

All this does is force index=0 when it otherwise wouldn't have been saved. There's likely a deeper, more involved solution that I couldn't wrap my brain around. But this gets the job done I guess.