### PR TITLE
fix nameclash with MSVC

### DIFF
--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -97,6 +97,7 @@ T *_nullptr() {
 #undef CLAMP // override standard definition
 #undef Error
 #undef OK
+#undef CONNECT_DEFERRED // override from Windows SDK, clashes with Object enum
 #endif
 
 #include "int_types.h"


### PR DESCRIPTION
When trying to compile the gles2 branch on my fork, people who use MSVC reported erros because the `CONNECT_DEFERRED` symbol is part of the Windows SDK, so the enum definition in `Object` causes problems.