### PR TITLE
Add argument to set_input_as_handled

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -372,9 +372,9 @@ void SceneTree::set_group(const StringName &p_group, const String &p_name, const
 	set_group_flags(0, p_group, p_name, p_value);
 }
 
-void SceneTree::set_input_as_handled() {
+void SceneTree::set_input_as_handled(bool p_handled) {
 
-	input_handled = true;
+	input_handled = p_handled;
 }
 
 void SceneTree::input_text(const String &p_text) {
@@ -1770,7 +1770,7 @@ void SceneTree::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_pause", "enable"), &SceneTree::set_pause);
 	ClassDB::bind_method(D_METHOD("is_paused"), &SceneTree::is_paused);
-	ClassDB::bind_method(D_METHOD("set_input_as_handled"), &SceneTree::set_input_as_handled);
+	ClassDB::bind_method(D_METHOD("set_input_as_handled", "handled"), &SceneTree::set_input_as_handled);
 	ClassDB::bind_method(D_METHOD("is_input_handled"), &SceneTree::is_input_handled);
 
 	ClassDB::bind_method(D_METHOD("create_timer", "time_sec", "pause_mode_process"), &SceneTree::create_timer, DEFVAL(true));

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -323,7 +323,7 @@ public:
 
 	void quit();
 
-	void set_input_as_handled();
+	void set_input_as_handled(bool p_handled = true);
 	bool is_input_handled();
 	_FORCE_INLINE_ float get_physics_process_time() const { return physics_process_time; }
 	_FORCE_INLINE_ float get_idle_process_time() const { return idle_process_time; }


### PR DESCRIPTION
This adds an argument to the set_input_as_handled as a way of manually setting the flag to false. There is an issue currently with dispatching events manually to custom viewports. When you use the Input method on a viewport to manually send events, it checks the input_as_handled flag in the tree is false, but since these events are not dispatched through the tree, the flag is usually set to true unless there are other unrelated InputEvents which haven't been handled.

This bug can be most effiectivel seen @BastiaanOlij 's VR modification to the Godot Sponza demo (https://github.com/BastiaanOlij/godot-sponza/tree/godot-sponza-vr), where he creates a 3D settings menu which can be interacted with raycasts cast from one of the VR controllers. The code is supposed to manually generate MouseButton and MouseMotion events, but the mouse button events are the only ones which reliably go through due to the fact that separate unhandled joystick events are being generated which sets the flag which allows the manually generated mouse events to go through. Most of the mouse motion data gets discarded.

This might not be the best way to fix this problem as it might be a little bit of a hackish workaround, but it's the only fix I've found so far to how the architecture of the engine's input system works. If anyone has better fix, please let me know.