### PR TITLE
Fix memory leak in GDScript during infinnity loops with yields

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -1552,7 +1552,7 @@ Variant GDScriptFunctionState::_signal_callback(const Variant **p_args, int p_ar
 		GDScriptFunctionState *gdfs = Object::cast_to<GDScriptFunctionState>(ret);
 		if (gdfs && gdfs->function == function) {
 			completed = false;
-			gdfs->previous_state = Ref<GDScriptFunctionState>(this);
+			gdfs->first_state = first_state.is_valid() ? first_state : Ref<GDScriptFunctionState>(this);
 		}
 	}
 
@@ -1560,10 +1560,10 @@ Variant GDScriptFunctionState::_signal_callback(const Variant **p_args, int p_ar
 	state.result = Variant();
 
 	if (completed) {
-		GDScriptFunctionState *state = this;
-		while (state != NULL) {
-			state->emit_signal("completed", ret);
-			state = *(state->previous_state);
+		if (first_state.is_valid()) {
+			first_state->emit_signal("completed", ret);
+		} else {
+			emit_signal("completed", ret);
 		}
 	}
 
@@ -1614,7 +1614,7 @@ Variant GDScriptFunctionState::resume(const Variant &p_arg) {
 		GDScriptFunctionState *gdfs = Object::cast_to<GDScriptFunctionState>(ret);
 		if (gdfs && gdfs->function == function) {
 			completed = false;
-			gdfs->previous_state = Ref<GDScriptFunctionState>(this);
+			gdfs->first_state = first_state.is_valid() ? first_state : Ref<GDScriptFunctionState>(this);
 		}
 	}
 
@@ -1622,10 +1622,10 @@ Variant GDScriptFunctionState::resume(const Variant &p_arg) {
 	state.result = Variant();
 
 	if (completed) {
-		GDScriptFunctionState *state = this;
-		while (state != NULL) {
-			state->emit_signal("completed", ret);
-			state = *(state->previous_state);
+		if (first_state.is_valid()) {
+			first_state->emit_signal("completed", ret);
+		} else {
+			emit_signal("completed", ret);
 		}
 	}
 

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -234,7 +234,7 @@ class GDScriptFunctionState : public Reference {
 	GDScriptFunction *function;
 	GDScriptFunction::CallState state;
 	Variant _signal_callback(const Variant **p_args, int p_argcount, Variant::CallError &r_error);
-	Ref<GDScriptFunctionState> previous_state;
+	Ref<GDScriptFunctionState> first_state;
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
Fixes #19823 introduced in #17291

The code below passes assertions
```gd
extends Node

var iterations = 5;

func _ready():
	print("start single_yield()")
	assert(yield(single_yield(), "completed") == 1)
	print("done single_yield()")
	print("start three_yields()")
	assert(yield(three_yields(), "completed") == 3)
	print("done three_yields()")
	var num_objects = Performance.get_monitor(Performance.OBJECT_COUNT) - 2
	while iterations:
		yield(get_tree(), "idle_frame")
		yield(get_tree(), "idle_frame")
		yield(get_tree(), "idle_frame")
		var current_objects = Performance.get_monitor(Performance.OBJECT_COUNT)
		print("yield 3 idle frames, current objects == ", current_objects, ", awaits ", num_objects, " objects")
		assert(num_objects == current_objects)
		iterations -= 1
	
func single_yield():
	var i = 0
	print("  single_yield: -> yield1")
	yield(get_tree(), "idle_frame")
	print("  single_yield: -> yield1 ->")
	i += 1
	return i
	
func three_yields():
	var i = 0
	print(" three_yields: -> yield1")
	yield(get_tree(), "idle_frame")
	
	print(" three_yields: -> yield1 -> yield2")
	i += 1

	yield(get_tree(), "idle_frame")
	
	print(" three_yields: -> yield1 -> yield2 -> yield3")	
	i += 1

	yield(get_tree(), "idle_frame")
	
	i += 1
	print(" three_yields: -> yield1 -> yield2 -> yield3 ->")	
	return i
```
and produce output
```
start single_yield()
  single_yield: -> yield1
  single_yield: -> yield1 ->
done single_yield()
start three_yields()
 three_yields: -> yield1
 three_yields: -> yield1 -> yield2
 three_yields: -> yield1 -> yield2 -> yield3
 three_yields: -> yield1 -> yield2 -> yield3 ->
done three_yields()
yield 3 idle frames, current objects == 837, awaits 837 objects
yield 3 idle frames, current objects == 837, awaits 837 objects
yield 3 idle frames, current objects == 837, awaits 837 objects
yield 3 idle frames, current objects == 837, awaits 837 objects
yield 3 idle frames, current objects == 837, awaits 837 objects
```

Also I'm attaching example project witch fails with 3.0.3+ and passes with current pr.
[godot_yield_leak.zip](https://github.com/godotengine/godot/files/2145986/godot_yield_leak.zip)

CC @Warlaan