### PR TITLE
Fix texscreen to return color/vec4 as in docs

### DIFF
--- a/drivers/gles2/shader_compiler_gles2.cpp
+++ b/drivers/gles2/shader_compiler_gles2.cpp
@@ -429,7 +429,7 @@ String ShaderCompilerGLES2::dump_node_code(SL::Node *p_node, int p_level, bool p
 					} else if (callfunc == "texscreen") {
 						//create the call to sample the screen, and clamp it
 						uses_texscreen = true;
-						code = "(texture2D( texscreen_tex, clamp((" + dump_node_code(onode->arguments[1], p_level) + ").xy*texscreen_screen_mult,texscreen_screen_clamp.xy,texscreen_screen_clamp.zw))).rgb";
+						code = "(texture2D( texscreen_tex, clamp((" + dump_node_code(onode->arguments[1], p_level) + ").xy*texscreen_screen_mult,texscreen_screen_clamp.xy,texscreen_screen_clamp.zw)))";
 						//code="(texture2D( screen_texture, ("+dump_node_code(onode->arguments[1],p_level)+").xy).rgb";
 						break;
 					} else if (callfunc == "texpos") {

--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -901,7 +901,7 @@ const ShaderLanguage::IntrinsicFuncDef ShaderLanguage::intrinsic_func_defs[] = {
 	//intrinsics - texture
 	{ "tex", TYPE_VEC4, { TYPE_TEXTURE, TYPE_VEC2, TYPE_VOID } },
 	{ "texcube", TYPE_VEC4, { TYPE_CUBEMAP, TYPE_VEC3, TYPE_VOID } },
-	{ "texscreen", TYPE_VEC3, { TYPE_VEC2, TYPE_VOID } },
+	{ "texscreen", TYPE_VEC4, { TYPE_VEC2, TYPE_VOID } },
 	{ "texpos", TYPE_VEC3, { TYPE_VEC3, TYPE_VOID } },
 
 	{ NULL, TYPE_VOID, { TYPE_VOID } }


### PR DESCRIPTION
`texscreen` behaves differently from `tex`, it returns `vec3` and I
think at the time the rationale was that you can't have alpha on a
screen taken picture, I mean it would be always 1.0. In any case, [the
documentaiton also says that it renturns color](http://docs.godotengine.org/en/2.1/learning/features/shading/shading_language.html#built-in-functions) which I think should be the
correct behavior. Ya... it's been ages, I thought I'd help close some of
my old issues, they bug me :D. Fixes #3651