### PR TITLE
Fixed nativescript getter and setter logic

### DIFF
--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -556,12 +556,17 @@ bool NativeScriptInstance::set(const StringName &p_name, const Variant &p_value)
 			Variant name = p_name;
 			const Variant *args[2] = { &name, &p_value };
 
-			E->get().method.method((godot_object *)owner,
+			godot_variant result;
+			result = E->get().method.method((godot_object *)owner,
 					E->get().method.method_data,
 					userdata,
 					2,
 					(godot_variant **)args);
-			return true;
+			bool handled = *(Variant *)&result;
+			godot_variant_destroy(&result);
+			if (handled) {
+				return true;
+			}
 		}
 
 		script_data = script_data->base_data;
@@ -596,10 +601,9 @@ bool NativeScriptInstance::get(const StringName &p_name, Variant &r_ret) const {
 					(godot_variant **)args);
 			r_ret = *(Variant *)&result;
 			godot_variant_destroy(&result);
-			if (r_ret.get_type() == Variant::NIL) {
-				return false;
+			if (r_ret.get_type() != Variant::NIL) {
+				return true;
 			}
-			return true;
 		}
 
 		script_data = script_data->base_data;


### PR DESCRIPTION
For setting and getting properties through _set and _get the code broke if the property was from a base class.

When _set returns false we should continue down the class tree but we were finishing and returning true regardless

Same when _get returns NULL, it needs to go down the tree.

Note that when a getter method or setter method for a property is found we can fully trust our resulting value as I understand it.