### PR TITLE
Fix Mono exception handling.

### DIFF
--- a/modules/mono/mono_gd/gd_mono_utils.cpp
+++ b/modules/mono/mono_gd/gd_mono_utils.cpp
@@ -590,14 +590,14 @@ current_invoke_count = 0;
 
 MonoObject *runtime_invoke(MonoMethod *p_method, void *p_obj, void **p_params, MonoException **p_exc) {
 	GD_MONO_BEGIN_RUNTIME_INVOKE;
-	MonoObject *ret = mono_runtime_invoke(p_method, p_obj, p_params, (MonoObject **)&p_exc);
+	MonoObject *ret = mono_runtime_invoke(p_method, p_obj, p_params, (MonoObject **)p_exc);
 	GD_MONO_END_RUNTIME_INVOKE;
 	return ret;
 }
 
 MonoObject *runtime_invoke_array(MonoMethod *p_method, void *p_obj, MonoArray *p_params, MonoException **p_exc) {
 	GD_MONO_BEGIN_RUNTIME_INVOKE;
-	MonoObject *ret = mono_runtime_invoke_array(p_method, p_obj, p_params, (MonoObject **)&p_exc);
+	MonoObject *ret = mono_runtime_invoke_array(p_method, p_obj, p_params, (MonoObject **)p_exc);
 	GD_MONO_END_RUNTIME_INVOKE;
 	return ret;
 }


### PR DESCRIPTION
First of all, this fixes the handling of exceptions so the engine actually notices them, it was broken in 4172fa03b56bb60fe096639585e0ca40df73b677.

Next, unhandled exceptions now do NOT cause an abort(). They're logged now, so before #16987. The pending exception thing still works though.