### PR TITLE
Add accessible_description property to Control.

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -599,6 +599,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="accessible_text" type="String" setter="set_accessible_text" getter="get_accessible_text">
+			An accessibility-related textual description of this control.
+		</member>
 		<member name="anchor_bottom" type="float" setter="_set_anchor" getter="get_anchor">
 			Anchors the bottom edge of the node to the origin, the center, or the end of its parent container. It changes how the bottom margin updates when the node moves or changes size. Use one of the [code]ANCHOR_*[/code] constants. Default value: [code]ANCHOR_BEGIN[/code].
 		</member>

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2682,6 +2682,16 @@ Control::GrowDirection Control::get_v_grow_direction() const {
 	return data.v_grow;
 }
 
+void Control::set_accessible_text(const String &p_accessible_text) {
+
+	accessible_text = p_accessible_text;
+}
+
+String Control::get_accessible_text() const {
+
+	return accessible_text;
+}
+
 void Control::_bind_methods() {
 
 	//ClassDB::bind_method(D_METHOD("_window_resize_event"),&Control::_window_resize_event);
@@ -2815,6 +2825,9 @@ void Control::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_font_changed"), &Control::_font_changed);
 
+	ClassDB::bind_method(D_METHOD("set_accessible_text", "accessible_text"), &Control::set_accessible_text);
+	ClassDB::bind_method(D_METHOD("get_accessible_text"), &Control::get_accessible_text);
+
 	BIND_VMETHOD(MethodInfo("_gui_input", PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
 	BIND_VMETHOD(MethodInfo(Variant::VECTOR2, "_get_minimum_size"));
 	BIND_VMETHOD(MethodInfo(Variant::OBJECT, "get_drag_data", PropertyInfo(Variant::VECTOR2, "position")));
@@ -2870,6 +2883,8 @@ void Control::_bind_methods() {
 	ADD_GROUP("Theme", "");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::OBJECT, "theme", PROPERTY_HINT_RESOURCE_TYPE, "Theme"), "set_theme", "get_theme");
 	ADD_GROUP("", "");
+
+	ADD_PROPERTYNZ(PropertyInfo(Variant::STRING, "accessible_text", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT_INTL), "set_accessible_text", "get_accessible_text");
 
 	BIND_ENUM_CONSTANT(FOCUS_NONE);
 	BIND_ENUM_CONSTANT(FOCUS_CLICK);

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -212,6 +212,8 @@ private:
 
 	} data;
 
+	String accessible_text;
+
 	// used internally
 	Control *_find_control_at_pos(CanvasItem *p_node, const Point2 &p_pos, const Transform2D &p_xform, Transform2D &r_inv_xform);
 
@@ -486,6 +488,9 @@ public:
 	bool is_visibility_clip_disabled() const;
 
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const;
+
+	void set_accessible_text(const String &p_accessible_text);
+	String get_accessible_text() const;
 
 	Control();
 	~Control();


### PR DESCRIPTION
Continuing my work on #14011 and my [accessibility addon](https://gitlab.com/lightsoutgames/godot-accessibility/), I discovered many buttons in the editor without text labels. There doesn't appear to be a consistent way to map these to semi-meaningful identifiers that might give some indication to their use but that wouldn't be visible as on-screen text.

This PR adds an `accessible_description` property to `Control`. We can use this for labeling buttons, describing complex custom controls, etc.

To truly leverage this PR, I'll need to provide others labeling unlabelled controls such as the buttons in the editor. I'll then need to present these controls in the accessibility addon. So this PR is foundational to much of the work that needs doing if we're to make Godot more accessible.

Thanks!