### PR TITLE
Fix game crash when you pass invalid or null parameter to ImageTexture.set_data

### DIFF
--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -235,6 +235,8 @@ Error ImageTexture::load(const String &p_path) {
 
 void ImageTexture::set_data(const Ref<Image> &p_image) {
 
+	ERR_FAIL_COND(p_image.is_null());
+
 	VisualServer::get_singleton()->texture_set_data(texture, p_image);
 
 	_change_notify();


### PR DESCRIPTION
Fix #18817