### PR TITLE
Expose ScriptCreateDialog to EditorPlugin

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -235,6 +235,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_script_create_dialog">
+			<return type="ScriptCreateDialog">
+			</return>
+			<description>
+				Gets the Editor's dialogue used for making scripts. Note that users can configure it before use.
+			</description>
+		</method>
 		<method name="get_state" qualifiers="virtual">
 			<return type="Dictionary">
 			</return>

--- a/doc/classes/ScriptCreateDialog.xml
+++ b/doc/classes/ScriptCreateDialog.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ScriptCreateDialog" inherits="ConfirmationDialog" category="Core" version="3.1">
+	<brief_description>
+		The Editor's popup dialog for creating new [Script] files.
+	</brief_description>
+	<description>
+		The ScriptCreateDialog creates script files according to a given template for a given scripting language. The standard use is to configure its fields prior to calling a [method popup]() method.
+		[codeblock]
+		func _ready():
+			dialog.config("Node", "res://new_node.gd") # for in-engine types
+			dialog.config("\"res://base_node.gd\"", "res://derived_node.gd") # for script types
+			dialog.popup_centered()
+		[/codeblock]
+	</description>
+	<tutorials>
+	</tutorials>
+	<demos>
+	</demos>
+	<methods>
+		<method name="config">
+			<return type="void">
+			</return>
+			<argument index="0" name="inherits" type="String">
+				The dialog's "Inherits" field content.
+			</argument>
+			<argument index="1" name="path" type="String">
+				The dialog's "Path" field content.
+			</argument>
+			<description>
+				Prefills required fields to configure the ScriptCreateDialog for use.
+			</description>
+		</method>
+	</methods>
+	<signals>
+		<signal name="script_created">
+			<argument index="0" name="script" type="Object">
+			</argument>
+			<description>
+				Emitted when the user clicks the OK button.
+			</description>
+		</signal>
+	</signals>
+	<constants>
+	</constants>
+</class>

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -58,6 +58,7 @@ class CreateDialog : public ConfirmationDialog {
 	String preferred_search_result_type;
 	EditorHelpBit *help_bit;
 	List<StringName> type_list;
+	Set<StringName> type_blacklist;
 
 	void _item_selected();
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3075,6 +3075,7 @@ void EditorNode::register_editor_types() {
 	ClassDB::register_class<EditorInspectorPlugin>();
 	ClassDB::register_class<EditorProperty>();
 	ClassDB::register_class<AnimationTrackEditPlugin>();
+	ClassDB::register_class<ScriptCreateDialog>();
 
 	// FIXME: Is this stuff obsolete, or should it be ported to new APIs?
 	ClassDB::register_class<EditorScenePostImport>();
@@ -4429,6 +4430,8 @@ void EditorNode::_bind_methods() {
 	ClassDB::bind_method("_open_recent_scene", &EditorNode::_open_recent_scene);
 
 	ClassDB::bind_method("stop_child_process", &EditorNode::stop_child_process);
+
+	ClassDB::bind_method("get_script_create_dialog", &EditorNode::get_script_create_dialog);
 
 	ClassDB::bind_method("_sources_changed", &EditorNode::_sources_changed);
 	ClassDB::bind_method("_fs_changed", &EditorNode::_fs_changed);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -598,6 +598,7 @@ public:
 	EditorPluginList *get_editor_plugins_force_input_forwarding() { return editor_plugins_force_input_forwarding; }
 	EditorInspector *get_inspector() { return inspector_dock->get_inspector(); }
 	Container *get_inspector_dock_addon_area() { return inspector_dock->get_addon_area(); }
+	ScriptCreateDialog *get_script_create_dialog() { return scene_tree_dock->get_script_create_dialog(); }
 
 	ProjectSettingsEditor *get_project_settings() { return project_settings; }
 

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -717,6 +717,10 @@ EditorInterface *EditorPlugin::get_editor_interface() {
 	return EditorInterface::get_singleton();
 }
 
+ScriptCreateDialog *EditorPlugin::get_script_create_dialog() {
+	return EditorNode::get_singleton()->get_script_create_dialog();
+}
+
 void EditorPlugin::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("add_control_to_container", "container", "control"), &EditorPlugin::add_control_to_container);
@@ -753,6 +757,7 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_force_draw_over_forwarding_enabled"), &EditorPlugin::set_force_draw_over_forwarding_enabled);
 
 	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorPlugin::get_editor_interface);
+	ClassDB::bind_method(D_METHOD("get_script_create_dialog"), &EditorPlugin::get_script_create_dialog);
 
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "forward_canvas_gui_input", PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo("forward_draw_over_viewport", PropertyInfo(Variant::OBJECT, "overlay", PROPERTY_HINT_RESOURCE_TYPE, "Control")));

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -34,6 +34,7 @@
 #include "editor/editor_inspector.h"
 #include "editor/import/editor_import_plugin.h"
 #include "editor/import/resource_importer_scene.h"
