### PR TITLE
remove transform from editor

### DIFF
--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -797,7 +797,7 @@ void Spatial::_bind_methods() {
 
 	//ADD_PROPERTY( PropertyInfo(Variant::TRANSFORM,"transform/global",PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR ), "set_global_transform", "get_global_transform") ;
 	ADD_GROUP("Transform", "");
-	ADD_PROPERTYNZ(PropertyInfo(Variant::TRANSFORM, "transform", PROPERTY_HINT_NONE, ""), "set_transform", "get_transform");
+	ADD_PROPERTYNZ(PropertyInfo(Variant::TRANSFORM, "transform", PROPERTY_HINT_NONE, "",PROPERTY_USAGE_NOEDITOR), "set_transform", "get_transform");
 	ADD_PROPERTYNZ(PropertyInfo(Variant::TRANSFORM, "global_transform", PROPERTY_HINT_NONE, "", 0), "set_global_transform", "get_global_transform");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "translation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_translation", "get_translation");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "rotation_degrees", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_rotation_degrees", "get_rotation_degrees");


### PR DESCRIPTION
The Transform Property has always been a mild annoyance to me.

Im Talking about this thingy here:
![image](https://user-images.githubusercontent.com/10299514/43160100-85deb240-8f84-11e8-9137-b9cf996d10a8.png)


I Recently removed it from the inspector while working on my own project, and im not gonna lie, i don't plan on going back anywhere soon.

Modifying the transform itself is highly unintuitive. The only times i modified the transform in the inspector was when i clicked on it on accident, messing up the position of my node. Not once have i modified it intentionally.

Not only does the Transform feel unnecessary in the inspector, it also takes a lot of space away from other properties and therefore decreases discoverability. And that not just in the spatial node, but in every single node that derives from it, which are needlessly to say, quite a lot. 

I'm not saying the Transform doesn't have its uses in the editor, but the vast majority of developers who use godot probably barely know what the different values of a transform do, and what needs to be changed to achieve a desired output.

 What do y'all think?