### PR TITLE
Fixes Z-level 2d light problem introduced in #19807

### DIFF
--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -520,7 +520,8 @@ FRAGMENT_SHADER_CODE
 
 #ifdef USE_LIGHTING
 
-	vec2 light_vec = (inverse(light_matrix)*vec4(normalize(light_uv_interp.zw),0.0,0.0)).xy; //for normal mapping
+	mat3 inverse_light_matrix = mat3(inverse(light_matrix));
+	vec2 light_vec = (mat3(normalize(inverse_light_matrix[0]),normalize(inverse_light_matrix[1]),normalize(inverse_light_matrix[2])) * vec3(light_uv_interp.zw,0.0)).xy;
 
 	if (normal_used) {
 		normal.xy =  mat2(local_rot.xy,local_rot.zw) * normal.xy;
@@ -566,7 +567,7 @@ FRAGMENT_SHADER_CODE
 		color*=light;
 
 #ifdef USE_SHADOWS
-		light_vec = light_uv_interp.zw; //for shadows
+		light_vec = light_uv_interp.zw;
 		float angle_to_light = -atan(light_vec.x,light_vec.y);
 		float PI = 3.14159265358979323846264;
 		/*int i = int(mod(floor((angle_to_light+7.0*PI/6.0)/(4.0*PI/6.0))+1.0, 3.0)); // +1 pq os indices estao em ordem 2,0,1 nos arrays


### PR DESCRIPTION
While #19807 fixed normal mapping of rotating 2D lights, it introduced height issue for lights.
All credits go to @JFonS ; I just tested this in my fork and found it working as intended.