### PR TITLE
Check before disconnecting a signal (fixes #20521)

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -668,7 +668,8 @@ real_t RigidBody2D::get_bounce() const {
 #endif // DISABLE_DEPRECATED
 
 void RigidBody2D::set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override) {
-	if (physics_material_override.is_valid()) {
+	if (physics_material_override.is_valid() &&
+			physics_material_override->is_connected(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics")) {
 		physics_material_override->disconnect(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
 	}
 

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -664,7 +664,8 @@ real_t RigidBody::get_bounce() const {
 #endif // DISABLE_DEPRECATED
 
 void RigidBody::set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override) {
-	if (physics_material_override.is_valid()) {
+	if (physics_material_override.is_valid() &&
+			physics_material_override->is_connected(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics")) {
 		physics_material_override->disconnect(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
 	}
 


### PR DESCRIPTION
I'm not entirely sure if it's the right way to fix this issue. But as I understand it, the `signal_map` is lazily populated upon connecting a signal, so I assumed it's an expected case that it may be missing the target signal when `disconnect` is invoked.