+#include "editor/script_create_dialog.h"
 #include "io/config_file.h"
 #include "scene/gui/tool_button.h"
 #include "scene/main/node.h"
@@ -195,6 +196,7 @@ public:
 	virtual bool build(); // builds with external tools. Returns true if safe to continue running scene.
 
 	EditorInterface *get_editor_interface();
+	ScriptCreateDialog *get_script_create_dialog();
 
 	int update_overlays() const;
 

--- a/editor/icons/icon_script_create_dialog.svg
+++ b/editor/icons/icon_script_create_dialog.svg
@@ -1,0 +1,10 @@
+<svg width="17.067" height="17.067" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<g transform="translate(0 -1036.4)">
+<path transform="translate(0 1036.4)" d="m6 1v1c-0.55228 0-1 0.44772-1 1v10h-1v-2h-2v2c2.826e-4 0.35698 0.19084 0.68674 0.5 0.86523 0.15194 0.088045 0.32439 0.13452 0.5 0.13477v1h6v-5l3-2v-3h3v-2c0-1.1046-0.89543-2-2-2z" fill="#a5efac"/>
+<path transform="translate(0 1036.4)" d="m6 1c-1.1046 0-2 0.89543-2 2v7h-3v3c0 1.1046 0.89543 2 2 2s2-0.89543 2-2v-10c0-0.55228 0.44772-1 1-1s1 0.44772 1 1v3h5v-1h-4v-2c0-1.1046-0.89543-2-2-2zm-4 10h2v2c0 0.55228-0.44772 1-1 1s-1-0.44772-1-1z" fill="#87e29f"/>
+<circle cx="3" cy="1048.4" r="0" fill="#e0e0e0"/>
+<ellipse cx="12" cy="1048.4" rx=".5" ry="3" fill="#87e29f"/>
+<ellipse transform="rotate(60)" cx="913.91" cy="513.79" rx=".5" ry="3" fill="#87e29f"/>
+<ellipse transform="rotate(120)" cx="901.91" cy="-534.57" rx=".5" ry="3" fill="#87e29f"/>
+</g>
+</svg>

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -215,6 +215,9 @@ public:
 	void replace_node(Node *p_node, Node *p_by_node);
 
 	void open_script_dialog(Node *p_for_node);
+
+	ScriptCreateDialog *get_script_create_dialog() { return script_create_dialog; }
+
 	SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSelection *p_editor_selection, EditorData &p_editor_data);
 };
 

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -582,6 +582,9 @@ void ScriptCreateDialog::_bind_methods() {
 	ClassDB::bind_method("_path_changed", &ScriptCreateDialog::_path_changed);
 	ClassDB::bind_method("_path_entered", &ScriptCreateDialog::_path_entered);
 	ClassDB::bind_method("_template_changed", &ScriptCreateDialog::_template_changed);
+
+	ClassDB::bind_method(D_METHOD("config", "inherits", "path"), &ScriptCreateDialog::config);
+
 	ADD_SIGNAL(MethodInfo("script_created", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));
 }
 


### PR DESCRIPTION
Solves #19458.

![expose_script_create_dialog_2](https://user-images.githubusercontent.com/16217563/42121678-09b37280-7bf9-11e8-98e3-f3e5cb43964e.png)
![expose_script_create_dialog_1](https://user-images.githubusercontent.com/16217563/42121677-099e6a16-7bf9-11e8-9918-58777172bf21.png)

Other issues...

1. The XML documentation doesn't want to seem to update the names/descriptions of the parameters in the config function. That is, if I generate the file and then modify it so it's filled, those values and others revert back to how they were beforehand when I run the doctool. Not sure if that's all a bug or if I'm just putting information in wrong. I didn't bother filling in the documentation until this problem is solved.

2. ~I created an `/editor/icons/icon_script_create_dialog.svg` file. It is a copy of the `icon_script.svg` file, but with the added InkScape filter to Colorize it so that it matches the color of a Control node. However, even after recompiling, the Classes API dialog that searches through types shows the node in its original color. Any idea as to how to fix it?~ Edit: I solved this problem by directly editing the fill color of the objects in the original, unoptimized svg files from the godot-design repo.

![expose_script_create_dialog_3](https://user-images.githubusercontent.com/16217563/42121714-96a70918-7bf9-11e8-8b05-7a338cf79515.png)
