### PR TITLE
Expose OS.get_ticks_usec()

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -799,6 +799,11 @@ uint32_t _OS::get_ticks_msec() const {
 	return OS::get_singleton()->get_ticks_msec();
 }
 
+uint64_t _OS::get_ticks_usec() const {
+
+	return OS::get_singleton()->get_ticks_usec();
+}
+
 uint32_t _OS::get_splash_tick_msec() const {
 
 	return OS::get_singleton()->get_splash_tick_msec();
@@ -1131,6 +1136,7 @@ void _OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("delay_usec", "usec"), &_OS::delay_usec);
 	ClassDB::bind_method(D_METHOD("delay_msec", "msec"), &_OS::delay_msec);
 	ClassDB::bind_method(D_METHOD("get_ticks_msec"), &_OS::get_ticks_msec);
+	ClassDB::bind_method(D_METHOD("get_ticks_usec"), &_OS::get_ticks_usec);
 	ClassDB::bind_method(D_METHOD("get_splash_tick_msec"), &_OS::get_splash_tick_msec);
 	ClassDB::bind_method(D_METHOD("get_locale"), &_OS::get_locale);
 	ClassDB::bind_method(D_METHOD("get_latin_keyboard_variant"), &_OS::get_latin_keyboard_variant);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -277,6 +277,7 @@ public:
 	void delay_usec(uint32_t p_usec) const;
 	void delay_msec(uint32_t p_msec) const;
 	uint32_t get_ticks_msec() const;
+	uint64_t get_ticks_usec() const;
 	uint32_t get_splash_tick_msec() const;
 
 	bool can_use_threads() const;

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -362,6 +362,13 @@
 				Returns the amount of time passed in milliseconds since the engine started.
 			</description>
 		</method>
+		<method name="get_ticks_usec" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the amount of time passed in microseconds since the engine started.
+			</description>
+		</method>
 		<method name="get_time" qualifiers="const">
 			<return type="Dictionary">
 			</return>


### PR DESCRIPTION
For more precise time measurement.