### PR TITLE
Fix CORS problems due to added headers on JS target

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -30,6 +30,7 @@
 
 #include "http_client.h"
 #include "io/stream_peer_ssl.h"
+#include "version.h"
 
 const char *HTTPClient::_methods[METHOD_MAX] = {
 	"GET",
@@ -121,15 +122,29 @@ Error HTTPClient::request_raw(Method p_method, const String &p_url, const Vector
 		request += "Host: " + conn_host + ":" + itos(conn_port) + "\r\n";
 	}
 	bool add_clen = p_body.size() > 0;
+	bool add_uagent = true;
+	bool add_accept = true;
 	for (int i = 0; i < p_headers.size(); i++) {
 		request += p_headers[i] + "\r\n";
-		if (add_clen && p_headers[i].find("Content-Length:") == 0) {
+		if (add_clen && p_headers[i].findn("Content-Length:") == 0) {
 			add_clen = false;
+		}
+		if (add_uagent && p_headers[i].findn("User-Agent:") == 0) {
+			add_uagent = false;
+		}
+		if (add_accept && p_headers[i].findn("Accept:") == 0) {
+			add_accept = false;
 		}
 	}
 	if (add_clen) {
 		request += "Content-Length: " + itos(p_body.size()) + "\r\n";
 		// Should it add utf8 encoding?
+	}
+	if (add_uagent) {
+		request += "User-Agent: GodotEngine/" + String(VERSION_FULL_BUILD) + " (" + OS::get_singleton()->get_name() + ")\r\n";
+	}
+	if (add_accept) {
+		request += "Accept: */*\r\n";
 	}
 	request += "\r\n";
 	CharString cs = request.utf8();
@@ -173,16 +188,30 @@ Error HTTPClient::request(Method p_method, const String &p_url, const Vector<Str
 	} else {
 		request += "Host: " + conn_host + ":" + itos(conn_port) + "\r\n";
 	}
+	bool add_uagent = true;
+	bool add_accept = true;
 	bool add_clen = p_body.length() > 0;
 	for (int i = 0; i < p_headers.size(); i++) {
 		request += p_headers[i] + "\r\n";
-		if (add_clen && p_headers[i].find("Content-Length:") == 0) {
+		if (add_clen && p_headers[i].findn("Content-Length:") == 0) {
 			add_clen = false;
+		}
+		if (add_uagent && p_headers[i].findn("User-Agent:") == 0) {
+			add_uagent = false;
+		}
+		if (add_accept && p_headers[i].findn("Accept:") == 0) {
+			add_accept = false;
 		}
 	}
 	if (add_clen) {
 		request += "Content-Length: " + itos(p_body.utf8().length()) + "\r\n";
 		// Should it add utf8 encoding?
+	}
+	if (add_uagent) {
+		request += "User-Agent: GodotEngine/" + String(VERSION_FULL_BUILD) + " (" + OS::get_singleton()->get_name() + ")\r\n";
+	}
+	if (add_accept) {
+		request += "Accept: */*\r\n";
 	}
 	request += "\r\n";
 	request += p_body;

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -30,8 +30,6 @@
 
 #include "http_request.h"
 
-#include "version.h"
-
 void HTTPRequest::_redirect_request(const String &p_new_url) {
 }
 
@@ -106,27 +104,9 @@ Error HTTPRequest::request(const String &p_url, const Vector<String> &p_custom_h
 
 	validate_ssl = p_ssl_validate_domain;
 
-	bool has_user_agent = false;
-	bool has_accept = false;
 	headers = p_custom_headers;
 
 	request_data = p_request_data;
-
-	for (int i = 0; i < headers.size(); i++) {
-
-		if (headers[i].findn("user-agent:") == 0)
-			has_user_agent = true;
-		if (headers[i].findn("Accept:") == 0)
-			has_accept = true;
-	}
-
-	if (!has_user_agent) {
-		headers.push_back("User-Agent: GodotEngine/" + String(VERSION_FULL_BUILD) + " (" + OS::get_singleton()->get_name() + ")");
-	}
-
-	if (!has_accept) {
-		headers.push_back("Accept: */*");
-	}
 
 	requesting = true;
 


### PR DESCRIPTION
Currently, missing `User-Agent` and `Accept` headers are automatically added on all platforms. Setting the `User-Agent` header forces the browser to do a [CORS preflight](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Simple_requests) which fails if the HTTP endpoint is not configured appropriate. It's not necessary to set either header as the browser sets them so this commit disables that functionality on the JS target.