### PR TITLE
mono: convert unicode mono root path to ascii string

### DIFF
--- a/modules/mono/mono_reg_utils.py
+++ b/modules/mono/mono_reg_utils.py
@@ -60,10 +60,10 @@ def _find_mono_in_reg_old(subkey, bits):
 def find_mono_root_dir(bits):
     root_dir = _find_mono_in_reg(r'SOFTWARE\Mono', bits)
     if root_dir is not None:
-        return root_dir
+        return str(root_dir)
     root_dir = _find_mono_in_reg_old(r'SOFTWARE\Novell\Mono', bits)
     if root_dir is not None:
-        return root_dir
+        return str(root_dir)
     return ''
 
 


### PR DESCRIPTION
Fixes #19739

scons was choking when the environment variables where unicode strings, this will convert compatible paths to ascii or throw an exception.