### PR TITLE
Added description for abs function in Rect2 in documentation

### DIFF
--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -42,6 +42,7 @@
 			<return type="Rect2">
 			</return>
 			<description>
+				Returns an equivalent [code]Rect2[/code] with a positive width and height.
 			</description>
 		</method>
 		<method name="clip">


### PR DESCRIPTION
The documentation for Rect2 did not contain a description for what abs() does.

The description added was: Returns an equivalent Rect2 with a positive width and height.