### PR TITLE
TileMap now calculates its editor extents.

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -35,6 +35,31 @@
 #include "os/os.h"
 #include "servers/physics_2d_server.h"
 
+Rect2 TileMap::_edit_get_rect() const {
+
+	Rect2 map_size = _compute_used_size();
+	if (mode != MODE_CUSTOM) {
+		map_size.position *= cell_size;
+		map_size.size *= cell_size;
+	}
+	return map_size;
+}
+
+Rect2 TileMap::_compute_used_size() const {
+
+	Rect2 used_size;
+	if (tile_map.size() > 0) {
+		used_size = Rect2(tile_map.front()->key().x, tile_map.front()->key().y, 0, 0);
+		for (Map<PosKey, Cell>::Element *E = tile_map.front(); E; E = E->next()) {
+			used_size.expand_to(Vector2(E->key().x, E->key().y));
+		}
+		used_size.size += Vector2(1, 1);
+	} else {
+		used_size = Rect2();
+	}
+	return used_size;
+}
+
 int TileMap::_get_quadrant_size() const {
 
 	if (y_sort_mode)
@@ -1493,18 +1518,7 @@ Array TileMap::get_used_cells_by_id(int p_id) const {
 Rect2 TileMap::get_used_rect() { // Not const because of cache
 
 	if (used_size_cache_dirty) {
-		if (tile_map.size() > 0) {
-			used_size_cache = Rect2(tile_map.front()->key().x, tile_map.front()->key().y, 0, 0);
-
-			for (Map<PosKey, Cell>::Element *E = tile_map.front(); E; E = E->next()) {
-				used_size_cache.expand_to(Vector2(E->key().x, E->key().y));
-			}
-
-			used_size_cache.size += Vector2(1, 1);
-		} else {
-			used_size_cache = Rect2();
-		}
-
+		used_size_cache = _compute_used_size();
 		used_size_cache_dirty = false;
 	}
 

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -194,6 +194,7 @@ private:
 	void _update_quadrant_space(const RID &p_space);
 	void _update_quadrant_transform();
 	void _recompute_rect_cache();
+	Rect2 _compute_used_size() const;
 
 	void _update_all_items_material_state();
 	_FORCE_INLINE_ void _update_item_material_state(const RID &p_canvas_item);
@@ -222,6 +223,9 @@ public:
 	enum {
 		INVALID_CELL = -1
 	};
+
+	virtual Rect2 _edit_get_rect() const;
+	virtual bool _edit_use_rect() const { return true; };
 
 	void set_tileset(const Ref<TileSet> &p_tileset);
 	Ref<TileSet> get_tileset() const;


### PR DESCRIPTION
This alleviates (but needs some extra polish, see below) #18202, and may help with #18738 and #18254.

Tilemaps calculate their extents using the used cells Rect2, but don't take into account individual tile sizes and offsets. That means the pixels size of a tilemap will not be calculated correctly when using tiles greater than the cell size.

But at least, it's a start.

I suspect many of these scroll problems are caused by descendants of CanvasItem that don't implement _edit_get_rect and _edit_use_rect. The 2D editor needs these to calculate the scene extents and, with it, the scrollbar sizes/ranges.