### PR TITLE
Add editor configurable completion theme constants

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -815,6 +815,10 @@ void CodeTextEditor::_on_settings_change() {
 
 	enable_complete_timer = EDITOR_DEF("text_editor/completion/enable_code_completion_delay", true);
 
+	// Custom completion theme constants
+	text_editor->add_constant_override("completion_lines", EDITOR_DEF("text_editor/completion/completion_lines", 7));
+	text_editor->add_constant_override("completion_max_width", EDITOR_DEF("text_editor/completion/completion_max_width", 50));
+
 	// call hint settings
 	text_editor->set_callhint_settings(
 			EDITOR_DEF("text_editor/completion/put_callhint_tooltip_below_current_line", true),


### PR DESCRIPTION
This pr add 2 new configuration that override theme constants for editor textedit code completion. Now completion max width and lines can be customized in the editor settings.

![completioncfg](https://user-images.githubusercontent.com/10296472/42205473-c7dd13a6-7ece-11e8-885e-9acd168f2497.jpg)

![customwidthcompletion](https://user-images.githubusercontent.com/10296472/42205330-5c21e448-7ece-11e8-915b-49337bd7c571.jpg)

Fix #19893
