### PR TITLE
Convert final HDR output to RGBA8

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -260,6 +260,9 @@
 		<member name="render_target_v_flip" type="bool" setter="set_vflip" getter="get_vflip">
 			If [code]true[/code] the result of rendering will be flipped vertically. Default value: [code]false[/code].
 		</member>
+		<member name="rgba8_out" type="bool" setter="set_rgba8_out" getter="get_rgba8_out">
+			If [code]true[/code] and HDR is enabled rendering will use HDR buffers but the final output will be converted to 8 bits per channel. Default value: [code]false[/code].
+		</member>
 		<member name="shadow_atlas_quad_0" type="int" setter="set_shadow_atlas_quadrant_subdiv" getter="get_shadow_atlas_quadrant_subdiv" enum="Viewport.ShadowAtlasQuadrantSubdiv">
 			The subdivision amount of first quadrant on shadow atlas. Default value: [code]SHADOW_ATLAS_QUADRANT_SUBDIV_4[/code].
 		</member>

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -778,7 +778,7 @@ public:
 	void initialize() {}
 	void begin_frame(double frame_step) {}
 	void set_current_render_target(RID p_render_target) {}
-	void restore_render_target() {}
+	void restore_render_target(bool p_3d_drawn) {}
 	void clear_render_target(const Color &p_color) {}
 	void blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen = 0) {}
 	void output_lens_distorted_to_screen(RID p_render_target, const Rect2 &p_screen_rect, float p_k1, float p_k2, const Vector2 &p_eye_center, float p_oversample) {}

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -316,7 +316,7 @@ void RasterizerGLES2::set_current_render_target(RID p_render_target) {
 	}
 }
 
-void RasterizerGLES2::restore_render_target() {
+void RasterizerGLES2::restore_render_target(bool p_3d_drawn) {
 	ERR_FAIL_COND(storage->frame.current_rt == NULL);
 	RasterizerStorageGLES2::RenderTarget *rt = storage->frame.current_rt;
 	glBindFramebuffer(GL_FRAMEBUFFER, rt->fbo);

--- a/drivers/gles2/rasterizer_gles2.h
+++ b/drivers/gles2/rasterizer_gles2.h
@@ -56,7 +56,7 @@ public:
 	virtual void initialize();
 	virtual void begin_frame(double frame_step);
 	virtual void set_current_render_target(RID p_render_target);
-	virtual void restore_render_target();
+	virtual void restore_render_target(bool p_3d_drawn);
 	virtual void clear_render_target(const Color &p_color);
 	virtual void blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen = 0);
 	virtual void output_lens_distorted_to_screen(RID p_render_target, const Rect2 &p_screen_rect, float p_k1, float p_k2, const Vector2 &p_eye_center, float p_oversample);

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -253,11 +253,15 @@ void RasterizerGLES3::set_current_render_target(RID p_render_target) {
 	}
 }
 
-void RasterizerGLES3::restore_render_target() {
+void RasterizerGLES3::restore_render_target(bool p_3d_drawn) {
 
 	ERR_FAIL_COND(storage->frame.current_rt == NULL);
 	RasterizerStorageGLES3::RenderTarget *rt = storage->frame.current_rt;
-	glBindFramebuffer(GL_FRAMEBUFFER, rt->fbo);
+	if (p_3d_drawn && rt->rgba8_out.fbo) {
+		glBindFramebuffer(GL_FRAMEBUFFER, rt->rgba8_out.fbo);
+	} else {
+		glBindFramebuffer(GL_FRAMEBUFFER, rt->fbo);
+	}
 	glViewport(0, 0, rt->width, rt->height);
 }
 
@@ -339,7 +343,11 @@ void RasterizerGLES3::blit_render_target_to_screen(RID p_render_target, const Re
 #if 1
 
 	Size2 win_size = OS::get_singleton()->get_window_size();
-	glBindFramebuffer(GL_READ_FRAMEBUFFER, rt->fbo);
+	if (rt->rgba8_out.fbo) {
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, rt->rgba8_out.fbo);
+	} else {
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, rt->fbo);
+	}
 	glReadBuffer(GL_COLOR_ATTACHMENT0);
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, RasterizerStorageGLES3::system_fbo);
 	glBlitFramebuffer(0, 0, rt->width, rt->height, p_screen_rect.position.x, win_size.height - p_screen_rect.position.y - p_screen_rect.size.height, p_screen_rect.position.x + p_screen_rect.size.width, win_size.height - p_screen_rect.position.y, GL_COLOR_BUFFER_BIT, GL_NEAREST);

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -56,7 +56,7 @@ public:
 	virtual void initialize();
 	virtual void begin_frame(double frame_step);
 	virtual void set_current_render_target(RID p_render_target);
