### PR TITLE
Stop Particles3D to use ressources when not emitting (fixes #19507)

### DIFF
--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -679,7 +679,7 @@ public:
 	void particles_set_draw_passes(RID p_particles, int p_count) {}
 	void particles_set_draw_pass_mesh(RID p_particles, int p_pass, RID p_mesh) {}
 
-	void particles_request_process(RID p_particles) {}
+	bool particles_request_process(RID p_particles) {}
 	AABB particles_get_current_aabb(RID p_particles) { return AABB(); }
 	AABB particles_get_aabb(RID p_particles) const { return AABB(); }
 

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -3554,7 +3554,8 @@ void RasterizerStorageGLES2::particles_set_draw_pass_mesh(RID p_particles, int p
 void RasterizerStorageGLES2::particles_restart(RID p_particles) {
 }
 
-void RasterizerStorageGLES2::particles_request_process(RID p_particles) {
+bool RasterizerStorageGLES2::particles_request_process(RID p_particles) {
+	return false;
 }
 
 AABB RasterizerStorageGLES2::particles_get_current_aabb(RID p_particles) {

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -1057,7 +1057,7 @@ public:
 	virtual void particles_set_draw_passes(RID p_particles, int p_passes);
 	virtual void particles_set_draw_pass_mesh(RID p_particles, int p_pass, RID p_mesh);
 
-	virtual void particles_request_process(RID p_particles);
+	virtual bool particles_request_process(RID p_particles);
 	virtual AABB particles_get_current_aabb(RID p_particles);
 	virtual AABB particles_get_aabb(RID p_particles) const;
 

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -840,14 +840,13 @@ void RasterizerCanvasGLES3::_canvas_item_render_commands(Item *p_item, Item *cur
 				if (!particles)
 					break;
 
-				if (particles->inactive && !particles->emitting)
+				if (!(storage->particles_request_process(particles_cmd->particles)))
 					break;
 
 				glVertexAttrib4f(VS::ARRAY_COLOR, 1, 1, 1, 1); //not used, so keep white
 
 				VisualServerRaster::redraw_request();
 
-				storage->particles_request_process(particles_cmd->particles);
 				//enable instancing
 
 				state.canvas_shader.set_conditional(CanvasShaderGLES3::USE_INSTANCE_CUSTOM, true);

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1821,7 +1821,6 @@ void RasterizerSceneGLES3::_render_geometry(RenderList::Element *e) {
 					storage->info.render.vertices_count += s->array_len * amount;
 				}
 			}
-
 		} break;
 	}
 }

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -5955,14 +5955,17 @@ void RasterizerStorageGLES3::particles_restart(RID p_particles) {
 	particles->restart_request = true;
 }
 
-void RasterizerStorageGLES3::particles_request_process(RID p_particles) {
+bool RasterizerStorageGLES3::particles_request_process(RID p_particles) {
 
 	Particles *particles = particles_owner.getornull(p_particles);
-	ERR_FAIL_COND(!particles);
+	ERR_FAIL_COND_V(!particles, false);
 
-	if (!particles->particle_element.in_list()) {
+	if (!particles->particle_element.in_list() && (particles->emitting || !particles->inactive)) {
 		particle_update_list.add(&particles->particle_element);
+		return true;
 	}
+
+	return false;
 }
 
 AABB RasterizerStorageGLES3::particles_get_current_aabb(RID p_particles) {

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1249,7 +1249,7 @@ public:
 	virtual void particles_set_draw_passes(RID p_particles, int p_passes);
 	virtual void particles_set_draw_pass_mesh(RID p_particles, int p_pass, RID p_mesh);
 
-	virtual void particles_request_process(RID p_particles);
+	virtual bool particles_request_process(RID p_particles);
 	virtual AABB particles_get_current_aabb(RID p_particles);
 	virtual AABB particles_get_aabb(RID p_particles) const;
 

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -523,7 +523,7 @@ public:
 	virtual void particles_set_draw_passes(RID p_particles, int p_count) = 0;
 	virtual void particles_set_draw_pass_mesh(RID p_particles, int p_pass, RID p_mesh) = 0;
 
-	virtual void particles_request_process(RID p_particles) = 0;
+	virtual bool particles_request_process(RID p_particles) = 0;
 	virtual AABB particles_get_current_aabb(RID p_particles) = 0;
 	virtual AABB particles_get_aabb(RID p_particles) const = 0;
 

--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -770,17 +770,18 @@ void VisualServerCanvas::canvas_item_add_particles(RID p_item, RID p_particles, 
 
 	Item::CommandParticles *part = memnew(Item::CommandParticles);
 	ERR_FAIL_COND(!part);
-	part->particles = p_particles;
-	part->texture = p_texture;
-	part->normal_map = p_normal;
-	part->h_frames = p_h_frames;
-	part->v_frames = p_v_frames;
 
 	//take the chance and request processing for them, at least once until they become visible again
-	VSG::storage->particles_request_process(p_particles);
+	if (VSG::storage->particles_request_process(p_particles)) {
 
-	canvas_item->rect_dirty = true;
-	canvas_item->commands.push_back(part);
+		part->particles = p_particles;
+		part->texture = p_texture;
+		part->normal_map = p_normal;
+		part->h_frames = p_h_frames;
+		part->v_frames = p_v_frames;
+		canvas_item->rect_dirty = true;
+		canvas_item->commands.push_back(part);
+	}
 }
 
 void VisualServerCanvas::canvas_item_add_multimesh(RID p_item, RID p_mesh, RID p_texture, RID p_normal_map) {

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -1885,9 +1885,10 @@ void VisualServerScene::_prepare_scene(const Transform p_cam_transform, const Ca
 
 			if (ins->base_type == VS::INSTANCE_PARTICLES) {
 				//particles visible? process them
-				VSG::storage->particles_request_process(ins->base);
-				//particles visible? request redraw
-				VisualServerRaster::redraw_request();
+				if (VSG::storage->particles_request_process(ins->base)) {
+					//particles visible? request redraw
+					VisualServerRaster::redraw_request();
+				}
 			}
 
 			if (geom->lighting_dirty) {


### PR DESCRIPTION
This PR prevents Particles3D to use resources when not emitting (issue #19507).

For the record, this does the same as my last PR #19764, but this time internally.
