### PR TITLE
fix ColorPickerButton.get_popup()

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -743,8 +743,9 @@ ColorPicker *ColorPickerButton::get_picker() {
 	return picker;
 }
 
-PopupPanel *ColorPickerButton::get_popup() const {
+PopupPanel *ColorPickerButton::get_popup() {
 
+	_update_picker();
 	return popup;
 }
 

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -144,7 +144,7 @@ public:
 	bool is_editing_alpha() const;
 
 	ColorPicker *get_picker();
-	PopupPanel *get_popup() const;
+	PopupPanel *get_popup();
 
 	ColorPickerButton();
 };


### PR DESCRIPTION
closes https://github.com/godotengine/godot/issues/20002

```
extends Node


func _ready():
	add_child(ColorPickerButton.new())
	print(get_children()[0].get_popup())
```