### PR TITLE
File Menu for Script Editor cleanup + few new closing options

### DIFF
--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -143,6 +143,8 @@ class ScriptEditor : public PanelContainer {
 		CLOSE_DOCS,
 		CLOSE_ALL,
 		CLOSE_OTHER_TABS,
+		CLOSE_UPWARD,
+		CLOSE_BELOW,
 		TOGGLE_SCRIPTS_PANEL,
 		SHOW_IN_FILE_SYSTEM,
 		FILE_COPY_PATH,
@@ -185,6 +187,7 @@ class ScriptEditor : public PanelContainer {
 	MenuButton *edit_menu;
 	MenuButton *script_search_menu;
 	MenuButton *debug_menu;
+	MenuButton *theme_menu;
 	PopupMenu *context_menu;
 	Timer *autosave_timer;
 	uint64_t idle;
@@ -276,6 +279,8 @@ class ScriptEditor : public PanelContainer {
 	void _close_discard_current_tab(const String &p_str);
 	void _close_docs_tab();
 	void _close_other_tabs();
+	void _close_upward();
+	void _close_below();
 	void _close_all_tabs();
 
 	void _copy_script_path();


### PR DESCRIPTION
UPDATED - 

Cleanup for File menu of Script Editor..


![image](https://user-images.githubusercontent.com/3036176/41511282-7520d944-727c-11e8-9a12-aed980275ff0.png)

I get rid much of closing options. Its much cleaner now. I moved Theme to separate tab also

![image](https://user-images.githubusercontent.com/3036176/41509105-8dabfc20-7257-11e8-8ada-144006674678.png)

This commit also adds two new tab closing options. You can use them to easily close up tabs below or upper than current selected tab.

![image](https://user-images.githubusercontent.com/3036176/41509158-64ab82c2-7258-11e8-8828-492fb356e700.png)
