### PR TITLE
openssl: Update to pristine 1.0.2o (security update)

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -305,7 +305,7 @@ License: Zlib
 
 Files: ./thirdparty/openssl/
 Comment: The OpenSSL Project
-Copyright: 1998-2017, The OpenSSL Project.
+Copyright: 1998-2018, The OpenSSL Project.
 License: OpenSSL
 
 Files: ./thirdparty/opus/

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -322,7 +322,7 @@ Files extracted from the upstream source:
 ## openssl
 
 - Upstream: https://www.openssl.org
-- Version: 1.0.2n
+- Version: 1.0.2o
 - License: OpenSSL license / BSD-like
 
 Files extracted from the upstream source:

--- a/thirdparty/openssl/LICENSE
+++ b/thirdparty/openssl/LICENSE
@@ -12,7 +12,7 @@
   ---------------
 
 /* ====================================================================
- * Copyright (c) 1998-2017 The OpenSSL Project.  All rights reserved.
+ * Copyright (c) 1998-2018 The OpenSSL Project.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/thirdparty/openssl/crypto/asn1/a_gentm.c
+++ b/thirdparty/openssl/crypto/asn1/a_gentm.c
@@ -78,7 +78,7 @@ int i2d_ASN1_GENERALIZEDTIME(ASN1_GENERALIZEDTIME *a, unsigned char **pp)
     ASN1_STRING tmpstr = *(ASN1_STRING *)a;
 
     len = tmpstr.length;
-    ebcdic2ascii(tmp, tmpstr.data, (len >= sizeof tmp) ? sizeof tmp : len);
+    ebcdic2ascii(tmp, tmpstr.data, (len >= sizeof(tmp)) ? sizeof(tmp) : len);
     tmpstr.data = tmp;
 
     a = (ASN1_GENERALIZEDTIME *)&tmpstr;

--- a/thirdparty/openssl/crypto/asn1/a_mbstr.c
+++ b/thirdparty/openssl/crypto/asn1/a_mbstr.c
@@ -149,14 +149,14 @@ int ASN1_mbstring_ncopy(ASN1_STRING **out, const unsigned char *in, int len,
 
     if ((minsize > 0) && (nchar < minsize)) {
         ASN1err(ASN1_F_ASN1_MBSTRING_NCOPY, ASN1_R_STRING_TOO_SHORT);
-        BIO_snprintf(strbuf, sizeof strbuf, "%ld", minsize);
+        BIO_snprintf(strbuf, sizeof(strbuf), "%ld", minsize);
         ERR_add_error_data(2, "minsize=", strbuf);
         return -1;
     }
 
     if ((maxsize > 0) && (nchar > maxsize)) {
         ASN1err(ASN1_F_ASN1_MBSTRING_NCOPY, ASN1_R_STRING_TOO_LONG);
-        BIO_snprintf(strbuf, sizeof strbuf, "%ld", maxsize);
+        BIO_snprintf(strbuf, sizeof(strbuf), "%ld", maxsize);
         ERR_add_error_data(2, "maxsize=", strbuf);
         return -1;
     }

--- a/thirdparty/openssl/crypto/asn1/a_object.c
+++ b/thirdparty/openssl/crypto/asn1/a_object.c
@@ -89,7 +89,7 @@ int a2d_ASN1_OBJECT(unsigned char *out, int olen, const char *buf, int num)
 {
     int i, first, len = 0, c, use_bn;
     char ftmp[24], *tmp = ftmp;
-    int tmpsize = sizeof ftmp;
+    int tmpsize = sizeof(ftmp);
     const char *p;
     unsigned long l;
     BIGNUM *bl = NULL;
@@ -226,7 +226,7 @@ int i2a_ASN1_OBJECT(BIO *bp, ASN1_OBJECT *a)
 
     if ((a == NULL) || (a->data == NULL))
         return (BIO_write(bp, "NULL", 4));
-    i = i2t_ASN1_OBJECT(buf, sizeof buf, a);
+    i = i2t_ASN1_OBJECT(buf, sizeof(buf), a);
     if (i > (int)(sizeof(buf) - 1)) {
         p = OPENSSL_malloc(i + 1);
         if (!p)

--- a/thirdparty/openssl/crypto/asn1/a_strex.c
+++ b/thirdparty/openssl/crypto/asn1/a_strex.c
@@ -130,13 +130,13 @@ static int do_esc_char(unsigned long c, unsigned char flags, char *do_quotes,
     if (c > 0xffffffffL)
         return -1;
     if (c > 0xffff) {
-        BIO_snprintf(tmphex, sizeof tmphex, "\\W%08lX", c);
+        BIO_snprintf(tmphex, sizeof(tmphex), "\\W%08lX", c);
         if (!io_ch(arg, tmphex, 10))
             return -1;
         return 10;
     }
     if (c > 0xff) {
-        BIO_snprintf(tmphex, sizeof tmphex, "\\U%04lX", c);
+        BIO_snprintf(tmphex, sizeof(tmphex), "\\U%04lX", c);
         if (!io_ch(arg, tmphex, 6))
             return -1;
         return 6;
@@ -236,7 +236,7 @@ static int do_buf(unsigned char *buf, int buflen,
         if (type & BUF_TYPE_CONVUTF8) {
             unsigned char utfbuf[6];
             int utflen;
-            utflen = UTF8_putc(utfbuf, sizeof utfbuf, c);
+            utflen = UTF8_putc(utfbuf, sizeof(utfbuf), c);
             for (i = 0; i < utflen; i++) {
                 /*
                  * We don't need to worry about setting orflags correctly
@@ -533,7 +533,7 @@ static int do_name_ex(char_io *io_ch, void *arg, X509_NAME *n,
         if (fn_opt != XN_FLAG_FN_NONE) {
             int objlen, fld_len;
             if ((fn_opt == XN_FLAG_FN_OID) || (fn_nid == NID_undef)) {
-                OBJ_obj2txt(objtmp, sizeof objtmp, fn, 1);
+                OBJ_obj2txt(objtmp, sizeof(objtmp), fn, 1);
                 fld_len = 0;    /* XXX: what should this be? */
                 objbuf = objtmp;
             } else {

--- a/thirdparty/openssl/crypto/asn1/a_time.c
+++ b/thirdparty/openssl/crypto/asn1/a_time.c
@@ -86,7 +86,7 @@ int i2d_ASN1_TIME(ASN1_TIME *a, unsigned char **pp)
         tmpstr = *(ASN1_STRING *)a;
         len = tmpstr.length;
         ebcdic2ascii(tmp, tmpstr.data,
-                     (len >= sizeof tmp) ? sizeof tmp : len);
+                     (len >= sizeof(tmp)) ? sizeof(tmp) : len);
         tmpstr.data = tmp;
         a = (ASN1_GENERALIZEDTIME *)&tmpstr;
     }

--- a/thirdparty/openssl/crypto/asn1/a_utctm.c
+++ b/thirdparty/openssl/crypto/asn1/a_utctm.c
@@ -76,7 +76,7 @@ int i2d_ASN1_UTCTIME(ASN1_UTCTIME *a, unsigned char **pp)
     ASN1_STRING x = *(ASN1_STRING *)a;
 
     len = x.length;
-    ebcdic2ascii(tmp, x.data, (len >= sizeof tmp) ? sizeof tmp : len);
+    ebcdic2ascii(tmp, x.data, (len >= sizeof(tmp)) ? sizeof(tmp) : len);
     x.data = tmp;
     return i2d_ASN1_bytes(&x, pp, V_ASN1_UTCTIME, V_ASN1_UNIVERSAL);
 # endif
@@ -317,7 +317,7 @@ time_t ASN1_UTCTIME_get(const ASN1_UTCTIME *s)
     struct tm tm;
     int offset;
 
-    memset(&tm, '\0', sizeof tm);
+    memset(&tm, '\0', sizeof(tm));
 
 # define g2(p) (((p)[0]-'0')*10+(p)[1]-'0')
     tm.tm_year = g2(s->data);

--- a/thirdparty/openssl/crypto/asn1/asn1_err.c
+++ b/thirdparty/openssl/crypto/asn1/asn1_err.c
@@ -1,6 +1,6 @@
 /* crypto/asn1/asn1_err.c */
 /* ====================================================================
- * Copyright (c) 1999-2014 The OpenSSL Project.  All rights reserved.
+ * Copyright (c) 1999-2018 The OpenSSL Project.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -279,6 +279,7 @@ static ERR_STRING_DATA ASN1_str_reasons[] = {
     {ERR_REASON(ASN1_R_MSTRING_NOT_UNIVERSAL), "mstring not universal"},
     {ERR_REASON(ASN1_R_MSTRING_WRONG_TAG), "mstring wrong tag"},
     {ERR_REASON(ASN1_R_NESTED_ASN1_STRING), "nested asn1 string"},
+    {ERR_REASON(ASN1_R_NESTED_TOO_DEEP), "nested too deep"},
     {ERR_REASON(ASN1_R_NON_HEX_CHARACTERS), "non hex characters"},
     {ERR_REASON(ASN1_R_NOT_ASCII_FORMAT), "not ascii format"},
     {ERR_REASON(ASN1_R_NOT_ENOUGH_DATA), "not enough data"},

--- a/thirdparty/openssl/crypto/asn1/asn1_lib.c
+++ b/thirdparty/openssl/crypto/asn1/asn1_lib.c
@@ -456,8 +456,8 @@ void asn1_add_error(const unsigned char *address, int offset)
 {
     char buf1[DECIMAL_SIZE(address) + 1], buf2[DECIMAL_SIZE(offset) + 1];
 
-    BIO_snprintf(buf1, sizeof buf1, "%lu", (unsigned long)address);
-    BIO_snprintf(buf2, sizeof buf2, "%d", offset);
+    BIO_snprintf(buf1, sizeof(buf1), "%lu", (unsigned long)address);
+    BIO_snprintf(buf2, sizeof(buf2), "%d", offset);
     ERR_add_error_data(4, "address=", buf1, " offset=", buf2);
 }
 

--- a/thirdparty/openssl/crypto/asn1/asn1_par.c
+++ b/thirdparty/openssl/crypto/asn1/asn1_par.c
@@ -87,13 +87,13 @@ static int asn1_print_info(BIO *bp, int tag, int xclass, int constructed,
 
     p = str;
     if ((xclass & V_ASN1_PRIVATE) == V_ASN1_PRIVATE)
-        BIO_snprintf(str, sizeof str, "priv [ %d ] ", tag);
+        BIO_snprintf(str, sizeof(str), "priv [ %d ] ", tag);
     else if ((xclass & V_ASN1_CONTEXT_SPECIFIC) == V_ASN1_CONTEXT_SPECIFIC)
-        BIO_snprintf(str, sizeof str, "cont [ %d ]", tag);
+        BIO_snprintf(str, sizeof(str), "cont [ %d ]", tag);
     else if ((xclass & V_ASN1_APPLICATION) == V_ASN1_APPLICATION)
-        BIO_snprintf(str, sizeof str, "appl [ %d ]", tag);
+        BIO_snprintf(str, sizeof(str), "appl [ %d ]", tag);
     else if (tag > 30)
-        BIO_snprintf(str, sizeof str, "<ASN1 %d>", tag);
+        BIO_snprintf(str, sizeof(str), "<ASN1 %d>", tag);
     else
         p = ASN1_tag2str(tag);
 

--- a/thirdparty/openssl/crypto/asn1/asn_mime.c
+++ b/thirdparty/openssl/crypto/asn1/asn_mime.c
@@ -4,7 +4,7 @@
  * project.
  */
 /* ====================================================================
- * Copyright (c) 1999-2008 The OpenSSL Project.  All rights reserved.
+ * Copyright (c) 1999-2018 The OpenSSL Project.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -473,6 +473,7 @@ ASN1_VALUE *SMIME_read_ASN1(BIO *bio, BIO **bcont, const ASN1_ITEM *it)
         if (!(hdr = mime_hdr_find(headers, "content-type")) || !hdr->value) {
             sk_MIME_HEADER_pop_free(headers, mime_hdr_free);
             ASN1err(ASN1_F_SMIME_READ_ASN1, ASN1_R_NO_SIG_CONTENT_TYPE);
+            sk_BIO_pop_free(parts, BIO_vfree);
             return NULL;
         }
 

--- a/thirdparty/openssl/crypto/asn1/t_x509a.c
+++ b/thirdparty/openssl/crypto/asn1/t_x509a.c
@@ -81,7 +81,7 @@ int X509_CERT_AUX_print(BIO *out, X509_CERT_AUX *aux, int indent)
                 BIO_puts(out, ", ");
             else
                 first = 0;
-            OBJ_obj2txt(oidstr, sizeof oidstr,
+            OBJ_obj2txt(oidstr, sizeof(oidstr),
                         sk_ASN1_OBJECT_value(aux->trust, i), 0);
             BIO_puts(out, oidstr);
         }
@@ -96,7 +96,7 @@ int X509_CERT_AUX_print(BIO *out, X509_CERT_AUX *aux, int indent)
                 BIO_puts(out, ", ");
             else
                 first = 0;
-            OBJ_obj2txt(oidstr, sizeof oidstr,
+            OBJ_obj2txt(oidstr, sizeof(oidstr),
                         sk_ASN1_OBJECT_value(aux->reject, i), 0);
             BIO_puts(out, oidstr);
         }

--- a/thirdparty/openssl/crypto/asn1/tasn_dec.c
+++ b/thirdparty/openssl/crypto/asn1/tasn_dec.c
@@ -4,7 +4,7 @@
  * 2000.
  */
 /* ====================================================================
- * Copyright (c) 2000-2005 The OpenSSL Project.  All rights reserved.
+ * Copyright (c) 2000-2018 The OpenSSL Project.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -65,6 +65,14 @@
 #include <openssl/buffer.h>
 #include <openssl/err.h>
 
+/*
+ * Constructed types with a recursive definition (such as can be found in PKCS7)
+ * could eventually exceed the stack given malicious input with excessive
+ * recursion. Therefore we limit the stack depth. This is the maximum number of
+ * recursive invocations of asn1_item_embed_d2i().
+ */
+#define ASN1_MAX_CONSTRUCTED_NEST 30
+
 static int asn1_check_eoc(const unsigned char **in, long len);
 static int asn1_find_end(const unsigned char **in, long len, char inf);
 
