### PR TITLE
Add support for tutorial links to makerst.py

### DIFF
--- a/doc/classes/AABB.xml
+++ b/doc/classes/AABB.xml
@@ -7,7 +7,7 @@
 		AABB consists of a position, a size, and several utility functions. It is typically used for fast overlap tests.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/math/index.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/math/index.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -8,7 +8,7 @@
 		Animations are just data containers, and must be added to odes such as an [AnimationPlayer] or [AnimationTreePlayer] to be played back.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/animation/index.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/animation/index.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -7,8 +7,8 @@
 		An animation player is used for general purpose playback of [Animation] resources. It contains a dictionary of animations (referenced by name) and custom blend times between their transitions. Additionally, animations can be played and blended in different channels.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/getting_started/step_by_step/animations.html
-		http://docs.godotengine.org/en/3.0/tutorials/animation/index.html
+		<link>http://docs.godotengine.org/en/3.0/getting_started/step_by_step/animations.html</link>
+		<link>http://docs.godotengine.org/en/3.0/tutorials/animation/index.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -7,7 +7,7 @@
 		AudioServer is a low level server interface for audio access. It is in charge of creating sample data (playable audio) as well as its playback via a voice interface.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/audio/audio_buses.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/AudioStream.xml
+++ b/doc/classes/AudioStream.xml
@@ -7,7 +7,7 @@
 		Base class for audio streams. Audio streams are used for music playback, or other types of streamed sounds that don't fit or require more flexibility than a [Sample].
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/audio/audio_streams.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/audio/audio_streams.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -7,8 +7,8 @@
 		Plays background audio.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/latest/learning/features/audio/index.html
-		http://docs.godotengine.org/en/3.0/tutorials/audio/audio_streams.html
+		<link>http://docs.godotengine.org/en/latest/learning/features/audio/index.html</link>
+		<link>http://docs.godotengine.org/en/3.0/tutorials/audio/audio_streams.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -7,8 +7,8 @@
 		Plays audio that dampens with distance from screen center.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/latest/learning/features/audio/index.html
-		http://docs.godotengine.org/en/3.0/tutorials/audio/audio_streams.html
+		<link>http://docs.godotengine.org/en/latest/learning/features/audio/index.html</link>
+		<link>http://docs.godotengine.org/en/3.0/tutorials/audio/audio_streams.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -7,8 +7,8 @@
 		Plays a sound effect with directed sound effects, dampens with distance if needed, generates effect of hearable position in space.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/latest/learning/features/audio/index.html
-		http://docs.godotengine.org/en/3.0/tutorials/audio/audio_streams.html
+		<link>http://docs.godotengine.org/en/latest/learning/features/audio/index.html</link>
+		<link>http://docs.godotengine.org/en/3.0/tutorials/audio/audio_streams.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/BakedLightmap.xml
+++ b/doc/classes/BakedLightmap.xml
@@ -5,7 +5,7 @@
 	<description>
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/3d/baked_lightmaps.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/3d/baked_lightmaps.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -8,8 +8,8 @@
 		For such use, it is composed of a scaling and a rotation matrix, in that order (M = R.S).
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/latest/tutorials/3d/using_transforms.html
-		http://docs.godotengine.org/en/latest/tutorials/math/rotations.html
+		<link>http://docs.godotengine.org/en/latest/tutorials/3d/using_transforms.html</link>
+		<link>http://docs.godotengine.org/en/latest/tutorials/math/rotations.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -11,8 +11,8 @@
 		Ultimately, a transform notification can be requested, which will notify the node that its global position changed in case the parent tree changed.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/2d/2d_transforms.html
