### PR TITLE
Fixed regression making the logger not respect the max files limit

### DIFF
--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -112,7 +112,7 @@ void RotatedFileLogger::clear_old_backups() {
 	int max_backups = max_files - 1; // -1 for the current file
 
 	String basename = base_path.get_file().get_basename();
-	String extension = "." + base_path.get_extension();
+	String extension = base_path.get_extension();
 
 	DirAccess *da = DirAccess::open(base_path.get_base_dir());
 	if (!da) {
@@ -123,7 +123,7 @@ void RotatedFileLogger::clear_old_backups() {
 	String f = da->get_next();
 	Set<String> backups;
 	while (f != String()) {
-		if (!da->current_is_dir() && f.begins_with(basename) && f.ends_with(extension) && f != base_path.get_file()) {
+		if (!da->current_is_dir() && f.begins_with(basename) && f.get_extension() == extension && f != base_path.get_file()) {
 			backups.insert(f);
 		}
 		f = da->get_next();


### PR DESCRIPTION
Regression caused by me (#19261). Oops.

I forgot to make this part of the code also check for files without an extension.