### PR TITLE
Added String.format "no index" support

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -2781,7 +2781,11 @@ String String::format(const Variant &values, String placeholder) const {
 					val = val.substr(1, val.length() - 2);
 				}
 
-				new_string = new_string.replace(placeholder.replace("_", i_as_str), val);
+				if (placeholder.find("_") > -1) {
+					new_string = new_string.replace(placeholder.replace("_", i_as_str), val);
+				} else {
+					new_string = new_string.replace_first(placeholder, val);
+				}
 			}
 		}
 	} else if (values.get_type() == Variant::DICTIONARY) {


### PR DESCRIPTION
Maybe wait for a response before merging from @Mochnant https://github.com/godotengine/godot/issues/5493

Tested with (Test 15 and 16)

```

func _ready():
	test01()

var t1 = "Hello {name},\nI am {magic_teacher1} your first teacher.\n{name} can get the title {title1}"
var t1_rs = "Hello RobotGuy,\nI am Logis your first teacher.\nRobotGuy can get the title rookie"

var t2 = "Hello {0},\nI am {1} your first teacher.\n{0} can get the title {2}."
var t2_rs = "Hello RobotGuy,\nI am Logis your first teacher.\nRobotGuy can get the title rookie."

var t3 = "Hello {0},\nI am {magic_teacher1} your first teacher.\n{0} can get the title {2}."
var t3_rs = "Hello RobotGuy,\nI am Logis your first teacher.\nRobotGuy can get the title 9000.91."

var t4 = "I know your name, [name] \nI am [magic_teacher1] your first teacher.\n[name] can get the title [title1]"
var t4_rs = "I know your name, RobotGuy \nI am Logis your first teacher.\nRobotGuy can get the title rookie"

var t5 = "I know your name, [0] \nI am [1] your first teacher.\n[0] can get the title [2]"
var t5_rs = "I know your name, RobotGuy \nI am Logis your first teacher.\nRobotGuy can get the title rookie"

var t6 = "Hello {name},\nI am {0} your first teacher.\n{name} can get the title {title1}"
var t6_rs = "Hello RobotGuy,\nI am Logis your first teacher.\nRobotGuy can get the title 9000.91"

var t7 = "Hello {0},\nI am {1} your first teacher.\n{0} can get the title {2}."
var t7_rs = "Hello RobotGuy,\nI am 42 your first teacher.\nRobotGuy can get the title 9000.91."
 
var t8 = "Hello 0[. I am 1[."
var t8_rs = "Hello RobotGuy. I am Logis."

var t9 = "Hello [0. I am [1."
var t9_rs = "Hello RobotGuy. I am Logis."

var t10 = "Hello {0}. I am {9000.91}."
var t10_rs = "Hello RobotGuy. I am Logis."

var t11 = "Hello {name}. I am {magic_teacher1}."
var t11_rs = "Hello RobotGuy. I am Logis."

var t12 = "Hello name[. I am magic_teacher1[."
var t12_rs = "Hello RobotGuy. I am Logis."

var t13 = "Hello [name. I am [magic_teacher1."
var t13_rs = "Hello RobotGuy. I am Logis."

var t14 = "Hello {name}. I am {magic_teacher1}, strength {strength}."
var t14_rs = "Hello RobotGuy. I am Logis, strength 9000.91."

var t15 = "Hello {},\nI am {} your first teacher.\n{} can get the title {}."
var t15_rs = "Hello RobotGuy,\nI am Logis your first teacher.\nRobotGuy can get the title rookie."

var t16 = "Hello %s,\nI am %s your first teacher.\n%s can get the title %s."
var t16_rs = "Hello RobotGuy,\nI am Logis your first teacher.\nRobotGuy can get the title rookie."

func test01():
	#Test01 array with dict style
	assert(t1.format([["name","RobotGuy"],["magic_teacher1","Logis"],["title1","rookie"]]) == t1_rs)

	#Test02 with array
	assert(t2.format(["RobotGuy","Logis","rookie"]) == t2_rs)
	
	#Test03 mixed array
	assert(t3.format(["RobotGuy",["magic_teacher1","Logis"],9000.91]) == t3_rs)

	#Test04 custom placeholder with dict style
	assert(t4.format([["name","RobotGuy"],["magic_teacher1","Logis"],["title1","rookie"]],"[_]") == t4_rs)
	
	#Test05 custom placeholder with array style
	assert(t5.format(["RobotGuy","Logis","rookie"],"[_]") == t5_rs)
	
	#Test06 with string,int,real as key and value
	assert(t6.format([["name","RobotGuy"],[0,"Logis"],["title1",9000.91]]) == t6_rs)

	#Test07 with string,int,real as value
	assert(t7.format(["RobotGuy",42,9000.91]) == t7_rs)

	#Test08 postfix
	assert(t8.format(["RobotGuy","Logis"],"_[") == t8_rs)
	
	#Test09 prefix
	assert(t9.format(["RobotGuy","Logis"],"[_") == t9_rs)
	
	#Test10 with dictionary
	assert(t10.format({"0":"RobotGuy",9000.91:"Logis"}) == t10_rs)
	assert(t11.format({"name":"RobotGuy","magic_teacher1":"Logis"}) == t11_rs)
	assert(t12.format({"name":"RobotGuy","magic_teacher1":"Logis"},"_[") == t12_rs)
	assert(t13.format({"name":"RobotGuy","magic_teacher1":"Logis"},"[_") == t13_rs)
	assert(t14.format({"name":"RobotGuy","magic_teacher1":"Logis","strength":9000.91}) == t14_rs)
	
	#Test15 with array no index, mixing will lead to unexpected results
	assert(t15.format(["RobotGuy","Logis","RobotGuy","rookie"], "{}") == t15_rs)
	assert(t16.format(["RobotGuy","Logis","RobotGuy","rookie"], "%s") == t16_rs)
	
	#Test error messages
	#print("1234".format(["a",[0],"b",[0,1,2]]))
	#print("1234".format(Vector2(0,0)))
```