### PR TITLE
Fix main scene file filter

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -959,7 +959,7 @@ ProjectSettings::ProjectSettings() {
 
 	GLOBAL_DEF("application/config/name", "");
 	GLOBAL_DEF("application/run/main_scene", "");
-	custom_prop_info["application/run/main_scene"] = PropertyInfo(Variant::STRING, "application/run/main_scene", PROPERTY_HINT_FILE, "tscn,scn,res");
+	custom_prop_info["application/run/main_scene"] = PropertyInfo(Variant::STRING, "application/run/main_scene", PROPERTY_HINT_FILE, "*.tscn,*.scn,*.res");
 	GLOBAL_DEF("application/run/disable_stdout", false);
 	GLOBAL_DEF("application/run/disable_stderr", false);
 	GLOBAL_DEF("application/config/use_custom_user_dir", false);


### PR DESCRIPTION
Scene filter was not in the correct format and therefore, no scene was selectable when choosing the main scene.