### PR TITLE
Use Xcode 9.4 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,12 +63,10 @@ matrix:
 
     - env: GODOT_TARGET=osx TOOLS=yes CACHE_NAME=${GODOT_TARGET}-tools-clang
       os: osx
-      osx_image: xcode9.3
       compiler: clang
 
     - env: GODOT_TARGET=iphone TOOLS=no CACHE_NAME=${GODOT_TARGET}-clang
       os: osx
-      osx_image: xcode9.3
       compiler: clang
 
     - env: GODOT_TARGET=server TOOLS=yes CACHE_NAME=${GODOT_TARGET}-tools-gcc


### PR DESCRIPTION
See [xcode9.4 OS X new default image on July 31st](https://blog.travis-ci.com/2018-07-19-xcode9-4-default-announce). The `osx_image` line is now redundant, so it has been removed.

I tested it on my [Godot nightly builds system](https://github.com/Calinou/godot-builds-ci) and it seems to work fine.