### PR TITLE
Implement OpenGL ES rasterizer selection logic for Android.

### DIFF
--- a/platform/android/java/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/src/org/godotengine/godot/Godot.java
@@ -32,6 +32,7 @@ package org.godotengine.godot;
 
 import android.R;
 import android.app.Activity;
+import android.content.pm.ConfigurationInfo;
 import android.os.Bundle;
 import android.view.MotionEvent;
 import android.view.View;
@@ -246,9 +247,11 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 		}
 	};
 
-	public void onVideoInit(boolean use_gl2) {
+	public void onVideoInit() {
 
-		//mView = new GodotView(getApplication(),io,use_gl2);
+		boolean use_gl3 = getGLESVersionCode() >= 0x00030000;
+
+		//mView = new GodotView(getApplication(),io,use_gl3);
 		//setContentView(mView);
 
 		layout = new FrameLayout(this);
@@ -261,7 +264,7 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 		// ...add to FrameLayout
 		layout.addView(edittext);
 
-		mView = new GodotView(getApplication(), io, use_gl2, use_32_bits, this);
+		mView = new GodotView(getApplication(), io, use_gl3, use_32_bits, this);
 		layout.addView(mView, new LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.FILL_PARENT));
 		edittext.setView(mView);
 		io.setEdit(edittext);
@@ -336,6 +339,12 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 
 	public static Godot getInstance() {
 		return Godot._self;
+	}
+
+	public int getGLESVersionCode() {
+		ActivityManager am = (ActivityManager)Godot.getInstance().getSystemService(Context.ACTIVITY_SERVICE);
+		ConfigurationInfo deviceInfo = am.getDeviceConfigurationInfo();
+		return deviceInfo.reqGlEsVersion;
 	}
 
 	private String[] getCommandLine() {

--- a/platform/android/java_glue.cpp
+++ b/platform/android/java_glue.cpp
@@ -614,6 +614,7 @@ static jmethodID _hideKeyboard = 0;
 static jmethodID _setScreenOrientation = 0;
 static jmethodID _getUniqueID = 0;
 static jmethodID _getSystemDir = 0;
+static jmethodID _getGLESVersionCode = 0;
 static jmethodID _playVideo = 0;
 static jmethodID _isVideoPlaying = 0;
 static jmethodID _pauseVideo = 0;
@@ -683,6 +684,11 @@ static String _get_system_dir(int p_dir) {
 	JNIEnv *env = ThreadAndroid::get_env();
 	jstring s = (jstring)env->CallObjectMethod(godot_io, _getSystemDir, p_dir);
 	return String(env->GetStringUTFChars(s, NULL));
+}
+
+static int _get_gles_version_code() {
+	JNIEnv *env = ThreadAndroid::get_env();
+	return env->CallIntMethod(_godot_instance, _getGLESVersionCode);
 }
 
 static void _hide_vk() {
@@ -764,9 +770,10 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_initialize(JNIEnv *en
 
 		godot_io = gob;
 
-		_on_video_init = env->GetMethodID(cls, "onVideoInit", "(Z)V");
+		_on_video_init = env->GetMethodID(cls, "onVideoInit", "()V");
 		_setKeepScreenOn = env->GetMethodID(cls, "setKeepScreenOn", "(Z)V");
 		_alertDialog = env->GetMethodID(cls, "alert", "(Ljava/lang/String;Ljava/lang/String;)V");
+		_getGLESVersionCode = env->GetMethodID(cls, "getGLESVersionCode", "()I");
 
 		jclass clsio = env->FindClass("org/godotengine/godot/Godot");
 		if (cls) {
@@ -800,16 +807,13 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_initialize(JNIEnv *en
 		AudioDriverAndroid::setup(gob);
 	}
 
-	os_android = new OS_Android(_gfx_init_func, env, _open_uri, _get_user_data_dir, _get_locale, _get_model, _get_screen_dpi, _show_vk, _hide_vk, _get_vk_height, _set_screen_orient, _get_unique_id, _get_system_dir, _play_video, _is_video_playing, _pause_video, _stop_video, _set_keep_screen_on, _alert, p_use_apk_expansion);
+	os_android = new OS_Android(_gfx_init_func, env, _open_uri, _get_user_data_dir, _get_locale, _get_model, _get_screen_dpi, _show_vk, _hide_vk, _get_vk_height, _set_screen_orient, _get_unique_id, _get_system_dir, _get_gles_version_code, _play_video, _is_video_playing, _pause_video, _stop_video, _set_keep_screen_on, _alert, p_use_apk_expansion);
 	os_android->set_need_reload_hooks(p_need_reload_hook);
 
 	char wd[500];
 	getcwd(wd, 500);
 
-	//video driver is determined here, because once initialized, it can't be changed
-	// String vd = ProjectSettings::get_singleton()->get("display/driver");
-
-	env->CallVoidMethod(_godot_instance, _on_video_init, (jboolean) true);
+	env->CallVoidMethod(_godot_instance, _on_video_init);
 }
 
 static void _initialize_java_modules() {

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -58,6 +58,7 @@ typedef void (*ShowVirtualKeyboardFunc)(const String &);
 typedef void (*HideVirtualKeyboardFunc)();
 typedef void (*SetScreenOrientationFunc)(int);
 typedef String (*GetSystemDirFunc)(int);
+typedef int (*GetGLVersionCodeFunc)();
 
 typedef void (*VideoPlayFunc)(const String &);
 typedef bool (*VideoIsPlayingFunc)();
@@ -126,6 +127,7 @@ private:
 	SetScreenOrientationFunc set_screen_orientation_func;
 	GetUniqueIDFunc get_unique_id_func;
 	GetSystemDirFunc get_system_dir_func;
+	GetGLVersionCodeFunc get_gl_version_code_func;
 
 	VideoPlayFunc video_play_func;
 	VideoIsPlayingFunc video_is_playing_func;
@@ -239,7 +241,7 @@ public:
 	void joy_connection_changed(int p_device, bool p_connected, String p_name);
 
 	virtual bool _check_internal_feature_support(const String &p_feature);
-	OS_Android(GFXInitFunc p_gfx_init_func, void *p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetUserDataDirFunc p_get_user_data_dir_func, GetLocaleFunc p_get_locale_func, GetModelFunc p_get_model_func, GetScreenDPIFunc p_get_screen_dpi_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk, VirtualKeyboardHeightFunc p_vk_height_func, SetScreenOrientationFunc p_screen_orient, GetUniqueIDFunc p_get_unique_id, GetSystemDirFunc p_get_sdir_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func, SetKeepScreenOnFunc p_set_keep_screen_on_func, AlertFunc p_alert_func, bool p_use_apk_expansion);
+	OS_Android(GFXInitFunc p_gfx_init_func, void *p_gfx_init_ud, OpenURIFunc p_open_uri_func, GetUserDataDirFunc p_get_user_data_dir_func, GetLocaleFunc p_get_locale_func, GetModelFunc p_get_model_func, GetScreenDPIFunc p_get_screen_dpi_func, ShowVirtualKeyboardFunc p_show_vk, HideVirtualKeyboardFunc p_hide_vk, VirtualKeyboardHeightFunc p_vk_height_func, SetScreenOrientationFunc p_screen_orient, GetUniqueIDFunc p_get_unique_id, GetSystemDirFunc p_get_sdir_func, GetGLVersionCodeFunc p_get_gl_version_func, VideoPlayFunc p_video_play_func, VideoIsPlayingFunc p_video_is_playing_func, VideoPauseFunc p_video_pause_func, VideoStopFunc p_video_stop_func, SetKeepScreenOnFunc p_set_keep_screen_on_func, AlertFunc p_alert_func, bool p_use_apk_expansion);
 	~OS_Android();
 };
 


### PR DESCRIPTION
If the device support OpenGL ES 3.0 the context is created with GLES3 support on the Java side.
The rasterizer version is decided by both the configuration in peoject settings and the device.

Fix #19761