### PR TITLE
Added path_local, path_continuous_u and path_joined properties to CSGPolygon

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1585,7 +1585,11 @@ CSGBrush *CSGPolygon::_build_brush() {
 		case MODE_PATH: {
 			float bl = curve->get_baked_length();
 			int splits = MAX(2, Math::ceil(bl / path_interval));
-			face_count = triangles.size() * 2 / 3 + splits * final_polygon.size() * 2;
+			if (path_joined) {
+				face_count = splits * final_polygon.size() * 2;
+			} else {
+				face_count = triangles.size() * 2 / 3 + splits * final_polygon.size() * 2;
+			}
 		} break;
 	}
 
@@ -1793,8 +1797,14 @@ CSGBrush *CSGPolygon::_build_brush() {
 
 				float bl = curve->get_baked_length();
 				int splits = MAX(2, Math::ceil(bl / path_interval));
+				float u1 = 0.0;
+				float u2 = path_continuous_u ? 0.0 : 1.0;
 
-				Transform path_to_this = get_global_transform().affine_inverse() * path->get_global_transform();
+				Transform path_to_this;
+				if (!path_local) {
+					// center on paths origin
+					path_to_this = get_global_transform().affine_inverse() * path->get_global_transform();
+				}
 
 				Transform prev_xf;
 
@@ -1812,6 +1822,9 @@ CSGBrush *CSGPolygon::_build_brush() {
 				for (int i = 0; i <= splits; i++) {
 
 					float ofs = i * path_interval;
+					if (i == splits && path_joined) {
+						ofs = 0.0;
+					}
 
 					Transform xf;
 					xf.origin = curve->interpolate_baked(ofs);
@@ -1836,6 +1849,11 @@ CSGBrush *CSGPolygon::_build_brush() {
 					xf = path_to_this * xf;
 
 					if (i > 0) {
+						if (path_continuous_u) {
+							u1 = u2;
+							u2 += (prev_xf.origin - xf.origin).length();
+						};
+
 						//put triangles where they belong
 						//add triangles for depth
 						for (int j = 0; j < final_polygon.size(); j++) {
@@ -1850,10 +1868,10 @@ CSGBrush *CSGPolygon::_build_brush() {
 							};
 
 							Vector2 u[4] = {
-								Vector2(0, 0),
-								Vector2(0, 1),
-								Vector2(1, 1),
-								Vector2(1, 0)
+								Vector2(u1, 0),
+								Vector2(u1, 1),
+								Vector2(u2, 1),
+								Vector2(u2, 0)
 							};
 
 							// face 1
@@ -1888,7 +1906,7 @@ CSGBrush *CSGPolygon::_build_brush() {
 						}
 					}
 
-					if (i == 0) {
+					if (i == 0 && !path_joined) {
 
 						for (int j = 0; j < triangles.size(); j += 3) {
 							for (int k = 0; k < 3; k++) {
@@ -1905,7 +1923,7 @@ CSGBrush *CSGPolygon::_build_brush() {
 						}
 					}
 
-					if (i == splits) {
+					if (i == splits && !path_joined) {
 
 						for (int j = 0; j < triangles.size(); j += 3) {
 							for (int k = 0; k < 3; k++) {
@@ -2003,6 +2021,15 @@ void CSGPolygon::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_path_rotation", "mode"), &CSGPolygon::set_path_rotation);
 	ClassDB::bind_method(D_METHOD("get_path_rotation"), &CSGPolygon::get_path_rotation);
 
+	ClassDB::bind_method(D_METHOD("set_path_local", "enable"), &CSGPolygon::set_path_local);
+	ClassDB::bind_method(D_METHOD("is_path_local"), &CSGPolygon::is_path_local);
+
+	ClassDB::bind_method(D_METHOD("set_path_continuous_u", "enable"), &CSGPolygon::set_path_continuous_u);
+	ClassDB::bind_method(D_METHOD("is_path_continuous_u"), &CSGPolygon::is_path_continuous_u);
+
+	ClassDB::bind_method(D_METHOD("set_path_joined", "enable"), &CSGPolygon::set_path_joined);
+	ClassDB::bind_method(D_METHOD("is_path_joined"), &CSGPolygon::is_path_joined);
+
 	ClassDB::bind_method(D_METHOD("set_material", "material"), &CSGPolygon::set_material);
 	ClassDB::bind_method(D_METHOD("get_material"), &CSGPolygon::get_material);
 
@@ -2023,6 +2050,9 @@ void CSGPolygon::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "path_node", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Path"), "set_path_node", "get_path_node");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "path_interval", PROPERTY_HINT_EXP_RANGE, "0.001,1000.0,0.001,or_greater"), "set_path_interval", "get_path_interval");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "path_rotation", PROPERTY_HINT_ENUM, "Polygon,Path,PathFollow"), "set_path_rotation", "get_path_rotation");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "path_local"), "set_path_local", "is_path_local");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "path_continuous_u"), "set_path_continuous_u", "is_path_continuous_u");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "path_joined"), "set_path_joined", "is_path_joined");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "smooth_faces"), "set_smooth_faces", "get_smooth_faces");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "SpatialMaterial,ShaderMaterial"), "set_material", "get_material");
 
@@ -2065,6 +2095,15 @@ void CSGPolygon::set_depth(const float p_depth) {
 
 float CSGPolygon::get_depth() const {
 	return depth;
+}
+
+void CSGPolygon::set_path_continuous_u(bool p_enable) {
+	path_continuous_u = p_enable;
+	_make_dirty();
+}
+
+bool CSGPolygon::is_path_continuous_u() const {
+	return path_continuous_u;
 }
 
 void CSGPolygon::set_spin_degrees(const float p_spin_degrees) {
@@ -2119,6 +2158,26 @@ CSGPolygon::PathRotation CSGPolygon::get_path_rotation() const {
 	return path_rotation;
 }
 
+void CSGPolygon::set_path_local(bool p_enable) {
+	path_local = p_enable;
+	_make_dirty();
+	update_gizmo();
+}
+
+bool CSGPolygon::is_path_local() const {
+	return path_local;
+}
+
+void CSGPolygon::set_path_joined(bool p_enable) {
+	path_joined = p_enable;
+	_make_dirty();
+	update_gizmo();
+}
+
+bool CSGPolygon::is_path_joined() const {
+	return path_joined;
+}
+
 void CSGPolygon::set_smooth_faces(const bool p_smooth_faces) {
 	smooth_faces = p_smooth_faces;
 	_make_dirty();
@@ -2160,5 +2219,8 @@ CSGPolygon::CSGPolygon() {
 	smooth_faces = false;
 	path_interval = 1;
 	path_rotation = PATH_ROTATION_PATH;
+	path_local = false;
+	path_continuous_u = false;
+	path_joined = false;
 	path_cache = NULL;
 }

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -334,10 +334,13 @@ private:
 	NodePath path_node;
 	float path_interval;
 	PathRotation path_rotation;
+	bool path_local;
 
 	Node *path_cache;
 
 	bool smooth_faces;
+	bool path_continuous_u;
+	bool path_joined;
 
 	bool _is_editable_3d_polygon() const;
 	bool _has_editable_3d_polygon_no_depth() const;
@@ -374,6 +377,15 @@ public:
 
 	void set_path_rotation(PathRotation p_rotation);
 	PathRotation get_path_rotation() const;
+
+	void set_path_local(bool p_enable);
+	bool is_path_local() const;
+
+	void set_path_continuous_u(bool p_enable);
+	bool is_path_continuous_u() const;
+
+	void set_path_joined(bool p_enable);
+	bool is_path_joined() const;
 
 	void set_smooth_faces(bool p_smooth_faces);
 	bool get_smooth_faces() const;

--- a/modules/csg/doc_classes/CSGPolygon.xml
+++ b/modules/csg/doc_classes/CSGPolygon.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="CSGPolygon" inherits="CSGPrimitive" category="Core" version="3.1">
 	<brief_description>
+		Extrudes a 2D polygon shape to create a 3D mesh
 	</brief_description>
 	<description>
+		This node takes a 2D polygon shape and extrudes it to create a 3D mesh.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -12,38 +14,63 @@
 	</methods>
 	<members>
 		<member name="depth" type="float" setter="set_depth" getter="get_depth">
+			Extrusion depth when [member mode] is [constant MODE_DEPTH]
 		</member>
 		<member name="material" type="Material" setter="set_material" getter="get_material">
+			Material to use for the resulting mesh
 		</member>
 		<member name="mode" type="int" setter="set_mode" getter="get_mode" enum="CSGPolygon.Mode">
+			Extrusion mode
 		</member>
 		<member name="path_interval" type="float" setter="set_path_interval" getter="get_path_interval">
+			Interval at which a new extrusion slice is added along the path when [member mode] is [constant MODE_PATH]
 		</member>
 		<member name="path_node" type="NodePath" setter="set_path_node" getter="get_path_node">
+			The [Shape] object containing the path along which we extrude when [member mode] is [constant MODE_PATH]
 		</member>
 		<member name="path_rotation" type="int" setter="set_path_rotation" getter="get_path_rotation" enum="CSGPolygon.PathRotation">
+			The method by which each slice is rotated along the path when [member mode] is [constant MODE_PATH]
+		</member>
+		<member name="path_local" type="bool" setter="set_path_local" getter="is_path_local">
+			If false we extrude centered on our path, if true we extrude in relation to the position of our CSGPolygon when [member mode] is [constant MODE_PATH]
+		</member>
+		<member name="path_continuous_u" type="bool" setter="set_path_continuous_u" getter="is_path_continuous_u">
+			If true the u component of our uv will continuously increase in unison with the distance traveled along our path when [member mode] is [constant MODE_PATH]
+		</member>
+		<member name="path_joined" type="bool" setter="set_path_joined" getter="is_path_joined">
+			If true the start and end of our path are joined together ensuring there is no seam when [member mode] is [constant MODE_PATH]
 		</member>
 		<member name="polygon" type="PoolVector2Array" setter="set_polygon" getter="get_polygon">
+			Point array that defines the shape that we'll extrude
 		</member>
 		<member name="smooth_faces" type="bool" setter="set_smooth_faces" getter="get_smooth_faces">
+			Generates smooth normals so smooth shading is applied to our mesh
 		</member>
 		<member name="spin_degrees" type="float" setter="set_spin_degrees" getter="get_spin_degrees">
+			Degrees to rotate our extrusion for each slice when [member mode] is [constant MODE_SPIN]
 		</member>
 		<member name="spin_sides" type="int" setter="set_spin_sides" getter="get_spin_sides">
+			Number of extrusion when [member mode] is [constant MODE_SPIN]
 		</member>
 	</members>
 	<constants>
 		<constant name="MODE_DEPTH" value="0" enum="Mode">
+			Shape is extruded to [member depth]
 		</constant>
 		<constant name="MODE_SPIN" value="1" enum="Mode">
+			Shape is extruded by rotating it around an axis
 		</constant>
 		<constant name="MODE_PATH" value="2" enum="Mode">
+			Shape is extruded along a path set by a [Shape] set in [member path_node]
 		</constant>
 		<constant name="PATH_ROTATION_POLYGON" value="0" enum="PathRotation">
+			Slice is not rotated
 		</constant>
 		<constant name="PATH_ROTATION_PATH" value="1" enum="PathRotation">
+			Slice is rotated around the up vector of the path
 		</constant>
 		<constant name="PATH_ROTATION_PATH_FOLLOW" value="2" enum="PathRotation">
+			Slice is rotate to match the path exactly
 		</constant>
 	</constants>
 </class>


### PR DESCRIPTION
Add three new properties to CSGPolygon.

**path_local** toggles whether the transform of the Shape is used as our starting point or the transform of the polygon node. The default behavior was the use the transform from the Shape so the extrusion follows the path.

The problem with this approach is that if you want multiple shapes to follow the same path, they can't be moved into location. 

When the new property is turned on we use the transform of the CSGPolygon and the path is in essence transposed to the polygons location. We can now use the same path for multiple extrusion such as in this bridge:

![image](https://user-images.githubusercontent.com/1945449/42217164-81cf237a-7f07-11e8-95df-a27dfcd327c1.png)

**path_continuous_u** ensures the u component of our uv keeps increasing as the mesh is extruded along the path. This allows proper tiling of textures regardless of any scale that is applied to the UV.

**path_joined** will leave out the "end caps" and instead join the start of our shape to the end of our shape. 
While you can make sure that your curve nicely ends at the same position as it starts, getting the angle at which they join is near impossible resulting in a mismatch between start and end. 

*Bugsquad edit:* Fixes #19915.