### PR TITLE
Added support for 16-bit gray PNG, Image and Texture

### DIFF
--- a/core/image.h
+++ b/core/image.h
@@ -66,9 +66,11 @@ public:
 		FORMAT_R8,
 		FORMAT_RG8,
 		FORMAT_RGB8,
-		FORMAT_RGBA8,
+		FORMAT_RGBA8, // beware, it's also used as separator for non-byte formats
+
 		FORMAT_RGBA4444,
 		FORMAT_RGBA5551,
+		FORMAT_R16, //16-bit integer
 		FORMAT_RF, //float
 		FORMAT_RGF,
 		FORMAT_RGBF,
@@ -78,6 +80,7 @@ public:
 		FORMAT_RGBH,
 		FORMAT_RGBAH,
 		FORMAT_RGBE9995,
+
 		FORMAT_DXT1, //s3tc bc1
 		FORMAT_DXT3, //bc2
 		FORMAT_DXT5, //bc3
@@ -267,6 +270,8 @@ public:
 
 	static int get_image_data_size(int p_width, int p_height, Format p_format, int p_mipmaps = 0);
 	static int get_image_required_mipmaps(int p_width, int p_height, Format p_format);
+
+	static bool is_compressed_format(Format format);
 
 	enum CompressMode {
 		COMPRESS_S3TC,

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -97,6 +97,13 @@ Ref<Image> RasterizerStorageGLES2::_get_gl_image_and_format(const Ref<Image> &p_
 			r_gl_type = GL_UNSIGNED_SHORT_5_5_5_1;
 
 		} break;
+		case Image::FORMAT_R16: {
+
+			r_gl_internal_format = GL_R16;
+			r_gl_format = GL_RED;
+			r_gl_type = GL_UNSIGNED_SHORT;
+
+		} break;
 		case Image::FORMAT_RF: {
 			ERR_EXPLAIN("R float texture not supported");
 			ERR_FAIL_V(image);

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -195,6 +195,13 @@ Ref<Image> RasterizerStorageGLES3::_get_gl_image_and_format(const Ref<Image> &p_
 			r_gl_type = GL_UNSIGNED_SHORT_5_5_5_1;
 
 		} break;
+		case Image::FORMAT_R16: {
+
+			r_gl_internal_format = GL_R16;
+			r_gl_format = GL_RED;
+			r_gl_type = GL_UNSIGNED_SHORT;
+
+		} break;
 		case Image::FORMAT_RF: {
 
 			r_gl_internal_format = GL_R32F;


### PR DESCRIPTION
This adds support for `Image.FORMAT_R16`, which stores one channel as 16-bit integers.
They can be saved or loaded as 16-bit gray PNG (based a little on #19391).
They can also be rendered as textures using the `GL_R16` internal format.

The use case for such textures are high-precision depth maps, or height maps for making terrains with a better precision than the `RH` format (half-precision float) while keeping the same memory footprint. It can also allow to directly use maps produced by other software such as WorldMachine, or Gimp.

Notes:
- I initially wanted the format to be `L16` with `GL_LUMINANCE16`. While textures were correctly uploading, it was rendering as black and I couldn't find why. Using `GL_R16` worked so that's why I used it.
- Previews show up as black and white, I'm not sure why. They will normally render as red if used as is on a sprite.
- It looks like `GL_R16` isn't recognized by compilers for Android and iOS :( are they misconfigured or is it really not supported at all there? Or maybe another format has to be picked? `GL_R16UI` appears to be in common but does it mean shaders will need to sample that as an ushort and normalize themselves?