### PR TITLE
Added double clicking to all buttons on Linux and Javascript

### DIFF
--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -302,6 +302,30 @@ EM_BOOL OS_JavaScript::mouse_button_callback(int p_event_type, const EmscriptenM
 		default: return false;
 	}
 
+	if (ev->is_pressed()) {
+
+		uint64_t diff = p_event->timestamp - os->last_click_ms;
+
+		if (ev->get_button_index() == os->last_click_button_index) {
+
+			if (diff < 400 && Point2(os->last_click_pos).distance_to(ev->get_position()) < 5) {
+
+				os->last_click_ms = 0;
+				os->last_click_pos = Point2(-100, -100);
+				os->last_click_button_index = -1;
+				ev->set_doubleclick(true);
+			}
+
+		} else {
+			os->last_click_button_index = ev->get_button_index();
+		}
+
+		if (!ev->is_doubleclick()) {
+			os->last_click_ms += diff;
+			os->last_click_pos = ev->get_position();
+		}
+	}
+
 	int mask = os->input->get_mouse_button_mask();
 	int button_flag = 1 << (ev->get_button_index() - 1);
 	if (ev->is_pressed()) {
@@ -956,6 +980,10 @@ OS_JavaScript::OS_JavaScript(int p_argc, char *p_argv[]) {
 		arguments.push_back(String::utf8(p_argv[i]));
 	}
 	set_cmdline(p_argv[0], arguments);
+
+	last_click_button_index = -1;
+	last_click_ms = 0;
+	last_click_pos = Point2(-100, -100);
 
 	window_maximized = false;
 	soft_fullscreen_enabled = false;

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -52,6 +52,10 @@ class OS_JavaScript : public OS_Unix {
 	CursorShape cursor_shape;
 	Point2 touches[32];
 
+	Point2i last_click_pos;
+	uint64_t last_click_ms;
+	int last_click_button_index;
+
 	MainLoop *main_loop;
 	AudioDriverJavaScript audio_driver_javascript;
 

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -96,6 +96,8 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 	xmbstring = NULL;
 	x11_window = 0;
 	last_click_ms = 0;
+	last_click_button_index = -1;
+	last_click_pos = Point2(-100, -100);
 	args = OS::get_singleton()->get_cmdline_args();
 	current_videomode = p_desired;
 	main_loop = NULL;
@@ -1909,17 +1911,25 @@ void OS_X11::process_xevents() {
 
 				mb->set_pressed((event.type == ButtonPress));
 
-				if (event.type == ButtonPress && event.xbutton.button == 1) {
+				if (event.type == ButtonPress) {
 
 					uint64_t diff = get_ticks_usec() / 1000 - last_click_ms;
 
-					if (diff < 400 && Point2(last_click_pos).distance_to(Point2(event.xbutton.x, event.xbutton.y)) < 5) {
+					if (mb->get_button_index() == last_click_button_index) {
 
-						last_click_ms = 0;
-						last_click_pos = Point2(-100, -100);
-						mb->set_doubleclick(true);
+						if (diff < 400 && Point2(last_click_pos).distance_to(Point2(event.xbutton.x, event.xbutton.y)) < 5) {
 
-					} else {
+							last_click_ms = 0;
+							last_click_pos = Point2(-100, -100);
+							last_click_button_index = -1;
+							mb->set_doubleclick(true);
+						}
+
+					} else if (mb->get_button_index() < 4 || mb->get_button_index() > 7) {
+						last_click_button_index = mb->get_button_index();
+					}
+
+					if (!mb->is_doubleclick()) {
 						last_click_ms += diff;
 						last_click_pos = Point2(event.xbutton.x, event.xbutton.y);
 					}

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -125,6 +125,7 @@ class OS_X11 : public OS_Unix {
 	bool last_mouse_pos_valid;
 	Point2i last_click_pos;
 	uint64_t last_click_ms;
+	int last_click_button_index;
 	uint32_t last_button_state;
 #ifdef TOUCH_ENABLED
 	struct {


### PR DESCRIPTION
Before only windows supported double clicking on all buttons.
Javascript didn't have double clicking at all and linux and OSX supported double clicking only on left/primary mouse button.

This PR adds double clicking support on all buttons for linux and javascript. For javascript to function properly #20081 is needed or there won't be release event after double click.

It might be better if someone else implements the OSX support, because I don't have a mac and the current implementation is quite different. Though it could be changed to similar to linux and javascript.

Fixes #20042. Not on mac obviously.