### PR TITLE
Fix upper/lower case convertion for characters > 0x80

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -921,8 +921,8 @@ String String::to_upper() const {
 
 	for (int i = 0; i < upper.size(); i++) {
 
-		const char s = upper[i];
-		const char t = _find_upper(s);
+		const CharType s = upper[i];
+		const CharType t = _find_upper(s);
 		if (s != t) // avoid copy on write
 			upper[i] = t;
 	}
@@ -936,8 +936,8 @@ String String::to_lower() const {
 
 	for (int i = 0; i < lower.size(); i++) {
 
-		const char s = lower[i];
-		const char t = _find_lower(s);
+		const CharType s = lower[i];
+		const CharType t = _find_lower(s);
 		if (s != t) // avoid copy on write
 			lower[i] = t;
 	}


### PR DESCRIPTION
The following script now works as expect:

	var text = "áéae"
	print(text)
	print(text.to_upper())
	print('ÁÉAE'.to_lower())

![captura de pantalla 2018-07-21 a las 7 58 07 p m](https://user-images.githubusercontent.com/10578225/43040685-9e298606-8d20-11e8-9dd5-8dbddb2508dc.png)

