### PR TITLE
Hide play position in animation editor if no animation node is selected

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -874,9 +874,11 @@ void AnimationTimelineEdit::set_animation(const Ref<Animation> &p_animation) {
 	if (animation.is_valid()) {
 		len_hb->show();
 		add_track->show();
+		play_position->show();
 	} else {
 		len_hb->hide();
 		add_track->hide();
+		play_position->hide();
 	}
 	update();
 	update_values();


### PR DESCRIPTION
Fix #19848