### PR TITLE
Open visual editor when "open editor" button in the inspector is pressed

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2000,7 +2000,7 @@ void EditorPropertyResource::_sub_inspector_object_id_selected(int p_id) {
 void EditorPropertyResource::_open_editor_pressed() {
 	RES res = get_edited_object()->get(get_edited_property());
 	if (res.is_valid()) {
-		EditorNode::get_singleton()->edit_item(res.ptr());
+		EditorNode::get_singleton()->edit_resource(res.ptr());
 	}
 }
 


### PR DESCRIPTION
Open visual editor for visual scripts when "open editor" button in the inspector is pressed.
Fixes #20111