### PR TITLE
Prevent redraws when an inactive Particles2D node is present

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -832,6 +832,9 @@ void RasterizerCanvasGLES3::_canvas_item_render_commands(Item *p_item, Item *cur
 				if (!particles)
 					break;
 
+				if (particles->inactive && !particles->emitting)
+					break;
+
 				glVertexAttrib4f(VS::ARRAY_COLOR, 1, 1, 1, 1); //not used, so keep white
 
 				VisualServerRaster::redraw_request();


### PR DESCRIPTION
This fixes redraws when a Particles2D node is not active. This was reproducible with the following steps:

1. Create a new scene
2. Add Particles2D node to the scene
3. Turn off Emitting for the Particles2D node
4. Notice the spinner is still updating