### PR TITLE
Make the caret thicker in TextEdit and scale it with the editor scale

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -35,7 +35,9 @@
 #include "os/os.h"
 #include "print_string.h"
 #include "translation.h"
+
 #ifdef TOOLS_ENABLED
+#include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
 #endif
 
@@ -716,7 +718,11 @@ void LineEdit::_notification(int p_what) {
 
 				if (char_ofs == cursor_pos && draw_caret) {
 					if (ime_text.length() == 0) {
+#ifdef TOOLS_ENABLED
+						VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(Point2(x_ofs, y_ofs), Size2(Math::round(EDSCALE), caret_height)), cursor_color);
+#else
 						VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(Point2(x_ofs, y_ofs), Size2(1, caret_height)), cursor_color);
+#endif
 					}
 				}
 
@@ -755,7 +761,11 @@ void LineEdit::_notification(int p_what) {
 
 			if (char_ofs == cursor_pos && draw_caret) { //may be at the end
 				if (ime_text.length() == 0) {
+#ifdef TOOLS_ENABLED
+					VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(Point2(x_ofs, y_ofs), Size2(Math::round(EDSCALE), caret_height)), cursor_color);
+#else
 					VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(Point2(x_ofs, y_ofs), Size2(1, caret_height)), cursor_color);
+#endif
 				}
 			}
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1148,10 +1148,18 @@ void TextEdit::_notification(int p_what) {
 							if (ime_text.length() == 0) {
 								if (draw_caret) {
 									if (insert_mode) {
-										int caret_h = (block_caret) ? 4 : 1;
+#ifdef TOOLS_ENABLED
+										int caret_h = (block_caret) ? 4 : 2 * EDSCALE;
+#else
+										int caret_h = (block_caret) ? 4 : 2;
+#endif
 										VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(cursor_pos, Size2i(caret_w, caret_h)), cache.caret_color);
 									} else {
-										caret_w = (block_caret) ? caret_w : 1;
+#ifdef TOOLS_ENABLED
+										caret_w = (block_caret) ? caret_w : 2 * EDSCALE;
+#else
+										caret_w = (block_caret) ? caret_w : 2;
+#endif
 										VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(cursor_pos, Size2i(caret_w, get_row_height())), cache.caret_color);
 									}
 								}
@@ -1224,11 +1232,19 @@ void TextEdit::_notification(int p_what) {
 							if (draw_caret) {
 								if (insert_mode) {
 									int char_w = cache.font->get_char_size(' ').width;
-									int caret_h = (block_caret) ? 4 : 1;
+#ifdef TOOLS_ENABLED
+									int caret_h = (block_caret) ? 4 : 2 * EDSCALE;
+#else
+									int caret_h = (block_caret) ? 4 : 2;
+#endif
 									VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(cursor_pos, Size2i(char_w, caret_h)), cache.caret_color);
 								} else {
 									int char_w = cache.font->get_char_size(' ').width;
-									int caret_w = (block_caret) ? char_w : 1;
+#ifdef TOOLS_ENABLED
+									int caret_w = (block_caret) ? char_w : 2 * EDSCALE;
+#else
+									int caret_w = (block_caret) ? char_w : 2;
+#endif
 									VisualServer::get_singleton()->canvas_item_add_rect(ci, Rect2(cursor_pos, Size2i(caret_w, get_row_height())), cache.caret_color);
 								}
 							}


### PR DESCRIPTION
The caret in LineEdit is still 1 pixel thick, but it will become 2 pixels thick at editor scales higher than or equal to 150%.

For the record, 2 pixel-thick carets are common in other text editors, such as Visual Studio Code, Atom or JetBrains IDEs. However, single-line inputs often stick to 1 pixel-thick carets except on hiDPI displays.