### PR TITLE
Respect window/handheld/orientation setting in iOS

### DIFF
--- a/misc/dist/ios_xcode/godot_ios/godot_ios-Info.plist
+++ b/misc/dist/ios_xcode/godot_ios/godot_ios-Info.plist
@@ -41,11 +41,15 @@
 	<array>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	$additional_plist_content
 </dict>

--- a/platform/iphone/os_iphone.cpp
+++ b/platform/iphone/os_iphone.cpp
@@ -64,11 +64,6 @@ OSIPhone *OSIPhone::get_singleton() {
 	return (OSIPhone *)OS::get_singleton();
 };
 
-uint8_t OSIPhone::get_orientations() const {
-
-	return supported_orientations;
-};
-
 extern int gl_view_base_fb; // from gl_view.mm
 
 void OSIPhone::set_data_dir(String p_dir) {
@@ -99,12 +94,6 @@ void OSIPhone::initialize_core() {
 };
 
 Error OSIPhone::initialize(const VideoMode &p_desired, int p_video_driver, int p_audio_driver) {
-
-	supported_orientations = 0;
-	supported_orientations |= ((GLOBAL_DEF("video_mode/allow_horizontal", true) ? 1 : 0) << LandscapeLeft);
-	supported_orientations |= ((GLOBAL_DEF("video_mode/allow_horizontal_flipped", false) ? 1 : 0) << LandscapeRight);
-	supported_orientations |= ((GLOBAL_DEF("video_mode/allow_vertical", false) ? 1 : 0) << PortraitDown);
-	supported_orientations |= ((GLOBAL_DEF("video_mode/allow_vertical_flipped", false) ? 1 : 0) << PortraitUp);
 
 	RasterizerGLES3::register_config();
 	RasterizerGLES3::make_current();

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -47,14 +47,6 @@
 
 class OSIPhone : public OS_Unix {
 
-public:
-	enum Orientations {
-		PortraitDown,
-		PortraitUp,
-		LandscapeLeft,
-		LandscapeRight,
-	};
-
 private:
 	enum {
 		MAX_MOUSE_COUNT = 8,
@@ -63,8 +55,6 @@ private:
 
 	static HashMap<String, void *> dynamic_symbol_lookup_table;
 	friend void register_dynamic_symbol(char *name, void *address);
-
-	uint8_t supported_orientations;
 
 	VisualServer *visual_server;
 

--- a/platform/iphone/view_controller.mm
+++ b/platform/iphone/view_controller.mm
@@ -83,48 +83,33 @@ int add_cmdline(int p_argc, char **p_args) {
 	printf("*********** did receive memory warning!\n");
 };
 
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)p_orientation {
-
-	if (/*OSIPhone::get_singleton() == NULL*/ TRUE) {
-
-		printf("checking on info.plist\n");
-		NSArray *arr = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"UISupportedInterfaceOrientations"];
-		switch (p_orientation) {
-
-			case UIInterfaceOrientationLandscapeLeft:
-				return [arr indexOfObject:@"UIInterfaceOrientationLandscapeLeft"] != NSNotFound ? YES : NO;
-
-			case UIInterfaceOrientationLandscapeRight:
-				return [arr indexOfObject:@"UIInterfaceOrientationLandscapeRight"] != NSNotFound ? YES : NO;
-
-			case UIInterfaceOrientationPortrait:
-				return [arr indexOfObject:@"UIInterfaceOrientationPortrait"] != NSNotFound ? YES : NO;
-
-			case UIInterfaceOrientationPortraitUpsideDown:
-				return [arr indexOfObject:@"UIInterfaceOrientationPortraitUpsideDown"] != NSNotFound ? YES : NO;
-
-			default:
-				return NO;
-		}
-	};
-
-	uint8_t supported = OSIPhone::get_singleton()->get_orientations();
-	switch (p_orientation) {
-
-		case UIInterfaceOrientationLandscapeLeft:
-			return supported & (1 << OSIPhone::LandscapeLeft) ? YES : NO;
-
-		case UIInterfaceOrientationLandscapeRight:
-			return supported & (1 << OSIPhone::LandscapeRight) ? YES : NO;
-
-		case UIInterfaceOrientationPortrait:
-			return supported & (1 << OSIPhone::PortraitDown) ? YES : NO;
-
-		case UIInterfaceOrientationPortraitUpsideDown:
-			return supported & (1 << OSIPhone::PortraitUp) ? YES : NO;
-
+- (BOOL)shouldAutorotate {
+	switch (OS::get_singleton()->get_screen_orientation()) {
+		case OS::SCREEN_SENSOR:
+		case OS::SCREEN_SENSOR_LANDSCAPE:
+		case OS::SCREEN_SENSOR_PORTRAIT:
+			return YES;
 		default:
 			return NO;
+	}
+};
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+	switch (OS::get_singleton()->get_screen_orientation()) {
+		case OS::SCREEN_PORTRAIT:
+			return UIInterfaceOrientationMaskPortrait;
+		case OS::SCREEN_REVERSE_LANDSCAPE:
+			return UIInterfaceOrientationMaskLandscapeRight;
+		case OS::SCREEN_REVERSE_PORTRAIT:
+			return UIInterfaceOrientationMaskPortraitUpsideDown;
+		case OS::SCREEN_SENSOR_LANDSCAPE:
+			return UIInterfaceOrientationMaskLandscape;
+		case OS::SCREEN_SENSOR_PORTRAIT:
+			return UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown;
+		case OS::SCREEN_SENSOR:
+			return UIInterfaceOrientationMaskAll;
+		case OS::SCREEN_LANDSCAPE:
+			return UIInterfaceOrientationMaskLandscapeLeft;
 	}
 };
 


### PR DESCRIPTION
This PR
- removes `video_mode/allow_*` properties (which are even no presented in my project settings)
- replaces deprecated UIViewController.shouldAutorotateToInterfaceOrientation with supportedInterfaceOrientations + shouldAutorotate
- it also now possible to have custom UIViewControllers to have own autorotate logic witch is very useful when implementing third-party integrations or custom plugins (my game is landscape for example, but ZendeskSupport plugin is hundred times more useful when it is portrait)