### PR TITLE
Tweak AppStream metadata and add MIME type integration

### DIFF
--- a/misc/dist/linux/org.godotengine.Godot.appdata.xml
+++ b/misc/dist/linux/org.godotengine.Godot.appdata.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2017-2018 Rémi Verschelde <akien@godotengine.org> -->
 <component type="desktop">
-  <id>org.godotengine.Godot.desktop</id>
+  <id>org.godotengine.Godot</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MIT</project_license>
   <name>Godot Engine</name>
   <summary>Multi-platform 2D and 3D game engine with a feature-rich editor</summary>
-  <icon type="remote">https://raw.githubusercontent.com/godotengine/godot/master/icon.png</icon>
   ​<launchable type="desktop-id">org.godotengine.Godot.desktop</launchable>
   <description>
     <p>
@@ -26,9 +25,6 @@
       <image>https://download.tuxfamily.org/godotengine/media/screenshots/editor_3d_fracteed-720p.jpg</image>
     </screenshot>
   </screenshots>
-  <categories>
-    <category>Development</category>
-  </categories>
   <url type="homepage">https://godotengine.org</url>
   <url type="bugtracker">https://github.com/godotengine/godot/issues</url>
   <url type="faq">http://docs.godotengine.org/en/latest/about/faq.html</url>

--- a/misc/dist/linux/org.godotengine.Godot.desktop
+++ b/misc/dist/linux/org.godotengine.Godot.desktop
@@ -2,8 +2,9 @@
 Name=Godot Engine
 GenericName=Libre game engine
 Comment=Multi-platform 2D and 3D game engine with a feature-rich editor
-Exec=godot -p
+Exec=godot %f
 Icon=godot
 Terminal=false
 Type=Application
+MimeType=application/x-godot-project;
 Categories=Development;IDE;

--- a/misc/dist/linux/org.godotengine.Godot.xml
+++ b/misc/dist/linux/org.godotengine.Godot.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+ <mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+   <mime-type type="application/x-godot-project">
+   <comment>Godot Engine project</comment>
+   <icon name="godot" />
+   <glob pattern="*.godot" weight="100" />
+  </mime-type>
+</mime-info>


### PR DESCRIPTION
This allows Godot to be registered as an application to open Godot project files.

Follow-up to https://github.com/godotengine/godot/pull/20282.