-	http://docs.godotengine.org/en/3.0/tutorials/2d/custom_drawing_in_2d.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/2d/2d_transforms.html</link>
+		<link>http://docs.godotengine.org/en/3.0/tutorials/2d/custom_drawing_in_2d.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/CanvasLayer.xml
+++ b/doc/classes/CanvasLayer.xml
@@ -7,8 +7,8 @@
 		Canvas drawing layer. [CanvasItem] nodes that are direct or indirect children of a [code]CanvasLayer[/code] will be drawn in that layer. The layer is a numeric index that defines the draw order. The default 2D scene renders with index 0, so a [code]CanvasLayer[/code] with index -1 will be drawn below, and one with index 1 will be drawn above. This is very useful for HUDs (in layer 1+ or above), or backgrounds (in layer -1 or below).
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/2d/2d_transforms.html
-	http://docs.godotengine.org/en/3.0/tutorials/2d/canvas_layers.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/2d/2d_transforms.html</link>
+		<link>http://docs.godotengine.org/en/3.0/tutorials/2d/canvas_layers.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/CollisionShape.xml
+++ b/doc/classes/CollisionShape.xml
@@ -7,7 +7,7 @@
 		Editor facility for creating and editing collision shapes in 3D space. You can use this node to represent all sorts of collision shapes, for example, add this to an [Area] to give it a detection shape, or add it to a [PhysicsBody] to create a solid object. [b]IMPORTANT[/b]: this is an Editor-only helper to create shapes, use [method get_shape] to get the actual shape.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/physics/physics_introduction.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/physics/physics_introduction.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/CollisionShape2D.xml
+++ b/doc/classes/CollisionShape2D.xml
@@ -7,7 +7,7 @@
 		Editor facility for creating and editing collision shapes in 2D space. You can use this node to represent all sorts of collision shapes, for example, add this to an [Area2D] to give it a detection shape, or add it to a [PhysicsBody2D] to create a solid object. [b]IMPORTANT[/b]: this is an Editor-only helper to create shapes, use [method get_shape] to get the actual shape.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/physics/physics_introduction.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/physics/physics_introduction.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -13,8 +13,8 @@
 		[Theme] resources change the Control's appearance. If you change the [Theme] on a [code]Control[/code] node, it affects all of its children. To override some of the theme's parameters, call one of the [code]add_*_override[/code] methods, like [method add_font_override]. You can override the theme with the inspector.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/gui/index.html
-		http://docs.godotengine.org/en/3.0/tutorials/2d/custom_drawing_in_2d.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/gui/index.html</link>
+		<link>http://docs.godotengine.org/en/3.0/tutorials/2d/custom_drawing_in_2d.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/DirectionalLight.xml
+++ b/doc/classes/DirectionalLight.xml
@@ -7,7 +7,7 @@
 		A DirectionalLight is a type of [Light] node that emits light constantly in one direction (the negative z axis of the node). It is used lights with strong intensity that are located far away from the scene to model sunlight or moonlight. The worldspace location of the DirectionalLight transform (origin) is ignored, only the basis is used do determine light direction.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/3d/lights_and_shadows.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/3d/lights_and_shadows.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Directory.xml
+++ b/doc/classes/Directory.xml
@@ -23,7 +23,7 @@
 		[/codeblock]
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/getting_started/step_by_step/filesystem.html
+		<link>http://docs.godotengine.org/en/3.0/getting_started/step_by_step/filesystem.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -7,7 +7,7 @@
 		Plugins are used by the editor to extend functionality. The most common types of plugins are those which edit a given node or resource type, import plugins and export plugins.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/development/plugins/index.html
