### PR TITLE
Implemented a new effect called AudioEffectBuffer

### DIFF
--- a/servers/audio/effects/audio_effect_buffer.cpp
+++ b/servers/audio/effects/audio_effect_buffer.cpp
@@ -1,0 +1,206 @@
+/*************************************************************************/
+/*  audio_effect_auffer.cpp                                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "audio_effect_buffer.h"
+
+#define BUFFER_SIZE 1024
+
+void AudioEffectBufferInstance::process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) {
+
+	mutex->lock();
+	read_pos = 0;
+	read_size = 0;
+
+	for (int i = 0; i < p_frame_count; i++) {
+		AudioFrame frame = p_src_frames[i];
+
+		if (read_size < buffer_read.size()) {
+			buffer_read.write[read_size++] = Vector2(frame.l, frame.r);
+		}
+
+		if (i < buffer_write.size()) {
+			frame += AudioFrame(buffer_write[i].x, buffer_write[i].y);
+		}
+
+		p_dst_frames[i] = frame;
+	}
+
+	write_pos = 0;
+	mutex->unlock();
+}
+
+AudioEffectBufferInstance::AudioEffectBufferInstance() {
+
+	mutex = Mutex::create();
+
+	buffer_read.resize(BUFFER_SIZE);
+	buffer_write.resize(BUFFER_SIZE);
+
+	read_pos = 0;
+	read_size = 0;
+	write_pos = 0;
+	write_size = buffer_write.size();
+}
+
+int AudioEffectBufferInstance::avail_frames_to_read() {
+
+	return read_size - read_pos;
+}
+
+int AudioEffectBufferInstance::avail_frames_to_write() {
+
+	return write_size - write_pos;
+}
+
+Vector2 AudioEffectBufferInstance::read_frame() {
+
+	Vector2 frame;
+
+	mutex->lock();
+
+	if (read_pos < read_size) {
+		frame = buffer_read[read_pos++];
+	}
+
+	mutex->unlock();
+	return frame;
+}
+
+void AudioEffectBufferInstance::write_frame(const Vector2 &p_frame) {
+
+	mutex->lock();
+
+	if (write_pos < write_size) {
+		buffer_write.write[write_pos++] = p_frame;
+	}
+
+	mutex->unlock();
+}
+
+PoolVector2Array AudioEffectBufferInstance::read_frames() {
+
+	PoolVector2Array frames;
+
+	mutex->lock();
+
+	frames.resize(avail_frames_to_read());
+	PoolVector2Array::Write w = frames.write();
+	for (int i = 0; read_pos < read_size; i++) {
+		w[i] = buffer_read[read_pos++];
+	}
+
+	mutex->unlock();
+	return frames;
+}
+
+void AudioEffectBufferInstance::write_frames(const PoolVector2Array &p_frames) {
+
+	mutex->lock();
+
+	for (int i = 0; write_pos < write_size; i++) {
+		buffer_write.write[write_pos++] = p_frames[i];
+	}
+
+	mutex->unlock();
+}
+
+AudioEffectBufferInstance::~AudioEffectBufferInstance() {
+
+	if (mutex) {
+		memdelete(mutex);
+		mutex = NULL;
+	}
+}
+
+Ref<AudioEffectInstance> AudioEffectBuffer::instance() {
+	Ref<AudioEffectBufferInstance> ins;
+	ins.instance();
+	ins->base = Ref<AudioEffectBuffer>(this);
+	current_instance = ins;
+	return ins;
+}
+
+Vector2 AudioEffectBuffer::read_frame() {
+
+	if (current_instance.is_valid()) {
+		return current_instance->read_frame();
+	}
+	return Vector2();
+}
+
+void AudioEffectBuffer::write_frame(const Vector2 &p_frame) {
+
+	if (current_instance.is_valid()) {
+		current_instance->write_frame(p_frame);
+	}
+}
+
+PoolVector2Array AudioEffectBuffer::read_frames() {
+
+	if (current_instance.is_valid()) {
+		return current_instance->read_frames();
+	}
+	return PoolVector2Array();
+}
+
+void AudioEffectBuffer::write_frames(const PoolVector2Array &p_frames) {
+
+	if (current_instance.is_valid()) {
+		current_instance->write_frames(p_frames);
+	}
+}
+
+int AudioEffectBuffer::avail_frames_to_read() {
+
+	if (current_instance.is_valid()) {
+		return current_instance->avail_frames_to_read();
+	}
+	return 0;
+}
+
+int AudioEffectBuffer::avail_frames_to_write() {
+
+	if (current_instance.is_valid()) {
+		return current_instance->avail_frames_to_write();
+	}
+	return 0;
+}
+
+void AudioEffectBuffer::_bind_methods() {
+
+	ClassDB::bind_method(D_METHOD("avail_frames_to_read"), &AudioEffectBuffer::avail_frames_to_read);
+	ClassDB::bind_method(D_METHOD("avail_frames_to_write"), &AudioEffectBuffer::avail_frames_to_write);
+
+	ClassDB::bind_method(D_METHOD("write_frame", "frame"), &AudioEffectBuffer::write_frame);
+	ClassDB::bind_method(D_METHOD("read_frame"), &AudioEffectBuffer::read_frame);
+
+	ClassDB::bind_method(D_METHOD("write_frames", "frames"), &AudioEffectBuffer::write_frames);
+	ClassDB::bind_method(D_METHOD("read_frames"), &AudioEffectBuffer::read_frames);
+}

--- a/servers/audio/effects/audio_effect_buffer.h
+++ b/servers/audio/effects/audio_effect_buffer.h
@@ -1,0 +1,91 @@
+/*************************************************************************/
+/*  audio_effect_buffer.h                                                */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2018 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2018 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef AUDIOEFFECTBUFFER_H
+#define AUDIOEFFECTBUFFER_H
+
+#include "servers/audio/audio_effect.h"
+
+class AudioEffectBuffer;
+
+class AudioEffectBufferInstance : public AudioEffectInstance {
+	GDCLASS(AudioEffectBufferInstance, AudioEffectInstance)
+	friend class AudioEffectBuffer;
+	Ref<AudioEffectBuffer> base;
+
+	Vector<Vector2> buffer_read;
+	Vector<Vector2> buffer_write;
+
+	Mutex *mutex;
+
+	int read_pos;
+	int read_size;
+	int write_pos;
+	int write_size;
+
+	int avail_frames_to_read();
+	int avail_frames_to_write();
+
+	Vector2 read_frame();
+	void write_frame(const Vector2 &p_frame);
+
+	PoolVector2Array read_frames();
+	void write_frames(const PoolVector2Array &p_frames);
+
+public:
+	virtual void process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count);
+
+	AudioEffectBufferInstance();
+	~AudioEffectBufferInstance();
+};
+
+class AudioEffectBuffer : public AudioEffect {
+	GDCLASS(AudioEffectBuffer, AudioEffect)
+
+	friend class AudioEffectBufferInstance;
+	Ref<AudioEffectBufferInstance> current_instance;
+
+protected:
+	static void _bind_methods();
+
+	int avail_frames_to_read();
+	int avail_frames_to_write();
+
+	Vector2 read_frame();
+	void write_frame(const Vector2 &p_frame);
+
+	PoolVector2Array read_frames();
+	void write_frames(const PoolVector2Array &p_frames);
+
+public:
+	Ref<AudioEffectInstance> instance();
+};
+
+#endif // AUDIOEFFECTBUFFER_H

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -38,6 +38,7 @@
 #include "audio/audio_effect.h"
 #include "audio/audio_stream.h"
 #include "audio/effects/audio_effect_amplify.h"
