### PR TITLE
fix issue with bezier tracks using incorrect duration for interpolating values

### DIFF
--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -2329,13 +2329,14 @@ float Animation::bezier_track_interpolate(int p_track, float p_time) const {
 
 	int iterations = 10;
 
-	float low = 0;
-	float high = bt->values[idx + 1].time - bt->values[idx].time;
+	float duration = bt->values[idx + 1].time - bt->values[idx].time; // time duration between our two keyframes
+	float low = 0; // 0% of the current animation segment
+	float high = 1; // 100% of the current animation segment
 	float middle = 0;
 
 	Vector2 start(0, bt->values[idx].value.value);
 	Vector2 start_out = start + bt->values[idx].value.out_handle;
-	Vector2 end(high, bt->values[idx + 1].value.value);
+	Vector2 end(duration, bt->values[idx + 1].value.value);
 	Vector2 end_in = end + bt->values[idx + 1].value.in_handle;
 
 	//narrow high and low as much as possible
@@ -2355,7 +2356,6 @@ float Animation::bezier_track_interpolate(int p_track, float p_time) const {
 	//interpolate the result:
 	Vector2 low_pos = _bezier_interp(low, start, start_out, end_in, end);
 	Vector2 high_pos = _bezier_interp(high, start, start_out, end_in, end);
-
 	float c = (t - low_pos.x) / (high_pos.x - low_pos.x);
 
 	return low_pos.linear_interpolate(high_pos, c).y;


### PR DESCRIPTION
This is to fix the problem with bezier tracks in animation player as outlined in issue #19777 

*Bugsquad edit:* Fixes #19777