### PR TITLE
Scripts can now access the audio buffer

### DIFF
--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -139,7 +139,7 @@ Error AudioDriverALSA::init_device() {
 	status = snd_pcm_sw_params(pcm_handle, swparams);
 	CHECK_FAIL(status < 0);
 
-	samples_in.resize(period_size * channels);
+	output_buffer.resize(period_size * channels);
 	samples_out.resize(period_size * channels);
 
 	return OK;
@@ -166,22 +166,22 @@ void AudioDriverALSA::thread_func(void *p_udata) {
 	AudioDriverALSA *ad = (AudioDriverALSA *)p_udata;
 
 	while (!ad->exit_thread) {
-
 		ad->lock();
 		ad->start_counting_ticks();
 
-		if (!ad->active) {
-			for (unsigned int i = 0; i < ad->period_size * ad->channels; i++) {
-				ad->samples_out[i] = 0;
-			}
-
+		if (ad->active) {
+			ad->audio_server_process(ad->period_size, ad->output_buffer.ptrw());
 		} else {
-			ad->audio_server_process(ad->period_size, ad->samples_in.ptrw());
-
-			for (unsigned int i = 0; i < ad->period_size * ad->channels; i++) {
-				ad->samples_out[i] = ad->samples_in[i] >> 16;
+			for (unsigned int i = 0; i < ad->output_buffer.size(); i++) {
+				ad->output_buffer[i] = 0;
 			}
 		}
+
+		for (unsigned int i = 0; i < ad->output_buffer.size(); i++) {
+			ad->samples_out[i] = ad->output_buffer[i] >> 16;
+		}
+
+		ad->output_position += ad->output_buffer.size();
 
 		int todo = ad->period_size;
 		int total = 0;

--- a/drivers/alsa/audio_driver_alsa.h
+++ b/drivers/alsa/audio_driver_alsa.h
@@ -47,7 +47,6 @@ class AudioDriverALSA : public AudioDriver {
 	String device_name;
 	String new_device;
 
-	Vector<int32_t> samples_in;
 	Vector<int16_t> samples_out;
 
 	Error init_device();

--- a/drivers/coreaudio/audio_driver_coreaudio.h
+++ b/drivers/coreaudio/audio_driver_coreaudio.h
@@ -54,8 +54,6 @@ class AudioDriverCoreAudio : public AudioDriver {
 	unsigned int buffer_frames;
 	unsigned int buffer_size;
 
-	Vector<int32_t> samples_in;
-
 #ifdef OSX_ENABLED
 	static OSStatus output_device_address_cb(AudioObjectID inObjectID,
 			UInt32 inNumberAddresses, const AudioObjectPropertyAddress *inAddresses,

--- a/drivers/pulseaudio/audio_driver_pulseaudio.h
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.h
@@ -53,12 +53,10 @@ class AudioDriverPulseAudio : public AudioDriver {
 	String new_device;
 	String default_device;
 
-	Vector<int32_t> samples_in;
 	Vector<int16_t> samples_out;
 
 	unsigned int mix_rate;
 	unsigned int buffer_frames;
-	unsigned int pa_buffer_size;
 	int channels;
 	int pa_ready;
 	int pa_status;

--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -57,7 +57,6 @@ class AudioDriverWASAPI : public AudioDriver {
 
 	Vector<int32_t> samples_in;
 
-	unsigned int buffer_size;
 	unsigned int channels;
 	unsigned int wasapi_channels;
 	int mix_rate;

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -117,6 +117,8 @@ AudioDriver::AudioDriver() {
 
 	_last_mix_time = 0;
 	_mix_amount = 0;
+	output_buffer.clear();
+	output_position = 0;
 
 #ifdef DEBUG_ENABLED
 	prof_time = 0;
@@ -1250,6 +1252,10 @@ void AudioServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_device_list"), &AudioServer::get_device_list);
 	ClassDB::bind_method(D_METHOD("get_device"), &AudioServer::get_device);
 	ClassDB::bind_method(D_METHOD("set_device"), &AudioServer::set_device);
+
+	ClassDB::bind_method(D_METHOD("get_output_buffer"), &AudioServer::get_output_buffer);
+	ClassDB::bind_method(D_METHOD("get_output_position"), &AudioServer::get_output_position);
+	ClassDB::bind_method(D_METHOD("get_output_channels"), &AudioServer::get_output_channels);
 
 	ClassDB::bind_method(D_METHOD("set_bus_layout", "bus_layout"), &AudioServer::set_bus_layout);
 	ClassDB::bind_method(D_METHOD("generate_bus_layout"), &AudioServer::generate_bus_layout);

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -51,6 +51,9 @@ class AudioDriver {
 #endif
 
 protected:
+	Vector<int32_t> output_buffer;
+	unsigned int output_position;
+
 	void audio_server_process(int p_frames, int32_t *p_buffer, bool p_update_mix_time = true);
 	void update_mix_time(int p_frames);
 
@@ -100,6 +103,10 @@ public:
 	uint64_t get_profiling_time() const { return prof_time; }
 	void reset_profiling_time() { prof_time = 0; }
 #endif
+
+	Vector<int32_t> get_output_buffer() { return output_buffer; }
+	unsigned int get_output_position() { return output_position; }
+	unsigned int get_output_channels() { return get_total_channels_by_speaker_mode(get_speaker_mode()); }
 
 	AudioDriver();
 	virtual ~AudioDriver() {}
@@ -336,6 +343,10 @@ public:
 	void set_device(String device);
 
 	float get_output_latency() { return output_latency; }
+
+	Vector<int32_t> get_output_buffer() { return AudioDriver::get_singleton()->get_output_buffer(); }
+	unsigned int get_output_position() { return AudioDriver::get_singleton()->get_output_position(); }
+	unsigned int get_output_channels() { return AudioDriver::get_singleton()->get_output_channels(); }
 
 	AudioServer();
 	virtual ~AudioServer();


### PR DESCRIPTION
This PR allows read access to the audio buffer using:

- `AudioServer.get_output_buffer`
- `AudioServer.get_output_position`
- `AudioServer.get_output_channels`

Works with ALSA, CoreAudio, PulseAudio and WASAPI.

I built a simple audio meter project using this:

![screenshot from 2018-07-04 23-24-55](https://user-images.githubusercontent.com/10578225/42299435-861d9490-7fe1-11e8-806a-b9a73438d3ad.png)

Audio Meter v3 Project: [AudioMeterv3.zip](https://github.com/godotengine/godot/files/2205734/AudioMeterv3.zip)
