### PR TITLE
[Regression] Fixed editor bad responsibility after #19244

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -1985,7 +1985,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	tab_container->add_child(plugin_settings);
 
 	timer = memnew(Timer);
-	timer->set_wait_time(0.1);
+	timer->set_wait_time(1.5);
 	timer->connect("timeout", ProjectSettings::get_singleton(), "save");
 	timer->set_one_shot(true);
 	add_child(timer);

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -493,7 +493,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	//get_cancel()->set_text("Close");
 
 	timer = memnew(Timer);
-	timer->set_wait_time(0.1);
+	timer->set_wait_time(1.5);
 	timer->connect("timeout", this, "_settings_save");
 	timer->set_one_shot(true);
 	add_child(timer);


### PR DESCRIPTION
Sorry about it, its barely visible bug I found after commit of #19244.

![image](https://user-images.githubusercontent.com/3036176/42235615-fc53b946-7f00-11e8-95c1-8d67787be2a7.png)

 Looks like this button become badly responsive after this PR, even decreasing the time only a bit affects it, and I think more editor elements could suffer from it, sadly but I need to revert a part of this PR about settings responsibility(but leave deferred_mode for colorpicker)


