### PR TITLE
Fix move_and_slide missing colliders

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1257,6 +1257,8 @@ Vector2 KinematicBody2D::move_and_slide(const Vector2 &p_linear_velocity, const 
 
 			if (collided) {
 
+				colliders.push_back(collision);
+
 				motion = collision.remainder;
 
 				if (p_floor_direction == Vector2()) {
@@ -1288,8 +1290,6 @@ Vector2 KinematicBody2D::move_and_slide(const Vector2 &p_linear_velocity, const 
 				Vector2 n = collision.normal;
 				motion = motion.slide(n);
 				lv = lv.slide(n);
-
-				colliders.push_back(collision);
 			}
 		}
 

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -1156,6 +1156,8 @@ Vector3 KinematicBody::move_and_slide(const Vector3 &p_linear_velocity, const Ve
 
 		if (collided) {
 
+			colliders.push_back(collision);
+
 			motion = collision.remainder;
 
 			if (p_floor_direction == Vector3()) {
@@ -1192,8 +1194,6 @@ Vector3 KinematicBody::move_and_slide(const Vector3 &p_linear_velocity, const Ve
 					lv[i] = 0;
 				}
 			}
-
-			colliders.push_back(collision);
 
 		} else {
 			break;


### PR DESCRIPTION
Move the storing of colliders in the KinematicBody move_and_slide method to the beginning to ensure all colliders are stored method for later access. It is currently possible to return a value without storing any colliders.