### PR TITLE
Visualscript: misc generic search changes

### DIFF
--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -1330,7 +1330,7 @@ void VisualScriptEditor::_input(const Ref<InputEvent> &p_event) {
 }
 
 void VisualScriptEditor::_generic_search() {
-	new_connect_node_select->select_from_visual_script(String(""));
+	new_connect_node_select->select_from_visual_script(String(""), false);
 }
 
 void VisualScriptEditor::_members_gui_input(const Ref<InputEvent> &p_event) {
@@ -2610,7 +2610,7 @@ void VisualScriptEditor::connect_data(Ref<VisualScriptNode> vnode_old, Ref<Visua
 	undo_redo->commit_action();
 }
 
-void VisualScriptEditor::_selected_connect_node(const String &p_text, const String &p_category) {
+void VisualScriptEditor::_selected_connect_node(const String &p_text, const String &p_category, const bool p_connecting) {
 	Vector2 ofs = graph->get_scroll_ofs() + port_action_pos;
 	if (graph->is_using_snap()) {
 		int snap = graph->get_snap();
@@ -2625,12 +2625,12 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 		Ref<VisualScriptNode> vnode_old = script->get_node(edited_func, port_action_node);
 		int new_id = script->get_available_id();
 
-		if (Object::cast_to<VisualScriptOperator>(vnode_new.ptr())) {
+		if (Object::cast_to<VisualScriptOperator>(vnode_new.ptr()) && script->get_node(edited_func, port_action_node).is_valid()) {
 			Variant::Type type = script->get_node(edited_func, port_action_node)->get_output_value_port_info(port_action_output).type;
 			Object::cast_to<VisualScriptOperator>(vnode_new.ptr())->set_typed(type);
 		}
 
-		if (Object::cast_to<VisualScriptTypeCast>(vnode_new.ptr())) {
+		if (Object::cast_to<VisualScriptTypeCast>(vnode_new.ptr()) && script->get_node(edited_func, port_action_node).is_valid()) {
 			Variant::Type type = script->get_node(edited_func, port_action_node)->get_output_value_port_info(port_action_output).type;
 			String hint_name = script->get_node(edited_func, port_action_node)->get_output_value_port_info(port_action_output).hint_string;
 
@@ -2644,8 +2644,11 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 		}
 		undo_redo->create_action(TTR("Add Node"));
 		undo_redo->add_do_method(script.ptr(), "add_node", edited_func, new_id, vnode_new, ofs);
-		connect_seq(vnode_old, vnode_new, new_id);
-		connect_data(vnode_old, vnode_new, new_id);
+		if (vnode_old.is_valid() && p_connecting == true) {
+			connect_seq(vnode_old, vnode_new, new_id);
+			connect_data(vnode_old, vnode_new, new_id);
+		}
+
 		undo_redo->add_undo_method(script.ptr(), "remove_node", edited_func, new_id);
 		undo_redo->add_do_method(this, "_update_graph");
 		undo_redo->add_undo_method(this, "_update_graph");
@@ -2732,7 +2735,7 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 			if (tg.gdclass != StringName()) {
 				vsfc->set_base_type(tg.gdclass);
 
-			} else {
+			} else if (script->get_node(edited_func, port_action_node).is_valid()) {
 				PropertyHint hint = script->get_node(edited_func, port_action_node)->get_output_value_port_info(port_action_output).hint;
 				String base_type = script->get_node(edited_func, port_action_node)->get_output_value_port_info(port_action_output).hint_string;
 
@@ -2766,7 +2769,7 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 			if (tg.gdclass != StringName()) {
 				vsp->set_base_type(tg.gdclass);
 
-			} else {
+			} else if (script->get_node(edited_func, port_action_node).is_valid()) {
 				PropertyHint hint = script->get_node(edited_func, port_action_node)->get_output_value_port_info(port_action_output).hint;
 				String base_type = script->get_node(edited_func, port_action_node)->get_output_value_port_info(port_action_output).hint_string;
 
@@ -2796,10 +2799,9 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 			if (tg.gdclass != StringName()) {
 				vsp->set_base_type(tg.gdclass);
 
-			} else {
+			} else if (script->get_node(edited_func, port_action_node).is_valid()) {
 				PropertyHint hint = script->get_node(edited_func, port_action_node)->get_output_value_port_info(port_action_output).hint;
 				String base_type = script->get_node(edited_func, port_action_node)->get_output_value_port_info(port_action_output).hint_string;
-
 				if (base_type != String() && hint == PROPERTY_HINT_TYPE_STRING) {
 					vsp->set_base_type(base_type);
 				}
@@ -2816,9 +2818,10 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 		}
 	}
 	Ref<VisualScriptNode> vnode_old = script->get_node(edited_func, port_action_node);
-	connect_seq(vnode_old, vnode, port_action_new_node);
-	connect_data(vnode_old, vnode, port_action_new_node);
-
+	if (vnode_old.is_valid() && p_connecting == true) {
+		connect_seq(vnode_old, vnode, port_action_new_node);
+		connect_data(vnode_old, vnode, port_action_new_node);
+	}
 	_update_graph(port_action_new_node);
 	_update_graph_connections();
 }
@@ -2869,7 +2872,7 @@ void VisualScriptEditor::connect_seq(Ref<VisualScriptNode> vnode_old, Ref<Visual
 	undo_redo->commit_action();
 }
 
-void VisualScriptEditor::_selected_new_virtual_method(const String &p_text, const String &p_category) {
+void VisualScriptEditor::_selected_new_virtual_method(const String &p_text, const String &p_category, const bool p_connecting) {
 
 	String name = p_text;
 	if (script->has_function(name)) {

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -172,12 +172,12 @@ class VisualScriptEditor : public ScriptEditorBase {
 
 	void connect_data(Ref<VisualScriptNode> vnode_old, Ref<VisualScriptNode> vnode, int new_id);
 
-	void _selected_connect_node(const String &p_text, const String &p_category);
+	void _selected_connect_node(const String &p_text, const String &p_category, const bool p_connecting = true);
 	void connect_seq(Ref<VisualScriptNode> vnode_old, Ref<VisualScriptNode> vnode_new, int new_id);
 
 	void _cancel_connect_node();
 	void _create_new_node(const String &p_text, const String &p_category, const Vector2 &p_point);
-	void _selected_new_virtual_method(const String &p_text, const String &p_category);
+	void _selected_new_virtual_method(const String &p_text, const String &p_category, const bool p_connecting = true);
 
 	int error_line;
 

--- a/modules/visual_script/visual_script_property_selector.cpp
+++ b/modules/visual_script/visual_script_property_selector.cpp
@@ -206,8 +206,10 @@ void VisualScriptPropertySelector::_update_search() {
 				item->set_icon(0, type_icons[E->get().type]);
 				item->set_metadata(1, "get");
 				item->set_collapsed(1);
-				item->set_selectable(1, false);
 				item->set_selectable(0, true);
+				item->set_selectable(1, false);
+				item->set_selectable(2, false);
+				item->set_metadata(2, connecting);
 			}
 
 			if (input == String() ||
@@ -218,8 +220,10 @@ void VisualScriptPropertySelector::_update_search() {
 				item->set_metadata(0, E->get().name);
 				item->set_icon(0, type_icons[E->get().type]);
 				item->set_metadata(1, "set");
-				item->set_selectable(1, false);
 				item->set_selectable(0, true);
+				item->set_selectable(1, false);
+				item->set_selectable(2, false);
+				item->set_metadata(2, connecting);
 			}
 		}
 
@@ -341,6 +345,9 @@ void VisualScriptPropertySelector::_update_search() {
 		item->set_collapsed(1);
 		item->set_selectable(1, false);
 
+		item->set_selectable(2, false);
+		item->set_metadata(2, connecting);
+
 		if (category && category->get_children() == NULL) {
 			memdelete(category); //old category was unused
 		}
@@ -369,6 +376,8 @@ void VisualScriptPropertySelector::create_visualscript_item(const String &name, 
 		item->set_selectable(0, true);
 		item->set_collapsed(1);
 		item->set_selectable(1, false);
+		item->set_selectable(2, false);
+		item->set_metadata(2, connecting);
 	}
 }
 
@@ -423,6 +432,8 @@ void VisualScriptPropertySelector::get_visual_node_names(const String &root_filt
 		item->set_selectable(0, true);
 		item->set_metadata(1, "visualscript");
 		item->set_selectable(1, false);
+		item->set_selectable(2, false);
+		item->set_metadata(2, connecting);
 	}
 }
 
@@ -431,7 +442,7 @@ void VisualScriptPropertySelector::_confirmed() {
 	TreeItem *ti = search_options->get_selected();
 	if (!ti)
 		return;
-	emit_signal("selected", ti->get_metadata(0), ti->get_metadata(1));
+	emit_signal("selected", ti->get_metadata(0), ti->get_metadata(1), ti->get_metadata(2));
 	hide();
 }
 
@@ -542,7 +553,7 @@ void VisualScriptPropertySelector::_notification(int p_what) {
 	}
 }
 
-void VisualScriptPropertySelector::select_method_from_base_type(const String &p_base, const String &p_current, bool p_virtuals_only) {
+void VisualScriptPropertySelector::select_method_from_base_type(const String &p_base, const String &p_current, const bool p_virtuals_only, const bool p_connecting) {
 
 	base_type = p_base;
 	selected = p_current;
@@ -555,6 +566,8 @@ void VisualScriptPropertySelector::select_method_from_base_type(const String &p_
 	show_window(.5f);
 	search_box->set_text("");
 	search_box->grab_focus();
+	connecting = p_connecting;
+
 	_update_search();
 }
 
@@ -562,7 +575,7 @@ void VisualScriptPropertySelector::set_type_filter(const Vector<Variant::Type> &
 	type_filter = p_type_filter;
 }
 
-void VisualScriptPropertySelector::select_from_base_type(const String &p_base, const String &p_current /*= ""*/, bool p_virtuals_only /*= false*/, bool p_seq_connect /*= false*/) {
+void VisualScriptPropertySelector::select_from_base_type(const String &p_base, const String &p_current, bool p_virtuals_only, bool p_seq_connect, const bool p_connecting) {
 
 	base_type = p_base;
 	selected = p_current;
@@ -576,11 +589,12 @@ void VisualScriptPropertySelector::select_from_base_type(const String &p_base, c
 	search_box->set_text("");
 	search_box->grab_focus();
 	seq_connect = p_seq_connect;
+	connecting = p_connecting;
 
 	_update_search();
 }
 
-void VisualScriptPropertySelector::select_from_script(const Ref<Script> &p_script, const String &p_current /*= ""*/) {
+void VisualScriptPropertySelector::select_from_script(const Ref<Script> &p_script, const String &p_current, const bool p_connecting) {
 	ERR_FAIL_COND(p_script.is_null());
 
 	base_type = p_script->get_instance_base_type();
@@ -595,11 +609,12 @@ void VisualScriptPropertySelector::select_from_script(const Ref<Script> &p_scrip
 	search_box->set_text("");
 	search_box->grab_focus();
 	seq_connect = false;
+	connecting = p_connecting;
 
 	_update_search();
 }
 
-void VisualScriptPropertySelector::select_from_basic_type(Variant::Type p_type, const String &p_current /*= ""*/) {
+void VisualScriptPropertySelector::select_from_basic_type(Variant::Type p_type, const String &p_current, const bool p_connecting) {
 	ERR_FAIL_COND(p_type == Variant::NIL);
 	base_type = "";
 	selected = p_current;
@@ -613,11 +628,12 @@ void VisualScriptPropertySelector::select_from_basic_type(Variant::Type p_type, 
 	search_box->set_text("");
 	search_box->grab_focus();
 	seq_connect = false;
+	connecting = p_connecting;
 
 	_update_search();
 }
 
-void VisualScriptPropertySelector::select_from_action(const String &p_type, const String &p_current /*= ""*/) {
+void VisualScriptPropertySelector::select_from_action(const String &p_type, const String &p_current, const bool p_connecting) {
 	base_type = p_type;
 	selected = p_current;
 	type = Variant::NIL;
@@ -630,10 +646,12 @@ void VisualScriptPropertySelector::select_from_action(const String &p_type, cons
 	search_box->set_text("");
 	search_box->grab_focus();
 	seq_connect = true;
+	connecting = p_connecting;
+
 	_update_search();
 }
 
-void VisualScriptPropertySelector::select_from_instance(Object *p_instance, const String &p_current /*= ""*/) {
+void VisualScriptPropertySelector::select_from_instance(Object *p_instance, const String &p_current, const bool p_connecting) {
 	base_type = "";
 	selected = p_current;
 	type = Variant::NIL;
@@ -646,11 +664,12 @@ void VisualScriptPropertySelector::select_from_instance(Object *p_instance, cons
 	search_box->set_text("");
 	search_box->grab_focus();
 	seq_connect = false;
+	connecting = p_connecting;
 
 	_update_search();
 }
 
-void VisualScriptPropertySelector::select_from_visual_script(const String &p_base) {
+void VisualScriptPropertySelector::select_from_visual_script(const String &p_base, const bool p_connecting) {
 	base_type = p_base;
 	selected = "";
 	type = Variant::NIL;
@@ -662,6 +681,7 @@ void VisualScriptPropertySelector::select_from_visual_script(const String &p_bas
 	show_window(.5f);
 	search_box->set_text("");
 	search_box->grab_focus();
+	connecting = p_connecting;
 
 	_update_search();
 }
@@ -682,7 +702,7 @@ void VisualScriptPropertySelector::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_sbox_input"), &VisualScriptPropertySelector::_sbox_input);
 	ClassDB::bind_method(D_METHOD("_item_selected"), &VisualScriptPropertySelector::_item_selected);
 
-	ADD_SIGNAL(MethodInfo("selected", PropertyInfo(Variant::STRING, "name")));
+	ADD_SIGNAL(MethodInfo("selected", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::STRING, "category"), PropertyInfo(Variant::BOOL, "connecting")));
 }
 
 VisualScriptPropertySelector::VisualScriptPropertySelector() {
@@ -708,6 +728,7 @@ VisualScriptPropertySelector::VisualScriptPropertySelector() {
 	help_bit = memnew(EditorHelpBit);
 	vbc->add_margin_child(TTR("Description:"), help_bit);
 	help_bit->connect("request_hide", this, "_closed");
-	search_options->set_columns(2);
+	search_options->set_columns(3);
 	search_options->set_column_expand(1, false);
+	search_options->set_column_expand(2, false);
 }

--- a/modules/visual_script/visual_script_property_selector.h
+++ b/modules/visual_script/visual_script_property_selector.h
@@ -56,6 +56,7 @@ class VisualScriptPropertySelector : public ConfirmationDialog {
 
 	bool properties;
 	bool visual_script_generic;
+	bool connecting;
 	String selected;
 	Variant::Type type;
 	String base_type;
@@ -74,13 +75,13 @@ protected:
 	static void _bind_methods();
 
 public:
-	void select_method_from_base_type(const String &p_base, const String &p_current = "", bool p_virtuals_only = false);
-	void select_from_base_type(const String &p_base, const String &p_current = "", bool p_virtuals_only = false, bool p_seq_connect = false);
-	void select_from_script(const Ref<Script> &p_script, const String &p_current /*= ""*/);
-	void select_from_basic_type(Variant::Type p_type, const String &p_current = "");
-	void select_from_action(const String &p_type, const String &p_current = "");
-	void select_from_instance(Object *p_instance, const String &p_current = "");
-	void select_from_visual_script(const String &p_base);
+	void select_method_from_base_type(const String &p_base, const String &p_current = "", const bool p_virtuals_only = false, const bool p_connecting = true);
+	void select_from_base_type(const String &p_base, const String &p_current = "", bool p_virtuals_only = false, bool p_seq_connect = false, const bool p_connecting = true);
+	void select_from_script(const Ref<Script> &p_script, const String &p_current = "", const bool p_connecting = true);
+	void select_from_basic_type(Variant::Type p_type, const String &p_current = "", const bool p_connecting = true);
+	void select_from_action(const String &p_type, const String &p_current = "", const bool p_connecting = true);
+	void select_from_instance(Object *p_instance, const String &p_current = "", const bool p_connecting = true);
+	void select_from_visual_script(const String &p_base, const bool p_connecting = true);
 
 	void show_window(float p_screen_ratio);
 


### PR DESCRIPTION
Visualscript generic changes:

* fix crash
* generic search should not connect ports because it wouldn't know which one to connect so it'll randomly pick one.

Still working on generic search putting nodes at the very top left.