-	virtual void restore_render_target();
+	virtual void restore_render_target(bool p_3d_drawn);
 	virtual void clear_render_target(const Color &p_color);
 	virtual void blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen = 0);
 	virtual void output_lens_distorted_to_screen(RID p_render_target, const Rect2 &p_screen_rect, float p_k1, float p_k2, const Vector2 &p_eye_center, float p_oversample);

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -3599,7 +3599,12 @@ void RasterizerSceneGLES3::_post_process(Environment *env, const CameraMatrix &p
 
 	if (!env || storage->frame.current_rt->flags[RasterizerStorage::RENDER_TARGET_TRANSPARENT] || storage->frame.current_rt->width < 4 || storage->frame.current_rt->height < 4) { //no post process on small render targets
 		//no environment or transparent render, simply return and convert to SRGB
-		glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->fbo);
+		if (storage->frame.current_rt->rgba8_out.fbo) {
+			// unlikely to use rgba8_out in this mode but better safe then sorry
+			glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->rgba8_out.fbo);
+		} else {
+			glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->fbo);
+		}
 		glActiveTexture(GL_TEXTURE0);
 		glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->effects.mip_maps[0].color);
 		storage->shaders.copy.set_conditional(CopyShaderGLES3::LINEAR_TO_SRGB, true);
@@ -3942,7 +3947,11 @@ void RasterizerSceneGLES3::_post_process(Environment *env, const CameraMatrix &p
 		glViewport(0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height);
 	}
 
-	glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->fbo);
+	if (storage->frame.current_rt->rgba8_out.fbo) {
+		glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->rgba8_out.fbo);
+	} else {
+		glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->fbo);
+	}
 
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(GL_TEXTURE_2D, composite_from);
@@ -4030,7 +4039,7 @@ void RasterizerSceneGLES3::_post_process(Environment *env, const CameraMatrix &p
 		state.tonemap_shader.set_uniform(TonemapShaderGLES3::BCS, Vector3(env->adjustments_brightness, env->adjustments_contrast, env->adjustments_saturation));
 	}
 
-	_copy_screen(true, true);
+	_copy_screen(true, !storage->frame.current_rt->rgba8_out.fbo);
 
 	//turn off everything used
 	state.tonemap_shader.set_conditional(TonemapShaderGLES3::USE_AUTO_EXPOSURE, false);

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1344,6 +1344,13 @@ public:
 			Exposure() { fbo = 0; }
 		} exposure;
 
+		struct RGBA8_out {
+			GLuint fbo;
+			GLuint color;
+
+			RGBA8_out() { fbo = 0; }
+		} rgba8_out;
+
 		uint64_t last_exposure_tick;
 
 		int width, height;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2740,6 +2740,16 @@ bool Viewport::get_keep_3d_linear() const {
 	return keep_3d_linear;
 }
 
+void Viewport::set_rgba8_out(bool p_rgba8_out) {
+	rgba8_out = p_rgba8_out;
+	VS::get_singleton()->viewport_set_rgba8_out(viewport, rgba8_out);
+}
+
+bool Viewport::get_rgba8_out() const {
+
+	return rgba8_out;
+}
+
 Variant Viewport::gui_get_drag_data() const {
 	return gui.drag_data;
 }
@@ -2959,6 +2969,9 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_keep_3d_linear", "keep_3d_linear"), &Viewport::set_keep_3d_linear);
 	ClassDB::bind_method(D_METHOD("get_keep_3d_linear"), &Viewport::get_keep_3d_linear);
 
+	ClassDB::bind_method(D_METHOD("set_rgba8_out", "rgba8_out"), &Viewport::set_rgba8_out);
+	ClassDB::bind_method(D_METHOD("get_rgba8_out"), &Viewport::get_rgba8_out);
+
 	ClassDB::bind_method(D_METHOD("_gui_show_tooltip"), &Viewport::_gui_show_tooltip);
 	ClassDB::bind_method(D_METHOD("_gui_remove_focus"), &Viewport::_gui_remove_focus);
 	ClassDB::bind_method(D_METHOD("_post_gui_grab_click_focus"), &Viewport::_post_gui_grab_click_focus);
@@ -2993,6 +3006,7 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hdr"), "set_hdr", "get_hdr");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disable_3d"), "set_disable_3d", "is_3d_disabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keep_3d_linear"), "set_keep_3d_linear", "get_keep_3d_linear");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "rgba8_out"), "set_rgba8_out", "get_rgba8_out");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "usage", PROPERTY_HINT_ENUM, "2D,2D No-Sampling,3D,3D No-Effects"), "set_usage", "get_usage");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "debug_draw", PROPERTY_HINT_ENUM, "Disabled,Unshaded,Overdraw,Wireframe"), "set_debug_draw", "get_debug_draw");
 	ADD_GROUP("Render Target", "render_target_");
