### PR TITLE
Fix error msg when selecting popupmenu if there is no animation selected

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1102,9 +1102,12 @@ void AnimationPlayerEditor::_animation_about_to_show_menu() {
 
 void AnimationPlayerEditor::_animation_tool_menu(int p_option) {
 
-	String current = animation->get_item_text(animation->get_selected());
+	String current;
+	if (animation->get_selected() >= 0 && animation->get_selected() < animation->get_item_count())
+		current = animation->get_item_text(animation->get_selected());
+
 	Ref<Animation> anim;
-	if (current != "") {
+	if (current != String()) {
 		anim = player->get_animation(current);
 	}
 


### PR DESCRIPTION
When items in Animation menu and no animation selected, it will print error message to output tab.

![animation_edit_popup](https://user-images.githubusercontent.com/10296472/42132529-d60f99d0-7d43-11e8-85d4-c3b1901343ba.gif)
