### PR TITLE
2to3 exporter: Improved BaseButton and Focus Mode conversion

### DIFF
--- a/editor/editor_export_godot3.h
+++ b/editor/editor_export_godot3.h
@@ -83,6 +83,7 @@ class EditorExportGodot3 {
 	void _save_config(const String &p_path);
 
 	void _rename_properties(const String &p_type, List<ExportData::PropertyData> *p_props);
+	void _add_new_properties(const String &p_type, List<ExportData::PropertyData> *p_props);
 	void _convert_resources(ExportData &resource);
 	void _unpack_packed_scene(ExportData &resource);
 	void _pack_packed_scene(ExportData &resource);


### PR DESCRIPTION
Improvements to the exporter from godot 2 to godot 3, see #9656 

Fixes:
> Control nodes and their Focus Mode in 2.1 doesn't really correspond to the Mouse/Filter in 3.0 - I can't seem to find consistency in what the 3.0 Filter will be set to based on the 2.1 Focus Mode

And:
>  Button Click On Press isn't set to the corresponding Action Mode in 3.0

Also fixes: BaseButton 'is_pressed' has  been renamed to 'pressed'