### PR TITLE
Fixed inspecting objects inside arrays and dictionaries in debugger

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -294,6 +294,8 @@ class EditorInspector : public ScrollContainer {
 
 	void _vscroll_changed(double);
 
+	void _handle_prop_signal(const String &p_signal_name, const Array &p_params);
+
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -249,6 +249,8 @@ class EditorPropertyObjectID : public EditorProperty {
 	GDCLASS(EditorPropertyObjectID, EditorProperty)
 	Button *edit;
 	String base_type;
+	bool is_encoded;
+	ObjectID _get_id();
 	void _edit_pressed();
 
 protected:
@@ -256,7 +258,7 @@ protected:
 
 public:
 	virtual void update_property();
-	void setup(const String &p_base_type);
+	void setup(const String &p_base_type, const bool p_encoded);
 	EditorPropertyObjectID();
 };
 
@@ -553,6 +555,11 @@ public:
 ///
 class EditorInspectorDefaultPlugin : public EditorInspectorPlugin {
 	GDCLASS(EditorInspectorDefaultPlugin, EditorInspectorPlugin)
+
+	void _prop_signal(const String &p_signal_name, const Array &p_params);
+
+protected:
+	static void _bind_methods();
 
 public:
 	virtual bool can_handle(Object *p_object);

--- a/editor/editor_properties_array_dict.h
+++ b/editor/editor_properties_array_dict.h
@@ -70,6 +70,8 @@ class EditorPropertyArray : public EditorProperty {
 	void _property_changed(const String &p_prop, Variant p_value);
 	void _change_type(Object *p_button, int p_index);
 	void _change_type_menu(int p_index);
+	void _prop_signal(const Variant &p_arg0, const Variant &p_arg1, const Variant &p_arg2, const Variant &p_arg3);
+	void _relay_prop_signal(const String &p_signal_name, const Array &p_params);
 
 protected:
 	static void _bind_methods();
@@ -102,6 +104,8 @@ class EditorPropertyDictionary : public EditorProperty {
 	void _property_changed(const String &p_prop, Variant p_value);
 	void _change_type(Object *p_button, int p_index);
 	void _change_type_menu(int p_index);
+	void _prop_signal(const Variant &p_arg0, const Variant &p_arg1, const Variant &p_arg2, const Variant &p_arg3);
+	void _relay_prop_signal(const String &p_signal_name, const Array &p_params);
 
 	void _add_key_value();
 


### PR DESCRIPTION
Fixes #20225, updated version of #8644
Allows accessing all the objects inside array, dicitonaries, even ones multiple levels deep, when debugging.
