### PR TITLE
Explicitly disable WebAssembly in HTML5 builds

### DIFF
--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -91,6 +91,7 @@ def configure(env):
         env.Append(LINKFLAGS=['--compression', lzma_binpath + "," + lzma_decoder + "," + lzma_dec])
 
     env.Append(LINKFLAGS=['-s', 'ASM_JS=1'])
+    env.Append(LINKFLAGS=['-s', 'WASM=0'])
     env.Append(LINKFLAGS=['-s', 'EXTRA_EXPORTED_RUNTIME_METHODS="[\'FS\']"'])
     env.Append(LINKFLAGS=['--separate-asm'])
     env.Append(LINKFLAGS=['-O2'])


### PR DESCRIPTION
Emscripten enables WebAssembly by default since version 1.38.1, so disable it to force asm.js.