### PR TITLE
Fix display scale bug in visual shaders

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -157,7 +157,7 @@ void VisualShaderEditor::_update_graph() {
 			vsnode->connect("changed", this, "_node_changed", varray(vsnode->get_instance_id()), CONNECT_DEFERRED);
 		}*/
 
-		node->set_offset(position * EDSCALE);
+		node->set_offset(position);
 
 		node->set_title(vsnode->get_caption());
 		node->set_name(itos(nodes[n_i]));


### PR DESCRIPTION
I found that visual shader editor is changed positions of many graph node elements when one of them is removed or added, its happens only when display scale is different than 100%. I removed EDSCALE modifier and now its work correctly.