### PR TITLE
Action Event Layers, multifocus for split screen

### DIFF
--- a/core/input_map.cpp
+++ b/core/input_map.cpp
@@ -108,6 +108,9 @@ List<Ref<InputEvent> >::Element *InputMap::_find_event(Action &p_action, const R
 		//if (e.type != Ref<InputEvent>::KEY && e.device != p_event.device) -- unsure about the KEY comparison, why is this here?
 		//	continue;
 
+		if (e->get_layer() != p_event->get_layer())
+			continue;
+
 		int device = e->get_device();
 		if (device == ALL_DEVICES || device == p_event->get_device()) {
 			if (e->action_match(p_event, p_pressed, p_strength, p_action.deadzone)) {

--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -41,6 +41,14 @@ int InputEvent::get_device() const {
 	return device;
 }
 
+void InputEvent::set_layer(int p_layer) {
+	layer = p_layer;
+}
+
+int InputEvent::get_layer() const {
+	return layer;
+}
+
 bool InputEvent::is_action(const StringName &p_action) const {
 
 	return InputMap::get_singleton()->event_is_action(Ref<InputEvent>((InputEvent *)this), p_action);
@@ -108,6 +116,9 @@ void InputEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_device", "device"), &InputEvent::set_device);
 	ClassDB::bind_method(D_METHOD("get_device"), &InputEvent::get_device);
 
+	ClassDB::bind_method(D_METHOD("set_layer", "layer"), &InputEvent::set_layer);
+	ClassDB::bind_method(D_METHOD("get_layer"), &InputEvent::get_layer);
+
 	ClassDB::bind_method(D_METHOD("is_action", "action"), &InputEvent::is_action);
 	ClassDB::bind_method(D_METHOD("is_action_pressed", "action"), &InputEvent::is_action_pressed);
 	ClassDB::bind_method(D_METHOD("is_action_released", "action"), &InputEvent::is_action_released);
@@ -125,11 +136,13 @@ void InputEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("xformed_by", "xform", "local_ofs"), &InputEvent::xformed_by, DEFVAL(Vector2()));
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "device"), "set_device", "get_device");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "layer"), "set_layer", "get_layer");
 }
 
 InputEvent::InputEvent() {
 
 	device = 0;
+	layer = 0;
 }
 
 //////////////////

--- a/core/os/input_event.h
+++ b/core/os/input_event.h
@@ -149,6 +149,7 @@ class InputEvent : public Resource {
 	GDCLASS(InputEvent, Resource)
 
 	int device;
+	int layer;
 
 protected:
 	static void _bind_methods();
@@ -156,6 +157,9 @@ protected:
 public:
 	void set_device(int p_device);
 	int get_device() const;
+
+	void set_layer(int p_layer);
+	int get_layer() const;
 
 	bool is_action(const StringName &p_action) const;
 	bool is_action_pressed(const StringName &p_action) const;

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -207,7 +207,6 @@ void ProjectSettingsEditor::_action_edited() {
 
 		undo_redo->create_action(TTR("Change Action deadzone"));
 		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, new_action);
-		undo_redo->add_do_method(this, "_update_actions");
 		undo_redo->add_do_method(this, "_settings_changed");
 		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", name, old_action);
 		undo_redo->add_undo_method(this, "_update_actions");

--- a/scene/gui/viewport_container.cpp
+++ b/scene/gui/viewport_container.cpp
@@ -161,6 +161,7 @@ void ViewportContainer::_input(const Ref<InputEvent> &p_event) {
 		if (!c || c->is_input_disabled())
 			continue;
 
+		ev->set_layer(c->get_focus_layer());
 		c->input(ev);
 	}
 }

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1188,7 +1188,10 @@ Ref<InputEvent> Viewport::_make_input_local(const Ref<InputEvent> &ev) {
 	Vector2 vp_ofs = _get_window_offset();
 	Transform2D ai = get_final_transform().affine_inverse() * _get_input_pre_xform();
 
-	return ev->xformed_by(ai, -vp_ofs);
+	Ref<InputEvent> out = ev->xformed_by(ai, -vp_ofs);
+	out->set_layer(get_focus_layer());
+
+	return out;
 }
 
 void Viewport::_vp_input_text(const String &p_text) {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -279,6 +279,8 @@ private:
 	} gui;
 
 	bool disable_input;
+	int focus_layer;
+	StringName focus_group;
 
 	void _gui_call_input(Control *p_control, const Ref<InputEvent> &p_input);
 	void _gui_prepare_subwindows();
@@ -432,6 +434,9 @@ public:
 
 	void input(const Ref<InputEvent> &p_event);
 	void unhandled_input(const Ref<InputEvent> &p_event);
+
+	void set_focus_layer(int p_focus_layer);
+	int get_focus_layer() const;
 
 	void set_disable_input(bool p_disable);
 	bool is_input_disabled() const;


### PR DESCRIPTION
This is something I briefly discussed with some devs at last GodotCon.
Closes #10755

TL;DR;
---
This PR adds adds Viewport-based multifocus support to GUI elements.
Additionally, it adds a new `layer` property in the Input Map editor to control this new focus behaviour.
Check out the demo: [ActionLayer.zip](https://github.com/godotengine/godot/files/2182090/ActionLayer.zip)


How does it work?
---
`InputEvent` now has a new `layer` property.
Each Viewport is assigned a new `focus_layer` property.
Focusing something inside that Viewport will only remove the focus from elements in viewports that have the same `focus_layer`.
When receiving input the `Viewport` (or `ViewportContainer`) will set the InputEvent `layer` property to the current `focus_layer`.
The `InputMap._find_event` (and thus all `is_action`,`add_action`,  ...) will ignore actions with mismatching layers, causing UI inside each Viewport to only react to the appropriate input.

How do I use it?
---
Create a scene with multiple Viewports, eg:
![hierarchy](https://user-images.githubusercontent.com/1687918/42536828-6fbd5828-8493-11e8-867d-6ebff3c205db.png)

Assign to the Viewport the desired focus_layer:
![inspector](https://user-images.githubusercontent.com/1687918/42536853-82bcfa6e-8493-11e8-96d1-dbe4e092cdf3.png)

Consigure Input Map `Layer` property accordingly:
![settings](https://user-images.githubusercontent.com/1687918/42536892-a19fb020-8493-11e8-8e44-06745276cfbe.png)

