### PR TITLE
Reduce unnecessary COW on Vector by make writing explicit

### DIFF
--- a/core/array.cpp
+++ b/core/array.cpp
@@ -72,7 +72,7 @@ void Array::_unref() const {
 
 Variant &Array::operator[](int p_idx) {
 
-	return _p->array[p_idx];
+	return _p->array.write[p_idx];
 }
 
 const Variant &Array::operator[](int p_idx) const {

--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -58,8 +58,8 @@ MethodDefinition D_METHOD(const char *p_name, const char *p_arg1, const char *p_
 	MethodDefinition md;
 	md.name = StaticCString::create(p_name);
 	md.args.resize(2);
-	md.args[0] = StaticCString::create(p_arg1);
-	md.args[1] = StaticCString::create(p_arg2);
+	md.args.write[0] = StaticCString::create(p_arg1);
+	md.args.write[1] = StaticCString::create(p_arg2);
 	return md;
 }
 
@@ -68,9 +68,9 @@ MethodDefinition D_METHOD(const char *p_name, const char *p_arg1, const char *p_
 	MethodDefinition md;
 	md.name = StaticCString::create(p_name);
 	md.args.resize(3);
-	md.args[0] = StaticCString::create(p_arg1);
-	md.args[1] = StaticCString::create(p_arg2);
-	md.args[2] = StaticCString::create(p_arg3);
+	md.args.write[0] = StaticCString::create(p_arg1);
+	md.args.write[1] = StaticCString::create(p_arg2);
+	md.args.write[2] = StaticCString::create(p_arg3);
 	return md;
 }
 
@@ -79,10 +79,10 @@ MethodDefinition D_METHOD(const char *p_name, const char *p_arg1, const char *p_
 	MethodDefinition md;
 	md.name = StaticCString::create(p_name);
 	md.args.resize(4);
-	md.args[0] = StaticCString::create(p_arg1);
-	md.args[1] = StaticCString::create(p_arg2);
-	md.args[2] = StaticCString::create(p_arg3);
-	md.args[3] = StaticCString::create(p_arg4);
+	md.args.write[0] = StaticCString::create(p_arg1);
+	md.args.write[1] = StaticCString::create(p_arg2);
+	md.args.write[2] = StaticCString::create(p_arg3);
+	md.args.write[3] = StaticCString::create(p_arg4);
 	return md;
 }
 
@@ -91,11 +91,11 @@ MethodDefinition D_METHOD(const char *p_name, const char *p_arg1, const char *p_
 	MethodDefinition md;
 	md.name = StaticCString::create(p_name);
 	md.args.resize(5);
-	md.args[0] = StaticCString::create(p_arg1);
-	md.args[1] = StaticCString::create(p_arg2);
-	md.args[2] = StaticCString::create(p_arg3);
-	md.args[3] = StaticCString::create(p_arg4);
-	md.args[4] = StaticCString::create(p_arg5);
+	md.args.write[0] = StaticCString::create(p_arg1);
+	md.args.write[1] = StaticCString::create(p_arg2);
+	md.args.write[2] = StaticCString::create(p_arg3);
+	md.args.write[3] = StaticCString::create(p_arg4);
+	md.args.write[4] = StaticCString::create(p_arg5);
 	return md;
 }
 
@@ -104,12 +104,12 @@ MethodDefinition D_METHOD(const char *p_name, const char *p_arg1, const char *p_
 	MethodDefinition md;
 	md.name = StaticCString::create(p_name);
 	md.args.resize(6);
-	md.args[0] = StaticCString::create(p_arg1);
-	md.args[1] = StaticCString::create(p_arg2);
-	md.args[2] = StaticCString::create(p_arg3);
-	md.args[3] = StaticCString::create(p_arg4);
-	md.args[4] = StaticCString::create(p_arg5);
-	md.args[5] = StaticCString::create(p_arg6);
+	md.args.write[0] = StaticCString::create(p_arg1);
+	md.args.write[1] = StaticCString::create(p_arg2);
+	md.args.write[2] = StaticCString::create(p_arg3);
+	md.args.write[3] = StaticCString::create(p_arg4);
+	md.args.write[4] = StaticCString::create(p_arg5);
+	md.args.write[5] = StaticCString::create(p_arg6);
 	return md;
 }
 
@@ -118,13 +118,13 @@ MethodDefinition D_METHOD(const char *p_name, const char *p_arg1, const char *p_
 	MethodDefinition md;
 	md.name = StaticCString::create(p_name);
 	md.args.resize(7);
-	md.args[0] = StaticCString::create(p_arg1);
-	md.args[1] = StaticCString::create(p_arg2);
-	md.args[2] = StaticCString::create(p_arg3);
-	md.args[3] = StaticCString::create(p_arg4);
-	md.args[4] = StaticCString::create(p_arg5);
-	md.args[5] = StaticCString::create(p_arg6);
-	md.args[6] = StaticCString::create(p_arg7);
+	md.args.write[0] = StaticCString::create(p_arg1);
+	md.args.write[1] = StaticCString::create(p_arg2);
+	md.args.write[2] = StaticCString::create(p_arg3);
+	md.args.write[3] = StaticCString::create(p_arg4);
+	md.args.write[4] = StaticCString::create(p_arg5);
+	md.args.write[5] = StaticCString::create(p_arg6);
+	md.args.write[6] = StaticCString::create(p_arg7);
 	return md;
 }
 
@@ -133,14 +133,14 @@ MethodDefinition D_METHOD(const char *p_name, const char *p_arg1, const char *p_
 	MethodDefinition md;
 	md.name = StaticCString::create(p_name);
 	md.args.resize(8);
-	md.args[0] = StaticCString::create(p_arg1);
-	md.args[1] = StaticCString::create(p_arg2);
-	md.args[2] = StaticCString::create(p_arg3);
-	md.args[3] = StaticCString::create(p_arg4);
-	md.args[4] = StaticCString::create(p_arg5);
-	md.args[5] = StaticCString::create(p_arg6);
-	md.args[6] = StaticCString::create(p_arg7);
-	md.args[7] = StaticCString::create(p_arg8);
+	md.args.write[0] = StaticCString::create(p_arg1);
+	md.args.write[1] = StaticCString::create(p_arg2);
+	md.args.write[2] = StaticCString::create(p_arg3);
+	md.args.write[3] = StaticCString::create(p_arg4);
+	md.args.write[4] = StaticCString::create(p_arg5);
+	md.args.write[5] = StaticCString::create(p_arg6);
+	md.args.write[6] = StaticCString::create(p_arg7);
+	md.args.write[7] = StaticCString::create(p_arg8);
 	return md;
 }
 
@@ -149,15 +149,15 @@ MethodDefinition D_METHOD(const char *p_name, const char *p_arg1, const char *p_
 	MethodDefinition md;
 	md.name = StaticCString::create(p_name);
 	md.args.resize(9);
-	md.args[0] = StaticCString::create(p_arg1);
-	md.args[1] = StaticCString::create(p_arg2);
-	md.args[2] = StaticCString::create(p_arg3);
-	md.args[3] = StaticCString::create(p_arg4);
-	md.args[4] = StaticCString::create(p_arg5);
-	md.args[5] = StaticCString::create(p_arg6);
-	md.args[6] = StaticCString::create(p_arg7);
-	md.args[7] = StaticCString::create(p_arg8);
-	md.args[8] = StaticCString::create(p_arg9);
+	md.args.write[0] = StaticCString::create(p_arg1);
+	md.args.write[1] = StaticCString::create(p_arg2);
+	md.args.write[2] = StaticCString::create(p_arg3);
+	md.args.write[3] = StaticCString::create(p_arg4);
+	md.args.write[4] = StaticCString::create(p_arg5);
+	md.args.write[5] = StaticCString::create(p_arg6);
+	md.args.write[6] = StaticCString::create(p_arg7);
+	md.args.write[7] = StaticCString::create(p_arg8);
+	md.args.write[8] = StaticCString::create(p_arg9);
 	return md;
 }
 
@@ -166,16 +166,16 @@ MethodDefinition D_METHOD(const char *p_name, const char *p_arg1, const char *p_
 	MethodDefinition md;
 	md.name = StaticCString::create(p_name);
 	md.args.resize(10);
-	md.args[0] = StaticCString::create(p_arg1);
-	md.args[1] = StaticCString::create(p_arg2);
-	md.args[2] = StaticCString::create(p_arg3);
-	md.args[3] = StaticCString::create(p_arg4);
-	md.args[4] = StaticCString::create(p_arg5);
-	md.args[5] = StaticCString::create(p_arg6);
-	md.args[6] = StaticCString::create(p_arg7);
-	md.args[7] = StaticCString::create(p_arg8);
-	md.args[8] = StaticCString::create(p_arg9);
-	md.args[9] = StaticCString::create(p_arg10);
+	md.args.write[0] = StaticCString::create(p_arg1);
+	md.args.write[1] = StaticCString::create(p_arg2);
+	md.args.write[2] = StaticCString::create(p_arg3);
+	md.args.write[3] = StaticCString::create(p_arg4);
+	md.args.write[4] = StaticCString::create(p_arg5);
+	md.args.write[5] = StaticCString::create(p_arg6);
+	md.args.write[6] = StaticCString::create(p_arg7);
+	md.args.write[7] = StaticCString::create(p_arg8);
+	md.args.write[8] = StaticCString::create(p_arg9);
+	md.args.write[9] = StaticCString::create(p_arg10);
 	return md;
 }
 
@@ -184,17 +184,17 @@ MethodDefinition D_METHOD(const char *p_name, const char *p_arg1, const char *p_
 	MethodDefinition md;
 	md.name = StaticCString::create(p_name);
 	md.args.resize(11);
-	md.args[0] = StaticCString::create(p_arg1);
-	md.args[1] = StaticCString::create(p_arg2);
-	md.args[2] = StaticCString::create(p_arg3);
-	md.args[3] = StaticCString::create(p_arg4);
-	md.args[4] = StaticCString::create(p_arg5);
-	md.args[5] = StaticCString::create(p_arg6);
-	md.args[6] = StaticCString::create(p_arg7);
-	md.args[7] = StaticCString::create(p_arg8);
-	md.args[8] = StaticCString::create(p_arg9);
-	md.args[9] = StaticCString::create(p_arg10);
-	md.args[10] = StaticCString::create(p_arg11);
+	md.args.write[0] = StaticCString::create(p_arg1);
+	md.args.write[1] = StaticCString::create(p_arg2);
+	md.args.write[2] = StaticCString::create(p_arg3);
+	md.args.write[3] = StaticCString::create(p_arg4);
+	md.args.write[4] = StaticCString::create(p_arg5);
+	md.args.write[5] = StaticCString::create(p_arg6);
+	md.args.write[6] = StaticCString::create(p_arg7);
+	md.args.write[7] = StaticCString::create(p_arg8);
+	md.args.write[8] = StaticCString::create(p_arg9);
+	md.args.write[9] = StaticCString::create(p_arg10);
+	md.args.write[10] = StaticCString::create(p_arg11);
 	return md;
 }
 
@@ -203,18 +203,18 @@ MethodDefinition D_METHOD(const char *p_name, const char *p_arg1, const char *p_
 	MethodDefinition md;
 	md.name = StaticCString::create(p_name);
 	md.args.resize(12);
-	md.args[0] = StaticCString::create(p_arg1);
-	md.args[1] = StaticCString::create(p_arg2);
-	md.args[2] = StaticCString::create(p_arg3);
-	md.args[3] = StaticCString::create(p_arg4);
-	md.args[4] = StaticCString::create(p_arg5);
-	md.args[5] = StaticCString::create(p_arg6);
-	md.args[6] = StaticCString::create(p_arg7);
-	md.args[7] = StaticCString::create(p_arg8);
-	md.args[8] = StaticCString::create(p_arg9);
-	md.args[9] = StaticCString::create(p_arg10);
-	md.args[10] = StaticCString::create(p_arg11);
-	md.args[11] = StaticCString::create(p_arg12);
+	md.args.write[0] = StaticCString::create(p_arg1);
+	md.args.write[1] = StaticCString::create(p_arg2);
+	md.args.write[2] = StaticCString::create(p_arg3);
+	md.args.write[3] = StaticCString::create(p_arg4);
+	md.args.write[4] = StaticCString::create(p_arg5);
+	md.args.write[5] = StaticCString::create(p_arg6);
+	md.args.write[6] = StaticCString::create(p_arg7);
+	md.args.write[7] = StaticCString::create(p_arg8);
+	md.args.write[8] = StaticCString::create(p_arg9);
+	md.args.write[9] = StaticCString::create(p_arg10);
+	md.args.write[10] = StaticCString::create(p_arg11);
+	md.args.write[11] = StaticCString::create(p_arg12);
 	return md;
 }
 
@@ -223,19 +223,19 @@ MethodDefinition D_METHOD(const char *p_name, const char *p_arg1, const char *p_
 	MethodDefinition md;
 	md.name = StaticCString::create(p_name);
 	md.args.resize(13);
-	md.args[0] = StaticCString::create(p_arg1);
-	md.args[1] = StaticCString::create(p_arg2);
-	md.args[2] = StaticCString::create(p_arg3);
-	md.args[3] = StaticCString::create(p_arg4);
-	md.args[4] = StaticCString::create(p_arg5);
-	md.args[5] = StaticCString::create(p_arg6);
-	md.args[6] = StaticCString::create(p_arg7);
-	md.args[7] = StaticCString::create(p_arg8);
-	md.args[8] = StaticCString::create(p_arg9);
-	md.args[9] = StaticCString::create(p_arg10);
-	md.args[10] = StaticCString::create(p_arg11);
-	md.args[11] = StaticCString::create(p_arg12);
-	md.args[12] = StaticCString::create(p_arg13);
+	md.args.write[0] = StaticCString::create(p_arg1);
+	md.args.write[1] = StaticCString::create(p_arg2);
+	md.args.write[2] = StaticCString::create(p_arg3);
+	md.args.write[3] = StaticCString::create(p_arg4);
+	md.args.write[4] = StaticCString::create(p_arg5);
+	md.args.write[5] = StaticCString::create(p_arg6);
+	md.args.write[6] = StaticCString::create(p_arg7);
+	md.args.write[7] = StaticCString::create(p_arg8);
+	md.args.write[8] = StaticCString::create(p_arg9);
+	md.args.write[9] = StaticCString::create(p_arg10);
+	md.args.write[10] = StaticCString::create(p_arg11);
+	md.args.write[11] = StaticCString::create(p_arg12);
+	md.args.write[12] = StaticCString::create(p_arg13);
 	return md;
 }
 
@@ -1246,7 +1246,7 @@ MethodBind *ClassDB::bind_methodfi(uint32_t p_flags, MethodBind *p_bind, const c
 	defvals.resize(p_defcount);
 	for (int i = 0; i < p_defcount; i++) {
 
-		defvals[i] = *p_defs[p_defcount - i - 1];
+		defvals.write[i] = *p_defs[p_defcount - i - 1];
 	}
 
 	p_bind->set_default_arguments(defvals);

--- a/core/compressed_translation.cpp
+++ b/core/compressed_translation.cpp
@@ -73,7 +73,7 @@ void PHashTranslation::generate(const Ref<Translation> &p_from) {
 		Pair<int, CharString> p;
 		p.first = idx;
 		p.second = cs;
-		buckets[h % size].push_back(p);
+		buckets.write[h % size].push_back(p);
 
 		//compress string
 		CharString src_s = p_from->get_message(E->get()).operator String().utf8();
@@ -100,7 +100,7 @@ void PHashTranslation::generate(const Ref<Translation> &p_from) {
 			ps.compressed[0] = 0;
 		}
 
-		compressed[idx] = ps;
+		compressed.write[idx] = ps;
 		total_compression_size += ps.compressed.size();
 		total_string_size += src_s.size();
 		idx++;
@@ -111,8 +111,8 @@ void PHashTranslation::generate(const Ref<Translation> &p_from) {
 
 	for (int i = 0; i < size; i++) {
 
-		Vector<Pair<int, CharString> > &b = buckets[i];
-		Map<uint32_t, int> &t = table[i];
+		const Vector<Pair<int, CharString> > &b = buckets[i];
+		Map<uint32_t, int> &t = table.write[i];
 
 		if (b.size() == 0)
 			continue;
@@ -136,7 +136,7 @@ void PHashTranslation::generate(const Ref<Translation> &p_from) {
 			}
 		}
 
-		hfunc_table[i] = d;
+		hfunc_table.write[i] = d;
 		bucket_table_size += 2 + b.size() * 4;
 	}
 
@@ -157,7 +157,7 @@ void PHashTranslation::generate(const Ref<Translation> &p_from) {
 
 	for (int i = 0; i < size; i++) {
 
-		Map<uint32_t, int> &t = table[i];
+		const Map<uint32_t, int> &t = table[i];
 		if (t.size() == 0) {
 			htw[i] = 0xFFFFFFFF; //nothing
 			continue;

--- a/core/cowdata.h
+++ b/core/cowdata.h
@@ -1,0 +1,332 @@
+/*************************************************************************/
+/*  cowdata.h                                                            */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef COWDATA_H_
+#define COWDATA_H_
+
+#include "os/memory.h"
+#include "safe_refcount.h"
+
+template <class T>
+class Vector;
+class String;
+class CharString;
+template <class T, class V>
+class VMap;
+
+template <class T>
+class CowData {
+	template <class TV>
+	friend class Vector;
+	friend class String;
+	friend class CharString;
+	template <class TV, class VV>
+	friend class VMap;
+
+private:
+	mutable T *_ptr;
+
+	// internal helpers
+
+	_FORCE_INLINE_ uint32_t *_get_refcount() const {
+
+		if (!_ptr)
+			return NULL;
+
+		return reinterpret_cast<uint32_t *>(_ptr) - 2;
+	}
+
+	_FORCE_INLINE_ uint32_t *_get_size() const {
+
+		if (!_ptr)
+			return NULL;
+
+		return reinterpret_cast<uint32_t *>(_ptr) - 1;
+	}
+
+	_FORCE_INLINE_ T *_get_data() const {
+
+		if (!_ptr)
+			return NULL;
+		return reinterpret_cast<T *>(_ptr);
+	}
+
+	_FORCE_INLINE_ size_t _get_alloc_size(size_t p_elements) const {
+		//return nearest_power_of_2_templated(p_elements*sizeof(T)+sizeof(SafeRefCount)+sizeof(int));
+		return next_power_of_2(p_elements * sizeof(T));
+	}
+
+	_FORCE_INLINE_ bool _get_alloc_size_checked(size_t p_elements, size_t *out) const {
+#if defined(_add_overflow) && defined(_mul_overflow)
+		size_t o;
+		size_t p;
+		if (_mul_overflow(p_elements, sizeof(T), &o)) return false;
+		*out = next_power_of_2(o);
+		if (_add_overflow(o, static_cast<size_t>(32), &p)) return false; //no longer allocated here
+		return true;
+#else
+		// Speed is more important than correctness here, do the operations unchecked
+		// and hope the best
+		*out = _get_alloc_size(p_elements);
+		return true;
+#endif
+	}
+
+	void _unref(void *p_data);
+	void _ref(const CowData &p_from);
+	void _copy_on_write();
+
+public:
+	void operator=(const CowData<T> &p_from) { _ref(p_from); }
+
+	_FORCE_INLINE_ T *ptrw() {
+		_copy_on_write();
+		return (T *)_get_data();
+	}
+
+	_FORCE_INLINE_ const T *ptr() const {
+		return _get_data();
+	}
+
+	_FORCE_INLINE_ int size() const {
+		uint32_t *size = (uint32_t *)_get_size();
+		if (size)
+			return *size;
+		else
+			return 0;
+	}
+
+	_FORCE_INLINE_ void clear() { resize(0); }
+	_FORCE_INLINE_ bool empty() const { return _ptr == 0; }
+
+	_FORCE_INLINE_ void set(int p_index, const T &p_elem) {
+
+		CRASH_BAD_INDEX(p_index, size());
+		_copy_on_write();
+		_get_data()[p_index] = p_elem;
+	}
+
+	_FORCE_INLINE_ T &get_m(int p_index) {
+
+		CRASH_BAD_INDEX(p_index, size());
+		_copy_on_write();
+		return _get_data()[p_index];
+	}
+
+	_FORCE_INLINE_ const T &get(int p_index) const {
+
+		CRASH_BAD_INDEX(p_index, size());
+
+		return _get_data()[p_index];
+	}
+
+	Error resize(int p_size);
+
+	_FORCE_INLINE_ void remove(int p_index) {
+
+		ERR_FAIL_INDEX(p_index, size());
+		T *p = ptrw();
+		int len = size();
+		for (int i = p_index; i < len - 1; i++) {
+
+			p[i] = p[i + 1];
+		};
+
+		resize(len - 1);
+	};
+
+	Error insert(int p_pos, const T &p_val) {
+
+		ERR_FAIL_INDEX_V(p_pos, size() + 1, ERR_INVALID_PARAMETER);
+		resize(size() + 1);
+		for (int i = (size() - 1); i > p_pos; i--)
+			set(i, get(i - 1));
+		set(p_pos, p_val);
+
+		return OK;
+	};
+
+	_FORCE_INLINE_ CowData();
+	_FORCE_INLINE_ ~CowData();
+	_FORCE_INLINE_ CowData(CowData<T> &p_from) { _ref(p_from); };
+};
+
+template <class T>
+void CowData<T>::_unref(void *p_data) {
+
+	if (!p_data)
+		return;
+
+	uint32_t *refc = _get_refcount();
+
+	if (atomic_decrement(refc) > 0)
+		return; // still in use
+	// clean up
+
+	uint32_t *count = _get_size();
+	T *data = (T *)(count + 1);
+
+	for (uint32_t i = 0; i < *count; ++i) {
+		// call destructors
+		data[i].~T();
+	}
+
+	// free mem
+	Memory::free_static((uint8_t *)p_data, true);
+}
+
+template <class T>
+void CowData<T>::_copy_on_write() {
+
+	if (!_ptr)
+		return;
+
+	uint32_t *refc = _get_refcount();
+
+	if (unlikely(*refc > 1)) {
+		/* in use by more than me */
+		uint32_t current_size = *_get_size();
+
+		uint32_t *mem_new = (uint32_t *)Memory::alloc_static(_get_alloc_size(current_size), true);
+
+		*(mem_new - 2) = 1; //refcount
+		*(mem_new - 1) = current_size; //size
+
+		T *_data = (T *)(mem_new);
+
+		// initialize new elements
+		for (uint32_t i = 0; i < current_size; i++) {
+
+			memnew_placement(&_data[i], T(_get_data()[i]));
+		}
+
+		_unref(_ptr);
+		_ptr = _data;
+	}
+}
+
+template <class T>
+Error CowData<T>::resize(int p_size) {
+
+	ERR_FAIL_COND_V(p_size < 0, ERR_INVALID_PARAMETER);
+
+	if (p_size == size())
+		return OK;
+
+	if (p_size == 0) {
+		// wants to clean up
+		_unref(_ptr);
+		_ptr = NULL;
+		return OK;
+	}
+
+	// possibly changing size, copy on write
+	_copy_on_write();
+
+	size_t alloc_size;
+	ERR_FAIL_COND_V(!_get_alloc_size_checked(p_size, &alloc_size), ERR_OUT_OF_MEMORY);
+
+	if (p_size > size()) {
+
+		if (size() == 0) {
+			// alloc from scratch
+			uint32_t *ptr = (uint32_t *)Memory::alloc_static(alloc_size, true);
+			ERR_FAIL_COND_V(!ptr, ERR_OUT_OF_MEMORY);
+			*(ptr - 1) = 0; //size, currently none
+			*(ptr - 2) = 1; //refcount
+
+			_ptr = (T *)ptr;
+
+		} else {
+			void *_ptrnew = (T *)Memory::realloc_static(_ptr, alloc_size, true);
+			ERR_FAIL_COND_V(!_ptrnew, ERR_OUT_OF_MEMORY);
+			_ptr = (T *)(_ptrnew);
+		}
+
+		// construct the newly created elements
+		T *elems = _get_data();
+
+		for (int i = *_get_size(); i < p_size; i++) {
+
+			memnew_placement(&elems[i], T);
+		}
+
+		*_get_size() = p_size;
+
+	} else if (p_size < size()) {
+
+		// deinitialize no longer needed elements
+		for (uint32_t i = p_size; i < *_get_size(); i++) {
+
+			T *t = &_get_data()[i];
+			t->~T();
+		}
+
+		void *_ptrnew = (T *)Memory::realloc_static(_ptr, alloc_size, true);
+		ERR_FAIL_COND_V(!_ptrnew, ERR_OUT_OF_MEMORY);
+
+		_ptr = (T *)(_ptrnew);
+
+		*_get_size() = p_size;
+	}
+
+	return OK;
+}
+
+template <class T>
+void CowData<T>::_ref(const CowData &p_from) {
+
+	if (_ptr == p_from._ptr)
+		return; // self assign, do nothing.
+
+	_unref(_ptr);
+	_ptr = NULL;
+
+	if (!p_from._ptr)
+		return; //nothing to do
+
+	if (atomic_conditional_increment(p_from._get_refcount()) > 0) { // could reference
+		_ptr = p_from._ptr;
+	}
+}
+
+template <class T>
+CowData<T>::CowData() {
+
+	_ptr = NULL;
+}
+
+template <class T>
+CowData<T>::~CowData() {
+
+	_unref(_ptr);
+}
+
+#endif /* COW_H_ */

--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -89,7 +89,7 @@ Error FileAccessEncrypted::open_and_parse(FileAccess *p_base, const Vector<uint8
 
 		for (size_t i = 0; i < ds; i += 16) {
 
-			aes256_decrypt_ecb(&ctx, &data[i]);
+			aes256_decrypt_ecb(&ctx, &data.write[i]);
 		}
 
 		aes256_done(&ctx);
@@ -117,7 +117,7 @@ Error FileAccessEncrypted::open_and_parse_password(FileAccess *p_base, const Str
 	key.resize(32);
 	for (int i = 0; i < 32; i++) {
 
-		key[i] = cs[i];
+		key.write[i] = cs[i];
 	}
 
 	return open_and_parse(p_base, key, p_mode);
@@ -148,7 +148,7 @@ void FileAccessEncrypted::close() {
 		compressed.resize(len);
 		zeromem(compressed.ptrw(), len);
 		for (int i = 0; i < data.size(); i++) {
-			compressed[i] = data[i];
+			compressed.write[i] = data[i];
 		}
 
 		aes256_context ctx;
@@ -156,7 +156,7 @@ void FileAccessEncrypted::close() {
 
 		for (size_t i = 0; i < len; i += 16) {
 
-			aes256_encrypt_ecb(&ctx, &compressed[i]);
+			aes256_encrypt_ecb(&ctx, &compressed.write[i]);
 		}
 
 		aes256_done(&ctx);
@@ -263,7 +263,7 @@ void FileAccessEncrypted::store_buffer(const uint8_t *p_src, int p_length) {
 		data.resize(pos + p_length);
 		for (int i = 0; i < p_length; i++) {
 
-			data[pos + i] = p_src[i];
+			data.write[pos + i] = p_src[i];
 		}
 		pos += p_length;
 	}
@@ -280,7 +280,7 @@ void FileAccessEncrypted::store_8(uint8_t p_dest) {
 	ERR_FAIL_COND(!writing);
 
 	if (pos < data.size()) {
-		data[pos] = p_dest;
+		data.write[pos] = p_dest;
 		pos++;
 	} else if (pos == data.size()) {
 		data.push_back(p_dest);

--- a/core/io/file_access_memory.cpp
+++ b/core/io/file_access_memory.cpp
@@ -92,7 +92,7 @@ Error FileAccessMemory::_open(const String &p_path, int p_mode_flags) {
 	Map<String, Vector<uint8_t> >::Element *E = files->find(name);
 	ERR_FAIL_COND_V(!E, ERR_FILE_NOT_FOUND);
 
-	data = &(E->get()[0]);
+	data = E->get().ptrw();
 	length = E->get().size();
 	pos = 0;
 

--- a/core/io/file_access_network.cpp
+++ b/core/io/file_access_network.cpp
@@ -258,8 +258,8 @@ void FileAccessNetwork::_set_block(int p_offset, const Vector<uint8_t> &p_block)
 	}
 
 	buffer_mutex->lock();
-	pages[page].buffer = p_block;
-	pages[page].queued = false;
+	pages.write[page].buffer = p_block;
+	pages.write[page].queued = false;
 	buffer_mutex->unlock();
 
 	if (waiting_on_page == page) {
@@ -389,7 +389,7 @@ void FileAccessNetwork::_queue_page(int p_page) const {
 		br.offset = size_t(p_page) * page_size;
 		br.size = page_size;
 		nc->block_requests.push_back(br);
-		pages[p_page].queued = true;
+		pages.write[p_page].queued = true;
 		nc->blockrequest_mutex->unlock();
 		DEBUG_PRINT("QUEUE PAGE POST");
 		nc->sem->post();
@@ -433,12 +433,12 @@ int FileAccessNetwork::get_buffer(uint8_t *p_dst, int p_length) const {
 
 					_queue_page(page + j);
 				}
-				buff = pages[page].buffer.ptrw();
+				buff = pages.write[page].buffer.ptrw();
 				//queue pages
 				buffer_mutex->unlock();
 			}
 
-			buff = pages[page].buffer.ptrw();
+			buff = pages.write[page].buffer.ptrw();
 			last_page_buff = buff;
 			last_page = page;
 		}

--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -552,7 +552,7 @@ PoolByteArray HTTPClient::read_response_body_chunk() {
 			} else {
 
 				int rec = 0;
-				err = _get_http_data(&chunk[chunk.size() - chunk_left], chunk_left, rec);
+				err = _get_http_data(&chunk.write[chunk.size() - chunk_left], chunk_left, rec);
 				if (rec == 0) {
 					break;
 				}

--- a/core/io/packet_peer.cpp
+++ b/core/io/packet_peer.cpp
@@ -173,7 +173,7 @@ Error PacketPeerStream::_poll_buffer() const {
 
 	int read = 0;
 	ERR_FAIL_COND_V(input_buffer.size() < ring_buffer.space_left(), ERR_UNAVAILABLE);
-	Error err = peer->get_partial_data(&input_buffer[0], ring_buffer.space_left(), read);
+	Error err = peer->get_partial_data(input_buffer.ptrw(), ring_buffer.space_left(), read);
 	if (err)
 		return err;
 	if (read == 0)
@@ -226,7 +226,7 @@ Error PacketPeerStream::get_packet(const uint8_t **r_buffer, int &r_buffer_size)
 
 	ERR_FAIL_COND_V(input_buffer.size() < len, ERR_UNAVAILABLE);
 	ring_buffer.read(lbuf, 4); //get rid of first 4 bytes
-	ring_buffer.read(&input_buffer[0], len); // read packet
+	ring_buffer.read(input_buffer.ptrw(), len); // read packet
 
 	*r_buffer = &input_buffer[0];
 	r_buffer_size = len;
@@ -247,8 +247,8 @@ Error PacketPeerStream::put_packet(const uint8_t *p_buffer, int p_buffer_size) {
 	ERR_FAIL_COND_V(p_buffer_size < 0, ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(p_buffer_size + 4 > output_buffer.size(), ERR_INVALID_PARAMETER);
 
-	encode_uint32(p_buffer_size, &output_buffer[0]);
-	uint8_t *dst = &output_buffer[4];
+	encode_uint32(p_buffer_size, output_buffer.ptrw());
+	uint8_t *dst = &output_buffer.write[4];
 	for (int i = 0; i < p_buffer_size; i++)
 		dst[i] = p_buffer[i];
 

--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -120,7 +120,7 @@ Error PCKPacker::flush(bool p_verbose) {
 	for (int i = 0; i < files.size(); i++) {
 
 		file->store_pascal_string(files[i].path);
-		files[i].offset_offset = file->get_position();
+		files.write[i].offset_offset = file->get_position();
 		file->store_64(0); // offset
 		file->store_64(files[i].size); // size
 

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -894,7 +894,7 @@ void ResourceInteractiveLoaderBinary::open(FileAccess *p_f) {
 	for (uint32_t i = 0; i < string_table_size; i++) {
 
 		StringName s = get_unicode_string();
-		string_map[i] = s;
+		string_map.write[i] = s;
 	}
 
 	print_bl("strings: " + itos(string_table_size));
@@ -1834,7 +1834,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const RES &p
 	save_order.resize(external_resources.size());
 
 	for (Map<RES, int>::Element *E = external_resources.front(); E; E = E->next()) {
-		save_order[E->get()] = E->key();
+		save_order.write[E->get()] = E->key();
 	}
 
 	for (int i = 0; i < save_order.size(); i++) {

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -556,7 +556,7 @@ void ResourceLoader::load_translation_remaps() {
 		Vector<String> lang_remaps;
 		lang_remaps.resize(langs.size());
 		for (int i = 0; i < langs.size(); i++) {
-			lang_remaps[i] = langs[i];
+			lang_remaps.write[i] = langs[i];
 		}
 
 		translation_remaps[String(E->get())] = lang_remaps;

--- a/core/io/stream_peer.cpp
+++ b/core/io/stream_peer.cpp
@@ -331,7 +331,7 @@ String StreamPeer::get_string(int p_bytes) {
 	ERR_FAIL_COND_V(err != OK, String());
 	err = get_data((uint8_t *)&buf[0], p_bytes);
 	ERR_FAIL_COND_V(err != OK, String());
-	buf[p_bytes] = 0;
+	buf.write[p_bytes] = 0;
 	return buf.ptr();
 }
 String StreamPeer::get_utf8_string(int p_bytes) {

--- a/core/math/bsp_tree.cpp
+++ b/core/math/bsp_tree.cpp
@@ -449,10 +449,10 @@ BSP_Tree::operator Variant() const {
 
 	for (int i = 0; i < planes.size(); i++) {
 
-		plane_values[i * 4 + 0] = planes[i].normal.x;
-		plane_values[i * 4 + 1] = planes[i].normal.y;
-		plane_values[i * 4 + 2] = planes[i].normal.z;
-		plane_values[i * 4 + 3] = planes[i].d;
+		plane_values.write[i * 4 + 0] = planes[i].normal.x;
+		plane_values.write[i * 4 + 1] = planes[i].normal.y;
+		plane_values.write[i * 4 + 2] = planes[i].normal.z;
+		plane_values.write[i * 4 + 3] = planes[i].d;
 	}
 
 	d["planes"] = plane_values;
@@ -498,10 +498,10 @@ BSP_Tree::BSP_Tree(const Variant &p_variant) {
 			PoolVector<real_t>::Read r = src_planes.read();
 			for (int i = 0; i < plane_count / 4; i++) {
 
-				planes[i].normal.x = r[i * 4 + 0];
-				planes[i].normal.y = r[i * 4 + 1];
-				planes[i].normal.z = r[i * 4 + 2];
-				planes[i].d = r[i * 4 + 3];
+				planes.write[i].normal.x = r[i * 4 + 0];
+				planes.write[i].normal.y = r[i * 4 + 1];
+				planes.write[i].normal.z = r[i * 4 + 2];
+				planes.write[i].d = r[i * 4 + 3];
 			}
 		}
 
@@ -520,9 +520,9 @@ BSP_Tree::BSP_Tree(const Variant &p_variant) {
 
 	for (int i = 0; i < nodes.size(); i++) {
 
-		nodes[i].over = r[i * 3 + 0];
-		nodes[i].under = r[i * 3 + 1];
-		nodes[i].plane = r[i * 3 + 2];
+		nodes.write[i].over = r[i * 3 + 0];
+		nodes.write[i].under = r[i * 3 + 1];
+		nodes.write[i].plane = r[i * 3 + 2];
 	}
 }
 

--- a/core/math/delaunay.h
+++ b/core/math/delaunay.h
@@ -92,7 +92,7 @@ public:
 
 			for (int j = 0; j < triangles.size(); j++) {
 				if (circum_circle_contains(points, triangles[j], i)) {
-					triangles[j].bad = true;
+					triangles.write[j].bad = true;
 					polygon.push_back(Edge(triangles[j].points[0], triangles[j].points[1]));
 					polygon.push_back(Edge(triangles[j].points[1], triangles[j].points[2]));
 					polygon.push_back(Edge(triangles[j].points[2], triangles[j].points[0]));
@@ -109,8 +109,8 @@ public:
 			for (int j = 0; j < polygon.size(); j++) {
 				for (int k = j + 1; k < polygon.size(); k++) {
 					if (edge_compare(points, polygon[j], polygon[k])) {
-						polygon[j].bad = true;
-						polygon[k].bad = true;
+						polygon.write[j].bad = true;
+						polygon.write[k].bad = true;
 					}
 				}
 			}

--- a/core/math/geometry.cpp
+++ b/core/math/geometry.cpp
@@ -56,7 +56,7 @@ void Geometry::MeshData::optimize_vertices() {
 				vtx_remap[idx] = ni;
 			}
 
-			faces[i].indices[j] = vtx_remap[idx];
+			faces.write[i].indices.write[j] = vtx_remap[idx];
 		}
 	}
 
@@ -74,8 +74,8 @@ void Geometry::MeshData::optimize_vertices() {
 			vtx_remap[b] = ni;
 		}
 
-		edges[i].a = vtx_remap[a];
-		edges[i].b = vtx_remap[b];
+		edges.write[i].a = vtx_remap[a];
+		edges.write[i].b = vtx_remap[b];
 	}
 
 	Vector<Vector3> new_vertices;
@@ -84,7 +84,7 @@ void Geometry::MeshData::optimize_vertices() {
 	for (int i = 0; i < vertices.size(); i++) {
 
 		if (vtx_remap.has(i))
-			new_vertices[vtx_remap[i]] = vertices[i];
+			new_vertices.write[vtx_remap[i]] = vertices[i];
 	}
 	vertices = new_vertices;
 }
@@ -1014,8 +1014,8 @@ void Geometry::make_atlas(const Vector<Size2i> &p_rects, Vector<Point2i> &r_resu
 	Vector<_AtlasWorkRect> wrects;
 	wrects.resize(p_rects.size());
 	for (int i = 0; i < p_rects.size(); i++) {
-		wrects[i].s = p_rects[i];
-		wrects[i].idx = i;
+		wrects.write[i].s = p_rects[i];
+		wrects.write[i].idx = i;
 	}
 	wrects.sort();
 	int widest = wrects[0].s.width;
@@ -1033,7 +1033,7 @@ void Geometry::make_atlas(const Vector<Size2i> &p_rects, Vector<Point2i> &r_resu
 		Vector<int> hmax;
 		hmax.resize(w);
 		for (int j = 0; j < w; j++)
-			hmax[j] = 0;
+			hmax.write[j] = 0;
 
 		//place them
 		int ofs = 0;
@@ -1052,8 +1052,8 @@ void Geometry::make_atlas(const Vector<Size2i> &p_rects, Vector<Point2i> &r_resu
 					from_y = hmax[ofs + k];
 			}
 
-			wrects[j].p.x = ofs;
-			wrects[j].p.y = from_y;
+			wrects.write[j].p.x = ofs;
+			wrects.write[j].p.y = from_y;
 			int end_h = from_y + wrects[j].s.height;
 			int end_w = ofs + wrects[j].s.width;
 			if (ofs == 0)
@@ -1061,7 +1061,7 @@ void Geometry::make_atlas(const Vector<Size2i> &p_rects, Vector<Point2i> &r_resu
 
 			for (int k = 0; k < wrects[j].s.width; k++) {
 
-				hmax[ofs + k] = end_h;
+				hmax.write[ofs + k] = end_h;
 			}
 
 			if (end_h > max_h)
@@ -1101,7 +1101,7 @@ void Geometry::make_atlas(const Vector<Size2i> &p_rects, Vector<Point2i> &r_resu
 
 	for (int i = 0; i < p_rects.size(); i++) {
 
-		r_result[results[best].result[i].idx] = results[best].result[i].p;
+		r_result.write[results[best].result[i].idx] = results[best].result[i].p;
 	}
 
 	r_size = Size2(results[best].max_w, results[best].max_h);

--- a/core/math/geometry.h
+++ b/core/math/geometry.h
@@ -890,14 +890,14 @@ public:
 		for (int i = 0; i < n; ++i) {
 			while (k >= 2 && vec2_cross(H[k - 2], H[k - 1], P[i]) <= 0)
 				k--;
-			H[k++] = P[i];
+			H.write[k++] = P[i];
 		}
 
 		// Build upper hull
 		for (int i = n - 2, t = k + 1; i >= 0; i--) {
 			while (k >= t && vec2_cross(H[k - 2], H[k - 1], P[i]) <= 0)
 				k--;
-			H[k++] = P[i];
+			H.write[k++] = P[i];
 		}
 
 		H.resize(k);

--- a/core/math/quick_hull.cpp
+++ b/core/math/quick_hull.cpp
@@ -61,10 +61,10 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry::MeshData &r_me
 
 		Vector3 sp = p_points[i].snapped(Vector3(0.0001, 0.0001, 0.0001));
 		if (valid_cache.has(sp)) {
-			valid_points[i] = false;
+			valid_points.write[i] = false;
 			//print_line("INVALIDATED: "+itos(i));
 		} else {
-			valid_points[i] = true;
+			valid_points.write[i] = true;
 			valid_cache.insert(sp);
 		}
 	}
@@ -452,7 +452,7 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry::MeshData &r_me
 
 	int idx = 0;
 	for (List<Geometry::MeshData::Face>::Element *E = ret_faces.front(); E; E = E->next()) {
-		r_mesh.faces[idx++] = E->get();
+		r_mesh.faces.write[idx++] = E->get();
 	}
 	r_mesh.edges.resize(ret_edges.size());
 	idx = 0;
@@ -461,7 +461,7 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry::MeshData &r_me
 		Geometry::MeshData::Edge e;
 		e.a = E->key().vertices[0];
 		e.b = E->key().vertices[1];
-		r_mesh.edges[idx++] = e;
+		r_mesh.edges.write[idx++] = e;
 	}
 
 	r_mesh.vertices = p_points;

--- a/core/math/triangulate.cpp
+++ b/core/math/triangulate.cpp
@@ -128,10 +128,10 @@ bool Triangulate::triangulate(const Vector<Vector2> &contour, Vector<int> &resul
 
 	if (0.0 < get_area(contour))
 		for (int v = 0; v < n; v++)
-			V[v] = v;
+			V.write[v] = v;
 	else
 		for (int v = 0; v < n; v++)
-			V[v] = (n - 1) - v;
+			V.write[v] = (n - 1) - v;
 
 	bool relaxed = false;
 
@@ -182,7 +182,7 @@ bool Triangulate::triangulate(const Vector<Vector2> &contour, Vector<int> &resul
 
 			/* remove v from remaining polygon */
 			for (s = v, t = v + 1; t < nv; s++, t++)
-				V[s] = V[t];
+				V.write[s] = V[t];
 
 			nv--;
 

--- a/core/method_bind.h
+++ b/core/method_bind.h
@@ -354,7 +354,7 @@ public:
 			for (int i = 0; i < p_info.arguments.size(); i++) {
 
 				at[i + 1] = p_info.arguments[i].type;
-				names[i] = p_info.arguments[i].name;
+				names.write[i] = p_info.arguments[i].name;
 			}
 
 			set_argument_names(names);

--- a/core/method_ptrcall.h
+++ b/core/method_ptrcall.h
@@ -180,7 +180,7 @@ struct PtrToArg<const T *> {
 			{                                                                                    \
 				PoolVector<m_type>::Read r = dvs->read();                                        \
 				for (int i = 0; i < len; i++) {                                                  \
-					ret[i] = r[i];                                                               \
+					ret.write[i] = r[i];                                                         \
 				}                                                                                \
 			}                                                                                    \
 			return ret;                                                                          \
@@ -207,7 +207,7 @@ struct PtrToArg<const T *> {
 			{                                                                                    \
 				PoolVector<m_type>::Read r = dvs->read();                                        \
 				for (int i = 0; i < len; i++) {                                                  \
-					ret[i] = r[i];                                                               \
+					ret.write[i] = r[i];                                                         \
 				}                                                                                \
 			}                                                                                    \
 			return ret;                                                                          \
@@ -225,7 +225,7 @@ struct PtrToArg<const T *> {
 			{                                                                                    \
 				PoolVector<m_type>::Read r = dvs->read();                                        \
 				for (int i = 0; i < len; i++) {                                                  \
-					ret[i] = r[i];                                                               \
+					ret.write[i] = r[i];                                                         \
 				}                                                                                \
 			}                                                                                    \
 			return ret;                                                                          \
@@ -252,7 +252,7 @@ struct PtrToArg<const T *> {
 			{                                                                                    \
 				PoolVector<m_type>::Read r = dvs->read();                                        \
 				for (int i = 0; i < len; i++) {                                                  \
-					ret[i] = r[i];                                                               \
+					ret.write[i] = r[i];                                                         \
 				}                                                                                \
 			}                                                                                    \
 			return ret;                                                                          \
@@ -277,7 +277,7 @@ MAKE_VECARG_ALT(String, StringName);
 			int len = arr->size();                                             \
 			ret.resize(len);                                                   \
 			for (int i = 0; i < len; i++) {                                    \
-				ret[i] = (*arr)[i];                                            \
+				ret.write[i] = (*arr)[i];                                      \
 			}                                                                  \
 			return ret;                                                        \
 		}                                                                      \
@@ -298,7 +298,7 @@ MAKE_VECARG_ALT(String, StringName);
 			int len = arr->size();                                             \
 			ret.resize(len);                                                   \
 			for (int i = 0; i < len; i++) {                                    \
-				ret[i] = (*arr)[i];                                            \
+				ret.write[i] = (*arr)[i];                                      \
 			}                                                                  \
 			return ret;                                                        \
 		}                                                                      \

--- a/core/node_path.cpp
+++ b/core/node_path.cpp
@@ -427,7 +427,7 @@ NodePath::NodePath(const String &p_path) {
 
 				String name = path.substr(from, i - from);
 				ERR_FAIL_INDEX(slice, data->path.size());
-				data->path[slice++] = name;
+				data->path.write[slice++] = name;
 			}
 			from = i + 1;
 			last_is_slash = true;

--- a/core/object.cpp
+++ b/core/object.cpp
@@ -818,8 +818,8 @@ Variant Object::callv(const StringName &p_method, const Array &p_args) {
 	argptrs.resize(p_args.size());
 
 	for (int i = 0; i < p_args.size(); i++) {
-		args[i] = p_args[i];
-		argptrs[i] = &args[i];
+		args.write[i] = p_args[i];
+		argptrs.write[i] = &args[i];
 	}
 
 	Variant::CallError ce;
@@ -1182,10 +1182,10 @@ Error Object::emit_signal(const StringName &p_name, const Variant **p_args, int 
 			bind_mem.resize(p_argcount + c.binds.size());
 
 			for (int j = 0; j < p_argcount; j++) {
-				bind_mem[j] = p_args[j];
+				bind_mem.write[j] = p_args[j];
 			}
 			for (int j = 0; j < c.binds.size(); j++) {
-				bind_mem[p_argcount + j] = &c.binds[j];
+				bind_mem.write[p_argcount + j] = &c.binds[j];
 			}
 
 			args = (const Variant **)bind_mem.ptr();

--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -262,15 +262,15 @@ String FileAccess::get_token() const {
 	while (!eof_reached()) {
 
 		if (c <= ' ') {
-			if (!token.empty())
+			if (token.length())
 				break;
 		} else {
-			token.push_back(c);
+			token += c;
 		}
 		c = get_8();
 	}
 
-	token.push_back(0);
+	token += '0';
 	return String::utf8(token.get_data());
 }
 
@@ -293,7 +293,7 @@ class CharBuffer {
 
 			for (int i = 0; i < written; i++) {
 
-				vector[i] = stack_buffer[i];
+				vector.write[i] = stack_buffer[i];
 			}
 		}
 

--- a/core/os/threaded_array_processor.h
+++ b/core/os/threaded_array_processor.h
@@ -80,7 +80,7 @@ void thread_process_array(uint32_t p_elements, C *p_instance, M p_method, U p_us
 	threads.resize(OS::get_singleton()->get_processor_count());
 
 	for (int i = 0; i < threads.size(); i++) {
-		threads[i] = Thread::create(process_array_thread<ThreadArrayProcessData<C, U> >, &data);
+		threads.write[i] = Thread::create(process_array_thread<ThreadArrayProcessData<C, U> >, &data);
 	}
 
 	for (int i = 0; i < threads.size(); i++) {

--- a/core/packed_data_container.cpp
+++ b/core/packed_data_container.cpp
@@ -251,7 +251,7 @@ uint32_t PackedDataContainer::_pack(const Variant &p_data, Vector<uint8_t> &tmpd
 			int len;
 			encode_variant(p_data, NULL, len);
 			tmpdata.resize(tmpdata.size() + len);
-			encode_variant(p_data, &tmpdata[pos], len);
+			encode_variant(p_data, &tmpdata.write[pos], len);
 			return pos;
 
 		} break;
@@ -268,8 +268,8 @@ uint32_t PackedDataContainer::_pack(const Variant &p_data, Vector<uint8_t> &tmpd
 			uint32_t pos = tmpdata.size();
 			int len = d.size();
 			tmpdata.resize(tmpdata.size() + len * 12 + 8);
-			encode_uint32(TYPE_DICT, &tmpdata[pos + 0]);
-			encode_uint32(len, &tmpdata[pos + 4]);
+			encode_uint32(TYPE_DICT, &tmpdata.write[pos + 0]);
+			encode_uint32(len, &tmpdata.write[pos + 4]);
 
 			List<Variant> keys;
 			d.get_key_list(&keys);
@@ -288,11 +288,11 @@ uint32_t PackedDataContainer::_pack(const Variant &p_data, Vector<uint8_t> &tmpd
 			int idx = 0;
 			for (List<DictKey>::Element *E = sortk.front(); E; E = E->next()) {
 
-				encode_uint32(E->get().hash, &tmpdata[pos + 8 + idx * 12 + 0]);
+				encode_uint32(E->get().hash, &tmpdata.write[pos + 8 + idx * 12 + 0]);
 				uint32_t ofs = _pack(E->get().key, tmpdata, string_cache);
-				encode_uint32(ofs, &tmpdata[pos + 8 + idx * 12 + 4]);
+				encode_uint32(ofs, &tmpdata.write[pos + 8 + idx * 12 + 4]);
 				ofs = _pack(d[E->get().key], tmpdata, string_cache);
-				encode_uint32(ofs, &tmpdata[pos + 8 + idx * 12 + 8]);
+				encode_uint32(ofs, &tmpdata.write[pos + 8 + idx * 12 + 8]);
 				idx++;
 			}
 
@@ -306,13 +306,13 @@ uint32_t PackedDataContainer::_pack(const Variant &p_data, Vector<uint8_t> &tmpd
 			uint32_t pos = tmpdata.size();
 			int len = a.size();
 			tmpdata.resize(tmpdata.size() + len * 4 + 8);
-			encode_uint32(TYPE_ARRAY, &tmpdata[pos + 0]);
-			encode_uint32(len, &tmpdata[pos + 4]);
+			encode_uint32(TYPE_ARRAY, &tmpdata.write[pos + 0]);
+			encode_uint32(len, &tmpdata.write[pos + 4]);
 
 			for (int i = 0; i < len; i++) {
 
 				uint32_t ofs = _pack(a[i], tmpdata, string_cache);
-				encode_uint32(ofs, &tmpdata[pos + 8 + i * 4]);
+				encode_uint32(ofs, &tmpdata.write[pos + 8 + i * 4]);
 			}
 
 			return pos;

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -627,7 +627,7 @@ Error ProjectSettings::_save_settings_binary(const String &p_file, const Map<Str
 		Vector<uint8_t> buff;
 		buff.resize(len);
 
-		err = encode_variant(p_custom_features, &buff[0], len);
+		err = encode_variant(p_custom_features, buff.ptrw(), len);
 		if (err != OK) {
 			memdelete(file);
 			ERR_FAIL_V(err);
@@ -664,7 +664,7 @@ Error ProjectSettings::_save_settings_binary(const String &p_file, const Map<Str
 			Vector<uint8_t> buff;
 			buff.resize(len);
 
-			err = encode_variant(value, &buff[0], len);
+			err = encode_variant(value, buff.ptrw(), len);
 			if (err != OK)
 				memdelete(file);
 			ERR_FAIL_COND_V(err != OK, ERR_INVALID_DATA);

--- a/core/ring_buffer.h
+++ b/core/ring_buffer.h
@@ -137,7 +137,7 @@ public:
 
 	Error write(const T &p_v) {
 		ERR_FAIL_COND_V(space_left() < 1, FAILED);
-		data[inc(write_pos, 1)] = p_v;
+		data.write[inc(write_pos, 1)] = p_v;
 		return OK;
 	};
 
@@ -156,7 +156,7 @@ public:
 			int total = end - pos;
 
 			for (int i = 0; i < total; i++) {
-				data[pos + i] = p_buf[src++];
+				data.write[pos + i] = p_buf[src++];
 			};
 			to_write -= total;
 			pos = 0;
@@ -196,7 +196,7 @@ public:
 		data.resize(1 << p_power);
 		if (old_size < new_size && read_pos > write_pos) {
 			for (int i = 0; i < write_pos; i++) {
-				data[(old_size + i) & mask] = data[i];
+				data.write[(old_size + i) & mask] = data[i];
 			};
 			write_pos = (old_size + write_pos) & mask;
 		} else {

--- a/core/script_debugger_local.cpp
+++ b/core/script_debugger_local.cpp
@@ -325,7 +325,7 @@ void ScriptDebuggerLocal::idle_poll() {
 
 	int ofs = 0;
 	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
-		ofs += ScriptServer::get_language(i)->profiling_get_frame_data(&pinfo[ofs], pinfo.size() - ofs);
+		ofs += ScriptServer::get_language(i)->profiling_get_frame_data(&pinfo.write[ofs], pinfo.size() - ofs);
 	}
 
 	SortArray<ScriptLanguage::ProfilingInfo, _ScriptDebuggerLocalProfileInfoSort> sort;
@@ -377,7 +377,7 @@ void ScriptDebuggerLocal::profiling_end() {
 	int ofs = 0;
 
 	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
-		ofs += ScriptServer::get_language(i)->profiling_get_accumulated_data(&pinfo[ofs], pinfo.size() - ofs);
+		ofs += ScriptServer::get_language(i)->profiling_get_accumulated_data(&pinfo.write[ofs], pinfo.size() - ofs);
 	}
 
 	SortArray<ScriptLanguage::ProfilingInfo, _ScriptDebuggerLocalProfileInfoSort> sort;

--- a/core/script_debugger_remote.cpp
+++ b/core/script_debugger_remote.cpp
@@ -783,13 +783,13 @@ void ScriptDebuggerRemote::_send_profiling_data(bool p_for_frame) {
 
 	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
 		if (p_for_frame)
-			ofs += ScriptServer::get_language(i)->profiling_get_frame_data(&profile_info[ofs], profile_info.size() - ofs);
+			ofs += ScriptServer::get_language(i)->profiling_get_frame_data(&profile_info.write[ofs], profile_info.size() - ofs);
 		else
-			ofs += ScriptServer::get_language(i)->profiling_get_accumulated_data(&profile_info[ofs], profile_info.size() - ofs);
+			ofs += ScriptServer::get_language(i)->profiling_get_accumulated_data(&profile_info.write[ofs], profile_info.size() - ofs);
 	}
 
 	for (int i = 0; i < ofs; i++) {
-		profile_info_ptrs[i] = &profile_info[i];
+		profile_info_ptrs.write[i] = &profile_info.write[i];
 	}
 
 	SortArray<ScriptLanguage::ProfilingInfo *, ProfileInfoSort> sa;
@@ -1054,7 +1054,7 @@ void ScriptDebuggerRemote::add_profiling_frame_data(const StringName &p_name, co
 	if (idx == -1) {
 		profile_frame_data.push_back(fd);
 	} else {
-		profile_frame_data[idx] = fd;
+		profile_frame_data.write[idx] = fd;
 	}
 }
 

--- a/core/string_buffer.h
+++ b/core/string_buffer.h
@@ -42,7 +42,7 @@ class StringBuffer {
 	int string_length;
 
 	_FORCE_INLINE_ CharType *current_buffer_ptr() {
-		return static_cast<Vector<CharType> &>(buffer).empty() ? short_buffer : buffer.ptrw();
+		return static_cast<String &>(buffer).empty() ? short_buffer : buffer.ptrw();
 	}
 
 public:

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -58,11 +58,7 @@
 #endif
 
 #ifndef _FORCE_INLINE_
-#ifdef DEBUG_ENABLED
-#define _FORCE_INLINE_ inline
-#else
 #define _FORCE_INLINE_ _ALWAYS_INLINE_
-#endif
 #endif
 
 //custom, gcc-safe offsetof, because gcc complains a lot.
@@ -267,7 +263,7 @@ static inline uint64_t BSWAP64(uint64_t x) {
 template <class T>
 struct Comparator {
 
-	inline bool operator()(const T &p_a, const T &p_b) const { return (p_a < p_b); }
+	_ALWAYS_INLINE_ bool operator()(const T &p_a, const T &p_b) const { return (p_a < p_b); }
 };
 
 void _global_lock();

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -102,6 +102,15 @@ bool CharString::operator<(const CharString &p_right) const {
 	return is_str_less(get_data(), p_right.get_data());
 }
 
+CharString &CharString::operator+=(char p_char) {
+
+	resize(size() ? size() + 1 : 2);
+	set(length(), 0);
+	set(length() - 1, p_char);
+
+	return *this;
+}
+
 const char *CharString::get_data() const {
 
 	if (size())
@@ -1578,6 +1587,7 @@ String::String(const char *p_str) {
 
 	copy_from(p_str);
 }
+
 String::String(const CharType *p_str, int p_clip_to_len) {
 
 	copy_from(p_str, p_clip_to_len);
@@ -2197,7 +2207,7 @@ Vector<uint8_t> String::md5_buffer() const {
 	Vector<uint8_t> ret;
 	ret.resize(16);
 	for (int i = 0; i < 16; i++) {
-		ret[i] = ctx.digest[i];
+		ret.write[i] = ctx.digest[i];
 	};
 
 	return ret;
@@ -2214,7 +2224,7 @@ Vector<uint8_t> String::sha256_buffer() const {
 	Vector<uint8_t> ret;
 	ret.resize(32);
 	for (int i = 0; i < 32; i++) {
-		ret[i] = hash[i];
+		ret.write[i] = hash[i];
 	}
 
 	return ret;
@@ -2673,7 +2683,7 @@ Vector<String> String::bigrams() const {
 	}
 	b.resize(n_pairs);
 	for (int i = 0; i < n_pairs; i++) {
-		b[i] = substr(i, 2);
+		b.write[i] = substr(i, 2);
 	}
 	return b;
 }
@@ -3032,14 +3042,14 @@ String String::strip_escapes() const {
 	return substr(beg, end - beg);
 }
 
-String String::lstrip(const Vector<CharType> &p_chars) const {
+String String::lstrip(const String &p_chars) const {
 
 	int len = length();
 	int beg;
 
 	for (beg = 0; beg < len; beg++) {
 
-		if (p_chars.find(operator[](beg)) == -1)
+		if (p_chars.find(&ptr()[beg]) == -1)
 			break;
 	}
 
@@ -3049,14 +3059,14 @@ String String::lstrip(const Vector<CharType> &p_chars) const {
 	return substr(beg, len - beg);
 }
 
-String String::rstrip(const Vector<CharType> &p_chars) const {
+String String::rstrip(const String &p_chars) const {
 
 	int len = length();
 	int end;
 
 	for (end = len - 1; end >= 0; end--) {
 
-		if (p_chars.find(operator[](end)) == -1)
+		if (p_chars.find(&ptr()[end]) == -1)
 			break;
 	}
 
@@ -3868,10 +3878,10 @@ String String::percent_decode() const {
 			c += d;
 			i += 2;
 		}
-		pe.push_back(c);
+		pe += c;
 	}
 
-	pe.push_back(0);
+	pe += '0';
 
 	return String::utf8(pe.ptr());
 }

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -32,6 +32,7 @@
 #define RSTRING_H
 
 #include "array.h"
+#include "cowdata.h"
 #include "typedefs.h"
 #include "vector.h"
 
@@ -39,9 +40,27 @@
 	@author red <red@killy>
 */
 
-class CharString : public Vector<char> {
+class CharString {
+
+	CowData<char> _cowdata;
+
 public:
+	_FORCE_INLINE_ char *ptrw() { return _cowdata.ptrw(); }
+	_FORCE_INLINE_ const char *ptr() const { return _cowdata.ptr(); }
+	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
+	Error resize(int p_size) { return _cowdata.resize(p_size); }
+
+	_FORCE_INLINE_ char get(int p_index) { return _cowdata.get(p_index); }
+	_FORCE_INLINE_ const char get(int p_index) const { return _cowdata.get(p_index); }
+	_FORCE_INLINE_ void set(int p_index, const char &p_elem) { _cowdata.set(p_index, p_elem); }
+	_FORCE_INLINE_ char &operator[](int p_index) { return _cowdata.get_m(p_index); }
+	_FORCE_INLINE_ const char &operator[](int p_index) const { return _cowdata.get(p_index); }
+
+	_FORCE_INLINE_ CharString() {}
+	_FORCE_INLINE_ CharString(const CharString &p_str) { _cowdata._ref(p_str._cowdata); }
+
 	bool operator<(const CharString &p_right) const;
+	CharString &operator+=(char p_char);
 	int length() const { return size() ? size() - 1 : 0; }
 	const char *get_data() const;
 	operator const char *() { return get_data(); };
@@ -60,7 +79,9 @@ struct StrRange {
 	}
 };
 
-class String : public Vector<CharType> {
+class String {
+
+	CowData<CharType> _cowdata;
 
 	void copy_from(const char *p_cstr);
 	void copy_from(const CharType *p_cstr, int p_clip_to = -1);
@@ -73,6 +94,21 @@ public:
 
 		npos = -1 ///<for "some" compatibility with std::string (npos is a huge value in std::string)
 	};
+
+	_FORCE_INLINE_ CharType *ptrw() { return _cowdata.ptrw(); }
+	_FORCE_INLINE_ const CharType *ptr() const { return _cowdata.ptr(); }
+
+	void remove(int p_index) { _cowdata.remove(p_index); }
+
+	_FORCE_INLINE_ void clear() { resize(0); }
+
+	_FORCE_INLINE_ CharType get(int p_index) { return _cowdata.get(p_index); }
+	_FORCE_INLINE_ const CharType get(int p_index) const { return _cowdata.get(p_index); }
+	_FORCE_INLINE_ void set(int p_index, const CharType &p_elem) { _cowdata.set(p_index, p_elem); }
+	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
+	Error resize(int p_size) { return _cowdata.resize(p_size); }
+	_FORCE_INLINE_ CharType &operator[](int p_index) { return _cowdata.get_m(p_index); }
+	_FORCE_INLINE_ const CharType &operator[](int p_index) const { return _cowdata.get(p_index); }
 
 	bool operator==(const String &p_str) const;
 	bool operator!=(const String &p_str) const;
@@ -192,8 +228,8 @@ public:
 	String dedent() const;
 	String strip_edges(bool left = true, bool right = true) const;
 	String strip_escapes() const;
-	String lstrip(const Vector<CharType> &p_chars) const;
-	String rstrip(const Vector<CharType> &p_chars) const;
+	String lstrip(const String &p_chars) const;
+	String rstrip(const String &p_chars) const;
 	String get_extension() const;
 	String get_basename() const;
 	String plus_file(const String &p_file) const;
@@ -254,9 +290,10 @@ public:
 	 * The constructors must not depend on other overloads
 	 */
 	/*	String(CharType p_char);*/
-	inline String() {}
-	inline String(const String &p_str) :
-			Vector(p_str) {}
+
+	_FORCE_INLINE_ String() {}
+	_FORCE_INLINE_ String(const String &p_str) { _cowdata._ref(p_str._cowdata); }
+
 	String(const char *p_str);
 	String(const CharType *p_str, int p_clip_to_len = -1);
 	String(const StrRange &p_range);

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -1878,7 +1878,7 @@ Variant::operator Vector<RID>() const {
 	Vector<RID> rids;
 	rids.resize(va.size());
 	for (int i = 0; i < rids.size(); i++)
-		rids[i] = va[i];
+		rids.write[i] = va[i];
 	return rids;
 }
 
@@ -1891,7 +1891,7 @@ Variant::operator Vector<Vector2>() const {
 		return Vector<Vector2>();
 	to.resize(len);
 	PoolVector<Vector2>::Read r = from.read();
-	Vector2 *w = &to[0];
+	Vector2 *w = to.ptrw();
 	for (int i = 0; i < len; i++) {
 
 		w[i] = r[i];
@@ -1945,7 +1945,7 @@ Variant::operator Vector<Plane>() const {
 	planes.resize(va_size);
 
 	for (int i = 0; i < va_size; i++)
-		planes[i] = va[i];
+		planes.write[i] = va[i];
 
 	return planes;
 }
@@ -1958,7 +1958,7 @@ Variant::operator Vector<Variant>() const {
 	to.resize(len);
 	for (int i = 0; i < len; i++) {
 
-		to[i] = from[i];
+		to.write[i] = from[i];
 	}
 	return to;
 }
@@ -1971,7 +1971,7 @@ Variant::operator Vector<uint8_t>() const {
 	to.resize(len);
 	for (int i = 0; i < len; i++) {
 
-		to[i] = from[i];
+		to.write[i] = from[i];
 	}
 	return to;
 }
@@ -1983,7 +1983,7 @@ Variant::operator Vector<int>() const {
 	to.resize(len);
 	for (int i = 0; i < len; i++) {
 
-		to[i] = from[i];
+		to.write[i] = from[i];
 	}
 	return to;
 }
@@ -1995,7 +1995,7 @@ Variant::operator Vector<real_t>() const {
 	to.resize(len);
 	for (int i = 0; i < len; i++) {
 
-		to[i] = from[i];
+		to.write[i] = from[i];
 	}
 	return to;
 }
@@ -2008,7 +2008,7 @@ Variant::operator Vector<String>() const {
 	to.resize(len);
 	for (int i = 0; i < len; i++) {
 
-		to[i] = from[i];
+		to.write[i] = from[i];
 	}
 	return to;
 }
@@ -2020,7 +2020,7 @@ Variant::operator Vector<StringName>() const {
 	to.resize(len);
 	for (int i = 0; i < len; i++) {
 
-		to[i] = from[i];
+		to.write[i] = from[i];
 	}
 	return to;
 }
@@ -2034,7 +2034,7 @@ Variant::operator Vector<Vector3>() const {
 		return Vector<Vector3>();
 	to.resize(len);
 	PoolVector<Vector3>::Read r = from.read();
-	Vector3 *w = &to[0];
+	Vector3 *w = to.ptrw();
 	for (int i = 0; i < len; i++) {
 
 		w[i] = r[i];
@@ -2050,7 +2050,7 @@ Variant::operator Vector<Color>() const {
 		return Vector<Color>();
 	to.resize(len);
 	PoolVector<Color>::Read r = from.read();
-	Color *w = &to[0];
+	Color *w = to.ptrw();
 	for (int i = 0; i < len; i++) {
 
 		w[i] = r[i];

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -64,7 +64,7 @@ struct _VariantCall {
 			if (arg_count == 0)
 				return true;
 
-			Variant::Type *tptr = &arg_types[0];
+			const Variant::Type *tptr = &arg_types[0];
 
 			for (int i = 0; i < arg_count; i++) {
 

--- a/core/vector.h
+++ b/core/vector.h
@@ -36,131 +36,69 @@
  * @author Juan Linietsky
  * Vector container. Regular Vector Container. Use with care and for smaller arrays when possible. Use PoolVector for large arrays.
 */
+#include "cowdata.h"
 #include "error_macros.h"
 #include "os/memory.h"
-#include "safe_refcount.h"
 #include "sort.h"
 
 template <class T>
-class Vector {
+class VectorWriteProxy {
+	friend class Vector<T>;
+	Vector<T> &_parent;
 
-	mutable T *_ptr;
-
-	// internal helpers
-
-	_FORCE_INLINE_ uint32_t *_get_refcount() const {
-
-		if (!_ptr)
-			return NULL;
-
-		return reinterpret_cast<uint32_t *>(_ptr) - 2;
-	}
-
-	_FORCE_INLINE_ uint32_t *_get_size() const {
-
-		if (!_ptr)
-			return NULL;
-
-		return reinterpret_cast<uint32_t *>(_ptr) - 1;
-	}
-	_FORCE_INLINE_ T *_get_data() const {
-
-		if (!_ptr)
-			return NULL;
-		return reinterpret_cast<T *>(_ptr);
-	}
-
-	_FORCE_INLINE_ size_t _get_alloc_size(size_t p_elements) const {
-		//return nearest_power_of_2_templated(p_elements*sizeof(T)+sizeof(SafeRefCount)+sizeof(int));
-		return next_power_of_2(p_elements * sizeof(T));
-	}
-
-	_FORCE_INLINE_ bool _get_alloc_size_checked(size_t p_elements, size_t *out) const {
-#if defined(_add_overflow) && defined(_mul_overflow)
-		size_t o;
-		size_t p;
-		if (_mul_overflow(p_elements, sizeof(T), &o)) return false;
-		*out = next_power_of_2(o);
-		if (_add_overflow(o, static_cast<size_t>(32), &p)) return false; //no longer allocated here
-		return true;
-#else
-		// Speed is more important than correctness here, do the operations unchecked
-		// and hope the best
-		*out = _get_alloc_size(p_elements);
-		return true;
-#endif
-	}
-
-	void _unref(void *p_data);
-
-	void _copy_from(const Vector &p_from);
-	void _copy_on_write();
+	_FORCE_INLINE_ VectorWriteProxy(Vector<T> &parent) :
+			_parent(parent){};
+	VectorWriteProxy(const VectorWriteProxy<T> &p_other);
 
 public:
-	_FORCE_INLINE_ T *ptrw() {
-		if (!_ptr) return NULL;
-		_copy_on_write();
-		return (T *)_get_data();
-	}
-	_FORCE_INLINE_ const T *ptr() const {
-		if (!_ptr) return NULL;
-		return _get_data();
-	}
+	_FORCE_INLINE_ T &operator[](int p_index) {
+		CRASH_BAD_INDEX(p_index, _parent.size());
 
-	_FORCE_INLINE_ void clear() { resize(0); }
-
-	_FORCE_INLINE_ int size() const {
-		uint32_t *size = (uint32_t *)_get_size();
-		if (size)
-			return *size;
-		else
-			return 0;
+		return _parent.ptrw()[p_index];
 	}
-	_FORCE_INLINE_ bool empty() const { return _ptr == 0; }
-	Error resize(int p_size);
+};
+
+template <class T>
+class Vector {
+	friend class VectorWriteProxy<T>;
+
+	CowData<T> _cowdata;
+
+public:
+	VectorWriteProxy<T> write;
+
 	bool push_back(const T &p_elem);
 
-	void remove(int p_index);
+	void remove(int p_index) { _cowdata.remove(p_index); }
 	void erase(const T &p_val) {
 		int idx = find(p_val);
 		if (idx >= 0) remove(idx);
 	};
 	void invert();
 
-	template <class T_val>
-	int find(const T_val &p_val, int p_from = 0) const;
+	_FORCE_INLINE_ T *ptrw() { return _cowdata.ptrw(); }
+	_FORCE_INLINE_ const T *ptr() const { return _cowdata.ptr(); }
+	_FORCE_INLINE_ void clear() { resize(0); }
+	_FORCE_INLINE_ bool empty() const { return _cowdata.empty(); }
 
-	void set(int p_index, const T &p_elem);
-	T get(int p_index) const;
-
-	inline T &operator[](int p_index) {
-
-		CRASH_BAD_INDEX(p_index, size());
-
-		_copy_on_write(); // wants to write, so copy on write.
-
-		return _get_data()[p_index];
-	}
-
-	inline const T &operator[](int p_index) const {
-
-		CRASH_BAD_INDEX(p_index, size());
-
-		// no cow needed, since it's reading
-		return _get_data()[p_index];
-	}
-
-	Error insert(int p_pos, const T &p_val);
+	_FORCE_INLINE_ T get(int p_index) { return _cowdata.get(p_index); }
+	_FORCE_INLINE_ const T get(int p_index) const { return _cowdata.get(p_index); }
+	_FORCE_INLINE_ void set(int p_index, const T &p_elem) { _cowdata.set(p_index, p_elem); }
+	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
+	Error resize(int p_size) { return _cowdata.resize(p_size); }
+	_FORCE_INLINE_ const T &operator[](int p_index) const { return _cowdata.get(p_index); }
+	Error insert(int p_pos, const T &p_val) { return _cowdata.insert(p_pos, p_val); }
 
 	void append_array(const Vector<T> &p_other);
 
 	template <class C>
 	void sort_custom() {
 
-		int len = size();
+		int len = _cowdata.size();
 		if (len == 0)
 			return;
-		T *data = &operator[](0);
+
+		T *data = ptrw();
 		SortArray<T, C> sorter;
 		sorter.sort(data, len);
 	}
@@ -172,7 +110,7 @@ public:
 
 	void ordered_insert(const T &p_val) {
 		int i;
-		for (i = 0; i < size(); i++) {
+		for (i = 0; i < _cowdata.size(); i++) {
 
 			if (p_val < operator[](i)) {
 				break;
@@ -181,232 +119,39 @@ public:
 		insert(i, p_val);
 	}
 
-	void operator=(const Vector &p_from);
-	Vector(const Vector &p_from);
+	int find(const T &p_val, int p_from = 0) const {
+		int ret = -1;
+		if (p_from < 0 || size() == 0)
+			return ret;
 
-	_FORCE_INLINE_ Vector();
-	_FORCE_INLINE_ ~Vector();
-};
+		for (int i = p_from; i < size(); i++) {
 
-template <class T>
-void Vector<T>::_unref(void *p_data) {
-
-	if (!p_data)
-		return;
-
-	uint32_t *refc = _get_refcount();
-
-	if (atomic_decrement(refc) > 0)
-		return; // still in use
-	// clean up
-
-	uint32_t *count = _get_size();
-	T *data = (T *)(count + 1);
-
-	for (uint32_t i = 0; i < *count; i++) {
-		// call destructors
-		data[i].~T();
-	}
-
-	// free mem
-	Memory::free_static((uint8_t *)p_data, true);
-}
-
-template <class T>
-void Vector<T>::_copy_on_write() {
-
-	if (!_ptr)
-		return;
-
-	uint32_t *refc = _get_refcount();
-
-	if (*refc > 1) {
-		/* in use by more than me */
-		uint32_t current_size = *_get_size();
-
-		uint32_t *mem_new = (uint32_t *)Memory::alloc_static(_get_alloc_size(current_size), true);
-
-		*(mem_new - 2) = 1; //refcount
-		*(mem_new - 1) = current_size; //size
-
-		T *_data = (T *)(mem_new);
-
-		// initialize new elements
-		for (uint32_t i = 0; i < current_size; i++) {
-
-			memnew_placement(&_data[i], T(_get_data()[i]));
-		}
-
-		_unref(_ptr);
-		_ptr = _data;
-	}
-}
-
-template <class T>
-template <class T_val>
-int Vector<T>::find(const T_val &p_val, int p_from) const {
-
-	int ret = -1;
-	if (p_from < 0 || size() == 0)
-		return ret;
-
-	for (int i = p_from; i < size(); i++) {
-
-		if (operator[](i) == p_val) {
-			ret = i;
-			break;
+			if (ptr()[i] == p_val) {
+				ret = i;
+				break;
+			};
 		};
-	};
 
-	return ret;
-}
-
-template <class T>
-Error Vector<T>::resize(int p_size) {
-
-	ERR_FAIL_COND_V(p_size < 0, ERR_INVALID_PARAMETER);
-
-	if (p_size == size())
-		return OK;
-
-	if (p_size == 0) {
-		// wants to clean up
-		_unref(_ptr);
-		_ptr = NULL;
-		return OK;
+		return ret;
 	}
 
-	// possibly changing size, copy on write
-	_copy_on_write();
-
-	size_t alloc_size;
-	ERR_FAIL_COND_V(!_get_alloc_size_checked(p_size, &alloc_size), ERR_OUT_OF_MEMORY);
-
-	if (p_size > size()) {
-
-		if (size() == 0) {
-			// alloc from scratch
-			uint32_t *ptr = (uint32_t *)Memory::alloc_static(alloc_size, true);
-			ERR_FAIL_COND_V(!ptr, ERR_OUT_OF_MEMORY);
-			*(ptr - 1) = 0; //size, currently none
-			*(ptr - 2) = 1; //refcount
-
-			_ptr = (T *)ptr;
-
-		} else {
-			void *_ptrnew = (T *)Memory::realloc_static(_ptr, alloc_size, true);
-			ERR_FAIL_COND_V(!_ptrnew, ERR_OUT_OF_MEMORY);
-			_ptr = (T *)(_ptrnew);
-		}
-
-		// construct the newly created elements
-		T *elems = _get_data();
-
-		for (int i = *_get_size(); i < p_size; i++) {
-
-			memnew_placement(&elems[i], T);
-		}
-
-		*_get_size() = p_size;
-
-	} else if (p_size < size()) {
-
-		// deinitialize no longer needed elements
-		for (uint32_t i = p_size; i < *_get_size(); i++) {
-
-			T *t = &_get_data()[i];
-			t->~T();
-		}
-
-		void *_ptrnew = (T *)Memory::realloc_static(_ptr, alloc_size, true);
-		ERR_FAIL_COND_V(!_ptrnew, ERR_OUT_OF_MEMORY);
-
-		_ptr = (T *)(_ptrnew);
-
-		*_get_size() = p_size;
+	_FORCE_INLINE_ Vector() :
+			write(VectorWriteProxy<T>(*this)) {}
+	_FORCE_INLINE_ Vector(const Vector &p_from) :
+			write(VectorWriteProxy<T>(*this)) { _cowdata._ref(p_from._cowdata); }
+	inline Vector &operator=(const Vector &p_from) {
+		_cowdata._ref(p_from._cowdata);
+		return *this;
 	}
-
-	return OK;
-}
+};
 
 template <class T>
 void Vector<T>::invert() {
 
 	for (int i = 0; i < size() / 2; i++) {
-
-		SWAP(operator[](i), operator[](size() - i - 1));
+		T *p = ptrw();
+		SWAP(p[i], p[size() - i - 1]);
 	}
-}
-
-template <class T>
-void Vector<T>::set(int p_index, const T &p_elem) {
-
-	operator[](p_index) = p_elem;
-}
-
-template <class T>
-T Vector<T>::get(int p_index) const {
-
-	return operator[](p_index);
-}
-
-template <class T>
-bool Vector<T>::push_back(const T &p_elem) {
-
-	Error err = resize(size() + 1);
-	ERR_FAIL_COND_V(err, true)
-	set(size() - 1, p_elem);
-
-	return false;
-}
-
-template <class T>
-void Vector<T>::remove(int p_index) {
-
-	ERR_FAIL_INDEX(p_index, size());
-	T *p = ptrw();
-	int len = size();
-	for (int i = p_index; i < len - 1; i++) {
-
-		p[i] = p[i + 1];
-	};
-
-	resize(len - 1);
-};
-
-template <class T>
-void Vector<T>::_copy_from(const Vector &p_from) {
-
-	if (_ptr == p_from._ptr)
-		return; // self assign, do nothing.
-
-	_unref(_ptr);
-	_ptr = NULL;
-
-	if (!p_from._ptr)
-		return; //nothing to do
-
-	if (atomic_conditional_increment(p_from._get_refcount()) > 0) { // could reference
-		_ptr = p_from._ptr;
-	}
-}
-
-template <class T>
-void Vector<T>::operator=(const Vector &p_from) {
-
-	_copy_from(p_from);
-}
-
-template <class T>
-Error Vector<T>::insert(int p_pos, const T &p_val) {
-
-	ERR_FAIL_INDEX_V(p_pos, size() + 1, ERR_INVALID_PARAMETER);
-	resize(size() + 1);
-	for (int i = (size() - 1); i > p_pos; i--)
-		set(i, get(i - 1));
-	set(p_pos, p_val);
-
-	return OK;
 }
 
 template <class T>
@@ -417,26 +162,17 @@ void Vector<T>::append_array(const Vector<T> &p_other) {
 	const int bs = size();
 	resize(bs + ds);
 	for (int i = 0; i < ds; ++i)
-		operator[](bs + i) = p_other[i];
+		ptrw()[bs + i] = p_other[i];
 }
 
 template <class T>
-Vector<T>::Vector(const Vector &p_from) {
+bool Vector<T>::push_back(const T &p_elem) {
 
-	_ptr = NULL;
-	_copy_from(p_from);
-}
+	Error err = resize(size() + 1);
+	ERR_FAIL_COND_V(err, true)
+	set(size() - 1, p_elem);
 
-template <class T>
-Vector<T>::Vector() {
-
-	_ptr = NULL;
-}
-
-template <class T>
-Vector<T>::~Vector() {
-
-	_unref(_ptr);
+	return false;
 }
 
 #endif

--- a/core/vmap.h
+++ b/core/vmap.h
@@ -31,8 +31,8 @@
 #ifndef VMAP_H
 #define VMAP_H
 
+#include "cowdata.h"
 #include "typedefs.h"
-#include "vector.h"
 
 template <class T, class V>
 class VMap {
@@ -51,17 +51,17 @@ class VMap {
 		}
 	};
 
-	Vector<_Pair> _data;
+	CowData<_Pair> _cowdata;
 
 	_FORCE_INLINE_ int _find(const T &p_val, bool &r_exact) const {
 
 		r_exact = false;
-		if (_data.empty())
+		if (_cowdata.empty())
 			return 0;
 
 		int low = 0;
-		int high = _data.size() - 1;
-		const _Pair *a = &_data[0];
+		int high = _cowdata.size() - 1;
+		const _Pair *a = _cowdata.ptr();
 		int middle = 0;
 
 #if DEBUG_ENABLED
@@ -89,13 +89,13 @@ class VMap {
 
 	_FORCE_INLINE_ int _find_exact(const T &p_val) const {
 
-		if (_data.empty())
+		if (_cowdata.empty())
 			return -1;
 
 		int low = 0;
-		int high = _data.size() - 1;
+		int high = _cowdata.size() - 1;
 		int middle;
-		const _Pair *a = &_data[0];
+		const _Pair *a = _cowdata.ptr();
 
 		while (low <= high) {
 			middle = (low + high) / 2;
@@ -118,10 +118,10 @@ public:
 		bool exact;
 		int pos = _find(p_key, exact);
 		if (exact) {
-			_data[pos].value = p_val;
+			_cowdata.get_m(pos).value = p_val;
 			return pos;
 		}
-		_data.insert(pos, _Pair(p_key, p_val));
+		_cowdata.insert(pos, _Pair(p_key, p_val));
 		return pos;
 	}
 
@@ -135,7 +135,7 @@ public:
 		int pos = _find_exact(p_val);
 		if (pos < 0)
 			return;
-		_data.remove(pos);
+		_cowdata.remove(pos);
 	}
 
 	int find(const T &p_val) const {
@@ -149,37 +149,37 @@ public:
 		return _find(p_val, exact);
 	}
 
-	_FORCE_INLINE_ int size() const { return _data.size(); }
-	_FORCE_INLINE_ bool empty() const { return _data.empty(); }
+	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
+	_FORCE_INLINE_ bool empty() const { return _cowdata.empty(); }
 
 	const _Pair *get_array() const {
 
-		return _data.ptr();
+		return _cowdata.ptr();
 	}
 
 	_Pair *get_array() {
 
-		return _data.ptr();
+		return _cowdata.ptrw();
 	}
 
 	const V &getv(int p_index) const {
 
-		return _data[p_index].value;
+		return _cowdata.get(p_index).value;
 	}
 
 	V &getv(int p_index) {
 
-		return _data[p_index].value;
+		return _cowdata.get_m(p_index).value;
 	}
 
 	const T &getk(int p_index) const {
 
-		return _data[p_index].key;
+		return _cowdata.get(p_index).key;
 	}
 
 	T &getk(int p_index) {
 
-		return _data[p_index].key;
+		return _cowdata.get_m(p_index).key;
 	}
 
 	inline const V &operator[](const T &p_key) const {
@@ -188,7 +188,7 @@ public:
 
 		CRASH_COND(pos < 0);
 
-		return _data[pos].value;
+		return _cowdata.get(pos).value;
 	}
 
 	inline V &operator[](const T &p_key) {
@@ -199,7 +199,14 @@ public:
 			pos = insert(p_key, val);
 		}
 
-		return _data[pos].value;
+		return _cowdata.get_m(pos).value;
+	}
+
+	_FORCE_INLINE_ VMap(){};
+	_FORCE_INLINE_ VMap(const VMap &p_from) { _cowdata._ref(p_from._cowdata); }
+	inline VMap &operator=(const VMap &p_from) {
+		_cowdata._ref(p_from._cowdata);
+		return *this;
 	}
 };
 #endif // VMAP_H

--- a/core/vset.h
+++ b/core/vset.h
@@ -133,7 +133,7 @@ public:
 
 	inline T &operator[](int p_index) {
 
-		return _data[p_index];
+		return _data.write[p_index];
 	}
 
 	inline const T &operator[](int p_index) const {

--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -174,14 +174,14 @@ void AudioDriverALSA::thread_func(void *p_udata) {
 
 		if (!ad->active) {
 			for (unsigned int i = 0; i < ad->period_size * ad->channels; i++) {
-				ad->samples_out[i] = 0;
+				ad->samples_out.write[i] = 0;
 			}
 
 		} else {
 			ad->audio_server_process(ad->period_size, ad->samples_in.ptrw());
 
 			for (unsigned int i = 0; i < ad->period_size * ad->channels; i++) {
-				ad->samples_out[i] = ad->samples_in[i] >> 16;
+				ad->samples_out.write[i] = ad->samples_in[i] >> 16;
 			}
 		}
 

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -289,7 +289,7 @@ public:
 		ERR_FAIL_COND(!m);
 
 		m->surfaces.push_back(DummySurface());
-		DummySurface *s = &m->surfaces[m->surfaces.size() - 1];
+		DummySurface *s = &m->surfaces.write[m->surfaces.size() - 1];
 		s->format = p_format;
 		s->primitive = p_primitive;
 		s->array = p_array;

--- a/drivers/gles2/shader_compiler_gles2.cpp
+++ b/drivers/gles2/shader_compiler_gles2.cpp
@@ -325,10 +325,10 @@ String ShaderCompilerGLES2::_dump_node_code(SL::Node *p_node, int p_level, Gener
 				uniform_code += ";\n";
 
 				if (SL::is_sampler_type(E->get().type)) {
-					r_gen_code.texture_uniforms[E->get().texture_order] = _mkid(E->key());
-					r_gen_code.texture_hints[E->get().texture_order] = E->get().hint;
+					r_gen_code.texture_uniforms.write[E->get().texture_order] = _mkid(E->key());
+					r_gen_code.texture_hints.write[E->get().texture_order] = E->get().hint;
 				} else {
-					r_gen_code.uniforms[E->get().order] = E->key();
+					r_gen_code.uniforms.write[E->get().order] = E->key();
 				}
 
 				vertex_global += uniform_code.as_string();

--- a/drivers/gles2/shader_gles2.cpp
+++ b/drivers/gles2/shader_gles2.cpp
@@ -288,7 +288,7 @@ ShaderGLES2::Version *ShaderGLES2::get_current_version() {
 
 	if (cc) {
 		for (int i = 0; i < cc->custom_defines.size(); i++) {
-			strings.push_back(cc->custom_defines[i]);
+			strings.push_back(cc->custom_defines.write[i]);
 			DEBUG_PRINT("CD #" + itos(i) + ": " + String(cc->custom_defines[i]));
 		}
 	}
@@ -502,7 +502,7 @@ ShaderGLES2::Version *ShaderGLES2::get_current_version() {
 	if (cc) {
 		v.custom_uniform_locations.resize(cc->custom_uniforms.size());
 		for (int i = 0; i < cc->custom_uniforms.size(); i++) {
-			v.custom_uniform_locations[i] = glGetUniformLocation(v.id, String(cc->custom_uniforms[i]).ascii().get_data());
+			v.custom_uniform_locations.write[i] = glGetUniformLocation(v.id, String(cc->custom_uniforms[i]).ascii().get_data());
 		}
 	}
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -355,7 +355,7 @@ bool RasterizerSceneGLES3::shadow_atlas_update_light(RID p_atlas, RID p_light_in
 		bool should_redraw = shadow_atlas->quadrants[q].shadows[s].version != p_light_version;
 
 		if (!should_realloc) {
-			shadow_atlas->quadrants[q].shadows[s].version = p_light_version;
+			shadow_atlas->quadrants[q].shadows.write[s].version = p_light_version;
 			//already existing, see if it should redraw or it's just OK
 			return should_redraw;
 		}
@@ -365,7 +365,7 @@ bool RasterizerSceneGLES3::shadow_atlas_update_light(RID p_atlas, RID p_light_in
 		//find a better place
 		if (_shadow_atlas_find_shadow(shadow_atlas, valid_quadrants, valid_quadrant_count, shadow_atlas->quadrants[q].subdivision, tick, new_quadrant, new_shadow)) {
 			//found a better place!
-			ShadowAtlas::Quadrant::Shadow *sh = &shadow_atlas->quadrants[new_quadrant].shadows[new_shadow];
+			ShadowAtlas::Quadrant::Shadow *sh = &shadow_atlas->quadrants[new_quadrant].shadows.write[new_shadow];
 			if (sh->owner.is_valid()) {
 				//is taken, but is invalid, erasing it
 				shadow_atlas->shadow_owners.erase(sh->owner);
@@ -374,8 +374,8 @@ bool RasterizerSceneGLES3::shadow_atlas_update_light(RID p_atlas, RID p_light_in
 			}
 
 			//erase previous
-			shadow_atlas->quadrants[q].shadows[s].version = 0;
-			shadow_atlas->quadrants[q].shadows[s].owner = RID();
+			shadow_atlas->quadrants[q].shadows.write[s].version = 0;
+			shadow_atlas->quadrants[q].shadows.write[s].owner = RID();
 
 			sh->owner = p_light_intance;
 			sh->alloc_tick = tick;
@@ -395,7 +395,7 @@ bool RasterizerSceneGLES3::shadow_atlas_update_light(RID p_atlas, RID p_light_in
 
 		//already existing, see if it should redraw or it's just OK
 
-		shadow_atlas->quadrants[q].shadows[s].version = p_light_version;
+		shadow_atlas->quadrants[q].shadows.write[s].version = p_light_version;
 
 		return should_redraw;
 	}
@@ -405,7 +405,7 @@ bool RasterizerSceneGLES3::shadow_atlas_update_light(RID p_atlas, RID p_light_in
 	//find a better place
 	if (_shadow_atlas_find_shadow(shadow_atlas, valid_quadrants, valid_quadrant_count, -1, tick, new_quadrant, new_shadow)) {
 		//found a better place!
-		ShadowAtlas::Quadrant::Shadow *sh = &shadow_atlas->quadrants[new_quadrant].shadows[new_shadow];
+		ShadowAtlas::Quadrant::Shadow *sh = &shadow_atlas->quadrants[new_quadrant].shadows.write[new_shadow];
 		if (sh->owner.is_valid()) {
 			//is taken, but is invalid, erasing it
 			shadow_atlas->shadow_owners.erase(sh->owner);
@@ -502,7 +502,7 @@ void RasterizerSceneGLES3::reflection_atlas_set_size(RID p_ref_atlas, int p_size
 		//erase probes reference to this
 		if (reflection_atlas->reflections[i].owner.is_valid()) {
 			ReflectionProbeInstance *reflection_probe_instance = reflection_probe_instance_owner.getornull(reflection_atlas->reflections[i].owner);
-			reflection_atlas->reflections[i].owner = RID();
+			reflection_atlas->reflections.write[i].owner = RID();
 
 			ERR_CONTINUE(!reflection_probe_instance);
 			reflection_probe_instance->reflection_atlas_index = -1;
@@ -574,7 +574,7 @@ void RasterizerSceneGLES3::reflection_atlas_set_subdivision(RID p_ref_atlas, int
 			//erase probes reference to this
 			if (reflection_atlas->reflections[i].owner.is_valid()) {
 				ReflectionProbeInstance *reflection_probe_instance = reflection_probe_instance_owner.getornull(reflection_atlas->reflections[i].owner);
-				reflection_atlas->reflections[i].owner = RID();
+				reflection_atlas->reflections.write[i].owner = RID();
 
 				ERR_CONTINUE(!reflection_probe_instance);
 				reflection_probe_instance->reflection_atlas_index = -1;
@@ -629,7 +629,7 @@ void RasterizerSceneGLES3::reflection_probe_release_atlas_index(RID p_instance) 
 
 	ERR_FAIL_COND(reflection_atlas->reflections[rpi->reflection_atlas_index].owner != rpi->self);
 
-	reflection_atlas->reflections[rpi->reflection_atlas_index].owner = RID();
+	reflection_atlas->reflections.write[rpi->reflection_atlas_index].owner = RID();
 
 	rpi->reflection_atlas_index = -1;
 	rpi->atlas = RID();
@@ -701,8 +701,8 @@ bool RasterizerSceneGLES3::reflection_probe_instance_begin_render(RID p_instance
 		victim_rpi->reflection_atlas_index = -1;
 	}
 
-	reflection_atlas->reflections[best_free].owner = p_instance;
-	reflection_atlas->reflections[best_free].last_frame = storage->frame.count;
+	reflection_atlas->reflections.write[best_free].owner = p_instance;
+	reflection_atlas->reflections.write[best_free].last_frame = storage->frame.count;
 
 	rpi->reflection_atlas_index = best_free;
 	rpi->atlas = p_reflection_atlas;
@@ -3848,8 +3848,8 @@ void RasterizerSceneGLES3::_post_process(Environment *env, const CameraMatrix &p
 		state.exposure_shader.set_conditional(ExposureShaderGLES3::EXPOSURE_END, false);
 
 		//last step, swap with the framebuffer exposure, so the right exposure is kept int he framebuffer
-		SWAP(exposure_shrink[exposure_shrink.size() - 1].fbo, storage->frame.current_rt->exposure.fbo);
-		SWAP(exposure_shrink[exposure_shrink.size() - 1].color, storage->frame.current_rt->exposure.color);
+		SWAP(exposure_shrink.write[exposure_shrink.size() - 1].fbo, storage->frame.current_rt->exposure.fbo);
+		SWAP(exposure_shrink.write[exposure_shrink.size() - 1].color, storage->frame.current_rt->exposure.color);
 
 		glViewport(0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height);
 
@@ -4778,7 +4778,7 @@ bool RasterizerSceneGLES3::free(RID p_rid) {
 			uint32_t q = (key >> ShadowAtlas::QUADRANT_SHIFT) & 0x3;
 			uint32_t s = key & ShadowAtlas::SHADOW_INDEX_MASK;
 
-			shadow_atlas->quadrants[q].shadows[s].owner = RID();
+			shadow_atlas->quadrants[q].shadows.write[s].owner = RID();
 			shadow_atlas->shadow_owners.erase(p_rid);
 		}
 

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -2670,7 +2670,7 @@ void RasterizerStorageGLES3::_update_material(Material *material) {
 				}
 			}
 
-			material->textures[E->get().texture_order] = texture;
+			material->textures.write[E->get().texture_order] = texture;
 		}
 
 	} else {
@@ -2975,9 +2975,9 @@ void RasterizerStorageGLES3::mesh_add_surface(RID p_mesh, uint32_t p_format, VS:
 
 	for (int i = 0; i < surface->skeleton_bone_used.size(); i++) {
 		if (surface->skeleton_bone_aabb[i].size.x < 0 || surface->skeleton_bone_aabb[i].size.y < 0 || surface->skeleton_bone_aabb[i].size.z < 0) {
-			surface->skeleton_bone_used[i] = false;
+			surface->skeleton_bone_used.write[i] = false;
 		} else {
-			surface->skeleton_bone_used[i] = true;
+			surface->skeleton_bone_used.write[i] = true;
 		}
 	}
 
@@ -3878,29 +3878,29 @@ void RasterizerStorageGLES3::multimesh_allocate(RID p_multimesh, int p_instances
 			int custom_data_from = 0;
 
 			if (multimesh->transform_format == VS::MULTIMESH_TRANSFORM_2D) {
-				multimesh->data[i + 0] = 1.0;
-				multimesh->data[i + 1] = 0.0;
-				multimesh->data[i + 2] = 0.0;
-				multimesh->data[i + 3] = 0.0;
-				multimesh->data[i + 4] = 0.0;
-				multimesh->data[i + 5] = 1.0;
-				multimesh->data[i + 6] = 0.0;
-				multimesh->data[i + 7] = 0.0;
+				multimesh->data.write[i + 0] = 1.0;
+				multimesh->data.write[i + 1] = 0.0;
+				multimesh->data.write[i + 2] = 0.0;
+				multimesh->data.write[i + 3] = 0.0;
+				multimesh->data.write[i + 4] = 0.0;
+				multimesh->data.write[i + 5] = 1.0;
+				multimesh->data.write[i + 6] = 0.0;
+				multimesh->data.write[i + 7] = 0.0;
 				color_from = 8;
 				custom_data_from = 8;
 			} else {
-				multimesh->data[i + 0] = 1.0;
-				multimesh->data[i + 1] = 0.0;
-				multimesh->data[i + 2] = 0.0;
-				multimesh->data[i + 3] = 0.0;
-				multimesh->data[i + 4] = 0.0;
-				multimesh->data[i + 5] = 1.0;
-				multimesh->data[i + 6] = 0.0;
-				multimesh->data[i + 7] = 0.0;
-				multimesh->data[i + 8] = 0.0;
-				multimesh->data[i + 9] = 0.0;
-				multimesh->data[i + 10] = 1.0;
-				multimesh->data[i + 11] = 0.0;
+				multimesh->data.write[i + 0] = 1.0;
+				multimesh->data.write[i + 1] = 0.0;
+				multimesh->data.write[i + 2] = 0.0;
+				multimesh->data.write[i + 3] = 0.0;
+				multimesh->data.write[i + 4] = 0.0;
+				multimesh->data.write[i + 5] = 1.0;
+				multimesh->data.write[i + 6] = 0.0;
+				multimesh->data.write[i + 7] = 0.0;
+				multimesh->data.write[i + 8] = 0.0;
+				multimesh->data.write[i + 9] = 0.0;
+				multimesh->data.write[i + 10] = 1.0;
+				multimesh->data.write[i + 11] = 0.0;
 				color_from = 12;
 				custom_data_from = 12;
 			}
@@ -3915,14 +3915,14 @@ void RasterizerStorageGLES3::multimesh_allocate(RID p_multimesh, int p_instances
 				} cu;
 
 				cu.colu = 0xFFFFFFFF;
-				multimesh->data[i + color_from + 0] = cu.colf;
+				multimesh->data.write[i + color_from + 0] = cu.colf;
 				custom_data_from = color_from + 1;
 
 			} else if (multimesh->color_format == VS::MULTIMESH_COLOR_FLOAT) {
-				multimesh->data[i + color_from + 0] = 1.0;
-				multimesh->data[i + color_from + 1] = 1.0;
-				multimesh->data[i + color_from + 2] = 1.0;
-				multimesh->data[i + color_from + 3] = 1.0;
+				multimesh->data.write[i + color_from + 0] = 1.0;
+				multimesh->data.write[i + color_from + 1] = 1.0;
+				multimesh->data.write[i + color_from + 2] = 1.0;
+				multimesh->data.write[i + color_from + 3] = 1.0;
 				custom_data_from = color_from + 4;
 			}
 
@@ -3936,13 +3936,13 @@ void RasterizerStorageGLES3::multimesh_allocate(RID p_multimesh, int p_instances
 				} cu;
 
 				cu.colu = 0;
-				multimesh->data[i + custom_data_from + 0] = cu.colf;
+				multimesh->data.write[i + custom_data_from + 0] = cu.colf;
 
 			} else if (multimesh->custom_data_format == VS::MULTIMESH_CUSTOM_DATA_FLOAT) {
-				multimesh->data[i + custom_data_from + 0] = 0.0;
-				multimesh->data[i + custom_data_from + 1] = 0.0;
-				multimesh->data[i + custom_data_from + 2] = 0.0;
-				multimesh->data[i + custom_data_from + 3] = 0.0;
+				multimesh->data.write[i + custom_data_from + 0] = 0.0;
+				multimesh->data.write[i + custom_data_from + 1] = 0.0;
+				multimesh->data.write[i + custom_data_from + 2] = 0.0;
+				multimesh->data.write[i + custom_data_from + 3] = 0.0;
 			}
 		}
 
@@ -4004,7 +4004,7 @@ void RasterizerStorageGLES3::multimesh_instance_set_transform(RID p_multimesh, i
 	ERR_FAIL_COND(multimesh->transform_format == VS::MULTIMESH_TRANSFORM_2D);
 
 	int stride = multimesh->color_floats + multimesh->xform_floats + multimesh->custom_data_floats;
-	float *dataptr = &multimesh->data[stride * p_index];
+	float *dataptr = &multimesh->data.write[stride * p_index];
 
 	dataptr[0] = p_transform.basis.elements[0][0];
 	dataptr[1] = p_transform.basis.elements[0][1];
@@ -4035,7 +4035,7 @@ void RasterizerStorageGLES3::multimesh_instance_set_transform_2d(RID p_multimesh
 	ERR_FAIL_COND(multimesh->transform_format == VS::MULTIMESH_TRANSFORM_3D);
 
 	int stride = multimesh->color_floats + multimesh->xform_floats + multimesh->custom_data_floats;
-	float *dataptr = &multimesh->data[stride * p_index];
+	float *dataptr = &multimesh->data.write[stride * p_index];
 
 	dataptr[0] = p_transform.elements[0][0];
 	dataptr[1] = p_transform.elements[1][0];
@@ -4061,7 +4061,7 @@ void RasterizerStorageGLES3::multimesh_instance_set_color(RID p_multimesh, int p
 	ERR_FAIL_COND(multimesh->color_format == VS::MULTIMESH_COLOR_NONE);
 
 	int stride = multimesh->color_floats + multimesh->xform_floats + multimesh->custom_data_floats;
-	float *dataptr = &multimesh->data[stride * p_index + multimesh->xform_floats];
+	float *dataptr = &multimesh->data.write[stride * p_index + multimesh->xform_floats];
 
 	if (multimesh->color_format == VS::MULTIMESH_COLOR_8BIT) {
 
@@ -4094,7 +4094,7 @@ void RasterizerStorageGLES3::multimesh_instance_set_custom_data(RID p_multimesh,
 	ERR_FAIL_COND(multimesh->custom_data_format == VS::MULTIMESH_CUSTOM_DATA_NONE);
 
 	int stride = multimesh->color_floats + multimesh->xform_floats + multimesh->custom_data_floats;
-	float *dataptr = &multimesh->data[stride * p_index + multimesh->xform_floats + multimesh->color_floats];
+	float *dataptr = &multimesh->data.write[stride * p_index + multimesh->xform_floats + multimesh->color_floats];
 
 	if (multimesh->custom_data_format == VS::MULTIMESH_CUSTOM_DATA_8BIT) {
 
@@ -4134,7 +4134,7 @@ Transform RasterizerStorageGLES3::multimesh_instance_get_transform(RID p_multime
 	ERR_FAIL_COND_V(multimesh->transform_format == VS::MULTIMESH_TRANSFORM_2D, Transform());
 
 	int stride = multimesh->color_floats + multimesh->xform_floats + multimesh->custom_data_floats;
-	float *dataptr = &multimesh->data[stride * p_index];
+	float *dataptr = &multimesh->data.write[stride * p_index];
 
 	Transform xform;
 
@@ -4161,7 +4161,7 @@ Transform2D RasterizerStorageGLES3::multimesh_instance_get_transform_2d(RID p_mu
 	ERR_FAIL_COND_V(multimesh->transform_format == VS::MULTIMESH_TRANSFORM_3D, Transform2D());
 
 	int stride = multimesh->color_floats + multimesh->xform_floats + multimesh->custom_data_floats;
-	float *dataptr = &multimesh->data[stride * p_index];
+	float *dataptr = &multimesh->data.write[stride * p_index];
 
 	Transform2D xform;
 
@@ -4183,7 +4183,7 @@ Color RasterizerStorageGLES3::multimesh_instance_get_color(RID p_multimesh, int 
 	ERR_FAIL_COND_V(multimesh->color_format == VS::MULTIMESH_COLOR_NONE, Color());
 
 	int stride = multimesh->color_floats + multimesh->xform_floats + multimesh->custom_data_floats;
-	float *dataptr = &multimesh->data[stride * p_index + multimesh->xform_floats];
+	float *dataptr = &multimesh->data.write[stride * p_index + multimesh->xform_floats];
 
 	if (multimesh->color_format == VS::MULTIMESH_COLOR_8BIT) {
 		union {
@@ -4216,7 +4216,7 @@ Color RasterizerStorageGLES3::multimesh_instance_get_custom_data(RID p_multimesh
 	ERR_FAIL_COND_V(multimesh->custom_data_format == VS::MULTIMESH_CUSTOM_DATA_NONE, Color());
 
 	int stride = multimesh->color_floats + multimesh->xform_floats + multimesh->custom_data_floats;
-	float *dataptr = &multimesh->data[stride * p_index + multimesh->xform_floats + multimesh->color_floats];
+	float *dataptr = &multimesh->data.write[stride * p_index + multimesh->xform_floats + multimesh->color_floats];
 
 	if (multimesh->custom_data_format == VS::MULTIMESH_CUSTOM_DATA_8BIT) {
 		union {
@@ -5772,7 +5772,7 @@ void RasterizerStorageGLES3::particles_set_draw_pass_mesh(RID p_particles, int p
 	Particles *particles = particles_owner.getornull(p_particles);
 	ERR_FAIL_COND(!particles);
 	ERR_FAIL_INDEX(p_pass, particles->draw_passes.size());
-	particles->draw_passes[p_pass] = p_mesh;
+	particles->draw_passes.write[p_pass] = p_mesh;
 }
 
 void RasterizerStorageGLES3::particles_restart(RID p_particles) {
@@ -6646,7 +6646,7 @@ void RasterizerStorageGLES3::_render_target_allocate(RenderTarget *rt) {
 
 			for (int j = 0; j < rt->effects.mip_maps[i].sizes.size(); j++) {
 
-				RenderTarget::Effects::MipMaps::Size &mm = rt->effects.mip_maps[i].sizes[j];
+				RenderTarget::Effects::MipMaps::Size &mm = rt->effects.mip_maps[i].sizes.write[j];
 
 				glGenFramebuffers(1, &mm.fbo);
 				glBindFramebuffer(GL_FRAMEBUFFER, mm.fbo);
@@ -7058,7 +7058,7 @@ bool RasterizerStorageGLES3::free(RID p_rid) {
 
 			for (int i = 0; i < ins->materials.size(); i++) {
 				if (ins->materials[i] == p_rid) {
-					ins->materials[i] = RID();
+					ins->materials.write[i] = RID();
 				}
 			}
 		}

--- a/drivers/gles3/shader_compiler_gles3.cpp
+++ b/drivers/gles3/shader_compiler_gles3.cpp
@@ -365,17 +365,17 @@ String ShaderCompilerGLES3::_dump_node_code(SL::Node *p_node, int p_level, Gener
 				if (SL::is_sampler_type(E->get().type)) {
 					r_gen_code.vertex_global += ucode;
 					r_gen_code.fragment_global += ucode;
-					r_gen_code.texture_uniforms[E->get().texture_order] = _mkid(E->key());
-					r_gen_code.texture_hints[E->get().texture_order] = E->get().hint;
+					r_gen_code.texture_uniforms.write[E->get().texture_order] = _mkid(E->key());
+					r_gen_code.texture_hints.write[E->get().texture_order] = E->get().hint;
 				} else {
 					if (!uses_uniforms) {
 
 						r_gen_code.defines.push_back(String("#define USE_MATERIAL\n").ascii());
 						uses_uniforms = true;
 					}
-					uniform_defines[E->get().order] = ucode;
-					uniform_sizes[E->get().order] = _get_datatype_size(E->get().type);
-					uniform_alignments[E->get().order] = _get_datatype_alignment(E->get().type);
+					uniform_defines.write[E->get().order] = ucode;
+					uniform_sizes.write[E->get().order] = _get_datatype_size(E->get().type);
+					uniform_alignments.write[E->get().order] = _get_datatype_alignment(E->get().type);
 				}
 
 				p_actions.uniforms->insert(E->key(), E->get());

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -554,7 +554,7 @@ ShaderGLES3::Version *ShaderGLES3::get_current_version() {
 		v.texture_uniform_locations.resize(cc->texture_uniforms.size());
 		for (int i = 0; i < cc->texture_uniforms.size(); i++) {
 
-			v.texture_uniform_locations[i] = glGetUniformLocation(v.id, String(cc->texture_uniforms[i]).ascii().get_data());
+			v.texture_uniform_locations.write[i] = glGetUniformLocation(v.id, String(cc->texture_uniforms[i]).ascii().get_data());
 			glUniform1i(v.texture_uniform_locations[i], i + base_material_tex_index);
 		}
 	}

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -295,7 +295,7 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 
 		if (!ad->active) {
 			for (unsigned int i = 0; i < ad->pa_buffer_size; i++) {
-				ad->samples_out[i] = 0;
+				ad->samples_out.write[i] = 0;
 			}
 
 		} else {
@@ -303,7 +303,7 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 
 			if (ad->channels == ad->pa_map.channels) {
 				for (unsigned int i = 0; i < ad->pa_buffer_size; i++) {
-					ad->samples_out[i] = ad->samples_in[i] >> 16;
+					ad->samples_out.write[i] = ad->samples_in[i] >> 16;
 				}
 			} else {
 				// Uneven amount of channels
@@ -312,11 +312,11 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 
 				for (unsigned int i = 0; i < ad->buffer_frames; i++) {
 					for (unsigned int j = 0; j < ad->pa_map.channels - 1; j++) {
-						ad->samples_out[out_idx++] = ad->samples_in[in_idx++] >> 16;
+						ad->samples_out.write[out_idx++] = ad->samples_in[in_idx++] >> 16;
 					}
 					uint32_t l = ad->samples_in[in_idx++];
 					uint32_t r = ad->samples_in[in_idx++];
-					ad->samples_out[out_idx++] = (l >> 1 + r >> 1) >> 16;
+					ad->samples_out.write[out_idx++] = (l >> 1 + r >> 1) >> 16;
 				}
 			}
 		}

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -447,7 +447,7 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 			ad->audio_server_process(ad->buffer_frames, ad->samples_in.ptrw());
 		} else {
 			for (unsigned int i = 0; i < ad->buffer_size; i++) {
-				ad->samples_in[i] = 0;
+				ad->samples_in.write[i] = 0;
 			}
 		}
 

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -231,10 +231,10 @@ public:
 							if (Variant::can_convert(args[idx].get_type(), t)) {
 								Variant old = args[idx];
 								Variant *ptrs[1] = { &old };
-								args[idx] = Variant::construct(t, (const Variant **)ptrs, 1, err);
+								args.write[idx] = Variant::construct(t, (const Variant **)ptrs, 1, err);
 							} else {
 
-								args[idx] = Variant::construct(t, NULL, 0, err);
+								args.write[idx] = Variant::construct(t, NULL, 0, err);
 							}
 							change_notify_deserved = true;
 							d_new["args"] = args;
@@ -248,7 +248,7 @@ public:
 							_fix_node_path(value);
 						}
 
-						args[idx] = value;
+						args.write[idx] = value;
 						d_new["args"] = args;
 						mergeable = true;
 					}
@@ -3316,7 +3316,7 @@ void AnimationTrackEditor::_update_tracks() {
 					}
 
 					for (int j = 0; j < track_edit_plugins.size(); j++) {
-						track_edit = track_edit_plugins[j]->create_value_track_edit(object, pinfo.type, pinfo.name, pinfo.hint, pinfo.hint_string, pinfo.usage);
+						track_edit = track_edit_plugins.write[j]->create_value_track_edit(object, pinfo.type, pinfo.name, pinfo.hint, pinfo.hint_string, pinfo.usage);
 						if (track_edit) {
 							break;
 						}
@@ -3327,7 +3327,7 @@ void AnimationTrackEditor::_update_tracks() {
 		if (animation->track_get_type(i) == Animation::TYPE_AUDIO) {
 
 			for (int j = 0; j < track_edit_plugins.size(); j++) {
-				track_edit = track_edit_plugins[j]->create_audio_track_edit();
+				track_edit = track_edit_plugins.write[j]->create_audio_track_edit();
 				if (track_edit) {
 					break;
 				}
@@ -3344,7 +3344,7 @@ void AnimationTrackEditor::_update_tracks() {
 
 			if (node && Object::cast_to<AnimationPlayer>(node)) {
 				for (int j = 0; j < track_edit_plugins.size(); j++) {
-					track_edit = track_edit_plugins[j]->create_animation_track_edit(node);
+					track_edit = track_edit_plugins.write[j]->create_animation_track_edit(node);
 					if (track_edit) {
 						break;
 					}

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -271,8 +271,8 @@ void AnimationTrackEditAudio::draw_key(int p_index, float p_pixels_sec, int p_x,
 			float min = preview->get_min(ofs, ofs_n) * 0.5 + 0.5;
 
 			int idx = i - from_x;
-			lines[idx * 2 + 0] = Vector2(i, rect.position.y + min * rect.size.y);
-			lines[idx * 2 + 1] = Vector2(i, rect.position.y + max * rect.size.y);
+			lines.write[idx * 2 + 0] = Vector2(i, rect.position.y + min * rect.size.y);
+			lines.write[idx * 2 + 1] = Vector2(i, rect.position.y + max * rect.size.y);
 		}
 
 		Vector<Color> color;
@@ -883,8 +883,8 @@ void AnimationTrackEditTypeAudio::draw_key(int p_index, float p_pixels_sec, int 
 		float min = preview->get_min(ofs, ofs_n) * 0.5 + 0.5;
 
 		int idx = i - from_x;
-		lines[idx * 2 + 0] = Vector2(i, rect.position.y + min * rect.size.y);
-		lines[idx * 2 + 1] = Vector2(i, rect.position.y + max * rect.size.y);
+		lines.write[idx * 2 + 0] = Vector2(i, rect.position.y + min * rect.size.y);
+		lines.write[idx * 2 + 1] = Vector2(i, rect.position.y + max * rect.size.y);
 	}
 
 	Vector<Color> color;

--- a/editor/audio_stream_preview.cpp
+++ b/editor/audio_stream_preview.cpp
@@ -118,8 +118,8 @@ void AudioStreamPreviewGenerator::_preview_thread(void *p_preview) {
 			uint8_t pfrom = CLAMP((min * 0.5 + 0.5) * 255, 0, 255);
 			uint8_t pto = CLAMP((max * 0.5 + 0.5) * 255, 0, 255);
 
-			preview->preview->preview[(ofs_write + i) * 2 + 0] = pfrom;
-			preview->preview->preview[(ofs_write + i) * 2 + 1] = pto;
+			preview->preview->preview.write[(ofs_write + i) * 2 + 0] = pfrom;
+			preview->preview->preview.write[(ofs_write + i) * 2 + 1] = pto;
 		}
 
 		frames_todo -= to_read;

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -725,7 +725,7 @@ void CodeTextEditor::_complete_request() {
 	int i = 0;
 	for (List<String>::Element *E = entries.front(); E; E = E->next()) {
 
-		strs[i++] = E->get();
+		strs.write[i++] = E->get();
 	}
 
 	text_editor->code_complete(strs, forced);

--- a/editor/collada/collada.h
+++ b/editor/collada/collada.h
@@ -312,7 +312,7 @@ public:
 					total += weights[i].weight;
 				if (total)
 					for (int i = 0; i < 4; i++)
-						weights[i].weight /= total;
+						weights.write[i].weight /= total;
 			}
 		}
 
@@ -515,7 +515,7 @@ public:
 			Key() { interp_type = INTERP_LINEAR; }
 		};
 
-		Vector<float> get_value_at_time(float p_time);
+		Vector<float> get_value_at_time(float p_time) const;
 
 		Vector<Key> keys;
 

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -51,7 +51,7 @@ public:
 		if (name.begins_with("bind/")) {
 			int which = name.get_slice("/", 1).to_int() - 1;
 			ERR_FAIL_INDEX_V(which, params.size(), false);
-			params[which] = p_value;
+			params.write[which] = p_value;
 		} else
 			return false;
 

--- a/editor/doc/doc_data.cpp
+++ b/editor/doc/doc_data.cpp
@@ -58,7 +58,7 @@ void DocData::merge_from(const DocData &p_data) {
 
 		for (int i = 0; i < c.methods.size(); i++) {
 
-			MethodDoc &m = c.methods[i];
+			MethodDoc &m = c.methods.write[i];
 
 			for (int j = 0; j < cf.methods.size(); j++) {
 
@@ -72,13 +72,13 @@ void DocData::merge_from(const DocData &p_data) {
 				Vector<bool> arg_used;
 				arg_used.resize(arg_count);
 				for (int l = 0; l < arg_count; ++l)
-					arg_used[l] = false;
+					arg_used.write[l] = false;
 				// also there is no guarantee that argument ordering will match, so we
 				// have to check one by one so we make sure we have an exact match
 				for (int k = 0; k < arg_count; ++k) {
 					for (int l = 0; l < arg_count; ++l)
 						if (cf.methods[j].arguments[k].type == m.arguments[l].type && !arg_used[l]) {
-							arg_used[l] = true;
+							arg_used.write[l] = true;
 							break;
 						}
 				}
@@ -98,7 +98,7 @@ void DocData::merge_from(const DocData &p_data) {
 
 		for (int i = 0; i < c.signals.size(); i++) {
 
-			MethodDoc &m = c.signals[i];
+			MethodDoc &m = c.signals.write[i];
 
 			for (int j = 0; j < cf.signals.size(); j++) {
 
@@ -113,7 +113,7 @@ void DocData::merge_from(const DocData &p_data) {
 
 		for (int i = 0; i < c.constants.size(); i++) {
 
-			ConstantDoc &m = c.constants[i];
+			ConstantDoc &m = c.constants.write[i];
 
 			for (int j = 0; j < cf.constants.size(); j++) {
 
@@ -128,7 +128,7 @@ void DocData::merge_from(const DocData &p_data) {
 
 		for (int i = 0; i < c.properties.size(); i++) {
 
-			PropertyDoc &p = c.properties[i];
+			PropertyDoc &p = c.properties.write[i];
 
 			for (int j = 0; j < cf.properties.size(); j++) {
 
@@ -146,7 +146,7 @@ void DocData::merge_from(const DocData &p_data) {
 
 		for (int i = 0; i < c.theme_properties.size(); i++) {
 
-			PropertyDoc &p = c.theme_properties[i];
+			PropertyDoc &p = c.theme_properties.write[i];
 
 			for (int j = 0; j < cf.theme_properties.size(); j++) {
 
@@ -1020,7 +1020,7 @@ Error DocData::save_classes(const String &p_default_path, const Map<String, Stri
 
 		for (int i = 0; i < c.methods.size(); i++) {
 
-			MethodDoc &m = c.methods[i];
+			const MethodDoc &m = c.methods[i];
 
 			String qualifiers;
 			if (m.qualifiers != "")
@@ -1040,7 +1040,7 @@ Error DocData::save_classes(const String &p_default_path, const Map<String, Stri
 
 			for (int j = 0; j < m.arguments.size(); j++) {
 
-				ArgumentDoc &a = m.arguments[j];
+				const ArgumentDoc &a = m.arguments[j];
 
 				String enum_text;
 				if (a.enumeration != String()) {
@@ -1075,7 +1075,7 @@ Error DocData::save_classes(const String &p_default_path, const Map<String, Stri
 				if (c.properties[i].enumeration != String()) {
 					enum_text = " enum=\"" + c.properties[i].enumeration + "\"";
 				}
-				PropertyDoc &p = c.properties[i];
+				const PropertyDoc &p = c.properties[i];
 				_write_string(f, 2, "<member name=\"" + p.name + "\" type=\"" + p.type + "\" setter=\"" + p.setter + "\" getter=\"" + p.getter + "\"" + enum_text + ">");
 				_write_string(f, 3, p.description.strip_edges().xml_escape());
 				_write_string(f, 2, "</member>");
@@ -1090,11 +1090,11 @@ Error DocData::save_classes(const String &p_default_path, const Map<String, Stri
 			_write_string(f, 1, "<signals>");
 			for (int i = 0; i < c.signals.size(); i++) {
 
-				MethodDoc &m = c.signals[i];
+				const MethodDoc &m = c.signals[i];
 				_write_string(f, 2, "<signal name=\"" + m.name + "\">");
 				for (int j = 0; j < m.arguments.size(); j++) {
 
-					ArgumentDoc &a = m.arguments[j];
+					const ArgumentDoc &a = m.arguments[j];
 					_write_string(f, 3, "<argument index=\"" + itos(j) + "\" name=\"" + a.name.xml_escape() + "\" type=\"" + a.type.xml_escape() + "\">");
 					_write_string(f, 3, "</argument>");
 				}
@@ -1113,7 +1113,7 @@ Error DocData::save_classes(const String &p_default_path, const Map<String, Stri
 
 		for (int i = 0; i < c.constants.size(); i++) {
 
-			ConstantDoc &k = c.constants[i];
+			const ConstantDoc &k = c.constants[i];
 			if (k.enumeration != String()) {
 				_write_string(f, 2, "<constant name=\"" + k.name + "\" value=\"" + k.value + "\" enum=\"" + k.enumeration + "\">");
 			} else {
@@ -1132,7 +1132,7 @@ Error DocData::save_classes(const String &p_default_path, const Map<String, Stri
 			_write_string(f, 1, "<theme_items>");
 			for (int i = 0; i < c.theme_properties.size(); i++) {
 
-				PropertyDoc &p = c.theme_properties[i];
+				const PropertyDoc &p = c.theme_properties[i];
 				_write_string(f, 2, "<theme_item name=\"" + p.name + "\" type=\"" + p.type + "\">");
 				_write_string(f, 2, "</theme_item>");
 			}

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -598,7 +598,7 @@ void EditorAutoloadSettings::drop_data_fw(const Point2 &p_point, const Variant &
 	int i = 0;
 
 	for (List<AutoLoadInfo>::Element *E = autoload_cache.front(); E; E = E->next()) {
-		orders[i++] = E->get().order;
+		orders.write[i++] = E->get().order;
 	}
 
 	orders.sort();

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -62,7 +62,7 @@ void EditorHistory::cleanup_history() {
 				fail = true;
 			} else {
 				//after level, clip
-				history[i].path.resize(j);
+				history.write[i].path.resize(j);
 			}
 
 			break;
@@ -100,14 +100,14 @@ void EditorHistory::_add_object(ObjectID p_object, const String &p_property, int
 
 	if (p_property != "" && has_prev) {
 		//add a sub property
-		History &pr = history[current];
+		History &pr = history.write[current];
 		h = pr;
 		h.path.resize(h.level + 1);
 		h.path.push_back(o);
 		h.level++;
 	} else if (p_level_change != -1 && has_prev) {
 		//add a sub property
-		History &pr = history[current];
+		History &pr = history.write[current];
 		h = pr;
 		ERR_FAIL_INDEX(p_level_change, h.path.size());
 		h.level = p_level_change;
@@ -206,7 +206,7 @@ ObjectID EditorHistory::get_current() {
 	if (current < 0 || current >= history.size())
 		return 0;
 
-	History &h = history[current];
+	History &h = history.write[current];
 	Object *obj = ObjectDB::get_instance(h.path[h.level].object);
 	if (!obj)
 		return 0;
@@ -558,7 +558,7 @@ void EditorData::move_edited_scene_index(int p_idx, int p_to_idx) {
 
 	ERR_FAIL_INDEX(p_idx, edited_scene.size());
 	ERR_FAIL_INDEX(p_to_idx, edited_scene.size());
-	SWAP(edited_scene[p_idx], edited_scene[p_to_idx]);
+	SWAP(edited_scene.write[p_idx], edited_scene.write[p_to_idx]);
 }
 void EditorData::remove_scene(int p_idx) {
 	ERR_FAIL_INDEX(p_idx, edited_scene.size());
@@ -644,7 +644,7 @@ bool EditorData::check_and_update_scene(int p_idx) {
 
 		//transfer selection
 		List<Node *> new_selection;
-		for (List<Node *>::Element *E = edited_scene[p_idx].selection.front(); E; E = E->next()) {
+		for (List<Node *>::Element *E = edited_scene.write[p_idx].selection.front(); E; E = E->next()) {
 			NodePath p = edited_scene[p_idx].root->get_path_to(E->get());
 			Node *new_node = new_scene->get_node(p);
 			if (new_node)
@@ -654,8 +654,8 @@ bool EditorData::check_and_update_scene(int p_idx) {
 		new_scene->set_filename(edited_scene[p_idx].root->get_filename());
 
 		memdelete(edited_scene[p_idx].root);
-		edited_scene[p_idx].root = new_scene;
-		edited_scene[p_idx].selection = new_selection;
+		edited_scene.write[p_idx].root = new_scene;
+		edited_scene.write[p_idx].selection = new_selection;
 
 		return true;
 	}
@@ -685,7 +685,7 @@ Node *EditorData::get_edited_scene_root(int p_idx) {
 void EditorData::set_edited_scene_root(Node *p_root) {
 
 	ERR_FAIL_INDEX(current_edited_scene, edited_scene.size());
-	edited_scene[current_edited_scene].root = p_root;
+	edited_scene.write[current_edited_scene].root = p_root;
 }
 
 int EditorData::get_edited_scene_count() const {
@@ -707,10 +707,10 @@ Vector<EditorData::EditedScene> EditorData::get_edited_scenes() const {
 void EditorData::set_edited_scene_version(uint64_t version, int p_scene_idx) {
 	ERR_FAIL_INDEX(current_edited_scene, edited_scene.size());
 	if (p_scene_idx < 0) {
-		edited_scene[current_edited_scene].version = version;
+		edited_scene.write[current_edited_scene].version = version;
 	} else {
 		ERR_FAIL_INDEX(p_scene_idx, edited_scene.size());
-		edited_scene[p_scene_idx].version = version;
+		edited_scene.write[p_scene_idx].version = version;
 	}
 }
 
@@ -793,7 +793,7 @@ String EditorData::get_scene_path(int p_idx) const {
 void EditorData::set_edited_scene_live_edit_root(const NodePath &p_root) {
 	ERR_FAIL_INDEX(current_edited_scene, edited_scene.size());
 
-	edited_scene[current_edited_scene].live_edit_root = p_root;
+	edited_scene.write[current_edited_scene].live_edit_root = p_root;
 }
 NodePath EditorData::get_edited_scene_live_edit_root() {
 
@@ -806,7 +806,7 @@ void EditorData::save_edited_scene_state(EditorSelection *p_selection, EditorHis
 
 	ERR_FAIL_INDEX(current_edited_scene, edited_scene.size());
 
-	EditedScene &es = edited_scene[current_edited_scene];
+	EditedScene &es = edited_scene.write[current_edited_scene];
 	es.selection = p_selection->get_selected_node_list();
 	es.history_current = p_history->current;
 	es.history_stored = p_history->history;
@@ -817,7 +817,7 @@ void EditorData::save_edited_scene_state(EditorSelection *p_selection, EditorHis
 Dictionary EditorData::restore_edited_scene_state(EditorSelection *p_selection, EditorHistory *p_history) {
 	ERR_FAIL_INDEX_V(current_edited_scene, edited_scene.size(), Dictionary());
 
-	EditedScene &es = edited_scene[current_edited_scene];
+	EditedScene &es = edited_scene.write[current_edited_scene];
 
 	p_history->current = es.history_current;
 	p_history->history = es.history_stored;

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -187,7 +187,7 @@ void EditorExportPreset::remove_patch(int p_idx) {
 
 void EditorExportPreset::set_patch(int p_index, const String &p_path) {
 	ERR_FAIL_INDEX(p_index, patches.size());
-	patches[p_index] = p_path;
+	patches.write[p_index] = p_path;
 	EditorExport::singleton->save_presets();
 }
 String EditorExportPreset::get_patch(int p_index) {
@@ -295,7 +295,7 @@ Error EditorExportPlatform::_save_pack_file(void *p_userdata, const String &p_pa
 		MD5Final(&ctx);
 		sd.md5.resize(16);
 		for (int i = 0; i < 16; i++) {
-			sd.md5[i] = ctx.digest[i];
+			sd.md5.write[i] = ctx.digest[i];
 		}
 	}
 
@@ -584,9 +584,9 @@ EditorExportPlatform::ExportNotifier::ExportNotifier(EditorExportPlatform &p_pla
 	//initial export plugin callback
 	for (int i = 0; i < export_plugins.size(); i++) {
 		if (export_plugins[i]->get_script_instance()) { //script based
-			export_plugins[i]->_export_begin_script(features.features_pv, p_debug, p_path, p_flags);
+			export_plugins.write[i]->_export_begin_script(features.features_pv, p_debug, p_path, p_flags);
 		} else {
-			export_plugins[i]->_export_begin(features.features, p_debug, p_path, p_flags);
+			export_plugins.write[i]->_export_begin(features.features, p_debug, p_path, p_flags);
 		}
 	}
 }
@@ -594,7 +594,7 @@ EditorExportPlatform::ExportNotifier::ExportNotifier(EditorExportPlatform &p_pla
 EditorExportPlatform::ExportNotifier::~ExportNotifier() {
 	Vector<Ref<EditorExportPlugin> > export_plugins = EditorExport::get_singleton()->get_export_plugins();
 	for (int i = 0; i < export_plugins.size(); i++) {
-		export_plugins[i]->_export_end();
+		export_plugins.write[i]->_export_end();
 	}
 }
 
@@ -632,7 +632,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 			p_func(p_udata, export_plugins[i]->extra_files[j].path, export_plugins[i]->extra_files[j].data, 0, paths.size());
 		}
 
-		export_plugins[i]->_clear();
+		export_plugins.write[i]->_clear();
 	}
 
 	FeatureContainers feature_containers = get_feature_containers(p_preset);
@@ -687,9 +687,9 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 			bool do_export = true;
 			for (int i = 0; i < export_plugins.size(); i++) {
 				if (export_plugins[i]->get_script_instance()) { //script based
-					export_plugins[i]->_export_file_script(path, type, features_pv);
+					export_plugins.write[i]->_export_file_script(path, type, features_pv);
 				} else {
-					export_plugins[i]->_export_file(path, type, features);
+					export_plugins.write[i]->_export_file(path, type, features);
 				}
 				if (p_so_func) {
 					for (int j = 0; j < export_plugins[i]->shared_objects.size(); j++) {
@@ -709,7 +709,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				if (export_plugins[i]->skipped) {
 					do_export = false;
 				}
-				export_plugins[i]->_clear();
+				export_plugins.write[i]->_clear();
 
 				if (!do_export)
 					break; //apologies, not exporting
@@ -751,7 +751,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				Vector<uint8_t> new_file;
 				new_file.resize(utf8.length());
 				for (int j = 0; j < utf8.length(); j++) {
-					new_file[j] = utf8[j];
+					new_file.write[j] = utf8[j];
 				}
 
 				p_func(p_udata, from + ".remap", new_file, idx, total);
@@ -1130,7 +1130,7 @@ void EditorExport::load_config() {
 
 		for (int i = 0; i < export_platforms.size(); i++) {
 			if (export_platforms[i]->get_name() == platform) {
-				preset = export_platforms[i]->create_preset();
+				preset = export_platforms.write[i]->create_preset();
 				break;
 			}
 		}
@@ -1203,7 +1203,7 @@ bool EditorExport::poll_export_platforms() {
 
 	bool changed = false;
 	for (int i = 0; i < export_platforms.size(); i++) {
-		if (export_platforms[i]->poll_devices()) {
+		if (export_platforms.write[i]->poll_devices()) {
 			changed = true;
 		}
 	}

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -1135,7 +1135,7 @@ void EditorFileDialog::_favorite_move_up() {
 
 		if (a_idx == -1 || b_idx == -1)
 			return;
-		SWAP(favorited[a_idx], favorited[b_idx]);
+		SWAP(favorited.write[a_idx], favorited.write[b_idx]);
 
 		EditorSettings::get_singleton()->set_favorite_dirs(favorited);
 
@@ -1155,7 +1155,7 @@ void EditorFileDialog::_favorite_move_down() {
 
 		if (a_idx == -1 || b_idx == -1)
 			return;
-		SWAP(favorited[a_idx], favorited[b_idx]);
+		SWAP(favorited.write[a_idx], favorited.write[b_idx]);
 
 		EditorSettings::get_singleton()->set_favorite_dirs(favorited);
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3947,7 +3947,7 @@ void EditorNode::raise_bottom_panel_item(Control *p_item) {
 
 		if (bottom_panel_items[i].control == p_item) {
 			bottom_panel_items[i].button->raise();
-			SWAP(bottom_panel_items[i], bottom_panel_items[bottom_panel_items.size() - 1]);
+			SWAP(bottom_panel_items.write[i], bottom_panel_items.write[bottom_panel_items.size() - 1]);
 			break;
 		}
 	}

--- a/editor/editor_profiler.cpp
+++ b/editor/editor_profiler.cpp
@@ -37,9 +37,9 @@
 void EditorProfiler::_make_metric_ptrs(Metric &m) {
 
 	for (int i = 0; i < m.categories.size(); i++) {
-		m.category_ptrs[m.categories[i].signature] = &m.categories[i];
+		m.category_ptrs[m.categories[i].signature] = &m.categories.write[i];
 		for (int j = 0; j < m.categories[i].items.size(); j++) {
-			m.item_ptrs[m.categories[i].items[j].signature] = &m.categories[i].items[j];
+			m.item_ptrs[m.categories[i].items[j].signature] = &m.categories.write[i].items.write[j];
 		}
 	}
 }
@@ -50,8 +50,8 @@ void EditorProfiler::add_frame_metric(const Metric &p_metric, bool p_final) {
 	if (last_metric >= frame_metrics.size())
 		last_metric = 0;
 
-	frame_metrics[last_metric] = p_metric;
-	_make_metric_ptrs(frame_metrics[last_metric]);
+	frame_metrics.write[last_metric] = p_metric;
+	_make_metric_ptrs(frame_metrics.write[last_metric]);
 
 	updating_frame = true;
 	cursor_metric_edit->set_max(frame_metrics[last_metric].frame_number);
@@ -108,7 +108,7 @@ static String _get_percent_txt(float p_value, float p_total) {
 	return String::num((p_value / p_total) * 100, 1) + "%";
 }
 
-String EditorProfiler::_get_time_as_text(Metric &m, float p_time, int p_calls) {
+String EditorProfiler::_get_time_as_text(const Metric &m, float p_time, int p_calls) {
 
 	int dmode = display_mode->get_selected();
 
@@ -192,18 +192,18 @@ void EditorProfiler::_update_plot() {
 	float highest = 0;
 
 	for (int i = 0; i < frame_metrics.size(); i++) {
-		Metric &m = frame_metrics[i];
+		const Metric &m = frame_metrics[i];
 		if (!m.valid)
 			continue;
 
 		for (Set<StringName>::Element *E = plot_sigs.front(); E; E = E->next()) {
 
-			Map<StringName, Metric::Category *>::Element *F = m.category_ptrs.find(E->get());
+			const Map<StringName, Metric::Category *>::Element *F = m.category_ptrs.find(E->get());
 			if (F) {
 				highest = MAX(F->get()->total_time, highest);
 			}
 
-			Map<StringName, Metric::Category::Item *>::Element *G = m.item_ptrs.find(E->get());
+			const Map<StringName, Metric::Category::Item *>::Element *G = m.item_ptrs.find(E->get());
 			if (G) {
 				if (use_self) {
 					highest = MAX(G->get()->self, highest);
@@ -256,18 +256,18 @@ void EditorProfiler::_update_plot() {
 					}
 
 					//get
-					Metric &m = frame_metrics[idx];
+					const Metric &m = frame_metrics[idx];
 					if (m.valid == false)
 						continue; //skip because invalid
 
 					float value = 0;
 
-					Map<StringName, Metric::Category *>::Element *F = m.category_ptrs.find(E->get());
+					const Map<StringName, Metric::Category *>::Element *F = m.category_ptrs.find(E->get());
 					if (F) {
 						value = F->get()->total_time;
 					}
 
-					Map<StringName, Metric::Category::Item *>::Element *G = m.item_ptrs.find(E->get());
+					const Map<StringName, Metric::Category::Item *>::Element *G = m.item_ptrs.find(E->get());
 					if (G) {
 						if (use_self) {
 							value = G->get()->self;
@@ -375,7 +375,7 @@ void EditorProfiler::_update_frame() {
 	variables->clear();
 
 	TreeItem *root = variables->create_item();
-	Metric &m = frame_metrics[cursor_metric];
+	const Metric &m = frame_metrics[cursor_metric];
 
 	int dtime = display_time->get_selected();
 
@@ -394,7 +394,7 @@ void EditorProfiler::_update_frame() {
 		}
 
 		for (int j = 0; j < m.categories[i].items.size(); j++) {
-			Metric::Category::Item &it = m.categories[i].items[j];
+			const Metric::Category::Item &it = m.categories[i].items[j];
 
 			TreeItem *item = variables->create_item(category);
 			item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);

--- a/editor/editor_profiler.h
+++ b/editor/editor_profiler.h
@@ -136,7 +136,7 @@ private:
 	void _activate_pressed();
 	void _clear_pressed();
 
-	String _get_time_as_text(Metric &m, float p_time, int p_calls);
+	String _get_time_as_text(const Metric &m, float p_time, int p_calls);
 
 	void _make_metric_ptrs(Metric &m);
 	void _item_edited();

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -46,7 +46,7 @@ bool EditorResourcePreviewGenerator::handles(const String &p_type) const {
 	ERR_EXPLAIN("EditorResourcePreviewGenerator::handles needs to be overridden");
 	ERR_FAIL_V(false);
 }
-Ref<Texture> EditorResourcePreviewGenerator::generate(const RES &p_from) {
+Ref<Texture> EditorResourcePreviewGenerator::generate(const RES &p_from) const {
 
 	if (get_script_instance() && get_script_instance()->has_method("generate")) {
 		return get_script_instance()->call("generate", p_from);
@@ -55,7 +55,7 @@ Ref<Texture> EditorResourcePreviewGenerator::generate(const RES &p_from) {
 	ERR_FAIL_V(Ref<Texture>());
 }
 
-Ref<Texture> EditorResourcePreviewGenerator::generate_from_path(const String &p_path) {
+Ref<Texture> EditorResourcePreviewGenerator::generate_from_path(const String &p_path) const {
 
 	if (get_script_instance() && get_script_instance()->has_method("generate_from_path")) {
 		return get_script_instance()->call("generate_from_path", p_path);

--- a/editor/editor_resource_preview.h
+++ b/editor/editor_resource_preview.h
@@ -63,8 +63,8 @@ protected:
 
 public:
 	virtual bool handles(const String &p_type) const;
-	virtual Ref<Texture> generate(const RES &p_from);
-	virtual Ref<Texture> generate_from_path(const String &p_path);
+	virtual Ref<Texture> generate(const RES &p_from) const;
+	virtual Ref<Texture> generate_from_path(const String &p_path) const;
 
 	EditorResourcePreviewGenerator();
 };

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -881,7 +881,7 @@ fail:
 		Vector<String> list = extra_config->get_value("init_projects", "list");
 		for (int i = 0; i < list.size(); i++) {
 
-			list[i] = exe_path + "/" + list[i];
+			list.write[i] = exe_path + "/" + list[i];
 		};
 		extra_config->set_value("init_projects", "list", list);
 	};

--- a/editor/fileserver/editor_file_server.cpp
+++ b/editor/fileserver/editor_file_server.cpp
@@ -78,7 +78,7 @@ void EditorFileServer::_subthread_start(void *s) {
 			_close_client(cd);
 			ERR_FAIL_COND(err != OK);
 		}
-		passutf8[passlen] = 0;
+		passutf8.write[passlen] = 0;
 		String s;
 		s.parse_utf8(passutf8.ptr());
 		if (s != cd->efs->password) {
@@ -145,7 +145,7 @@ void EditorFileServer::_subthread_start(void *s) {
 					_close_client(cd);
 					ERR_FAIL_COND(err != OK);
 				}
-				fileutf8[namelen] = 0;
+				fileutf8.write[namelen] = 0;
 				String s;
 				s.parse_utf8(fileutf8.ptr());
 

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -143,7 +143,7 @@ void FindInFiles::_iterate() {
 
 		// Scan folders first so we can build a list of files and have progress info later
 
-		PoolStringArray &folders_to_scan = _folders_stack[_folders_stack.size() - 1];
+		PoolStringArray &folders_to_scan = _folders_stack.write[_folders_stack.size() - 1];
 
 		if (folders_to_scan.size() != 0) {
 			// Scan one folder below

--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -651,7 +651,7 @@ Vector<double> EditorSceneImporterGLTF::_decode_accessor(GLTFState &state, int p
 	} else {
 		//fill with zeros, as bufferview is not defined.
 		for (int i = 0; i < (a.count * component_count); i++) {
-			dst_buffer[i] = 0;
+			dst_buffer.write[i] = 0;
 		}
 	}
 
@@ -794,7 +794,7 @@ Vector<Quat> EditorSceneImporterGLTF::_decode_accessor_as_quat(GLTFState &state,
 	ret.resize(ret_size);
 	{
 		for (int i = 0; i < ret_size; i++) {
-			ret[i] = Quat(attribs_ptr[i * 4 + 0], attribs_ptr[i * 4 + 1], attribs_ptr[i * 4 + 2], attribs_ptr[i * 4 + 3]);
+			ret.write[i] = Quat(attribs_ptr[i * 4 + 0], attribs_ptr[i * 4 + 1], attribs_ptr[i * 4 + 2], attribs_ptr[i * 4 + 3]);
 		}
 	}
 	return ret;
@@ -808,8 +808,8 @@ Vector<Transform2D> EditorSceneImporterGLTF::_decode_accessor_as_xform2d(GLTFSta
 	ERR_FAIL_COND_V(attribs.size() % 4 != 0, ret);
 	ret.resize(attribs.size() / 4);
 	for (int i = 0; i < ret.size(); i++) {
-		ret[i][0] = Vector2(attribs[i * 4 + 0], attribs[i * 4 + 1]);
-		ret[i][1] = Vector2(attribs[i * 4 + 2], attribs[i * 4 + 3]);
+		ret.write[i][0] = Vector2(attribs[i * 4 + 0], attribs[i * 4 + 1]);
+		ret.write[i][1] = Vector2(attribs[i * 4 + 2], attribs[i * 4 + 3]);
 	}
 	return ret;
 }
@@ -823,9 +823,9 @@ Vector<Basis> EditorSceneImporterGLTF::_decode_accessor_as_basis(GLTFState &stat
 	ERR_FAIL_COND_V(attribs.size() % 9 != 0, ret);
 	ret.resize(attribs.size() / 9);
 	for (int i = 0; i < ret.size(); i++) {
-		ret[i].set_axis(0, Vector3(attribs[i * 9 + 0], attribs[i * 9 + 1], attribs[i * 9 + 2]));
-		ret[i].set_axis(1, Vector3(attribs[i * 9 + 3], attribs[i * 9 + 4], attribs[i * 9 + 5]));
-		ret[i].set_axis(2, Vector3(attribs[i * 9 + 6], attribs[i * 9 + 7], attribs[i * 9 + 8]));
+		ret.write[i].set_axis(0, Vector3(attribs[i * 9 + 0], attribs[i * 9 + 1], attribs[i * 9 + 2]));
+		ret.write[i].set_axis(1, Vector3(attribs[i * 9 + 3], attribs[i * 9 + 4], attribs[i * 9 + 5]));
+		ret.write[i].set_axis(2, Vector3(attribs[i * 9 + 6], attribs[i * 9 + 7], attribs[i * 9 + 8]));
 	}
 	return ret;
 }
@@ -838,10 +838,10 @@ Vector<Transform> EditorSceneImporterGLTF::_decode_accessor_as_xform(GLTFState &
 	ERR_FAIL_COND_V(attribs.size() % 16 != 0, ret);
 	ret.resize(attribs.size() / 16);
 	for (int i = 0; i < ret.size(); i++) {
-		ret[i].basis.set_axis(0, Vector3(attribs[i * 16 + 0], attribs[i * 16 + 1], attribs[i * 16 + 2]));
-		ret[i].basis.set_axis(1, Vector3(attribs[i * 16 + 4], attribs[i * 16 + 5], attribs[i * 16 + 6]));
-		ret[i].basis.set_axis(2, Vector3(attribs[i * 16 + 8], attribs[i * 16 + 9], attribs[i * 16 + 10]));
-		ret[i].set_origin(Vector3(attribs[i * 16 + 12], attribs[i * 16 + 13], attribs[i * 16 + 14]));
+		ret.write[i].basis.set_axis(0, Vector3(attribs[i * 16 + 0], attribs[i * 16 + 1], attribs[i * 16 + 2]));
+		ret.write[i].basis.set_axis(1, Vector3(attribs[i * 16 + 4], attribs[i * 16 + 5], attribs[i * 16 + 6]));
+		ret.write[i].basis.set_axis(2, Vector3(attribs[i * 16 + 8], attribs[i * 16 + 9], attribs[i * 16 + 10]));
+		ret.write[i].set_origin(Vector3(attribs[i * 16 + 12], attribs[i * 16 + 13], attribs[i * 16 + 14]));
 	}
 	return ret;
 }
@@ -1085,7 +1085,7 @@ Error EditorSceneImporterGLTF::_parse_meshes(GLTFState &state) {
 			ERR_FAIL_COND_V(mesh.mesh->get_blend_shape_count() != weights.size(), ERR_PARSE_ERROR);
 			mesh.blend_weights.resize(weights.size());
 			for (int j = 0; j < weights.size(); j++) {
-				mesh.blend_weights[j] = weights[j];
+				mesh.blend_weights.write[j] = weights[j];
 			}
 		}
 
@@ -1139,7 +1139,7 @@ Error EditorSceneImporterGLTF::_parse_images(GLTFState &state, const String &p_b
 
 			ERR_FAIL_INDEX_V(bvi, state.buffer_views.size(), ERR_PARAMETER_RANGE_ERROR);
 
-			GLTFBufferView &bv = state.buffer_views[bvi];
+			const GLTFBufferView &bv = state.buffer_views[bvi];
 
 			int bi = bv.buffer;
 			ERR_FAIL_INDEX_V(bi, state.buffers.size(), ERR_PARAMETER_RANGE_ERROR);
@@ -1596,7 +1596,7 @@ Error EditorSceneImporterGLTF::_parse_animations(GLTFState &state) {
 				PoolVector<float> weights = _decode_accessor_as_floats(state, output, false);
 
 				ERR_FAIL_INDEX_V(state.nodes[node]->mesh, state.meshes.size(), ERR_PARSE_ERROR);
-				GLTFMesh *mesh = &state.meshes[state.nodes[node]->mesh];
+				const GLTFMesh *mesh = &state.meshes[state.nodes[node]->mesh];
 				ERR_FAIL_COND_V(mesh->blend_weights.size() == 0, ERR_PARSE_ERROR);
 				int wc = mesh->blend_weights.size();
 
@@ -1611,11 +1611,11 @@ Error EditorSceneImporterGLTF::_parse_animations(GLTFState &state) {
 					Vector<float> wdata;
 					wdata.resize(wlen);
 					for (int l = 0; l < wlen; l++) {
-						wdata[l] = r[l * wc + k];
+						wdata.write[l] = r[l * wc + k];
 					}
 
 					cf.values = wdata;
-					track->weight_tracks[k] = cf;
+					track->weight_tracks.write[k] = cf;
 				}
 			} else {
 				WARN_PRINTS("Invalid path: " + path);
@@ -1657,7 +1657,7 @@ void EditorSceneImporterGLTF::_generate_node(GLTFState &state, int p_node, Node 
 	if (n->mesh >= 0) {
 		ERR_FAIL_INDEX(n->mesh, state.meshes.size());
 		MeshInstance *mi = memnew(MeshInstance);
-		GLTFMesh &mesh = state.meshes[n->mesh];
+		GLTFMesh &mesh = state.meshes.write[n->mesh];
 		mi->set_mesh(mesh.mesh);
 		if (mesh.mesh->get_name() == "") {
 			mesh.mesh->set_name(n->name);
@@ -1750,7 +1750,7 @@ void EditorSceneImporterGLTF::_generate_bone(GLTFState &state, int p_node, Vecto
 		s->set_bone_rest(bone_index, state.skins[skin].bones[n->joints[i].bone].inverse_bind.affine_inverse());
 
 		n->godot_nodes.push_back(s);
-		n->joints[i].godot_bone_index = bone_index;
+		n->joints.write[i].godot_bone_index = bone_index;
 	}
 
 	for (int i = 0; i < n->children.size(); i++) {

--- a/editor/import/resource_importer_csv_translation.cpp
+++ b/editor/import/resource_importer_csv_translation.cpp
@@ -119,7 +119,7 @@ Error ResourceImporterCSVTranslation::import(const String &p_source_file, const 
 		if (key != "") {
 
 			for (int i = 1; i < line.size(); i++) {
-				translations[i - 1]->add_message(key, line[i]);
+				translations.write[i - 1]->add_message(key, line[i]);
 			}
 		}
 

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -750,7 +750,7 @@ void ResourceImporterScene::_filter_tracks(Node *scene, const String &p_text) {
 	Vector<String> strings = p_text.split("\n");
 	for (int i = 0; i < strings.size(); i++) {
 
-		strings[i] = strings[i].strip_edges();
+		strings.write[i] = strings[i].strip_edges();
 	}
 
 	List<StringName> anim_names;

--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -215,19 +215,19 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 				for (int i = 0; i < frames * format_channels; i++) {
 					// 8 bit samples are UNSIGNED
 
-					data[i] = int8_t(file->get_8() - 128) / 128.f;
+					data.write[i] = int8_t(file->get_8() - 128) / 128.f;
 				}
 			} else if (format_bits == 32 && compression_code == 3) {
 				for (int i = 0; i < frames * format_channels; i++) {
 					//32 bit IEEE Float
 
-					data[i] = file->get_float();
+					data.write[i] = file->get_float();
 				}
 			} else if (format_bits == 16) {
 				for (int i = 0; i < frames * format_channels; i++) {
 					//16 bit SIGNED
 
-					data[i] = int16_t(file->get_16()) / 32768.f;
+					data.write[i] = int16_t(file->get_16()) / 32768.f;
 				}
 			} else {
 				for (int i = 0; i < frames * format_channels; i++) {
@@ -241,7 +241,7 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 					}
 					s <<= (32 - format_bits);
 
-					data[i] = (int32_t(s) >> 16) / 32768.f;
+					data.write[i] = (int32_t(s) >> 16) / 32768.f;
 				}
 			}
 
@@ -335,7 +335,7 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 
 				float res = (a0 * mu * mu2 + a1 * mu2 + a2 * mu + a3);
 
-				new_data[i * format_channels + c] = res;
+				new_data.write[i * format_channels + c] = res;
 
 				// update position and always keep fractional part within ]0...1]
 				// in order to avoid 32bit floating point precision errors
@@ -374,7 +374,7 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 			float mult = 1.0 / max;
 			for (int i = 0; i < data.size(); i++) {
 
-				data[i] *= mult;
+				data.write[i] *= mult;
 			}
 		}
 	}
@@ -408,7 +408,7 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 			Vector<float> new_data;
 			new_data.resize((last - first + 1) * format_channels);
 			for (int i = first * format_channels; i < (last + 1) * format_channels; i++) {
-				new_data[i - first * format_channels] = data[i];
+				new_data.write[i - first * format_channels] = data[i];
 			}
 
 			data = new_data;
@@ -433,7 +433,7 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 		Vector<float> new_data;
 		new_data.resize(data.size() / 2);
 		for (int i = 0; i < frames; i++) {
-			new_data[i] = (data[i * 2 + 0] + data[i * 2 + 1]) / 2.0;
+			new_data.write[i] = (data[i * 2 + 0] + data[i * 2 + 1]) / 2.0;
 		}
 
 		data = new_data;
@@ -465,8 +465,8 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 			right.resize(tframes);
 
 			for (int i = 0; i < tframes; i++) {
-				left[i] = data[i * 2 + 0];
-				right[i] = data[i * 2 + 1];
+				left.write[i] = data[i * 2 + 0];
+				right.write[i] = data[i * 2 + 1];
 			}
 
 			PoolVector<uint8_t> bleft;

--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -345,7 +345,7 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 
 						Vector<Vector2> vertices = _get_polygon(edited_point.polygon);
 						ERR_FAIL_INDEX_V(edited_point.vertex, vertices.size(), false);
-						vertices[edited_point.vertex] = edited_point.pos - _get_offset(edited_point.polygon);
+						vertices.write[edited_point.vertex] = edited_point.pos - _get_offset(edited_point.polygon);
 
 						undo_redo->create_action(TTR("Edit Poly"));
 						_action_set_polygon(edited_point.polygon, pre_move_edit, vertices);
@@ -445,7 +445,7 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 
 				Vector<Vector2> vertices = _get_polygon(edited_point.polygon);
 				ERR_FAIL_INDEX_V(edited_point.vertex, vertices.size(), false);
-				vertices[edited_point.vertex] = cpoint - _get_offset(edited_point.polygon);
+				vertices.write[edited_point.vertex] = cpoint - _get_offset(edited_point.polygon);
 				_set_polygon(edited_point.polygon, vertices);
 			}
 

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -414,7 +414,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 			point = (point - blend_space->get_min_space()) / (blend_space->get_max_space() - blend_space->get_min_space());
 			point *= s;
 			point.y = s.height - point.y;
-			points[j] = point;
+			points.write[j] = point;
 		}
 
 		for (int j = 0; j < 3; j++) {

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1333,7 +1333,7 @@ void AnimationPlayerEditor::_allocate_onion_layers() {
 		bool is_present = onion.differences_only && i == captures - 1;
 
 		// Each capture is a viewport with a canvas item attached that renders a full-size rect with the contents of the main viewport
-		onion.captures[i] = VS::get_singleton()->viewport_create();
+		onion.captures.write[i] = VS::get_singleton()->viewport_create();
 		VS::get_singleton()->viewport_set_usage(onion.captures[i], VS::VIEWPORT_USAGE_2D);
 		VS::get_singleton()->viewport_set_size(onion.captures[i], capture_size.width, capture_size.height);
 		VS::get_singleton()->viewport_set_update_mode(onion.captures[i], VS::VIEWPORT_UPDATE_ALWAYS);
@@ -1473,7 +1473,7 @@ void AnimationPlayerEditor::_prepare_onion_layers_2() {
 		float pos = cpos + step_off * anim->get_step();
 
 		bool valid = anim->has_loop() || (pos >= 0 && pos <= anim->get_length());
-		onion.captures_valid[cidx] = valid;
+		onion.captures_valid.write[cidx] = valid;
 		if (valid) {
 			player->seek(pos, true);
 			get_tree()->flush_transform_notifications(); // Needed for transforms of Spatials

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -679,7 +679,7 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 		Ref<StyleBox> sb = name == selected_node ? style_selected : style;
 		int strsize = font->get_string_size(name).width;
 
-		NodeRect &nr = node_rects[i];
+		NodeRect &nr = node_rects.write[i];
 
 		Vector2 offset = nr.node.position;
 		int h = nr.node.size.height;
@@ -771,7 +771,7 @@ void AnimationNodeStateMachineEditor::_state_machine_pos_draw() {
 	if (idx == -1)
 		return;
 
-	NodeRect &nr = node_rects[idx];
+	const NodeRect &nr = node_rects[idx];
 
 	Vector2 from;
 	from.x = nr.play.position.x;

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -197,7 +197,7 @@ void EditorAssetLibraryItemDescription::set_image(int p_type, int p_index, const
 
 			for (int i = 0; i < preview_images.size(); i++) {
 				if (preview_images[i].id == p_index) {
-					preview_images[i].image = p_image;
+					preview_images.write[i].image = p_image;
 					if (preview_images[i].button->is_pressed()) {
 						_preview_click(p_index);
 					}

--- a/editor/plugins/audio_stream_editor_plugin.cpp
+++ b/editor/plugins/audio_stream_editor_plugin.cpp
@@ -81,8 +81,8 @@ void AudioStreamEditor::_draw_preview() {
 		float min = preview->get_min(ofs, ofs_n) * 0.5 + 0.5;
 
 		int idx = i;
-		lines[idx * 2 + 0] = Vector2(i + 1, rect.position.y + min * rect.size.y);
-		lines[idx * 2 + 1] = Vector2(i + 1, rect.position.y + max * rect.size.y);
+		lines.write[idx * 2 + 0] = Vector2(i + 1, rect.position.y + min * rect.size.y);
+		lines.write[idx * 2 + 1] = Vector2(i + 1, rect.position.y + max * rect.size.y);
 	}
 
 	Vector<Color> color;

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -533,7 +533,7 @@ void CanvasItemEditor::_get_canvas_items_at_pos(const Point2 &p_pos, Vector<_Sel
 			r_items.remove(i);
 			i--;
 		} else {
-			r_items[i].item = canvas_item;
+			r_items.write[i].item = canvas_item;
 		}
 	}
 }

--- a/editor/plugins/collision_polygon_editor_plugin.cpp
+++ b/editor/plugins/collision_polygon_editor_plugin.cpp
@@ -276,7 +276,7 @@ bool Polygon3DEditor::forward_spatial_gui_input(Camera *p_camera, const Ref<Inpu
 							//apply
 
 							ERR_FAIL_INDEX_V(edited_point, poly.size(), false);
-							poly[edited_point] = edited_point_pos;
+							poly.write[edited_point] = edited_point_pos;
 							undo_redo->create_action(TTR("Edit Poly"));
 							undo_redo->add_do_method(node, "set_polygon", poly);
 							undo_redo->add_undo_method(node, "set_polygon", pre_move_edit);

--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -446,8 +446,8 @@ void CollisionShape2DEditor::forward_draw_over_viewport(Control *p_overlay) {
 			float radius = shape->get_radius();
 			float height = shape->get_height() / 2;
 
-			handles[0] = Point2(radius, -height);
-			handles[1] = Point2(0, -(height + radius));
+			handles.write[0] = Point2(radius, -height);
+			handles.write[1] = Point2(0, -(height + radius));
 
 			p_overlay->draw_texture(h, gt.xform(handles[0]) - size);
 			p_overlay->draw_texture(h, gt.xform(handles[1]) - size);
@@ -458,7 +458,7 @@ void CollisionShape2DEditor::forward_draw_over_viewport(Control *p_overlay) {
 			Ref<CircleShape2D> shape = node->get_shape();
 
 			handles.resize(1);
-			handles[0] = Point2(shape->get_radius(), 0);
+			handles.write[0] = Point2(shape->get_radius(), 0);
 
 			p_overlay->draw_texture(h, gt.xform(handles[0]) - size);
 
@@ -476,8 +476,8 @@ void CollisionShape2DEditor::forward_draw_over_viewport(Control *p_overlay) {
 			Ref<LineShape2D> shape = node->get_shape();
 
 			handles.resize(2);
-			handles[0] = shape->get_normal() * shape->get_d();
-			handles[1] = shape->get_normal() * (shape->get_d() + 30.0);
+			handles.write[0] = shape->get_normal() * shape->get_d();
+			handles.write[1] = shape->get_normal() * (shape->get_d() + 30.0);
 
 			p_overlay->draw_texture(h, gt.xform(handles[0]) - size);
 			p_overlay->draw_texture(h, gt.xform(handles[1]) - size);
@@ -488,7 +488,7 @@ void CollisionShape2DEditor::forward_draw_over_viewport(Control *p_overlay) {
 			Ref<RayShape2D> shape = node->get_shape();
 
 			handles.resize(1);
-			handles[0] = Point2(0, shape->get_length());
+			handles.write[0] = Point2(0, shape->get_length());
 
 			p_overlay->draw_texture(h, gt.xform(handles[0]) - size);
 
@@ -499,8 +499,8 @@ void CollisionShape2DEditor::forward_draw_over_viewport(Control *p_overlay) {
 
 			handles.resize(2);
 			Vector2 ext = shape->get_extents();
-			handles[0] = Point2(ext.x, 0);
-			handles[1] = Point2(0, -ext.y);
+			handles.write[0] = Point2(ext.x, 0);
+			handles.write[1] = Point2(0, -ext.y);
 
 			p_overlay->draw_texture(h, gt.xform(handles[0]) - size);
 			p_overlay->draw_texture(h, gt.xform(handles[1]) - size);
@@ -511,8 +511,8 @@ void CollisionShape2DEditor::forward_draw_over_viewport(Control *p_overlay) {
 			Ref<SegmentShape2D> shape = node->get_shape();
 
 			handles.resize(2);
-			handles[0] = shape->get_a();
-			handles[1] = shape->get_b();
+			handles.write[0] = shape->get_a();
+			handles.write[1] = shape->get_b();
 
 			p_overlay->draw_texture(h, gt.xform(handles[0]) - size);
 			p_overlay->draw_texture(h, gt.xform(handles[1]) - size);

--- a/editor/plugins/light_occluder_2d_editor_plugin.cpp
+++ b/editor/plugins/light_occluder_2d_editor_plugin.cpp
@@ -255,7 +255,7 @@ bool LightOccluder2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 							//apply
 
 							ERR_FAIL_INDEX_V(edited_point, poly.size(), false);
-							poly[edited_point] = edited_point_pos;
+							poly.write[edited_point] = edited_point_pos;
 							undo_redo->create_action(TTR("Edit Poly"));
 							undo_redo->add_do_method(node->get_occluder_polygon().ptr(), "set_polygon", poly);
 							undo_redo->add_undo_method(node->get_occluder_polygon().ptr(), "set_polygon", pre_move_edit);

--- a/editor/plugins/particles_2d_editor_plugin.cpp
+++ b/editor/plugins/particles_2d_editor_plugin.cpp
@@ -165,12 +165,12 @@ void Particles2DEditorPlugin::_generate_emission_mask() {
 					if (emode == EMISSION_MODE_SOLID) {
 
 						if (capture_colors) {
-							valid_colors[vpc * 4 + 0] = r[(j * s.width + i) * 4 + 0];
-							valid_colors[vpc * 4 + 1] = r[(j * s.width + i) * 4 + 1];
-							valid_colors[vpc * 4 + 2] = r[(j * s.width + i) * 4 + 2];
-							valid_colors[vpc * 4 + 3] = r[(j * s.width + i) * 4 + 3];
+							valid_colors.write[vpc * 4 + 0] = r[(j * s.width + i) * 4 + 0];
+							valid_colors.write[vpc * 4 + 1] = r[(j * s.width + i) * 4 + 1];
+							valid_colors.write[vpc * 4 + 2] = r[(j * s.width + i) * 4 + 2];
+							valid_colors.write[vpc * 4 + 3] = r[(j * s.width + i) * 4 + 3];
 						}
-						valid_positions[vpc++] = Point2(i, j);
+						valid_positions.write[vpc++] = Point2(i, j);
 
 					} else {
 
@@ -189,7 +189,7 @@ void Particles2DEditorPlugin::_generate_emission_mask() {
 						}
 
 						if (on_border) {
-							valid_positions[vpc] = Point2(i, j);
+							valid_positions.write[vpc] = Point2(i, j);
 
 							if (emode == EMISSION_MODE_BORDER_DIRECTED) {
 								Vector2 normal;
@@ -206,14 +206,14 @@ void Particles2DEditorPlugin::_generate_emission_mask() {
 								}
 
 								normal.normalize();
-								valid_normals[vpc] = normal;
+								valid_normals.write[vpc] = normal;
 							}
 
 							if (capture_colors) {
-								valid_colors[vpc * 4 + 0] = r[(j * s.width + i) * 4 + 0];
-								valid_colors[vpc * 4 + 1] = r[(j * s.width + i) * 4 + 1];
-								valid_colors[vpc * 4 + 2] = r[(j * s.width + i) * 4 + 2];
-								valid_colors[vpc * 4 + 3] = r[(j * s.width + i) * 4 + 3];
+								valid_colors.write[vpc * 4 + 0] = r[(j * s.width + i) * 4 + 0];
+								valid_colors.write[vpc * 4 + 1] = r[(j * s.width + i) * 4 + 1];
+								valid_colors.write[vpc * 4 + 2] = r[(j * s.width + i) * 4 + 2];
+								valid_colors.write[vpc * 4 + 3] = r[(j * s.width + i) * 4 + 3];
 							}
 
 							vpc++;

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -342,11 +342,11 @@ void ScriptEditor::_save_history() {
 
 		if (Object::cast_to<ScriptEditorBase>(n)) {
 
-			history[history_pos].state = Object::cast_to<ScriptEditorBase>(n)->get_edit_state();
+			history.write[history_pos].state = Object::cast_to<ScriptEditorBase>(n)->get_edit_state();
 		}
 		if (Object::cast_to<EditorHelp>(n)) {
 
-			history[history_pos].state = Object::cast_to<EditorHelp>(n)->get_scroll();
+			history.write[history_pos].state = Object::cast_to<EditorHelp>(n)->get_scroll();
 		}
 	}
 
@@ -373,11 +373,11 @@ void ScriptEditor::_go_to_tab(int p_idx) {
 
 		if (Object::cast_to<ScriptEditorBase>(n)) {
 
-			history[history_pos].state = Object::cast_to<ScriptEditorBase>(n)->get_edit_state();
+			history.write[history_pos].state = Object::cast_to<ScriptEditorBase>(n)->get_edit_state();
 		}
 		if (Object::cast_to<EditorHelp>(n)) {
 
-			history[history_pos].state = Object::cast_to<EditorHelp>(n)->get_scroll();
+			history.write[history_pos].state = Object::cast_to<EditorHelp>(n)->get_scroll();
 		}
 	}
 
@@ -2612,11 +2612,11 @@ void ScriptEditor::_update_history_pos(int p_new_pos) {
 
 	if (Object::cast_to<ScriptEditorBase>(n)) {
 
-		history[history_pos].state = Object::cast_to<ScriptEditorBase>(n)->get_edit_state();
+		history.write[history_pos].state = Object::cast_to<ScriptEditorBase>(n)->get_edit_state();
 	}
 	if (Object::cast_to<EditorHelp>(n)) {
 
-		history[history_pos].state = Object::cast_to<EditorHelp>(n)->get_scroll();
+		history.write[history_pos].state = Object::cast_to<EditorHelp>(n)->get_scroll();
 	}
 
 	history_pos = p_new_pos;

--- a/editor/plugins/skeleton_editor_plugin.cpp
+++ b/editor/plugins/skeleton_editor_plugin.cpp
@@ -68,16 +68,16 @@ void SkeletonEditor::create_physical_skeleton() {
 
 		if (parent < 0) {
 
-			bones_infos[bone_id].relative_rest = skeleton->get_bone_rest(bone_id);
+			bones_infos.write[bone_id].relative_rest = skeleton->get_bone_rest(bone_id);
 
 		} else {
 
-			bones_infos[bone_id].relative_rest = bones_infos[parent].relative_rest * skeleton->get_bone_rest(bone_id);
+			bones_infos.write[bone_id].relative_rest = bones_infos[parent].relative_rest * skeleton->get_bone_rest(bone_id);
 
 			/// create physical bone on parent
 			if (!bones_infos[parent].physical_bone) {
 
-				bones_infos[parent].physical_bone = create_physical_bone(parent, bone_id, bones_infos);
+				bones_infos.write[parent].physical_bone = create_physical_bone(parent, bone_id, bones_infos);
 
 				ur->create_action(TTR("Create physical bones"));
 				ur->add_do_method(skeleton, "add_child", bones_infos[parent].physical_bone);

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -5009,7 +5009,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	tool_button[TOOL_MODE_SELECT]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_SELECT]->set_flat(true);
 	tool_button[TOOL_MODE_SELECT]->set_pressed(true);
-	button_binds[0] = MENU_TOOL_SELECT;
+	button_binds.write[0] = MENU_TOOL_SELECT;
 	tool_button[TOOL_MODE_SELECT]->connect("pressed", this, "_menu_item_pressed", button_binds);
 	tool_button[TOOL_MODE_SELECT]->set_tooltip(TTR("Select Mode (Q)") + "\n" + keycode_get_string(KEY_MASK_CMD) + TTR("Drag: Rotate\nAlt+Drag: Move\nAlt+RMB: Depth list selection"));
 
@@ -5017,7 +5017,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	hbc_menu->add_child(tool_button[TOOL_MODE_MOVE]);
 	tool_button[TOOL_MODE_MOVE]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_MOVE]->set_flat(true);
-	button_binds[0] = MENU_TOOL_MOVE;
+	button_binds.write[0] = MENU_TOOL_MOVE;
 	tool_button[TOOL_MODE_MOVE]->connect("pressed", this, "_menu_item_pressed", button_binds);
 	tool_button[TOOL_MODE_MOVE]->set_tooltip(TTR("Move Mode (W)"));
 
@@ -5025,7 +5025,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	hbc_menu->add_child(tool_button[TOOL_MODE_ROTATE]);
 	tool_button[TOOL_MODE_ROTATE]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_ROTATE]->set_flat(true);
-	button_binds[0] = MENU_TOOL_ROTATE;
+	button_binds.write[0] = MENU_TOOL_ROTATE;
 	tool_button[TOOL_MODE_ROTATE]->connect("pressed", this, "_menu_item_pressed", button_binds);
 	tool_button[TOOL_MODE_ROTATE]->set_tooltip(TTR("Rotate Mode (E)"));
 
@@ -5033,7 +5033,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	hbc_menu->add_child(tool_button[TOOL_MODE_SCALE]);
 	tool_button[TOOL_MODE_SCALE]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_SCALE]->set_flat(true);
-	button_binds[0] = MENU_TOOL_SCALE;
+	button_binds.write[0] = MENU_TOOL_SCALE;
 	tool_button[TOOL_MODE_SCALE]->connect("pressed", this, "_menu_item_pressed", button_binds);
 	tool_button[TOOL_MODE_SCALE]->set_tooltip(TTR("Scale Mode (R)"));
 
@@ -5041,19 +5041,19 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	hbc_menu->add_child(tool_button[TOOL_MODE_LIST_SELECT]);
 	tool_button[TOOL_MODE_LIST_SELECT]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_LIST_SELECT]->set_flat(true);
-	button_binds[0] = MENU_TOOL_LIST_SELECT;
+	button_binds.write[0] = MENU_TOOL_LIST_SELECT;
 	tool_button[TOOL_MODE_LIST_SELECT]->connect("pressed", this, "_menu_item_pressed", button_binds);
 	tool_button[TOOL_MODE_LIST_SELECT]->set_tooltip(TTR("Show a list of all objects at the position clicked\n(same as Alt+RMB in select mode)."));
 
 	tool_button[TOOL_LOCK_SELECTED] = memnew(ToolButton);
 	hbc_menu->add_child(tool_button[TOOL_LOCK_SELECTED]);
-	button_binds[0] = MENU_LOCK_SELECTED;
+	button_binds.write[0] = MENU_LOCK_SELECTED;
 	tool_button[TOOL_LOCK_SELECTED]->connect("pressed", this, "_menu_item_pressed", button_binds);
 	tool_button[TOOL_LOCK_SELECTED]->set_tooltip(TTR("Lock the selected object in place (can't be moved)."));
 
 	tool_button[TOOL_UNLOCK_SELECTED] = memnew(ToolButton);
 	hbc_menu->add_child(tool_button[TOOL_UNLOCK_SELECTED]);
-	button_binds[0] = MENU_UNLOCK_SELECTED;
+	button_binds.write[0] = MENU_UNLOCK_SELECTED;
 	tool_button[TOOL_UNLOCK_SELECTED]->connect("pressed", this, "_menu_item_pressed", button_binds);
 	tool_button[TOOL_UNLOCK_SELECTED]->set_tooltip(TTR("Unlock the selected object (can be moved)."));
 
@@ -5064,7 +5064,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	hbc_menu->add_child(tool_option_button[TOOL_OPT_LOCAL_COORDS]);
 	tool_option_button[TOOL_OPT_LOCAL_COORDS]->set_toggle_mode(true);
 	tool_option_button[TOOL_OPT_LOCAL_COORDS]->set_flat(true);
-	button_binds[0] = MENU_TOOL_LOCAL_COORDS;
+	button_binds.write[0] = MENU_TOOL_LOCAL_COORDS;
 	tool_option_button[TOOL_OPT_LOCAL_COORDS]->connect("toggled", this, "_menu_item_toggled", button_binds);
 	ED_SHORTCUT("spatial_editor/local_coords", TTR("Local Coords"), KEY_T);
 	sct = ED_GET_SHORTCUT("spatial_editor/local_coords").ptr()->get_as_text();
@@ -5074,7 +5074,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	hbc_menu->add_child(tool_option_button[TOOL_OPT_USE_SNAP]);
 	tool_option_button[TOOL_OPT_USE_SNAP]->set_toggle_mode(true);
 	tool_option_button[TOOL_OPT_USE_SNAP]->set_flat(true);
-	button_binds[0] = MENU_TOOL_USE_SNAP;
+	button_binds.write[0] = MENU_TOOL_USE_SNAP;
 	tool_option_button[TOOL_OPT_USE_SNAP]->connect("toggled", this, "_menu_item_toggled", button_binds);
 	ED_SHORTCUT("spatial_editor/snap", TTR("Snap"), KEY_Y);
 	sct = ED_GET_SHORTCUT("spatial_editor/snap").ptr()->get_as_text();

--- a/editor/plugins/sprite_editor_plugin.cpp
+++ b/editor/plugins/sprite_editor_plugin.cpp
@@ -169,7 +169,7 @@ void SpriteEditor::_update_mesh_data() {
 
 	Size2 img_size = Vector2(image->get_width(), image->get_height());
 	for (int j = 0; j < lines.size(); j++) {
-		lines[j] = expand(lines[j], rect, epsilon);
+		lines.write[j] = expand(lines[j], rect, epsilon);
 
 		int index_ofs = computed_vertices.size();
 

--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -196,7 +196,7 @@ Vector<int> TileMapEditor::get_selected_tiles() const {
 	}
 
 	for (int i = items.size() - 1; i >= 0; i--) {
-		items[i] = palette->get_item_metadata(items[i]);
+		items.write[i] = palette->get_item_metadata(items[i]);
 	}
 	return items;
 }
@@ -983,7 +983,7 @@ bool TileMapEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 						ids.push_back(0);
 						for (List<TileData>::Element *E = copydata.front(); E; E = E->next()) {
 
-							ids[0] = E->get().cell;
+							ids.write[0] = E->get().cell;
 							_set_cell(E->get().pos + ofs, ids, E->get().flip_h, E->get().flip_v, E->get().transpose);
 						}
 						_finish_undo();
@@ -1006,7 +1006,7 @@ bool TileMapEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 						}
 						for (List<TileData>::Element *E = copydata.front(); E; E = E->next()) {
 
-							ids[0] = E->get().cell;
+							ids.write[0] = E->get().cell;
 							_set_cell(E->get().pos + ofs, ids, E->get().flip_h, E->get().flip_v, E->get().transpose);
 						}
 						_finish_undo();
@@ -1228,7 +1228,7 @@ bool TileMapEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 
 				for (Map<Point2i, CellOp>::Element *E = paint_undo.front(); E; E = E->next()) {
 
-					tmp_cell[0] = E->get().idx;
+					tmp_cell.write[0] = E->get().idx;
 					_set_cell(E->key(), tmp_cell, E->get().xf, E->get().yf, E->get().tr);
 				}
 			}
@@ -1265,7 +1265,7 @@ bool TileMapEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 
 					for (Map<Point2i, CellOp>::Element *E = paint_undo.front(); E; E = E->next()) {
 
-						tmp_cell[0] = E->get().idx;
+						tmp_cell.write[0] = E->get().idx;
 						_set_cell(E->key(), tmp_cell, E->get().xf, E->get().yf, E->get().tr);
 					}
 				}
@@ -1750,7 +1750,7 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 	bucket_cache_visited = 0;
 
 	invalid_cell.resize(1);
-	invalid_cell[0] = TileMap::INVALID_CELL;
+	invalid_cell.write[0] = TileMap::INVALID_CELL;
 
 	ED_SHORTCUT("tile_map_editor/erase_selection", TTR("Erase Selection"), KEY_DELETE);
 	ED_SHORTCUT("tile_map_editor/find_tile", TTR("Find Tile"), KEY_MASK_CMD + KEY_F);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -190,7 +190,7 @@ void VisualShaderEditor::_update_graph() {
 		}
 
 		for (int i = 0; i < plugins.size(); i++) {
-			custom_editor = plugins[i]->create_editor(vsnode);
+			custom_editor = plugins.write[i]->create_editor(vsnode);
 			if (custom_editor) {
 				break;
 			}

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1781,8 +1781,8 @@ ProjectManager::ProjectManager() {
 	vb->add_constant_override("separation", 15 * EDSCALE);
 
 	String cp;
-	cp.push_back(0xA9);
-	cp.push_back(0);
+	cp += 0xA9;
+	cp += '0';
 	OS::get_singleton()->set_window_title(VERSION_NAME + String(" - ") + TTR("Project Manager") + " - " + cp + " 2007-2018 Juan Linietsky, Ariel Manzur & Godot Contributors");
 
 	HBoxContainer *top_hb = memnew(HBoxContainer);

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -1462,7 +1462,7 @@ void ProjectSettingsEditor::_update_translations() {
 			t->set_editable(0, true);
 			t->set_tooltip(0, l);
 			t->set_checked(0, l_filter.has(l));
-			translation_filter_treeitems[i] = t;
+			translation_filter_treeitems.write[i] = t;
 		}
 	} else {
 		for (int i = 0; i < s; i++) {
@@ -1502,7 +1502,7 @@ void ProjectSettingsEditor::_update_translations() {
 					if (langnames.length() > 0)
 						langnames += ",";
 					langnames += names[i];
-					translation_locales_idxs_remap[l_idx] = i;
+					translation_locales_idxs_remap.write[l_idx] = i;
 					l_idx++;
 				}
 			}

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -90,7 +90,7 @@ bool EditorResourceConversionPlugin::handles(const Ref<Resource> &p_resource) co
 	return false;
 }
 
-Ref<Resource> EditorResourceConversionPlugin::convert(const Ref<Resource> &p_resource) {
+Ref<Resource> EditorResourceConversionPlugin::convert(const Ref<Resource> &p_resource) const {
 
 	if (get_script_instance())
 		return get_script_instance()->call("_convert", p_resource);

--- a/editor/property_editor.h
+++ b/editor/property_editor.h
@@ -64,7 +64,7 @@ protected:
 public:
 	virtual String converts_to() const;
 	virtual bool handles(const Ref<Resource> &p_resource) const;
-	virtual Ref<Resource> convert(const Ref<Resource> &p_resource);
+	virtual Ref<Resource> convert(const Ref<Resource> &p_resource) const;
 };
 
 class CustomPropertyEditor : public Popup {

--- a/editor/quick_open.cpp
+++ b/editor/quick_open.cpp
@@ -195,7 +195,7 @@ Vector<Pair<String, Ref<Texture> > > EditorQuickOpen::_sort_fs(Vector<Pair<Strin
 	Vector<float> scores;
 	scores.resize(list.size());
 	for (int i = 0; i < list.size(); i++)
-		scores[i] = _path_cmp(search_text, list[i].first);
+		scores.write[i] = _path_cmp(search_text, list[i].first);
 
 	while (list.size() > 0) {
 

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -658,7 +658,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		Vector<float> p;
 		p.resize(arr.size());
 		for (int i = 0; i < arr.size(); i++) {
-			p[i] = arr[i];
+			p.write[i] = arr[i];
 			if (i < perf_items.size()) {
 
 				float v = p[i];
@@ -693,7 +693,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 				perf_items[i]->set_text(1, vs);
 				perf_items[i]->set_tooltip(1, tt);
 				if (p[i] > perf_max[i])
-					perf_max[i] = p[i];
+					perf_max.write[i] = p[i];
 			}
 		}
 		perf_history.push_front(p);
@@ -807,7 +807,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 				item.signature = "categ::" + name + "::" + item.name;
 				item.name = item.name.capitalize();
 				c.total_time += item.total;
-				c.items[i / 2] = item;
+				c.items.write[i / 2] = item;
 			}
 			metric.categories.push_back(c);
 		}
@@ -844,7 +844,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 			item.calls = calls;
 			item.self = self;
 			item.total = total;
-			funcs.items[i] = item;
+			funcs.items.write[i] = item;
 		}
 
 		metric.categories.push_back(funcs);
@@ -1193,7 +1193,7 @@ void ScriptEditorDebugger::start() {
 	perf_history.clear();
 	for (int i = 0; i < Performance::MONITOR_MAX; i++) {
 
-		perf_max[i] = 0;
+		perf_max.write[i] = 0;
 	}
 
 	int remote_port = (int)EditorSettings::get_singleton()->get("network/debug/remote_port");
@@ -2076,7 +2076,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 			it->set_selectable(1, false);
 			it->set_text(0, name.capitalize());
 			perf_items.push_back(it);
-			perf_max[i] = 0;
+			perf_max.write[i] = 0;
 		}
 	}
 

--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -229,7 +229,7 @@ void EditorSpatialGizmo::add_collision_segments(const Vector<Vector3> &p_lines) 
 	collision_segments.resize(from + p_lines.size());
 	for (int i = 0; i < p_lines.size(); i++) {
 
-		collision_segments[from + i] = p_lines[i];
+		collision_segments.write[from + i] = p_lines[i];
 	}
 }
 
@@ -296,14 +296,14 @@ void EditorSpatialGizmo::add_handles(const Vector<Vector3> &p_handles, bool p_bi
 		int chs = handles.size();
 		handles.resize(chs + p_handles.size());
 		for (int i = 0; i < p_handles.size(); i++) {
-			handles[i + chs] = p_handles[i];
+			handles.write[i + chs] = p_handles[i];
 		}
 	} else {
 
 		int chs = secondary_handles.size();
 		secondary_handles.resize(chs + p_handles.size());
 		for (int i = 0; i < p_handles.size(); i++) {
-			secondary_handles[i + chs] = p_handles[i];
+			secondary_handles.write[i + chs] = p_handles[i];
 		}
 	}
 }
@@ -597,7 +597,7 @@ void EditorSpatialGizmo::create() {
 
 	for (int i = 0; i < instances.size(); i++) {
 
-		instances[i].create_instance(spatial_node);
+		instances.write[i].create_instance(spatial_node);
 	}
 
 	transform();
@@ -621,7 +621,7 @@ void EditorSpatialGizmo::free() {
 
 		if (instances[i].instance.is_valid())
 			VS::get_singleton()->free(instances[i].instance);
-		instances[i].instance = RID();
+		instances.write[i].instance = RID();
 	}
 
 	valid = false;
@@ -1124,8 +1124,8 @@ void AudioStreamPlayer3DSpatialGizmo::redraw() {
 			Vector3 from(Math::sin(a) * radius, Math::cos(a) * radius, ofs);
 			Vector3 to(Math::sin(an) * radius, Math::cos(an) * radius, ofs);
 
-			points[i * 2 + 0] = from;
-			points[i * 2 + 1] = to;
+			points.write[i * 2 + 0] = from;
+			points.write[i * 2 + 1] = to;
 		}
 
 		for (int i = 0; i < 4; i++) {
@@ -1134,8 +1134,8 @@ void AudioStreamPlayer3DSpatialGizmo::redraw() {
 
 			Vector3 from(Math::sin(a) * radius, Math::cos(a) * radius, ofs);
 
-			points[200 + i * 2 + 0] = from;
-			points[200 + i * 2 + 1] = Vector3();
+			points.write[200 + i * 2 + 0] = from;
+			points.write[200 + i * 2 + 1] = Vector3();
 		}
 
 		add_lines(points, material);
@@ -1441,11 +1441,11 @@ void SkeletonSpatialGizmo::redraw() {
 	weights.resize(4);
 
 	for (int i = 0; i < 4; i++) {
-		bones[i] = 0;
-		weights[i] = 0;
+		bones.write[i] = 0;
+		weights.write[i] = 0;
 	}
 
-	weights[0] = 1;
+	weights.write[0] = 1;
 
 	AABB aabb;
 
@@ -1457,7 +1457,7 @@ void SkeletonSpatialGizmo::redraw() {
 		int parent = skel->get_bone_parent(i);
 
 		if (parent >= 0) {
-			grests[i] = grests[parent] * skel->get_bone_rest(i);
+			grests.write[i] = grests[parent] * skel->get_bone_rest(i);
 
 			Vector3 v0 = grests[parent].origin;
 			Vector3 v1 = grests[i].origin;
@@ -1480,7 +1480,7 @@ void SkeletonSpatialGizmo::redraw() {
 			int pointidx = 0;
 			for (int j = 0; j < 3; j++) {
 
-				bones[0] = parent;
+				bones.write[0] = parent;
 				surface_tool->add_bones(bones);
 				surface_tool->add_weights(weights);
 				surface_tool->add_color(rootcolor);
@@ -1508,7 +1508,7 @@ void SkeletonSpatialGizmo::redraw() {
 					Vector3 point = v0 + d * dist * 0.2;
 					point += axis * dist * 0.1;
 
-					bones[0] = parent;
+					bones.write[0] = parent;
 					surface_tool->add_bones(bones);
 					surface_tool->add_weights(weights);
 					surface_tool->add_color(bonecolor);
@@ -1518,12 +1518,12 @@ void SkeletonSpatialGizmo::redraw() {
 					surface_tool->add_color(bonecolor);
 					surface_tool->add_vertex(point);
 
-					bones[0] = parent;
+					bones.write[0] = parent;
 					surface_tool->add_bones(bones);
 					surface_tool->add_weights(weights);
 					surface_tool->add_color(bonecolor);
 					surface_tool->add_vertex(point);
-					bones[0] = i;
+					bones.write[0] = i;
 					surface_tool->add_bones(bones);
 					surface_tool->add_weights(weights);
 					surface_tool->add_color(bonecolor);
@@ -1535,7 +1535,7 @@ void SkeletonSpatialGizmo::redraw() {
 			SWAP(points[1], points[2]);
 			for (int j = 0; j < 4; j++) {
 
-				bones[0] = parent;
+				bones.write[0] = parent;
 				surface_tool->add_bones(bones);
 				surface_tool->add_weights(weights);
 				surface_tool->add_color(bonecolor);
@@ -1560,8 +1560,8 @@ void SkeletonSpatialGizmo::redraw() {
 */
 		} else {
 
-			grests[i] = skel->get_bone_rest(i);
-			bones[0] = i;
+			grests.write[i] = skel->get_bone_rest(i);
+			bones.write[0] = i;
 		}
 		/*
 		Transform  t = grests[i];
@@ -2542,8 +2542,8 @@ void CollisionShapeSpatialGizmo::redraw() {
 				Vector<Vector3> points;
 				points.resize(md.edges.size() * 2);
 				for (int i = 0; i < md.edges.size(); i++) {
-					points[i * 2 + 0] = md.vertices[md.edges[i].a];
-					points[i * 2 + 1] = md.vertices[md.edges[i].b];
+					points.write[i * 2 + 0] = md.vertices[md.edges[i].a];
+					points.write[i * 2 + 1] = md.vertices[md.edges[i].b];
 				}
 
 				add_lines(points, material);

--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -684,7 +684,7 @@ void InputDefault::joy_button(int p_device, int p_button, bool p_pressed) {
 		return;
 	};
 
-	Map<int, JoyEvent>::Element *el = map_db[joy.mapping].buttons.find(p_button);
+	const Map<int, JoyEvent>::Element *el = map_db[joy.mapping].buttons.find(p_button);
 	if (!el) {
 		//don't process un-mapped events for now, it could mess things up badly for devices with additional buttons/axis
 		//return _button_event(p_last_id, p_device, p_button, p_pressed);
@@ -755,7 +755,7 @@ void InputDefault::joy_axis(int p_device, int p_axis, const JoyAxis &p_value) {
 		return;
 	};
 
-	Map<int, JoyEvent>::Element *el = map_db[joy.mapping].axis.find(p_axis);
+	const Map<int, JoyEvent>::Element *el = map_db[joy.mapping].axis.find(p_axis);
 	if (!el) {
 		//return _axis_event(p_last_id, p_device, p_axis, p_value);
 		return;
@@ -831,7 +831,7 @@ void InputDefault::joy_hat(int p_device, int p_val) {
 	_THREAD_SAFE_METHOD_;
 	const Joypad &joy = joy_names[p_device];
 
-	JoyEvent *map;
+	const JoyEvent *map;
 
 	if (joy.mapping == -1) {
 		map = hat_map_default;

--- a/main/tests/test_gdscript.cpp
+++ b/main/tests/test_gdscript.cpp
@@ -924,8 +924,8 @@ MainLoop *test(TestType p_type) {
 	Vector<uint8_t> buf;
 	int flen = fa->get_len();
 	buf.resize(fa->get_len() + 1);
-	fa->get_buffer(&buf[0], flen);
-	buf[flen] = 0;
+	fa->get_buffer(buf.ptrw(), flen);
+	buf.write[flen] = 0;
 
 	String code;
 	code.parse_utf8((const char *)&buf[0]);

--- a/main/tests/test_io.cpp
+++ b/main/tests/test_io.cpp
@@ -103,7 +103,7 @@ MainLoop *test() {
 		int len = z->get_len();
 		Vector<uint8_t> zip;
 		zip.resize(len);
-		z->get_buffer(&zip[0], len);
+		z->get_buffer(zip.ptrw(), len);
 		z->close();
 		memdelete(z);
 

--- a/main/tests/test_math.cpp
+++ b/main/tests/test_math.cpp
@@ -503,8 +503,8 @@ MainLoop *test() {
 	Vector<uint8_t> buf;
 	int flen = fa->get_len();
 	buf.resize(fa->get_len() + 1);
-	fa->get_buffer(&buf[0], flen);
-	buf[flen] = 0;
+	fa->get_buffer(buf.ptrw(), flen);
+	buf.write[flen] = 0;
 
 	String code;
 	code.parse_utf8((const char *)&buf[0]);

--- a/main/tests/test_physics.cpp
+++ b/main/tests/test_physics.cpp
@@ -228,11 +228,11 @@ protected:
 
 		for (int i = 0; i < p_width; i++) {
 
-			grid[i].resize(p_height);
+			grid.write[i].resize(p_height);
 
 			for (int j = 0; j < p_height; j++) {
 
-				grid[i][j] = 1.0 + Math::random(-p_cellheight, p_cellheight);
+				grid.write[i].write[j] = 1.0 + Math::random(-p_cellheight, p_cellheight);
 			}
 		}
 

--- a/modules/bullet/area_bullet.cpp
+++ b/modules/bullet/area_bullet.cpp
@@ -80,7 +80,7 @@ void AreaBullet::dispatch_callbacks() {
 
 	// Reverse order because I've to remove EXIT objects
 	for (int i = overlappingObjects.size() - 1; 0 <= i; --i) {
-		OverlappingObjectData &otherObj = overlappingObjects[i];
+		OverlappingObjectData &otherObj = overlappingObjects.write[i];
 
 		switch (otherObj.state) {
 			case OVERLAP_STATE_ENTER:
@@ -199,13 +199,13 @@ void AreaBullet::add_overlap(CollisionObjectBullet *p_otherObject) {
 
 void AreaBullet::put_overlap_as_exit(int p_index) {
 	scratch();
-	overlappingObjects[p_index].state = OVERLAP_STATE_EXIT;
+	overlappingObjects.write[p_index].state = OVERLAP_STATE_EXIT;
 }
 
 void AreaBullet::put_overlap_as_inside(int p_index) {
 	// This check is required to be sure this body was inside
 	if (OVERLAP_STATE_DIRTY == overlappingObjects[p_index].state) {
-		overlappingObjects[p_index].state = OVERLAP_STATE_INSIDE;
+		overlappingObjects.write[p_index].state = OVERLAP_STATE_INSIDE;
 	}
 }
 

--- a/modules/bullet/collision_object_bullet.cpp
+++ b/modules/bullet/collision_object_bullet.cpp
@@ -223,7 +223,7 @@ void RigidCollisionObjectBullet::add_shape(ShapeBullet *p_shape, const Transform
 }
 
 void RigidCollisionObjectBullet::set_shape(int p_index, ShapeBullet *p_shape) {
-	ShapeWrapper &shp = shapes[p_index];
+	ShapeWrapper &shp = shapes.write[p_index];
 	shp.shape->remove_owner(this);
 	p_shape->add_owner(this);
 	shp.shape = p_shape;
@@ -233,8 +233,8 @@ void RigidCollisionObjectBullet::set_shape(int p_index, ShapeBullet *p_shape) {
 void RigidCollisionObjectBullet::set_shape_transform(int p_index, const Transform &p_transform) {
 	ERR_FAIL_INDEX(p_index, get_shape_count());
 
-	shapes[p_index].set_transform(p_transform);
-	on_shape_changed(shapes[p_index].shape);
+	shapes.write[p_index].set_transform(p_transform);
+	on_shape_changed(shapes.write[p_index].shape);
 }
 
 void RigidCollisionObjectBullet::remove_shape(ShapeBullet *p_shape) {
@@ -287,7 +287,7 @@ void RigidCollisionObjectBullet::on_shape_changed(const ShapeBullet *const p_sha
 	const int size = shapes.size();
 	for (int i = 0; i < size; ++i) {
 		if (shapes[i].shape == p_shape) {
-			bulletdelete(shapes[i].bt_shape);
+			bulletdelete(shapes.write[i].bt_shape);
 		}
 	}
 	on_shapes_changed();
@@ -307,7 +307,7 @@ void RigidCollisionObjectBullet::on_shapes_changed() {
 	// Reset shape if required
 	if (force_shape_reset) {
 		for (i = 0; i < shapes_size; ++i) {
-			shpWrapper = &shapes[i];
+			shpWrapper = &shapes.write[i];
 			bulletdelete(shpWrapper->bt_shape);
 		}
 		force_shape_reset = false;
@@ -316,7 +316,7 @@ void RigidCollisionObjectBullet::on_shapes_changed() {
 	// Insert all shapes
 	btVector3 body_scale(get_bt_body_scale());
 	for (i = 0; i < shapes_size; ++i) {
-		shpWrapper = &shapes[i];
+		shpWrapper = &shapes.write[i];
 		if (shpWrapper->active) {
 			if (!shpWrapper->bt_shape) {
 				shpWrapper->bt_shape = shpWrapper->shape->create_bt_shape(shpWrapper->scale * body_scale);
@@ -334,7 +334,7 @@ void RigidCollisionObjectBullet::on_shapes_changed() {
 }
 
 void RigidCollisionObjectBullet::set_shape_disabled(int p_index, bool p_disabled) {
-	shapes[p_index].active = !p_disabled;
+	shapes.write[p_index].active = !p_disabled;
 	on_shapes_changed();
 }
 
@@ -348,7 +348,7 @@ void RigidCollisionObjectBullet::on_body_scale_changed() {
 }
 
 void RigidCollisionObjectBullet::internal_shape_destroy(int p_index, bool p_permanentlyFromThisBody) {
-	ShapeWrapper &shp = shapes[p_index];
+	ShapeWrapper &shp = shapes.write[p_index];
 	shp.shape->remove_owner(this, p_permanentlyFromThisBody);
 	bulletdelete(shp.bt_shape);
 }

--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -179,7 +179,7 @@ int BulletPhysicsDirectBodyState::get_contact_collider_shape(int p_contact_idx) 
 }
 
 Vector3 BulletPhysicsDirectBodyState::get_contact_collider_velocity_at_position(int p_contact_idx) const {
-	RigidBodyBullet::CollisionData &colDat = body->collisions[p_contact_idx];
+	RigidBodyBullet::CollisionData &colDat = body->collisions.write[p_contact_idx];
 
 	btVector3 hitLocation;
 	G_TO_B(colDat.hitLocalLocation, hitLocation);
@@ -224,8 +224,8 @@ void RigidBodyBullet::KinematicUtilities::copyAllOwnerShapes() {
 			continue;
 		}
 
-		shapes[i].transform = shape_wrapper->transform;
-		shapes[i].transform.getOrigin() *= owner_scale;
+		shapes.write[i].transform = shape_wrapper->transform;
+		shapes.write[i].transform.getOrigin() *= owner_scale;
 		switch (shape_wrapper->shape->get_type()) {
 			case PhysicsServer::SHAPE_SPHERE:
 			case PhysicsServer::SHAPE_BOX:
@@ -233,11 +233,11 @@ void RigidBodyBullet::KinematicUtilities::copyAllOwnerShapes() {
 			case PhysicsServer::SHAPE_CYLINDER:
 			case PhysicsServer::SHAPE_CONVEX_POLYGON:
 			case PhysicsServer::SHAPE_RAY: {
-				shapes[i].shape = static_cast<btConvexShape *>(shape_wrapper->shape->create_bt_shape(owner_scale * shape_wrapper->scale, safe_margin));
+				shapes.write[i].shape = static_cast<btConvexShape *>(shape_wrapper->shape->create_bt_shape(owner_scale * shape_wrapper->scale, safe_margin));
 			} break;
 			default:
 				WARN_PRINT("This shape is not supported to be kinematic!");
-				shapes[i].shape = NULL;
+				shapes.write[i].shape = NULL;
 		}
 	}
 }
@@ -245,7 +245,7 @@ void RigidBodyBullet::KinematicUtilities::copyAllOwnerShapes() {
 void RigidBodyBullet::KinematicUtilities::just_delete_shapes(int new_size) {
 	for (int i = shapes.size() - 1; 0 <= i; --i) {
 		if (shapes[i].shape) {
-			bulletdelete(shapes[i].shape);
+			bulletdelete(shapes.write[i].shape);
 		}
 	}
 	shapes.resize(new_size);
@@ -287,7 +287,7 @@ RigidBodyBullet::RigidBodyBullet() :
 
 	areasWhereIam.resize(maxAreasWhereIam);
 	for (int i = areasWhereIam.size() - 1; 0 <= i; --i) {
-		areasWhereIam[i] = NULL;
+		areasWhereIam.write[i] = NULL;
 	}
 	btBody->setSleepingThresholds(0.2, 0.2);
 }
@@ -413,7 +413,7 @@ bool RigidBodyBullet::add_collision_object(RigidBodyBullet *p_otherObject, const
 		return false;
 	}
 
-	CollisionData &cd = collisions[collisionsCount];
+	CollisionData &cd = collisions.write[collisionsCount];
 	cd.hitLocalLocation = p_hitLocalLocation;
 	cd.otherObject = p_otherObject;
 	cd.hitWorldLocation = p_hitWorldLocation;
@@ -817,15 +817,15 @@ void RigidBodyBullet::on_enter_area(AreaBullet *p_area) {
 
 		if (NULL == areasWhereIam[i]) {
 			// This area has the highest priority
-			areasWhereIam[i] = p_area;
+			areasWhereIam.write[i] = p_area;
 			break;
 		} else {
 			if (areasWhereIam[i]->get_spOv_priority() > p_area->get_spOv_priority()) {
 				// The position was found, just shift all elements
 				for (int j = i; j < areaWhereIamCount; ++j) {
-					areasWhereIam[j + 1] = areasWhereIam[j];
+					areasWhereIam.write[j + 1] = areasWhereIam[j];
 				}
-				areasWhereIam[i] = p_area;
+				areasWhereIam.write[i] = p_area;
 				break;
 			}
 		}
@@ -849,7 +849,7 @@ void RigidBodyBullet::on_exit_area(AreaBullet *p_area) {
 		if (p_area == areasWhereIam[i]) {
 			// The area was fount, just shift down all elements
 			for (int j = i; j < areaWhereIamCount; ++j) {
-				areasWhereIam[j] = areasWhereIam[j + 1];
+				areasWhereIam.write[j] = areasWhereIam[j + 1];
 			}
 			wasTheAreaFound = true;
 			break;
@@ -862,7 +862,7 @@ void RigidBodyBullet::on_exit_area(AreaBullet *p_area) {
 		}
 
 		--areaWhereIamCount;
-		areasWhereIam[areaWhereIamCount] = NULL; // Even if this is not required, I clear the last element to be safe
+		areasWhereIam.write[areaWhereIamCount] = NULL; // Even if this is not required, I clear the last element to be safe
 		if (PhysicsServer::AREA_SPACE_OVERRIDE_DISABLED != p_area->get_spOv_mode()) {
 			scratch_space_override_modificator();
 		}

--- a/modules/bullet/shape_bullet.cpp
+++ b/modules/bullet/shape_bullet.cpp
@@ -304,7 +304,7 @@ void ConvexPolygonShapeBullet::get_vertices(Vector<Vector3> &out_vertices) {
 	const int n_of_vertices = vertices.size();
 	out_vertices.resize(n_of_vertices);
 	for (int i = n_of_vertices - 1; 0 <= i; --i) {
-		B_TO_G(vertices[i], out_vertices[i]);
+		B_TO_G(vertices[i], out_vertices.write[i]);
 	}
 }
 

--- a/modules/bullet/soft_body_bullet.cpp
+++ b/modules/bullet/soft_body_bullet.cpp
@@ -90,7 +90,7 @@ void SoftBodyBullet::update_visual_server(SoftBodyVisualServerHandler *p_visual_
 	const btSoftBody::tNodeArray &nodes(bt_soft_body->m_nodes);
 	const int nodes_count = nodes.size();
 
-	Vector<int> *vs_indices;
+	const Vector<int> *vs_indices;
 	const void *vertex_position;
 	const void *vertex_normal;
 
@@ -359,7 +359,7 @@ void SoftBodyBullet::set_trimesh_body_shape(PoolVector<int> p_indices, PoolVecto
 					indices_table.push_back(Vector<int>());
 				}
 
-				indices_table[vertex_id].push_back(vs_vertex_index);
+				indices_table.write[vertex_id].push_back(vs_vertex_index);
 				vs_indices_to_physics_table.push_back(vertex_id);
 			}
 		}
@@ -374,9 +374,9 @@ void SoftBodyBullet::set_trimesh_body_shape(PoolVector<int> p_indices, PoolVecto
 			PoolVector<Vector3>::Read p_vertices_read = p_vertices.read();
 
 			for (int i = 0; i < indices_map_size; ++i) {
-				bt_vertices[3 * i + 0] = p_vertices_read[indices_table[i][0]].x;
-				bt_vertices[3 * i + 1] = p_vertices_read[indices_table[i][0]].y;
-				bt_vertices[3 * i + 2] = p_vertices_read[indices_table[i][0]].z;
+				bt_vertices.write[3 * i + 0] = p_vertices_read[indices_table[i][0]].x;
+				bt_vertices.write[3 * i + 1] = p_vertices_read[indices_table[i][0]].y;
+				bt_vertices.write[3 * i + 2] = p_vertices_read[indices_table[i][0]].z;
 			}
 		}
 
@@ -390,9 +390,9 @@ void SoftBodyBullet::set_trimesh_body_shape(PoolVector<int> p_indices, PoolVecto
 			PoolVector<int>::Read p_indices_read = p_indices.read();
 
 			for (int i = 0; i < triangles_size; ++i) {
-				bt_triangles[3 * i + 0] = vs_indices_to_physics_table[p_indices_read[3 * i + 2]];
-				bt_triangles[3 * i + 1] = vs_indices_to_physics_table[p_indices_read[3 * i + 1]];
-				bt_triangles[3 * i + 2] = vs_indices_to_physics_table[p_indices_read[3 * i + 0]];
+				bt_triangles.write[3 * i + 0] = vs_indices_to_physics_table[p_indices_read[3 * i + 2]];
+				bt_triangles.write[3 * i + 1] = vs_indices_to_physics_table[p_indices_read[3 * i + 1]];
+				bt_triangles.write[3 * i + 2] = vs_indices_to_physics_table[p_indices_read[3 * i + 0]];
 			}
 		}
 

--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -686,7 +686,7 @@ void SpaceBullet::check_ghost_overlaps() {
 
 		/// 1. Reset all states
 		for (i = area->overlappingObjects.size() - 1; 0 <= i; --i) {
-			AreaBullet::OverlappingObjectData &otherObj = area->overlappingObjects[i];
+			AreaBullet::OverlappingObjectData &otherObj = area->overlappingObjects.write[i];
 			// This check prevent the overwrite of ENTER state
 			// if this function is called more times before dispatchCallbacks
 			if (otherObj.state != AreaBullet::OVERLAP_STATE_ENTER) {

--- a/modules/bullet/space_bullet.h
+++ b/modules/bullet/space_bullet.h
@@ -164,7 +164,7 @@ public:
 		contactDebugCount = 0;
 	}
 	_FORCE_INLINE_ void add_debug_contact(const Vector3 &p_contact) {
-		if (contactDebugCount < contactDebug.size()) contactDebug[contactDebugCount++] = p_contact;
+		if (contactDebugCount < contactDebug.size()) contactDebug.write[contactDebugCount++] = p_contact;
 	}
 	_FORCE_INLINE_ Vector<Vector3> get_debug_contacts() { return contactDebug; }
 	_FORCE_INLINE_ int get_debug_contact_count() { return contactDebugCount; }

--- a/modules/csg/csg.cpp
+++ b/modules/csg/csg.cpp
@@ -62,7 +62,7 @@ void CSGBrush::build_from_faces(const PoolVector<Vector3> &p_vertices, const Poo
 	faces.resize(p_vertices.size() / 3);
 
 	for (int i = 0; i < faces.size(); i++) {
-		Face &f = faces[i];
+		Face &f = faces.write[i];
 		f.vertices[0] = rv[i * 3 + 0];
 		f.vertices[1] = rv[i * 3 + 1];
 		f.vertices[2] = rv[i * 3 + 2];
@@ -101,7 +101,7 @@ void CSGBrush::build_from_faces(const PoolVector<Vector3> &p_vertices, const Poo
 
 	materials.resize(material_map.size());
 	for (Map<Ref<Material>, int>::Element *E = material_map.front(); E; E = E->next()) {
-		materials[E->get()] = E->key();
+		materials.write[E->get()] = E->key();
 	}
 
 	_regen_face_aabbs();
@@ -111,10 +111,10 @@ void CSGBrush::_regen_face_aabbs() {
 
 	for (int i = 0; i < faces.size(); i++) {
 
-		faces[i].aabb.position = faces[i].vertices[0];
-		faces[i].aabb.expand_to(faces[i].vertices[1]);
-		faces[i].aabb.expand_to(faces[i].vertices[2]);
-		faces[i].aabb.grow_by(faces[i].aabb.get_longest_axis_size() * 0.001); //make it a tad bigger to avoid num precision erros
+		faces.write[i].aabb.position = faces[i].vertices[0];
+		faces.write[i].aabb.expand_to(faces[i].vertices[1]);
+		faces.write[i].aabb.expand_to(faces[i].vertices[2]);
+		faces.write[i].aabb.grow_by(faces[i].aabb.get_longest_axis_size() * 0.001); //make it a tad bigger to avoid num precision erros
 	}
 }
 
@@ -125,7 +125,7 @@ void CSGBrush::copy_from(const CSGBrush &p_brush, const Transform &p_xform) {
 
 	for (int i = 0; i < faces.size(); i++) {
 		for (int j = 0; j < 3; j++) {
-			faces[i].vertices[j] = p_xform.xform(p_brush.faces[i].vertices[j]);
+			faces.write[i].vertices[j] = p_xform.xform(p_brush.faces[i].vertices[j]);
 		}
 	}
 
@@ -341,7 +341,7 @@ void CSGBrushOperation::BuildPoly::_clip_segment(const CSGBrush *p_brush, int p_
 			new_edge.points[0] = edges[i].points[0];
 			new_edge.points[1] = point_idx;
 			new_edge.outer = edges[i].outer;
-			edges[i].points[0] = point_idx;
+			edges.write[i].points[0] = point_idx;
 			edges.insert(i, new_edge);
 			i++; //skip newly inserted edge
 			base_edges++; //will need an extra one in the base triangle
@@ -637,7 +637,7 @@ void CSGBrushOperation::_add_poly_points(const BuildPoly &p_poly, int p_edge, in
 		int to_point = e.edge_point;
 		int current_edge = e.edge;
 
-		edge_process[e.edge] = true; //mark as processed
+		edge_process.write[e.edge] = true; //mark as processed
 
 		int limit = p_poly.points.size() * 4; //avoid infinite recursion
 
@@ -708,7 +708,7 @@ void CSGBrushOperation::_add_poly_points(const BuildPoly &p_poly, int p_edge, in
 
 			prev_point = to_point;
 			to_point = next_point;
-			edge_process[next_edge] = true; //mark this edge as processed
+			edge_process.write[next_edge] = true; //mark this edge as processed
 			current_edge = next_edge;
 
 			limit--;
@@ -792,13 +792,13 @@ void CSGBrushOperation::_merge_poly(MeshMerge &mesh, int p_face_idx, const Build
 
 	//none processed by default
 	for (int i = 0; i < edge_process.size(); i++) {
-		edge_process[i] = false;
+		edge_process.write[i] = false;
 	}
 
 	//put edges in points, so points can go through them
 	for (int i = 0; i < p_poly.edges.size(); i++) {
-		vertex_process[p_poly.edges[i].points[0]].push_back(i);
-		vertex_process[p_poly.edges[i].points[1]].push_back(i);
+		vertex_process.write[p_poly.edges[i].points[0]].push_back(i);
+		vertex_process.write[p_poly.edges[i].points[1]].push_back(i);
 	}
 
 	Vector<PolyPoints> polys;
@@ -854,7 +854,7 @@ void CSGBrushOperation::_merge_poly(MeshMerge &mesh, int p_face_idx, const Build
 			_add_poly_outline(p_poly, p_poly.edges[i].points[0], p_poly.edges[i].points[1], vertex_process, outline);
 
 			if (outline.size() > 1) {
-				polys[intersect_poly].holes.push_back(outline);
+				polys.write[intersect_poly].holes.push_back(outline);
 			}
 		}
 		_add_poly_points(p_poly, i, p_poly.edges[i].points[0], p_poly.edges[i].points[1], vertex_process, edge_process, polys);
@@ -953,18 +953,18 @@ void CSGBrushOperation::_merge_poly(MeshMerge &mesh, int p_face_idx, const Build
 
 					//duplicate point
 					int insert_at = with_outline_vertex;
-					polys[i].points.insert(insert_at, polys[i].points[insert_at]);
+					polys.write[i].points.insert(insert_at, polys[i].points[insert_at]);
 					insert_at++;
 					//insert all others, outline should be backwards (must check)
 					int holesize = polys[i].holes[j].size();
 					for (int k = 0; k <= holesize; k++) {
 						int idx = (from_hole_vertex + k) % holesize;
-						polys[i].points.insert(insert_at, polys[i].holes[j][idx]);
+						polys.write[i].points.insert(insert_at, polys[i].holes[j][idx]);
 						insert_at++;
 					}
 
 					added_hole = true;
-					polys[i].holes.remove(j);
+					polys.write[i].holes.remove(j);
 					break; //got rid of hole, break and continue
 				}
 			}
@@ -980,7 +980,7 @@ void CSGBrushOperation::_merge_poly(MeshMerge &mesh, int p_face_idx, const Build
 		Vector<Vector2> vertices;
 		vertices.resize(polys[i].points.size());
 		for (int j = 0; j < vertices.size(); j++) {
-			vertices[j] = p_poly.points[polys[i].points[j]].point;
+			vertices.write[j] = p_poly.points[polys[i].points[j]].point;
 		}
 
 		Vector<int> indices = Geometry::triangulate_polygon(vertices);
@@ -1267,7 +1267,7 @@ void CSGBrushOperation::MeshMerge::mark_inside_faces() {
 		int intersections = _bvh_count_intersections(bvh, max_depth, max_alloc - 1, center, target, i);
 
 		if (intersections & 1) {
-			faces[i].inside = true;
+			faces.write[i].inside = true;
 		}
 	}
 }
@@ -1419,13 +1419,13 @@ void CSGBrushOperation::merge_brushes(Operation p_operation, const CSGBrush &p_A
 				if (mesh_merge.faces[i].inside)
 					continue;
 				for (int j = 0; j < 3; j++) {
-					result.faces[outside_count].vertices[j] = mesh_merge.points[mesh_merge.faces[i].points[j]];
-					result.faces[outside_count].uvs[j] = mesh_merge.faces[i].uvs[j];
+					result.faces.write[outside_count].vertices[j] = mesh_merge.points[mesh_merge.faces[i].points[j]];
+					result.faces.write[outside_count].uvs[j] = mesh_merge.faces[i].uvs[j];
 				}
 
-				result.faces[outside_count].smooth = mesh_merge.faces[i].smooth;
-				result.faces[outside_count].invert = mesh_merge.faces[i].invert;
-				result.faces[outside_count].material = mesh_merge.faces[i].material_idx;
+				result.faces.write[outside_count].smooth = mesh_merge.faces[i].smooth;
+				result.faces.write[outside_count].invert = mesh_merge.faces[i].invert;
+				result.faces.write[outside_count].material = mesh_merge.faces[i].material_idx;
 				outside_count++;
 			}
 
@@ -1451,13 +1451,13 @@ void CSGBrushOperation::merge_brushes(Operation p_operation, const CSGBrush &p_A
 				if (!mesh_merge.faces[i].inside)
 					continue;
 				for (int j = 0; j < 3; j++) {
-					result.faces[inside_count].vertices[j] = mesh_merge.points[mesh_merge.faces[i].points[j]];
-					result.faces[inside_count].uvs[j] = mesh_merge.faces[i].uvs[j];
+					result.faces.write[inside_count].vertices[j] = mesh_merge.points[mesh_merge.faces[i].points[j]];
+					result.faces.write[inside_count].uvs[j] = mesh_merge.faces[i].uvs[j];
 				}
 
-				result.faces[inside_count].smooth = mesh_merge.faces[i].smooth;
-				result.faces[inside_count].invert = mesh_merge.faces[i].invert;
-				result.faces[inside_count].material = mesh_merge.faces[i].material_idx;
+				result.faces.write[inside_count].smooth = mesh_merge.faces[i].smooth;
+				result.faces.write[inside_count].invert = mesh_merge.faces[i].invert;
+				result.faces.write[inside_count].material = mesh_merge.faces[i].material_idx;
 				inside_count++;
 			}
 
@@ -1489,19 +1489,19 @@ void CSGBrushOperation::merge_brushes(Operation p_operation, const CSGBrush &p_A
 					continue;
 
 				for (int j = 0; j < 3; j++) {
-					result.faces[face_count].vertices[j] = mesh_merge.points[mesh_merge.faces[i].points[j]];
-					result.faces[face_count].uvs[j] = mesh_merge.faces[i].uvs[j];
+					result.faces.write[face_count].vertices[j] = mesh_merge.points[mesh_merge.faces[i].points[j]];
+					result.faces.write[face_count].uvs[j] = mesh_merge.faces[i].uvs[j];
 				}
 
 				if (mesh_merge.faces[i].from_b) {
 					//invert facing of insides of B
-					SWAP(result.faces[face_count].vertices[1], result.faces[face_count].vertices[2]);
-					SWAP(result.faces[face_count].uvs[1], result.faces[face_count].uvs[2]);
+					SWAP(result.faces.write[face_count].vertices[1], result.faces.write[face_count].vertices[2]);
+					SWAP(result.faces.write[face_count].uvs[1], result.faces.write[face_count].uvs[2]);
 				}
 
-				result.faces[face_count].smooth = mesh_merge.faces[i].smooth;
-				result.faces[face_count].invert = mesh_merge.faces[i].invert;
-				result.faces[face_count].material = mesh_merge.faces[i].material_idx;
+				result.faces.write[face_count].smooth = mesh_merge.faces[i].smooth;
+				result.faces.write[face_count].invert = mesh_merge.faces[i].invert;
+				result.faces.write[face_count].material = mesh_merge.faces[i].material_idx;
 				face_count++;
 			}
 
@@ -1513,6 +1513,6 @@ void CSGBrushOperation::merge_brushes(Operation p_operation, const CSGBrush &p_A
 	//updatelist of materials
 	result.materials.resize(mesh_merge.materials.size());
 	for (const Map<Ref<Material>, int>::Element *E = mesh_merge.materials.front(); E; E = E->next()) {
-		result.materials[E->get()] = E->key();
+		result.materials.write[E->get()] = E->key();
 	}
 }

--- a/modules/csg/csg_gizmos.cpp
+++ b/modules/csg/csg_gizmos.cpp
@@ -278,8 +278,8 @@ void CSGShapeSpatialGizmo::redraw() {
 			int f = i / 6;
 			for (int j = 0; j < 3; j++) {
 				int j_n = (j + 1) % 3;
-				lines[i + j * 2 + 0] = r[f * 3 + j];
-				lines[i + j * 2 + 1] = r[f * 3 + j_n];
+				lines.write[i + j * 2 + 0] = r[f * 3 + j];
+				lines.write[i + j * 2 + 1] = r[f * 3 + j_n];
 			}
 		}
 	}

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -177,7 +177,7 @@ void CSGShape::_update_shape() {
 	Vector<int> face_count;
 	face_count.resize(n->materials.size() + 1);
 	for (int i = 0; i < face_count.size(); i++) {
-		face_count[i] = 0;
+		face_count.write[i] = 0;
 	}
 
 	for (int i = 0; i < n->faces.size(); i++) {
@@ -200,7 +200,7 @@ void CSGShape::_update_shape() {
 			}
 		}
 
-		face_count[idx]++;
+		face_count.write[idx]++;
 	}
 
 	Vector<ShapeUpdateSurface> surfaces;
@@ -210,18 +210,18 @@ void CSGShape::_update_shape() {
 	//create arrays
 	for (int i = 0; i < surfaces.size(); i++) {
 
-		surfaces[i].vertices.resize(face_count[i] * 3);
-		surfaces[i].normals.resize(face_count[i] * 3);
-		surfaces[i].uvs.resize(face_count[i] * 3);
-		surfaces[i].last_added = 0;
+		surfaces.write[i].vertices.resize(face_count[i] * 3);
+		surfaces.write[i].normals.resize(face_count[i] * 3);
+		surfaces.write[i].uvs.resize(face_count[i] * 3);
+		surfaces.write[i].last_added = 0;
 
 		if (i != surfaces.size() - 1) {
-			surfaces[i].material = n->materials[i];
+			surfaces.write[i].material = n->materials[i];
 		}
 
-		surfaces[i].verticesw = surfaces[i].vertices.write();
-		surfaces[i].normalsw = surfaces[i].normals.write();
-		surfaces[i].uvsw = surfaces[i].uvs.write();
+		surfaces.write[i].verticesw = surfaces.write[i].vertices.write();
+		surfaces.write[i].normalsw = surfaces.write[i].normals.write();
+		surfaces.write[i].uvsw = surfaces.write[i].uvs.write();
 	}
 
 	//fill arrays
@@ -281,7 +281,7 @@ void CSGShape::_update_shape() {
 				surfaces[idx].normalsw[last + order[j]] = normal;
 			}
 
-			surfaces[idx].last_added += 3;
+			surfaces.write[idx].last_added += 3;
 		}
 	}
 
@@ -290,9 +290,9 @@ void CSGShape::_update_shape() {
 
 	for (int i = 0; i < surfaces.size(); i++) {
 
-		surfaces[i].verticesw = PoolVector<Vector3>::Write();
-		surfaces[i].normalsw = PoolVector<Vector3>::Write();
-		surfaces[i].uvsw = PoolVector<Vector2>::Write();
+		surfaces.write[i].verticesw = PoolVector<Vector3>::Write();
+		surfaces.write[i].normalsw = PoolVector<Vector3>::Write();
+		surfaces.write[i].uvsw = PoolVector<Vector2>::Write();
 
 		if (surfaces[i].last_added == 0)
 			continue;

--- a/modules/enet/networked_multiplayer_enet.cpp
+++ b/modules/enet/networked_multiplayer_enet.cpp
@@ -666,7 +666,7 @@ size_t NetworkedMultiplayerENet::enet_compress(void *context, const ENetBuffer *
 	while (total) {
 		for (size_t i = 0; i < inBufferCount; i++) {
 			int to_copy = MIN(total, int(inBuffers[i].dataLength));
-			copymem(&enet->src_compressor_mem[ofs], inBuffers[i].data, to_copy);
+			copymem(&enet->src_compressor_mem.write[ofs], inBuffers[i].data, to_copy);
 			ofs += to_copy;
 			total -= to_copy;
 		}

--- a/modules/gdnative/arvr/arvr_interface_gdnative.cpp
+++ b/modules/gdnative/arvr/arvr_interface_gdnative.cpp
@@ -125,7 +125,7 @@ bool ARVRInterfaceGDNative::is_stereo() {
 	return stereo;
 }
 
-bool ARVRInterfaceGDNative::is_initialized() {
+bool ARVRInterfaceGDNative::is_initialized() const {
 	bool initialized;
 
 	ERR_FAIL_COND_V(interface == NULL, false);

--- a/modules/gdnative/arvr/arvr_interface_gdnative.h
+++ b/modules/gdnative/arvr/arvr_interface_gdnative.h
@@ -59,7 +59,7 @@ public:
 	virtual StringName get_name() const;
 	virtual int get_capabilities() const;
 
-	virtual bool is_initialized();
+	virtual bool is_initialized() const;
 	virtual bool initialize();
 	virtual void uninitialize();
 

--- a/modules/gdnative/gdnative.cpp
+++ b/modules/gdnative/gdnative.cpp
@@ -277,7 +277,7 @@ void GDNative::set_library(Ref<GDNativeLibrary> p_library) {
 	library = p_library;
 }
 
-Ref<GDNativeLibrary> GDNative::get_library() {
+Ref<GDNativeLibrary> GDNative::get_library() const {
 	return library;
 }
 
@@ -373,7 +373,7 @@ bool GDNative::initialize() {
 	if (library->should_load_once() && !GDNativeLibrary::loaded_libraries->has(lib_path)) {
 		Vector<Ref<GDNative> > gdnatives;
 		gdnatives.resize(1);
-		gdnatives[0] = Ref<GDNative>(this);
+		gdnatives.write[0] = Ref<GDNative>(this);
 		GDNativeLibrary::loaded_libraries->insert(lib_path, gdnatives);
 	}
 
@@ -428,7 +428,7 @@ bool GDNative::terminate() {
 	return true;
 }
 
-bool GDNative::is_initialized() {
+bool GDNative::is_initialized() const {
 	return initialized;
 }
 
@@ -442,7 +442,7 @@ Vector<StringName> GDNativeCallRegistry::get_native_call_types() {
 
 	size_t idx = 0;
 	for (Map<StringName, native_call_cb>::Element *E = native_calls.front(); E; E = E->next(), idx++) {
-		call_types[idx] = E->key();
+		call_types.write[idx] = E->key();
 	}
 
 	return call_types;
@@ -474,7 +474,7 @@ Variant GDNative::call_native(StringName p_native_call_type, StringName p_proced
 	return res;
 }
 
-Error GDNative::get_symbol(StringName p_procedure_name, void *&r_handle, bool p_optional) {
+Error GDNative::get_symbol(StringName p_procedure_name, void *&r_handle, bool p_optional) const {
 
 	if (!initialized) {
 		ERR_PRINT("No valid library handle, can't get symbol from GDNative object");

--- a/modules/gdnative/gdnative.h
+++ b/modules/gdnative/gdnative.h
@@ -148,16 +148,16 @@ public:
 	static void _bind_methods();
 
 	void set_library(Ref<GDNativeLibrary> p_library);
-	Ref<GDNativeLibrary> get_library();
+	Ref<GDNativeLibrary> get_library() const;
 
-	bool is_initialized();
+	bool is_initialized() const;
 
 	bool initialize();
 	bool terminate();
 
 	Variant call_native(StringName p_native_call_type, StringName p_procedure_name, Array p_arguments = Array());
 
-	Error get_symbol(StringName p_procedure_name, void *&r_handle, bool p_optional = true);
+	Error get_symbol(StringName p_procedure_name, void *&r_handle, bool p_optional = true) const;
 };
 
 class GDNativeLibraryResourceLoader : public ResourceFormatLoader {

--- a/modules/gdnative/gdnative/string.cpp
+++ b/modules/gdnative/gdnative/string.cpp
@@ -207,7 +207,7 @@ godot_int GDAPI godot_string_findmk(const godot_string *p_self, const godot_arra
 	Array *keys_proxy = (Array *)p_keys;
 	keys.resize(keys_proxy->size());
 	for (int i = 0; i < keys_proxy->size(); i++) {
-		keys[i] = (*keys_proxy)[i];
+		keys.write[i] = (*keys_proxy)[i];
 	}
 
 	return self->findmk(keys);
@@ -220,7 +220,7 @@ godot_int GDAPI godot_string_findmk_from(const godot_string *p_self, const godot
 	Array *keys_proxy = (Array *)p_keys;
 	keys.resize(keys_proxy->size());
 	for (int i = 0; i < keys_proxy->size(); i++) {
-		keys[i] = (*keys_proxy)[i];
+		keys.write[i] = (*keys_proxy)[i];
 	}
 
 	return self->findmk(keys, p_from);
@@ -233,7 +233,7 @@ godot_int GDAPI godot_string_findmk_from_in_place(const godot_string *p_self, co
 	Array *keys_proxy = (Array *)p_keys;
 	keys.resize(keys_proxy->size());
 	for (int i = 0; i < keys_proxy->size(); i++) {
-		keys[i] = (*keys_proxy)[i];
+		keys.write[i] = (*keys_proxy)[i];
 	}
 
 	return self->findmk(keys, p_from, r_key);
@@ -696,7 +696,7 @@ godot_array GDAPI godot_string_split_floats_mk(const godot_string *p_self, const
 	Array *splitter_proxy = (Array *)p_splitters;
 	splitters.resize(splitter_proxy->size());
 	for (int i = 0; i < splitter_proxy->size(); i++) {
-		splitters[i] = (*splitter_proxy)[i];
+		splitters.write[i] = (*splitter_proxy)[i];
 	}
 
 	godot_array result;
@@ -719,7 +719,7 @@ godot_array GDAPI godot_string_split_floats_mk_allows_empty(const godot_string *
 	Array *splitter_proxy = (Array *)p_splitters;
 	splitters.resize(splitter_proxy->size());
 	for (int i = 0; i < splitter_proxy->size(); i++) {
-		splitters[i] = (*splitter_proxy)[i];
+		splitters.write[i] = (*splitter_proxy)[i];
 	}
 
 	godot_array result;
@@ -774,7 +774,7 @@ godot_array GDAPI godot_string_split_ints_mk(const godot_string *p_self, const g
 	Array *splitter_proxy = (Array *)p_splitters;
 	splitters.resize(splitter_proxy->size());
 	for (int i = 0; i < splitter_proxy->size(); i++) {
-		splitters[i] = (*splitter_proxy)[i];
+		splitters.write[i] = (*splitter_proxy)[i];
 	}
 
 	godot_array result;
@@ -797,7 +797,7 @@ godot_array GDAPI godot_string_split_ints_mk_allows_empty(const godot_string *p_
 	Array *splitter_proxy = (Array *)p_splitters;
 	splitters.resize(splitter_proxy->size());
 	for (int i = 0; i < splitter_proxy->size(); i++) {
-		splitters[i] = (*splitter_proxy)[i];
+		splitters.write[i] = (*splitter_proxy)[i];
 	}
 
 	godot_array result;

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -1157,8 +1157,8 @@ int NativeScriptLanguage::register_binding_functions(godot_instance_binding_func
 	}
 
 	// set the functions
-	binding_functions[idx].first = true;
-	binding_functions[idx].second = p_binding_functions;
+	binding_functions.write[idx].first = true;
+	binding_functions.write[idx].second = p_binding_functions;
 
 	return idx;
 }
@@ -1173,7 +1173,7 @@ void NativeScriptLanguage::unregister_binding_functions(int p_idx) {
 			binding_functions[p_idx].second.free_instance_binding_data(binding_functions[p_idx].second.data, binding_data[p_idx]);
 	}
 
-	binding_functions[p_idx].first = false;
+	binding_functions.write[p_idx].first = false;
 
 	if (binding_functions[p_idx].second.free_func)
 		binding_functions[p_idx].second.free_func(binding_functions[p_idx].second.data);
@@ -1199,7 +1199,7 @@ void *NativeScriptLanguage::get_instance_binding_data(int p_idx, Object *p_objec
 		binding_data->resize(p_idx + 1);
 
 		for (int i = old_size; i <= p_idx; i++) {
-			(*binding_data)[i] = NULL;
+			(*binding_data).write[i] = NULL;
 		}
 	}
 
@@ -1208,7 +1208,7 @@ void *NativeScriptLanguage::get_instance_binding_data(int p_idx, Object *p_objec
 		const void *global_type_tag = global_type_tags[p_idx].get(p_object->get_class_name());
 
 		// no binding data yet, soooooo alloc new one \o/
-		(*binding_data)[p_idx] = binding_functions[p_idx].second.alloc_instance_binding_data(binding_functions[p_idx].second.data, global_type_tag, (godot_object *)p_object);
+		(*binding_data).write[p_idx] = binding_functions[p_idx].second.alloc_instance_binding_data(binding_functions[p_idx].second.data, global_type_tag, (godot_object *)p_object);
 	}
 
 	return (*binding_data)[p_idx];
@@ -1221,7 +1221,7 @@ void *NativeScriptLanguage::alloc_instance_binding_data(Object *p_object) {
 	binding_data->resize(binding_functions.size());
 
 	for (int i = 0; i < binding_functions.size(); i++) {
-		(*binding_data)[i] = NULL;
+		(*binding_data).write[i] = NULL;
 	}
 
 	binding_instances.insert(binding_data);

--- a/modules/gdnative/register_types.cpp
+++ b/modules/gdnative/register_types.cpp
@@ -341,10 +341,10 @@ void register_gdnative_types() {
 
 		Ref<GDNativeLibrary> lib = ResourceLoader::load(path);
 
-		singleton_gdnatives[i].instance();
-		singleton_gdnatives[i]->set_library(lib);
+		singleton_gdnatives.write[i].instance();
+		singleton_gdnatives.write[i]->set_library(lib);
 
-		if (!singleton_gdnatives[i]->initialize()) {
+		if (!singleton_gdnatives.write[i]->initialize()) {
 			// Can't initialize. Don't make a native_call then
 			continue;
 		}
@@ -374,7 +374,7 @@ void unregister_gdnative_types() {
 			continue;
 		}
 
-		singleton_gdnatives[i]->terminate();
+		singleton_gdnatives.write[i]->terminate();
 	}
 	singleton_gdnatives.clear();
 

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -730,7 +730,7 @@ Error GDScript::load_byte_code(const String &p_path) {
 		Vector<uint8_t> key;
 		key.resize(32);
 		for (int i = 0; i < key.size(); i++) {
-			key[i] = script_encryption_key[i];
+			key.write[i] = script_encryption_key[i];
 		}
 		Error err = fae->open_and_parse(fa, key, FileAccessEncrypted::MODE_READ);
 		ERR_FAIL_COND_V(err, err);
@@ -941,7 +941,7 @@ bool GDScriptInstance::set(const StringName &p_name, const Variant &p_value) {
 				if (!E->get().data_type.is_type(p_value)) {
 					return false; // Type mismatch
 				}
-				members[E->get().index] = p_value;
+				members.write[E->get().index] = p_value;
 			}
 			return true;
 		}
@@ -1270,7 +1270,7 @@ void GDScriptInstance::reload_members() {
 
 		if (member_indices_cache.has(E->key())) {
 			Variant value = members[member_indices_cache[E->key()]];
-			new_members[E->get().index] = value;
+			new_members.write[E->get().index] = value;
 		}
 	}
 
@@ -1320,7 +1320,7 @@ void GDScriptLanguage::_add_global(const StringName &p_name, const Variant &p_va
 
 	if (globals.has(p_name)) {
 		//overwrite existing
-		global_array[globals[p_name]] = p_value;
+		global_array.write[globals[p_name]] = p_value;
 		return;
 	}
 	globals[p_name] = global_array.size();

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -355,10 +355,10 @@ public:
 		Vector<StackInfo> csi;
 		csi.resize(_debug_call_stack_pos);
 		for (int i = 0; i < _debug_call_stack_pos; i++) {
-			csi[_debug_call_stack_pos - i - 1].line = _call_stack[i].line ? *_call_stack[i].line : 0;
+			csi.write[_debug_call_stack_pos - i - 1].line = _call_stack[i].line ? *_call_stack[i].line : 0;
 			if (_call_stack[i].function)
-				csi[_debug_call_stack_pos - i - 1].func = _call_stack[i].function->get_name();
-			csi[_debug_call_stack_pos - i - 1].file = _call_stack[i].function->get_script()->get_path();
+				csi.write[_debug_call_stack_pos - i - 1].func = _call_stack[i].function->get_name();
+			csi.write[_debug_call_stack_pos - i - 1].file = _call_stack[i].function->get_script()->get_path();
 		}
 		return csi;
 	}

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -785,8 +785,8 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 					codegen.opcodes.push_back(p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
 					codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
 					codegen.opcodes.push_back(codegen.opcodes.size() + 3);
-					codegen.opcodes[jump_fail_pos] = codegen.opcodes.size();
-					codegen.opcodes[jump_fail_pos2] = codegen.opcodes.size();
+					codegen.opcodes.write[jump_fail_pos] = codegen.opcodes.size();
+					codegen.opcodes.write[jump_fail_pos2] = codegen.opcodes.size();
 					codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN_FALSE);
 					codegen.opcodes.push_back(p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
 					return p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS;
@@ -818,8 +818,8 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 					codegen.opcodes.push_back(p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
 					codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
 					codegen.opcodes.push_back(codegen.opcodes.size() + 3);
-					codegen.opcodes[jump_success_pos] = codegen.opcodes.size();
-					codegen.opcodes[jump_success_pos2] = codegen.opcodes.size();
+					codegen.opcodes.write[jump_success_pos] = codegen.opcodes.size();
+					codegen.opcodes.write[jump_success_pos2] = codegen.opcodes.size();
 					codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN_TRUE);
 					codegen.opcodes.push_back(p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
 					return p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS;
@@ -850,7 +850,7 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 					int jump_past_pos = codegen.opcodes.size();
 					codegen.opcodes.push_back(0);
 
-					codegen.opcodes[jump_fail_pos] = codegen.opcodes.size();
+					codegen.opcodes.write[jump_fail_pos] = codegen.opcodes.size();
 					res = _parse_expression(codegen, on->arguments[2], p_stack_level);
 					if (res < 0)
 						return res;
@@ -859,7 +859,7 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 					codegen.opcodes.push_back(p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
 					codegen.opcodes.push_back(res);
 
-					codegen.opcodes[jump_past_pos] = codegen.opcodes.size();
+					codegen.opcodes.write[jump_past_pos] = codegen.opcodes.size();
 
 					return p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS;
 
@@ -1361,10 +1361,10 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Blo
 							codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
 							codegen.opcodes.push_back(break_addr);
 
-							codegen.opcodes[continue_addr + 1] = codegen.opcodes.size();
+							codegen.opcodes.write[continue_addr + 1] = codegen.opcodes.size();
 						}
 
-						codegen.opcodes[break_addr + 1] = codegen.opcodes.size();
+						codegen.opcodes.write[break_addr + 1] = codegen.opcodes.size();
 
 					} break;
 
@@ -1393,16 +1393,16 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Blo
 							codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
 							int end_addr = codegen.opcodes.size();
 							codegen.opcodes.push_back(0);
-							codegen.opcodes[else_addr] = codegen.opcodes.size();
+							codegen.opcodes.write[else_addr] = codegen.opcodes.size();
 
 							Error err = _parse_block(codegen, cf->body_else, p_stack_level, p_break_addr, p_continue_addr);
 							if (err)
 								return err;
 
-							codegen.opcodes[end_addr] = codegen.opcodes.size();
+							codegen.opcodes.write[end_addr] = codegen.opcodes.size();
 						} else {
 							//end without else
-							codegen.opcodes[else_addr] = codegen.opcodes.size();
+							codegen.opcodes.write[else_addr] = codegen.opcodes.size();
 						}
 
 					} break;
@@ -1453,7 +1453,7 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Blo
 
 						codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
 						codegen.opcodes.push_back(continue_pos);
-						codegen.opcodes[break_pos + 1] = codegen.opcodes.size();
+						codegen.opcodes.write[break_pos + 1] = codegen.opcodes.size();
 
 						codegen.pop_stack_identifiers();
 
@@ -1479,7 +1479,7 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Blo
 						codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
 						codegen.opcodes.push_back(continue_addr);
 
-						codegen.opcodes[break_addr + 1] = codegen.opcodes.size();
+						codegen.opcodes.write[break_addr + 1] = codegen.opcodes.size();
 
 					} break;
 					case GDScriptParser::ControlFlowNode::CF_SWITCH: {
@@ -1689,7 +1689,7 @@ Error GDScriptCompiler::_parse_function(GDScript *p_script, const GDScriptParser
 		gdfunc->rpc_mode = p_func->rpc_mode;
 		gdfunc->argument_types.resize(p_func->argument_types.size());
 		for (int i = 0; i < p_func->argument_types.size(); i++) {
-			gdfunc->argument_types[i] = _gdtype_from_datatype(p_func->argument_types[i]);
+			gdfunc->argument_types.write[i] = _gdtype_from_datatype(p_func->argument_types[i]);
 		}
 		gdfunc->return_type = _gdtype_from_datatype(p_func->return_type);
 	} else {
@@ -1708,11 +1708,11 @@ Error GDScriptCompiler::_parse_function(GDScript *p_script, const GDScriptParser
 	if (codegen.constant_map.size()) {
 		gdfunc->_constant_count = codegen.constant_map.size();
 		gdfunc->constants.resize(codegen.constant_map.size());
-		gdfunc->_constants_ptr = &gdfunc->constants[0];
+		gdfunc->_constants_ptr = gdfunc->constants.ptrw();
 		const Variant *K = NULL;
 		while ((K = codegen.constant_map.next(K))) {
 			int idx = codegen.constant_map[*K];
-			gdfunc->constants[idx] = *K;
+			gdfunc->constants.write[idx] = *K;
 		}
 	} else {
 
@@ -1726,7 +1726,7 @@ Error GDScriptCompiler::_parse_function(GDScript *p_script, const GDScriptParser
 		gdfunc->_global_names_ptr = &gdfunc->global_names[0];
 		for (Map<StringName, int>::Element *E = codegen.name_map.front(); E; E = E->next()) {
 
-			gdfunc->global_names[E->get()] = E->key();
+			gdfunc->global_names.write[E->get()] = E->key();
 		}
 		gdfunc->_global_names_count = gdfunc->global_names.size();
 
@@ -1741,7 +1741,7 @@ Error GDScriptCompiler::_parse_function(GDScript *p_script, const GDScriptParser
 		gdfunc->named_globals.resize(codegen.named_globals.size());
 		gdfunc->_named_globals_ptr = gdfunc->named_globals.ptr();
 		for (int i = 0; i < codegen.named_globals.size(); i++) {
-			gdfunc->named_globals[i] = codegen.named_globals[i];
+			gdfunc->named_globals.write[i] = codegen.named_globals[i];
 		}
 		gdfunc->_named_globals_count = gdfunc->named_globals.size();
 	}

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2918,7 +2918,7 @@ void GDScriptLanguage::auto_indent_code(String &p_code, int p_from_line, int p_t
 		}
 
 		//print_line(itos(indent_stack.size())+","+itos(tc)+": "+l);
-		lines[i] = l;
+		lines.write[i] = l;
 	}
 
 	p_code = "";

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -62,7 +62,7 @@ Variant *GDScriptFunction::_get_variant(int p_address, GDScriptInstance *p_insta
 			}
 #endif
 			//member indexing is O(1)
-			return &p_instance->members[address];
+			return &p_instance->members.write[address];
 		} break;
 		case ADDR_TYPE_CLASS_CONSTANT: {
 
@@ -1218,7 +1218,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				gdfs->state.stack.resize(alloca_size);
 				//copy variant stack
 				for (int i = 0; i < _stack_size; i++) {
-					memnew_placement(&gdfs->state.stack[sizeof(Variant) * i], Variant(stack[i]));
+					memnew_placement(&gdfs->state.stack.write[sizeof(Variant) * i], Variant(stack[i]));
 				}
 				gdfs->state.stack_size = _stack_size;
 				gdfs->state.self = self;

--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -1098,7 +1098,7 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 
 			for (Map<StringName, GDScript::MemberInfo>::Element *E = gd_ref->member_indices.front(); E; E = E->next()) {
 				if (d.has(E->key())) {
-					ins->members[E->get().index] = d[E->key()];
+					ins->members.write[E->get().index] = d[E->key()];
 				}
 			}
 

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -1172,15 +1172,15 @@ Error GDScriptTokenizerBuffer::set_code_buffer(const Vector<uint8_t> &p_buffer) 
 		Vector<uint8_t> cs;
 		cs.resize(len);
 		for (int j = 0; j < len; j++) {
-			cs[j] = b[j] ^ 0xb6;
+			cs.write[j] = b[j] ^ 0xb6;
 		}
 
-		cs[cs.size() - 1] = 0;
+		cs.write[cs.size() - 1] = 0;
 		String s;
 		s.parse_utf8((const char *)cs.ptr());
 		b += len;
 		total_len -= len + 4;
-		identifiers[i] = s;
+		identifiers.write[i] = s;
 	}
 
 	constants.resize(constant_count);
@@ -1193,7 +1193,7 @@ Error GDScriptTokenizerBuffer::set_code_buffer(const Vector<uint8_t> &p_buffer) 
 			return err;
 		b += len;
 		total_len -= len;
-		constants[i] = v;
+		constants.write[i] = v;
 	}
 
 	ERR_FAIL_COND_V(line_count * 8 > total_len, ERR_INVALID_DATA);
@@ -1218,10 +1218,10 @@ Error GDScriptTokenizerBuffer::set_code_buffer(const Vector<uint8_t> &p_buffer) 
 		if ((*b) & TOKEN_BYTE_MASK) { //little endian always
 			ERR_FAIL_COND_V(total_len < 4, ERR_INVALID_DATA);
 
-			tokens[i] = decode_uint32(b) & ~TOKEN_BYTE_MASK;
+			tokens.write[i] = decode_uint32(b) & ~TOKEN_BYTE_MASK;
 			b += 4;
 		} else {
-			tokens[i] = *b;
+			tokens.write[i] = *b;
 			b += 1;
 			total_len--;
 		}
@@ -1320,15 +1320,15 @@ Vector<uint8_t> GDScriptTokenizerBuffer::parse_code_string(const String &p_code)
 
 	//save header
 	buf.resize(24);
-	buf[0] = 'G';
-	buf[1] = 'D';
-	buf[2] = 'S';
-	buf[3] = 'C';
-	encode_uint32(BYTECODE_VERSION, &buf[4]);
-	encode_uint32(identifier_map.size(), &buf[8]);
-	encode_uint32(constant_map.size(), &buf[12]);
-	encode_uint32(line_map.size(), &buf[16]);
-	encode_uint32(token_array.size(), &buf[20]);
+	buf.write[0] = 'G';
+	buf.write[1] = 'D';
+	buf.write[2] = 'S';
+	buf.write[3] = 'C';
+	encode_uint32(BYTECODE_VERSION, &buf.write[4]);
+	encode_uint32(identifier_map.size(), &buf.write[8]);
+	encode_uint32(constant_map.size(), &buf.write[12]);
+	encode_uint32(line_map.size(), &buf.write[16]);
+	encode_uint32(token_array.size(), &buf.write[20]);
 
 	//save identifiers
 
@@ -1360,7 +1360,7 @@ Vector<uint8_t> GDScriptTokenizerBuffer::parse_code_string(const String &p_code)
 		ERR_FAIL_COND_V(err != OK, Vector<uint8_t>());
 		int pos = buf.size();
 		buf.resize(pos + len);
-		encode_variant(E->get(), &buf[pos], len);
+		encode_variant(E->get(), &buf.write[pos], len);
 	}
 
 	for (Map<int, uint32_t>::Element *E = rev_line_map.front(); E; E = E->next()) {

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -508,7 +508,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 				continue;
 			PhysicsServer::get_singleton()->body_add_shape(g.static_body, shapes[i].shape->get_rid(), xform * shapes[i].local_transform);
 			if (g.collision_debug.is_valid()) {
-				shapes[i].shape->add_vertices_to_array(col_debug, xform * shapes[i].local_transform);
+				shapes.write[i].shape->add_vertices_to_array(col_debug, xform * shapes[i].local_transform);
 			}
 
 			//print_line("PHIS x: "+xform);
@@ -758,7 +758,7 @@ void GridMap::_update_visibility() {
 	for (Map<OctantKey, Octant *>::Element *e = octant_map.front(); e; e = e->next()) {
 		Octant *octant = e->value();
 		for (int i = 0; i < octant->multimesh_instances.size(); i++) {
-			Octant::MultimeshInstance &mi = octant->multimesh_instances[i];
+			const Octant::MultimeshInstance &mi = octant->multimesh_instances[i];
 			VS::get_singleton()->instance_set_visible(mi.instance, is_visible());
 		}
 	}

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -523,7 +523,7 @@ Vector<ScriptLanguage::StackInfo> CSharpLanguage::stack_trace_get_info(MonoObjec
 	si.resize(frame_count);
 
 	for (int i = 0; i < frame_count; i++) {
-		StackInfo &sif = si[i];
+		StackInfo &sif = si.write[i];
 		MonoObject *frame = mono_array_get(frames, MonoObject *, i);
 
 		MonoString *file_name;

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -1650,7 +1650,7 @@ Error BindingsGenerator::_generate_glue_method(const BindingsGenerator::TypeInte
 								   "\t\tvarargs.set(i, GDMonoMarshal::mono_object_to_variant(elem));\n"
 								   "\t\t" C_LOCAL_PTRCALL_ARGS ".set(");
 				p_output.push_back(real_argc_str);
-				p_output.push_back(" + i, &varargs[i]);\n\t" CLOSE_BLOCK);
+				p_output.push_back(" + i, &varargs.write[i]);\n\t" CLOSE_BLOCK);
 			} else {
 				p_output.push_back(c_in_statements);
 				p_output.push_back("\tconst void* " C_LOCAL_PTRCALL_ARGS "[");

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -77,12 +77,12 @@ void setup_runtime_main_args() {
 	Vector<char *> main_args;
 	main_args.resize(cmdline_args.size() + 1);
 
-	main_args[0] = execpath.ptrw();
+	main_args.write[0] = execpath.ptrw();
 
 	int i = 1;
 	for (List<String>::Element *E = cmdline_args.front(); E; E = E->next()) {
 		CharString &stored = cmdline_args_utf8.push_back(E->get().utf8())->get();
-		main_args[i] = stored.ptrw();
+		main_args.write[i] = stored.ptrw();
 		i++;
 	}
 

--- a/modules/mono/mono_gd/gd_mono_class.cpp
+++ b/modules/mono/mono_gd/gd_mono_class.cpp
@@ -503,7 +503,7 @@ GDMonoClass::~GDMonoClass() {
 					}
 				}
 
-				deleted_methods[offset] = method;
+				deleted_methods.write[offset] = method;
 				++offset;
 
 				memdelete(method);

--- a/modules/recast/navigation_mesh_generator.cpp
+++ b/modules/recast/navigation_mesh_generator.cpp
@@ -126,9 +126,9 @@ void NavigationMeshGenerator::_convert_detail_mesh_to_native_navigation_mesh(con
 		for (unsigned int j = 0; j < ntris; j++) {
 			Vector<int> nav_indices;
 			nav_indices.resize(3);
-			nav_indices[0] = ((int)(bverts + tris[j * 4 + 0]));
-			nav_indices[1] = ((int)(bverts + tris[j * 4 + 1]));
-			nav_indices[2] = ((int)(bverts + tris[j * 4 + 2]));
+			nav_indices.write[0] = ((int)(bverts + tris[j * 4 + 0]));
+			nav_indices.write[1] = ((int)(bverts + tris[j * 4 + 1]));
+			nav_indices.write[2] = ((int)(bverts + tris[j * 4 + 2]));
 			p_nav_mesh->add_polygon(nav_indices);
 		}
 	}

--- a/modules/regex/regex.cpp
+++ b/modules/regex/regex.cpp
@@ -265,8 +265,8 @@ Ref<RegExMatch> RegEx::search(const String &p_subject, int p_offset, int p_end) 
 
 		for (uint32_t i = 0; i < size; i++) {
 
-			result->data[i].start = ovector[i * 2];
-			result->data[i].end = ovector[i * 2 + 1];
+			result->data.write[i].start = ovector[i * 2];
+			result->data.write[i].end = ovector[i * 2 + 1];
 		}
 
 		pcre2_match_data_free_16(match);
@@ -295,8 +295,8 @@ Ref<RegExMatch> RegEx::search(const String &p_subject, int p_offset, int p_end) 
 
 		for (uint32_t i = 0; i < size; i++) {
 
-			result->data[i].start = ovector[i * 2];
-			result->data[i].end = ovector[i * 2 + 1];
+			result->data.write[i].start = ovector[i * 2];
+			result->data.write[i].end = ovector[i * 2 + 1];
 		}
 
 		pcre2_match_data_free_32(match);

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -771,7 +771,7 @@ void VisualScript::custom_signal_set_argument_type(const StringName &p_func, int
 	ERR_FAIL_COND(instances.size());
 	ERR_FAIL_COND(!custom_signals.has(p_func));
 	ERR_FAIL_INDEX(p_argidx, custom_signals[p_func].size());
-	custom_signals[p_func][p_argidx].type = p_type;
+	custom_signals[p_func].write[p_argidx].type = p_type;
 }
 Variant::Type VisualScript::custom_signal_get_argument_type(const StringName &p_func, int p_argidx) const {
 
@@ -783,7 +783,7 @@ void VisualScript::custom_signal_set_argument_name(const StringName &p_func, int
 	ERR_FAIL_COND(instances.size());
 	ERR_FAIL_COND(!custom_signals.has(p_func));
 	ERR_FAIL_INDEX(p_argidx, custom_signals[p_func].size());
-	custom_signals[p_func][p_argidx].name = p_name;
+	custom_signals[p_func].write[p_argidx].name = p_name;
 }
 String VisualScript::custom_signal_get_argument_name(const StringName &p_func, int p_argidx) const {
 
@@ -811,7 +811,7 @@ void VisualScript::custom_signal_swap_argument(const StringName &p_func, int p_a
 	ERR_FAIL_INDEX(p_argidx, custom_signals[p_func].size());
 	ERR_FAIL_INDEX(p_with_argidx, custom_signals[p_func].size());
 
-	SWAP(custom_signals[p_func][p_argidx], custom_signals[p_func][p_with_argidx]);
+	SWAP(custom_signals[p_func].write[p_argidx], custom_signals[p_func].write[p_with_argidx]);
 }
 void VisualScript::remove_custom_signal(const StringName &p_name) {
 

--- a/modules/visual_script/visual_script_expression.cpp
+++ b/modules/visual_script/visual_script_expression.cpp
@@ -56,11 +56,11 @@ bool VisualScriptExpression::_set(const StringName &p_name, const Variant &p_val
 		int from = inputs.size();
 		inputs.resize(int(p_value));
 		for (int i = from; i < inputs.size(); i++) {
-			inputs[i].name = String::chr('a' + i);
+			inputs.write[i].name = String::chr('a' + i);
 			if (from == 0) {
-				inputs[i].type = output_type;
+				inputs.write[i].type = output_type;
 			} else {
-				inputs[i].type = inputs[from - 1].type;
+				inputs.write[i].type = inputs[from - 1].type;
 			}
 		}
 		expression_dirty = true;
@@ -78,10 +78,10 @@ bool VisualScriptExpression::_set(const StringName &p_name, const Variant &p_val
 
 		if (what == "type") {
 
-			inputs[idx].type = Variant::Type(int(p_value));
+			inputs.write[idx].type = Variant::Type(int(p_value));
 		} else if (what == "name") {
 
-			inputs[idx].name = p_value;
+			inputs.write[idx].name = p_value;
 		} else {
 			return false;
 		}
@@ -1153,8 +1153,8 @@ VisualScriptExpression::ENode *VisualScriptExpression::_parse_expression() {
 				op->op = expression[i].op;
 				op->nodes[0] = expression[i + 1].node;
 				op->nodes[1] = NULL;
-				expression[i].is_op = false;
-				expression[i].node = op;
+				expression.write[i].is_op = false;
+				expression.write[i].node = op;
 				expression.remove(i + 1);
 			}
 
@@ -1188,7 +1188,7 @@ VisualScriptExpression::ENode *VisualScriptExpression::_parse_expression() {
 			op->nodes[1] = expression[next_op + 1].node; //next expression goes as right
 
 			//replace all 3 nodes by this operator and make it an expression
-			expression[next_op - 1].node = op;
+			expression.write[next_op - 1].node = op;
 			expression.remove(next_op);
 			expression.remove(next_op);
 		}
@@ -1370,8 +1370,8 @@ public:
 					bool ret = _execute(p_inputs, constructor->arguments[i], value, r_error_str, ce);
 					if (ret)
 						return true;
-					arr[i] = value;
-					argp[i] = &arr[i];
+					arr.write[i] = value;
+					argp.write[i] = &arr[i];
 				}
 
 				r_ret = Variant::construct(constructor->data_type, (const Variant **)argp.ptr(), argp.size(), ce);
@@ -1397,8 +1397,8 @@ public:
 					bool ret = _execute(p_inputs, bifunc->arguments[i], value, r_error_str, ce);
 					if (ret)
 						return true;
-					arr[i] = value;
-					argp[i] = &arr[i];
+					arr.write[i] = value;
+					argp.write[i] = &arr[i];
 				}
 
 				VisualScriptBuiltinFunc::exec_func(bifunc->func, (const Variant **)argp.ptr(), &r_ret, ce, r_error_str);
@@ -1429,8 +1429,8 @@ public:
 					bool ret = _execute(p_inputs, call->arguments[i], value, r_error_str, ce);
 					if (ret)
 						return true;
-					arr[i] = value;
-					argp[i] = &arr[i];
+					arr.write[i] = value;
+					argp.write[i] = &arr[i];
 				}
 
 				r_ret = base.call(call->method, (const Variant **)argp.ptr(), argp.size(), ce);

--- a/modules/visual_script/visual_script_flow_control.cpp
+++ b/modules/visual_script/visual_script_flow_control.cpp
@@ -684,7 +684,7 @@ bool VisualScriptSwitch::_set(const StringName &p_name, const Variant &p_value) 
 		int idx = String(p_name).get_slice("/", 1).to_int();
 		ERR_FAIL_INDEX_V(idx, case_values.size(), false);
 
-		case_values[idx].type = Variant::Type(int(p_value));
+		case_values.write[idx].type = Variant::Type(int(p_value));
 		_change_notify();
 		ports_changed_notify();
 

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -54,8 +54,8 @@ bool VisualScriptFunction::_set(const StringName &p_name, const Variant &p_value
 		arguments.resize(new_argc);
 
 		for (int i = argc; i < new_argc; i++) {
-			arguments[i].name = "arg" + itos(i + 1);
-			arguments[i].type = Variant::NIL;
+			arguments.write[i].name = "arg" + itos(i + 1);
+			arguments.write[i].type = Variant::NIL;
 		}
 		ports_changed_notify();
 		_change_notify();
@@ -68,7 +68,7 @@ bool VisualScriptFunction::_set(const StringName &p_name, const Variant &p_value
 		if (what == "type") {
 
 			Variant::Type new_type = Variant::Type(int(p_value));
-			arguments[idx].type = new_type;
+			arguments.write[idx].type = new_type;
 			ports_changed_notify();
 
 			return true;
@@ -76,7 +76,7 @@ bool VisualScriptFunction::_set(const StringName &p_name, const Variant &p_value
 
 		if (what == "name") {
 
-			arguments[idx].name = p_value;
+			arguments.write[idx].name = p_value;
 			ports_changed_notify();
 			return true;
 		}
@@ -234,7 +234,7 @@ void VisualScriptFunction::set_argument_type(int p_argidx, Variant::Type p_type)
 
 	ERR_FAIL_INDEX(p_argidx, arguments.size());
 
-	arguments[p_argidx].type = p_type;
+	arguments.write[p_argidx].type = p_type;
 	ports_changed_notify();
 }
 Variant::Type VisualScriptFunction::get_argument_type(int p_argidx) const {
@@ -246,7 +246,7 @@ void VisualScriptFunction::set_argument_name(int p_argidx, const String &p_name)
 
 	ERR_FAIL_INDEX(p_argidx, arguments.size());
 
-	arguments[p_argidx].name = p_name;
+	arguments.write[p_argidx].name = p_name;
 	ports_changed_notify();
 }
 String VisualScriptFunction::get_argument_name(int p_argidx) const {
@@ -3560,8 +3560,8 @@ void VisualScriptDeconstruct::_set_elem_cache(const Array &p_elements) {
 	ERR_FAIL_COND(p_elements.size() % 2 == 1);
 	elements.resize(p_elements.size() / 2);
 	for (int i = 0; i < elements.size(); i++) {
-		elements[i].name = p_elements[i * 2 + 0];
-		elements[i].type = Variant::Type(int(p_elements[i * 2 + 1]));
+		elements.write[i].name = p_elements[i * 2 + 0];
+		elements.write[i].type = Variant::Type(int(p_elements[i * 2 + 1]));
 	}
 }
 
@@ -3606,7 +3606,7 @@ VisualScriptNodeInstance *VisualScriptDeconstruct::instance(VisualScriptInstance
 	instance->instance = p_instance;
 	instance->outputs.resize(elements.size());
 	for (int i = 0; i < elements.size(); i++) {
-		instance->outputs[i] = elements[i].name;
+		instance->outputs.write[i] = elements[i].name;
 	}
 
 	return instance;

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -665,11 +665,11 @@ class EditorExportAndroid : public EditorExportPlatform {
 							ucstring.resize(len + 1);
 							for (uint32_t j = 0; j < len; j++) {
 								uint16_t c = decode_uint16(&p_manifest[string_at + 2 + 2 * j]);
-								ucstring[j] = c;
+								ucstring.write[j] = c;
 							}
 							string_end = MAX(string_at + 2 + 2 * len, string_end);
-							ucstring[len] = 0;
-							string_table[i] = ucstring.ptr();
+							ucstring.write[len] = 0;
+							string_table.write[i] = ucstring.ptr();
 						}
 
 						//print_line("String "+itos(i)+": "+string_table[i]);
@@ -716,13 +716,13 @@ class EditorExportAndroid : public EditorExportPlatform {
 						if (tname == "manifest" && attrname == "package") {
 
 							print_line("FOUND package");
-							string_table[attr_value] = get_package_name(package_name);
+							string_table.write[attr_value] = get_package_name(package_name);
 						}
 
 						if (tname == "manifest" && /*nspace=="android" &&*/ attrname == "versionCode") {
 
 							print_line("FOUND versionCode");
-							encode_uint32(version_code, &p_manifest[iofs + 16]);
+							encode_uint32(version_code, &p_manifest.write[iofs + 16]);
 						}
 
 						if (tname == "manifest" && /*nspace=="android" &&*/ attrname == "versionName") {
@@ -731,12 +731,12 @@ class EditorExportAndroid : public EditorExportPlatform {
 							if (attr_value == 0xFFFFFFFF) {
 								WARN_PRINT("Version name in a resource, should be plaintext")
 							} else
-								string_table[attr_value] = version_name;
+								string_table.write[attr_value] = version_name;
 						}
 
 						if (tname == "activity" && /*nspace=="android" &&*/ attrname == "screenOrientation") {
 
-							encode_uint32(orientation == 0 ? 0 : 1, &p_manifest[iofs + 16]);
+							encode_uint32(orientation == 0 ? 0 : 1, &p_manifest.write[iofs + 16]);
 						}
 
 						if (tname == "uses-feature" && /*nspace=="android" &&*/ attrname == "glEsVersion") {
@@ -747,19 +747,19 @@ class EditorExportAndroid : public EditorExportPlatform {
 
 							if (attrname == "smallScreens") {
 
-								encode_uint32(screen_support_small ? 0xFFFFFFFF : 0, &p_manifest[iofs + 16]);
+								encode_uint32(screen_support_small ? 0xFFFFFFFF : 0, &p_manifest.write[iofs + 16]);
 
 							} else if (attrname == "normalScreens") {
 
-								encode_uint32(screen_support_normal ? 0xFFFFFFFF : 0, &p_manifest[iofs + 16]);
+								encode_uint32(screen_support_normal ? 0xFFFFFFFF : 0, &p_manifest.write[iofs + 16]);
 
 							} else if (attrname == "largeScreens") {
 
-								encode_uint32(screen_support_large ? 0xFFFFFFFF : 0, &p_manifest[iofs + 16]);
+								encode_uint32(screen_support_large ? 0xFFFFFFFF : 0, &p_manifest.write[iofs + 16]);
 
 							} else if (attrname == "xlargeScreens") {
 
-								encode_uint32(screen_support_xlarge ? 0xFFFFFFFF : 0, &p_manifest[iofs + 16]);
+								encode_uint32(screen_support_xlarge ? 0xFFFFFFFF : 0, &p_manifest.write[iofs + 16]);
 							}
 						}
 
@@ -811,45 +811,45 @@ class EditorExportAndroid : public EditorExportPlatform {
 							}
 
 							// start tag
-							encode_uint16(0x102, &p_manifest[ofs]); // type
-							encode_uint16(16, &p_manifest[ofs + 2]); // headersize
-							encode_uint32(56, &p_manifest[ofs + 4]); // size
-							encode_uint32(0, &p_manifest[ofs + 8]); // lineno
-							encode_uint32(-1, &p_manifest[ofs + 12]); // comment
-							encode_uint32(-1, &p_manifest[ofs + 16]); // ns
-							encode_uint32(attr_uses_permission_string, &p_manifest[ofs + 20]); // name
-							encode_uint16(20, &p_manifest[ofs + 24]); // attr_start
-							encode_uint16(20, &p_manifest[ofs + 26]); // attr_size
-							encode_uint16(1, &p_manifest[ofs + 28]); // num_attrs
-							encode_uint16(0, &p_manifest[ofs + 30]); // id_index
-							encode_uint16(0, &p_manifest[ofs + 32]); // class_index
-							encode_uint16(0, &p_manifest[ofs + 34]); // style_index
+							encode_uint16(0x102, &p_manifest.write[ofs]); // type
+							encode_uint16(16, &p_manifest.write[ofs + 2]); // headersize
+							encode_uint32(56, &p_manifest.write[ofs + 4]); // size
+							encode_uint32(0, &p_manifest.write[ofs + 8]); // lineno
+							encode_uint32(-1, &p_manifest.write[ofs + 12]); // comment
+							encode_uint32(-1, &p_manifest.write[ofs + 16]); // ns
+							encode_uint32(attr_uses_permission_string, &p_manifest.write[ofs + 20]); // name
+							encode_uint16(20, &p_manifest.write[ofs + 24]); // attr_start
+							encode_uint16(20, &p_manifest.write[ofs + 26]); // attr_size
+							encode_uint16(1, &p_manifest.write[ofs + 28]); // num_attrs
+							encode_uint16(0, &p_manifest.write[ofs + 30]); // id_index
+							encode_uint16(0, &p_manifest.write[ofs + 32]); // class_index
+							encode_uint16(0, &p_manifest.write[ofs + 34]); // style_index
 
 							// attribute
-							encode_uint32(ns_android_string, &p_manifest[ofs + 36]); // ns
-							encode_uint32(attr_name_string, &p_manifest[ofs + 40]); // 'name'
-							encode_uint32(perm_string, &p_manifest[ofs + 44]); // raw_value
-							encode_uint16(8, &p_manifest[ofs + 48]); // typedvalue_size
-							p_manifest[ofs + 50] = 0; // typedvalue_always0
-							p_manifest[ofs + 51] = 0x03; // typedvalue_type (string)
-							encode_uint32(perm_string, &p_manifest[ofs + 52]); // typedvalue reference
+							encode_uint32(ns_android_string, &p_manifest.write[ofs + 36]); // ns
+							encode_uint32(attr_name_string, &p_manifest.write[ofs + 40]); // 'name'
+							encode_uint32(perm_string, &p_manifest.write[ofs + 44]); // raw_value
+							encode_uint16(8, &p_manifest.write[ofs + 48]); // typedvalue_size
+							p_manifest.write[ofs + 50] = 0; // typedvalue_always0
+							p_manifest.write[ofs + 51] = 0x03; // typedvalue_type (string)
+							encode_uint32(perm_string, &p_manifest.write[ofs + 52]); // typedvalue reference
 
 							ofs += 56;
 
 							// end tag
-							encode_uint16(0x103, &p_manifest[ofs]); // type
-							encode_uint16(16, &p_manifest[ofs + 2]); // headersize
-							encode_uint32(24, &p_manifest[ofs + 4]); // size
-							encode_uint32(0, &p_manifest[ofs + 8]); // lineno
-							encode_uint32(-1, &p_manifest[ofs + 12]); // comment
-							encode_uint32(-1, &p_manifest[ofs + 16]); // ns
-							encode_uint32(attr_uses_permission_string, &p_manifest[ofs + 20]); // name
+							encode_uint16(0x103, &p_manifest.write[ofs]); // type
+							encode_uint16(16, &p_manifest.write[ofs + 2]); // headersize
+							encode_uint32(24, &p_manifest.write[ofs + 4]); // size
+							encode_uint32(0, &p_manifest.write[ofs + 8]); // lineno
+							encode_uint32(-1, &p_manifest.write[ofs + 12]); // comment
+							encode_uint32(-1, &p_manifest.write[ofs + 16]); // ns
+							encode_uint32(attr_uses_permission_string, &p_manifest.write[ofs + 20]); // name
 
 							ofs += 24;
 						}
 
 						// copy footer back in
-						memcpy(&p_manifest[ofs], manifest_end.ptr(), manifest_end.size());
+						memcpy(&p_manifest.write[ofs], manifest_end.ptr(), manifest_end.size());
 					}
 				} break;
 			}
@@ -864,19 +864,19 @@ class EditorExportAndroid : public EditorExportPlatform {
 
 		for (uint32_t i = 0; i < string_table_begins; i++) {
 
-			ret[i] = p_manifest[i];
+			ret.write[i] = p_manifest[i];
 		}
 
 		ofs = 0;
 		for (int i = 0; i < string_table.size(); i++) {
 
-			encode_uint32(ofs, &ret[string_table_begins + i * 4]);
+			encode_uint32(ofs, &ret.write[string_table_begins + i * 4]);
 			ofs += string_table[i].length() * 2 + 2 + 2;
 		}
 
 		ret.resize(ret.size() + ofs);
 		string_data_offset = ret.size() - ofs;
-		uint8_t *chars = &ret[string_data_offset];
+		uint8_t *chars = &ret.write[string_data_offset];
 		for (int i = 0; i < string_table.size(); i++) {
 
 			String s = string_table[i];
@@ -903,15 +903,15 @@ class EditorExportAndroid : public EditorExportPlatform {
 		uint32_t extra = (p_manifest.size() - string_table_ends);
 		ret.resize(new_stable_end + extra);
 		for (uint32_t i = 0; i < extra; i++)
-			ret[new_stable_end + i] = p_manifest[string_table_ends + i];
+			ret.write[new_stable_end + i] = p_manifest[string_table_ends + i];
 
 		while (ret.size() % 4)
 			ret.push_back(0);
-		encode_uint32(ret.size(), &ret[4]); //update new file size
+		encode_uint32(ret.size(), &ret.write[4]); //update new file size
 
-		encode_uint32(new_stable_end - 8, &ret[12]); //update new string table size
-		encode_uint32(string_table.size(), &ret[16]); //update new number of strings
-		encode_uint32(string_data_offset - 8, &ret[28]); //update new string data offset
+		encode_uint32(new_stable_end - 8, &ret.write[12]); //update new string table size
+		encode_uint32(string_table.size(), &ret.write[16]); //update new number of strings
+		encode_uint32(string_data_offset - 8, &ret.write[28]); //update new string data offset
 
 		//print_line("file size: "+itos(ret.size()));
 
@@ -935,9 +935,9 @@ class EditorExportAndroid : public EditorExportPlatform {
 			Vector<uint8_t> str8;
 			str8.resize(len + 1);
 			for (uint32_t i = 0; i < len; i++) {
-				str8[i] = p_bytes[offset + i];
+				str8.write[i] = p_bytes[offset + i];
 			}
-			str8[len] = 0;
+			str8.write[len] = 0;
 			String str;
 			str.parse_utf8((const char *)str8.ptr());
 			return str;
@@ -1001,18 +1001,18 @@ class EditorExportAndroid : public EditorExportPlatform {
 
 		for (uint32_t i = 0; i < string_table_begins; i++) {
 
-			ret[i] = p_manifest[i];
+			ret.write[i] = p_manifest[i];
 		}
 
 		int ofs = 0;
 		for (int i = 0; i < string_table.size(); i++) {
 
-			encode_uint32(ofs, &ret[string_table_begins + i * 4]);
+			encode_uint32(ofs, &ret.write[string_table_begins + i * 4]);
 			ofs += string_table[i].length() * 2 + 2 + 2;
 		}
 
 		ret.resize(ret.size() + ofs);
-		uint8_t *chars = &ret[ret.size() - ofs];
+		uint8_t *chars = &ret.write[ret.size() - ofs];
 		for (int i = 0; i < string_table.size(); i++) {
 
 			String s = string_table[i];
@@ -1031,19 +1031,19 @@ class EditorExportAndroid : public EditorExportPlatform {
 			ret.push_back(0);
 
 		//change flags to not use utf8
-		encode_uint32(string_flags & ~0x100, &ret[28]);
+		encode_uint32(string_flags & ~0x100, &ret.write[28]);
 		//change length
-		encode_uint32(ret.size() - 12, &ret[16]);
+		encode_uint32(ret.size() - 12, &ret.write[16]);
 		//append the rest...
 		int rest_from = 12 + string_block_len;
 		int rest_to = ret.size();
 		int rest_len = (p_manifest.size() - rest_from);
 		ret.resize(ret.size() + (p_manifest.size() - rest_from));
 		for (int i = 0; i < rest_len; i++) {
-			ret[rest_to + i] = p_manifest[rest_from + i];
+			ret.write[rest_to + i] = p_manifest[rest_from + i];
 		}
 		//finally update the size
-		encode_uint32(ret.size(), &ret[4]);
+		encode_uint32(ret.size(), &ret.write[4]);
 
 		p_manifest = ret;
 		//printf("end\n");
@@ -1644,7 +1644,7 @@ public:
 			//add comandline
 			Vector<uint8_t> clf;
 			clf.resize(4);
-			encode_uint32(cl.size(), &clf[0]);
+			encode_uint32(cl.size(), &clf.write[0]);
 			for (int i = 0; i < cl.size(); i++) {
 
 				print_line(itos(i) + " param: " + cl[i]);
@@ -1654,8 +1654,8 @@ public:
 				if (!length)
 					continue;
 				clf.resize(base + 4 + length);
-				encode_uint32(length, &clf[base]);
-				copymem(&clf[base + 4], txt.ptr(), length);
+				encode_uint32(length, &clf.write[base]);
+				copymem(&clf.write[base + 4], txt.ptr(), length);
 			}
 
 			zip_fileinfo zipfi = get_zip_fileinfo();

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -357,8 +357,8 @@ void OS_Android::process_touch(int p_what, int p_pointer, const Vector<TouchPos>
 
 			touch.resize(p_points.size());
 			for (int i = 0; i < p_points.size(); i++) {
-				touch[i].id = p_points[i].id;
-				touch[i].pos = p_points[i].pos;
+				touch.write[i].id = p_points[i].id;
+				touch.write[i].pos = p_points[i].pos;
 			}
 
 			//send touch
@@ -399,7 +399,7 @@ void OS_Android::process_touch(int p_what, int p_pointer, const Vector<TouchPos>
 				ev->set_position(p_points[idx].pos);
 				ev->set_relative(p_points[idx].pos - touch[i].pos);
 				input->parse_input_event(ev);
-				touch[i].pos = p_points[idx].pos;
+				touch.write[i].pos = p_points[idx].pos;
 			}
 
 		} break;

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -276,7 +276,7 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 	CharString cs = strnew.utf8();
 	pfile.resize(cs.size() - 1);
 	for (int i = 0; i < cs.size() - 1; i++) {
-		pfile[i] = cs[i];
+		pfile.write[i] = cs[i];
 	}
 }
 
@@ -489,7 +489,7 @@ private:
 		ret.resize(sizeof(num) * 2);
 		for (int i = 0; i < sizeof(num) * 2; ++i) {
 			uint8_t four_bits = (num >> (sizeof(num) * 8 - (i + 1) * 4)) & 0xF;
-			ret[i] = _hex_char(four_bits);
+			ret.write[i] = _hex_char(four_bits);
 		}
 		return String::utf8(ret.ptr(), ret.size());
 	}
@@ -587,7 +587,7 @@ void EditorExportPlatformIOS::_add_assets_to_project(Vector<uint8_t> &p_project_
 	CharString cs = str.utf8();
 	p_project_data.resize(cs.size() - 1);
 	for (int i = 0; i < cs.size() - 1; i++) {
-		p_project_data[i] = cs[i];
+		p_project_data.write[i] = cs[i];
 	}
 }
 

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -95,7 +95,7 @@ void EditorExportPlatformJavaScript::_fix_html(Vector<uint8_t> &p_html, const Re
 	CharString cs = str_export.utf8();
 	p_html.resize(cs.length());
 	for (int i = 0; i < cs.length(); i++) {
-		p_html[i] = cs[i];
+		p_html.write[i] = cs[i];
 	}
 }
 

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -137,10 +137,10 @@ void EditorExportPlatformOSX::_make_icon(const Ref<Image> &p_icon, Vector<uint8_
 	Vector<uint8_t> data;
 
 	data.resize(8);
-	data[0] = 'i';
-	data[1] = 'c';
-	data[2] = 'n';
-	data[3] = 's';
+	data.write[0] = 'i';
+	data.write[1] = 'c';
+	data.write[2] = 'n';
+	data.write[3] = 's';
 
 	const char *name[] = { "ic09", "ic08", "ic07", "icp6", "icp5", "icp4" };
 	int index = 0;
@@ -160,19 +160,19 @@ void EditorExportPlatformOSX::_make_icon(const Ref<Image> &p_icon, Vector<uint8_
 		int ofs = data.size();
 		uint32_t len = f->get_len();
 		data.resize(data.size() + len + 8);
-		f->get_buffer(&data[ofs + 8], len);
+		f->get_buffer(&data.write[ofs + 8], len);
 		memdelete(f);
 		len += 8;
 		len = BSWAP32(len);
-		copymem(&data[ofs], name[index], 4);
-		encode_uint32(len, &data[ofs + 4]);
+		copymem(&data.write[ofs], name[index], 4);
+		encode_uint32(len, &data.write[ofs + 4]);
 		index++;
 		size /= 2;
 	}
 
 	uint32_t total_len = data.size();
 	total_len = BSWAP32(total_len);
-	encode_uint32(total_len, &data[4]);
+	encode_uint32(total_len, &data.write[4]);
 
 	p_data = data;
 }
@@ -210,7 +210,7 @@ void EditorExportPlatformOSX::_fix_plist(const Ref<EditorExportPreset> &p_preset
 	CharString cs = strnew.utf8();
 	plist.resize(cs.size() - 1);
 	for (int i = 0; i < cs.size() - 1; i++) {
-		plist[i] = cs[i];
+		plist.write[i] = cs[i];
 	}
 }
 

--- a/platform/osx/joypad_osx.cpp
+++ b/platform/osx/joypad_osx.cpp
@@ -271,7 +271,7 @@ void JoypadOSX::_device_removed(int p_id) {
 	ERR_FAIL_COND(device == -1);
 
 	input->joy_connection_changed(p_id, false, "");
-	device_list[device].free();
+	device_list.write[device].free();
 	device_list.remove(device);
 }
 
@@ -460,19 +460,19 @@ void JoypadOSX::process_joypads() {
 	poll_joypads();
 
 	for (int i = 0; i < device_list.size(); i++) {
-		joypad &joy = device_list[i];
+		joypad &joy = device_list.write[i];
 
 		for (int j = 0; j < joy.axis_elements.size(); j++) {
-			rec_element &elem = joy.axis_elements[j];
+			rec_element &elem = joy.axis_elements.write[j];
 			int value = joy.get_hid_element_state(&elem);
 			input->joy_axis(joy.id, j, axis_correct(value, elem.min, elem.max));
 		}
 		for (int j = 0; j < joy.button_elements.size(); j++) {
-			int value = joy.get_hid_element_state(&joy.button_elements[j]);
+			int value = joy.get_hid_element_state(&joy.button_elements.write[j]);
 			input->joy_button(joy.id, j, (value >= 1));
 		}
 		for (int j = 0; j < joy.hat_elements.size(); j++) {
-			rec_element &elem = joy.hat_elements[j];
+			rec_element &elem = joy.hat_elements.write[j];
 			int value = joy.get_hid_element_state(&elem);
 			int hat_value = process_hat_value(elem.min, elem.max, value);
 			input->joy_hat(joy.id, hat_value);
@@ -495,7 +495,7 @@ void JoypadOSX::process_joypads() {
 }
 
 void JoypadOSX::joypad_vibration_start(int p_id, float p_magnitude, float p_duration, uint64_t p_timestamp) {
-	joypad *joy = &device_list[get_joy_index(p_id)];
+	joypad *joy = &device_list.write[get_joy_index(p_id)];
 	joy->ff_timestamp = p_timestamp;
 	joy->ff_effect.dwDuration = p_duration * FF_SECONDS;
 	joy->ff_effect.dwGain = p_magnitude * FF_FFNOMINALMAX;
@@ -504,7 +504,7 @@ void JoypadOSX::joypad_vibration_start(int p_id, float p_magnitude, float p_dura
 }
 
 void JoypadOSX::joypad_vibration_stop(int p_id, uint64_t p_timestamp) {
-	joypad *joy = &device_list[get_joy_index(p_id)];
+	joypad *joy = &device_list.write[get_joy_index(p_id)];
 	joy->ff_timestamp = p_timestamp;
 	FFEffectStop(joy->ff_object);
 }
@@ -596,7 +596,7 @@ JoypadOSX::JoypadOSX() {
 JoypadOSX::~JoypadOSX() {
 
 	for (int i = 0; i < device_list.size(); i++) {
-		device_list[i].free();
+		device_list.write[i].free();
 	}
 
 	IOHIDManagerUnscheduleFromRunLoop(hid_manager, CFRunLoopGetCurrent(), GODOT_JOY_LOOP_RUN_MODE);

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -95,7 +95,7 @@ static void push_to_key_event_buffer(const OS_OSX::KeyEvent &p_event) {
 	if (OS_OSX::singleton->key_event_pos >= buffer.size()) {
 		buffer.resize(1 + OS_OSX::singleton->key_event_pos);
 	}
-	buffer[OS_OSX::singleton->key_event_pos++] = p_event;
+	buffer.write[OS_OSX::singleton->key_event_pos++] = p_event;
 }
 
 static int mouse_x = 0;
@@ -602,8 +602,8 @@ static void _mouseDownEvent(NSEvent *event, int index, int mask, bool pressed) {
 	mm->set_position(pos);
 	mm->set_global_position(pos);
 	Vector2 relativeMotion = Vector2();
-	relativeMotion.x = [event deltaX] * OS_OSX::singleton->_mouse_scale([[event window] backingScaleFactor]);
-	relativeMotion.y = [event deltaY] * OS_OSX::singleton->_mouse_scale([[event window] backingScaleFactor]);
+	relativeMotion.x = [event deltaX] * OS_OSX::singleton -> _mouse_scale([[event window] backingScaleFactor]);
+	relativeMotion.y = [event deltaY] * OS_OSX::singleton -> _mouse_scale([[event window] backingScaleFactor]);
 	mm->set_relative(relativeMotion);
 	get_key_modifier_state([event modifierFlags], mm);
 
@@ -2405,7 +2405,7 @@ void OS_OSX::process_key_events() {
 	Ref<InputEventKey> k;
 	for (int i = 0; i < key_event_pos; i++) {
 
-		KeyEvent &ke = key_event_buffer[i];
+		const KeyEvent &ke = key_event_buffer[i];
 
 		if ((i == 0 && ke.scancode == 0) || (i > 0 && key_event_buffer[i - 1].scancode == 0)) {
 			k.instance();

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -301,37 +301,37 @@ Vector<uint8_t> AppxPackager::make_file_header(FileMeta p_file_meta) {
 
 	int offs = 0;
 	// Write magic
-	offs += buf_put_int32(FILE_HEADER_MAGIC, &buf[offs]);
+	offs += buf_put_int32(FILE_HEADER_MAGIC, &buf.write[offs]);
 
 	// Version
-	offs += buf_put_int16(ZIP_VERSION, &buf[offs]);
+	offs += buf_put_int16(ZIP_VERSION, &buf.write[offs]);
 
 	// Special flag
-	offs += buf_put_int16(GENERAL_PURPOSE, &buf[offs]);
+	offs += buf_put_int16(GENERAL_PURPOSE, &buf.write[offs]);
 
 	// Compression
-	offs += buf_put_int16(p_file_meta.compressed ? Z_DEFLATED : 0, &buf[offs]);
+	offs += buf_put_int16(p_file_meta.compressed ? Z_DEFLATED : 0, &buf.write[offs]);
 
 	// File date and time
-	offs += buf_put_int32(0, &buf[offs]);
+	offs += buf_put_int32(0, &buf.write[offs]);
 
 	// CRC-32
-	offs += buf_put_int32(p_file_meta.file_crc32, &buf[offs]);
+	offs += buf_put_int32(p_file_meta.file_crc32, &buf.write[offs]);
 
 	// Compressed size
-	offs += buf_put_int32(p_file_meta.compressed_size, &buf[offs]);
+	offs += buf_put_int32(p_file_meta.compressed_size, &buf.write[offs]);
 
 	// Uncompressed size
-	offs += buf_put_int32(p_file_meta.uncompressed_size, &buf[offs]);
+	offs += buf_put_int32(p_file_meta.uncompressed_size, &buf.write[offs]);
 
 	// File name length
-	offs += buf_put_int16(p_file_meta.name.length(), &buf[offs]);
+	offs += buf_put_int16(p_file_meta.name.length(), &buf.write[offs]);
 
 	// Extra data length
-	offs += buf_put_int16(0, &buf[offs]);
+	offs += buf_put_int16(0, &buf.write[offs]);
 
 	// File name
-	offs += buf_put_string(p_file_meta.name, &buf[offs]);
+	offs += buf_put_string(p_file_meta.name, &buf.write[offs]);
 
 	// Done!
 	return buf;
@@ -344,47 +344,47 @@ void AppxPackager::store_central_dir_header(const FileMeta &p_file, bool p_do_ha
 	buf.resize(buf.size() + BASE_CENTRAL_DIR_SIZE + p_file.name.length());
 
 	// Write magic
-	offs += buf_put_int32(CENTRAL_DIR_MAGIC, &buf[offs]);
+	offs += buf_put_int32(CENTRAL_DIR_MAGIC, &buf.write[offs]);
 
 	// ZIP versions
-	offs += buf_put_int16(ZIP_ARCHIVE_VERSION, &buf[offs]);
-	offs += buf_put_int16(ZIP_VERSION, &buf[offs]);
+	offs += buf_put_int16(ZIP_ARCHIVE_VERSION, &buf.write[offs]);
+	offs += buf_put_int16(ZIP_VERSION, &buf.write[offs]);
 
 	// General purpose flag
-	offs += buf_put_int16(GENERAL_PURPOSE, &buf[offs]);
+	offs += buf_put_int16(GENERAL_PURPOSE, &buf.write[offs]);
 
 	// Compression
-	offs += buf_put_int16(p_file.compressed ? Z_DEFLATED : 0, &buf[offs]);
+	offs += buf_put_int16(p_file.compressed ? Z_DEFLATED : 0, &buf.write[offs]);
 
 	// Modification date/time
-	offs += buf_put_int32(0, &buf[offs]);
+	offs += buf_put_int32(0, &buf.write[offs]);
 
 	// Crc-32
-	offs += buf_put_int32(p_file.file_crc32, &buf[offs]);
+	offs += buf_put_int32(p_file.file_crc32, &buf.write[offs]);
 
 	// File sizes
-	offs += buf_put_int32(p_file.compressed_size, &buf[offs]);
-	offs += buf_put_int32(p_file.uncompressed_size, &buf[offs]);
+	offs += buf_put_int32(p_file.compressed_size, &buf.write[offs]);
+	offs += buf_put_int32(p_file.uncompressed_size, &buf.write[offs]);
 
 	// File name length
-	offs += buf_put_int16(p_file.name.length(), &buf[offs]);
+	offs += buf_put_int16(p_file.name.length(), &buf.write[offs]);
 
 	// Extra field length
-	offs += buf_put_int16(0, &buf[offs]);
+	offs += buf_put_int16(0, &buf.write[offs]);
 
 	// Comment length
-	offs += buf_put_int16(0, &buf[offs]);
+	offs += buf_put_int16(0, &buf.write[offs]);
 
 	// Disk number start, internal/external file attributes
 	for (int i = 0; i < 8; i++) {
-		buf[offs++] = 0;
+		buf.write[offs++] = 0;
 	}
 
 	// Relative offset
-	offs += buf_put_int32(p_file.zip_offset, &buf[offs]);
+	offs += buf_put_int32(p_file.zip_offset, &buf.write[offs]);
 
 	// File name
-	offs += buf_put_string(p_file.name, &buf[offs]);
+	offs += buf_put_string(p_file.name, &buf.write[offs]);
 
 	// Done!
 }
@@ -397,62 +397,62 @@ Vector<uint8_t> AppxPackager::make_end_of_central_record() {
 	int offs = 0;
 
 	// Write magic
-	offs += buf_put_int32(ZIP64_END_OF_CENTRAL_DIR_MAGIC, &buf[offs]);
+	offs += buf_put_int32(ZIP64_END_OF_CENTRAL_DIR_MAGIC, &buf.write[offs]);
 
 	// Size of this record
-	offs += buf_put_int64(ZIP64_END_OF_CENTRAL_DIR_SIZE, &buf[offs]);
+	offs += buf_put_int64(ZIP64_END_OF_CENTRAL_DIR_SIZE, &buf.write[offs]);
 
 	// Version (yes, twice)
-	offs += buf_put_int16(ZIP_ARCHIVE_VERSION, &buf[offs]);
-	offs += buf_put_int16(ZIP_ARCHIVE_VERSION, &buf[offs]);
+	offs += buf_put_int16(ZIP_ARCHIVE_VERSION, &buf.write[offs]);
+	offs += buf_put_int16(ZIP_ARCHIVE_VERSION, &buf.write[offs]);
 
 	// Disk number
 	for (int i = 0; i < 8; i++) {
-		buf[offs++] = 0;
+		buf.write[offs++] = 0;
 	}
 
 	// Number of entries (total and per disk)
-	offs += buf_put_int64(file_metadata.size(), &buf[offs]);
-	offs += buf_put_int64(file_metadata.size(), &buf[offs]);
+	offs += buf_put_int64(file_metadata.size(), &buf.write[offs]);
+	offs += buf_put_int64(file_metadata.size(), &buf.write[offs]);
 
 	// Size of central dir
-	offs += buf_put_int64(central_dir_data.size(), &buf[offs]);
+	offs += buf_put_int64(central_dir_data.size(), &buf.write[offs]);
 
 	// Central dir offset
-	offs += buf_put_int64(central_dir_offset, &buf[offs]);
+	offs += buf_put_int64(central_dir_offset, &buf.write[offs]);
 
 	////// ZIP64 locator
 
 	// Write magic for zip64 central dir locator
-	offs += buf_put_int32(ZIP64_END_DIR_LOCATOR_MAGIC, &buf[offs]);
+	offs += buf_put_int32(ZIP64_END_DIR_LOCATOR_MAGIC, &buf.write[offs]);
 
 	// Disk number
 	for (int i = 0; i < 4; i++) {
-		buf[offs++] = 0;
+		buf.write[offs++] = 0;
 	}
 
 	// Relative offset
-	offs += buf_put_int64(end_of_central_dir_offset, &buf[offs]);
+	offs += buf_put_int64(end_of_central_dir_offset, &buf.write[offs]);
 
 	// Number of disks
-	offs += buf_put_int32(1, &buf[offs]);
+	offs += buf_put_int32(1, &buf.write[offs]);
 
 	/////// End of zip directory
 
 	// Write magic for end central dir
-	offs += buf_put_int32(END_OF_CENTRAL_DIR_MAGIC, &buf[offs]);
+	offs += buf_put_int32(END_OF_CENTRAL_DIR_MAGIC, &buf.write[offs]);
 
 	// Dummy stuff for Zip64
 	for (int i = 0; i < 4; i++) {
-		buf[offs++] = 0x0;
+		buf.write[offs++] = 0x0;
 	}
 	for (int i = 0; i < 12; i++) {
-		buf[offs++] = 0xFF;
+		buf.write[offs++] = 0xFF;
 	}
 
 	// Size of comments
 	for (int i = 0; i < 2; i++) {
-		buf[offs++] = 0;
+		buf.write[offs++] = 0;
 	}
 
 	// Done!
@@ -508,7 +508,7 @@ void AppxPackager::add_file(String p_file_name, const uint8_t *p_buffer, size_t 
 		size_t block_size = (p_len - step) > BLOCK_SIZE ? BLOCK_SIZE : (p_len - step);
 
 		for (uint32_t i = 0; i < block_size; i++) {
-			strm_in[i] = p_buffer[step + i];
+			strm_in.write[i] = p_buffer[step + i];
 		}
 
 		BlockHash bh;
@@ -530,14 +530,14 @@ void AppxPackager::add_file(String p_file_name, const uint8_t *p_buffer, size_t 
 			int start = file_buffer.size();
 			file_buffer.resize(file_buffer.size() + bh.compressed_size);
 			for (uint32_t i = 0; i < bh.compressed_size; i++)
-				file_buffer[start + i] = strm_out[i];
+				file_buffer.write[start + i] = strm_out[i];
 		} else {
 			bh.compressed_size = block_size;
 			//package->store_buffer(strm_in.ptr(), block_size);
 			int start = file_buffer.size();
 			file_buffer.resize(file_buffer.size() + block_size);
 			for (uint32_t i = 0; i < bh.compressed_size; i++)
-				file_buffer[start + i] = strm_in[i];
+				file_buffer.write[start + i] = strm_in[i];
 		}
 
 		meta.hashes.push_back(bh);
@@ -560,7 +560,7 @@ void AppxPackager::add_file(String p_file_name, const uint8_t *p_buffer, size_t 
 		int start = file_buffer.size();
 		file_buffer.resize(file_buffer.size() + (strm.total_out - total_out_before));
 		for (uint32_t i = 0; i < (strm.total_out - total_out_before); i++)
-			file_buffer[start + i] = strm_out[i];
+			file_buffer.write[start + i] = strm_out[i];
 
 		deflateEnd(&strm);
 		meta.compressed_size = strm.total_out;
@@ -864,7 +864,7 @@ class EditorExportUWP : public EditorExportPlatform {
 		r_ret.resize(result.length());
 
 		for (int i = 0; i < result.length(); i++)
-			r_ret[i] = result.utf8().get(i);
+			r_ret.write[i] = result.utf8().get(i);
 
 		return r_ret;
 	}
@@ -1371,8 +1371,8 @@ public:
 			CharString txt = cl[i].utf8();
 			int base = clf.size();
 			clf.resize(base + 4 + txt.length());
-			encode_uint32(txt.length(), &clf[base]);
-			copymem(&clf[base + 4], txt.ptr(), txt.length());
+			encode_uint32(txt.length(), &clf.write[base]);
+			copymem(&clf.write[base + 4], txt.ptr(), txt.length());
 			print_line(itos(i) + " param: " + cl[i]);
 		}
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2299,7 +2299,7 @@ Error OS_Windows::execute(const String &p_path, const List<String> &p_arguments,
 	Vector<CharType> modstr; //windows wants to change this no idea why
 	modstr.resize(cmdline.size());
 	for (int i = 0; i < cmdline.size(); i++)
-		modstr[i] = cmdline[i];
+		modstr.write[i] = cmdline[i];
 	int ret = CreateProcessW(NULL, modstr.ptrw(), NULL, NULL, 0, NORMAL_PRIORITY_CLASS, NULL, NULL, si_w, &pi.pi);
 	ERR_FAIL_COND_V(ret == 0, ERR_CANT_FORK);
 
@@ -2370,7 +2370,7 @@ void OS_Windows::set_icon(const Ref<Image> &p_icon) {
 	int icon_len = 40 + h * w * 4;
 	Vector<BYTE> v;
 	v.resize(icon_len);
-	BYTE *icon_bmp = &v[0];
+	BYTE *icon_bmp = v.ptrw();
 
 	encode_uint32(40, &icon_bmp[0]);
 	encode_uint32(w, &icon_bmp[4]);

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -1838,8 +1838,8 @@ void OS_X11::process_xevents() {
 							GrabModeAsync, GrabModeAsync, x11_window, None, CurrentTime);
 				}
 #ifdef TOUCH_ENABLED
-					// Grab touch devices to avoid OS gesture interference
-					/*for (int i = 0; i < touch.devices.size(); ++i) {
+				// Grab touch devices to avoid OS gesture interference
+				/*for (int i = 0; i < touch.devices.size(); ++i) {
 					XIGrabDevice(x11_display, touch.devices[i], x11_window, CurrentTime, None, XIGrabModeAsync, XIGrabModeAsync, False, &touch.event_mask);
 				}*/
 #endif
@@ -2105,7 +2105,7 @@ void OS_X11::process_xevents() {
 
 					Vector<String> files = String((char *)p.data).split("\n", false);
 					for (int i = 0; i < files.size(); i++) {
-						files[i] = files[i].replace("file://", "").replace("%20", " ").strip_escapes();
+						files.write[i] = files[i].replace("file://", "").replace("%20", " ").strip_escapes();
 					}
 					main_loop->drop_files(files);
 
@@ -2587,12 +2587,12 @@ void OS_X11::set_icon(const Ref<Image> &p_icon) {
 
 		pd.resize(2 + w * h);
 
-		pd[0] = w;
-		pd[1] = h;
+		pd.write[0] = w;
+		pd.write[1] = h;
 
 		PoolVector<uint8_t>::Read r = img->get_data().read();
 
-		long *wr = &pd[2];
+		long *wr = &pd.write[2];
 		uint8_t const *pr = r.ptr();
 
 		for (int i = 0; i < w * h; i++) {

--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -235,7 +235,7 @@ void SpriteFrames::_set_frames(const Array &p_frames) {
 
 	E->get().frames.resize(p_frames.size());
 	for (int i = 0; i < E->get().frames.size(); i++)
-		E->get().frames[i] = p_frames[i];
+		E->get().frames.write[i] = p_frames[i];
 }
 Array SpriteFrames::_get_frames() const {
 

--- a/scene/2d/animated_sprite.h
+++ b/scene/2d/animated_sprite.h
@@ -113,7 +113,7 @@ public:
 		ERR_FAIL_COND(p_idx < 0);
 		if (p_idx >= E->get().frames.size())
 			return;
-		E->get().frames[p_idx] = p_frame;
+		E->get().frames.write[p_idx] = p_frame;
 	}
 	void remove_frame(const StringName &p_anim, int p_idx);
 	void clear(const StringName &p_anim);

--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -259,7 +259,7 @@ void CollisionObject2D::shape_owner_remove_shape(uint32_t p_owner, int p_shape) 
 	for (Map<uint32_t, ShapeData>::Element *E = shapes.front(); E; E = E->next()) {
 		for (int i = 0; i < E->get().shapes.size(); i++) {
 			if (E->get().shapes[i].index > index_to_remove) {
-				E->get().shapes[i].index -= 1;
+				E->get().shapes.write[i].index -= 1;
 			}
 		}
 	}

--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -102,11 +102,11 @@ Vector<Vector<Vector2> > CollisionPolygon2D::_decompose_in_convex() {
 
 		TriangulatorPoly &tp = I->get();
 
-		decomp[idx].resize(tp.GetNumPoints());
+		decomp.write[idx].resize(tp.GetNumPoints());
 
 		for (int i = 0; i < tp.GetNumPoints(); i++) {
 
-			decomp[idx][i] = tp.GetPoint(i);
+			decomp.write[idx].write[i] = tp.GetPoint(i);
 		}
 
 		idx++;

--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -239,7 +239,7 @@ void Line2D::_draw() {
 	{
 		PoolVector<Vector2>::Read points_read = _points.read();
 		for (int i = 0; i < len; ++i) {
-			points[i] = points_read[i];
+			points.write[i] = points_read[i];
 		}
 	}
 

--- a/scene/2d/navigation2d.cpp
+++ b/scene/2d/navigation2d.cpp
@@ -74,7 +74,7 @@ void Navigation2D::_navpoly_link(int p_id) {
 			Vector2 ep = nm.xform.xform(r[idx]);
 			center += ep;
 			e.point = _get_point(ep);
-			p.edges[j] = e;
+			p.edges.write[j] = e;
 
 			int idxn = indices[(j + 1) % plen];
 			if (idxn < 0 || idxn >= len) {
@@ -119,17 +119,17 @@ void Navigation2D::_navpoly_link(int p_id) {
 					ConnectionPending pending;
 					pending.polygon = &p;
 					pending.edge = j;
-					p.edges[j].P = C->get().pending.push_back(pending);
+					p.edges.write[j].P = C->get().pending.push_back(pending);
 					continue;
 					//print_line(String()+_get_vertex(ek.a)+" -> "+_get_vertex(ek.b));
 				}
 
 				C->get().B = &p;
 				C->get().B_edge = j;
-				C->get().A->edges[C->get().A_edge].C = &p;
-				C->get().A->edges[C->get().A_edge].C_edge = j;
-				p.edges[j].C = C->get().A;
-				p.edges[j].C_edge = C->get().A_edge;
+				C->get().A->edges.write[C->get().A_edge].C = &p;
+				C->get().A->edges.write[C->get().A_edge].C_edge = j;
+				p.edges.write[j].C = C->get().A;
+				p.edges.write[j].C_edge = C->get().A_edge;
 				//connection successful.
 			}
 		}
@@ -167,10 +167,10 @@ void Navigation2D::_navpoly_unlink(int p_id) {
 			} else if (C->get().B) {
 				//disconnect
 
-				C->get().B->edges[C->get().B_edge].C = NULL;
-				C->get().B->edges[C->get().B_edge].C_edge = -1;
-				C->get().A->edges[C->get().A_edge].C = NULL;
-				C->get().A->edges[C->get().A_edge].C_edge = -1;
+				C->get().B->edges.write[C->get().B_edge].C = NULL;
+				C->get().B->edges.write[C->get().B_edge].C_edge = -1;
+				C->get().A->edges.write[C->get().A_edge].C = NULL;
+				C->get().A->edges.write[C->get().A_edge].C_edge = -1;
 
 				if (C->get().A == &E->get()) {
 
@@ -187,11 +187,11 @@ void Navigation2D::_navpoly_unlink(int p_id) {
 
 					C->get().B = cp.polygon;
 					C->get().B_edge = cp.edge;
-					C->get().A->edges[C->get().A_edge].C = cp.polygon;
-					C->get().A->edges[C->get().A_edge].C_edge = cp.edge;
-					cp.polygon->edges[cp.edge].C = C->get().A;
-					cp.polygon->edges[cp.edge].C_edge = C->get().A_edge;
-					cp.polygon->edges[cp.edge].P = NULL;
+					C->get().A->edges.write[C->get().A_edge].C = cp.polygon;
+					C->get().A->edges.write[C->get().A_edge].C_edge = cp.edge;
+					cp.polygon->edges.write[cp.edge].C = C->get().A;
+					cp.polygon->edges.write[cp.edge].C_edge = C->get().A_edge;
+					cp.polygon->edges.write[cp.edge].P = NULL;
 				}
 
 			} else {
@@ -339,8 +339,8 @@ Vector<Vector2> Navigation2D::get_simple_path(const Vector2 &p_start, const Vect
 
 		Vector<Vector2> path;
 		path.resize(2);
-		path[0] = begin_point;
-		path[1] = end_point;
+		path.write[0] = begin_point;
+		path.write[1] = end_point;
 		//print_line("Direct Path");
 		return path;
 	}
@@ -408,7 +408,7 @@ Vector<Vector2> Navigation2D::get_simple_path(const Vector2 &p_start, const Vect
 
 		for (int i = 0; i < es; i++) {
 
-			Polygon::Edge &e = p->edges[i];
+			Polygon::Edge &e = p->edges.write[i];
 
 			if (!e.C)
 				continue;
@@ -586,7 +586,7 @@ Vector<Vector2> Navigation2D::get_simple_path(const Vector2 &p_start, const Vect
 		if (!path.size() || path[path.size() - 1].distance_squared_to(begin_point) > CMP_EPSILON) {
 			path.push_back(begin_point); // Add the begin point
 		} else {
-			path[path.size() - 1] = begin_point; // Replace first midpoint by the exact begin point
+			path.write[path.size() - 1] = begin_point; // Replace first midpoint by the exact begin point
 		}
 
 		path.invert();
@@ -594,7 +594,7 @@ Vector<Vector2> Navigation2D::get_simple_path(const Vector2 &p_start, const Vect
 		if (path.size() <= 1 || path[path.size() - 1].distance_squared_to(end_point) > CMP_EPSILON) {
 			path.push_back(end_point); // Add the end point
 		} else {
-			path[path.size() - 1] = end_point; // Replace last midpoint by the exact end point
+			path.write[path.size() - 1] = end_point; // Replace last midpoint by the exact end point
 		}
 
 		return path;

--- a/scene/2d/navigation_polygon.cpp
+++ b/scene/2d/navigation_polygon.cpp
@@ -91,7 +91,7 @@ void NavigationPolygon::_set_polygons(const Array &p_array) {
 
 	polygons.resize(p_array.size());
 	for (int i = 0; i < p_array.size(); i++) {
-		polygons[i].indices = p_array[i];
+		polygons.write[i].indices = p_array[i];
 	}
 }
 
@@ -110,7 +110,7 @@ void NavigationPolygon::_set_outlines(const Array &p_array) {
 
 	outlines.resize(p_array.size());
 	for (int i = 0; i < p_array.size(); i++) {
-		outlines[i] = p_array[i];
+		outlines.write[i] = p_array[i];
 	}
 	rect_cache_dirty = true;
 }
@@ -166,7 +166,7 @@ int NavigationPolygon::get_outline_count() const {
 
 void NavigationPolygon::set_outline(int p_idx, const PoolVector<Vector2> &p_outline) {
 	ERR_FAIL_INDEX(p_idx, outlines.size());
-	outlines[p_idx] = p_outline;
+	outlines.write[p_idx] = p_outline;
 	rect_cache_dirty = true;
 }
 
@@ -432,8 +432,8 @@ void NavigationPolygonInstance::_notification(int p_what) {
 				{
 					PoolVector<Vector2>::Read vr = verts.read();
 					for (int i = 0; i < vsize; i++) {
-						vertices[i] = vr[i];
-						colors[i] = color;
+						vertices.write[i] = vr[i];
+						colors.write[i] = color;
 					}
 				}
 

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1373,11 +1373,11 @@ Ref<KinematicCollision2D> KinematicBody2D::_get_slide_collision(int p_bounce) {
 	}
 
 	if (slide_colliders[p_bounce].is_null()) {
-		slide_colliders[p_bounce].instance();
-		slide_colliders[p_bounce]->owner = this;
+		slide_colliders.write[p_bounce].instance();
+		slide_colliders.write[p_bounce]->owner = this;
 	}
 
-	slide_colliders[p_bounce]->collision = colliders[p_bounce];
+	slide_colliders.write[p_bounce]->collision = colliders[p_bounce];
 	return slide_colliders[p_bounce];
 }
 
@@ -1475,7 +1475,7 @@ KinematicBody2D::~KinematicBody2D() {
 
 	for (int i = 0; i < slide_colliders.size(); i++) {
 		if (slide_colliders[i].is_valid()) {
-			slide_colliders[i]->owner = NULL;
+			slide_colliders.write[i]->owner = NULL;
 		}
 	}
 }

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -113,7 +113,7 @@ void Polygon2D::_notification(int p_what) {
 
 				PoolVector<Vector2>::Read polyr = polygon.read();
 				for (int i = 0; i < len; i++) {
-					points[i] = polyr[i] + offset;
+					points.write[i] = polyr[i] + offset;
 				}
 			}
 
@@ -153,18 +153,18 @@ void Polygon2D::_notification(int p_what) {
 					SWAP(ep[1], ep[4]);
 					SWAP(ep[2], ep[3]);
 					SWAP(ep[5], ep[0]);
-					SWAP(ep[6], points[highest_idx]);
+					SWAP(ep[6], points.write[highest_idx]);
 				}
 
 				points.resize(points.size() + 7);
 				for (int i = points.size() - 1; i >= highest_idx + 7; i--) {
 
-					points[i] = points[i - 7];
+					points.write[i] = points[i - 7];
 				}
 
 				for (int i = 0; i < 7; i++) {
 
-					points[highest_idx + i + 1] = ep[i];
+					points.write[highest_idx + i + 1] = ep[i];
 				}
 
 				len = points.size();
@@ -182,12 +182,12 @@ void Polygon2D::_notification(int p_what) {
 					PoolVector<Vector2>::Read uvr = uv.read();
 
 					for (int i = 0; i < len; i++) {
-						uvs[i] = texmat.xform(uvr[i]) / tex_size;
+						uvs.write[i] = texmat.xform(uvr[i]) / tex_size;
 					}
 
 				} else {
 					for (int i = 0; i < len; i++) {
-						uvs[i] = texmat.xform(points[i]) / tex_size;
+						uvs.write[i] = texmat.xform(points[i]) / tex_size;
 					}
 				}
 			}
@@ -262,10 +262,10 @@ void Polygon2D::_notification(int p_what) {
 			{
 				PoolVector<Color>::Read color_r = vertex_colors.read();
 				for (int i = 0; i < color_len && i < len; i++) {
-					colors[i] = color_r[i];
+					colors.write[i] = color_r[i];
 				}
 				for (int i = color_len; i < len; i++) {
-					colors[i] = color;
+					colors.write[i] = color;
 				}
 			}
 
@@ -333,13 +333,13 @@ void Polygon2D::_notification(int p_what) {
 					Vector<Vector2> vertices;
 					vertices.resize(loop.size());
 					for (int j = 0; j < vertices.size(); j++) {
-						vertices[j] = points[loop[j]];
+						vertices.write[j] = points[loop[j]];
 					}
 					Vector<int> sub_indices = Geometry::triangulate_polygon(vertices);
 					int from = indices.size();
 					indices.resize(from + sub_indices.size());
 					for (int j = 0; j < sub_indices.size(); j++) {
-						indices[from + j] = loop[sub_indices[j]];
+						indices.write[from + j] = loop[sub_indices[j]];
 					}
 				}
 
@@ -538,12 +538,12 @@ void Polygon2D::clear_bones() {
 
 void Polygon2D::set_bone_weights(int p_index, const PoolVector<float> &p_weights) {
 	ERR_FAIL_INDEX(p_index, bone_weights.size());
-	bone_weights[p_index].weights = p_weights;
+	bone_weights.write[p_index].weights = p_weights;
 	update();
 }
 void Polygon2D::set_bone_path(int p_index, const NodePath &p_path) {
 	ERR_FAIL_INDEX(p_index, bone_weights.size());
-	bone_weights[p_index].path = p_path;
+	bone_weights.write[p_index].path = p_path;
 	update();
 }
 

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -191,13 +191,13 @@ void Skeleton2D::_update_bone_setup() {
 	bones.sort(); //sorty so they are always in the same order/index
 
 	for (int i = 0; i < bones.size(); i++) {
-		bones[i].rest_inverse = bones[i].bone->get_skeleton_rest().affine_inverse(); //bind pose
-		bones[i].bone->skeleton_index = i;
+		bones.write[i].rest_inverse = bones[i].bone->get_skeleton_rest().affine_inverse(); //bind pose
+		bones.write[i].bone->skeleton_index = i;
 		Bone2D *parent_bone = Object::cast_to<Bone2D>(bones[i].bone->get_parent());
 		if (parent_bone) {
-			bones[i].parent_index = parent_bone->skeleton_index;
+			bones.write[i].parent_index = parent_bone->skeleton_index;
 		} else {
-			bones[i].parent_index = -1;
+			bones.write[i].parent_index = -1;
 		}
 	}
 
@@ -230,9 +230,9 @@ void Skeleton2D::_update_transform() {
 
 		ERR_CONTINUE(bones[i].parent_index >= i);
 		if (bones[i].parent_index >= 0) {
-			bones[i].accum_transform = bones[bones[i].parent_index].accum_transform * bones[i].bone->get_transform();
+			bones.write[i].accum_transform = bones[bones[i].parent_index].accum_transform * bones[i].bone->get_transform();
 		} else {
-			bones[i].accum_transform = bones[i].bone->get_transform();
+			bones.write[i].accum_transform = bones[i].bone->get_transform();
 		}
 	}
 

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -529,8 +529,8 @@ void TileMap::update_dirty_quadrants() {
 								{
 									PoolVector<Vector2>::Read vr = navigation_polygon_vertices.read();
 									for (int i = 0; i < vsize; i++) {
-										vertices[i] = vr[i];
-										colors[i] = debug_navigation_color;
+										vertices.write[i] = vr[i];
+										colors.write[i] = debug_navigation_color;
 									}
 								}
 

--- a/scene/3d/collision_object.cpp
+++ b/scene/3d/collision_object.cpp
@@ -305,7 +305,7 @@ void CollisionObject::shape_owner_remove_shape(uint32_t p_owner, int p_shape) {
 	for (Map<uint32_t, ShapeData>::Element *E = shapes.front(); E; E = E->next()) {
 		for (int i = 0; i < E->get().shapes.size(); i++) {
 			if (E->get().shapes[i].index > index_to_remove) {
-				E->get().shapes[i].index -= 1;
+				E->get().shapes.write[i].index -= 1;
 			}
 		}
 	}

--- a/scene/3d/mesh_instance.cpp
+++ b/scene/3d/mesh_instance.cpp
@@ -257,7 +257,7 @@ void MeshInstance::set_surface_material(int p_surface, const Ref<Material> &p_ma
 
 	ERR_FAIL_INDEX(p_surface, materials.size());
 
-	materials[p_surface] = p_material;
+	materials.write[p_surface] = p_material;
 
 	if (materials[p_surface].is_valid())
 		VS::get_singleton()->instance_set_surface_material(get_instance(), p_surface, materials[p_surface]->get_rid());

--- a/scene/3d/navigation.cpp
+++ b/scene/3d/navigation.cpp
@@ -73,7 +73,7 @@ void Navigation::_navmesh_link(int p_id) {
 			Vector3 ep = nm.xform.xform(r[idx]);
 			center += ep;
 			e.point = _get_point(ep);
-			p.edges[j] = e;
+			p.edges.write[j] = e;
 
 			if (j >= 2) {
 				Vector3 epa = nm.xform.xform(r[indices[j - 2]]);
@@ -118,7 +118,7 @@ void Navigation::_navmesh_link(int p_id) {
 					ConnectionPending pending;
 					pending.polygon = &p;
 					pending.edge = j;
-					p.edges[j].P = C->get().pending.push_back(pending);
+					p.edges.write[j].P = C->get().pending.push_back(pending);
 					continue;
 					//print_line(String()+_get_vertex(ek.a)+" -> "+_get_vertex(ek.b));
 				}
@@ -126,10 +126,10 @@ void Navigation::_navmesh_link(int p_id) {
 
 				C->get().B = &p;
 				C->get().B_edge = j;
-				C->get().A->edges[C->get().A_edge].C = &p;
-				C->get().A->edges[C->get().A_edge].C_edge = j;
-				p.edges[j].C = C->get().A;
-				p.edges[j].C_edge = C->get().A_edge;
+				C->get().A->edges.write[C->get().A_edge].C = &p;
+				C->get().A->edges.write[C->get().A_edge].C_edge = j;
+				p.edges.write[j].C = C->get().A;
+				p.edges.write[j].C_edge = C->get().A_edge;
 				//connection successful.
 			}
 		}
@@ -165,10 +165,10 @@ void Navigation::_navmesh_unlink(int p_id) {
 			} else if (C->get().B) {
 				//disconnect
 
-				C->get().B->edges[C->get().B_edge].C = NULL;
-				C->get().B->edges[C->get().B_edge].C_edge = -1;
-				C->get().A->edges[C->get().A_edge].C = NULL;
-				C->get().A->edges[C->get().A_edge].C_edge = -1;
+				C->get().B->edges.write[C->get().B_edge].C = NULL;
+				C->get().B->edges.write[C->get().B_edge].C_edge = -1;
+				C->get().A->edges.write[C->get().A_edge].C = NULL;
+				C->get().A->edges.write[C->get().A_edge].C_edge = -1;
 
 				if (C->get().A == &E->get()) {
 
@@ -185,11 +185,11 @@ void Navigation::_navmesh_unlink(int p_id) {
 
 					C->get().B = cp.polygon;
 					C->get().B_edge = cp.edge;
-					C->get().A->edges[C->get().A_edge].C = cp.polygon;
-					C->get().A->edges[C->get().A_edge].C_edge = cp.edge;
-					cp.polygon->edges[cp.edge].C = C->get().A;
-					cp.polygon->edges[cp.edge].C_edge = C->get().A_edge;
-					cp.polygon->edges[cp.edge].P = NULL;
+					C->get().A->edges.write[C->get().A_edge].C = cp.polygon;
+					C->get().A->edges.write[C->get().A_edge].C_edge = cp.edge;
+					cp.polygon->edges.write[cp.edge].C = C->get().A;
+					cp.polygon->edges.write[cp.edge].C_edge = C->get().A_edge;
+					cp.polygon->edges.write[cp.edge].P = NULL;
 				}
 
 			} else {
@@ -320,8 +320,8 @@ Vector<Vector3> Navigation::get_simple_path(const Vector3 &p_start, const Vector
 
 		Vector<Vector3> path;
 		path.resize(2);
-		path[0] = begin_point;
-		path[1] = end_point;
+		path.write[0] = begin_point;
+		path.write[1] = end_point;
 		//print_line("Direct Path");
 		return path;
 	}
@@ -375,7 +375,7 @@ Vector<Vector3> Navigation::get_simple_path(const Vector3 &p_start, const Vector
 
 		for (int i = 0; i < p->edges.size(); i++) {
 
-			Polygon::Edge &e = p->edges[i];
+			Polygon::Edge &e = p->edges.write[i];
 
 			if (!e.C)
 				continue;

--- a/scene/3d/navigation_mesh.cpp
+++ b/scene/3d/navigation_mesh.cpp
@@ -55,9 +55,9 @@ void NavigationMesh::create_from_mesh(const Ref<Mesh> &p_mesh) {
 		for (int j = 0; j < rlen; j += 3) {
 			Vector<int> vi;
 			vi.resize(3);
-			vi[0] = r[j + 0] + from;
-			vi[1] = r[j + 1] + from;
-			vi[2] = r[j + 2] + from;
+			vi.write[0] = r[j + 0] + from;
+			vi.write[1] = r[j + 1] + from;
+			vi.write[2] = r[j + 2] + from;
 
 			add_polygon(vi);
 		}
@@ -215,7 +215,7 @@ void NavigationMesh::_set_polygons(const Array &p_array) {
 
 	polygons.resize(p_array.size());
 	for (int i = 0; i < p_array.size(); i++) {
-		polygons[i].indices = p_array[i];
+		polygons.write[i].indices = p_array[i];
 	}
 }
 

--- a/scene/3d/particles.cpp
+++ b/scene/3d/particles.cpp
@@ -185,7 +185,7 @@ void Particles::set_draw_pass_mesh(int p_pass, const Ref<Mesh> &p_mesh) {
 
 	ERR_FAIL_INDEX(p_pass, draw_passes.size());
 
-	draw_passes[p_pass] = p_mesh;
+	draw_passes.write[p_pass] = p_mesh;
 
 	RID mesh_rid;
 	if (p_mesh.is_valid())

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -1260,11 +1260,11 @@ Ref<KinematicCollision> KinematicBody::_get_slide_collision(int p_bounce) {
 	}
 
 	if (slide_colliders[p_bounce].is_null()) {
-		slide_colliders[p_bounce].instance();
-		slide_colliders[p_bounce]->owner = this;
+		slide_colliders.write[p_bounce].instance();
+		slide_colliders.write[p_bounce]->owner = this;
 	}
 
-	slide_colliders[p_bounce]->collision = colliders[p_bounce];
+	slide_colliders.write[p_bounce]->collision = colliders[p_bounce];
 	return slide_colliders[p_bounce];
 }
 
@@ -1317,7 +1317,7 @@ KinematicBody::~KinematicBody() {
 
 	for (int i = 0; i < slide_colliders.size(); i++) {
 		if (slide_colliders[i].is_valid()) {
-			slide_colliders[i]->owner = NULL;
+			slide_colliders.write[i]->owner = NULL;
 		}
 	}
 }

--- a/scene/3d/spatial_velocity_tracker.cpp
+++ b/scene/3d/spatial_velocity_tracker.cpp
@@ -53,11 +53,11 @@ void SpatialVelocityTracker::update_position(const Vector3 &p_position) {
 	if (position_history_len == 0 || position_history[0].frame != ph.frame) { //in same frame, use latest
 		position_history_len = MIN(position_history.size(), position_history_len + 1);
 		for (int i = position_history_len - 1; i > 0; i--) {
-			position_history[i] = position_history[i - 1];
+			position_history.write[i] = position_history[i - 1];
 		}
 	}
 
-	position_history[0] = ph;
+	position_history.write[0] = ph;
 }
 Vector3 SpatialVelocityTracker::get_tracked_linear_velocity() const {
 
@@ -114,7 +114,7 @@ void SpatialVelocityTracker::reset(const Vector3 &p_new_pos) {
 		ph.frame = Engine::get_singleton()->get_idle_frame_ticks();
 	}
 
-	position_history[0] = ph;
+	position_history.write[0] = ph;
 	position_history_len = 1;
 }
 

--- a/scene/3d/vehicle_body.cpp
+++ b/scene/3d/vehicle_body.cpp
@@ -524,7 +524,7 @@ void VehicleBody::_update_suspension(PhysicsDirectBodyState *s) {
 
 //bilateral constraint between two dynamic objects
 void VehicleBody::_resolve_single_bilateral(PhysicsDirectBodyState *s, const Vector3 &pos1,
-		PhysicsBody *body2, const Vector3 &pos2, const Vector3 &normal, real_t &impulse, real_t p_rollInfluence) {
+		PhysicsBody *body2, const Vector3 &pos2, const Vector3 &normal, real_t &impulse, const real_t p_rollInfluence) {
 
 	real_t normalLenSqr = normal.length_squared();
 	//ERR_FAIL_COND( normalLenSqr < real_t(1.1));
@@ -677,8 +677,8 @@ void VehicleBody::_update_friction(PhysicsDirectBodyState *s) {
 
 	//collapse all those loops into one!
 	for (int i = 0; i < wheels.size(); i++) {
-		m_sideImpulse[i] = real_t(0.);
-		m_forwardImpulse[i] = real_t(0.);
+		m_sideImpulse.write[i] = real_t(0.);
+		m_forwardImpulse.write[i] = real_t(0.);
 	}
 
 	{
@@ -693,22 +693,22 @@ void VehicleBody::_update_friction(PhysicsDirectBodyState *s) {
 
 				Basis wheelBasis0 = wheelInfo.m_worldTransform.basis; //get_global_transform().basis;
 
-				m_axle[i] = wheelBasis0.get_axis(Vector3::AXIS_X);
+				m_axle.write[i] = wheelBasis0.get_axis(Vector3::AXIS_X);
 				//m_axle[i] = wheelInfo.m_raycastInfo.m_wheelAxleWS;
 
 				const Vector3 &surfNormalWS = wheelInfo.m_raycastInfo.m_contactNormalWS;
 				real_t proj = m_axle[i].dot(surfNormalWS);
-				m_axle[i] -= surfNormalWS * proj;
-				m_axle[i] = m_axle[i].normalized();
+				m_axle.write[i] -= surfNormalWS * proj;
+				m_axle.write[i] = m_axle[i].normalized();
 
-				m_forwardWS[i] = surfNormalWS.cross(m_axle[i]);
-				m_forwardWS[i].normalize();
+				m_forwardWS.write[i] = surfNormalWS.cross(m_axle[i]);
+				m_forwardWS.write[i].normalize();
 
 				_resolve_single_bilateral(s, wheelInfo.m_raycastInfo.m_contactPointWS,
 						wheelInfo.m_raycastInfo.m_groundObject, wheelInfo.m_raycastInfo.m_contactPointWS,
-						m_axle[i], m_sideImpulse[i], wheelInfo.m_rollInfluence);
+						m_axle[i], m_sideImpulse.write[i], wheelInfo.m_rollInfluence);
 
-				m_sideImpulse[i] *= sideFrictionStiffness2;
+				m_sideImpulse.write[i] *= sideFrictionStiffness2;
 			}
 		}
 	}
@@ -739,7 +739,7 @@ void VehicleBody::_update_friction(PhysicsDirectBodyState *s) {
 
 			//switch between active rolling (throttle), braking and non-active rolling friction (no throttle/break)
 
-			m_forwardImpulse[wheel] = real_t(0.);
+			m_forwardImpulse.write[wheel] = real_t(0.);
 			wheelInfo.m_skidInfo = real_t(1.);
 
 			if (wheelInfo.m_raycastInfo.m_isInContact) {
@@ -750,7 +750,7 @@ void VehicleBody::_update_friction(PhysicsDirectBodyState *s) {
 
 				real_t maximpSquared = maximp * maximpSide;
 
-				m_forwardImpulse[wheel] = rollingFriction; //wheelInfo.m_engineForce* timeStep;
+				m_forwardImpulse.write[wheel] = rollingFriction; //wheelInfo.m_engineForce* timeStep;
 
 				real_t x = (m_forwardImpulse[wheel]) * fwdFactor;
 				real_t y = (m_sideImpulse[wheel]) * sideFactor;
@@ -772,8 +772,8 @@ void VehicleBody::_update_friction(PhysicsDirectBodyState *s) {
 		for (int wheel = 0; wheel < wheels.size(); wheel++) {
 			if (m_sideImpulse[wheel] != real_t(0.)) {
 				if (wheels[wheel]->m_skidInfo < real_t(1.)) {
-					m_forwardImpulse[wheel] *= wheels[wheel]->m_skidInfo;
-					m_sideImpulse[wheel] *= wheels[wheel]->m_skidInfo;
+					m_forwardImpulse.write[wheel] *= wheels[wheel]->m_skidInfo;
+					m_sideImpulse.write[wheel] *= wheels[wheel]->m_skidInfo;
 				}
 			}
 		}

--- a/scene/3d/vehicle_body.h
+++ b/scene/3d/vehicle_body.h
@@ -168,7 +168,7 @@ class VehicleBody : public RigidBody {
 		btVehicleWheelContactPoint(PhysicsDirectBodyState *s, PhysicsBody *body1, const Vector3 &frictionPosWorld, const Vector3 &frictionDirectionWorld, real_t maxImpulse);
 	};
 
-	void _resolve_single_bilateral(PhysicsDirectBodyState *s, const Vector3 &pos1, PhysicsBody *body2, const Vector3 &pos2, const Vector3 &normal, real_t &impulse, real_t p_rollInfluence);
+	void _resolve_single_bilateral(PhysicsDirectBodyState *s, const Vector3 &pos1, PhysicsBody *body2, const Vector3 &pos2, const Vector3 &normal, real_t &impulse, const real_t p_rollInfluence);
 	real_t _calc_rolling_friction(btVehicleWheelContactPoint &contactPoint);
 
 	void _update_friction(PhysicsDirectBodyState *s);

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -24,7 +24,7 @@ void AnimationNodeBlendSpace2D::add_blend_point(const Ref<AnimationRootNode> &p_
 		for (int i = 0; i < triangles.size(); i++) {
 			for (int j = 0; j < 3; j++) {
 				if (triangles[i].points[j] >= p_at_index) {
-					triangles[i].points[j]++;
+					triangles.write[i].points[j]++;
 				}
 			}
 		}
@@ -81,7 +81,7 @@ void AnimationNodeBlendSpace2D::remove_blend_point(int p_point) {
 				erase = true;
 				break;
 			} else if (triangles[i].points[j] > p_point) {
-				triangles[i].points[j]--;
+				triangles.write[i].points[j]--;
 			}
 		}
 		if (erase) {
@@ -264,9 +264,9 @@ Vector<int> AnimationNodeBlendSpace2D::_get_triangles() const {
 
 	t.resize(triangles.size() * 3);
 	for (int i = 0; i < triangles.size(); i++) {
-		t[i * 3 + 0] = triangles[i].points[0];
-		t[i * 3 + 1] = triangles[i].points[1];
-		t[i * 3 + 2] = triangles[i].points[2];
+		t.write[i * 3 + 0] = triangles[i].points[0];
+		t.write[i * 3 + 1] = triangles[i].points[1];
+		t.write[i * 3 + 2] = triangles[i].points[2];
 	}
 	return t;
 }
@@ -284,7 +284,7 @@ void AnimationNodeBlendSpace2D::_update_triangles() {
 	Vector<Vector2> points;
 	points.resize(blend_points_used);
 	for (int i = 0; i < blend_points_used; i++) {
-		points[i] = blend_points[i].position;
+		points.write[i] = blend_points[i].position;
 	}
 
 	Vector<Delaunay2D::Triangle> triangles = Delaunay2D::triangulate(points);

--- a/scene/animation/animation_cache.cpp
+++ b/scene/animation/animation_cache.cpp
@@ -43,7 +43,7 @@ void AnimationCache::_node_exit_tree(Node *p_node) {
 		if (path_cache[i].node != p_node)
 			continue;
 
-		path_cache[i].valid = false; //invalidate path cache
+		path_cache.write[i].valid = false; //invalidate path cache
 	}
 }
 
@@ -196,7 +196,7 @@ void AnimationCache::set_track_transform(int p_idx, const Transform &p_transform
 
 	ERR_FAIL_COND(!cache_valid);
 	ERR_FAIL_INDEX(p_idx, path_cache.size());
-	Path &p = path_cache[p_idx];
+	Path &p = path_cache.write[p_idx];
 	if (!p.valid)
 		return;
 
@@ -217,7 +217,7 @@ void AnimationCache::set_track_value(int p_idx, const Variant &p_value) {
 
 	ERR_FAIL_COND(!cache_valid);
 	ERR_FAIL_INDEX(p_idx, path_cache.size());
-	Path &p = path_cache[p_idx];
+	Path &p = path_cache.write[p_idx];
 	if (!p.valid)
 		return;
 
@@ -232,7 +232,7 @@ void AnimationCache::call_track(int p_idx, const StringName &p_method, const Var
 
 	ERR_FAIL_COND(!cache_valid);
 	ERR_FAIL_INDEX(p_idx, path_cache.size());
-	Path &p = path_cache[p_idx];
+	Path &p = path_cache.write[p_idx];
 	if (!p.valid)
 		return;
 
@@ -297,11 +297,11 @@ void AnimationCache::set_all(float p_time, float p_delta) {
 						call_track(i, name, NULL, 0, err);
 					} else {
 
-						Vector<Variant *> argptrs;
+						Vector<const Variant *> argptrs;
 						argptrs.resize(args.size());
 						for (int j = 0; j < args.size(); j++) {
 
-							argptrs[j] = &args[j];
+							argptrs.write[j] = &args.write[j];
 						}
 
 						call_track(i, name, (const Variant **)&argptrs[0], args.size(), err);

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -169,11 +169,11 @@ void AnimationNodeStateMachine::rename_node(const StringName &p_name, const Stri
 
 	for (int i = 0; i < transitions.size(); i++) {
 		if (transitions[i].from == p_name) {
-			transitions[i].from = p_new_name;
+			transitions.write[i].from = p_new_name;
 		}
 
 		if (transitions[i].to == p_name) {
-			transitions[i].to = p_new_name;
+			transitions.write[i].to = p_new_name;
 		}
 	}
 

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -233,7 +233,7 @@ void AnimationPlayer::_ensure_node_caches(AnimationData *p_anim) {
 
 	for (int i = 0; i < a->get_track_count(); i++) {
 
-		p_anim->node_cache[i] = NULL;
+		p_anim->node_cache.write[i] = NULL;
 		RES resource;
 		Vector<StringName> leftover_path;
 		Node *child = parent->get_node_and_resource(a->track_get_path(i), resource, leftover_path);
@@ -265,12 +265,12 @@ void AnimationPlayer::_ensure_node_caches(AnimationData *p_anim) {
 
 		if (node_cache_map.has(key)) {
 
-			p_anim->node_cache[i] = &node_cache_map[key];
+			p_anim->node_cache.write[i] = &node_cache_map[key];
 		} else {
 
 			node_cache_map[key] = TrackNodeCache();
 
-			p_anim->node_cache[i] = &node_cache_map[key];
+			p_anim->node_cache.write[i] = &node_cache_map[key];
 			p_anim->node_cache[i]->path = a->track_get_path(i);
 			p_anim->node_cache[i]->node = child;
 			p_anim->node_cache[i]->resource = resource;

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -78,9 +78,9 @@ float AnimationNode::blend_input(int p_input, float p_time, bool p_seek, float p
 		return 0;
 	}
 
-	inputs[p_input].last_pass = state->last_pass;
+	inputs.write[p_input].last_pass = state->last_pass;
 
-	return _blend_node(node, p_time, p_seek, p_blend, p_filter, p_optimize, &inputs[p_input].activity);
+	return _blend_node(node, p_time, p_seek, p_blend, p_filter, p_optimize, &inputs.write[p_input].activity);
 }
 
 float AnimationNode::blend_node(Ref<AnimationNode> p_node, float p_time, bool p_seek, float p_blend, FilterAction p_filter, bool p_optimize) {
@@ -221,7 +221,7 @@ StringName AnimationNode::get_input_connection(int p_input) {
 void AnimationNode::set_input_connection(int p_input, const StringName &p_connection) {
 
 	ERR_FAIL_INDEX(p_input, inputs.size());
-	inputs[p_input].connected_to = p_connection;
+	inputs.write[p_input].connected_to = p_connection;
 }
 
 String AnimationNode::get_caption() const {
@@ -248,7 +248,7 @@ void AnimationNode::add_input(const String &p_name) {
 void AnimationNode::set_input_name(int p_input, const String &p_name) {
 	ERR_FAIL_INDEX(p_input, inputs.size());
 	ERR_FAIL_COND(p_name.find(".") != -1 || p_name.find("/") != -1);
-	inputs[p_input].name = p_name;
+	inputs.write[p_input].name = p_name;
 	emit_changed();
 }
 

--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -1152,7 +1152,7 @@ void AnimationTreePlayer::transition_node_set_input_auto_advance(const StringNam
 	GET_NODE(NODE_TRANSITION, TransitionNode);
 	ERR_FAIL_INDEX(p_input, n->input_data.size());
 
-	n->input_data[p_input].auto_advance = p_auto_advance;
+	n->input_data.write[p_input].auto_advance = p_auto_advance;
 }
 void AnimationTreePlayer::transition_node_set_xfade_time(const StringName &p_node, float p_time) {
 
@@ -1365,7 +1365,7 @@ void AnimationTreePlayer::remove_node(const StringName &p_node) {
 		for (int i = 0; i < nb->inputs.size(); i++) {
 
 			if (nb->inputs[i].node == p_node)
-				nb->inputs[i].node = StringName();
+				nb->inputs.write[i].node = StringName();
 		}
 	}
 
@@ -1426,11 +1426,11 @@ Error AnimationTreePlayer::connect_nodes(const StringName &p_src_node, const Str
 		for (int i = 0; i < nb->inputs.size(); i++) {
 
 			if (nb->inputs[i].node == p_src_node)
-				nb->inputs[i].node = StringName();
+				nb->inputs.write[i].node = StringName();
 		}
 	}
 
-	dst->inputs[p_dst_input].node = p_src_node;
+	dst->inputs.write[p_dst_input].node = p_src_node;
 
 	_clear_cycle_test();
 
@@ -1463,7 +1463,7 @@ void AnimationTreePlayer::disconnect_nodes(const StringName &p_node, int p_input
 
 	NodeBase *dst = node_map[p_node];
 	ERR_FAIL_INDEX(p_input, dst->inputs.size());
-	dst->inputs[p_input].node = StringName();
+	dst->inputs.write[p_input].node = StringName();
 	last_error = CONNECT_INCOMPLETE;
 	dirty_caches = true;
 }
@@ -1703,7 +1703,7 @@ Error AnimationTreePlayer::node_rename(const StringName &p_node, const StringNam
 		for (int i = 0; i < nb->inputs.size(); i++) {
 
 			if (nb->inputs[i].node == p_node) {
-				nb->inputs[i].node = p_new_name;
+				nb->inputs.write[i].node = p_new_name;
 			}
 		}
 	}

--- a/scene/gui/gradient_edit.cpp
+++ b/scene/gui/gradient_edit.cpp
@@ -256,7 +256,7 @@ void GradientEdit::_gui_input(const Ref<InputEvent> &p_event) {
 		if (!valid)
 			return;
 
-		points[grabbed].offset = newofs;
+		points.write[grabbed].offset = newofs;
 
 		points.sort();
 		for (int i = 0; i < points.size(); i++) {
@@ -407,7 +407,7 @@ void GradientEdit::_color_changed(const Color &p_color) {
 
 	if (grabbed == -1)
 		return;
-	points[grabbed].color = p_color;
+	points.write[grabbed].color = p_color;
 	update();
 	emit_signal("ramp_changed");
 }

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -72,7 +72,7 @@ void ItemList::set_item_text(int p_idx, const String &p_text) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
 
-	items[p_idx].text = p_text;
+	items.write[p_idx].text = p_text;
 	update();
 	shape_changed = true;
 }
@@ -85,7 +85,7 @@ String ItemList::get_item_text(int p_idx) const {
 
 void ItemList::set_item_tooltip_enabled(int p_idx, const bool p_enabled) {
 	ERR_FAIL_INDEX(p_idx, items.size());
-	items[p_idx].tooltip_enabled = p_enabled;
+	items.write[p_idx].tooltip_enabled = p_enabled;
 }
 
 bool ItemList::is_item_tooltip_enabled(int p_idx) const {
@@ -97,7 +97,7 @@ void ItemList::set_item_tooltip(int p_idx, const String &p_tooltip) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
 
-	items[p_idx].tooltip = p_tooltip;
+	items.write[p_idx].tooltip = p_tooltip;
 	update();
 	shape_changed = true;
 }
@@ -112,7 +112,7 @@ void ItemList::set_item_icon(int p_idx, const Ref<Texture> &p_icon) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
 
-	items[p_idx].icon = p_icon;
+	items.write[p_idx].icon = p_icon;
 	update();
 	shape_changed = true;
 }
@@ -128,7 +128,7 @@ void ItemList::set_item_icon_region(int p_idx, const Rect2 &p_region) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
 
-	items[p_idx].icon_region = p_region;
+	items.write[p_idx].icon_region = p_region;
 	update();
 	shape_changed = true;
 }
@@ -144,7 +144,7 @@ void ItemList::set_item_icon_modulate(int p_idx, const Color &p_modulate) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
 
-	items[p_idx].icon_modulate = p_modulate;
+	items.write[p_idx].icon_modulate = p_modulate;
 	update();
 }
 
@@ -159,7 +159,7 @@ void ItemList::set_item_custom_bg_color(int p_idx, const Color &p_custom_bg_colo
 
 	ERR_FAIL_INDEX(p_idx, items.size());
 
-	items[p_idx].custom_bg = p_custom_bg_color;
+	items.write[p_idx].custom_bg = p_custom_bg_color;
 }
 
 Color ItemList::get_item_custom_bg_color(int p_idx) const {
@@ -173,7 +173,7 @@ void ItemList::set_item_custom_fg_color(int p_idx, const Color &p_custom_fg_colo
 
 	ERR_FAIL_INDEX(p_idx, items.size());
 
-	items[p_idx].custom_fg = p_custom_fg_color;
+	items.write[p_idx].custom_fg = p_custom_fg_color;
 }
 
 Color ItemList::get_item_custom_fg_color(int p_idx) const {
@@ -187,7 +187,7 @@ void ItemList::set_item_tag_icon(int p_idx, const Ref<Texture> &p_tag_icon) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
 
-	items[p_idx].tag_icon = p_tag_icon;
+	items.write[p_idx].tag_icon = p_tag_icon;
 	update();
 	shape_changed = true;
 }
@@ -202,7 +202,7 @@ void ItemList::set_item_selectable(int p_idx, bool p_selectable) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
 
-	items[p_idx].selectable = p_selectable;
+	items.write[p_idx].selectable = p_selectable;
 }
 
 bool ItemList::is_item_selectable(int p_idx) const {
@@ -215,7 +215,7 @@ void ItemList::set_item_disabled(int p_idx, bool p_disabled) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
 
-	items[p_idx].disabled = p_disabled;
+	items.write[p_idx].disabled = p_disabled;
 	update();
 }
 
@@ -229,7 +229,7 @@ void ItemList::set_item_metadata(int p_idx, const Variant &p_metadata) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
 
-	items[p_idx].metadata = p_metadata;
+	items.write[p_idx].metadata = p_metadata;
 	update();
 	shape_changed = true;
 }
@@ -250,7 +250,7 @@ void ItemList::select(int p_idx, bool p_single) {
 		}
 
 		for (int i = 0; i < items.size(); i++) {
-			items[i].selected = p_idx == i;
+			items.write[i].selected = p_idx == i;
 		}
 
 		current = p_idx;
@@ -258,7 +258,7 @@ void ItemList::select(int p_idx, bool p_single) {
 	} else {
 
 		if (items[p_idx].selectable && !items[p_idx].disabled) {
-			items[p_idx].selected = true;
+			items.write[p_idx].selected = true;
 		}
 	}
 	update();
@@ -268,10 +268,10 @@ void ItemList::unselect(int p_idx) {
 	ERR_FAIL_INDEX(p_idx, items.size());
 
 	if (select_mode != SELECT_MULTI) {
-		items[p_idx].selected = false;
+		items.write[p_idx].selected = false;
 		current = -1;
 	} else {
-		items[p_idx].selected = false;
+		items.write[p_idx].selected = false;
 	}
 	update();
 }
@@ -283,7 +283,7 @@ void ItemList::unselect_all() {
 
 	for (int i = 0; i < items.size(); i++) {
 
-		items[i].selected = false;
+		items.write[i].selected = false;
 	}
 	current = -1;
 	update();
@@ -869,8 +869,8 @@ void ItemList::_notification(int p_what) {
 				// elements need to adapt to the selected size
 				minsize.y += vseparation;
 				minsize.x += hseparation;
-				items[i].rect_cache.size = minsize;
-				items[i].min_rect_cache.size = minsize;
+				items.write[i].rect_cache.size = minsize;
+				items.write[i].min_rect_cache.size = minsize;
 			}
 
 			int fit_size = size.x - bg->get_minimum_size().width - mw;
@@ -897,8 +897,8 @@ void ItemList::_notification(int p_what) {
 					}
 
 					if (same_column_width)
-						items[i].rect_cache.size.x = max_column_width;
-					items[i].rect_cache.position = ofs;
+						items.write[i].rect_cache.size.x = max_column_width;
+					items.write[i].rect_cache.position = ofs;
 					max_h = MAX(max_h, items[i].rect_cache.size.y);
 					ofs.x += items[i].rect_cache.size.x + hseparation;
 					col++;
@@ -908,7 +908,7 @@ void ItemList::_notification(int p_what) {
 							separators.push_back(ofs.y + max_h + vseparation / 2);
 
 						for (int j = i; j >= 0 && col > 0; j--, col--) {
-							items[j].rect_cache.size.y = max_h;
+							items.write[j].rect_cache.size.y = max_h;
 						}
 
 						ofs.x = 0;
@@ -919,7 +919,7 @@ void ItemList::_notification(int p_what) {
 				}
 
 				for (int j = items.size() - 1; j >= 0 && col > 0; j--, col--) {
-					items[j].rect_cache.size.y = max_h;
+					items.write[j].rect_cache.size.y = max_h;
 				}
 
 				if (all_fit) {
@@ -1103,8 +1103,8 @@ void ItemList::_notification(int p_what) {
 
 						int cs = j < ss ? font->get_char_size(items[i].text[j], items[i].text[j + 1]).x : 0;
 						if (ofs + cs > max_len || j == ss) {
-							line_limit_cache[line] = j;
-							line_size_cache[line] = ofs;
+							line_limit_cache.write[line] = j;
+							line_size_cache.write[line] = ofs;
 							line++;
 							ofs = 0;
 							if (line >= max_text_lines)

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -410,7 +410,7 @@ void PopupMenu::_notification(int p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 
 			for (int i = 0; i < items.size(); i++) {
-				items[i].xl_text = tr(items[i].text);
+				items.write[i].xl_text = tr(items[i].text);
 			}
 
 			minimum_size_changed();
@@ -524,7 +524,7 @@ void PopupMenu::_notification(int p_what) {
 					font->draw(ci, item_ofs + Point2(0, Math::floor((h - font_h) / 2.0)), text, i == mouse_over ? font_color_hover : font_color_accel);
 				}
 
-				items[i]._ofs_cache = ofs.y;
+				items.write[i]._ofs_cache = ofs.y;
 
 				ofs.y += h;
 			}
@@ -622,7 +622,7 @@ void PopupMenu::add_check_item(const String &p_label, int p_ID, uint32_t p_accel
 void PopupMenu::add_radio_check_item(const String &p_label, int p_ID, uint32_t p_accel) {
 
 	add_check_item(p_label, p_ID, p_accel);
-	items[items.size() - 1].checkable_type = Item::CHECKABLE_TYPE_RADIO_BUTTON;
+	items.write[items.size() - 1].checkable_type = Item::CHECKABLE_TYPE_RADIO_BUTTON;
 	update();
 	minimum_size_changed();
 }
@@ -630,7 +630,7 @@ void PopupMenu::add_radio_check_item(const String &p_label, int p_ID, uint32_t p
 void PopupMenu::add_icon_radio_check_item(const Ref<Texture> &p_icon, const String &p_label, int p_ID, uint32_t p_accel) {
 
 	add_icon_check_item(p_icon, p_label, p_ID, p_accel);
-	items[items.size() - 1].checkable_type = Item::CHECKABLE_TYPE_RADIO_BUTTON;
+	items.write[items.size() - 1].checkable_type = Item::CHECKABLE_TYPE_RADIO_BUTTON;
 	update();
 	minimum_size_changed();
 }
@@ -702,7 +702,7 @@ void PopupMenu::add_check_shortcut(const Ref<ShortCut> &p_shortcut, int p_ID, bo
 void PopupMenu::add_radio_check_shortcut(const Ref<ShortCut> &p_shortcut, int p_ID, bool p_global) {
 
 	add_check_shortcut(p_shortcut, p_ID, p_global);
-	items[items.size() - 1].checkable_type = Item::CHECKABLE_TYPE_RADIO_BUTTON;
+	items.write[items.size() - 1].checkable_type = Item::CHECKABLE_TYPE_RADIO_BUTTON;
 	update();
 	minimum_size_changed();
 }
@@ -724,8 +724,8 @@ void PopupMenu::add_multistate_item(const String &p_label, int p_max_states, int
 void PopupMenu::set_item_text(int p_idx, const String &p_text) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
-	items[p_idx].text = p_text;
-	items[p_idx].xl_text = tr(p_text);
+	items.write[p_idx].text = p_text;
+	items.write[p_idx].xl_text = tr(p_text);
 
 	update();
 	minimum_size_changed();
@@ -733,7 +733,7 @@ void PopupMenu::set_item_text(int p_idx, const String &p_text) {
 void PopupMenu::set_item_icon(int p_idx, const Ref<Texture> &p_icon) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
-	items[p_idx].icon = p_icon;
+	items.write[p_idx].icon = p_icon;
 
 	update();
 	minimum_size_changed();
@@ -742,7 +742,7 @@ void PopupMenu::set_item_checked(int p_idx, bool p_checked) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
 
-	items[p_idx].checked = p_checked;
+	items.write[p_idx].checked = p_checked;
 
 	update();
 	minimum_size_changed();
@@ -750,7 +750,7 @@ void PopupMenu::set_item_checked(int p_idx, bool p_checked) {
 void PopupMenu::set_item_id(int p_idx, int p_ID) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
-	items[p_idx].ID = p_ID;
+	items.write[p_idx].ID = p_ID;
 
 	update();
 	minimum_size_changed();
@@ -759,7 +759,7 @@ void PopupMenu::set_item_id(int p_idx, int p_ID) {
 void PopupMenu::set_item_accelerator(int p_idx, uint32_t p_accel) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
-	items[p_idx].accel = p_accel;
+	items.write[p_idx].accel = p_accel;
 
 	update();
 	minimum_size_changed();
@@ -768,7 +768,7 @@ void PopupMenu::set_item_accelerator(int p_idx, uint32_t p_accel) {
 void PopupMenu::set_item_metadata(int p_idx, const Variant &p_meta) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
-	items[p_idx].metadata = p_meta;
+	items.write[p_idx].metadata = p_meta;
 	update();
 	minimum_size_changed();
 }
@@ -776,7 +776,7 @@ void PopupMenu::set_item_metadata(int p_idx, const Variant &p_meta) {
 void PopupMenu::set_item_disabled(int p_idx, bool p_disabled) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
-	items[p_idx].disabled = p_disabled;
+	items.write[p_idx].disabled = p_disabled;
 	update();
 	minimum_size_changed();
 }
@@ -784,7 +784,7 @@ void PopupMenu::set_item_disabled(int p_idx, bool p_disabled) {
 void PopupMenu::set_item_submenu(int p_idx, const String &p_submenu) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
-	items[p_idx].submenu = p_submenu;
+	items.write[p_idx].submenu = p_submenu;
 	update();
 	minimum_size_changed();
 }
@@ -792,7 +792,7 @@ void PopupMenu::set_item_submenu(int p_idx, const String &p_submenu) {
 void PopupMenu::toggle_item_checked(int p_idx) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
-	items[p_idx].checked = !items[p_idx].checked;
+	items.write[p_idx].checked = !items[p_idx].checked;
 	update();
 	minimum_size_changed();
 }
@@ -886,7 +886,7 @@ int PopupMenu::get_item_state(int p_idx) const {
 void PopupMenu::set_item_as_separator(int p_idx, bool p_separator) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
-	items[p_idx].separator = p_separator;
+	items.write[p_idx].separator = p_separator;
 	update();
 }
 
@@ -898,21 +898,21 @@ bool PopupMenu::is_item_separator(int p_idx) const {
 void PopupMenu::set_item_as_checkable(int p_idx, bool p_checkable) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
-	items[p_idx].checkable_type = p_checkable ? Item::CHECKABLE_TYPE_CHECK_BOX : Item::CHECKABLE_TYPE_NONE;
+	items.write[p_idx].checkable_type = p_checkable ? Item::CHECKABLE_TYPE_CHECK_BOX : Item::CHECKABLE_TYPE_NONE;
 	update();
 }
 
 void PopupMenu::set_item_as_radio_checkable(int p_idx, bool p_radio_checkable) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
-	items[p_idx].checkable_type = p_radio_checkable ? Item::CHECKABLE_TYPE_RADIO_BUTTON : Item::CHECKABLE_TYPE_NONE;
+	items.write[p_idx].checkable_type = p_radio_checkable ? Item::CHECKABLE_TYPE_RADIO_BUTTON : Item::CHECKABLE_TYPE_NONE;
 	update();
 }
 
 void PopupMenu::set_item_tooltip(int p_idx, const String &p_tooltip) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
-	items[p_idx].tooltip = p_tooltip;
+	items.write[p_idx].tooltip = p_tooltip;
 	update();
 }
 
@@ -921,8 +921,8 @@ void PopupMenu::set_item_shortcut(int p_idx, const Ref<ShortCut> &p_shortcut, bo
 	if (items[p_idx].shortcut.is_valid()) {
 		_unref_shortcut(items[p_idx].shortcut);
 	}
-	items[p_idx].shortcut = p_shortcut;
-	items[p_idx].shortcut_is_global = p_global;
+	items.write[p_idx].shortcut = p_shortcut;
+	items.write[p_idx].shortcut_is_global = p_global;
 
 	if (items[p_idx].shortcut.is_valid()) {
 		_ref_shortcut(items[p_idx].shortcut);
@@ -934,7 +934,7 @@ void PopupMenu::set_item_shortcut(int p_idx, const Ref<ShortCut> &p_shortcut, bo
 void PopupMenu::set_item_h_offset(int p_idx, int p_offset) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
-	items[p_idx].h_ofs = p_offset;
+	items.write[p_idx].h_ofs = p_offset;
 	update();
 	minimum_size_changed();
 }
@@ -942,14 +942,14 @@ void PopupMenu::set_item_h_offset(int p_idx, int p_offset) {
 void PopupMenu::set_item_multistate(int p_idx, int p_state) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
-	items[p_idx].state = p_state;
+	items.write[p_idx].state = p_state;
 	update();
 }
 
 void PopupMenu::set_item_shortcut_disabled(int p_idx, bool p_disabled) {
 
 	ERR_FAIL_INDEX(p_idx, items.size());
-	items[p_idx].shortcut_is_disabled = p_disabled;
+	items.write[p_idx].shortcut_is_disabled = p_disabled;
 	update();
 }
 
@@ -960,9 +960,9 @@ void PopupMenu::toggle_item_multistate(int p_idx) {
 		return;
 	}
 
-	++items[p_idx].state;
-	if (items[p_idx].max_states <= items[p_idx].state)
-		items[p_idx].state = 0;
+	++items.write[p_idx].state;
+	if (items.write[p_idx].max_states <= items[p_idx].state)
+		items.write[p_idx].state = 0;
 
 	update();
 }

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -149,7 +149,7 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 		if (r_click_item)
 			*r_click_item = NULL;
 	}
-	Line &l = p_frame->lines[p_line];
+	Line &l = p_frame->lines.write[p_line];
 	Item *it = l.from;
 
 	int line_ofs = 0;
@@ -535,9 +535,9 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 					int idx = 0;
 					//set minimums to zero
 					for (int i = 0; i < table->columns.size(); i++) {
-						table->columns[i].min_width = 0;
-						table->columns[i].max_width = 0;
-						table->columns[i].width = 0;
+						table->columns.write[i].min_width = 0;
+						table->columns.write[i].max_width = 0;
+						table->columns.write[i].width = 0;
 					}
 					//compute minimum width for each cell
 					const int available_width = p_width - hseparation * (table->columns.size() - 1) - wofs;
@@ -553,8 +553,8 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 						for (int i = 0; i < frame->lines.size(); i++) {
 
 							_process_line(frame, Point2(), ly, available_width, i, PROCESS_CACHE, cfont, Color(), font_color_shadow, use_outline, shadow_ofs);
-							table->columns[column].min_width = MAX(table->columns[column].min_width, frame->lines[i].minimum_width);
-							table->columns[column].max_width = MAX(table->columns[column].max_width, frame->lines[i].maximum_width);
+							table->columns.write[column].min_width = MAX(table->columns[column].min_width, frame->lines[i].minimum_width);
+							table->columns.write[column].max_width = MAX(table->columns[column].max_width, frame->lines[i].maximum_width);
 						}
 						idx++;
 					}
@@ -568,16 +568,16 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 					for (int i = 0; i < table->columns.size(); i++) {
 						remaining_width -= table->columns[i].min_width;
 						if (table->columns[i].max_width > table->columns[i].min_width)
-							table->columns[i].expand = true;
+							table->columns.write[i].expand = true;
 						if (table->columns[i].expand)
 							total_ratio += table->columns[i].expand_ratio;
 					}
 
 					//assign actual widths
 					for (int i = 0; i < table->columns.size(); i++) {
-						table->columns[i].width = table->columns[i].min_width;
+						table->columns.write[i].width = table->columns[i].min_width;
 						if (table->columns[i].expand)
-							table->columns[i].width += table->columns[i].expand_ratio * remaining_width / total_ratio;
+							table->columns.write[i].width += table->columns[i].expand_ratio * remaining_width / total_ratio;
 						table->total_width += table->columns[i].width + hseparation;
 					}
 
@@ -592,7 +592,7 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 							int dif = table->columns[i].width - table->columns[i].max_width;
 							if (dif > 0) {
 								table_need_fit = true;
-								table->columns[i].width = table->columns[i].max_width;
+								table->columns.write[i].width = table->columns[i].max_width;
 								table->total_width -= dif;
 								total_ratio -= table->columns[i].expand_ratio;
 							}
@@ -606,7 +606,7 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 									if (dif > 0) {
 										int slice = table->columns[i].expand_ratio * remaining_width / total_ratio;
 										int incr = MIN(dif, slice);
-										table->columns[i].width += incr;
+										table->columns.write[i].width += incr;
 										table->total_width += incr;
 									}
 								}
@@ -626,8 +626,8 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 
 							int ly = 0;
 							_process_line(frame, Point2(), ly, table->columns[column].width, i, PROCESS_CACHE, cfont, Color(), font_color_shadow, use_outline, shadow_ofs);
-							frame->lines[i].height_cache = ly; //actual height
-							frame->lines[i].height_accum_cache = ly; //actual height
+							frame->lines.write[i].height_cache = ly; //actual height
+							frame->lines.write[i].height_accum_cache = ly; //actual height
 						}
 						idx++;
 					}
@@ -669,7 +669,7 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 
 						yofs += frame->lines[i].height_cache;
 						if (p_mode == PROCESS_CACHE) {
-							frame->lines[i].height_accum_cache = offset.y + draw_ofs.y + frame->lines[i].height_cache;
+							frame->lines.write[i].height_accum_cache = offset.y + draw_ofs.y + frame->lines[i].height_cache;
 						}
 					}
 
@@ -1267,11 +1267,11 @@ void RichTextLabel::_validate_line_caches(ItemFrame *p_frame) {
 
 		int y = 0;
 		_process_line(p_frame, text_rect.get_position(), y, text_rect.get_size().width - scroll_w, i, PROCESS_CACHE, base_font, Color(), font_color_shadow, use_outline, shadow_ofs);
-		p_frame->lines[i].height_cache = y;
-		p_frame->lines[i].height_accum_cache = y;
+		p_frame->lines.write[i].height_cache = y;
+		p_frame->lines.write[i].height_accum_cache = y;
 
 		if (i > 0)
-			p_frame->lines[i].height_accum_cache += p_frame->lines[i - 1].height_accum_cache;
+			p_frame->lines.write[i].height_accum_cache += p_frame->lines[i - 1].height_accum_cache;
 	}
 
 	int total_height = 0;
@@ -1346,7 +1346,7 @@ void RichTextLabel::add_text(const String &p_text) {
 			_add_item(item, false);
 			current_frame->lines.resize(current_frame->lines.size() + 1);
 			if (item->type != ITEM_NEWLINE)
-				current_frame->lines[current_frame->lines.size() - 1].from = item;
+				current_frame->lines.write[current_frame->lines.size() - 1].from = item;
 			_invalidate_current_line(current_frame);
 		}
 
@@ -1369,7 +1369,7 @@ void RichTextLabel::_add_item(Item *p_item, bool p_enter, bool p_ensure_newline)
 	}
 
 	if (current_frame->lines[current_frame->lines.size() - 1].from == NULL) {
-		current_frame->lines[current_frame->lines.size() - 1].from = p_item;
+		current_frame->lines.write[current_frame->lines.size() - 1].from = p_item;
 	}
 	p_item->line = current_frame->lines.size() - 1;
 
@@ -1431,7 +1431,7 @@ bool RichTextLabel::remove_line(const int p_line) {
 	_remove_item(current->subitems[lines], current->subitems[lines]->line, lines);
 
 	if (p_line == 0) {
-		main->lines[0].from = main;
+		main->lines.write[0].from = main;
 	}
 
 	main->first_invalid_line = 0;
@@ -1510,8 +1510,8 @@ void RichTextLabel::push_table(int p_columns) {
 	item->columns.resize(p_columns);
 	item->total_width = 0;
 	for (int i = 0; i < item->columns.size(); i++) {
-		item->columns[i].expand = false;
-		item->columns[i].expand_ratio = 1;
+		item->columns.write[i].expand = false;
+		item->columns.write[i].expand_ratio = 1;
 	}
 	_add_item(item, true, true);
 }
@@ -1521,8 +1521,8 @@ void RichTextLabel::set_table_column_expand(int p_column, bool p_expand, int p_r
 	ERR_FAIL_COND(current->type != ITEM_TABLE);
 	ItemTable *table = static_cast<ItemTable *>(current);
 	ERR_FAIL_INDEX(p_column, table->columns.size());
-	table->columns[p_column].expand = p_expand;
-	table->columns[p_column].expand_ratio = p_ratio;
+	table->columns.write[p_column].expand = p_expand;
+	table->columns.write[p_column].expand_ratio = p_ratio;
 }
 
 void RichTextLabel::push_cell() {
@@ -1536,7 +1536,7 @@ void RichTextLabel::push_cell() {
 	item->cell = true;
 	item->parent_line = item->parent_frame->lines.size() - 1;
 	item->lines.resize(1);
-	item->lines[0].from = NULL;
+	item->lines.write[0].from = NULL;
 	item->first_invalid_line = 0;
 }
 
@@ -2269,7 +2269,7 @@ RichTextLabel::RichTextLabel() {
 	main->index = 0;
 	current = main;
 	main->lines.resize(1);
-	main->lines[0].from = main;
+	main->lines.write[0].from = main;
 	main->first_invalid_line = 0;
 	current_frame = main;
 	tab_size = 4;

--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -286,7 +286,7 @@ void Tabs::_notification(int p_what) {
 
 			for (int i = 0; i < tabs.size(); i++) {
 
-				tabs[i].ofs_cache = mw;
+				tabs.write[i].ofs_cache = mw;
 				mw += get_tab_width(i);
 			}
 
@@ -314,7 +314,7 @@ void Tabs::_notification(int p_what) {
 				if (i < offset)
 					continue;
 
-				tabs[i].ofs_cache = w;
+				tabs.write[i].ofs_cache = w;
 
 				int lsize = tabs[i].size_cache;
 
@@ -379,7 +379,7 @@ void Tabs::_notification(int p_what) {
 
 					rb->draw(ci, Point2i(w + style->get_margin(MARGIN_LEFT), rb_rect.position.y + style->get_margin(MARGIN_TOP)));
 					w += rb->get_width();
-					tabs[i].rb_rect = rb_rect;
+					tabs.write[i].rb_rect = rb_rect;
 				}
 
 				if (cb_displaypolicy == CLOSE_BUTTON_SHOW_ALWAYS || (cb_displaypolicy == CLOSE_BUTTON_SHOW_ACTIVE_ONLY && i == current)) {
@@ -403,7 +403,7 @@ void Tabs::_notification(int p_what) {
 
 					cb->draw(ci, Point2i(w + style->get_margin(MARGIN_LEFT), cb_rect.position.y + style->get_margin(MARGIN_TOP)));
 					w += cb->get_width();
-					tabs[i].cb_rect = cb_rect;
+					tabs.write[i].cb_rect = cb_rect;
 				}
 
 				w += sb->get_margin(MARGIN_RIGHT);
@@ -471,7 +471,7 @@ bool Tabs::get_offset_buttons_visible() const {
 void Tabs::set_tab_title(int p_tab, const String &p_title) {
 
 	ERR_FAIL_INDEX(p_tab, tabs.size());
-	tabs[p_tab].text = p_title;
+	tabs.write[p_tab].text = p_title;
 	update();
 	minimum_size_changed();
 }
@@ -485,7 +485,7 @@ String Tabs::get_tab_title(int p_tab) const {
 void Tabs::set_tab_icon(int p_tab, const Ref<Texture> &p_icon) {
 
 	ERR_FAIL_INDEX(p_tab, tabs.size());
-	tabs[p_tab].icon = p_icon;
+	tabs.write[p_tab].icon = p_icon;
 	update();
 	minimum_size_changed();
 }
@@ -499,7 +499,7 @@ Ref<Texture> Tabs::get_tab_icon(int p_tab) const {
 void Tabs::set_tab_disabled(int p_tab, bool p_disabled) {
 
 	ERR_FAIL_INDEX(p_tab, tabs.size());
-	tabs[p_tab].disabled = p_disabled;
+	tabs.write[p_tab].disabled = p_disabled;
 	update();
 }
 bool Tabs::get_tab_disabled(int p_tab) const {
@@ -511,7 +511,7 @@ bool Tabs::get_tab_disabled(int p_tab) const {
 void Tabs::set_tab_right_button(int p_tab, const Ref<Texture> &p_right_button) {
 
 	ERR_FAIL_INDEX(p_tab, tabs.size());
-	tabs[p_tab].right_button = p_right_button;
+	tabs.write[p_tab].right_button = p_right_button;
 	_update_cache();
 	update();
 	minimum_size_changed();
@@ -536,9 +536,9 @@ void Tabs::_update_cache() {
 	int size_fixed = 0;
 	int count_resize = 0;
 	for (int i = 0; i < tabs.size(); i++) {
-		tabs[i].ofs_cache = mw;
-		tabs[i].size_cache = get_tab_width(i);
-		tabs[i].size_text = font->get_string_size(tabs[i].text).width;
+		tabs.write[i].ofs_cache = mw;
+		tabs.write[i].size_cache = get_tab_width(i);
+		tabs.write[i].size_text = font->get_string_size(tabs[i].text).width;
 		mw += tabs[i].size_cache;
 		if (tabs[i].size_cache <= min_width || i == current) {
 			size_fixed += tabs[i].size_cache;
@@ -579,9 +579,9 @@ void Tabs::_update_cache() {
 				lsize = m_width;
 			}
 		}
-		tabs[i].ofs_cache = w;
-		tabs[i].size_cache = lsize;
-		tabs[i].size_text = slen;
+		tabs.write[i].ofs_cache = w;
+		tabs.write[i].size_cache = lsize;
+		tabs.write[i].size_text = slen;
 		w += lsize;
 	}
 }

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -127,13 +127,13 @@ void TextEdit::Text::_update_line_cache(int p_line) const {
 		w += get_char_width(str[i], str[i + 1], w);
 	}
 
-	text[p_line].width_cache = w;
+	text.write[p_line].width_cache = w;
 
-	text[p_line].wrap_amount_cache = -1;
+	text.write[p_line].wrap_amount_cache = -1;
 
 	//update regions
 
-	text[p_line].region_info.clear();
+	text.write[p_line].region_info.clear();
 
 	for (int i = 0; i < len; i++) {
 
@@ -172,7 +172,7 @@ void TextEdit::Text::_update_line_cache(int p_line) const {
 				ColorRegionInfo cri;
 				cri.end = false;
 				cri.region = j;
-				text[p_line].region_info[i] = cri;
+				text.write[p_line].region_info[i] = cri;
 				i += lr - 1;
 
 				break;
@@ -200,7 +200,7 @@ void TextEdit::Text::_update_line_cache(int p_line) const {
 				ColorRegionInfo cri;
 				cri.end = true;
 				cri.region = j;
-				text[p_line].region_info[i] = cri;
+				text.write[p_line].region_info[i] = cri;
 				i += lr - 1;
 
 				break;
@@ -236,7 +236,7 @@ void TextEdit::Text::set_line_wrap_amount(int p_line, int p_wrap_amount) const {
 
 	ERR_FAIL_INDEX(p_line, text.size());
 
-	text[p_line].wrap_amount_cache = p_wrap_amount;
+	text.write[p_line].wrap_amount_cache = p_wrap_amount;
 }
 
 int TextEdit::Text::get_line_wrap_amount(int p_line) const {
@@ -249,14 +249,14 @@ int TextEdit::Text::get_line_wrap_amount(int p_line) const {
 void TextEdit::Text::clear_width_cache() {
 
 	for (int i = 0; i < text.size(); i++) {
-		text[i].width_cache = -1;
+		text.write[i].width_cache = -1;
 	}
 }
 
 void TextEdit::Text::clear_wrap_cache() {
 
 	for (int i = 0; i < text.size(); i++) {
-		text[i].wrap_amount_cache = -1;
+		text.write[i].wrap_amount_cache = -1;
 	}
 }
 
@@ -281,9 +281,9 @@ void TextEdit::Text::set(int p_line, const String &p_text) {
 
 	ERR_FAIL_INDEX(p_line, text.size());
 
-	text[p_line].width_cache = -1;
-	text[p_line].wrap_amount_cache = -1;
-	text[p_line].data = p_text;
+	text.write[p_line].width_cache = -1;
+	text.write[p_line].wrap_amount_cache = -1;
+	text.write[p_line].data = p_text;
 }
 
 void TextEdit::Text::insert(int p_at, const String &p_text) {
@@ -5729,7 +5729,7 @@ void TextEdit::_update_completion_candidates() {
 
 	for (int i = 0; i < completion_strings.size(); i++) {
 		if (single_quote && completion_strings[i].is_quoted()) {
-			completion_strings[i] = completion_strings[i].unquote().quote("'");
+			completion_strings.write[i] = completion_strings[i].unquote().quote("'");
 		}
 
 		if (s == completion_strings[i]) {

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -101,13 +101,13 @@ public:
 		int get_line_wrap_amount(int p_line) const;
 		const Map<int, ColorRegionInfo> &get_color_region_info(int p_line) const;
 		void set(int p_line, const String &p_text);
-		void set_marked(int p_line, bool p_marked) { text[p_line].marked = p_marked; }
+		void set_marked(int p_line, bool p_marked) { text.write[p_line].marked = p_marked; }
 		bool is_marked(int p_line) const { return text[p_line].marked; }
-		void set_breakpoint(int p_line, bool p_breakpoint) { text[p_line].breakpoint = p_breakpoint; }
+		void set_breakpoint(int p_line, bool p_breakpoint) { text.write[p_line].breakpoint = p_breakpoint; }
 		bool is_breakpoint(int p_line) const { return text[p_line].breakpoint; }
-		void set_hidden(int p_line, bool p_hidden) { text[p_line].hidden = p_hidden; }
+		void set_hidden(int p_line, bool p_hidden) { text.write[p_line].hidden = p_hidden; }
 		bool is_hidden(int p_line) const { return text[p_line].hidden; }
-		void set_safe(int p_line, bool p_safe) { text[p_line].safe = p_safe; }
+		void set_safe(int p_line, bool p_safe) { text.write[p_line].safe = p_safe; }
 		bool is_safe(int p_line) const { return text[p_line].safe; }
 		void insert(int p_at, const String &p_text);
 		void remove(int p_at);

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -121,7 +121,7 @@ void TreeItem::_cell_deselected(int p_cell) {
 void TreeItem::set_cell_mode(int p_column, TreeCellMode p_mode) {
 
 	ERR_FAIL_INDEX(p_column, cells.size());
-	Cell &c = cells[p_column];
+	Cell &c = cells.write[p_column];
 	c.mode = p_mode;
 	c.min = 0;
 	c.max = 100;
@@ -144,7 +144,7 @@ TreeItem::TreeCellMode TreeItem::get_cell_mode(int p_column) const {
 void TreeItem::set_checked(int p_column, bool p_checked) {
 
 	ERR_FAIL_INDEX(p_column, cells.size());
-	cells[p_column].checked = p_checked;
+	cells.write[p_column].checked = p_checked;
 	_changed_notify(p_column);
 }
 
@@ -157,22 +157,22 @@ bool TreeItem::is_checked(int p_column) const {
 void TreeItem::set_text(int p_column, String p_text) {
 
 	ERR_FAIL_INDEX(p_column, cells.size());
-	cells[p_column].text = p_text;
+	cells.write[p_column].text = p_text;
 
 	if (cells[p_column].mode == TreeItem::CELL_MODE_RANGE || cells[p_column].mode == TreeItem::CELL_MODE_RANGE_EXPRESSION) {
 
 		Vector<String> strings = p_text.split(",");
-		cells[p_column].min = INT_MAX;
-		cells[p_column].max = INT_MIN;
+		cells.write[p_column].min = INT_MAX;
+		cells.write[p_column].max = INT_MIN;
 		for (int i = 0; i < strings.size(); i++) {
 			int value = i;
 			if (!strings[i].get_slicec(':', 1).empty()) {
 				value = strings[i].get_slicec(':', 1).to_int();
 			}
-			cells[p_column].min = MIN(cells[p_column].min, value);
-			cells[p_column].max = MAX(cells[p_column].max, value);
+			cells.write[p_column].min = MIN(cells[p_column].min, value);
+			cells.write[p_column].max = MAX(cells[p_column].max, value);
 		}
-		cells[p_column].step = 0;
+		cells.write[p_column].step = 0;
 	}
 	_changed_notify(p_column);
 }
@@ -186,7 +186,7 @@ String TreeItem::get_text(int p_column) const {
 void TreeItem::set_suffix(int p_column, String p_suffix) {
 
 	ERR_FAIL_INDEX(p_column, cells.size());
-	cells[p_column].suffix = p_suffix;
+	cells.write[p_column].suffix = p_suffix;
 
 	_changed_notify(p_column);
 }
@@ -200,7 +200,7 @@ String TreeItem::get_suffix(int p_column) const {
 void TreeItem::set_icon(int p_column, const Ref<Texture> &p_icon) {
 
 	ERR_FAIL_INDEX(p_column, cells.size());
-	cells[p_column].icon = p_icon;
+	cells.write[p_column].icon = p_icon;
 	_changed_notify(p_column);
 }
 
@@ -213,7 +213,7 @@ Ref<Texture> TreeItem::get_icon(int p_column) const {
 void TreeItem::set_icon_region(int p_column, const Rect2 &p_icon_region) {
 
 	ERR_FAIL_INDEX(p_column, cells.size());
-	cells[p_column].icon_region = p_icon_region;
+	cells.write[p_column].icon_region = p_icon_region;
 	_changed_notify(p_column);
 }
 
@@ -226,7 +226,7 @@ Rect2 TreeItem::get_icon_region(int p_column) const {
 void TreeItem::set_icon_color(int p_column, const Color &p_icon_color) {
 
 	ERR_FAIL_INDEX(p_column, cells.size());
-	cells[p_column].icon_color = p_icon_color;
+	cells.write[p_column].icon_color = p_icon_color;
 	_changed_notify(p_column);
 }
 
@@ -239,7 +239,7 @@ Color TreeItem::get_icon_color(int p_column) const {
 void TreeItem::set_icon_max_width(int p_column, int p_max) {
 
 	ERR_FAIL_INDEX(p_column, cells.size());
-	cells[p_column].icon_max_w = p_max;
+	cells.write[p_column].icon_max_w = p_max;
 	_changed_notify(p_column);
 }
 
@@ -260,7 +260,7 @@ void TreeItem::set_range(int p_column, double p_value) {
 	if (p_value > cells[p_column].max)
 		p_value = cells[p_column].max;
 
-	cells[p_column].val = p_value;
+	cells.write[p_column].val = p_value;
 	_changed_notify(p_column);
 }
 
@@ -278,10 +278,10 @@ bool TreeItem::is_range_exponential(int p_column) const {
 void TreeItem::set_range_config(int p_column, double p_min, double p_max, double p_step, bool p_exp) {
 
 	ERR_FAIL_INDEX(p_column, cells.size());
-	cells[p_column].min = p_min;
-	cells[p_column].max = p_max;
-	cells[p_column].step = p_step;
-	cells[p_column].expr = p_exp;
+	cells.write[p_column].min = p_min;
+	cells.write[p_column].max = p_max;
+	cells.write[p_column].step = p_step;
+	cells.write[p_column].expr = p_exp;
 	_changed_notify(p_column);
 }
 
@@ -296,7 +296,7 @@ void TreeItem::get_range_config(int p_column, double &r_min, double &r_max, doub
 void TreeItem::set_metadata(int p_column, const Variant &p_meta) {
 
 	ERR_FAIL_INDEX(p_column, cells.size());
-	cells[p_column].meta = p_meta;
+	cells.write[p_column].meta = p_meta;
 }
 
 Variant TreeItem::get_metadata(int p_column) const {
@@ -311,8 +311,8 @@ void TreeItem::set_custom_draw(int p_column, Object *p_object, const StringName 
 	ERR_FAIL_INDEX(p_column, cells.size());
 	ERR_FAIL_NULL(p_object);
 
-	cells[p_column].custom_draw_obj = p_object->get_instance_id();
-	cells[p_column].custom_draw_callback = p_callback;
+	cells.write[p_column].custom_draw_obj = p_object->get_instance_id();
+	cells.write[p_column].custom_draw_callback = p_callback;
 }
 
 void TreeItem::set_collapsed(bool p_collapsed) {
@@ -467,7 +467,7 @@ void TreeItem::remove_child(TreeItem *p_item) {
 void TreeItem::set_selectable(int p_column, bool p_selectable) {
 
 	ERR_FAIL_INDEX(p_column, cells.size());
-	cells[p_column].selectable = p_selectable;
+	cells.write[p_column].selectable = p_selectable;
 }
 
 bool TreeItem::is_selectable(int p_column) const {
@@ -517,7 +517,7 @@ void TreeItem::add_button(int p_column, const Ref<Texture> &p_button, int p_id, 
 	button.id = p_id;
 	button.disabled = p_disabled;
 	button.tooltip = p_tooltip;
-	cells[p_column].buttons.push_back(button);
+	cells.write[p_column].buttons.push_back(button);
 	_changed_notify(p_column);
 }
 
@@ -540,7 +540,7 @@ void TreeItem::erase_button(int p_column, int p_idx) {
 
 	ERR_FAIL_INDEX(p_column, cells.size());
 	ERR_FAIL_INDEX(p_idx, cells[p_column].buttons.size());
-	cells[p_column].buttons.remove(p_idx);
+	cells.write[p_column].buttons.remove(p_idx);
 	_changed_notify(p_column);
 }
 
@@ -568,7 +568,7 @@ void TreeItem::set_button(int p_column, int p_idx, const Ref<Texture> &p_button)
 	ERR_FAIL_COND(p_button.is_null());
 	ERR_FAIL_INDEX(p_column, cells.size());
 	ERR_FAIL_INDEX(p_idx, cells[p_column].buttons.size());
-	cells[p_column].buttons[p_idx].texture = p_button;
+	cells.write[p_column].buttons.write[p_idx].texture = p_button;
 	_changed_notify(p_column);
 }
 
@@ -576,14 +576,14 @@ void TreeItem::set_button_color(int p_column, int p_idx, const Color &p_color) {
 
 	ERR_FAIL_INDEX(p_column, cells.size());
 	ERR_FAIL_INDEX(p_idx, cells[p_column].buttons.size());
-	cells[p_column].buttons[p_idx].color = p_color;
+	cells.write[p_column].buttons.write[p_idx].color = p_color;
 	_changed_notify(p_column);
 }
 
 void TreeItem::set_editable(int p_column, bool p_editable) {
 
 	ERR_FAIL_INDEX(p_column, cells.size());
-	cells[p_column].editable = p_editable;
+	cells.write[p_column].editable = p_editable;
 	_changed_notify(p_column);
 }
 
@@ -596,8 +596,8 @@ bool TreeItem::is_editable(int p_column) {
 void TreeItem::set_custom_color(int p_column, const Color &p_color) {
 
 	ERR_FAIL_INDEX(p_column, cells.size());
-	cells[p_column].custom_color = true;
-	cells[p_column].color = p_color;
+	cells.write[p_column].custom_color = true;
+	cells.write[p_column].color = p_color;
 	_changed_notify(p_column);
 }
 Color TreeItem::get_custom_color(int p_column) const {
@@ -610,15 +610,15 @@ Color TreeItem::get_custom_color(int p_column) const {
 void TreeItem::clear_custom_color(int p_column) {
 
 	ERR_FAIL_INDEX(p_column, cells.size());
-	cells[p_column].custom_color = false;
-	cells[p_column].color = Color();
+	cells.write[p_column].custom_color = false;
+	cells.write[p_column].color = Color();
 	_changed_notify(p_column);
 }
 
 void TreeItem::set_tooltip(int p_column, const String &p_tooltip) {
 
 	ERR_FAIL_INDEX(p_column, cells.size());
-	cells[p_column].tooltip = p_tooltip;
+	cells.write[p_column].tooltip = p_tooltip;
 }
 
 String TreeItem::get_tooltip(int p_column) const {
@@ -630,17 +630,17 @@ String TreeItem::get_tooltip(int p_column) const {
 void TreeItem::set_custom_bg_color(int p_column, const Color &p_color, bool p_bg_outline) {
 
 	ERR_FAIL_INDEX(p_column, cells.size());
-	cells[p_column].custom_bg_color = true;
-	cells[p_column].custom_bg_outline = p_bg_outline;
-	cells[p_column].bg_color = p_color;
+	cells.write[p_column].custom_bg_color = true;
+	cells.write[p_column].custom_bg_outline = p_bg_outline;
+	cells.write[p_column].bg_color = p_color;
 	_changed_notify(p_column);
 }
 
 void TreeItem::clear_custom_bg_color(int p_column) {
 
 	ERR_FAIL_INDEX(p_column, cells.size());
-	cells[p_column].custom_bg_color = false;
-	cells[p_column].bg_color = Color();
+	cells.write[p_column].custom_bg_color = false;
+	cells.write[p_column].bg_color = Color();
 	_changed_notify(p_column);
 }
 
@@ -655,7 +655,7 @@ Color TreeItem::get_custom_bg_color(int p_column) const {
 void TreeItem::set_custom_as_button(int p_column, bool p_button) {
 
 	ERR_FAIL_INDEX(p_column, cells.size());
-	cells[p_column].custom_button = p_button;
+	cells.write[p_column].custom_button = p_button;
 }
 
 bool TreeItem::is_custom_set_as_button(int p_column) const {
@@ -666,7 +666,7 @@ bool TreeItem::is_custom_set_as_button(int p_column) const {
 
 void TreeItem::set_text_align(int p_column, TextAlign p_align) {
 	ERR_FAIL_INDEX(p_column, cells.size());
-	cells[p_column].text_align = p_align;
+	cells.write[p_column].text_align = p_align;
 	_changed_notify(p_column);
 }
 
@@ -678,7 +678,7 @@ TreeItem::TextAlign TreeItem::get_text_align(int p_column) const {
 void TreeItem::set_expand_right(int p_column, bool p_enable) {
 
 	ERR_FAIL_INDEX(p_column, cells.size());
-	cells[p_column].expand_right = p_enable;
+	cells.write[p_column].expand_right = p_enable;
 	_changed_notify(p_column);
 }
 
@@ -1486,7 +1486,7 @@ int Tree::_count_selected_items(TreeItem *p_from) const {
 }
 void Tree::select_single_item(TreeItem *p_selected, TreeItem *p_current, int p_col, TreeItem *p_prev, bool *r_in_range, bool p_force_deselect) {
 
-	TreeItem::Cell &selected_cell = p_selected->cells[p_col];
+	TreeItem::Cell &selected_cell = p_selected->cells.write[p_col];
 
 	bool switched = false;
 	if (r_in_range && !*r_in_range && (p_current == p_selected || p_current == p_prev)) {
@@ -1498,7 +1498,7 @@ void Tree::select_single_item(TreeItem *p_selected, TreeItem *p_current, int p_c
 
 	for (int i = 0; i < columns.size(); i++) {
 
-		TreeItem::Cell &c = p_current->cells[i];
+		TreeItem::Cell &c = p_current->cells.write[i];
 
 		if (!c.selectable)
 			continue;
@@ -1689,7 +1689,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool
 			return -1; //collapse/uncollapse because nothing can be done with item
 		}
 
-		TreeItem::Cell &c = p_item->cells[col];
+		const TreeItem::Cell &c = p_item->cells[col];
 
 		bool already_selected = c.selected;
 		bool already_cursor = (p_item == selected_item) && col == selected_col;
@@ -1990,7 +1990,7 @@ void Tree::text_editor_enter(String p_text) {
 	if (popup_edited_item_col < 0 || popup_edited_item_col > columns.size())
 		return;
 
-	TreeItem::Cell &c = popup_edited_item->cells[popup_edited_item_col];
+	TreeItem::Cell &c = popup_edited_item->cells.write[popup_edited_item_col];
 	switch (c.mode) {
 
 		case TreeItem::CELL_MODE_STRING: {
@@ -2041,7 +2041,7 @@ void Tree::value_editor_changed(double p_value) {
 		return;
 	}
 
-	TreeItem::Cell &c = popup_edited_item->cells[popup_edited_item_col];
+	TreeItem::Cell &c = popup_edited_item->cells.write[popup_edited_item_col];
 	c.val = p_value;
 	item_edited(popup_edited_item_col, popup_edited_item);
 	update();
@@ -2055,7 +2055,7 @@ void Tree::popup_select(int p_option) {
 	if (popup_edited_item_col < 0 || popup_edited_item_col > columns.size())
 		return;
 
-	popup_edited_item->cells[popup_edited_item_col].val = p_option;
+	popup_edited_item->cells.write[popup_edited_item_col].val = p_option;
 	//popup_edited_item->edited_signal.call( popup_edited_item_col );
 	update();
 	item_edited(popup_edited_item_col, popup_edited_item);
@@ -2467,7 +2467,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 				}
 			} else {
 
-				TreeItem::Cell &c = popup_edited_item->cells[popup_edited_item_col];
+				const TreeItem::Cell &c = popup_edited_item->cells[popup_edited_item_col];
 				float diff_y = -mm->get_relative().y;
 				diff_y = Math::pow(ABS(diff_y), 1.8f) * SGN(diff_y);
 				diff_y *= 0.1;
@@ -2681,7 +2681,7 @@ bool Tree::edit_selected() {
 	popup_edited_item = s;
 	popup_edited_item_col = col;
 
-	TreeItem::Cell &c = s->cells[col];
+	const TreeItem::Cell &c = s->cells[col];
 
 	if (c.mode == TreeItem::CELL_MODE_CHECK) {
 
@@ -3072,7 +3072,7 @@ void Tree::item_selected(int p_column, TreeItem *p_item) {
 		if (!p_item->cells[p_column].selectable)
 			return;
 
-		p_item->cells[p_column].selected = true;
+		p_item->cells.write[p_column].selected = true;
 		//emit_signal("multi_selected",p_item,p_column,true); - NO this is for TreeItem::select
 
 		selected_col = p_column;
@@ -3086,7 +3086,7 @@ void Tree::item_selected(int p_column, TreeItem *p_item) {
 void Tree::item_deselected(int p_column, TreeItem *p_item) {
 
 	if (select_mode == SELECT_MULTI || select_mode == SELECT_SINGLE) {
-		p_item->cells[p_column].selected = false;
+		p_item->cells.write[p_column].selected = false;
 	}
 	update();
 }
@@ -3167,14 +3167,14 @@ void Tree::set_column_min_width(int p_column, int p_min_width) {
 
 	if (p_min_width < 1)
 		return;
-	columns[p_column].min_width = p_min_width;
+	columns.write[p_column].min_width = p_min_width;
 	update();
 }
 void Tree::set_column_expand(int p_column, bool p_expand) {
 
 	ERR_FAIL_INDEX(p_column, columns.size());
 
-	columns[p_column].expand = p_expand;
+	columns.write[p_column].expand = p_expand;
 	update();
 }
 
@@ -3422,7 +3422,7 @@ bool Tree::are_column_titles_visible() const {
 void Tree::set_column_title(int p_column, const String &p_title) {
 
 	ERR_FAIL_INDEX(p_column, columns.size());
-	columns[p_column].title = p_title;
+	columns.write[p_column].title = p_title;
 	update();
 }
 
@@ -3668,7 +3668,7 @@ String Tree::get_tooltip(const Point2 &p_pos) const {
 
 		if (it) {
 
-			TreeItem::Cell &c = it->cells[col];
+			const TreeItem::Cell &c = it->cells[col];
 			int col_width = get_column_width(col);
 			for (int j = c.buttons.size() - 1; j >= 0; j--) {
 				Ref<Texture> b = c.buttons[j].texture;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -178,7 +178,7 @@ void SceneTree::_update_group_order(Group &g, bool p_use_priority) {
 	if (g.nodes.empty())
 		return;
 
-	Node **nodes = &g.nodes[0];
+	Node **nodes = g.nodes.ptrw();
 	int node_count = g.nodes.size();
 
 	if (p_use_priority) {
@@ -227,7 +227,7 @@ void SceneTree::call_group_flags(uint32_t p_call_flags, const StringName &p_grou
 	_update_group_order(g);
 
 	Vector<Node *> nodes_copy = g.nodes;
-	Node **nodes = &nodes_copy[0];
+	Node **nodes = nodes_copy.ptrw();
 	int node_count = nodes_copy.size();
 
 	call_lock++;
@@ -282,7 +282,7 @@ void SceneTree::notify_group_flags(uint32_t p_call_flags, const StringName &p_gr
 	_update_group_order(g);
 
 	Vector<Node *> nodes_copy = g.nodes;
-	Node **nodes = &nodes_copy[0];
+	Node **nodes = nodes_copy.ptrw();
 	int node_count = nodes_copy.size();
 
 	call_lock++;
@@ -331,7 +331,7 @@ void SceneTree::set_group_flags(uint32_t p_call_flags, const StringName &p_group
 	_update_group_order(g);
 
 	Vector<Node *> nodes_copy = g.nodes;
-	Node **nodes = &nodes_copy[0];
+	Node **nodes = nodes_copy.ptrw();
 	int node_count = nodes_copy.size();
 
 	call_lock++;
@@ -895,7 +895,7 @@ void SceneTree::_call_input_pause(const StringName &p_group, const StringName &p
 	Vector<Node *> nodes_copy = g.nodes;
 
 	int node_count = nodes_copy.size();
-	Node **nodes = &nodes_copy[0];
+	Node **nodes = nodes_copy.ptrw();
 
 	Variant arg = p_input;
 	const Variant *v[1] = { &arg };
@@ -939,7 +939,7 @@ void SceneTree::_notify_group_pause(const StringName &p_group, int p_notificatio
 	Vector<Node *> nodes_copy = g.nodes;
 
 	int node_count = nodes_copy.size();
-	Node **nodes = &nodes_copy[0];
+	Node **nodes = nodes_copy.ptrw();
 
 	call_lock++;
 

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -100,7 +100,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 
 				for (int i = 0; i < (vcount / 12); i++) {
 
-					TKey<TransformKey> &tk = tt->transforms[i];
+					TKey<TransformKey> &tk = tt->transforms.write[i];
 					const float *ofs = &r[i * 12];
 					tk.time = ofs[0];
 					tk.transition = ofs[1];
@@ -154,8 +154,8 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 
 					for (int i = 0; i < valcount; i++) {
 
-						vt->values[i].time = rt[i];
-						vt->values[i].value = values[i];
+						vt->values.write[i].time = rt[i];
+						vt->values.write[i].value = values[i];
 					}
 
 					if (d.has("transitions")) {
@@ -167,7 +167,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 
 						for (int i = 0; i < valcount; i++) {
 
-							vt->values[i].transition = rtr[i];
+							vt->values.write[i].transition = rtr[i];
 						}
 					}
 				}
@@ -235,13 +235,13 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 
 					for (int i = 0; i < valcount; i++) {
 
-						bt->values[i].time = rt[i];
-						bt->values[i].transition = 0; //unused in bezier
-						bt->values[i].value.value = rv[i * 5 + 0];
-						bt->values[i].value.in_handle.x = rv[i * 5 + 1];
-						bt->values[i].value.in_handle.y = rv[i * 5 + 2];
-						bt->values[i].value.out_handle.x = rv[i * 5 + 3];
-						bt->values[i].value.out_handle.y = rv[i * 5 + 4];
+						bt->values.write[i].time = rt[i];
+						bt->values.write[i].transition = 0; //unused in bezier
+						bt->values.write[i].value.value = rv[i * 5 + 0];
+						bt->values.write[i].value.in_handle.x = rv[i * 5 + 1];
+						bt->values.write[i].value.in_handle.y = rv[i * 5 + 2];
+						bt->values.write[i].value.out_handle.x = rv[i * 5 + 3];
+						bt->values.write[i].value.out_handle.y = rv[i * 5 + 4];
 					}
 				}
 
@@ -313,7 +313,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 						TKey<StringName> ak;
 						ak.time = rt[i];
 						ak.value = rc[i];
-						an->values[i] = ak;
+						an->values.write[i] = ak;
 					}
 				}
 
@@ -822,7 +822,7 @@ int Animation::_insert(float p_time, T &p_keys, const V &p_value) {
 		} else if (p_keys[idx - 1].time == p_time) {
 
 			// condition for replacing.
-			p_keys[idx - 1] = p_value;
+			p_keys.write[idx - 1] = p_value;
 			return idx - 1;
 		}
 
@@ -1349,18 +1349,18 @@ void Animation::track_set_key_value(int p_track, int p_key_idx, const Variant &p
 			ERR_FAIL_INDEX(p_key_idx, tt->transforms.size());
 			Dictionary d = p_value;
 			if (d.has("location"))
-				tt->transforms[p_key_idx].value.loc = d["location"];
+				tt->transforms.write[p_key_idx].value.loc = d["location"];
 			if (d.has("rotation"))
-				tt->transforms[p_key_idx].value.rot = d["rotation"];
+				tt->transforms.write[p_key_idx].value.rot = d["rotation"];
 			if (d.has("scale"))
-				tt->transforms[p_key_idx].value.scale = d["scale"];
+				tt->transforms.write[p_key_idx].value.scale = d["scale"];
 
 		} break;
 		case TYPE_VALUE: {
 
 			ValueTrack *vt = static_cast<ValueTrack *>(t);
 			ERR_FAIL_INDEX(p_key_idx, vt->values.size());
-			vt->values[p_key_idx].value = p_value;
+			vt->values.write[p_key_idx].value = p_value;
 
 		} break;
 		case TYPE_METHOD: {
@@ -1369,9 +1369,9 @@ void Animation::track_set_key_value(int p_track, int p_key_idx, const Variant &p
 			ERR_FAIL_INDEX(p_key_idx, mt->methods.size());
 			Dictionary d = p_value;
 			if (d.has("method"))
-				mt->methods[p_key_idx].method = d["method"];
+				mt->methods.write[p_key_idx].method = d["method"];
 			if (d.has("args"))
-				mt->methods[p_key_idx].params = d["args"];
+				mt->methods.write[p_key_idx].params = d["args"];
 		} break;
 		case TYPE_BEZIER: {
 
@@ -1381,11 +1381,11 @@ void Animation::track_set_key_value(int p_track, int p_key_idx, const Variant &p
 			Array arr = p_value;
 			ERR_FAIL_COND(arr.size() != 5);
 
-			bt->values[p_key_idx].value.value = arr[0];
-			bt->values[p_key_idx].value.in_handle.x = arr[1];
-			bt->values[p_key_idx].value.in_handle.y = arr[2];
-			bt->values[p_key_idx].value.out_handle.x = arr[3];
-			bt->values[p_key_idx].value.out_handle.y = arr[4];
+			bt->values.write[p_key_idx].value.value = arr[0];
+			bt->values.write[p_key_idx].value.in_handle.x = arr[1];
+			bt->values.write[p_key_idx].value.in_handle.y = arr[2];
+			bt->values.write[p_key_idx].value.out_handle.x = arr[3];
+			bt->values.write[p_key_idx].value.out_handle.y = arr[4];
 
 		} break;
 		case TYPE_AUDIO: {
@@ -1397,16 +1397,16 @@ void Animation::track_set_key_value(int p_track, int p_key_idx, const Variant &p
 			ERR_FAIL_COND(!k.has("end_offset"));
 			ERR_FAIL_COND(!k.has("stream"));
 
-			at->values[p_key_idx].value.start_offset = k["start_offset"];
-			at->values[p_key_idx].value.end_offset = k["end_offset"];
-			at->values[p_key_idx].value.stream = k["stream"];
+			at->values.write[p_key_idx].value.start_offset = k["start_offset"];
+			at->values.write[p_key_idx].value.end_offset = k["end_offset"];
+			at->values.write[p_key_idx].value.stream = k["stream"];
 
 		} break;
 		case TYPE_ANIMATION: {
 
 			AnimationTrack *at = static_cast<AnimationTrack *>(t);
 
-			at->values[p_key_idx].value = p_value;
+			at->values.write[p_key_idx].value = p_value;
 
 		} break;
 	}
@@ -1423,20 +1423,20 @@ void Animation::track_set_key_transition(int p_track, int p_key_idx, float p_tra
 
 			TransformTrack *tt = static_cast<TransformTrack *>(t);
 			ERR_FAIL_INDEX(p_key_idx, tt->transforms.size());
-			tt->transforms[p_key_idx].transition = p_transition;
+			tt->transforms.write[p_key_idx].transition = p_transition;
 		} break;
 		case TYPE_VALUE: {
 
 			ValueTrack *vt = static_cast<ValueTrack *>(t);
 			ERR_FAIL_INDEX(p_key_idx, vt->values.size());
-			vt->values[p_key_idx].transition = p_transition;
+			vt->values.write[p_key_idx].transition = p_transition;
 
 		} break;
 		case TYPE_METHOD: {
 
 			MethodTrack *mt = static_cast<MethodTrack *>(t);
 			ERR_FAIL_INDEX(p_key_idx, mt->methods.size());
-			mt->methods[p_key_idx].transition = p_transition;
+			mt->methods.write[p_key_idx].transition = p_transition;
 
 		} break;
 		case TYPE_BEZIER:
@@ -2210,7 +2210,7 @@ void Animation::bezier_track_set_key_value(int p_track, int p_index, float p_val
 
 	ERR_FAIL_INDEX(p_index, bt->values.size());
 
-	bt->values[p_index].value.value = p_value;
+	bt->values.write[p_index].value.value = p_value;
 	emit_changed();
 }
 
@@ -2224,9 +2224,9 @@ void Animation::bezier_track_set_key_in_handle(int p_track, int p_index, const V
 
 	ERR_FAIL_INDEX(p_index, bt->values.size());
 
-	bt->values[p_index].value.in_handle = p_handle;
+	bt->values.write[p_index].value.in_handle = p_handle;
 	if (bt->values[p_index].value.in_handle.x > 0) {
-		bt->values[p_index].value.in_handle.x = 0;
+		bt->values.write[p_index].value.in_handle.x = 0;
 	}
 	emit_changed();
 }
@@ -2240,9 +2240,9 @@ void Animation::bezier_track_set_key_out_handle(int p_track, int p_index, const 
 
 	ERR_FAIL_INDEX(p_index, bt->values.size());
 
-	bt->values[p_index].value.out_handle = p_handle;
+	bt->values.write[p_index].value.out_handle = p_handle;
 	if (bt->values[p_index].value.out_handle.x < 0) {
-		bt->values[p_index].value.out_handle.x = 0;
+		bt->values.write[p_index].value.out_handle.x = 0;
 	}
 	emit_changed();
 }
@@ -2396,7 +2396,7 @@ void Animation::audio_track_set_key_stream(int p_track, int p_key, const RES &p_
 
 	ERR_FAIL_INDEX(p_key, at->values.size());
 
-	at->values[p_key].value.stream = p_stream;
+	at->values.write[p_key].value.stream = p_stream;
 
 	emit_changed();
 }
@@ -2414,7 +2414,7 @@ void Animation::audio_track_set_key_start_offset(int p_track, int p_key, float p
 	if (p_offset < 0)
 		p_offset = 0;
 
-	at->values[p_key].value.start_offset = p_offset;
+	at->values.write[p_key].value.start_offset = p_offset;
 
 	emit_changed();
 }
@@ -2432,7 +2432,7 @@ void Animation::audio_track_set_key_end_offset(int p_track, int p_key, float p_o
 	if (p_offset < 0)
 		p_offset = 0;
 
-	at->values[p_key].value.end_offset = p_offset;
+	at->values.write[p_key].value.end_offset = p_offset;
 
 	emit_changed();
 }
@@ -2505,7 +2505,7 @@ void Animation::animation_track_set_key_animation(int p_track, int p_key, const 
 
 	ERR_FAIL_INDEX(p_key, at->values.size());
 
-	at->values[p_key].value = p_animation;
+	at->values.write[p_key].value = p_animation;
 
 	emit_changed();
 }
@@ -2550,7 +2550,7 @@ void Animation::track_move_up(int p_track) {
 
 	if (p_track >= 0 && p_track < (tracks.size() - 1)) {
 
-		SWAP(tracks[p_track], tracks[p_track + 1]);
+		SWAP(tracks.write[p_track], tracks.write[p_track + 1]);
 	}
 
 	emit_changed();
@@ -2585,7 +2585,7 @@ void Animation::track_move_down(int p_track) {
 
 	if (p_track > 0 && p_track < tracks.size()) {
 
-		SWAP(tracks[p_track], tracks[p_track - 1]);
+		SWAP(tracks.write[p_track], tracks.write[p_track - 1]);
 	}
 	emit_changed();
 }
@@ -2596,7 +2596,7 @@ void Animation::track_swap(int p_track, int p_with_track) {
 	ERR_FAIL_INDEX(p_with_track, tracks.size());
 	if (p_track == p_with_track)
 		return;
-	SWAP(tracks[p_track], tracks[p_with_track]);
+	SWAP(tracks.write[p_track], tracks.write[p_with_track]);
 	emit_changed();
 }
 
@@ -2927,9 +2927,9 @@ void Animation::_transform_track_optimize(int p_idx, float p_allowed_linear_err,
 
 	for (int i = 1; i < tt->transforms.size() - 1; i++) {
 
-		TKey<TransformKey> &t0 = tt->transforms[i - 1];
-		TKey<TransformKey> &t1 = tt->transforms[i];
-		TKey<TransformKey> &t2 = tt->transforms[i + 1];
+		TKey<TransformKey> &t0 = tt->transforms.write[i - 1];
+		TKey<TransformKey> &t1 = tt->transforms.write[i];
+		TKey<TransformKey> &t2 = tt->transforms.write[i + 1];
 
 		bool erase = _transform_track_optimize_key(t0, t1, t2, p_allowed_linear_err, p_allowed_angular_err, p_max_optimizable_angle, norm);
 		if (erase && !prev_erased) {

--- a/scene/resources/bit_mask.cpp
+++ b/scene/resources/bit_mask.cpp
@@ -130,7 +130,7 @@ void BitMap::set_bit(const Point2 &p_pos, bool p_value) {
 	else
 		b &= ~(1 << bbit);
 
-	bitmask[bbyte] = b;
+	bitmask.write[bbyte] = b;
 }
 
 bool BitMap::get_bit(const Point2 &p_pos) const {
@@ -322,8 +322,8 @@ Vector<Vector2> BitMap::_march_square(const Rect2i &rect, const Point2i &start) 
 		curx += stepx;
 		cury += stepy;
 		if (stepx == prevx && stepy == prevy) {
-			_points[_points.size() - 1].x = (float)(curx - rect.position.x);
-			_points[_points.size() - 1].y = (float)(cury + rect.position.y);
+			_points.write[_points.size() - 1].x = (float)(curx - rect.position.x);
+			_points.write[_points.size() - 1].y = (float)(cury + rect.position.y);
 		} else {
 			_points.push_back(Vector2((float)(curx - rect.position.x), (float)(cury + rect.position.y)));
 		}
@@ -373,11 +373,11 @@ static Vector<Vector2> rdp(const Vector<Vector2> &v, float optimization) {
 		Vector<Vector2> left, right;
 		left.resize(index);
 		for (int i = 0; i < index; i++) {
-			left[i] = v[i];
+			left.write[i] = v[i];
 		}
 		right.resize(v.size() - index);
 		for (int i = 0; i < right.size(); i++) {
-			right[i] = v[index + i];
+			right.write[i] = v[index + i];
 		}
 		Vector<Vector2> r1 = rdp(left, optimization);
 		Vector<Vector2> r2 = rdp(right, optimization);
@@ -385,7 +385,7 @@ static Vector<Vector2> rdp(const Vector<Vector2> &v, float optimization) {
 		int middle = r1.size();
 		r1.resize(r1.size() + r2.size());
 		for (int i = 0; i < r2.size(); i++) {
-			r1[middle + i] = r2[i];
+			r1.write[middle + i] = r2[i];
 		}
 		return r1;
 	} else {
@@ -412,7 +412,7 @@ static Vector<Vector2> reduce(const Vector<Vector2> &points, const Rect2i &rect,
 	Vector2 last = result[result.size() - 1];
 
 	if (last.y > result[0].y && last.distance_to(result[0]) < ep * 0.5f) {
-		result[0].y = last.y;
+		result.write[0].y = last.y;
 		result.resize(result.size() - 1);
 	}
 	return result;

--- a/scene/resources/color_ramp.cpp
+++ b/scene/resources/color_ramp.cpp
@@ -40,10 +40,10 @@
 Gradient::Gradient() {
 	//Set initial color ramp transition from black to white
 	points.resize(2);
-	points[0].color = Color(0, 0, 0, 1);
-	points[0].offset = 0;
-	points[1].color = Color(1, 1, 1, 1);
-	points[1].offset = 1;
+	points.write[0].color = Color(0, 0, 0, 1);
+	points.write[0].offset = 0;
+	points.write[1].color = Color(1, 1, 1, 1);
+	points.write[1].offset = 1;
 	is_sorted = true;
 }
 
@@ -79,7 +79,7 @@ Vector<float> Gradient::get_offsets() const {
 	Vector<float> offsets;
 	offsets.resize(points.size());
 	for (int i = 0; i < points.size(); i++) {
-		offsets[i] = points[i].offset;
+		offsets.write[i] = points[i].offset;
 	}
 	return offsets;
 }
@@ -88,7 +88,7 @@ Vector<Color> Gradient::get_colors() const {
 	Vector<Color> colors;
 	colors.resize(points.size());
 	for (int i = 0; i < points.size(); i++) {
-		colors[i] = points[i].color;
+		colors.write[i] = points[i].color;
 	}
 	return colors;
 }
@@ -96,7 +96,7 @@ Vector<Color> Gradient::get_colors() const {
 void Gradient::set_offsets(const Vector<float> &p_offsets) {
 	points.resize(p_offsets.size());
 	for (int i = 0; i < points.size(); i++) {
-		points[i].offset = p_offsets[i];
+		points.write[i].offset = p_offsets[i];
 	}
 	is_sorted = false;
 	emit_signal(CoreStringNames::get_singleton()->changed);
@@ -107,7 +107,7 @@ void Gradient::set_colors(const Vector<Color> &p_colors) {
 		is_sorted = false;
 	points.resize(p_colors.size());
 	for (int i = 0; i < points.size(); i++) {
-		points[i].color = p_colors[i];
+		points.write[i].color = p_colors[i];
 	}
 	emit_signal(CoreStringNames::get_singleton()->changed);
 }
@@ -144,7 +144,7 @@ void Gradient::set_points(Vector<Gradient::Point> &p_points) {
 void Gradient::set_offset(int pos, const float offset) {
 	if (points.size() <= pos)
 		points.resize(pos + 1);
-	points[pos].offset = offset;
+	points.write[pos].offset = offset;
 	is_sorted = false;
 	emit_signal(CoreStringNames::get_singleton()->changed);
 }
@@ -160,7 +160,7 @@ void Gradient::set_color(int pos, const Color &color) {
 		points.resize(pos + 1);
 		is_sorted = false;
 	}
-	points[pos].color = color;
+	points.write[pos].color = color;
 	emit_signal(CoreStringNames::get_singleton()->changed);
 }
 

--- a/scene/resources/color_ramp.h
+++ b/scene/resources/color_ramp.h
@@ -98,7 +98,7 @@ public:
 
 		while (low <= high) {
 			middle = (low + high) / 2;
-			Point &point = points[middle];
+			const Point &point = points[middle];
 			if (point.offset > p_offset) {
 				high = middle - 1; //search low end of array
 			} else if (point.offset < p_offset) {
@@ -118,8 +118,8 @@ public:
 			return points[points.size() - 1].color;
 		if (first < 0)
 			return points[0].color;
-		Point &pointFirst = points[first];
-		Point &pointSecond = points[second];
+		const Point &pointFirst = points[first];
+		const Point &pointSecond = points[second];
 		return pointFirst.color.linear_interpolate(pointSecond.color, (p_offset - pointFirst.offset) / (pointSecond.offset - pointFirst.offset));
 	}
 

--- a/scene/resources/concave_polygon_shape.cpp
+++ b/scene/resources/concave_polygon_shape.cpp
@@ -56,8 +56,8 @@ Vector<Vector3> ConcavePolygonShape::_gen_debug_mesh_lines() {
 	int idx = 0;
 	for (Set<DrawEdge>::Element *E = edges.front(); E; E = E->next()) {
 
-		points[idx + 0] = E->get().a;
-		points[idx + 1] = E->get().b;
+		points.write[idx + 0] = E->get().a;
+		points.write[idx + 1] = E->get().b;
 		idx += 2;
 	}
 

--- a/scene/resources/convex_polygon_shape.cpp
+++ b/scene/resources/convex_polygon_shape.cpp
@@ -46,8 +46,8 @@ Vector<Vector3> ConvexPolygonShape::_gen_debug_mesh_lines() {
 			Vector<Vector3> lines;
 			lines.resize(md.edges.size() * 2);
 			for (int i = 0; i < md.edges.size(); i++) {
-				lines[i * 2 + 0] = md.vertices[md.edges[i].a];
-				lines[i * 2 + 1] = md.vertices[md.edges[i].b];
+				lines.write[i * 2 + 0] = md.vertices[md.edges[i].a];
+				lines.write[i * 2 + 1] = md.vertices[md.edges[i].b];
 			}
 			return lines;
 		}

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -153,25 +153,25 @@ void Curve::clean_dupes() {
 
 void Curve::set_point_left_tangent(int i, real_t tangent) {
 	ERR_FAIL_INDEX(i, _points.size());
-	_points[i].left_tangent = tangent;
-	_points[i].left_mode = TANGENT_FREE;
+	_points.write[i].left_tangent = tangent;
+	_points.write[i].left_mode = TANGENT_FREE;
 	mark_dirty();
 }
 
 void Curve::set_point_right_tangent(int i, real_t tangent) {
 	ERR_FAIL_INDEX(i, _points.size());
-	_points[i].right_tangent = tangent;
-	_points[i].right_mode = TANGENT_FREE;
+	_points.write[i].right_tangent = tangent;
+	_points.write[i].right_mode = TANGENT_FREE;
 	mark_dirty();
 }
 
 void Curve::set_point_left_mode(int i, TangentMode p_mode) {
 	ERR_FAIL_INDEX(i, _points.size());
-	_points[i].left_mode = p_mode;
+	_points.write[i].left_mode = p_mode;
 	if (i > 0) {
 		if (p_mode == TANGENT_LINEAR) {
 			Vector2 v = (_points[i - 1].pos - _points[i].pos).normalized();
-			_points[i].left_tangent = v.y / v.x;
+			_points.write[i].left_tangent = v.y / v.x;
 		}
 	}
 	mark_dirty();
@@ -179,11 +179,11 @@ void Curve::set_point_left_mode(int i, TangentMode p_mode) {
 
 void Curve::set_point_right_mode(int i, TangentMode p_mode) {
 	ERR_FAIL_INDEX(i, _points.size());
-	_points[i].right_mode = p_mode;
+	_points.write[i].right_mode = p_mode;
 	if (i + 1 < _points.size()) {
 		if (p_mode == TANGENT_LINEAR) {
 			Vector2 v = (_points[i + 1].pos - _points[i].pos).normalized();
-			_points[i].right_tangent = v.y / v.x;
+			_points.write[i].right_tangent = v.y / v.x;
 		}
 	}
 	mark_dirty();
@@ -222,7 +222,7 @@ void Curve::clear_points() {
 
 void Curve::set_point_value(int p_index, real_t pos) {
 	ERR_FAIL_INDEX(p_index, _points.size());
-	_points[p_index].pos.y = pos;
+	_points.write[p_index].pos.y = pos;
 	update_auto_tangents(p_index);
 	mark_dirty();
 }
@@ -232,10 +232,10 @@ int Curve::set_point_offset(int p_index, float offset) {
 	Point p = _points[p_index];
 	remove_point(p_index);
 	int i = add_point(Vector2(offset, p.pos.y));
-	_points[i].left_tangent = p.left_tangent;
-	_points[i].right_tangent = p.right_tangent;
-	_points[i].left_mode = p.left_mode;
-	_points[i].right_mode = p.right_mode;
+	_points.write[i].left_tangent = p.left_tangent;
+	_points.write[i].right_tangent = p.right_tangent;
+	_points.write[i].left_mode = p.left_mode;
+	_points.write[i].right_mode = p.right_mode;
 	if (p_index != i)
 		update_auto_tangents(p_index);
 	update_auto_tangents(i);
@@ -254,7 +254,7 @@ Curve::Point Curve::get_point(int p_index) const {
 
 void Curve::update_auto_tangents(int i) {
 
-	Point &p = _points[i];
+	Point &p = _points.write[i];
 
 	if (i > 0) {
 		if (p.left_mode == TANGENT_LINEAR) {
@@ -263,7 +263,7 @@ void Curve::update_auto_tangents(int i) {
 		}
 		if (_points[i - 1].right_mode == TANGENT_LINEAR) {
 			Vector2 v = (_points[i - 1].pos - p.pos).normalized();
-			_points[i - 1].right_tangent = v.y / v.x;
+			_points.write[i - 1].right_tangent = v.y / v.x;
 		}
 	}
 
@@ -274,7 +274,7 @@ void Curve::update_auto_tangents(int i) {
 		}
 		if (_points[i + 1].left_mode == TANGENT_LINEAR) {
 			Vector2 v = (_points[i + 1].pos - p.pos).normalized();
-			_points[i + 1].left_tangent = v.y / v.x;
+			_points.write[i + 1].left_tangent = v.y / v.x;
 		}
 	}
 }
@@ -402,7 +402,7 @@ void Curve::set_data(Array input) {
 
 	for (int j = 0; j < _points.size(); ++j) {
 
-		Point &p = _points[j];
+		Point &p = _points.write[j];
 		int i = j * ELEMS;
 
 		p.pos = input[i];
@@ -426,12 +426,12 @@ void Curve::bake() {
 	for (int i = 1; i < _bake_resolution - 1; ++i) {
 		real_t x = i / static_cast<real_t>(_bake_resolution);
 		real_t y = interpolate(x);
-		_baked_cache[i] = y;
+		_baked_cache.write[i] = y;
 	}
 
 	if (_points.size() != 0) {
-		_baked_cache[0] = _points[0].pos.y;
-		_baked_cache[_baked_cache.size() - 1] = _points[_points.size() - 1].pos.y;
+		_baked_cache.write[0] = _points[0].pos.y;
+		_baked_cache.write[_baked_cache.size() - 1] = _points[_points.size() - 1].pos.y;
 	}
 
 	_baked_cache_dirty = false;
@@ -553,7 +553,7 @@ void Curve2D::set_point_position(int p_index, const Vector2 &p_pos) {
 
 	ERR_FAIL_INDEX(p_index, points.size());
 
-	points[p_index].pos = p_pos;
+	points.write[p_index].pos = p_pos;
 	baked_cache_dirty = true;
 	emit_signal(CoreStringNames::get_singleton()->changed);
 }
@@ -567,7 +567,7 @@ void Curve2D::set_point_in(int p_index, const Vector2 &p_in) {
 
 	ERR_FAIL_INDEX(p_index, points.size());
 
-	points[p_index].in = p_in;
+	points.write[p_index].in = p_in;
 	baked_cache_dirty = true;
 	emit_signal(CoreStringNames::get_singleton()->changed);
 }
@@ -581,7 +581,7 @@ void Curve2D::set_point_out(int p_index, const Vector2 &p_out) {
 
 	ERR_FAIL_INDEX(p_index, points.size());
 
-	points[p_index].out = p_out;
+	points.write[p_index].out = p_out;
 	baked_cache_dirty = true;
 	emit_signal(CoreStringNames::get_singleton()->changed);
 }
@@ -930,9 +930,9 @@ void Curve2D::_set_data(const Dictionary &p_data) {
 
 	for (int i = 0; i < points.size(); i++) {
 
-		points[i].in = r[i * 3 + 0];
-		points[i].out = r[i * 3 + 1];
-		points[i].pos = r[i * 3 + 2];
+		points.write[i].in = r[i * 3 + 0];
+		points.write[i].out = r[i * 3 + 1];
+		points.write[i].pos = r[i * 3 + 2];
 	}
 
 	baked_cache_dirty = true;
@@ -952,7 +952,7 @@ PoolVector2Array Curve2D::tessellate(int p_max_stages, float p_tolerance) const 
 	int pc = 1;
 	for (int i = 0; i < points.size() - 1; i++) {
 
-		_bake_segment2d(midpoints[i], 0, 1, points[i].pos, points[i].out, points[i + 1].pos, points[i + 1].in, 0, p_max_stages, p_tolerance);
+		_bake_segment2d(midpoints.write[i], 0, 1, points[i].pos, points[i].out, points[i + 1].pos, points[i + 1].in, 0, p_max_stages, p_tolerance);
 		pc++;
 		pc += midpoints[i].size();
 	}
@@ -1049,7 +1049,7 @@ void Curve3D::set_point_position(int p_index, const Vector3 &p_pos) {
 
 	ERR_FAIL_INDEX(p_index, points.size());
 
-	points[p_index].pos = p_pos;
+	points.write[p_index].pos = p_pos;
 	baked_cache_dirty = true;
 	emit_signal(CoreStringNames::get_singleton()->changed);
 }
@@ -1063,7 +1063,7 @@ void Curve3D::set_point_tilt(int p_index, float p_tilt) {
 
 	ERR_FAIL_INDEX(p_index, points.size());
 
-	points[p_index].tilt = p_tilt;
+	points.write[p_index].tilt = p_tilt;
 	baked_cache_dirty = true;
 	emit_signal(CoreStringNames::get_singleton()->changed);
 }
@@ -1077,7 +1077,7 @@ void Curve3D::set_point_in(int p_index, const Vector3 &p_in) {
 
 	ERR_FAIL_INDEX(p_index, points.size());
 
-	points[p_index].in = p_in;
+	points.write[p_index].in = p_in;
 	baked_cache_dirty = true;
 	emit_signal(CoreStringNames::get_singleton()->changed);
 }
@@ -1091,7 +1091,7 @@ void Curve3D::set_point_out(int p_index, const Vector3 &p_out) {
 
 	ERR_FAIL_INDEX(p_index, points.size());
 
-	points[p_index].out = p_out;
+	points.write[p_index].out = p_out;
 	baked_cache_dirty = true;
 	emit_signal(CoreStringNames::get_singleton()->changed);
 }
@@ -1621,10 +1621,10 @@ void Curve3D::_set_data(const Dictionary &p_data) {
 
 	for (int i = 0; i < points.size(); i++) {
 
-		points[i].in = r[i * 3 + 0];
-		points[i].out = r[i * 3 + 1];
-		points[i].pos = r[i * 3 + 2];
-		points[i].tilt = rt[i];
+		points.write[i].in = r[i * 3 + 0];
+		points.write[i].out = r[i * 3 + 1];
+		points.write[i].pos = r[i * 3 + 2];
+		points.write[i].tilt = rt[i];
 	}
 
 	baked_cache_dirty = true;
@@ -1644,7 +1644,7 @@ PoolVector3Array Curve3D::tessellate(int p_max_stages, float p_tolerance) const 
 	int pc = 1;
 	for (int i = 0; i < points.size() - 1; i++) {
 
-		_bake_segment3d(midpoints[i], 0, 1, points[i].pos, points[i].out, points[i + 1].pos, points[i + 1].in, 0, p_max_stages, p_tolerance);
+		_bake_segment3d(midpoints.write[i], 0, 1, points[i].pos, points[i].out, points[i + 1].pos, points[i + 1].in, 0, p_max_stages, p_tolerance);
 		pc++;
 		pc += midpoints[i].size();
 	}

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -314,7 +314,7 @@ void DynamicFontAtSize::set_texture_flags(uint32_t p_flags) {
 
 	texture_flags = p_flags;
 	for (int i = 0; i < textures.size(); i++) {
-		Ref<ImageTexture> &tex = textures[i].texture;
+		Ref<ImageTexture> &tex = textures.write[i].texture;
 		if (!tex.is_null())
 			tex->set_flags(p_flags);
 	}
@@ -400,7 +400,7 @@ DynamicFontAtSize::TexturePosition DynamicFontAtSize::_find_texture_pos_for_glyp
 
 	for (int i = 0; i < textures.size(); i++) {
 
-		CharTexture &ct = textures[i];
+		const CharTexture &ct = textures[i];
 
 		if (ct.texture->get_format() != p_image_format)
 			continue;
@@ -466,7 +466,7 @@ DynamicFontAtSize::TexturePosition DynamicFontAtSize::_find_texture_pos_for_glyp
 		}
 		tex.offsets.resize(texsize);
 		for (int i = 0; i < texsize; i++) //zero offsets
-			tex.offsets[i] = 0;
+			tex.offsets.write[i] = 0;
 
 		textures.push_back(tex);
 		ret.index = textures.size() - 1;
@@ -493,7 +493,7 @@ DynamicFontAtSize::Character DynamicFontAtSize::_bitmap_to_character(FT_Bitmap b
 
 	//fit character in char texture
 
-	CharTexture &tex = textures[tex_pos.index];
+	CharTexture &tex = textures.write[tex_pos.index];
 
 	{
 		PoolVector<uint8_t>::Write wr = tex.imgdata.write();
@@ -547,7 +547,7 @@ DynamicFontAtSize::Character DynamicFontAtSize::_bitmap_to_character(FT_Bitmap b
 	// update height array
 
 	for (int k = tex_pos.x; k < tex_pos.x + mw; k++) {
-		tex.offsets[k] = tex_pos.y + mh;
+		tex.offsets.write[k] = tex_pos.y + mh;
 	}
 
 	Character chr;
@@ -698,9 +698,9 @@ void DynamicFont::_reload_cache() {
 	}
 
 	for (int i = 0; i < fallbacks.size(); i++) {
-		fallback_data_at_size[i] = fallbacks[i]->_get_dynamic_font_at_size(cache_id);
+		fallback_data_at_size.write[i] = fallbacks.write[i]->_get_dynamic_font_at_size(cache_id);
 		if (outline_cache_id.outline_size > 0)
-			fallback_outline_data_at_size[i] = fallbacks[i]->_get_dynamic_font_at_size(outline_cache_id);
+			fallback_outline_data_at_size.write[i] = fallbacks.write[i]->_get_dynamic_font_at_size(outline_cache_id);
 	}
 
 	emit_changed();
@@ -895,17 +895,17 @@ void DynamicFont::set_fallback(int p_idx, const Ref<DynamicFontData> &p_data) {
 
 	ERR_FAIL_COND(p_data.is_null());
 	ERR_FAIL_INDEX(p_idx, fallbacks.size());
-	fallbacks[p_idx] = p_data;
-	fallback_data_at_size[p_idx] = fallbacks[p_idx]->_get_dynamic_font_at_size(cache_id);
+	fallbacks.write[p_idx] = p_data;
+	fallback_data_at_size.write[p_idx] = fallbacks.write[p_idx]->_get_dynamic_font_at_size(cache_id);
 }
 
 void DynamicFont::add_fallback(const Ref<DynamicFontData> &p_data) {
 
 	ERR_FAIL_COND(p_data.is_null());
 	fallbacks.push_back(p_data);
-	fallback_data_at_size.push_back(fallbacks[fallbacks.size() - 1]->_get_dynamic_font_at_size(cache_id)); //const..
+	fallback_data_at_size.push_back(fallbacks.write[fallbacks.size() - 1]->_get_dynamic_font_at_size(cache_id)); //const..
 	if (outline_cache_id.outline_size > 0)
-		fallback_outline_data_at_size.push_back(fallbacks[fallbacks.size() - 1]->_get_dynamic_font_at_size(outline_cache_id));
+		fallback_outline_data_at_size.push_back(fallbacks.write[fallbacks.size() - 1]->_get_dynamic_font_at_size(outline_cache_id));
 
 	_change_notify();
 	emit_changed();
@@ -1092,7 +1092,7 @@ void DynamicFont::update_oversampling() {
 		dynamic_font_mutex->unlock();
 
 	for (int i = 0; i < changed.size(); i++) {
-		changed[i]->emit_changed();
+		changed.write[i]->emit_changed();
 	}
 }
 

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -386,7 +386,7 @@ Vector<CharType> BitmapFont::get_char_keys() const {
 	int count = 0;
 	while ((ct = char_map.next(ct))) {
 
-		chars[count++] = *ct;
+		chars.write[count++] = *ct;
 	};
 
 	return chars;
@@ -438,7 +438,7 @@ Vector<BitmapFont::KerningPairKey> BitmapFont::get_kerning_pair_keys() const {
 	int i = 0;
 
 	for (Map<KerningPairKey, int>::Element *E = kerning_map.front(); E; E = E->next()) {
-		ret[i++] = E->key();
+		ret.write[i++] = E->key();
 	}
 
 	return ret;

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -126,16 +126,16 @@ void Mesh::generate_debug_mesh_lines(Vector<Vector3> &r_lines) {
 	PoolVector<Vector3>::Read ver_r = vertices.read();
 	for (int j = 0, x = 0, i = 0; i < triangles_num; j += 6, x += 3, ++i) {
 		// Triangle line 1
-		r_lines[j + 0] = ver_r[ind_r[x + 0]];
-		r_lines[j + 1] = ver_r[ind_r[x + 1]];
+		r_lines.write[j + 0] = ver_r[ind_r[x + 0]];
+		r_lines.write[j + 1] = ver_r[ind_r[x + 1]];
 
 		// Triangle line 2
-		r_lines[j + 2] = ver_r[ind_r[x + 1]];
-		r_lines[j + 3] = ver_r[ind_r[x + 2]];
+		r_lines.write[j + 2] = ver_r[ind_r[x + 1]];
+		r_lines.write[j + 3] = ver_r[ind_r[x + 2]];
 
 		// Triangle line 3
-		r_lines[j + 4] = ver_r[ind_r[x + 2]];
-		r_lines[j + 5] = ver_r[ind_r[x + 0]];
+		r_lines.write[j + 4] = ver_r[ind_r[x + 2]];
+		r_lines.write[j + 5] = ver_r[ind_r[x + 0]];
 	}
 }
 void Mesh::generate_debug_mesh_indices(Vector<Vector3> &r_points) {
@@ -148,7 +148,7 @@ void Mesh::generate_debug_mesh_indices(Vector<Vector3> &r_points) {
 	int vertices_size = vertices.size();
 	r_points.resize(vertices_size);
 	for (int i = 0; i < vertices_size; ++i) {
-		r_points[i] = vertices[i];
+		r_points.write[i] = vertices[i];
 	}
 }
 
@@ -667,7 +667,7 @@ bool ArrayMesh::_set(const StringName &p_name, const Variant &p_value) {
 				bone_aabb.resize(baabb.size());
 
 				for (int i = 0; i < baabb.size(); i++) {
-					bone_aabb[i] = baabb[i];
+					bone_aabb.write[i] = baabb[i];
 				}
 			}
 
@@ -839,8 +839,8 @@ void ArrayMesh::add_surface_from_arrays(PrimitiveType p_primitive, const Array &
 				aabb.expand_to(vtx[i]);
 		}
 
-		surfaces[surfaces.size() - 1].aabb = aabb;
-		surfaces[surfaces.size() - 1].is_2d = arr.get_type() == Variant::POOL_VECTOR2_ARRAY;
+		surfaces.write[surfaces.size() - 1].aabb = aabb;
+		surfaces.write[surfaces.size() - 1].is_2d = arr.get_type() == Variant::POOL_VECTOR2_ARRAY;
 
 		_recompute_aabb();
 	}
@@ -959,7 +959,7 @@ void ArrayMesh::surface_set_material(int p_idx, const Ref<Material> &p_material)
 	ERR_FAIL_INDEX(p_idx, surfaces.size());
 	if (surfaces[p_idx].material == p_material)
 		return;
-	surfaces[p_idx].material = p_material;
+	surfaces.write[p_idx].material = p_material;
 	VisualServer::get_singleton()->mesh_surface_set_material(mesh, p_idx, p_material.is_null() ? RID() : p_material->get_rid());
 
 	_change_notify("material");
@@ -970,7 +970,7 @@ void ArrayMesh::surface_set_name(int p_idx, const String &p_name) {
 
 	ERR_FAIL_INDEX(p_idx, surfaces.size());
 
-	surfaces[p_idx].name = p_name;
+	surfaces.write[p_idx].name = p_name;
 	emit_changed();
 }
 
@@ -990,7 +990,7 @@ void ArrayMesh::surface_update_region(int p_surface, int p_offset, const PoolVec
 void ArrayMesh::surface_set_custom_aabb(int p_idx, const AABB &p_aabb) {
 
 	ERR_FAIL_INDEX(p_idx, surfaces.size());
-	surfaces[p_idx].aabb = p_aabb;
+	surfaces.write[p_idx].aabb = p_aabb;
 	// set custom aabb too?
 	emit_changed();
 }
@@ -1093,8 +1093,8 @@ void ArrayMesh::regen_normalmaps() {
 
 	for (int i = 0; i < surfs.size(); i++) {
 
-		surfs[i]->generate_tangents();
-		surfs[i]->commit(Ref<ArrayMesh>(this));
+		surfs.write[i]->generate_tangents();
+		surfs.write[i]->commit(Ref<ArrayMesh>(this));
 	}
 }
 
@@ -1159,13 +1159,13 @@ Error ArrayMesh::lightmap_unwrap(const Transform &p_base_transform, float p_texe
 			Vector3 v = p_base_transform.xform(r[j]);
 			Vector3 n = p_base_transform.basis.xform(rn[j]).normalized();
 
-			vertices[(j + vertex_ofs) * 3 + 0] = v.x;
-			vertices[(j + vertex_ofs) * 3 + 1] = v.y;
-			vertices[(j + vertex_ofs) * 3 + 2] = v.z;
-			normals[(j + vertex_ofs) * 3 + 0] = n.x;
-			normals[(j + vertex_ofs) * 3 + 1] = n.y;
-			normals[(j + vertex_ofs) * 3 + 2] = n.z;
-			uv_index[j + vertex_ofs] = Pair<int, int>(i, j);
+			vertices.write[(j + vertex_ofs) * 3 + 0] = v.x;
+			vertices.write[(j + vertex_ofs) * 3 + 1] = v.y;
+			vertices.write[(j + vertex_ofs) * 3 + 2] = v.z;
+			normals.write[(j + vertex_ofs) * 3 + 0] = n.x;
+			normals.write[(j + vertex_ofs) * 3 + 1] = n.y;
+			normals.write[(j + vertex_ofs) * 3 + 2] = n.z;
+			uv_index.write[j + vertex_ofs] = Pair<int, int>(i, j);
 		}
 
 		PoolVector<int> rindices = arrays[Mesh::ARRAY_INDEX];
@@ -1248,31 +1248,31 @@ Error ArrayMesh::lightmap_unwrap(const Transform &p_base_transform, float p_texe
 			SurfaceTool::Vertex v = surfaces[surface].vertices[uv_index[gen_vertices[gen_indices[i + j]]].second];
 
 			if (surfaces[surface].format & ARRAY_FORMAT_COLOR) {
-				surfaces_tools[surface]->add_color(v.color);
+				surfaces_tools.write[surface]->add_color(v.color);
 			}
 			if (surfaces[surface].format & ARRAY_FORMAT_TEX_UV) {
-				surfaces_tools[surface]->add_uv(v.uv);
+				surfaces_tools.write[surface]->add_uv(v.uv);
 			}
 			if (surfaces[surface].format & ARRAY_FORMAT_NORMAL) {
-				surfaces_tools[surface]->add_normal(v.normal);
+				surfaces_tools.write[surface]->add_normal(v.normal);
 			}
 			if (surfaces[surface].format & ARRAY_FORMAT_TANGENT) {
 				Plane t;
 				t.normal = v.tangent;
 				t.d = v.binormal.dot(v.normal.cross(v.tangent)) < 0 ? -1 : 1;
-				surfaces_tools[surface]->add_tangent(t);
+				surfaces_tools.write[surface]->add_tangent(t);
 			}
 			if (surfaces[surface].format & ARRAY_FORMAT_BONES) {
-				surfaces_tools[surface]->add_bones(v.bones);
+				surfaces_tools.write[surface]->add_bones(v.bones);
 			}
 			if (surfaces[surface].format & ARRAY_FORMAT_WEIGHTS) {
-				surfaces_tools[surface]->add_weights(v.weights);
+				surfaces_tools.write[surface]->add_weights(v.weights);
 			}
 
 			Vector2 uv2(gen_uvs[gen_indices[i + j] * 2 + 0], gen_uvs[gen_indices[i + j] * 2 + 1]);
-			surfaces_tools[surface]->add_uv2(uv2);
+			surfaces_tools.write[surface]->add_uv2(uv2);
 
-			surfaces_tools[surface]->add_vertex(v.vertex);
+			surfaces_tools.write[surface]->add_vertex(v.vertex);
 		}
 	}
 
@@ -1284,8 +1284,8 @@ Error ArrayMesh::lightmap_unwrap(const Transform &p_base_transform, float p_texe
 	//generate surfaces
 
 	for (int i = 0; i < surfaces_tools.size(); i++) {
-		surfaces_tools[i]->index();
-		surfaces_tools[i]->commit(Ref<ArrayMesh>((ArrayMesh *)this), surfaces[i].format);
+		surfaces_tools.write[i]->index();
+		surfaces_tools.write[i]->commit(Ref<ArrayMesh>((ArrayMesh *)this), surfaces[i].format);
 	}
 
 	set_lightmap_size_hint(Size2(size_x, size_y));

--- a/scene/resources/mesh_data_tool.cpp
+++ b/scene/resources/mesh_data_tool.cpp
@@ -120,7 +120,7 @@ Error MeshDataTool::create_from_surface(const Ref<ArrayMesh> &p_mesh, int p_surf
 			v.bones.push_back(bo[i * 4 + 3]);
 		}
 
-		vertices[i] = v;
+		vertices.write[i] = v;
 	}
 
 	PoolVector<int> indices;
@@ -143,7 +143,7 @@ Error MeshDataTool::create_from_surface(const Ref<ArrayMesh> &p_mesh, int p_surf
 
 	for (int i = 0; i < icount; i += 3) {
 
-		Vertex *v[3] = { &vertices[r[i + 0]], &vertices[r[i + 1]], &vertices[r[i + 2]] };
+		Vertex *v[3] = { &vertices.write[r[i + 0]], &vertices.write[r[i + 1]], &vertices.write[r[i + 2]] };
 
 		int fidx = faces.size();
 		Face face;
@@ -169,7 +169,7 @@ Error MeshDataTool::create_from_surface(const Ref<ArrayMesh> &p_mesh, int p_surf
 				edges.push_back(e);
 			}
 
-			edges[face.edges[j]].faces.push_back(fidx);
+			edges.write[face.edges[j]].faces.push_back(fidx);
 			v[j]->faces.push_back(fidx);
 			v[j]->edges.push_back(face.edges[j]);
 		}
@@ -247,7 +247,7 @@ Error MeshDataTool::commit_to_surface(const Ref<ArrayMesh> &p_mesh) {
 
 		for (int i = 0; i < vcount; i++) {
 
-			Vertex &vtx = vertices[i];
+			const Vertex &vtx = vertices[i];
 
 			vr[i] = vtx.vertex;
 			if (nr.ptr())
@@ -344,7 +344,7 @@ Vector3 MeshDataTool::get_vertex(int p_idx) const {
 void MeshDataTool::set_vertex(int p_idx, const Vector3 &p_vertex) {
 
 	ERR_FAIL_INDEX(p_idx, vertices.size());
-	vertices[p_idx].vertex = p_vertex;
+	vertices.write[p_idx].vertex = p_vertex;
 }
 
 Vector3 MeshDataTool::get_vertex_normal(int p_idx) const {
@@ -355,7 +355,7 @@ Vector3 MeshDataTool::get_vertex_normal(int p_idx) const {
 void MeshDataTool::set_vertex_normal(int p_idx, const Vector3 &p_normal) {
 
 	ERR_FAIL_INDEX(p_idx, vertices.size());
-	vertices[p_idx].normal = p_normal;
+	vertices.write[p_idx].normal = p_normal;
 	format |= Mesh::ARRAY_FORMAT_NORMAL;
 }
 
@@ -367,7 +367,7 @@ Plane MeshDataTool::get_vertex_tangent(int p_idx) const {
 void MeshDataTool::set_vertex_tangent(int p_idx, const Plane &p_tangent) {
 
 	ERR_FAIL_INDEX(p_idx, vertices.size());
-	vertices[p_idx].tangent = p_tangent;
+	vertices.write[p_idx].tangent = p_tangent;
 	format |= Mesh::ARRAY_FORMAT_TANGENT;
 }
 
@@ -379,7 +379,7 @@ Vector2 MeshDataTool::get_vertex_uv(int p_idx) const {
 void MeshDataTool::set_vertex_uv(int p_idx, const Vector2 &p_uv) {
 
 	ERR_FAIL_INDEX(p_idx, vertices.size());
-	vertices[p_idx].uv = p_uv;
+	vertices.write[p_idx].uv = p_uv;
 	format |= Mesh::ARRAY_FORMAT_TEX_UV;
 }
 
@@ -391,7 +391,7 @@ Vector2 MeshDataTool::get_vertex_uv2(int p_idx) const {
 void MeshDataTool::set_vertex_uv2(int p_idx, const Vector2 &p_uv2) {
 
 	ERR_FAIL_INDEX(p_idx, vertices.size());
-	vertices[p_idx].uv2 = p_uv2;
+	vertices.write[p_idx].uv2 = p_uv2;
 	format |= Mesh::ARRAY_FORMAT_TEX_UV2;
 }
 
@@ -403,7 +403,7 @@ Color MeshDataTool::get_vertex_color(int p_idx) const {
 void MeshDataTool::set_vertex_color(int p_idx, const Color &p_color) {
 
 	ERR_FAIL_INDEX(p_idx, vertices.size());
-	vertices[p_idx].color = p_color;
+	vertices.write[p_idx].color = p_color;
 	format |= Mesh::ARRAY_FORMAT_COLOR;
 }
 
@@ -415,7 +415,7 @@ Vector<int> MeshDataTool::get_vertex_bones(int p_idx) const {
 void MeshDataTool::set_vertex_bones(int p_idx, const Vector<int> &p_bones) {
 
 	ERR_FAIL_INDEX(p_idx, vertices.size());
-	vertices[p_idx].bones = p_bones;
+	vertices.write[p_idx].bones = p_bones;
 	format |= Mesh::ARRAY_FORMAT_BONES;
 }
 
@@ -426,7 +426,7 @@ Vector<float> MeshDataTool::get_vertex_weights(int p_idx) const {
 }
 void MeshDataTool::set_vertex_weights(int p_idx, const Vector<float> &p_weights) {
 	ERR_FAIL_INDEX(p_idx, vertices.size());
-	vertices[p_idx].weights = p_weights;
+	vertices.write[p_idx].weights = p_weights;
 	format |= Mesh::ARRAY_FORMAT_WEIGHTS;
 }
 
@@ -439,7 +439,7 @@ Variant MeshDataTool::get_vertex_meta(int p_idx) const {
 void MeshDataTool::set_vertex_meta(int p_idx, const Variant &p_meta) {
 
 	ERR_FAIL_INDEX(p_idx, vertices.size());
-	vertices[p_idx].meta = p_meta;
+	vertices.write[p_idx].meta = p_meta;
 }
 
 Vector<int> MeshDataTool::get_vertex_edges(int p_idx) const {
@@ -472,7 +472,7 @@ Variant MeshDataTool::get_edge_meta(int p_idx) const {
 void MeshDataTool::set_edge_meta(int p_idx, const Variant &p_meta) {
 
 	ERR_FAIL_INDEX(p_idx, edges.size());
-	edges[p_idx].meta = p_meta;
+	edges.write[p_idx].meta = p_meta;
 }
 
 int MeshDataTool::get_face_vertex(int p_face, int p_vertex) const {
@@ -495,7 +495,7 @@ Variant MeshDataTool::get_face_meta(int p_face) const {
 void MeshDataTool::set_face_meta(int p_face, const Variant &p_meta) {
 
 	ERR_FAIL_INDEX(p_face, faces.size());
-	faces[p_face].meta = p_meta;
+	faces.write[p_face].meta = p_meta;
 }
 
 Vector3 MeshDataTool::get_face_normal(int p_face) const {

--- a/scene/resources/mesh_library.cpp
+++ b/scene/resources/mesh_library.cpp
@@ -209,7 +209,7 @@ Vector<int> MeshLibrary::get_item_list() const {
 	int idx = 0;
 	for (Map<int, Item>::Element *E = item_map.front(); E; E = E->next()) {
 
-		ret[idx++] = E->key();
+		ret.write[idx++] = E->key();
 	}
 
 	return ret;

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -325,7 +325,7 @@ Node *SceneState::instance(GenEditState p_edit_state) const {
 		if (c.binds.size()) {
 			binds.resize(c.binds.size());
 			for (int j = 0; j < c.binds.size(); j++)
-				binds[j] = props[c.binds[j]];
+				binds.write[j] = props[c.binds[j]];
 		}
 
 		cfrom->connect(snames[c.signal], cto, snames[c.method], binds, CONNECT_PERSIST | c.flags);
@@ -875,7 +875,7 @@ Error SceneState::pack(Node *p_scene) {
 
 	for (Map<StringName, int>::Element *E = name_map.front(); E; E = E->next()) {
 
-		names[E->get()] = E->key();
+		names.write[E->get()] = E->key();
 	}
 
 	variants.resize(variant_map.size());
@@ -883,13 +883,13 @@ Error SceneState::pack(Node *p_scene) {
 	while ((K = variant_map.next(K))) {
 
 		int idx = variant_map[*K];
-		variants[idx] = *K;
+		variants.write[idx] = *K;
 	}
 
 	node_paths.resize(nodepath_map.size());
 	for (Map<Node *, int>::Element *E = nodepath_map.front(); E; E = E->next()) {
 
-		node_paths[E->get()] = scene->get_path_to(E->key());
+		node_paths.write[E->get()] = scene->get_path_to(E->key());
 	}
 
 	return OK;
@@ -1090,7 +1090,7 @@ void SceneState::set_bundled_scene(const Dictionary &p_dictionary) {
 		names.resize(namecount);
 		PoolVector<String>::Read r = snames.read();
 		for (int i = 0; i < names.size(); i++)
-			names[i] = r[i];
+			names.write[i] = r[i];
 	}
 
 	Array svariants = p_dictionary["variants"];
@@ -1100,7 +1100,7 @@ void SceneState::set_bundled_scene(const Dictionary &p_dictionary) {
 		variants.resize(varcount);
 		for (int i = 0; i < varcount; i++) {
 
-			variants[i] = svariants[i];
+			variants.write[i] = svariants[i];
 		}
 
 	} else {
@@ -1114,7 +1114,7 @@ void SceneState::set_bundled_scene(const Dictionary &p_dictionary) {
 		PoolVector<int>::Read r = snodes.read();
 		int idx = 0;
 		for (int i = 0; i < nc; i++) {
-			NodeData &nd = nodes[i];
+			NodeData &nd = nodes.write[i];
 			nd.parent = r[idx++];
 			nd.owner = r[idx++];
 			nd.type = r[idx++];
@@ -1126,13 +1126,13 @@ void SceneState::set_bundled_scene(const Dictionary &p_dictionary) {
 			nd.properties.resize(r[idx++]);
 			for (int j = 0; j < nd.properties.size(); j++) {
 
-				nd.properties[j].name = r[idx++];
-				nd.properties[j].value = r[idx++];
+				nd.properties.write[j].name = r[idx++];
+				nd.properties.write[j].value = r[idx++];
 			}
 			nd.groups.resize(r[idx++]);
 			for (int j = 0; j < nd.groups.size(); j++) {
 
-				nd.groups[j] = r[idx++];
+				nd.groups.write[j] = r[idx++];
 			}
 		}
 	}
@@ -1146,7 +1146,7 @@ void SceneState::set_bundled_scene(const Dictionary &p_dictionary) {
 		PoolVector<int>::Read r = sconns.read();
 		int idx = 0;
 		for (int i = 0; i < cc; i++) {
-			ConnectionData &cd = connections[i];
+			ConnectionData &cd = connections.write[i];
 			cd.from = r[idx++];
 			cd.to = r[idx++];
 			cd.signal = r[idx++];
@@ -1156,7 +1156,7 @@ void SceneState::set_bundled_scene(const Dictionary &p_dictionary) {
 
 			for (int j = 0; j < cd.binds.size(); j++) {
 
-				cd.binds[j] = r[idx++];
+				cd.binds.write[j] = r[idx++];
 			}
 		}
 	}
@@ -1167,7 +1167,7 @@ void SceneState::set_bundled_scene(const Dictionary &p_dictionary) {
 	}
 	node_paths.resize(np.size());
 	for (int i = 0; i < np.size(); i++) {
-		node_paths[i] = np[i];
+		node_paths.write[i] = np[i];
 	}
 
 	Array ei;
@@ -1181,7 +1181,7 @@ void SceneState::set_bundled_scene(const Dictionary &p_dictionary) {
 
 	editable_instances.resize(ei.size());
 	for (int i = 0; i < editable_instances.size(); i++) {
-		editable_instances[i] = ei[i];
+		editable_instances.write[i] = ei[i];
 	}
 
 	//path=p_dictionary["path"];
@@ -1563,13 +1563,13 @@ void SceneState::add_node_property(int p_node, int p_name, int p_value) {
 	NodeData::Property prop;
 	prop.name = p_name;
 	prop.value = p_value;
-	nodes[p_node].properties.push_back(prop);
+	nodes.write[p_node].properties.push_back(prop);
 }
 void SceneState::add_node_group(int p_node, int p_group) {
 
 	ERR_FAIL_INDEX(p_node, nodes.size());
 	ERR_FAIL_INDEX(p_group, names.size());
-	nodes[p_node].groups.push_back(p_group);
+	nodes.write[p_node].groups.push_back(p_group);
 }
 void SceneState::set_base_scene(int p_idx) {
 

--- a/scene/resources/polygon_path_finder.cpp
+++ b/scene/resources/polygon_path_finder.cpp
@@ -65,8 +65,8 @@ void PolygonPathFinder::setup(const Vector<Vector2> &p_points, const Vector<int>
 
 	for (int i = 0; i < p_points.size(); i++) {
 
-		points[i].pos = p_points[i];
-		points[i].penalty = 0;
+		points.write[i].pos = p_points[i];
+		points.write[i].penalty = 0;
 
 		outside_point.x = i == 0 ? p_points[0].x : (MAX(p_points[i].x, outside_point.x));
 		outside_point.y = i == 0 ? p_points[0].y : (MAX(p_points[i].y, outside_point.y));
@@ -88,8 +88,8 @@ void PolygonPathFinder::setup(const Vector<Vector2> &p_points, const Vector<int>
 		Edge e(p_connections[i], p_connections[i + 1]);
 		ERR_FAIL_INDEX(e.points[0], point_count);
 		ERR_FAIL_INDEX(e.points[1], point_count);
-		points[p_connections[i]].connections.insert(p_connections[i + 1]);
-		points[p_connections[i + 1]].connections.insert(p_connections[i]);
+		points.write[p_connections[i]].connections.insert(p_connections[i + 1]);
+		points.write[p_connections[i + 1]].connections.insert(p_connections[i]);
 		edges.insert(e);
 	}
 
@@ -126,8 +126,8 @@ void PolygonPathFinder::setup(const Vector<Vector2> &p_points, const Vector<int>
 			}
 
 			if (valid) {
-				points[i].connections.insert(j);
-				points[j].connections.insert(i);
+				points.write[i].connections.insert(j);
+				points.write[j].connections.insert(i);
 			}
 		}
 	}
@@ -227,21 +227,21 @@ Vector<Vector2> PolygonPathFinder::find_path(const Vector2 &p_from, const Vector
 
 	int aidx = points.size() - 2;
 	int bidx = points.size() - 1;
-	points[aidx].pos = from;
-	points[bidx].pos = to;
-	points[aidx].distance = 0;
-	points[bidx].distance = 0;
-	points[aidx].prev = -1;
-	points[bidx].prev = -1;
-	points[aidx].penalty = 0;
-	points[bidx].penalty = 0;
+	points.write[aidx].pos = from;
+	points.write[bidx].pos = to;
+	points.write[aidx].distance = 0;
+	points.write[bidx].distance = 0;
+	points.write[aidx].prev = -1;
+	points.write[bidx].prev = -1;
+	points.write[aidx].penalty = 0;
+	points.write[bidx].penalty = 0;
 
 	for (int i = 0; i < points.size() - 2; i++) {
 
 		bool valid_a = true;
 		bool valid_b = true;
-		points[i].prev = -1;
-		points[i].distance = 0;
+		points.write[i].prev = -1;
+		points.write[i].distance = 0;
 
 		if (!_is_point_inside(from * 0.5 + points[i].pos * 0.5)) {
 			valid_a = false;
@@ -292,26 +292,26 @@ Vector<Vector2> PolygonPathFinder::find_path(const Vector2 &p_from, const Vector
 		}
 
 		if (valid_a) {
-			points[i].connections.insert(aidx);
-			points[aidx].connections.insert(i);
+			points.write[i].connections.insert(aidx);
+			points.write[aidx].connections.insert(i);
 		}
 
 		if (valid_b) {
-			points[i].connections.insert(bidx);
-			points[bidx].connections.insert(i);
+			points.write[i].connections.insert(bidx);
+			points.write[bidx].connections.insert(i);
 		}
 	}
 	//solve graph
 
 	Set<int> open_list;
 
-	points[aidx].distance = 0;
-	points[aidx].prev = aidx;
+	points.write[aidx].distance = 0;
+	points.write[aidx].prev = aidx;
 	for (Set<int>::Element *E = points[aidx].connections.front(); E; E = E->next()) {
 
 		open_list.insert(E->get());
-		points[E->get()].distance = from.distance_to(points[E->get()].pos);
-		points[E->get()].prev = aidx;
+		points.write[E->get()].distance = from.distance_to(points[E->get()].pos);
+		points.write[E->get()].prev = aidx;
 	}
 
 	bool found_route = false;
@@ -342,12 +342,12 @@ Vector<Vector2> PolygonPathFinder::find_path(const Vector2 &p_from, const Vector
 			}
 		}
 
-		Point &np = points[least_cost_point];
+		const Point &np = points[least_cost_point];
 		//open the neighbours for search
 
 		for (Set<int>::Element *E = np.connections.front(); E; E = E->next()) {
 
-			Point &p = points[E->get()];
+			Point &p = points.write[E->get()];
 			float distance = np.pos.distance_to(p.pos) + np.distance;
 
 			if (p.prev != -1) {
@@ -392,18 +392,18 @@ Vector<Vector2> PolygonPathFinder::find_path(const Vector2 &p_from, const Vector
 
 	for (int i = 0; i < points.size() - 2; i++) {
 
-		points[i].connections.erase(aidx);
-		points[i].connections.erase(bidx);
-		points[i].prev = -1;
-		points[i].distance = 0;
+		points.write[i].connections.erase(aidx);
+		points.write[i].connections.erase(bidx);
+		points.write[i].prev = -1;
+		points.write[i].distance = 0;
 	}
 
-	points[aidx].connections.clear();
-	points[aidx].prev = -1;
-	points[aidx].distance = 0;
-	points[bidx].connections.clear();
-	points[bidx].prev = -1;
-	points[bidx].distance = 0;
+	points.write[aidx].connections.clear();
+	points.write[aidx].prev = -1;
+	points.write[aidx].distance = 0;
+	points.write[bidx].connections.clear();
+	points.write[bidx].prev = -1;
+	points.write[bidx].distance = 0;
 
 	return path;
 }
@@ -427,13 +427,13 @@ void PolygonPathFinder::_set_data(const Dictionary &p_data) {
 
 	PoolVector<Vector2>::Read pr = p.read();
 	for (int i = 0; i < pc; i++) {
-		points[i].pos = pr[i];
+		points.write[i].pos = pr[i];
 		PoolVector<int> con = c[i];
 		PoolVector<int>::Read cr = con.read();
 		int cc = con.size();
 		for (int j = 0; j < cc; j++) {
 
-			points[i].connections.insert(cr[j]);
+			points.write[i].connections.insert(cr[j]);
 		}
 	}
 
@@ -443,7 +443,7 @@ void PolygonPathFinder::_set_data(const Dictionary &p_data) {
 		if (penalties.size() == pc) {
 			PoolVector<float>::Read pr = penalties.read();
 			for (int i = 0; i < pc; i++) {
-				points[i].penalty = pr[i];
+				points.write[i].penalty = pr[i];
 			}
 		}
 	}
@@ -566,7 +566,7 @@ Rect2 PolygonPathFinder::get_bounds() const {
 void PolygonPathFinder::set_point_penalty(int p_point, float p_penalty) {
 
 	ERR_FAIL_INDEX(p_point, points.size() - 2);
-	points[p_point].penalty = p_penalty;
+	points.write[p_point].penalty = p_penalty;
 }
 
 float PolygonPathFinder::get_point_penalty(int p_point) const {

--- a/scene/resources/scene_format_text.cpp
+++ b/scene/resources/scene_format_text.cpp
@@ -1523,7 +1523,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_r
 
 	for (Map<RES, int>::Element *E = external_resources.front(); E; E = E->next()) {
 
-		sorted_er[E->get()] = E->key();
+		sorted_er.write[E->get()] = E->key();
 	}
 
 	for (int i = 0; i < sorted_er.size(); i++) {

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -466,7 +466,7 @@ void SurfaceTool::deindex() {
 	int idx = 0;
 	for (List<Vertex>::Element *E = vertex_array.front(); E; E = E->next()) {
 
-		varr[idx++] = E->get();
+		varr.write[idx++] = E->get();
 	}
 	vertex_array.clear();
 	for (List<int>::Element *E = index_array.front(); E; E = E->next()) {
@@ -570,19 +570,19 @@ Vector<SurfaceTool::Vertex> SurfaceTool::create_vertex_array_from_triangle_array
 		if (lformat & VS::ARRAY_FORMAT_BONES) {
 			Vector<int> b;
 			b.resize(4);
-			b[0] = barr[i * 4 + 0];
-			b[1] = barr[i * 4 + 1];
-			b[2] = barr[i * 4 + 2];
-			b[3] = barr[i * 4 + 3];
+			b.write[0] = barr[i * 4 + 0];
+			b.write[1] = barr[i * 4 + 1];
+			b.write[2] = barr[i * 4 + 2];
+			b.write[3] = barr[i * 4 + 3];
 			v.bones = b;
 		}
 		if (lformat & VS::ARRAY_FORMAT_WEIGHTS) {
 			Vector<float> w;
 			w.resize(4);
-			w[0] = warr[i * 4 + 0];
-			w[1] = warr[i * 4 + 1];
-			w[2] = warr[i * 4 + 2];
-			w[3] = warr[i * 4 + 3];
+			w.write[0] = warr[i * 4 + 0];
+			w.write[1] = warr[i * 4 + 1];
+			w.write[2] = warr[i * 4 + 2];
+			w.write[3] = warr[i * 4 + 3];
 			v.weights = w;
 		}
 
@@ -675,19 +675,19 @@ void SurfaceTool::_create_list_from_arrays(Array arr, List<Vertex> *r_vertex, Li
 		if (lformat & VS::ARRAY_FORMAT_BONES) {
 			Vector<int> b;
 			b.resize(4);
-			b[0] = barr[i * 4 + 0];
-			b[1] = barr[i * 4 + 1];
-			b[2] = barr[i * 4 + 2];
-			b[3] = barr[i * 4 + 3];
+			b.write[0] = barr[i * 4 + 0];
+			b.write[1] = barr[i * 4 + 1];
+			b.write[2] = barr[i * 4 + 2];
+			b.write[3] = barr[i * 4 + 3];
 			v.bones = b;
 		}
 		if (lformat & VS::ARRAY_FORMAT_WEIGHTS) {
 			Vector<float> w;
 			w.resize(4);
-			w[0] = warr[i * 4 + 0];
-			w[1] = warr[i * 4 + 1];
-			w[2] = warr[i * 4 + 2];
-			w[3] = warr[i * 4 + 3];
+			w.write[0] = warr[i * 4 + 0];
+			w.write[1] = warr[i * 4 + 1];
+			w.write[2] = warr[i * 4 + 2];
+			w.write[3] = warr[i * 4 + 3];
 			v.weights = w;
 		}
 
@@ -846,7 +846,7 @@ void SurfaceTool::generate_tangents() {
 	vtx.resize(vertex_array.size());
 	int idx = 0;
 	for (List<Vertex>::Element *E = vertex_array.front(); E; E = E->next()) {
-		vtx[idx++] = E;
+		vtx.write[idx++] = E;
 		E->get().binormal = Vector3();
 		E->get().tangent = Vector3();
 	}

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1039,7 +1039,7 @@ bool LargeTexture::has_alpha() const {
 void LargeTexture::set_flags(uint32_t p_flags) {
 
 	for (int i = 0; i < pieces.size(); i++) {
-		pieces[i].texture->set_flags(p_flags);
+		pieces.write[i].texture->set_flags(p_flags);
 	}
 }
 
@@ -1065,13 +1065,13 @@ int LargeTexture::add_piece(const Point2 &p_offset, const Ref<Texture> &p_textur
 void LargeTexture::set_piece_offset(int p_idx, const Point2 &p_offset) {
 
 	ERR_FAIL_INDEX(p_idx, pieces.size());
-	pieces[p_idx].offset = p_offset;
+	pieces.write[p_idx].offset = p_offset;
 };
 
 void LargeTexture::set_piece_texture(int p_idx, const Ref<Texture> &p_texture) {
 
 	ERR_FAIL_INDEX(p_idx, pieces.size());
-	pieces[p_idx].texture = p_texture;
+	pieces.write[p_idx].texture = p_texture;
 };
 
 void LargeTexture::set_size(const Size2 &p_size) {

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -576,7 +576,7 @@ void TileSet::tile_set_shape(int p_id, int p_shape_id, const Ref<Shape2D> &p_sha
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	if (tile_map[p_id].shapes_data.size() <= p_shape_id)
 		tile_map[p_id].shapes_data.resize(p_shape_id + 1);
-	tile_map[p_id].shapes_data[p_shape_id].shape = p_shape;
+	tile_map[p_id].shapes_data.write[p_shape_id].shape = p_shape;
 	emit_changed();
 }
 
@@ -594,7 +594,7 @@ void TileSet::tile_set_shape_transform(int p_id, int p_shape_id, const Transform
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	if (tile_map[p_id].shapes_data.size() <= p_shape_id)
 		tile_map[p_id].shapes_data.resize(p_shape_id + 1);
-	tile_map[p_id].shapes_data[p_shape_id].shape_transform = p_offset;
+	tile_map[p_id].shapes_data.write[p_shape_id].shape_transform = p_offset;
 	emit_changed();
 }
 
@@ -622,7 +622,7 @@ void TileSet::tile_set_shape_one_way(int p_id, int p_shape_id, const bool p_one_
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	if (tile_map[p_id].shapes_data.size() <= p_shape_id)
 		tile_map[p_id].shapes_data.resize(p_shape_id + 1);
-	tile_map[p_id].shapes_data[p_shape_id].one_way_collision = p_one_way;
+	tile_map[p_id].shapes_data.write[p_shape_id].one_way_collision = p_one_way;
 	emit_changed();
 }
 

--- a/servers/arvr/arvr_interface.h
+++ b/servers/arvr/arvr_interface.h
@@ -88,7 +88,7 @@ public:
 	bool is_primary();
 	void set_is_primary(bool p_is_primary);
 
-	virtual bool is_initialized() = 0; /* returns true if we've initialized this interface */
+	virtual bool is_initialized() const = 0; /* returns true if we've initialized this interface */
 	void set_is_initialized(bool p_initialized); /* helper function, will call initialize or uninitialize */
 	virtual bool initialize() = 0; /* initialize this interface, if this has an HMD it becomes the primary interface */
 	virtual void uninitialize() = 0; /* deinitialize this interface */

--- a/servers/arvr_server.cpp
+++ b/servers/arvr_server.cpp
@@ -353,7 +353,7 @@ void ARVRServer::_process() {
 		if (!interfaces[i].is_valid()) {
 			// ignore, not a valid reference
 		} else if (interfaces[i]->is_initialized()) {
-			interfaces[i]->process();
+			interfaces.write[i]->process();
 		};
 	};
 };

--- a/servers/audio/effects/audio_effect_chorus.cpp
+++ b/servers/audio/effects/audio_effect_chorus.cpp
@@ -53,7 +53,7 @@ void AudioEffectChorusInstance::_process_chunk(const AudioFrame *p_src_frames, A
 
 	//fill ringbuffer
 	for (int i = 0; i < p_frame_count; i++) {
-		audio_buffer[(buffer_pos + i) & buffer_mask] = p_src_frames[i];
+		audio_buffer.write[(buffer_pos + i) & buffer_mask] = p_src_frames[i];
 		p_dst_frames[i] = p_src_frames[i] * base->dry;
 	}
 
@@ -175,7 +175,7 @@ Ref<AudioEffectInstance> AudioEffectChorus::instance() {
 	ins->buffer_pos = 0;
 	ins->audio_buffer.resize(ringbuff_size);
 	for (int i = 0; i < ringbuff_size; i++) {
-		ins->audio_buffer[i] = AudioFrame(0, 0);
+		ins->audio_buffer.write[i] = AudioFrame(0, 0);
 	}
 
 	return ins;

--- a/servers/audio/effects/audio_effect_eq.cpp
+++ b/servers/audio/effects/audio_effect_eq.cpp
@@ -70,7 +70,7 @@ Ref<AudioEffectInstance> AudioEffectEQ::instance() {
 	for (int i = 0; i < 2; i++) {
 		ins->bands[i].resize(eq.get_band_count());
 		for (int j = 0; j < ins->bands[i].size(); j++) {
-			ins->bands[i][j] = eq.get_band_processor(j);
+			ins->bands[i].write[j] = eq.get_band_processor(j);
 		}
 	}
 
@@ -79,7 +79,7 @@ Ref<AudioEffectInstance> AudioEffectEQ::instance() {
 
 void AudioEffectEQ::set_band_gain_db(int p_band, float p_volume) {
 	ERR_FAIL_INDEX(p_band, gain.size());
-	gain[p_band] = p_volume;
+	gain.write[p_band] = p_volume;
 }
 
 float AudioEffectEQ::get_band_gain_db(int p_band) const {
@@ -134,7 +134,7 @@ AudioEffectEQ::AudioEffectEQ(EQ::Preset p_preset) {
 	eq.set_preset_band_mode(p_preset);
 	gain.resize(eq.get_band_count());
 	for (int i = 0; i < gain.size(); i++) {
-		gain[i] = 0.0;
+		gain.write[i] = 0.0;
 		String name = "band_db/" + itos(eq.get_band_frequency(i)) + "_hz";
 		prop_band_map[name] = i;
 		band_names.push_back(name);

--- a/servers/audio/effects/eq.cpp
+++ b/servers/audio/effects/eq.cpp
@@ -108,9 +108,9 @@ void EQ::recalculate_band_coefficients() {
 
 		ERR_CONTINUE(roots == 0);
 
-		band[i].c1 = 2.0 * ((0.5 - r1) / 2.0);
-		band[i].c2 = 2.0 * r1;
-		band[i].c3 = 2.0 * (0.5 + r1) * cos(th);
+		band.write[i].c1 = 2.0 * ((0.5 - r1) / 2.0);
+		band.write[i].c2 = 2.0 * r1;
+		band.write[i].c3 = 2.0 * (0.5 + r1) * cos(th);
 		//printf("band %i, coefs = %f,%f,%f\n",i,(float)bands[i].c1,(float)bands[i].c2,(float)bands[i].c3);
 	}
 }
@@ -180,7 +180,7 @@ void EQ::set_bands(const Vector<float> &p_bands) {
 	band.resize(p_bands.size());
 	for (int i = 0; i < p_bands.size(); i++) {
 
-		band[i].freq = p_bands[i];
+		band.write[i].freq = p_bands[i];
 	}
 
 	recalculate_band_coefficients();

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -264,7 +264,7 @@ void AudioServer::_mix_step() {
 		bus->index_cache = i; //might be moved around by editor, so..
 		for (int k = 0; k < bus->channels.size(); k++) {
 
-			bus->channels[k].used = false;
+			bus->channels.write[k].used = false;
 		}
 
 		if (bus->solo) {
@@ -310,7 +310,7 @@ void AudioServer::_mix_step() {
 
 			if (bus->channels[k].active && !bus->channels[k].used) {
 				//buffer was not used, but it's still active, so it must be cleaned
-				AudioFrame *buf = bus->channels[k].buffer.ptrw();
+				AudioFrame *buf = bus->channels.write[k].buffer.ptrw();
 
 				for (uint32_t j = 0; j < buffer_size; j++) {
 
@@ -334,7 +334,7 @@ void AudioServer::_mix_step() {
 
 					if (!bus->channels[k].active)
 						continue;
-					bus->channels[k].effect_instances[j]->process(bus->channels[k].buffer.ptr(), temp_buffer[k].ptrw(), buffer_size);
+					bus->channels.write[k].effect_instances.write[j]->process(bus->channels[k].buffer.ptr(), temp_buffer.write[k].ptrw(), buffer_size);
 				}
 
 				//swap buffers, so internal buffer always has the right data
@@ -342,11 +342,11 @@ void AudioServer::_mix_step() {
 
 					if (!buses[i]->channels[k].active)
 						continue;
-					SWAP(bus->channels[k].buffer, temp_buffer[k]);
+					SWAP(bus->channels.write[k].buffer, temp_buffer.write[k]);
 				}
 
 #ifdef DEBUG_ENABLED
-				bus->effects[j].prof_time += OS::get_singleton()->get_ticks_usec() - ticks;
+				bus->effects.write[j].prof_time += OS::get_singleton()->get_ticks_usec() - ticks;
 #endif
 			}
 		}
@@ -372,7 +372,7 @@ void AudioServer::_mix_step() {
 			if (!bus->channels[k].active)
 				continue;
 
-			AudioFrame *buf = bus->channels[k].buffer.ptrw();
+			AudioFrame *buf = bus->channels.write[k].buffer.ptrw();
 
 			AudioFrame peak = AudioFrame(0, 0);
 
@@ -403,15 +403,15 @@ void AudioServer::_mix_step() {
 				}
 			}
 
-			bus->channels[k].peak_volume = AudioFrame(Math::linear2db(peak.l + 0.0000000001), Math::linear2db(peak.r + 0.0000000001));
+			bus->channels.write[k].peak_volume = AudioFrame(Math::linear2db(peak.l + 0.0000000001), Math::linear2db(peak.r + 0.0000000001));
 
 			if (!bus->channels[k].used) {
 				//see if any audio is contained, because channel was not used
 
 				if (MAX(peak.r, peak.l) > Math::db2linear(channel_disable_threshold_db)) {
-					bus->channels[k].last_mix_with_audio = mix_frames;
+					bus->channels.write[k].last_mix_with_audio = mix_frames;
 				} else if (mix_frames - bus->channels[k].last_mix_with_audio > channel_disable_frames) {
-					bus->channels[k].active = false;
+					bus->channels.write[k].active = false;
 					continue; //went inactive, don't mix.
 				}
 			}
@@ -436,12 +436,12 @@ AudioFrame *AudioServer::thread_get_channel_mix_buffer(int p_bus, int p_buffer) 
 	ERR_FAIL_INDEX_V(p_bus, buses.size(), NULL);
 	ERR_FAIL_INDEX_V(p_buffer, buses[p_bus]->channels.size(), NULL);
 
-	AudioFrame *data = buses[p_bus]->channels[p_buffer].buffer.ptrw();
+	AudioFrame *data = buses.write[p_bus]->channels.write[p_buffer].buffer.ptrw();
 
 	if (!buses[p_bus]->channels[p_buffer].used) {
-		buses[p_bus]->channels[p_buffer].used = true;
-		buses[p_bus]->channels[p_buffer].active = true;
-		buses[p_bus]->channels[p_buffer].last_mix_with_audio = mix_frames;
+		buses.write[p_bus]->channels.write[p_buffer].used = true;
+		buses.write[p_bus]->channels.write[p_buffer].active = true;
+		buses.write[p_bus]->channels.write[p_buffer].last_mix_with_audio = mix_frames;
 		for (uint32_t i = 0; i < buffer_size; i++) {
 			data[i] = AudioFrame(0, 0);
 		}
@@ -506,10 +506,10 @@ void AudioServer::set_bus_count(int p_count) {
 			}
 		}
 
-		buses[i] = memnew(Bus);
-		buses[i]->channels.resize(channel_count);
+		buses.write[i] = memnew(Bus);
+		buses.write[i]->channels.resize(channel_count);
 		for (int j = 0; j < channel_count; j++) {
-			buses[i]->channels[j].buffer.resize(buffer_size);
+			buses.write[i]->channels.write[j].buffer.resize(buffer_size);
 		}
 		buses[i]->name = attempt;
 		buses[i]->solo = false;
@@ -581,7 +581,7 @@ void AudioServer::add_bus(int p_at_pos) {
 	Bus *bus = memnew(Bus);
 	bus->channels.resize(channel_count);
 	for (int j = 0; j < channel_count; j++) {
-		bus->channels[j].buffer.resize(buffer_size);
+		bus->channels.write[j].buffer.resize(buffer_size);
 	}
 	bus->name = attempt;
 	bus->solo = false;
@@ -764,13 +764,13 @@ bool AudioServer::is_bus_bypassing_effects(int p_bus) const {
 void AudioServer::_update_bus_effects(int p_bus) {
 
 	for (int i = 0; i < buses[p_bus]->channels.size(); i++) {
-		buses[p_bus]->channels[i].effect_instances.resize(buses[p_bus]->effects.size());
+		buses.write[p_bus]->channels.write[i].effect_instances.resize(buses[p_bus]->effects.size());
 		for (int j = 0; j < buses[p_bus]->effects.size(); j++) {
-			Ref<AudioEffectInstance> fx = buses[p_bus]->effects[j].effect->instance();
+			Ref<AudioEffectInstance> fx = buses.write[p_bus]->effects.write[j].effect->instance();
 			if (Object::cast_to<AudioEffectCompressorInstance>(*fx)) {
 				Object::cast_to<AudioEffectCompressorInstance>(*fx)->set_current_channel(i);
 			}
-			buses[p_bus]->channels[i].effect_instances[j] = fx;
+			buses.write[p_bus]->channels.write[i].effect_instances.write[j] = fx;
 		}
 	}
 }
@@ -841,7 +841,7 @@ void AudioServer::swap_bus_effects(int p_bus, int p_effect, int p_by_effect) {
 	MARK_EDITED
 
 	lock();
-	SWAP(buses[p_bus]->effects[p_effect], buses[p_bus]->effects[p_by_effect]);
+	SWAP(buses.write[p_bus]->effects.write[p_effect], buses.write[p_bus]->effects.write[p_by_effect]);
 	_update_bus_effects(p_bus);
 	unlock();
 }
@@ -853,7 +853,7 @@ void AudioServer::set_bus_effect_enabled(int p_bus, int p_effect, bool p_enabled
 
 	MARK_EDITED
 
-	buses[p_bus]->effects[p_effect].enabled = p_enabled;
+	buses.write[p_bus]->effects.write[p_effect].enabled = p_enabled;
 }
 bool AudioServer::is_bus_effect_enabled(int p_bus, int p_effect) const {
 
@@ -890,13 +890,13 @@ void AudioServer::init_channels_and_buffers() {
 	temp_buffer.resize(channel_count);
 
 	for (int i = 0; i < temp_buffer.size(); i++) {
-		temp_buffer[i].resize(buffer_size);
+		temp_buffer.write[i].resize(buffer_size);
 	}
 
 	for (int i = 0; i < buses.size(); i++) {
 		buses[i]->channels.resize(channel_count);
 		for (int j = 0; j < channel_count; j++) {
-			buses[i]->channels[j].buffer.resize(buffer_size);
+			buses.write[i]->channels.write[j].buffer.resize(buffer_size);
 		}
 	}
 }
@@ -976,7 +976,7 @@ void AudioServer::update() {
 			if (!bus->effects[j].enabled)
 				continue;
 
-			bus->effects[j].prof_time = 0;
+			bus->effects.write[j].prof_time = 0;
 		}
 	}
 
@@ -1146,11 +1146,11 @@ void AudioServer::set_bus_layout(const Ref<AudioBusLayout> &p_bus_layout) {
 		}
 
 		bus_map[bus->name] = bus;
-		buses[i] = bus;
+		buses.write[i] = bus;
 
 		buses[i]->channels.resize(channel_count);
 		for (int j = 0; j < channel_count; j++) {
-			buses[i]->channels[j].buffer.resize(buffer_size);
+			buses.write[i]->channels.write[j].buffer.resize(buffer_size);
 		}
 		_update_bus_effects(i);
 	}
@@ -1169,17 +1169,17 @@ Ref<AudioBusLayout> AudioServer::generate_bus_layout() const {
 
 	for (int i = 0; i < buses.size(); i++) {
 
-		state->buses[i].name = buses[i]->name;
-		state->buses[i].send = buses[i]->send;
-		state->buses[i].mute = buses[i]->mute;
-		state->buses[i].solo = buses[i]->solo;
-		state->buses[i].bypass = buses[i]->bypass;
-		state->buses[i].volume_db = buses[i]->volume_db;
+		state->buses.write[i].name = buses[i]->name;
+		state->buses.write[i].send = buses[i]->send;
+		state->buses.write[i].mute = buses[i]->mute;
+		state->buses.write[i].solo = buses[i]->solo;
+		state->buses.write[i].bypass = buses[i]->bypass;
+		state->buses.write[i].volume_db = buses[i]->volume_db;
 		for (int j = 0; j < buses[i]->effects.size(); j++) {
 			AudioBusLayout::Bus::Effect fx;
 			fx.effect = buses[i]->effects[j].effect;
 			fx.enabled = buses[i]->effects[j].enabled;
-			state->buses[i].effects.push_back(fx);
+			state->buses.write[i].effects.push_back(fx);
 		}
 	}
 
@@ -1294,7 +1294,7 @@ bool AudioBusLayout::_set(const StringName &p_name, const Variant &p_value) {
 			buses.resize(index + 1);
 		}
 
-		Bus &bus = buses[index];
+		Bus &bus = buses.write[index];
 
 		String what = s.get_slice("/", 2);
 
@@ -1316,7 +1316,7 @@ bool AudioBusLayout::_set(const StringName &p_name, const Variant &p_value) {
 				bus.effects.resize(which + 1);
 			}
 
-			Bus::Effect &fx = bus.effects[which];
+			Bus::Effect &fx = bus.effects.write[which];
 
 			String fxwhat = s.get_slice("/", 4);
 			if (fxwhat == "effect") {
@@ -1410,5 +1410,5 @@ void AudioBusLayout::_get_property_list(List<PropertyInfo> *p_list) const {
 AudioBusLayout::AudioBusLayout() {
 
 	buses.resize(1);
-	buses[0].name = "Master";
+	buses.write[0].name = "Master";
 }

--- a/servers/physics/body_sw.h
+++ b/servers/physics/body_sw.h
@@ -159,7 +159,7 @@ public:
 	_FORCE_INLINE_ void add_area(AreaSW *p_area) {
 		int index = areas.find(AreaCMP(p_area));
 		if (index > -1) {
-			areas[index].refCount += 1;
+			areas.write[index].refCount += 1;
 		} else {
 			areas.ordered_insert(AreaCMP(p_area));
 		}
@@ -168,7 +168,7 @@ public:
 	_FORCE_INLINE_ void remove_area(AreaSW *p_area) {
 		int index = areas.find(AreaCMP(p_area));
 		if (index > -1) {
-			areas[index].refCount -= 1;
+			areas.write[index].refCount -= 1;
 			if (areas[index].refCount < 1)
 				areas.remove(index);
 		}
@@ -356,7 +356,7 @@ void BodySW::add_contact(const Vector3 &p_local_pos, const Vector3 &p_local_norm
 	if (c_max == 0)
 		return;
 
-	Contact *c = &contacts[0];
+	Contact *c = contacts.ptrw();
 
 	int idx = -1;
 

--- a/servers/physics/collision_object_sw.cpp
+++ b/servers/physics/collision_object_sw.cpp
@@ -53,7 +53,7 @@ void CollisionObjectSW::set_shape(int p_index, ShapeSW *p_shape) {
 
 	ERR_FAIL_INDEX(p_index, shapes.size());
 	shapes[p_index].shape->remove_owner(this);
-	shapes[p_index].shape = p_shape;
+	shapes.write[p_index].shape = p_shape;
 
 	p_shape->add_owner(this);
 	if (!pending_shape_update_list.in_list()) {
@@ -66,8 +66,8 @@ void CollisionObjectSW::set_shape_transform(int p_index, const Transform &p_tran
 
 	ERR_FAIL_INDEX(p_index, shapes.size());
 
-	shapes[p_index].xform = p_transform;
-	shapes[p_index].xform_inv = p_transform.affine_inverse();
+	shapes.write[p_index].xform = p_transform;
+	shapes.write[p_index].xform_inv = p_transform.affine_inverse();
 	if (!pending_shape_update_list.in_list()) {
 		PhysicsServerSW::singleton->pending_shape_update_list.add(&pending_shape_update_list);
 	}
@@ -97,7 +97,7 @@ void CollisionObjectSW::remove_shape(int p_index) {
 			continue;
 		//should never get here with a null owner
 		space->get_broadphase()->remove(shapes[i].bpid);
-		shapes[i].bpid = 0;
+		shapes.write[i].bpid = 0;
 	}
 	shapes[p_index].shape->remove_owner(this);
 	shapes.remove(p_index);
@@ -117,7 +117,7 @@ void CollisionObjectSW::_set_static(bool p_static) {
 	if (!space)
 		return;
 	for (int i = 0; i < get_shape_count(); i++) {
-		Shape &s = shapes[i];
+		const Shape &s = shapes[i];
 		if (s.bpid > 0) {
 			space->get_broadphase()->set_static(s.bpid, _static);
 		}
@@ -128,7 +128,7 @@ void CollisionObjectSW::_unregister_shapes() {
 
 	for (int i = 0; i < shapes.size(); i++) {
 
-		Shape &s = shapes[i];
+		Shape &s = shapes.write[i];
 		if (s.bpid > 0) {
 			space->get_broadphase()->remove(s.bpid);
 			s.bpid = 0;
@@ -143,7 +143,7 @@ void CollisionObjectSW::_update_shapes() {
 
 	for (int i = 0; i < shapes.size(); i++) {
 
-		Shape &s = shapes[i];
+		Shape &s = shapes.write[i];
 		if (s.bpid == 0) {
 			s.bpid = space->get_broadphase()->create(this, i);
 			space->get_broadphase()->set_static(s.bpid, _static);
@@ -170,7 +170,7 @@ void CollisionObjectSW::_update_shapes_with_motion(const Vector3 &p_motion) {
 
 	for (int i = 0; i < shapes.size(); i++) {
 
-		Shape &s = shapes[i];
+		Shape &s = shapes.write[i];
 		if (s.bpid == 0) {
 			s.bpid = space->get_broadphase()->create(this, i);
 			space->get_broadphase()->set_static(s.bpid, _static);
@@ -195,7 +195,7 @@ void CollisionObjectSW::_set_space(SpaceSW *p_space) {
 
 		for (int i = 0; i < shapes.size(); i++) {
 
-			Shape &s = shapes[i];
+			Shape &s = shapes.write[i];
 			if (s.bpid) {
 				space->get_broadphase()->remove(s.bpid);
 				s.bpid = 0;

--- a/servers/physics/collision_object_sw.h
+++ b/servers/physics/collision_object_sw.h
@@ -135,7 +135,7 @@ public:
 	_FORCE_INLINE_ void set_ray_pickable(bool p_enable) { ray_pickable = p_enable; }
 	_FORCE_INLINE_ bool is_ray_pickable() const { return ray_pickable; }
 
-	_FORCE_INLINE_ void set_shape_as_disabled(int p_idx, bool p_enable) { shapes[p_idx].disabled = p_enable; }
+	_FORCE_INLINE_ void set_shape_as_disabled(int p_idx, bool p_enable) { shapes.write[p_idx].disabled = p_enable; }
 	_FORCE_INLINE_ bool is_shape_set_as_disabled(int p_idx) const { return shapes[p_idx].disabled; }
 
 	_FORCE_INLINE_ void set_collision_layer(uint32_t p_layer) { collision_layer = p_layer; }

--- a/servers/physics/space_sw.h
+++ b/servers/physics/space_sw.h
@@ -186,7 +186,7 @@ public:
 	void set_debug_contacts(int p_amount) { contact_debug.resize(p_amount); }
 	_FORCE_INLINE_ bool is_debugging_contacts() const { return !contact_debug.empty(); }
 	_FORCE_INLINE_ void add_debug_contact(const Vector3 &p_contact) {
-		if (contact_debug_count < contact_debug.size()) contact_debug[contact_debug_count++] = p_contact;
+		if (contact_debug_count < contact_debug.size()) contact_debug.write[contact_debug_count++] = p_contact;
 	}
 	_FORCE_INLINE_ Vector<Vector3> get_debug_contacts() { return contact_debug; }
 	_FORCE_INLINE_ int get_debug_contact_count() { return contact_debug_count; }

--- a/servers/physics_2d/body_2d_sw.h
+++ b/servers/physics_2d/body_2d_sw.h
@@ -141,7 +141,7 @@ public:
 	_FORCE_INLINE_ void add_area(Area2DSW *p_area) {
 		int index = areas.find(AreaCMP(p_area));
 		if (index > -1) {
-			areas[index].refCount += 1;
+			areas.write[index].refCount += 1;
 		} else {
 			areas.ordered_insert(AreaCMP(p_area));
 		}
@@ -150,7 +150,7 @@ public:
 	_FORCE_INLINE_ void remove_area(Area2DSW *p_area) {
 		int index = areas.find(AreaCMP(p_area));
 		if (index > -1) {
-			areas[index].refCount -= 1;
+			areas.write[index].refCount -= 1;
 			if (areas[index].refCount < 1)
 				areas.remove(index);
 		}
@@ -311,7 +311,7 @@ void Body2DSW::add_contact(const Vector2 &p_local_pos, const Vector2 &p_local_no
 	if (c_max == 0)
 		return;
 
-	Contact *c = &contacts[0];
+	Contact *c = contacts.ptrw();
 
 	int idx = -1;
 

--- a/servers/physics_2d/collision_object_2d_sw.cpp
+++ b/servers/physics_2d/collision_object_2d_sw.cpp
@@ -50,7 +50,7 @@ void CollisionObject2DSW::set_shape(int p_index, Shape2DSW *p_shape) {
 
 	ERR_FAIL_INDEX(p_index, shapes.size());
 	shapes[p_index].shape->remove_owner(this);
-	shapes[p_index].shape = p_shape;
+	shapes.write[p_index].shape = p_shape;
 
 	p_shape->add_owner(this);
 	_update_shapes();
@@ -60,15 +60,15 @@ void CollisionObject2DSW::set_shape(int p_index, Shape2DSW *p_shape) {
 void CollisionObject2DSW::set_shape_metadata(int p_index, const Variant &p_metadata) {
 
 	ERR_FAIL_INDEX(p_index, shapes.size());
-	shapes[p_index].metadata = p_metadata;
+	shapes.write[p_index].metadata = p_metadata;
 }
 
 void CollisionObject2DSW::set_shape_transform(int p_index, const Transform2D &p_transform) {
 
 	ERR_FAIL_INDEX(p_index, shapes.size());
 
-	shapes[p_index].xform = p_transform;
-	shapes[p_index].xform_inv = p_transform.affine_inverse();
+	shapes.write[p_index].xform = p_transform;
+	shapes.write[p_index].xform_inv = p_transform.affine_inverse();
 	_update_shapes();
 	_shapes_changed();
 }
@@ -76,7 +76,7 @@ void CollisionObject2DSW::set_shape_transform(int p_index, const Transform2D &p_
 void CollisionObject2DSW::set_shape_as_disabled(int p_idx, bool p_disabled) {
 	ERR_FAIL_INDEX(p_idx, shapes.size());
 
-	CollisionObject2DSW::Shape &shape = shapes[p_idx];
+	CollisionObject2DSW::Shape &shape = shapes.write[p_idx];
 	if (shape.disabled == p_disabled)
 		return;
 
@@ -116,7 +116,7 @@ void CollisionObject2DSW::remove_shape(int p_index) {
 			continue;
 		//should never get here with a null owner
 		space->get_broadphase()->remove(shapes[i].bpid);
-		shapes[i].bpid = 0;
+		shapes.write[i].bpid = 0;
 	}
 	shapes[p_index].shape->remove_owner(this);
 	shapes.remove(p_index);
@@ -133,7 +133,7 @@ void CollisionObject2DSW::_set_static(bool p_static) {
 	if (!space)
 		return;
 	for (int i = 0; i < get_shape_count(); i++) {
-		Shape &s = shapes[i];
+		const Shape &s = shapes[i];
 		if (s.bpid > 0) {
 			space->get_broadphase()->set_static(s.bpid, _static);
 		}
@@ -144,7 +144,7 @@ void CollisionObject2DSW::_unregister_shapes() {
 
 	for (int i = 0; i < shapes.size(); i++) {
 
-		Shape &s = shapes[i];
+		Shape &s = shapes.write[i];
 		if (s.bpid > 0) {
 			space->get_broadphase()->remove(s.bpid);
 			s.bpid = 0;
@@ -159,7 +159,7 @@ void CollisionObject2DSW::_update_shapes() {
 
 	for (int i = 0; i < shapes.size(); i++) {
 
-		Shape &s = shapes[i];
+		Shape &s = shapes.write[i];
 
 		if (s.disabled)
 			continue;
@@ -187,7 +187,7 @@ void CollisionObject2DSW::_update_shapes_with_motion(const Vector2 &p_motion) {
 
 	for (int i = 0; i < shapes.size(); i++) {
 
-		Shape &s = shapes[i];
+		Shape &s = shapes.write[i];
 		if (s.disabled)
 			continue;
 
@@ -215,7 +215,7 @@ void CollisionObject2DSW::_set_space(Space2DSW *p_space) {
 
 		for (int i = 0; i < shapes.size(); i++) {
 
-			Shape &s = shapes[i];
+			Shape &s = shapes.write[i];
 			if (s.bpid) {
 				space->get_broadphase()->remove(s.bpid);
 				s.bpid = 0;

--- a/servers/physics_2d/collision_object_2d_sw.h
+++ b/servers/physics_2d/collision_object_2d_sw.h
@@ -144,7 +144,7 @@ public:
 
 	_FORCE_INLINE_ void set_shape_as_one_way_collision(int p_idx, bool p_one_way_collision) {
 		ERR_FAIL_INDEX(p_idx, shapes.size());
-		shapes[p_idx].one_way_collision = p_one_way_collision;
+		shapes.write[p_idx].one_way_collision = p_one_way_collision;
 	}
 	_FORCE_INLINE_ bool is_shape_set_as_one_way_collision(int p_idx) const {
 		ERR_FAIL_INDEX_V(p_idx, shapes.size(), false);

--- a/servers/physics_2d/shape_2d_sw.cpp
+++ b/servers/physics_2d/shape_2d_sw.cpp
@@ -891,8 +891,8 @@ int ConcavePolygonShape2DSW::_generate_bvh(BVH *p_bvh, int p_len, int p_depth) {
 
 	int l = _generate_bvh(p_bvh, median, p_depth + 1);
 	int r = _generate_bvh(&p_bvh[median], p_len - median, p_depth + 1);
-	bvh[node_idx].left = l;
-	bvh[node_idx].right = r;
+	bvh.write[node_idx].left = l;
+	bvh.write[node_idx].right = r;
 
 	return node_idx;
 }
@@ -953,20 +953,20 @@ void ConcavePolygonShape2DSW::set_data(const Variant &p_data) {
 		for (Map<Point2, int>::Element *E = pointmap.front(); E; E = E->next()) {
 
 			aabb.expand_to(E->key());
-			points[E->get()] = E->key();
+			points.write[E->get()] = E->key();
 		}
 
 		Vector<BVH> main_vbh;
 		main_vbh.resize(segments.size());
 		for (int i = 0; i < main_vbh.size(); i++) {
 
-			main_vbh[i].aabb.position = points[segments[i].points[0]];
-			main_vbh[i].aabb.expand_to(points[segments[i].points[1]]);
-			main_vbh[i].left = -1;
-			main_vbh[i].right = i;
+			main_vbh.write[i].aabb.position = points[segments[i].points[0]];
+			main_vbh.write[i].aabb.expand_to(points[segments[i].points[1]]);
+			main_vbh.write[i].left = -1;
+			main_vbh.write[i].right = i;
 		}
 
-		_generate_bvh(&main_vbh[0], main_vbh.size(), 1);
+		_generate_bvh(main_vbh.ptrw(), main_vbh.size(), 1);
 
 	} else {
 		//dictionary with arrays

--- a/servers/physics_2d/space_2d_sw.h
+++ b/servers/physics_2d/space_2d_sw.h
@@ -188,7 +188,7 @@ public:
 	void set_debug_contacts(int p_amount) { contact_debug.resize(p_amount); }
 	_FORCE_INLINE_ bool is_debugging_contacts() const { return !contact_debug.empty(); }
 	_FORCE_INLINE_ void add_debug_contact(const Vector2 &p_contact) {
-		if (contact_debug_count < contact_debug.size()) contact_debug[contact_debug_count++] = p_contact;
+		if (contact_debug_count < contact_debug.size()) contact_debug.write[contact_debug_count++] = p_contact;
 	}
 	_FORCE_INLINE_ Vector<Vector2> get_debug_contacts() { return contact_debug; }
 	_FORCE_INLINE_ int get_debug_contact_count() { return contact_debug_count; }

--- a/servers/physics_2d_server.cpp
+++ b/servers/physics_2d_server.cpp
@@ -198,7 +198,7 @@ Vector<RID> Physics2DShapeQueryParameters::get_exclude() const {
 	ret.resize(exclude.size());
 	int idx = 0;
 	for (Set<RID>::Element *E = exclude.front(); E; E = E->next()) {
-		ret[idx] = E->get();
+		ret.write[idx] = E->get();
 	}
 	return ret;
 }

--- a/servers/physics_server.cpp
+++ b/servers/physics_server.cpp
@@ -192,7 +192,7 @@ Vector<RID> PhysicsShapeQueryParameters::get_exclude() const {
 	ret.resize(exclude.size());
 	int idx = 0;
 	for (Set<RID>::Element *E = exclude.front(); E; E = E->next()) {
-		ret[idx] = E->get();
+		ret.write[idx] = E->get();
 	}
 	return ret;
 }

--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -2471,7 +2471,7 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 						//add to current function as dependency
 						for (int j = 0; j < shader->functions.size(); j++) {
 							if (shader->functions[j].name == current_function) {
-								shader->functions[j].uses_function.insert(name);
+								shader->functions.write[j].uses_function.insert(name);
 								break;
 							}
 						}
@@ -3021,8 +3021,8 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 				}
 				op->arguments.push_back(expression[i + 1].node);
 
-				expression[i].is_op = false;
-				expression[i].node = op;
+				expression.write[i].is_op = false;
+				expression.write[i].node = op;
 
 				if (!_validate_operator(op, &op->return_cache)) {
 
@@ -3056,8 +3056,8 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 			op->arguments.push_back(expression[next_op + 1].node);
 			op->arguments.push_back(expression[next_op + 3].node);
 
-			expression[next_op - 1].is_op = false;
-			expression[next_op - 1].node = op;
+			expression.write[next_op - 1].is_op = false;
+			expression.write[next_op - 1].node = op;
 			if (!_validate_operator(op, &op->return_cache)) {
 
 				String at;
@@ -3107,7 +3107,7 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 
 			op->arguments.push_back(expression[next_op - 1].node); //expression goes as left
 			op->arguments.push_back(expression[next_op + 1].node); //next expression goes as right
-			expression[next_op - 1].node = op;
+			expression.write[next_op - 1].node = op;
 
 			//replace all 3 nodes by this operator and make it an expression
 
@@ -3149,7 +3149,7 @@ ShaderLanguage::Node *ShaderLanguage::_reduce_expression(BlockNode *p_block, Sha
 
 		for (int i = 1; i < op->arguments.size(); i++) {
 
-			op->arguments[i] = _reduce_expression(p_block, op->arguments[i]);
+			op->arguments.write[i] = _reduce_expression(p_block, op->arguments[i]);
 			if (op->arguments[i]->type == Node::TYPE_CONSTANT) {
 				ConstantNode *cn = static_cast<ConstantNode *>(op->arguments[i]);
 
@@ -3189,7 +3189,7 @@ ShaderLanguage::Node *ShaderLanguage::_reduce_expression(BlockNode *p_block, Sha
 		return cn;
 	} else if (op->op == OP_NEGATE) {
 
-		op->arguments[0] = _reduce_expression(p_block, op->arguments[0]);
+		op->arguments.write[0] = _reduce_expression(p_block, op->arguments[0]);
 		if (op->arguments[0]->type == Node::TYPE_CONSTANT) {
 
 			ConstantNode *cn = static_cast<ConstantNode *>(op->arguments[0]);

--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -220,7 +220,7 @@ void VisualServerCanvas::render_canvas(Canvas *p_canvas, const Transform2D &p_tr
 
 		for (int i = 0; i < l; i++) {
 
-			Canvas::ChildItem &ci = p_canvas->child_items[i];
+			const Canvas::ChildItem &ci = p_canvas->child_items[i];
 			_render_canvas_item_tree(ci.item, p_transform, p_clip_rect, p_canvas->modulate, p_lights);
 
 			//mirroring (useful for scrolling backgrounds)
@@ -263,7 +263,7 @@ void VisualServerCanvas::canvas_set_item_mirroring(RID p_canvas, RID p_item, con
 
 	int idx = canvas->find_item(canvas_item);
 	ERR_FAIL_COND(idx == -1);
-	canvas->child_items[idx].mirror = p_mirroring;
+	canvas->child_items.write[idx].mirror = p_mirroring;
 }
 void VisualServerCanvas::canvas_set_modulate(RID p_canvas, const Color &p_color) {
 
@@ -468,21 +468,21 @@ void VisualServerCanvas::canvas_item_add_polyline(RID p_item, const Vector<Point
 			Vector2 tangent = ((t + prev_t).normalized()) * p_width * 0.5;
 
 			if (p_antialiased) {
-				pline->lines[i] = p_points[i] + tangent;
-				pline->lines[p_points.size() * 2 - i - 1] = p_points[i] - tangent;
+				pline->lines.write[i] = p_points[i] + tangent;
+				pline->lines.write[p_points.size() * 2 - i - 1] = p_points[i] - tangent;
 				if (pline->line_colors.size() > 1) {
-					pline->line_colors[i] = p_colors[i];
-					pline->line_colors[p_points.size() * 2 - i - 1] = p_colors[i];
+					pline->line_colors.write[i] = p_colors[i];
+					pline->line_colors.write[p_points.size() * 2 - i - 1] = p_colors[i];
 				}
 			}
 
-			pline->triangles[i * 2 + 0] = p_points[i] + tangent;
-			pline->triangles[i * 2 + 1] = p_points[i] - tangent;
+			pline->triangles.write[i * 2 + 0] = p_points[i] + tangent;
+			pline->triangles.write[i * 2 + 1] = p_points[i] - tangent;
 
 			if (pline->triangle_colors.size() > 1) {
 
-				pline->triangle_colors[i * 2 + 0] = p_colors[i];
-				pline->triangle_colors[i * 2 + 1] = p_colors[i];
+				pline->triangle_colors.write[i * 2 + 0] = p_colors[i];
+				pline->triangle_colors.write[i * 2 + 1] = p_colors[i];
 			}
 
 			prev_t = t;

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -589,7 +589,7 @@ void VisualServerScene::instance_set_blend_shape_weight(RID p_instance, int p_sh
 	}
 
 	ERR_FAIL_INDEX(p_shape, instance->blend_values.size());
-	instance->blend_values[p_shape] = p_weight;
+	instance->blend_values.write[p_shape] = p_weight;
 }
 
 void VisualServerScene::instance_set_surface_material(RID p_instance, int p_surface, RID p_material) {
@@ -606,7 +606,7 @@ void VisualServerScene::instance_set_surface_material(RID p_instance, int p_surf
 	if (instance->materials[p_surface].is_valid()) {
 		VSG::storage->material_remove_instance_owner(instance->materials[p_surface], instance);
 	}
-	instance->materials[p_surface] = p_material;
+	instance->materials.write[p_surface] = p_material;
 	instance->base_material_changed();
 
 	if (instance->materials[p_surface].is_valid()) {
@@ -1253,7 +1253,7 @@ void VisualServerScene::_update_instance_lightmap_captures(Instance *p_instance)
 
 			Vector3 dir = to_cell_xform.basis.xform(cone_traces[i]).normalized();
 			Color capture = _light_capture_voxel_cone_trace(octree_r.ptr(), pos, dir, cone_aperture, cell_subdiv);
-			p_instance->lightmap_capture_data[i] += capture;
+			p_instance->lightmap_capture_data.write[i] += capture;
 		}
 	}
 }
@@ -1464,14 +1464,14 @@ void VisualServerScene::_light_instance_update_shadow(Instance *p_instance, cons
 				light_frustum_planes.resize(6);
 
 				//right/left
-				light_frustum_planes[0] = Plane(x_vec, x_max);
-				light_frustum_planes[1] = Plane(-x_vec, -x_min);
+				light_frustum_planes.write[0] = Plane(x_vec, x_max);
+				light_frustum_planes.write[1] = Plane(-x_vec, -x_min);
 				//top/bottom
-				light_frustum_planes[2] = Plane(y_vec, y_max);
-				light_frustum_planes[3] = Plane(-y_vec, -y_min);
+				light_frustum_planes.write[2] = Plane(y_vec, y_max);
+				light_frustum_planes.write[3] = Plane(-y_vec, -y_min);
 				//near/far
-				light_frustum_planes[4] = Plane(z_vec, z_max + 1e6);
-				light_frustum_planes[5] = Plane(-z_vec, -z_min); // z_min is ok, since casters further than far-light plane are not needed
+				light_frustum_planes.write[4] = Plane(z_vec, z_max + 1e6);
+				light_frustum_planes.write[5] = Plane(-z_vec, -z_min); // z_min is ok, since casters further than far-light plane are not needed
 
 				int cull_count = p_scenario->octree.cull_convex(light_frustum_planes, instance_shadow_cull_result, MAX_INSTANCE_CULL, VS::INSTANCE_GEOMETRY_MASK);
 
@@ -1532,11 +1532,11 @@ void VisualServerScene::_light_instance_update_shadow(Instance *p_instance, cons
 						float z = i == 0 ? -1 : 1;
 						Vector<Plane> planes;
 						planes.resize(5);
-						planes[0] = light_transform.xform(Plane(Vector3(0, 0, z), radius));
-						planes[1] = light_transform.xform(Plane(Vector3(1, 0, z).normalized(), radius));
-						planes[2] = light_transform.xform(Plane(Vector3(-1, 0, z).normalized(), radius));
-						planes[3] = light_transform.xform(Plane(Vector3(0, 1, z).normalized(), radius));
-						planes[4] = light_transform.xform(Plane(Vector3(0, -1, z).normalized(), radius));
+						planes.write[0] = light_transform.xform(Plane(Vector3(0, 0, z), radius));
+						planes.write[1] = light_transform.xform(Plane(Vector3(1, 0, z).normalized(), radius));
+						planes.write[2] = light_transform.xform(Plane(Vector3(-1, 0, z).normalized(), radius));
+						planes.write[3] = light_transform.xform(Plane(Vector3(0, 1, z).normalized(), radius));
+						planes.write[4] = light_transform.xform(Plane(Vector3(0, -1, z).normalized(), radius));
 
 						int cull_count = p_scenario->octree.cull_convex(planes, instance_shadow_cull_result, MAX_INSTANCE_CULL, VS::INSTANCE_GEOMETRY_MASK);
 						Plane near_plane(light_transform.origin, light_transform.basis.get_axis(2) * z);
@@ -1898,7 +1898,7 @@ void VisualServerScene::_prepare_scene(const Transform p_cam_transform, const Ca
 
 					InstanceLightData *light = static_cast<InstanceLightData *>(E->get()->base_data);
 
-					ins->light_instances[l++] = light->instance;
+					ins->light_instances.write[l++] = light->instance;
 				}
 
 				geom->lighting_dirty = false;
@@ -1913,7 +1913,7 @@ void VisualServerScene::_prepare_scene(const Transform p_cam_transform, const Ca
 
 					InstanceReflectionProbeData *reflection_probe = static_cast<InstanceReflectionProbeData *>(E->get()->base_data);
 
-					ins->reflection_probe_instances[l++] = reflection_probe->instance;
+					ins->reflection_probe_instances.write[l++] = reflection_probe->instance;
 				}
 
 				geom->reflection_dirty = false;
@@ -1928,7 +1928,7 @@ void VisualServerScene::_prepare_scene(const Transform p_cam_transform, const Ca
 
 					InstanceGIProbeData *gi_probe = static_cast<InstanceGIProbeData *>(E->get()->base_data);
 
-					ins->gi_probe_instances[l++] = gi_probe->probe_instance;
+					ins->gi_probe_instances.write[l++] = gi_probe->probe_instance;
 				}
 
 				geom->gi_probes_dirty = false;
@@ -2372,7 +2372,7 @@ void VisualServerScene::_setup_gi_probe(Instance *p_instance) {
 
 			uint32_t key = blockz * blockw * blockh + blocky * blockw + blockx;
 
-			Map<uint32_t, InstanceGIProbeData::CompBlockS3TC> &cmap = comp_blocks[mipmap];
+			Map<uint32_t, InstanceGIProbeData::CompBlockS3TC> &cmap = comp_blocks.write[mipmap];
 
 			if (!cmap.has(key)) {
 
@@ -2392,8 +2392,8 @@ void VisualServerScene::_setup_gi_probe(Instance *p_instance) {
 
 		for (int i = 0; i < mipmap_count; i++) {
 			print_line("S3TC level: " + itos(i) + " blocks: " + itos(comp_blocks[i].size()));
-			probe->dynamic.mipmaps_s3tc[i].resize(comp_blocks[i].size());
-			PoolVector<InstanceGIProbeData::CompBlockS3TC>::Write w = probe->dynamic.mipmaps_s3tc[i].write();
+			probe->dynamic.mipmaps_s3tc.write[i].resize(comp_blocks[i].size());
+			PoolVector<InstanceGIProbeData::CompBlockS3TC>::Write w = probe->dynamic.mipmaps_s3tc.write[i].write();
 			int block_idx = 0;
 
 			for (Map<uint32_t, InstanceGIProbeData::CompBlockS3TC>::Element *E = comp_blocks[i].front(); E; E = E->next()) {
@@ -2861,7 +2861,7 @@ void VisualServerScene::_bake_gi_probe(Instance *p_gi_probe) {
 			int level_cell_count = probe_data->dynamic.level_cell_lists[i].size();
 			const uint32_t *level_cells = probe_data->dynamic.level_cell_lists[i].ptr();
 
-			PoolVector<uint8_t>::Write lw = probe_data->dynamic.mipmaps_3d[stage].write();
+			PoolVector<uint8_t>::Write lw = probe_data->dynamic.mipmaps_3d.write[stage].write();
 			uint8_t *mipmapw = lw.ptr();
 
 			uint32_t sizes[3] = { header->width >> stage, header->height >> stage, header->depth >> stage };
@@ -2890,7 +2890,7 @@ void VisualServerScene::_bake_gi_probe(Instance *p_gi_probe) {
 
 		for (int mmi = 0; mmi < mipmap_count; mmi++) {
 
-			PoolVector<uint8_t>::Write mmw = probe_data->dynamic.mipmaps_3d[mmi].write();
+			PoolVector<uint8_t>::Write mmw = probe_data->dynamic.mipmaps_3d.write[mmi].write();
 			int block_count = probe_data->dynamic.mipmaps_s3tc[mmi].size();
 			PoolVector<InstanceGIProbeData::CompBlockS3TC>::Read mmr = probe_data->dynamic.mipmaps_s3tc[mmi].read();
 
@@ -3223,7 +3223,7 @@ void VisualServerScene::_update_dirty_instance(Instance *p_instance) {
 			if (new_blend_shape_count != p_instance->blend_values.size()) {
 				p_instance->blend_values.resize(new_blend_shape_count);
 				for (int i = 0; i < new_blend_shape_count; i++) {
-					p_instance->blend_values[i] = 0;
+					p_instance->blend_values.write[i] = 0;
 				}
 			}
 		}

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -744,7 +744,7 @@ Error VisualServer::_surface_set_data(Array p_arrays, uint32_t p_format, uint32_
 
 		if (first) {
 			for (int i = 0; i < total_bones; i++) {
-				r_bone_aabb[i].size = Vector3(-1, -1, -1); //negative means unused
+				r_bone_aabb.write[i].size = Vector3(-1, -1, -1); //negative means unused
 			}
 		}
 


### PR DESCRIPTION
This PR makes operator[] on Vector const and adds a write proxy to it. From now on writes to Vectors need to happen through the .write proxy. So for instance:

```c++
Vector<int> vec;
vec.push_back(10);
std::cout << vec[0] << std::endl;
vec.write[0] = 20;
```
Failing to use the .write proxy will cause a compilation error.

In addition COWable datatypes can now embed a CowData pointer to their data. This means that String, CharString, and VMap no longer use or derive from Vector. 

`_ALWAYS_INLINE_` and `_FORCE_INLINE_` are now equivalent for debug and non-debug builds. This is a lot faster for Vector in the editor and while running tests. The reason why this difference used to exist is because force-inlined methods used to give a bad debugging experience. After extensive testing with modern compilers this is no longer the case.

Still TODO:
* Add String and CharString proxies so that cow can be reduced there also (These will not get a .write member instead we will use proxies that 'decay' into the appropriate types there)
* Find other datatypes that (ab)use Vector as their backend storage and move them to CowData also.

Given how much files this touches I'd prefer to do this in a separate PR later this week.