### PR TITLE
Added path for Mono installed through Homebrew

### DIFF
--- a/modules/mono/SCsub
+++ b/modules/mono/SCsub
@@ -97,7 +97,7 @@ def find_msbuild_unix(filename):
 
     hint_dirs = ['/opt/novell/mono/bin']
     if sys.platform == 'darwin':
-        hint_dirs = ['/Library/Frameworks/Mono.framework/Versions/Current/bin'] + hint_dirs
+        hint_dirs = ['/Library/Frameworks/Mono.framework/Versions/Current/bin', '/usr/local/var/homebrew/linked/mono/bin'] + hint_dirs
 
     for hint_dir in hint_dirs:
         hint_path = os.path.join(hint_dir, filename)

--- a/modules/mono/editor/godotsharp_builds.cpp
+++ b/modules/mono/editor/godotsharp_builds.cpp
@@ -64,6 +64,7 @@ String _find_build_engine_on_unix(const String &p_name) {
 	const char *locations[] = {
 #ifdef OSX_ENABLED
 		"/Library/Frameworks/Mono.framework/Versions/Current/bin/",
+		"/usr/local/var/homebrew/linked/mono/bin/",
 #endif
 		"/opt/novell/mono/bin/"
 	};


### PR DESCRIPTION
On macOS, it is common to install packages like Mono through the third-party
package-manager Homebrew. This commit simply adds an additional path, to
support where Homebrew installs the Mono framework.