### PR TITLE
CubeMap sides now able to accept Textures

### DIFF
--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -366,6 +366,8 @@ private:
 		return false;
 	}
 
+	Vector<Ref<Texture> > textures;
+
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
@@ -376,8 +378,8 @@ protected:
 public:
 	void set_flags(uint32_t p_flags);
 	uint32_t get_flags() const;
-	void set_side(Side p_side, const Ref<Image> &p_image);
-	Ref<Image> get_side(Side p_side) const;
+	void set_side(Side p_side, const Ref<Texture> &p_texture);
+	Ref<Texture> get_side(Side p_side) const;
 
 	Image::Format get_format() const;
 	int get_width() const;


### PR DESCRIPTION
CubeMap resource only accepted Image type resources, resulting in users not
being able to assign anything to any sides of the CubeMap.

Fixed by allowing Texture type resources to be assigned to each side.

This also allows samplerCube to be used in shaders.

Fixes #10251