### PR TITLE
Add missing GetPtr() for Dictionary<> and Array<>

### DIFF
--- a/modules/mono/glue/cs_files/Array.cs
+++ b/modules/mono/glue/cs_files/Array.cs
@@ -331,5 +331,10 @@ namespace Godot
         {
             return GetEnumerator();
         }
+
+        internal IntPtr GetPtr()
+        {
+            return objectArray.GetPtr();
+        }
     }
 }

--- a/modules/mono/glue/cs_files/Dictionary.cs
+++ b/modules/mono/glue/cs_files/Dictionary.cs
@@ -397,5 +397,10 @@ namespace Godot
         {
             return GetEnumerator();
         }
+
+        internal IntPtr GetPtr()
+        {
+            return objectDict.GetPtr();
+        }
     }
 }


### PR DESCRIPTION
Add missing GetPtr() method for generic versions of Dictionary and Array to fix #20705.