### PR TITLE
Fix #20564 HDR import fail

### DIFF
--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -270,7 +270,6 @@ String FileAccess::get_token() const {
 		c = get_8();
 	}
 
-	token += '0';
 	return String::utf8(token.get_data());
 }
 


### PR DESCRIPTION
Token has extra "0" at the end so it fail condition checking