### PR TITLE
Fix image_loader type validation

### DIFF
--- a/core/io/image_loader.cpp
+++ b/core/io/image_loader.cpp
@@ -185,5 +185,7 @@ bool ResourceFormatLoaderImage::handles_type(const String &p_type) const {
 
 String ResourceFormatLoaderImage::get_resource_type(const String &p_path) const {
 
-	return "Image";
+	if (p_path.get_extension().to_lower() == "image")
+		return "Image";
+	return "";
 }


### PR DESCRIPTION
Validates the file extension in the image_loader. Without this, anything iterating through the loaders is recognized as an Image if its respective loader occurs after the image_loader. This most notably fixes GDNative modules not working.