### PR TITLE
Additions to how the create node window handles custom types

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -232,6 +232,55 @@ void CreateDialog::add_type(const String &p_type, HashMap<String, TreeItem *> &p
 	p_types[p_type] = item;
 }
 
+void CreateDialog::add_custom_type(const String &p_type, Ref<Texture> p_icon, const String &parent_type, const String &built_in_parent_type, HashMap<String, TreeItem *> &p_types, TreeItem *p_root, TreeItem **to_select) {
+	if (p_types.has(p_type))
+		return;
+	if (p_type == base_type)
+		return;
+
+	bool show = search_box->get_text().is_subsequence_ofi(p_type);
+
+	if (!show)
+		return;
+
+	TreeItem *parent = p_root;
+
+	if (p_types.has(parent_type))
+		parent = p_types[parent_type];
+	else
+		parent = search_options->get_root();
+	TreeItem *item = search_options->create_item(parent);
+	item->set_text(0, p_type);
+
+	item->set_metadata(0, parent_type);
+	item->set_meta("built_in_type", built_in_parent_type);
+	bool is_search_subsequence = search_box->get_text().is_subsequence_ofi(p_type);
+	if ((!to_select && is_search_subsequence) || p_type == search_box->get_text()) {
+		*to_select = item;
+	}
+
+	if (bool(EditorSettings::get_singleton()->get("docks/scene_tree/start_create_dialog_fully_expanded"))) {
+		item->set_collapsed(false);
+	} else {
+		// don't collapse search results
+		bool collapse = (search_box->get_text() == "");
+		// don't collapse the root node
+		collapse &= (item != p_root);
+		// don't collapse abstract nodes on the first tree level
+		collapse &= ((parent != p_root) || (ClassDB::can_instance(p_type)));
+		item->set_collapsed(collapse);
+	}
+
+	const String &description = EditorHelp::get_doc_data()->class_list[p_type].brief_description;
+	item->set_tooltip(0, description);
+
+	if (p_icon.is_valid()) {
+		item->set_icon(0, p_icon);
+	}
+
+	p_types[p_type] = item;
+}
+
 void CreateDialog::_update_search() {
 
 	search_options->clear();
@@ -291,33 +340,21 @@ void CreateDialog::_update_search() {
 
 		if (EditorNode::get_editor_data().get_custom_types().has(type) && ClassDB::is_parent_class(type, base_type)) {
 			//there are custom types based on this... cool.
+			List<StringName> types_to_handle = List<StringName>();
 
-			const Vector<EditorData::CustomType> &ct = EditorNode::get_editor_data().get_custom_types()[type];
-			for (int i = 0; i < ct.size(); i++) {
+			types_to_handle.push_back(type);
 
-				bool show = search_box->get_text().is_subsequence_ofi(ct[i].name);
+			List<StringName>::Element *E = types_to_handle.front();
+			for (; E; E = E->next()) {
+				String current_type = E->get();
 
-				if (!show)
-					continue;
+				const Vector<EditorData::CustomType> &ct = EditorNode::get_editor_data().get_custom_types()[current_type];
+				for (int i = 0; i < ct.size(); i++) {
+					if (EditorNode::get_editor_data().get_custom_types().has(ct[i].name)) {
+						types_to_handle.push_back(ct[i].name);
+					}
 
-				if (!types.has(type))
-					add_type(type, types, root, &to_select);
-
-				TreeItem *ti;
-				if (types.has(type))
-					ti = types[type];
-				else
-					ti = search_options->get_root();
-
-				TreeItem *item = search_options->create_item(ti);
-				item->set_metadata(0, type);
-				item->set_text(0, ct[i].name);
-				if (ct[i].icon.is_valid()) {
-					item->set_icon(0, ct[i].icon);
-				}
-
-				if (!to_select || ct[i].name == search_box->get_text()) {
-					to_select = item;
+					add_custom_type(ct[i].name, ct[i].icon, current_type, type, types, root, &to_select);
 				}
 			}
 		}
@@ -439,8 +476,14 @@ Object *CreateDialog::instance_selected() {
 		if (md.get_type() != Variant::NIL)
 			custom = md;
 
-		if (custom != String()) {
-			return EditorNode::get_editor_data().instance_custom_type(selected->get_text(0), custom);
+		Variant md2 = selected->get_meta("built_in_type");
+
+		String custom_base;
+		if (md2.get_type() != Variant::NIL)
+			custom_base = md2;
+
+		if (custom != String() && custom_base != String()) {
+			return EditorNode::get_editor_data().instance_custom_type(selected->get_text(0), custom, custom_base);
 		} else {
 			return ClassDB::instance(selected->get_text(0));
 		}

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -80,6 +80,7 @@ class CreateDialog : public ConfirmationDialog {
 	Ref<Texture> _get_editor_icon(const String &p_type) const;
 
 	void add_type(const String &p_type, HashMap<String, TreeItem *> &p_types, TreeItem *p_root, TreeItem **to_select);
+	void add_custom_type(const String &p_type, Ref<Texture> p_icon, const String &parent_type, const String &built_in_parent_type, HashMap<String, TreeItem *> &p_types, TreeItem *p_root, TreeItem **to_select);
 
 	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -494,15 +494,18 @@ void EditorData::add_custom_type(const String &p_type, const String &p_inherits,
 }
 
 Object *EditorData::instance_custom_type(const String &p_type, const String &p_inherits) {
+	return instance_custom_type(p_type, p_inherits, p_inherits);
+}
+
+Object *EditorData::instance_custom_type(const String &p_type, const String &p_inherits, const String &p_inherits_built_in) {
 
 	if (get_custom_types().has(p_inherits)) {
-
 		for (int i = 0; i < get_custom_types()[p_inherits].size(); i++) {
 			if (get_custom_types()[p_inherits][i].name == p_type) {
 				Ref<Texture> icon = get_custom_types()[p_inherits][i].icon;
 				Ref<Script> script = get_custom_types()[p_inherits][i].script;
 
-				Object *ob = ClassDB::instance(p_inherits);
+				Object *ob = ClassDB::instance(p_inherits_built_in);
 				ERR_FAIL_COND_V(!ob, NULL);
 				if (ob->is_class("Node")) {
 					ob->call("set_name", p_type);

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -175,7 +175,10 @@ public:
 	void restore_editor_global_states();
 
 	void add_custom_type(const String &p_type, const String &p_inherits, const Ref<Script> &p_script, const Ref<Texture> &p_icon);
+
+	Object *instance_custom_type(const String &p_type, const String &p_inherits, const String &p_inherits_built_in);
 	Object *instance_custom_type(const String &p_type, const String &p_inherits);
+
 	void remove_custom_type(const String &p_type);
 	const Map<String, Vector<CustomType> > &get_custom_types() const { return custom_types; }
 


### PR DESCRIPTION
Made it so custom types that extend custom types can now show up under their parent in the Create Node window.

This is now possible:

![custom_button](https://user-images.githubusercontent.com/7482073/42337644-affb515c-8087-11e8-9eac-197b5da170bd.png)
