### PR TITLE
Revert "Fix saving unmodified scenes and resources"

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -587,7 +587,6 @@ void EditorNode::edit_node(Node *p_node) {
 void EditorNode::save_resource_in_path(const Ref<Resource> &p_resource, const String &p_path) {
 
 	editor_data.apply_changes_in_editors();
-
 	int flg = 0;
 	if (EditorSettings::get_singleton()->get("filesystem/on_save/compress_binary_resources"))
 		flg |= ResourceSaver::FLAG_COMPRESS;
@@ -1074,8 +1073,7 @@ void EditorNode::_save_scene(String p_file, int idx) {
 
 void EditorNode::_save_all_scenes() {
 
-	int i = _next_unsaved_scene(true, 0);
-	while (i != -1) {
+	for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
 		Node *scene = editor_data.get_edited_scene_root(i);
 		if (scene && scene->get_filename() != "") {
 			if (i != editor_data.get_edited_scene())
@@ -1083,7 +1081,6 @@ void EditorNode::_save_all_scenes() {
 			else
 				_save_scene_with_preview(scene->get_filename());
 		} // else: ignore new scenes
-		i = _next_unsaved_scene(true, ++i);
 	}
 
 	_save_default_environment();
@@ -1359,8 +1356,7 @@ void EditorNode::_save_default_environment() {
 	if (fallback.is_valid() && fallback->get_path().is_resource_file()) {
 		Map<RES, bool> processed;
 		_find_and_save_edited_subresources(fallback.ptr(), processed, 0);
-		if (fallback->get_last_modified_time() != fallback->get_import_last_modified_time())
-			save_resource_in_path(fallback, fallback->get_path());
+		save_resource_in_path(fallback, fallback->get_path());
 	}
 }
 


### PR DESCRIPTION
This reverts commits 28ab60422d648d43d219186ea0ecffce1645188f (#17589) and 7821b70a00768cb99c0b48450eabe5a687ae276c (#17747) (cc @robfram). A better fix will be needed for #6025.

Fixes #19576, and likely the fact that subresources are no longer saved when saving scenes with no change (cc @reduz).

This needs to be cherry-picked for 3.0.5 @hpvb, it fixes regressions from 3.0.3.