### PR TITLE
Export: Make debug opt-in instead of opt-out

### DIFF
--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -985,7 +985,7 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	export_debug = memnew(CheckButton);
 	export_debug->set_text(TTR("Export With Debug"));
-	export_debug->set_pressed(true);
+	export_debug->set_pressed(false);
 	export_project->get_vbox()->add_child(export_debug);
 
 	export_pck_zip_debug = memnew(CheckButton);


### PR DESCRIPTION
Rationale: Many users miss the button and end up releasing debug builds in production, which have worse performance than release builds.

The overall usability of this dialog needs to be reviewed, but as a short term solution, non-debug by default seems better to me than debug by default. I'm open to suggestions for a better overall workflow though.

The drawback is that games with errors might crash in release mode where they would error out in debug mode, so if users don't fix their bugs while running in the editor (debug), they will likely get a crashy build.