### PR TITLE
Added Solarized Dark and Light themes

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -314,7 +314,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("interface/editor/quit_confirmation", true);
 
 	_initial_set("interface/theme/preset", 0);
-	hints["interface/theme/preset"] = PropertyInfo(Variant::INT, "interface/theme/preset", PROPERTY_HINT_ENUM, "Default,Grey,Godot 2,Arc,Light,Alien,Custom", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
+	hints["interface/theme/preset"] = PropertyInfo(Variant::INT, "interface/theme/preset", PROPERTY_HINT_ENUM, "Default,Custom,Grey,Godot 2,Arc,Light,Alien,Solarized (Dark),Solarized (Light)", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/theme/icon_and_font_color", 0);
 	hints["interface/theme/icon_and_font_color"] = PropertyInfo(Variant::INT, "interface/theme/icon_and_font_color", PROPERTY_HINT_ENUM, "Auto,Dark,Light", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/theme/base_color", Color::html("#323b4f"));

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -272,39 +272,49 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 			preset_base_color = Color::html("#323b4f");
 			preset_contrast = default_contrast;
 		} break;
-		case 1: { // Grey
+		case 1: { // Custom
+			accent_color = EDITOR_DEF("interface/theme/accent_color", Color::html("#699ce8"));
+			base_color = EDITOR_DEF("interface/theme/base_color", Color::html("#323b4f"));
+			contrast = EDITOR_DEF("interface/theme/contrast", default_contrast);
+		} break;
+		case 2: { // Grey
 			preset_accent_color = Color::html("#b8e4ff");
 			preset_base_color = Color::html("#3d3d3d");
 			preset_contrast = 0.2;
 		} break;
-		case 2: { // Godot 2
+		case 3: { // Godot 2
 			preset_accent_color = Color::html("#86ace2");
 			preset_base_color = Color::html("#3C3A44");
 			preset_contrast = 0.25;
 		} break;
-		case 3: { // Arc
+		case 4: { // Arc
 			preset_accent_color = Color::html("#5294e2");
 			preset_base_color = Color::html("#383c4a");
 			preset_contrast = 0.25;
 		} break;
-		case 4: { // Light
+		case 5: { // Light
 			preset_accent_color = Color::html("#2070ff");
 			preset_base_color = Color::html("#ffffff");
 			preset_contrast = 0.08;
 		} break;
-		case 5: { // Alien
+		case 6: { // Alien
 			preset_accent_color = Color::html("#1bfe99");
 			preset_base_color = Color::html("#2f373f");
 			preset_contrast = 0.25;
-		}
-		default: { // Custom
-			accent_color = EDITOR_DEF("interface/theme/accent_color", Color::html("#699ce8"));
-			base_color = EDITOR_DEF("interface/theme/base_color", Color::html("#323b4f"));
-			contrast = EDITOR_DEF("interface/theme/contrast", default_contrast);
-		}
+		} break;
+		case 7: { // Solarized (Dark)
+			preset_accent_color = Color::html("#268bd2");
+			preset_base_color = Color::html("#002b36");
+			preset_contrast = 0.2;
+		} break;
+		case 8: { // Solarized (Light)
+			preset_accent_color = Color::html("#268bd2");
+			preset_base_color = Color::html("#fdf6e3");
+			preset_contrast = 0.06;
+		} break;
 	}
 
-	if (preset != 6) {
+	if (preset != 1) {
 		accent_color = preset_accent_color;
 		base_color = preset_base_color;
 		contrast = preset_contrast;
@@ -1050,7 +1060,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Color function_definition_color = Color::html(dark_theme ? "#01e1ff" : "#00a5ba");
 	const Color node_path_color = Color::html(dark_theme ? "64c15a" : "#518b4b");
 
-	const Color te_background_color = dark_theme ? background_color : Color::html("#ffffff");
+	const Color te_background_color = dark_theme ? background_color : base_color;
 	const Color completion_background_color = base_color;
 	const Color completion_selected_color = alpha1;
 	const Color completion_existing_color = alpha2;

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -61,7 +61,7 @@ void EditorSettingsDialog::_settings_property_edited(const String &p_name) {
 	if (full_name == "text_editor/theme/color_theme") {
 		property_editor->get_property_editor()->update_tree();
 	} else if (full_name == "interface/theme/accent_color" || full_name == "interface/theme/base_color" || full_name == "interface/theme/contrast") {
-		EditorSettings::get_singleton()->set_manually("interface/theme/preset", 6); // set preset to Custom
+		EditorSettings::get_singleton()->set_manually("interface/theme/preset", 1); // set preset to Custom
 	} else if (full_name.begins_with("text_editor/highlighting")) {
 		EditorSettings::get_singleton()->set_manually("text_editor/theme/color_theme", "Custom");
 	}


### PR DESCRIPTION
I decided to add these themes to editor... I tried to follow these instructions(https://adrien.is/configuring-solarized-colors/), I think Solarized Light is not a bad addition(now 2 light themes are exist)

**Solarized (Dark)** 
![s1](https://user-images.githubusercontent.com/3036176/41272795-55345e5a-6e1f-11e8-9de1-7613094394b2.jpg)

**Solarized (Light)**
![image](https://user-images.githubusercontent.com/3036176/41276636-804930f8-6e2d-11e8-868b-3c973079fce5.png)





