### PR TITLE
Make LineEdit IME position hook ignore placeholder text

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -610,7 +610,8 @@ void LineEdit::_notification(int p_what) {
 			}
 
 			int x_ofs = 0;
-			int cached_text_width = text.empty() ? cached_placeholder_width : cached_width;
+			bool using_placeholder = text.empty();
+			int cached_text_width = using_placeholder ? cached_placeholder_width : cached_width;
 
 			switch (align) {
 
@@ -645,9 +646,9 @@ void LineEdit::_notification(int p_what) {
 			Color font_color_selected = get_color("font_color_selected");
 			Color cursor_color = get_color("cursor_color");
 
-			const String &t = text.empty() ? placeholder : text;
+			const String &t = using_placeholder ? placeholder : text;
 			// draw placeholder color
-			if (text.empty())
+			if (using_placeholder)
 				font_color.a *= placeholder_alpha;
 			font_color.a *= disabled_alpha;
 
@@ -757,7 +758,7 @@ void LineEdit::_notification(int p_what) {
 			if (has_focus()) {
 
 				OS::get_singleton()->set_ime_active(true);
-				OS::get_singleton()->set_ime_position(get_global_position() + Point2(x_ofs, y_ofs + caret_height));
+				OS::get_singleton()->set_ime_position(get_global_position() + Point2(using_placeholder ? 0 : x_ofs, y_ofs + caret_height));
 				OS::get_singleton()->set_ime_intermediate_text_callback(_ime_text_callback, this);
 			}
 		} break;


### PR DESCRIPTION
The LineEdit control has a hook built into to reposition where the IME text input window should appear when starting an IME composition, in this case at the end of the LineEdit's string. This fixes it so that placeholder text will be ignored when starting a new composition.