### PR TITLE
fix scrollbar icons with atlas texture.

### DIFF
--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -257,9 +257,7 @@ void ScrollBar::_notification(int p_what) {
 
 		Point2 ofs;
 
-		VisualServer *vs = VisualServer::get_singleton();
-
-		vs->canvas_item_add_texture_rect(ci, Rect2(Point2(), decr->get_size()), decr->get_rid());
+		decr->draw(ci, Point2());
 
 		if (orientation == HORIZONTAL)
 			ofs.x += decr->get_width();
@@ -280,7 +278,7 @@ void ScrollBar::_notification(int p_what) {
 		else
 			ofs.height += area.height;
 
-		vs->canvas_item_add_texture_rect(ci, Rect2(ofs, decr->get_size()), incr->get_rid());
+		incr->draw(ci, ofs);
 		Rect2 grabber_rect;
 
 		if (orientation == HORIZONTAL) {


### PR DESCRIPTION
Draw scrollbar icons through their textures, rather than calling
directly to the server. Allows atlas textures to manipulate the source
rect as required.

fixes #20145