### PR TITLE
Initialize theme after init_languages has been called in main function

### DIFF
--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -694,43 +694,6 @@ void register_scene_types() {
 #endif
 
 	OS::get_singleton()->yield(); //may take time to init
-
-	for (int i = 0; i < 20; i++) {
-		GLOBAL_DEF("layer_names/2d_render/layer_" + itos(i + 1), "");
-		GLOBAL_DEF("layer_names/2d_physics/layer_" + itos(i + 1), "");
-		GLOBAL_DEF("layer_names/3d_render/layer_" + itos(i + 1), "");
-		GLOBAL_DEF("layer_names/3d_physics/layer_" + itos(i + 1), "");
-	}
-
-	bool default_theme_hidpi = GLOBAL_DEF("gui/theme/use_hidpi", false);
-	ProjectSettings::get_singleton()->set_custom_property_info("gui/theme/use_hidpi", PropertyInfo(Variant::BOOL, "gui/theme/use_hidpi", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED));
-	String theme_path = GLOBAL_DEF("gui/theme/custom", "");
-	ProjectSettings::get_singleton()->set_custom_property_info("gui/theme/custom", PropertyInfo(Variant::STRING, "gui/theme/custom", PROPERTY_HINT_FILE, "*.tres,*.res,*.theme", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED));
-	String font_path = GLOBAL_DEF("gui/theme/custom_font", "");
-	ProjectSettings::get_singleton()->set_custom_property_info("gui/theme/custom_font", PropertyInfo(Variant::STRING, "gui/theme/custom_font", PROPERTY_HINT_FILE, "*.tres,*.res,*.font", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED));
-
-	Ref<Font> font;
-	if (font_path != String()) {
-		font = ResourceLoader::load(font_path);
-		if (!font.is_valid()) {
-			ERR_PRINTS("Error loading custom font '" + font_path + "'");
-		}
-	}
-
-	// Always make the default theme to avoid invalid default font/icon/style in the given theme
-	make_default_theme(default_theme_hidpi, font);
-
-	if (theme_path != String()) {
-		Ref<Theme> theme = ResourceLoader::load(theme_path);
-		if (theme.is_valid()) {
-			Theme::set_default(theme);
-			if (font.is_valid()) {
-				Theme::set_default_font(font);
-			}
-		} else {
-			ERR_PRINTS("Error loading custom theme '" + theme_path + "'");
-		}
-	}
 }
 
 void unregister_scene_types() {


### PR DESCRIPTION
This changes the load order of the code to set up a theme defined in the configuration to only after the scripting languages have been initialized and has been segregated into its own separate function, as well as one for layers and the mouse cursor. This is to fix a very specific issue where I'm creating a custom resource derived from a theme with extensions for things like embedding audio data, but with the original load order, the script the theme was deriving from would not load if it was defined as a custom theme in the project config, because at this stage, it does not know how to load a GDScript resource and thus fails.

From a design perspective, it probably also makes more sense for the theme loading code to be separated from type initialization code too.