### PR TITLE
Add custom toolbar to editor with EditorPlugin interface

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4711,6 +4711,12 @@ EditorNode::EditorNode() {
 	menu_hb = memnew(HBoxContainer);
 	main_vbox->add_child(menu_hb);
 
+	submenu_vb = memnew(VBoxContainer);
+	submenu_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	submenu_vb->set_custom_minimum_size(Size2(0, 20));
+	submenu_vb->set_visible(false);
+	main_vbox->add_child(submenu_vb);
+
 	left_l_hsplit = memnew(HSplitContainer);
 	main_vbox->add_child(left_l_hsplit);
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -226,6 +226,7 @@ private:
 
 	CenterContainer *play_cc;
 	HBoxContainer *menu_hb;
+	VBoxContainer *submenu_vb;
 	Control *viewport;
 	MenuButton *file_menu;
 	MenuButton *project_menu;
@@ -633,6 +634,7 @@ public:
 	static bool has_unsaved_changes() { return singleton->unsaved_cache; }
 
 	static HBoxContainer *get_menu_hb() { return singleton->menu_hb; }
+	static VBoxContainer *get_submenu_vb() { return singleton->submenu_vb; }
 
 	void push_item(Object *p_object, const String &p_property = "", bool p_inspector_only = false);
 	void edit_item(Object *p_object);

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -381,6 +381,80 @@ void EditorPlugin::add_control_to_container(CustomControlContainer p_location, C
 	}
 }
 
