### PR TITLE
Makes the group dialog resizable

### DIFF
--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -444,6 +444,7 @@ GroupDialog::GroupDialog() {
 	set_title("Group Editor");
 	get_cancel()->hide();
 	set_as_toplevel(true);
+	set_resizable(true);
 
 	error = memnew(ConfirmationDialog);
 	add_child(error);


### PR DESCRIPTION
I can't see the full path of my nodes with default size:
![captura de tela de 2018-07-02 16-25-53](https://user-images.githubusercontent.com/1387165/42182741-a227ac66-7e15-11e8-9a28-37d932445141.png)
