### PR TITLE
Detect and update .csproj when C# files are added, moved or removed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -308,7 +308,7 @@ platform/windows/godot_res.res
 
 # Visual Studio 2017 and Visual Studio Code workspace folder
 /.vs
-/.vscode
+.vscode/
 
 # Scons progress indicator
 .scons_node_count

--- a/modules/mono/editor/GodotSharpTools/Project/ProjectExtensions.cs
+++ b/modules/mono/editor/GodotSharpTools/Project/ProjectExtensions.cs
@@ -32,10 +32,28 @@ namespace GodotSharpTools.Project
             if (!root.HasItem(itemType, include))
             {
                 root.AddItem(itemType, include);
+
                 return true;
             }
 
             return false;
+        }
+
+        public static void RemoveItem(this ProjectRootElement root, string itemType, string include)
+        {
+            foreach (var itemGroup in root.ItemGroups)
+            {
+                if (itemGroup.Condition.Length != 0)
+                    continue;
+
+                foreach (var item in itemGroup.Items)
+                {
+                    if (item.ItemType == itemType && item.Include == include)
+                    {
+                        itemGroup.RemoveChild(item);
+                    }
+                }
+            }
         }
 
         public static Guid GetGuid(this ProjectRootElement root)

--- a/modules/mono/editor/GodotSharpTools/Project/ProjectUtils.cs
+++ b/modules/mono/editor/GodotSharpTools/Project/ProjectUtils.cs
@@ -10,6 +10,7 @@ namespace GodotSharpTools.Project
         {
             var dir = Directory.GetParent(projectPath).FullName;
             var root = ProjectRootElement.Open(projectPath);
+
             if (root.AddItemChecked(itemType, include.RelativeToPath(dir).Replace("/", "\\")))
                 root.Save();
         }


### PR DESCRIPTION
The .csproj file is updated when the C# solution is built to also account for changes outside the Godot editor. I also updated the .gitignore file to ignore .vscode directories in any directory, not just the root. 

This closes #12917 and closes #12415.