### PR TITLE
Fixed renaming/reparenting/duplicating a node disabling editable_children

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -244,7 +244,7 @@ void Node::_propagate_enter_tree() {
 
 void Node::_propagate_exit_tree() {
 
-//block while removing children
+	//block while removing children
 
 #ifdef DEBUG_ENABLED
 
@@ -1815,10 +1815,14 @@ void Node::set_editable_instance(Node *p_node, bool p_editable) {
 
 		if (p_node->is_connected("path_changed", this, "reconnect_editable_instance"))
 			p_node->disconnect("path_changed", this, "reconnect_editable_instance");
+		if (p_node->is_connected("tree_entered", this, "reconnect_editable_instance"))
+			p_node->disconnect("tree_entered", this, "reconnect_editable_instance");
 	} else {
 		data.editable_instances[p] = true;
 		if (!p_node->is_connected("path_changed", this, "reconnect_editable_instance"))
 			p_node->connect("path_changed", this, "reconnect_editable_instance", varray(p_node, p));
+		if (!p_node->is_connected("tree_entered", this, "reconnect_editable_instance"))
+			p_node->connect("tree_entered", this, "reconnect_editable_instance", varray(p_node, p));
 	}
 }
 
@@ -2764,6 +2768,7 @@ void Node::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("ready"));
 	ADD_SIGNAL(MethodInfo("renamed"));
+	ADD_SIGNAL(MethodInfo("duplicated"));
 	ADD_SIGNAL(MethodInfo("path_changed"));
 	ADD_SIGNAL(MethodInfo("tree_entered"));
 	ADD_SIGNAL(MethodInfo("tree_exiting"));

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1826,6 +1826,12 @@ void Node::set_editable_instance(Node *p_node, bool p_editable) {
 	}
 }
 
+void Node::make_editable() {
+	ERR_FAIL_NULL(get_owner());
+
+	get_owner()->set_editable_instance(this, true);
+}
+
 void Node::remove_editable_instance_by_path(NodePath path) {
 	data.editable_instances.erase(path);
 	// Avoid this flag being needlessly saved;
@@ -1839,7 +1845,7 @@ void Node::reconnect_editable_instance(Node *p_node, NodePath prev_path) {
 	set_editable_instance(p_node, true);
 }
 
-bool Node::is_editable_instance(Node *p_node) const {
+bool Node::is_editable_instance(const Node *p_node) const {
 
 	if (!p_node)
 		return false; //easier, null is never editable :)
@@ -2066,6 +2072,9 @@ Node *Node::_duplicate(int p_flags, Map<const Node *, Node *> *r_duplimap) const
 			parent->move_child(dup, pos);
 		}
 	}
+
+	if (get_owner() && get_owner()->is_editable_instance(this))
+		node->connect("tree_entered", node, "make_editable", varray(), CONNECT_ONESHOT | CONNECT_DEFERRED);
 
 	return node;
 }
@@ -2680,6 +2689,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_displayed_folded"), &Node::is_displayed_folded);
 	ClassDB::bind_method(D_METHOD("set_editable_instance"), &Node::set_editable_instance);
 	ClassDB::bind_method(D_METHOD("reconnect_editable_instance"), &Node::reconnect_editable_instance);
+	ClassDB::bind_method(D_METHOD("make_editable"), &Node::make_editable);
 
 	ClassDB::bind_method(D_METHOD("set_process_internal", "enable"), &Node::set_process_internal);
 	ClassDB::bind_method(D_METHOD("is_processing_internal"), &Node::is_processing_internal);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -301,11 +301,12 @@ public:
 	String get_filename() const;
 
 	void set_editable_instance(Node *p_node, bool p_editable);
-	bool is_editable_instance(Node *p_node) const;
+	bool is_editable_instance(const Node *p_node) const;
 	void set_editable_instances(const HashMap<NodePath, int> &p_editable_instances);
 	HashMap<NodePath, int> get_editable_instances() const;
 	void reconnect_editable_instance(Node *p_node, NodePath prev_path);
 	void remove_editable_instance_by_path(NodePath path);
+	void make_editable();
 
 	/* NOTIFICATIONS */
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -304,6 +304,8 @@ public:
 	bool is_editable_instance(Node *p_node) const;
 	void set_editable_instances(const HashMap<NodePath, int> &p_editable_instances);
 	HashMap<NodePath, int> get_editable_instances() const;
+	void reconnect_editable_instance(Node *p_node, NodePath prev_path);
+	void remove_editable_instance_by_path(NodePath path);
 
 	/* NOTIFICATIONS */
 


### PR DESCRIPTION
Fixed renaming/reparenting/duplicating a node disabling editable_children.

This should fix #20409 & fix #6455 and probably some others I missed.