### PR TITLE
Fixed project settings overrides not using custom feature tags.

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -137,7 +137,7 @@ bool ProjectSettings::_set(const StringName &p_name, const Variant &p_value) {
 	else {
 
 		if (p_name == CoreStringNames::get_singleton()->_custom_features) {
-			Vector<String> custom_feature_array = p_value;
+			Vector<String> custom_feature_array = String(p_value).split(",");
 			for (int i = 0; i < custom_feature_array.size(); i++) {
 
 				custom_features.insert(custom_feature_array[i]);


### PR DESCRIPTION
Custom feature tags were not being parsed correctly in ProjectSettings::_set. This prevented them from being used to override project settings.