### PR TITLE
fix default glTF metallic & roughness factor values

### DIFF
--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -1256,12 +1256,15 @@ Error EditorSceneImporterGLTF::_parse_materials(GLTFState &state) {
 			}
 
 			if (mr.has("metallicFactor")) {
-
 				material->set_metallic(mr["metallicFactor"]);
+			} else {
+				material->set_metallic(1.0);
 			}
-			if (mr.has("roughnessFactor")) {
 
+			if (mr.has("roughnessFactor")) {
 				material->set_roughness(mr["roughnessFactor"]);
+			} else {
+				material->set_roughness(1.0);
 			}
 
 			if (mr.has("metallicRoughnessTexture")) {


### PR DESCRIPTION
The glTF 2.0 spec says that these pbrMetallicRoughness material
properties should be set as 1.0 by default.
In fact, KhronosGroup's official Blender Exporter does not even write
down those parameters if they are set as 1.0.

However, Godot import them as 0.0.

https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#pbrmetallicroughness

Fixes: #19613