### PR TITLE
Multiply TextEdit line spacing by the editor scale

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4328,7 +4328,11 @@ void TextEdit::_update_caches() {
 	cache.search_result_border_color = get_color("search_result_border_color");
 	cache.symbol_color = get_color("symbol_color");
 	cache.background_color = get_color("background_color");
+#ifdef TOOLS_ENABLED
+	cache.line_spacing = get_constant("line_spacing") * EDSCALE;
+#else
 	cache.line_spacing = get_constant("line_spacing");
+#endif
 	cache.row_height = cache.font->get_height() + cache.line_spacing;
 	cache.tab_icon = get_icon("tab");
 	cache.folded_icon = get_icon("GuiTreeArrowRight", "EditorIcons");


### PR DESCRIPTION
This makes sure the default line spacing in the script editor is consistent with the editor scale in use.

**Before (editor scale set to 200%, line spacing set to 6):**
![textedit_before_edscale_fix](https://user-images.githubusercontent.com/180032/43288418-0c2251f0-9128-11e8-8375-50e907aa2155.png)

**After (editor scale set to 200%, line spacing set to 6):**
![textedit_after_edscale_fix](https://user-images.githubusercontent.com/180032/43288408-03cce06a-9128-11e8-9743-8b72bd885b12.png)