### PR TITLE
Fallback to default font if main/code font path doesn't exist

### DIFF
--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -31,6 +31,7 @@
 #include "editor_fonts.h"
 
 #include "builtin_fonts.gen.h"
+#include "core/os/dir_access.h"
 #include "editor_scale.h"
 #include "editor_settings.h"
 #include "scene/resources/default_theme/default_theme.h"
@@ -114,28 +115,34 @@ static Ref<BitmapFont> make_font(int p_height, int p_ascent, int p_valign, int p
 	MAKE_FALLBACKS(m_name);
 
 void editor_register_fonts(Ref<Theme> p_theme) {
+	DirAccess *dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+
 	/* Custom font */
 
 	DynamicFontData::Hinting font_hinting = (DynamicFontData::Hinting)(int)EditorSettings::get_singleton()->get("interface/editor/main_font_hinting");
 
 	String custom_font_path = EditorSettings::get_singleton()->get("interface/editor/main_font");
 	Ref<DynamicFontData> CustomFont;
-	if (custom_font_path.length() > 0) {
+	if (custom_font_path.length() > 0 && dir->file_exists(custom_font_path)) {
 		CustomFont.instance();
 		CustomFont->set_hinting(font_hinting);
 		CustomFont->set_font_path(custom_font_path);
 		CustomFont->set_force_autohinter(true); //just looks better..i think?
+	} else {
+		EditorSettings::get_singleton()->set_manually("interface/editor/main_font", "");
 	}
 
 	/* Custom Bold font */
 
 	String custom_font_path_bold = EditorSettings::get_singleton()->get("interface/editor/main_font_bold");
 	Ref<DynamicFontData> CustomFontBold;
-	if (custom_font_path_bold.length() > 0) {
+	if (custom_font_path_bold.length() > 0 && dir->file_exists(custom_font_path_bold)) {
 		CustomFontBold.instance();
 		CustomFontBold->set_hinting(font_hinting);
 		CustomFontBold->set_font_path(custom_font_path_bold);
 		CustomFontBold->set_force_autohinter(true); //just looks better..i think?
+	} else {
+		EditorSettings::get_singleton()->set_manually("interface/editor/main_font_bold", "");
 	}
 
 	/* Custom source code font */
@@ -143,11 +150,15 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	String custom_font_path_source = EditorSettings::get_singleton()->get("interface/editor/code_font");
 	DynamicFontData::Hinting font_source_hinting = (DynamicFontData::Hinting)(int)EditorSettings::get_singleton()->get("interface/editor/code_font_hinting");
 	Ref<DynamicFontData> CustomFontSource;
-	if (custom_font_path_source.length() > 0) {
+	if (custom_font_path_source.length() > 0 && dir->file_exists(custom_font_path_source)) {
 		CustomFontSource.instance();
 		CustomFontSource->set_hinting(font_source_hinting);
 		CustomFontSource->set_font_path(custom_font_path_source);
+	} else {
+		EditorSettings::get_singleton()->set_manually("interface/editor/code_font", "");
 	}
+
+	memdelete(dir);
 
 	/* Droid Sans */
 


### PR DESCRIPTION
Fallback to default font if main/code font path doesn't exist. Fixes #19859.

Idea is to check if file with specified path exists.