### PR TITLE
Tweak adaptative guideline and completion_background color

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1056,7 +1056,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Color string_color = Color::html(dark_theme ? "#ffd942" : "#ffd118").linear_interpolate(mono_color, dark_theme ? 0.5 : 0.3);
 
 	const Color te_background_color = dark_theme ? background_color : base_color;
-	const Color completion_background_color = base_color;
+	const Color completion_background_color = dark_theme ? base_color : background_color;
 	const Color completion_selected_color = alpha1;
 	const Color completion_existing_color = alpha2;
 	const Color completion_scroll_color = alpha1;
@@ -1069,7 +1069,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Color selection_color = alpha2;
 	const Color brace_mismatch_color = error_color;
 	const Color current_line_color = alpha1;
-	const Color line_length_guideline_color = warning_color;
+	const Color line_length_guideline_color = dark_theme ? base_color : background_color;
 	const Color word_highlighted_color = alpha1;
 	const Color number_color = basetype_color.linear_interpolate(mono_color, dark_theme ? 0.5 : 0.3);
 	const Color function_color = main_color;


### PR DESCRIPTION
The line length guideline is a glaring yellow right now so I made it more discreet.

Contrast is a bit too low maybe given that it's so thin but that's better than too much for the line.

I noticed that `te_background_color` and `completion_background_color` are the same when `!dark_theme` so I changed it too.

Before (3.0.3):
![capture d ecran de 2018-06-14 23-55-39](https://user-images.githubusercontent.com/5330692/41442088-d2556f6a-7035-11e8-85c6-281737f9da4a.png)

After:
![capture d ecran de 2018-06-15 00-45-39](https://user-images.githubusercontent.com/5330692/41442125-f8e89b70-7035-11e8-8ac3-4543ac8c075a.png)

After — light theme with completions:
![capture d ecran de 2018-06-15 00-46-10](https://user-images.githubusercontent.com/5330692/41442134-006e3ec2-7036-11e8-8968-a94586acd321.png)

Though I heard djrm is reworking the theming so I don't know if it's actually useful.