### PR TITLE
Keeping track of discard

### DIFF
--- a/drivers/gles2/shader_compiler_gles2.cpp
+++ b/drivers/gles2/shader_compiler_gles2.cpp
@@ -704,6 +704,10 @@ String ShaderCompilerGLES2::_dump_node_code(SL::Node *p_node, int p_level, Gener
 				}
 				code += ";\n";
 			} else if (cf_node->flow_op == SL::FLOW_OP_DISCARD) {
+				if (p_actions.usage_flag_pointers.has("DISCARD") && !used_flag_pointers.has("DISCARD")) {
+					*p_actions.usage_flag_pointers["DISCARD"] = true;
+					used_flag_pointers.insert("DISCARD");
+				}
 				code += "discard;";
 			} else if (cf_node->flow_op == SL::FLOW_OP_CONTINUE) {
 				code += "continue;";

--- a/drivers/gles3/shader_compiler_gles3.cpp
+++ b/drivers/gles3/shader_compiler_gles3.cpp
@@ -700,6 +700,11 @@ String ShaderCompilerGLES3::_dump_node_code(SL::Node *p_node, int p_level, Gener
 				}
 			} else if (cfnode->flow_op == SL::FLOW_OP_DISCARD) {
 
+				if (p_actions.usage_flag_pointers.has("DISCARD") && !used_flag_pointers.has("DISCARD")) {
+					*p_actions.usage_flag_pointers["DISCARD"] = true;
+					used_flag_pointers.insert("DISCARD");
+				}
+
 				code = "discard;";
 			} else if (cfnode->flow_op == SL::FLOW_OP_CONTINUE) {
 


### PR DESCRIPTION
Shader compilation now keeps track of the discard key word. 
fixes #20159

Previously only variables were monitored. But discard, which needs
special treatment in some cases, went unnoticed by the compiler as
discard is not a variable but a flow control.

This commit adds monitoring for discard.