### PR TITLE
Fixed shader parsing error log

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -2545,7 +2545,9 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 			TkPos pos = _get_tkpos();
 			tk = _get_token();
 
-			if (tk.type == TK_PERIOD) {
+			if (tk.type == TK_CURSOR) {
+				//do nothing
+			} else if (tk.type == TK_PERIOD) {
 
 				StringName identifier;
 				if (_get_completable_identifier(p_block, COMPLETION_INDEX, identifier)) {
@@ -4130,8 +4132,8 @@ Error ShaderLanguage::complete(const String &p_code, const Map<StringName, Funct
 	switch (completion_type) {
 
 		case COMPLETION_NONE: {
-			//do none
-			return ERR_PARSE_ERROR;
+			//do nothing
+			return OK;
 		} break;
 		case COMPLETION_RENDER_MODE: {
 			for (const Set<String>::Element *E = p_render_modes.front(); E; E = E->next()) {


### PR DESCRIPTION
Fixed error due to bad cursor handling when parsing shader code
Fixed completion error log thrown on "no auto-completion found" for typings with no completion.

![capture](https://user-images.githubusercontent.com/31958866/42727116-bdeab3d2-87a0-11e8-8268-1b6e4bc061e8.PNG)
