### PR TITLE
Fix onready vars / vars accessing class members if _ready / _init not present

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -34,7 +34,7 @@
 
 bool GDScriptCompiler::_is_class_member_property(CodeGen &codegen, const StringName &p_name) {
 
-	if (!codegen.function_node || codegen.function_node->_static)
+	if (codegen.function_node && codegen.function_node->_static)
 		return false;
 
 	if (codegen.stack_identifiers.has(p_name))


### PR DESCRIPTION
Fixes #19548

**Please review**
I'm assuming that the condition was supposed to check for a static function only as per http://docs.godotengine.org/en/3.0/getting_started/scripting/gdscript/gdscript_basics.html:
"When a function is static it has no access to the instance member variables"