### PR TITLE
Remove shortcut conflict

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4351,7 +4351,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	snap_button->set_toggle_mode(true);
 	snap_button->connect("toggled", this, "_button_toggle_snap");
 	snap_button->set_tooltip(TTR("Toggle snapping."));
-	snap_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/use_snap", TTR("Use Snap"), KEY_S));
+	snap_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/use_snap", TTR("Use Snap"), KEY_MASK_SHIFT | KEY_S));
 
 	snap_config_menu = memnew(MenuButton);
 	hb->add_child(snap_config_menu);


### PR DESCRIPTION
Remove conflict with "Use Snap (S)" and "Stop animation playback. (S)".

Before:
When I press "S" to stop the animation, the snap changes together.