### PR TITLE
Add an option to check if a node is a direct parent of the current node

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -339,8 +339,10 @@
 			</return>
 			<argument index="0" name="node" type="Node">
 			</argument>
+			<argument index="1" name="direct" type="bool">
+			</argument>
 			<description>
-				Returns [code]true[/code] if the given node is a direct or indirect child of the current node.
+				Returns [code]true[/code] if the given node is a direct or indirect child of the current node. If [code]direct[/code], returns [code]true[/code] if the given node is an immediate child of the current node.
 			</description>
 		</method>
 		<method name="is_displayed_folded" qualifiers="const">

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1309,17 +1309,21 @@ Node *Node::get_parent() const {
 	return data.parent;
 }
 
-bool Node::is_a_parent_of(const Node *p_node) const {
+bool Node::is_a_parent_of(const Node *p_node, bool p_direct) const {
 
 	ERR_FAIL_NULL_V(p_node, false);
 	Node *p = p_node->data.parent;
-	while (p) {
 
+	if (p_direct) {
 		if (p == this)
 			return true;
-		p = p->data.parent;
+	} else {
+		while (p) {
+			if (p == this)
+				return true;
+			p = p->data.parent;
+		}
 	}
-
 	return false;
 }
 
@@ -2582,7 +2586,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_node_and_resource", "path"), &Node::_get_node_and_resource);
 
 	ClassDB::bind_method(D_METHOD("is_inside_tree"), &Node::is_inside_tree);
-	ClassDB::bind_method(D_METHOD("is_a_parent_of", "node"), &Node::is_a_parent_of);
+	ClassDB::bind_method(D_METHOD("is_a_parent_of", "node", "direct"), &Node::is_a_parent_of, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("is_greater_than", "node"), &Node::is_greater_than);
 	ClassDB::bind_method(D_METHOD("get_path"), &Node::get_path);
 	ClassDB::bind_method(D_METHOD("get_path_to", "node"), &Node::get_path_to);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -257,7 +257,7 @@ public:
 
 	_FORCE_INLINE_ bool is_inside_tree() const { return data.inside_tree; }
 
-	bool is_a_parent_of(const Node *p_node) const;
+	bool is_a_parent_of(const Node *p_node, bool p_direct = false) const;
 	bool is_greater_than(const Node *p_node) const;
 
 	NodePath get_path() const;


### PR DESCRIPTION
This PR adds ability to check whether the given node is an immediate child of a current node, filtering out indirect children.

Shouldn't break the existing API (added simple boolean with default value)

Possible use case:

```gdscript
func _ready():
	get_tree().connect("node_added", self, "_on_node_added")

func _on_node_added(node):
	if is_a_parent_of(node, true):
		# Only care about instanced scenes disregarding their children
```