### PR TITLE
Fixed shortcuts not working with InputEventActions

### DIFF
--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -937,6 +937,14 @@ bool InputEventAction::is_pressed() const {
 	return pressed;
 }
 
+bool InputEventAction::shortcut_match(const Ref<InputEvent> &p_event) const {
+	Ref<InputEventKey> event = p_event;
+	if (event.is_null())
+		return false;
+
+	return event->is_action(action);
+}
+
 bool InputEventAction::is_action(const StringName &p_action) const {
 
 	return action == p_action;

--- a/core/os/input_event.h
+++ b/core/os/input_event.h
@@ -467,6 +467,7 @@ public:
 
 	virtual bool is_action(const StringName &p_action) const;
 
+	virtual bool shortcut_match(const Ref<InputEvent> &p_event) const;
 	virtual bool is_action_type() const { return true; }
 	virtual String as_text() const;
 


### PR DESCRIPTION
This fixes #15979
[Bug moved to #20526]