+		<link>http://docs.godotengine.org/en/3.0/development/plugins/index.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -13,8 +13,8 @@
 		- Adjustments
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/3d/environment_and_post_processing.html
-		http://docs.godotengine.org/en/3.0/tutorials/3d/high_dynamic_range.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/3d/environment_and_post_processing.html</link>
+		<link>http://docs.godotengine.org/en/3.0/tutorials/3d/high_dynamic_range.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/File.xml
+++ b/doc/classes/File.xml
@@ -22,7 +22,7 @@
 		[/codeblock]
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/getting_started/step_by_step/filesystem.html
+		<link>http://docs.godotengine.org/en/3.0/getting_started/step_by_step/filesystem.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/GIProbe.xml
+++ b/doc/classes/GIProbe.xml
@@ -5,7 +5,7 @@
 	<description>
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/3d/gi_probes.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/3d/gi_probes.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -10,8 +10,8 @@
 		For more information on HTTP, see https://developer.mozilla.org/en-US/docs/Web/HTTP (or read RFC 2616 to get it straight from the source: https://tools.ietf.org/html/rfc2616).
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/networking/http_client_class.html
-	http://docs.godotengine.org/en/3.0/tutorials/networking/ssl_certificates.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/networking/http_client_class.html</link>
+		<link>http://docs.godotengine.org/en/3.0/tutorials/networking/ssl_certificates.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -8,7 +8,7 @@
 		Can be used to make HTTP requests, i.e. download or upload files or web content via HTTP.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/networking/ssl_certificates.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/networking/ssl_certificates.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -7,7 +7,7 @@
 		A Singleton that deals with inputs. This includes key presses, mouse buttons and movement, joypads, and input actions. Actions and their events can be set in the Project Settings / Input Map tab. Or be set with [InputMap].
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/inputs/index.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/inputs/index.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/InputEvent.xml
+++ b/doc/classes/InputEvent.xml
@@ -7,8 +7,8 @@
 		Base class of all sort of input event. See [method Node._input].
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/inputs/inputevent.html
-		http://docs.godotengine.org/en/3.0/tutorials/2d/2d_transforms.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/inputs/inputevent.html</link>
+		<link>http://docs.godotengine.org/en/3.0/tutorials/2d/2d_transforms.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/InputEventAction.xml
+++ b/doc/classes/InputEventAction.xml
@@ -7,7 +7,7 @@
 		Contains a generic action which can be targeted from several type of inputs. Actions can be created from the project settings menu [code]Project &gt; Project Settings &gt; Input Map[/code]. See [method Node._input].
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/inputs/inputevent.html#actions
+		<link>http://docs.godotengine.org/en/3.0/tutorials/inputs/inputevent.html#actions</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/InputEventJoypadButton.xml
+++ b/doc/classes/InputEventJoypadButton.xml
@@ -7,7 +7,7 @@
 		Input event type for gamepad buttons. For joysticks see [InputEventJoypadMotion].
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/inputs/inputevent.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/InputEventJoypadMotion.xml
+++ b/doc/classes/InputEventJoypadMotion.xml
@@ -7,7 +7,7 @@
 		Stores information about joystick motions. One [code]InputEventJoypadMotion[/code] represents one axis at a time.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/inputs/inputevent.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/InputEventKey.xml
+++ b/doc/classes/InputEventKey.xml
@@ -7,7 +7,7 @@
 		Stores key presses on the keyboard. Supports key presses, key releases and [member echo] events.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/inputs/inputevent.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/InputEventMouse.xml
+++ b/doc/classes/InputEventMouse.xml
@@ -7,7 +7,7 @@
 		Stores general mouse events information.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/inputs/inputevent.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/InputEventMouseButton.xml
+++ b/doc/classes/InputEventMouseButton.xml
@@ -7,7 +7,7 @@
 		Contains mouse click information. See [method Node._input].
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/inputs/mouse_and_input_coordinates.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/inputs/mouse_and_input_coordinates.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/InputEventMouseMotion.xml
+++ b/doc/classes/InputEventMouseMotion.xml
@@ -7,7 +7,7 @@
 		Contains mouse motion information. Supports relative, absolute positions and speed. See [method Node._input].
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/inputs/mouse_and_input_coordinates.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/inputs/mouse_and_input_coordinates.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/InputEventScreenDrag.xml
+++ b/doc/classes/InputEventScreenDrag.xml
@@ -8,7 +8,7 @@
 		Contains screen drag information. See [method Node._input].
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/inputs/inputevent.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/InputEventScreenTouch.xml
+++ b/doc/classes/InputEventScreenTouch.xml
@@ -8,7 +8,7 @@
 		Stores multi-touch press/release information. Supports touch press, touch release and [member index] for multi-touch count and order.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/inputs/inputevent.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/InputEventWithModifiers.xml
