### PR TITLE
Add a suffix to MinGW builds to differentiate them from MSVC ones

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -349,4 +349,5 @@ def configure(env):
         configure_msvc(env, manual_msvc_config)
 
     else: # MinGW
+        env.extra_suffix = ".mingw" + env.extra_suffix
         configure_mingw(env)


### PR DESCRIPTION
Builds cross-compiled from Linux or macOS will also include the MinGW build suffix in object file names. This closes https://github.com/godotengine/godot/issues/17509.

**Note:** This will likely break automated build/continuous integration scripts.