### PR TITLE
Fix performance for godot's interface

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -160,9 +160,16 @@ void Control::_update_minimum_size_cache() {
 	Size2 minsize = get_minimum_size();
 	minsize.x = MAX(minsize.x, data.custom_minimum_size.x);
 	minsize.y = MAX(minsize.y, data.custom_minimum_size.y);
+
+	bool size_changed = false;
+	if (data.minimum_size_cache != minsize)
+		size_changed = true;
+
 	data.minimum_size_cache = minsize;
 	data.minimum_size_valid = true;
-	minimum_size_changed();
+
+	if (size_changed)
+		minimum_size_changed();
 }
 
 Size2 Control::get_combined_minimum_size() const {

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -942,6 +942,7 @@ void ItemList::_notification(int p_what) {
 				}
 			}
 
+			minimum_size_changed();
 			shape_changed = false;
 		}
 


### PR DESCRIPTION
Make godot performance great again :)

Fix #19864, Fix #12391.

This fix isn't only for TileMap, it's for all control nodes. All interface now is very smooth when doing resizing.

This was a regression from changes that I made here #19334.