### PR TITLE
Fixed Windows mono compile

### DIFF
--- a/modules/mono/utils/thread_local.cpp
+++ b/modules/mono/utils/thread_local.cpp
@@ -69,7 +69,7 @@ struct ThreadLocalStorage::Impl {
 #define _CALLBACK_FUNC_
 #endif
 
-	Impl(void _CALLBACK_FUNC_ (*p_destr_callback_func)(void *)) {
+	Impl(void (_CALLBACK_FUNC_ *p_destr_callback_func)(void *)) {
 #ifdef WINDOWS_ENABLED
 		dwFlsIndex = FlsAlloc(p_destr_callback_func);
 		ERR_FAIL_COND(dwFlsIndex == FLS_OUT_OF_INDEXES);
@@ -95,7 +95,7 @@ void ThreadLocalStorage::set_value(void *p_value) const {
 	pimpl->set_value(p_value);
 }
 
-void ThreadLocalStorage::alloc(void _CALLBACK_FUNC_ (*p_destr_callback)(void *)) {
+void ThreadLocalStorage::alloc(void (_CALLBACK_FUNC_ *p_destr_callback)(void *)) {
 	pimpl = memnew(ThreadLocalStorage::Impl(p_destr_callback));
 }
 

--- a/modules/mono/utils/thread_local.h
+++ b/modules/mono/utils/thread_local.h
@@ -76,7 +76,7 @@ struct ThreadLocalStorage {
 	void *get_value() const;
 	void set_value(void *p_value) const;
 
-	void alloc(void _CALLBACK_FUNC_ (*p_dest_callback)(void *));
+	void alloc(void (_CALLBACK_FUNC_ *p_dest_callback)(void *));
 	void free();
 
 private:


### PR DESCRIPTION
This resolves #20598, an issue which prevented Godot Mono 64 being built on Windows.

(Tested on Windows 10)