### PR TITLE
Add OS::open_midi_inputs and OS::close_midi_inputs

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -225,6 +225,14 @@ PoolStringArray _OS::get_connected_midi_inputs() {
 	return OS::get_singleton()->get_connected_midi_inputs();
 }
 
+void _OS::open_midi_inputs() {
+	return OS::get_singleton()->open_midi_inputs();
+}
+
+void _OS::close_midi_inputs() {
+	return OS::get_singleton()->close_midi_inputs();
+}
+
 void _OS::set_video_mode(const Size2 &p_size, bool p_fullscreen, bool p_resizeable, int p_screen) {
 
 	OS::VideoMode vm;
@@ -1063,6 +1071,8 @@ void _OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_audio_driver_count"), &_OS::get_audio_driver_count);
 	ClassDB::bind_method(D_METHOD("get_audio_driver_name", "driver"), &_OS::get_audio_driver_name);
 	ClassDB::bind_method(D_METHOD("get_connected_midi_inputs"), &_OS::get_connected_midi_inputs);
+	ClassDB::bind_method(D_METHOD("open_midi_inputs"), &_OS::open_midi_inputs);
+	ClassDB::bind_method(D_METHOD("close_midi_inputs"), &_OS::close_midi_inputs);
 
 	ClassDB::bind_method(D_METHOD("get_screen_count"), &_OS::get_screen_count);
 	ClassDB::bind_method(D_METHOD("get_current_screen"), &_OS::get_current_screen);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -153,6 +153,8 @@ public:
 	virtual String get_audio_driver_name(int p_driver) const;
 
 	virtual PoolStringArray get_connected_midi_inputs();
+	virtual void open_midi_inputs();
+	virtual void close_midi_inputs();
 
 	virtual int get_screen_count() const;
 	virtual int get_current_screen() const;

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -689,6 +689,18 @@ PoolStringArray OS::get_connected_midi_inputs() {
 	return list;
 }
 
+void OS::open_midi_inputs() {
+
+	if (MIDIDriver::get_singleton())
+		MIDIDriver::get_singleton()->open();
+}
+
+void OS::close_midi_inputs() {
+
+	if (MIDIDriver::get_singleton())
+		MIDIDriver::get_singleton()->close();
+}
+
 OS::OS() {
 	void *volatile stack_bottom;
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -190,6 +190,8 @@ public:
 	virtual const char *get_audio_driver_name(int p_driver) const;
 
 	virtual PoolStringArray get_connected_midi_inputs();
+	virtual void open_midi_inputs();
+	virtual void close_midi_inputs();
 
 	virtual int get_screen_count() const { return 1; }
 	virtual int get_current_screen() const { return 0; }

--- a/drivers/coremidi/core_midi.cpp
+++ b/drivers/coremidi/core_midi.cpp
@@ -92,6 +92,25 @@ void MIDIDriverCoreMidi::close() {
 	}
 }
 
+PoolStringArray MIDIDriverCoreMidi::get_connected_inputs() {
+
+	PoolStringArray list;
+
+	for (int i = 0; i < connected_sources.size(); i++) {
+		MIDIEndpointRef source = connected_sources[i];
+		CFStringRef ref = NULL;
+		char name[256];
+
+		MIDIObjectGetStringProperty(source, kMIDIPropertyDisplayName, &ref);
+		CFStringGetCString(ref, name, sizeof(name), kCFStringEncodingUTF8);
+		CFRelease(ref);
+
+		list.push_back(name);
+	}
+
+	return list;
+}
+
 MIDIDriverCoreMidi::MIDIDriverCoreMidi() {
 
 	client = 0;

--- a/drivers/coremidi/core_midi.h
+++ b/drivers/coremidi/core_midi.h
@@ -53,6 +53,8 @@ public:
 	virtual Error open();
 	virtual void close();
 
+	PoolStringArray get_connected_inputs();
+
 	MIDIDriverCoreMidi();
 	virtual ~MIDIDriverCoreMidi();
 };

--- a/drivers/winmidi/win_midi.cpp
+++ b/drivers/winmidi/win_midi.cpp
@@ -53,6 +53,12 @@ Error MIDIDriverWinMidi::open() {
 			char err[256];
 			midiInGetErrorText(res, err, 256);
 			ERR_PRINTS("midiInOpen error: " + String(err));
+
+			MIDIINCAPS caps;
+			res = midiInGetDevCaps(i, &caps, sizeof(MIDIINCAPS));
+			if (res == MMSYSERR_NOERROR) {
+				ERR_PRINTS("Can't open MIDI device \"" + String(caps.szPname) + "\", is it being used by another application?");
+			}
 		}
 	}
 

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1351,8 +1351,6 @@ Error OS_OSX::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 
 	AudioDriverManager::initialize(p_audio_driver);
 
-	midi_driver.open();
-
 	input = memnew(InputDefault);
 	joypad_osx = memnew(JoypadOSX);
 
@@ -1369,6 +1367,8 @@ Error OS_OSX::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 }
 
 void OS_OSX::finalize() {
+
+	midi_driver.close();
 
 	CFNotificationCenterRemoveObserver(CFNotificationCenterGetDistributedCenter(), NULL, kTISNotifySelectedKeyboardInputSourceChanged, NULL);
 	CGDisplayRemoveReconfigurationCallback(displays_arrangement_changed, NULL);

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1219,10 +1219,6 @@ Error OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int
 
 	AudioDriverManager::initialize(p_audio_driver);
 
-#ifdef WINMIDI_ENABLED
-	driver_midi.open();
-#endif
-
 	TRACKMOUSEEVENT tme;
 	tme.cbSize = sizeof(TRACKMOUSEEVENT);
 	tme.dwFlags = TME_LEAVE;

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -342,10 +342,6 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 
 	AudioDriverManager::initialize(p_audio_driver);
 
-#ifdef ALSAMIDI_ENABLED
-	driver_alsamidi.open();
-#endif
-
 	ERR_FAIL_COND_V(!visual_server, ERR_UNAVAILABLE);
 	ERR_FAIL_COND_V(x11_window == 0, ERR_UNAVAILABLE);
 


### PR DESCRIPTION
I've added this two functions because Linux ALSA MIDI and some Windows MIDI drivers (that I recently found out thanks to some feedback on IRC) don't support multi-client connections.
Before enabling MIDI inputs the user must explicitly call for `OS.open_midi_inputs`, and the user can close it with `OS.close_midi_inputs` (OSes finalize function will close if not called anyways).
I've also added `get_connected_inputs` support on CoreMIDI which I missed in my first PR.