+++ b/doc/classes/InputEventWithModifiers.xml
@@ -7,7 +7,7 @@
 		Contains keys events information with modifiers support like [code]SHIFT[/code] or [code]ALT[/code]. See [method Node._input].
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/inputs/inputevent.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/InputMap.xml
+++ b/doc/classes/InputMap.xml
@@ -7,7 +7,7 @@
 		Manages all [InputEventAction] which can be created/modified from the project settings menu [code]Project &gt; Project Settings &gt; Input Map[/code] or in code with [method add_action] and [method action_add_event]. See [method Node._input].
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/inputs/inputevent.html#inputmap
+		<link>http://docs.godotengine.org/en/3.0/tutorials/inputs/inputevent.html#inputmap</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/JavaScript.xml
+++ b/doc/classes/JavaScript.xml
@@ -7,7 +7,7 @@
 		The JavaScript singleton is implemented only in HTML5 export. It's used to access the browser's JavaScript context. This allows interaction with embedding pages or calling third-party JavaScript APIs.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/getting_started/workflow/export/exporting_for_web.html#calling-javascript-from-script
+		<link>http://docs.godotengine.org/en/3.0/getting_started/workflow/export/exporting_for_web.html#calling-javascript-from-script</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/KinematicBody.xml
+++ b/doc/classes/KinematicBody.xml
@@ -9,7 +9,7 @@
 		Kinematic Characters: KinematicBody also has an API for moving objects (the [method move_and_collide] and [method move_and_slide] methods) while performing collision tests. This makes them really useful to implement characters that collide against a world, but that don't require advanced physics.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/physics/kinematic_character_2d.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/physics/kinematic_character_2d.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Light.xml
+++ b/doc/classes/Light.xml
@@ -7,7 +7,7 @@
 		Light is the abstract base class for light nodes, so it shouldn't be used directly (It can't be instanced). Other types of light nodes inherit from it. Light contains the common variables and parameters used for lighting.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/3d/lights_and_shadows.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/3d/lights_and_shadows.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/NetworkedMultiplayerPeer.xml
+++ b/doc/classes/NetworkedMultiplayerPeer.xml
@@ -7,7 +7,7 @@
 		Manages the connection to network peers. Assigns unique IDs to each client connected to the server.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/networking/high_level_multiplayer.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/networking/high_level_multiplayer.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -17,7 +17,7 @@
 		[b]Networking with nodes:[/b] After connecting to a server (or making one, see [NetworkedMultiplayerENet]) it is possible to use the built-in RPC (remote procedure call) system to communicate over the network. By calling [method rpc] with a method name, it will be called locally and in all connected peers (peers = clients and the server that accepts connections). To identify which node receives the RPC call Godot will use its [NodePath] (make sure node names are the same on all peers). Also take a look at the high-level networking tutorial and corresponding demos.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/getting_started/step_by_step/scenes_and_nodes.html
+		<link>http://docs.godotengine.org/en/3.0/getting_started/step_by_step/scenes_and_nodes.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Node2D.xml
+++ b/doc/classes/Node2D.xml
@@ -7,7 +7,7 @@
 		A 2D game object, with a position, rotation and scale. All 2D physics nodes and sprites inherit from Node2D. Use Node2D as a parent node to move, scale and rotate children in a 2D project. Also gives control on the node's render order.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/2d/custom_drawing_in_2d.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/2d/custom_drawing_in_2d.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -16,7 +16,7 @@
 	</demos>
 	<methods>
 		<method name="_get" qualifiers="virtual">
-			<return type="void">
+			<return type="Variant">
 			</return>
 			<argument index="0" name="property" type="String">
 			</argument>

