### PR TITLE
TypeDB and GDScript 'Scripts' global added.

### DIFF
--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -37,6 +37,17 @@ bool ScriptServer::scripting_enabled = true;
 bool ScriptServer::reload_scripts_on_save = false;
 ScriptEditRequestFunction ScriptServer::edit_request_func = NULL;
 
+Dictionary Script::get_script_metadata() {
+	if (has_method("_get_script_metadata")) {
+		Variant::CallError ce;
+		Variant ret = call("_get_script_metadata", NULL, 0, ce);
+		if (ce.error = Variant::CallError::CALL_OK) {
+			return (Dictionary)ret;
+		}
+	}
+	return Dictionary();
+}
+
 void Script::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_POSTINITIALIZE) {
@@ -61,6 +72,8 @@ void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_script_signal", "signal_name"), &Script::has_script_signal);
 
 	ClassDB::bind_method(D_METHOD("is_tool"), &Script::is_tool);
+
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo("_get_script_metadata"));
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "source_code", PROPERTY_HINT_NONE, "", 0), "set_source_code", "get_source_code");
 }

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -118,12 +118,14 @@ public:
 
 	virtual void update_exports() {} //editor tool
 	virtual void get_script_method_list(List<MethodInfo> *p_list) const = 0;
-	virtual void get_script_property_list(List<PropertyInfo> *p_list) const = 0;
+	virtual void get_script_property_list(List<PropertyInfo> *p_list, bool p_no_inherited = false) const = 0;
 
 	virtual int get_member_line(const StringName &p_member) const { return -1; }
 
 	virtual void get_constants(Map<StringName, Variant> *p_constants) {}
 	virtual void get_members(Set<StringName> *p_constants) {}
+
+	virtual Dictionary get_script_metadata();
 
 	Script() {}
 };

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -590,6 +590,23 @@ String String::camelcase_to_underscore(bool lowercase) const {
 	return lowercase ? new_string.to_lower() : new_string;
 }
 
+String String::typenamify() const {
+	String name = get_file().get_basename().strip_edges();
+	String result;
+
+	for (int i = 0; i < name.length() && name[i] == '_'; i++) {
+		result += '_';
+	}
+
+	result += name.capitalize().replace("_", "").replace(" ", "");
+
+	for (int i = name.length() - 1; i > 0 && name[i] == '_'; i++) {
+		result += '_';
+	}
+
+	return result;
+}
+
 int String::get_slice_count(String p_splitter) const {
 
 	if (empty())

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -166,6 +166,7 @@ public:
 	static int64_t to_int(const CharType *p_str, int p_len = -1);
 	String capitalize() const;
 	String camelcase_to_underscore(bool lowercase = true) const;
+	String typenamify() const;
 
 	int get_slice_count(String p_splitter) const;
 	String get_slice(String p_splitter, int p_slice) const;

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -101,6 +101,8 @@ public:
 
 	void popup_create(bool p_dont_clear, bool p_replace_mode = false);
 
+	void update_types();
+
 	CreateDialog();
 };
 

--- a/editor/doc/doc_data.h
+++ b/editor/doc/doc_data.h
@@ -35,6 +35,8 @@
 #include "map.h"
 #include "variant.h"
 
