### PR TITLE
Add text_inserted and text_deleted signals to LineEdit.

### DIFF
--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -127,6 +127,20 @@
 				Emitted when the text changes.
 			</description>
 		</signal>
+		<signal name="text_inserted">
+			<argument index="0" name="text" type="String">
+			</argument>
+			<description>
+				Emitted when text is inserted.
+			</description>
+		</signal>
+		<signal name="text_deleted">
+			<argument index="0" name="text" type="String">
+			</argument>
+			<description>
+				Emitted when text is deleted.
+			</description>
+		</signal>
 		<signal name="text_entered">
 			<argument index="0" name="new_text" type="String">
 			</argument>


### PR DESCRIPTION
This continues my work on a Godot accessibility addon for blind users.

Without these signals, the only way to determine if text has been inserted or deleted is to do the following:
 * Cache the current text.
 * Hook the `text_changed` signal, then do the following:
   * Loop through the new text, comparing it with the old, to determine what text has been added. Correctly manage the index to avoid off-by-one errors in the diff, and also handle the corner case where text is pasted so more than one character was inserted.
   * Essentially do the opposite on deletion.
 * Cache the new text for future iterations.

This is certainly doable, but a huge mess, and realistically I'm probably going to be the only one developing this addon for quite some time. So if it doesn't need complex diffing logic right out of the gate, that's probably a massive plus.

It's probably also better to handle this directly in the engine, because the engine already knows when text is being inserted or deleted. As such, the logic is much simpler.

I'll gladly implement this in `TextEdit` once we've agreed on the design.

I'm a bit unclear how to handle the undo/redo case. Given that the only use for this is a screen reader, I'm happy just stating that the screen reader won't perfectly handle the undo/redo case for now, then punting implementation down the road for anyone else who may need it.

Thanks.