### PR TITLE
Fix ERR_FAIL_COND in generate_normals

### DIFF
--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -863,8 +863,6 @@ void SurfaceTool::generate_tangents() {
 
 void SurfaceTool::generate_normals(bool p_flip) {
 
-	ERR_FAIL_COND(primitive != Mesh::PRIMITIVE_TRIANGLES);
-
 	bool was_indexed = index_array.size();
 
 	deindex();


### PR DESCRIPTION
I found that generate_normal correctly worked with triangle strips and no need to spam error message in that case..

Update - after some thinking I removed it completly cuz user may want generate normals in any case, and they are probably valid(its the same vertex positions after all)