### PR TITLE
Control, set_global_position behaves like get_global_position

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1705,7 +1705,13 @@ Size2 Control::get_end() const {
 
 Point2 Control::get_global_position() const {
 
-	return get_global_transform().get_origin();
+	Transform2D inv;
+
+	if (data.parent_canvas_item) {
+
+		inv = data.parent_canvas_item->get_global_transform().affine_inverse();
+	}
+	return inv.xform(get_position());
 }
 
 void Control::set_global_position(const Point2 &p_point) {

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -128,10 +128,7 @@ bool Control::_edit_use_rotation() const {
 }
 
 void Control::_edit_set_pivot(const Point2 &p_pivot) {
-	Vector2 delta_pivot = p_pivot - get_pivot_offset();
-	Vector2 move = Vector2((cos(data.rotation) - 1.0) * delta_pivot.x - sin(data.rotation) * delta_pivot.y, sin(data.rotation) * delta_pivot.x + (cos(data.rotation) - 1.0) * delta_pivot.y);
-	set_position(get_position() + move);
-	set_pivot_offset(p_pivot);
+	set_pivot_offset(get_transform().xform(p_pivot));
 }
 
 Point2 Control::_edit_get_pivot() const {


### PR DESCRIPTION
**get_global_position** behaved different than the according set function. (regarding rotations)

this lead to the annoying problem that:
```
rect_global_position = rect_global_position 
#of course the example is dumb, but there are reasons to do 
rect_global_position = rect_global_position * 0.5
```
moved the node (when it was rotated with a rotation pivot != (0,0) ).

<img width="431" alt="screen shot 2018-07-11 at 10 40 33" src="https://user-images.githubusercontent.com/16718859/42560408-dc4334e6-84f6-11e8-9d4b-f3d4f196e92e.png">

In the case above:
### before:
 - get_global_position returned the green point
 - set_global_position used the red one
### now:

now both functions use the red one.
so setting with the same value does not move the node anymore.


## Second commit
also fixed behaviour when editing the pivot. Before it was changing the position of the node.
(the pivot stuff was really complex anyways)


I would like to have a review by @groud because I think you know fairly well how the control stuff should behave.