### PR TITLE
Do not use deprecated stuff that only glibc now implements

### DIFF
--- a/thirdparty/thekla_atlas/nvmath/nvmath.h
+++ b/thirdparty/thekla_atlas/nvmath/nvmath.h
@@ -181,10 +181,8 @@ namespace nv
     {
 #if NV_OS_WIN32 || NV_OS_XBOX || NV_OS_DURANGO
         return _finite(f) != 0;
-#elif NV_OS_DARWIN || NV_OS_FREEBSD || NV_OS_OPENBSD || NV_OS_ORBIS
+#elif NV_OS_DARWIN || NV_OS_FREEBSD || NV_OS_OPENBSD || NV_OS_ORBIS || NV_OS_LINUX
         return isfinite(f);
-#elif NV_OS_LINUX
-        return finitef(f);
 #else
 #   error "isFinite not supported"
 #endif
@@ -196,10 +194,8 @@ namespace nv
     {
 #if NV_OS_WIN32 || NV_OS_XBOX || NV_OS_DURANGO
         return _isnan(f) != 0;
-#elif NV_OS_DARWIN || NV_OS_FREEBSD || NV_OS_OPENBSD || NV_OS_ORBIS
+#elif NV_OS_DARWIN || NV_OS_FREEBSD || NV_OS_OPENBSD || NV_OS_ORBIS || NV_OS_LINUX
         return isnan(f);
-#elif NV_OS_LINUX
-        return isnanf(f);
 #else
 #   error "isNan not supported"
 #endif


### PR DESCRIPTION
Since C99, finitef, isnanf and friends have been deprecated, use the standard replacements on linux too.

Fixes #20036