### PR TITLE
Added OS.get_adapter_name/vendor functions

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -387,6 +387,14 @@ Array _OS::get_fullscreen_mode_list(int p_screen) const {
 	return vmarr;
 }
 
+String _OS::get_adapter_name() const {
+	return OS::get_singleton()->get_adapter_name();
+}
+
+String _OS::get_adapter_vendor() const {
+	return OS::get_singleton()->get_adapter_vendor();
+}
+
 void _OS::set_low_processor_usage_mode(bool p_enabled) {
 
 	OS::get_singleton()->set_low_processor_usage_mode(p_enabled);
@@ -1194,6 +1202,9 @@ void _OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("alert", "text", "title"), &_OS::alert, DEFVAL("Alert!"));
 
 	ClassDB::bind_method(D_METHOD("set_thread_name", "name"), &_OS::set_thread_name);
+
+	ClassDB::bind_method(D_METHOD("get_adapter_name"), &_OS::get_adapter_name);
+	ClassDB::bind_method(D_METHOD("get_adapter_vendor"), &_OS::get_adapter_vendor);
 
 	ClassDB::bind_method(D_METHOD("set_use_vsync", "enable"), &_OS::set_use_vsync);
 	ClassDB::bind_method(D_METHOD("is_vsync_enabled"), &_OS::is_vsync_enabled);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -146,6 +146,9 @@ public:
 	bool is_video_mode_resizable(int p_screen = 0) const;
 	Array get_fullscreen_mode_list(int p_screen = 0) const;
 
+	virtual String get_adapter_name() const;
+	virtual String get_adapter_vendor() const;
+
 	virtual int get_video_driver_count() const;
 	virtual String get_video_driver_name(int p_driver) const;
 

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -632,6 +632,22 @@ void OS::center_window() {
 	set_window_position(Vector2(x, y));
 }
 
+void OS::set_adapter_name(const String &p_adapter_name) {
+	_adapter = p_adapter_name;
+}
+
+String OS::get_adapter_name() const {
+	return _adapter;
+}
+
+void OS::set_adapter_vendor(const String &p_adapter_vendor) {
+	_adapter_vendor = p_adapter_vendor;
+}
+
+String OS::get_adapter_vendor() const {
+	return _adapter_vendor;
+}
+
 int OS::get_video_driver_count() const {
 
 	return 2;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -67,6 +67,8 @@ class OS {
 	bool _allow_hidpi;
 	bool _allow_layered;
 	bool _use_vsync;
+	String _adapter;
+	String _adapter_vendor;
 
 	char *last_error;
 
@@ -182,6 +184,11 @@ public:
 	virtual void set_video_mode(const VideoMode &p_video_mode, int p_screen = 0) = 0;
 	virtual VideoMode get_video_mode(int p_screen = 0) const = 0;
 	virtual void get_fullscreen_mode_list(List<VideoMode> *p_list, int p_screen = 0) const = 0;
+
+	virtual void set_adapter_name(const String &p_adapter_name);
+	virtual String get_adapter_name() const;
+	virtual void set_adapter_vendor(const String &p_adapter_vendor);
+	virtual String get_adapter_vendor() const;
 
 	virtual int get_video_driver_count() const;
 	virtual const char *get_video_driver_name(int p_driver) const;

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -124,6 +124,20 @@
 				Returns the scancode of the given string (e.g. "Escape")
 			</description>
 		</method>
+		<method name="get_adapter_name" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+				Returns a name of the graphics adapter.
+			</description>
+		</method>
+		<method name="get_adapter_vendor" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+				Returns a vendor name of the graphics adapter.
+			</description>
+		</method>
 		<method name="get_audio_driver_count" qualifiers="const">
 			<return type="int">
 			</return>

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -220,8 +220,11 @@ void RasterizerGLES2::initialize() {
 	}
 #endif
 
-	const GLubyte *renderer = glGetString(GL_RENDERER);
-	print_line("OpenGL ES 2.0 Renderer: " + String((const char *)renderer));
+	String renderer = (const char *)glGetString(GL_RENDERER);
+	String vendor = (const char *)glGetString(GL_VENDOR);
+	OS::get_singleton()->set_adapter_name(renderer);
+	OS::get_singleton()->set_adapter_vendor(vendor);
+	print_line("OpenGL ES 2.0 Renderer: " + renderer);
 	storage->initialize();
 	canvas->initialize();
 	scene->initialize();

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -185,8 +185,11 @@ void RasterizerGLES3::initialize() {
 	}
 	*/
 
-	const GLubyte *renderer = glGetString(GL_RENDERER);
-	print_line("OpenGL ES 3.0 Renderer: " + String((const char *)renderer));
+	String renderer = (const char *)glGetString(GL_RENDERER);
+	String vendor = (const char *)glGetString(GL_VENDOR);
+	OS::get_singleton()->set_adapter_name(renderer);
+	OS::get_singleton()->set_adapter_vendor(vendor);
+	print_line("OpenGL ES 3.0 Renderer: " + renderer);
 	storage->initialize();
 	canvas->initialize();
 	scene->initialize();


### PR DESCRIPTION
I've noticed that famous games have the easy way to retrieve the videocard string but Godot games cannot.. 

![image](https://user-images.githubusercontent.com/3036176/43203805-e3ade7d0-9027-11e8-90a3-27cd0e72e52e.png)

So I've added new methods to OS called get_adapter_name and get_adapter_vendor
Example

```
print("OS.get_adapter_vendor = " + OS.get_adapter_vendor())
print("OS.get_adapter_name = " + OS.get_adapter_name())
```
Output
```
OS.get_adapter_vendor = NVIDIA Corporation
OS.get_adapter_name = GeForce GTX 1060 6GB/PCIe/SSE2
```



