### PR TITLE
Fix the DynamicFont hinting setting being ineffective

### DIFF
--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -625,7 +625,7 @@ void DynamicFontAtSize::_update_char(CharType p_char) {
 			break;
 	}
 
-	int error = FT_Load_Char(face, p_char, FT_HAS_COLOR(face) ? FT_LOAD_COLOR : FT_LOAD_DEFAULT | (font->force_autohinter ? FT_LOAD_FORCE_AUTOHINT : 0));
+	int error = FT_Load_Char(face, p_char, FT_HAS_COLOR(face) ? FT_LOAD_COLOR : FT_LOAD_DEFAULT | (font->force_autohinter ? FT_LOAD_FORCE_AUTOHINT : 0) | ft_hinting);
 	if (error) {
 		char_map[p_char] = character;
 		return;


### PR DESCRIPTION
The `ft_hinting` variable set in the switch statement wasn't used anywhere, which made the Freetype font loader always use the default hinting option (which matches the "Normal" setting).