### PR TITLE
Raw input relative motion for Windows

### DIFF
--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -125,6 +125,8 @@ class OS_Windows : public OS {
 	bool force_quit;
 	bool window_has_focus;
 	uint32_t last_button_state;
+	Vector2 last_absolute_position;
+	bool use_raw_input;
 
 	HCURSOR cursors[CURSOR_MAX] = { NULL };
 	CursorShape cursor_shape;


### PR DESCRIPTION
This makes Windows use raw input when using MOUSE_MODE_CAPTURED.

When captured mouse position will always return center of the window and speed will  return 0.
I think this is okay, because they aren't really relevant when capturing mouse. Right?