### PR TITLE
Adds C# rule to .editorconfig.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ insert_final_newline = true
 [*.{cpp,hpp,c,h,mm}]
 trim_trailing_whitespace = true
 
-[*.py]
+[*.{py,cs}]
 indent_style = space
 indent_size = 4
 


### PR DESCRIPTION
C# standard is 4 width spaces, not tabs.