### PR TITLE
Added new scaling modes to splash screen

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -157,8 +157,8 @@
 		</method>
 	</methods>
 	<members>
-		<member name="application/boot_splash/fullsize" type="bool" setter="" getter="">
-			Scale the boot splash image to the full window length when engine starts (will leave it as default pixel size otherwise).
+		<member name="application/boot_splash/scale" type="String" setter="" getter="">
+			Scale the boot splash image using the selected mode (will leave it as default pixel size if disabled).
 		</member>
 		<member name="application/boot_splash/image" type="String" setter="" getter="">
 			Path to an image used for boot splash.

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -774,7 +774,7 @@ public:
 	RasterizerCanvas *get_canvas() { return &canvas; }
 	RasterizerScene *get_scene() { return &scene; }
 
-	void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale) {}
+	void set_boot_image(const Ref<Image> &p_image, const Color &p_color, const String &p_scale) {}
 
 	void initialize() {}
 	void begin_frame(double frame_step) {}

--- a/drivers/gles2/rasterizer_gles2.h
+++ b/drivers/gles2/rasterizer_gles2.h
@@ -50,7 +50,7 @@ public:
 	virtual RasterizerCanvas *get_canvas();
 	virtual RasterizerScene *get_scene();
 
-	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale);
+	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, const String &p_scale);
 
 	virtual void initialize();
 	virtual void begin_frame(double frame_step);

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -267,7 +267,7 @@ void RasterizerGLES3::clear_render_target(const Color &p_color) {
 	storage->frame.clear_request_color = p_color;
 }
 
-void RasterizerGLES3::set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale) {
+void RasterizerGLES3::set_boot_image(const Ref<Image> &p_image, const Color &p_color, const String &p_scale) {
 
 	if (p_image.is_null() || p_image->empty())
 		return;
@@ -295,14 +295,41 @@ void RasterizerGLES3::set_boot_image(const Ref<Image> &p_image, const Color &p_c
 
 	Rect2 imgrect(0, 0, p_image->get_width(), p_image->get_height());
 	Rect2 screenrect;
-	if (p_scale) {
 
+	if (p_scale == "keep_height") {
+		//scale horizontally
+		screenrect.size.y = window_h;
+		screenrect.size.x = imgrect.size.x * window_h / imgrect.size.y;
+		screenrect.position.x = (window_w - screenrect.size.x) / 2;
+	} else if (p_scale == "keep_width") {
+		//scale vertically
+		screenrect.size.x = window_w;
+		screenrect.size.y = imgrect.size.y * window_w / imgrect.size.x;
+		screenrect.position.y = (window_h - screenrect.size.y) / 2;
+	} else if (p_scale == "cover") {
+		double window_aspect = (double)window_w / window_h;
+		double img_aspect = imgrect.size.x / imgrect.size.y;
+
+		if (window_aspect > img_aspect) {
+			//scale vertically
+			screenrect.size.x = window_w;
+			screenrect.size.y = imgrect.size.y * window_w / imgrect.size.x;
+			screenrect.position.y = (window_h - screenrect.size.y) / 2;
+		} else {
+			//scale horizontally
+			screenrect.size.y = window_h;
+			screenrect.size.x = imgrect.size.x * window_h / imgrect.size.y;
+			screenrect.position.x = (window_w - screenrect.size.x) / 2;
+		}
+	} else if (p_scale == "expand") {
+		screenrect.size.x = window_w;
+		screenrect.size.y = window_h;
+	} else if (p_scale == "full_size") {
 		if (window_w > window_h) {
 			//scale horizontally
 			screenrect.size.y = window_h;
 			screenrect.size.x = imgrect.size.x * window_h / imgrect.size.y;
 			screenrect.position.x = (window_w - screenrect.size.x) / 2;
-
 		} else {
 			//scale vertically
 			screenrect.size.x = window_w;
@@ -310,7 +337,6 @@ void RasterizerGLES3::set_boot_image(const Ref<Image> &p_image, const Color &p_c
 			screenrect.position.y = (window_h - screenrect.size.y) / 2;
 		}
 	} else {
-
 		screenrect = imgrect;
 		screenrect.position += ((Size2(window_w, window_h) - screenrect.size) / 2.0).floor();
 	}

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -51,7 +51,7 @@ public:
 	virtual RasterizerCanvas *get_canvas();
 	virtual RasterizerScene *get_scene();
 
-	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale);
+	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, const String &p_scale);
 
 	virtual void initialize();
 	virtual void begin_frame(double frame_step);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1085,8 +1085,10 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	if (show_logo) { //boot logo!
 		String boot_logo_path = GLOBAL_DEF("application/boot_splash/image", String());
-		bool boot_logo_scale = GLOBAL_DEF("application/boot_splash/fullsize", true);
 		ProjectSettings::get_singleton()->set_custom_property_info("application/boot_splash/image", PropertyInfo(Variant::STRING, "application/boot_splash/image", PROPERTY_HINT_FILE, "*.png"));
+
+		const String boot_logo_scale = GLOBAL_DEF("application/boot_splash/scale", "disabled");
+		ProjectSettings::get_singleton()->set_custom_property_info("application/boot_splash/scale", PropertyInfo(Variant::STRING, "application/boot_splash/scale", PROPERTY_HINT_ENUM, "disabled,keep_width,keep_height,cover,expand,full_size"));
 
 		Ref<Image> boot_logo;
 
@@ -1104,6 +1106,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 			OS::get_singleton()->_msec_splash = OS::get_singleton()->get_ticks_msec();
 			Color boot_bg = GLOBAL_DEF("application/boot_splash/bg_color", clear);
 			VisualServer::get_singleton()->set_boot_image(boot_logo, boot_bg, boot_logo_scale);
+
 #ifndef TOOLS_ENABLED
 //no tools, so free the boot logo (no longer needed)
 //ProjectSettings::get_singleton()->set("application/boot_logo",Image());
@@ -1123,7 +1126,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 			MAIN_PRINT("Main: ClearColor");
 			VisualServer::get_singleton()->set_default_clear_color(boot_splash_bg_color);
 			MAIN_PRINT("Main: Image");
-			VisualServer::get_singleton()->set_boot_image(splash, boot_splash_bg_color, false);
+			VisualServer::get_singleton()->set_boot_image(splash, boot_splash_bg_color, "disabled");
 #endif
 		}
 

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -1075,7 +1075,7 @@ public:
 	virtual RasterizerCanvas *get_canvas() = 0;
 	virtual RasterizerScene *get_scene() = 0;
 
-	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale) = 0;
+	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, const String &p_scale) = 0;
 
 	virtual void initialize() = 0;
 	virtual void begin_frame(double frame_step) = 0;

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -155,7 +155,7 @@ int VisualServerRaster::get_render_info(RenderInfo p_info) {
 
 /* TESTING */
 
-void VisualServerRaster::set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale) {
+void VisualServerRaster::set_boot_image(const Ref<Image> &p_image, const Color &p_color, const String &p_scale) {
 
 	redraw_request();
 	VSG::rasterizer->set_boot_image(p_image, p_color, p_scale);

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -674,7 +674,7 @@ public:
 
 	/* TESTING */
 
-	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale);
+	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, const String &p_scale);
 	virtual void set_default_clear_color(const Color &p_color);
 
 	virtual bool has_feature(Features p_feature) const;

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -589,7 +589,7 @@ public:
 		return visual_server->get_render_info(p_info);
 	}
 
