### PR TITLE
Add toggle for favorites in create_root_dialog

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -86,7 +86,7 @@ void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode) {
 		memdelete(f);
 	}
 
-	_update_favorite_list();
+	_save_and_update_favorite_list();
 
 	// Restore valid window bounds or pop up at default size.
 	if (EditorSettings::get_singleton()->has_setting("interface/dialogs/create_new_node_bounds")) {
@@ -543,8 +543,7 @@ void CreateDialog::_favorite_toggled() {
 		favorite->set_pressed(false);
 	}
 
-	_save_favorite_list();
-	_update_favorite_list();
+	_save_and_update_favorite_list();
 }
 
 void CreateDialog::_save_favorite_list() {
@@ -554,8 +553,11 @@ void CreateDialog::_save_favorite_list() {
 	if (f) {
 
 		for (int i = 0; i < favorite_list.size(); i++) {
-
-			f->store_line(favorite_list[i]);
+			String l = favorite_list[i];
+			String name = l.split(" ")[0];
+			if (!(ClassDB::class_exists(name) || ScriptServer::is_global_class(name)))
+				continue;
+			f->store_line(l);
 		}
 		memdelete(f);
 	}
@@ -566,11 +568,15 @@ void CreateDialog::_update_favorite_list() {
 	favorites->clear();
 	TreeItem *root = favorites->create_item();
 	for (int i = 0; i < favorite_list.size(); i++) {
-		TreeItem *ti = favorites->create_item(root);
 		String l = favorite_list[i];
+		String name = l.split(" ")[0];
+		if (!(ClassDB::class_exists(name) || ScriptServer::is_global_class(name)))
+			continue;
+		TreeItem *ti = favorites->create_item(root);
 		ti->set_text(0, l);
 		ti->set_icon(0, _get_editor_icon(l));
 	}
+	emit_signal("favorites_updated");
 }
 
 void CreateDialog::_history_selected() {
@@ -673,6 +679,10 @@ void CreateDialog::drop_data_fw(const Point2 &p_point, const Variant &p_data, Co
 		}
 	}
 
+	_save_and_update_favorite_list();
+}
+
+void CreateDialog::_save_and_update_favorite_list() {
 	_save_favorite_list();
 	_update_favorite_list();
 }
@@ -688,12 +698,14 @@ void CreateDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_favorite_selected"), &CreateDialog::_favorite_selected);
 	ClassDB::bind_method(D_METHOD("_history_activated"), &CreateDialog::_history_activated);
 	ClassDB::bind_method(D_METHOD("_favorite_activated"), &CreateDialog::_favorite_activated);
+	ClassDB::bind_method(D_METHOD("_save_and_update_favorite_list"), &CreateDialog::_save_and_update_favorite_list);
 
 	ClassDB::bind_method("get_drag_data_fw", &CreateDialog::get_drag_data_fw);
 	ClassDB::bind_method("can_drop_data_fw", &CreateDialog::can_drop_data_fw);
 	ClassDB::bind_method("drop_data_fw", &CreateDialog::drop_data_fw);
 
 	ADD_SIGNAL(MethodInfo("create"));
+	ADD_SIGNAL(MethodInfo("favorites_updated"));
 }
 
 CreateDialog::CreateDialog() {

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -90,6 +90,8 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+	void _save_and_update_favorite_list();
+
 public:
 	Object *instance_selected();
 	String get_selected_type();

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1366,6 +1366,7 @@ void EditorFileSystem::update_script_classes() {
 	}
 
 	ScriptServer::save_global_classes();
+	emit_signal("script_classes_updated");
 }
 
 void EditorFileSystem::_queue_update_script_classes() {
@@ -1704,6 +1705,7 @@ void EditorFileSystem::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("filesystem_changed"));
 	ADD_SIGNAL(MethodInfo("sources_changed", PropertyInfo(Variant::BOOL, "exist")));
 	ADD_SIGNAL(MethodInfo("resources_reimported", PropertyInfo(Variant::POOL_STRING_ARRAY, "resources")));
+	ADD_SIGNAL(MethodInfo("script_classes_updated"));
 }
 
 void EditorFileSystem::_update_extensions() {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -797,18 +797,38 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 		} break;
 		case TOOL_CREATE_2D_SCENE:
 		case TOOL_CREATE_3D_SCENE:
