### PR TITLE
Survive editor crash if a plugin scene's root is null.

### DIFF
--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -310,7 +310,7 @@ void EditorPlugin::remove_autoload_singleton(const String &p_name) {
 }
 
 ToolButton *EditorPlugin::add_control_to_bottom_panel(Control *p_control, const String &p_title) {
-
+	ERR_FAIL_NULL_V(p_control, NULL);
 	return EditorNode::get_singleton()->add_bottom_panel_item(p_title, p_control);
 }
 
@@ -333,6 +333,7 @@ void EditorPlugin::remove_control_from_bottom_panel(Control *p_control) {
 }
 
 void EditorPlugin::add_control_to_container(CustomControlContainer p_location, Control *p_control) {
+	ERR_FAIL_NULL(p_control);
 
 	switch (p_location) {
 
@@ -382,6 +383,7 @@ void EditorPlugin::add_control_to_container(CustomControlContainer p_location, C
 }
 
 void EditorPlugin::remove_control_from_container(CustomControlContainer p_location, Control *p_control) {
+	ERR_FAIL_NULL(p_control);
 
 	switch (p_location) {
 


### PR DESCRIPTION
Fixes #19605.
Checks for null before attempting to add a plugin to the bottom dock.