--- a/doc/classes/OmniLight.xml
+++ b/doc/classes/OmniLight.xml
@@ -7,7 +7,7 @@
 		An OmniDirectional light is a type of [Light] node that emits lights in all directions. The light is attenuated through the distance and this attenuation can be configured by changing the energy, radius and attenuation parameters of [Light].
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/3d/lights_and_shadows.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/3d/lights_and_shadows.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Physics2DDirectSpaceState.xml
+++ b/doc/classes/Physics2DDirectSpaceState.xml
@@ -7,7 +7,7 @@
 		Direct access object to a space in the [Physics2DServer]. It's used mainly to do queries against objects and areas residing in a given space.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/physics/ray-casting.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/physics/ray-casting.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/PhysicsBody.xml
+++ b/doc/classes/PhysicsBody.xml
@@ -7,7 +7,7 @@
 		PhysicsBody is an abstract base class for implementing a physics body. All *Body types inherit from it.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/physics/physics_introduction.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/physics/physics_introduction.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/PhysicsBody2D.xml
+++ b/doc/classes/PhysicsBody2D.xml
@@ -7,7 +7,7 @@
 		PhysicsBody2D is an abstract base class for implementing a physics body. All *Body2D types inherit from it.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/physics/physics_introduction.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/physics/physics_introduction.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/PhysicsDirectSpaceState.xml
+++ b/doc/classes/PhysicsDirectSpaceState.xml
@@ -7,7 +7,7 @@
 		Direct access object to a space in the [PhysicsServer]. It's used mainly to do queries against objects and areas residing in a given space.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/physics/ray-casting.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/physics/ray-casting.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Plane.xml
+++ b/doc/classes/Plane.xml
@@ -7,7 +7,7 @@
 		Plane represents a normalized plane equation. Basically, "normal" is the normal of the plane (a,b,c normalized), and "d" is the distance from the origin to the plane (in the direction of "normal"). "Over" or "Above" the plane is considered the side of the plane towards where the normal is pointing.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/math/index.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/math/index.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Quat.xml
+++ b/doc/classes/Quat.xml
@@ -10,8 +10,8 @@
 		Quaternions need to be (re)normalized.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/latest/tutorials/3d/using_transforms.html#interpolating-with-quaternions
-		http://docs.godotengine.org/en/latest/tutorials/math/rotations.html
+		<link>http://docs.godotengine.org/en/latest/tutorials/3d/using_transforms.html#interpolating-with-quaternions</link>
+		<link>http://docs.godotengine.org/en/latest/tutorials/math/rotations.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -7,7 +7,7 @@
 		Rect2 consists of a position, a size, and several utility functions. It is typically used for fast overlap tests.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/math/index.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/math/index.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/ReflectionProbe.xml
+++ b/doc/classes/ReflectionProbe.xml
@@ -5,7 +5,7 @@
 	<description>
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/3d/reflection_probes.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/3d/reflection_probes.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -8,7 +8,7 @@
 		Note that assignments to [member bbcode_text] clear the tag stack and reconstruct it from the property's contents. Any edits made to [member bbcode_text] will erase previous edits made from other manual sources such as [method append_bbcode] and the [code]push_*[/code] / [method pop] methods.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/gui/bbcode_in_richtextlabel.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/gui/bbcode_in_richtextlabel.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/RigidBody.xml
+++ b/doc/classes/RigidBody.xml
@@ -10,7 +10,7 @@
 		If you need to override the default physics behavior, you can write a custom force integration. See [member custom_integrator].
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/physics/physics_introduction.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/physics/physics_introduction.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -7,8 +7,8 @@
 		As one of the most important classes, the [code]SceneTree[/code] manages the hierarchy of nodes in a scene as well as scenes themselves. Nodes can be added, retrieved and removed. The whole scene tree (and thus the current scene) can be paused. Scenes can be loaded, switched and reloaded. You can also use the SceneTree to organize your nodes into groups: every node can be assigned as many groups as you want to create, e.g. a "enemy" group. You can then iterate these groups or even call methods and set properties on all the group's members at once.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/getting_started/step_by_step/scene_tree.html
