### PR TITLE
Fix crash when assigning a node on editing animation key

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -25,6 +25,7 @@ public:
 		ClassDB::bind_method("_update_obj", &AnimationTrackKeyEdit::_update_obj);
 		ClassDB::bind_method("_key_ofs_changed", &AnimationTrackKeyEdit::_key_ofs_changed);
 		ClassDB::bind_method("_hide_script_from_inspector", &AnimationTrackKeyEdit::_hide_script_from_inspector);
+		ClassDB::bind_method("get_root_path", &AnimationTrackKeyEdit::get_root_path);
 	}
 
 	//PopupDialog *ke_dialog;
@@ -610,6 +611,10 @@ public:
 	void notify_change() {
 
 		_change_notify();
+	}
+
+	Node *get_root_path() {
+		return root_path;
 	}
 
 	AnimationTrackKeyEdit() {

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1522,8 +1522,15 @@ EditorPropertyColor::EditorPropertyColor() {
 
 void EditorPropertyNodePath::_node_selected(const NodePath &p_path) {
 
+	NodePath path = p_path;
 	Node *base_node = Object::cast_to<Node>(get_edited_object());
-	emit_signal("property_changed", get_edited_property(), base_node->get_path().rel_path_to(p_path));
+	if (base_node == NULL && get_edited_object()->has_method("get_root_path")) {
+		base_node = get_edited_object()->call("get_root_path");
+	}
+	if (base_node) { // for AnimationTrackKeyEdit
+		path = base_node->get_path().rel_path_to(p_path);
+	}
+	emit_signal("property_changed", get_edited_property(), path);
 	update_property();
 }
 


### PR DESCRIPTION
Fix #19712