### PR TITLE
Small improvement to solarized theme

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -304,8 +304,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 		} break;
 		case 7: { // Solarized (Dark)
 			preset_accent_color = Color::html("#268bd2");
-			preset_base_color = Color::html("#002b36");
-			preset_contrast = 0.2;
+			preset_base_color = Color::html("#073642");
+			preset_contrast = 0.15;
 		} break;
 		case 8: { // Solarized (Light)
 			preset_accent_color = Color::html("#268bd2");


### PR DESCRIPTION
I don't think it's a good ideia to use "base03" for base color because this is the most darker color of the theme and godot will use `preset_contrast` to create a color more darker yet, resulting in a theme more darker that the original. I think using "base02" will look better.

**Dark**
base03    #002b36    (background)
base02    #073642    (background highlights)

http://ethanschoonover.com/solarized#the-values

## Comparasion
On the left side is the original reference from http://ethanschoonover.com/solarized#c-vim to comparete with godot.

Before:
![captura de tela de 2018-06-13 21-02-20](https://user-images.githubusercontent.com/1387165/41384646-68858bda-6f4d-11e8-9b10-948a7da9834d.png)
After:
![captura de tela de 2018-06-13 22-42-28](https://user-images.githubusercontent.com/1387165/41387030-1b4e64c8-6f5b-11e8-8bc2-a9cfcab5581a.png)

## Comparasion with VSCode
Before:
![before](https://user-images.githubusercontent.com/1387165/41413811-96c10a16-6fba-11e8-9eef-136b9e6a0d6c.png)

After:
![15](https://user-images.githubusercontent.com/1387165/41413815-9b58be5c-6fba-11e8-9917-df9bce44e682.png)
*\*The color of "Explorer" in vscode is not part of the original pallet.*