+#include "audio/effects/audio_effect_buffer.h"
 #include "audio/effects/audio_effect_chorus.h"
 #include "audio/effects/audio_effect_compressor.h"
 #include "audio/effects/audio_effect_delay.h"
@@ -113,6 +114,7 @@ void register_server_types() {
 	{
 		//audio effects
 		ClassDB::register_class<AudioEffectAmplify>();
+		ClassDB::register_class<AudioEffectBuffer>();
 
 		ClassDB::register_class<AudioEffectReverb>();
 


### PR DESCRIPTION
Fixes #18135

This PR implements a new effect called AudioEffectBuffer that can be used by scripts to read/write audio frames at any point of the bus chain.

I've attached a test project which is an audio meter with a generated sine wave with a crescendo effect: [AudioMeterv4.zip](https://github.com/godotengine/godot/files/2249472/AudioMeterv4.zip)

Note: In the PR #20612 @reduz suggested to use an AudioStream instead of this but I think this offers more possibilities as you can place this effect at any point of the bus chain.

Note2: I've used Vector2 for this but in my opinion this should use AudioFrame which I tried to add at #20612.

Note3: The test projects uses GDScript but I know that GDNative is best suited for handling audio frames, I didn't check but if GDNative doesn't supports at the moment AudioEffects I will add support for this.