### PR TITLE
[AnimationPlayer] Fix preview for both AnimatedSprite (2D and 3D)

### DIFF
--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -357,12 +357,26 @@ Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index, float p_pixels_se
 		}
 	} else if (Object::cast_to<AnimatedSprite>(object) || Object::cast_to<AnimatedSprite3D>(object)) {
 
-		int frame = get_animation()->track_get_key_value(get_track(), p_index);
-		String animation = "default"; //may be smart and go through other tracks to find if animation is set
-
 		Ref<SpriteFrames> sf = object->call("get_sprite_frames");
 		if (sf.is_null()) {
 			return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
+		}
+
+		List<StringName> animations;
+		sf->get_animation_list(&animations);
+
+		int frame = get_animation()->track_get_key_value(get_track(), p_index);
+		String animation;
+		if (animations.size() == 1) {
+			animation = animations.front()->get();
+		} else {
+			// Go through other track to find if animation is set
+			String animation_path = get_animation()->track_get_path(get_track());
+			animation_path = animation_path.replace(":frame", ":animation");
+			int animation_track = get_animation()->find_track(animation_path);
+			float track_time = get_animation()->track_get_key_time(get_track(), p_index);
+			int animaiton_index = get_animation()->track_find_key(animation_track, track_time);
+			animation = get_animation()->track_get_key_value(animation_track, animaiton_index);
 		}
 
 		Ref<Texture> texture = sf->get_frame(animation, frame);
@@ -430,13 +444,27 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 
 	} else if (Object::cast_to<AnimatedSprite>(object) || Object::cast_to<AnimatedSprite3D>(object)) {
 
-		int frame = get_animation()->track_get_key_value(get_track(), p_index);
-		String animation = "default"; //may be smart and go through other tracks to find if animation is set
-
 		Ref<SpriteFrames> sf = object->call("get_sprite_frames");
 		if (sf.is_null()) {
 			AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
 			return;
+		}
+
+		List<StringName> animations;
+		sf->get_animation_list(&animations);
+
+		int frame = get_animation()->track_get_key_value(get_track(), p_index);
+		String animation;
+		if (animations.size() == 1) {
+			animation = animations.front()->get();
+		} else {
+			// Go through other track to find if animation is set
+			String animation_path = get_animation()->track_get_path(get_track());
+			animation_path = animation_path.replace(":frame", ":animation");
+			int animation_track = get_animation()->find_track(animation_path);
+			float track_time = get_animation()->track_get_key_time(get_track(), p_index);
+			int animaiton_index = get_animation()->track_find_key(animation_track, track_time);
+			animation = get_animation()->track_get_key_value(animation_track, animaiton_index);
 		}
 
 		texture = sf->get_frame(animation, frame);


### PR DESCRIPTION
Fix #19566.

![captura de tela de 2018-06-14 20-35-23](https://user-images.githubusercontent.com/1387165/41443324-82bd365e-7012-11e8-8a31-a80cb1d92ae0.png)

If you've more than one `animation` and you don't put any key to tell which `animation` you are using, I think it's a good idea (and this will be very useful for my workflow at least) not to show any preview because godot can't guarantee what `animation` will be played, eg: if you switch from an *animation to other, the last `animation` played will be the actual image.

\*animation means animation clip and `animation` refers to property.

Example 1, Two animations, no preview:
![captura de tela de 2018-06-14 19-39-50](https://user-images.githubusercontent.com/1387165/41441834-c303665a-700a-11e8-907a-62f8dad811b3.png)

Example 2, Two animations, only two previews because the first frame the animation is not setted:
![captura de tela de 2018-06-14 20-38-32](https://user-images.githubusercontent.com/1387165/41443395-f5f24e7a-7012-11e8-928c-9820b317bb94.png)

And if you've only one animation, this will be the default and can be previewed.
