### PR TITLE
Add script class hierarchies & add-script button permanence/auto-derivation

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -853,6 +853,41 @@ void EditorData::get_plugin_window_layout(Ref<ConfigFile> p_layout) {
 	}
 }
 
+bool EditorData::script_class_is_parent(const String &p_class, const String &p_inherits) {
+	if (!ScriptServer::is_global_class(p_class))
+		return false;
+	String base = script_class_get_base(p_class);
+	while (p_inherits != base) {
+		if (ClassDB::class_exists(base)) {
+			return ClassDB::is_parent_class(base, p_inherits);
+		} else if (ScriptServer::is_global_class(base)) {
+			base = script_class_get_base(base);
+		} else {
+			return false;
+		}
+	}
+	return true;
+}
+
+StringName EditorData::script_class_get_base(const String &p_class) {
+
+	if (!ScriptServer::is_global_class(p_class))
+		return StringName();
+
+	String path = ScriptServer::get_global_class_path(p_class);
+
+	Ref<Script> script = ResourceLoader::load(path, "Script");
+	if (script.is_null())
+		return StringName();
+
+	Ref<Script> base_script = script->get_base_script();
+	if (base_script.is_null()) {
+		return ScriptServer::get_global_class_base(p_class);
+	}
+
+	return script->get_language()->get_global_class_name(base_script->get_path());
+}
+
 EditorData::EditorData() {
 
 	current_edited_scene = -1;

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -211,6 +211,9 @@ public:
 	void notify_edited_scene_changed();
 	void notify_resource_saved(const Ref<Resource> &p_resource);
 
+	bool script_class_is_parent(const String &p_class, const String &p_inherits);
+	StringName script_class_get_base(const String &p_class);
+
 	EditorData();
 };
 


### PR DESCRIPTION
Previously, if you attempted to create a script class that extends another script, it wouldn't show up in the CreateDialog. I have altered the backend to fix this.

This PR allows you to have hierarchies of script classes that show up in the CreateDialog. It also modifies the scene tree dock so that the Add Script button is the only one that exists (no remove button - it's just hidden) and the add script button will auto-populate the Inherits field of the ScriptCreateDialog if the selected node already has a script. Finally, I made it so that script classes that are part of an editor plugin will be added/removed from the CreateDialog when their respective EditorPlugin is toggled active/inactive.

In the example below, "new_script.gd" is in a plugin I created, and you can see the effect on the Derived class in my res:// folder which derives it whenever you toggle the plugin.

Plugin Active:
![create_dialog1](https://user-images.githubusercontent.com/16217563/42847822-e0e06ec4-89e2-11e8-9711-5ad5e80ea27a.png)

Plugin Inactive:
![create_dialog2](https://user-images.githubusercontent.com/16217563/42847837-edd8ed7c-89e2-11e8-9234-d70fbf8a6068.png)
