### PR TITLE
Remove audio latency print

### DIFF
--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -234,29 +234,6 @@ void AudioServer::_driver_process(int p_frames, int32_t *p_buffer) {
 		todo -= to_copy;
 		to_mix -= to_copy;
 	}
-
-#ifdef DEBUG_ENABLED
-	if (OS::get_singleton() && OS::get_singleton()->is_stdout_verbose()) {
-		static uint64_t first_ticks = 0;
-		static uint64_t last_ticks = 0;
-		static uint64_t ticks = 0;
-		static int count = 0;
-		static int total = 0;
-
-		ticks = OS::get_singleton()->get_ticks_msec();
-		if ((ticks - first_ticks) > 10 * 1000 && count > 0) {
-			print_line("Audio Driver " + String(AudioDriver::get_singleton()->get_name()) + " average latency: " + itos(total / count) + "ms (frame=" + itos(p_frames) + ")");
-			first_ticks = ticks;
-			total = 0;
-			count = 0;
-		}
-
-		total += ticks - last_ticks;
-		count++;
-
-		last_ticks = ticks;
-	}
-#endif
 }
 
 void AudioServer::_mix_step() {


### PR DESCRIPTION
This generates noise when using the verbose mode, and it's not useful information if you're not interested in the latency (akin to the FPS counter, which thankfully is not enabled by default in verbose mode anymore). If this information is really needed it should be provided in some other way.

This also causes crashes when debugging, because sometimes it tries to print after the handlers were already destroyed.

Cc @marcelofg55 who added this code.