+void EditorPlugin::add_custom_toolbar(Control *p_control) {
+
+	HBoxContainer *toolbar = memnew(HBoxContainer);
+	toolbar->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	toolbar->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	EditorNode::get_submenu_vb()->add_child(toolbar);
+	toolbar->add_child(p_control);
+	Vector<Variant> args;
+	args.push_back(p_control);
+	p_control->connect("visibility_changed", this, "_toolbar_visibility_changed", args);
+}
+
+void EditorPlugin::remove_custom_toolbar(Control *p_control) {
+
+	VBoxContainer *submenu = EditorNode::get_submenu_vb();
+	for (int i = 0; i < submenu->get_child_count(); i++) {
+		Control *child = Object::cast_to<Control>(submenu->get_child(i));
+		if (child && child->get_child(0) == p_control) {
+			if (child->is_visible()) {
+				submenu->set_visible(false);
+			}
+			submenu->remove_child(p_control);
+		}
+	}
+}
+
+Control *EditorPlugin::get_custom_toolbar() {
+
+	VBoxContainer *submenu = EditorNode::get_submenu_vb();
+	for (int i = 0; i < submenu->get_child_count(); i++) {
+		Control *child = Object::cast_to<Control>(submenu->get_child(i));
+		if (child && child->is_visible()) {
+			Control *custom_toolbar = Object::cast_to<Control>(child->get_child(0));
+			if (custom_toolbar)
+				return custom_toolbar;
+		}
+	}
+	return NULL;
+}
+
+void EditorPlugin::show_custom_toolbar(Control *p_control) {
+
+	VBoxContainer *submenu = EditorNode::get_submenu_vb();
+	for (int i = 0; i < submenu->get_child_count(); i++) {
+		Control *child = Object::cast_to<Control>(submenu->get_child(i));
+		if (child) {
+			if (child->get_child(0) == p_control) {
+				submenu->set_visible(true);
+				child->set_visible(true);
+			} else {
+				child->set_visible(false);
+			}
+		}
+	}
+}
+
+void EditorPlugin::hide_custom_toolbar() {
+
+	VBoxContainer *submenu = EditorNode::get_submenu_vb();
+	submenu->set_visible(false);
+	for (int i = 0; i < submenu->get_child_count(); i++) {
+		Control *child = Object::cast_to<Control>(EditorNode::get_submenu_vb()->get_child(i));
+		if (child) {
+			child->set_visible(false);
+			break;
+		}
+	}
+}
+
+void EditorPlugin::_toolbar_visibility_changed(const Variant &p_control) {
+	//TODO
+	print_line("triggered!");
+}
+
 void EditorPlugin::remove_control_from_container(CustomControlContainer p_location, Control *p_control) {
 
 	switch (p_location) {
@@ -730,6 +804,13 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_tool_menu_item", "name"), &EditorPlugin::remove_tool_menu_item);
 	ClassDB::bind_method(D_METHOD("add_custom_type", "type", "base", "script", "icon"), &EditorPlugin::add_custom_type);
 	ClassDB::bind_method(D_METHOD("remove_custom_type", "type"), &EditorPlugin::remove_custom_type);
+
+	ClassDB::bind_method(D_METHOD("add_custom_toolbar", "control"), &EditorPlugin::add_custom_toolbar);
+	ClassDB::bind_method(D_METHOD("remove_custom_toolbar", "control"), &EditorPlugin::remove_custom_toolbar);
+	ClassDB::bind_method(D_METHOD("get_custom_toolbar"), &EditorPlugin::get_custom_toolbar);
+	ClassDB::bind_method(D_METHOD("show_custom_toolbar", "control"), &EditorPlugin::show_custom_toolbar);
+	ClassDB::bind_method(D_METHOD("hide_custom_toolbar"), &EditorPlugin::hide_custom_toolbar);
+	ClassDB::bind_method(D_METHOD("_toolbar_visibility_changed", "control"), &EditorPlugin::_toolbar_visibility_changed);
 
 	ClassDB::bind_method(D_METHOD("add_autoload_singleton", "name", "path"), &EditorPlugin::add_autoload_singleton);
 	ClassDB::bind_method(D_METHOD("remove_autoload_singleton", "name"), &EditorPlugin::remove_autoload_singleton);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -122,6 +122,8 @@ protected:
 	void add_custom_type(const String &p_type, const String &p_base, const Ref<Script> &p_script, const Ref<Texture> &p_icon);
 	void remove_custom_type(const String &p_type);
 
+	void _toolbar_visibility_changed(const Variant &p_control);
+
 public:
 	enum CustomControlContainer {
 		CONTAINER_TOOLBAR,
@@ -154,6 +156,12 @@ public:
 	void add_control_to_dock(DockSlot p_slot, Control *p_control);
 	void remove_control_from_docks(Control *p_control);
 	void remove_control_from_bottom_panel(Control *p_control);
+
+	void add_custom_toolbar(Control *p_control);
+	void remove_custom_toolbar(Control *p_control);
+	Control *get_custom_toolbar();
+	void show_custom_toolbar(Control *p_control);
+	void hide_custom_toolbar();
 
 	void add_tool_menu_item(const String &p_name, Object *p_handler, const String &p_callback, const Variant &p_ud = Variant());
 	void add_tool_submenu_item(const String &p_name, Object *p_submenu);


### PR DESCRIPTION
Implements #19922.

Will create a custom toolbar that only allows one to be shown at a time. Functions similarly to TabContainer, only its a VBoxContainer that automatically wraps any added controls with an HBoxContainer. Currently, you can add/remove custom toolbars, show/hide them, and get the active one. Because it's controlling visibility, you can check whether a current toolbar is active by checking whether it is visible.

It's getting late for me, and I wanna submit this now, but I'll update it soon so that it has a version that uses the "visibility_changed" signal callback rather than needing to use explicit show/hide methods for the custom toolbar. Will update here with a message once it's finished.

This shows what it looks like, but, as far as showcasing this particular usage, I would probably move the highlighted button to the main toolbar and have it show/hide my stuff whenever it's toggled.

![custom_toolbar](https://user-images.githubusercontent.com/16217563/42199210-d259e182-7e52-11e8-9655-63d9b7d6194d.png)


cc @eon-s @toger5 