### PR TITLE
Fixes the hyperlinks for enumerators inside classes in the editor help.

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -541,6 +541,7 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 		String class_name;
 		if (select.find(".") != -1) {
 			class_name = select.get_slice(".", 0);
+			select = select.get_slice(".", 1);
 		} else {
 			class_name = "@GlobalScope";
 		}


### PR DESCRIPTION
As the title says, fixes a bug where clicking on an enumerator in the editor help would go to the top of the document containing the enumerator rather than the enumerator itself.