-	FUNC3(set_boot_image, const Ref<Image> &, const Color &, bool)
+	FUNC3(set_boot_image, const Ref<Image> &, const Color &, const String &)
 	FUNC1(set_default_clear_color, const Color &)
 
 	FUNC0R(RID, get_test_cube)

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -993,7 +993,7 @@ public:
 	virtual void mesh_add_surface_from_mesh_data(RID p_mesh, const Geometry::MeshData &p_mesh_data);
 	virtual void mesh_add_surface_from_planes(RID p_mesh, const PoolVector<Plane> &p_planes);
 
-	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale) = 0;
+	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, const String &p_scale) = 0;
 	virtual void set_default_clear_color(const Color &p_color) = 0;
 
 	enum Features {


### PR DESCRIPTION
The only way to scale the boot splash image is the option "Application/Boot Splash/fullsize" in the project settings. This PR adds 4 new ways of scaling: keep_width, keep_height, cover and expand and keeps the previous one (calling it full_size).

The old fullsize option looked like this:
![fullsize_option](https://user-images.githubusercontent.com/8157352/43356151-9a4e94fe-926b-11e8-914d-cdd455b33321.png)

And I replaced it for a new option I called "scale":
![new_scaling_modes](https://user-images.githubusercontent.com/8157352/43356154-ac65bd5c-926b-11e8-84b2-bc1ccf9752c9.png)

Here I show some pictures to illustrate how each scaling mode works. In each case an icon with size 64x64 is used:

| Scaling Mode | Horizontal (960x540) | Vertical (540x960) |
| ------------- | ------------- | ------------- |
| disabled  | ![h_fullsize_off](https://user-images.githubusercontent.com/8157352/43355917-985f0818-9266-11e8-85e0-3e76241e3cc0.png) | ![v_fullsize_off](https://user-images.githubusercontent.com/8157352/43355920-acea9b44-9266-11e8-9eec-0f8483652ede.png) |
| keep_width  | ![h_keep_width](https://user-images.githubusercontent.com/8157352/43355935-dd389bf2-9266-11e8-8f16-69b363d3c5a5.png)  | ![v_fullsize_on](https://user-images.githubusercontent.com/8157352/43355943-f0a2d144-9266-11e8-94c6-131086427154.png)  |
| keep_height  | ![h_fullsize_on](https://user-images.githubusercontent.com/8157352/43355939-ee6ae6be-9266-11e8-9186-2ee769baa5c9.png)  | ![v_keep_height](https://user-images.githubusercontent.com/8157352/43355944-f0d9b8ee-9266-11e8-9fe1-f2c2dfcc3401.png)  |
| cover | ![h_keep_width](https://user-images.githubusercontent.com/8157352/43355935-dd389bf2-9266-11e8-8f16-69b363d3c5a5.png)  | ![v_keep_height](https://user-images.githubusercontent.com/8157352/43355944-f0d9b8ee-9266-11e8-9fe1-f2c2dfcc3401.png)  |
| expand  | ![h_expand](https://user-images.githubusercontent.com/8157352/43355937-ee2b2326-9266-11e8-87c9-83af89423e21.png) | ![v_expand](https://user-images.githubusercontent.com/8157352/43355940-eed1dc7a-9266-11e8-87c9-05c7e358db77.png)  |
| full_size  | ![h_fullsize_on](https://user-images.githubusercontent.com/8157352/43355939-ee6ae6be-9266-11e8-9186-2ee769baa5c9.png) | ![v_fullsize_on](https://user-images.githubusercontent.com/8157352/43355943-f0a2d144-9266-11e8-94c6-131086427154.png) |

The last one scales in the same way as the previous "fullsize" boolean option.

I updated both `rasterizer_gles2.cpp` and `rasterizer_gles3.cpp`. I also realised that the old "fullsize" option was not working when using GLES2.

This is my first PR so any tips, suggestions, recommendations... about anything are very welcome, specially if it's code-related.