### PR TITLE
Fixes is_pressed when holding double click.

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -276,7 +276,7 @@ void InputDefault::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool 
 
 	Ref<InputEventMouseButton> mb = p_event;
 
-	if (mb.is_valid() && !mb->is_doubleclick()) {
+	if (mb.is_valid()) {
 
 		if (mb->is_pressed()) {
 			mouse_button_mask |= (1 << (mb->get_button_index() - 1));


### PR DESCRIPTION
This fixes #20070 .

This also affects mouse to touch emulation.
Before when you would hold after double click it wouldn't make touch input, after this commit it will.
If for whatever reason this isn't wanted behavior it can be easily fixed.