### PR TITLE
Fix bits_per_pixel validation in BMP and TGA loader modules.

### DIFF
--- a/modules/bmp/image_loader_bmp.cpp
+++ b/modules/bmp/image_loader_bmp.cpp
@@ -53,7 +53,7 @@ Error ImageLoaderBMP::convert_to_image(Ref<Image> p_image,
 			err = FAILED;
 		}
 
-		if (bits_per_pixel != 24 || bits_per_pixel != 32) {
+		if (!(bits_per_pixel == 24 || bits_per_pixel == 32)) {
 			err = FAILED;
 		}
 

--- a/modules/tga/image_loader_tga.cpp
+++ b/modules/tga/image_loader_tga.cpp
@@ -250,8 +250,9 @@ Error ImageLoaderTGA::load_image(Ref<Image> p_image, FileAccess *f, bool p_force
 	if (tga_header.image_width <= 0 || tga_header.image_height <= 0)
 		err = FAILED;
 
-	if (tga_header.pixel_depth != 8 && tga_header.pixel_depth != 24 && tga_header.pixel_depth != 32)
+	if (!(tga_header.pixel_depth == 8 || tga_header.pixel_depth == 24 || tga_header.pixel_depth == 32)) {
 		err = FAILED;
+	}
 
 	if (err == OK) {
 		f->seek(f->get_position() + tga_header.id_length);


### PR DESCRIPTION
Fix the issue noted here #20038