### PR TITLE
Fixed mouse position when capturing mouse

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -451,11 +451,10 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 
 				if (mm->get_position() == c) {
 					center = c;
+					input->set_mouse_position(Vector2((int)c.x, (int)c.y));
 					return 0;
 				}
 
-				Point2i ncenter = mm->get_position();
-				center = ncenter;
 				POINT pos = { (int)c.x, (int)c.y };
 				ClientToScreen(hWnd, &pos);
 				SetCursorPos(pos.x, pos.y);

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -1982,18 +1982,18 @@ void OS_X11::process_xevents() {
 #endif
 
 				if (mouse_mode == MOUSE_MODE_CAPTURED) {
+					Point2i c(current_videomode.width / 2, current_videomode.height / 2);
+					last_mouse_pos = c;
 
-					if (pos == Point2i(current_videomode.width / 2, current_videomode.height / 2)) {
+					if (pos == c) {
 						//this sucks, it's a hack, etc and is a little inaccurate, etc.
 						//but nothing I can do, X11 sucks.
 
 						center = pos;
+						input->set_mouse_position(pos);
 						break;
 					}
 
-					Point2i new_center = pos;
-					pos = last_mouse_pos + (pos - center);
-					center = new_center;
 					do_mouse_warp = window_has_focus; // warp the cursor if we're focused in
 				}
 


### PR DESCRIPTION
Before when mouse mode was set to captured, Viewport.get_mouse_position() would return inconsistent value after centering on Windows. On Linux values would keep increasing if one would keep moving their mouse to the same direction.

After this commit correct mouse position is returned on both platforms.

#20410 is related, but on godot 2.1.

Also doesn't "center" variable seem pretty useless on both platforms?