### PR TITLE
Add custom icons to script classes.

### DIFF
--- a/core/script_language.h
+++ b/core/script_language.h
@@ -315,7 +315,7 @@ public:
 	virtual void frame();
 
 	virtual bool handles_global_class_type(const String &p_type) const { return false; }
-	virtual String get_global_class_name(const String &p_path, String *r_base_type = NULL) const { return String(); }
+	virtual String get_global_class_name(const String &p_path, String *r_base_type = NULL, String *r_icon_path = NULL) const { return String(); }
 
 	virtual ~ScriptLanguage() {}
 };

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -146,6 +146,8 @@ private:
 
 	bool _find_updated_instances(Node *p_root, Node *p_node, Set<String> &checked_paths);
 
+	HashMap<StringName, String> _script_class_icon_paths;
+
 public:
 	EditorPlugin *get_editor(Object *p_object);
 	EditorPlugin *get_subeditor(Object *p_object);
@@ -213,6 +215,12 @@ public:
 
 	bool script_class_is_parent(const String &p_class, const String &p_inherits);
 	StringName script_class_get_base(const String &p_class);
+	Object *script_class_instance(const String &p_class);
+	String script_class_get_icon_path(const String &p_class) const { return _script_class_icon_paths.has(p_class) ? _script_class_icon_paths[p_class] : String(); }
+	void script_class_set_icon_path(const String &p_class, const String &p_icon_path) { _script_class_icon_paths[p_class] = p_icon_path; }
+	void script_class_clear_icon_paths() { _script_class_icon_paths.clear(); }
+	void script_class_save_icon_paths();
+	void script_class_load_icon_paths();
 
 	EditorData();
 };

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -60,6 +60,7 @@ class EditorFileSystemDirectory : public Object {
 		bool verified; //used for checking changes
 		String script_class_name;
 		String script_class_extends;
+		String script_class_icon_path;
 	};
 
 	struct FileInfoSort {
@@ -90,6 +91,7 @@ public:
 	bool get_file_import_is_valid(int p_idx) const;
 	String get_file_script_class_name(int p_idx) const; //used for scripts
 	String get_file_script_class_extends(int p_idx) const; //used for scripts
+	String get_file_script_class_icon_path(int p_idx) const; //used for scripts
 
 	EditorFileSystemDirectory *get_parent();
 
@@ -163,6 +165,7 @@ class EditorFileSystem : public Node {
 		bool import_valid;
 		String script_class_name;
 		String script_class_extends;
+		String script_class_icon_path;
 	};
 
 	HashMap<String, FileCache> file_cache;
@@ -225,7 +228,7 @@ class EditorFileSystem : public Node {
 	volatile bool update_script_classes_queued;
 	void _queue_update_script_classes();
 
-	String _get_global_script_class(const String &p_type, const String &p_path, String *r_extends) const;
+	String _get_global_script_class(const String &p_type, const String &p_path, String *r_extends, String *r_icon_path) const;
 
 protected:
 	void _notification(int p_what);

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -287,7 +287,11 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 					Object *obj = ClassDB::instance(intype);
 
 					if (!obj) {
-						obj = EditorNode::get_editor_data().instance_custom_type(intype, "Resource");
+						if (ScriptServer::is_global_class(intype)) {
+							obj = EditorNode::get_editor_data().script_class_instance(intype);
+						} else {
+							obj = EditorNode::get_editor_data().instance_custom_type(intype, "Resource");
+						}
 					}
 
 					ERR_BREAK(!obj);
@@ -1132,7 +1136,11 @@ void CustomPropertyEditor::_type_create_selected(int p_idx) {
 		Object *obj = ClassDB::instance(intype);
 
 		if (!obj) {
-			obj = EditorNode::get_editor_data().instance_custom_type(intype, "Resource");
+			if (ScriptServer::is_global_class(intype)) {
+				obj = EditorNode::get_editor_data().script_class_instance(intype);
+			} else {
+				obj = EditorNode::get_editor_data().instance_custom_type(intype, "Resource");
+			}
 		}
 
 		ERR_FAIL_COND(!obj);
@@ -1334,7 +1342,11 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 					Object *obj = ClassDB::instance(intype);
 
 					if (!obj) {
-						obj = EditorNode::get_editor_data().instance_custom_type(intype, "Resource");
+						if (ScriptServer::is_global_class(intype)) {
+							obj = EditorNode::get_editor_data().script_class_instance(intype);
+						} else {
+							obj = EditorNode::get_editor_data().instance_custom_type(intype, "Resource");
+						}
 					}
 
 					ERR_BREAK(!obj);

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1811,7 +1811,7 @@ bool GDScriptLanguage::handles_global_class_type(const String &p_type) const {
 	return p_type == "GDScript";
 }
 
-String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_base_type) const {
+String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_base_type, String *r_icon_path) const {
 
 	PoolVector<uint8_t> sourcef;
 	Error err;
@@ -1875,6 +1875,12 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 					*r_base_type = "Reference";
 				}
 			}
+		}
+		if (r_icon_path) {
+			if (c->icon_path.is_abs_path())
+				*r_icon_path = c->icon_path;
+			else if (c->icon_path.is_rel_path())
+				*r_icon_path = p_path.get_base_dir().plus_file(c->icon_path).simplify_path();
 		}
 		return c->name;
 	}

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -492,7 +492,7 @@ public:
 	/* GLOBAL CLASSES */
 
 	virtual bool handles_global_class_type(const String &p_type) const;
