### PR TITLE
Temporary fix to issue #19628 and #19207

### DIFF
--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -268,7 +268,7 @@ void VisualServerViewport::draw_viewports() {
 		ERR_CONTINUE(!vp->render_target.is_valid());
 
 		bool visible = vp->viewport_to_screen_rect != Rect2() || vp->update_mode == VS::VIEWPORT_UPDATE_ALWAYS || vp->update_mode == VS::VIEWPORT_UPDATE_ONCE || (vp->update_mode == VS::VIEWPORT_UPDATE_WHEN_VISIBLE && VSG::storage->render_target_was_used(vp->render_target));
-		visible = visible && vp->size.x > 0 && vp->size.y > 0;
+		visible = visible && vp->size.x > 1 && vp->size.y > 1;
 
 		if (!visible)
 			continue;


### PR DESCRIPTION
Temporary fix to #19628 and #19207

Viewports with a height of 1 are causing storage->frame.current_rt->effects.mip_maps[0].sizes.empty() to be true in at least GLES3's _post_process method of rasterizer_scene_gles3.cpp. This in turn causes crashes as there are multiple locations throughout this source file in which the sizes Vector is being indexed without any checks to see if it is empty.

This PR simply modifies the visible Boolean in VisualServerViewport::draw_viewports to stop rendering at window widths / heights of 1 rather than 0 to prevent this state from occurring. I would rather fix the cause of mip_maps[0].sizes becoming empty at window size 1, but after hours of digging this was the best solution I was able to devise. Feel free to deny this PR if the tradeoff of not rendering for 1x1 viewports is not acceptable. I feel that it is way to easy to reproduce this crash by end users to leave it in its current state.

For more information and context, please refer to the discussion on issue #19628 