### PR TITLE
Fix nested Vectors

### DIFF
--- a/core/cowdata.h
+++ b/core/cowdata.h
@@ -100,6 +100,7 @@ private:
 	}
 
 	void _unref(void *p_data);
+	void _ref(const CowData *p_from);
 	void _ref(const CowData &p_from);
 	void _copy_on_write();
 
@@ -298,6 +299,11 @@ Error CowData<T>::resize(int p_size) {
 	}
 
 	return OK;
+}
+
+template <class T>
+void CowData<T>::_ref(const CowData *p_from) {
+	_ref(*p_from);
 }
 
 template <class T>

--- a/core/vector.h
+++ b/core/vector.h
@@ -44,17 +44,16 @@
 template <class T>
 class VectorWriteProxy {
 	friend class Vector<T>;
-	Vector<T> &_parent;
+	CowData<T> *_parent;
 
-	_FORCE_INLINE_ VectorWriteProxy(Vector<T> &parent) :
+	_FORCE_INLINE_ VectorWriteProxy(CowData<T> *parent) :
 			_parent(parent){};
-	VectorWriteProxy(const VectorWriteProxy<T> &p_other);
 
 public:
 	_FORCE_INLINE_ T &operator[](int p_index) {
-		CRASH_BAD_INDEX(p_index, _parent.size());
+		CRASH_BAD_INDEX(p_index, _parent->size());
 
-		return _parent.ptrw()[p_index];
+		return _parent->ptrw()[p_index];
 	}
 };
 
@@ -62,39 +61,39 @@ template <class T>
 class Vector {
 	friend class VectorWriteProxy<T>;
 
-	CowData<T> _cowdata;
+	CowData<T> *_cowdata;
 
 public:
 	VectorWriteProxy<T> write;
 
 	bool push_back(const T &p_elem);
 
-	void remove(int p_index) { _cowdata.remove(p_index); }
+	void remove(int p_index) { _cowdata->remove(p_index); }
 	void erase(const T &p_val) {
 		int idx = find(p_val);
 		if (idx >= 0) remove(idx);
 	};
 	void invert();
 
-	_FORCE_INLINE_ T *ptrw() { return _cowdata.ptrw(); }
-	_FORCE_INLINE_ const T *ptr() const { return _cowdata.ptr(); }
+	_FORCE_INLINE_ T *ptrw() { return _cowdata->ptrw(); }
+	_FORCE_INLINE_ const T *ptr() const { return _cowdata->ptr(); }
 	_FORCE_INLINE_ void clear() { resize(0); }
-	_FORCE_INLINE_ bool empty() const { return _cowdata.empty(); }
+	_FORCE_INLINE_ bool empty() const { return _cowdata->empty(); }
 
-	_FORCE_INLINE_ T get(int p_index) { return _cowdata.get(p_index); }
-	_FORCE_INLINE_ const T get(int p_index) const { return _cowdata.get(p_index); }
-	_FORCE_INLINE_ void set(int p_index, const T &p_elem) { _cowdata.set(p_index, p_elem); }
-	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
-	Error resize(int p_size) { return _cowdata.resize(p_size); }
-	_FORCE_INLINE_ const T &operator[](int p_index) const { return _cowdata.get(p_index); }
-	Error insert(int p_pos, const T &p_val) { return _cowdata.insert(p_pos, p_val); }
+	_FORCE_INLINE_ T get(int p_index) { return _cowdata->get(p_index); }
+	_FORCE_INLINE_ const T get(int p_index) const { return _cowdata->get(p_index); }
+	_FORCE_INLINE_ void set(int p_index, const T &p_elem) { _cowdata->set(p_index, p_elem); }
+	_FORCE_INLINE_ int size() const { return _cowdata->size(); }
+	Error resize(int p_size) { return _cowdata->resize(p_size); }
+	_FORCE_INLINE_ const T &operator[](int p_index) const { return _cowdata->get(p_index); }
+	Error insert(int p_pos, const T &p_val) { return _cowdata->insert(p_pos, p_val); }
 
 	void append_array(const Vector<T> &p_other);
 
 	template <class C>
 	void sort_custom() {
 
-		int len = _cowdata.size();
+		int len = _cowdata->size();
 		if (len == 0)
 			return;
 
@@ -110,7 +109,7 @@ public:
 
 	void ordered_insert(const T &p_val) {
 		int i;
-		for (i = 0; i < _cowdata.size(); i++) {
+		for (i = 0; i < _cowdata->size(); i++) {
 
 			if (p_val < operator[](i)) {
 				break;
@@ -136,12 +135,18 @@ public:
 	}
 
 	_FORCE_INLINE_ Vector() :
-			write(VectorWriteProxy<T>(*this)) {}
+			_cowdata(new CowData<T>()),
+			write(VectorWriteProxy<T>(_cowdata)) {}
 	_FORCE_INLINE_ Vector(const Vector &p_from) :
-			write(VectorWriteProxy<T>(*this)) { _cowdata._ref(p_from._cowdata); }
+			_cowdata(new CowData<T>()),
+			write(VectorWriteProxy<T>(_cowdata)) { _cowdata->_ref(p_from._cowdata); }
 	inline Vector &operator=(const Vector &p_from) {
-		_cowdata._ref(p_from._cowdata);
+		_cowdata->_ref(p_from._cowdata);
 		return *this;
+	}
+
+	_FORCE_INLINE_ ~Vector() {
+		delete _cowdata;
 	}
 };
 


### PR DESCRIPTION
When a Vector of Vectors gets resized the 'this' pointer of the Vectors
change. This means that the VectorWriteProxy _parent references get
invalidated. Thanks a lot to @ibrahn for finding the root cause of this.

To fix this we now create a pointer to CowData in Vector (which won't
change when the vectors move) and pass that to the write proxy also.

This fixes #20475