### PR TITLE
Add Audio Server profiling time to the profiler

### DIFF
--- a/drivers/coreaudio/audio_driver_coreaudio.cpp
+++ b/drivers/coreaudio/audio_driver_coreaudio.cpp
@@ -163,6 +163,8 @@ OSStatus AudioDriverCoreAudio::output_callback(void *inRefCon,
 		return 0;
 	};
 
+	ad->start_counting_ticks();
+
 	for (unsigned int i = 0; i < ioData->mNumberBuffers; i++) {
 
 		AudioBuffer *abuf = &ioData->mBuffers[i];
@@ -184,6 +186,7 @@ OSStatus AudioDriverCoreAudio::output_callback(void *inRefCon,
 		};
 	};
 
+	ad->stop_counting_ticks();
 	ad->unlock();
 
 	return 0;

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -289,17 +289,17 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 	AudioDriverPulseAudio *ad = (AudioDriverPulseAudio *)p_udata;
 
 	while (!ad->exit_thread) {
+
+		ad->lock();
+		ad->start_counting_ticks();
+
 		if (!ad->active) {
 			for (unsigned int i = 0; i < ad->pa_buffer_size; i++) {
 				ad->samples_out[i] = 0;
 			}
 
 		} else {
-			ad->lock();
-
 			ad->audio_server_process(ad->buffer_frames, ad->samples_in.ptrw());
-
-			ad->unlock();
 
 			if (ad->channels == ad->pa_map.channels) {
 				for (unsigned int i = 0; i < ad->pa_buffer_size; i++) {
@@ -323,9 +323,6 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 
 		int error_code;
 		int byte_size = ad->pa_buffer_size * sizeof(int16_t);
-
-		ad->lock();
-
 		int ret;
 		do {
 			ret = pa_mainloop_iterate(ad->pa_ml, 0, NULL);
@@ -350,11 +347,13 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 					if (ret == 0) {
 						// If pa_mainloop_iterate returns 0 sleep for 1 msec to wait
 						// for the stream to be able to process more bytes
+						ad->stop_counting_ticks();
 						ad->unlock();
 
 						OS::get_singleton()->delay_usec(1000);
 
 						ad->lock();
+						ad->start_counting_ticks();
 					}
 				}
 			}
@@ -380,6 +379,7 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 			}
 		}
 
+		ad->stop_counting_ticks();
 		ad->unlock();
 	}
 
@@ -453,7 +453,9 @@ String AudioDriverPulseAudio::get_device() {
 
 void AudioDriverPulseAudio::set_device(String device) {
 
+	lock();
 	new_device = device;
+	unlock();
 }
 
 void AudioDriverPulseAudio::lock() {

--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -72,7 +72,6 @@ class AudioDriverWASAPI : public AudioDriver {
 
 	Error init_device(bool reinit = false);
 	Error finish_device();
-	Error reopen();
 
 public:
 	virtual const char *get_name() const {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1823,6 +1823,8 @@ bool Main::iteration() {
 		ScriptServer::get_language(i)->frame();
 	}
 
+	AudioServer::get_singleton()->update();
+
 	if (script_debugger) {
 		if (script_debugger->is_profiling()) {
 			script_debugger->profiling_set_frame_times(USEC_TO_SEC(frame_time), USEC_TO_SEC(idle_process_ticks), USEC_TO_SEC(physics_process_ticks), frame_slice);


### PR DESCRIPTION
This PR adds profiling data for audio related processing.
Includes includes profiling time from Audio Effects, Audio Server and Audio Driver (CoreAudio, ALSA, PulseAudio and WASAPI).

![audioprofiling](https://user-images.githubusercontent.com/10578225/41740817-9db9ff66-756f-11e8-9c0d-75a29d181393.png)
