### PR TITLE
[C#] Lerp now consistent with Godot API. InverseLerp fixed.

### DIFF
--- a/modules/mono/glue/cs_files/Mathf.cs
+++ b/modules/mono/glue/cs_files/Mathf.cs
@@ -150,7 +150,7 @@ namespace Godot
 
         public static real_t InverseLerp(real_t from, real_t to, real_t weight)
         {
-           return (Clamp(weight, 0f, 1f) - from) / (to - from);
+           return (weight - from) / (to - from);
         }
 
         public static bool IsInf(real_t s)
@@ -165,7 +165,7 @@ namespace Godot
 
         public static real_t Lerp(real_t from, real_t to, real_t weight)
         {
-            return from + (to - from) * Clamp(weight, 0f, 1f);
+            return from + (to - from) * weight;
         }
 
         public static real_t Log(real_t s)


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/19755

Lerp now consistent with Godot API. It was clamping weight between 0 and 1, but GDScript (and I'm assuming Godot cpp code) doesn't clamp the value. Has this been discussed before somewhere that C# should be different and should clamp the value? I might have missed this.

InverseLerp wasn't working at all, but should now be fixed. It doesn't clamp the value because GDScript doesn't clamp the value either.

I've added it to my Unit testing project: https://github.com/NathanWarden/godot-test-tools