### PR TITLE
Inspector: Add bit/value info to layer tooltip

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -617,8 +617,10 @@ void EditorPropertyLayers::setup(LayerType p_layer_type) {
 		}
 
 		if (name == "") {
-			name = "Layer " + itos(i + 1);
+			name = TTR("Layer") + " " + itos(i + 1);
 		}
+
+		name += "\n" + vformat(TTR("Bit %d, value %d"), i, 1 << i);
 
 		names.push_back(name);
 	}


### PR DESCRIPTION
Fixes #20213.

Looks like this:
![screenshot_20180717_143421](https://user-images.githubusercontent.com/4701338/42817467-7f591944-89ce-11e8-9106-aaaa9d54b41f.png)