### PR TITLE
Added conversions between matrixes in shaders

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -1376,6 +1376,15 @@ const ShaderLanguage::BuiltinFuncDef ShaderLanguage::builtin_func_defs[] = {
 	{ "bvec4", TYPE_BVEC4, { TYPE_UVEC4, TYPE_VOID } },
 	{ "bvec4", TYPE_BVEC4, { TYPE_VEC4, TYPE_VOID } },
 
+	//conversion between matrixes
+
+	{ "mat2", TYPE_MAT2, { TYPE_MAT3, TYPE_VOID } },
+	{ "mat2", TYPE_MAT2, { TYPE_MAT4, TYPE_VOID } },
+	{ "mat3", TYPE_MAT3, { TYPE_MAT2, TYPE_VOID } },
+	{ "mat3", TYPE_MAT3, { TYPE_MAT4, TYPE_VOID } },
+	{ "mat4", TYPE_MAT4, { TYPE_MAT2, TYPE_VOID } },
+	{ "mat4", TYPE_MAT4, { TYPE_MAT3, TYPE_VOID } },
+
 	//builtins - trigonometry
 
 	{ "radians", TYPE_FLOAT, { TYPE_FLOAT, TYPE_VOID } },


### PR DESCRIPTION
 Its possible in GLSL -https://en.wikibooks.org/wiki/GLSL_Programming/Vector_and_Matrix_Operations
`If a larger matrix is constructed from a smaller matrix, the additional rows and columns are set to the values they would have in an identity matrix`
`If a smaller matrix is constructed from a larger matrix, the top, left submatrix of the larger matrix is chosen`
Fix #19214