### PR TITLE
Mono: Fix build script not decoding process utf-8 output

### DIFF
--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -276,7 +276,10 @@ def pkgconfig_try_find_mono_version():
 
 
 def mono_root_try_find_mono_version(mono_root):
-    first_line = subprocess.check_output([os.path.join(mono_root, 'bin', 'mono'), '--version']).splitlines()[0]
+    from compat import decode_utf8
+
+    output = subprocess.check_output([os.path.join(mono_root, 'bin', 'mono'), '--version'])
+    first_line = decode_utf8(output.splitlines()[0])
     try:
         return LooseVersion(first_line.split()[len('Mono JIT compiler version'.split())])
     except (ValueError, IndexError):


### PR DESCRIPTION
Fixes #19961