### PR TITLE
Opens the menu with the same parent on mouse focus

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2972,7 +2972,6 @@ Control::Control() {
 	data.SI = NULL;
 	data.MI = NULL;
 	data.RI = NULL;
-	data.modal = false;
 	data.theme_owner = NULL;
 	data.modal_exclusive = false;
 	data.default_cursor = CURSOR_ARROW;

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -182,7 +182,6 @@ private:
 
 		Control *parent;
 		ObjectID drag_owner;
-		bool modal;
 		bool modal_exclusive;
 		uint64_t modal_frame; //frame used to put something as modal
 		Ref<Theme> theme;

--- a/scene/gui/menu_button.h
+++ b/scene/gui/menu_button.h
@@ -43,7 +43,6 @@ class MenuButton : public Button {
 	bool clicked;
 	bool disable_shortcuts;
 	PopupMenu *popup;
-	virtual void pressed();
 
 	void _unhandled_key_input(Ref<InputEvent> p_event);
 	Array _get_items() const;
@@ -55,6 +54,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual void pressed();
+
 	PopupMenu *get_popup() const;
 	void set_disable_shortcuts(bool p_disabled);
 


### PR DESCRIPTION
Fix #11692.

This code only consider menu button with text, if the button has an icon, it will be ignored. This seems to be the common behaviour in all programs I've tested.

Screencast:
![out_split mp4](https://user-images.githubusercontent.com/1387165/41810611-dddae93e-76d7-11e8-8d2e-6e30e68245a5.gif)

