### PR TITLE
A fix for the export templates installation error...

### DIFF
--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -228,7 +228,10 @@ void ExportTemplateManager::_install_from_file(const String &p_file, bool p_use_
 			version = data_str;
 		}
 
-		fc++;
+		if (file.get_file().size() != 0) {
+			fc++;
+		}
+
 		ret = unzGoToNextFile(pkg);
 	}
 
@@ -267,6 +270,11 @@ void ExportTemplateManager::_install_from_file(const String &p_file, bool p_use_
 		unzGetCurrentFileInfo(pkg, &info, fname, 16384, NULL, 0, NULL, 0);
 
 		String file = String(fname).get_file();
+
+		if (file.size() == 0) {
+			ret = unzGoToNextFile(pkg);
+			continue;
+		}
 
 		Vector<uint8_t> data;
 		data.resize(info.uncompressed_size);


### PR DESCRIPTION
Dear Godot Engine developers,

I have found a bug and made a fix for it. This bug has been reported by various people (e.g. #19389). Master branch, it seems, still has it. Thus, I would like to contribute my own solution. I do not know how detailed pull request descriptions are expected to be, so I provided all the major details of and reasoning behind my solution.

Depending on the version and platform some errors appeared in the console and sometimes as a pop up window in course of export templates installation. I have investigated this error messages and they led me to '_install_from_file' method of 'ExportTemplateManager'. Apparently, when it loops over files it does not skip directories inside the archives being processed. As a result it attempts to create files with empty names. Thus, we get error messages.

I have looked up minizip library and found an example 'miniunz.c'. In this file in line range 281-288 they process directories. After removing everything up to the last forward or back slash they check if the remaining string is of zero length or not. In the former case they assume that this is a folder, while in the latter that this is a file. Then they process them accordingly. I adapted their way of determining if archive entry is a file or a folder.

I have made two changes to 'editor/export_template_manager.cpp'. Their goal is to skip folders and to count files only (for installation progress window). Lines 231-234: increase counter only if file is encountered (i.e. length of the file name is not 0) and do not increase counter if folder (directory) is encountered (i.e. length of the file name after the last '\\' or '/' is 0). Lines 274-278: if folder is encountered do not process it (i.e. do not attempt to create a file with empty name which will lead to an error) and go directly to the next file without incrementing 'fc'.

After these two fixes are applied the error messages do not appear any more, installation progress is displayed correctly and export templates installation goes smoothly.

With best regards,

Danial