### PR TITLE
Fix zoom display in the script editor on hiDPI displays

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -745,7 +745,7 @@ bool CodeTextEditor::_add_font_size(int p_delta) {
 	if (font.is_valid()) {
 		int new_size = CLAMP(font->get_size() + p_delta, 8 * EDSCALE, 96 * EDSCALE);
 
-		zoom_nb->set_text(itos(100 * new_size / 14) + "%");
+		zoom_nb->set_text(itos(100 * new_size / (14 * EDSCALE)) + "%");
 
 		if (new_size != font->get_size()) {
 			EditorSettings::get_singleton()->set("interface/editor/code_font_size", new_size / EDSCALE);
@@ -1318,7 +1318,7 @@ CodeTextEditor::CodeTextEditor() {
 
 	font_resize_val = 0;
 	font_size = EditorSettings::get_singleton()->get("interface/editor/code_font_size");
-	zoom_nb->set_text(itos(100 * font_size / 14) + "%");
+	zoom_nb->set_text(itos(100 * font_size / (14 * EDSCALE)) + "%");
 	font_resize_timer = memnew(Timer);
 	add_child(font_resize_timer);
 	font_resize_timer->set_one_shot(true);


### PR DESCRIPTION
This fixes the zoom percentage displayed in the script editor when using editor scales higher than 100%. The percentage displayed used to be too high as it was comparing the current font size to the default *unscaled* font size.

![Preview](https://user-images.githubusercontent.com/180032/43576253-3320e4c6-9649-11e8-84e8-92a0c8d4a3a7.png)