### PR TITLE
SCons: Prevent using disable_3d or disable_advanced_gui with tools=yes

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -417,11 +417,19 @@ if selected_platform in platform_list:
     if env['tools']:
         env.Append(CPPDEFINES=['TOOLS_ENABLED'])
     if env['disable_3d']:
-        env.Append(CPPDEFINES=['_3D_DISABLED'])
+        if env['tools']:
+            print("Build option 'disable_3d=yes' cannot be used with 'tools=yes' (editor), only with 'tools=no' (export template).")
+            sys.exit(255)
+        else:
+            env.Append(CPPDEFINES=['_3D_DISABLED'])
     if env['gdscript']:
         env.Append(CPPDEFINES=['GDSCRIPT_ENABLED'])
     if env['disable_advanced_gui']:
-        env.Append(CPPDEFINES=['ADVANCED_GUI_DISABLED'])
+        if env['tools']:
+            print("Build option 'disable_advanced_gui=yes' cannot be used with 'tools=yes' (editor), only with 'tools=no' (export template).")
+            sys.exit(255)
+        else:
+            env.Append(CPPDEFINES=['ADVANCED_GUI_DISABLED'])
     if env['minizip']:
         env.Append(CPPDEFINES=['MINIZIP_ENABLED'])
     if env['xml']:


### PR DESCRIPTION
Those make no sense for tools build, as the editor uses advanced GUI features heavily, and adding checks for 3D/physics features everywhere in the editor would be cumbersome (and error-prone).

Fixes #1701.