### PR TITLE
Fix CanvasItem's search for a CanvasLayer

### DIFF
--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -411,6 +411,9 @@ void CanvasItem::_enter_canvas() {
 			if (canvas_layer) {
 				break;
 			}
+			if (Object::cast_to<Viewport>(n)) {
+				break;
+			}
 			n = n->get_parent();
 		}
 


### PR DESCRIPTION
This fixes the situation where a `CanvasItem` descendant of a `Viewport` which in turn is a descendant of a `CanvasLayer` prefers the more outer `CanvasLayer` rather than the `Vierport`'s.

Because of that, `CanvasItem`s inside a `Viewport` inside a `CanvasLayer` were being rendered to the main `Viewport` instead of the render target of the innermost one.

Fixes #7286.