### PR TITLE
Fix #19507 Not emitted particles affects performance

### DIFF
--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -677,6 +677,7 @@ public:
 	void particles_set_emission_transform(RID p_particles, const Transform &p_transform) {}
 
 	bool particles_get_emitting(RID p_particles) { return false; }
+	bool particles_get_inactive(RID p_particles) { return false; }
 	int particles_get_draw_passes(RID p_particles) const { return 0; }
 	RID particles_get_draw_pass_mesh(RID p_particles, int p_pass) const { return RID(); }
 

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -1616,6 +1616,10 @@ bool RasterizerStorageGLES2::particles_get_emitting(RID p_particles) {
 	return false;
 }
 
+bool RasterizerStorageGLES2::particles_get_inactive(RID p_particles) {
+	return false;
+}
+
 void RasterizerStorageGLES2::particles_set_amount(RID p_particles, int p_amount) {
 }
 

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -682,6 +682,7 @@ public:
 
 	virtual void particles_set_emitting(RID p_particles, bool p_emitting);
 	virtual bool particles_get_emitting(RID p_particles);
+	virtual bool particles_get_inactive(RID p_particles);
 
 	virtual void particles_set_amount(RID p_particles, int p_amount);
 	virtual void particles_set_lifetime(RID p_particles, float p_lifetime);

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1645,6 +1645,9 @@ void RasterizerSceneGLES3::_render_geometry(RenderList::Element *e) {
 			RasterizerStorageGLES3::Particles *particles = static_cast<RasterizerStorageGLES3::Particles *>(e->owner);
 			RasterizerStorageGLES3::Surface *s = static_cast<RasterizerStorageGLES3::Surface *>(e->geometry);
 
+			if (!particles->emitting && particles->inactive)
+				break;
+
 			if (!particles->use_local_coords) //not using local coordinates? then clear transform..
 				state.scene_shader.set_uniform(SceneShaderGLES3::WORLD_TRANSFORM, Transform());
 

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -5447,6 +5447,13 @@ bool RasterizerStorageGLES3::particles_get_emitting(RID p_particles) {
 	return particles->emitting;
 }
 
+bool RasterizerStorageGLES3::particles_get_inactive(RID p_particles) {
+	Particles *particles = particles_owner.getornull(p_particles);
+	ERR_FAIL_COND_V(!particles, false);
+
+	return particles->inactive;
+}
+
 void RasterizerStorageGLES3::particles_set_amount(RID p_particles, int p_amount) {
 
 	Particles *particles = particles_owner.getornull(p_particles);

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1213,6 +1213,7 @@ public:
 
 	virtual void particles_set_emitting(RID p_particles, bool p_emitting);
 	virtual bool particles_get_emitting(RID p_particles);
+	virtual bool particles_get_inactive(RID p_particles);
 	virtual void particles_set_amount(RID p_particles, int p_amount);
 	virtual void particles_set_lifetime(RID p_particles, float p_lifetime);
 	virtual void particles_set_one_shot(RID p_particles, bool p_one_shot);

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -477,6 +477,7 @@ public:
 
 	virtual void particles_set_emitting(RID p_particles, bool p_emitting) = 0;
 	virtual bool particles_get_emitting(RID p_particles) = 0;
+	virtual bool particles_get_inactive(RID p_particles) = 0;
 
 	virtual void particles_set_amount(RID p_particles, int p_amount) = 0;
 	virtual void particles_set_lifetime(RID p_particles, float p_lifetime) = 0;

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -388,6 +388,7 @@ public:
 
 	BIND2(particles_set_emitting, RID, bool)
 	BIND1R(bool, particles_get_emitting, RID)
+	BIND1R(bool, particles_get_inactive, RID)
 	BIND2(particles_set_amount, RID, int)
 	BIND2(particles_set_lifetime, RID, float)
 	BIND2(particles_set_one_shot, RID, bool)

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -1869,10 +1869,12 @@ void VisualServerScene::_prepare_scene(const Transform p_cam_transform, const Ca
 			InstanceGeometryData *geom = static_cast<InstanceGeometryData *>(ins->base_data);
 
 			if (ins->base_type == VS::INSTANCE_PARTICLES) {
-				//particles visible? process them
-				VSG::storage->particles_request_process(ins->base);
-				//particles visible? request redraw
-				VisualServerRaster::redraw_request();
+				if (VSG::storage->particles_get_emitting(ins->base) || !VSG::storage->particles_get_inactive(ins->base)) {
+					//particles visible? process them
+					VSG::storage->particles_request_process(ins->base);
+					//particles visible? request redraw
+					VisualServerRaster::redraw_request();
+				}
 			}
 
 			if (geom->lighting_dirty) {

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -322,6 +322,7 @@ public:
 
 	FUNC2(particles_set_emitting, RID, bool)
 	FUNC1R(bool, particles_get_emitting, RID)
+	FUNC1R(bool, particles_get_inactive, RID)
 	FUNC2(particles_set_amount, RID, int)
 	FUNC2(particles_set_lifetime, RID, float)
 	FUNC2(particles_set_one_shot, RID, bool)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1696,6 +1696,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("particles_create"), &VisualServer::particles_create);
 	ClassDB::bind_method(D_METHOD("particles_set_emitting", "particles", "emitting"), &VisualServer::particles_set_emitting);
 	ClassDB::bind_method(D_METHOD("particles_get_emitting", "particles"), &VisualServer::particles_get_emitting);
+	ClassDB::bind_method(D_METHOD("particles_get_inactive", "particles"), &VisualServer::particles_get_inactive);
 	ClassDB::bind_method(D_METHOD("particles_set_amount", "particles", "amount"), &VisualServer::particles_set_amount);
 	ClassDB::bind_method(D_METHOD("particles_set_lifetime", "particles", "lifetime"), &VisualServer::particles_set_lifetime);
 	ClassDB::bind_method(D_METHOD("particles_set_one_shot", "particles", "one_shot"), &VisualServer::particles_set_one_shot);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -508,6 +508,7 @@ public:
 
 	virtual void particles_set_emitting(RID p_particles, bool p_emitting) = 0;
 	virtual bool particles_get_emitting(RID p_particles) = 0;
+	virtual bool particles_get_inactive(RID p_particles) = 0;
 	virtual void particles_set_amount(RID p_particles, int p_amount) = 0;
 	virtual void particles_set_lifetime(RID p_particles, float p_lifetime) = 0;
 	virtual void particles_set_one_shot(RID p_particles, bool p_one_shot) = 0;


### PR DESCRIPTION
This PR is to fix #19507, where Particles3D uses ressources (mostly GPU) even when not emitting.