### PR TITLE
Shader language - Add optional float typings

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6384,7 +6384,7 @@ Map<int, TextEdit::HighlighterInfo> TextEdit::_get_line_syntax_highlighting(int 
 		}
 
 		// check for dot or underscore or 'x' for hex notation in floating point number
-		if ((str[j] == '.' || str[j] == 'x' || str[j] == '_') && !in_word && prev_is_number && !is_number) {
+		if ((str[j] == '.' || str[j] == 'x' || str[j] == '_' || str[j] == 'f') && !in_word && prev_is_number && !is_number) {
 			is_number = true;
 			is_symbol = false;
 			is_char = false;


### PR DESCRIPTION
- Added optional typing for floats, eg:

`1f `-> `1.0`
`1.f` -> `1.0`
`1.99f `-> `1.99`
`1.` -> `1.0`

- Small hex/float/integer parsing refactoring
- Potential bug fix on hex (but actually hex cannot be used atm)

Closes #20103