### PR TITLE
Fixes bugs on the 2D editor scrollable area

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -390,7 +390,7 @@ class CanvasItemEditor : public VBoxContainer {
 
 	List<CanvasItem *> _get_edited_canvas_items(bool retreive_locked = false, bool remove_canvas_item_if_parent_in_selection = true);
 	Rect2 _get_encompassing_rect_from_list(List<CanvasItem *> p_list);
-	void _expand_encompassing_rect_using_children(Rect2 &p_rect, const Node *p_node, bool &r_first, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D());
+	void _expand_encompassing_rect_using_children(Rect2 &p_rect, const Node *p_node, bool &r_first, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D(), bool include_locked_nodes = true);
 	Rect2 _get_encompassing_rect(const Node *p_node);
 
 	Object *_get_editor_data(Object *p_what);

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -631,11 +631,7 @@ void TileMap::_recompute_rect_cache() {
 			r_total = r_total.merge(r);
 	}
 
-	if (r_total == Rect2()) {
-		rect_cache = Rect2(-10, -10, 20, 20);
-	} else {
-		rect_cache = r_total.grow(MAX(cell_size.x, cell_size.y) * _get_quadrant_size());
-	}
+	rect_cache = r_total;
 
 	item_rect_changed();
 
@@ -1150,6 +1146,11 @@ PoolVector<int> TileMap::_get_tile_data() const {
 	w = PoolVector<int>::Write();
 
 	return data;
+}
+
+Rect2 TileMap::_edit_get_rect() const {
+	const_cast<TileMap *>(this)->update_dirty_quadrants();
+	return rect_cache;
 }
 
 void TileMap::set_collision_layer(uint32_t p_layer) {

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -223,6 +223,8 @@ public:
 		INVALID_CELL = -1
 	};
 
+	virtual Rect2 _edit_get_rect() const;
+
 	void set_tileset(const Ref<TileSet> &p_tileset);
 	Ref<TileSet> get_tileset() const;
 


### PR DESCRIPTION
Uses _edit_get_rect in all situation, even for nodes not using the "rect gizmo".
It is then used as a node "visible area" by the editor.

According to my tests, this closes #18202, closes #18738 and closes #5736.