### PR TITLE
ResourceFormatLoaderImage::get_resource_type now uses file path

### DIFF
--- a/core/io/image_loader.cpp
+++ b/core/io/image_loader.cpp
@@ -185,5 +185,5 @@ bool ResourceFormatLoaderImage::handles_type(const String &p_type) const {
 
 String ResourceFormatLoaderImage::get_resource_type(const String &p_path) const {
 
-	return "Image";
+	return p_path.get_extension().to_lower() == "image" ? "Image" : String();
 }


### PR DESCRIPTION
Script classes stopped working because this method was returning "Image" without actually examining the file path it was looking at. This change fixes #20625 and probably a few other bugs that could be related to not loading resources properly.