### PR TITLE
Add "editor" and "standalone" feature tags

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -577,6 +577,13 @@ bool OS::has_feature(const String &p_feature) {
 	if (p_feature == "release")
 		return true;
 #endif
+#ifdef TOOLS_ENABLED
+	if (p_feature == "editor")
+		return true;
+#else
+	if (p_feature == "standalone")
+		return true;
+#endif
 
 	if (sizeof(void *) == 8 && p_feature == "64") {
 		return true;


### PR DESCRIPTION
These feature tags can be used to check whether the project was started from an editor binary or from an export template binary.

Example use cases:

- Set different user data paths depending on whether the project has been exported or not. This can be used to make sure data generated during development (such as configuration files) cannot mess up with data from an exported copy of the project. For instance, `use_custom_user_dir` can be enabled only when the `standalone` feature flag is present.
- Enable development features only while working on a project, disabling them in the exported project even if it was exported in `debug` mode. This is not currently possible, as the `release` feature flag implies a non-editor build, but the `debug` flag doesn't.

I used the "standalone" term rather than "exported" here, since the flag will be enabled when running a project using a non-tools binary, even if the project itself was not actually exported using the traditional export process.