### PR TITLE
Fix crash with DynamicFont

### DIFF
--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -547,7 +547,7 @@ DynamicFontAtSize::Character DynamicFontAtSize::_bitmap_to_character(FT_Bitmap b
 	// update height array
 
 	for (int k = tex_pos.x; k < tex_pos.x + mw; k++) {
-		tex.offsets.write[k] = tex_pos.y + mh;
+		tex.offsets.set(k, tex_pos.y + mh);
 	}
 
 	Character chr;


### PR DESCRIPTION
Fix #20475

I don't understand it doesn't crash with this
https://github.com/godotengine/godot/blob/90298ddf01622ec4d8a50deaf7c351a766b9e78a/core/vector.h#L86

it actually call `size()`
https://github.com/godotengine/godot/blob/90298ddf01622ec4d8a50deaf7c351a766b9e78a/core/cowdata.h#L129-L134

like `.write[]`
https://github.com/godotengine/godot/blob/90298ddf01622ec4d8a50deaf7c351a766b9e78a/core/vector.h#L54-L58

if I understand correctly, both `Vector.set()` and `Vector.write[]` calls the same `CowData.size()`

but anyway `Vector.set()` works for this case.