-		case TOOL_CREATE_USER_INTERFACE: {
+		case TOOL_CREATE_USER_INTERFACE:
+		case TOOL_CREATE_FAVORITE: {
 
 			Node *new_node;
-			switch (p_tool) {
-				case TOOL_CREATE_2D_SCENE: new_node = memnew(Node2D); break;
-				case TOOL_CREATE_3D_SCENE: new_node = memnew(Spatial); break;
-				case TOOL_CREATE_USER_INTERFACE: {
-					Control *node = memnew(Control);
-					node->set_anchors_and_margins_preset(PRESET_WIDE); //more useful for resizable UIs.
-					new_node = node;
 
-				} break;
+			if (TOOL_CREATE_FAVORITE == p_tool) {
+				String name = selected_favorite_root.get_slicec(' ', 0);
+				if (ScriptServer::is_global_class(name)) {
+					new_node = Object::cast_to<Node>(ClassDB::instance(ScriptServer::get_global_class_base(name)));
+					Ref<Script> script = ResourceLoader::load(ScriptServer::get_global_class_path(name), "Script");
+					if (new_node && script.is_valid()) {
+						new_node->set_script(script.get_ref_ptr());
+						new_node->set_name(name);
+					}
+				} else {
+					new_node = Object::cast_to<Node>(ClassDB::instance(selected_favorite_root));
+				}
+				if (!new_node) {
+					ERR_EXPLAIN("Creating root from favorite '" + selected_favorite_root + "' failed. Creating 'Node' instead.");
+					new_node = memnew(Node);
+				}
+			} else {
+				switch (p_tool) {
+					case TOOL_CREATE_2D_SCENE: new_node = memnew(Node2D); break;
+					case TOOL_CREATE_3D_SCENE: new_node = memnew(Spatial); break;
+					case TOOL_CREATE_USER_INTERFACE: {
+						Control *node = memnew(Control);
+						node->set_anchors_and_margins_preset(PRESET_WIDE); //more useful for resizable UIs.
+						new_node = node;
+
+					} break;
+				}
 			}
 
 			editor_data->get_undo_redo().create_action("New Scene Root");
@@ -866,35 +886,62 @@ void SceneTreeDock::_notification(int p_what) {
 
 			EditorNode::get_singleton()->get_editor_selection()->connect("selection_changed", this, "_selection_changed");
 
-			create_root_dialog->add_child(memnew(Label(TTR("Create Root Node:"))));
+			// create_root_dialog
+			HBoxContainer *top_row = memnew(HBoxContainer);
+			top_row->set_name("NodeShortcutsTopRow");
+			top_row->set_h_size_flags(SIZE_EXPAND_FILL);
+			top_row->add_child(memnew(Label(TTR("Create Root Node:"))));
+			top_row->add_spacer();
+
+			ToolButton *node_shortcuts_toggle = memnew(ToolButton);
+			node_shortcuts_toggle->set_name("NodeShortcutsToggle");
+			node_shortcuts_toggle->set_icon(get_icon("Favorites", "EditorIcons"));
+			node_shortcuts_toggle->set_toggle_mode(true);
+			node_shortcuts_toggle->set_pressed(EDITOR_GET("_use_favorites_root_selection"));
+			node_shortcuts_toggle->set_anchors_and_margins_preset(Control::PRESET_CENTER_RIGHT);
+			node_shortcuts_toggle->connect("pressed", this, "_update_create_root_dialog");
+			top_row->add_child(node_shortcuts_toggle);
+
+			create_root_dialog->add_child(top_row);
+
+			VBoxContainer *node_shortcuts = memnew(VBoxContainer);
+			node_shortcuts->set_name("NodeShortcuts");
+
+			VBoxContainer *beginner_node_shortcuts = memnew(VBoxContainer);
+			beginner_node_shortcuts->set_name("BeginnerNodeShortcuts");
+			node_shortcuts->add_child(beginner_node_shortcuts);
 
 			Button *button_2d = memnew(Button);
-			create_root_dialog->add_child(button_2d);
-
+			beginner_node_shortcuts->add_child(button_2d);
 			button_2d->set_text(TTR("2D Scene"));
 			button_2d->set_icon(get_icon("Node2D", "EditorIcons"));
 			button_2d->connect("pressed", this, "_tool_selected", make_binds(TOOL_CREATE_2D_SCENE, false));
 
 			Button *button_3d = memnew(Button);
-			create_root_dialog->add_child(button_3d);
+			beginner_node_shortcuts->add_child(button_3d);
 			button_3d->set_text(TTR("3D Scene"));
 			button_3d->set_icon(get_icon("Spatial", "EditorIcons"));
 			button_3d->connect("pressed", this, "_tool_selected", make_binds(TOOL_CREATE_3D_SCENE, false));
 
 			Button *button_ui = memnew(Button);
-			create_root_dialog->add_child(button_ui);
+			beginner_node_shortcuts->add_child(button_ui);
 			button_ui->set_text(TTR("User Interface"));
 			button_ui->set_icon(get_icon("Control", "EditorIcons"));
 			button_ui->connect("pressed", this, "_tool_selected", make_binds(TOOL_CREATE_USER_INTERFACE, false));
 
+			VBoxContainer *favorite_node_shortcuts = memnew(VBoxContainer);
+			favorite_node_shortcuts->set_name("FavoriteNodeShortcuts");
+			node_shortcuts->add_child(favorite_node_shortcuts);
+
 			Button *button_custom = memnew(Button);
-			create_root_dialog->add_child(button_custom);
+			node_shortcuts->add_child(button_custom);
 			button_custom->set_text(TTR("Custom Node"));
 			button_custom->set_icon(get_icon("Add", "EditorIcons"));
 			button_custom->connect("pressed", this, "_tool_selected", make_binds(TOOL_NEW, false));
 
-			create_root_dialog->add_spacer();
-
+			node_shortcuts->add_spacer();
+			create_root_dialog->add_child(node_shortcuts);
+			_update_create_root_dialog();
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
@@ -2148,6 +2195,67 @@ void SceneTreeDock::_local_tree_selected() {
 	edit_local->set_pressed(true);
 }
 
+void SceneTreeDock::_update_create_root_dialog() {
+
+	BaseButton *toggle = Object::cast_to<BaseButton>(create_root_dialog->get_node(String("NodeShortcutsTopRow/NodeShortcutsToggle")));
+	Node *node_shortcuts = create_root_dialog->get_node(String("NodeShortcuts"));
+
+	if (!toggle || !node_shortcuts)
+		return;
+
+	Control *beginner_nodes = Object::cast_to<Control>(node_shortcuts->get_node(String("BeginnerNodeShortcuts")));
+	Control *favorite_nodes = Object::cast_to<Control>(node_shortcuts->get_node(String("FavoriteNodeShortcuts")));
+
+	if (!beginner_nodes || !favorite_nodes)
+		return;
+
+	EditorSettings::get_singleton()->set_setting("_use_favorites_root_selection", toggle->is_pressed());
+	EditorSettings::get_singleton()->save();
+	if (toggle->is_pressed()) {
+
+		for (int i = 0; i < favorite_nodes->get_child_count(); i++) {
+			favorite_nodes->get_child(i)->queue_delete();
+		}
+
+		FileAccess *f = FileAccess::open(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("favorites.Node"), FileAccess::READ);
+
+		if (f) {
+
+			while (!f->eof_reached()) {
+				String l = f->get_line().strip_edges();
+
+				if (l != String()) {
+					Button *button = memnew(Button);
+					favorite_nodes->add_child(button);
+					button->set_text(TTR(l));
+					String name = l.get_slicec(' ', 0);
+					if (ScriptServer::is_global_class(name))
+						name = ScriptServer::get_global_class_base(name);
+					button->set_icon(get_icon(name, "EditorIcons"));
+					button->connect("pressed", this, "_favorite_root_selected", make_binds(l));
+				}
+			}
+
+			memdelete(f);
+		}
+
+		if (!favorite_nodes->is_visible_in_tree()) {
+			favorite_nodes->show();
+			beginner_nodes->hide();
+		}
+	} else {
+		if (!beginner_nodes->is_visible_in_tree()) {
+			beginner_nodes->show();
+			favorite_nodes->hide();
+		}
+	}
+}
+
+void SceneTreeDock::_favorite_root_selected(const String &p_class) {
+	selected_favorite_root = p_class;
+	_tool_selected(TOOL_CREATE_FAVORITE, false);
+}
+
 void SceneTreeDock::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_tool_selected"), &SceneTreeDock::_tool_selected, DEFVAL(false));
@@ -2176,6 +2284,8 @@ void SceneTreeDock::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_remote_tree_selected"), &SceneTreeDock::_remote_tree_selected);
 	ClassDB::bind_method(D_METHOD("_local_tree_selected"), &SceneTreeDock::_local_tree_selected);
 	ClassDB::bind_method(D_METHOD("_update_script_button"), &SceneTreeDock::_update_script_button);
+	ClassDB::bind_method(D_METHOD("_favorite_root_selected"), &SceneTreeDock::_favorite_root_selected);
+	ClassDB::bind_method(D_METHOD("_update_create_root_dialog"), &SceneTreeDock::_update_create_root_dialog);
 
 	ClassDB::bind_method(D_METHOD("instance"), &SceneTreeDock::instance);
 
@@ -2301,6 +2411,8 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	create_dialog->set_base_type("Node");
 	add_child(create_dialog);
 	create_dialog->connect("create", this, "_create");
+	create_dialog->connect("favorites_updated", this, "_update_create_root_dialog");
+	EditorFileSystem::get_singleton()->connect("script_classes_updated", create_dialog, "_save_and_update_favorite_list");
 
 	rename_dialog = memnew(RenameDialog(scene_tree, &editor_data->get_undo_redo()));
 	add_child(rename_dialog);
@@ -2354,4 +2466,5 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	set_process(true);
 
 	EDITOR_DEF("interface/editors/show_scene_tree_root_selection", true);
+	EDITOR_DEF("_use_favorites_root_selection", false);
 }

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -86,6 +86,7 @@ class SceneTreeDock : public VBoxContainer {
 		TOOL_CREATE_2D_SCENE,
 		TOOL_CREATE_3D_SCENE,
 		TOOL_CREATE_USER_INTERFACE,
+		TOOL_CREATE_FAVORITE,
 
 	};
 
@@ -141,6 +142,7 @@ class SceneTreeDock : public VBoxContainer {
 	EditorNode *editor;
 
 	VBoxContainer *create_root_dialog;
+	String selected_favorite_root;
 
 	void _add_children_to_popup(Object *p_obj, int p_depth);
 
@@ -200,6 +202,9 @@ class SceneTreeDock : public VBoxContainer {
 
 	void _remote_tree_selected();
 	void _local_tree_selected();
+
+	void _update_create_root_dialog();
+	void _favorite_root_selected(const String &p_class);
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
This is in reference to @akien-mga and @groud's suggestion at the end of #20238.

It creates an alternative scene root creation dialog that can be toggled in the EditorSettings. It enables users to have their favorites list show up in place of the beginner-friendly `create_root_dialog`. It also supports the creation of script classes from this list.

It all updates in real-time as things are changed.

Toggled Off:
![toggle_off](https://user-images.githubusercontent.com/16217563/43284530-b5a2b504-90e1-11e8-8b92-9e1cfa655faf.png)

Toggled On:
![toggle_on](https://user-images.githubusercontent.com/16217563/43284533-b9562bd6-90e1-11e8-9f82-f1f65139b23b.png)

Unfavorited Node:
![unfavorited](https://user-images.githubusercontent.com/16217563/43284556-caffcb44-90e1-11e8-9862-f09ddc9e9c41.png)

Favorited Node:
![favorited](https://user-images.githubusercontent.com/16217563/43284563-d042d3b2-90e1-11e8-967b-2af4c48ea9ea.png)

EDIT:

The change is now toggled on or off via signal callbacks from an in-panel button rather than making the process logic more complicated. Here is what it looks like now:

Button Toggled Off:
![button_off](https://user-images.githubusercontent.com/16217563/43734072-33b3aef6-997c-11e8-9ad9-5039b1dc3b90.png)

Button Toggled On:
![button_on](https://user-images.githubusercontent.com/16217563/43734081-38142d90-997c-11e8-8dfe-1664fbcc1d43.png)

If you have a script class and the script class's information is updated while it is in this list, it will be automatically removed from the list (since it ceased to exist). The serialized favorites data should automatically be updated too.