### PR TITLE
New TileSet Editor

### DIFF
--- a/editor/icons/icon_add_atlas_tile.svg
+++ b/editor/icons/icon_add_atlas_tile.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<path d="m7 1v6h-6v2h6v6h2v-6h6v-2h-6v-6h-2z" fill="#c9cfd4"/>
+</svg>

--- a/editor/icons/icon_add_autotile.svg
+++ b/editor/icons/icon_add_autotile.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<path d="m7 1v6h-6v2h6v6h2v-6h6v-2h-6v-6h-2z" fill="#4490fc"/>
+</svg>

--- a/editor/icons/icon_add_single_tile.svg
+++ b/editor/icons/icon_add_single_tile.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<path d="m7 1v6h-6v2h6v6h2v-6h6v-2h-6v-6h-2z" fill="#fce844"/>
+</svg>

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -57,8 +57,6 @@ void TextureRegionEditor::_region_draw() {
 		base_tex = obj_styleBox->get_texture();
 	else if (atlas_tex.is_valid())
 		base_tex = atlas_tex->get_atlas();
-	else if (tile_set.is_valid() && selected_tile != -1 && tile_set->has_tile(selected_tile))
-		base_tex = tile_set->tile_get_texture(selected_tile);
 
 	if (base_tex.is_null())
 		return;
@@ -284,8 +282,6 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 									r = obj_styleBox->get_region_rect();
 								else if (atlas_tex.is_valid())
 									r = atlas_tex->get_region();
-								else if (tile_set.is_valid() && selected_tile != -1)
-									r = tile_set->tile_get_region(selected_tile);
 								rect.expand_to(r.position);
 								rect.expand_to(r.position + r.size);
 							}
@@ -302,9 +298,6 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 							} else if (atlas_tex.is_valid()) {
 								undo_redo->add_do_method(atlas_tex.ptr(), "set_region", rect);
 								undo_redo->add_undo_method(atlas_tex.ptr(), "set_region", atlas_tex->get_region());
-							} else if (tile_set.is_valid() && selected_tile != -1) {
-								undo_redo->add_do_method(tile_set.ptr(), "tile_set_region", selected_tile, rect);
-								undo_redo->add_undo_method(tile_set.ptr(), "tile_set_region", selected_tile, tile_set->tile_get_region(selected_tile));
 							}
 							undo_redo->add_do_method(edit_draw, "update");
 							undo_redo->add_undo_method(edit_draw, "update");
@@ -327,8 +320,6 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 						rect_prev = obj_styleBox->get_region_rect();
 					else if (atlas_tex.is_valid())
 						rect_prev = atlas_tex->get_region();
-					else if (tile_set.is_valid() && selected_tile != -1)
-						rect_prev = tile_set->tile_get_region(selected_tile);
 
 					for (int i = 0; i < 8; i++) {
 						Vector2 tuv = endpoints[i];
@@ -372,9 +363,6 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 					} else if (obj_styleBox.is_valid()) {
 						undo_redo->add_do_method(obj_styleBox.ptr(), "set_region_rect", obj_styleBox->get_region_rect());
 						undo_redo->add_undo_method(obj_styleBox.ptr(), "set_region_rect", rect_prev);
-					} else if (tile_set.is_valid()) {
-						undo_redo->add_do_method(tile_set.ptr(), "tile_set_region", selected_tile, tile_set->tile_get_region(selected_tile));
-						undo_redo->add_undo_method(tile_set.ptr(), "tile_set_region", selected_tile, rect_prev);
 					}
 					drag_index = -1;
 				}
