### PR TITLE
Corrected art depo link in editor icons readme.

### DIFF
--- a/editor/icons/README.md
+++ b/editor/icons/README.md
@@ -2,11 +2,11 @@ The icons here are optimized SVGs, because the editor renders the svgs at runtim
 to be small in size, so they can be efficiently parsed.
 
 The original icons can be found at:
-https://github.com/djrm/godot-design/tree/master/assets/icons
+https://github.com/godotengine/godot-design/tree/master/engine/icons
 
 There you can find the optimizer script.
 
 If you add a new icon, please make a pull request to this repo:
-https://github.com/djrm/godot-design/
+https://github.com/godotengine/godot-design/
 
 and store the the optimized SVG version here.


### PR DESCRIPTION
Icons have moved in art depo. Updating link here to match.