### PR TITLE
Fix crash when deallocating named colors map

### DIFF
--- a/core/color.cpp
+++ b/core/color.cpp
@@ -344,6 +344,10 @@ Color Color::named(const String &p_name) {
 	}
 }
 
+void Color::cleanup() {
+	_named_colors.clear();
+}
+
 String _to_hex(float p_val) {
 
 	int v = p_val * 255;

--- a/core/color.h
+++ b/core/color.h
@@ -135,6 +135,10 @@ struct Color {
 		b = p_b;
 		a = p_a;
 	}
+
+private:
+	friend void unregister_core_types();
+	static void cleanup();
 };
 
 bool Color::operator<(const Color &p_color) const {

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -32,6 +32,7 @@
 #include "bind/core_bind.h"
 #include "compressed_translation.h"
 #include "core/io/xml_parser.h"
+#include "color.h"
 #include "core_string_names.h"
 #include "func_ref.h"
 #include "geometry.h"
@@ -199,6 +200,7 @@ void unregister_core_types() {
 
 	unregister_variant_methods();
 
+	Color::cleanup();
 	ObjectTypeDB::cleanup();
 	ResourceCache::clear();
 	CoreStringNames::free();


### PR DESCRIPTION
Fixes #18216.
Not sure why it doesn't happen on 3.0, but it can be cherrypicked there as well.

The code is a bit of a hack, unfortunately.The code is a bit of a hack, unfortunately.