@@ -81,11 +89,11 @@ static int asn1_check_tlen(long *olen, int *otag, unsigned char *oclass,
 static int asn1_template_ex_d2i(ASN1_VALUE **pval,
                                 const unsigned char **in, long len,
                                 const ASN1_TEMPLATE *tt, char opt,
-                                ASN1_TLC *ctx);
+                                ASN1_TLC *ctx, int depth);
 static int asn1_template_noexp_d2i(ASN1_VALUE **val,
                                    const unsigned char **in, long len,
                                    const ASN1_TEMPLATE *tt, char opt,
-                                   ASN1_TLC *ctx);
+                                   ASN1_TLC *ctx, int depth);
 static int asn1_d2i_ex_primitive(ASN1_VALUE **pval,
                                  const unsigned char **in, long len,
                                  const ASN1_ITEM *it,
@@ -154,17 +162,16 @@ int ASN1_template_d2i(ASN1_VALUE **pval,
 {
     ASN1_TLC c;
     asn1_tlc_clear_nc(&c);
-    return asn1_template_ex_d2i(pval, in, len, tt, 0, &c);
+    return asn1_template_ex_d2i(pval, in, len, tt, 0, &c, 0);
 }
 
 /*
  * Decode an item, taking care of IMPLICIT tagging, if any. If 'opt' set and
  * tag mismatch return -1 to handle OPTIONAL
  */
-
-int ASN1_item_ex_d2i(ASN1_VALUE **pval, const unsigned char **in, long len,
-                     const ASN1_ITEM *it,
-                     int tag, int aclass, char opt, ASN1_TLC *ctx)
+static int asn1_item_ex_d2i(ASN1_VALUE **pval, const unsigned char **in,
+                            long len, const ASN1_ITEM *it, int tag, int aclass,
+                            char opt, ASN1_TLC *ctx, int depth)
 {
     const ASN1_TEMPLATE *tt, *errtt = NULL;
     const ASN1_COMPAT_FUNCS *cf;
@@ -189,6 +196,11 @@ int ASN1_item_ex_d2i(ASN1_VALUE **pval, const unsigned char **in, long len,
     else
         asn1_cb = 0;
 
+    if (++depth > ASN1_MAX_CONSTRUCTED_NEST) {
+        ASN1err(ASN1_F_ASN1_ITEM_EX_D2I, ASN1_R_NESTED_TOO_DEEP);
+        goto err;
+    }
+
     switch (it->itype) {
     case ASN1_ITYPE_PRIMITIVE:
         if (it->templates) {
@@ -204,7 +216,7 @@ int ASN1_item_ex_d2i(ASN1_VALUE **pval, const unsigned char **in, long len,
                 goto err;
             }
             return asn1_template_ex_d2i(pval, in, len,
-                                        it->templates, opt, ctx);
+                                        it->templates, opt, ctx, depth);
         }
         return asn1_d2i_ex_primitive(pval, in, len, it,
                                      tag, aclass, opt, ctx);
@@ -326,7 +338,7 @@ int ASN1_item_ex_d2i(ASN1_VALUE **pval, const unsigned char **in, long len,
             /*
              * We mark field as OPTIONAL so its absence can be recognised.
              */
-            ret = asn1_template_ex_d2i(pchptr, &p, len, tt, 1, ctx);
+            ret = asn1_template_ex_d2i(pchptr, &p, len, tt, 1, ctx, depth);
             /* If field not present, try the next one */
             if (ret == -1)
                 continue;
@@ -444,7 +456,8 @@ int ASN1_item_ex_d2i(ASN1_VALUE **pval, const unsigned char **in, long len,
              * attempt to read in field, allowing each to be OPTIONAL
              */
 
-            ret = asn1_template_ex_d2i(pseqval, &p, len, seqtt, isopt, ctx);
+            ret = asn1_template_ex_d2i(pseqval, &p, len, seqtt, isopt, ctx,
+                                       depth);
             if (!ret) {
                 errtt = seqtt;
                 goto err;
@@ -514,6 +527,13 @@ int ASN1_item_ex_d2i(ASN1_VALUE **pval, const unsigned char **in, long len,
     return 0;
 }
 
+int ASN1_item_ex_d2i(ASN1_VALUE **pval, const unsigned char **in, long len,
+                     const ASN1_ITEM *it,
+                     int tag, int aclass, char opt, ASN1_TLC *ctx)
+{
+    return asn1_item_ex_d2i(pval, in, len, it, tag, aclass, opt, ctx, 0);
+}
+
 /*
  * Templates are handled with two separate functions. One handles any
  * EXPLICIT tag and the other handles the rest.
@@ -522,7 +542,7 @@ int ASN1_item_ex_d2i(ASN1_VALUE **pval, const unsigned char **in, long len,
 static int asn1_template_ex_d2i(ASN1_VALUE **val,
                                 const unsigned char **in, long inlen,
                                 const ASN1_TEMPLATE *tt, char opt,
-                                ASN1_TLC *ctx)
+                                ASN1_TLC *ctx, int depth)
 {
     int flags, aclass;
     int ret;
@@ -557,7 +577,7 @@ static int asn1_template_ex_d2i(ASN1_VALUE **val,
             return 0;
         }
         /* We've found the field so it can't be OPTIONAL now */
-        ret = asn1_template_noexp_d2i(val, &p, len, tt, 0, ctx);
+        ret = asn1_template_noexp_d2i(val, &p, len, tt, 0, ctx, depth);
         if (!ret) {
             ASN1err(ASN1_F_ASN1_TEMPLATE_EX_D2I, ERR_R_NESTED_ASN1_ERROR);
             return 0;
@@ -581,7 +601,7 @@ static int asn1_template_ex_d2i(ASN1_VALUE **val,
             }
         }
     } else
-        return asn1_template_noexp_d2i(val, in, inlen, tt, opt, ctx);
+        return asn1_template_noexp_d2i(val, in, inlen, tt, opt, ctx, depth);
 
     *in = p;
     return 1;
@@ -594,7 +614,7 @@ static int asn1_template_ex_d2i(ASN1_VALUE **val,
 static int asn1_template_noexp_d2i(ASN1_VALUE **val,
                                    const unsigned char **in, long len,
                                    const ASN1_TEMPLATE *tt, char opt,
-                                   ASN1_TLC *ctx)
+                                   ASN1_TLC *ctx, int depth)
 {
     int flags, aclass;
     int ret;
@@ -665,8 +685,8 @@ static int asn1_template_noexp_d2i(ASN1_VALUE **val,
                 break;
             }
             skfield = NULL;
-            if (!ASN1_item_ex_d2i(&skfield, &p, len,
-                                  ASN1_ITEM_ptr(tt->item), -1, 0, 0, ctx)) {
+            if (!asn1_item_ex_d2i(&skfield, &p, len, ASN1_ITEM_ptr(tt->item),
+                                  -1, 0, 0, ctx, depth)) {
                 ASN1err(ASN1_F_ASN1_TEMPLATE_NOEXP_D2I,
                         ERR_R_NESTED_ASN1_ERROR);
                 goto err;
@@ -684,9 +704,8 @@ static int asn1_template_noexp_d2i(ASN1_VALUE **val,
         }
     } else if (flags & ASN1_TFLG_IMPTAG) {
         /* IMPLICIT tagging */
-        ret = ASN1_item_ex_d2i(val, &p, len,
-                               ASN1_ITEM_ptr(tt->item), tt->tag, aclass, opt,
-                               ctx);
+        ret = asn1_item_ex_d2i(val, &p, len, ASN1_ITEM_ptr(tt->item), tt->tag,
+                               aclass, opt, ctx, depth);
         if (!ret) {
             ASN1err(ASN1_F_ASN1_TEMPLATE_NOEXP_D2I, ERR_R_NESTED_ASN1_ERROR);
             goto err;
@@ -694,8 +713,9 @@ static int asn1_template_noexp_d2i(ASN1_VALUE **val,
             return -1;
     } else {
         /* Nothing special */
-        ret = ASN1_item_ex_d2i(val, &p, len, ASN1_ITEM_ptr(tt->item),
-                               -1, tt->flags & ASN1_TFLG_COMBINE, opt, ctx);
+        ret = asn1_item_ex_d2i(val, &p, len, ASN1_ITEM_ptr(tt->item),
+                               -1, tt->flags & ASN1_TFLG_COMBINE, opt, ctx,
+                               depth);
         if (!ret) {
             ASN1err(ASN1_F_ASN1_TEMPLATE_NOEXP_D2I, ERR_R_NESTED_ASN1_ERROR);
             goto err;

--- a/thirdparty/openssl/crypto/asn1/tasn_prn.c
+++ b/thirdparty/openssl/crypto/asn1/tasn_prn.c
@@ -463,7 +463,7 @@ static int asn1_print_oid_ctx(BIO *out, const ASN1_OBJECT *oid,
     ln = OBJ_nid2ln(OBJ_obj2nid(oid));
     if (!ln)
         ln = "";
-    OBJ_obj2txt(objbuf, sizeof objbuf, oid, 1);
+    OBJ_obj2txt(objbuf, sizeof(objbuf), oid, 1);
     if (BIO_printf(out, "%s (%s)", ln, objbuf) <= 0)
         return 0;
     return 1;

--- a/thirdparty/openssl/crypto/bio/b_dump.c
+++ b/thirdparty/openssl/crypto/bio/b_dump.c
@@ -64,7 +64,6 @@
 #include "cryptlib.h"
 #include "bio_lcl.h"
 
-#define TRUNCATE
 #define DUMP_WIDTH      16
 #define DUMP_WIDTH_LESS_INDENT(i) (DUMP_WIDTH-((i-(i>6?6:i)+3)/4))
 
@@ -79,16 +78,9 @@ int BIO_dump_indent_cb(int (*cb) (const void *data, size_t len, void *u),
 {
     int ret = 0;
     char buf[288 + 1], tmp[20], str[128 + 1];
-    int i, j, rows, trc;
+    int i, j, rows;
     unsigned char ch;
     int dump_width;
-
-    trc = 0;
-
-#ifdef TRUNCATE
-    for (; (len > 0) && ((s[len - 1] == ' ') || (s[len - 1] == '\0')); len--)
-        trc++;
-#endif
 
     if (indent < 0)
         indent = 0;
@@ -104,50 +96,43 @@ int BIO_dump_indent_cb(int (*cb) (const void *data, size_t len, void *u),
     if ((rows * dump_width) < len)
         rows++;
     for (i = 0; i < rows; i++) {
-        BUF_strlcpy(buf, str, sizeof buf);
-        BIO_snprintf(tmp, sizeof tmp, "%04x - ", i * dump_width);
-        BUF_strlcat(buf, tmp, sizeof buf);
+        BUF_strlcpy(buf, str, sizeof(buf));
+        BIO_snprintf(tmp, sizeof(tmp), "%04x - ", i * dump_width);
+        BUF_strlcat(buf, tmp, sizeof(buf));
         for (j = 0; j < dump_width; j++) {
             if (((i * dump_width) + j) >= len) {
-                BUF_strlcat(buf, "   ", sizeof buf);
+                BUF_strlcat(buf, "   ", sizeof(buf));
             } else {
                 ch = ((unsigned char)*(s + i * dump_width + j)) & 0xff;
-                BIO_snprintf(tmp, sizeof tmp, "%02x%c", ch,
+                BIO_snprintf(tmp, sizeof(tmp), "%02x%c", ch,
                              j == 7 ? '-' : ' ');
-                BUF_strlcat(buf, tmp, sizeof buf);
+                BUF_strlcat(buf, tmp, sizeof(buf));
             }
         }
-        BUF_strlcat(buf, "  ", sizeof buf);
+        BUF_strlcat(buf, "  ", sizeof(buf));
         for (j = 0; j < dump_width; j++) {
             if (((i * dump_width) + j) >= len)
                 break;
             ch = ((unsigned char)*(s + i * dump_width + j)) & 0xff;
 #ifndef CHARSET_EBCDIC
-            BIO_snprintf(tmp, sizeof tmp, "%c",
+            BIO_snprintf(tmp, sizeof(tmp), "%c",
                          ((ch >= ' ') && (ch <= '~')) ? ch : '.');
 #else
-            BIO_snprintf(tmp, sizeof tmp, "%c",
+            BIO_snprintf(tmp, sizeof(tmp), "%c",
                          ((ch >= os_toascii[' ']) && (ch <= os_toascii['~']))
                          ? os_toebcdic[ch]
                          : '.');
 #endif
-            BUF_strlcat(buf, tmp, sizeof buf);
+            BUF_strlcat(buf, tmp, sizeof(buf));
         }
-        BUF_strlcat(buf, "\n", sizeof buf);
+        BUF_strlcat(buf, "\n", sizeof(buf));
         /*
          * if this is the last call then update the ddt_dump thing so that we
          * will move the selection point in the debug window
          */
         ret += cb((void *)buf, strlen(buf), u);
     }
-#ifdef TRUNCATE
-    if (trc > 0) {
-        BIO_snprintf(buf, sizeof buf, "%s%04x - <SPACES/NULS>\n", str,
-                     len + trc);
-        ret += cb((void *)buf, strlen(buf), u);
-    }
-#endif
-    return (ret);
+    return ret;
 }
 
 #ifndef OPENSSL_NO_FP_API

--- a/thirdparty/openssl/crypto/bio/b_print.c
+++ b/thirdparty/openssl/crypto/bio/b_print.c
@@ -663,7 +663,7 @@ fmtfp(char **sbuffer,
         iconvert[iplace++] = "0123456789"[intpart % 10];
         intpart = (intpart / 10);
     } while (intpart && (iplace < (int)sizeof(iconvert)));
-    if (iplace == sizeof iconvert)
+    if (iplace == sizeof(iconvert))
         iplace--;
     iconvert[iplace] = 0;
 
@@ -672,7 +672,7 @@ fmtfp(char **sbuffer,
         fconvert[fplace++] = "0123456789"[fracpart % 10];
         fracpart = (fracpart / 10);
     } while (fplace < max);
-    if (fplace == sizeof fconvert)
+    if (fplace == sizeof(fconvert))
         fplace--;
     fconvert[fplace] = 0;
 

--- a/thirdparty/openssl/crypto/bio/bio_cb.c
+++ b/thirdparty/openssl/crypto/bio/bio_cb.c
@@ -76,7 +76,7 @@ long MS_CALLBACK BIO_debug_callback(BIO *bio, int cmd, const char *argp,
     if (BIO_CB_RETURN & cmd)
         r = ret;
 
-    len = BIO_snprintf(buf,sizeof buf,"BIO[%p]: ",(void *)bio);
+    len = BIO_snprintf(buf,sizeof(buf),"BIO[%p]: ",(void *)bio);
 
     /* Ignore errors and continue printing the other information. */
     if (len < 0)

--- a/thirdparty/openssl/crypto/bio/bss_bio.c
+++ b/thirdparty/openssl/crypto/bio/bss_bio.c
@@ -144,7 +144,7 @@ static int bio_new(BIO *bio)
 {
     struct bio_bio_st *b;
 
-    b = OPENSSL_malloc(sizeof *b);
+    b = OPENSSL_malloc(sizeof(*b));
     if (b == NULL)
         return 0;
 

--- a/thirdparty/openssl/crypto/bio/bss_conn.c
+++ b/thirdparty/openssl/crypto/bio/bss_conn.c
@@ -481,7 +481,7 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
                 char buf[16];
                 unsigned char *p = ptr;
 
-                BIO_snprintf(buf, sizeof buf, "%d.%d.%d.%d",
+                BIO_snprintf(buf, sizeof(buf), "%d.%d.%d.%d",
                              p[0], p[1], p[2], p[3]);
                 if (data->param_hostname != NULL)
                     OPENSSL_free(data->param_hostname);
@@ -490,7 +490,7 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
             } else if (num == 3) {
                 char buf[DECIMAL_SIZE(int) + 1];
 
-                BIO_snprintf(buf, sizeof buf, "%d", *(int *)ptr);
+                BIO_snprintf(buf, sizeof(buf), "%d", *(int *)ptr);
                 if (data->param_port != NULL)
                     OPENSSL_free(data->param_port);
                 data->param_port = BUF_strdup(buf);

--- a/thirdparty/openssl/crypto/bio/bss_file.c
+++ b/thirdparty/openssl/crypto/bio/bss_file.c
@@ -375,15 +375,15 @@ static long MS_CALLBACK file_ctrl(BIO *b, int cmd, long num, void *ptr)
         b->shutdown = (int)num & BIO_CLOSE;
         if (num & BIO_FP_APPEND) {
             if (num & BIO_FP_READ)
-                BUF_strlcpy(p, "a+", sizeof p);
+                BUF_strlcpy(p, "a+", sizeof(p));
             else
-                BUF_strlcpy(p, "a", sizeof p);
+                BUF_strlcpy(p, "a", sizeof(p));
         } else if ((num & BIO_FP_READ) && (num & BIO_FP_WRITE))
-            BUF_strlcpy(p, "r+", sizeof p);
+            BUF_strlcpy(p, "r+", sizeof(p));
         else if (num & BIO_FP_WRITE)
-            BUF_strlcpy(p, "w", sizeof p);
+            BUF_strlcpy(p, "w", sizeof(p));
         else if (num & BIO_FP_READ)
-            BUF_strlcpy(p, "r", sizeof p);
+            BUF_strlcpy(p, "r", sizeof(p));
         else {
             BIOerr(BIO_F_FILE_CTRL, BIO_R_BAD_FOPEN_MODE);
             ret = 0;

--- a/thirdparty/openssl/crypto/bn/bn_exp.c
+++ b/thirdparty/openssl/crypto/bn/bn_exp.c
@@ -56,7 +56,7 @@
  * [including the GNU Public Licence.]
  */
 /* ====================================================================
- * Copyright (c) 1998-2005 The OpenSSL Project.  All rights reserved.
+ * Copyright (c) 1998-2018 The OpenSSL Project.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -727,7 +727,11 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
 
     top = m->top;
 
-    bits = BN_num_bits(p);
+    /*
+     * Use all bits stored in |p|, rather than |BN_num_bits|, so we do not leak
+     * whether the top bits are zero.
+     */
+    bits = p->top * BN_BITS2;
     if (bits == 0) {
         /* x**0 mod 1 is still zero. */
         if (BN_is_one(m)) {

--- a/thirdparty/openssl/crypto/bn/bn_print.c
+++ b/thirdparty/openssl/crypto/bn/bn_print.c
@@ -391,10 +391,10 @@ char *BN_options(void)
     if (!init) {
         init++;
 #ifdef BN_LLONG
-        BIO_snprintf(data, sizeof data, "bn(%d,%d)",
+        BIO_snprintf(data, sizeof(data), "bn(%d,%d)",
                      (int)sizeof(BN_ULLONG) * 8, (int)sizeof(BN_ULONG) * 8);
 #else
-        BIO_snprintf(data, sizeof data, "bn(%d,%d)",
+        BIO_snprintf(data, sizeof(data), "bn(%d,%d)",
                      (int)sizeof(BN_ULONG) * 8, (int)sizeof(BN_ULONG) * 8);
 #endif
     }

--- a/thirdparty/openssl/crypto/bn/expspeed.c
+++ b/thirdparty/openssl/crypto/bn/expspeed.c
@@ -198,7 +198,7 @@ static int mul_c[NUM_SIZES] =
  * static int sizes[NUM_SIZES]={59,179,299,419,539};
  */
 
-#define RAND_SEED(string) { const char str[] = string; RAND_seed(string, sizeof str); }
+#define RAND_SEED(string) { const char str[] = string; RAND_seed(string, sizeof(str)); }
 
 void do_mul_exp(BIGNUM *r, BIGNUM *a, BIGNUM *b, BIGNUM *c, BN_CTX *ctx);
 

--- a/thirdparty/openssl/crypto/conf/conf_def.c
+++ b/thirdparty/openssl/crypto/conf/conf_def.c
@@ -423,7 +423,7 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
         OPENSSL_free(section);
     if (line != NULL)
         *line = eline;
-    BIO_snprintf(btmp, sizeof btmp, "%ld", eline);
+    BIO_snprintf(btmp, sizeof(btmp), "%ld", eline);
     ERR_add_error_data(2, "line ", btmp);
     if ((h != conf->data) && (conf->data != NULL)) {
         CONF_free(conf->data);

--- a/thirdparty/openssl/crypto/conf/conf_mod.c
+++ b/thirdparty/openssl/crypto/conf/conf_mod.c
@@ -221,7 +221,7 @@ static int module_run(const CONF *cnf, char *name, char *value,
         if (!(flags & CONF_MFLAGS_SILENT)) {
             char rcode[DECIMAL_SIZE(ret) + 1];
             CONFerr(CONF_F_MODULE_RUN, CONF_R_MODULE_INITIALIZATION_ERROR);
-            BIO_snprintf(rcode, sizeof rcode, "%-8d", ret);
+            BIO_snprintf(rcode, sizeof(rcode), "%-8d", ret);
             ERR_add_error_data(6, "module=", name, ", value=", value,
                                ", retcode=", rcode);
         }

--- a/thirdparty/openssl/crypto/des/ecb_enc.c
+++ b/thirdparty/openssl/crypto/des/ecb_enc.c
@@ -96,7 +96,7 @@ const char *DES_options(void)
             size = "int";
         else
             size = "long";
-        BIO_snprintf(buf, sizeof buf, "des(%s,%s,%s,%s)", ptr, risc, unroll,
+        BIO_snprintf(buf, sizeof(buf), "des(%s,%s,%s,%s)", ptr, risc, unroll,
                      size);
         init = 0;
     }

--- a/thirdparty/openssl/crypto/des/fcrypt.c
+++ b/thirdparty/openssl/crypto/des/fcrypt.c
@@ -80,10 +80,10 @@ char *DES_crypt(const char *buf, const char *salt)
     e_salt[sizeof(e_salt) - 1] = e_buf[sizeof(e_buf) - 1] = '\0';
 
     /* Convert the e_salt to ASCII, as that's what DES_fcrypt works on */
-    ebcdic2ascii(e_salt, e_salt, sizeof e_salt);
+    ebcdic2ascii(e_salt, e_salt, sizeof(e_salt));
 
     /* Convert the cleartext password to ASCII */
-    ebcdic2ascii(e_buf, e_buf, sizeof e_buf);
+    ebcdic2ascii(e_buf, e_buf, sizeof(e_buf));
 
     /* Encrypt it (from/to ASCII) */
     ret = DES_fcrypt(e_buf, e_salt, buff);

--- a/thirdparty/openssl/crypto/des/read_pwd.c
+++ b/thirdparty/openssl/crypto/des/read_pwd.c
@@ -434,7 +434,7 @@ static void pushsig(void)
 # ifdef SIGACTION
     struct sigaction sa;
 
-    memset(&sa, 0, sizeof sa);
+    memset(&sa, 0, sizeof(sa));
     sa.sa_handler = recsig;
 # endif
 

--- a/thirdparty/openssl/crypto/des/set_key.c
+++ b/thirdparty/openssl/crypto/des/set_key.c
@@ -377,7 +377,7 @@ void private_DES_set_key_unchecked(const_DES_cblock *key,
     register int i;
 
 #ifdef OPENBSD_DEV_CRYPTO
-    memcpy(schedule->key, key, sizeof schedule->key);
+    memcpy(schedule->key, key, sizeof(schedule->key));
     schedule->session = NULL;
 #endif
     k = &schedule->ks->deslong[0];

--- a/thirdparty/openssl/crypto/ec/ec_lib.c
+++ b/thirdparty/openssl/crypto/ec/ec_lib.c
@@ -85,7 +85,7 @@ EC_GROUP *EC_GROUP_new(const EC_METHOD *meth)
         return NULL;
     }
 
-    ret = OPENSSL_malloc(sizeof *ret);
+    ret = OPENSSL_malloc(sizeof(*ret));
     if (ret == NULL) {
         ECerr(EC_F_EC_GROUP_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;
@@ -164,7 +164,7 @@ void EC_GROUP_clear_free(EC_GROUP *group)
         OPENSSL_free(group->seed);
     }
 
-    OPENSSL_cleanse(group, sizeof *group);
+    OPENSSL_cleanse(group, sizeof(*group));
     OPENSSL_free(group);
 }
 
@@ -575,7 +575,7 @@ int EC_EX_DATA_set_data(EC_EXTRA_DATA **ex_data, void *data,
         /* no explicit entry needed */
         return 1;
 
-    d = OPENSSL_malloc(sizeof *d);
+    d = OPENSSL_malloc(sizeof(*d));
     if (d == NULL)
         return 0;
 
@@ -712,7 +712,7 @@ EC_POINT *EC_POINT_new(const EC_GROUP *group)
         return NULL;
     }
 
-    ret = OPENSSL_malloc(sizeof *ret);
+    ret = OPENSSL_malloc(sizeof(*ret));
     if (ret == NULL) {
         ECerr(EC_F_EC_POINT_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;
@@ -747,7 +747,7 @@ void EC_POINT_clear_free(EC_POINT *point)
         point->meth->point_clear_finish(point);
     else if (point->meth->point_finish != 0)
         point->meth->point_finish(point);
-    OPENSSL_cleanse(point, sizeof *point);
+    OPENSSL_cleanse(point, sizeof(*point));
     OPENSSL_free(point);
 }
 

--- a/thirdparty/openssl/crypto/ec/ec_mult.c
+++ b/thirdparty/openssl/crypto/ec/ec_mult.c
@@ -169,11 +169,11 @@ static void ec_pre_comp_clear_free(void *pre_)
 
         for (p = pre->points; *p != NULL; p++) {
             EC_POINT_clear_free(*p);
-            OPENSSL_cleanse(p, sizeof *p);
+            OPENSSL_cleanse(p, sizeof(*p));
         }
         OPENSSL_free(pre->points);
     }
-    OPENSSL_cleanse(pre, sizeof *pre);
+    OPENSSL_cleanse(pre, sizeof(*pre));
     OPENSSL_free(pre);
 }
 
@@ -430,11 +430,11 @@ int ec_wNAF_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
 
     totalnum = num + numblocks;
 
-    wsize = OPENSSL_malloc(totalnum * sizeof wsize[0]);
-    wNAF_len = OPENSSL_malloc(totalnum * sizeof wNAF_len[0]);
-    wNAF = OPENSSL_malloc((totalnum + 1) * sizeof wNAF[0]); /* includes space
-                                                             * for pivot */
-    val_sub = OPENSSL_malloc(totalnum * sizeof val_sub[0]);
+    wsize = OPENSSL_malloc(totalnum * sizeof(wsize[0]));
+    wNAF_len = OPENSSL_malloc(totalnum * sizeof(wNAF_len[0]));
+    /* include space for pivot */
+    wNAF = OPENSSL_malloc((totalnum + 1) * sizeof(wNAF[0]));
+    val_sub = OPENSSL_malloc(totalnum * sizeof(val_sub[0]));
 
     /* Ensure wNAF is initialised in case we end up going to err */
     if (wNAF)
@@ -580,7 +580,7 @@ int ec_wNAF_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
      * 'val_sub[i]' is a pointer to the subarray for the i-th point, or to a
      * subarray of 'pre_comp->points' if we already have precomputation.
      */
-    val = OPENSSL_malloc((num_val + 1) * sizeof val[0]);
+    val = OPENSSL_malloc((num_val + 1) * sizeof(val[0]));
     if (val == NULL) {
         ECerr(EC_F_EC_WNAF_MUL, ERR_R_MALLOC_FAILURE);
         goto err;

--- a/thirdparty/openssl/crypto/ec/ecp_nistp224.c
+++ b/thirdparty/openssl/crypto/ec/ecp_nistp224.c
@@ -48,7 +48,6 @@ typedef __uint128_t uint128_t;  /* nonstandard; implemented by gcc on 64-bit
 
 typedef uint8_t u8;
 typedef uint64_t u64;
-typedef int64_t s64;
 
 /******************************************************************************/
 /*-
@@ -351,9 +350,9 @@ static int BN_to_felem(felem out, const BIGNUM *bn)
     unsigned num_bytes;
 
     /* BN_bn2bin eats leading zeroes */
-    memset(b_out, 0, sizeof b_out);
+    memset(b_out, 0, sizeof(b_out));
     num_bytes = BN_num_bytes(bn);
-    if (num_bytes > sizeof b_out) {
+    if (num_bytes > sizeof(b_out)) {
         ECerr(EC_F_BN_TO_FELEM, EC_R_BIGNUM_OUT_OF_RANGE);
         return 0;
     }
@@ -372,8 +371,8 @@ static BIGNUM *felem_to_BN(BIGNUM *out, const felem in)
 {
     felem_bytearray b_in, b_out;
     felem_to_bin28(b_in, in);
-    flip_endian(b_out, b_in, sizeof b_out);
-    return BN_bin2bn(b_out, sizeof b_out, out);
+    flip_endian(b_out, b_in, sizeof(b_out));
+    return BN_bin2bn(b_out, sizeof(b_out), out);
 }
 
 /******************************************************************************/
@@ -1234,7 +1233,7 @@ static void batch_mul(felem x_out, felem y_out, felem z_out,
 static NISTP224_PRE_COMP *nistp224_pre_comp_new()
 {
     NISTP224_PRE_COMP *ret = NULL;
-    ret = (NISTP224_PRE_COMP *) OPENSSL_malloc(sizeof *ret);
+    ret = (NISTP224_PRE_COMP *) OPENSSL_malloc(sizeof(*ret));
     if (!ret) {
         ECerr(EC_F_NISTP224_PRE_COMP_NEW, ERR_R_MALLOC_FAILURE);
         return ret;
@@ -1281,7 +1280,7 @@ static void nistp224_pre_comp_clear_free(void *pre_)
     if (i > 0)
         return;
 
-    OPENSSL_cleanse(pre, sizeof *pre);
+    OPENSSL_cleanse(pre, sizeof(*pre));
     OPENSSL_free(pre);
 }
 
@@ -1568,7 +1567,7 @@ int ec_GFp_nistp224_points_mul(const EC_GROUP *group, EC_POINT *r,
 
     /* the scalar for the generator */
     if ((scalar != NULL) && (have_pre_comp)) {
-        memset(g_secret, 0, sizeof g_secret);
+        memset(g_secret, 0, sizeof(g_secret));
         /* reduce scalar to 0 <= scalar < 2^224 */
         if ((BN_num_bits(scalar) > 224) || (BN_is_negative(scalar))) {
             /*

--- a/thirdparty/openssl/crypto/ec/ecp_nistp521.c
+++ b/thirdparty/openssl/crypto/ec/ecp_nistp521.c
@@ -49,7 +49,6 @@ typedef __uint128_t uint128_t;  /* nonstandard; implemented by gcc on 64-bit
 
 typedef uint8_t u8;
 typedef uint64_t u64;
-typedef int64_t s64;
 
 /*
  * The underlying field. P521 operates over GF(2^521-1). We can serialise an
@@ -185,9 +184,9 @@ static int BN_to_felem(felem out, const BIGNUM *bn)
     unsigned num_bytes;
 
     /* BN_bn2bin eats leading zeroes */
-    memset(b_out, 0, sizeof b_out);
+    memset(b_out, 0, sizeof(b_out));
     num_bytes = BN_num_bytes(bn);
-    if (num_bytes > sizeof b_out) {
+    if (num_bytes > sizeof(b_out)) {
         ECerr(EC_F_BN_TO_FELEM, EC_R_BIGNUM_OUT_OF_RANGE);
         return 0;
     }
@@ -206,8 +205,8 @@ static BIGNUM *felem_to_BN(BIGNUM *out, const felem in)
 {
     felem_bytearray b_in, b_out;
     felem_to_bin66(b_in, in);
-    flip_endian(b_out, b_in, sizeof b_out);
-    return BN_bin2bn(b_out, sizeof b_out, out);
+    flip_endian(b_out, b_in, sizeof(b_out));
+    return BN_bin2bn(b_out, sizeof(b_out), out);
 }
 
 /*-
@@ -852,7 +851,7 @@ static limb felem_is_zero(const felem in)
      * We know that ftmp[i] < 2^63, therefore the only way that the top bit
      * can be set is if is_zero was 0 before the decrement.
      */
-    is_zero = ((s64) is_zero) >> 63;
+    is_zero = 0 - (is_zero >> 63);
 
     is_p = ftmp[0] ^ kPrime[0];
     is_p |= ftmp[1] ^ kPrime[1];
@@ -865,7 +864,7 @@ static limb felem_is_zero(const felem in)
     is_p |= ftmp[8] ^ kPrime[8];
 
     is_p--;
-    is_p = ((s64) is_p) >> 63;
+    is_p = 0 - (is_p >> 63);
 
     is_zero |= is_p;
     return is_zero;
@@ -936,7 +935,7 @@ static void felem_contract(felem out, const felem in)
     is_p &= is_p << 4;
     is_p &= is_p << 2;
     is_p &= is_p << 1;
-    is_p = ((s64) is_p) >> 63;
+    is_p = 0 - (is_p >> 63);
     is_p = ~is_p;
 
     /* is_p is 0 iff |out| == 2^521-1 and all ones otherwise */
@@ -962,7 +961,7 @@ static void felem_contract(felem out, const felem in)
     is_greater |= is_greater << 4;
     is_greater |= is_greater << 2;
     is_greater |= is_greater << 1;
-    is_greater = ((s64) is_greater) >> 63;
+    is_greater = 0 - (is_greater >> 63);
 
     out[0] -= kPrime[0] & is_greater;
     out[1] -= kPrime[1] & is_greater;

--- a/thirdparty/openssl/crypto/ec/ecp_nistz256.c
+++ b/thirdparty/openssl/crypto/ec/ecp_nistz256.c
@@ -1504,7 +1504,7 @@ static void ecp_nistz256_pre_comp_clear_free(void *pre_)
                         32 * sizeof(unsigned char) * (1 << pre->w) * 2 * 37);
         OPENSSL_free(pre->precomp_storage);
     }
-    OPENSSL_cleanse(pre, sizeof *pre);
+    OPENSSL_cleanse(pre, sizeof(*pre));
     OPENSSL_free(pre);
 }
 

--- a/thirdparty/openssl/crypto/ec/ecp_smpl.c
+++ b/thirdparty/openssl/crypto/ec/ecp_smpl.c
@@ -1270,7 +1270,7 @@ int ec_GFp_simple_points_make_affine(const EC_GROUP *group, size_t num,
     if (tmp == NULL || tmp_Z == NULL)
         goto err;
 
-    prod_Z = OPENSSL_malloc(num * sizeof prod_Z[0]);
+    prod_Z = OPENSSL_malloc(num * sizeof(prod_Z[0]));
     if (prod_Z == NULL)
         goto err;
     for (i = 0; i < num; i++) {

--- a/thirdparty/openssl/crypto/engine/eng_cryptodev.c
+++ b/thirdparty/openssl/crypto/engine/eng_cryptodev.c
@@ -1057,7 +1057,7 @@ static int crparam2bn(struct crparam *crp, BIGNUM *a)
         return (-1);
 
     for (i = 0; i < bytes; i++)
-        pd[i] = crp->crp_p[bytes - i - 1];
+        pd[i] = ((char *)crp->crp_p)[bytes - i - 1];
 
     BN_bin2bn(pd, bytes, a);
     free(pd);
@@ -1133,7 +1133,7 @@ cryptodev_bn_mod_exp(BIGNUM *r, const BIGNUM *a, const BIGNUM *p,
         return (ret);
     }
 
-    memset(&kop, 0, sizeof kop);
+    memset(&kop, 0, sizeof(kop));
     kop.crk_op = CRK_MOD_EXP;
 
     /* inputs: a^p % m */
@@ -1184,7 +1184,7 @@ cryptodev_rsa_mod_exp(BIGNUM *r0, const BIGNUM *I, RSA *rsa, BN_CTX *ctx)
         return (0);
     }
 
-    memset(&kop, 0, sizeof kop);
+    memset(&kop, 0, sizeof(kop));
     kop.crk_op = CRK_MOD_EXP_CRT;
     /* inputs: rsa->p rsa->q I rsa->dmp1 rsa->dmq1 rsa->iqmp */
     if (bn2crparam(rsa->p, &kop.crk_param[0]))
@@ -1287,7 +1287,7 @@ static DSA_SIG *cryptodev_dsa_do_sign(const unsigned char *dgst, int dlen,
         goto err;
     }
 
-    memset(&kop, 0, sizeof kop);
+    memset(&kop, 0, sizeof(kop));
     kop.crk_op = CRK_DSA_SIGN;
 
     /* inputs: dgst dsa->p dsa->q dsa->g dsa->priv_key */
@@ -1330,7 +1330,7 @@ cryptodev_dsa_verify(const unsigned char *dgst, int dlen,
     struct crypt_kop kop;
     int dsaret = 1;
 
-    memset(&kop, 0, sizeof kop);
+    memset(&kop, 0, sizeof(kop));
     kop.crk_op = CRK_DSA_VERIFY;
 
     /* inputs: dgst dsa->p dsa->q dsa->g dsa->pub_key sig->r sig->s */
@@ -1403,7 +1403,7 @@ cryptodev_dh_compute_key(unsigned char *key, const BIGNUM *pub_key, DH *dh)
 
     keylen = BN_num_bits(dh->p);
 
-    memset(&kop, 0, sizeof kop);
+    memset(&kop, 0, sizeof(kop));
     kop.crk_op = CRK_DH_COMPUTE_KEY;
 
     /* inputs: dh->priv_key pub_key dh->p key */

--- a/thirdparty/openssl/crypto/engine/eng_table.c
+++ b/thirdparty/openssl/crypto/engine/eng_table.c
@@ -1,5 +1,5 @@
 /* ====================================================================
- * Copyright (c) 2001 The OpenSSL Project.  All rights reserved.
+ * Copyright (c) 2001-2018 The OpenSSL Project.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -159,6 +159,11 @@ int engine_table_register(ENGINE_TABLE **table, ENGINE_CLEANUP_CB *cleanup,
             }
             fnd->funct = NULL;
             (void)lh_ENGINE_PILE_insert(&(*table)->piles, fnd);
+            if (lh_ENGINE_PILE_retrieve(&(*table)->piles, &tmplate) != fnd) {
+                sk_ENGINE_free(fnd->sk);
+                OPENSSL_free(fnd);
+                goto end;
+            }
         }
         /* A registration shouldn't add duplciate entries */
         (void)sk_ENGINE_delete_ptr(fnd->sk, e);

--- a/thirdparty/openssl/crypto/err/err.c
+++ b/thirdparty/openssl/crypto/err/err.c
@@ -602,8 +602,8 @@ static void build_SYS_str_reasons(void)
             char (*dest)[LEN_SYS_STR_REASON] = &(strerror_tab[i - 1]);
             char *src = strerror(i);
             if (src != NULL) {
-                strncpy(*dest, src, sizeof *dest);
-                (*dest)[sizeof *dest - 1] = '\0';
+                strncpy(*dest, src, sizeof(*dest));
+                (*dest)[sizeof(*dest) - 1] = '\0';
                 str->string = *dest;
             }
         }

--- a/thirdparty/openssl/crypto/err/err_prn.c
+++ b/thirdparty/openssl/crypto/err/err_prn.c
@@ -77,7 +77,7 @@ void ERR_print_errors_cb(int (*cb) (const char *str, size_t len, void *u),
     CRYPTO_THREADID_current(&cur);
     es = CRYPTO_THREADID_hash(&cur);
     while ((l = ERR_get_error_line_data(&file, &line, &data, &flags)) != 0) {
-        ERR_error_string_n(l, buf, sizeof buf);
+        ERR_error_string_n(l, buf, sizeof(buf));
         BIO_snprintf(buf2, sizeof(buf2), "%lu:%s:%s:%d:%s\n", es, buf,
                      file, line, (flags & ERR_TXT_STRING) ? data : "");
         if (cb(buf2, strlen(buf2), u) <= 0)

--- a/thirdparty/openssl/crypto/evp/bio_b64.c
+++ b/thirdparty/openssl/crypto/evp/bio_b64.c
@@ -330,6 +330,14 @@ static int b64_read(BIO *b, char *out, int outl)
                                  (unsigned char *)ctx->tmp, i);
             ctx->tmp_len = 0;
         }
+        /*
+         * If eof or an error was signalled, then the condition
+         * 'ctx->cont <= 0' will prevent b64_read() from reading
+         * more data on subsequent calls. This assignment was
+         * deleted accidentally in commit 5562cfaca4f3.
+         */
+        ctx->cont = i;
+
         ctx->buf_off = 0;
         if (i < 0) {
             ret_code = 0;

--- a/thirdparty/openssl/crypto/evp/digest.c
+++ b/thirdparty/openssl/crypto/evp/digest.c
@@ -124,12 +124,12 @@
 
 void EVP_MD_CTX_init(EVP_MD_CTX *ctx)
 {
-    memset(ctx, '\0', sizeof *ctx);
+    memset(ctx, '\0', sizeof(*ctx));
 }
 
 EVP_MD_CTX *EVP_MD_CTX_create(void)
 {
-    EVP_MD_CTX *ctx = OPENSSL_malloc(sizeof *ctx);
+    EVP_MD_CTX *ctx = OPENSSL_malloc(sizeof(*ctx));
 
     if (ctx)
         EVP_MD_CTX_init(ctx);
@@ -316,7 +316,7 @@ int EVP_MD_CTX_copy_ex(EVP_MD_CTX *out, const EVP_MD_CTX *in)
     } else
         tmp_buf = NULL;
     EVP_MD_CTX_cleanup(out);
-    memcpy(out, in, sizeof *out);
+    memcpy(out, in, sizeof(*out));
 
     if (in->md_data && out->digest->ctx_size) {
         if (tmp_buf)
@@ -402,7 +402,7 @@ int EVP_MD_CTX_cleanup(EVP_MD_CTX *ctx)
 #ifdef OPENSSL_FIPS
     FIPS_md_ctx_cleanup(ctx);
 #endif
-    memset(ctx, '\0', sizeof *ctx);
+    memset(ctx, '\0', sizeof(*ctx));
 
     return 1;
 }

--- a/thirdparty/openssl/crypto/evp/e_aes.c
+++ b/thirdparty/openssl/crypto/evp/e_aes.c
@@ -1,5 +1,5 @@
 /* ====================================================================
- * Copyright (c) 2001-2011 The OpenSSL Project.  All rights reserved.
+ * Copyright (c) 2001-2018 The OpenSSL Project.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1089,6 +1089,8 @@ static int aes_cfb1_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         CRYPTO_cfb128_1_encrypt(in, out, MAXBITCHUNK * 8, &dat->ks,
                                 ctx->iv, &ctx->num, ctx->encrypt, dat->block);
         len -= MAXBITCHUNK;
+        out += MAXBITCHUNK;
+        in  += MAXBITCHUNK;
     }
     if (len)
         CRYPTO_cfb128_1_encrypt(in, out, len * 8, &dat->ks,

--- a/thirdparty/openssl/crypto/evp/e_camellia.c
+++ b/thirdparty/openssl/crypto/evp/e_camellia.c
@@ -1,6 +1,6 @@
 /* crypto/evp/e_camellia.c */
 /* ====================================================================
- * Copyright (c) 2006 The OpenSSL Project.  All rights reserved.
+ * Copyright (c) 2006-2018 The OpenSSL Project.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -356,6 +356,8 @@ static int camellia_cfb1_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         CRYPTO_cfb128_1_encrypt(in, out, MAXBITCHUNK * 8, &dat->ks,
                                 ctx->iv, &ctx->num, ctx->encrypt, dat->block);
         len -= MAXBITCHUNK;
+        out += MAXBITCHUNK;
+        in  += MAXBITCHUNK;
     }
     if (len)
         CRYPTO_cfb128_1_encrypt(in, out, len * 8, &dat->ks,

--- a/thirdparty/openssl/crypto/evp/evp_enc.c
+++ b/thirdparty/openssl/crypto/evp/evp_enc.c
@@ -85,7 +85,7 @@ void EVP_CIPHER_CTX_init(EVP_CIPHER_CTX *ctx)
 
 EVP_CIPHER_CTX *EVP_CIPHER_CTX_new(void)
 {
-    EVP_CIPHER_CTX *ctx = OPENSSL_malloc(sizeof *ctx);
+    EVP_CIPHER_CTX *ctx = OPENSSL_malloc(sizeof(*ctx));
     if (ctx)
         EVP_CIPHER_CTX_init(ctx);
     return ctx;
@@ -402,7 +402,7 @@ int EVP_EncryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
     }
 
     b = ctx->cipher->block_size;
-    OPENSSL_assert(b <= sizeof ctx->buf);
+    OPENSSL_assert(b <= sizeof(ctx->buf));
     if (b == 1) {
         *outl = 0;
         return 1;
@@ -454,7 +454,7 @@ int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
         return EVP_EncryptUpdate(ctx, out, outl, in, inl);
 
     b = ctx->cipher->block_size;
-    OPENSSL_assert(b <= sizeof ctx->final);
+    OPENSSL_assert(b <= sizeof(ctx->final));
 
     if (ctx->final_used) {
         memcpy(out, ctx->final, b);
@@ -520,7 +520,7 @@ int EVP_DecryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
             EVPerr(EVP_F_EVP_DECRYPTFINAL_EX, EVP_R_WRONG_FINAL_BLOCK_LENGTH);
             return (0);
         }
-        OPENSSL_assert(b <= sizeof ctx->final);
+        OPENSSL_assert(b <= sizeof(ctx->final));
 
         /*
          * The following assumes that the ciphertext has been authenticated.
@@ -651,7 +651,7 @@ int EVP_CIPHER_CTX_copy(EVP_CIPHER_CTX *out, const EVP_CIPHER_CTX *in)
 #endif
 
     EVP_CIPHER_CTX_cleanup(out);
-    memcpy(out, in, sizeof *out);
+    memcpy(out, in, sizeof(*out));
 
     if (in->cipher_data && in->cipher->ctx_size) {
         out->cipher_data = OPENSSL_malloc(in->cipher->ctx_size);

--- a/thirdparty/openssl/crypto/evp/evp_locl.h
+++ b/thirdparty/openssl/crypto/evp/evp_locl.h
@@ -4,7 +4,7 @@
  * 2000.
  */
 /* ====================================================================
- * Copyright (c) 1999 The OpenSSL Project.  All rights reserved.
+ * Copyright (c) 1999-2018 The OpenSSL Project.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -116,7 +116,7 @@ static int cname##_cfb##cbits##_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out, 
         if (inl<chunk) chunk=inl;\
         while(inl && inl>=chunk)\
             {\
-            cprefix##_cfb##cbits##_encrypt(in, out, (long)((cbits==1) && !(ctx->flags & EVP_CIPH_FLAG_LENGTH_BITS) ?inl*8:inl), &((kstruct *)ctx->cipher_data)->ksched, ctx->iv, &ctx->num, ctx->encrypt);\
+            cprefix##_cfb##cbits##_encrypt(in, out, (long)((cbits==1) && !(ctx->flags & EVP_CIPH_FLAG_LENGTH_BITS) ?chunk*8:chunk), &((kstruct *)ctx->cipher_data)->ksched, ctx->iv, &ctx->num, ctx->encrypt);\
             inl-=chunk;\
             in +=chunk;\
             out+=chunk;\

--- a/thirdparty/openssl/crypto/evp/evp_pbe.c
+++ b/thirdparty/openssl/crypto/evp/evp_pbe.c
@@ -161,9 +161,9 @@ int EVP_PBE_CipherInit(ASN1_OBJECT *pbe_obj, const char *pass, int passlen,
         char obj_tmp[80];
         EVPerr(EVP_F_EVP_PBE_CIPHERINIT, EVP_R_UNKNOWN_PBE_ALGORITHM);
         if (!pbe_obj)
-            BUF_strlcpy(obj_tmp, "NULL", sizeof obj_tmp);
+            BUF_strlcpy(obj_tmp, "NULL", sizeof(obj_tmp));
         else
-            i2t_ASN1_OBJECT(obj_tmp, sizeof obj_tmp, pbe_obj);
+            i2t_ASN1_OBJECT(obj_tmp, sizeof(obj_tmp), pbe_obj);
         ERR_add_error_data(2, "TYPE=", obj_tmp);
         return 0;
     }

--- a/thirdparty/openssl/crypto/evp/openbsd_hw.c
+++ b/thirdparty/openssl/crypto/evp/openbsd_hw.c
@@ -111,7 +111,7 @@ static int dev_crypto_init(session_op *ses)
         close(cryptodev_fd);
     }
     assert(ses);
-    memset(ses, '\0', sizeof *ses);
+    memset(ses, '\0', sizeof(*ses));
 
     return 1;
 }
@@ -164,7 +164,7 @@ static int dev_crypto_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     assert(CDATA(ctx));
     assert(!dev_failed);
 
-    memset(&cryp, '\0', sizeof cryp);
+    memset(&cryp, '\0', sizeof(cryp));
     cryp.ses = CDATA(ctx)->ses;
     cryp.op = ctx->encrypt ? COP_ENCRYPT : COP_DECRYPT;
     cryp.flags = 0;
@@ -329,7 +329,7 @@ static int do_digest(int ses, unsigned char *md, const void *data, int len)
         return 1;
     }
 
-    memset(&cryp, '\0', sizeof cryp);
+    memset(&cryp, '\0', sizeof(cryp));
     cryp.ses = ses;
     cryp.op = COP_ENCRYPT;      /* required to do the MAC rather than check
                                  * it */

--- a/thirdparty/openssl/crypto/evp/p5_crpt2.c
+++ b/thirdparty/openssl/crypto/evp/p5_crpt2.c
@@ -262,7 +262,7 @@ int PKCS5_v2_PBKDF2_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass,
         goto err;
     }
     keylen = EVP_CIPHER_CTX_key_length(ctx);
-    OPENSSL_assert(keylen <= sizeof key);
+    OPENSSL_assert(keylen <= sizeof(key));
 
     /* Decode parameter */
 

--- a/thirdparty/openssl/crypto/hmac/hmac.c
+++ b/thirdparty/openssl/crypto/hmac/hmac.c
@@ -234,7 +234,7 @@ void HMAC_CTX_cleanup(HMAC_CTX *ctx)
     EVP_MD_CTX_cleanup(&ctx->i_ctx);
     EVP_MD_CTX_cleanup(&ctx->o_ctx);
     EVP_MD_CTX_cleanup(&ctx->md_ctx);
-    OPENSSL_cleanse(ctx, sizeof *ctx);
+    OPENSSL_cleanse(ctx, sizeof(*ctx));
 }
 
 unsigned char *HMAC(const EVP_MD *evp_md, const void *key, int key_len,

--- a/thirdparty/openssl/crypto/jpake/jpake.c
+++ b/thirdparty/openssl/crypto/jpake/jpake.c
@@ -108,14 +108,14 @@ static void JPAKE_CTX_release(JPAKE_CTX *ctx)
     OPENSSL_free(ctx->p.peer_name);
     OPENSSL_free(ctx->p.name);
 
-    memset(ctx, '\0', sizeof *ctx);
+    memset(ctx, '\0', sizeof(*ctx));
 }
 
 JPAKE_CTX *JPAKE_CTX_new(const char *name, const char *peer_name,
                          const BIGNUM *p, const BIGNUM *g, const BIGNUM *q,
                          const BIGNUM *secret)
 {
-    JPAKE_CTX *ctx = OPENSSL_malloc(sizeof *ctx);
+    JPAKE_CTX *ctx = OPENSSL_malloc(sizeof(*ctx));
     if (ctx == NULL)
         return NULL;
 
@@ -460,7 +460,7 @@ void JPAKE_STEP3A_init(JPAKE_STEP3A *s3a)
 int JPAKE_STEP3A_generate(JPAKE_STEP3A *send, JPAKE_CTX *ctx)
 {
     quickhashbn(send->hhk, ctx->key);
-    SHA1(send->hhk, sizeof send->hhk, send->hhk);
+    SHA1(send->hhk, sizeof(send->hhk), send->hhk);
 
     return 1;
 }
@@ -470,8 +470,8 @@ int JPAKE_STEP3A_process(JPAKE_CTX *ctx, const JPAKE_STEP3A *received)
     unsigned char hhk[SHA_DIGEST_LENGTH];
 
     quickhashbn(hhk, ctx->key);
-    SHA1(hhk, sizeof hhk, hhk);
-    if (memcmp(hhk, received->hhk, sizeof hhk)) {
+    SHA1(hhk, sizeof(hhk), hhk);
+    if (memcmp(hhk, received->hhk, sizeof(hhk))) {
         JPAKEerr(JPAKE_F_JPAKE_STEP3A_PROCESS,
                  JPAKE_R_HASH_OF_HASH_OF_KEY_MISMATCH);
         return 0;
@@ -499,7 +499,7 @@ int JPAKE_STEP3B_process(JPAKE_CTX *ctx, const JPAKE_STEP3B *received)
     unsigned char hk[SHA_DIGEST_LENGTH];
 
     quickhashbn(hk, ctx->key);
-    if (memcmp(hk, received->hk, sizeof hk)) {
+    if (memcmp(hk, received->hk, sizeof(hk))) {
         JPAKEerr(JPAKE_F_JPAKE_STEP3B_PROCESS, JPAKE_R_HASH_OF_KEY_MISMATCH);
         return 0;
     }

--- a/thirdparty/openssl/crypto/md2/md2_dgst.c
+++ b/thirdparty/openssl/crypto/md2/md2_dgst.c
@@ -122,9 +122,9 @@ const char *MD2_options(void)
 fips_md_init(MD2)
 {
     c->num = 0;
-    memset(c->state, 0, sizeof c->state);
-    memset(c->cksm, 0, sizeof c->cksm);
-    memset(c->data, 0, sizeof c->data);
+    memset(c->state, 0, sizeof(c->state));
+    memset(c->cksm, 0, sizeof(c->cksm));
+    memset(c->data, 0, sizeof(c->data));
     return 1;
 }
 

--- a/thirdparty/openssl/crypto/md4/md4.c
+++ b/thirdparty/openssl/crypto/md4/md4.c
@@ -102,7 +102,7 @@ void do_fp(FILE *f)
     fd = fileno(f);
     MD4_Init(&c);
     for (;;) {
-        i = read(fd, buf, sizeof buf);
+        i = read(fd, buf, sizeof(buf));
         if (i <= 0)
             break;
         MD4_Update(&c, buf, (unsigned long)i);

--- a/thirdparty/openssl/crypto/o_init.c
+++ b/thirdparty/openssl/crypto/o_init.c
@@ -58,6 +58,11 @@
 #ifdef OPENSSL_FIPS
 # include <openssl/fips.h>
 # include <openssl/rand.h>
+
+# ifndef OPENSSL_NO_DEPRECATED
+/* the prototype is missing in <openssl/fips.h> */
+void FIPS_crypto_set_id_callback(unsigned long (*func)(void));
+# endif
 #endif
 
 /*

--- a/thirdparty/openssl/crypto/o_time.c
+++ b/thirdparty/openssl/crypto/o_time.c
@@ -8,7 +8,7 @@
  * 2008.
  */
 /* ====================================================================
- * Copyright (c) 2001 The OpenSSL Project.  All rights reserved.
+ * Copyright (c) 2001-2018 The OpenSSL Project.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -105,7 +105,7 @@ struct tm *OPENSSL_gmtime(const time_t *timer, struct tm *result)
 {
     struct tm *ts = NULL;
 
-#if defined(OPENSSL_THREADS) && !defined(OPENSSL_SYS_WIN32) && !defined(OPENSSL_SYS_OS2) && (!defined(OPENSSL_SYS_VMS) || defined(gmtime_r)) && !defined(OPENSSL_SYS_MACOSX) && !defined(OPENSSL_SYS_SUNOS)
+#if defined(OPENSSL_THREADS) && !defined(OPENSSL_SYS_WIN32) && !defined(OPENSSL_SYS_OS2) && (!defined(OPENSSL_SYS_VMS) || defined(gmtime_r)) && !defined(OPENSSL_SYS_SUNOS)
     if (gmtime_r(timer, result) == NULL)
         return NULL;
     ts = result;
@@ -141,14 +141,14 @@ struct tm *OPENSSL_gmtime(const time_t *timer, struct tm *result)
         pitem->ileb_64$w_mbo = 1;
         pitem->ileb_64$w_code = LNM$_STRING;
         pitem->ileb_64$l_mbmo = -1;
-        pitem->ileb_64$q_length = sizeof (logvalue);
+        pitem->ileb_64$q_length = sizeof(logvalue);
         pitem->ileb_64$pq_bufaddr = logvalue;
         pitem->ileb_64$pq_retlen_addr = (unsigned __int64 *) &reslen;
         pitem++;
         /* Last item of the item list is null terminated */
         pitem->ileb_64$q_length = pitem->ileb_64$w_code = 0;
 # else
-        pitem->ile3$w_length = sizeof (logvalue);
+        pitem->ile3$w_length = sizeof(logvalue);
         pitem->ile3$w_code = LNM$_STRING;
         pitem->ile3$ps_bufaddr = logvalue;
         pitem->ile3$ps_retlen_addr = (unsigned short int *) &reslen;

--- a/thirdparty/openssl/crypto/objects/o_names.c
+++ b/thirdparty/openssl/crypto/objects/o_names.c
@@ -312,13 +312,13 @@ void OBJ_NAME_do_all_sorted(int type,
 
     d.type = type;
     d.names =
-        OPENSSL_malloc(lh_OBJ_NAME_num_items(names_lh) * sizeof *d.names);
+        OPENSSL_malloc(lh_OBJ_NAME_num_items(names_lh) * sizeof(*d.names));
     /* Really should return an error if !d.names...but its a void function! */
     if (d.names) {
         d.n = 0;
         OBJ_NAME_do_all(type, do_all_sorted_fn, &d);
 
-        qsort((void *)d.names, d.n, sizeof *d.names, do_all_sorted_cmp);
+        qsort((void *)d.names, d.n, sizeof(*d.names), do_all_sorted_cmp);
 
         for (n = 0; n < d.n; ++n)
             fn(d.names[n], arg);

--- a/thirdparty/openssl/crypto/objects/obj_dat.c
+++ b/thirdparty/openssl/crypto/objects/obj_dat.c
@@ -305,9 +305,8 @@ int OBJ_add_object(const ASN1_OBJECT *obj)
     for (i = ADDED_DATA; i <= ADDED_NID; i++)
         if (ao[i] != NULL)
             OPENSSL_free(ao[i]);
-    if (o != NULL)
-        OPENSSL_free(o);
-    return (NID_undef);
+    ASN1_OBJECT_free(o);
+    return NID_undef;
 }
 
 ASN1_OBJECT *OBJ_nid2obj(int n)
@@ -591,7 +590,7 @@ int OBJ_obj2txt(char *buf, int buf_len, const ASN1_OBJECT *a, int no_name)
             n += i;
             OPENSSL_free(bndec);
         } else {
-            BIO_snprintf(tbuf, sizeof tbuf, ".%lu", l);
+            BIO_snprintf(tbuf, sizeof(tbuf), ".%lu", l);
             i = strlen(tbuf);
             if (buf && (buf_len > 0)) {
                 BUF_strlcpy(buf, tbuf, buf_len);
@@ -725,6 +724,10 @@ const void *OBJ_bsearch_ex_(const void *key, const void *base_, int num,
     return (p);
 }
 
+/*
+ * Parse a BIO sink to create some extra oid's objects.
+ * Line format:<OID:isdigit or '.']><isspace><SN><isspace><LN>
+ */
 int OBJ_create_objects(BIO *in)
 {
     MS_STATIC char buf[512];
@@ -746,9 +749,9 @@ int OBJ_create_objects(BIO *in)
             *(s++) = '\0';
             while (isspace((unsigned char)*s))
                 s++;
-            if (*s == '\0')
+            if (*s == '\0') {
                 s = NULL;
-            else {
+            } else {
                 l = s;
                 while ((*l != '\0') && !isspace((unsigned char)*l))
                     l++;
@@ -756,15 +759,18 @@ int OBJ_create_objects(BIO *in)
                     *(l++) = '\0';
                     while (isspace((unsigned char)*l))
                         l++;
-                    if (*l == '\0')
+                    if (*l == '\0') {
                         l = NULL;
-                } else
+                    }
+                } else {
                     l = NULL;
+                }
             }
-        } else
+        } else {
             s = NULL;
-        if ((o == NULL) || (*o == '\0'))
-            return (num);
+        }
+        if (*o == '\0')
+            return num;
         if (!OBJ_create(o, s, l))
             return (num);
         num++;

--- a/thirdparty/openssl/crypto/pem/pem_info.c
+++ b/thirdparty/openssl/crypto/pem/pem_info.c
@@ -354,7 +354,7 @@ int PEM_X509_INFO_write_bio(BIO *bp, X509_INFO *xi, EVP_CIPHER *enc,
 
             /* create the right magic header stuff */
             OPENSSL_assert(strlen(objstr) + 23 + 2 * enc->iv_len + 13 <=
-                           sizeof buf);
+                           sizeof(buf));
             buf[0] = '\0';
             PEM_proc_type(buf, PEM_TYPE_ENCRYPTED);
             PEM_dek_info(buf, objstr, enc->iv_len, (char *)iv);

--- a/thirdparty/openssl/crypto/pem/pem_lib.c
+++ b/thirdparty/openssl/crypto/pem/pem_lib.c
@@ -406,7 +406,7 @@ int PEM_ASN1_write_bio(i2d_of_void *i2d, const char *name, BIO *bp,
             OPENSSL_cleanse(buf, PEM_BUFSIZE);
 
         OPENSSL_assert(strlen(objstr) + 23 + 2 * enc->iv_len + 13 <=
-                       sizeof buf);
+                       sizeof(buf));
 
         buf[0] = '\0';
         PEM_proc_type(buf, PEM_TYPE_ENCRYPTED);

--- a/thirdparty/openssl/crypto/pkcs7/pk7_doit.c
+++ b/thirdparty/openssl/crypto/pkcs7/pk7_doit.c
@@ -375,16 +375,18 @@ BIO *PKCS7_dataInit(PKCS7 *p7, BIO *bio)
     }
 
     if (bio == NULL) {
-        if (PKCS7_is_detached(p7))
+        if (PKCS7_is_detached(p7)) {
             bio = BIO_new(BIO_s_null());
-        else if (os && os->length > 0)
+        } else if (os && os->length > 0) {
             bio = BIO_new_mem_buf(os->data, os->length);
-        if (bio == NULL) {
+        } else {
             bio = BIO_new(BIO_s_mem());
             if (bio == NULL)
                 goto err;
             BIO_set_mem_eof_return(bio, 0);
         }
+        if (bio == NULL)
+            goto err;
     }
     if (out)
         BIO_push(out, bio);

--- a/thirdparty/openssl/crypto/rand/md_rand.c
+++ b/thirdparty/openssl/crypto/rand/md_rand.c
@@ -238,7 +238,7 @@ static void ssleay_rand_add(const void *buf, int num, double add)
     md_c[0] = md_count[0];
     md_c[1] = md_count[1];
 
-    memcpy(local_md, md, sizeof md);
+    memcpy(local_md, md, sizeof(md));
 
     /* state_index <= state_num <= STATE_SIZE */
     state_index += num;
@@ -454,7 +454,7 @@ int ssleay_rand_bytes(unsigned char *buf, int num, int pseudo, int lock)
     st_num = state_num;
     md_c[0] = md_count[0];
     md_c[1] = md_count[1];
-    memcpy(local_md, md, sizeof md);
+    memcpy(local_md, md, sizeof(md));
 
     state_index += num_ceil;
     if (state_index > state_num)
@@ -480,7 +480,7 @@ int ssleay_rand_bytes(unsigned char *buf, int num, int pseudo, int lock)
            goto err;
 #ifndef GETPID_IS_MEANINGLESS
         if (curr_pid) {         /* just in the first iteration to save time */
-            if (!MD_Update(&m, (unsigned char *)&curr_pid, sizeof curr_pid))
+            if (!MD_Update(&m, (unsigned char *)&curr_pid, sizeof(curr_pid)))
                 goto err;
             curr_pid = 0;
         }

--- a/thirdparty/openssl/crypto/rand/rand_egd.c
+++ b/thirdparty/openssl/crypto/rand/rand_egd.c
@@ -148,7 +148,7 @@ int RAND_query_egd_bytes(const char *path, unsigned char *buf, int bytes)
     addr.sun_family = AF_UNIX;
     if (strlen(path) >= sizeof(addr.sun_path))
         return (-1);
-    BUF_strlcpy(addr.sun_path, path, sizeof addr.sun_path);
+    BUF_strlcpy(addr.sun_path, path, sizeof(addr.sun_path));
     len = offsetof(struct sockaddr_un, sun_path) + strlen(path);
     fd = socket(AF_UNIX, SOCK_STREAM, 0);
     if (fd == -1)

--- a/thirdparty/openssl/crypto/rand/rand_unix.c
+++ b/thirdparty/openssl/crypto/rand/rand_unix.c
@@ -181,15 +181,15 @@ int RAND_poll(void)
      */
 
     curr_gid = getgid();
-    RAND_add(&curr_gid, sizeof curr_gid, 1);
+    RAND_add(&curr_gid, sizeof(curr_gid), 1);
     curr_gid = 0;
 
     curr_pid = getpid();
-    RAND_add(&curr_pid, sizeof curr_pid, 1);
+    RAND_add(&curr_pid, sizeof(curr_pid), 1);
     curr_pid = 0;
 
     curr_uid = getuid();
-    RAND_add(&curr_uid, sizeof curr_uid, 1);
+    RAND_add(&curr_uid, sizeof(curr_uid), 1);
     curr_uid = 0;
 
     for (i = 0; i < (ENTROPY_NEEDED * 4); i++) {
@@ -217,7 +217,7 @@ int RAND_poll(void)
 
         /* take 8 bits */
         v = (unsigned char)(ts.tv_nsec % 256);
-        RAND_add(&v, sizeof v, 1);
+        RAND_add(&v, sizeof(v), 1);
         v = 0;
     }
     return 1;
@@ -402,7 +402,7 @@ int RAND_poll(void)
 
 #  if defined(DEVRANDOM) || defined(DEVRANDOM_EGD)
     if (n > 0) {
-        RAND_add(tmpbuf, sizeof tmpbuf, (double)n);
+        RAND_add(tmpbuf, sizeof(tmpbuf), (double)n);
         OPENSSL_cleanse(tmpbuf, n);
     }
 #  endif

--- a/thirdparty/openssl/crypto/rsa/rsa_crpt.c
+++ b/thirdparty/openssl/crypto/rsa/rsa_crpt.c
@@ -219,7 +219,7 @@ BN_BLINDING *RSA_setup_blinding(RSA *rsa, BN_CTX *in_ctx)
          * if PRNG is not properly seeded, resort to secret exponent as
          * unpredictable seed
          */
-        RAND_add(rsa->d->d, rsa->d->dmax * sizeof rsa->d->d[0], 0.0);
+        RAND_add(rsa->d->d, rsa->d->dmax * sizeof(rsa->d->d[0]), 0.0);
     }
 
     if (!(rsa->flags & RSA_FLAG_NO_CONSTTIME)) {

--- a/thirdparty/openssl/crypto/rsa/rsa_pss.c
+++ b/thirdparty/openssl/crypto/rsa/rsa_pss.c
@@ -157,7 +157,7 @@ int RSA_verify_PKCS1_PSS_mgf1(RSA *rsa, const unsigned char *mHash,
         goto err;
     }
     if (!EVP_DigestInit_ex(&ctx, Hash, NULL)
-        || !EVP_DigestUpdate(&ctx, zeroes, sizeof zeroes)
+        || !EVP_DigestUpdate(&ctx, zeroes, sizeof(zeroes))
         || !EVP_DigestUpdate(&ctx, mHash, hLen))
         goto err;
     if (maskedDBLen - i) {
@@ -252,7 +252,7 @@ int RSA_padding_add_PKCS1_PSS_mgf1(RSA *rsa, unsigned char *EM,
     H = EM + maskedDBLen;
     EVP_MD_CTX_init(&ctx);
     if (!EVP_DigestInit_ex(&ctx, Hash, NULL)
-        || !EVP_DigestUpdate(&ctx, zeroes, sizeof zeroes)
+        || !EVP_DigestUpdate(&ctx, zeroes, sizeof(zeroes))
         || !EVP_DigestUpdate(&ctx, mHash, hLen))
         goto err;
     if (sLen && !EVP_DigestUpdate(&ctx, salt, sLen))

--- a/thirdparty/openssl/crypto/srp/srp_grps.h
+++ b/thirdparty/openssl/crypto/srp/srp_grps.h
@@ -21,8 +21,8 @@ static BN_ULONG bn_group_1024_value[] = {
 
 static BIGNUM bn_group_1024 = {
     bn_group_1024_value,
-    (sizeof bn_group_1024_value) / sizeof(BN_ULONG),
-    (sizeof bn_group_1024_value) / sizeof(BN_ULONG),
+    (sizeof(bn_group_1024_value)) / sizeof(BN_ULONG),
+    (sizeof(bn_group_1024_value)) / sizeof(BN_ULONG),
     0,
     BN_FLG_STATIC_DATA
 };
@@ -56,8 +56,8 @@ static BN_ULONG bn_group_1536_value[] = {
 
 static BIGNUM bn_group_1536 = {
     bn_group_1536_value,
-    (sizeof bn_group_1536_value) / sizeof(BN_ULONG),
-    (sizeof bn_group_1536_value) / sizeof(BN_ULONG),
+    (sizeof(bn_group_1536_value)) / sizeof(BN_ULONG),
+    (sizeof(bn_group_1536_value)) / sizeof(BN_ULONG),
     0,
     BN_FLG_STATIC_DATA
 };
@@ -99,8 +99,8 @@ static BN_ULONG bn_group_2048_value[] = {
 
 static BIGNUM bn_group_2048 = {
     bn_group_2048_value,
-    (sizeof bn_group_2048_value) / sizeof(BN_ULONG),
-    (sizeof bn_group_2048_value) / sizeof(BN_ULONG),
+    (sizeof(bn_group_2048_value)) / sizeof(BN_ULONG),
+    (sizeof(bn_group_2048_value)) / sizeof(BN_ULONG),
     0,
     BN_FLG_STATIC_DATA
 };
@@ -158,8 +158,8 @@ static BN_ULONG bn_group_3072_value[] = {
 
 static BIGNUM bn_group_3072 = {
     bn_group_3072_value,
-    (sizeof bn_group_3072_value) / sizeof(BN_ULONG),
-    (sizeof bn_group_3072_value) / sizeof(BN_ULONG),
+    (sizeof(bn_group_3072_value)) / sizeof(BN_ULONG),
+    (sizeof(bn_group_3072_value)) / sizeof(BN_ULONG),
     0,
     BN_FLG_STATIC_DATA
 };
@@ -233,8 +233,8 @@ static BN_ULONG bn_group_4096_value[] = {
 
 static BIGNUM bn_group_4096 = {
     bn_group_4096_value,
-    (sizeof bn_group_4096_value) / sizeof(BN_ULONG),
-    (sizeof bn_group_4096_value) / sizeof(BN_ULONG),
+    (sizeof(bn_group_4096_value)) / sizeof(BN_ULONG),
+    (sizeof(bn_group_4096_value)) / sizeof(BN_ULONG),
     0,
     BN_FLG_STATIC_DATA
 };
@@ -340,8 +340,8 @@ static BN_ULONG bn_group_6144_value[] = {
 
 static BIGNUM bn_group_6144 = {
     bn_group_6144_value,
-    (sizeof bn_group_6144_value) / sizeof(BN_ULONG),
-    (sizeof bn_group_6144_value) / sizeof(BN_ULONG),
+    (sizeof(bn_group_6144_value)) / sizeof(BN_ULONG),
+    (sizeof(bn_group_6144_value)) / sizeof(BN_ULONG),
     0,
     BN_FLG_STATIC_DATA
 };
@@ -479,8 +479,8 @@ static BN_ULONG bn_group_8192_value[] = {
 
 static BIGNUM bn_group_8192 = {
     bn_group_8192_value,
-    (sizeof bn_group_8192_value) / sizeof(BN_ULONG),
-    (sizeof bn_group_8192_value) / sizeof(BN_ULONG),
+    (sizeof(bn_group_8192_value)) / sizeof(BN_ULONG),
+    (sizeof(bn_group_8192_value)) / sizeof(BN_ULONG),
     0,
     BN_FLG_STATIC_DATA
 };

--- a/thirdparty/openssl/crypto/ts/ts_rsp_sign.c
+++ b/thirdparty/openssl/crypto/ts/ts_rsp_sign.c
@@ -4,7 +4,7 @@
  * 2002.
  */
 /* ====================================================================
- * Copyright (c) 2006 The OpenSSL Project.  All rights reserved.
+ * Copyright (c) 2006-2018 The OpenSSL Project.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -58,6 +58,7 @@
  */
 
 #include "cryptlib.h"
+#include "o_time.h"
 
 #if defined(OPENSSL_SYS_UNIX)
 # include <sys/time.h>
@@ -948,6 +949,7 @@ static ASN1_GENERALIZEDTIME
 {
     time_t time_sec = (time_t)sec;
     struct tm *tm = NULL;
+    struct tm result = {0};
     char genTime_str[17 + TS_MAX_CLOCK_PRECISION_DIGITS];
     char *p = genTime_str;
     char *p_end = genTime_str + sizeof(genTime_str);
@@ -955,7 +957,7 @@ static ASN1_GENERALIZEDTIME
     if (precision > TS_MAX_CLOCK_PRECISION_DIGITS)
         goto err;
 
-    if (!(tm = gmtime(&time_sec)))
+    if (!(tm = OPENSSL_gmtime(&time_sec, &result)))
         goto err;
 
     /*

--- a/thirdparty/openssl/crypto/ui/ui_openssl.c
+++ b/thirdparty/openssl/crypto/ui/ui_openssl.c
@@ -614,7 +614,7 @@ static void pushsig(void)
 # ifdef SIGACTION
     struct sigaction sa;
 
-    memset(&sa, 0, sizeof sa);
+    memset(&sa, 0, sizeof(sa));
     sa.sa_handler = recsig;
 # endif
 

--- a/thirdparty/openssl/crypto/x509/x509_txt.c
+++ b/thirdparty/openssl/crypto/x509/x509_txt.c
@@ -212,7 +212,7 @@ const char *X509_verify_cert_error_string(long n)
         return ("proxy subject name violation");
 
     default:
-        BIO_snprintf(buf, sizeof buf, "error number %ld", n);
+        BIO_snprintf(buf, sizeof(buf), "error number %ld", n);
         return (buf);
     }
 }

--- a/thirdparty/openssl/crypto/x509/x509_v3.c
+++ b/thirdparty/openssl/crypto/x509/x509_v3.c
@@ -177,7 +177,7 @@ STACK_OF(X509_EXTENSION) *X509v3_add_ext(STACK_OF(X509_EXTENSION) **x,
  err2:
     if (new_ex != NULL)
         X509_EXTENSION_free(new_ex);
-    if (sk != NULL)
+    if (x != NULL && *x == NULL && sk != NULL)
         sk_X509_EXTENSION_free(sk);
     return (NULL);
 }

--- a/thirdparty/openssl/crypto/x509/x509_vpm.c
+++ b/thirdparty/openssl/crypto/x509/x509_vpm.c
@@ -173,7 +173,7 @@ X509_VERIFY_PARAM *X509_VERIFY_PARAM_new(void)
     X509_VERIFY_PARAM *param;
     X509_VERIFY_PARAM_ID *paramid;
 
-    param = OPENSSL_malloc(sizeof *param);
+    param = OPENSSL_malloc(sizeof(*param));
     if (!param)
         return NULL;
     memset(param, 0, sizeof(*param));

--- a/thirdparty/openssl/crypto/x509v3/v3_alt.c
+++ b/thirdparty/openssl/crypto/x509v3/v3_alt.c
@@ -157,12 +157,12 @@ STACK_OF(CONF_VALUE) *i2v_GENERAL_NAME(X509V3_EXT_METHOD *method,
     case GEN_IPADD:
         p = gen->d.ip->data;
         if (gen->d.ip->length == 4)
-            BIO_snprintf(oline, sizeof oline,
+            BIO_snprintf(oline, sizeof(oline),
                          "%d.%d.%d.%d", p[0], p[1], p[2], p[3]);
         else if (gen->d.ip->length == 16) {
             oline[0] = 0;
             for (i = 0; i < 8; i++) {
-                BIO_snprintf(htmp, sizeof htmp, "%X", p[0] << 8 | p[1]);
+                BIO_snprintf(htmp, sizeof(htmp), "%X", p[0] << 8 | p[1]);
                 p += 2;
                 strcat(oline, htmp);
                 if (i != 7)

--- a/thirdparty/openssl/crypto/x509v3/v3_conf.c
+++ b/thirdparty/openssl/crypto/x509v3/v3_conf.c
@@ -4,7 +4,7 @@
  * 1999.
  */
 /* ====================================================================
- * Copyright (c) 1999-2002 The OpenSSL Project.  All rights reserved.
+ * Copyright (c) 1999-2018 The OpenSSL Project.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -340,8 +340,12 @@ int X509V3_EXT_add_nconf_sk(CONF *conf, X509V3_CTX *ctx, char *section,
         val = sk_CONF_VALUE_value(nval, i);
         if (!(ext = X509V3_EXT_nconf(conf, ctx, val->name, val->value)))
             return 0;
-        if (sk)
-            X509v3_add_ext(sk, ext, -1);
+        if (sk != NULL) {
+            if (X509v3_add_ext(sk, ext, -1) == NULL) {
+                X509_EXTENSION_free(ext);
+                return 0;
+            }
+        }
         X509_EXTENSION_free(ext);
     }
     return 1;

--- a/thirdparty/openssl/crypto/x509v3/v3_info.c
+++ b/thirdparty/openssl/crypto/x509v3/v3_info.c
@@ -126,7 +126,7 @@ static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_INFO_ACCESS(
             goto err;
         tret = tmp;
         vtmp = sk_CONF_VALUE_value(tret, i);
-        i2t_ASN1_OBJECT(objtmp, sizeof objtmp, desc->method);
+        i2t_ASN1_OBJECT(objtmp, sizeof(objtmp), desc->method);
         nlen = strlen(objtmp) + strlen(vtmp->name) + 5;
         ntmp = OPENSSL_malloc(nlen);
         if (ntmp == NULL)

--- a/thirdparty/openssl/openssl/asn1.h
+++ b/thirdparty/openssl/openssl/asn1.h
@@ -1365,6 +1365,7 @@ void ERR_load_ASN1_strings(void);
 # define ASN1_R_MSTRING_NOT_UNIVERSAL                     139
 # define ASN1_R_MSTRING_WRONG_TAG                         140
 # define ASN1_R_NESTED_ASN1_STRING                        197
+# define ASN1_R_NESTED_TOO_DEEP                           219
 # define ASN1_R_NON_HEX_CHARACTERS                        141
 # define ASN1_R_NOT_ASCII_FORMAT                          190
 # define ASN1_R_NOT_ENOUGH_DATA                           142

--- a/thirdparty/openssl/openssl/opensslv.h
+++ b/thirdparty/openssl/openssl/opensslv.h
@@ -30,11 +30,11 @@ extern "C" {
  * (Prior to 0.9.5a beta1, a different scheme was used: MMNNFFRBB for
  *  major minor fix final patch/beta)
  */
-# define OPENSSL_VERSION_NUMBER  0x100020efL
+# define OPENSSL_VERSION_NUMBER  0x100020ffL
 # ifdef OPENSSL_FIPS
-#  define OPENSSL_VERSION_TEXT    "OpenSSL 1.0.2n-fips  7 Dec 2017"
+#  define OPENSSL_VERSION_TEXT    "OpenSSL 1.0.2o-fips  27 Mar 2018"
 # else
-#  define OPENSSL_VERSION_TEXT    "OpenSSL 1.0.2n  7 Dec 2017"
+#  define OPENSSL_VERSION_TEXT    "OpenSSL 1.0.2o  27 Mar 2018"
 # endif
 # define OPENSSL_VERSION_PTEXT   " part of " OPENSSL_VERSION_TEXT
 

--- a/thirdparty/openssl/ssl/d1_lib.c
+++ b/thirdparty/openssl/ssl/d1_lib.c
@@ -126,9 +126,9 @@ int dtls1_new(SSL *s)
 
     if (!ssl3_new(s))
         return (0);
-    if ((d1 = OPENSSL_malloc(sizeof *d1)) == NULL)
+    if ((d1 = OPENSSL_malloc(sizeof(*d1))) == NULL)
         return (0);
-    memset(d1, 0, sizeof *d1);
+    memset(d1, 0, sizeof(*d1));
 
     /* d1->handshake_epoch=0; */
 

--- a/thirdparty/openssl/ssl/s23_srvr.c
+++ b/thirdparty/openssl/ssl/s23_srvr.c
@@ -268,8 +268,8 @@ int ssl23_get_client_hello(SSL *s)
         if (!ssl3_setup_buffers(s))
             goto err;
 
-        n = ssl23_read_bytes(s, sizeof buf_space);
-        if (n != sizeof buf_space)
+        n = ssl23_read_bytes(s, sizeof(buf_space));
+        if (n != sizeof(buf_space))
             return (n);         /* n == -1 || n == 0 */
 
         p = s->packet;

--- a/thirdparty/openssl/ssl/s2_clnt.c
+++ b/thirdparty/openssl/ssl/s2_clnt.c
@@ -523,7 +523,7 @@ static int get_server_hello(SSL *s)
     }
 
     s->s2->conn_id_length = s->s2->tmp.conn_id_length;
-    if (s->s2->conn_id_length > sizeof s->s2->conn_id) {
+    if (s->s2->conn_id_length > sizeof(s->s2->conn_id)) {
         ssl2_return_error(s, SSL2_PE_UNDEFINED_ERROR);
         SSLerr(SSL_F_GET_SERVER_HELLO, SSL_R_SSL2_CONNECTION_ID_TOO_LONG);
         return -1;
@@ -708,7 +708,7 @@ static int client_finished(SSL *s)
     if (s->state == SSL2_ST_SEND_CLIENT_FINISHED_A) {
         p = (unsigned char *)s->init_buf->data;
         *(p++) = SSL2_MT_CLIENT_FINISHED;
-        if (s->s2->conn_id_length > sizeof s->s2->conn_id) {
+        if (s->s2->conn_id_length > sizeof(s->s2->conn_id)) {
             SSLerr(SSL_F_CLIENT_FINISHED, ERR_R_INTERNAL_ERROR);
             return -1;
         }
@@ -981,7 +981,7 @@ static int get_server_finished(SSL *s)
     } else {
         if (!(s->options & SSL_OP_MICROSOFT_SESS_ID_BUG)) {
             if ((s->session->session_id_length >
-                 sizeof s->session->session_id)
+                 sizeof(s->session->session_id))
                 || (0 !=
                     memcmp(buf + 1, s->session->session_id,
                            (unsigned int)s->session->session_id_length))) {

--- a/thirdparty/openssl/ssl/s2_enc.c
+++ b/thirdparty/openssl/ssl/s2_enc.c
@@ -99,7 +99,7 @@ int ssl2_enc_init(SSL *s, int client)
 
     num = c->key_len;
     s->s2->key_material_length = num * 2;
-    OPENSSL_assert(s->s2->key_material_length <= sizeof s->s2->key_material);
+    OPENSSL_assert(s->s2->key_material_length <= sizeof(s->s2->key_material));
 
     if (ssl2_generate_key_material(s) <= 0)
         return 0;

--- a/thirdparty/openssl/ssl/s2_lib.c
+++ b/thirdparty/openssl/ssl/s2_lib.c
@@ -326,9 +326,9 @@ int ssl2_new(SSL *s)
 {
     SSL2_STATE *s2;
 
-    if ((s2 = OPENSSL_malloc(sizeof *s2)) == NULL)
+    if ((s2 = OPENSSL_malloc(sizeof(*s2))) == NULL)
         goto err;
-    memset(s2, 0, sizeof *s2);
+    memset(s2, 0, sizeof(*s2));
 
 # if SSL2_MAX_RECORD_LENGTH_3_BYTE_HEADER + 3 > SSL2_MAX_RECORD_LENGTH_2_BYTE_HEADER + 2
 #  error "assertion failed"
@@ -371,7 +371,7 @@ void ssl2_free(SSL *s)
         OPENSSL_free(s2->rbuf);
     if (s2->wbuf != NULL)
         OPENSSL_free(s2->wbuf);
-    OPENSSL_cleanse(s2, sizeof *s2);
+    OPENSSL_cleanse(s2, sizeof(*s2));
     OPENSSL_free(s2);
     s->s2 = NULL;
 }
@@ -386,7 +386,7 @@ void ssl2_clear(SSL *s)
     rbuf = s2->rbuf;
     wbuf = s2->wbuf;
 
-    memset(s2, 0, sizeof *s2);
+    memset(s2, 0, sizeof(*s2));
 
     s2->rbuf = rbuf;
     s2->wbuf = wbuf;

--- a/thirdparty/openssl/ssl/s2_srvr.c
+++ b/thirdparty/openssl/ssl/s2_srvr.c
@@ -724,7 +724,7 @@ static int get_client_hello(SSL *s)
     p += s->s2->tmp.session_id_length;
 
     /* challenge */
-    if (s->s2->challenge_length > sizeof s->s2->challenge) {
+    if (s->s2->challenge_length > sizeof(s->s2->challenge)) {
         ssl2_return_error(s, SSL2_PE_UNDEFINED_ERROR);
         SSLerr(SSL_F_GET_CLIENT_HELLO, ERR_R_INTERNAL_ERROR);
         return -1;
@@ -872,7 +872,7 @@ static int get_client_finished(SSL *s)
     }
 
     /* SSL2_ST_GET_CLIENT_FINISHED_B */
-    if (s->s2->conn_id_length > sizeof s->s2->conn_id) {
+    if (s->s2->conn_id_length > sizeof(s->s2->conn_id)) {
         ssl2_return_error(s, SSL2_PE_UNDEFINED_ERROR);
         SSLerr(SSL_F_GET_CLIENT_FINISHED, ERR_R_INTERNAL_ERROR);
         return -1;
@@ -903,7 +903,7 @@ static int server_verify(SSL *s)
     if (s->state == SSL2_ST_SEND_SERVER_VERIFY_A) {
         p = (unsigned char *)s->init_buf->data;
         *(p++) = SSL2_MT_SERVER_VERIFY;
-        if (s->s2->challenge_length > sizeof s->s2->challenge) {
+        if (s->s2->challenge_length > sizeof(s->s2->challenge)) {
             SSLerr(SSL_F_SERVER_VERIFY, ERR_R_INTERNAL_ERROR);
             return -1;
         }
@@ -925,7 +925,7 @@ static int server_finish(SSL *s)
         p = (unsigned char *)s->init_buf->data;
         *(p++) = SSL2_MT_SERVER_FINISHED;
 
-        if (s->session->session_id_length > sizeof s->session->session_id) {
+        if (s->session->session_id_length > sizeof(s->session->session_id)) {
             SSLerr(SSL_F_SERVER_FINISH, ERR_R_INTERNAL_ERROR);
             return -1;
         }

--- a/thirdparty/openssl/ssl/s3_clnt.c
+++ b/thirdparty/openssl/ssl/s3_clnt.c
@@ -984,7 +984,7 @@ int ssl3_get_server_hello(SSL *s)
     /* get the session-id */
     j = *(p++);
 
-    if ((j > sizeof s->session->session_id) || (j > SSL3_SESSION_ID_SIZE)) {
+    if ((j > sizeof(s->session->session_id)) || (j > SSL3_SESSION_ID_SIZE)) {
         al = SSL_AD_ILLEGAL_PARAMETER;
         SSLerr(SSL_F_SSL3_GET_SERVER_HELLO, SSL_R_SSL3_SESSION_ID_TOO_LONG);
         goto f_err;
@@ -2561,16 +2561,16 @@ int ssl3_send_client_key_exchange(SSL *s)
 
             tmp_buf[0] = s->client_version >> 8;
             tmp_buf[1] = s->client_version & 0xff;
-            if (RAND_bytes(&(tmp_buf[2]), sizeof tmp_buf - 2) <= 0)
+            if (RAND_bytes(&(tmp_buf[2]), sizeof(tmp_buf) - 2) <= 0)
                 goto err;
 
-            s->session->master_key_length = sizeof tmp_buf;
+            s->session->master_key_length = sizeof(tmp_buf);
 
             q = p;
             /* Fix buf for TLS and beyond */
             if (s->version > SSL3_VERSION)
                 p += 2;
-            n = RSA_public_encrypt(sizeof tmp_buf,
+            n = RSA_public_encrypt(sizeof(tmp_buf),
                                    tmp_buf, p, rsa, RSA_PKCS1_PADDING);
 # ifdef PKCS1_CHECK
             if (s->options & SSL_OP_PKCS1_CHECK_1)
@@ -2595,8 +2595,8 @@ int ssl3_send_client_key_exchange(SSL *s)
                                                             s->
                                                             session->master_key,
                                                             tmp_buf,
-                                                            sizeof tmp_buf);
-            OPENSSL_cleanse(tmp_buf, sizeof tmp_buf);
+                                                            sizeof(tmp_buf));
+            OPENSSL_cleanse(tmp_buf, sizeof(tmp_buf));
         }
 #endif
 #ifndef OPENSSL_NO_KRB5
@@ -2688,7 +2688,7 @@ int ssl3_send_client_key_exchange(SSL *s)
 
             tmp_buf[0] = s->client_version >> 8;
             tmp_buf[1] = s->client_version & 0xff;
-            if (RAND_bytes(&(tmp_buf[2]), sizeof tmp_buf - 2) <= 0)
+            if (RAND_bytes(&(tmp_buf[2]), sizeof(tmp_buf) - 2) <= 0)
                 goto err;
 
             /*-
@@ -2699,13 +2699,13 @@ int ssl3_send_client_key_exchange(SSL *s)
              *      EVP_EncryptInit_ex(&ciph_ctx,NULL, key,iv);
              */
 
-            memset(iv, 0, sizeof iv); /* per RFC 1510 */
+            memset(iv, 0, sizeof(iv)); /* per RFC 1510 */
             EVP_EncryptInit_ex(&ciph_ctx, enc, NULL, kssl_ctx->key, iv);
             EVP_EncryptUpdate(&ciph_ctx, epms, &outl, tmp_buf,
-                              sizeof tmp_buf);
+                              sizeof(tmp_buf));
             EVP_EncryptFinal_ex(&ciph_ctx, &(epms[outl]), &padl);
             outl += padl;
-            if (outl > (int)sizeof epms) {
+            if (outl > (int)sizeof(epms)) {
                 SSLerr(SSL_F_SSL3_SEND_CLIENT_KEY_EXCHANGE,
                        ERR_R_INTERNAL_ERROR);
                 goto err;
@@ -2723,9 +2723,9 @@ int ssl3_send_client_key_exchange(SSL *s)
                                                             s->
                                                             session->master_key,
                                                             tmp_buf,
-                                                            sizeof tmp_buf);
+                                                            sizeof(tmp_buf));
 
-            OPENSSL_cleanse(tmp_buf, sizeof tmp_buf);
+            OPENSSL_cleanse(tmp_buf, sizeof(tmp_buf));
             OPENSSL_cleanse(epms, outl);
         }
 #endif

--- a/thirdparty/openssl/ssl/s3_lib.c
+++ b/thirdparty/openssl/ssl/s3_lib.c
@@ -3018,9 +3018,9 @@ int ssl3_new(SSL *s)
 {
     SSL3_STATE *s3;
 
-    if ((s3 = OPENSSL_malloc(sizeof *s3)) == NULL)
+    if ((s3 = OPENSSL_malloc(sizeof(*s3))) == NULL)
         goto err;
-    memset(s3, 0, sizeof *s3);
+    memset(s3, 0, sizeof(*s3));
     memset(s3->rrec.seq_num, 0, sizeof(s3->rrec.seq_num));
     memset(s3->wrec.seq_num, 0, sizeof(s3->wrec.seq_num));
 
@@ -3078,7 +3078,7 @@ void ssl3_free(SSL *s)
 #ifndef OPENSSL_NO_SRP
     SSL_SRP_CTX_free(s);
 #endif
-    OPENSSL_cleanse(s->s3, sizeof *s->s3);
+    OPENSSL_cleanse(s->s3, sizeof(*s->s3));
     OPENSSL_free(s->s3);
     s->s3 = NULL;
 }
@@ -3142,7 +3142,7 @@ void ssl3_clear(SSL *s)
         s->s3->alpn_selected = NULL;
     }
 #endif
-    memset(s->s3, 0, sizeof *s->s3);
+    memset(s->s3, 0, sizeof(*s->s3));
     s->s3->rbuf.buf = rp;
     s->s3->wbuf.buf = wp;
     s->s3->rbuf.len = rlen;

--- a/thirdparty/openssl/ssl/s3_srvr.c
+++ b/thirdparty/openssl/ssl/s3_srvr.c
@@ -2510,7 +2510,7 @@ int ssl3_get_client_key_exchange(SSL *s)
         /*
          * Note that the length is checked again below, ** after decryption
          */
-        if (enc_pms.length > sizeof pms) {
+        if (enc_pms.length > sizeof(pms)) {
             SSLerr(SSL_F_SSL3_GET_CLIENT_KEY_EXCHANGE,
                    SSL_R_DATA_LENGTH_TOO_LONG);
             goto err;
@@ -2563,7 +2563,7 @@ int ssl3_get_client_key_exchange(SSL *s)
         if (enc == NULL)
             goto err;
 
-        memset(iv, 0, sizeof iv); /* per RFC 1510 */
+        memset(iv, 0, sizeof(iv)); /* per RFC 1510 */
 
         if (!EVP_DecryptInit_ex(&ciph_ctx, enc, NULL, kssl_ctx->key, iv)) {
             SSLerr(SSL_F_SSL3_GET_CLIENT_KEY_EXCHANGE,

--- a/thirdparty/openssl/ssl/ssl_cert.c
+++ b/thirdparty/openssl/ssl/ssl_cert.c
@@ -636,13 +636,13 @@ SESS_CERT *ssl_sess_cert_new(void)
 {
     SESS_CERT *ret;
 
-    ret = OPENSSL_malloc(sizeof *ret);
+    ret = OPENSSL_malloc(sizeof(*ret));
     if (ret == NULL) {
         SSLerr(SSL_F_SSL_SESS_CERT_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
 
-    memset(ret, 0, sizeof *ret);
+    memset(ret, 0, sizeof(*ret));
     ret->peer_key = &(ret->peer_pkeys[SSL_PKEY_RSA_ENC]);
     ret->references = 1;
 
@@ -1018,15 +1018,15 @@ int SSL_add_dir_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
         char buf[1024];
         int r;
 
-        if (strlen(dir) + strlen(filename) + 2 > sizeof buf) {
+        if (strlen(dir) + strlen(filename) + 2 > sizeof(buf)) {
             SSLerr(SSL_F_SSL_ADD_DIR_CERT_SUBJECTS_TO_STACK,
                    SSL_R_PATH_TOO_LONG);
             goto err;
         }
 #ifdef OPENSSL_SYS_VMS
-        r = BIO_snprintf(buf, sizeof buf, "%s%s", dir, filename);
+        r = BIO_snprintf(buf, sizeof(buf), "%s%s", dir, filename);
 #else
-        r = BIO_snprintf(buf, sizeof buf, "%s/%s", dir, filename);
+        r = BIO_snprintf(buf, sizeof(buf), "%s/%s", dir, filename);
 #endif
         if (r <= 0 || r >= (int)sizeof(buf))
             goto err;

--- a/thirdparty/openssl/ssl/ssl_lib.c
+++ b/thirdparty/openssl/ssl/ssl_lib.c
@@ -343,7 +343,7 @@ SSL *SSL_new(SSL_CTX *ctx)
     s->verify_depth = ctx->verify_depth;
 #endif
     s->sid_ctx_length = ctx->sid_ctx_length;
-    OPENSSL_assert(s->sid_ctx_length <= sizeof s->sid_ctx);
+    OPENSSL_assert(s->sid_ctx_length <= sizeof(s->sid_ctx));
     memcpy(&s->sid_ctx, &ctx->sid_ctx, sizeof(s->sid_ctx));
     s->verify_callback = ctx->default_verify_callback;
     s->generate_session_id = ctx->generate_session_id;
@@ -437,7 +437,7 @@ SSL *SSL_new(SSL_CTX *ctx)
 int SSL_CTX_set_session_id_context(SSL_CTX *ctx, const unsigned char *sid_ctx,
                                    unsigned int sid_ctx_len)
 {
-    if (sid_ctx_len > sizeof ctx->sid_ctx) {
+    if (sid_ctx_len > sizeof(ctx->sid_ctx)) {
         SSLerr(SSL_F_SSL_CTX_SET_SESSION_ID_CONTEXT,
                SSL_R_SSL_SESSION_ID_CONTEXT_TOO_LONG);
         return 0;
@@ -490,7 +490,7 @@ int SSL_has_matching_session_id(const SSL *ssl, const unsigned char *id,
      */
     SSL_SESSION r, *p;
 
-    if (id_len > sizeof r.session_id)
+    if (id_len > sizeof(r.session_id))
         return 0;
 
     r.ssl_version = ssl->version;

--- a/thirdparty/openssl/ssl/ssl_sess.c
+++ b/thirdparty/openssl/ssl/ssl_sess.c
@@ -529,7 +529,7 @@ int ssl_get_new_session(SSL *s, int session)
         ss->session_id_length = 0;
     }
 
-    if (s->sid_ctx_length > sizeof ss->sid_ctx) {
+    if (s->sid_ctx_length > sizeof(ss->sid_ctx)) {
         SSLerr(SSL_F_SSL_GET_NEW_SESSION, ERR_R_INTERNAL_ERROR);
         SSL_SESSION_free(ss);
         return 0;
@@ -870,9 +870,9 @@ void SSL_SESSION_free(SSL_SESSION *ss)
 
     CRYPTO_free_ex_data(CRYPTO_EX_INDEX_SSL_SESSION, ss, &ss->ex_data);
 
-    OPENSSL_cleanse(ss->key_arg, sizeof ss->key_arg);
-    OPENSSL_cleanse(ss->master_key, sizeof ss->master_key);
-    OPENSSL_cleanse(ss->session_id, sizeof ss->session_id);
+    OPENSSL_cleanse(ss->key_arg, sizeof(ss->key_arg));
+    OPENSSL_cleanse(ss->master_key, sizeof(ss->master_key));
+    OPENSSL_cleanse(ss->session_id, sizeof(ss->session_id));
     if (ss->sess_cert != NULL)
         ssl_sess_cert_free(ss->sess_cert);
     if (ss->peer != NULL)

--- a/thirdparty/openssl/ssl/t1_enc.c
+++ b/thirdparty/openssl/ssl/t1_enc.c
@@ -972,7 +972,7 @@ int tls1_final_finish_mac(SSL *s,
             int hashsize = EVP_MD_size(md);
             EVP_MD_CTX *hdgst = s->s3->handshake_dgst[idx];
             if (!hdgst || hashsize < 0
-                || hashsize > (int)(sizeof buf - (size_t)(q - buf))) {
+                || hashsize > (int)(sizeof(buf) - (size_t)(q - buf))) {
                 /*
                  * internal error: 'buf' is too small for this cipersuite!
                  */
@@ -990,7 +990,7 @@ int tls1_final_finish_mac(SSL *s,
     if (!tls1_PRF(ssl_get_algorithm2(s),
                   str, slen, buf, (int)(q - buf), NULL, 0, NULL, 0, NULL, 0,
                   s->session->master_key, s->session->master_key_length,
-                  out, buf2, sizeof buf2))
+                  out, buf2, sizeof(buf2)))
         err = 1;
     EVP_MD_CTX_cleanup(&ctx);
 
@@ -999,7 +999,7 @@ int tls1_final_finish_mac(SSL *s,
     if (err)
         return 0;
     else
-        return sizeof buf2;
+        return sizeof(buf2);
 }
 
 int tls1_mac(SSL *ssl, unsigned char *md, int send)
@@ -1165,8 +1165,8 @@ int tls1_generate_master_secret(SSL *s, unsigned char *out, unsigned char *p,
              s->s3->client_random, SSL3_RANDOM_SIZE,
              co, col,
              s->s3->server_random, SSL3_RANDOM_SIZE,
-             so, sol, p, len, s->session->master_key, buff, sizeof buff);
-    OPENSSL_cleanse(buff, sizeof buff);
+             so, sol, p, len, s->session->master_key, buff, sizeof(buff));
+    OPENSSL_cleanse(buff, sizeof(buff));
 #ifdef SSL_DEBUG
     fprintf(stderr, "Premaster Secret:\n");
     BIO_dump_fp(stderr, (char *)p, len);

--- a/thirdparty/openssl/ssl/t1_lib.c
+++ b/thirdparty/openssl/ssl/t1_lib.c
@@ -56,7 +56,7 @@
  * [including the GNU Public Licence.]
  */
 /* ====================================================================
- * Copyright (c) 1998-2007 The OpenSSL Project.  All rights reserved.
+ * Copyright (c) 1998-2018 The OpenSSL Project.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -2284,8 +2284,12 @@ static int ssl_scan_clienthello_tlsext(SSL *s, unsigned char **p,
 # ifndef OPENSSL_NO_EC
         else if (type == TLSEXT_TYPE_ec_point_formats) {
             unsigned char *sdata = data;
-            int ecpointformatlist_length = *(sdata++);
+            int ecpointformatlist_length;
 
+            if (size == 0)
+                goto err;
+
+            ecpointformatlist_length = *(sdata++);
             if (ecpointformatlist_length != size - 1 ||
                 ecpointformatlist_length < 1)
                 goto err;
@@ -2711,8 +2715,14 @@ static int ssl_scan_serverhello_tlsext(SSL *s, unsigned char **p,
 # ifndef OPENSSL_NO_EC
         else if (type == TLSEXT_TYPE_ec_point_formats) {
             unsigned char *sdata = data;
-            int ecpointformatlist_length = *(sdata++);
+            int ecpointformatlist_length;
 
+            if (size == 0) {
+                *al = TLS1_AD_DECODE_ERROR;
+                return 0;
+            }
+
+            ecpointformatlist_length = *(sdata++);
             if (ecpointformatlist_length != size - 1) {
                 *al = TLS1_AD_DECODE_ERROR;
                 return 0;
@@ -3505,6 +3515,10 @@ static int tls_decrypt_ticket(SSL *s, const unsigned char *etick,
     EVP_CIPHER_CTX ctx;
     SSL_CTX *tctx = s->initial_ctx;
 
+    /* Need at least keyname + iv */
+    if (eticklen < 16 + EVP_MAX_IV_LENGTH)
+        return 2;
+
     /* Initialize session ticket encryption and HMAC contexts */
     HMAC_CTX_init(&hctx);
     EVP_CIPHER_CTX_init(&ctx);
@@ -3513,9 +3527,12 @@ static int tls_decrypt_ticket(SSL *s, const unsigned char *etick,
         int rv = tctx->tlsext_ticket_key_cb(s, nctick, nctick + 16,
                                             &ctx, &hctx, 0);
         if (rv < 0)
-            return -1;
-        if (rv == 0)
+            goto err;
+        if (rv == 0) {
+            HMAC_CTX_cleanup(&hctx);
+            EVP_CIPHER_CTX_cleanup(&ctx);
             return 2;
+        }
         if (rv == 2)
             renew_ticket = 1;
     } else {

--- a/thirdparty/openssl/ssl/t1_trce.c
+++ b/thirdparty/openssl/ssl/t1_trce.c
@@ -1247,13 +1247,15 @@ void SSL_trace(int write_p, int version, int content_type,
         break;
 
     case SSL3_RT_ALERT:
-        if (msglen != 2)
+        if (msglen != 2) {
             BIO_puts(bio, "    Illegal Alert Length\n");
-        else {
+        } else {
             BIO_printf(bio, "    Level=%s(%d), description=%s(%d)\n",
                        SSL_alert_type_string_long(msg[0] << 8),
                        msg[0], SSL_alert_desc_string_long(msg[1]), msg[1]);
         }
+        break;
+
     case TLS1_RT_HEARTBEAT:
         ssl_print_heartbeat(bio, 4, msg, msglen);
         break;


### PR DESCRIPTION
Fixes:
- Constructed ASN.1 types with a recursive definition could exceed the stack (CVE-2018-0739)

Will also cherry-pick for 2.1 - master is not affected.