### PR TITLE
Remove .64 suffix from macOS export template binary names

### DIFF
--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -314,7 +314,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 	ERR_FAIL_COND_V(!src_pkg_zip, ERR_CANT_OPEN);
 	int ret = unzGoToFirstFile(src_pkg_zip);
 
-	String binary_to_use = "godot_osx_" + String(p_debug ? "debug" : "release") + ".64";
+	String binary_to_use = "godot_osx_" + String(p_debug ? "debug" : "release");
 
 	String pkg_name;
 	if (p_preset->get("application/name") != "")


### PR DESCRIPTION
Only 64-bit macOS is supported now, so there is no point in keeping the suffix.

**Note:** This will break automated export template building systems, as the old binary names are no longer valid. There is no other compatibility issue I know of, since 3.0.x export templates cannot be used with an editor compiled from the  Git `master` branch anyway.