### PR TITLE
Attempt to correct Camera2D drag margin behavior (#20142)

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -84,6 +84,7 @@ Transform2D Camera2D::get_camera_transform() {
 	Size2 screen_size = viewport->get_visible_rect().size;
 
 	Point2 new_camera_pos = get_global_transform().get_origin();
+	Point2 parent_pos = new_camera_pos - (get_transform().get_origin() + offset);
 	Point2 ret_camera_pos;
 
 	if (!first) {
@@ -91,8 +92,8 @@ Transform2D Camera2D::get_camera_transform() {
 		if (anchor_mode == ANCHOR_MODE_DRAG_CENTER) {
 
 			if (h_drag_enabled && !Engine::get_singleton()->is_editor_hint()) {
-				camera_pos.x = MIN(camera_pos.x, (new_camera_pos.x + screen_size.x * 0.5 * zoom.x * drag_margin[MARGIN_LEFT]));
-				camera_pos.x = MAX(camera_pos.x, (new_camera_pos.x - screen_size.x * 0.5 * zoom.x * drag_margin[MARGIN_RIGHT]));
+				camera_pos.x = MIN(camera_pos.x, (parent_pos.x + screen_size.x * 0.5 * zoom.x * drag_margin[MARGIN_LEFT]));
+				camera_pos.x = MAX(camera_pos.x, (parent_pos.x - screen_size.x * 0.5 * zoom.x * drag_margin[MARGIN_RIGHT]));
 			} else {
 
 				if (h_ofs < 0) {
@@ -104,8 +105,8 @@ Transform2D Camera2D::get_camera_transform() {
 
 			if (v_drag_enabled && !Engine::get_singleton()->is_editor_hint()) {
 
-				camera_pos.y = MIN(camera_pos.y, (new_camera_pos.y + screen_size.y * 0.5 * zoom.y * drag_margin[MARGIN_TOP]));
-				camera_pos.y = MAX(camera_pos.y, (new_camera_pos.y - screen_size.y * 0.5 * zoom.y * drag_margin[MARGIN_BOTTOM]));
+				camera_pos.y = MIN(camera_pos.y, (parent_pos.y + screen_size.y * 0.5 * zoom.y * drag_margin[MARGIN_TOP]));
+				camera_pos.y = MAX(camera_pos.y, (parent_pos.y - screen_size.y * 0.5 * zoom.y * drag_margin[MARGIN_BOTTOM]));
 
 			} else {
 


### PR DESCRIPTION
Attempt to correct drag margin behavior when the Camera2D is offset. Drag margin now respects the offset of the camera relative to the parent. Refer to #20142.

Note that I am very new to Godot so it's possible this change could cause issues with other normal camera behavior. I ran some basic tests and everything seemed okay.