### PR TITLE
Fix Label autowrap clips text

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -75,7 +75,7 @@ void Label::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_DRAW) {
 
-		if (clip || autowrap) {
+		if (clip) {
 			VisualServer::get_singleton()->canvas_item_set_clip(get_canvas_item(), true);
 		}
 


### PR DESCRIPTION
This PR prevent to clip text when using only `Autowrap`
![screenshot_20180718_021839](https://user-images.githubusercontent.com/8281454/42834129-2b15345e-8a31-11e8-9660-89b79892bf06.png)
but it shows over than its size when can't wrap.

if really want, `Clip text` can be used together.
![screenshot_20180718_021854](https://user-images.githubusercontent.com/8281454/42834130-2b441c60-8a31-11e8-93b0-b03d27b04f52.png)

Fix #20226