-		http://docs.godotengine.org/en/3.0/tutorials/viewports/multiple_resolutions.html
+		<link>http://docs.godotengine.org/en/3.0/getting_started/step_by_step/scene_tree.html</link>
+		<link>http://docs.godotengine.org/en/3.0/tutorials/viewports/multiple_resolutions.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -8,7 +8,7 @@
 		The 'new' method of a script subclass creates a new instance. [method Object.set_script] extends an existing object, if that object's class matches one of the script's base classes.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/getting_started/step_by_step/scripting.html
+		<link>http://docs.godotengine.org/en/3.0/getting_started/step_by_step/scripting.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Shader.xml
+++ b/doc/classes/Shader.xml
@@ -7,7 +7,7 @@
 		This class allows you to define a custom shader program that can be used for various materials to render objects.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/shading/index.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/shading/index.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Shape.xml
+++ b/doc/classes/Shape.xml
@@ -7,7 +7,7 @@
 		Base class for all 3D shape resources. All 3D shapes that inherit from this can be set into a [PhysicsBody] or [Area].
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/physics/physics_introduction.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/physics/physics_introduction.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Shape2D.xml
+++ b/doc/classes/Shape2D.xml
@@ -7,7 +7,7 @@
 		Base class for all 2D Shapes. All 2D shape types inherit from this.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/physics/physics_introduction.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/physics/physics_introduction.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Spatial.xml
+++ b/doc/classes/Spatial.xml
@@ -9,7 +9,7 @@
 		Affine operations (rotate, scale, translate) happen in parent's local coordinate system, unless the Spatial object is set as top level. Affine operations in this coordinate system correspond to direct affine operations on the Spatial's transform. The word local below refers to this coordinate system. The coordinate system that is attached to the Spatial object itself is referred to as object-local coordinate system.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/3d/introduction_to_3d.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/3d/introduction_to_3d.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/SpatialMaterial.xml
+++ b/doc/classes/SpatialMaterial.xml
@@ -5,7 +5,7 @@
 	<description>
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/3d/spatial_material.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/3d/spatial_material.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/SpotLight.xml
+++ b/doc/classes/SpotLight.xml
@@ -7,7 +7,7 @@
 		A SpotLight light is a type of [Light] node that emits lights in a specific direction, in the shape of a cone. The light is attenuated through the distance and this attenuation can be configured by changing the energy, radius and attenuation parameters of [Light]. TODO: Image of a spotlight.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/3d/lights_and_shadows.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/3d/lights_and_shadows.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/StreamPeerSSL.xml
+++ b/doc/classes/StreamPeerSSL.xml
@@ -7,7 +7,7 @@
 		SSL Stream peer. This object can be used to connect to SSL servers.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/networking/ssl_certificates.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/networking/ssl_certificates.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -7,7 +7,7 @@
 		Node for 2D tile-based maps. Tilemaps use a [TileSet] which contain a list of tiles (textures plus optional collision, navigation, and/or occluder shapes) which are used to create grid-based maps.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/2d/using_tilemaps.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/2d/using_tilemaps.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Transform.xml
+++ b/doc/classes/Transform.xml
@@ -7,8 +7,8 @@
 		Represents one or many transformations in 3D space such as translation, rotation, or scaling. It consists of a [Basis] "basis" and an [Vector3] "origin". It is similar to a 3x4 matrix.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/math/index.html
-		http://docs.godotengine.org/en/latest/tutorials/3d/using_transforms.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/math/index.html</link>
+		<link>http://docs.godotengine.org/en/latest/tutorials/3d/using_transforms.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -7,7 +7,7 @@
 		2-element structure that can be used to represent positions in 2d space or any other pair of numeric values.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/math/index.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/math/index.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -7,7 +7,7 @@
 		Vector3 is one of the core classes of the engine, and includes several built-in helper functions to perform basic vector math operations.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/math/index.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/math/index.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -12,8 +12,8 @@
 		Finally, viewports can also behave as render targets, in which case they will not be visible unless the associated texture is used to draw.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/2d/2d_transforms.html
