### PR TITLE
Visualscript: Carry property hint and hint string through to Visualscript virtual funcs

### DIFF
--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -2905,7 +2905,7 @@ void VisualScriptEditor::_selected_new_virtual_method(const String &p_text, cons
 	undo_redo->add_do_method(script.ptr(), "add_function", name);
 
 	for (int i = 0; i < minfo.arguments.size(); i++) {
-		func_node->add_argument(minfo.arguments[i].type, minfo.arguments[i].name);
+		func_node->add_argument(minfo.arguments[i].type, minfo.arguments[i].name, -1, minfo.arguments[i].hint, minfo.arguments[i].hint_string);
 	}
 
 	undo_redo->add_do_method(script.ptr(), "add_node", name, script->get_available_id(), func_node);

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -177,7 +177,7 @@ class VisualScriptEditor : public ScriptEditorBase {
 
 	void _cancel_connect_node();
 	void _create_new_node(const String &p_text, const String &p_category, const Vector2 &p_point);
-	void _selected_new_virtual_method(const String &p_text, const String &p_category, const bool p_connecting = true);
+	void _selected_new_virtual_method(const String &p_text = String(""), const String &p_category = String(""), const bool p_connecting = true);
 
 	int error_line;
 

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -205,6 +205,8 @@ PropertyInfo VisualScriptFunction::get_output_value_port_info(int p_idx) const {
 	PropertyInfo out;
 	out.type = arguments[p_idx].type;
 	out.name = arguments[p_idx].name;
+	out.hint = arguments[p_idx].hint;
+	out.hint_string = arguments[p_idx].hint_string;
 	return out;
 }
 
@@ -218,11 +220,13 @@ String VisualScriptFunction::get_text() const {
 	return get_name(); //use name as function name I guess
 }
 
-void VisualScriptFunction::add_argument(Variant::Type p_type, const String &p_name, int p_index) {
+void VisualScriptFunction::add_argument(Variant::Type p_type, const String &p_name, int p_index, const PropertyHint p_hint, const String &p_hint_string) {
 
 	Argument arg;
 	arg.name = p_name;
 	arg.type = p_type;
+	arg.hint = p_hint;
+	arg.hint_string = p_hint_string;
 	if (p_index >= 0)
 		arguments.insert(p_index, arg);
 	else

--- a/modules/visual_script/visual_script_nodes.h
+++ b/modules/visual_script/visual_script_nodes.h
@@ -40,6 +40,8 @@ class VisualScriptFunction : public VisualScriptNode {
 	struct Argument {
 		String name;
 		Variant::Type type;
+		PropertyHint hint;
+		String hint_string;
 	};
 
 	Vector<Argument> arguments;
@@ -70,7 +72,7 @@ public:
 	virtual String get_text() const;
 	virtual String get_category() const { return "flow_control"; }
 
-	void add_argument(Variant::Type p_type, const String &p_name, int p_index = -1);
+	void add_argument(Variant::Type p_type, const String &p_name, int p_index = -1, const PropertyHint p_hint = PROPERTY_HINT_NONE, const String &p_hint_string = String(""));
 	void set_argument_type(int p_argidx, Variant::Type p_type);
 	Variant::Type get_argument_type(int p_argidx) const;
 	void set_argument_name(int p_argidx, const String &p_name);


### PR DESCRIPTION
Error case:

wall.vs has a _input_event on a Area2D class.

Drag the event obj port and creating the type cast node will assume the port is an object rather than InputEvent. [EDITED]

I can't do anything for cases like the viewport obj port being object typed becauses it is actually a literal object class in the parameters.

Final result:

![godot windows tools 64_2018-07-25_14-30-42](https://user-images.githubusercontent.com/32321/43228775-569aacd0-9017-11e8-8a6f-f4ab63fad42c.png)