@@ -3124,6 +3138,7 @@ Viewport::Viewport() {
 	disable_input = false;
 	disable_3d = false;
 	keep_3d_linear = false;
+	rgba8_out = false;
 
 	//window tooltip
 	gui.tooltip_timer = -1;

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -262,6 +262,7 @@ private:
 
 	MSAA msaa;
 	bool hdr;
+	bool rgba8_out;
 
 	Ref<ViewportTexture> default_texture;
 	Set<ViewportTexture *> viewport_textures;
@@ -469,6 +470,9 @@ public:
 
 	void set_keep_3d_linear(bool p_keep_3d_linear);
 	bool get_keep_3d_linear() const;
+
+	void set_rgba8_out(bool p_rgba8_out);
+	bool get_rgba8_out() const;
 
 	void set_attach_to_screen_rect(const Rect2 &p_rect);
 	Rect2 get_attach_to_screen_rect() const;

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -544,6 +544,7 @@ public:
 		RENDER_TARGET_NO_SAMPLING,
 		RENDER_TARGET_HDR,
 		RENDER_TARGET_KEEP_3D_LINEAR,
+		RENDER_TARGET_RGBA8_OUT,
 		RENDER_TARGET_FLAG_MAX
 	};
 
@@ -1099,7 +1100,7 @@ public:
 	virtual void initialize() = 0;
 	virtual void begin_frame(double frame_step) = 0;
 	virtual void set_current_render_target(RID p_render_target) = 0;
-	virtual void restore_render_target() = 0;
+	virtual void restore_render_target(bool p_3d_drawn = false) = 0;
 	virtual void clear_render_target(const Color &p_color) = 0;
 	virtual void blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen = 0) = 0;
 	virtual void output_lens_distorted_to_screen(RID p_render_target, const Rect2 &p_screen_rect, float p_k1, float p_k2, const Vector2 &p_eye_center, float p_oversample) = 0;

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -464,6 +464,7 @@ public:
 	BIND2(viewport_set_disable_environment, RID, bool)
 	BIND2(viewport_set_disable_3d, RID, bool)
 	BIND2(viewport_set_keep_3d_linear, RID, bool)
+	BIND2(viewport_set_rgba8_out, RID, bool)
 
 	BIND2(viewport_attach_camera, RID, RID)
 	BIND2(viewport_set_scenario, RID, RID)

--- a/servers/visual/visual_server_viewport.h
+++ b/servers/visual/visual_server_viewport.h
@@ -146,6 +146,7 @@ public:
 
 private:
 	Color clear_color;
+	void _draw_3d(Viewport *p_viewport, ARVRInterface::Eyes p_eye = ARVRInterface::EYE_MONO);
 	void _draw_viewport(Viewport *p_viewport, ARVRInterface::Eyes p_eye = ARVRInterface::EYE_MONO);
 
 public:
@@ -172,6 +173,7 @@ public:
 	void viewport_set_disable_environment(RID p_viewport, bool p_disable);
 	void viewport_set_disable_3d(RID p_viewport, bool p_disable);
 	void viewport_set_keep_3d_linear(RID p_viewport, bool p_keep_3d_linear);
+	void viewport_set_rgba8_out(RID p_viewport, bool p_rgba8_out);
 
 	void viewport_attach_camera(RID p_viewport, RID p_camera);
 	void viewport_set_scenario(RID p_viewport, RID p_scenario);

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -390,6 +390,7 @@ public:
 	FUNC2(viewport_set_disable_environment, RID, bool)
 	FUNC2(viewport_set_disable_3d, RID, bool)
 	FUNC2(viewport_set_keep_3d_linear, RID, bool)
+	FUNC2(viewport_set_rgba8_out, RID, bool)
 
 	FUNC2(viewport_attach_camera, RID, RID)
 	FUNC2(viewport_set_scenario, RID, RID)

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -635,6 +635,7 @@ public:
 	virtual void viewport_set_disable_environment(RID p_viewport, bool p_disable) = 0;
 	virtual void viewport_set_disable_3d(RID p_viewport, bool p_disable) = 0;
 	virtual void viewport_set_keep_3d_linear(RID p_viewport, bool p_disable) = 0;
+	virtual void viewport_set_rgba8_out(RID p_viewport, bool p_rgba8_out) = 0;
 
 	virtual void viewport_attach_camera(RID p_viewport, RID p_camera) = 0;
 	virtual void viewport_set_scenario(RID p_viewport, RID p_scenario) = 0;


### PR DESCRIPTION
**Note** I haven't tested this in VR yet to see if it indeed has the desired effect. Hope to do this tonight.

This PR adds a new setting to the viewport that if enabled adds an extra RGBA8 buffer to our viewport which will hold the final result of our rendering. We need this mainly because OpenVR does not accept 16 bits per pixel framebuffers when rendering in VR. There may however be other uses for this.

As 3D rendering still happens in HDR buffers and it is only the final tonemapping stage that now outputs into the 8bits per pixel buffer there is no performance penalty in this approach, only a memory penalty.
2D rendering will happen directly into the RGBA8 buffer when this is enabled in most scenarios. 

The setting is ignored if 3D is turned off on the viewport or if HDR is turned off on the viewport.

This should solve the banding issues we've experienced on OpenVR when turning off HDR.