@@ -595,8 +583,6 @@ void TextureRegionEditor::apply_rect(const Rect2 &rect) {
 		obj_styleBox->set_region_rect(rect);
 	else if (atlas_tex.is_valid())
 		atlas_tex->set_region(rect);
-	else if (tile_set.is_valid() && selected_tile != -1)
-		tile_set->tile_set_region(selected_tile, rect);
 }
 
 void TextureRegionEditor::_notification(int p_what) {
@@ -623,12 +609,11 @@ void TextureRegionEditor::_notification(int p_what) {
 }
 
 void TextureRegionEditor::_node_removed(Object *p_obj) {
-	if (p_obj == node_sprite || p_obj == node_ninepatch || p_obj == obj_styleBox.ptr() || p_obj == atlas_tex.ptr() || p_obj == tile_set.ptr()) {
+	if (p_obj == node_sprite || p_obj == node_ninepatch || p_obj == obj_styleBox.ptr() || p_obj == atlas_tex.ptr()) {
 		node_ninepatch = NULL;
 		node_sprite = NULL;
 		obj_styleBox = Ref<StyleBox>(NULL);
 		atlas_tex = Ref<AtlasTexture>(NULL);
-		tile_set = Ref<TileSet>(NULL);
 		hide();
 	}
 }
@@ -677,8 +662,6 @@ void TextureRegionEditor::edit(Object *p_obj) {
 		obj_styleBox->remove_change_receptor(this);
 	if (atlas_tex.is_valid())
 		atlas_tex->remove_change_receptor(this);
-	if (tile_set.is_valid())
-		tile_set->remove_change_receptor(this);
 	if (p_obj) {
 		node_sprite = Object::cast_to<Sprite>(p_obj);
 		node_ninepatch = Object::cast_to<NinePatchRect>(p_obj);
@@ -686,8 +669,6 @@ void TextureRegionEditor::edit(Object *p_obj) {
 			obj_styleBox = Ref<StyleBoxTexture>(Object::cast_to<StyleBoxTexture>(p_obj));
 		if (Object::cast_to<AtlasTexture>(p_obj))
 			atlas_tex = Ref<AtlasTexture>(Object::cast_to<AtlasTexture>(p_obj));
-		if (Object::cast_to<TileSet>(p_obj))
-			tile_set = Ref<TileSet>(Object::cast_to<TileSet>(p_obj));
 		p_obj->add_change_receptor(this);
 		_edit_region();
 	} else {
@@ -695,7 +676,6 @@ void TextureRegionEditor::edit(Object *p_obj) {
 		node_ninepatch = NULL;
 		obj_styleBox = Ref<StyleBoxTexture>(NULL);
 		atlas_tex = Ref<AtlasTexture>(NULL);
-		tile_set = Ref<TileSet>(NULL);
 	}
 	edit_draw->update();
 	if (node_sprite && !node_sprite->is_region()) {
@@ -724,8 +704,6 @@ void TextureRegionEditor::_edit_region() {
 		texture = obj_styleBox->get_texture();
 	else if (atlas_tex.is_valid())
 		texture = atlas_tex->get_atlas();
-	else if (tile_set.is_valid() && selected_tile != -1 && tile_set->has_tile(selected_tile))
-		texture = tile_set->tile_get_texture(selected_tile);
 
 	if (texture.is_null()) {
 		edit_draw->update();
@@ -794,8 +772,6 @@ void TextureRegionEditor::_edit_region() {
 		rect = obj_styleBox->get_region_rect();
 	else if (atlas_tex.is_valid())
 		rect = atlas_tex->get_region();
-	else if (tile_set.is_valid() && selected_tile != -1)
-		rect = tile_set->tile_get_region(selected_tile);
 
 	edit_draw->update();
 }
@@ -814,10 +790,8 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	node_ninepatch = NULL;
 	obj_styleBox = Ref<StyleBoxTexture>(NULL);
 	atlas_tex = Ref<AtlasTexture>(NULL);
-	tile_set = Ref<TileSet>(NULL);
 	editor = p_editor;
 	undo_redo = editor->get_undo_redo();
-	selected_tile = -1;
 
 	snap_step = Vector2(10, 10);
 	snap_separation = Vector2(0, 0);

--- a/editor/plugins/texture_region_editor_plugin.h
+++ b/editor/plugins/texture_region_editor_plugin.h
@@ -38,7 +38,6 @@
 #include "scene/gui/nine_patch_rect.h"
 #include "scene/resources/style_box.h"
 #include "scene/resources/texture.h"
-#include "scene/resources/tile_set.h"
 
 /**
 	@author Mariano Suligoy
@@ -56,8 +55,6 @@ class TextureRegionEditor : public Control {
 	};
 
 	friend class TextureRegionEditorPlugin;
-	friend class TileSetEditor;
-	friend class TileSetEditorPlugin;
 	MenuButton *snap_mode_button;
 	TextureRect *icon_zoom;
 	ToolButton *zoom_in;
@@ -91,14 +88,12 @@ class TextureRegionEditor : public Control {
 	Sprite *node_sprite;
 	Ref<StyleBoxTexture> obj_styleBox;
 	Ref<AtlasTexture> atlas_tex;
-	Ref<TileSet> tile_set;
 
 	Rect2 rect;
 	Rect2 rect_prev;
 	float prev_margin;
 	int edited_margin;
 	List<Rect2> autoslice_cache;
-	int selected_tile;
 
 	bool drag;
 	bool creating;

--- a/editor/plugins/tile_map_editor_plugin.h
+++ b/editor/plugins/tile_map_editor_plugin.h
@@ -184,6 +184,7 @@ class TileMapEditor : public VBoxContainer {
 	void _update_palette();
 	void _menu_option(int p_option);
 	void _palette_selected(int index);
+	void _palette_multi_selected(int index, bool selected);
 
 	void _start_undo(const String &p_action);
 	void _finish_undo();

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -30,6 +30,8 @@
 
 #include "tile_set_editor_plugin.h"
 
+#include "core/os/input.h"
+#include "core/os/keyboard.h"
 #include "editor/plugins/canvas_item_editor_plugin.h"
 #include "scene/2d/physics_body_2d.h"
 #include "scene/2d/sprite.h"
@@ -39,7 +41,9 @@ void TileSetEditor::edit(const Ref<TileSet> &p_tileset) {
 	tileset = p_tileset;
 	tileset->add_change_receptor(this);
 
-	update_tile_list();
+	texture_list->clear();
+	texture_map.clear();
+	update_texture_list();
 }
 
 void TileSetEditor::_import_node(Node *p_node, Ref<TileSet> p_library) {
@@ -161,75 +165,6 @@ void TileSetEditor::_import_scene(Node *p_scene, Ref<TileSet> p_library, bool p_
 	_import_node(p_scene, p_library);
 }
 
-void TileSetEditor::_menu_confirm() {
-
-	switch (option) {
-
-		case MENU_OPTION_MERGE_FROM_SCENE:
-		case MENU_OPTION_CREATE_FROM_SCENE: {
-
-			EditorNode *en = editor;
-			Node *scene = en->get_edited_scene();
-			if (!scene)
-				break;
-
-			_import_scene(scene, tileset, option == MENU_OPTION_MERGE_FROM_SCENE);
-
-		} break;
-	}
-}
-
-void TileSetEditor::_name_dialog_confirm(const String &name) {
-
-	switch (option) {
-
-		case MENU_OPTION_REMOVE_ITEM: {
-
-			int id = tileset->find_tile_by_name(name);
-
-			if (id < 0 && name.is_valid_integer())
-				id = name.to_int();
-
-			if (tileset->has_tile(id)) {
-				tileset->remove_tile(id);
-				update_tile_list();
-			} else {
-				err_dialog->set_text(TTR("Could not find tile:") + " " + name);
-				err_dialog->popup_centered(Size2(300, 60));
-			}
-		} break;
-	}
-}
-
-void TileSetEditor::_menu_cbk(int p_option) {
-
-	option = p_option;
-	switch (p_option) {
-
-		case MENU_OPTION_ADD_ITEM: {
-			tileset->create_tile(tileset->get_last_unused_tile_id());
-			tileset->tile_set_name(tileset->get_last_unused_tile_id() - 1, itos(tileset->get_last_unused_tile_id() - 1));
-			update_tile_list();
-		} break;
-		case MENU_OPTION_REMOVE_ITEM: {
-
-			nd->set_title(TTR("Remove Item"));
-			nd->set_text(TTR("Item name or ID:"));
-			nd->popup_centered(Size2(300, 95));
-		} break;
-		case MENU_OPTION_CREATE_FROM_SCENE: {
-
-			cd->set_text(TTR("Create from scene?"));
-			cd->popup_centered(Size2(300, 60));
-		} break;
-		case MENU_OPTION_MERGE_FROM_SCENE: {
-
-			cd->set_text(TTR("Merge from scene?"));
-			cd->popup_centered(Size2(300, 60));
-		} break;
-	}
-}
-
 Error TileSetEditor::update_library_file(Node *p_base_scene, Ref<TileSet> ml, bool p_merge) {
 
 	_import_scene(p_base_scene, ml, p_merge);
@@ -237,28 +172,36 @@ Error TileSetEditor::update_library_file(Node *p_base_scene, Ref<TileSet> ml, bo
 }
 
 void TileSetEditor::_bind_methods() {
-
-	ClassDB::bind_method("_menu_cbk", &TileSetEditor::_menu_cbk);
-	ClassDB::bind_method("_menu_confirm", &TileSetEditor::_menu_confirm);
-	ClassDB::bind_method("_name_dialog_confirm", &TileSetEditor::_name_dialog_confirm);
-	ClassDB::bind_method("_on_tile_list_selected", &TileSetEditor::_on_tile_list_selected);
+	ClassDB::bind_method("_on_tileset_toolbar_button_pressed", &TileSetEditor::_on_tileset_toolbar_button_pressed);
+	ClassDB::bind_method("_on_textures_added", &TileSetEditor::_on_textures_added);
+	ClassDB::bind_method("_on_tileset_toolbar_confirm", &TileSetEditor::_on_tileset_toolbar_confirm);
+	ClassDB::bind_method("_on_texture_list_selected", &TileSetEditor::_on_texture_list_selected);
 	ClassDB::bind_method("_on_edit_mode_changed", &TileSetEditor::_on_edit_mode_changed);
+	ClassDB::bind_method("_on_workspace_mode_changed", &TileSetEditor::_on_workspace_mode_changed);
 	ClassDB::bind_method("_on_workspace_overlay_draw", &TileSetEditor::_on_workspace_overlay_draw);
+	ClassDB::bind_method("_on_workspace_process", &TileSetEditor::_on_workspace_process);
 	ClassDB::bind_method("_on_workspace_draw", &TileSetEditor::_on_workspace_draw);
 	ClassDB::bind_method("_on_workspace_input", &TileSetEditor::_on_workspace_input);
 	ClassDB::bind_method("_on_tool_clicked", &TileSetEditor::_on_tool_clicked);
 	ClassDB::bind_method("_on_priority_changed", &TileSetEditor::_on_priority_changed);
 	ClassDB::bind_method("_on_grid_snap_toggled", &TileSetEditor::_on_grid_snap_toggled);
-	ClassDB::bind_method("_set_snap_step_x", &TileSetEditor::_set_snap_step_x);
-	ClassDB::bind_method("_set_snap_step_y", &TileSetEditor::_set_snap_step_y);
-	ClassDB::bind_method("_set_snap_off_x", &TileSetEditor::_set_snap_off_x);
-	ClassDB::bind_method("_set_snap_off_y", &TileSetEditor::_set_snap_off_y);
-	ClassDB::bind_method("_set_snap_sep_x", &TileSetEditor::_set_snap_sep_x);
-	ClassDB::bind_method("_set_snap_sep_y", &TileSetEditor::_set_snap_sep_y);
+	ClassDB::bind_method("_set_snap_step", &TileSetEditor::_set_snap_step);
+	ClassDB::bind_method("_set_snap_off", &TileSetEditor::_set_snap_off);
+	ClassDB::bind_method("_set_snap_sep", &TileSetEditor::_set_snap_sep);
 }
 
 void TileSetEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
+
+		tileset_toolbar_buttons[TOOL_TILESET_ADD_TEXTURE]->set_icon(get_icon("ToolAddNode", "EditorIcons"));
+		tileset_toolbar_buttons[TOOL_TILESET_REMOVE_TEXTURE]->set_icon(get_icon("Remove", "EditorIcons"));
+		tileset_toolbar_tools->set_icon(get_icon("Tools", "EditorIcons"));
+
+		tool_workspacemode[WORKSPACE_EDIT]->set_icon(get_icon("Edit", "EditorIcons"));
+		tool_workspacemode[WORKSPACE_CREATE_SINGLE]->set_icon(get_icon("AddSingleTile", "EditorIcons"));
+		tool_workspacemode[WORKSPACE_CREATE_AUTOTILE]->set_icon(get_icon("AddAutotile", "EditorIcons"));
+		tool_workspacemode[WORKSPACE_CREATE_ATLAS]->set_icon(get_icon("AddAtlasTile", "EditorIcons"));
+
 		tools[TOOL_SELECT]->set_icon(get_icon("ToolSelect", "EditorIcons"));
 		tools[BITMASK_COPY]->set_icon(get_icon("Duplicate", "EditorIcons"));
 		tools[BITMASK_PASTE]->set_icon(get_icon("Override", "EditorIcons"));
@@ -266,91 +209,126 @@ void TileSetEditor::_notification(int p_what) {
 		tools[SHAPE_NEW_POLYGON]->set_icon(get_icon("CollisionPolygon2D", "EditorIcons"));
 		tools[SHAPE_DELETE]->set_icon(get_icon("Remove", "EditorIcons"));
 		tools[SHAPE_KEEP_INSIDE_TILE]->set_icon(get_icon("Snap", "EditorIcons"));
-		tools[SHAPE_GRID_SNAP]->set_icon(get_icon("SnapGrid", "EditorIcons"));
+		tools[TOOL_GRID_SNAP]->set_icon(get_icon("SnapGrid", "EditorIcons"));
 		tools[ZOOM_OUT]->set_icon(get_icon("ZoomLess", "EditorIcons"));
 		tools[ZOOM_1]->set_icon(get_icon("ZoomReset", "EditorIcons"));
 		tools[ZOOM_IN]->set_icon(get_icon("ZoomMore", "EditorIcons"));
+		tools[VISIBLE_INFO]->set_icon(get_icon("InformationSign", "EditorIcons"));
+
+		tool_editmode[EDITMODE_REGION]->set_icon(get_icon("RegionEdit", "EditorIcons"));
+		tool_editmode[EDITMODE_COLLISION]->set_icon(get_icon("StaticBody2D", "EditorIcons"));
+		tool_editmode[EDITMODE_OCCLUSION]->set_icon(get_icon("LightOccluder2D", "EditorIcons"));
+		tool_editmode[EDITMODE_NAVIGATION]->set_icon(get_icon("Navigation2D", "EditorIcons"));
+		tool_editmode[EDITMODE_BITMASK]->set_icon(get_icon("PackedDataContainer", "EditorIcons"));
+		tool_editmode[EDITMODE_PRIORITY]->set_icon(get_icon("MaterialPreviewLight1", "EditorIcons"));
+		tool_editmode[EDITMODE_ICON]->set_icon(get_icon("LargeTexture", "EditorIcons"));
 	}
 }
 
-void TileSetEditor::_changed_callback(Object *p_changed, const char *p_prop) {
-	if (p_prop == StringName("region")) {
-		update_tile_list_icon();
-		preview->set_region_rect(tileset->tile_get_region(get_current_tile()));
-	} else if (p_prop == StringName("name")) {
-		update_tile_list_icon();
-	} else if (p_prop == StringName("texture") || p_prop == StringName("modulate") || p_prop == StringName("tile_mode")) {
-		_on_tile_list_selected(get_current_tile());
-		workspace->update();
-		preview->set_texture(tileset->tile_get_texture(get_current_tile()));
-		preview->set_modulate(tileset->tile_get_modulate(get_current_tile()));
-		preview->set_region_rect(tileset->tile_get_region(get_current_tile()));
-		if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE)
-			property_editor->show();
-		else
-			property_editor->hide();
-		texture_region_editor->_edit_region();
-		update_tile_list_icon();
-	} else if (p_prop == StringName("autotile")) {
-		workspace->update();
-	}
-}
+TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 
-void TileSetEditor::initialize_bottom_editor() {
+	editor = p_editor;
+	set_name("Tile Set Bottom Editor");
 
-	//Side Panel
-	side_panel = memnew(Control);
-	side_panel->set_name("Tile Set");
+	HSplitContainer *split = memnew(HSplitContainer);
+	split->set_anchors_and_margins_preset(PRESET_WIDE, PRESET_MODE_MINSIZE, 10);
+	add_child(split);
 
-	VSplitContainer *split = memnew(VSplitContainer);
-	side_panel->add_child(split);
-	split->set_anchors_and_margins_preset(Control::PRESET_WIDE);
+	VBoxContainer *left_container = memnew(VBoxContainer);
+	split->add_child(left_container);
 
-	tile_list = memnew(ItemList);
-	tile_list->set_v_size_flags(SIZE_EXPAND_FILL);
-	tile_list->set_h_size_flags(SIZE_EXPAND_FILL);
-	tile_list->set_custom_minimum_size(Size2(10, 200));
-	tile_list->connect("item_selected", this, "_on_tile_list_selected");
-	split->add_child(tile_list);
+	texture_list = memnew(ItemList);
+	left_container->add_child(texture_list);
+	texture_list->set_v_size_flags(SIZE_EXPAND_FILL);
+	texture_list->set_custom_minimum_size(Size2(200, 0));
+	texture_list->connect("item_selected", this, "_on_texture_list_selected");
 
-	property_editor = memnew(PropertyEditor);
-	property_editor->set_v_size_flags(SIZE_EXPAND_FILL);
-	property_editor->set_h_size_flags(SIZE_EXPAND_FILL);
-	property_editor->set_custom_minimum_size(Size2(10, 70));
-	split->add_child(property_editor);
+	HBoxContainer *tileset_toolbar_container = memnew(HBoxContainer);
+	left_container->add_child(tileset_toolbar_container);
 
-	helper = memnew(TileSetEditorHelper(this));
-	property_editor->call_deferred("edit", helper);
-	helper->add_change_receptor(this);
+	tileset_toolbar_buttons[TOOL_TILESET_ADD_TEXTURE] = memnew(ToolButton);
+	Vector<Variant> p;
+	p.push_back((int)TOOL_TILESET_ADD_TEXTURE);
+	tileset_toolbar_buttons[TOOL_TILESET_ADD_TEXTURE]->connect("pressed", this, "_on_tileset_toolbar_button_pressed", p);
+	tileset_toolbar_container->add_child(tileset_toolbar_buttons[TOOL_TILESET_ADD_TEXTURE]);
+	tileset_toolbar_buttons[TOOL_TILESET_ADD_TEXTURE]->set_tooltip(TTR("Add Texture(s) to TileSet"));
 
-	//Editor
-	//Bottom Panel
-	bottom_panel = memnew(Control);
-	bottom_panel->set_name("Tile Set Bottom Editor");
+	tileset_toolbar_buttons[TOOL_TILESET_REMOVE_TEXTURE] = memnew(ToolButton);
+	p = Vector<Variant>();
+	p.push_back((int)TOOL_TILESET_REMOVE_TEXTURE);
+	tileset_toolbar_buttons[TOOL_TILESET_REMOVE_TEXTURE]->connect("pressed", this, "_on_tileset_toolbar_button_pressed", p);
+	tileset_toolbar_container->add_child(tileset_toolbar_buttons[TOOL_TILESET_REMOVE_TEXTURE]);
+	tileset_toolbar_buttons[TOOL_TILESET_REMOVE_TEXTURE]->set_tooltip(TTR("Remove current Texture from TileSet"));
+
+	Control *toolbar_separator = memnew(Control);
+	toolbar_separator->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	tileset_toolbar_container->add_child(toolbar_separator);
+
+	tileset_toolbar_tools = memnew(MenuButton);
+	tileset_toolbar_tools->set_text("Tools");
+	p = Vector<Variant>();
+	p.push_back((int)TOOL_TILESET_CREATE_SCENE);
+	tileset_toolbar_tools->get_popup()->add_item(TTR("Create from Scene"), TOOL_TILESET_CREATE_SCENE);
+	p = Vector<Variant>();
+	p.push_back((int)TOOL_TILESET_MERGE_SCENE);
+	tileset_toolbar_tools->get_popup()->add_item(TTR("Merge from Scene"), TOOL_TILESET_MERGE_SCENE);
+
+	tileset_toolbar_tools->get_popup()->connect("id_pressed", this, "_on_tileset_toolbar_button_pressed");
+	tileset_toolbar_container->add_child(tileset_toolbar_tools);
+
+	//---------------
+	VBoxContainer *right_container = memnew(VBoxContainer);
+	right_container->set_v_size_flags(SIZE_EXPAND_FILL);
+	split->add_child(right_container);
 
 	dragging_point = -1;
 	creating_shape = false;
 	snap_step = Vector2(32, 32);
+	snap_offset = WORKSPACE_MARGIN;
 
-	bottom_panel->set_custom_minimum_size(Size2(0, 150));
+	set_custom_minimum_size(Size2(0, 150));
 
 	VBoxContainer *main_vb = memnew(VBoxContainer);
-	bottom_panel->add_child(main_vb);
-	main_vb->set_anchors_and_margins_preset(Control::PRESET_WIDE);
+	right_container->add_child(main_vb);
+	main_vb->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	HBoxContainer *tool_hb = memnew(HBoxContainer);
 	Ref<ButtonGroup> g(memnew(ButtonGroup));
 
-	String label[EDITMODE_MAX] = { "Collision", "Occlusion", "Navigation", "Bitmask", "Priority", "Icon" };
+	String workspace_label[WORKSPACE_MODE_MAX] = { "Edit", "New Single Tile", "New Autotile", "New Atlas" };
+
+	for (int i = 0; i < (int)WORKSPACE_MODE_MAX; i++) {
+		tool_workspacemode[i] = memnew(Button);
+		tool_workspacemode[i]->set_text(workspace_label[i]);
+		tool_workspacemode[i]->set_toggle_mode(true);
+		tool_workspacemode[i]->set_button_group(g);
+		Vector<Variant> p;
+		p.push_back(i);
+		tool_workspacemode[i]->connect("pressed", this, "_on_workspace_mode_changed", p);
+		tool_hb->add_child(tool_workspacemode[i]);
+	}
+	tool_workspacemode[WORKSPACE_EDIT]->set_pressed(true);
+	workspace_mode = WORKSPACE_EDIT;
+
+	main_vb->add_child(tool_hb);
+	main_vb->add_child(memnew(HSeparator));
+
+	tool_hb = memnew(HBoxContainer);
+	Control *spacer = memnew(Control);
+	spacer->set_custom_minimum_size(Size2(30, 0));
+	tool_hb->add_child(spacer);
+
+	g = Ref<ButtonGroup>(memnew(ButtonGroup));
+	String label[EDITMODE_MAX] = { "Region", "Collision", "Occlusion", "Navigation", "Bitmask", "Priority", "Icon" };
 
 	for (int i = 0; i < (int)EDITMODE_MAX; i++) {
 		tool_editmode[i] = memnew(Button);
 		tool_editmode[i]->set_text(label[i]);
 		tool_editmode[i]->set_toggle_mode(true);
 		tool_editmode[i]->set_button_group(g);
-		Vector<Variant> args;
-		args.push_back(i);
-		tool_editmode[i]->connect("pressed", this, "_on_edit_mode_changed", args);
+		Vector<Variant> p;
+		p.push_back(i);
+		tool_editmode[i]->connect("pressed", this, "_on_edit_mode_changed", p);
 		tool_hb->add_child(tool_editmode[i]);
 	}
 	tool_editmode[EDITMODE_COLLISION]->set_pressed(true);
@@ -360,127 +338,52 @@ void TileSetEditor::initialize_bottom_editor() {
 	main_vb->add_child(memnew(HSeparator));
 
 	toolbar = memnew(HBoxContainer);
-	for (int i = 0; i < (int)TOOLBAR_MAX; i++) {
-		tool_containers[i] = memnew(HBoxContainer);
-		toolbar->add_child(tool_containers[i]);
-		tool_containers[i]->hide();
-	}
-
 	Ref<ButtonGroup> tg(memnew(ButtonGroup));
 
-	Vector<Variant> p;
+	p = Vector<Variant>();
 	tools[TOOL_SELECT] = memnew(ToolButton);
-	tool_containers[TOOLBAR_DUMMY]->add_child(tools[TOOL_SELECT]);
+	toolbar->add_child(tools[TOOL_SELECT]);
 	tools[TOOL_SELECT]->set_tooltip(TTR("Select sub-tile to use as icon, this will be also used on invalid autotile bindings."));
 	tools[TOOL_SELECT]->set_toggle_mode(true);
 	tools[TOOL_SELECT]->set_button_group(tg);
 	tools[TOOL_SELECT]->set_pressed(true);
 	p.push_back((int)TOOL_SELECT);
 	tools[TOOL_SELECT]->connect("pressed", this, "_on_tool_clicked", p);
-	tool_containers[TOOLBAR_DUMMY]->show();
 
 	tools[BITMASK_COPY] = memnew(ToolButton);
 	p.push_back((int)BITMASK_COPY);
 	tools[BITMASK_COPY]->connect("pressed", this, "_on_tool_clicked", p);
-	tool_containers[TOOLBAR_BITMASK]->add_child(tools[BITMASK_COPY]);
+	toolbar->add_child(tools[BITMASK_COPY]);
 	tools[BITMASK_PASTE] = memnew(ToolButton);
 	p = Vector<Variant>();
 	p.push_back((int)BITMASK_PASTE);
 	tools[BITMASK_PASTE]->connect("pressed", this, "_on_tool_clicked", p);
-	tool_containers[TOOLBAR_BITMASK]->add_child(tools[BITMASK_PASTE]);
+	toolbar->add_child(tools[BITMASK_PASTE]);
 	tools[BITMASK_CLEAR] = memnew(ToolButton);
 	p = Vector<Variant>();
 	p.push_back((int)BITMASK_CLEAR);
 	tools[BITMASK_CLEAR]->connect("pressed", this, "_on_tool_clicked", p);
-	tool_containers[TOOLBAR_BITMASK]->add_child(tools[BITMASK_CLEAR]);
+	toolbar->add_child(tools[BITMASK_CLEAR]);
 
 	tools[SHAPE_NEW_POLYGON] = memnew(ToolButton);
-	tool_containers[TOOLBAR_SHAPE]->add_child(tools[SHAPE_NEW_POLYGON]);
+	toolbar->add_child(tools[SHAPE_NEW_POLYGON]);
 	tools[SHAPE_NEW_POLYGON]->set_toggle_mode(true);
 	tools[SHAPE_NEW_POLYGON]->set_button_group(tg);
-	tool_containers[TOOLBAR_SHAPE]->add_child(memnew(VSeparator));
+	toolbar->add_child(memnew(VSeparator));
 	tools[SHAPE_DELETE] = memnew(ToolButton);
 	p = Vector<Variant>();
 	p.push_back((int)SHAPE_DELETE);
 	tools[SHAPE_DELETE]->connect("pressed", this, "_on_tool_clicked", p);
-	tool_containers[TOOLBAR_SHAPE]->add_child(tools[SHAPE_DELETE]);
-	tool_containers[TOOLBAR_SHAPE]->add_child(memnew(VSeparator));
+	toolbar->add_child(tools[SHAPE_DELETE]);
+	toolbar->add_child(memnew(VSeparator));
 	tools[SHAPE_KEEP_INSIDE_TILE] = memnew(ToolButton);
 	tools[SHAPE_KEEP_INSIDE_TILE]->set_toggle_mode(true);
 	tools[SHAPE_KEEP_INSIDE_TILE]->set_pressed(true);
-	tool_containers[TOOLBAR_SHAPE]->add_child(tools[SHAPE_KEEP_INSIDE_TILE]);
-	tools[SHAPE_GRID_SNAP] = memnew(ToolButton);
-	tools[SHAPE_GRID_SNAP]->set_toggle_mode(true);
-	tools[SHAPE_GRID_SNAP]->connect("toggled", this, "_on_grid_snap_toggled");
-	tool_containers[TOOLBAR_SHAPE]->add_child(tools[SHAPE_GRID_SNAP]);
-
-	hb_grid = memnew(HBoxContainer);
-	tool_containers[TOOLBAR_SHAPE]->add_child(hb_grid);
-
-	hb_grid->add_child(memnew(VSeparator));
-	hb_grid->add_child(memnew(Label(TTR("Offset:"))));
-
-	sb_off_x = memnew(SpinBox);
-	sb_off_x->set_min(-256);
-	sb_off_x->set_max(256);
-	sb_off_x->set_step(1);
-	sb_off_x->set_value(snap_offset.x);
-	sb_off_x->set_suffix("px");
-	sb_off_x->connect("value_changed", this, "_set_snap_off_x");
-	hb_grid->add_child(sb_off_x);
-
-	sb_off_y = memnew(SpinBox);
-	sb_off_y->set_min(-256);
-	sb_off_y->set_max(256);
-	sb_off_y->set_step(1);
-	sb_off_y->set_value(snap_offset.y);
-	sb_off_y->set_suffix("px");
-	sb_off_y->connect("value_changed", this, "_set_snap_off_y");
-	hb_grid->add_child(sb_off_y);
-
-	hb_grid->add_child(memnew(VSeparator));
-	hb_grid->add_child(memnew(Label(TTR("Step:"))));
-
-	sb_step_x = memnew(SpinBox);
-	sb_step_x->set_min(-256);
-	sb_step_x->set_max(256);
-	sb_step_x->set_step(1);
-	sb_step_x->set_value(snap_step.x);
-	sb_step_x->set_suffix("px");
-	sb_step_x->connect("value_changed", this, "_set_snap_step_x");
-	hb_grid->add_child(sb_step_x);
-
-	sb_step_y = memnew(SpinBox);
-	sb_step_y->set_min(-256);
-	sb_step_y->set_max(256);
-	sb_step_y->set_step(1);
-	sb_step_y->set_value(snap_step.y);
-	sb_step_y->set_suffix("px");
-	sb_step_y->connect("value_changed", this, "_set_snap_step_y");
-	hb_grid->add_child(sb_step_y);
-
-	hb_grid->add_child(memnew(VSeparator));
-	hb_grid->add_child(memnew(Label(TTR("Separation:"))));
-
-	sb_sep_x = memnew(SpinBox);
-	sb_sep_x->set_min(0);
-	sb_sep_x->set_max(256);
-	sb_sep_x->set_step(1);
-	sb_sep_x->set_value(snap_separation.x);
-	sb_sep_x->set_suffix("px");
-	sb_sep_x->connect("value_changed", this, "_set_snap_sep_x");
-	hb_grid->add_child(sb_sep_x);
-
-	sb_sep_y = memnew(SpinBox);
-	sb_sep_y->set_min(0);
-	sb_sep_y->set_max(256);
-	sb_sep_y->set_step(1);
-	sb_sep_y->set_value(snap_separation.y);
-	sb_sep_y->set_suffix("px");
-	sb_sep_y->connect("value_changed", this, "_set_snap_sep_y");
-	hb_grid->add_child(sb_sep_y);
-
-	hb_grid->hide();
+	toolbar->add_child(tools[SHAPE_KEEP_INSIDE_TILE]);
+	tools[TOOL_GRID_SNAP] = memnew(ToolButton);
+	tools[TOOL_GRID_SNAP]->set_toggle_mode(true);
+	tools[TOOL_GRID_SNAP]->connect("toggled", this, "_on_grid_snap_toggled");
+	toolbar->add_child(tools[TOOL_GRID_SNAP]);
 
 	spin_priority = memnew(SpinBox);
 	spin_priority->set_min(1);
@@ -491,8 +394,6 @@ void TileSetEditor::initialize_bottom_editor() {
 	spin_priority->hide();
 	toolbar->add_child(spin_priority);
 
-	tool_containers[TOOLBAR_SHAPE]->show();
-
 	Control *separator = memnew(Control);
 	separator->set_h_size_flags(SIZE_EXPAND_FILL);
 	toolbar->add_child(separator);
@@ -502,22 +403,31 @@ void TileSetEditor::initialize_bottom_editor() {
 	p.push_back((int)ZOOM_OUT);
 	tools[ZOOM_OUT]->connect("pressed", this, "_on_tool_clicked", p);
 	toolbar->add_child(tools[ZOOM_OUT]);
+	tools[ZOOM_OUT]->set_tooltip(TTR("Zoom Out"));
 	tools[ZOOM_1] = memnew(ToolButton);
 	p = Vector<Variant>();
 	p.push_back((int)ZOOM_1);
 	tools[ZOOM_1]->connect("pressed", this, "_on_tool_clicked", p);
 	toolbar->add_child(tools[ZOOM_1]);
+	tools[ZOOM_1]->set_tooltip(TTR("Reset Zoom"));
 	tools[ZOOM_IN] = memnew(ToolButton);
 	p = Vector<Variant>();
 	p.push_back((int)ZOOM_IN);
 	tools[ZOOM_IN]->connect("pressed", this, "_on_tool_clicked", p);
 	toolbar->add_child(tools[ZOOM_IN]);
+	tools[ZOOM_IN]->set_tooltip(TTR("Zoom In"));
+
+	tools[VISIBLE_INFO] = memnew(ToolButton);
+	tools[VISIBLE_INFO]->set_toggle_mode(true);
+	tools[VISIBLE_INFO]->set_tooltip(TTR("Display tile's names (hold Alt Key)"));
+	toolbar->add_child(tools[VISIBLE_INFO]);
 
 	main_vb->add_child(toolbar);
 
 	scroll = memnew(ScrollContainer);
 	main_vb->add_child(scroll);
 	scroll->set_v_size_flags(SIZE_EXPAND_FILL);
+	scroll->set_clip_contents(true);
 
 	workspace_container = memnew(Control);
 	scroll->add_child(workspace_container);
@@ -527,6 +437,7 @@ void TileSetEditor::initialize_bottom_editor() {
 	workspace_container->add_child(workspace_overlay);
 
 	workspace = memnew(Control);
+	workspace->set_focus_mode(FOCUS_ALL);
 	workspace->connect("draw", this, "_on_workspace_draw");
 	workspace->connect("gui_input", this, "_on_workspace_input");
 	workspace->set_draw_behind_parent(true);
@@ -536,39 +447,35 @@ void TileSetEditor::initialize_bottom_editor() {
 	workspace->add_child(preview);
 	preview->set_centered(false);
 	preview->set_draw_behind_parent(true);
-	preview->set_region(true);
-}
+	preview->set_position(WORKSPACE_MARGIN);
 
-TileSetEditor::TileSetEditor(EditorNode *p_editor) {
-
-	menu = memnew(MenuButton);
-	CanvasItemEditor::get_singleton()->add_control_to_menu_panel(menu);
-	menu->hide();
-	menu->set_text(TTR("Tile Set"));
-	menu->get_popup()->add_item(TTR("Add Item"), MENU_OPTION_ADD_ITEM);
-	menu->get_popup()->add_item(TTR("Remove Item"), MENU_OPTION_REMOVE_ITEM);
-	menu->get_popup()->add_separator();
-	menu->get_popup()->add_item(TTR("Create from Scene"), MENU_OPTION_CREATE_FROM_SCENE);
-	menu->get_popup()->add_item(TTR("Merge from Scene"), MENU_OPTION_MERGE_FROM_SCENE);
-	menu->get_popup()->connect("id_pressed", this, "_menu_cbk");
-	editor = p_editor;
+	//---------------
 	cd = memnew(ConfirmationDialog);
 	add_child(cd);
-	cd->get_ok()->connect("pressed", this, "_menu_confirm");
+	cd->connect("confirmed", this, "_on_tileset_toolbar_confirm");
 
-	nd = memnew(EditorNameDialog);
-	add_child(nd);
-	nd->set_hide_on_ok(true);
-	nd->get_line_edit()->set_margin(MARGIN_TOP, 28);
-	nd->connect("name_confirmed", this, "_name_dialog_confirm");
-
+	//---------------
 	err_dialog = memnew(AcceptDialog);
 	add_child(err_dialog);
-	err_dialog->set_title(TTR("Error"));
 
-	draw_handles = false;
+	//---------------
+	texture_dialog = memnew(EditorFileDialog);
+	texture_dialog->set_access(EditorFileDialog::ACCESS_RESOURCES);
+	texture_dialog->set_mode(EditorFileDialog::MODE_OPEN_FILES);
+	texture_dialog->clear_filters();
+	List<String> extensions;
 
-	initialize_bottom_editor();
+	ResourceLoader::get_recognized_extensions_for_type("Texture", &extensions);
+	for (List<String>::Element *E = extensions.front(); E; E = E->next()) {
+
+		texture_dialog->add_filter("*." + E->get() + " ; " + E->get().to_upper());
+	}
+	add_child(texture_dialog);
+	texture_dialog->connect("files_selected", this, "_on_textures_added");
+
+	//---------------
+	helper = memnew(TilesetEditorContext(this));
+	tile_names_opacity = 0;
 }
 
 TileSetEditor::~TileSetEditor() {
@@ -576,57 +483,166 @@ TileSetEditor::~TileSetEditor() {
 		memdelete(helper);
 }
 
-void TileSetEditor::_on_tile_list_selected(int p_index) {
-	if (get_current_tile() >= 0) {
+void TileSetEditor::_on_tileset_toolbar_button_pressed(int p_index) {
+	option = p_index;
+	switch (option) {
+		case TOOL_TILESET_ADD_TEXTURE: {
+			texture_dialog->popup_centered_ratio();
+		} break;
+		case TOOL_TILESET_REMOVE_TEXTURE: {
+			if (get_current_texture().is_valid()) {
+				cd->set_text(TTR("Remove Selected Textue and ALL TILES wich uses it?"));
+				cd->popup_centered(Size2(300, 60));
+			} else {
+				err_dialog->set_text(TTR("You haven't selected a texture to remove."));
+				err_dialog->popup_centered(Size2(300, 60));
+			}
+		} break;
+		case TOOL_TILESET_CREATE_SCENE: {
+
+			cd->set_text(TTR("Create from scene?"));
+			cd->popup_centered(Size2(300, 60));
+		} break;
+		case TOOL_TILESET_MERGE_SCENE: {
+
+			cd->set_text(TTR("Merge from scene?"));
+			cd->popup_centered(Size2(300, 60));
+		} break;
+	}
+}
+
+void TileSetEditor::_on_tileset_toolbar_confirm() {
+	switch (option) {
+		case TOOL_TILESET_REMOVE_TEXTURE: {
+			RID current_rid = get_current_texture()->get_rid();
+			List<int> ids;
+			tileset->get_tile_list(&ids);
+			for (List<int>::Element *E = ids.front(); E; E = E->next()) {
+				if (tileset->tile_get_texture(E->get())->get_rid() == current_rid) {
+					tileset->remove_tile(E->get());
+				}
+			}
+			texture_list->remove_item(texture_list->find_metadata(current_rid));
+			texture_map.erase(current_rid);
+			_on_texture_list_selected(-1);
+		} break;
+		case TOOL_TILESET_MERGE_SCENE:
+		case TOOL_TILESET_CREATE_SCENE: {
+
+			EditorNode *en = editor;
+			Node *scene = en->get_edited_scene();
+			if (!scene)
+				break;
+			_import_scene(scene, tileset, option == TOOL_TILESET_MERGE_SCENE);
+
+			edit(tileset);
+		} break;
+	}
+}
+
+void TileSetEditor::_on_texture_list_selected(int p_index) {
+	if (get_current_texture().is_valid()) {
 		current_item_index = p_index;
-		preview->set_texture(tileset->tile_get_texture(get_current_tile()));
-		preview->set_modulate(tileset->tile_get_modulate(get_current_tile()));
-		preview->set_region_rect(tileset->tile_get_region(get_current_tile()));
-		workspace->set_custom_minimum_size(tileset->tile_get_region(get_current_tile()).size);
+		preview->set_texture(get_current_texture());
+		workspace->set_custom_minimum_size(get_current_texture()->get_size() + WORKSPACE_MARGIN * 2);
+		workspace_container->set_custom_minimum_size(get_current_texture()->get_size() + WORKSPACE_MARGIN * 2);
+		workspace_overlay->set_custom_minimum_size(get_current_texture()->get_size() + WORKSPACE_MARGIN * 2);
 		update_workspace_tile_mode();
 	} else {
 		current_item_index = -1;
 		preview->set_texture(NULL);
 		workspace->set_custom_minimum_size(Size2i());
+		update_workspace_tile_mode();
 	}
-	texture_region_editor->selected_tile = get_current_tile();
-	texture_region_editor->_edit_region();
-	helper->selected_tile = get_current_tile();
-	helper->_change_notify("");
+	set_current_tile(-1);
 	workspace->update();
+}
+
+void TileSetEditor::_on_textures_added(const PoolStringArray &p_paths) {
+	int invalid_count = 0;
+	for (int i = 0; i < p_paths.size(); i++) {
+		Ref<Texture> t = Ref<Texture>(ResourceLoader::load(p_paths[i]));
+		if (texture_map.has(t->get_rid())) {
+			invalid_count++;
+		} else {
+			texture_list->add_item(t->get_path().get_file());
+			texture_map.insert(t->get_rid(), t);
+			texture_list->set_item_metadata(texture_list->get_item_count() - 1, t->get_rid());
+		}
+	}
+	update_texture_list_icon();
+	texture_list->select(texture_list->get_item_count() - 1);
+	_on_texture_list_selected(texture_list->get_item_count() - 1);
+	if (invalid_count > 0) {
+		err_dialog->set_text(String::num(invalid_count, 0) + TTR(" file(s) was not added because was already on the list."));
+		err_dialog->popup_centered(Size2(300, 60));
+	}
 }
 
 void TileSetEditor::_on_edit_mode_changed(int p_edit_mode) {
 	edit_mode = (EditMode)p_edit_mode;
 	switch (edit_mode) {
-		case EDITMODE_BITMASK: {
-			tool_containers[TOOLBAR_DUMMY]->show();
-			tool_containers[TOOLBAR_BITMASK]->show();
-			tool_containers[TOOLBAR_SHAPE]->hide();
+		case EDITMODE_REGION: {
+			tools[TOOL_SELECT]->show();
+			tools[BITMASK_COPY]->hide();
+			tools[BITMASK_PASTE]->hide();
+			tools[BITMASK_CLEAR]->hide();
+			tools[SHAPE_NEW_POLYGON]->hide();
+			if (workspace_mode == WORKSPACE_EDIT)
+				tools[SHAPE_DELETE]->show();
+			else
+				tools[SHAPE_DELETE]->hide();
+			tools[SHAPE_KEEP_INSIDE_TILE]->hide();
+			tools[TOOL_GRID_SNAP]->show();
+
 			tools[TOOL_SELECT]->set_pressed(true);
-			tools[TOOL_SELECT]->set_tooltip(TTR("LMB: set bit on.\nRMB: set bit off."));
+			tools[TOOL_SELECT]->set_tooltip(TTR("Drag handles to edit Rect.\nClick on another Tile to edit it."));
+			spin_priority->hide();
+		} break;
+		case EDITMODE_BITMASK: {
+			tools[TOOL_SELECT]->show();
+			tools[BITMASK_COPY]->show();
+			tools[BITMASK_PASTE]->show();
+			tools[BITMASK_CLEAR]->show();
+			tools[SHAPE_NEW_POLYGON]->hide();
+			tools[SHAPE_DELETE]->hide();
+			tools[SHAPE_KEEP_INSIDE_TILE]->hide();
+			tools[TOOL_GRID_SNAP]->hide();
+
+			tools[TOOL_SELECT]->set_pressed(true);
+			tools[TOOL_SELECT]->set_tooltip(TTR("LMB: set bit on.\nRMB: set bit off.\nClick on another Tile to edit it."));
 			spin_priority->hide();
 		} break;
 		case EDITMODE_COLLISION:
 		case EDITMODE_NAVIGATION:
 		case EDITMODE_OCCLUSION: {
-			tool_containers[TOOLBAR_DUMMY]->show();
-			tool_containers[TOOLBAR_BITMASK]->hide();
-			tool_containers[TOOLBAR_SHAPE]->show();
-			tools[TOOL_SELECT]->set_tooltip(TTR("Select current edited sub-tile."));
-			spin_priority->hide();
+			tools[TOOL_SELECT]->show();
+			tools[BITMASK_COPY]->hide();
+			tools[BITMASK_PASTE]->hide();
+			tools[BITMASK_CLEAR]->hide();
+			tools[SHAPE_NEW_POLYGON]->show();
+			tools[SHAPE_DELETE]->show();
+			tools[SHAPE_KEEP_INSIDE_TILE]->show();
+			tools[TOOL_GRID_SNAP]->show();
 
+			tools[TOOL_SELECT]->set_tooltip(TTR("Select current edited sub-tile.\nClick on another Tile to edit it."));
+			spin_priority->hide();
 			select_coord(edited_shape_coord);
 		} break;
 		default: {
-			tool_containers[TOOLBAR_DUMMY]->show();
-			tool_containers[TOOLBAR_BITMASK]->hide();
-			tool_containers[TOOLBAR_SHAPE]->hide();
+			tools[TOOL_SELECT]->show();
+			tools[BITMASK_COPY]->hide();
+			tools[BITMASK_PASTE]->hide();
+			tools[BITMASK_CLEAR]->hide();
+			tools[SHAPE_NEW_POLYGON]->hide();
+			tools[SHAPE_DELETE]->hide();
+			tools[SHAPE_KEEP_INSIDE_TILE]->hide();
+			tools[TOOL_GRID_SNAP]->show();
 			if (edit_mode == EDITMODE_ICON) {
-				tools[TOOL_SELECT]->set_tooltip(TTR("Select sub-tile to use as icon, this will be also used on invalid autotile bindings."));
+				tools[TOOL_SELECT]->set_tooltip(TTR("Select sub-tile to use as icon, this will be also used on invalid autotile bindings.\nClick on another Tile to edit it."));
 				spin_priority->hide();
 			} else {
-				tools[TOOL_SELECT]->set_tooltip(TTR("Select sub-tile to change its priority."));
+				tools[TOOL_SELECT]->set_tooltip(TTR("Select sub-tile to change its priority.\nClick on another Tile to edit it."));
 				spin_priority->show();
 			}
 		} break;
@@ -634,25 +650,52 @@ void TileSetEditor::_on_edit_mode_changed(int p_edit_mode) {
 	workspace->update();
 }
 
+void TileSetEditor::_on_workspace_mode_changed(int p_workspace_mode) {
+	workspace_mode = (WorkspaceMode)p_workspace_mode;
+	if (p_workspace_mode == WORKSPACE_EDIT) {
+		update_workspace_tile_mode();
+	} else {
+		for (int i = 0; i < EDITMODE_MAX; i++) {
+			tool_editmode[i]->hide();
+		}
+		tool_editmode[EDITMODE_REGION]->show();
+		tool_editmode[EDITMODE_REGION]->set_pressed(true);
+		_on_edit_mode_changed(EDITMODE_REGION);
+	}
+}
+
 void TileSetEditor::_on_workspace_draw() {
 
-	if (get_current_tile() >= 0 && !tileset.is_null()) {
+	const Color COLOR_AUTOTILE = Color(0.266373, 0.565288, 0.988281);
+	const Color COLOR_SINGLE = Color(0.988281, 0.909323, 0.266373);
+	const Color COLOR_ATLAS = Color(0.78653, 0.812835, 0.832031);
+
+	if (tileset.is_null())
+		return;
+	if (!get_current_texture().is_valid())
+		return;
+
+	draw_highlight_current_tile();
+
+	draw_grid_snap();
+	if (get_current_tile() >= 0) {
 		int spacing = tileset->autotile_get_spacing(get_current_tile());
 		Vector2 size = tileset->autotile_get_size(get_current_tile());
 		Rect2i region = tileset->tile_get_region(get_current_tile());
-		Color c(0.347214, 0.722656, 0.617063);
 
 		switch (edit_mode) {
 			case EDITMODE_ICON: {
 				Vector2 coord = tileset->autotile_get_icon_coordinate(get_current_tile());
-				draw_highlight_tile(coord);
+				draw_highlight_subtile(coord);
 			} break;
 			case EDITMODE_BITMASK: {
-				c = Color(1, 0, 0, 0.5);
+				Color c(1, 0, 0, 0.5);
 				for (float x = 0; x < region.size.x / (spacing + size.x); x++) {
 					for (float y = 0; y < region.size.y / (spacing + size.y); y++) {
 						Vector2 coord(x, y);
 						Point2 anchor(coord.x * (spacing + size.x), coord.y * (spacing + size.y));
+						anchor += WORKSPACE_MARGIN;
+						anchor += region.position;
 						uint16_t mask = tileset->autotile_get_bitmask(get_current_tile(), coord);
 						if (tileset->autotile_get_bitmask_mode(get_current_tile()) == TileSet::BITMASK_2X2) {
 							if (mask & TileSet::BIND_TOPLEFT) {
@@ -702,9 +745,9 @@ void TileSetEditor::_on_workspace_draw() {
 			case EDITMODE_COLLISION:
 			case EDITMODE_OCCLUSION:
 			case EDITMODE_NAVIGATION: {
-				if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE) {
+				if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE || tileset->tile_get_tile_mode(get_current_tile()) == TileSet::ATLAS_TILE) {
 					Vector2 coord = edited_shape_coord;
-					draw_highlight_tile(coord);
+					draw_highlight_subtile(coord);
 				}
 				draw_polygon_shapes();
 				draw_grid_snap();
@@ -723,89 +766,334 @@ void TileSetEditor::_on_workspace_draw() {
 					}
 				}
 				spin_priority->set_suffix(" / " + String::num(total, 0));
-				draw_highlight_tile(edited_shape_coord, queue_others);
+				draw_highlight_subtile(edited_shape_coord, queue_others);
 			} break;
 		}
 
-		if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE) {
-			float j = -size.x; //make sure to draw at 0
-			while (j < region.size.x) {
-				j += size.x;
-				if (spacing <= 0) {
-					workspace->draw_line(Point2(j, 0), Point2(j, region.size.y), c);
-				} else {
-					workspace->draw_rect(Rect2(Point2(j, 0), Size2(spacing, region.size.y)), c);
-				}
-				j += spacing;
+		draw_tile_subdivision(get_current_tile(), Color(0.347214, 0.722656, 0.617063));
+	}
+
+	RID current_texture_rid = get_current_texture()->get_rid();
+	List<int> *tiles = new List<int>();
+	tileset->get_tile_list(tiles);
+	for (List<int>::Element *E = tiles->front(); E; E = E->next()) {
+		int t_id = E->get();
+		if (tileset->tile_get_texture(t_id)->get_rid() == current_texture_rid && (t_id != get_current_tile() || edit_mode != EDITMODE_REGION)) {
+			Rect2i region = tileset->tile_get_region(t_id);
+			region.position += WORKSPACE_MARGIN;
+			Color c;
+			if (tileset->tile_get_tile_mode(t_id) == TileSet::SINGLE_TILE)
+				c = COLOR_SINGLE;
+			else if (tileset->tile_get_tile_mode(t_id) == TileSet::AUTO_TILE)
+				c = COLOR_AUTOTILE;
+			else if (tileset->tile_get_tile_mode(t_id) == TileSet::ATLAS_TILE)
+				c = COLOR_ATLAS;
+			draw_tile_subdivision(t_id, Color(0.347214, 0.722656, 0.617063, 0.5));
+			workspace->draw_rect(region, c, false);
+		}
+	}
+	if (edit_mode == EDITMODE_REGION) {
+		if (workspace_mode != WORKSPACE_EDIT) {
+			Rect2i region = edited_region;
+			Color c;
+			if (workspace_mode == WORKSPACE_CREATE_SINGLE)
+				c = COLOR_SINGLE;
+			else if (workspace_mode == WORKSPACE_CREATE_AUTOTILE)
+				c = COLOR_AUTOTILE;
+			else if (workspace_mode == WORKSPACE_CREATE_ATLAS)
+				c = COLOR_ATLAS;
+			workspace->draw_rect(region, c, false);
+			draw_edited_region_subdivision();
+		} else {
+			int t_id = get_current_tile();
+			Rect2i region;
+			if (draw_edited_region)
+				region = edited_region;
+			else {
+				region = tileset->tile_get_region(t_id);
+				region.position += WORKSPACE_MARGIN;
 			}
-			j = -size.y; //make sure to draw at 0
-			while (j < region.size.y) {
-				j += size.y;
-				if (spacing <= 0) {
-					workspace->draw_line(Point2(0, j), Point2(region.size.x, j), c);
-				} else {
-					workspace->draw_rect(Rect2(Point2(0, j), Size2(region.size.x, spacing)), c);
-				}
-				j += spacing;
-			}
+			Color c;
+			if (tileset->tile_get_tile_mode(t_id) == TileSet::SINGLE_TILE)
+				c = COLOR_SINGLE;
+			else if (tileset->tile_get_tile_mode(t_id) == TileSet::AUTO_TILE)
+				c = COLOR_AUTOTILE;
+			else if (tileset->tile_get_tile_mode(t_id) == TileSet::ATLAS_TILE)
+				c = COLOR_ATLAS;
+			if (draw_edited_region)
+				draw_edited_region_subdivision();
+			else
+				draw_tile_subdivision(t_id, Color(0.347214, 0.722656, 0.617063, 1));
+			workspace->draw_rect(region, c, false);
 		}
 	}
 	workspace_overlay->update();
 }
 
+void TileSetEditor::_on_workspace_process() {
+	float a = tile_names_opacity;
+	if (Input::get_singleton()->is_key_pressed(KEY_ALT) || tools[VISIBLE_INFO]->is_pressed()) {
+		a += get_tree()->get_idle_process_time() * 2;
+	} else {
+		a -= get_tree()->get_idle_process_time() * 2;
+	}
+
+	a = CLAMP(a, 0, 1);
+	if (a != tile_names_opacity)
+		workspace_overlay->update();
+	tile_names_opacity = a;
+}
+
 void TileSetEditor::_on_workspace_overlay_draw() {
 
+	if (!tileset.is_valid())
+		return;
+	if (!get_current_texture().is_valid())
+		return;
+
+	const Color COLOR_AUTOTILE = Color(0.266373, 0.565288, 0.988281);
+	const Color COLOR_SINGLE = Color(0.988281, 0.909323, 0.266373);
+	const Color COLOR_ATLAS = Color(0.78653, 0.812835, 0.832031);
+
+	if (tile_names_opacity > 0) {
+		RID current_texture_rid = get_current_texture()->get_rid();
+		List<int> *tiles = new List<int>();
+		tileset->get_tile_list(tiles);
+		for (List<int>::Element *E = tiles->front(); E; E = E->next()) {
+			int t_id = E->get();
+			if (tileset->tile_get_texture(t_id)->get_rid() == current_texture_rid) {
+				Rect2i region = tileset->tile_get_region(t_id);
+				region.position += WORKSPACE_MARGIN;
+				region.position *= workspace->get_scale().x;
+				Color c;
+				if (tileset->tile_get_tile_mode(t_id) == TileSet::SINGLE_TILE)
+					c = COLOR_SINGLE;
+				else if (tileset->tile_get_tile_mode(t_id) == TileSet::AUTO_TILE)
+					c = COLOR_AUTOTILE;
+				else if (tileset->tile_get_tile_mode(t_id) == TileSet::ATLAS_TILE)
+					c = COLOR_ATLAS;
+				c.a = tile_names_opacity;
+				Ref<Font> font = get_font("font", "Label");
+				region.set_size(font->get_string_size(tileset->tile_get_name(t_id)));
+				workspace_overlay->draw_rect(region, c);
+				region.position.y += region.size.y - 2;
+				c = Color(0.1, 0.1, 0.1, tile_names_opacity);
+				workspace_overlay->draw_string(font, region.position, tileset->tile_get_name(t_id), c);
+			}
+		}
+	}
+
 	int t_id = get_current_tile();
-	if (t_id < 0 || !draw_handles)
+	if (t_id < 0)
 		return;
 
 	Ref<Texture> handle = get_icon("EditorHandle", "EditorIcons");
-
-	for (int i = 0; i < current_shape.size(); i++) {
-		workspace_overlay->draw_texture(handle, current_shape[i] * workspace->get_scale().x - handle->get_size() * 0.5);
+	if (draw_handles) {
+		for (int i = 0; i < current_shape.size(); i++) {
+			workspace_overlay->draw_texture(handle, current_shape[i] * workspace->get_scale().x - handle->get_size() * 0.5);
+		}
 	}
 }
 
 #define MIN_DISTANCE_SQUARED 6
 void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
+	if (tileset.is_null())
+		return;
+	if (!get_current_texture().is_valid())
+		return;
 
-	if (get_current_tile() >= 0 && !tileset.is_null()) {
-		Ref<InputEventMouseButton> mb = p_ie;
-		Ref<InputEventMouseMotion> mm = p_ie;
+	static bool dragging;
+	static bool erasing;
+	draw_edited_region = false;
 
-		static bool dragging;
-		static bool erasing;
+	Rect2 current_tile_region = Rect2();
+	if (get_current_tile() >= 0) {
+		current_tile_region = tileset->tile_get_region(get_current_tile());
+	}
+	current_tile_region.position += WORKSPACE_MARGIN;
 
-		int spacing = tileset->autotile_get_spacing(get_current_tile());
-		Vector2 size = tileset->autotile_get_size(get_current_tile());
-		switch (edit_mode) {
-			case EDITMODE_ICON: {
-				if (mb.is_valid()) {
-					if (mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
-						Vector2 coord((int)(mb->get_position().x / (spacing + size.x)), (int)(mb->get_position().y / (spacing + size.y)));
-						tileset->autotile_set_icon_coordinate(get_current_tile(), coord);
-						Rect2 region = tileset->tile_get_region(get_current_tile());
-						region.size = size;
-						coord.x *= (spacing + size.x);
-						coord.y *= (spacing + size.y);
-						region.position += coord;
-						tile_list->set_item_icon_region(current_item_index, region);
-						workspace->update();
-					}
-				}
-			} break;
-			case EDITMODE_BITMASK: {
-				if (mb.is_valid()) {
-					if (mb->is_pressed()) {
-						if (dragging) {
+	Ref<InputEventMouseButton> mb = p_ie;
+	Ref<InputEventMouseMotion> mm = p_ie;
+
+	if (mb.is_valid()) {
+		if (mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
+			if (!current_tile_region.has_point(mb->get_position())) {
+				List<int> *tiles = new List<int>();
+				tileset->get_tile_list(tiles);
+				for (List<int>::Element *E = tiles->front(); E; E = E->next()) {
+					int t_id = E->get();
+					if (get_current_texture()->get_rid() == tileset->tile_get_texture(t_id)->get_rid()) {
+						Rect2 r = tileset->tile_get_region(t_id);
+						r.position += WORKSPACE_MARGIN;
+						if (r.has_point(mb->get_position())) {
+							set_current_tile(t_id);
+							workspace->update();
+							workspace_overlay->update();
 							return;
 						}
-						if (mb->get_button_index() == BUTTON_RIGHT || mb->get_button_index() == BUTTON_LEFT) {
-							dragging = true;
-							erasing = (mb->get_button_index() == BUTTON_RIGHT);
-							Vector2 coord((int)(mb->get_position().x / (spacing + size.x)), (int)(mb->get_position().y / (spacing + size.y)));
+					}
+				}
+			}
+		}
+	}
+	// Drag Middle Mouse
+	if (mm.is_valid()) {
+		if (mm->get_button_mask() & BUTTON_MASK_MIDDLE) {
+			Vector2 dragged(mm->get_relative().x, mm->get_relative().y);
+			scroll->set_h_scroll(scroll->get_h_scroll() - dragged.x * workspace->get_scale().x);
+			scroll->set_v_scroll(scroll->get_v_scroll() - dragged.y * workspace->get_scale().x);
+		}
+	}
+
+	if (edit_mode == EDITMODE_REGION) {
+		if (mb.is_valid()) {
+			if (mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
+				if (get_current_tile() >= 0 || workspace_mode != WORKSPACE_EDIT) {
+					dragging = true;
+					region_from = mb->get_position();
+					edited_region = Rect2(region_from, Size2());
+					workspace->update();
+					workspace_overlay->update();
+					return;
+				}
+			} else if (dragging && mb->is_pressed() && mb->get_button_index() == BUTTON_RIGHT) {
+				dragging = false;
+				edited_region = Rect2();
+				workspace->update();
+				workspace_overlay->update();
+				return;
+			} else if (dragging && !mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
+				dragging = false;
+				update_edited_region(mb->get_position());
+				edited_region.position -= WORKSPACE_MARGIN;
+				if (!edited_region.has_no_area()) {
+					if (get_current_tile() >= 0 && workspace_mode == WORKSPACE_EDIT) {
+						tileset->tile_set_region(get_current_tile(), edited_region);
+					} else {
+						int t_id = tileset->get_last_unused_tile_id();
+						tileset->create_tile(t_id);
+						tileset->tile_set_texture(t_id, get_current_texture());
+						tileset->tile_set_region(t_id, edited_region);
+						tileset->tile_set_name(t_id, get_current_texture()->get_path().get_file() + " " + String::num(t_id, 0));
+						if (workspace_mode != WORKSPACE_CREATE_SINGLE) {
+							tileset->autotile_set_size(t_id, snap_step);
+							tileset->autotile_set_spacing(t_id, snap_separation.x);
+							tileset->tile_set_tile_mode(t_id, workspace_mode == WORKSPACE_CREATE_AUTOTILE ? TileSet::AUTO_TILE : TileSet::ATLAS_TILE);
+						}
+						set_current_tile(t_id);
+						tool_workspacemode[WORKSPACE_EDIT]->set_pressed(true);
+						_on_workspace_mode_changed(WORKSPACE_EDIT);
+					}
+				}
+				workspace->update();
+				workspace_overlay->update();
+				return;
+			}
+		} else if (mm.is_valid()) {
+			if (dragging) {
+				update_edited_region(mm->get_position());
+				draw_edited_region = true;
+				workspace->update();
+				workspace_overlay->update();
+				return;
+			}
+		}
+	}
+	if (workspace_mode == WORKSPACE_EDIT) {
+
+		if (get_current_tile() >= 0) {
+			int spacing = tileset->autotile_get_spacing(get_current_tile());
+			Vector2 size = tileset->autotile_get_size(get_current_tile());
+			switch (edit_mode) {
+				case EDITMODE_ICON: {
+					if (mb.is_valid()) {
+						if (mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT && current_tile_region.has_point(mb->get_position())) {
+							Vector2 coord((int)((mb->get_position().x - current_tile_region.position.x) / (spacing + size.x)), (int)((mb->get_position().y - current_tile_region.position.y) / (spacing + size.y)));
+							tileset->autotile_set_icon_coordinate(get_current_tile(), coord);
+							Rect2 region = tileset->tile_get_region(get_current_tile());
+							region.size = size;
+							coord.x *= (spacing + size.x);
+							coord.y *= (spacing + size.y);
+							region.position += coord;
+							workspace->update();
+						}
+					}
+				} break;
+				case EDITMODE_BITMASK: {
+					if (mb.is_valid()) {
+						if (mb->is_pressed()) {
+							if (dragging) {
+								return;
+							}
+							if ((mb->get_button_index() == BUTTON_RIGHT || mb->get_button_index() == BUTTON_LEFT) && current_tile_region.has_point(mb->get_position())) {
+								dragging = true;
+								erasing = (mb->get_button_index() == BUTTON_RIGHT);
+								Vector2 coord((int)((mb->get_position().x - current_tile_region.position.x) / (spacing + size.x)), (int)((mb->get_position().y - current_tile_region.position.y) / (spacing + size.y)));
+								Vector2 pos(coord.x * (spacing + size.x), coord.y * (spacing + size.y));
+								pos = mb->get_position() - (pos + current_tile_region.position);
+								uint16_t bit = 0;
+								if (tileset->autotile_get_bitmask_mode(get_current_tile()) == TileSet::BITMASK_2X2) {
+									if (pos.x < size.x / 2) {
+										if (pos.y < size.y / 2) {
+											bit = TileSet::BIND_TOPLEFT;
+										} else {
+											bit = TileSet::BIND_BOTTOMLEFT;
+										}
+									} else {
+										if (pos.y < size.y / 2) {
+											bit = TileSet::BIND_TOPRIGHT;
+										} else {
+											bit = TileSet::BIND_BOTTOMRIGHT;
+										}
+									}
+								} else {
+									if (pos.x < size.x / 3) {
+										if (pos.y < size.y / 3) {
+											bit = TileSet::BIND_TOPLEFT;
+										} else if (pos.y > (size.y / 3) * 2) {
+											bit = TileSet::BIND_BOTTOMLEFT;
+										} else {
+											bit = TileSet::BIND_LEFT;
+										}
+									} else if (pos.x > (size.x / 3) * 2) {
+										if (pos.y < size.y / 3) {
+											bit = TileSet::BIND_TOPRIGHT;
+										} else if (pos.y > (size.y / 3) * 2) {
+											bit = TileSet::BIND_BOTTOMRIGHT;
+										} else {
+											bit = TileSet::BIND_RIGHT;
+										}
+									} else {
+										if (pos.y < size.y / 3) {
+											bit = TileSet::BIND_TOP;
+										} else if (pos.y > (size.y / 3) * 2) {
+											bit = TileSet::BIND_BOTTOM;
+										} else {
+											bit = TileSet::BIND_CENTER;
+										}
+									}
+								}
+								uint16_t mask = tileset->autotile_get_bitmask(get_current_tile(), coord);
+								if (erasing) {
+									mask &= ~bit;
+								} else {
+									mask |= bit;
+								}
+								tileset->autotile_set_bitmask(get_current_tile(), coord, mask);
+								workspace->update();
+							}
+						} else {
+							if ((erasing && mb->get_button_index() == BUTTON_RIGHT) || (!erasing && mb->get_button_index() == BUTTON_LEFT)) {
+								dragging = false;
+								erasing = false;
+							}
+						}
+					}
+					if (mm.is_valid()) {
+						if (dragging && current_tile_region.has_point(mm->get_position())) {
+							Vector2 coord((int)((mm->get_position().x - current_tile_region.position.x) / (spacing + size.x)), (int)((mm->get_position().y - current_tile_region.position.y) / (spacing + size.y)));
 							Vector2 pos(coord.x * (spacing + size.x), coord.y * (spacing + size.y));
-							pos = mb->get_position() - pos;
+							pos = mm->get_position() - (pos + current_tile_region.position);
 							uint16_t bit = 0;
 							if (tileset->autotile_get_bitmask_mode(get_current_tile()) == TileSet::BITMASK_2X2) {
 								if (pos.x < size.x / 2) {
@@ -857,269 +1145,198 @@ void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 							tileset->autotile_set_bitmask(get_current_tile(), coord, mask);
 							workspace->update();
 						}
-					} else {
-						if ((erasing && mb->get_button_index() == BUTTON_RIGHT) || (!erasing && mb->get_button_index() == BUTTON_LEFT)) {
-							dragging = false;
-							erasing = false;
-						}
 					}
-				}
-				if (mm.is_valid()) {
-					if (dragging) {
-						Vector2 coord((int)(mm->get_position().x / (spacing + size.x)), (int)(mm->get_position().y / (spacing + size.y)));
-						Vector2 pos(coord.x * (spacing + size.x), coord.y * (spacing + size.y));
-						pos = mm->get_position() - pos;
-						uint16_t bit = 0;
-						if (tileset->autotile_get_bitmask_mode(get_current_tile()) == TileSet::BITMASK_2X2) {
-							if (pos.x < size.x / 2) {
-								if (pos.y < size.y / 2) {
-									bit = TileSet::BIND_TOPLEFT;
-								} else {
-									bit = TileSet::BIND_BOTTOMLEFT;
-								}
-							} else {
-								if (pos.y < size.y / 2) {
-									bit = TileSet::BIND_TOPRIGHT;
-								} else {
-									bit = TileSet::BIND_BOTTOMRIGHT;
-								}
-							}
-						} else {
-							if (pos.x < size.x / 3) {
-								if (pos.y < size.y / 3) {
-									bit = TileSet::BIND_TOPLEFT;
-								} else if (pos.y > (size.y / 3) * 2) {
-									bit = TileSet::BIND_BOTTOMLEFT;
-								} else {
-									bit = TileSet::BIND_LEFT;
-								}
-							} else if (pos.x > (size.x / 3) * 2) {
-								if (pos.y < size.y / 3) {
-									bit = TileSet::BIND_TOPRIGHT;
-								} else if (pos.y > (size.y / 3) * 2) {
-									bit = TileSet::BIND_BOTTOMRIGHT;
-								} else {
-									bit = TileSet::BIND_RIGHT;
-								}
-							} else {
-								if (pos.y < size.y / 3) {
-									bit = TileSet::BIND_TOP;
-								} else if (pos.y > (size.y / 3) * 2) {
-									bit = TileSet::BIND_BOTTOM;
-								} else {
-									bit = TileSet::BIND_CENTER;
-								}
-							}
-						}
-						uint16_t mask = tileset->autotile_get_bitmask(get_current_tile(), coord);
-						if (erasing) {
-							mask &= ~bit;
-						} else {
-							mask |= bit;
-						}
-						tileset->autotile_set_bitmask(get_current_tile(), coord, mask);
-						workspace->update();
+				} break;
+				case EDITMODE_COLLISION:
+				case EDITMODE_OCCLUSION:
+				case EDITMODE_NAVIGATION:
+				case EDITMODE_PRIORITY: {
+					Vector2 shape_anchor = Vector2(0, 0);
+					if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE || tileset->tile_get_tile_mode(get_current_tile()) == TileSet::ATLAS_TILE) {
+						shape_anchor = edited_shape_coord;
+						shape_anchor.x *= (size.x + spacing);
+						shape_anchor.y *= (size.y + spacing);
 					}
-				}
-			} break;
-			case EDITMODE_COLLISION:
-			case EDITMODE_OCCLUSION:
-			case EDITMODE_NAVIGATION:
-			case EDITMODE_PRIORITY: {
-				Vector2 shape_anchor = Vector2(0, 0);
-				if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE) {
-					shape_anchor = edited_shape_coord;
-					shape_anchor.x *= (size.x + spacing);
-					shape_anchor.y *= (size.y + spacing);
-				}
-				if (tools[TOOL_SELECT]->is_pressed()) {
-					if (mb.is_valid()) {
-						if (mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
-							if (edit_mode != EDITMODE_PRIORITY && current_shape.size() > 0) {
-								for (int i = 0; i < current_shape.size(); i++) {
-									if ((current_shape[i] - mb->get_position()).length_squared() <= MIN_DISTANCE_SQUARED) {
-										dragging_point = i;
-										workspace->update();
-										return;
-									}
-								}
-							}
-							if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE) {
-								Vector2 coord((int)(mb->get_position().x / (spacing + size.x)), (int)(mb->get_position().y / (spacing + size.y)));
-								if (edited_shape_coord != coord) {
-									edited_shape_coord = coord;
-									edited_occlusion_shape = tileset->autotile_get_light_occluder(get_current_tile(), edited_shape_coord);
-									edited_navigation_shape = tileset->autotile_get_navigation_polygon(get_current_tile(), edited_shape_coord);
-									Vector<TileSet::ShapeData> sd = tileset->tile_get_shapes(get_current_tile());
-									bool found_collision_shape = false;
-									for (int i = 0; i < sd.size(); i++) {
-										if (sd[i].autotile_coord == coord) {
-											edited_collision_shape = sd[i].shape;
-											found_collision_shape = true;
-											break;
-										}
-									}
-									if (!found_collision_shape)
-										edited_collision_shape = Ref<ConvexPolygonShape2D>(NULL);
-									select_coord(edited_shape_coord);
-								}
-							}
-							workspace->update();
-						} else if (!mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
-							if (edit_mode == EDITMODE_COLLISION) {
-								if (dragging_point >= 0) {
-									dragging_point = -1;
-
-									Vector<Vector2> points;
-
+					shape_anchor += current_tile_region.position;
+					if (tools[TOOL_SELECT]->is_pressed()) {
+						if (mb.is_valid()) {
+							if (mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
+								if (edit_mode != EDITMODE_PRIORITY && current_shape.size() > 0) {
 									for (int i = 0; i < current_shape.size(); i++) {
-										Vector2 p = current_shape[i];
-										if (tools[SHAPE_GRID_SNAP]->is_pressed() || tools[SHAPE_KEEP_INSIDE_TILE]->is_pressed()) {
-											p = snap_point(p);
-										}
-										points.push_back(p - shape_anchor);
-									}
-
-									edited_collision_shape->set_points(points);
-
-									workspace->update();
-								}
-							} else if (edit_mode == EDITMODE_OCCLUSION) {
-								if (dragging_point >= 0) {
-									dragging_point = -1;
-
-									PoolVector<Vector2> polygon;
-									polygon.resize(current_shape.size());
-									PoolVector<Vector2>::Write w = polygon.write();
-
-									for (int i = 0; i < current_shape.size(); i++) {
-										w[i] = current_shape[i] - shape_anchor;
-									}
-
-									w = PoolVector<Vector2>::Write();
-									edited_occlusion_shape->set_polygon(polygon);
-
-									workspace->update();
-								}
-							} else if (edit_mode == EDITMODE_NAVIGATION) {
-								if (dragging_point >= 0) {
-									dragging_point = -1;
-
-									PoolVector<Vector2> polygon;
-									Vector<int> indices;
-									polygon.resize(current_shape.size());
-									PoolVector<Vector2>::Write w = polygon.write();
-
-									for (int i = 0; i < current_shape.size(); i++) {
-										w[i] = current_shape[i] - shape_anchor;
-										indices.push_back(i);
-									}
-
-									w = PoolVector<Vector2>::Write();
-									edited_navigation_shape->set_vertices(polygon);
-									edited_navigation_shape->add_polygon(indices);
-
-									workspace->update();
-								}
-							}
-						}
-					} else if (mm.is_valid()) {
-						if (dragging_point >= 0) {
-							current_shape.set(dragging_point, snap_point(mm->get_position()));
-							workspace->update();
-						}
-					}
-				} else if (tools[SHAPE_NEW_POLYGON]->is_pressed()) {
-
-					if (mb.is_valid()) {
-						if (mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
-							Vector2 pos = mb->get_position();
-							pos = snap_point(pos);
-							if (creating_shape) {
-								if (current_shape.size() > 0) {
-									if ((pos - current_shape[0]).length_squared() <= MIN_DISTANCE_SQUARED) {
-										if (current_shape.size() > 2) {
-											close_shape(shape_anchor);
+										if ((current_shape[i] - mb->get_position()).length_squared() <= MIN_DISTANCE_SQUARED) {
+											dragging_point = i;
 											workspace->update();
 											return;
 										}
 									}
 								}
-								current_shape.push_back(pos);
-								workspace->update();
-							} else {
-								int t_id = get_current_tile();
-								if (t_id >= 0) {
-									if (edit_mode == EDITMODE_COLLISION) {
-										Vector<TileSet::ShapeData> sd = tileset->tile_get_shapes(t_id);
+								if ((tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE || tileset->tile_get_tile_mode(get_current_tile()) == TileSet::ATLAS_TILE) && current_tile_region.has_point(mb->get_position())) {
+									Vector2 coord((int)((mb->get_position().x - current_tile_region.position.x) / (spacing + size.x)), (int)((mb->get_position().y - current_tile_region.position.y) / (spacing + size.y)));
+									if (edited_shape_coord != coord) {
+										edited_shape_coord = coord;
+										edited_occlusion_shape = tileset->autotile_get_light_occluder(get_current_tile(), edited_shape_coord);
+										edited_navigation_shape = tileset->autotile_get_navigation_polygon(get_current_tile(), edited_shape_coord);
+										Vector<TileSet::ShapeData> sd = tileset->tile_get_shapes(get_current_tile());
+										bool found_collision_shape = false;
 										for (int i = 0; i < sd.size(); i++) {
-											if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::SINGLE_TILE || sd[i].autotile_coord == edited_shape_coord) {
-												Ref<ConvexPolygonShape2D> shape = sd[i].shape;
-
-												if (!shape.is_null()) {
-													sd.remove(i);
-													tileset->tile_set_shapes(get_current_tile(), sd);
-													edited_collision_shape = Ref<Shape2D>();
-													workspace->update();
-												}
+											if (sd[i].autotile_coord == coord) {
+												edited_collision_shape = sd[i].shape;
+												found_collision_shape = true;
 												break;
 											}
 										}
-									} else if (edit_mode == EDITMODE_OCCLUSION) {
-										if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE) {
-											Map<Vector2, Ref<OccluderPolygon2D> > map = tileset->autotile_get_light_oclusion_map(t_id);
-											for (Map<Vector2, Ref<OccluderPolygon2D> >::Element *E = map.front(); E; E = E->next()) {
-												if (E->key() == edited_shape_coord) {
-													tileset->autotile_set_light_occluder(get_current_tile(), Ref<OccluderPolygon2D>(), edited_shape_coord);
-													break;
-												}
-											}
-										} else
-											tileset->tile_set_light_occluder(t_id, Ref<OccluderPolygon2D>());
+										if (!found_collision_shape)
+											edited_collision_shape = Ref<ConvexPolygonShape2D>(NULL);
+										select_coord(edited_shape_coord);
+									}
+								}
+								workspace->update();
+							} else if (!mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
+								if (edit_mode == EDITMODE_COLLISION) {
+									if (dragging_point >= 0) {
+										dragging_point = -1;
 
-										edited_occlusion_shape = Ref<OccluderPolygon2D>();
-										workspace->update();
-									} else if (edit_mode == EDITMODE_NAVIGATION) {
-										if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE) {
-											Map<Vector2, Ref<NavigationPolygon> > map = tileset->autotile_get_navigation_map(t_id);
-											for (Map<Vector2, Ref<NavigationPolygon> >::Element *E = map.front(); E; E = E->next()) {
-												if (E->key() == edited_shape_coord) {
-													tileset->autotile_set_navigation_polygon(t_id, Ref<NavigationPolygon>(), edited_shape_coord);
-													break;
-												}
+										Vector<Vector2> points;
+
+										for (int i = 0; i < current_shape.size(); i++) {
+											Vector2 p = current_shape[i];
+											if (tools[TOOL_GRID_SNAP]->is_pressed() || tools[SHAPE_KEEP_INSIDE_TILE]->is_pressed()) {
+												p = snap_point(p);
 											}
-										} else
-											tileset->tile_set_navigation_polygon(t_id, Ref<NavigationPolygon>());
-										edited_navigation_shape = Ref<NavigationPolygon>();
+											points.push_back(p - shape_anchor);
+										}
+
+										edited_collision_shape->set_points(points);
+
+										workspace->update();
+									}
+								} else if (edit_mode == EDITMODE_OCCLUSION) {
+									if (dragging_point >= 0) {
+										dragging_point = -1;
+
+										PoolVector<Vector2> polygon;
+										polygon.resize(current_shape.size());
+										PoolVector<Vector2>::Write w = polygon.write();
+
+										for (int i = 0; i < current_shape.size(); i++) {
+											w[i] = current_shape[i] - shape_anchor;
+										}
+
+										w = PoolVector<Vector2>::Write();
+										edited_occlusion_shape->set_polygon(polygon);
+
+										workspace->update();
+									}
+								} else if (edit_mode == EDITMODE_NAVIGATION) {
+									if (dragging_point >= 0) {
+										dragging_point = -1;
+
+										PoolVector<Vector2> polygon;
+										Vector<int> indices;
+										polygon.resize(current_shape.size());
+										PoolVector<Vector2>::Write w = polygon.write();
+
+										for (int i = 0; i < current_shape.size(); i++) {
+											w[i] = current_shape[i] - shape_anchor;
+											indices.push_back(i);
+										}
+
+										w = PoolVector<Vector2>::Write();
+										edited_navigation_shape->set_vertices(polygon);
+										edited_navigation_shape->add_polygon(indices);
+
 										workspace->update();
 									}
 								}
-
-								creating_shape = true;
-								current_shape.resize(0);
-								current_shape.push_back(snap_point(pos));
 							}
-						} else if (mb->is_pressed() && mb->get_button_index() == BUTTON_RIGHT && current_shape.size() > 2) {
-							if (creating_shape) {
-								close_shape(shape_anchor);
+						} else if (mm.is_valid()) {
+							if (dragging_point >= 0) {
+								current_shape.set(dragging_point, snap_point(mm->get_position()));
+								workspace->update();
 							}
 						}
-					} else if (mm.is_valid()) {
-						if (creating_shape) {
-							workspace->update();
+					} else if (tools[SHAPE_NEW_POLYGON]->is_pressed()) {
+
+						if (mb.is_valid()) {
+							if (mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
+								Vector2 pos = mb->get_position();
+								pos = snap_point(pos);
+								if (creating_shape) {
+									if (current_shape.size() > 0) {
+										if ((pos - current_shape[0]).length_squared() <= MIN_DISTANCE_SQUARED) {
+											if (current_shape.size() > 2) {
+												close_shape(shape_anchor);
+												workspace->update();
+												return;
+											}
+										}
+									}
+									current_shape.push_back(pos);
+									workspace->update();
+								} else {
+									int t_id = get_current_tile();
+									if (t_id >= 0) {
+										if (edit_mode == EDITMODE_COLLISION) {
+											Vector<TileSet::ShapeData> sd = tileset->tile_get_shapes(t_id);
+											for (int i = 0; i < sd.size(); i++) {
+												if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::SINGLE_TILE || sd[i].autotile_coord == edited_shape_coord) {
+													Ref<ConvexPolygonShape2D> shape = sd[i].shape;
+
+													if (!shape.is_null()) {
+														sd.remove(i);
+														tileset->tile_set_shapes(get_current_tile(), sd);
+														edited_collision_shape = Ref<Shape2D>();
+														workspace->update();
+													}
+													break;
+												}
+											}
+										} else if (edit_mode == EDITMODE_OCCLUSION) {
+											if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE || tileset->tile_get_tile_mode(get_current_tile()) == TileSet::ATLAS_TILE) {
+												Map<Vector2, Ref<OccluderPolygon2D> > map = tileset->autotile_get_light_oclusion_map(t_id);
+												for (Map<Vector2, Ref<OccluderPolygon2D> >::Element *E = map.front(); E; E = E->next()) {
+													if (E->key() == edited_shape_coord) {
+														tileset->autotile_set_light_occluder(get_current_tile(), Ref<OccluderPolygon2D>(), edited_shape_coord);
+														break;
+													}
+												}
+											} else
+												tileset->tile_set_light_occluder(t_id, Ref<OccluderPolygon2D>());
+
+											edited_occlusion_shape = Ref<OccluderPolygon2D>();
+											workspace->update();
+										} else if (edit_mode == EDITMODE_NAVIGATION) {
+											if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE || tileset->tile_get_tile_mode(get_current_tile()) == TileSet::ATLAS_TILE) {
+												Map<Vector2, Ref<NavigationPolygon> > map = tileset->autotile_get_navigation_map(t_id);
+												for (Map<Vector2, Ref<NavigationPolygon> >::Element *E = map.front(); E; E = E->next()) {
+													if (E->key() == edited_shape_coord) {
+														tileset->autotile_set_navigation_polygon(t_id, Ref<NavigationPolygon>(), edited_shape_coord);
+														break;
+													}
+												}
+											} else
+												tileset->tile_set_navigation_polygon(t_id, Ref<NavigationPolygon>());
+											edited_navigation_shape = Ref<NavigationPolygon>();
+											workspace->update();
+										}
+									}
+
+									creating_shape = true;
+									current_shape.resize(0);
+									current_shape.push_back(snap_point(pos));
+								}
+							} else if (mb->is_pressed() && mb->get_button_index() == BUTTON_RIGHT && current_shape.size() > 2) {
+								if (creating_shape) {
+									close_shape(shape_anchor);
+								}
+							}
+						} else if (mm.is_valid()) {
+							if (creating_shape) {
+								workspace->update();
+							}
 						}
 					}
-				}
-			} break;
-		}
-
-		//Drag Middle Mouse
-		if (mm.is_valid()) {
-			if (mm->get_button_mask() & BUTTON_MASK_MIDDLE) {
-
-				Vector2 dragged(mm->get_relative().x, mm->get_relative().y);
-				scroll->set_h_scroll(scroll->get_h_scroll() - dragged.x * workspace->get_scale().x);
-				scroll->set_v_scroll(scroll->get_v_scroll() - dragged.y * workspace->get_scale().x);
+				} break;
 			}
 		}
 	}
@@ -1144,6 +1361,16 @@ void TileSetEditor::_on_tool_clicked(int p_tool) {
 			workspace->update();
 		} else {
 			switch (edit_mode) {
+				case EDITMODE_REGION: {
+					if (workspace_mode == WORKSPACE_EDIT && get_current_tile() >= 0) {
+						tileset->remove_tile(get_current_tile());
+						workspace->update();
+						workspace_overlay->update();
+					}
+					tool_workspacemode[WORKSPACE_EDIT]->set_pressed(true);
+					workspace_mode = WORKSPACE_EDIT;
+					update_workspace_tile_mode();
+				} break;
 				case EDITMODE_COLLISION: {
 					if (!edited_collision_shape.is_null()) {
 						Vector<TileSet::ShapeData> sd = tileset->tile_get_shapes(get_current_tile());
@@ -1186,22 +1413,22 @@ void TileSetEditor::_on_tool_clicked(int p_tool) {
 		if (scale > 0.1) {
 			scale /= 2;
 			workspace->set_scale(Vector2(scale, scale));
-			workspace_container->set_custom_minimum_size(preview->get_region_rect().size * scale);
-			workspace_overlay->set_custom_minimum_size(preview->get_region_rect().size * scale);
+			workspace_container->set_custom_minimum_size(workspace->get_rect().size * scale);
+			workspace_overlay->set_custom_minimum_size(workspace->get_rect().size * scale);
 		}
 	} else if (p_tool == ZOOM_1) {
 		workspace->set_scale(Vector2(1, 1));
-		workspace_container->set_custom_minimum_size(preview->get_region_rect().size);
-		workspace_overlay->set_custom_minimum_size(preview->get_region_rect().size);
+		workspace_container->set_custom_minimum_size(workspace->get_rect().size);
+		workspace_overlay->set_custom_minimum_size(workspace->get_rect().size);
 	} else if (p_tool == ZOOM_IN) {
 		float scale = workspace->get_scale().x;
 		scale *= 2;
 		workspace->set_scale(Vector2(scale, scale));
-		workspace_container->set_custom_minimum_size(preview->get_region_rect().size * scale);
-		workspace_overlay->set_custom_minimum_size(preview->get_region_rect().size * scale);
+		workspace_container->set_custom_minimum_size(workspace->get_rect().size * scale);
+		workspace_overlay->set_custom_minimum_size(workspace->get_rect().size * scale);
 	} else if (p_tool == TOOL_SELECT) {
 		if (creating_shape) {
-			//Cancel Creation
+			// Cancel Creation
 			creating_shape = false;
 			current_shape.resize(0);
 			workspace->update();
@@ -1215,66 +1442,140 @@ void TileSetEditor::_on_priority_changed(float val) {
 }
 
 void TileSetEditor::_on_grid_snap_toggled(bool p_val) {
-	if (p_val)
-		hb_grid->show();
-	else
-		hb_grid->hide();
+	helper->set_snap_options_visible(p_val);
 	workspace->update();
 }
 
-void TileSetEditor::_set_snap_step_x(float p_val) {
-	snap_step.x = p_val;
+void TileSetEditor::_set_snap_step(Vector2 p_val) {
+	snap_step.x = CLAMP(p_val.x, 0, 256);
+	snap_step.y = CLAMP(p_val.y, 0, 256);
 	workspace->update();
 }
 
-void TileSetEditor::_set_snap_step_y(float p_val) {
-	snap_step.y = p_val;
+void TileSetEditor::_set_snap_off(Vector2 p_val) {
+	snap_offset.x = CLAMP(p_val.x, 0, 256 + WORKSPACE_MARGIN.x);
+	snap_offset.y = CLAMP(p_val.y, 0, 256 + WORKSPACE_MARGIN.y);
 	workspace->update();
 }
 
-void TileSetEditor::_set_snap_off_x(float p_val) {
-	snap_offset.x = p_val;
+void TileSetEditor::_set_snap_sep(Vector2 p_val) {
+	snap_separation.x = CLAMP(p_val.x, 0, 256);
+	snap_separation.y = CLAMP(p_val.y, 0, 256);
 	workspace->update();
 }
 
-void TileSetEditor::_set_snap_off_y(float p_val) {
-	snap_offset.y = p_val;
-	workspace->update();
-}
-void TileSetEditor::_set_snap_sep_x(float p_val) {
-	snap_separation.x = p_val;
-	workspace->update();
+void TileSetEditor::draw_highlight_current_tile() {
+
+	if (get_current_tile() >= 0) {
+		Rect2 region = tileset->tile_get_region(get_current_tile());
+		region.position += WORKSPACE_MARGIN;
+		workspace->draw_rect(Rect2(0, 0, workspace->get_rect().size.x, region.position.y), Color(0.3, 0.3, 0.3, 0.3));
+		workspace->draw_rect(Rect2(0, region.position.y, region.position.x, region.size.y), Color(0.3, 0.3, 0.3, 0.3));
+		workspace->draw_rect(Rect2(region.position.x + region.size.x, region.position.y, workspace->get_rect().size.x - region.position.x - region.size.x, region.size.y), Color(0.3, 0.3, 0.3, 0.3));
+		workspace->draw_rect(Rect2(0, region.position.y + region.size.y, workspace->get_rect().size.x, workspace->get_rect().size.y - region.size.y - region.position.y), Color(0.3, 0.3, 0.3, 0.3));
+	} else {
+		workspace->draw_rect(Rect2(Point2(0, 0), workspace->get_rect().size), Color(0.3, 0.3, 0.3, 0.3));
+	}
 }
 
-void TileSetEditor::_set_snap_sep_y(float p_val) {
-	snap_separation.y = p_val;
-	workspace->update();
-}
-
-void TileSetEditor::draw_highlight_tile(Vector2 coord, const Vector<Vector2> &other_highlighted) {
+void TileSetEditor::draw_highlight_subtile(Vector2 coord, const Vector<Vector2> &other_highlighted) {
 
 	Vector2 size = tileset->autotile_get_size(get_current_tile());
 	int spacing = tileset->autotile_get_spacing(get_current_tile());
 	Rect2 region = tileset->tile_get_region(get_current_tile());
 	coord.x *= (size.x + spacing);
 	coord.y *= (size.y + spacing);
-	workspace->draw_rect(Rect2(0, 0, region.size.x, coord.y), Color(0.5, 0.5, 0.5, 0.5));
-	workspace->draw_rect(Rect2(0, coord.y, coord.x, size.y), Color(0.5, 0.5, 0.5, 0.5));
-	workspace->draw_rect(Rect2(coord.x + size.x, coord.y, region.size.x - coord.x - size.x, size.y), Color(0.5, 0.5, 0.5, 0.5));
-	workspace->draw_rect(Rect2(0, coord.y + size.y, region.size.x, region.size.y - size.y - coord.y), Color(0.5, 0.5, 0.5, 0.5));
+	coord += region.position;
+	coord += WORKSPACE_MARGIN;
+	workspace->draw_rect(Rect2(0, 0, workspace->get_rect().size.x, coord.y), Color(0.3, 0.3, 0.3, 0.3));
+	workspace->draw_rect(Rect2(0, coord.y, coord.x, size.y), Color(0.3, 0.3, 0.3, 0.3));
+	workspace->draw_rect(Rect2(coord.x + size.x, coord.y, workspace->get_rect().size.x - coord.x - size.x, size.y), Color(0.3, 0.3, 0.3, 0.3));
+	workspace->draw_rect(Rect2(0, coord.y + size.y, workspace->get_rect().size.x, workspace->get_rect().size.y - size.y - coord.y), Color(0.3, 0.3, 0.3, 0.3));
 	coord += Vector2(1, 1) / workspace->get_scale().x;
 	workspace->draw_rect(Rect2(coord, size - Vector2(2, 2) / workspace->get_scale().x), Color(1, 0, 0), false);
 	for (int i = 0; i < other_highlighted.size(); i++) {
 		coord = other_highlighted[i];
 		coord.x *= (size.x + spacing);
 		coord.y *= (size.y + spacing);
+		coord += region.position;
+		coord += WORKSPACE_MARGIN;
 		coord += Vector2(1, 1) / workspace->get_scale().x;
-		workspace->draw_rect(Rect2(coord, size - Vector2(2, 2) / workspace->get_scale().x), Color(1, 0, 0), false);
+		workspace->draw_rect(Rect2(coord, size - Vector2(2, 2) / workspace->get_scale().x), Color(1, 0.5, 0.5), false);
+	}
+}
+
+void TileSetEditor::draw_tile_subdivision(int p_id, Color p_color) const {
+	Color c = p_color;
+	if (tileset->tile_get_tile_mode(p_id) == TileSet::AUTO_TILE || tileset->tile_get_tile_mode(p_id) == TileSet::ATLAS_TILE) {
+		Rect2 region = tileset->tile_get_region(p_id);
+		Size2 size = tileset->autotile_get_size(p_id);
+		int spacing = tileset->autotile_get_spacing(p_id);
+		float j = 0;
+		while (j < region.size.x) {
+			j += size.x;
+			if (spacing <= 0) {
+				workspace->draw_line(region.position + WORKSPACE_MARGIN + Point2(j, 0), region.position + WORKSPACE_MARGIN + Point2(j, region.size.y), c);
+			} else {
+				workspace->draw_rect(Rect2(region.position + WORKSPACE_MARGIN + Point2(j, 0), Size2(spacing, region.size.y)), c);
+			}
+			j += spacing;
+		}
+		j = 0;
+		while (j < region.size.y) {
+			j += size.y;
+			if (spacing <= 0) {
+				workspace->draw_line(region.position + WORKSPACE_MARGIN + Point2(0, j), region.position + WORKSPACE_MARGIN + Point2(region.size.x, j), c);
+			} else {
+				workspace->draw_rect(Rect2(region.position + WORKSPACE_MARGIN + Point2(0, j), Size2(region.size.x, spacing)), c);
+			}
+			j += spacing;
+		}
+	}
+}
+
+void TileSetEditor::draw_edited_region_subdivision() const {
+	Color c = Color(0.347214, 0.722656, 0.617063, 1);
+	Rect2 region = edited_region;
+	Size2 size;
+	int spacing;
+	bool draw;
+	if (workspace_mode == WORKSPACE_EDIT) {
+		int p_id = get_current_tile();
+		size = tileset->autotile_get_size(p_id);
+		spacing = tileset->autotile_get_spacing(p_id);
+		draw = tileset->tile_get_tile_mode(p_id) == TileSet::AUTO_TILE || tileset->tile_get_tile_mode(p_id) == TileSet::ATLAS_TILE;
+	} else {
+		size = snap_step;
+		spacing = snap_separation.x;
+		draw = workspace_mode != WORKSPACE_CREATE_SINGLE;
+	}
+	if (draw) {
+
+		float j = 0;
+		while (j < region.size.x) {
+			j += size.x;
+			if (spacing <= 0) {
+				workspace->draw_line(region.position + Point2(j, 0), region.position + Point2(j, region.size.y), c);
+			} else {
+				workspace->draw_rect(Rect2(region.position + Point2(j, 0), Size2(spacing, region.size.y)), c);
+			}
+			j += spacing;
+		}
+		j = 0;
+		while (j < region.size.y) {
+			j += size.y;
+			if (spacing <= 0) {
+				workspace->draw_line(region.position + Point2(0, j), region.position + Point2(region.size.x, j), c);
+			} else {
+				workspace->draw_rect(Rect2(region.position + Point2(0, j), Size2(region.size.x, spacing)), c);
+			}
+			j += spacing;
+		}
 	}
 }
 
 void TileSetEditor::draw_grid_snap() {
-	if (tools[SHAPE_GRID_SNAP]->is_pressed()) {
+	if (tools[TOOL_GRID_SNAP]->is_pressed()) {
 		Color grid_color = Color(0.39, 0, 1, 0.2f);
 		Size2 s = workspace->get_size();
 
@@ -1328,7 +1629,7 @@ void TileSetEditor::draw_polygon_shapes() {
 			for (int i = 0; i < sd.size(); i++) {
 				Vector2 coord = Vector2(0, 0);
 				Vector2 anchor = Vector2(0, 0);
-				if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE) {
+				if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE || tileset->tile_get_tile_mode(get_current_tile()) == TileSet::ATLAS_TILE) {
 					coord = sd[i].autotile_coord;
 					anchor = tileset->autotile_get_size(t_id);
 					anchor.x += tileset->autotile_get_spacing(t_id);
@@ -1336,6 +1637,8 @@ void TileSetEditor::draw_polygon_shapes() {
 					anchor.x *= coord.x;
 					anchor.y *= coord.y;
 				}
+				anchor += WORKSPACE_MARGIN;
+				anchor += tileset->tile_get_region(t_id).position;
 				Ref<ConvexPolygonShape2D> shape = sd[i].shape;
 				if (shape.is_valid()) {
 					Color c_bg;
@@ -1407,6 +1710,8 @@ void TileSetEditor::draw_polygon_shapes() {
 					anchor.y += tileset->autotile_get_spacing(t_id);
 					anchor.x *= coord.x;
 					anchor.y *= coord.y;
+					anchor += WORKSPACE_MARGIN;
+					anchor += tileset->tile_get_region(t_id).position;
 					Ref<OccluderPolygon2D> shape = E->value();
 					if (shape.is_valid()) {
 						Color c_bg;
@@ -1483,6 +1788,8 @@ void TileSetEditor::draw_polygon_shapes() {
 					anchor.y += tileset->autotile_get_spacing(t_id);
 					anchor.x *= coord.x;
 					anchor.y *= coord.y;
+					anchor += WORKSPACE_MARGIN;
+					anchor += tileset->tile_get_region(t_id).position;
 					Ref<NavigationPolygon> shape = E->value();
 					if (shape.is_valid()) {
 						Color c_bg;
@@ -1558,10 +1865,10 @@ void TileSetEditor::close_shape(const Vector2 &shape_anchor) {
 
 			shape->set_points(segments);
 
-			if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE)
+			if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE || tileset->tile_get_tile_mode(get_current_tile()) == TileSet::ATLAS_TILE)
 				tileset->tile_add_shape(get_current_tile(), shape, Transform2D(), false, edited_shape_coord);
 			else
-				tileset->tile_set_shape(get_current_tile(), 0, shape);
+				tileset->tile_add_shape(get_current_tile(), shape, Transform2D());
 
 			edited_collision_shape = shape;
 		}
@@ -1582,7 +1889,7 @@ void TileSetEditor::close_shape(const Vector2 &shape_anchor) {
 		w = PoolVector<Vector2>::Write();
 		shape->set_polygon(polygon);
 
-		if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE)
+		if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE || tileset->tile_get_tile_mode(get_current_tile()) == TileSet::ATLAS_TILE)
 			tileset->autotile_set_light_occluder(get_current_tile(), shape, edited_shape_coord);
 		else
 			tileset->tile_set_light_occluder(get_current_tile(), shape);
@@ -1606,7 +1913,7 @@ void TileSetEditor::close_shape(const Vector2 &shape_anchor) {
 		shape->set_vertices(polygon);
 		shape->add_polygon(indices);
 
-		if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE)
+		if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE || tileset->tile_get_tile_mode(get_current_tile()) == TileSet::ATLAS_TILE)
 			tileset->autotile_set_navigation_polygon(get_current_tile(), shape, edited_shape_coord);
 		else
 			tileset->tile_set_navigation_polygon(get_current_tile(), shape);
@@ -1619,6 +1926,8 @@ void TileSetEditor::close_shape(const Vector2 &shape_anchor) {
 
 void TileSetEditor::select_coord(const Vector2 &coord) {
 	current_shape = PoolVector2Array();
+	Rect2 current_tile_region = tileset->tile_get_region(get_current_tile());
+	current_tile_region.position += WORKSPACE_MARGIN;
 	if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::SINGLE_TILE) {
 		if (edited_collision_shape != tileset->tile_get_shape(get_current_tile(), 0))
 			edited_collision_shape = tileset->tile_get_shape(get_current_tile(), 0);
@@ -1631,14 +1940,14 @@ void TileSetEditor::select_coord(const Vector2 &coord) {
 			current_shape.resize(0);
 			if (edited_collision_shape.is_valid()) {
 				for (int i = 0; i < edited_collision_shape->get_points().size(); i++) {
-					current_shape.push_back(edited_collision_shape->get_points()[i]);
+					current_shape.push_back(edited_collision_shape->get_points()[i] + current_tile_region.position);
 				}
 			}
 		} else if (edit_mode == EDITMODE_OCCLUSION) {
 			current_shape.resize(0);
 			if (edited_occlusion_shape.is_valid()) {
 				for (int i = 0; i < edited_occlusion_shape->get_polygon().size(); i++) {
-					current_shape.push_back(edited_occlusion_shape->get_polygon()[i]);
+					current_shape.push_back(edited_occlusion_shape->get_polygon()[i] + current_tile_region.position);
 				}
 			}
 		} else if (edit_mode == EDITMODE_NAVIGATION) {
@@ -1647,7 +1956,7 @@ void TileSetEditor::select_coord(const Vector2 &coord) {
 				if (edited_navigation_shape->get_polygon_count() > 0) {
 					PoolVector<Vector2> vertices = edited_navigation_shape->get_vertices();
 					for (int i = 0; i < edited_navigation_shape->get_polygon(0).size(); i++) {
-						current_shape.push_back(vertices[edited_navigation_shape->get_polygon(0)[i]]);
+						current_shape.push_back(vertices[edited_navigation_shape->get_polygon(0)[i]] + current_tile_region.position);
 					}
 				}
 			}
@@ -1658,6 +1967,7 @@ void TileSetEditor::select_coord(const Vector2 &coord) {
 		Vector2 shape_anchor = coord;
 		shape_anchor.x *= (size.x + spacing);
 		shape_anchor.y *= (size.y + spacing);
+		shape_anchor += current_tile_region.position;
 		if (edit_mode == EDITMODE_COLLISION) {
 			current_shape.resize(0);
 			if (edited_collision_shape.is_valid()) {
@@ -1684,6 +1994,9 @@ void TileSetEditor::select_coord(const Vector2 &coord) {
 			}
 		}
 	}
+	workspace->update();
+	workspace_container->update();
+	helper->_change_notify("");
 }
 
 Vector2 TileSetEditor::snap_point(const Vector2 &point) {
@@ -1694,11 +2007,13 @@ Vector2 TileSetEditor::snap_point(const Vector2 &point) {
 	Vector2 anchor = coord;
 	anchor.x *= (tile_size.x + spacing);
 	anchor.y *= (tile_size.y + spacing);
+	anchor += tileset->tile_get_region(get_current_tile()).position;
+	anchor += WORKSPACE_MARGIN;
 	Rect2 region(anchor, tile_size);
 	if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::SINGLE_TILE)
-		region.position = Point2(0, 0);
+		region.position = tileset->tile_get_region(get_current_tile()).position + WORKSPACE_MARGIN;
 
-	if (tools[SHAPE_GRID_SNAP]->is_pressed()) {
+	if (tools[TOOL_GRID_SNAP]->is_pressed()) {
 		p.x = Math::snap_scalar_seperation(snap_offset.x, snap_step.x, p.x, snap_separation.x);
 		p.y = Math::snap_scalar_seperation(snap_offset.y, snap_step.y, p.y, snap_separation.y);
 	}
@@ -1715,211 +2030,332 @@ Vector2 TileSetEditor::snap_point(const Vector2 &point) {
 	return p;
 }
 
-void TileSetEditor::update_tile_list() {
-	int selected_tile = get_current_tile();
-
-	if (selected_tile < 0)
-		selected_tile = 0;
+void TileSetEditor::update_texture_list() {
+	Ref<Texture> selected_texture = get_current_texture();
 
 	helper->set_tileset(tileset);
 
-	tile_list->clear();
 	List<int> ids;
 	tileset->get_tile_list(&ids);
 	for (List<int>::Element *E = ids.front(); E; E = E->next()) {
-		tile_list->add_item(tileset->tile_get_name(E->get()));
-		tile_list->set_item_metadata(tile_list->get_item_count() - 1, E->get());
-		tile_list->set_item_icon(tile_list->get_item_count() - 1, tileset->tile_get_texture(E->get()));
-		Rect2 region = tileset->tile_get_region(E->get());
-		if (tileset->tile_get_tile_mode(E->get()) == TileSet::AUTO_TILE) {
-			region.size = tileset->autotile_get_size(E->get());
-			Vector2 pos = tileset->autotile_get_icon_coordinate(E->get());
-			pos.x *= (tileset->autotile_get_spacing(E->get()) + region.size.x);
-			pos.y *= (tileset->autotile_get_spacing(E->get()) + region.size.y);
-			region.position += pos;
+		if (!texture_map.has(tileset->tile_get_texture(E->get())->get_rid())) {
+			texture_list->add_item(tileset->tile_get_texture(E->get())->get_path().get_file());
+			texture_map.insert(tileset->tile_get_texture(E->get())->get_rid(), tileset->tile_get_texture(E->get()));
+			texture_list->set_item_metadata(texture_list->get_item_count() - 1, tileset->tile_get_texture(E->get())->get_rid());
 		}
-		tile_list->set_item_icon_region(tile_list->get_item_count() - 1, region);
-		tile_list->set_item_icon_modulate(tile_list->get_item_count() - 1, tileset->tile_get_modulate(E->get()));
 	}
-	if (tile_list->get_item_count() > 0 && selected_tile < tile_list->get_item_count()) {
-		tile_list->select(selected_tile);
-		_on_tile_list_selected(selected_tile);
+	if (texture_list->get_item_count() > 0 && selected_texture.is_valid()) {
+		texture_list->select(texture_list->find_metadata(selected_texture->get_rid()));
+		if (texture_list->get_selected_items().size() > 0)
+			_on_texture_list_selected(texture_list->get_selected_items()[0]);
+	} else if (get_current_texture().is_valid()) {
+		_on_texture_list_selected(texture_list->find_metadata(get_current_texture()->get_rid()));
+	} else {
+		_on_texture_list_selected(-1);
 	}
+	update_texture_list_icon();
 	helper->_change_notify("");
 }
 
-void TileSetEditor::update_tile_list_icon() {
-	List<int> ids;
-	tileset->get_tile_list(&ids);
-	int current_idx = 0;
-	for (List<int>::Element *E = ids.front(); E; E = E->next()) {
-		if (current_idx >= tile_list->get_item_count())
-			break;
+void TileSetEditor::update_texture_list_icon() {
 
-		Rect2 region = tileset->tile_get_region(E->get());
-		if (tileset->tile_get_tile_mode(E->get()) == TileSet::AUTO_TILE) {
-			region.size = tileset->autotile_get_size(E->get());
-			Vector2 pos = tileset->autotile_get_icon_coordinate(E->get());
-			pos.x *= (tileset->autotile_get_spacing(E->get()) + region.size.x);
-			pos.y *= (tileset->autotile_get_spacing(E->get()) + region.size.y);
-			region.position += pos;
-		}
-		tile_list->set_item_metadata(current_idx, E->get());
-		tile_list->set_item_icon(current_idx, tileset->tile_get_texture(E->get()));
-		tile_list->set_item_icon_region(current_idx, region);
-		tile_list->set_item_icon_modulate(current_idx, tileset->tile_get_modulate(E->get()));
-		tile_list->set_item_text(current_idx, tileset->tile_get_name(E->get()));
-		current_idx += 1;
+	for (int current_idx = 0; current_idx < texture_list->get_item_count(); current_idx++) {
+		RID rid = texture_list->get_item_metadata(current_idx);
+		texture_list->set_item_icon(current_idx, texture_map[rid]);
+		texture_list->set_item_icon_region(current_idx, Rect2(0, 0, 150, 100));
 	}
-	tile_list->update();
+	texture_list->update();
 }
 
 void TileSetEditor::update_workspace_tile_mode() {
-	if (get_current_tile() < 0)
+
+	if (workspace_mode != WORKSPACE_EDIT) {
+		for (int i = 0; i < EDITMODE_MAX; i++) {
+			tool_editmode[i]->hide();
+		}
+		tool_editmode[EDITMODE_REGION]->show();
+		tool_editmode[EDITMODE_REGION]->set_pressed(true);
+		_on_edit_mode_changed(EDITMODE_REGION);
 		return;
+	}
+
+	if (get_current_tile() < 0) {
+		for (int i = 0; i < EDITMODE_MAX; i++) {
+			tool_editmode[i]->hide();
+		}
+		for (int i = 0; i < ZOOM_OUT; i++) {
+			tools[i]->hide();
+		}
+		return;
+	}
+
+	for (int i = 0; i < EDITMODE_MAX; i++) {
+		tool_editmode[i]->show();
+	}
+
 	if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::SINGLE_TILE) {
 		if (tool_editmode[EDITMODE_ICON]->is_pressed() || tool_editmode[EDITMODE_PRIORITY]->is_pressed() || tool_editmode[EDITMODE_BITMASK]->is_pressed()) {
 			tool_editmode[EDITMODE_COLLISION]->set_pressed(true);
-			_on_edit_mode_changed(EDITMODE_COLLISION);
-		} else {
-			select_coord(Vector2(0, 0));
+			edit_mode = EDITMODE_COLLISION;
 		}
+		select_coord(Vector2(0, 0));
 
 		tool_editmode[EDITMODE_ICON]->hide();
 		tool_editmode[EDITMODE_BITMASK]->hide();
 		tool_editmode[EDITMODE_PRIORITY]->hide();
-		property_editor->hide();
+	} else if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE || tileset->tile_get_tile_mode(get_current_tile()) == TileSet::ATLAS_TILE) {
+		if (edit_mode == EDITMODE_ICON)
+			select_coord(tileset->autotile_get_icon_coordinate(get_current_tile()));
+		else
+			select_coord(edited_shape_coord);
+	} else if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::ATLAS_TILE) {
+		if (tool_editmode[EDITMODE_PRIORITY]->is_pressed() || tool_editmode[EDITMODE_BITMASK]->is_pressed()) {
+			tool_editmode[EDITMODE_COLLISION]->set_pressed(true);
+			edit_mode = EDITMODE_COLLISION;
+		}
+		if (edit_mode == EDITMODE_ICON)
+			select_coord(tileset->autotile_get_icon_coordinate(get_current_tile()));
+		else
+			select_coord(edited_shape_coord);
+
+		tool_editmode[EDITMODE_BITMASK]->hide();
+		tool_editmode[EDITMODE_PRIORITY]->hide();
+	}
+	_on_edit_mode_changed(edit_mode);
+}
+
+void TileSetEditor::update_edited_region(const Vector2 &end_point) {
+	edited_region = Rect2(region_from, Size2());
+	if (tools[TOOL_GRID_SNAP]->is_pressed()) {
+		Vector2 grid_coord;
+		grid_coord.x = Math::floor((region_from.x - snap_offset.x) / (snap_step.x + snap_separation.x));
+		grid_coord.y = Math::floor((region_from.y - snap_offset.y) / (snap_step.y + snap_separation.y));
+		grid_coord.x *= (snap_step.x + snap_separation.x);
+		grid_coord.y *= (snap_step.y + snap_separation.y);
+		grid_coord += snap_offset;
+		edited_region.expand_to(grid_coord);
+		grid_coord += snap_step;
+		edited_region.expand_to(grid_coord);
+		grid_coord.x = Math::floor((end_point.x - snap_offset.x) / (snap_step.x + snap_separation.x));
+		grid_coord.y = Math::floor((end_point.y - snap_offset.y) / (snap_step.y + snap_separation.y));
+		grid_coord.x *= (snap_step.x + snap_separation.x);
+		grid_coord.y *= (snap_step.y + snap_separation.y);
+		grid_coord += snap_offset;
+		edited_region.expand_to(grid_coord);
+		grid_coord += snap_step;
+		if (grid_coord.x < end_point.x)
+			grid_coord.x += snap_separation.x;
+		if (grid_coord.y < end_point.y)
+			grid_coord.y += snap_separation.y;
+		edited_region.expand_to(grid_coord);
 	} else {
-		tool_editmode[EDITMODE_ICON]->show();
-		tool_editmode[EDITMODE_BITMASK]->show();
-		tool_editmode[EDITMODE_PRIORITY]->show();
-		property_editor->show();
+		edited_region.expand_to(end_point);
 	}
 }
 
-int TileSetEditor::get_current_tile() {
-	if (tile_list->get_selected_items().size() == 0)
-		return -1;
-	else
-		return tile_list->get_item_metadata(tile_list->get_selected_items()[0]);
+int TileSetEditor::get_current_tile() const {
+	return current_tile;
 }
 
-void TileSetEditorHelper::set_tileset(const Ref<TileSet> &p_tileset) {
+void TileSetEditor::set_current_tile(int p_id) {
+	if (current_tile != p_id) {
+		current_tile = p_id;
+		helper->_change_notify("");
+		select_coord(Vector2(0, 0));
+		update_workspace_tile_mode();
+	}
+}
+
+Ref<Texture> TileSetEditor::get_current_texture() {
+	if (texture_list->get_selected_items().size() == 0)
+		return Ref<Texture>();
+	else
+		return texture_map[texture_list->get_item_metadata(texture_list->get_selected_items()[0])];
+}
+
+void TilesetEditorContext::set_tileset(const Ref<TileSet> &p_tileset) {
 
 	tileset = p_tileset;
 }
 
-bool TileSetEditorHelper::_set(const StringName &p_name, const Variant &p_value) {
+void TilesetEditorContext::set_snap_options_visible(bool p_visible) {
+	snap_options_visible = p_visible;
+	_change_notify("");
+}
 
-	if (selected_tile < 0 || tileset.is_null())
-		return false;
+bool TilesetEditorContext::_set(const StringName &p_name, const Variant &p_value) {
+
+	String name = p_name.operator String();
+
+	if (name == "options_offset") {
+		Vector2 snap = p_value;
+		tileset_editor->_set_snap_off(snap + WORKSPACE_MARGIN);
+		return true;
+	} else if (name == "options_step") {
+		Vector2 snap = p_value;
+		tileset_editor->_set_snap_step(snap);
+		return true;
+	} else if (name == "options_separation") {
+		Vector2 snap = p_value;
+		tileset_editor->_set_snap_sep(snap);
+		return true;
+	} else if (p_name.operator String().left(5) == "tile_") {
+		String name = p_name.operator String().right(5);
+		bool v = false;
+
+		if (tileset_editor->get_current_tile() < 0 || tileset.is_null())
+			return false;
+
+		if (name == "autotile_bitmask_mode") {
+			tileset->set(String::num(tileset_editor->get_current_tile(), 0) + "/autotile/bitmask_mode", p_value, &v);
+		} else if (name == "subtile_size") {
+			tileset->set(String::num(tileset_editor->get_current_tile(), 0) + "/autotile/tile_size", p_value, &v);
+		} else if (name == "subtile_spacing") {
+			tileset->set(String::num(tileset_editor->get_current_tile(), 0) + "/autotile/spacing", p_value, &v);
+		} else {
+			tileset->set(String::num(tileset_editor->get_current_tile(), 0) + "/" + name, p_value, &v);
+		}
+		if (v) {
+			tileset->_change_notify("");
+			tileset_editor->workspace->update();
+			tileset_editor->workspace_overlay->update();
+		}
+		return v;
+	}
+
+	tileset_editor->err_dialog->set_text(TTR("This property can't be changed."));
+	tileset_editor->err_dialog->popup_centered(Size2(300, 60));
+	return false;
+}
+
+bool TilesetEditorContext::_get(const StringName &p_name, Variant &r_ret) const {
 
 	String name = p_name.operator String();
 	bool v = false;
-	if (name == "bitmask_mode") {
-		tileset->set(String::num(selected_tile, 0) + "/autotile/bitmask_mode", p_value, &v);
-	} else if (name.left(7) == "layout/") {
-		tileset->set(String::num(selected_tile, 0) + "/autotile" + name.right(6), p_value, &v);
-	}
-	if (v) {
-		tileset->_change_notify("autotile");
+
+	if (name == "options_offset") {
+		r_ret = tileset_editor->snap_offset - WORKSPACE_MARGIN;
+		v = true;
+	} else if (name == "options_step") {
+		r_ret = tileset_editor->snap_step;
+		v = true;
+	} else if (name == "options_separation") {
+		r_ret = tileset_editor->snap_separation;
+		v = true;
+	} else if (name.left(5) == "tile_") {
+		name = name.right(5);
+
+		if (tileset_editor->get_current_tile() < 0 || tileset.is_null())
+			return false;
+		if (!tileset->has_tile(tileset_editor->get_current_tile()))
+			return false;
+
+		if (name == "autotile_bitmask_mode") {
+			r_ret = tileset->get(String::num(tileset_editor->get_current_tile(), 0) + "/autotile/bitmask_mode", &v);
+		} else if (name == "subtile_size") {
+			r_ret = tileset->get(String::num(tileset_editor->get_current_tile(), 0) + "/autotile/tile_size", &v);
+		} else if (name == "subtile_spacing") {
+			r_ret = tileset->get(String::num(tileset_editor->get_current_tile(), 0) + "/autotile/spacing", &v);
+		} else {
+			r_ret = tileset->get(String::num(tileset_editor->get_current_tile(), 0) + "/" + name, &v);
+		}
+		return v;
+	} else if (name == "selected_collision") {
+		r_ret = tileset_editor->edited_collision_shape;
+		v = true;
+	} else if (name == "selected_navigation") {
+		r_ret = tileset_editor->edited_navigation_shape;
+		v = true;
+	} else if (name == "selected_occlusion") {
+		r_ret = tileset_editor->edited_occlusion_shape;
+		v = true;
 	}
 	return v;
 }
 
-bool TileSetEditorHelper::_get(const StringName &p_name, Variant &r_ret) const {
+void TilesetEditorContext::_get_property_list(List<PropertyInfo> *p_list) const {
 
-	if (selected_tile < 0 || tileset.is_null())
-		return false;
-	if (!tileset->has_tile(selected_tile))
-		return false;
-
-	String name = p_name.operator String();
-	bool v = false;
-	if (name == "bitmask_mode") {
-		r_ret = tileset->get(String::num(selected_tile, 0) + "/autotile/bitmask_mode", &v);
-	} else if (name.left(7) == "layout/") {
-		r_ret = tileset->get(String::num(selected_tile, 0) + "/autotile" + name.right(6), &v);
+	if (snap_options_visible) {
+		p_list->push_back(PropertyInfo(Variant::NIL, "Snap Options", PROPERTY_HINT_NONE, "options_", PROPERTY_USAGE_GROUP));
+		p_list->push_back(PropertyInfo(Variant::VECTOR2, "options_offset"));
+		p_list->push_back(PropertyInfo(Variant::VECTOR2, "options_step"));
+		p_list->push_back(PropertyInfo(Variant::VECTOR2, "options_separation"));
 	}
-	return v;
+	if (tileset_editor->get_current_tile() >= 0 && !tileset.is_null()) {
+		int id = tileset_editor->get_current_tile();
+		p_list->push_back(PropertyInfo(Variant::NIL, "Selected Tile", PROPERTY_HINT_NONE, "tile_", PROPERTY_USAGE_GROUP));
+		p_list->push_back(PropertyInfo(Variant::STRING, "tile_name"));
+		p_list->push_back(PropertyInfo(Variant::OBJECT, "tile_normal_map", PROPERTY_HINT_RESOURCE_TYPE, "Texture"));
+		p_list->push_back(PropertyInfo(Variant::VECTOR2, "tile_tex_offset"));
+		p_list->push_back(PropertyInfo(Variant::OBJECT, "tile_material", PROPERTY_HINT_RESOURCE_TYPE, "ShaderMaterial"));
+		p_list->push_back(PropertyInfo(Variant::COLOR, "tile_modulate"));
+		p_list->push_back(PropertyInfo(Variant::INT, "tile_tile_mode", PROPERTY_HINT_ENUM, "SINGLE_TILE,AUTO_TILE,ATLAS_TILE"));
+		if (tileset->tile_get_tile_mode(id) == TileSet::AUTO_TILE) {
+			p_list->push_back(PropertyInfo(Variant::INT, "tile_autotile_bitmask_mode", PROPERTY_HINT_ENUM, "2X2,3X3 (minimal),3X3"));
+			p_list->push_back(PropertyInfo(Variant::VECTOR2, "tile_subtile_size"));
+			p_list->push_back(PropertyInfo(Variant::INT, "tile_subtile_spacing", PROPERTY_HINT_RANGE, "0, 256, 1"));
+		} else if (tileset->tile_get_tile_mode(id) == TileSet::ATLAS_TILE) {
+			p_list->push_back(PropertyInfo(Variant::VECTOR2, "tile_subtile_size"));
+			p_list->push_back(PropertyInfo(Variant::INT, "tile_subtile_spacing", PROPERTY_HINT_RANGE, "0, 256, 1"));
+		}
+		p_list->push_back(PropertyInfo(Variant::VECTOR2, "tile_occluder_offset"));
+		p_list->push_back(PropertyInfo(Variant::VECTOR2, "tile_navigation_offset"));
+		p_list->push_back(PropertyInfo(Variant::VECTOR2, "tile_shape_offset", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
+		p_list->push_back(PropertyInfo(Variant::VECTOR2, "tile_shape_transform", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
+		p_list->push_back(PropertyInfo(Variant::INT, "tile_z_index", PROPERTY_HINT_RANGE, itos(VS::CANVAS_ITEM_Z_MIN) + "," + itos(VS::CANVAS_ITEM_Z_MAX) + ",1"));
+	}
+	if (tileset_editor->edit_mode == TileSetEditor::EDITMODE_COLLISION && tileset_editor->edited_collision_shape.is_valid()) {
+		p_list->push_back(PropertyInfo(Variant::OBJECT, "selected_collision", PROPERTY_HINT_RESOURCE_TYPE, tileset_editor->edited_collision_shape->get_class()));
+	}
+	if (tileset_editor->edit_mode == TileSetEditor::EDITMODE_NAVIGATION && tileset_editor->edited_navigation_shape.is_valid()) {
+		p_list->push_back(PropertyInfo(Variant::OBJECT, "selected_navigation", PROPERTY_HINT_RESOURCE_TYPE, tileset_editor->edited_navigation_shape->get_class()));
+	}
+	if (tileset_editor->edit_mode == TileSetEditor::EDITMODE_OCCLUSION && tileset_editor->edited_occlusion_shape.is_valid()) {
+		p_list->push_back(PropertyInfo(Variant::OBJECT, "selected_occlusion", PROPERTY_HINT_RESOURCE_TYPE, tileset_editor->edited_occlusion_shape->get_class()));
+	}
 }
 
-void TileSetEditorHelper::_get_property_list(List<PropertyInfo> *p_list) const {
-
-	if (selected_tile < 0 || tileset.is_null())
-		return;
-
-	p_list->push_back(PropertyInfo(Variant::INT, "bitmask_mode", PROPERTY_HINT_ENUM, "2x2,3x3 (minimal),3x3"));
-	p_list->push_back(PropertyInfo(Variant::VECTOR2, "layout/tile_size"));
-	p_list->push_back(PropertyInfo(Variant::INT, "layout/spacing", PROPERTY_HINT_RANGE, "0,256,1"));
-}
-
-TileSetEditorHelper::TileSetEditorHelper(TileSetEditor *p_tileset_editor) {
-
+TilesetEditorContext::TilesetEditorContext(TileSetEditor *p_tileset_editor) {
 	tileset_editor = p_tileset_editor;
-	selected_tile = -1;
 }
 
 void TileSetEditorPlugin::edit(Object *p_node) {
 
 	if (Object::cast_to<TileSet>(p_node)) {
 		tileset_editor->edit(Object::cast_to<TileSet>(p_node));
-		tileset_editor->show();
-		tileset_editor->texture_region_editor->edit(p_node);
-	} else
-		tileset_editor->hide();
+		editor->get_inspector()->edit(tileset_editor->helper);
+	}
 }
 
 bool TileSetEditorPlugin::handles(Object *p_node) const {
 
-	return p_node->is_class("TileSet");
+	return p_node->is_class("TileSet") ||
+		   p_node->is_class("TilesetEditorContext");
 }
 
 void TileSetEditorPlugin::make_visible(bool p_visible) {
-
 	if (p_visible) {
-		tileset_editor->show();
-		tileset_editor->menu->show();
 		tileset_editor_button->show();
-		tileset_editor->side_panel->show();
 		if (tileset_editor_button->is_pressed()) {
-			tileset_editor->bottom_panel->show();
+			tileset_editor->show();
 		}
-		texture_region_button->show();
-		if (texture_region_button->is_pressed())
-			tileset_editor->texture_region_editor->show();
+		get_tree()->connect("idle_frame", tileset_editor, "_on_workspace_process");
 	} else {
 		tileset_editor->hide();
-		tileset_editor->menu->hide();
-		tileset_editor->side_panel->hide();
-		tileset_editor->bottom_panel->hide();
 		tileset_editor_button->hide();
-		texture_region_button->hide();
-		tileset_editor->texture_region_editor->hide();
+		get_tree()->disconnect("idle_frame", tileset_editor, "_on_workspace_process");
 	}
 }
 
 TileSetEditorPlugin::TileSetEditorPlugin(EditorNode *p_node) {
-
+	editor = p_node;
 	tileset_editor = memnew(TileSetEditor(p_node));
 
-	add_control_to_container(CONTAINER_CANVAS_EDITOR_MENU, tileset_editor);
-	tileset_editor->set_anchors_and_margins_preset(Control::PRESET_TOP_WIDE);
-	tileset_editor->set_end(Point2(0, 22));
+	tileset_editor_button =
+			p_node->add_bottom_panel_item(TTR("Tile Set"), tileset_editor);
+	tileset_editor_button->set_tooltip(TTR("Tile Set Editor"));
+
+	tileset_editor->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
 	tileset_editor->hide();
-
-	tileset_editor->texture_region_editor = memnew(TextureRegionEditor(p_node));
-	texture_region_button = p_node->add_bottom_panel_item(TTR("Texture Region"), tileset_editor->texture_region_editor);
-	texture_region_button->set_tooltip(TTR("Texture Region Editor"));
-
-	tileset_editor->texture_region_editor->set_custom_minimum_size(Size2(0, 200));
-	tileset_editor->texture_region_editor->hide();
-	texture_region_button->hide();
-
-	add_control_to_container(CONTAINER_CANVAS_EDITOR_SIDE, tileset_editor->side_panel);
-	tileset_editor->side_panel->set_anchors_and_margins_preset(Control::PRESET_WIDE);
-	tileset_editor->side_panel->set_custom_minimum_size(Size2(200, 0));
-	tileset_editor->side_panel->hide();
-	tileset_editor_button = p_node->add_bottom_panel_item(TTR("Tile Set"), tileset_editor->bottom_panel);
 	tileset_editor_button->hide();
 }

--- a/editor/plugins/tile_set_editor_plugin.h
+++ b/editor/plugins/tile_set_editor_plugin.h
@@ -33,21 +33,38 @@
 
 #include "editor/editor_name_dialog.h"
 #include "editor/editor_node.h"
-#include "editor/plugins/texture_region_editor_plugin.h"
 #include "scene/2d/sprite.h"
 #include "scene/resources/convex_polygon_shape_2d.h"
 #include "scene/resources/tile_set.h"
 
-class TileSetEditorHelper;
+#define WORKSPACE_MARGIN Vector2(10, 10)
+class TilesetEditorContext;
 
-class TileSetEditor : public Control {
+class TileSetEditor : public Panel {
 
 	friend class TileSetEditorPlugin;
-	friend class TextureRegionEditor;
+	friend class TilesetEditorContext;
 
-	GDCLASS(TileSetEditor, Control);
+	GDCLASS(TileSetEditor, Panel)
+
+	enum TextureToolButtons {
+		TOOL_TILESET_ADD_TEXTURE,
+		TOOL_TILESET_REMOVE_TEXTURE,
+		TOOL_TILESET_CREATE_SCENE,
+		TOOL_TILESET_MERGE_SCENE,
+		TOOL_TILESET_MAX
+	};
+
+	enum WorkspaceMode {
+		WORKSPACE_EDIT,
+		WORKSPACE_CREATE_SINGLE,
+		WORKSPACE_CREATE_AUTOTILE,
+		WORKSPACE_CREATE_ATLAS,
+		WORKSPACE_MODE_MAX
+	};
 
 	enum EditMode {
+		EDITMODE_REGION,
 		EDITMODE_COLLISION,
 		EDITMODE_OCCLUSION,
 		EDITMODE_NAVIGATION,
@@ -57,13 +74,6 @@ class TileSetEditor : public Control {
 		EDITMODE_MAX
 	};
 
-	enum TileSetToolbar {
-		TOOLBAR_DUMMY,
-		TOOLBAR_BITMASK,
-		TOOLBAR_SHAPE,
-		TOOLBAR_MAX
-	};
-
 	enum TileSetTools {
 		TOOL_SELECT,
 		BITMASK_COPY,
@@ -71,17 +81,42 @@ class TileSetEditor : public Control {
 		BITMASK_CLEAR,
 		SHAPE_NEW_POLYGON,
 		SHAPE_DELETE,
-		SHAPE_CREATE_FROM_BITMASK,
-		SHAPE_CREATE_FROM_NOT_BITMASK,
 		SHAPE_KEEP_INSIDE_TILE,
-		SHAPE_GRID_SNAP,
+		TOOL_GRID_SNAP,
 		ZOOM_OUT,
 		ZOOM_1,
 		ZOOM_IN,
+		VISIBLE_INFO,
 		TOOL_MAX
 	};
 
 	Ref<TileSet> tileset;
+	TilesetEditorContext *helper;
+	EditorNode *editor;
+
+	ConfirmationDialog *cd;
+	AcceptDialog *err_dialog;
+	EditorFileDialog *texture_dialog;
+
+	ItemList *texture_list;
+	int option;
+	ToolButton *tileset_toolbar_buttons[TOOL_TILESET_MAX];
+	MenuButton *tileset_toolbar_tools;
+	Map<RID, Ref<Texture> > texture_map;
+
+	bool creating_shape;
+	int dragging_point;
+	float tile_names_opacity;
+	Vector2 region_from;
+	Rect2 edited_region;
+	bool draw_edited_region;
+	Vector2 edited_shape_coord;
+	PoolVector2Array current_shape;
+	Map<Vector2, uint16_t> bitmask_map_copy;
+
+	Vector2 snap_step;
+	Vector2 snap_offset;
+	Vector2 snap_separation;
 
 	Ref<ConvexPolygonShape2D> edited_collision_shape;
 	Ref<OccluderPolygon2D> edited_occlusion_shape;
@@ -94,55 +129,19 @@ class TileSetEditor : public Control {
 	bool draw_handles;
 	Control *workspace_overlay;
 	Control *workspace;
+	Button *tool_workspacemode[WORKSPACE_MODE_MAX];
 	Button *tool_editmode[EDITMODE_MAX];
-	HBoxContainer *tool_containers[TOOLBAR_MAX];
 	HBoxContainer *toolbar;
-	HBoxContainer *hb_grid;
 	ToolButton *tools[TOOL_MAX];
 	SpinBox *spin_priority;
-	SpinBox *sb_step_y;
-	SpinBox *sb_step_x;
-	SpinBox *sb_off_y;
-	SpinBox *sb_off_x;
-	SpinBox *sb_sep_y;
-	SpinBox *sb_sep_x;
+	WorkspaceMode workspace_mode;
 	EditMode edit_mode;
+	int current_tile;
 
-	Vector2 snap_step;
-	Vector2 snap_offset;
-	Vector2 snap_separation;
+	void update_texture_list();
+	void update_texture_list_icon();
 
-	bool creating_shape;
-	int dragging_point;
-	Vector2 edited_shape_coord;
-	PoolVector2Array current_shape;
-	Map<Vector2, uint16_t> bitmask_map_copy;
-
-	EditorNode *editor;
-	TextureRegionEditor *texture_region_editor;
-	Control *bottom_panel;
-	Control *side_panel;
-	ItemList *tile_list;
-	PropertyEditor *property_editor;
-	TileSetEditorHelper *helper;
-
-	MenuButton *menu;
-	ConfirmationDialog *cd;
-	EditorNameDialog *nd;
-	AcceptDialog *err_dialog;
-
-	enum {
-
-		MENU_OPTION_ADD_ITEM,
-		MENU_OPTION_REMOVE_ITEM,
-		MENU_OPTION_CREATE_FROM_SCENE,
-		MENU_OPTION_MERGE_FROM_SCENE
-	};
-
-	int option;
-	void _menu_cbk(int p_option);
-	void _menu_confirm();
-	void _name_dialog_confirm(const String &name);
+	Ref<Texture> get_current_texture();
 
 	static void _import_node(Node *p_node, Ref<TileSet> p_library);
 	static void _import_scene(Node *p_scene, Ref<TileSet> p_library, bool p_merge);
@@ -150,7 +149,6 @@ class TileSetEditor : public Control {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
-	virtual void _changed_callback(Object *p_changed, const char *p_prop);
 
 public:
 	void edit(const Ref<TileSet> &p_tileset);
@@ -160,53 +158,61 @@ public:
 	~TileSetEditor();
 
 private:
-	void _on_tile_list_selected(int p_index);
+	void _on_tileset_toolbar_button_pressed(int p_index);
+	void _on_tileset_toolbar_confirm();
+	void _on_texture_list_selected(int p_index);
+	void _on_textures_added(const PoolStringArray &p_paths);
 	void _on_edit_mode_changed(int p_edit_mode);
+	void _on_workspace_mode_changed(int p_workspace_mode);
 	void _on_workspace_overlay_draw();
 	void _on_workspace_draw();
+	void _on_workspace_process();
 	void _on_workspace_input(const Ref<InputEvent> &p_ie);
 	void _on_tool_clicked(int p_tool);
 	void _on_priority_changed(float val);
 	void _on_grid_snap_toggled(bool p_val);
-	void _set_snap_step_x(float p_val);
-	void _set_snap_step_y(float p_val);
-	void _set_snap_off_x(float p_val);
-	void _set_snap_off_y(float p_val);
-	void _set_snap_sep_x(float p_val);
-	void _set_snap_sep_y(float p_val);
+	void _set_snap_step(Vector2 p_val);
+	void _set_snap_off(Vector2 p_val);
+	void _set_snap_sep(Vector2 p_val);
 
-	void initialize_bottom_editor();
-	void draw_highlight_tile(Vector2 coord, const Vector<Vector2> &other_highlighted = Vector<Vector2>());
+	void draw_highlight_current_tile();
+	void draw_highlight_subtile(Vector2 coord, const Vector<Vector2> &other_highlighted = Vector<Vector2>());
+	void draw_tile_subdivision(int p_id, Color p_color) const;
+	void draw_edited_region_subdivision() const;
 	void draw_grid_snap();
 	void draw_polygon_shapes();
 	void close_shape(const Vector2 &shape_anchor);
 	void select_coord(const Vector2 &coord);
 	Vector2 snap_point(const Vector2 &point);
-	void update_tile_list();
-	void update_tile_list_icon();
 	void update_workspace_tile_mode();
+	void update_edited_region(const Vector2 &end_point);
 
-	int get_current_tile();
+	int get_current_tile() const;
+	void set_current_tile(int p_id);
 };
 
-class TileSetEditorHelper : public Object {
+class TilesetEditorContext : public Object {
 
 	friend class TileSetEditor;
-	GDCLASS(TileSetEditorHelper, Object);
+	GDCLASS(TilesetEditorContext, Object);
 
 	Ref<TileSet> tileset;
 	TileSetEditor *tileset_editor;
-	int selected_tile;
+	bool snap_options_visible;
 
 public:
 	void set_tileset(const Ref<TileSet> &p_tileset);
+
+private:
+	void set_snap_options_visible(bool p_visible);
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
-	TileSetEditorHelper(TileSetEditor *p_tileset_editor);
+public:
+	TilesetEditorContext(TileSetEditor *p_tileset_editor);
 };
 
 class TileSetEditorPlugin : public EditorPlugin {
@@ -214,10 +220,8 @@ class TileSetEditorPlugin : public EditorPlugin {
 	GDCLASS(TileSetEditorPlugin, EditorPlugin);
 
 	TileSetEditor *tileset_editor;
+	Button *tileset_editor_button;
 	EditorNode *editor;
-
-	ToolButton *tileset_editor_button;
-	ToolButton *texture_region_button;
 
 public:
 	virtual String get_name() const { return "TileSet"; }

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -368,7 +368,7 @@ void TileMap::update_dirty_quadrants() {
 			}
 
 			Rect2 r = tile_set->tile_get_region(c.id);
-			if (tile_set->tile_get_tile_mode(c.id) == TileSet::AUTO_TILE) {
+			if (tile_set->tile_get_tile_mode(c.id) == TileSet::AUTO_TILE || tile_set->tile_get_tile_mode(c.id) == TileSet::ATLAS_TILE) {
 				int spacing = tile_set->autotile_get_spacing(c.id);
 				r.size = tile_set->autotile_get_size(c.id);
 				r.position += (r.size + Vector2(spacing, spacing)) * Vector2(c.autotile_coord_x, c.autotile_coord_y);
@@ -491,7 +491,7 @@ void TileMap::update_dirty_quadrants() {
 			if (navigation) {
 				Ref<NavigationPolygon> navpoly;
 				Vector2 npoly_ofs;
-				if (tile_set->tile_get_tile_mode(c.id) == TileSet::AUTO_TILE) {
+				if (tile_set->tile_get_tile_mode(c.id) == TileSet::AUTO_TILE || tile_set->tile_get_tile_mode(c.id) == TileSet::ATLAS_TILE) {
 					navpoly = tile_set->autotile_get_navigation_polygon(c.id, Vector2(c.autotile_coord_x, c.autotile_coord_y));
 					npoly_ofs = Vector2();
 				} else {
@@ -563,7 +563,7 @@ void TileMap::update_dirty_quadrants() {
 			}
 
 			Ref<OccluderPolygon2D> occluder;
-			if (tile_set->tile_get_tile_mode(c.id) == TileSet::AUTO_TILE) {
+			if (tile_set->tile_get_tile_mode(c.id) == TileSet::AUTO_TILE || tile_set->tile_get_tile_mode(c.id) == TileSet::ATLAS_TILE) {
 				occluder = tile_set->autotile_get_light_occluder(c.id, Vector2(c.autotile_coord_x, c.autotile_coord_y));
 			} else {
 				occluder = tile_set->tile_get_light_occluder(c.id);
@@ -840,7 +840,7 @@ void TileMap::update_cell_bitmask(int p_x, int p_y) {
 	Map<PosKey, Cell>::Element *E = tile_map.find(p);
 	if (E != NULL) {
 		int id = get_cell(p_x, p_y);
-		if (tile_set->tile_get_tile_mode(id) == TileSet::AUTO_TILE) {
+		if (tile_set->tile_get_tile_mode(id) == TileSet::AUTO_TILE || tile_set->tile_get_tile_mode(id) == TileSet::ATLAS_TILE) {
 			uint16_t mask = 0;
 			if (tile_set->autotile_get_bitmask_mode(id) == TileSet::BITMASK_2X2) {
 				if (tile_set->is_tile_bound(id, get_cell(p_x - 1, p_y - 1)) && tile_set->is_tile_bound(id, get_cell(p_x, p_y - 1)) && tile_set->is_tile_bound(id, get_cell(p_x - 1, p_y))) {

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -75,7 +75,7 @@ public:
 	enum TileMode {
 		SINGLE_TILE,
 		AUTO_TILE,
-		ANIMATED_TILE
+		ATLAS_TILE
 	};
 
 	struct AutotileData {


### PR DESCRIPTION
This new editor allows to select a texture and add tiles from it selecting a regiond and then configure it's collision, oclusion, navigation, and bitmask in the case of autotiling.
Also adds the ATLAS_TILE mode, wich is configured the same way as the AUTO_TILE, but it doesn't have a bitmask, instead a subpalette popups to pick wich tile to draw on the tilemap