### PR TITLE
Mono: Added generic methods for ResourceLoader.Load

### DIFF
--- a/modules/mono/glue/cs_files/GD.cs
+++ b/modules/mono/glue/cs_files/GD.cs
@@ -64,6 +64,11 @@ namespace Godot
             return ResourceLoader.Load(path);
         }
 
+        public static T Load<T>(string path) where T : Godot.Resource
+        {
+            return (T) ResourceLoader.Load(path);
+        }
+
         public static void Print(params object[] what)
         {
             NativeCalls.godot_icall_Godot_print(what);

--- a/modules/mono/glue/cs_files/ResourceLoaderExtensions.cs
+++ b/modules/mono/glue/cs_files/ResourceLoaderExtensions.cs
@@ -1,0 +1,10 @@
+namespace Godot
+{
+    public static partial class ResourceLoader
+    {
+        public static T Load<T>(string path) where T : Godot.Resource
+        {
+            return (T) Load(path);
+        }
+    }
+}


### PR DESCRIPTION
Added a few QoL generic methods to PackedScene and ResourceLoader (as well as the GD.Load alias). Now you can do the following:

```
var pc = ResourceLoader.Load<PackedScene>("path/to/resource");
//var pc = GD.Load<PackedScene>("path/to/resource");
var pcInstance = pc.Instance<CustomNodeType>();
```

These are used a lot and it's much cleaner with generics instead of type casting everything. Inline with GetNode\<T>() and those other methods.