+class Script;
+
 class DocData {
 public:
 	struct ArgumentDoc {
@@ -103,6 +105,7 @@ public:
 	void merge_from(const DocData &p_data);
 	void remove_from(const DocData &p_data);
 	void generate(bool p_basic_types = false);
+	static String get_script_xml(Ref<Script> &p_script);
 	Error load_classes(const String &p_dir);
 	static Error erase_classes(const String &p_dir);
 	Error save_classes(const String &p_default_path, const Map<String, String> &p_class_path);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -402,6 +402,18 @@ void EditorNode::_notification(int p_what) {
 	}
 }
 
+void EditorNode::_on_plugin_ready(Object *p_script, const String &p_activate_name) {
+	Script *script = Object::cast_to<Script>(p_script);
+	if (!script)
+		return;
+	if (p_activate_name.length()) {
+		set_addon_plugin_enabled(p_activate_name, true);
+	}
+	project_settings->update_plugins();
+	project_settings->hide();
+	push_item(script);
+}
+
 void EditorNode::_fs_changed() {
 
 	for (Set<FileDialog *>::Element *E = file_dialogs.front(); E; E = E->next()) {
@@ -422,6 +434,7 @@ void EditorNode::_fs_changed() {
 		ResourceCache::get_cached_resources(&cached);
 		// FIXME: This should be done in a thread.
 		for (List<Ref<Resource> >::Element *E = cached.front(); E; E = E->next()) {
+			editor_data.get_type_db().update_res(String(E->get()->get_path()));
 
 			if (!E->get()->editor_can_reload_from_file())
 				continue;
@@ -441,6 +454,7 @@ void EditorNode::_fs_changed() {
 				changed.push_back(E->get());
 			}
 		}
+		editor_data.get_type_db().update_globals();
 
 		if (changed.size()) {
 			for (List<Ref<Resource> >::Element *E = changed.front(); E; E = E->next()) {
@@ -2257,6 +2271,13 @@ void EditorNode::_tool_menu_option(int p_idx) {
 		case TOOLS_ORPHAN_RESOURCES: {
 			orphan_resources->show();
 		} break;
+		case TOOLS_RELOAD_DOCS: {
+			OS *os = OS::get_singleton();
+			List<String> args;
+			args.push_back("--doctool");
+			args.push_back("\"" + os->get_executable_path().get_base_dir().get_base_dir() + "\"");
+			os->execute(os->get_executable_path(), args, false);
+		} break;
 		case TOOLS_CUSTOM: {
 			if (tool_menu->get_item_submenu(p_idx) == "") {
 				Array params = tool_menu->get_item_metadata(p_idx);
@@ -2434,6 +2455,13 @@ void EditorNode::add_editor_plugin(EditorPlugin *p_editor) {
 	}
 	singleton->editor_data.add_editor_plugin(p_editor);
 	singleton->add_child(p_editor);
+	if (!p_editor->get_script().is_null()) {
+		Ref<Script> script = p_editor->get_script();
+		if (script.is_valid()) {
+			String plugin_dir = "res://addons/" + script->get_path().get_slicec('/', 3);
+			singleton->editor_data.get_type_db().toggle_directory(plugin_dir, true);
+		}
+	}
 }
 
 void EditorNode::remove_editor_plugin(EditorPlugin *p_editor) {
@@ -2457,6 +2485,15 @@ void EditorNode::remove_editor_plugin(EditorPlugin *p_editor) {
 
 		singleton->editor_table.erase(p_editor);
 	}
+
+	if (!p_editor->get_script().is_null()) {
+		Ref<Script> script = p_editor->get_script();
+		if (script.is_valid()) {
+			String plugin_dir = "res://addons/" + script->get_path().get_slicec('/', 3);
+			singleton->editor_data.get_type_db().toggle_directory(plugin_dir, false);
+		}
+	}
+
 	p_editor->make_visible(false);
 	p_editor->clear();
 	singleton->editor_plugins_over->get_plugins_list().erase(p_editor);
@@ -2536,6 +2573,7 @@ void EditorNode::set_addon_plugin_enabled(const String &p_addon, bool p_enabled)
 
 	EditorPlugin *ep = memnew(EditorPlugin);
 	ep->set_script(script.get_ref_ptr());
+	ep->set_config(cf);
 	plugin_addons[p_addon] = ep;
 	add_editor_plugin(ep);
 
@@ -2545,6 +2583,11 @@ void EditorNode::set_addon_plugin_enabled(const String &p_addon, bool p_enabled)
 bool EditorNode::is_addon_plugin_enabled(const String &p_addon) const {
 
 	return plugin_addons.has(p_addon);
+}
+
+EditorPlugin *EditorNode::get_addon_plugin(const String &p_addon) {
+
+	return plugin_addons.has(p_addon) ? plugin_addons[p_addon] : NULL;
 }
 
 void EditorNode::_remove_edited_scene() {
@@ -4473,6 +4516,8 @@ void EditorNode::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_resources_reimported"), &EditorNode::_resources_reimported);
 
+	ClassDB::bind_method(D_METHOD("_on_plugin_ready"), &EditorNode::_on_plugin_ready);
+
 	ADD_SIGNAL(MethodInfo("play_pressed"));
 	ADD_SIGNAL(MethodInfo("pause_pressed"));
 	ADD_SIGNAL(MethodInfo("stop_pressed"));
@@ -5026,12 +5071,17 @@ EditorNode::EditorNode() {
 	p->connect("id_pressed", this, "_menu_option");
 	p->add_item(TTR("Export"), FILE_EXPORT_PROJECT);
 
+	plugin_create_dialog = memnew(PluginCreateDialog);
+	plugin_create_dialog->connect("plugin_ready", this, "_on_plugin_ready");
+	gui_base->add_child(plugin_create_dialog);
+
 	tool_menu = memnew(PopupMenu);
 	tool_menu->set_name("Tools");
 	tool_menu->connect("index_pressed", this, "_tool_menu_option");
 	p->add_child(tool_menu);
 	p->add_submenu_item(TTR("Tools"), "Tools");
 	tool_menu->add_item(TTR("Orphan Resource Explorer"), TOOLS_ORPHAN_RESOURCES);
+	tool_menu->add_item(TTR("Rebuild Documentation"), TOOLS_RELOAD_DOCS);
 	p->add_separator();
 
 #ifdef OSX_ENABLED

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -56,6 +56,7 @@
 #include "editor/inspector_dock.h"
 #include "editor/node_dock.h"
 #include "editor/pane_drag.h"
+#include "editor/plugin_create_dialog.h"
 #include "editor/progress_dialog.h"
 #include "editor/project_export.h"
 #include "editor/project_settings_editor.h"
@@ -143,6 +144,7 @@ private:
 		EDIT_REDO,
 		EDIT_REVERT,
 		TOOLS_ORPHAN_RESOURCES,
+		TOOLS_RELOAD_DOCS,
 		TOOLS_CUSTOM,
 		RESOURCE_SAVE,
 		RESOURCE_SAVE_AS,
@@ -244,6 +246,8 @@ private:
 	ToolButton *play_custom_scene_button;
 	ToolButton *search_button;
 	TextureProgress *audio_vu;
+
+	PluginCreateDialog *plugin_create_dialog;
 
 	RichTextLabel *load_errors;
 	AcceptDialog *load_error_dialog;
@@ -399,6 +403,8 @@ private:
 	void _menu_option_confirm(int p_option, bool p_confirmed);
 	void _tool_menu_option(int p_idx);
 	void _update_debug_options();
+
+	void _on_plugin_ready(Object *p_script, const String &p_activate_name);
 
 	void _fs_changed();
 	void _resources_reimported(const Vector<String> &p_resources);
@@ -617,6 +623,7 @@ public:
 
 	void set_addon_plugin_enabled(const String &p_addon, bool p_enabled);
 	bool is_addon_plugin_enabled(const String &p_addon) const;
+	EditorPlugin *get_addon_plugin(const String &p_addon);
 
 	void edit_node(Node *p_node);
 	void edit_resource(const Ref<Resource> &p_resource) { inspector_dock->edit_resource(p_resource); };

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -91,11 +91,14 @@ public:
 
 	Control *get_base_control();
 
-	void set_plugin_enabled(const String &p_plugin, bool p_enabled);
-	bool is_plugin_enabled(const String &p_plugin) const;
+	void set_plugin_enabled(const String &p_plugin_dir_name, bool p_enabled);
+	bool is_plugin_enabled(const String &p_plugin_dir_name) const;
 
 	Error save_scene();
 	void save_scene_as(const String &p_scene, bool p_with_preview = true);
+
+	void load_class_docs(const String &p_dir = "");
+	void generate_script_docs(const String &p_script_path, const String &p_output_path = "");
 
 	Vector<Ref<Texture> > make_mesh_previews(const Vector<Ref<Mesh> > &p_meshes, int p_preview_size);
 
@@ -110,17 +113,18 @@ class EditorPlugin : public Node {
 
 	UndoRedo *_get_undo_redo() { return undo_redo; }
 
+	Ref<ConfigFile> _config;
+
 	bool input_event_forwarding_always_enabled;
 	bool force_draw_over_forwarding_enabled;
 
 	String last_main_screen_name;
 
+	String _get_type_name(const String &p_type, bool p_allow_class = false);
+
 protected:
 	static void _bind_methods();
 	UndoRedo &get_undo_redo() { return *undo_redo; }
-
-	void add_custom_type(const String &p_type, const String &p_base, const Ref<Script> &p_script, const Ref<Texture> &p_icon);
-	void remove_custom_type(const String &p_type);
 
 public:
 	enum CustomControlContainer {
@@ -158,6 +162,18 @@ public:
 	void add_tool_menu_item(const String &p_name, Object *p_handler, const String &p_callback, const Variant &p_ud = Variant());
 	void add_tool_submenu_item(const String &p_name, Object *p_submenu);
 	void remove_tool_menu_item(const String &p_name);
+
+	void add_custom_type(const StringName &p_type, const StringName &p_inherits, const Ref<Script> &p_script, const Ref<Texture> &p_icon = NULL, bool p_is_abstract = false);
+	void add_custom_scene(const StringName &p_type, const StringName &p_inherits, const Ref<PackedScene> &p_scene, const Ref<Texture> &p_icon = NULL, bool p_is_abstract = false);
+	void remove_custom_type(const StringName &p_type);
+	void remove_custom_scene(const StringName &p_type);
+	void toggle_custom_namespace(const String &p_namespace, bool p_active);
+	void toggle_custom_directory(const String &p_directory, bool p_active);
+
+	String get_domain();
+
+	Ref<ConfigFile> get_config() const { return _config; }
+	void set_config(const Ref<ConfigFile> &p_config) { _config = p_config; }
 
 	void set_input_event_forwarding_always_enabled();
 	bool is_input_event_forwarding_always_enabled() { return input_event_forwarding_always_enabled; }

--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -41,6 +41,9 @@ void EditorPluginSettings::_notification(int p_what) {
 
 	if (p_what == MainLoop::NOTIFICATION_WM_FOCUS_IN) {
 		update_plugins();
+	} else if (p_what == Node::NOTIFICATION_READY) {
+		plugin_create_dialog->connect("plugin_ready", EditorNode::get_singleton(), "_on_plugin_ready");
+		plugin_list->connect("button_pressed", this, "_cell_button_pressed");
 	}
 }
 
@@ -124,6 +127,7 @@ void EditorPluginSettings::update_plugins() {
 			item->set_range_config(3, 0, 1, 1);
 			item->set_text(3, "Inactive,Active");
 			item->set_editable(3, true);
+			item->add_button(4, get_icon("Edit", "EditorIcons"), BUTTON_PLUGIN_EDIT, false, TTR("Edit Plugin"));
 
 			if (EditorNode::get_singleton()->is_addon_plugin_enabled(d)) {
 				item->set_custom_color(3, get_color("success_color", "Editor"));
@@ -164,17 +168,44 @@ void EditorPluginSettings::_plugin_activity_changed() {
 		ti->set_custom_color(3, get_color("disabled_font_color", "Editor"));
 }
 
+void EditorPluginSettings::_create_clicked() {
+	plugin_create_dialog->config("");
+	plugin_create_dialog->popup_centered();
+}
+
+void EditorPluginSettings::_cell_button_pressed(Object *p_item, int p_column, int p_id) {
+	TreeItem *item = Object::cast_to<TreeItem>(p_item);
+	if (!item)
+		return;
+	if (p_id == BUTTON_PLUGIN_EDIT) {
+		if (p_column == 4) {
+			String dir = item->get_metadata(0);
+			plugin_create_dialog->config(dir);
+			plugin_create_dialog->popup_centered();
+		}
+	}
+}
+
 void EditorPluginSettings::_bind_methods() {
 
 	ClassDB::bind_method("update_plugins", &EditorPluginSettings::update_plugins);
+	ClassDB::bind_method("_create_clicked", &EditorPluginSettings::_create_clicked);
 	ClassDB::bind_method("_plugin_activity_changed", &EditorPluginSettings::_plugin_activity_changed);
+	ClassDB::bind_method("_cell_button_pressed", &EditorPluginSettings::_cell_button_pressed);
 }
 
 EditorPluginSettings::EditorPluginSettings() {
 
+	plugin_create_dialog = memnew(PluginCreateDialog);
+	plugin_create_dialog->config("");
+	add_child(plugin_create_dialog);
+
 	HBoxContainer *title_hb = memnew(HBoxContainer);
 	title_hb->add_child(memnew(Label(TTR("Installed Plugins:"))));
 	title_hb->add_spacer();
+	create_plugin = memnew(Button(TTR("Create")));
+	create_plugin->connect("pressed", this, "_create_clicked");
+	title_hb->add_child(create_plugin);
 	update_list = memnew(Button(TTR("Update")));
 	update_list->connect("pressed", this, "update_plugins");
 	title_hb->add_child(update_list);
@@ -182,19 +213,22 @@ EditorPluginSettings::EditorPluginSettings() {
 
 	plugin_list = memnew(Tree);
 	plugin_list->set_v_size_flags(SIZE_EXPAND_FILL);
-	plugin_list->set_columns(4);
+	plugin_list->set_columns(5);
 	plugin_list->set_column_titles_visible(true);
 	plugin_list->set_column_title(0, TTR("Name:"));
 	plugin_list->set_column_title(1, TTR("Version:"));
 	plugin_list->set_column_title(2, TTR("Author:"));
 	plugin_list->set_column_title(3, TTR("Status:"));
+	plugin_list->set_column_title(4, TTR("Edit:"));
 	plugin_list->set_column_expand(0, true);
 	plugin_list->set_column_expand(1, false);
 	plugin_list->set_column_expand(2, false);
 	plugin_list->set_column_expand(3, false);
+	plugin_list->set_column_expand(4, false);
 	plugin_list->set_column_min_width(1, 100 * EDSCALE);
 	plugin_list->set_column_min_width(2, 250 * EDSCALE);
 	plugin_list->set_column_min_width(3, 80 * EDSCALE);
+	plugin_list->set_column_min_width(4, 40 * EDSCALE);
 	plugin_list->set_hide_root(true);
 	plugin_list->connect("item_edited", this, "_plugin_activity_changed");
 

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_properties.h"
 #include "editor/editor_resource_preview.h"
+#include "editor_data.h"
 #include "editor_node.h"
 #include "editor_properties_array_dict.h"
 #include "scene/main/viewport.h"
@@ -1791,7 +1792,7 @@ void EditorPropertyResource::_menu_option(int p_which) {
 			Object *obj = ClassDB::instance(intype);
 
 			if (!obj) {
-				obj = EditorNode::get_editor_data().instance_custom_type(intype, "Resource");
+				obj = EditorNode::get_editor_data().get_type_db().instance(intype, EditorData::TYPEDB_TYPE_SCRIPT);
 			}
 
 			ERR_BREAK(!obj);
@@ -1832,48 +1833,36 @@ void EditorPropertyResource::_update_menu() {
 	} else if (base_type != "") {
 		int idx = 0;
 
-		Vector<EditorData::CustomType> custom_resources;
-
-		if (EditorNode::get_editor_data().get_custom_types().has("Resource")) {
-			custom_resources = EditorNode::get_editor_data().get_custom_types()["Resource"];
+		List<StringName> custom_resources;
+		EditorData::TypeDB &tdb = EditorNode::get_singleton()->get_editor_data().get_type_db();
+		tdb.get_class_list(&custom_resources, EditorData::TYPEDB_TYPE_SCRIPT);
+		for (List<StringName>::Element *E = custom_resources.front(); E; E = E->next()) {
+			if (!tdb.is_parent_class(E->get(), "Resource"))
+				custom_resources.erase(E->get());
 		}
 
 		for (int i = 0; i < base_type.get_slice_count(","); i++) {
 
 			String base = base_type.get_slice(",", i);
 
-			Set<String> valid_inheritors;
-			valid_inheritors.insert(base);
 			List<StringName> inheritors;
-			ClassDB::get_inheriters_from_class(base.strip_edges(), &inheritors);
+			inheritors.push_back(base);
+			ClassDB::get_inheriters_from_class(base, &inheritors);
 
-			for (int i = 0; i < custom_resources.size(); i++) {
-				inheritors.push_back(custom_resources[i].name);
+			for (List<StringName>::Element *E = custom_resources.front(); E; E = E->next()) {
+				if (tdb.is_parent_class(E->get(), base))
+					inheritors.push_back(E->get());
 			}
 
-			List<StringName>::Element *E = inheritors.front();
-			while (E) {
-				valid_inheritors.insert(E->get());
-				E = E->next();
-			}
-
-			for (Set<String>::Element *E = valid_inheritors.front(); E; E = E->next()) {
+			for (List<StringName>::Element *E = inheritors.front(); E; E = E->next()) {
 				String t = E->get();
 
-				bool is_custom_resource = false;
+				const EditorData::TypeInfo *res_ti = tdb.get_type_info(t, EditorData::TYPEDB_TYPE_SCRIPT);
 				Ref<Texture> icon;
-				if (!custom_resources.empty()) {
-					for (int i = 0; i < custom_resources.size(); i++) {
-						if (custom_resources[i].name == t) {
-							is_custom_resource = true;
-							if (custom_resources[i].icon.is_valid())
-								icon = custom_resources[i].icon;
-							break;
-						}
-					}
-				}
+				if (res_ti && res_ti->icon.is_valid())
+					icon = res_ti->icon;
 
-				if (!is_custom_resource && !ClassDB::can_instance(t))
+				if ((res_ti && res_ti->is_abstract) || (ClassDB::class_exists(t) && !ClassDB::can_instance(t)))
 					continue;
 
 				inheritors_array.push_back(t);

--- a/editor/plugin_create_dialog.cpp
+++ b/editor/plugin_create_dialog.cpp
@@ -1,0 +1,198 @@
+#include "plugin_create_dialog.h"
+
+#include "../core/io/config_file.h"
+#include "../core/os/dir_access.h"
+#include "../editor/editor_node.h"
+#include "../editor/editor_plugin.h"
+#include "../modules/gdscript/gdscript.h"
+#include "../scene/gui/grid_container.h"
+
+void PluginCreateDialog::_clear_fields() {
+	name_edit->set_text("");
+	subfolder_edit->set_text("");
+	desc_edit->set_text("");
+	author_edit->set_text("");
+	version_edit->set_text("");
+	script_edit->set_text("");
+}
+
+void PluginCreateDialog::_on_confirmed() {
+
+	String path = "res://addons/" + subfolder_edit->get_text();
+
+	if (!_edit_mode) {
+		DirAccess *d = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+		if (!d || d->make_dir_recursive(path) != OK)
+			return;
+	}
+
+	Ref<ConfigFile> cf = memnew(ConfigFile);
+	cf->set_value("plugin", "name", name_edit->get_text());
+	cf->set_value("plugin", "description", desc_edit->get_text());
+	cf->set_value("plugin", "author", author_edit->get_text());
+	cf->set_value("plugin", "version", version_edit->get_text());
+	cf->set_value("plugin", "script", script_edit->get_text());
+
+	cf->save(path.plus_file("plugin.cfg"));
+
+	if (!_edit_mode) {
+		String type = script_option_edit->get_item_text(script_option_edit->get_selected());
+
+		Ref<Script> script;
+
+		if (type == GDScriptLanguage::get_singleton()->get_name()) {
+			Ref<GDScript> gdscript = memnew(GDScript);
+			gdscript->set_source_code(
+					"tool\n"
+					"extends EditorPlugin\n"
+					"\n"
+					"func _enter_tree():\n"
+					"\tpass");
+			ResourceSaver::save(path.plus_file(script_edit->get_text()), gdscript);
+			script = gdscript;
+		}
+		//TODO: other languages
+
+		emit_signal("plugin_ready", script.operator->(), active_edit->is_pressed() ? name_edit->get_text() : "");
+	} else {
+		EditorNode::get_singleton()->get_project_settings()->update_plugins();
+	}
+	_clear_fields();
+}
+
+void PluginCreateDialog::_on_cancelled() {
+	_clear_fields();
+}
+
+void PluginCreateDialog::_on_required_text_changed(const String &p_text) {
+	String ext = script_option_edit->get_item_metadata(script_option_edit->get_selected());
+	get_ok()->set_disabled(script_edit->get_text().get_basename().empty() || script_edit->get_text().get_extension() != ext || name_edit->get_text().empty());
+}
+
+void PluginCreateDialog::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_READY: {
+			connect("confirmed", this, "_on_confirmed");
+			get_cancel()->connect("pressed", this, "_on_cancelled");
+		} break;
+	}
+}
+
+void PluginCreateDialog::config(const String &p_plugin_dir_name) {
+	if (p_plugin_dir_name.length()) {
+		EditorPlugin *plugin = EditorNode::get_singleton()->get_addon_plugin(p_plugin_dir_name);
+		Ref<ConfigFile> cf = plugin->get_config();
+
+		name_edit->set_text(cf->get_value("plugin", "name"));
+		subfolder_edit->set_text(p_plugin_dir_name); //make read-only
+		desc_edit->set_text(cf->get_value("plugin", "description"));
+		author_edit->set_text(cf->get_value("plugin", "author"));
+		version_edit->set_text(cf->get_value("plugin", "version"));
+		script_edit->set_text(cf->get_value("plugin", "script"));
+
+		_edit_mode = true;
+		active_edit->hide();
+		Object::cast_to<Label>(active_edit->get_parent()->get_child(active_edit->get_index() - 1))->hide();
+		subfolder_edit->hide();
+		Object::cast_to<Label>(subfolder_edit->get_parent()->get_child(subfolder_edit->get_index() - 1))->hide();
+		set_title(TTR("Edit a Plugin"));
+	} else {
+		_clear_fields();
+		_edit_mode = false;
+		active_edit->show();
+		Object::cast_to<Label>(active_edit->get_parent()->get_child(active_edit->get_index() - 1))->show();
+		subfolder_edit->show();
+		Object::cast_to<Label>(subfolder_edit->get_parent()->get_child(subfolder_edit->get_index() - 1))->show();
+		set_title(TTR("Create a Plugin"));
+	}
+	get_ok()->set_disabled(!_edit_mode);
+	get_ok()->set_text(_edit_mode ? TTR("Update") : TTR("Create"));
+}
+
+void PluginCreateDialog::_bind_methods() {
+	ClassDB::bind_method("_on_required_text_changed", &PluginCreateDialog::_on_required_text_changed);
+	ClassDB::bind_method("_on_confirmed", &PluginCreateDialog::_on_confirmed);
+	ClassDB::bind_method("_on_cancelled", &PluginCreateDialog::_on_cancelled);
+	ADD_SIGNAL(MethodInfo("plugin_ready", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script"), PropertyInfo(Variant::STRING, "activate_name")));
+}
+
+PluginCreateDialog::PluginCreateDialog() {
+	get_ok()->set_disabled(true);
+	set_hide_on_ok(true);
+
+	GridContainer *grid = memnew(GridContainer);
+	grid->set_columns(2);
+	add_child(grid);
+
+	Label *name_lb = memnew(Label);
+	name_lb->set_text(TTR("Plugin Name:"));
+	grid->add_child(name_lb);
+
+	name_edit = memnew(LineEdit);
+	name_edit->connect("text_changed", this, "_on_required_text_changed");
+	name_edit->set_placeholder("MyPlugin");
+	grid->add_child(name_edit);
+
+	Label *subfolder_lb = memnew(Label);
+	subfolder_lb->set_text(TTR("Subfolder:"));
+	grid->add_child(subfolder_lb);
+
+	subfolder_edit = memnew(LineEdit);
+	subfolder_edit->set_placeholder("\"my_plugin\" -> res://addons/my_plugin");
+	grid->add_child(subfolder_edit);
+
+	Label *desc_lb = memnew(Label);
+	desc_lb->set_text(TTR("Description:"));
+	grid->add_child(desc_lb);
+
+	desc_edit = memnew(TextEdit);
+	desc_edit->set_custom_minimum_size(Size2(400.0f, 50.0f));
+	grid->add_child(desc_edit);
+
+	Label *author_lb = memnew(Label);
+	author_lb->set_text(TTR("Author:"));
+	grid->add_child(author_lb);
+
+	author_edit = memnew(LineEdit);
+	author_edit->set_placeholder("Godette");
+	grid->add_child(author_edit);
+
+	Label *version_lb = memnew(Label);
+	version_lb->set_text(TTR("Version:"));
+	grid->add_child(version_lb);
+
+	version_edit = memnew(LineEdit);
+	version_edit->set_placeholder("1.0");
+	grid->add_child(version_edit);
+
+	Label *script_option_lb = memnew(Label);
+	script_option_lb->set_text(TTR("Language:"));
+	grid->add_child(script_option_lb);
+
+	script_option_edit = memnew(OptionButton);
+	script_option_edit->add_item(GDScriptLanguage::get_singleton()->get_name());
+	script_option_edit->set_item_metadata(0, GDScriptLanguage::get_singleton()->get_extension());
+	script_option_edit->select(0);
+	//TODO: add other languages
+	grid->add_child(script_option_edit);
+
+	Label *script_lb = memnew(Label);
+	script_lb->set_text(TTR("Script Name:"));
+	grid->add_child(script_lb);
+
+	script_edit = memnew(LineEdit);
+	script_edit->connect("text_changed", this, "_on_required_text_changed");
+	script_edit->set_placeholder("\"plugin.gd\" -> res://addons/my_plugin/plugin.gd");
+	grid->add_child(script_edit);
+
+	Label *active_lb = memnew(Label);
+	active_lb->set_text(TTR("Activate now?"));
+	grid->add_child(active_lb);
+
+	active_edit = memnew(CheckBox);
+	active_edit->set_pressed(true);
+	grid->add_child(active_edit);
+}
+
+PluginCreateDialog::~PluginCreateDialog() {
+}

--- a/editor/plugin_create_dialog.h
+++ b/editor/plugin_create_dialog.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  editor_plugin_settings.h                                             */
+/*  plugin_create_dialog.h                                               */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,42 +28,44 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef EDITORPLUGINSETTINGS_H
-#define EDITORPLUGINSETTINGS_H
+#ifndef PLUGIN_CREATE_DIALOG_H
+#define PLUGIN_CREATE_DIALOG_H
 
-#include "editor/plugin_create_dialog.h";
-#include "editor_data.h"
-#include "property_editor.h"
-#include "scene/gui/dialogs.h"
-#include "undo_redo.h"
+#include "../scene/gui/check_box.h"
+#include "../scene/gui/dialogs.h"
+#include "../scene/gui/line_edit.h"
+#include "../scene/gui/option_button.h"
+#include "../scene/gui/text_edit.h"
 
-class EditorPluginSettings : public VBoxContainer {
+class PluginCreateDialog : public ConfirmationDialog {
 
-	GDCLASS(EditorPluginSettings, VBoxContainer);
+	GDCLASS(PluginCreateDialog, ConfirmationDialog);
 
-	enum {
-		BUTTON_PLUGIN_EDIT
-	};
+	LineEdit *name_edit;
+	LineEdit *subfolder_edit;
+	TextEdit *desc_edit;
+	LineEdit *author_edit;
+	LineEdit *version_edit;
+	OptionButton *script_option_edit;
+	LineEdit *script_edit;
+	CheckBox *active_edit;
 
-	PluginCreateDialog *plugin_create_dialog;
-	Button *create_plugin;
-	Button *update_list;
-	Tree *plugin_list;
-	bool updating;
+	bool _edit_mode;
 
-	void _plugin_activity_changed();
-	void _create_clicked();
-	void _cell_button_pressed(Object *p_item, int p_column, int p_id);
+	void _clear_fields();
+	void _on_confirmed();
+	void _on_cancelled();
+	void _on_required_text_changed(const String &p_text);
 
 protected:
-	void _notification(int p_what);
-
+	virtual void _notification(int p_what);
 	static void _bind_methods();
 
 public:
-	void update_plugins();
+	void config(const String &p_plugin_dir_name);
 
-	EditorPluginSettings();
+	PluginCreateDialog();
+	~PluginCreateDialog();
 };
 
-#endif // EDITORPLUGINSETTINGS_H
+#endif

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -783,6 +783,10 @@ void ProjectSettingsEditor::popup_project_settings() {
 	plugin_settings->update_plugins();
 }
 
+void ProjectSettingsEditor::update_plugins() {
+	plugin_settings->update_plugins();
+}
+
 void ProjectSettingsEditor::_item_selected() {
 
 	TreeItem *ti = globals_editor->get_property_editor()->get_property_tree()->get_selected();

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -181,6 +181,7 @@ public:
 	static ProjectSettingsEditor *get_singleton() { return singleton; }
 	void popup_project_settings();
 	void set_plugins_page();
+	void update_plugins();
 
 	EditorAutoloadSettings *get_autoload_settings() { return autoload_settings; }
 

--- a/editor/property_editor.h
+++ b/editor/property_editor.h
@@ -143,6 +143,8 @@ class CustomPropertyEditor : public Popup {
 	void _create_dialog_callback();
 	void _create_selected_property(const String &p_prop);
 
+	Object *_instance_type(const String &p_type);
+
 	void _color_changed(const Color &p_color);
 	void _draw_easing();
 	void _menu_option(int p_which);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -252,7 +252,8 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 
 		if (!p_node->get_script().is_null()) {
 
-			item->add_button(0, get_icon("Script", "EditorIcons"), BUTTON_SCRIPT, false, TTR("Open Script"));
+			item->add_button(0, get_icon("Script", "EditorIcons"), BUTTON_SCRIPT, false, TTR("Open script"));
+			_update_script_button_alpha(item, p_node);
 		}
 
 		if (p_node->is_class("CanvasItem")) {
@@ -329,6 +330,18 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 	} else {
 		return true;
 	}
+}
+
+void SceneTreeEditor::_update_script_button_alpha(TreeItem *p_item, Node *p_node) {
+
+	Ref<Script> s = p_node->get_script();
+	bool script_is_custom = false;
+	EditorData::TypeDB &tdb = EditorNode::get_singleton()->get_editor_data().get_type_db();
+	if (s.is_valid() && tdb.has_path(s->get_path())) {
+		EditorData::TypeInfo &ti = tdb.get_path(s->get_path());
+		script_is_custom = ti.is_custom;
+	}
+	p_item->set_button_color(0, p_item->get_button_by_id(0, BUTTON_SCRIPT), Color(1, 1, 1, (script_is_custom ? 0.3 : 1)));
 }
 
 void SceneTreeEditor::_node_visibility_changed(Node *p_node) {

--- a/editor/scene_tree_editor.h
+++ b/editor/scene_tree_editor.h
@@ -110,6 +110,7 @@ class SceneTreeEditor : public Control {
 	void _node_script_changed(Node *p_node);
 	void _node_visibility_changed(Node *p_node);
 	void _update_visibility_color(Node *p_node, TreeItem *p_item);
+	void _update_script_button_alpha(TreeItem *p_item, Node *p_node);
 
 	void _node_replace_owner(Node *p_base, Node *p_node, Node *p_root);
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1310,7 +1310,7 @@ bool Main::start() {
 		{
 			DirAccessRef da = DirAccess::open(doc_tool);
 			if (!da) {
-				ERR_EXPLAIN("Argument supplied to --doctool must be a base godot build directory");
+				ERR_EXPLAIN("Argument supplied to --doctool must be a base godot build directory. Given: " + doc_tool);
 				ERR_FAIL_V(false);
 			}
 		}
@@ -1333,6 +1333,53 @@ bool Main::start() {
 			}
 		}
 
+		{
+			String path = "res://doc_classes";
+			if (DirAccess::exists(ProjectSettings::get_singleton()->globalize_path(path))) {
+				checked_paths.insert(path);
+				docsrc.load_classes(path);
+				print_line("Loading docs from: " + path);
+			}
+		}
+		{
+			Error err;
+			DirAccessRef da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+			if (da) {
+				da->change_dir(ProjectSettings::get_singleton()->globalize_path("res://addons/"));
+				da->list_dir_begin();
+				String path;
+				bool isdir;
+				path = da->get_next(&isdir);
+				while (path != String()) {
+					if (isdir) {
+						DirAccessRef subda = DirAccess::open("res://addons/" + path, &err);
+						if (subda) {
+							subda->list_dir_begin();
+							String sub_path;
+							bool subisdir;
+							sub_path = subda->get_next(&subisdir);
+							while (sub_path != String()) {
+								if (sub_path == "." || sub_path == "..") {
+									sub_path = da->get_next(&subisdir);
+									continue;
+								}
+								String doc_path = "res://addons/" + sub_path.plus_file("doc_classes");
+								if (subisdir && DirAccess::exists(doc_path) && !checked_paths.has(doc_path)) {
+									checked_paths.insert(doc_path);
+									docsrc.load_classes(doc_path);
+									print_line("Loading docs from: " + doc_path);
+								}
+								sub_path = da->get_next(&subisdir);
+							}
+							subda->list_dir_end();
+						}
+					}
+					path = da->get_next(&isdir);
+				}
+				da->list_dir_end();
+			}
+		}
+
 		String index_path = doc_tool.plus_file("doc/classes");
 		docsrc.load_classes(index_path);
 		checked_paths.insert(index_path);
@@ -1352,6 +1399,9 @@ bool Main::start() {
 	}
 
 #endif
+
+	GLOBAL_DEF("typedb/automation/inherit_by_typename_for_custom_types", true);
+	GLOBAL_DEF("typedb/automation/auto_generate_custom_script_docs", false);
 
 	if (_export_preset != "") {
 		if (game_path == "") {

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -353,7 +353,7 @@ void NativeScript::get_script_method_list(List<MethodInfo> *p_list) const {
 	}
 }
 
-void NativeScript::get_script_property_list(List<PropertyInfo> *p_list) const {
+void NativeScript::get_script_property_list(List<PropertyInfo> *p_list, bool p_no_inherited) const {
 	NativeScriptDesc *script_data = get_script_desc();
 
 	Set<StringName> existing_properties;
@@ -367,6 +367,10 @@ void NativeScript::get_script_property_list(List<PropertyInfo> *p_list) const {
 				existing_properties.insert(E.key());
 			}
 		}
+
+		if (p_no_inherited)
+			break;
+
 		script_data = script_data->base_data;
 	}
 }

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -162,7 +162,7 @@ public:
 
 	virtual void update_exports(); //editor tool
 	virtual void get_script_method_list(List<MethodInfo> *p_list) const;
-	virtual void get_script_property_list(List<PropertyInfo> *p_list) const;
+	virtual void get_script_property_list(List<PropertyInfo> *p_list, bool p_no_inherited = false) const;
 
 	String get_class_documentation() const;
 	String get_method_documentation(const StringName &p_method) const;

--- a/modules/gdnative/pluginscript/pluginscript_script.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_script.cpp
@@ -279,7 +279,7 @@ void PluginScript::get_script_method_list(List<MethodInfo> *r_methods) const {
 	}
 }
 
-void PluginScript::get_script_property_list(List<PropertyInfo> *r_properties) const {
+void PluginScript::get_script_property_list(List<PropertyInfo> *r_properties, bool p_no_inherited) const {
 	ASSERT_SCRIPT_VALID();
 	for (Map<StringName, PropertyInfo>::Element *e = _properties_info.front(); e != NULL; e = e->next()) {
 		r_properties->push_back(e->get());

--- a/modules/gdnative/pluginscript/pluginscript_script.h
+++ b/modules/gdnative/pluginscript/pluginscript_script.h
@@ -112,7 +112,7 @@ public:
 
 	virtual void update_exports();
 	virtual void get_script_method_list(List<MethodInfo> *r_methods) const;
-	virtual void get_script_property_list(List<PropertyInfo> *r_properties) const;
+	virtual void get_script_property_list(List<PropertyInfo> *r_properties, bool p_no_inherited = false) const;
 
 	virtual int get_member_line(const StringName &p_member) const;
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -58,6 +58,7 @@ class GDScript : public Script {
 	GDCLASS(GDScript, Script);
 	bool tool;
 	bool valid;
+	bool instanceable;
 
 	struct MemberInfo {
 		int index;
@@ -186,7 +187,7 @@ public:
 	virtual bool has_method(const StringName &p_method) const;
 	virtual MethodInfo get_method_info(const StringName &p_method) const;
 
-	virtual void get_script_property_list(List<PropertyInfo> *p_list) const;
+	virtual void get_script_property_list(List<PropertyInfo> *p_list, bool p_no_inherited = false) const;
 
 	virtual ScriptLanguage *get_language() const;
 
@@ -201,6 +202,8 @@ public:
 
 	virtual void get_constants(Map<StringName, Variant> *p_constants);
 	virtual void get_members(Set<StringName> *p_members);
+
+	virtual Dictionary get_script_metadata();
 
 	GDScript();
 	~GDScript();

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2183,7 +2183,7 @@ Ref<Script> CSharpScript::get_base_script() const {
 	return Ref<Script>();
 }
 
-void CSharpScript::get_script_property_list(List<PropertyInfo> *p_list) const {
+void CSharpScript::get_script_property_list(List<PropertyInfo> *p_list, bool p_no_inheritance) const {
 
 	for (Map<StringName, PropertyInfo>::Element *E = member_info.front(); E; E = E->next()) {
 		p_list->push_back(E->value());

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -152,7 +152,7 @@ public:
 	virtual void update_signals();
 
 	/* TODO */ virtual bool get_property_default_value(const StringName &p_property, Variant &r_value) const;
-	virtual void get_script_property_list(List<PropertyInfo> *p_list) const;
+	virtual void get_script_property_list(List<PropertyInfo> *p_list, bool p_no_inheritance = false) const;
 	virtual void update_exports();
 
 	virtual bool is_tool() const { return tool; }

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -1071,7 +1071,7 @@ MethodInfo VisualScript::get_method_info(const StringName &p_method) const {
 	return mi;
 }
 
-void VisualScript::get_script_property_list(List<PropertyInfo> *p_list) const {
+void VisualScript::get_script_property_list(List<PropertyInfo> *p_list, bool p_no_inherited) const {
 
 	List<StringName> vars;
 	get_variable_list(&vars);

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -351,7 +351,7 @@ public:
 	virtual bool has_method(const StringName &p_method) const;
 	virtual MethodInfo get_method_info(const StringName &p_method) const;
 
-	virtual void get_script_property_list(List<PropertyInfo> *p_list) const;
+	virtual void get_script_property_list(List<PropertyInfo> *p_list, bool p_no_inherited = false) const;
 
 	virtual int get_member_line(const StringName &p_member) const;
 


### PR DESCRIPTION
@reduz @karroffel 

This PR makes several changes to a variety of systems in Godot, but it's meant to mostly be confined to the editor and gdscript areas.

The functional summary is that it permits the namespaced registration of scripts (eventually scenes), enables scripting languages to inspect this data, improves editor responsiveness to the registration of types without hiding any information about the presence of a script, and gives GDScript an interface to access and inherit from these registered scripts by name.

# Changes to Core

- The `Script` class now has a `get_script_metadata()` method. This method's purpose is purely to have an implementation-specific means of acquiring script data that is important to the Editor. I initially attempted to NOT have a method like this whereby the Editor would directly inspect the file extension of a script, open up the file, and parse data directly from the source code in an effort to not modify core. However, this was just as dirty/hacky as it sounds, and it isn't even applicable to things like NativeScript which have no perceptible source code. Instead, any script may now define this method (probably a static method) to return a Dictionary containing the relevant editor metadata. It's simpler, cross-language compatible, and has been given a default implementation to return the results of the defined method, if it exists.

- To simplify the implementation of a method in the `DocData` class which can generate an XML documentation file from a `Script` class, I appended a defaulted-to-false `p_no_inheritance` boolean parameter to the `get_script_property_list` method so that I could more easily extract only the properties related to the current script when generating documentation. I also have in mind to re-apply this method in the unrelated PR #13116.

# Major Changes

- The custom type system in EditorData has been replaced with a TypeDB class that allows users to register types of scripts. It is designed with the intention of eventually including scenes as well, but the UI for this has not been implemented.

    - The TypeDB has a set of methods which mimic the behavior of the ClassDB. The only one of these methods which actually wraps ClassDB functionality is the `is_parent_class` method.
    - TypeDB types are distinguished from ClassDB types in that they *must* have a namespace prefix, designated with a period '.' delimeter. Only C++ types will exist in the global namespace.
    - For backwards compatibility, the `EditorPlugin::add_custom_type()` method inserts the "Custom." namespace as a prefix to any registered types which do not already have a namespace.
    - Whenever the filesystem is changed, the TypeDB is serialized into a `StringName typename => String filepath` Dictionary stored in ProjectSettings at `typedb/scripts` and `typedb/scenes`.

- The GDScript language accesses the TypeDB's serialized data from ProjectSettings to generate a pair of `Scripts` and `Scenes` globals.

    - The parser identifies usages of these globals and parses their subsequent identifiers for matching namespaced typenames. If one is found, the parser interprets it as a `RESOURCE_LOAD` operation with the filepath as a parameter.
    - The parser also puts together a Scripts.Namespace.Typename pattern for the `extends_class` array, enabling inheritance.
    - The compiler parses the inherited name and likewise tries to find a match in the Scripts global.

- GDScript files may now optionally export their class name, whether they are custom, and if custom, whether they are abstract and/or have a custom icon. This is executed using the `export` keyword and is expected to be the first line of a GDScript file, save for any comments.

        # my_node.gd, variations include...
        export("Game.MyNode") # merely registers the name in the Scripts global. No editor functionality.
        export("Game.MyNode", CUSTOM) # registered as custom type using base type icon
        export("Game.MyNode", CUSTOM, "res://icon_my_node.svg") # registered as custom type with custom icon.
        export("Game.MyNode", ABSTRACT, CUSTOM) # registered as abstract custom type (similar to CanvasItem) with the base type icon.
        export("Game.MyNode", ABSTRACT, CUSTOM, "res://icon_my_node.svg") # everything
        extends Node

- The Editor has improved responsiveness to custom types.

    - Custom types have a faded script icon in the Scene dock, indicating that the script is overrideable, but still a script. The "add a script" button is displayed if a node with a custom script is selected. Clicking on the faded script icon will take you to the custom script.
    - Clicking on the "add a script" button will open the `ScriptCreateDialog` with the `inherits` field pre-populated. The content here is determined by a method within the TypeDB in cases where the node already has a script that is a custom type.
    - Clicking the "remove script" button on a node with a script that derives a custom script in its inheritance hierarchy will remove the script, but reinstate the most-derived custom script.

- The `EditorPlugin` (Edit, moved to the `EditorInterface` for `EditorScript` compatibility) now has exposed API methods for XML documentation, namely, generating a file from a `Script` and loading up all files within a directory. These methods are mostly implemented within the `DocData` class.
- Edit: The EditorPluginSettings now has create and edit buttons which open a new PluginCreateDialog to simplify the process of building and editing plugins.
- Edit: A docs reload button now exists in Projects -> Tools -> Rebuild Documentation. It simply calls the godot executable with "--doctool ." parameters.
- Edit: The Editor now automatically adds and removes any *registered* custom types when the plugin is activated and deactivated, respectively. As such, if using exclusively GDScript at this point, all one needs is an EditorPlugin tool script defined (with no other content) in order to define custom types as a group.

A demo of the changes can be found on my [YouTube video](https://youtu.be/TwEV4NmcLT0). Note that the following issues from the video are already fixed:

1. Only pre-populating the `inherits` field of the `ScriptCreateDialog` when appropriate.
2. Making the icon an optional parameter in the GDScript class export.

During my rebase with master, the most conflicts I had were in the `editor_properties.cpp` file where many references to the old custom type system had been made. I believe I made the updates properly, but I had trouble determining how to test the changed code.

Anyway, please let me know if there are additional changes I need to make before this can be integrated for 3.1.

# Known Bugs At This Time (Will Update)

- ~The Inspector is showing certain custom types in submenus when it shouldn't be.~
- Resolve conflicts that will inevitably happen with #19264 based on changes to the compiler.
- Refactor script accesses in GDScript (will be in separate branch, eventually merged in. Can be integrated before that's done).