### PR TITLE
Correct test list returned by test_get_names

### DIFF
--- a/main/tests/test_main.cpp
+++ b/main/tests/test_main.cpp
@@ -50,15 +50,20 @@ const char **tests_get_names() {
 
 	static const char *test_names[] = {
 		"string",
-		"containers",
 		"math",
+		"physics",
+		"physics_2d",
 		"render",
-		"multimesh",
+		"oa_hash_map",
 		"gui",
 		"io",
 		"shaderlang",
-		"physics",
-		"oa_hash_map",
+		"gd_tokenizer",
+		"gd_parser",
+		"gd_compiler",
+		"gd_bytecode",
+		"image",
+		"ordered_hash_map",
 		NULL
 	};
 


### PR DESCRIPTION
This list is used in when calling `godot --help`, so better not to display misleading info ;-)