-	virtual String get_global_class_name(const String &p_path, String *r_base_type = NULL) const;
+	virtual String get_global_class_name(const String &p_path, String *r_base_type = NULL, String *r_icon_path = NULL) const;
 
 	GDScriptLanguage();
 	~GDScriptLanguage();

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3429,6 +3429,32 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 
 				tokenizer->advance(2);
 
+				if (tokenizer->get_token() == GDScriptTokenizer::TK_COMMA) {
+					tokenizer->advance();
+
+					if ((tokenizer->get_token() == GDScriptTokenizer::TK_CONSTANT && tokenizer->get_token_constant().get_type() == Variant::STRING)) {
+						Variant constant = tokenizer->get_token_constant();
+						String icon_path = constant.operator String();
+
+						String abs_icon_path = icon_path.is_rel_path() ? self_path.get_base_dir().plus_file(icon_path).simplify_path() : icon_path;
+						if (!FileAccess::exists(abs_icon_path)) {
+							_set_error("No class icon found at: " + abs_icon_path);
+							return;
+						}
+
+						p_class->icon_path = icon_path;
+
+						tokenizer->advance();
+					} else {
+						_set_error("Optional parameter after 'class_name' must be a string constant file path to an icon.");
+						return;
+					}
+
+				} else if (tokenizer->get_token() == GDScriptTokenizer::TK_CONSTANT) {
+					_set_error("Class icon must be separated by a comma.");
+					return;
+				}
+
 			} break;
 			case GDScriptTokenizer::TK_PR_TOOL: {
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -149,6 +149,7 @@ public:
 		StringName extends_file;
 		Vector<StringName> extends_class;
 		DataType base_type;
+		String icon_path;
 
 		struct Member {
 			PropertyInfo _export;


### PR DESCRIPTION
This builds on #20233 by adding custom icon support. It lets you supply a string constant following the class name in order to define a custom icon. It does not support other data types (e.g. singleton.ICON or something). However, I've tested it for running, closing, and re-opening the editor, showing in the CreateDialog, showing in the SceneTreeDock, clearing the script (to revert back to base class icon), and then loading the script from the ScriptCreateDIalog (to bring the custom icon back). All of that is working, so I think it should be good to go. I also added a few custom error reports to the parser.

Edit: Also, the "correct usage" works with both absolute and relative file paths.

Correct Usage:
![correct_usage](https://user-images.githubusercontent.com/16217563/43362769-e2ef0d8c-92b7-11e8-83b0-3903852330f0.png)

Bad Filepath:
![bad_file](https://user-images.githubusercontent.com/16217563/43362772-e87d77ca-92b7-11e8-91c3-2234c8287618.png)

Bad data type:
![bad_type](https://user-images.githubusercontent.com/16217563/43362773-edf475be-92b7-11e8-896e-44e7d6ede83b.png)

CreateDialog Display:
![demo_create_dialog](https://user-images.githubusercontent.com/16217563/43362775-f85848aa-92b7-11e8-896e-1d3080ee257a.png)

SceneTreeDock Display, after creating the node:
![demo_scene_tree_dock_created](https://user-images.githubusercontent.com/16217563/43362778-0a2a24ae-92b8-11e8-89c3-aa53121cc6ab.png)

SceneTreeDock Display, after clearing the script:
![demo_scene_tree_dock_cleared](https://user-images.githubusercontent.com/16217563/43362779-136cdc28-92b8-11e8-93c4-924b4844d4fb.png)

SceneTreeDock Display, after re-adding the script:
![demo_scene_tree_dock_added](https://user-images.githubusercontent.com/16217563/43362784-22636c1a-92b8-11e8-841e-81af85bdc87a.png)