-	http://docs.godotengine.org/en/3.0/tutorials/viewports/index.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/2d/2d_transforms.html</link>
+		<link>http://docs.godotengine.org/en/3.0/tutorials/viewports/index.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/World.xml
+++ b/doc/classes/World.xml
@@ -7,7 +7,7 @@
 		Class that has everything pertaining to a world. A physics space, a visual scenario and a sound space. Spatial nodes register their resources into the current world.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/physics/ray-casting.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/physics/ray-casting.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/World2D.xml
+++ b/doc/classes/World2D.xml
@@ -7,7 +7,7 @@
 		Class that has everything pertaining to a 2D world. A physics space, a visual scenario and a sound space. 2D nodes register their resources into the current 2D world.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/physics/ray-casting.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/physics/ray-casting.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/doc/classes/WorldEnvironment.xml
+++ b/doc/classes/WorldEnvironment.xml
@@ -9,7 +9,7 @@
 		The [code]WorldEnvironment[/code] allows the user to specify default lighting parameters (e.g. ambient lighting), various post-processing effects (e.g. SSAO, DOF, Tonemapping), and how to draw the background (e.g. solid color, skybox). Usually, these are added in order to improve the realism/color balance of the scene.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/3d/environment_and_post_processing.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/3d/environment_and_post_processing.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/editor/doc/doc_data.cpp
