### PR TITLE
Fixed issue #20459 by clamping audio stream pitch at a minimum of 0.02f

### DIFF
--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -296,6 +296,11 @@ float AudioStreamPlayer2D::get_volume_db() const {
 }
 
 void AudioStreamPlayer2D::set_pitch_scale(float p_pitch_scale) {
+	if (p_pitch_scale < MIN_PITCH_SCALE) {
+		WARN_PRINT("Pitch scale has a minimum value of 0.02");
+		pitch_scale = MIN_PITCH_SCALE;
+		return;
+	}
 	pitch_scale = p_pitch_scale;
 }
 float AudioStreamPlayer2D::get_pitch_scale() const {

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -35,6 +35,8 @@
 #include "servers/audio/audio_stream.h"
 #include "servers/audio_server.h"
 
+#define MIN_PITCH_SCALE 0.02f
+
 class AudioStreamPlayer2D : public Node2D {
 
 	GDCLASS(AudioStreamPlayer2D, Node2D)


### PR DESCRIPTION
Fix for issue https://github.com/godotengine/godot/issues/20459.
From my analysis of this issue it is caused by the audio stream not sending any bytes to the tcp socket when the pitch is very low like 0 or 0.01, however data is expected to be read on the receiver side, when no data is read the generic function assumes that there was a disconnection and issues a disconnect error.
To mitigate this I stop audio mixing when the pitch is lower than the macro `MIN_PITCH_SCALE` in the method `AudioStreamPlayer2D::_mix_audio`. The  `MIN_PITCH_SCALE` has a default value of 0.02 as originally suggested in the bug report issue.

To  test this I created a 2D scene and added the following script to it:
```
extends Node2D

var player
var lower = true

func _ready():
	player = AudioStreamPlayer2D.new()
	self.add_child(player)
	player.stream = load("res://msc.wav")
	player.pitch_scale = 1
	player.play()

func _process(delta):
	if lower:
		player.pitch_scale = player.pitch_scale - 0.01
		if player.pitch_scale<=0.0:
			lower = false
	else:
		if player.pitch_scale < 1.0:
			player.pitch_scale = player.pitch_scale + 0.01
```

As far as my testing goes this handles all values fine including those bellow 0.02 fixing both the game and editor crash.