### PR TITLE
Correct RayCast.get_collider* docs

### DIFF
--- a/doc/classes/RayCast.xml
+++ b/doc/classes/RayCast.xml
@@ -51,24 +51,14 @@
 			<return type="Object">
 			</return>
 			<description>
-				Return the closest object the ray is pointing to. Note that this does not consider the length of the ray, so you must also use [method is_colliding] to check if the object returned is actually colliding with the ray.
-				Example:
-				[codeblock]
-				if RayCast.is_colliding():
-				    var collider = RayCast.get_collider()
-				[/codeblock]
+				Returns the first object that the ray intersects.
 			</description>
 		</method>
 		<method name="get_collider_shape" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Returns the collision shape of the closest object the ray is pointing to.  Note that this does not consider the length of the ray, so you must also use [method is_colliding] to check if the object returned is actually colliding with the ray.
-				Example:
-				[codeblock]
-				if RayCast.is_colliding():
-				    var shape = RayCast.get_collider_shape()
-				[/codeblock]
+				Returns the ID of the first collision shape that the ray intersects.
 			</description>
 		</method>
 		<method name="get_collision_mask_bit" qualifiers="const">


### PR DESCRIPTION
I discovered that `RayCast.get_collider` apparently *does* consider the length of the ray these days. Maybe this changed with the switch to Bullet?

Also I'm not sure if the description of `is_colliding` should be changed as well?