### PR TITLE
Separate profiler idle time into visual and idle time

### DIFF
--- a/core/script_debugger_local.cpp
+++ b/core/script_debugger_local.cpp
@@ -303,12 +303,9 @@ struct _ScriptDebuggerLocalProfileInfoSort {
 	}
 };
 
-void ScriptDebuggerLocal::profiling_set_frame_times(float p_frame_time, float p_idle_time, float p_physics_time, float p_physics_frame_time) {
+void ScriptDebuggerLocal::profiling_set_frame_times(const FrameTimeData &p_ftd) {
 
-	frame_time = p_frame_time;
-	idle_time = p_idle_time;
-	physics_time = p_physics_time;
-	physics_frame_time = p_physics_frame_time;
+	ftd = p_ftd;
 }
 
 void ScriptDebuggerLocal::idle_poll() {
@@ -342,11 +339,11 @@ void ScriptDebuggerLocal::idle_poll() {
 
 	float script_time = USEC_TO_SEC(script_time_us);
 
-	float total_time = frame_time;
+	float total_time = ftd.frame_time;
 
 	//print script total
 
-	print_line("FRAME: total: " + rtos(frame_time) + " script: " + rtos(script_time) + "/" + itos(script_time * 100 / total_time) + " %");
+	print_line("FRAME: total: " + rtos(ftd.frame_time) + " script: " + rtos(script_time) + "/" + itos(script_time * 100 / total_time) + " %");
 
 	for (int i = 0; i < ofs; i++) {
 
@@ -366,10 +363,11 @@ void ScriptDebuggerLocal::profiling_start() {
 	print_line("BEGIN PROFILING");
 	profiling = true;
 	pinfo.resize(32768);
-	frame_time = 0;
-	physics_time = 0;
-	idle_time = 0;
-	physics_frame_time = 0;
+	ftd.frame_time = 0;
+	ftd.physics_time = 0;
+	ftd.visual_time = 0;
+	ftd.idle_time = 0;
+	ftd.physics_frame_time = 0;
 }
 
 void ScriptDebuggerLocal::profiling_end() {

--- a/core/script_debugger_local.h
+++ b/core/script_debugger_local.h
@@ -37,7 +37,8 @@
 class ScriptDebuggerLocal : public ScriptDebugger {
 
 	bool profiling;
-	float frame_time, idle_time, physics_time, physics_frame_time;
+
+	FrameTimeData ftd;
 	uint64_t idle_accum;
 	String target_function;
 	Map<String, String> options;
@@ -59,7 +60,7 @@ public:
 
 	virtual void profiling_start();
 	virtual void profiling_end();
-	virtual void profiling_set_frame_times(float p_frame_time, float p_idle_time, float p_physics_time, float p_physics_frame_time);
+	virtual void profiling_set_frame_times(const FrameTimeData &p_ftd);
 
 	ScriptDebuggerLocal();
 };

--- a/core/script_debugger_remote.cpp
+++ b/core/script_debugger_remote.cpp
@@ -743,10 +743,11 @@ void ScriptDebuggerRemote::_poll_events() {
 			max_frame_functions = cmd[1];
 			profiler_function_signature_map.clear();
 			profiling = true;
-			frame_time = 0;
-			idle_time = 0;
-			physics_time = 0;
-			physics_frame_time = 0;
+			ftd.frame_time = 0;
+			ftd.visual_time = 0;
+			ftd.idle_time = 0;
+			ftd.physics_time = 0;
+			ftd.physics_frame_time = 0;
 
 			print_line("PROFILING ALRIGHT!");
 
@@ -816,17 +817,18 @@ void ScriptDebuggerRemote::_send_profiling_data(bool p_for_frame) {
 
 	if (p_for_frame) {
 		packet_peer_stream->put_var("profile_frame");
-		packet_peer_stream->put_var(8 + profile_frame_data.size() * 2 + to_send * 4);
+		packet_peer_stream->put_var(9 + profile_frame_data.size() * 2 + to_send * 4);
 	} else {
 		packet_peer_stream->put_var("profile_total");
-		packet_peer_stream->put_var(8 + to_send * 4);
+		packet_peer_stream->put_var(9 + to_send * 4);
 	}
 
 	packet_peer_stream->put_var(Engine::get_singleton()->get_frames_drawn()); //total frame time
-	packet_peer_stream->put_var(frame_time); //total frame time
-	packet_peer_stream->put_var(idle_time); //idle frame time
-	packet_peer_stream->put_var(physics_time); //fixed frame time
-	packet_peer_stream->put_var(physics_frame_time); //fixed frame time
+	packet_peer_stream->put_var(ftd.frame_time); //total frame time
+	packet_peer_stream->put_var(ftd.visual_time); //visual frame time
+	packet_peer_stream->put_var(ftd.idle_time); //idle frame time
+	packet_peer_stream->put_var(ftd.physics_time); //fixed frame time
+	packet_peer_stream->put_var(ftd.physics_frame_time); //fixed frame time
 
 	packet_peer_stream->put_var(USEC_TO_SEC(total_script_time)); //total script execution time
 
@@ -1062,12 +1064,9 @@ void ScriptDebuggerRemote::profiling_end() {
 	//ignores this, uses it via connection
 }
 
-void ScriptDebuggerRemote::profiling_set_frame_times(float p_frame_time, float p_idle_time, float p_physics_time, float p_physics_frame_time) {
+void ScriptDebuggerRemote::profiling_set_frame_times(const FrameTimeData &p_ftd) {
 
-	frame_time = p_frame_time;
-	idle_time = p_idle_time;
-	physics_time = p_physics_time;
-	physics_frame_time = p_physics_frame_time;
+	ftd = p_ftd;
 }
 
 ScriptDebuggerRemote::ResourceUsageFunc ScriptDebuggerRemote::resource_usage_func = NULL;

--- a/core/script_debugger_remote.h
+++ b/core/script_debugger_remote.h
@@ -55,7 +55,8 @@ class ScriptDebuggerRemote : public ScriptDebugger {
 	Vector<ScriptLanguage::ProfilingInfo *> profile_info_ptrs;
 
 	Map<StringName, int> profiler_function_signature_map;
-	float frame_time, idle_time, physics_time, physics_frame_time;
+
+	FrameTimeData ftd;
 
 	bool profiling;
 	int max_frame_functions;
@@ -169,7 +170,7 @@ public:
 
 	virtual void profiling_start();
 	virtual void profiling_end();
-	virtual void profiling_set_frame_times(float p_frame_time, float p_idle_time, float p_physics_time, float p_physics_frame_time);
+	virtual void profiling_set_frame_times(const FrameTimeData &p_ftd);
 
 	ScriptDebuggerRemote();
 	~ScriptDebuggerRemote();

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -332,6 +332,14 @@ public:
 	~PlaceHolderScriptInstance();
 };
 
+struct FrameTimeData {
+	float frame_time;
+	float visual_time;
+	float idle_time;
+	float physics_time;
+	float physics_frame_time;
+};
+
 class ScriptDebugger {
 
 	int lines_left;
@@ -403,7 +411,7 @@ public:
 	virtual void add_profiling_frame_data(const StringName &p_name, const Array &p_data) = 0;
 	virtual void profiling_start() = 0;
 	virtual void profiling_end() = 0;
-	virtual void profiling_set_frame_times(float p_frame_time, float p_idle_time, float p_physics_time, float p_physics_frame_time) = 0;
+	virtual void profiling_set_frame_times(const FrameTimeData &p_ftd) = 0;
 
 	ScriptDebugger();
 	virtual ~ScriptDebugger() { singleton = NULL; }

--- a/editor/editor_profiler.h
+++ b/editor/editor_profiler.h
@@ -51,6 +51,7 @@ public:
 
 		int frame_number;
 		float frame_time;
+		float visual_time;
 		float idle_time;
 		float physics_time;
 		float physics_frame_time;

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -742,15 +742,18 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 
 	} else if (p_msg == "profile_frame" || p_msg == "profile_total") {
 
+		int idx = 0;
 		EditorProfiler::Metric metric;
 		metric.valid = true;
-		metric.frame_number = p_data[0];
-		metric.frame_time = p_data[1];
-		metric.idle_time = p_data[2];
-		metric.physics_time = p_data[3];
-		metric.physics_frame_time = p_data[4];
-		int frame_data_amount = p_data[6];
-		int frame_function_amount = p_data[7];
+		metric.frame_number = p_data[idx++];
+		metric.frame_time = p_data[idx++];
+		metric.visual_time = p_data[idx++];
+		metric.idle_time = p_data[idx++];
+		metric.physics_time = p_data[idx++];
+		metric.physics_frame_time = p_data[idx++];
+		float script_time = p_data[idx++];
+		int frame_data_amount = p_data[idx++];
+		int frame_function_amount = p_data[idx++];
 
 		if (frame_data_amount) {
 			EditorProfiler::Metric::Category frame_time;
@@ -766,6 +769,13 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 			item.total = metric.physics_time;
 			item.self = item.total;
 			item.signature = "physics_time";
+
+			frame_time.items.push_back(item);
+
+			item.name = "Visual Time";
+			item.total = metric.visual_time;
+			item.self = item.total;
+			item.signature = "visual_time";
 
 			frame_time.items.push_back(item);
 
@@ -786,7 +796,6 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 			metric.categories.push_back(frame_time);
 		}
 
-		int idx = 8;
 		for (int i = 0; i < frame_data_amount; i++) {
 
 			EditorProfiler::Metric::Category c;
@@ -813,7 +822,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		}
 
 		EditorProfiler::Metric::Category funcs;
-		funcs.total_time = p_data[5]; //script time
+		funcs.total_time = script_time;
 		funcs.items.resize(frame_function_amount);
 		funcs.name = "Script Functions";
 		funcs.signature = "script_functions";


### PR DESCRIPTION
Fixes #18290
Right now idle time in the Profiler contains also the visual time. This PR creates a new "Visual Time" item on the Profiler which contains the amount of time the Visual Server takes to draw the frame.
Also Performance,TIME_PROCESS will now show the "Time it took to complete one frame" (as per the docs http://docs.godotengine.org/en/3.0/classes/class_performance.html) instead of showing Visual + Idle time.

I think @reduz should check this to see if I didn't miss something on the changes.

PD: Audio Time is not included since actually audio is not updated on Main::iteration but on its own thread on each audio driver.