### PR TITLE
Removed unused AudioServer::update function

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1815,9 +1815,6 @@ bool Main::iteration() {
 		}
 	}
 
-	if (AudioServer::get_singleton())
-		AudioServer::get_singleton()->update();
-
 	idle_process_ticks = OS::get_singleton()->get_ticks_usec() - idle_begin;
 	idle_process_max = MAX(idle_process_ticks, idle_process_max);
 	uint64_t frame_time = OS::get_singleton()->get_ticks_usec() - ticks;

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -939,9 +939,6 @@ void AudioServer::finish() {
 	buses.clear();
 }
 
-void AudioServer::update() {
-}
-
 /* MISC config */
 
 void AudioServer::lock() {

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -273,7 +273,6 @@ public:
 
 	virtual void init();
 	virtual void finish();
-	virtual void update();
 	virtual void load_default_bus_layout();
 
 	/* MISC config */


### PR DESCRIPTION
AudioServer::update is not needed since the audio is updated in its own thread by the drivers.