### PR TITLE
correctly close handle in alsa audio driver.

### DIFF
--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -58,7 +58,10 @@ Error AudioDriverALSA::init_device() {
 #define CHECK_FAIL(m_cond)                                       \
 	if (m_cond) {                                                \
 		fprintf(stderr, "ALSA ERR: %s\n", snd_strerror(status)); \
-		snd_pcm_close(pcm_handle);                               \
+		if (pcm_handle) {                                        \
+			snd_pcm_close(pcm_handle);                           \
+			pcm_handle = NULL;                                   \
+		}                                                        \
 		ERR_FAIL_COND_V(m_cond, ERR_CANT_OPEN);                  \
 	}
 
@@ -150,7 +153,6 @@ Error AudioDriverALSA::init() {
 	active = false;
 	thread_exited = false;
 	exit_thread = false;
-	pcm_open = false;
 
 	Error err = init_device();
 	if (err == OK) {
@@ -313,9 +315,9 @@ void AudioDriverALSA::unlock() {
 
 void AudioDriverALSA::finish_device() {
 
-	if (pcm_open) {
+	if (pcm_handle) {
 		snd_pcm_close(pcm_handle);
-		pcm_open = NULL;
+		pcm_handle = NULL;
 	}
 }
 

--- a/drivers/alsa/audio_driver_alsa.h
+++ b/drivers/alsa/audio_driver_alsa.h
@@ -66,7 +66,6 @@ class AudioDriverALSA : public AudioDriver {
 	bool active;
 	bool thread_exited;
 	mutable bool exit_thread;
-	bool pcm_open;
 
 public:
 	const char *get_name() const {


### PR DESCRIPTION
`pcm_open` looks like an unnecessary member variable and possibly caused some confusion here.
When switching devices, the old handle would be left open.
Removed it and branched against the relevant pointer instead.