+++ b/editor/doc/doc_data.cpp
@@ -810,9 +810,24 @@ Error DocData::_load(Ref<XMLParser> parser) {
 					if (parser->get_node_type() == XMLParser::NODE_TEXT)
 						c.description = parser->get_node_data();
 				} else if (name == "tutorials") {
-					parser->read();
-					if (parser->get_node_type() == XMLParser::NODE_TEXT)
-						c.tutorials = parser->get_node_data();
+					while (parser->read() == OK) {
+
+						if (parser->get_node_type() == XMLParser::NODE_ELEMENT) {
+
+							String name = parser->get_node_name();
+
+							if (name == "link") {
+
+								parser->read();
+								if (parser->get_node_type() == XMLParser::NODE_TEXT)
+									c.tutorials.push_back(parser->get_node_data().strip_edges());
+							} else {
+								ERR_EXPLAIN("Invalid tag in doc file: " + name);
+								ERR_FAIL_V(ERR_FILE_CORRUPT);
+							}
+						} else if (parser->get_node_type() == XMLParser::NODE_ELEMENT_END && parser->get_node_name() == "tutorials")
+							break; //end of <tutorials>
+					}
 				} else if (name == "demos") {
 					parser->read();
 					if (parser->get_node_type() == XMLParser::NODE_TEXT)
@@ -987,7 +1002,9 @@ Error DocData::save_classes(const String &p_default_path, const Map<String, Stri
 		_write_string(f, 2, c.description.strip_edges().xml_escape());
 		_write_string(f, 1, "</description>");
 		_write_string(f, 1, "<tutorials>");
-		_write_string(f, 2, c.tutorials.strip_edges().xml_escape());
+		for (int i = 0; i < c.tutorials.size(); i++) {
+			_write_string(f, 2, "<link>" + c.tutorials.get(i).xml_escape() + "</link>");
+		}
 		_write_string(f, 1, "</tutorials>");
 		_write_string(f, 1, "<demos>");
 		_write_string(f, 2, c.demos.strip_edges().xml_escape());

--- a/editor/doc/doc_data.h
+++ b/editor/doc/doc_data.h
@@ -85,7 +85,7 @@ public:
 		String category;
 		String brief_description;
 		String description;
-		String tutorials;
+		Vector<String> tutorials;
 		String demos;
 		Vector<MethodDoc> methods;
 		Vector<MethodDoc> signals;

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1280,11 +1280,10 @@ Error EditorHelp::_goto_desc(const String &p_class, int p_vscr) {
 		class_desc->add_newline();
 		//	class_desc->add_newline();
 
-		Vector<String> tutorials = cd.tutorials.split_spaces();
-		if (tutorials.size() != 0) {
+		if (cd.tutorials.size() != 0) {
 
-			for (int i = 0; i < tutorials.size(); i++) {
-				String link = tutorials[i];
+			for (int i = 0; i < cd.tutorials.size(); i++) {
+				String link = cd.tutorials[i];
 				String linktxt = link;
 				int seppos = linktxt.find("//");
 				if (seppos != -1) {

--- a/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
+++ b/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
@@ -7,8 +7,8 @@
 		A PacketPeer implementation that should be passed to [method SceneTree.set_network_peer] after being initialized as either a client or server. Events can then be handled by connecting to [SceneTree] signals.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/networking/high_level_multiplayer.html
-		http://enet.bespin.org/usergroup0.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/networking/high_level_multiplayer.html</link>
+		<link>http://enet.bespin.org/usergroup0.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/modules/gdscript/doc_classes/GDScript.xml
+++ b/modules/gdscript/doc_classes/GDScript.xml
@@ -8,7 +8,7 @@
 		[method new] creates a new instance of the script. [method Object.set_script] extends an existing object, if that object's class matches one of the script's base classes.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/getting_started/scripting/gdscript/index.html
+		<link>http://docs.godotengine.org/en/3.0/getting_started/scripting/gdscript/index.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -10,7 +10,7 @@
 		A GridMap is split into a sparse collection of octants for efficient rendering and physics processing. Every octant has the same dimensions and can contain several cells.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/tutorials/3d/using_gridmaps.html
+		<link>http://docs.godotengine.org/en/3.0/tutorials/3d/using_gridmaps.html</link>
 	</tutorials>
 	<demos>
 	</demos>

--- a/modules/visual_script/doc_classes/VisualScript.xml
+++ b/modules/visual_script/doc_classes/VisualScript.xml
@@ -9,7 +9,7 @@
 		You are most likely to use this class via the Visual Script editor or when writing plugins for it.
 	</description>
 	<tutorials>
-		http://docs.godotengine.org/en/3.0/getting_started/scripting/visual_script/index.html
+		<link>http://docs.godotengine.org/en/3.0/getting_started/scripting/visual_script/index.html</link>
 	</tutorials>
 	<demos>
 	</demos>


### PR DESCRIPTION
Resolves #19495, where the `<tutorials>` in class documentation were unused for online docs. The Tutorials section is inserted after the long description and before the method descriptions, similar to how the C++ class editor help is generated.

The changes to `makerst.py` also try to convert absolute `http://` tutorial URLs to Sphinx `:doc:` links, which a) makes the tutorial links point to the version of the same language, and b) shows a nice title instead of an URL.

Example for an internal and an external link: 

![grafik](https://user-images.githubusercontent.com/14299449/41302001-a91af354-6e69-11e8-850e-6e68deb981b2.png)

Generated rst:

    - :doc:`../tutorials/networking/high_level_multiplayer`
    - `http://enet.bespin.org/usergroup0.html <http://enet.bespin.org/usergroup0.html>`_

Example for an internal link with fragment identifier:

![grafik](https://user-images.githubusercontent.com/14299449/41302284-643ac24a-6e6a-11e8-825f-e0f02037e399.png)

Generated rst:

    - `#calling-javascript-from-script <../getting_started/workflow/export/exporting_for_web.html#calling-javascript-from-script>`_ in :doc:`../getting_started/workflow/export/exporting_for_web`

Fragment identifiers are a bit weird right now, because they'll always be named after the english header title. A `:ref:` would be ideal, but everytime someone wants to refer to a subsection, they'd have to make changes to `godot-docs` and create a new label there first, which in turn breaks existing urls because the fragment identifier now uses the label etc... I can add optional support for a `ref` attribute in `<link>` if support for `:ref:`s is desired.